### PR TITLE
kv/storage: hunt memory allocations with KV writes

### DIFF
--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -33,7 +33,7 @@ func init() {
 }
 
 func declareKeysExport(
-	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
+	desc *roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
 ) {
 	batcheval.DefaultDeclareKeys(desc, header, req, spans)
 	spans.Add(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeLastGCKey(header.RangeID)})

--- a/pkg/internal/client/db.go
+++ b/pkg/internal/client/db.go
@@ -15,9 +15,9 @@
 package client
 
 import (
-	"bytes"
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -153,12 +153,12 @@ func (r Result) String() string {
 	if r.Err != nil {
 		return r.Err.Error()
 	}
-	var buf bytes.Buffer
-	for i, row := range r.Rows {
+	var buf strings.Builder
+	for i := range r.Rows {
 		if i > 0 {
 			buf.WriteString("\n")
 		}
-		fmt.Fprintf(&buf, "%d: %s", i, &row)
+		fmt.Fprintf(&buf, "%d: %s", i, &r.Rows[i])
 	}
 	return buf.String()
 }

--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -559,7 +559,8 @@ func (txn *Txn) UpdateDeadlineMaybe(ctx context.Context, deadline hlc.Timestamp)
 			log.Fatalf(ctx, "deadline below txn.OrigTimestamp() is nonsensical; "+
 				"txn has would have no change to commit. Deadline: %s", deadline)
 		}
-		txn.mu.deadline = &deadline
+		txn.mu.deadline = new(hlc.Timestamp)
+		*txn.mu.deadline = deadline
 		return true
 	}
 	return false

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -828,7 +828,7 @@ func (t Transaction) Clone() *Transaction {
 // AssertInitialized crashes if the transaction is not initialized.
 func (t *Transaction) AssertInitialized(ctx context.Context) {
 	if t.ID == (uuid.UUID{}) || t.Timestamp == (hlc.Timestamp{}) {
-		log.Fatalf(ctx, "uninitialized txn: %s", t)
+		log.Fatalf(ctx, "uninitialized txn: %s", *t)
 	}
 }
 

--- a/pkg/storage/batcheval/cmd_begin_transaction.go
+++ b/pkg/storage/batcheval/cmd_begin_transaction.go
@@ -33,7 +33,7 @@ func init() {
 // declareKeysWriteTransaction is the shared portion of
 // declareKeys{Begin,End,Heartbeat}Transaction.
 func declareKeysWriteTransaction(
-	_ roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
+	_ *roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
 ) {
 	if header.Txn != nil {
 		header.Txn.AssertInitialized(context.TODO())
@@ -44,7 +44,7 @@ func declareKeysWriteTransaction(
 }
 
 func declareKeysBeginTransaction(
-	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
+	desc *roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
 ) {
 	declareKeysWriteTransaction(desc, header, req, spans)
 	spans.Add(spanset.SpanReadOnly, roachpb.Span{

--- a/pkg/storage/batcheval/cmd_clear_range.go
+++ b/pkg/storage/batcheval/cmd_clear_range.go
@@ -41,7 +41,7 @@ func init() {
 }
 
 func declareKeysClearRange(
-	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
+	desc *roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
 ) {
 	DefaultDeclareKeys(desc, header, req, spans)
 	// We look up the range descriptor key to check whether the span

--- a/pkg/storage/batcheval/cmd_compute_checksum.go
+++ b/pkg/storage/batcheval/cmd_compute_checksum.go
@@ -32,7 +32,7 @@ func init() {
 }
 
 func declareKeysComputeChecksum(
-	roachpb.RangeDescriptor, roachpb.Header, roachpb.Request, *spanset.SpanSet,
+	*roachpb.RangeDescriptor, roachpb.Header, roachpb.Request, *spanset.SpanSet,
 ) {
 	// Intentionally declare no keys, as ComputeChecksum does not need to be
 	// serialized with any other commands. It simply needs to be committed into

--- a/pkg/storage/batcheval/cmd_end_transaction.go
+++ b/pkg/storage/batcheval/cmd_end_transaction.go
@@ -51,7 +51,7 @@ func init() {
 }
 
 func declareKeysEndTransaction(
-	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
+	desc *roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
 ) {
 	et := req.(*roachpb.EndTransactionRequest)
 	declareKeysWriteTransaction(desc, header, req, spans)

--- a/pkg/storage/batcheval/cmd_gc.go
+++ b/pkg/storage/batcheval/cmd_gc.go
@@ -31,7 +31,7 @@ func init() {
 }
 
 func declareKeysGC(
-	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
+	desc *roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
 ) {
 	// Intentionally don't call DefaultDeclareKeys: the key range in the header
 	// is usually the whole range (pending resolution of #7880).

--- a/pkg/storage/batcheval/cmd_heartbeat_txn.go
+++ b/pkg/storage/batcheval/cmd_heartbeat_txn.go
@@ -31,7 +31,7 @@ func init() {
 }
 
 func declareKeysHeartbeatTransaction(
-	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
+	desc *roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
 ) {
 	declareKeysWriteTransaction(desc, header, req, spans)
 }

--- a/pkg/storage/batcheval/cmd_lease.go
+++ b/pkg/storage/batcheval/cmd_lease.go
@@ -29,7 +29,7 @@ import (
 )
 
 func declareKeysRequestLease(
-	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
+	desc *roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
 ) {
 	spans.Add(spanset.SpanReadWrite, roachpb.Span{Key: keys.RangeLeaseKey(header.RangeID)})
 	spans.Add(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeDescriptorKey(desc.StartKey)})

--- a/pkg/storage/batcheval/cmd_lease_info.go
+++ b/pkg/storage/batcheval/cmd_lease_info.go
@@ -29,7 +29,7 @@ func init() {
 }
 
 func declareKeysLeaseInfo(
-	_ roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
+	_ *roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
 ) {
 	spans.Add(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeLeaseKey(header.RangeID)})
 }

--- a/pkg/storage/batcheval/cmd_push_txn.go
+++ b/pkg/storage/batcheval/cmd_push_txn.go
@@ -34,7 +34,7 @@ func init() {
 }
 
 func declareKeysPushTransaction(
-	_ roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
+	_ *roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
 ) {
 	pr := req.(*roachpb.PushTxnRequest)
 	spans.Add(spanset.SpanReadWrite, roachpb.Span{Key: keys.TransactionKey(pr.PusheeTxn.Key, pr.PusheeTxn.ID)})

--- a/pkg/storage/batcheval/cmd_push_txn.go
+++ b/pkg/storage/batcheval/cmd_push_txn.go
@@ -208,6 +208,7 @@ func PushTxn(
 	}
 	reply.PusheeTxn.UpgradePriority(args.PusheeTxn.Priority)
 
+	pushType := args.PushType
 	var pusherWins bool
 	var reason string
 
@@ -216,9 +217,9 @@ func PushTxn(
 		reason = "pushee is expired"
 		// When cleaning up, actually clean up (as opposed to simply pushing
 		// the garbage in the path of future writers).
-		args.PushType = roachpb.PUSH_ABORT
+		pushType = roachpb.PUSH_ABORT
 		pusherWins = true
-	case args.PushType == roachpb.PUSH_TOUCH:
+	case pushType == roachpb.PUSH_TOUCH:
 		// If just attempting to cleanup old or already-committed txns,
 		// pusher always fails.
 		pusherWins = false
@@ -236,7 +237,7 @@ func PushTxn(
 			s = "failed to push"
 		}
 		log.Infof(ctx, "%s "+s+" (push type=%s) %s: %s (pushee last active: %s)",
-			args.PusherTxn.Short(), args.PushType, args.PusheeTxn.Short(),
+			args.PusherTxn.Short(), pushType, args.PusheeTxn.Short(),
 			reason, reply.PusheeTxn.LastActive())
 	}
 
@@ -264,7 +265,7 @@ func PushTxn(
 	reply.PusheeTxn.UpgradePriority(args.PusherTxn.Priority - 1)
 
 	// Determine what to do with the pushee, based on the push type.
-	switch args.PushType {
+	switch pushType {
 	case roachpb.PUSH_ABORT:
 		// If aborting the transaction, set the new status.
 		reply.PusheeTxn.Status = roachpb.ABORTED
@@ -281,7 +282,7 @@ func PushTxn(
 		// ever being written with a timestamp beneath this timestamp.
 		reply.PusheeTxn.Timestamp.Forward(args.PushTo)
 	default:
-		return result.Result{}, errors.Errorf("unexpected push type: %v", args.PushType)
+		return result.Result{}, errors.Errorf("unexpected push type: %v", pushType)
 	}
 
 	// If the transaction record was already present, persist the updates to it.

--- a/pkg/storage/batcheval/cmd_query_txn.go
+++ b/pkg/storage/batcheval/cmd_query_txn.go
@@ -33,7 +33,7 @@ func init() {
 }
 
 func declareKeysQueryTransaction(
-	_ roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
+	_ *roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
 ) {
 	qr := req.(*roachpb.QueryTxnRequest)
 	spans.Add(spanset.SpanReadOnly, roachpb.Span{Key: keys.TransactionKey(qr.Txn.Key, qr.Txn.ID)})

--- a/pkg/storage/batcheval/cmd_recompute_stats.go
+++ b/pkg/storage/batcheval/cmd_recompute_stats.go
@@ -33,7 +33,7 @@ func init() {
 }
 
 func declareKeysRecomputeStats(
-	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
+	desc *roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
 ) {
 	// We don't declare any user key in the range. This is OK since all we're doing is computing a
 	// stats delta, and applying this delta commutes with other operations on the same key space.

--- a/pkg/storage/batcheval/cmd_recover_txn.go
+++ b/pkg/storage/batcheval/cmd_recover_txn.go
@@ -33,7 +33,7 @@ func init() {
 }
 
 func declareKeysRecoverTransaction(
-	_ roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
+	_ *roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
 ) {
 	rr := req.(*roachpb.RecoverTxnRequest)
 	spans.Add(spanset.SpanReadWrite, roachpb.Span{Key: keys.TransactionKey(rr.Txn.Key, rr.Txn.ID)})

--- a/pkg/storage/batcheval/cmd_resolve_intent.go
+++ b/pkg/storage/batcheval/cmd_resolve_intent.go
@@ -30,7 +30,7 @@ func init() {
 }
 
 func declareKeysResolveIntentCombined(
-	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
+	desc *roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
 ) {
 	DefaultDeclareKeys(desc, header, req, spans)
 	var status roachpb.TransactionStatus
@@ -49,7 +49,7 @@ func declareKeysResolveIntentCombined(
 }
 
 func declareKeysResolveIntent(
-	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
+	desc *roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
 ) {
 	declareKeysResolveIntentCombined(desc, header, req, spans)
 }

--- a/pkg/storage/batcheval/cmd_resolve_intent_range.go
+++ b/pkg/storage/batcheval/cmd_resolve_intent_range.go
@@ -28,7 +28,7 @@ func init() {
 }
 
 func declareKeysResolveIntentRange(
-	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
+	desc *roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
 ) {
 	declareKeysResolveIntentCombined(desc, header, req, spans)
 }

--- a/pkg/storage/batcheval/cmd_resolve_intent_test.go
+++ b/pkg/storage/batcheval/cmd_resolve_intent_test.go
@@ -203,13 +203,13 @@ func TestDeclareKeysResolveIntent(t *testing.T) {
 
 				if !ranged {
 					cArgs.Args = &ri
-					declareKeysResolveIntent(desc, h, &ri, &spans)
+					declareKeysResolveIntent(&desc, h, &ri, &spans)
 					if _, err := ResolveIntent(ctx, batch, cArgs, &roachpb.ResolveIntentResponse{}); err != nil {
 						t.Fatal(err)
 					}
 				} else {
 					cArgs.Args = &rir
-					declareKeysResolveIntentRange(desc, h, &rir, &spans)
+					declareKeysResolveIntentRange(&desc, h, &rir, &spans)
 					if _, err := ResolveIntentRange(ctx, batch, cArgs, &roachpb.ResolveIntentRangeResponse{}); err != nil {
 						t.Fatal(err)
 					}

--- a/pkg/storage/batcheval/cmd_subsume.go
+++ b/pkg/storage/batcheval/cmd_subsume.go
@@ -32,7 +32,7 @@ func init() {
 }
 
 func declareKeysSubsume(
-	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
+	desc *roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
 ) {
 	// Subsume must not run concurrently with any other command. It declares that
 	// it reads and writes every addressable key in the range; this guarantees
@@ -43,7 +43,7 @@ func declareKeysSubsume(
 	// has completed its migration.
 	args := req.(*roachpb.SubsumeRequest)
 	if args.RightDesc != nil {
-		desc = *args.RightDesc
+		desc = args.RightDesc
 	}
 	spans.Add(spanset.SpanReadWrite, roachpb.Span{
 		Key:    desc.StartKey.AsRawKey(),

--- a/pkg/storage/batcheval/cmd_truncate_log.go
+++ b/pkg/storage/batcheval/cmd_truncate_log.go
@@ -34,7 +34,7 @@ func init() {
 }
 
 func declareKeysTruncateLog(
-	_ roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
+	_ *roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
 ) {
 	spans.Add(spanset.SpanReadWrite, roachpb.Span{Key: keys.RaftTruncatedStateLegacyKey(header.RangeID)})
 	prefix := keys.RaftLogPrefix(header.RangeID)

--- a/pkg/storage/batcheval/command.go
+++ b/pkg/storage/batcheval/command.go
@@ -31,11 +31,11 @@ type Command struct {
 	// between key declaration and cmd evaluation?
 	DeclareKeys func(*roachpb.RangeDescriptor, roachpb.Header, roachpb.Request, *spanset.SpanSet)
 
-	// Eval evaluates a command on the given engine. It should populate
-	// the supplied response (always a non-nil pointer to the correct
-	// type) and return special side effects (if any) in the Result.
-	// If it writes to the engine it should also update
-	// *CommandArgs.Stats.
+	// Eval evaluates a command on the given engine. It should populate the
+	// supplied response (always a non-nil pointer to the correct type) and
+	// return special side effects (if any) in the Result. If it writes to the
+	// engine it should also update *CommandArgs.Stats. It should treat the
+	// provided request as immutable.
 	Eval func(context.Context, engine.ReadWriter, CommandArgs, roachpb.Response) (result.Result, error)
 }
 

--- a/pkg/storage/batcheval/command.go
+++ b/pkg/storage/batcheval/command.go
@@ -26,7 +26,7 @@ import (
 
 // A Command is the implementation of a single request within a BatchRequest.
 type Command struct {
-	// DeclareKeys adds all keys this command touches to the given spanSet.
+	// DeclareKeys adds all keys this command touches to the given SpanSet.
 	// TODO(nvanbenschoten): rationalize this RangeDescriptor. Can it change
 	// between key declaration and cmd evaluation?
 	DeclareKeys func(roachpb.RangeDescriptor, roachpb.Header, roachpb.Request, *spanset.SpanSet)

--- a/pkg/storage/batcheval/command.go
+++ b/pkg/storage/batcheval/command.go
@@ -29,7 +29,7 @@ type Command struct {
 	// DeclareKeys adds all keys this command touches to the given SpanSet.
 	// TODO(nvanbenschoten): rationalize this RangeDescriptor. Can it change
 	// between key declaration and cmd evaluation?
-	DeclareKeys func(roachpb.RangeDescriptor, roachpb.Header, roachpb.Request, *spanset.SpanSet)
+	DeclareKeys func(*roachpb.RangeDescriptor, roachpb.Header, roachpb.Request, *spanset.SpanSet)
 
 	// Eval evaluates a command on the given engine. It should populate
 	// the supplied response (always a non-nil pointer to the correct
@@ -45,7 +45,7 @@ var cmds = make(map[roachpb.Method]Command)
 // called before any evaluation takes place.
 func RegisterCommand(
 	method roachpb.Method,
-	declare func(roachpb.RangeDescriptor, roachpb.Header, roachpb.Request, *spanset.SpanSet),
+	declare func(*roachpb.RangeDescriptor, roachpb.Header, roachpb.Request, *spanset.SpanSet),
 	impl func(context.Context, engine.ReadWriter, CommandArgs, roachpb.Response) (result.Result, error),
 ) {
 	if _, ok := cmds[method]; ok {

--- a/pkg/storage/batcheval/declare.go
+++ b/pkg/storage/batcheval/declare.go
@@ -25,7 +25,7 @@ import (
 
 // DefaultDeclareKeys is the default implementation of Command.DeclareKeys.
 func DefaultDeclareKeys(
-	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
+	desc *roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
 ) {
 	if roachpb.IsReadOnly(req) {
 		spans.Add(spanset.SpanReadOnly, req.Header().Span())
@@ -38,7 +38,7 @@ func DefaultDeclareKeys(
 // touches to the given SpanSet. This does not include keys touched during the
 // processing of the batch's individual commands.
 func DeclareKeysForBatch(
-	desc roachpb.RangeDescriptor, header roachpb.Header, spans *spanset.SpanSet,
+	desc *roachpb.RangeDescriptor, header roachpb.Header, spans *spanset.SpanSet,
 ) {
 	if header.Txn != nil {
 		header.Txn.AssertInitialized(context.TODO())

--- a/pkg/storage/batcheval/declare.go
+++ b/pkg/storage/batcheval/declare.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
 )
 
-// DefaultDeclareKeys is the default implementation of Command.DeclareKeys
+// DefaultDeclareKeys is the default implementation of Command.DeclareKeys.
 func DefaultDeclareKeys(
 	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
 ) {
@@ -32,6 +32,14 @@ func DefaultDeclareKeys(
 	} else {
 		spans.Add(spanset.SpanReadWrite, req.Header().Span())
 	}
+}
+
+// DeclareKeysForBatch adds all keys that the batch with the provided header
+// touches to the given SpanSet. This does not include keys touched during the
+// processing of the batch's individual commands.
+func DeclareKeysForBatch(
+	desc roachpb.RangeDescriptor, header roachpb.Header, spans *spanset.SpanSet,
+) {
 	if header.Txn != nil {
 		header.Txn.AssertInitialized(context.TODO())
 		spans.Add(spanset.SpanReadOnly, roachpb.Span{

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1077,6 +1077,7 @@ func (r *Replica) collectSpans(ba *roachpb.BatchRequest) (*spanset.SpanSet, erro
 	}
 
 	desc := r.Desc()
+	batcheval.DeclareKeysForBatch(*desc, ba.Header, spans)
 	for _, union := range ba.Requests {
 		inner := union.GetInner()
 		if cmd, ok := batcheval.LookupCommand(inner.Method()); ok {

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1195,11 +1195,7 @@ func (r *Replica) beginCmds(
 	// Handle load-based splitting.
 	if r.SplitByLoadEnabled() {
 		shouldInitSplit := r.loadBasedSplitter.Record(timeutil.Now(), len(ba.Requests), func() roachpb.Span {
-			boundarySpan := spans.BoundarySpan(spanset.SpanGlobal)
-			if boundarySpan == nil {
-				return roachpb.Span{}
-			}
-			return *boundarySpan
+			return spans.BoundarySpan(spanset.SpanGlobal)
 		})
 		if shouldInitSplit {
 			r.store.splitQueue.MaybeAddAsync(ctx, r, r.store.Clock().Now())

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1077,11 +1077,11 @@ func (r *Replica) collectSpans(ba *roachpb.BatchRequest) (*spanset.SpanSet, erro
 	}
 
 	desc := r.Desc()
-	batcheval.DeclareKeysForBatch(*desc, ba.Header, spans)
+	batcheval.DeclareKeysForBatch(desc, ba.Header, spans)
 	for _, union := range ba.Requests {
 		inner := union.GetInner()
 		if cmd, ok := batcheval.LookupCommand(inner.Method()); ok {
-			cmd.DeclareKeys(*desc, ba.Header, inner, spans)
+			cmd.DeclareKeys(desc, ba.Header, inner, spans)
 		} else {
 			return nil, errors.Errorf("unrecognized command %s", inner.Method())
 		}

--- a/pkg/storage/replica_evaluate.go
+++ b/pkg/storage/replica_evaluate.go
@@ -379,10 +379,7 @@ func evaluateCommand(
 		cArgs := batcheval.CommandArgs{
 			EvalCtx: rec,
 			Header:  h,
-			// Some commands mutate their arguments, so give each invocation
-			// its own copy (shallow to mimic earlier versions of this code
-			// in which args were passed by value instead of pointer).
-			Args:    args.ShallowCopy(),
+			Args:    args,
 			MaxKeys: maxKeys,
 			Stats:   ms,
 		}

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -2669,7 +2669,7 @@ func TestReplicaLatchingSplitDeclaresWrites(t *testing.T) {
 	var spans spanset.SpanSet
 	cmd, _ := batcheval.LookupCommand(roachpb.EndTransaction)
 	cmd.DeclareKeys(
-		roachpb.RangeDescriptor{StartKey: roachpb.RKey("a"), EndKey: roachpb.RKey("d")},
+		&roachpb.RangeDescriptor{StartKey: roachpb.RKey("a"), EndKey: roachpb.RKey("d")},
 		roachpb.Header{},
 		&roachpb.EndTransactionRequest{
 			InternalCommitTrigger: &roachpb.InternalCommitTrigger{
@@ -7913,7 +7913,7 @@ func TestReplicaRefreshMultiple(t *testing.T) {
 func TestGCWithoutThreshold(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	desc := roachpb.RangeDescriptor{StartKey: roachpb.RKey("a"), EndKey: roachpb.RKey("z")}
+	desc := &roachpb.RangeDescriptor{StartKey: roachpb.RKey("a"), EndKey: roachpb.RKey("z")}
 	ctx := context.Background()
 
 	tc := &testContext{}


### PR DESCRIPTION
This PR includes a number of improvements that focus on memory allocation reduction in the hot path of KV writes. It was driven by an investigation into allocation patterns in the `BenchmarkKV/Insert/Native` benchmark.

```
name                          old time/op    new time/op    delta
KV/Insert/Native/rows=1-4        134µs ± 9%     127µs ± 1%   -5.20%  (p=0.000 n=10+10)
KV/Insert/Native/rows=10-4       196µs ± 4%     183µs ± 0%   -6.49%  (p=0.000 n=10+10)
KV/Insert/Native/rows=100-4      670µs ± 4%     628µs ± 4%   -6.27%  (p=0.000 n=10+9)
KV/Insert/Native/rows=1000-4    5.34ms ± 3%    4.87ms ± 2%   -8.83%  (p=0.000 n=10+9)

name                          old alloc/op   new alloc/op   delta
KV/Insert/Native/rows=1-4       14.8kB ± 0%    12.7kB ± 0%  -14.32%  (p=0.000 n=10+10)
KV/Insert/Native/rows=10-4      32.0kB ± 0%    25.9kB ± 0%  -19.13%  (p=0.000 n=10+10)
KV/Insert/Native/rows=100-4      207kB ± 0%     165kB ± 0%  -20.14%  (p=0.000 n=10+10)
KV/Insert/Native/rows=1000-4    1.89MB ± 0%    1.50MB ± 0%  -20.45%  (p=0.000 n=10+10)

name                          old allocs/op  new allocs/op  delta
KV/Insert/Native/rows=1-4          131 ± 0%       123 ± 0%   -6.11%  (p=0.000 n=10+10)
KV/Insert/Native/rows=10-4         263 ± 0%       233 ± 0%  -11.51%  (p=0.000 n=10+10)
KV/Insert/Native/rows=100-4      1.46k ± 0%     1.24k ± 0%  -14.67%  (p=0.000 n=8+10)
KV/Insert/Native/rows=1000-4     13.3k ± 0%     11.2k ± 0%  -15.25%  (p=0.000 n=10+10)
```