### PR TITLE
kv: finish and enable parallel commits

### DIFF
--- a/docs/RFCS/20180324_parallel_commit.md
+++ b/docs/RFCS/20180324_parallel_commit.md
@@ -1,5 +1,5 @@
 - Feature Name: parallel commit
-- Status: in-progress
+- Status: completed
 - Start Date: 2018-03-24
 - Authors: Tobias Schottdorf, Nathan VanBenschoten
 - RFC PR: #24194

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -53,7 +53,7 @@
 <tr><td><code>kv.snapshot_recovery.max_rate</code></td><td>byte size</td><td><code>8.0 MiB</code></td><td>the rate limit (bytes/sec) to use for recovery snapshots</td></tr>
 <tr><td><code>kv.transaction.max_intents_bytes</code></td><td>integer</td><td><code>262144</code></td><td>maximum number of bytes used to track write intents in transactions</td></tr>
 <tr><td><code>kv.transaction.max_refresh_spans_bytes</code></td><td>integer</td><td><code>256000</code></td><td>maximum number of bytes used to track refresh spans in serializable transactions</td></tr>
-<tr><td><code>kv.transaction.parallel_commits_enabled</code></td><td>boolean</td><td><code>false</code></td><td>if enabled, transactional commits will be parallelized with transactional writes</td></tr>
+<tr><td><code>kv.transaction.parallel_commits_enabled</code></td><td>boolean</td><td><code>true</code></td><td>if enabled, transactional commits will be parallelized with transactional writes</td></tr>
 <tr><td><code>kv.transaction.write_pipelining_enabled</code></td><td>boolean</td><td><code>true</code></td><td>if enabled, transactional writes are pipelined through Raft consensus</td></tr>
 <tr><td><code>kv.transaction.write_pipelining_max_batch_size</code></td><td>integer</td><td><code>128</code></td><td>if non-zero, defines that maximum size batch that will be pipelined through Raft consensus</td></tr>
 <tr><td><code>kv.transaction.write_pipelining_max_outstanding_size</code></td><td>byte size</td><td><code>256 KiB</code></td><td>maximum number of bytes used to track in-flight pipelined writes before disabling pipelining</td></tr>

