### PR TITLE
tla-plus: QueryTxn on ambiguous QueryIntent failure during ParallelCommit

### DIFF
--- a/docs/tla-plus/ParallelCommits/ParallelCommits.tla
+++ b/docs/tla-plus/ParallelCommits/ParallelCommits.tla
@@ -29,11 +29,14 @@ ASSUME MAX_ATTEMPTS > 0
 (*                                                                       *)
 (* The spec asserts the following liveness properties:                   *)
 (* - the transaction record is eventually aborted or committed.          *)
+(* - all of the transaction's intents are eventually resolved.           *)
 (*                                                                       *)
 (*                                                                       *)
 (* The "committer" process corresponds to logic in the following files:  *)
 (* - pkg/kv/txn_interceptor_committer.go                                 *)
+(* - pkg/kv/txn_interceptor_pipeliner.go                                 *)
 (* - pkg/storage/batcheval/cmd_end_transaction.go                        *)
+(* - pkg/storage/batcheval/cmd_query_intent.go                           *)
 (* - pkg/storage/replica_tscache.go                                      *)
 (*                                                                       *)
 (* The "preventer" process corresponds to logic in the following files:  *)
@@ -52,6 +55,16 @@ variables
   commit_ack = FALSE;
 
 define
+  \* Simulates a QueryIntent request, taking care to model the exact
+  \* condition in which the request considers an intent to be found.
+  QueryIntent(key, query_epoch, query_ts) ==
+    LET
+      intent == intent_writes[key]
+    IN
+      /\ intent.epoch = query_epoch
+      /\ intent.ts <= query_ts
+      /\ intent.resolved = FALSE
+
   RecordStatuses  == {"pending", "staging", "committed", "aborted"}
   RecordStaged    == record.status = "staging"
   RecordCommitted == record.status = "committed"
@@ -93,8 +106,8 @@ define
     /\ [][\A k \in KEYS: intent_writes'[k].epoch >= intent_writes[k].epoch]_intent_writes
     \* Intent writes' timestamps must always grow.
     /\ [][\A k \in KEYS: intent_writes'[k].ts >= intent_writes[k].ts]_intent_writes
-    \* Once an intent is resolved, it stays resolved.
-    /\ [][\A k \in KEYS: intent_writes[k].resolved => intent_writes'[k].resolved]_intent_writes
+    \* All intents are eventually resolved and stay resolved.
+    /\ <>[](\A k \in KEYS: intent_writes[k].resolved)
 
   TemporalTSCacheProperties ==
     \* The timestamp cache always advances.
@@ -108,77 +121,148 @@ define
   AckLeadsToExplicitCommit == commit_ack ~> ExplicitCommit
 end define;
 
+\* Give up after MAX_ATTEMPTS attempts. This bounds the state space for the
+\* spec and ensures that it terminates. A real transaction coordinator will not
+\* give up after a certain number of attempts. However, real transactions will
+\* probabilistically terminate because concurrent transactions will not attempt
+\* to recover a parallel commit (i.e. serve as a "preventer" process) until the
+\* parallel committing transaction's heartbeat expires.
+macro maybe_abandon_retry()
+begin
+  if attempt > MAX_ATTEMPTS then
+    goto EndCommitter;
+  end if;
+end macro;
+
 process committer = "committer"
 variables
-  txn_epoch = 1;
-  txn_ts = 1;
-  attempt = 0;
-  to_write = KEYS;
+  \* -- constants --
+  \* Represents keys that are written before the final Batch.
+  pipelined_keys \in SUBSET KEYS;
+  \* Represents keys that are written in the final Batch.
+  parallel_keys = KEYS \ pipelined_keys;
+
+  \* -- variables --
+  attempt = 1;
+  txn_epoch = 0;
+  txn_ts = 0;
+  to_write = {};
+  to_check = {};
   have_staged_record = FALSE;
 begin
-  \* Attempt to perform all intent writes and
-  \* stage the transaction record in parallel.
-  StageWrites:
-    \* Give up after MAX_ATTEMPTS attempts. This bounds the state space for the
-    \* spec and ensures that it terminates. A real transaction coordinator will not
-    \* give up after a certain number of attempts. However, real transactions will
-    \* probabilistically terminate because concurrent transactions will not attempt
-    \* to recover a parallel commit (i.e. serve as a "preventer" process) until the
-    \* parallel committing transaction's heartbeat expires.
-    attempt := attempt + 1;
-    if attempt > MAX_ATTEMPTS then
-      goto EndCommitter;
-    end if;
+  \* Begin a new transaction epoch.
+  BeginTxnEpoch:
+    txn_epoch := txn_epoch + 1;
+    txn_ts := txn_ts + 1;
+    to_write := pipelined_keys;
+    maybe_abandon_retry();
 
-    TryStageWrites:
-      while to_write /= {} \/ ~have_staged_record do
+  \* Attempt to perform all pipelined intent writes. These are writes that
+  \* occur before the final Batch containing the EndTransaction request.
+  \* These writes are ordered, but it's more hassle than it's worth to model
+  \* them that way.
+  PipelineWrites:
+    while to_write /= {} do
+      with key \in to_write do
+        if intent_writes[key].resolved then
+          \* Can't write over resolved write. In reality, this would result
+          \* in laying down an (uncommitable) intent at a higher timestamp
+          \* and returning a WriteTooOld error. For the sake of this model,
+          \* we don't write anything. The pre-commit QueryIntent sent to
+          \* this key during the parallel commit will fail.
+          to_write := to_write \ {key};
+        elsif tscache[key] >= txn_ts then
+          \* Write prevented. This shouldn't happen.
+          assert FALSE;
+        else
+          \* Write successful.
+          intent_writes[key] := [
+            epoch    |-> txn_epoch,
+            ts       |-> txn_ts,
+            resolved |-> FALSE
+          ];
+          to_write := to_write \ {key};
+        end if;
+      end with;
+    end while;
+
+  \* Attempt to perform all final-batch intent writes, query all pipelined
+  \* writes, and stage the transaction record in parallel.
+  StageWritesAndRecord:
+    to_write := parallel_keys;
+    to_check := pipelined_keys;
+    have_staged_record := FALSE;
+    maybe_abandon_retry();
+
+    StageWritesAndRecordLoop:
+      while to_check /= {} \/ to_write /= {} \/ ~have_staged_record do
         either
+          await to_check /= {};
+          QueryPipelinedWrite:
+            with key \in to_check do
+              if QueryIntent(key, txn_epoch, txn_ts) then
+                \* Intent found. Pipelined write succeeded.
+                to_check := to_check \union {key}
+              else
+                \* Intent missing. Pipelined write failed.
+                \* Perform a transaction restart at new epoch.
+                attempt := attempt + 1;
+                goto BeginTxnEpoch;
+              end if;
+            end with;
+        or
           await to_write /= {};
-          with key \in to_write do
-            if tscache[key] >= txn_ts then
-              \* Write prevented.
-              either
-                \* Successful refresh. Try again at new epoch.
-                \* No need to re-write existing intents at new timestamp.
-                txn_ts := txn_ts + 1;
-                have_staged_record := FALSE;
-                goto StageWrites;
-              or
-                \* Failed refresh. Try again at new epoch.
-                \* Must re-write all intents at new epoch.
-                txn_epoch := txn_epoch + 1;
-                txn_ts := txn_ts + 1;
-                to_write := KEYS;
-                have_staged_record := FALSE;
-                goto StageWrites;
-              end either;
-            else
-              \* Write successful.
-              intent_writes[key] := [
-                epoch    |-> txn_epoch, 
-                ts       |-> txn_ts, 
-                resolved |-> FALSE
-              ];
-              to_write := to_write \ {key};
-            end if;
-          end with;
+          ParallelWrite:
+            with key \in to_write,
+                 cur_intent = intent_writes[key] do
+              if cur_intent.epoch = txn_epoch then
+                \* Write already succeeded before refresh. Writes should be idempotent,
+                \* so there's nothing to do. In practice, this is not strictly true (e.g.
+                \* after intents are resolved), which is why we currently reject retry
+                \* attempts that would rely on idempotence with MixedSuccessErrors.
+                to_write := to_write \ {key};
+              elsif tscache[key] >= txn_ts \/ cur_intent.resolved then
+                \* Write prevented.
+                either
+                  \* Successful refresh. Try again at same epoch.
+                  \* No need to re-write existing intents at new timestamp.
+                  txn_ts := txn_ts + 1;
+                  attempt := attempt + 1;
+                  goto StageWritesAndRecord;
+                or
+                  \* Failed refresh. Try again at new epoch.
+                  \* Must re-write all intents at new epoch.
+                  attempt := attempt + 1;
+                  goto BeginTxnEpoch;
+                end either;
+              else
+                \* Write successful.
+                intent_writes[key] := [
+                  epoch    |-> txn_epoch,
+                  ts       |-> txn_ts,
+                  resolved |-> FALSE
+                ];
+                to_write := to_write \ {key};
+              end if;
+            end with;
         or
           await ~have_staged_record;
-          have_staged_record := TRUE;
-          if record.status = "pending" then
-            \* Move to staging status.
-            record := [status |-> "staging", epoch |-> txn_epoch, ts |-> txn_ts];
-          elsif record.status = "staging" then
-            \* Bump record timestamp and maybe epoch.
-            assert record.epoch <= txn_epoch /\ record.ts < txn_ts;
-            record := [status |-> "staging", epoch |-> txn_epoch, ts |-> txn_ts];
-          elsif record.status = "aborted" then
-            \* Aborted before STAGING transaction record.
-            goto EndCommitter;
-          elsif record.status = "committed" then
-            \* Should not already be committed.
-            assert FALSE;
-          end if;
+          StageRecord:
+            have_staged_record := TRUE;
+            if record.status = "pending" then
+              \* Move to staging status.
+              record := [status |-> "staging", epoch |-> txn_epoch, ts |-> txn_ts];
+            elsif record.status = "staging" then
+              \* Bump record timestamp and maybe epoch.
+              assert record.epoch <= txn_epoch /\ record.ts < txn_ts;
+              record := [status |-> "staging", epoch |-> txn_epoch, ts |-> txn_ts];
+            elsif record.status = "aborted" then
+              \* Aborted before STAGING transaction record.
+              goto EndCommitter;
+            elsif record.status = "committed" then
+              \* Should not already be committed.
+              assert FALSE;
+            end if;
         end either
       end while;
 
@@ -202,14 +286,16 @@ begin
       \* Should not be pending or aborted at this point.
       assert FALSE;
     end if;
-  
+
   \* Now that the commit is explicit, asynchronously resolve
   \* all intents. Re-use the to_write variable for convenience.
   to_write := KEYS;
   AsyncResolveIntents:
     while to_write /= {} do
       with key \in to_write do
-        intent_writes[key].resolved := TRUE;
+        if ~intent_writes[key].resolved then
+          intent_writes[key].resolved := TRUE;
+        end if;
         to_write := to_write \ {key};
       end with;
     end while;
@@ -224,6 +310,7 @@ variable
   prevent_epoch = 0;
   prevent_ts = 0;
   found_writes = {};
+  to_resolve = KEYS;
 begin
   PreventLoop:
     found_writes := {};
@@ -234,37 +321,30 @@ begin
       if record.status = "pending" then
         \* Transaction not yet staged, abort.
         record.status := "aborted";
-        goto EndRecover;
+        goto ResolveIntents;
       elsif record.status = "staging" then
         \* Transaction staging, kick off recovery process.
         prevent_epoch := record.epoch;
         prevent_ts := record.ts;
       elsif record.status \in {"committed", "aborted"} then
         \* Already finalized, nothing to do.
-        goto EndRecover;
+        goto ResolveIntents;
       end if;
 
     \* Attempt to prevent any of its in-flight intent writes.
     PreventWrites:
       while found_writes /= KEYS do
         with key \in KEYS \ found_writes do
-          with intent = intent_writes[key] do
-            \* Simulate a QueryIntent request, taking care to model the exact
-            \* condition in which the request considers an intent to be found.
-            if /\ intent.epoch = prevent_epoch
-               /\ intent.ts <= prevent_ts
-               /\ intent.resolved = FALSE
-            then
-              \* Intent found. Could not prevent.
-              found_writes := found_writes \union {key}
-            else
-              \* Intent missing. Prevent.
-              if tscache[key] < prevent_ts then
-                tscache[key] := prevent_ts;
-              end if;
-              goto RecoverRecord;
+          if QueryIntent(key, prevent_epoch, prevent_ts) then
+            \* Intent found. Could not prevent.
+            found_writes := found_writes \union {key}
+          else
+            \* Intent missing. Prevent.
+            if tscache[key] < prevent_ts then
+              tscache[key] := prevent_ts;
             end if;
-          end with;
+            goto RecoverRecord;
+          end if;
         end with;
       end while;
 
@@ -314,8 +394,18 @@ begin
         end if;
       end with;
 
-  EndRecover:
-    skip;
+  \* Now that the transaction is finalized, synchronously resolve
+  \* all of its intents. After this point, the conflicting transaction
+  \* can return to doing whatever it was doing.
+  ResolveIntents:
+    while to_resolve /= {} do
+      with key \in to_resolve do
+        if ~intent_writes[key].resolved then
+          intent_writes[key].resolved := TRUE;
+        end if;
+        to_resolve := to_resolve \ {key};
+      end with;
+    end while;
 
 end process;
 end algorithm;*)
@@ -323,6 +413,14 @@ end algorithm;*)
 VARIABLES record, intent_writes, tscache, commit_ack, pc
 
 (* define statement *)
+QueryIntent(key, query_epoch, query_ts) ==
+  LET
+    intent == intent_writes[key]
+  IN
+    /\ intent.epoch = query_epoch
+    /\ intent.ts <= query_ts
+    /\ intent.resolved = FALSE
+
 RecordStatuses  == {"pending", "staging", "committed", "aborted"}
 RecordStaged    == record.status = "staging"
 RecordCommitted == record.status = "committed"
@@ -365,7 +463,7 @@ TemporalIntentProperties ==
 
   /\ [][\A k \in KEYS: intent_writes'[k].ts >= intent_writes[k].ts]_intent_writes
 
-  /\ [][\A k \in KEYS: intent_writes[k].resolved => intent_writes'[k].resolved]_intent_writes
+  /\ <>[](\A k \in KEYS: intent_writes[k].resolved)
 
 TemporalTSCacheProperties ==
 
@@ -378,12 +476,14 @@ ImplicitCommitLeadsToExplicitCommit == ImplicitCommit ~> ExplicitCommit
 
 AckLeadsToExplicitCommit == commit_ack ~> ExplicitCommit
 
-VARIABLES txn_epoch, txn_ts, attempt, to_write, have_staged_record, 
-          prevent_epoch, prevent_ts, found_writes
+VARIABLES pipelined_keys, parallel_keys, attempt, txn_epoch, txn_ts, to_write, 
+          to_check, have_staged_record, prevent_epoch, prevent_ts, 
+          found_writes, to_resolve
 
-vars == << record, intent_writes, tscache, commit_ack, pc, txn_epoch, txn_ts, 
-           attempt, to_write, have_staged_record, prevent_epoch, prevent_ts, 
-           found_writes >>
+vars == << record, intent_writes, tscache, commit_ack, pc, pipelined_keys, 
+           parallel_keys, attempt, txn_epoch, txn_ts, to_write, to_check, 
+           have_staged_record, prevent_epoch, prevent_ts, found_writes, 
+           to_resolve >>
 
 ProcSet == {"committer"} \cup (PREVENTERS)
 
@@ -393,126 +493,216 @@ Init == (* Global variables *)
         /\ tscache = [k \in KEYS |-> 0]
         /\ commit_ack = FALSE
         (* Process committer *)
-        /\ txn_epoch = 1
-        /\ txn_ts = 1
-        /\ attempt = 0
-        /\ to_write = KEYS
+        /\ pipelined_keys \in SUBSET KEYS
+        /\ parallel_keys = KEYS \ pipelined_keys
+        /\ attempt = 1
+        /\ txn_epoch = 0
+        /\ txn_ts = 0
+        /\ to_write = {}
+        /\ to_check = {}
         /\ have_staged_record = FALSE
         (* Process preventer *)
         /\ prevent_epoch = [self \in PREVENTERS |-> 0]
         /\ prevent_ts = [self \in PREVENTERS |-> 0]
         /\ found_writes = [self \in PREVENTERS |-> {}]
-        /\ pc = [self \in ProcSet |-> CASE self = "committer" -> "StageWrites"
+        /\ to_resolve = [self \in PREVENTERS |-> KEYS]
+        /\ pc = [self \in ProcSet |-> CASE self = "committer" -> "BeginTxnEpoch"
                                         [] self \in PREVENTERS -> "PreventLoop"]
 
-StageWrites == /\ pc["committer"] = "StageWrites"
-               /\ attempt' = attempt + 1
-               /\ IF attempt' > MAX_ATTEMPTS
-                     THEN /\ pc' = [pc EXCEPT !["committer"] = "EndCommitter"]
-                     ELSE /\ pc' = [pc EXCEPT !["committer"] = "TryStageWrites"]
-               /\ UNCHANGED << record, intent_writes, tscache, commit_ack, 
-                               txn_epoch, txn_ts, to_write, have_staged_record, 
-                               prevent_epoch, prevent_ts, found_writes >>
+BeginTxnEpoch == /\ pc["committer"] = "BeginTxnEpoch"
+                 /\ txn_epoch' = txn_epoch + 1
+                 /\ txn_ts' = txn_ts + 1
+                 /\ to_write' = pipelined_keys
+                 /\ IF attempt > MAX_ATTEMPTS
+                       THEN /\ pc' = [pc EXCEPT !["committer"] = "EndCommitter"]
+                       ELSE /\ pc' = [pc EXCEPT !["committer"] = "PipelineWrites"]
+                 /\ UNCHANGED << record, intent_writes, tscache, commit_ack, 
+                                 pipelined_keys, parallel_keys, attempt, 
+                                 to_check, have_staged_record, prevent_epoch, 
+                                 prevent_ts, found_writes, to_resolve >>
 
-TryStageWrites == /\ pc["committer"] = "TryStageWrites"
-                  /\ IF to_write /= {} \/ ~have_staged_record
-                        THEN /\ \/ /\ to_write /= {}
-                                   /\ \E key \in to_write:
-                                        IF tscache[key] >= txn_ts
-                                           THEN /\ \/ /\ txn_ts' = txn_ts + 1
-                                                      /\ have_staged_record' = FALSE
-                                                      /\ pc' = [pc EXCEPT !["committer"] = "StageWrites"]
-                                                      /\ UNCHANGED <<txn_epoch, to_write>>
-                                                   \/ /\ txn_epoch' = txn_epoch + 1
-                                                      /\ txn_ts' = txn_ts + 1
-                                                      /\ to_write' = KEYS
-                                                      /\ have_staged_record' = FALSE
-                                                      /\ pc' = [pc EXCEPT !["committer"] = "StageWrites"]
-                                                /\ UNCHANGED intent_writes
-                                           ELSE /\ intent_writes' = [intent_writes EXCEPT ![key] =                       [
-                                                                                                     epoch    |-> txn_epoch,
-                                                                                                     ts       |-> txn_ts,
-                                                                                                     resolved |-> FALSE
-                                                                                                   ]]
-                                                /\ to_write' = to_write \ {key}
-                                                /\ pc' = [pc EXCEPT !["committer"] = "TryStageWrites"]
-                                                /\ UNCHANGED << txn_epoch, 
-                                                                txn_ts, 
-                                                                have_staged_record >>
-                                   /\ UNCHANGED record
-                                \/ /\ ~have_staged_record
-                                   /\ have_staged_record' = TRUE
-                                   /\ IF record.status = "pending"
-                                         THEN /\ record' = [status |-> "staging", epoch |-> txn_epoch, ts |-> txn_ts]
-                                              /\ pc' = [pc EXCEPT !["committer"] = "TryStageWrites"]
-                                         ELSE /\ IF record.status = "staging"
-                                                    THEN /\ Assert(record.epoch <= txn_epoch /\ record.ts < txn_ts, 
-                                                                   "Failure of assertion at line 173, column 13.")
-                                                         /\ record' = [status |-> "staging", epoch |-> txn_epoch, ts |-> txn_ts]
-                                                         /\ pc' = [pc EXCEPT !["committer"] = "TryStageWrites"]
-                                                    ELSE /\ IF record.status = "aborted"
-                                                               THEN /\ pc' = [pc EXCEPT !["committer"] = "EndCommitter"]
-                                                               ELSE /\ IF record.status = "committed"
-                                                                          THEN /\ Assert(FALSE, 
-                                                                                         "Failure of assertion at line 180, column 13.")
-                                                                          ELSE /\ TRUE
-                                                                    /\ pc' = [pc EXCEPT !["committer"] = "TryStageWrites"]
-                                                         /\ UNCHANGED record
-                                   /\ UNCHANGED <<intent_writes, txn_epoch, txn_ts, to_write>>
-                        ELSE /\ pc' = [pc EXCEPT !["committer"] = "AckClient"]
-                             /\ UNCHANGED << record, intent_writes, txn_epoch, 
-                                             txn_ts, to_write, 
-                                             have_staged_record >>
-                  /\ UNCHANGED << tscache, commit_ack, attempt, prevent_epoch, 
-                                  prevent_ts, found_writes >>
+PipelineWrites == /\ pc["committer"] = "PipelineWrites"
+                  /\ IF to_write /= {}
+                        THEN /\ \E key \in to_write:
+                                  IF intent_writes[key].resolved
+                                     THEN /\ to_write' = to_write \ {key}
+                                          /\ UNCHANGED intent_writes
+                                     ELSE /\ IF tscache[key] >= txn_ts
+                                                THEN /\ Assert(FALSE, 
+                                                               "Failure of assertion at line 176, column 11.")
+                                                     /\ UNCHANGED << intent_writes, 
+                                                                     to_write >>
+                                                ELSE /\ intent_writes' = [intent_writes EXCEPT ![key] =                       [
+                                                                                                          epoch    |-> txn_epoch,
+                                                                                                          ts       |-> txn_ts,
+                                                                                                          resolved |-> FALSE
+                                                                                                        ]]
+                                                     /\ to_write' = to_write \ {key}
+                             /\ pc' = [pc EXCEPT !["committer"] = "PipelineWrites"]
+                        ELSE /\ pc' = [pc EXCEPT !["committer"] = "StageWritesAndRecord"]
+                             /\ UNCHANGED << intent_writes, to_write >>
+                  /\ UNCHANGED << record, tscache, commit_ack, pipelined_keys, 
+                                  parallel_keys, attempt, txn_epoch, txn_ts, 
+                                  to_check, have_staged_record, prevent_epoch, 
+                                  prevent_ts, found_writes, to_resolve >>
+
+StageWritesAndRecord == /\ pc["committer"] = "StageWritesAndRecord"
+                        /\ to_write' = parallel_keys
+                        /\ to_check' = pipelined_keys
+                        /\ have_staged_record' = FALSE
+                        /\ IF attempt > MAX_ATTEMPTS
+                              THEN /\ pc' = [pc EXCEPT !["committer"] = "EndCommitter"]
+                              ELSE /\ pc' = [pc EXCEPT !["committer"] = "StageWritesAndRecordLoop"]
+                        /\ UNCHANGED << record, intent_writes, tscache, 
+                                        commit_ack, pipelined_keys, 
+                                        parallel_keys, attempt, txn_epoch, 
+                                        txn_ts, prevent_epoch, prevent_ts, 
+                                        found_writes, to_resolve >>
+
+StageWritesAndRecordLoop == /\ pc["committer"] = "StageWritesAndRecordLoop"
+                            /\ IF to_check /= {} \/ to_write /= {} \/ ~have_staged_record
+                                  THEN /\ \/ /\ to_check /= {}
+                                             /\ pc' = [pc EXCEPT !["committer"] = "QueryPipelinedWrite"]
+                                          \/ /\ to_write /= {}
+                                             /\ pc' = [pc EXCEPT !["committer"] = "ParallelWrite"]
+                                          \/ /\ ~have_staged_record
+                                             /\ pc' = [pc EXCEPT !["committer"] = "StageRecord"]
+                                  ELSE /\ pc' = [pc EXCEPT !["committer"] = "AckClient"]
+                            /\ UNCHANGED << record, intent_writes, tscache, 
+                                            commit_ack, pipelined_keys, 
+                                            parallel_keys, attempt, txn_epoch, 
+                                            txn_ts, to_write, to_check, 
+                                            have_staged_record, prevent_epoch, 
+                                            prevent_ts, found_writes, 
+                                            to_resolve >>
+
+QueryPipelinedWrite == /\ pc["committer"] = "QueryPipelinedWrite"
+                       /\ \E key \in to_check:
+                            IF QueryIntent(key, txn_epoch, txn_ts)
+                               THEN /\ to_check' = (to_check \union {key})
+                                    /\ pc' = [pc EXCEPT !["committer"] = "StageWritesAndRecordLoop"]
+                                    /\ UNCHANGED attempt
+                               ELSE /\ attempt' = attempt + 1
+                                    /\ pc' = [pc EXCEPT !["committer"] = "BeginTxnEpoch"]
+                                    /\ UNCHANGED to_check
+                       /\ UNCHANGED << record, intent_writes, tscache, 
+                                       commit_ack, pipelined_keys, 
+                                       parallel_keys, txn_epoch, txn_ts, 
+                                       to_write, have_staged_record, 
+                                       prevent_epoch, prevent_ts, found_writes, 
+                                       to_resolve >>
+
+ParallelWrite == /\ pc["committer"] = "ParallelWrite"
+                 /\ \E key \in to_write:
+                      LET cur_intent == intent_writes[key] IN
+                        IF cur_intent.epoch = txn_epoch
+                           THEN /\ to_write' = to_write \ {key}
+                                /\ pc' = [pc EXCEPT !["committer"] = "StageWritesAndRecordLoop"]
+                                /\ UNCHANGED << intent_writes, attempt, txn_ts >>
+                           ELSE /\ IF tscache[key] >= txn_ts \/ cur_intent.resolved
+                                      THEN /\ \/ /\ txn_ts' = txn_ts + 1
+                                                 /\ attempt' = attempt + 1
+                                                 /\ pc' = [pc EXCEPT !["committer"] = "StageWritesAndRecord"]
+                                              \/ /\ attempt' = attempt + 1
+                                                 /\ pc' = [pc EXCEPT !["committer"] = "BeginTxnEpoch"]
+                                                 /\ UNCHANGED txn_ts
+                                           /\ UNCHANGED << intent_writes, 
+                                                           to_write >>
+                                      ELSE /\ intent_writes' = [intent_writes EXCEPT ![key] =                       [
+                                                                                                epoch    |-> txn_epoch,
+                                                                                                ts       |-> txn_ts,
+                                                                                                resolved |-> FALSE
+                                                                                              ]]
+                                           /\ to_write' = to_write \ {key}
+                                           /\ pc' = [pc EXCEPT !["committer"] = "StageWritesAndRecordLoop"]
+                                           /\ UNCHANGED << attempt, txn_ts >>
+                 /\ UNCHANGED << record, tscache, commit_ack, pipelined_keys, 
+                                 parallel_keys, txn_epoch, to_check, 
+                                 have_staged_record, prevent_epoch, prevent_ts, 
+                                 found_writes, to_resolve >>
+
+StageRecord == /\ pc["committer"] = "StageRecord"
+               /\ have_staged_record' = TRUE
+               /\ IF record.status = "pending"
+                     THEN /\ record' = [status |-> "staging", epoch |-> txn_epoch, ts |-> txn_ts]
+                          /\ pc' = [pc EXCEPT !["committer"] = "StageWritesAndRecordLoop"]
+                     ELSE /\ IF record.status = "staging"
+                                THEN /\ Assert(record.epoch <= txn_epoch /\ record.ts < txn_ts, 
+                                               "Failure of assertion at line 257, column 15.")
+                                     /\ record' = [status |-> "staging", epoch |-> txn_epoch, ts |-> txn_ts]
+                                     /\ pc' = [pc EXCEPT !["committer"] = "StageWritesAndRecordLoop"]
+                                ELSE /\ IF record.status = "aborted"
+                                           THEN /\ pc' = [pc EXCEPT !["committer"] = "EndCommitter"]
+                                           ELSE /\ IF record.status = "committed"
+                                                      THEN /\ Assert(FALSE, 
+                                                                     "Failure of assertion at line 264, column 15.")
+                                                      ELSE /\ TRUE
+                                                /\ pc' = [pc EXCEPT !["committer"] = "StageWritesAndRecordLoop"]
+                                     /\ UNCHANGED record
+               /\ UNCHANGED << intent_writes, tscache, commit_ack, 
+                               pipelined_keys, parallel_keys, attempt, 
+                               txn_epoch, txn_ts, to_write, to_check, 
+                               prevent_epoch, prevent_ts, found_writes, 
+                               to_resolve >>
 
 AckClient == /\ pc["committer"] = "AckClient"
              /\ Assert(ImplicitCommit \/ ExplicitCommit, 
-                       "Failure of assertion at line 188, column 5.")
+                       "Failure of assertion at line 272, column 5.")
              /\ commit_ack' = TRUE
              /\ pc' = [pc EXCEPT !["committer"] = "AsyncExplicitCommit"]
