### PR TITLE
exec: handle nulls in selection operators

### DIFF
--- a/pkg/sql/exec/coldata/nulls_test.go
+++ b/pkg/sql/exec/coldata/nulls_test.go
@@ -1,0 +1,45 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package coldata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNullsOr(t *testing.T) {
+	length1, length2 := uint16(300), uint16(400)
+	n1, n2 := NewNulls(int(length1)), NewNulls(int(length2))
+	for i := uint16(0); i < length1; i++ {
+		if i%3 == 0 {
+			n1.SetNull(i)
+		}
+	}
+	for i := uint16(0); i < length2; i++ {
+		if i%5 == 0 {
+			n2.SetNull(i)
+		}
+	}
+	or := n1.Or(&n2)
+	require.True(t, or.hasNulls)
+	for i := uint16(0); i < length2; i++ {
+		if i < length1 && n1.NullAt(i) || i < length2 && n2.NullAt(i) {
+			require.True(t, or.NullAt(i), "or.NullAt(%d) should be true", i)
+		} else {
+			require.False(t, or.NullAt(i), "or.NullAt(%d) should be false", i)
+		}
+	}
+}

--- a/pkg/sql/exec/execgen/cmd/execgen/like_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/like_ops_gen.go
@@ -43,7 +43,7 @@ import (
 `
 
 func genLikeOps(wr io.Writer) error {
-	tmpl := template.New("like_ops")
+	tmpl := template.New("like_ops").Funcs(template.FuncMap{"buildDict": buildDict})
 	var err error
 	tmpl, err = tmpl.Parse(selTemplate)
 	if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -13,6 +13,12 @@ INSERT INTO a SELECT g//2, g FROM generate_series(0,2000) g(g)
 statement ok
 CREATE TABLE bools (b BOOL, i INT, PRIMARY KEY (b, i)); INSERT INTO bools VALUES (true, 0), (false, 1), (true, 2), (false, 3);
 
+statement ok
+CREATE TABLE nulls (a INT, b INT)
+
+statement ok
+INSERT INTO nulls VALUES (NULL, NULL), (NULL, 1), (1, NULL), (1, 1)
+
 query I
 SELECT count(*) FROM a
 ----
@@ -58,6 +64,19 @@ SELECT b FROM a WHERE b < 3
 0
 1
 2
+
+# Simple filter with nulls.
+query I
+SELECT a FROM nulls WHERE a < 2
+----
+1
+1
+
+query II
+SELECT a, b FROM nulls WHERE a <= b
+----
+1 1
+
 
 # Filter on the result of a projection.
 query II


### PR DESCRIPTION
Our selection operators now properly handle null values. This required a
bit of extra templating. I also added a Nulls.Or implementation which
does a bitwise or between two null bitmaps, which is convenient (and
efficient) for combining two columns with nulls.

Note that the implementation actually performs the selection before
doing the null check. This is because I'm assuming that in general it's
more likely that a value will be selected out due to the comparison than
due to being null. This would not be true for queries with lots of nulls
or a very permissive selection, but that seems like a minority of cases.

I also updated the selection benchmarks to remove most of the
randomness, which was contributing to unpredictable benchmarks. For
instance, a very low constant value in the selLTInt64Int64ConstOp
benchmark would cause significantly faster results than a very high one.

Benchmarks:
```
BenchmarkSelLTInt64Int64ConstOp/useSel=true,hasNulls=true-4         	 1000000	      1256 ns/op	6517.93 MB/s
BenchmarkSelLTInt64Int64ConstOp/useSel=true,hasNulls=false-4        	 2000000	       725 ns/op	11295.46 MB/s
BenchmarkSelLTInt64Int64ConstOp/useSel=false,hasNulls=true-4        	 1000000	      1243 ns/op	6588.45 MB/s
BenchmarkSelLTInt64Int64ConstOp/useSel=false,hasNulls=false-4       	 3000000	       491 ns/op	16663.51 MB/s
BenchmarkSelLTInt64Int64Op/useSel=true,hasNulls=true-4              	 1000000	      1603 ns/op	10216.66 MB/s
BenchmarkSelLTInt64Int64Op/useSel=true,hasNulls=false-4             	 2000000	       725 ns/op	22579.94 MB/s
BenchmarkSelLTInt64Int64Op/useSel=false,hasNulls=true-4             	 1000000	      1382 ns/op	11854.27 MB/s
BenchmarkSelLTInt64Int64Op/useSel=false,hasNulls=false-4            	 3000000	       542 ns/op	30181.99 MB/s
```

Refers #36931

Release note: None