### PR TITLE
sql: filter KV TRACEs in interleaved test

### DIFF
--- a/pkg/sql/logictest/testdata/planner_test/interleaved
+++ b/pkg/sql/logictest/testdata/planner_test/interleaved
@@ -238,16 +238,14 @@ c_id  a_id  b_id
 statement ok
 SET TRACING = on,kv,results; DELETE FROM a where a_id <= 7 and a_id >= 5; SET tracing = off
 
+# Only look at traces from SQL land.
 query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION]
+WHERE operation='flow' OR operation LIKE 'exec cmd:%'
 ----
 DelRange /Table/61/1/5 - /Table/61/1/7/NULL
-querying next range at /Table/61/1/5
-r20: sending batch 1 DelRng to (n1,s1):1
 fast path completed
 rows affected: 3
-querying next range at /Table/61/1/5
-r20: sending batch 1 EndTxn to (n1,s1):1
 
 query II colnames
 select * from b order by a_id, b_id
@@ -283,15 +281,12 @@ statement ok
 SET TRACING = on,kv,results; DELETE FROM a; SET tracing = off
 
 query T
-select message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION]
+WHERE operation='flow' OR operation LIKE 'exec cmd:%'
 ----
 DelRange /Table/61/1 - /Table/61/3
-querying next range at /Table/61/1
-r20: sending batch 1 DelRng to (n1,s1):1
 fast path completed
 rows affected: 5
-querying next range at /Table/61/1
-r20: sending batch 1 EndTxn to (n1,s1):1
 
 query II colnames
 select * from b order by a_id, b_id
@@ -328,233 +323,99 @@ statement ok
 SET TRACING=off;
 
 query T
-select message FROM [SHOW KV TRACE FOR SESSION];
+SELECT message FROM [SHOW KV TRACE FOR SESSION]
+WHERE operation IN ('flow', 'consuming rows') OR operation LIKE 'exec cmd:%'
 ----
-Scan /Table/61/{1-2}
-querying next range at /Table/61/1
-r20: sending batch 1 Scan to (n1,s1):1
-fetched: /a/primary/1 -> NULL
 Del /Table/61/1/1/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/1/#/62/{1-2}
-querying next range at /Table/61/1/1/#/62/1
-r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/1/#/62/1/1{-/#}
-querying next range at /Table/61/1/1/#/62/1/1
-r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/1/#/62/1/1/0
-querying next range at /Table/61/1/1/#/62/1/1/0
-r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/1/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/1/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/1/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/1/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/1/#/62/{1-2}
-querying next range at /Table/61/1/1/#/62/1
-r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
-fetched: /a/primary/2 -> NULL
 Del /Table/61/1/2/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/2/#/62/{1-2}
-querying next range at /Table/61/1/2/#/62/1
-r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/2/#/62/1/1{-/#}
-querying next range at /Table/61/1/2/#/62/1/1
-r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/2/#/62/1/1/0
-querying next range at /Table/61/1/2/#/62/1/1/0
-r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/2/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/2/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/2/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/2/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/2/#/62/{1-2}
-querying next range at /Table/61/1/2/#/62/1
-r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
-fetched: /a/primary/3 -> NULL
 Del /Table/61/1/3/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/3/#/62/{1-2}
-querying next range at /Table/61/1/3/#/62/1
-r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/3/#/62/1/1{-/#}
-querying next range at /Table/61/1/3/#/62/1/1
-r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/3/#/62/1/1/0
-querying next range at /Table/61/1/3/#/62/1/1/0
-r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/3/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/3/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/3/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/3/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/3/#/62/{1-2}
-querying next range at /Table/61/1/3/#/62/1
-r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
-fetched: /a/primary/4 -> NULL
 Del /Table/61/1/4/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/4/#/62/{1-2}
