### PR TITLE
roachtest: skip kv/gracefuldraining

### DIFF
--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -274,6 +274,7 @@ func registerKVQuiescenceDead(r *registry) {
 
 func registerKVGracefulDraining(r *registry) {
 	r.Add(testSpec{
+		Skip:    "https://github.com/cockroachdb/cockroach/issues/33501",
 		Name:    "kv/gracefuldraining/nodes=3",
 		Cluster: makeClusterSpec(4),
 		Run: func(ctx context.Context, t *test, c *cluster) {


### PR DESCRIPTION
I should've done this a long time ago, it's been flaky for five months
and failed approximately 120 times (i.e. most of the time).

See https://github.com/cockroachdb/cockroach/issues/33501#issuecomment-494386738

Release note: None