### PR TITLE
exec: add support for PARTITION BY clause of window functions

### DIFF
--- a/pkg/sql/exec/coldata/batch.go
+++ b/pkg/sql/exec/coldata/batch.go
@@ -27,9 +27,9 @@ type Batch interface {
 	SetLength(uint16)
 	// Width returns the number of columns in the batch.
 	Width() int
-	// Vec returns the ith Vec in this batch.
+	// ColVec returns the ith Vec in this batch.
 	ColVec(i int) Vec
-	// ColVecs returns all of the underlying ColVecs in this batch.
+	// ColVecs returns all of the underlying Vecs in this batch.
 	ColVecs() []Vec
 	// Selection, if not nil, returns the selection vector on this batch: a
 	// densely-packed list of the indices in each column that have not been

--- a/pkg/sql/exec/partitioner.go
+++ b/pkg/sql/exec/partitioner.go
@@ -1,0 +1,94 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+// NewWindowSortingPartitioner creates a new exec.Operator that orders input
+// first based on the partitionIdxs columns and second on ordCols (i.e. it
+// handles both PARTITION BY and ORDER BY clauses of a window function) and
+// puts true in partitionColIdx'th column (which is appended if needed) for
+// every tuple that is the first within its partition.
+func NewWindowSortingPartitioner(
+	input Operator,
+	inputTyps []types.T,
+	partitionIdxs []uint32,
+	ordCols []distsqlpb.Ordering_Column,
+	partitionColIdx int,
+) (op Operator, orderingColsIdxs []uint32, err error) {
+	partitionAndOrderingCols := make([]distsqlpb.Ordering_Column, len(partitionIdxs)+len(ordCols))
+	for i, idx := range partitionIdxs {
+		partitionAndOrderingCols[i] = distsqlpb.Ordering_Column{ColIdx: idx}
+	}
+	copy(partitionAndOrderingCols[len(partitionIdxs):], ordCols)
+	orderingColsIdxs = make([]uint32, len(ordCols))
+	for i := range ordCols {
+		orderingColsIdxs[i] = uint32(len(partitionIdxs) + i)
+	}
+	input, err = NewSorter(input, inputTyps, partitionAndOrderingCols)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var distinctCol []bool
+	input, distinctCol, err = OrderedDistinctColsToOperators(input, partitionIdxs, inputTyps)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &windowSortingPartitioner{input: input, distinctCol: distinctCol, partitionColIdx: partitionColIdx}, orderingColsIdxs, nil
+}
+
+type windowSortingPartitioner struct {
+	input Operator
+
+	// distinctCol is the output column of the chain of ordered distinct
+	// operators in which true will indicate that a new partition begins with the
+	// corresponding tuple.
+	distinctCol     []bool
+	partitionColIdx int
+}
+
+func (p *windowSortingPartitioner) Init() {
+	p.input.Init()
+}
+
+func (p *windowSortingPartitioner) Next(ctx context.Context) coldata.Batch {
+	b := p.input.Next(ctx)
+	if b.Length() == 0 {
+		return b
+	}
+	if p.partitionColIdx == b.Width() {
+		b.AppendCol(types.Bool)
+	} else if p.partitionColIdx > b.Width() {
+		panic("unexpected: column partitionColIdx is neither present nor the next to be appended")
+	}
+	partitionVec := b.ColVec(p.partitionColIdx).Bool()
+	sel := b.Selection()
+	if sel != nil {
+		for i := uint16(0); i < b.Length(); i++ {
+			partitionVec[sel[i]] = p.distinctCol[sel[i]]
+		}
+	} else {
+		copy(partitionVec, p.distinctCol[:b.Length()])
+	}
+	return b
+}

--- a/pkg/sql/exec/vecbuiltins/row_number.go
+++ b/pkg/sql/exec/vecbuiltins/row_number.go
@@ -22,9 +22,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 )
 
+// TODO(yuzefovich): add randomized tests.
 type rowNumberOp struct {
-	input        exec.Operator
-	outputColIdx int
+	input           exec.Operator
+	outputColIdx    int
+	partitionColIdx int
 
 	rowNumber int64
 }
