### PR TITLE
opt: add PushSelectIntoWindow

### DIFF
--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -1122,6 +1122,12 @@ func (c *CustomFuncs) ReduceWindowPartitionCols(
 	return &p
 }
 
+// WindowPartition returns the set of columns that the window function uses to
+// partition.
+func (c *CustomFuncs) WindowPartition(priv *memo.WindowPrivate) opt.ColSet {
+	return priv.Partition
+}
+
 // ----------------------------------------------------------------------
 //
 // Boolean Rules

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -235,6 +235,13 @@ func (c *CustomFuncs) IsBoundBy(src opt.Expr, cols opt.ColSet) bool {
 	return c.OuterCols(src).SubsetOf(cols)
 }
 
+// IsDeterminedBy returns true if all outer references in the source expression
+// are bound by the closure of the given columns according to the functional
+// dependencies of the input expression.
+func (c *CustomFuncs) IsDeterminedBy(src opt.Expr, cols opt.ColSet, input memo.RelExpr) bool {
+	return input.Relational().FuncDeps.InClosureOf(c.OuterCols(src), cols)
+}
+
 // IsCorrelated returns true if any variable in the source expression references
 // a column from the destination expression. For example:
 //   (InnerJoin
@@ -525,6 +532,35 @@ func (c *CustomFuncs) ExtractUnboundConditions(
 	newFilters := make(memo.FiltersExpr, 0, len(filters))
 	for i := range filters {
 		if !c.IsBoundBy(&filters[i], cols) {
+			newFilters = append(newFilters, filters[i])
+		}
+	}
+	return newFilters
+}
+
+// ExtractDeterminedConditions returns a new list of filters containing only
+// those expressions from the given list which are bound by columns which
+// are functionally determined by the given columns.
+func (c *CustomFuncs) ExtractDeterminedConditions(
+	filters memo.FiltersExpr, cols opt.ColSet, input memo.RelExpr,
+) memo.FiltersExpr {
+	newFilters := make(memo.FiltersExpr, 0, len(filters))
+	for i := range filters {
+		if c.IsDeterminedBy(&filters[i], cols, input) {
+			newFilters = append(newFilters, filters[i])
+		}
+	}
+	return newFilters
+}
+
+// ExtractUndeterminedConditions is the opposite of
+// ExtractDeterminedConditions.
+func (c *CustomFuncs) ExtractUndeterminedConditions(
+	filters memo.FiltersExpr, cols opt.ColSet, input memo.RelExpr,
+) memo.FiltersExpr {
+	newFilters := make(memo.FiltersExpr, 0, len(filters))
+	for i := range filters {
+		if !c.IsDeterminedBy(&filters[i], cols, input) {
 			newFilters = append(newFilters, filters[i])
 		}
 	}

--- a/pkg/sql/opt/norm/rules/window.opt
+++ b/pkg/sql/opt/norm/rules/window.opt
@@ -44,3 +44,32 @@ $input
     $fn
     (SimplifyWindowOrdering $input $private)
 )
+
+# PushSelectIntoWindow pushes down a Select which can be satisfied by only the
+# columns being partitioned over. This is valid because it's "all-or-nothing" -
+# we only entirely eliminate a partition or don't eliminate it at all.
+[PushSelectIntoWindow, Normalize]
+(Select
+    (Window
+      $input:*
+      $fn:*
+      $private:*
+    )
+    $filters:[
+        ...
+        $item:* & (IsBoundBy $item $partitionCols:(WindowPartition $private))
+        ...
+    ]
+)
+=>
+(Select
+    (Window
+        (Select
+            $input
+            (ExtractBoundConditions $filters $partitionCols)
+        )
+        $fn
+        $private
+    )
+    (ExtractUnboundConditions $filters $partitionCols)
+)

--- a/pkg/sql/opt/norm/rules/window.opt
+++ b/pkg/sql/opt/norm/rules/window.opt
@@ -46,8 +46,9 @@ $input
 )
 
 # PushSelectIntoWindow pushes down a Select which can be satisfied by only the
