### PR TITLE
sql: add missing physprop for commentOnDBNode

### DIFF
--- a/pkg/sql/plan_physical_props.go
+++ b/pkg/sql/plan_physical_props.go
@@ -103,6 +103,7 @@ func planPhysicalProps(plan planNode) physicalProps {
 	case *cancelSessionsNode:
 	case *commentOnTableNode:
 	case *commentOnColumnNode:
+	case *commentOnDatabaseNode:
 	case *controlJobsNode:
 	case *createDatabaseNode:
 	case *createIndexNode:


### PR DESCRIPTION
Closes #37305.

Release note (sql change): prevent crashes when adding comments to
database objects at high verbosity