### PR TITLE
release-19.1: opt, sql: fix type inference of TypeCheck for subqueries

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/subquery-opt
+++ b/pkg/sql/logictest/testdata/logic_test/subquery-opt
@@ -1,0 +1,26 @@
+# LogicTest: local-opt fakedist-opt
+
+# Regression test for #37263. This test is broken in the heuristic planner
+# because it does not correctly type check subqueries.
+query B
+SELECT 3::decimal IN (SELECT 1)
+----
+false
+
+query error unsupported comparison operator
+SELECT 3::decimal IN (SELECT 1::int)
+
+query B
+SELECT 1 IN (SELECT '1');
+----
+true
+
+# Regression test for #14554.
+query ITIIIII
+SELECT t.oid, t.typname, t.typsend, t.typreceive, t.typoutput, t.typinput, t.typelem
+	FROM pg_type AS t
+	WHERE t.oid NOT IN (
+	  SELECT (ARRAY[704,11676,10005,3912,11765,59410,11397])[i]
+	  FROM generate_series(1, 376) AS i
+	)
+----

--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -167,7 +167,9 @@ SELECT 1 in (SELECT 1)
 ----
 true
 
-statement error unsupported comparison operator: <int> IN <tuple{string}>
+# The heuristic planner and the optimizer give different errors for this query.
+# Accept them both.
+statement error (unsupported comparison operator: <int> IN <tuple{string}>|could not parse "a" as type int)
 SELECT 1 IN (SELECT 'a')
 
 statement error unsupported comparison operator: <int> IN <tuple{tuple{int, int}}>

--- a/pkg/sql/opt/optbuilder/explain.go
+++ b/pkg/sql/opt/optbuilder/explain.go
@@ -31,7 +31,7 @@ func (b *Builder) buildExplain(explain *tree.Explain, inScope *scope) (outScope 
 
 	// We don't allow the statement under Explain to reference outer columns, so we
 	// pass a "blank" scope rather than inScope.
-	stmtScope := b.buildStmt(explain.Statement, &scope{builder: b})
+	stmtScope := b.buildStmt(explain.Statement, nil /* desiredTypes */, &scope{builder: b})
 	outScope = inScope.push()
 
 	var cols sqlbase.ResultColumns

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -850,7 +850,9 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 		if sub, ok := t.Subquery.(*tree.Subquery); ok {
 			// Copy the ArrayFlatten expression so that the tree isn't mutated.
 			copy := *t
-			copy.Subquery = s.replaceSubquery(sub, false /* wrapInTuple */, 1 /* desiredColumns */, extraColsAllowed)
+			copy.Subquery = s.replaceSubquery(
+				sub, false /* wrapInTuple */, 1 /* desiredNumColumns */, extraColsAllowed,
+			)
 			expr = &copy
 		}
 
@@ -865,7 +867,9 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 			if sub, ok := t.Right.(*tree.Subquery); ok {
 				// Copy the Comparison expression so that the tree isn't mutated.
 				copy := *t
-				copy.Right = s.replaceSubquery(sub, true /* wrapInTuple */, -1 /* desiredColumns */, noExtraColsAllowed)
+				copy.Right = s.replaceSubquery(
+					sub, true /* wrapInTuple */, -1 /* desiredNumColumns */, noExtraColsAllowed,
+				)
 				expr = &copy
 			}
 		}
@@ -877,9 +881,13 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 		}
 
 		if t.Exists {
-			expr = s.replaceSubquery(t, true /* wrapInTuple */, -1 /* desiredColumns */, noExtraColsAllowed)
+			expr = s.replaceSubquery(
+				t, true /* wrapInTuple */, -1 /* desiredNumColumns */, noExtraColsAllowed,
+			)
 		} else {
-			expr = s.replaceSubquery(t, false /* wrapInTuple */, s.columns /* desiredColumns */, noExtraColsAllowed)
+			expr = s.replaceSubquery(
+				t, false /* wrapInTuple */, s.columns /* desiredNumColumns */, noExtraColsAllowed,
+			)
 		}
 	}
 
