### PR TITLE
importccl: add a benchmark for converting data to sstables

### DIFF
--- a/pkg/storage/bulk/buffering_adder.go
+++ b/pkg/storage/bulk/buffering_adder.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"sort"
 
-	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
@@ -50,7 +49,7 @@ type BufferingAdder struct {
 // MakeBulkAdder makes a storagebase.BulkAdder that buffers and sorts K/Vs passed
 // to add into SSTs that are then ingested.
 func MakeBulkAdder(
-	db *client.DB,
+	db sender,
 	rangeCache *kv.RangeDescriptorCache,
 	flushBytes, sstBytes int64,
 	timestamp hlc.Timestamp,

--- a/pkg/storage/bulk/sst_batcher.go
+++ b/pkg/storage/bulk/sst_batcher.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -42,7 +41,7 @@ func (b sz) String() string {
 // it to attempt to flush SSTs before they cross range boundaries to minimize
 // expensive on-split retries.
 type SSTBatcher struct {
-	db *client.DB
+	db sender
 
 	flushKeyChecked bool
 	flushKey        roachpb.Key
@@ -68,7 +67,7 @@ type SSTBatcher struct {
 }
 
 // MakeSSTBatcher makes a ready-to-use SSTBatcher.
-func MakeSSTBatcher(ctx context.Context, db *client.DB, flushBytes int64) (*SSTBatcher, error) {
+func MakeSSTBatcher(ctx context.Context, db sender, flushBytes int64) (*SSTBatcher, error) {
 	b := &SSTBatcher{db: db, maxSize: flushBytes}
 	err := b.Reset()
 	return b, err


### PR DESCRIPTION
Benchmark results for generating ~80 MiB of sstables:

    name                                  time/op
    ConvertToSSTable/tpcc/warehouses=1-8     5.28s ± 1%

    name                                  speed
    ConvertToSSTable/tpcc/warehouses=1-8  15.9MB/s ± 1%

    name                                  alloc/op
    ConvertToSSTable/tpcc/warehouses=1-8    1.71GB ± 0%

    name                                  allocs/op
    ConvertToSSTable/tpcc/warehouses=1-8     18.8M ± 0%

Touches #34809

Release note: None