### PR TITLE
changefeedccl: fix DELETEs in cloud storage sinks

### DIFF
--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/cockroach/pkg/workload/bank"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkChangefeedTicks(b *testing.B) {
@@ -63,7 +64,8 @@ func BenchmarkChangefeedTicks(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			b.StartTimer()
-			sink, cancelFeed := createBenchmarkChangefeed(ctx, s, feedClock, `d`, `bank`)
+			sink, cancelFeed, err := createBenchmarkChangefeed(ctx, s, feedClock, `d`, `bank`)
+			require.NoError(b, err)
 			for rows := 0; rows < numRows; {
 				r, sb := sink.WaitForEmit()
 				rows += r
@@ -167,7 +169,7 @@ func createBenchmarkChangefeed(
 	s serverutils.TestServerInterface,
 	feedClock *hlc.Clock,
 	database, table string,
-) (*benchSink, func() error) {
+) (*benchSink, func() error, error) {
 	tableDesc := sqlbase.GetTableDescriptor(s.DB(), database, table)
 	spans := []roachpb.Span{tableDesc.PrimaryIndexSpan()}
 	details := jobspb.ChangefeedDetails{
@@ -179,7 +181,10 @@ func createBenchmarkChangefeed(
 		},
 	}
 	initialHighWater := hlc.Timestamp{}
-	encoder := makeJSONEncoder(details.Opts)
+	encoder, err := makeJSONEncoder(details.Opts)
+	if err != nil {
+		return nil, nil, err
+	}
 	sink := makeBenchSink()
 
 	settings := s.ClusterSettings()
@@ -248,7 +253,7 @@ func createBenchmarkChangefeed(
 		wg.Wait()
 		return nil
 	}
-	return sink, cancelFn
+	return sink, cancelFn, nil
 }
 
 // loadWorkloadBatches inserts a workload.Table's row batches, each in one

--- a/pkg/ccl/changefeedccl/cdctest/validator.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator.go
@@ -119,6 +119,7 @@ type validatorRow struct {
 type fingerprintValidator struct {
 	sqlDB                  *gosql.DB
 	origTable, fprintTable string
+	primaryKeyCols         []string
 	partitionResolved      map[string]hlc.Timestamp
 	resolved               hlc.Timestamp
 	// It's possible to get a resolved timestamp from before the table even
@@ -132,20 +133,49 @@ type fingerprintValidator struct {
 }
 
 // NewFingerprintValidator returns a new FingerprintValidator that uses
-// `fprintTable` as scratch space to recreate `origTable`.
+// `fprintTable` as scratch space to recreate `origTable`. `fprintTable` must
+// exist before calling this constructor.
 func NewFingerprintValidator(
 	sqlDB *gosql.DB, origTable, fprintTable string, partitions []string,
-) Validator {
+) (Validator, error) {
+	// Fetch the primary keys though information_schema schema inspections so we
+	// can use them to construct the SQL for DELETEs and also so we can verify
+	// that the key in a message matches what's expected for the value.
+	var primaryKeyCols []string
+	rows, err := sqlDB.Query(`
+		SELECT column_name
+		FROM information_schema.key_column_usage
+		WHERE table_name=$1
+			AND constraint_name='primary'
+		ORDER BY ordinal_position`,
+		fprintTable,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var primaryKeyCol string
+		if err := rows.Scan(&primaryKeyCol); err != nil {
+			return nil, err
+		}
+		primaryKeyCols = append(primaryKeyCols, primaryKeyCol)
+	}
+	if len(primaryKeyCols) == 0 {
+		return nil, errors.Errorf("no primary key information found for %s", fprintTable)
+	}
+
 	v := &fingerprintValidator{
-		sqlDB:       sqlDB,
-		origTable:   origTable,
-		fprintTable: fprintTable,
+		sqlDB:          sqlDB,
+		origTable:      origTable,
+		fprintTable:    fprintTable,
+		primaryKeyCols: primaryKeyCols,
 	}
 	v.partitionResolved = make(map[string]hlc.Timestamp)
 	for _, partition := range partitions {
 		v.partitionResolved[partition] = hlc.Timestamp{}
 	}
-	return v
+	return v, nil
 }
 
 // NoteRow implements the Validator interface.
@@ -227,22 +257,57 @@ func (v *fingerprintValidator) NoteResolved(partition string, resolved hlc.Times
 
 		var stmtBuf bytes.Buffer
 		var args []interface{}
-		fmt.Fprintf(&stmtBuf, `UPSERT INTO %s (`, v.fprintTable)
-		for col, colValue := range value.After {
-			if len(args) != 0 {
-				stmtBuf.WriteString(`,`)
+		if value.After != nil {
+			// UPDATE or INSERT
+			fmt.Fprintf(&stmtBuf, `UPSERT INTO %s (`, v.fprintTable)
+			for col, colValue := range value.After {
+				if len(args) != 0 {
+					stmtBuf.WriteString(`,`)
+				}
+				stmtBuf.WriteString(col)
+				args = append(args, colValue)
 			}
-			stmtBuf.WriteString(col)
-			args = append(args, colValue)
-		}
-		stmtBuf.WriteString(`) VALUES (`)
-		for i := range args {
-			if i != 0 {
-				stmtBuf.WriteString(`,`)
+			stmtBuf.WriteString(`) VALUES (`)
+			for i := range args {
+				if i != 0 {
+					stmtBuf.WriteString(`,`)
+				}
+				fmt.Fprintf(&stmtBuf, `$%d`, i+1)
 			}
-			fmt.Fprintf(&stmtBuf, `$%d`, i+1)
+			stmtBuf.WriteString(`)`)
+
+			// Also verify that the key matches the value.
+			primaryKeyDatums := make([]interface{}, len(v.primaryKeyCols))
+			for idx, primaryKeyCol := range v.primaryKeyCols {
+				primaryKeyDatums[idx] = value.After[primaryKeyCol]
+			}
+			primaryKeyJSON, err := gojson.Marshal(primaryKeyDatums)
+			if err != nil {
+				return err
+			}
+			if string(primaryKeyJSON) != row.key {
+				v.failures = append(v.failures, fmt.Sprintf(
+					`key %s did not match expected key %s for value %s`, row.key, primaryKeyJSON, row.value))
+			}
+		} else {
+			// DELETE
+			var primaryKeyDatums []interface{}
+			if err := gojson.Unmarshal([]byte(row.key), &primaryKeyDatums); err != nil {
+				return err
+			}
+			if len(primaryKeyDatums) != len(v.primaryKeyCols) {
+				return errors.Errorf(
+					`expected primary key columns %s got datums %s`, v.primaryKeyCols, primaryKeyDatums)
+			}
+			fmt.Fprintf(&stmtBuf, `DELETE FROM %s WHERE `, v.fprintTable)
+			for i, datum := range primaryKeyDatums {
+				if len(args) != 0 {
+					stmtBuf.WriteString(`,`)
+				}
+				fmt.Fprintf(&stmtBuf, `%s = $%d`, v.primaryKeyCols[i], i+1)
+				args = append(args, datum)
+			}
 		}
-		stmtBuf.WriteString(`)`)
 		if len(args) > 0 {
 			if _, err := v.sqlDB.Exec(stmtBuf.String(), args...); err != nil {
 				return errors.Wrap(err, stmtBuf.String())

--- a/pkg/ccl/changefeedccl/cdctest/validator_test.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
 )
 
 func ts(i int64) hlc.Timestamp {
@@ -101,7 +102,7 @@ func TestFingerprintValidator(t *testing.T) {
 	sqlDB.Exec(t, `CREATE DATABASE d`)
 	sqlDB.Exec(t, `CREATE TABLE foo (k INT PRIMARY KEY, v INT)`)
 
-	tsRaw := make([]string, 5)
+	tsRaw := make([]string, 6)
 	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&tsRaw[0])
 	sqlDB.QueryRow(t,
 		`UPSERT INTO foo VALUES (1, 1) RETURNING cluster_logical_timestamp()`,
@@ -112,7 +113,10 @@ func TestFingerprintValidator(t *testing.T) {
 	sqlDB.QueryRow(t,
 		`UPSERT INTO foo VALUES (1, 3) RETURNING cluster_logical_timestamp()`,
 	).Scan(&tsRaw[3])
-	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&tsRaw[4])
+	sqlDB.QueryRow(t,
+		`DELETE FROM foo WHERE k = 1 RETURNING cluster_logical_timestamp()`,
+	).Scan(&tsRaw[4])
+	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&tsRaw[5])
 	ts := make([]hlc.Timestamp, len(tsRaw))
 	for i := range tsRaw {
 		var err error
@@ -124,13 +128,15 @@ func TestFingerprintValidator(t *testing.T) {
 
 	t.Run(`empty`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE empty (k INT PRIMARY KEY, v INT)`)
-		v := NewFingerprintValidator(sqlDBRaw, `foo`, `empty`, []string{`p`})
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `empty`, []string{`p`})
+		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		assertValidatorFailures(t, v)
 	})
 	t.Run(`wrong_data`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE wrong_data (k INT PRIMARY KEY, v INT)`)
-		v := NewFingerprintValidator(sqlDBRaw, `foo`, `wrong_data`, []string{`p`})
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `wrong_data`, []string{`p`})
+		require.NoError(t, err)
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":10}}`, ts[1])
 		noteResolved(t, v, `p`, ts[1])
 		assertValidatorFailures(t, v,
@@ -140,37 +146,43 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`all_resolved`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE all_resolved (k INT PRIMARY KEY, v INT)`)
-		v := NewFingerprintValidator(sqlDBRaw, `foo`, `all_resolved`, []string{`p`})
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `all_resolved`, []string{`p`})
+		require.NoError(t, err)
 		if err := v.NoteResolved(`p`, ts[0]); err != nil {
 			t.Fatal(err)
 		}
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
 		noteResolved(t, v, `p`, ts[1])
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2])
-		v.NoteRow(ignored, `[1]`, `{"after": {"k":2,"v":2}}`, ts[2])
+		v.NoteRow(ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[2])
 		noteResolved(t, v, `p`, ts[2])
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":3}}`, ts[3])
 		noteResolved(t, v, `p`, ts[3])
+		v.NoteRow(ignored, `[1]`, `{"after": null}`, ts[4])
 		noteResolved(t, v, `p`, ts[4])
+		noteResolved(t, v, `p`, ts[5])
 		assertValidatorFailures(t, v)
 	})
 	t.Run(`rows_unsorted`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE rows_unsorted (k INT PRIMARY KEY, v INT)`)
-		v := NewFingerprintValidator(sqlDBRaw, `foo`, `rows_unsorted`, []string{`p`})
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `rows_unsorted`, []string{`p`})
+		require.NoError(t, err)
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":3}}`, ts[3])
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2])
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
-		v.NoteRow(ignored, `[1]`, `{"after": {"k":2,"v":2}}`, ts[2])
-		noteResolved(t, v, `p`, ts[4])
+		v.NoteRow(ignored, `[1]`, `{"after": null}`, ts[4])
+		v.NoteRow(ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[2])
+		noteResolved(t, v, `p`, ts[5])
 		assertValidatorFailures(t, v)
 	})
 	t.Run(`missed_initial`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE missed_initial (k INT PRIMARY KEY, v INT)`)
-		v := NewFingerprintValidator(sqlDBRaw, `foo`, `missed_initial`, []string{`p`})
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `missed_initial`, []string{`p`})
+		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		// Intentionally missing {"k":1,"v":1} at ts[1].
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2])
-		v.NoteRow(ignored, `[1]`, `{"after": {"k":2,"v":2}}`, ts[2])
+		v.NoteRow(ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[2])
 		noteResolved(t, v, `p`, ts[2])
 		assertValidatorFailures(t, v,
 			`fingerprints did not match at `+ts[2].Prev().AsOfSystemTime()+
@@ -179,11 +191,12 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`missed_middle`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE missed_middle (k INT PRIMARY KEY, v INT)`)
-		v := NewFingerprintValidator(sqlDBRaw, `foo`, `missed_middle`, []string{`p`})
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `missed_middle`, []string{`p`})
+		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
 		// Intentionally missing {"k":1,"v":2} at ts[2].
-		v.NoteRow(ignored, `[1]`, `{"after": {"k":2,"v":2}}`, ts[2])
+		v.NoteRow(ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[2])
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":3}}`, ts[3])
 		noteResolved(t, v, `p`, ts[3])
 		assertValidatorFailures(t, v,
@@ -195,11 +208,12 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`missed_end`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE missed_end (k INT PRIMARY KEY, v INT)`)
-		v := NewFingerprintValidator(sqlDBRaw, `foo`, `missed_end`, []string{`p`})
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `missed_end`, []string{`p`})
+		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2])
-		v.NoteRow(ignored, `[1]`, `{"after": {"k":2,"v":2}}`, ts[2])
+		v.NoteRow(ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[2])
 		// Intentionally missing {"k":1,"v":3} at ts[3].
 		noteResolved(t, v, `p`, ts[3])
 		assertValidatorFailures(t, v,
@@ -209,21 +223,25 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`initial_scan`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE initial_scan (k INT PRIMARY KEY, v INT)`)
-		v := NewFingerprintValidator(sqlDBRaw, `foo`, `initial_scan`, []string{`p`})
-		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":3}}`, ts[4])
-		v.NoteRow(ignored, `[1]`, `{"after": {"k":2,"v":2}}`, ts[4])
-		noteResolved(t, v, `p`, ts[4])
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `initial_scan`, []string{`p`})
+		require.NoError(t, err)
+		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":3}}`, ts[3])
+		v.NoteRow(ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[3])
+		noteResolved(t, v, `p`, ts[3])
 		assertValidatorFailures(t, v)
 	})
 	t.Run(`unknown_partition`, func(t *testing.T) {
-		v := NewFingerprintValidator(sqlDBRaw, `foo`, `unknown_partition`, []string{`p`})
+		sqlDB.Exec(t, `CREATE TABLE unknown_partition (k INT PRIMARY KEY, v INT)`)
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `unknown_partition`, []string{`p`})
+		require.NoError(t, err)
 		if err := v.NoteResolved(`nope`, ts[1]); !testutils.IsError(err, `unknown partition`) {
 			t.Fatalf(`expected "unknown partition" error got: %+v`, err)
 		}
 	})
 	t.Run(`resolved_unsorted`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE resolved_unsorted (k INT PRIMARY KEY, v INT)`)
-		v := NewFingerprintValidator(sqlDBRaw, `foo`, `resolved_unsorted`, []string{`p`})
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `resolved_unsorted`, []string{`p`})
+		require.NoError(t, err)
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
 		noteResolved(t, v, `p`, ts[1])
 		noteResolved(t, v, `p`, ts[1])
@@ -232,7 +250,8 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`two_partitions`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE two_partitions (k INT PRIMARY KEY, v INT)`)
-		v := NewFingerprintValidator(sqlDBRaw, `foo`, `two_partitions`, []string{`p0`, `p1`})
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `two_partitions`, []string{`p0`, `p1`})
+		require.NoError(t, err)
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2])
 		// Intentionally missing {"k":2,"v":2}.

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -238,12 +238,11 @@ func changefeedPlanHook(
 		//   storage sink. Kafka etc have a key and value field in each message but
 		//   cloud storage sinks don't have anywhere to put the key. So if the key
 		//   is not in the value, then for DELETEs there is no way to recover which
-		//   key was deleted. We could make the user explictly pass this option for
+		//   key was deleted. We could make the user explicitly pass this option for
 		//   every cloud storage sink and error if they don't, but that seems
 		//   user-hostile for insufficient reason. We can't do this any earlier,
 		//   because we might return errors about `key_in_value` being incompatible
-		//   with something when the user didn't explictly request that option,
-		//   which is confusing.
+		//   which is confusing when the user didn't type that option.
 		// - Finally, we create a "canary" sink to test sink configuration and
 		//   connectivity. This has to go last because it is strange to return sink
 		//   connectivity errors before we've finished validating all the other

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -61,19 +61,21 @@ func TestCloudStorageSink(t *testing.T) {
 	settings := cluster.MakeTestingClusterSettings()
 	settings.ExternalIODir = dir
 	opts := map[string]string{
-		optFormat:   string(optFormatJSON),
-		optEnvelope: string(optEnvelopeWrapped),
+		optFormat:     string(optFormatJSON),
+		optEnvelope:   string(optEnvelopeWrapped),
+		optKeyInValue: ``,
 	}
 	ts := func(i int64) hlc.Timestamp { return hlc.Timestamp{WallTime: i} }
-	e := makeJSONEncoder(opts)
+	e, err := makeJSONEncoder(opts)
+	require.NoError(t, err)
 
 	t.Run(`golden`, func(t *testing.T) {
 		t1 := &sqlbase.TableDescriptor{Name: `t1`}
 
 		sinkDir := `golden`
 		s, err := makeCloudStorageSink(`nodelocal:///`+sinkDir, 1, unlimitedFileSize, settings, opts)
-		s.(*cloudStorageSink).sinkID = 7 // Force a deterministic sinkID.
 		require.NoError(t, err)
+		s.(*cloudStorageSink).sinkID = 7 // Force a deterministic sinkID.
 
 		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1)))
 		require.NoError(t, s.Flush(ctx))

--- a/pkg/ccl/changefeedccl/validations_test.go
+++ b/pkg/ccl/changefeedccl/validations_test.go
@@ -69,11 +69,13 @@ func TestValidations(t *testing.T) {
 			})
 
 			const requestedResolved = 7