--- a/pkg/kv/txn_interceptor_committer.go
+++ b/pkg/kv/txn_interceptor_committer.go
@@ -28,7 +28,7 @@ import (
 var parallelCommitsEnabled = settings.RegisterBoolSetting(
 	"kv.transaction.parallel_commits_enabled",
 	"if enabled, transactional commits will be parallelized with transactional writes",
-	false,
+	true,
 )
 
 // txnCommitter is a txnInterceptor that concerns itself with committing and

--- a/pkg/kv/txn_interceptor_committer_test.go
+++ b/pkg/kv/txn_interceptor_committer_test.go
@@ -28,12 +28,9 @@ import (
 )
 
 func makeMockTxnCommitter() (txnCommitter, *mockLockedSender) {
-	st := cluster.MakeTestingClusterSettings()
-	// TODO(nvanbenschoten): remove when parallel commits are enabled.
-	parallelCommitsEnabled.Override(&st.SV, true)
 	mockSender := &mockLockedSender{}
 	return txnCommitter{
-		st:      st,
+		st:      cluster.MakeTestingClusterSettings(),
 		stopper: stop.NewStopper(),
 		wrapped: mockSender,
 		mu:      new(syncutil.Mutex),

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -388,7 +388,7 @@ func TestTransactionBumpEpoch(t *testing.T) {
 	origNow := makeTS(10, 1)
 	txn := MakeTransaction("test", Key("a"), 1, origNow, 0)
 	// Advance the txn timestamp.
-	txn.Timestamp.Add(10, 2)
+	txn.Timestamp = txn.Timestamp.Add(10, 2)
 	txn.BumpEpoch()
 	if a, e := txn.Epoch, enginepb.TxnEpoch(1); a != e {
 		t.Errorf("expected epoch %d; got %d", e, a)

--- a/pkg/sql/logictest/testdata/planner_test/show_trace
+++ b/pkg/sql/logictest/testdata/planner_test/show_trace
@@ -80,7 +80,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
 flow                                  CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
 flow                                  InitPut /Table/54/2/2/0 -> /BYTES/0x89
-kv.DistSender: sending partial batch  r20: sending batch 1 CPut to (n1,s1):1
+kv.DistSender: sending partial batch  r20: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
 flow                                  fast path completed
 exec cmd: exec stmt                   rows affected: 1
 
@@ -95,7 +95,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
 flow                                  CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
 flow                                  InitPut /Table/54/2/2/0 -> /BYTES/0x89
-kv.DistSender: sending partial batch  r20: sending batch 1 CPut to (n1,s1):1
+kv.DistSender: sending partial batch  r20: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
 exec cmd: exec stmt                   execution failed after 0 rows: duplicate key value (k)=(1) violates unique constraint "primary"
 
 statement error duplicate key value
@@ -108,7 +108,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
 flow                                  CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/2
 flow                                  InitPut /Table/54/2/2/0 -> /BYTES/0x8a
-kv.DistSender: sending partial batch  r20: sending batch 1 CPut to (n1,s1):1
+kv.DistSender: sending partial batch  r20: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
 exec cmd: exec stmt                   execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
 
 statement ok
@@ -146,11 +146,12 @@ WHERE message NOT LIKE '%Z/%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-table reader         Scan /Table/55/{1-2}
-table reader         fetched: /kv2/primary/...PK.../k/v -> /1/2
-flow                 Put /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/4
-flow                 fast path completed
-exec cmd: exec stmt  rows affected: 1
+[async] kv.DistSender: sending pre-commit query intents  r7: sending batch 1 QueryIntent to (n1,s1):1
+table reader                                             Scan /Table/55/{1-2}
+table reader                                             fetched: /kv2/primary/...PK.../k/v -> /1/2
+flow                                                     Put /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/4
+flow                                                     fast path completed
+exec cmd: exec stmt                                      rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DELETE FROM t.kv2; SET tracing = off

--- a/pkg/sql/logictest/testdata/planner_test/upsert
+++ b/pkg/sql/logictest/testdata/planner_test/upsert
@@ -62,7 +62,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 flow                                  Scan /Table/56/1/2{-/#}
 flow                                  CPut /Table/56/1/2/0 -> /TUPLE/2:2:Int/3
 flow                                  InitPut /Table/56/2/3/0 -> /BYTES/0x8a
-kv.DistSender: sending partial batch  r20: sending batch 1 CPut to (n1,s1):1
+kv.DistSender: sending partial batch  r20: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
 flow                                  fast path completed
 exec cmd: exec stmt                   rows affected: 1
 
@@ -76,7 +76,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 flow                                  Scan /Table/56/1/1{-/#}
 flow                                  CPut /Table/56/1/1/0 -> /TUPLE/2:2:Int/2
 flow                                  InitPut /Table/56/2/2/0 -> /BYTES/0x89
-kv.DistSender: sending partial batch  r20: sending batch 1 CPut to (n1,s1):1
+kv.DistSender: sending partial batch  r20: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
 flow                                  fast path completed
 exec cmd: exec stmt                   rows affected: 1
 
@@ -93,7 +93,7 @@ flow                                  fetched: /kv/primary/2/v -> /3
 flow                                  Put /Table/56/1/2/0 -> /TUPLE/2:2:Int/2
 flow                                  Del /Table/56/2/3/0
 flow                                  CPut /Table/56/2/2/0 -> /BYTES/0x8a (expecting does not exist)
-kv.DistSender: sending partial batch  r20: sending batch 1 Put to (n1,s1):1
+kv.DistSender: sending partial batch  r20: sending batch 1 Put, 1 EndTxn to (n1,s1):1
 exec cmd: exec stmt                   execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
 
 subtest regression_32834

--- a/pkg/sql/opt/exec/execbuilder/testdata/interleaved
+++ b/pkg/sql/opt/exec/execbuilder/testdata/interleaved
@@ -562,8 +562,10 @@ output row: [8]
 output row: [9]
 output row: [10]
 rows affected: 10
+querying next range at /Table/61/1/1/#/62/1/1/0
+r20: sending batch 1 EndTxn to (n1,s1):1
 querying next range at /Table/61/1/1/0
-r20: sending batch 1 EndTxn, 10 QueryIntent to (n1,s1):1
+r20: sending batch 10 QueryIntent to (n1,s1):1
 
 statement ok
 DROP TABLE c; DROP TABLE b; DROP TABLE a

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace
@@ -76,7 +76,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
 flow                                  CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
 flow                                  InitPut /Table/54/2/2/0 -> /BYTES/0x89
-kv.DistSender: sending partial batch  r20: sending batch 1 CPut to (n1,s1):1
+kv.DistSender: sending partial batch  r20: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
 flow                                  fast path completed
 exec cmd: exec stmt                   rows affected: 1
 
@@ -91,7 +91,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
 flow                                  CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
 flow                                  InitPut /Table/54/2/2/0 -> /BYTES/0x89
-kv.DistSender: sending partial batch  r20: sending batch 1 CPut to (n1,s1):1
+kv.DistSender: sending partial batch  r20: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
 exec cmd: exec stmt                   execution failed after 0 rows: duplicate key value (k)=(1) violates unique constraint "primary"
 
 statement error duplicate key value
@@ -104,7 +104,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
 flow                                  CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/2
 flow                                  InitPut /Table/54/2/2/0 -> /BYTES/0x8a
-kv.DistSender: sending partial batch  r20: sending batch 1 CPut to (n1,s1):1
+kv.DistSender: sending partial batch  r20: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
 exec cmd: exec stmt                   execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
 
 statement ok
@@ -142,11 +142,12 @@ WHERE message NOT LIKE '%Z/%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-table reader         Scan /Table/55/{1-2}
-table reader         fetched: /kv2/primary/...PK.../k/v -> /1/2
-flow                 Put /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/4
-flow                 fast path completed
-exec cmd: exec stmt  rows affected: 1
+[async] kv.DistSender: sending pre-commit query intents  r7: sending batch 1 QueryIntent to (n1,s1):1
+table reader                                             Scan /Table/55/{1-2}
+table reader                                             fetched: /kv2/primary/...PK.../k/v -> /1/2
+flow                                                     Put /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/4
+flow                                                     fast path completed
+exec cmd: exec stmt                                      rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DELETE FROM t.kv2; SET tracing = off

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -229,7 +229,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 table reader                          Scan /Table/57/1/2{-/#}
 flow                                  CPut /Table/57/1/2/0 -> /TUPLE/2:2:Int/3
 flow                                  InitPut /Table/57/2/3/0 -> /BYTES/0x8a
-kv.DistSender: sending partial batch  r20: sending batch 1 CPut to (n1,s1):1
+kv.DistSender: sending partial batch  r20: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
 flow                                  fast path completed
 exec cmd: exec stmt                   rows affected: 1
 
@@ -243,7 +243,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 table reader                          Scan /Table/57/1/1{-/#}
 flow                                  CPut /Table/57/1/1/0 -> /TUPLE/2:2:Int/2
 flow                                  InitPut /Table/57/2/2/0 -> /BYTES/0x89
-kv.DistSender: sending partial batch  r20: sending batch 1 CPut to (n1,s1):1
+kv.DistSender: sending partial batch  r20: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
 flow                                  fast path completed
 exec cmd: exec stmt                   rows affected: 1
 
@@ -260,7 +260,7 @@ table reader                          fetched: /kv/primary/2/v -> /3
 flow                                  Put /Table/57/1/2/0 -> /TUPLE/2:2:Int/2
 flow                                  Del /Table/57/2/3/0
 flow                                  CPut /Table/57/2/2/0 -> /BYTES/0x8a (expecting does not exist)
-kv.DistSender: sending partial batch  r20: sending batch 1 Put to (n1,s1):1
+kv.DistSender: sending partial batch  r20: sending batch 1 Put, 1 EndTxn to (n1,s1):1
 exec cmd: exec stmt                   execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
 
 


### PR DESCRIPTION
The majority of this PR is addressing the final work item for parallel commits - splitting pre-commit QueryIntents from parallel committing EndTransaction requests.

If a batch is performing a parallel commit and the transaction has previously pipelined writes that have yet to be proven successful then the EndTransaction request will be preceded by a series of QueryIntent requests (see txn_pipeliner.go). Before evaluating, each of these QueryIntent requests will grab latches and wait for their corresponding write to finish. This is how the QueryIntent requests synchronize with the write they are trying to verify.

If these QueryIntents remained in the same batch as the EndTransaction request then they would force the EndTransaction request to wait for the previous write before evaluating itself. This "pipeline stall" would effectively negate the benefit of the parallel commit. To avoid this, we make sure that these "pre-commit" QueryIntent requests are split from and issued concurrently with the rest of the parallel commit batch.

With this complete, parallel commits is then able to be enabled.

### Benchmarks

The original benchmarking for parallel commits was presented in https://github.com/cockroachdb/cockroach/pull/35165#issue-255582656.

One of my recent experiments was to run the `indexes` benchmark at varying numbers of secondary indexes on a 3-node geo-distributed cluster. Below are plots with and without parallel commits enabled. We can see that without parallel commits, the introduction of the first secondary index doubles p50 latency and reduces throughput (at a fixed concurrency) by 56%. With parallel commits, the introduction of the secondary index has almost no noticeable effect on p50 latency and reduces throughput by only 29%.

![Secondary Indexes Throughput With Parallel Commits (1)](https://user-images.githubusercontent.com/5438456/58153546-50aee800-7c3d-11e9-9845-ca5ddf9e0779.png)

![Secondary Indexes p50 Latency With Parallel Commits (1)](https://user-images.githubusercontent.com/5438456/58153550-5278ab80-7c3d-11e9-8b9f-bcc1d702e39f.png)

I expect I'll polish off more comparison benchmarks over the next few weeks to further demonstrate the effect of parallel commits.