### PR TITLE
opt: use check constraints to use and constrain index scans

### DIFF
--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -141,14 +141,17 @@ type Table interface {
 	InboundForeignKey(i int) ForeignKeyConstraint
 }
 
-// CheckConstraint is the SQL text for a check constraint on a table. Check
-// constraints are user-defined restrictions on the content of each row in a
-// table. For example, this check constraint ensures that only values greater
-// than zero can be inserted into the table:
+// CheckConstraint contains the SQL text and the validity status for a check
+// constraint on a table. Check constraints are user-defined restrictions
+// on the content of each row in a table. For example, this check constraint
+// ensures that only values greater than zero can be inserted into the table:
 //
 //   CREATE TABLE a (a INT CHECK (a > 0))
 //
-type CheckConstraint string
+type CheckConstraint struct {
+	Constraint string
+	Validated  bool
+}
 
 // TableStatistic is an interface to a table statistic. Each statistic is
 // associated with a set of columns.

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -153,7 +153,7 @@ func FormatTable(cat Catalog, tab Table, tp treeprinter.Node) {
 	}
 
 	for i := 0; i < tab.CheckCount(); i++ {
-		child.Childf("CHECK (%s)", tab.Check(i))
+		child.Childf("CHECK (%s)", tab.Check(i).Constraint)
 	}
 
 	// Don't print the primary family, since it's implied.

--- a/pkg/sql/opt/memo/testdata/expr
+++ b/pkg/sql/opt/memo/testdata/expr
@@ -1,0 +1,45 @@
+# Test nullability of scalar expressions.
+scalar-is-not-nullable
+true AND false
+----
+true
+
+scalar-is-not-nullable vars=(int)
+@1 >= 5
+----
+false
+
+scalar-is-not-nullable vars=(int!null)
+@1 >= 5
+----
+true
+
+scalar-is-not-nullable vars=(int!null, int!null)
+@1 >= 5 AND @1 <= 10 AND @2 < 4
+----
+true
+
+scalar-is-not-nullable vars=(int!null, int)
+@1 >= 5 AND @1 <= 10 AND @2 < 4
+----
+false
+
+scalar-is-not-nullable vars=(int!null)
+@1 >= 5 AND @1 IN (1, 2)
+----
+true
+
+scalar-is-not-nullable vars=(int!null)
+@1 >= 5 AND @1 IN (1, 2, NULL)
+----
+false
+
+scalar-is-not-nullable vars=(int!null, int!null)
+CASE WHEN @1 >= 5 THEN @1 <= 10 ELSE @2 < 4 END
+----
+true
+
+scalar-is-not-nullable vars=(int!null, int!null)
+CASE WHEN @1 >= 5 THEN @1 <= 10 ELSE (@2 IN (4, NULL)) END
+----
+false

--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -218,12 +218,12 @@ project
  ├── fd: (1)-->(2,3), (2)-->(3)
  ├── prune: (1-3)
  └── insert abc
-      ├── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int) abc.rowid:4(int!null)
+      ├── columns: a:1(int!null) b:2(int) c:3(int) rowid:4(int!null)
       ├── insert-mapping:
-      │    ├──  x:5 => abc.a:1
-      │    ├──  y:6 => abc.b:2
-      │    ├──  column9:9 => abc.c:3
-      │    └──  column8:8 => abc.rowid:4
+      │    ├──  x:5 => a:1
+      │    ├──  y:6 => b:2
+      │    ├──  column9:9 => c:3
+      │    └──  column8:8 => rowid:4
       ├── side-effects, mutations
       ├── key: (1)
       ├── fd: (1)-->(2-4), (2)-->(3)
@@ -235,14 +235,14 @@ project
            ├── prune: (5,6,8,9)
            ├── interesting orderings: (+5) (+6)
            └── select
-                ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) abc_3.a:18(int) abc_3.b:19(int) abc_3.c:20(int) abc_3.rowid:21(int)
+                ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:18(int) b:19(int) c:20(int) rowid:21(int)
                 ├── side-effects
                 ├── key: (5)
                 ├── fd: ()-->(18-21), (5)-->(6,8), (6)-->(9)
                 ├── prune: (5,8,18)
                 ├── interesting orderings: (+5) (+6) (+21) (+18) (+19,+20,+21)
                 ├── left-join
-                │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) abc_3.a:18(int) abc_3.b:19(int) abc_3.c:20(int) abc_3.rowid:21(int)
+                │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:18(int) b:19(int) c:20(int) rowid:21(int)
                 │    ├── side-effects
                 │    ├── key: (5,21)
                 │    ├── fd: (5)-->(6,8), (6)-->(9), (21)-->(18-20), (18)-->(19-21), (19,20)~~>(18,21)
@@ -257,14 +257,14 @@ project
                 │    │    ├── prune: (5,6,8,9)
                 │    │    ├── interesting orderings: (+5) (+6)
                 │    │    └── select
-                │    │         ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) abc_2.a:14(int) abc_2.b:15(int) abc_2.c:16(int) abc_2.rowid:17(int)
+                │    │         ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:14(int) b:15(int) c:16(int) rowid:17(int)
                 │    │         ├── side-effects
                 │    │         ├── key: (5)
                 │    │         ├── fd: ()-->(14-17), (5)-->(6,8), (6)-->(9)
                 │    │         ├── prune: (6,8,9,15-17)
                 │    │         ├── interesting orderings: (+5) (+6) (+17) (+14) (+15,+16,+17)
                 │    │         ├── left-join
-                │    │         │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) abc_2.a:14(int) abc_2.b:15(int) abc_2.c:16(int) abc_2.rowid:17(int)
+                │    │         │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:14(int) b:15(int) c:16(int) rowid:17(int)
                 │    │         │    ├── side-effects
                 │    │         │    ├── key: (5,17)
                 │    │         │    ├── fd: (5)-->(6,8), (6)-->(9), (17)-->(14-16), (14)-->(15-17), (15,16)~~>(14,17)
