### PR TITLE
tree: support casting empty arrays to array types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -1275,3 +1275,8 @@ a  b
 
 statement ok
 DROP TABLE array_single_family
+
+query TT
+SELECT ARRAY[]::int[], ARRAY[]:::int[]
+----
+{}  {}

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -90,6 +90,8 @@ func TestTypeCheck(t *testing.T) {
 		{`ARRAY[NULL]`, `ARRAY[NULL]`},
 		{`ARRAY[NULL]:::int[]`, `ARRAY[NULL]`},
 		{`ARRAY[NULL, NULL]:::int[]`, `ARRAY[NULL, NULL]`},
+		{`ARRAY[]::INT8[]`, `ARRAY[]::INT8[]`},
+		{`ARRAY[]:::INT8[]`, `ARRAY[]`},
 		{`1 = ANY ARRAY[1.5, 2.5, 3.5]`, `1:::DECIMAL = ANY ARRAY[1.5:::DECIMAL, 2.5:::DECIMAL, 3.5:::DECIMAL]`},
 		{`true = SOME (ARRAY[true, false])`, `true = SOME ARRAY[true, false]`},
 		{`1.3 = ALL ARRAY[1, 2, 3]`, `1.3:::DECIMAL = ALL ARRAY[1:::DECIMAL, 2:::DECIMAL, 3:::DECIMAL]`},


### PR DESCRIPTION
Previously, empty arrays couldn't be cast to array types - you'd have to
use the type annotation syntax.

Now, this limitation is lifted.

Closes #18420.

Release note (sql change): permit casting empty arrays to any array
type.