### PR TITLE
exec: template comparisons for ordered sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -755,7 +755,8 @@ EXECGEN_TARGETS = \
   pkg/sql/exec/selection_ops.eg.go \
   pkg/sql/exec/sort.eg.go \
   pkg/sql/exec/sum_agg.eg.go \
-  pkg/sql/exec/tuples_differ.eg.go
+  pkg/sql/exec/tuples_differ.eg.go \
+  pkg/sql/exec/vec_comparators.eg.go
 
 OPTGEN_TARGETS = \
 	pkg/sql/opt/memo/expr.og.go \
@@ -1411,6 +1412,7 @@ pkg/sql/exec/rowstovec.eg.go: pkg/sql/exec/rowstovec_tmpl.go
 pkg/sql/exec/sort.eg.go: pkg/sql/exec/sort_tmpl.go
 pkg/sql/exec/sum_agg.eg.go: pkg/sql/exec/sum_agg_tmpl.go
 pkg/sql/exec/tuples_differ.eg.go: pkg/sql/exec/tuples_differ_tmpl.go
+pkg/sql/exec/vec_comparators.eg.go: pkg/sql/exec/vec_comparators_tmpl.go
 
 $(EXECGEN_TARGETS): bin/execgen
 	@# Remove generated files with the old suffix to avoid conflicts.

--- a/pkg/sql/exec/.gitignore
+++ b/pkg/sql/exec/.gitignore
@@ -14,3 +14,4 @@ selection_ops.eg.go
 sort.eg.go
 sum_agg.eg.go
 tuples_differ.eg.go
+vec_comparators.eg.go

--- a/pkg/sql/exec/execgen/cmd/execgen/vec_comparators_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/vec_comparators_gen.go
@@ -1,0 +1,54 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"io"
+	"io/ioutil"
+	"regexp"
+	"strings"
+	"text/template"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+func genVecComparators(wr io.Writer) error {
+	d, err := ioutil.ReadFile("pkg/sql/exec/vec_comparators_tmpl.go")
+	if err != nil {
+		return err
+	}
+	s := string(d)
+	s = strings.Replace(s, "_TYPE", "{{.LTyp}}", -1)
+	s = strings.Replace(s, "_GOTYPE", "{{.LGoType}}", -1)
+	compareRe := regexp.MustCompile(`_COMPARE\((.*),(.*),(.*)\)`)
+	s = compareRe.ReplaceAllString(s, "{{.Compare $1 $2 $3}}")
+
+	tmpl, err := template.New("vec_comparators").Parse(s)
+	if err != nil {
+		return err
+	}
+
+	ltOverloads := make([]*overload, 0)
+	for _, overload := range comparisonOpOverloads {
+		if overload.CmpOp == tree.LT {
+			ltOverloads = append(ltOverloads, overload)
+		}
+	}
+	return tmpl.Execute(wr, ltOverloads)
+}
+
+func init() {
+	registerGenerator(genVecComparators, "vec_comparators.eg.go")
+}

--- a/pkg/sql/exec/vec_comparators.go
+++ b/pkg/sql/exec/vec_comparators.go
@@ -1,0 +1,30 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import "github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+
+// vecComparator is a helper for the ordered synchronizer. It stores multiple
+// column vectors of a single type and facilitates comparing values between
+// them. The implementations are templated by vec_comparators_gen.go.
+type vecComparator interface {
+	// compare compares values from two vectors. vecIdx is the index of the vector
+	// and valIdx is the index of the value in that vector to compare. Returns -1,
+	// 0, or 1.
+	compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 uint16) int
+
+	// setVec updates the vector at idx.
+	setVec(idx int, vec coldata.Vec)
+}

--- a/pkg/sql/exec/vec_comparators_tmpl.go
+++ b/pkg/sql/exec/vec_comparators_tmpl.go
@@ -1,0 +1,98 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// {{/*
+// +build execgen_template
+//
+// This file is the execgen template for sort.eg.go. It's formatted in a
+// special way, so it's both valid Go and a valid text/template input. This
+// permits editing this file with editor support.
+//
+// */}}
+
+package exec
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// {{/*
+
+// Declarations to make the template compile properly.
+
+// Dummy import to pull in "bytes" package.
+var _ bytes.Buffer
+
+// Dummy import to pull in "apd" package.
+var _ apd.Decimal
+
+// Dummy import to pull in "tree" package.
+var _ tree.Datum
+
+// _COMPARE is the template equality function for assigning the first input
+// to the result of comparing second and third inputs.
+func _COMPARE(_, _, _ string) bool {
+	panic("")
+}
+
+// */}}
+
+// {{range .}}
+type _TYPEVecComparator struct {
+	vecs  [][]_GOTYPE
+	nulls []*coldata.Nulls
+}
+
+func (c *_TYPEVecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 uint16) int {
+	n1 := c.nulls[vecIdx1].HasNulls() && c.nulls[vecIdx1].NullAt(valIdx1)
+	n2 := c.nulls[vecIdx2].HasNulls() && c.nulls[vecIdx2].NullAt(valIdx2)
+	if n1 && n2 {
+		return 0
+	} else if n1 {
+		return -1
+	} else if n2 {
+		return 1
+	}
+	left := c.vecs[vecIdx1][valIdx1]
+	right := c.vecs[vecIdx2][valIdx2]
+	var cmp int
+	_COMPARE("cmp", "left", "right")
+	return cmp
+}
+
+func (c *_TYPEVecComparator) setVec(idx int, vec coldata.Vec) {
+	c.vecs[idx] = vec._TYPE()
+	c.nulls[idx] = vec.Nulls()
+}
+
+// {{end}}
+
+func GetVecComparator(t types.T, numVecs int) vecComparator {
+	switch t {
+	// {{range .}}
+	case types._TYPE:
+		return &_TYPEVecComparator{
+			vecs:  make([][]_GOTYPE, numVecs),
+			nulls: make([]*coldata.Nulls, numVecs),
+		}
+		// {{end}}
+	}
+	panic(fmt.Sprintf("unhandled type %v", t))
+}


### PR DESCRIPTION
The ordered synchronizer now supports all types rather than just int64.
To implement this I introduced a vecComparator interface which compares
values across multiple same-typed vectors. The synchronizer creates one
of these for each ordering column.

Introducing the comparators provided a significant speed-up since it
prevents needing to repeatedly call `Vec.Int64()`.
```
name                   old time/op   new time/op   delta
OrderedSynchronizer-4   94.7µs ± 1%   61.5µs ± 1%  -35.09%  (p=0.008 n=5+5)

name                   old speed     new speed     delta
OrderedSynchronizer-4  259MB/s ± 1%  400MB/s ± 1%  +54.05%  (p=0.008 n=5+5)
```

Refers #37304

Release note: None