### PR TITLE
storage: fix data race accessing defaultZoneConfig

### DIFF
--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -8445,7 +8445,7 @@ func TestReplicaMetrics(t *testing.T) {
 
 	for i, c := range testCases {
 		t.Run("", func(t *testing.T) {
-			zoneConfig := cfg.DefaultZoneConfig
+			zoneConfig := protoutil.Clone(cfg.DefaultZoneConfig).(*config.ZoneConfig)
 			zoneConfig.NumReplicas = proto.Int32(c.replicas)
 
 			// Alternate between quiescent and non-quiescent replicas to test the


### PR DESCRIPTION
Multiple tests were accessing the cfg.DefaultZoneConfig concurrently.
The data race is resolved by cloning cfg.DefaultZoneConfig.

Resolves: #37521

Release note: None