### PR TITLE
release-19.1: changefeedccl: improve retryable error whitelisting

### DIFF
--- a/pkg/ccl/changefeedccl/errors.go
+++ b/pkg/ccl/changefeedccl/errors.go
@@ -1,0 +1,79 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"fmt"
+	"strings"
+)
+
+const retryableErrorString = "retryable changefeed error"
+
+type retryableError struct {
+	wrapped error
+}
+
+// MarkRetryableError wraps the given error, marking it as retryable to
+// changefeeds.
+func MarkRetryableError(e error) error {
+	return &retryableError{wrapped: e}
+}
+
+// Error implements the error interface.
+func (e *retryableError) Error() string {
+	return fmt.Sprintf("%s: %s", retryableErrorString, e.wrapped.Error())
+}
+
+// Cause implements the github.com/pkg/errors.causer interface.
+func (e *retryableError) Cause() error { return e.wrapped }
+
+// Unwrap implements the github.com/golang/xerrors.Wrapper interface, which is
+// planned to be moved to the stdlib in go 1.13.
+func (e *retryableError) Unwrap() error { return e.wrapped }
+
+// IsRetryableError returns true if the supplied error, or any of its parent
+// causes, is a IsRetryableError.
+func IsRetryableError(err error) bool {
+	for {
+		if err == nil {
+			return false
+		}
+		if _, ok := err.(*retryableError); ok {
+			return true
+		}
+		errStr := err.Error()
+		if strings.Contains(errStr, retryableErrorString) {
+			// If a RetryableError occurs on a remote node, DistSQL serializes it such
+			// that we can't recover the structure and we have to rely on this
+			// unfortunate string comparison.
+			return true
+		}
+		if strings.Contains(errStr, `rpc error`) {
+			// When a crdb node dies, any DistSQL flows with processors scheduled on
+			// it get an error with "rpc error" in the message from the call to
+			// `(*DistSQLPlanner).Run`.
+			return true
+		}
+		if e, ok := err.(interface{ Unwrap() error }); ok {
+			err = e.Unwrap()
+			continue
+		}
+		return false
+	}
+}
+
+// MaybeStripRetryableErrorMarker performs some minimal attempt to clean the
+// RetryableError marker out. This won't do anything if the RetryableError
+// itself has been wrapped, but that's okay, we'll just have an uglier string.
+func MaybeStripRetryableErrorMarker(err error) error {
+	if e, ok := err.(*retryableError); ok {
+		err = e.wrapped
+	}
+	return err
+}

--- a/pkg/ccl/changefeedccl/metrics.go
+++ b/pkg/ccl/changefeedccl/metrics.go
@@ -95,9 +95,9 @@ var (
 		Measurement: "Flushes",
 		Unit:        metric.Unit_COUNT,
 	}
