### PR TITLE
lint: switch to new staticcheck

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -45,6 +45,14 @@
   revision = "d6e3b3328b783f23731bc4d058875b0371ff8109"
 
 [[projects]]
+  digest = "1:9f3b30d9f8e0d7040f729b82dcbc8f0dead820a133b3147ce355fc451f32d761"
+  name = "github.com/BurntSushi/toml"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005"
+  version = "v0.3.1"
+
+[[projects]]
   digest = "1:ed77032e4241e3b8329c9304d66452ed196e795876e14be677a546f36b94e67a"
   name = "github.com/DataDog/zstd"
   packages = ["."]
@@ -1587,7 +1595,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:e98ff366c777a4ccb71b95544fabeb59660aaf4df1d8d12193b44c1fb5cb1f7b"
+  digest = "1:1466e9d841b30213a2bdb0db95ff122e996983a7ad7a5fea4ef5ba88f13cf070"
   name = "golang.org/x/tools"
   packages = [
     "cmd/goyacc",
@@ -1643,7 +1651,7 @@
     "internal/semver",
   ]
   pruneopts = "UT"
-  revision = "bf090417da8b6150dcfe96795325f5aa78fff718"
+  revision = "63859f3815cb436d25749575cb14aef1153e5634"
 
 [[projects]]
   digest = "1:768c35ec83dd17029060ea581d6ca9fdcaef473ec87e93e4bb750949035f6070"
@@ -1742,25 +1750,37 @@
   source = "https://github.com/cockroachdb/yaml"
 
 [[projects]]
-  digest = "1:ce504fbb2b67961ac269fc0a9fcf16a48f638d622af3d87f5cdff766e2559161"
+  digest = "1:be57199733b1f758f0de225280c40dbc5435a8b60224d8ddb773b1dad84ad934"
   name = "honnef.co/go/tools"
   packages = [
-    "callgraph",
-    "callgraph/static",
+    "arg",
+    "cmd/staticcheck",
+    "config",
     "deprecated",
+    "facts",
     "functions",
+    "go/types/typeutil",
+    "internal/cache",
+    "internal/passes/buildssa",
+    "internal/renameio",
     "internal/sharedcheck",
     "lint",
+    "lint/lintdsl",
+    "lint/lintutil",
+    "lint/lintutil/format",
+    "loader",
+    "printf",
     "simple",
     "ssa",
-    "ssa/ssautil",
+    "ssautil",
     "staticcheck",
     "staticcheck/vrp",
+    "stylecheck",
     "unused",
+    "version",
   ]
   pruneopts = "UT"
-  revision = "d73ab98e7c39fdcf9ba65062e43d34310f198353"
-  version = "2017.2.2"
+  revision = "4187a5ff696fcfe80ef2204f78a3ae8262b2d54d"
 
 [[projects]]
   branch = "no-flag-names-parens"
@@ -1940,7 +1960,6 @@
     "golang.org/x/tools/container/intsets",
     "golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow",
     "golang.org/x/tools/go/buildutil",
-    "golang.org/x/tools/go/loader",
     "google.golang.org/api/iterator",
     "google.golang.org/api/option",
     "google.golang.org/grpc",
@@ -1957,10 +1976,8 @@
     "google.golang.org/grpc/status",
     "google.golang.org/grpc/transport",
     "gopkg.in/yaml.v2",
+    "honnef.co/go/tools/cmd/staticcheck",
     "honnef.co/go/tools/lint",
