### PR TITLE
exec: fix nulls for composite index columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -311,3 +311,27 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJy8kkFr4zAQhe_7K8ycdlm1sZ
 
 statement ok
 RESET optimizer; RESET experimental_vectorize; RESET distsql
+
+# Regression test for composite null handling
+# https://github.com/cockroachdb/cockroach/issues/37358
+statement ok
+CREATE TABLE composite (d DECIMAL, INDEX d_idx (d))
+
+statement ok
+INSERT INTO composite VALUES (NULL), (1), (1.0), (1.00)
+
+query T rowsort
+SELECT d FROM composite@primary
+----
+NULL
+1
+1.0
+1.00
+
+query T rowsort
+SELECT d FROM composite@d_idx
+----
+NULL
+1
+1.0
+1.00


### PR DESCRIPTION
For composite columns in secondary indexes, cfetcher was sometimes
incorrectly marking values as null. This happened for columns in the
index key which did not have value encodings. Since we already check for
nulls when decoding the index key, I added logic to ignore key columns
in the `fillNulls` step.

Fixes #37358

Release note: None