### PR TITLE
roachtest: Skip flaky election-after-restart

### DIFF
--- a/pkg/cmd/roachtest/election.go
+++ b/pkg/cmd/roachtest/election.go
@@ -25,6 +25,7 @@ import (
 func registerElectionAfterRestart(r *registry) {
 	r.Add(testSpec{
 		Name:    "election-after-restart",
+		Skip:    "https://github.com/cockroachdb/cockroach/issues/35047",
 		Cluster: makeClusterSpec(3),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			t.Status("starting up")


### PR DESCRIPTION
See #35047

Release note: None