### PR TITLE
sql: improve interval math

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -1350,3 +1350,31 @@ SELECT '-239852040018-04-28':::DATE
 
 statement error out of range
 SELECT(7133080445639580613::INT8 + '1977-11-03'::DATE) = '-239852040018-04-28':::DATE
+
+subtest interval_math
+
+query TTTTTTT
+SELECT
+    i,
+    i / 2::INT8,
+    i * 2::INT8,
+    i / 2::FLOAT8,
+    i * 2::FLOAT8,
+    i / .2362::FLOAT8,
+    i * .2362::FLOAT8
+FROM
+    (
+        VALUES
+            ('1 day'::INTERVAL),
+            ('1 month'::INTERVAL),
+            ('1 hour'::INTERVAL),
+            ('1 month 2 days 4 hours'::INTERVAL)
+    )
+        AS v (i)
+ORDER BY
+    i
+----
+01:00:00               00:30:00          02:00:00                00:30:00          02:00:00                04:14:01.320914                 00:14:10.32
+1 day                  12:00:00          2 days                  12:00:00          2 days                  4 days 05:36:31.701948          05:40:07.68
+1 mon                  15 days           2 mons                  15 days           2 mons                  4 mons 7 days 00:15:51.058425   7 days 02:03:50.4
+1 mon 2 days 04:00:00  16 days 02:00:00  2 mons 4 days 08:00:00  16 days 02:00:00  2 mons 4 days 08:00:00  4 mons 15 days 28:24:59.745978  7 days 14:20:47.04

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -1037,7 +1037,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			RightType:  types.Interval,
 			ReturnType: types.Interval,
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
-				return &DInterval{Duration: right.(*DInterval).Duration.Mul(int64(MustBeDInt(left)))}, nil
+				return &DInterval{Duration: right.(*DInterval).Duration.Mul(float64(MustBeDInt(left)))}, nil
 			},
 		},
 		&BinOp{
@@ -1045,7 +1045,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			RightType:  types.Int,
 			ReturnType: types.Interval,
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
-				return &DInterval{Duration: left.(*DInterval).Duration.Mul(int64(MustBeDInt(right)))}, nil
+				return &DInterval{Duration: left.(*DInterval).Duration.Mul(float64(MustBeDInt(right)))}, nil
 			},
 		},
 		&BinOp{
@@ -1054,7 +1054,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			ReturnType: types.Interval,
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				r := float64(*right.(*DFloat))
-				return &DInterval{Duration: left.(*DInterval).Duration.MulFloat(r)}, nil
+				return &DInterval{Duration: left.(*DInterval).Duration.Mul(r)}, nil
 			},
 		},
 		&BinOp{
@@ -1063,7 +1063,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			ReturnType: types.Interval,
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				l := float64(*left.(*DFloat))
-				return &DInterval{Duration: right.(*DInterval).Duration.MulFloat(l)}, nil
+				return &DInterval{Duration: right.(*DInterval).Duration.Mul(l)}, nil
 			},
 		},
 		&BinOp{
@@ -1076,7 +1076,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 				if err != nil {
 					return nil, err
 				}
-				return &DInterval{Duration: right.(*DInterval).Duration.MulFloat(t)}, nil
+				return &DInterval{Duration: right.(*DInterval).Duration.Mul(t)}, nil
 			},
 		},
 		&BinOp{
@@ -1089,7 +1089,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 				if err != nil {
 					return nil, err
 				}
-				return &DInterval{Duration: left.(*DInterval).Duration.MulFloat(t)}, nil
+				return &DInterval{Duration: left.(*DInterval).Duration.Mul(t)}, nil
 			},
 		},
 	},
@@ -1175,7 +1175,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 				if rInt == 0 {
 					return nil, ErrDivByZero
 				}
-				return &DInterval{Duration: left.(*DInterval).Duration.Div(int64(rInt))}, nil
+				return &DInterval{Duration: left.(*DInterval).Duration.Div(float64(rInt))}, nil
 			},
 		},
 		&BinOp{
@@ -1187,7 +1187,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 				if r == 0.0 {
 					return nil, ErrDivByZero
 				}
-				return &DInterval{Duration: left.(*DInterval).Duration.DivFloat(r)}, nil
+				return &DInterval{Duration: left.(*DInterval).Duration.Div(r)}, nil
 			},
 		},
 	},

