### PR TITLE
sql/sqlbase: avoid various allocations during name resolution

### DIFF
--- a/pkg/sql/sqlbase/column_resolver.go
+++ b/pkg/sql/sqlbase/column_resolver.go
@@ -71,19 +71,16 @@ func (r *ColumnResolver) FindSourceMatchingName(
 	srcMeta tree.ColumnSourceMeta,
 	err error,
 ) {
-	// log.VEventf(ctx, 2, "FindSourceMatchingName(%s) w/\n%s", tn, r.Sources.String())
-	// defer func() {
-	// 	log.VEventf(ctx, 2, "FindSourceMachingName(%s) -> %v %v %v %v",
-	// 		&tn, res, prefix, srcMeta, err)
-	// }()
 	found := false
 	for srcIdx, src := range r.Sources {
-		for colSetIdx, alias := range src.SourceAliases {
+		for colSetIdx := range src.SourceAliases {
+			alias := &src.SourceAliases[colSetIdx]
 			if !sourceNameMatches(&alias.Name, tn) {
 				continue
 			}
 			if found {
-				return tree.MoreThanOne, nil, nil, newAmbiguousSourceError(&tn)
+				tnAlloc := tn
+				return tree.MoreThanOne, nil, nil, newAmbiguousSourceError(&tnAlloc)
 			}
 			found = true
 			prefix = &alias.Name

--- a/pkg/sql/sqlbase/column_resolver.go
+++ b/pkg/sql/sqlbase/column_resolver.go
@@ -101,11 +101,6 @@ const invalidSrcIdx = -1
 func (r *ColumnResolver) FindSourceProvidingColumn(
 	ctx context.Context, col tree.Name,
 ) (prefix *tree.TableName, srcMeta tree.ColumnSourceMeta, colHint int, err error) {
-	// log.VEventf(ctx, 2, "FindSourceProvidingColumn(%s) w/\n%s", col, r.Sources.String())
-	// defer func() {
-	// 	log.VEventf(ctx, 2, "FindSourceProvidingColumn(%s) -> %q %v %v %v",
-	// 		col, prefix, srcMeta, colHint, err)
-	// }()
 	colIdx := invalidColIdx
 	srcIdx := 0
 	colName := string(col)
@@ -147,7 +142,8 @@ func (r *ColumnResolver) FindSourceProvidingColumn(
 		}
 	}
 	if colIdx == invalidColIdx {
-		return nil, nil, -1, NewUndefinedColumnError(tree.ErrString(&col))
+		colAlloc := col
+		return nil, nil, -1, NewUndefinedColumnError(tree.ErrString(&colAlloc))
 	}
 	r.ResolverState.SrcIdx = srcIdx
 	r.ResolverState.ColIdx = colIdx

--- a/pkg/sql/sqlbase/data_source.go
+++ b/pkg/sql/sqlbase/data_source.go
@@ -160,12 +160,13 @@ func (src *DataSourceInfo) String() string {
 		buf.WriteString(c.Name)
 	}
 	buf.WriteString("\toutput column names\n")
-	for _, a := range src.SourceAliases {
-		for i := range src.SourceColumns {
-			if i > 0 {
+	for i := range src.SourceAliases {
+		a := &src.SourceAliases[i]
+		for j := range src.SourceColumns {
+			if j > 0 {
 				buf.WriteByte('\t')
 			}
-			if a.ColumnSet.Contains(i) {
+			if a.ColumnSet.Contains(j) {
 				buf.WriteString("x")
 			}
 		}

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -15,7 +15,6 @@
 package sqlbase
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"sort"
@@ -629,7 +628,7 @@ func (desc *TableDescriptor) ForeachNonDropIndex(f func(*IndexDescriptor) error)
 }
 
 func generatedFamilyName(familyID FamilyID, columnNames []string) string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	fmt.Fprintf(&buf, "fam_%d", familyID)
 	for _, n := range columnNames {
 		buf.WriteString(`_`)
@@ -1750,7 +1749,7 @@ func notIndexableError(cols []ColumnDescriptor, inverted bool) error {
 	var msg string
 	var typInfo string
 	if len(cols) == 1 {
-		col := cols[0]
+		col := &cols[0]
 		msg = "column %s is of type %s and thus is not indexable"
 		if inverted {
 			msg += " with an inverted index"
@@ -1759,7 +1758,8 @@ func notIndexableError(cols []ColumnDescriptor, inverted bool) error {
 		msg = fmt.Sprintf(msg, col.Name, col.Type.Name())
 	} else {
 		msg = "the following columns are not indexable due to their type: "
-		for i, col := range cols {
+		for i := range cols {
+			col := &cols[i]
 			msg += fmt.Sprintf("%s (type %s)", col.Name, col.Type.Name())
 			typInfo += col.Type.DebugString()
 			if i != len(cols)-1 {


### PR DESCRIPTION
This PR fell out of some poking around in #37059. It removes a number of
allocations throughout the `sql/sqlbase` package. All were found using `goescape`.