### PR TITLE
roachpb: re-use Value.RawBytes on repeat assignments, avoid allocs in Replica.append

### DIFF
--- a/pkg/roachpb/data.pb.go
+++ b/pkg/roachpb/data.pb.go
@@ -89,7 +89,7 @@ func (x ValueType) String() string {
 	return proto.EnumName(ValueType_name, int32(x))
 }
 func (ValueType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_data_16e2e632a95b5e7e, []int{0}
+	return fileDescriptor_data_8a666ae61b681501, []int{0}
 }
 
 // ReplicaChangeType is a parameter of ChangeReplicasTrigger.
@@ -113,7 +113,7 @@ func (x ReplicaChangeType) String() string {
 	return proto.EnumName(ReplicaChangeType_name, int32(x))
 }
 func (ReplicaChangeType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_data_16e2e632a95b5e7e, []int{1}
+	return fileDescriptor_data_8a666ae61b681501, []int{1}
 }
 
 // TransactionStatus specifies possible states for a transaction.
@@ -165,7 +165,7 @@ func (x TransactionStatus) String() string {
 	return proto.EnumName(TransactionStatus_name, int32(x))
 }
 func (TransactionStatus) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_data_16e2e632a95b5e7e, []int{2}
+	return fileDescriptor_data_8a666ae61b681501, []int{2}
 }
 
 // Span is a key range with an inclusive start Key and an exclusive end Key.
@@ -184,7 +184,7 @@ type Span struct {
 func (m *Span) Reset()      { *m = Span{} }
 func (*Span) ProtoMessage() {}
 func (*Span) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_16e2e632a95b5e7e, []int{0}
+	return fileDescriptor_data_8a666ae61b681501, []int{0}
 }
 func (m *Span) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -225,6 +225,8 @@ var xxx_messageInfo_Span proto.InternalMessageInfo
 // will be less than 64KB?
 type Value struct {
 	// raw_bytes contains the encoded value and checksum.
+	//
+	// Its contents may be modified on the next call to Value.SetFoo.
 	RawBytes []byte `protobuf:"bytes,1,opt,name=raw_bytes,json=rawBytes,proto3" json:"raw_bytes,omitempty"`
 	// Timestamp of value.
 	Timestamp            hlc.Timestamp `protobuf:"bytes,2,opt,name=timestamp,proto3" json:"timestamp"`
@@ -236,7 +238,7 @@ func (m *Value) Reset()         { *m = Value{} }
 func (m *Value) String() string { return proto.CompactTextString(m) }
 func (*Value) ProtoMessage()    {}
 func (*Value) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_16e2e632a95b5e7e, []int{1}
+	return fileDescriptor_data_8a666ae61b681501, []int{1}
 }
 func (m *Value) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -274,7 +276,7 @@ func (m *KeyValue) Reset()         { *m = KeyValue{} }
 func (m *KeyValue) String() string { return proto.CompactTextString(m) }
 func (*KeyValue) ProtoMessage()    {}
 func (*KeyValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_16e2e632a95b5e7e, []int{2}
+	return fileDescriptor_data_8a666ae61b681501, []int{2}
 }
 func (m *KeyValue) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -314,7 +316,7 @@ func (m *StoreIdent) Reset()         { *m = StoreIdent{} }
 func (m *StoreIdent) String() string { return proto.CompactTextString(m) }
 func (*StoreIdent) ProtoMessage()    {}
 func (*StoreIdent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_16e2e632a95b5e7e, []int{3}
+	return fileDescriptor_data_8a666ae61b681501, []int{3}
 }
 func (m *StoreIdent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -356,7 +358,7 @@ func (m *SplitTrigger) Reset()         { *m = SplitTrigger{} }
 func (m *SplitTrigger) String() string { return proto.CompactTextString(m) }
 func (*SplitTrigger) ProtoMessage()    {}
 func (*SplitTrigger) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_16e2e632a95b5e7e, []int{4}
+	return fileDescriptor_data_8a666ae61b681501, []int{4}
 }
 func (m *SplitTrigger) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -406,7 +408,7 @@ func (m *MergeTrigger) Reset()         { *m = MergeTrigger{} }
 func (m *MergeTrigger) String() string { return proto.CompactTextString(m) }
 func (*MergeTrigger) ProtoMessage()    {}
 func (*MergeTrigger) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_16e2e632a95b5e7e, []int{5}
