### PR TITLE
release-19.1: partitionccl: error instead of panic for an invalid partitioning

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -46,6 +46,13 @@ CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b, c)) PARTITION BY LIST (a
     )
 )
 
+# Regression test for #37682
+statement error declared partition columns \(a, b\) do not match first 1 columns in index being partitioned \(rowid\)
+CREATE TABLE t (a INT DEFAULT 12, b INT DEFAULT 34) PARTITION BY LIST (a, b) (
+  PARTITION p1 VALUES IN ((1,2)),
+  PARTITION default VALUES IN (DEFAULT)
+)
+
 statement error PARTITION p1: name must be unique \(used twice in index "primary"\)
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN (1),

--- a/pkg/ccl/partitionccl/partition.go
+++ b/pkg/ccl/partitionccl/partition.go
@@ -178,7 +178,9 @@ func createPartitioningImpl(
 		}
 		cols = append(cols, col)
 		if string(partBy.Fields[i]) != col.Name {
-			n := colOffset + len(partBy.Fields)
+			// This used to print the first `colOffset + len(partBy.Fields)` fields
+			// but there might not be this many columns in the index. See #37682.
+			n := colOffset + i + 1
 			return partDesc, fmt.Errorf(
 				"declared partition columns (%s) do not match first %d columns in index being partitioned (%s)",
 				partitioningString(), n, strings.Join(indexDesc.ColumnNames[:n], ", "))


### PR DESCRIPTION
Backport 1/1 commits from #37689.

/cc @cockroachdb/release

---

If a PARTITION BY LIST both didn't match the column names in the index
being partitioned and also tried to partition by more columns than were
in the index, we previously panic'd when constructing the error.

Closes #37682

Release note (bug fix): Fixed a panic when construting the error message
for an invalid partitioning.
