### PR TITLE
sql: support empty default_tablespace for compat

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1491,6 +1491,7 @@ client_min_messages                  notice        NULL      NULL        NULL   
 database                             test          NULL      NULL        NULL        string
 datestyle                            ISO, MDY      NULL      NULL        NULL        string
 default_int_size                     8             NULL      NULL        NULL        string
+default_tablespace                   ·             NULL      NULL        NULL        string
 default_transaction_isolation        serializable  NULL      NULL        NULL        string
 default_transaction_read_only        off           NULL      NULL        NULL        string
 distsql                              off           NULL      NULL        NULL        string
@@ -1541,6 +1542,7 @@ client_min_messages                  notice        NULL  user     NULL      noti
 database                             test          NULL  user     NULL      ·             test
 datestyle                            ISO, MDY      NULL  user     NULL      ISO, MDY      ISO, MDY
 default_int_size                     8             NULL  user     NULL      8             8
+default_tablespace                   ·             NULL  user     NULL      ·             ·
 default_transaction_isolation        serializable  NULL  user     NULL      default       default
 default_transaction_read_only        off           NULL  user     NULL      off           off
 distsql                              off           NULL  user     NULL      off           off
@@ -1587,6 +1589,7 @@ crdb_version                         NULL    NULL     NULL     NULL        NULL
 database                             NULL    NULL     NULL     NULL        NULL
 datestyle                            NULL    NULL     NULL     NULL        NULL
 default_int_size                     NULL    NULL     NULL     NULL        NULL
+default_tablespace                   NULL    NULL     NULL     NULL        NULL
 default_transaction_isolation        NULL    NULL     NULL     NULL        NULL
 default_transaction_read_only        NULL    NULL     NULL     NULL        NULL
 distsql                              NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -201,6 +201,12 @@ SET bytea_output = hex
 statement error invalid value for parameter "bytea_output": "bogus"
 SET bytea_output = bogus
 
+statement ok
+SET default_tablespace = ''
+
+statement error invalid value for parameter "default_tablespace": "bleepis"
+SET default_tablespace = 'bleepis'
+
 query T colnames
 SHOW server_version
 ----

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -33,6 +33,7 @@ client_min_messages                  notice
 database                             test
 datestyle                            ISO, MDY
 default_int_size                     8
+default_tablespace                   ·
 default_transaction_isolation        serializable
 default_transaction_read_only        off
 distsql                              off

--- a/pkg/sql/unsupported_vars.go
+++ b/pkg/sql/unsupported_vars.go
@@ -58,7 +58,6 @@ var UnsupportedVars = func(ss ...string) map[string]struct{} {
 	"debug_print_plan",
 	"debug_print_rewritten",
 	"default_statistics_target",
-	"default_tablespace",
 	"default_text_search_config",
 	"default_transaction_deferrable",
 	// "default_transaction_isolation",

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -257,6 +257,21 @@ var varGen = map[string]sessionVar{
 			return strconv.FormatInt(defaultIntSize.Get(sv), 10)
 		},
 	},
+	// See https://www.postgresql.org/docs/10/runtime-config-client.html.
+	// Supported only for pg compatibility - CockroachDB has no notion of
+	// tablespaces.
+	`default_tablespace`: {
+		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
+			if s != "" {
+				return newVarValueError(`default_tablespace`, s, "")
+			}
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) string {
+			return ""
+		},
+		GlobalDefault: func(sv *settings.Values) string { return "" },
+	},
 	// See https://www.postgresql.org/docs/10/static/runtime-config-client.html#GUC-DEFAULT-TRANSACTION-ISOLATION
 	`default_transaction_isolation`: {
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {


### PR DESCRIPTION
Closes #26409

Release note (sql change): support the empty default_tablespace session
variable for pg compatibility