### PR TITLE
exec: naive ordered synchronizer implementation

### DIFF
--- a/pkg/sql/exec/orderedsynchronizer.go
+++ b/pkg/sql/exec/orderedsynchronizer.go
@@ -1,0 +1,160 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+)
+
+// orderedSynchronizer receives rows from multiple inputs and produces a single
+// stream of rows, ordered according to a set of columns. The rows in each input
+// stream are assumed to be ordered according to the same set of columns.
+type orderedSynchronizer struct {
+	inputs      []Operator
+	ordering    sqlbase.ColumnOrdering
+	columnTypes []types.T
+
+	// inputBatches stores the current batch for each input.
+	inputBatches []coldata.Batch
+	// inputIndices stores the current index into each input batch.
+	inputIndices []uint16
+	output       coldata.Batch
+}
+
+func (o *orderedSynchronizer) Next(ctx context.Context) coldata.Batch {
+	if o.inputBatches == nil {
+		o.inputBatches = make([]coldata.Batch, len(o.inputs))
+		for i := range o.inputs {
+			o.inputBatches[i] = o.inputs[i].Next(ctx)
+		}
+	}
+	outputIdx := uint16(0)
+	for outputIdx < coldata.BatchSize {
+		// Determine the batch with the smallest row.
+		minBatch := -1
+		for i := range o.inputs {
+			if o.inputBatches[i].Length() == 0 {
+				// Input exhausted.
+				continue
+			}
+			if minBatch == -1 || o.compareRow(i, minBatch) < 0 {
+				minBatch = i
+			}
+		}
+		if minBatch == -1 {
+			// All inputs exhausted.
+			break
+		}
+
+		// Copy the min row into the output.
+		for i := range o.columnTypes {
+			batch := o.inputBatches[minBatch]
+			vec := batch.ColVec(i)
+			srcStartIdx := o.inputIndices[minBatch]
+			if sel := batch.Selection(); sel != nil {
+				srcStartIdx = sel[srcStartIdx]
+			}
+			o.output.ColVec(i).AppendSlice(
+				vec, o.columnTypes[i], uint64(outputIdx), srcStartIdx, srcStartIdx+1)
+		}
+
+		// Advance the input batch, fetching a new batch if necessary.
+		if o.inputIndices[minBatch]+1 < o.inputBatches[minBatch].Length() {
+			o.inputIndices[minBatch]++
+		} else {
+			o.inputBatches[minBatch] = o.inputs[minBatch].Next(ctx)
+			o.inputIndices[minBatch] = 0
+		}
+
+		outputIdx++
+	}
+	o.output.SetLength(outputIdx)
+	return o.output
+}
+
+func (o *orderedSynchronizer) Init() {
+	o.inputIndices = make([]uint16, len(o.inputs))
+	o.output = coldata.NewMemBatch(o.columnTypes)
+	for i := range o.inputs {
+		o.inputs[i].Init()
+	}
+}
+
+func (o *orderedSynchronizer) compareRow(batch1 int, batch2 int) int {
+	for i := range o.ordering {
+		info := o.ordering[i]
+		res := o.compareCol(batch1, batch2, info.ColIdx)
+		if res != 0 {
+			switch d := info.Direction; d {
+			case encoding.Ascending:
+				return res
+			case encoding.Descending:
+				return res * -1
+			default:
+				panic(fmt.Sprintf("unexpected direction value %d", d))
+			}
+		}
+	}
+	return 0
+}
+
+func (o *orderedSynchronizer) compareCol(batchIdx1 int, batchIdx2 int, colIdx int) int {
+	batch1 := o.inputBatches[batchIdx1]
+	batch2 := o.inputBatches[batchIdx2]
+	rowIdx1 := o.inputIndices[batchIdx1]
+	rowIdx2 := o.inputIndices[batchIdx2]
+	if sel := batch1.Selection(); sel != nil {
+		rowIdx1 = sel[rowIdx1]
+	}
+	if sel := batch2.Selection(); sel != nil {
+		rowIdx2 = sel[rowIdx2]
+	}
+
+	// Handle null cases. Nulls sort before non-null values.
+	nulls1 := batch1.ColVec(colIdx).Nulls()
+	nulls2 := batch2.ColVec(colIdx).Nulls()
+	n1 := nulls1.HasNulls() && nulls1.NullAt(rowIdx1)
+	n2 := nulls2.HasNulls() && nulls2.NullAt(rowIdx2)
+	if n1 && n2 {
+		return 0
+	} else if n1 {
+		return -1
+	} else if n2 {
+		return 1
+	}
+
+	// Both values are non-null. Compare them according to type.
+	// TODO(solon): Template this to handle all types.
+	switch o.columnTypes[colIdx] {
+	case types.Int64:
+		left := batch1.ColVec(colIdx).Int64()[rowIdx1]
+		right := batch2.ColVec(colIdx).Int64()[rowIdx2]
+		if left < right {
+			return -1
+		} else if left > right {
+			return 1
+		} else {
+			return 0
+		}
+	default:
+		panic(fmt.Sprintf("unhandled type %v", o.columnTypes[colIdx]))
+	}
+}

