### PR TITLE
opt: avoid estimating row count = 0

### DIFF
--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -700,7 +700,9 @@ func (b *logicalPropsBuilder) buildExplainProps(explain *ExplainExpr, rel *props
 
 	// Statistics
 	// ----------
-	// Zero value for Stats is ok for Explain.
+	if !b.disableStats {
+		b.sb.buildExplain(rel)
+	}
 }
 
 func (b *logicalPropsBuilder) buildShowTraceForSessionProps(
@@ -732,7 +734,10 @@ func (b *logicalPropsBuilder) buildShowTraceForSessionProps(
 
 	// Statistics
 	// ----------
-	// Zero value for Stats is ok for ShowTrace.
+	if !b.disableStats {
+		b.sb.buildShowTrace(rel)
+	}
+
 }
 
 func (b *logicalPropsBuilder) buildLimitProps(limit *LimitExpr, rel *props.Relational) {

--- a/pkg/sql/opt/memo/testdata/format
+++ b/pkg/sql/opt/memo/testdata/format
@@ -13,24 +13,24 @@ SELECT a + 1, min(b) FROM t WHERE k + a > b GROUP BY a ORDER BY a
 ----
 sort
  ├── columns: "?column?":5(int) min:4(int)  [hidden: t.public.t.a:1(int)]
- ├── stats: [rows=98.1771622]
- ├── cost: 1097.86224
+ ├── stats: [rows=99.1771622]
+ ├── cost: 1098.07359
  ├── key: (1)
  ├── fd: (1)-->(4,5)
  ├── ordering: +1
  ├── prune: (1,4,5)
  └── project
       ├── columns: "?column?":5(int) t.public.t.a:1(int) min:4(int)
-      ├── stats: [rows=98.1771622]
-      ├── cost: 1082.89531
+      ├── stats: [rows=99.1771622]
+      ├── cost: 1082.92531
       ├── key: (1)
       ├── fd: (1)-->(4,5)
       ├── prune: (1,4,5)
       ├── group-by
       │    ├── columns: t.public.t.a:1(int) min:4(int)
       │    ├── grouping columns: t.public.t.a:1(int)
-      │    ├── stats: [rows=98.1771622, distinct(1)=98.1771622, null(1)=3.3]
-      │    ├── cost: 1080.92177
+      │    ├── stats: [rows=99.1771622, distinct(1)=98.1771622, null(1)=3.3]
+      │    ├── cost: 1080.93177
       │    ├── key: (1)
       │    ├── fd: (1)-->(4)
       │    ├── prune: (4)
@@ -68,18 +68,18 @@ SELECT a + 1, min(b) FROM t WHERE k + a > b GROUP BY a ORDER BY a
 ----
 sort
  ├── columns: "?column?":5(int) min:4(int)  [hidden: t.public.t.a:1(int)]
- ├── stats: [rows=98.1771622]
- ├── cost: 1097.86224
+ ├── stats: [rows=99.1771622]
+ ├── cost: 1098.07359
  ├── ordering: +1
  └── project
       ├── columns: "?column?":5(int) t.public.t.a:1(int) min:4(int)
-      ├── stats: [rows=98.1771622]
-      ├── cost: 1082.89531
+      ├── stats: [rows=99.1771622]
+      ├── cost: 1082.92531
       ├── group-by
       │    ├── columns: t.public.t.a:1(int) min:4(int)
       │    ├── grouping columns: t.public.t.a:1(int)
-      │    ├── stats: [rows=98.1771622, distinct(1)=98.1771622, null(1)=3.3]
-      │    ├── cost: 1080.92177
+      │    ├── stats: [rows=99.1771622, distinct(1)=98.1771622, null(1)=3.3]
+      │    ├── cost: 1080.93177
       │    ├── select
       │    │    ├── columns: t.public.t.a:1(int) t.public.t.b:2(int!null) t.public.t.k:3(int!null)
       │    │    ├── stats: [rows=330, distinct(1)=98.1771622, null(1)=3.3, distinct(2)=98.265847, null(2)=0, distinct(3)=330, null(3)=0]
@@ -184,20 +184,20 @@ opt format=(hide-miscprops,hide-orderings,hide-columns)
 SELECT a + 1, min(b) FROM t WHERE k + a > b GROUP BY a ORDER BY a
 ----
 sort
- ├── stats: [rows=98.1771622]
- ├── cost: 1097.86224
+ ├── stats: [rows=99.1771622]
+ ├── cost: 1098.07359
  ├── key: (1)
  ├── fd: (1)-->(4,5)
  ├── prune: (1,4,5)
  └── project
-      ├── stats: [rows=98.1771622]
-      ├── cost: 1082.89531
+      ├── stats: [rows=99.1771622]
+      ├── cost: 1082.92531
       ├── key: (1)
       ├── fd: (1)-->(4,5)
       ├── prune: (1,4,5)
       ├── group-by
-      │    ├── stats: [rows=98.1771622, distinct(1)=98.1771622, null(1)=3.3]
-      │    ├── cost: 1080.92177
+      │    ├── stats: [rows=99.1771622, distinct(1)=98.1771622, null(1)=3.3]
+      │    ├── cost: 1080.93177
       │    ├── key: (1)
       │    ├── fd: (1)-->(4)
       │    ├── prune: (4)

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -317,11 +317,11 @@ memo (optimized, ~3KB, required=[presentation: array_agg:3])
  ├── G1: (project G2 G3 array_agg)
  │    └── [presentation: array_agg:3]
  │         ├── best: (project G2 G3 array_agg)
- │         └── cost: 1072.04
+ │         └── cost: 1072.06
  ├── G2: (group-by G4 G5 cols=(2))
  │    └── []
  │         ├── best: (group-by G4 G5 cols=(2))
- │         └── cost: 1071.03
+ │         └── cost: 1071.04
  ├── G3: (projections)
  ├── G4: (scan a)
  │    └── []
@@ -357,7 +357,7 @@ memo (optimized, ~5KB, required=[presentation: field:3])
  ├── G1: (distinct-on G2 G3 cols=(3))
  │    └── [presentation: field:3]
  │         ├── best: (distinct-on G2 G3 cols=(3))
- │         └── cost: 0.04
+ │         └── cost: 0.34
  ├── G2: (explain G4 [presentation: k:1])
  │    └── []
  │         ├── best: (explain G4="[presentation: k:1]" [presentation: k:1])
@@ -379,7 +379,7 @@ memo (optimized, ~2KB, required=[presentation: tag:4])
  ├── G1: (distinct-on G2 G3 cols=(4))
  │    └── [presentation: tag:4]
  │         ├── best: (distinct-on G2 G3 cols=(4))
- │         └── cost: 0.02
+ │         └── cost: 0.32
  ├── G2: (show-trace-for-session &{TRACE false [1 2 3 4 5 6 7]})
  │    └── []
  │         ├── best: (show-trace-for-session &{TRACE false [1 2 3 4 5 6 7]})

--- a/pkg/sql/opt/memo/testdata/stats/explain
+++ b/pkg/sql/opt/memo/testdata/stats/explain
@@ -1,0 +1,26 @@
+build
+EXPLAIN SELECT 1
+----
+explain
+ ├── columns: tree:2(string) field:3(string) description:4(string)
+ ├── stats: [rows=10]
+ └── project
+      ├── columns: "?column?":1(int!null)
+      ├── cardinality: [1 - 1]
+      ├── stats: [rows=1]
+      ├── key: ()
+      ├── fd: ()-->(1)
+      ├── values
+      │    ├── cardinality: [1 - 1]
+      │    ├── stats: [rows=1]
+      │    ├── key: ()
+      │    └── tuple [type=tuple]
+      └── projections
+           └── const: 1 [type=int]
+
+build
+SHOW TRACE FOR SESSION
+----
+show-trace-for-session &{TRACE false [1 2 3 4 5 6 7]}
+ ├── columns: timestamp:1(timestamptz) age:2(interval) message:3(string) tag:4(string) location:5(string) operation:6(string) span:7(int)
+ └── stats: [rows=10]

--- a/pkg/sql/opt/memo/testdata/stats/groupby
+++ b/pkg/sql/opt/memo/testdata/stats/groupby
@@ -293,12 +293,12 @@ SELECT x FROM a GROUP BY x, y
 ----
 project
  ├── columns: x:1(int!null)
- ├── stats: [rows=1000]
+ ├── stats: [rows=1001]
  ├── key: (1)
  └── group-by
       ├── columns: x:1(int!null) y:2(int)
       ├── grouping columns: x:1(int!null) y:2(int)
-      ├── stats: [rows=1000, distinct(1,2)=1000, null(1,2)=1000]
+      ├── stats: [rows=1001, distinct(1,2)=1000, null(1,2)=1000]
       ├── key: (1)
       ├── fd: (1)-->(2)
       └── project
@@ -346,7 +346,7 @@ SELECT y, sum(z) FROM a GROUP BY y
 group-by
  ├── columns: y:2(int) sum:5(float)
  ├── grouping columns: y:2(int)
- ├── stats: [rows=400, distinct(2)=400, null(2)=400]
+ ├── stats: [rows=401, distinct(2)=400, null(2)=401]
  ├── key: (2)
  ├── fd: (2)-->(5)
  ├── project
@@ -366,11 +366,11 @@ SELECT max(x) FROM a GROUP BY y, z, s
 ----
 project
  ├── columns: max:5(int)
- ├── stats: [rows=600]
+ ├── stats: [rows=601]
  └── group-by
       ├── columns: y:2(int) z:3(float!null) s:4(string) max:5(int)
       ├── grouping columns: y:2(int) z:3(float!null) s:4(string)
-      ├── stats: [rows=600, distinct(2-4)=600, null(2-4)=600]
+      ├── stats: [rows=601, distinct(2-4)=600, null(2-4)=601]
       ├── key: (2-4)
       ├── fd: (3,4)~~>(2), (2-4)-->(5)
       ├── scan a
@@ -413,16 +413,16 @@ SELECT max(x) FROM a GROUP BY y, z, s HAVING s IN ('a', 'b')
 ----
 project
  ├── columns: max:5(int)
- ├── stats: [rows=118.9]
+ ├── stats: [rows=119.1]
  └── select
       ├── columns: y:2(int) z:3(float!null) s:4(string!null) max:5(int)
-      ├── stats: [rows=118.9, distinct(3)=97.6, null(3)=0, distinct(4)=2, null(4)=0]
+      ├── stats: [rows=119.1, distinct(3)=97.7141858, null(3)=0, distinct(4)=2, null(4)=0]
       ├── key: (3,4)
       ├── fd: (3,4)-->(2), (2-4)-->(5)
       ├── group-by
       │    ├── columns: y:2(int) z:3(float!null) s:4(string) max:5(int)
       │    ├── grouping columns: y:2(int) z:3(float!null) s:4(string)
-      │    ├── stats: [rows=600, distinct(3)=200, null(3)=0, distinct(4)=10, null(4)=5.5, distinct(2-4)=600, null(2-4)=600]
+      │    ├── stats: [rows=601, distinct(3)=200, null(3)=0, distinct(4)=10, null(4)=5.5, distinct(2-4)=600, null(2-4)=601]
       │    ├── key: (2-4)
       │    ├── fd: (3,4)~~>(2), (2-4)-->(5)
       │    ├── scan a
@@ -442,13 +442,13 @@ SELECT sum(x), s FROM a GROUP BY s HAVING sum(x) = 5
 ----
 select
  ├── columns: sum:5(decimal!null) s:4(string)
- ├── stats: [rows=0.9, distinct(5)=0.9, null(5)=0]
+ ├── stats: [rows=1, distinct(5)=1, null(5)=0]
  ├── key: (4)
  ├── fd: ()-->(5)
  ├── group-by
  │    ├── columns: s:4(string) sum:5(decimal)
  │    ├── grouping columns: s:4(string)
- │    ├── stats: [rows=10, distinct(4)=10, null(4)=10, distinct(5)=10, null(5)=1]
+ │    ├── stats: [rows=11, distinct(4)=10, null(4)=11, distinct(5)=10, null(5)=1]
  │    ├── key: (4)
  │    ├── fd: (4)-->(5)
  │    ├── project
@@ -479,19 +479,19 @@ GROUP BY q.b
 project
  ├── columns: "?column?":4(int!null)
  ├── cardinality: [0 - 3]
- ├── stats: [rows=0]
+ ├── stats: [rows=0.5]
  ├── fd: ()-->(4)
  ├── select
  │    ├── columns: column2:2(int) bool_or:3(bool!null)
  │    ├── cardinality: [0 - 3]
- │    ├── stats: [rows=0, distinct(3)=0, null(3)=0]
+ │    ├── stats: [rows=0.5, distinct(3)=0.5, null(3)=0]
  │    ├── key: (2)
  │    ├── fd: ()-->(3)
  │    ├── group-by
  │    │    ├── columns: column2:2(int) bool_or:3(bool)
  │    │    ├── grouping columns: column2:2(int)
  │    │    ├── cardinality: [0 - 3]
- │    │    ├── stats: [rows=0.875, distinct(2)=0.875, null(2)=0.875, distinct(3)=0.875, null(3)=0.875]
+ │    │    ├── stats: [rows=1.5, distinct(2)=0.875, null(2)=1, distinct(3)=0.875, null(3)=1]
  │    │    ├── key: (2)
  │    │    ├── fd: (2)-->(3)
  │    │    ├── select

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -523,11 +523,11 @@ GROUP BY y
 ----
 project
  ├── columns: count:8(int)
- ├── stats: [rows=399.903879]
+ ├── stats: [rows=400.903879]
  └── group-by
       ├── columns: y:2(int) count_rows:8(int)
       ├── grouping columns: y:2(int)
-      ├── stats: [rows=399.903879, distinct(2)=399.903879, null(2)=399.903879]
+      ├── stats: [rows=400.903879, distinct(2)=399.903879, null(2)=400.903879]
       ├── key: (2)
       ├── fd: (2)-->(8)
       ├── right-join
@@ -556,11 +556,11 @@ GROUP BY y
 ----
 project
  ├── columns: count:8(int)
- ├── stats: [rows=400]
+ ├── stats: [rows=401]
  └── group-by
       ├── columns: y:2(int) count_rows:8(int)
       ├── grouping columns: y:2(int)
-      ├── stats: [rows=400, distinct(2)=400, null(2)=400]
+      ├── stats: [rows=401, distinct(2)=400, null(2)=401]
       ├── key: (2)
       ├── fd: (2)-->(8)
       ├── full-join
@@ -944,3 +944,163 @@ left-join (merge)
  │         └── fd: (7)-->(5,6)
  └── filters
       └── y > v [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ])]
