### PR TITLE
backport-2.1: stop: allow double-calling Stop()

### DIFF
--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -109,6 +109,8 @@ func TestStopperIsStopped(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("stopper should have finished stopping")
 	}
+
+	s.Stop(context.Background())
 }
 
 func TestStopperMultipleStopees(t *testing.T) {


### PR DESCRIPTION
Closes #37892.

Backport 1/1 commits from #34823.

/cc @cockroachdb/release

---

Stop() can be called multiple times and it's better to embrace that fact
than to try to fight it. See

https://github.com/cockroachdb/cockroach/blob/89ce71e9b733df3855b370aa20bb809db3d4362c/pkg/cli/start.go#L794-L809

Fixes #34572

Release note (bug fix): Fix a rare crash ("close of closed channel")
that could occur when shutting down a server.
