### PR TITLE
 importccl: prototype support for IMPORT INTO

### DIFF
--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -94,6 +94,9 @@ type PlanHookState interface {
 	EvalAsOfTimestamp(asOf tree.AsOfClause) (hlc.Timestamp, error)
 	ResolveUncachedDatabaseByName(
 		ctx context.Context, dbName string, required bool) (*UncachedDatabaseDescriptor, error)
+	ResolveMutableTableDescriptor(
+		ctx context.Context, tn *ObjectName, required bool, requiredType ResolveRequiredType,
+	) (table *MutableTableDescriptor, err error)
 }
 
 // AddPlanHook adds a hook used to short-circuit creating a planNode from a


### PR DESCRIPTION
This adds a prototype of incremental IMPORT, allowing importing CSV data
into an existing table as opposed to only into as new table with current
IMPORT.

Unlike traditional IMPORT which takes a specification of the table to
create, this takes a reference to an existing table into which it will
import data. Initially only CSV data, importing into a single table, is
supported (the SQL dumpfiles are typically dumps of an entire table so
it seems likess likely that we need to support them here for now).

Since the actual bulk ingestion is done via non-transactional AddSSTable
commands, the table must be taken offline during ingestion. The IMPORT
job begins by schema-changing the table to an offline 'IMPORTING' state
that should prevent leasing it and moves it back to public when it
finishes (on success or failure, unlike a newly table created table
which is usually rolled back via a drop on failure).

This prototype, and as such has many unfinshed pieces (some of which are
captured as TODOs). Given the number of unresolved UX questions
around this feature, we wanted to start playing with something concrete
to help guide the feature specification and further development.

A few of the more significant areas to be resolved are how the hook uses
transactions for table creation, resolution and alteration versus the
job creation, resolving, checking and plumbing specified subsets of the
columns to IMPORT into, handling rollbacks of partial ingestion,
updating job status messages, and a careful audit of everywhere that 
table descriptors are acquired to ensure the IMPORTING state is handled
correctly. That said, these are mostly seperable issues that make better
standalone follow-up changes (and can be done in parallel) 


Release note: none.