-             /\ UNCHANGED << record, intent_writes, tscache, txn_epoch, txn_ts, 
-                             attempt, to_write, have_staged_record, 
-                             prevent_epoch, prevent_ts, found_writes >>
+             /\ UNCHANGED << record, intent_writes, tscache, pipelined_keys, 
+                             parallel_keys, attempt, txn_epoch, txn_ts, 
+                             to_write, to_check, have_staged_record, 
+                             prevent_epoch, prevent_ts, found_writes, 
+                             to_resolve >>
 
 AsyncExplicitCommit == /\ pc["committer"] = "AsyncExplicitCommit"
                        /\ IF record.status = "staging"
                              THEN /\ Assert(ImplicitCommit, 
-                                            "Failure of assertion at line 195, column 7.")
+                                            "Failure of assertion at line 279, column 7.")
                                   /\ record' = [record EXCEPT !.status = "committed"]
                              ELSE /\ IF record.status = "committed"
                                         THEN /\ TRUE
                                         ELSE /\ Assert(FALSE, 
-                                                       "Failure of assertion at line 203, column 7.")
+                                                       "Failure of assertion at line 287, column 7.")
                                   /\ UNCHANGED record
                        /\ to_write' = KEYS
                        /\ pc' = [pc EXCEPT !["committer"] = "AsyncResolveIntents"]
                        /\ UNCHANGED << intent_writes, tscache, commit_ack, 
