### PR TITLE
release-19.1: exec: fix sort chunks when ordering columns are not "in order"

### DIFF
--- a/pkg/sql/exec/sort.go
+++ b/pkg/sql/exec/sort.go
@@ -359,7 +359,7 @@ func (p *sortOp) sort() {
 			// on it, ORing the results together with each subsequent column. This
 			// produces a distinct vector (a boolean vector that has true in each
 			// position that is different from the last position).
-			p.partitioners[i-offset].partition(p.input.getValues(int(p.orderingCols[i].ColIdx)), partitionsCol, spooledTuples)
+			p.partitioners[i-offset].partition(p.input.getValues(int(p.orderingCols[i-offset].ColIdx)), partitionsCol, spooledTuples)
 		} else {
 			omitNextPartitioning = false
 		}


### PR DESCRIPTION
Backport 1/1 commits from #36105.

/cc @cockroachdb/release

---

Previously, sort chunks would return incorrect results when ordering
columns were not in order (for example, on column ordering as
`<col2 ASC>, <col0 DESC>, <col1 ASC>` with input already ordered on the
first ordering column - col2). Now, this problem is fixed.

Also, adds more randomization to the randomized tests of sorter and
sort chunks.

Release note: None