### PR TITLE
release-2.1: opt: Fix cycle between two optimization rules that crashes server.

### DIFF
--- a/pkg/sql/opt/norm/join.go
+++ b/pkg/sql/opt/norm/join.go
@@ -130,7 +130,7 @@ func (c *CustomFuncs) CanMap(filters, src, dst memo.GroupID) bool {
 		return true
 	}
 
-	if c.HasHoistableSubquery(src) {
+	if c.HasCorrelatedSubquery(src) {
 		return false
 	}
 

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -966,6 +966,50 @@ project
  └── projections
       └── const: 1 [type=int]
 
+# Regression for issue 36137. Try to trigger undetectable cycle between the
+# PushFilterIntoJoinLeftAndRight and TryDecorrelateSelect rules.
+opt
+SELECT * FROM a JOIN b ON a.k = b.x
+WHERE (a.k = b.x) OR (a.k IN (SELECT 5 FROM b WHERE x = y));
+----
+inner-join (merge)
+ ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
+ ├── key: (6)
+ ├── fd: (1)-->(2-5), (6)-->(7), (1)==(6), (6)==(1)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-5)
+ │    └── ordering: +1
+ ├── scan b
+ │    ├── columns: b.x:6(int!null) b.y:7(int)
+ │    ├── key: (6)
+ │    ├── fd: (6)-->(7)
+ │    └── ordering: +6
+ └── merge-on
+      ├── left ordering: +1
+      ├── right ordering: +6
+      └── filters [type=bool, outer=(1,6)]
+           └── or [type=bool, outer=(1,6)]
+                ├── k = b.x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+                └── any: eq [type=bool, outer=(1)]
+                     ├── project
+                     │    ├── columns: "?column?":10(int!null)
+                     │    ├── fd: ()-->(10)
+                     │    ├── select
+                     │    │    ├── columns: b.x:8(int!null) b.y:9(int!null)
+                     │    │    ├── key: (8)
+                     │    │    ├── fd: (8)==(9), (9)==(8)
+                     │    │    ├── scan b
+                     │    │    │    ├── columns: b.x:8(int!null) b.y:9(int)
+                     │    │    │    ├── key: (8)
+                     │    │    │    └── fd: (8)-->(9)
+                     │    │    └── filters [type=bool, outer=(8,9), constraints=(/8: (/NULL - ]; /9: (/NULL - ]), fd=(8)==(9), (9)==(8)]
+                     │    │         └── b.x = b.y [type=bool, outer=(8,9), constraints=(/8: (/NULL - ]; /9: (/NULL - ])]
+                     │    └── projections
+                     │         └── const: 5 [type=int]
+                     └── variable: k [type=int, outer=(1)]
+
 # --------------------------------------------------
 # PushFilterIntoJoinLeft + PushFilterIntoJoinRight
 # --------------------------------------------------


### PR DESCRIPTION
The PushFilterIntoJoinLeftAndRight and TryDecorrelateSelect rules will
cycle with one another when the first rule tries to push down a filter
condition that contains a correlated subquery, and the second pulls it
back up.

The bug is that CanMap was testing for HasHoistableSubquery rather than
HasCorrelatedSubquery. So it would cycle when a filter condition had an
unhoistable correlated subquery. The current heuristic is not to hoist
an ANY query that is correlated only in its 2nd argument. The fix is to
check for HasCorrelatedSubquery instead.

Fixes #37373

Release note: None