### PR TITLE
sql: correct how localities are displayed in crdb_internal tables

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1954,7 +1954,7 @@ CREATE TABLE crdb_internal.gossip_nodes (
   address         		STRING NOT NULL,
   advertise_address   STRING NOT NULL,
   attrs           		JSON NOT NULL,
-  locality        		JSON NOT NULL,
+  locality        		STRING NOT NULL,
   server_version  		STRING NOT NULL,
   build_tag       		STRING NOT NULL,
   started_at     	 		TIMESTAMP NOT NULL,
@@ -2038,11 +2038,6 @@ CREATE TABLE crdb_internal.gossip_nodes (
 				attrs.Add(json.FromString(a))
 			}
 
-			locality := json.NewObjectBuilder(len(d.Locality.Tiers))
-			for _, t := range d.Locality.Tiers {
-				locality.Add(t.Key, json.FromString(t.Value))
-			}
-
 			addr, err := g.GetNodeIDAddress(d.NodeID)
 			if err != nil {
 				return err
@@ -2054,7 +2049,7 @@ CREATE TABLE crdb_internal.gossip_nodes (
 				tree.NewDString(d.Address.AddressField),
 				tree.NewDString(addr.String()),
 				tree.NewDJSON(attrs.Build()),
-				tree.NewDJSON(locality.Build()),
+				tree.NewDString(d.Locality.String()),
 				tree.NewDString(d.ServerVersion.String()),
 				tree.NewDString(d.BuildTag),
 				tree.MakeDTimestamp(timeutil.Unix(0, d.StartedAt), time.Microsecond),
@@ -2322,7 +2317,7 @@ CREATE TABLE crdb_internal.kv_node_status (
   network        STRING NOT NULL,
   address        STRING NOT NULL,
   attrs          JSON NOT NULL,
-  locality       JSON NOT NULL,
+  locality       STRING NOT NULL,
   server_version STRING NOT NULL,
   go_version     STRING NOT NULL,
   tag            STRING NOT NULL,
@@ -2355,11 +2350,6 @@ CREATE TABLE crdb_internal.kv_node_status (
 			attrs := json.NewArrayBuilder(len(n.Desc.Attrs.Attrs))
 			for _, a := range n.Desc.Attrs.Attrs {
 				attrs.Add(json.FromString(a))
-			}
-
-			locality := json.NewObjectBuilder(len(n.Desc.Locality.Tiers))
-			for _, t := range n.Desc.Locality.Tiers {
-				locality.Add(t.Key, json.FromString(t.Value))
 			}
 
 			var dependencies string
@@ -2402,7 +2392,7 @@ CREATE TABLE crdb_internal.kv_node_status (
 				tree.NewDString(n.Desc.Address.NetworkField),
 				tree.NewDString(n.Desc.Address.AddressField),
 				tree.NewDJSON(attrs.Build()),
-				tree.NewDJSON(locality.Build()),
+				tree.NewDString(n.Desc.Locality.String()),
 				tree.NewDString(n.Desc.ServerVersion.String()),
 				tree.NewDString(n.BuildInfo.GoVersion),
 				tree.NewDString(n.BuildInfo.Tag),

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -301,8 +301,8 @@ node_id  component  field   value
 query ITTTTT colnames
 SELECT node_id, network, regexp_replace(address, '\d+$', '<port>') as address, attrs, locality, regexp_replace(server_version, '^\d+\.\d+(-\d+)?$', '<server_version>') as server_version FROM crdb_internal.gossip_nodes WHERE node_id = 1
 ----
-node_id  network  address           attrs  locality                         server_version
-1        tcp      127.0.0.1:<port>  []     {"dc": "dc1", "region": "test"}  <server_version>
+node_id  network  address           attrs  locality            server_version
+1        tcp      127.0.0.1:<port>  []     region=test,dc=dc1  <server_version>
 
 query IITBB colnames
 SELECT node_id, epoch, regexp_replace(expiration, '^\d+\.\d+,\d+$', '<timestamp>') as expiration, draining, decommissioning FROM crdb_internal.gossip_liveness WHERE node_id = 1
@@ -314,8 +314,8 @@ query ITTTTTT colnames
 SELECT node_id, network, regexp_replace(address, '\d+$', '<port>') as address, attrs, locality, regexp_replace(server_version, '^\d+\.\d+(-\d+)?$', '<server_version>') as server_version, regexp_replace(go_version, '^go.+$', '<go_version>') as go_version
 FROM crdb_internal.kv_node_status WHERE node_id = 1
 ----
-node_id  network  address           attrs  locality                         server_version    go_version
-1        tcp      127.0.0.1:<port>  []     {"dc": "dc1", "region": "test"}  <server_version>  <go_version>
+node_id  network  address           attrs  locality            server_version    go_version
+1        tcp      127.0.0.1:<port>  []     region=test,dc=dc1  <server_version>  <go_version>
 
 query IITI colnames
 SELECT node_id, store_id, attrs, used


### PR DESCRIPTION
Prior to this patch, localities were turned into a JSON object (not an array),
which removed the order. This now uses the same string format that we use when
declaring the localities in the command line.

Release note: None