### PR TITLE
pgwire: return right-sized int and float types

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1050,15 +1050,16 @@
   revision = "634a59d12406abc51545000deab7cf43ebc32378"
 
 [[projects]]
-  digest = "1:8ef506fc2bb9ced9b151dafa592d4046063d744c646c1bbe801982ce87e4bc24"
+  digest = "1:bdd53b87de8185da386bae179c84d4848854c6870bacacf6a154fe63e2e750f7"
   name = "github.com/lib/pq"
   packages = [
     ".",
     "oid",
+    "scram",
   ]
   pruneopts = "UT"
-  revision = "4ded0e9383f75c197b3a2aaa6d590ac52df6fd79"
-  version = "v1.0.0"
+  revision = "bc6a3c0594130b1e34005880bc600b6d3f49fa7f"
+  version = "v1.1.1"
 
 [[projects]]
   digest = "1:078d0b47a888546a9f8810d64f76792f70b2fa564ad2bbe6dddd002c032ce7cf"

--- a/pkg/acceptance/testdata/java/src/main/java/MainTest.java
+++ b/pkg/acceptance/testdata/java/src/main/java/MainTest.java
@@ -133,6 +133,40 @@ public class MainTest extends CockroachDBTest {
     }
 
     @Test
+    public void testIntTypes() throws Exception {
+        PreparedStatement stmt = conn.prepareStatement("CREATE TABLE x (a SMALLINT, b INT4, c INT, d BIGINT)");
+        stmt.execute();
+        stmt = conn.prepareStatement("INSERT INTO x VALUES (1, 1, 1, 1)");
+        stmt.execute();
+        stmt = conn.prepareStatement("SELECT a, b, c, d FROM x");
+        ResultSet rs = stmt.executeQuery();
+        rs.next();
+        Short s = rs.getShort(1);
+        Assert.assertEquals(1, (short)s);
+        Integer i = rs.getInt(2);
+        Assert.assertEquals(1, (int)i);
+        Long l = rs.getLong(3);
+        Assert.assertEquals(1L, (long)l);
+        l = rs.getLong(4);
+        Assert.assertEquals(1L, (long)l);
+    }
+
+    @Test
+    public void testFloatTypes() throws Exception {
+        PreparedStatement stmt = conn.prepareStatement("CREATE TABLE x (a FLOAT4, b FLOAT8)");
+        stmt.execute();
+        stmt = conn.prepareStatement("INSERT INTO x VALUES (1.2, 1.2)");
+        stmt.execute();
+        stmt = conn.prepareStatement("SELECT a, b FROM x");
+        ResultSet rs = stmt.executeQuery();
+        rs.next();
+        Float f = rs.getFloat(1);
+        Assert.assertEquals((float)1.2, (float)f, 0.0001);
+        Double d = rs.getDouble(2);
+        Assert.assertEquals(1.2, (double)d, 0.0001);
+    }
+
+    @Test
     public void testTime() throws Exception {
         PreparedStatement stmt = conn.prepareStatement("SELECT '01:02:03.456'::TIME");
         ResultSet rs = stmt.executeQuery();
@@ -165,17 +199,23 @@ public class MainTest extends CockroachDBTest {
 
     @Test
     public void testArrayWithProps() throws Exception {
-        PreparedStatement stmt = conn.prepareStatement("CREATE TABLE x (a SMALLINT[])");
+        PreparedStatement stmt = conn.prepareStatement("CREATE TABLE x (a SMALLINT[], b INT4[], c BIGINT[])");
         stmt.execute();
-        stmt = conn.prepareStatement("INSERT INTO x VALUES (ARRAY[123])");
+        stmt = conn.prepareStatement("INSERT INTO x VALUES (ARRAY[123], ARRAY[123], ARRAY[123])");
         stmt.execute();
-        stmt = conn.prepareStatement("SELECT a FROM x");
+        stmt = conn.prepareStatement("SELECT a, b, c FROM x");
         ResultSet rs = stmt.executeQuery();
         rs.next();
 
         Array ar = rs.getArray(1);
-        Long[] fs = (Long[]) ar.getArray();
-        Assert.assertArrayEquals(new Long[]{123L}, fs);
+        Integer[] fs = (Integer[]) ar.getArray();
+        Assert.assertArrayEquals(new Integer[]{123}, fs);
+        ar = rs.getArray(2);
+        fs = (Integer[]) ar.getArray();
+        Assert.assertArrayEquals(new Integer[]{123}, fs);
+        ar = rs.getArray(3);
+        Long[] longs = (Long[]) ar.getArray();
+        Assert.assertArrayEquals(new Long[]{123L}, longs);
     }
 
     @Test

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -72,12 +72,6 @@ var resultOidMap = map[oid.Oid]oid.Oid{
 	oid.T__bpchar:  oid.T__text,
 	oid.T_char:     oid.T_text,
 	oid.T__char:    oid.T__text,
-	oid.T_float4:   oid.T_float8,
-	oid.T__float4:  oid.T__float8,
-	oid.T_int2:     oid.T_int8,
-	oid.T__int2:    oid.T__int8,
-	oid.T_int4:     oid.T_int8,
-	oid.T__int4:    oid.T__int8,
 	oid.T_varchar:  oid.T_text,
 	oid.T__varchar: oid.T__text,
 }


### PR DESCRIPTION
With the upgraded type system, we're now in the position to return the
right size of integers to clients that use the binary protocol. Do so.

Closes #36811.

Release note (backwards-incompatible change): integer and float columns
of less than the max width will now be returned as their own type via
the binary protocol. For example, an int4 column will be returned in 32
bits over the pgwire binary protocol instead of 64 bits.