### PR TITLE
telemetry: make telemetry endpoint read-only

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1749,7 +1749,7 @@ func TestChangefeedTelemetry(t *testing.T) {
 		sqlDB.Exec(t, `INSERT INTO bar VALUES (1)`)
 
 		// Reset the counts.
-		_ = telemetry.GetAndResetFeatureCounts(false)
+		_ = telemetry.GetFeatureCounts(telemetry.Raw, telemetry.ResetCounts)
 
 		// Start some feeds (and read from them to make sure they've started.
 		foo := feed(t, f, `CREATE CHANGEFEED FOR foo`)
@@ -1778,7 +1778,7 @@ func TestChangefeedTelemetry(t *testing.T) {
 			expectedPushEnabled = `disabled`
 		}
 
-		counts := telemetry.GetAndResetFeatureCounts(false)
+		counts := telemetry.GetFeatureCounts(telemetry.Raw, telemetry.ResetCounts)
 		require.Equal(t, int32(2), counts[`changefeed.create.sink.`+expectedSink])
 		require.Equal(t, int32(2), counts[`changefeed.create.format.json`])
 		require.Equal(t, int32(1), counts[`changefeed.create.num_tables.1`])

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/diagnosticspb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -1746,7 +1747,7 @@ func (s *statusServer) Diagnostics(
 		return status.Diagnostics(ctx, req)
 	}
 
-	return s.admin.server.getReportingInfo(ctx), nil
+	return s.admin.server.getReportingInfo(ctx, telemetry.ReadOnly), nil
 }
 
 // Stores returns details for each store.

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -230,7 +230,7 @@ func TestCBOReportUsage(t *testing.T) {
 	ts := s.(*TestServer)
 
 	// make sure the test's generated activity is the only activity we measure.
-	telemetry.GetAndResetFeatureCounts(false)
+	telemetry.GetFeatureCounts(telemetry.Raw, telemetry.ResetCounts)
 
 	sqlDB := sqlutils.MakeSQLRunner(db)
 
@@ -368,7 +368,7 @@ func TestReportUsage(t *testing.T) {
 	ts := s.(*TestServer)
 
 	// make sure the test's generated activity is the only activity we measure.
-	telemetry.GetAndResetFeatureCounts(false)
+	telemetry.GetFeatureCounts(telemetry.Raw, telemetry.ResetCounts)
 
 	if _, err := db.Exec(fmt.Sprintf(`CREATE DATABASE %s`, elemName)); err != nil {
 		t.Fatal(err)

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1537,7 +1537,7 @@ CREATE TABLE crdb_internal.feature_usage (
 )
 `,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		for feature, count := range telemetry.GetFeatureCounts() {
+		for feature, count := range telemetry.GetFeatureCounts(telemetry.Raw, telemetry.ReadOnly) {
 			if count == 0 {
 				// Skip over empty counters to avoid polluting the output.
 				continue

--- a/pkg/sql/err_count_test.go
+++ b/pkg/sql/err_count_test.go
@@ -30,20 +30,20 @@ import (
 func TestErrorCounts(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	telemetry.GetAndResetFeatureCounts(false)
+	telemetry.GetFeatureCounts(telemetry.Raw, telemetry.ResetCounts)
 
 	params, _ := tests.CreateTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 
-	count1 := telemetry.GetFeatureCounts()["errorcodes."+pgerror.CodeSyntaxError]
+	count1 := telemetry.GetRawFeatureCounts()["errorcodes."+pgerror.CodeSyntaxError]
 
 	_, err := db.Query("SELECT 1+")
 	if err == nil {
 		t.Fatal("expected error, got no error")
 	}
 
-	count2 := telemetry.GetFeatureCounts()["errorcodes."+pgerror.CodeSyntaxError]
+	count2 := telemetry.GetRawFeatureCounts()["errorcodes."+pgerror.CodeSyntaxError]
 
 	if count2-count1 != 1 {
 		t.Fatalf("expected 1 syntax error, got %d", count2-count1)
@@ -59,7 +59,7 @@ func TestErrorCounts(t *testing.T) {
 	}
 	rows.Close()
 
-	count3 := telemetry.GetFeatureCounts()["errorcodes."+pgerror.CodeSyntaxError]
+	count3 := telemetry.GetRawFeatureCounts()["errorcodes."+pgerror.CodeSyntaxError]
 
 	if count3-count2 != 1 {
 		t.Fatalf("expected 1 syntax error, got %d", count3-count2)
@@ -69,7 +69,7 @@ func TestErrorCounts(t *testing.T) {
 func TestUnimplementedCounts(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	telemetry.GetAndResetFeatureCounts(false)
+	telemetry.GetFeatureCounts(telemetry.Raw, telemetry.ResetCounts)
 
 	params, _ := tests.CreateTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
@@ -83,7 +83,7 @@ func TestUnimplementedCounts(t *testing.T) {
 		t.Fatal("expected error, got no error")
 	}
 
-	if telemetry.GetFeatureCounts()["unimplemented.#9851.INT8->STRING"] == 0 {
+	if telemetry.GetRawFeatureCounts()["unimplemented.#9851.INT8->STRING"] == 0 {
 		t.Fatal("expected unimplemented telemetry, got nothing")
 	}
 }
@@ -91,7 +91,7 @@ func TestUnimplementedCounts(t *testing.T) {
 func TestTransactionRetryErrorCounts(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	telemetry.GetAndResetFeatureCounts(false)
+	telemetry.GetFeatureCounts(telemetry.Raw, telemetry.ResetCounts)
 
 	// Transaction retry errors aren't given a pg error code until deep
 	// in pgwire (pgwire.convertToErrWithPGCode). Make sure we're
@@ -137,7 +137,7 @@ func TestTransactionRetryErrorCounts(t *testing.T) {
 		}
 	}
 
-	if telemetry.GetFeatureCounts()["errorcodes.40001"] == 0 {
+	if telemetry.GetRawFeatureCounts()["errorcodes.40001"] == 0 {
 		t.Fatal("expected error code telemetry, got nothing")
 	}
 }

--- a/pkg/sql/pgwire/encoding_test.go
+++ b/pkg/sql/pgwire/encoding_test.go
@@ -230,7 +230,7 @@ func TestEncodingErrorCounts(t *testing.T) {
 	buf := newWriteBuffer(metric.NewCounter(metric.Metadata{}))
 	d, _ := tree.ParseDDecimal("Inf")
 	buf.writeBinaryDatum(context.Background(), d, nil, d.ResolvedType().Oid())
-	if count := telemetry.GetFeatureCounts()["pgwire.#32489.binary_decimal_infinity"]; count != 1 {
+	if count := telemetry.GetRawFeatureCounts()["pgwire.#32489.binary_decimal_infinity"]; count != 1 {
 		t.Fatalf("expected 1 encoding error, got %d", count)
 	}
 }

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -2303,7 +2303,7 @@ func TestCancelRequest(t *testing.T) {
 	if _, err := fe.Receive(); err != io.EOF {
 		t.Fatalf("unexpected: %v", err)
 	}
-	if count := telemetry.GetFeatureCounts()["pgwire.unimplemented.cancel_request"]; count != 1 {
+	if count := telemetry.GetRawFeatureCounts()["pgwire.unimplemented.cancel_request"]; count != 1 {
 		t.Fatalf("expected 1 cancel request, got %d", count)
 	}
 }


### PR DESCRIPTION
Previously it was reusing the code used in periodic reporting exactly, which had the side-effect of clearing the report.
This changes the endpoint to pass a paramter to the report generation to prevent that.

It also makes explicit what the various callers of GetFeatureCounts want -- raw vs quantized, read-only vs resetting.

Release note: none.