### PR TITLE
opt: add some window function norm rules

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -3014,8 +3014,9 @@ SELECT sum(a) OVER (PARTITION BY count(a) OVER () + 1) FROM x
 statement error window function calls cannot be nested
 SELECT sum(a) OVER (ORDER BY count(a) OVER () + 1) FROM x
 
-statement error more than one row returned by a subquery used as an expression
-SELECT sum(a) OVER (PARTITION BY (SELECT count(*) FROM x GROUP BY a)) FROM x
+# TODO(justin): blocked by #37134.
+# statement error more than one row returned by a subquery used as an expression
+# SELECT sum(a) OVER (PARTITION BY (SELECT count(*) FROM x GROUP BY a)) FROM x
 
 query I
 SELECT sum(a) OVER (PARTITION BY (SELECT count(*) FROM x GROUP BY a LIMIT 1))::INT FROM x

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
@@ -298,19 +298,16 @@ render                    ·            ·            (min)     ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(row_number() OVER()) y FROM xyz
 ----
-render                    ·            ·                     (y)                              ·
- │                        render 0     y                     ·                                ·
- └── distinct             ·            ·                     (y, row_number)                  weak-key(row_number)
-      │                   distinct on  row_number            ·                                ·
-      └── render          ·            ·                     (y, row_number)                  ·
-           │              render 0     y                     ·                                ·
-           │              render 1     row_number            ·                                ·
-           └── window     ·            ·                     (x, y, z, pk1, pk2, row_number)  ·
-                │         window 0     row_number() OVER ()  ·                                ·
-                │         render 5     row_number() OVER ()  ·                                ·
-                └── scan  ·            ·                     (x, y, z, pk1, pk2)              ·
-·                         table        xyz@primary           ·                                ·
-·                         spans        ALL                   ·                                ·
+render               ·            ·                     (y)              ·
+ │                   render 0     y                     ·                ·
+ └── distinct        ·            ·                     (y, row_number)  weak-key(row_number)
+      │              distinct on  row_number            ·                ·
+      └── window     ·            ·                     (y, row_number)  ·
+           │         window 0     row_number() OVER ()  ·                ·
+           │         render 1     row_number() OVER ()  ·                ·
+           └── scan  ·            ·                     (y)              ·
+·                    table        xyz@primary           ·                ·
+·                    spans        ALL                   ·                ·
 
 ###########################
 # With ordinal references #

--- a/pkg/sql/opt/exec/execbuilder/testdata/window
+++ b/pkg/sql/opt/exec/execbuilder/testdata/window
@@ -57,45 +57,31 @@ output row: [8 3.5355339059327376220]
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ntile(1) OVER () FROM kv
 ----
-render               ·         ·                  (ntile)                                     ·
- │                   render 0  ntile              ·                                           ·
- └── window          ·         ·                  (k, v, w, f, d, s, b, ntile_1_arg1, ntile)  ·
-      │              window 0  ntile(@8) OVER ()  ·                                           ·
-      │              render 8  ntile(@8) OVER ()  ·                                           ·
-      └── render     ·         ·                  (k, v, w, f, d, s, b, ntile_1_arg1)         ·
-           │         render 0  k                  ·                                           ·
-           │         render 1  v                  ·                                           ·
-           │         render 2  w                  ·                                           ·
-           │         render 3  f                  ·                                           ·
-           │         render 4  d                  ·                                           ·
-           │         render 5  s                  ·                                           ·
-           │         render 6  b                  ·                                           ·
-           │         render 7  1                  ·                                           ·
-           └── scan  ·         ·                  (k, v, w, f, d, s, b)                       ·
-·                    table     kv@primary         ·                                           ·
-·                    spans     ALL                ·                                           ·
+render               ·         ·                  (ntile)                ·
+ │                   render 0  ntile              ·                      ·
+ └── window          ·         ·                  (ntile_1_arg1, ntile)  ·
+      │              window 0  ntile(@1) OVER ()  ·                      ·
+      │              render 1  ntile(@1) OVER ()  ·                      ·
+      └── render     ·         ·                  (ntile_1_arg1)         ·
+           │         render 0  1                  ·                      ·
+           └── scan  ·         ·                  ()                     ·
+·                    table     kv@primary         ·                      ·
+·                    spans     ALL                ·                      ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT nth_value(1, 2) OVER () FROM kv
 ----
-render               ·         ·                          (nth_value)                                                           ·
- │                   render 0  nth_value                  ·                                                                     ·
- └── window          ·         ·                          (k, v, w, f, d, s, b, nth_value_1_arg1, nth_value_1_arg2, nth_value)  ·
-      │              window 0  nth_value(@8, @9) OVER ()  ·                                                                     ·
-      │              render 9  nth_value(@8, @9) OVER ()  ·                                                                     ·
-      └── render     ·         ·                          (k, v, w, f, d, s, b, nth_value_1_arg1, nth_value_1_arg2)             ·
-           │         render 0  k                          ·                                                                     ·
-           │         render 1  v                          ·                                                                     ·
-           │         render 2  w                          ·                                                                     ·
-           │         render 3  f                          ·                                                                     ·
-           │         render 4  d                          ·                                                                     ·
-           │         render 5  s                          ·                                                                     ·
-           │         render 6  b                          ·                                                                     ·
-           │         render 7  1                          ·                                                                     ·
-           │         render 8  2                          ·                                                                     ·
-           └── scan  ·         ·                          (k, v, w, f, d, s, b)                                                 ·
-·                    table     kv@primary                 ·                                                                     ·
-·                    spans     ALL                        ·                                                                     ·
+render               ·         ·                          (nth_value)                                      ·
+ │                   render 0  nth_value                  ·                                                ·
+ └── window          ·         ·                          (nth_value_1_arg1, nth_value_1_arg2, nth_value)  ·
+      │              window 0  nth_value(@1, @2) OVER ()  ·                                                ·
+      │              render 2  nth_value(@1, @2) OVER ()  ·                                                ·
+      └── render     ·         ·                          (nth_value_1_arg1, nth_value_1_arg2)             ·
+           │         render 0  1                          ·                                                ·
+           │         render 1  2                          ·                                                ·
+           └── scan  ·         ·                          ()                                               ·
+·                    table     kv@primary                 ·                                                ·
+·                    spans     ALL                        ·                                                ·
 
 statement error column "v" must appear in the GROUP BY clause or be used in an aggregate function
 EXPLAIN (VERBOSE) SELECT max(v) OVER (), min(v) FROM kv ORDER BY 1
