### PR TITLE
storage: remove spammy log about failed RemoveTarget simulation

### DIFF
--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -628,6 +628,12 @@ func (a Allocator) RebalanceTarget(
 			replicaCandidates = simulateFilterUnremovableReplicas(
 				raftStatus, desc.Replicas, newReplica.ReplicaID)
 		}
+		if len(replicaCandidates) == 0 {
+			// No existing replicas are suitable to remove.
+			log.VEventf(ctx, 2, "not rebalancing to s%d because there are no existing "+
+				"replicas that can be removed", target.store.StoreID)
+			return nil, ""
+		}
 
 		removeReplica, removeDetails, err := a.simulateRemoveTarget(
 			ctx,


### PR DESCRIPTION
We repeatedly see in the logs of clusters undergoing chaos:
```
W190425 06:17:19.438001 251 storage/allocator.go:639  [n9,replicate,s9,r2946/3:/Table/53/1/96{2/4/2â€¦-4/4/7â€¦}] simulating RemoveTarget failed: must supply at least one candidate replica to allocator.RemoveTarget()
W190425 06:17:19.638430 289 storage/allocator.go:639  [n9,replicate,s9,r6893/5:/Table/59/1/158{6/9/-â€¦-7/1/-â€¦}] simulating RemoveTarget failed: must supply at least one candidate replica to allocator.RemoveTarget()
W190425 06:17:19.837870 256 storage/allocator.go:639  [n9,replicate,s9,r6472/3:/Table/59/1/129{0/2/-â€¦-2/1/-â€¦}] simulating RemoveTarget failed: must supply at least one candidate replica to allocator.RemoveTarget()
W190425 06:17:20.238586 276 storage/allocator.go:639  [n9,replicate,s9,r1555/3:/Table/54/1/"\xc8\x{dasâ€¦-f5\â€¦}] simulating RemoveTarget failed: must supply at least one candidate replica to allocator.RemoveTarget()
```

For instance, it dominates the logs in https://github.com/cockroachdb/cockroach/issues/36720.

This was first picked up in https://github.com/cockroachdb/cockroach/issues/34860#issuecomment-463172059. This seems relatively new, so it might have been impacted by 3c76d7782a4aaef09895cbd88f19482f307e2695.

Release note: None