### PR TITLE
workloadcccl: fix two regressions in fixtures make/load

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -26,6 +26,7 @@ const (
 	directIngestion  = true
 	oneFilePerNode   = 1
 	noInjectStats    = false
+	noSkipPostLoad   = false
 	skipCSVRoundtrip = ``
 )
 
@@ -84,7 +85,8 @@ func TestAllRegisteredImportFixture(t *testing.T) {
 			sqlutils.MakeSQLRunner(db).Exec(t, `CREATE DATABASE d`)
 
 			if _, err := workloadccl.ImportFixture(
-				ctx, db, gen, `d`, directIngestion, oneFilePerNode, noInjectStats, skipCSVRoundtrip,
+				ctx, db, gen, `d`, directIngestion, oneFilePerNode, noInjectStats, noSkipPostLoad,
+				skipCSVRoundtrip,
 			); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/ccl/workloadccl/bench_test.go
+++ b/pkg/ccl/workloadccl/bench_test.go
@@ -33,9 +33,9 @@ func benchmarkImportFixture(b *testing.B, gen workload.Generator) {
 
 		b.StartTimer()
 		const filesPerNode = 1
+		const directIngest, noInjectStats, skipPostLoad, csvServer = true, false, true, ``
 		importBytes, err := ImportFixture(
-			ctx, db, gen, `d`, true /* directIngestion */, filesPerNode, false, /* injectStats */
-			``, /* csvServer */
+			ctx, db, gen, `d`, directIngest, filesPerNode, noInjectStats, skipPostLoad, csvServer,
 		)
 		require.NoError(b, err)
 		bytes += importBytes

--- a/pkg/ccl/workloadccl/cliccl/fixtures.go
+++ b/pkg/ccl/workloadccl/cliccl/fixtures.go
@@ -333,9 +333,10 @@ func fixturesImport(gen workload.Generator, urls []string, dbName string) error 
 	directIngestion := *fixturesImportDirectIngestionTable
 	filesPerNode := *fixturesImportFilesPerNode
 	injectStats := *fixturesImportInjectStats
+	noSkipPostLoad := false
 	csvServer := *fixturesMakeImportCSVServerURL
 	bytes, err := workloadccl.ImportFixture(
-		ctx, sqlDB, gen, dbName, directIngestion, filesPerNode, injectStats, csvServer,
+		ctx, sqlDB, gen, dbName, directIngestion, filesPerNode, injectStats, noSkipPostLoad, csvServer,
 	)
 	if err != nil {
 		return errors.Wrap(err, `importing fixture`)

--- a/pkg/ccl/workloadccl/fixture_test.go
+++ b/pkg/ccl/workloadccl/fixture_test.go
@@ -183,10 +183,11 @@ func TestImportFixture(t *testing.T) {
 	}
 
 	const filesPerNode = 1
+	const noSkipPostLoad = false
 	sqlDB.Exec(t, `CREATE DATABASE distsort`)
 	_, err := ImportFixture(
 		ctx, db, gen, `distsort`, false /* directIngestion */, filesPerNode, true, /* injectStats */
-		``, /* csvServer */
+		noSkipPostLoad, ``, /* csvServer */
 	)
 	require.NoError(t, err)
 	sqlDB.CheckQueryResults(t,
@@ -203,7 +204,7 @@ func TestImportFixture(t *testing.T) {
 	sqlDB.Exec(t, `CREATE DATABASE direct`)
 	_, err = ImportFixture(
 		ctx, db, gen, `direct`, true /* directIngestion */, filesPerNode, false, /* injectStats */
-		``, /* csvServer */
+		noSkipPostLoad, ``, /* csvServer */
 	)
 	require.NoError(t, err)
 	sqlDB.CheckQueryResults(t,
@@ -240,9 +241,10 @@ func TestImportFixtureCSVServer(t *testing.T) {
 	}
 
 	const filesPerNode = 1
+	const noDirectIngest, noInjectStats, noSkipPostLoad = false, false, true
 	sqlDB.Exec(t, `CREATE DATABASE d`)
 	_, err := ImportFixture(
-		ctx, db, gen, `d`, false /* directIngestion */, filesPerNode, false /* injectStats */, ts.URL,
+		ctx, db, gen, `d`, noDirectIngest, filesPerNode, noInjectStats, noSkipPostLoad, ts.URL,
 	)
 	require.NoError(t, err)
 	sqlDB.CheckQueryResults(t,


### PR DESCRIPTION
The SQL database for all the tables in the BACKUPs created by `fixtures
make` used to be "csv" (an artifact of the way we made them), but as
of #37343 it's the name of the generator. This seems better so change
`fixtures load` to match.

The same PR also (accidentally) started adding foreign keys in the
BACKUPs, but since there's one table per BACKUP (another artifact of the
way we used to make fixtures), we can't restore the foreign keys. It'd
be nice to switch to one BACKUP with all tables and get the foreign
keys, but the UX of the postLoad hook becomes tricky and I don't have
time right now to sort it all out. So, revert to the previous behavior
(no fks in fixtures) for now.

Release note: None