### PR TITLE
roachprod: distribute authorized_keys to creating user on gce

### DIFF
--- a/pkg/cmd/roachprod/install/cluster_synced.go
+++ b/pkg/cmd/roachprod/install/cluster_synced.go
@@ -703,6 +703,11 @@ fi
 		return nil, nil
 	})
 	if len(c.AuthorizedKeys) > 0 {
+		// When clusters are created using cloud APIs they only have a subset of
+		// desired keys installed on a subset of users. This code distributes
+		// additional authorized_keys to both the current user (your username on
+		// gce and the shared user on aws) as well as to the shared user on both
+		// platforms.
 		c.Parallel("adding additional authorized keys", len(c.Nodes), 0, func(i int) ([]byte, error) {
 			sess, err := c.newSession(c.Nodes[i])
 			if err != nil {
@@ -711,7 +716,6 @@ fi
 			defer sess.Close()
 
 			sess.SetStdin(bytes.NewReader(c.AuthorizedKeys))
-
 			const cmd = `
 keys_data="$(cat)"
 set -e
@@ -721,12 +725,19 @@ on_exit() {
     rm -f "${tmp1}" "${tmp2}"
 }
 trap on_exit EXIT
-[[ -f ~/.ssh/authorized_keys ]] && cat ~/.ssh/authorized_keys > "${tmp1}"
+if [[ -f ~/.ssh/authorized_keys ]]; then
+    cat ~/.ssh/authorized_keys > "${tmp1}"
+fi
 echo "${keys_data}" >> "${tmp1}"
 sort -u < "${tmp1}" > "${tmp2}"
-sudo install --mode 0600 --owner ` + sharedUser +
-				` --group ` + sharedUser +
-				` "${tmp2}" ~` + sharedUser + `/.ssh/authorized_keys`
+install --mode 0600 "${tmp2}" ~/.ssh/authorized_keys
+if [[ "$(whoami)" != "` + sharedUser + `" ]]; then
+    sudo install --mode 0600 \
+        --owner ` + sharedUser + `\
+        --group ` + sharedUser + `\
+        "${tmp2}" ~` + sharedUser + `/.ssh/authorized_keys
+fi
+`
 			if out, err := sess.CombinedOutput(cmd); err != nil {
 				return nil, errors.Wrapf(err, "~ %s\n%s", cmd, out)
 			}


### PR DESCRIPTION
Previously in #35759 logic was added to read public keys from the gce project
metadata and distribute them into the authorized_keys file of the shared user
(ubuntu) on AWS. #37077 primarily served to distribute known_hosts files to
the shared user (ubuntu) on both AWS and GCE as well as the creating user on GCE.
That change also included logic to write the authorized_keys file to the shared
user on GCE (as opposed to just AWS) in anticipation of switching roachprod to
use the shared user across cloud providers. This change extends the previous
change by also distributing all public keys to the authorized_keys file for the
cluster creating user on GCE.

Release note: None