### PR TITLE
release-19.1: opt: Fold functions that are contained in a whitelist

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -552,7 +552,7 @@ filter              ·       ·                           (attrelid, attname, at
 ·                   source  ·                           ·                                                                                                                                                                                                                                              ·
 
 query TTTTT
-EXPLAIN (VERBOSE) SELECT CASE WHEN length('foo') = 3 THEN 42 ELSE 1/3 END
+EXPLAIN (VERBOSE) SELECT CASE WHEN current_database() = 'test' THEN 42 ELSE 1/3 END
 ----
 values  ·              ·                ("case")  ·
 ·       size           1 column, 1 row  ·         ·
@@ -560,7 +560,7 @@ values  ·              ·                ("case")  ·
 
 # Don't fold the CASE since there is an error in the ELSE clause.
 query TTTTT
-EXPLAIN (VERBOSE) SELECT CASE WHEN length('foo') = 3 THEN 42 ELSE 1/0 END
+EXPLAIN (VERBOSE) SELECT CASE WHEN current_database() = 'test' THEN 42 ELSE 1/0 END
 ----
 values  ·              ·                                      ("case")  ·
 ·       size           1 column, 1 row                        ·         ·

--- a/pkg/sql/opt/memo/testdata/stats/srfs
+++ b/pkg/sql/opt/memo/testdata/stats/srfs
@@ -30,13 +30,11 @@ inner-join
  │    │    │    ├── key: ()
  │    │    │    └── tuple [type=tuple]
  │    │    └── zip
- │    │         ├── function: upper [type=string]
- │    │         │    └── const: 'def' [type=string]
+ │    │         ├── const: 'DEF' [type=string]
  │    │         ├── function: generate_series [type=int, side-effects]
  │    │         │    ├── const: 1 [type=int]
  │    │         │    └── const: 3 [type=int]
- │    │         └── function: upper [type=string]
- │    │              └── const: 'ghi' [type=string]
+ │    │         └── const: 'GHI' [type=string]
  │    ├── project-set
  │    │    ├── columns: upper:1(string)
  │    │    ├── stats: [rows=1, distinct(1)=1, null(1)=0]
@@ -46,8 +44,7 @@ inner-join
  │    │    │    ├── key: ()
  │    │    │    └── tuple [type=tuple]
  │    │    └── zip
- │    │         └── function: upper [type=string]
- │    │              └── const: 'abc' [type=string]
+ │    │         └── const: 'ABC' [type=string]
  │    └── filters (true)
  ├── project-set
  │    ├── columns: generate_series:5(int)
@@ -99,8 +96,7 @@ distinct-on
       │    │    ├── key: ()
       │    │    └── tuple [type=tuple]
       │    └── zip
-      │         └── function: upper [type=string]
-      │              └── const: 'abc' [type=string]
+      │         └── const: 'ABC' [type=string]
       └── filters (true)
 
 opt colstat=3 colstat=(1,2,3)
@@ -215,8 +211,7 @@ distinct-on
       │         ├── function: generate_series [type=int, side-effects]
       │         │    ├── const: 0 [type=int]
       │         │    └── const: 1 [type=int]
-      │         └── function: lower [type=string]
-      │              └── const: 'ABC' [type=string]
+      │         └── const: 'abc' [type=string]
       └── filters
            └── title = upper [type=bool, outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ]), fd=(4)==(10), (10)==(4)]
 
@@ -254,8 +249,7 @@ distinct-on
       │         ├── function: generate_series [type=int, side-effects]
       │         │    ├── const: 0 [type=int]
       │         │    └── const: 1 [type=int]
-      │         └── function: lower [type=string]
-      │              └── const: 'ABC' [type=string]
+      │         └── const: 'abc' [type=string]
       └── filters
            └── title = unnest [type=bool, outer=(4,11), constraints=(/4: (/NULL - ]; /11: (/NULL - ]), fd=(4)==(11), (11)==(4)]
 
@@ -293,8 +287,7 @@ distinct-on
       │         ├── function: generate_series [type=int, side-effects]
       │         │    ├── const: 0 [type=int]
       │         │    └── const: 1 [type=int]
-      │         └── function: lower [type=string]
-      │              └── const: 'ABC' [type=string]
+      │         └── const: 'abc' [type=string]
       └── filters
            └── id = generate_series [type=bool, outer=(1,12), constraints=(/1: (/NULL - ]; /12: (/NULL - ]), fd=(1)==(12), (12)==(1)]
 
@@ -332,7 +325,6 @@ distinct-on
       │         ├── function: generate_series [type=int, side-effects]
       │         │    ├── const: 0 [type=int]
       │         │    └── const: 1 [type=int]
-      │         └── function: lower [type=string]
-      │              └── const: 'ABC' [type=string]
+      │         └── const: 'abc' [type=string]
       └── filters
            └── title = lower [type=bool, outer=(4,13), constraints=(/4: (/NULL - ]; /13: (/NULL - ]), fd=(4)==(13), (13)==(4)]

