### PR TITLE
storage: drop raftentry.Cache data in applySnapshot

### DIFF
--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -856,6 +856,9 @@ func (r *Replica) applySnapshot(
 	if err := clearRangeData(ctx, s.Desc, r.store.Engine(), batch, true /* destroyData */); err != nil {
 		return err
 	}
+	// Clear the cached raft log entries to ensure that old or uncommitted
+	// entries don't impact the in-memory state.
+	r.store.raftEntryCache.Drop(r.RangeID)
 	stats.clear = timeutil.Now()
 
 	// Write the snapshot into the range.


### PR DESCRIPTION
This PR adds a new `.Drop` method to the `raftentry.Cache` which will clear all data associated with a range more efficiently than calling `.Clear` with a large index. The second commit then uses this call when applying a snapshot to ensure that stale cached raft entries are never used.

Fixes #37056.