-    "honnef.co/go/tools/simple",
-    "honnef.co/go/tools/staticcheck",
-    "honnef.co/go/tools/unused",
     "vitess.io/vitess/go/sqltypes",
     "vitess.io/vitess/go/vt/sqlparser",
   ]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -16,6 +16,7 @@ required = [
  "golang.org/x/tools/cmd/goyacc",
  "golang.org/x/tools/cmd/stringer",
  "golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow",
+ "honnef.co/go/tools/cmd/staticcheck",
 ]
 
 ignored = [
@@ -98,7 +99,9 @@ ignored = [
 # Pin to 2017.2.2 because of https://github.com/cockroachdb/cockroach/issues/33669.
 [[constraint]]
   name = "honnef.co/go/tools"
-  version = "=2017.2.2"
+  # This revision is not yet on master (as of 05-12-2019); when it is, we can
+  # switch to just using the master branch.
+  revision = "4187a5ff696fcfe80ef2204f78a3ae8262b2d54d"
 
 # Test util - don't need to pin.
 [[constraint]]

--- a/Makefile
+++ b/Makefile
@@ -313,7 +313,8 @@ bin/.bootstrap: $(GITHOOKS) Gopkg.lock | bin/.submodules-initialized
 		./vendor/golang.org/x/perf/cmd/benchstat \
 		./vendor/golang.org/x/tools/cmd/goyacc \
 		./vendor/golang.org/x/tools/cmd/stringer \
-		./vendor/golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
+		./vendor/golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow \
+		./vendor/honnef.co/go/tools/cmd/staticcheck
 	touch $@
 
 .SECONDARY: bin/.submodules-initialized

--- a/pkg/base/testclusterreplicationmode_string.go
+++ b/pkg/base/testclusterreplicationmode_string.go
@@ -4,6 +4,14 @@ package base
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[ReplicationAuto-0]
+	_ = x[ReplicationManual-1]
+}
+
 const _TestClusterReplicationMode_name = "ReplicationAutoReplicationManual"
 
 var _TestClusterReplicationMode_index = [...]uint8{0, 15, 32}

--- a/pkg/cli/flags_util.go
+++ b/pkg/cli/flags_util.go
@@ -31,9 +31,12 @@ import (
 	humanize "github.com/dustin/go-humanize"
 	"github.com/elastic/gosigar"
 	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
 )
 
 type localityList []roachpb.LocalityAddress
+
+var _ pflag.Value = &localityList{}
 
 // Type implements the pflag.Value interface.
 func (l *localityList) Type() string { return "localityList" }

--- a/pkg/cli/keytype_string.go
+++ b/pkg/cli/keytype_string.go
@@ -4,6 +4,16 @@ package cli
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[raw-0]
+	_ = x[human-1]
+	_ = x[rangeID-2]
+	_ = x[hex-3]
+}
+
 const _keyType_name = "rawhumanrangeIDhex"
 
 var _keyType_index = [...]uint8{0, 3, 8, 15, 18}

--- a/pkg/cmd/roachtest/tpchbench_string.go
+++ b/pkg/cmd/roachtest/tpchbench_string.go
@@ -4,6 +4,13 @@ package main
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[sql20-0]
+}
+
 const _tpchBench_name = "sql20"
 
 var _tpchBench_index = [...]uint8{0, 5}

--- a/pkg/kv/txnstate_string.go
+++ b/pkg/kv/txnstate_string.go
@@ -4,6 +4,15 @@ package kv
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[txnPending-0]
+	_ = x[txnError-1]
+	_ = x[txnFinalized-2]
+}
+
 const _txnState_name = "txnPendingtxnErrortxnFinalized"
 
 var _txnState_index = [...]uint8{0, 10, 18, 30}