@@ -132,233 +118,146 @@ sort                 ·         ·                                         (k in
 query TTTTT
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
 ----
-render                                   ·          ·                                                                             (k int, stddev decimal)                                                                                                                                 ·
- │                                       render 0   (k)[int]                                                                      ·                                                                                                                                                       ·
- │                                       render 1   (stddev)[decimal]                                                             ·                                                                                                                                                       ·
- └── sort                                ·          ·                                                                             (k int, stddev decimal, variance decimal)                                                                                                               +variance,+k
-      │                                  order      +variance,+k                                                                  ·                                                                                                                                                       ·
-      └── render                         ·          ·                                                                             (k int, stddev decimal, variance decimal)                                                                                                               ·
-           │                             render 0   (k)[int]                                                                      ·                                                                                                                                                       ·
-           │                             render 1   (stddev)[decimal]                                                             ·                                                                                                                                                       ·
-           │                             render 2   (variance)[decimal]                                                           ·                                                                                                                                                       ·
-           └── window                    ·          ·                                                                             (k int, v int, w int, f float, d decimal, s string, b bool, stddev decimal, stddev_1_partition_2 string, variance_2_partition_2 int, variance decimal)  ·
-                │                        window 0   (variance((@5)[decimal]) OVER (PARTITION BY (@2)[int], (@10)[int]))[decimal]  ·                                                                                                                                                       ·
-                │                        render 10  (variance((@5)[decimal]) OVER (PARTITION BY (@2)[int], (@10)[int]))[decimal]  ·                                                                                                                                                       ·
-                └── render               ·          ·                                                                             (k int, v int, w int, f float, d decimal, s string, b bool, stddev decimal, stddev_1_partition_2 string, variance_2_partition_2 int)                    ·
-                     │                   render 0   (k)[int]                                                                      ·                                                                                                                                                       ·
-                     │                   render 1   (v)[int]                                                                      ·                                                                                                                                                       ·
-                     │                   render 2   (w)[int]                                                                      ·                                                                                                                                                       ·
-                     │                   render 3   (f)[float]                                                                    ·                                                                                                                                                       ·
-                     │                   render 4   (d)[decimal]                                                                  ·                                                                                                                                                       ·
-                     │                   render 5   (s)[string]                                                                   ·                                                                                                                                                       ·
-                     │                   render 6   (b)[bool]                                                                     ·                                                                                                                                                       ·
-                     │                   render 7   (stddev)[decimal]                                                             ·                                                                                                                                                       ·
-                     │                   render 8   (stddev_1_partition_2)[string]                                                ·                                                                                                                                                       ·
-                     │                   render 9   (variance_2_partition_2)[int]                                                 ·                                                                                                                                                       ·
-                     └── window          ·          ·                                                                             (k int, v int, w int, f float, d decimal, s string, b bool, stddev_1_partition_2 string, variance_2_partition_2 int, stddev decimal)                    ·
-                          │              window 0   (stddev((@5)[decimal]) OVER (PARTITION BY (@2)[int], (@8)[string]))[decimal]  ·                                                                                                                                                       ·
-                          │              render 9   (stddev((@5)[decimal]) OVER (PARTITION BY (@2)[int], (@8)[string]))[decimal]  ·                                                                                                                                                       ·
-                          └── render     ·          ·                                                                             (k int, v int, w int, f float, d decimal, s string, b bool, stddev_1_partition_2 string, variance_2_partition_2 int)                                    ·
-                               │         render 0   (k)[int]                                                                      ·                                                                                                                                                       ·
-                               │         render 1   (v)[int]                                                                      ·                                                                                                                                                       ·
-                               │         render 2   (w)[int]                                                                      ·                                                                                                                                                       ·
-                               │         render 3   (f)[float]                                                                    ·                                                                                                                                                       ·
-                               │         render 4   (d)[decimal]                                                                  ·                                                                                                                                                       ·
-                               │         render 5   (s)[string]                                                                   ·                                                                                                                                                       ·
-                               │         render 6   (b)[bool]                                                                     ·                                                                                                                                                       ·
-                               │         render 7   ('a')[string]                                                                 ·                                                                                                                                                       ·
-                               │         render 8   (100)[int]                                                                    ·                                                                                                                                                       ·
-                               └── scan  ·          ·                                                                             (k int, v int, w int, f float, d decimal, s string, b bool)                                                                                             ·
-·                                        table      kv@primary                                                                    ·                                                                                                                                                       ·
-·                                        spans      ALL                                                                           ·                                                                                                                                                       ·
+render                         ·         ·                                                                 (k int, stddev decimal)                                      ·
+ │                             render 0  (k)[int]                                                          ·                                                            ·
+ │                             render 1  (stddev)[decimal]                                                 ·                                                            ·
+ └── sort                      ·         ·                                                                 (k int, stddev decimal, variance decimal)                    +variance,+k
+      │                        order     +variance,+k                                                      ·                                                            ·
+      └── render               ·         ·                                                                 (k int, stddev decimal, variance decimal)                    ·
+           │                   render 0  (k)[int]                                                          ·                                                            ·
+           │                   render 1  (stddev)[decimal]                                                 ·                                                            ·
+           │                   render 2  (variance)[decimal]                                               ·                                                            ·
+           └── window          ·         ·                                                                 (k int, v int, d decimal, stddev decimal, variance decimal)  ·
+                │              window 0  (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int]))[decimal]  ·                                                            ·
+                │              render 4  (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int]))[decimal]  ·                                                            ·
+                └── window     ·         ·                                                                 (k int, v int, d decimal, stddev decimal)                    ·
+                     │         window 0  (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int]))[decimal]    ·                                                            ·
+                     │         render 3  (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int]))[decimal]    ·                                                            ·
+                     └── scan  ·         ·                                                                 (k int, v int, d decimal)                                    ·
+·                              table     kv@primary                                                        ·                                                            ·
+·                              spans     ALL                                                               ·                                                            ·
 
 query TTTTT
 EXPLAIN (TYPES,NONORMALIZE) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY k
 ----