+
+# Check that true filters are handled correctly for all join types.
+norm
+SELECT * FROM (SELECT 1) JOIN (SELECT 1 WHERE false) ON true
+----
+values
+ ├── columns: "?column?":1(int) "?column?":2(int)
+ ├── cardinality: [0 - 0]
+ ├── stats: [rows=0]
+ ├── key: ()
+ └── fd: ()-->(1,2)
+
+norm
+SELECT * FROM (SELECT 1) LEFT JOIN (SELECT 1 WHERE false) ON true
+----
+left-join
+ ├── columns: "?column?":1(int) "?column?":2(int)
+ ├── cardinality: [1 - 1]
+ ├── stats: [rows=1]
+ ├── key: ()
+ ├── fd: ()-->(1,2)
+ ├── values
+ │    ├── columns: "?column?":1(int)
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1)
+ │    └── (1,) [type=tuple{int}]
+ ├── values
+ │    ├── columns: "?column?":2(int)
+ │    ├── cardinality: [0 - 0]
+ │    ├── stats: [rows=0]
+ │    ├── key: ()
+ │    └── fd: ()-->(2)
+ └── filters (true)
+
+norm
+SELECT * FROM (SELECT 1) RIGHT JOIN (SELECT 1 WHERE false) ON true
+----
+values
+ ├── columns: "?column?":1(int) "?column?":2(int)
+ ├── cardinality: [0 - 0]
+ ├── stats: [rows=0]
+ ├── key: ()
+ └── fd: ()-->(1,2)
+
+norm
+SELECT * FROM (SELECT 1) FULL JOIN (SELECT 1 WHERE false) ON true
+----
+left-join
+ ├── columns: "?column?":1(int) "?column?":2(int)
+ ├── cardinality: [1 - 1]
+ ├── stats: [rows=1]
+ ├── key: ()
+ ├── fd: ()-->(1,2)
+ ├── values
+ │    ├── columns: "?column?":1(int)
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1)
+ │    └── (1,) [type=tuple{int}]
+ ├── values
+ │    ├── columns: "?column?":2(int)
+ │    ├── cardinality: [0 - 0]
+ │    ├── stats: [rows=0]
+ │    ├── key: ()
+ │    └── fd: ()-->(2)
+ └── filters (true)
+
+norm
+SELECT * FROM (SELECT 1 WHERE false) JOIN (SELECT 1) ON true
+----
+values
+ ├── columns: "?column?":1(int) "?column?":2(int)
+ ├── cardinality: [0 - 0]
+ ├── stats: [rows=0]
+ ├── key: ()
+ └── fd: ()-->(1,2)
+
+norm
+SELECT * FROM (SELECT 1 WHERE false) LEFT JOIN (SELECT 1) ON true
+----
+values
+ ├── columns: "?column?":1(int) "?column?":2(int)
+ ├── cardinality: [0 - 0]
+ ├── stats: [rows=0]
+ ├── key: ()
+ └── fd: ()-->(1,2)
+
+norm
+SELECT * FROM (SELECT 1 WHERE false) RIGHT JOIN (SELECT 1) ON true
+----
+right-join
+ ├── columns: "?column?":1(int) "?column?":2(int)
+ ├── cardinality: [1 - 1]
+ ├── stats: [rows=1]
+ ├── key: ()
+ ├── fd: ()-->(1,2)
+ ├── values
+ │    ├── columns: "?column?":1(int)
+ │    ├── cardinality: [0 - 0]
+ │    ├── stats: [rows=0]
+ │    ├── key: ()
+ │    └── fd: ()-->(1)
+ ├── values
+ │    ├── columns: "?column?":2(int)
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(2)
+ │    └── (1,) [type=tuple{int}]
+ └── filters (true)
+
+norm
+SELECT * FROM (SELECT 1 WHERE false) FULL JOIN (SELECT 1) ON true
+----
+right-join
+ ├── columns: "?column?":1(int) "?column?":2(int)
+ ├── cardinality: [1 - 1]
+ ├── stats: [rows=1]
+ ├── key: ()
+ ├── fd: ()-->(1,2)
+ ├── values
+ │    ├── columns: "?column?":1(int)
+ │    ├── cardinality: [0 - 0]
+ │    ├── stats: [rows=0]
+ │    ├── key: ()
+ │    └── fd: ()-->(1)
+ ├── values
+ │    ├── columns: "?column?":2(int)
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(2)
+ │    └── (1,) [type=tuple{int}]
+ └── filters (true)
+
+norm
+SELECT * FROM (SELECT 1) FULL JOIN (VALUES (1), (2)) ON true
+----
+inner-join
+ ├── columns: "?column?":1(int) column1:2(int)
+ ├── cardinality: [2 - 2]
+ ├── stats: [rows=2]
+ ├── fd: ()-->(1)
+ ├── values
+ │    ├── columns: "?column?":1(int)
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1)
+ │    └── (1,) [type=tuple{int}]
+ ├── values
+ │    ├── columns: column1:2(int)
+ │    ├── cardinality: [2 - 2]
+ │    ├── stats: [rows=2]
+ │    ├── (1,) [type=tuple{int}]
+ │    └── (2,) [type=tuple{int}]
+ └── filters (true)

