### PR TITLE
changefeedccl: expand nemeses testing

### DIFF
--- a/pkg/ccl/changefeedccl/nemeses_test.go
+++ b/pkg/ccl/changefeedccl/nemeses_test.go
@@ -33,7 +33,7 @@ func TestChangefeedNemeses(t *testing.T) {
 		}
 	}
 	t.Run(`sinkless`, sinklessTest(testFn))
-	// TODO(dan): This deadlocks t.Run(`enterprise`, enterpriseTest(testFn))
-	// TODO(dan): This deadlocks t.Run(`poller`, pollerTest(sinklessTest, testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 	t.Run(`cloudstorage`, cloudStorageTest(testFn))
 }


### PR DESCRIPTION
Most importantly, also run the `enterprise` and `poller` variants. These
were flaky the last time I looked at this (~month ago), but the fixes
that have gone in were enough to stabilize them. \o/

The one major addition necessary to get this to work is a timeout to
break deadlocks in the poller test. See the comment in the code for
details. Luckily, the poller is going away in 19.2, so we get to remove
this when that happens.

The `eventPush` nemesis is also enabled. It's possible that the other
ones could be turned on at this point, too, but I ran out of time to
test this today.

Also include a few cleanups:

- Move reading from the changefeed into `noteFeedMessage`. It was being
  read before and passed as a payload as a historical accident.
  Originally, the state machine kept track of whether the changefeed was
  in the initial scan or not and so row update vs resolved timestamp had
  to be different events, requiring that the message be read first.
  Keeping track of initial scan vs steady state in the state machine
  never turned out to be interesting for anything, so reversing course
  on this is no big loss. Also this is cleaner.
- Include the `Paused` field name in the fsm.Pattern, greatly increasing
  readability.

Ran this with roachprod-stress for a while and everything seems pretty
stable:

    16951 runs so far, 0 failures, over 41m15s

Release note: None