### PR TITLE
internal/client: store ResumeSpan as pointer on Result

### DIFF
--- a/pkg/internal/client/batch.go
+++ b/pkg/internal/client/batch.go
@@ -270,7 +270,7 @@ func (b *Batch) fillResults(ctx context.Context) {
 			}
 			// Fill up the resume span.
 			if result.Err == nil && reply != nil && reply.Header().ResumeSpan != nil {
-				result.ResumeSpan = *reply.Header().ResumeSpan
+				result.ResumeSpan = reply.Header().ResumeSpan
 				result.ResumeReason = reply.Header().ResumeReason
 				// The ResumeReason might be missing when talking to a 1.1 node; assume
 				// it's the key limit (which was the only reason why 1.1 would return a

--- a/pkg/internal/client/db.go
+++ b/pkg/internal/client/db.go
@@ -135,9 +135,9 @@ type Result struct {
 	// sequence of operations. It is returned whenever an operation over a
 	// span of keys is bounded and the operation returns before completely
 	// running over the span. It allows the operation to be called again with
-	// a new shorter span of keys. An empty span is returned when the
-	// operation has successfully completed running through the span.
-	ResumeSpan roachpb.Span
+	// a new shorter span of keys. A nil span is set when the operation has
+	// successfully completed running through the span.
+	ResumeSpan *roachpb.Span
 	// When ResumeSpan is populated, this specifies the reason why the operation
 	// wasn't completed and needs to be resumed.
 	ResumeReason roachpb.ResponseHeader_ResumeReason
@@ -147,6 +147,15 @@ type Result struct {
 	// This is only populated if Err == nil and if ReturnRangeInfo has been set on
 	// the request.
 	RangeInfos []roachpb.RangeInfo
+}
+
+// ResumeSpanAsValue returns the resume span as a value if one is set,
+// or an empty span if one is not set.
+func (r *Result) ResumeSpanAsValue() roachpb.Span {
+	if r.ResumeSpan == nil {
+		return roachpb.Span{}
+	}
+	return *r.ResumeSpan
 }
 
 func (r Result) String() string {

--- a/pkg/sql/tablewriter_delete.go
+++ b/pkg/sql/tablewriter_delete.go
@@ -142,7 +142,7 @@ func (td *tableDeleter) deleteAllRowsFast(
 	if l := len(td.b.Results); l != 1 {
 		panic(fmt.Sprintf("%d results returned", l))
 	}
-	return td.b.Results[0].ResumeSpan, nil
+	return td.b.Results[0].ResumeSpanAsValue(), nil
 }
 
 func (td *tableDeleter) deleteAllRowsScan(
@@ -235,7 +235,7 @@ func (td *tableDeleter) deleteIndexFast(
 	if l := len(td.b.Results); l != 1 {
 		panic(fmt.Sprintf("%d results returned, expected 1", l))
 	}
-	return td.b.Results[0].ResumeSpan, nil
+	return td.b.Results[0].ResumeSpanAsValue(), nil
 }
 
 func (td *tableDeleter) clearIndex(ctx context.Context, idx *sqlbase.IndexDescriptor) error {

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -699,8 +699,8 @@ func upgradeDescsWithFn(
 	// use multiple transactions to prevent blocking reads on the
 	// table descriptors while running this upgrade process.
 	startKey := sqlbase.MakeAllDescsMetadataKey()
-	span := roachpb.Span{Key: startKey, EndKey: startKey.PrefixEnd()}
-	for resumeSpan := (roachpb.Span{}); span.Key != nil; span = resumeSpan {
+	span := &roachpb.Span{Key: startKey, EndKey: startKey.PrefixEnd()}
+	for span != nil {
 		// It's safe to use multiple transactions here because it is assumed
 		// that a new table created will be created upgraded.
 		if err := r.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
@@ -714,7 +714,7 @@ func upgradeDescsWithFn(
 			result := b.Results[0]
 			kvs := result.Rows
 			// Store away the span for the next batch.
-			resumeSpan = result.ResumeSpan
+			span = result.ResumeSpan
 
 			var idVersions []sql.IDVersion
 			var now hlc.Timestamp

--- a/pkg/ts/rollup.go
+++ b/pkg/ts/rollup.go
@@ -284,7 +284,7 @@ func (db *DB) queryAndComputeRollupsForSpan(
 		}
 		rollupDataMap[source] = rollup
 	}
-	return b.Results[0].ResumeSpan, nil
+	return b.Results[0].ResumeSpanAsValue(), nil
 }
 
 type parallelVarianceArgs struct {

--- a/pkg/ts/server.go
+++ b/pkg/ts/server.go
@@ -316,12 +316,12 @@ func (s *Server) Query(
 // and will thus not be totally organized by series.
 func (s *Server) Dump(req *tspb.DumpRequest, stream tspb.TimeSeries_DumpServer) error {
 	ctx := stream.Context()
-	span := roachpb.Span{
+	span := &roachpb.Span{
 		Key:    roachpb.Key(firstTSRKey),
 		EndKey: roachpb.Key(lastTSRKey),
 	}
 
-	for span.Valid() {
+	for span != nil {
 		b := &client.Batch{}
 		b.Header.MaxSpanRequestKeys = dumpBatchSize
 		b.Scan(span.Key, span.EndKey)


### PR DESCRIPTION
A span is 56 bytes, so storing one in each Result was causing significant
bloat (up to 160 bytes). This was also causing bloat in the Batch struct,
which embeds 8 of these Result structs.

This commit reduces the size of the Result struct down to a more manageable
112 bytes. It does so without any new allocations, because resume spans are
already passed around by pointer in most places.

```
name                           old time/op    new time/op    delta
KV/Delete/Native/rows=1-4         129µs ± 6%     126µs ± 1%   -2.53%  (p=0.063 n=10+10)
KV/Delete/Native/rows=10-4        201µs ± 2%     201µs ± 2%     ~     (p=0.971 n=10+10)
KV/Delete/Native/rows=100-4       811µs ± 2%     794µs ± 1%   -2.07%  (p=0.000 n=9+8)
KV/Delete/Native/rows=1000-4     6.87ms ± 1%    6.73ms ± 2%   -2.03%  (p=0.000 n=9+10)
KV/Delete/Native/rows=10000-4    74.7ms ± 2%    72.4ms ± 2%   -3.08%  (p=0.000 n=9+9)

name                           old alloc/op   new alloc/op   delta
KV/Delete/Native/rows=1-4        12.6kB ± 0%    12.2kB ± 0%   -3.07%  (p=0.000 n=10+9)
KV/Delete/Native/rows=10-4       23.5kB ± 0%    22.2kB ± 0%   -5.45%  (p=0.000 n=9+10)
KV/Delete/Native/rows=100-4       143kB ± 0%     132kB ± 0%   -7.46%  (p=0.000 n=10+10)
KV/Delete/Native/rows=1000-4     1.27MB ± 0%    1.14MB ± 0%  -10.04%  (p=0.000 n=10+9)
KV/Delete/Native/rows=10000-4    19.2MB ± 1%    16.2MB ± 1%  -15.70%  (p=0.000 n=10+10)

name                           old allocs/op  new allocs/op  delta
KV/Delete/Native/rows=1-4           122 ± 0%       122 ± 0%     ~     (all equal)
KV/Delete/Native/rows=10-4          202 ± 0%       202 ± 0%     ~     (all equal)
KV/Delete/Native/rows=100-4         941 ± 0%       941 ± 0%     ~     (p=0.294 n=8+10)
KV/Delete/Native/rows=1000-4      8.24k ± 0%     8.24k ± 0%     ~     (p=0.985 n=10+9)
KV/Delete/Native/rows=10000-4     81.1k ± 0%     81.2k ± 0%     ~     (p=0.811 n=10+10)
```

Release note: None