### PR TITLE
sql: don't copy ColumnFamilyDescriptor and IndexDescriptor by value in loops

### DIFF
--- a/pkg/kv/txn_interceptor_committer.go
+++ b/pkg/kv/txn_interceptor_committer.go
@@ -324,16 +324,15 @@ func (tc *txnCommitter) canCommitInParallelWithWrites(
 }
 
 // mergeIntoSpans merges all provided sequenced writes into the span slice. It
-// then sorts the spans and merges an that overlap. Returns true iff all of the
-// spans are distinct.
+// then sorts the spans and merges an that overlap. The function does not mutate
+// the provided span slice. Returns true iff all of the spans are distinct.
 func mergeIntoSpans(s []roachpb.Span, ws []roachpb.SequencedWrite) ([]roachpb.Span, bool) {
-	if s == nil {
-		s = make([]roachpb.Span, 0, len(ws))
+	m := make([]roachpb.Span, len(s)+len(ws))
+	copy(m, s)
+	for i, w := range ws {
+		m[len(s)+i] = roachpb.Span{Key: w.Key}
 	}
-	for _, w := range ws {
-		s = append(s, roachpb.Span{Key: w.Key})
-	}
-	return roachpb.MergeSpans(s)
+	return roachpb.MergeSpans(m)
 }
 
 // needTxnRetryAfterStaging determines whether the transaction needs to refresh

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -722,7 +722,8 @@ func neededColumnFamilyIDs(
 	colIdxMap := tableDesc.ColumnIdxMap()
 
 	var needed []sqlbase.FamilyID
-	for _, family := range tableDesc.Families {
+	for i := range tableDesc.Families {
+		family := &tableDesc.Families[i]
 		for _, columnID := range family.ColumnIDs {
 			columnOrdinal := colIdxMap[columnID]
 			if neededCols.Contains(columnOrdinal) {

--- a/pkg/sql/row/deleter.go
+++ b/pkg/sql/row/deleter.go
@@ -153,14 +153,15 @@ func (rd *Deleter) DeleteRow(
 	}
 
 	// Delete the row.
-	for i, family := range rd.Helper.TableDesc.Families {
+	for i := range rd.Helper.TableDesc.Families {
 		if i > 0 {
 			// HACK: MakeFamilyKey appends to its argument, so on every loop iteration
 			// after the first, trim primaryIndexKey so nothing gets overwritten.
 			// TODO(dan): Instead of this, use something like engine.ChunkAllocator.
 			primaryIndexKey = primaryIndexKey[:len(primaryIndexKey):len(primaryIndexKey)]
 		}
-		rd.key = keys.MakeFamilyKey(primaryIndexKey, uint32(family.ID))
+		familyID := rd.Helper.TableDesc.Families[i].ID
+		rd.key = keys.MakeFamilyKey(primaryIndexKey, uint32(familyID))
 		if traceKV {
 			log.VEventf(ctx, 2, "Del %s", keys.PrettyPrint(rd.Helper.primIndexValDirs, rd.key))
 		}

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -1199,9 +1199,10 @@ func (rf *Fetcher) checkPrimaryIndexDatumEncodings(ctx context.Context) error {
 
 	rh := rowHelper{TableDesc: table.desc, Indexes: table.desc.Indexes}
 
-	for _, family := range table.desc.Families {
+	for i := range table.desc.Families {
 		var lastColID sqlbase.ColumnID
-		familySortedColumnIDs, ok := rh.sortedColumnFamily(family.ID)
+		familyID := table.desc.Families[i].ID
+		familySortedColumnIDs, ok := rh.sortedColumnFamily(familyID)
 		if !ok {
 			panic("invalid family sorted column id map")
 		}
@@ -1213,7 +1214,7 @@ func (rf *Fetcher) checkPrimaryIndexDatumEncodings(ctx context.Context) error {
 				continue
 			}
 
-			if skip, err := rh.skipColumnInPK(colID, family.ID, rowVal.Datum); err != nil {
+			if skip, err := rh.skipColumnInPK(colID, familyID, rowVal.Datum); err != nil {
 				log.Errorf(ctx, "unexpected error: %s", err)
 				continue
 			} else if skip {

--- a/pkg/sql/row/helper.go
+++ b/pkg/sql/row/helper.go
@@ -50,8 +50,8 @@ func newRowHelper(
 	rh.primIndexValDirs = sqlbase.IndexKeyValDirs(&rh.TableDesc.PrimaryIndex)
 
 	rh.secIndexValDirs = make([][]encoding.Direction, len(rh.Indexes))
-	for i, index := range rh.Indexes {
-		rh.secIndexValDirs[i] = sqlbase.IndexKeyValDirs(&index)
+	for i := range rh.Indexes {
+		rh.secIndexValDirs[i] = sqlbase.IndexKeyValDirs(&rh.Indexes[i])
 	}
 
 	return rh

--- a/pkg/sql/row/helper.go
+++ b/pkg/sql/row/helper.go
@@ -129,7 +129,8 @@ func (rh *rowHelper) skipColumnInPK(
 func (rh *rowHelper) sortedColumnFamily(famID sqlbase.FamilyID) ([]sqlbase.ColumnID, bool) {
 	if rh.sortedColumnFamilies == nil {
 		rh.sortedColumnFamilies = make(map[sqlbase.FamilyID][]sqlbase.ColumnID, len(rh.TableDesc.Families))
-		for _, family := range rh.TableDesc.Families {
+		for i := range rh.TableDesc.Families {
+			family := &rh.TableDesc.Families[i]
 			colIDs := append([]sqlbase.ColumnID(nil), family.ColumnIDs...)
 			sort.Sort(sqlbase.ColumnIDs(colIDs))
 			rh.sortedColumnFamilies[family.ID] = colIDs

--- a/pkg/sql/row/inserter.go
+++ b/pkg/sql/row/inserter.go
@@ -147,7 +147,7 @@ func (ri *Inserter) InsertRow(
 	for i, val := range values {
 		// Make sure the value can be written to the column before proceeding.
 		var err error
-		if ri.marshaled[i], err = sqlbase.MarshalColumnValue(ri.InsertCols[i], val); err != nil {
+		if ri.marshaled[i], err = sqlbase.MarshalColumnValue(&ri.InsertCols[i], val); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -320,7 +320,7 @@ func (ru *Updater) UpdateRow(
 	// happen before index encoding because certain datum types (i.e. tuple)
 	// cannot be used as index values.
 	for i, val := range updateValues {
-		if ru.marshaled[i], err = sqlbase.MarshalColumnValue(ru.UpdateCols[i], val); err != nil {
+		if ru.marshaled[i], err = sqlbase.MarshalColumnValue(&ru.UpdateCols[i], val); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -232,16 +232,17 @@ func makeUpdaterWithoutCascader(
 		// If any part of a column family is being updated, fetch all columns in
 		// that column family so that we can reconstruct the column family with
 		// the updated columns before writing it.
-		for _, fam := range tableDesc.Families {
+		for i := range tableDesc.Families {
+			family := &tableDesc.Families[i]
 			familyBeingUpdated := false
-			for _, colID := range fam.ColumnIDs {
+			for _, colID := range family.ColumnIDs {
 				if _, ok := ru.UpdateColIDtoRowIndex[colID]; ok {
 					familyBeingUpdated = true
 					break
 				}
 			}
 			if familyBeingUpdated {
-				for _, colID := range fam.ColumnIDs {
+				for _, colID := range family.ColumnIDs {
 					if err := maybeAddCol(colID); err != nil {
 						return Updater{}, err
 					}

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -410,7 +410,8 @@ func (ru *Updater) UpdateRow(
 	// We're iterating through all of the indexes, which should have corresponding entries in both oldSecondaryIndexEntries
 	// and newSecondaryIndexEntries. Inverted indexes could potentially have more entries at the end of both and we will
 	// update those separately.
-	for i, index := range ru.Helper.Indexes {
+	for i := range ru.Helper.Indexes {
+		index := &ru.Helper.Indexes[i]
 		oldSecondaryIndexEntry := &oldSecondaryIndexEntries[i]
 		newSecondaryIndexEntry := &newSecondaryIndexEntries[i]
 

--- a/pkg/sql/row/writer.go
+++ b/pkg/sql/row/writer.go
@@ -87,7 +87,8 @@ func prepareInsertOrUpdateBatch(
 	putFn func(ctx context.Context, b putter, key *roachpb.Key, value *roachpb.Value, traceKV bool),
 	overwrite, traceKV bool,
 ) ([]byte, error) {
-	for i, family := range helper.TableDesc.Families {
+	for i := range helper.TableDesc.Families {
+		family := &helper.TableDesc.Families[i]
 		update := false
 		for _, colID := range family.ColumnIDs {
 			if _, ok := marshaledColIDMapping[colID]; ok {

--- a/pkg/sql/row/writer.go
+++ b/pkg/sql/row/writer.go
@@ -153,8 +153,7 @@ func prepareInsertOrUpdateBatch(
 				continue
 			}
 
-			col := fetchedCols[idx]
-
+			col := &fetchedCols[idx]
 			if lastColID > col.ID {
 				return nil, pgerror.AssertionFailedf("cannot write column id %d after %d", col.ID, lastColID)
 			}

--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -562,7 +562,7 @@ func EncodeDatumsKeyAscending(b []byte, d tree.Datums) ([]byte, error) {
 //
 // If val's type is incompatible with col, or if col's type is not yet
 // implemented by this function, an error is returned.
-func MarshalColumnValue(col ColumnDescriptor, val tree.Datum) (roachpb.Value, error) {
+func MarshalColumnValue(col *ColumnDescriptor, val tree.Datum) (roachpb.Value, error) {
 	var r roachpb.Value
 
 	if val == tree.DNull {

--- a/pkg/sql/sqlbase/column_type_encoding_test.go
+++ b/pkg/sql/sqlbase/column_type_encoding_test.go
@@ -197,7 +197,7 @@ func TestMarshalColumnValueRoundtrip(t *testing.T) {
 				desc := ColumnDescriptor{
 					Type: *typ,
 				}
-				value, err := MarshalColumnValue(desc, datum)
+				value, err := MarshalColumnValue(&desc, datum)
 				if err != nil {
 					return "error marshaling: " + err.Error()
 				}

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1518,8 +1518,8 @@ func (desc *TableDescriptor) validateTableIndexes(
 		}
 
 		if _, ok := indexNames[index.Name]; ok {
-			for _, idx := range desc.Indexes {
-				if idx.Name == index.Name {
+			for i := range desc.Indexes {
+				if desc.Indexes[i].Name == index.Name {
 					return fmt.Errorf("duplicate index name: %q", index.Name)
 				}
 			}
@@ -2153,9 +2153,10 @@ func (desc *TableDescriptor) FindIndexByName(name string) (*IndexDescriptor, boo
 	if desc.IsPhysicalTable() && desc.PrimaryIndex.Name == name {
 		return &desc.PrimaryIndex, false, nil
 	}
-	for i, idx := range desc.Indexes {
+	for i := range desc.Indexes {
+		idx := &desc.Indexes[i]
 		if idx.Name == name {
-			return &desc.Indexes[i], false, nil
+			return idx, false, nil
 		}
 	}
 	for _, m := range desc.Mutations {
@@ -2304,9 +2305,10 @@ func (desc *TableDescriptor) FindIndexByID(id IndexID) (*IndexDescriptor, error)
 	if desc.PrimaryIndex.ID == id {
 		return &desc.PrimaryIndex, nil
 	}
-	for i, c := range desc.Indexes {
-		if c.ID == id {
-			return &desc.Indexes[i], nil
+	for i := range desc.Indexes {
+		idx := &desc.Indexes[i]
+		if idx.ID == id {
+			return idx, nil
 		}
 	}
 	for _, m := range desc.Mutations {

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -991,7 +991,8 @@ func (desc *MutableTableDescriptor) allocateColumnFamilyIDs(columnNames map[stri
 	}
 
 	columnsInFamilies := make(map[ColumnID]struct{}, len(desc.Columns))
-	for i, family := range desc.Families {
+	for i := range desc.Families {
+		family := &desc.Families[i]
 		if family.ID == 0 && i != 0 {
 			family.ID = desc.NextFamilyID
 			desc.NextFamilyID++
@@ -1007,7 +1008,7 @@ func (desc *MutableTableDescriptor) allocateColumnFamilyIDs(columnNames map[stri
 			columnsInFamilies[family.ColumnIDs[j]] = struct{}{}
 		}
 
-		desc.Families[i] = family
+		desc.Families[i] = *family
 	}
 
 	primaryIndexColIDs := make(map[ColumnID]struct{}, len(desc.PrimaryIndex.ColumnIDs))
@@ -1064,7 +1065,8 @@ func (desc *MutableTableDescriptor) allocateColumnFamilyIDs(columnNames map[stri
 		}
 	}
 
-	for i, family := range desc.Families {
+	for i := range desc.Families {
+		family := &desc.Families[i]
 		if len(family.Name) == 0 {
 			family.Name = generatedFamilyName(family.ID, family.ColumnNames)
 		}
@@ -1084,7 +1086,7 @@ func (desc *MutableTableDescriptor) allocateColumnFamilyIDs(columnNames map[stri
 			family.DefaultColumnID = defaultColumnID
 		}
 
-		desc.Families[i] = family
+		desc.Families[i] = *family
 	}
 }
 
@@ -1440,7 +1442,8 @@ func (desc *TableDescriptor) validateColumnFamilies(
 	familyNames := map[string]struct{}{}
 	familyIDs := map[FamilyID]string{}
 	colIDToFamilyID := map[ColumnID]FamilyID{}
-	for _, family := range desc.Families {
+	for i := range desc.Families {
+		family := &desc.Families[i]
 		if err := validateName(family.Name, "family"); err != nil {
 			return nil, err
 		}
@@ -1957,8 +1960,8 @@ func (desc *MutableTableDescriptor) AddColumnToFamilyMaybeCreate(
 
 // RemoveColumnFromFamily removes a colID from the family it's assigned to.
 func (desc *MutableTableDescriptor) RemoveColumnFromFamily(colID ColumnID) {
-	for i, family := range desc.Families {
-		for j, c := range family.ColumnIDs {
+	for i := range desc.Families {
+		for j, c := range desc.Families[i].ColumnIDs {
 			if c == colID {
 				desc.Families[i].ColumnIDs = append(
 					desc.Families[i].ColumnIDs[:j], desc.Families[i].ColumnIDs[j+1:]...)
@@ -2124,9 +2127,10 @@ func (desc *TableDescriptor) FindActiveColumnByID(id ColumnID) (*ColumnDescripto
 func (desc *ImmutableTableDescriptor) FindReadableColumnByID(
 	id ColumnID,
 ) (*ColumnDescriptor, bool, error) {
-	for i, c := range desc.ReadableColumns {
+	for i := range desc.ReadableColumns {
+		c := &desc.ReadableColumns[i]
 		if c.ID == id {
-			return &desc.ReadableColumns[i], i >= len(desc.Columns), nil
+			return c, i >= len(desc.Columns), nil
 		}
 	}
 	return nil, false, fmt.Errorf("column-id \"%d\" does not exist", id)
@@ -2134,9 +2138,10 @@ func (desc *ImmutableTableDescriptor) FindReadableColumnByID(
 
 // FindFamilyByID finds the family with specified ID.
 func (desc *TableDescriptor) FindFamilyByID(id FamilyID) (*ColumnFamilyDescriptor, error) {
-	for i, f := range desc.Families {
-		if f.ID == id {
-			return &desc.Families[i], nil
+	for i := range desc.Families {
+		family := &desc.Families[i]
+		if family.ID == id {
+			return family, nil
 		}
 	}
 	return nil, fmt.Errorf("family-id \"%d\" does not exist", id)

--- a/pkg/sql/sqlbase/table_test.go
+++ b/pkg/sql/sqlbase/table_test.go
@@ -531,7 +531,7 @@ func TestMarshalColumnValue(t *testing.T) {
 		typ := testCase.typ
 		col := ColumnDescriptor{ID: ColumnID(typ.Family() + 1), Type: *typ}
 
-		if actual, err := MarshalColumnValue(col, testCase.datum); err != nil {
+		if actual, err := MarshalColumnValue(&col, testCase.datum); err != nil {
 			t.Errorf("%d: unexpected error with column type %v: %v", i, typ, err)
 		} else if !reflect.DeepEqual(actual, testCase.exp) {
 			t.Errorf("%d: MarshalColumnValue() got %v, expected %v", i, actual, testCase.exp)


### PR DESCRIPTION
`ColumnFamilyDescriptor`s are 80 bytes and `IndexDescriptor`s are 392 bytes, so they're too big to be copying by value when it's trivial to avoid doing so.

I was originally prompted to look into this when I saw the copy in `prepareInsertOrUpdateBatch` account for .59% of a CPU profile.

#### Performance diff (excluding the first commit):
```
name                       old time/op    new time/op    delta
KV/Insert/SQL/rows=1000-4    24.0ms ± 3%    23.6ms ± 2%  -1.88%  (p=0.027 n=10+8)

name                       old alloc/op   new alloc/op   delta
KV/Insert/SQL/rows=1000-4    4.89MB ± 0%    4.89MB ± 0%    ~     (p=0.796 n=10+10)

name                       old allocs/op  new allocs/op  delta
KV/Insert/SQL/rows=1000-4     26.8k ± 0%     26.8k ± 0%    ~     (p=0.838 n=10+10)
```