### PR TITLE
sql: Fix issues causing failures in SQLSmith

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/json_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/json_builtins
@@ -481,6 +481,12 @@ SELECT json_build_object(json_object_keys('{"x":3, "y":4}'::JSON), 2)
 {"x": 2}
 {"y": 2}
 
+# Regression for panic when bit array is passed as argument.
+query T
+SELECT json_build_object('a', '0100110'::varbit)
+----
+{"a": "0100110"}
+
 # even number of arguments
 query error pq: json_build_object\(\): argument list must have even number of elements
 SELECT json_build_object(1,2,3)

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4473,7 +4473,9 @@ func asJSONBuildObjectKey(d tree.Datum) (string, error) {
 		return string(*t), nil
 	case *tree.DCollatedString:
 		return t.Contents, nil
-	case *tree.DBool, *tree.DInt, *tree.DFloat, *tree.DDecimal, *tree.DTimestamp, *tree.DTimestampTZ, *tree.DDate, *tree.DUuid, *tree.DInterval, *tree.DBytes, *tree.DIPAddr, *tree.DOid, *tree.DTime:
+	case *tree.DBool, *tree.DInt, *tree.DFloat, *tree.DDecimal, *tree.DTimestamp, *tree.DTimestampTZ,
+		*tree.DDate, *tree.DUuid, *tree.DInterval, *tree.DBytes, *tree.DIPAddr, *tree.DOid,
+		*tree.DTime, *tree.DBitArray:
 		return tree.AsStringWithFlags(d, tree.FmtBareStrings), nil
 	default:
 		return "", pgerror.AssertionFailedf("unexpected type %T for key value", d)

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -199,6 +199,8 @@ func RandDatumWithNullChance(rng *rand.Rand, typ *types.T, nullChance int) tree.
 			}
 		}
 		return arr
+	case types.AnyFamily:
+		return RandDatumWithNullChance(rng, RandType(rng), nullChance)
 	default:
 		panic(fmt.Sprintf("invalid type %v", typ.DebugString()))
 	}


### PR DESCRIPTION
There are (at least) 3 issues that are currently causing the SQLSmith nightly
test to fail:

1. Issue #36830 - panic: windowNode can't be run in local mode
2. Panic when calling builtin functions with ANY parameters
3. Panic when json_build_object is called with DBitArray datum

This commit fixes #2 and #3:

2. SQLSmith now generates a random datum type when it encounters an ANY param.
3. Add DBitArray to the list of datums handled by the json_build_object function.

In addition, the fix for #2 exposed a SQLSmith bug, where it ws unable to
parse the type names of existing tables. The fix is to change typeFromName to
use parser.ParseType.

After these fixes, and once issue #36830 is fixed, the SQLSmith tests should
start passing again in nightlies.

Release note (sql change): Fix panic when json_build_object is called with
BIT/VARBIT values.