### PR TITLE
exec: add metadata propagation to Outbox/Inbox

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -93,7 +93,7 @@ func newChangeAggregatorProcessor(
 		output,
 		memMonitor,
 		distsqlrun.ProcStateOpts{
-			TrailingMetaCallback: func(context.Context) []distsqlrun.ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []distsqlpb.ProducerMetadata {
 				ca.close()
 				return nil
 			},
@@ -242,7 +242,7 @@ func (ca *changeAggregator) close() {
 }
 
 // Next is part of the RowSource interface.
-func (ca *changeAggregator) Next() (sqlbase.EncDatumRow, *distsqlrun.ProducerMetadata) {
+func (ca *changeAggregator) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata) {
 	for ca.State == distsqlrun.StateRunning {
 		if !ca.changedRowBuf.IsEmpty() {
 			return ca.changedRowBuf.Pop(), nil
@@ -382,7 +382,7 @@ func newChangeFrontierProcessor(
 		output,
 		memMonitor,
 		distsqlrun.ProcStateOpts{
-			TrailingMetaCallback: func(context.Context) []distsqlrun.ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []distsqlpb.ProducerMetadata {
 				cf.close()
 				return nil
 			},
@@ -506,7 +506,7 @@ func (cf *changeFrontier) closeMetrics() {
 }
 
 // Next is part of the RowSource interface.
-func (cf *changeFrontier) Next() (sqlbase.EncDatumRow, *distsqlrun.ProducerMetadata) {
+func (cf *changeFrontier) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata) {
 	for cf.State == distsqlrun.StateRunning {
 		if !cf.passthroughBuf.IsEmpty() {
 			return cf.passthroughBuf.Pop(), nil

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -234,7 +234,7 @@ func TestDistSQLReceiverUpdatesCaches(t *testing.T) {
 	}
 
 	// Push some metadata and check that the caches are updated with it.
-	status := r.Push(nil /* row */, &distsqlrun.ProducerMetadata{
+	status := r.Push(nil /* row */, &distsqlpb.ProducerMetadata{
 		Ranges: []roachpb.RangeInfo{
 			{
 				Desc: descs[0],
@@ -250,7 +250,7 @@ func TestDistSQLReceiverUpdatesCaches(t *testing.T) {
 	if status != distsqlrun.NeedMoreRows {
 		t.Fatalf("expected status NeedMoreRows, got: %d", status)
 	}
-	status = r.Push(nil /* row */, &distsqlrun.ProducerMetadata{
+	status = r.Push(nil /* row */, &distsqlpb.ProducerMetadata{
 		Ranges: []roachpb.RangeInfo{
 			{
 				Desc: descs[2],

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -36,7 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -470,7 +470,7 @@ func (r *DistSQLReceiver) SetError(err error) {
 
 // Push is part of the RowReceiver interface.
 func (r *DistSQLReceiver) Push(
-	row sqlbase.EncDatumRow, meta *distsqlrun.ProducerMetadata,
+	row sqlbase.EncDatumRow, meta *distsqlpb.ProducerMetadata,
 ) distsqlrun.ConsumerStatus {
 	if meta != nil {
 		if meta.TxnCoordMeta != nil {

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
-	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -255,7 +255,7 @@ func TestDistSQLReceiverErrorRanking(t *testing.T) {
 
 	for i, tc := range errs {
 		recv.Push(nil, /* row */
-			&distsqlrun.ProducerMetadata{
+			&distsqlpb.ProducerMetadata{
 				Err: tc.err,
 			})
 		if !testutils.IsError(rw.Err(), tc.expErr) {

--- a/pkg/sql/distsqlpb/data.go
+++ b/pkg/sql/distsqlpb/data.go
@@ -15,6 +15,7 @@
 package distsqlpb
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -22,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/pkg/errors"
 )
 
@@ -185,4 +187,98 @@ func (e *Error) ErrorDetail() error {
 		// through. We'll pick it up in reporting.
 		return pgerror.AssertionFailedf("unknown error detail type: %+v", t)
 	}
+}
+
+// ProducerMetadata represents a metadata record flowing through a DistSQL flow.
+type ProducerMetadata struct {
+	// Only one of these fields will be set. If this ever changes, note that
+	// there're consumers out there that extract the error and, if there is one,
+	// forward it in isolation and drop the rest of the record.
+	Ranges []roachpb.RangeInfo
+	// TODO(vivek): change to type Error
+	Err error
+	// TraceData is sent if snowball tracing is enabled.
+	TraceData []tracing.RecordedSpan
+	// TxnCoordMeta contains the updated transaction coordinator metadata,
+	// to be sent from leaf transactions to augment the root transaction,
+	// held by the flow's ultimate receiver.
+	TxnCoordMeta *roachpb.TxnCoordMeta
+	// RowNum corresponds to a row produced by a "source" processor that takes no
+	// inputs. It is used in tests to verify that all metadata is forwarded
+	// exactly once to the receiver on the gateway node.
+	RowNum *RemoteProducerMetadata_RowNum
+	// SamplerProgress contains incremental progress information from the sampler
+	// processor.
+	SamplerProgress *RemoteProducerMetadata_SamplerProgress
+}
+
+// RemoteProducerMetaToLocalMeta converts a RemoteProducerMetadata struct to
+// ProducerMetadata and returns whether the conversion was successful or not.
+func RemoteProducerMetaToLocalMeta(rpm RemoteProducerMetadata) (ProducerMetadata, bool) {
+	var meta ProducerMetadata
+	switch v := rpm.Value.(type) {
+	case *RemoteProducerMetadata_RangeInfo:
+		meta.Ranges = v.RangeInfo.RangeInfo
+	case *RemoteProducerMetadata_TraceData_:
+		meta.TraceData = v.TraceData.CollectedSpans
+	case *RemoteProducerMetadata_TxnCoordMeta:
+		meta.TxnCoordMeta = v.TxnCoordMeta
+	case *RemoteProducerMetadata_RowNum_:
+		meta.RowNum = v.RowNum
+	case *RemoteProducerMetadata_SamplerProgress_:
+		meta.SamplerProgress = v.SamplerProgress
+	case *RemoteProducerMetadata_Error:
+		meta.Err = v.Error.ErrorDetail()
+	default:
+		return meta, false
+	}
+	return meta, true
+}
+
+// LocalMetaToRemoteProducerMeta converts a ProducerMetadata struct to
+// RemoteProducerMetadata.
+func LocalMetaToRemoteProducerMeta(meta ProducerMetadata) RemoteProducerMetadata {
+	var rpm RemoteProducerMetadata
+	if meta.Ranges != nil {
+		rpm.Value = &RemoteProducerMetadata_RangeInfo{
+			RangeInfo: &RemoteProducerMetadata_RangeInfos{
+				RangeInfo: meta.Ranges,
+			},
+		}
+	} else if meta.TraceData != nil {
+		rpm.Value = &RemoteProducerMetadata_TraceData_{
+			TraceData: &RemoteProducerMetadata_TraceData{
+				CollectedSpans: meta.TraceData,
+			},
+		}
+	} else if meta.TxnCoordMeta != nil {
+		rpm.Value = &RemoteProducerMetadata_TxnCoordMeta{
+			TxnCoordMeta: meta.TxnCoordMeta,
+		}
+	} else if meta.RowNum != nil {
+		rpm.Value = &RemoteProducerMetadata_RowNum_{
+			RowNum: meta.RowNum,
+		}
+	} else if meta.SamplerProgress != nil {
+		rpm.Value = &RemoteProducerMetadata_SamplerProgress_{
+			SamplerProgress: meta.SamplerProgress,
+		}
+	} else {
+		rpm.Value = &RemoteProducerMetadata_Error{
+			Error: NewError(meta.Err),
+		}
+	}
+	return rpm
+}
+
+// MetadataSource is an interface implemented by processors and columnar
+// operators that can produce metadata.
+type MetadataSource interface {
+	// DrainMeta returns all the metadata produced by the processor or operator.
+	// It will be called exactly once, usually, when the processor or operator
+	// has finished doing its computations.
+	// Implementers can choose what to do on subsequent calls (if such occur).
+	// TODO(yuzefovich): modify the contract to require returning nil on all
+	// calls after the first one.
+	DrainMeta(context.Context) []ProducerMetadata
 }

--- a/pkg/sql/distsqlpb/testutils.go
+++ b/pkg/sql/distsqlpb/testutils.go
@@ -1,0 +1,28 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package distsqlpb
+
+import "context"
+
+// CallbackMetadataSource is a utility struct that implements the MetadataSource
+// interface by calling a provided callback.
+type CallbackMetadataSource struct {
+	DrainMetaCb func(context.Context) []ProducerMetadata
+}
+
+// DrainMeta is part of the MetadataSource interface.
+func (s CallbackMetadataSource) DrainMeta(ctx context.Context) []ProducerMetadata {
+	return s.DrainMetaCb(ctx)
+}

--- a/pkg/sql/distsqlrun/backfiller.go
+++ b/pkg/sql/distsqlrun/backfiller.go
@@ -89,7 +89,7 @@ func (b *backfiller) Run(ctx context.Context) {
 	defer tracing.FinishSpan(span)
 
 	if err := b.mainLoop(ctx); err != nil {
-		b.output.Push(nil /* row */, &ProducerMetadata{Err: err})
+		b.output.Push(nil /* row */, &distsqlpb.ProducerMetadata{Err: err})
 	}
 	sendTraceData(ctx, b.output)
 	b.output.ProducerDone()

--- a/pkg/sql/distsqlrun/base_test.go
+++ b/pkg/sql/distsqlrun/base_test.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -36,7 +37,7 @@ func TestRunDrain(t *testing.T) {
 	// A source with no rows and 2 ProducerMetadata messages.
 	src := &RowChannel{}
 	src.initWithBufSizeAndNumSenders(nil, 10, 1)
-	src.Push(nil /* row */, &ProducerMetadata{Err: fmt.Errorf("test")})
+	src.Push(nil /* row */, &distsqlpb.ProducerMetadata{Err: fmt.Errorf("test")})
 	src.Push(nil /* row */, nil /* meta */)
 	src.Start(ctx)
 

--- a/pkg/sql/distsqlrun/cluster_test.go
+++ b/pkg/sql/distsqlrun/cluster_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 )
 
 func TestClusterFlow(t *testing.T) {
@@ -241,7 +241,7 @@ func TestClusterFlow(t *testing.T) {
 
 	var decoder StreamDecoder
 	var rows sqlbase.EncDatumRows
-	var metas []ProducerMetadata
+	var metas []distsqlpb.ProducerMetadata
 	for {
 		msg, err := stream.Recv()
 		if err != nil {
@@ -280,8 +280,8 @@ func TestClusterFlow(t *testing.T) {
 
 // ignoreMisplannedRanges takes a slice of metadata and returns the entries that
 // are not about range info from mis-planned ranges.
-func ignoreMisplannedRanges(metas []ProducerMetadata) []ProducerMetadata {
-	res := make([]ProducerMetadata, 0)
+func ignoreMisplannedRanges(metas []distsqlpb.ProducerMetadata) []distsqlpb.ProducerMetadata {
+	res := make([]distsqlpb.ProducerMetadata, 0)
 	for _, m := range metas {
 		if len(m.Ranges) == 0 {
 			res = append(res, m)
@@ -292,8 +292,8 @@ func ignoreMisplannedRanges(metas []ProducerMetadata) []ProducerMetadata {
 
 // ignoreTxnCoordMeta takes a slice of metadata and returns the entries excluding
 // the transaction coordinator metadata.
-func ignoreTxnCoordMeta(metas []ProducerMetadata) []ProducerMetadata {
-	res := make([]ProducerMetadata, 0)
+func ignoreTxnCoordMeta(metas []distsqlpb.ProducerMetadata) []distsqlpb.ProducerMetadata {
+	res := make([]distsqlpb.ProducerMetadata, 0)
 	for _, m := range metas {
 		if m.TxnCoordMeta == nil {
 			res = append(res, m)
@@ -493,7 +493,7 @@ func TestLimitedBufferingDeadlock(t *testing.T) {
 
 	var decoder StreamDecoder
 	var rows sqlbase.EncDatumRows
-	var metas []ProducerMetadata
+	var metas []distsqlpb.ProducerMetadata
 	for {
 		msg, err := stream.Recv()
 		if err != nil {
@@ -737,7 +737,7 @@ func BenchmarkInfrastructure(b *testing.B) {
 
 						var decoder StreamDecoder
 						var rows sqlbase.EncDatumRows
-						var metas []ProducerMetadata
+						var metas []distsqlpb.ProducerMetadata
 						for {
 							msg, err := stream.Recv()
 							if err != nil {

--- a/pkg/sql/distsqlrun/colbatch_scan.go
+++ b/pkg/sql/distsqlrun/colbatch_scan.go
@@ -59,16 +59,16 @@ func (s *colBatchScan) Next(ctx context.Context) coldata.Batch {
 }
 
 // DrainMeta is part of the MetadataSource interface.
-func (s *colBatchScan) DrainMeta(ctx context.Context) []ProducerMetadata {
-	var trailingMeta []ProducerMetadata
+func (s *colBatchScan) DrainMeta(ctx context.Context) []distsqlpb.ProducerMetadata {
+	var trailingMeta []distsqlpb.ProducerMetadata
 	if !s.flowCtx.local {
 		ranges := misplannedRanges(ctx, s.rf.GetRangesInfo(), s.flowCtx.nodeID)
 		if ranges != nil {
-			trailingMeta = append(trailingMeta, ProducerMetadata{Ranges: ranges})
+			trailingMeta = append(trailingMeta, distsqlpb.ProducerMetadata{Ranges: ranges})
 		}
 	}
 	if meta := getTxnCoordMeta(ctx, s.flowCtx.txn); meta != nil {
-		trailingMeta = append(trailingMeta, ProducerMetadata{TxnCoordMeta: meta})
+		trailingMeta = append(trailingMeta, distsqlpb.ProducerMetadata{TxnCoordMeta: meta})
 	}
 	return trailingMeta
 }

--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -716,7 +716,7 @@ func (f *Flow) setupVectorized(ctx context.Context) error {
 	}
 
 	inputs := make([]exec.Operator, 0, 2)
-	metadataSourcesQueue := make([]MetadataSource, 0, 1)
+	metadataSourcesQueue := make([]distsqlpb.MetadataSource, 0, 1)
 
 	recordingStats := false
 	if sp := opentracing.SpanFromContext(ctx); sp != nil && tracing.IsRecording(sp) {
@@ -755,7 +755,7 @@ func (f *Flow) setupVectorized(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		if metaSource, ok := op.(MetadataSource); ok {
+		if metaSource, ok := op.(distsqlpb.MetadataSource); ok {
 			metadataSourcesQueue = append(metadataSourcesQueue, metaSource)
 		}
 		if recordingStats {

--- a/pkg/sql/distsqlrun/columnarizer.go
+++ b/pkg/sql/distsqlrun/columnarizer.go
@@ -35,7 +35,7 @@ type columnarizer struct {
 
 	buffered        sqlbase.EncDatumRows
 	batch           coldata.Batch
-	accumulatedMeta []ProducerMetadata
+	accumulatedMeta []distsqlpb.ProducerMetadata
 }
 
 var _ exec.Operator = &columnarizer{}
@@ -68,7 +68,7 @@ func (c *columnarizer) Init() {
 	for i := range c.buffered {
 		c.buffered[i] = make(sqlbase.EncDatumRow, len(typs))
 	}
-	c.accumulatedMeta = make([]ProducerMetadata, 0, 1)
+	c.accumulatedMeta = make([]distsqlpb.ProducerMetadata, 0, 1)
 	c.input.Start(context.TODO())
 }
 
@@ -111,11 +111,11 @@ func (c *columnarizer) Run(context.Context) {
 }
 
 var _ exec.Operator = &columnarizer{}
-var _ MetadataSource = &columnarizer{}
+var _ distsqlpb.MetadataSource = &columnarizer{}
 
 // DrainMeta is part of the MetadataSource interface.
-func (c *columnarizer) DrainMeta(ctx context.Context) []ProducerMetadata {
-	if src, ok := c.input.(MetadataSource); ok {
+func (c *columnarizer) DrainMeta(ctx context.Context) []distsqlpb.ProducerMetadata {
+	if src, ok := c.input.(distsqlpb.MetadataSource); ok {
 		c.accumulatedMeta = append(c.accumulatedMeta, src.DrainMeta(ctx)...)
 	}
 	return c.accumulatedMeta

--- a/pkg/sql/distsqlrun/countrows.go
+++ b/pkg/sql/distsqlrun/countrows.go
@@ -79,7 +79,7 @@ func (ag *countAggregator) Start(ctx context.Context) context.Context {
 	return ag.StartInternal(ctx, countRowsProcName)
 }
 
-func (ag *countAggregator) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
+func (ag *countAggregator) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata) {
 	for ag.State == StateRunning {
 		row, meta := ag.input.Next()
 		if meta != nil {

--- a/pkg/sql/distsqlrun/distinct.go
+++ b/pkg/sql/distsqlrun/distinct.go
@@ -119,7 +119,7 @@ func NewDistinct(
 		d, post, d.types, flowCtx, processorID, output, memMonitor, /* memMonitor */
 		ProcStateOpts{
 			InputsToDrain: []RowSource{d.input},
-			TrailingMetaCallback: func(context.Context) []ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []distsqlpb.ProducerMetadata {
 				d.close()
 				return nil
 			},
@@ -199,7 +199,7 @@ func (d *Distinct) close() {
 }
 
 // Next is part of the RowSource interface.
-func (d *Distinct) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
+func (d *Distinct) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata) {
 	for d.State == StateRunning {
 		row, meta := d.input.Next()
 		if meta != nil {
@@ -267,7 +267,7 @@ func (d *Distinct) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 //
 // sortedDistinct is simpler than distinct. All it has to do is keep track
 // of the last row it saw, emitting if the new row is different.
-func (d *SortedDistinct) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
+func (d *SortedDistinct) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata) {
 	for d.State == StateRunning {
 		row, meta := d.input.Next()
 		if meta != nil {

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -588,7 +588,7 @@ func (f *Flow) Start(ctx context.Context, doneFn func()) error {
 	if err := f.startInternal(ctx, doneFn); err != nil {
 		// For sync flows, the error goes to the consumer.
 		if f.syncFlowConsumer != nil {
-			f.syncFlowConsumer.Push(nil /* row */, &ProducerMetadata{Err: err})
+			f.syncFlowConsumer.Push(nil /* row */, &distsqlpb.ProducerMetadata{Err: err})
 			f.syncFlowConsumer.ProducerDone()
 			return nil
 		}
@@ -617,7 +617,7 @@ func (f *Flow) Run(ctx context.Context, doneFn func()) error {
 	if err := f.startInternal(ctx, doneFn); err != nil {
 		// For sync flows, the error goes to the consumer.
 		if f.syncFlowConsumer != nil {
-			f.syncFlowConsumer.Push(nil /* row */, &ProducerMetadata{Err: err})
+			f.syncFlowConsumer.Push(nil /* row */, &distsqlpb.ProducerMetadata{Err: err})
 			f.syncFlowConsumer.ProducerDone()
 			return nil
 		}
@@ -706,7 +706,7 @@ func (f *Flow) cancel() {
 			// receiver and prevent it from being connected.
 			receiver.Push(
 				nil, /* row */
-				&ProducerMetadata{Err: sqlbase.QueryCanceledError})
+				&distsqlpb.ProducerMetadata{Err: sqlbase.QueryCanceledError})
 			receiver.ProducerDone()
 		}(receiver)
 	}

--- a/pkg/sql/distsqlrun/flow_registry.go
+++ b/pkg/sql/distsqlrun/flow_registry.go
@@ -233,7 +233,7 @@ func (fr *flowRegistry) RegisterFlow(
 				go func(r RowReceiver) {
 					r.Push(
 						nil, /* row */
-						&ProducerMetadata{Err: errNoInboundStreamConnection})
+						&distsqlpb.ProducerMetadata{Err: errNoInboundStreamConnection})
 					r.ProducerDone()
 				}(r)
 			}

--- a/pkg/sql/distsqlrun/flow_registry_test.go
+++ b/pkg/sql/distsqlrun/flow_registry_test.go
@@ -622,12 +622,12 @@ func TestTimeoutPushDoesntBlockRegister(t *testing.T) {
 	fr := makeFlowRegistry(0)
 	// pushChan is used to be able to tell when a Push on the RowBuffer has
 	// occurred.
-	pushChan := make(chan *ProducerMetadata)
+	pushChan := make(chan *distsqlpb.ProducerMetadata)
 	rc := NewRowBuffer(
 		sqlbase.OneIntCol,
 		nil, /* rows */
 		RowBufferArgs{
-			OnPush: func(_ sqlbase.EncDatumRow, meta *ProducerMetadata) {
+			OnPush: func(_ sqlbase.EncDatumRow, meta *distsqlpb.ProducerMetadata) {
 				pushChan <- meta
 				<-pushChan
 			},
@@ -696,7 +696,7 @@ func TestFlowCancelPartiallyBlocked(t *testing.T) {
 	}
 
 	// Fill up the left, so pushes to it block.
-	left.Push(nil, &ProducerMetadata{})
+	left.Push(nil, &distsqlpb.ProducerMetadata{})
 
 	// RegisterFlow with an immediate timeout.
 	flow := &Flow{

--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -421,11 +421,11 @@ func TestHashJoinerDrainAfterBuildPhaseError(t *testing.T) {
 		rightInputDrainNotification <- nil
 	}
 	rightErrorReturned := false
-	rightInputNext := func(rb *RowBuffer) (sqlbase.EncDatumRow, *ProducerMetadata) {
+	rightInputNext := func(rb *RowBuffer) (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata) {
 		if !rightErrorReturned {
 			rightErrorReturned = true
 			// The right input is going to return an error as the first thing.
-			return nil, &ProducerMetadata{Err: errors.Errorf("Test error. Please drain.")}
+			return nil, &distsqlpb.ProducerMetadata{Err: errors.Errorf("Test error. Please drain.")}
 		}
 		// Let RowBuffer.Next() do its usual thing.
 		return nil, nil

--- a/pkg/sql/distsqlrun/inbound.go
+++ b/pkg/sql/distsqlrun/inbound.go
@@ -63,7 +63,7 @@ func processInboundStreamHelper(
 
 	sendErrToConsumer := func(err error) {
 		if err != nil {
-			dst.Push(nil, &ProducerMetadata{Err: err})
+			dst.Push(nil, &distsqlpb.ProducerMetadata{Err: err})
 		}
 		dst.ProducerDone()
 	}

--- a/pkg/sql/distsqlrun/input_sync_test.go
+++ b/pkg/sql/distsqlrun/input_sync_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -143,7 +144,7 @@ func TestOrderedSync(t *testing.T) {
 func TestOrderedSyncDrainBeforeNext(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	expectedMeta := &ProducerMetadata{Err: errors.New("expected metadata")}
+	expectedMeta := &distsqlpb.ProducerMetadata{Err: errors.New("expected metadata")}
 
 	var sources []RowSource
 	for i := 0; i < 4; i++ {
@@ -248,7 +249,7 @@ func TestUnorderedSync(t *testing.T) {
 			}
 			if i == 3 {
 				err := fmt.Errorf("Test error")
-				mrc.Push(nil /* row */, &ProducerMetadata{Err: err})
+				mrc.Push(nil /* row */, &distsqlpb.ProducerMetadata{Err: err})
 			}
 			mrc.ProducerDone()
 		}(i)

--- a/pkg/sql/distsqlrun/joinreader_test.go
+++ b/pkg/sql/distsqlrun/joinreader_test.go
@@ -400,7 +400,7 @@ func TestJoinReaderDrain(t *testing.T) {
 	t.Run("ConsumerDone", func(t *testing.T) {
 		expectedMetaErr := errors.New("dummy")
 		in := NewRowBuffer(sqlbase.OneIntCol, nil /* rows */, RowBufferArgs{})
-		if status := in.Push(encRow, &ProducerMetadata{Err: expectedMetaErr}); status != NeedMoreRows {
+		if status := in.Push(encRow, &distsqlpb.ProducerMetadata{Err: expectedMetaErr}); status != NeedMoreRows {
 			t.Fatalf("unexpected response: %d", status)
 		}
 

--- a/pkg/sql/distsqlrun/materializer.go
+++ b/pkg/sql/distsqlrun/materializer.go
@@ -64,7 +64,7 @@ func newMaterializer(
 	outputToInputColIdx []int,
 	post *distsqlpb.PostProcessSpec,
 	output RowReceiver,
-	metadataSourcesQueue []MetadataSource,
+	metadataSourcesQueue []distsqlpb.MetadataSource,
 	outputStatsToTrace func(),
 ) (*materializer, error) {
 	m := &materializer{
@@ -82,8 +82,8 @@ func newMaterializer(
 		output,
 		nil, /* memMonitor */
 		ProcStateOpts{
-			TrailingMetaCallback: func(ctx context.Context) []ProducerMetadata {
-				var trailingMeta []ProducerMetadata
+			TrailingMetaCallback: func(ctx context.Context) []distsqlpb.ProducerMetadata {
+				var trailingMeta []distsqlpb.ProducerMetadata
 				for _, src := range metadataSourcesQueue {
 					trailingMeta = append(trailingMeta, src.DrainMeta(ctx)...)
 				}
@@ -110,7 +110,7 @@ func (m *materializer) nextBatch() {
 	m.batch = m.input.Next(m.Ctx)
 }
 
-func (m *materializer) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
+func (m *materializer) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata) {
 	for m.State == StateRunning {
 		if m.batch == nil || m.curIdx >= m.batch.Length() {
 			// Get a fresh batch.

--- a/pkg/sql/distsqlrun/metadata_test_sender.go
+++ b/pkg/sql/distsqlrun/metadata_test_sender.go
@@ -57,17 +57,17 @@ func newMetadataTestSender(
 		nil, /* memMonitor */
 		ProcStateOpts{
 			InputsToDrain: []RowSource{mts.input},
-			TrailingMetaCallback: func(context.Context) []ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []distsqlpb.ProducerMetadata {
 				mts.InternalClose()
 				// Send a final record with LastMsg set.
-				meta := ProducerMetadata{
+				meta := distsqlpb.ProducerMetadata{
 					RowNum: &distsqlpb.RemoteProducerMetadata_RowNum{
 						RowNum:   mts.rowNumCnt,
 						SenderID: mts.id,
 						LastMsg:  true,
 					},
 				}
-				return []ProducerMetadata{meta}
+				return []distsqlpb.ProducerMetadata{meta}
 			},
 		},
 	); err != nil {
@@ -83,12 +83,12 @@ func (mts *metadataTestSender) Start(ctx context.Context) context.Context {
 }
 
 // Next is part of the RowSource interface.
-func (mts *metadataTestSender) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
+func (mts *metadataTestSender) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata) {
 	// Every call after a row has been returned returns a metadata record.
 	if mts.sendRowNumMeta {
 		mts.sendRowNumMeta = false
 		mts.rowNumCnt++
-		return nil, &ProducerMetadata{
+		return nil, &distsqlpb.ProducerMetadata{
 			RowNum: &distsqlpb.RemoteProducerMetadata_RowNum{
 				RowNum:   mts.rowNumCnt,
 				SenderID: mts.id,

--- a/pkg/sql/distsqlrun/noop.go
+++ b/pkg/sql/distsqlrun/noop.go
@@ -65,7 +65,7 @@ func (n *noopProcessor) Start(ctx context.Context) context.Context {
 }
 
 // Next is part of the RowSource interface.
-func (n *noopProcessor) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
+func (n *noopProcessor) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata) {
 	for n.State == StateRunning {
 		row, meta := n.input.Next()
 

--- a/pkg/sql/distsqlrun/outbox.go
+++ b/pkg/sql/distsqlrun/outbox.go
@@ -29,7 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"google.golang.org/grpc"
 )
 
@@ -118,7 +118,7 @@ func (m *outbox) init(typs []types.T) {
 // too, or it might be an encoding error, in which case we've forwarded it on
 // the stream.
 func (m *outbox) addRow(
-	ctx context.Context, row sqlbase.EncDatumRow, meta *ProducerMetadata,
+	ctx context.Context, row sqlbase.EncDatumRow, meta *distsqlpb.ProducerMetadata,
 ) error {
 	mustFlush := false
 	var encodingErr error
@@ -130,7 +130,7 @@ func (m *outbox) addRow(
 	} else {
 		encodingErr = m.encoder.AddRow(row)
 		if encodingErr != nil {
-			m.encoder.AddMetadata(ProducerMetadata{Err: encodingErr})
+			m.encoder.AddMetadata(distsqlpb.ProducerMetadata{Err: encodingErr})
 			mustFlush = true
 		}
 	}
@@ -281,7 +281,7 @@ func (m *outbox) mainLoop(ctx context.Context) error {
 					tracing.FinishSpan(span)
 					spanFinished = true
 					if trace := getTraceData(ctx); trace != nil {
-						err := m.addRow(ctx, nil, &ProducerMetadata{TraceData: trace})
+						err := m.addRow(ctx, nil, &distsqlpb.ProducerMetadata{TraceData: trace})
 						if err != nil {
 							return err
 						}

--- a/pkg/sql/distsqlrun/outbox_test.go
+++ b/pkg/sql/distsqlrun/outbox_test.go
@@ -117,8 +117,8 @@ func TestOutbox(t *testing.T) {
 			}
 
 			// Send some metadata.
-			outbox.Push(nil /* row */, &ProducerMetadata{Err: errors.Errorf("meta 0")})
-			outbox.Push(nil /* row */, &ProducerMetadata{Err: errors.Errorf("meta 1")})
+			outbox.Push(nil /* row */, &distsqlpb.ProducerMetadata{Err: errors.Errorf("meta 0")})
+			outbox.Push(nil /* row */, &distsqlpb.ProducerMetadata{Err: errors.Errorf("meta 1")})
 			// Send the termination signal.
 			outbox.ProducerDone()
 
@@ -133,7 +133,7 @@ func TestOutbox(t *testing.T) {
 	// Consume everything that the outbox sends on the stream.
 	var decoder StreamDecoder
 	var rows sqlbase.EncDatumRows
-	var metas []ProducerMetadata
+	var metas []distsqlpb.ProducerMetadata
 	drainSignalSent := false
 	for {
 		msg, err := serverStream.Recv()
@@ -491,7 +491,7 @@ func TestOutboxUnblocksProducers(t *testing.T) {
 
 	// Fill up the outbox.
 	for i := 0; i < outboxBufRows; i++ {
-		outbox.Push(nil, &ProducerMetadata{})
+		outbox.Push(nil, &distsqlpb.ProducerMetadata{})
 	}
 
 	var blockedPusherWg sync.WaitGroup
@@ -499,7 +499,7 @@ func TestOutboxUnblocksProducers(t *testing.T) {
 	go func() {
 		// Push to the outbox one last time, which will block since the channel
 		// is full.
-		outbox.Push(nil, &ProducerMetadata{})
+		outbox.Push(nil, &distsqlpb.ProducerMetadata{})
 		// We should become unblocked once outbox.start fails.
 		blockedPusherWg.Done()
 	}()
@@ -510,7 +510,7 @@ func TestOutboxUnblocksProducers(t *testing.T) {
 	wg.Wait()
 	// Also, make sure that pushing to the outbox after its failed shows that
 	// it's been correctly ConsumerClosed.
-	status := outbox.RowChannel.Push(nil, &ProducerMetadata{})
+	status := outbox.RowChannel.Push(nil, &distsqlpb.ProducerMetadata{})
 	if status != ConsumerClosed {
 		t.Fatalf("expected status=ConsumerClosed, got %s", status)
 	}

--- a/pkg/sql/distsqlrun/project_set.go
+++ b/pkg/sql/distsqlrun/project_set.go
@@ -125,7 +125,11 @@ func (ps *projectSetProcessor) Start(ctx context.Context) context.Context {
 
 // nextInputRow returns the next row or metadata from ps.input. It also
 // initializes the value generators for that row.
-func (ps *projectSetProcessor) nextInputRow() (sqlbase.EncDatumRow, *ProducerMetadata, error) {
+func (ps *projectSetProcessor) nextInputRow() (
+	sqlbase.EncDatumRow,
+	*distsqlpb.ProducerMetadata,
+	error,
+) {
 	row, meta := ps.input.Next()
 	if row == nil {
 		return nil, meta, nil
@@ -216,7 +220,7 @@ func (ps *projectSetProcessor) nextGeneratorValues() (newValAvail bool, err erro
 }
 
 // Next is part of the RowSource interface.
-func (ps *projectSetProcessor) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
+func (ps *projectSetProcessor) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata) {
 	const cancelCheckCount = 10000
 
 	for ps.State == StateRunning {

--- a/pkg/sql/distsqlrun/routers.go
+++ b/pkg/sql/distsqlrun/routers.go
@@ -86,7 +86,7 @@ type routerOutput struct {
 		cond         *sync.Cond
 		streamStatus ConsumerStatus
 
-		metadataBuf []*ProducerMetadata
+		metadataBuf []*distsqlpb.ProducerMetadata
 		// The "level 1" row buffer is used first, to avoid going through the row
 		// container if we don't need to buffer many rows. The buffer is a circular
 		// FIFO queue, with rowBufLen elements and the left-most (oldest) element at
@@ -110,7 +110,7 @@ type routerOutput struct {
 	memoryMonitor, diskMonitor *mon.BytesMonitor
 }
 
-func (ro *routerOutput) addMetadataLocked(meta *ProducerMetadata) {
+func (ro *routerOutput) addMetadataLocked(meta *distsqlpb.ProducerMetadata) {
 	// We don't need any fancy buffering because normally there is not a lot of
 	// metadata being passed around.
 	ro.mu.metadataBuf = append(ro.mu.metadataBuf, meta)
@@ -316,7 +316,7 @@ func (rb *routerBase) start(ctx context.Context, wg *sync.WaitGroup, ctxCancel c
 					// Send any rows that have been buffered. We grab multiple rows at a
 					// time to reduce contention.
 					if rows, err := ro.popRowsLocked(ctx, rowBuf); err != nil {
-						rb.fwdMetadata(&ProducerMetadata{Err: err})
+						rb.fwdMetadata(&distsqlpb.ProducerMetadata{Err: err})
 						atomic.StoreUint32(&rb.aggregatedStatus, uint32(DrainRequested))
 						drain = true
 						continue
@@ -346,7 +346,7 @@ func (rb *routerBase) start(ctx context.Context, wg *sync.WaitGroup, ctxCancel c
 						tracing.FinishSpan(span)
 						if trace := getTraceData(ctx); trace != nil {
 							rb.semaphore <- struct{}{}
-							status := ro.stream.Push(nil, &ProducerMetadata{TraceData: trace})
+							status := ro.stream.Push(nil, &distsqlpb.ProducerMetadata{TraceData: trace})
 							rb.updateStreamState(&streamStatus, status)
 							<-rb.semaphore
 						}
@@ -410,7 +410,7 @@ func (rb *routerBase) updateStreamState(streamStatus *ConsumerStatus, newState C
 
 // fwdMetadata forwards a metadata record to the first stream that's still
 // accepting data.
-func (rb *routerBase) fwdMetadata(meta *ProducerMetadata) {
+func (rb *routerBase) fwdMetadata(meta *distsqlpb.ProducerMetadata) {
 	if meta == nil {
 		log.Fatalf(context.TODO(), "asked to fwd empty metadata")
 	}
@@ -488,7 +488,9 @@ func makeMirrorRouter(rb routerBase) (router, error) {
 }
 
 // Push is part of the RowReceiver interface.
-func (mr *mirrorRouter) Push(row sqlbase.EncDatumRow, meta *ProducerMetadata) ConsumerStatus {
+func (mr *mirrorRouter) Push(
+	row sqlbase.EncDatumRow, meta *distsqlpb.ProducerMetadata,
+) ConsumerStatus {
 	aggStatus := mr.aggStatus()
 	if meta != nil {
 		mr.fwdMetadata(meta)
@@ -512,7 +514,7 @@ func (mr *mirrorRouter) Push(row sqlbase.EncDatumRow, meta *ProducerMetadata) Co
 			if useSema {
 				<-mr.semaphore
 			}
-			mr.fwdMetadata(&ProducerMetadata{Err: err})
+			mr.fwdMetadata(&distsqlpb.ProducerMetadata{Err: err})
 			atomic.StoreUint32(&mr.aggregatedStatus, uint32(ConsumerClosed))
 			return ConsumerClosed
 		}
@@ -540,7 +542,9 @@ func makeHashRouter(rb routerBase, hashCols []uint32) (router, error) {
 //
 // If, according to the hash, the row needs to go to a consumer that's draining
 // or closed, the row is silently dropped.
-func (hr *hashRouter) Push(row sqlbase.EncDatumRow, meta *ProducerMetadata) ConsumerStatus {
+func (hr *hashRouter) Push(
+	row sqlbase.EncDatumRow, meta *distsqlpb.ProducerMetadata,
+) ConsumerStatus {
 	aggStatus := hr.aggStatus()
 	if meta != nil {
 		hr.fwdMetadata(meta)
@@ -568,7 +572,7 @@ func (hr *hashRouter) Push(row sqlbase.EncDatumRow, meta *ProducerMetadata) Cons
 		<-hr.semaphore
 	}
 	if err != nil {
-		hr.fwdMetadata(&ProducerMetadata{Err: err})
+		hr.fwdMetadata(&distsqlpb.ProducerMetadata{Err: err})
 		atomic.StoreUint32(&hr.aggregatedStatus, uint32(ConsumerClosed))
 		return ConsumerClosed
 	}
@@ -628,7 +632,9 @@ func makeRangeRouter(
 	}, nil
 }
 
-func (rr *rangeRouter) Push(row sqlbase.EncDatumRow, meta *ProducerMetadata) ConsumerStatus {
+func (rr *rangeRouter) Push(
+	row sqlbase.EncDatumRow, meta *distsqlpb.ProducerMetadata,
+) ConsumerStatus {
 	aggStatus := rr.aggStatus()
 	if meta != nil {
 		rr.fwdMetadata(meta)
@@ -653,7 +659,7 @@ func (rr *rangeRouter) Push(row sqlbase.EncDatumRow, meta *ProducerMetadata) Con
 		<-rr.semaphore
 	}
 	if err != nil {
-		rr.fwdMetadata(&ProducerMetadata{Err: err})
+		rr.fwdMetadata(&distsqlpb.ProducerMetadata{Err: err})
 		atomic.StoreUint32(&rr.aggregatedStatus, uint32(ConsumerClosed))
 		return ConsumerClosed
 	}

--- a/pkg/sql/distsqlrun/routers_test.go
+++ b/pkg/sql/distsqlrun/routers_test.go
@@ -397,7 +397,7 @@ func TestConsumerStatus(t *testing.T) {
 			// that everything's closed now.
 			testutils.SucceedsSoon(t, func() error {
 				consumerStatus := router.Push(
-					nil /* row */, &ProducerMetadata{Err: errors.Errorf("test error")},
+					nil /* row */, &distsqlpb.ProducerMetadata{Err: errors.Errorf("test error")},
 				)
 				if consumerStatus != ConsumerClosed {
 					return fmt.Errorf("expected status %d, got: %d", ConsumerClosed, consumerStatus)
@@ -474,7 +474,7 @@ func TestMetadataIsForwarded(t *testing.T) {
 
 			// Push metadata; it should go to stream 0.
 			for i := 0; i < 10; i++ {
-				consumerStatus := router.Push(nil /* row */, &ProducerMetadata{Err: err1})
+				consumerStatus := router.Push(nil /* row */, &distsqlpb.ProducerMetadata{Err: err1})
 				if consumerStatus != NeedMoreRows {
 					t.Fatalf("expected status %d, got: %d", NeedMoreRows, consumerStatus)
 				}
@@ -487,7 +487,7 @@ func TestMetadataIsForwarded(t *testing.T) {
 			chans[0].ConsumerDone()
 			// Push metadata; it should still go to stream 0.
 			for i := 0; i < 10; i++ {
-				consumerStatus := router.Push(nil /* row */, &ProducerMetadata{Err: err2})
+				consumerStatus := router.Push(nil /* row */, &distsqlpb.ProducerMetadata{Err: err2})
 				if consumerStatus != NeedMoreRows {
 					t.Fatalf("expected status %d, got: %d", NeedMoreRows, consumerStatus)
 				}
@@ -502,7 +502,7 @@ func TestMetadataIsForwarded(t *testing.T) {
 			// Metadata should switch to going to stream 1 once the new status is
 			// observed.
 			testutils.SucceedsSoon(t, func() error {
-				consumerStatus := router.Push(nil /* row */, &ProducerMetadata{Err: err3})
+				consumerStatus := router.Push(nil /* row */, &distsqlpb.ProducerMetadata{Err: err3})
 				if consumerStatus != NeedMoreRows {
 					t.Fatalf("expected status %d, got: %d", NeedMoreRows, consumerStatus)
 				}
@@ -527,7 +527,7 @@ func TestMetadataIsForwarded(t *testing.T) {
 			}
 
 			testutils.SucceedsSoon(t, func() error {
-				consumerStatus := router.Push(nil /* row */, &ProducerMetadata{Err: err4})
+				consumerStatus := router.Push(nil /* row */, &distsqlpb.ProducerMetadata{Err: err4})
 				if consumerStatus != ConsumerClosed {
 					return fmt.Errorf("expected status %d, got: %d", ConsumerClosed, consumerStatus)
 				}

--- a/pkg/sql/distsqlrun/sampler.go
+++ b/pkg/sql/distsqlrun/sampler.go
@@ -206,7 +206,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 		if rowCount%SamplerProgressInterval == 0 {
 			// Send a metadata record to check that the consumer is still alive and
 			// report number of rows processed since the last update.
-			meta := &ProducerMetadata{SamplerProgress: &distsqlpb.RemoteProducerMetadata_SamplerProgress{
+			meta := &distsqlpb.ProducerMetadata{SamplerProgress: &distsqlpb.RemoteProducerMetadata_SamplerProgress{
 				RowsProcessed: uint64(SamplerProgressInterval),
 			}}
 			if !emitHelper(ctx, &s.out, nil /* row */, meta, s.pushTrailingMeta, s.input) {
@@ -343,7 +343,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 	}
 
 	// Send one last progress update to the consumer.
-	meta := &ProducerMetadata{SamplerProgress: &distsqlpb.RemoteProducerMetadata_SamplerProgress{
+	meta := &distsqlpb.ProducerMetadata{SamplerProgress: &distsqlpb.RemoteProducerMetadata_SamplerProgress{
 		RowsProcessed: uint64(rowCount % SamplerProgressInterval),
 	}}
 	if !emitHelper(ctx, &s.out, nil /* row */, meta, s.pushTrailingMeta, s.input) {

--- a/pkg/sql/distsqlrun/scrub_tablereader.go
+++ b/pkg/sql/distsqlrun/scrub_tablereader.go
@@ -229,7 +229,7 @@ func (tr *scrubTableReader) Start(ctx context.Context) context.Context {
 }
 
 // Next is part of the RowSource interface.
-func (tr *scrubTableReader) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
+func (tr *scrubTableReader) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata) {
 	for tr.State == StateRunning {
 		var row sqlbase.EncDatumRow
 		var err error

--- a/pkg/sql/distsqlrun/server_test.go
+++ b/pkg/sql/distsqlrun/server_test.go
@@ -89,7 +89,7 @@ func TestServer(t *testing.T) {
 
 	var decoder StreamDecoder
 	var rows sqlbase.EncDatumRows
-	var metas []ProducerMetadata
+	var metas []distsqlpb.ProducerMetadata
 	for {
 		msg, err := stream.Recv()
 		if err != nil {

--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -27,7 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -117,7 +117,7 @@ func (s *sorterBase) init(
 // Next is part of the RowSource interface. It is extracted into sorterBase
 // because this implementation of next is shared between the sortAllProcessor
 // and the sortTopKProcessor.
-func (s *sorterBase) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
+func (s *sorterBase) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata) {
 	for s.State == StateRunning {
 		if ok, err := s.i.Valid(); err != nil || !ok {
 			s.MoveToDraining(err)
@@ -270,7 +270,7 @@ func newSortAllProcessor(
 		spec.OrderingMatchLen,
 		ProcStateOpts{
 			InputsToDrain: []RowSource{input},
-			TrailingMetaCallback: func(context.Context) []ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []distsqlpb.ProducerMetadata {
 				proc.close()
 				return nil
 			},
@@ -388,7 +388,7 @@ func newSortTopKProcessor(
 		ordering, spec.OrderingMatchLen,
 		ProcStateOpts{
 			InputsToDrain: []RowSource{input},
-			TrailingMetaCallback: func(context.Context) []ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []distsqlpb.ProducerMetadata {
 				proc.close()
 				return nil
 			},
@@ -491,7 +491,7 @@ func newSortChunksProcessor(
 		proc, flowCtx, processorID, input, post, out, ordering, spec.OrderingMatchLen,
 		ProcStateOpts{
 			InputsToDrain: []RowSource{input},
-			TrailingMetaCallback: func(context.Context) []ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []distsqlpb.ProducerMetadata {
 				proc.close()
 				return nil
 			},
@@ -528,7 +528,7 @@ func (s *sortChunksProcessor) chunkCompleted(
 func (s *sortChunksProcessor) fill() (bool, error) {
 	ctx := s.Ctx
 
-	var meta *ProducerMetadata
+	var meta *distsqlpb.ProducerMetadata
 
 	nextChunkRow := s.nextChunkRow
 	s.nextChunkRow = nil
@@ -595,7 +595,7 @@ func (s *sortChunksProcessor) Start(ctx context.Context) context.Context {
 }
 
 // Next is part of the RowSource interface.
-func (s *sortChunksProcessor) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
+func (s *sortChunksProcessor) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata) {
 	ctx := s.Ctx
 	for s.State == StateRunning {
 		ok, err := s.i.Valid()

--- a/pkg/sql/distsqlrun/stats.go
+++ b/pkg/sql/distsqlrun/stats.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
@@ -38,7 +39,7 @@ func NewInputStatCollector(input RowSource) *InputStatCollector {
 
 // Next implements the RowSource interface. It calls Next on the embedded
 // RowSource and collects stats.
-func (isc *InputStatCollector) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
+func (isc *InputStatCollector) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata) {
 	start := timeutil.Now()
 	row, meta := isc.RowSource.Next()
 	if row != nil {

--- a/pkg/sql/distsqlrun/stream_data_test.go
+++ b/pkg/sql/distsqlrun/stream_data_test.go
@@ -30,8 +30,11 @@ import (
 // The encoder/decoder don't maintain the ordering between rows and metadata
 // records.
 func testGetDecodedRows(
-	tb testing.TB, sd *StreamDecoder, decodedRows sqlbase.EncDatumRows, metas []ProducerMetadata,
-) (sqlbase.EncDatumRows, []ProducerMetadata) {
+	tb testing.TB,
+	sd *StreamDecoder,
+	decodedRows sqlbase.EncDatumRows,
+	metas []distsqlpb.ProducerMetadata,
+) (sqlbase.EncDatumRows, []distsqlpb.ProducerMetadata) {
 	for {
 		row, meta, err := sd.GetRow(nil /* rowBuf */)
 		if err != nil {
@@ -54,7 +57,7 @@ func testRowStream(tb testing.TB, rng *rand.Rand, types []types.T, records []row
 	var sd StreamDecoder
 
 	var decodedRows sqlbase.EncDatumRows
-	var metas []ProducerMetadata
+	var metas []distsqlpb.ProducerMetadata
 	numRows := 0
 	numMeta := 0
 
@@ -95,7 +98,7 @@ func testRowStream(tb testing.TB, rng *rand.Rand, types []types.T, records []row
 
 type rowOrMeta struct {
 	row  sqlbase.EncDatumRow
-	meta ProducerMetadata
+	meta distsqlpb.ProducerMetadata
 }
 
 // TestStreamEncodeDecode generates random streams of EncDatums and passes them

--- a/pkg/sql/distsqlrun/stream_decoder.go
+++ b/pkg/sql/distsqlrun/stream_decoder.go
@@ -48,7 +48,7 @@ type StreamDecoder struct {
 	typing       []distsqlpb.DatumInfo
 	data         []byte
 	numEmptyRows int
-	metadata     []ProducerMetadata
+	metadata     []distsqlpb.ProducerMetadata
 	rowAlloc     sqlbase.EncDatumRowAlloc
 
 	headerReceived bool
@@ -102,31 +102,11 @@ func (sd *StreamDecoder) AddMessage(msg *distsqlpb.ProducerMessage) error {
 	}
 	if len(msg.Data.Metadata) > 0 {
 		for _, md := range msg.Data.Metadata {
-			var meta ProducerMetadata
-			switch v := md.Value.(type) {
-			case *distsqlpb.RemoteProducerMetadata_RangeInfo:
-				meta.Ranges = v.RangeInfo.RangeInfo
-
-			case *distsqlpb.RemoteProducerMetadata_TraceData_:
-				meta.TraceData = v.TraceData.CollectedSpans
-
-			case *distsqlpb.RemoteProducerMetadata_TxnCoordMeta:
-				meta.TxnCoordMeta = v.TxnCoordMeta
-
-			case *distsqlpb.RemoteProducerMetadata_RowNum_:
-				meta.RowNum = v.RowNum
-
-			case *distsqlpb.RemoteProducerMetadata_SamplerProgress_:
-				meta.SamplerProgress = v.SamplerProgress
-
-			case *distsqlpb.RemoteProducerMetadata_Error:
-				meta.Err = v.Error.ErrorDetail()
-
-			default:
+			meta, ok := distsqlpb.RemoteProducerMetaToLocalMeta(md)
+			if !ok {
 				// Unknown metadata, ignore.
 				continue
 			}
-
 			sd.metadata = append(sd.metadata, meta)
 		}
 	}
@@ -142,7 +122,7 @@ func (sd *StreamDecoder) AddMessage(msg *distsqlpb.ProducerMessage) error {
 // coming from the upstream (through ProducerMetadata.Err).
 func (sd *StreamDecoder) GetRow(
 	rowBuf sqlbase.EncDatumRow,
-) (sqlbase.EncDatumRow, *ProducerMetadata, error) {
+) (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata, error) {
 	if len(sd.metadata) != 0 {
 		r := &sd.metadata[0]
 		sd.metadata = sd.metadata[1:]

--- a/pkg/sql/distsqlrun/stream_encoder.go
+++ b/pkg/sql/distsqlrun/stream_encoder.go
@@ -79,38 +79,8 @@ func (se *StreamEncoder) init(types []types.T) {
 // that the StreamDecoder will return them first, before the data rows, thus
 // ensuring that rows produced _after_ an error are not received _before_ the
 // error.
-func (se *StreamEncoder) AddMetadata(meta ProducerMetadata) {
-	var enc distsqlpb.RemoteProducerMetadata
-	if meta.Ranges != nil {
-		enc.Value = &distsqlpb.RemoteProducerMetadata_RangeInfo{
-			RangeInfo: &distsqlpb.RemoteProducerMetadata_RangeInfos{
-				RangeInfo: meta.Ranges,
-			},
-		}
-	} else if meta.TraceData != nil {
-		enc.Value = &distsqlpb.RemoteProducerMetadata_TraceData_{
-			TraceData: &distsqlpb.RemoteProducerMetadata_TraceData{
-				CollectedSpans: meta.TraceData,
-			},
-		}
-	} else if meta.TxnCoordMeta != nil {
-		enc.Value = &distsqlpb.RemoteProducerMetadata_TxnCoordMeta{
-			TxnCoordMeta: meta.TxnCoordMeta,
-		}
-	} else if meta.RowNum != nil {
-		enc.Value = &distsqlpb.RemoteProducerMetadata_RowNum_{
-			RowNum: meta.RowNum,
-		}
-	} else if meta.SamplerProgress != nil {
-		enc.Value = &distsqlpb.RemoteProducerMetadata_SamplerProgress_{
-			SamplerProgress: meta.SamplerProgress,
-		}
-	} else {
-		enc.Value = &distsqlpb.RemoteProducerMetadata_Error{
-			Error: distsqlpb.NewError(meta.Err),
-		}
-	}
-	se.metadata = append(se.metadata, enc)
+func (se *StreamEncoder) AddMetadata(meta distsqlpb.ProducerMetadata) {
+	se.metadata = append(se.metadata, distsqlpb.LocalMetaToRemoteProducerMeta(meta))
 }
 
 // AddRow encodes a message.

--- a/pkg/sql/distsqlrun/stream_merger.go
+++ b/pkg/sql/distsqlrun/stream_merger.go
@@ -17,6 +17,7 @@ package distsqlrun
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -51,16 +52,16 @@ func (sm *streamMerger) start(ctx context.Context) {
 // be empty.
 func (sm *streamMerger) NextBatch(
 	ctx context.Context, evalCtx *tree.EvalContext,
-) ([]sqlbase.EncDatumRow, []sqlbase.EncDatumRow, *ProducerMetadata) {
+) ([]sqlbase.EncDatumRow, []sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata) {
 	if sm.leftGroup == nil {
-		var meta *ProducerMetadata
+		var meta *distsqlpb.ProducerMetadata
 		sm.leftGroup, meta = sm.left.nextGroup(ctx, evalCtx)
 		if meta != nil {
 			return nil, nil, meta
 		}
 	}
 	if sm.rightGroup == nil {
-		var meta *ProducerMetadata
+		var meta *distsqlpb.ProducerMetadata
 		sm.rightGroup, meta = sm.right.nextGroup(ctx, evalCtx)
 		if meta != nil {
 			return nil, nil, meta
@@ -83,7 +84,7 @@ func (sm *streamMerger) NextBatch(
 		sm.nullEquality, &sm.datumAlloc, evalCtx,
 	)
 	if err != nil {
-		return nil, nil, &ProducerMetadata{Err: err}
+		return nil, nil, &distsqlpb.ProducerMetadata{Err: err}
 	}
 	var leftGroup, rightGroup []sqlbase.EncDatumRow
 	if cmp <= 0 {

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -255,7 +255,7 @@ ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[
 		}
 
 		var res sqlbase.EncDatumRows
-		var metas []*ProducerMetadata
+		var metas []*distsqlpb.ProducerMetadata
 		for {
 			row, meta := results.Next()
 			if meta != nil {

--- a/pkg/sql/distsqlrun/utils_test.go
+++ b/pkg/sql/distsqlrun/utils_test.go
@@ -64,7 +64,7 @@ func (r *RepeatableRowSource) OutputTypes() []types.T {
 func (r *RepeatableRowSource) Start(ctx context.Context) context.Context { return ctx }
 
 // Next is part of the RowSource interface.
-func (r *RepeatableRowSource) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
+func (r *RepeatableRowSource) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata) {
 	// If we've emitted all rows, signal that we have reached the end.
 	if r.nextRowIdx >= len(r.rows) {
 		return nil, nil
@@ -92,7 +92,9 @@ type RowDisposer struct{}
 var _ RowReceiver = &RowDisposer{}
 
 // Push is part of the RowReceiver interface.
-func (r *RowDisposer) Push(row sqlbase.EncDatumRow, meta *ProducerMetadata) ConsumerStatus {
+func (r *RowDisposer) Push(
+	row sqlbase.EncDatumRow, meta *distsqlpb.ProducerMetadata,
+) ConsumerStatus {
 	return NeedMoreRows
 }
 

--- a/pkg/sql/distsqlrun/values.go
+++ b/pkg/sql/distsqlrun/values.go
@@ -87,7 +87,7 @@ func (v *valuesProcessor) Start(ctx context.Context) context.Context {
 }
 
 // Next is part of the RowSource interface.
-func (v *valuesProcessor) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
+func (v *valuesProcessor) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata) {
 	for v.State == StateRunning {
 		row, meta, err := v.sd.GetRow(v.rowBuf)
 		if err != nil {

--- a/pkg/sql/distsqlrun/vectorized_error_propagation_test.go
+++ b/pkg/sql/distsqlrun/vectorized_error_propagation_test.go
@@ -69,7 +69,7 @@ func TestVectorizedErrorPropagation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var meta *ProducerMetadata
+	var meta *distsqlpb.ProducerMetadata
 	panicEmitted := false
 	func() {
 		defer func() {

--- a/pkg/sql/distsqlrun/vectorized_meta_propagation_test.go
+++ b/pkg/sql/distsqlrun/vectorized_meta_propagation_test.go
@@ -78,7 +78,7 @@ func TestVectorizedMetaPropagation(t *testing.T) {
 		[]int{0},
 		&distsqlpb.PostProcessSpec{},
 		nil, /* output */
-		[]MetadataSource{col},
+		[]distsqlpb.MetadataSource{col},
 		nil, /* outputStatsToTrace */
 	)
 	if err != nil {

--- a/pkg/sql/exec/cancel_checker_test.go
+++ b/pkg/sql/exec/cancel_checker_test.go
@@ -29,7 +29,7 @@ import (
 func TestCancelChecker(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	batch := coldata.NewMemBatch([]types.T{types.Int64})
-	op := NewCancelChecker(NewNoop(newRepeatableBatchSource(batch)))
+	op := NewCancelChecker(NewNoop(NewRepeatableBatchSource(batch)))
 	cancel()
 	require.PanicsWithValue(t, sqlbase.QueryCanceledError, func() {
 		op.Next(ctx)

--- a/pkg/sql/exec/colrpc/colrpc_test.go
+++ b/pkg/sql/exec/colrpc/colrpc_test.go
@@ -16,7 +16,10 @@ package colrpc
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
+	"math"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -28,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -118,7 +122,6 @@ func handleStream(
 
 const staticNodeID roachpb.NodeID = 3
 
-// TODO(asubiotto): Add draining and cancellation tests.
 func TestOutboxInbox(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -131,94 +134,400 @@ func TestOutboxInbox(t *testing.T) {
 	_, mockServer, addr, err := distsqlrun.StartMockDistSQLServer(clock, stopper, staticNodeID)
 	require.NoError(t, err)
 
+	// Generate a random cancellation scenario.
+	rng, _ := randutil.NewPseudoRand()
+	type cancellationType int
+	const (
+		// In this scenario, no cancellation happens and all the data is pushed from
+		// the Outbox to the Inbox.
+		noCancel cancellationType = iota
+		// streamCtxCancel models a scenario in which the Outbox host cancels the
+		// flow.
+		streamCtxCancel
+		// readerCtxCancel models a scenario in which the Inbox host cancels the
+		// flow.
+		readerCtxCancel
+		// transportBreaks models a scenario in which the transport breaks.
+		transportBreaks
+	)
+	var (
+		cancellationScenario     cancellationType
+		cancellationScenarioName string
+	)
+	switch randVal := rng.Float64(); {
+	case randVal <= 0.25:
+		cancellationScenario = noCancel
+		cancellationScenarioName = "noCancel"
+	case randVal <= 0.50:
+		cancellationScenario = streamCtxCancel
+		cancellationScenarioName = "streamCtxCancel"
+	case randVal <= 0.75:
+		cancellationScenario = readerCtxCancel
+		cancellationScenarioName = "readerCtxCancel"
+	case randVal <= 1:
+		cancellationScenario = transportBreaks
+		cancellationScenarioName = "transportBreaks"
+	}
+
 	conn, err := grpc.Dial(addr.String(), grpc.WithInsecure())
 	require.NoError(t, err)
-	defer func() { require.NoError(t, conn.Close()) }()
+	if cancellationScenario != transportBreaks {
+		defer func() {
+			require.NoError(t, conn.Close())
+		}()
+	}
 
+	streamCtx, streamCancelFn := context.WithCancel(ctx)
 	client := distsqlpb.NewDistSQLClient(conn)
-	clientStream, err := client.FlowStream(ctx)
+	clientStream, err := client.FlowStream(streamCtx)
 	require.NoError(t, err)
 
 	serverStreamNotification := <-mockServer.InboundStreams
 	serverStream := serverStreamNotification.Stream
 
 	// Do the actual testing.
-	var (
-		typs        = []types.T{types.Int64}
-		rng, _      = randutil.NewPseudoRand()
-		inputBuffer = exec.NewBatchBuffer()
-	)
+	t.Run(fmt.Sprintf("cancellationScenario=%s", cancellationScenarioName), func(t *testing.T) {
+		var (
+			typs        = []types.T{types.Int64}
+			inputBuffer = exec.NewBatchBuffer()
+			// Generate some random behavior before passing the random number
+			// generator to be used in the Outbox goroutine (to avoid races). These
+			// sleep variables enable a sleep for up to half a millisecond with a .25
+			// probability before cancellation.
+			sleepBeforeCancellation = rng.Float64() <= 0.25
+			sleepTime               = time.Microsecond * time.Duration(rng.Intn(500))
+		)
 
-	input := exec.NewRandomDataOp(
-		rng,
 		// Test random selection as the Outbox should be deselecting before sending
 		// over data. Nulls and types are not worth testing as those are tested in
 		// colserde.
-		exec.RandomDataOpArgs{
+		args := exec.RandomDataOpArgs{
 			DeterministicTyps: typs,
+			NumBatches:        64,
 			Selection:         true,
 			BatchAccumulator:  inputBuffer.Add,
-		},
-	)
+		}
 
-	outbox, err := NewOutbox(input, typs)
+		if cancellationScenario != noCancel {
+			// Crank up the number of batches so cancellation always happens in the
+			// middle of execution (or before).
+			args.NumBatches = math.MaxInt64
+			// Disable accumulation to avoid memory blowups.
+			args.BatchAccumulator = nil
+		}
+		input := exec.NewRandomDataOp(rng, args)
+
+		outbox, err := NewOutbox(input, typs, nil)
+		require.NoError(t, err)
+
+		inbox, err := NewInbox(typs)
+		require.NoError(t, err)
+
+		streamHandlerErrCh := handleStream(serverStream.Context(), inbox, serverStream, func() { close(serverStreamNotification.Donec) })
+
+		var (
+			canceled uint32
+			wg       sync.WaitGroup
+		)
+		wg.Add(1)
+		go func() {
+			outbox.runWithStream(streamCtx, clientStream, func() { atomic.StoreUint32(&canceled, 1) })
+			wg.Done()
+		}()
+
+		readerCtx, readerCancelFn := context.WithCancel(ctx)
+		wg.Add(1)
+		go func() {
+			if sleepBeforeCancellation {
+				time.Sleep(sleepTime)
+			}
+			switch cancellationScenario {
+			case noCancel:
+			case streamCtxCancel:
+				streamCancelFn()
+			case readerCtxCancel:
+				readerCancelFn()
+			case transportBreaks:
+				_ = conn.Close()
+			}
+			wg.Done()
+		}()
+
+		// Use a deselector op to verify that the Outbox gets rid of the selection
+		// vector.
+		inputBatches := exec.NewDeselectorOp(inputBuffer, typs)
+		inputBatches.Init()
+		outputBatches := exec.NewBatchBuffer()
+		var readerErr error
+		for {
+			var outputBatch coldata.Batch
+			if err := exec.CatchVectorizedRuntimeError(func() {
+				outputBatch = inbox.Next(readerCtx)
+			}); err != nil {
+				readerErr = err
+				break
+			}
+			if cancellationScenario == noCancel {
+				// Accumulate batches to check for correctness.
+				// Copy batch since it's not safe to reuse after calling Next.
+				batchCopy := coldata.NewMemBatchWithSize(typs, int(outputBatch.Length()))
+				for i := range typs {
+					batchCopy.ColVec(i).Append(outputBatch.ColVec(i), typs[i], 0, outputBatch.Length())
+				}
+				batchCopy.SetLength(outputBatch.Length())
+				outputBatches.Add(batchCopy)
+			}
+			if outputBatch.Length() == 0 {
+				break
+			}
+		}
+
+		// Wait for the Outbox to return, and any cancellation scenario to take
+		// place.
+		wg.Wait()
+		// Make sure the Inbox stream handler returned.
+		streamHandlerErr := <-streamHandlerErrCh
+
+		// Verify expected state.
+		switch cancellationScenario {
+		case noCancel:
+			// Verify that the Outbox terminated gracefully (did not cancel its flow).
+			require.True(t, atomic.LoadUint32(&canceled) == 0)
+			// And the Inbox did as well.
+			require.NoError(t, streamHandlerErr)
+			require.NoError(t, readerErr)
+
+			// If no cancellation happened, the output can be fully verified against
+			// the input.
+			for batchNum := 0; ; batchNum++ {
+				outputBatch := outputBatches.Next(ctx)
+				inputBatch := inputBatches.Next(ctx)
+				for i := range typs {
+					require.Equal(
+						t,
+						inputBatch.ColVec(i).Slice(typs[i], 0, uint64(inputBatch.Length())),
+						outputBatch.ColVec(i).Slice(typs[i], 0, uint64(outputBatch.Length())),
+						"batchNum: %d", batchNum,
+					)
+				}
+				if outputBatch.Length() == 0 {
+					break
+				}
+			}
+		case streamCtxCancel:
+			// If the stream context gets canceled, GRPC should take care of closing
+			// and cleaning up the stream. The Inbox stream handler should have
+			// received the context cancellation and returned.
+			require.Error(t, streamHandlerErr, "context canceled")
+			// The Inbox propagates this cancellation on its host.
+			require.True(t, testutils.IsError(readerErr, "context canceled"), readerErr)
+
+			// Recving on a canceled stream produces a context canceled error, but
+			// Sending produces an EOF, that should have triggered a flow context
+			// cancellation (which is redundant) in the Outbox.
+			require.True(t, atomic.LoadUint32(&canceled) == 1)
+		case readerCtxCancel:
+			// If the reader context gets canceled, the Inbox should have returned
+			// from the stream handler.
+			require.Error(t, streamHandlerErr, "context canceled")
+			// The Inbox should propagate this error upwards.
+			require.True(t, testutils.IsError(readerErr, "context canceled"), readerErr)
+
+			// The cancellation should have been communicated to the Outbox, resulting
+			// in a Send EOF and a flow cancellation on the Outbox's host.
+			require.True(t, atomic.LoadUint32(&canceled) == 1)
+		case transportBreaks:
+			// If the transport breaks, the scenario is very similar to
+			// streamCtxCancel. GRPC will cancel the stream handler's context.
+			require.True(t, testutils.IsError(streamHandlerErr, "context canceled"), streamHandlerErr)
+			require.True(t, testutils.IsError(readerErr, "context canceled"), readerErr)
+
+			require.True(t, atomic.LoadUint32(&canceled) == 1)
+		}
+	})
+}
+
+func TestOutboxInboxMetadataPropagation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	_, mockServer, addr, err := distsqlrun.StartMockDistSQLServer(
+		hlc.NewClock(hlc.UnixNano, time.Nanosecond), stopper, staticNodeID,
+	)
 	require.NoError(t, err)
+
+	conn, err := grpc.Dial(addr.String(), grpc.WithInsecure())
+	require.NoError(t, err)
+	defer func() { require.NoError(t, conn.Close()) }()
+
+	rng, _ := randutil.NewPseudoRand()
+	// numNextsBeforeDrain is used in ExplicitDrainRequest. This number is
+	// generated now to avoid racing on rng accesses between this main goroutine
+	// and the Outbox generating random batches.
+	numNextsBeforeDrain := rng.Intn(10)
+
+	testCases := []struct {
+		name       string
+		numBatches int
+		// test is the body of the test to be run. Metadata should be returned to
+		// be verified.
+		test func(context.Context, *Inbox) []distsqlpb.ProducerMetadata
+	}{
+		{
+			// ExplicitDrainRequest verifies that an Outbox responds to an explicit drain
+			// request even if it is not finished processing data.
+			name: "ExplicitDrainRequest",
+			// Set a high number of batches to ensure that the Outbox is very far
+			// from being finished when it receives a DrainRequest.
+			numBatches: math.MaxInt64,
+			test: func(ctx context.Context, inbox *Inbox) []distsqlpb.ProducerMetadata {
+				// Simulate the inbox flow calling Next an arbitrary amount of times
+				// (including none).
+				for i := 0; i < numNextsBeforeDrain; i++ {
+					inbox.Next(ctx)
+				}
+				return inbox.DrainMeta(ctx)
+			},
+		},
+		{
+			// AfterSuccessfulCompletion is the usual way DrainMeta is called: after
+			// Next has returned a zero batch.
+			name:       "AfterSuccessfulCompletion",
+			numBatches: 4,
+			test: func(ctx context.Context, inbox *Inbox) []distsqlpb.ProducerMetadata {
+				for {
+					b := inbox.Next(ctx)
+					if b.Length() == 0 {
+						break
+					}
+				}
+				return inbox.DrainMeta(ctx)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := distsqlpb.NewDistSQLClient(conn)
+			clientStream, err := client.FlowStream(ctx)
+			require.NoError(t, err)
+
+			var (
+				serverStreamNotification = <-mockServer.InboundStreams
+				serverStream             = serverStreamNotification.Stream
+				typs                     = []types.T{types.Int64}
+				input                    = exec.NewRandomDataOp(
+					rng,
+					exec.RandomDataOpArgs{
+						DeterministicTyps: typs,
+						NumBatches:        tc.numBatches,
+						Selection:         true,
+					},
+				)
+			)
+
+			const expectedMeta = "someError"
+
+			outbox, err := NewOutbox(
+				input,
+				typs,
+				[]distsqlpb.MetadataSource{
+					distsqlpb.CallbackMetadataSource{
+						DrainMetaCb: func(context.Context) []distsqlpb.ProducerMetadata {
+							return []distsqlpb.ProducerMetadata{{Err: errors.New(expectedMeta)}}
+						},
+					},
+				},
+			)
+			require.NoError(t, err)
+
+			inbox, err := NewInbox(typs)
+			require.NoError(t, err)
+
+			var (
+				canceled uint32
+				wg       sync.WaitGroup
+			)
+			wg.Add(1)
+			go func() {
+				outbox.runWithStream(ctx, clientStream, func() { atomic.StoreUint32(&canceled, 1) })
+				wg.Done()
+			}()
+
+			streamHanderErrCh := handleStream(serverStream.Context(), inbox, serverStream, func() { close(serverStreamNotification.Donec) })
+
+			meta := tc.test(ctx, inbox)
+
+			wg.Wait()
+			require.NoError(t, <-streamHanderErrCh)
+			// Require that the outbox did not cancel the flow, this is a graceful
+			// drain.
+			require.True(t, atomic.LoadUint32(&canceled) == 0)
+
+			// Verify that we received the expected metadata.
+			require.True(t, len(meta) == 1)
+			require.True(t, testutils.IsError(meta[0].Err, expectedMeta), meta[0].Err)
+		})
+	}
+}
+
+func BenchmarkOutboxInbox(b *testing.B) {
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	_, mockServer, addr, err := distsqlrun.StartMockDistSQLServer(
+		hlc.NewClock(hlc.UnixNano, time.Nanosecond), stopper, staticNodeID,
+	)
+	require.NoError(b, err)
+
+	conn, err := grpc.Dial(addr.String(), grpc.WithInsecure())
+	require.NoError(b, err)
+	defer func() { require.NoError(b, conn.Close()) }()
+
+	client := distsqlpb.NewDistSQLClient(conn)
+	clientStream, err := client.FlowStream(ctx)
+	require.NoError(b, err)
+
+	serverStreamNotification := <-mockServer.InboundStreams
+	serverStream := serverStreamNotification.Stream
+
+	typs := []types.T{types.Int64}
+
+	batch := coldata.NewMemBatch(typs)
+	batch.SetLength(coldata.BatchSize)
+
+	input := exec.NewRepeatableBatchSource(batch)
+
+	outbox, err := NewOutbox(input, typs, nil /* metadataSources */)
+	require.NoError(b, err)
 
 	inbox, err := NewInbox(typs)
-	require.NoError(t, err)
+	require.NoError(b, err)
 
-	streamHandlerErrCh := handleStream(serverStream.Context(), inbox, serverStream, func() { close(serverStreamNotification.Donec) })
-
-	var (
-		canceled uint32
-		wg       sync.WaitGroup
-	)
+	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		outbox.runWithStream(ctx, clientStream, func() { atomic.StoreUint32(&canceled, 1) })
+		outbox.runWithStream(ctx, clientStream, nil /* cancelFn */)
 		wg.Done()
 	}()
 
-	// Use a deselector op to verify that the Outbox gets rid of the selection
-	// vector.
-	inputBatches := exec.NewDeselectorOp(inputBuffer, typs)
-	inputBatches.Init()
-	outputBatches := exec.NewBatchBuffer()
-	for batchNum := 0; ; batchNum++ {
-		outputBatch := inbox.Next(ctx)
-		// Copy batch since it's not safe to reuse after calling Next.
-		batchCopy := coldata.NewMemBatchWithSize(typs, int(outputBatch.Length()))
-		for i := range typs {
-			batchCopy.ColVec(i).Append(outputBatch.ColVec(i), typs[i], 0, outputBatch.Length())
-		}
-		batchCopy.SetLength(outputBatch.Length())
-		outputBatches.Add(batchCopy)
+	streamHandlerErrCh := handleStream(serverStream.Context(), inbox, serverStream, func() { close(serverStreamNotification.Donec) })
 
-		if outputBatch.Length() == 0 {
-			break
-		}
+	b.SetBytes(8 * coldata.BatchSize)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		inbox.Next(ctx)
 	}
+	b.StopTimer()
 
-	// Wait for the Inbox to return.
-	require.NoError(t, <-streamHandlerErrCh)
-	// Wait for the Outbox to return.
+	// This is a way of telling the Outbox we're satisfied with the data received.
+	meta := inbox.DrainMeta(ctx)
+	require.True(b, len(meta) == 0)
+
+	require.NoError(b, <-streamHandlerErrCh)
 	wg.Wait()
-	// Verify that the Outbox terminated gracefully.
-	require.True(t, atomic.LoadUint32(&canceled) == 0)
-
-	for batchNum := 0; ; batchNum++ {
-		inputBatch := inputBatches.Next(ctx)
-		outputBatch := outputBatches.Next(ctx)
-		for i := range typs {
-			require.Equal(
-				t,
-				inputBatch.ColVec(i).Slice(typs[i], 0, uint64(inputBatch.Length())),
-				outputBatch.ColVec(i).Slice(typs[i], 0, uint64(outputBatch.Length())),
-				"batchNum: %d", batchNum,
-			)
-		}
-		if outputBatch.Length() == 0 {
-			break
-		}
-	}
 }

--- a/pkg/sql/exec/colrpc/inbox.go
+++ b/pkg/sql/exec/colrpc/inbox.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/apache/arrow/go/arrow/array"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/colserde"
@@ -53,7 +52,10 @@ type Inbox struct {
 	converter  *colserde.ArrowBatchConverter
 	serializer *colserde.RecordBatchSerializer
 
+	// initialized and done prevent double initialization/closing. Should not be
+	// used by the RunWithStream goroutine.
 	initialized bool
+	done        bool
 	// stream is the RPC stream. It is set when RunWithStream is called but only
 	// the Next goroutine may access it.
 	stream flowStreamServer
@@ -65,10 +67,15 @@ type Inbox struct {
 	// cancellation.
 	contextCh chan context.Context
 
-	// errCh is that channel that RunWithStream will block on, waiting until Next
-	// encounters an exit condition. An error will only be sent on this channel
-	// in the event of a cancellation.
+	// errCh is that channel that RunWithStream will block on, waiting until the
+	// Inbox does not need a stream any more. An error will only be sent on this
+	// channel in the event of a cancellation or a non-io.EOF error originating
+	// from a stream.Recv.
 	errCh chan error
+
+	// bufferedMeta buffers any metadata found in Next when reading from the
+	// stream and is returned by DrainMeta.
+	bufferedMeta []distsqlpb.ProducerMetadata
 
 	scratch struct {
 		data []*array.Data
@@ -84,17 +91,31 @@ func NewInbox(typs []types.T) (*Inbox, error) {
 		return nil, err
 	}
 	i := &Inbox{
-		typs:       typs,
-		zeroBatch:  coldata.NewMemBatchWithSize(typs, 0),
-		converter:  colserde.NewArrowBatchConverter(typs),
-		serializer: s,
-		streamCh:   make(chan flowStreamServer, 1),
-		contextCh:  make(chan context.Context, 1),
-		errCh:      make(chan error, 1),
+		typs:         typs,
+		zeroBatch:    coldata.NewMemBatchWithSize(typs, 0),
+		converter:    colserde.NewArrowBatchConverter(typs),
+		serializer:   s,
+		streamCh:     make(chan flowStreamServer, 1),
+		contextCh:    make(chan context.Context, 1),
+		errCh:        make(chan error, 1),
+		bufferedMeta: make([]distsqlpb.ProducerMetadata, 0),
 	}
 	i.zeroBatch.SetLength(0)
 	i.scratch.data = make([]*array.Data, len(typs))
 	return i, nil
+}
+
+// maybeInit calls Inbox.init if the inbox is not initialized and returns an
+// error if the initialization was not successful. Usually this is because the
+// given context is canceled before the remote stream arrives.
+func (i *Inbox) maybeInit(ctx context.Context) error {
+	if !i.initialized {
+		if err := i.init(ctx); err != nil {
+			return err
+		}
+		i.initialized = true
+	}
+	return nil
 }
 
 // init initializes the Inbox for operation by blocking until RunWithStream
@@ -102,17 +123,26 @@ func NewInbox(typs []types.T) (*Inbox, error) {
 // arrives (to allow for unblocking the wait for a stream), at which point
 // ownership is transferred to RunWithStream. This should only be called from
 // the reader goroutine when it needs a stream.
-func (i *Inbox) init(ctx context.Context) bool {
+func (i *Inbox) init(ctx context.Context) error {
 	// Wait for the stream to be initialized. We're essentially waiting for the
 	// remote connection.
 	select {
 	case i.stream = <-i.streamCh:
 	case <-ctx.Done():
 		i.errCh <- fmt.Errorf("%s: Inbox while waiting for stream", ctx.Err())
-		return false
+		return ctx.Err()
 	}
 	i.contextCh <- ctx
-	return true
+	return nil
+}
+
+// close closes the inbox, ensuring that any call to RunWithStream will return
+// immediately. close is idempotent.
+func (i *Inbox) close() {
+	if !i.done {
+		i.done = true
+		close(i.errCh)
+	}
 }
 
 // RunWithStream sets the Inbox's stream and waits until either streamCtx is
@@ -157,47 +187,103 @@ func (i *Inbox) Init() {}
 // For simplicity, the Inbox will only listen for cancellation of the context
 // passed in to the first Next call.
 func (i *Inbox) Next(ctx context.Context) coldata.Batch {
+	if i.done {
+		return i.zeroBatch
+	}
+
 	defer func() {
 		// Catch any panics that occur and close the errCh in order to not leak the
 		// goroutine listening for context cancellation. errCh must still be closed
 		// during normal termination.
 		if err := recover(); err != nil {
-			close(i.errCh)
+			i.close()
 			panic(err)
 		}
 	}()
 
-	// NOTE: It is very important to close i.errCh on termination of execution
-	// (normally or when panicking), otherwise we might leak RunWithStream.
-	if !i.initialized {
-		if !i.init(ctx) {
-			close(i.errCh)
-			return i.zeroBatch
-		}
-		i.initialized = true
+	// NOTE: It is very important to close i.errCh only when execution terminates
+	// ungracefully. DrainMeta will use the stream to read any remaining metadata
+	// after Next returns a zero-length batch during normal execution.
+	if err := i.maybeInit(ctx); err != nil {
+		panic(err)
 	}
 
-	m, err := i.stream.Recv()
-	if err != nil {
-		if err == io.EOF {
-			close(i.errCh)
-			return i.zeroBatch
+	for {
+		m, err := i.stream.Recv()
+		if err != nil {
+			if err == io.EOF {
+				// Done.
+				i.close()
+				return i.zeroBatch
+			}
+			i.errCh <- err
+			panic(err)
 		}
-		panic(err)
+		if len(m.Data.Metadata) != 0 {
+			for _, rpm := range m.Data.Metadata {
+				meta, ok := distsqlpb.RemoteProducerMetaToLocalMeta(rpm)
+				if !ok {
+					continue
+				}
+				i.bufferedMeta = append(i.bufferedMeta, meta)
+			}
+			// Continue until we get the next batch or EOF.
+			continue
+		}
+		if len(m.Data.RawBytes) == 0 {
+			// Protect against Deserialization panics by skipping empty messages.
+			// TODO(asubiotto): I don't think we're using NumEmptyRows, right?
+			continue
+		}
+		i.scratch.data = i.scratch.data[:0]
+		if err := i.serializer.Deserialize(&i.scratch.data, m.Data.RawBytes); err != nil {
+			panic(err)
+		}
+		b, err := i.converter.ArrowToBatch(i.scratch.data)
+		if err != nil {
+			panic(err)
+		}
+		return b
 	}
-	i.scratch.data = i.scratch.data[:0]
-	if err := i.serializer.Deserialize(&i.scratch.data, m.Data.RawBytes); err != nil {
-		panic(err)
-	}
-	b, err := i.converter.ArrowToBatch(i.scratch.data)
-	if err != nil {
-		panic(err)
-	}
-	return b
 }
 
-// DrainMeta is part of the MetadataGenerator interface.
-// TODO(asubiotto): Implement this.
-func (i *Inbox) DrainMeta(context.Context) []distsqlrun.ProducerMetadata {
-	return nil
+// DrainMeta is part of the MetadataGenerator interface. DrainMeta may not be
+// called concurrently with Next.
+func (i *Inbox) DrainMeta(ctx context.Context) []distsqlpb.ProducerMetadata {
+	allMeta := i.bufferedMeta
+	i.bufferedMeta = i.bufferedMeta[:0]
+
+	if i.done {
+		return allMeta
+	}
+
+	defer i.close()
+	if err := i.maybeInit(ctx); err != nil {
+		log.Warningf(ctx, "Inbox unable to initialize stream while draining metadata: %s", err)
+		return allMeta
+	}
+	log.VEvent(ctx, 2, "Inbox sending drain signal to Outbox")
+	if err := i.stream.Send(&distsqlpb.ConsumerSignal{DrainRequest: &distsqlpb.DrainRequest{}}); err != nil {
+		log.Warningf(ctx, "Inbox unable to send drain signal to Outbox: %s", err)
+		return allMeta
+	}
+	for {
+		msg, err := i.stream.Recv()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			log.Warningf(ctx, "Inbox Recv connection error while draining metadata: %s", err)
+			return allMeta
+		}
+		for _, remoteMeta := range msg.Data.Metadata {
+			meta, ok := distsqlpb.RemoteProducerMetaToLocalMeta(remoteMeta)
+			if !ok {
+				continue
+			}
+			allMeta = append(allMeta, meta)
+		}
+	}
+
+	return allMeta
 }

--- a/pkg/sql/exec/colrpc/main_test.go
+++ b/pkg/sql/exec/colrpc/main_test.go
@@ -1,0 +1,27 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package colrpc
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestMain(m *testing.M) {
+	randutil.SeedForTests()
+	os.Exit(m.Run())
+}

--- a/pkg/sql/exec/colrpc/outbox_test.go
+++ b/pkg/sql/exec/colrpc/outbox_test.go
@@ -16,10 +16,15 @@ package colrpc
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/stretchr/testify/require"
 )
@@ -30,21 +35,107 @@ func TestOutboxCatchesPanics(t *testing.T) {
 	var (
 		ctx      = context.Background()
 		input    = exec.NewBatchBuffer()
+		typs     = []types.T{types.Int64}
 		rpcLayer = makeMockFlowStreamRPCLayer()
 	)
-	outbox, err := NewOutbox(input, []types.T{types.Int64})
+	outbox, err := NewOutbox(input, typs, nil)
 	require.NoError(t, err)
 
 	// This test relies on the fact that BatchBuffer panics when there are no
 	// batches to return. Verify this assumption.
 	require.Panics(t, func() { input.Next(ctx) })
 
-	// Close the client csChan so that the Outbox's Recv goroutine returns.
-	close(rpcLayer.client.csChan)
-
 	// The actual test verifies that the Outbox handles input execution tree
 	// panics by not panicking and returning.
-	// TODO(asubiotto): Extend this test by verifying that the Outbox sends this
-	// error as metadata to an Inbox.
-	require.NotPanics(t, func() { outbox.runWithStream(ctx, rpcLayer.client, nil /* cancelFn */) })
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		outbox.runWithStream(ctx, rpcLayer.client, nil /* cancelFn */)
+		wg.Done()
+	}()
+
+	inbox, err := NewInbox(typs)
+	require.NoError(t, err)
+
+	streamHandlerErrCh := handleStream(ctx, inbox, rpcLayer.server, func() { close(rpcLayer.server.csChan) })
+
+	// The outbox will be sending the panic as metadata eagerly. This Next call
+	// is valid, but should return a zero-length batch, indicating that the caller
+	// should call DrainMeta.
+	require.True(t, inbox.Next(ctx).Length() == 0)
+
+	// Expect the panic as an error in DrainMeta.
+	meta := inbox.DrainMeta(ctx)
+
+	require.True(t, len(meta) == 1)
+	require.True(t, testutils.IsError(meta[0].Err, "panic"), meta[0])
+
+	require.NoError(t, <-streamHandlerErrCh)
+	wg.Wait()
+}
+
+func TestOutboxDrainsMetadataSources(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	var (
+		ctx   = context.Background()
+		input = exec.NewBatchBuffer()
+		typs  = []types.T{types.Int64}
+	)
+
+	// Define common function that returns both an Outbox and a pointer to a
+	// uint32 that is set atomically when the outbox drains a metadata source.
+	newOutboxWithMetaSources := func() (*Outbox, *uint32, error) {
+		var sourceDrained uint32
+		outbox, err := NewOutbox(
+			input,
+			typs,
+			[]distsqlpb.MetadataSource{
+				distsqlpb.CallbackMetadataSource{
+					DrainMetaCb: func(context.Context) []distsqlpb.ProducerMetadata {
+						atomic.StoreUint32(&sourceDrained, 1)
+						return nil
+					},
+				},
+			},
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		return outbox, &sourceDrained, nil
+	}
+
+	t.Run("AfterSuccessfulRun", func(t *testing.T) {
+		rpcLayer := makeMockFlowStreamRPCLayer()
+		outbox, sourceDrained, err := newOutboxWithMetaSources()
+		require.NoError(t, err)
+
+		b := coldata.NewMemBatch(typs)
+		b.SetLength(0)
+		input.Add(b)
+
+		// Close the csChan to unblock the Recv goroutine (we don't need it for this
+		// test).
+		close(rpcLayer.client.csChan)
+		outbox.runWithStream(ctx, rpcLayer.client, nil /* cancelFn */)
+
+		require.True(t, atomic.LoadUint32(sourceDrained) == 1)
+	})
+
+	// This is similar to TestOutboxCatchesPanics, but focuses on verifying that
+	// the Outbox drains its metadata sources even after an error.
+	t.Run("AfterOutboxError", func(t *testing.T) {
+		// This test, similar to TestOutboxCatchesPanics, relies on the fact that
+		// a BatchBuffer panics when there are no batches to return.
+		require.Panics(t, func() { input.Next(ctx) })
+
+		rpcLayer := makeMockFlowStreamRPCLayer()
+		outbox, sourceDrained, err := newOutboxWithMetaSources()
+		require.NoError(t, err)
+
+		close(rpcLayer.client.csChan)
+		outbox.runWithStream(ctx, rpcLayer.client, nil /* cancelFn */)
+
+		require.True(t, atomic.LoadUint32(sourceDrained) == 1)
+	})
 }

--- a/pkg/sql/exec/deselector_test.go
+++ b/pkg/sql/exec/deselector_test.go
@@ -105,7 +105,7 @@ func BenchmarkDeselector(b *testing.B) {
 				batch.SetSelection(true)
 				copy(batch.Selection(), sel)
 				batch.SetLength(batchLen)
-				input := newRepeatableBatchSource(batch)
+				input := NewRepeatableBatchSource(batch)
 				op := NewDeselectorOp(input, inputTypes)
 				op.Init()
 				b.ResetTimer()

--- a/pkg/sql/exec/distinct_test.go
+++ b/pkg/sql/exec/distinct_test.go
@@ -107,7 +107,7 @@ func BenchmarkSortedDistinct(b *testing.B) {
 		bCol[i] = lastB
 	}
 	batch.SetLength(coldata.BatchSize)
-	source := newRepeatableBatchSource(batch)
+	source := NewRepeatableBatchSource(batch)
 	source.Init()
 
 	distinct, err := NewOrderedDistinct(source, []uint32{1, 2}, []types.T{types.Int64, types.Int64, types.Int64})

--- a/pkg/sql/exec/hashjoiner_test.go
+++ b/pkg/sql/exec/hashjoiner_test.go
@@ -797,7 +797,7 @@ func BenchmarkHashJoiner(b *testing.B) {
 									b.ResetTimer()
 									for i := 0; i < b.N; i++ {
 										leftSource := newFiniteBatchSource(batch, nBatches)
-										rightSource := newRepeatableBatchSource(batch)
+										rightSource := NewRepeatableBatchSource(batch)
 
 										spec := hashJoinerSpec{
 											left: hashJoinerSourceSpec{

--- a/pkg/sql/exec/like_ops_test.go
+++ b/pkg/sql/exec/like_ops_test.go
@@ -98,7 +98,7 @@ func BenchmarkLikeOps(b *testing.B) {
 	}
 
 	batch.SetLength(coldata.BatchSize)
-	source := newRepeatableBatchSource(batch)
+	source := NewRepeatableBatchSource(batch)
 	source.Init()
 
 	prefixOp := &selPrefixBytesBytesConstOp{

--- a/pkg/sql/exec/offset_test.go
+++ b/pkg/sql/exec/offset_test.go
@@ -71,7 +71,7 @@ func BenchmarkOffset(b *testing.B) {
 	ctx := context.Background()
 	batch := coldata.NewMemBatch([]types.T{types.Int64, types.Int64, types.Int64})
 	batch.SetLength(coldata.BatchSize)
-	source := newRepeatableBatchSource(batch)
+	source := NewRepeatableBatchSource(batch)
 	source.Init()
 
 	o := NewOffsetOp(source, 1)

--- a/pkg/sql/exec/operator.go
+++ b/pkg/sql/exec/operator.go
@@ -33,6 +33,8 @@ type Operator interface {
 	//
 	// Calling Next may invalidate the contents of the last Batch returned by
 	// Next.
+	// Canceling the provided context results in forceful termination of
+	// execution.
 	Next(context.Context) coldata.Batch
 }
 

--- a/pkg/sql/exec/orderedsynchronizer_test.go
+++ b/pkg/sql/exec/orderedsynchronizer_test.go
@@ -241,7 +241,7 @@ func BenchmarkOrderedSynchronizer(b *testing.B) {
 
 	inputs := make([]Operator, len(batches))
 	for i := range batches {
-		inputs[i] = newRepeatableBatchSource(batches[i])
+		inputs[i] = NewRepeatableBatchSource(batches[i])
 	}
 
 	op := orderedSynchronizer{

--- a/pkg/sql/exec/projection_ops_test.go
+++ b/pkg/sql/exec/projection_ops_test.go
@@ -82,7 +82,7 @@ func benchmarkProjPlusInt64Int64ConstOp(b *testing.B, useSelectionVector bool, h
 			sel[i] = uint16(i)
 		}
 	}
-	source := newRepeatableBatchSource(batch)
+	source := NewRepeatableBatchSource(batch)
 	source.Init()
 
 	plusOp := &projPlusInt64Int64ConstOp{
@@ -181,7 +181,7 @@ func benchmarkProjPlusInt64Int64Op(b *testing.B, useSelectionVector bool, hasNul
 			sel[i] = uint16(i)
 		}
 	}
-	source := newRepeatableBatchSource(batch)
+	source := NewRepeatableBatchSource(batch)
 	source.Init()
 
 	plusOp := &projPlusInt64Int64Op{

--- a/pkg/sql/exec/routers_test.go
+++ b/pkg/sql/exec/routers_test.go
@@ -519,7 +519,7 @@ func TestHashRouterCancellation(t *testing.T) {
 	// Never-ending input of 0s.
 	batch := coldata.NewMemBatch([]types.T{types.Int64})
 	batch.SetLength(coldata.BatchSize)
-	in := newRepeatableBatchSource(batch)
+	in := NewRepeatableBatchSource(batch)
 
 	unbufferedCh := make(chan struct{})
 	r := newHashRouterWithOutputs(in, []types.T{types.Int64}, []int{0}, unbufferedCh, outputs)
@@ -778,7 +778,7 @@ func BenchmarkHashRouter(b *testing.B) {
 	// numbers.
 	batch := coldata.NewMemBatch(types)
 	batch.SetLength(coldata.BatchSize)
-	input := newRepeatableBatchSource(batch)
+	input := NewRepeatableBatchSource(batch)
 
 	var wg sync.WaitGroup
 	for _, numOutputs := range []int{2, 4, 8, 16} {

--- a/pkg/sql/exec/selection_ops_test.go
+++ b/pkg/sql/exec/selection_ops_test.go
@@ -132,7 +132,7 @@ func benchmarkSelLTInt64Int64ConstOp(b *testing.B, useSelectionVector bool, hasN
 			sel[i] = uint16(i)
 		}
 	}
-	source := newRepeatableBatchSource(batch)
+	source := NewRepeatableBatchSource(batch)
 	source.Init()
 
 	plusOp := &selLTInt64Int64ConstOp{
@@ -190,7 +190,7 @@ func benchmarkSelLTInt64Int64Op(b *testing.B, useSelectionVector bool, hasNulls 
 			sel[i] = uint16(i)
 		}
 	}
-	source := newRepeatableBatchSource(batch)
+	source := NewRepeatableBatchSource(batch)
 	source.Init()
 
 	plusOp := &selLTInt64Int64Op{

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -26,7 +26,7 @@ import (
 )
 
 type metadataForwarder interface {
-	forwardMetadata(metadata *distsqlrun.ProducerMetadata)
+	forwardMetadata(metadata *distsqlpb.ProducerMetadata)
 }
 
 type planNodeToRowSource struct {
@@ -132,7 +132,7 @@ func (p *planNodeToRowSource) InternalClose() {
 	}
 }
 
-func (p *planNodeToRowSource) Next() (sqlbase.EncDatumRow, *distsqlrun.ProducerMetadata) {
+func (p *planNodeToRowSource) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata) {
 	if p.State == distsqlrun.StateRunning && p.fastPath {
 		var count int
 		// If our node is a "fast path node", it means that we're set up to just
@@ -211,6 +211,6 @@ func (p *planNodeToRowSource) IsException() bool {
 // that need to forward metadata to the end of the flow. They can't pass
 // metadata through local processors, so they instead add the metadata to our
 // trailing metadata and expect us to forward it further.
-func (p *planNodeToRowSource) forwardMetadata(metadata *distsqlrun.ProducerMetadata) {
+func (p *planNodeToRowSource) forwardMetadata(metadata *distsqlpb.ProducerMetadata) {
 	p.ProcessorBase.AppendTrailingMeta(*metadata)
 }

--- a/pkg/sql/row_source_to_plan_node.go
+++ b/pkg/sql/row_source_to_plan_node.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -74,7 +75,7 @@ func (r *rowSourceToPlanNode) startExec(params runParams) error {
 
 func (r *rowSourceToPlanNode) Next(params runParams) (bool, error) {
 	for {
-		var p *distsqlrun.ProducerMetadata
+		var p *distsqlpb.ProducerMetadata
 		r.row, p = r.source.Next()
 
 		if p != nil {


### PR DESCRIPTION
This commit adds metadata propagation from an Outbox to an Inbox. In
case of an error or graceful termination, the Outbox will drain its
given metadata sources (similar to the Materializer) and send this
metadata over. Inbox implements the MetadataSource interface to expose
this metadata to its local flow.

Cancellation tests are also added with an accompanying description of
the expected behavior.

Release note: None

The first four commits are miscellaneous code movement and testing utility additions and bug fixes.

Closes #37224 

cc @yuzefovich @solongordon 