-sort                      ·         ·                                                                             (k int, stddev decimal)                                                                                   +k
- │                        order     +k                                                                            ·                                                                                                         ·
- └── render               ·         ·                                                                             (k int, stddev decimal)                                                                                   ·
-      │                   render 0  (k)[int]                                                                      ·                                                                                                         ·
-      │                   render 1  (stddev)[decimal]                                                             ·                                                                                                         ·
-      └── window          ·         ·                                                                             (k int, v int, w int, f float, d decimal, s string, b bool, stddev_1_partition_2 string, stddev decimal)  ·
-           │              window 0  (stddev((@5)[decimal]) OVER (PARTITION BY (@2)[int], (@8)[string]))[decimal]  ·                                                                                                         ·
-           │              render 8  (stddev((@5)[decimal]) OVER (PARTITION BY (@2)[int], (@8)[string]))[decimal]  ·                                                                                                         ·
-           └── render     ·         ·                                                                             (k int, v int, w int, f float, d decimal, s string, b bool, stddev_1_partition_2 string)                  ·
-                │         render 0  (k)[int]                                                                      ·                                                                                                         ·
-                │         render 1  (v)[int]                                                                      ·                                                                                                         ·
-                │         render 2  (w)[int]                                                                      ·                                                                                                         ·
-                │         render 3  (f)[float]                                                                    ·                                                                                                         ·
-                │         render 4  (d)[decimal]                                                                  ·                                                                                                         ·
-                │         render 5  (s)[string]                                                                   ·                                                                                                         ·
-                │         render 6  (b)[bool]                                                                     ·                                                                                                         ·
-                │         render 7  ('a')[string]                                                                 ·                                                                                                         ·
-                └── scan  ·         ·                                                                             (k int, v int, w int, f float, d decimal, s string, b bool)                                               ·
-·                         table     kv@primary                                                                    ·                                                                                                         ·
-·                         spans     ALL                                                                           ·                                                                                                         ·
+sort                 ·         ·                                                               (k int, stddev decimal)                    +k
+ │                   order     +k                                                              ·                                          ·
+ └── render          ·         ·                                                               (k int, stddev decimal)                    ·
+      │              render 0  (k)[int]                                                        ·                                          ·
+      │              render 1  (stddev)[decimal]                                               ·                                          ·
+      └── window     ·         ·                                                               (k int, v int, d decimal, stddev decimal)  ·
+           │         window 0  (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int]))[decimal]  ·                                          ·
+           │         render 3  (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int]))[decimal]  ·                                          ·
+           └── scan  ·         ·                                                               (k int, v int, d decimal)                  ·
+·                    table     kv@primary                                                      ·                                          ·
+·                    spans     ALL                                                             ·                                          ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT k, k + stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
 ----
-render                                   ·          ·                                                                             (k int, "?column?" decimal)                                                                                                                             ·
- │                                       render 0   (k)[int]                                                                      ·                                                                                                                                                       ·
- │                                       render 1   ("?column?")[decimal]                                                         ·                                                                                                                                                       ·
- └── sort                                ·          ·                                                                             ("?column?" decimal, k int, variance decimal)                                                                                                           +variance,+k
-      │                                  order      +variance,+k                                                                  ·                                                                                                                                                       ·
-      └── render                         ·          ·                                                                             ("?column?" decimal, k int, variance decimal)                                                                                                           ·
-           │                             render 0   ((k)[int] + (stddev)[decimal])[decimal]                                       ·                                                                                                                                                       ·
-           │                             render 1   (k)[int]                                                                      ·                                                                                                                                                       ·
-           │                             render 2   (variance)[decimal]                                                           ·                                                                                                                                                       ·
-           └── window                    ·          ·                                                                             (k int, v int, w int, f float, d decimal, s string, b bool, stddev decimal, stddev_1_partition_2 string, variance_2_partition_2 int, variance decimal)  ·
-                │                        window 0   (variance((@5)[decimal]) OVER (PARTITION BY (@2)[int], (@10)[int]))[decimal]  ·                                                                                                                                                       ·
-                │                        render 10  (variance((@5)[decimal]) OVER (PARTITION BY (@2)[int], (@10)[int]))[decimal]  ·                                                                                                                                                       ·
-                └── render               ·          ·                                                                             (k int, v int, w int, f float, d decimal, s string, b bool, stddev decimal, stddev_1_partition_2 string, variance_2_partition_2 int)                    ·
-                     │                   render 0   (k)[int]                                                                      ·                                                                                                                                                       ·
-                     │                   render 1   (v)[int]                                                                      ·                                                                                                                                                       ·
-                     │                   render 2   (w)[int]                                                                      ·                                                                                                                                                       ·
-                     │                   render 3   (f)[float]                                                                    ·                                                                                                                                                       ·
-                     │                   render 4   (d)[decimal]                                                                  ·                                                                                                                                                       ·
-                     │                   render 5   (s)[string]                                                                   ·                                                                                                                                                       ·
-                     │                   render 6   (b)[bool]                                                                     ·                                                                                                                                                       ·
-                     │                   render 7   (stddev)[decimal]                                                             ·                                                                                                                                                       ·
-                     │                   render 8   (stddev_1_partition_2)[string]                                                ·                                                                                                                                                       ·
-                     │                   render 9   (variance_2_partition_2)[int]                                                 ·                                                                                                                                                       ·
-                     └── window          ·          ·                                                                             (k int, v int, w int, f float, d decimal, s string, b bool, stddev_1_partition_2 string, variance_2_partition_2 int, stddev decimal)                    ·
-                          │              window 0   (stddev((@5)[decimal]) OVER (PARTITION BY (@2)[int], (@8)[string]))[decimal]  ·                                                                                                                                                       ·
-                          │              render 9   (stddev((@5)[decimal]) OVER (PARTITION BY (@2)[int], (@8)[string]))[decimal]  ·                                                                                                                                                       ·
-                          └── render     ·          ·                                                                             (k int, v int, w int, f float, d decimal, s string, b bool, stddev_1_partition_2 string, variance_2_partition_2 int)                                    ·
-                               │         render 0   (k)[int]                                                                      ·                                                                                                                                                       ·
-                               │         render 1   (v)[int]                                                                      ·                                                                                                                                                       ·
-                               │         render 2   (w)[int]                                                                      ·                                                                                                                                                       ·
-                               │         render 3   (f)[float]                                                                    ·                                                                                                                                                       ·
-                               │         render 4   (d)[decimal]                                                                  ·                                                                                                                                                       ·
-                               │         render 5   (s)[string]                                                                   ·                                                                                                                                                       ·
-                               │         render 6   (b)[bool]                                                                     ·                                                                                                                                                       ·
-                               │         render 7   ('a')[string]                                                                 ·                                                                                                                                                       ·
-                               │         render 8   (100)[int]                                                                    ·                                                                                                                                                       ·
-                               └── scan  ·          ·                                                                             (k int, v int, w int, f float, d decimal, s string, b bool)                                                                                             ·
-·                                        table      kv@primary                                                                    ·                                                                                                                                                       ·
-·                                        spans      ALL                                                                           ·                                                                                                                                                       ·
+render                         ·         ·                                                                 (k int, "?column?" decimal)                                  ·
+ │                             render 0  (k)[int]                                                          ·                                                            ·
+ │                             render 1  ("?column?")[decimal]                                             ·                                                            ·
+ └── sort                      ·         ·                                                                 ("?column?" decimal, k int, variance decimal)                +variance,+k
+      │                        order     +variance,+k                                                      ·                                                            ·
+      └── render               ·         ·                                                                 ("?column?" decimal, k int, variance decimal)                ·
+           │                   render 0  ((k)[int] + (stddev)[decimal])[decimal]                           ·                                                            ·
+           │                   render 1  (k)[int]                                                          ·                                                            ·
+           │                   render 2  (variance)[decimal]                                               ·                                                            ·
+           └── window          ·         ·                                                                 (k int, v int, d decimal, stddev decimal, variance decimal)  ·
+                │              window 0  (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int]))[decimal]  ·                                                            ·
+                │              render 4  (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int]))[decimal]  ·                                                            ·
+                └── window     ·         ·                                                                 (k int, v int, d decimal, stddev decimal)                    ·
+                     │         window 0  (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int]))[decimal]    ·                                                            ·
+                     │         render 3  (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int]))[decimal]    ·                                                            ·
+                     └── scan  ·         ·                                                                 (k int, v int, d decimal)                                    ·
+·                              table     kv@primary                                                        ·                                                            ·
+·                              spans     ALL                                                               ·                                                            ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT max(k), max(k) + stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROUP BY d, v ORDER BY variance(d) OVER (PARTITION BY v, 100)
 ----
