### PR TITLE
util/json: escape non-finite number values when marshaling

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/json_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/json_builtins
@@ -589,6 +589,12 @@ SELECT jsonb_build_array(1, '1'::JSON, 1.2, NULL, ARRAY['x', 'y'])
 ----
 [1, 1, 1.2, null, ["x", "y"]]
 
+# Regression for #37318
+query T
+SELECT jsonb_build_array('+Inf'::FLOAT8, 'NaN'::FLOAT8)::STRING::JSONB
+----
+["Infinity", "NaN"]
+
 query error pq: json_object\(\): array must have even number of elements
 SELECT json_object('{a,b,c}'::TEXT[])
 


### PR DESCRIPTION
Since the resulting value is a string, not a number, it is unclear how
to test the roundtrip-ness of this, since it depends on the receiving
language. In JavaScript both of the following are true:

`Infinity == "Infinity"`
`"Infinity" == Infinity`

This explains why JSON didn't need to define +inf, -inf or NaN is special
values and instead leaves that up to the runtime. Thus for now we only
test that the output of this is parseable, not that it is equal, to
its input. This output matches postgres.

Fixes #37318

Release note (bug fix): correctly escape non-finite JSON number values
when marshaling to text.