### PR TITLE
exec: implement MIN/MAX aggregations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -749,6 +749,7 @@ EXECGEN_TARGETS = \
   pkg/sql/exec/hashjoiner.eg.go \
   pkg/sql/exec/like_ops.eg.go \
   pkg/sql/exec/mergejoiner.eg.go \
+  pkg/sql/exec/min_max_agg.eg.go \
   pkg/sql/exec/projection_ops.eg.go \
   pkg/sql/exec/quicksort.eg.go \
   pkg/sql/exec/rowstovec.eg.go \
@@ -756,7 +757,8 @@ EXECGEN_TARGETS = \
   pkg/sql/exec/sort.eg.go \
   pkg/sql/exec/sum_agg.eg.go \
   pkg/sql/exec/tuples_differ.eg.go \
-  pkg/sql/exec/vec_comparators.eg.go
+  pkg/sql/exec/vec_comparators.eg.go \
+  pkg/sql/exec/zerocolumns.eg.go
 
 OPTGEN_TARGETS = \
 	pkg/sql/opt/memo/expr.og.go \
@@ -1407,12 +1409,14 @@ pkg/sql/exec/const.eg.go: pkg/sql/exec/const_tmpl.go
 pkg/sql/exec/distinct.eg.go: pkg/sql/exec/distinct_tmpl.go
 pkg/sql/exec/hashjoiner.eg.go: pkg/sql/exec/hashjoiner_tmpl.go
 pkg/sql/exec/mergejoiner.eg.go: pkg/sql/exec/mergejoiner_tmpl.go
+pkg/sql/exec/min_max_agg.eg.go: pkg/sql/exec/min_max_agg_tmpl.go
 pkg/sql/exec/quicksort.eg.go: pkg/sql/exec/quicksort_tmpl.go
 pkg/sql/exec/rowstovec.eg.go: pkg/sql/exec/rowstovec_tmpl.go
 pkg/sql/exec/sort.eg.go: pkg/sql/exec/sort_tmpl.go
 pkg/sql/exec/sum_agg.eg.go: pkg/sql/exec/sum_agg_tmpl.go
 pkg/sql/exec/tuples_differ.eg.go: pkg/sql/exec/tuples_differ_tmpl.go
 pkg/sql/exec/vec_comparators.eg.go: pkg/sql/exec/vec_comparators_tmpl.go
+pkg/sql/exec/zerocolumns.eg.go: pkg/sql/exec/zerocolumns_tmpl.go
 
 $(EXECGEN_TARGETS): bin/execgen
 	@# Remove generated files with the old suffix to avoid conflicts.

--- a/pkg/sql/exec/.gitignore
+++ b/pkg/sql/exec/.gitignore
@@ -7,6 +7,7 @@ distinct.eg.go
 hashjoiner.eg.go
 like_ops.eg.go
 mergejoiner.eg.go
+min_max_agg.eg.go
 projection_ops.eg.go
 quicksort.eg.go
 rowstovec.eg.go
@@ -15,3 +16,4 @@ sort.eg.go
 sum_agg.eg.go
 tuples_differ.eg.go
 vec_comparators.eg.go
+zerocolumns.eg.go

--- a/pkg/sql/exec/aggregator.go
+++ b/pkg/sql/exec/aggregator.go
@@ -194,6 +194,10 @@ func makeAggregateFuncs(
 			funcs[i], err = newSumAgg(aggTyps[i][0])
 		case distsqlpb.AggregatorSpec_COUNT_ROWS:
 			funcs[i] = newCountAgg()
+		case distsqlpb.AggregatorSpec_MIN:
+			funcs[i], err = newMinAgg(aggTyps[i][0])
+		case distsqlpb.AggregatorSpec_MAX:
+			funcs[i], err = newMaxAgg(aggTyps[i][0])
 		default:
 			return nil, nil, errors.Errorf("unsupported columnar aggregate function %d", aggFns[i])
 		}
