### PR TITLE
sql: version check for adding FKs with the new validation behavior

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -121,6 +121,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>19.1-3</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>19.1-4</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -71,6 +71,7 @@ const (
 	VersionStart19_2
 	VersionQueryTxnTimestamp
 	VersionStickyBit
+	VersionForeignKeyValidation
 
 	// Add new versions here (step one of two).
 
@@ -472,6 +473,11 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// VersionStickyBit is https://github.com/cockroachdb/cockroach/pull/37506
 		Key:     VersionStickyBit,
 		Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 3},
+	},
+	{
+		// VersionForeignKeyValidation is https://github.com/cockroachdb/cockroach/pull/37433
+		Key:     VersionForeignKeyValidation,
+		Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 4},
 	},
 
 	// Add new versions here (step two of two).


### PR DESCRIPTION
Add a new cluster version corresponding to adding foreign keys via a new type
of mutation that's processed in the schema changer, which can't be handled by
prior versions. Trying to add a FK constraint via `ALTER TABLE` will fail with
an error until the entire cluster has been upgraded to this version.

In general, we're not going to prioritize supporting schema changes during
version updates, so in cases where incompatible changes must be made, we'll
fail immediately as in this PR instead of trying to support both versions in
the code.

Release note: None