-querying next range at /Table/61/1/4/#/62/1
-r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/4/#/62/1/1{-/#}
-querying next range at /Table/61/1/4/#/62/1/1
-r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/4/#/62/1/1/0
-querying next range at /Table/61/1/4/#/62/1/1/0
-r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/4/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/4/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/4/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/4/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/4/#/62/{1-2}
-querying next range at /Table/61/1/4/#/62/1
-r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
-fetched: /a/primary/5 -> NULL
 Del /Table/61/1/5/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/5/#/62/{1-2}
-querying next range at /Table/61/1/5/#/62/1
-r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/5/#/62/1/1{-/#}
-querying next range at /Table/61/1/5/#/62/1/1
-r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/5/#/62/1/1/0
-querying next range at /Table/61/1/5/#/62/1/1/0
-r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/5/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/5/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/5/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/5/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/5/#/62/{1-2}
-querying next range at /Table/61/1/5/#/62/1
-r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
-fetched: /a/primary/6 -> NULL
 Del /Table/61/1/6/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/6/#/62/{1-2}
-querying next range at /Table/61/1/6/#/62/1
-r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/6/#/62/1/1{-/#}
-querying next range at /Table/61/1/6/#/62/1/1
-r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/6/#/62/1/1/0
-querying next range at /Table/61/1/6/#/62/1/1/0
-r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/6/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/6/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/6/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/6/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/6/#/62/{1-2}
-querying next range at /Table/61/1/6/#/62/1
-r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
-fetched: /a/primary/7 -> NULL
 Del /Table/61/1/7/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/7/#/62/{1-2}
-querying next range at /Table/61/1/7/#/62/1
-r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/7/#/62/1/1{-/#}
-querying next range at /Table/61/1/7/#/62/1/1
-r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/7/#/62/1/1/0
-querying next range at /Table/61/1/7/#/62/1/1/0
-r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/7/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/7/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/7/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/7/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/7/#/62/{1-2}
-querying next range at /Table/61/1/7/#/62/1
-r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
-fetched: /a/primary/8 -> NULL
 Del /Table/61/1/8/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/8/#/62/{1-2}
-querying next range at /Table/61/1/8/#/62/1
-r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/8/#/62/1/1{-/#}
-querying next range at /Table/61/1/8/#/62/1/1
-r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/8/#/62/1/1/0
-querying next range at /Table/61/1/8/#/62/1/1/0
-r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/8/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/8/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/8/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/8/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/8/#/62/{1-2}
-querying next range at /Table/61/1/8/#/62/1
-r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
-fetched: /a/primary/9 -> NULL
 Del /Table/61/1/9/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/9/#/62/{1-2}
-querying next range at /Table/61/1/9/#/62/1
-r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/9/#/62/1/1{-/#}
-querying next range at /Table/61/1/9/#/62/1/1
-r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/9/#/62/1/1/0
-querying next range at /Table/61/1/9/#/62/1/1/0
-r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/9/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/9/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/9/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/9/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/9/#/62/{1-2}
-querying next range at /Table/61/1/9/#/62/1
-r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
-fetched: /a/primary/10 -> NULL
 Del /Table/61/1/10/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/10/#/62/{1-2}
-querying next range at /Table/61/1/10/#/62/1
-r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/10/#/62/1/1{-/#}
-querying next range at /Table/61/1/10/#/62/1/1
-r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/10/#/62/1/1/0
-querying next range at /Table/61/1/10/#/62/1/1/0
-r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/10/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/10/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/10/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/10/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/10/#/62/{1-2}
-querying next range at /Table/61/1/10/#/62/1
-r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
-querying next range at /Table/61/1/1/0
-r20: sending batch 10 Del, 1 EndTxn to (n1,s1):1
 output row: [1]
 output row: [2]
 output row: [3]

--- a/pkg/sql/opt/exec/execbuilder/testdata/interleaved
+++ b/pkg/sql/opt/exec/execbuilder/testdata/interleaved
@@ -238,16 +238,14 @@ c_id  a_id  b_id
 statement ok
 SET TRACING = on,kv,results; DELETE FROM a where a_id <= 7 and a_id >= 5; SET tracing = off
 
