### PR TITLE
colserde: add serde for the arrow file format

### DIFF
--- a/pkg/sql/exec/colrpc/inbox.go
+++ b/pkg/sql/exec/colrpc/inbox.go
@@ -79,6 +79,7 @@ type Inbox struct {
 
 	scratch struct {
 		data []*array.Data
+		b    coldata.Batch
 	}
 }
 
@@ -103,6 +104,7 @@ func NewInbox(typs []types.T) (*Inbox, error) {
 	}
 	i.zeroBatch.SetLength(0)
 	i.scratch.data = make([]*array.Data, len(typs))
+	i.scratch.b = coldata.NewMemBatch(typs)
 	return i, nil
 }
 
@@ -249,11 +251,10 @@ func (i *Inbox) Next(ctx context.Context) coldata.Batch {
 		if err := i.serializer.Deserialize(&i.scratch.data, m.Data.RawBytes); err != nil {
 			panic(err)
 		}
-		b, err := i.converter.ArrowToBatch(i.scratch.data)
-		if err != nil {
+		if err := i.converter.ArrowToBatch(i.scratch.data, i.scratch.b); err != nil {
 			panic(err)
 		}
-		return b
+		return i.scratch.b
 	}
 }
 

--- a/pkg/sql/exec/colrpc/outbox.go
+++ b/pkg/sql/exec/colrpc/outbox.go
@@ -203,7 +203,7 @@ func (o *Outbox) sendBatches(
 			log.Errorf(ctx, "Outbox BatchToArrow data serialization error: %+v", err)
 			return false, err
 		}