@@ -32,11 +34,13 @@ type rowNumberOp struct {
 var _ exec.Operator = &rowNumberOp{}
 
 // NewRowNumberOperator creates a new exec.Operator that computes window
-// function ROW_NUMBER. outputColIdx specifies in which exec.ColVec the
-// operator should put its output (if there is no such column, a new column is
+// function ROW_NUMBER. outputColIdx specifies in which exec.Vec the operator
+// should put its output (if there is no such column, a new column is
 // appended).
-func NewRowNumberOperator(input exec.Operator, outputColIdx int) exec.Operator {
-	return &rowNumberOp{input: input, outputColIdx: outputColIdx}
+func NewRowNumberOperator(
+	input exec.Operator, outputColIdx int, partitionColIdx int,
+) exec.Operator {
+	return &rowNumberOp{input: input, outputColIdx: outputColIdx, partitionColIdx: partitionColIdx}
 }
 
 func (r *rowNumberOp) Init() {
@@ -50,22 +54,56 @@ func (r *rowNumberOp) Next(ctx context.Context) coldata.Batch {
 	if b.Length() == 0 {
 		return b
 	}
-	if r.outputColIdx == b.Width() {
-		b.AppendCol(types.Int64)
-	} else if r.outputColIdx > b.Width() {
-		panic("unexpected: column outputColIdx is neither present nor the next to be appended")
-	}
-	rowNumberCol := b.ColVec(r.outputColIdx).Int64()
-	sel := b.Selection()
-	if sel != nil {
-		for i := uint16(0); i < b.Length(); i++ {
-			rowNumberCol[sel[i]] = r.rowNumber
-			r.rowNumber++
+	// TODO(yuzefovich): template partition out.
+	if r.partitionColIdx != -1 {
+		if r.partitionColIdx == b.Width() {
+			b.AppendCol(types.Bool)
+		} else if r.partitionColIdx > b.Width() {
+			panic("unexpected: column partitionColIdx is neither present nor the next to be appended")
+		}
+		if r.outputColIdx == b.Width() {
+			b.AppendCol(types.Int64)
+		} else if r.outputColIdx > b.Width() {
+			panic("unexpected: column outputColIdx is neither present nor the next to be appended")
+		}
+		partitionCol := b.ColVec(r.partitionColIdx).Bool()
+		rowNumberCol := b.ColVec(r.outputColIdx).Int64()
+		sel := b.Selection()
+		if sel != nil {
+			for i := uint16(0); i < b.Length(); i++ {
+				if partitionCol[sel[i]] {
+					r.rowNumber = 1
+				}
+				rowNumberCol[sel[i]] = r.rowNumber
+				r.rowNumber++
+			}
+		} else {
+			for i := uint16(0); i < b.Length(); i++ {
+				if partitionCol[i] {
+					r.rowNumber = 1
+				}
+				rowNumberCol[i] = r.rowNumber
+				r.rowNumber++
+			}
 		}
 	} else {
-		for i := uint16(0); i < b.Length(); i++ {
-			rowNumberCol[i] = r.rowNumber
-			r.rowNumber++
+		if r.outputColIdx == b.Width() {
+			b.AppendCol(types.Int64)
+		} else if r.outputColIdx > b.Width() {
+			panic("unexpected: column outputColIdx is neither present nor the next to be appended")
+		}
+		rowNumberCol := b.ColVec(r.outputColIdx).Int64()
+		sel := b.Selection()
+		if sel != nil {
+			for i := uint16(0); i < b.Length(); i++ {
+				rowNumberCol[sel[i]] = r.rowNumber
+				r.rowNumber++
+			}
+		} else {
+			for i := uint16(0); i < b.Length(); i++ {
+				rowNumberCol[i] = r.rowNumber
+				r.rowNumber++
+			}
 		}
 	}
 	return b

--- a/pkg/sql/logictest/testdata/logic_test/exec_window
+++ b/pkg/sql/logictest/testdata/logic_test/exec_window
@@ -28,6 +28,22 @@ SELECT a, b, row_number() OVER (ORDER BY a, b) FROM t ORDER BY b, a
 1 b 4
 
 query ITI
+SELECT a, b, row_number() OVER (PARTITION BY a) FROM t ORDER BY b, a
+----
+0 a 1
+1 a 1
+0 b 2
+1 b 2
+
+query ITI
+SELECT a, b, row_number() OVER (PARTITION BY a, b) FROM t ORDER BY b, a
+----
+0 a 1
+1 a 1
+0 b 1
+1 b 1
+
+query ITI
 SELECT a, b, rank() OVER () FROM t ORDER BY b, a
 ----
 0 a 1
@@ -44,6 +60,14 @@ SELECT a, b, rank() OVER (ORDER BY a) FROM t ORDER BY b, a
 1 b 3
 
 query ITI
+SELECT a, b, rank() OVER (PARTITION BY a ORDER BY b) FROM t ORDER BY b, a
+----
+0 a 1
+1 a 1
+0 b 2
+1 b 2
+
+query ITI
 SELECT a, b, dense_rank() OVER () FROM t ORDER BY b, a
 ----
 0 a 1
@@ -51,10 +75,19 @@ SELECT a, b, dense_rank() OVER () FROM t ORDER BY b, a
 0 b 1
 1 b 1
 
+
 query ITI
 SELECT a, b, dense_rank() OVER (ORDER BY a) FROM t ORDER BY b, a
 ----
 0 a 1
 1 a 2
 0 b 1
+1 b 2
+
+query ITI
+SELECT a, b, dense_rank() OVER (PARTITION BY a ORDER BY b) FROM t ORDER BY b, a
+----
+0 a 1
+1 a 1
+0 b 2
 1 b 2


### PR DESCRIPTION
Adds a sorting partitioner that takes care of both PARTITION BY and
ORDER BY clauses. It is probably slower that hashing partitioning,
but that will be added later.

Fixes: #37034.

Release note: None