### PR TITLE
settings: move parallel commits behind cluster version gate

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -121,6 +121,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>19.1-3</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>19.1-4</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/kv/txn_interceptor_committer.go
+++ b/pkg/kv/txn_interceptor_committer.go
@@ -294,6 +294,9 @@ func (tc *txnCommitter) sendLockedWithElidedEndTransaction(
 func (tc *txnCommitter) canCommitInParallelWithWrites(
 	ba roachpb.BatchRequest, et *roachpb.EndTransactionRequest,
 ) bool {
+	if !tc.st.Version.IsActive(cluster.VersionParallelCommits) {
+		return false
+	}
 	if !parallelCommitsEnabled.Get(&tc.st.SV) {
 		return false
 	}

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -71,6 +71,7 @@ const (
 	VersionStart19_2
 	VersionQueryTxnTimestamp
 	VersionStickyBit
+	VersionParallelCommits
 
 	// Add new versions here (step one of two).
 
@@ -469,9 +470,14 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 2},
 	},
 	{
-		// VersionStickyBit is https://github.com/cockroachdb/cockroach/pull/37506
+		// VersionStickyBit is https://github.com/cockroachdb/cockroach/pull/37506.
 		Key:     VersionStickyBit,
 		Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 3},
+	},
+	{
+		// VersionParallelCommits is https://github.com/cockroachdb/cockroach/pull/37777.
+		Key:     VersionParallelCommits,
+		Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 4},
 	},
 
 	// Add new versions here (step two of two).


### PR DESCRIPTION
See #36983.

Release note: None