### PR TITLE
storage: relax assertion about "prevented" parallel commits that succeed

### DIFF
--- a/pkg/storage/batcheval/cmd_recover_txn_test.go
+++ b/pkg/storage/batcheval/cmd_recover_txn_test.go
@@ -158,7 +158,6 @@ func TestRecoverTxnRecordChanged(t *testing.T) {
 		{
 			name:                "transaction commit after write prevented",
 			implicitlyCommitted: false,
-			expError:            "found COMMITTED record for prevented implicit commit",
 			changedTxn: func() roachpb.Transaction {
 				txnCopy := txn
 				txnCopy.Status = roachpb.COMMITTED


### PR DESCRIPTION
I was seeing the following assertion fire when running TPC-C:
```
programming error: found COMMITTED record for prevented implicit commit
```

This was very concerning until I realized that the assertion was not taking into account how QueryIntent requests interact with resolved writes.

If a transaction recovery process believes it successfully prevented a write that was in-flight while a transaction was performing a parallel commit then we would expect that the transaction record could only be committed if it has a higher epoch or timestamp. This is true if the recovery process did actually prevent the in-flight write.

However, due to QueryIntent's implementation, a successful intent write that was already resolved after the parallel commit finished can be mistaken for a missing in-flight write by a recovery process. This ambiguity is harmless, as the transaction stays committed either way, but it means that we can't be quite as strict about what we assert in RecoverTxn as we would like to be.

The PR starts by modeling intent resolution to demonstrate that it can cause the assertion to fire. It then fixes (read: removes) the assertion in the next commit.