### PR TITLE
roachtest: make TPCC import test call import instead of make, use htt…

### DIFF
--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -25,10 +25,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const (
-	gcsTestBucket = `cockroach-tmp`
-)
-
 func registerImportTPCC(r *registry) {
 	runImportTPCC := func(ctx context.Context, t *test, c *cluster, warehouses int) {
 		c.Put(ctx, cockroach, "./cockroach")
@@ -48,9 +44,8 @@ func registerImportTPCC(r *registry) {
 			defer dul.Done()
 			defer hc.Done()
 			cmd := fmt.Sprintf(
-				`./workload fixtures make tpcc --warehouses=%d --csv-server='http://localhost:8081' `+
-					`--gcs-bucket-override=%s --gcs-prefix-override=%s`,
-				warehouses, gcsTestBucket, c.name)
+				`./workload fixtures import tpcc --warehouses=%d --csv-server='http://localhost:8081'`,
+				warehouses)
 			c.Run(ctx, c.Node(1), cmd)
 			return nil
 		})


### PR DESCRIPTION
…p server

The import test was using 'fixtures make' rather than 'fixtures import'. A recent change in 'fixtures make' caused it to assume it
had in-process workload data generation and thus broke the test when run against older versions of cockroach.

Using 'fixtures import' rather than 'make' is a better test of 'IMPORT' anyway, and by using the HTTP server flag,
can avoid requiring in-progress data-generation.

Release note: none