### PR TITLE
roachtest: copy roachprod state to artifacts when tests fail

### DIFF
--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -1202,6 +1202,9 @@ func (r *registry) runAsync(
 				if err := c.FetchCores(ctx); err != nil {
 					c.l.Printf("failed to fetch cores: %s", err)
 				}
+				if err := c.CopyRoachprodState(ctx); err != nil {
+					c.l.Printf("failed to copy roachprod state: %s", err)
+				}
 			}
 			// NB: fetch the logs even when we have a debug zip because
 			// debug zip can't ever get the logs for down nodes.


### PR DESCRIPTION
There have been a number of mysterious test failures that imply that
roachprod state can get corrupted. While that may be due to some yet
undiscovered race accessing that state, if it is a persistent problem
this data should give us some insight into it.

Release note: None