+# Only look at traces from SQL land.
 query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION]
+WHERE operation='flow' OR operation LIKE 'exec cmd:%'
 ----
 DelRange /Table/61/1/5 - /Table/61/1/7/NULL
-querying next range at /Table/61/1/5
-r20: sending batch 1 DelRng to (n1,s1):1
 fast path completed
 rows affected: 3
-querying next range at /Table/61/1/5
-r20: sending batch 1 EndTxn to (n1,s1):1
 
 query II colnames
 select * from b order by a_id, b_id
@@ -283,15 +281,12 @@ statement ok
 SET TRACING = on,kv,results; DELETE FROM a; SET tracing = off
 
 query T
-select message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION]
+WHERE operation='flow' OR operation LIKE 'exec cmd:%'
 ----
 DelRange /Table/61/1 - /Table/61/3
-querying next range at /Table/61/1
-r20: sending batch 1 DelRng to (n1,s1):1
 fast path completed
 rows affected: 5
-querying next range at /Table/61/1
-r20: sending batch 1 EndTxn to (n1,s1):1
 
 query II colnames
 select * from b order by a_id, b_id
@@ -328,233 +323,99 @@ statement ok
 SET TRACING=off;
 
 query T
-select message FROM [SHOW KV TRACE FOR SESSION];
+SELECT message FROM [SHOW KV TRACE FOR SESSION]
+WHERE operation IN ('flow', 'consuming rows') OR operation LIKE 'exec cmd:%'
 ----
-Scan /Table/61/{1-2}
-querying next range at /Table/61/1
-r20: sending batch 1 Scan to (n1,s1):1
-fetched: /a/primary/1 -> NULL
 Del /Table/61/1/1/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/1/#/62/{1-2}
-querying next range at /Table/61/1/1/#/62/1
-r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/1/#/62/1/1{-/#}
-querying next range at /Table/61/1/1/#/62/1/1
-r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/1/#/62/1/1/0
-querying next range at /Table/61/1/1/#/62/1/1/0
-r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/1/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/1/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/1/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/1/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/1/#/62/{1-2}
-querying next range at /Table/61/1/1/#/62/1
-r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
-fetched: /a/primary/2 -> NULL
 Del /Table/61/1/2/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/2/#/62/{1-2}
-querying next range at /Table/61/1/2/#/62/1
-r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/2/#/62/1/1{-/#}
-querying next range at /Table/61/1/2/#/62/1/1
-r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/2/#/62/1/1/0
-querying next range at /Table/61/1/2/#/62/1/1/0
-r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/2/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/2/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/2/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/2/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/2/#/62/{1-2}
-querying next range at /Table/61/1/2/#/62/1
-r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
-fetched: /a/primary/3 -> NULL
 Del /Table/61/1/3/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/3/#/62/{1-2}
-querying next range at /Table/61/1/3/#/62/1
-r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/3/#/62/1/1{-/#}
-querying next range at /Table/61/1/3/#/62/1/1
-r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/3/#/62/1/1/0
-querying next range at /Table/61/1/3/#/62/1/1/0
-r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/3/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/3/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/3/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/3/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/3/#/62/{1-2}
-querying next range at /Table/61/1/3/#/62/1
-r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
-fetched: /a/primary/4 -> NULL
 Del /Table/61/1/4/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/4/#/62/{1-2}
-querying next range at /Table/61/1/4/#/62/1
-r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/4/#/62/1/1{-/#}
-querying next range at /Table/61/1/4/#/62/1/1
-r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/4/#/62/1/1/0
-querying next range at /Table/61/1/4/#/62/1/1/0
-r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/4/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/4/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/4/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/4/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/4/#/62/{1-2}
-querying next range at /Table/61/1/4/#/62/1
-r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
-fetched: /a/primary/5 -> NULL
 Del /Table/61/1/5/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/5/#/62/{1-2}
