### PR TITLE
[DNM] metric: add Summary metric to track a trailing distribution of values

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -143,6 +143,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:96670a7a5ed372862c668ffa47c859d0384d9696ece6dc845e177ef4c248fb5e"
+  name = "github.com/ajwerner/tdigest"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e530829c34c8d168133b77a220d2eba419f76a50"
+
+[[projects]]
+  branch = "master"
   digest = "1:caed868e37c6cda382a217d8ad4f55da579e1a1d046836de57f11a569e383443"
   name = "github.com/andy-kimball/arenaskl"
   packages = ["."]
@@ -1793,6 +1801,7 @@
     "github.com/Shopify/toxiproxy/client",
     "github.com/VividCortex/ewma",
     "github.com/abourget/teamcity",
+    "github.com/ajwerner/tdigest",
     "github.com/andy-kimball/arenaskl",
     "github.com/apache/arrow/go/arrow",
     "github.com/apache/arrow/go/arrow/array",


### PR DESCRIPTION
A Summary tracks a trailing distribution of values. It is similar in principle
to a histogram with a different set of trade-offs. Prometheus has support for
summaries but generally recommends against them in the common case for reasons
outlined below.

Pros:
  - No configuration for the value range.
  - Generally much higher precision, often 10s of PPM rather than 2 sig-figs
    over a very wide range.
  - Amenable to exponential trailing summaries.
    - Histograms might be too, the way we do windowing now is a bit
      under-considered.
  - Data structure is optimized concurrent modification.
    - More of an implementation detail than anything, could imagine optimizing
      HDRHistogram similarly.
  - Smaller serialized footprint than HDRHistogram for much higher precision.
    - The upper bound of the serialized size is controlled by the Compression
      factor which today defaults to 128. The size of a serialized TDigest is
      o(16*Compression) so by default a TDigest will be less than 2kb.

Cons:
  - Larger in-memory footprint than HDRHistogram.
    - The TDigest data structure uses memory o(16*Compression*(1+BufferFactor))
      bytes which means at the default setting of 12kb whereas an HDRHistogram
      like we use for latency defaults to 4kb but we keep two of them (windowed
      and cumulative) so the total in memory footprint of a histogram metric is
      ~8kb making this not much bigger.
  - No out-of-the-box merging of data between nodes by Prometheus.
    - See [the Prometheus docs on Histograms vs Summaries](https://prometheus.io/docs/practices/histograms/).
    - These things are mergeable and require less data to be shipped around for
      more precision but there's currently no out of the box support in either
      our own tsdb or in prometheus (I intend to look at adding support to
      prometheus at some point).

Another potential point of contention with this PR is that it adds a dependency
on a personal repository github.com/ajwerner/tdigest. I would be happy to move
this over and/or get it reviewed.

The main motivation for adding this metric type is to drive request size
approximation for use in a read quota. The TDigest is much cheaper to use in a
best-effort way to pick a value at a given quantile than is a histogram which
today requires locking the data structure and allocating the `Bars`. I imagine
that the HDRHistogram could be optimized to better provide this functionality
but given I've already written the TDigest, may as well use it for situations
where it fits pretty well.

Using a summary like this may also be nice for the SQL latency we display which
carries incredibly low precision at the top of the distribution where this data
structure would have high precision at the top of the distribution.

Release note: None