### PR TITLE
storage: skip-race TestStoreRangeMoveDecommissioning

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -2983,6 +2983,11 @@ func TestReplicaGCRace(t *testing.T) {
 // decommission, the ReplicateQueue will notice and move any replicas on it.
 func TestStoreRangeMoveDecommissioning(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	if testutils.NightlyStress() && util.RaceEnabled {
+		t.Skip("can't handle nightly stress: #37811")
+	}
+
 	sc := storage.TestStoreConfig(nil)
 	sc.TestingKnobs.DisableReplicaRebalancing = true
 	mtc := &multiTestContext{storeConfig: &sc}


### PR DESCRIPTION
See https://github.com/cockroachdb/cockroach/issues/37811.

Release note: None