-querying next range at /Table/61/1/5/#/62/1
-r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/5/#/62/1/1{-/#}
-querying next range at /Table/61/1/5/#/62/1/1
-r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/5/#/62/1/1/0
-querying next range at /Table/61/1/5/#/62/1/1/0
-r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/5/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/5/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/5/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/5/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/5/#/62/{1-2}
-querying next range at /Table/61/1/5/#/62/1
-r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
-fetched: /a/primary/6 -> NULL
 Del /Table/61/1/6/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/6/#/62/{1-2}
-querying next range at /Table/61/1/6/#/62/1
-r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/6/#/62/1/1{-/#}
-querying next range at /Table/61/1/6/#/62/1/1
-r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/6/#/62/1/1/0
-querying next range at /Table/61/1/6/#/62/1/1/0
-r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/6/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/6/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/6/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/6/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/6/#/62/{1-2}
-querying next range at /Table/61/1/6/#/62/1
-r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
-fetched: /a/primary/7 -> NULL
 Del /Table/61/1/7/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/7/#/62/{1-2}
-querying next range at /Table/61/1/7/#/62/1
-r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/7/#/62/1/1{-/#}
-querying next range at /Table/61/1/7/#/62/1/1
-r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/7/#/62/1/1/0
-querying next range at /Table/61/1/7/#/62/1/1/0
-r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/7/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/7/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/7/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/7/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/7/#/62/{1-2}
-querying next range at /Table/61/1/7/#/62/1
-r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
-fetched: /a/primary/8 -> NULL
 Del /Table/61/1/8/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/8/#/62/{1-2}
-querying next range at /Table/61/1/8/#/62/1
-r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/8/#/62/1/1{-/#}
-querying next range at /Table/61/1/8/#/62/1/1
-r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/8/#/62/1/1/0
-querying next range at /Table/61/1/8/#/62/1/1/0
-r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/8/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/8/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/8/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/8/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/8/#/62/{1-2}
-querying next range at /Table/61/1/8/#/62/1
-r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
-fetched: /a/primary/9 -> NULL
 Del /Table/61/1/9/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/9/#/62/{1-2}
-querying next range at /Table/61/1/9/#/62/1
-r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/9/#/62/1/1{-/#}
-querying next range at /Table/61/1/9/#/62/1/1
-r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/9/#/62/1/1/0
-querying next range at /Table/61/1/9/#/62/1/1/0
-r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/9/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/9/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/9/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/9/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/9/#/62/{1-2}
-querying next range at /Table/61/1/9/#/62/1
-r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
-fetched: /a/primary/10 -> NULL
 Del /Table/61/1/10/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/10/#/62/{1-2}
-querying next range at /Table/61/1/10/#/62/1
-r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/10/#/62/1/1{-/#}
-querying next range at /Table/61/1/10/#/62/1/1
-r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/10/#/62/1/1/0
-querying next range at /Table/61/1/10/#/62/1/1/0
-r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/10/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/10/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/10/#/62/1/1/#/63/{1-2}
-querying next range at /Table/61/1/10/#/62/1/1/#/63/1
-r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/10/#/62/{1-2}
-querying next range at /Table/61/1/10/#/62/1
-r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
-querying next range at /Table/61/1/1/0
-r20: sending batch 10 Del to (n1,s1):1
 output row: [1]
 output row: [2]
 output row: [3]
@@ -566,10 +427,6 @@ output row: [8]
 output row: [9]
 output row: [10]
 rows affected: 10
-querying next range at /Table/61/1/1/#/62/1/1/0
-r20: sending batch 1 EndTxn to (n1,s1):1
-querying next range at /Table/61/1/1/0
-r20: sending batch 10 QueryIntent to (n1,s1):1
 
 statement ok
 DROP TABLE c; DROP TABLE b; DROP TABLE a


### PR DESCRIPTION
Testcases with full KV traces are flaky because they can change when
KV internals change. We should only care about the SQL-level traces in
these tests.

Fixes #37756.

Release note: None