### PR TITLE
release-19.1: build: whitelist `prefix` Make variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -344,6 +344,8 @@ build/variables.mk: Makefile build/archive/contents/Makefile pkg/ui/Makefile bui
 	@sed -nE -e '/^	/d' -e 's/([^#]*)#.*/\1/' \
 	  -e 's/(^|^[^:]+:)[ ]*(export)?[ ]*([[:upper:]_]+)[ ]*[:?+]?=.*/  \3/p' $^ \
 	  | sort -u >> $@
+	# Special case for 'prefix' variable, which is required by Homebrew.
+	@echo '  prefix' >> $@
 	@echo 'endef' >> $@
 
 # The following section handles building our C/C++ dependencies. These are

--- a/build/variables.mk
+++ b/build/variables.mk
@@ -154,4 +154,5 @@ define VALID_VARS
   XCXX
   XGOARCH
   XGOOS
+  prefix
 endef


### PR DESCRIPTION
Backport 1/1 commits from #37239.

/cc @cockroachdb/release

---

In 0bf05c9, we disallowed setting lowercase Make variables on the
command line. However, our Homebrew recipe relies on setting the
`prefix` variable to set the install directory. I whitelisted `prefix`
as an exception to the general uppercase rule.

Release note: None
