### PR TITLE
roachtest: create new multi-az and multi-region benchmark roachtests

### DIFF
--- a/pkg/cmd/roachtest/indexes.go
+++ b/pkg/cmd/roachtest/indexes.go
@@ -1,0 +1,74 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"context"
+	"fmt"
+)
+
+func registerNIndexes(r *registry, secondaryIndexes int) {
+	const nodes = 6
+	const geoZones = "us-west1-b,us-east1-b,us-central1-a"
+	r.Add(testSpec{
+		Name:    fmt.Sprintf("indexes/%d/nodes=%d/multi-region", secondaryIndexes, nodes),
+		Cluster: makeClusterSpec(nodes+1, cpu(16), geo(), zones(geoZones)),
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			lastNodeInFirstAZ := nodes / 3
+			var roachNodes, gatewayNodes, loadNode nodeListOption
+			for i := 0; i < c.nodes; i++ {
+				n := c.Node(i + 1)
+				if i == lastNodeInFirstAZ {
+					loadNode = n
+				} else {
+					roachNodes = roachNodes.merge(n)
+					if i < lastNodeInFirstAZ {
+						gatewayNodes = gatewayNodes.merge(n)
+					}
+				}
+			}
+
+			c.Put(ctx, cockroach, "./cockroach", roachNodes)
+			c.Put(ctx, workload, "./workload", loadNode)
+			c.Start(ctx, t, roachNodes)
+
+			t.Status("running workload")
+			m := newMonitor(ctx, c, roachNodes)
+			m.Go(func(ctx context.Context) error {
+				payload := " --payload=256"
+				indexes := " --secondary-indexes=" + fmt.Sprint(secondaryIndexes)
+				concurrency := ifLocal("", " --concurrency="+fmt.Sprint(nodes*32))
+				duration := " --duration=" + ifLocal("10s", "30m")
+
+				cmd := fmt.Sprintf("./workload run indexes --init --histograms=logs/stats.json"+
+					payload+indexes+concurrency+duration+" {pgurl%s}", gatewayNodes)
+				c.Run(ctx, loadNode, cmd)
+				return nil
+			})
+			m.Wait()
+		},
+	})
+}
+
+func registerIndexes(r *registry) {
+	registerNIndexes(r, 2)
+}
+
+func registerIndexesBench(r *registry) {
+	for i := 0; i <= 10; i++ {
+		registerNIndexes(r, i)
+	}
+}

--- a/pkg/cmd/roachtest/ledger.go
+++ b/pkg/cmd/roachtest/ledger.go
@@ -1,0 +1,62 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"context"
+	"fmt"
+)
+
+func registerLedger(r *registry) {
+	const nodes = 6
+	const azs = "us-central1-a,us-central1-b,us-central1-c"
+	r.Add(testSpec{
+		Name:    fmt.Sprintf("ledger/nodes=%d/multi-az", nodes),
+		Cluster: makeClusterSpec(nodes+1, cpu(16), geo(), zones(azs)),
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			lastNodeInFirstAZ := nodes / 3
+			var roachNodes, gatewayNodes, loadNode nodeListOption
+			for i := 0; i < c.nodes; i++ {
+				n := c.Node(i + 1)
+				if i == lastNodeInFirstAZ {
+					loadNode = n
+				} else {
+					roachNodes = roachNodes.merge(n)
+					if i < lastNodeInFirstAZ {
+						gatewayNodes = gatewayNodes.merge(n)
+					}
+				}
+			}
+
+			c.Put(ctx, cockroach, "./cockroach", roachNodes)
+			c.Put(ctx, workload, "./workload", loadNode)
+			c.Start(ctx, t, roachNodes)
+
+			t.Status("running workload")
+			m := newMonitor(ctx, c, roachNodes)
+			m.Go(func(ctx context.Context) error {
+				concurrency := ifLocal("", " --concurrency="+fmt.Sprint(nodes*32))
+				duration := " --duration=" + ifLocal("10s", "30m")
+
+				cmd := fmt.Sprintf("./workload run ledger --init --histograms=logs/stats.json"+
+					concurrency+duration+" {pgurl%s}", gatewayNodes)
+				c.Run(ctx, loadNode, cmd)
+				return nil
+			})
+			m.Wait()
+		},
+	})
+}

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -42,6 +42,7 @@ func registerTests(r *registry) {
 	registerHotSpotSplits(r)
 	registerImportTPCC(r)
 	registerImportTPCH(r)
+	registerIndexes(r)
 	registerInterleaved(r)
 	registerJepsen(r)
 	registerKV(r)
@@ -85,6 +86,7 @@ func registerBenchmarks(r *registry) {
 	//
 	// grep -h -E 'func register[^(]+\(.*registry\) {' *.go | grep -E -o 'register[^(]+' | grep -v '^registerTests$' | grep '^\w*Bench$' | sort | awk '{printf "\t%s(r)\n", $0}'
 
+	registerIndexesBench(r)
 	registerTPCCBench(r)
 	registerSQL20Bench(r)
 }

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -51,6 +51,7 @@ func registerTests(r *registry) {
 	registerKVScalability(r)
 	registerKVSplits(r)
 	registerLargeRange(r)
+	registerLedger(r)
 	registerNetwork(r)
 	registerPsycopg(r)
 	registerQueue(r)


### PR DESCRIPTION
This PR creates two new roachtests:
- `ledger/nodes=6/multi-az`
- `indexes/2/nodes=6/multi-region`

These two roachtests complete the set of benchmarks that we want to track in roachperf for Core OKRs. The goal is to run them on AWS, but that will require a separate change I'm working on to translate GCP zones to AWS zones.