### PR TITLE
roachprod: avoid crash thanks to progress tracker

### DIFF
--- a/pkg/cmd/roachprod/install/cluster_synced.go
+++ b/pkg/cmd/roachprod/install/cluster_synced.go
@@ -825,6 +825,9 @@ func formatProgress(p float64) string {
 	if i > len(progressDone) {
 		i = len(progressDone)
 	}
+	if i < 0 {
+		i = 0
+	}
 	return fmt.Sprintf("[%s%s] %.0f%%", progressDone[i:], progressTodo[:i], 100*p)
 }
 


### PR DESCRIPTION
I suspect I saw one where `i` turned negative.

@petermattis wrote:

> Hmm, I think I do see how this could happen. If you try to get a file that is being actively written to, SyncedCluster.Get will determine the size of the file and use that as the Total passed to the progress tracker. If the file then grows in size I think we can copy more than 100% of the original file size which would push i negative.

Release note: None