### PR TITLE
 opt: support SHOW GRANTS

### DIFF
--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -343,7 +343,7 @@ func TestAdminAPIDatabaseSQLInjection(t *testing.T) {
 
 	const fakedb = "system;DROP DATABASE system;"
 	const path = "databases/" + fakedb
-	const errPattern = `database \\"` + fakedb + `\\" does not exist`
+	const errPattern = `target database or schema does not exist`
 	if err := getAdminJSONProto(s, path, nil); !testutils.IsError(err, errPattern) {
 		t.Fatalf("unexpected error: %v\nexpected: %s", err, errPattern)
 	}

--- a/pkg/sql/delegate/delegate.go
+++ b/pkg/sql/delegate/delegate.go
@@ -58,6 +58,9 @@ func TryDelegate(
 	case *tree.ShowConstraints:
 		return d.delegateShowConstraints(t)
 
+	case *tree.ShowGrants:
+		return d.delegateShowGrants(t)
+
 	case *tree.ShowJobs:
 		return d.delegateShowJobs(t)
 

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -145,7 +145,7 @@ test           public              NULL        root     ALL
 statement ok
 SET DATABASE = ''
 
-query TTTTT colnames
+query TTTTT colnames,rowsort
 SELECT * FROM [SHOW GRANTS]
  WHERE schema_name NOT IN ('crdb_internal', 'pg_catalog', 'information_schema')
 ----

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -702,7 +702,7 @@ SET DATABASE = ""
 statement error pq: syntax error at or near "@"
 GRANT ALL ON a.t@xyz TO readwrite
 
-statement error pq: "\*" does not match any valid database or schema
+statement error pq: target database or schema does not exist
 GRANT ALL ON * TO readwrite
 
 statement error pgcode 42P01 relation "a.tt" does not exist

--- a/pkg/sql/logictest/testdata/logic_test/rename_database
+++ b/pkg/sql/logictest/testdata/logic_test/rename_database
@@ -50,7 +50,7 @@ SET sql_safe_updates = FALSE;
 statement error pgcode 42P01 relation "kv" does not exist
 SELECT * FROM kv
 
-statement error database "test" does not exist
+statement error target database or schema does not exist
 SHOW GRANTS ON DATABASE test
 
 query T

--- a/pkg/sql/opt/cat/schema.go
+++ b/pkg/sql/opt/cat/schema.go
@@ -14,6 +14,8 @@
 
 package cat
 
+import "context"
+
 // Schema is an interface to a database schema, which is a namespace that
 // contains other database objects, like tables and views. Examples of schema
 // are "public" and "crdb_internal".
@@ -25,4 +27,8 @@ type Schema interface {
 	// and ExplicitSchema fields will always be true, since all parts of the
 	// name are always specified.
 	Name() *SchemaName
+
+	// GetDataSourceNames returns the list of names for the data sources that the
+	// schema contains.
+	GetDataSourceNames(ctx context.Context) ([]DataSourceName, error)
 }

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -1,0 +1,49 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cat
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/pkg/errors"
+)
+
+// ExpandDataSourceGlob is a utility function that expands a tree.TablePattern
+// into a list of object names.
+func ExpandDataSourceGlob(
+	ctx context.Context, catalog Catalog, flags Flags, pattern tree.TablePattern,
+) ([]DataSourceName, error) {
+
+	switch p := pattern.(type) {
+	case *tree.TableName:
+		_, name, err := catalog.ResolveDataSource(ctx, flags, p)
+		if err != nil {
+			return nil, err
+		}
+		return []DataSourceName{name}, nil
+
+	case *tree.AllTablesSelector:
+		schema, _, err := catalog.ResolveSchema(ctx, flags, &p.TableNamePrefix)
+		if err != nil {
+			return nil, err
+		}
+
+		return schema.GetDataSourceNames(ctx)
+
+	default:
+		return nil, errors.Errorf("invalid TablePattern type %T", p)
+	}
+}

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -250,12 +250,14 @@ render                                       ·            ·
 query TTT
 SELECT * FROM [EXPLAIN SHOW GRANTS ON foo] WHERE field != 'size'
 ----
-sort                   ·       ·
- │                     order   +database_name,+schema_name,+table_name,+grantee,+privilege_type
- └── render            ·       ·
-      └── filter       ·       ·
-           │           filter  (table_catalog, table_schema, table_name) IN (('test', 'public', 'foo'),)
-           └── values  ·       ·
+render                             ·       ·
+ └── sort                          ·       ·
+      │                            order   +grantee,+privilege_type
+      └── render                   ·       ·
+           └── filter              ·       ·
+                │                  filter  (table_catalog, table_schema, table_name) IN (('test', 'public', 'foo'),)
+                └── virtual table  ·       ·
+·                                  source  ·
 
 query TTT
 EXPLAIN SHOW INDEX FROM foo

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -411,6 +411,11 @@ func (s *Schema) Name() *cat.SchemaName {
 	return &s.SchemaName
 }
 
+// GetDataSourceNames is part of the cat.Schema interface.
+func (s *Schema) GetDataSourceNames(ctx context.Context) ([]cat.DataSourceName, error) {
+	panic("not implemented")
+}
+
 // View implements the cat.View interface for testing purposes.
 type View struct {
 	ViewID      cat.StableID

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -692,8 +692,6 @@ func (p *planner) newPlan(
 		return p.ShowClusterSetting(ctx, n)
 	case *tree.ShowVar:
 		return p.ShowVar(ctx, n)
-	case *tree.ShowGrants:
-		return p.ShowGrants(ctx, n)
 	case *tree.ShowHistogram:
 		return p.ShowHistogram(ctx, n)
 	case *tree.ShowRoles:
@@ -807,8 +805,6 @@ func (p *planner) doPrepare(ctx context.Context, stmt tree.Statement) (planNode,
 		return p.ShowClusterSetting(ctx, n)
 	case *tree.ShowVar:
 		return p.ShowVar(ctx, n)
-	case *tree.ShowGrants:
-		return p.ShowGrants(ctx, n)
 	case *tree.ShowRoles:
 		return p.ShowRoles(ctx, n)
 	case *tree.ShowTables:

--- a/pkg/sql/show_grants.go
+++ b/pkg/sql/show_grants.go
@@ -100,7 +100,7 @@ FROM "".information_schema.table_privileges`
 				//
 				// TODO(vivek): check if the cache can be used.
 				p.runWithOptions(resolveFlags{skipCache: true}, func() {
-					tables, err = expandTableGlob(ctx, p.txn, p, tableGlob)
+					tables, err = expandTableGlob(ctx, p, tableGlob)
 				})
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
The first commit rewrites `expandTableGlob` to use the catalog. The second commit moves the ShowGrants implementation to `delegate`.