-                                       txn_epoch, txn_ts, attempt, 
+                                       pipelined_keys, parallel_keys, attempt, 
+                                       txn_epoch, txn_ts, to_check, 
                                        have_staged_record, prevent_epoch, 
-                                       prevent_ts, found_writes >>
+                                       prevent_ts, found_writes, to_resolve >>
 
 AsyncResolveIntents == /\ pc["committer"] = "AsyncResolveIntents"
                        /\ IF to_write /= {}
                              THEN /\ \E key \in to_write:
-                                       /\ intent_writes' = [intent_writes EXCEPT ![key].resolved = TRUE]
+                                       /\ IF ~intent_writes[key].resolved
+                                             THEN /\ intent_writes' = [intent_writes EXCEPT ![key].resolved = TRUE]
+                                             ELSE /\ TRUE
+                                                  /\ UNCHANGED intent_writes
                                        /\ to_write' = to_write \ {key}
                                   /\ pc' = [pc EXCEPT !["committer"] = "AsyncResolveIntents"]
                              ELSE /\ pc' = [pc EXCEPT !["committer"] = "EndCommitter"]
                                   /\ UNCHANGED << intent_writes, to_write >>
-                       /\ UNCHANGED << record, tscache, commit_ack, txn_epoch, 
-                                       txn_ts, attempt, have_staged_record, 
-                                       prevent_epoch, prevent_ts, found_writes >>
+                       /\ UNCHANGED << record, tscache, commit_ack, 
+                                       pipelined_keys, parallel_keys, attempt, 
+                                       txn_epoch, txn_ts, to_check, 
+                                       have_staged_record, prevent_epoch, 
+                                       prevent_ts, found_writes, to_resolve >>
 
 EndCommitter == /\ pc["committer"] = "EndCommitter"
                 /\ TRUE
                 /\ pc' = [pc EXCEPT !["committer"] = "Done"]
                 /\ UNCHANGED << record, intent_writes, tscache, commit_ack, 