-# columns being partitioned over. This is valid because it's "all-or-nothing" -
-# we only entirely eliminate a partition or don't eliminate it at all.
+# functional closure of the columns being partitioned over. This is valid
+# because it's "all-or-nothing" - we only entirely eliminate a partition or
+# don't eliminate it at all.
 [PushSelectIntoWindow, Normalize]
 (Select
     (Window
@@ -57,7 +58,7 @@ $input
     )
     $filters:[
         ...
-        $item:* & (IsBoundBy $item $partitionCols:(WindowPartition $private))
+        $item:* & (IsDeterminedBy $item $partitionCols:(WindowPartition $private) $input)
         ...
     ]
 )
@@ -66,10 +67,10 @@ $input
     (Window
         (Select
             $input
-            (ExtractBoundConditions $filters $partitionCols)
+            (ExtractDeterminedConditions $filters $partitionCols $input)
         )
         $fn
         $private
     )
-    (ExtractUnboundConditions $filters $partitionCols)
+    (ExtractUndeterminedConditions $filters $partitionCols $input)
 )

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -296,34 +296,34 @@ WHERE i = 3
 ----
 project
  ├── columns: u:1(int!null) v:2(int) rank:8(int) i:4(int!null)
- ├── key: (1)
- ├── fd: ()-->(4), (1)-->(2,8)
- └── select
+ ├── key: (1,8)
+ ├── fd: ()-->(4), (1)-->(2)
+ └── window partition=(1)
       ├── columns: u:1(int!null) v:2(int) k:3(int!null) i:4(int!null) rank:8(int)
       ├── key: (3)
-      ├── fd: ()-->(4), (1)-->(2), (1)==(3), (3)==(1), (3)-->(8)
-      ├── window partition=(1)
-      │    ├── columns: u:1(int!null) v:2(int) k:3(int!null) i:4(int) rank:8(int)
+      ├── fd: ()-->(4), (1)-->(2), (1)==(3), (3)==(1)
+      ├── inner-join
+      │    ├── columns: u:1(int!null) v:2(int) k:3(int!null) i:4(int!null)
       │    ├── key: (3)
-      │    ├── fd: (1)-->(2), (3)-->(4), (1)==(3), (3)==(1)
-      │    ├── inner-join
-      │    │    ├── columns: u:1(int!null) v:2(int) k:3(int!null) i:4(int)
+      │    ├── fd: ()-->(4), (1)-->(2), (1)==(3), (3)==(1)
+      │    ├── scan uv
+      │    │    ├── columns: u:1(int!null) v:2(int)
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2)
+      │    ├── select
+      │    │    ├── columns: k:3(int!null) i:4(int!null)
       │    │    ├── key: (3)
-      │    │    ├── fd: (1)-->(2), (3)-->(4), (1)==(3), (3)==(1)
-      │    │    ├── scan uv
-      │    │    │    ├── columns: u:1(int!null) v:2(int)
-      │    │    │    ├── key: (1)
-      │    │    │    └── fd: (1)-->(2)
+      │    │    ├── fd: ()-->(4)
       │    │    ├── scan a
       │    │    │    ├── columns: k:3(int!null) i:4(int)
       │    │    │    ├── key: (3)
       │    │    │    └── fd: (3)-->(4)
       │    │    └── filters
