### PR TITLE
exec: check for unset output columnTypes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/exec_window
+++ b/pkg/sql/logictest/testdata/logic_test/exec_window
@@ -10,6 +10,9 @@ INSERT INTO t VALUES
   (0, 'b'),
   (1, 'b')
 
+statement ok
+SET experimental_vectorize=always
+
 # We sort the output on all queries to get deterministic results.
 query ITI
 SELECT a, b, row_number() OVER () FROM t ORDER BY b, a


### PR DESCRIPTION
Future planning PRs need these to be set, so this commit introduces a
check for unset columnTypes that will return an error.

Release note: None