-                                txn_epoch, txn_ts, attempt, to_write, 
+                                pipelined_keys, parallel_keys, attempt, 
+                                txn_epoch, txn_ts, to_write, to_check, 
                                 have_staged_record, prevent_epoch, prevent_ts, 
-                                found_writes >>
+                                found_writes, to_resolve >>
 
-committer == StageWrites \/ TryStageWrites \/ AckClient
+committer == BeginTxnEpoch \/ PipelineWrites \/ StageWritesAndRecord
+                \/ StageWritesAndRecordLoop \/ QueryPipelinedWrite
+                \/ ParallelWrite \/ StageRecord \/ AckClient
                 \/ AsyncExplicitCommit \/ AsyncResolveIntents
                 \/ EndCommitter
 
@@ -520,51 +710,52 @@ PreventLoop(self) == /\ pc[self] = "PreventLoop"
                      /\ found_writes' = [found_writes EXCEPT ![self] = {}]
                      /\ pc' = [pc EXCEPT ![self] = "PushRecord"]
                      /\ UNCHANGED << record, intent_writes, tscache, 
-                                     commit_ack, txn_epoch, txn_ts, attempt, 
-                                     to_write, have_staged_record, 
-                                     prevent_epoch, prevent_ts >>
+                                     commit_ack, pipelined_keys, parallel_keys, 
+                                     attempt, txn_epoch, txn_ts, to_write, 
+                                     to_check, have_staged_record, 
+                                     prevent_epoch, prevent_ts, to_resolve >>
 
 PushRecord(self) == /\ pc[self] = "PushRecord"
                     /\ IF record.status = "pending"
                           THEN /\ record' = [record EXCEPT !.status = "aborted"]
