### PR TITLE
opt: support SHOW TABLES

### DIFF
--- a/pkg/sql/delegate/delegate.go
+++ b/pkg/sql/delegate/delegate.go
@@ -82,6 +82,9 @@ func TryDelegate(
 	case *tree.ShowSyntax:
 		return d.delegateShowSyntax(t)
 
+	case *tree.ShowTables:
+		return d.delegateShowTables(t)
+
 	case *tree.ShowUsers:
 		return d.delegateShowUsers(t)
 

--- a/pkg/sql/logictest/testdata/logic_test/case_sensitive_names
+++ b/pkg/sql/logictest/testdata/logic_test/case_sensitive_names
@@ -8,13 +8,13 @@ CREATE DATABASE D
 statement ok
 SHOW TABLES FROM d
 
-statement error "D" does not match any valid database or schema
+statement error target database or schema does not exist
 SHOW TABLES FROM "D"
 
 statement ok
 CREATE DATABASE "E"
 
-statement error "e" does not match any valid database or schema
+statement error target database or schema does not exist
 SHOW TABLES FROM e
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -702,7 +702,7 @@ SET DATABASE = ""
 statement error pq: syntax error at or near "@"
 GRANT ALL ON a.t@xyz TO readwrite
 
-statement error pq: target database or schema does not exist
+statement error no database specified
 GRANT ALL ON * TO readwrite
 
 statement error pgcode 42P01 relation "a.tt" does not exist

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -151,7 +151,7 @@ SELECT * FROM [SHOW SEQUENCES FROM system]
 ----
 sequence_name
 
-query T colnames
+query T colnames,rowsort
 SELECT * FROM [SHOW TABLES FROM system]
 ----
 table_name
@@ -171,7 +171,7 @@ users
 web_sessions
 zones
 
-query TT colnames
+query TT colnames,rowsort
 SELECT * FROM [SHOW TABLES FROM system WITH COMMENT]
 ----
 table_name        comment

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -3,7 +3,7 @@
 statement ok
 SET DATABASE = ""
 
-statement error cannot create "a" because the target database or schema does not exist
+statement error no database specified
 CREATE TABLE a (id INT PRIMARY KEY)
 
 statement error invalid table name: test.""

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -158,7 +158,7 @@ query TTT
 SELECT * FROM [EXPLAIN SHOW TABLES] WHERE field != 'size'
 ----
 sort                   ·       ·
- │                     order   +table_schema,+table_name
+ │                     order   +table_name
  └── render            ·       ·
       └── filter       ·       ·
            │           filter  table_schema = 'public'

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -73,6 +73,8 @@ type Flags struct {
 type Catalog interface {
 	// ResolveSchema locates a schema with the given name and returns it along
 	// with the resolved SchemaName (which has all components filled in).
+	// If the SchemaName is empty, returns the current database/schema (if one is
+	// set; otherwise returns an error).
 	//
 	// The resolved SchemaName is the same with the resulting Schema.Name() except
 	// that it has the ExplicitCatalog/ExplicitSchema flags set to correspond to

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -150,32 +150,36 @@ sort                          ·            ·
 query TTT
 SELECT * FROM [EXPLAIN SHOW TABLES] WHERE field != 'size'
 ----
-sort                   ·       ·
- │                     order   +table_schema,+table_name
- └── render            ·       ·
-      └── filter       ·       ·
-           │           filter  table_schema = 'public'
-           └── values  ·       ·
+sort                          ·       ·
+ │                            order   +table_name
+ └── render                   ·       ·
+      └── filter              ·       ·
+           │                  filter  table_schema = 'public'
+           └── virtual table  ·       ·
+·                             source  ·
 
 query TTT
 SELECT * FROM [EXPLAIN SHOW TABLES WITH COMMENT] WHERE field != 'size'
 ----
-render                      ·         ·
- └── hash-join              ·         ·
-      │                     type      left outer
-      │                     equality  (oid) = (objoid)
-      ├── hash-join         ·         ·
-      │    │                type      inner
-      │    │                equality  (relnamespace) = (oid)
-      │    ├── filter       ·         ·
-      │    │    │           filter    relkind IN ('r', 'v')
-      │    │    └── values  ·         ·
-      │    └── filter       ·         ·
-      │         │           filter    nspname = 'public'
-      │         └── values  ·         ·
-      └── filter            ·         ·
-           │                filter    objsubid = 0
-           └── values       ·         ·
+render                             ·         ·
+ └── hash-join                     ·         ·
+      │                            type      left outer
+      │                            equality  (oid) = (objoid)
+      ├── hash-join                ·         ·
+      │    │                       type      inner
+      │    │                       equality  (relnamespace) = (oid)
+      │    ├── filter              ·         ·
+      │    │    │                  filter    relkind IN ('r', 'v')
+      │    │    └── virtual table  ·         ·
+      │    │                       source    ·
+      │    └── filter              ·         ·
+      │         │                  filter    nspname = 'public'
+      │         └── virtual table  ·         ·
+      │                            source    ·
+      └── filter                   ·         ·
+           │                       filter    objsubid = 0
+           └── virtual table       ·         ·
+·                                  source    ·
 
 query TTT
 SELECT * FROM [EXPLAIN SHOW DATABASE] WHERE field != 'size'

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -138,8 +138,14 @@ func (oc *optCatalog) ResolveSchema(
 		return nil, cat.SchemaName{}, err
 	}
 	if !found {
-		return nil, cat.SchemaName{}, pgerror.Newf(pgerror.CodeInvalidSchemaNameError,
-			"target database or schema does not exist")
+		if !name.ExplicitSchema && !name.ExplicitCatalog {
+			return nil, cat.SchemaName{}, pgerror.New(
+				pgerror.CodeInvalidNameError, "no database specified",
+			)
+		}
+		return nil, cat.SchemaName{}, pgerror.Newf(
+			pgerror.CodeInvalidSchemaNameError, "target database or schema does not exist",
+		)
 	}
 	return &optSchema{
 		planner: oc.planner,

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -699,8 +699,6 @@ func (p *planner) newPlan(
 		return p.ShowRoles(ctx, n)
 	case *tree.ShowTableStats:
 		return p.ShowTableStats(ctx, n)
-	case *tree.ShowTables:
-		return p.ShowTables(ctx, n)
 	case *tree.ShowTraceForSession:
 		return p.ShowTrace(ctx, n)
 	case *tree.ShowTransactionStatus:
@@ -808,8 +806,6 @@ func (p *planner) doPrepare(ctx context.Context, stmt tree.Statement) (planNode,
 		return p.ShowVar(ctx, n)
 	case *tree.ShowRoles:
 		return p.ShowRoles(ctx, n)
-	case *tree.ShowTables:
-		return p.ShowTables(ctx, n)
 	case *tree.ShowTraceForSession:
 		return p.ShowTrace(ctx, n)
 	case *tree.ShowTransactionStatus:

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -215,6 +215,9 @@ func ResolveTargetObject(
 		return nil, err
 	}
 	if !found {
+		if !tn.ExplicitSchema && !tn.ExplicitCatalog {
+			return nil, pgerror.New(pgerror.CodeInvalidNameError, "no database specified")
+		}
 		return nil, pgerror.Newf(pgerror.CodeInvalidSchemaNameError,
 			"cannot create %q because the target database or schema does not exist",
 			tree.ErrString(tn)).SetHintf("verify that the current database and search_path are valid and/or the target database exists")


### PR DESCRIPTION
Move SHOW TABLES implementation to `delegate`. Move the "no database
specified" error inside the catalog, and clean up
`getSpecifiedOrCurrentDatabase` to use the catalog to figure out if
there is a current database set.

Release note: None