### PR TITLE
release-19.1: storage: Fix a race related to QueryWaiting metric

### DIFF
--- a/pkg/storage/txnwait/txnqueue.go
+++ b/pkg/storage/txnwait/txnqueue.go
@@ -641,7 +641,7 @@ func (q *Queue) MaybeWaitForQuery(
 	if !req.WaitForUpdate {
 		return nil
 	}
-
+	metrics := q.store.GetTxnWaitMetrics()
 	q.mu.Lock()
 	// If the txn wait queue is not enabled or if the request is not
 	// contained within the replica, do nothing. The request can fall
@@ -681,10 +681,9 @@ func (q *Queue) MaybeWaitForQuery(
 		}
 		q.mu.queries[req.Txn.ID] = query
 	}
+	metrics.QueryWaiting.Inc(1)
 	q.mu.Unlock()
 
-	metrics := q.store.GetTxnWaitMetrics()
-	metrics.QueryWaiting.Inc(1)
 	tBegin := timeutil.Now()
 	defer func() { metrics.QueryWaitTime.RecordValue(timeutil.Since(tBegin).Nanoseconds()) }()
 


### PR DESCRIPTION
Backport 1/1 commits from #37510.

/cc @cockroachdb/release

---

fixes: #37415

The failure in #37415 is due to a race condition that exists currently. This isn't
a bug in the code as there is no assumption that the metric decrease/increases
will happen in some precisely defined order. The fix moves the metric increase
inside the mutex lock section and guarantees that the test will work. There
may be other tests (current and future) that may have the same problem and
may just need to be changed to work around the lack of guaranteed ordering.
The #37415 is easy to reproduce by adding an 1ms sleep before the metric increase
line.

Release note: None
