### PR TITLE
builtins: add now() -> date implementation

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -285,6 +285,11 @@
 and which stays constant throughout the transaction. This timestamp
 has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
+<tr><td><code>current_timestamp() &rarr; <a href="date.html">date</a></code></td><td><span class="funcdesc"><p>Returns the time of the current transaction.</p>
+<p>The value is based on a timestamp picked when the transaction starts
+and which stays constant throughout the transaction. This timestamp
+has no relationship with the commit order of concurrent transactions.</p>
+</span></td></tr>
 <tr><td><code>current_timestamp() &rarr; <a href="timestamp.html">timestamp</a></code></td><td><span class="funcdesc"><p>Returns the time of the current transaction.</p>
 <p>The value is based on a timestamp picked when the transaction starts
 and which stays constant throughout the transaction. This timestamp
@@ -349,6 +354,11 @@ hour, minute, second, millisecond, microsecond, epoch</p>
 <tr><td><code>extract_duration(element: <a href="string.html">string</a>, input: <a href="interval.html">interval</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Extracts <code>element</code> from <code>input</code>.
 Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 </span></td></tr>
+<tr><td><code>now() &rarr; <a href="date.html">date</a></code></td><td><span class="funcdesc"><p>Returns the time of the current transaction.</p>
+<p>The value is based on a timestamp picked when the transaction starts
+and which stays constant throughout the transaction. This timestamp
+has no relationship with the commit order of concurrent transactions.</p>
+</span></td></tr>
 <tr><td><code>now() &rarr; <a href="timestamp.html">timestamp</a></code></td><td><span class="funcdesc"><p>Returns the time of the current transaction.</p>
 <p>The value is based on a timestamp picked when the transaction starts
 and which stays constant throughout the transaction. This timestamp
@@ -362,6 +372,11 @@ has no relationship with the commit order of concurrent transactions.</p>
 <tr><td><code>statement_timestamp() &rarr; <a href="timestamp.html">timestamp</a></code></td><td><span class="funcdesc"><p>Returns the start time of the current statement.</p>
 </span></td></tr>
 <tr><td><code>statement_timestamp() &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Returns the start time of the current statement.</p>
+</span></td></tr>
+<tr><td><code>transaction_timestamp() &rarr; <a href="date.html">date</a></code></td><td><span class="funcdesc"><p>Returns the time of the current transaction.</p>
+<p>The value is based on a timestamp picked when the transaction starts
+and which stays constant throughout the transaction. This timestamp
+has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><code>transaction_timestamp() &rarr; <a href="timestamp.html">timestamp</a></code></td><td><span class="funcdesc"><p>Returns the time of the current transaction.</p>
 <p>The value is based on a timestamp picked when the transaction starts

--- a/pkg/sql/logictest/testdata/logic_test/default
+++ b/pkg/sql/logictest/testdata/logic_test/default
@@ -25,7 +25,8 @@ statement ok
 CREATE TABLE t (
   a INT PRIMARY KEY DEFAULT 42,
   b TIMESTAMP DEFAULT now(),
-  c FLOAT DEFAULT random()
+  c FLOAT DEFAULT random(),
+  d DATE DEFAULT now()
 )
 
 query TTBTTTB colnames
@@ -35,14 +36,15 @@ column_name  data_type  is_nullable  column_default     generation_expression  i
 a            INT8       false        42:::INT8          ·                      {primary}  false
 b            TIMESTAMP  true         now():::TIMESTAMP  ·                      {}         false
 c            FLOAT8     true         random()           ·                      {}         false
+d            DATE       true         now():::DATE       ·                      {}         false
 
 statement ok
-INSERT INTO t VALUES (DEFAULT, DEFAULT, DEFAULT)
+INSERT INTO t VALUES (DEFAULT, DEFAULT, DEFAULT, DEFAULT)
 
-query IBB
-SELECT a, b <= now(), c >= 0.0 FROM t
+query IBBB
+SELECT a, b <= now(), c >= 0.0, d <= now() FROM t
 ----
-42 true true
+42 true true true
 
 statement ok
 TRUNCATE TABLE t
@@ -50,26 +52,26 @@ TRUNCATE TABLE t
 statement ok
 INSERT INTO t DEFAULT VALUES
 
-query IBB
-SELECT a, b <= now(), c >= 0.0 FROM t
+query IBBB
+SELECT a, b <= now(), c >= 0.0, d <= now() FROM t
 ----
-42 true true
+42 true true true
 
 statement ok
 INSERT INTO t (a) VALUES (1)
 
-query IBB
-SELECT a, b <= now(), c >= 0.0 FROM t WHERE a = 1
+query IBBB
+SELECT a, b <= now(), c >= 0.0, d <= now() FROM t WHERE a = 1
 ----
-1 true true
+1 true true true
 
 statement ok
 INSERT INTO t VALUES (2)
 
-query IBB
-SELECT a, b <= now(), c >= 0.0 FROM t WHERE a = 2
+query IBBB
+SELECT a, b <= now(), c >= 0.0, d <= now() FROM t WHERE a = 2
 ----
-2 true true
+2 true true true
 
 statement ok
 UPDATE t SET (b, c) = ('2015-09-18 00:00:00', -1.0)
@@ -77,24 +79,24 @@ UPDATE t SET (b, c) = ('2015-09-18 00:00:00', -1.0)
 statement ok
 UPDATE t SET b = DEFAULT WHERE a = 1
 
-query IBB
-SELECT a, b <= now(), c = -1.0 FROM t WHERE a = 1
+query IBBB
+SELECT a, b <= now(), c = -1.0, d <= now() FROM t WHERE a = 1
 ----
-1 true true
+1 true true true
 
 statement ok
 UPDATE t SET (b, c) = (DEFAULT, DEFAULT) WHERE a = 2
 
-query IBB
-SELECT a, b <= now(), c >= 0.0 FROM t WHERE a = 2
+query IBBB
+SELECT a, b <= now(), c >= 0.0, d <= now() FROM t WHERE a = 2
 ----
-2 true true
+2 true true true
 
 statement ok
-UPDATE t SET b = DEFAULT, c = DEFAULT
+UPDATE t SET b = DEFAULT, c = DEFAULT, d = DEFAULT
 
 statement ok
-UPDATE t SET (b) = (DEFAULT), (c) = (DEFAULT)
+UPDATE t SET (b) = (DEFAULT), (c) = (DEFAULT), (d) = (DEFAULT)
 
 # Test a table without a default and with a null default
 statement ok

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3211,6 +3211,14 @@ var txnTSImpl = makeBuiltin(
 		},
 		Info: txnTSDoc,
 	},
+	tree.Overload{
+		Types:      tree.ArgTypes{},
+		ReturnType: tree.FixedReturnType(types.Date),
+		Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+			return tree.NewDDateFromTime(ctx.GetTxnTimestampNoZone(time.Microsecond).Time, time.UTC), nil
+		},
+		Info: txnTSDoc,
+	},
 )
 
 var powImpls = makeBuiltin(defProps(),


### PR DESCRIPTION
Resolving a small irritation for date columns that want a default value
of now.

Closes #20402

Release note (sql change): add an overload for now() that returns a
date.