--- a/pkg/roachpb/method_string.go
+++ b/pkg/roachpb/method_string.go
@@ -4,6 +4,54 @@ package roachpb
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[Get-0]
+	_ = x[Put-1]
+	_ = x[ConditionalPut-2]
+	_ = x[Increment-3]
+	_ = x[Delete-4]
+	_ = x[DeleteRange-5]
+	_ = x[ClearRange-6]
+	_ = x[Scan-7]
+	_ = x[ReverseScan-8]
+	_ = x[BeginTransaction-9]
+	_ = x[EndTransaction-10]
+	_ = x[AdminSplit-11]
+	_ = x[AdminMerge-12]
+	_ = x[AdminTransferLease-13]
+	_ = x[AdminChangeReplicas-14]
+	_ = x[AdminRelocateRange-15]
+	_ = x[HeartbeatTxn-16]
+	_ = x[GC-17]
+	_ = x[PushTxn-18]
+	_ = x[RecoverTxn-19]
+	_ = x[QueryTxn-20]
+	_ = x[QueryIntent-21]
+	_ = x[ResolveIntent-22]
+	_ = x[ResolveIntentRange-23]
+	_ = x[Merge-24]
+	_ = x[TruncateLog-25]
+	_ = x[RequestLease-26]
+	_ = x[TransferLease-27]
+	_ = x[LeaseInfo-28]
+	_ = x[ComputeChecksum-29]
+	_ = x[CheckConsistency-30]
+	_ = x[InitPut-31]
+	_ = x[WriteBatch-32]
+	_ = x[Export-33]
+	_ = x[Import-34]
+	_ = x[AdminScatter-35]
+	_ = x[AddSSTable-36]
+	_ = x[RecomputeStats-37]
+	_ = x[Refresh-38]
+	_ = x[RefreshRange-39]
+	_ = x[Subsume-40]
+	_ = x[RangeStats-41]
+}
+
 const _Method_name = "GetPutConditionalPutIncrementDeleteDeleteRangeClearRangeScanReverseScanBeginTransactionEndTransactionAdminSplitAdminMergeAdminTransferLeaseAdminChangeReplicasAdminRelocateRangeHeartbeatTxnGCPushTxnRecoverTxnQueryTxnQueryIntentResolveIntentResolveIntentRangeMergeTruncateLogRequestLeaseTransferLeaseLeaseInfoComputeChecksumCheckConsistencyInitPutWriteBatchExportImportAdminScatterAddSSTableRecomputeStatsRefreshRefreshRangeSubsumeRangeStats"
 
 var _Method_index = [...]uint16{0, 3, 6, 20, 29, 35, 46, 56, 60, 71, 87, 101, 111, 121, 139, 158, 176, 188, 190, 197, 207, 215, 226, 239, 257, 262, 273, 285, 298, 307, 322, 338, 345, 355, 361, 367, 379, 389, 403, 410, 422, 429, 439}

--- a/pkg/roachpb/span_group.go
+++ b/pkg/roachpb/span_group.go
@@ -68,6 +68,8 @@ func (g *SpanGroup) Len() int {
 	return g.rg.Len()
 }
 
+var _ = (*SpanGroup).Len
+
 // Slice will return the contents of the SpanGroup as a slice of Spans.
 func (g *SpanGroup) Slice() []Span {
 	rg := g.rg

--- a/pkg/sql/advancecode_string.go
+++ b/pkg/sql/advancecode_string.go
@@ -4,6 +4,17 @@ package sql
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[advanceUnknown-0]
+	_ = x[stayInPlace-1]
+	_ = x[advanceOne-2]
+	_ = x[skipBatch-3]
+	_ = x[rewind-4]
+}
+
 const _advanceCode_name = "advanceUnknownstayInPlaceadvanceOneskipBatchrewind"
 
 var _advanceCode_index = [...]uint8{0, 14, 25, 35, 44, 50}

--- a/pkg/sql/distsqlrun/consumerstatus_string.go
+++ b/pkg/sql/distsqlrun/consumerstatus_string.go
@@ -4,6 +4,15 @@ package distsqlrun
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[NeedMoreRows-0]
+	_ = x[DrainRequested-1]
+	_ = x[ConsumerClosed-2]
+}
+
 const _ConsumerStatus_name = "NeedMoreRowsDrainRequestedConsumerClosed"
 
 var _ConsumerStatus_index = [...]uint8{0, 12, 26, 40}

--- a/pkg/sql/distsqlrun/procstate_string.go
+++ b/pkg/sql/distsqlrun/procstate_string.go
@@ -4,6 +4,16 @@ package distsqlrun
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[StateRunning-0]
+	_ = x[stateDraining-1]
+	_ = x[stateTrailingMeta-2]
+	_ = x[stateExhausted-3]
+}
+
 const _procState_name = "StateRunningstateDrainingstateTrailingMetastateExhausted"
 
 var _procState_index = [...]uint8{0, 12, 25, 42, 56}