@@ -279,14 +279,14 @@ project
                 │    │         │    │    ├── prune: (5,6,8,9)
                 │    │         │    │    ├── interesting orderings: (+5) (+6)
                 │    │         │    │    └── select
-                │    │         │    │         ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) abc_1.a:10(int) abc_1.b:11(int) abc_1.c:12(int) abc_1.rowid:13(int)
+                │    │         │    │         ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
                 │    │         │    │         ├── side-effects
                 │    │         │    │         ├── key: (5)
                 │    │         │    │         ├── fd: ()-->(10-13), (5)-->(6,8), (6)-->(9)
                 │    │         │    │         ├── prune: (5,6,9-12)
                 │    │         │    │         ├── interesting orderings: (+5) (+6) (+13) (+10) (+11,+12,+13)
                 │    │         │    │         ├── left-join
-                │    │         │    │         │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) abc_1.a:10(int) abc_1.b:11(int) abc_1.c:12(int) abc_1.rowid:13(int)
+                │    │         │    │         │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
                 │    │         │    │         │    ├── side-effects
                 │    │         │    │         │    ├── key: (5,13)
                 │    │         │    │         │    ├── fd: (5)-->(6,8), (6)-->(9), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13)
@@ -325,8 +325,8 @@ project
                 │    │         │    │         │    │         └── plus [type=int, outer=(6)]
                 │    │         │    │         │    │              ├── variable: y [type=int]
                 │    │         │    │         │    │              └── const: 1 [type=int]
-                │    │         │    │         │    ├── scan abc_1
-                │    │         │    │         │    │    ├── columns: abc_1.a:10(int!null) abc_1.b:11(int) abc_1.c:12(int) abc_1.rowid:13(int!null)
+                │    │         │    │         │    ├── scan abc
+                │    │         │    │         │    │    ├── columns: a:10(int!null) b:11(int) c:12(int) rowid:13(int!null)
                 │    │         │    │         │    │    ├── key: (13)
                 │    │         │    │         │    │    ├── fd: (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13)
                 │    │         │    │         │    │    ├── prune: (10-13)
@@ -334,13 +334,13 @@ project
                 │    │         │    │         │    └── filters
                 │    │         │    │         │         └── eq [type=bool, outer=(8,13), constraints=(/8: (/NULL - ]; /13: (/NULL - ]), fd=(8)==(13), (13)==(8)]
                 │    │         │    │         │              ├── variable: column8 [type=int]
-                │    │         │    │         │              └── variable: abc_1.rowid [type=int]
+                │    │         │    │         │              └── variable: rowid [type=int]
                 │    │         │    │         └── filters
                 │    │         │    │              └── is [type=bool, outer=(13), constraints=(/13: [/NULL - /NULL]; tight), fd=()-->(13)]
-                │    │         │    │                   ├── variable: abc_1.rowid [type=int]
+                │    │         │    │                   ├── variable: rowid [type=int]
                 │    │         │    │                   └── null [type=unknown]
-                │    │         │    ├── scan abc_2
-                │    │         │    │    ├── columns: abc_2.a:14(int!null) abc_2.b:15(int) abc_2.c:16(int) abc_2.rowid:17(int!null)
+                │    │         │    ├── scan abc
+                │    │         │    │    ├── columns: a:14(int!null) b:15(int) c:16(int) rowid:17(int!null)
                 │    │         │    │    ├── key: (17)
                 │    │         │    │    ├── fd: (17)-->(14-16), (14)-->(15-17), (15,16)~~>(14,17)
                 │    │         │    │    ├── prune: (14-17)
@@ -348,13 +348,13 @@ project
                 │    │         │    └── filters
                 │    │         │         └── eq [type=bool, outer=(5,14), constraints=(/5: (/NULL - ]; /14: (/NULL - ]), fd=(5)==(14), (14)==(5)]
                 │    │         │              ├── variable: x [type=int]
-                │    │         │              └── variable: abc_2.a [type=int]
+                │    │         │              └── variable: a [type=int]
                 │    │         └── filters
                 │    │              └── is [type=bool, outer=(14), constraints=(/14: [/NULL - /NULL]; tight), fd=()-->(14)]
-                │    │                   ├── variable: abc_2.a [type=int]
+                │    │                   ├── variable: a [type=int]
                 │    │                   └── null [type=unknown]
-                │    ├── scan abc_3
-                │    │    ├── columns: abc_3.a:18(int!null) abc_3.b:19(int) abc_3.c:20(int) abc_3.rowid:21(int!null)
+                │    ├── scan abc
+                │    │    ├── columns: a:18(int!null) b:19(int) c:20(int) rowid:21(int!null)
                 │    │    ├── key: (21)
                 │    │    ├── fd: (21)-->(18-20), (18)-->(19-21), (19,20)~~>(18,21)
                 │    │    ├── prune: (18-21)
@@ -362,13 +362,13 @@ project
                 │    └── filters
                 │         ├── eq [type=bool, outer=(6,19), constraints=(/6: (/NULL - ]; /19: (/NULL - ]), fd=(6)==(19), (19)==(6)]
                 │         │    ├── variable: y [type=int]
-                │         │    └── variable: abc_3.b [type=int]
+                │         │    └── variable: b [type=int]
                 │         └── eq [type=bool, outer=(9,20), constraints=(/9: (/NULL - ]; /20: (/NULL - ]), fd=(9)==(20), (20)==(9)]
                 │              ├── variable: column9 [type=int]
