### PR TITLE
workloadccl: fix multi-table fixture generation

### DIFF
--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -265,6 +265,7 @@ func MakeFixture(
 	g := ctxgroup.WithContext(ctx)
 
 	for _, t := range gen.Tables() {
+		t := t
 		g.Go(func() error {
 			q := fmt.Sprintf(`BACKUP "%s"."%s" TO $1`, dbName, t.Name)
 			output := config.objectPathToURI(filepath.Join(fixtureFolder, t.Name))


### PR DESCRIPTION
This was broken in f4a0350. `workload fixtures make tpcc` was failing with:

~Error: pq: gs://cockroach-fixtures/workload/tpcc/version=2.1.0,fks=true,interleaved=false,seed=1,warehouses=1/order_line already contains a BACKUP file~


I'm surprised how long it took us to catch this. Are there tests that should have caught this? Perhaps the issue is that most nightly tests are overwriting existing fixtures.

EDIT: `workload fixtures make tpcc` was failing with the following error, which better explains why this wasn't caught by existing tests (due to the overwriting mentioned above):
```
Error: fixture table not found: workload/tpcc/version=2.1.0,fks=true,interleaved=false,seed=1,warehouses=1/warehouse
```

Release note: None