### PR TITLE
util/quotapool: generalize the storage.quotaPool

### DIFF
--- a/pkg/util/quotapool/config.go
+++ b/pkg/util/quotapool/config.go
@@ -1,0 +1,68 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package quotapool
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// Option is used to configure a QuotaPool.
+type Option interface {
+	apply(*config)
+}
+
+// OnSlowAcquisition creates an Option to configure a callback upon slow
+// acquisitions. Only one OnSlowAcquisition may be used. If multiple are
+// specified only the last will be used.
+func OnSlowAcquisition(threshold time.Duration, f SlowAcquisitionFunc) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.slowAcquisitionThreshold = threshold
+		cfg.onSlowAcquisition = f
+	})
+}
+
+// LogSlowAcquisition is an Option to log slow acquisitions.
+var LogSlowAcquisition = OnSlowAcquisition(base.SlowRequestThreshold, logSlowAcquire)
+
+func logSlowAcquire(ctx context.Context, poolName string, r Request, start time.Time) func() {
+	log.Warningf(ctx, "have been waiting %s attempting to acquire %s quota",
+		timeutil.Since(start), poolName)
+	return func() {
+		log.Infof(ctx, "acquired %s quota after %s",
+			poolName, timeutil.Since(start))
+	}
+}
+
+// SlowAcquisitionFunc is used to configure a quotapool to call a function when
+// quota acquisition is slow. The returned callback is called when the
+// acquisition occurs.
+type SlowAcquisitionFunc func(
+	ctx context.Context, poolName string, r Request, start time.Time,
+) (onAcquire func())
+
+type optionFunc func(cfg *config)
+
+func (f optionFunc) apply(cfg *config) { f(cfg) }
+
+type config struct {
+	name                     string
+	onSlowAcquisition        SlowAcquisitionFunc
+	slowAcquisitionThreshold time.Duration
+}

--- a/pkg/util/quotapool/example_test.go
+++ b/pkg/util/quotapool/example_test.go
@@ -1,0 +1,100 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL.txt and at www.mariadb.com/bsl11.
+//
+// Change Date: 2022-10-01
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt and at
+// https://www.apache.org/licenses/LICENSE-2.0
+
+package quotapool
+
+import (
+	"context"
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+)
+
+// An example use case for AcquireFunc is a pool of workers attempting to
+// acquire resources to run a heterogenous set of jobs. Imagine for example we
+// have a set of workers and a list of jobs which need to be run. The function
+// might be used to choose the largest job which can be run by the existing
+// quantity of quota.
+func ExampleIntPool_AcquireFunc() {
+	const quota = 7
+	const workers = 3
+	qp := NewIntPool("work units", quota)
+	type job struct {
+		name string
+		cost int64
+	}
+	jobs := []*job{
+		{name: "foo", cost: 3},
+		{name: "bar", cost: 2},
+		{name: "baz", cost: 4},
+		{name: "qux", cost: 6},
+		{name: "quux", cost: 3},
+		{name: "quuz", cost: 3},
+	}
+	// sortJobs sorts the jobs in highest-to-lowest order with nil last.
+	sortJobs := func() {
+		sort.Slice(jobs, func(i, j int) bool {
+			ij, jj := jobs[i], jobs[j]
+			if ij != nil && jj != nil {
+				return ij.cost > jj.cost
+			}
+			return ij != nil
+		})
+	}
+	// getJob finds the largest job which can be run with the current quota.
+	getJob := func(
+		ctx context.Context, qp *IntPool,
+	) (j *job, alloc *IntAlloc, err error) {
+		alloc, err = qp.AcquireFunc(ctx, func(
+			ctx context.Context, v int64,
+		) (fulfilled bool, took int64) {
+			sortJobs()
+			// There are no more jobs, take 0 and return.
+			if jobs[0] == nil {
+				return true, 0
+			}
+			// Find the largest jobs which can be run.
+			for i := range jobs {
+				if jobs[i] == nil {
+					break
+				}
+				if jobs[i].cost <= v {
+					j, jobs[i] = jobs[i], nil
+					return true, j.cost
+				}
+			}
+			return false, 0
+		})
+		return j, alloc, err
+	}
+	runWorker := func(workerNum int) func(ctx context.Context) error {
+		return func(ctx context.Context) error {
+			for {
+				j, alloc, err := getJob(ctx, qp)
+				if err != nil {
+					return err
+				}
+				if j == nil {
+					return nil
+				}
+				alloc.Release()
+			}
+		}
+	}
+	g := ctxgroup.WithContext(context.Background())
+	for i := 0; i < workers; i++ {
+		g.GoCtx(runWorker(i))
+	}
+	if err := g.Wait(); err != nil {
+		panic(err)
+	}
+}

