### PR TITLE
release-19.1: roachtest: use 2.0.7 in a test

### DIFF
--- a/pkg/cmd/roachtest/upgrade.go
+++ b/pkg/cmd/roachtest/upgrade.go
@@ -371,6 +371,10 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster) {
 
 	// clusterVersionUpgrade performs a cluster version upgrade to its version.
 	// It waits until all nodes have seen the upgraded cluster version.
+	// If manual is set, we'll performe a SET CLUSTER SETTING version =
+	// <newVersion>. If it's not, we'll rely on the automatic cluster version
+	// upgrade mechanism (which is not inhibited by the
+	// cluster.preserve_downgrade_option cluster setting in this test.
 	var currentVersion string
 	clusterVersionUpgrade := func(newVersion string, manual bool) versionStep {
 		return versionStep{
@@ -463,9 +467,7 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster) {
 		binaryVersionUpgrade("v1.1.9", nodes),
 		clusterVersionUpgrade("1.1", true /* manual */),
 
-		// NB: v2.0.6 doesn't have https://github.com/cockroachdb/cockroach/issues/31380,
-		// so this acceptance test will fail on OSX Mojave. v2.0.7 will have the patch.
-		binaryVersionUpgrade("v2.0.6", nodes),
+		binaryVersionUpgrade("v2.0.7", nodes),
 		clusterVersionUpgrade("2.0", true /* manual */),
 
 		binaryVersionUpgrade("v2.1.2", nodes),


### PR DESCRIPTION
Backport 1/1 commits from #37189.

On OSX, the respective test is messed up for me without that patch on the release-19.1 branch, hence the backport. It did not seem messed up on master, though... Very confused.

/cc @cockroachdb/release

---

... instead of 2.0.6, now that 2.0.7 is out. This addresses a TODO about
2.0.6 not working right on Mojave.

Release note: None
