### PR TITLE
sql: add IGNORE_FOREIGN_KEY table hint

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -682,6 +682,7 @@ unreserved_keyword ::=
 	| 'NO'
 	| 'NORMAL'
 	| 'NO_INDEX_JOIN'
+	| 'IGNORE_FOREIGN_KEYS'
 	| 'OF'
 	| 'OFF'
 	| 'OID'

--- a/pkg/sql/opt/norm/join.go
+++ b/pkg/sql/opt/norm/join.go
@@ -427,6 +427,10 @@ func (c *CustomFuncs) JoinFiltersMatchAllLeftRows(
 	// Condition #5: All remaining left columns correspond to a validated foreign
 	// key relation.
 	leftTabMeta := md.TableMeta(leftTab)
+	if leftTabMeta.IgnoreForeignKeys {
+		// We are not allowed to use any of the left table's outbound foreign keys.
+		return false
+	}
 	rightTabMeta := md.TableMeta(rightTab)
 	for i, cnt := 0, leftTabMeta.Table.IndexCount(); i < cnt; i++ {
 		index := leftTabMeta.Table.Index(i)

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -1576,7 +1576,7 @@ inner-join
       └── a.f = a.f [type=bool, outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
 
 # Left joins on a foreign key turn into inner joins.
-opt
+opt expect=SimplifyLeftJoinWithFilters
 SELECT *
 FROM c
 LEFT OUTER JOIN a
@@ -1598,7 +1598,7 @@ inner-join
       └── y = k [type=bool, outer=(2,4), constraints=(/2: (/NULL - ]; /4: (/NULL - ]), fd=(2)==(4), (4)==(2)]
 
 # Left joins on a multiple-column foreign key turn into inner joins.
-opt
+opt expect=SimplifyLeftJoinWithFilters
 SELECT *
 FROM d
 LEFT OUTER JOIN c
@@ -1624,7 +1624,7 @@ inner-join (merge)
  └── filters (true)
 
 # Left join on a part of a foreign key turns into an inner join.
-opt
+opt expect=SimplifyLeftJoinWithFilters
 SELECT *
 FROM d
 LEFT OUTER JOIN c
@@ -1646,7 +1646,7 @@ inner-join
       └── d.z = c.z [type=bool, outer=(3,6), constraints=(/3: (/NULL - ]; /6: (/NULL - ]), fd=(3)==(6), (6)==(3)]
 
 # Can't simplify: joins on non-foreign keys.
-opt
+opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT *
 FROM c
 LEFT OUTER JOIN a
@@ -1668,7 +1668,7 @@ left-join
       └── z = k [type=bool, outer=(3,4), constraints=(/3: (/NULL - ]; /4: (/NULL - ]), fd=(3)==(4), (4)==(3)]
 
 # Can't simplify: joins on non-foreign keys still in foreign key index.
-opt
+opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT *
 FROM c
 LEFT OUTER JOIN a
@@ -1693,7 +1693,7 @@ left-join (merge)
  └── filters (true)
 
 # Can't simplify: non-equality condition.
-opt
+opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM a FULL JOIN a AS a2 ON a.k<a2.k
 ----
 full-join
@@ -1712,7 +1712,7 @@ full-join
       └── a.k < a2.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 
 # Can't simplify: non-join equality condition.
-opt
+opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM a FULL JOIN a AS a2 ON a.f=1 AND a.f=a2.f
 ----
 full-join
@@ -1732,7 +1732,7 @@ full-join
       └── a.f = a2.f [type=bool, outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
 
 # Can't simplify: non-null column.
-opt
+opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM a FULL JOIN a AS a2 ON a.s=a2.s
 ----
 full-join
@@ -1751,7 +1751,7 @@ full-join
       └── a.s = a2.s [type=bool, outer=(4,9), constraints=(/4: (/NULL - ]; /9: (/NULL - ]), fd=(4)==(9), (9)==(4)]
 
 # Can't simplify: equality column that is synthesized.
-opt
+opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM a FULL JOIN (SELECT k+1 AS k FROM a) AS a2 ON a.k=a2.k
 ----
 full-join
@@ -1772,7 +1772,7 @@ full-join
       └── a.k = k [type=bool, outer=(1,11), constraints=(/1: (/NULL - ]; /11: (/NULL - ]), fd=(1)==(11), (11)==(1)]
 
 # Can't simplify: equality condition with different column ordinals.
-opt
+opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM a FULL JOIN a AS a2 ON a.k=a2.f
 ----
 full-join
@@ -1791,7 +1791,7 @@ full-join
       └── a.k = a2.f [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
 
 # Can't simplify: one equality condition has columns from same side of join.
-opt
+opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM a FULL JOIN a AS a2 ON a.k=a2.k AND a.f=a.f AND a2.f=a2.f
 ----
 full-join (merge)
@@ -1815,7 +1815,7 @@ full-join (merge)
       └── a2.f = a2.f [type=bool, outer=(8), constraints=(/8: (/NULL - ])]
 
 # Can't simplify: equality conditions have columns from different tables.
-opt
+opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM (SELECT * FROM a, b) AS a FULL JOIN a AS a2 ON a.k=a2.k AND a.x=a2.k
 ----
 full-join
@@ -1844,7 +1844,7 @@ full-join
       └── x = a2.k [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6)]
 
 # Can't simplify: The a2.x column is not part of unfilteredCols.
-opt
+opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM a LEFT JOIN (SELECT * FROM a, b) AS a2 ON a.k=a2.x
 ----
 right-join
@@ -1870,6 +1870,28 @@ right-join
  │    └── fd: (1)-->(2-5)
  └── filters
       └── k = x [type=bool, outer=(1,11), constraints=(/1: (/NULL - ]; /11: (/NULL - ]), fd=(1)==(11), (11)==(1)]
+
+# Can't simplify if IGNORE_FOREIGN_KEYS hint is passed.
+opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
+SELECT *
+FROM c@{IGNORE_FOREIGN_KEYS}
+LEFT OUTER JOIN a
+ON c.y = a.k
+----
+left-join
+ ├── columns: x:1(int!null) y:2(int!null) z:3(int!null) k:4(int) i:5(int) f:6(float) s:7(string) j:8(jsonb)
+ ├── key: (1,4)
+ ├── fd: (1)-->(2,3), (4)-->(5-8)
+ ├── scan c
+ │    ├── columns: x:1(int!null) y:2(int!null) z:3(int!null)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ ├── scan a
+ │    ├── columns: k:4(int!null) i:5(int) f:6(float!null) s:7(string) j:8(jsonb)
+ │    ├── key: (4)
+ │    └── fd: (4)-->(5-8)
+ └── filters
+      └── y = k [type=bool, outer=(2,4), constraints=(/2: (/NULL - ]; /4: (/NULL - ]), fd=(2)==(4), (4)==(2)]
 
 # --------------------------------------------------
 # EliminateSemiJoin

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -92,6 +92,9 @@ func (b *Builder) buildDataSource(
 		switch t := ds.(type) {
 		case cat.Table:
 			tabID := b.factory.Metadata().AddTableWithAlias(t, &resName)
+			if indexFlags != nil && indexFlags.IgnoreForeignKeys {
+				b.factory.Metadata().TableMeta(tabID).IgnoreForeignKeys = true
+			}
 			return b.buildScan(tabID, nil /* ordinals */, indexFlags, excludeMutations, inScope)
 		case cat.View:
 			return b.buildView(t, inScope)

--- a/pkg/sql/opt/table_meta.go
+++ b/pkg/sql/opt/table_meta.go
@@ -130,6 +130,12 @@ type TableMeta struct {
 	// is always an unqualified name.
 	Alias tree.TableName
 
+	// IgnoreForeignKeys is true if we should disable any rules that depend on the
+	// consistency of outgoing foreign key references. Set by the
+	// IGNORE_FOREIGN_KEYS table hint; useful for scrub queries meant to verify
+	// the consistency of foreign keys.
+	IgnoreForeignKeys bool
+
 	// anns annotates the table metadata with arbitrary data.
 	anns [maxTableAnnIDCount]interface{}
 }

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -674,8 +674,9 @@ func TestParse(t *testing.T) {
 		{`SELECT 'a' FROM t@primary`},
 		{`SELECT 'a' FROM t@like`},
 		{`SELECT 'a' FROM t@{NO_INDEX_JOIN}`},
+		{`SELECT 'a' FROM t@{IGNORE_FOREIGN_KEYS}`},
 		{`SELECT 'a' FROM t@{FORCE_INDEX=idx,ASC}`},
-		{`SELECT 'a' FROM t@{FORCE_INDEX=idx,DESC}`},
+		{`SELECT 'a' FROM t@{FORCE_INDEX=idx,DESC,IGNORE_FOREIGN_KEYS}`},
 		{`SELECT * FROM t AS "of" AS OF SYSTEM TIME '2016-01-01'`},
 
 		{`SELECT BOOL 'foo', 'foo'::BOOL`},
@@ -2308,6 +2309,13 @@ SELECT a FROM foo@{FORCE_INDEX=bar,NO_INDEX_JOIN}
 			`syntax error: NO_INDEX_JOIN specified multiple times at or near "no_index_join"
 SELECT a FROM foo@{NO_INDEX_JOIN,NO_INDEX_JOIN}
                                  ^
+`,
+		},
+		{
+			`SELECT a FROM foo@{IGNORE_FOREIGN_KEYS,IGNORE_FOREIGN_KEYS}`,
+			`syntax error: IGNORE_FOREIGN_KEYS specified multiple times at or near "ignore_foreign_keys"
+SELECT a FROM foo@{IGNORE_FOREIGN_KEYS,IGNORE_FOREIGN_KEYS}
+                                       ^
 `,
 		},
 		{

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -508,7 +508,7 @@ func newNameFromStr(s string) *tree.Name {
 
 %token <str> HAVING HASH HIGH HISTOGRAM HOUR
 
-%token <str> IF IFERROR IFNULL ILIKE IMMEDIATE IMPORT IN INCREMENT INCREMENTAL
+%token <str> IF IFERROR IFNULL IGNORE_FOREIGN_KEYS ILIKE IMMEDIATE IMPORT IN INCREMENT INCREMENTAL
 %token <str> INET INET_CONTAINED_BY_OR_EQUALS INET_CONTAINS_OR_CONTAINED_BY
 %token <str> INET_CONTAINS_OR_EQUALS INDEX INDEXES INJECT INTERLEAVE INITIALLY
 %token <str> INNER INSERT INT INT2VECTOR INT2 INT4 INT8 INT64 INTEGER
@@ -5975,7 +5975,13 @@ index_flags_param:
 |
   NO_INDEX_JOIN
   {
-     $$.val = &tree.IndexFlags{NoIndexJoin: true}
+    $$.val = &tree.IndexFlags{NoIndexJoin: true}
+  }
+|
+  IGNORE_FOREIGN_KEYS
+  {
+    /* SKIP DOC */
+    $$.val = &tree.IndexFlags{IgnoreForeignKeys: true}
   }
 
 index_flags_param_list:
@@ -6035,6 +6041,7 @@ opt_index_flags:
 // Index flags:
 //   '{' FORCE_INDEX = <idxname> [, ...] '}'
 //   '{' NO_INDEX_JOIN [, ...] '}'
+//   '{' IGNORE_FOREIGN_KEYS [, ...] '}'
 //
 // Join types:
 //   { INNER | { LEFT | RIGHT | FULL } [OUTER] } [ { HASH | MERGE | LOOKUP } ]
@@ -8960,6 +8967,7 @@ unreserved_keyword:
 | NO
 | NORMAL
 | NO_INDEX_JOIN
+| IGNORE_FOREIGN_KEYS
 | OF
 | OFF
 | OID


### PR DESCRIPTION
Add a hint that prevents optimizations that depend on the consistency
of foreign key relations. This will be useful for SCRUB queries which
are specifically meant to verify this consistency.

This hint doesn't need to be documented.

Release note: None