-                               /\ pc' = [pc EXCEPT ![self] = "EndRecover"]
+                               /\ pc' = [pc EXCEPT ![self] = "ResolveIntents"]
                                /\ UNCHANGED << prevent_epoch, prevent_ts >>
                           ELSE /\ IF record.status = "staging"
                                      THEN /\ prevent_epoch' = [prevent_epoch EXCEPT ![self] = record.epoch]
                                           /\ prevent_ts' = [prevent_ts EXCEPT ![self] = record.ts]
                                           /\ pc' = [pc EXCEPT ![self] = "PreventWrites"]
                                      ELSE /\ IF record.status \in {"committed", "aborted"}
-                                                THEN /\ pc' = [pc EXCEPT ![self] = "EndRecover"]
+                                                THEN /\ pc' = [pc EXCEPT ![self] = "ResolveIntents"]
                                                 ELSE /\ pc' = [pc EXCEPT ![self] = "PreventWrites"]
                                           /\ UNCHANGED << prevent_epoch, 
                                                           prevent_ts >>
                                /\ UNCHANGED record
                     /\ UNCHANGED << intent_writes, tscache, commit_ack, 
-                                    txn_epoch, txn_ts, attempt, to_write, 
-                                    have_staged_record, found_writes >>
+                                    pipelined_keys, parallel_keys, attempt, 
+                                    txn_epoch, txn_ts, to_write, to_check, 
+                                    have_staged_record, found_writes, 
+                                    to_resolve >>
 
 PreventWrites(self) == /\ pc[self] = "PreventWrites"
                        /\ IF found_writes[self] /= KEYS
                              THEN /\ \E key \in KEYS \ found_writes[self]:
