### PR TITLE
roachtest: Move jepsen-initialized marker out of defer

### DIFF
--- a/pkg/cmd/roachtest/jepsen.go
+++ b/pkg/cmd/roachtest/jepsen.go
@@ -70,9 +70,6 @@ func initJepsen(ctx context.Context, t *test, c *cluster) {
 	}
 	t.l.Printf("initializing cluster\n")
 	t.Status("initializing cluster")
-	defer func() {
-		c.Run(ctx, c.Node(1), "touch jepsen_initialized")
-	}()
 
 	// Roachprod collects this directory by default. If we fail early,
 	// this is the only log collection that is done. Otherwise, we
@@ -130,6 +127,9 @@ func initJepsen(ctx context.Context, t *test, c *cluster) {
 	for _, ip := range c.InternalIP(ctx, workers) {
 		c.Run(ctx, controller, "sh", "-c", fmt.Sprintf(`"ssh-keyscan -t rsa %s >> .ssh/known_hosts"`, ip))
 	}
+
+	t.l.Printf("cluster initialization complete\n")
+	c.Run(ctx, c.Node(1), "touch jepsen_initialized")
 }
 
 func runJepsen(ctx context.Context, t *test, c *cluster, testName, nemesis string) {


### PR DESCRIPTION
This was running whether the test succeeded or failed, which is silly.

Fixes #37831

Release note: None