-      │    │         └── k = u [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
-      │    └── windows
-      │         └── rank [type=undefined]
-      └── filters
-           └── i = 3 [type=bool, outer=(4), constraints=(/4: [/3 - /3]; tight), fd=()-->(4)]
+      │    │         └── i = 3 [type=bool, outer=(4), constraints=(/4: [/3 - /3]; tight), fd=()-->(4)]
+      │    └── filters
+      │         └── k = u [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+      └── windows
+           └── rank [type=undefined]
 
 # TryDecorrelateWindow will trigger twice here: first to pull the window above
 # the non-apply join, and then again the pull it above the apply join.

--- a/pkg/sql/opt/norm/testdata/rules/window
+++ b/pkg/sql/opt/norm/testdata/rules/window
@@ -212,3 +212,72 @@ project
       │         └── rank [type=undefined]
       └── filters
            └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+
+# Can push down filters on columns in the closure of the partition columns.
+norm expect=PushSelectIntoWindow
+SELECT * FROM (SELECT i, rank() OVER (PARTITION BY k ORDER BY f) FROM a) WHERE i = 3
+----
+project
+ ├── columns: i:2(int!null) rank:6(int)
+ ├── fd: ()-->(2)
+ └── window partition=(1)
+      ├── columns: k:1(int!null) i:2(int!null) rank:6(int)
+      ├── key: (1)
+      ├── fd: ()-->(2)
+      ├── select
+      │    ├── columns: k:1(int!null) i:2(int!null)
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2)
+      │    ├── scan a
+      │    │    ├── columns: k:1(int!null) i:2(int)
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2)
+      │    └── filters
+      │         └── i = 3 [type=bool, outer=(2), constraints=(/2: [/3 - /3]; tight), fd=()-->(2)]
+      └── windows
+           └── rank [type=undefined]
+
+norm expect=PushSelectIntoWindow
+SELECT * FROM (SELECT i, f, rank() OVER (PARTITION BY k ORDER BY f) FROM a) WHERE i*f::int = 3
+----
+project
+ ├── columns: i:2(int) f:3(float) rank:6(int)
+ └── window partition=(1)
+      ├── columns: k:1(int!null) i:2(int) f:3(float) rank:6(int)
+      ├── key: (1)
+      ├── fd: (1)-->(2,3)
+      ├── select
+      │    ├── columns: k:1(int!null) i:2(int) f:3(float)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2,3)
+      │    ├── scan a
+      │    │    ├── columns: k:1(int!null) i:2(int) f:3(float)
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2,3)
+      │    └── filters
+      │         └── (i * f::INT8) = 3 [type=bool, outer=(2,3)]
+      └── windows
+           └── rank [type=undefined]
+
+norm expect-not=PushSelectIntoWindow
+SELECT * FROM (SELECT i, f, rank() OVER (PARTITION BY k ORDER BY f) AS rnk FROM a) WHERE rnk = 3
+----
+project
+ ├── columns: i:2(int) f:3(float) rnk:6(int!null)
+ ├── fd: ()-->(6)
+ └── select
+      ├── columns: k:1(int!null) i:2(int) f:3(float) rank:6(int!null)
+      ├── key: (1)
+      ├── fd: ()-->(6), (1)-->(2,3)
+      ├── window partition=(1)
+      │    ├── columns: k:1(int!null) i:2(int) f:3(float) rank:6(int)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2,3)
+      │    ├── scan a
+      │    │    ├── columns: k:1(int!null) i:2(int) f:3(float)
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2,3)
+      │    └── windows
+      │         └── rank [type=undefined]
+      └── filters
+           └── rank = 3 [type=bool, outer=(6), constraints=(/6: [/3 - /3]; tight), fd=()-->(6)]

--- a/pkg/sql/opt/norm/testdata/rules/window
+++ b/pkg/sql/opt/norm/testdata/rules/window
@@ -99,3 +99,116 @@ project
       │    └── columns: i:2(int) f:3(float)
       └── windows
            └── rank [type=undefined]
