### PR TITLE
roachprod: don't pollute logs with verbose ssh logs

### DIFF
--- a/pkg/cmd/roachprod/config/config.go
+++ b/pkg/cmd/roachprod/config/config.go
@@ -41,7 +41,8 @@ func init() {
 // take place on the local machine.  Later in the refactoring,
 // this ought to be replaced by a LocalCloudProvider or somesuch.
 const (
-	DefaultHostDir = "${HOME}/.roachprod/hosts"
-	EmailDomain    = "@cockroachlabs.com"
-	Local          = "local"
+	DefaultDebugDir = "${HOME}/.roachprod/debug"
+	DefaultHostDir  = "${HOME}/.roachprod/hosts"
+	EmailDomain     = "@cockroachlabs.com"
+	Local           = "local"
 )

--- a/pkg/cmd/roachprod/hosts.go
+++ b/pkg/cmd/roachprod/hosts.go
@@ -31,9 +31,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-func initHostDir() error {
+func initDirs() error {
 	hd := os.ExpandEnv(config.DefaultHostDir)
-	return os.MkdirAll(hd, 0755)
+	if err := os.MkdirAll(hd, 0755); err != nil {
+		return err
+	}
+	return os.MkdirAll(os.ExpandEnv(config.DefaultDebugDir), 0755)
 }
 
 func syncHosts(cloud *cloud.Cloud) error {
@@ -116,6 +119,8 @@ func loadClusters() error {
 		return err
 	}
 
+	debugDir := os.ExpandEnv(config.DefaultDebugDir)
+
 	for _, file := range files {
 		if !file.Mode().IsRegular() {
 			continue
@@ -132,7 +137,8 @@ func loadClusters() error {
 		lines := strings.Split(string(contents), "\n")
 
 		c := &install.SyncedCluster{
-			Name: file.Name(),
+			Name:     file.Name(),
+			DebugDir: debugDir,
 		}
 
 		for _, l := range lines {

--- a/pkg/cmd/roachprod/install/cluster_synced.go
+++ b/pkg/cmd/roachprod/install/cluster_synced.go
@@ -79,6 +79,9 @@ type SyncedCluster struct {
 	Quiet       bool
 	// AuthorizedKeys is used by SetupSSH to add additional authorized keys.
 	AuthorizedKeys []byte
+
+	// Used to stash debug information.
+	DebugDir string
 }
 
 func (c *SyncedCluster) host(index int) string {
@@ -144,7 +147,7 @@ func (c *SyncedCluster) newSession(i int) (session, error) {
 	if c.IsLocal() {
 		return newLocalSession(), nil
 	}
-	return newRemoteSession(c.user(i), c.host(i))
+	return newRemoteSession(c.user(i), c.host(i), c.DebugDir)
 }
 
 // Stop TODO(peter): document

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -1715,7 +1715,7 @@ Node specification
 		os.Exit(1)
 	}
 
-	if err := initHostDir(); err != nil {
+	if err := initDirs(); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
I added verbose logging in #37483 but made the poor decision to spew it
to stderr when the command exited nonzero. As a consequence, many test
failures are now obfuscated by high-verbosity ssh logs.

Change the behavior so that the error message is wrapped with a path to
the logs. We grab the contents of `~/.roachprod` in CI, so we'll be able
to access the logs in the artifacts (`roachprod_state`).

```
$ ./bin/roachprod ssh tobias-test -- echo hi
hi
$ ls ~/.roachprod/debug/
$ ./bin/roachprod ssh tobias-test -- false
Error:  ssh verbose log retained in /Users/tschottdorf/.roachprod/debug/ssh_35.231.83.24_2019-05-20T12:53:49Z: exit status 1
$ ls ~/.roachprod/debug/
ssh_35.231.83.24_2019-05-20T12:53:49Z
```

Touches #36963.

Release note: None