### PR TITLE
storage: remove a couple papercuts in baseQueue/scanner

### DIFF
--- a/pkg/storage/queue_helpers_testutil.go
+++ b/pkg/storage/queue_helpers_testutil.go
@@ -27,7 +27,7 @@ import (
 func (bq *baseQueue) testingAdd(
 	ctx context.Context, repl replicaInQueue, priority float64,
 ) (bool, error) {
-	return bq.addInternal(ctx, repl.Desc(), true, priority)
+	return bq.addInternal(ctx, repl.Desc(), priority)
 }
 
 func forceScanAndProcess(s *Store, q *baseQueue) error {

--- a/pkg/storage/scanner.go
+++ b/pkg/storage/scanner.go
@@ -288,24 +288,25 @@ func (rs *replicaScanner) scanLoop(stopper *stop.Stopper) {
 				shouldStop = rs.waitAndProcess(ctx, stopper, start, nil)
 			}
 
-			shouldStop = shouldStop || nil != stopper.RunTask(
-				ctx, "storage.replicaScanner: scan loop",
-				func(ctx context.Context) {
-					// Increment iteration count.
-					rs.mu.Lock()
-					defer rs.mu.Unlock()
-					rs.mu.scanCount++
-					rs.mu.total += timeutil.Since(start)
-					if log.V(6) {
-						log.Infof(ctx, "reset replica scan iteration")
-					}
-
-					// Reset iteration and start time.
-					start = timeutil.Now()
-				})
+			// waitAndProcess returns true when the system is stopping. Note that this
+			// means we don't have to check the stopper as well.
 			if shouldStop {
 				return
 			}
+
+			// Increment iteration count.
+			func() {
+				rs.mu.Lock()
+				defer rs.mu.Unlock()
+				rs.mu.scanCount++
+				rs.mu.total += timeutil.Since(start)
+			}()
+			if log.V(6) {
+				log.Infof(ctx, "reset replica scan iteration")
+			}
+
+			// Reset iteration and start time.
+			start = timeutil.Now()
 		}
 	})
 }


### PR DESCRIPTION
See individual commits for details. Found while trying to grok the queue stuff. Both of these tripped me up for a minute -- "why is this necessary?" -- and in both cases I had to convince myself it wasn't.