### PR TITLE
release-19.1: opt: check validation status of FK constraints

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -1692,6 +1692,18 @@ INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', 'y1', 'z1')
 statement ok
 ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x)
 
+# Verify that the optimizer doesn't use an unvalidated constraint to simplify plans.
+query TTT
+SELECT
+  s.a_z, s.a_y, s.a_x
+FROM
+  (SELECT * FROM b WHERE a_z IS NOT NULL AND a_y IS NOT NULL AND a_x IS NOT NULL) AS s
+  LEFT JOIN a AS t ON s.a_z = t.z AND s.a_y = t.y AND s.a_x = t.x
+WHERE
+  t.z IS NULL
+----
+z1 y1 x2
+
 statement error foreign key violation: "b" row a_z='z1', a_y='y1', a_x='x2' has no match in "a"
 ALTER TABLE b VALIDATE CONSTRAINT fk_ref
 

--- a/pkg/sql/opt/cat/index.go
+++ b/pkg/sql/opt/cat/index.go
@@ -116,6 +116,8 @@ type Index interface {
 	// ForeignKey returns a ForeignKeyReference if this index is part
 	// of an outbound foreign key relation. Returns false for the second
 	// return value if there is no foreign key reference on this index.
+	// TODO(radu): this does not belong here: foreign key references should not be
+	// tied to specific indexes.
 	ForeignKey() (ForeignKeyReference, bool)
 
 	// Zone returns the zone which constrains placement of the index's range

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -187,6 +187,12 @@ type ForeignKeyReference struct {
 	// relation in the current and destination indexes.
 	PrefixLen int32
 
+	// Validated is true if the reference is validated (i.e. we know that the
+	// existing data satisfies the constraint). It is possible to set up a foreign
+	// key constraint on existing tables without validating it, in which case we
+	// cannot make any assumptions about the data.
+	Validated bool
+
 	// Match contains the method used for comparing composite foreign keys.
 	Match tree.CompositeKeyMatchMethod
 }

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -1,0 +1,63 @@
+# LogicTest: local-opt
+
+statement ok
+CREATE TABLE a (
+  x STRING NULL,
+  y STRING NULL,
+  z STRING NULL,
+  CONSTRAINT "primary" PRIMARY KEY (z, y, x)
+)
+
+statement ok
+CREATE TABLE b (
+  a_y STRING NULL,
+  a_x STRING NULL,
+  a_z STRING NULL,
+  INDEX idx (a_z, a_y, a_x)
+)
+
+statement ok
+ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x)
+
+# Verify that the optimizer doesn't use an unvalidated constraint to simplify plans.
+query TTT colnames
+EXPLAIN SELECT
+  s.a_z, s.a_y, s.a_x
+FROM
+  (SELECT * FROM b WHERE a_z IS NOT NULL AND a_y IS NOT NULL AND a_x IS NOT NULL) AS s
+  LEFT JOIN a AS t ON s.a_z = t.z AND s.a_y = t.y AND s.a_x = t.x
+WHERE
+  t.z IS NULL
+----
+tree                  field           description
+render                ·               ·
+ └── filter           ·               ·
+      │               filter          z IS NULL
+      └── merge-join  ·               ·
+           │          type            left outer
+           │          equality        (a_z, a_y, a_x) = (z, y, x)
+           │          mergeJoinOrder  +"(a_z=z)",+"(a_y=y)",+"(a_x=x)"
+           ├── scan   ·               ·
+           │          table           b@idx
+           │          spans           /!NULL-
+           │          filter          (a_y IS NOT NULL) AND (a_x IS NOT NULL)
+           └── scan   ·               ·
+·                     table           a@primary
+·                     spans           ALL
+
+statement ok
+ALTER TABLE b VALIDATE CONSTRAINT fk_ref
+
+# Now the plan should be simplified.
+query TTT colnames
+EXPLAIN SELECT
+  s.a_z, s.a_y, s.a_x
+FROM
+  (SELECT * FROM b WHERE a_z IS NOT NULL AND a_y IS NOT NULL AND a_x IS NOT NULL) AS s
+  LEFT JOIN a AS t ON s.a_z = t.z AND s.a_y = t.y AND s.a_x = t.x
+WHERE
+  t.z IS NULL
+----
+tree         field  description
+render       ·      ·
+ └── norows  ·      ·