--- a/pkg/sql/exec/types/t_string.go
+++ b/pkg/sql/exec/types/t_string.go
@@ -4,6 +4,22 @@ package types
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[Bool-0]
+	_ = x[Bytes-1]
+	_ = x[Decimal-2]
+	_ = x[Int8-3]
+	_ = x[Int16-4]
+	_ = x[Int32-5]
+	_ = x[Int64-6]
+	_ = x[Float32-7]
+	_ = x[Float64-8]
+	_ = x[Unhandled-9]
+}
+
 const _T_name = "BoolBytesDecimalInt8Int16Int32Int64Float32Float64Unhandled"
 
 var _T_index = [...]uint8{0, 4, 9, 16, 20, 25, 30, 35, 42, 49, 58}

--- a/pkg/sql/opt/optgen/lang/operator_string.go
+++ b/pkg/sql/opt/optgen/lang/operator_string.go
@@ -4,6 +4,38 @@ package lang
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[UnknownOp-0]
+	_ = x[RootOp-1]
+	_ = x[DefineSetOp-2]
+	_ = x[RuleSetOp-3]
+	_ = x[DefineOp-4]
+	_ = x[CommentsOp-5]
+	_ = x[CommentOp-6]
+	_ = x[TagsOp-7]
+	_ = x[TagOp-8]
+	_ = x[DefineFieldsOp-9]
+	_ = x[DefineFieldOp-10]
+	_ = x[RuleOp-11]
+	_ = x[FuncOp-12]
+	_ = x[NamesOp-13]
+	_ = x[NameOp-14]
+	_ = x[AndOp-15]
+	_ = x[NotOp-16]
+	_ = x[ListOp-17]
+	_ = x[ListAnyOp-18]
+	_ = x[BindOp-19]
+	_ = x[RefOp-20]
+	_ = x[AnyOp-21]
+	_ = x[SliceOp-22]
+	_ = x[StringOp-23]
+	_ = x[NumberOp-24]
+	_ = x[CustomFuncOp-25]
+}
+
 const _Operator_name = "UnknownOpRootOpDefineSetOpRuleSetOpDefineOpCommentsOpCommentOpTagsOpTagOpDefineFieldsOpDefineFieldOpRuleOpFuncOpNamesOpNameOpAndOpNotOpListOpListAnyOpBindOpRefOpAnyOpSliceOpStringOpNumberOpCustomFuncOp"
 
 var _Operator_index = [...]uint8{0, 9, 15, 26, 35, 43, 53, 62, 68, 73, 87, 100, 106, 112, 119, 125, 130, 135, 141, 150, 156, 161, 166, 173, 181, 189, 201}

--- a/pkg/sql/opt/optgen/lang/token_string.go
+++ b/pkg/sql/opt/optgen/lang/token_string.go
@@ -4,6 +4,36 @@ package lang
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[ILLEGAL-0]
+	_ = x[ERROR-1]
+	_ = x[EOF-2]
+	_ = x[IDENT-3]
+	_ = x[STRING-4]
+	_ = x[NUMBER-5]
+	_ = x[WHITESPACE-6]
+	_ = x[COMMENT-7]
+	_ = x[LPAREN-8]
+	_ = x[RPAREN-9]
+	_ = x[LBRACKET-10]
+	_ = x[RBRACKET-11]
+	_ = x[LBRACE-12]
+	_ = x[RBRACE-13]
+	_ = x[DOLLAR-14]
+	_ = x[COLON-15]
+	_ = x[ASTERISK-16]
+	_ = x[EQUALS-17]
+	_ = x[ARROW-18]
+	_ = x[AMPERSAND-19]
+	_ = x[COMMA-20]
+	_ = x[CARET-21]
+	_ = x[ELLIPSES-22]
+	_ = x[PIPE-23]
+}
+
 const _Token_name = "ILLEGALERROREOFIDENTSTRINGNUMBERWHITESPACECOMMENTLPARENRPARENLBRACKETRBRACKETLBRACERBRACEDOLLARCOLONASTERISKEQUALSARROWAMPERSANDCOMMACARETELLIPSESPIPE"
 
 var _Token_index = [...]uint8{0, 7, 12, 15, 20, 26, 32, 42, 49, 55, 61, 69, 77, 83, 89, 95, 100, 108, 114, 119, 128, 133, 138, 146, 150}