--- a/pkg/sql/sem/tree/interval.go
+++ b/pkg/sql/sem/tree/interval.go
@@ -287,7 +287,7 @@ func sqlStdToDuration(s string) (duration.Duration, error) {
 				month, errMonth = strconv.Atoi(yms[1])
 			}
 			if errYear == nil && errMonth == nil {
-				delta := duration.MakeDuration(0, 0, 1).Mul(int64(year)*12 + int64(month))
+				delta := duration.MakeDuration(0, 0, 1).Mul(float64(year)*12 + float64(month))
 				if neg {
 					d = d.Sub(delta)
 				} else {
@@ -322,7 +322,7 @@ func sqlStdToDuration(s string) (duration.Duration, error) {
 			} else if parsedIdx == hmsParsed {
 				// Day part.
 				// TODO(hainesc): support float value in day part?
-				delta := duration.MakeDuration(0, 1, 0).Mul(int64(value))
+				delta := duration.MakeDuration(0, 1, 0).Mul(float64(value))
 				if neg {
 					d = d.Sub(delta)
 				} else {
@@ -366,7 +366,7 @@ func iso8601ToDuration(s string) (duration.Duration, error) {
 		}
 
 		if unit, ok := unitMap[u]; ok {
-			d = d.Add(unit.Mul(v))
+			d = d.Add(unit.Mul(float64(v)))
 		} else {
 			return d, pgerror.Newf(
 				pgerror.CodeInvalidDatetimeFormatError,
@@ -456,7 +456,7 @@ func parseDuration(s string) (duration.Duration, error) {
 		l.consumeSpaces()
 		if unit, ok := unitMap[strings.ToLower(u)]; ok {
 			// A regular number followed by a unit, such as "9 day".
-			d = d.Add(unit.Mul(v))
+			d = d.Add(unit.Mul(float64(v)))
 			if hasDecimal {
 				d = addFrac(d, unit, vp)
 			}

--- a/pkg/util/duration/duration.go
+++ b/pkg/util/duration/duration.go
@@ -474,17 +474,7 @@ func (d Duration) Sub(x Duration) Duration {
 }
 
 // Mul returns a Duration representing a time length of d*x.
-func (d Duration) Mul(x int64) Duration {
-	return MakeDuration(d.nanos*x, d.Days*x, d.Months*x)
-}
-
-// Div returns a Duration representing a time length of d/x.
-func (d Duration) Div(x int64) Duration {
-	return MakeDuration(d.nanos/x, d.Days/x, d.Months/x)
-}
-
-// MulFloat returns a Duration representing a time length of d*x.
-func (d Duration) MulFloat(x float64) Duration {
+func (d Duration) Mul(x float64) Duration {
 	monthInt, monthFrac := math.Modf(float64(d.Months) * x)
 	dayInt, dayFrac := math.Modf((float64(d.Days) * x) + (monthFrac * daysInMonth))
 
@@ -495,12 +485,15 @@ func (d Duration) MulFloat(x float64) Duration {
 	)
 }
 
-// DivFloat returns a Duration representing a time length of d/x.
-func (d Duration) DivFloat(x float64) Duration {
+// Div returns a Duration representing a time length of d/x.
+func (d Duration) Div(x float64) Duration {
+	monthInt, monthFrac := math.Modf(float64(d.Months) / x)
+	dayInt, dayFrac := math.Modf((float64(d.Days) / x) + (monthFrac * daysInMonth))
+
 	return MakeDuration(
-		int64(float64(d.nanos)/x),
-		int64(float64(d.Days)/x),
-		int64(float64(d.Months)/x),
+		int64((float64(d.nanos)/x)+(dayFrac*float64(nanosInDay))),
+		int64(dayInt),
+		int64(monthInt),
 	)
 }
 

--- a/pkg/util/duration/duration_test.go
+++ b/pkg/util/duration/duration_test.go
@@ -344,50 +344,65 @@ func TestAddMicros(t *testing.T) {
 	}
 }
 
-func TestMulFloat(t *testing.T) {
+func TestFloatMath(t *testing.T) {
 	const nanosInMinute = nanosInSecond * 60
 	const nanosInHour = nanosInMinute * 60
 
 	tests := []struct {
 		d   Duration
 		f   float64
-		res Duration
+		mul Duration
+		div Duration
 	}{
 		{
 			Duration{Months: 1, Days: 2, nanos: nanosInHour * 2},
 			0.15,
 			Duration{Days: 4, nanos: nanosInHour*19 + nanosInMinute*30},
+			Duration{Months: 6, Days: 33, nanos: nanosInHour*21 + nanosInMinute*20},
 		},
 		{
 			Duration{Months: 1, Days: 2, nanos: nanosInHour * 2},
 			0.3,
 			Duration{Days: 9, nanos: nanosInHour * 15},
+			Duration{Months: 3, Days: 16, nanos: nanosInHour*22 + nanosInMinute*40},
 		},
 		{
 			Duration{Months: 1, Days: 2, nanos: nanosInHour * 2},
 			0.5,
 			Duration{Days: 16, nanos: nanosInHour * 1},
+			Duration{Months: 2, Days: 4, nanos: nanosInHour * 4},
 		},
 		{
 			Duration{Months: 1, Days: 2, nanos: nanosInHour * 2},
 			0.8,
 			Duration{Days: 25, nanos: nanosInHour * 16},
+			Duration{Months: 1, Days: 10, nanos: nanosInHour*2 + nanosInMinute*30},
 		},
 		{
 			Duration{Months: 1, Days: 17, nanos: nanosInHour * 2},
 			2.0,
 			Duration{Months: 2, Days: 34, nanos: nanosInHour * 4},
+			Duration{Days: 23, nanos: nanosInHour * 13},
 		},
 	}
 
 	for i, test := range tests {
-		if res := test.d.MulFloat(test.f); test.res != res {
+		if res := test.d.Mul(test.f); test.mul != res {
 			t.Errorf(
-				"%d: expected %v.MulFloat(%f) = %v, found %v",
+				"%d: expected %v.Mul(%f) = %v, found %v",
 				i,
 				test.d,
 				test.f,
-				test.res,
+				test.mul,
+				res)
+		}
+		if res := test.d.Div(test.f); test.div != res {
+			t.Errorf(
+				"%d: expected %v.Div(%f) = %v, found %v",
+				i,
+				test.d,
+				test.f,
+				test.div,
 				res)
 		}
 	}


### PR DESCRIPTION
In #37582 we added correct `interval * float` semantics. Here we extend that
to division.

In addition, remove the int variants because they need to share the same
semantics as float, so just force external users to cast their ints to
floats. None of our tests thus far have demonstrated a problem with the
possible precision loss for this operation. Since it was definitely incorrect
before this is an improvement. If we find some edge cases where the int ->
float conversion causes rounding or other problems we can revisit this
decision.

Release note (sql change): Correct interval math when multiplying or dividing
by floats or ints.