### PR TITLE
opt: don't use delegateQuery for ShowZoneConfig

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1841,7 +1841,7 @@ CREATE TABLE crdb_internal.zones (
 		if err != nil {
 			return err
 		}
-		values := make(tree.Datums, len(showZoneConfigNodeColumns))
+		values := make(tree.Datums, len(showZoneConfigColumns))
 		for _, r := range rows {
 			id := uint32(tree.MustBeDInt(r[0]))
 

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -392,7 +392,6 @@ func doExpandPlan(
 	case *setVarNode:
 	case *setClusterSettingNode:
 	case *setZoneConfigNode:
-	case *showZoneConfigNode:
 	case *showFingerprintsNode:
 	case *showTraceNode:
 	case *scatterNode:
@@ -903,7 +902,6 @@ func (p *planner) simplifyOrderings(plan planNode, usefulOrdering sqlbase.Column
 	case *setVarNode:
 	case *setClusterSettingNode:
 	case *setZoneConfigNode:
-	case *showZoneConfigNode:
 	case *showFingerprintsNode:
 	case *showTraceNode:
 	case *scatterNode:

--- a/pkg/sql/opt_filters.go
+++ b/pkg/sql/opt_filters.go
@@ -399,7 +399,6 @@ func (p *planner) propagateFilters(
 	case *setVarNode:
 	case *setClusterSettingNode:
 	case *setZoneConfigNode:
-	case *showZoneConfigNode:
 	case *showFingerprintsNode:
 	case *showTraceNode:
 	case *scatterNode:

--- a/pkg/sql/opt_limits.go
+++ b/pkg/sql/opt_limits.go
@@ -234,7 +234,6 @@ func (p *planner) applyLimit(plan planNode, numRows int64, soft bool) {
 	case *setVarNode:
 	case *setClusterSettingNode:
 	case *setZoneConfigNode:
-	case *showZoneConfigNode:
 	case *showFingerprintsNode:
 	case *showTraceNode:
 	case *scatterNode:

--- a/pkg/sql/opt_needed.go
+++ b/pkg/sql/opt_needed.go
@@ -290,7 +290,6 @@ func setNeededColumns(plan planNode, needed []bool) {
 	case *setVarNode:
 	case *setClusterSettingNode:
 	case *setZoneConfigNode:
-	case *showZoneConfigNode:
 	case *showFingerprintsNode:
 	case *showTraceNode:
 	case *scatterNode:

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -107,8 +107,6 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		return n.getColumns(mut, relocateNodeColumns)
 	case *scatterNode:
 		return n.getColumns(mut, scatterNodeColumns)
-	case *showZoneConfigNode:
-		return n.getColumns(mut, showZoneConfigNodeColumns)
 	case *showFingerprintsNode:
 		return n.getColumns(mut, showFingerprintsColumns)
 	case *splitNode:

--- a/pkg/sql/plan_physical_props.go
+++ b/pkg/sql/plan_physical_props.go
@@ -136,7 +136,6 @@ func planPhysicalProps(plan planNode) physicalProps {
 	case *showFingerprintsNode:
 	case *showTraceNode:
 	case *showTraceReplicaNode:
-	case *showZoneConfigNode:
 	case *splitNode:
 	case *truncateNode:
 	case *unaryNode:

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -777,7 +777,6 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&showFingerprintsNode{}):     "showFingerprints",
 	reflect.TypeOf(&showTraceNode{}):            "show trace for",
 	reflect.TypeOf(&showTraceReplicaNode{}):     "replica trace",
-	reflect.TypeOf(&showZoneConfigNode{}):       "show zone configuration",
 	reflect.TypeOf(&sortNode{}):                 "sort",
 	reflect.TypeOf(&splitNode{}):                "split",
 	reflect.TypeOf(&spoolNode{}):                "spool",


### PR DESCRIPTION
Part of a larger work item to remove `delegateQuery`, as it doesn't
work with the optimizer.

I could not use the new delegate infrastructure because it doesn't support hiding columns returned by the delegated query.

Release note: None