### PR TITLE
sql: support SHOW DATABASES WITH COMMENTS

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -465,7 +465,7 @@ show_csettings_stmt ::=
 	| 'SHOW' 'ALL' 'CLUSTER' 'SETTINGS'
 
 show_databases_stmt ::=
-	'SHOW' 'DATABASES'
+	'SHOW' 'DATABASES' with_comment
 
 show_grants_stmt ::=
 	'SHOW' 'GRANTS' opt_on_targets_roles for_grantee_clause

--- a/pkg/sql/logictest/testdata/logic_test/database
+++ b/pkg/sql/logictest/testdata/logic_test/database
@@ -22,6 +22,19 @@ postgres
 system
 test
 
+statement ok
+COMMENT ON DATABASE a IS 'A'
+
+query TT colnames
+SHOW DATABASES WITH COMMENT
+----
+database_name  comment
+a              A
+defaultdb      NULL
+postgres       NULL
+system         NULL
+test           NULL
+
 query T colnames
 SHOW SCHEMAS FROM a
 ----

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3318,9 +3318,9 @@ show_columns_stmt:
 // %Text: SHOW DATABASES
 // %SeeAlso: WEBDOCS/show-databases.html
 show_databases_stmt:
-  SHOW DATABASES
+  SHOW DATABASES with_comment
   {
-    $$.val = &tree.ShowDatabases{}
+    $$.val = &tree.ShowDatabases{WithComment: $3.bool()}
   }
 | SHOW DATABASES error // SHOW HELP: SHOW DATABASES
 

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -111,11 +111,17 @@ func (node *ShowColumns) Format(ctx *FmtCtx) {
 }
 
 // ShowDatabases represents a SHOW DATABASES statement.
-type ShowDatabases struct{}
+type ShowDatabases struct {
+	WithComment bool
+}
 
 // Format implements the NodeFormatter interface.
 func (node *ShowDatabases) Format(ctx *FmtCtx) {
 	ctx.WriteString("SHOW DATABASES")
+
+	if node.WithComment {
+		ctx.WriteString(" WITH COMMENT")
+	}
 }
 
 // ShowTraceType is an enum of SHOW TRACE variants.


### PR DESCRIPTION
Informs #36439.

Release note (sql change): support SHOW DATABASES WITH COMMENTS
now supports printing out database comments using the optional phrase
`WITH COMMENT`, e.g `SHOW DATABASES WITH COMMENT`.