### PR TITLE
storage: remove outdated log.Event about copying timestamp cache

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2143,7 +2143,6 @@ func splitPostApply(
 	rightLease := *rightRng.mu.state.Lease
 	rightRng.mu.Unlock()
 	r.mu.Unlock()
-	log.Event(ctx, "copied timestamp cache")
 
 	// We need to explicitly wake up the Raft group on the right-hand range or
 	// else the range could be underreplicated for an indefinite period of time.


### PR DESCRIPTION
This has been misleading since 7eac2ddf64a438bc34ed788160b54b370761d4ec.

Release note: None