--- a/pkg/sql/opt/memo/testdata/stats/limit
+++ b/pkg/sql/opt/memo/testdata/stats/limit
@@ -209,3 +209,39 @@ limit
  │    └── filters
  │         └── s = 'foo' [type=bool, outer=(3), constraints=(/3: [/'foo' - /'foo']; tight), fd=()-->(3)]
  └── const: 5 [type=int]
+
+exec-ddl
+CREATE TABLE b (x int)
+----
+TABLE b
+ ├── x int
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+# Regression test for #32578. Ensure that we don't estimate 0 rows for the
+# offset.
+opt colstat=1
+SELECT * FROM b ORDER BY x LIMIT 1 OFFSET 9999
+----
+limit
+ ├── columns: x:1(int)
+ ├── internal-ordering: +1
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=1, distinct(1)=0.995511979, null(1)=0.01]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ ├── offset
+ │    ├── columns: x:1(int)
+ │    ├── internal-ordering: +1
+ │    ├── stats: [rows=1, distinct(1)=0.995511979, null(1)=0.01]
+ │    ├── ordering: +1
+ │    ├── sort
+ │    │    ├── columns: x:1(int)
+ │    │    ├── stats: [rows=1000, distinct(1)=100, null(1)=10]
+ │    │    ├── ordering: +1
+ │    │    └── scan b
+ │    │         ├── columns: x:1(int)
+ │    │         └── stats: [rows=1000, distinct(1)=100, null(1)=10]
+ │    └── const: 9999 [type=int]
+ └── const: 1 [type=int]

