### PR TITLE
release-19.1: sql: mark age() as impure

### DIFF
--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -1013,15 +1013,17 @@ SELECT * FROM t1, t2 WHERE a = b AND age(b, TIMESTAMPTZ '2017-01-01') > INTERVAL
 ----
 inner-join
  ├── columns: a:1(date!null) b:3(timestamptz!null)
+ ├── side-effects
  ├── fd: (1)==(3), (3)==(1)
  ├── scan t1
  │    └── columns: a:1(date)
  ├── select
  │    ├── columns: b:3(timestamptz)
+ │    ├── side-effects
  │    ├── scan t2
  │    │    └── columns: b:3(timestamptz)
  │    └── filters
- │         └── age(b, '2017-01-01 00:00:00+00:00') > '1 day' [type=bool, outer=(3)]
+ │         └── age(b, '2017-01-01 00:00:00+00:00') > '1 day' [type=bool, outer=(3), side-effects]
  └── filters
       └── a = b [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1660,7 +1660,8 @@ CockroachDB supports the following flags:
 	),
 
 	// https://www.postgresql.org/docs/10/static/functions-datetime.html
-	"age": makeBuiltin(defProps(),
+	"age": makeBuiltin(
+		tree.FunctionProperties{Impure: true},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.TimestampTZ}},
 			ReturnType: tree.FixedReturnType(types.Interval),


### PR DESCRIPTION
Backport 1/1 commits from #37609.

/cc @cockroachdb/release

---

Release note (bug fix): The age() function is now correctly marked as
impure, causing it to be unavailable in certain contexts.