--- a/pkg/sql/pgwire/pgwirebase/clientmessagetype_string.go
+++ b/pkg/sql/pgwire/pgwirebase/clientmessagetype_string.go
@@ -4,6 +4,25 @@ package pgwirebase
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[ClientMsgBind-66]
+	_ = x[ClientMsgClose-67]
+	_ = x[ClientMsgCopyData-100]
+	_ = x[ClientMsgCopyDone-99]
+	_ = x[ClientMsgCopyFail-102]
+	_ = x[ClientMsgDescribe-68]
+	_ = x[ClientMsgExecute-69]
+	_ = x[ClientMsgFlush-72]
+	_ = x[ClientMsgParse-80]
+	_ = x[ClientMsgPassword-112]
+	_ = x[ClientMsgSimpleQuery-81]
+	_ = x[ClientMsgSync-83]
+	_ = x[ClientMsgTerminate-88]
+}
+
 const (
 	_ClientMessageType_name_0 = "ClientMsgBindClientMsgCloseClientMsgDescribeClientMsgExecute"
 	_ClientMessageType_name_1 = "ClientMsgFlush"

--- a/pkg/sql/pgwire/pgwirebase/formatcode_string.go
+++ b/pkg/sql/pgwire/pgwirebase/formatcode_string.go
@@ -4,6 +4,14 @@ package pgwirebase
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[FormatText-0]
+	_ = x[FormatBinary-1]
+}
+
 const _FormatCode_name = "FormatTextFormatBinary"
 
 var _FormatCode_index = [...]uint8{0, 10, 22}

