### PR TITLE
opt, sql: fix type inference of TypeCheck for subqueries

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/subquery-opt
+++ b/pkg/sql/logictest/testdata/logic_test/subquery-opt
@@ -1,0 +1,26 @@
+# LogicTest: local-opt fakedist-opt
+
+# Regression test for #37263. This test is broken in the heuristic planner
+# because it does not correctly type check subqueries.
+query B
+SELECT 3::decimal IN (SELECT 1)
+----
+false
+
+query error unsupported comparison operator
+SELECT 3::decimal IN (SELECT 1::int)
+
+query B
+SELECT 1 IN (SELECT '1');
+----
+true
+
+# Regression test for #14554.
+query ITIIIII
+SELECT t.oid, t.typname, t.typsend, t.typreceive, t.typoutput, t.typinput, t.typelem
+	FROM pg_type AS t
+	WHERE t.oid NOT IN (
+	  SELECT (ARRAY[704,11676,10005,3912,11765,59410,11397])[i]
+	  FROM generate_series(1, 376) AS i
+	)
+----

--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -167,7 +167,9 @@ SELECT 1 in (SELECT 1)
 ----
 true
 
-statement error unsupported comparison operator: <int> IN <tuple{string}>
+# The heuristic planner and the optimizer give different errors for this query.
+# Accept them both.
+statement error (unsupported comparison operator: <int> IN <tuple{string}>|could not parse "a" as type int)
 SELECT 1 IN (SELECT 'a')
 
 statement error unsupported comparison operator: <int> IN <tuple{tuple{int, int}}>

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
 
 // Builder holds the context needed for building a memo structure from a SQL
