### PR TITLE
workload: fix --splits regression introduced in #35349

### DIFF
--- a/pkg/workload/csv.go
+++ b/pkg/workload/csv.go
@@ -150,6 +150,7 @@ func colDatumToCSVString(col coldata.Vec, rowIdx int) string {
 	case types.Float64:
 		return strconv.FormatFloat(col.Float64()[rowIdx], 'f', -1, 64)
 	case types.Bytes:
+		// See the HACK comment in ColBatchToRows.
 		bytes := col.Bytes()[rowIdx]
 		return *(*string)(unsafe.Pointer(&bytes))
 	}


### PR DESCRIPTION
workload's Table schemas are SQL schemas, but #35349 switched the
initial data to be returned as a coldata.Batch, which has a more limited
set of types. (Or, in the case of simple workloads that return a
[]interface{}, it's roundtripped through coldata.Batch by the `Tuples`
helper.) Notably, this means a SQL STRING column is represented the same
as a BYTES column (ditto UUID, etc).

This caused a regression in splits, which received some []byte data for
a column tried to hand it to SPLIT as a SQL BYTES datum. This didn't
work for the UUID column in tpcc's history table nor the VARCHAR in
ycsb's usertable. Happily, a STRING works for both of these. It also
seems to work for BYTES columns, so it seems like the ambiguity is fine
in this case. When/if someone wants to add a workload that splits a
BYTES primary key column containing non-utf8 data, we'll may need to
revisit.

A more principled fix would be to get the fidelity back by parsing the
SQL schema, which in fact we do in `importccl.makeDatumFromColOffset`.
However, at the moment, this hack works and avoids the complexity and
the undesirable pkg/sql/parser dep.

Closes #37383
Closes #37382
Closes #37381
Closes #37380
Closes #37379
Closes #37378
Closes #37377
Closes #37393

Release note: None