--- a/pkg/sql/pgwire/pgwirebase/pgnumericsign_string.go
+++ b/pkg/sql/pgwire/pgwirebase/pgnumericsign_string.go
@@ -4,6 +4,14 @@ package pgwirebase
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[PGNumericPos-0]
+	_ = x[PGNumericNeg-16384]
+}
+
 const (
 	_PGNumericSign_name_0 = "PGNumericPos"
 	_PGNumericSign_name_1 = "PGNumericNeg"

--- a/pkg/sql/pgwire/pgwirebase/preparetype_string.go
+++ b/pkg/sql/pgwire/pgwirebase/preparetype_string.go
@@ -4,6 +4,14 @@ package pgwirebase
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[PrepareStatement-83]
+	_ = x[PreparePortal-80]
+}
+
 const (
 	_PrepareType_name_0 = "PreparePortal"
 	_PrepareType_name_1 = "PrepareStatement"

--- a/pkg/sql/pgwire/pgwirebase/servererrfieldtype_string.go
+++ b/pkg/sql/pgwire/pgwirebase/servererrfieldtype_string.go
@@ -4,6 +4,20 @@ package pgwirebase
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[ServerErrFieldSeverity-83]
+	_ = x[ServerErrFieldSQLState-67]
+	_ = x[ServerErrFieldMsgPrimary-77]
+	_ = x[ServerErrFileldDetail-68]
+	_ = x[ServerErrFileldHint-72]
+	_ = x[ServerErrFieldSrcFile-70]
+	_ = x[ServerErrFieldSrcLine-76]
+	_ = x[ServerErrFieldSrcFunction-82]
+}
+
 const (
 	_ServerErrFieldType_name_0 = "ServerErrFieldSQLStateServerErrFileldDetail"
 	_ServerErrFieldType_name_1 = "ServerErrFieldSrcFile"

--- a/pkg/sql/pgwire/pgwirebase/servermessagetype_string.go
+++ b/pkg/sql/pgwire/pgwirebase/servermessagetype_string.go
@@ -4,6 +4,26 @@ package pgwirebase
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[ServerMsgAuth-82]
+	_ = x[ServerMsgBindComplete-50]
+	_ = x[ServerMsgCommandComplete-67]
+	_ = x[ServerMsgCloseComplete-51]
+	_ = x[ServerMsgCopyInResponse-71]
+	_ = x[ServerMsgDataRow-68]
+	_ = x[ServerMsgEmptyQuery-73]
+	_ = x[ServerMsgErrorResponse-69]
+	_ = x[ServerMsgNoData-110]
+	_ = x[ServerMsgParameterDescription-116]
+	_ = x[ServerMsgParameterStatus-83]
+	_ = x[ServerMsgParseComplete-49]
+	_ = x[ServerMsgReady-90]
+	_ = x[ServerMsgRowDescription-84]
+}
+
 const (
 	_ServerMessageType_name_0 = "ServerMsgParseCompleteServerMsgBindCompleteServerMsgCloseComplete"
 	_ServerMessageType_name_1 = "ServerMsgCommandCompleteServerMsgDataRowServerMsgErrorResponse"

--- a/pkg/sql/privilege/kind_string.go
+++ b/pkg/sql/privilege/kind_string.go
@@ -4,6 +4,20 @@ package privilege
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[ALL-1]
+	_ = x[CREATE-2]
+	_ = x[DROP-3]
+	_ = x[GRANT-4]
+	_ = x[SELECT-5]
+	_ = x[INSERT-6]
+	_ = x[DELETE-7]
+	_ = x[UPDATE-8]
+}
+
 const _Kind_name = "ALLCREATEDROPGRANTSELECTINSERTDELETEUPDATE"
 
 var _Kind_index = [...]uint8{0, 3, 9, 13, 18, 24, 30, 36, 42}

--- a/pkg/sql/row/fetcherstate_string.go
+++ b/pkg/sql/row/fetcherstate_string.go
@@ -4,6 +4,21 @@ package row
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[stateInvalid-0]
+	_ = x[stateInitFetch-1]
+	_ = x[stateResetBatch-2]
+	_ = x[stateDecodeFirstKVOfRow-3]
+	_ = x[stateSeekPrefix-4]
+	_ = x[stateFetchNextKVWithUnfinishedRow-5]
+	_ = x[stateFinalizeRow-6]
+	_ = x[stateEmitLastBatch-7]
+	_ = x[stateFinished-8]
+}
+
 const _fetcherState_name = "stateInvalidstateInitFetchstateResetBatchstateDecodeFirstKVOfRowstateSeekPrefixstateFetchNextKVWithUnfinishedRowstateFinalizeRowstateEmitLastBatchstateFinished"
 
 var _fetcherState_index = [...]uint8{0, 12, 26, 41, 64, 79, 112, 128, 146, 159}

--- a/pkg/sql/schemachange/columnconversionkind_string.go
+++ b/pkg/sql/schemachange/columnconversionkind_string.go
@@ -4,6 +4,17 @@ package schemachange
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[ColumnConversionDangerous - -1]
+	_ = x[ColumnConversionImpossible-0]
+	_ = x[ColumnConversionTrivial-1]
+	_ = x[ColumnConversionValidate-2]
+	_ = x[ColumnConversionGeneral-3]
+}
+
 const _ColumnConversionKind_name = "DangerousImpossibleTrivialValidateGeneral"
 
 var _ColumnConversionKind_index = [...]uint8{0, 9, 19, 26, 34, 41}

--- a/pkg/sql/sem/tree/statementtype_string.go
+++ b/pkg/sql/sem/tree/statementtype_string.go
@@ -4,6 +4,18 @@ package tree
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[Ack-0]
+	_ = x[DDL-1]
+	_ = x[RowsAffected-2]
+	_ = x[Rows-3]
+	_ = x[CopyIn-4]
+	_ = x[Unknown-5]
+}
+
 const _StatementType_name = "AckDDLRowsAffectedRowsCopyInUnknown"
 
 var _StatementType_index = [...]uint8{0, 3, 6, 18, 22, 28, 35}

