### PR TITLE
release-19.1: cli/{start,init}: ensure `cockroach init` always errors on ready clusters

### DIFF
--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -97,9 +97,11 @@ func (s *initServer) awaitBootstrap() (initServerResult, error) {
 func (s *initServer) Bootstrap(
 	ctx context.Context, request *serverpb.BootstrapRequest,
 ) (response *serverpb.BootstrapResponse, err error) {
-	if err := s.testOrSetRejectErr(fmt.Errorf("cluster has already been initialized")); err != nil {
+	if err := s.testOrSetRejectErr(errClusterInitialized); err != nil {
 		return nil, err
 	}
 	close(s.bootstrapReqCh)
 	return &serverpb.BootstrapResponse{}, nil
 }
+
+var errClusterInitialized = fmt.Errorf("cluster has already been initialized")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1403,6 +1403,13 @@ func (s *Server) Start(ctx context.Context) error {
 			hlcUpperBound,
 			timeutil.SleepUntil,
 		)
+
+		// Ensure that any subsequent use of `cockroach init` will receive
+		// an error "the cluster was already initialized."
+		if _, err := s.initServer.Bootstrap(ctx, &serverpb.BootstrapRequest{}); err != nil {
+			log.Fatal(ctx, err)
+		}
+
 	} else if len(s.cfg.GossipBootstrapResolvers) == 0 {
 		// If the _unfiltered_ list of hosts from the --join flag is
 		// empty, then this node can bootstrap a new cluster. We disallow


### PR DESCRIPTION
Backport 1/1 commits from #37399.

/cc @cockroachdb/release

---

Release note (bug fix): `cockroach init` will now always properly
report when a cluster is already initialized, even after the node that
it's connecting to is restarted.
