### PR TITLE
roachtest: revert not disabling merge queue

### DIFF
--- a/pkg/cmd/roachtest/election.go
+++ b/pkg/cmd/roachtest/election.go
@@ -42,6 +42,8 @@ func registerElectionAfterRestart(r *registry) {
 			c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "
         CREATE DATABASE IF NOT EXISTS test;
         CREATE TABLE test.kv (k INT PRIMARY KEY, v INT);
+        -- Prevent the merge queue from immediately discarding our splits.
+        SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
         ALTER TABLE test.kv SPLIT AT SELECT generate_series(0, 10000, 100)"`)
 
 			start := timeutil.Now()

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -541,8 +541,24 @@ func Setup(
 	return size, nil
 }
 
+func maybeDisableMergeQueue(db *gosql.DB) error {
+	var ok bool
+	if err := db.QueryRow(
+		`SELECT count(*) > 0 FROM [ SHOW ALL CLUSTER SETTINGS ] AS _ (v) WHERE v = 'kv.range_merge.queue_enabled'`,
+	).Scan(&ok); err != nil || !ok {
+		return err
+	}
+	_, err := db.Exec("SET CLUSTER SETTING kv.range_merge.queue_enabled = false")
+	return err
+}
+
 // Split creates the range splits defined by the given table.
 func Split(ctx context.Context, db *gosql.DB, table Table, concurrency int) error {
+	// Prevent the merge queue from immediately discarding our splits.
+	if err := maybeDisableMergeQueue(db); err != nil {
+		return err
+	}
+
 	if table.Splits.NumBatches <= 0 {
 		return nil
 	}


### PR DESCRIPTION
Roachtests need to remain compatible with 19.1 and having the merge
queue enabled when performing a split will throw an error.

Release note: None