--- a/pkg/sql/sqlbase/formatversion_string.go
+++ b/pkg/sql/sqlbase/formatversion_string.go
@@ -4,6 +4,15 @@ package sqlbase
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[BaseFormatVersion-1]
+	_ = x[FamilyFormatVersion-2]
+	_ = x[InterleavedFormatVersion-3]
+}
+
 const _FormatVersion_name = "BaseFormatVersionFamilyFormatVersionInterleavedFormatVersion"
 
 var _FormatVersion_index = [...]uint8{0, 17, 36, 60}

--- a/pkg/sql/txnevent_string.go
+++ b/pkg/sql/txnevent_string.go
@@ -4,6 +4,17 @@ package sql
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[noEvent-0]
+	_ = x[txnStart-1]
+	_ = x[txnCommit-2]
+	_ = x[txnAborted-3]
+	_ = x[txnRestart-4]
+}
+
 const _txnEvent_name = "noEventtxnStarttxnCommittxnAbortedtxnRestart"
 
 var _txnEvent_index = [...]uint8{0, 7, 15, 24, 34, 44}

--- a/pkg/sql/txntype_string.go
+++ b/pkg/sql/txntype_string.go
@@ -4,6 +4,14 @@ package sql
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[implicitTxn-0]
+	_ = x[explicitTxn-1]
+}
+
 const _txnType_name = "implicitTxnexplicitTxn"
 
 var _txnType_index = [...]uint8{0, 11, 22}

--- a/pkg/storage/engine/batch.go
+++ b/pkg/storage/engine/batch.go
@@ -135,6 +135,8 @@ func (b *RocksDBBatchBuilder) Len() int {
 	return len(b.repr)
 }
 
+var _ = (*RocksDBBatchBuilder).Len
+
 // getRepr constructs the batch representation and returns it.
 func (b *RocksDBBatchBuilder) getRepr() []byte {
 	b.maybeInit()

--- a/pkg/storage/refreshraftreason_string.go
+++ b/pkg/storage/refreshraftreason_string.go
@@ -4,6 +4,18 @@ package storage
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[noReason-0]
+	_ = x[reasonNewLeader-1]
+	_ = x[reasonNewLeaderOrConfigChange-2]
+	_ = x[reasonSnapshotApplied-3]
+	_ = x[reasonReplicaIDChanged-4]
+	_ = x[reasonTicks-5]
+}
+
 const _refreshRaftReason_name = "noReasonreasonNewLeaderreasonNewLeaderOrConfigChangereasonSnapshotAppliedreasonReplicaIDChangedreasonTicks"
 
 var _refreshRaftReason_index = [...]uint8{0, 8, 23, 52, 73, 95, 106}

--- a/pkg/testutils/lint/checker_float.go
+++ b/pkg/testutils/lint/checker_float.go
@@ -12,7 +12,8 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// +build lint
+// TODO(radu): re-enable the checkers using the new staticcheck interfaces.
+// +build lint_todo
 
 package lint
 

--- a/pkg/testutils/lint/checker_hash.go
+++ b/pkg/testutils/lint/checker_hash.go
@@ -12,7 +12,8 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// +build lint
+// TODO(radu): re-enable the checkers using the new staticcheck interfaces.
+// +build lint_todo
 
 package lint
 

--- a/pkg/testutils/lint/checker_misc.go
+++ b/pkg/testutils/lint/checker_misc.go
@@ -12,7 +12,8 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// +build lint
+// TODO(radu): re-enable the checkers using the new staticcheck interfaces.
+// +build lint_todo
 
 package lint
 

--- a/pkg/testutils/lint/checker_timer.go
+++ b/pkg/testutils/lint/checker_timer.go
@@ -12,7 +12,8 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// +build lint
+// TODO(radu): re-enable the checkers using the new staticcheck interfaces.
+// +build lint_todo
 
 package lint
 

