### PR TITLE
sql: always collect stats after a table is created

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 
@@ -303,10 +304,12 @@ func (n *createTableNode) startExec(params runParams) error {
 			}
 			n.run.rowsAffected++
 		}
-
-		// Initiate a run of CREATE STATISTICS.
-		params.ExecCfg().StatsRefresher.NotifyMutation(desc.ID, n.run.rowsAffected)
 	}
+
+	// Initiate a run of CREATE STATISTICS. We use a large number
+	// for rowsAffected because we want to make sure that stats always get
+	// created/refreshed here.
+	params.ExecCfg().StatsRefresher.NotifyMutation(desc.ID, math.MaxInt32 /* rowsAffected */)
 	return nil
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
@@ -1,5 +1,9 @@
 # LogicTest: fakedist fakedist-opt fakedist-metadata
 
+# Disable automatic stats
+statement ok
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
+
 statement ok
 CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, PRIMARY KEY (a, b, c), INDEX d_idx (d))
 
@@ -132,6 +136,17 @@ __auto__         {b}           550        0
 __auto__         {c}           550        0
 __auto__         {d}           550        0
 __auto__         {rowid}       550        0
+
+statement ok
+CREATE TABLE test_create (x INT PRIMARY KEY, y CHAR)
+
+query TTIII colnames,rowsort,retry
+SELECT statistics_name, column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE test_create] ORDER BY column_names::STRING, created
+----
+statistics_name  column_names  row_count  distinct_count  null_count
+__auto__         {x}           0          0               0
+__auto__         {y}           0          0               0
 
 # Test fast path delete.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/distsql_event_log
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_event_log
@@ -4,6 +4,9 @@
 # CREATE STATISTICS
 ###################
 
+statement ok
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
+
 # This test verifies that events are posted for table statistics creation.
 statement ok
 SET CLUSTER SETTING sql.stats.post_events.enabled = TRUE

--- a/pkg/sql/logictest/testdata/logic_test/distsql_interleaved_join
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_interleaved_join
@@ -27,6 +27,9 @@
 #   - no interleaved relationship (parent1 - parent2, parent2 - child1)
 #   - TODO(richardwu): sibling-sibling (child1 - child2)
 
+statement ok
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
+
 #################
 # Create tables #
 #################

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1,5 +1,8 @@
 # LogicTest: local local-opt
 
+statement ok
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
+
 # Verify pg_catalog database handles mutation statements correctly.
 
 query error database "pg_catalog" does not exist

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -1,5 +1,8 @@
 # LogicTest: local
 
+statement ok
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
+
 query TTT colnames
 EXPLAIN (PLAN) SELECT 1 FROM system.jobs WHERE FALSE
 ----

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -4246,6 +4246,8 @@ func TestCreateStatsAfterSchemaChange(t *testing.T) {
 	defer server.Stopper().Stop(context.TODO())
 	sqlRun := sqlutils.MakeSQLRunner(sqlDB)
 
+	sqlRun.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled=false`)
+
 	sqlRun.Exec(t, `
 		CREATE DATABASE t;
 		CREATE TABLE t.test (k INT PRIMARY KEY, v CHAR, w CHAR);`)


### PR DESCRIPTION
Prior to this commit, we only collected automatic statistics on a
`CREATE TABLE` statement if it was of the form `CREATE TABLE AS <query>`.
To avoid inconsistencies, this commit changes the logic so we always
create statistics on every successful `CREATE TABLE` statement.

Fixes #37362

Release note (sql change): CREATE TABLE statements now always trigger automatic
statistics collection on the newly created table.