### PR TITLE
[DNM] sql: add cost throughput metrics

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -303,6 +303,11 @@ func makeMetrics(internal bool) Metrics {
 
 			TxnAbortCount: metric.NewCounter(getMetricMeta(MetaTxnAbort, internal)),
 			FailureCount:  metric.NewCounter(getMetricMeta(MetaFailure, internal)),
+
+			FailureCostThroughput1m:  metric.NewRate(getMetricMeta(MetaFailureCostThroughput1m, internal), 1*time.Minute),
+			FailureCostThroughput10m: metric.NewRate(getMetricMeta(MetaFailureCostThroughput10m, internal), 10*time.Minute),
+			SuccessCostThroughput1m:  metric.NewRate(getMetricMeta(MetaSuccessCostThroughput1m, internal), 1*time.Minute),
+			SuccessCostThroughput10m: metric.NewRate(getMetricMeta(MetaSuccessCostThroughput10m, internal), 10*time.Minute),
 		},
 		StatementCounters: makeStatementCounters(internal),
 	}

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -874,7 +874,6 @@ func (ex *connExecutor) execWithDistSQLEngine(
 	planCtx.isLocal = !distribute
 	planCtx.planner = planner
 	planCtx.stmtType = recv.stmtType
-
 	if len(planner.curPlan.subqueryPlans) != 0 {
 		var evalCtx extendedEvalContext
 		ex.initEvalCtx(ctx, &evalCtx, planner)

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -343,6 +343,31 @@ var (
 		Measurement: "SQL Statements",
 		Unit:        metric.Unit_COUNT,
 	}
+
+	MetaSuccessCostThroughput1m = metric.Metadata{
+		Name:        "sql.success.cost_throughput.1m",
+		Help:        "Rate of cost for successfully executed statements for the last 1m",
+		Measurement: "Optimizer cost/s",
+		Unit:        metric.Unit_COUNT,
+	}
+	MetaSuccessCostThroughput10m = metric.Metadata{
+		Name:        "sql.success.cost_throughput.10m",
+		Help:        "Rate of cost for successfully executed statements for the last 10m",
+		Measurement: "Optimizer cost/s",
+		Unit:        metric.Unit_COUNT,
+	}
+	MetaFailureCostThroughput1m = metric.Metadata{
+		Name:        "sql.failure.cost_throughput.1m",
+		Help:        "Rate of cost for failed statements for the last 1m",
+		Measurement: "Optimizer cost/s",
+		Unit:        metric.Unit_COUNT,
+	}
+	MetaFailureCostThroughput10m = metric.Metadata{
+		Name:        "sql.failure.cost_throughput.10m",
+		Help:        "Rate of cost for failed statements for the last 10m",
+		Measurement: "Optimizer cost/s",
+		Unit:        metric.Unit_COUNT,
+	}
 )
 
 func getMetricMeta(meta metric.Metadata, internal bool) metric.Metadata {


### PR DESCRIPTION
This PR add metrics to track the throughput of cost through the system.

It may be worthwhile to set a minimum cost per statement or to track this as
a distribution rather than just a rate but this is a starting a point and
tracking this doesn't hurt.

Release note: None