### PR TITLE
storage: deflake TestStoreRangeMergeRaftSnapshot

### DIFF
--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -57,6 +57,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"go.etcd.io/etcd/raft/raftpb"
 )
 
 func adminMergeArgs(key roachpb.Key) *roachpb.AdminMergeRequest {
@@ -3088,7 +3089,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 	}
 
 	// Truncate the logs of the LHS.
-	{
+	index := func() uint64 {
 		repl := store0.LookupReplica(roachpb.RKey("a"))
 		index, err := repl.GetLastIndex()
 		if err != nil {
@@ -3104,12 +3105,27 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 		if _, err := client.SendWrapped(ctx, mtc.distSenders[0], truncArgs); err != nil {
 			t.Fatal(err)
 		}
-	}
+		return index
+	}()
 
 	beforeRaftSnaps := store2.Metrics().RangeSnapshotsNormalApplied.Count()
 
 	// Restore Raft traffic to the LHS on store2.
-	mtc.transport.Listen(store2.Ident.StoreID, store2)
+	mtc.transport.Listen(store2.Ident.StoreID, &unreliableRaftHandler{
+		rangeID:            aRepl0.RangeID,
+		RaftMessageHandler: store2,
+		dropReq: func(req *storage.RaftMessageRequest) bool {
+			// Make sure that even going forward no MsgApp for what we just
+			// truncated can make it through. The Raft transport is asynchronous
+			// so this is necessary to make the test pass reliably - otherwise
+			// the follower on store2 may catch up without needing a snapshot,
+			// tripping up the test.
+			//
+			// NB: the Index on the message is the log index that _precedes_ any of the
+			// entries in the MsgApp, so filter where msg.Index < index, not <= index.
+			return req.Message.Type == raftpb.MsgApp && req.Message.Index < index
+		},
+	})
 
 	// Wait for all replicas to catch up to the same point. Because we truncated
 	// the log while store2 was unavailable, this will require a Raft snapshot.


### PR DESCRIPTION
Make sure Raft messages we wanted to be dropped are 100% dropped,
or the follower we were expecting to get a snapshot would get by
without one, confusing the test.

Note that this hasn't failed since roughly Christmas 2018, but
the bug is there (we've fixed similar ones in different places,
which is where I copied the snippet from). Might as well prevent
this from becoming an issue again in the future.

Closes #33006.

Release note: None