-	metaChangefeedSinkErrorRetries = metric.Metadata{
-		Name:        "changefeed.sink_error_retries",
-		Help:        "Total retryable errors encountered while emitting to sinks",
+	metaChangefeedErrorRetries = metric.Metadata{
+		Name:        "changefeed.error_retries",
+		Help:        "Total retryable errors encountered by all changefeeds",
 		Measurement: "Errors",
 		Unit:        metric.Unit_COUNT,
 	}
@@ -174,7 +174,7 @@ type Metrics struct {
 	EmittedMessages  *metric.Counter
 	EmittedBytes     *metric.Counter
 	Flushes          *metric.Counter
-	SinkErrorRetries *metric.Counter
+	ErrorRetries     *metric.Counter
 	BufferEntriesIn  *metric.Counter
 	BufferEntriesOut *metric.Counter
 
@@ -202,7 +202,7 @@ func MakeMetrics(histogramWindow time.Duration) metric.Struct {
 		EmittedMessages:  metric.NewCounter(metaChangefeedEmittedMessages),
 		EmittedBytes:     metric.NewCounter(metaChangefeedEmittedBytes),
 		Flushes:          metric.NewCounter(metaChangefeedFlushes),
-		SinkErrorRetries: metric.NewCounter(metaChangefeedSinkErrorRetries),
+		ErrorRetries:     metric.NewCounter(metaChangefeedErrorRetries),
 		BufferEntriesIn:  metric.NewCounter(metaChangefeedBufferEntriesIn),
 		BufferEntriesOut: metric.NewCounter(metaChangefeedBufferEntriesOut),
 

--- a/pkg/ccl/changefeedccl/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/rowfetcher_cache.go
@@ -52,7 +52,9 @@ func (c *rowFetcherCache) TableDescForKey(
 		// own caching.
 		tableDesc, _, err = c.leaseMgr.Acquire(ctx, ts, tableID)
 		if err != nil {
-			return nil, err
+			// LeaseManager can return all kinds of errors during chaos, but based on
+			// its usage, none of them should ever be terminal.
+			return nil, MarkRetryableError(err)
 		}
 		// Immediately release the lease, since we only need it for the exact
 		// timestamp requested.

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -204,6 +203,46 @@ func getSink(
 	return s, nil
 }
 
+// errorWrapperSink delegates to another sink and marks all returned errors as
+// retryable. During changefeed setup, we use the sink once without this to
+// verify configuration, but in the steady state, no sink error should be
+// terminal.
+type errorWrapperSink struct {
+	wrapped Sink
+}
+
+func (s errorWrapperSink) EmitRow(
+	ctx context.Context, table *sqlbase.TableDescriptor, key, value []byte, updated hlc.Timestamp,
+) error {
+	if err := s.wrapped.EmitRow(ctx, table, key, value, updated); err != nil {
+		return MarkRetryableError(err)
+	}
+	return nil
+}
+
+func (s errorWrapperSink) EmitResolvedTimestamp(
+	ctx context.Context, encoder Encoder, resolved hlc.Timestamp,
+) error {
+	if err := s.wrapped.EmitResolvedTimestamp(ctx, encoder, resolved); err != nil {
+		return MarkRetryableError(err)
+	}
+	return nil
+}
+
+func (s errorWrapperSink) Flush(ctx context.Context) error {
+	if err := s.wrapped.Flush(ctx); err != nil {
+		return MarkRetryableError(err)
+	}
+	return nil
+}
+
+func (s errorWrapperSink) Close() error {
+	if err := s.wrapped.Close(); err != nil {
+		return MarkRetryableError(err)
+	}
+	return nil
+}
+
 type kafkaLogAdapter struct {
 	ctx context.Context
 }
@@ -335,12 +374,12 @@ func makeKafkaSink(
 	sink.client, err = sarama.NewClient(strings.Split(bootstrapServers, `,`), config)
 	if err != nil {
 		err = errors.Wrapf(err, `connecting to kafka: %s`, bootstrapServers)
-		return nil, &retryableSinkError{cause: err}
+		return nil, err
 	}
 	sink.producer, err = sarama.NewAsyncProducerFromClient(sink.client)
 	if err != nil {
 		err = errors.Wrapf(err, `connecting to kafka: %s`, bootstrapServers)
-		return nil, &retryableSinkError{cause: err}
+		return nil, err
 	}
 
 	sink.start()
@@ -453,9 +492,6 @@ func (s *kafkaSink) Flush(ctx context.Context) error {
 	s.mu.Unlock()
 
 	if immediateFlush {
-		if _, ok := flushErr.(*sarama.ProducerError); ok {
-			flushErr = &retryableSinkError{cause: flushErr}
-		}
 		return flushErr
 	}
 
@@ -470,9 +506,6 @@ func (s *kafkaSink) Flush(ctx context.Context) error {
 		flushErr := s.mu.flushErr
 		s.mu.flushErr = nil
 		s.mu.Unlock()
-		if _, ok := flushErr.(*sarama.ProducerError); ok {
-			flushErr = &retryableSinkError{cause: flushErr}
-		}
 		return flushErr
 	}
 }
@@ -770,47 +803,4 @@ func (s *bufferSink) Flush(_ context.Context) error {
 func (s *bufferSink) Close() error {
 	s.closed = true
 	return nil
-}
-
-// causer matches the (unexported) interface used by Go to allow errors to wrap
-// their parent cause.
-type causer interface {
-	Cause() error
-}
-
-// String and regex used to match retryable sink errors when they have been
-// "flattened" into a pgerror.
-const retryableSinkErrorString = "retryable sink error"
-
-// retryableSinkError should be used by sinks to wrap any error which may
-// be retried.
-type retryableSinkError struct {
-	cause error
-}
-
-func (e retryableSinkError) Error() string {
-	return fmt.Sprintf(retryableSinkErrorString+": %s", e.cause.Error())
-}
-func (e retryableSinkError) Cause() error { return e.cause }
-
-// isRetryableSinkError returns true if the supplied error, or any of its parent
-// causes, is a retryableSinkError.
-func isRetryableSinkError(err error) bool {
-	for {
-		if _, ok := err.(*retryableSinkError); ok {
-			return true
-		}
-		// TODO(mrtracy): This pathway, which occurs when the retryable error is
-		// detected on a non-local node of the distsql flow, is only currently
-		// being tested with a roachtest, which is expensive. See if it can be
-		// tested via a unit test,
-		if _, ok := err.(*pgerror.Error); ok {
-			return strings.Contains(err.Error(), retryableSinkErrorString)
-		}
-		if e, ok := err.(causer); ok {
-			err = e.Cause()
-			continue
-		}
-		return false
-	}
 }


### PR DESCRIPTION
Backport:
  * 1/2 commits from "changefeedccl: switch retryable errors back to a whitelist" (#36852)
  * 1/1 commits from "changefeedccl: log more details when returning with non-retryable errors" (#37030)

Please see individual PRs for details.

/cc @cockroachdb/release

Targeting 19.1.1