--- a/pkg/sql/opt/memo/testdata/stats/ordinality
+++ b/pkg/sql/opt/memo/testdata/stats/ordinality
@@ -34,12 +34,12 @@ select
  ├── fd: (1)-->(2,3), (3)-->(1,2)
  ├── ordinality
  │    ├── columns: x:1(int!null) y:2(int) ordinality:3(int!null)
- │    ├── stats: [rows=4000, distinct(1)=5000, null(1)=0, distinct(3)=4000, null(3)=0]
+ │    ├── stats: [rows=4000, distinct(1)=4000, null(1)=0, distinct(3)=4000, null(3)=0]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3), (3)-->(1,2)
  │    └── scan a
  │         ├── columns: x:1(int!null) y:2(int)
- │         ├── stats: [rows=4000, distinct(1)=5000, null(1)=0]
+ │         ├── stats: [rows=4000, distinct(1)=4000, null(1)=0]
  │         ├── key: (1)
  │         └── fd: (1)-->(2)
  └── filters
@@ -55,12 +55,12 @@ select
  ├── fd: (1)-->(2,3), (3)-->(1,2)
  ├── ordinality
  │    ├── columns: x:1(int!null) y:2(int) ordinality:3(int!null)
- │    ├── stats: [rows=4000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=0, distinct(3)=4000, null(3)=0]
+ │    ├── stats: [rows=4000, distinct(1)=4000, null(1)=0, distinct(2)=400, null(2)=0, distinct(3)=4000, null(3)=0]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3), (3)-->(1,2)
  │    └── scan a
  │         ├── columns: x:1(int!null) y:2(int)
- │         ├── stats: [rows=4000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=0]
+ │         ├── stats: [rows=4000, distinct(1)=4000, null(1)=0, distinct(2)=400, null(2)=0]
  │         ├── key: (1)
  │         └── fd: (1)-->(2)
  └── filters
