### PR TITLE
storage: fix and test a bogus source of replica divergence errors

### DIFF
--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -95,7 +95,7 @@ func registerVersion(r *registry) {
 				// Make sure everyone is still running.
 				for i := 1; i <= nodes; i++ {
 					t.WorkerStatus("checking ", i)
-					db := c.Conn(ctx, 1)
+					db := c.Conn(ctx, i)
 					defer db.Close()
 					rows, err := db.Query(`SHOW DATABASES`)
 					if err != nil {

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/binfetcher"
 	_ "github.com/lib/pq"
+	"github.com/pkg/errors"
 )
 
 func registerVersion(r *registry) {
@@ -103,6 +104,10 @@ func registerVersion(r *registry) {
 					}
 					if err := rows.Close(); err != nil {
 						return err
+					}
+					// Regression test for #37425.
+					if err := c.CheckReplicaDivergenceOnDB(ctx, db); err != nil {
+						return errors.Wrapf(err, "node %d", i)
 					}
 				}
 				return nil

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -962,8 +962,10 @@ func (c *checkConsistencyGenerator) Start() error {
 			Key:    c.from,
 			EndKey: c.to,
 		},
-		Mode:     c.mode,
-		WithDiff: true,
+		Mode: c.mode,
+		// No meaningful diff can be created if we're checking the stats only,
+		// so request one only if a full check is run.
+		WithDiff: c.mode == roachpb.ChecksumMode_CHECK_FULL,
 	})
 	if err := c.db.Run(c.ctx, &b); err != nil {
 		return err

--- a/pkg/storage/batcheval/cmd_compute_checksum.go
+++ b/pkg/storage/batcheval/cmd_compute_checksum.go
@@ -42,7 +42,7 @@ func declareKeysComputeChecksum(
 // Version numbers for Replica checksum computation. Requests silently no-op
 // unless the versions are compatible.
 const (
-	ReplicaChecksumVersion    = 3
+	ReplicaChecksumVersion    = 4
 	ReplicaChecksumGCInterval = time.Hour
 )
 


### PR DESCRIPTION
An incompatibility in the consistency checks was introduced between v2.1 and v19.1.
See individual commit messages and #37425 for details.

Release note (bug fix): Fixed a potential source of (faux) replica
inconsistencies that can be reported while running a mixed v19.1 / v2.1
cluster. This error (in that situation only) is benign and can be
resolved by upgrading to the latest v19.1 patch release. Every time this
error occurs a "checkpoint" is created which will occupy a large amount
of disk space and which needs to be removed manually (see <store
directory>/auxiliary/checkpoints).

Release note (bug fix): Fixed a case in which `./cockroach quit` would
return success even though the server process was still running in a
severely degraded state.