### PR TITLE
server: ensure first node status written within Server.Start()

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -759,12 +759,12 @@ func (n *Node) startGraphiteStatsExporter(st *cluster.Settings) {
 func (n *Node) startWriteNodeStatus(frequency time.Duration) {
 	ctx := logtags.AddTag(n.AnnotateCtx(context.Background()), "summaries", nil)
 	// Immediately record summaries once on server startup.
+	if err := n.writeNodeStatus(ctx, 0 /* alertTTL */); err != nil {
+		log.Warningf(ctx, "error recording initial status summaries: %s", err)
+	}
 	n.stopper.RunWorker(ctx, func(ctx context.Context) {
 		// Write a status summary immediately; this helps the UI remain
 		// responsive when new nodes are added.
-		if err := n.writeNodeStatus(ctx, 0 /* alertTTL */); err != nil {
-			log.Warningf(ctx, "error recording initial status summaries: %s", err)
-		}
 		ticker := time.NewTicker(frequency)
 		defer ticker.Stop()
 		for {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1545,9 +1545,6 @@ func (s *Server) Start(ctx context.Context) error {
 		s.cfg.AmbientCtx, s.recorder, DefaultMetricsSampleInterval, ts.Resolution10s, s.stopper,
 	)
 
-	// Begin recording status summaries.
-	s.node.startWriteNodeStatus(DefaultMetricsSampleInterval)
-
 	var graphiteOnce sync.Once
 	graphiteEndpoint.SetOnChange(&s.st.SV, func() {
 		if graphiteEndpoint.Get(&s.st.SV) != "" {
@@ -1600,6 +1597,9 @@ func (s *Server) Start(ctx context.Context) error {
 			log.Warning(ctx, errors.Wrap(err, "writing last up timestamp"))
 		}
 	})
+
+	// Begin recording status summaries.
+	s.node.startWriteNodeStatus(DefaultMetricsSampleInterval)
 
 	{
 		var regLiveness jobs.NodeLiveness = s.nodeLiveness


### PR DESCRIPTION
The fix ensures that the status of the first node is written before
the end of `Server.Start`. Currently this is deferred
and sometimes the code doesn't execute by the time the tests start
running. For the rest of the nodes, the status is written as part of
the node bootstrap.

Fixes #33559, FIxes #36990.

Release note: None