@@ -96,12 +96,12 @@ project
       ├── fd: (1)-->(3), (3)-->(1)
       ├── ordinality
       │    ├── columns: x:1(int!null) ordinality:3(int!null)
-      │    ├── stats: [rows=4000, distinct(1)=5000, null(1)=0, distinct(3)=4000, null(3)=0]
+      │    ├── stats: [rows=4000, distinct(1)=4000, null(1)=0, distinct(3)=4000, null(3)=0]
       │    ├── key: (1)
       │    ├── fd: (1)-->(3), (3)-->(1)
       │    └── scan a
       │         ├── columns: x:1(int!null)
-      │         ├── stats: [rows=4000, distinct(1)=5000, null(1)=0]
+      │         ├── stats: [rows=4000, distinct(1)=4000, null(1)=0]
       │         └── key: (1)
       └── filters
            └── (ordinality > 0) AND (ordinality <= 10) [type=bool, outer=(3), constraints=(/3: [/1 - /10]; tight)]
@@ -118,12 +118,12 @@ select
  ├── fd: ()-->(1-3)
  ├── ordinality
  │    ├── columns: x:1(int!null) y:2(int) ordinality:3(int!null)
- │    ├── stats: [rows=4000, distinct(1)=5000, null(1)=0, distinct(3)=4000, null(3)=0]
+ │    ├── stats: [rows=4000, distinct(1)=4000, null(1)=0, distinct(3)=4000, null(3)=0]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3), (3)-->(1,2)
  │    └── scan a
  │         ├── columns: x:1(int!null) y:2(int)
- │         ├── stats: [rows=4000, distinct(1)=5000, null(1)=0]
+ │         ├── stats: [rows=4000, distinct(1)=4000, null(1)=0]
  │         ├── key: (1)
  │         └── fd: (1)-->(2)
  └── filters

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -332,7 +332,7 @@ SELECT y, s FROM a GROUP BY y, s
 distinct-on
  ├── columns: y:2(int) s:3(string)
  ├── grouping columns: y:2(int) s:3(string)
- ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=1000]
+ ├── stats: [rows=1001, distinct(2,3)=1000, null(2,3)=1001]
  ├── key: (2,3)
  └── scan a
       ├── columns: y:2(int) s:3(string)
@@ -481,3 +481,31 @@ sequence-select t.public.seq
  ├── stats: [rows=1]
  ├── key: ()
  └── fd: ()-->(1-3)
+
+exec-ddl
+CREATE TABLE empty (x INT)
+----
+TABLE empty
+ ├── x int
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+exec-ddl
+ALTER TABLE empty INJECT STATISTICS '[
+  {
+    "columns": ["x"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 0,
+    "distinct_count": 0
+  }
+]'
+----
+
+# We should always estimate at least 1 row even if the stats have 0 rows.
+opt
+SELECT * FROM empty
+----
+scan empty
+ ├── columns: x:1(int)
+ └── stats: [rows=1]

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -110,7 +110,7 @@ select
  ├── fd: (1)-->(2)
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(int)
- │    ├── stats: [rows=4000, distinct(1)=5000, null(1)=0]
+ │    ├── stats: [rows=4000, distinct(1)=4000, null(1)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── filters
@@ -127,7 +127,7 @@ select
  ├── fd: ()-->(2)
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(int)
- │    ├── stats: [rows=4000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=0]
+ │    ├── stats: [rows=4000, distinct(1)=4000, null(1)=0, distinct(2)=400, null(2)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── filters
@@ -141,12 +141,12 @@ SELECT * FROM a WHERE x IS NULL
 select
  ├── columns: x:1(int!null) y:2(int)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=0.8, distinct(1)=0.8, null(1)=0]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0]
  ├── key: ()
  ├── fd: ()-->(1,2)
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(int)
- │    ├── stats: [rows=4000, distinct(1)=5000, null(1)=0]
+ │    ├── stats: [rows=4000, distinct(1)=4000, null(1)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── filters
@@ -263,20 +263,20 @@ SELECT count(*) FROM (SELECT * FROM tab0 WHERE col3 = 10) GROUP BY col0
 ----
 project
  ├── columns: count:8(int)
- ├── stats: [rows=0]
+ ├── stats: [rows=1.99997344]
  └── group-by
       ├── columns: col0:2(int) count_rows:8(int)
       ├── grouping columns: col0:2(int)
-      ├── stats: [rows=0, distinct(2)=0, null(2)=0]
+      ├── stats: [rows=1.99997344, distinct(2)=0.999973439, null(2)=1.99997344]
       ├── key: (2)
       ├── fd: (2)-->(8)
       ├── select
       │    ├── columns: col0:2(int) col3:5(int!null)
-      │    ├── stats: [rows=10, distinct(2)=0, null(2)=10, distinct(5)=1, null(5)=0]
+      │    ├── stats: [rows=10, distinct(2)=0.999973439, null(2)=10, distinct(5)=1, null(5)=0]
       │    ├── fd: ()-->(5)
       │    ├── scan tab0
       │    │    ├── columns: col0:2(int) col3:5(int)
-      │    │    └── stats: [rows=100, distinct(2)=0, null(2)=100, distinct(5)=10, null(5)=0]
+      │    │    └── stats: [rows=100, distinct(2)=1, null(2)=100, distinct(5)=10, null(5)=0]
       │    └── filters
       │         └── col3 = 10 [type=bool, outer=(5), constraints=(/5: [/10 - /10]; tight), fd=()-->(5)]
       └── aggregations
@@ -1308,16 +1308,16 @@ SELECT * FROM nulls WHERE y = 3
 ----
 project
  ├── columns: x:1(int) y:2(int!null)
- ├── stats: [rows=9.9, distinct(1)=0, null(1)=9.9]
+ ├── stats: [rows=9.9, distinct(1)=0.99995224, null(1)=9.9]
  ├── fd: ()-->(2)
  └── select
       ├── columns: x:1(int) y:2(int!null) rowid:3(int!null)
-      ├── stats: [rows=9.9, distinct(1)=0, null(1)=9.9, distinct(2)=1, null(2)=0, distinct(3)=9.9, null(3)=0]
+      ├── stats: [rows=9.9, distinct(1)=0.99995224, null(1)=9.9, distinct(2)=1, null(2)=0, distinct(3)=9.9, null(3)=0]
       ├── key: (3)
       ├── fd: ()-->(2), (3)-->(1)
       ├── scan nulls
       │    ├── columns: x:1(int) y:2(int) rowid:3(int!null)
-      │    ├── stats: [rows=1000, distinct(1)=0, null(1)=1000, distinct(2)=100, null(2)=10, distinct(3)=1000, null(3)=0]
+      │    ├── stats: [rows=1000, distinct(1)=1, null(1)=1000, distinct(2)=100, null(2)=10, distinct(3)=1000, null(3)=0]
       │    ├── key: (3)
       │    └── fd: (3)-->(1,2)
       └── filters

--- a/pkg/sql/opt/memo/testdata/stats/set
+++ b/pkg/sql/opt/memo/testdata/stats/set
@@ -926,3 +926,35 @@ except
       │    └── (3, 4) [type=tuple{int, int}]
       └── filters
            └── column1 IS NULL [type=bool, outer=(3), constraints=(/3: [/NULL - /NULL]; tight), fd=()-->(3)]
+
+# Make sure that we estimate at least 1 row for the intersect.
+opt
+VALUES (1) INTERSECT VALUES (NULL) ORDER BY 1
+----
+sort
+ ├── columns: column1:1(int)
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+ ├── key: (1)
+ ├── ordering: +1
+ └── intersect
+      ├── columns: column1:1(int)
+      ├── left columns: column1:1(int)
+      ├── right columns: column1:3(int)
+      ├── cardinality: [0 - 1]
+      ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+      ├── key: (1)
+      ├── values
+      │    ├── columns: column1:1(int)
+      │    ├── cardinality: [1 - 1]
+      │    ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+      │    ├── key: ()
+      │    ├── fd: ()-->(1)
+      │    └── (1,) [type=tuple{int}]
+      └── values
+           ├── columns: column1:3(int)
+           ├── cardinality: [1 - 1]
+           ├── stats: [rows=1, distinct(3)=0, null(3)=1]
+           ├── key: ()
+           ├── fd: ()-->(3)
+           └── (NULL,) [type=tuple{int}]

--- a/pkg/sql/opt/memo/testdata/stats/srfs
+++ b/pkg/sql/opt/memo/testdata/stats/srfs
@@ -68,7 +68,7 @@ distinct-on
  ├── columns: a:1(string) b:2(int)
  ├── grouping columns: upper:1(string) generate_series:2(int)
  ├── side-effects
- ├── stats: [rows=7, distinct(1,2)=7, null(1,2)=0.1]
+ ├── stats: [rows=7.1, distinct(1,2)=7, null(1,2)=0.1]
  ├── key: (1,2)
  └── inner-join
       ├── columns: upper:1(string) generate_series:2(int)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpcc
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpcc
@@ -1497,7 +1497,7 @@ project
  ├── save-table-name: delivery_01_project_1
  ├── columns: no_o_id:1(int!null)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=1, distinct(1)=94.6943635, null(1)=0]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0]
  ├── cost: 1.09
  ├── key: ()
  ├── fd: ()-->(1)
