### PR TITLE
roachtest: Another attempt at deflaking election-after-restart

### DIFF
--- a/pkg/cmd/roachtest/election.go
+++ b/pkg/cmd/roachtest/election.go
@@ -31,6 +31,12 @@ func registerElectionAfterRestart(r *registry) {
 			c.Put(ctx, cockroach, "./cockroach")
 			c.Start(ctx, t)
 
+			// If the initial ranges aren't fully replicated by the time we
+			// run our splits, replicating them after the splits will take
+			// longer, so wait for the initial replication before
+			// proceeding.
+			time.Sleep(3 * time.Second)
+
 			t.Status("creating table and splits")
 			c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "
         CREATE DATABASE IF NOT EXISTS test;


### PR DESCRIPTION
The sleep added in the previous PR didn't eliminate the flakiness,
because it appears that the initial ranges weren't fully replicated.
Add another sleep before the splits in another attempt to get
everything into a stable configuration before restart.

Updates #35047

Release note: None