### PR TITLE
release-19.1: raftentry: deflake TestConcurrentUpdates

### DIFF
--- a/pkg/storage/raftentry/metrics.go
+++ b/pkg/storage/raftentry/metrics.go
@@ -45,6 +45,8 @@ var (
 
 // Metrics is the set of metrics for the raft entry cache.
 type Metrics struct {
+	// NB: the values in the gauges are updated asynchronously and may hold stale
+	// values in the face of concurrent updates.
 	Size     *metric.Gauge
 	Bytes    *metric.Gauge
 	Accesses *metric.Counter


### PR DESCRIPTION
Backport 1/1 commits from #37165.

Fixes #37288.

/cc @cockroachdb/release

---

I spent way too long looking at this concerned that it was a correctness
bug before I remembered that the gauges are updated with a snapshot of the
cache state but the writes are not totally ordered and thus can become out of sync
in the face of concurrent updates. Later updates will update to later values. This
isn't a correctness problem, just an artifact of the design of the metrics which the
test relied on. This PR adds logic to sync the gauges before verifying their state
which deflakes the test when run under stress.

Fixes #37111.

Release note: None
