### PR TITLE
sql: fix crash on prepared show statements

### DIFF
--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -798,12 +798,18 @@ func (p *planner) doPrepare(ctx context.Context, stmt tree.Statement) (planNode,
 		return p.SetZoneConfig(ctx, n)
 	case *tree.ShowClusterSetting:
 		return p.ShowClusterSetting(ctx, n)
-	case *tree.ShowRoles:
-		return p.ShowRoles(ctx, n)
-	case *tree.ShowTraceForSession:
-		return p.ShowTrace(ctx, n)
+	case *tree.ShowHistogram:
+		return p.ShowHistogram(ctx, n)
 	case *tree.ShowRanges:
 		return p.ShowRanges(ctx, n)
+	case *tree.ShowRoles:
+		return p.ShowRoles(ctx, n)
+	case *tree.ShowTableStats:
+		return p.ShowTableStats(ctx, n)
+	case *tree.ShowTraceForSession:
+		return p.ShowTrace(ctx, n)
+	case *tree.ShowZoneConfig:
+		return p.ShowZoneConfig(ctx, n)
 	case *tree.Split:
 		return p.Split(ctx, n)
 	case *tree.Truncate:


### PR DESCRIPTION
Some show statements were missing a prepare path.

Closes #37297.

Release note (sql change): fix crashes when trying to run certain SHOW
commands via the pgwire prepare path