--- a/pkg/sql/opt/norm/norm_test.go
+++ b/pkg/sql/opt/norm/norm_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/opttester"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datadriven"
 )
@@ -89,4 +90,30 @@ func TestRuleBinaryAssumption(t *testing.T) {
 	fn(opt.BitandOp)
 	fn(opt.BitorOp)
 	fn(opt.BitxorOp)
+}
+
+// These constants are copied from sql/sem/builtins/builtins.go.
+const (
+	categorySystemInfo  = "System info"
+	categoryDateAndTime = "Date and time"
+)
+
+// TestRuleFunctionAssumption checks that we do not fold impure functions.
+// There are other functions we should not fold such as current_user() because
+// they depend on context, but it is very difficult to test that we avoid all
+// such cases. Instead, we rely on clues like the category.
+func TestRuleFunctionAssumption(t *testing.T) {
+	for name := range norm.FoldFunctionWhitelist {
+		props, _ := builtins.GetBuiltinProperties(name)
+		if props == nil {
+			t.Errorf("could not find properties for function %s", name)
+			continue
+		}
+		if props.Impure {
+			t.Errorf("%s should not be folded because it is impure", name)
+		}
+		if props.Category == categorySystemInfo || props.Category == categoryDateAndTime {
+			t.Errorf("%s should not be folded because it has category %s", name, props.Category)
+		}
+	}
 }

--- a/pkg/sql/opt/norm/rules/fold_constants.opt
+++ b/pkg/sql/opt/norm/rules/fold_constants.opt
@@ -81,3 +81,19 @@ $result
 )
 =>
 $result
+
+# FoldFunction is similar to FoldBinary, but it involves a function with
+# constant inputs. As with FoldBinary, FoldFunction applies as long as the
+# evaluation would not cause an error. Additionally, only certain functions
+# are safe to fold as part of normalization. Other functions rely on context
+# that may change between runs of a prepared query.
+#
+# This rule is marked as low priority so that the FoldNull rules in scalar.opt
+# can run first.
+[FoldFunction, Normalize, LowPriority]
+(Function
+  $args:* & (IsListOfConstants $args)
+  $private:* & (Succeeded $result:(FoldFunction $args $private))
+)
+=>
+$result

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -55,8 +55,7 @@ select
       ├── i < 5 [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
       └── s <= 'foo' [type=bool, outer=(4), constraints=(/4: (/NULL - /'foo']; tight)]
 
-# TODO(andyk): Constant fold functions
-opt expect-not=CommuteConstInequality
+opt expect=CommuteConstInequality
 SELECT * FROM a WHERE length('foo')+1<i+k AND length('bar')<=i*2
 ----
 select
@@ -68,8 +67,8 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6)
  └── filters
-      ├── (length('foo') + 1) < (i + k) [type=bool, outer=(1,2)]
-      └── length('bar') <= (i * 2) [type=bool, outer=(2)]
+      ├── (i + k) > 4 [type=bool, outer=(1,2)]
+      └── (i * 2) >= 3 [type=bool, outer=(2)]
 
 # Impure function should not be considered constant.
 opt expect-not=CommuteConstInequality
@@ -96,7 +95,7 @@ FROM a
 WHERE
     k+1 = 2 AND
     (f+f)+2 < 5 AND
-    1::decimal+i <= length('foo') AND
+    1::decimal+i >= length('foo') AND
     i+2+2 > 10 AND
     '1:00:00'::time + i::interval >= '2:00:00'::time
 ----
@@ -112,9 +111,8 @@ select
  │    ├── key: ()
  │    └── fd: ()-->(1-6)
  └── filters
+      ├── (i >= 2) AND (i > 6) [type=bool, outer=(2), constraints=(/2: [/7 - ]; tight)]
       ├── (f + f) < 3.0 [type=bool, outer=(3)]
-      ├── (i + 1) <= length('foo') [type=bool, outer=(2)]
-      ├── i > 6 [type=bool, outer=(2), constraints=(/2: [/7 - ]; tight)]
       └── i::INTERVAL >= '01:00:00' [type=bool, outer=(2)]
 
 # Try case that should not match pattern because Minus overload is not defined.
@@ -141,8 +139,8 @@ FROM a
 WHERE
     k-1 = 2 AND
     (f+f)-2 < 5 AND
-    i-1::decimal <= length('foo') AND
-    i-2-2 > 10 AND
+    i-1::decimal >= length('foo') AND
+    i-2-2 < 10 AND
     f+i::float-10.0 >= 100.0 AND
     d-'1w'::interval >= '2018-09-23'::date
 ----
@@ -158,9 +156,8 @@ select
  │    ├── key: ()
  │    └── fd: ()-->(1-6)
  └── filters
+      ├── (i >= 4) AND (i < 14) [type=bool, outer=(2), constraints=(/2: [/4 - /13]; tight)]
       ├── (f + f) < 7.0 [type=bool, outer=(3)]
