### PR TITLE
opt: support SHOW RANGES + TableIndexName cleanup

### DIFF
--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -33,7 +33,7 @@ type alterIndexNode struct {
 // AlterIndex applies a schema change on an index.
 // Privileges: CREATE on table.
 func (p *planner) AlterIndex(ctx context.Context, n *tree.AlterIndex) (planNode, error) {
-	tableDesc, indexDesc, err := p.getTableAndIndex(ctx, nil, n.Index, privilege.CREATE)
+	tableDesc, indexDesc, err := p.getTableAndIndex(ctx, &n.Index, privilege.CREATE)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/delegate/delegate.go
+++ b/pkg/sql/delegate/delegate.go
@@ -67,6 +67,9 @@ func TryDelegate(
 	case *tree.ShowQueries:
 		return d.delegateShowQueries(t)
 
+	case *tree.ShowRanges:
+		return d.delegateShowRanges(t)
+
 	case *tree.ShowRoleGrants:
 		return d.delegateShowRoleGrants(t)
 

--- a/pkg/sql/delegate/show_ranges.go
+++ b/pkg/sql/delegate/show_ranges.go
@@ -1,0 +1,58 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package delegate
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// delegateShowRanges implements the SHOW EXPERIMENTAL_RANGES statement:
+//   SHOW EXPERIMENTAL_RANGES FROM TABLE t
+//   SHOW EXPERIMENTAL_RANGES FROM INDEX t@idx
+//
+// These statements show the ranges corresponding to the given table or index,
+// along with the list of replicas and the lease holder.
+func (d *delegator) delegateShowRanges(n *tree.ShowRanges) (tree.Statement, error) {
+	idx, err := cat.ResolveTableIndex(
+		d.ctx, d.catalog, cat.Flags{AvoidDescriptorCaches: true}, &n.TableOrIndex,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := d.catalog.CheckPrivilege(d.ctx, idx.Table(), privilege.SELECT); err != nil {
+		return nil, err
+	}
+
+	span := idx.Span()
+	startKey := hex.EncodeToString([]byte(span.Key))
+	endKey := hex.EncodeToString([]byte(span.EndKey))
+	return parse(fmt.Sprintf(`
+SELECT 
+  CASE WHEN r.start_key <= x'%s' THEN NULL ELSE crdb_internal.pretty_key(r.start_key, 2) END AS start_key,
+  CASE WHEN r.end_key >= x'%s' THEN NULL ELSE crdb_internal.pretty_key(r.end_key, 2) END AS end_key,
+  range_id,
+  replicas,
+  lease_holder
+FROM crdb_internal.ranges AS r
+WHERE (r.start_key < x'%s')
+  AND (r.end_key   > x'%s')`,
+		startKey, endKey, endKey, startKey,
+	))
+}

--- a/pkg/sql/opt/cat/index.go
+++ b/pkg/sql/opt/cat/index.go
@@ -14,7 +14,10 @@
 
 package cat
 
-import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+import (
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
 
 // PrimaryIndex selects the primary index of a table when calling the
 // Table.Index method. Every table is guaranteed to have a unique primary
@@ -129,6 +132,9 @@ type Index interface {
 	// NOTE: This zone always applies to the entire index and never to any
 	// partifular partition of the index.
 	Zone() Zone
+
+	// Span returns the KV span associated with the index.
+	Span() roachpb.Span
 }
 
 // IndexColumn describes a single column that is part of an index definition.

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -17,6 +17,7 @@ package cat
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/pkg/errors"
 )
@@ -46,4 +47,73 @@ func ExpandDataSourceGlob(
 	default:
 		return nil, errors.Errorf("invalid TablePattern type %T", p)
 	}
+}
+
+// ResolveTableIndex resolves a TableIndexName.
+func ResolveTableIndex(
+	ctx context.Context, catalog Catalog, flags Flags, name *tree.TableIndexName,
+) (Index, error) {
+	if name.Table.TableName != "" {
+		ds, _, err := catalog.ResolveDataSource(ctx, flags, &name.Table)
+		if err != nil {
+			return nil, err
+		}
+		table, ok := ds.(Table)
+		if !ok {
+			return nil, pgerror.Newf(
+				pgerror.CodeWrongObjectTypeError, "%q is not a table", name.Table.TableName,
+			)
+		}
+		if name.Index == "" {
+			// Return primary index.
+			return table.Index(0), nil
+		}
+		for i := 0; i < table.IndexCount(); i++ {
+			if idx := table.Index(i); idx.Name() == tree.Name(name.Index) {
+				return idx, nil
+			}
+		}
+		return nil, pgerror.Newf(
+			pgerror.CodeUndefinedObjectError, "index %q does not exist", name.Index,
+		)
+	}
+
+	// We have to search for a table that has an index with the given name.
+	schema, _, err := catalog.ResolveSchema(ctx, flags, &name.Table.TableNamePrefix)
+	if err != nil {
+		return nil, err
+	}
+	dsNames, err := schema.GetDataSourceNames(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var found Index
+	for i := range dsNames {
+		ds, _, err := catalog.ResolveDataSource(ctx, flags, &dsNames[i])
+		if err != nil {
+			return nil, err
+		}
+		table, ok := ds.(Table)
+		if !ok {
+			// Not a table, ignore.
+			continue
+		}
+		for i := 0; i < table.IndexCount(); i++ {
+			if idx := table.Index(i); idx.Name() == tree.Name(name.Index) {
+				if found != nil {
+					return nil, pgerror.Newf(pgerror.CodeAmbiguousParameterError,
+						"index name %q is ambiguous (found in %s and %s)",
+						name.Index, table.Name().String(), found.Table().Name().String())
+				}
+				found = idx
+				break
+			}
+		}
+	}
+	if found == nil {
+		return nil, pgerror.Newf(
+			pgerror.CodeUndefinedObjectError, "index %q does not exist", name.Index,
+		)
+	}
+	return found, nil
 }

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Cockroach Authors.
+// Copyright 2019 The Cockroach Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/sql/opt/cat/utils_test.go
+++ b/pkg/sql/opt/cat/utils_test.go
@@ -1,0 +1,194 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cat_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+func TestExpandDataSourceGlob(t *testing.T) {
+	testcat := testcat.New()
+	ctx := context.Background()
+
+	exec := func(sql string) {
+		if _, err := testcat.ExecuteDDL(sql); err != nil {
+			t.Fatal(err)
+		}
+	}
+	exec("CREATE TABLE a (x INT)")
+	exec("CREATE TABLE b (x INT)")
+	exec("CREATE TABLE c (x INT)")
+
+	testCases := []struct {
+		pattern  tree.TablePattern
+		expected string
+	}{
+		{
+			pattern:  tree.NewTableName("t", "a"),
+			expected: `[t.public.a]`,
+		},
+		{
+			pattern:  tree.NewTableName("t", "z"),
+			expected: `error: no data source matches prefix: "t.public.z"`,
+		},
+		{
+			pattern:  &tree.AllTablesSelector{TableNamePrefix: tree.TableNamePrefix{}},
+			expected: `[t.public.a t.public.b t.public.c]`,
+		},
+		{
+			pattern: &tree.AllTablesSelector{TableNamePrefix: tree.TableNamePrefix{
+				SchemaName: "t", ExplicitSchema: true,
+			}},
+			expected: `[t.public.a t.public.b t.public.c]`,
+		},
+		{
+			pattern: &tree.AllTablesSelector{TableNamePrefix: tree.TableNamePrefix{
+				SchemaName: "z", ExplicitSchema: true,
+			}},
+			expected: `error: target database or schema does not exist`,
+		},
+	}
+
+	for _, tc := range testCases {
+		var res string
+		names, err := cat.ExpandDataSourceGlob(ctx, testcat, cat.Flags{}, tc.pattern)
+		if err != nil {
+			res = fmt.Sprintf("error: %v", err)
+		} else {
+			var r []string
+			for _, n := range names {
+				r = append(r, n.FQString())
+			}
+			res = fmt.Sprintf("%v", r)
+		}
+		if res != tc.expected {
+			t.Errorf("pattern: %v  expected: %s  got: %s", tc.pattern, tc.expected, res)
+		}
+	}
+}
+
+func TestResolveTableIndex(t *testing.T) {
+	testcat := testcat.New()
+	ctx := context.Background()
+
+	exec := func(sql string) {
+		if _, err := testcat.ExecuteDDL(sql); err != nil {
+			t.Fatal(err)
+		}
+	}
+	exec("CREATE TABLE a (x INT, INDEX idx1(x))")
+	exec("CREATE TABLE b (x INT, INDEX idx2(x))")
+	exec("CREATE TABLE c (x INT, INDEX idx2(x))")
+
+	testCases := []struct {
+		name     tree.TableIndexName
+		expected string
+	}{
+		// Both table name and index are set.
+		{
+			name: tree.TableIndexName{
+				Table: tree.MakeTableName("t", "a"),
+				Index: "idx1",
+			},
+			expected: `t.public.a@idx1`,
+		},
+		{
+			name: tree.TableIndexName{
+				Table: tree.MakeTableName("t", "a"),
+				Index: "idx2",
+			},
+			expected: `error: index "idx2" does not exist`,
+		},
+
+		// Only table name is set.
+		{
+			name: tree.TableIndexName{
+				Table: tree.MakeTableName("t", "a"),
+			},
+			expected: `t.public.a@primary`,
+		},
+		{
+			name: tree.TableIndexName{
+				Table: tree.MakeTableName("z", "a"),
+			},
+			expected: `error: no data source matches prefix: "z.public.a"`,
+		},
+		{
+			name: tree.TableIndexName{
+				Table: tree.MakeTableName("t", "z"),
+			},
+			expected: `error: no data source matches prefix: "t.public.z"`,
+		},
+
+		// Only index name is set.
+		{
+			name: tree.TableIndexName{
+				Index: "idx1",
+			},
+			expected: `t.public.a@idx1`,
+		},
+		{
+			name: tree.TableIndexName{
+				Table: tree.MakeTableName("t", ""),
+				Index: "idx1",
+			},
+			expected: `t.public.a@idx1`,
+		},
+		{
+			name: tree.TableIndexName{
+				Table: func() tree.TableName {
+					var t tree.TableName
+					t.SchemaName = "public"
+					t.ExplicitSchema = true
+					return t
+				}(),
+				Index: "idx1",
+			},
+			expected: `t.public.a@idx1`,
+		},
+		{
+			name: tree.TableIndexName{
+				Table: tree.MakeTableName("z", ""),
+				Index: "idx1",
+			},
+			expected: `error: target database or schema does not exist`,
+		},
+		{
+			name: tree.TableIndexName{
+				Index: "idx2",
+			},
+			expected: `error: index name "idx2" is ambiguous (found in t.public.c and t.public.b)`,
+		},
+	}
+
+	for _, tc := range testCases {
+		var res string
+		idx, err := cat.ResolveTableIndex(ctx, testcat, cat.Flags{}, &tc.name)
+		if err != nil {
+			res = fmt.Sprintf("error: %v", err)
+		} else {
+			res = fmt.Sprintf("%s@%s", idx.Table().Name().FQString(), idx.Name())
+		}
+		if res != tc.expected {
+			t.Errorf("pattern: %v  expected: %s  got: %s", tc.name.String(), tc.expected, res)
+		}
+	}
+}

--- a/pkg/sql/opt/testutils/testcat/drop_table.go
+++ b/pkg/sql/opt/testutils/testcat/drop_table.go
@@ -28,6 +28,6 @@ func (tc *Catalog) DropTable(stmt *tree.DropTable) {
 		tc.Table(tn)
 
 		// Remove the table from the catalog.
-		delete(tc.dataSources, tn.FQString())
+		delete(tc.testSchema.dataSources, tn.FQString())
 	}
 }

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -726,6 +727,11 @@ func (ti *Index) ForeignKey() (cat.ForeignKeyReference, bool) {
 // Zone is part of the cat.Index interface.
 func (ti *Index) Zone() cat.Zone {
 	return ti.IdxZone
+}
+
+// Span is part of the cat.Index interface.
+func (ti *Index) Span() roachpb.Span {
+	panic("not implemented")
 }
 
 // Column implements the cat.Column interface for testing purposes.

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -17,6 +17,7 @@ package testcat
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/config"
@@ -37,9 +38,8 @@ const (
 
 // Catalog implements the cat.Catalog interface for testing purposes.
 type Catalog struct {
-	testSchema  Schema
-	dataSources map[string]cat.DataSource
-	counter     int
+	testSchema Schema
+	counter    int
 }
 
 var _ cat.Catalog = &Catalog{}
@@ -55,8 +55,8 @@ func New() *Catalog {
 				ExplicitSchema:  true,
 				ExplicitCatalog: true,
 			},
+			dataSources: make(map[string]cat.DataSource),
 		},
-		dataSources: make(map[string]cat.DataSource),
 	}
 }
 
@@ -153,7 +153,7 @@ func (tc *Catalog) ResolveDataSource(
 func (tc *Catalog) ResolveDataSourceByID(
 	ctx context.Context, id cat.StableID,
 ) (cat.DataSource, error) {
-	for _, ds := range tc.dataSources {
+	for _, ds := range tc.testSchema.dataSources {
 		if tab, ok := ds.(*Table); ok && tab.TabID == id {
 			return ds, nil
 		}
@@ -200,9 +200,7 @@ func (tc *Catalog) RequireSuperUser(ctx context.Context, action string) error {
 func (tc *Catalog) resolveSchema(toResolve *cat.SchemaName) (cat.Schema, cat.SchemaName, error) {
 	if string(toResolve.CatalogName) != testDB {
 		return nil, cat.SchemaName{}, pgerror.Newf(pgerror.CodeInvalidSchemaNameError,
-			"cannot create %q because the target database or schema does not exist",
-			tree.ErrString(&toResolve.CatalogName)).
-			SetHintf("verify that the current database and search_path are valid and/or the target database exists")
+			"target database or schema does not exist")
 	}
 
 	if string(toResolve.SchemaName) != tree.PublicSchema {
@@ -217,7 +215,7 @@ func (tc *Catalog) resolveSchema(toResolve *cat.SchemaName) (cat.Schema, cat.Sch
 // Catalog. If it does, returns the corresponding data source. Otherwise, it
 // returns an error.
 func (tc *Catalog) resolveDataSource(toResolve *cat.DataSourceName) (cat.DataSource, error) {
-	if table, ok := tc.dataSources[toResolve.FQString()]; ok {
+	if table, ok := tc.testSchema.dataSources[toResolve.FQString()]; ok {
 		return table, nil
 	}
 	return nil, fmt.Errorf("no data source matches prefix: %q", tree.ErrString(toResolve))
@@ -243,10 +241,10 @@ func (tc *Catalog) Table(name *tree.TableName) *Table {
 // AddTable adds the given test table to the catalog.
 func (tc *Catalog) AddTable(tab *Table) {
 	fq := tab.TabName.FQString()
-	if _, ok := tc.dataSources[fq]; ok {
+	if _, ok := tc.testSchema.dataSources[fq]; ok {
 		panic(fmt.Errorf("table %q already exists", tree.ErrString(&tab.TabName)))
 	}
-	tc.dataSources[fq] = tab
+	tc.testSchema.dataSources[fq] = tab
 }
 
 // View returns the test view that was previously added with the given name.
@@ -264,19 +262,19 @@ func (tc *Catalog) View(name *cat.DataSourceName) *View {
 // AddView adds the given test view to the catalog.
 func (tc *Catalog) AddView(view *View) {
 	fq := view.ViewName.FQString()
-	if _, ok := tc.dataSources[fq]; ok {
+	if _, ok := tc.testSchema.dataSources[fq]; ok {
 		panic(fmt.Errorf("view %q already exists", tree.ErrString(&view.ViewName)))
 	}
-	tc.dataSources[fq] = view
+	tc.testSchema.dataSources[fq] = view
 }
 
 // AddSequence adds the given test sequence to the catalog.
 func (tc *Catalog) AddSequence(seq *Sequence) {
 	fq := seq.SeqName.FQString()
-	if _, ok := tc.dataSources[fq]; ok {
+	if _, ok := tc.testSchema.dataSources[fq]; ok {
 		panic(fmt.Errorf("sequence %q already exists", tree.ErrString(&seq.SeqName)))
 	}
-	tc.dataSources[fq] = seq
+	tc.testSchema.dataSources[fq] = seq
 }
 
 // ExecuteMultipleDDL parses the given semicolon-separated DDL SQL statements
@@ -391,6 +389,8 @@ type Schema struct {
 
 	// If Revoked is true, then the user has had privileges on the schema revoked.
 	Revoked bool
+
+	dataSources map[string]cat.DataSource
 }
 
 var _ cat.Schema = &Schema{}
@@ -413,7 +413,16 @@ func (s *Schema) Name() *cat.SchemaName {
 
 // GetDataSourceNames is part of the cat.Schema interface.
 func (s *Schema) GetDataSourceNames(ctx context.Context) ([]cat.DataSourceName, error) {
-	panic("not implemented")
+	var keys []string
+	for k := range s.dataSources {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var res []cat.DataSourceName
+	for _, k := range keys {
+		res = append(res, *s.dataSources[k].Name())
+	}
+	return res, nil
 }
 
 // View implements the cat.View interface for testing purposes.

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -20,6 +20,8 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -953,6 +955,17 @@ func (oi *optIndex) ForeignKey() (cat.ForeignKeyReference, bool) {
 // Zone is part of the cat.Index interface.
 func (oi *optIndex) Zone() cat.Zone {
 	return oi.zone
+}
+
+// Span is part of the cat.Index interface.
+func (oi *optIndex) Span() roachpb.Span {
+	desc := oi.tab.desc
+	// Tables up to MaxSystemConfigDescID are grouped in a single system config
+	// span.
+	if desc.ID <= keys.MaxSystemConfigDescID {
+		return keys.SystemConfigSpan
+	}
+	return desc.IndexSpan(oi.desc.ID)
 }
 
 // Table is part of the cat.Index interface.

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -701,8 +701,6 @@ func (p *planner) newPlan(
 		return p.ShowTrace(ctx, n)
 	case *tree.ShowZoneConfig:
 		return p.ShowZoneConfig(ctx, n)
-	case *tree.ShowRanges:
-		return p.ShowRanges(ctx, n)
 	case *tree.ShowFingerprints:
 		return p.ShowFingerprints(ctx, n)
 	case *tree.Split:
@@ -800,8 +798,6 @@ func (p *planner) doPrepare(ctx context.Context, stmt tree.Statement) (planNode,
 		return p.ShowClusterSetting(ctx, n)
 	case *tree.ShowHistogram:
 		return p.ShowHistogram(ctx, n)
-	case *tree.ShowRanges:
-		return p.ShowRanges(ctx, n)
 	case *tree.ShowRoles:
 		return p.ShowRoles(ctx, n)
 	case *tree.ShowTableStats:

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -284,6 +284,11 @@ func (opc *optPlanningCtx) buildReusableMemo(
 		return nil, bld.IsCorrelated, err
 	}
 
+	if bld.DisableMemoReuse {
+		opc.allowMemoReuse = false
+		opc.useCache = false
+	}
+
 	if isCanned {
 		if f.Memo().HasPlaceholders() {
 			// We don't support placeholders inside the canned plan. The main reason
@@ -413,7 +418,7 @@ func (opc *optPlanningCtx) buildExecMemo(
 	// If this statement doesn't have placeholders, add it to the cache. Note
 	// that non-prepared statements from pgwire clients cannot have
 	// placeholders.
-	if opc.useCache && !bld.HadPlaceholders {
+	if opc.useCache && !bld.HadPlaceholders && !bld.DisableMemoReuse {
 		memo := opc.optimizer.DetachMemo()
 		cachedData := querycache.CachedData{
 			SQL:  opc.p.stmt.SQL,

--- a/pkg/sql/relocate.go
+++ b/pkg/sql/relocate.go
@@ -45,7 +45,7 @@ type relocateNode struct {
 // (`ALTER TABLE/INDEX ... EXPERIMENTAL_RELOCATE [LEASE] ...` statement)
 // Privileges: INSERT on table.
 func (p *planner) Relocate(ctx context.Context, n *tree.Relocate) (planNode, error) {
-	tableDesc, index, err := p.getTableAndIndex(ctx, n.Table, n.Index, privilege.INSERT)
+	tableDesc, index, err := p.getTableAndIndex(ctx, &n.TableOrIndex, privilege.INSERT)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -492,40 +492,21 @@ func expandIndexName(
 func (p *planner) getTableAndIndex(
 	ctx context.Context, tableWithIndex *tree.TableIndexName, privilege privilege.Kind,
 ) (*MutableTableDescriptor, *sqlbase.IndexDescriptor, error) {
-	var tableDesc *MutableTableDescriptor
-	var err error
-	if tableWithIndex.Index == "" {
-		// Variant: ALTER TABLE
-		tableDesc, err = p.ResolveMutableTableDescriptor(
-			ctx, &tableWithIndex.Table, true /*required*/, requireTableDesc,
-		)
-	} else {
-		// Variant: ALTER INDEX
-		_, tableDesc, err = expandMutableIndexName(ctx, p, tableWithIndex, true /* requireTable */)
-	}
+	var catalog optCatalog
+	catalog.init(p)
+	catalog.reset()
+
+	idx, err := cat.ResolveTableIndex(
+		ctx, &catalog, cat.Flags{AvoidDescriptorCaches: true}, tableWithIndex,
+	)
 	if err != nil {
 		return nil, nil, err
 	}
-
-	if err := p.CheckPrivilege(ctx, tableDesc, privilege); err != nil {
+	if err := catalog.CheckPrivilege(ctx, idx.Table(), privilege); err != nil {
 		return nil, nil, err
 	}
-
-	// Determine which index to use.
-	var index *sqlbase.IndexDescriptor
-	if tableWithIndex.Index == "" {
-		index = &tableDesc.PrimaryIndex
-	} else {
-		idx, dropped, err := tableDesc.FindIndexByName(string(tableWithIndex.Index))
-		if err != nil {
-			return nil, nil, err
-		}
-		if dropped {
-			return nil, nil, fmt.Errorf("index %q being dropped", tableWithIndex.Index)
-		}
-		index = idx
-	}
-	return tableDesc, index, nil
+	optIdx := idx.(*optIndex)
+	return sqlbase.NewMutableExistingTableDescriptor(optIdx.tab.desc.TableDescriptor), optIdx.desc, nil
 }
 
 // expandTableGlob expands pattern into a list of tables represented

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -485,23 +485,19 @@ func expandIndexName(
 	return tn, desc, nil
 }
 
-// getTableAndIndex returns the table and index descriptors for a table
-// (primary index) or table-with-index. Only one of table and tableWithIndex can
-// be set.  This is useful for statements that have both table and index
-// variants (like `ALTER TABLE/INDEX ... SPLIT AT ...`).
+// getTableAndIndex returns the table and index descriptors for a
+// TableIndexName.
+//
 // It can return indexes that are being rolled out.
 func (p *planner) getTableAndIndex(
-	ctx context.Context,
-	table *tree.TableName,
-	tableWithIndex *tree.TableIndexName,
-	privilege privilege.Kind,
+	ctx context.Context, tableWithIndex *tree.TableIndexName, privilege privilege.Kind,
 ) (*MutableTableDescriptor, *sqlbase.IndexDescriptor, error) {
 	var tableDesc *MutableTableDescriptor
 	var err error
-	if tableWithIndex == nil {
+	if tableWithIndex.Index == "" {
 		// Variant: ALTER TABLE
 		tableDesc, err = p.ResolveMutableTableDescriptor(
-			ctx, table, true /*required*/, requireTableDesc,
+			ctx, &tableWithIndex.Table, true /*required*/, requireTableDesc,
 		)
 	} else {
 		// Variant: ALTER INDEX
@@ -517,7 +513,7 @@ func (p *planner) getTableAndIndex(
 
 	// Determine which index to use.
 	var index *sqlbase.IndexDescriptor
-	if tableWithIndex == nil {
+	if tableWithIndex.Index == "" {
 		index = &tableDesc.PrimaryIndex
 	} else {
 		idx, dropped, err := tableDesc.FindIndexByName(string(tableWithIndex.Index))

--- a/pkg/sql/scatter.go
+++ b/pkg/sql/scatter.go
@@ -37,7 +37,7 @@ type scatterNode struct {
 // (`ALTER TABLE/INDEX ... SCATTER ...` statement)
 // Privileges: INSERT on table.
 func (p *planner) Scatter(ctx context.Context, n *tree.Scatter) (planNode, error) {
-	tableDesc, index, err := p.getTableAndIndex(ctx, n.Table, n.Index, privilege.INSERT)
+	tableDesc, index, err := p.getTableAndIndex(ctx, &n.TableOrIndex, privilege.INSERT)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/sem/tree/alter_index.go
+++ b/pkg/sql/sem/tree/alter_index.go
@@ -17,7 +17,7 @@ package tree
 // AlterIndex represents an ALTER INDEX statement.
 type AlterIndex struct {
 	IfExists bool
-	Index    *TableIndexName
+	Index    TableIndexName
 	Cmds     AlterIndexCmds
 }
 
@@ -29,7 +29,7 @@ func (node *AlterIndex) Format(ctx *FmtCtx) {
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")
 	}
-	ctx.FormatNode(node.Index)
+	ctx.FormatNode(&node.Index)
 	ctx.FormatNode(&node.Cmds)
 }
 

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -356,22 +356,19 @@ func (node *ShowRoles) Format(ctx *FmtCtx) {
 }
 
 // ShowRanges represents a SHOW EXPERIMENTAL_RANGES statement.
-// Only one of Table and Index can be set.
 type ShowRanges struct {
-	Table *TableName
-	Index *TableIndexName
+	TableOrIndex TableIndexName
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowRanges) Format(ctx *FmtCtx) {
 	ctx.WriteString("SHOW EXPERIMENTAL_RANGES FROM ")
-	if node.Index != nil {
+	if node.TableOrIndex.Index != "" {
 		ctx.WriteString("INDEX ")
-		ctx.FormatNode(node.Index)
 	} else {
 		ctx.WriteString("TABLE ")
-		ctx.FormatNode(node.Table)
 	}
+	ctx.FormatNode(&node.TableOrIndex)
 }
 
 // ShowFingerprints represents a SHOW EXPERIMENTAL_FINGERPRINTS statement.

--- a/pkg/sql/sem/tree/split.go
+++ b/pkg/sql/sem/tree/split.go
@@ -16,9 +16,7 @@ package tree
 
 // Split represents an `ALTER TABLE/INDEX .. SPLIT AT ..` statement.
 type Split struct {
-	// Only one of Table and Index can be set.
-	Table *TableName
-	Index *TableIndexName
+	TableOrIndex TableIndexName
 	// Each row contains values for the columns in the PK or index (or a prefix
 	// of the columns).
 	Rows *Select
@@ -27,13 +25,12 @@ type Split struct {
 // Format implements the NodeFormatter interface.
 func (node *Split) Format(ctx *FmtCtx) {
 	ctx.WriteString("ALTER ")
-	if node.Index != nil {
+	if node.TableOrIndex.Index != "" {
 		ctx.WriteString("INDEX ")
-		ctx.FormatNode(node.Index)
 	} else {
 		ctx.WriteString("TABLE ")
-		ctx.FormatNode(node.Table)
 	}
+	ctx.FormatNode(&node.TableOrIndex)
 	ctx.WriteString(" SPLIT AT ")
 	ctx.FormatNode(node.Rows)
 }
@@ -41,11 +38,9 @@ func (node *Split) Format(ctx *FmtCtx) {
 // Relocate represents an `ALTER TABLE/INDEX .. EXPERIMENTAL_RELOCATE ..`
 // statement.
 type Relocate struct {
-	// Only one of Table and Index can be set.
 	// TODO(a-robinson): It's not great that this can only work on ranges that
 	// are part of a currently valid table or index.
-	Table *TableName
-	Index *TableIndexName
+	TableOrIndex TableIndexName
 	// Each row contains an array with store ids and values for the columns in the
 	// PK or index (or a prefix of the columns).
 	// See docs/RFCS/sql_split_syntax.md.
@@ -56,13 +51,12 @@ type Relocate struct {
 // Format implements the NodeFormatter interface.
 func (node *Relocate) Format(ctx *FmtCtx) {
 	ctx.WriteString("ALTER ")
-	if node.Index != nil {
+	if node.TableOrIndex.Index != "" {
 		ctx.WriteString("INDEX ")
-		ctx.FormatNode(node.Index)
 	} else {
 		ctx.WriteString("TABLE ")
-		ctx.FormatNode(node.Table)
 	}
+	ctx.FormatNode(&node.TableOrIndex)
 	ctx.WriteString(" EXPERIMENTAL_RELOCATE ")
 	if node.RelocateLease {
 		ctx.WriteString("LEASE ")
@@ -73,9 +67,7 @@ func (node *Relocate) Format(ctx *FmtCtx) {
 // Scatter represents an `ALTER TABLE/INDEX .. SCATTER ..`
 // statement.
 type Scatter struct {
-	// Only one of Table and Index can be set.
-	Table *TableName
-	Index *TableIndexName
+	TableOrIndex TableIndexName
 	// Optional from and to values for the columns in the PK or index (or a prefix
 	// of the columns).
 	// See docs/RFCS/sql_split_syntax.md.
@@ -85,13 +77,12 @@ type Scatter struct {
 // Format implements the NodeFormatter interface.
 func (node *Scatter) Format(ctx *FmtCtx) {
 	ctx.WriteString("ALTER ")
-	if node.Index != nil {
+	if node.TableOrIndex.Index != "" {
 		ctx.WriteString("INDEX ")
-		ctx.FormatNode(node.Index)
 	} else {
 		ctx.WriteString("TABLE ")
-		ctx.FormatNode(node.Table)
 	}
+	ctx.FormatNode(&node.TableOrIndex)
 	ctx.WriteString(" SCATTER")
 	if node.From != nil {
 		ctx.WriteString(" FROM (")

--- a/pkg/sql/sem/tree/table_name.go
+++ b/pkg/sql/sem/tree/table_name.go
@@ -194,12 +194,20 @@ func (ts *TableNames) Format(ctx *FmtCtx) {
 }
 func (ts *TableNames) String() string { return AsString(ts) }
 
-// TableIndexName is the name of an index, used in statements that
-// specifically refer to an index.
+// TableIndexName refers to a table index. There are a few cases:
 //
-// The table name is optional. It is possible to specify the schema or catalog
-// without specifying a table name; in this case, Table.TableNamePrefix has the
-// fields set but Table.TableName is empty.
+//  - if both the table name and the index name are set, refers to a specific
+//    index in a specific table.
+//
+//  - if the table name is set and index name is empty, refers to the primary
+//    index of that table.
+//
+//  - if the table name is empty and the index name is set, refers to an index
+//    of that name among all tables within a catalog/schema; if there is a
+//    duplicate name, that will result in an error. Note that it is possible to
+//    specify the schema or catalog without specifying a table name; in this
+//    case, Table.TableNamePrefix has the fields set but Table.TableName is
+//    empty.
 type TableIndexName struct {
 	Table TableName
 	Index UnrestrictedName
@@ -208,8 +216,6 @@ type TableIndexName struct {
 // Format implements the NodeFormatter interface.
 func (n *TableIndexName) Format(ctx *FmtCtx) {
 	if n.Index == "" {
-		// This case is only for ZoneSpecifier.TableOrIndex; normally an empty Index
-		// is not valid.
 		ctx.FormatNode(&n.Table)
 		return
 	}

--- a/pkg/sql/show_ranges.go
+++ b/pkg/sql/show_ranges.go
@@ -33,7 +33,7 @@ import (
 // These statements show the ranges corresponding to the given table or index,
 // along with the list of replicas and the lease holder.
 func (p *planner) ShowRanges(ctx context.Context, n *tree.ShowRanges) (planNode, error) {
-	desc, index, err := p.getTableAndIndex(ctx, n.Table, n.Index, privilege.SELECT)
+	desc, index, err := p.getTableAndIndex(ctx, &n.TableOrIndex, privilege.SELECT)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/show_ranges.go
+++ b/pkg/sql/show_ranges.go
@@ -16,46 +16,11 @@ package sql
 
 import (
 	"context"
-	"encoding/hex"
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
-
-// ShowRanges implements the SHOW EXPERIMENTAL_RANGES statement:
-//   SHOW EXPERIMENTAL_RANGES FROM TABLE t
-//   SHOW EXPERIMENTAL_RANGES FROM INDEX t@idx
-//
-// These statements show the ranges corresponding to the given table or index,
-// along with the list of replicas and the lease holder.
-func (p *planner) ShowRanges(ctx context.Context, n *tree.ShowRanges) (planNode, error) {
-	desc, index, err := p.getTableAndIndex(ctx, &n.TableOrIndex, privilege.SELECT)
-	if err != nil {
-		return nil, err
-	}
-	span := desc.IndexSpan(index.ID)
-	if desc.ID < keys.MaxSystemConfigDescID {
-		span = keys.SystemConfigSpan
-	}
-	startKey := hex.EncodeToString([]byte(span.Key))
-	endKey := hex.EncodeToString([]byte(span.EndKey))
-	return p.delegateQuery(ctx, "SHOW RANGES",
-		fmt.Sprintf(`
-SELECT 
-  CASE WHEN r.start_key <= x'%s' THEN NULL ELSE crdb_internal.pretty_key(r.start_key, 2) END AS start_key,
-  CASE WHEN r.end_key >= x'%s' THEN NULL ELSE crdb_internal.pretty_key(r.end_key, 2) END AS end_key,
-  range_id,
-  replicas,
-  lease_holder
-FROM crdb_internal.ranges AS r
-WHERE (r.start_key < x'%s')
-  AND (r.end_key   > x'%s')
-`, startKey, endKey, endKey, startKey), nil, nil)
-}
 
 // ScanMetaKVs returns the meta KVs for the ranges that touch the given span.
 func ScanMetaKVs(

--- a/pkg/sql/split.go
+++ b/pkg/sql/split.go
@@ -39,7 +39,7 @@ type splitNode struct {
 // Split executes a KV split.
 // Privileges: INSERT on table.
 func (p *planner) Split(ctx context.Context, n *tree.Split) (planNode, error) {
-	tableDesc, index, err := p.getTableAndIndex(ctx, n.Table, n.Index, privilege.INSERT)
+	tableDesc, index, err := p.getTableAndIndex(ctx, &n.TableOrIndex, privilege.INSERT)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### sql: use TableIndexName for the case of a table and no index

Allow `TableIndexName` to have an empty index and explicit table (in
which case it refers to the primary index of that table). The zone
specifier was already using it in that way. This simplifies some of
the statements that have both TABLE and INDEX versions.

Release note: None

#### sql: move resolution of a TableIndexName to the catalog

Rewriting the code to resolve a TableIndexName in the catalog, and
rerouting the exiting code path.

Release note: None

#### opt: disable memo reuse for delegated statements

The delegate implementations don't register their dependencies with
the metadata. For some it would be very difficult (e.g. some search
for an index name through all tables in a catalog).

This change disables memo caching if we encountered any delegated
statements. We should probably do this for `CreateTable` as well, and
simplify the cache invalidation code to not care about schemas.

Release note: None

#### opt: support SHOW RANGES

Move the ShowRanges implementation to `delegate`.

Release note: None