-                                       LET intent == intent_writes[key] IN
-                                         IF /\ intent.epoch = prevent_epoch[self]
-                                            /\ intent.ts <= prevent_ts[self]
-                                            /\ intent.resolved = FALSE
-                                            THEN /\ found_writes' = [found_writes EXCEPT ![self] = found_writes[self] \union {key}]
-                                                 /\ pc' = [pc EXCEPT ![self] = "PreventWrites"]
-                                                 /\ UNCHANGED tscache
-                                            ELSE /\ IF tscache[key] < prevent_ts[self]
-                                                       THEN /\ tscache' = [tscache EXCEPT ![key] = prevent_ts[self]]
-                                                       ELSE /\ TRUE
-                                                            /\ UNCHANGED tscache
-                                                 /\ pc' = [pc EXCEPT ![self] = "RecoverRecord"]
-                                                 /\ UNCHANGED found_writes
+                                       IF QueryIntent(key, prevent_epoch[self], prevent_ts[self])
+                                          THEN /\ found_writes' = [found_writes EXCEPT ![self] = found_writes[self] \union {key}]
+                                               /\ pc' = [pc EXCEPT ![self] = "PreventWrites"]
+                                               /\ UNCHANGED tscache
+                                          ELSE /\ IF tscache[key] < prevent_ts[self]
+                                                     THEN /\ tscache' = [tscache EXCEPT ![key] = prevent_ts[self]]
+                                                     ELSE /\ TRUE
+                                                          /\ UNCHANGED tscache
+                                               /\ pc' = [pc EXCEPT ![self] = "RecoverRecord"]
+                                               /\ UNCHANGED found_writes
                              ELSE /\ pc' = [pc EXCEPT ![self] = "RecoverRecord"]
                                   /\ UNCHANGED << tscache, found_writes >>
                        /\ UNCHANGED << record, intent_writes, commit_ack, 
