### PR TITLE
exec: handle nulls in projection operators

### DIFF
--- a/pkg/sql/exec/coldata/nulls.go
+++ b/pkg/sql/exec/coldata/nulls.go
@@ -257,3 +257,13 @@ func (n *Nulls) Or(n2 *Nulls) *Nulls {
 		nulls:    nulls,
 	}
 }
+
+// Copy returns a copy of n which can be modified independently.
+func (n *Nulls) Copy() Nulls {
+	c := Nulls{
+		hasNulls: n.hasNulls,
+		nulls:    make([]uint64, len(n.nulls)),
+	}
+	copy(c.nulls, n.nulls)
+	return c
+}

--- a/pkg/sql/exec/coldata/vec.go
+++ b/pkg/sql/exec/coldata/vec.go
@@ -106,6 +106,9 @@ type Vec interface {
 
 	// Nulls returns the nulls vector for the column.
 	Nulls() *Nulls
+
+	// SetNulls sets the nulls vector for this column.
+	SetNulls(*Nulls)
 }
 
 var _ Vec = &memColumn{}
@@ -204,4 +207,8 @@ func (m *memColumn) HasNulls() bool {
 
 func (m *memColumn) Nulls() *Nulls {
 	return &m.nulls
+}
+
+func (m *memColumn) SetNulls(n *Nulls) {
+	m.nulls = *n
 }

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -96,6 +96,23 @@ SELECT b + 1 FROM a WHERE b < 3
 2
 3
 
+# Simple projection with nulls.
+query I rowsort
+SELECT b + 1 FROM nulls
+----
+NULL
+NULL
+2
+2
+
+query III rowsort
+SELECT a, b, a + b FROM nulls
+----
+NULL NULL NULL
+NULL 1    NULL
+1    NULL NULL
+1    1    2
+
 # Multiple step projection.
 query III
 SELECT a, b, (a + 1) * (b + 2) FROM a WHERE a < 3


### PR DESCRIPTION
Unlike in selections, there is essentially no performance penalty to
nulls in projections because the null vector can be set directly based
on the input nulls.

Fixes #36931

Release note: None