### PR TITLE
roachtest: add minVersion to schemachange/bulkingest

### DIFF
--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -445,6 +445,8 @@ func makeSchemaChangeBulkIngestTest(numNodes, numRows int, length time.Duration)
 		Name:    "schemachange/bulkingest",
 		Cluster: makeClusterSpec(numNodes),
 		Timeout: length * 2,
+		// `fixtures import` (with the experimental-workload paths) is not supported in 2.1
+		MinVersion: "v19.1.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			// Configure column a to have sequential ascending values, and columns b and c to be constant.
 			// The payload column will be randomized and thus uncorrelated with the primary key (a, b, c).


### PR DESCRIPTION
Set `minVersion` to 19.1 for the `schemachange/bulkingest` roachtest, since
`fixtures import` with the `experimental-workload` paths is not supported on
2.1.

Fixes this test failure specifically: https://github.com/cockroachdb/cockroach/issues/37206#issuecomment-488267024

Release note: None