### PR TITLE
roachprod: prevent infinite loop in monitor --oneshot

### DIFF
--- a/pkg/cmd/roachprod/install/session.go
+++ b/pkg/cmd/roachprod/install/session.go
@@ -32,10 +32,12 @@ type session interface {
 	SetStdin(r io.Reader)
 	SetStdout(w io.Writer)
 	SetStderr(w io.Writer)
+	Start(cmd string) error
 	StdinPipe() (io.WriteCloser, error)
 	StdoutPipe() (io.Reader, error)
 	StderrPipe() (io.Reader, error)
 	RequestPty() error
+	Wait() error
 	Close()
 }
 
@@ -73,6 +75,11 @@ func (s *remoteSession) Run(cmd string) error {
 	return s.Cmd.Run()
 }
 
+func (s *remoteSession) Start(cmd string) error {
+	s.Cmd.Args = append(s.Cmd.Args, cmd)
+	return s.Cmd.Start()
+}
+
 func (s *remoteSession) SetStdin(r io.Reader) {
 	s.Stdin = r
 }
@@ -104,6 +111,10 @@ func (s *remoteSession) RequestPty() error {
 	return nil
 }
 
+func (s *remoteSession) Wait() error {
+	return s.Cmd.Wait()
+}
+
 func (s *remoteSession) Close() {
 	s.cancel()
 }
@@ -127,6 +138,11 @@ func (s *localSession) CombinedOutput(cmd string) ([]byte, error) {
 func (s *localSession) Run(cmd string) error {
 	s.Cmd.Args = append(s.Cmd.Args, cmd)
 	return s.Cmd.Run()
+}
+
+func (s *localSession) Start(cmd string) error {
+	s.Cmd.Args = append(s.Cmd.Args, cmd)
+	return s.Cmd.Start()
 }
 
 func (s *localSession) SetStdin(r io.Reader) {
@@ -157,6 +173,10 @@ func (s *localSession) StderrPipe() (io.Reader, error) {
 
 func (s *localSession) RequestPty() error {
 	return nil
+}
+
+func (s *localSession) Wait() error {
+	return s.Cmd.Wait()
 }
 
 func (s *localSession) Close() {


### PR DESCRIPTION
The os/exec package suggests not using `StdoutPipe()` together with
`Run()` as run might close the pipe while we're reading from it. Instead
of `Run()` we should use `Start()` followed by `Wait()`, ensuring that
the reads from the pipe all complete before the `Wait()`.

This prevents an infinite loop in the goroutine reading from the stdout
pipe. When `Run()` was closing the pipe before it reached EOF, `ReadLine()`
was returning an error saying the file was already closed (different
from EOF) and an empty line, causing it to print output like this
forever:

```
$ go run ./pkg/cmd/roachprod monitor local --oneshot
1:
1:
1:
1:
1:
...
```

Now, I've run it many many times and verified it doesn't get stuck in an
infinite loop printing empty status for any nodes.

Fixes #37389.

Release note: None