--- a/pkg/util/quotapool/intpool.go
+++ b/pkg/util/quotapool/intpool.go
@@ -1,0 +1,236 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL.txt and at www.mariadb.com/bsl11.
+//
+// Change Date: 2022-10-01
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt and at
+// https://www.apache.org/licenses/LICENSE-2.0
+
+package quotapool
+
+import (
+	"context"
+	"strconv"
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+// IntPool manages allocating integer units of quota to clients.
+// Clients may acquire quota in two ways, using Acquire which requires the
+// client to specify the quantity of quota at call time and AcquireFunc which
+// allows the client to provide a function which will be used to determine
+// whether a quantity of quota is sufficient when it becomes available.
+type IntPool struct {
+	qp  *QuotaPool
+	max int64
+
+	intAllocSyncPool       sync.Pool
+	intRequestSyncPool     sync.Pool
+	intFuncRequestSyncPool sync.Pool
+}
+
+// IntAlloc is an allocated quantity which should be released.
+type IntAlloc struct {
+	alloc int64
+	p     *IntPool
+}
+
+// Release releases an IntAlloc back into the IntPool.
+func (ia *IntAlloc) Release() {
+	ia.p.qp.Add((*intAlloc)(ia))
+}
+
+// Acquired returns the quantity that this alloc has acquired.
+func (ia *IntAlloc) Acquired() int64 {
+	return ia.alloc
+}
+
+// Merge adds the acquired resources in other to ia. Other may not be used after
+// it has been merged. It is illegal to merge allocs from different pools and
+// doing so will result in a panic.
+func (ia *IntAlloc) Merge(other *IntAlloc) {
+	if ia.p != other.p {
+		panic("cannot merge IntAllocs from two different pools")
+	}
+	ia.alloc = min(ia.p.max, ia.alloc+other.alloc)
+	ia.p.putIntAlloc(other)
+}
+
+// String formats an IntAlloc as a string.
+func (ia *IntAlloc) String() string {
+	if ia == nil {
+		return strconv.Itoa(0)
+	}
+	return strconv.FormatInt(ia.alloc, 10)
+}
+
+// intAlloc is used to make IntAlloc implement Resource without muddling its
+// exported interface.
+type intAlloc IntAlloc
+
+// Merge makes intAlloc a Resource.
+func (ia *intAlloc) Merge(other Resource) {
+	(*IntAlloc)(ia).Merge((*IntAlloc)(other.(*intAlloc)))
+}
+
+// NewIntPool creates a new named IntPool with a maximum quota value.
+func NewIntPool(name string, max int64, options ...Option) *IntPool {
+	p := IntPool{
+		max: max,
+		intAllocSyncPool: sync.Pool{
+			New: func() interface{} { return new(IntAlloc) },
+		},
+		intRequestSyncPool: sync.Pool{
+			New: func() interface{} { return new(intRequest) },
+		},
+		intFuncRequestSyncPool: sync.Pool{
+			New: func() interface{} { return new(intFuncRequest) },
+		},
+	}
+	p.qp = New(name, (*intAlloc)(p.newIntAlloc(max)), options...)
+	return &p
+}
+
+// Acquire acquires the specified amount of quota from the pool. On success,
+// nil is returned and the caller must call add(v) or otherwise arrange for the
+// quota to be returned to the pool. If 'v' is greater than the total capacity
+// of the pool, we instead try to acquire quota equal to the maximum capacity.
+//
+// Acquisitions of 0 return immediately with no error, even if the IntPool is
+// closed.
+//
+// Safe for concurrent use.
+func (p *IntPool) Acquire(ctx context.Context, v int64) (*IntAlloc, error) {
+	// Special case acquisitions of size 0.
+	if v < 0 {
+		panic("cannot acquire negative quota")
+	} else if v == 0 {
+		return p.newIntAlloc(v), nil
+	}
+	r := p.newIntRequest(v)
+	defer p.putIntRequest(r)
+	if err := p.qp.Acquire(ctx, r); err != nil {
+		return nil, err
+	}
+	return p.newIntAlloc(r.want), nil
+}
+
+// IntRequestFunc is used to request a quantity of quota determined when quota is
+// available rather than before requesting.
+type IntRequestFunc func(ctx context.Context, v int64) (fulfilled bool, took int64)
+
+// AcquireFunc acquires a quantity of quota determined by a function which is
+// called with a quantity of available quota.
+func (p *IntPool) AcquireFunc(ctx context.Context, f IntRequestFunc) (*IntAlloc, error) {
+	r := p.newIntFuncRequest(f)
+	defer p.putIntFuncRequest(r)
+	err := p.qp.Acquire(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	return p.newIntAlloc(r.took), nil
+}
+
+// ApproximateQuota will report approximately the amount of quota available in
+// the pool. It is precise if there are no ongoing acquisitions. If there are,
+// the return value can be up to 'v' less than actual available quota where 'v'
+// is the value the acquisition goroutine first in line is attempting to
+// acquire.
+func (p *IntPool) ApproximateQuota() (q int64) {
+	p.qp.ApproximateQuota(func(r Resource) {
+		if ia, ok := r.(*intAlloc); ok {
+			q = ia.alloc
+		}
+	})
+	return q
+}
+
+// Close signals to all ongoing and subsequent acquisitions that the pool is
+// closed and that an error should be returned.
+//
+// Safe for concurrent use.
+func (p *IntPool) Close(reason string) {
+	p.qp.Close(reason)
+}
+
+func (p *IntPool) newIntAlloc(v int64) *IntAlloc {
+	ia := p.intAllocSyncPool.Get().(*IntAlloc)
+	*ia = IntAlloc{p: p, alloc: v}
+	return ia
+}
+
+func (p *IntPool) putIntAlloc(ia *IntAlloc) {
+	p.intAllocSyncPool.Put(ia)
+}
+
+// newIntRequest allocates an intRequest from the sync.Pool.
+// It should be returned with putIntRequest.
+func (p *IntPool) newIntRequest(v int64) *intRequest {
+	r := p.intRequestSyncPool.Get().(*intRequest)
+	r.want = min(v, p.max)
+	return r
+}
+
+func (p *IntPool) putIntRequest(r *intRequest) {
+	p.intRequestSyncPool.Put(r)
+}
+
+// newIntRequest allocates an intFuncRequest from the sync.Pool.
+// It should be returned with putIntFuncRequest.
+func (p *IntPool) newIntFuncRequest(f IntRequestFunc) *intFuncRequest {
+	r := p.intFuncRequestSyncPool.Get().(*intFuncRequest)
+	r.f = f
+	return r
+}
+
+func (p *IntPool) putIntFuncRequest(r *intFuncRequest) {
+	r.f = nil
+	p.intFuncRequestSyncPool.Put(r)
+}
+
+// intRequest is used to acquire a quantity from the quota known ahead of time.
+type intRequest struct {
+	want int64
+}
+
+func (r *intRequest) Acquire(ctx context.Context, v Resource) (fulfilled bool, extra Resource) {
+	ia := v.(*intAlloc)
+	if ia.alloc < r.want {
+		return false, nil
+	}
+	ia.alloc -= r.want
+	return true, ia
+}
+
+// intFuncRequest is used to acquire a quantity from the pool which is not
+// known ahead of time.
+type intFuncRequest struct {
+	f    IntRequestFunc
+	took int64
+}
+
+func (r *intFuncRequest) Acquire(ctx context.Context, v Resource) (fulfilled bool, extra Resource) {
+	ia := v.(*intAlloc)
+	ok, took := r.f(ctx, ia.alloc)
+	if !ok {
+		return false, nil
+	}
+	if took > ia.alloc {
+		panic(errors.Errorf("took %d quota > %d allocated", took, ia.alloc))
+	}
+	r.took = took
+	ia.alloc -= took
+	return true, ia
+}
+
+func min(a, b int64) (v int64) {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/pkg/util/quotapool/intpool_test.go
+++ b/pkg/util/quotapool/intpool_test.go
@@ -1,0 +1,437 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL.txt and at www.mariadb.com/bsl11.
+//
+// Change Date: 2022-10-01
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt and at
+// https://www.apache.org/licenses/LICENSE-2.0
+
+package quotapool_test
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
+	"golang.org/x/sync/errgroup"
+)
+
+// TestQuotaPoolBasic tests the minimal expected behavior of the quota pool
+// with different sized quota pool and a varying number of goroutines, each
+// acquiring a unit quota and releasing it immediately after.
+func TestQuotaPoolBasic(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	quotas := []int64{1, 10, 100, 1000}
+	goroutineCounts := []int{1, 10, 100}
+
+	for _, quota := range quotas {
+		for _, numGoroutines := range goroutineCounts {
+			qp := quotapool.NewIntPool("test", quota)
+			ctx := context.Background()
+			resCh := make(chan error, numGoroutines)
+
+			for i := 0; i < numGoroutines; i++ {
+				go func() {
+					alloc, err := qp.Acquire(ctx, 1)
+					if err != nil {
+						resCh <- err
+						return
+					}
+					alloc.Release()
+					resCh <- nil
+				}()
+			}
+
+			for i := 0; i < numGoroutines; i++ {
+				select {
+				case <-time.After(5 * time.Second):
+					t.Fatal("did not complete acquisitions within 5s")
+				case err := <-resCh:
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+
+			if q := qp.ApproximateQuota(); q != quota {
+				t.Fatalf("expected quota: %d, got: %d", quota, q)
+			}
+		}
+	}
+}
+
+// TestQuotaPoolContextCancellation tests the behavior that for an ongoing
+// blocked acquisition, if the context passed in gets canceled the acquisition
+// gets canceled too with an error indicating so. This should not affect the
+// available quota in the pool.
+func TestQuotaPoolContextCancellation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	qp := quotapool.NewIntPool("test", 1)
+	alloc, err := qp.Acquire(ctx, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	errCh := make(chan error)
+	go func() {
+		_, canceledErr := qp.Acquire(ctx, 1)
+		errCh <- canceledErr
+	}()
+
+	cancel()
+
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatal("context cancellation did not unblock acquisitions within 5s")
+	case err := <-errCh:
+		if err != context.Canceled {
+			t.Fatalf("expected context cancellation error, got %v", err)
+		}
+	}
+
+	alloc.Release()
+
+	if q := qp.ApproximateQuota(); q != 1 {
+		t.Fatalf("expected quota: 1, got: %d", q)
+	}
+}
+
+// TestQuotaPoolClose tests the behavior that for an ongoing blocked
+// acquisition if the quota pool gets closed, all ongoing and subsequent
+// acquisitions return an *ErrClosed.
+func TestQuotaPoolClose(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	qp := quotapool.NewIntPool("test", 1)
+	if _, err := qp.Acquire(ctx, 1); err != nil {
+		t.Fatal(err)
+	}
+	const numGoroutines = 5
+	resCh := make(chan error, numGoroutines)
+
+	tryAcquire := func() {
+		_, err := qp.Acquire(ctx, 1)
+		resCh <- err
+	}
+	for i := 0; i < numGoroutines; i++ {
+		go tryAcquire()
+	}
+
+	qp.Close("")
+
+	// Second call should be a no-op.
+	qp.Close("")
+
+	for i := 0; i < numGoroutines; i++ {
+		select {
+		case <-time.After(5 * time.Second):
+			t.Fatal("quota pool closing did not unblock acquisitions within 5s")
+		case err := <-resCh:
+			if _, isErrClosed := err.(*quotapool.ErrClosed); !isErrClosed {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	go tryAcquire()
+
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatal("quota pool closing did not unblock acquisitions within 5s")
+	case err := <-resCh:
+		if _, isErrClosed := err.(*quotapool.ErrClosed); !isErrClosed {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestQuotaPoolCanceledAcquisitions tests the behavior where we enqueue
+// multiple acquisitions with canceled contexts and expect any subsequent
+// acquisition with a valid context to proceed without error.
+func TestQuotaPoolCanceledAcquisitions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	qp := quotapool.NewIntPool("test", 1)
+	alloc, err := qp.Acquire(ctx, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cancel()
+	const numGoroutines = 5
+
+	errCh := make(chan error)
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			_, err := qp.Acquire(ctx, 1)
+			errCh <- err
+		}()
+	}
+
+	for i := 0; i < numGoroutines; i++ {
+		select {
+		case <-time.After(5 * time.Second):
+			t.Fatal("context cancellations did not unblock acquisitions within 5s")
+		case err := <-errCh:
+			if err != context.Canceled {
+				t.Fatalf("expected context cancellation error, got %v", err)
+			}
+		}
+	}
+
+	alloc.Release()
+	go func() {
+		_, err := qp.Acquire(context.Background(), 1)
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("acquisition didn't go through within 5s")
+	}
+}
+
+// TestQuotaPoolNoops tests that quota pool operations that should be noops are
+// so, e.g. quotaPool.acquire(0) and quotaPool.release(0).
+func TestQuotaPoolNoops(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	qp := quotapool.NewIntPool("test", 1)
+	ctx := context.Background()
+	initialAlloc, err := qp.Acquire(ctx, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Acquisition of blockedAlloc will block until initialAlloc is released.
+	errCh := make(chan error)
+	var blockedAlloc *quotapool.IntAlloc
+	go func() {
+		blockedAlloc, err = qp.Acquire(ctx, 1)
+		errCh <- err
+	}()
+
+	// Allocation of zero should not block.
+	emptyAlloc, err := qp.Acquire(ctx, 0)
+	if err != nil {
+		t.Fatalf("failed to acquire 0 quota: %v", err)
+	}
+	emptyAlloc.Release() // Release of 0 should do nothing
+
+	initialAlloc.Release()
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatal("context cancellations did not unblock acquisitions within 5s")
+	case err := <-errCh:
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if q := qp.ApproximateQuota(); q != 0 {
+		t.Fatalf("expected quota: 0, got: %d", q)
+	}
+	blockedAlloc.Release()
+	if q := qp.ApproximateQuota(); q != 1 {
+		t.Fatalf("expected quota: 1, got: %d", q)
+	}
+}
+
+// TestQuotaPoolMaxQuota tests that Acquire cannot acquire more than the
+// maximum amount with which the pool was initialized.
+func TestQuotaPoolMaxQuota(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const quota = 100
+	qp := quotapool.NewIntPool("test", quota)
+	ctx := context.Background()
+	alloc, err := qp.Acquire(ctx, 2*quota)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := alloc.Acquired(); got != quota {
+		t.Fatalf("expected to acquire the max quota %d, instead got %d", quota, got)
+	}
+	alloc.Release()
+	if q := qp.ApproximateQuota(); q != quota {
+		t.Fatalf("expected quota: %d, got: %d", quota, q)
+	}
+}
+
+// TestQuotaPoolCappedAcquisition verifies that when an acquisition request
+// greater than the maximum quota is placed, we still allow the acquisition to
+// proceed but after having acquired the maximum quota amount.
+func TestQuotaPoolCappedAcquisition(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const quota = 1
+	qp := quotapool.NewIntPool("test", quota)
+	alloc, err := qp.Acquire(context.Background(), quota*100)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if q := qp.ApproximateQuota(); q != 0 {
+		t.Fatalf("expected quota: %d, got: %d", 0, q)
+	}
+
+	alloc.Release()
+	if q := qp.ApproximateQuota(); q != quota {
+		t.Fatalf("expected quota: %d, got: %d", quota, q)
+	}
+}
+
+// TestSlowAcquisition ensures that the SlowAcquisition callback is called
+// when an Acquire call takes longer than the configured timeout.
+func TestSlowAcquisition(t *testing.T) {
+	// The test will set up an IntPool with 1 quota and a SlowAcquisition callback
+	// which closes channels when called by the second goroutine. An initial call
+	// to Acquire will take all of the quota. Then a second call with go should be
+	// blocked leading to the callback being triggered.
+
+	// In order to prevent the first call to Acquire from triggering the callback
+	// we mark its context with a value.
+	ctx := context.Background()
+	type ctxKey int
+	firstKey := ctxKey(1)
+	firstCtx := context.WithValue(ctx, firstKey, "foo")
+	slowCalled, acquiredCalled := make(chan struct{}), make(chan struct{})
+	f := func(ctx context.Context, _ string, _ quotapool.Request, _ time.Time) func() {
+		if ctx.Value(firstKey) != nil {
+			return func() {}
+		}
+		close(slowCalled)
+		return func() {
+			close(acquiredCalled)
+		}
+	}
+	qp := quotapool.NewIntPool("test", 1, quotapool.OnSlowAcquisition(time.Microsecond, f))
+	alloc, err := qp.Acquire(firstCtx, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		_, _ = qp.Acquire(ctx, 1)
+	}()
+	select {
+	case <-slowCalled:
+	case <-time.After(time.Second):
+		t.Fatalf("OnSlowAcquisition not called long after timeout")
+	}
+	select {
+	case <-acquiredCalled:
+		t.Fatalf("acquired callback called when insufficient quota was available")
+	default:
+	}
+	alloc.Release()
+	select {
+	case <-slowCalled:
+	case <-time.After(time.Second):
+		t.Fatalf("OnSlowAcquisition acquired callback not called long after timeout")
+	}
+}
+
+// BenchmarkIntQuotaPool benchmarks the common case where we have sufficient
+// quota available in the pool and we repeatedly acquire and release quota.
+func BenchmarkIntQuotaPool(b *testing.B) {
+	qp := quotapool.NewIntPool("test", 1)
+	ctx := context.Background()
+	for n := 0; n < b.N; n++ {
+		alloc, err := qp.Acquire(ctx, 1)
+		if err != nil {
+			b.Fatal(err)
+		}
+		alloc.Release()
+	}
+	qp.Close("")
+}
+
+// BenchmarkConcurrentIntQuotaPool benchmarks concurrent workers in a variety
+// of ratios between adequate and inadequate quota to concurrently serve all
+// workers.
+func BenchmarkConcurrentIntQuotaPool(b *testing.B) {
+	// test returns the arguments to b.Run for a given number of workers and
+	// quantity of quota.
+	test := func(workers, quota int) (string, func(b *testing.B)) {
+		return fmt.Sprintf("workers=%d,quota=%d", workers, quota), func(b *testing.B) {
+			qp := quotapool.NewIntPool("test", int64(quota), quotapool.LogSlowAcquisition)
+			g, ctx := errgroup.WithContext(context.Background())
+			runWorker := func(workerNum int) {
+				g.Go(func() error {
+					for i := workerNum; i < b.N; i += workers {
+						alloc, err := qp.Acquire(ctx, 1)
+						if err != nil {
+							b.Fatal(err)
+						}
+						runtime.Gosched()
+						alloc.Release()
+					}
+					return nil
+				})
+			}
+			for i := 0; i < workers; i++ {
+				runWorker(i)
+			}
+			if err := g.Wait(); err != nil {
+				b.Fatal(err)
+			}
+			qp.Close("")
+		}
+	}
+	for _, c := range []struct {
+		workers, quota int
+	}{
+		{1, 1},
+		{2, 2},
+		{8, 4},
+		{128, 4},
+		{512, 128},
+		{512, 513},
+	} {
+		b.Run(test(c.workers, c.quota))
+	}
+}
+
+// BenchmarkIntQuotaPoolFunc benchmarks the common case where we have sufficient
+// quota available in the pool and we repeatedly acquire and release quota.
+func BenchmarkIntQuotaPoolFunc(b *testing.B) {
+	qp := quotapool.NewIntPool("test", 1, quotapool.LogSlowAcquisition)
+	ctx := context.Background()
+	toAcquire := intRequest(1)
+	for n := 0; n < b.N; n++ {
+		alloc, err := qp.AcquireFunc(ctx, toAcquire.acquire)
+		if err != nil {
+			b.Fatal(err)
+		} else if acquired := alloc.Acquired(); acquired != 1 {
+			b.Fatalf("expected to acquire %d, got %d", 1, acquired)
+		}
+		alloc.Release()
+	}
+	qp.Close("")
+}
+
+// intRequest is a wrapper to create a IntRequestFunc from an int64.
+type intRequest int64
+
+func (ir intRequest) acquire(_ context.Context, v int64) (fulfilled bool, took int64) {
+	if int64(ir) < v {
+		return false, 0
+	}
+	return true, int64(ir)
+}

--- a/pkg/util/quotapool/quotapool.go
+++ b/pkg/util/quotapool/quotapool.go
@@ -1,0 +1,358 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL.txt and at www.mariadb.com/bsl11.
+//
+// Change Date: 2022-10-01
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt and at
+// https://www.apache.org/licenses/LICENSE-2.0
+
+// Package quotapool provides an abstract implementation of a pool of resources
+// to be distributed among concurrent clients.
+//
+// The library also offers a concrete implementation of such a quota pool for
+// single-dimension integer quota. This IntPool acts like a weighted semaphore
+// that additionally offers FIFO ordering for serving requests.
+package quotapool
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// TODO(ajwerner): provide option to limit the maximum queue size.
+// TODO(ajwerner): provide mechanism to collect metrics.
+
+// Resource is an interface that represents a quantity which is being
+// pooled and allocated. It is any quantity that can be subdivided and
+// combined.
+//
+// This library does not provide any concrete implementations of Resource but
+// internally the *IntAlloc is used as a resource.
+type Resource interface {
+
+	// Merge combines other into the current resource.
+	// After a Resource (other) is passed to Merge, the QuotaPool will never use
+	// that Resource again. This behavior allows clients to pool instances of
+	// Resources by creating Resource during Acquisition and destroying them in
+	// Merge.
+	Merge(other Resource)
+}
+
+// Request is an interface used to acquire quota from the pool.
+// Request is responsible for subdividing a resource into the portion which is
+// retained when the Request is fulfilled and the remainder.
+type Request interface {
+
+	// Acquire decides whether a Request can be fulfilled by a given quantity of
+	// Resource.
+	//
+	// If it is not fulfilled it must not modify or retain the passed alloc.
+	// If it is fulfilled, it should return any portion of the Alloc it does
+	// not intend to use.
+	//
+	// It is up to the implementer to decide if it makes sense to return a
+	// zero-valued, non-nil Resource or nil as unused when acquiring all of the
+	// passed Resource. If nil is returned and there is a notion of acquiring a
+	// zero-valued Resource unit from the pool then those acquisitions may need to
+	// wait until the pool is non-empty before proceeding. Those zero-valued
+	// acquisitions will still need to wait to be at the front of the queue. It
+	// may make sense for implementers to special case zero-valued acquisitions
+	// entirely as IntPool does.
+	Acquire(context.Context, Resource) (fulfilled bool, unused Resource)
+}
+
+// ErrClosed is returned from Acquire after Close has been called.
+type ErrClosed struct {
+	poolName string
+	reason   string
+}
+
+// Error implements error.
+func (ec *ErrClosed) Error() string {
+	return fmt.Sprintf("%s pool closed: %s", ec.poolName, ec.reason)
+}
+
+// QuotaPool is an abstract implementation of a pool that stores some unit of
+// Resource. The basic idea is that it allows requests to acquire a quantity of
+// Resource from the pool in FIFO order in a way that interacts well with
+// context cancelation.
+type QuotaPool struct {
+	config
+
+	// chanSyncPool is used to pool allocations of the channels used to notify
+	// goroutines waiting in Acquire.
+	chanSyncPool sync.Pool
+
+	// We use a channel to 'park' our quota value for easier composition with
+	// context cancellation and quotaPool closing (see quotaPool.Acquire).
+	//
+	// Resource additions push a value into the channel whereas the acquisition
+	// first in line waits on the channel itself.
+	quota chan Resource
+
+	// Ongoing acquisitions listen on done which is closed when the quota
+	// pool is closed (see QuotaPool.Close).
+	done chan struct{}
+
+	// closeErr is populated with a non-nil error when Close is called.
+	closeErr *ErrClosed
+
+	mu struct {
+		syncutil.Mutex
+
+		// We service quota acquisitions in a first come, first serve basis. This
+		// is done in order to prevent starvations of large acquisitions by a
+		// continuous stream of smaller ones. Acquisitions 'register' themselves
+		// for a notification that indicates they're now first in line. This is
+		// done by appending to the queue the channel they will then wait
+		// on. If a goroutine no longer needs to be notified, i.e. their
+		// acquisition context has been canceled, the goroutine is responsible for
+		// blocking subsequent notifications to the channel by filling up the
+		// channel buffer.
+		queue []chan struct{}
+
+		// closed is set to true when the quota pool is closed (see
+		// QuotaPool.Close).
+		closed bool
+	}
+}
+
+// New returns a new quota pool initialized with a given quota. The quota
+// is capped at this amount, meaning that callers may return more quota than they
+// acquired without ever making more than the quota capacity available.
+func New(name string, initialResource Resource, options ...Option) *QuotaPool {
+	qp := &QuotaPool{
+		quota: make(chan Resource, 1),
+		done:  make(chan struct{}),
+		chanSyncPool: sync.Pool{
+			New: func() interface{} { return make(chan struct{}, 1) },
+		},
+	}
+	for _, o := range options {
+		o.apply(&qp.config)
+	}
+	qp.quota <- initialResource
+	return qp
+}
+
+// Add adds the provided Alloc back to the pool. The value will be merged with
+// the existing resources in the QuotaPool if there are any.
+//
+// Safe for concurrent use.
+func (qp *QuotaPool) Add(v Resource) {
+	qp.mu.Lock()
+	defer qp.mu.Unlock()
+	qp.addLocked(v)
+}
+
+func (qp *QuotaPool) addLocked(r Resource) {
+	select {
+	case q := <-qp.quota:
+		r.Merge(q)
+	default:
+	}
+	qp.quota <- r
+}
+
+// Acquire attempts to fulfill the Request with Resource from the qp.
+// Requests are serviced in a FIFO order; only a single request is ever
+// being offered resources at a time. A Request will be offered the pool's
+// current quantity of Resource until it is fulfilled or its context is
+// canceled.
+//
+// Safe for concurrent use.
+func (qp *QuotaPool) Acquire(ctx context.Context, r Request) (err error) {
+	notifyCh := qp.chanSyncPool.Get().(chan struct{})
+	qp.mu.Lock()
+	var closeErr error
+	if qp.mu.closed {
+		closeErr = qp.closeErr
+	} else {
+		qp.mu.queue = append(qp.mu.queue, notifyCh)
+		// If we're first in line, we notify ourself immediately.
+		if len(qp.mu.queue) == 1 {
+			notifyCh <- struct{}{}
+		}
+	}
+	qp.mu.Unlock()
+	if closeErr != nil {
+		return closeErr
+	}
+	// Set up the infrastructure to report slow requests.
+	var slowTimer *timeutil.Timer
+	var slowTimerC <-chan time.Time
+	var start time.Time
+	if qp.onSlowAcquisition != nil {
+		start = timeutil.Now()
+		slowTimer = timeutil.NewTimer()
+		defer slowTimer.Stop()
+		// Intentionally reset only once, for we care more about the select duration in
+		// goroutine profiles than periodic logging.
+		slowTimer.Reset(qp.slowAcquisitionThreshold)
+		slowTimerC = slowTimer.C
+	}
+	for {
+		select {
+		case <-slowTimerC:
+			slowTimer.Read = true
+			defer qp.onSlowAcquisition(ctx, qp.name, r, start)()
+			continue
+		case <-ctx.Done():
+			qp.mu.Lock()
+			// We no longer need to be notified but we need to be careful and check
+			// whether or not we're first in queue. If so, we need to notify the
+			// next acquisition goroutine and clean up the waiting queue while
+			// doing so.
+			//
+			// Else we simply 'unregister' ourselves from the queue by filling
+			// up the channel buffer. This is what is checked when a goroutine
+			// wishes to notify the next in line.
+			if qp.mu.queue[0] == notifyCh {
+				// It is possible that we were notified before we grabbed the mutex but
+				// after the context cancellation in which case we must clear notifyCh
+				// so that qp.notifyNextLocked() can put it back into the pool.
+				select {
+				case <-notifyCh:
+				default:
+				}
+				qp.notifyNextLocked()
+			} else {
+				// NB: Notifying the channel before moving it to the head of the
+				// queue is safe because the queue itself is guarded by a lock.
+				// Goroutines are not a risk of getting notified and finding
+				// out they're not first in line.
+				notifyCh <- struct{}{}
+			}
+
+			qp.mu.Unlock()
+			return ctx.Err()
+		case <-qp.done:
+			// We don't need to 'unregister' ourselves as in the case when the
+			// context is canceled. In fact, we want others waiters to only
+			// receive on qp.done and signaling them would work against that.
+			return qp.closeErr // always non-nil when qp.done is closed
+		case <-notifyCh:
+
+		}
+		break
+	}
+
+	// We're first in line to receive quota, we keep accumulating quota until
+	// we've acquired enough or determine we no longer need the acquisition.
+	// If we have acquired the quota needed or our context gets canceled,
+	// we're sure to remove ourselves from the queue and notify the goroutine
+	// next in line (if any).
+	var alloc, unused Resource
+	var fulfilled bool
+	for !fulfilled {
+		select {
+		case <-slowTimerC:
+			slowTimer.Read = true
+			defer qp.onSlowAcquisition(ctx, qp.name, r, start)()
+		case <-ctx.Done():
+			qp.mu.Lock()
+			if alloc != nil {
+				qp.addLocked(alloc)
+			}
+			qp.notifyNextLocked()
+			qp.mu.Unlock()
+			return ctx.Err()
+		case <-qp.done:
+			// We don't need to release quota back as all ongoing and
+			// subsequent acquisitions will succeed immediately.
+			return qp.closeErr // always non-nil when qp.done is closed
+		case more := <-qp.quota:
+			if alloc == nil {
+				alloc = more
+			} else {
+				alloc.Merge(more)
+			}
+			fulfilled, unused = r.Acquire(ctx, alloc)
+		}
+	}
+	qp.mu.Lock()
+	if unused != nil {
+		qp.addLocked(unused)
+	}
+	qp.notifyNextLocked()
+	qp.mu.Unlock()
+	return nil
+}
+
+// notifyNextLocked notifies the waiting acquisition goroutine next in line (if
+// any). It requires that qp.mu.Mutex is held.
+func (qp *QuotaPool) notifyNextLocked() {
+	// We're at the head of the queue. In all cases we ensure that the channel
+	// at the head of the queue has already been notified.
+	qp.chanSyncPool.Put(qp.mu.queue[0])
+	// We traverse until we find a goroutine waiting to be notified, notify the
+	// goroutine and truncate our queue so to ensure the said goroutine is at the
+	// head of the queue. Normally the next lined up waiter is the one waiting for
+	// notification, but if others behind us have also gotten their context
+	// canceled, they will leave behind waiters that we would skip below.
+	//
+	// If we determine there are no goroutines waiting, we simply truncate the
+	// queue to reflect this.
+	qp.mu.queue = qp.mu.queue[1:]
+	for _, ch := range qp.mu.queue {
+		select {
+		case ch <- struct{}{}:
+		default:
+			// When requests are canceled by their context, they ensure that they
+			// cannot be notified by sending a message on their own queued notify
+			// channel. The default case here deals with canceled queued channels
+			// by clearing the channel before putting it back in the pool and then
+			// shifting the queue.
+			<-ch
+			qp.chanSyncPool.Put(ch)
+			qp.mu.queue = qp.mu.queue[1:]
+			continue
+		}
+		break
+	}
+}
+
+// ApproximateQuota will report approximately the amount of quota available
+// in the pool to f. It is accurate only if there are no ongoing acquisition
+// goroutines. If there are, the passed value can be nil if there is an ongoing
+// acquisition or if non-nil may contain a value up to 'v' less than actual
+// available quota where 'v' is the value the acquisition goroutine first in
+// line is attempting to acquire. The provided Resource must not be mutated.
+func (qp *QuotaPool) ApproximateQuota(f func(Resource)) {
+	qp.mu.Lock()
+	defer qp.mu.Unlock()
+	select {
+	case q := <-qp.quota:
+		f(q)
+		qp.quota <- q
+	default:
+		f(nil)
+	}
+}
+
+// Close signals to all ongoing and subsequent acquisitions that they are
+// free to return to their callers. They will receive an *ErrClosed which
+// contains this reason.
+//
+// Safe for concurrent use.
+func (qp *QuotaPool) Close(reason string) {
+	qp.mu.Lock()
+	defer qp.mu.Unlock()
+	if qp.closeErr == nil {
+		qp.mu.closed = true
+		qp.closeErr = &ErrClosed{
+			poolName: qp.name,
+			reason:   reason,
+		}
+		close(qp.done)
+	}
+}


### PR DESCRIPTION
This commit takes that existed storage/quota_pool.go and generalized it to
enable more implementations of quota pools with different logic for how
acquisition decisions are made. It then implements the interface as currently
used by the storage package to control the rate of outgoing proposals.

The bulk of the complexity comes from the usual challenge when abstracting
data structures in go, reducing allocations due to boxing in interfaces.

Release note: None