### PR TITLE
release-2.1: roachpb: prevent data race on Transaction

### DIFF
--- a/pkg/internal/client/txn_test.go
+++ b/pkg/internal/client/txn_test.go
@@ -392,7 +392,6 @@ func TestSetPriority(t *testing.T) {
 				}
 
 				br := &roachpb.BatchResponse{}
-				br.Txn = &roachpb.Transaction{}
 				br.Txn.Update(ba.Txn) // copy
 				return br, nil
 			}), clock)

--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -935,7 +935,9 @@ func (ds *DistSender) divideAndSendBatchToRanges(
 			// Update the transaction from the response. Note that this wouldn't happen
 			// on the asynchronous path, but if we have newer information it's good to
 			// use it.
-			ba.UpdateTxn(resp.reply.Txn)
+			if !lastRange {
+				ba.UpdateTxn(resp.reply.Txn)
+			}
 
 			mightStopEarly := ba.MaxSpanRequestKeys > 0 || stopAtRangeBoundary
 			// Check whether we've received enough responses to exit query loop.

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -383,10 +383,13 @@ func (h *BatchResponse_Header) combine(o BatchResponse_Header) error {
 		)
 	}
 	h.Timestamp.Forward(o.Timestamp)
-	if h.Txn == nil {
-		h.Txn = o.Txn
-	} else {
-		h.Txn.Update(o.Txn)
+	if txn := o.Txn; txn != nil {
+		if h.Txn == nil {
+			txnClone := txn.Clone()
+			h.Txn = &txnClone
+		} else {
+			h.Txn.Update(txn)
+		}
 	}
 	h.Now.Forward(o.Now)
 	h.CollectedSpans = append(h.CollectedSpans, o.CollectedSpans...)

--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -60,17 +60,17 @@ func (ba *BatchRequest) SetActiveTimestamp(nowFn func() hlc.Timestamp) error {
 // UpdateTxn updates the batch transaction from the supplied one in
 // a copy-on-write fashion, i.e. without mutating an existing
 // Transaction struct.
-func (ba *BatchRequest) UpdateTxn(otherTxn *Transaction) {
-	if otherTxn == nil {
+func (ba *BatchRequest) UpdateTxn(o *Transaction) {
+	if o == nil {
 		return
 	}
-	otherTxn.AssertInitialized(context.TODO())
+	o.AssertInitialized(context.TODO())
 	if ba.Txn == nil {
-		ba.Txn = otherTxn
+		ba.Txn = o
 		return
 	}
 	clonedTxn := ba.Txn.Clone()
-	clonedTxn.Update(otherTxn)
+	clonedTxn.Update(o)
 	ba.Txn = &clonedTxn
 }
 

--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -365,7 +365,6 @@ func (br *BatchResponse) Combine(otherBatch *BatchResponse, positions []int) err
 			return errors.Errorf("can not combine %T and %T", valLeft, valRight)
 		}
 	}
-	br.Txn.Update(otherBatch.Txn)
 	return nil
 }
 

--- a/pkg/roachpb/data.pb.go
+++ b/pkg/roachpb/data.pb.go
@@ -440,8 +440,10 @@ type Transaction struct {
 	// clock, we may add that to the map, which eliminates read uncertainty for
 	// reads on that node.
 	//
-	// The list of observed timestamps is kept sorted by NodeID. Use
-	// Transaction.UpdateObservedTimestamp to maintain the sorted order.
+	// The slice of observed timestamps is kept sorted by NodeID. Use
+	// Transaction.UpdateObservedTimestamp to maintain the sorted order. The
+	// slice should be treated as immutable and all updates should be performed
+	// on a copy of the slice.
 	ObservedTimestamps []ObservedTimestamp `protobuf:"bytes,8,rep,name=observed_timestamps,json=observedTimestamps" json:"observed_timestamps"`
 	// Writing is true if the transaction has previously sent a Begin transaction
 	// (i.e. if it ever attempted to perform a write, so if it ever attempted to
@@ -463,8 +465,10 @@ type Transaction struct {
 	// the transaction contains any calls to DeleteRange, in order to
 	// prevent the LostDeleteRange anomaly. This flag is relevant only
 	// for SNAPSHOT transactions.
-	RetryOnPush bool   `protobuf:"varint,13,opt,name=retry_on_push,json=retryOnPush,proto3" json:"retry_on_push,omitempty"`
-	Intents     []Span `protobuf:"bytes,11,rep,name=intents" json:"intents"`
+	RetryOnPush bool `protobuf:"varint,13,opt,name=retry_on_push,json=retryOnPush,proto3" json:"retry_on_push,omitempty"`
+	// The slice should be treated as immutable and all updates should be
+	// performed on a copy of the slice.
+	Intents []Span `protobuf:"bytes,11,rep,name=intents" json:"intents"`
 	// Epoch zero timestamp is used to keep track of the earliest timestamp
 	// that any epoch of the transaction used. This is set only if the
 	// transaction is restarted and the epoch is bumped. It is used during

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -351,8 +351,10 @@ message Transaction {
   // clock, we may add that to the map, which eliminates read uncertainty for
   // reads on that node.
   //
-  // The list of observed timestamps is kept sorted by NodeID. Use
-  // Transaction.UpdateObservedTimestamp to maintain the sorted order.
+  // The slice of observed timestamps is kept sorted by NodeID. Use
+  // Transaction.UpdateObservedTimestamp to maintain the sorted order. The
+  // slice should be treated as immutable and all updates should be performed
+  // on a copy of the slice.
   repeated ObservedTimestamp observed_timestamps = 8 [(gogoproto.nullable) = false];
   // Writing is true if the transaction has previously sent a Begin transaction
   // (i.e. if it ever attempted to perform a write, so if it ever attempted to
@@ -375,6 +377,8 @@ message Transaction {
   // prevent the LostDeleteRange anomaly. This flag is relevant only
   // for SNAPSHOT transactions.
   bool retry_on_push = 13;
+  // The slice should be treated as immutable and all updates should be
+  // performed on a copy of the slice.
   repeated Span intents = 11 [(gogoproto.nullable) = false];
   // Epoch zero timestamp is used to keep track of the earliest timestamp
   // that any epoch of the transaction used. This is set only if the

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -550,8 +550,10 @@ func TestTransactionClone(t *testing.T) {
 	// listed below. If this test fails, please update the list below and/or
 	// Transaction.Clone().
 	expFields := []string{
+		"Intents",
 		"Intents.EndKey",
 		"Intents.Key",
+		"ObservedTimestamps",
 		"TxnMeta.Key",
 	}
 	if !reflect.DeepEqual(expFields, fields) {

--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -493,7 +493,7 @@ func NewReadWithinUncertaintyIntervalError(
 	if txn != nil {
 		maxTS := txn.MaxTimestamp
 		rwue.MaxTimestamp = &maxTS
-		rwue.ObservedTimestamps = append([]ObservedTimestamp(nil), txn.ObservedTimestamps...)
+		rwue.ObservedTimestamps = txn.ObservedTimestamps
 	}
 	return rwue
 }

--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -169,9 +169,9 @@ func (e *Error) GetTxn() *Transaction {
 	return e.UnexposedTxn
 }
 
-// UpdateTxn updates the txn.
+// UpdateTxn updates the error transaction.
 func (e *Error) UpdateTxn(o *Transaction) {
-	if e == nil {
+	if o == nil {
 		return
 	}
 	if e.UnexposedTxn == nil {

--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -149,7 +149,6 @@ func (e *Error) GoError() error {
 
 // SetTxn sets the txn and resets the error message. txn is cloned before being
 // stored in the Error.
-// TODO(kaneda): Unexpose this method and make callers use NewErrorWithTxn.
 func (e *Error) SetTxn(txn *Transaction) {
 	e.UnexposedTxn = txn
 	if txn != nil {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3069,18 +3069,13 @@ func (s *Store) Send(
 			// this node.
 			if pErr != nil {
 				pErr.OriginNode = ba.Replica.NodeID
-				if txn := pErr.GetTxn(); txn != nil {
-					// Clone the txn, as we'll modify it.
-					pErr.SetTxn(txn)
-				} else {
+				if txn := pErr.GetTxn(); txn == nil {
 					pErr.SetTxn(ba.Txn)
 				}
-				pErr.GetTxn().UpdateObservedTimestamp(ba.Replica.NodeID, now)
 			} else {
 				if br.Txn == nil {
 					br.Txn = ba.Txn
 				}
-				br.Txn.UpdateObservedTimestamp(ba.Replica.NodeID, now)
 				// Update our clock with the outgoing response txn timestamp
 				// (if timestamp has been forwarded).
 				if ba.Timestamp.Less(br.Txn.Timestamp) {

--- a/pkg/testutils/storageutils/mocking.go
+++ b/pkg/testutils/storageutils/mocking.go
@@ -58,11 +58,7 @@ func WrapFilterForReplayProtection(
 func shallowCloneErrorWithTxn(pErr *roachpb.Error) *roachpb.Error {
 	if pErr != nil {
 		pErrCopy := *pErr
-		txn := pErrCopy.GetTxn()
-		if txn != nil {
-			txnClone := txn.Clone()
-			pErrCopy.SetTxn(&txnClone)
-		}
+		pErrCopy.SetTxn(pErrCopy.GetTxn())
 		return &pErrCopy
 	}
 


### PR DESCRIPTION
Backport:
  * 7/7 commits from "roachpb: prevent data race on Transaction" (#35719)
  * 1/2 commits from "roachpb: refine Transaction proto cloning" (#35762)

Fixes #34674.
Fixes #35785.

Please see individual PRs for details.

/cc @cockroachdb/release
