### PR TITLE
release-19.1: distsqlpb: whitelist node unavailability errors

### DIFF
--- a/pkg/sql/distsqlpb/data.go
+++ b/pkg/sql/distsqlpb/data.go
@@ -164,6 +164,9 @@ func (e *Error) ErrorDetail() error {
 	case *Error_RetryableTxnError:
 		return t.RetryableTxnError
 	default:
-		panic(fmt.Sprintf("bad error detail: %+v", t))
+		// We're receiving an error we don't know about. It's all right,
+		// it's still an error, just one we didn't expect. Let it go
+		// through. We'll pick it up in reporting.
+		return pgerror.NewAssertionErrorf("unknown error detail type: %+v", t)
 	}
 }

--- a/pkg/sql/pgwire/pgerror/codes.go
+++ b/pkg/sql/pgwire/pgerror/codes.go
@@ -296,4 +296,9 @@ const (
 	CodeInternalError       = "XX000"
 	CodeDataCorruptedError  = "XX001"
 	CodeIndexCorruptedError = "XX002"
+
+	// RangeUnavailable signals that some data from the cluster cannot be
+	// accessed (e.g. because all replicas awol).
+	// We're using the postgres "Internal Error" error class "XX".
+	CodeRangeUnavailable = "XXC00"
 )

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -191,7 +191,7 @@ func isPermanentSchemaChangeError(err error) bool {
 		case pgerror.CodeSerializationFailureError, pgerror.CodeConnectionFailureError:
 			return false
 
-		case pgerror.CodeInternalError:
+		case pgerror.CodeInternalError, pgerror.CodeRangeUnavailable:
 			if strings.Contains(err.Message, context.DeadlineExceeded.Error()) {
 				return false
 			}


### PR DESCRIPTION
Backport 2/2 commits from #37367.
Backport 1/1 commits from #37800.

/cc @cockroachdb/release

---

Fixes #37215.

A node being down during distsql query processing is a legitimate (and
expected) error. It needs not be reported to telemetry.
