### PR TITLE
coldata,workload/tpcc: more allocation savings

### DIFF
--- a/pkg/sql/exec/coldata/batch.go
+++ b/pkg/sql/exec/coldata/batch.go
@@ -137,8 +137,12 @@ func (m *MemBatch) AppendCol(t types.T) {
 
 // Reset implements the Batch interface.
 func (m *MemBatch) Reset(types []types.T, length int) {
-	// TODO(dan): Reset could be more aggressive about finding columns to reuse.
-	if m == nil || int(m.Length()) != length || m.Width() != len(types) {
+	// The columns are always sized the same as the selection vector, so use it as
+	// a shortcut for the capacity (like a go slice, the batch's `Length` could be
+	// shorter than the capacity). We could be more defensive and type switch
+	// every column to verify its capacity, but that doesn't seem necessary yet.
+	hasColCapacity := len(m.sel) >= length
+	if m == nil || !hasColCapacity || m.Width() != len(types) {
 		*m = *NewMemBatchWithSize(types, length).(*MemBatch)
 		m.SetLength(uint16(length))
 		return

--- a/pkg/util/uuid/uuid.go
+++ b/pkg/util/uuid/uuid.go
@@ -114,7 +114,14 @@ func (u UUID) bytes() []byte {
 // xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
 func (u UUID) String() string {
 	buf := make([]byte, 36)
+	u.StringBytes(buf)
+	return string(buf)
+}
 
+// StringBytes writes the result of String directly into a buffer, which must
+// have a length of at least 36.
+func (u UUID) StringBytes(buf []byte) {
+	_ = buf[:36]
 	hex.Encode(buf[0:8], u[0:4])
 	buf[8] = '-'
 	hex.Encode(buf[9:13], u[4:6])
@@ -124,8 +131,6 @@ func (u UUID) String() string {
 	hex.Encode(buf[19:23], u[8:10])
 	buf[23] = '-'
 	hex.Encode(buf[24:], u[10:])
-
-	return string(buf)
 }
 
 // SetVersion sets the version bits.

--- a/pkg/workload/tpcc/order_status.go
+++ b/pkg/workload/tpcc/order_status.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach-go/crdb"
+	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/jackc/pgx/pgtype"
@@ -68,6 +69,8 @@ type orderStatus struct {
 	selectByLastName workload.StmtHandle
 	selectOrder      workload.StmtHandle
 	selectItems      workload.StmtHandle
+
+	a bufalloc.ByteAllocator
 }
 
 var _ tpccTx = &orderStatus{}
@@ -136,7 +139,7 @@ func (o *orderStatus) run(ctx context.Context, wID int) (interface{}, error) {
 	// 2.6.1.2: The customer is randomly selected 60% of the time by last name
 	// and 40% by number.
 	if rng.Intn(100) < 60 {
-		d.cLast = string(randCLast(rng))
+		d.cLast = string(randCLast(rng, &o.a))
 		atomic.AddUint64(&o.config.auditor.orderStatusByLastName, 1)
 	} else {
 		d.cID = randCustomerID(rng)


### PR DESCRIPTION
Okay, this is all I have for now. See the individual commits for details. Note that we can now generate the ~80MiB dataset for one tpcc warehouse using less than 1MB of allocations, which is pretty cool.

```
name                             old time/op    new time/op    delta
InitialData/tpcc/warehouses=1-8     481ms ± 4%     388ms ± 1%  -19.38%  (p=0.000 n=5+14)

name                             old speed      new speed      delta
InitialData/tpcc/warehouses=1-8   198MB/s ± 4%   284MB/s ± 1%  +43.74%  (p=0.000 n=5+14)

name                             old alloc/op   new alloc/op   delta
InitialData/tpcc/warehouses=1-8    74.6MB ± 0%     0.9MB ± 0%  -98.78%  (p=0.000 n=4+13)

name                             old allocs/op  new allocs/op  delta
InitialData/tpcc/warehouses=1-8     1.48M ± 0%     0.06M ± 0%  -95.91%  (p=0.000 n=5+15)
```

Touches #34809