### PR TITLE
release-19.1: fix crashes with commentOnDB; other prepared SHOW statements

### DIFF
--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -855,6 +855,10 @@ func (p *planner) doPrepare(ctx context.Context, stmt tree.Statement) (planNode,
 		return p.ShowJobs(ctx, n)
 	case *tree.ShowRoleGrants:
 		return p.ShowRoleGrants(ctx, n)
+	case *tree.ShowHistogram:
+		return p.ShowHistogram(ctx, n)
+	case *tree.ShowRanges:
+		return p.ShowRanges(ctx, n)
 	case *tree.ShowRoles:
 		return p.ShowRoles(ctx, n)
 	case *tree.ShowSessions:
@@ -865,14 +869,16 @@ func (p *planner) doPrepare(ctx context.Context, stmt tree.Statement) (planNode,
 		return p.ShowSchemas(ctx, n)
 	case *tree.ShowSequences:
 		return p.ShowSequences(ctx, n)
+	case *tree.ShowTableStats:
+		return p.ShowTableStats(ctx, n)
 	case *tree.ShowTraceForSession:
 		return p.ShowTrace(ctx, n)
 	case *tree.ShowUsers:
 		return p.ShowUsers(ctx, n)
 	case *tree.ShowTransactionStatus:
 		return p.ShowTransactionStatus(ctx)
-	case *tree.ShowRanges:
-		return p.ShowRanges(ctx, n)
+	case *tree.ShowZoneConfig:
+		return p.ShowZoneConfig(ctx, n)
 	case *tree.Split:
 		return p.Split(ctx, n)
 	case *tree.Truncate:

--- a/pkg/sql/plan_physical_props.go
+++ b/pkg/sql/plan_physical_props.go
@@ -101,6 +101,9 @@ func planPhysicalProps(plan planNode) physicalProps {
 	case *alterUserSetPasswordNode:
 	case *cancelQueriesNode:
 	case *cancelSessionsNode:
+	case *commentOnTableNode:
+	case *commentOnColumnNode:
+	case *commentOnDatabaseNode:
 	case *controlJobsNode:
 	case *createDatabaseNode:
 	case *createIndexNode:
@@ -140,8 +143,6 @@ func planPhysicalProps(plan planNode) physicalProps {
 	case *valuesNode:
 	case *virtualTableNode:
 	case *zeroNode:
-	case *commentOnTableNode:
-	case *commentOnColumnNode:
 	default:
 		panic(fmt.Sprintf("unhandled node type: %T", plan))
 	}


### PR DESCRIPTION
Backport:
  * 1/1 commits from "sql: add missing physprop for commentOnDBNode" (#37320)
  * 1/1 commits from "sql: fix crash on prepared show statements" (#37321)

Please see individual PRs for details.

/cc @cockroachdb/release
