### PR TITLE
backport-19.1: storage: de-flake TestLeaseNotUsedAfterRestart

### DIFF
--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -1079,8 +1079,6 @@ func TestLeaseMetricsOnSplitAndTransfer(t *testing.T) {
 func TestLeaseNotUsedAfterRestart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/34111")
-
 	ctx := context.Background()
 
 	sc := storage.TestStoreConfig(nil)
@@ -1103,17 +1101,14 @@ func TestLeaseNotUsedAfterRestart(t *testing.T) {
 	defer mtc.Stop()
 	mtc.Start(t, 1)
 
+	key := []byte("a")
 	// Send a read, to acquire a lease.
-	getArgs := getArgs([]byte("a"))
+	getArgs := getArgs(key)
 	if _, err := client.SendWrapped(ctx, mtc.stores[0].TestSender(), getArgs); err != nil {
 		t.Fatal(err)
 	}
 
-	preRepl1, err := mtc.stores[0].GetReplica(1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	preRestartLease, _ := preRepl1.GetLease()
+	preRestartLease, _ := mtc.stores[0].LookupReplica(key).GetLease()
 
 	mtc.manualClock.Increment(1E9)
 
@@ -1144,11 +1139,7 @@ func TestLeaseNotUsedAfterRestart(t *testing.T) {
 		t.Fatalf("read did not acquire a new lease")
 	}
 
-	postRepl1, err := mtc.stores[0].GetReplica(1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	postRestartLease, _ := postRepl1.GetLease()
+	postRestartLease, _ := mtc.stores[0].LookupReplica(key).GetLease()
 
 	// Verify that not only is a new lease requested, it also gets a new sequence
 	// number. This makes sure that previously proposed commands actually fail at


### PR DESCRIPTION
Backport 1/1 commits from #37353.

/cc @cockroachdb/release

---

The test hard-coded that "a" is contained in range one, but this hasn't
been true for a while. Consequently the test got bogus results and was
flaky.

Before, failed immediately under

```
make roachprod-stress CLUSTER=tobias-stss TESTS=TestLeaseNotUsedAfterRestart PKG=github.com/cockroachdb/cockroach/pkg/storage TESTTIMEOUT=5m STRESSFLAGS='-timeout 10m' 2>&1 | tee /tmp/stress.log
```

and make it through a few minutes so far after, so pretty sure that was it.

Fixes #34111.

Release note: None
