### PR TITLE
release-19.1: changefeedccl: de-register from the progress registry in more situations

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -445,18 +445,16 @@ func (cf *changeFrontier) Start(ctx context.Context) context.Context {
 	cf.metricsID = cf.metrics.mu.id
 	cf.metrics.mu.id++
 	cf.metrics.mu.Unlock()
+	// TODO(dan): It's very important that we de-register from the metric because
+	// if we orphan an entry in there, our monitoring will lie (say the changefeed
+	// is behind when it may not be). We call this in `close` but that doesn't
+	// always get called when the processor is shut down (especially during crdb
+	// chaos), so here's something that maybe will work some of the times that
+	// close doesn't. This is all very hacky. The real answer is to fix whatever
+	// bugs currently exist in processor shutdown.
 	go func() {
-		// Delete this feed from the MinHighwater metric so it's no longer
-		// considered by the gauge.
-		//
-		// TODO(dan): Ideally this would be done in something like `close` but
-		// there's nothing that's guaranteed to be called when a processor shuts
-		// down.
 		<-ctx.Done()
-		cf.metrics.mu.Lock()
-		delete(cf.metrics.mu.resolved, cf.metricsID)
-		cf.metricsID = -1
-		cf.metrics.mu.Unlock()
+		cf.closeMetrics()
 	}()
 
 	return ctx
@@ -464,6 +462,9 @@ func (cf *changeFrontier) Start(ctx context.Context) context.Context {
 
 func (cf *changeFrontier) close() {
 	if cf.InternalClose() {
+		if cf.metrics != nil {
+			cf.closeMetrics()
+		}
 		if cf.sink != nil {
 			if err := cf.sink.Close(); err != nil {
 				log.Warningf(cf.Ctx, `error closing sink. goroutines may have leaked: %v`, err)
@@ -472,6 +473,17 @@ func (cf *changeFrontier) close() {
 		cf.memAcc.Close(cf.Ctx)
 		cf.MemMonitor.Stop(cf.Ctx)
 	}
+}
+
+// closeMetrics de-registers from the progress registry that powers
+// `changefeed.max_behind_nanos`. This method is idempotent.
+func (cf *changeFrontier) closeMetrics() {
+	// Delete this feed from the MaxBehindNanos metric so it's no longer
+	// considered by the gauge.
+	cf.metrics.mu.Lock()
+	delete(cf.metrics.mu.resolved, cf.metricsID)
+	cf.metricsID = -1
+	cf.metrics.mu.Unlock()
 }
 
 // Next is part of the RowSource interface.


### PR DESCRIPTION
Backport 1/1 commits from #37004.

/cc @cockroachdb/release

It'd be really nice to have this in 19.1.0, but I originally wrote it without the `if cf.metrics != nil` guard and got a panic, so I'm a little spooked about the risk/reward. However, if end up cutting an rc5, maybe this should be in it. I haven't seen any `changefeed.max_behind_nanos` issues in my local crdb-chaos testing since this went in on master.

---

It's very important that we deregister from the metric because if we
orphan an entry in there, our monitoring will lie (say the changefeed is
behind when it may not be). We de-register in `close` but that doesn't
always get called when the processor is shut down (especially during
crdb chaos), so here's something that maybe will work some of the times
that close doesn't. This is all very hacky. The real answer is to fix
whatever bugs currently exist in processor shutdown.

Anecdotally, this seems to greatly improve the reliability of this
metric in the cdc/crdb-chaos roachtest.

Touches #36908

Release note (bug fix): The `changefeed.max_behind_nanos` now has fewer
false positives of changefeeds falling behind.