-		if err := o.serializer.Serialize(o.scratch.buf, d); err != nil {
+		if _, _, err := o.serializer.Serialize(o.scratch.buf, d); err != nil {
 			log.Errorf(ctx, "Outbox Serialize data error: %+v", err)
 			return false, err
 		}

--- a/pkg/sql/exec/colserde/arrowbatchconverter.go
+++ b/pkg/sql/exec/colserde/arrowbatchconverter.go
@@ -40,9 +40,8 @@ type ArrowBatchConverter struct {
 	}
 
 	scratch struct {
-		// batch and arrowData are used as scratch space returned as the corresponding
+		// arrowData is used as scratch space returned as the corresponding
 		// conversion result.
-		batch     coldata.Batch
 		arrowData []*array.Data
 		// buffers is scratch space for exactly two buffers per element in
 		// arrowData.
@@ -57,7 +56,6 @@ func NewArrowBatchConverter(typs []types.T) *ArrowBatchConverter {
 	c := &ArrowBatchConverter{typs: typs}
 	c.builders.boolBuilder = array.NewBooleanBuilder(memory.DefaultAllocator)
 	c.builders.binaryBuilder = array.NewBinaryBuilder(memory.DefaultAllocator, arrow.BinaryTypes.Binary)
-	c.scratch.batch = coldata.NewMemBatch(typs)
 	c.scratch.arrowData = make([]*array.Data, len(typs))
 	c.scratch.buffers = make([][]*memory.Buffer, len(typs))
 	for i := range c.scratch.buffers {
@@ -182,16 +180,32 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]*array.Data, 
 }
 
 // ArrowToBatch converts []*array.Data to a coldata.Batch. There must not be
-// more than coldata.BatchSize elements in data. The returned batch may only be
-// used until the next call to ArrowToBatch.
-func (c *ArrowBatchConverter) ArrowToBatch(data []*array.Data) (coldata.Batch, error) {
+// more than coldata.BatchSize elements in data. It's safe to call ArrowToBatch
+// concurrently.
+//
+// The passed in batch is overwritten, but after this method returns it stays
+// valid as long as `data` stays valid. Callers can use this to control the
+// lifetimes of the batches, saving allocations when they can be reused (i.e.
+// reused by passing them back into this function).
+//
+// The passed in data is also mutated (we store nulls differently than arrow and
+// the adjustment is done in place).
+func (c *ArrowBatchConverter) ArrowToBatch(data []*array.Data, b coldata.Batch) error {
 	if len(data) != len(c.typs) {
-		return nil, errors.Errorf("mismatched data and schema length: %d != %d", len(data), len(c.typs))
+		return errors.Errorf("mismatched data and schema length: %d != %d", len(data), len(c.typs))
 	}
 	// Assume > 0 length data.
 	n := data[0].Len()
+	// Reset reuses the passed-in Batch when possible, saving allocations but
+	// overwriting it. If the passed-in Batch is not suitable for use, a new one
+	// is allocated.
+	b.Reset(c.typs, n)
+	b.SetLength(uint16(n))
+	// No selection, all values are valid.
+	b.SetSelection(false)
+
 	for i, typ := range c.typs {
-		vec := c.scratch.batch.ColVec(i)
+		vec := b.ColVec(i)
 		d := data[i]
 
 		var arr array.Interface
@@ -261,8 +275,5 @@ func (c *ArrowBatchConverter) ArrowToBatch(data []*array.Data) (coldata.Batch, e
 			vec.Nulls().SetNullBitmap(arrowBitmap, n)
 		}
 	}
-	c.scratch.batch.SetLength(uint16(n))
-	// No selection, all values are valid.
-	c.scratch.batch.SetSelection(false)
-	return c.scratch.batch, nil
+	return nil
 }

--- a/pkg/sql/exec/colserde/arrowbatchconverter_test.go
+++ b/pkg/sql/exec/colserde/arrowbatchconverter_test.go
@@ -11,6 +11,7 @@
 package colserde
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 
@@ -23,11 +24,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestArrowBatchConverterRandom(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
+func randomBatch() ([]types.T, coldata.Batch) {
 	const maxTyps = 16
-
 	rng, _ := randutil.NewPseudoRand()
 
 	availableTyps := make([]types.T, 0, len(types.AllTypes))
@@ -44,45 +42,92 @@ func TestArrowBatchConverterRandom(t *testing.T) {
 	}
 
 	b := exec.RandomBatch(rng, typs, rng.Intn(coldata.BatchSize)+1, rng.Float64())
-	c := NewArrowBatchConverter(typs)
+	return typs, b
+}
 
-	// Make a copy of the original batch because the converter modifies and casts
-	// data without copying for performance reasons.
-	expectedLength := b.Length()
-	expectedWidth := b.Width()
-	expectedColVecs := make([]coldata.Vec, len(b.ColVecs()))
-	for i := range typs {
-		expectedColVecs[i] = coldata.NewMemColumn(typs[i], int(b.Length()))
-		expectedColVecs[i].Copy(
-			coldata.CopyArgs{
-				ColType:   typs[i],
-				Src:       b.ColVec(i),
-				SrcEndIdx: uint64(b.Length()),
-			},
-		)
+func copyBatch(original coldata.Batch) coldata.Batch {
+	typs := make([]types.T, original.Width())
+	for i, vec := range original.ColVecs() {
+		typs[i] = vec.Type()
 	}
+	b := coldata.NewMemBatchWithSize(typs, int(original.Length()))
+	b.SetLength(original.Length())
+	for colIdx, col := range original.ColVecs() {
+		b.ColVec(colIdx).Copy(coldata.CopyArgs{
+			ColType:   typs[colIdx],
+			Src:       col,
+			SrcEndIdx: uint64(original.Length()),
+		})
+	}
+	return b
+}
 
-	arrowData, err := c.BatchToArrow(b)
-	require.NoError(t, err)
-	result, err := c.ArrowToBatch(arrowData)
-	require.NoError(t, err)
-	if result.Selection() != nil {
+func assertEqualBatches(t *testing.T, expected, actual coldata.Batch) {
+	t.Helper()
+
+	if actual.Selection() != nil {
 		t.Fatal("violated invariant that batches have no selection vectors")
 	}
-	require.Equal(t, expectedLength, result.Length())
-	require.Equal(t, expectedWidth, result.Width())
-	for i, typ := range typs {
+	require.Equal(t, expected.Length(), actual.Length())
+	require.Equal(t, expected.Width(), actual.Width())
+	for colIdx := 0; colIdx < expected.Width(); colIdx++ {
 		// Verify equality of ColVecs (this includes nulls). Since the coldata.Vec
 		// backing array is always of coldata.BatchSize due to the scratch batch
 		// that the converter keeps around, the coldata.Vec needs to be sliced to
 		// the first length elements to match on length, otherwise the check will
 		// fail.
+		expectedVec := expected.ColVec(colIdx)
+		actualVec := actual.ColVec(colIdx)
 		require.Equal(
 			t,
-			expectedColVecs[i].Slice(typ, 0, uint64(b.Length())),
-			result.ColVec(i).Slice(typ, 0, uint64(result.Length())),
+			expectedVec.Slice(expectedVec.Type(), 0, uint64(expected.Length())),
+			actualVec.Slice(actualVec.Type(), 0, uint64(actual.Length())),
 		)
 	}
+}
+
+func TestArrowBatchConverterRandom(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	typs, b := randomBatch()
+	c := NewArrowBatchConverter(typs)
+
+	// Make a copy of the original batch because the converter modifies and casts
+	// data without copying for performance reasons.
+	expected := copyBatch(b)
+
+	arrowData, err := c.BatchToArrow(b)
+	require.NoError(t, err)
+	actual := coldata.NewMemBatchWithSize(nil, 0)
+	require.NoError(t, c.ArrowToBatch(arrowData, actual))
+
+	assertEqualBatches(t, expected, actual)
+}
+
+func TestRecordBatchRoundtripThroughBytes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	typs, b := randomBatch()
+	c := NewArrowBatchConverter(typs)
+	r, err := NewRecordBatchSerializer(typs)
+	require.NoError(t, err)
+
+	// Make a copy of the original batch because the converter modifies and casts
+	// data without copying for performance reasons.
+	expected := copyBatch(b)
+
+	var buf bytes.Buffer
+	arrowDataIn, err := c.BatchToArrow(b)
+	require.NoError(t, err)
+	_, _, err = r.Serialize(&buf, arrowDataIn)
+	require.NoError(t, err)
+
+	var arrowDataOut []*array.Data
+	require.NoError(t, r.Deserialize(&arrowDataOut, buf.Bytes()))
+	actual := coldata.NewMemBatchWithSize(nil, 0)
+	require.NoError(t, c.ArrowToBatch(arrowDataOut, actual))
+
+	assertEqualBatches(t, expected, actual)
 }
 
 func BenchmarkArrowBatchConverter(b *testing.B) {
@@ -149,10 +194,15 @@ func BenchmarkArrowBatchConverter(b *testing.B) {
 			data, err := c.BatchToArrow(batch)
 			require.NoError(b, err)
 			testPrefix := fmt.Sprintf("%s/nullFraction=%0.2f", typ.String(), nullFraction)
+			result := coldata.NewMemBatch(typs)
 			b.Run(testPrefix+"/ArrowToBatch", func(b *testing.B) {
 				b.SetBytes(numBytes[typIdx])
 				for i := 0; i < b.N; i++ {
-					result, _ := c.ArrowToBatch(data)
+					// Using require.NoError here causes large enough allocations to
+					// affect the result.
+					if err := c.ArrowToBatch(data, result); err != nil {
+						b.Fatal(err)
+					}
 					if result.Width() != 1 {
 						b.Fatal("expected one column")
 					}

--- a/pkg/sql/exec/colserde/file.go
+++ b/pkg/sql/exec/colserde/file.go
@@ -1,0 +1,463 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colserde
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"io/ioutil"
+
+	"github.com/apache/arrow/go/arrow/array"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/colserde/arrowserde"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	flatbuffers "github.com/google/flatbuffers/go"
+	"github.com/pkg/errors"
+)
+
+const fileMagic = `ARROW1`
+
+var fileMagicPadding [8 - len(fileMagic)]byte
+
+type fileBlock struct {
+	offset      int64
+	metadataLen int32
+	bodyLen     int64
+}
+
+// FileSerializer converts our in-mem columnar batch representation into the
+// arrow specification's file format. All batches serialized to a file must have
+// the same schema.
+type FileSerializer struct {
+	scratch [4]byte
+
+	w    *countingWriter
+	typs []types.T
+	fb   *flatbuffers.Builder
+	a    *ArrowBatchConverter
+	rb   *RecordBatchSerializer
+
+	recordBatches []fileBlock
+}
+
+// NewFileSerializer creates a FileSerializer for the given types. The caller is
+// responsible for closing the given writer.
+func NewFileSerializer(w io.Writer, typs []types.T) (*FileSerializer, error) {
+	rb, err := NewRecordBatchSerializer(typs)
+	if err != nil {
+		return nil, err
+	}
+	s := &FileSerializer{
+		typs: typs,
+		fb:   flatbuffers.NewBuilder(flatbufferBuilderInitialCapacity),
+		a:    NewArrowBatchConverter(typs),
+		rb:   rb,
+	}
+	return s, s.Reset(w)
+}
+
+// Reset can be called to reuse this FileSerializer with a new io.Writer after
+// calling Finish. The types will remain the ones passed to the constructor. The
+// caller is responsible for closing the given writer.
+func (s *FileSerializer) Reset(w io.Writer) error {
+	if s.w != nil {
+		return errors.New(`Finish must be called before Reset`)
+	}
+	s.w = &countingWriter{wrapped: w}
+	s.recordBatches = s.recordBatches[:0]
+	if _, err := io.WriteString(s.w, fileMagic); err != nil {
+		return err
+	}
+	// Pad to 8 byte boundary.
+	if _, err := s.w.Write(fileMagicPadding[:]); err != nil {
+		return err
+	}
+
+	// The file format is a wrapper around the streaming format and the streaming
+	// format starts with a Schema message.
+	s.fb.Reset()
+	messageOffset := schemaMessage(s.fb, s.typs)
+	s.fb.Finish(messageOffset)
+	schemaBytes := s.fb.FinishedBytes()
+	if _, err := s.w.Write(schemaBytes); err != nil {
+		return err
+	}
+	_, err := s.w.Write(make([]byte, calculatePadding(len(schemaBytes))))
+	return err
+}
+
+// AppendBatch adds one batch of columnar data to the file.
+func (s *FileSerializer) AppendBatch(batch coldata.Batch) error {
+	offset := int64(s.w.written)
+
+	arrow, err := s.a.BatchToArrow(batch)
+	if err != nil {
+		return err
+	}
+	metadataLen, bodyLen, err := s.rb.Serialize(s.w, arrow)
+	if err != nil {
+		return err
+	}
+
+	s.recordBatches = append(s.recordBatches, fileBlock{
+		offset:      offset,
+		metadataLen: int32(metadataLen),
+		bodyLen:     int64(bodyLen),
+	})
+	return nil
+}
+
+// Finish writes the footer metadata described by the arrow spec. Nothing can be
+// called after Finish except Reset.
+func (s *FileSerializer) Finish() error {
+	defer func() {
+		s.w = nil
+	}()
+
+	// Write the footer flatbuffer, which has byte offsets of all the record
+	// batch messages in the file.
+	s.fb.Reset()
+	footerOffset := fileFooter(s.fb, s.typs, s.recordBatches)
+	s.fb.Finish(footerOffset)
+	footerBytes := s.fb.FinishedBytes()
+	if _, err := s.w.Write(footerBytes); err != nil {
+		return err
+	}
+	// For the footer, and only the footer, the spec requires the length _after_
+	// the footer so that it can be read by starting at the back of the file and
+	// working forward.
+	binary.LittleEndian.PutUint32(s.scratch[:], uint32(len(footerBytes)))
+	if _, err := s.w.Write(s.scratch[:]); err != nil {
+		return err
+	}
+	// Spec wants the magic again here.
+	_, err := io.WriteString(s.w, fileMagic)
+	return err
+}
+
+// FileDeserializer decodes columnar data batches from files encoded according
+// to the arrow spec.
+type FileDeserializer struct {
+	buf        []byte
+	bufCloseFn func() error
+
+	recordBatches []fileBlock
+
+	idx  int
+	end  int
+	typs []types.T
+	a    *ArrowBatchConverter
+	rb   *RecordBatchSerializer
+
+	arrowScratch []*array.Data
+}
+
+// NewFileDeserializerFromBytes constructs a FileDeserializer for an in-memory
+// buffer.
+func NewFileDeserializerFromBytes(buf []byte) (*FileDeserializer, error) {
+	return newFileDeserializer(buf, func() error { return nil })
+}
+
+// NewFileDeserializerFromPath constructs a FileDeserializer by reading it from
+// a file.
+//
+// TODO(dan): mmap instead. This is mostly completely in an interim version of
+// #37803.
+func NewFileDeserializerFromPath(path string) (*FileDeserializer, error) {
+	buf, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, pgerror.Wrapf(err, pgcode.Io, `reading %s`, path)
+	}
+	return newFileDeserializer(buf, func() error { return nil })
+}
+
+func newFileDeserializer(buf []byte, bufCloseFn func() error) (*FileDeserializer, error) {
+	d := &FileDeserializer{
+		buf:        buf,
+		bufCloseFn: bufCloseFn,
+		end:        len(buf),
+	}
+	typs, err := d.init()
+	if err != nil {
+		return nil, err
+	}
+	d.typs = typs
+
+	if d.rb, err = NewRecordBatchSerializer(typs); err != nil {
+		return nil, err
+	}
+	d.a = NewArrowBatchConverter(typs)
+	d.arrowScratch = make([]*array.Data, 0, len(typs))
+
+	return d, nil
+}
+
+// Close releases any resources held by this deserializer.
+func (d *FileDeserializer) Close() error {
+	return d.bufCloseFn()
+}
+
+// Typs returns the in-memory columnar types for the data stored in this file.
+func (d *FileDeserializer) Typs() []types.T {
+	return d.typs
+}
+
+// NumBatches returns the number of record batches stored in this file.
+func (d *FileDeserializer) NumBatches() int {
+	return len(d.recordBatches)
+}
+
+// GetBatch fills in the given in-mem batch with the requested on-disk data.
+func (d *FileDeserializer) GetBatch(batchIdx int, b coldata.Batch) error {
+	rb := d.recordBatches[batchIdx]
+	d.idx = int(rb.offset)
+	buf, err := d.read(metadataLengthNumBytes + int(rb.metadataLen) + int(rb.bodyLen))
+	if err != nil {
+		return err
+	}
+	d.arrowScratch = d.arrowScratch[:0]
+	if err := d.rb.Deserialize(&d.arrowScratch, buf); err != nil {
+		return err
+	}
+	return d.a.ArrowToBatch(d.arrowScratch, b)
+}
+
+// read gets the next `n` bytes from the start of the buffer, consuming them.
+func (d *FileDeserializer) read(n int) ([]byte, error) {
+	if d.idx+n > d.end {
+		return nil, io.EOF
+	}
+	start := d.idx
+	d.idx += n
+	return d.buf[start:d.idx], nil
+}
+
+// readBackward gets the `n` bytes from the end of the buffer, consuming them.
+func (d *FileDeserializer) readBackward(n int) ([]byte, error) {
+	if d.idx+n > d.end {
+		return nil, io.EOF
+	}
+	end := d.end
+	d.end -= n
+	return d.buf[d.end:end], nil
+}
+
+// init verifies the file magic and headers. After init, the `idx` and `end`
+// fields are set to the range of record batches and dictionary batches
+// described by the arrow spec's streaming format.
+func (d *FileDeserializer) init() ([]types.T, error) {
+	// Check the header magic
+	if magic, err := d.read(8); err != nil {
+		return nil, pgerror.Wrap(err, pgcode.DataException, `verifying arrow file header magic`)
+	} else if !bytes.Equal([]byte(fileMagic), magic[:len(fileMagic)]) {
+		return nil, errors.New(`arrow file header magic mismatch`)
+	}
+	if magic, err := d.readBackward(len(fileMagic)); err != nil {
+		return nil, pgerror.Wrap(err, pgcode.DataException, `verifying arrow file footer magic`)
+	} else if !bytes.Equal([]byte(fileMagic), magic) {
+		return nil, errors.New(`arrow file magic footer mismatch`)
+	}
+
+	footerSize, err := d.readBackward(4)
+	if err != nil {
+		return nil, pgerror.Wrap(err, pgcode.DataException, `reading arrow file footer`)
+	}
+	footerBytes, err := d.readBackward(int(binary.LittleEndian.Uint32(footerSize)))
+	if err != nil {
+		return nil, pgerror.Wrap(err, pgcode.DataException, `reading arrow file footer`)
+	}
+	footer := arrowserde.GetRootAsFooter(footerBytes, 0)
+	if footer.Version() != arrowserde.MetadataVersionV1 {
+		return nil, errors.Errorf(`only arrow V1 is supported got %d`, footer.Version())
+	}
+
+	var schema arrowserde.Schema
+	footer.Schema(&schema)
+	typs := make([]types.T, schema.FieldsLength())
+	var field arrowserde.Field
+	for i := range typs {
+		schema.Fields(&field, i)
+		if typs[i], err = typeFromField(&field); err != nil {
+			return nil, err
+		}
+	}
+
+	var block arrowserde.Block
+	d.recordBatches = d.recordBatches[:0]
+	for blockIdx := 0; blockIdx < footer.RecordBatchesLength(); blockIdx++ {
+		footer.RecordBatches(&block, blockIdx)
+		d.recordBatches = append(d.recordBatches, fileBlock{
+			offset:      block.Offset(),
+			metadataLen: block.MetaDataLength(),
+			bodyLen:     block.BodyLength(),
+		})
+	}
+
+	return typs, nil
+}
+
+type countingWriter struct {
+	wrapped io.Writer
+	written int
+}
+
+func (w *countingWriter) Write(buf []byte) (int, error) {
+	n, err := w.wrapped.Write(buf)
+	w.written += n
+	return n, err
+}
+
+func schema(fb *flatbuffers.Builder, typs []types.T) flatbuffers.UOffsetT {
+	fieldOffsets := make([]flatbuffers.UOffsetT, len(typs))
+	for idx, typ := range typs {
+		var fbTyp byte
+		var fbTypOffset flatbuffers.UOffsetT
+		switch typ {
+		case types.Bool:
+			arrowserde.BoolStart(fb)
+			fbTypOffset = arrowserde.BoolEnd(fb)
+			fbTyp = arrowserde.TypeBool
+		case types.Bytes:
+			arrowserde.BinaryStart(fb)
+			fbTypOffset = arrowserde.BinaryEnd(fb)
+			fbTyp = arrowserde.TypeBinary
+		case types.Int8:
+			arrowserde.IntStart(fb)
+			arrowserde.IntAddBitWidth(fb, 8)
+			arrowserde.IntAddIsSigned(fb, 1)
+			fbTypOffset = arrowserde.IntEnd(fb)
+			fbTyp = arrowserde.TypeInt
+		case types.Int16:
+			arrowserde.IntStart(fb)
+			arrowserde.IntAddBitWidth(fb, 16)
+			arrowserde.IntAddIsSigned(fb, 1)
+			fbTypOffset = arrowserde.IntEnd(fb)
+			fbTyp = arrowserde.TypeInt
+		case types.Int32:
+			arrowserde.IntStart(fb)
+			arrowserde.IntAddBitWidth(fb, 32)
+			arrowserde.IntAddIsSigned(fb, 1)
+			fbTypOffset = arrowserde.IntEnd(fb)
+			fbTyp = arrowserde.TypeInt
+		case types.Int64:
+			arrowserde.IntStart(fb)
+			arrowserde.IntAddBitWidth(fb, 64)
+			arrowserde.IntAddIsSigned(fb, 1)
+			fbTypOffset = arrowserde.IntEnd(fb)
+			fbTyp = arrowserde.TypeInt
+		case types.Float32:
+			arrowserde.FloatingPointStart(fb)
+			arrowserde.FloatingPointAddPrecision(fb, arrowserde.PrecisionSINGLE)
+			fbTypOffset = arrowserde.FloatingPointEnd(fb)
+			fbTyp = arrowserde.TypeFloatingPoint
+		case types.Float64:
+			arrowserde.FloatingPointStart(fb)
+			arrowserde.FloatingPointAddPrecision(fb, arrowserde.PrecisionDOUBLE)
+			fbTypOffset = arrowserde.FloatingPointEnd(fb)
+			fbTyp = arrowserde.TypeFloatingPoint
+		default:
+			panic(errors.Errorf(`don't know how to map %s`, typ))
+		}
+		arrowserde.FieldStart(fb)
+		arrowserde.FieldAddTypeType(fb, fbTyp)
+		arrowserde.FieldAddType(fb, fbTypOffset)
+		fieldOffsets[idx] = arrowserde.FieldEnd(fb)
+	}
+
+	arrowserde.SchemaStartFieldsVector(fb, len(typs))
+	// flatbuffers adds everything back to front. Reverse iterate so they're in
+	// the right order when they come out.
+	for i := len(fieldOffsets) - 1; i >= 0; i-- {
+		fb.PrependUOffsetT(fieldOffsets[i])
+	}
+	fields := fb.EndVector(len(typs))
+
+	arrowserde.SchemaStart(fb)
+	arrowserde.SchemaAddFields(fb, fields)
+	return arrowserde.SchemaEnd(fb)
+}
+
+func schemaMessage(fb *flatbuffers.Builder, typs []types.T) flatbuffers.UOffsetT {
+	schemaOffset := schema(fb, typs)
+	arrowserde.MessageStart(fb)
+	arrowserde.MessageAddVersion(fb, arrowserde.MetadataVersionV1)
+	arrowserde.MessageAddHeaderType(fb, arrowserde.MessageHeaderSchema)
+	arrowserde.MessageAddHeader(fb, schemaOffset)
+	return arrowserde.MessageEnd(fb)
+}
+
+func fileFooter(
+	fb *flatbuffers.Builder, typs []types.T, recordBatches []fileBlock,
+) flatbuffers.UOffsetT {
+	schemaOffset := schema(fb, typs)
+	arrowserde.FooterStartRecordBatchesVector(fb, len(recordBatches))
+	// flatbuffers adds everything back to front. Reverse iterate so they're in
+	// the right order when they come out.
+	for i := len(recordBatches) - 1; i >= 0; i-- {
+		rb := recordBatches[i]
+		arrowserde.CreateBlock(fb, rb.offset, rb.metadataLen, rb.bodyLen)
+	}
+	recordBatchesOffset := fb.EndVector(len(recordBatches))
+	arrowserde.FooterStart(fb)
+	arrowserde.FooterAddVersion(fb, arrowserde.MetadataVersionV1)
+	arrowserde.FooterAddSchema(fb, schemaOffset)
+	arrowserde.FooterAddRecordBatches(fb, recordBatchesOffset)
+	return arrowserde.FooterEnd(fb)
+}
+
+func typeFromField(field *arrowserde.Field) (types.T, error) {
+	var typeTab flatbuffers.Table
+	field.Type(&typeTab)
+	typeType := field.TypeType()
+	switch typeType {
+	case arrowserde.TypeBool:
+		return types.Bool, nil
+	case arrowserde.TypeBinary:
+		return types.Bytes, nil
+	case arrowserde.TypeInt:
+		var intType arrowserde.Int
+		intType.Init(typeTab.Bytes, typeTab.Pos)
+		if intType.IsSigned() > 0 {
+			switch intType.BitWidth() {
+			case 8:
+				return types.Int8, nil
+			case 16:
+				return types.Int16, nil
+			case 32:
+				return types.Int32, nil
+			case 64:
+				return types.Int64, nil
+			default:
+				return types.Unhandled, errors.Errorf(`unhandled bit width %d`, intType.BitWidth())
+			}
+		}
+	case arrowserde.TypeFloatingPoint:
+		var floatType arrowserde.FloatingPoint
+		floatType.Init(typeTab.Bytes, typeTab.Pos)
+		switch floatType.Precision() {
+		case arrowserde.PrecisionDOUBLE:
+			return types.Float64, nil
+		case arrowserde.PrecisionSINGLE:
+			return types.Float32, nil
+		default:
+			return types.Unhandled, errors.Errorf(`unhandled float precision %d`, floatType.Precision())
+		}
+	}
+	// It'd be nice if this error could include more details, but flatbuffers
+	// doesn't make a String method or anything like that.
+	if typeName, ok := arrowserde.EnumNamesType[typeType]; ok {
+		return types.Unhandled, errors.Errorf(`unknown type: %s`, typeName)
+	}
+	return types.Unhandled, errors.Errorf(`unknown type: %d`, typeType)
+}

--- a/pkg/sql/exec/colserde/file_test.go
+++ b/pkg/sql/exec/colserde/file_test.go
@@ -1,0 +1,127 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colserde
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileRoundtrip(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	typs, b := randomBatch()
+
+	t.Run(`mem`, func(t *testing.T) {
+		// Make a copy of the original batch because the converter modifies and
+		// casts data without copying for performance reasons.
+		original := copyBatch(b)
+
+		var buf bytes.Buffer
+		s, err := NewFileSerializer(&buf, typs)
+		require.NoError(t, err)
+		require.NoError(t, s.AppendBatch(b))
+		require.NoError(t, s.Finish())
+
+		// Parts of the deserialization modify things (null bitmaps) in place, so
+		// run it twice to make sure those modifications don't leak back to the
+		// buffer.
+		for i := 0; i < 2; i++ {
+			func() {
+				roundtrip := coldata.NewMemBatchWithSize(nil, 0)
+				d, err := NewFileDeserializerFromBytes(buf.Bytes())
+				require.NoError(t, err)
+				defer func() { require.NoError(t, d.Close()) }()
+				require.Equal(t, typs, d.Typs())
+				require.Equal(t, 1, d.NumBatches())
+				require.NoError(t, d.GetBatch(0, roundtrip))
+
+				assertEqualBatches(t, original, roundtrip)
+			}()
+		}
+	})
+
+	t.Run(`disk`, func(t *testing.T) {
+		dir, cleanup := testutils.TempDir(t)
+		defer cleanup()
+		path := filepath.Join(dir, `rng.arrow`)
+
+		// Make a copy of the original batch because the converter modifies and
+		// casts data without copying for performance reasons.
+		original := copyBatch(b)
+
+		f, err := os.Create(path)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, f.Close()) }()
+		s, err := NewFileSerializer(f, typs)
+		require.NoError(t, err)
+		require.NoError(t, s.AppendBatch(b))
+		require.NoError(t, s.Finish())
+		require.NoError(t, f.Sync())
+
+		// Parts of the deserialization modify things (null bitmaps) in place, so
+		// run it twice to make sure those modifications don't leak back to the
+		// file.
+		for i := 0; i < 2; i++ {
+			func() {
+				roundtrip := coldata.NewMemBatchWithSize(nil, 0)
+				d, err := NewFileDeserializerFromPath(path)
+				require.NoError(t, err)
+				defer func() { require.NoError(t, d.Close()) }()
+				require.Equal(t, typs, d.Typs())
+				require.Equal(t, 1, d.NumBatches())
+				require.NoError(t, d.GetBatch(0, roundtrip))
+
+				assertEqualBatches(t, original, roundtrip)
+			}()
+		}
+	})
+}
+
+func TestFileIndexing(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const numInts = 10
+	typs := []types.T{types.Int64}
+
+	var buf bytes.Buffer
+	s, err := NewFileSerializer(&buf, typs)
+	require.NoError(t, err)
+
+	for i := 0; i < numInts; i++ {
+		b := coldata.NewMemBatchWithSize(typs, 1)
+		b.SetLength(1)
+		b.ColVec(0).Int64()[0] = int64(i)
+		require.NoError(t, s.AppendBatch(b))
+	}
+	require.NoError(t, s.Finish())
+
+	d, err := NewFileDeserializerFromBytes(buf.Bytes())
+	require.NoError(t, err)
+	defer func() { require.NoError(t, d.Close()) }()
+	require.Equal(t, typs, d.Typs())
+	require.Equal(t, numInts, d.NumBatches())
+	for batchIdx := numInts - 1; batchIdx >= 0; batchIdx-- {
+		b := coldata.NewMemBatchWithSize(nil, 0)
+		require.NoError(t, d.GetBatch(batchIdx, b))
+		require.Equal(t, uint16(1), b.Length())
+		require.Equal(t, 1, b.Width())
+		require.Equal(t, types.Int64, b.ColVec(0).Type())
+		require.Equal(t, int64(batchIdx), b.ColVec(0).Int64()[0])
+	}
+}

--- a/pkg/sql/exec/colserde/record_batch.go
+++ b/pkg/sql/exec/colserde/record_batch.go
@@ -87,26 +87,28 @@ func NewRecordBatchSerializer(typs []types.T) (*RecordBatchSerializer, error) {
 
 // calculatePadding calculates how many bytes must be added to numBytes to round
 // it up to the nearest multiple of 8.
-func (s *RecordBatchSerializer) calculatePadding(numBytes int) int {
+func calculatePadding(numBytes int) int {
 	return (8 - (numBytes & 7)) & 7
 }
 
 // Serialize serializes data as an arrow RecordBatch message and writes it to w.
 // Serializing a schema that does not match the schema given in
 // NewRecordBatchSerializer results in undefined behavior.
-func (s *RecordBatchSerializer) Serialize(w io.Writer, data []*array.Data) error {
+func (s *RecordBatchSerializer) Serialize(
+	w io.Writer, data []*array.Data,
+) (metadataLen uint32, dataLen uint64, _ error) {
 	if len(data) != len(s.numBuffers) {
-		return errors.Errorf("mismatched schema length and number of columns: %d != %d", len(s.numBuffers), len(data))
+		return 0, 0, errors.Errorf("mismatched schema length and number of columns: %d != %d", len(s.numBuffers), len(data))
 	}
 	// Ensure equal data length and expected number of buffers. We don't support
 	// zero-length schemas, so data[0] is in bounds at this point.
 	headerLength := data[0].Len()
 	for i := range data {
 		if data[i].Len() != headerLength {
-			return errors.Errorf("mismatched data lengths at column %d: %d != %d", i, headerLength, data[i].Len())
+			return 0, 0, errors.Errorf("mismatched data lengths at column %d: %d != %d", i, headerLength, data[i].Len())
 		}
 		if len(data[i].Buffers()) != s.numBuffers[i] {
-			return errors.Errorf(
+			return 0, 0, errors.Errorf(
 				"mismatched number of buffers at column %d: %d != %d", i, len(data[i].Buffers()), s.numBuffers[i],
 			)
 		}
@@ -180,22 +182,23 @@ func (s *RecordBatchSerializer) Serialize(w io.Writer, data []*array.Data) error
 	metadataBytes := s.builder.FinishedBytes()
 
 	// Use s.scratch.padding to align metadata to 8-byte boundary.
-	s.scratch.padding = s.scratch.padding[:s.calculatePadding(metadataLengthNumBytes+len(metadataBytes))]
+	s.scratch.padding = s.scratch.padding[:calculatePadding(metadataLengthNumBytes+len(metadataBytes))]
 
 	// Write metadata + padding length as the first metadataLengthNumBytes.
-	binary.LittleEndian.PutUint32(s.scratch.metadataLength[:], uint32(len(metadataBytes)+len(s.scratch.padding)))
+	metadataLength := uint32(len(metadataBytes) + len(s.scratch.padding))
+	binary.LittleEndian.PutUint32(s.scratch.metadataLength[:], metadataLength)
 	if _, err := w.Write(s.scratch.metadataLength[:]); err != nil {
-		return err
+		return 0, 0, err
 	}
 
 	// Write metadata.
 	if _, err := w.Write(metadataBytes); err != nil {
-		return err
+		return 0, 0, err
 	}
 
 	// Add metadata padding.
 	if _, err := w.Write(s.scratch.padding); err != nil {
-		return err
+		return 0, 0, err
 	}
 
 	// Add message body. The metadata holds the offsets and lengths of these
@@ -211,15 +214,16 @@ func (s *RecordBatchSerializer) Serialize(w io.Writer, data []*array.Data) error
 			}
 			bodyLength += len(bufferBytes)
 			if _, err := w.Write(bufferBytes); err != nil {
-				return err
+				return 0, 0, err
 			}
 		}
 	}
 
 	// Add body padding. The body also needs to be a multiple of 8 bytes.
-	s.scratch.padding = s.scratch.padding[:s.calculatePadding(bodyLength)]
+	s.scratch.padding = s.scratch.padding[:calculatePadding(bodyLength)]
 	_, err := w.Write(s.scratch.padding)
-	return err
+	bodyLength += len(s.scratch.padding)
+	return metadataLength, uint64(bodyLength), err
 }
 
 // Deserialize deserializes an arrow IPC RecordBatch message contained in bytes

--- a/pkg/sql/exec/colserde/record_batch_test.go
+++ b/pkg/sql/exec/colserde/record_batch_test.go
@@ -170,7 +170,7 @@ func TestRecordBatchSerializer(t *testing.T) {
 		firstCol := b.NewArray().Data()
 		b.AppendValues([]int64{3}, nil /* valid */)
 		secondCol := b.NewArray().Data()
-		err = s.Serialize(&bytes.Buffer{}, []*array.Data{firstCol, secondCol})
+		_, _, err = s.Serialize(&bytes.Buffer{}, []*array.Data{firstCol, secondCol})
 		require.True(t, testutils.IsError(err, "mismatched data lengths"), err)
 	})
 }
@@ -215,7 +215,8 @@ func TestRecordBatchSerializerSerializeDeserializeRandom(t *testing.T) {
 	// Run Serialize/Deserialize in a loop to test reuse.
 	for i := 0; i < 2; i++ {
 		buf.Reset()
-		require.NoError(t, s.Serialize(&buf, data))
+		_, _, err := s.Serialize(&buf, data)
+		require.NoError(t, err)
 		if buf.Len()%8 != 0 {
 			t.Fatal("message length must align to 8 byte boundary")
 		}
@@ -266,7 +267,7 @@ func BenchmarkRecordBatchSerializerInt64(b *testing.B) {
 			b.SetBytes(numBytes)
 			for i := 0; i < b.N; i++ {
 				buf.Reset()
-				if err := s.Serialize(&buf, data); err != nil {
+				if _, _, err := s.Serialize(&buf, data); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -275,7 +276,7 @@ func BenchmarkRecordBatchSerializerInt64(b *testing.B) {
 		// buf should still have the result of the last serialization. It is still
 		// empty in cases in which we run only the Deserialize benchmarks.
 		if buf.Len() == 0 {
-			if err := s.Serialize(&buf, data); err != nil {
+			if _, _, err := s.Serialize(&buf, data); err != nil {
 				b.Fatal(err)
 			}
 		}


### PR DESCRIPTION
The arrow file format is basically the streaming format plus a
flatbuffer footer with offset information to allow indexing. We could
pull an abstraction for reading and writing the streaming format out of
this if we need to, but I didn't do it here to save the complexity until
we need it.

I'm hoping to use this to build on-disk caches of precomputed workload
colbatches for testing/benchmarking. If we write each batch in some
workload.Table as a record in the file, the random access will allow us
to later fake out a workload.Table to use in the test that just fills
the precomputed data from a mmap'd file.

The Reset call I added to ArrowToBatch will help with the above, but
seems to have slowed the benchmarks down a bit, though the diff is small
in absolute terms. Reset is clearing the nulls just for ArrowToBatch to
then go and overwrite them, which is wasteful. Avoiding the waste is a
bit awkward but I think gets us most of this back if we care.

    name                                                        old time/op    new time/op    delta
    ArrowBatchConverter/Bool/nullFraction=0.00/ArrowToBatch-8     2.02µs ± 3%    2.22µs ± 7%   +9.99%  (p=0.008 n=5+5)
    ArrowBatchConverter/Bytes/nullFraction=0.00/ArrowToBatch-8    2.83µs ± 1%    3.13µs ± 9%  +10.41%  (p=0.008 n=5+5)
    ArrowBatchConverter/Int64/nullFraction=0.00/ArrowToBatch-8     145ns ± 1%     173ns ± 4%  +19.36%  (p=0.008 n=5+5)

    name                                                        old speed      new speed      delta
    ArrowBatchConverter/Bool/nullFraction=0.00/ArrowToBatch-8    507MB/s ± 3%   462MB/s ± 7%   -8.96%  (p=0.008 n=5+5)
    ArrowBatchConverter/Bytes/nullFraction=0.00/ArrowToBatch-8  23.1GB/s ± 1%  21.0GB/s ± 8%   -9.09%  (p=0.008 n=5+5)
    ArrowBatchConverter/Int64/nullFraction=0.00/ArrowToBatch-8  56.4GB/s ± 1%  47.3GB/s ± 4%  -16.09%  (p=0.008 n=5+5)

    name                                                        old alloc/op   new alloc/op   delta
    ArrowBatchConverter/Bool/nullFraction=0.00/ArrowToBatch-8      64.0B ± 0%     64.0B ± 0%     ~     (all equal)
    ArrowBatchConverter/Bytes/nullFraction=0.00/ArrowToBatch-8     96.0B ± 0%     96.0B ± 0%     ~     (all equal)
    ArrowBatchConverter/Int64/nullFraction=0.00/ArrowToBatch-8     96.0B ± 0%     96.0B ± 0%     ~     (all equal)

    name                                                        old allocs/op  new allocs/op  delta
    ArrowBatchConverter/Bool/nullFraction=0.00/ArrowToBatch-8       1.00 ± 0%      1.00 ± 0%     ~     (all equal)
    ArrowBatchConverter/Bytes/nullFraction=0.00/ArrowToBatch-8      1.00 ± 0%      1.00 ± 0%     ~     (all equal)
    ArrowBatchConverter/Int64/nullFraction=0.00/ArrowToBatch-8      2.00 ± 0%      2.00 ± 0%     ~     (all equal)

Release note: None