### PR TITLE
sql: add AST annotations

### DIFF
--- a/pkg/ccl/backupccl/restore.go
+++ b/pkg/ccl/backupccl/restore.go
@@ -949,7 +949,7 @@ func WriteTableDescs(
 }
 
 func restoreJobDescription(
-	restore *tree.Restore, from []string, opts map[string]string,
+	p sql.PlanHookState, restore *tree.Restore, from []string, opts map[string]string,
 ) (string, error) {
 	r := &tree.Restore{
 		AsOf:    restore.AsOf,
@@ -966,7 +966,8 @@ func restoreJobDescription(
 		r.From[i] = tree.NewDString(sf)
 	}
 
-	return tree.AsStringWithFlags(r, tree.FmtAlwaysQualifyTableNames), nil
+	ann := p.ExtendedEvalContext().Annotations
+	return tree.AsStringWithFQNames(r, ann), nil
 }
 
 // rewriteBackupSpanKey rewrites a backup span start key for the purposes of
@@ -1385,7 +1386,7 @@ func doRestorePlan(
 	if err != nil {
 		return err
 	}
-	description, err := restoreJobDescription(restoreStmt, from, opts)
+	description, err := restoreJobDescription(p, restoreStmt, from, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -161,7 +161,7 @@ func changefeedPlanHook(
 			return err
 		}
 
-		jobDescription, err := changefeedJobDescription(changefeedStmt, sinkURI, opts)
+		jobDescription, err := changefeedJobDescription(p, changefeedStmt, sinkURI, opts)
 		if err != nil {
 			return err
 		}
@@ -341,7 +341,7 @@ func changefeedPlanHook(
 }
 
 func changefeedJobDescription(
-	changefeed *tree.CreateChangefeed, sinkURI string, opts map[string]string,
+	p sql.PlanHookState, changefeed *tree.CreateChangefeed, sinkURI string, opts map[string]string,
 ) (string, error) {
 	cleanedSinkURI, err := storageccl.SanitizeExportStorageURI(sinkURI)
 	if err != nil {
@@ -359,7 +359,8 @@ func changefeedJobDescription(
 		c.Options = append(c.Options, opt)
 	}
 	sort.Slice(c.Options, func(i, j int) bool { return c.Options[i].Key < c.Options[j].Key })
-	return tree.AsStringWithFlags(c, tree.FmtAlwaysQualifyTableNames), nil
+	ann := p.ExtendedEvalContext().Annotations
+	return tree.AsStringWithFQNames(c, ann), nil
 }
 
 func validateDetails(details jobspb.ChangefeedDetails) (jobspb.ChangefeedDetails, error) {

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -325,7 +325,7 @@ func readPostgresCreateTable(
 			}
 			create.Defs = append(create.Defs, idx)
 		case *tree.AlterTable:
-			name, err := getTableName(&stmt.Table)
+			name, err := getTableName2(stmt.Table)
 			if err != nil {
 				return nil, err
 			}
@@ -379,6 +379,17 @@ func getTableName(tn *tree.TableName) (string, error) {
 		)
 	}
 	return tn.Table(), nil
+}
+
+// getTableName variant for UnresolvedObjectName.
+func getTableName2(u *tree.UnresolvedObjectName) (string, error) {
+	if u.NumParts >= 2 && u.Parts[1] != "public" {
+		return "", pgerror.Unimplementedf(
+			"import non-public schema",
+			"non-public schemas unsupported: %s", u.Parts[1],
+		)
+	}
+	return u.Parts[0], nil
 }
 
 type pgDumpReader struct {

--- a/pkg/internal/sqlsmith/alter.go
+++ b/pkg/internal/sqlsmith/alter.go
@@ -122,7 +122,7 @@ func makeAlterColumnType(s *scope) (tree.Statement, bool) {
 	col := tableRef.Columns[s.schema.rnd.Intn(len(tableRef.Columns))]
 
 	return &tree.AlterTable{
-		Table: *tableRef.TableName,
+		Table: tableRef.TableName.ToUnresolvedObjectName(),
 		Cmds: tree.AlterTableCmds{
 			&tree.AlterTableAlterColumnType{
 				Column: col.Name,
@@ -157,7 +157,7 @@ func makeAddColumn(s *scope) (tree.Statement, bool) {
 	}
 
 	return &tree.AlterTable{
-		Table: *tableRef.TableName,
+		Table: tableRef.TableName.ToUnresolvedObjectName(),
 		Cmds: tree.AlterTableCmds{
 			&tree.AlterTableAddColumn{
 				ColumnDef: col,
@@ -174,7 +174,7 @@ func makeDropColumn(s *scope) (tree.Statement, bool) {
 	col := tableRef.Columns[s.schema.rnd.Intn(len(tableRef.Columns))]
 
 	return &tree.AlterTable{
-		Table: *tableRef.TableName,
+		Table: tableRef.TableName.ToUnresolvedObjectName(),
 		Cmds: tree.AlterTableCmds{
 			&tree.AlterTableDropColumn{
 				Column:       col.Name,

--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -93,8 +93,9 @@ func (n *alterIndexNode) startExec(params runParams) error {
 	mutationID := sqlbase.InvalidMutationID
 	var err error
 	if addedMutations {
-		mutationID, err = params.p.createOrUpdateSchemaChangeJob(params.ctx, n.tableDesc,
-			tree.AsStringWithFlags(n.n, tree.FmtAlwaysQualifyTableNames))
+		mutationID, err = params.p.createOrUpdateSchemaChangeJob(
+			params.ctx, n.tableDesc, tree.AsStringWithFQNames(n.n, params.Ann()),
+		)
 	} else if !descriptorChanged {
 		// Nothing to be done
 		return nil

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -46,10 +46,13 @@ type alterTableNode struct {
 //   notes: postgres requires CREATE on the table.
 //          mysql requires ALTER, CREATE, INSERT on the table.
 func (p *planner) AlterTable(ctx context.Context, n *tree.AlterTable) (planNode, error) {
-	tableDesc, err := p.ResolveMutableTableDescriptor(ctx, &n.Table, !n.IfExists, ResolveRequireTableDesc)
+	tableDesc, err := p.ResolveMutableTableDescriptorEx(
+		ctx, n.Table, !n.IfExists, ResolveRequireTableDesc,
+	)
 	if err != nil {
 		return nil, err
 	}
+
 	if tableDesc == nil {
 		return newZeroNode(nil /* columns */), nil
 	}
@@ -80,7 +83,11 @@ func (p *planner) AlterTable(ctx context.Context, n *tree.AlterTable) (planNode,
 		statsData[i] = typedExpr
 	}
 
-	return &alterTableNode{n: n, tableDesc: tableDesc, statsData: statsData}, nil
+	return &alterTableNode{
+		n:         n,
+		tableDesc: tableDesc,
+		statsData: statsData,
+	}, nil
 }
 
 func (n *alterTableNode) startExec(params runParams) error {
@@ -90,7 +97,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 	descriptorChanged := false
 	origNumMutations := len(n.tableDesc.Mutations)
 	var droppedViews []string
-	tn := &n.n.Table
+	tn := params.p.ResolvedName(n.n.Table)
 
 	for i, cmd := range n.n.Cmds {
 		switch t := cmd.(type) {
@@ -218,7 +225,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 
 			case *tree.CheckConstraintTableDef:
 				ck, err := MakeCheckConstraint(params.ctx,
-					n.tableDesc, d, inuseNames, &params.p.semaCtx, n.n.Table)
+					n.tableDesc, d, inuseNames, &params.p.semaCtx, *tn)
 				if err != nil {
 					return err
 				}
@@ -539,7 +546,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 			default:
 				return pgerror.Newf(pgerror.CodeWrongObjectTypeError,
 					"constraint %q of relation %q is not a foreign key or check constraint",
-					tree.ErrString(&t.Constraint), tree.ErrString(&n.n.Table))
+					tree.ErrString(&t.Constraint), tree.ErrString(n.n.Table))
 			}
 
 		case tree.ColumnMutationCmd:
@@ -690,7 +697,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 			User                string
 			MutationID          uint32
 			CascadeDroppedViews []string
-		}{n.n.Table.FQString(), n.n.String(),
+		}{params.p.ResolvedName(n.n.Table).FQString(), n.n.String(),
 			params.SessionData().User, uint32(mutationID), droppedViews},
 	)
 }

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -397,7 +397,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 						if err := params.p.dropIndexByName(
 							params.ctx, tn, tree.UnrestrictedName(idx.Name), n.tableDesc, false,
 							t.DropBehavior, ignoreIdxConstraint,
-							tree.AsStringWithFlags(n.n, tree.FmtAlwaysQualifyTableNames),
+							tree.AsStringWithFQNames(n.n, params.Ann()),
 						); err != nil {
 							return err
 						}
@@ -662,8 +662,10 @@ func (n *alterTableNode) startExec(params runParams) error {
 	mutationID := sqlbase.InvalidMutationID
 	if addedMutations {
 		var err error
-		mutationID, err = params.p.createOrUpdateSchemaChangeJob(params.ctx, n.tableDesc,
-			tree.AsStringWithFlags(n.n, tree.FmtAlwaysQualifyTableNames))
+		mutationID, err = params.p.createOrUpdateSchemaChangeJob(
+			params.ctx, n.tableDesc,
+			tree.AsStringWithFQNames(n.n, params.Ann()),
+		)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -156,7 +156,7 @@ func (ex *connExecutor) prepare(
 	txn := client.NewTxn(ctx, ex.server.cfg.DB, ex.server.cfg.NodeID.Get(), client.RootTxn)
 
 	p := &ex.planner
-	ex.resetPlanner(ctx, p, txn, ex.server.cfg.Clock.PhysicalTime() /* stmtTS */)
+	ex.resetPlanner(ctx, p, txn, ex.server.cfg.Clock.PhysicalTime() /* stmtTS */, stmt.NumAnnotations)
 	p.stmt = &stmt
 	flags, err := ex.populatePrepared(ctx, txn, placeholderHints, p)
 	if err != nil {

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -128,8 +128,10 @@ func (n *createIndexNode) startExec(params runParams) error {
 		}
 	}
 
-	mutationID, err := params.p.createOrUpdateSchemaChangeJob(params.ctx, n.tableDesc,
-		tree.AsStringWithFlags(n.n, tree.FmtAlwaysQualifyTableNames))
+	mutationID, err := params.p.createOrUpdateSchemaChangeJob(
+		params.ctx, n.tableDesc,
+		tree.AsStringWithFQNames(n.n, params.Ann()),
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -229,7 +229,7 @@ func (n *createStatsNode) makeJobRecord(ctx context.Context) (*jobs.Record, erro
 	}
 
 	// Create a job to run statistics creation.
-	statement := tree.AsStringWithFlags(n, tree.FmtAlwaysQualifyTableNames)
+	statement := tree.AsStringWithFQNames(n, n.p.EvalContext().Annotations)
 	var description string
 	if n.Name == stats.AutoStatsName {
 		// Use a user-friendly description for automatic statistics.

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -135,7 +135,7 @@ func (n *dropDatabaseNode) startExec(params runParams) error {
 		ctx,
 		tableDescs,
 		droppedTableDetails,
-		tree.AsStringWithFlags(n.n, tree.FmtAlwaysQualifyTableNames),
+		tree.AsStringWithFQNames(n.n, params.Ann()),
 		true, /* drainNames */
 		n.dbDesc.ID)
 	if err != nil {

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -78,7 +78,7 @@ func (n *dropIndexNode) startExec(params runParams) error {
 
 		if err := params.p.dropIndexByName(
 			ctx, index.tn, index.idxName, tableDesc, n.n.IfExists, n.n.DropBehavior, checkIdxConstraint,
-			tree.AsStringWithFlags(n.n, tree.FmtAlwaysQualifyTableNames),
+			tree.AsStringWithFQNames(n.n, params.Ann()),
 		); err != nil {
 			return err
 		}

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -111,7 +111,7 @@ func (n *dropTableNode) startExec(params runParams) error {
 			ctx,
 			[]*sqlbase.MutableTableDescriptor{droppedDesc},
 			[]jobspb.DroppedTableDetails{droppedDetails},
-			tree.AsStringWithFlags(n.n, tree.FmtAlwaysQualifyTableNames),
+			tree.AsStringWithFQNames(n.n, params.Ann()),
 			true, /* drainNames */
 			sqlbase.InvalidID /* droppedDatabaseID */); err != nil {
 			return err

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -537,6 +537,7 @@ func (h *harness) prepareUsingAPI(tb testing.TB) {
 		h.semaCtx.Placeholders.Values[i] = texpr
 	}
 	h.evalCtx.Placeholders = &h.semaCtx.Placeholders
+	h.evalCtx.Annotations = &h.semaCtx.Annotations
 }
 
 func (h *harness) runUsingAPI(tb testing.TB, bmType BenchmarkType, usePrepared bool) {

--- a/pkg/sql/opt/testutils/build.go
+++ b/pkg/sql/opt/testutils/build.go
@@ -39,6 +39,7 @@ func BuildQuery(
 	if err := semaCtx.Placeholders.Init(stmt.NumPlaceholders, nil /* typeHints */); err != nil {
 		t.Fatal(err)
 	}
+	semaCtx.Annotations = tree.MakeAnnotations(stmt.NumAnnotations)
 	o.Init(evalCtx)
 	err = optbuilder.New(ctx, &semaCtx, evalCtx, catalog, o.Factory(), stmt.AST).Build()
 	if err != nil {

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -1207,6 +1207,7 @@ func (ot *OptTester) buildExpr(factory *norm.Factory) error {
 	if err := ot.semaCtx.Placeholders.Init(stmt.NumPlaceholders, nil /* typeHints */); err != nil {
 		return err
 	}
+	ot.semaCtx.Annotations = tree.MakeAnnotations(stmt.NumAnnotations)
 	b := optbuilder.New(ot.ctx, &ot.semaCtx, &ot.evalCtx, ot.catalog, factory, stmt.AST)
 	b.AllowUnsupportedExpr = ot.Flags.AllowUnsupportedExpr
 	return b.Build()

--- a/pkg/sql/opt/testutils/testcat/alter_table.go
+++ b/pkg/sql/opt/testutils/testcat/alter_table.go
@@ -31,9 +31,10 @@ import (
 //  - INJECT STATISTICS: imports table statistics from a JSON object.
 //
 func (tc *Catalog) AlterTable(stmt *tree.AlterTable) {
+	tn := stmt.Table.ToTableName()
 	// Update the table name to include catalog and schema if not provided.
-	tc.qualifyTableName(&stmt.Table)
-	tab := tc.Table(&stmt.Table)
+	tc.qualifyTableName(&tn)
+	tab := tc.Table(&tn)
 
 	for _, cmd := range stmt.Cmds {
 		switch t := cmd.(type) {

--- a/pkg/sql/parser/lexer.go
+++ b/pkg/sql/parser/lexer.go
@@ -39,6 +39,7 @@ type lexer struct {
 	stmt tree.Statement
 	// numPlaceholders is 1 + the highest placeholder index encountered.
 	numPlaceholders int
+	numAnnotations  tree.AnnotationIdx
 
 	lastError *pgerror.Error
 }
@@ -49,6 +50,7 @@ func (l *lexer) init(sql string, tokens []sqlSymType, nakedIntType *types.T) {
 	l.lastPos = -1
 	l.stmt = nil
 	l.numPlaceholders = 0
+	l.numAnnotations = 0
 	l.lastError = nil
 
 	l.nakedIntType = nakedIntType
@@ -122,6 +124,12 @@ func (l *lexer) lastToken() sqlSymType {
 		}
 	}
 	return l.tokens[l.lastPos]
+}
+
+// NewAnnotation returns a new annotation index.
+func (l *lexer) NewAnnotation() tree.AnnotationIdx {
+	l.numAnnotations++
+	return l.numAnnotations
 }
 
 // SetStmt is called from the parser when the statement is constructed.

--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -52,6 +52,10 @@ type Statement struct {
 	// NumPlaceholders is 3. These cases are malformed and will result in a
 	// type-check error.
 	NumPlaceholders int
+
+	// NumAnnotations indicates the number of annotations in the tree. It is equal
+	// to the maximum annotation index.
+	NumAnnotations tree.AnnotationIdx
 }
 
 // Statements is a list of parsed statements.
@@ -191,6 +195,7 @@ func (p *Parser) parse(
 		AST:             p.lexer.stmt,
 		SQL:             sql,
 		NumPlaceholders: p.lexer.numPlaceholders,
+		NumAnnotations:  p.lexer.numAnnotations,
 	}, nil
 }
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -8741,7 +8741,8 @@ db_object_name:
 simple_db_object_name:
   db_object_name_component
   {
-    res, err := tree.NewUnresolvedObjectName(1, [3]string{$1})
+    aIdx := sqllex.(*lexer).NewAnnotation()
+    res, err := tree.NewUnresolvedObjectName(1, [3]string{$1}, aIdx)
     if err != nil { return setErr(sqllex, err) }
     $$.val = res
   }
@@ -8753,13 +8754,15 @@ simple_db_object_name:
 complex_db_object_name:
   db_object_name_component '.' unrestricted_name
   {
-    res, err := tree.NewUnresolvedObjectName(2, [3]string{$3, $1})
+    aIdx := sqllex.(*lexer).NewAnnotation()
+    res, err := tree.NewUnresolvedObjectName(2, [3]string{$3, $1}, aIdx)
     if err != nil { return setErr(sqllex, err) }
     $$.val = res
   }
 | db_object_name_component '.' unrestricted_name '.' unrestricted_name
   {
-    res, err := tree.NewUnresolvedObjectName(3, [3]string{$5, $3, $1})
+    aIdx := sqllex.(*lexer).NewAnnotation()
+    res, err := tree.NewUnresolvedObjectName(3, [3]string{$5, $3, $1}, aIdx)
     if err != nil { return setErr(sqllex, err) }
     $$.val = res
   }

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1252,13 +1252,11 @@ alter_index_stmt:
 alter_onetable_stmt:
   ALTER TABLE relation_expr alter_table_cmds
   {
-    name := $3.unresolvedObjectName().ToTableName()
-    $$.val = &tree.AlterTable{Table: name, IfExists: false, Cmds: $4.alterTableCmds()}
+    $$.val = &tree.AlterTable{Table: $3.unresolvedObjectName(), IfExists: false, Cmds: $4.alterTableCmds()}
   }
 | ALTER TABLE IF EXISTS relation_expr alter_table_cmds
   {
-    name := $5.unresolvedObjectName().ToTableName()
-    $$.val = &tree.AlterTable{Table: name, IfExists: true, Cmds: $6.alterTableCmds()}
+    $$.val = &tree.AlterTable{Table: $5.unresolvedObjectName(), IfExists: true, Cmds: $6.alterTableCmds()}
   }
 
 alter_oneindex_stmt:

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -98,6 +98,11 @@ func (r *runParams) ExecCfg() *ExecutorConfig {
 	return r.extendedEvalCtx.ExecCfg
 }
 
+// Ann is a shortcut for the Annotations from the eval context.
+func (r *runParams) Ann() *tree.Annotations {
+	return r.extendedEvalCtx.EvalContext.Annotations
+}
+
 // planNode defines the interface for executing a query or portion of a query.
 //
 // The following methods apply to planNodes and contain special cases

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -276,6 +276,7 @@ func newInternalPlanner(
 	p.extendedEvalCtx.MemMetrics = memMetrics
 	p.extendedEvalCtx.ExecCfg = execCfg
 	p.extendedEvalCtx.Placeholders = &p.semaCtx.Placeholders
+	p.extendedEvalCtx.Annotations = &p.semaCtx.Annotations
 	p.extendedEvalCtx.Tables = tables
 
 	p.queryCacheSession.Init()

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -640,3 +640,27 @@ func (l *internalLookupCtx) getParentName(table *TableDescriptor) string {
 	}
 	return parentName
 }
+
+// The versions below are part of the work for #34240.
+// TODO(radu): clean these up when everything is switched over.
+
+// See ResolveMutableTableDescriptor.
+func (p *planner) ResolveMutableTableDescriptorEx(
+	ctx context.Context,
+	name *tree.UnresolvedObjectName,
+	required bool,
+	requiredType ResolveRequiredType,
+) (*MutableTableDescriptor, error) {
+	tn := name.ToTableName()
+	table, err := ResolveMutableExistingObject(ctx, p, &tn, required, requiredType)
+	if err != nil {
+		return nil, err
+	}
+	name.SetAnnotation(&p.semaCtx.Annotations, &tn)
+	return table, nil
+}
+
+// ResolvedName is a convenience wrapper for UnresolvedObjectName.Resolved.
+func (p *planner) ResolvedName(u *tree.UnresolvedObjectName) *tree.TableName {
+	return u.Resolved(&p.semaCtx.Annotations)
+}

--- a/pkg/sql/sem/tree/alter_table.go
+++ b/pkg/sql/sem/tree/alter_table.go
@@ -19,7 +19,7 @@ import "github.com/cockroachdb/cockroach/pkg/sql/types"
 // AlterTable represents an ALTER TABLE statement.
 type AlterTable struct {
 	IfExists bool
-	Table    TableName
+	Table    *UnresolvedObjectName
 	Cmds     AlterTableCmds
 }
 
@@ -29,7 +29,7 @@ func (node *AlterTable) Format(ctx *FmtCtx) {
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")
 	}
-	ctx.FormatNode(&node.Table)
+	ctx.FormatNode(node.Table)
 	ctx.FormatNode(&node.Cmds)
 }
 

--- a/pkg/sql/sem/tree/annotation.go
+++ b/pkg/sql/sem/tree/annotation.go
@@ -1,0 +1,58 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tree
+
+// AnnotationIdx is the 1-based index of an annotation. AST nodes that can
+// be annotated store such an index (unique within that AST).
+type AnnotationIdx int32
+
+// NoAnnotation is the uninitialized annotation index.
+const NoAnnotation AnnotationIdx = 0
+
+// AnnotatedNode is embedded in AST nodes that have an annotation.
+type AnnotatedNode struct {
+	AnnIdx AnnotationIdx
+}
+
+// GetAnnotation retrieves the annotation associated with this node.
+func (n AnnotatedNode) GetAnnotation(ann *Annotations) interface{} {
+	if n.AnnIdx == NoAnnotation {
+		return nil
+	}
+	return ann.Get(n.AnnIdx)
+}
+
+// SetAnnotation sets the annotation associated with this node.
+func (n AnnotatedNode) SetAnnotation(ann *Annotations, annotation interface{}) {
+	ann.Set(n.AnnIdx, annotation)
+}
+
+// Annotations is a container for AST annotations.
+type Annotations []interface{}
+
+// MakeAnnotations allocates an annotations container of the given size.
+func MakeAnnotations(numAnnotations AnnotationIdx) Annotations {
+	return make(Annotations, numAnnotations)
+}
+
+// Set an annotation in the container.
+func (a *Annotations) Set(idx AnnotationIdx, annotation interface{}) {
+	(*a)[idx-1] = annotation
+}
+
+// Get an annotation from the container.
+func (a *Annotations) Get(idx AnnotationIdx) interface{} {
+	return (*a)[idx-1]
+}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2583,6 +2583,11 @@ type EvalContext struct {
 	// underlying datum, if available.
 	Placeholders *PlaceholderInfo
 
+	// Annotations augments the AST with extra information. This pointer should
+	// always be set to the location of the Annotations in the corresponding
+	// SemaContext.
+	Annotations *Annotations
+
 	// IVarContainer is used to evaluate IndexedVars.
 	IVarContainer IndexedVarContainer
 	// iVarContainerStack is used when we swap out IVarContainers in order to

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -96,7 +96,11 @@ func classifyColumnItem(n *UnresolvedName) (VarName, error) {
 	var tn *UnresolvedObjectName
 	if n.NumParts > 1 {
 		var err error
-		tn, err = NewUnresolvedObjectName(n.NumParts-1, [3]string{n.Parts[1], n.Parts[2], n.Parts[3]})
+		tn, err = NewUnresolvedObjectName(
+			n.NumParts-1,
+			[3]string{n.Parts[1], n.Parts[2], n.Parts[3]},
+			NoAnnotation,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -1904,7 +1904,7 @@ func (node *AlterTable) doc(p *PrettyCfg) pretty.Doc {
 	if node.IfExists {
 		title = pretty.ConcatSpace(title, pretty.Keyword("IF EXISTS"))
 	}
-	title = pretty.ConcatSpace(title, p.Doc(&node.Table))
+	title = pretty.ConcatSpace(title, p.Doc(node.Table))
 	return p.nestUnder(
 		title,
 		p.Doc(&node.Cmds),

--- a/pkg/sql/sem/tree/table_name.go
+++ b/pkg/sql/sem/tree/table_name.go
@@ -100,7 +100,13 @@ func (t *TableName) String() string { return AsString(t) }
 // FQString renders the table name in full, not omitting the prefix
 // schema and catalog names. Suitable for logging, etc.
 func (t *TableName) FQString() string {
-	return AsStringWithFlags(t, FmtAlwaysQualifyTableNames)
+	ctx := NewFmtCtx(FmtSimple)
+	ctx.FormatNode(&t.CatalogName)
+	ctx.WriteByte('.')
+	ctx.FormatNode(&t.SchemaName)
+	ctx.WriteByte('.')
+	ctx.FormatNode(&t.TableName)
+	return ctx.CloseAndGetString()
 }
 
 // Table retrieves the unqualified table name.
@@ -112,6 +118,25 @@ func (t *TableName) Table() string {
 // the ExplicitSchema/ExplicitCatalog flags).
 func (t *TableName) Equals(other *TableName) bool {
 	return *t == *other
+}
+
+// ToUnresolvedObjectName converts the table name to an unresolved object name.
+// Schema and catalog are included if indicated by the ExplicitSchema and
+// ExplicitCatalog flags.
+func (t *TableName) ToUnresolvedObjectName() *UnresolvedObjectName {
+	u := &UnresolvedObjectName{}
+
+	u.NumParts = 1
+	u.Parts[0] = string(t.TableName)
+	if t.ExplicitSchema {
+		u.Parts[u.NumParts] = string(t.SchemaName)
+		u.NumParts++
+	}
+	if t.ExplicitCatalog {
+		u.Parts[u.NumParts] = string(t.CatalogName)
+		u.NumParts++
+	}
+	return u
 }
 
 // tableExpr implements the TableExpr interface.

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -35,6 +35,9 @@ import (
 // SemaContext defines the context in which to perform semantic analysis on an
 // expression syntax tree.
 type SemaContext struct {
+	// Annotations augments the AST with extra information.
+	Annotations Annotations
+
 	// Placeholders relates placeholder names to their type and, later, value.
 	Placeholders PlaceholderInfo
 

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -88,7 +88,7 @@ func (t *truncateNode) startExec(params runParams) error {
 		ctx,
 		stmtTableDescs,
 		droppedTableDetails,
-		tree.AsStringWithFlags(n, tree.FmtAlwaysQualifyTableNames),
+		tree.AsStringWithFQNames(n, params.Ann()),
 		false, /* drainNames */
 		sqlbase.InvalidID /* droppedDatabaseID */)
 	if err != nil {


### PR DESCRIPTION
#### sql: add AST annotations

This change adds infrastructure for annotating AST nodes. Only certain
nodes can be annotated (currently `UnresolvedObjectName`). The parser
sets up annotation indices for these nodes, and the annotations are
stored in a separate Annotation container. The annotations will allow
us to stop modifying the AST during type and semantic checking.

The annotation for an `UnresolvedObjectName` will contain the resolved
`*TableName`.

See #34240 and #22847 for more context.

Release note: None

#### sql: use UnresolvedObjectName in AlterTable

Change AlterTable to contain an `UnresolvedObjectName`.

Release note: None
