### PR TITLE
roachtest: ignore apt errors in jepsen

### DIFF
--- a/pkg/cmd/roachtest/jepsen.go
+++ b/pkg/cmd/roachtest/jepsen.go
@@ -99,7 +99,16 @@ func initJepsen(ctx context.Context, t *test, c *cluster) {
 	c.Run(ctx, c.All(), "tar --transform s,^,cockroach/, -c -z -f cockroach.tgz cockroach")
 
 	// Install Jepsen's prereqs on the controller.
-	c.Run(ctx, controller, "sh", "-c", `"sudo apt-get -qqy install openjdk-8-jre openjdk-8-jre-headless libjna-java gnuplot > /dev/null 2>&1"`)
+	if out, err := c.RunWithBuffer(
+		ctx, t.l, controller, "sh", "-c",
+		`"sudo apt-get -qqy install openjdk-8-jre openjdk-8-jre-headless libjna-java gnuplot > /dev/null 2>&1"`,
+	); err != nil {
+		if strings.Contains(string(out), "exit status 100") {
+			t.Skip("apt-get failure (#31944)", string(out))
+		}
+		t.Fatal(err)
+	}
+
 	c.Run(ctx, controller, "test -x lein || (curl -o lein https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && chmod +x lein)")
 
 	// SSH setup: create a key on the controller.
@@ -245,9 +254,10 @@ cd /mnt/data1/jepsen/cockroachdb && set -eo pipefail && \
 		if err := ioutil.WriteFile(filepath.Join(outputDir, "failure-logs.tbz"), output, 0666); err != nil {
 			t.Fatal(err)
 		}
-		if !ignoreErr {
-			t.Fatal(testErr)
+		if ignoreErr {
+			t.Skip("recognized known error", testErr.Error())
 		}
+		t.Fatal(testErr)
 	} else {
 		collectFiles := []string{
 			"test.fressian", "results.edn", "latency-quantiles.png", "latency-raw.png", "rate.png",


### PR DESCRIPTION
Jepsen setup sometimes gets an exit code 100 from apt-get. This patch
skips the test instead of failing when that happens.
apt problems are tracked in #31944

Fixes #37375

Release note: None