### PR TITLE
sql: run scrub FK queries through the internal executor

### DIFF
--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -71,24 +71,43 @@ func validateCheckExpr(
 // For example, a FK constraint on columns (a_id, b_id) with an index c_id on
 // the table "child" would require the following query:
 //
-// SELECT * FROM child@c_idx
+// SELECT s.a_id, s.b_id, s.pk1, s.pk2 FROM child@c_idx
 // WHERE
 //   NOT ((COALESCE(a_id, b_id) IS NULL) OR (a_id IS NOT NULL AND b_id IS NOT NULL))
 // LIMIT 1;
 func matchFullUnacceptableKeyQuery(
-	prefix int, srcID sqlbase.ID, srcIdx *sqlbase.IndexDescriptor,
-) string {
-	srcCols, srcNotNullClause := make([]string, prefix), make([]string, prefix)
+	prefix int, srcTbl *sqlbase.TableDescriptor, srcIdx *sqlbase.IndexDescriptor, limitResults bool,
+) (sql string, colNames []string, _ error) {
+	srcCols := make([]string, prefix)
+	srcNotNullClause := make([]string, prefix)
 	for i := 0; i < prefix; i++ {
 		srcCols[i] = tree.NameString(srcIdx.ColumnNames[i])
 		srcNotNullClause[i] = fmt.Sprintf("%s IS NOT NULL", tree.NameString(srcIdx.ColumnNames[i]))
 	}
+
+	returnedCols := srcCols
+	// ExtraColumns will include primary index key values not already part of the index.
+	for _, id := range srcIdx.ExtraColumnIDs {
+		column, err := srcTbl.FindActiveColumnByID(id)
+		if err != nil {
+			return "", nil, err
+		}
+		returnedCols = append(returnedCols, column.Name)
+	}
+
+	limit := ""
+	if limitResults {
+		limit = " LIMIT 1"
+	}
 	return fmt.Sprintf(
-		`SELECT * FROM [%d AS tbl]@[%d] WHERE NOT ((COALESCE(%s) IS NULL) OR (%s)) LIMIT 1`,
-		srcID, srcIdx.ID,
-		strings.Join(srcCols, ", "),
-		strings.Join(srcNotNullClause, " AND "),
-	)
+		`SELECT %[1]s FROM [%[2]d AS tbl]@[%[3]d] WHERE NOT ((COALESCE(%[4]s) IS NULL) OR (%[5]s)) %[6]s`,
+		strings.Join(returnedCols, ","),         // 1
+		srcTbl.ID,                               // 2
+		srcIdx.ID,                               // 3
+		strings.Join(srcCols, ", "),             // 4
+		strings.Join(srcNotNullClause, " AND "), // 5
+		limit,                                   // 6
+	), returnedCols, nil
 }
 
 // nonMatchingRowQuery generates and returns a query for rows that violate the
