### PR TITLE
server: remove global defaultZoneConfig

### DIFF
--- a/pkg/ccl/partitionccl/zone_test.go
+++ b/pkg/ccl/partitionccl/zone_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -43,9 +44,9 @@ func TestValidIndexPartitionSetShowZones(t *testing.T) {
 			PARTITION p1 VALUES IN (DEFAULT)
 		)`)
 
-	yamlDefault := fmt.Sprintf("gc: {ttlseconds: %d}", config.DefaultZoneConfig().GC.TTLSeconds)
+	yamlDefault := fmt.Sprintf("gc: {ttlseconds: %d}", s.(*server.TestServer).Cfg.DefaultZoneConfig.GC.TTLSeconds)
 	yamlOverride := "gc: {ttlseconds: 42}"
-	zoneOverride := config.DefaultZoneConfig()
+	zoneOverride := s.(*server.TestServer).Cfg.DefaultZoneConfig
 	zoneOverride.GC = &config.GCPolicy{TTLSeconds: 42}
 	partialZoneOverride := *config.NewZoneConfig()
 	partialZoneOverride.GC = &config.GCPolicy{TTLSeconds: 42}
@@ -56,7 +57,7 @@ func TestValidIndexPartitionSetShowZones(t *testing.T) {
 	defaultRow := sqlutils.ZoneRow{
 		ID:           keys.RootNamespaceID,
 		CLISpecifier: ".default",
-		Config:       config.DefaultZoneConfig(),
+		Config:       s.(*server.TestServer).Cfg.DefaultZoneConfig,
 	}
 	defaultOverrideRow := sqlutils.ZoneRow{
 		ID:           keys.RootNamespaceID,

--- a/pkg/cmd/gossipsim/main.go
+++ b/pkg/cmd/gossipsim/main.go
@@ -67,6 +67,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/gossip/simulation"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -306,7 +307,7 @@ func main() {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
 
-	n := simulation.NewNetwork(stopper, nodeCount, true)
+	n := simulation.NewNetwork(stopper, nodeCount, true, config.DefaultZoneConfigRef())
 	n.SimulateNetwork(
 		func(cycle int, network *simulation.Network) bool {
 			// Output dot graph.

--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -71,7 +71,8 @@ type zoneEntry struct {
 // that should not be considered for splits.
 type SystemConfig struct {
 	SystemConfigEntries
-	mu struct {
+	DefaultZoneConfig *ZoneConfig
+	mu                struct {
 		syncutil.RWMutex
 		zoneCache        map[uint32]zoneEntry
 		shouldSplitCache map[uint32]bool

--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -80,8 +80,9 @@ type SystemConfig struct {
 }
 
 // NewSystemConfig returns an initialized instance of SystemConfig.
-func NewSystemConfig() *SystemConfig {
+func NewSystemConfig(defaultZoneConfig *ZoneConfig) *SystemConfig {
 	sc := &SystemConfig{}
+	sc.DefaultZoneConfig = defaultZoneConfig
 	sc.mu.zoneCache = map[uint32]zoneEntry{}
 	sc.mu.shouldSplitCache = map[uint32]bool{}
 	return sc
@@ -356,7 +357,7 @@ func (s *SystemConfig) getZoneConfigForKey(id uint32, keySuffix []byte) (*ZoneCo
 		}
 		return entry.zone, nil
 	}
-	return DefaultZoneConfigRef(), nil
+	return s.DefaultZoneConfig, nil
 }
 
 var staticSplits = []roachpb.RKey{

--- a/pkg/config/system_test.go
+++ b/pkg/config/system_test.go
@@ -110,7 +110,7 @@ func TestGet(t *testing.T) {
 		{someKeys, "d", &cVal},
 	}
 
-	cfg := config.NewSystemConfig()
+	cfg := config.NewSystemConfig(config.DefaultZoneConfigRef())
 	for tcNum, tc := range testCases {
 		cfg.Values = tc.values
 		if val := cfg.GetValue([]byte(tc.key)); !proto.Equal(val, tc.value) {
@@ -164,7 +164,7 @@ func TestGetLargestID(t *testing.T) {
 
 		// Real SQL layout.
 		func() testCase {
-			ms := sqlbase.MakeMetadataSchema()
+			ms := sqlbase.MakeMetadataSchema(config.DefaultZoneConfigRef(), config.DefaultSystemZoneConfigRef())
 			descIDs := ms.DescriptorIDs()
 			maxDescID := descIDs[len(descIDs)-1]
 			kvs, _ /* splits */ := ms.GetInitialValues()
@@ -188,7 +188,7 @@ func TestGetLargestID(t *testing.T) {
 		}, 5, 7, ""},
 	}
 
-	cfg := config.NewSystemConfig()
+	cfg := config.NewSystemConfig(config.DefaultZoneConfigRef())
 	for tcNum, tc := range testCases {
 		cfg.Values = tc.values
 		ret, err := cfg.GetLargestObjectID(tc.maxID)
@@ -259,8 +259,8 @@ func TestComputeSplitKeySystemRanges(t *testing.T) {
 		{roachpb.RKey(keys.TimeseriesPrefix.PrefixEnd()), roachpb.RKeyMax, keys.SystemConfigSplitKey},
 	}
 
-	cfg := config.NewSystemConfig()
-	kvs, _ /* splits */ := sqlbase.MakeMetadataSchema().GetInitialValues()
+	cfg := config.NewSystemConfig(config.DefaultZoneConfigRef())
+	kvs, _ /* splits */ := sqlbase.MakeMetadataSchema(cfg.DefaultZoneConfig, config.DefaultSystemZoneConfigRef()).GetInitialValues()
 	cfg.SystemConfigEntries = config.SystemConfigEntries{
 		Values: kvs,
 	}
@@ -290,7 +290,7 @@ func TestComputeSplitKeyTableIDs(t *testing.T) {
 	// separately above.
 	minKey := roachpb.RKey(keys.TimeseriesPrefix.PrefixEnd())
 
-	schema := sqlbase.MakeMetadataSchema()
+	schema := sqlbase.MakeMetadataSchema(config.DefaultZoneConfigRef(), config.DefaultSystemZoneConfigRef())
 	// Real system tables only.
 	baseSql, _ /* splits */ := schema.GetInitialValues()
 	// Real system tables plus some user stuff.
@@ -369,7 +369,7 @@ func TestComputeSplitKeyTableIDs(t *testing.T) {
 		{userSQL, tkey(start + 1), tkey(start + 5), nil},
 	}
 
-	cfg := config.NewSystemConfig()
+	cfg := config.NewSystemConfig(config.DefaultZoneConfigRef())
 	for tcNum, tc := range testCases {
 		cfg.Values = tc.values
 		splitKey := cfg.ComputeSplitKey(tc.start, tc.end)
@@ -420,9 +420,9 @@ func TestGetZoneConfigForKey(t *testing.T) {
 	defer func() {
 		config.ZoneConfigHook = originalZoneConfigHook
 	}()
-	cfg := config.NewSystemConfig()
+	cfg := config.NewSystemConfig(config.DefaultZoneConfigRef())
 
-	kvs, _ /* splits */ := sqlbase.MakeMetadataSchema().GetInitialValues()
+	kvs, _ /* splits */ := sqlbase.MakeMetadataSchema(cfg.DefaultZoneConfig, config.DefaultSystemZoneConfigRef()).GetInitialValues()
 	cfg.SystemConfigEntries = config.SystemConfigEntries{
 		Values: kvs,
 	}

--- a/pkg/gossip/client_test.go
+++ b/pkg/gossip/client_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip/resolver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
@@ -88,7 +89,7 @@ func startGossipAtAddr(
 	rpcContext.ClusterID.Reset(clusterID)
 
 	server := rpc.NewServer(rpcContext)
-	g := NewTest(nodeID, rpcContext, server, stopper, registry)
+	g := NewTest(nodeID, rpcContext, server, stopper, registry, config.DefaultZoneConfigRef())
 	ln, err := netutil.ListenAndServeGRPC(stopper, server, addr)
 	if err != nil {
 		t.Fatal(err)
@@ -150,7 +151,7 @@ func startFakeServerGossips(
 	lRPCContext.ClusterID.Reset(clusterID)
 
 	lserver := rpc.NewServer(lRPCContext)
-	local := NewTest(localNodeID, lRPCContext, lserver, stopper, metric.NewRegistry())
+	local := NewTest(localNodeID, lRPCContext, lserver, stopper, metric.NewRegistry(), config.DefaultZoneConfigRef())
 	lln, err := netutil.ListenAndServeGRPC(stopper, lserver, util.IsolatedTestAddr)
 	if err != nil {
 		t.Fatal(err)
@@ -513,7 +514,7 @@ func TestClientRegisterWithInitNodeID(t *testing.T) {
 		server := rpc.NewServer(RPCContext)
 		// node ID must be non-zero
 		gnode := NewTest(
-			nodeID, RPCContext, server, stopper, metric.NewRegistry(),
+			nodeID, RPCContext, server, stopper, metric.NewRegistry(), config.DefaultZoneConfigRef(),
 		)
 		g = append(g, gnode)
 

--- a/pkg/gossip/convergence_test.go
+++ b/pkg/gossip/convergence_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip/simulation"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -63,7 +64,7 @@ func TestConvergence(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
 
-	network := simulation.NewNetwork(stopper, testConvergenceSize, true)
+	network := simulation.NewNetwork(stopper, testConvergenceSize, true, config.DefaultZoneConfigRef())
 
 	const maxCycles = 100
 	if connectedCycle := network.RunUntilFullyConnected(); connectedCycle > maxCycles {
@@ -96,7 +97,7 @@ func TestNetworkReachesEquilibrium(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
 
-	network := simulation.NewNetwork(stopper, testReachesEquilibriumSize, true)
+	network := simulation.NewNetwork(stopper, testReachesEquilibriumSize, true, config.DefaultZoneConfigRef())
 
 	var connsRefused int64
 	var cyclesWithoutChange int

--- a/pkg/gossip/disable_merges_test.go
+++ b/pkg/gossip/disable_merges_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -38,7 +39,7 @@ func TestDisableMerges(t *testing.T) {
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
 			g := NewTest(1, nil /* rpcContext */, nil, /* grpcServer */
-				stopper, metric.NewRegistry())
+				stopper, metric.NewRegistry(), config.DefaultZoneConfigRef())
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -300,6 +300,7 @@ func New(
 	stopper *stop.Stopper,
 	registry *metric.Registry,
 	locality roachpb.Locality,
+	defaultZoneConfig *config.ZoneConfig,
 ) *Gossip {
 	ambient.SetEventLog("gossip", "gossip")
 	g := &Gossip{
@@ -319,6 +320,7 @@ func New(
 		resolverAddrs:     map[util.UnresolvedAddr]resolver.Resolver{},
 		bootstrapAddrs:    map[util.UnresolvedAddr]roachpb.NodeID{},
 		localityTierMap:   map[string]struct{}{},
+		defaultZoneConfig: defaultZoneConfig,
 	}
 
 	for _, loc := range locality.Tiers {
@@ -359,8 +361,9 @@ func NewTest(
 	grpcServer *grpc.Server,
 	stopper *stop.Stopper,
 	registry *metric.Registry,
+	defaultZoneConfig *config.ZoneConfig,
 ) *Gossip {
-	return NewTestWithLocality(nodeID, rpcContext, grpcServer, stopper, registry, roachpb.Locality{})
+	return NewTestWithLocality(nodeID, rpcContext, grpcServer, stopper, registry, roachpb.Locality{}, defaultZoneConfig)
 }
 
 // NewTestWithLocality calls NewTest with an explicit locality value.
@@ -371,12 +374,13 @@ func NewTestWithLocality(
 	stopper *stop.Stopper,
 	registry *metric.Registry,
 	locality roachpb.Locality,
+	defaultZoneConfig *config.ZoneConfig,
 ) *Gossip {
 	c := &base.ClusterIDContainer{}
 	n := &base.NodeIDContainer{}
 	var ac log.AmbientContext
 	ac.AddLogTag("n", n)
-	gossip := New(ac, c, n, rpcContext, grpcServer, stopper, registry, locality)
+	gossip := New(ac, c, n, rpcContext, grpcServer, stopper, registry, locality, defaultZoneConfig)
 	if nodeID != 0 {
 		n.Set(context.TODO(), nodeID)
 	}
@@ -1166,7 +1170,7 @@ func (g *Gossip) updateSystemConfig(key string, content roachpb.Value) {
 	if key != KeySystemConfig {
 		log.Fatalf(ctx, "wrong key received on SystemConfig callback: %s", key)
 	}
-	cfg := config.NewSystemConfig()
+	cfg := config.NewSystemConfig(g.defaultZoneConfig)
 	if err := content.GetProto(&cfg.SystemConfigEntries); err != nil {
 		log.Errorf(ctx, "could not unmarshal system config on callback: %s", err)
 		return

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -276,6 +276,8 @@ type Gossip struct {
 	localityTierMap map[string]struct{}
 
 	lastConnectivity string
+
+	defaultZoneConfig *config.ZoneConfig
 }
 
 // New creates an instance of a gossip node.

--- a/pkg/gossip/gossip_test.go
+++ b/pkg/gossip/gossip_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip/resolver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
@@ -47,7 +48,7 @@ func TestGossipInfoStore(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
 	rpcContext := newInsecureRPCContext(stopper)
-	g := NewTest(1, rpcContext, rpc.NewServer(rpcContext), stopper, metric.NewRegistry())
+	g := NewTest(1, rpcContext, rpc.NewServer(rpcContext), stopper, metric.NewRegistry(), config.DefaultZoneConfigRef())
 	slice := []byte("b")
 	if err := g.AddInfo("s", slice, time.Hour); err != nil {
 		t.Fatal(err)
@@ -67,7 +68,7 @@ func TestGossipMoveNode(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
 	rpcContext := newInsecureRPCContext(stopper)
-	g := NewTest(1, rpcContext, rpc.NewServer(rpcContext), stopper, metric.NewRegistry())
+	g := NewTest(1, rpcContext, rpc.NewServer(rpcContext), stopper, metric.NewRegistry(), config.DefaultZoneConfigRef())
 	var nodes []*roachpb.NodeDescriptor
 	for i := 1; i <= 3; i++ {
 		node := &roachpb.NodeDescriptor{
@@ -127,7 +128,7 @@ func TestGossipGetNextBootstrapAddress(t *testing.T) {
 		t.Errorf("expected 3 resolvers; got %d", len(resolvers))
 	}
 	server := rpc.NewServer(newInsecureRPCContext(stopper))
-	g := NewTest(0, nil, server, stopper, metric.NewRegistry())
+	g := NewTest(0, nil, server, stopper, metric.NewRegistry(), config.DefaultZoneConfigRef())
 	g.setResolvers(resolvers)
 
 	// Using specified resolvers, fetch bootstrap addresses 3 times
@@ -186,7 +187,7 @@ func TestGossipLocalityResolver(t *testing.T) {
 	var node2LocalityList []roachpb.LocalityAddress
 	node2LocalityList = append(node2LocalityList, nodeLocalityAddress2)
 
-	g := NewTestWithLocality(1, rpcContext, rpc.NewServer(rpcContext), stopper, metric.NewRegistry(), gossipLocalityAdvertiseList)
+	g := NewTestWithLocality(1, rpcContext, rpc.NewServer(rpcContext), stopper, metric.NewRegistry(), gossipLocalityAdvertiseList, config.DefaultZoneConfigRef())
 	node1 := &roachpb.NodeDescriptor{NodeID: 1, Address: node1PublicAddress, LocalityAddress: node1LocalityList}
 	node2 := &roachpb.NodeDescriptor{NodeID: 2, Address: node2PublicAddress, LocalityAddress: node2LocalityList}
 
@@ -700,7 +701,7 @@ func TestGossipJoinTwoClusters(t *testing.T) {
 
 		// node ID must be non-zero
 		gnode := NewTest(
-			roachpb.NodeID(i+1), rpcCtx, server, stopper, metric.NewRegistry())
+			roachpb.NodeID(i+1), rpcCtx, server, stopper, metric.NewRegistry(), config.DefaultZoneConfigRef())
 		g = append(g, gnode)
 		gnode.SetStallInterval(interval)
 		gnode.SetBootstrapInterval(interval)

--- a/pkg/gossip/storage_test.go
+++ b/pkg/gossip/storage_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/gossip/resolver"
 	"github.com/cockroachdb/cockroach/pkg/gossip/simulation"
@@ -100,7 +101,8 @@ func TestGossipStorage(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
 
-	network := simulation.NewNetwork(stopper, 3, true)
+	defaultZoneConfig := config.DefaultZoneConfigRef()
+	network := simulation.NewNetwork(stopper, 3, true, defaultZoneConfig)
 
 	// Set storage for each of the nodes.
 	addresses := make(unresolvedAddrSlice, len(network.Nodes))
@@ -157,7 +159,7 @@ func TestGossipStorage(t *testing.T) {
 
 	// Create an unaffiliated gossip node with only itself as a resolver,
 	// leaving it no way to reach the gossip network.
-	node, err := network.CreateNode()
+	node, err := network.CreateNode(defaultZoneConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,7 +220,7 @@ func TestGossipStorageCleanup(t *testing.T) {
 	defer stopper.Stop(context.TODO())
 
 	const numNodes = 3
-	network := simulation.NewNetwork(stopper, numNodes, false)
+	network := simulation.NewNetwork(stopper, numNodes, false, config.DefaultZoneConfigRef())
 
 	const notReachableAddr = "localhost:0"
 	const invalidAddr = "10.0.0.1000:3333333"

--- a/pkg/gossip/util.go
+++ b/pkg/gossip/util.go
@@ -39,7 +39,7 @@ type SystemConfigDeltaFilter struct {
 func MakeSystemConfigDeltaFilter(keyPrefix roachpb.Key) SystemConfigDeltaFilter {
 	return SystemConfigDeltaFilter{
 		keyPrefix: keyPrefix,
-		lastCfg:   config.NewSystemConfig(),
+		lastCfg:   config.NewSystemConfig(config.DefaultZoneConfigRef()),
 	}
 }
 
@@ -50,7 +50,7 @@ func (df *SystemConfigDeltaFilter) ForModified(
 ) {
 	// Save newCfg in the filter.
 	lastCfg := df.lastCfg
-	df.lastCfg = config.NewSystemConfig()
+	df.lastCfg = config.NewSystemConfig(newCfg.DefaultZoneConfig)
 	df.lastCfg.Values = newCfg.Values
 
 	// SystemConfig values are always sorted by key, so scan over new and old

--- a/pkg/gossip/util_test.go
+++ b/pkg/gossip/util_test.go
@@ -84,7 +84,7 @@ func TestSystemConfigDeltaFilter(t *testing.T) {
 	rng, _ := randutil.NewPseudoRand()
 
 	df := MakeSystemConfigDeltaFilter(nil)
-	cfg := config.NewSystemConfig()
+	cfg := config.NewSystemConfig(config.DefaultZoneConfigRef())
 
 	// Add one key.
 	addKV(rng, cfg, 1)
@@ -114,7 +114,7 @@ func TestSystemConfigDeltaFilterWithKeyPrefix(t *testing.T) {
 	rng, _ := randutil.NewPseudoRand()
 
 	df := MakeSystemConfigDeltaFilter(keyFromInt(12))
-	cfg := config.NewSystemConfig()
+	cfg := config.NewSystemConfig(config.DefaultZoneConfigRef())
 
 	// Add one non-matching key.
 	addKV(rng, cfg, 1)
@@ -140,7 +140,7 @@ func BenchmarkSystemConfigDeltaFilter(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
 
 	// Create two configs.
-	cfg1, cfg2 := config.NewSystemConfig(), config.NewSystemConfig()
+	cfg1, cfg2 := config.NewSystemConfig(config.DefaultZoneConfigRef()), config.NewSystemConfig(config.DefaultZoneConfigRef())
 	for i := 0; i < 1000; i++ {
 		key := i + 100000 // +100000 to match filter
 		addKV(rng, cfg1, key)
@@ -164,7 +164,7 @@ func BenchmarkSystemConfigDeltaFilter(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		cfg := config.NewSystemConfig()
+		cfg := config.NewSystemConfig(config.DefaultZoneConfigRef())
 		cfg.Values = cfg1.Values
 		if i%2 == 1 {
 			cfg.Values = cfg2.Values

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/gossip/simulation"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
@@ -818,7 +819,7 @@ func makeGossip(t *testing.T, stopper *stop.Stopper) (*gossip.Gossip, *hlc.Clock
 	server := rpc.NewServer(rpcContext)
 
 	const nodeID = 1
-	g := gossip.NewTest(nodeID, rpcContext, server, stopper, metric.NewRegistry())
+	g := gossip.NewTest(nodeID, rpcContext, server, stopper, metric.NewRegistry(), config.DefaultZoneConfigRef())
 	if err := g.SetNodeDescriptor(newNodeDesc(nodeID)); err != nil {
 		t.Fatal(err)
 	}
@@ -1263,7 +1264,7 @@ func TestGetFirstRangeDescriptor(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
 
-	n := simulation.NewNetwork(stopper, 3, true)
+	n := simulation.NewNetwork(stopper, 3, true, config.DefaultZoneConfigRef())
 	for _, node := range n.Nodes {
 		// TODO(spencer): remove the use of gossip/simulation here.
 		node.Gossip.EnableSimulationCycler(false)

--- a/pkg/kv/split_test.go
+++ b/pkg/kv/split_test.go
@@ -178,13 +178,15 @@ func TestRangeSplitsWithConcurrentTxns(t *testing.T) {
 func TestRangeSplitsWithWritePressure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// Override default zone config.
-	cfg := config.DefaultZoneConfig()
+	cfg := config.DefaultZoneConfigRef()
 	cfg.RangeMaxBytes = proto.Int64(1 << 18)
-	defer config.TestingSetDefaultZoneConfig(cfg)()
 
 	// Manually create the local test cluster so that the split queue
 	// is not disabled (LocalTestCluster disables it by default).
 	s := &localtestcluster.LocalTestCluster{
+		Cfg: storage.StoreConfig{
+			DefaultZoneConfig: cfg,
+		},
 		StoreTestingKnobs: &storage.StoreTestingKnobs{
 			DisableScanner: true,
 		},

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -291,7 +291,7 @@ func (s *adminServer) DatabaseDetails(
 		}
 
 		if !zoneExists {
-			zone = config.DefaultZoneConfig()
+			zone = s.server.cfg.DefaultZoneConfig
 		}
 		resp.ZoneConfig = zone
 
@@ -509,7 +509,7 @@ func (s *adminServer) TableDetails(
 		}
 
 		if !zoneExists {
-			zone = config.DefaultZoneConfig()
+			zone = s.server.cfg.DefaultZoneConfig
 		}
 		resp.ZoneConfig = zone
 

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -703,8 +703,8 @@ func TestAdminAPIZoneDetails(t *testing.T) {
 	}
 
 	// Verify zone matches cluster default.
-	verifyDbZone(config.DefaultZoneConfig(), serverpb.ZoneConfigurationLevel_CLUSTER)
-	verifyTblZone(config.DefaultZoneConfig(), serverpb.ZoneConfigurationLevel_CLUSTER)
+	verifyDbZone(s.(*TestServer).Cfg.DefaultZoneConfig, serverpb.ZoneConfigurationLevel_CLUSTER)
+	verifyTblZone(s.(*TestServer).Cfg.DefaultZoneConfig, serverpb.ZoneConfigurationLevel_CLUSTER)
 
 	// Get ID path for table. This will be an array of three IDs, containing the ID of the root namespace,
 	// the database, and the table (in that order).

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip/resolver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
@@ -233,6 +234,15 @@ type Config struct {
 	// AmbientCtx is used to annotate contexts used inside the server.
 	AmbientCtx log.AmbientContext
 
+	// DefaultZoneConfig is used to set the default zone config inside the server.
+	// It can be overridden during tests by setting the DefaultZoneConfigOverride
+	// server testing knob.
+	DefaultZoneConfig config.ZoneConfig
+	// DefaultSystemZoneConfig is used to set the default system zone config
+	// inside the server. It can be overridden during tests by setting the
+	// DefaultSystemZoneConfigOverride server testing knob.
+	DefaultSystemZoneConfig config.ZoneConfig
+
 	// Locality is a description of the topography of the server.
 	Locality roachpb.Locality
 
@@ -331,6 +341,8 @@ func MakeConfig(ctx context.Context, st *cluster.Settings) Config {
 
 	cfg := Config{
 		Config:                         new(base.Config),
+		DefaultZoneConfig:              config.DefaultZoneConfig(),
+		DefaultSystemZoneConfig:        config.DefaultSystemZoneConfig(),
 		MaxOffset:                      MaxOffsetType(base.DefaultMaxClockOffset),
 		Settings:                       st,
 		CacheSize:                      DefaultCacheSize,

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -78,6 +78,7 @@ func createTestNode(
 		grpcServer,
 		stopper,
 		metric.NewRegistry(),
+		cfg.DefaultZoneConfig,
 	)
 	retryOpts := base.DefaultRetryOptions()
 	retryOpts.Closer = stopper.ShouldQuiesce()
@@ -208,7 +209,7 @@ func TestBootstrapCluster(t *testing.T) {
 	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
 	defer e.Close()
 	if _, err := bootstrapCluster(
-		ctx, []engine.Engine{e}, cluster.TestingClusterVersion,
+		ctx, []engine.Engine{e}, cluster.TestingClusterVersion, config.DefaultZoneConfigRef(), config.DefaultSystemZoneConfigRef(),
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -236,7 +237,7 @@ func TestBootstrapCluster(t *testing.T) {
 	}
 
 	// Add the initial keys for sql.
-	kvs, tableSplits := GetBootstrapSchema().GetInitialValues()
+	kvs, tableSplits := GetBootstrapSchema(config.DefaultZoneConfigRef(), config.DefaultSystemZoneConfigRef()).GetInitialValues()
 	for _, kv := range kvs {
 		expectedKeys = append(expectedKeys, kv.Key)
 	}
@@ -263,7 +264,7 @@ func TestBootstrapNewStore(t *testing.T) {
 	ctx := context.Background()
 	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
 	if _, err := bootstrapCluster(
-		ctx, []engine.Engine{e}, cluster.TestingClusterVersion,
+		ctx, []engine.Engine{e}, cluster.TestingClusterVersion, config.DefaultZoneConfigRef(), config.DefaultSystemZoneConfigRef(),
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -318,7 +319,7 @@ func TestNodeJoin(t *testing.T) {
 	engineStopper.AddCloser(e)
 
 	if _, err := bootstrapCluster(
-		ctx, []engine.Engine{e}, cluster.TestingClusterVersion,
+		ctx, []engine.Engine{e}, cluster.TestingClusterVersion, config.DefaultZoneConfigRef(), config.DefaultSystemZoneConfigRef(),
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -389,7 +390,7 @@ func TestCorruptedClusterID(t *testing.T) {
 	defer e.Close()
 
 	if _, err := bootstrapCluster(
-		ctx, []engine.Engine{e}, cluster.TestingClusterVersion,
+		ctx, []engine.Engine{e}, cluster.TestingClusterVersion, config.DefaultZoneConfigRef(), config.DefaultSystemZoneConfigRef(),
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -580,7 +581,7 @@ func TestNodeStatusWritten(t *testing.T) {
 	}
 
 	// Wait for full replication of initial ranges.
-	initialRanges, err := ExpectedInitialRangeCount(kvDB)
+	initialRanges, err := ExpectedInitialRangeCount(kvDB, &ts.cfg.DefaultZoneConfig, &ts.cfg.DefaultSystemZoneConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -737,7 +738,7 @@ func TestStartNodeWithLocality(t *testing.T) {
 		e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
 		defer e.Close()
 		if _, err := bootstrapCluster(
-			ctx, []engine.Engine{e}, cluster.TestingClusterVersion,
+			ctx, []engine.Engine{e}, cluster.TestingClusterVersion, config.DefaultZoneConfigRef(), config.DefaultSystemZoneConfigRef(),
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -266,6 +266,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		s.stopper,
 		s.registry,
 		s.cfg.Locality,
+		&s.cfg.DefaultZoneConfig,
 	)
 	s.nodeDialer = nodedialer.New(s.rpcContext, gossip.AddressResolver(s.gossip))
 
@@ -1772,7 +1773,7 @@ func (s *Server) bootstrapCluster(ctx context.Context) error {
 		}
 	}
 
-	if err := s.node.bootstrapCluster(ctx, s.engines, bootstrapVersion); err != nil {
+	if err := s.node.bootstrapCluster(ctx, s.engines, bootstrapVersion, &s.cfg.DefaultZoneConfig, &s.cfg.DefaultSystemZoneConfig); err != nil {
 		return err
 	}
 	// Force all the system ranges through the replication queue so they

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -430,6 +430,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 
 	// TODO(bdarnell): make StoreConfig configurable.
 	storeCfg := storage.StoreConfig{
+		DefaultZoneConfig:       &s.cfg.DefaultZoneConfig,
 		Settings:                st,
 		AmbientCtx:              s.cfg.AmbientCtx,
 		RaftConfig:              s.cfg.RaftConfig,
@@ -603,6 +604,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	execCfg = sql.ExecutorConfig{
 		Settings:                s.st,
 		NodeInfo:                nodeInfo,
+		DefaultZoneConfig:       &s.cfg.DefaultZoneConfig,
 		Locality:                s.cfg.Locality,
 		AmbientCtx:              s.cfg.AmbientCtx,
 		DB:                      s.db,
@@ -726,6 +728,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	s.leaseMgr.PeriodicallyRefreshSomeLeases()
 
 	s.node.InitLogger(&execCfg)
+	s.cfg.DefaultZoneConfig = cfg.DefaultZoneConfig
 
 	return s, nil
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -79,10 +79,13 @@ func TestHealthCheck(t *testing.T) {
 
 	cfg := config.DefaultZoneConfig()
 	cfg.NumReplicas = proto.Int32(1)
-	fnSys := config.TestingSetDefaultSystemZoneConfig(cfg)
-	defer fnSys()
-
-	s, err := serverutils.StartServerRaw(base.TestServerArgs{})
+	s, err := serverutils.StartServerRaw(base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			Server: &TestingKnobs{
+				DefaultZoneConfigOverride: &cfg,
+			},
+		},
+	})
 
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/server/server_update.go
+++ b/pkg/server/server_update.go
@@ -19,6 +19,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -31,6 +32,10 @@ type TestingKnobs struct {
 	// DisableAutomaticVersionUpgrade, if set, temporarily disables the server's
 	// automatic version upgrade mechanism.
 	DisableAutomaticVersionUpgrade int32 // accessed atomically
+	// DefaultZoneConfigOverride, if set, overrides the default zone config defined in `pkg/config/zone.go`
+	DefaultZoneConfigOverride *config.ZoneConfig
+	// DefaultSystemZoneConfigOverride, if set, overrides the default system zone config defined in `pkg/config/zone.go`
+	DefaultSystemZoneConfigOverride *config.ZoneConfig
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -48,7 +48,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 )
@@ -309,40 +308,6 @@ func (ts *TestServer) PGServer() *pgwire.Server {
 	return nil
 }
 
-// This object implements a hack to allow multiple tests to use StartServer and
-// not mess up the default zone config. Note that we still have problems if a
-// test runs in parallel with another test that sets up a test cluster.
-//
-// The real problem here is that the default zone config is a global (#37054);
-// this should go away if that's fixed.
-var messWithZoneConfig struct {
-	mutex    syncutil.Mutex
-	refCount int
-	restore  func()
-}
-
-func messWithZoneConfigBegin() {
-	messWithZoneConfig.mutex.Lock()
-	defer messWithZoneConfig.mutex.Unlock()
-
-	if messWithZoneConfig.refCount == 0 {
-		cfg := config.DefaultZoneConfig()
-		cfg.NumReplicas = proto.Int32(1)
-		messWithZoneConfig.restore = config.TestingSetDefaultZoneConfig(cfg)
-	}
-	messWithZoneConfig.refCount++
-}
-
-func messWithZoneConfigEnd() {
-	messWithZoneConfig.mutex.Lock()
-	defer messWithZoneConfig.mutex.Unlock()
-	messWithZoneConfig.refCount--
-	if messWithZoneConfig.refCount == 0 {
-		messWithZoneConfig.restore()
-		messWithZoneConfig.restore = nil
-	}
-}
-
 // Start starts the TestServer by bootstrapping an in-memory store
 // (defaults to maximum of 100M). The server is started, launching the
 // node RPC server and all HTTP endpoints. Use the value of
@@ -359,10 +324,7 @@ func (ts *TestServer) Start(params base.TestServerArgs) error {
 	}
 
 	if !params.PartOfCluster {
-		// Change the replication requirements so we don't get log spam about ranges
-		// not being replicated enough.
-		messWithZoneConfigBegin()
-		params.Stopper.AddCloser(stop.CloserFn(messWithZoneConfigEnd))
+		ts.Cfg.DefaultZoneConfig.NumReplicas = proto.Int32(1)
 	}
 
 	// Needs to be called before NewServer to ensure resolvers are initialized.
@@ -395,13 +357,15 @@ func (ts *TestServer) Start(params base.TestServerArgs) error {
 // assuming no additional information is added outside of the normal bootstrap
 // process.
 func (ts *TestServer) ExpectedInitialRangeCount() (int, error) {
-	return ExpectedInitialRangeCount(ts.DB())
+	return ExpectedInitialRangeCount(ts.DB(), &ts.cfg.DefaultZoneConfig, &ts.cfg.DefaultSystemZoneConfig)
 }
 
 // ExpectedInitialRangeCount returns the expected number of ranges that should
 // be on the server after bootstrap.
-func ExpectedInitialRangeCount(db *client.DB) (int, error) {
-	descriptorIDs, err := sqlmigrations.ExpectedDescriptorIDs(context.Background(), db)
+func ExpectedInitialRangeCount(
+	db *client.DB, defaultZoneConfig *config.ZoneConfig, defaultSystemZoneConfig *config.ZoneConfig,
+) (int, error) {
+	descriptorIDs, err := sqlmigrations.ExpectedDescriptorIDs(context.Background(), db, defaultZoneConfig, defaultSystemZoneConfig)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -124,6 +124,14 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 			cfg.MaxOffset = MaxOffsetType(mo)
 		}
 	}
+	if params.Knobs.Server != nil {
+		if zoneConfig := params.Knobs.Server.(*TestingKnobs).DefaultZoneConfigOverride; zoneConfig != nil {
+			cfg.DefaultZoneConfig = *zoneConfig
+		}
+		if systemZoneConfig := params.Knobs.Server.(*TestingKnobs).DefaultSystemZoneConfigOverride; systemZoneConfig != nil {
+			cfg.DefaultSystemZoneConfig = *systemZoneConfig
+		}
+	}
 	if params.ScanInterval != 0 {
 		cfg.ScanInterval = params.ScanInterval
 	}

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -777,7 +777,7 @@ func TestReportUsage(t *testing.T) {
 	hashedZone := sql.HashForReporting(clusterSecret, "zone")
 	for id, zone := range r.last.ZoneConfigs {
 		if id == keys.RootNamespaceID {
-			if defZone := config.DefaultZoneConfig(); !reflect.DeepEqual(zone, defZone) {
+			if defZone := ts.Cfg.DefaultZoneConfig; !reflect.DeepEqual(zone, defZone) {
 				t.Errorf("default zone config does not match: expected\n%+v got\n%+v", defZone, zone)
 			}
 		}

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -270,12 +270,13 @@ type Metrics struct {
 // NewServer creates a new Server. Start() needs to be called before the Server
 // is used.
 func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
+	systemCfg := config.NewSystemConfig(cfg.DefaultZoneConfig)
 	return &Server{
 		cfg:             cfg,
 		Metrics:         makeMetrics(false /*internal*/),
 		InternalMetrics: makeMetrics(true /*internal*/),
 		// dbCache will be updated on Start().
-		dbCache:  newDatabaseCacheHolder(newDatabaseCache(config.NewSystemConfig())),
+		dbCache:  newDatabaseCacheHolder(newDatabaseCache(systemCfg)),
 		pool:     pool,
 		sqlStats: sqlStats{st: cfg.Settings, apps: make(map[string]*appStats)},
 		reCache:  tree.NewRegexpCache(512),

--- a/pkg/sql/create_test.go
+++ b/pkg/sql/create_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/sqlmigrations"
@@ -96,7 +97,7 @@ func TestDatabaseDescriptor(t *testing.T) {
 	if kvs, err := kvDB.Scan(ctx, start, start.PrefixEnd(), 0 /* maxRows */); err != nil {
 		t.Fatal(err)
 	} else {
-		descriptorIDs, err := sqlmigrations.ExpectedDescriptorIDs(ctx, kvDB)
+		descriptorIDs, err := sqlmigrations.ExpectedDescriptorIDs(ctx, kvDB, &s.(*server.TestServer).Cfg.DefaultZoneConfig, &s.(*server.TestServer).Cfg.DefaultSystemZoneConfig)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/database_test.go
+++ b/pkg/sql/database_test.go
@@ -62,7 +62,7 @@ func TestDatabaseAccessors(t *testing.T) {
 			return err
 		}
 
-		databaseCache := newDatabaseCache(config.NewSystemConfig())
+		databaseCache := newDatabaseCache(config.NewSystemConfig(config.DefaultZoneConfigRef()))
 		_, err := databaseCache.getDatabaseDescByID(ctx, txn, sqlbase.SystemDB.ID)
 		return err
 	}); err != nil {

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -749,7 +750,7 @@ func TestPartitionSpans(t *testing.T) {
 	testStopper := stop.NewStopper()
 	defer testStopper.Stop(context.TODO())
 	mockGossip := gossip.NewTest(roachpb.NodeID(1), nil /* rpcContext */, nil, /* grpcServer */
-		testStopper, metric.NewRegistry())
+		testStopper, metric.NewRegistry(), config.DefaultZoneConfigRef())
 	var nodeDescs []*roachpb.NodeDescriptor
 	for i := 1; i <= 10; i++ {
 		nodeID := roachpb.NodeID(i)
@@ -939,7 +940,7 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 			testStopper := stop.NewStopper()
 			defer testStopper.Stop(context.TODO())
 			mockGossip := gossip.NewTest(roachpb.NodeID(1), nil /* rpcContext */, nil, /* grpcServer */
-				testStopper, metric.NewRegistry())
+				testStopper, metric.NewRegistry(), config.DefaultZoneConfigRef())
 			var nodeDescs []*roachpb.NodeDescriptor
 			for i := 1; i <= 2; i++ {
 				nodeID := roachpb.NodeID(i)
@@ -1028,7 +1029,7 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 	defer stopper.Stop(context.TODO())
 
 	mockGossip := gossip.NewTest(roachpb.NodeID(1), nil /* rpcContext */, nil, /* grpcServer */
-		stopper, metric.NewRegistry())
+		stopper, metric.NewRegistry(), config.DefaultZoneConfigRef())
 	var nodeDescs []*roachpb.NodeDescriptor
 	for i := 1; i <= 2; i++ {
 		nodeID := roachpb.NodeID(i)
@@ -1118,7 +1119,7 @@ func TestCheckNodeHealth(t *testing.T) {
 	const nodeID = roachpb.NodeID(5)
 
 	mockGossip := gossip.NewTest(nodeID, nil /* rpcContext */, nil, /* grpcServer */
-		stopper, metric.NewRegistry())
+		stopper, metric.NewRegistry(), config.DefaultZoneConfigRef())
 
 	desc := &roachpb.NodeDescriptor{
 		NodeID:  nodeID,

--- a/pkg/sql/distsqlplan/replicaoracle/oracle_test.go
+++ b/pkg/sql/distsqlplan/replicaoracle/oracle_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -110,7 +111,7 @@ func makeGossip(t *testing.T, stopper *stop.Stopper) (*gossip.Gossip, *hlc.Clock
 	server := rpc.NewServer(rpcContext)
 
 	const nodeID = 1
-	g := gossip.NewTest(nodeID, rpcContext, server, stopper, metric.NewRegistry())
+	g := gossip.NewTest(nodeID, rpcContext, server, stopper, metric.NewRegistry(), config.DefaultZoneConfigRef())
 	if err := g.SetNodeDescriptor(newNodeDesc(nodeID)); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -625,8 +626,8 @@ func TestDropIndexWithZoneConfigOSS(t *testing.T) {
 	// required" error.
 	zoneConfig := config.ZoneConfig{
 		Subzones: []config.Subzone{
-			{IndexID: uint32(tableDesc.PrimaryIndex.ID), Config: config.DefaultZoneConfig()},
-			{IndexID: uint32(indexDesc.ID), Config: config.DefaultZoneConfig()},
+			{IndexID: uint32(tableDesc.PrimaryIndex.ID), Config: s.(*server.TestServer).Cfg.DefaultZoneConfig},
+			{IndexID: uint32(indexDesc.ID), Config: s.(*server.TestServer).Cfg.DefaultZoneConfig},
 		},
 	}
 	zoneConfigBytes, err := protoutil.Marshal(&zoneConfig)

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -375,27 +375,28 @@ type nodeStatusGenerator interface {
 type ExecutorConfig struct {
 	Settings *cluster.Settings
 	NodeInfo
-	Locality         roachpb.Locality
-	AmbientCtx       log.AmbientContext
-	DB               *client.DB
-	Gossip           *gossip.Gossip
-	DistSender       *kv.DistSender
-	RPCContext       *rpc.Context
-	LeaseManager     *LeaseManager
-	Clock            *hlc.Clock
-	DistSQLSrv       *distsqlrun.ServerImpl
-	StatusServer     serverpb.StatusServer
-	MetricsRecorder  nodeStatusGenerator
-	SessionRegistry  *SessionRegistry
-	JobRegistry      *jobs.Registry
-	VirtualSchemas   *VirtualSchemaHolder
-	DistSQLPlanner   *DistSQLPlanner
-	TableStatsCache  *stats.TableStatisticsCache
-	StatsRefresher   *stats.Refresher
-	ExecLogger       *log.SecondaryLogger
-	AuditLogger      *log.SecondaryLogger
-	InternalExecutor *InternalExecutor
-	QueryCache       *querycache.C
+	DefaultZoneConfig *config.ZoneConfig
+	Locality          roachpb.Locality
+	AmbientCtx        log.AmbientContext
+	DB                *client.DB
+	Gossip            *gossip.Gossip
+	DistSender        *kv.DistSender
+	RPCContext        *rpc.Context
+	LeaseManager      *LeaseManager
+	Clock             *hlc.Clock
+	DistSQLSrv        *distsqlrun.ServerImpl
+	StatusServer      serverpb.StatusServer
+	MetricsRecorder   nodeStatusGenerator
+	SessionRegistry   *SessionRegistry
+	JobRegistry       *jobs.Registry
+	VirtualSchemas    *VirtualSchemaHolder
+	DistSQLPlanner    *DistSQLPlanner
+	TableStatsCache   *stats.TableStatisticsCache
+	StatsRefresher    *stats.Refresher
+	ExecLogger        *log.SecondaryLogger
+	AuditLogger       *log.SecondaryLogger
+	InternalExecutor  *InternalExecutor
+	QueryCache        *querycache.C
 
 	TestingKnobs              ExecutorTestingKnobs
 	PGWireTestingKnobs        *PGWireTestingKnobs

--- a/pkg/sql/partition_test.go
+++ b/pkg/sql/partition_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -87,12 +88,12 @@ func TestRemovePartitioningOSS(t *testing.T) {
 			{
 				IndexID:       uint32(tableDesc.PrimaryIndex.ID),
 				PartitionName: "p1",
-				Config:        config.DefaultZoneConfig(),
+				Config:        s.(*server.TestServer).Cfg.DefaultZoneConfig,
 			},
 			{
 				IndexID:       uint32(tableDesc.Indexes[0].ID),
 				PartitionName: "p2",
-				Config:        config.DefaultZoneConfig(),
+				Config:        s.(*server.TestServer).Cfg.DefaultZoneConfig,
 			},
 		},
 	}

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
@@ -220,9 +219,11 @@ func newInternalPlanner(
 			Location: time.UTC,
 		},
 	}
+	// The table collection used by the internal planner does not rely on the
+	// databaseCache and there are no subscribers to the databaseCache, so we can
+	// leave it uninitialized.
 	tables := &TableCollection{
-		leaseMgr:      execCfg.LeaseManager,
-		databaseCache: newDatabaseCache(config.NewSystemConfig()),
+		leaseMgr: execCfg.LeaseManager,
 	}
 	dataMutator := &sessionDataMutator{
 		data: sd,

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1674,7 +1674,7 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 		if s.testingKnobs.AsyncExecQuickly {
 			delay = 20 * time.Millisecond
 		}
-		defTTL := config.DefaultZoneConfig().GC.TTLSeconds
+		defTTL := s.execCfg.DefaultZoneConfig.GC.TTLSeconds
 
 		execOneSchemaChange := func(schemaChangers map[sqlbase.ID]SchemaChanger) {
 			for tableID, sc := range schemaChangers {

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -311,8 +311,7 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 		// the target ID is not a database object, i.e. one of the system
 		// ranges (liveness, meta, etc.), and did not have a zone config
 		// already.
-		defZone := config.DefaultZoneConfig()
-		completeZone = &defZone
+		completeZone = protoutil.Clone(params.extendedEvalCtx.ExecCfg.DefaultZoneConfig).(*config.ZoneConfig)
 	} else if err != nil {
 		return err
 	}
@@ -359,7 +358,7 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 		// ALTER RANGE default USING DEFAULT sets the default to the in
 		// memory default value.
 		if n.setDefault && keys.RootNamespaceID == uint32(targetID) {
-			finalZone = config.DefaultZoneConfig()
+			finalZone = *protoutil.Clone(params.extendedEvalCtx.ExecCfg.DefaultZoneConfig).(*config.ZoneConfig)
 		} else if n.setDefault {
 			finalZone = *config.NewZoneConfig()
 		}

--- a/pkg/sql/show_trace_replica_test.go
+++ b/pkg/sql/show_trace_replica_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
@@ -38,14 +39,18 @@ func TestShowTraceReplica(t *testing.T) {
 
 	const numNodes = 4
 
-	cfg := config.DefaultZoneConfig()
-	cfg.NumReplicas = proto.Int32(1)
-	defer config.TestingSetDefaultZoneConfig(cfg)()
-	defer config.TestingSetDefaultSystemZoneConfig(cfg)()
+	zoneConfig := config.DefaultZoneConfig()
+	zoneConfig.NumReplicas = proto.Int32(1)
 
 	ctx := context.Background()
 	tsArgs := func(node string) base.TestServerArgs {
 		return base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Server: &server.TestingKnobs{
+					DefaultZoneConfigOverride:       &zoneConfig,
+					DefaultSystemZoneConfigOverride: &zoneConfig,
+				},
+			},
 			StoreSpecs: []base.StoreSpec{{InMemory: true, Attributes: roachpb.Attributes{Attrs: []string{node}}}},
 		}
 	}

--- a/pkg/sql/show_zone_config.go
+++ b/pkg/sql/show_zone_config.go
@@ -115,8 +115,7 @@ func getShowZoneConfigRow(
 		// TODO(benesch): This shouldn't be the caller's responsibility;
 		// GetZoneConfigInTxn should just return the default zone config if no zone
 		// config applies.
-		defZone := config.DefaultZoneConfig()
-		zone = &defZone
+		zone = p.execCfg.DefaultZoneConfig
 		zoneID = keys.RootNamespaceID
 	} else if err != nil {
 		return nil, err

--- a/pkg/sql/sqlbase/metadata.go
+++ b/pkg/sql/sqlbase/metadata.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -83,9 +84,11 @@ type metadataDescriptor struct {
 
 // MakeMetadataSchema constructs a new MetadataSchema value which constructs
 // the "system" database.
-func MakeMetadataSchema() MetadataSchema {
+func MakeMetadataSchema(
+	defaultZoneConfig *config.ZoneConfig, defaultSystemZoneConfig *config.ZoneConfig,
+) MetadataSchema {
 	ms := MetadataSchema{}
-	addSystemDatabaseToSchema(&ms)
+	addSystemDatabaseToSchema(&ms, defaultZoneConfig, defaultSystemZoneConfig)
 	return ms
 }
 

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -161,6 +161,7 @@ type TableCollection struct {
 	uncommittedTables []uncommittedTable
 
 	// databaseCache is used as a cache for database names.
+	// This field is nil when the field is initialized for an internalPlanner.
 	// TODO(andrei): get rid of it and replace it with a leasing system for
 	// database descriptors.
 	databaseCache *databaseCache
@@ -212,7 +213,7 @@ func (tc *TableCollection) getMutableTableDescriptor(
 		return nil, err
 	}
 
-	if dbID == sqlbase.InvalidID {
+	if dbID == sqlbase.InvalidID && tc.databaseCache != nil {
 		// Resolve the database from the database cache when the transaction
 		// hasn't modified the database.
 		dbID, err = tc.databaseCache.getDatabaseID(ctx,
@@ -268,7 +269,7 @@ func (tc *TableCollection) getTableVersion(
 		return nil, err
 	}
 
-	if dbID == sqlbase.InvalidID {
+	if dbID == sqlbase.InvalidID && tc.databaseCache != nil {
 		// Resolve the database from the database cache when the transaction
 		// hasn't modified the database.
 		dbID, err = tc.databaseCache.getDatabaseID(ctx,

--- a/pkg/sql/tests/split_test.go
+++ b/pkg/sql/tests/split_test.go
@@ -77,7 +77,7 @@ func TestSplitOnTableBoundaries(t *testing.T) {
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 
-	expectedInitialRanges, err := server.ExpectedInitialRangeCount(kvDB)
+	expectedInitialRanges, err := server.ExpectedInitialRangeCount(kvDB, &s.(*server.TestServer).Cfg.DefaultZoneConfig, &s.(*server.TestServer).Cfg.DefaultSystemZoneConfig)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/tests/system_table_test.go
+++ b/pkg/sql/tests/system_table_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -35,7 +36,7 @@ func TestInitialKeys(t *testing.T) {
 	const keysPerDesc = 2
 	const nonDescKeys = 7
 
-	ms := sqlbase.MakeMetadataSchema()
+	ms := sqlbase.MakeMetadataSchema(config.DefaultZoneConfigRef(), config.DefaultSystemZoneConfigRef())
 	kv, _ /* splits */ := ms.GetInitialValues()
 	expected := nonDescKeys + keysPerDesc*ms.SystemDescriptorCount()
 	if actual := len(kv); actual != expected {

--- a/pkg/sql/zone_config_test.go
+++ b/pkg/sql/zone_config_test.go
@@ -89,25 +89,21 @@ func waitForConfigChange(t testing.TB, s *server.TestServer) *config.SystemConfi
 func TestGetZoneConfig(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	params, _ := tests.CreateTestServerParams()
-	cfg := config.DefaultSystemZoneConfig()
-	cfg.NumReplicas = proto.Int32(1)
-	cfg.RangeMinBytes = proto.Int64(1 << 20)
-	cfg.RangeMaxBytes = proto.Int64(1 << 20)
-	cfg.GC = &config.GCPolicy{TTLSeconds: 60}
-
-	fnSys := config.TestingSetDefaultSystemZoneConfig(cfg)
-	defer fnSys()
+	defaultZoneConfig := config.DefaultSystemZoneConfig()
+	defaultZoneConfig.NumReplicas = proto.Int32(1)
+	defaultZoneConfig.RangeMinBytes = proto.Int64(1 << 20)
+	defaultZoneConfig.RangeMaxBytes = proto.Int64(1 << 20)
+	defaultZoneConfig.GC = &config.GCPolicy{TTLSeconds: 60}
+	params.Knobs.Server = &server.TestingKnobs{
+		DefaultZoneConfigOverride:       &defaultZoneConfig,
+		DefaultSystemZoneConfigOverride: &defaultZoneConfig,
+	}
 
 	srv, sqlDB, _ := serverutils.StartServer(t, params)
 	defer srv.Stopper().Stop(context.TODO())
 	s := srv.(*server.TestServer)
 
 	expectedCounter := uint32(keys.MinNonPredefinedUserDescID)
-
-	defaultZoneConfig := config.DefaultZoneConfig()
-	defaultZoneConfig.RangeMinBytes = proto.Int64(1 << 20)
-	defaultZoneConfig.RangeMaxBytes = proto.Int64(1 << 20)
-	defaultZoneConfig.GC = &config.GCPolicy{TTLSeconds: 60}
 
 	type testCase struct {
 		objectID uint32
@@ -328,27 +324,21 @@ func TestCascadingZoneConfig(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	params, _ := tests.CreateTestServerParams()
 
-	cfg := config.DefaultSystemZoneConfig()
-	cfg.NumReplicas = proto.Int32(1)
-	cfg.RangeMinBytes = proto.Int64(1 << 20)
-	cfg.RangeMaxBytes = proto.Int64(1 << 20)
-	cfg.GC = &config.GCPolicy{TTLSeconds: 60}
-
-	defer config.TestingSetDefaultSystemZoneConfig(cfg)()
+	defaultZoneConfig := config.DefaultZoneConfig()
+	defaultZoneConfig.NumReplicas = proto.Int32(1)
+	defaultZoneConfig.RangeMinBytes = proto.Int64(1 << 20)
+	defaultZoneConfig.RangeMaxBytes = proto.Int64(1 << 20)
+	defaultZoneConfig.GC = &config.GCPolicy{TTLSeconds: 60}
+	params.Knobs.Server = &server.TestingKnobs{
+		DefaultZoneConfigOverride:       &defaultZoneConfig,
+		DefaultSystemZoneConfigOverride: &defaultZoneConfig,
+	}
 
 	srv, sqlDB, _ := serverutils.StartServer(t, params)
 	defer srv.Stopper().Stop(context.TODO())
 	s := srv.(*server.TestServer)
 
 	expectedCounter := uint32(keys.MinNonPredefinedUserDescID)
-
-	defaultZoneConfig := config.DefaultZoneConfig()
-	defaultZoneConfig.NumReplicas = proto.Int32(1)
-	defaultZoneConfig.RangeMinBytes = proto.Int64(1 << 20)
-	defaultZoneConfig.RangeMaxBytes = proto.Int64(1 << 20)
-	defaultZoneConfig.GC = &config.GCPolicy{TTLSeconds: 60}
-
-	defer config.TestingSetDefaultZoneConfig(defaultZoneConfig)()
 
 	type testCase struct {
 		objectID uint32

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -331,12 +332,17 @@ func NewManager(
 // NOTE: This value may be out-of-date if another node is actively running
 // migrations, and so should only be used in test code where the migration
 // lifecycle is tightly controlled.
-func ExpectedDescriptorIDs(ctx context.Context, db db) (sqlbase.IDs, error) {
+func ExpectedDescriptorIDs(
+	ctx context.Context,
+	db db,
+	defaultZoneConfig *config.ZoneConfig,
+	defaultSystemZoneConfig *config.ZoneConfig,
+) (sqlbase.IDs, error) {
 	completedMigrations, err := getCompletedMigrations(ctx, db)
 	if err != nil {
 		return nil, err
 	}
-	descriptorIDs := sqlbase.MakeMetadataSchema().DescriptorIDs()
+	descriptorIDs := sqlbase.MakeMetadataSchema(defaultZoneConfig, defaultSystemZoneConfig).DescriptorIDs()
 	for _, migration := range backwardCompatibleMigrations {
 		// Is the migration not creating descriptors?
 		if migration.newDescriptorIDs == nil ||

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -5506,7 +5506,7 @@ func TestAllocatorFullDisks(t *testing.T) {
 		&st.Version,
 	)
 	server := rpc.NewServer(rpcContext) // never started
-	g := gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry())
+	g := gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry(), config.DefaultZoneConfigRef())
 
 	TimeUntilStoreDead.Override(&st.SV, TestTimeUntilStoreDeadOff)
 
@@ -5646,7 +5646,7 @@ func Example_rebalancing() {
 		&st.Version,
 	)
 	server := rpc.NewServer(rpcContext) // never started
-	g := gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry())
+	g := gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry(), config.DefaultZoneConfigRef())
 
 	TimeUntilStoreDead.Override(&st.SV, TestTimeUntilStoreDeadOff)
 

--- a/pkg/storage/client_lease_test.go
+++ b/pkg/storage/client_lease_test.go
@@ -196,7 +196,7 @@ func TestStoreGossipSystemData(t *testing.T) {
 		t.Fatal(err)
 	}
 	testutils.SucceedsSoon(t, func() error {
-		if !reflect.DeepEqual(getSystemConfig(), config.NewSystemConfig()) {
+		if !reflect.DeepEqual(getSystemConfig(), config.NewSystemConfig(sc.DefaultZoneConfig)) {
 			return errors.New("system config not empty")
 		}
 		if getNodeLiveness() != (storagepb.Liveness{}) {
@@ -209,7 +209,7 @@ func TestStoreGossipSystemData(t *testing.T) {
 	// data is gossiped.
 	mtc.restartStore(0)
 	testutils.SucceedsSoon(t, func() error {
-		if reflect.DeepEqual(getSystemConfig(), config.NewSystemConfig()) {
+		if reflect.DeepEqual(getSystemConfig(), config.NewSystemConfig(sc.DefaultZoneConfig)) {
 			return errors.New("system config not gossiped")
 		}
 		if getNodeLiveness() == (storagepb.Liveness{}) {

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -3326,7 +3326,7 @@ func TestMergeQueue(t *testing.T) {
 	}
 
 	rng, _ := randutil.NewPseudoRand()
-	randBytes := randutil.RandBytes(rng, int(*config.DefaultZoneConfig().RangeMinBytes))
+	randBytes := randutil.RandBytes(rng, int(*storeCfg.DefaultZoneConfig.RangeMinBytes))
 
 	reset := func(t *testing.T) {
 		t.Helper()
@@ -3336,7 +3336,7 @@ func TestMergeQueue(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		setZones(config.DefaultZoneConfig())
+		setZones(*storeCfg.DefaultZoneConfig)
 		store.MustForceMergeScanAndProcess() // drain any merges that might already be queued
 		split(t, roachpb.Key("b"))
 	}
@@ -3376,9 +3376,9 @@ func TestMergeQueue(t *testing.T) {
 
 	t.Run("lhs-undersize", func(t *testing.T) {
 		reset(t)
-		zone := config.DefaultZoneConfig()
+		zone := protoutil.Clone(storeCfg.DefaultZoneConfig).(*config.ZoneConfig)
 		*zone.RangeMinBytes *= 2
-		lhs().SetZoneConfig(&zone)
+		lhs().SetZoneConfig(zone)
 		store.MustForceMergeScanAndProcess()
 		verifyMerged(t)
 	})
@@ -3388,17 +3388,16 @@ func TestMergeQueue(t *testing.T) {
 
 		// The ranges are individually beneath the minimum size threshold, but
 		// together they'll exceed the maximum size threshold.
-		zone := config.DefaultZoneConfig()
+		zone := protoutil.Clone(storeCfg.DefaultZoneConfig).(*config.ZoneConfig)
 		zone.RangeMinBytes = proto.Int64(lhs().GetMVCCStats().Total() + 1)
 		zone.RangeMaxBytes = proto.Int64(lhs().GetMVCCStats().Total()*2 - 1)
-		setZones(zone)
+		setZones(*zone)
 		store.MustForceMergeScanAndProcess()
 		verifyUnmerged(t)
 
 		// Once the maximum size threshold is increased, the merge can occur.
-		zone = *protoutil.Clone(&zone).(*config.ZoneConfig)
-		*zone.RangeMaxBytes += 1
-		setZones(zone)
+		zone.RangeMaxBytes = proto.Int64(*zone.RangeMaxBytes + 1)
+		setZones(*zone)
 		store.MustForceMergeScanAndProcess()
 		verifyMerged(t)
 	})

--- a/pkg/storage/client_raft_log_queue_test.go
+++ b/pkg/storage/client_raft_log_queue_test.go
@@ -21,7 +21,6 @@ import (
 	"math"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -38,13 +37,11 @@ func TestRaftLogQueue(t *testing.T) {
 	// Set maxBytes to something small so we can trigger the raft log truncation
 	// without adding 64MB of logs.
 	const maxBytes = 1 << 16
-	cfg := config.DefaultZoneConfig()
-	cfg.RangeMaxBytes = proto.Int64(maxBytes)
-	defer config.TestingSetDefaultZoneConfig(cfg)()
 
 	// Turn off raft elections so the raft leader won't change out from under
 	// us in this test.
 	sc := storage.TestStoreConfig(nil)
+	sc.DefaultZoneConfig.RangeMaxBytes = proto.Int64(maxBytes)
 	sc.RaftTickInterval = math.MaxInt32
 	sc.RaftElectionTimeoutTicks = 1000000
 	mtc.storeConfig = &sc

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -1100,13 +1100,6 @@ func TestStoreRangeSplitWithMaxBytesUpdate(t *testing.T) {
 func TestStoreRangeSplitBackpressureWrites(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	// Set maxBytes to something small so we can exceed the maximum split
-	// size without adding 2x64MB of data.
-	const maxBytes = 1 << 16
-	cfg := config.DefaultZoneConfig()
-	cfg.RangeMaxBytes = proto.Int64(maxBytes)
-	defer config.TestingSetDefaultZoneConfig(cfg)()
-
 	// Backpressured writes react differently depending on whether there is an
 	// ongoing split or not. If there is an ongoing split then the writes wait
 	// on the split are only allowed to proceed if the split succeeds. If there
@@ -1135,6 +1128,10 @@ func TestStoreRangeSplitBackpressureWrites(t *testing.T) {
 			splitKey := roachpb.RKey(keys.UserTableDataMin)
 			splitPending, blockSplits := make(chan struct{}), make(chan struct{})
 			storeCfg := storage.TestStoreConfig(nil)
+			// Set maxBytes to something small so we can exceed the maximum split
+			// size without adding 2x64MB of data.
+			const maxBytes = 1 << 16
+			storeCfg.DefaultZoneConfig.RangeMaxBytes = proto.Int64(maxBytes)
 			storeCfg.TestingKnobs.DisableGCQueue = true
 			storeCfg.TestingKnobs.DisableMergeQueue = true
 			storeCfg.TestingKnobs.DisableSplitQueue = true
@@ -1272,7 +1269,7 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 
 	userTableMax := keys.MinUserDescID + 4
 	var exceptions map[int]struct{}
-	schema := sqlbase.MakeMetadataSchema()
+	schema := sqlbase.MakeMetadataSchema(config.DefaultZoneConfigRef(), config.DefaultSystemZoneConfigRef())
 	// Write table descriptors for the tables in the metadata schema as well as
 	// five dummy user tables. This does two things:
 	//   - descriptor IDs are used to determine split keys
@@ -2591,13 +2588,6 @@ func TestUnsplittableRange(t *testing.T) {
 	ctx := context.Background()
 	ttl := 1 * time.Hour
 	const maxBytes = 1 << 16
-	zoneConfig := config.DefaultZoneConfig()
-	zoneConfig.RangeMaxBytes = proto.Int64(maxBytes)
-	zoneConfig.GC = &config.GCPolicy{
-		TTLSeconds: int32(ttl.Seconds()),
-	}
-	defer config.TestingSetDefaultZoneConfig(zoneConfig)()
-	defer config.TestingSetDefaultSystemZoneConfig(zoneConfig)()
 
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
@@ -2605,6 +2595,14 @@ func TestUnsplittableRange(t *testing.T) {
 	manual := hlc.NewManualClock(123)
 	splitQueuePurgatoryChan := make(chan time.Time, 1)
 	cfg := storage.TestStoreConfig(hlc.NewClock(manual.UnixNano, time.Nanosecond))
+	cfg.DefaultZoneConfig.RangeMaxBytes = proto.Int64(maxBytes)
+	cfg.DefaultZoneConfig.GC = &config.GCPolicy{
+		TTLSeconds: int32(ttl.Seconds()),
+	}
+	cfg.DefaultSystemZoneConfig.RangeMaxBytes = proto.Int64(maxBytes)
+	cfg.DefaultSystemZoneConfig.GC = &config.GCPolicy{
+		TTLSeconds: int32(ttl.Seconds()),
+	}
 	cfg.TestingKnobs.SplitQueuePurgatoryChan = splitQueuePurgatoryChan
 	cfg.TestingKnobs.DisableMergeQueue = true
 	store := createTestStoreWithConfig(t, stopper, cfg)

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -139,7 +139,7 @@ func createTestStoreWithOpts(
 	}
 	server := rpc.NewServer(rpcContext) // never started
 	storeCfg.Gossip = gossip.NewTest(
-		nodeDesc.NodeID, rpcContext, server, stopper, metric.NewRegistry(),
+		nodeDesc.NodeID, rpcContext, server, stopper, metric.NewRegistry(), storeCfg.DefaultZoneConfig,
 	)
 	storeCfg.ScanMaxIdleTime = 1 * time.Second
 	stores := storage.NewStores(ac, storeCfg.Clock, storeCfg.Settings.Version.MinSupportedVersion, storeCfg.Settings.Version.ServerVersion)
@@ -185,7 +185,7 @@ func createTestStoreWithOpts(
 	if !opts.dontBootstrap {
 		var kvs []roachpb.KeyValue
 		var splits []roachpb.RKey
-		kvs, tableSplits := sqlbase.MakeMetadataSchema().GetInitialValues()
+		kvs, tableSplits := sqlbase.MakeMetadataSchema(storeCfg.DefaultZoneConfig, storeCfg.DefaultSystemZoneConfig).GetInitialValues()
 		if !opts.dontCreateSystemRanges {
 			splits = config.StaticSplits()
 			splits = append(splits, tableSplits...)
@@ -824,6 +824,7 @@ func (m *multiTestContext) addStore(idx int) {
 		grpcServer,
 		m.transportStopper,
 		metric.NewRegistry(),
+		config.DefaultZoneConfigRef(),
 	)
 
 	nodeID := roachpb.NodeID(idx + 1)
@@ -852,7 +853,7 @@ func (m *multiTestContext) addStore(idx int) {
 	if needBootstrap && idx == 0 {
 		// Bootstrap the initial range on the first engine.
 		var splits []roachpb.RKey
-		kvs, tableSplits := sqlbase.MakeMetadataSchema().GetInitialValues()
+		kvs, tableSplits := sqlbase.MakeMetadataSchema(cfg.DefaultZoneConfig, cfg.DefaultSystemZoneConfig).GetInitialValues()
 		if !m.startWithSingleRange {
 			splits = config.StaticSplits()
 			splits = append(splits, tableSplits...)

--- a/pkg/storage/consistency_queue_test.go
+++ b/pkg/storage/consistency_queue_test.go
@@ -57,7 +57,7 @@ func TestConsistencyQueueRequiresLive(t *testing.T) {
 
 	// Verify that queueing is immediately possible.
 	if shouldQ, priority := mtc.stores[0].ConsistencyQueueShouldQueue(
-		context.TODO(), mtc.clock.Now(), repl, config.NewSystemConfig()); !shouldQ {
+		context.TODO(), mtc.clock.Now(), repl, config.NewSystemConfig(sc.DefaultZoneConfig)); !shouldQ {
 		t.Fatalf("expected shouldQ true; got %t, %f", shouldQ, priority)
 	}
 
@@ -66,7 +66,7 @@ func TestConsistencyQueueRequiresLive(t *testing.T) {
 	mtc.advanceClock(context.TODO())
 
 	if shouldQ, priority := mtc.stores[0].ConsistencyQueueShouldQueue(
-		context.TODO(), mtc.clock.Now(), repl, config.NewSystemConfig()); shouldQ {
+		context.TODO(), mtc.clock.Now(), repl, config.NewSystemConfig(sc.DefaultZoneConfig)); shouldQ {
 		t.Fatalf("expected shouldQ false; got %t, %f", shouldQ, priority)
 	}
 }

--- a/pkg/storage/merge_queue_test.go
+++ b/pkg/storage/merge_queue_test.go
@@ -179,10 +179,10 @@ func TestMergeQueueShouldQueue(t *testing.T) {
 			repl := &Replica{}
 			repl.mu.state.Desc = &roachpb.RangeDescriptor{StartKey: tc.startKey, EndKey: tc.endKey}
 			repl.mu.state.Stats = &enginepb.MVCCStats{KeyBytes: tc.bytes}
-			zoneConfig := config.DefaultZoneConfig()
+			zoneConfig := config.DefaultZoneConfigRef()
 			zoneConfig.RangeMinBytes = proto.Int64(tc.minBytes)
-			repl.SetZoneConfig(&zoneConfig)
-			shouldQ, priority := mq.shouldQueue(ctx, hlc.Timestamp{}, repl, config.NewSystemConfig())
+			repl.SetZoneConfig(zoneConfig)
+			shouldQ, priority := mq.shouldQueue(ctx, hlc.Timestamp{}, repl, config.NewSystemConfig(zoneConfig))
 			if tc.expShouldQ != shouldQ {
 				t.Errorf("incorrect shouldQ: expected %v but got %v", tc.expShouldQ, shouldQ)
 			}

--- a/pkg/storage/queue_concurrency_test.go
+++ b/pkg/storage/queue_concurrency_test.go
@@ -67,8 +67,10 @@ func TestBaseQueueConcurrent(t *testing.T) {
 	// replicaInQueue, but this isn't an ideal world. Deal with it.
 	store := &Store{
 		cfg: StoreConfig{
-			Clock:      hlc.NewClock(hlc.UnixNano, time.Second),
-			AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()}},
+			Clock:             hlc.NewClock(hlc.UnixNano, time.Second),
+			AmbientCtx:        log.AmbientContext{Tracer: tracing.NewTracer()},
+			DefaultZoneConfig: config.DefaultZoneConfigRef(),
+		},
 	}
 
 	// Set up a queue impl that will return random results from processing.

--- a/pkg/storage/queue_test.go
+++ b/pkg/storage/queue_test.go
@@ -514,7 +514,7 @@ func TestNeedsSystemConfig(t *testing.T) {
 		tc.store.cfg.AmbientCtx, &base.Config{Insecure: true}, tc.store.cfg.Clock, stopper,
 		&cluster.MakeTestingClusterSettings().Version)
 	emptyGossip := gossip.NewTest(
-		tc.gossip.NodeID.Get(), rpcContext, rpc.NewServer(rpcContext), stopper, tc.store.Registry())
+		tc.gossip.NodeID.Get(), rpcContext, rpc.NewServer(rpcContext), stopper, tc.store.Registry(), config.DefaultZoneConfigRef())
 	bqNeedsSysCfg := makeTestBaseQueue("test", testQueue, tc.store, emptyGossip, queueConfig{
 		needsSystemConfig:    true,
 		acceptsUnsplitRanges: true,

--- a/pkg/storage/raft_transport_test.go
+++ b/pkg/storage/raft_transport_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
@@ -130,7 +131,7 @@ func newRaftTransportTestContext(t testing.TB) *raftTransportTestContext {
 
 	server := rpc.NewServer(rttc.nodeRPCContext) // never started
 	rttc.gossip = gossip.NewTest(
-		1, rttc.nodeRPCContext, server, rttc.stopper, metric.NewRegistry(),
+		1, rttc.nodeRPCContext, server, rttc.stopper, metric.NewRegistry(), config.DefaultZoneConfigRef(),
 	)
 
 	return rttc

--- a/pkg/storage/replica_init.go
+++ b/pkg/storage/replica_init.go
@@ -19,7 +19,6 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/abortspan"
 	"github.com/cockroachdb/cockroach/pkg/storage/spanlatch"
@@ -52,7 +51,7 @@ func newReplica(rangeID roachpb.RangeID, store *Store) *Replica {
 	r.mu.pendingLeaseRequest = makePendingLeaseRequest(r)
 	r.mu.stateLoader = stateloader.Make(rangeID)
 	r.mu.quiescent = true
-	r.mu.zone = config.DefaultZoneConfigRef()
+	r.mu.zone = store.cfg.DefaultZoneConfig
 	split.Init(&r.loadBasedSplitter, rand.Intn, func() float64 {
 		return float64(SplitByLoadQPSThreshold.Get(&store.cfg.Settings.SV))
 	})

--- a/pkg/storage/replicate_queue_test.go
+++ b/pkg/storage/replicate_queue_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -90,7 +91,7 @@ func TestReplicateQueueRebalance(t *testing.T) {
 		return counts
 	}
 
-	initialRanges, err := server.ExpectedInitialRangeCount(tc.Servers[0].DB())
+	initialRanges, err := server.ExpectedInitialRangeCount(tc.Servers[0].DB(), config.DefaultZoneConfigRef(), config.DefaultSystemZoneConfigRef())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1699,7 +1699,7 @@ func (s *Store) systemGossipUpdate(sysCfg *config.SystemConfig) {
 			if log.V(1) {
 				log.Infof(context.TODO(), "failed to get zone config for key %s", key)
 			}
-			zone = config.DefaultZoneConfigRef()
+			zone = s.cfg.DefaultZoneConfig
 		}
 		repl.SetZoneConfig(zone)
 		s.splitQueue.Async(ctx, "gossip update", true /* wait */, func(ctx context.Context, h queueHelper) {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -167,6 +167,8 @@ func TestStoreConfig(clock *hlc.Clock) StoreConfig {
 	}
 	st := cluster.MakeTestingClusterSettings()
 	sc := StoreConfig{
+		DefaultZoneConfig:           config.DefaultZoneConfigRef(),
+		DefaultSystemZoneConfig:     config.DefaultSystemZoneConfigRef(),
 		Settings:                    st,
 		AmbientCtx:                  log.AmbientContext{Tracer: st.Tracer},
 		Clock:                       clock,
@@ -619,16 +621,18 @@ type StoreConfig struct {
 	AmbientCtx log.AmbientContext
 	base.RaftConfig
 
-	Settings             *cluster.Settings
-	Clock                *hlc.Clock
-	DB                   *client.DB
-	Gossip               *gossip.Gossip
-	NodeLiveness         *NodeLiveness
-	StorePool            *StorePool
-	Transport            *RaftTransport
-	NodeDialer           *nodedialer.Dialer
-	RPCContext           *rpc.Context
-	RangeDescriptorCache kvbase.RangeDescriptorCache
+	DefaultZoneConfig       *config.ZoneConfig
+	DefaultSystemZoneConfig *config.ZoneConfig
+	Settings                *cluster.Settings
+	Clock                   *hlc.Clock
+	DB                      *client.DB
+	Gossip                  *gossip.Gossip
+	NodeLiveness            *NodeLiveness
+	StorePool               *StorePool
+	Transport               *RaftTransport
+	NodeDialer              *nodedialer.Dialer
+	RPCContext              *rpc.Context
+	RangeDescriptorCache    kvbase.RangeDescriptorCache
 
 	ClosedTimestamp *container.Container
 

--- a/pkg/storage/store_pool_test.go
+++ b/pkg/storage/store_pool_test.go
@@ -107,7 +107,7 @@ func createTestStorePool(
 		log.AmbientContext{Tracer: st.Tracer}, &base.Config{Insecure: true}, clock, stopper,
 		&st.Version)
 	server := rpc.NewServer(rpcContext) // never started
-	g := gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry())
+	g := gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry(), config.DefaultZoneConfigRef())
 	mnl := newMockNodeLiveness(defaultNodeStatus)
 
 	TimeUntilStoreDead.Override(&st.SV, timeUntilStoreDeadValue)

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -120,7 +120,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 	rpcContext.NodeID.Set(ambient.AnnotateCtx(context.Background()), nodeID)
 	c := &rpcContext.ClusterID
 	server := rpc.NewServer(rpcContext) // never started
-	ltc.Gossip = gossip.New(ambient, c, nc, rpcContext, server, ltc.Stopper, metric.NewRegistry(), roachpb.Locality{})
+	ltc.Gossip = gossip.New(ambient, c, nc, rpcContext, server, ltc.Stopper, metric.NewRegistry(), roachpb.Locality{}, config.DefaultZoneConfigRef())
 	ltc.Eng = engine.NewInMem(roachpb.Attributes{}, 50<<20)
 	ltc.Stopper.AddCloser(ltc.Eng)
 
@@ -181,7 +181,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 	var initialValues []roachpb.KeyValue
 	var splits []roachpb.RKey
 	if !ltc.DontCreateSystemRanges {
-		schema := sqlbase.MakeMetadataSchema()
+		schema := sqlbase.MakeMetadataSchema(cfg.DefaultZoneConfig, cfg.DefaultSystemZoneConfig)
 		var tableSplits []roachpb.RKey
 		initialValues, tableSplits = schema.GetInitialValues()
 		splits = append(config.StaticSplits(), tableSplits...)


### PR DESCRIPTION
Previously the default zone config was stored as a global and code in various layers would use `config.DefaultZoneConfig()` directly. It was difficult for parallel tests to modify the global and restore it
correctly.

The default zone config can be overridden in tests by setting the `DefaultZoneConfigOverride` testing knob.

Fixes #37054