### PR TITLE
sql: fix checking for presence of window functions in some edge cases

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -3008,6 +3008,12 @@ SELECT sum(a) OVER (PARTITION BY count(a) OVER ()) FROM x
 statement error window functions are not allowed in window definitions
 SELECT sum(a) OVER (ORDER BY count(a) OVER ()) FROM x
 
+statement error window functions are not allowed in window definitions
+SELECT sum(a) OVER (PARTITION BY count(a) OVER () + 1) FROM x
+
+statement error window functions are not allowed in window definitions
+SELECT sum(a) OVER (ORDER BY count(a) OVER () + 1) FROM x
+
 statement error more than one row returned by a subquery used as an expression
 SELECT sum(a) OVER (PARTITION BY (SELECT count(*) FROM x GROUP BY a)) FROM x
 


### PR DESCRIPTION
Previously, when a window function was a part of another expression
(say BinaryExpr) instead of being used directly within PARTITION BY
and ORDER BY clauses of another window function, we would incorrectly
not reject such a query and would actually crash while trying to
execute it.

Release note: None