### PR TITLE
sql: add errorIfRows node

### DIFF
--- a/pkg/sql/error_if_rows.go
+++ b/pkg/sql/error_if_rows.go
@@ -1,0 +1,60 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// errorIfRowsNode wraps another planNode and returns an error if the wrapped
+// node produces any rows.
+type errorIfRowsNode struct {
+	plan planNode
+
+	nexted bool
+}
+
+func (n *errorIfRowsNode) startExec(params runParams) error {
+	return nil
+}
+
+func (n *errorIfRowsNode) Next(params runParams) (bool, error) {
+	if n.nexted {
+		return false, nil
+	}
+	n.nexted = true
+
+	ok, err := n.plan.Next(params)
+	if err != nil {
+		return false, err
+	}
+	if ok {
+		// TODO(yuzefovich): update the error once the optimizer plans this node.
+		return false, pgerror.Newf(pgerror.CodeForeignKeyViolationError,
+			"foreign key violation: values %s", n.plan.Values())
+	}
+	return false, nil
+}
+
+func (n *errorIfRowsNode) Values() tree.Datums {
+	return nil
+}
+
+func (n *errorIfRowsNode) Close(ctx context.Context) {
+	n.plan.Close(ctx)
+}

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -349,6 +349,9 @@ func doExpandPlan(
 	case *projectSetNode:
 		n.source, err = doExpandPlan(ctx, p, noParams, n.source)
 
+	case *errorIfRowsNode:
+		n.plan, err = doExpandPlan(ctx, p, noParams, n.plan)
+
 	case *valuesNode:
 	case *virtualTableNode:
 	case *alterIndexNode:
@@ -862,6 +865,9 @@ func (p *planner) simplifyOrderings(plan planNode, usefulOrdering sqlbase.Column
 
 	case *controlJobsNode:
 		n.rows = p.simplifyOrderings(n.rows, nil)
+
+	case *errorIfRowsNode:
+		n.plan = p.simplifyOrderings(n.plan, nil)
 
 	case *valuesNode:
 	case *virtualTableNode:

--- a/pkg/sql/opt_filters.go
+++ b/pkg/sql/opt_filters.go
@@ -361,6 +361,11 @@ func (p *planner) propagateFilters(
 			return plan, extraFilter, err
 		}
 
+	case *errorIfRowsNode:
+		if n.plan, err = p.triggerFilterPropagation(ctx, n.plan); err != nil {
+			return plan, extraFilter, err
+		}
+
 	case *alterIndexNode:
 	case *alterTableNode:
 	case *alterSequenceNode:

--- a/pkg/sql/opt_limits.go
+++ b/pkg/sql/opt_limits.go
@@ -196,6 +196,9 @@ func (p *planner) applyLimit(plan planNode, numRows int64, soft bool) {
 	case *controlJobsNode:
 		p.setUnlimited(n.rows)
 
+	case *errorIfRowsNode:
+		p.setUnlimited(n.plan)
+
 	case *valuesNode:
 	case *virtualTableNode:
 	case *alterIndexNode:

--- a/pkg/sql/opt_needed.go
+++ b/pkg/sql/opt_needed.go
@@ -254,6 +254,9 @@ func setNeededColumns(plan planNode, needed []bool) {
 	case *controlJobsNode:
 		setNeededColumns(n.rows, allColumns(n.rows))
 
+	case *errorIfRowsNode:
+		setNeededColumns(n.plan, allColumns(n.plan))
+
 	case *alterIndexNode:
 	case *alterTableNode:
 	case *alterSequenceNode:

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -184,6 +184,7 @@ var _ planNode = &dropSequenceNode{}
 var _ planNode = &dropTableNode{}
 var _ planNode = &DropUserNode{}
 var _ planNode = &dropViewNode{}
+var _ planNode = &errorIfRowsNode{}
 var _ planNode = &explainDistSQLNode{}
 var _ planNode = &explainPlanNode{}
 var _ planNode = &filterNode{}

--- a/pkg/sql/plan_physical_props.go
+++ b/pkg/sql/plan_physical_props.go
@@ -101,6 +101,8 @@ func planPhysicalProps(plan planNode) physicalProps {
 	case *alterUserSetPasswordNode:
 	case *cancelQueriesNode:
 	case *cancelSessionsNode:
+	case *commentOnTableNode:
+	case *commentOnColumnNode:
 	case *controlJobsNode:
 	case *createDatabaseNode:
 	case *createIndexNode:
@@ -115,6 +117,7 @@ func planPhysicalProps(plan planNode) physicalProps {
 	case *dropSequenceNode:
 	case *dropTableNode:
 	case *dropViewNode:
+	case *errorIfRowsNode:
 	case *explainDistSQLNode:
 	case *hookFnNode:
 	case *relocateNode:
@@ -140,8 +143,6 @@ func planPhysicalProps(plan planNode) physicalProps {
 	case *valuesNode:
 	case *virtualTableNode:
 	case *zeroNode:
-	case *commentOnTableNode:
-	case *commentOnColumnNode:
 	default:
 		panic(fmt.Sprintf("unhandled node type: %T", plan))
 	}

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -612,6 +612,9 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 		if v.observer.followRowSourceToPlanNode && n.originalPlanNode != nil {
 			v.visit(n.originalPlanNode)
 		}
+
+	case *errorIfRowsNode:
+		n.plan = v.visit(n.plan)
 	}
 }
 
@@ -741,6 +744,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&dropTableNode{}):            "drop table",
 	reflect.TypeOf(&DropUserNode{}):             "drop user/role",
 	reflect.TypeOf(&dropViewNode{}):             "drop view",
+	reflect.TypeOf(&errorIfRowsNode{}):          "errorIfRows",
 	reflect.TypeOf(&explainDistSQLNode{}):       "explain distsql",
 	reflect.TypeOf(&explainPlanNode{}):          "explain plan",
 	reflect.TypeOf(&filterNode{}):               "filter",


### PR DESCRIPTION
Add errorIfRows node that returns an error if it receives a row
from its input. It is needed for foreign keys checks implementation
with joins.

Fixes: #37053.

I'm not sure whether some of these additions are necessary or if something is missing. Also, I'm not sure whether it deserves a unit test.

Release note: None