### PR TITLE
server: handle new behavior of setrlimit on macOS

### DIFF
--- a/pkg/server/rlimit_darwin.go
+++ b/pkg/server/rlimit_darwin.go
@@ -1,0 +1,62 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// +build !windows,!freebsd,!dragonfly
+
+package server
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// #include <sys/types.h>
+// #include <sys/sysctl.h>
+import "C"
+
+func setRlimitNoFile(limits *rlimit) error {
+	return unix.Setrlimit(unix.RLIMIT_NOFILE, (*unix.Rlimit)(limits))
+}
+
+func getRlimitNoFile(limits *rlimit) error {
+	if err := unix.Getrlimit(unix.RLIMIT_NOFILE, (*unix.Rlimit)(limits)); err != nil {
+		return err
+	}
+	sysctlMaxFiles, err := getSysctlMaxFiles()
+	if err != nil {
+		return err
+	}
+	if limits.Max > sysctlMaxFiles {
+		// Per the setrlimit(2) manpage on macOS, the true hard open file limit is
+		// min(sysctl("kern.maxfiles"), getrlimit(RLIMIT_NOFILE)), so adjust the
+		// limit returned by getrlimit accordingly.
+		//
+		// See https://github.com/golang/go/issues/30401 for more context.
+		limits.Max = sysctlMaxFiles
+	}
+	return nil
+}
+
+func getSysctlMaxFiles() (uint64, error) {
+	var out int32
+	outLen := C.size_t(unsafe.Sizeof(out))
+	sysctlMib := [...]C.int{C.CTL_KERN, C.KERN_MAXFILES} // identifies the "kern.maxfiles" sysctl
+	r, errno := C.sysctl(&sysctlMib[0], C.u_int(len(sysctlMib)), unsafe.Pointer(&out), &outLen,
+		nil /* newp */, 0 /* newlen */)
+	if r != 0 {
+		return 0, errno
+	}
+	return uint64(out), nil
+}

--- a/pkg/server/rlimit_unix.go
+++ b/pkg/server/rlimit_unix.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// +build !windows,!freebsd,!dragonfly
+// +build !windows,!freebsd,!dragonfly,!darwin
 
 package server
 


### PR DESCRIPTION
macOS's getrlimit can return a garbage hard limit for the number of open
files--that is, a hard limit which is higher than what setrlimit(2) will
accept. Since Go 1.12's syscall.Setrlimit actually delegates to the C
library's setrlimit, rather than making a system call directly,
Cockroach can fail to start because its call to syscall.Setrlimit now
fails.

This commit fixes the problem in two ways:

  1. It prevents a failed setrlimit call from stopping the entire
     server startup process, unless the original rlimit is really
     beneath the minimum allowable rlimit.

  2. It provides a macOS wrapper for syscall.Getrlimit that returns the
     actual hard limit, thus preventing the setrlimit call from failing
     in the first place.

Fix #37685.

Release note: None