### PR TITLE
sql: fix schema change auto-retry upon node failures

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -221,7 +221,7 @@ func isPermanentSchemaChangeError(err error) bool {
 		case pgerror.CodeSerializationFailureError, pgerror.CodeConnectionFailureError:
 			return false
 
-		case pgerror.CodeInternalError:
+		case pgerror.CodeInternalError, pgerror.CodeRangeUnavailable:
 			if strings.Contains(err.Message, context.DeadlineExceeded.Error()) {
 				return false
 			}


### PR DESCRIPTION
Prior to #37367, a node unavailable error was reported in distsql as
a pgerror with code "internal" (assertion). Change #37367 changes this
to report node availability using a different code.

Meanwhile, the schema change logic wants to be able to retry if a
schema change appears to fail due a node going down. Since this is not
exercised in CI (only in nightly test), #37367 forgot about that. This
commit completes the fix.

(Note that this dance with error codes are band-aids; a more robust
fix is upcoming in #37765 and following.)

Release note: None