@@ -1507,7 +1507,7 @@ project
       ├── columns: no_o_id:1(int!null) no_d_id:2(int!null) no_w_id:3(int!null)
       ├── constraint: /3/2/-1: [/7/6 - /7/6]
       ├── limit: 1(rev)
-      ├── stats: [rows=1, distinct(1)=94.6943635, null(1)=0, distinct(2)=9.99954852, null(2)=0, distinct(3)=9.99954852, null(3)=0]
+      ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0]
       ├── cost: 1.07
       ├── key: ()
       ├── fd: ()-->(1-3)
@@ -1522,9 +1522,9 @@ column_names  row_count  distinct_count  null_count
 {no_w_id}     1          1               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{no_d_id}     1.00           1.00           10.00               10.00 <==           0.00            1.00
-{no_o_id}     1.00           1.00           95.00               95.00 <==           0.00            1.00
-{no_w_id}     1.00           1.00           10.00               10.00 <==           0.00            1.00
+{no_d_id}     1.00           1.00           1.00                1.00                0.00            1.00
+{no_o_id}     1.00           1.00           1.00                1.00                0.00            1.00
+{no_w_id}     1.00           1.00           1.00                1.00                0.00            1.00
 
 save-tables format=hide-qual database=tpcc save-tables-prefix=delivery_02
 SELECT sum(ol_amount)

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -3141,8 +3141,8 @@ firstCol, secondCol, thirdCol;
 group-by
  ├── columns: firstcol:1(int!null) secondcol:2(int) thirdcol:2(int)
  ├── grouping columns: t.public.xyz.x:1(int!null) t.public.xyz.y:2(int)
- ├── stats: [rows=990, distinct(1,2)=990, null(1,2)=10]
- ├── cost: 1109.94
+ ├── stats: [rows=991, distinct(1,2)=990, null(1,2)=10]
+ ├── cost: 1109.95
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── interesting orderings: (+1,+2)

--- a/pkg/sql/opt/optbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/optbuilder/testdata/distinct_on
@@ -428,17 +428,18 @@ distinct-on
 build
 SELECT DISTINCT ON(pk1, pk2, x, y) x, y, z FROM xyz ORDER BY x, y
 ----
-sort
+distinct-on
  ├── columns: x:1(int) y:2(int) z:3(int)  [hidden: pk1:4(int!null) pk2:5(int!null)]
+ ├── grouping columns: x:1(int) y:2(int) pk1:4(int!null) pk2:5(int!null)
  ├── ordering: +1,+2