-      ├── (i - 1) <= length('foo') [type=bool, outer=(2)]
-      ├── i > 14 [type=bool, outer=(2), constraints=(/2: [/15 - ]; tight)]
       ├── (f + i::FLOAT8) >= 110.0 [type=bool, outer=(2,3)]
       └── d >= '2018-09-30' [type=bool, outer=(6), constraints=(/6: [/'2018-09-30' - ]; tight)]
 
@@ -204,9 +201,8 @@ select
  │    ├── key: ()
  │    └── fd: ()-->(1-6)
  └── filters
+      ├── (i >= -2) AND (i > 10) [type=bool, outer=(2), constraints=(/2: [/11 - ]; tight)]
       ├── (f + f) > -3.0 [type=bool, outer=(3)]
-      ├── (1 - i) <= length('foo') [type=bool, outer=(2)]
-      ├── i > 10 [type=bool, outer=(2), constraints=(/2: [/11 - ]; tight)]
       └── (f + i::FLOAT8) <= -90.0 [type=bool, outer=(2,3)]
 
 # Try case that should not match pattern because Minus overload is not defined.

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -4541,8 +4541,7 @@ distinct-on
       │         ├── function: generate_series [type=int, side-effects]
       │         │    ├── const: 0 [type=int]
       │         │    └── const: 1 [type=int]
-      │         └── function: lower [type=string]
-      │              └── const: 'ABC' [type=string]
+      │         └── const: 'abc' [type=string]
       └── filters
            └── title = unnest [type=bool, outer=(4,11), constraints=(/4: (/NULL - ]; /11: (/NULL - ]), fd=(4)==(11), (11)==(4)]
 

--- a/pkg/sql/opt/norm/testdata/rules/fold_constants
+++ b/pkg/sql/opt/norm/testdata/rules/fold_constants
@@ -586,3 +586,38 @@ values
  ├── key: ()
  ├── fd: ()-->(1)
  └── (1,) [type=tuple{decimal}]
+
+# --------------------------------------------------
+# FoldFunction
+# --------------------------------------------------
+
+opt expect=FoldFunction
+SELECT length('abc'), upper('xyz'), lower('DEF')
+----
+values
+ ├── columns: length:1(int) upper:2(string) lower:3(string)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1-3)
+ └── (3, 'XYZ', 'def') [type=tuple{int, string, string}]
+
+opt expect=FoldFunction
+SELECT encode('abc', 'hex'), decode('616263', 'hex')
+----
+values
+ ├── columns: encode:1(string) decode:2(bytes)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1,2)
+ └── ('616263', '\x616263') [type=tuple{string, bytes}]
+
+opt expect-not=FoldFunction
+SELECT now(), current_user(), current_database()
+----
+values
+ ├── columns: now:1(timestamptz) current_user:2(string) current_database:3(string)
+ ├── cardinality: [1 - 1]
+ ├── side-effects
+ ├── key: ()
+ ├── fd: ()-->(1-3)
+ └── (now(), current_user(), current_database()) [type=tuple{timestamptz, string, string}]

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -72,15 +72,15 @@ project
  │    ├── key: (1)
  │    └── fd: (1)-->(2,3)
  └── projections
-      ├── (length('foo') + 1) = (i + k) [type=bool, outer=(1,2)]
-      ├── length('bar') != (i * 2) [type=bool, outer=(2)]
+      ├── (i + k) = 4 [type=bool, outer=(1,2)]
+      ├── (i * 2) != 3 [type=bool, outer=(2)]
       ├── (1 - k) IS NOT DISTINCT FROM 5 [type=bool, outer=(1)]
       ├── k IS DISTINCT FROM 11 [type=bool, outer=(1)]
       ├── f + 1.0 [type=float, outer=(3)]
-      ├── (length('foo') * 5) * (i * i) [type=int, outer=(2)]
+      ├── (i * i) * 15 [type=int, outer=(2)]
       ├── (i + i) & 10000 [type=int, outer=(2)]
-      ├── (length('foo') + 1) | (i + i) [type=int, outer=(2)]
-      └── (1 - length('foo')) # (k ^ 2) [type=int, outer=(1)]
+      ├── (i + i) | 4 [type=int, outer=(2)]
+      └── (k ^ 2) # -2 [type=int, outer=(1)]
 
 # --------------------------------------------------
 # EliminateCoalesce


### PR DESCRIPTION
Backport 1/1 commits from #36639.

/cc @cockroachdb/release

---

This commit adds a whitelist of functions that are always ok
to fold during normalization, because they always produce the same
results given the same set of inputs. This will allow us to generate
spans for predicates that contain constant functions.

This is not the ideal way to solve this problem, but it provides
a stopgap until #26582 is addressed.

Fixes #31617

Release note (performance improvement): Improved the performance of
some queries containing predicates with constant functions, since
these functions are now evaluated earlier during query optimization.