-render                                        ·            ·                                                                             (max int, "?column?" decimal)                                                                                           ·
- │                                            render 0     (max)[int]                                                                    ·                                                                                                                       ·
- │                                            render 1     ("?column?")[decimal]                                                         ·                                                                                                                       ·
- └── sort                                     ·            ·                                                                             ("?column?" decimal, max int, variance decimal)                                                                         +variance
-      │                                       order        +variance                                                                     ·                                                                                                                       ·
-      └── render                              ·            ·                                                                             ("?column?" decimal, max int, variance decimal)                                                                         ·
-           │                                  render 0     ((max)[int] + (stddev)[decimal])[decimal]                                     ·                                                                                                                       ·
-           │                                  render 1     (max)[int]                                                                    ·                                                                                                                       ·
-           │                                  render 2     (variance)[decimal]                                                           ·                                                                                                                       ·
-           └── window                         ·            ·                                                                             (v int, d decimal, max int, stddev decimal, stddev_1_partition_2 string, variance_2_partition_2 int, variance decimal)  ·
-                │                             window 0     (variance((@2)[decimal]) OVER (PARTITION BY (@1)[int], (@6)[int]))[decimal]   ·                                                                                                                       ·
-                │                             render 6     (variance((@2)[decimal]) OVER (PARTITION BY (@1)[int], (@6)[int]))[decimal]   ·                                                                                                                       ·
-                └── render                    ·            ·                                                                             (v int, d decimal, max int, stddev decimal, stddev_1_partition_2 string, variance_2_partition_2 int)                    ·
-                     │                        render 0     (v)[int]                                                                      ·                                                                                                                       ·
-                     │                        render 1     (d)[decimal]                                                                  ·                                                                                                                       ·
-                     │                        render 2     (max)[int]                                                                    ·                                                                                                                       ·
-                     │                        render 3     (stddev)[decimal]                                                             ·                                                                                                                       ·
-                     │                        render 4     (stddev_1_partition_2)[string]                                                ·                                                                                                                       ·
-                     │                        render 5     (variance_2_partition_2)[int]                                                 ·                                                                                                                       ·
-                     └── window               ·            ·                                                                             (v int, d decimal, max int, stddev_1_partition_2 string, variance_2_partition_2 int, stddev decimal)                    ·
-                          │                   window 0     (stddev((@2)[decimal]) OVER (PARTITION BY (@1)[int], (@4)[string]))[decimal]  ·                                                                                                                       ·
-                          │                   render 5     (stddev((@2)[decimal]) OVER (PARTITION BY (@1)[int], (@4)[string]))[decimal]  ·                                                                                                                       ·
-                          └── render          ·            ·                                                                             (v int, d decimal, max int, stddev_1_partition_2 string, variance_2_partition_2 int)                                    ·
-                               │              render 0     (v)[int]                                                                      ·                                                                                                                       ·
-                               │              render 1     (d)[decimal]                                                                  ·                                                                                                                       ·
-                               │              render 2     (max)[int]                                                                    ·                                                                                                                       ·
-                               │              render 3     ('a')[string]                                                                 ·                                                                                                                       ·
-                               │              render 4     (100)[int]                                                                    ·                                                                                                                       ·
-                               └── group      ·            ·                                                                             (v int, d decimal, max int)                                                                                             ·
-                                    │         aggregate 0  v                                                                             ·                                                                                                                       ·
-                                    │         aggregate 1  d                                                                             ·                                                                                                                       ·
-                                    │         aggregate 2  max(k)                                                                        ·                                                                                                                       ·
-                                    │         group by     @2,@3                                                                         ·                                                                                                                       ·
-                                    └── scan  ·            ·                                                                             (k int, v int, d decimal)                                                                                               ·
-·                                             table        kv@primary                                                                    ·                                                                                                                       ·
-·                                             spans        ALL                                                                           ·                                                                                                                       ·
+render                              ·            ·                                                                 (max int, "?column?" decimal)                                  ·
+ │                                  render 0     (max)[int]                                                        ·                                                              ·
+ │                                  render 1     ("?column?")[decimal]                                             ·                                                              ·
+ └── sort                           ·            ·                                                                 ("?column?" decimal, max int, variance decimal)                +variance
+      │                             order        +variance                                                         ·                                                              ·
+      └── render                    ·            ·                                                                 ("?column?" decimal, max int, variance decimal)                ·
+           │                        render 0     ((max)[int] + (stddev)[decimal])[decimal]                         ·                                                              ·
+           │                        render 1     (max)[int]                                                        ·                                                              ·
+           │                        render 2     (variance)[decimal]                                               ·                                                              ·
+           └── window               ·            ·                                                                 (v int, d decimal, max int, stddev decimal, variance decimal)  ·
+                │                   window 0     (variance((@2)[decimal]) OVER (PARTITION BY (@1)[int]))[decimal]  ·                                                              ·
+                │                   render 4     (variance((@2)[decimal]) OVER (PARTITION BY (@1)[int]))[decimal]  ·                                                              ·
+                └── window          ·            ·                                                                 (v int, d decimal, max int, stddev decimal)                    ·
+                     │              window 0     (stddev((@2)[decimal]) OVER (PARTITION BY (@1)[int]))[decimal]    ·                                                              ·
+                     │              render 3     (stddev((@2)[decimal]) OVER (PARTITION BY (@1)[int]))[decimal]    ·                                                              ·
+                     └── group      ·            ·                                                                 (v int, d decimal, max int)                                    ·
+                          │         aggregate 0  v                                                                 ·                                                              ·
+                          │         aggregate 1  d                                                                 ·                                                              ·
+                          │         aggregate 2  max(k)                                                            ·                                                              ·
+                          │         group by     @2,@3                                                             ·                                                              ·
+                          └── scan  ·            ·                                                                 (k int, v int, d decimal)                                      ·
+·                                   table        kv@primary                                                        ·                                                              ·
+·                                   spans        ALL                                                               ·                                                              ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT max(k), stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROUP BY d, v ORDER BY 1
 ----
