### PR TITLE
sql/row: avoid various allocations during mutations

### DIFF
--- a/pkg/sql/row/deleter.go
+++ b/pkg/sql/row/deleter.go
@@ -144,7 +144,8 @@ func (rd *Deleter) DeleteRow(
 	}
 
 	// Delete the row from any secondary indices.
-	for i, secondaryIndexEntry := range secondaryIndexEntries {
+	for i := range secondaryIndexEntries {
+		secondaryIndexEntry := &secondaryIndexEntries[i]
 		if traceKV {
 			log.VEventf(ctx, 2, "Del %s", keys.PrettyPrint(rd.Helper.secIndexValDirs[i], secondaryIndexEntry.Key))
 		}

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -651,12 +651,14 @@ func (rf *Fetcher) NextKey(ctx context.Context) (rowDone bool, err error) {
 }
 
 func (rf *Fetcher) prettyEncDatums(types []types.T, vals []sqlbase.EncDatum) string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	for i, v := range vals {
 		if err := v.EnsureDecoded(&types[i], rf.alloc); err != nil {
-			fmt.Fprintf(&buf, "error decoding: %v", err)
+			buf.WriteString("error decoding: ")
+			buf.WriteString(err.Error())
 		}
-		fmt.Fprintf(&buf, "/%v", v.Datum)
+		buf.WriteByte('/')
+		buf.WriteString(v.Datum.String())
 	}
 	return buf.String()
 }

--- a/pkg/sql/row/fk_existence_batch.go
+++ b/pkg/sql/row/fk_existence_batch.go
@@ -57,15 +57,14 @@ func (f *fkExistenceBatchChecker) addCheck(
 	if err != nil {
 		return err
 	}
-	r := roachpb.RequestUnion{}
 	scan := roachpb.ScanRequest{
 		RequestHeader: roachpb.RequestHeaderFromSpan(span),
 	}
 	if traceKV {
 		log.VEventf(ctx, 2, "FKScan %s", span)
 	}
-	r.MustSetInner(&scan)
-	f.batch.Requests = append(f.batch.Requests, r)
+	f.batch.Requests = append(f.batch.Requests, roachpb.RequestUnion{})
+	f.batch.Requests[len(f.batch.Requests)-1].MustSetInner(&scan)
 	f.batchIdxToFk = append(f.batchIdxToFk, source)
 	return nil
 }

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -410,15 +410,15 @@ func (ru *Updater) UpdateRow(
 	// and newSecondaryIndexEntries. Inverted indexes could potentially have more entries at the end of both and we will
 	// update those separately.
 	for i, index := range ru.Helper.Indexes {
-		oldSecondaryIndexEntry := oldSecondaryIndexEntries[i]
-		newSecondaryIndexEntry := newSecondaryIndexEntries[i]
+		oldSecondaryIndexEntry := &oldSecondaryIndexEntries[i]
+		newSecondaryIndexEntry := &newSecondaryIndexEntries[i]
 
 		// We're skipping inverted indexes in this loop, but appending the inverted index entry to the back of
 		// newSecondaryIndexEntries to process later. For inverted indexes we need to remove all old entries before adding
 		// new ones.
 		if index.Type == sqlbase.IndexDescriptor_INVERTED {
-			newSecondaryIndexEntries = append(newSecondaryIndexEntries, newSecondaryIndexEntry)
-			oldSecondaryIndexEntries = append(oldSecondaryIndexEntries, oldSecondaryIndexEntry)
+			newSecondaryIndexEntries = append(newSecondaryIndexEntries, *newSecondaryIndexEntry)
+			oldSecondaryIndexEntries = append(oldSecondaryIndexEntries, *oldSecondaryIndexEntry)
 
 			continue
 		}


### PR DESCRIPTION
This PR fell out of some poking around in #37059. It removes a number of
allocations throughout the `sql/row` package. All were found using `goescape`.