### PR TITLE
roachtest: add TPCH benchmark to roachperf

### DIFF
--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -75,7 +75,7 @@ func registerTests(r *registry) {
 	registerUpgrade(r)
 	registerVersion(r)
 	registerYCSB(r)
-	registerSQL20Bench(r)
+	registerTPCHBench(r)
 }
 
 func registerBenchmarks(r *registry) {
@@ -84,5 +84,5 @@ func registerBenchmarks(r *registry) {
 	// grep -h -E 'func register[^(]+\(.*registry\) {' *.go | grep -E -o 'register[^(]+' | grep -v '^registerTests$' | grep '^\w*Bench$' | sort | awk '{printf "\t%s(r)\n", $0}'
 
 	registerTPCCBench(r)
-	registerSQL20Bench(r)
+	registerTPCHBench(r)
 }

--- a/pkg/cmd/roachtest/tpchbench_string.go
+++ b/pkg/cmd/roachtest/tpchbench_string.go
@@ -9,11 +9,12 @@ func _() {
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
 	_ = x[sql20-0]
+	_ = x[tpch-1]
 }
 
-const _tpchBench_name = "sql20"
+const _tpchBench_name = "sql20tpch"
 
-var _tpchBench_index = [...]uint8{0, 5}
+var _tpchBench_index = [...]uint8{0, 5, 9}
 
 func (i tpchBench) String() string {
 	if i < 0 || i >= tpchBench(len(_tpchBench_index)-1) {


### PR DESCRIPTION
Adds TPCH benchmark to be run regularly and displayed on roachperf.
At the moment, query 15 is not being run.

Fixes: #37416.

Release note: None