+	return fileDescriptor_data_8a666ae61b681501, []int{5}
 }
 func (m *MergeTrigger) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -445,7 +447,7 @@ type ChangeReplicasTrigger struct {
 func (m *ChangeReplicasTrigger) Reset()      { *m = ChangeReplicasTrigger{} }
 func (*ChangeReplicasTrigger) ProtoMessage() {}
 func (*ChangeReplicasTrigger) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_16e2e632a95b5e7e, []int{6}
+	return fileDescriptor_data_8a666ae61b681501, []int{6}
 }
 func (m *ChangeReplicasTrigger) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -489,7 +491,7 @@ func (m *ModifiedSpanTrigger) Reset()         { *m = ModifiedSpanTrigger{} }
 func (m *ModifiedSpanTrigger) String() string { return proto.CompactTextString(m) }
 func (*ModifiedSpanTrigger) ProtoMessage()    {}
 func (*ModifiedSpanTrigger) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_16e2e632a95b5e7e, []int{7}
+	return fileDescriptor_data_8a666ae61b681501, []int{7}
 }
 func (m *ModifiedSpanTrigger) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -529,7 +531,7 @@ func (m *InternalCommitTrigger) Reset()         { *m = InternalCommitTrigger{} }
 func (m *InternalCommitTrigger) String() string { return proto.CompactTextString(m) }
 func (*InternalCommitTrigger) ProtoMessage()    {}
 func (*InternalCommitTrigger) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_16e2e632a95b5e7e, []int{8}
+	return fileDescriptor_data_8a666ae61b681501, []int{8}
 }
 func (m *InternalCommitTrigger) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -593,7 +595,7 @@ func (m *ObservedTimestamp) Reset()         { *m = ObservedTimestamp{} }
 func (m *ObservedTimestamp) String() string { return proto.CompactTextString(m) }
 func (*ObservedTimestamp) ProtoMessage()    {}
 func (*ObservedTimestamp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_16e2e632a95b5e7e, []int{9}
+	return fileDescriptor_data_8a666ae61b681501, []int{9}
 }
 func (m *ObservedTimestamp) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -804,7 +806,7 @@ type Transaction struct {
 func (m *Transaction) Reset()      { *m = Transaction{} }
 func (*Transaction) ProtoMessage() {}
 func (*Transaction) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_16e2e632a95b5e7e, []int{10}
+	return fileDescriptor_data_8a666ae61b681501, []int{10}
 }
 func (m *Transaction) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -861,7 +863,7 @@ func (m *TransactionRecord) Reset()         { *m = TransactionRecord{} }
 func (m *TransactionRecord) String() string { return proto.CompactTextString(m) }
 func (*TransactionRecord) ProtoMessage()    {}
 func (*TransactionRecord) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_16e2e632a95b5e7e, []int{11}
+	return fileDescriptor_data_8a666ae61b681501, []int{11}
 }
 func (m *TransactionRecord) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -899,7 +901,7 @@ func (m *Intent) Reset()         { *m = Intent{} }
 func (m *Intent) String() string { return proto.CompactTextString(m) }
 func (*Intent) ProtoMessage()    {}
 func (*Intent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_16e2e632a95b5e7e, []int{12}
+	return fileDescriptor_data_8a666ae61b681501, []int{12}
 }
 func (m *Intent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -940,7 +942,7 @@ func (m *SequencedWrite) Reset()         { *m = SequencedWrite{} }
 func (m *SequencedWrite) String() string { return proto.CompactTextString(m) }
 func (*SequencedWrite) ProtoMessage()    {}
 func (*SequencedWrite) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_16e2e632a95b5e7e, []int{13}
+	return fileDescriptor_data_8a666ae61b681501, []int{13}
 }
 func (m *SequencedWrite) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1006,7 +1008,7 @@ type Lease struct {
 func (m *Lease) Reset()      { *m = Lease{} }
 func (*Lease) ProtoMessage() {}
 func (*Lease) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_16e2e632a95b5e7e, []int{14}
+	return fileDescriptor_data_8a666ae61b681501, []int{14}
 }
 func (m *Lease) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1053,7 +1055,7 @@ func (m *AbortSpanEntry) Reset()         { *m = AbortSpanEntry{} }
 func (m *AbortSpanEntry) String() string { return proto.CompactTextString(m) }
 func (*AbortSpanEntry) ProtoMessage()    {}
 func (*AbortSpanEntry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_16e2e632a95b5e7e, []int{15}
+	return fileDescriptor_data_8a666ae61b681501, []int{15}
 }
 func (m *AbortSpanEntry) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1124,7 +1126,7 @@ func (m *TxnCoordMeta) Reset()         { *m = TxnCoordMeta{} }
 func (m *TxnCoordMeta) String() string { return proto.CompactTextString(m) }
 func (*TxnCoordMeta) ProtoMessage()    {}
 func (*TxnCoordMeta) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_16e2e632a95b5e7e, []int{16}
