### PR TITLE
sql: support SHOW COLUMNS ... WITH COMMENTS

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -450,7 +450,7 @@ show_backup_stmt ::=
 	'SHOW' 'BACKUP' string_or_placeholder
 
 show_columns_stmt ::=
-	'SHOW' 'COLUMNS' 'FROM' table_name
+	'SHOW' 'COLUMNS' 'FROM' table_name with_comment
 
 show_constraints_stmt ::=
 	'SHOW' 'CONSTRAINT' 'FROM' table_name
@@ -1123,6 +1123,10 @@ var_value ::=
 	a_expr
 	| extra_var_value
 
+with_comment ::=
+	'WITH' 'COMMENT'
+	| 
+
 opt_on_targets_roles ::=
 	'ON' targets_roles
 	| 
@@ -1146,10 +1150,6 @@ ranges_kw ::=
 table_index_name ::=
 	table_name '@' index_name
 	| standalone_index_name
-
-with_comment ::=
-	'WITH' 'COMMENT'
-	| 
 
 opt_compact ::=
 	'COMPACT'

--- a/pkg/sql/logictest/testdata/logic_test/default
+++ b/pkg/sql/logictest/testdata/logic_test/default
@@ -39,6 +39,18 @@ c            FLOAT8     true         random()           ·                      
 d            DATE       true         now():::DATE       ·                      {}         false
 
 statement ok
+COMMENT ON COLUMN t.a IS 'a'
+
+query TTBTTTBT colnames
+SHOW COLUMNS FROM t WITH COMMENT
+----
+column_name  data_type  is_nullable  column_default     generation_expression  indices    is_hidden  comment
+a            INT8       false        42:::INT8          ·                      {primary}  false      a
+b            TIMESTAMP  true         now():::TIMESTAMP  ·                      {}         false      NULL
+c            FLOAT8     true         random()           ·                      {}         false      NULL
+d            DATE       true         now():::DATE       ·                      {}         false      NULL
+
+statement ok
 INSERT INTO t VALUES (DEFAULT, DEFAULT, DEFAULT, DEFAULT)
 
 query IBBB

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3292,10 +3292,10 @@ show_csettings_stmt:
 // %Text: SHOW COLUMNS FROM <tablename>
 // %SeeAlso: WEBDOCS/show-columns.html
 show_columns_stmt:
-  SHOW COLUMNS FROM table_name
+  SHOW COLUMNS FROM table_name with_comment
   {
     name := $4.unresolvedObjectName().ToTableName()
-    $$.val = &tree.ShowColumns{Table: name}
+    $$.val = &tree.ShowColumns{Table: name, WithComment: $5.bool()}
   }
 | SHOW COLUMNS error // SHOW HELP: SHOW COLUMNS
 

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -96,13 +96,18 @@ func (node *ShowBackup) Format(ctx *FmtCtx) {
 
 // ShowColumns represents a SHOW COLUMNS statement.
 type ShowColumns struct {
-	Table TableName
+	Table       TableName
+	WithComment bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowColumns) Format(ctx *FmtCtx) {
 	ctx.WriteString("SHOW COLUMNS FROM ")
 	ctx.FormatNode(&node.Table)
+
+	if node.WithComment {
+		ctx.WriteString(" WITH COMMENT")
+	}
 }
 
 // ShowDatabases represents a SHOW DATABASES statement.


### PR DESCRIPTION
Informs #36439.

Release note (sql change): support SHOW COLUMNS ... WITH COMMENTS
now supports printing out column comments using the optional phrase
`WITH COMMENT`, e.g `SHOW COLUMNS FROM mytable WITH COMMENT`.