### PR TITLE
kv: replace unexpected txn state assertion with error

### DIFF
--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -908,9 +908,8 @@ func (tc *TxnCoordSender) maybeRejectClientLocked(
 		return roachpb.NewError(roachpb.NewTransactionRetryWithProtoRefreshError(
 			abortedErr.Message, tc.mu.txn.ID, newTxn))
 	}
-
 	if tc.mu.txn.Status != roachpb.PENDING {
-		log.Fatalf(ctx, "unexpected txn state: %s", tc.mu.txn)
+		return roachpb.NewErrorf("(see issue #37866) unexpected txn state: %s", tc.mu.txn)
 	}
 	return nil
 }


### PR DESCRIPTION
See #37866.

This has been failing in roachtests like #37488. This will make it easier to debug until the issue is fixed.

Release note: None