### PR TITLE
sql: implement pg_catalog.pg_attribute.atttypmod

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -165,6 +165,9 @@ CREATE TABLE constraint_db.t1 (
   a INT UNIQUE,
   b INT,
   c INT DEFAULT 12,
+  d VARCHAR(5),
+  e BIT(5),
+  f DECIMAL(10,7),
   UNIQUE INDEX index_key(b, c)
 )
 
@@ -309,7 +312,7 @@ JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'public'
 ----
 relname       relistemp  relkind  relnatts  relchecks  relhasoids  relhaspkey
-t1            false      r        4         0          false       true
+t1            false      r        7         0          false       true
 primary       false      i        1         0          false       false
 t1_a_key      false      i        1         0          false       false
 index_key     false      i        2         0          false       false
@@ -354,6 +357,9 @@ attrelid    relname       attname  atttypid  attstattarget  attlen  attnum  attn
 55          t1            a        20        0              8       2       0         -1
 55          t1            b        20        0              8       3       0         -1
 55          t1            c        20        0              8       4       0         -1
+55          t1            d        1043      0              -1      5       0         -1
+55          t1            e        1560      0              -1      6       0         -1
+55          t1            f        1700      0              -1      7       0         -1
 450499963   primary       p        701       0              8       1       0         -1
 450499960   t1_a_key      a        20        0              8       2       0         -1
 450499961   index_key     b        20        0              8       3       0         -1
@@ -386,6 +392,9 @@ t1            p        -1         NULL      NULL        NULL      true        fa
 t1            a        -1         NULL      NULL        NULL      false       false
 t1            b        -1         NULL      NULL        NULL      false       false
 t1            c        -1         NULL      NULL        NULL      false       true
+t1            d        9          NULL      NULL        NULL      false       false
+t1            e        5          NULL      NULL        NULL      false       false
+t1            f        655371     NULL      NULL        NULL      false       false
 primary       p        -1         NULL      NULL        NULL      true        false
 t1_a_key      a        -1         NULL      NULL        NULL      false       false
 index_key     b        -1         NULL      NULL        NULL      false       false
@@ -418,6 +427,9 @@ t1            p        false         true        0            NULL    NULL      
 t1            a        false         true        0            NULL    NULL        NULL
 t1            b        false         true        0            NULL    NULL        NULL
 t1            c        false         true        0            NULL    NULL        NULL
+t1            d        false         true        0            NULL    NULL        NULL
+t1            e        false         true        0            NULL    NULL        NULL
+t1            f        false         true        0            NULL    NULL        NULL
 primary       p        false         true        0            NULL    NULL        NULL
 t1_a_key      a        false         true        0            NULL    NULL        NULL
 index_key     b        false         true        0            NULL    NULL        NULL
@@ -487,6 +499,7 @@ JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'public'
 ----
 relname  attname  typname  attcollation  collname
+t1       d        varchar  3903121477    en-US
 t3       c        text     3903121477    en-US
 
 

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -378,19 +378,36 @@ CREATE TABLE pg_catalog.pg_attribute (
 			// addColumn adds adds either a table or a index column to the pg_attribute table.
 			addColumn := func(column *sqlbase.ColumnDescriptor, attRelID tree.Datum, colID sqlbase.ColumnID) error {
 				colTyp := &column.Type
+				attTypMod := int32(-1)
+				if width := colTyp.Width(); width != 0 {
+					switch colTyp.Family() {
+					case types.StringFamily:
+						// Postgres adds 4 to the attypmod for bounded string types, the
+						// var header size.
+						attTypMod = width + 4
+					case types.BitFamily:
+						attTypMod = width
+					case types.DecimalFamily:
+						// attTypMod is calculated by putting the precision in the upper
+						// bits and the scale in the lower bits of a 32-bit int, and adding
+						// 4 (the var header size). We mock this for clients' sake. See
+						// numeric.c.
+						attTypMod = ((colTyp.Precision() << 16) | width) + 4
+					}
+				}
 				return addRow(
-					attRelID,                       // attrelid
-					tree.NewDName(column.Name),     // attname
-					typOid(colTyp),                 // atttypid
-					zeroVal,                        // attstattarget
-					typLen(colTyp),                 // attlen
-					tree.NewDInt(tree.DInt(colID)), // attnum
-					zeroVal,                        // attndims
-					negOneVal,                      // attcacheoff
-					negOneVal,                      // atttypmod
-					tree.DNull,                     // attbyval (see pg_type.typbyval)
-					tree.DNull,                     // attstorage
-					tree.DNull,                     // attalign
+					attRelID,                           // attrelid
+					tree.NewDName(column.Name),         // attname
+					typOid(colTyp),                     // atttypid
+					zeroVal,                            // attstattarget
+					typLen(colTyp),                     // attlen
+					tree.NewDInt(tree.DInt(colID)),     // attnum
+					zeroVal,                            // attndims
+					negOneVal,                          // attcacheoff
+					tree.NewDInt(tree.DInt(attTypMod)), // atttypmod
+					tree.DNull,                         // attbyval (see pg_type.typbyval)
+					tree.DNull,                         // attstorage
+					tree.DNull,                         // attalign
 					tree.MakeDBool(tree.DBool(!column.Nullable)),          // attnotnull
 					tree.MakeDBool(tree.DBool(column.DefaultExpr != nil)), // atthasdef
 					tree.DBoolFalse,    // attisdropped


### PR DESCRIPTION
This field contains information about the scale, precision and/or width
of various datatypes and is important for client compatibility.

Fixes #16032.

Release note (sql change): the atttypmod column of the pg_attribute
catalog table is supported.