### PR TITLE
release-19.1: storage: don't backpressure writes to the system config span

### DIFF
--- a/pkg/storage/replica_backpressure.go
+++ b/pkg/storage/replica_backpressure.go
@@ -63,7 +63,9 @@ var backpressurableReqMethods = util.MakeFastIntSet(
 // to be backpressured.
 var backpressurableSpans = []roachpb.Span{
 	{Key: keys.TimeseriesPrefix, EndKey: keys.TimeseriesKeyMax},
-	{Key: keys.TableDataMin, EndKey: keys.TableDataMax},
+	// Backpressure from the end of the system config forward instead of
+	// over all table data to avoid backpressuring unsplittable ranges.
+	{Key: keys.SystemConfigTableDataMax, EndKey: keys.TableDataMax},
 }
 
 // canBackpressureBatch returns whether the provided BatchRequest is eligible


### PR DESCRIPTION
Backport 1/1 commits from #37605.

/cc @cockroachdb/release

---

We're seeing in multiple issues (e.g. #35842, #37337, #37530, etc.) that write backpressure is kicking in on the system config span range itself. This is a serious issue because it means that write backpressure can't be disabled using the `kv.range.backpressure_range_size_multiplier` cluster setting.

The reason for the system config span growth is still somewhat unclear and it is being tracked https://github.com/cockroachdb/cockroach/issues/34211#issuecomment-494109750. It's likely that it has to do with a runaway schema change that continuously grabs and releases a schema change lease. This is an issue and should be fixed, but letting this cause such devastation to a cluster is a problem. To address this, this commit disables write backpressure on the system config span.

Release note: None
