### PR TITLE
storage: deflake TestStoreRangeMergeRaftSnapshot

### DIFF
--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -3135,6 +3135,9 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 			// entries in the MsgApp, so filter where msg.Index < index, not <= index.
 			return req.Message.Type == raftpb.MsgApp && req.Message.Index < index
 		},
+		// Don't drop heartbeats or responses.
+		dropHB:   func(*storage.RaftHeartbeat) bool { return false },
+		dropResp: func(*storage.RaftMessageResponse) bool { return false },
 	})
 
 	// Wait for all replicas to catch up to the same point. Because we truncated


### PR DESCRIPTION
The "restored" Raft handler was still dropping heartbeats and responses.

Closes #33006.

Release note: None