### PR TITLE
pkg/util/ipaddr: break the dependency to pgerror

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -689,7 +689,15 @@ func TestLint(t *testing.T) {
 	t.Run("TestPGErrors", func(t *testing.T) {
 		t.Parallel()
 		// TODO(justin): we should expand the packages this applies to as possible.
-		cmd, stderr, filter, err := dirCmd(pkgDir, "git", "grep", "-nE", `((fmt|errors).Errorf|errors.New)`, "--", "sql/parser/*.go", "util/ipaddr/*.go")
+		cmd, stderr, filter, err := dirCmd(pkgDir,
+			"git",
+			"grep",
+			"-nE",
+			`((fmt|errors).Errorf|errors.New)`,
+			"--",
+			"sql/parser/*.go",
+			// "util/ipaddr/*.go", // removed until `roachpb` stops depending on `ipaddr`, see #37075
+		)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
To work towards better error handling it would be desirable to
integrate the functionality in package `pgerror` with that of
`roachpb.Error`. However, prior to this patch it was difficult to make
`pgerror` (or a new package that `pgerror` would depend on) depend on
`roachpb`, because `roachpb` had an implicit dependency on `pgerror`
itself (via `util/ipaddr`).

This patch breaks the `roachpb` -> `pgerror` dependency by breaking
`util/ipaddr` -> `pgerror`.

Arguably, it is a misdesign that `roachpb` has so many dependencies on
"SQL scalar value packages" (`util/ipaddr`, `util/duration`,
`util/interval`, etc). `roachpb` should really be a leaf package. However,
the work to break those dependencies is more significant and it is
desirable to bring it out of the critical path towards better error
handling.

Release note: None