-sort                           ·            ·                                                                             (max int, stddev decimal)                                                 +max
- │                             order        +max                                                                          ·                                                                         ·
- └── render                    ·            ·                                                                             (max int, stddev decimal)                                                 ·
-      │                        render 0     (max)[int]                                                                    ·                                                                         ·
-      │                        render 1     (stddev)[decimal]                                                             ·                                                                         ·
-      └── window               ·            ·                                                                             (v int, d decimal, max int, stddev_1_partition_2 string, stddev decimal)  ·
-           │                   window 0     (stddev((@2)[decimal]) OVER (PARTITION BY (@1)[int], (@4)[string]))[decimal]  ·                                                                         ·
-           │                   render 4     (stddev((@2)[decimal]) OVER (PARTITION BY (@1)[int], (@4)[string]))[decimal]  ·                                                                         ·
-           └── render          ·            ·                                                                             (v int, d decimal, max int, stddev_1_partition_2 string)                  ·
-                │              render 0     (v)[int]                                                                      ·                                                                         ·
-                │              render 1     (d)[decimal]                                                                  ·                                                                         ·
-                │              render 2     (max)[int]                                                                    ·                                                                         ·
-                │              render 3     ('a')[string]                                                                 ·                                                                         ·
-                └── group      ·            ·                                                                             (v int, d decimal, max int)                                               ·
-                     │         aggregate 0  v                                                                             ·                                                                         ·
-                     │         aggregate 1  d                                                                             ·                                                                         ·
-                     │         aggregate 2  max(k)                                                                        ·                                                                         ·
-                     │         group by     @2,@3                                                                         ·                                                                         ·
-                     └── scan  ·            ·                                                                             (k int, v int, d decimal)                                                 ·
-·                              table        kv@primary                                                                    ·                                                                         ·
-·                              spans        ALL                                                                           ·                                                                         ·
+sort                      ·            ·                                                               (max int, stddev decimal)                    +max
+ │                        order        +max                                                            ·                                            ·
+ └── render               ·            ·                                                               (max int, stddev decimal)                    ·
+      │                   render 0     (max)[int]                                                      ·                                            ·
+      │                   render 1     (stddev)[decimal]                                               ·                                            ·
+      └── window          ·            ·                                                               (v int, d decimal, max int, stddev decimal)  ·
+           │              window 0     (stddev((@2)[decimal]) OVER (PARTITION BY (@1)[int]))[decimal]  ·                                            ·
+           │              render 3     (stddev((@2)[decimal]) OVER (PARTITION BY (@1)[int]))[decimal]  ·                                            ·
+           └── group      ·            ·                                                               (v int, d decimal, max int)                  ·
+                │         aggregate 0  v                                                               ·                                            ·
+                │         aggregate 1  d                                                               ·                                            ·
+                │         aggregate 2  max(k)                                                          ·                                            ·
+                │         group by     @2,@3                                                           ·                                            ·
+                └── scan  ·            ·                                                               (k int, v int, d decimal)                    ·
+·                         table        kv@primary                                                      ·                                            ·
+·                         spans        ALL                                                             ·                                            ·
 
 # Partition
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT lag(1) OVER (PARTITION BY 2), lead(2) OVER (PARTITION BY 1) FROM kv
 ----
-render                         ·          ·                                          (lag, lead)                                                                  ·
- │                             render 0   lag                                        ·                                                                            ·
- │                             render 1   lead                                       ·                                                                            ·
- └── window                    ·          ·                                          (k, v, w, f, d, s, b, lag, lag_1_arg1, lag_1_arg3, lag_1_partition_1, lead)  ·
-      │                        window 0   lead(@11, @9, @10) OVER (PARTITION BY @9)  ·                                                                            ·
-      │                        render 11  lead(@11, @9, @10) OVER (PARTITION BY @9)  ·                                                                            ·
-      └── render               ·          ·                                          (k, v, w, f, d, s, b, lag, lag_1_arg1, lag_1_arg3, lag_1_partition_1)        ·
-           │                   render 0   k                                          ·                                                                            ·
-           │                   render 1   v                                          ·                                                                            ·
-           │                   render 2   w                                          ·                                                                            ·
-           │                   render 3   f                                          ·                                                                            ·
-           │                   render 4   d                                          ·                                                                            ·
-           │                   render 5   s                                          ·                                                                            ·
-           │                   render 6   b                                          ·                                                                            ·
-           │                   render 7   lag                                        ·                                                                            ·
-           │                   render 8   lag_1_arg1                                 ·                                                                            ·
-           │                   render 9   lag_1_arg3                                 ·                                                                            ·
-           │                   render 10  lag_1_partition_1                          ·                                                                            ·
-           └── window          ·          ·                                          (k, v, w, f, d, s, b, lag_1_arg1, lag_1_arg3, lag_1_partition_1, lag)        ·
-                │              window 0   lag(@8, @8, @9) OVER (PARTITION BY @10)    ·                                                                            ·
-                │              render 10  lag(@8, @8, @9) OVER (PARTITION BY @10)    ·                                                                            ·
-                └── render     ·          ·                                          (k, v, w, f, d, s, b, lag_1_arg1, lag_1_arg3, lag_1_partition_1)             ·
-                     │         render 0   k                                          ·                                                                            ·
-                     │         render 1   v                                          ·                                                                            ·
-                     │         render 2   w                                          ·                                                                            ·
-                     │         render 3   f                                          ·                                                                            ·
-                     │         render 4   d                                          ·                                                                            ·
-                     │         render 5   s                                          ·                                                                            ·
-                     │         render 6   b                                          ·                                                                            ·
-                     │         render 7   1                                          ·                                                                            ·
-                     │         render 8   CAST(NULL AS INT8)                         ·                                                                            ·
-                     │         render 9   2                                          ·                                                                            ·
-                     └── scan  ·          ·                                          (k, v, w, f, d, s, b)                                                        ·
-·                              table      kv@primary                                 ·                                                                            ·
-·                              spans      ALL                                        ·                                                                            ·
+render                         ·         ·                         (lag, lead)                                             ·
+ │                             render 0  lag                       ·                                                       ·
+ │                             render 1  lead                      ·                                                       ·
+ └── window                    ·         ·                         (lag, lag_1_arg1, lag_1_arg3, lag_1_partition_1, lead)  ·
+      │                        window 0  lead(@4, @2, @3) OVER ()  ·                                                       ·
+      │                        render 4  lead(@4, @2, @3) OVER ()  ·                                                       ·
+      └── render               ·         ·                         (lag, lag_1_arg1, lag_1_arg3, lag_1_partition_1)        ·
+           │                   render 0  lag                       ·                                                       ·
+           │                   render 1  lag_1_arg1                ·                                                       ·
+           │                   render 2  lag_1_arg3                ·                                                       ·
+           │                   render 3  lag_1_partition_1         ·                                                       ·
+           └── window          ·         ·                         (lag_1_arg1, lag_1_arg3, lag_1_partition_1, lag)        ·
+                │              window 0  lag(@1, @1, @2) OVER ()   ·                                                       ·
+                │              render 3  lag(@1, @1, @2) OVER ()   ·                                                       ·
+                └── render     ·         ·                         (lag_1_arg1, lag_1_arg3, lag_1_partition_1)             ·
+                     │         render 0  1                         ·                                                       ·
+                     │         render 1  CAST(NULL AS INT8)        ·                                                       ·
+                     │         render 2  2                         ·                                                       ·
+                     └── scan  ·         ·                         ()                                                      ·
+·                              table     kv@primary                ·                                                       ·
+·                              spans     ALL                       ·                                                       ·
 
 # Ordering
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, v, rank() OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
-sort                 ·         ·                              (k, v, rank)                 +k
- │                   order     +k                             ·                            ·
- └── render          ·         ·                              (k, v, rank)                 ·
-      │              render 0  k                              ·                            ·
-      │              render 1  v                              ·                            ·
-      │              render 2  rank                           ·                            ·
-      └── window     ·         ·                              (k, v, w, f, d, s, b, rank)  ·
-           │         window 0  rank() OVER (ORDER BY @1 ASC)  ·                            ·
-           │         render 7  rank() OVER (ORDER BY @1 ASC)  ·                            ·
-           └── scan  ·         ·                              (k, v, w, f, d, s, b)        ·
-·                    table     kv@primary                     ·                            ·
-·                    spans     ALL                            ·                            ·
+sort            ·         ·                              (k, v, rank)  +k
+ │              order     +k                             ·             ·
+ └── window     ·         ·                              (k, v, rank)  ·
+      │         window 0  rank() OVER (ORDER BY @1 ASC)  ·             ·
+      │         render 2  rank() OVER (ORDER BY @1 ASC)  ·             ·
+      └── scan  ·         ·                              (k, v)        ·
+·               table     kv@primary                     ·             ·
+·               spans     ALL                            ·             ·

