### PR TITLE
roachprod: fail to expand when not all nodes are known

### DIFF
--- a/pkg/cmd/roachprod/install/cluster_synced.go
+++ b/pkg/cmd/roachprod/install/cluster_synced.go
@@ -437,7 +437,10 @@ func (c *SyncedCluster) Run(stdout, stderr io.Writer, nodes []int, title, cmd st
 		e := expander{
 			node: nodes[i],
 		}
-		expandedCmd := e.expand(c, cmd)
+		expandedCmd, err := e.expand(c, cmd)
+		if err != nil {
+			return nil, err
+		}
 
 		// Be careful about changing these command strings. In particular, we need
 		// to support running commands in the background on both local and remote
@@ -1341,8 +1344,11 @@ func (c *SyncedCluster) SSH(sshArgs, args []string) error {
 	}
 	var expandedArgs []string
 	for _, arg := range args {
-		arg = e.expand(c, arg)
-		expandedArgs = append(expandedArgs, strings.Split(arg, " ")...)
+		expandedArg, err := e.expand(c, arg)
+		if err != nil {
+			return err
+		}
+		expandedArgs = append(expandedArgs, strings.Split(expandedArg, " ")...)
 	}
 
 	var allArgs []string

--- a/pkg/cmd/roachprod/install/cockroach.go
+++ b/pkg/cmd/roachprod/install/cockroach.go
@@ -372,8 +372,11 @@ tar cvf certs.tar certs
 			node: nodes[i],
 		}
 		for _, arg := range extraArgs {
-			arg = e.expand(c, arg)
-			args = append(args, strings.Split(arg, " ")...)
+			expandedArg, err := e.expand(c, arg)
+			if err != nil {
+				return nil, err
+			}
+			args = append(args, strings.Split(expandedArg, " ")...)
 		}
 
 		binary := cockroachNodeBinary(c, nodes[i])


### PR DESCRIPTION
This PR adds error propagation to the roachprod `expander` and ensures that
we return an error when the node spec being used for expansion does not
match the shape of the cluster.

Why the data in the SyncedCluster doesn't match reality remains a mystery but
this should at least lead to better error messages.

Release note: None