### PR TITLE
roachtest: add a test with 1000 connections

### DIFF
--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -78,6 +78,7 @@ func registerTests(r *registry) {
 	registerVersion(r)
 	registerYCSB(r)
 	registerTPCHBench(r)
+	registerTPCHHighConcurrency(r)
 }
 
 func registerBenchmarks(r *registry) {


### PR DESCRIPTION
The test attempts to simulate a workload with high number of
concurrent connections by using querybench with 1000 concurrent
workers on TPCH dataset.

Addresses: #36172.

Release note: None