### PR TITLE
roachtest: add tpcc/overload test

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -299,7 +299,6 @@ func registerTPCC(r *registry) {
 			})
 		},
 	})
-
 	r.Add(testSpec{
 		Name:       "tpcc/w=100/nodes=3/chaos=true",
 		Cluster:    makeClusterSpec(4),
@@ -322,6 +321,24 @@ func registerTPCC(r *registry) {
 					}
 				},
 				ZFS: false, // change to true during debugging/development
+			})
+		},
+	})
+	// Overload runs with TPCC on a cluster with insufficient resources for the
+	// warehouse count. At time of writing a cluster with this spec cannot
+	// support even half this warehouse count. The goal of this test is to ensure
+	// that nodes do not crash.
+	overloadSpec := makeClusterSpec(4, cpu(4))
+	r.Add(testSpec{
+		Name:       "tpcc/overload/" + overloadSpec.String(),
+		MinVersion: maybeMinVersionForFixturesImport(cloud),
+		Cluster:    overloadSpec,
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			warehouses := 1000
+			runTPCC(ctx, t, c, tpccOptions{
+				Warehouses: warehouses,
+				Duration:   2 * time.Hour,
+				Extra:      "--tolerate-errors",
 			})
 		},
 	})


### PR DESCRIPTION
This PR adds a tpcc roachtest configuration which is sorely overloaded.
We expect that on cluster with 3x 4 vcpu nodes can handle 400 to 600
warehouses on gcp and aws respectively where this test uses 1000.
The test's passing criterion is just that nodes do not crash and that
the test does not fail from the client's perspective.

After landing, the intention is to add this to the nightly suite.

Fixes #37047.

Release note: None