### PR TITLE
workload/ycsb: fix TestZipfGenerator histogram display

### DIFF
--- a/pkg/workload/ycsb/zipfgenerator_test.go
+++ b/pkg/workload/ycsb/zipfgenerator_test.go
@@ -152,7 +152,7 @@ func runZipfGenerators(t *testing.T, withIncrements bool) {
 	for i := 0; i < max; i += step {
 		count = 0
 		for {
-			if x[index] >= i {
+			if x[index] >= i+step {
 				break
 			}
 			index++


### PR DESCRIPTION
Noticed that the histogram display never had any values in the `0-5`
bucket which seemed bad. Turns out it was just the display that was
broken.

Release note: None