### PR TITLE
kv: remove withMarshalingDebugging function

### DIFF
--- a/pkg/kv/batch.go
+++ b/pkg/kv/batch.go
@@ -110,12 +110,11 @@ func truncate(ba roachpb.BatchRequest, rs roachpb.RSpan) (roachpb.BatchRequest, 
 			if newSpan.EqualValue(oldHeader.Span()) {
 				truncBA.Requests = append(truncBA.Requests, ba.Requests[pos])
 			} else {
-				var union roachpb.RequestUnion
 				oldHeader.SetSpan(newSpan)
 				shallowCopy := inner.ShallowCopy()
 				shallowCopy.SetHeader(oldHeader)
-				union.MustSetInner(shallowCopy)
-				truncBA.Requests = append(truncBA.Requests, union)
+				truncBA.Requests = append(truncBA.Requests, roachpb.RequestUnion{})
+				truncBA.Requests[len(truncBA.Requests)-1].MustSetInner(shallowCopy)
 			}
 			positions = append(positions, pos)
 		}

--- a/pkg/kv/range_cache.go
+++ b/pkg/kv/range_cache.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/biogo/store/llrb"
@@ -162,7 +163,7 @@ func (rdc *RangeDescriptorCache) String() string {
 }
 
 func (rdc *RangeDescriptorCache) stringLocked() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	rdc.rangeCache.cache.Do(func(k, v interface{}) bool {
 		fmt.Fprintf(&buf, "key=%s desc=%+v\n", roachpb.Key(k.(rangeCacheKey)), v)
 		return false

--- a/pkg/kv/transport_test.go
+++ b/pkg/kv/transport_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 )
 
@@ -172,31 +171,4 @@ func (m *mockInternalClient) RangeFeed(
 	ctx context.Context, in *roachpb.RangeFeedRequest, opts ...grpc.CallOption,
 ) (roachpb.Internal_RangeFeedClient, error) {
 	return nil, fmt.Errorf("unsupported RangeFeed call")
-}
-
-func TestWithMarshalingDebugging(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	t.Skip(fmt.Sprintf("Skipped until #34241 is resolved"))
-
-	ctx := context.Background()
-
-	exp := `batch size 23 -> 28 bytes
-re-marshaled protobuf:
-00000000  0a 0a 0a 00 12 06 08 00  10 00 18 00 12 0e 3a 0c  |..............:.|
-00000010  0a 0a 1a 03 66 6f 6f 22  03 62 61 72              |....foo".bar|
-
-original panic:  <nil>
-`
-
-	assert.PanicsWithValue(t, exp, func() {
-		var ba roachpb.BatchRequest
-		ba.Add(&roachpb.ScanRequest{
-			RequestHeader: roachpb.RequestHeader{
-				Key: []byte("foo"),
-			},
-		})
-		withMarshalingDebugging(ctx, ba, func() {
-			ba.Requests[0].GetInner().(*roachpb.ScanRequest).EndKey = roachpb.Key("bar")
-		})
-	})
 }

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -703,11 +703,11 @@ func (tc *TxnCoordSender) commitReadOnlyTxnLocked(
 	ctx context.Context, ba roachpb.BatchRequest,
 ) *roachpb.Error {
 	deadline := ba.Requests[0].GetEndTransaction().Deadline
-	txn := tc.mu.txn
-	if deadline != nil && !txn.Timestamp.Less(*deadline) {
-		pErr := generateTxnDeadlineExceededErr(&txn, *deadline)
+	if deadline != nil && !tc.mu.txn.Timestamp.Less(*deadline) {
+		txn := tc.mu.txn.Clone()
+		pErr := generateTxnDeadlineExceededErr(txn, *deadline)
 		// We need to bump the epoch and transform this retriable error.
-		ba.Txn = &txn
+		ba.Txn = txn
 		return tc.updateStateLocked(ctx, ba, nil /* br */, pErr)
 	}
 	tc.mu.txnState = txnFinalized


### PR DESCRIPTION
This debugging function was removed when we fixed #34241 and added back
in when #35803 appeared because it was clear that we hadn't fully fixed
the issue. It's been about 2 months since #35762 merged and we haven't
seen any issues since, so this can now be removed.

I don't think we meant to keep this in for the 19.1 release. We should
backport this commit.