### PR TITLE
distsql: remove legacy batched-write index dist-backfiller

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -64,7 +64,6 @@
 <tr><td><code>schemachanger.backfiller.buffer_size</code></td><td>byte size</td><td><code>196 MiB</code></td><td>amount to buffer in memory during backfills</td></tr>
 <tr><td><code>schemachanger.backfiller.max_sst_size</code></td><td>byte size</td><td><code>16 MiB</code></td><td>target size for ingested files during backfills</td></tr>
 <tr><td><code>schemachanger.bulk_index_backfill.batch_size</code></td><td>integer</td><td><code>50000</code></td><td>number of rows to process at a time during bulk index backfill</td></tr>
-<tr><td><code>schemachanger.bulk_index_backfill.enabled</code></td><td>boolean</td><td><code>true</code></td><td>backfill indexes in bulk via addsstable</td></tr>
 <tr><td><code>schemachanger.lease.duration</code></td><td>duration</td><td><code>5m0s</code></td><td>the duration of a schema change lease</td></tr>
 <tr><td><code>schemachanger.lease.renew_fraction</code></td><td>float</td><td><code>0.5</code></td><td>the fraction of schemachanger.lease_duration remaining to trigger a renew of the lease</td></tr>
 <tr><td><code>server.clock.forward_jump_check_enabled</code></td><td>boolean</td><td><code>false</code></td><td>if enabled, forward clock jumps > max_offset/2 will cause a panic</td></tr>

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -43,6 +43,8 @@ var retiredSettings = map[string]struct{}{
 	"kv.allocator.stat_rebalance_threshold":       {},
 	// removed as of 2.2.
 	"kv.raft_log.synchronize": {},
+	// removed as of 19.2.
+	"schemachanger.bulk_index_backfill.enabled": {},
 }
 
 // Register adds a setting to the registry.

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
@@ -364,11 +363,6 @@ func (ib *IndexBackfiller) Init(desc *sqlbase.ImmutableTableDescriptor) error {
 		false /* reverse */, false /* returnRangeInfo */, false /* isCheck */, &ib.alloc, tableArgs,
 	)
 }
-
-// BulkWriteIndex enables experimental bulk-ingestion of index entries.
-var BulkWriteIndex = settings.RegisterBoolSetting(
-	"schemachanger.bulk_index_backfill.enabled", "backfill indexes in bulk via addsstable", true,
-)
 
 // BuildIndexEntriesChunk reads a chunk of rows from a table using the span sp
 // provided, and builds all the added indexes.

--- a/pkg/sql/distsqlrun/indexbackfiller.go
+++ b/pkg/sql/distsqlrun/indexbackfiller.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/backfill"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
@@ -143,27 +142,6 @@ func (ib *indexBackfiller) runChunk(
 	defer tracing.FinishSpan(traceSpan)
 
 	var key roachpb.Key
-	transactionalChunk := func(ctx context.Context) error {
-		return ib.flowCtx.ClientDB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-			// TODO(knz): do KV tracing in DistSQL processors.
-			var err error
-			key, err = ib.RunIndexBackfillChunk(
-				ctx, txn, ib.desc, sp, chunkSize, true /*alsoCommit*/, false /*traceKV*/)
-			return err
-		})
-	}
-
-	// TODO(jordan): enable this once IsMigrated is a real implementation.
-	/*
-		if !util.IsMigrated() {
-			// If we're running a mixed cluster, some of the nodes will have an old
-			// implementation of InitPut that doesn't take into account the expected
-			// timetsamp. In that case, we have to run our chunk transactionally at the
-			// current time.
-			err := transactionalChunk(ctx)
-			return ib.fetcher.Key(), err
-		}
-	*/
 
 	start := timeutil.Now()
 	var entries []sqlbase.IndexEntry
@@ -179,74 +157,22 @@ func (ib *indexBackfiller) runChunk(
 	}
 	prepTime := timeutil.Now().Sub(start)
 