-                │              └── variable: abc_3.c [type=int]
+                │              └── variable: c [type=int]
                 └── filters
                      └── is [type=bool, outer=(21), constraints=(/21: [/NULL - /NULL]; tight), fd=()-->(21)]
-                          ├── variable: abc_3.rowid [type=int]
+                          ├── variable: rowid [type=int]
                           └── null [type=unknown]
 
 # UPSERT case.

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -641,11 +641,9 @@ func (mb *mutationBuilder) buildInputForDoNothing(inScope *scope, onConflict *tr
 		// Build the right side of the left outer join. Use a new metadata instance
 		// of the mutation table so that a different set of column IDs are used for
 		// the two tables in the self-join.
-		tn := mb.tab.Name().TableName
-		alias := tree.MakeUnqualifiedTableName(tree.Name(fmt.Sprintf("%s_%d", tn, idx+1)))
 		scanScope := mb.b.buildScan(
 			mb.tab,
-			&alias,
+			&mb.alias,
 			nil, /* ordinals */
 			nil, /* indexFlags */
 			excludeMutations,

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -518,7 +518,7 @@ func (mb *mutationBuilder) addCheckConstraintCols() {
 		projectionsScope.appendColumnsFromScope(mb.outScope)
 
 		for i, n := 0, mb.tab.CheckCount(); i < n; i++ {
-			expr, err := parser.ParseExpr(string(mb.tab.Check(i)))
+			expr, err := parser.ParseExpr(string(mb.tab.Check(i).Constraint))
 			if err != nil {
 				panic(builderError{err})
 			}
@@ -526,6 +526,9 @@ func (mb *mutationBuilder) addCheckConstraintCols() {
 			alias := fmt.Sprintf("check%d", i+1)
 			texpr := mb.outScope.resolveAndRequireType(expr, types.Bool)
 			scopeCol := mb.b.addColumn(projectionsScope, alias, texpr)
+
+			// TODO(ridwanmsharif): Maybe we can avoid building constraints here
+			// and instead use the constraints stored in the table metadata.
 			mb.b.buildScalar(texpr, mb.outScope, projectionsScope, scopeCol, nil)
 			mb.checkOrds[i] = scopeOrdinal(len(projectionsScope.cols) - 1)
 		}

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -1175,3 +1175,4 @@ if-err [type=decimal]
  │    └── variable: @1 [type=decimal]
  └── err-code
       └── const: '10000' [type=string]
+

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -650,27 +650,27 @@ ON CONFLICT DO NOTHING
 insert xyz
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  column1:4 => xyz.x:1
- │    ├──  column2:5 => xyz.y:2
- │    └──  column3:6 => xyz.z:3
+ │    ├──  column1:4 => x:1
+ │    ├──  column2:5 => y:2
+ │    └──  column3:6 => z:3
  └── project
       ├── columns: column1:4(int) column2:5(int) column3:6(int)
       └── select
-           ├── columns: column1:4(int) column2:5(int) column3:6(int) xyz_3.x:13(int) xyz_3.y:14(int) xyz_3.z:15(int)
+           ├── columns: column1:4(int) column2:5(int) column3:6(int) x:13(int) y:14(int) z:15(int)
            ├── left-join
-           │    ├── columns: column1:4(int) column2:5(int) column3:6(int) xyz_3.x:13(int) xyz_3.y:14(int) xyz_3.z:15(int)
+           │    ├── columns: column1:4(int) column2:5(int) column3:6(int) x:13(int) y:14(int) z:15(int)
            │    ├── project
            │    │    ├── columns: column1:4(int) column2:5(int) column3:6(int)
            │    │    └── select
-           │    │         ├── columns: column1:4(int) column2:5(int) column3:6(int) xyz_2.x:10(int) xyz_2.y:11(int) xyz_2.z:12(int)
+           │    │         ├── columns: column1:4(int) column2:5(int) column3:6(int) x:10(int) y:11(int) z:12(int)
            │    │         ├── left-join
-           │    │         │    ├── columns: column1:4(int) column2:5(int) column3:6(int) xyz_2.x:10(int) xyz_2.y:11(int) xyz_2.z:12(int)
+           │    │         │    ├── columns: column1:4(int) column2:5(int) column3:6(int) x:10(int) y:11(int) z:12(int)
            │    │         │    ├── project
            │    │         │    │    ├── columns: column1:4(int) column2:5(int) column3:6(int)
            │    │         │    │    └── select
-           │    │         │    │         ├── columns: column1:4(int) column2:5(int) column3:6(int) xyz_1.x:7(int) xyz_1.y:8(int) xyz_1.z:9(int)
+           │    │         │    │         ├── columns: column1:4(int) column2:5(int) column3:6(int) x:7(int) y:8(int) z:9(int)
            │    │         │    │         ├── left-join
-           │    │         │    │         │    ├── columns: column1:4(int) column2:5(int) column3:6(int) xyz_1.x:7(int) xyz_1.y:8(int) xyz_1.z:9(int)
+           │    │         │    │         │    ├── columns: column1:4(int) column2:5(int) column3:6(int) x:7(int) y:8(int) z:9(int)
            │    │         │    │         │    ├── values
            │    │         │    │         │    │    ├── columns: column1:4(int) column2:5(int) column3:6(int)
            │    │         │    │         │    │    ├── tuple [type=tuple{int, int, int}]
@@ -681,41 +681,41 @@ insert xyz
            │    │         │    │         │    │         ├── const: 4 [type=int]
            │    │         │    │         │    │         ├── const: 5 [type=int]
            │    │         │    │         │    │         └── const: 6 [type=int]
-           │    │         │    │         │    ├── scan xyz_1
-           │    │         │    │         │    │    └── columns: xyz_1.x:7(int!null) xyz_1.y:8(int) xyz_1.z:9(int)
+           │    │         │    │         │    ├── scan xyz
+           │    │         │    │         │    │    └── columns: x:7(int!null) y:8(int) z:9(int)
            │    │         │    │         │    └── filters
            │    │         │    │         │         └── eq [type=bool]
            │    │         │    │         │              ├── variable: column1 [type=int]
-           │    │         │    │         │              └── variable: xyz_1.x [type=int]
+           │    │         │    │         │              └── variable: x [type=int]
            │    │         │    │         └── filters
            │    │         │    │              └── is [type=bool]
-           │    │         │    │                   ├── variable: xyz_1.x [type=int]
+           │    │         │    │                   ├── variable: x [type=int]
            │    │         │    │                   └── null [type=unknown]
-           │    │         │    ├── scan xyz_2
-           │    │         │    │    └── columns: xyz_2.x:10(int!null) xyz_2.y:11(int) xyz_2.z:12(int)
+           │    │         │    ├── scan xyz
+           │    │         │    │    └── columns: x:10(int!null) y:11(int) z:12(int)
            │    │         │    └── filters
            │    │         │         ├── eq [type=bool]
            │    │         │         │    ├── variable: column2 [type=int]
-           │    │         │         │    └── variable: xyz_2.y [type=int]
+           │    │         │         │    └── variable: y [type=int]
            │    │         │         └── eq [type=bool]
            │    │         │              ├── variable: column3 [type=int]
-           │    │         │              └── variable: xyz_2.z [type=int]
+           │    │         │              └── variable: z [type=int]
            │    │         └── filters
            │    │              └── is [type=bool]
-           │    │                   ├── variable: xyz_2.x [type=int]
+           │    │                   ├── variable: x [type=int]
            │    │                   └── null [type=unknown]
-           │    ├── scan xyz_3
-           │    │    └── columns: xyz_3.x:13(int!null) xyz_3.y:14(int) xyz_3.z:15(int)
+           │    ├── scan xyz
+           │    │    └── columns: x:13(int!null) y:14(int) z:15(int)
            │    └── filters
            │         ├── eq [type=bool]
            │         │    ├── variable: column3 [type=int]
-           │         │    └── variable: xyz_3.z [type=int]
+           │         │    └── variable: z [type=int]
            │         └── eq [type=bool]
            │              ├── variable: column2 [type=int]
-           │              └── variable: xyz_3.y [type=int]
+           │              └── variable: y [type=int]
            └── filters
                 └── is [type=bool]
-                     ├── variable: xyz_3.x [type=int]
+                     ├── variable: x [type=int]
                      └── null [type=unknown]
 
 # Conflict columns are explicitly specified.
@@ -727,15 +727,15 @@ ON CONFLICT (y, z) DO NOTHING
 insert xyz
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  column1:4 => xyz.x:1
- │    ├──  column2:5 => xyz.y:2
- │    └──  column3:6 => xyz.z:3
+ │    ├──  column1:4 => x:1
+ │    ├──  column2:5 => y:2
+ │    └──  column3:6 => z:3
  └── project
       ├── columns: column1:4(int) column2:5(int) column3:6(int)
       └── select
-           ├── columns: column1:4(int) column2:5(int) column3:6(int) xyz_2.x:7(int) xyz_2.y:8(int) xyz_2.z:9(int)
+           ├── columns: column1:4(int) column2:5(int) column3:6(int) x:7(int) y:8(int) z:9(int)
            ├── left-join
-           │    ├── columns: column1:4(int) column2:5(int) column3:6(int) xyz_2.x:7(int) xyz_2.y:8(int) xyz_2.z:9(int)
+           │    ├── columns: column1:4(int) column2:5(int) column3:6(int) x:7(int) y:8(int) z:9(int)
            │    ├── values
            │    │    ├── columns: column1:4(int) column2:5(int) column3:6(int)
            │    │    ├── tuple [type=tuple{int, int, int}]
@@ -746,18 +746,18 @@ insert xyz
            │    │         ├── const: 4 [type=int]
            │    │         ├── const: 5 [type=int]
            │    │         └── const: 6 [type=int]
-           │    ├── scan xyz_2
-           │    │    └── columns: xyz_2.x:7(int!null) xyz_2.y:8(int) xyz_2.z:9(int)
+           │    ├── scan xyz
+           │    │    └── columns: x:7(int!null) y:8(int) z:9(int)
            │    └── filters
            │         ├── eq [type=bool]
            │         │    ├── variable: column2 [type=int]
-           │         │    └── variable: xyz_2.y [type=int]
+           │         │    └── variable: y [type=int]
            │         └── eq [type=bool]
            │              ├── variable: column3 [type=int]
-           │              └── variable: xyz_2.z [type=int]
+           │              └── variable: z [type=int]
            └── filters
                 └── is [type=bool]
-                     ├── variable: xyz_2.x [type=int]
+                     ├── variable: x [type=int]
                      └── null [type=unknown]
 
 # ------------------------------------------------------------------------------
@@ -1706,19 +1706,19 @@ INSERT INTO checks (a, b) VALUES (1, 2) ON CONFLICT (a) DO NOTHING
 insert checks
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  column1:5 => checks.a:1
- │    ├──  column2:6 => checks.b:2
- │    ├──  column7:7 => checks.c:3
- │    └──  column8:8 => checks.d:4
+ │    ├──  column1:5 => a:1
+ │    ├──  column2:6 => b:2
+ │    ├──  column7:7 => c:3
+ │    └──  column8:8 => d:4
  ├── check columns: check1:13(bool) check2:14(bool)
  └── project
       ├── columns: check1:13(bool) check2:14(bool) column1:5(int) column2:6(int) column7:7(int) column8:8(int)
       ├── project
       │    ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int)
       │    └── select
-      │         ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) checks_1.a:9(int) checks_1.b:10(int) checks_1.c:11(int) checks_1.d:12(int)
+      │         ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
       │         ├── left-join
-      │         │    ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) checks_1.a:9(int) checks_1.b:10(int) checks_1.c:11(int) checks_1.d:12(int)
+      │         │    ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
       │         │    ├── project
       │         │    │    ├── columns: column8:8(int) column1:5(int) column2:6(int) column7:7(int)
       │         │    │    ├── project
@@ -1735,15 +1735,15 @@ insert checks
       │         │    │         └── plus [type=int]
       │         │    │              ├── variable: column7 [type=int]
       │         │    │              └── const: 1 [type=int]
-      │         │    ├── scan checks_1
-      │         │    │    └── columns: checks_1.a:9(int!null) checks_1.b:10(int) checks_1.c:11(int) checks_1.d:12(int)
+      │         │    ├── scan checks
+      │         │    │    └── columns: a:9(int!null) b:10(int) c:11(int) d:12(int)
       │         │    └── filters
       │         │         └── eq [type=bool]
       │         │              ├── variable: column1 [type=int]
-      │         │              └── variable: checks_1.a [type=int]
+      │         │              └── variable: a [type=int]
       │         └── filters
       │              └── is [type=bool]
-      │                   ├── variable: checks_1.a [type=int]
+      │                   ├── variable: a [type=int]
       │                   └── null [type=unknown]
       └── projections
            ├── lt [type=bool]

--- a/pkg/sql/opt/table_meta.go
+++ b/pkg/sql/opt/table_meta.go
@@ -138,6 +138,12 @@ type TableMeta struct {
 
 	// anns annotates the table metadata with arbitrary data.
 	anns [maxTableAnnIDCount]interface{}
+
+	// constraints stores the list of validated check constraints on the table
+	// stored in the ScalarExpr form so they can possibly be used as filters
+	// in certain queries. See comment above GenerateConstrainedScans for more
+	// detail.
+	constraints []ScalarExpr
 }
 
 // clearAnnotations resets all the table annotations; used when copying a
@@ -173,6 +179,23 @@ func (tm *TableMeta) IndexKeyColumns(indexOrd int) ColSet {
 		indexCols.Add(int(tm.MetaID.ColumnID(ord)))
 	}
 	return indexCols
+}
+
+// ConstraintCount returns the number of validated check constraints that are
+// applied to the table.
+func (tm *TableMeta) ConstraintCount() int {
+	return len(tm.constraints)
+}
+
+// Constraint looks up the ith valid table constraint on the table where
+// i < ConstraintCount().
+func (tm *TableMeta) Constraint(i int) ScalarExpr {
+	return tm.constraints[i]
+}
+
+// AddConstraint adds a valid table constraint to the table's metadata.
+func (tm *TableMeta) AddConstraint(constraint ScalarExpr) {
+	tm.constraints = append(tm.constraints, constraint)
 }
 
 // TableAnnotation returns the given annotation that is associated with the

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -142,7 +142,10 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 	for _, def := range stmt.Defs {
 		switch def := def.(type) {
 		case *tree.CheckConstraintTableDef:
-			tab.Checks = append(tab.Checks, cat.CheckConstraint(tree.Serialize(def.Expr)))
+			tab.Checks = append(tab.Checks, cat.CheckConstraint{
+				Constraint: tree.Serialize(def.Expr),
+				Validated:  validatedCheckConstraint(def),
+			})
 		}
 	}
 
