### PR TITLE
roachprod: error when node spec refers to a non-existent vm

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -169,7 +169,12 @@ Hint: use "roachprod sync" to update the list of available clusters.
 	if err != nil {
 		return nil, err
 	}
-
+	for _, n := range nodes {
+		if n > len(c.VMs) {
+			return nil, fmt.Errorf("invalid node spec %s, cluster contains %d nodes",
+				nodeNames, len(c.VMs))
+		}
+	}
 	c.Nodes = nodes
 	if reserveLoadGen {
 		// TODO(marc): make loadgen node configurable. For now, we always use the


### PR DESCRIPTION
Before:
```
$ roachprod run ajwerner-test1:7 -- 'echo foo'
panic: runtime error: index out of range

goroutine 23 [running]:
github.com/cockroachdb/cockroach/pkg/cmd/roachprod/install.(*SyncedCluster).user(...)
        /home/ajwerner/src/github.com/cockroachdb/cockroach/pkg/cmd/roachprod/install/cluster_synced.go:89
github.com/cockroachdb/cockroach/pkg/cmd/roachprod/install.(*SyncedCluster).newSession(0xc000470000, 0x7, 0x0, 0x0, 0x0, 0x0)
        /home/ajwerner/src/github.com/cockroachdb/cockroach/pkg/cmd/roachprod/install/cluster_synced.go:147 +0x124
...
```
After:
```
$ roachprod run ajwerner-test1:7 -- 'echo foo'
Error:  invalid node spec 7, cluster contains 2 nodes
```

Release note: None