+			sqlDB.Exec(t, `CREATE TABLE fprint (id INT PRIMARY KEY, balance INT, payload STRING)`)
+			fprintV, err := cdctest.NewFingerprintValidator(db, `bank`, `fprint`, bankFeed.Partitions())
+			require.NoError(t, err)
 			v := cdctest.MakeCountValidator(cdctest.Validators{
 				cdctest.NewOrderValidator(`bank`),
-				cdctest.NewFingerprintValidator(db, `bank`, `fprint`, bankFeed.Partitions()),
+				fprintV,
 			})
-			sqlDB.Exec(t, `CREATE TABLE fprint (id INT PRIMARY KEY, balance INT, payload STRING)`)
 			for {
 				m, err := bankFeed.Next()
 				if err != nil {

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -306,6 +306,12 @@ func runCDCBank(ctx context.Context, t *test, c *cluster) {
 		}
 		defer tc.Close()
 
+		if _, err := db.Exec(
+			`CREATE TABLE fprint (id INT PRIMARY KEY, balance INT, payload STRING)`,
+		); err != nil {
+			return err
+		}
+
 		const requestedResolved = 100
 		fprintV, err := cdctest.NewFingerprintValidator(db, `bank.bank`, `fprint`, tc.partitions)
 		if err != nil {
@@ -315,11 +321,6 @@ func runCDCBank(ctx context.Context, t *test, c *cluster) {
 			cdctest.NewOrderValidator(`bank`),
 			fprintV,
 		})
-		if _, err := db.Exec(
-			`CREATE TABLE fprint (id INT PRIMARY KEY, balance INT, payload STRING)`,
-		); err != nil {
-			return err
-		}
 
 		for {
 			m := tc.Next(ctx)

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -307,9 +307,13 @@ func runCDCBank(ctx context.Context, t *test, c *cluster) {
 		defer tc.Close()
 
 		const requestedResolved = 100
+		fprintV, err := cdctest.NewFingerprintValidator(db, `bank.bank`, `fprint`, tc.partitions)
+		if err != nil {
+			return err
+		}
 		v := cdctest.MakeCountValidator(cdctest.Validators{
 			cdctest.NewOrderValidator(`bank`),
-			cdctest.NewFingerprintValidator(db, `bank.bank`, `fprint`, tc.partitions),
+			fprintV,
 		})
 		if _, err := db.Exec(
 			`CREATE TABLE fprint (id INT PRIMARY KEY, balance INT, payload STRING)`,


### PR DESCRIPTION
All the other sinks (Kafka etc) have a place in each message for a key
and a value, but cloud storage sinks only have a place for a key. The
wrapper format we just moved to has a natural place to put the key (as
an entry in the wrapper), but we weren't doing this.

This commit adds a `WITH key_in_value` option that turns on this
behavior and defaults it to on for any changefeed using a cloud storage
sink.

Closes #36994

Release note (bug fix): `CHANGEFEED` now have a key_in_value option;
this is automatically used for cloud storage sinks, making the primary
key of deleted rows recoverable