### PR TITLE
roachprod: enable verbose logging for scp

### DIFF
--- a/pkg/cmd/roachprod/install/cluster_synced.go
+++ b/pkg/cmd/roachprod/install/cluster_synced.go
@@ -1383,7 +1383,7 @@ func (c *SyncedCluster) SSH(sshArgs, args []string) error {
 
 func (c *SyncedCluster) scp(src, dest string) error {
 	args := []string{
-		"scp", "-r", "-C",
+		"scp", "-v", "-r", "-C",
 		"-o", "StrictHostKeyChecking=no",
 	}
 	args = append(args, sshAuthArgs()...)


### PR DESCRIPTION
This single '-v' flag enable debug1 level logging in ssh in hopes
of helping root cause issues like #37113.