### PR TITLE
util/metric: make Rate into a real metric

### DIFF
--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -541,6 +541,8 @@ func extractValue(mtr interface{}) (float64, error) {
 		return float64(mtr.Count()), nil
 	case *metric.Gauge:
 		return float64(mtr.Value()), nil
+	case *metric.Rate:
+		return mtr.Value(), nil
 	case *metric.GaugeFloat64:
 		return mtr.Value(), nil
 	default:

--- a/pkg/util/metric/metric_test.go
+++ b/pkg/util/metric/metric_test.go
@@ -75,6 +75,15 @@ func TestGaugeFloat64(t *testing.T) {
 	testMarshal(t, g, "10.4")
 }
 
+func TestRate(t *testing.T) {
+	r := NewRate(emptyMetadata, time.Minute)
+	r.Add(0)
+	if v := r.Value(); v != 0 {
+		t.Fatalf("unexpected value: %f", v)
+	}
+	testMarshal(t, r, "0")
+}
+
 func TestCounter(t *testing.T) {
 	c := NewCounter(emptyMetadata)
 	c.Inc(90)
@@ -164,7 +173,7 @@ func TestRateRotate(t *testing.T) {
 	defer TestingSetNow(nil)()
 	setNow(0)
 	const interval = 10 * time.Second
-	r := NewRate(interval)
+	r := NewRate(emptyMetadata, interval)
 
 	// Skip the warmup phase of the wrapped EWMA for this test.
 	for i := 0; i < 100; i++ {


### PR DESCRIPTION
The metric package had a Rate type to track an exponential weighted moving
average for a Rate but it was unclear how a caller would use it as a metric
in a metric struct. This PR makes that Rate type into a real metric in
anticipation of using it to track throughputs.

Release note: None