### PR TITLE
docs/tla-plus: add initial ParallelCommits spec and init file structure

### DIFF
--- a/docs/tla-plus/ParallelCommits/ParallelCommits.tla
+++ b/docs/tla-plus/ParallelCommits/ParallelCommits.tla
@@ -1,0 +1,280 @@
+-------------------------- MODULE ParallelCommits --------------------------
+EXTENDS TLC, Integers, FiniteSets, Sequences
+CONSTANTS KEYS, PREVENTERS
+ASSUME Cardinality(KEYS) > 0
+
+STATUSES == {"pending", "staging", "committed", "aborted"}
+
+(*--algorithm parallelcommits
+variables
+  record = "pending";
+  intent_writes = {};
+  tscache = [k \in KEYS |-> FALSE];
+  
+define
+  TypeInvariant ==
+    /\ record \in STATUSES
+    
+  TemporalProperties ==
+    <>[](record \in {"aborted", "committed"})
+end define;
+
+process committer = "committer"
+variables
+  to_write = KEYS;
+  have_staged_record = FALSE;
+begin
+  StagingWrites:
+    while to_write /= {} \/ ~have_staged_record do
+      either
+        await to_write /= {};
+        with key \in to_write do
+          if tscache[key] then
+            \* Write prevented.
+            record := "aborted";
+            goto EndCommitter;
+          else
+            \* Write successful.
+            intent_writes := intent_writes \union {key};
+            to_write := to_write \ {key};
+          end if;
+        end with;
+      or
+        await ~have_staged_record;
+        have_staged_record := TRUE;
+        if record = "pending" then
+          record := "staging";
+        elsif record = "aborted" then
+          \* Aborted before STAGING transaction record.
+          goto EndCommitter;
+        else
+          assert FALSE;
+        end if;
+      end either
+    end while;
+  
+  ExplicitCommit:
+    if record = "staging" then
+      record := "committed";
+    elsif record = "committed" then
+      \* Already committed by a recovery process.
+      skip;
+    else
+      assert FALSE;
+    end if;
+    
+  EndCommitter:
+    skip;
+  
+end process;
+
+fair process preventer \in PREVENTERS
+variable
+  checked_writes = {};
+begin
+  PushRecord:
+    if record = "pending" then
+      record := "aborted";
+      goto EndRecover;
+    elsif record = "staging" then
+      skip;
+    elsif record = "committed" then
+      goto EndRecover;
+    elsif record = "aborted" then
+      goto EndRecover;
+    end if;
+    
+  PreventWrites:
+    while checked_writes /= KEYS do
+      with key \in KEYS \ checked_writes do
+        if key \in intent_writes then
+          checked_writes := checked_writes \union {key}
+        else 
+          tscache[key] := TRUE;
+          goto RecoverRecord;
+        end if;
+      end with;
+    end while;
+  
+  RecoverRecord:
+    with prevented = checked_writes /= KEYS do
+      if record = "pending" then
+        assert FALSE;
+      elsif record = "staging" then
+        if prevented then
+           record := "aborted";
+        else
+           record := "committed";
+        end if;
+      elsif record = "committed" then
+        assert ~prevented;
+      elsif record = "aborted" then
+        assert prevented;
+      end if;
+    end with;
+    
+  EndRecover:
+    skip;
+    
+end process;  
+end algorithm;*)
+\* BEGIN TRANSLATION
+VARIABLES record, intent_writes, tscache, pc
+
+(* define statement *)
+TypeInvariant ==
+  /\ record \in STATUSES
+
+TemporalProperties ==
+  <>[](record \in {"aborted", "committed"})
+
+VARIABLES to_write, have_staged_record, checked_writes
+
+vars == << record, intent_writes, tscache, pc, to_write, have_staged_record, 
+           checked_writes >>
+
+ProcSet == {"committer"} \cup (PREVENTERS)
+
+Init == (* Global variables *)
+        /\ record = "pending"
+        /\ intent_writes = {}
+        /\ tscache = [k \in KEYS |-> FALSE]
+        (* Process committer *)
+        /\ to_write = KEYS
+        /\ have_staged_record = FALSE
+        (* Process preventer *)
+        /\ checked_writes = [self \in PREVENTERS |-> {}]
+        /\ pc = [self \in ProcSet |-> CASE self = "committer" -> "StagingWrites"
+                                        [] self \in PREVENTERS -> "PushRecord"]
+
+StagingWrites == /\ pc["committer"] = "StagingWrites"
+                 /\ IF to_write /= {} \/ ~have_staged_record
+                       THEN /\ \/ /\ to_write /= {}
+                                  /\ \E key \in to_write:
+                                       IF tscache[key]
+                                          THEN /\ record' = "aborted"
+                                               /\ pc' = [pc EXCEPT !["committer"] = "EndCommitter"]
+                                               /\ UNCHANGED << intent_writes, 
+                                                               to_write >>
+                                          ELSE /\ intent_writes' = (intent_writes \union {key})
+                                               /\ to_write' = to_write \ {key}
+                                               /\ pc' = [pc EXCEPT !["committer"] = "StagingWrites"]
+                                               /\ UNCHANGED record
+                                  /\ UNCHANGED have_staged_record
+                               \/ /\ ~have_staged_record
+                                  /\ have_staged_record' = TRUE
+                                  /\ IF record = "pending"
+                                        THEN /\ record' = "staging"
+                                             /\ pc' = [pc EXCEPT !["committer"] = "StagingWrites"]
+                                        ELSE /\ IF record = "aborted"
+                                                   THEN /\ pc' = [pc EXCEPT !["committer"] = "EndCommitter"]
+                                                   ELSE /\ Assert(FALSE, 
+                                                                  "Failure of assertion at line 51, column 11.")
+                                                        /\ pc' = [pc EXCEPT !["committer"] = "StagingWrites"]
+                                             /\ UNCHANGED record
+                                  /\ UNCHANGED <<intent_writes, to_write>>
+                       ELSE /\ pc' = [pc EXCEPT !["committer"] = "ExplicitCommit"]
+                            /\ UNCHANGED << record, intent_writes, to_write, 
+                                            have_staged_record >>
+                 /\ UNCHANGED << tscache, checked_writes >>
+
+ExplicitCommit == /\ pc["committer"] = "ExplicitCommit"
+                  /\ IF record = "staging"
+                        THEN /\ record' = "committed"
+                        ELSE /\ IF record = "committed"
+                                   THEN /\ TRUE
+                                   ELSE /\ Assert(FALSE, 
+                                                  "Failure of assertion at line 63, column 7.")
+                             /\ UNCHANGED record
+                  /\ pc' = [pc EXCEPT !["committer"] = "EndCommitter"]
+                  /\ UNCHANGED << intent_writes, tscache, to_write, 
+                                  have_staged_record, checked_writes >>
+
+EndCommitter == /\ pc["committer"] = "EndCommitter"
+                /\ TRUE
+                /\ pc' = [pc EXCEPT !["committer"] = "Done"]
+                /\ UNCHANGED << record, intent_writes, tscache, to_write, 
+                                have_staged_record, checked_writes >>
+
+committer == StagingWrites \/ ExplicitCommit \/ EndCommitter
+
+PushRecord(self) == /\ pc[self] = "PushRecord"
+                    /\ IF record = "pending"
+                          THEN /\ record' = "aborted"
+                               /\ pc' = [pc EXCEPT ![self] = "EndRecover"]
+                          ELSE /\ IF record = "staging"
+                                     THEN /\ TRUE
+                                          /\ pc' = [pc EXCEPT ![self] = "PreventWrites"]
+                                     ELSE /\ IF record = "committed"
+                                                THEN /\ pc' = [pc EXCEPT ![self] = "EndRecover"]
+                                                ELSE /\ IF record = "aborted"
+                                                           THEN /\ pc' = [pc EXCEPT ![self] = "EndRecover"]
+                                                           ELSE /\ pc' = [pc EXCEPT ![self] = "PreventWrites"]
+                               /\ UNCHANGED record
+                    /\ UNCHANGED << intent_writes, tscache, to_write, 
+                                    have_staged_record, checked_writes >>
+
+PreventWrites(self) == /\ pc[self] = "PreventWrites"
+                       /\ IF checked_writes[self] /= KEYS
+                             THEN /\ \E key \in KEYS \ checked_writes[self]:
+                                       IF key \in intent_writes
+                                          THEN /\ checked_writes' = [checked_writes EXCEPT ![self] = checked_writes[self] \union {key}]
+                                               /\ pc' = [pc EXCEPT ![self] = "PreventWrites"]
+                                               /\ UNCHANGED tscache
+                                          ELSE /\ tscache' = [tscache EXCEPT ![key] = TRUE]
+                                               /\ pc' = [pc EXCEPT ![self] = "RecoverRecord"]
+                                               /\ UNCHANGED checked_writes
+                             ELSE /\ pc' = [pc EXCEPT ![self] = "RecoverRecord"]
+                                  /\ UNCHANGED << tscache, checked_writes >>
+                       /\ UNCHANGED << record, intent_writes, to_write, 
+                                       have_staged_record >>
+
+RecoverRecord(self) == /\ pc[self] = "RecoverRecord"
+                       /\ LET prevented == checked_writes[self] /= KEYS IN
+                            IF record = "pending"
+                               THEN /\ Assert(FALSE, 
+                                              "Failure of assertion at line 102, column 9.")
+                                    /\ UNCHANGED record
+                               ELSE /\ IF record = "staging"
+                                          THEN /\ IF prevented
+                                                     THEN /\ record' = "aborted"
+                                                     ELSE /\ record' = "committed"
+                                          ELSE /\ IF record = "committed"
+                                                     THEN /\ Assert(~prevented, 
+                                                                    "Failure of assertion at line 110, column 9.")
+                                                     ELSE /\ IF record = "aborted"
+                                                                THEN /\ Assert(prevented, 
+                                                                               "Failure of assertion at line 112, column 9.")
+                                                                ELSE /\ TRUE
+                                               /\ UNCHANGED record
+                       /\ pc' = [pc EXCEPT ![self] = "EndRecover"]
+                       /\ UNCHANGED << intent_writes, tscache, to_write, 
+                                       have_staged_record, checked_writes >>
+
+EndRecover(self) == /\ pc[self] = "EndRecover"
+                    /\ TRUE
+                    /\ pc' = [pc EXCEPT ![self] = "Done"]
+                    /\ UNCHANGED << record, intent_writes, tscache, to_write, 
+                                    have_staged_record, checked_writes >>
+
+preventer(self) == PushRecord(self) \/ PreventWrites(self)
+                      \/ RecoverRecord(self) \/ EndRecover(self)
+
+Next == committer
+           \/ (\E self \in PREVENTERS: preventer(self))
+           \/ (* Disjunct to prevent deadlock on termination *)
+              ((\A self \in ProcSet: pc[self] = "Done") /\ UNCHANGED vars)
+
+Spec == /\ Init /\ [][Next]_vars
+        /\ \A self \in PREVENTERS : WF_vars(preventer(self))
+
+Termination == <>(\A self \in ProcSet: pc[self] = "Done")
+
+\* END TRANSLATION
+
+
+
+=============================================================================
+\* Modification History
+\* Last modified Tue May 14 18:50:26 EDT 2019 by nathan
+\* Created Mon May 13 10:03:40 EDT 2019 by nathan