--- a/pkg/testutils/lint/checker_unconvert.go
+++ b/pkg/testutils/lint/checker_unconvert.go
@@ -12,7 +12,8 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// +build lint
+// TODO(radu): re-enable the checkers using the new staticcheck interfaces.
+// +build lint_todo
 
 package lint
 

--- a/pkg/util/encoding/type_string.go
+++ b/pkg/util/encoding/type_string.go
@@ -4,6 +4,31 @@ package encoding
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[Unknown-0]
+	_ = x[Null-1]
+	_ = x[NotNull-2]
+	_ = x[Int-3]
+	_ = x[Float-4]
+	_ = x[Decimal-5]
+	_ = x[Bytes-6]
+	_ = x[BytesDesc-7]
+	_ = x[Time-8]
+	_ = x[Duration-9]
+	_ = x[True-10]
+	_ = x[False-11]
+	_ = x[UUID-12]
+	_ = x[Array-13]
+	_ = x[IPAddr-14]
+	_ = x[JSON-15]
+	_ = x[Tuple-16]
+	_ = x[BitArray-17]
+	_ = x[BitArrayDesc-18]
+}
+
 const _Type_name = "UnknownNullNotNullIntFloatDecimalBytesBytesDescTimeDurationTrueFalseUUIDArrayIPAddrJSONTupleBitArrayBitArrayDesc"
 
 var _Type_index = [...]uint8{0, 7, 11, 18, 21, 26, 33, 38, 47, 51, 59, 63, 68, 72, 77, 83, 87, 92, 100, 112}

--- a/pkg/util/log/logflags/logflags.go
+++ b/pkg/util/log/logflags/logflags.go
@@ -27,9 +27,12 @@ type atomicBool struct {
 	b *bool
 }
 
+// IsBoolFlag is recognized by pflags.
 func (ab *atomicBool) IsBoolFlag() bool {
 	return true
 }
+
+var _ = (*atomicBool).IsBoolFlag
 
 func (ab *atomicBool) String() string {
 	if ab.Locker == nil {

--- a/pkg/util/timeutil/pgdate/field_string.go
+++ b/pkg/util/timeutil/pgdate/field_string.go
@@ -4,6 +4,24 @@ package pgdate
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[fieldYear-0]
+	_ = x[fieldMonth-1]
+	_ = x[fieldDay-2]
+	_ = x[fieldEra-3]
+	_ = x[fieldHour-4]
+	_ = x[fieldMinute-5]
+	_ = x[fieldSecond-6]
+	_ = x[fieldNanos-7]
+	_ = x[fieldMeridian-8]
+	_ = x[fieldTZHour-9]
+	_ = x[fieldTZMinute-10]
+	_ = x[fieldTZSecond-11]
+}
+
 const _field_name = "fieldYearfieldMonthfieldDayfieldErafieldHourfieldMinutefieldSecondfieldNanosfieldMeridianfieldTZHourfieldTZMinutefieldTZSecond"
 
 var _field_index = [...]uint8{0, 9, 19, 27, 35, 44, 55, 66, 76, 89, 100, 113, 126}

--- a/pkg/util/timeutil/pgdate/parsemode_string.go
+++ b/pkg/util/timeutil/pgdate/parsemode_string.go
@@ -4,6 +4,15 @@ package pgdate
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[ParseModeYMD-0]
+	_ = x[ParseModeDMY-1]
+	_ = x[ParseModeMDY-2]
+}
+
 const _ParseMode_name = "ParseModeYMDParseModeDMYParseModeMDY"
 
 var _ParseMode_index = [...]uint8{0, 12, 24, 36}


### PR DESCRIPTION
Replace the TestMegacheck and TestUnused tests with a call to the new
`staticcheck`.

Our custom checkers will need to be rewritten using the new
interfaces; disable the old code until then (this will be tracked
by #33669).

Fixes #37061.

Release note: None