### PR TITLE
release-19.1: bulkingest: fix string-vs-bytes col in generator

### DIFF
--- a/pkg/ccl/importccl/read_import_workload.go
+++ b/pkg/ccl/importccl/read_import_workload.go
@@ -72,6 +72,8 @@ func makeDatumFromRaw(
 		case types.Timestamp:
 			return tree.MakeDTimestamp(t, time.Microsecond), nil
 		}
+	case tree.DString:
+		return alloc.NewDString(t), nil
 	case string:
 		return tree.ParseDatumStringAs(hint, t, evalCtx)
 	}

--- a/pkg/workload/bulkingest/bulkingest.go
+++ b/pkg/workload/bulkingest/bulkingest.go
@@ -56,6 +56,7 @@ import (
 	"math/rand"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
@@ -150,7 +151,7 @@ func (w *bulkingest) Tables() []workload.Table {
 				randutil.ReadTestdataBytes(rng, payload)
 				for c := 0; c < w.cCount; c++ {
 					off := c * w.payloadBytes
-					batch[c] = []interface{}{a, b, c, payload[off : off+w.payloadBytes]}
+					batch[c] = []interface{}{a, b, c, tree.DString(payload[off : off+w.payloadBytes])}
 				}
 				return batch
 			},


### PR DESCRIPTION
Backport 1/1 commits from #36264.

/cc @cockroachdb/release

---

Release note: None