-	enabled := backfill.BulkWriteIndex.Get(&ib.flowCtx.Settings.SV)
-	if enabled {
-		start := timeutil.Now()
-
-		for _, i := range entries {
-			if err := ib.adder.Add(ctx, i.Key, i.Value.RawBytes); err != nil {
-				return nil, ib.wrapDupError(ctx, err)
-			}
-		}
-		if ib.flowCtx.testingKnobs.RunAfterBackfillChunk != nil {
-			if err := ib.adder.Flush(ctx); err != nil {
-				return nil, ib.wrapDupError(ctx, err)
-			}
-		}
-		addTime := timeutil.Now().Sub(start)
-
-		// Don't log perf stats in tests with small indexes.
-		if len(entries) > 1000 {
-			log.Infof(ctx, "index backfill stats: entries %d, prepare %+v, add-sst %+v",
-				len(entries), prepTime, addTime)
-		}
-		return key, nil
-	}
-	retried := false
-	// Write the new index values.
-	if err := ib.flowCtx.ClientDB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-		batch := txn.NewBatch()
-
-		for _, entry := range entries {
-			// Since we're not regenerating the index entries here, if the
-			// transaction restarts the values might already have their checksums
-			// set which is invalid - clear them.
-			if retried {
-				// Reset the value slice. This is necessary because gRPC may still be
-				// holding onto the underlying slice here. See #17348 for more details.
-				// We only need to reset RawBytes because neither entry nor entry.Value
-				// are pointer types.
-				rawBytes := entry.Value.RawBytes
-				entry.Value.RawBytes = make([]byte, len(rawBytes))
-				copy(entry.Value.RawBytes, rawBytes)
-				entry.Value.ClearChecksum()
-			}
-			batch.InitPut(entry.Key, &entry.Value, true /* failOnTombstones */)
-		}
-		retried = true
-		if err := txn.CommitInBatch(ctx, batch); err != nil {
-			if _, ok := batch.MustPErr().GetDetail().(*roachpb.ConditionFailedError); ok {
-				return pgerror.New(pgerror.CodeUniqueViolationError, "")
-			}
-			return err
-		}
-		return nil
-	}); err != nil {
-		if sqlbase.IsUniquenessConstraintViolationError(err) {
-			log.VEventf(ctx, 2, "failed write. retrying transactionally: %v", err)
-			// Someone wrote a value above one of our new index entries. Since we did
-			// a historical read, we didn't have the most up-to-date value for the
-			// row we were backfilling so we can't just blindly write it to the
-			// index. Instead, we retry the transaction at the present timestamp.
-			if err := transactionalChunk(ctx); err != nil {
-				log.VEventf(ctx, 2, "failed transactional write: %v", err)
-				return nil, err
-			}
-		} else {
-			log.VEventf(ctx, 2, "failed write due to other error, not retrying: %v", err)
-			return nil, err
+	start = timeutil.Now()
+	for _, i := range entries {
+		if err := ib.adder.Add(ctx, i.Key, i.Value.RawBytes); err != nil {
+			return nil, ib.wrapDupError(ctx, err)
 		}
 	}
+	if ib.flowCtx.testingKnobs.RunAfterBackfillChunk != nil {
+		if err := ib.adder.Flush(ctx); err != nil {
+			return nil, ib.wrapDupError(ctx, err)
+		}
+	}
+	addTime := timeutil.Now().Sub(start)
 
+	if log.V(3) {
+		log.Infof(ctx, "index backfill stats: entries %d, prepare %+v, add-sst %+v",
+			len(entries), prepTime, addTime)
+	}
 	return key, nil
 }

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -58,12 +58,6 @@ func NewNonNullViolationError(columnName string) error {
 	return pgerror.Newf(pgerror.CodeNotNullViolationError, "null value in column %q violates not-null constraint", columnName)
 }
 
-// IsUniquenessConstraintViolationError returns true if the error is for a
-// uniqueness constraint violation.
-func IsUniquenessConstraintViolationError(err error) bool {
-	return errHasCode(err, pgerror.CodeUniqueViolationError)
-}
-
 // NewInvalidSchemaDefinitionError creates an error for an invalid schema
 // definition such as a schema definition that doesn't parse.
 func NewInvalidSchemaDefinitionError(err error) error {


### PR DESCRIPTION
This removes the legacy batched-writes implementaiton for the distributed index backfiller.

This version was off-by-default in 19.1 in favor of the SST-ingestion implementation, but was still available via
a setting in case anyone encountered problems with the new backfiller. However maintaining both long term is
undesirable and the SST-based ingestion implementation will have had two development cycles (19.1 development and
19.2 polish) when 19.2 is released, so keeping the slower legacy implementation around seems less worth it.

Release note (sql change): removed the legacy batch-by-batch index backfiller, as well as the 'schemachanger.bulk_index_backfill.enabled' setting that could be disabled to activate it