-                                       txn_epoch, txn_ts, attempt, to_write, 
+                                       pipelined_keys, parallel_keys, attempt, 
+                                       txn_epoch, txn_ts, to_write, to_check, 
                                        have_staged_record, prevent_epoch, 
-                                       prevent_ts >>
+                                       prevent_ts, to_resolve >>
 
 RecoverRecord(self) == /\ pc[self] = "RecoverRecord"
                        /\ LET prevented == found_writes[self] /= KEYS IN
@@ -573,59 +764,69 @@ RecoverRecord(self) == /\ pc[self] = "RecoverRecord"
                                                            /\ record.ts    >  prevent_ts[self] IN
                                          IF record.status = "aborted"
                                             THEN /\ TRUE
-                                                 /\ pc' = [pc EXCEPT ![self] = "EndRecover"]
+                                                 /\ pc' = [pc EXCEPT ![self] = "ResolveIntents"]
                                                  /\ UNCHANGED record
                                             ELSE /\ IF record.status = "committed"
                                                        THEN /\ TRUE
-                                                            /\ pc' = [pc EXCEPT ![self] = "EndRecover"]
+                                                            /\ pc' = [pc EXCEPT ![self] = "ResolveIntents"]
                                                             /\ UNCHANGED record
                                                        ELSE /\ IF record.status = "pending"
                                                                   THEN /\ Assert(FALSE, 
-                                                                                 "Failure of assertion at line 287, column 15.")
-                                                                       /\ pc' = [pc EXCEPT ![self] = "EndRecover"]
+                                                                                 "Failure of assertion at line 367, column 15.")
+                                                                       /\ pc' = [pc EXCEPT ![self] = "ResolveIntents"]
                                                                        /\ UNCHANGED record
                                                                   ELSE /\ IF record.status = "staging"
                                                                              THEN /\ IF legal_change
                                                                                         THEN /\ pc' = [pc EXCEPT ![self] = "PreventLoop"]
                                                                                              /\ UNCHANGED record
                                                                                         ELSE /\ record' = [record EXCEPT !.status = "aborted"]
-                                                                                             /\ pc' = [pc EXCEPT ![self] = "EndRecover"]
-                                                                             ELSE /\ pc' = [pc EXCEPT ![self] = "EndRecover"]
+                                                                                             /\ pc' = [pc EXCEPT ![self] = "ResolveIntents"]
+                                                                             ELSE /\ pc' = [pc EXCEPT ![self] = "ResolveIntents"]
                                                                                   /\ UNCHANGED record
                                ELSE /\ IF record.status \in {"pending", "aborted"}
                                           THEN /\ Assert(FALSE, 
-                                                         "Failure of assertion at line 302, column 13.")
+                                                         "Failure of assertion at line 382, column 13.")
                                                /\ UNCHANGED record
                                           ELSE /\ IF record.status \in {"staging", "committed"}
                                                      THEN /\ Assert(record.epoch = prevent_epoch[self], 
-                                                                    "Failure of assertion at line 305, column 13.")
+                                                                    "Failure of assertion at line 385, column 13.")
                                                           /\ Assert(record.ts    = prevent_ts[self], 
-                                                                    "Failure of assertion at line 306, column 13.")
+                                                                    "Failure of assertion at line 386, column 13.")
                                                           /\ IF record.status = "staging"
                                                                 THEN /\ Assert(ImplicitCommit, 
-                                                                               "Failure of assertion at line 310, column 15.")
+                                                                               "Failure of assertion at line 390, column 15.")
                                                                      /\ record' = [record EXCEPT !.status = "committed"]
                                                                 ELSE /\ TRUE
                                                                      /\ UNCHANGED record
                                                      ELSE /\ TRUE
                                                           /\ UNCHANGED record
-                                    /\ pc' = [pc EXCEPT ![self] = "EndRecover"]
+                                    /\ pc' = [pc EXCEPT ![self] = "ResolveIntents"]
                        /\ UNCHANGED << intent_writes, tscache, commit_ack, 
-                                       txn_epoch, txn_ts, attempt, to_write, 
+                                       pipelined_keys, parallel_keys, attempt, 
+                                       txn_epoch, txn_ts, to_write, to_check, 
                                        have_staged_record, prevent_epoch, 
-                                       prevent_ts, found_writes >>
+                                       prevent_ts, found_writes, to_resolve >>
 
