### PR TITLE
storage/txnrecovery: add transaction recovery metrics

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1315,13 +1315,13 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		TestingKnobs:         s.cfg.TestingKnobs.IntentResolverKnobs,
 		RangeDescriptorCache: s.cfg.RangeDescriptorCache,
 	})
+	s.metrics.registry.AddMetricStruct(s.intentResolver.Metrics)
 
 	// Create the recovery manager.
 	s.recoveryMgr = txnrecovery.NewManager(
 		s.cfg.AmbientCtx, s.cfg.Clock, s.db, stopper,
 	)
-
-	s.metrics.registry.AddMetricStruct(s.intentResolver.Metrics)
+	s.metrics.registry.AddMetricStruct(s.recoveryMgr.Metrics())
 
 	s.rangeIDAlloc = idAlloc
 

--- a/pkg/storage/txnrecovery/metrics.go
+++ b/pkg/storage/txnrecovery/metrics.go
@@ -1,0 +1,86 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package txnrecovery
+
+import "github.com/cockroachdb/cockroach/pkg/util/metric"
+
+// Metrics holds all metrics relating to a transaction recovery Manager.
+type Metrics struct {
+	AttemptsPending      *metric.Gauge
+	Attempts             *metric.Counter
+	SuccessesAsCommitted *metric.Counter
+	SuccessesAsAborted   *metric.Counter
+	SuccessesAsPending   *metric.Counter
+	Failures             *metric.Counter
+}
+
+// makeMetrics creates a new Metrics instance with all related metric fields.
+func makeMetrics() Metrics {
+	return Metrics{
+		AttemptsPending: metric.NewGauge(
+			metric.Metadata{
+				Name:        "txnrecovery.attempts.pending",
+				Help:        "Number of transaction recovery attempts currently in-flight",
+				Measurement: "Recovery Attempts",
+				Unit:        metric.Unit_COUNT,
+			},
+		),
+
+		Attempts: metric.NewCounter(
+			metric.Metadata{
+				Name:        "txnrecovery.attempts.total",
+				Help:        "Number of transaction recovery attempts executed",
+				Measurement: "Recovery Attempts",
+				Unit:        metric.Unit_COUNT,
+			},
+		),
+
+		SuccessesAsCommitted: metric.NewCounter(
+			metric.Metadata{
+				Name:        "txnrecovery.successes.committed",
+				Help:        "Number of transaction recovery attempts that committed a transaction",
+				Measurement: "Recovery Attempts",
+				Unit:        metric.Unit_COUNT,
+			},
+		),
+
+		SuccessesAsAborted: metric.NewCounter(
+			metric.Metadata{
+				Name:        "txnrecovery.successes.aborted",
+				Help:        "Number of transaction recovery attempts that aborted a transaction",
+				Measurement: "Recovery Attempts",
+				Unit:        metric.Unit_COUNT,
+			},
+		),
+
+		SuccessesAsPending: metric.NewCounter(
+			metric.Metadata{
+				Name:        "txnrecovery.successes.pending",
+				Help:        "Number of transaction recovery attempts that left a transaction pending",
+				Measurement: "Recovery Attempts",
+				Unit:        metric.Unit_COUNT,
+			},
+		),
+
+		Failures: metric.NewCounter(
+			metric.Metadata{
+				Name:        "txnrecovery.failures",
+				Help:        "Number of transaction recovery attempts that failed",
+				Measurement: "Recovery Attempts",
+				Unit:        metric.Unit_COUNT,
+			},
+		),
+	}
+}


### PR DESCRIPTION
This commit adds a series of time series metrics that provide insight
into the process of transaction recovery due to abandoned parallel
commits.

New metrics:
- `txnrecovery.attempts.pending`
- `txnrecovery.attempts.total`
- `txnrecovery.successes.committed`
- `txnrecovery.successes.aborted`
- `txnrecovery.successes.pending`
- `txnrecovery.failures`

Release note: None