- └── distinct-on
-      ├── columns: x:1(int) y:2(int) z:3(int) pk1:4(int!null) pk2:5(int!null)
-      ├── grouping columns: x:1(int) y:2(int) pk1:4(int!null) pk2:5(int!null)
-      ├── scan xyz
-      │    └── columns: x:1(int) y:2(int) z:3(int) pk1:4(int!null) pk2:5(int!null)
-      └── aggregations
-           └── first-agg [type=int]
-                └── variable: z [type=int]
+ ├── sort
+ │    ├── columns: x:1(int) y:2(int) z:3(int) pk1:4(int!null) pk2:5(int!null)
+ │    ├── ordering: +1,+2
+ │    └── scan xyz
+ │         └── columns: x:1(int) y:2(int) z:3(int) pk1:4(int!null) pk2:5(int!null)
+ └── aggregations
+      └── first-agg [type=int]
+           └── variable: z [type=int]
 
 build
 SELECT DISTINCT ON (x, y, z) pk1 FROM xyz ORDER BY x

--- a/pkg/sql/opt/optgen/exprgen/testdata/explain
+++ b/pkg/sql/opt/optgen/exprgen/testdata/explain
@@ -24,7 +24,7 @@ expr
 ----
 explain
  ├── mode: opt, verbose
- ├── stats: [rows=0]
+ ├── stats: [rows=10]
  ├── cost: 1050.03
  └── scan t.public.abc
       ├── columns: t.public.abc.a:1(int)
@@ -44,7 +44,7 @@ expr
 ----
 explain
  ├── mode: verbose
- ├── stats: [rows=0]
+ ├── stats: [rows=10]
  ├── cost: 1050.03
  └── scan t.public.abc
       ├── columns: t.public.abc.a:1(int)
@@ -64,7 +64,7 @@ expr
 ----
 explain
  ├── mode: opt
- ├── stats: [rows=0]
+ ├── stats: [rows=10]
  ├── cost: 1050.03
  └── scan t.public.abc
       ├── columns: t.public.abc.a:1(int)
@@ -91,7 +91,7 @@ expr
 ----
 explain
  ├── mode: opt
- ├── stats: [rows=0]
+ ├── stats: [rows=10]
  ├── cost: 1279.35569
  └── sort
       ├── columns: a:1(int)  [hidden: t.public.abc.b:2(int)]
@@ -114,7 +114,7 @@ expr
 ----
 explain
  ├── mode: distsql
- ├── stats: [rows=0]
+ ├── stats: [rows=10]
  ├── cost: 1050.03
  └── scan t.public.abc
       ├── columns: t.public.abc.a:1(int)

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -1104,8 +1104,8 @@ ORDER BY i_id
 scan item
  ├── columns: i_price:4(decimal) i_name:3(varchar) i_data:5(varchar)  [hidden: i_id:1(int!null)]
  ├── constraint: /1: [/25 - /25] [/50 - /50] [/75 - /75] [/100 - /100] [/125 - /125] [/150 - /150] [/175 - /175] [/200 - /200] [/225 - /225] [/250 - /250] [/275 - /275] [/300 - /300]
- ├── stats: [rows=11.8491602, distinct(1)=11.8491602, null(1)=0]
- ├── cost: 12.9255846
+ ├── stats: [rows=12, distinct(1)=12, null(1)=0]
+ ├── cost: 13.09
  ├── key: (1)
  ├── fd: (1)-->(3-5)
  ├── ordering: +1
@@ -2735,8 +2735,8 @@ ORDER BY i_id
 scan item
  ├── columns: i_price:4(decimal) i_name:3(varchar) i_data:5(varchar)  [hidden: i_id:1(int!null)]
  ├── constraint: /1: [/25 - /25] [/50 - /50] [/75 - /75] [/100 - /100] [/125 - /125] [/150 - /150] [/175 - /175] [/200 - /200] [/225 - /225] [/250 - /250] [/275 - /275] [/300 - /300]
- ├── stats: [rows=11.8491602, distinct(1)=11.8491602, null(1)=0]
- ├── cost: 12.9255846
+ ├── stats: [rows=12, distinct(1)=12, null(1)=0]
+ ├── cost: 13.09
  ├── key: (1)
  ├── fd: (1)-->(3-5)
  ├── ordering: +1

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -800,11 +800,11 @@ memo (optimized, ~5KB, required=[presentation: sum:5])
  ├── G1: (project G2 G3 sum)
  │    └── [presentation: sum:5]
  │         ├── best: (project G2 G3 sum)
- │         └── cost: 1082.04
+ │         └── cost: 1082.06
  ├── G2: (group-by G4 G5 cols=(3)) (group-by G4 G5 cols=(3),ordering=+3)
  │    └── []
  │         ├── best: (group-by G4="[ordering: +3]" G5 cols=(3),ordering=+3)
- │         └── cost: 1081.03
+ │         └── cost: 1081.04
  ├── G3: (projections)
  ├── G4: (scan kuvw,cols=(3,4)) (scan kuvw@uvw,cols=(3,4)) (scan kuvw@wvu,cols=(3,4)) (scan kuvw@vw,cols=(3,4)) (scan kuvw@w,cols=(3,4))
  │    ├── [ordering: +3]
@@ -825,11 +825,11 @@ memo (optimized, ~5KB, required=[presentation: array_agg:5])
  ├── G1: (project G2 G3 array_agg)
  │    └── [presentation: array_agg:5]
  │         ├── best: (project G2 G3 array_agg)
- │         └── cost: 1102.04
+ │         └── cost: 1102.06
  ├── G2: (group-by G4 G5 cols=(3),ordering=+2,+4 opt(3)) (group-by G4 G5 cols=(3),ordering=+2,+3,+4)
  │    └── []
  │         ├── best: (group-by G4="[ordering: +2,+4 opt(3)]" G5 cols=(3),ordering=+2,+4 opt(3))