@@ -271,7 +275,7 @@ func (a *orderedAggregator) Next(ctx context.Context) coldata.Batch {
 		// zero out a.groupCol. This is necessary because distinct ors the
 		// uniqueness of a value with the groupCol, allowing the operators to be
 		// linked.
-		copy(a.groupCol, zeroBoolVec)
+		copy(a.groupCol, zeroBoolColumn)
 	}
 
 	if a.scratch.resumeIdx > a.scratch.outputSize {

--- a/pkg/sql/exec/aggregator_test.go
+++ b/pkg/sql/exec/aggregator_test.go
@@ -388,8 +388,10 @@ func TestAggregatorAllFunctions(t *testing.T) {
 				distsqlpb.AggregatorSpec_AVG,
 				distsqlpb.AggregatorSpec_COUNT_ROWS,
 				distsqlpb.AggregatorSpec_SUM,
+				distsqlpb.AggregatorSpec_MIN,
+				distsqlpb.AggregatorSpec_MAX,
 			},
-			aggCols:  [][]uint32{{0}, {1}, {}, {2}},
+			aggCols:  [][]uint32{{0}, {1}, {}, {2}, {2}, {2}},
 			colTypes: []types.T{types.Int64, types.Decimal, types.Int64},
 			input: tuples{
 				{0, 3.1, 2},
@@ -401,10 +403,10 @@ func TestAggregatorAllFunctions(t *testing.T) {
 				{3, 5.1, 0},
 			},
 			expected: tuples{
-				{0, 2.1, 2, 5},
-				{1, 2.6, 2, 1},
-				{2, 1.1, 1, 1},
-				{3, 4.6, 2, 0},
+				{0, 2.1, 2, 5, 2, 3},
+				{1, 2.6, 2, 1, 0, 1},
+				{2, 1.1, 1, 1, 1, 1},
+				{3, 4.6, 2, 0, 0, 0},
 			},
 			convToDecimal: true,
 		},
@@ -421,7 +423,7 @@ func TestAggregatorAllFunctions(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					out := newOpTestOutput(a, []int{0, 1, 2, 3}, tc.expected)
+					out := newOpTestOutput(a, []int{0, 1, 2, 3, 4, 5}, tc.expected)
 					if err := out.Verify(); err != nil {
 						t.Fatal(err)
 					}
@@ -516,6 +518,8 @@ func BenchmarkAggregator(b *testing.B) {
 		distsqlpb.AggregatorSpec_AVG,
 		distsqlpb.AggregatorSpec_COUNT_ROWS,
 		distsqlpb.AggregatorSpec_SUM,
+		distsqlpb.AggregatorSpec_MIN,
+		distsqlpb.AggregatorSpec_MAX,
 	} {
 		fName := distsqlpb.AggregatorSpec_Func_name[int32(aggFn)]
 		b.Run(fName, func(b *testing.B) {

--- a/pkg/sql/exec/avg_agg_tmpl.go
+++ b/pkg/sql/exec/avg_agg_tmpl.go
@@ -90,9 +90,9 @@ func (a *avg_TYPEAgg) Init(groups []bool, v coldata.Vec) {
 }
 
 func (a *avg_TYPEAgg) Reset() {
-	copy(a.scratch.groupSums, zero_TYPEBatch)
-	copy(a.scratch.groupCounts, zeroInt64Batch)
-	copy(a.scratch.vec, zero_TYPEBatch)
+	copy(a.scratch.groupSums, zero_TYPEColumn)
+	copy(a.scratch.groupCounts, zeroInt64Column)
+	copy(a.scratch.vec, zero_TYPEColumn)
 	a.scratch.curIdx = -1
 	a.done = false
 }
@@ -104,11 +104,11 @@ func (a *avg_TYPEAgg) CurrentOutputIndex() int {
 func (a *avg_TYPEAgg) SetOutputIndex(idx int) {
 	if a.scratch.curIdx != -1 {
 		a.scratch.curIdx = idx
-		copy(a.scratch.groupSums[idx+1:], zero_TYPEBatch)
-		copy(a.scratch.groupCounts[idx+1:], zeroInt64Batch)
+		copy(a.scratch.groupSums[idx+1:], zero_TYPEColumn)
+		copy(a.scratch.groupCounts[idx+1:], zeroInt64Column)
 		// TODO(asubiotto): We might not have to zero a.scratch.vec since we
 		// overwrite with an independent value.
-		copy(a.scratch.vec[idx+1:], zero_TYPEBatch)
+		copy(a.scratch.vec[idx+1:], zero_TYPEColumn)
 	}
 }
 

--- a/pkg/sql/exec/bool_vec_to_sel.go
+++ b/pkg/sql/exec/bool_vec_to_sel.go
@@ -32,8 +32,6 @@ type boolVecToSelOp struct {
 
 var _ Operator = &boolVecToSelOp{}
 
-var zeroBoolVec = make([]bool, coldata.BatchSize)
-
 func (p *boolVecToSelOp) Next(ctx context.Context) coldata.Batch {
 	// Loop until we have non-zero amount of output to return, or our input's been
 	// exhausted.

--- a/pkg/sql/exec/count_agg.go
+++ b/pkg/sql/exec/count_agg.go
@@ -37,7 +37,7 @@ func (a *countAgg) Init(groups []bool, vec coldata.Vec) {
 func (a *countAgg) Reset() {
 	a.curIdx = -1
 	a.done = false
-	copy(a.vec, zeroInt64Batch)
+	copy(a.vec, zeroInt64Column)
 }
 
 func (a *countAgg) CurrentOutputIndex() int {
@@ -47,7 +47,7 @@ func (a *countAgg) CurrentOutputIndex() int {
 func (a *countAgg) SetOutputIndex(idx int) {
 	if a.curIdx != -1 {
 		a.curIdx = idx
-		copy(a.vec[idx+1:], zeroInt64Batch)
+		copy(a.vec[idx+1:], zeroInt64Column)
 	}
 }
 

--- a/pkg/sql/exec/distinct_tmpl.go
+++ b/pkg/sql/exec/distinct_tmpl.go
@@ -42,7 +42,7 @@ func OrderedDistinctColsToOperators(
 ) (Operator, []bool, error) {
 	distinctCol := make([]bool, coldata.BatchSize)
 	// zero the boolean column on every iteration.
-	input = fnOp{input: input, fn: func() { copy(distinctCol, zeroBoolVec) }}
+	input = fnOp{input: input, fn: func() { copy(distinctCol, zeroBoolColumn) }}
 	var err error
 	for i := range distinctCols {
 		input, err = newSingleOrderedDistinct(input, int(distinctCols[i]), distinctCol, typs[distinctCols[i]])

--- a/pkg/sql/exec/execgen/cmd/execgen/min_max_agg_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/min_max_agg_gen.go
@@ -1,0 +1,82 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"io"
+	"io/ioutil"
+	"regexp"
+	"strings"
+	"text/template"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+type aggOverloads struct {
+	Agg       distsqlpb.AggregatorSpec_Func
+	Overloads []*overload
+}
+
+// AggNameLower returns the aggregation name in lower case, e.g. "min".
+func (a aggOverloads) AggNameLower() string {
+	return strings.ToLower(a.Agg.String())
+}
+
+// AggNameTitle returns the aggregation name in title case, e.g. "Min".
+func (a aggOverloads) AggNameTitle() string {
+	return strings.Title(a.AggNameLower())
+}
+
+// Avoid unused warning for functions which are only used in templates.
+var _ = aggOverloads{}.AggNameLower()
+var _ = aggOverloads{}.AggNameTitle()
+
+func genMinMaxAgg(wr io.Writer) error {
+	t, err := ioutil.ReadFile("pkg/sql/exec/min_max_agg_tmpl.go")
+	if err != nil {
+		return err
+	}
+
+	s := string(t)
+	s = strings.Replace(s, "_AGG_TITLE", "{{.AggNameTitle}}", -1)
+	s = strings.Replace(s, "_AGG", "{{$agg}}", -1)
+	s = strings.Replace(s, "_GOTYPE", "{{.LTyp.GoTypeName}}", -1)
+	s = strings.Replace(s, "_TYPES_T", "types.{{.LTyp}}", -1)
+	s = strings.Replace(s, "_TYPE", "{{.LTyp}}", -1)
+
+	assignCmpRe := regexp.MustCompile(`_ASSIGN_CMP\((.*),(.*),(.*)\)`)
+	s = assignCmpRe.ReplaceAllString(s, "{{.Assign $1 $2 $3}}")
+
+	tmpl, err := template.New("min_max_agg").Parse(s)
+	if err != nil {
+		return err
+	}
+	data := []aggOverloads{
+		{
+			Agg:       distsqlpb.AggregatorSpec_MIN,
+			Overloads: comparisonOpToOverloads[tree.LT],
+		},
+		{
+			Agg:       distsqlpb.AggregatorSpec_MAX,
+			Overloads: comparisonOpToOverloads[tree.GT],
+		},
+	}
+	return tmpl.Execute(wr, data)
+}
+
+func init() {
+	registerGenerator(genMinMaxAgg, "min_max_agg.eg.go")
+}

--- a/pkg/sql/exec/execgen/cmd/execgen/zerocolumns_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/zerocolumns_gen.go
@@ -1,0 +1,45 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"io"
+	"io/ioutil"
+	"strings"
+	"text/template"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+func genZeroColumns(wr io.Writer) error {
+	t, err := ioutil.ReadFile("pkg/sql/exec/zerocolumns_tmpl.go")
+	if err != nil {
+		return err
+	}
+
+	s := string(t)
+	s = strings.Replace(s, "_GOTYPE", "{{.GoTypeName}}", -1)
+	s = strings.Replace(s, "_TYPE", "{{.}}", -1)
+
+	tmpl, err := template.New("zerocolumns").Parse(s)
+	if err != nil {
+		return err
+	}
+	return tmpl.Execute(wr, types.AllTypes)
+}
+
+func init() {
+	registerGenerator(genZeroColumns, "zerocolumns.eg.go")
+}

--- a/pkg/sql/exec/mergejoiner.go
+++ b/pkg/sql/exec/mergejoiner.go
@@ -399,7 +399,7 @@ func (o *mergeJoinOp) completeGroup(
 		}
 
 		// Zero out the distinct output for the next pass.
-		copy(input.distinctOutput, zeroBoolVec)
+		copy(input.distinctOutput, zeroBoolColumn)
 		loopStartIndex = 0
 
 		// Save the group to state.

--- a/pkg/sql/exec/sort_chunks.go
+++ b/pkg/sql/exec/sort_chunks.go
@@ -247,7 +247,7 @@ func (s *chunker) prepareNextChunks(ctx context.Context) chunkerReadingState {
 
 			// First, run the partitioners on our pre-sorted columns to determine the
 			// boundaries of the chunks (stored in s.chunks) to sort further.
-			copy(s.partitionCol, zeroBoolVec)
+			copy(s.partitionCol, zeroBoolColumn)
 			for i, orderedCol := range s.alreadySortedCols {
 				s.partitioners[i].partition(s.batch.ColVec(int(orderedCol.ColIdx)), s.partitionCol, uint64(s.batch.Length()))
 			}
@@ -400,7 +400,7 @@ func (s *chunker) getPartitionsCol() []bool {
 			// per spooler's contract, we return nil.
 			return nil
 		}
-		copy(s.partitionCol, zeroBoolVec)
+		copy(s.partitionCol, zeroBoolColumn)
 		for i := s.chunksStartIdx; i < len(s.chunks)-1; i++ {
 			// getValues returns a slice starting from s.chunks[s.chunksStartIdx], so
 			// we need to account for that by shifting as well.

--- a/pkg/sql/exec/zerocolumns_tmpl.go
+++ b/pkg/sql/exec/zerocolumns_tmpl.go
@@ -1,0 +1,42 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// {{/*
+// +build execgen_template
+//
+// This file is the execgen template for min_agg.eg.go. It's formatted in a
+// special way, so it's both valid Go and a valid text/template input. This
+// permits editing this file with editor support.
+//
+// */}}
+
+package exec
+
+import (
+	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+)
+
+// {{/*
+// Declarations to make the template compile properly
+
+// Dummy import to pull in "apd" package.
+var _ apd.Decimal
+
+// */}}
+
+// {{range .}}
+var zero_TYPEColumn = make([]_GOTYPE, coldata.BatchSize)
+
+// {{end}}


### PR DESCRIPTION
I added vectorized implementations for MIN and MAX. This is fairly
similar to SUM, though a bit of extra templating logic was necessary to
be able to reuse the same template for both MIN and MAX.

Like the other aggregations we've implemented so far, these do not yet
handle NULLs.

I also added another template for generating zeroed out columns for all
types.T, since this is used in several places.

Fixes #37700

Release note: None