+	return fileDescriptor_data_8a666ae61b681501, []int{16}
 }
 func (m *TxnCoordMeta) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -6130,9 +6132,9 @@ var (
 	ErrIntOverflowData   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("roachpb/data.proto", fileDescriptor_data_16e2e632a95b5e7e) }
+func init() { proto.RegisterFile("roachpb/data.proto", fileDescriptor_data_8a666ae61b681501) }
 
-var fileDescriptor_data_16e2e632a95b5e7e = []byte{
+var fileDescriptor_data_8a666ae61b681501 = []byte{
 	// 2069 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xdc, 0x58, 0xcd, 0x6f, 0xdb, 0xc8,
 	0x15, 0x37, 0x45, 0xca, 0xa2, 0x9e, 0x3e, 0x4c, 0x8f, 0xe3, 0x44, 0xcd, 0xa2, 0x56, 0x56, 0x5b,

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -86,6 +86,8 @@ message Value {
   option (gogoproto.equal) = true;
 
   // raw_bytes contains the encoded value and checksum.
+  //
+  // Its contents may be modified on the next call to Value.SetFoo.
   bytes raw_bytes = 1;
   // Timestamp of value.
   util.hlc.Timestamp timestamp = 2 [(gogoproto.nullable) = false];

--- a/pkg/sql/tests/kv_test.go
+++ b/pkg/sql/tests/kv_test.go
@@ -269,14 +269,14 @@ func BenchmarkKV(b *testing.B) {
 		kvInterface.Scan,
 	} {
 		opName := runtime.FuncForPC(reflect.ValueOf(opFn).Pointer()).Name()
-		opName = strings.TrimPrefix(opName, "github.com/cockroachdb/cockroach/pkg/sql_test.kvInterface.")
+		opName = strings.TrimPrefix(opName, "github.com/cockroachdb/cockroach/pkg/sql/tests_test.kvInterface.")
 		b.Run(opName, func(b *testing.B) {
 			for _, kvFn := range []func(*testing.B) kvInterface{
 				newKVNative,
 				newKVSQL,
 			} {
 				kvTyp := runtime.FuncForPC(reflect.ValueOf(kvFn).Pointer()).Name()
-				kvTyp = strings.TrimPrefix(kvTyp, "github.com/cockroachdb/cockroach/pkg/sql_test.newKV")
+				kvTyp = strings.TrimPrefix(kvTyp, "github.com/cockroachdb/cockroach/pkg/sql/tests_test.newKV")
 				b.Run(kvTyp, func(b *testing.B) {
 					for _, rows := range []int{1, 10, 100, 1000, 10000} {
 						b.Run(fmt.Sprintf("rows=%d", rows), func(b *testing.B) {

--- a/pkg/storage/engine/batch.go
+++ b/pkg/storage/engine/batch.go
@@ -241,6 +241,8 @@ func (b *RocksDBBatchBuilder) encodeKeyValue(key MVCCKey, value []byte, tag Batc
 }
 
 // Put sets the given key to the value provided.
+//
+// It is safe to modify the contents of the arguments after Put returns.
 func (b *RocksDBBatchBuilder) Put(key MVCCKey, value []byte) {
 	b.encodeKeyValue(key, value, BatchTypeValue)
 }
@@ -249,11 +251,15 @@ func (b *RocksDBBatchBuilder) Put(key MVCCKey, value []byte) {
 // accumulated over several writes. Multiple values can be merged sequentially
 // into a single key; a subsequent read will return a "merged" value which is
 // computed from the original merged values.
+//
+// It is safe to modify the contents of the arguments after Merge returns.
 func (b *RocksDBBatchBuilder) Merge(key MVCCKey, value []byte) {
 	b.encodeKeyValue(key, value, BatchTypeMerge)
 }
 
 // Clear removes the item from the db with the given key.
+//
+// It is safe to modify the contents of the arguments after Clear returns.
 func (b *RocksDBBatchBuilder) Clear(key MVCCKey) {
 	b.maybeInit()
 	b.count++
@@ -263,6 +269,8 @@ func (b *RocksDBBatchBuilder) Clear(key MVCCKey) {
 }
 
 // SingleClear removes the most recent item from the db with the given key.
+//
+// It is safe to modify the contents of the arguments after SingleClear returns.
 func (b *RocksDBBatchBuilder) SingleClear(key MVCCKey) {
 	b.maybeInit()
 	b.count++
@@ -273,6 +281,8 @@ func (b *RocksDBBatchBuilder) SingleClear(key MVCCKey) {
 
 // LogData adds a blob of log data to the batch. It will be written to the WAL,
 // but otherwise uninterpreted by RocksDB.
+//
+// It is safe to modify the contents of the arguments after LogData returns.
 func (b *RocksDBBatchBuilder) LogData(data []byte) {
 	b.maybeInit()
 	b.logData = true
@@ -287,6 +297,9 @@ func (b *RocksDBBatchBuilder) LogData(data []byte) {
 }
 
 // ApplyRepr applies the mutations in repr to the current batch.
+//
+// It is safe to modify the contents of the arguments after ApplyRepr
+// returns.
 func (b *RocksDBBatchBuilder) ApplyRepr(repr []byte) error {
 	if len(repr) < headerSize {
 		return errors.Errorf("batch repr too small: %d < %d", len(repr), headerSize)

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -202,10 +202,15 @@ type Writer interface {
 	// and committing a batch whose Repr() equals repr. If sync is true, the
 	// batch is synchronously written to disk. It is an error to specify
 	// sync=true if the Writer is a Batch.
+	//
+	// It is safe to modify the contents of the arguments after ApplyBatchRepr
+	// returns.
 	ApplyBatchRepr(repr []byte, sync bool) error
-	// Clear removes the item from the db with the given key.
-	// Note that clear actually removes entries from the storage
-	// engine, rather than inserting tombstones.
+	// Clear removes the item from the db with the given key. Note that clear
+	// actually removes entries from the storage engine, rather than inserting
+	// tombstones.
+	//
+	// It is safe to modify the contents of the arguments after Clear returns.
 	Clear(key MVCCKey) error
 	// SingleClear removes the most recent write to the item from the db with
 	// the given key. Whether older version of the item will come back to life
@@ -214,16 +219,25 @@ type Writer interface {
 	// for details on the SingleDelete operation that this method invokes. Note
 	// that clear actually removes entries from the storage engine, rather than
 	// inserting tombstones.
+	//
+	// It is safe to modify the contents of the arguments after SingleClear
+	// returns.
 	SingleClear(key MVCCKey) error
 	// ClearRange removes a set of entries, from start (inclusive) to end
 	// (exclusive). Similar to Clear, this method actually removes entries from
 	// the storage engine.
+	//
+	// It is safe to modify the contents of the arguments after ClearRange
+	// returns.
 	ClearRange(start, end MVCCKey) error
 	// ClearIterRange removes a set of entries, from start (inclusive) to end
 	// (exclusive). Similar to Clear and ClearRange, this method actually removes
 	// entries from the storage engine. Unlike ClearRange, the entries to remove
 	// are determined by iterating over iter and per-key tombstones are
 	// generated.
+	//
+	// It is safe to modify the contents of the arguments after ClearIterRange
+	// returns.
 	ClearIterRange(iter Iterator, start, end MVCCKey) error
 	// Merge is a high-performance write operation used for values which are
 	// accumulated over several writes. Multiple values can be merged
@@ -237,12 +251,19 @@ type Writer interface {
 	// (stored as byte slices with a special tag on the roachpb.Value) are
 	// combined with specialized logic beyond that of simple byte slices.
 	//
-	// The logic for merges is written in db.cc in order to be compatible with RocksDB.
+	// The logic for merges is written in db.cc in order to be compatible with
+	// RocksDB.
+	//
+	// It is safe to modify the contents of the arguments after Merge returns.
 	Merge(key MVCCKey, value []byte) error
 	// Put sets the given key to the value provided.
+	//
+	// It is safe to modify the contents of the arguments after Put returns.
 	Put(key MVCCKey, value []byte) error
 	// LogData adds the specified data to the RocksDB WAL. The data is
 	// uninterpreted by RocksDB (i.e. not added to the memtable or sstables).
+	//
+	// It is safe to modify the contents of the arguments after LogData returns.
 	LogData(data []byte) error
 	// LogLogicalOp logs the specified logical mvcc operation with the provided
 	// details to the writer, if it has logical op logging enabled. For most

--- a/pkg/storage/engine/merge.go
+++ b/pkg/storage/engine/merge.go
@@ -36,8 +36,8 @@ func MergeInternalTimeSeriesData(
 	// Wrap each proto in an inlined MVCC value, and marshal each wrapped value
 	// to bytes. This is the format required by the engine.
 	srcBytes := make([][]byte, 0, len(sources))
+	var val roachpb.Value
 	for _, src := range sources {
-		var val roachpb.Value
 		if err := val.SetProto(&src); err != nil {
 			return roachpb.InternalTimeSeriesData{}, err
 		}

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -795,8 +795,7 @@ func (r *RocksDB) Attrs() roachpb.Attributes {
 
 // Put sets the given key to the value provided.
 //
-// The key and value byte slices may be reused safely. put takes a copy of
-// them before returning.
+// It is safe to modify the contents of the arguments after Put returns.
 func (r *RocksDB) Put(key MVCCKey, value []byte) error {
 	return dbPut(r.rdb, key, value)
 }
@@ -807,13 +806,14 @@ func (r *RocksDB) Put(key MVCCKey, value []byte) error {
 // Currently 64-bit counter logic is implemented. See the documentation of
 // goMerge and goMergeInit for details.
 //
-// The key and value byte slices may be reused safely. merge takes a copy
-// of them before returning.
+// It is safe to modify the contents of the arguments after Merge returns.
 func (r *RocksDB) Merge(key MVCCKey, value []byte) error {
 	return dbMerge(r.rdb, key, value)
 }
 
 // LogData is part of the Writer interface.
+//
+// It is safe to modify the contents of the arguments after LogData returns.
 func (r *RocksDB) LogData(data []byte) error {
 	panic("unimplemented")
 }
@@ -826,6 +826,9 @@ func (r *RocksDB) LogLogicalOp(op MVCCLogicalOpType, details MVCCLogicalOpDetail
 // ApplyBatchRepr atomically applies a set of batched updates. Created by
 // calling Repr() on a batch. Using this method is equivalent to constructing
 // and committing a batch whose Repr() equals repr.
+//
+// It is safe to modify the contents of the arguments after ApplyBatchRepr
+// returns.
 func (r *RocksDB) ApplyBatchRepr(repr []byte, sync bool) error {
 	return dbApplyBatchRepr(r.rdb, repr, sync)
 }
@@ -843,23 +846,32 @@ func (r *RocksDB) GetProto(
 }
 
 // Clear removes the item from the db with the given key.
+//
+// It is safe to modify the contents of the arguments after Clear returns.
 func (r *RocksDB) Clear(key MVCCKey) error {
 	return dbClear(r.rdb, key)
 }
 
 // SingleClear removes the most recent item from the db with the given key.
+//
+// It is safe to modify the contents of the arguments after SingleClear returns.
 func (r *RocksDB) SingleClear(key MVCCKey) error {
 	return dbSingleClear(r.rdb, key)
 }
 
 // ClearRange removes a set of entries, from start (inclusive) to end
 // (exclusive).
+//
+// It is safe to modify the contents of the arguments after ClearRange returns.
 func (r *RocksDB) ClearRange(start, end MVCCKey) error {
 	return dbClearRange(r.rdb, start, end)
 }
 
 // ClearIterRange removes a set of entries, from start (inclusive) to end
 // (exclusive).
+//
+// It is safe to modify the contents of the arguments after ClearIterRange
+// returns.
 func (r *RocksDB) ClearIterRange(iter Iterator, start, end MVCCKey) error {
 	return dbClearIterRange(r.rdb, iter, start, end)
 }


### PR DESCRIPTION
This commit addresses an old TODO to re-use Value.RawBytes when it is
already sufficiently sized. The focus of this change is to avoid repeat
allocations in `Replica.append` when writing to a Replica's Raft log.

@danhhz assigning you for review because this was your TODO. Plus you also
happen to be thinking about Raft perf these days 😃 