--- a/pkg/sql/opt/memo/testdata/logprops/window
+++ b/pkg/sql/opt/memo/testdata/logprops/window
@@ -44,6 +44,39 @@ project
       ├── cardinality: [0 - 10]
       ├── key: (1)
       ├── fd: (1)-->(2-7)
+      ├── prune: (1-8)
+      ├── limit
+      │    ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    ├── cardinality: [0 - 10]
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-7)
+      │    ├── prune: (1-7)
+      │    ├── interesting orderings: (+1)
+      │    ├── scan kv
+      │    │    ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-7)
+      │    │    ├── prune: (1-7)
+      │    │    └── interesting orderings: (+1)
+      │    └── const: 10 [type=int]
+      └── windows
+           └── rank [type=undefined]
+
+build
+SELECT k, rank() OVER (PARTITION BY v ORDER BY f) FROM (SELECT * FROM kv LIMIT 10)
+----
+project
+ ├── columns: k:1(int!null) rank:8(int)
+ ├── cardinality: [0 - 10]
+ ├── key: (1)
+ ├── fd: (1)-->(8)
+ ├── prune: (1,8)
+ └── window partition=(2) ordering=+4
+      ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) rank:8(int)
+      ├── cardinality: [0 - 10]
+      ├── key: (1)
+      ├── fd: (1)-->(2-7)
+      ├── prune: (1,3,5-8)
       ├── limit
       │    ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
       │    ├── cardinality: [0 - 10]
@@ -99,6 +132,7 @@ project
                      │    ├── cardinality: [1 - 1]
                      │    ├── key: ()
                      │    ├── fd: ()-->(8)
+                     │    ├── prune: (8,9)
                      │    ├── project
                      │    │    ├── columns: x:8(int)
                      │    │    ├── outer: (1)
@@ -129,6 +163,7 @@ project
       ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) lag:8(string) lag:9(int) lag_1_arg1:10(string) lag_1_arg2:11(int!null) lag_1_arg3:12(string) lag_2_arg3:13(int)
       ├── key: (1)
       ├── fd: ()-->(10-13), (1)-->(2-7)
+      ├── prune: (1-9)
       ├── project
       │    ├── columns: lag_1_arg1:10(string) lag_1_arg2:11(int!null) lag_1_arg3:12(string) lag_2_arg3:13(int) k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
       │    ├── key: (1)

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -1018,6 +1018,34 @@ func (c *CustomFuncs) projectColMapSide(toList, fromList opt.ColList) memo.Proje
 
 // ----------------------------------------------------------------------
 //
+// Window Rules
+//   Custom match and replace functions used with window.opt rules.
+//
+// ----------------------------------------------------------------------
+
+// CanReduceWindowPartitionCols is true if the set of columns being partitioned
+// on can be made smaller via use of functional dependencies (for instance,
+// partitioning on (k, k+1) can be reduced to just (k)).
+func (c *CustomFuncs) CanReduceWindowPartitionCols(
+	input memo.RelExpr, private *memo.WindowPrivate,
+) bool {
+	fdset := input.Relational().FuncDeps
+	return !fdset.ReduceCols(private.Partition).Equals(private.Partition)
+}
+
+// ReduceWindowPartitionCols reduces the set of columns being partitioned on
+// to a smaller set.
+func (c *CustomFuncs) ReduceWindowPartitionCols(
+	input memo.RelExpr, private *memo.WindowPrivate,
+) *memo.WindowPrivate {
+	fdset := input.Relational().FuncDeps
+	p := *private
+	p.Partition = fdset.ReduceCols(private.Partition)
+	return &p
+}
+
+// ----------------------------------------------------------------------
+//
 // Boolean Rules
 //   Custom match and replace functions used with bool.opt rules.
 //

--- a/pkg/sql/opt/norm/ordering.go
+++ b/pkg/sql/opt/norm/ordering.go
@@ -16,6 +16,7 @@ package norm
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 )
 
