### PR TITLE
opt: maintain a set of grouping cols instead of a list

### DIFF
--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -406,12 +406,19 @@ func (b *Builder) buildGrouping(
 
 	// Finally, build each of the GROUP BY columns.
 	for _, e := range exprs {
+		// If a grouping column has already been added, don't add it again.
+		// GROUP BY a, a is semantically equivalent to GROUP BY a.
+		exprStr := symbolicExprStr(e)
+		if _, ok := inScope.groupby.groupStrs[exprStr]; ok {
+			continue
+		}
+
 		// Save a representation of the GROUP BY expression for validation of the
 		// SELECT and HAVING expressions. This enables queries such as:
 		//   SELECT x+y FROM t GROUP BY x+y
 		col := b.addColumn(outScope, alias, e)
 		b.buildScalar(e, inScope, outScope, col, nil)
-		inScope.groupby.groupStrs[symbolicExprStr(e)] = col
+		inScope.groupby.groupStrs[exprStr] = col
 	}
 }
 

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -3122,3 +3122,43 @@ scalar-group-by
  └── aggregations
       └── array-agg [type=int[]]
            └── variable: generate_series [type=int]
+
+# Regression test for #37317: duplicate column in GROUP BY
+build format=show-all
+SELECT
+*
+FROM
+(
+ SELECT
+ x AS firstCol,
+ y AS secondCol,
+ y AS thirdCol
+ FROM xyz
+)
+GROUP BY
+firstCol, secondCol, thirdCol;
+----
+group-by
+ ├── columns: firstcol:1(int!null) secondcol:2(int) thirdcol:2(int)
+ ├── grouping columns: t.public.xyz.x:1(int!null) t.public.xyz.y:2(int)
+ ├── stats: [rows=990, distinct(1,2)=990, null(1,2)=10]
+ ├── cost: 1109.94
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── interesting orderings: (+1,+2)
+ └── project
+      ├── columns: t.public.xyz.x:1(int!null) t.public.xyz.y:2(int)
+      ├── stats: [rows=1000, distinct(1,2)=990, null(1,2)=10]
+      ├── cost: 1070.03
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      ├── prune: (1,2)
+      ├── interesting orderings: (+1,+2)
+      └── scan t.public.xyz
+           ├── columns: t.public.xyz.x:1(int!null) t.public.xyz.y:2(int) t.public.xyz.z:3(float)
+           ├── stats: [rows=1000, distinct(1,2)=990, null(1,2)=10]
+           ├── cost: 1060.02
+           ├── key: (1)
+           ├── fd: (1)-->(2,3)
+           ├── prune: (1-3)
+           └── interesting orderings: (+1,+2) (+3,+2,+1)


### PR DESCRIPTION
Fixes #37317.

And possibly also fixes #37444.
This commit changes the semantics of the grouping columns stored
in scope to only now save the columns if they're unique.

Release note: None