### PR TITLE
exec: add Outbox/Inbox for remote communication

### DIFF
--- a/pkg/sql/distsqlrun/outbox_test.go
+++ b/pkg/sql/distsqlrun/outbox_test.go
@@ -54,7 +54,7 @@ func TestOutbox(t *testing.T) {
 	// Create a mock server that the outbox will connect and push rows to.
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
-	clusterID, mockServer, addr, err := startMockDistSQLServer(stopper)
+	clusterID, mockServer, addr, err := StartMockDistSQLServer(stopper, staticNodeID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,8 +126,8 @@ func TestOutbox(t *testing.T) {
 	}()
 
 	// Wait for the outbox to connect the stream.
-	streamNotification := <-mockServer.inboundStreams
-	serverStream := streamNotification.stream
+	streamNotification := <-mockServer.InboundStreams
+	serverStream := streamNotification.Stream
 
 	// Consume everything that the outbox sends on the stream.
 	var decoder StreamDecoder
@@ -198,7 +198,7 @@ func TestOutbox(t *testing.T) {
 	// The outbox should shut down since the producer closed.
 	outboxWG.Wait()
 	// Signal the server to shut down the stream.
-	streamNotification.donec <- nil
+	streamNotification.Donec <- nil
 }
 
 // Test that an outbox connects its stream as soon as possible (i.e. before
@@ -209,7 +209,7 @@ func TestOutboxInitializesStreamBeforeReceivingAnyRows(t *testing.T) {
 
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
-	clusterID, mockServer, addr, err := startMockDistSQLServer(stopper)
+	clusterID, mockServer, addr, err := StartMockDistSQLServer(stopper, staticNodeID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -240,8 +240,8 @@ func TestOutboxInitializesStreamBeforeReceivingAnyRows(t *testing.T) {
 	// we're not sending any rows.
 	outbox.start(ctx, &outboxWG, cancel)
 
-	streamNotification := <-mockServer.inboundStreams
-	serverStream := streamNotification.stream
+	streamNotification := <-mockServer.InboundStreams
+	serverStream := streamNotification.Stream
 	producerMsg, err := serverStream.Recv()
 	if err != nil {
 		t.Fatal(err)
@@ -255,7 +255,7 @@ func TestOutboxInitializesStreamBeforeReceivingAnyRows(t *testing.T) {
 
 	// Signal the server to shut down the stream. This should also prompt the
 	// outbox (the client) to terminate its loop.
-	streamNotification.donec <- nil
+	streamNotification.Donec <- nil
 	outboxWG.Wait()
 }
 
@@ -283,7 +283,7 @@ func TestOutboxClosesWhenConsumerCloses(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			stopper := stop.NewStopper()
 			defer stopper.Stop(context.TODO())
-			clusterID, mockServer, addr, err := startMockDistSQLServer(stopper)
+			clusterID, mockServer, addr, err := StartMockDistSQLServer(stopper, staticNodeID)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -316,12 +316,12 @@ func TestOutboxClosesWhenConsumerCloses(t *testing.T) {
 				outbox.start(ctx, &wg, cancel)
 
 				// Wait for the outbox to connect the stream.
-				streamNotification := <-mockServer.inboundStreams
+				streamNotification := <-mockServer.InboundStreams
 				// Wait for the consumer to receive the header message that the outbox
 				// sends on start. If we don't wait, the consumer returning from the
 				// FlowStream() RPC races with the outbox sending the header msg and the
 				// send might get an io.EOF error.
-				if _, err := streamNotification.stream.Recv(); err != nil {
+				if _, err := streamNotification.Stream.Recv(); err != nil {
 					t.Errorf("expected err: %q, got %v", expectedErr, err)
 				}
 
@@ -332,7 +332,7 @@ func TestOutboxClosesWhenConsumerCloses(t *testing.T) {
 				} else {
 					expectedErr = nil
 				}
-				streamNotification.donec <- expectedErr
+				streamNotification.Donec <- expectedErr
 			} else {
 				// We're going to perform a RunSyncFlow call and then have the client
 				// cancel the call's context.
@@ -414,7 +414,7 @@ func TestOutboxCancelsFlowOnError(t *testing.T) {
 
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
-	clusterID, mockServer, addr, err := startMockDistSQLServer(stopper)
+	clusterID, mockServer, addr, err := StartMockDistSQLServer(stopper, staticNodeID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -452,12 +452,12 @@ func TestOutboxCancelsFlowOnError(t *testing.T) {
 	outbox.start(ctx, &wg, mockCancel)
 
 	// Wait for the outbox to connect the stream.
-	streamNotification := <-mockServer.inboundStreams
-	if _, err := streamNotification.stream.Recv(); err != nil {
+	streamNotification := <-mockServer.InboundStreams
+	if _, err := streamNotification.Stream.Recv(); err != nil {
 		t.Fatal(err)
 	}
 
-	streamNotification.donec <- sqlbase.QueryCanceledError
+	streamNotification.Donec <- sqlbase.QueryCanceledError
 
 	wg.Wait()
 	if !ctxCanceled {
@@ -529,7 +529,7 @@ func BenchmarkOutbox(b *testing.B) {
 	// Create a mock server that the outbox will connect and push rows to.
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
-	clusterID, mockServer, addr, err := startMockDistSQLServer(stopper)
+	clusterID, mockServer, addr, err := StartMockDistSQLServer(stopper, staticNodeID)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -565,8 +565,8 @@ func BenchmarkOutbox(b *testing.B) {
 			outbox.start(ctx, &outboxWG, cancel)
 
 			// Wait for the outbox to connect the stream.
-			streamNotification := <-mockServer.inboundStreams
-			serverStream := streamNotification.stream
+			streamNotification := <-mockServer.InboundStreams
+			serverStream := streamNotification.Stream
 			go func() {
 				for {
 					_, err := serverStream.Recv()
@@ -584,7 +584,7 @@ func BenchmarkOutbox(b *testing.B) {
 			}
 			outbox.ProducerDone()
 			outboxWG.Wait()
-			streamNotification.donec <- nil
+			streamNotification.Donec <- nil
 		})
 	}
 }

--- a/pkg/sql/distsqlrun/testutils.go
+++ b/pkg/sql/distsqlrun/testutils.go
@@ -1,0 +1,112 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package distsqlrun
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/netutil"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+)
+
+func newInsecureRPCContext(stopper *stop.Stopper) *rpc.Context {
+	return rpc.NewContext(
+		log.AmbientContext{Tracer: tracing.NewTracer()},
+		&base.Config{Insecure: true},
+		hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+		stopper,
+		&cluster.MakeTestingClusterSettings().Version,
+	)
+}
+
+// StartMockDistSQLServer starts a MockDistSQLServer and returns the address on
+// which it's listening.
+func StartMockDistSQLServer(
+	stopper *stop.Stopper, nodeID roachpb.NodeID,
+) (uuid.UUID, *MockDistSQLServer, net.Addr, error) {
+	rpcContext := newInsecureRPCContext(stopper)
+	rpcContext.NodeID.Set(context.TODO(), nodeID)
+	server := rpc.NewServer(rpcContext)
+	mock := newMockDistSQLServer()
+	distsqlpb.RegisterDistSQLServer(server, mock)
+	ln, err := netutil.ListenAndServeGRPC(stopper, server, util.IsolatedTestAddr)
+	if err != nil {
+		return uuid.Nil, nil, nil, err
+	}
+	return rpcContext.ClusterID.Get(), mock, ln.Addr(), nil
+}
+
+// MockDistSQLServer implements the DistSQLServer (gRPC) interface and allows
+// clients to control the inbound streams.
+type MockDistSQLServer struct {
+	InboundStreams   chan InboundStreamNotification
+	runSyncFlowCalls chan RunSyncFlowCall
+}
+
+// InboundStreamNotification is the MockDistSQLServer's way to tell its clients
+// that a new gRPC call has arrived and thus a stream has arrived. The rpc
+// handler is blocked until Donec is signaled.
+type InboundStreamNotification struct {
+	Stream distsqlpb.DistSQL_FlowStreamServer
+	Donec  chan<- error
+}
+
+type RunSyncFlowCall struct {
+	stream distsqlpb.DistSQL_RunSyncFlowServer
+	donec  chan<- error
+}
+
+// MockDistSQLServer implements the DistSQLServer interface.
+var _ distsqlpb.DistSQLServer = &MockDistSQLServer{}
+
+func newMockDistSQLServer() *MockDistSQLServer {
+	return &MockDistSQLServer{
+		InboundStreams:   make(chan InboundStreamNotification),
+		runSyncFlowCalls: make(chan RunSyncFlowCall),
+	}
+}
+
+// RunSyncFlow is part of the DistSQLServer interface.
+func (ds *MockDistSQLServer) RunSyncFlow(stream distsqlpb.DistSQL_RunSyncFlowServer) error {
+	donec := make(chan error)
+	ds.runSyncFlowCalls <- RunSyncFlowCall{stream: stream, donec: donec}
+	return <-donec
+}
+
+// SetupFlow is part of the DistSQLServer interface.
+func (ds *MockDistSQLServer) SetupFlow(
+	_ context.Context, req *distsqlpb.SetupFlowRequest,
+) (*distsqlpb.SimpleResponse, error) {
+	return nil, nil
+}
+
+// FlowStream is part of the DistSQLServer interface.
+func (ds *MockDistSQLServer) FlowStream(stream distsqlpb.DistSQL_FlowStreamServer) error {
+	donec := make(chan error)
+	ds.InboundStreams <- InboundStreamNotification{Stream: stream, Donec: donec}
+	return <-donec
+}

--- a/pkg/sql/distsqlrun/testutils.go
+++ b/pkg/sql/distsqlrun/testutils.go
@@ -75,6 +75,9 @@ type InboundStreamNotification struct {
 	Donec  chan<- error
 }
 
+// RunSyncFlowCall is the MockDistSQLServer's way to tell its clients that a
+// RunSyncFlowCall has arrived. The rpc handler is blocked until Donec is
+// signaled.
 type RunSyncFlowCall struct {
 	stream distsqlpb.DistSQL_RunSyncFlowServer
 	donec  chan<- error

--- a/pkg/sql/exec/colrpc/colrpc_test.go
+++ b/pkg/sql/exec/colrpc/colrpc_test.go
@@ -1,0 +1,221 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package colrpc
+
+import (
+	"context"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+type mockFlowStreamClient struct {
+	pmChan chan *distsqlpb.ProducerMessage
+	csChan chan *distsqlpb.ConsumerSignal
+}
+
+var _ flowStreamClient = mockFlowStreamClient{}
+
+func (c mockFlowStreamClient) Send(m *distsqlpb.ProducerMessage) error {
+	c.pmChan <- m
+	return nil
+}
+
+func (c mockFlowStreamClient) Recv() (*distsqlpb.ConsumerSignal, error) {
+	s := <-c.csChan
+	if s == nil {
+		return nil, io.EOF
+	}
+	return s, nil
+}
+
+func (c mockFlowStreamClient) CloseSend() error {
+	close(c.pmChan)
+	return nil
+}
+
+type mockFlowStreamServer struct {
+	pmChan chan *distsqlpb.ProducerMessage
+	csChan chan *distsqlpb.ConsumerSignal
+}
+
+func (s mockFlowStreamServer) Send(cs *distsqlpb.ConsumerSignal) error {
+	s.csChan <- cs
+	return nil
+}
+
+func (s mockFlowStreamServer) Recv() (*distsqlpb.ProducerMessage, error) {
+	pm := <-s.pmChan
+	if pm == nil {
+		return nil, io.EOF
+	}
+	return pm, nil
+}
+
+var _ flowStreamServer = mockFlowStreamServer{}
+
+// mockFlowStreamRPCLayer mocks out a bidirectional FlowStream RPC. The client
+// and server simply send messages over channels and return io.EOF when these
+// channels are closed. This RPC layer does not aim to implement more than that.
+// Use MockDistSQLServer for more involved RPC behavior testing.
+type mockFlowStreamRPCLayer struct {
+	client mockFlowStreamClient
+	server mockFlowStreamServer
+}
+
+func makeMockFlowStreamRPCLayer() mockFlowStreamRPCLayer {
+	// Buffer channels to simulate non-blocking sends.
+	pmChan := make(chan *distsqlpb.ProducerMessage, 16)
+	csChan := make(chan *distsqlpb.ConsumerSignal, 16)
+	return mockFlowStreamRPCLayer{
+		client: mockFlowStreamClient{pmChan: pmChan, csChan: csChan},
+		server: mockFlowStreamServer{pmChan: pmChan, csChan: csChan},
+	}
+}
+
+// handleStream spawns a goroutine to call Inbox.RunWithStream with the
+// provided stream and returns any error on the returned channel. handleStream
+// will call doneFn if non-nil once the handler returns.
+func handleStream(
+	ctx context.Context, inbox *Inbox, stream flowStreamServer, doneFn func(),
+) chan error {
+	handleStreamErrCh := make(chan error, 1)
+	go func() {
+		handleStreamErrCh <- inbox.RunWithStream(ctx, stream)
+		if doneFn != nil {
+			doneFn()
+		}
+	}()
+	return handleStreamErrCh
+}
+
+const staticNodeID roachpb.NodeID = 3
+
+// TODO(asubiotto): Add draining and cancellation tests.
+func TestOutboxInbox(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Set up the RPC layer.
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	_, mockServer, addr, err := distsqlrun.StartMockDistSQLServer(stopper, staticNodeID)
+	require.NoError(t, err)
+
+	conn, err := grpc.Dial(addr.String(), grpc.WithInsecure())
+	require.NoError(t, err)
+	defer func() { require.NoError(t, conn.Close()) }()
+
+	client := distsqlpb.NewDistSQLClient(conn)
+	clientStream, err := client.FlowStream(ctx)
+	require.NoError(t, err)
+
+	serverStreamNotification := <-mockServer.InboundStreams
+	serverStream := serverStreamNotification.Stream
+
+	// Do the actual testing.
+	var (
+		typs        = []types.T{types.Int64}
+		rng, _      = randutil.NewPseudoRand()
+		inputBuffer = exec.NewBatchBuffer()
+	)
+
+	input := exec.NewRandomDataOp(
+		rng,
+		// Test random selection as the Outbox should be deselecting before sending
+		// over data. Nulls and types are not worth testing as those are tested in
+		// colserde.
+		exec.RandomDataOpArgs{
+			DeterministicTyps: typs,
+			Selection:         true,
+			BatchAccumulator:  inputBuffer.Add,
+		},
+	)
+
+	outbox, err := NewOutbox(input, typs)
+	require.NoError(t, err)
+
+	inbox, err := NewInbox(typs)
+	require.NoError(t, err)
+
+	streamHandlerErrCh := handleStream(serverStream.Context(), inbox, serverStream, func() { close(serverStreamNotification.Donec) })
+
+	var (
+		canceled uint32
+		wg       sync.WaitGroup
+	)
+	wg.Add(1)
+	go func() {
+		outbox.runWithStream(ctx, clientStream, func() { atomic.StoreUint32(&canceled, 1) })
+		wg.Done()
+	}()
+
+	// Use a deselector op to verify that the Outbox gets rid of the selection
+	// vector.
+	inputBatches := exec.NewDeselectorOp(inputBuffer, typs)
+	inputBatches.Init()
+	outputBatches := exec.NewBatchBuffer()
+	for batchNum := 0; ; batchNum++ {
+		outputBatch := inbox.Next(ctx)
+		// Copy batch since it's not safe to reuse after calling Next.
+		batchCopy := coldata.NewMemBatchWithSize(typs, int(outputBatch.Length()))
+		for i := range typs {
+			batchCopy.ColVec(i).Append(outputBatch.ColVec(i), typs[i], 0, outputBatch.Length())
+		}
+		batchCopy.SetLength(outputBatch.Length())
+		outputBatches.Add(batchCopy)
+
+		if outputBatch.Length() == 0 {
+			break
+		}
+	}
+
+	// Wait for the Inbox to return.
+	require.NoError(t, <-streamHandlerErrCh)
+	// Wait for the Outbox to return.
+	wg.Wait()
+	// Verify that the Outbox terminated gracefully.
+	require.True(t, atomic.LoadUint32(&canceled) == 0)
+
+	for batchNum := 0; ; batchNum++ {
+		inputBatch := inputBatches.Next(ctx)
+		outputBatch := outputBatches.Next(ctx)
+		for i := range typs {
+			require.Equal(
+				t,
+				inputBatch.ColVec(i).Slice(typs[i], 0, uint64(inputBatch.Length())),
+				outputBatch.ColVec(i).Slice(typs[i], 0, uint64(outputBatch.Length())),
+				"batchNum: %d", batchNum,
+			)
+		}
+		if outputBatch.Length() == 0 {
+			break
+		}
+	}
+}

--- a/pkg/sql/exec/colrpc/inbox.go
+++ b/pkg/sql/exec/colrpc/inbox.go
@@ -1,0 +1,203 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package colrpc
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/apache/arrow/go/arrow/array"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/colserde"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+// flowStreamServer is a utility interface used to mock out the RPC layer.
+type flowStreamServer interface {
+	Send(*distsqlpb.ConsumerSignal) error
+	Recv() (*distsqlpb.ProducerMessage, error)
+}
+
+// Inbox is used to expose data from remote flows through an exec.Operator
+// interface. FlowStream RPC handlers should call RunWithStream (which blocks
+// until operation terminates, gracefully or unexpectedly) to pass the stream
+// to the inbox. Next may be called before RunWithStream, it will just block
+// until the stream is made available or its context is canceled. Note that
+// ownership of the stream is passed from the RunWithStream goroutine to the
+// Next goroutine. In exchange, the RunWithStream goroutine receives the first
+// context passed into Next and listens for cancellation. Returning from
+// RunWithStream (or more specifically, the RPC handler) will unblock Next by
+// closing the stream.
+type Inbox struct {
+	typs []types.T
+
+	zeroBatch coldata.Batch
+
+	converter  *colserde.ArrowBatchConverter
+	serializer *colserde.RecordBatchSerializer
+
+	initialized bool
+	// stream is the RPC stream. It is set when RunWithStream is called but only
+	// the Next goroutine may access it.
+	stream flowStreamServer
+	// streamCh is the channel over which the stream is passed from the stream
+	// handler to the reader goroutine.
+	streamCh chan flowStreamServer
+	// contextCh is the channel over which the reader goroutine passes the first
+	// context to the stream handler, so that it can listen for context
+	// cancellation.
+	contextCh chan context.Context
+
+	// errCh is that channel that RunWithStream will block on, waiting until Next
+	// encounters an exit condition. An error will only be sent on this channel
+	// in the event of a cancellation.
+	errCh chan error
+
+	scratch struct {
+		data []*array.Data
+	}
+}
+
+var _ exec.Operator = &Inbox{}
+
+// NewInbox creates a new Inbox.
+func NewInbox(typs []types.T) (*Inbox, error) {
+	s, err := colserde.NewRecordBatchSerializer(typs)
+	if err != nil {
+		return nil, err
+	}
+	i := &Inbox{
+		typs:       typs,
+		zeroBatch:  coldata.NewMemBatchWithSize(typs, 0),
+		converter:  colserde.NewArrowBatchConverter(typs),
+		serializer: s,
+		streamCh:   make(chan flowStreamServer, 1),
+		contextCh:  make(chan context.Context, 1),
+		errCh:      make(chan error, 1),
+	}
+	i.zeroBatch.SetLength(0)
+	i.scratch.data = make([]*array.Data, len(typs))
+	return i, nil
+}
+
+// init initializes the Inbox for operation by blocking until RunWithStream
+// sets the stream to read from. ctx ownership is retained until the stream
+// arrives (to allow for unblocking the wait for a stream), at which point
+// ownership is transferred to RunWithStream. This should only be called from
+// the reader goroutine when it needs a stream.
+func (i *Inbox) init(ctx context.Context) bool {
+	// Wait for the stream to be initialized. We're essentially waiting for the
+	// remote connection.
+	select {
+	case i.stream = <-i.streamCh:
+	case <-ctx.Done():
+		i.errCh <- fmt.Errorf("%s: Inbox while waiting for stream", ctx.Err())
+		return false
+	}
+	i.contextCh <- ctx
+	return true
+}
+
+// RunWithStream sets the Inbox's stream and waits until either streamCtx is
+// canceled, a caller of Next cancels the first context passed into Next, or
+// an EOF is encountered on the stream by the Next goroutine.
+func (i *Inbox) RunWithStream(streamCtx context.Context, stream flowStreamServer) error {
+	log.VEvent(streamCtx, 2, "Inbox handling stream")
+	defer log.VEvent(streamCtx, 2, "Inbox exited stream handler")
+	// Pass the stream to the reader goroutine (non-blocking) and get the context
+	// to listen for cancellation.
+	i.streamCh <- stream
+	var readerCtx context.Context
+	select {
+	case err := <-i.errCh:
+		return err
+	case readerCtx = <-i.contextCh:
+		log.VEvent(streamCtx, 2, "Inbox reader arrived")
+	case <-streamCtx.Done():
+		return fmt.Errorf("%s: streamCtx while waiting for reader (remote client canceled)", streamCtx.Err())
+	}
+
+	// Now wait for one of the events described in the method comment. If a
+	// cancellation is encountered, nothing special must be done to cancel the
+	// reader goroutine, as returning from the handler will close the stream.
+	select {
+	case err := <-i.errCh:
+		// nil will be read from errCh when the channel is closed.
+		return err
+	case <-readerCtx.Done():
+		// The reader canceled the stream.
+		return fmt.Errorf("%s: readerCtx in Inbox stream handler (local reader canceled)", readerCtx.Err())
+	case <-streamCtx.Done():
+		// The client canceled the stream.
+		return fmt.Errorf("%s: streamCtx in Inbox stream handler (remote client canceled)", streamCtx.Err())
+	}
+}
+
+// Init is part of the Operator interface.
+func (i *Inbox) Init() {}
+
+// Next returns the next batch. It will block until there is data available.
+// For simplicity, the Inbox will only listen for cancellation of the context
+// passed in to the first Next call.
+func (i *Inbox) Next(ctx context.Context) coldata.Batch {
+	defer func() {
+		// Catch any panics that occur and close the errCh in order to not leak the
+		// goroutine listening for context cancellation. errCh must still be closed
+		// during normal termination.
+		if err := recover(); err != nil {
+			close(i.errCh)
+			panic(err)
+		}
+	}()
+
+	// NOTE: It is very important to close i.errCh on termination of execution
+	// (normally or when panicking), otherwise we might leak RunWithStream.
+	if !i.initialized {
+		if !i.init(ctx) {
+			close(i.errCh)
+			return i.zeroBatch
+		}
+		i.initialized = true
+	}
+
+	m, err := i.stream.Recv()
+	if err != nil {
+		if err == io.EOF {
+			close(i.errCh)
+			return i.zeroBatch
+		}
+		panic(err)
+	}
+	i.scratch.data = i.scratch.data[:0]
+	if err := i.serializer.Deserialize(&i.scratch.data, m.Data.RawBytes); err != nil {
+		panic(err)
+	}
+	b, err := i.converter.ArrowToBatch(i.scratch.data)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+// DrainMeta is part of the MetadataGenerator interface.
+// TODO(asubiotto): Implement this.
+func (i *Inbox) DrainMeta(context.Context) []distsqlrun.ProducerMetadata {
+	return nil
+}

--- a/pkg/sql/exec/colrpc/inbox_test.go
+++ b/pkg/sql/exec/colrpc/inbox_test.go
@@ -1,0 +1,140 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package colrpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+type callbackFlowStreamServer struct {
+	server flowStreamServer
+	sendCb func()
+	recvCb func()
+}
+
+func (s callbackFlowStreamServer) Send(cs *distsqlpb.ConsumerSignal) error {
+	if s.sendCb != nil {
+		s.sendCb()
+	}
+	return s.server.Send(cs)
+}
+
+func (s callbackFlowStreamServer) Recv() (*distsqlpb.ProducerMessage, error) {
+	if s.recvCb != nil {
+		s.recvCb()
+	}
+	return s.server.Recv()
+}
+
+var _ flowStreamServer = callbackFlowStreamServer{}
+
+func TestInboxCancellation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	typs := []types.T{types.Int64}
+	t.Run("ReaderWaitingForStreamHandler", func(t *testing.T) {
+		inbox, err := NewInbox(typs)
+		require.NoError(t, err)
+		ctx, cancelFn := context.WithCancel(context.Background())
+		// Cancel the context.
+		cancelFn()
+		// Next should not block if the context is canceled.
+		require.True(t, inbox.Next(ctx).Length() == 0)
+		// Now, the remote stream arrives.
+		err = inbox.RunWithStream(context.Background(), mockFlowStreamServer{})
+		require.True(t, testutils.IsError(err, "while waiting for stream"), err)
+	})
+
+	// TODO(asubiotto): This is testing interaction with the RPC layer, which
+	// might be better off as a test with an actual RPC layer.
+	t.Run("DuringRecv", func(t *testing.T) {
+		rpcLayer := makeMockFlowStreamRPCLayer()
+		inbox, err := NewInbox(typs)
+		require.NoError(t, err)
+		ctx, cancelFn := context.WithCancel(context.Background())
+
+		// Setup reader and stream.
+		go func() {
+			inbox.Next(ctx)
+		}()
+		recvCalled := make(chan struct{})
+		streamHandlerErrCh := handleStream(context.Background(), inbox, callbackFlowStreamServer{
+			server: rpcLayer.server,
+			recvCb: func() {
+				recvCalled <- struct{}{}
+			},
+		}, func() { close(rpcLayer.server.csChan) })
+
+		// Now wait for the Inbox to call Recv on the stream.
+		<-recvCalled
+
+		// Cancel the context.
+		cancelFn()
+		err = <-streamHandlerErrCh
+		require.True(t, testutils.IsError(err, "readerCtx in Inbox stream handler"), err)
+
+		// The mock RPC layer does not unblock the Recv for us on the server side,
+		// so manually send an io.EOF to the reader goroutine.
+		close(rpcLayer.server.pmChan)
+	})
+
+	t.Run("StreamHandlerWaitingForReader", func(t *testing.T) {
+		rpcLayer := makeMockFlowStreamRPCLayer()
+		inbox, err := NewInbox(typs)
+		require.NoError(t, err)
+
+		ctx, cancelFn := context.WithCancel(context.Background())
+
+		cancelFn()
+		// A stream arrives but there is no reader.
+		err = <-handleStream(ctx, inbox, rpcLayer.server, func() { close(rpcLayer.client.csChan) })
+		require.True(t, testutils.IsError(err, "while waiting for reader"), err)
+	})
+}
+
+// TestInboxNextPanicDoesntLeakGoroutines verifies that goroutines that are
+// spawned as part of an Inbox's normal operation are cleaned up even on a
+// panic.
+func TestInboxNextPanicDoesntLeakGoroutines(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	inbox, err := NewInbox([]types.T{types.Int64})
+	require.NoError(t, err)
+
+	rpcLayer := makeMockFlowStreamRPCLayer()
+	streamHandlerErrCh := handleStream(context.Background(), inbox, rpcLayer.server, func() { close(rpcLayer.client.csChan) })
+
+	m := &distsqlpb.ProducerMessage{}
+	m.Data.RawBytes = []byte("garbage")
+
+	go func() {
+		_ = rpcLayer.client.Send(m)
+	}()
+
+	// inbox.Next should panic given that the deserializer will encounter garbage
+	// data.
+	require.Panics(t, func() { inbox.Next(context.Background()) })
+
+	// We require no error from the stream handler as nothing was canceled. The
+	// panic is bubbled up through the Next chain on the Inbox's host.
+	require.NoError(t, <-streamHandlerErrCh)
+}

--- a/pkg/sql/exec/colrpc/outbox.go
+++ b/pkg/sql/exec/colrpc/outbox.go
@@ -1,0 +1,230 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package colrpc
+
+import (
+	"bytes"
+	"context"
+	"io"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/colserde"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logtags"
+)
+
+// flowStreamClient is a utility interface used to mock out the RPC layer.
+type flowStreamClient interface {
+	Send(*distsqlpb.ProducerMessage) error
+	Recv() (*distsqlpb.ConsumerSignal, error)
+	CloseSend() error
+}
+
+// Outbox is used to push data from local flows to a remote endpoint. Run may
+// be called with the necessary information to establish a connection to a
+// given remote endpoint.
+type Outbox struct {
+	input exec.Operator
+	typs  []types.T
+
+	converter  *colserde.ArrowBatchConverter
+	serializer *colserde.RecordBatchSerializer
+
+	scratch struct {
+		buf *bytes.Buffer
+		msg *distsqlpb.ProducerMessage
+	}
+}
+
+// NewOutbox creates a new Outbox.
+func NewOutbox(input exec.Operator, typs []types.T) (*Outbox, error) {
+	s, err := colserde.NewRecordBatchSerializer(typs)
+	if err != nil {
+		// TODO(asubiotto): Remove err? The only case in which an error is returned
+		// is with zero-length types. Might be good to just panic in this case.
+		return nil, err
+	}
+	o := &Outbox{
+		// Add a deselector as selection vectors are not serialized (nor should they
+		// be).
+		input:      exec.NewDeselectorOp(input, typs),
+		typs:       typs,
+		converter:  colserde.NewArrowBatchConverter(typs),
+		serializer: s,
+	}
+	o.scratch.buf = &bytes.Buffer{}
+	o.scratch.msg = &distsqlpb.ProducerMessage{}
+	return o, nil
+}
+
+// Get rid of unused warning.
+// TODO(asubiotto): Remove this once Outbox is used.
+var _ = (&Outbox{}).Run
+
+// Run starts an outbox by connecting to the provided node and pushing
+// coldata.Batches over the stream after sending a header with the provided flow
+// and stream ID. Note that an extra goroutine is spawned so that Recv may be
+// called concurrently wrt the Send goroutine to listen for drain signals.
+// If an io.EOF is received while sending, the outbox will call cancelFn to
+// indicate an unexpected termination of the stream.
+// If an error is encountered that cannot be sent over the stream, the error
+// will be logged but not returned.
+// There are several ways the bidirectional FlowStream RPC may terminate.
+// 1) Execution is finished. In this case, the upstream operator signals
+// termination by returning a zero-length batch. The Outbox will call CloseSend
+// on the stream. The Outbox will wait until its Recv goroutine receives a
+// non-nil error to not leak resources.
+// 2) A cancellation happened. This can come from the provided context or the
+// remote reader. TODO(asubiotto): Exact behavior explanation to be explained
+// in following PR.
+// 3) A drain signal was received from the server (consumer). In this case, the
+// Outbox drains all its metadata sources and sends the metadata to the consumer
+// before going through the same steps as 1). TODO(asubiotto): Expand.
+func (o *Outbox) Run(
+	ctx context.Context,
+	dialer *nodedialer.Dialer,
+	nodeID roachpb.NodeID,
+	flowID distsqlpb.FlowID,
+	streamID distsqlpb.StreamID,
+	cancelFn context.CancelFunc,
+) {
+	ctx = logtags.AddTag(ctx, "streamID", streamID)
+
+	// TODO(asubiotto): Currently runWithStream waits for the Recv goroutine to
+	// return. Should we just assume that this context cancellation will clean
+	// that up? If not, this context cancellation doesn't seem useful. I would
+	// prefer to just have runWithStream keep responsibility of the Recv
+	// goroutine.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	log.VEventf(ctx, 2, "Outbox Dialing %s", nodeID)
+	conn, err := dialer.Dial(ctx, nodeID)
+	if err != nil {
+		log.Warningf(
+			ctx,
+			"Outbox Dial connection error, distributed query will fail: %s",
+			err,
+		)
+		return
+	}
+
+	client := distsqlpb.NewDistSQLClient(conn)
+	stream, err := client.FlowStream(ctx)
+	if err != nil {
+		log.Warningf(
+			ctx,
+			"Outbox FlowStream connection error, distributed query will fail: %s",
+			err,
+		)
+		return
+	}
+
+	log.VEvent(ctx, 2, "Outbox sending header")
+	// Send header message to establish the remote server (consumer).
+	if err := stream.Send(
+		&distsqlpb.ProducerMessage{Header: &distsqlpb.ProducerHeader{FlowID: flowID, StreamID: streamID}},
+	); err != nil {
+		log.Warningf(
+			ctx,
+			"Outbox Send header error, distributed query will fail: %s",
+			err,
+		)
+		return
+	}
+
+	log.VEvent(ctx, 2, "Outbox starting normal operation")
+	o.runWithStream(ctx, stream, cancelFn)
+}
+
+// runwWithStream should be called after sending the ProducerHeader on the
+// stream. It implements the behavior described in Run.
+func (o *Outbox) runWithStream(
+	ctx context.Context, stream flowStreamClient, cancelFn context.CancelFunc,
+) {
+	o.input.Init()
+
+	waitCh := make(chan struct{})
+	go func() {
+		// TODO(asubiotto): Receive drain signals.
+		for {
+			_, err := stream.Recv()
+			if err != nil {
+				if err != io.EOF {
+					log.Warningf(ctx, "Outbox Recv connection error: %s", err)
+				}
+				break
+			}
+		}
+		close(waitCh)
+	}()
+	for {
+		var b coldata.Batch
+		if err := exec.CatchVectorizedRuntimeError(func() { b = o.input.Next(ctx) }); err != nil {
+			// TODO(asubiotto): Send this error as metadata.
+			log.Warningf(ctx, "Outbox Next error: %s", err)
+			break
+		}
+		if b.Length() == 0 {
+			if err := stream.CloseSend(); err != nil {
+				if err == io.EOF {
+					cancelFn()
+					break
+				}
+				log.Warningf(ctx, "Outbox CloseSend connection error: %s", err)
+				break
+			}
+			// The receiver goroutine will read from the stream until io.EOF is
+			// returned.
+			break
+		}
+
+		o.scratch.buf.Reset()
+		d, err := o.converter.BatchToArrow(b)
+		if err != nil {
+			// TODO(asubiotto): Send this error as metadata.
+			log.Warningf(ctx, "Outbox BatchToArrow data serialization error: %s", err)
+			break
+		}
+		if err := o.serializer.Serialize(o.scratch.buf, d); err != nil {
+			// TODO(asubiotto): Send this error as metadata.
+			log.Warningf(ctx, "Outbox Serialize data error: %s", err)
+			break
+		}
+		o.scratch.msg.Data.RawBytes = o.scratch.buf.Bytes()
+
+		// o.scratch.msg can be reused as soon as Send returns since it returns as
+		// soon as the message is written to the control buffer. The message is
+		// marshaled (bytes are copied) before writing.
+		if err := stream.Send(o.scratch.msg); err != nil {
+			if err == io.EOF {
+				cancelFn()
+				break
+			}
+			log.Warningf(
+				ctx,
+				"Outbox Send data error, distributed query will fail: %s",
+				err,
+			)
+			break
+		}
+	}
+	<-waitCh
+}

--- a/pkg/sql/exec/colrpc/outbox_test.go
+++ b/pkg/sql/exec/colrpc/outbox_test.go
@@ -1,0 +1,50 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package colrpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOutboxCatchesPanics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	var (
+		ctx      = context.Background()
+		input    = exec.NewBatchBuffer()
+		rpcLayer = makeMockFlowStreamRPCLayer()
+	)
+	outbox, err := NewOutbox(input, []types.T{types.Int64})
+	require.NoError(t, err)
+
+	// This test relies on the fact that BatchBuffer panics when there are no
+	// batches to return. Verify this assumption.
+	require.Panics(t, func() { input.Next(ctx) })
+
+	// Close the client csChan so that the Outbox's Recv goroutine returns.
+	close(rpcLayer.client.csChan)
+
+	// The actual test verifies that the Outbox handles input execution tree
+	// panics by not panicking and returning.
+	// TODO(asubiotto): Extend this test by verifying that the Outbox sends this
+	// error as metadata to an Inbox.
+	require.NotPanics(t, func() { outbox.runWithStream(ctx, rpcLayer.client, nil /* cancelFn */) })
+}

--- a/pkg/sql/exec/colserde/arrowbatchconverter.go
+++ b/pkg/sql/exec/colserde/arrowbatchconverter.go
@@ -279,21 +279,19 @@ func (c *ArrowBatchConverter) ArrowToBatch(data []*array.Data) (coldata.Batch, e
 		// arr.NullN() on a converted coldata.Vec is meaningless.
 
 		arrowBitmap := arr.NullBitmapBytes()
-		if arrowBitmap != nil {
-			if n > 1 {
-				// Similar to BatchToArrow, our bitmap representations are currently the
-				// inverse of arrow, so convert them back.
-				// TODO(asubiotto): Transition to using arrow bitmap semantics.
-				endIdx := ((n - 1) >> 3) + 1
-				for i := range arrowBitmap[:endIdx] {
-					arrowBitmap[i] = arrowBitmap[i] ^ math.MaxUint8
-				}
-				// After n elements, the bitmap is unset, so we have to clear the
-				// remaining bits in the last element we iterated over.
-				mod := n & 7
-				if mod != 0 {
-					arrowBitmap[endIdx-1] = arrowBitmap[endIdx-1] ^ (math.MaxUint8 << uint8(mod))
-				}
+		if len(arrowBitmap) != 0 {
+			// Similar to BatchToArrow, our bitmap representations are currently the
+			// inverse of arrow, so convert them back.
+			// TODO(asubiotto): Transition to using arrow bitmap semantics.
+			endIdx := ((n - 1) >> 3) + 1
+			for i := range arrowBitmap[:endIdx] {
+				arrowBitmap[i] = arrowBitmap[i] ^ math.MaxUint8
+			}
+			// After n elements, the bitmap is unset, so we have to clear the
+			// remaining bits in the last element we iterated over.
+			mod := n & 7
+			if mod != 0 {
+				arrowBitmap[endIdx-1] = arrowBitmap[endIdx-1] ^ (math.MaxUint8 << uint8(mod))
 			}
 
 			var vecBitmap []uint64

--- a/pkg/sql/exec/routers_test.go
+++ b/pkg/sql/exec/routers_test.go
@@ -204,11 +204,11 @@ func TestRouterOutputNext(t *testing.T) {
 			tc.unblockEvent(in, o)
 
 			// Should have data available, pushed by our reader goroutine.
-			batches := newBatchBuffer()
+			batches := NewBatchBuffer()
 			out := newOpTestOutput(batches, []int{0}, tc.expected)
 			for {
 				b := <-batchChan
-				batches.add(b)
+				batches.Add(b)
 				if b.Length() == 0 {
 					break
 				}
@@ -385,14 +385,14 @@ func TestRouterOutputRandom(t *testing.T) {
 				}
 			}()
 
-			actual := newBatchBuffer()
+			actual := NewBatchBuffer()
 
 			// Consumer.
 			wg.Add(1)
 			go func() {
 				for {
 					b := o.Next(ctx)
-					actual.add(b)
+					actual.Add(b)
 					if b.Length() == 0 {
 						wg.Done()
 						return

--- a/pkg/sql/exec/testutils.go
+++ b/pkg/sql/exec/testutils.go
@@ -1,0 +1,51 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+)
+
+// BatchBuffer exposes a buffer of coldata.Batches through an Operator
+// interface. If there are no batches to return, Next will panic.
+type BatchBuffer struct {
+	buffer []coldata.Batch
+}
+
+var _ Operator = &BatchBuffer{}
+
+// NewBatchBuffer creates a new BatchBuffer.
+func NewBatchBuffer() *BatchBuffer {
+	return &BatchBuffer{
+		buffer: make([]coldata.Batch, 0, 2),
+	}
+}
+
+// Add adds a batch to the buffer.
+func (b *BatchBuffer) Add(batch coldata.Batch) {
+	b.buffer = append(b.buffer, batch)
+}
+
+// Init is part of the Operator interface.
+func (b *BatchBuffer) Init() {}
+
+// Next is part of the Operator interface.
+func (b *BatchBuffer) Next(context.Context) coldata.Batch {
+	batch := b.buffer[0]
+	b.buffer = b.buffer[1:]
+	return batch
+}

--- a/pkg/sql/exec/utils_test.go
+++ b/pkg/sql/exec/utils_test.go
@@ -785,29 +785,3 @@ func (c *chunkingBatchSource) Next(context.Context) coldata.Batch {
 func (c *chunkingBatchSource) reset() {
 	c.curIdx = 0
 }
-
-// batchBuffer exposes a buffer of coldata.Batches through an Operator
-// interface. If there are no batches to return, Next will panic.
-type batchBuffer struct {
-	buffer []coldata.Batch
-}
-
-var _ Operator = &batchBuffer{}
-
-func newBatchBuffer() *batchBuffer {
-	return &batchBuffer{
-		buffer: make([]coldata.Batch, 0, 2),
-	}
-}
-
-func (b *batchBuffer) add(batch coldata.Batch) {
-	b.buffer = append(b.buffer, batch)
-}
-
-func (b *batchBuffer) Init() {}
-
-func (b *batchBuffer) Next(context.Context) coldata.Batch {
-	batch := b.buffer[0]
-	b.buffer = b.buffer[1:]
-	return batch
-}


### PR DESCRIPTION
This commit adds an Outbox component that pulls coldata.Batches from
an upstream Operator, serializes them, and sends them over a FlowStream
bidirectional RPC to an Inbox, that then exposes these batches to its
vectorized execution flow.

This commit does not include metadata or draining or planning of these
components. These features will be added in following PRs. The goal of
this commit is to simply introduce the components and test a normal
flow of execution (graceful termination) but nothing else.

Release note: None

The other commits are mostly testing-related, with one bugfix.

Closes #37052 

The work that still needs to be done is outlined in #37224 and #37051