### PR TITLE
release-2.0: storage: Add a retry loop in replicate_queue removal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,6 +317,7 @@ endif
 # to a target.
 YARN_INSTALLED_TARGET := $(UI_ROOT)/yarn.installed
 
+
 .SECONDARY: $(YARN_INSTALLED_TARGET)
 $(YARN_INSTALLED_TARGET): $(UI_ROOT)/package.json $(UI_ROOT)/yarn.lock
 	$(NODE_RUN) -C $(UI_ROOT) yarn install

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -21,9 +21,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/coreos/etcd/raft"
-	"github.com/pkg/errors"
-
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -32,6 +30,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/coreos/etcd/raft"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -333,17 +333,65 @@ func (rq *replicateQueue) processOneChange(
 		}
 	case AllocatorRemove:
 		log.VEventf(ctx, 1, "removing a replica")
-		lastReplAdded, lastAddedTime := repl.LastReplicaAdded()
-		if timeutil.Since(lastAddedTime) > newReplicaGracePeriod {
-			lastReplAdded = 0
+
+		// This retry loop involves quick operations on local state, so a
+		// small MaxBackoff is good (but those local variables change on
+		// network time scales as raft receives responses).
+		//
+		// TODO(bdarnell): There's another retry loop at process(). It
+		// would be nice to combine these, but I'm keeping them separate
+		// for now so we can tune the options separately.
+		retryOpts := retry.Options{
+			InitialBackoff: time.Millisecond,
+			MaxBackoff:     200 * time.Millisecond,
+			Multiplier:     2,
 		}
-		candidates := filterUnremovableReplicas(repl.RaftStatus(), desc.Replicas, lastReplAdded)
-		log.VEventf(ctx, 3, "filtered unremovable replicas from %v to get %v as candidates for removal",
-			desc.Replicas, candidates)
+
+		var candidates []roachpb.ReplicaDescriptor
+		deadline := timeutil.Now().Add(2 * base.NetworkTimeout)
+		for r := retry.StartWithCtx(ctx, retryOpts); r.Next() && timeutil.Now().Before(deadline); {
+			lastReplAdded, lastAddedTime := repl.LastReplicaAdded()
+			if timeutil.Since(lastAddedTime) > newReplicaGracePeriod {
+				lastReplAdded = 0
+			}
+			raftStatus := repl.RaftStatus()
+			if raftStatus == nil || raftStatus.RaftState != raft.StateLeader {
+				// If we've lost raft leadership, we're unlikely to regain it so give up immediately.
+				return false, errors.Errorf("not raft leader while range needs removal")
+			}
+			candidates = filterUnremovableReplicas(raftStatus, desc.Replicas, lastReplAdded)
+			log.VEventf(ctx, 3, "filtered unremovable replicas from %v to get %v as candidates for removal: %s",
+				desc.Replicas, candidates, rangeRaftProgress(raftStatus, desc.Replicas))
+			if len(candidates) > 0 {
+				break
+			}
+			if len(raftStatus.Progress) <= 2 {
+				// HACK(bdarnell): Downreplicating to a single node from
+				// multiple nodes is not really supported. There are edge
+				// cases in which the two peers stop communicating with each
+				// other too soon and we don't reach a satisfactory
+				// resolution. However, some tests (notably
+				// TestRepartitioning) get into this state, and if the
+				// replication queue spends its entire timeout waiting for the
+				// downreplication to finish the test will time out. As a
+				// hack, just fail-fast when we're trying to go down to a
+				// single replica.
+				break
+			}
+			// After upreplication, the candidates for removal could still
+			// be catching up. The allocator determined that the range was
+			// over-replicated, and it's important to clear that state as
+			// quickly as we can (because over-replicated ranges may be
+			// under-diversified). If we return an error here, this range
+			// probably won't be processed again until the next scanner
+			// cycle, which is too long, so we retry here.
+		}
 		if len(candidates) == 0 {
+			// If we timed out and still don't have any valid candidates, give up.
 			return false, errors.Errorf("no removable replicas from range that needs a removal: %s",
 				rangeRaftProgress(repl.RaftStatus(), desc.Replicas))
 		}
+
 		removeReplica, details, err := rq.allocator.RemoveTarget(ctx, zone, candidates, rangeInfo, disableStatsBasedRebalancing)
 		if err != nil {
 			return false, err

--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -119,6 +119,7 @@
     "yarn": ">=1.0.0"
   },
   "resolutions": {
-    "@types/react": "~15.0.39"
+    "@types/react": "~15.0.39",
+    "**/catharsis": "0.8.9"
   }
 }

--- a/pkg/ui/yarn.lock
+++ b/pkg/ui/yarn.lock
@@ -1327,6 +1327,13 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
+catharsis@0.8.9:
+  version "0.8.9"
+  resolved "https://registry.yarnpkg.com/catharsis/-/catharsis-0.8.9.tgz#98cc890ca652dd2ef0e70b37925310ff9e90fc8b"
+  integrity sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=
+  dependencies:
+    underscore-contrib "~0.3.0"
+
 center-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/center-align/-/center-align-0.1.3.tgz#aa0d32629b6ee972200411cbd4461c907bc2b7ad"
@@ -5980,6 +5987,18 @@ uid-number@^0.0.6:
 ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
+
+underscore-contrib@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/underscore-contrib/-/underscore-contrib-0.3.0.tgz#665b66c24783f8fa2b18c9f8cbb0e2c7d48c26c7"
+  integrity sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=
+  dependencies:
+    underscore "1.6.0"
+
+underscore@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
+  integrity sha1-izixDKze9jM3uLJOT/htRa6lKag=
 
 uniq@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Backport 1/1 commits from #36117.

/cc @cockroachdb/release

---

During rebalancing, we reach this point quickly after committing an
upreplication. The combination of the chagned quorum size and the
newly-added node means its common for filterUnremovableReplicas to
find no eligible candidates, which returns an error and gives up until
the next scanner cycle. This leaves ranges in a vulnerable state for
too long.

Greatly reduces the impact of #12768. In one test the portion of data
at risk was reduced from an estimated 11% to less than 1% (maybe much
lower; it was below the effective resolution of the test)

Release note (bug fix): Reduced risk of data unavailability during
AZ/region failure.