### PR TITLE
roachtest: set min version for indexes tests

### DIFF
--- a/pkg/cmd/roachtest/indexes.go
+++ b/pkg/cmd/roachtest/indexes.go
@@ -29,6 +29,8 @@ func registerNIndexes(r *registry, secondaryIndexes int) {
 	r.Add(testSpec{
 		Name:    fmt.Sprintf("indexes/%d/nodes=%d/multi-region", secondaryIndexes, nodes),
 		Cluster: makeClusterSpec(nodes+1, cpu(16), geo(), zones(geoZonesStr)),
+		// Uses CONFIGURE ZONE USING ... COPY FROM PARENT syntax.
+		MinVersion: `v19.1.0`,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			firstAZ := geoZones[0]
 			lastNodeInFirstAZ := nodes / 3


### PR DESCRIPTION
Fixes #37761.

The tests use the `CONFIGURE ZONE USING ... COPY FROM PARENT` syntax,
so they require at least version 19.1.0.

Release note: None