--- a/pkg/sql/exec/orderedsynchronizer_test.go
+++ b/pkg/sql/exec/orderedsynchronizer_test.go
@@ -1,0 +1,261 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sort"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+// Adapted from the same-named test in the distsqlrun package.
+func TestOrderedSync(t *testing.T) {
+	rng, _ := randutil.NewPseudoRand()
+	testCases := []struct {
+		sources  []tuples
+		ordering sqlbase.ColumnOrdering
+		expected tuples
+	}{
+		{
+			sources: []tuples{
+				{
+					{0, 1, 4},
+					{0, 1, 2},
+					{0, 2, 3},
+					{1, 1, 3},
+				},
+				{
+					{1, 0, 4},
+				},
+				{
+					{0, 0, 0},
+					{4, 4, 4},
+				},
+			},
+			ordering: sqlbase.ColumnOrdering{
+				{ColIdx: 0, Direction: encoding.Ascending},
+				{ColIdx: 1, Direction: encoding.Ascending},
+			},
+			expected: tuples{
+				{0, 0, 0},
+				{0, 1, 4},
+				{0, 1, 2},
+				{0, 2, 3},
+				{1, 0, 4},
+				{1, 1, 3},
+				{4, 4, 4},
+			},
+		},
+		{
+			sources: []tuples{
+				{
+					{1, 0, 4},
+				},
+				{
+					{3, 4, 1},
+					{4, 4, 4},
+					{3, 2, 0},
+				},
+				{
+					{4, 4, 5},
+					{3, 3, 0},
+					{0, 0, 0},
+				},
+			},
+			ordering: sqlbase.ColumnOrdering{
+				{ColIdx: 1, Direction: encoding.Descending},
+				{ColIdx: 0, Direction: encoding.Ascending},
+				{ColIdx: 2, Direction: encoding.Ascending},
+			},
+			expected: tuples{
+				{3, 4, 1},
+				{4, 4, 4},
+				{4, 4, 5},
+				{3, 3, 0},
+				{3, 2, 0},
+				{0, 0, 0},
+				{1, 0, 4},
+			},
+		},
+		{
+			sources: []tuples{
+				{
+					{-1},
+				},
+				{
+					{1},
+				},
+				{
+					{nil},
+				},
+			},
+			ordering: sqlbase.ColumnOrdering{
+				{ColIdx: 0, Direction: encoding.Ascending},
+			},
+			expected: tuples{
+				{nil},
+				{-1},
+				{1},
+			},
+		},
+		{
+			sources: []tuples{
+				{
+					{-1},
+				},
+				{
+					{1},
+				},
+				{
+					{nil},
+				},
+			},
+			ordering: sqlbase.ColumnOrdering{
+				{ColIdx: 0, Direction: encoding.Descending},
+			},
+			expected: tuples{
+				{1},
+				{-1},
+				{nil},
+			},
+		},
+	}
+	for testIdx, tc := range testCases {
+		for _, batchSize := range []uint16{1, 2, 3, coldata.BatchSize} {
+			for _, useSel := range []bool{false, true} {
+				name := fmt.Sprintf("case=%d/batchSize=%d/sel=%t", testIdx, batchSize, useSel)
+				t.Run(name, func(t *testing.T) {
+					inputs := make([]Operator, len(tc.sources))
+					for i := range inputs {
+						if useSel {
+							inputs[i] = newOpTestSelInput(rng, batchSize, tc.sources[i])
+						} else {
+							inputs[i] = newOpTestInput(batchSize, tc.sources[i])
+						}
+					}
+
+					numCols := len(tc.sources[0][0])
+					columnTypes := make([]types.T, numCols)
+					cols := make([]int, numCols)
+					for i := range columnTypes {
+						columnTypes[i] = types.Int64
+						cols[i] = i
+					}
+
+					op := orderedSynchronizer{
+						inputs:      inputs,
+						ordering:    tc.ordering,
+						columnTypes: columnTypes,
+					}
+					op.Init()
+					out := newOpTestOutput(&op, cols, tc.expected)
+					if err := out.Verify(); err != nil {
+						t.Error(err)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestOrderedSyncRandomInput(t *testing.T) {
+	numInputs := 3
+	inputLen := 1024
+	batchSize := uint16(16)
+
+	// Generate a random slice of sorted ints.
+	randInts := make([]int, inputLen)
+	for i := range randInts {
+		randInts[i] = rand.Int()
+	}
+	sort.Ints(randInts)
+
+	// Randomly distribute them among the inputs.
+	expected := make(tuples, inputLen)
+	sources := make([]tuples, numInputs)
+	for i := range expected {
+		t := tuple{randInts[i]}
+		expected[i] = t
+		sourceIdx := rand.Int() % 3
+		if i < numInputs {
+			// Make sure each input has at least one row.
+			sourceIdx = i
+		}
+		sources[sourceIdx] = append(sources[sourceIdx], t)
+	}
+	inputs := make([]Operator, numInputs)
+	for i := range inputs {
+		inputs[i] = newOpTestInput(batchSize, sources[i])
+	}
+
+	op := orderedSynchronizer{
+		inputs: inputs,
+		ordering: sqlbase.ColumnOrdering{
+			{
+				ColIdx:    0,
+				Direction: encoding.Ascending,
+			},
+		},
+		columnTypes: []types.T{types.Int64},
+	}
+	op.Init()
+	out := newOpTestOutput(&op, []int{0}, expected)
+	if err := out.Verify(); err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkOrderedSynchronizer(b *testing.B) {
+	ctx := context.Background()
+
+	numInputs := int64(3)
+	batches := make([]coldata.Batch, numInputs)
+	for i := range batches {
+		batches[i] = coldata.NewMemBatch([]types.T{types.Int64})
+		batches[i].SetLength(coldata.BatchSize)
+	}
+	for i := int64(0); i < coldata.BatchSize*numInputs; i++ {
+		batch := batches[i%numInputs]
+		batch.ColVec(0).Int64()[i/numInputs] = i
+	}
+
+	inputs := make([]Operator, len(batches))
+	for i := range batches {
+		inputs[i] = newRepeatableBatchSource(batches[i])
+	}
+
+	op := orderedSynchronizer{
+		inputs: inputs,
+		ordering: sqlbase.ColumnOrdering{
+			{ColIdx: 0, Direction: encoding.Ascending},
+		},
+		columnTypes: []types.T{types.Int64},
+	}
+	op.Init()
+
+	b.SetBytes(int64(8 * coldata.BatchSize * numInputs))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		op.Next(ctx)
+	}
+}


### PR DESCRIPTION
I implemented a vectorized ordered synchronizer with no mind to
efficiency, along with unit tests and a benchmark. This gives us a
jumping off point to explore more efficient approaches. I also only
supported int64s for this first pass. Other types will be supported via
templating in a future PR.

Refers #37304

Release note: None