-EndRecover(self) == /\ pc[self] = "EndRecover"
-                    /\ TRUE
-                    /\ pc' = [pc EXCEPT ![self] = "Done"]
-                    /\ UNCHANGED << record, intent_writes, tscache, commit_ack, 
-                                    txn_epoch, txn_ts, attempt, to_write, 
-                                    have_staged_record, prevent_epoch, 
-                                    prevent_ts, found_writes >>
+ResolveIntents(self) == /\ pc[self] = "ResolveIntents"
+                        /\ IF to_resolve[self] /= {}
+                              THEN /\ \E key \in to_resolve[self]:
+                                        /\ IF ~intent_writes[key].resolved
+                                              THEN /\ intent_writes' = [intent_writes EXCEPT ![key].resolved = TRUE]
+                                              ELSE /\ TRUE
+                                                   /\ UNCHANGED intent_writes
+                                        /\ to_resolve' = [to_resolve EXCEPT ![self] = to_resolve[self] \ {key}]
+                                   /\ pc' = [pc EXCEPT ![self] = "ResolveIntents"]
+                              ELSE /\ pc' = [pc EXCEPT ![self] = "Done"]
+                                   /\ UNCHANGED << intent_writes, to_resolve >>
+                        /\ UNCHANGED << record, tscache, commit_ack, 
+                                        pipelined_keys, parallel_keys, attempt, 
+                                        txn_epoch, txn_ts, to_write, to_check, 
+                                        have_staged_record, prevent_epoch, 
+                                        prevent_ts, found_writes >>
 
 preventer(self) == PreventLoop(self) \/ PushRecord(self)
                       \/ PreventWrites(self) \/ RecoverRecord(self)
-                      \/ EndRecover(self)
+                      \/ ResolveIntents(self)
 
 Next == committer
            \/ (\E self \in PREVENTERS: preventer(self))
@@ -643,5 +844,5 @@ Termination == <>(\A self \in ProcSet: pc[self] = "Done")
 
 =============================================================================
 \* Modification History
-\* Last modified Fri May 24 00:38:49 EDT 2019 by nathan
+\* Last modified Wed May 29 00:09:05 EDT 2019 by nathan
 \* Created Mon May 13 10:03:40 EDT 2019 by nathan

--- a/docs/tla-plus/ParallelCommits/ParallelCommits.toolbox/ParallelCommits___Model_1.launch
+++ b/docs/tla-plus/ParallelCommits/ParallelCommits.toolbox/ParallelCommits___Model_1.launch
@@ -6,7 +6,7 @@
 <intAttribute key="dfidDepth" value="100"/>
 <booleanAttribute key="dfidMode" value="false"/>
 <intAttribute key="distributedFPSetCount" value="0"/>
-<stringAttribute key="distributedNetworkInterface" value="10.0.0.104"/>
+<stringAttribute key="distributedNetworkInterface" value="192.168.13.240"/>
 <intAttribute key="distributedNodesCount" value="1"/>
 <stringAttribute key="distributedTLC" value="off"/>
 <stringAttribute key="distributedTLCVMArgs" value=""/>
@@ -19,7 +19,7 @@
 <stringAttribute key="modelBehaviorNext" value=""/>
 <stringAttribute key="modelBehaviorSpec" value="Spec"/>
 <intAttribute key="modelBehaviorSpecType" value="1"/>
-<stringAttribute key="modelBehaviorVars" value="intent_writes, to_write, txn_epoch, txn_ts, prevent_epoch, pc, commit_ack, record, have_staged_record, found_writes, prevent_ts, tscache, attempt"/>
+<stringAttribute key="modelBehaviorVars" value="intent_writes, to_write, txn_epoch, txn_ts, pipelined_keys, to_check, prevent_epoch, pc, commit_ack, to_resolve, record, have_staged_record, found_writes, prevent_ts, parallel_keys, tscache, attempt"/>
 <stringAttribute key="modelComments" value=""/>
 <booleanAttribute key="modelCorrectnessCheckDeadlock" value="true"/>
 <listAttribute key="modelCorrectnessInvariants">
@@ -50,6 +50,9 @@
 <intAttribute key="simuDepth" value="100"/>
 <intAttribute key="simuSeed" value="-1"/>
 <stringAttribute key="specName" value="ParallelCommits"/>
+<listAttribute key="traceExploreExpressions">
+<listEntry value="1ImplicitCommit"/>
+</listAttribute>
 <stringAttribute key="view" value=""/>
 <booleanAttribute key="visualizeStateGraph" value="false"/>
 </launchConfiguration>


### PR DESCRIPTION
This PR starts by adding write pipelining and concurrent intent resolution by conflicting transactions to the parallel commits TLA+ spec. This causes an assertion to be triggered by the hazard discussed in #37866.

The assertion fires when the pre-commit QueryIntent for a pipelined write gets confused about an already resolved intent. This triggers a transaction retry, at which point the transaction record is unexpectedly already committed.

This PR then proposes a medium-term solution to #37866. In doing so, it resolved the model failure from the previous commit.

The medium-term solution is to catch `IntentMissingErrors` in `DistSender`'s `divideAndSendParallelCommit` method coming from the pre-commit QueryIntent batch (right around [here](https://github.com/cockroachdb/cockroach/blob/2428567cba5e0838615521cbc9d0e1310f0ee6ad/pkg/kv/dist_sender.go#L916)). When we see one of these errors, we immediately send a `QueryTxn` request to the transaction record. This will result in one of the four statuses:
1. PENDING: Unexpected because the parallel commit `EndTransactionRequest` succeeded. Ignore.
2. STAGING: Unambiguously not the issue from #37866. Ignore.
3. COMMITTED: Unambiguously the issue from #37866. Strip the error and return the updated proto.
4. ABORTED: Still ambiguous. Transform error into an AmbiguousCommitError and return.

This solution isolates the ambiguity caused by the loss of information during intent resolution to just the case where the result of the QueryTxn is ABORTED. This is because an ABORTED record can mean either 1) the transaction was ABORTED and the missing intent was removed or 2) the transaction was COMMITTED, all intents were resolved, and the transaction record was GCed.

This is a significant reduction in the cases where an AmbiguousCommitError will be needed and I suspect it will be able to tide us over until we're able to eliminate the loss of information caused by intent resolution almost entirely (e.g. by storing transaction IDs in committed values). There will still be some loss of information if we're not careful about MVCC GC, and it's still not completely clear to me how we'll need to handle that in every case. That's a discussion for a different time.