+
+# PushSelectIntoWindow
+
+norm expect=PushSelectIntoWindow
+SELECT * FROM (SELECT i, rank() OVER (PARTITION BY i) FROM a) WHERE i > 4
+----
+window partition=(2)
+ ├── columns: i:2(int!null) rank:6(int)
+ ├── select
+ │    ├── columns: i:2(int!null)
+ │    ├── scan a
+ │    │    └── columns: i:2(int)
+ │    └── filters
+ │         └── i > 4 [type=bool, outer=(2), constraints=(/2: [/5 - ]; tight)]
+ └── windows
+      └── rank [type=undefined]
+
+# Only push down filters bound by the partition cols.
+norm expect=PushSelectIntoWindow
+SELECT * FROM (SELECT i, s, rank() OVER (PARTITION BY i) FROM a) WHERE i > 4 AND s = 'foo'
+----
+select
+ ├── columns: i:2(int!null) s:4(string!null) rank:6(int)
+ ├── fd: ()-->(4)
+ ├── window partition=(2)
+ │    ├── columns: i:2(int!null) s:4(string) rank:6(int)
+ │    ├── select
+ │    │    ├── columns: i:2(int!null) s:4(string)
+ │    │    ├── scan a
+ │    │    │    └── columns: i:2(int) s:4(string)
+ │    │    └── filters
+ │    │         └── i > 4 [type=bool, outer=(2), constraints=(/2: [/5 - ]; tight)]
+ │    └── windows
+ │         └── rank [type=undefined]
+ └── filters
+      └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+
+# Multiple partition cols.
+norm expect=PushSelectIntoWindow
+SELECT * FROM (SELECT i, s, f, rank() OVER (PARTITION BY i, f) FROM a) WHERE i > 4 AND f = 3.0 AND s = 'foo'
+----
+select
+ ├── columns: i:2(int!null) s:4(string!null) f:3(float!null) rank:6(int)
+ ├── fd: ()-->(3,4)
+ ├── window partition=(2)
+ │    ├── columns: i:2(int!null) f:3(float!null) s:4(string) rank:6(int)
+ │    ├── fd: ()-->(3)
+ │    ├── select
+ │    │    ├── columns: i:2(int!null) f:3(float!null) s:4(string)
+ │    │    ├── fd: ()-->(3)
+ │    │    ├── scan a
+ │    │    │    └── columns: i:2(int) f:3(float) s:4(string)
+ │    │    └── filters
+ │    │         ├── i > 4 [type=bool, outer=(2), constraints=(/2: [/5 - ]; tight)]
+ │    │         └── f = 3.0 [type=bool, outer=(3), constraints=(/3: [/3.0 - /3.0]; tight), fd=()-->(3)]
+ │    └── windows
+ │         └── rank [type=undefined]
+ └── filters
+      └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+
+# This is not really correct, but there isn't a precedent for rejecting such filters.
+# TODO(justin): consider revisiting this and not pushing this filter down.
+norm expect=PushSelectIntoWindow
+SELECT * FROM (SELECT i, s, f, rank() OVER (PARTITION BY i, f) FROM a) WHERE random() < 0.5
+----
+window partition=(2,3)
+ ├── columns: i:2(int) s:4(string) f:3(float) rank:6(int)
+ ├── side-effects
+ ├── select
+ │    ├── columns: i:2(int) f:3(float) s:4(string)
+ │    ├── side-effects
+ │    ├── scan a
+ │    │    └── columns: i:2(int) f:3(float) s:4(string)
+ │    └── filters
+ │         └── random() < 0.5 [type=bool, side-effects]
+ └── windows
+      └── rank [type=undefined]
+
+# Can't push down a filter on an ordering column.
+norm expect-not=PushSelectIntoWindow
+SELECT * FROM (SELECT f, rank() OVER (PARTITION BY i ORDER BY f) FROM a) WHERE f > 4
+----
+project
+ ├── columns: f:3(float!null) rank:6(int)
+ └── select
+      ├── columns: i:2(int) f:3(float!null) rank:6(int)
+      ├── window partition=(2) ordering=+3 opt(2)
+      │    ├── columns: i:2(int) f:3(float) rank:6(int)
+      │    ├── scan a
+      │    │    └── columns: i:2(int) f:3(float)
+      │    └── windows
+      │         └── rank [type=undefined]
+      └── filters
+           └── f > 4.0 [type=bool, outer=(3), constraints=(/3: [/4.000000000000001 - ]; tight)]
+
+# Can't push down a filter on an arbitrary column.
+norm expect-not=PushSelectIntoWindow
+SELECT * FROM (SELECT s, rank() OVER (PARTITION BY i ORDER BY f) FROM a) WHERE s = 'foo'
+----
+project
+ ├── columns: s:4(string!null) rank:6(int)
+ ├── fd: ()-->(4)
+ └── select
+      ├── columns: i:2(int) f:3(float) s:4(string!null) rank:6(int)
+      ├── fd: ()-->(4)
+      ├── window partition=(2) ordering=+3 opt(2)
+      │    ├── columns: i:2(int) f:3(float) s:4(string) rank:6(int)
+      │    ├── scan a
+      │    │    └── columns: i:2(int) f:3(float) s:4(string)
+      │    └── windows
+      │         └── rank [type=undefined]
+      └── filters
+           └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]


### PR DESCRIPTION
This commit adds a rule to push select filters into a Window expression.
This is valid to do whenever a filter is bound by the partition columns
of the Window expression.

Release note: None