- │         └── cost: 1101.03
+ │         └── cost: 1101.04
  ├── G3: (projections)
  ├── G4: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: +2,+3,+4]
@@ -1073,7 +1073,7 @@ memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4])
  ├── G1: (distinct-on G2 G3 cols=(2)) (distinct-on G2 G3 cols=(2),ordering=+2)
  │    └── [presentation: u:2,v:3,w:4]
  │         ├── best: (distinct-on G2="[ordering: +2]" G3 cols=(2),ordering=+2)
- │         └── cost: 1101.03
+ │         └── cost: 1101.04
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: +2]
  │    │    ├── best: (scan kuvw@uvw,cols=(2-4))
@@ -1095,7 +1095,7 @@ memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4])
  ├── G1: (distinct-on G2 G3 cols=(3)) (distinct-on G2 G3 cols=(3),ordering=+3)
  │    └── [presentation: u:2,v:3,w:4]
  │         ├── best: (distinct-on G2="[ordering: +3]" G3 cols=(3),ordering=+3)
- │         └── cost: 1101.03
+ │         └── cost: 1101.04
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: +3]
  │    │    ├── best: (scan kuvw@vw,cols=(2-4))
@@ -1117,7 +1117,7 @@ memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4])
  ├── G1: (distinct-on G2 G3 cols=(4)) (distinct-on G2 G3 cols=(4),ordering=+4)
  │    └── [presentation: u:2,v:3,w:4]
  │         ├── best: (distinct-on G2="[ordering: +4]" G3 cols=(4),ordering=+4)
- │         └── cost: 1101.03
+ │         └── cost: 1101.04
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: +4]
  │    │    ├── best: (scan kuvw@wvu,cols=(2-4))
@@ -1139,10 +1139,10 @@ memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4] [ordering: +2])
  ├── G1: (distinct-on G2 G3 cols=(2),ordering=+4 opt(2)) (distinct-on G2 G3 cols=(2),ordering=+4)
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +2]
  │    │    ├── best: (sort G1)
- │    │    └── cost: 1126.33
+ │    │    └── cost: 1126.52
  │    └── []
  │         ├── best: (distinct-on G2="[ordering: +4 opt(2)]" G3 cols=(2),ordering=+4 opt(2))
- │         └── cost: 1111.03
+ │         └── cost: 1111.04
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: +2,+4]
  │    │    ├── best: (sort G2)
@@ -1170,10 +1170,10 @@ memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4] [ordering: +2])
  ├── G1: (distinct-on G2 G3 cols=(2),ordering=+3,+4 opt(2)) (distinct-on G2 G3 cols=(2),ordering=+2,+3,+4) (distinct-on G2 G3 cols=(2),ordering=+3,+4)
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +2]
  │    │    ├── best: (distinct-on G2="[ordering: +2,+3,+4]" G3 cols=(2),ordering=+3,+4 opt(2))
- │    │    └── cost: 1101.03
+ │    │    └── cost: 1101.04
  │    └── []
  │         ├── best: (distinct-on G2="[ordering: +2,+3,+4]" G3 cols=(2),ordering=+2,+3,+4)
- │         └── cost: 1101.03
+ │         └── cost: 1101.04
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: +2,+3,+4]
  │    │    ├── best: (scan kuvw@uvw,cols=(2-4))
@@ -1226,10 +1226,10 @@ memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
  ├── G1: (distinct-on G2 G3 cols=(4),ordering=-2,+3 opt(4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +4]
  │    │    ├── best: (distinct-on G2="[ordering: +4,-2,+3]" G3 cols=(4),ordering=-2,+3 opt(4))
- │    │    └── cost: 1332.42
+ │    │    └── cost: 1332.43
  │    └── []
  │         ├── best: (distinct-on G2="[ordering: -2,+3 opt(4)]" G3 cols=(4),ordering=-2,+3 opt(4))
- │         └── cost: 1341.32
+ │         └── cost: 1341.33
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: +4,-2,+3]
  │    │    ├── best: (sort G2)
@@ -1253,10 +1253,10 @@ memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: -4])
  ├── G1: (distinct-on G2 G3 cols=(4),ordering=-2,+3 opt(4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: -4]
  │    │    ├── best: (distinct-on G2="[ordering: -4,-2,+3]" G3 cols=(4),ordering=-2,+3 opt(4))
- │    │    └── cost: 1332.42
+ │    │    └── cost: 1332.43
  │    └── []
  │         ├── best: (distinct-on G2="[ordering: -2,+3 opt(4)]" G3 cols=(4),ordering=-2,+3 opt(4))
- │         └── cost: 1341.32
+ │         └── cost: 1341.33
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: -2,+3 opt(4)]
  │    │    ├── best: (sort G2)
@@ -1280,10 +1280,10 @@ memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
  ├── G1: (distinct-on G2 G3 cols=(4),ordering=+2,-3 opt(4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +4]
  │    │    ├── best: (distinct-on G2="[ordering: +4,+2,-3]" G3 cols=(4),ordering=+2,-3 opt(4))
- │    │    └── cost: 1332.42
+ │    │    └── cost: 1332.43
  │    └── []
  │         ├── best: (distinct-on G2="[ordering: +2,-3 opt(4)]" G3 cols=(4),ordering=+2,-3 opt(4))
- │         └── cost: 1341.32
+ │         └── cost: 1341.33
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: +2,-3 opt(4)]
  │    │    ├── best: (sort G2)


### PR DESCRIPTION
This commit improves our statistics estimates so that we never estimate
zero rows unless the row count is provably zero (e.g., `SELECT ... WHERE false`).
We want to avoid estimating zero rows since the stats may be stale, and
we can end up with weird and inefficient plans if we estimate zero rows.

This commit also updates all estimates for distinct count and null count
to ensure that they are never larger than the row count. We also ensure
that there is at least one distinct or null value if row count > 0.

Fixes #32578

Release note: None