### PR TITLE
all: fix various static checks

### DIFF
--- a/pkg/base/store_spec.go
+++ b/pkg/base/store_spec.go
@@ -26,7 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
-	"github.com/dustin/go-humanize"
+	humanize "github.com/dustin/go-humanize"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 )
@@ -196,7 +196,7 @@ func (ss StoreSpec) String() string {
 			if i != 0 {
 				fmt.Fprint(&buffer, ":")
 			}
-			fmt.Fprintf(&buffer, attr)
+			buffer.WriteString(attr)
 		}
 		fmt.Fprintf(&buffer, ",")
 	}

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -45,9 +45,6 @@ func TestShowBackup(t *testing.T) {
 	if !(*end).After(beforeFull) {
 		t.Errorf("expected now (%s) to be in (%s, %s)", beforeFull, start, end)
 	}
-	if dataSize <= 0 {
-		t.Errorf("expected dataSize to be >0 got : %d", dataSize)
-	}
 	if rows != numAccounts {
 		t.Errorf("expected %d got: %d", numAccounts, rows)
 	}
@@ -73,9 +70,6 @@ func TestShowBackup(t *testing.T) {
 	}
 	if !(*end).After(beforeInc) {
 		t.Errorf("expected now (%s) to be in (%s, %s)", beforeInc, start, end)
-	}
-	if dataSize <= 0 {
-		t.Errorf("expected dataSize to be >0 got : %d", dataSize)
 	}
 	// We added affectedRows and removed affectedRows, so there should be 2*
 	// affectedRows in the backup.

--- a/pkg/ccl/partitionccl/partition.go
+++ b/pkg/ccl/partitionccl/partition.go
@@ -297,15 +297,15 @@ func selectPartitionExprs(
 	}
 	// In order to typecheck during simplification and normalization, we used
 	// dummy IndexVars. Swap them out for actual column references.
-	finalExpr, err := tree.SimpleVisit(expr, func(e tree.Expr) (error, bool, tree.Expr) {
+	finalExpr, err := tree.SimpleVisit(expr, func(e tree.Expr) (recurse bool, newExpr tree.Expr, _ error) {
 		if ivar, ok := e.(*tree.IndexedVar); ok {
 			col, err := tableDesc.FindColumnByID(sqlbase.ColumnID(ivar.Idx))
 			if err != nil {
-				return err, false, nil
+				return false, nil, err
 			}
-			return nil, false, &tree.ColumnItem{ColumnName: tree.Name(col.Name)}
+			return false, &tree.ColumnItem{ColumnName: tree.Name(col.Name)}, nil
 		}
-		return nil, true, e
+		return true, e, nil
 	})
 	return finalExpr, err
 }

--- a/pkg/cli/examples.go
+++ b/pkg/cli/examples.go
@@ -69,7 +69,7 @@ func runGenExamplesCmd(gen workload.Generator) {
 		}
 	}
 
-	fmt.Fprintf(w, footerComment)
+	fmt.Fprint(w, footerComment)
 }
 
 const footerComment = `--

--- a/pkg/cmd/roachtest/canary.go
+++ b/pkg/cmd/roachtest/canary.go
@@ -178,7 +178,7 @@ func repeatGitCloneE(
 		}
 		return nil
 	}
-	return fmt.Errorf("Could not clone %s due to error: %s", src, lastError)
+	return fmt.Errorf("could not clone %s due to error: %s", src, lastError)
 }
 
 // repeatGetLatestTag fetches the latest (sorted) tag from a github repo.

--- a/pkg/jobs/jobspb/wrap.go
+++ b/pkg/jobs/jobspb/wrap.go
@@ -47,7 +47,7 @@ func (p *Payload) Type() Type {
 
 // DetailsType returns the type for a payload detail.
 func DetailsType(d isPayload_Details) Type {
-	switch d.(type) {
+	switch d := d.(type) {
 	case *Payload_Backup:
 		return TypeBackup
 	case *Payload_Restore:
@@ -59,7 +59,7 @@ func DetailsType(d isPayload_Details) Type {
 	case *Payload_Changefeed:
 		return TypeChangefeed
 	case *Payload_CreateStats:
-		createStatsName := d.(*Payload_CreateStats).CreateStats.Name
+		createStatsName := d.CreateStats.Name
 		if createStatsName == stats.AutoStatsName {
 			return TypeAutoCreateStats
 		}

--- a/pkg/settings/updater.go
+++ b/pkg/settings/updater.go
@@ -101,7 +101,7 @@ func (u updater) Set(key, rawValue string, vt string) error {
 		}
 		setting.set(u.sv, b)
 		return nil
-	case numericSetting:
+	case numericSetting: // includes *EnumSetting
 		i, err := strconv.Atoi(rawValue)
 		if err != nil {
 			return err
@@ -119,12 +119,6 @@ func (u updater) Set(key, rawValue string, vt string) error {
 			return err
 		}
 		return setting.set(u.sv, d)
-	case *EnumSetting:
-		i, err := strconv.Atoi(rawValue)
-		if err != nil {
-			return err
-		}
-		return setting.set(u.sv, int64(i))
 	case *StateMachineSetting:
 		return setting.set(u.sv, []byte(rawValue))
 	}

--- a/pkg/sql/distsqlrun/mergejoiner.go
+++ b/pkg/sql/distsqlrun/mergejoiner.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 // mergeJoiner performs merge join, it has two input row sources with the same

--- a/pkg/sql/distsqlrun/mergejoiner.go
+++ b/pkg/sql/distsqlrun/mergejoiner.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/opentracing/opentracing-go"
 )
 
 // mergeJoiner performs merge join, it has two input row sources with the same
@@ -64,7 +63,7 @@ func newMergeJoiner(
 	rightEqCols := make([]uint32, 0, len(spec.RightOrdering.Columns))
 	for i, c := range spec.LeftOrdering.Columns {
 		if spec.RightOrdering.Columns[i].Direction != c.Direction {
-			return nil, errors.New("Unmatched column orderings")
+			return nil, errors.New("unmatched column orderings")
 		}
 		leftEqCols = append(leftEqCols, c.ColIdx)
 		rightEqCols = append(rightEqCols, spec.RightOrdering.Columns[i].ColIdx)

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_env
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_env
@@ -74,7 +74,6 @@ ALTER TABLE test.public.x INJECT STATISTICS '[
         "created_at": "2018-01-01 01:00:00+00:00",
         "distinct_count": 100,
         "histo_col_type": "",
-        "name": "",
         "null_count": 0,
         "row_count": 123123
     },
@@ -85,7 +84,6 @@ ALTER TABLE test.public.x INJECT STATISTICS '[
         "created_at": "2018-01-01 01:00:00+00:00",
         "distinct_count": 123123,
         "histo_col_type": "",
-        "name": "",
         "null_count": 0,
         "row_count": 123123
     }
@@ -122,7 +120,6 @@ ALTER TABLE test.public.x INJECT STATISTICS '[
         "created_at": "2018-01-01 01:00:00+00:00",
         "distinct_count": 100,
         "histo_col_type": "",
-        "name": "",
         "null_count": 0,
         "row_count": 123123
     },
@@ -133,7 +130,6 @@ ALTER TABLE test.public.x INJECT STATISTICS '[
         "created_at": "2018-01-01 01:00:00+00:00",
         "distinct_count": 123123,
         "histo_col_type": "",
-        "name": "",
         "null_count": 0,
         "row_count": 123123
     }
@@ -184,7 +180,6 @@ ALTER TABLE test.public.x INJECT STATISTICS '[
         "created_at": "2018-01-01 01:00:00+00:00",
         "distinct_count": 100,
         "histo_col_type": "",
-        "name": "",
         "null_count": 0,
         "row_count": 123123
     },
@@ -195,7 +190,6 @@ ALTER TABLE test.public.x INJECT STATISTICS '[
         "created_at": "2018-01-01 01:00:00+00:00",
         "distinct_count": 123123,
         "histo_col_type": "",
-        "name": "",
         "null_count": 0,
         "row_count": 123123
     }
@@ -323,7 +317,6 @@ ALTER TABLE test.public.x INJECT STATISTICS '[
         "created_at": "2018-01-01 01:00:00+00:00",
         "distinct_count": 100,
         "histo_col_type": "",
-        "name": "",
         "null_count": 0,
         "row_count": 123123
     },
@@ -334,7 +327,6 @@ ALTER TABLE test.public.x INJECT STATISTICS '[
         "created_at": "2018-01-01 01:00:00+00:00",
         "distinct_count": 123123,
         "histo_col_type": "",
-        "name": "",
         "null_count": 0,
         "row_count": 123123
     }

--- a/pkg/sql/opt/optgen/cmd/langgen/main.go
+++ b/pkg/sql/opt/optgen/cmd/langgen/main.go
@@ -134,7 +134,7 @@ func generate(compiled *lang.CompiledExpr, out string, genFunc genFunc) error {
 		if err != nil {
 			// Write out incorrect source for easier debugging.
 			b = buf.Bytes()
-			err = fmt.Errorf("Code formatting failed with Go parse error\n%s:%s", out, err)
+			err = fmt.Errorf("code formatting failed with Go parse error\n%s:%s", out, err)
 		}
 	} else {
 		b = buf.Bytes()

--- a/pkg/sql/opt/optgen/cmd/optgen/main.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/main.go
@@ -206,7 +206,7 @@ func (g *optgen) generate(compiled *lang.CompiledExpr, genFunc genFunc) error {
 			// Write out incorrect source for easier debugging.
 			b = buf.Bytes()
 			out := g.cmdLine.Lookup("out").Value.String()
-			err = fmt.Errorf("Code formatting failed with Go parse error\n%s:%s", out, err)
+			err = fmt.Errorf("code formatting failed with Go parse error\n%s:%s", out, err)
 		}
 	} else {
 		b = buf.Bytes()

--- a/pkg/sql/opt/optgen/cmd/optgen/match_writer.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/match_writer.go
@@ -63,7 +63,7 @@ func (w *matchWriter) write(format string, args ...interface{}) {
 }
 
 func (w *matchWriter) writeIndent(format string, args ...interface{}) {
-	fmt.Fprintf(w.writer, strings.Repeat("  ", w.nesting))
+	fmt.Fprint(w.writer, strings.Repeat("  ", w.nesting))
 	fmt.Fprintf(w.writer, format, args...)
 }
 
@@ -78,7 +78,7 @@ func (w *matchWriter) unnest(suffix string) {
 func (w *matchWriter) unnestToMarker(marker marker, suffix string) {
 	for w.nesting > int(marker) {
 		w.nesting--
-		fmt.Fprintf(w.writer, strings.Repeat("  ", w.nesting))
-		fmt.Fprintf(w.writer, suffix)
+		fmt.Fprint(w.writer, strings.Repeat("  ", w.nesting))
+		fmt.Fprint(w.writer, suffix)
 	}
 }

--- a/pkg/sql/rename_column.go
+++ b/pkg/sql/rename_column.go
@@ -108,20 +108,20 @@ func (p *planner) renameColumn(
 		return false, fmt.Errorf("column name %q already exists", tree.ErrString(newName))
 	}
 
-	preFn := func(expr tree.Expr) (err error, recurse bool, newExpr tree.Expr) {
+	preFn := func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
 		if vBase, ok := expr.(tree.VarName); ok {
 			v, err := vBase.NormalizeVarName()
 			if err != nil {
-				return err, false, nil
+				return false, nil, err
 			}
 			if c, ok := v.(*tree.ColumnItem); ok {
 				if string(c.ColumnName) == string(*oldName) {
 					c.ColumnName = *newName
 				}
 			}
-			return nil, false, v
+			return false, v, nil
 		}
-		return nil, true, expr
+		return true, expr, nil
 	}
 
 	renameIn := func(expression string) (string, error) {

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -716,7 +716,7 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 		if count != val {
 			t.Errorf("e = %d, v = %d", count, val)
 		}
-		if 1.4 != x {
+		if x != 1.4 {
 			t.Errorf("e = %f, v = %f", 1.4, x)
 		}
 	}
@@ -3532,7 +3532,7 @@ ALTER TABLE t.test ADD COLUMN c INT AS (v + 4) STORED, ADD COLUMN d INT DEFAULT 
 		if count+4 != c {
 			t.Errorf("e = %d, v = %d", count, c)
 		}
-		if 23 != d {
+		if d != 23 {
 			t.Errorf("e = %d, v = %d", 23, d)
 		}
 	}
@@ -3725,7 +3725,7 @@ func TestCancelSchemaChange(t *testing.T) {
 		if count != val {
 			t.Errorf("e = %d, v = %d", count, val)
 		}
-		if 1.2 != x {
+		if x != 1.2 {
 			t.Errorf("e = %f, v = %f", 1.2, x)
 		}
 	}

--- a/pkg/sql/sem/builtins/aggregate_builtins_test.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins_test.go
@@ -187,7 +187,7 @@ func makeSmallIntTestDatum(count int) []tree.Datum {
 	vals := make([]tree.Datum, count)
 	for i := range vals {
 		sign := int32(1)
-		if 0 == rng.Int31()&1 {
+		if rng.Int31()&1 == 0 {
 			sign = -1
 		}
 		vals[i] = tree.NewDInt(tree.DInt(rng.Int31() * sign))

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -1386,7 +1386,7 @@ func (v *simpleVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
 	if v.err != nil {
 		return false, expr
 	}
-	v.err, recurse, newExpr = v.fn(expr)
+	recurse, newExpr, v.err = v.fn(expr)
 	if v.err != nil {
 		return false, expr
 	}
@@ -1397,7 +1397,7 @@ func (*simpleVisitor) VisitPost(expr Expr) Expr { return expr }
 
 // SimpleVisitFn is a function that is run for every node in the VisitPre stage;
 // see SimpleVisit.
-type SimpleVisitFn func(expr Expr) (err error, recurse bool, newExpr Expr)
+type SimpleVisitFn func(expr Expr) (recurse bool, newExpr Expr, err error)
 
 // SimpleVisit is a convenience wrapper for visitors that only have VisitPre
 // code and don't return any results except an error. The given function is

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -379,12 +379,12 @@ func getUsedSequenceNames(defaultExpr tree.TypedExpr) ([]string, error) {
 	var names []string
 	_, err := tree.SimpleVisit(
 		defaultExpr,
-		func(expr tree.Expr) (err error, recurse bool, newExpr tree.Expr) {
+		func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
 			switch t := expr.(type) {
 			case *tree.FuncExpr:
 				def, err := t.Func.Resolve(searchPath)
 				if err != nil {
-					return err, false, expr
+					return false, expr, err
 				}
 				if def.Name == "nextval" {
 					arg := t.Exprs[0]
@@ -394,7 +394,7 @@ func getUsedSequenceNames(defaultExpr tree.TypedExpr) ([]string, error) {
 					}
 				}
 			}
-			return nil, true, expr
+			return true, expr, nil
 		},
 	)
 	if err != nil {

--- a/pkg/sql/stats/create_stats_job_test.go
+++ b/pkg/sql/stats/create_stats_job_test.go
@@ -617,7 +617,7 @@ func TestCreateStatsAsOfTime(t *testing.T) {
 
 	sqlDB.Exec(t, `INSERT INTO d.t VALUES (2)`)
 
-	sqlDB.Exec(t, fmt.Sprintf("CREATE STATISTICS s FROM d.t AS OF SYSTEM TIME %s", ts1))
+	sqlDB.Exec(t, fmt.Sprintf("CREATE STATISTICS s FROM d.t AS OF SYSTEM TIME %s", string(ts1)))
 
 	// Check that we only see the first row, not the second.
 	sqlDB.CheckQueryResults(t,

--- a/pkg/sql/stats/json.go
+++ b/pkg/sql/stats/json.go
@@ -29,7 +29,7 @@ import (
 //
 // See TableStatistic for a description of the fields.
 type JSONStatistic struct {
-	Name          string   `json:"name,omitEmpty"`
+	Name          string   `json:"name,omitempty"`
 	CreatedAt     string   `json:"created_at"`
 	Columns       []string `json:"columns"`
 	RowCount      uint64   `json:"row_count"`
@@ -39,7 +39,7 @@ type JSONStatistic struct {
 	// histogram (or unset if there is no histogram). Parsable with
 	// tree.ParseType.
 	HistogramColumnType string            `json:"histo_col_type"`
-	HistogramBuckets    []JSONHistoBucket `json:"histo_buckets,omitEmpty"`
+	HistogramBuckets    []JSONHistoBucket `json:"histo_buckets,omitempty"`
 }
 
 // JSONHistoBucket is a struct used for JSON marshaling and unmarshaling of

--- a/pkg/sql/tablewriter_upsert.go
+++ b/pkg/sql/tablewriter_upsert.go
@@ -865,7 +865,7 @@ func (tu *tableUpserter) upsertRowPKSpans(
 			}
 		} else if len(result.Rows) > 1 {
 			panic(fmt.Errorf(
-				"Expected <= 1 but got %d conflicts for row %s", len(result.Rows), tu.insertRows.At(i)))
+				"expected <= 1 but got %d conflicts for row %s", len(result.Rows), tu.insertRows.At(i)))
 		}
 	}
 

--- a/pkg/sql/types/oid.go
+++ b/pkg/sql/types/oid.go
@@ -162,9 +162,6 @@ var familyToOid = map[Family]oid.Oid{
 var ArrayOids = map[oid.Oid]struct{}{}
 
 func init() {
-	if len(oidToArrayOid) != len(oidToArrayOid) {
-		panic("missing some mapping from array element OID to array OID")
-	}
 	for o, ao := range oidToArrayOid {
 		ArrayOids[ao] = struct{}{}
 		OidToType[ao] = MakeArray(OidToType[o])

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -536,12 +536,10 @@ func createSystemTable(ctx context.Context, r runner, desc sqlbase.TableDescript
 		}
 		return txn.Run(ctx, b)
 	})
-	if err != nil {
-		// CPuts only provide idempotent inserts if we ignore the errors that arise
-		// when the condition isn't met.
-		if _, ok := err.(*roachpb.ConditionFailedError); ok {
-			return nil
-		}
+	// CPuts only provide idempotent inserts if we ignore the errors that arise
+	// when the condition isn't met.
+	if _, ok := err.(*roachpb.ConditionFailedError); ok {
+		return nil
 	}
 	return err
 }

--- a/pkg/storage/batcheval/cmd_heartbeat_txn.go
+++ b/pkg/storage/batcheval/cmd_heartbeat_txn.go
@@ -51,7 +51,7 @@ func HeartbeatTxn(
 	}
 
 	if args.Now.IsEmpty() {
-		return result.Result{}, fmt.Errorf("Now not specified for heartbeat")
+		return result.Result{}, fmt.Errorf("now not specified for heartbeat")
 	}
 
 	key := keys.TransactionKey(h.Txn.Key, h.Txn.ID)

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -649,15 +649,13 @@ func (l *leaseTransferTest) forceLeaseExtension(storeIdx int, lease roachpb.Leas
 	shouldRenewTS := lease.Expiration.Add(-1, 0)
 	l.mtc.manualClock.Set(shouldRenewTS.WallTime + 1)
 	err := l.sendRead(storeIdx).GoError()
-	if err != nil {
-		// We can sometimes receive an error from our renewal attempt because the
-		// lease transfer ends up causing the renewal to re-propose and second
-		// attempt fails because it's already been renewed. This used to work
-		// before we compared the proposer's lease with the actual lease because
-		// the renewed lease still encompassed the previous request.
-		if _, ok := err.(*roachpb.NotLeaseHolderError); ok {
-			err = nil
-		}
+	// We can sometimes receive an error from our renewal attempt because the
+	// lease transfer ends up causing the renewal to re-propose and second
+	// attempt fails because it's already been renewed. This used to work
+	// before we compared the proposer's lease with the actual lease because
+	// the renewed lease still encompassed the previous request.
+	if _, ok := err.(*roachpb.NotLeaseHolderError); ok {
+		err = nil
 	}
 	return err
 }

--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -2255,9 +2255,6 @@ func (r *Replica) applyRaftCommand(
 	raftAppliedIndex, leaseAppliedIndex uint64,
 	writeBatch *storagepb.WriteBatch,
 ) (storagepb.ReplicatedEvalResult, error) {
-	if raftAppliedIndex <= 0 {
-		return storagepb.ReplicatedEvalResult{}, errors.New("raft command index is <= 0")
-	}
 	if writeBatch != nil && len(writeBatch.Data) > 0 {
 		// Record the write activity, passing a 0 nodeID because replica.writeStats
 		// intentionally doesn't track the origin of the writes.

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -4330,7 +4330,7 @@ func (s *Store) ManuallyEnqueue(
 	var queue queueImpl
 	var needsLease bool
 	for _, replicaQueue := range s.scanner.queues {
-		if strings.ToLower(replicaQueue.Name()) == strings.ToLower(queueName) {
+		if strings.EqualFold(replicaQueue.Name(), queueName) {
 			queue = replicaQueue.(queueImpl)
 			needsLease = replicaQueue.NeedsLease()
 		}

--- a/pkg/testutils/net_test.go
+++ b/pkg/testutils/net_test.go
@@ -109,7 +109,7 @@ func TestPartitionableConnBasic(t *testing.T) {
 	defer pConn.Close()
 
 	exp := "let's see if this value comes back\n"
-	fmt.Fprintf(pConn, exp)
+	fmt.Fprint(pConn, exp)
 	got, err := bufio.NewReader(pConn).ReadString('\n')
 	if err != nil {
 		t.Fatal(err)
@@ -155,7 +155,7 @@ func TestPartitionableConnPartitionC2S(t *testing.T) {
 
 	// Client sends data.
 	exp := "let's see when this value comes back\n"
-	fmt.Fprintf(pConn, exp)
+	fmt.Fprint(pConn, exp)
 
 	// In the background, the client waits on a read.
 	clientDoneCh := make(chan error)
@@ -238,7 +238,7 @@ func TestPartitionableConnPartitionS2C(t *testing.T) {
 
 	// Client sends data.
 	exp := "let's see when this value comes back\n"
-	fmt.Fprintf(pConn, exp)
+	fmt.Fprint(pConn, exp)
 
 	if s := <-serverSideCh; string(s) != exp {
 		t.Fatalf("expected server to receive %q, got %q", exp, s)

--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -739,7 +739,7 @@ func TestRedirectStderr(t *testing.T) {
 	Infof(context.Background(), "test")
 
 	const stderrText = "hello stderr"
-	fmt.Fprintf(os.Stderr, stderrText)
+	fmt.Fprint(os.Stderr, stderrText)
 
 	contents, err := ioutil.ReadFile(logging.file.(*syncBuffer).file.Name())
 	if err != nil {

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -604,7 +604,7 @@ func (t *Tracer) Extract(format interface{}, carrier interface{}) (opentracing.S
 		// Using a shadow tracer only works if all hosts use the same shadow tracer.
 		// If that's not the case, ignore the shadow context.
 		if shadowTr := t.getShadowTracer(); shadowTr != nil &&
-			strings.ToLower(shadowType) == strings.ToLower(shadowTr.Typ()) {
+			strings.EqualFold(shadowType, shadowTr.Typ()) {
 			sc.shadowTr = shadowTr
 			// Extract the shadow context using the un-encapsulated textmap.
 			sc.shadowCtx, err = shadowTr.Extract(format, shadowCarrier)

--- a/pkg/workload/stats.go
+++ b/pkg/workload/stats.go
@@ -29,7 +29,7 @@ const AutoStatsName = "__auto__"
 // JSONStatistic is copied from stats.JSONStatistic to avoid pulling
 // in a dependency on sql/stats.
 type JSONStatistic struct {
-	Name          string   `json:"name,omitEmpty"`
+	Name          string   `json:"name,omitempty"`
 	CreatedAt     string   `json:"created_at"`
 	Columns       []string `json:"columns"`
 	RowCount      uint64   `json:"row_count"`


### PR DESCRIPTION
#### all: fix static checks (printf with dynamic string)

Fixing instances of: printf-style function with dynamic format string
and no further arguments should use print-style function instead
(SA1006).

Release note: None

#### all: fix static checks (uint >= 0 checks)

Fixing instances of "no value of type uint64 is less than 0 (SA4003)".

Release note: None

#### all: fix static checks (capitalized error messages)

Fixing instances of "error strings should not be capitalized (ST1005)".

Release note: None

#### all: fix static checks (misc checks)

Release note: None

#### tree: move error as last return of SimpleVisitFn

Main reason is to appease some linter checks of an upcoming version.

Release note: None

#### all: fix static checks (dot imports)

Removing some dot imports.

Release note: None
