### PR TITLE
workload/ycsb: fix key acknowledgement race conditions

### DIFF
--- a/pkg/workload/ycsb/acknowledged_counter.go
+++ b/pkg/workload/ycsb/acknowledged_counter.go
@@ -54,18 +54,20 @@ func (c *AcknowledgedCounter) Last() uint64 {
 }
 
 // Acknowledge marks v as being acknowledged.
-func (c *AcknowledgedCounter) Acknowledge(v uint64) error {
+func (c *AcknowledgedCounter) Acknowledge(v uint64) (uint64, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	if c.mu.window[v&windowMask] {
-		return errors.Errorf("Number of pending acknowledgements exceeded window size: %d has been acknowledged, but %d is not acknowledged", v, c.mu.count)
+		return 0, errors.Errorf("Number of pending acknowledgements exceeded window size: %d has been acknowledged, but %d is not acknowledged", v, c.mu.count)
 	}
 
 	c.mu.window[v&windowMask] = true
+	count := uint64(0)
 	for c.mu.window[c.mu.count&windowMask] {
 		c.mu.window[c.mu.count&windowMask] = false
 		c.mu.count++
+		count++
 	}
-	return nil
+	return count, nil
 }

--- a/pkg/workload/ycsb/skewed_latest_generator.go
+++ b/pkg/workload/ycsb/skewed_latest_generator.go
@@ -50,12 +50,12 @@ func NewSkewedLatestGenerator(
 	return &z, nil
 }
 
-// IncrementIMax increments iMax.
-func (z *SkewedLatestGenerator) IncrementIMax() error {
+// IncrementIMax increments iMax by count.
+func (z *SkewedLatestGenerator) IncrementIMax(count uint64) error {
 	z.mu.Lock()
 	defer z.mu.Unlock()
-	z.mu.iMax++
-	return z.mu.zipfGen.IncrementIMax()
+	z.mu.iMax += count
+	return z.mu.zipfGen.IncrementIMax(count)
 }
 
 // Uint64 returns a random Uint64 between iMin and iMax, where keys near iMax

--- a/pkg/workload/ycsb/uniform_generator.go
+++ b/pkg/workload/ycsb/uniform_generator.go
@@ -44,11 +44,11 @@ func NewUniformGenerator(rng *rand.Rand, iMin, iMax uint64) (*UniformGenerator, 
 	return &z, nil
 }
 
-// IncrementIMax increments iMax.
-func (z *UniformGenerator) IncrementIMax() error {
+// IncrementIMax increments iMax by count.
+func (z *UniformGenerator) IncrementIMax(count uint64) error {
 	z.mu.Lock()
 	defer z.mu.Unlock()
-	z.mu.iMax++
+	z.mu.iMax += count
 	return nil
 }
 

--- a/pkg/workload/ycsb/zipfgenerator.go
+++ b/pkg/workload/ycsb/zipfgenerator.go
@@ -48,8 +48,8 @@ type ZipfGenerator struct {
 	theta float64
 	iMin  uint64
 	// internally computed values
-	alpha, zeta2 float64
-	verbose      bool
+	alpha, zeta2, halfPowTheta float64
+	verbose                    bool
 }
 
 // ZipfGeneratorMu holds variables which must be globally synced.
@@ -99,6 +99,7 @@ func NewZipfGenerator(
 	z.zipfGenMu.eta = (1 - math.Pow(2.0/float64(z.zipfGenMu.iMax+1-z.iMin), 1.0-theta)) / (1.0 - zeta2/zetaN)
 	z.zipfGenMu.zetaN = zetaN
 	z.zeta2 = zeta2
+	z.halfPowTheta = 1.0 + math.Pow(0.5, z.theta)
 	return &z, nil
 }
 
@@ -138,7 +139,7 @@ func (z *ZipfGenerator) Uint64() uint64 {
 	var result uint64
 	if uz < 1.0 {
 		result = z.iMin
-	} else if uz < 1.0+math.Pow(0.5, z.theta) {
+	} else if uz < z.halfPowTheta {
 		result = z.iMin + 1
 	} else {
 		spread := float64(z.zipfGenMu.iMax + 1 - z.iMin)

--- a/pkg/workload/ycsb/zipfgenerator_test.go
+++ b/pkg/workload/ycsb/zipfgenerator_test.go
@@ -131,7 +131,7 @@ func runZipfGenerators(t *testing.T, withIncrements bool) {
 			t.Fatalf("zipf(%d,%d,%f) rolled %d at index %d", z.iMin, z.zipfGenMu.iMax, z.theta, x[i], i)
 			z.zipfGenMu.mu.Unlock()
 			if withIncrements {
-				if err := z.IncrementIMax(); err != nil {
+				if err := z.IncrementIMax(1); err != nil {
 					t.Fatalf("could not increment iMax: %s", err)
 				}
 			}


### PR DESCRIPTION
Determining how many times to increment the request generator was
previously a race condition because querying the previous row counter
and the current row counter is not atomic. This logic has been moved
into Acknowledge.

There was a race condition with ramping up workers. If worker that was
ramping up queried and incremented the next row key to insert, but never
inserted it because the ramp context was finished, the row is not
inserted and the row index is not acknowledged. This race condition
causes insert workloads to fail hard because of the addition of
AcknowledgedCounter. Workers will reattempt to insert its previous row
index if the row is not acknowledged.

Release note: None

Fixes: #37955, #37928