### PR TITLE
release-19.1: sql: fix interpretation of 0-ndims array in pgwire

### DIFF
--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -953,6 +953,9 @@ func TestPGPreparedQuery(t *testing.T) {
 		{"SELECT $1::INT[]", []preparedQueryTest{
 			baseTest.SetArgs(pq.Array([]int64{10})).Results(pq.Array([]int64{10})),
 		}},
+		{"INSERT INTO d.arr VALUES($1, $2)", []preparedQueryTest{
+			baseTest.SetArgs(pq.Array([]int64{}), pq.Array([]string{})),
+		}},
 		{"EXPERIMENTAL SCRUB TABLE system.locations", []preparedQueryTest{
 			baseTest.SetArgs(),
 		}},
@@ -1081,6 +1084,7 @@ CREATE TABLE d.ts (a TIMESTAMP, b DATE);
 CREATE TABLE d.two (a INT, b INT);
 CREATE TABLE d.intStr (a INT, s STRING);
 CREATE TABLE d.str (s STRING, b BYTES);
+CREATE TABLE d.arr (a INT[], b TEXT[]);
 CREATE TABLE d.emptynorows (); -- zero columns, zero rows
 CREATE TABLE d.emptyrows (x INT);
 INSERT INTO d.emptyrows VALUES (1),(2),(3);

--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -189,6 +189,25 @@ func NewProtocolViolationErrorf(format string, args ...interface{}) error {
 	return pgerror.NewErrorf(pgerror.CodeProtocolViolationError, format, args...)
 }
 
+// validateArrayDimensions takes the number of dimensions and elements and
+// returns an error if we don't support that combination.
+func validateArrayDimensions(nDimensions int, nElements int) error {
+	switch nDimensions {
+	case 1:
+		break
+	case 0:
+		// 0-dimensional array means 0-length array: validate that.
+		if nElements == 0 {
+			break
+		}
+		fallthrough
+	default:
+		return pgerror.UnimplementedWithIssueErrorf(32552,
+			"%d-dimension arrays not supported; only 1-dimension", nDimensions)
+	}
+	return nil
+}
+
 // DecodeOidDatum decodes bytes with specified Oid and format code into
 // a datum. If the ParseTimeContext is nil, reasonable defaults
 // will be applied.
@@ -291,8 +310,8 @@ func DecodeOidDatum(
 			if arr.Status != pgtype.Present {
 				return tree.DNull, nil
 			}
-			if len(arr.Dimensions) != 1 {
-				return nil, errors.Errorf("only 1-dimension arrays supported")
+			if err := validateArrayDimensions(len(arr.Dimensions), len(arr.Elements)); err != nil {
+				return nil, err
 			}
 			out := tree.NewDArray(types.Int)
 			var d tree.Datum
@@ -315,8 +334,8 @@ func DecodeOidDatum(
 			if arr.Status != pgtype.Present {
 				return tree.DNull, nil
 			}
-			if len(arr.Dimensions) != 1 {
-				return nil, errors.Errorf("only 1-dimension arrays supported")
+			if err := validateArrayDimensions(len(arr.Dimensions), len(arr.Elements)); err != nil {
+				return nil, err
 			}
 			out := tree.NewDArray(types.String)
 			if id == oid.T__name {
@@ -687,9 +706,8 @@ func decodeBinaryArray(ctx tree.ParseTimeContext, b []byte, code FormatCode) (tr
 	if err := binary.Read(r, binary.BigEndian, &hdr); err != nil {
 		return nil, err
 	}
-	// Only 1-dimensional arrays are supported for now.
-	if hdr.Ndims != 1 {
-		return nil, errors.Errorf("unsupported number of array dimensions: %d", hdr.Ndims)
+	if err := validateArrayDimensions(int(hdr.Ndims), int(hdr.DimSize)); err != nil {
+		return nil, err
 	}
 
 	elemOid := oid.Oid(hdr.ElemOid)


### PR DESCRIPTION
Backport 1/1 commits from #37376.

/cc @cockroachdb/release

---

An array of 0 dimensions is an empty array. Previously, we were
validating that arrays sent over pgwire always had dimension 1, which
prevents empty arrays from being accepted over pgwire. Now, we accept
empty arrays as expected, after validating that arrays with 0 dimensions
also have 0 elements.

Fixes #37365.

Release note (sql change): fix regression in 19.1 that prevented empty
arrays from being accepted over pgwire.
