### PR TITLE
sql: don't exclude unvalidated check constraints

### DIFF
--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -589,11 +589,15 @@ func (desc *TableDescriptor) AllNonDropIndexes() []*IndexDescriptor {
 // "active" ones on the table descriptor which are being enforced for all
 // writes, and "inactive" ones queued in the mutations list.
 func (desc *TableDescriptor) AllActiveAndInactiveChecks() []*TableDescriptor_CheckConstraint {
-	// For now, a check constraint is either in the mutations list or Validated.
-	// If it shows up twice after combining those two slices, it's a duplicate.
+	// A check constraint could be both on the table descriptor and in the
+	// list of mutations while the constraint is validated for existing rows. In
+	// that case, the constraint is in the Validating state, and we avoid
+	// including it twice. (Note that even though unvalidated check constraints
+	// cannot be added as of 19.1, they can still exist if they were created under
+	// previous versions.)
 	checks := make([]*TableDescriptor_CheckConstraint, 0, len(desc.Checks)+len(desc.Mutations))
 	for _, c := range desc.Checks {
-		if c.Validity == ConstraintValidity_Validated {
+		if c.Validity != ConstraintValidity_Validating {
 			checks = append(checks, c)
 		}
 	}


### PR DESCRIPTION
Previously, as of 19.1, AllActiveAndInactiveChecks(), which gets check
constraints for ALTER TABLE as well as SHOW CONSTRAINT, etc., excluded
unvalidated checks on the table descriptor, under the assumption that all
checks would be validated once they'd been added to the table descriptor. This
was to avoid double-counting constraints that were both on the table descriptor
and in the list of mutations. This caused unvalidated checks added in earlier
versions to disappear (though they are still on the table descriptor itself,
and are still enforced for writes). This PR fixes the issue by only excluding
`Validating` checks on the table descriptor to avoid double-counting.

Fixes #37285.

Release note (bug fix): Fixes bug where unvalidated check constraints disappear
from the output of SHOW CONSTRAINT and cannot be referenced in ALTER TABLE
after upgrading to 19.1.