### PR TITLE
roachprod: include all regions by default for commands other than create

### DIFF
--- a/pkg/cmd/roachprod/vm/aws/config.go
+++ b/pkg/cmd/roachprod/vm/aws/config.go
@@ -136,6 +136,16 @@ func (c *awsConfig) getAvailabilityZone(azName string) *availabilityZone {
 	return c.azByName[azName]
 }
 
+func (c *awsConfig) availabilityZoneNames() (zoneNames []string) {
+	for _, r := range c.regions {
+		for _, az := range r.AvailabilityZones {
+			zoneNames = append(zoneNames, az.name)
+		}
+	}
+	sort.Strings(zoneNames)
+	return zoneNames
+}
+
 // availabilityZones is a slice of availabilityZone which implements
 // json.Marshaler and json.Unmarshaler.
 type availabilityZones []availabilityZone


### PR DESCRIPTION
Before this change, roachprod would always use the list of defaultZones
which were intended to make creating geo-distributed clusters using the `--geo`
flag more predictable. The problem is that this set of zones was also used for
operations like list and gc which had the unfortunate consequence of zones
outside of default set not being scanned. This change sets up roachprod to
use all known regions by default for commands other than create.

Release note: None