--- a/pkg/sql/opt/norm/join.go
+++ b/pkg/sql/opt/norm/join.go
@@ -420,15 +420,16 @@ func (c *CustomFuncs) JoinFiltersMatchAllLeftRows(
 	}
 
 	var leftRightColMap map[opt.ColumnID]opt.ColumnID
-	// Condition #5: All remaining left columns correspond to a foreign key relation.
+	// Condition #5: All remaining left columns correspond to a validated foreign
+	// key relation.
 	leftTabMeta := md.TableMeta(leftTab)
 	rightTabMeta := md.TableMeta(rightTab)
 	for i, cnt := 0, leftTabMeta.Table.IndexCount(); i < cnt; i++ {
 		index := leftTabMeta.Table.Index(i)
 		fkRef, ok := index.ForeignKey()
 
-		if !ok {
-			// No foreign key reference on this index.
+		if !ok || !fkRef.Validated {
+			// No validated foreign key reference on this index.
 			continue
 		}
 

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -267,6 +267,7 @@ func (tc *Catalog) resolveFK(tab *Table, d *tree.ForeignKeyConstraintTableDef) {
 			idx.foreignKey.TableID = targetTable.ID()
 			idx.foreignKey.IndexID = targetIndex.ID()
 			idx.foreignKey.PrefixLen = int32(len(fromCols))
+			idx.foreignKey.Validated = true
 			idx.fkSet = true
 			break
 		}
@@ -291,6 +292,7 @@ func (tc *Catalog) resolveFK(tab *Table, d *tree.ForeignKeyConstraintTableDef) {
 		index.foreignKey.TableID = targetTable.ID()
 		index.foreignKey.IndexID = targetIndex.ID()
 		index.foreignKey.PrefixLen = int32(len(fromCols))
+		index.foreignKey.Validated = true
 		index.fkSet = true
 	}
 }

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -821,6 +821,8 @@ func (oi *optIndex) init(tab *optTable, desc *sqlbase.IndexDescriptor, zone *con
 		oi.foreignKey.TableID = cat.StableID(desc.ForeignKey.Table)
 		oi.foreignKey.IndexID = cat.StableID(desc.ForeignKey.Index)
 		oi.foreignKey.PrefixLen = desc.ForeignKey.SharedPrefixLen
+		oi.foreignKey.Validated = (desc.ForeignKey.Validity == sqlbase.ConstraintValidity_Validated)
+		oi.foreignKey.Match = sqlbase.ForeignKeyReferenceMatchValue[desc.ForeignKey.Match]
 	}
 }
 
@@ -885,14 +887,7 @@ func (oi *optIndex) Column(i int) cat.IndexColumn {
 
 // ForeignKey is part of the cat.Index interface.
 func (oi *optIndex) ForeignKey() (cat.ForeignKeyReference, bool) {
-	desc := oi.desc
-	if desc.ForeignKey.IsSet() {
-		oi.foreignKey.TableID = cat.StableID(desc.ForeignKey.Table)
-		oi.foreignKey.IndexID = cat.StableID(desc.ForeignKey.Index)
-		oi.foreignKey.PrefixLen = desc.ForeignKey.SharedPrefixLen
-		oi.foreignKey.Match = sqlbase.ForeignKeyReferenceMatchValue[desc.ForeignKey.Match]
-	}
-	return oi.foreignKey, oi.desc.ForeignKey.IsSet()
+	return oi.foreignKey, oi.foreignKey.TableID != 0
 }
 
 // Zone is part of the cat.Index interface.


### PR DESCRIPTION
Backport 1/1 commits from #37208.

/cc @cockroachdb/release

---

The optimizer uses FK constraints to simplify plans, but it does not
verify that the constraint has been validated. This change plumbs the
validation status to the optimizer to fix this.

Fixes #37197.

Release note (bug fix): Fixed incorrect query plans/results when there
are non-validated FK constraints that are not satisfied by the data.