@@ -571,4 +574,8 @@ func extractDeleteOnlyIndex(def *tree.IndexTableDef) (name string, ok bool) {
 		return "", false
 	}
 	return strings.TrimSuffix(string(def.Name), ":delete-only"), true
+}
+
+func validatedCheckConstraint(def *tree.CheckConstraintTableDef) bool {
+	return !strings.HasSuffix(string(def.Name), ":unvalidated")
 }

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -121,6 +121,76 @@ func (c *CustomFuncs) GenerateIndexScans(grp memo.RelExpr, scanPrivate *memo.Sca
 //
 // ----------------------------------------------------------------------
 
+// checkConstraintFilters generates all filters that we can derive from the
+// check constraints. These are constraints that have been validated and are
+// non-nullable. We only use non-nullable check constraints because they
+// behave differently from filters on NULL. Check constraints are satisfied
+// when their expression evaluates to NULL, while filters are not.
+//
+// For example, the check constraint a > 1 is satisfied if a is NULL but the
+// equivalent filter a > 1 is not.
+//
+// These filters do not really filter any rows, they are rather facts or
+// guarantees about the data but treating them as filters may allow some
+// indexes to be constrained and used. Consider the following example:
+//
+// CREATE TABLE abc (
+// 	a INT PRIMARY KEY,
+// 	b INT NOT NULL,
+// 	c STRING NOT NULL,
+// 	CHECK (a < 10 AND a > 1),
+// 	CHECK (b < 10 AND b > 1),
+// 	CHECK (c in ('first', 'second')),
+// 	INDEX secondary (b, a),
+// 	INDEX tertiary (c, b, a))
+//
+// Now consider the query: SELECT a, b WHERE a > 5
+//
+// Notice that the filter provided previously wouldn't let the optimizer use
+// the secondary or tertiary indexes. However, given that we can use the
+// constraints on a, b and c, we can actually use the secondary and tertiary
+// indexes. In fact, for the above query we can do the following:
+//
+// select
+//  ├── columns: a:1(int!null) b:2(int!null)
+//  ├── scan abc@tertiary
+//  │		├── columns: a:1(int!null) b:2(int!null)
+//  │		└── constraint: /3/2/1: [/'first'/2/6 - /'first'/9/9] [/'second'/2/6 - /'second'/9/9]
+//  └── filters
+//        └── gt [type=bool]
+//            ├── variable: a [type=int]
+//            └── const: 5 [type=int]
+//
+// Similarly, the secondary index could also be used. All such index scans
+// will be added to the memo group.
+func (c *CustomFuncs) checkConstraintFilters(tabID opt.TableID) memo.FiltersExpr {
+	md := c.e.mem.Metadata()
+	tab := md.Table(tabID)
+	tabMeta := md.TableMeta(tabID)
+
+	// Maintain a ColSet of non-nullable columns.
+	var notNullCols opt.ColSet
+	for i := 0; i < tab.ColumnCount(); i++ {
+		if !tab.Column(i).IsNullable() {
+			notNullCols.Add(int(tabID.ColumnID(i)))
+		}
+	}
+
+	numCheckConstraints := tabMeta.ConstraintCount()
+	checkFilters := make(memo.FiltersExpr, 0, numCheckConstraints)
+	for i := 0; i < numCheckConstraints; i++ {
+		checkConstraint := tabMeta.Constraint(i)
+
+		// Check constraints that are guaranteed to not evaluate to NULL
+		// are the only ones converted into filters.
+		if memo.ExprIsNeverNull(checkConstraint, notNullCols) {
+			checkFilters = append(checkFilters, memo.FiltersItem{Condition: checkConstraint})
+		}
+	}
+
+	return checkFilters
+}
+
 // GenerateConstrainedScans enumerates all secondary indexes on the Scan
 // operator's table and tries to push the given Select filter into new
 // constrained Scan operators using those indexes. Since this only needs to be
@@ -179,27 +249,49 @@ func (c *CustomFuncs) GenerateIndexScans(grp memo.RelExpr, scanPrivate *memo.Sca
 //        $outerFilter
 //      )
 //
+// GenerateConstrainedScans will further constrain the enumerated index scans
+// by trying to use the check constraints that apply to the table being
+// scanned.
 func (c *CustomFuncs) GenerateConstrainedScans(
-	grp memo.RelExpr, scanPrivate *memo.ScanPrivate, filters memo.FiltersExpr,
+	grp memo.RelExpr, scanPrivate *memo.ScanPrivate, explicitFilters memo.FiltersExpr,
 ) {
 	var sb indexScanBuilder
 	sb.init(c, scanPrivate.Table)
+
+	// Generate appropriate filters from constraints.
+	checkFilters := c.checkConstraintFilters(scanPrivate.Table)
+
+	// Consider the checkFilters as well to constrain each of the indexes.
+	filters := append(explicitFilters, checkFilters...)
 
 	// Iterate over all indexes.
 	var iter scanIndexIter
 	iter.init(c.e.mem, scanPrivate)
 	for iter.next() {
 		// Check whether the filter can constrain the index.
-		constraint, remaining, ok := c.tryConstrainIndex(
+		constraintFilters, remainingFilters, ok := c.tryConstrainIndex(
 			filters, scanPrivate.Table, iter.indexOrdinal, false /* isInverted */)
 		if !ok {
 			continue
 		}
 
+		// If a check constraint filter wasn't able to constrain the index, it
+		// should not be used anymore for this group expression.
+		// TODO(ridwanmsharif): Does it ever make sense for us to continue
+		// using any constraint filter that wasn't able to constrain a scan?
+		// Maybe once we have more information about data distribution, we may
+		// use it to further constrain an index scan. We should revisit this
+		// once we have index skip scans.  A constraint that may not constrain
+		// an index scan may still allow the index to be used more effectively
+		// if an index skip scan is possible.
+		if len(checkFilters) != 0 {
+			remainingFilters.RetainCommonFilters(explicitFilters)
+		}
+
 		// Construct new constrained ScanPrivate.
 		newScanPrivate := *scanPrivate
 		newScanPrivate.Index = iter.indexOrdinal
-		newScanPrivate.Constraint = constraint
+		newScanPrivate.Constraint = constraintFilters
 
 		// If the alternate index includes the set of needed columns, then construct
 		// a new Scan operator using that index.
@@ -209,7 +301,8 @@ func (c *CustomFuncs) GenerateConstrainedScans(
 			// If there are remaining filters, then the constrained Scan operator
 			// will be created in a new group, and a Select operator will be added
 			// to the same group as the original operator.
-			sb.addSelect(remaining)
+			sb.addSelect(remainingFilters)
+
 			sb.build(grp)
 			continue
 		}
@@ -228,9 +321,9 @@ func (c *CustomFuncs) GenerateConstrainedScans(
 
 		// If remaining filter exists, split it into one part that can be pushed
 		// below the IndexJoin, and one part that needs to stay above.
-		remaining = sb.addSelectAfterSplit(remaining, newScanPrivate.Cols)
+		remainingFilters = sb.addSelectAfterSplit(remainingFilters, newScanPrivate.Cols)
 		sb.addIndexJoin(scanPrivate.Cols)
-		sb.addSelect(remaining)
+		sb.addSelect(remainingFilters)
 
 		sb.build(grp)
 	}

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -554,3 +554,246 @@ select
  │    └── key: (1)
  └── filters
       └── s COLLATE en = 'hello' COLLATE en [type=bool, outer=(1)]
+
+# Realistic example where using constraints as filters help.
+exec-ddl
+CREATE TABLE "orders" (
+  region STRING NOT NULL,
+  id INT NOT NULL,
+  total DECIMAL NOT NULL,
+  created_at TIMESTAMP NOT NULL,
+  PRIMARY KEY (region, id),
+  UNIQUE INDEX orders_by_created_at (region, created_at, id) STORING (total),
+  CHECK (region IN ('us-east1', 'us-west1', 'europe-west2'))
+)
+----
+TABLE orders
+ ├── region string not null
+ ├── id int not null
+ ├── total decimal not null
+ ├── created_at timestamp not null
+ ├── INDEX primary
+ │    ├── region string not null
+ │    └── id int not null
+ ├── INDEX orders_by_created_at
+ │    ├── region string not null
+ │    ├── created_at timestamp not null
+ │    ├── id int not null
+ │    └── total decimal not null (storing)
+ └── CHECK (region IN ('us-east1', 'us-west1', 'europe-west2'))
+
+exec-ddl
+ALTER TABLE "orders" INJECT STATISTICS '[
+  {
+    "columns": ["region"],
+    "distinct_count": 3,
+    "null_count": 0,
+    "row_count": 100,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["id"],
+    "distinct_count": 100,
+    "null_count": 0,
+    "row_count": 100,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["total"],
+    "distinct_count": 100,
+    "null_count": 0,
+    "row_count": 100,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["created_at"],
+    "distinct_count": 50,
+    "null_count": 0,
+    "row_count": 100,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  }
+]'
+----
+
+opt
+SELECT sum(total) FROM "orders" WHERE created_at >= '2019-05-04' AND created_at < '2019-05-05'
+----
+scalar-group-by
+ ├── columns: sum:5(decimal)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(5)
+ ├── scan orders@orders_by_created_at
+ │    ├── columns: total:3(decimal!null) created_at:4(timestamp!null)
+ │    └── constraint: /1/4/2: [/'europe-west2'/'2019-05-04 00:00:00+00:00' - /'europe-west2'/'2019-05-04 23:59:59.999999+00:00'] [/'us-east1'/'2019-05-04 00:00:00+00:00' - /'us-east1'/'2019-05-04 23:59:59.999999+00:00'] [/'us-west1'/'2019-05-04 00:00:00+00:00' - /'us-west1'/'2019-05-04 23:59:59.999999+00:00']
+ └── aggregations
+      └── sum [type=decimal, outer=(3)]
+           └── variable: total [type=decimal]
+
+exec-ddl
+CREATE TABLE xyz (
+  x INT PRIMARY KEY,
+  y INT NOT NULL,
+  z STRING NOT NULL,
+  CHECK (x < 10 AND x > 1),
+  CHECK (y < 10 AND y > 1),
+  CHECK (z in ('first', 'second')),
+  INDEX secondary (y, x),
+  INDEX tertiary (z, y, x))
+----
+TABLE xyz
+ ├── x int not null
+ ├── y int not null
+ ├── z string not null
+ ├── INDEX primary
+ │    └── x int not null
+ ├── INDEX secondary
+ │    ├── y int not null
+ │    └── x int not null
+ ├── INDEX tertiary
+ │    ├── z string not null
+ │    ├── y int not null
+ │    └── x int not null
+ ├── CHECK ((x < 10) AND (x > 1))
+ ├── CHECK ((y < 10) AND (y > 1))
+ └── CHECK (z IN ('first', 'second'))
+
+opt
+SELECT x, y  FROM xyz WHERE x > 5
+----
+select
+ ├── columns: x:1(int!null) y:2(int!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── scan xyz@tertiary
+ │    ├── columns: x:1(int!null) y:2(int!null)
+ │    ├── constraint: /3/2/1: [/'first'/2/6 - /'first'/9/9] [/'second'/2/6 - /'second'/9/9]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ └── filters
+      └── x > 5 [type=bool, outer=(1), constraints=(/1: [/6 - ]; tight)]
+
+# TODO(ridwanmsharif): Confirm if this makes sense. I would've expected that the primary index
+#  would be used here. But it isn't the plan being picked. Curious.
+opt
+SELECT * FROM xyz WHERE x > 5
+----
+select
+ ├── columns: x:1(int!null) y:2(int!null) z:3(string!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── scan xyz@tertiary
+ │    ├── columns: x:1(int!null) y:2(int!null) z:3(string!null)
+ │    ├── constraint: /3/2/1: [/'first'/2/6 - /'first'/9/9] [/'second'/2/6 - /'second'/9/9]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── x > 5 [type=bool, outer=(1), constraints=(/1: [/6 - ]; tight)]
+
+# Check constraint used only for the non nullable column. Constraints on x are ignored.
+exec-ddl
+CREATE TABLE xy (
+  x INT,
+  y INT NOT NULL,
+  CHECK (x < 10 AND x > 1),
+  CHECK (y < 10 AND y > 1),
+  INDEX secondary (y, x))
+----
+TABLE xy
+ ├── x int
+ ├── y int not null
+ ├── rowid int not null (hidden)
+ ├── INDEX primary
+ │    └── rowid int not null (hidden)
+ ├── INDEX secondary
+ │    ├── y int not null
+ │    ├── x int
+ │    └── rowid int not null (hidden)
+ ├── CHECK ((x < 10) AND (x > 1))
+ └── CHECK ((y < 10) AND (y > 1))
+
+opt
+SELECT x, y FROM xy WHERE x > 5
+----
+select
+ ├── columns: x:1(int!null) y:2(int!null)
+ ├── scan xy@secondary
+ │    ├── columns: x:1(int) y:2(int!null)
+ │    └── constraint: /2/1/3: [/2/6 - /9]
+ └── filters
+      └── x > 5 [type=bool, outer=(1), constraints=(/1: [/6 - ]; tight)]
+
+# Check constraints that can evaluate to NULL are ignored.
+exec-ddl
+CREATE TABLE null_constraint (
+  y INT NOT NULL,
+  CHECK (y IN (1, 2, NULL)),
+  INDEX index_1 (y))
+----
+TABLE null_constraint
+ ├── y int not null
+ ├── rowid int not null (hidden)
+ ├── INDEX primary
+ │    └── rowid int not null (hidden)
+ ├── INDEX index_1
+ │    ├── y int not null
+ │    └── rowid int not null (hidden)
+ └── CHECK (y IN (1, 2, NULL))
+
+opt
+SELECT y FROM null_constraint WHERE y > 0
+----
+scan null_constraint@index_1
+ ├── columns: y:1(int!null)
+ └── constraint: /1/2: [/1 - ]
+
+exec-ddl
+CREATE TABLE null_constraint_2 (
+  y INT NOT NULL,
+  CHECK ((y IN (1, 2, NULL)) AND (y > 10)),
+  CHECK (y < 15),
+  INDEX index_1 (y))
+----
+TABLE null_constraint_2
+ ├── y int not null
+ ├── rowid int not null (hidden)
+ ├── INDEX primary
+ │    └── rowid int not null (hidden)
+ ├── INDEX index_1
+ │    ├── y int not null
+ │    └── rowid int not null (hidden)
+ ├── CHECK ((y IN (1, 2, NULL)) AND (y > 10))
+ └── CHECK (y < 15)
+
+opt
+SELECT y FROM null_constraint_2 WHERE y > 0
+----
+scan null_constraint_2@index_1
+ ├── columns: y:1(int!null)
+ └── constraint: /1/2: [/1 - /14]
+
+# Unvalidated constraints are ignored.
+exec-ddl
+CREATE TABLE check_constraint_validity (
+ a int NOT NULL,
+ INDEX secondary (a),
+ CONSTRAINT "check:unvalidated" CHECK (a < 10),
+ CONSTRAINT "check:validated" CHECK (a < 20))
+----
+TABLE check_constraint_validity
+ ├── a int not null
+ ├── rowid int not null (hidden)
+ ├── INDEX primary
+ │    └── rowid int not null (hidden)
+ ├── INDEX secondary
+ │    ├── a int not null
+ │    └── rowid int not null (hidden)
+ ├── CHECK (a < 10)
+ └── CHECK (a < 20)
+
+opt
+SELECT * FROM check_constraint_validity WHERE a > 6
+----
+scan check_constraint_validity@secondary
+ ├── columns: a:1(int!null)
+ └── constraint: /1/2: [/7 - /19]

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -797,3 +797,72 @@ SELECT * FROM check_constraint_validity WHERE a > 6
 scan check_constraint_validity@secondary
  ├── columns: a:1(int!null)
  └── constraint: /1/2: [/7 - /19]
+
+exec-ddl
+CREATE TABLE check_test.alias_test (
+  a INT PRIMARY KEY,
+  CHECK (a > 0),
+  CHECK (alias_test.a > 2),
+  CHECK (check_test.alias_test.a > 4)
+)
+----
+TABLE alias_test
+ ├── a int not null
+ ├── INDEX primary
+ │    └── a int not null
+ ├── CHECK (a > 0)
+ ├── CHECK (alias_test.a > 2)
+ └── CHECK (check_test.alias_test.a > 4)
+
+opt
+SELECT * FROM check_test.alias_test WHERE a < 10
+----
+scan check_test.public.alias_test
+ ├── columns: a:1(int!null)
+ ├── constraint: /1: [/5 - /9]
+ └── key: (1)
+
+opt
+INSERT INTO check_test.alias_test VALUES (6) ON CONFLICT DO NOTHING
+----
+insert check_test.public.alias_test
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    └──  column1:2 => a:1
+ ├── check columns: check1:4(bool) check2:5(bool) check3:6(bool)
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ └── project
+      ├── columns: check1:4(bool) check2:5(bool) check3:6(bool) column1:2(int)
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(2,4-6)
+      ├── select
+      │    ├── columns: column1:2(int) a:3(int)
+      │    ├── cardinality: [0 - 1]
+      │    ├── key: ()
+      │    ├── fd: ()-->(2,3)
+      │    ├── left-join
+      │    │    ├── columns: column1:2(int) a:3(int)
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(2,3)
+      │    │    ├── values
+      │    │    │    ├── columns: column1:2(int)
+      │    │    │    ├── cardinality: [1 - 1]
+      │    │    │    ├── key: ()
+      │    │    │    ├── fd: ()-->(2)
+      │    │    │    └── (6,) [type=tuple{int}]
+      │    │    ├── scan check_test.public.alias_test
+      │    │    │    ├── columns: a:3(int!null)
+      │    │    │    ├── constraint: /3: [/6 - /6]
+      │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    ├── key: ()
+      │    │    │    └── fd: ()-->(3)
+      │    │    └── filters (true)
+      │    └── filters
+      │         └── a IS NULL [type=bool, outer=(3), constraints=(/3: [/NULL - /NULL]; tight), fd=()-->(3)]
+      └── projections
+           ├── column1 > 0 [type=bool, outer=(2)]
+           ├── column1 > 2 [type=bool, outer=(2)]
+           └── column1 > 4 [type=bool, outer=(2)]

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -791,7 +791,10 @@ func (ot *optTable) CheckCount() int {
 // Check is part of the cat.Table interface.
 func (ot *optTable) Check(i int) cat.CheckConstraint {
 	check := ot.desc.ActiveChecks()[i]
-	return cat.CheckConstraint(check.Expr)
+	return cat.CheckConstraint{
+		Constraint: check.Expr,
+		Validated:  check.Validity == sqlbase.ConstraintValidity_Validated,
+	}
 }
 
 // FamilyCount is part of the cat.Table interface.


### PR DESCRIPTION
Closes #37312.

This change converts some of the constraints that are validated on
a table, into filters, so that some index scans can be used and/or
further constrained. The only constrains that can be converted into
filters for this are ones that:
  - Have been validated.
  - Don't constrain nullable columns (filters and constrains behave
  differently on nullable columns).
  - Are comparison expressions.

Release note: None