### PR TITLE
sql: Add crdb_internal.locality_value builtin function

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -971,6 +971,8 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 </span></td></tr>
 <tr><td><code>crdb_internal.lease_holder(key: <a href="bytes.html">bytes</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used to fetch the leaseholder corresponding to a request key</p>
 </span></td></tr>
+<tr><td><code>crdb_internal.locality_value(key: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the value of the specified locality key.</p>
+</span></td></tr>
 <tr><td><code>crdb_internal.no_constant_folding(input: anyelement) &rarr; anyelement</code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
 </span></td></tr>
 <tr><td><code>crdb_internal.node_executable_version() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the version of CockroachDB this node is running.</p>

--- a/pkg/sql/logictest/testdata/logic_test/locality
+++ b/pkg/sql/logictest/testdata/logic_test/locality
@@ -1,0 +1,16 @@
+# LogicTest: 5node-dist 5node-dist-opt
+
+query T
+SELECT crdb_internal.locality_value('region')
+----
+test
+
+query T
+SELECT crdb_internal.locality_value('dc')
+----
+dc1
+
+query T
+SELECT crdb_internal.locality_value('unk')
+----
+NULL

--- a/pkg/sql/opt/norm/fold_constants.go
+++ b/pkg/sql/opt/norm/fold_constants.go
@@ -461,4 +461,5 @@ var FoldFunctionWhitelist = map[string]struct{}{
 	"jsonb_strip_nulls":             {},
 	"json_array_length":             {},
 	"jsonb_array_length":            {},
+	"crdb_internal.locality_value":  {},
 }

--- a/pkg/sql/opt/norm/norm_test.go
+++ b/pkg/sql/opt/norm/norm_test.go
@@ -113,7 +113,13 @@ func TestRuleFunctionAssumption(t *testing.T) {
 			t.Errorf("%s should not be folded because it is impure", name)
 		}
 		if props.Category == categorySystemInfo || props.Category == categoryDateAndTime {
-			t.Errorf("%s should not be folded because it has category %s", name, props.Category)
+			switch name {
+			case "crdb_internal.locality_value":
+				// OK to fold this function.
+
+			default:
+				t.Errorf("%s should not be folded because it has category %s", name, props.Category)
+			}
 		}
 	}
 }

--- a/pkg/sql/opt/norm/testdata/rules/fold_constants
+++ b/pkg/sql/opt/norm/testdata/rules/fold_constants
@@ -742,6 +742,26 @@ values
  ├── fd: ()-->(1,2)
  └── ('616263', '\x616263') [type=tuple{string, bytes}]
 
+opt expect=FoldFunction locality=(region=east,dc=east1-b)
+SELECT crdb_internal.locality_value('dc')
+----
+values
+ ├── columns: crdb_internal.locality_value:1(string)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── ('east1-b',) [type=tuple{string}]
+
+opt expect=FoldFunction
+SELECT crdb_internal.locality_value('unk')
+----
+values
+ ├── columns: crdb_internal.locality_value:1(string)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (NULL,) [type=tuple{string}]
+
 opt expect-not=FoldFunction
 SELECT now(), current_user(), current_database()
 ----

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2756,6 +2756,25 @@ may increase either contention or retry errors, or both.`,
 		},
 	),
 
+	"crdb_internal.locality_value": makeBuiltin(
+		tree.FunctionProperties{Category: categorySystemInfo},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"key", types.String}},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				key := string(*(args[0].(*tree.DString)))
+				for i := range ctx.Locality.Tiers {
+					tier := &ctx.Locality.Tiers[i]
+					if tier.Key == key {
+						return tree.NewDString(tier.Value), nil
+					}
+				}
+				return tree.DNull, nil
+			},
+			Info: "Returns the value of the specified locality key.",
+		},
+	),
+
 	"crdb_internal.node_executable_version": makeBuiltin(
 		tree.FunctionProperties{Category: categorySystemInfo},
 		tree.Overload{


### PR DESCRIPTION
There is currently no easy way to programmatically inspect the locality of the
current node. It appears in crdb_internal.gossip_nodes, but it's hard to work
with because it's JSON, not constant-foldable, and keyed by node id.

This commit adds a new crdb_internal.locality_value builtin function that returns
the value of the locality key given as its argument.

When building geo-distributed applications, this enables a very nice way to
automatically assign the partition key, as illustrated below:

  CREATE TABLE charges (
    region STRING NOT NULL DEFAULT crdb_internal.locality_value('region'),
    id UUID NOT NULL DEFAULT gen_random_uuid(),
    ...

The DEFAULT expression for the region column automatically inserts the region
value from the current node's locality.

It also enables queries like this, that only touch rows in the current region
(which is necessary to avoid cross-region hops):

  SELECT * FROM charges WHERE region = crdb_internal.locality_value('region') AND id = $1

The optimizer folds the function to a constant value, which can then be used
to select an optimal index.

Resolves #37310

Release note (sql change): Adds a new locality_value builtin function that
returns the value of the locality key given as its argument.