### PR TITLE
roachtest: fix import/tpcc/warehouses=1000/nodes=4

### DIFF
--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -43,10 +43,8 @@ func registerImportTPCC(r *registry) {
 		m.Go(func(ctx context.Context) error {
 			defer dul.Done()
 			defer hc.Done()
-			// For fixtures import, use the version built into the cockroach binary so
-			// the tpcc workload-versions match on release branches.
 			cmd := fmt.Sprintf(
-				`./cockroach workload fixtures import tpcc --warehouses=%d --csv-server='http://localhost:8081'`,
+				`./workload fixtures import tpcc --warehouses=%d --csv-server='http://localhost:8081'`,
 				warehouses)
 			c.Run(ctx, c.Node(1), cmd)
 			return nil


### PR DESCRIPTION
In #37726, I switched a few places use the `workload fixtures import` in
the cockroach cli so the version string would match between the
`fixtures import` command and whatever was producing the data, but I
should have left this one alone. It's using `--csv-server` so, in
contrast to the other places I fixed that that PR, in this case the
workload binary is both ends. (`--csv-server` causes cockroach to read
csv data from an http server inside the standalone workload command.)

This broke because `fixtures import` works with the `--csv-server` flag
on master, but that hasn't been backported to anything else, so the
workload built into the cockroach cli doesn't know about that flag for
fixtures import. My smoke tests didn't catch this because I was using a
cockroach binary built from master.

Hopefully this is the last of the fallout.

Touches #37371

Release note: None