@@ -1070,12 +1078,12 @@ const (
 	noExtraColsAllowed = false
 )
 
-// Replace a raw subquery node with a typed subquery. wrapInTuple specifies
-// whether the return type of the subquery should be wrapped in a tuple.
-// wrapInTuple is true for subqueries that may return multiple rows in
+// Replace a raw tree.Subquery node with a lazily typed subquery. wrapInTuple
+// specifies whether the return type of the subquery should be wrapped in a
+// tuple. wrapInTuple is true for subqueries that may return multiple rows in
 // comparison expressions (e.g., IN, ANY, ALL) and EXISTS expressions.
-// desiredColumns specifies the desired number of columns for the
-// subquery. Specifying -1 for desiredColumns allows the subquery to return any
+// desiredNumColumns specifies the desired number of columns for the subquery.
+// Specifying -1 for desiredNumColumns allows the subquery to return any
 // number of columns and is used when the normal type checking machinery will
 // verify that the correct number of columns is returned.
 // If extraColsAllowed is true, extra columns built from the subquery (such as
@@ -1083,59 +1091,15 @@ const (
 // It is the duty of the caller to ensure that those columns are eventually
 // dealt with.
 func (s *scope) replaceSubquery(
-	sub *tree.Subquery, wrapInTuple bool, desiredColumns int, extraColsAllowed bool,
+	sub *tree.Subquery, wrapInTuple bool, desiredNumColumns int, extraColsAllowed bool,
 ) *subquery {
-	if s.replaceSRFs {
-		// We need to save and restore the previous value of the replaceSRFs field in
-		// case we are recursively called within a subquery context.
-		defer func() { s.replaceSRFs = true }()
-		s.replaceSRFs = false
+	return &subquery{
+		Subquery:          sub,
+		wrapInTuple:       wrapInTuple,
+		desiredNumColumns: desiredNumColumns,
+		extraColsAllowed:  extraColsAllowed,
+		scope:             s,
 	}
-
-	subq := subquery{
-		Subquery:    sub,
-		wrapInTuple: wrapInTuple,
-	}
-
-	// Save and restore the previous value of s.builder.subquery in case we are
-	// recursively called within a subquery context.
-	outer := s.builder.subquery
-	defer func() { s.builder.subquery = outer }()
-	s.builder.subquery = &subq
-
-	outScope := s.builder.buildStmt(sub.Select, s)
-	ord := outScope.ordering
-
-	// Treat the subquery result as an anonymous data source (i.e. column names
-	// are not qualified). Remove hidden columns, as they are not accessible
-	// outside the subquery.
-	outScope.setTableAlias("")
-	outScope.removeHiddenCols()
-
-	if desiredColumns > 0 && len(outScope.cols) != desiredColumns {
-		n := len(outScope.cols)
-		switch desiredColumns {
-		case 1:
-			panic(pgerror.NewErrorf(pgerror.CodeSyntaxError,
-				"subquery must return only one column, found %d", n))
-		default:
-			panic(pgerror.NewErrorf(pgerror.CodeSyntaxError,
-				"subquery must return %d columns, found %d", desiredColumns, n))
-		}
-	}
-
-	if len(outScope.extraCols) > 0 && !extraColsAllowed {
-		// We need to add a projection to remove the extra columns.
-		projScope := outScope.push()
-		projScope.appendColumnsFromScope(outScope)
-		projScope.expr = s.builder.constructProject(outScope.expr.(memo.RelExpr), projScope.cols)
-		outScope = projScope
-	}
-
-	subq.cols = outScope.cols
-	subq.node = outScope.expr.(memo.RelExpr)
-	subq.ordering = ord
-	return &subq
 }
 
 // VisitPost is part of the Visitor interface.

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -108,7 +108,7 @@ func (b *Builder) buildDataSource(
 		return b.buildZip(source.Items, inScope)
 
 	case *tree.Subquery:
-		outScope = b.buildStmt(source.Select, inScope)
+		outScope = b.buildStmt(source.Select, nil /* desiredTypes */, inScope)
 
 		// Treat the subquery result as an anonymous data source (i.e. column names
 		// are not qualified). Remove hidden columns, as they are not accessible
@@ -119,7 +119,7 @@ func (b *Builder) buildDataSource(
 		return outScope
 
 	case *tree.StatementSource:
-		outScope = b.buildStmt(source.Statement, inScope)
+		outScope = b.buildStmt(source.Statement, nil /* desiredTypes */, inScope)
 		if len(outScope.cols) == 0 {
 			panic(pgerror.NewErrorf(pgerror.CodeUndefinedColumnError,
 				"statement source \"%v\" does not return any columns", source.Statement))
@@ -446,7 +446,7 @@ func (b *Builder) buildCTE(ctes []*tree.CTE, inScope *scope) (outScope *scope) {
 
 	outScope.ctes = make(map[string]*cteSource)
 	for i := range ctes {
-		cteScope := b.buildStmt(ctes[i].Stmt, outScope)
+		cteScope := b.buildStmt(ctes[i].Stmt, nil /* desiredTypes */, outScope)
 		cols := cteScope.cols
 		name := ctes[i].Name.Alias
 

--- a/pkg/sql/opt/optbuilder/subquery.go
+++ b/pkg/sql/opt/optbuilder/subquery.go
@@ -53,6 +53,21 @@ type subquery struct {
 	// columns which are referenced within the subquery but are bound in an
 	// outer scope.
 	outerCols opt.ColSet
+
+	// desiredNumColumns specifies the desired number of columns for the subquery.
+	// Specifying -1 for desiredNumColumns allows the subquery to return any
+	// number of columns and is used when the normal type checking machinery will
+	// verify that the correct number of columns is returned.
+	desiredNumColumns int
+
+	// extraColsAllowed indicates that extra columns built from the subquery
+	// (such as columns for which orderings have been requested) will not be
+	// stripped away.
+	extraColsAllowed bool
+
+	// scope is the input scope of the subquery. It is needed to lazily build
+	// the subquery in TypeCheck.
+	scope *scope
 }
 
 // isMultiRow returns whether the subquery can return multiple rows.
@@ -70,6 +85,16 @@ func (s *subquery) TypeCheck(_ *tree.SemaContext, desired types.T) (tree.TypedEx
 	if s.typ != nil {
 		return s, nil
 	}
+
+	// Convert desired to an array of desired types for building the subquery.
+	var desiredTypes []types.T
+	if tup, ok := desired.(types.TTuple); ok {
+		desiredTypes = tup.Types
+	}
+
+	// Build the subquery. We cannot build the subquery earlier because we do
+	// not know the desired types until TypeCheck is called.
+	s.buildSubquery(desiredTypes)
 
 	// The typing for subqueries is complex, but regular.
 	//
@@ -171,6 +196,57 @@ func (s *subquery) ResolvedType() types.T {
 // Eval is part of the tree.TypedExpr interface.
 func (s *subquery) Eval(_ *tree.EvalContext) (tree.Datum, error) {
 	panic(pgerror.NewAssertionErrorf("subquery must be replaced before evaluation"))
+}
+
+// buildSubquery builds a relational expression that represents this subquery.
+// It stores the resulting relational expression in s.node, and also updates
+// s.cols and s.ordering with the output columns and ordering of the subquery.
+func (s *subquery) buildSubquery(desiredTypes []types.T) {
+	if s.scope.replaceSRFs {
+		// We need to save and restore the previous value of the replaceSRFs field in
+		// case we are recursively called within a subquery context.
+		defer func() { s.scope.replaceSRFs = true }()
+		s.scope.replaceSRFs = false
+	}
+
+	// Save and restore the previous value of s.builder.subquery in case we are
+	// recursively called within a subquery context.
+	outer := s.scope.builder.subquery
+	defer func() { s.scope.builder.subquery = outer }()
+	s.scope.builder.subquery = s
+
+	outScope := s.scope.builder.buildStmt(s.Subquery.Select, desiredTypes, s.scope)
+	ord := outScope.ordering
+
+	// Treat the subquery result as an anonymous data source (i.e. column names
+	// are not qualified). Remove hidden columns, as they are not accessible
+	// outside the subquery.
+	outScope.setTableAlias("")
+	outScope.removeHiddenCols()
+
+	if s.desiredNumColumns > 0 && len(outScope.cols) != s.desiredNumColumns {
+		n := len(outScope.cols)
+		switch s.desiredNumColumns {
+		case 1:
+			panic(pgerror.NewErrorf(pgerror.CodeSyntaxError,
+				"subquery must return only one column, found %d", n))
+		default:
+			panic(pgerror.NewErrorf(pgerror.CodeSyntaxError,
+				"subquery must return %d columns, found %d", s.desiredNumColumns, n))
+		}
+	}
+
+	if len(outScope.extraCols) > 0 && !s.extraColsAllowed {
+		// We need to add a projection to remove the extra columns.
+		projScope := outScope.push()
+		projScope.appendColumnsFromScope(outScope)
+		projScope.expr = s.scope.builder.constructProject(outScope.expr.(memo.RelExpr), projScope.cols)
+		outScope = projScope
+	}
+
+	s.cols = outScope.cols
+	s.node = outScope.expr.(memo.RelExpr)
+	s.ordering = ord
 }
 
 // buildSubqueryProjection ensures that a subquery returns exactly one column.
@@ -312,3 +388,8 @@ func (b *Builder) buildMultiRowSubquery(
 
 var _ tree.Expr = &subquery{}
 var _ tree.TypedExpr = &subquery{}
+
+// SubqueryExpr implements the SubqueryExpr interface.
+func (*subquery) SubqueryExpr() {}
+
+var _ tree.SubqueryExpr = &subquery{}

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -246,16 +246,16 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: y:1(int!null)
+           │    ├── columns: y:2(int!null)
            │    ├── values
            │    │    └── tuple [type=tuple]
            │    └── projections
            │         └── const: 1 [type=int]
            └── subquery [type=int]
                 └── max1-row
-                     ├── columns: x:2(int!null)
+                     ├── columns: x:1(int!null)
                      └── project
-                          ├── columns: x:2(int!null)
+                          ├── columns: x:1(int!null)
                           ├── values
                           │    └── tuple [type=tuple]
                           └── projections
@@ -304,7 +304,7 @@ project
            ├── project
            │    ├── columns: column5:5(tuple{int, int})
            │    ├── project
-           │    │    ├── columns: c:1(int!null) d:2(int!null)
+           │    │    ├── columns: c:3(int!null) d:4(int!null)
            │    │    ├── values
            │    │    │    └── tuple [type=tuple]
            │    │    └── projections
@@ -320,7 +320,7 @@ project
                      └── project
                           ├── columns: column6:6(tuple{int, int})
                           ├── project
-                          │    ├── columns: a:3(int!null) b:4(int!null)
+                          │    ├── columns: a:1(int!null) b:2(int!null)
                           │    ├── values
                           │    │    └── tuple [type=tuple]
                           │    └── projections
@@ -381,7 +381,7 @@ project
            ├── project
            │    ├── columns: column4:4(tuple{int, int})
            │    ├── project
-           │    │    ├── columns: b:1(int!null) c:2(int!null)
+           │    │    ├── columns: b:2(int!null) c:3(int!null)
            │    │    ├── values
            │    │    │    └── tuple [type=tuple]
            │    │    └── projections
@@ -393,9 +393,9 @@ project
            │              └── variable: c [type=int]
            └── subquery [type=tuple{int, int}]
                 └── max1-row
-                     ├── columns: a:3(tuple{int, int})
+                     ├── columns: a:1(tuple{int, int})
                      └── project
-                          ├── columns: a:3(tuple{int, int})
+                          ├── columns: a:1(tuple{int, int})
                           ├── values
                           │    └── tuple [type=tuple]
                           └── projections
@@ -442,7 +442,7 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: c:1(tuple{int, int})
+           │    ├── columns: c:3(tuple{int, int})
            │    ├── values
            │    │    └── tuple [type=tuple]
            │    └── projections
@@ -455,7 +455,7 @@ project
                      └── project
                           ├── columns: column4:4(tuple{int, int})
                           ├── project
-                          │    ├── columns: a:2(int!null) b:3(int!null)
+                          │    ├── columns: a:1(int!null) b:2(int!null)
                           │    ├── values
                           │    │    └── tuple [type=tuple]
                           │    └── projections
@@ -476,7 +476,7 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: b:1(tuple{int, int})
+           │    ├── columns: b:2(tuple{int, int})
            │    ├── values
            │    │    └── tuple [type=tuple]
            │    └── projections
@@ -485,9 +485,9 @@ project
            │              └── const: 2 [type=int]
            └── subquery [type=tuple{int, int}]
                 └── max1-row
-                     ├── columns: a:2(tuple{int, int})
+                     ├── columns: a:1(tuple{int, int})
                      └── project
-                          ├── columns: a:2(tuple{int, int})
+                          ├── columns: a:1(tuple{int, int})
                           ├── values
                           │    └── tuple [type=tuple]
                           └── projections
@@ -1965,7 +1965,7 @@ SELECT min(a) IN (SELECT b FROM u) FROM t
 project
  ├── columns: "?column?":6(bool)
  ├── scalar-group-by
- │    ├── columns: min:5(string)
+ │    ├── columns: min:3(string)
  │    ├── project
  │    │    ├── columns: a:1(string)
  │    │    └── scan t
@@ -1976,9 +1976,9 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: b:3(string)
+           │    ├── columns: b:4(string)
            │    └── scan u
-           │         └── columns: b:3(string) u.rowid:4(int!null)
+           │         └── columns: b:4(string) u.rowid:5(int!null)
            └── variable: min [type=string]
 
 # Regression test for #28240. Make sure that the tuple labels are stripped from
@@ -2365,35 +2365,35 @@ FROM
 project
  ├── columns: "?column?":21(tuple{bool, int})
  ├── scalar-group-by
- │    ├── columns: max:16(int) max:19(int)
+ │    ├── columns: max:8(int) max:18(int)
  │    ├── project
- │    │    ├── columns: column15:15(int) a:18(int)
+ │    │    ├── columns: a:7(int) column17:17(int)
  │    │    ├── scan t3
  │    │    │    └── columns: t3.a:1(int) t3.b:2(int) t3.rowid:3(int!null)
  │    │    └── projections
- │    │         ├── subquery [type=int]
- │    │         │    └── max1-row
- │    │         │         ├── columns: max:13(int)
- │    │         │         └── project
- │    │         │              ├── columns: max:13(int)
- │    │         │              └── group-by
- │    │         │                   ├── columns: max:13(int) b:14(int)
- │    │         │                   ├── grouping columns: b:14(int)
- │    │         │                   ├── project
- │    │         │                   │    ├── columns: b:14(int) t1.a:10(int)
- │    │         │                   │    ├── scan t1
- │    │         │                   │    │    └── columns: t1.a:10(int) t1.b:11(int) t1.rowid:12(int!null)
- │    │         │                   │    └── projections
- │    │         │                   │         └── variable: t3.b [type=int]
- │    │         │                   └── aggregations
- │    │         │                        └── max [type=int]
- │    │         │                             └── variable: t1.a [type=int]
- │    │         └── variable: t3.a [type=int]
+ │    │         ├── variable: t3.a [type=int]
+ │    │         └── subquery [type=int]
+ │    │              └── max1-row
+ │    │                   ├── columns: max:15(int)
+ │    │                   └── project
+ │    │                        ├── columns: max:15(int)
+ │    │                        └── group-by
+ │    │                             ├── columns: max:15(int) b:16(int)
+ │    │                             ├── grouping columns: b:16(int)
+ │    │                             ├── project
+ │    │                             │    ├── columns: b:16(int) t1.a:12(int)
+ │    │                             │    ├── scan t1
+ │    │                             │    │    └── columns: t1.a:12(int) t1.b:13(int) t1.rowid:14(int!null)
+ │    │                             │    └── projections
+ │    │                             │         └── variable: t3.b [type=int]
+ │    │                             └── aggregations
+ │    │                                  └── max [type=int]
+ │    │                                       └── variable: t1.a [type=int]
  │    └── aggregations
  │         ├── max [type=int]
- │         │    └── variable: column15 [type=int]
+ │         │    └── variable: a [type=int]
  │         └── max [type=int]
- │              └── variable: a [type=int]
+ │              └── variable: column17 [type=int]
  └── projections
       └── subquery [type=tuple{bool, int}]
            └── max1-row
@@ -2407,9 +2407,9 @@ project
                                ├── not [type=bool]
                                │    └── any: ge [type=bool]
                                │         ├── project
-                               │         │    ├── columns: max:17(int)
+                               │         │    ├── columns: max:19(int)
                                │         │    ├── scan t1
-                               │         │    │    └── columns: t1.a:7(int) t1.b:8(int) t1.rowid:9(int!null)
+                               │         │    │    └── columns: t1.a:9(int) t1.b:10(int) t1.rowid:11(int!null)
                                │         │    └── projections
                                │         │         └── variable: max [type=int]
                                │         └── variable: t2.a [type=int]
@@ -2526,3 +2526,27 @@ build
 SELECT * FROM xyzs WHERE (SELECT sum(x) FROM (SELECT u FROM kuv) GROUP BY u) > 100;
 ----
 error (42803): aggregate functions are not allowed in WHERE
+
+# Regression test for #37263.
+build
+SELECT 3::decimal IN (SELECT 1)
+----
+project
+ ├── columns: "?column?":2(bool)
+ ├── values
+ │    └── tuple [type=tuple]
+ └── projections
+      └── any: eq [type=bool]
+           ├── project
+           │    ├── columns: "?column?":1(decimal!null)
+           │    ├── values
+           │    │    └── tuple [type=tuple]
+           │    └── projections
+           │         └── const: 1 [type=decimal]
+           └── cast: DECIMAL [type=decimal]
+                └── const: 3 [type=decimal]
+
+build
+SELECT 3::decimal IN (SELECT 1::int)
+----
+error (22023): unsupported comparison operator: <decimal> IN <tuple{int}>

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -109,6 +109,16 @@ var _ Operator = UnaryOperator(0)
 var _ Operator = BinaryOperator(0)
 var _ Operator = ComparisonOperator(0)
 
+// SubqueryExpr is an interface used to identify an expression as a subquery.
+// It is implemented by both tree.Subquery and optbuilder.subquery, and is
+// used in TypeCheck.
+type SubqueryExpr interface {
+	Expr
+	SubqueryExpr()
+}
+
+var _ SubqueryExpr = &Subquery{}
+
 // exprFmtWithParen is a variant of Format() which adds a set of outer parens
 // if the expression involves an operator. It is used internally when the
 // expression is part of another expression and we know it is preceded or
@@ -962,6 +972,9 @@ func (node *Subquery) SetType(t types.T) {
 
 // Variable implements the VariableExpr interface.
 func (*Subquery) Variable() {}
+
+// SubqueryExpr implements the SubqueryExpr interface.
+func (*Subquery) SubqueryExpr() {}
 
 // Format implements the NodeFormatter interface.
 func (node *Subquery) Format(ctx *FmtCtx) {


### PR DESCRIPTION
Backport 1/1 commits from #37578.

/cc @cockroachdb/release

---

Prior to this commit, the optimizer was not correctly inferring the types of
columns in subqueries for expressions of the form `scalar IN (subquery)`.
This was due to two problems which have now been fixed:

1. The subquery was built as a relational expression before the desired types
   were known. Now the subquery build is delayed until `TypeCheck` is called for
   the first time.

2. For subqueries on the right side of an `IN` expression, the desired type
   passed into `TypeCheck` was `AnyTuple`. This resulted in an error later on in
   `typeCheckSubqueryWithIn`, which checks to make sure the type of the subquery
   is `tuple{T}` where `T` is the type of the left expression. Now the desired
   type passed into `TypeCheck` is `tuple{T}`.

Note that this commit only fixes type inference for the optimizer. It is still
broken in the heuristic planner.

Fixes #37263
Fixes #14554

Release note (bug fix): Fixed type inference of columns in subqueries for
some expressions of the form `scalar IN (subquery)`.