@@ -77,6 +78,58 @@ func (c *CustomFuncs) SimplifyOrdinalityOrdering(
 	copy := *private
 	copy.Ordering = c.simplifyOrdering(in, private.Ordering)
 	return &copy
+}
+
+// withinPartitionFuncDeps returns the functional dependencies that apply
+// within any given partition in a window function's input. These are stronger
+// than the input's FDs since within any partition the partition columns are
+// held constant.
+func (c *CustomFuncs) withinPartitionFuncDeps(
+	in memo.RelExpr, private *memo.WindowPrivate,
+) *props.FuncDepSet {
+	if private.Partition.Empty() {
+		return &in.Relational().FuncDeps
+	}
+	var fdset props.FuncDepSet
+	fdset.CopyFrom(&in.Relational().FuncDeps)
+	fdset.AddConstants(private.Partition)
+	return &fdset
+}
+
+// CanSimplifyWindowOrdering is true if the intra-partition ordering used by
+// the window function can be made less restrictive.
+func (c *CustomFuncs) CanSimplifyWindowOrdering(in memo.RelExpr, private *memo.WindowPrivate) bool {
+	// If any ordering is allowed, nothing to simplify.
+	if private.Ordering.Any() {
+		return false
+	}
+	// Indiscriminately simplifying the ordering introduces a subtle bug right now:
+	// the framing behavior of aggregates is dependent on whether or not there was
+	// an ordering specified. If we eliminate the ordering here then we can lose
+	// that information because the execution engine doesn't know whether or not
+	// an ordering was initially specified. This will be fixed when we explicitly
+	// handle framing in the optimizer.
+	// TODO(justin): when the above is fixed, change this to just use CanSimplify.
+	deps := c.withinPartitionFuncDeps(in, private)
+	simplified := private.Ordering.Copy()
+	simplified.Simplify(deps)
+	if simplified.Any() {
+		return false
+	}
+
+	return private.Ordering.CanSimplify(deps)
+}
+
+// SimplifyWindowOrdering makes the intra-partition ordering used by the window
+// function less restrictive.
+func (c *CustomFuncs) SimplifyWindowOrdering(
+	in memo.RelExpr, private *memo.WindowPrivate,
+) *memo.WindowPrivate {
+	simplified := private.Ordering.Copy()
+	simplified.Simplify(c.withinPartitionFuncDeps(in, private))
+	cpy := *private
+	cpy.Ordering = simplified
+	return &cpy
 }
 
 // CanSimplifyExplainOrdering returns true if the ordering required by the

--- a/pkg/sql/opt/norm/rules/prune_cols.opt
+++ b/pkg/sql/opt/norm/rules/prune_cols.opt
@@ -368,6 +368,64 @@
     $passthrough
 )
 
+# PruneWindowOutputCols eliminates unused window functions from a Window
+# expression.
+[PruneWindowOutputCols, Normalize]
+(Project
+    (Window
+        $input:*
+        $windows:*
+        $private:*
+    )
+    $projections:*
+    $passthrough:* & (CanPruneWindows
+        $needed:(UnionCols (ProjectionOuterCols $projections) $passthrough)
+        $windows
+    )
+)
+=>
+(Project
+    (Window
+        $input
+        (PruneWindows $needed $windows)
+        $private
+    )
+    $projections
+    $passthrough
+)
+
+# PruneWindowInputCols discards window passthrough columns which are never used.
+# NB: This rule should go after PruneWindowOutputCols, or else this rule can get
+# into a cycle.
+[PruneWindowInputCols, Normalize]
+(Project
+    $input:(Window
+        $innerInput:*
+        $fn:*
+        $private:*
+    )
+    $projections:*
+    $passthrough:* &
+        (CanPruneCols
+            $input
+            $needed:(UnionCols3
+                (NeededWindowCols $fn $private)
+                (ProjectionOuterCols $projections)
+                $passthrough
+            )
+        )
+)
+=>
+(Project
+    (Window
+      (PruneCols $innerInput $needed)
+      $fn
+      $private
+    )
+    $projections
+    $passthrough
+)
+
 # PruneMutationFetchCols removes columns from the mutation operator's FetchCols
 # set if they are never used. Removing FetchCols can in turn can trigger the
 # PruneMutationInputCols rule, which can prune any input columns which are now

--- a/pkg/sql/opt/norm/rules/window.opt
+++ b/pkg/sql/opt/norm/rules/window.opt
@@ -1,0 +1,46 @@
+# =============================================================================
+# window.opt contains normalization rules for the Window operator.
+# =============================================================================
+
+# TODO(justin): add a rule to best-effort collapse same ordering+partition
+# window functions, like in:
+# SELECT
+#     rank() OVER (PARTITION BY i), rank() OVER (PARTITION BY i, 1), rank() OVER (PARTITION BY i, 2)
+# FROM
+#     a
+
+# EliminateWindow removes a Window operator with no window functions (which can
+# occur via column pruning).
+[EliminateWindow, Normalize]
+(Window $input:* [])
+=>
+$input
+
+# ReduceWindowPartitionCols reduces a set of partition columns to a simpler form
+# using FDs.
+[ReduceWindowPartitionCols, Normalize]
+(Window
+    $input:*
+    $fn:*
+    $private:* & (CanReduceWindowPartitionCols $input $private)
+)
+=>
+(Window
+    $input
+    $fn
+    (ReduceWindowPartitionCols $input $private)
+)
+
+# SimplifyWindowOrdering reduces an ordering to a simpler form using FDs.
+[SimplifyWindowOrdering, Normalize]
+(Window
+    $input:*
+    $fn:*
+    $private:* & (CanSimplifyWindowOrdering $input $private)
+)
+=>
+(Window
+    $input
+    $fn
+    (SimplifyWindowOrdering $input $private)
+)

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -1662,6 +1662,146 @@ distinct-on
                 └── variable: s [type=string]
 
 # --------------------------------------------------
