### PR TITLE
distsqlrun: use uint64 for offsets in window frames

### DIFF
--- a/pkg/sql/distsqlpb/processors.go
+++ b/pkg/sql/distsqlpb/processors.go
@@ -99,11 +99,11 @@ func (spec *WindowerSpec_Frame_Bounds) initFromAST(
 		}
 		switch m {
 		case tree.ROWS:
-			startOffset := int(tree.MustBeDInt(dStartOffset))
+			startOffset := int64(tree.MustBeDInt(dStartOffset))
 			if startOffset < 0 {
 				return pgerror.Newf(pgerror.CodeInvalidWindowFrameOffsetError, "frame starting offset must not be negative")
 			}
-			spec.Start.IntOffset = uint32(startOffset)
+			spec.Start.IntOffset = uint64(startOffset)
 		case tree.RANGE:
 			if isNegative(evalCtx, dStartOffset) {
 				return pgerror.Newf(pgerror.CodeInvalidWindowFrameOffsetError, "invalid preceding or following size in window function")
@@ -119,11 +119,11 @@ func (spec *WindowerSpec_Frame_Bounds) initFromAST(
 			}
 			spec.Start.TypedOffset = buf
 		case tree.GROUPS:
-			startOffset := int(tree.MustBeDInt(dStartOffset))
+			startOffset := int64(tree.MustBeDInt(dStartOffset))
 			if startOffset < 0 {
 				return pgerror.Newf(pgerror.CodeInvalidWindowFrameOffsetError, "frame starting offset must not be negative")
 			}
-			spec.Start.IntOffset = uint32(startOffset)
+			spec.Start.IntOffset = uint64(startOffset)
 		}
 	}
 
@@ -141,11 +141,11 @@ func (spec *WindowerSpec_Frame_Bounds) initFromAST(
 			}
 			switch m {
 			case tree.ROWS:
-				endOffset := int(tree.MustBeDInt(dEndOffset))
+				endOffset := int64(tree.MustBeDInt(dEndOffset))
 				if endOffset < 0 {
 					return pgerror.Newf(pgerror.CodeInvalidWindowFrameOffsetError, "frame ending offset must not be negative")
 				}
-				spec.End.IntOffset = uint32(endOffset)
+				spec.End.IntOffset = uint64(endOffset)
 			case tree.RANGE:
 				if isNegative(evalCtx, dEndOffset) {
 					return pgerror.Newf(pgerror.CodeInvalidWindowFrameOffsetError, "invalid preceding or following size in window function")
@@ -161,11 +161,11 @@ func (spec *WindowerSpec_Frame_Bounds) initFromAST(
 				}
 				spec.End.TypedOffset = buf
 			case tree.GROUPS:
-				endOffset := int(tree.MustBeDInt(dEndOffset))
+				endOffset := int64(tree.MustBeDInt(dEndOffset))
 				if endOffset < 0 {
 					return pgerror.Newf(pgerror.CodeInvalidWindowFrameOffsetError, "frame ending offset must not be negative")
 				}
-				spec.End.IntOffset = uint32(endOffset)
+				spec.End.IntOffset = uint64(endOffset)
 			}
 		}
 	}

--- a/pkg/sql/distsqlpb/processors.pb.go
+++ b/pkg/sql/distsqlpb/processors.pb.go
@@ -74,7 +74,7 @@ func (x *ScanVisibility) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ScanVisibility) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{0}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{0}
 }
 
 type SketchType int32
@@ -110,7 +110,7 @@ func (x *SketchType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (SketchType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{1}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{1}
 }
 
 // These mirror the aggregate functions supported by sql/parser. See
@@ -206,7 +206,7 @@ func (x *AggregatorSpec_Func) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (AggregatorSpec_Func) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{17, 0}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{17, 0}
 }
 
 type AggregatorSpec_Type int32
@@ -252,7 +252,7 @@ func (x *AggregatorSpec_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (AggregatorSpec_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{17, 1}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{17, 1}
 }
 
 type BackfillerSpec_Type int32
@@ -291,7 +291,7 @@ func (x *BackfillerSpec_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (BackfillerSpec_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{18, 0}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{18, 0}
 }
 
 type WindowerSpec_WindowFunc int32
@@ -355,7 +355,7 @@ func (x *WindowerSpec_WindowFunc) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_WindowFunc) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{29, 0}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{29, 0}
 }
 
 // Mode indicates which mode of framing is used.
@@ -399,7 +399,7 @@ func (x *WindowerSpec_Frame_Mode) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_Frame_Mode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{29, 1, 0}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{29, 1, 0}
 }
 
 // BoundType indicates which type of boundary is used.
@@ -446,7 +446,7 @@ func (x *WindowerSpec_Frame_BoundType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_Frame_BoundType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{29, 1, 1}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{29, 1, 1}
 }
 
 // Each processor has the following components:
@@ -495,7 +495,7 @@ func (m *ProcessorSpec) Reset()         { *m = ProcessorSpec{} }
 func (m *ProcessorSpec) String() string { return proto.CompactTextString(m) }
 func (*ProcessorSpec) ProtoMessage()    {}
 func (*ProcessorSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{0}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{0}
 }
 func (m *ProcessorSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -556,7 +556,7 @@ func (m *PostProcessSpec) Reset()         { *m = PostProcessSpec{} }
 func (m *PostProcessSpec) String() string { return proto.CompactTextString(m) }
 func (*PostProcessSpec) ProtoMessage()    {}
 func (*PostProcessSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{1}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{1}
 }
 func (m *PostProcessSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -614,7 +614,7 @@ func (m *ProcessorCoreUnion) Reset()         { *m = ProcessorCoreUnion{} }
 func (m *ProcessorCoreUnion) String() string { return proto.CompactTextString(m) }
 func (*ProcessorCoreUnion) ProtoMessage()    {}
 func (*ProcessorCoreUnion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{2}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{2}
 }
 func (m *ProcessorCoreUnion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -651,7 +651,7 @@ func (m *NoopCoreSpec) Reset()         { *m = NoopCoreSpec{} }
 func (m *NoopCoreSpec) String() string { return proto.CompactTextString(m) }
 func (*NoopCoreSpec) ProtoMessage()    {}
 func (*NoopCoreSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{3}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{3}
 }
 func (m *NoopCoreSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -686,7 +686,7 @@ func (m *MetadataTestSenderSpec) Reset()         { *m = MetadataTestSenderSpec{}
 func (m *MetadataTestSenderSpec) String() string { return proto.CompactTextString(m) }
 func (*MetadataTestSenderSpec) ProtoMessage()    {}
 func (*MetadataTestSenderSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{4}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{4}
 }
 func (m *MetadataTestSenderSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -721,7 +721,7 @@ func (m *MetadataTestReceiverSpec) Reset()         { *m = MetadataTestReceiverSp
 func (m *MetadataTestReceiverSpec) String() string { return proto.CompactTextString(m) }
 func (*MetadataTestReceiverSpec) ProtoMessage()    {}
 func (*MetadataTestReceiverSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{5}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{5}
 }
 func (m *MetadataTestReceiverSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -765,7 +765,7 @@ func (m *ValuesCoreSpec) Reset()         { *m = ValuesCoreSpec{} }
 func (m *ValuesCoreSpec) String() string { return proto.CompactTextString(m) }
 func (*ValuesCoreSpec) ProtoMessage()    {}
 func (*ValuesCoreSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{6}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{6}
 }
 func (m *ValuesCoreSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -803,7 +803,7 @@ func (m *TableReaderSpan) Reset()         { *m = TableReaderSpan{} }
 func (m *TableReaderSpan) String() string { return proto.CompactTextString(m) }
 func (*TableReaderSpan) ProtoMessage()    {}
 func (*TableReaderSpan) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{7}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{7}
 }
 func (m *TableReaderSpan) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -873,7 +873,7 @@ func (m *TableReaderSpec) Reset()         { *m = TableReaderSpec{} }
 func (m *TableReaderSpec) String() string { return proto.CompactTextString(m) }
 func (*TableReaderSpec) ProtoMessage()    {}
 func (*TableReaderSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{8}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{8}
 }
 func (m *TableReaderSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -958,7 +958,7 @@ func (m *JoinReaderSpec) Reset()         { *m = JoinReaderSpec{} }
 func (m *JoinReaderSpec) String() string { return proto.CompactTextString(m) }
 func (*JoinReaderSpec) ProtoMessage()    {}
 func (*JoinReaderSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{9}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{9}
 }
 func (m *JoinReaderSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1004,7 +1004,7 @@ func (m *SorterSpec) Reset()         { *m = SorterSpec{} }
 func (m *SorterSpec) String() string { return proto.CompactTextString(m) }
 func (*SorterSpec) ProtoMessage()    {}
 func (*SorterSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{10}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{10}
 }
 func (m *SorterSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1050,7 +1050,7 @@ func (m *DistinctSpec) Reset()         { *m = DistinctSpec{} }
 func (m *DistinctSpec) String() string { return proto.CompactTextString(m) }
 func (*DistinctSpec) ProtoMessage()    {}
 func (*DistinctSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{11}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{11}
 }
 func (m *DistinctSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1108,7 +1108,7 @@ func (m *ZigzagJoinerSpec) Reset()         { *m = ZigzagJoinerSpec{} }
 func (m *ZigzagJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*ZigzagJoinerSpec) ProtoMessage()    {}
 func (*ZigzagJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{12}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{12}
 }
 func (m *ZigzagJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1152,7 +1152,7 @@ func (m *LocalPlanNodeSpec) Reset()         { *m = LocalPlanNodeSpec{} }
 func (m *LocalPlanNodeSpec) String() string { return proto.CompactTextString(m) }
 func (*LocalPlanNodeSpec) ProtoMessage()    {}
 func (*LocalPlanNodeSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{13}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{13}
 }
 func (m *LocalPlanNodeSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1187,7 +1187,7 @@ func (m *Columns) Reset()         { *m = Columns{} }
 func (m *Columns) String() string { return proto.CompactTextString(m) }
 func (*Columns) ProtoMessage()    {}
 func (*Columns) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{14}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{14}
 }
 func (m *Columns) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1257,7 +1257,7 @@ func (m *MergeJoinerSpec) Reset()         { *m = MergeJoinerSpec{} }
 func (m *MergeJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*MergeJoinerSpec) ProtoMessage()    {}
 func (*MergeJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{15}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{15}
 }
 func (m *MergeJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1346,7 +1346,7 @@ func (m *HashJoinerSpec) Reset()         { *m = HashJoinerSpec{} }
 func (m *HashJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*HashJoinerSpec) ProtoMessage()    {}
 func (*HashJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{16}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{16}
 }
 func (m *HashJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1394,7 +1394,7 @@ func (m *AggregatorSpec) Reset()         { *m = AggregatorSpec{} }
 func (m *AggregatorSpec) String() string { return proto.CompactTextString(m) }
 func (*AggregatorSpec) ProtoMessage()    {}
 func (*AggregatorSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{17}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{17}
 }
 func (m *AggregatorSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1447,7 +1447,7 @@ func (m *AggregatorSpec_Aggregation) Reset()         { *m = AggregatorSpec_Aggre
 func (m *AggregatorSpec_Aggregation) String() string { return proto.CompactTextString(m) }
 func (*AggregatorSpec_Aggregation) ProtoMessage()    {}
 func (*AggregatorSpec_Aggregation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{17, 0}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{17, 0}
 }
 func (m *AggregatorSpec_Aggregation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1507,7 +1507,7 @@ func (m *BackfillerSpec) Reset()         { *m = BackfillerSpec{} }
 func (m *BackfillerSpec) String() string { return proto.CompactTextString(m) }
 func (*BackfillerSpec) ProtoMessage()    {}
 func (*BackfillerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{18}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{18}
 }
 func (m *BackfillerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1547,7 +1547,7 @@ func (m *FlowSpec) Reset()         { *m = FlowSpec{} }
 func (m *FlowSpec) String() string { return proto.CompactTextString(m) }
 func (*FlowSpec) ProtoMessage()    {}
 func (*FlowSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{19}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{19}
 }
 func (m *FlowSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1589,7 +1589,7 @@ func (m *JobProgress) Reset()         { *m = JobProgress{} }
 func (m *JobProgress) String() string { return proto.CompactTextString(m) }
 func (*JobProgress) ProtoMessage()    {}
 func (*JobProgress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{20}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{20}
 }
 func (m *JobProgress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1649,7 +1649,7 @@ func (m *ReadImportDataSpec) Reset()         { *m = ReadImportDataSpec{} }
 func (m *ReadImportDataSpec) String() string { return proto.CompactTextString(m) }
 func (*ReadImportDataSpec) ProtoMessage()    {}
 func (*ReadImportDataSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{21}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{21}
 }
 func (m *ReadImportDataSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1696,7 +1696,7 @@ func (m *SSTWriterSpec) Reset()         { *m = SSTWriterSpec{} }
 func (m *SSTWriterSpec) String() string { return proto.CompactTextString(m) }
 func (*SSTWriterSpec) ProtoMessage()    {}
 func (*SSTWriterSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{22}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{22}
 }
 func (m *SSTWriterSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1734,7 +1734,7 @@ func (m *SSTWriterSpec_SpanName) Reset()         { *m = SSTWriterSpec_SpanName{}
 func (m *SSTWriterSpec_SpanName) String() string { return proto.CompactTextString(m) }
 func (*SSTWriterSpec_SpanName) ProtoMessage()    {}
 func (*SSTWriterSpec_SpanName) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{22, 0}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{22, 0}
 }
 func (m *SSTWriterSpec_SpanName) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1778,7 +1778,7 @@ func (m *CSVWriterSpec) Reset()         { *m = CSVWriterSpec{} }
 func (m *CSVWriterSpec) String() string { return proto.CompactTextString(m) }
 func (*CSVWriterSpec) ProtoMessage()    {}
 func (*CSVWriterSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{23}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{23}
 }
 func (m *CSVWriterSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1825,7 +1825,7 @@ func (m *SketchSpec) Reset()         { *m = SketchSpec{} }
 func (m *SketchSpec) String() string { return proto.CompactTextString(m) }
 func (*SketchSpec) ProtoMessage()    {}
 func (*SketchSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{24}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{24}
 }
 func (m *SketchSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1901,7 +1901,7 @@ func (m *SamplerSpec) Reset()         { *m = SamplerSpec{} }
 func (m *SamplerSpec) String() string { return proto.CompactTextString(m) }
 func (*SamplerSpec) ProtoMessage()    {}
 func (*SamplerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{25}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{25}
 }
 func (m *SamplerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1964,7 +1964,7 @@ func (m *SampleAggregatorSpec) Reset()         { *m = SampleAggregatorSpec{} }
 func (m *SampleAggregatorSpec) String() string { return proto.CompactTextString(m) }
 func (*SampleAggregatorSpec) ProtoMessage()    {}
 func (*SampleAggregatorSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{26}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{26}
 }
 func (m *SampleAggregatorSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2029,7 +2029,7 @@ func (m *InterleavedReaderJoinerSpec) Reset()         { *m = InterleavedReaderJo
 func (m *InterleavedReaderJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*InterleavedReaderJoinerSpec) ProtoMessage()    {}
 func (*InterleavedReaderJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{27}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{27}
 }
 func (m *InterleavedReaderJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2087,7 +2087,7 @@ func (m *InterleavedReaderJoinerSpec_Table) Reset()         { *m = InterleavedRe
 func (m *InterleavedReaderJoinerSpec_Table) String() string { return proto.CompactTextString(m) }
 func (*InterleavedReaderJoinerSpec_Table) ProtoMessage()    {}
 func (*InterleavedReaderJoinerSpec_Table) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{27, 0}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{27, 0}
 }
 func (m *InterleavedReaderJoinerSpec_Table) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2129,7 +2129,7 @@ func (m *ProjectSetSpec) Reset()         { *m = ProjectSetSpec{} }
 func (m *ProjectSetSpec) String() string { return proto.CompactTextString(m) }
 func (*ProjectSetSpec) ProtoMessage()    {}
 func (*ProjectSetSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{28}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{28}
 }
 func (m *ProjectSetSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2173,7 +2173,7 @@ func (m *WindowerSpec) Reset()         { *m = WindowerSpec{} }
 func (m *WindowerSpec) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec) ProtoMessage()    {}
 func (*WindowerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{29}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{29}
 }
 func (m *WindowerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2211,7 +2211,7 @@ func (m *WindowerSpec_Func) Reset()         { *m = WindowerSpec_Func{} }
 func (m *WindowerSpec_Func) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Func) ProtoMessage()    {}
 func (*WindowerSpec_Func) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{29, 0}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{29, 0}
 }
 func (m *WindowerSpec_Func) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2248,7 +2248,7 @@ func (m *WindowerSpec_Frame) Reset()         { *m = WindowerSpec_Frame{} }
 func (m *WindowerSpec_Frame) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Frame) ProtoMessage()    {}
 func (*WindowerSpec_Frame) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{29, 1}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{29, 1}
 }
 func (m *WindowerSpec_Frame) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2277,9 +2277,10 @@ var xxx_messageInfo_WindowerSpec_Frame proto.InternalMessageInfo
 type WindowerSpec_Frame_Bound struct {
 	BoundType WindowerSpec_Frame_BoundType `protobuf:"varint,1,opt,name=boundType,enum=cockroach.sql.distsqlrun.WindowerSpec_Frame_BoundType" json:"boundType"`
 	// For UNBOUNDED_PRECEDING, UNBOUNDED_FOLLOWING, and CURRENT_ROW offset
-	// is ignored. Integer offset for ROWS mode is stored in int_offset while
-	// an encoded datum and the type information are stored for RANGE mode.
-	IntOffset            uint32    `protobuf:"varint,2,opt,name=int_offset,json=intOffset" json:"int_offset"`
+	// is ignored. Integer offset for ROWS and GROUPS modes is stored in
+	// int_offset while an encoded datum and the type information are stored
+	// for RANGE mode.
+	IntOffset            uint64    `protobuf:"varint,2,opt,name=int_offset,json=intOffset" json:"int_offset"`
 	TypedOffset          []byte    `protobuf:"bytes,3,opt,name=typed_offset,json=typedOffset" json:"typed_offset,omitempty"`
 	OffsetType           DatumInfo `protobuf:"bytes,4,opt,name=offset_type,json=offsetType" json:"offset_type"`
 	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
@@ -2290,7 +2291,7 @@ func (m *WindowerSpec_Frame_Bound) Reset()         { *m = WindowerSpec_Frame_Bou
 func (m *WindowerSpec_Frame_Bound) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Frame_Bound) ProtoMessage()    {}
 func (*WindowerSpec_Frame_Bound) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{29, 1, 0}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{29, 1, 0}
 }
 func (m *WindowerSpec_Frame_Bound) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2328,7 +2329,7 @@ func (m *WindowerSpec_Frame_Bounds) Reset()         { *m = WindowerSpec_Frame_Bo
 func (m *WindowerSpec_Frame_Bounds) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Frame_Bounds) ProtoMessage()    {}
 func (*WindowerSpec_Frame_Bounds) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{29, 1, 1}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{29, 1, 1}
 }
 func (m *WindowerSpec_Frame_Bounds) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2380,7 +2381,7 @@ func (m *WindowerSpec_WindowFn) Reset()         { *m = WindowerSpec_WindowFn{} }
 func (m *WindowerSpec_WindowFn) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_WindowFn) ProtoMessage()    {}
 func (*WindowerSpec_WindowFn) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{29, 2}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{29, 2}
 }
 func (m *WindowerSpec_WindowFn) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2419,7 +2420,7 @@ func (m *ChangeAggregatorSpec) Reset()         { *m = ChangeAggregatorSpec{} }
 func (m *ChangeAggregatorSpec) String() string { return proto.CompactTextString(m) }
 func (*ChangeAggregatorSpec) ProtoMessage()    {}
 func (*ChangeAggregatorSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{30}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{30}
 }
 func (m *ChangeAggregatorSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2455,7 +2456,7 @@ func (m *ChangeAggregatorSpec_Watch) Reset()         { *m = ChangeAggregatorSpec
 func (m *ChangeAggregatorSpec_Watch) String() string { return proto.CompactTextString(m) }
 func (*ChangeAggregatorSpec_Watch) ProtoMessage()    {}
 func (*ChangeAggregatorSpec_Watch) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{30, 0}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{30, 0}
 }
 func (m *ChangeAggregatorSpec_Watch) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2500,7 +2501,7 @@ func (m *ChangeFrontierSpec) Reset()         { *m = ChangeFrontierSpec{} }
 func (m *ChangeFrontierSpec) String() string { return proto.CompactTextString(m) }
 func (*ChangeFrontierSpec) ProtoMessage()    {}
 func (*ChangeFrontierSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_137023c5e4ef3379, []int{31}
+	return fileDescriptor_processors_e11b3d6ebe9a5182, []int{31}
 }
 func (m *ChangeFrontierSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -12554,7 +12555,7 @@ func (m *WindowerSpec_Frame_Bound) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.IntOffset |= (uint32(b) & 0x7F) << shift
+				m.IntOffset |= (uint64(b) & 0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -13465,11 +13466,11 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/distsqlpb/processors.proto", fileDescriptor_processors_137023c5e4ef3379)
+	proto.RegisterFile("sql/distsqlpb/processors.proto", fileDescriptor_processors_e11b3d6ebe9a5182)
 }
 
-var fileDescriptor_processors_137023c5e4ef3379 = []byte{
-	// 4146 bytes of a gzipped FileDescriptorProto
+var fileDescriptor_processors_e11b3d6ebe9a5182 = []byte{
+	// 4147 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xc4, 0x5b, 0x4d, 0x8c, 0x1b, 0x47,
 	0x76, 0x16, 0xc9, 0xe6, 0xdf, 0xe3, 0xcf, 0xb4, 0x4a, 0x63, 0x8b, 0x1e, 0x3b, 0x1a, 0x89, 0xf6,
 	0xae, 0x7e, 0x56, 0x3b, 0x23, 0xc9, 0x5e, 0xc7, 0xf6, 0x7a, 0x61, 0xf3, 0x77, 0xc4, 0x11, 0x87,
@@ -13692,42 +13693,42 @@ var fileDescriptor_processors_137023c5e4ef3379 = []byte{
 	0x45, 0xc1, 0x51, 0x76, 0x65, 0xc3, 0xd6, 0x83, 0xbd, 0xcb, 0x40, 0xc8, 0x63, 0x48, 0x0d, 0xec,
 	0xa9, 0xa5, 0xbb, 0x22, 0x18, 0xfe, 0x78, 0x2e, 0xb8, 0x2a, 0x8a, 0xfa, 0x9e, 0x84, 0x03, 0x2d,
 	0xfd, 0x4f, 0x0c, 0x92, 0x48, 0x20, 0xdf, 0x42, 0x16, 0xdb, 0xfa, 0xb3, 0x18, 0xe6, 0xd3, 0xf9,
-	0xf1, 0x43, 0xfe, 0x66, 0x06, 0xc7, 0x3c, 0xa3, 0x61, 0x79, 0xaa, 0x78, 0x5e, 0x17, 0xf6, 0x14,
-	0x59, 0xc3, 0xf2, 0xba, 0xfc, 0x85, 0xdd, 0x0d, 0xc8, 0x33, 0xcb, 0xd5, 0x7d, 0xb6, 0x04, 0x46,
-	0x8f, 0x39, 0x6c, 0x13, 0x2c, 0xeb, 0x90, 0xe3, 0x44, 0x1e, 0x69, 0x71, 0x5f, 0x30, 0xc7, 0x3d,
-	0x3a, 0x70, 0x69, 0x36, 0xa6, 0xa5, 0x3f, 0x89, 0x41, 0x8a, 0xab, 0x84, 0x74, 0x20, 0xe9, 0x7a,
-	0x9a, 0xe3, 0x09, 0x57, 0xf8, 0x60, 0xfe, 0x69, 0x07, 0x2e, 0x82, 0xc1, 0x90, 0xfa, 0x2c, 0xfc,
-	0x7d, 0x2d, 0x34, 0x0c, 0x99, 0xcb, 0x37, 0x41, 0x62, 0x16, 0x40, 0xb2, 0x90, 0x54, 0x2a, 0x9d,
-	0xb5, 0x86, 0x7c, 0x89, 0x64, 0x40, 0xc2, 0x92, 0x59, 0x8c, 0x00, 0xa4, 0xd6, 0x94, 0xee, 0xd6,
-	0x66, 0x4f, 0x8e, 0x97, 0x5f, 0x40, 0x36, 0xd0, 0x3d, 0xb9, 0x0a, 0x57, 0xb6, 0x3a, 0xd5, 0xee,
-	0x56, 0xa7, 0xde, 0xa8, 0xab, 0x9b, 0x4a, 0xa3, 0xd6, 0xa8, 0xb7, 0x3a, 0x6b, 0xf2, 0xa5, 0x28,
-	0xa1, 0xd9, 0x6d, 0xb7, 0xbb, 0x4f, 0x18, 0x21, 0x46, 0x16, 0x41, 0xee, 0x36, 0x9b, 0xbd, 0x46,
-	0x3f, 0xc4, 0x1e, 0x0f, 0xb5, 0xce, 0x78, 0x13, 0x64, 0x01, 0x72, 0xb5, 0x2d, 0x45, 0x69, 0xf0,
-	0xda, 0x9d, 0x2c, 0x2d, 0xfd, 0x4b, 0x1c, 0x32, 0xfe, 0xf6, 0x25, 0x8d, 0x50, 0xe9, 0xf5, 0xcc,
-	0x37, 0x29, 0xd1, 0x89, 0x1f, 0x2d, 0xbc, 0xbe, 0x1d, 0x77, 0x5f, 0x85, 0xe4, 0x8e, 0xe3, 0xc7,
-	0xae, 0x67, 0xbe, 0x38, 0x39, 0xbe, 0x0c, 0x0a, 0x17, 0x25, 0xb7, 0x20, 0x52, 0xca, 0x15, 0x4f,
-	0x68, 0x45, 0x70, 0x12, 0x29, 0xf2, 0x2e, 0x41, 0x46, 0x73, 0x46, 0x6e, 0x4b, 0x3f, 0x70, 0xb1,
-	0x8e, 0x50, 0x50, 0x82, 0x6f, 0x86, 0x12, 0x3c, 0x5c, 0x65, 0x28, 0x99, 0x90, 0xfd, 0x47, 0x28,
-	0x3c, 0x4b, 0xf2, 0xab, 0xb9, 0x31, 0x80, 0x99, 0x93, 0x21, 0x45, 0x00, 0xa5, 0xfb, 0x44, 0xed,
-	0x6c, 0x6d, 0x54, 0x1b, 0x8a, 0x30, 0x85, 0x4a, 0xe7, 0x11, 0x2f, 0x58, 0xd6, 0x1b, 0x9d, 0x5e,
-	0x43, 0xc5, 0xef, 0x38, 0x91, 0x21, 0xbf, 0xd9, 0x50, 0x6a, 0xb8, 0x46, 0xac, 0x25, 0x41, 0x0a,
-	0x90, 0xad, 0x6d, 0x6d, 0x34, 0xd4, 0x7a, 0xab, 0xd7, 0xe7, 0x85, 0xdd, 0x4e, 0xbf, 0xd5, 0x6e,
-	0xf0, 0xc2, 0x6e, 0xbb, 0xb2, 0x26, 0xa7, 0x18, 0x5c, 0xbb, 0x51, 0xa9, 0xcb, 0x69, 0xb6, 0xc4,
-	0xcd, 0x96, 0xd2, 0xeb, 0xab, 0xdb, 0x95, 0xf6, 0x56, 0x43, 0xce, 0x30, 0xfc, 0x76, 0x25, 0xf8,
-	0xce, 0x32, 0xb4, 0x4e, 0xff, 0xa1, 0xf8, 0x84, 0xf2, 0xdf, 0xc7, 0x61, 0xf1, 0xa4, 0xd7, 0x40,
-	0xa4, 0x0f, 0xe9, 0x7d, 0x2d, 0x1c, 0x52, 0x7f, 0x32, 0xdf, 0x73, 0xa2, 0x95, 0x27, 0x4c, 0xda,
-	0x0f, 0xb2, 0x04, 0x14, 0x69, 0x82, 0xb4, 0x43, 0xa9, 0x7e, 0xca, 0xc3, 0x6e, 0x7c, 0x0b, 0xcf,
-	0xdf, 0xc5, 0x0b, 0x4c, 0xc6, 0x5c, 0xa7, 0x9e, 0x66, 0x98, 0x6e, 0x60, 0x64, 0x94, 0xea, 0x4b,
-	0xbf, 0x1b, 0x83, 0x24, 0x76, 0x40, 0x3a, 0x20, 0x1b, 0x96, 0xe1, 0x19, 0x9a, 0xa9, 0x3a, 0xd4,
-	0xb5, 0xcd, 0xe7, 0x54, 0x17, 0x16, 0x7c, 0xa1, 0xc2, 0xe2, 0x82, 0x10, 0x56, 0x84, 0x6c, 0xf0,
-	0xa4, 0x26, 0x7e, 0xf1, 0x27, 0x35, 0xff, 0x18, 0x03, 0x72, 0xfc, 0xdd, 0x13, 0xa9, 0x42, 0xc1,
-	0x73, 0xb4, 0xe1, 0x1e, 0xd5, 0x55, 0x1e, 0xb9, 0x70, 0x3d, 0x9e, 0x03, 0x99, 0x17, 0x32, 0x3d,
-	0xcc, 0xfc, 0xdf, 0x92, 0xbe, 0x42, 0xe1, 0x7c, 0xe2, 0xf4, 0x70, 0xfe, 0xce, 0xaf, 0x43, 0x31,
-	0xfa, 0xa6, 0x81, 0x39, 0xaa, 0xcd, 0xad, 0x6a, 0xbb, 0x55, 0x93, 0x2f, 0x91, 0xf7, 0xe0, 0x1d,
-	0xfe, 0x5b, 0xad, 0x74, 0xea, 0x78, 0x3d, 0x21, 0x48, 0xb1, 0x3b, 0x65, 0x3f, 0xa3, 0x46, 0x27,
-	0xb6, 0x08, 0xf2, 0xc3, 0x76, 0x5b, 0xdd, 0x6c, 0x6f, 0xf5, 0xf8, 0x9f, 0xed, 0xfb, 0xf2, 0xa5,
-	0xea, 0x87, 0xdf, 0xfd, 0xe7, 0xb5, 0x4b, 0xdf, 0xbd, 0xba, 0x16, 0xfb, 0xe7, 0x57, 0xd7, 0x62,
-	0xff, 0xfa, 0xea, 0x5a, 0xec, 0x3f, 0x5e, 0x5d, 0x8b, 0xfd, 0xc1, 0x2f, 0xae, 0x5d, 0xfa, 0x36,
-	0x1b, 0xfc, 0x57, 0x84, 0xff, 0x0f, 0x00, 0x00, 0xff, 0xff, 0xfa, 0x9c, 0xb6, 0xc4, 0x55, 0x31,
-	0x00, 0x00,
+	0xf1, 0x43, 0xfe, 0x66, 0x06, 0xc7, 0x3c, 0xa3, 0x61, 0x79, 0xaa, 0x78, 0x5e, 0x17, 0x0f, 0xb9,
+	0xf8, 0xac, 0x61, 0x79, 0x5d, 0xfe, 0xc2, 0xee, 0x06, 0xe4, 0x99, 0xe5, 0xea, 0x3e, 0x5b, 0x02,
+	0xa3, 0xc7, 0x1c, 0xb6, 0x09, 0x96, 0x75, 0xc8, 0x71, 0x22, 0x8f, 0xb4, 0xb8, 0x2f, 0x98, 0xe3,
+	0x1e, 0x1d, 0xb8, 0x34, 0x1b, 0xd3, 0xd2, 0x9f, 0xc4, 0x20, 0xc5, 0x55, 0x42, 0x3a, 0x90, 0x74,
+	0x3d, 0xcd, 0xf1, 0x84, 0x2b, 0x7c, 0x30, 0xff, 0xb4, 0x03, 0x17, 0xc1, 0x60, 0x48, 0x7d, 0x16,
+	0xfe, 0xbe, 0x16, 0x1a, 0x86, 0xcc, 0xe5, 0x9b, 0x20, 0x31, 0x0b, 0x20, 0x59, 0x48, 0x2a, 0x95,
+	0xce, 0x5a, 0x43, 0xbe, 0x44, 0x32, 0x20, 0x61, 0xc9, 0x2c, 0x46, 0x00, 0x52, 0x6b, 0x4a, 0x77,
+	0x6b, 0xb3, 0x27, 0xc7, 0xcb, 0x2f, 0x20, 0x1b, 0xe8, 0x9e, 0x5c, 0x85, 0x2b, 0x5b, 0x9d, 0x6a,
+	0x77, 0xab, 0x53, 0x6f, 0xd4, 0xd5, 0x4d, 0xa5, 0x51, 0x6b, 0xd4, 0x5b, 0x9d, 0x35, 0xf9, 0x52,
+	0x94, 0xd0, 0xec, 0xb6, 0xdb, 0xdd, 0x27, 0x8c, 0x10, 0x23, 0x8b, 0x20, 0x77, 0x9b, 0xcd, 0x5e,
+	0xa3, 0x1f, 0x62, 0x8f, 0x87, 0x5a, 0x67, 0xbc, 0x09, 0xb2, 0x00, 0xb9, 0xda, 0x96, 0xa2, 0x34,
+	0x78, 0xed, 0x4e, 0x96, 0x96, 0xfe, 0x25, 0x0e, 0x19, 0x7f, 0xfb, 0x92, 0x46, 0xa8, 0xf4, 0x7a,
+	0xe6, 0x9b, 0x94, 0xe8, 0xc4, 0x8f, 0x16, 0x5e, 0xdf, 0x8e, 0xbb, 0xaf, 0x42, 0x72, 0xc7, 0xf1,
+	0x63, 0xd7, 0x33, 0x5f, 0x9c, 0x1c, 0x5f, 0x06, 0x85, 0x8b, 0x92, 0x5b, 0x10, 0x29, 0xe5, 0x8a,
+	0x27, 0xb4, 0x22, 0x38, 0x89, 0x14, 0x79, 0x97, 0x20, 0xa3, 0x39, 0x23, 0xb7, 0xa5, 0x1f, 0xb8,
+	0x58, 0x47, 0x28, 0x28, 0xc1, 0x37, 0x43, 0x09, 0x1e, 0xae, 0x32, 0x94, 0x4c, 0xe8, 0xa4, 0x8c,
+	0x50, 0x78, 0x96, 0xe4, 0x57, 0x73, 0x63, 0x00, 0x33, 0x27, 0x43, 0x8a, 0x00, 0x4a, 0xf7, 0x89,
+	0xda, 0xd9, 0xda, 0xa8, 0x36, 0x14, 0x61, 0x0a, 0x95, 0xce, 0x23, 0x5e, 0xb0, 0xac, 0x37, 0x3a,
+	0xbd, 0x86, 0x8a, 0xdf, 0x71, 0x22, 0x43, 0x7e, 0xb3, 0xa1, 0xd4, 0x70, 0x8d, 0x58, 0x4b, 0x82,
+	0x14, 0x20, 0x5b, 0xdb, 0xda, 0x68, 0xa8, 0xf5, 0x56, 0xaf, 0xcf, 0x0b, 0xbb, 0x9d, 0x7e, 0xab,
+	0xdd, 0xe0, 0x85, 0xdd, 0x76, 0x65, 0x4d, 0x4e, 0x31, 0xb8, 0x76, 0xa3, 0x52, 0x97, 0xd3, 0x6c,
+	0x89, 0x9b, 0x2d, 0xa5, 0xd7, 0x57, 0xb7, 0x2b, 0xed, 0xad, 0x86, 0x9c, 0x61, 0xf8, 0xed, 0x4a,
+	0xf0, 0x9d, 0x65, 0x68, 0x9d, 0xfe, 0x43, 0xf1, 0x09, 0xe5, 0xbf, 0x8f, 0xc3, 0xe2, 0x49, 0xaf,
+	0x81, 0x48, 0x1f, 0xd2, 0xfb, 0x5a, 0x38, 0xa4, 0xfe, 0x64, 0xbe, 0xe7, 0x44, 0x2b, 0x4f, 0x98,
+	0xb4, 0x1f, 0x64, 0x09, 0x28, 0xd2, 0x04, 0x69, 0x87, 0x52, 0xfd, 0x94, 0x87, 0xdd, 0xf8, 0x16,
+	0x9e, 0xbf, 0x8b, 0x17, 0x98, 0x8c, 0xb9, 0x4e, 0x3d, 0xcd, 0x30, 0xdd, 0xc0, 0xc8, 0x28, 0xd5,
+	0x97, 0x7e, 0x37, 0x06, 0x49, 0xec, 0x80, 0x74, 0x40, 0x36, 0x2c, 0xc3, 0x33, 0x34, 0x53, 0x75,
+	0xa8, 0x6b, 0x9b, 0xcf, 0xa9, 0x2e, 0x2c, 0xf8, 0x42, 0x85, 0xc5, 0x05, 0x21, 0xac, 0x08, 0xd9,
+	0xe0, 0x49, 0x4d, 0xfc, 0xe2, 0x4f, 0x6a, 0xfe, 0x31, 0x06, 0xe4, 0xf8, 0xbb, 0x27, 0x52, 0x85,
+	0x82, 0xe7, 0x68, 0xc3, 0x3d, 0xaa, 0xab, 0x3c, 0x72, 0xe1, 0x7a, 0x3c, 0x07, 0x32, 0x2f, 0x64,
+	0x7a, 0x98, 0xf9, 0xbf, 0x25, 0x7d, 0x85, 0xc2, 0xf9, 0xc4, 0xe9, 0xe1, 0xfc, 0x9d, 0x5f, 0x87,
+	0x62, 0xf4, 0x4d, 0x03, 0x73, 0x54, 0x9b, 0x5b, 0xd5, 0x76, 0xab, 0x26, 0x5f, 0x22, 0xef, 0xc1,
+	0x3b, 0xfc, 0xb7, 0x5a, 0xe9, 0xd4, 0xf1, 0x7a, 0x42, 0x90, 0x62, 0x77, 0xca, 0x7e, 0x46, 0x8d,
+	0x4e, 0x6c, 0x11, 0xe4, 0x87, 0xed, 0xb6, 0xba, 0xd9, 0xde, 0xea, 0xf1, 0x3f, 0xdb, 0xf7, 0xe5,
+	0x4b, 0xd5, 0x0f, 0xbf, 0xfb, 0xcf, 0x6b, 0x97, 0xbe, 0x7b, 0x75, 0x2d, 0xf6, 0xcf, 0xaf, 0xae,
+	0xc5, 0xfe, 0xf5, 0xd5, 0xb5, 0xd8, 0x7f, 0xbc, 0xba, 0x16, 0xfb, 0x83, 0x5f, 0x5c, 0xbb, 0xf4,
+	0x6d, 0x36, 0xf8, 0xaf, 0x08, 0xff, 0x1f, 0x00, 0x00, 0xff, 0xff, 0x57, 0x3c, 0xa0, 0x19, 0x55,
+	0x31, 0x00, 0x00,
 }

--- a/pkg/sql/distsqlpb/processors.proto
+++ b/pkg/sql/distsqlpb/processors.proto
@@ -972,9 +972,10 @@ message WindowerSpec {
     message Bound {
       optional BoundType boundType = 1 [(gogoproto.nullable) = false];
       // For UNBOUNDED_PRECEDING, UNBOUNDED_FOLLOWING, and CURRENT_ROW offset
-      // is ignored. Integer offset for ROWS mode is stored in int_offset while
-      // an encoded datum and the type information are stored for RANGE mode.
-      optional uint32 int_offset = 2 [(gogoproto.nullable) = false];
+      // is ignored. Integer offset for ROWS and GROUPS modes is stored in
+      // int_offset while an encoded datum and the type information are stored
+      // for RANGE mode.
+      optional uint64 int_offset = 2 [(gogoproto.nullable) = false];
       optional bytes typed_offset = 3;
       optional DatumInfo offset_type = 4 [(gogoproto.nullable) = false];
     }


### PR DESCRIPTION
Previously, we stored integer offsets of window frame boundaries
as uint32 which could lead to incorrect behavior in some very
unlucky edge cases (e.g. rank() OVER (ROWS MaxInt32+1 PRECEDING)
or similar would overflow and be treated as something like
ROWS 0 PRECEDING - the correct behavior would be to include up to
about 2 billions of preceding rows while we would include only the
current one). Now, we use uint64, so such cases will be handled
correctly.

Note that uint32 and uint64 are compatible, so there is no need
to bump the DistSQL version.

Release note: None