### PR TITLE
bulk: use pebble sstable builder to write SSTs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1310,6 +1310,29 @@
   revision = "b0b1615b78e5ee59739545bb38426383b2cda4c9"
 
 [[projects]]
+  branch = "master"
+  digest = "1:a00ca3a2402bb841b2b0cc9606e7b08df8af1bc50f6bca6fece1bd9f083247ae"
+  name = "github.com/petermattis/pebble"
+  packages = [
+    ".",
+    "cache",
+    "internal/arenaskl",
+    "internal/base",
+    "internal/batchskl",
+    "internal/bytealloc",
+    "internal/crc",
+    "internal/humanize",
+    "internal/rangedel",
+    "internal/rate",
+    "internal/rawalloc",
+    "internal/record",
+    "sstable",
+    "vfs",
+  ]
+  pruneopts = "UT"
+  revision = "fcb9ed13025a2407eb66dd0bc6b370868b52cc17"
+
+[[projects]]
   digest = "1:e39a5ee8fcbec487f8fc68863ef95f2b025e0739b0e4aa55558a2b4cf8f0ecf0"
   name = "github.com/pierrec/lz4"
   packages = [
@@ -1995,6 +2018,8 @@
     "github.com/opentracing/opentracing-go/log",
     "github.com/openzipkin-contrib/zipkin-go-opentracing",
     "github.com/petermattis/goid",
+    "github.com/petermattis/pebble",
+    "github.com/petermattis/pebble/sstable",
     "github.com/pkg/errors",
     "github.com/pmezard/go-difflib/difflib",
     "github.com/prometheus/client_golang/prometheus",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -113,6 +113,10 @@ ignored = [
   name = "github.com/leanovate/gopter"
   branch = "master"
 
+[[constraint]]
+  name = "github.com/petermattis/pebble"
+  branch = "master"
+
 # github.com/openzipkin-contrib/zipkin-go-opentracing requires a newer
 # version of thrift than is currently present in a release.
 [[override]]

--- a/c-deps/libroach/table_props.cc
+++ b/c-deps/libroach/table_props.cc
@@ -19,6 +19,7 @@ namespace cockroach {
 
 namespace {
 
+// This is re-implemented in sst_writer.go and should be kept in sync.
 class TimeBoundTblPropCollector : public rocksdb::TablePropertiesCollector {
  public:
   const char* Name() const override { return "TimeBoundTblPropCollector"; }

--- a/pkg/storage/bulk/sst_batcher_test.go
+++ b/pkg/storage/bulk/sst_batcher_test.go
@@ -24,13 +24,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/bulk"
-	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
@@ -232,36 +230,19 @@ func TestAddBigSpanningSSTWithSplits(t *testing.T) {
 
 	const numKeys, valueSize, splitEvery = 500, 5000, 1
 
-	prefix := encoding.EncodeUvarintAscending(keys.MakeTablePrefix(uint32(100)), uint64(1))
-	key := func(i int) []byte {
-		return encoding.EncodeVarintAscending(append([]byte{}, prefix...), int64(i))
-	}
-
-	var splits []roachpb.Key
+	// Make some KVs and grab [start,end). Generate one extra for exclusive `end`.
+	kvs := makeIntTableKVs(t, numKeys+1, valueSize, 1)
+	start, end := kvs[0].Key.Key, kvs[numKeys].Key.Key
+	kvs = kvs[:numKeys]
 
 	// Create a large SST.
-	w, err := engine.MakeRocksDBSstFileWriter()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer w.Close()
-	r, _ := randutil.NewPseudoRand()
-	buf := make([]byte, valueSize)
-	for i := 0; i < numKeys; i++ {
-		randutil.ReadTestdataBytes(r, buf)
+	sst := makeRocksSST(t, kvs)
+
+	var splits []roachpb.Key
+	for i := range kvs {
 		if i%splitEvery == 0 {
-			splits = append(splits, key(i))
+			splits = append(splits, kvs[i].Key.Key)
 		}
-		if err := w.Add(engine.MVCCKeyValue{
-			Key:   engine.MVCCKey{Key: key(i), Timestamp: hlc.Timestamp{WallTime: 1}},
-			Value: roachpb.MakeValueFromString(string(buf)).RawBytes,
-		}); err != nil {
-			t.Fatal(err)
-		}
-	}
-	sst, err := w.Finish()
-	if err != nil {
-		t.Fatal(err)
 	}
 
 	// Keep track of the memory.
@@ -292,8 +273,10 @@ func TestAddBigSpanningSSTWithSplits(t *testing.T) {
 
 	const kb = 1 << 10
 
-	t.Logf("Adding %dkb sst spanning %d splits", len(sst)/kb, len(splits))
-	if err := bulk.AddSSTable(context.TODO(), mock, key(0), key(numKeys), sst, false /* disallowShadowing */); err != nil {
+	t.Logf("Adding %dkb sst spanning %d splits from %v to %v", len(sst)/kb, len(splits), start, end)
+	if err := bulk.AddSSTable(
+		context.TODO(), mock, start, end, sst, false, /* disallowShadowing */
+	); err != nil {
 		t.Fatal(err)
 	}
 	t.Logf("Adding took %d total attempts", totalAdditionAttempts)

--- a/pkg/storage/bulk/sst_writer.go
+++ b/pkg/storage/bulk/sst_writer.go
@@ -1,0 +1,219 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package bulk
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/petermattis/pebble"
+	"github.com/petermattis/pebble/sstable"
+	"github.com/pkg/errors"
+)
+
+// SSTWriter writes SSTables.
+type SSTWriter struct {
+	fw *sstable.Writer
+	f  *memFile
+	// DataSize tracks the total key and value bytes added so far.
+	DataSize int64
+	scratch  []byte
+}
+
+var mvccComparer = &pebble.Comparer{
+	Compare: engine.MVCCKeyCompare,
+	AbbreviatedKey: func(k []byte) uint64 {
+		key, _, ok := enginepb.SplitMVCCKey(k)
+		if !ok {
+			return 0
+		}
+		return pebble.DefaultComparer.AbbreviatedKey(key)
+	},
+
+	Separator: func(dst, a, b []byte) []byte {
+		return append(dst, a...)
+	},
+
+	Successor: func(dst, a []byte) []byte {
+		return append(dst, a...)
+	},
+	Split: func(k []byte) int {
+		if len(k) == 0 {
+			return len(k)
+		}
+		// This is similar to what enginepb.SplitMVCCKey does.
+		tsLen := int(k[len(k)-1])
+		keyPartEnd := len(k) - 1 - tsLen
+		if keyPartEnd < 0 {
+			return len(k)
+		}
+		return keyPartEnd
+	},
+
+	Name: "cockroach_comparator",
+}
+
+// timeboundPropCollector implements a property collector for MVCC Timestamps.
+// Its behavior matches TimeBoundTblPropCollector in table_props.cc.
+type timeboundPropCollector struct {
+	min, max []byte
+}
+
+var _ pebble.TablePropertyCollector = &timeboundPropCollector{}
+
+func (t *timeboundPropCollector) Add(key pebble.InternalKey, value []byte) error {
+	_, ts, ok := enginepb.SplitMVCCKey(key.UserKey)
+	if !ok {
+		return errors.Errorf("failed to split MVCC key")
+	}
+	if len(ts) > 0 {
+		if len(t.min) == 0 || bytes.Compare(ts, t.min) < 0 {
+			t.min = append(t.min[:0], ts...)
+		}
+		if len(t.max) == 0 || bytes.Compare(ts, t.max) > 0 {
+			t.max = append(t.max[:0], ts...)
+		}
+	}
+	return nil
+}
+
+func (t *timeboundPropCollector) Finish(userProps map[string]string) error {
+	userProps["crdb.ts.min"] = string(t.min)
+	userProps["crdb.ts.max"] = string(t.max)
+	return nil
+}
+
+func (t *timeboundPropCollector) Name() string {
+	return "TimeBoundTblPropCollectorFactory"
+}
+
+// dummyDeleteRangeCollector is a stub collector that just identifies itself.
+// This stub can be installed so that SSTs claim to have the same props as those
+// written by the Rocks writer, using the collector in table_props.cc. However
+// since bulk-ingestion SSTs never contain deletions (range or otherwise), there
+// is no actual implementation needed here.
+type dummyDeleteRangeCollector struct{}
+
+var _ pebble.TablePropertyCollector = &dummyDeleteRangeCollector{}
+
+func (dummyDeleteRangeCollector) Add(key pebble.InternalKey, value []byte) error {
+	if key.Kind() != pebble.InternalKeyKindSet {
+		return errors.Errorf("unsupported key kind %v", key.Kind())
+	}
+	return nil
+}
+
+func (dummyDeleteRangeCollector) Finish(userProps map[string]string) error {
+	return nil
+}
+
+func (dummyDeleteRangeCollector) Name() string {
+	return "DeleteRangeTblPropCollectorFactory"
+}
+
+var pebbleOpts = func() *pebble.Options {
+	merger := *pebble.DefaultMerger
+	merger.Name = "nullptr"
+	opts := &pebble.Options{
+		TableFormat: pebble.TableFormatLevelDB,
+		Comparer:    mvccComparer,
+		Merger:      &merger,
+	}
+	opts.EnsureDefaults()
+	opts.TablePropertyCollectors = append(
+		opts.TablePropertyCollectors,
+		func() pebble.TablePropertyCollector { return &timeboundPropCollector{} },
+		func() pebble.TablePropertyCollector { return &dummyDeleteRangeCollector{} },
+	)
+	return opts
+}()
+
+// MakeSSTWriter creates a new SSTWriter.
+func MakeSSTWriter() SSTWriter {
+	f := &memFile{}
+	sst := sstable.NewWriter(f, pebbleOpts, pebble.LevelOptions{BlockSize: 64 * 1024})
+	return SSTWriter{fw: sst, f: f}
+}
+
+// Add puts a kv entry into the sstable being built. An error is returned if it
+// is not greater than any previously added entry (according to the comparator
+// configured during writer creation). `Close` cannot have been called.
+func (fw *SSTWriter) Add(kv engine.MVCCKeyValue) error {
+	if fw.fw == nil {
+		return errors.New("cannot call Open on a closed writer")
+	}
+	fw.DataSize += int64(len(kv.Key.Key)) + int64(len(kv.Value))
+	fw.scratch = engine.EncodeKeyToBuf(fw.scratch[:0], kv.Key)
+	return fw.fw.Set(fw.scratch, kv.Value)
+}
+
+// Finish finalizes the writer and returns the constructed file's contents. At
+// least one kv entry must have been added.
+func (fw *SSTWriter) Finish() ([]byte, error) {
+	if fw.fw == nil {
+		return nil, errors.New("cannot call Finish on a closed writer")
+	}
+	if err := fw.fw.Close(); err != nil {
+		return nil, err
+	}
+	fw.fw = nil
+	return fw.f.data, nil
+}
+
+// Close finishes and frees memory and other resources. Close is idempotent.
+func (fw *SSTWriter) Close() {
+	if fw.fw == nil {
+		return
+	}
+	// pebble.Writer *does* return interesting errors from Close... but normally
+	// we already called its Close() in Finish() and we no-op here. Thus the only
+	// time we expect to be here is in a deferred Close(), in which case the caller
+	// probably is already returning some other error, so returning one from this
+	// method just makes for messy defers.
+	_ = fw.fw.Close()
+	fw.fw = nil
+}
+
+type memFile struct {
+	data []byte
+	pos  int
+}
+
+func (*memFile) Close() error {
+	return nil
+}
+
+func (*memFile) Sync() error {
+	return nil
+}
+
+func (f *memFile) Read(p []byte) (int, error) {
+	if f.pos >= len(f.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, f.data[f.pos:])
+	f.pos += n
+	return n, nil
+}
+
+func (f *memFile) ReadAt(p []byte, off int64) (int, error) {
+	if off >= int64(len(f.data)) {
+		return 0, io.EOF
+	}
+	return copy(p, f.data[off:]), nil
+}
+
+func (f *memFile) Write(p []byte) (int, error) {
+	f.data = append(f.data, p...)
+	return len(p), nil
+}

--- a/pkg/storage/bulk/sst_writer_test.go
+++ b/pkg/storage/bulk/sst_writer_test.go
@@ -1,0 +1,62 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package bulk_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func makeIntTableKVs(t testing.TB, numKeys, valueSize, maxRevisions int) []engine.MVCCKeyValue {
+	prefix := encoding.EncodeUvarintAscending(keys.MakeTablePrefix(uint32(100)), uint64(1))
+	kvs := make([]engine.MVCCKeyValue, numKeys)
+	r, _ := randutil.NewPseudoRand()
+
+	var k int
+	for i := 0; i < numKeys; {
+		k += 1 + rand.Intn(100)
+		key := encoding.EncodeVarintAscending(append([]byte{}, prefix...), int64(k))
+		buf := make([]byte, valueSize)
+		randutil.ReadTestdataBytes(r, buf)
+		revisions := 1 + r.Intn(maxRevisions)
+
+		ts := int64(maxRevisions * 100)
+		for j := 0; j < revisions && i < numKeys; j++ {
+			ts -= 1 + r.Int63n(99)
+			kvs[i].Key.Key = key
+			kvs[i].Key.Timestamp.WallTime = ts
+			kvs[i].Value = roachpb.MakeValueFromString(string(buf)).RawBytes
+			i++
+		}
+	}
+	return kvs
+}
+
+func makeRocksSST(t testing.TB, kvs []engine.MVCCKeyValue) []byte {
+	w, err := engine.MakeRocksDBSstFileWriter()
+	require.NoError(t, err)
+	defer w.Close()
+
+	for i := range kvs {
+		require.NoError(t, w.Add(kvs[i]))
+	}
+	sst, err := w.Finish()
+	require.NoError(t, err)
+	return sst
+}

--- a/pkg/storage/bulk/sst_writer_test.go
+++ b/pkg/storage/bulk/sst_writer_test.go
@@ -14,13 +14,14 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/bulk"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/stretchr/testify/require"
 )
 
 func makeIntTableKVs(t testing.TB, numKeys, valueSize, maxRevisions int) []engine.MVCCKeyValue {
@@ -41,6 +42,7 @@ func makeIntTableKVs(t testing.TB, numKeys, valueSize, maxRevisions int) []engin
 			ts -= 1 + r.Int63n(99)
 			kvs[i].Key.Key = key
 			kvs[i].Key.Timestamp.WallTime = ts
+			kvs[i].Key.Timestamp.Logical = r.Int31()
 			kvs[i].Value = roachpb.MakeValueFromString(string(buf)).RawBytes
 			i++
 		}
@@ -54,9 +56,101 @@ func makeRocksSST(t testing.TB, kvs []engine.MVCCKeyValue) []byte {
 	defer w.Close()
 
 	for i := range kvs {
-		require.NoError(t, w.Add(kvs[i]))
+		if err := w.Add(kvs[i]); err != nil {
+			t.Fatal(err)
+		}
 	}
 	sst, err := w.Finish()
 	require.NoError(t, err)
 	return sst
+}
+
+func makePebbleSST(t testing.TB, kvs []engine.MVCCKeyValue) []byte {
+	w := bulk.MakeSSTWriter()
+	defer w.Close()
+
+	for i := range kvs {
+		if err := w.Add(kvs[i]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sst, err := w.Finish()
+	require.NoError(t, err)
+	return sst
+}
+
+// TestPebbleWritesSameSSTs tests that using pebble to write some SST produces
+// the same file -- byte-for-byte -- as using our Rocks-based writer. This is is
+// done not because we don't trust pebble to write the correct SST, but more
+// because we otherwise don't have a great way to be sure we've configured it to
+// to the same thing we configured RocksDB to do w.r.t. all the block size, key
+// filtering, property collecting, etc settings. Getting these settings wrong
+// could easily produce an SST with the same K/V content but subtle and hard to
+// debug differences in runtime performance (which also could prove elusive when
+// it could compacted away at any time and replaced with a Rocks-written one).
+//
+// This test may need to be removed if/when Pebble's SSTs diverge from Rocks'.
+// That is probably OK: it is mostly intended to increase our confidence during
+// the transition that we're not introducing a regression. Once pebble-written
+// SSTs are the norm, comparing to ones written using the Rocks writer (which
+// didn't actually share a configuration with the serving RocksDB, so they were
+// already different from actual runtime-written SSTs) will no longer be a
+// concen (though we will likely want testing of things like prop collectors).
+func TestPebbleWritesSameSSTs(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	r, _ := randutil.NewPseudoRand()
+	const numKeys, valueSize, revisions = 5000, 100, 100
+
+	kvs := makeIntTableKVs(t, numKeys, valueSize, revisions)
+	sstRocks := makeRocksSST(t, kvs)
+	sstPebble := makePebbleSST(t, kvs)
+
+	itRocks, err := engine.NewMemSSTIterator(sstRocks, false)
+	require.NoError(t, err)
+	itPebble, err := engine.NewMemSSTIterator(sstPebble, false)
+	require.NoError(t, err)
+
+	itPebble.Seek(engine.NilKey)
+	for itRocks.Seek(engine.NilKey); ; {
+		okRocks, err := itRocks.Valid()
+		if err != nil {
+			t.Fatal(err)
+		}
+		okPebble, err := itPebble.Valid()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !okRocks {
+			break
+		}
+		if !okPebble {
+			t.Fatal("expected valid")
+		}
+		require.Equal(t, itRocks.UnsafeKey(), itPebble.UnsafeKey())
+		require.Equal(t, itRocks.UnsafeValue(), itPebble.UnsafeValue())
+
+		if r.Intn(5) == 0 {
+			itRocks.NextKey()
+			itPebble.NextKey()
+		} else {
+			itRocks.Next()
+			itPebble.Next()
+		}
+	}
+	require.Equal(t, string(sstRocks), string(sstPebble))
+}
+
+func BenchmarkWriteSSTable(b *testing.B) {
+	b.StopTimer()
+	// Writing the SST 10 times keeps size needed for ~10s benchtime under 1gb.
+	const valueSize, revisions, ssts = 100, 100, 10
+	kvs := makeIntTableKVs(b, b.N, valueSize, revisions)
+	approxUserDataSizePerKV := kvs[b.N/2].Key.EncodedSize() + valueSize
+	b.SetBytes(int64(approxUserDataSizePerKV * ssts))
+	b.ResetTimer()
+	b.StartTimer()
+	for i := 0; i < ssts; i++ {
+		_ = makePebbleSST(b, kvs)
+	}
 }

--- a/pkg/storage/engine/sst_iterator.go
+++ b/pkg/storage/engine/sst_iterator.go
@@ -230,8 +230,15 @@ func (cockroachComparer) Compare(a, b []byte) int {
 		panic(fmt.Sprintf("invalid keys: compare expects internal keys with 8b suffix: a: %v b: %v", a, b))
 	}
 
-	keyA, tsA, okA := enginepb.SplitMVCCKey(a[:len(a)-8])
-	keyB, tsB, okB := enginepb.SplitMVCCKey(b[:len(b)-8])
+	return MVCCKeyCompare(a[:len(a)-8], b[:len(b)-8])
+}
+
+// MVCCKeyCompare compares cockroach keys, including the MVCC timestamps.
+// This assumes these are the keys cockroach usually works with i.e. "user" keys
+// from the point of view of rocksdb.
+func MVCCKeyCompare(a, b []byte) int {
+	keyA, tsA, okA := enginepb.SplitMVCCKey(a)
+	keyB, tsB, okB := enginepb.SplitMVCCKey(b)
 	if !okA || !okB {
 		// This should never happen unless there is some sort of corruption of
 		// the keys. This is a little bizarre, but the behavior exactly matches


### PR DESCRIPTION
bulk: add wrapper for pebble SSTable builder to make SSTs
Comparing to the Rocks-based builder in `engine`:

```
name             old time/op    new time/op    delta
WriteSSTable-12    4.66µs ± 6%    3.05µs ±13%   -34.54%  (p=0.000 n=9+10)

name             old speed      new speed      delta
WriteSSTable-12   258MB/s ± 6%   396MB/s ±12%   +53.62%  (p=0.000 n=9+10)

name             old alloc/op   new alloc/op   delta
WriteSSTable-12      300B ± 0%     1662B ± 0%  +453.83%  (p=0.000 n=8+10)

name             old allocs/op  new allocs/op  delta
WriteSSTable-12      0.00           0.00           ~     (all equal)
```

```
name               old time/op    new time/op    delta
ClusterRestore-12    2.09µs ±19%    1.80µs ±10%  -14.05%  (p=0.016 n=5+5)

name               old speed      new speed      delta
ClusterRestore-12  55.5MB/s ±17%  64.4MB/s ±10%  +16.02%  (p=0.016 n=5+5)
```

Release note (performance improvement): speed up file-writing during bulk-ingestion.