+# PruneWindowInputCols
+# --------------------------------------------------
+
+norm expect=PruneWindowInputCols
+SELECT rank() OVER () FROM a
+----
+window partition=()
+ ├── columns: rank:5(int)
+ ├── scan a
+ └── windows
+      └── rank [type=undefined]
+
+norm expect=PruneWindowInputCols
+SELECT ntile(1) OVER () FROM a
+----
+project
+ ├── columns: ntile:5(int)
+ └── window partition=()
+      ├── columns: ntile:5(int) ntile_1_arg1:6(int!null)
+      ├── fd: ()-->(6)
+      ├── project
+      │    ├── columns: ntile_1_arg1:6(int!null)
+      │    ├── fd: ()-->(6)
+      │    ├── scan a
+      │    └── projections
+      │         └── const: 1 [type=int]
+      └── windows
+           └── ntile [type=int, outer=(6)]
+                └── variable: ntile_1_arg1 [type=int]
+
+norm expect=PruneWindowInputCols format=show-all
+SELECT ntile(i) OVER () FROM a
+----
+project
+ ├── columns: ntile:5(int)
+ ├── stats: [rows=1000]
+ ├── cost: 1060.04
+ ├── prune: (5)
+ └── window partition=()
+      ├── columns: t.public.a.i:2(int) ntile:5(int)
+      ├── stats: [rows=1000]
+      ├── cost: 1050.03
+      ├── prune: (5)
+      ├── scan t.public.a
+      │    ├── columns: t.public.a.i:2(int)
+      │    ├── stats: [rows=1000]
+      │    ├── cost: 1050.02
+      │    └── prune: (2)
+      └── windows
+           └── ntile [type=int, outer=(2)]
+                └── variable: t.public.a.i [type=int]
+
+# --------------------------------------------------
+# PruneWindowOutputCols
+# --------------------------------------------------
+
+norm expect=PruneWindowOutputCols
+SELECT x FROM (SELECT ntile(1) OVER () AS x, ntile(2) OVER () FROM a)
+----
+project
+ ├── columns: x:5(int)
+ └── window partition=()
+      ├── columns: ntile:5(int) ntile_1_arg1:7(int!null)
+      ├── fd: ()-->(7)
+      ├── project
+      │    ├── columns: ntile_1_arg1:7(int!null)
+      │    ├── fd: ()-->(7)
+      │    ├── scan a
+      │    └── projections
+      │         └── const: 1 [type=int]
+      └── windows
+           └── ntile [type=int, outer=(7)]
+                └── variable: ntile_1_arg1 [type=int]
+
+norm expect=(PruneWindowOutputCols,EliminateWindow)
+SELECT 1 FROM (SELECT ntile(1) OVER () FROM a)
+----
+project
+ ├── columns: "?column?":7(int!null)
+ ├── fd: ()-->(7)
+ ├── scan a
+ └── projections
+      └── const: 1 [type=int]
+
+norm expect=(PruneWindowOutputCols,EliminateWindow)
+SELECT 1 FROM (SELECT x FROM (SELECT ntile(1) OVER () AS x, ntile(2) OVER () FROM a))
+----
+project
+ ├── columns: "?column?":9(int!null)
+ ├── fd: ()-->(9)
+ ├── scan a
+ └── projections
+      └── const: 1 [type=int]
+
+norm expect-not=PruneWindowOutputCols
+SELECT round(avg(k) OVER (PARTITION BY f ORDER BY s)) FROM a ORDER BY 1
+----
+sort
+ ├── columns: round:6(decimal)
+ ├── ordering: +6
+ └── project
+      ├── columns: round:6(decimal)
+      ├── window partition=(3) ordering=+4 opt(3)
+      │    ├── columns: k:1(int!null) f:3(float) s:4(string) avg:5(decimal)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(3,4)
+      │    ├── scan a
+      │    │    ├── columns: k:1(int!null) f:3(float) s:4(string)
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(3,4)
+      │    └── windows
+      │         └── avg [type=decimal, outer=(1)]
+      │              └── variable: k [type=int]
+      └── projections
+           └── round(avg) [type=decimal, outer=(5)]
+
+norm expect=(PruneWindowInputCols,PruneWindowOutputCols) format=show-all
+SELECT x FROM (SELECT ntile(i) OVER () x, ntile(f::int) OVER () y FROM a)
+----
+project
+ ├── columns: x:5(int)
+ ├── stats: [rows=1000]
+ ├── cost: 1060.04
+ ├── prune: (5)
+ └── window partition=()
+      ├── columns: t.public.a.i:2(int) ntile:5(int)
+      ├── stats: [rows=1000]
+      ├── cost: 1050.03
+      ├── prune: (5)
+      ├── scan t.public.a
+      │    ├── columns: t.public.a.i:2(int)
+      │    ├── stats: [rows=1000]
+      │    ├── cost: 1050.02
+      │    └── prune: (2)
+      └── windows
+           └── ntile [type=int, outer=(2)]
+                └── variable: t.public.a.i [type=int]
+
+
+# --------------------------------------------------
 # PruneMutationFetchCols + PruneMutationInputCols
 # --------------------------------------------------
 

--- a/pkg/sql/opt/norm/testdata/rules/window
+++ b/pkg/sql/opt/norm/testdata/rules/window
@@ -1,0 +1,103 @@
+exec-ddl
+CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON)
+----
+TABLE a
+ ├── k int not null
+ ├── i int
+ ├── f float
+ ├── s string
+ ├── j jsonb
+ └── INDEX primary
+      └── k int not null
+
+# --------------------------------------------------
+# ReduceWindowPartitionCols
+# --------------------------------------------------
+
+norm expect=ReduceWindowPartitionCols
+SELECT rank() OVER (PARTITION BY k, i) FROM a
+----
+project
+ ├── columns: rank:6(int)
+ └── window partition=(1)
+      ├── columns: k:1(int!null) rank:6(int)
+      ├── key: (1)
+      ├── scan a
+      │    ├── columns: k:1(int!null)
+      │    └── key: (1)
+      └── windows
+           └── rank [type=undefined]
+
+norm expect=ReduceWindowPartitionCols
+SELECT rank() OVER (PARTITION BY i, i+1) FROM a
+----
+project
+ ├── columns: rank:6(int)
+ └── window partition=(2)
+      ├── columns: i:2(int) rank:6(int)
+      ├── scan a
+      │    └── columns: i:2(int)
+      └── windows
+           └── rank [type=undefined]
+
+# --------------------------------------------------
+# SimplifyWindowOrdering
+# --------------------------------------------------
+
+norm expect=SimplifyWindowOrdering
+SELECT rank() OVER (ORDER BY k, i) FROM a
+----
+project
+ ├── columns: rank:6(int)
+ └── window partition=() ordering=+1
+      ├── columns: k:1(int!null) rank:6(int)
+      ├── key: (1)
+      ├── scan a
+      │    ├── columns: k:1(int!null)
+      │    └── key: (1)
+      └── windows
+           └── rank [type=undefined]
+
+# We can simplify the ordering with the knowledge that within any partition
+# the set of partition cols is held constant.
+
+# TODO(justin): ensure these are fixed once we handle framing.
+norm
+SELECT rank() OVER (PARTITION BY k ORDER BY i) FROM a
+----
+project
+ ├── columns: rank:6(int)
+ └── window partition=(1) ordering=+2
+      ├── columns: k:1(int!null) i:2(int) rank:6(int)
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      ├── scan a
+      │    ├── columns: k:1(int!null) i:2(int)
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── windows
+           └── rank [type=undefined]
+
+norm expect=SimplifyWindowOrdering
+SELECT rank() OVER (PARTITION BY i ORDER BY f, i+1) FROM a
+----
+project
+ ├── columns: rank:6(int)
+ └── window partition=(2) ordering=+3 opt(2,7)
+      ├── columns: i:2(int) f:3(float) rank:6(int)
+      ├── scan a
+      │    └── columns: i:2(int) f:3(float)
+      └── windows
+           └── rank [type=undefined]
+
+norm expect=SimplifyWindowOrdering
+SELECT rank() OVER (PARTITION BY f ORDER BY i) FROM a
+----
+project
+ ├── columns: rank:6(int)
+ └── window partition=(3) ordering=+2 opt(3)
+      ├── columns: i:2(int) f:3(float) rank:6(int)
+      ├── scan a
+      │    └── columns: i:2(int) f:3(float)
+      └── windows
+           └── rank [type=undefined]


### PR DESCRIPTION
This commit introduces some basic window function norm rules, enabling
simplification of partitions and orderings via FDs and column pruning.

Release note: None