### PR TITLE
workload: use IMPORT then BACKUP in 'fixtures make'

### DIFF
--- a/pkg/ccl/workloadccl/cliccl/fixtures.go
+++ b/pkg/ccl/workloadccl/cliccl/fixtures.go
@@ -67,7 +67,7 @@ var fixturesListCmd = workloadcli.SetCmdDefaults(&cobra.Command{
 })
 var fixturesMakeCmd = workloadcli.SetCmdDefaults(&cobra.Command{
 	Use:   `make`,
-	Short: `regenerate and store a fixture on GCS`,
+	Short: `IMPORT a fixture and then store a BACKUP of it on GCS`,
 })
 var fixturesLoadCmd = workloadcli.SetCmdDefaults(&cobra.Command{
 	Use:   `load`,


### PR DESCRIPTION
Previously we used the 'transform' option on IMPORT.

However that option will soon go away as IMPORT is increasingly focused on ingestion.
Making fixtures should hopefully be rare enough that we can do a little extra work here
rather than maintain the special 'transform' mode.

Release note: none.