### PR TITLE
workloadccl: hook --csv-server flag up to `fixtures import` too

### DIFF
--- a/pkg/ccl/workloadccl/bench_test.go
+++ b/pkg/ccl/workloadccl/bench_test.go
@@ -35,6 +35,7 @@ func benchmarkImportFixture(b *testing.B, gen workload.Generator) {
 		const filesPerNode = 1
 		importBytes, err := ImportFixture(
 			ctx, db, gen, `d`, true /* directIngestion */, filesPerNode, false, /* injectStats */
+			``, /* csvServer */
 		)
 		require.NoError(b, err)
 		bytes += importBytes

--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -441,6 +441,7 @@ func ImportFixture(
 	directIngestion bool,
 	filesPerNode int,
 	injectStats bool,
+	csvServer string,
 ) (int64, error) {
 	var numNodes int
 	if err := sqlDB.QueryRow(numNodesQuery).Scan(&numNodes); err != nil {
@@ -460,9 +461,14 @@ func ImportFixture(
 		defer enableFn()
 	}
 
+	pathPrefix := csvServer
+	if pathPrefix == `` {
+		pathPrefix = `experimental-workload://`
+	}
+
 	for _, t := range tables {
 		table := t
-		paths := csvServerPaths(`experimental-workload://`, gen, table, numNodes*filesPerNode)
+		paths := csvServerPaths(pathPrefix, gen, table, numNodes*filesPerNode)
 		g.GoCtx(func(ctx context.Context) error {
 			tableBytes, err := importFixtureTable(
 				ctx, sqlDB, dbName, table, paths, directIngestion, `` /* output */, injectStats)


### PR DESCRIPTION
Previously it was only hooked up to `fixtures make`. This allows a cockroach 2.1
binary to do the following (with a recent worklod binary):

    roachprod run cluster -- "./workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &"
    roachprod run cluster:1 -- "./workload fixtures import tpcc --csv-server=http://localhost:8081"

Release note: None