### PR TITLE
sql: fix obj_description; support shobj_description

### DIFF
--- a/pkg/sql/comment_on_database_test.go
+++ b/pkg/sql/comment_on_database_test.go
@@ -44,17 +44,17 @@ func TestCommentOnDatabase(t *testing.T) {
 	}{
 		{
 			`COMMENT ON DATABASE d IS 'foo'`,
-			`SELECT obj_description(oid) FROM pg_database WHERE datname = 'd'`,
+			`SELECT shobj_description(oid, 'pg_database') FROM pg_database WHERE datname = 'd'`,
 			gosql.NullString{String: `foo`, Valid: true},
 		},
 		{
 			`ALTER DATABASE d RENAME TO d2`,
-			`SELECT obj_description(oid) FROM pg_database WHERE datname = 'd2'`,
+			`SELECT shobj_description(oid, 'pg_database') FROM pg_database WHERE datname = 'd2'`,
 			gosql.NullString{String: `foo`, Valid: true},
 		},
 		{
 			`COMMENT ON DATABASE d2 IS NULL`,
-			`SELECT obj_description(oid) FROM pg_database WHERE datname = 'd2'`,
+			`SELECT shobj_description(oid, 'pg_database') FROM pg_database WHERE datname = 'd2'`,
 			gosql.NullString{Valid: false},
 		},
 	}

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1982,7 +1982,7 @@ NULL  NULL
 # vtable comments are supported
 query TT
 SELECT regexp_replace(obj_description('pg_class'::regclass::oid), e' .*', '') AS comment1,
-       regexp_replace(obj_description('pg_class'::regclass::oid, 'test'), e' .*', '') AS comment2
+       regexp_replace(obj_description('pg_class'::regclass::oid, 'pg_class'), e' .*', '') AS comment2
 ----
 tables tables
 
@@ -1996,12 +1996,32 @@ COMMENT ON TABLE t IS 'waa'
 statement ok
 COMMENT ON COLUMN t.x IS 'woo'
 
-query TTT
+query TTTT
 SELECT obj_description('t'::regclass::oid),
-       obj_description('t'::regclass::oid, 'test'),
+       obj_description('t'::regclass::oid, 'pg_class'),
+       obj_description('t'::regclass::oid, 'notexist'),
        col_description('t'::regclass, 1)
 ----
-waa  waa  woo
+waa  waa  NULL  woo
+
+statement ok
+COMMENT ON DATABASE test is 'foo'
+
+query TTTT
+SELECT shobj_description((select oid from pg_database where datname = 'defaultdb')::oid, 'pg_database'),
+       shobj_description((select oid from pg_database where datname = 'test')::oid, 'pg_database'),
+       shobj_description((select oid from pg_database where datname = 'notexist')::oid, 'pg_database'),
+       shobj_description((select oid from pg_database where datname = 'test')::oid, 'notexist')
+----
+NULL foo NULL NULL
+
+# Ensure that shobj_ and obj_description don't return the opposite type of
+# comments.
+query TT
+SELECT shobj_description('t'::regclass::oid, 'pg_class'),
+       obj_description((select oid from pg_database where datname = 'test')::oid, 'pg_database')
+----
+NULL NULL
 
 # Check that base function names are also visible in namespace pg_catalog.
 query I

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1323,98 +1323,98 @@ query OOIT colnames
 SELECT objoid, classoid, objsubid, regexp_replace(description, e'\n.*', '') AS description
   FROM pg_catalog.pg_description
 ----
