### PR TITLE
release-19.1: changefeedccl: fix DELETEs in cloud storage sinks

### DIFF
--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/cockroach/pkg/workload/bank"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkChangefeedTicks(b *testing.B) {
@@ -63,7 +64,8 @@ func BenchmarkChangefeedTicks(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			b.StartTimer()
-			sink, cancelFeed := createBenchmarkChangefeed(ctx, s, feedClock, `d`, `bank`)
+			sink, cancelFeed, err := createBenchmarkChangefeed(ctx, s, feedClock, `d`, `bank`)
+			require.NoError(b, err)
 			for rows := 0; rows < numRows; {
 				r, sb := sink.WaitForEmit()
 				rows += r
@@ -167,7 +169,7 @@ func createBenchmarkChangefeed(
 	s serverutils.TestServerInterface,
 	feedClock *hlc.Clock,
 	database, table string,
-) (*benchSink, func() error) {
+) (*benchSink, func() error, error) {
 	tableDesc := sqlbase.GetTableDescriptor(s.DB(), database, table)
 	spans := []roachpb.Span{tableDesc.PrimaryIndexSpan()}
 	details := jobspb.ChangefeedDetails{
@@ -179,7 +181,10 @@ func createBenchmarkChangefeed(
 		},
 	}
 	initialHighWater := hlc.Timestamp{}
-	encoder := makeJSONEncoder(details.Opts)
+	encoder, err := makeJSONEncoder(details.Opts)
+	if err != nil {
+		return nil, nil, err
+	}
 	sink := makeBenchSink()
 
 	settings := s.ClusterSettings()
@@ -248,7 +253,7 @@ func createBenchmarkChangefeed(
 		wg.Wait()
 		return nil
 	}
-	return sink, cancelFn
+	return sink, cancelFn, nil
 }
 
 // loadWorkloadBatches inserts a workload.Table's row batches, each in one

--- a/pkg/ccl/changefeedccl/cdctest/testfeed.go
+++ b/pkg/ccl/changefeedccl/cdctest/testfeed.go
@@ -10,8 +10,10 @@ package cdctest
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	gosql "database/sql"
+	gojson "encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/url"
@@ -27,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -515,6 +518,43 @@ func (c *cloudFeed) Partitions() []string {
 	return []string{cloudFeedPartition}
 }
 
+// extractKeyFromJSONValue extracts the `WITH key_in_value` key from a `WITH
+// format=json, envelope=wrapped` value.
+func extractKeyFromJSONValue(wrapped []byte) (key []byte, value []byte, _ error) {
+	parsed := make(map[string]interface{})
+	if err := gojson.Unmarshal(wrapped, &parsed); err != nil {
+		return nil, nil, err
+	}
+	keyParsed := parsed[`key`]
+	delete(parsed, `key`)
+
+	reformatJSON := func(j interface{}) ([]byte, error) {
+		printed, err := gojson.Marshal(j)
+		if err != nil {
+			return nil, err
+		}
+		// The golang stdlib json library prints whitespace differently than our
+		// internal one. Roundtrip through the crdb json library to get the
+		// whitespace back to where it started.
+		parsed, err := json.ParseJSON(string(printed))
+		if err != nil {
+			return nil, err
+		}
+		var buf bytes.Buffer
+		parsed.Format(&buf)
+		return buf.Bytes(), nil
+	}
+
+	var err error
+	if key, err = reformatJSON(keyParsed); err != nil {
+		return nil, nil, err
+	}
+	if value, err = reformatJSON(parsed); err != nil {
+		return nil, nil, err
+	}
+	return key, value, nil
+}
+
 // Next implements the TestFeed interface.
 func (c *cloudFeed) Next() (*TestFeedMessage, error) {
 	for {
@@ -527,7 +567,22 @@ func (c *cloudFeed) Next() (*TestFeedMessage, error) {
 				Resolved: e.payload,
 			}
 
-			if len(m.Key) > 0 || len(m.Value) > 0 {
+			// The other TestFeed impls check both key and value here, but cloudFeeds
+			// don't have keys.
+			if len(m.Value) > 0 {
+				// Cloud storage sinks default the `WITH key_in_value` option so that
+				// the key is recoverable. Extract it out of the value (also removing it
+				// so the output matches the other sinks). Note that this assumes the
+				// format is json, this will have to be fixed once we add format=avro
+				// support to cloud storage.
+				//
+				// TODO(dan): Leave the key in the value if the TestFeed user
+				// specifically requested it.
+				var err error
+				if m.Key, m.Value, err = extractKeyFromJSONValue(m.Value); err != nil {
+					return nil, err
+				}
+
 				seenKey := m.Topic + m.Partition + string(m.Key) + string(m.Value)
 				if _, ok := c.seen[seenKey]; ok {
 					continue

--- a/pkg/ccl/changefeedccl/cdctest/validator.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator.go
@@ -119,6 +119,7 @@ type validatorRow struct {
 type fingerprintValidator struct {
 	sqlDB                  *gosql.DB
 	origTable, fprintTable string
+	primaryKeyCols         []string
 	partitionResolved      map[string]hlc.Timestamp
 	resolved               hlc.Timestamp
 	// It's possible to get a resolved timestamp from before the table even
@@ -132,20 +133,49 @@ type fingerprintValidator struct {
 }
 
 // NewFingerprintValidator returns a new FingerprintValidator that uses
-// `fprintTable` as scratch space to recreate `origTable`.
+// `fprintTable` as scratch space to recreate `origTable`. `fprintTable` must
+// exist before calling this constructor.
 func NewFingerprintValidator(
 	sqlDB *gosql.DB, origTable, fprintTable string, partitions []string,
-) Validator {
+) (Validator, error) {
+	// Fetch the primary keys though information_schema schema inspections so we
+	// can use them to construct the SQL for DELETEs and also so we can verify
+	// that the key in a message matches what's expected for the value.
+	var primaryKeyCols []string
+	rows, err := sqlDB.Query(`
+		SELECT column_name
+		FROM information_schema.key_column_usage
+		WHERE table_name=$1
+			AND constraint_name='primary'
+		ORDER BY ordinal_position`,
+		fprintTable,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var primaryKeyCol string
+		if err := rows.Scan(&primaryKeyCol); err != nil {
+			return nil, err
+		}
+		primaryKeyCols = append(primaryKeyCols, primaryKeyCol)
+	}
+	if len(primaryKeyCols) == 0 {
+		return nil, errors.Errorf("no primary key information found for %s", fprintTable)
+	}
+
 	v := &fingerprintValidator{
-		sqlDB:       sqlDB,
-		origTable:   origTable,
-		fprintTable: fprintTable,
+		sqlDB:          sqlDB,
+		origTable:      origTable,
+		fprintTable:    fprintTable,
+		primaryKeyCols: primaryKeyCols,
 	}
 	v.partitionResolved = make(map[string]hlc.Timestamp)
 	for _, partition := range partitions {
 		v.partitionResolved[partition] = hlc.Timestamp{}
 	}
-	return v
+	return v, nil
 }
 
 // NoteRow implements the Validator interface.
@@ -227,22 +257,57 @@ func (v *fingerprintValidator) NoteResolved(partition string, resolved hlc.Times
 
 		var stmtBuf bytes.Buffer
 		var args []interface{}
-		fmt.Fprintf(&stmtBuf, `UPSERT INTO %s (`, v.fprintTable)
-		for col, colValue := range value.After {
-			if len(args) != 0 {
-				stmtBuf.WriteString(`,`)
+		if value.After != nil {
+			// UPDATE or INSERT
+			fmt.Fprintf(&stmtBuf, `UPSERT INTO %s (`, v.fprintTable)
+			for col, colValue := range value.After {
+				if len(args) != 0 {
+					stmtBuf.WriteString(`,`)
+				}
+				stmtBuf.WriteString(col)
+				args = append(args, colValue)
 			}
-			stmtBuf.WriteString(col)
-			args = append(args, colValue)
-		}
-		stmtBuf.WriteString(`) VALUES (`)
-		for i := range args {
-			if i != 0 {
-				stmtBuf.WriteString(`,`)
+			stmtBuf.WriteString(`) VALUES (`)
+			for i := range args {
+				if i != 0 {
+					stmtBuf.WriteString(`,`)
+				}
+				fmt.Fprintf(&stmtBuf, `$%d`, i+1)
 			}
-			fmt.Fprintf(&stmtBuf, `$%d`, i+1)
+			stmtBuf.WriteString(`)`)
+
+			// Also verify that the key matches the value.
+			primaryKeyDatums := make([]interface{}, len(v.primaryKeyCols))
+			for idx, primaryKeyCol := range v.primaryKeyCols {
+				primaryKeyDatums[idx] = value.After[primaryKeyCol]
+			}
+			primaryKeyJSON, err := gojson.Marshal(primaryKeyDatums)
+			if err != nil {
+				return err
+			}
+			if string(primaryKeyJSON) != row.key {
+				v.failures = append(v.failures, fmt.Sprintf(
+					`key %s did not match expected key %s for value %s`, row.key, primaryKeyJSON, row.value))
+			}
+		} else {
+			// DELETE
+			var primaryKeyDatums []interface{}
+			if err := gojson.Unmarshal([]byte(row.key), &primaryKeyDatums); err != nil {
+				return err
+			}
+			if len(primaryKeyDatums) != len(v.primaryKeyCols) {
+				return errors.Errorf(
+					`expected primary key columns %s got datums %s`, v.primaryKeyCols, primaryKeyDatums)
+			}
+			fmt.Fprintf(&stmtBuf, `DELETE FROM %s WHERE `, v.fprintTable)
+			for i, datum := range primaryKeyDatums {
+				if len(args) != 0 {
+					stmtBuf.WriteString(`,`)
+				}
+				fmt.Fprintf(&stmtBuf, `%s = $%d`, v.primaryKeyCols[i], i+1)
+				args = append(args, datum)
+			}
 		}
-		stmtBuf.WriteString(`)`)
 		if len(args) > 0 {
 			if _, err := v.sqlDB.Exec(stmtBuf.String(), args...); err != nil {
 				return errors.Wrap(err, stmtBuf.String())

--- a/pkg/ccl/changefeedccl/cdctest/validator_test.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
 )
 
 func ts(i int64) hlc.Timestamp {
@@ -101,7 +102,7 @@ func TestFingerprintValidator(t *testing.T) {
 	sqlDB.Exec(t, `CREATE DATABASE d`)
 	sqlDB.Exec(t, `CREATE TABLE foo (k INT PRIMARY KEY, v INT)`)
 
-	tsRaw := make([]string, 5)
+	tsRaw := make([]string, 6)
 	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&tsRaw[0])
 	sqlDB.QueryRow(t,
 		`UPSERT INTO foo VALUES (1, 1) RETURNING cluster_logical_timestamp()`,
@@ -112,7 +113,10 @@ func TestFingerprintValidator(t *testing.T) {
 	sqlDB.QueryRow(t,
 		`UPSERT INTO foo VALUES (1, 3) RETURNING cluster_logical_timestamp()`,
 	).Scan(&tsRaw[3])
-	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&tsRaw[4])
+	sqlDB.QueryRow(t,
+		`DELETE FROM foo WHERE k = 1 RETURNING cluster_logical_timestamp()`,
+	).Scan(&tsRaw[4])
+	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&tsRaw[5])
 	ts := make([]hlc.Timestamp, len(tsRaw))
 	for i := range tsRaw {
 		var err error
@@ -124,13 +128,15 @@ func TestFingerprintValidator(t *testing.T) {
 
 	t.Run(`empty`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE empty (k INT PRIMARY KEY, v INT)`)
-		v := NewFingerprintValidator(sqlDBRaw, `foo`, `empty`, []string{`p`})
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `empty`, []string{`p`})
+		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		assertValidatorFailures(t, v)
 	})
 	t.Run(`wrong_data`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE wrong_data (k INT PRIMARY KEY, v INT)`)
-		v := NewFingerprintValidator(sqlDBRaw, `foo`, `wrong_data`, []string{`p`})
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `wrong_data`, []string{`p`})
+		require.NoError(t, err)
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":10}}`, ts[1])
 		noteResolved(t, v, `p`, ts[1])
 		assertValidatorFailures(t, v,
@@ -140,37 +146,43 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`all_resolved`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE all_resolved (k INT PRIMARY KEY, v INT)`)
-		v := NewFingerprintValidator(sqlDBRaw, `foo`, `all_resolved`, []string{`p`})
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `all_resolved`, []string{`p`})
+		require.NoError(t, err)
 		if err := v.NoteResolved(`p`, ts[0]); err != nil {
 			t.Fatal(err)
 		}
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
 		noteResolved(t, v, `p`, ts[1])
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2])
-		v.NoteRow(ignored, `[1]`, `{"after": {"k":2,"v":2}}`, ts[2])
+		v.NoteRow(ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[2])
 		noteResolved(t, v, `p`, ts[2])
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":3}}`, ts[3])
 		noteResolved(t, v, `p`, ts[3])
+		v.NoteRow(ignored, `[1]`, `{"after": null}`, ts[4])
 		noteResolved(t, v, `p`, ts[4])
+		noteResolved(t, v, `p`, ts[5])
 		assertValidatorFailures(t, v)
 	})
 	t.Run(`rows_unsorted`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE rows_unsorted (k INT PRIMARY KEY, v INT)`)
-		v := NewFingerprintValidator(sqlDBRaw, `foo`, `rows_unsorted`, []string{`p`})
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `rows_unsorted`, []string{`p`})
+		require.NoError(t, err)
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":3}}`, ts[3])
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2])
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
-		v.NoteRow(ignored, `[1]`, `{"after": {"k":2,"v":2}}`, ts[2])
-		noteResolved(t, v, `p`, ts[4])
+		v.NoteRow(ignored, `[1]`, `{"after": null}`, ts[4])
+		v.NoteRow(ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[2])
+		noteResolved(t, v, `p`, ts[5])
 		assertValidatorFailures(t, v)
 	})
 	t.Run(`missed_initial`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE missed_initial (k INT PRIMARY KEY, v INT)`)
-		v := NewFingerprintValidator(sqlDBRaw, `foo`, `missed_initial`, []string{`p`})
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `missed_initial`, []string{`p`})
+		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		// Intentionally missing {"k":1,"v":1} at ts[1].
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2])
-		v.NoteRow(ignored, `[1]`, `{"after": {"k":2,"v":2}}`, ts[2])
+		v.NoteRow(ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[2])
 		noteResolved(t, v, `p`, ts[2])
 		assertValidatorFailures(t, v,
 			`fingerprints did not match at `+ts[2].Prev().AsOfSystemTime()+
@@ -179,11 +191,12 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`missed_middle`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE missed_middle (k INT PRIMARY KEY, v INT)`)
-		v := NewFingerprintValidator(sqlDBRaw, `foo`, `missed_middle`, []string{`p`})
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `missed_middle`, []string{`p`})
+		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
 		// Intentionally missing {"k":1,"v":2} at ts[2].
-		v.NoteRow(ignored, `[1]`, `{"after": {"k":2,"v":2}}`, ts[2])
+		v.NoteRow(ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[2])
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":3}}`, ts[3])
 		noteResolved(t, v, `p`, ts[3])
 		assertValidatorFailures(t, v,
@@ -195,11 +208,12 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`missed_end`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE missed_end (k INT PRIMARY KEY, v INT)`)
-		v := NewFingerprintValidator(sqlDBRaw, `foo`, `missed_end`, []string{`p`})
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `missed_end`, []string{`p`})
+		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2])
-		v.NoteRow(ignored, `[1]`, `{"after": {"k":2,"v":2}}`, ts[2])
+		v.NoteRow(ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[2])
 		// Intentionally missing {"k":1,"v":3} at ts[3].
 		noteResolved(t, v, `p`, ts[3])
 		assertValidatorFailures(t, v,
@@ -209,21 +223,25 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`initial_scan`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE initial_scan (k INT PRIMARY KEY, v INT)`)
-		v := NewFingerprintValidator(sqlDBRaw, `foo`, `initial_scan`, []string{`p`})
-		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":3}}`, ts[4])
-		v.NoteRow(ignored, `[1]`, `{"after": {"k":2,"v":2}}`, ts[4])
-		noteResolved(t, v, `p`, ts[4])
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `initial_scan`, []string{`p`})
+		require.NoError(t, err)
+		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":3}}`, ts[3])
+		v.NoteRow(ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[3])
+		noteResolved(t, v, `p`, ts[3])
 		assertValidatorFailures(t, v)
 	})
 	t.Run(`unknown_partition`, func(t *testing.T) {
-		v := NewFingerprintValidator(sqlDBRaw, `foo`, `unknown_partition`, []string{`p`})
+		sqlDB.Exec(t, `CREATE TABLE unknown_partition (k INT PRIMARY KEY, v INT)`)
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `unknown_partition`, []string{`p`})
+		require.NoError(t, err)
 		if err := v.NoteResolved(`nope`, ts[1]); !testutils.IsError(err, `unknown partition`) {
 			t.Fatalf(`expected "unknown partition" error got: %+v`, err)
 		}
 	})
 	t.Run(`resolved_unsorted`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE resolved_unsorted (k INT PRIMARY KEY, v INT)`)
-		v := NewFingerprintValidator(sqlDBRaw, `foo`, `resolved_unsorted`, []string{`p`})
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `resolved_unsorted`, []string{`p`})
+		require.NoError(t, err)
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
 		noteResolved(t, v, `p`, ts[1])
 		noteResolved(t, v, `p`, ts[1])
@@ -232,7 +250,8 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`two_partitions`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE two_partitions (k INT PRIMARY KEY, v INT)`)
-		v := NewFingerprintValidator(sqlDBRaw, `foo`, `two_partitions`, []string{`p0`, `p1`})
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `two_partitions`, []string{`p0`, `p1`})
+		require.NoError(t, err)
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
 		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2])
 		// Intentionally missing {"k":2,"v":2}.

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -47,6 +47,7 @@ const (
 	optCursor                  = `cursor`
 	optEnvelope                = `envelope`
 	optFormat                  = `format`
+	optKeyInValue              = `key_in_value`
 	optResolvedTimestamps      = `resolved`
 	optUpdatedTimestamps       = `updated`
 
@@ -77,6 +78,7 @@ var changefeedOptionExpectValues = map[string]sql.KVStringOptValidate{
 	optCursor:                  sql.KVStringOptRequireValue,
 	optEnvelope:                sql.KVStringOptRequireValue,
 	optFormat:                  sql.KVStringOptRequireValue,
+	optKeyInValue:              sql.KVStringOptRequireNoValue,
 	optResolvedTimestamps:      sql.KVStringOptAny,
 	optUpdatedTimestamps:       sql.KVStringOptRequireNoValue,
 }
@@ -220,15 +222,47 @@ func changefeedPlanHook(
 			},
 		}
 
-		if details, err = validateDetails(details); err != nil {
-			return err
-		}
-
-		// Feature telemetry
+		// TODO(dan): In an attempt to present the most helpful error message to the
+		// user, the ordering requirements between all these usage validations have
+		// become extremely fragile and non-obvious.
+		//
+		// - `validateDetails` has to run first to fill in defaults for `envelope`
+		//   and `format` if the user didn't specify them.
+		// - Then `getEncoder` is run to return any configuration errors.
+		// - Then the changefeed is opted in to `optKeyInValue` for any cloud
+		//   storage sink. Kafka etc have a key and value field in each message but
+		//   cloud storage sinks don't have anywhere to put the key. So if the key
+		//   is not in the value, then for DELETEs there is no way to recover which
+		//   key was deleted. We could make the user explicitly pass this option for
+		//   every cloud storage sink and error if they don't, but that seems
+		//   user-hostile for insufficient reason. We can't do this any earlier,
+		//   because we might return errors about `key_in_value` being incompatible
+		//   which is confusing when the user didn't type that option.
+		// - Finally, we create a "canary" sink to test sink configuration and
+		//   connectivity. This has to go last because it is strange to return sink
+		//   connectivity errors before we've finished validating all the other
+		//   options. We should probably split sink configuration checking and sink
+		//   connectivity checking into separate methods.
+		//
+		// The only upside in all this nonsense is the tests are decent. I've tuned
+		// this particular order simply by rearranging stuff until the changefeedccl
+		// tests all pass.
 		parsedSink, err := url.Parse(sinkURI)
 		if err != nil {
 			return err
 		}
+		if details, err = validateDetails(details); err != nil {
+			return err
+		}
+
+		if _, err := getEncoder(details.Opts); err != nil {
+			return err
+		}
+		if isCloudStorageSink(parsedSink) {
+			details.Opts[optKeyInValue] = ``
+		}
+
+		// Feature telemetry
 		telemetrySink := parsedSink.Scheme
 		if telemetrySink == `` {
 			telemetrySink = `sinkless`

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -82,6 +82,10 @@ func TestChangefeedBasics(t *testing.T) {
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
 	t.Run(`poller`, pollerTest(sinklessTest, testFn))
+	t.Run(`cloudstorage`, cloudStorageTest(testFn))
+
+	// NB running TestChangefeedBasics, which includes a DELETE, with
+	// cloudStorageTest is a regression test for #36994.
 }
 
 func TestChangefeedEnvelope(t *testing.T) {
@@ -111,6 +115,11 @@ func TestChangefeedEnvelope(t *testing.T) {
 			foo := feed(t, f, `CREATE CHANGEFEED FOR foo WITH envelope='wrapped'`)
 			defer closeFeed(t, foo)
 			assertPayloads(t, foo, []string{`foo: [1]->{"after": {"a": 1, "b": "a"}}`})
+		})
+		t.Run(`envelope=wrapped,key_in_value`, func(t *testing.T) {
+			foo := feed(t, f, `CREATE CHANGEFEED FOR foo WITH key_in_value, envelope='wrapped'`)
+			defer closeFeed(t, foo)
+			assertPayloads(t, foo, []string{`foo: [1]->{"after": {"a": 1, "b": "a"}, "key": [1]}`})
 		})
 	}
 
@@ -1416,47 +1425,58 @@ func TestChangefeedErrors(t *testing.T) {
 		t, `param sasl_enabled must be a bool`,
 		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_enabled=maybe`,
 	)
-
 	sqlDB.ExpectErr(
 		t, `param sasl_handshake must be a bool`,
 		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_enabled=true&sasl_handshake=maybe`,
 	)
-
 	sqlDB.ExpectErr(
 		t, `sasl_enabled must be enabled to configure SASL handshake behavior`,
 		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_handshake=false`,
 	)
-
 	sqlDB.ExpectErr(
 		t, `sasl_user must be provided when SASL is enabled`,
 		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_enabled=true`,
 	)
-
 	sqlDB.ExpectErr(
 		t, `sasl_password must be provided when SASL is enabled`,
 		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_enabled=true&sasl_user=a`,
 	)
-
 	sqlDB.ExpectErr(
 		t, `sasl_enabled must be enabled if a SASL user is provided`,
 		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_user=a`,
 	)
-
 	sqlDB.ExpectErr(
 		t, `sasl_enabled must be enabled if a SASL password is provided`,
 		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_password=a`,
 	)
 
+	// The avro format doesn't support key_in_value yet.
+	sqlDB.ExpectErr(
+		t, `key_in_value is not supported with format=experimental_avro`,
+		`CREATE CHANGEFEED FOR foo INTO $1 WITH key_in_value, format='experimental_avro'`,
+		`kafka://nope`,
+	)
+
 	// The cloudStorageSink is particular about the options it will work with.
 	sqlDB.ExpectErr(
 		t, `this sink is incompatible with format=experimental_avro`,
-		`CREATE CHANGEFEED FOR foo INTO $1 WITH format='experimental_avro'`,
-		`experimental-nodelocal:///bar`,
+		`CREATE CHANGEFEED FOR foo INTO $1 WITH format='experimental_avro', confluent_schema_registry=$2`,
+		`experimental-nodelocal:///bar`, `schemareg-nope`,
 	)
 	sqlDB.ExpectErr(
 		t, `this sink is incompatible with envelope=key_only`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH envelope='key_only'`,
 		`experimental-nodelocal:///bar`,
+	)
+
+	// WITH key_in_value requires envelope=wrapped
+	sqlDB.ExpectErr(
+		t, `key_in_value is only usable with envelope=wrapped`,
+		`CREATE CHANGEFEED FOR foo INTO $1 WITH key_in_value, envelope='key_only'`, `kafka://nope`,
+	)
+	sqlDB.ExpectErr(
+		t, `key_in_value is only usable with envelope=wrapped`,
+		`CREATE CHANGEFEED FOR foo INTO $1 WITH key_in_value, envelope='row'`, `kafka://nope`,
 	)
 }
 

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -71,7 +71,7 @@ type Encoder interface {
 func getEncoder(opts map[string]string) (Encoder, error) {
 	switch formatType(opts[optFormat]) {
 	case ``, optFormatJSON:
-		return makeJSONEncoder(opts), nil
+		return makeJSONEncoder(opts)
 	case optFormatAvro:
 		return newConfluentAvroEncoder(opts)
 	default:
@@ -84,7 +84,7 @@ func getEncoder(opts map[string]string) (Encoder, error) {
 // to its value. Updated timestamps in rows and resolved timestamp payloads are
 // stored in a sub-object under the `__crdb__` key in the top-level JSON object.
 type jsonEncoder struct {
-	updatedField, wrapped, keyOnly bool
+	updatedField, wrapped, keyOnly, keyInValue bool
 
 	alloc sqlbase.DatumAlloc
 	buf   bytes.Buffer
@@ -92,17 +92,36 @@ type jsonEncoder struct {
 
 var _ Encoder = &jsonEncoder{}
 
-func makeJSONEncoder(opts map[string]string) *jsonEncoder {
+func makeJSONEncoder(opts map[string]string) (*jsonEncoder, error) {
 	e := &jsonEncoder{
 		keyOnly: envelopeType(opts[optEnvelope]) == optEnvelopeKeyOnly,
 		wrapped: envelopeType(opts[optEnvelope]) == optEnvelopeWrapped,
 	}
 	_, e.updatedField = opts[optUpdatedTimestamps]
-	return e
+	_, e.keyInValue = opts[optKeyInValue]
+	if e.keyInValue && !e.wrapped {
+		return nil, errors.Errorf(`%s is only usable with %s=%s`,
+			optKeyInValue, optEnvelope, optEnvelopeWrapped)
+	}
+	return e, nil
 }
 
 // EncodeKey implements the Encoder interface.
 func (e *jsonEncoder) EncodeKey(row encodeRow) ([]byte, error) {
+	jsonEntries, err := e.encodeKeyRaw(row)
+	if err != nil {
+		return nil, err
+	}
+	j, err := json.MakeJSON(jsonEntries)
+	if err != nil {
+		return nil, err
+	}
+	e.buf.Reset()
+	j.Format(&e.buf)
+	return e.buf.Bytes(), nil
+}
+
+func (e *jsonEncoder) encodeKeyRaw(row encodeRow) ([]interface{}, error) {
 	colIdxByID := row.tableDesc.ColumnIdxMap()
 	jsonEntries := make([]interface{}, len(row.tableDesc.PrimaryIndex.ColumnIDs))
 	for i, colID := range row.tableDesc.PrimaryIndex.ColumnIDs {
@@ -120,13 +139,7 @@ func (e *jsonEncoder) EncodeKey(row encodeRow) ([]byte, error) {
 			return nil, err
 		}
 	}
-	j, err := json.MakeJSON(jsonEntries)
-	if err != nil {
-		return nil, err
-	}
-	e.buf.Reset()
-	j.Format(&e.buf)
-	return e.buf.Bytes(), nil
+	return jsonEntries, nil
 }
 
 // EncodeValue implements the Encoder interface.
@@ -158,6 +171,13 @@ func (e *jsonEncoder) EncodeValue(row encodeRow) ([]byte, error) {
 			jsonEntries = map[string]interface{}{`after`: after}
 		} else {
 			jsonEntries = map[string]interface{}{`after`: nil}
+		}
+		if e.keyInValue {
+			keyEntries, err := e.encodeKeyRaw(row)
+			if err != nil {
+				return nil, err
+			}
+			jsonEntries[`key`] = keyEntries
 		}
 	} else {
 		jsonEntries = after
@@ -230,12 +250,7 @@ type confluentRegisteredEnvelopeSchema struct {
 var _ Encoder = &confluentAvroEncoder{}
 
 func newConfluentAvroEncoder(opts map[string]string) (*confluentAvroEncoder, error) {
-	registryURL := opts[optConfluentSchemaRegistry]
-	if len(registryURL) == 0 {
-		return nil, errors.Errorf(`WITH option %s is required for %s=%s`,
-			optConfluentSchemaRegistry, optFormat, optFormatAvro)
-	}
-	e := &confluentAvroEncoder{registryURL: registryURL}
+	e := &confluentAvroEncoder{registryURL: opts[optConfluentSchemaRegistry]}
 
 	switch opts[optEnvelope] {
 	case string(optEnvelopeKeyOnly):
@@ -246,6 +261,16 @@ func newConfluentAvroEncoder(opts map[string]string) (*confluentAvroEncoder, err
 			optEnvelope, opts[optEnvelope], optFormat, optFormatAvro)
 	}
 	_, e.updatedField = opts[optUpdatedTimestamps]
+
+	if _, ok := opts[optKeyInValue]; ok {
+		return nil, errors.Errorf(`%s is not supported with %s=%s`,
+			optKeyInValue, optFormat, optFormatAvro)
+	}
+
+	if len(e.registryURL) == 0 {
+		return nil, errors.Errorf(`WITH option %s is required for %s=%s`,
+			optConfluentSchemaRegistry, optFormat, optFormatAvro)
+	}
 
 	e.keyCache = make(map[tableIDAndVersion]confluentRegisteredKeySchema)
 	e.valueCache = make(map[tableIDAndVersion]confluentRegisteredEnvelopeSchema)

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -79,10 +79,10 @@ func getSink(
 	// Use a function here to delay creation of the sink until after we've done
 	// all the parameter verification.
 	var makeSink func() (Sink, error)
-	switch u.Scheme {
-	case sinkSchemeBuffer:
+	switch {
+	case u.Scheme == sinkSchemeBuffer:
 		makeSink = func() (Sink, error) { return &bufferSink{}, nil }
-	case sinkSchemeKafka:
+	case u.Scheme == sinkSchemeKafka:
 		var cfg kafkaSinkConfig
 		cfg.kafkaTopicPrefix = q.Get(sinkParamTopicPrefix)
 		q.Del(sinkParamTopicPrefix)
@@ -155,8 +155,7 @@ func getSink(
 		makeSink = func() (Sink, error) {
 			return makeKafkaSink(cfg, u.Host, targets)
 		}
-	case `experimental-s3`, `experimental-gs`, `experimental-nodelocal`, `experimental-http`,
-		`experimental-https`, `experimental-azure`:
+	case isCloudStorageSink(u):
 		fileSizeParam := q.Get(sinkParamFileSize)
 		q.Del(sinkParamFileSize)
 		var fileSize int64 = 16 << 20 // 16MB
@@ -173,7 +172,7 @@ func getSink(
 		makeSink = func() (Sink, error) {
 			return makeCloudStorageSink(u.String(), nodeID, fileSize, settings, opts)
 		}
-	case sinkSchemeExperimentalSQL:
+	case u.Scheme == sinkSchemeExperimentalSQL:
 		// Swap the changefeed prefix for the sql connection one that sqlSink
 		// expects.
 		u.Scheme = `postgres`

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -61,19 +61,21 @@ func TestCloudStorageSink(t *testing.T) {
 	settings := cluster.MakeTestingClusterSettings()
 	settings.ExternalIODir = dir
 	opts := map[string]string{
-		optFormat:   string(optFormatJSON),
-		optEnvelope: string(optEnvelopeWrapped),
+		optFormat:     string(optFormatJSON),
+		optEnvelope:   string(optEnvelopeWrapped),
+		optKeyInValue: ``,
 	}
 	ts := func(i int64) hlc.Timestamp { return hlc.Timestamp{WallTime: i} }
-	e := makeJSONEncoder(opts)
+	e, err := makeJSONEncoder(opts)
+	require.NoError(t, err)
 
 	t.Run(`golden`, func(t *testing.T) {
 		t1 := &sqlbase.TableDescriptor{Name: `t1`}
 
 		sinkDir := `golden`
 		s, err := makeCloudStorageSink(`nodelocal:///`+sinkDir, 1, unlimitedFileSize, settings, opts)
-		s.(*cloudStorageSink).sinkID = 7 // Force a deterministic sinkID.
 		require.NoError(t, err)
+		s.(*cloudStorageSink).sinkID = 7 // Force a deterministic sinkID.
 
 		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1)))
 		require.NoError(t, s.Flush(ctx))

--- a/pkg/ccl/changefeedccl/validations_test.go
+++ b/pkg/ccl/changefeedccl/validations_test.go
@@ -69,11 +69,13 @@ func TestValidations(t *testing.T) {
 			})
 
 			const requestedResolved = 7
+			sqlDB.Exec(t, `CREATE TABLE fprint (id INT PRIMARY KEY, balance INT, payload STRING)`)
+			fprintV, err := cdctest.NewFingerprintValidator(db, `bank`, `fprint`, bankFeed.Partitions())
+			require.NoError(t, err)
 			v := cdctest.MakeCountValidator(cdctest.Validators{
 				cdctest.NewOrderValidator(`bank`),
-				cdctest.NewFingerprintValidator(db, `bank`, `fprint`, bankFeed.Partitions()),
+				fprintV,
 			})
-			sqlDB.Exec(t, `CREATE TABLE fprint (id INT PRIMARY KEY, balance INT, payload STRING)`)
 			for {
 				m, err := bankFeed.Next()
 				if err != nil {


### PR DESCRIPTION
Backport 3/3 commits from #37147. Squashed the fixup commit.

/cc @cockroachdb/release

---

All the other sinks (Kafka etc) have a place in each message for a key
and a value, but cloud storage sinks only have a place for a key. The
wrapper format we just moved to has a natural place to put the key (as
an entry in the wrapper), but we weren't doing this.

This commit adds a `WITH key_in_value` option that turns on this
behavior and defaults it to on for any changefeed using a cloud storage
sink.

Closes #36994

Release note (bug fix): `CHANGEFEED` now have a key_in_value option;
this is automatically used for cloud storage sinks, making the primary
key of deleted rows recoverable
