### PR TITLE
distsql: fix column ID logic in zigzag joiner

### DIFF
--- a/pkg/sql/distsqlrun/zigzagjoiner_test.go
+++ b/pkg/sql/distsqlrun/zigzagjoiner_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
 )
 
 type zigzagJoinerTestCase struct {
@@ -90,11 +91,15 @@ func TestZigzagJoiner(t *testing.T) {
 	}
 
 	sqlutils.CreateTableDebug(t, sqlDB, "empty",
-		"a INT, b INT, c INT, d INT, PRIMARY KEY (a,b), INDEX c (c), INDEX d (d)",
+		"a INT, b INT, x INT, c INT, d INT, PRIMARY KEY (a,b), INDEX c (c), INDEX d (d)",
 		0,
 		sqlutils.ToRowFn(aFn, bFn, cFn, dFn),
 		true, /* shouldPrint */
 	)
+
+	// Drop a column to test https://github.com/cockroachdb/cockroach/issues/37196
+	_, err := sqlDB.Exec("ALTER TABLE test.empty DROP COLUMN x")
+	require.NoError(t, err)
 
 	sqlutils.CreateTableDebug(t, sqlDB, "single",
 		"a INT, b INT, c INT, d INT, PRIMARY KEY (a,b), INDEX c (c), INDEX d (d)",


### PR DESCRIPTION
In a few places, the zigzag joiner was making a bad assumption that a
columns ordinal position is always one less than its ID. This is not
true for tables with dropped columns. I fixed this and did a bit of
renaming so that "ID" is not used when we refer to column ordinals.

Fixes #37196

Release note (bug fix): Fixed an error which could occur when a zigzag
join was performed against a table with dropped columns.