### PR TITLE
 sql: save some EvalCtx allocations

### DIFF
--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -59,7 +59,7 @@ func Load(
 
 	var txCtx transform.ExprTransformContext
 	curTime := timeutil.Unix(0, ts.WallTime)
-	evalCtx := tree.EvalContext{}
+	evalCtx := &tree.EvalContext{}
 	evalCtx.SetTxnTimestamp(curTime)
 	evalCtx.SetStmtTimestamp(curTime)
 
@@ -164,7 +164,7 @@ func Load(
 			// At this point the CREATE statements in the loaded SQL do not
 			// use the SERIAL type so we need not process SERIAL types here.
 			desc, err := sql.MakeTableDesc(ctx, txn, nil /* vt */, st, s, dbDesc.ID,
-				0 /* table ID */, ts, privs, affected, nil, &evalCtx)
+				0 /* table ID */, ts, privs, affected, nil, evalCtx)
 			if err != nil {
 				return backupccl.BackupDescriptor{}, errors.Wrap(err, "make table desc")
 			}
@@ -188,7 +188,7 @@ func Load(
 				return backupccl.BackupDescriptor{}, errors.Wrap(err, "make row inserter")
 			}
 			cols, defaultExprs, err =
-				sqlbase.ProcessDefaultColumns(tableDesc.Columns, tableDesc, &txCtx, &evalCtx)
+				sqlbase.ProcessDefaultColumns(tableDesc.Columns, tableDesc, &txCtx, evalCtx)
 			if err != nil {
 				return backupccl.BackupDescriptor{}, errors.Wrap(err, "process default columns")
 			}
@@ -256,7 +256,7 @@ func insertStmtToKVs(
 	tableDesc *sqlbase.ImmutableTableDescriptor,
 	defaultExprs []tree.TypedExpr,
 	cols []sqlbase.ColumnDescriptor,
-	evalCtx tree.EvalContext,
+	evalCtx *tree.EvalContext,
 	ri row.Inserter,
 	stmt *tree.Insert,
 	f func(roachpb.KeyValue),

--- a/pkg/ccl/importccl/read_import_proc.go
+++ b/pkg/ccl/importccl/read_import_proc.go
@@ -300,7 +300,7 @@ func (c *rowConverter) row(ctx context.Context, fileIndex int32, rowIndex int64)
 	var computedCols []sqlbase.ColumnDescriptor
 
 	insertRow, err := sql.GenerateInsertRow(
-		c.defaultExprs, computeExprs, c.cols, computedCols, *c.evalCtx, c.tableDesc, c.datums, &c.computedIVarContainer)
+		c.defaultExprs, computeExprs, c.cols, computedCols, c.evalCtx, c.tableDesc, c.datums, &c.computedIVarContainer)
 	if err != nil {
 		return pgerror.Wrap(err, pgerror.CodeDataExceptionError,
 			"generate insert row")
@@ -437,9 +437,9 @@ func (cp *readImportDataProcessor) doRun(ctx context.Context) error {
 			}
 		}
 		if isWorkload {
-			conv = newWorkloadReader(kvCh, singleTable, cp.flowCtx.NewEvalCtx)
+			conv = newWorkloadReader(kvCh, singleTable, evalCtx)
 		} else {
-			conv = newCSVInputReader(kvCh, cp.spec.Format.Csv, singleTable, cp.flowCtx)
+			conv = newCSVInputReader(kvCh, cp.spec.Format.Csv, singleTable, evalCtx)
 		}
 	case roachpb.IOFileFormat_MysqlOutfile:
 		conv, err = newMysqloutfileReader(kvCh, cp.spec.Format.MysqlOut, singleTable, evalCtx)

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -528,7 +528,7 @@ func (n *insertNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 		n.run.computeExprs,
 		n.run.insertCols,
 		n.run.computedCols,
-		*params.EvalContext().Copy(),
+		params.EvalContext().Copy(),
 		n.run.ti.tableDesc(),
 		sourceVals,
 		&n.run.iVarContainerForComputedCols,
@@ -623,7 +623,7 @@ func GenerateInsertRow(
 	computeExprs []tree.TypedExpr,
 	insertCols []sqlbase.ColumnDescriptor,
 	computedCols []sqlbase.ColumnDescriptor,
-	evalCtx tree.EvalContext,
+	evalCtx *tree.EvalContext,
 	tableDesc *sqlbase.ImmutableTableDescriptor,
 	rowVals tree.Datums,
 	rowContainerForComputedVals *sqlbase.RowIndexedVarContainer,
@@ -644,7 +644,7 @@ func GenerateInsertRow(
 				rowVals[i] = tree.DNull
 				continue
 			}
-			d, err := defaultExprs[i].Eval(&evalCtx)
+			d, err := defaultExprs[i].Eval(evalCtx)
 			if err != nil {
 				return nil, err
 			}
@@ -661,7 +661,7 @@ func GenerateInsertRow(
 			// since we disallow computed columns from referencing other computed
 			// columns, all the columns which could possibly be referenced *are*
 			// available.
-			d, err := computeExprs[i].Eval(&evalCtx)
+			d, err := computeExprs[i].Eval(evalCtx)
 			if err != nil {
 				return nil, pgerror.Wrapf(err, pgerror.CodeDataExceptionError,
 					"computed column %s", tree.ErrString((*tree.Name)(&computedCols[i].Name)))

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -371,7 +371,7 @@ func (n *upsertNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 		n.run.computeExprs,
 		n.run.insertCols,
 		n.run.computedCols,
-		*params.EvalContext().Copy(),
+		params.EvalContext().Copy(),
 		n.run.tw.tableDesc(),
 		sourceVals,
 		&n.run.iVarContainerForComputedCols,


### PR DESCRIPTION
EvalCtx is big, so we shouldn't be passing it anyway. Found by digging
into allocations that pprof attributed to the method signature of
sql.GenerateInsertRow. I tried to see if this showed up on any of our
SQL level INSERT benchmarks, but it seemed to be in the noise.

    name                                  old time/op    new time/op    delta
    ConvertToKVs/tpcc/warehouses=1-8         3.83s ± 0%     3.66s ± 1%   -4.53%  (p=0.016 n=4+5)
    ConvertToSSTable/tpcc/warehouses=1-8     5.50s ± 4%     5.13s ± 1%   -6.80%  (p=0.008 n=5+5)

    name                                  old speed      new speed      delta
    ConvertToKVs/tpcc/warehouses=1-8      23.2MB/s ± 0%  24.3MB/s ± 1%   +4.77%  (p=0.016 n=4+5)
    ConvertToSSTable/tpcc/warehouses=1-8  15.1MB/s ± 4%  16.2MB/s ± 1%   +7.27%  (p=0.008 n=5+5)

    name                                  old alloc/op   new alloc/op   delta
    ConvertToKVs/tpcc/warehouses=1-8         953MB ± 0%     704MB ± 0%  -26.17%  (p=0.029 n=4+4)
    ConvertToSSTable/tpcc/warehouses=1-8    1.64GB ± 0%    1.39GB ± 0%  -15.19%  (p=0.016 n=4+5)

    name                                  old allocs/op  new allocs/op  delta
    ConvertToKVs/tpcc/warehouses=1-8         17.4M ± 0%     16.8M ± 0%   -3.45%  (p=0.008 n=5+5)
    ConvertToSSTable/tpcc/warehouses=1-8     17.4M ± 0%     16.8M ± 0%   -3.45%  (p=0.008 n=5+5)

Also a small cleanup in some import code to use EvalCtx's Copy method
instead of passing around a function closure.

Touches #34809

Release note: None