### PR TITLE
release-19.1: distsql: fix column ID logic in zigzag joiner

### DIFF
--- a/pkg/sql/distsqlrun/zigzagjoiner.go
+++ b/pkg/sql/distsqlrun/zigzagjoiner.go
@@ -363,7 +363,8 @@ type zigzagJoinerInfo struct {
 	// the cartesian product of the containers will be emitted.
 	container sqlbase.EncDatumRowContainer
 
-	eqColumnIDs columns
+	// eqColumns is the ordinal positions of the equality columns.
+	eqColumns columns
 
 	// Prefix of the index key that has fixed values.
 	fixedValues sqlbase.EncDatumRow
@@ -389,7 +390,7 @@ func (z *zigzagJoiner) setupInfo(spec *distsqlpb.ZigzagJoinerSpec, side int, col
 
 	info.alloc = &sqlbase.DatumAlloc{}
 	info.table = &spec.Tables[side]
-	info.eqColumnIDs = spec.EqColumns[side].Columns
+	info.eqColumns = spec.EqColumns[side].Columns
 	indexID := spec.IndexIds[side]
 	if indexID == 0 {
 		info.index = &info.table.PrimaryIndex
@@ -400,11 +401,9 @@ func (z *zigzagJoiner) setupInfo(spec *distsqlpb.ZigzagJoinerSpec, side int, col
 	var columnIDs []sqlbase.ColumnID
 	columnIDs, info.indexDirs = info.index.FullColumnIDs()
 	info.indexTypes = make([]sqlbase.ColumnType, len(columnIDs))
-	indexCols := make([]uint32, len(columnIDs))
 	columnTypes := info.table.ColumnTypes()
 	colIdxMap := info.table.ColumnIdxMap()
 	for i, columnID := range columnIDs {
-		indexCols[i] = uint32(columnID)
 		info.indexTypes[i] = columnTypes[colIdxMap[columnID]]
 	}
 
@@ -418,11 +417,11 @@ func (z *zigzagJoiner) setupInfo(spec *distsqlpb.ZigzagJoinerSpec, side int, col
 
 	// Add the fixed columns.
 	for i := 0; i < len(info.fixedValues); i++ {
-		neededCols.Add(int(indexCols[i]) - 1)
+		neededCols.Add(colIdxMap[columnIDs[i]])
 	}
 
 	// Add the equality columns.
-	for _, col := range info.eqColumnIDs {
+	for _, col := range info.eqColumns {
 		neededCols.Add(int(col))
 	}
 
@@ -502,7 +501,7 @@ func (z *zigzagJoiner) fetchRowFromSide(
 	// Keep fetching until a row is found that does not have null in an equality
 	// column.
 	hasNull := func(row sqlbase.EncDatumRow) bool {
-		for _, c := range z.infos[side].eqColumnIDs {
+		for _, c := range z.infos[side].eqColumns {
 			if row[c].IsNull() {
 				return true
 			}
@@ -524,12 +523,12 @@ func (z *zigzagJoiner) fetchRowFromSide(
 // Return the datums from the equality columns from a given non-empty row
 // from the specified side.
 func (z *zigzagJoiner) extractEqDatums(row sqlbase.EncDatumRow, side int) sqlbase.EncDatumRow {
-	eqColIDs := z.infos[side].eqColumnIDs
-	eqCols := make(sqlbase.EncDatumRow, len(eqColIDs))
-	for i, id := range eqColIDs {
-		eqCols[i] = row[id]
+	eqCols := z.infos[side].eqColumns
+	eqDatums := make(sqlbase.EncDatumRow, len(eqCols))
+	for i, col := range eqCols {
+		eqDatums[i] = row[col]
 	}
-	return eqCols
+	return eqDatums
 }
 
 // Generates a Key for an inverted index from the passed datums and side
@@ -617,28 +616,29 @@ func (z *zigzagJoiner) produceSpanFromBaseRow() (roachpb.Span, error) {
 
 // Returns the column types of the equality columns.
 func (zi *zigzagJoinerInfo) eqColTypes() []sqlbase.ColumnType {
-	eqColIDs := zi.eqColumnIDs
-	eqColTypes := make([]sqlbase.ColumnType, 0, len(eqColIDs))
-	for _, id := range eqColIDs {
-		eqColTypes = append(eqColTypes, zi.table.ColumnTypes()[id])
+	eqColTypes := make([]sqlbase.ColumnType, len(zi.eqColumns))
+	colTypes := zi.table.ColumnTypes()
+	for i := range eqColTypes {
+		eqColTypes[i] = colTypes[zi.eqColumns[i]]
 	}
 	return eqColTypes
 }
 
 // Returns the ordering of the equality columns.
 func (zi *zigzagJoinerInfo) eqOrdering() (sqlbase.ColumnOrdering, error) {
-	ordering := make(sqlbase.ColumnOrdering, len(zi.eqColumnIDs))
-	for i, colID := range zi.eqColumnIDs {
+	ordering := make(sqlbase.ColumnOrdering, len(zi.eqColumns))
+	for i := range zi.eqColumns {
+		colID := zi.table.Columns[zi.eqColumns[i]].ID
 		// Search the index columns, then the primary keys to find an ordering for
 		// the current column, 'colID'.
 		var direction encoding.Direction
 		var err error
-		if idx := findColumnID(zi.index.ColumnIDs, sqlbase.ColumnID(colID+1)); idx != -1 {
+		if idx := findColumnID(zi.index.ColumnIDs, colID); idx != -1 {
 			direction, err = zi.index.ColumnDirections[idx].ToEncodingDirection()
 			if err != nil {
 				return nil, err
 			}
-		} else if idx := findColumnID(zi.table.PrimaryIndex.ColumnIDs, sqlbase.ColumnID(colID+1)); idx != -1 {
+		} else if idx := findColumnID(zi.table.PrimaryIndex.ColumnIDs, colID); idx != -1 {
 			direction, err = zi.table.PrimaryIndex.ColumnDirections[idx].ToEncodingDirection()
 			if err != nil {
 				return nil, err

--- a/pkg/sql/distsqlrun/zigzagjoiner_test.go
+++ b/pkg/sql/distsqlrun/zigzagjoiner_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
 )
 
 type zigzagJoinerTestCase struct {
@@ -90,11 +91,15 @@ func TestZigzagJoiner(t *testing.T) {
 	}
 
 	sqlutils.CreateTableDebug(t, sqlDB, "empty",
-		"a INT, b INT, c INT, d INT, PRIMARY KEY (a,b), INDEX c (c), INDEX d (d)",
+		"a INT, b INT, x INT, c INT, d INT, PRIMARY KEY (a,b), INDEX c (c), INDEX d (d)",
 		0,
 		sqlutils.ToRowFn(aFn, bFn, cFn, dFn),
 		true, /* shouldPrint */
 	)
+
+	// Drop a column to test https://github.com/cockroachdb/cockroach/issues/37196
+	_, err := sqlDB.Exec("ALTER TABLE test.empty DROP COLUMN x")
+	require.NoError(t, err)
 
 	sqlutils.CreateTableDebug(t, sqlDB, "single",
 		"a INT, b INT, c INT, d INT, PRIMARY KEY (a,b), INDEX c (c), INDEX d (d)",


### PR DESCRIPTION
Backport 1/1 commits from #37218.

/cc @cockroachdb/release

---

In a few places, the zigzag joiner was making a bad assumption that a
columns ordinal position is always one less than its ID. This is not
true for tables with dropped columns. I fixed this and did a bit of
renaming so that "ID" is not used when we refer to column ordinals.

Fixes #37196

Release note (bug fix): Fixed an error which could occur when a zigzag
join was performed against a table with dropped columns.
