### PR TITLE
roachtest: Hopefully deflake election-after-restart

### DIFF
--- a/pkg/cmd/roachtest/election.go
+++ b/pkg/cmd/roachtest/election.go
@@ -45,6 +45,13 @@ func registerElectionAfterRestart(r *registry) {
 			duration := timeutil.Since(start)
 			t.l.Printf("pre-restart, query took %s\n", duration)
 
+			// If we restart before all the nodes have applied the splits,
+			// there will be a lot of snapshot attempts (which may fail)
+			// after the restart. This appears to slow down startup enough
+			// to fail the condition below, so wait a bit for the dust to
+			// settle before restarting.
+			time.Sleep(3 * time.Second)
+
 			t.Status("restarting")
 			c.Stop(ctx)
 			c.Start(ctx, t)


### PR DESCRIPTION
Logs suggest that we're seeing failures when nodes aren't caught up on
all the split processing before the restart, so give this a chance to
finish.

Updates #35047

Release note: None