### PR TITLE
release-19.1: changefeedccl: disable time-bound iterator in tableHistoryUpdater

### DIFF
--- a/pkg/ccl/changefeedccl/table_history.go
+++ b/pkg/ccl/changefeedccl/table_history.go
@@ -236,9 +236,6 @@ func fetchTableDescriptorVersions(
 		MVCCFilter:    roachpb.MVCCFilter_All,
 		ReturnSST:     true,
 		OmitChecksum:  true,
-		// TODO(dan): Remove this in a PR separate from the one that disables
-		// time-bound iterators for BACKUP.
-		EnableTimeBoundIteratorOptimization: true,
 	}
 	res, pErr := client.SendWrappedWith(ctx, db.NonTransactionalSender(), header, req)
 	if log.V(2) {


### PR DESCRIPTION
Backport 1/1 commits from #36447.

/cc @cockroachdb/release

This has been baking in master for a while with no issues. Targeting 19.1.1

---

The only other place we use TBIs now is poller-based changefeeds, which
absolutely don't work without them. There shouldn't be any noticable
performance impact of this, but I'm going to let it bake on master
before backporting to be sure. Perhaps we'll target 19.1.1?

Release note: None
