### PR TITLE
sql: use UnresolvedObjectName in various statements

### DIFF
--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -194,7 +194,12 @@ type importSequenceOperators struct {
 func (so *importSequenceOperators) ParseQualifiedTableName(
 	ctx context.Context, sql string,
 ) (*tree.TableName, error) {
-	return parser.ParseTableName(sql)
+	name, err := parser.ParseTableName(sql)
+	if err != nil {
+		return nil, err
+	}
+	tn := name.ToTableName()
+	return &tn, nil
 }
 
 // Implements the tree.EvalDatabase interface.

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -611,7 +611,7 @@ func (m *pgDumpReader) readFile(
 			if err != nil {
 				break
 			}
-			seq := m.descs[name.Table()]
+			seq := m.descs[name.Parts[0]]
 			if seq == nil {
 				break
 			}

--- a/pkg/internal/sqlsmith/alter.go
+++ b/pkg/internal/sqlsmith/alter.go
@@ -93,9 +93,16 @@ func makeRenameTable(s *scope) (tree.Statement, bool) {
 		return nil, false
 	}
 
+	newName, err := tree.NewUnresolvedObjectName(
+		1 /* numParts */, [3]string{string(s.schema.name("tab"))}, tree.NoAnnotation,
+	)
+	if err != nil {
+		return nil, false
+	}
+
 	return &tree.RenameTable{
-		Name:    *tableRef.TableName,
-		NewName: tree.MakeUnqualifiedTableName(s.schema.name("tab")),
+		Name:    tableRef.TableName.ToUnresolvedObjectName(),
+		NewName: newName,
 	}, true
 }
 

--- a/pkg/sql/alter_sequence.go
+++ b/pkg/sql/alter_sequence.go
@@ -29,7 +29,9 @@ type alterSequenceNode struct {
 
 // AlterSequence transforms a tree.AlterSequence into a plan node.
 func (p *planner) AlterSequence(ctx context.Context, n *tree.AlterSequence) (planNode, error) {
-	seqDesc, err := p.ResolveMutableTableDescriptor(ctx, &n.Name, !n.IfExists, ResolveRequireSequenceDesc)
+	seqDesc, err := p.ResolveMutableTableDescriptorEx(
+		ctx, n.Name, !n.IfExists, ResolveRequireSequenceDesc,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +71,7 @@ func (n *alterSequenceNode) startExec(params runParams) error {
 			SequenceName string
 			Statement    string
 			User         string
-		}{n.n.Name.FQString(), n.n.String(), params.SessionData().User},
+		}{params.p.ResolvedName(n.n.Name).FQString(), n.n.String(), params.SessionData().User},
 	)
 }
 

--- a/pkg/sql/comment_on_table.go
+++ b/pkg/sql/comment_on_table.go
@@ -32,7 +32,7 @@ type commentOnTableNode struct {
 //   notes: postgres requires CREATE on the table.
 //          mysql requires ALTER, CREATE, INSERT on the table.
 func (p *planner) CommentOnTable(ctx context.Context, n *tree.CommentOnTable) (planNode, error) {
-	tableDesc, err := p.ResolveUncachedTableDescriptor(ctx, &n.Table, true, ResolveRequireTableDesc)
+	tableDesc, err := p.ResolveUncachedTableDescriptorEx(ctx, n.Table, true, ResolveRequireTableDesc)
 	if err != nil {
 		return nil, err
 	}
@@ -82,10 +82,11 @@ func (n *commentOnTableNode) startExec(params runParams) error {
 			User      string
 			Comment   *string
 		}{
-			n.n.Table.FQString(),
+			params.p.ResolvedName(n.n.Table).FQString(),
 			n.n.String(),
 			params.SessionData().User,
-			n.n.Comment},
+			n.n.Comment,
+		},
 	)
 }
 

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -156,7 +156,7 @@ func (n *createStatsNode) makeJobRecord(ctx context.Context) (*jobs.Record, erro
 	var err error
 	switch t := n.Table.(type) {
 	case *tree.UnresolvedObjectName:
-		tableDesc, err = n.p.ResolveExistingObjectEx(ctx, n.p, t, true /*required*/, ResolveRequireTableDesc)
+		tableDesc, err = n.p.ResolveExistingObjectEx(ctx, t, true /*required*/, ResolveRequireTableDesc)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -155,15 +155,12 @@ func (n *createStatsNode) makeJobRecord(ctx context.Context) (*jobs.Record, erro
 	var fqTableName string
 	var err error
 	switch t := n.Table.(type) {
-	case *tree.TableName:
-		// TODO(anyone): if CREATE STATISTICS is meant to be able to operate
-		// within a transaction, then the following should probably run with
-		// caching disabled, like other DDL statements.
-		tableDesc, err = ResolveExistingObject(ctx, n.p, t, true /*required*/, ResolveRequireTableDesc)
+	case *tree.UnresolvedObjectName:
+		tableDesc, err = n.p.ResolveExistingObjectEx(ctx, n.p, t, true /*required*/, ResolveRequireTableDesc)
 		if err != nil {
 			return nil, err
 		}
-		fqTableName = t.FQString()
+		fqTableName = n.p.ResolvedName(t).FQString()
 
 	case *tree.TableRef:
 		flags := ObjectLookupFlags{CommonLookupFlags: CommonLookupFlags{

--- a/pkg/sql/delegate/delegate.go
+++ b/pkg/sql/delegate/delegate.go
@@ -49,8 +49,8 @@ func TryDelegate(
 	case *tree.ShowCreate:
 		return d.delegateShowCreate(t)
 
-	case *tree.ShowIndex:
-		return d.delegateShowIndex(t)
+	case *tree.ShowIndexes:
+		return d.delegateShowIndexes(t)
 
 	case *tree.ShowColumns:
 		return d.delegateShowColumns(t)

--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -247,7 +247,7 @@ func ParseTableIndexName(sql string) (tree.TableIndexName, error) {
 }
 
 // ParseTableName parses a table name.
-func ParseTableName(sql string) (*tree.TableName, error) {
+func ParseTableName(sql string) (*tree.UnresolvedObjectName, error) {
 	// We wrap the name we want to parse into a dummy statement since our parser
 	// can only parse full statements.
 	stmt, err := ParseOne(fmt.Sprintf("ALTER TABLE %s RENAME TO x", sql))
@@ -258,7 +258,7 @@ func ParseTableName(sql string) (*tree.TableName, error) {
 	if !ok {
 		return nil, pgerror.AssertionFailedf("expected an ALTER TABLE statement, but found %T", stmt)
 	}
-	return &rename.Name, nil
+	return rename.Name, nil
 }
 
 // parseExprs parses one or more sql expressions.

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4834,42 +4834,42 @@ alter_user_password_stmt:
 alter_rename_table_stmt:
   ALTER TABLE relation_expr RENAME TO table_name
   {
-    name := $3.unresolvedObjectName().ToTableName()
-    newName := $6.unresolvedObjectName().ToTableName()
+    name := $3.unresolvedObjectName()
+    newName := $6.unresolvedObjectName()
     $$.val = &tree.RenameTable{Name: name, NewName: newName, IfExists: false, IsView: false}
   }
 | ALTER TABLE IF EXISTS relation_expr RENAME TO table_name
   {
-    name := $5.unresolvedObjectName().ToTableName()
-    newName := $8.unresolvedObjectName().ToTableName()
+    name := $5.unresolvedObjectName()
+    newName := $8.unresolvedObjectName()
     $$.val = &tree.RenameTable{Name: name, NewName: newName, IfExists: true, IsView: false}
   }
 
 alter_rename_view_stmt:
   ALTER VIEW relation_expr RENAME TO view_name
   {
-    name := $3.unresolvedObjectName().ToTableName()
-    newName := $6.unresolvedObjectName().ToTableName()
+    name := $3.unresolvedObjectName()
+    newName := $6.unresolvedObjectName()
     $$.val = &tree.RenameTable{Name: name, NewName: newName, IfExists: false, IsView: true}
   }
 | ALTER VIEW IF EXISTS relation_expr RENAME TO view_name
   {
-    name := $5.unresolvedObjectName().ToTableName()
-    newName := $8.unresolvedObjectName().ToTableName()
+    name := $5.unresolvedObjectName()
+    newName := $8.unresolvedObjectName()
     $$.val = &tree.RenameTable{Name: name, NewName: newName, IfExists: true, IsView: true}
   }
 
 alter_rename_sequence_stmt:
   ALTER SEQUENCE relation_expr RENAME TO sequence_name
   {
-    name := $3.unresolvedObjectName().ToTableName()
-    newName := $6.unresolvedObjectName().ToTableName()
+    name := $3.unresolvedObjectName()
+    newName := $6.unresolvedObjectName()
     $$.val = &tree.RenameTable{Name: name, NewName: newName, IfExists: false, IsSequence: true}
   }
 | ALTER SEQUENCE IF EXISTS relation_expr RENAME TO sequence_name
   {
-    name := $5.unresolvedObjectName().ToTableName()
-    newName := $8.unresolvedObjectName().ToTableName()
+    name := $5.unresolvedObjectName()
+    newName := $8.unresolvedObjectName()
     $$.val = &tree.RenameTable{Name: name, NewName: newName, IfExists: true, IsSequence: true}
   }
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2003,8 +2003,7 @@ comment_stmt:
   }
 | COMMENT ON TABLE table_name IS comment_text
   {
-    name := $4.unresolvedObjectName().ToTableName()
-    $$.val = &tree.CommentOnTable{Table: name, Comment: $6.strPtr()}
+    $$.val = &tree.CommentOnTable{Table: $4.unresolvedObjectName(), Comment: $6.strPtr()}
   }
 | COMMENT ON COLUMN column_path IS comment_text
   {

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3200,14 +3200,12 @@ session_var:
 show_stats_stmt:
   SHOW STATISTICS FOR TABLE table_name
   {
-    name := $5.unresolvedObjectName().ToTableName()
-    $$.val = &tree.ShowTableStats{Table: name}
+    $$.val = &tree.ShowTableStats{Table: $5.unresolvedObjectName()}
   }
 | SHOW STATISTICS USING JSON FOR TABLE table_name
   {
     /* SKIP DOC */
-    name := $7.unresolvedObjectName().ToTableName()
-    $$.val = &tree.ShowTableStats{Table: name, UsingJSON: true}
+    $$.val = &tree.ShowTableStats{Table: $7.unresolvedObjectName(), UsingJSON: true}
   }
 | SHOW STATISTICS error // SHOW HELP: SHOW STATISTICS
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3287,8 +3287,7 @@ show_csettings_stmt:
 show_columns_stmt:
   SHOW COLUMNS FROM table_name with_comment
   {
-    name := $4.unresolvedObjectName().ToTableName()
-    $$.val = &tree.ShowColumns{Table: name, WithComment: $5.bool()}
+    $$.val = &tree.ShowColumns{Table: $4.unresolvedObjectName(), WithComment: $5.bool()}
   }
 | SHOW COLUMNS error // SHOW HELP: SHOW COLUMNS
 
@@ -3331,20 +3330,17 @@ show_grants_stmt:
 show_indexes_stmt:
   SHOW INDEX FROM table_name
   {
-    name := $4.unresolvedObjectName().ToTableName()
-    $$.val = &tree.ShowIndex{Table: name}
+    $$.val = &tree.ShowIndexes{Table: $4.unresolvedObjectName()}
   }
 | SHOW INDEX error // SHOW HELP: SHOW INDEXES
 | SHOW INDEXES FROM table_name
   {
-    name := $4.unresolvedObjectName().ToTableName()
-    $$.val = &tree.ShowIndex{Table: name}
+    $$.val = &tree.ShowIndexes{Table: $4.unresolvedObjectName()}
   }
 | SHOW INDEXES error // SHOW HELP: SHOW INDEXES
 | SHOW KEYS FROM table_name
   {
-    name := $4.unresolvedObjectName().ToTableName()
-    $$.val = &tree.ShowIndex{Table: name}
+    $$.val = &tree.ShowIndexes{Table: $4.unresolvedObjectName()}
   }
 | SHOW KEYS error // SHOW HELP: SHOW INDEXES
 
@@ -3355,14 +3351,12 @@ show_indexes_stmt:
 show_constraints_stmt:
   SHOW CONSTRAINT FROM table_name
   {
-    name := $4.unresolvedObjectName().ToTableName()
-    $$.val = &tree.ShowConstraints{Table: name}
+    $$.val = &tree.ShowConstraints{Table: $4.unresolvedObjectName()}
   }
 | SHOW CONSTRAINT error // SHOW HELP: SHOW CONSTRAINTS
 | SHOW CONSTRAINTS FROM table_name
   {
-    name := $4.unresolvedObjectName().ToTableName()
-    $$.val = &tree.ShowConstraints{Table: name}
+    $$.val = &tree.ShowConstraints{Table: $4.unresolvedObjectName()}
   }
 | SHOW CONSTRAINTS error // SHOW HELP: SHOW CONSTRAINTS
 
@@ -3551,14 +3545,12 @@ show_transaction_stmt:
 show_create_stmt:
   SHOW CREATE table_name
   {
-    name := $3.unresolvedObjectName().ToTableName()
-    $$.val = &tree.ShowCreate{Name: name}
+    $$.val = &tree.ShowCreate{Name: $3.unresolvedObjectName()}
   }
 | SHOW CREATE create_kw table_name
   {
     /* SKIP DOC */
-    name := $4.unresolvedObjectName().ToTableName()
-    $$.val = &tree.ShowCreate{Name: name}
+    $$.val = &tree.ShowCreate{Name: $4.unresolvedObjectName()}
   }
 | SHOW CREATE error // SHOW HELP: SHOW CREATE
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2151,8 +2151,7 @@ opt_stats_columns:
 create_stats_target:
   table_name
   {
-    name := $1.unresolvedObjectName().ToTableName()
-    $$.val = &name
+    $$.val = $1.unresolvedObjectName()
   }
 | '[' iconst64 ']'
   {

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1170,13 +1170,11 @@ alter_sequence_stmt:
 alter_sequence_options_stmt:
   ALTER SEQUENCE sequence_name sequence_option_list
   {
-    name := $3.unresolvedObjectName().ToTableName()
-    $$.val = &tree.AlterSequence{Name: name, Options: $4.seqOpts(), IfExists: false}
+    $$.val = &tree.AlterSequence{Name: $3.unresolvedObjectName(), Options: $4.seqOpts(), IfExists: false}
   }
 | ALTER SEQUENCE IF EXISTS sequence_name sequence_option_list
   {
-    name := $5.unresolvedObjectName().ToTableName()
-    $$.val = &tree.AlterSequence{Name: name, Options: $6.seqOpts(), IfExists: true}
+    $$.val = &tree.AlterSequence{Name: $5.unresolvedObjectName(), Options: $6.seqOpts(), IfExists: true}
   }
 
 // %Help: ALTER USER - change user properties

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2835,10 +2835,9 @@ scrub_database_stmt:
 scrub_table_stmt:
   EXPERIMENTAL SCRUB TABLE table_name opt_as_of_clause opt_scrub_options_clause
   {
-    name := $4.unresolvedObjectName().ToTableName()
     $$.val = &tree.Scrub{
       Typ: tree.ScrubTable,
-      Table: name,
+      Table: $4.unresolvedObjectName(),
       AsOf: $5.asOfClause(),
       Options: $6.scrubOptions(),
     }

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3654,8 +3654,7 @@ show_fingerprints_stmt:
   SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE table_name
   {
     /* SKIP DOC */
-    name := $5.unresolvedObjectName().ToTableName()
-    $$.val = &tree.ShowFingerprints{Table: name}
+    $$.val = &tree.ShowFingerprints{Table: $5.unresolvedObjectName()}
   }
 
 opt_on_targets_roles:

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -396,7 +396,12 @@ func (p *planner) ParseType(sql string) (*types.T, error) {
 func (p *planner) ParseQualifiedTableName(
 	ctx context.Context, sql string,
 ) (*tree.TableName, error) {
-	return parser.ParseTableName(sql)
+	name, err := parser.ParseTableName(sql)
+	if err != nil {
+		return nil, err
+	}
+	tn := name.ToTableName()
+	return &tn, nil
 }
 
 // ResolveTableName implements the tree.EvalDatabase interface.

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -38,8 +38,8 @@ type renameTableNode struct {
 //          mysql requires ALTER, DROP on the original table, and CREATE, INSERT
 //          on the new table (and does not copy privileges over).
 func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNode, error) {
-	oldTn := &n.Name
-	newTn := &n.NewName
+	oldTn := n.Name.ToTableName()
+	newTn := n.NewName.ToTableName()
 	toRequire := ResolveRequireTableOrViewDesc
 	if n.IsView {
 		toRequire = ResolveRequireViewDesc
@@ -47,7 +47,7 @@ func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNod
 		toRequire = ResolveRequireSequenceDesc
 	}
 
-	tableDesc, err := p.ResolveMutableTableDescriptor(ctx, oldTn, !n.IfExists, toRequire)
+	tableDesc, err := p.ResolveMutableTableDescriptor(ctx, &oldTn, !n.IfExists, toRequire)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNod
 	}
 
 	if tableDesc.State != sqlbase.TableDescriptor_PUBLIC {
-		return nil, sqlbase.NewUndefinedRelationError(oldTn)
+		return nil, sqlbase.NewUndefinedRelationError(&oldTn)
 	}
 
 	if err := p.CheckPrivilege(ctx, tableDesc, privilege.DROP); err != nil {
@@ -73,7 +73,7 @@ func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNod
 			ctx, tableDesc.TypeName(), oldTn.String(), tableDesc.ParentID, tableDesc.DependedOnBy[0].ID)
 	}
 
-	return &renameTableNode{n: n, oldTn: oldTn, newTn: newTn, tableDesc: tableDesc}, nil
+	return &renameTableNode{n: n, oldTn: &oldTn, newTn: &newTn, tableDesc: tableDesc}, nil
 }
 
 func (n *renameTableNode) startExec(params runParams) error {

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -668,7 +668,7 @@ func (p *planner) ResolveUncachedTableDescriptorEx(
 	requiredType ResolveRequiredType,
 ) (table *ImmutableTableDescriptor, err error) {
 	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		table, err = p.ResolveExistingObjectEx(ctx, p, name, required, requiredType)
+		table, err = p.ResolveExistingObjectEx(ctx, name, required, requiredType)
 	})
 	return table, err
 }
@@ -676,13 +676,12 @@ func (p *planner) ResolveUncachedTableDescriptorEx(
 // See ResolveExistingObject.
 func (p *planner) ResolveExistingObjectEx(
 	ctx context.Context,
-	sc SchemaResolver,
 	name *tree.UnresolvedObjectName,
 	required bool,
 	requiredType ResolveRequiredType,
 ) (res *ImmutableTableDescriptor, err error) {
 	tn := name.ToTableName()
-	desc, err := resolveExistingObjectImpl(ctx, sc, &tn, required, false /* requiredMutable */, requiredType)
+	desc, err := resolveExistingObjectImpl(ctx, p, &tn, required, false /* requiredMutable */, requiredType)
 	if err != nil || desc == nil {
 		return nil, err
 	}

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -660,6 +660,20 @@ func (p *planner) ResolveMutableTableDescriptorEx(
 	return table, nil
 }
 
+func (p *planner) ResolveUncachedTableDescriptorEx(
+	ctx context.Context,
+	name *tree.UnresolvedObjectName,
+	required bool,
+	requiredType ResolveRequiredType,
+) (table *ImmutableTableDescriptor, err error) {
+	tn := name.ToTableName()
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
+		table, err = ResolveExistingObject(ctx, p, &tn, required, requiredType)
+	})
+	name.SetAnnotation(&p.semaCtx.Annotations, &tn)
+	return table, err
+}
+
 // ResolvedName is a convenience wrapper for UnresolvedObjectName.Resolved.
 func (p *planner) ResolvedName(u *tree.UnresolvedObjectName) *tree.TableName {
 	return u.Resolved(&p.semaCtx.Annotations)

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -103,12 +103,14 @@ func (n *scrubNode) startExec(params runParams) error {
 	case tree.ScrubTable:
 		// If the tableName provided refers to a view and error will be
 		// returned here.
-		tableDesc, err := ResolveExistingObject(
-			params.ctx, params.p, &n.n.Table, true /*required*/, ResolveRequireTableDesc)
+		tableDesc, err := params.p.ResolveExistingObjectEx(
+			params.ctx, n.n.Table, true /*required*/, ResolveRequireTableDesc)
 		if err != nil {
 			return err
 		}
-		if err := n.startScrubTable(params.ctx, params.p, tableDesc, &n.n.Table); err != nil {
+		if err := n.startScrubTable(
+			params.ctx, params.p, tableDesc, params.p.ResolvedName(n.n.Table),
+		); err != nil {
 			return err
 		}
 	case tree.ScrubDatabase:

--- a/pkg/sql/sem/tree/alter_sequence.go
+++ b/pkg/sql/sem/tree/alter_sequence.go
@@ -19,7 +19,7 @@ package tree
 // RenameTable node.
 type AlterSequence struct {
 	IfExists bool
-	Name     TableName
+	Name     *UnresolvedObjectName
 	Options  SequenceOptions
 }
 
@@ -29,6 +29,6 @@ func (node *AlterSequence) Format(ctx *FmtCtx) {
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")
 	}
-	ctx.FormatNode(&node.Name)
+	ctx.FormatNode(node.Name)
 	ctx.FormatNode(&node.Options)
 }

--- a/pkg/sql/sem/tree/comment_on_table.go
+++ b/pkg/sql/sem/tree/comment_on_table.go
@@ -18,14 +18,14 @@ import "github.com/cockroachdb/cockroach/pkg/sql/lex"
 
 // CommentOnTable represents an COMMENT ON TABLE statement.
 type CommentOnTable struct {
-	Table   TableName
+	Table   *UnresolvedObjectName
 	Comment *string
 }
 
 // Format implements the NodeFormatter interface.
 func (n *CommentOnTable) Format(ctx *FmtCtx) {
 	ctx.WriteString("COMMENT ON TABLE ")
-	ctx.FormatNode(&n.Table)
+	ctx.FormatNode(n.Table)
 	ctx.WriteString(" IS ")
 	if n.Comment != nil {
 		lex.EncodeSQLStringWithFlags(&ctx.Buffer, *n.Comment, ctx.flags.EncodeFlags())

--- a/pkg/sql/sem/tree/name_part.go
+++ b/pkg/sql/sem/tree/name_part.go
@@ -226,6 +226,9 @@ type UnresolvedObjectName struct {
 	AnnotatedNode
 }
 
+// UnresolvedObjectName implements TableExpr.
+func (*UnresolvedObjectName) tableExpr() {}
+
 // NewUnresolvedObjectName creates an unresolved object name, verifying that it
 // is well-formed.
 func NewUnresolvedObjectName(

--- a/pkg/sql/sem/tree/name_part_test.go
+++ b/pkg/sql/sem/tree/name_part_test.go
@@ -52,13 +52,14 @@ func TestUnresolvedObjectName(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.in, func(t *testing.T) {
-			tn, err := parser.ParseTableName(tc.in)
+			name, err := parser.ParseTableName(tc.in)
 			if !testutils.IsError(err, tc.err) {
 				t.Fatalf("%s: expected %s, but found %v", tc.in, tc.err, err)
 			}
 			if tc.err != "" {
 				return
 			}
+			tn := name.ToTableName()
 			if out := tn.String(); tc.out != out {
 				t.Fatalf("%s: expected %s, but found %s", tc.in, tc.out, out)
 			}
@@ -93,11 +94,12 @@ func TestUnresolvedNameAnnotation(t *testing.T) {
 	// No annotation set.
 	expect("t")
 
-	tn, err := parser.ParseTableName("db.public.t")
+	name, err := parser.ParseTableName("db.public.t")
 	if err != nil {
 		t.Fatal(err)
 	}
-	u.SetAnnotation(&ann, tn)
+	tn := name.ToTableName()
+	u.SetAnnotation(&ann, &tn)
 
 	expect("db.public.t")
 

--- a/pkg/sql/sem/tree/rename.go
+++ b/pkg/sql/sem/tree/rename.go
@@ -41,8 +41,8 @@ func (node *RenameDatabase) Format(ctx *FmtCtx) {
 // Whether the user has asked to rename a table or view is indicated
 // by the IsView field.
 type RenameTable struct {
-	Name       TableName
-	NewName    TableName
+	Name       *UnresolvedObjectName
+	NewName    *UnresolvedObjectName
 	IfExists   bool
 	IsView     bool
 	IsSequence bool
@@ -61,9 +61,9 @@ func (node *RenameTable) Format(ctx *FmtCtx) {
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")
 	}
-	ctx.FormatNode(&node.Name)
+	ctx.FormatNode(node.Name)
 	ctx.WriteString(" RENAME TO ")
-	ctx.FormatNode(&node.NewName)
+	ctx.FormatNode(node.NewName)
 }
 
 // RenameIndex represents a RENAME INDEX statement.

--- a/pkg/sql/sem/tree/scrub.go
+++ b/pkg/sql/sem/tree/scrub.go
@@ -31,7 +31,7 @@ type Scrub struct {
 	Typ     ScrubType
 	Options ScrubOptions
 	// Table is only set during SCRUB TABLE statements.
-	Table TableName
+	Table *UnresolvedObjectName
 	// Database is only set during SCRUB DATABASE statements.
 	Database Name
 	AsOf     AsOfClause

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -389,7 +389,7 @@ func (node *ShowFingerprints) Format(ctx *FmtCtx) {
 
 // ShowTableStats represents a SHOW STATISTICS FOR TABLE statement.
 type ShowTableStats struct {
-	Table     TableName
+	Table     *UnresolvedObjectName
 	UsingJSON bool
 }
 
@@ -400,7 +400,7 @@ func (node *ShowTableStats) Format(ctx *FmtCtx) {
 		ctx.WriteString("USING JSON ")
 	}
 	ctx.WriteString("FOR TABLE ")
-	ctx.FormatNode(&node.Table)
+	ctx.FormatNode(node.Table)
 }
 
 // ShowHistogram represents a SHOW HISTOGRAM statement.

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -96,14 +96,14 @@ func (node *ShowBackup) Format(ctx *FmtCtx) {
 
 // ShowColumns represents a SHOW COLUMNS statement.
 type ShowColumns struct {
-	Table       TableName
+	Table       *UnresolvedObjectName
 	WithComment bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowColumns) Format(ctx *FmtCtx) {
 	ctx.WriteString("SHOW COLUMNS FROM ")
-	ctx.FormatNode(&node.Table)
+	ctx.FormatNode(node.Table)
 
 	if node.WithComment {
 		ctx.WriteString(" WITH COMMENT")
@@ -144,15 +144,15 @@ func (node *ShowTraceForSession) Format(ctx *FmtCtx) {
 	ctx.WriteString(" FOR SESSION")
 }
 
-// ShowIndex represents a SHOW INDEX statement.
-type ShowIndex struct {
-	Table TableName
+// ShowIndexes represents a SHOW INDEX statement.
+type ShowIndexes struct {
+	Table *UnresolvedObjectName
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ShowIndex) Format(ctx *FmtCtx) {
+func (node *ShowIndexes) Format(ctx *FmtCtx) {
 	ctx.WriteString("SHOW INDEXES FROM ")
-	ctx.FormatNode(&node.Table)
+	ctx.FormatNode(node.Table)
 }
 
 // ShowQueries represents a SHOW QUERIES statement
@@ -259,13 +259,13 @@ func (node *ShowTables) Format(ctx *FmtCtx) {
 
 // ShowConstraints represents a SHOW CONSTRAINTS statement.
 type ShowConstraints struct {
-	Table TableName
+	Table *UnresolvedObjectName
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowConstraints) Format(ctx *FmtCtx) {
 	ctx.WriteString("SHOW CONSTRAINTS FROM ")
-	ctx.FormatNode(&node.Table)
+	ctx.FormatNode(node.Table)
 }
 
 // ShowGrants represents a SHOW GRANTS statement.
@@ -309,13 +309,13 @@ func (node *ShowRoleGrants) Format(ctx *FmtCtx) {
 
 // ShowCreate represents a SHOW CREATE statement.
 type ShowCreate struct {
-	Name TableName
+	Name *UnresolvedObjectName
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowCreate) Format(ctx *FmtCtx) {
 	ctx.WriteString("SHOW CREATE ")
-	ctx.FormatNode(&node.Name)
+	ctx.FormatNode(node.Name)
 }
 
 // ShowSyntax represents a SHOW SYNTAX statement.

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -378,13 +378,13 @@ func (node *ShowRanges) Format(ctx *FmtCtx) {
 
 // ShowFingerprints represents a SHOW EXPERIMENTAL_FINGERPRINTS statement.
 type ShowFingerprints struct {
-	Table TableName
+	Table *UnresolvedObjectName
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowFingerprints) Format(ctx *FmtCtx) {
 	ctx.WriteString("SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE ")
-	ctx.FormatNode(&node.Table)
+	ctx.FormatNode(node.Table)
 }
 
 // ShowTableStats represents a SHOW STATISTICS FOR TABLE statement.

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -685,10 +685,10 @@ func (*ShowGrants) StatementType() StatementType { return Rows }
 func (*ShowGrants) StatementTag() string { return "SHOW GRANTS" }
 
 // StatementType implements the Statement interface.
-func (*ShowIndex) StatementType() StatementType { return Rows }
+func (*ShowIndexes) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
-func (*ShowIndex) StatementTag() string { return "SHOW INDEX" }
+func (*ShowIndexes) StatementTag() string { return "SHOW INDEXES" }
 
 // StatementType implements the Statement interface.
 func (*ShowQueries) StatementType() StatementType { return Rows }
@@ -911,7 +911,7 @@ func (n *ShowCreate) String() string                { return AsString(n) }
 func (n *ShowDatabases) String() string             { return AsString(n) }
 func (n *ShowGrants) String() string                { return AsString(n) }
 func (n *ShowHistogram) String() string             { return AsString(n) }
-func (n *ShowIndex) String() string                 { return AsString(n) }
+func (n *ShowIndexes) String() string               { return AsString(n) }
 func (n *ShowJobs) String() string                  { return AsString(n) }
 func (n *ShowQueries) String() string               { return AsString(n) }
 func (n *ShowRanges) String() string                { return AsString(n) }

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -310,17 +310,18 @@ func maybeAddSequenceDependencies(
 		if err != nil {
 			return nil, err
 		}
+		tn := parsedSeqName.ToTableName()
 
 		var seqDesc *MutableTableDescriptor
 		p, ok := sc.(*planner)
 		if ok {
-			seqDesc, err = p.ResolveMutableTableDescriptor(ctx, parsedSeqName, true /*required*/, ResolveRequireSequenceDesc)
+			seqDesc, err = p.ResolveMutableTableDescriptor(ctx, &tn, true /*required*/, ResolveRequireSequenceDesc)
 			if err != nil {
 				return nil, err
 			}
 		} else {
 			// This is only executed via IMPORT which uses its own resolver.
-			seqDesc, err = ResolveMutableExistingObject(ctx, sc, parsedSeqName, true /*required*/, ResolveRequireSequenceDesc)
+			seqDesc, err = ResolveMutableExistingObject(ctx, sc, &tn, true /*required*/, ResolveRequireSequenceDesc)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -56,8 +56,8 @@ func (p *planner) ShowFingerprints(
 ) (planNode, error) {
 	// We avoid the cache so that we can observe the fingerprints without
 	// taking a lease, like other SHOW commands.
-	tableDesc, err := p.ResolveUncachedTableDescriptor(
-		ctx, &n.Table, true /*required*/, ResolveRequireTableDesc)
+	tableDesc, err := p.ResolveUncachedTableDescriptorEx(
+		ctx, n.Table, true /*required*/, ResolveRequireTableDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/show_stats.go
+++ b/pkg/sql/show_stats.go
@@ -45,7 +45,7 @@ var showTableStatsJSONColumns = sqlbase.ResultColumns{
 func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (planNode, error) {
 	// We avoid the cache so that we can observe the stats without
 	// taking a lease, like other SHOW commands.
-	desc, err := p.ResolveUncachedTableDescriptor(ctx, &n.Table, true /*required*/, ResolveRequireTableDesc)
+	desc, err := p.ResolveUncachedTableDescriptorEx(ctx, n.Table, true /*required*/, ResolveRequireTableDesc)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Use UnresolvedObjectName in:
 - AlterSequence
 - CommentOnTable
 - CreateStats
 - Scrub
 - ShowTableStats
 - ShowCreate/Indexes/Columns/Constraints
 - ShowFingerprints
 - RenameTable

Each item is in a separate commit.

Part of #34240.