--- a/docs/tla-plus/ParallelCommits/ParallelCommits.toolbox/ParallelCommits___Model_1.launch
+++ b/docs/tla-plus/ParallelCommits/ParallelCommits.toolbox/ParallelCommits___Model_1.launch
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.lamport.tla.toolbox.tool.tlc.modelCheck">
+<stringAttribute key="TLCCmdLineParameters" value=""/>
+<stringAttribute key="configurationName" value="Model_1"/>
+<booleanAttribute key="deferLiveness" value="false"/>
+<intAttribute key="dfidDepth" value="100"/>
+<booleanAttribute key="dfidMode" value="false"/>
+<intAttribute key="distributedFPSetCount" value="0"/>
+<stringAttribute key="distributedNetworkInterface" value="192.168.1.56"/>
+<intAttribute key="distributedNodesCount" value="1"/>
+<stringAttribute key="distributedTLC" value="off"/>
+<stringAttribute key="distributedTLCVMArgs" value=""/>
+<intAttribute key="fpBits" value="1"/>
+<intAttribute key="fpIndex" value="1"/>
+<intAttribute key="maxHeapSize" value="8"/>
+<intAttribute key="maxSetSize" value="1000000"/>
+<booleanAttribute key="mcMode" value="true"/>
+<stringAttribute key="modelBehaviorInit" value=""/>
+<stringAttribute key="modelBehaviorNext" value=""/>
+<stringAttribute key="modelBehaviorSpec" value="Spec"/>
+<intAttribute key="modelBehaviorSpecType" value="1"/>
+<stringAttribute key="modelBehaviorVars" value="have_staged_record, intent_writes, record, checked_writes, tscache, pc, to_write"/>
+<stringAttribute key="modelComments" value=""/>
+<booleanAttribute key="modelCorrectnessCheckDeadlock" value="true"/>
+<listAttribute key="modelCorrectnessInvariants">
+<listEntry value="1TypeInvariant"/>
+</listAttribute>
+<listAttribute key="modelCorrectnessProperties">
+<listEntry value="1TemporalProperties"/>
+</listAttribute>
+<stringAttribute key="modelExpressionEval" value=""/>
+<stringAttribute key="modelParameterActionConstraint" value=""/>
+<listAttribute key="modelParameterConstants">
+<listEntry value="KEYS;;{k1, k2, k3};1;1"/>
+<listEntry value="PREVENTERS;;{p1, p2};1;1"/>
+</listAttribute>
+<stringAttribute key="modelParameterContraint" value=""/>
+<listAttribute key="modelParameterDefinitions"/>
+<stringAttribute key="modelParameterModelValues" value="{}"/>
+<stringAttribute key="modelParameterNewDefinitions" value=""/>
+<intAttribute key="numberOfWorkers" value="2"/>
+<booleanAttribute key="recover" value="false"/>
+<stringAttribute key="result.mail.address" value=""/>
+<intAttribute key="simuAril" value="-1"/>
+<intAttribute key="simuDepth" value="100"/>
+<intAttribute key="simuSeed" value="-1"/>
+<stringAttribute key="specName" value="ParallelCommits"/>
+<stringAttribute key="view" value=""/>
+<booleanAttribute key="visualizeStateGraph" value="false"/>
+</launchConfiguration>

--- a/docs/tla-plus/README.md
+++ b/docs/tla-plus/README.md
@@ -1,0 +1,8 @@
+# TLA+ in CockroachDB
+
+## About TLA+
+
+TLA+ is a formal specification and verification language to help engineers design, specify, reason about, and verify complex software and hardware systems. It is widely used to verify the algorithms in distributed systems.
+
+For further information about TLA+, see [tla-plus-resources](https://github.com/cmschmtt/tla-plus-resources).
+


### PR DESCRIPTION
This commit adds a PlusCal model for the parallel commits recovery
process. This will be improved over time, but it's nice to check
something in early and initialize the file structure for TLA+ specs.

Release note: None