### PR TITLE
sql: Address inet casting roundtrip issue

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inet
+++ b/pkg/sql/logictest/testdata/logic_test/inet
@@ -27,6 +27,11 @@ SELECT '0.0.0.0':::INET;
 ----
 0.0.0.0
 
+query T
+SELECT '::/0'::inet::text::inet;
+----
+::/0
+
 # Basic IPv6 tests
 
 query T

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3259,7 +3259,7 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 		case *DUuid:
 			s = t.UUID.String()
 		case *DIPAddr:
-			s = t.String()
+			s = AsStringWithFlags(d, FmtBareStrings)
 		case *DString:
 			s = string(*t)
 		case *DCollatedString:


### PR DESCRIPTION
Address a small issue brought up in #32876, where conversion of an inet into a string, and back into an inet would fail. 