### PR TITLE
build: dump stacks on testrace stall

### DIFF
--- a/build/teamcity-testrace.sh
+++ b/build/teamcity-testrace.sh
@@ -15,24 +15,24 @@ build/builder.sh env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" TARGET=stressrace gith
 tc_end_block "Maybe stressrace pull request"
 
 tc_start_block "Determine changed packages"
-if tc_release_branch; then
-	pkgspec=./pkg/...
-  echo "On release branch ($TC_BUILD_BRANCH), so running testrace on all packages ($pkgspec)"
-else
-  pkgspec=$(changed_go_pkgs)
-	if [[ -z "$pkgspec" ]]; then
-		echo "PR #$TC_BUILD_BRANCH has no changed packages; skipping race detector tests"
-		exit 0
-	fi
-  if [[ $pkgspec == *"./pkg/sql/opt"* ]]; then
-    # If one opt package was changed, run all opt packages (the optimizer puts
-    # various checks behind the race flag to keep them out of release builds).
-    echo "$pkgspec" | sed 's$./pkg/sql/opt/[^ ]*$$g'
-    pkgspec=$(echo "$pkgspec" | sed 's$./pkg/sql/opt[^ ]*$$g')
-    pkgspec="$pkgspec ./pkg/sql/opt/..."
-  fi
-	echo "PR #$TC_BUILD_BRANCH has changed packages; running race detector tests on $pkgspec"
-fi
+#if tc_release_branch; then
+pkgspec=./pkg/...
+echo "On release branch ($TC_BUILD_BRANCH), so running testrace on all packages ($pkgspec)"
+#else
+#  pkgspec=$(changed_go_pkgs)
+#	if [[ -z "$pkgspec" ]]; then
+#		echo "PR #$TC_BUILD_BRANCH has no changed packages; skipping race detector tests"
+#		exit 0
+#	fi
+#  if [[ $pkgspec == *"./pkg/sql/opt"* ]]; then
+#    # If one opt package was changed, run all opt packages (the optimizer puts
+#    # various checks behind the race flag to keep them out of release builds).
+#    echo "$pkgspec" | sed 's$./pkg/sql/opt/[^ ]*$$g'
+#    pkgspec=$(echo "$pkgspec" | sed 's$./pkg/sql/opt[^ ]*$$g')
+#    pkgspec="$pkgspec ./pkg/sql/opt/..."
+#  fi
+#	echo "PR #$TC_BUILD_BRANCH has changed packages; running race detector tests on $pkgspec"
+#fi
 tc_end_block "Determine changed packages"
 
 tc_start_block "Compile C dependencies"

--- a/build/teamcity-testrace.sh
+++ b/build/teamcity-testrace.sh
@@ -40,9 +40,12 @@ run build/builder.sh make -Otarget c-deps GOFLAGS=-race
 tc_end_block "Compile C dependencies"
 
 tc_start_block "Run Go tests under race detector"
+# Note: TC kills the build after 1h (at the time of writing) so we insert
+# our custom timeout that will dump the stacks.
 run build/builder.sh env \
     COCKROACH_LOGIC_TESTS_SKIP=true \
     stdbuf -oL -eL \
+    timeout --preserve-status --kill-after=59m --signal=QUIT 58m \
     make testrace \
     PKG="$pkgspec" \
     TESTTIMEOUT=45m \


### PR DESCRIPTION
We've observed hanging testrace builds on master for which we're not
sure what hangs. Wrap the testrace invocation in a timeout that sends
an ABRT to the process, which should result in new intel.

Release note: None