### PR TITLE
storage: move functionality from debug/print.go to storage for wider use

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -31,7 +31,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/cli/debug"
 	"github.com/cockroachdb/cockroach/pkg/cli/syncbench"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
@@ -178,7 +177,7 @@ func runDebugKeys(cmd *cobra.Command, args []string) error {
 	printer := printKey
 	if debugCtx.values {
 		printer = func(kv engine.MVCCKeyValue) (bool, error) {
-			debug.PrintKeyValue(kv)
+			storage.PrintKeyValue(kv)
 			return false, nil
 		}
 	}
@@ -279,7 +278,7 @@ func runDebugRangeData(cmd *cobra.Command, args []string) error {
 		} else if !ok {
 			break
 		}
-		debug.PrintKeyValue(engine.MVCCKeyValue{
+		storage.PrintKeyValue(engine.MVCCKeyValue{
 			Key:   iter.Key(),
 			Value: iter.Value(),
 		})
@@ -306,7 +305,7 @@ func loadRangeDescriptor(
 			// We only want values, not MVCCMetadata.
 			return false, nil
 		}
-		if err := debug.IsRangeDescriptorKey(kv.Key); err != nil {
+		if err := storage.IsRangeDescriptorKey(kv.Key); err != nil {
 			// Range descriptor keys are interleaved with others, so if it
 			// doesn't parse as a range descriptor just skip it.
 			return false, nil
@@ -349,10 +348,10 @@ func runDebugRangeDescriptors(cmd *cobra.Command, args []string) error {
 	end := engine.MakeMVCCMetadataKey(keys.LocalRangeMax)
 
 	return db.Iterate(start, end, func(kv engine.MVCCKeyValue) (bool, error) {
-		if debug.IsRangeDescriptorKey(kv.Key) != nil {
+		if storage.IsRangeDescriptorKey(kv.Key) != nil {
 			return false, nil
 		}
-		debug.PrintKeyValue(kv)
+		storage.PrintKeyValue(kv)
 		return false, nil
 	})
 }
@@ -418,7 +417,7 @@ Decode and print a hexadecimal-encoded key-value pair.
 			}
 		}
 
-		debug.PrintKeyValue(engine.MVCCKeyValue{
+		storage.PrintKeyValue(engine.MVCCKeyValue{
 			Key:   k,
 			Value: bs[1],
 		})
@@ -456,7 +455,7 @@ func runDebugRaftLog(cmd *cobra.Command, args []string) error {
 		start, end, string(engine.EncodeKey(start)), string(engine.EncodeKey(end)))
 
 	return db.Iterate(start, end, func(kv engine.MVCCKeyValue) (bool, error) {
-		debug.PrintKeyValue(kv)
+		storage.PrintKeyValue(kv)
 		return false, nil
 	})
 }

--- a/pkg/storage/debug_print.go
+++ b/pkg/storage/debug_print.go
@@ -13,7 +13,7 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 
-package debug
+package storage
 
 import (
 	"bytes"
@@ -24,7 +24,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
@@ -36,7 +35,7 @@ import (
 // PrintKeyValue attempts to pretty-print the specified MVCCKeyValue to
 // os.Stdout, falling back to '%q' formatting.
 func PrintKeyValue(kv engine.MVCCKeyValue) {
-	fmt.Println(SprintKeyValue(kv))
+	fmt.Println(SprintKeyValue(kv, true /* printKey */))
 }
 
 // SprintKey pretty-prings the specified MVCCKey.
@@ -44,10 +43,14 @@ func SprintKey(key engine.MVCCKey) string {
 	return fmt.Sprintf("%s %s (%#x): ", key.Timestamp, key.Key, engine.EncodeKey(key))
 }
 
-// SprintKeyValue is like PrintKeyValue, but returns a string.
-func SprintKeyValue(kv engine.MVCCKeyValue) string {
+// SprintKeyValue is like PrintKeyValue, but returns a string. If
+// printKey is true, prints the key and the value together; otherwise,
+// prints just the value.
+func SprintKeyValue(kv engine.MVCCKeyValue, printKey bool) string {
 	var sb strings.Builder
-	sb.WriteString(SprintKey(kv.Key))
+	if printKey {
+		sb.WriteString(SprintKey(kv.Key))
+	}
 	decoders := []func(kv engine.MVCCKeyValue) (string, error){
 		tryRaftLogEntry,
 		tryRangeDescriptor,
@@ -127,7 +130,7 @@ func decodeWriteBatch(writeBatch *storagepb.WriteBatch) (string, error) {
 			sb.WriteString(fmt.Sprintf("Put: %s\n", SprintKeyValue(engine.MVCCKeyValue{
 				Key:   mvccKey,
 				Value: r.Value(),
-			})))
+			}, true /* printKey */)))
 		case engine.BatchTypeMerge:
 			mvccKey, err := r.MVCCKey()
 			if err != nil {
@@ -136,7 +139,7 @@ func decodeWriteBatch(writeBatch *storagepb.WriteBatch) (string, error) {
 			sb.WriteString(fmt.Sprintf("Merge: %s\n", SprintKeyValue(engine.MVCCKeyValue{
 				Key:   mvccKey,
 				Value: r.Value(),
-			})))
+			}, true /* printKey */)))
 		case engine.BatchTypeSingleDeletion:
 			mvccKey, err := r.MVCCKey()
 			if err != nil {
@@ -169,7 +172,7 @@ func tryRaftLogEntry(kv engine.MVCCKeyValue) (string, error) {
 	}
 	if ent.Type == raftpb.EntryNormal {
 		if len(ent.Data) > 0 {
-			_, cmdData := storage.DecodeRaftCommand(ent.Data)
+			_, cmdData := DecodeRaftCommand(ent.Data)
 			var cmd storagepb.RaftCommand
 			if err := protoutil.Unmarshal(cmdData, &cmd); err != nil {
 				return "", err
@@ -195,7 +198,7 @@ func tryRaftLogEntry(kv engine.MVCCKeyValue) (string, error) {
 		if err := protoutil.Unmarshal(ent.Data, &cc); err != nil {
 			return "", err
 		}
-		var ctx storage.ConfChangeContext
+		var ctx ConfChangeContext
 		if err := protoutil.Unmarshal(cc.Context, &ctx); err != nil {
 			return "", err
 		}
@@ -364,4 +367,14 @@ func maybeUnmarshalInline(v []byte, dest protoutil.Message) error {
 		RawBytes: meta.RawBytes,
 	}
 	return value.GetProto(dest)
+}
+
+type stringifyWriteBatch storagepb.WriteBatch
+
+func (s *stringifyWriteBatch) String() string {
+	wbStr, err := decodeWriteBatch((*storagepb.WriteBatch)(s))
+	if err == nil {
+		return wbStr
+	}
+	return fmt.Sprintf("failed to stringify write batch (%x): %s", s.Data, err)
 }

--- a/pkg/storage/debug_print_test.go
+++ b/pkg/storage/debug_print_test.go
@@ -1,0 +1,47 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package storage
+
+import (
+	"math"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestStringifyWriteBatch(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	var wb storagepb.WriteBatch
+	swb := stringifyWriteBatch(wb)
+	if str, expStr := swb.String(), "failed to stringify write batch (): batch repr too small: 0 < 12"; str != expStr {
+		t.Errorf("expected %q for stringified write batch; got %q", expStr, str)
+	}
+
+	builder := engine.RocksDBBatchBuilder{}
+	builder.Put(engine.MVCCKey{
+		Key:       roachpb.Key("/db1"),
+		Timestamp: hlc.Timestamp{WallTime: math.MaxInt64},
+	}, []byte("test value"))
+	wb.Data = builder.Finish()
+	swb = stringifyWriteBatch(wb)
+	if str, expStr := swb.String(), "Put: 9223372036.854775807,0 \"/db1\" (0x2f646231007fffffffffffffff09): \"test value\"\n"; str != expStr {
+		t.Errorf("expected %q for stringified write batch; got %q", expStr, str)
+	}
+}


### PR DESCRIPTION
This allows replica_consistency_diff to print out readable MVCC keys and
values.

Release note: None