### PR TITLE
roachtest: fix `fixtures import` on release branches

### DIFF
--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -63,7 +63,7 @@ func cdcBasicTest(ctx context.Context, t *test, c *cluster, args cdcTestArgs) {
 	crdbNodes := c.Range(1, c.nodes-1)
 	workloadNode := c.Node(c.nodes)
 	kafkaNode := c.Node(c.nodes)
-	c.Put(ctx, cockroach, "./cockroach", crdbNodes)
+	c.Put(ctx, cockroach, "./cockroach")
 	c.Put(ctx, workload, "./workload", workloadNode)
 	c.Start(ctx, t, crdbNodes)
 
@@ -725,12 +725,14 @@ type tpccWorkload struct {
 }
 
 func (tw *tpccWorkload) install(ctx context.Context, c *cluster, fixturesImport bool) {
-	command := `fixtures load`
+	command := `./workload fixtures load`
 	if fixturesImport {
-		command = `fixtures import`
+		// For fixtures import, use the version built into the cockroach binary so
+		// the tpcc workload-versions match on release branches.
+		command = `./cockroach workload fixtures import`
 	}
 	c.Run(ctx, tw.workloadNodes, fmt.Sprintf(
-		`./workload %s tpcc --warehouses=%d --checks=false {pgurl%s}`,
+		`%s tpcc --warehouses=%d --checks=false {pgurl%s}`,
 		command,
 		tw.tpccWarehouseCount,
 		tw.sqlNodes.randNode(),

--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -43,8 +43,10 @@ func registerImportTPCC(r *registry) {
 		m.Go(func(ctx context.Context) error {
 			defer dul.Done()
 			defer hc.Done()
+			// For fixtures import, use the version built into the cockroach binary so
+			// the tpcc workload-versions match on release branches.
 			cmd := fmt.Sprintf(
-				`./workload fixtures import tpcc --warehouses=%d --csv-server='http://localhost:8081'`,
+				`./cockroach workload fixtures import tpcc --warehouses=%d --csv-server='http://localhost:8081'`,
 				warehouses)
 			c.Run(ctx, c.Node(1), cmd)
 			return nil

--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -344,14 +344,16 @@ func makeSchemaChangeBulkIngestTest(numNodes, numRows int, length time.Duration)
 			crdbNodes := c.Range(1, c.nodes-1)
 			workloadNode := c.Node(c.nodes)
 
-			c.Put(ctx, cockroach, "./cockroach", crdbNodes)
+			c.Put(ctx, cockroach, "./cockroach")
 			c.Put(ctx, workload, "./workload", workloadNode)
 			// TODO (lucy): Remove flag once the faster import is enabled by default
 			c.Start(ctx, t, crdbNodes, startArgs("--env=COCKROACH_IMPORT_WORKLOAD_FASTER=true"))
 
 			// Don't add another index when importing.
 			cmdWrite := fmt.Sprintf(
-				"./workload fixtures import bulkingest {pgurl:1} --a %d --b %d --c %d --payload-bytes %d --index-b-c-a=false",
+				// For fixtures import, use the version built into the cockroach binary
+				// so the tpcc workload-versions match on release branches.
+				"./cockroach workload fixtures import bulkingest {pgurl:1} --a %d --b %d --c %d --payload-bytes %d --index-b-c-a=false",
 				aNum, bNum, cNum, payloadBytes,
 			)
 


### PR DESCRIPTION
In #36855, we bumped the workload-version of tpcc from 2.0.1 to 2.1.0.
The IMPORT commands generated by `fixtures import` include the version
built in so that all the nodes processing the IMPORT (which internally
synthesize the data) can check against their internal version. This
prevents nodes from generating incompatible data, but an unfortunate
side effect of this is that the tpcc version in the workload binary must
match the one in the cockroach nodes.

This works for roachtests in master, but not for release branches, which
use a workload binary built from master. Instead, use the `cockroach
workload fixtures import` subcommand, which is guaranteed to match.

Release note: None