@@ -102,40 +121,77 @@ func matchFullUnacceptableKeyQuery(
 // "parent", would require the following query:
 //
 // SELECT
-//   s.a_id, s.b_id
+//   s.a_id, s.b_id, s.pk1, s.pk2
 // FROM
 //   (SELECT * FROM child@c_idx WHERE a_id IS NOT NULL AND b_id IS NOT NULL) AS s
 //   LEFT OUTER JOIN parent@p_idx AS t ON s.a_id = t.a AND s.b_id = t.b
 // WHERE
 //   t.a IS NULL
-// LIMIT 1;
+// LIMIT 1  -- if limitResults is set
+// AS OF SYSTEM TIME .. -- if asOf is not hlc.MaxTimestamp
+//
+// TODO(radu): change this to a query which executes as an anti-join when we
+// remove the heuristic planner.
 func nonMatchingRowQuery(
 	prefix int,
-	srcID sqlbase.ID,
+	srcTbl *sqlbase.TableDescriptor,
 	srcIdx *sqlbase.IndexDescriptor,
 	targetID sqlbase.ID,
 	targetIdx *sqlbase.IndexDescriptor,
-) string {
-	srcCols, srcWhere, targetCols, on := make([]string, prefix), make([]string, prefix), make([]string, prefix), make([]string, prefix)
+	limitResults bool,
+) (sql string, colNames []string, _ error) {
+	colNames = append([]string(nil), srcIdx.ColumnNames...)
+	// ExtraColumns will include primary index key values not already part of the index.
+	for _, id := range srcIdx.ExtraColumnIDs {
+		column, err := srcTbl.FindActiveColumnByID(id)
+		if err != nil {
+			return "", nil, err
+		}
+		colNames = append(colNames, column.Name)
+	}
+
+	srcCols := make([]string, len(colNames))
+	qualifiedSrcCols := make([]string, len(colNames))
+	for i, n := range colNames {
+		srcCols[i] = tree.NameString(n)
+		// s is the table alias used in the query.
+		qualifiedSrcCols[i] = fmt.Sprintf("s.%s", srcCols[i])
+	}
+
+	srcWhere := make([]string, prefix)
+	targetCols := make([]string, prefix)
+	on := make([]string, prefix)
 
 	for i := 0; i < prefix; i++ {
 		// s and t are table aliases used in the query
-		srcCols[i] = fmt.Sprintf("s.%s", tree.NameString(srcIdx.ColumnNames[i]))
 		srcWhere[i] = fmt.Sprintf("%s IS NOT NULL", tree.NameString(srcIdx.ColumnNames[i]))
 		targetCols[i] = fmt.Sprintf("t.%s", tree.NameString(targetIdx.ColumnNames[i]))
-		on[i] = fmt.Sprintf("%s = %s", srcCols[i], targetCols[i])
+		on[i] = fmt.Sprintf("%s = %s", qualifiedSrcCols[i], targetCols[i])
 	}
 
+	limit := ""
+	if limitResults {
+		limit = " LIMIT 1"
+	}
 	return fmt.Sprintf(
-		`SELECT %s FROM (SELECT * FROM [%d AS src]@[%d] WHERE %s) AS s LEFT OUTER JOIN [%d AS target]@[%d] AS t ON %s WHERE %s IS NULL LIMIT 1`,
-		strings.Join(srcCols, ", "),
-		srcID, srcIdx.ID,
-		strings.Join(srcWhere, " AND "),
-		targetID, targetIdx.ID,
-		strings.Join(on, " AND "),
+		`SELECT %[1]s FROM 
+		  (SELECT %[2]s FROM [%[3]d AS src]@{FORCE_INDEX=[%[4]d],IGNORE_FOREIGN_KEYS} WHERE %[5]s) AS s
+			LEFT OUTER JOIN
+			(SELECT * FROM [%[6]d AS target]@[%[7]d]) AS t
+			ON %[8]s
+		 WHERE %[9]s IS NULL %[10]s`,
+		strings.Join(qualifiedSrcCols, ", "), // 1
+		strings.Join(srcCols, ", "),          // 2
+		srcTbl.ID,                            // 3
+		srcIdx.ID,                            // 4
+		strings.Join(srcWhere, " AND "),      // 5
+		targetID,                             // 6
+		targetIdx.ID,                         // 7
+		strings.Join(on, " AND "),            // 8
 		// Sufficient to check the first column to see whether there was no matching row
-		targetCols[0],
-	)
+		targetCols[0], // 9
+		limit,         // 10
+	), colNames, nil
 }
 
 func validateForeignKey(
@@ -155,15 +211,21 @@ func validateForeignKey(
 	}
 
 	prefix := len(srcIdx.ColumnNames)
-	if p := len(targetIdx.ColumnNames); p < prefix {
-		prefix = p
+	if srcIdx.ForeignKey.SharedPrefixLen != 0 {
+		prefix = int(srcIdx.ForeignKey.SharedPrefixLen)
 	}
 
 	// For MATCH FULL FKs, first check whether any disallowed keys containing both
 	// null and non-null values exist.
 	// (The matching options only matter for FKs with more than one column.)
 	if prefix > 1 && srcIdx.ForeignKey.Match == sqlbase.ForeignKeyReference_FULL {
-		query := matchFullUnacceptableKeyQuery(prefix, srcTable.ID, srcIdx)
+		query, colNames, err := matchFullUnacceptableKeyQuery(
+			prefix, srcTable, srcIdx,
+			true, /* limitResults */
+		)
+		if err != nil {
+			return err
+		}
 
 		log.Infof(ctx, "Validating MATCH FULL FK %q (%q [%v] -> %q [%v]) with query %q",
 			srcIdx.ForeignKey.Name,
@@ -171,18 +233,24 @@ func validateForeignKey(
 			query,
 		)
 
-		rows, err := ie.QueryRow(ctx, "validate foreign key constraint", txn, query)
+		values, err := ie.QueryRow(ctx, "validate foreign key constraint", txn, query)
 		if err != nil {
 			return err
 		}
-		if rows.Len() > 0 {
+		if values.Len() > 0 {
 			return pgerror.Newf(pgerror.CodeForeignKeyViolationError,
 				"foreign key violation: MATCH FULL does not allow mixing of null and nonnull values %s for %s",
-				rows, srcIdx.ForeignKey.Name,
+				formatValues(colNames, values), srcIdx.ForeignKey.Name,
 			)
 		}
 	}
-	query := nonMatchingRowQuery(prefix, srcTable.ID, srcIdx, targetTable.ID, targetIdx)
+	query, colNames, err := nonMatchingRowQuery(
+		prefix, srcTable, srcIdx, targetTable.ID, targetIdx,
+		true, /* limitResults */
+	)
+	if err != nil {
+		return err
+	}
 
 	log.Infof(ctx, "Validating FK %q (%q [%v] -> %q [%v]) with query %q",
 		srcIdx.ForeignKey.Name,
@@ -195,16 +263,20 @@ func validateForeignKey(
 		return err
 	}
 	if values.Len() > 0 {
-		var pairs bytes.Buffer
-		for i := range values {
-			if i > 0 {
-				pairs.WriteString(", ")
-			}
-			pairs.WriteString(fmt.Sprintf("%s=%v", srcIdx.ColumnNames[i], values[i]))
-		}
 		return pgerror.Newf(pgerror.CodeForeignKeyViolationError,
 			"foreign key violation: %q row %s has no match in %q",
-			srcTable.Name, pairs.String(), targetTable.Name)
+			srcTable.Name, formatValues(colNames, values), targetTable.Name)
 	}
 	return nil
+}
+
+func formatValues(colNames []string, values tree.Datums) string {
+	var pairs bytes.Buffer
+	for i := range values {
+		if i > 0 {
+			pairs.WriteString(", ")
+		}
+		pairs.WriteString(fmt.Sprintf("%s=%v", colNames[i], values[i]))
+	}
+	return pairs.String()
 }

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -306,7 +306,7 @@ ALTER TABLE delivery DROP CONSTRAINT fk_item_ref_products
 statement ok
 UPDATE products SET upc = 'blah' WHERE sku = '780'
 
-statement error pgcode 23503 foreign key violation: "delivery" row item='885155001450' has no match in "products"
+statement error pgcode 23503 foreign key violation: "delivery" row item='885155001450', rowid=[0-9]* has no match in "products"
 ALTER TABLE delivery ADD FOREIGN KEY (item) REFERENCES products (upc)
 
 query TTTTB
@@ -1633,7 +1633,7 @@ CREATE TABLE b (
 statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', 'y1', 'z1')
 
-statement error foreign key violation: "b" row a_z='z1', a_y='y1', a_x='x2' has no match in "a"
+statement error foreign key violation: "b" row a_z='z1', a_y='y1', a_x='x2', rowid=[0-9]* has no match in "a"
 ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x)
 
 statement ok
@@ -1642,7 +1642,7 @@ TRUNCATE b
 statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', 'y2', 'z1')
 
-statement error foreign key violation: "b" row a_z='z1', a_y='y2', a_x='x2' has no match in "a"
+statement error foreign key violation: "b" row a_z='z1', a_y='y2', a_x='x2', rowid=[0-9]* has no match in "a"
 ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x)
 
 statement ok
@@ -1651,7 +1651,7 @@ TRUNCATE b
 statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', 'y2', 'z2')
 
-statement error foreign key violation: "b" row a_z='z2', a_y='y2', a_x='x2' has no match in "a"
+statement error foreign key violation: "b" row a_z='z2', a_y='y2', a_x='x2', rowid=[0-9]* has no match in "a"
 ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x)
 
 statement ok
@@ -1891,7 +1891,7 @@ TRUNCATE b
 statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', 'y1', 'z1')
 
-statement error foreign key violation: "b" row a_z='z1', a_y='y1', a_x='x2' has no match in "a"
+statement error foreign key violation: "b" row a_z='z1', a_y='y1', a_x='x2', rowid=[0-9]* has no match in "a"
 ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
 
 statement ok
@@ -1900,7 +1900,7 @@ TRUNCATE b
 statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', 'y2', 'z1')
 
-statement error foreign key violation: "b" row a_z='z1', a_y='y2', a_x='x2' has no match in "a"
+statement error foreign key violation: "b" row a_z='z1', a_y='y2', a_x='x2', rowid=[0-9]* has no match in "a"
 ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
 
 statement ok
@@ -1909,7 +1909,7 @@ TRUNCATE b
 statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', 'y2', 'z2')
 
-statement error foreign key violation: "b" row a_z='z2', a_y='y2', a_x='x2' has no match in "a"
+statement error foreign key violation: "b" row a_z='z2', a_y='y2', a_x='x2', rowid=[0-9]* has no match in "a"
 ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
 
 statement ok

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -645,9 +645,9 @@ func (mb *mutationBuilder) buildInputForDoNothing(inScope *scope, onConflict *tr
 		// the two tables in the self-join.
 		tn := mb.tab.Name().TableName
 		alias := tree.MakeUnqualifiedTableName(tree.Name(fmt.Sprintf("%s_%d", tn, idx+1)))
-		tabID := mb.md.AddTableWithAlias(mb.tab, &alias)
 		scanScope := mb.b.buildScan(
-			tabID,
+			mb.tab,
+			&alias,
 			nil, /* ordinals */
 			nil, /* indexFlags */
 			excludeMutations,
@@ -728,9 +728,9 @@ func (mb *mutationBuilder) buildInputForUpsert(
 	// Build the right side of the left outer join. Include mutation columns
 	// because they can be used by computed update expressions. Use a different
 	// instance of table metadata so that col IDs do not overlap.
-	inputTabID := mb.md.AddTableWithAlias(mb.tab, &mb.alias)
 	fetchScope := mb.b.buildScan(
-		inputTabID,
+		mb.tab,
+		&mb.alias,
 		nil, /* ordinals */
 		nil, /* indexFlags */
 		includeMutations,

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -183,11 +183,11 @@ func (mb *mutationBuilder) buildInputForUpdateOrDelete(
 	//
 	//   UPDATE abc SET a=b
 	//
-	inputTabID := mb.md.AddTableWithAlias(mb.tab, &mb.alias)
 
 	// FROM
 	mb.outScope = mb.b.buildScan(
-		inputTabID,
+		mb.tab,
+		&mb.alias,
 		nil, /* ordinals */
 		nil, /* indexFlags */
 		includeMutations,

--- a/pkg/sql/scrub_fk.go
+++ b/pkg/sql/scrub_fk.go
@@ -16,17 +16,12 @@ package sql
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/scrub"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/pkg/errors"
 )
 
 // sqlForeignKeyCheckOperation is a check on an indexes physical data.
@@ -45,7 +40,7 @@ type sqlForeignKeyCheckOperation struct {
 // sqlForeignKeyConstraintCheckOperation during local execution.
 type sqlForeignKeyConstraintCheckRun struct {
 	started  bool
-	rows     *rowcontainer.RowContainer
+	rows     []tree.Datums
 	rowIndex int
 }
 
@@ -68,31 +63,52 @@ func newSQLForeignKeyCheckOperation(
 // runs in the distSQL execution engine.
 func (o *sqlForeignKeyCheckOperation) Start(params runParams) error {
 	ctx := params.ctx
-	checkQuery, err := createFKCheckQuery(o.tableName.Catalog(), o.tableDesc, o.constraint, o.asOf)
-	if err != nil {
-		return err
+
+	prefix := len(o.constraint.Index.ColumnNames)
+	if o.constraint.FK.SharedPrefixLen > 0 {
+		prefix = int(o.constraint.FK.SharedPrefixLen)
 	}
-	plan, err := params.p.delegateQuery(ctx, "SCRUB TABLE ... WITH OPTIONS CONSTRAINT", checkQuery, nil, nil)
+
+	checkQuery, _, err := nonMatchingRowQuery(
+		prefix,
+		&o.tableDesc.TableDescriptor,
+		o.constraint.Index,
+		o.constraint.ReferencedTable.ID,
+		o.constraint.ReferencedIndex,
+		false, /* limitResults */
+	)
 	if err != nil {
 		return err
 	}
 
-	// All columns projected in the plan generated from the query are
-	// needed. The columns are the index columns and extra columns in the
-	// index, twice -- for the primary and then secondary index.
-	needed := make([]bool, len(planColumns(plan)))
-	for i := range needed {
-		needed[i] = true
-	}
-
-	// Optimize the plan. This is required in order to populate scanNode
-	// spans.
-	plan, err = params.p.optimizePlan(ctx, plan, needed)
+	rows, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.Query(
+		ctx, "scrub-fk", params.p.txn, checkQuery,
+	)
 	if err != nil {
-		plan.Close(ctx)
 		return err
 	}
-	defer plan.Close(ctx)
+	o.run.rows = rows
+
+	if prefix > 1 && o.constraint.FK.Match == sqlbase.ForeignKeyReference_FULL {
+		// Check if there are any disallowed references where some columns are NULL
+		// and some aren't.
+		checkNullsQuery, _, err := matchFullUnacceptableKeyQuery(
+			prefix,
+			&o.tableDesc.TableDescriptor,
+			o.constraint.Index,
+			false, /* limitResults */
+		)
+		if err != nil {
+			return err
+		}
+		rows, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.Query(
+			ctx, "scrub-fk", params.p.txn, checkNullsQuery,
+		)
+		if err != nil {
+			return err
+		}
+		o.run.rows = append(o.run.rows, rows...)
+	}
 
 	// Collect the expected types for the query results. This is all
 	// columns and extra columns in the secondary index used for foreign
@@ -104,49 +120,18 @@ func (o *sqlForeignKeyCheckOperation) Start(params runParams) error {
 	}
 
 	colIDs, _ := o.constraint.Index.FullColumnIDs()
-	columnTypes := make([]types.T, len(colIDs))
 	o.colIDToRowIdx = make(map[sqlbase.ColumnID]int, len(colIDs))
 	for i, id := range colIDs {
-		columnTypes[i] = columnsByID[id].Type
 		o.colIDToRowIdx[id] = i
 	}
 
-	planCtx := params.extendedEvalCtx.DistSQLPlanner.NewPlanningCtx(ctx, params.extendedEvalCtx, params.p.txn)
-	physPlan, err := scrubPlanDistSQL(ctx, planCtx, plan)
-	if err != nil {
-		return err
-	}
-
-	// Set NullEquality to true on all MergeJoinerSpecs. This changes the
-	// behavior of the query's equality semantics in the ON predicate. The
-	// equalities will now evaluate NULL = NULL to true, which is what we
-	// desire when testing the equivilance of two index entries. There
-	// might be multiple merge joiners (with hash-routing).
-	var foundMergeJoiner bool
-	for i := range physPlan.Processors {
-		if physPlan.Processors[i].Spec.Core.MergeJoiner != nil {
-			physPlan.Processors[i].Spec.Core.MergeJoiner.NullEquality = true
-			foundMergeJoiner = true
-		}
-	}
-	if !foundMergeJoiner {
-		return errors.Errorf("could not find MergeJoinerSpec in plan")
-	}
-
-	rows, err := scrubRunDistSQL(ctx, planCtx, params.p, physPlan, columnTypes)
-	if err != nil {
-		rows.Close(ctx)
-		return err
-	}
-
 	o.run.started = true
-	o.run.rows = rows
 	return nil
 }
 
 // Next implements the checkOperation interface.
 func (o *sqlForeignKeyCheckOperation) Next(params runParams) (tree.Datums, error) {
-	row := o.run.rows.At(o.run.rowIndex)
+	row := o.run.rows[o.run.rowIndex]
 	o.run.rowIndex++
 
 	details := make(map[string]interface{})
@@ -203,104 +188,10 @@ func (o *sqlForeignKeyCheckOperation) Started() bool {
 
 // Done implements the checkOperation interface.
 func (o *sqlForeignKeyCheckOperation) Done(ctx context.Context) bool {
-	return o.run.rows == nil || o.run.rowIndex >= o.run.rows.Len()
+	return o.run.rows == nil || o.run.rowIndex >= len(o.run.rows)
 }
 
 // Close implements the checkOperation interface.
 func (o *sqlForeignKeyCheckOperation) Close(ctx context.Context) {
-	if o.run.rows != nil {
-		o.run.rows.Close(ctx)
-	}
-}
-
-// createFKCheckQuery will make the foreign key check query for a given
-// table, the referenced tables and the mapping from table columns to
-// referenced table columns.
-//
-// For example, given the following table schemas:
-//
-//   CREATE TABLE parent (
-//     id INT, dept_id INT,
-//     PRIMARY KEY (id),
-//     UNIQUE INDEX dept_idx (dept_id)
-//   )
-//
-//   CREATE TABLE child (
-//     id INT, dept_id INT,
-//     PRIMARY KEY (id),
-//     CONSTRAINT "parent_fk" FOREIGN KEY (dept_id) REFERENCES parent (dept_id)
-//   )
-//
-// The generated query to check the `parent_fk` will be:
-//
-//   SELECT p.id, p.dept_id
-//   FROM
-//     (SELECT id, dept_id FROM child@{FORCE_INDEX=[..]} ORDER BY dept_id) AS p
-//   LEFT OUTER JOIN
-//     (SELECT dept_id FROM parent@{FORCE_INDEX=dept_idx} ORDER BY dept_id) AS c
-//   ON
-//      p.dept_id = c.dept_id
-//   WHERE p.dept_id IS NOT NULL AND c.dept_id IS NULL
-//
-// In short, this query is:
-// 1) Scanning the foreign key index of the child table and the
-//    referenced index of the foreign table.
-// 2) Explicitly ordering both of them by their index columns. This
-//    should be a NOOP as the indexes should already have a matching
-//    order. This is done to force a distSQL merge join.
-// 3) Joining all of the referencing columns from both tables columns
-//    that are equivalent. NB: The distSQL plan generated from this
-//    query is toggled to make NULL = NULL evaluate to true using the
-//    MergeJoinerSpec.NullEquality flag. Otherwise, we would need an ON
-//    predicate which uses hash join and is extremely slow.
-// 4) Filtering to achieve an anti-join. This filters out any child rows
-//    which have all NULL foreign key values and filters out any
-//    matches.
-//
-func createFKCheckQuery(
-	database string,
-	tableDesc *sqlbase.ImmutableTableDescriptor,
-	constraint *sqlbase.ConstraintDetail,
-	asOf hlc.Timestamp,
-) (string, error) {
-	var asOfClauseStr string
-	// If SCRUB is called with AS OF SYSTEM TIME <expr> the
-	// checkIndexQuery will also include the as of clause.
-	if asOf != hlc.MaxTimestamp {
-		asOfClauseStr = fmt.Sprintf("AS OF SYSTEM TIME %d", asOf.WallTime)
-	}
-
-	const checkIndexQuery = `
-				SELECT %[1]s
-				FROM
-					(SELECT %[9]s FROM %[2]s.%[3]s@{NO_INDEX_JOIN} %[12]s ORDER BY %[10]s) AS p
-				FULL OUTER JOIN
-					(SELECT %[11]s FROM %[2]s.%[4]s@{FORCE_INDEX=[%[5]d]} %[12]s ORDER BY %[11]s) AS c
-					ON %[6]s
-        WHERE (%[7]s) AND %[8]s`
-
-	columnNames := append([]string(nil), constraint.Index.ColumnNames...)
-	// ExtraColumns will include primary index key values not already part of the index.
-	for _, id := range constraint.Index.ExtraColumnIDs {
-		column, err := tableDesc.FindActiveColumnByID(id)
-		if err != nil {
-			return "", err
-		}
-		columnNames = append(columnNames, column.Name)
-	}
-
-	return fmt.Sprintf(checkIndexQuery,
-		tableColumnsProjection("p", columnNames), // 1
-		database,                                 // 2
-		tableDesc.Name,                           // 3
-		constraint.ReferencedTable.Name,          // 4
-		constraint.ReferencedIndex.ID,            // 5
-		tableColumnsEQ("p", "c", constraint.Columns, constraint.ReferencedIndex.ColumnNames),               // 6
-		tableColumnsIsNullPredicate("p", constraint.Columns, "OR", false /* isNull */),                     // 7
-		tableColumnsIsNullPredicate("c", constraint.ReferencedIndex.ColumnNames, "AND", true /* isNull */), // 8
-		strings.Join(columnNames, ","),                            // 9
-		strings.Join(constraint.Columns, ","),                     // 10
-		strings.Join(constraint.ReferencedIndex.ColumnNames, ","), // 11
-		asOfClauseStr, //12
-	), nil
+	o.run.rows = nil
 }

--- a/pkg/sql/scrub_test.go
+++ b/pkg/sql/scrub_test.go
@@ -16,8 +16,12 @@ package sql_test
 
 import (
 	"context"
+	gosql "database/sql"
+	"fmt"
+	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -407,7 +411,7 @@ INSERT INTO t.test VALUES (10, 2);
 	}
 }
 
-// TestScrubFKConstraintFKIsNull tests that `SCRUB TABLE ... CONSTRAINT
+// TestScrubFKConstraintFKMissing tests that `SCRUB TABLE ... CONSTRAINT
 // ALL` will report an error when a foreign key constraint is violated.
 // To test this, the secondary index used for the foreign key lookup is
 // modified using the KV client to change the value and cause a
@@ -416,24 +420,23 @@ func TestScrubFKConstraintFKMissing(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.TODO())
+	r := sqlutils.MakeSQLRunner(db)
 
 	// Create the table and the row entry.
-	if _, err := db.Exec(`
-CREATE DATABASE t;
-CREATE TABLE t.parent (
-	id INT PRIMARY KEY
-);
-CREATE TABLE t.child (
-	child_id INT PRIMARY KEY,
-	parent_id INT,
-	INDEX (parent_id),
-	FOREIGN KEY (parent_id) REFERENCES t.parent (id)
-);
-INSERT INTO t.parent VALUES (314);
-INSERT INTO t.child VALUES (10, 314);
-`); err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
+	r.Exec(t, `
+		CREATE DATABASE t;
+		CREATE TABLE t.parent (
+			id INT PRIMARY KEY
+		);
+		CREATE TABLE t.child (
+			child_id INT PRIMARY KEY,
+			parent_id INT,
+			INDEX (parent_id),
+			FOREIGN KEY (parent_id) REFERENCES t.parent (id)
+		);
+		INSERT INTO t.parent VALUES (314);
+		INSERT INTO t.child VALUES (10, 314);
+	`)
 
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "child")
 
@@ -483,46 +486,34 @@ INSERT INTO t.child VALUES (10, 314);
 	}
 
 	// Run SCRUB and find the FOREIGN KEY violation created.
-	rows, err := db.Query(`EXPERIMENTAL SCRUB TABLE t.child WITH OPTIONS CONSTRAINT ALL`)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	exp := expectedScrubResult{
+		ErrorType:    scrub.ForeignKeyConstraintViolation,
+		Database:     "t",
+		Table:        "child",
+		PrimaryKey:   "(10)",
+		DetailsRegex: `{"constraint_name": "fk_parent_id_ref_parent", "row_data": {"child_id": "10", "parent_id": "0"}}`,
 	}
-	defer rows.Close()
+	runScrub(t, db, `EXPERIMENTAL SCRUB TABLE t.child WITH OPTIONS CONSTRAINT ALL`, exp)
+	// Run again with AS OF SYSTEM TIME.
+	time.Sleep(1 * time.Millisecond)
+	runScrub(t, db, `EXPERIMENTAL SCRUB TABLE t.child AS OF SYSTEM TIME '-1ms' WITH OPTIONS CONSTRAINT ALL`, exp)
 
-	results, err := sqlutils.GetScrubResultRows(rows)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-
-	if len(results) != 1 {
-		t.Fatalf("expected 1 result, got %d. got %#v", len(results), results)
-	}
-
-	if result := results[0]; result.ErrorType != string(scrub.ForeignKeyConstraintViolation) {
-		t.Fatalf("expected %q error, instead got: %s",
-			scrub.ForeignKeyConstraintViolation, result.ErrorType)
-	} else if result.Database != "t" {
-		t.Fatalf("expected database %q, got %q", "t", result.Database)
-	} else if result.Table != "child" {
-		t.Fatalf("expected table %q, got %q", "child", result.Table)
-	} else if result.PrimaryKey != "(10)" {
-		t.Fatalf("expected primaryKey %q, got %q", "(10)", result.PrimaryKey)
-	} else if result.Repaired {
-		t.Fatalf("expected repaired %v, got %v", false, result.Repaired)
-	} else if !strings.Contains(result.Details,
-		`{"constraint_name": "fk_parent_id_ref_parent", "row_data": {"child_id": "10", "parent_id": "0"}}`) {
-		t.Fatalf("expected error details to contain %s, got %s",
-			`{"constraint_name": "fk_parent_id_ref_parent", "row_data": {"child_id": "10", "parent_id": "0"}}`,
-			result.Details)
-	}
+	// Verify that AS OF SYSTEM TIME actually operates in the past.
+	ts := r.QueryStr(t, `SELECT cluster_logical_timestamp()`)[0][0]
+	r.Exec(t, "INSERT INTO t.parent VALUES (0)")
+	runScrub(
+		t, db, fmt.Sprintf(
+			`EXPERIMENTAL SCRUB TABLE t.child AS OF SYSTEM TIME '%s' WITH OPTIONS CONSTRAINT ALL`, ts,
+		),
+		exp,
+	)
 }
 
-// TestScrubFKConstraintFKIsNullAndMissing tests that
-// `SCRUB TABLE ... CONSTRAINT ALL` will fail if a foreign key
-// constraint is violated when there is no referenced foreign key row
-// found and the foreign key values are partially null. To test this, a
-// row's underlying value is modified using the KV client.
-func TestScrubFKConstraintFKIsNullAndMissing(t *testing.T) {
+// TestScrubFKConstraintFKNulls tests that `SCRUB TABLE ... CONSTRAINT ALL` will
+// fail if a MATCH FULL foreign key constraint is violated when foreign key
+// values are partially null. To test this, a row's underlying value is
+// modified using the KV client.
+func TestScrubFKConstraintFKNulls(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.TODO())
@@ -540,7 +531,7 @@ CREATE TABLE t.child (
 	parent_id INT,
 	parent_id2 INT,
 	INDEX (parent_id, parent_id2),
-	FOREIGN KEY (parent_id, parent_id2) REFERENCES t.parent (id, id2)
+	FOREIGN KEY (parent_id, parent_id2) REFERENCES t.parent (id, id2) MATCH FULL
 );
 INSERT INTO t.parent VALUES (1337, 300);
 INSERT INTO t.child VALUES (11, 1337, 300);
@@ -591,38 +582,16 @@ INSERT INTO t.child VALUES (11, 1337, 300);
 	}
 
 	// Run SCRUB and find the FOREIGN KEY violation created.
-	rows, err := db.Query(`EXPERIMENTAL SCRUB TABLE t.child WITH OPTIONS CONSTRAINT ALL`)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	exp := expectedScrubResult{
+		ErrorType:    scrub.ForeignKeyConstraintViolation,
+		Database:     "t",
+		Table:        "child",
+		PrimaryKey:   "(11)",
+		DetailsRegex: `{"constraint_name": "fk_parent_id_ref_parent", "row_data": {"child_id": "11", "parent_id": "1337", "parent_id2": "NULL"}}`,
 	}
-	defer rows.Close()
-
-	results, err := sqlutils.GetScrubResultRows(rows)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-
-	if len(results) != 1 {
-		t.Fatalf("expected 1 result, got %d. got %#v", len(results), results)
-	}
-
-	if result := results[0]; result.ErrorType != string(scrub.ForeignKeyConstraintViolation) {
-		t.Fatalf("expected %q error, instead got: %s",
-			scrub.ForeignKeyConstraintViolation, result.ErrorType)
-	} else if result.Database != "t" {
-		t.Fatalf("expected database %q, got %q", "t", result.Database)
-	} else if result.Table != "child" {
-		t.Fatalf("expected table %q, got %q", "child", result.Table)
-	} else if result.PrimaryKey != "(11)" {
-		t.Fatalf("expected primaryKey %q, got %q", "(11)", result.PrimaryKey)
-	} else if result.Repaired {
-		t.Fatalf("expected repaired %v, got %v", false, result.Repaired)
-	} else if !strings.Contains(result.Details,
-		`{"constraint_name": "fk_parent_id_ref_parent", "row_data": {"child_id": "11", "parent_id": "1337", "parent_id2": "NULL"}}`) {
-		t.Fatalf("expected error details to contain %s, got %s",
-			`{"constraint_name": "fk_parent_id_ref_parent", "row_data": {"child_id": "11", "parent_id": "1337", "parent_id2": "NULL"}}`,
-			result.Details)
-	}
+	runScrub(t, db, `EXPERIMENTAL SCRUB TABLE t.child WITH OPTIONS CONSTRAINT ALL`, exp)
+	time.Sleep(1 * time.Millisecond)
+	runScrub(t, db, `EXPERIMENTAL SCRUB TABLE t.child AS OF SYSTEM TIME '-1ms' WITH OPTIONS CONSTRAINT ALL`, exp)
 }
 
 // TestScrubPhysicalNonnullableNullInSingleColumnFamily tests that
@@ -1005,4 +974,65 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v1 INT, v2 INT);
 	} else if !strings.Contains(result.Details, `"b": "<unset>"`) {
 		t.Fatalf("expected error details to contain `%s`, got %s", `"b": "<unset>"`, result.Details)
 	}
+}
+
+type expectedScrubResult struct {
+	ErrorType    string
+	Database     string
+	Table        string
+	PrimaryKey   string
+	Repaired     bool
+	DetailsRegex string
+}
+
+func checkScrubResult(t *testing.T, res sqlutils.ScrubResult, exp expectedScrubResult) {
+	t.Helper()
+
+	if res.ErrorType != exp.ErrorType {
+		t.Errorf("expected %q error, instead got: %s", exp.ErrorType, res.ErrorType)
+	}
+
+	if res.Database != exp.Database {
+		t.Errorf("expected database %q, got %q", exp.Database, res.Database)
+	}
+
+	if res.Table != exp.Table {
+		t.Errorf("expected table %q, got %q", exp.Table, res.Table)
+	}
+
+	if res.PrimaryKey != exp.PrimaryKey {
+		t.Errorf("expected primary key %q, got %q", exp.PrimaryKey, res.PrimaryKey)
+	}
+	if res.Repaired != exp.Repaired {
+		t.Fatalf("expected repaired %v, got %v", exp.Repaired, res.Repaired)
+	}
+
+	if matched, err := regexp.MatchString(exp.DetailsRegex, res.Details); err != nil {
+		t.Fatal(err)
+	} else if !matched {
+		t.Errorf("expected error details to contain `%s`, got `%s`", exp.DetailsRegex, res.Details)
+	}
+}
+
+// runScrub runs a SCRUB statement and checks that it returns exactly one scrub
+// result and that it matches the expected result.
+func runScrub(t *testing.T, db *gosql.DB, scrubStmt string, exp expectedScrubResult) {
+	t.Helper()
+
+	// Run SCRUB and find the FOREIGN KEY violation created.
+	rows, err := db.Query(scrubStmt)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	defer rows.Close()
+
+	results, err := sqlutils.GetScrubResultRows(rows)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d. got %#v", len(results), results)
+	}
+	checkScrubResult(t, results[0], exp)
 }


### PR DESCRIPTION
#### opt: handle ignore_foreign_keys hint for table-by-id

We weren't handling the `IGNORE_FOREIGN_KEYS` hint in the table-by-id
case. Moving the addition of the table to the metadata into
`buildScan`.

Release note: None

#### sql: run scrub FK queries through the internal executor

This commit rewrites the scrubbing of FKs to use the same queries used
by `VALIDATE CONSTRAINT`. This allows us to use the internal executor
instead of a hacky (non-optimizer-friendly) path which was tweaking
the distsql plan.

Note that the removed code was incorrectly handling NULLs for FKs
(mixing null and non-null columns is always ok with PARTIAL MATCH, and
is never ok with FULL MATCH).

The `VALIDATE CONSTRAINT` queries are improved to return the
referencing columns and the PK columns (which leads to improved error
messages).

Release note: None