@@ -154,7 +155,7 @@ func (b *Builder) Build() (err error) {
 
 	// Build the memo, and call SetRoot on the memo to indicate the root group
 	// and physical properties.
-	outScope := b.buildStmt(b.stmt, b.allocScope())
+	outScope := b.buildStmt(b.stmt, nil /* desiredTypes */, b.allocScope())
 	physical := outScope.makePhysicalProps()
 	b.factory.Memo().SetRoot(outScope.expr, physical)
 	return nil
@@ -192,9 +193,11 @@ func unimplementedWithIssueDetailf(
 //
 // outScope  This return value contains the newly bound variables that will be
 //           visible to enclosing statements, as well as a pointer to any
-//           "parent" scope that is still visible. The top-level memo group ID
-//           for the built statement/expression is returned in outScope.group.
-func (b *Builder) buildStmt(stmt tree.Statement, inScope *scope) (outScope *scope) {
+//           "parent" scope that is still visible. The top-level memo expression
+//           for the built statement/expression is returned in outScope.expr.
+func (b *Builder) buildStmt(
+	stmt tree.Statement, desiredTypes []*types.T, inScope *scope,
+) (outScope *scope) {
 	// NB: The case statements are sorted lexicographically.
 	switch stmt := stmt.(type) {
 	case *tree.CreateTable:
@@ -210,10 +213,10 @@ func (b *Builder) buildStmt(stmt tree.Statement, inScope *scope) (outScope *scop
 		return b.buildInsert(stmt, inScope)
 
 	case *tree.ParenSelect:
-		return b.buildSelect(stmt.Select, nil /* desiredTypes */, inScope)
+		return b.buildSelect(stmt.Select, desiredTypes, inScope)
 
 	case *tree.Select:
-		return b.buildSelect(stmt, nil /* desiredTypes */, inScope)
+		return b.buildSelect(stmt, desiredTypes, inScope)
 
 	case *tree.ShowTraceForSession:
 		return b.buildShowTrace(stmt, inScope)
@@ -231,7 +234,7 @@ func (b *Builder) buildStmt(stmt tree.Statement, inScope *scope) (outScope *scop
 			// register all those dependencies with the metadata (for cache
 			// invalidation). We don't care about caching plans for these statements.
 			b.DisableMemoReuse = true
-			return b.buildStmt(newStmt, inScope)
+			return b.buildStmt(newStmt, desiredTypes, inScope)
 		}
 		panic(unimplementedWithIssueDetailf(34848, stmt.StatementTag(), "unsupported statement: %T", stmt))
 	}

--- a/pkg/sql/opt/optbuilder/explain.go
+++ b/pkg/sql/opt/optbuilder/explain.go
@@ -31,7 +31,7 @@ func (b *Builder) buildExplain(explain *tree.Explain, inScope *scope) (outScope 
 
 	// We don't allow the statement under Explain to reference outer columns, so we
 	// pass a "blank" scope rather than inScope.
-	stmtScope := b.buildStmt(explain.Statement, &scope{builder: b})
+	stmtScope := b.buildStmt(explain.Statement, nil /* desiredTypes */, &scope{builder: b})
 	outScope = inScope.push()
 
 	var cols sqlbase.ResultColumns

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -861,7 +861,9 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 		if sub, ok := t.Subquery.(*tree.Subquery); ok {
 			// Copy the ArrayFlatten expression so that the tree isn't mutated.
 			copy := *t
-			copy.Subquery = s.replaceSubquery(sub, false /* wrapInTuple */, 1 /* desiredColumns */, extraColsAllowed)
+			copy.Subquery = s.replaceSubquery(
+				sub, false /* wrapInTuple */, 1 /* desiredNumColumns */, extraColsAllowed,
+			)
 			expr = &copy
 		}
 
@@ -876,7 +878,9 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 			if sub, ok := t.Right.(*tree.Subquery); ok {
 				// Copy the Comparison expression so that the tree isn't mutated.
 				copy := *t
-				copy.Right = s.replaceSubquery(sub, true /* wrapInTuple */, -1 /* desiredColumns */, noExtraColsAllowed)
+				copy.Right = s.replaceSubquery(
+					sub, true /* wrapInTuple */, -1 /* desiredNumColumns */, noExtraColsAllowed,
+				)
 				expr = &copy
 			}
 		}
@@ -888,9 +892,13 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 		}
 
 		if t.Exists {
-			expr = s.replaceSubquery(t, true /* wrapInTuple */, -1 /* desiredColumns */, noExtraColsAllowed)
+			expr = s.replaceSubquery(
+				t, true /* wrapInTuple */, -1 /* desiredNumColumns */, noExtraColsAllowed,
+			)
 		} else {
-			expr = s.replaceSubquery(t, false /* wrapInTuple */, s.columns /* desiredColumns */, noExtraColsAllowed)
+			expr = s.replaceSubquery(
+				t, false /* wrapInTuple */, s.columns /* desiredNumColumns */, noExtraColsAllowed,
+			)
 		}
 	}
 
@@ -1146,12 +1154,12 @@ const (
 	noExtraColsAllowed = false
 )
 
-// Replace a raw subquery node with a typed subquery. wrapInTuple specifies
-// whether the return type of the subquery should be wrapped in a tuple.
-// wrapInTuple is true for subqueries that may return multiple rows in
+// Replace a raw tree.Subquery node with a lazily typed subquery. wrapInTuple
+// specifies whether the return type of the subquery should be wrapped in a
+// tuple. wrapInTuple is true for subqueries that may return multiple rows in
 // comparison expressions (e.g., IN, ANY, ALL) and EXISTS expressions.
-// desiredColumns specifies the desired number of columns for the
-// subquery. Specifying -1 for desiredColumns allows the subquery to return any
+// desiredNumColumns specifies the desired number of columns for the subquery.
+// Specifying -1 for desiredNumColumns allows the subquery to return any
 // number of columns and is used when the normal type checking machinery will
 // verify that the correct number of columns is returned.
 // If extraColsAllowed is true, extra columns built from the subquery (such as
@@ -1159,59 +1167,15 @@ const (
 // It is the duty of the caller to ensure that those columns are eventually
 // dealt with.
 func (s *scope) replaceSubquery(
-	sub *tree.Subquery, wrapInTuple bool, desiredColumns int, extraColsAllowed bool,
+	sub *tree.Subquery, wrapInTuple bool, desiredNumColumns int, extraColsAllowed bool,
 ) *subquery {
-	if s.replaceSRFs {
-		// We need to save and restore the previous value of the replaceSRFs field in
-		// case we are recursively called within a subquery context.
-		defer func() { s.replaceSRFs = true }()
-		s.replaceSRFs = false
+	return &subquery{
+		Subquery:          sub,
+		wrapInTuple:       wrapInTuple,
+		desiredNumColumns: desiredNumColumns,
+		extraColsAllowed:  extraColsAllowed,
+		scope:             s,
 	}
-
-	subq := subquery{
-		Subquery:    sub,
-		wrapInTuple: wrapInTuple,
-	}
-
-	// Save and restore the previous value of s.builder.subquery in case we are
-	// recursively called within a subquery context.
-	outer := s.builder.subquery
-	defer func() { s.builder.subquery = outer }()
-	s.builder.subquery = &subq
-
-	outScope := s.builder.buildStmt(sub.Select, s)
-	ord := outScope.ordering
-
-	// Treat the subquery result as an anonymous data source (i.e. column names
-	// are not qualified). Remove hidden columns, as they are not accessible
-	// outside the subquery.
-	outScope.setTableAlias("")
-	outScope.removeHiddenCols()
-
-	if desiredColumns > 0 && len(outScope.cols) != desiredColumns {
-		n := len(outScope.cols)
-		switch desiredColumns {
-		case 1:
-			panic(pgerror.Newf(pgerror.CodeSyntaxError,
-				"subquery must return only one column, found %d", n))
-		default:
-			panic(pgerror.Newf(pgerror.CodeSyntaxError,
-				"subquery must return %d columns, found %d", desiredColumns, n))
-		}
-	}
-
-	if len(outScope.extraCols) > 0 && !extraColsAllowed {
-		// We need to add a projection to remove the extra columns.
-		projScope := outScope.push()
-		projScope.appendColumnsFromScope(outScope)
-		projScope.expr = s.builder.constructProject(outScope.expr.(memo.RelExpr), projScope.cols)
-		outScope = projScope
-	}
-
-	subq.cols = outScope.cols
-	subq.node = outScope.expr.(memo.RelExpr)
-	subq.ordering = ord
-	return &subq
 }
 
 // VisitPost is part of the Visitor interface.

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -108,7 +108,7 @@ func (b *Builder) buildDataSource(
 		return b.buildZip(source.Items, inScope)
 
 	case *tree.Subquery:
-		outScope = b.buildStmt(source.Select, inScope)
+		outScope = b.buildStmt(source.Select, nil /* desiredTypes */, inScope)
 
 		// Treat the subquery result as an anonymous data source (i.e. column names
 		// are not qualified). Remove hidden columns, as they are not accessible
@@ -119,7 +119,7 @@ func (b *Builder) buildDataSource(
 		return outScope
 
 	case *tree.StatementSource:
-		outScope = b.buildStmt(source.Statement, inScope)
+		outScope = b.buildStmt(source.Statement, nil /* desiredTypes */, inScope)
 		if len(outScope.cols) == 0 {
 			panic(pgerror.Newf(pgerror.CodeUndefinedColumnError,
 				"statement source \"%v\" does not return any columns", source.Statement))
@@ -447,7 +447,7 @@ func (b *Builder) buildCTE(ctes []*tree.CTE, inScope *scope) (outScope *scope) {
 
 	outScope.ctes = make(map[string]*cteSource)
 	for i := range ctes {
-		cteScope := b.buildStmt(ctes[i].Stmt, outScope)
+		cteScope := b.buildStmt(ctes[i].Stmt, nil /* desiredTypes */, outScope)
 		cols := cteScope.cols
 		name := ctes[i].Name.Alias
 

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -246,16 +246,16 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: y:1(int!null)
+           │    ├── columns: y:2(int!null)
            │    ├── values
            │    │    └── tuple [type=tuple]
            │    └── projections
            │         └── const: 1 [type=int]
            └── subquery [type=int]
                 └── max1-row
-                     ├── columns: x:2(int!null)
+                     ├── columns: x:1(int!null)
                      └── project
-                          ├── columns: x:2(int!null)
+                          ├── columns: x:1(int!null)
                           ├── values
                           │    └── tuple [type=tuple]
                           └── projections
@@ -304,7 +304,7 @@ project
            ├── project
            │    ├── columns: column5:5(tuple{int, int})
            │    ├── project
-           │    │    ├── columns: c:1(int!null) d:2(int!null)
+           │    │    ├── columns: c:3(int!null) d:4(int!null)
            │    │    ├── values
            │    │    │    └── tuple [type=tuple]
            │    │    └── projections
@@ -320,7 +320,7 @@ project
                      └── project
                           ├── columns: column6:6(tuple{int, int})
                           ├── project
-                          │    ├── columns: a:3(int!null) b:4(int!null)
+                          │    ├── columns: a:1(int!null) b:2(int!null)
                           │    ├── values
                           │    │    └── tuple [type=tuple]
                           │    └── projections
@@ -381,7 +381,7 @@ project
            ├── project
            │    ├── columns: column4:4(tuple{int, int})
            │    ├── project
-           │    │    ├── columns: b:1(int!null) c:2(int!null)
+           │    │    ├── columns: b:2(int!null) c:3(int!null)
            │    │    ├── values
            │    │    │    └── tuple [type=tuple]
            │    │    └── projections
@@ -393,9 +393,9 @@ project
            │              └── variable: c [type=int]
            └── subquery [type=tuple{int, int}]
                 └── max1-row
-                     ├── columns: a:3(tuple{int, int})
+                     ├── columns: a:1(tuple{int, int})
                      └── project
-                          ├── columns: a:3(tuple{int, int})
+                          ├── columns: a:1(tuple{int, int})
                           ├── values
                           │    └── tuple [type=tuple]
                           └── projections
@@ -442,7 +442,7 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: c:1(tuple{int, int})
+           │    ├── columns: c:3(tuple{int, int})
            │    ├── values
            │    │    └── tuple [type=tuple]
            │    └── projections
@@ -455,7 +455,7 @@ project
                      └── project
                           ├── columns: column4:4(tuple{int, int})
                           ├── project
-                          │    ├── columns: a:2(int!null) b:3(int!null)
+                          │    ├── columns: a:1(int!null) b:2(int!null)
                           │    ├── values
                           │    │    └── tuple [type=tuple]
                           │    └── projections
@@ -476,7 +476,7 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: b:1(tuple{int, int})
+           │    ├── columns: b:2(tuple{int, int})
            │    ├── values
            │    │    └── tuple [type=tuple]
            │    └── projections
@@ -485,9 +485,9 @@ project
            │              └── const: 2 [type=int]
            └── subquery [type=tuple{int, int}]
                 └── max1-row
-                     ├── columns: a:2(tuple{int, int})
+                     ├── columns: a:1(tuple{int, int})
                      └── project
-                          ├── columns: a:2(tuple{int, int})
+                          ├── columns: a:1(tuple{int, int})
                           ├── values
                           │    └── tuple [type=tuple]
                           └── projections
@@ -1965,7 +1965,7 @@ SELECT min(a) IN (SELECT b FROM u) FROM t
 project
  ├── columns: "?column?":6(bool)
  ├── scalar-group-by
- │    ├── columns: min:5(string)
+ │    ├── columns: min:3(string)
  │    ├── project
  │    │    ├── columns: a:1(string)
  │    │    └── scan t
@@ -1976,9 +1976,9 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: b:3(string)
+           │    ├── columns: b:4(string)
            │    └── scan u
-           │         └── columns: b:3(string) u.rowid:4(int!null)
+           │         └── columns: b:4(string) u.rowid:5(int!null)
            └── variable: min [type=string]
 
 # Regression test for #28240. Make sure that the tuple labels are stripped from
@@ -2365,35 +2365,35 @@ FROM
 project
  ├── columns: "?column?":21(tuple{bool, int})
  ├── scalar-group-by
- │    ├── columns: max:16(int) max:19(int)
+ │    ├── columns: max:8(int) max:18(int)
  │    ├── project
- │    │    ├── columns: column15:15(int) a:18(int)
+ │    │    ├── columns: a:7(int) column17:17(int)
  │    │    ├── scan t3
  │    │    │    └── columns: t3.a:1(int) t3.b:2(int) t3.rowid:3(int!null)
  │    │    └── projections
- │    │         ├── subquery [type=int]
- │    │         │    └── max1-row
- │    │         │         ├── columns: max:13(int)
- │    │         │         └── project
- │    │         │              ├── columns: max:13(int)
- │    │         │              └── group-by
- │    │         │                   ├── columns: max:13(int) b:14(int)
- │    │         │                   ├── grouping columns: b:14(int)
- │    │         │                   ├── project
- │    │         │                   │    ├── columns: b:14(int) t1.a:10(int)
- │    │         │                   │    ├── scan t1
- │    │         │                   │    │    └── columns: t1.a:10(int) t1.b:11(int) t1.rowid:12(int!null)
- │    │         │                   │    └── projections
- │    │         │                   │         └── variable: t3.b [type=int]
- │    │         │                   └── aggregations
- │    │         │                        └── max [type=int]
- │    │         │                             └── variable: t1.a [type=int]
- │    │         └── variable: t3.a [type=int]
+ │    │         ├── variable: t3.a [type=int]
+ │    │         └── subquery [type=int]
+ │    │              └── max1-row
+ │    │                   ├── columns: max:15(int)
+ │    │                   └── project
+ │    │                        ├── columns: max:15(int)
+ │    │                        └── group-by
+ │    │                             ├── columns: max:15(int) b:16(int)
+ │    │                             ├── grouping columns: b:16(int)
+ │    │                             ├── project
+ │    │                             │    ├── columns: b:16(int) t1.a:12(int)
+ │    │                             │    ├── scan t1
+ │    │                             │    │    └── columns: t1.a:12(int) t1.b:13(int) t1.rowid:14(int!null)
+ │    │                             │    └── projections
+ │    │                             │         └── variable: t3.b [type=int]
+ │    │                             └── aggregations
+ │    │                                  └── max [type=int]
+ │    │                                       └── variable: t1.a [type=int]
  │    └── aggregations
  │         ├── max [type=int]
- │         │    └── variable: column15 [type=int]
+ │         │    └── variable: a [type=int]
  │         └── max [type=int]
- │              └── variable: a [type=int]
+ │              └── variable: column17 [type=int]
  └── projections
       └── subquery [type=tuple{bool, int}]
            └── max1-row
@@ -2407,9 +2407,9 @@ project
                                ├── not [type=bool]
                                │    └── any: ge [type=bool]
                                │         ├── project
-                               │         │    ├── columns: max:17(int)
+                               │         │    ├── columns: max:19(int)
                                │         │    ├── scan t1
-                               │         │    │    └── columns: t1.a:7(int) t1.b:8(int) t1.rowid:9(int!null)
+                               │         │    │    └── columns: t1.a:9(int) t1.b:10(int) t1.rowid:11(int!null)
                                │         │    └── projections
                                │         │         └── variable: max [type=int]
                                │         └── variable: t2.a [type=int]
@@ -2526,3 +2526,27 @@ build
 SELECT * FROM xyzs WHERE (SELECT sum(x) FROM (SELECT u FROM kuv) GROUP BY u) > 100;
 ----
 error (42803): aggregate functions are not allowed in WHERE
+
+# Regression test for #37263.
+build
+SELECT 3::decimal IN (SELECT 1)
+----
+project
+ ├── columns: "?column?":2(bool)
+ ├── values
+ │    └── tuple [type=tuple]
+ └── projections
+      └── any: eq [type=bool]
+           ├── project
+           │    ├── columns: "?column?":1(decimal!null)
+           │    ├── values
+           │    │    └── tuple [type=tuple]
+           │    └── projections
+           │         └── const: 1 [type=decimal]
+           └── cast: DECIMAL [type=decimal]
+                └── const: 3 [type=decimal]
+
+build
+SELECT 3::decimal IN (SELECT 1::int)
+----
+error (22023): unsupported comparison operator: <decimal> IN <tuple{int}>

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -108,6 +108,16 @@ var _ Operator = UnaryOperator(0)
 var _ Operator = BinaryOperator(0)
 var _ Operator = ComparisonOperator(0)
 
+// SubqueryExpr is an interface used to identify an expression as a subquery.
+// It is implemented by both tree.Subquery and optbuilder.subquery, and is
+// used in TypeCheck.
+type SubqueryExpr interface {
+	Expr
+	SubqueryExpr()
+}
+
+var _ SubqueryExpr = &Subquery{}
+
 // exprFmtWithParen is a variant of Format() which adds a set of outer parens
 // if the expression involves an operator. It is used internally when the
 // expression is part of another expression and we know it is preceded or
@@ -961,6 +971,9 @@ func (node *Subquery) SetType(t *types.T) {
 
 // Variable implements the VariableExpr interface.
 func (*Subquery) Variable() {}
+
+// SubqueryExpr implements the SubqueryExpr interface.
+func (*Subquery) SubqueryExpr() {}
 
 // Format implements the NodeFormatter interface.
 func (node *Subquery) Format(ctx *FmtCtx) {

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1684,6 +1684,8 @@ func typeCheckComparisonOp(
 
 	_, leftIsTuple := foldedLeft.(*Tuple)
 	rightTuple, rightIsTuple := foldedRight.(*Tuple)
+
+	_, rightIsSubquery := foldedRight.(SubqueryExpr)
 	switch {
 	case foldedOp == In && rightIsTuple:
 		sameTypeExprs := make([]Expr, len(rightTuple.Exprs)+1)
@@ -1716,6 +1718,37 @@ func typeCheckComparisonOp(
 			return rightTuple, typedLeft, fn, false, nil
 		}
 		return typedLeft, rightTuple, fn, false, nil
+
+	case foldedOp == In && rightIsSubquery:
+		typedLeft, err := foldedLeft.TypeCheck(ctx, types.Any)
+		if err != nil {
+			sigWithErr := fmt.Sprintf(compExprsFmt, left, op, right, err)
+			return nil, nil, nil, false,
+				pgerror.Newf(pgerror.CodeInvalidParameterValueError, unsupportedCompErrFmt, sigWithErr)
+		}
+
+		typ := typedLeft.ResolvedType()
+		fn, ok := ops.lookupImpl(typ, types.AnyTuple)
+		if !ok {
+			sig := fmt.Sprintf(compSignatureFmt, typ, op, types.AnyTuple)
+			return nil, nil, nil, false,
+				pgerror.Newf(pgerror.CodeInvalidParameterValueError, unsupportedCompErrFmt, sig)
+		}
+
+		desired := types.MakeTuple([]types.T{*typ})
+		typedRight, err := foldedRight.TypeCheck(ctx, desired)
+		if err != nil {
+			sigWithErr := fmt.Sprintf(compExprsFmt, left, op, right, err)
+			return nil, nil, nil, false,
+				pgerror.Newf(pgerror.CodeInvalidParameterValueError, unsupportedCompErrFmt, sigWithErr)
+		}
+
+		if err := typeCheckSubqueryWithIn(
+			typedLeft.ResolvedType(), typedRight.ResolvedType(),
+		); err != nil {
+			return nil, nil, nil, false, err
+		}
+		return typedLeft, typedRight, fn, false, nil
 
 	case leftIsTuple && rightIsTuple:
 		fn, ok := ops.lookupImpl(types.AnyTuple, types.AnyTuple)
@@ -1750,12 +1783,6 @@ func typeCheckComparisonOp(
 	}
 	leftReturn := leftExpr.ResolvedType()
 	rightReturn := rightExpr.ResolvedType()
-
-	if foldedOp == In {
-		if err := typeCheckSubqueryWithIn(leftReturn, rightReturn); err != nil {
-			return nil, nil, nil, false, err
-		}
-	}
 
 	// Return early if at least one overload is possible, NULL is an argument,
 	// and none of the overloads accept NULL.


### PR DESCRIPTION
Prior to this commit, the optimizer was not correctly inferring the types of
columns in subqueries for expressions of the form `scalar IN (subquery)`.
This was due to two problems which have now been fixed:

1. The subquery was built as a relational expression before the desired types
   were known. Now the subquery build is delayed until `TypeCheck` is called for
   the first time.

2. For subqueries on the right side of an `IN` expression, the desired type
   passed into `TypeCheck` was `AnyTuple`. This resulted in an error later on in
   `typeCheckSubqueryWithIn`, which checks to make sure the type of the subquery
   is `tuple{T}` where `T` is the type of the left expression. Now the desired
   type passed into `TypeCheck` is `tuple{T}`.

Note that this commit only fixes type inference for the optimizer. It is still
broken in the heuristic planner.

Fixes #37263
Fixes #14554

Release note (bug fix): Fixed type inference of columns in subqueries for
some expressions of the form `scalar IN (subquery)`.