### PR TITLE
sqlbase: fix array encoding for arrays of wrapped types

### DIFF
--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -1135,6 +1135,8 @@ func encodeArrayElement(b []byte, d tree.Datum) ([]byte, error) {
 		return encoding.EncodeUntaggedIntValue(b, int64(t.DInt)), nil
 	case *tree.DCollatedString:
 		return encoding.EncodeUntaggedBytesValue(b, []byte(t.Contents)), nil
+	case *tree.DOidWrapper:
+		return encodeArrayElement(b, t.Wrapped)
 	default:
 		return nil, errors.Errorf("don't know how to encode %s (%T)", d, d)
 	}

--- a/pkg/sql/sqlbase/table_test.go
+++ b/pkg/sql/sqlbase/table_test.go
@@ -294,6 +294,14 @@ func TestArrayEncoding(t *testing.T) {
 			},
 			[]byte{1, 6, 3, 3, 102, 111, 111, 3, 98, 97, 114, 3, 98, 97, 122},
 		}, {
+			"name array",
+			tree.DArray{
+				ParamTyp: types.Name,
+				Array:    tree.Datums{tree.NewDName("foo"), tree.NewDName("bar"), tree.NewDName("baz")},
+			},
+			[]byte{1, 6, 3, 3, 102, 111, 111, 3, 98, 97, 114, 3, 98, 97, 122},
+		},
+		{
 			"bool array",
 			tree.DArray{
 				ParamTyp: types.Bool,


### PR DESCRIPTION
Previously, it was impossible to encode arrays with element types that
required oid wrapping (DName and DOid).

Fixes #36736.

Release note (bug fix): make it possible to write to columns of type
name[].