-objoid      classoid  objsubid  description
-4294967294  0         0         backward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
-4294967292  0         0         built-in functions (RAM/static)
-4294967291  0         0         running queries visible by current user (cluster RPC; expensive!)
-4294967290  0         0         running sessions visible to current user (cluster RPC; expensive!)
-4294967289  0         0         cluster settings (RAM)
-4294967288  0         0         CREATE and ALTER statements for all tables accessible by current user in current database (KV scan)
-4294967287  0         0         telemetry counters (RAM; local node only)
-4294967286  0         0         forward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
-4294967284  0         0         locally known gossiped health alerts (RAM; local node only)
-4294967283  0         0         locally known gossiped node liveness (RAM; local node only)
-4294967282  0         0         locally known edges in the gossip network (RAM; local node only)
-4294967285  0         0         locally known gossiped node details (RAM; local node only)
-4294967281  0         0         index columns for all indexes accessible by current user in current database (KV scan)
-4294967280  0         0         decoded job metadata from system.jobs (KV scan)
-4294967279  0         0         node details across the entire cluster (cluster RPC; expensive!)
-4294967278  0         0         store details and status (cluster RPC; expensive!)
-4294967277  0         0         acquired table leases (RAM; local node only)
-4294967293  0         0         detailed identification strings (RAM, local node only)
-4294967274  0         0         current values for metrics (RAM; local node only)
-4294967276  0         0         running queries visible by current user (RAM; local node only)
-4294967269  0         0         server parameters, useful to construct connection URLs (RAM, local node only)
-4294967275  0         0         running sessions visible by current user (RAM; local node only)
-4294967265  0         0         statement statistics (RAM; local node only)
-4294967273  0         0         defined partitions for all tables/indexes accessible by the current user in the current database (KV scan)
-4294967272  0         0         comments for predefined virtual tables (RAM/static)
-4294967271  0         0         range metadata without leaseholder details (KV join; expensive!)
-4294967268  0         0         ongoing schema changes, across all descriptors accessible by current user (KV scan; expensive!)
-4294967267  0         0         session trace accumulated so far (RAM)
-4294967266  0         0         session variables (RAM)
-4294967264  0         0         details for all columns accessible by current user in current database (KV scan)
-4294967263  0         0         indexes accessible by current user in current database (KV scan)
-4294967262  0         0         table descriptors accessible by current user, including non-public and virtual (KV scan; expensive!)
-4294967261  0         0         decoded zone configurations from system.zones (KV scan)
-4294967259  0         0         roles for which the current user has admin option
-4294967258  0         0         roles available to the current user
-4294967257  0         0         column privilege grants (incomplete)
-4294967256  0         0         table and view columns (incomplete)
-4294967255  0         0         columns usage by constraints
-4294967254  0         0         roles for the current user
-4294967253  0         0         column usage by indexes and key constraints
-4294967252  0         0         built-in function parameters (empty - introspection not yet supported)
-4294967251  0         0         foreign key constraints
-4294967250  0         0         privileges granted on table or views (incomplete; see also information_schema.table_privileges; may contain excess users or roles)
-4294967249  0         0         built-in functions (empty - introspection not yet supported)
-4294967247  0         0         schema privileges (incomplete; may contain excess users or roles)
-4294967248  0         0         database schemas (may contain schemata without permission)
-4294967246  0         0         sequences
-4294967245  0         0         index metadata and statistics (incomplete)
-4294967244  0         0         table constraints
-4294967243  0         0         privileges granted on table or views (incomplete; may contain excess users or roles)
-4294967242  0         0         tables and views
-4294967240  0         0         grantable privileges (incomplete)
-4294967241  0         0         views (incomplete)
-4294967238  0         0         index access methods (incomplete)
-4294967237  0         0         column default values
-4294967236  0         0         table columns (incomplete - see also information_schema.columns)
-4294967235  0         0         role membership
-4294967234  0         0         tables and relation-like objects (incomplete - see also information_schema.tables/sequences/views)
-4294967233  0         0         available collations (incomplete)
-4294967232  0         0         table constraints (incomplete - see also information_schema.table_constraints)
-4294967231  0         0         available databases (incomplete)
-4294967230  0         0         dependency relationships (incomplete)
-4294967229  0         0         object comments
-4294967227  0         0         enum types and labels (empty - feature does not exist)
-4294967226  0         0         installed extensions (empty - feature does not exist)
-4294967225  0         0         foreign data wrappers (empty - feature does not exist)
-4294967224  0         0         foreign servers (empty - feature does not exist)
-4294967223  0         0         foreign tables (empty  - feature does not exist)
-4294967222  0         0         indexes (incomplete)
-4294967221  0         0         index creation statements
-4294967220  0         0         table inheritance hierarchy (empty - feature does not exist)
-4294967219  0         0         available languages (empty - feature does not exist)
-4294967218  0         0         available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
-4294967217  0         0         operators (incomplete)
-4294967216  0         0         built-in functions (incomplete)
-4294967215  0         0         range types (empty - feature does not exist)
-4294967214  0         0         rewrite rules (empty - feature does not exist)
-4294967213  0         0         database roles
-4294967202  0         0         security labels (empty - feature does not exist)
-4294967212  0         0         sequences (see also information_schema.sequences)
-4294967211  0         0         session variables (incomplete)
-4294967228  0         0         shared object comments (empty - feature does not exist)
-4294967201  0         0         shared security labels (empty - feature not supported)
-4294967203  0         0         backend access statistics (empty - monitoring works differently in CockroachDB)
-4294967208  0         0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
-4294967207  0         0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
-4294967206  0         0         triggers (empty - feature does not exist)
-4294967205  0         0         scalar types (incomplete)
-4294967210  0         0         database users
-4294967209  0         0         local to remote user mapping (empty - feature does not exist)
-4294967204  0         0         view definitions (incomplete - see also information_schema.views)
+objoid      classoid    objsubid  description
+4294967294  4294967234  0         backward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
+4294967292  4294967234  0         built-in functions (RAM/static)
+4294967291  4294967234  0         running queries visible by current user (cluster RPC; expensive!)
+4294967290  4294967234  0         running sessions visible to current user (cluster RPC; expensive!)
+4294967289  4294967234  0         cluster settings (RAM)
+4294967288  4294967234  0         CREATE and ALTER statements for all tables accessible by current user in current database (KV scan)
+4294967287  4294967234  0         telemetry counters (RAM; local node only)
+4294967286  4294967234  0         forward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
+4294967284  4294967234  0         locally known gossiped health alerts (RAM; local node only)
+4294967283  4294967234  0         locally known gossiped node liveness (RAM; local node only)
+4294967282  4294967234  0         locally known edges in the gossip network (RAM; local node only)
+4294967285  4294967234  0         locally known gossiped node details (RAM; local node only)
+4294967281  4294967234  0         index columns for all indexes accessible by current user in current database (KV scan)
+4294967280  4294967234  0         decoded job metadata from system.jobs (KV scan)
+4294967279  4294967234  0         node details across the entire cluster (cluster RPC; expensive!)
+4294967278  4294967234  0         store details and status (cluster RPC; expensive!)
+4294967277  4294967234  0         acquired table leases (RAM; local node only)
+4294967293  4294967234  0         detailed identification strings (RAM, local node only)
+4294967274  4294967234  0         current values for metrics (RAM; local node only)
+4294967276  4294967234  0         running queries visible by current user (RAM; local node only)
+4294967269  4294967234  0         server parameters, useful to construct connection URLs (RAM, local node only)
+4294967275  4294967234  0         running sessions visible by current user (RAM; local node only)
+4294967265  4294967234  0         statement statistics (RAM; local node only)
+4294967273  4294967234  0         defined partitions for all tables/indexes accessible by the current user in the current database (KV scan)
+4294967272  4294967234  0         comments for predefined virtual tables (RAM/static)
+4294967271  4294967234  0         range metadata without leaseholder details (KV join; expensive!)
+4294967268  4294967234  0         ongoing schema changes, across all descriptors accessible by current user (KV scan; expensive!)
+4294967267  4294967234  0         session trace accumulated so far (RAM)
+4294967266  4294967234  0         session variables (RAM)
+4294967264  4294967234  0         details for all columns accessible by current user in current database (KV scan)
+4294967263  4294967234  0         indexes accessible by current user in current database (KV scan)
+4294967262  4294967234  0         table descriptors accessible by current user, including non-public and virtual (KV scan; expensive!)
+4294967261  4294967234  0         decoded zone configurations from system.zones (KV scan)
+4294967259  4294967234  0         roles for which the current user has admin option
+4294967258  4294967234  0         roles available to the current user
+4294967257  4294967234  0         column privilege grants (incomplete)
+4294967256  4294967234  0         table and view columns (incomplete)
+4294967255  4294967234  0         columns usage by constraints
+4294967254  4294967234  0         roles for the current user
+4294967253  4294967234  0         column usage by indexes and key constraints
+4294967252  4294967234  0         built-in function parameters (empty - introspection not yet supported)
+4294967251  4294967234  0         foreign key constraints
+4294967250  4294967234  0         privileges granted on table or views (incomplete; see also information_schema.table_privileges; may contain excess users or roles)
+4294967249  4294967234  0         built-in functions (empty - introspection not yet supported)
+4294967247  4294967234  0         schema privileges (incomplete; may contain excess users or roles)
+4294967248  4294967234  0         database schemas (may contain schemata without permission)
+4294967246  4294967234  0         sequences
+4294967245  4294967234  0         index metadata and statistics (incomplete)
+4294967244  4294967234  0         table constraints
+4294967243  4294967234  0         privileges granted on table or views (incomplete; may contain excess users or roles)
+4294967242  4294967234  0         tables and views
+4294967240  4294967234  0         grantable privileges (incomplete)
+4294967241  4294967234  0         views (incomplete)
+4294967238  4294967234  0         index access methods (incomplete)
+4294967237  4294967234  0         column default values
+4294967236  4294967234  0         table columns (incomplete - see also information_schema.columns)
+4294967235  4294967234  0         role membership
+4294967234  4294967234  0         tables and relation-like objects (incomplete - see also information_schema.tables/sequences/views)
+4294967233  4294967234  0         available collations (incomplete)
+4294967232  4294967234  0         table constraints (incomplete - see also information_schema.table_constraints)
+4294967231  4294967234  0         available databases (incomplete)
+4294967230  4294967234  0         dependency relationships (incomplete)
+4294967229  4294967234  0         object comments
+4294967227  4294967234  0         enum types and labels (empty - feature does not exist)
+4294967226  4294967234  0         installed extensions (empty - feature does not exist)
+4294967225  4294967234  0         foreign data wrappers (empty - feature does not exist)
+4294967224  4294967234  0         foreign servers (empty - feature does not exist)
+4294967223  4294967234  0         foreign tables (empty  - feature does not exist)
+4294967222  4294967234  0         indexes (incomplete)
+4294967221  4294967234  0         index creation statements
+4294967220  4294967234  0         table inheritance hierarchy (empty - feature does not exist)
+4294967219  4294967234  0         available languages (empty - feature does not exist)
+4294967218  4294967234  0         available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
+4294967217  4294967234  0         operators (incomplete)
+4294967216  4294967234  0         built-in functions (incomplete)
+4294967215  4294967234  0         range types (empty - feature does not exist)
+4294967214  4294967234  0         rewrite rules (empty - feature does not exist)
+4294967213  4294967234  0         database roles
+4294967202  4294967234  0         security labels (empty - feature does not exist)
+4294967212  4294967234  0         sequences (see also information_schema.sequences)
+4294967211  4294967234  0         session variables (incomplete)
+4294967228  4294967234  0         shared object comments
+4294967201  4294967234  0         shared security labels (empty - feature not supported)
+4294967203  4294967234  0         backend access statistics (empty - monitoring works differently in CockroachDB)
+4294967208  4294967234  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
+4294967207  4294967234  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
+4294967206  4294967234  0         triggers (empty - feature does not exist)
+4294967205  4294967234  0         scalar types (incomplete)
+4294967210  4294967234  0         database users
+4294967209  4294967234  0         local to remote user mapping (empty - feature does not exist)
+4294967204  4294967234  0         view definitions (incomplete - see also information_schema.views)
 
 ## pg_catalog.pg_shdescription
 


### PR DESCRIPTION
Previously, the pg obj_description builtin was buggy and assumed that
"catalog_name" meant the database name, when in fact it's supposed to
mean the name of the "system catalog" (e.g. pg_class, pg_type) since
oids aren't global and are in fact namespaced by their "catalog". This
led to invalid queries getting generated in some cases.

Closes #37266.

Release note (bug fix): fix obj_description