### PR TITLE
storage: add Range desc and request string to backpressure error

### DIFF
--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -1114,7 +1114,7 @@ func TestStoreRangeSplitBackpressureWrites(t *testing.T) {
 		{splitOngoing: true, splitErr: false, expErr: ""},
 		{splitOngoing: true, splitErr: true, expErr: "split failed while applying backpressure.* boom"},
 		{splitOngoing: false, expErr: ""},
-		{splitImpossible: true, expErr: "split failed while applying backpressure: could not find valid split key"},
+		{splitImpossible: true, expErr: "split failed while applying backpressure.* could not find valid split key"},
 	}
 	for _, tc := range testCases {
 		var name string

--- a/pkg/storage/replica_backpressure.go
+++ b/pkg/storage/replica_backpressure.go
@@ -128,10 +128,14 @@ func (r *Replica) maybeBackpressureWriteBatch(ctx context.Context, ba roachpb.Ba
 		// Wait for the callback to be called.
 		select {
 		case <-ctx.Done():
-			return errors.Wrap(ctx.Err(), "aborted while applying backpressure")
+			return errors.Wrapf(
+				ctx.Err(), "aborted while applying backpressure to %s on range %s", ba, r.Desc(),
+			)
 		case err := <-splitC:
 			if err != nil {
-				return errors.Wrap(err, "split failed while applying backpressure")
+				return errors.Wrapf(
+					err, "split failed while applying backpressure to %s on range %s", ba, r.Desc(),
+				)
 			}
 		}
 	}


### PR DESCRIPTION
This will help track down these errors in the future.

Release note: None