### PR TITLE
roachprod: fix roachprod start when spanning VPCs

### DIFF
--- a/pkg/cmd/roachprod/install/cockroach.go
+++ b/pkg/cmd/roachprod/install/cockroach.go
@@ -346,7 +346,7 @@ tar cvf certs.tar certs
 			args = append(args, fmt.Sprintf("--join=%s:%d", host1, r.NodePort(c, 1)))
 		}
 		if advertisePublicIP {
-			args = append(args, fmt.Sprintf("--advertise-host=%s", c.host(i)))
+			args = append(args, fmt.Sprintf("--advertise-host=%s", c.host(i+1)))
 		}
 
 		var keyCmd string


### PR DESCRIPTION
The variable `i` is 0-indexed but `c.host` expects a 1-indexed arg.
This was crashing the process before the change.

Release note: None