### PR TITLE
roachprod: verbose sshd logging

### DIFF
--- a/pkg/cmd/roachprod/vm/aws/support.go
+++ b/pkg/cmd/roachprod/vm/aws/support.go
@@ -94,6 +94,9 @@ sudo service sshguard stop
 # By default, only 10 unauthenticated connections are permitted before sshd
 # starts randomly dropping connections.
 sudo sh -c 'echo "MaxStartups 64:30:128" >> /etc/ssh/sshd_config'
+# Crank up the logging for issues such as:
+# https://github.com/cockroachdb/cockroach/issues/36929
+sudo sed -i'' 's/LogLevel.*$/LogLevel DEBUG/' /etc/ssh/sshd_config
 sudo service sshd restart
 # increase the default maximum number of open file descriptors for
 # root and non-root users. Load generators running a lot of concurrent

--- a/pkg/cmd/roachprod/vm/gce/utils.go
+++ b/pkg/cmd/roachprod/vm/gce/utils.go
@@ -82,6 +82,9 @@ sudo service sshguard stop
 # By default, only 10 unauthenticated connections are permitted before sshd
 # starts randomly dropping connections.
 sudo sh -c 'echo "MaxStartups 64:30:128" >> /etc/ssh/sshd_config'
+# Crank up the logging for issues such as:
+# https://github.com/cockroachdb/cockroach/issues/36929
+sudo sed -i'' 's/LogLevel.*$/LogLevel DEBUG/' /etc/ssh/sshd_config
 sudo service sshd restart
 # increase the default maximum number of open file descriptors for
 # root and non-root users. Load generators running a lot of concurrent


### PR DESCRIPTION
See #36929. Whenever these flakes happen, it'll be good to have verbose
logs. Anecdotally we're seeing fewer of them now, perhaps due to #37001.

Release note: None