### PR TITLE
opt: add TPC-H queries to statistics quality testing infrastructure

### DIFF
--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -276,7 +276,7 @@ func (f *stubFactory) ConstructSequenceSelect(seq cat.Sequence) (exec.Node, erro
 }
 
 func (f *stubFactory) ConstructSaveTable(
-	input exec.Node, table *cat.DataSourceName,
+	input exec.Node, table *cat.DataSourceName, colNames []string,
 ) (exec.Node, error) {
 	return struct{}{}, nil
 }

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -387,7 +387,7 @@ type Factory interface {
 
 	// ConstructSaveTable wraps the input into a node that passes through all the
 	// rows, but also creates a table and inserts all the rows into it.
-	ConstructSaveTable(input Node, table *cat.DataSourceName) (Node, error)
+	ConstructSaveTable(input Node, table *cat.DataSourceName, colNames []string) (Node, error)
 }
 
 // OutputOrdering indicates the required output ordering on a Node that is being

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch
@@ -1,0 +1,7601 @@
+exec-ddl
+CREATE TABLE public.region
+(
+    r_regionkey int PRIMARY KEY,
+    r_name char(25) NOT NULL,
+    r_comment varchar(152)
+);
+----
+TABLE region
+ ├── r_regionkey int not null
+ ├── r_name char not null
+ ├── r_comment varchar
+ └── INDEX primary
+      └── r_regionkey int not null
+
+exec-ddl
+ALTER TABLE region INJECT STATISTICS '[
+  {
+    "columns": ["r_regionkey"],
+    "created_at": "2019-05-30 11:48:35.797697+00:00",
+    "distinct_count": 5,
+    "null_count": 0,
+    "row_count": 5
+  },
+  {
+    "columns": ["r_name"],
+    "created_at": "2019-05-30 11:48:35.797697+00:00",
+    "distinct_count": 5,
+    "null_count": 0,
+    "row_count": 5
+  },
+  {
+    "columns": ["r_comment"],
+    "created_at": "2019-05-30 11:48:35.797697+00:00",
+    "distinct_count": 5,
+    "null_count": 0,
+    "row_count": 5
+  }
+]'
+----
+
+exec-ddl
+CREATE TABLE public.nation
+(
+    n_nationkey int PRIMARY KEY,
+    n_name char(25) NOT NULL,
+    n_regionkey int NOT NULL,
+    n_comment varchar(152),
+    INDEX n_rk (n_regionkey ASC),
+    CONSTRAINT nation_fkey_region FOREIGN KEY (n_regionkey) references public.region (r_regionkey)
+);
+----
+TABLE nation
+ ├── n_nationkey int not null
+ ├── n_name char not null
+ ├── n_regionkey int not null
+ ├── n_comment varchar
+ ├── INDEX primary
+ │    └── n_nationkey int not null
+ ├── INDEX n_rk
+ │    ├── n_regionkey int not null
+ │    └── n_nationkey int not null
+ └── CONSTRAINT nation_fkey_region FOREIGN KEY (n_regionkey) REFERENCES t.public.region (r_regionkey)
+
+exec-ddl
+ALTER TABLE nation INJECT STATISTICS '[
+  {
+    "columns": ["n_nationkey"],
+    "created_at": "2019-05-30 11:48:35.850516+00:00",
+    "distinct_count": 25,
+    "null_count": 0,
+    "row_count": 25
+  },
+  {
+    "columns": ["n_regionkey"],
+    "created_at": "2019-05-30 11:48:35.850516+00:00",
+    "distinct_count": 5,
+    "null_count": 0,
+    "row_count": 25
+  },
+  {
+    "columns": ["n_name"],
+    "created_at": "2019-05-30 11:48:35.850516+00:00",
+    "distinct_count": 25,
+    "null_count": 0,
+    "row_count": 25
+  },
+  {
+    "columns": ["n_comment"],
+    "created_at": "2019-05-30 11:48:35.850516+00:00",
+    "distinct_count": 25,
+    "null_count": 0,
+    "row_count": 25
+  }
+]'
+----
+
+exec-ddl
+CREATE TABLE public.supplier
+(
+    s_suppkey int PRIMARY KEY,
+    s_name char(25) NOT NULL,
+    s_address varchar(40) NOT NULL,
+    s_nationkey int NOT NULL,
+    s_phone char(15) NOT NULL,
+    s_acctbal float NOT NULL,
+    s_comment varchar(101) NOT NULL,
+    INDEX s_nk (s_nationkey ASC),
+    CONSTRAINT supplier_fkey_nation FOREIGN KEY (s_nationkey) references public.nation (n_nationkey)
+);
+----
+TABLE supplier
+ ├── s_suppkey int not null
+ ├── s_name char not null
+ ├── s_address varchar not null
+ ├── s_nationkey int not null
+ ├── s_phone char not null
+ ├── s_acctbal float not null
+ ├── s_comment varchar not null
+ ├── INDEX primary
+ │    └── s_suppkey int not null
+ ├── INDEX s_nk
+ │    ├── s_nationkey int not null
+ │    └── s_suppkey int not null
+ └── CONSTRAINT supplier_fkey_nation FOREIGN KEY (s_nationkey) REFERENCES t.public.nation (n_nationkey)
+
+exec-ddl
+ALTER TABLE supplier INJECT STATISTICS '[
+  {
+    "columns": ["s_suppkey"],
+    "created_at": "2019-05-30 11:48:36.81813+00:00",
+    "distinct_count": 9920,
+    "null_count": 0,
+    "row_count": 10000
+  },
+  {
+    "columns": ["s_nationkey"],
+    "created_at": "2019-05-30 11:48:36.81813+00:00",
+    "distinct_count": 25,
+    "null_count": 0,
+    "row_count": 10000
+  },
+  {
+    "columns": ["s_name"],
+    "created_at": "2019-05-30 11:48:36.81813+00:00",
+    "distinct_count": 9990,
+    "null_count": 0,
+    "row_count": 10000
+  },
+  {
+    "columns": ["s_address"],
+    "created_at": "2019-05-30 11:48:36.81813+00:00",
+    "distinct_count": 10027,
+    "null_count": 0,
+    "row_count": 10000
+  },
+  {
+    "columns": ["s_phone"],
+    "created_at": "2019-05-30 11:48:36.81813+00:00",
+    "distinct_count": 10021,
+    "null_count": 0,
+    "row_count": 10000
+  },
+  {
+    "columns": ["s_acctbal"],
+    "created_at": "2019-05-30 11:48:36.81813+00:00",
+    "distinct_count": 9967,
+    "null_count": 0,
+    "row_count": 10000
+  },
+  {
+    "columns": ["s_comment"],
+    "created_at": "2019-05-30 11:48:36.81813+00:00",
+    "distinct_count": 9934,
+    "null_count": 0,
+    "row_count": 10000
+  }
+]'
+----
+
+exec-ddl
+CREATE TABLE public.part
+(
+    p_partkey int PRIMARY KEY,
+    p_name varchar(55) NOT NULL,
+    p_mfgr char(25) NOT NULL,
+    p_brand char(10) NOT NULL,
+    p_type varchar(25) NOT NULL,
+    p_size int NOT NULL,
+    p_container char(10) NOT NULL,
+    p_retailprice float NOT NULL,
+    p_comment varchar(23) NOT NULL
+);
+----
+TABLE part
+ ├── p_partkey int not null
+ ├── p_name varchar not null
+ ├── p_mfgr char not null
+ ├── p_brand char not null
+ ├── p_type varchar not null
+ ├── p_size int not null
+ ├── p_container char not null
+ ├── p_retailprice float not null
+ ├── p_comment varchar not null
+ └── INDEX primary
+      └── p_partkey int not null
+
+exec-ddl
+ALTER TABLE part INJECT STATISTICS '[
+  {
+    "columns": ["p_partkey"],
+    "created_at": "2019-05-30 11:48:36.678445+00:00",
+    "distinct_count": 199241,
+    "null_count": 0,
+    "row_count": 200000
+  },
+  {
+    "columns": ["p_name"],
+    "created_at": "2019-05-30 11:48:36.678445+00:00",
+    "distinct_count": 198131,
+    "null_count": 0,
+    "row_count": 200000
+  },
+  {
+    "columns": ["p_mfgr"],
+    "created_at": "2019-05-30 11:48:36.678445+00:00",
+    "distinct_count": 5,
+    "null_count": 0,
+    "row_count": 200000
+  },
+  {
+    "columns": ["p_brand"],
+    "created_at": "2019-05-30 11:48:36.678445+00:00",
+    "distinct_count": 25,
+    "null_count": 0,
+    "row_count": 200000
+  },
+  {
+    "columns": ["p_type"],
+    "created_at": "2019-05-30 11:48:36.678445+00:00",
+    "distinct_count": 150,
+    "null_count": 0,
+    "row_count": 200000
+  },
+  {
+    "columns": ["p_size"],
+    "created_at": "2019-05-30 11:48:36.678445+00:00",
+    "distinct_count": 50,
+    "null_count": 0,
+    "row_count": 200000
+  },
+  {
+    "columns": ["p_container"],
+    "created_at": "2019-05-30 11:48:36.678445+00:00",
+    "distinct_count": 40,
+    "null_count": 0,
+    "row_count": 200000
+  },
+  {
+    "columns": ["p_retailprice"],
+    "created_at": "2019-05-30 11:48:36.678445+00:00",
+    "distinct_count": 20831,
+    "null_count": 0,
+    "row_count": 200000
+  },
+  {
+    "columns": ["p_comment"],
+    "created_at": "2019-05-30 11:48:36.678445+00:00",
+    "distinct_count": 132344,
+    "null_count": 0,
+    "row_count": 200000
+  }
+]'
+----
+
+exec-ddl
+CREATE TABLE public.partsupp
+(
+    ps_partkey int NOT NULL,
+    ps_suppkey int NOT NULL,
+    ps_availqty int NOT NULL,
+    ps_supplycost float NOT NULL,
+    ps_comment varchar(199) NOT NULL,
+    PRIMARY KEY (ps_partkey, ps_suppkey),
+    INDEX ps_sk (ps_suppkey ASC),
+    CONSTRAINT partsupp_fkey_part FOREIGN KEY (ps_partkey) references public.part (p_partkey),
+    CONSTRAINT partsupp_fkey_supplier FOREIGN KEY (ps_suppkey) references public.supplier (s_suppkey)
+);
+----
+TABLE partsupp
+ ├── ps_partkey int not null
+ ├── ps_suppkey int not null
+ ├── ps_availqty int not null
+ ├── ps_supplycost float not null
+ ├── ps_comment varchar not null
+ ├── INDEX primary
+ │    ├── ps_partkey int not null
+ │    └── ps_suppkey int not null
+ ├── INDEX ps_sk
+ │    ├── ps_suppkey int not null
+ │    └── ps_partkey int not null
+ ├── CONSTRAINT partsupp_fkey_part FOREIGN KEY (ps_partkey) REFERENCES t.public.part (p_partkey)
+ └── CONSTRAINT partsupp_fkey_supplier FOREIGN KEY (ps_suppkey) REFERENCES t.public.supplier (s_suppkey)
+
+exec-ddl
+ALTER TABLE partsupp INJECT STATISTICS '[
+  {
+    "columns": ["ps_partkey"],
+    "created_at": "2019-05-30 11:48:38.332172+00:00",
+    "distinct_count": 199241,
+    "null_count": 0,
+    "row_count": 800000
+  },
+  {
+    "columns": ["ps_suppkey"],
+    "created_at": "2019-05-30 11:48:38.332172+00:00",
+    "distinct_count": 9920,
+    "null_count": 0,
+    "row_count": 800000
+  },
+  {
+    "columns": ["ps_availqty"],
+    "created_at": "2019-05-30 11:48:38.332172+00:00",
+    "distinct_count": 9920,
+    "null_count": 0,
+    "row_count": 800000
+  },
+  {
+    "columns": ["ps_supplycost"],
+    "created_at": "2019-05-30 11:48:38.332172+00:00",
+    "distinct_count": 100379,
+    "null_count": 0,
+    "row_count": 800000
+  },
+  {
+    "columns": ["ps_comment"],
+    "created_at": "2019-05-30 11:48:38.332172+00:00",
+    "distinct_count": 799641,
+    "null_count": 0,
+    "row_count": 800000
+  }
+]'
+----
+
+exec-ddl
+CREATE TABLE public.customer
+(
+    c_custkey int PRIMARY KEY,
+    c_name varchar(25) NOT NULL,
+    c_address varchar(40) NOT NULL,
+    c_nationkey int NOT NULL NOT NULL,
+    c_phone char(15) NOT NULL,
+    c_acctbal float NOT NULL,
+    c_mktsegment char(10) NOT NULL,
+    c_comment varchar(117) NOT NULL,
+    INDEX c_nk (c_nationkey ASC),
+    CONSTRAINT customer_fkey_nation FOREIGN KEY (c_nationkey) references public.nation (n_nationkey)
+);
+----
+TABLE customer
+ ├── c_custkey int not null
+ ├── c_name varchar not null
+ ├── c_address varchar not null
+ ├── c_nationkey int not null
+ ├── c_phone char not null
+ ├── c_acctbal float not null
+ ├── c_mktsegment char not null
+ ├── c_comment varchar not null
+ ├── INDEX primary
+ │    └── c_custkey int not null
+ ├── INDEX c_nk
+ │    ├── c_nationkey int not null
+ │    └── c_custkey int not null
+ └── CONSTRAINT customer_fkey_nation FOREIGN KEY (c_nationkey) REFERENCES t.public.nation (n_nationkey)
+
+exec-ddl
+ALTER TABLE customer INJECT STATISTICS '[
+  {
+    "columns": ["c_custkey"],
+    "created_at": "2019-05-30 11:47:23.610042+00:00",
+    "distinct_count": 148813,
+    "null_count": 0,
+    "row_count": 150000
+  },
+  {
+    "columns": ["c_nationkey"],
+    "created_at": "2019-05-30 11:47:23.610042+00:00",
+    "distinct_count": 25,
+    "null_count": 0,
+    "row_count": 150000
+  },
+  {
+    "columns": ["c_name"],
+    "created_at": "2019-05-30 11:47:23.610042+00:00",
+    "distinct_count": 151126,
+    "null_count": 0,
+    "row_count": 150000
+  },
+  {
+    "columns": ["c_address"],
+    "created_at": "2019-05-30 11:47:23.610042+00:00",
+    "distinct_count": 149937,
+    "null_count": 0,
+    "row_count": 150000
+  },
+  {
+    "columns": ["c_phone"],
+    "created_at": "2019-05-30 11:47:23.610042+00:00",
+    "distinct_count": 150872,
+    "null_count": 0,
+    "row_count": 150000
+  },
+  {
+    "columns": ["c_acctbal"],
+    "created_at": "2019-05-30 11:47:23.610042+00:00",
+    "distinct_count": 140628,
+    "null_count": 0,
+    "row_count": 150000
+  },
+  {
+    "columns": ["c_mktsegment"],
+    "created_at": "2019-05-30 11:47:23.610042+00:00",
+    "distinct_count": 5,
+    "null_count": 0,
+    "row_count": 150000
+  },
+  {
+    "columns": ["c_comment"],
+    "created_at": "2019-05-30 11:47:23.610042+00:00",
+    "distinct_count": 149323,
+    "null_count": 0,
+    "row_count": 150000
+  }
+]'
+----
+
+exec-ddl
+CREATE TABLE public.orders
+(
+    o_orderkey int PRIMARY KEY,
+    o_custkey int NOT NULL,
+    o_orderstatus char(1) NOT NULL,
+    o_totalprice float NOT NULL,
+    o_orderdate date NOT NULL,
+    o_orderpriority char(15) NOT NULL,
+    o_clerk char(15) NOT NULL,
+    o_shippriority int NOT NULL,
+    o_comment varchar(79) NOT NULL,
+    INDEX o_ck (o_custkey ASC),
+    INDEX o_od (o_orderdate ASC),
+    CONSTRAINT orders_fkey_customer FOREIGN KEY (o_custkey) references public.customer (c_custkey)
+);
+----
+TABLE orders
+ ├── o_orderkey int not null
+ ├── o_custkey int not null
+ ├── o_orderstatus char not null
+ ├── o_totalprice float not null
+ ├── o_orderdate date not null
+ ├── o_orderpriority char not null
+ ├── o_clerk char not null
+ ├── o_shippriority int not null
+ ├── o_comment varchar not null
+ ├── INDEX primary
+ │    └── o_orderkey int not null
+ ├── INDEX o_ck
+ │    ├── o_custkey int not null
+ │    └── o_orderkey int not null
+ ├── INDEX o_od
+ │    ├── o_orderdate date not null
+ │    └── o_orderkey int not null
+ └── CONSTRAINT orders_fkey_customer FOREIGN KEY (o_custkey) REFERENCES t.public.customer (c_custkey)
+
+exec-ddl
+ALTER TABLE orders INJECT STATISTICS '[
+  {
+    "columns": ["o_orderkey"],
+    "created_at": "2019-05-30 11:47:32.472544+00:00",
+    "distinct_count": 1527270,
+    "null_count": 0,
+    "row_count": 1500000
+  },
+  {
+    "columns": ["o_custkey"],
+    "created_at": "2019-05-30 11:47:32.472544+00:00",
+    "distinct_count": 99846,
+    "null_count": 0,
+    "row_count": 1500000
+  },
+  {
+    "columns": ["o_orderdate"],
+    "created_at": "2019-05-30 11:47:32.472544+00:00",
+    "distinct_count": 2406,
+    "null_count": 0,
+    "row_count": 1500000
+  },
+  {
+    "columns": ["o_orderstatus"],
+    "created_at": "2019-05-30 11:47:32.472544+00:00",
+    "distinct_count": 3,
+    "null_count": 0,
+    "row_count": 1500000
+  },
+  {
+    "columns": ["o_totalprice"],
+    "created_at": "2019-05-30 11:47:32.472544+00:00",
+    "distinct_count": 1459167,
+    "null_count": 0,
+    "row_count": 1500000
+  },
+  {
+    "columns": ["o_orderpriority"],
+    "created_at": "2019-05-30 11:47:32.472544+00:00",
+    "distinct_count": 5,
+    "null_count": 0,
+    "row_count": 1500000
+  },
+  {
+    "columns": ["o_clerk"],
+    "created_at": "2019-05-30 11:47:32.472544+00:00",
+    "distinct_count": 1000,
+    "null_count": 0,
+    "row_count": 1500000
+  },
+  {
+    "columns": ["o_shippriority"],
+    "created_at": "2019-05-30 11:47:32.472544+00:00",
+    "distinct_count": 1,
+    "null_count": 0,
+    "row_count": 1500000
+  },
+  {
+    "columns": ["o_comment"],
+    "created_at": "2019-05-30 11:47:32.472544+00:00",
+    "distinct_count": 1469402,
+    "null_count": 0,
+    "row_count": 1500000
+  }
+]'
+----
+
+exec-ddl
+CREATE TABLE public.lineitem
+(
+    l_orderkey int NOT NULL,
+    l_partkey int NOT NULL,
+    l_suppkey int NOT NULL,
+    l_linenumber int NOT NULL,
+    l_quantity float NOT NULL,
+    l_extendedprice float NOT NULL,
+    l_discount float NOT NULL,
+    l_tax float NOT NULL,
+    l_returnflag char(1) NOT NULL,
+    l_linestatus char(1) NOT NULL,
+    l_shipdate date NOT NULL,
+    l_commitdate date NOT NULL,
+    l_receiptdate date NOT NULL,
+    l_shipinstruct char(25) NOT NULL,
+    l_shipmode char(10) NOT NULL,
+    l_comment varchar(44) NOT NULL,
+    PRIMARY KEY (l_orderkey, l_linenumber),
+    INDEX l_ok (l_orderkey ASC),
+    INDEX l_pk (l_partkey ASC),
+    INDEX l_sk (l_suppkey ASC),
+    INDEX l_sd (l_shipdate ASC),
+    INDEX l_cd (l_commitdate ASC),
+    INDEX l_rd (l_receiptdate ASC),
+    INDEX l_pk_sk (l_partkey ASC, l_suppkey ASC),
+    INDEX l_sk_pk (l_suppkey ASC, l_partkey ASC),
+    CONSTRAINT lineitem_fkey_orders FOREIGN KEY (l_orderkey) references public.orders (o_orderkey),
+    CONSTRAINT lineitem_fkey_part FOREIGN KEY (l_partkey) references public.part (p_partkey),
+    CONSTRAINT lineitem_fkey_supplier FOREIGN KEY (l_suppkey) references public.supplier (s_suppkey),
+    CONSTRAINT lineitem_fkey_partsupp FOREIGN KEY (l_partkey, l_suppkey) references public.partsupp (ps_partkey, ps_suppkey)
+);
+----
+TABLE lineitem
+ ├── l_orderkey int not null
+ ├── l_partkey int not null
+ ├── l_suppkey int not null
+ ├── l_linenumber int not null
+ ├── l_quantity float not null
+ ├── l_extendedprice float not null
+ ├── l_discount float not null
+ ├── l_tax float not null
+ ├── l_returnflag char not null
+ ├── l_linestatus char not null
+ ├── l_shipdate date not null
+ ├── l_commitdate date not null
+ ├── l_receiptdate date not null
+ ├── l_shipinstruct char not null
+ ├── l_shipmode char not null
+ ├── l_comment varchar not null
+ ├── INDEX primary
+ │    ├── l_orderkey int not null
+ │    └── l_linenumber int not null
+ ├── INDEX l_ok
+ │    ├── l_orderkey int not null
+ │    └── l_linenumber int not null
+ ├── INDEX l_pk
+ │    ├── l_partkey int not null
+ │    ├── l_orderkey int not null
+ │    └── l_linenumber int not null
+ ├── INDEX l_sk
+ │    ├── l_suppkey int not null
+ │    ├── l_orderkey int not null
+ │    └── l_linenumber int not null
+ ├── INDEX l_sd
+ │    ├── l_shipdate date not null
+ │    ├── l_orderkey int not null
+ │    └── l_linenumber int not null
+ ├── INDEX l_cd
+ │    ├── l_commitdate date not null
+ │    ├── l_orderkey int not null
+ │    └── l_linenumber int not null
+ ├── INDEX l_rd
+ │    ├── l_receiptdate date not null
+ │    ├── l_orderkey int not null
+ │    └── l_linenumber int not null
+ ├── INDEX l_pk_sk
+ │    ├── l_partkey int not null
+ │    ├── l_suppkey int not null
+ │    ├── l_orderkey int not null
+ │    └── l_linenumber int not null
+ ├── INDEX l_sk_pk
+ │    ├── l_suppkey int not null
+ │    ├── l_partkey int not null
+ │    ├── l_orderkey int not null
+ │    └── l_linenumber int not null
+ ├── CONSTRAINT lineitem_fkey_orders FOREIGN KEY (l_orderkey) REFERENCES t.public.orders (o_orderkey)
+ ├── CONSTRAINT lineitem_fkey_part FOREIGN KEY (l_partkey) REFERENCES t.public.part (p_partkey)
+ ├── CONSTRAINT lineitem_fkey_supplier FOREIGN KEY (l_suppkey) REFERENCES t.public.supplier (s_suppkey)
+ └── CONSTRAINT lineitem_fkey_partsupp FOREIGN KEY (l_partkey, l_suppkey) REFERENCES t.public.partsupp (ps_partkey, ps_suppkey)
+
+exec-ddl
+ALTER TABLE lineitem INJECT STATISTICS '[
+  {
+    "columns": ["l_orderkey"],
+    "created_at": "2019-05-30 11:48:35.649438+00:00",
+    "distinct_count": 1527270,
+    "null_count": 0,
+    "row_count": 6001215
+  },
+  {
+    "columns": ["l_partkey"],
+    "created_at": "2019-05-30 11:48:35.649438+00:00",
+    "distinct_count": 199241,
+    "null_count": 0,
+    "row_count": 6001215
+  },
+  {
+    "columns": ["l_suppkey"],
+    "created_at": "2019-05-30 11:48:35.649438+00:00",
+    "distinct_count": 9920,
+    "null_count": 0,
+    "row_count": 6001215
+  },
+  {
+    "columns": ["l_shipdate"],
+    "created_at": "2019-05-30 11:48:35.649438+00:00",
+    "distinct_count": 2526,
+    "null_count": 0,
+    "row_count": 6001215
+  },
+  {
+    "columns": ["l_commitdate"],
+    "created_at": "2019-05-30 11:48:35.649438+00:00",
+    "distinct_count": 2466,
+    "null_count": 0,
+    "row_count": 6001215
+  },
+  {
+    "columns": ["l_receiptdate"],
+    "created_at": "2019-05-30 11:48:35.649438+00:00",
+    "distinct_count": 2554,
+    "null_count": 0,
+    "row_count": 6001215
+  },
+  {
+    "columns": ["l_linenumber"],
+    "created_at": "2019-05-30 11:48:35.649438+00:00",
+    "distinct_count": 7,
+    "null_count": 0,
+    "row_count": 6001215
+  },
+  {
+    "columns": ["l_quantity"],
+    "created_at": "2019-05-30 11:48:35.649438+00:00",
+    "distinct_count": 50,
+    "null_count": 0,
+    "row_count": 6001215
+  },
+  {
+    "columns": ["l_extendedprice"],
+    "created_at": "2019-05-30 11:48:35.649438+00:00",
+    "distinct_count": 925955,
+    "null_count": 0,
+    "row_count": 6001215
+  },
+  {
+    "columns": ["l_discount"],
+    "created_at": "2019-05-30 11:48:35.649438+00:00",
+    "distinct_count": 11,
+    "null_count": 0,
+    "row_count": 6001215
+  },
+  {
+    "columns": ["l_tax"],
+    "created_at": "2019-05-30 11:48:35.649438+00:00",
+    "distinct_count": 9,
+    "null_count": 0,
+    "row_count": 6001215
+  },
+  {
+    "columns": ["l_returnflag"],
+    "created_at": "2019-05-30 11:48:35.649438+00:00",
+    "distinct_count": 3,
+    "null_count": 0,
+    "row_count": 6001215
+  },
+  {
+    "columns": ["l_linestatus"],
+    "created_at": "2019-05-30 11:48:35.649438+00:00",
+    "distinct_count": 2,
+    "null_count": 0,
+    "row_count": 6001215
+  },
+  {
+    "columns": ["l_shipinstruct"],
+    "created_at": "2019-05-30 11:48:35.649438+00:00",
+    "distinct_count": 4,
+    "null_count": 0,
+    "row_count": 6001215
+  },
+  {
+    "columns": ["l_shipmode"],
+    "created_at": "2019-05-30 11:48:35.649438+00:00",
+    "distinct_count": 7,
+    "null_count": 0,
+    "row_count": 6001215
+  },
+  {
+    "columns": ["l_comment"],
+    "created_at": "2019-05-30 11:48:35.649438+00:00",
+    "distinct_count": 4643303,
+    "null_count": 0,
+    "row_count": 6001215
+  }
+]'
+----
+
+
+# --------------------------------------------------
+# Q1
+# Pricing Summary Report
+# Reports the amount of business that was billed, shipped, and returned.
+#
+# Provides a summary pricing report for all lineitems shipped as of a given
+# date. The date is within 60 - 120 days of the greatest ship date contained in
+# the database. The query lists totals for extended price, discounted extended
+# price, discounted extended price plus tax, average quantity, average extended
+# price, and average discount. These aggregates are grouped by RETURNFLAG and
+# LINESTATUS, and listed in ascending order of RETURNFLAG and LINESTATUS. A
+# count of the number of lineitems in each group is included.
+# --------------------------------------------------
+save-tables database=tpch save-tables-prefix=q1
+SELECT
+    l_returnflag,
+    l_linestatus,
+    sum(l_quantity) AS sum_qty,
+    sum(l_extendedprice) AS sum_base_price,
+    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
+    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
+    avg(l_quantity) AS avg_qty,
+    avg(l_extendedprice) AS avg_price,
+    avg(l_discount) AS avg_disc,
+    count(*) AS count_order
+FROM
+    lineitem
+WHERE
+    l_shipdate <= DATE '1998-12-01' - INTERVAL '90' DAY
+GROUP BY
+    l_returnflag,
+    l_linestatus
+ORDER BY
+    l_returnflag,
+    l_linestatus;
+----
+sort
+ ├── save-table-name: q1_sort_1
+ ├── columns: l_returnflag:9(char!null) l_linestatus:10(char!null) sum_qty:17(float) sum_base_price:18(float) sum_disc_price:20(float) sum_charge:22(float) avg_qty:23(float) avg_price:24(float) avg_disc:25(float) count_order:26(int)
+ ├── stats: [rows=6, distinct(9)=3, null(9)=0, distinct(10)=2, null(10)=0, distinct(17)=6, null(17)=0, distinct(18)=6, null(18)=0, distinct(20)=6, null(20)=0, distinct(22)=6, null(22)=0, distinct(23)=6, null(23)=0, distinct(24)=6, null(24)=0, distinct(25)=6, null(25)=0, distinct(26)=6, null(26)=0, distinct(9,10)=6, null(9,10)=0]
+ ├── key: (9,10)
+ ├── fd: (9,10)-->(17,18,20,22-26)
+ ├── ordering: +9,+10
+ └── group-by
+      ├── save-table-name: q1_group_by_2
+      ├── columns: l_returnflag:9(char!null) l_linestatus:10(char!null) sum:17(float) sum:18(float) sum:20(float) sum:22(float) avg:23(float) avg:24(float) avg:25(float) count_rows:26(int)
+      ├── grouping columns: l_returnflag:9(char!null) l_linestatus:10(char!null)
+      ├── stats: [rows=6, distinct(9)=3, null(9)=0, distinct(10)=2, null(10)=0, distinct(17)=6, null(17)=0, distinct(18)=6, null(18)=0, distinct(20)=6, null(20)=0, distinct(22)=6, null(22)=0, distinct(23)=6, null(23)=0, distinct(24)=6, null(24)=0, distinct(25)=6, null(25)=0, distinct(26)=6, null(26)=0, distinct(9,10)=6, null(9,10)=0]
+      ├── key: (9,10)
+      ├── fd: (9,10)-->(17,18,20,22-26)
+      ├── project
+      │    ├── save-table-name: q1_project_3
+      │    ├── columns: column19:19(float) column21:21(float) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_returnflag:9(char!null) l_linestatus:10(char!null)
+      │    ├── stats: [rows=2000405, distinct(5)=50, null(5)=0, distinct(6)=859070.838, null(6)=0, distinct(7)=11, null(7)=0, distinct(9)=3, null(9)=0, distinct(10)=2, null(10)=0, distinct(19)=2000405, null(19)=0, distinct(21)=2000405, null(21)=0, distinct(9,10)=6, null(9,10)=0]
+      │    ├── select
+      │    │    ├── save-table-name: q1_select_4
+      │    │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_tax:8(float!null) l_returnflag:9(char!null) l_linestatus:10(char!null) l_shipdate:11(date!null)
+      │    │    ├── stats: [rows=2000405, distinct(5)=50, null(5)=0, distinct(6)=859070.838, null(6)=0, distinct(7)=11, null(7)=0, distinct(8)=9, null(8)=0, distinct(9)=3, null(9)=0, distinct(10)=2, null(10)=0, distinct(11)=2526, null(11)=0, distinct(6,7)=2000405, null(6,7)=0, distinct(9,10)=6, null(9,10)=0, distinct(6-8)=2000405, null(6-8)=0]
+      │    │    ├── scan lineitem
+      │    │    │    ├── save-table-name: q1_scan_5
+      │    │    │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_tax:8(float!null) l_returnflag:9(char!null) l_linestatus:10(char!null) l_shipdate:11(date!null)
+      │    │    │    └── stats: [rows=6001215, distinct(5)=50, null(5)=0, distinct(6)=925955, null(6)=0, distinct(7)=11, null(7)=0, distinct(8)=9, null(8)=0, distinct(9)=3, null(9)=0, distinct(10)=2, null(10)=0, distinct(11)=2526, null(11)=0, distinct(6,7)=6001215, null(6,7)=0, distinct(9,10)=6, null(9,10)=0, distinct(6-8)=6001215, null(6-8)=0]
+      │    │    └── filters
+      │    │         └── l_shipdate <= '1998-09-02' [type=bool, outer=(11), constraints=(/11: (/NULL - /'1998-09-02']; tight)]
+      │    └── projections
+      │         ├── l_extendedprice * (1.0 - l_discount) [type=float, outer=(6,7)]
+      │         └── (l_extendedprice * (1.0 - l_discount)) * (l_tax + 1.0) [type=float, outer=(6-8)]
+      └── aggregations
+           ├── sum [type=float, outer=(5)]
+           │    └── variable: l_quantity [type=float]
+           ├── sum [type=float, outer=(6)]
+           │    └── variable: l_extendedprice [type=float]
+           ├── sum [type=float, outer=(19)]
+           │    └── variable: column19 [type=float]
+           ├── sum [type=float, outer=(21)]
+           │    └── variable: column21 [type=float]
+           ├── avg [type=float, outer=(5)]
+           │    └── variable: l_quantity [type=float]
+           ├── avg [type=float, outer=(6)]
+           │    └── variable: l_extendedprice [type=float]
+           ├── avg [type=float, outer=(7)]
+           │    └── variable: l_discount [type=float]
+           └── count-rows [type=int]
+
+stats table=q1_sort_1
+----
+column_names      row_count  distinct_count  null_count
+{avg_disc}        4          4               0
+{avg_price}       4          4               0
+{avg_qty}         4          4               0
+{count_order}     4          4               0
+{l_linestatus}    4          2               0
+{l_returnflag}    4          3               0
+{sum_base_price}  4          4               0
+{sum_charge}      4          4               0
+{sum_disc_price}  4          4               0
+{sum_qty}         4          4               0
+~~~~
+column_names      row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{avg_disc}        6.00           1.50           6.00                1.50                0.00            1.00
+{avg_price}       6.00           1.50           6.00                1.50                0.00            1.00
+{avg_qty}         6.00           1.50           6.00                1.50                0.00            1.00
+{count_order}     6.00           1.50           6.00                1.50                0.00            1.00
+{l_linestatus}    6.00           1.50           2.00                1.00                0.00            1.00
+{l_returnflag}    6.00           1.50           3.00                1.00                0.00            1.00
+{sum_base_price}  6.00           1.50           6.00                1.50                0.00            1.00
+{sum_charge}      6.00           1.50           6.00                1.50                0.00            1.00
+{sum_disc_price}  6.00           1.50           6.00                1.50                0.00            1.00
+{sum_qty}         6.00           1.50           6.00                1.50                0.00            1.00
+
+stats table=q1_group_by_2
+----
+column_names    row_count  distinct_count  null_count
+{avg_1}         4          4               0
+{avg_2}         4          4               0
+{avg}           4          4               0
+{count_rows}    4          4               0
+{l_linestatus}  4          2               0
+{l_returnflag}  4          3               0
+{sum_1}         4          4               0
+{sum_2}         4          4               0
+{sum_3}         4          4               0
+{sum}           4          4               0
+~~~~
+column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{avg}           6.00           1.50           6.00                1.50                0.00            1.00
+{avg_1}         6.00           1.50           6.00                1.50                0.00            1.00
+{avg_2}         6.00           1.50           6.00                1.50                0.00            1.00
+{count_rows}    6.00           1.50           6.00                1.50                0.00            1.00
+{l_linestatus}  6.00           1.50           2.00                1.00                0.00            1.00
+{l_returnflag}  6.00           1.50           3.00                1.00                0.00            1.00
+{sum}           6.00           1.50           6.00                1.50                0.00            1.00
+{sum_1}         6.00           1.50           6.00                1.50                0.00            1.00
+{sum_2}         6.00           1.50           6.00                1.50                0.00            1.00
+{sum_3}         6.00           1.50           6.00                1.50                0.00            1.00
+
+stats table=q1_project_3
+----
+column_names       row_count  distinct_count  null_count
+{column19}         5916591    4150364         0
+{column21}         5916591    5661182         0
+{l_discount}       5916591    11              0
+{l_extendedprice}  5916591    925955          0
+{l_linestatus}     5916591    2               0
+{l_quantity}       5916591    50              0
+{l_returnflag}     5916591    3               0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{column19}         2000405.00     2.96 <==       2000405.00          2.07 <==            0.00            1.00
+{column21}         2000405.00     2.96 <==       2000405.00          2.83 <==            0.00            1.00
+{l_discount}       2000405.00     2.96 <==       11.00               1.00                0.00            1.00
+{l_extendedprice}  2000405.00     2.96 <==       859071.00           1.08                0.00            1.00
+{l_linestatus}     2000405.00     2.96 <==       2.00                1.00                0.00            1.00
+{l_quantity}       2000405.00     2.96 <==       50.00               1.00                0.00            1.00
+{l_returnflag}     2000405.00     2.96 <==       3.00                1.00                0.00            1.00
+
+stats table=q1_select_4
+----
+column_names       row_count  distinct_count  null_count
+{l_discount}       5916591    11              0
+{l_extendedprice}  5916591    925955          0
+{l_linestatus}     5916591    2               0
+{l_quantity}       5916591    50              0
+{l_returnflag}     5916591    3               0
+{l_shipdate}       5916591    2436            0
+{l_tax}            5916591    9               0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_discount}       2000405.00     2.96 <==       11.00               1.00                0.00            1.00
+{l_extendedprice}  2000405.00     2.96 <==       859071.00           1.08                0.00            1.00
+{l_linestatus}     2000405.00     2.96 <==       2.00                1.00                0.00            1.00
+{l_quantity}       2000405.00     2.96 <==       50.00               1.00                0.00            1.00
+{l_returnflag}     2000405.00     2.96 <==       3.00                1.00                0.00            1.00
+{l_shipdate}       2000405.00     2.96 <==       2526.00             1.04                0.00            1.00
+{l_tax}            2000405.00     2.96 <==       9.00                1.00                0.00            1.00
+
+stats table=q1_scan_5
+----
+column_names       row_count  distinct_count  null_count
+{l_discount}       6001215    11              0
+{l_extendedprice}  6001215    925955          0
+{l_linestatus}     6001215    2               0
+{l_quantity}       6001215    50              0
+{l_returnflag}     6001215    3               0
+{l_shipdate}       6001215    2526            0
+{l_tax}            6001215    9               0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_discount}       6001215.00     1.00           11.00               1.00                0.00            1.00
+{l_extendedprice}  6001215.00     1.00           925955.00           1.00                0.00            1.00
+{l_linestatus}     6001215.00     1.00           2.00                1.00                0.00            1.00
+{l_quantity}       6001215.00     1.00           50.00               1.00                0.00            1.00
+{l_returnflag}     6001215.00     1.00           3.00                1.00                0.00            1.00
+{l_shipdate}       6001215.00     1.00           2526.00             1.00                0.00            1.00
+{l_tax}            6001215.00     1.00           9.00                1.00                0.00            1.00
+
+# --------------------------------------------------
+# Q2
+# Minimum Cost Supplier
+# Finds which supplier should be selected to place an order for a given part in
+# a given region.
+#
+# Finds, in a given region, for each part of a certain type and size, the
+# supplier who can supply it at minimum cost. If several suppliers in that
+# region offer the desired part type and size at the same (minimum) cost, the
+# query lists the parts from suppliers with the 100 highest account balances.
+# For each supplier, the query lists the supplier's account balance, name and
+# nation; the part's number and manufacturer; the supplier's address, phone
+# number and comment information.
+#
+# TODO:
+#   1. Join ordering
+#   2. Push down equivalent column comparisons
+#   3. Allow Select to be pushed below Ordinality used to add key column
+#   4. Add decorrelation rule for Ordinality/RowKey
+# --------------------------------------------------
+save-tables database=tpch save-tables-prefix=q2
+SELECT
+    s_acctbal,
+    s_name,
+    n_name,
+    p_partkey,
+    p_mfgr,
+    s_address,
+    s_phone,
+    s_comment
+FROM
+    part,
+    supplier,
+    partsupp,
+    nation,
+    region
+WHERE
+    p_partkey = ps_partkey
+    AND s_suppkey = ps_suppkey
+    AND p_size = 15
+    AND p_type LIKE '%BRASS'
+    AND s_nationkey = n_nationkey
+    AND n_regionkey = r_regionkey
+    AND r_name = 'EUROPE'
+    AND ps_supplycost = (
+        SELECT
+            min(ps_supplycost)
+        FROM
+            partsupp,
+            supplier,
+            nation,
+            region
+        WHERE
+            p_partkey = ps_partkey
+            AND s_suppkey = ps_suppkey
+            AND s_nationkey = n_nationkey
+            AND n_regionkey = r_regionkey
+            AND r_name = 'EUROPE'
+    )
+ORDER BY
+    s_acctbal DESC,
+    n_name,
+    s_name,
+    p_partkey
+LIMIT 100;
+----
+project
+ ├── save-table-name: q2_project_1
+ ├── columns: s_acctbal:15(float) s_name:11(char) n_name:23(char) p_partkey:1(int) p_mfgr:3(char) s_address:12(varchar) s_phone:14(char) s_comment:16(varchar)
+ ├── cardinality: [0 - 100]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(3)=1, null(3)=0, distinct(11)=1, null(11)=0, distinct(12)=1, null(12)=0, distinct(14)=1, null(14)=0, distinct(15)=1, null(15)=0, distinct(16)=1, null(16)=0, distinct(23)=1, null(23)=0]
+ ├── fd: (1)-->(3)
+ ├── ordering: -15,+23,+11,+1
+ └── limit
+      ├── save-table-name: q2_limit_2
+      ├── columns: p_partkey:1(int) p_mfgr:3(char) s_name:11(char) s_address:12(varchar) s_phone:14(char) s_acctbal:15(float) s_comment:16(varchar) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_name:23(char) min:48(float!null)
+      ├── internal-ordering: -15,+23,+11,+(1|17)
+      ├── cardinality: [0 - 100]
+      ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(3)=1, null(3)=0, distinct(11)=1, null(11)=0, distinct(12)=1, null(12)=0, distinct(14)=1, null(14)=0, distinct(15)=1, null(15)=0, distinct(16)=1, null(16)=0, distinct(17)=0.999910488, null(17)=0, distinct(18)=0.999982066, null(18)=0, distinct(20)=1, null(20)=0, distinct(23)=1, null(23)=0, distinct(48)=1, null(48)=0]
+      ├── key: (17,18)
+      ├── fd: (1)-->(3), (17,18)-->(1,3,11,12,14-16,20,23,48), (1)==(17), (17)==(1), (18)-->(11,12,14-16,23), (20)==(48), (48)==(20)
+      ├── ordering: -15,+23,+11,+(1|17) [actual: -15,+23,+11,+1]
+      ├── sort
+      │    ├── save-table-name: q2_sort_3
+      │    ├── columns: p_partkey:1(int) p_mfgr:3(char) s_name:11(char) s_address:12(varchar) s_phone:14(char) s_acctbal:15(float) s_comment:16(varchar) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_name:23(char) min:48(float!null)
+      │    ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(3)=1, null(3)=0, distinct(11)=1, null(11)=0, distinct(12)=1, null(12)=0, distinct(14)=1, null(14)=0, distinct(15)=1, null(15)=0, distinct(16)=1, null(16)=0, distinct(17)=0.999910488, null(17)=0, distinct(18)=0.999982066, null(18)=0, distinct(20)=1, null(20)=0, distinct(23)=1, null(23)=0, distinct(48)=1, null(48)=0]
+      │    ├── key: (17,18)
+      │    ├── fd: (1)-->(3), (17,18)-->(1,3,11,12,14-16,20,23,48), (1)==(17), (17)==(1), (18)-->(11,12,14-16,23), (20)==(48), (48)==(20)
+      │    ├── ordering: -15,+23,+11,+(1|17) [actual: -15,+23,+11,+1]
+      │    └── select
+      │         ├── save-table-name: q2_select_4
+      │         ├── columns: p_partkey:1(int) p_mfgr:3(char) s_name:11(char) s_address:12(varchar) s_phone:14(char) s_acctbal:15(float) s_comment:16(varchar) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_name:23(char) min:48(float!null)
+      │         ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(3)=1, null(3)=0, distinct(11)=1, null(11)=0, distinct(12)=1, null(12)=0, distinct(14)=1, null(14)=0, distinct(15)=1, null(15)=0, distinct(16)=1, null(16)=0, distinct(17)=0.999910488, null(17)=0, distinct(18)=0.999982066, null(18)=0, distinct(20)=1, null(20)=0, distinct(23)=1, null(23)=0, distinct(48)=1, null(48)=0]
+      │         ├── key: (17,18)
+      │         ├── fd: (1)-->(3), (17,18)-->(1,3,11,12,14-16,20,23,48), (1)==(17), (17)==(1), (18)-->(11,12,14-16,23), (20)==(48), (48)==(20)
+      │         ├── group-by
+      │         │    ├── save-table-name: q2_group_by_5
+      │         │    ├── columns: p_partkey:1(int) p_mfgr:3(char) s_name:11(char) s_address:12(varchar) s_phone:14(char) s_acctbal:15(float) s_comment:16(varchar) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float) n_name:23(char) min:48(float)
+      │         │    ├── grouping columns: ps_partkey:17(int!null) ps_suppkey:18(int!null)
+      │         │    ├── stats: [rows=1487.22799, distinct(1)=1487.22799, null(1)=0, distinct(3)=1487.22799, null(3)=0, distinct(11)=1487.22799, null(11)=0, distinct(12)=1487.22799, null(12)=0, distinct(14)=1487.22799, null(14)=0, distinct(15)=1487.22799, null(15)=0, distinct(16)=1487.22799, null(16)=0, distinct(17)=1174.55443, null(17)=0, distinct(18)=1411.92479, null(18)=0, distinct(20)=1487.22799, null(20)=0, distinct(23)=1487.22799, null(23)=0, distinct(48)=1487.22799, null(48)=0, distinct(17,18)=1487.22799, null(17,18)=0]
+      │         │    ├── key: (17,18)
+      │         │    ├── fd: (1)-->(3), (17,18)-->(1,3,11,12,14-16,20,23,48), (1)==(17), (17)==(1), (18)-->(11,12,14-16,23)
+      │         │    ├── inner-join
+      │         │    │    ├── save-table-name: q2_inner_join_6
+      │         │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(char!null) p_type:5(varchar!null) p_size:6(int!null) s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null) ps_partkey:29(int!null) ps_suppkey:30(int!null) ps_supplycost:32(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
+      │         │    │    ├── stats: [rows=2837.30948, distinct(1)=1333.31636, null(1)=0, distinct(3)=5, null(3)=0, distinct(5)=149.979569, null(5)=0, distinct(6)=1, null(6)=0, distinct(10)=1411.92479, null(10)=0, distinct(11)=1412.48485, null(11)=0, distinct(12)=1412.56423, null(12)=0, distinct(13)=5, null(13)=0, distinct(14)=1412.56423, null(14)=0, distinct(15)=1412.30169, null(15)=0, distinct(16)=1412.03742, null(16)=0, distinct(17)=1174.55443, null(17)=0, distinct(18)=1411.92479, null(18)=0, distinct(20)=1482.68691, null(20)=0, distinct(22)=5, null(22)=0, distinct(23)=5, null(23)=0, distinct(24)=1, null(24)=0, distinct(26)=1, null(26)=0, distinct(27)=0.996222107, null(27)=0, distinct(29)=1333.31636, null(29)=0, distinct(30)=1448.52495, null(30)=0, distinct(32)=2787.75127, null(32)=0, distinct(34)=1448.52495, null(34)=0, distinct(37)=5, null(37)=0, distinct(41)=5, null(41)=0, distinct(43)=1, null(43)=0, distinct(45)=1, null(45)=0, distinct(46)=0.996222107, null(46)=0, distinct(17,18)=1487.22799, null(17,18)=0]
+      │         │    │    ├── key: (18,29,34)
+      │         │    │    ├── fd: ()-->(6,27,46), (1)-->(3,5), (10)-->(11-16), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24), (10)==(18), (18)==(10), (13)==(22), (22)==(13), (1)==(17,29), (17)==(1,29), (29,30)-->(32), (34)-->(37), (41)-->(43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (30)==(34), (34)==(30), (29)==(1,17)
+      │         │    │    ├── inner-join
+      │         │    │    │    ├── save-table-name: q2_inner_join_7
+      │         │    │    │    ├── columns: ps_partkey:29(int!null) ps_suppkey:30(int!null) ps_supplycost:32(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
+      │         │    │    │    ├── stats: [rows=161290.323, distinct(29)=110568.431, null(29)=0, distinct(30)=1844.80594, null(30)=0, distinct(32)=80252.0719, null(32)=0, distinct(34)=1844.80594, null(34)=0, distinct(37)=5, null(37)=0, distinct(41)=5, null(41)=0, distinct(43)=1, null(43)=0, distinct(45)=1, null(45)=0, distinct(46)=0.996222107, null(46)=0]
+      │         │    │    │    ├── key: (29,34)
+      │         │    │    │    ├── fd: ()-->(46), (29,30)-->(32), (34)-->(37), (41)-->(43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (30)==(34), (34)==(30)
+      │         │    │    │    ├── scan partsupp
+      │         │    │    │    │    ├── save-table-name: q2_scan_8
+      │         │    │    │    │    ├── columns: ps_partkey:29(int!null) ps_suppkey:30(int!null) ps_supplycost:32(float!null)
+      │         │    │    │    │    ├── stats: [rows=800000, distinct(29)=199241, null(29)=0, distinct(30)=9920, null(30)=0, distinct(32)=100379, null(32)=0]
+      │         │    │    │    │    ├── key: (29,30)
+      │         │    │    │    │    └── fd: (29,30)-->(32)
+      │         │    │    │    ├── inner-join (lookup supplier@s_nk)
+      │         │    │    │    │    ├── save-table-name: q2_lookup_join_9
+      │         │    │    │    │    ├── columns: s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
+      │         │    │    │    │    ├── key columns: [41] = [37]
+      │         │    │    │    │    ├── stats: [rows=2000, distinct(34)=1844.80594, null(34)=0, distinct(37)=5, null(37)=0, distinct(41)=5, null(41)=0, distinct(43)=1, null(43)=0, distinct(45)=1, null(45)=0, distinct(46)=0.996222107, null(46)=0]
+      │         │    │    │    │    ├── key: (34)
+      │         │    │    │    │    ├── fd: ()-->(46), (34)-->(37), (41)-->(43), (43)==(45), (45)==(43), (37)==(41), (41)==(37)
+      │         │    │    │    │    ├── inner-join (lookup nation@n_rk)
+      │         │    │    │    │    │    ├── save-table-name: q2_lookup_join_10
+      │         │    │    │    │    │    ├── columns: n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
+      │         │    │    │    │    │    ├── key columns: [45] = [43]
+      │         │    │    │    │    │    ├── stats: [rows=5, distinct(41)=5, null(41)=0, distinct(43)=1, null(43)=0, distinct(45)=1, null(45)=0, distinct(46)=0.996222107, null(46)=0]
+      │         │    │    │    │    │    ├── key: (41)
+      │         │    │    │    │    │    ├── fd: ()-->(46), (41)-->(43), (43)==(45), (45)==(43)
+      │         │    │    │    │    │    ├── select
+      │         │    │    │    │    │    │    ├── save-table-name: q2_select_11
+      │         │    │    │    │    │    │    ├── columns: r_regionkey:45(int!null) r_name:46(char!null)
+      │         │    │    │    │    │    │    ├── stats: [rows=1, distinct(45)=1, null(45)=0, distinct(46)=1, null(46)=0]
+      │         │    │    │    │    │    │    ├── key: (45)
+      │         │    │    │    │    │    │    ├── fd: ()-->(46)
+      │         │    │    │    │    │    │    ├── scan region
+      │         │    │    │    │    │    │    │    ├── save-table-name: q2_scan_12
+      │         │    │    │    │    │    │    │    ├── columns: r_regionkey:45(int!null) r_name:46(char!null)
+      │         │    │    │    │    │    │    │    ├── stats: [rows=5, distinct(45)=5, null(45)=0, distinct(46)=5, null(46)=0]
+      │         │    │    │    │    │    │    │    ├── key: (45)
+      │         │    │    │    │    │    │    │    └── fd: (45)-->(46)
+      │         │    │    │    │    │    │    └── filters
+      │         │    │    │    │    │    │         └── r_name = 'EUROPE' [type=bool, outer=(46), constraints=(/46: [/'EUROPE' - /'EUROPE']; tight), fd=()-->(46)]
+      │         │    │    │    │    │    └── filters (true)
+      │         │    │    │    │    └── filters (true)
+      │         │    │    │    └── filters
+      │         │    │    │         └── s_suppkey = ps_suppkey [type=bool, outer=(30,34), constraints=(/30: (/NULL - ]; /34: (/NULL - ]), fd=(30)==(34), (34)==(30)]
+      │         │    │    ├── inner-join
+      │         │    │    │    ├── save-table-name: q2_inner_join_13
+      │         │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(char!null) p_type:5(varchar!null) p_size:6(int!null) s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null)
+      │         │    │    │    ├── stats: [rows=1945.04451, distinct(1)=1333.31636, null(1)=0, distinct(3)=5, null(3)=0, distinct(5)=149.97957, null(5)=0, distinct(6)=1, null(6)=0, distinct(10)=1766.2414, null(10)=0, distinct(11)=1767.4156, null(11)=0, distinct(12)=1767.58209, null(12)=0, distinct(13)=5, null(13)=0, distinct(14)=1767.58209, null(14)=0, distinct(15)=1767.03149, null(15)=0, distinct(16)=1766.47747, null(16)=0, distinct(17)=1333.31636, null(17)=0, distinct(18)=1766.2414, null(18)=0, distinct(20)=1921.6712, null(20)=0, distinct(22)=5, null(22)=0, distinct(23)=5, null(23)=0, distinct(24)=1, null(24)=0, distinct(26)=1, null(26)=0, distinct(27)=0.996222107, null(27)=0, distinct(17,18)=1932.16064, null(17,18)=0]
+      │         │    │    │    ├── key: (17,18)
+      │         │    │    │    ├── fd: ()-->(6,27), (1)-->(3,5), (10)-->(11-16), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24), (10)==(18), (18)==(10), (13)==(22), (22)==(13), (1)==(17), (17)==(1)
+      │         │    │    │    ├── inner-join
+      │         │    │    │    │    ├── save-table-name: q2_inner_join_14
+      │         │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null)
+      │         │    │    │    │    ├── stats: [rows=161290.323, distinct(10)=9920, null(10)=0, distinct(11)=9989.99903, null(11)=0, distinct(12)=9999.99901, null(12)=0, distinct(13)=5, null(13)=0, distinct(14)=9999.99901, null(14)=0, distinct(15)=9966.99907, null(15)=0, distinct(16)=9933.99912, null(16)=0, distinct(17)=110564.957, null(17)=0, distinct(18)=9920, null(18)=0, distinct(20)=80250.5069, null(20)=0, distinct(22)=5, null(22)=0, distinct(23)=5, null(23)=0, distinct(24)=1, null(24)=0, distinct(26)=1, null(26)=0, distinct(27)=0.996222107, null(27)=0, distinct(17,18)=146071.239, null(17,18)=0]
+      │         │    │    │    │    ├── key: (17,18)
+      │         │    │    │    │    ├── fd: ()-->(27), (10)-->(11-16), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24), (10)==(18), (18)==(10), (13)==(22), (22)==(13)
+      │         │    │    │    │    ├── scan partsupp
+      │         │    │    │    │    │    ├── save-table-name: q2_scan_15
+      │         │    │    │    │    │    ├── columns: ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null)
+      │         │    │    │    │    │    ├── stats: [rows=800000, distinct(17)=199241, null(17)=0, distinct(18)=9920, null(18)=0, distinct(20)=100379, null(20)=0, distinct(17,18)=800000, null(17,18)=0]
+      │         │    │    │    │    │    ├── key: (17,18)
+      │         │    │    │    │    │    └── fd: (17,18)-->(20)
+      │         │    │    │    │    ├── inner-join
+      │         │    │    │    │    │    ├── save-table-name: q2_inner_join_16
+      │         │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null) n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null)
+      │         │    │    │    │    │    ├── stats: [rows=2000, distinct(10)=1844.80594, null(10)=0, distinct(11)=1846.09084, null(11)=0, distinct(12)=1846.27302, null(12)=0, distinct(13)=5, null(13)=0, distinct(14)=1846.27302, null(14)=0, distinct(15)=1845.67052, null(15)=0, distinct(16)=1845.06427, null(16)=0, distinct(22)=5, null(22)=0, distinct(23)=5, null(23)=0, distinct(24)=1, null(24)=0, distinct(26)=1, null(26)=0, distinct(27)=0.996222107, null(27)=0]
+      │         │    │    │    │    │    ├── key: (10)
+      │         │    │    │    │    │    ├── fd: ()-->(27), (22)-->(23,24), (24)==(26), (26)==(24), (10)-->(11-16), (13)==(22), (22)==(13)
+      │         │    │    │    │    │    ├── scan supplier
+      │         │    │    │    │    │    │    ├── save-table-name: q2_scan_17
+      │         │    │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null)
+      │         │    │    │    │    │    │    ├── stats: [rows=10000, distinct(10)=9920, null(10)=0, distinct(11)=9990, null(11)=0, distinct(12)=10000, null(12)=0, distinct(13)=25, null(13)=0, distinct(14)=10000, null(14)=0, distinct(15)=9967, null(15)=0, distinct(16)=9934, null(16)=0]
+      │         │    │    │    │    │    │    ├── key: (10)
+      │         │    │    │    │    │    │    └── fd: (10)-->(11-16)
+      │         │    │    │    │    │    ├── inner-join
+      │         │    │    │    │    │    │    ├── save-table-name: q2_inner_join_18
+      │         │    │    │    │    │    │    ├── columns: n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null)
+      │         │    │    │    │    │    │    ├── stats: [rows=5, distinct(22)=5, null(22)=0, distinct(23)=5, null(23)=0, distinct(24)=1, null(24)=0, distinct(26)=1, null(26)=0, distinct(27)=0.996222107, null(27)=0]
+      │         │    │    │    │    │    │    ├── key: (22)
+      │         │    │    │    │    │    │    ├── fd: ()-->(27), (22)-->(23,24), (24)==(26), (26)==(24)
+      │         │    │    │    │    │    │    ├── scan nation
+      │         │    │    │    │    │    │    │    ├── save-table-name: q2_scan_19
+      │         │    │    │    │    │    │    │    ├── columns: n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null)
+      │         │    │    │    │    │    │    │    ├── stats: [rows=25, distinct(22)=25, null(22)=0, distinct(23)=25, null(23)=0, distinct(24)=5, null(24)=0]
+      │         │    │    │    │    │    │    │    ├── key: (22)
+      │         │    │    │    │    │    │    │    └── fd: (22)-->(23,24)
+      │         │    │    │    │    │    │    ├── select
+      │         │    │    │    │    │    │    │    ├── save-table-name: q2_select_20
+      │         │    │    │    │    │    │    │    ├── columns: r_regionkey:26(int!null) r_name:27(char!null)
+      │         │    │    │    │    │    │    │    ├── stats: [rows=1, distinct(26)=1, null(26)=0, distinct(27)=1, null(27)=0]
+      │         │    │    │    │    │    │    │    ├── key: (26)
+      │         │    │    │    │    │    │    │    ├── fd: ()-->(27)
+      │         │    │    │    │    │    │    │    ├── scan region
+      │         │    │    │    │    │    │    │    │    ├── save-table-name: q2_scan_21
+      │         │    │    │    │    │    │    │    │    ├── columns: r_regionkey:26(int!null) r_name:27(char!null)
+      │         │    │    │    │    │    │    │    │    ├── stats: [rows=5, distinct(26)=5, null(26)=0, distinct(27)=5, null(27)=0]
+      │         │    │    │    │    │    │    │    │    ├── key: (26)
+      │         │    │    │    │    │    │    │    │    └── fd: (26)-->(27)
+      │         │    │    │    │    │    │    │    └── filters
+      │         │    │    │    │    │    │    │         └── r_name = 'EUROPE' [type=bool, outer=(27), constraints=(/27: [/'EUROPE' - /'EUROPE']; tight), fd=()-->(27)]
+      │         │    │    │    │    │    │    └── filters
+      │         │    │    │    │    │    │         └── n_regionkey = r_regionkey [type=bool, outer=(24,26), constraints=(/24: (/NULL - ]; /26: (/NULL - ]), fd=(24)==(26), (26)==(24)]
+      │         │    │    │    │    │    └── filters
+      │         │    │    │    │    │         └── s_nationkey = n_nationkey [type=bool, outer=(13,22), constraints=(/13: (/NULL - ]; /22: (/NULL - ]), fd=(13)==(22), (22)==(13)]
+      │         │    │    │    │    └── filters
+      │         │    │    │    │         └── s_suppkey = ps_suppkey [type=bool, outer=(10,18), constraints=(/10: (/NULL - ]; /18: (/NULL - ]), fd=(10)==(18), (18)==(10)]
+      │         │    │    │    ├── select
+      │         │    │    │    │    ├── save-table-name: q2_select_22
+      │         │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(char!null) p_type:5(varchar!null) p_size:6(int!null)
+      │         │    │    │    │    ├── stats: [rows=1333.33333, distinct(1)=1333.31636, null(1)=0, distinct(3)=5, null(3)=0, distinct(5)=149.97992, null(5)=0, distinct(6)=1, null(6)=0]
+      │         │    │    │    │    ├── key: (1)
+      │         │    │    │    │    ├── fd: ()-->(6), (1)-->(3,5)
+      │         │    │    │    │    ├── scan part
+      │         │    │    │    │    │    ├── save-table-name: q2_scan_23
+      │         │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(char!null) p_type:5(varchar!null) p_size:6(int!null)
+      │         │    │    │    │    │    ├── stats: [rows=200000, distinct(1)=199241, null(1)=0, distinct(3)=5, null(3)=0, distinct(5)=150, null(5)=0, distinct(6)=50, null(6)=0]
+      │         │    │    │    │    │    ├── key: (1)
+      │         │    │    │    │    │    └── fd: (1)-->(3,5,6)
+      │         │    │    │    │    └── filters
+      │         │    │    │    │         ├── p_size = 15 [type=bool, outer=(6), constraints=(/6: [/15 - /15]; tight), fd=()-->(6)]
+      │         │    │    │    │         └── p_type LIKE '%BRASS' [type=bool, outer=(5), constraints=(/5: (/NULL - ])]
+      │         │    │    │    └── filters
+      │         │    │    │         └── p_partkey = ps_partkey [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ]), fd=(1)==(17), (17)==(1)]
+      │         │    │    └── filters
+      │         │    │         └── p_partkey = ps_partkey [type=bool, outer=(1,29), constraints=(/1: (/NULL - ]; /29: (/NULL - ]), fd=(1)==(29), (29)==(1)]
+      │         │    └── aggregations
+      │         │         ├── min [type=float, outer=(32)]
+      │         │         │    └── variable: ps_supplycost [type=float]
+      │         │         ├── const-agg [type=char, outer=(11)]
+      │         │         │    └── variable: s_name [type=char]
+      │         │         ├── const-agg [type=varchar, outer=(12)]
+      │         │         │    └── variable: s_address [type=varchar]
+      │         │         ├── const-agg [type=char, outer=(14)]
+      │         │         │    └── variable: s_phone [type=char]
+      │         │         ├── const-agg [type=float, outer=(15)]
+      │         │         │    └── variable: s_acctbal [type=float]
+      │         │         ├── const-agg [type=varchar, outer=(16)]
+      │         │         │    └── variable: s_comment [type=varchar]
+      │         │         ├── const-agg [type=float, outer=(20)]
+      │         │         │    └── variable: ps_supplycost [type=float]
+      │         │         ├── const-agg [type=char, outer=(23)]
+      │         │         │    └── variable: n_name [type=char]
+      │         │         ├── const-agg [type=char, outer=(3)]
+      │         │         │    └── variable: p_mfgr [type=char]
+      │         │         └── const-agg [type=int, outer=(1)]
+      │         │              └── variable: p_partkey [type=int]
+      │         └── filters
+      │              └── ps_supplycost = min [type=bool, outer=(20,48), constraints=(/20: (/NULL - ]; /48: (/NULL - ]), fd=(20)==(48), (48)==(20)]
+      └── const: 100 [type=int]
+
+stats table=q2_project_1
+----
+column_names  row_count  distinct_count  null_count
+{n_name}      100        5               0
+{p_mfgr}      100        5               0
+{p_partkey}   100        100             0
+{s_acctbal}   100        89              0
+{s_address}   100        89              0
+{s_comment}   100        89              0
+{s_name}      100        89              0
+{s_phone}     100        89              0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}      1.00           100.00 <==     1.00                5.00 <==            0.00            1.00
+{p_mfgr}      1.00           100.00 <==     1.00                5.00 <==            0.00            1.00
+{p_partkey}   1.00           100.00 <==     1.00                100.00 <==          0.00            1.00
+{s_acctbal}   1.00           100.00 <==     1.00                89.00 <==           0.00            1.00
+{s_address}   1.00           100.00 <==     1.00                89.00 <==           0.00            1.00
+{s_comment}   1.00           100.00 <==     1.00                89.00 <==           0.00            1.00
+{s_name}      1.00           100.00 <==     1.00                89.00 <==           0.00            1.00
+{s_phone}     1.00           100.00 <==     1.00                89.00 <==           0.00            1.00
+
+stats table=q2_limit_2
+----
+column_names     row_count  distinct_count  null_count
+{min}            100        100             0
+{n_name}         100        5               0
+{p_mfgr}         100        5               0
+{p_partkey}      100        100             0
+{ps_partkey}     100        100             0
+{ps_suppkey}     100        89              0
+{ps_supplycost}  100        100             0
+{s_acctbal}      100        89              0
+{s_address}      100        89              0
+{s_comment}      100        89              0
+{s_name}         100        89              0
+{s_phone}        100        89              0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{min}            1.00           100.00 <==     1.00                100.00 <==          0.00            1.00
+{n_name}         1.00           100.00 <==     1.00                5.00 <==            0.00            1.00
+{p_mfgr}         1.00           100.00 <==     1.00                5.00 <==            0.00            1.00
+{p_partkey}      1.00           100.00 <==     1.00                100.00 <==          0.00            1.00
+{ps_partkey}     1.00           100.00 <==     1.00                100.00 <==          0.00            1.00
+{ps_suppkey}     1.00           100.00 <==     1.00                89.00 <==           0.00            1.00
+{ps_supplycost}  1.00           100.00 <==     1.00                100.00 <==          0.00            1.00
+{s_acctbal}      1.00           100.00 <==     1.00                89.00 <==           0.00            1.00
+{s_address}      1.00           100.00 <==     1.00                89.00 <==           0.00            1.00
+{s_comment}      1.00           100.00 <==     1.00                89.00 <==           0.00            1.00
+{s_name}         1.00           100.00 <==     1.00                89.00 <==           0.00            1.00
+{s_phone}        1.00           100.00 <==     1.00                89.00 <==           0.00            1.00
+
+stats table=q2_sort_3
+----
+column_names     row_count  distinct_count  null_count
+{min}            100        100             0
+{n_name}         100        5               0
+{p_mfgr}         100        5               0
+{p_partkey}      100        100             0
+{ps_partkey}     100        100             0
+{ps_suppkey}     100        89              0
+{ps_supplycost}  100        100             0
+{s_acctbal}      100        89              0
+{s_address}      100        89              0
+{s_comment}      100        89              0
+{s_name}         100        89              0
+{s_phone}        100        89              0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{min}            1.00           100.00 <==     1.00                100.00 <==          0.00            1.00
+{n_name}         1.00           100.00 <==     1.00                5.00 <==            0.00            1.00
+{p_mfgr}         1.00           100.00 <==     1.00                5.00 <==            0.00            1.00
+{p_partkey}      1.00           100.00 <==     1.00                100.00 <==          0.00            1.00
+{ps_partkey}     1.00           100.00 <==     1.00                100.00 <==          0.00            1.00
+{ps_suppkey}     1.00           100.00 <==     1.00                89.00 <==           0.00            1.00
+{ps_supplycost}  1.00           100.00 <==     1.00                100.00 <==          0.00            1.00
+{s_acctbal}      1.00           100.00 <==     1.00                89.00 <==           0.00            1.00
+{s_address}      1.00           100.00 <==     1.00                89.00 <==           0.00            1.00
+{s_comment}      1.00           100.00 <==     1.00                89.00 <==           0.00            1.00
+{s_name}         1.00           100.00 <==     1.00                89.00 <==           0.00            1.00
+{s_phone}        1.00           100.00 <==     1.00                89.00 <==           0.00            1.00
+
+stats table=q2_select_4
+----
+column_names     row_count  distinct_count  null_count
+{min}            460        458             0
+{n_name}         460        5               0
+{p_mfgr}         460        5               0
+{p_partkey}      460        460             0
+{ps_partkey}     460        460             0
+{ps_suppkey}     460        406             0
+{ps_supplycost}  460        458             0
+{s_acctbal}      460        406             0
+{s_address}      460        406             0
+{s_comment}      460        406             0
+{s_name}         460        406             0
+{s_phone}        460        406             0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{min}            1.00           460.00 <==     1.00                458.00 <==          0.00            1.00
+{n_name}         1.00           460.00 <==     1.00                5.00 <==            0.00            1.00
+{p_mfgr}         1.00           460.00 <==     1.00                5.00 <==            0.00            1.00
+{p_partkey}      1.00           460.00 <==     1.00                460.00 <==          0.00            1.00
+{ps_partkey}     1.00           460.00 <==     1.00                460.00 <==          0.00            1.00
+{ps_suppkey}     1.00           460.00 <==     1.00                406.00 <==          0.00            1.00
+{ps_supplycost}  1.00           460.00 <==     1.00                458.00 <==          0.00            1.00
+{s_acctbal}      1.00           460.00 <==     1.00                406.00 <==          0.00            1.00
+{s_address}      1.00           460.00 <==     1.00                406.00 <==          0.00            1.00
+{s_comment}      1.00           460.00 <==     1.00                406.00 <==          0.00            1.00
+{s_name}         1.00           460.00 <==     1.00                406.00 <==          0.00            1.00
+{s_phone}        1.00           460.00 <==     1.00                406.00 <==          0.00            1.00
+
+stats table=q2_group_by_5
+----
+column_names     row_count  distinct_count  null_count
+{min}            642        458             0
+{n_name}         642        5               0
+{p_mfgr}         642        5               0
+{p_partkey}      642        460             0
+{ps_partkey}     642        460             0
+{ps_suppkey}     642        548             0
+{ps_supplycost}  642        640             0
+{s_acctbal}      642        548             0
+{s_address}      642        548             0
+{s_comment}      642        548             0
+{s_name}         642        548             0
+{s_phone}        642        548             0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{min}            1487.00        2.32 <==       1487.00             3.25 <==            0.00            1.00
+{n_name}         1487.00        2.32 <==       1487.00             297.40 <==          0.00            1.00
+{p_mfgr}         1487.00        2.32 <==       1487.00             297.40 <==          0.00            1.00
+{p_partkey}      1487.00        2.32 <==       1487.00             3.23 <==            0.00            1.00
+{ps_partkey}     1487.00        2.32 <==       1175.00             2.55 <==            0.00            1.00
+{ps_suppkey}     1487.00        2.32 <==       1412.00             2.58 <==            0.00            1.00
+{ps_supplycost}  1487.00        2.32 <==       1487.00             2.32 <==            0.00            1.00
+{s_acctbal}      1487.00        2.32 <==       1487.00             2.71 <==            0.00            1.00
+{s_address}      1487.00        2.32 <==       1487.00             2.71 <==            0.00            1.00
+{s_comment}      1487.00        2.32 <==       1487.00             2.71 <==            0.00            1.00
+{s_name}         1487.00        2.32 <==       1487.00             2.71 <==            0.00            1.00
+{s_phone}        1487.00        2.32 <==       1487.00             2.71 <==            0.00            1.00
+
+stats table=q2_inner_join_6
+----
+column_names       row_count  distinct_count  null_count
+{n_name}           1070       5               0
+{n_nationkey_1}    1070       5               0
+{n_nationkey}      1070       5               0
+{n_regionkey_1}    1070       1               0
+{n_regionkey}      1070       1               0
+{p_mfgr}           1070       5               0
+{p_partkey}        1070       460             0
+{p_size}           1070       1               0
+{p_type}           1070       30              0
+{ps_partkey_1}     1070       460             0
+{ps_partkey}       1070       460             0
+{ps_suppkey_1}     1070       548             0
+{ps_suppkey}       1070       548             0
+{ps_supplycost_1}  1070       640             0
+{ps_supplycost}    1070       640             0
+{r_name_1}         1070       1               0
+{r_name}           1070       1               0
+{r_regionkey_1}    1070       1               0
+{r_regionkey}      1070       1               0
+{s_acctbal}        1070       548             0
+{s_address}        1070       548             0
+{s_comment}        1070       548             0
+{s_name}           1070       548             0
+{s_nationkey_1}    1070       5               0
+{s_nationkey}      1070       5               0
+{s_phone}          1070       548             0
+{s_suppkey_1}      1070       548             0
+{s_suppkey}        1070       548             0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}           2837.00        2.65 <==       5.00                1.00                0.00            1.00
+{n_nationkey}      2837.00        2.65 <==       5.00                1.00                0.00            1.00
+{n_nationkey_1}    2837.00        2.65 <==       5.00                1.00                0.00            1.00
+{n_regionkey}      2837.00        2.65 <==       1.00                1.00                0.00            1.00
+{n_regionkey_1}    2837.00        2.65 <==       1.00                1.00                0.00            1.00
+{p_mfgr}           2837.00        2.65 <==       5.00                1.00                0.00            1.00
+{p_partkey}        2837.00        2.65 <==       1333.00             2.90 <==            0.00            1.00
+{p_size}           2837.00        2.65 <==       1.00                1.00                0.00            1.00
+{p_type}           2837.00        2.65 <==       150.00              5.00 <==            0.00            1.00
+{ps_partkey}       2837.00        2.65 <==       1175.00             2.55 <==            0.00            1.00
+{ps_partkey_1}     2837.00        2.65 <==       1333.00             2.90 <==            0.00            1.00
+{ps_suppkey}       2837.00        2.65 <==       1412.00             2.58 <==            0.00            1.00
+{ps_suppkey_1}     2837.00        2.65 <==       1449.00             2.64 <==            0.00            1.00
+{ps_supplycost}    2837.00        2.65 <==       1483.00             2.32 <==            0.00            1.00
+{ps_supplycost_1}  2837.00        2.65 <==       2788.00             4.36 <==            0.00            1.00
+{r_name}           2837.00        2.65 <==       1.00                1.00                0.00            1.00
+{r_name_1}         2837.00        2.65 <==       1.00                1.00                0.00            1.00
+{r_regionkey}      2837.00        2.65 <==       1.00                1.00                0.00            1.00
+{r_regionkey_1}    2837.00        2.65 <==       1.00                1.00                0.00            1.00
+{s_acctbal}        2837.00        2.65 <==       1412.00             2.58 <==            0.00            1.00
+{s_address}        2837.00        2.65 <==       1413.00             2.58 <==            0.00            1.00
+{s_comment}        2837.00        2.65 <==       1412.00             2.58 <==            0.00            1.00
+{s_name}           2837.00        2.65 <==       1412.00             2.58 <==            0.00            1.00
+{s_nationkey}      2837.00        2.65 <==       5.00                1.00                0.00            1.00
+{s_nationkey_1}    2837.00        2.65 <==       5.00                1.00                0.00            1.00
+{s_phone}          2837.00        2.65 <==       1413.00             2.58 <==            0.00            1.00
+{s_suppkey}        2837.00        2.65 <==       1412.00             2.58 <==            0.00            1.00
+{s_suppkey_1}      2837.00        2.65 <==       1449.00             2.64 <==            0.00            1.00
+
+stats table=q2_inner_join_7
+----
+column_names     row_count  distinct_count  null_count
+{n_nationkey}    158960     5               0
+{n_regionkey}    158960     1               0
+{ps_partkey}     158960     117007          0
+{ps_suppkey}     158960     1987            0
+{ps_supplycost}  158960     79812           0
+{r_name}         158960     1               0
+{r_regionkey}    158960     1               0
+{s_nationkey}    158960     5               0
+{s_suppkey}      158960     1987            0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_nationkey}    161290.00      1.01           5.00                1.00                0.00            1.00
+{n_regionkey}    161290.00      1.01           1.00                1.00                0.00            1.00
+{ps_partkey}     161290.00      1.01           110568.00           1.06                0.00            1.00
+{ps_suppkey}     161290.00      1.01           1845.00             1.08                0.00            1.00
+{ps_supplycost}  161290.00      1.01           80252.00            1.01                0.00            1.00
+{r_name}         161290.00      1.01           1.00                1.00                0.00            1.00
+{r_regionkey}    161290.00      1.01           1.00                1.00                0.00            1.00
+{s_nationkey}    161290.00      1.01           5.00                1.00                0.00            1.00
+{s_suppkey}      161290.00      1.01           1845.00             1.08                0.00            1.00
+
+stats table=q2_scan_8
+----
+column_names     row_count  distinct_count  null_count
+{ps_partkey}     800000     199241          0
+{ps_suppkey}     800000     9920            0
+{ps_supplycost}  800000     100379          0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{ps_partkey}     800000.00      1.00           199241.00           1.00                0.00            1.00
+{ps_suppkey}     800000.00      1.00           9920.00             1.00                0.00            1.00
+{ps_supplycost}  800000.00      1.00           100379.00           1.00                0.00            1.00
+
+stats table=q2_lookup_join_9
+----
+column_names   row_count  distinct_count  null_count
+{n_nationkey}  1987       5               0
+{n_regionkey}  1987       1               0
+{r_name}       1987       1               0
+{r_regionkey}  1987       1               0
+{s_nationkey}  1987       5               0
+{s_suppkey}    1987       1987            0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_nationkey}  2000.00        1.01           5.00                1.00                0.00            1.00
+{n_regionkey}  2000.00        1.01           1.00                1.00                0.00            1.00
+{r_name}       2000.00        1.01           1.00                1.00                0.00            1.00
+{r_regionkey}  2000.00        1.01           1.00                1.00                0.00            1.00
+{s_nationkey}  2000.00        1.01           5.00                1.00                0.00            1.00
+{s_suppkey}    2000.00        1.01           1845.00             1.08                0.00            1.00
+
+stats table=q2_lookup_join_10
+----
+column_names   row_count  distinct_count  null_count
+{n_nationkey}  5          5               0
+{n_regionkey}  5          1               0
+{r_name}       5          1               0
+{r_regionkey}  5          1               0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_nationkey}  5.00           1.00           5.00                1.00                0.00            1.00
+{n_regionkey}  5.00           1.00           1.00                1.00                0.00            1.00
+{r_name}       5.00           1.00           1.00                1.00                0.00            1.00
+{r_regionkey}  5.00           1.00           1.00                1.00                0.00            1.00
+
+stats table=q2_select_11
+----
+column_names   row_count  distinct_count  null_count
+{r_name}       1          1               0
+{r_regionkey}  1          1               0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{r_name}       1.00           1.00           1.00                1.00                0.00            1.00
+{r_regionkey}  1.00           1.00           1.00                1.00                0.00            1.00
+
+stats table=q2_scan_12
+----
+column_names   row_count  distinct_count  null_count
+{r_name}       5          5               0
+{r_regionkey}  5          5               0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{r_name}       5.00           1.00           5.00                1.00                0.00            1.00
+{r_regionkey}  5.00           1.00           5.00                1.00                0.00            1.00
+
+stats table=q2_inner_join_13
+----
+column_names     row_count  distinct_count  null_count
+{n_name}         642        5               0
+{n_nationkey}    642        5               0
+{n_regionkey}    642        1               0
+{p_mfgr}         642        5               0
+{p_partkey}      642        460             0
+{p_size}         642        1               0
+{p_type}         642        30              0
+{ps_partkey}     642        460             0
+{ps_suppkey}     642        548             0
+{ps_supplycost}  642        640             0
+{r_name}         642        1               0
+{r_regionkey}    642        1               0
+{s_acctbal}      642        548             0
+{s_address}      642        548             0
+{s_comment}      642        548             0
+{s_name}         642        548             0
+{s_nationkey}    642        5               0
+{s_phone}        642        548             0
+{s_suppkey}      642        548             0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}         1945.00        3.03 <==       5.00                1.00                0.00            1.00
+{n_nationkey}    1945.00        3.03 <==       5.00                1.00                0.00            1.00
+{n_regionkey}    1945.00        3.03 <==       1.00                1.00                0.00            1.00
+{p_mfgr}         1945.00        3.03 <==       5.00                1.00                0.00            1.00
+{p_partkey}      1945.00        3.03 <==       1333.00             2.90 <==            0.00            1.00
+{p_size}         1945.00        3.03 <==       1.00                1.00                0.00            1.00
+{p_type}         1945.00        3.03 <==       150.00              5.00 <==            0.00            1.00
+{ps_partkey}     1945.00        3.03 <==       1333.00             2.90 <==            0.00            1.00
+{ps_suppkey}     1945.00        3.03 <==       1766.00             3.22 <==            0.00            1.00
+{ps_supplycost}  1945.00        3.03 <==       1922.00             3.00 <==            0.00            1.00
+{r_name}         1945.00        3.03 <==       1.00                1.00                0.00            1.00
+{r_regionkey}    1945.00        3.03 <==       1.00                1.00                0.00            1.00
+{s_acctbal}      1945.00        3.03 <==       1767.00             3.22 <==            0.00            1.00
+{s_address}      1945.00        3.03 <==       1768.00             3.23 <==            0.00            1.00
+{s_comment}      1945.00        3.03 <==       1766.00             3.22 <==            0.00            1.00
+{s_name}         1945.00        3.03 <==       1767.00             3.22 <==            0.00            1.00
+{s_nationkey}    1945.00        3.03 <==       5.00                1.00                0.00            1.00
+{s_phone}        1945.00        3.03 <==       1768.00             3.23 <==            0.00            1.00
+{s_suppkey}      1945.00        3.03 <==       1766.00             3.22 <==            0.00            1.00
+
+stats table=q2_inner_join_14
+----
+column_names     row_count  distinct_count  null_count
+{n_name}         158960     5               0
+{n_nationkey}    158960     5               0
+{n_regionkey}    158960     1               0
+{ps_partkey}     158960     117007          0
+{ps_suppkey}     158960     1987            0
+{ps_supplycost}  158960     79812           0
+{r_name}         158960     1               0
+{r_regionkey}    158960     1               0
+{s_acctbal}      158960     1983            0
+{s_address}      158960     1986            0
+{s_comment}      158960     1987            0
+{s_name}         158960     1987            0
+{s_nationkey}    158960     5               0
+{s_phone}        158960     1987            0
+{s_suppkey}      158960     1987            0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}         161290.00      1.01           5.00                1.00                0.00            1.00
+{n_nationkey}    161290.00      1.01           5.00                1.00                0.00            1.00
+{n_regionkey}    161290.00      1.01           1.00                1.00                0.00            1.00
+{ps_partkey}     161290.00      1.01           110565.00           1.06                0.00            1.00
+{ps_suppkey}     161290.00      1.01           9920.00             4.99 <==            0.00            1.00
+{ps_supplycost}  161290.00      1.01           80251.00            1.01                0.00            1.00
+{r_name}         161290.00      1.01           1.00                1.00                0.00            1.00
+{r_regionkey}    161290.00      1.01           1.00                1.00                0.00            1.00
+{s_acctbal}      161290.00      1.01           9967.00             5.03 <==            0.00            1.00
+{s_address}      161290.00      1.01           10000.00            5.04 <==            0.00            1.00
+{s_comment}      161290.00      1.01           9934.00             5.00 <==            0.00            1.00
+{s_name}         161290.00      1.01           9990.00             5.03 <==            0.00            1.00
+{s_nationkey}    161290.00      1.01           5.00                1.00                0.00            1.00
+{s_phone}        161290.00      1.01           10000.00            5.03 <==            0.00            1.00
+{s_suppkey}      161290.00      1.01           9920.00             4.99 <==            0.00            1.00
+
+stats table=q2_scan_15
+----
+column_names     row_count  distinct_count  null_count
+{ps_partkey}     800000     199241          0
+{ps_suppkey}     800000     9920            0
+{ps_supplycost}  800000     100379          0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{ps_partkey}     800000.00      1.00           199241.00           1.00                0.00            1.00
+{ps_suppkey}     800000.00      1.00           9920.00             1.00                0.00            1.00
+{ps_supplycost}  800000.00      1.00           100379.00           1.00                0.00            1.00
+
+stats table=q2_inner_join_16
+----
+column_names   row_count  distinct_count  null_count
+{n_name}       1987       5               0
+{n_nationkey}  1987       5               0
+{n_regionkey}  1987       1               0
+{r_name}       1987       1               0
+{r_regionkey}  1987       1               0
+{s_acctbal}    1987       1983            0
+{s_address}    1987       1986            0
+{s_comment}    1987       1987            0
+{s_name}       1987       1987            0
+{s_nationkey}  1987       5               0
+{s_phone}      1987       1987            0
+{s_suppkey}    1987       1987            0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}       2000.00        1.01           5.00                1.00                0.00            1.00
+{n_nationkey}  2000.00        1.01           5.00                1.00                0.00            1.00
+{n_regionkey}  2000.00        1.01           1.00                1.00                0.00            1.00
+{r_name}       2000.00        1.01           1.00                1.00                0.00            1.00
+{r_regionkey}  2000.00        1.01           1.00                1.00                0.00            1.00
+{s_acctbal}    2000.00        1.01           1846.00             1.07                0.00            1.00
+{s_address}    2000.00        1.01           1846.00             1.08                0.00            1.00
+{s_comment}    2000.00        1.01           1845.00             1.08                0.00            1.00
+{s_name}       2000.00        1.01           1846.00             1.08                0.00            1.00
+{s_nationkey}  2000.00        1.01           5.00                1.00                0.00            1.00
+{s_phone}      2000.00        1.01           1846.00             1.08                0.00            1.00
+{s_suppkey}    2000.00        1.01           1845.00             1.08                0.00            1.00
+
+stats table=q2_scan_17
+----
+column_names   row_count  distinct_count  null_count
+{s_acctbal}    10000      9967            0
+{s_address}    10000      10027           0
+{s_comment}    10000      9934            0
+{s_name}       10000      9990            0
+{s_nationkey}  10000      25              0
+{s_phone}      10000      10021           0
+{s_suppkey}    10000      9920            0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{s_acctbal}    10000.00       1.00           9967.00             1.00                0.00            1.00
+{s_address}    10000.00       1.00           10000.00            1.00                0.00            1.00
+{s_comment}    10000.00       1.00           9934.00             1.00                0.00            1.00
+{s_name}       10000.00       1.00           9990.00             1.00                0.00            1.00
+{s_nationkey}  10000.00       1.00           25.00               1.00                0.00            1.00
+{s_phone}      10000.00       1.00           10000.00            1.00                0.00            1.00
+{s_suppkey}    10000.00       1.00           9920.00             1.00                0.00            1.00
+
+stats table=q2_inner_join_18
+----
+column_names   row_count  distinct_count  null_count
+{n_name}       5          5               0
+{n_nationkey}  5          5               0
+{n_regionkey}  5          1               0
+{r_name}       5          1               0
+{r_regionkey}  5          1               0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}       5.00           1.00           5.00                1.00                0.00            1.00
+{n_nationkey}  5.00           1.00           5.00                1.00                0.00            1.00
+{n_regionkey}  5.00           1.00           1.00                1.00                0.00            1.00
+{r_name}       5.00           1.00           1.00                1.00                0.00            1.00
+{r_regionkey}  5.00           1.00           1.00                1.00                0.00            1.00
+
+stats table=q2_scan_19
+----
+column_names   row_count  distinct_count  null_count
+{n_name}       25         25              0
+{n_nationkey}  25         25              0
+{n_regionkey}  25         5               0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}       25.00          1.00           25.00               1.00                0.00            1.00
+{n_nationkey}  25.00          1.00           25.00               1.00                0.00            1.00
+{n_regionkey}  25.00          1.00           5.00                1.00                0.00            1.00
+
+stats table=q2_select_20
+----
+column_names   row_count  distinct_count  null_count
+{r_name}       1          1               0
+{r_regionkey}  1          1               0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{r_name}       1.00           1.00           1.00                1.00                0.00            1.00
+{r_regionkey}  1.00           1.00           1.00                1.00                0.00            1.00
+
+stats table=q2_scan_21
+----
+column_names   row_count  distinct_count  null_count
+{r_name}       5          5               0
+{r_regionkey}  5          5               0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{r_name}       5.00           1.00           5.00                1.00                0.00            1.00
+{r_regionkey}  5.00           1.00           5.00                1.00                0.00            1.00
+
+stats table=q2_select_22
+----
+column_names  row_count  distinct_count  null_count
+{p_mfgr}      747        5               0
+{p_partkey}   747        747             0
+{p_size}      747        1               0
+{p_type}      747        30              0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{p_mfgr}      1333.00        1.78           5.00                1.00                0.00            1.00
+{p_partkey}   1333.00        1.78           1333.00             1.78                0.00            1.00
+{p_size}      1333.00        1.78           1.00                1.00                0.00            1.00
+{p_type}      1333.00        1.78           150.00              5.00 <==            0.00            1.00
+
+stats table=q2_scan_23
+----
+column_names  row_count  distinct_count  null_count
+{p_mfgr}      200000     5               0
+{p_partkey}   200000     199241          0
+{p_size}      200000     50              0
+{p_type}      200000     150             0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{p_mfgr}      200000.00      1.00           5.00                1.00                0.00            1.00
+{p_partkey}   200000.00      1.00           199241.00           1.00                0.00            1.00
+{p_size}      200000.00      1.00           50.00               1.00                0.00            1.00
+{p_type}      200000.00      1.00           150.00              1.00                0.00            1.00
+
+# --------------------------------------------------
+# Q3
+# Shipping Priority
+# Retrieves the 10 unshipped orders with the highest value.
+#
+# Retrieves the shipping priority and potential revenue, defined as the sum of
+# l_extendedprice * (1-l_discount), of the orders having the largest revenue
+# among those that had not been shipped as of a given date. Orders are listed in
+# decreasing order of revenue. If more than 10 unshipped orders exist, only the
+# 10 orders with the largest revenue are listed.
+# --------------------------------------------------
+save-tables database=tpch save-tables-prefix=q3
+SELECT
+    l_orderkey,
+    sum(l_extendedprice * (1 - l_discount)) AS revenue,
+    o_orderdate,
+    o_shippriority
+FROM
+    customer,
+    orders,
+    lineitem
+WHERE
+    c_mktsegment = 'BUILDING'
+    AND c_custkey = o_custkey
+    AND l_orderkey = o_orderkey
+    AND o_orderDATE < DATE '1995-03-15'
+    AND l_shipdate > DATE '1995-03-15'
+GROUP BY
+    l_orderkey,
+    o_orderdate,
+    o_shippriority
+ORDER BY
+    revenue DESC,
+    o_orderdate
+LIMIT 10;
+----
+limit
+ ├── save-table-name: q3_limit_1
+ ├── columns: l_orderkey:18(int!null) revenue:35(float) o_orderdate:13(date) o_shippriority:16(int)
+ ├── internal-ordering: -35,+13
+ ├── cardinality: [0 - 10]
+ ├── stats: [rows=10, distinct(13)=10, null(13)=0, distinct(16)=10, null(16)=0, distinct(18)=10, null(18)=0, distinct(35)=10, null(35)=0]
+ ├── key: (18)
+ ├── fd: (18)-->(13,16,35)
+ ├── ordering: -35,+13
+ ├── sort
+ │    ├── save-table-name: q3_sort_2
+ │    ├── columns: o_orderdate:13(date) o_shippriority:16(int) l_orderkey:18(int!null) sum:35(float)
+ │    ├── stats: [rows=195275.364, distinct(13)=195275.364, null(13)=0, distinct(16)=195275.364, null(16)=0, distinct(18)=195275.364, null(18)=0, distinct(35)=195275.364, null(35)=0]
+ │    ├── key: (18)
+ │    ├── fd: (18)-->(13,16,35)
+ │    ├── ordering: -35,+13
+ │    └── group-by
+ │         ├── save-table-name: q3_group_by_3
+ │         ├── columns: o_orderdate:13(date) o_shippriority:16(int) l_orderkey:18(int!null) sum:35(float)
+ │         ├── grouping columns: l_orderkey:18(int!null)
+ │         ├── stats: [rows=195275.364, distinct(13)=195275.364, null(13)=0, distinct(16)=195275.364, null(16)=0, distinct(18)=195275.364, null(18)=0, distinct(35)=195275.364, null(35)=0]
+ │         ├── key: (18)
+ │         ├── fd: (18)-->(13,16,35)
+ │         ├── project
+ │         │    ├── save-table-name: q3_project_4
+ │         │    ├── columns: column34:34(float) o_orderdate:13(date!null) o_shippriority:16(int!null) l_orderkey:18(int!null)
+ │         │    ├── stats: [rows=247598.539, distinct(13)=2406, null(13)=0, distinct(16)=1, null(16)=0, distinct(18)=195275.364, null(18)=0, distinct(34)=247598.539, null(34)=0]
+ │         │    ├── fd: (18)-->(13,16)
+ │         │    ├── inner-join (lookup lineitem)
+ │         │    │    ├── save-table-name: q3_lookup_join_5
+ │         │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(char!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_shipdate:28(date!null)
+ │         │    │    ├── key columns: [9] = [18]
+ │         │    │    ├── stats: [rows=247598.539, distinct(1)=29974.3087, null(1)=0, distinct(7)=1, null(7)=0, distinct(9)=195275.364, null(9)=0, distinct(10)=29974.3087, null(10)=0, distinct(13)=2406, null(13)=0, distinct(16)=1, null(16)=0, distinct(18)=195275.364, null(18)=0, distinct(23)=197736.715, null(23)=0, distinct(24)=11, null(24)=0, distinct(28)=2526, null(28)=0, distinct(23,24)=247598.539, null(23,24)=0]
+ │         │    │    ├── fd: ()-->(7), (9)-->(10,13,16), (9)==(18), (18)==(9), (1)==(10), (10)==(1)
+ │         │    │    ├── inner-join
+ │         │    │    │    ├── save-table-name: q3_inner_join_6
+ │         │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(char!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null)
+ │         │    │    │    ├── stats: [rows=150572.001, distinct(1)=29974.3087, null(1)=0, distinct(7)=1, null(7)=0, distinct(9)=130014.955, null(9)=0, distinct(10)=29974.3087, null(10)=0, distinct(13)=2406, null(13)=0, distinct(16)=1, null(16)=0]
+ │         │    │    │    ├── key: (9)
+ │         │    │    │    ├── fd: ()-->(7), (9)-->(10,13,16), (1)==(10), (10)==(1)
+ │         │    │    │    ├── select
+ │         │    │    │    │    ├── save-table-name: q3_select_7
+ │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null)
+ │         │    │    │    │    ├── stats: [rows=500000, distinct(9)=500000, null(9)=0, distinct(10)=99620.1148, null(10)=0, distinct(13)=2406, null(13)=0, distinct(16)=1, null(16)=0]
+ │         │    │    │    │    ├── key: (9)
+ │         │    │    │    │    ├── fd: (9)-->(10,13,16)
+ │         │    │    │    │    ├── scan orders
+ │         │    │    │    │    │    ├── save-table-name: q3_scan_8
+ │         │    │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null)
+ │         │    │    │    │    │    ├── stats: [rows=1500000, distinct(9)=1500000, null(9)=0, distinct(10)=99846, null(10)=0, distinct(13)=2406, null(13)=0, distinct(16)=1, null(16)=0]
+ │         │    │    │    │    │    ├── key: (9)
+ │         │    │    │    │    │    └── fd: (9)-->(10,13,16)
+ │         │    │    │    │    └── filters
+ │         │    │    │    │         └── o_orderdate < '1995-03-15' [type=bool, outer=(13), constraints=(/13: (/NULL - /'1995-03-14']; tight)]
+ │         │    │    │    ├── select
+ │         │    │    │    │    ├── save-table-name: q3_select_9
+ │         │    │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(char!null)
+ │         │    │    │    │    ├── stats: [rows=30000, distinct(1)=29974.3087, null(1)=0, distinct(7)=1, null(7)=0]
+ │         │    │    │    │    ├── key: (1)
+ │         │    │    │    │    ├── fd: ()-->(7)
+ │         │    │    │    │    ├── scan customer
+ │         │    │    │    │    │    ├── save-table-name: q3_scan_10
+ │         │    │    │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(char!null)
+ │         │    │    │    │    │    ├── stats: [rows=150000, distinct(1)=148813, null(1)=0, distinct(7)=5, null(7)=0]
+ │         │    │    │    │    │    ├── key: (1)
+ │         │    │    │    │    │    └── fd: (1)-->(7)
+ │         │    │    │    │    └── filters
+ │         │    │    │    │         └── c_mktsegment = 'BUILDING' [type=bool, outer=(7), constraints=(/7: [/'BUILDING' - /'BUILDING']; tight), fd=()-->(7)]
+ │         │    │    │    └── filters
+ │         │    │    │         └── c_custkey = o_custkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+ │         │    │    └── filters
+ │         │    │         └── l_shipdate > '1995-03-15' [type=bool, outer=(28), constraints=(/28: [/'1995-03-16' - ]; tight)]
+ │         │    └── projections
+ │         │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(23,24)]
+ │         └── aggregations
+ │              ├── sum [type=float, outer=(34)]
+ │              │    └── variable: column34 [type=float]
+ │              ├── const-agg [type=date, outer=(13)]
+ │              │    └── variable: o_orderdate [type=date]
+ │              └── const-agg [type=int, outer=(16)]
+ │                   └── variable: o_shippriority [type=int]
+ └── const: 10 [type=int]
+
+stats table=q3_limit_1
+----
+column_names      row_count  distinct_count  null_count
+{l_orderkey}      10         10              0
+{o_orderdate}     10         8               0
+{o_shippriority}  10         1               0
+{revenue}         10         10              0
+~~~~
+column_names      row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_orderkey}      10.00          1.00           10.00               1.00                0.00            1.00
+{o_orderdate}     10.00          1.00           10.00               1.25                0.00            1.00
+{o_shippriority}  10.00          1.00           10.00               10.00 <==           0.00            1.00
+{revenue}         10.00          1.00           10.00               1.00                0.00            1.00
+
+stats table=q3_sort_2
+----
+column_names      row_count  distinct_count  null_count
+{l_orderkey}      0          0               0
+{o_orderdate}     0          0               0
+{o_shippriority}  0          0               0
+{sum}             0          0               0
+~~~~
+column_names      row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_orderkey}      195275.00      +Inf <==       195275.00           +Inf <==            0.00            1.00
+{o_orderdate}     195275.00      +Inf <==       195275.00           +Inf <==            0.00            1.00
+{o_shippriority}  195275.00      +Inf <==       195275.00           +Inf <==            0.00            1.00
+{sum}             195275.00      +Inf <==       195275.00           +Inf <==            0.00            1.00
+
+stats table=q3_group_by_3
+----
+column_names      row_count  distinct_count  null_count
+{l_orderkey}      11620      11611           0
+{o_orderdate}     11620      120             0
+{o_shippriority}  11620      1               0
+{sum}             11620      11601           0
+~~~~
+column_names      row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_orderkey}      195275.00      16.81 <==      195275.00           16.82 <==           0.00            1.00
+{o_orderdate}     195275.00      16.81 <==      195275.00           1627.29 <==         0.00            1.00
+{o_shippriority}  195275.00      16.81 <==      195275.00           195275.00 <==       0.00            1.00
+{sum}             195275.00      16.81 <==      195275.00           16.83 <==           0.00            1.00
+
+stats table=q3_project_4
+----
+column_names      row_count  distinct_count  null_count
+{column34}        30519      30424           0
+{l_orderkey}      30519      11611           0
+{o_orderdate}     30519      120             0
+{o_shippriority}  30519      1               0
+~~~~
+column_names      row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{column34}        247599.00      8.11 <==       247599.00           8.14 <==            0.00            1.00
+{l_orderkey}      247599.00      8.11 <==       195275.00           16.82 <==           0.00            1.00
+{o_orderdate}     247599.00      8.11 <==       2406.00             20.05 <==           0.00            1.00
+{o_shippriority}  247599.00      8.11 <==       1.00                1.00                0.00            1.00
+
+stats table=q3_lookup_join_5
+----
+column_names       row_count  distinct_count  null_count
+{c_custkey}        30519      8643            0
+{c_mktsegment}     30519      1               0
+{l_discount}       30519      11              0
+{l_extendedprice}  30519      30042           0
+{l_orderkey}       30519      11611           0
+{l_shipdate}       30519      120             0
+{o_custkey}        30519      8643            0
+{o_orderdate}      30519      120             0
+{o_orderkey}       30519      11611           0
+{o_shippriority}   30519      1               0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_custkey}        247599.00      8.11 <==       29974.00            3.47 <==            0.00            1.00
+{c_mktsegment}     247599.00      8.11 <==       1.00                1.00                0.00            1.00
+{l_discount}       247599.00      8.11 <==       11.00               1.00                0.00            1.00
+{l_extendedprice}  247599.00      8.11 <==       197737.00           6.58 <==            0.00            1.00
+{l_orderkey}       247599.00      8.11 <==       195275.00           16.82 <==           0.00            1.00
+{l_shipdate}       247599.00      8.11 <==       2526.00             21.05 <==           0.00            1.00
+{o_custkey}        247599.00      8.11 <==       29974.00            3.47 <==            0.00            1.00
+{o_orderdate}      247599.00      8.11 <==       2406.00             20.05 <==           0.00            1.00
+{o_orderkey}       247599.00      8.11 <==       195275.00           16.82 <==           0.00            1.00
+{o_shippriority}   247599.00      8.11 <==       1.00                1.00                0.00            1.00
+
+stats table=q3_inner_join_6
+----
+column_names      row_count  distinct_count  null_count
+{c_custkey}       147126     20129           0
+{c_mktsegment}    147126     1               0
+{o_custkey}       147126     20129           0
+{o_orderdate}     147126     1169            0
+{o_orderkey}      147126     145236          0
+{o_shippriority}  147126     1               0
+~~~~
+column_names      row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_custkey}       150572.00      1.02           29974.00            1.49                0.00            1.00
+{c_mktsegment}    150572.00      1.02           1.00                1.00                0.00            1.00
+{o_custkey}       150572.00      1.02           29974.00            1.49                0.00            1.00
+{o_orderdate}     150572.00      1.02           2406.00             2.06 <==            0.00            1.00
+{o_orderkey}      150572.00      1.02           130015.00           1.12                0.00            1.00
+{o_shippriority}  150572.00      1.02           1.00                1.00                0.00            1.00
+
+stats table=q3_select_7
+----
+column_names      row_count  distinct_count  null_count
+{o_custkey}       727305     99492           0
+{o_orderdate}     727305     1169            0
+{o_orderkey}      727305     730170          0
+{o_shippriority}  727305     1               0
+~~~~
+column_names      row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{o_custkey}       500000.00      1.45           99620.00            1.00                0.00            1.00
+{o_orderdate}     500000.00      1.45           2406.00             2.06 <==            0.00            1.00
+{o_orderkey}      500000.00      1.45           500000.00           1.46                0.00            1.00
+{o_shippriority}  500000.00      1.45           1.00                1.00                0.00            1.00
+
+stats table=q3_scan_8
+----
+column_names      row_count  distinct_count  null_count
+{o_custkey}       1500000    99846           0
+{o_orderdate}     1500000    2406            0
+{o_orderkey}      1500000    1527270         0
+{o_shippriority}  1500000    1               0
+~~~~
+column_names      row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{o_custkey}       1500000.00     1.00           99846.00            1.00                0.00            1.00
+{o_orderdate}     1500000.00     1.00           2406.00             1.00                0.00            1.00
+{o_orderkey}      1500000.00     1.00           1500000.00          1.02                0.00            1.00
+{o_shippriority}  1500000.00     1.00           1.00                1.00                0.00            1.00
+
+stats table=q3_select_9
+----
+column_names    row_count  distinct_count  null_count
+{c_custkey}     30142      30101           0
+{c_mktsegment}  30142      1               0
+~~~~
+column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_custkey}     30000.00       1.00           29974.00            1.00                0.00            1.00
+{c_mktsegment}  30000.00       1.00           1.00                1.00                0.00            1.00
+
+stats table=q3_scan_10
+----
+column_names    row_count  distinct_count  null_count
+{c_custkey}     150000     148813          0
+{c_mktsegment}  150000     5               0
+~~~~
+column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_custkey}     150000.00      1.00           148813.00           1.00                0.00            1.00
+{c_mktsegment}  150000.00      1.00           5.00                1.00                0.00            1.00
+
+# --------------------------------------------------
+# Q4
+# Order Priority Checking
+# Determines how well the order priority system is working and gives an
+# assessment of customer satisfaction.
+#
+# Counts the number of orders ordered in a given quarter of a given year in
+# which at least one lineitem was received by the customer later than its
+# committed date. The query lists the count of such orders for each order
+# priority sorted in ascending priority order.
+# --------------------------------------------------
+save-tables database=tpch save-tables-prefix=q4
+SELECT
+    o_orderpriority,
+    count(*) AS order_count
+FROM
+    orders
+WHERE
+    o_orderdate >= DATE '1993-07-01'
+    AND o_orderdate < DATE '1993-07-01' + INTERVAL '3' MONTH
+    AND EXISTS (
+        SELECT
+            *
+        FROM
+            lineitem
+        WHERE
+            l_orderkey = o_orderkey
+            AND l_commitDATE < l_receiptdate
+    )
+GROUP BY
+    o_orderpriority
+ORDER BY
+    o_orderpriority;
+----
+sort
+ ├── save-table-name: q4_sort_1
+ ├── columns: o_orderpriority:6(char!null) order_count:26(int)
+ ├── stats: [rows=5, distinct(6)=5, null(6)=0, distinct(26)=5, null(26)=0]
+ ├── key: (6)
+ ├── fd: (6)-->(26)
+ ├── ordering: +6
+ └── group-by
+      ├── save-table-name: q4_group_by_2
+      ├── columns: o_orderpriority:6(char!null) count_rows:26(int)
+      ├── grouping columns: o_orderpriority:6(char!null)
+      ├── stats: [rows=5, distinct(6)=5, null(6)=0, distinct(26)=5, null(26)=0]
+      ├── key: (6)
+      ├── fd: (6)-->(26)
+      ├── semi-join
+      │    ├── save-table-name: q4_semi_join_3
+      │    ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null) o_orderpriority:6(char!null)
+      │    ├── stats: [rows=166666.667, distinct(1)=166666.667, null(1)=0, distinct(5)=2406, null(5)=0, distinct(6)=5, null(6)=0]
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(5,6)
+      │    ├── index-join orders
+      │    │    ├── save-table-name: q4_index_join_4
+      │    │    ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null) o_orderpriority:6(char!null)
+      │    │    ├── stats: [rows=166666.667, distinct(1)=166666.667, null(1)=0, distinct(5)=2406, null(5)=0, distinct(6)=5, null(6)=0]
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(5,6)
+      │    │    └── scan orders@o_od
+      │    │         ├── save-table-name: q4_scan_5
+      │    │         ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null)
+      │    │         ├── constraint: /5/1: [/'1993-07-01' - /'1993-09-30']
+      │    │         ├── stats: [rows=166666.667, distinct(1)=166666.667, null(1)=0, distinct(5)=2406, null(5)=0]
+      │    │         ├── key: (1)
+      │    │         └── fd: (1)-->(5)
+      │    ├── select
+      │    │    ├── save-table-name: q4_select_6
+      │    │    ├── columns: l_orderkey:10(int!null) l_commitdate:21(date!null) l_receiptdate:22(date!null)
+      │    │    ├── stats: [rows=2000405, distinct(10)=1216823.04, null(10)=0, distinct(21)=2466, null(21)=0, distinct(22)=2554, null(22)=0]
+      │    │    ├── scan lineitem
+      │    │    │    ├── save-table-name: q4_scan_7
+      │    │    │    ├── columns: l_orderkey:10(int!null) l_commitdate:21(date!null) l_receiptdate:22(date!null)
+      │    │    │    └── stats: [rows=6001215, distinct(10)=1527270, null(10)=0, distinct(21)=2466, null(21)=0, distinct(22)=2554, null(22)=0]
+      │    │    └── filters
+      │    │         └── l_commitdate < l_receiptdate [type=bool, outer=(21,22), constraints=(/21: (/NULL - ]; /22: (/NULL - ])]
+      │    └── filters
+      │         └── l_orderkey = o_orderkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+      └── aggregations
+           └── count-rows [type=int]
+
+stats table=q4_sort_1
+----
+column_names       row_count  distinct_count  null_count
+{o_orderpriority}  5          5               0
+{order_count}      5          5               0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{o_orderpriority}  5.00           1.00           5.00                1.00                0.00            1.00
+{order_count}      5.00           1.00           5.00                1.00                0.00            1.00
+
+stats table=q4_group_by_2
+----
+column_names       row_count  distinct_count  null_count
+{count_rows}       5          5               0
+{o_orderpriority}  5          5               0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{count_rows}       5.00           1.00           5.00                1.00                0.00            1.00
+{o_orderpriority}  5.00           1.00           5.00                1.00                0.00            1.00
+
+stats table=q4_semi_join_3
+----
+column_names       row_count  distinct_count  null_count
+{o_orderdate}      52523      92              0
+{o_orderkey}       52523      52442           0
+{o_orderpriority}  52523      5               0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{o_orderdate}      166667.00      3.17 <==       2406.00             26.15 <==           0.00            1.00
+{o_orderkey}       166667.00      3.17 <==       166667.00           3.18 <==            0.00            1.00
+{o_orderpriority}  166667.00      3.17 <==       5.00                1.00                0.00            1.00
+
+stats table=q4_index_join_4
+----
+column_names       row_count  distinct_count  null_count
+{o_orderdate}      57218      92              0
+{o_orderkey}       57218      57392           0
+{o_orderpriority}  57218      5               0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{o_orderdate}      166667.00      2.91 <==       2406.00             26.15 <==           0.00            1.00
+{o_orderkey}       166667.00      2.91 <==       166667.00           2.90 <==            0.00            1.00
+{o_orderpriority}  166667.00      2.91 <==       5.00                1.00                0.00            1.00
+
+stats table=q4_select_6
+----
+column_names     row_count  distinct_count  null_count
+{l_commitdate}   3793296    2466            0
+{l_orderkey}     3793296    1405723         0
+{l_receiptdate}  3793296    2525            0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_commitdate}   2000405.00     1.90           2466.00             1.00                0.00            1.00
+{l_orderkey}     2000405.00     1.90           1216823.00          1.16                0.00            1.00
+{l_receiptdate}  2000405.00     1.90           2554.00             1.01                0.00            1.00
+
+stats table=q4_scan_7
+----
+column_names     row_count  distinct_count  null_count
+{l_commitdate}   6001215    2466            0
+{l_orderkey}     6001215    1527270         0
+{l_receiptdate}  6001215    2554            0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_commitdate}   6001215.00     1.00           2466.00             1.00                0.00            1.00
+{l_orderkey}     6001215.00     1.00           1527270.00          1.00                0.00            1.00
+{l_receiptdate}  6001215.00     1.00           2554.00             1.00                0.00            1.00
+
+# --------------------------------------------------
+# Q5
+# Local Supplier Volume
+# Lists the revenue volume done through local suppliers.
+#
+# Lists for each nation in a region the revenue volume that resulted from
+# lineitem transactions in which the customer ordering parts and the supplier
+# filling them were both within that nation. The query is run in order to
+# determine whether to institute local distribution centers in a given region.
+# The query considers only parts ordered in a given year. The query displays the
+# nations and revenue volume in descending order by revenue. Revenue volume for
+# all qualifying lineitems in a particular nation is defined as
+# sum(l_extendedprice * (1 - l_discount)).
+#
+# TODO:
+#   1. Join ordering
+# --------------------------------------------------
+save-tables database=tpch save-tables-prefix=q5
+SELECT
+    n_name,
+    sum(l_extendedprice * (1 - l_discount)) AS revenue
+FROM
+    customer,
+    orders,
+    lineitem,
+    supplier,
+    nation,
+    region
+WHERE
+    c_custkey = o_custkey
+    AND l_orderkey = o_orderkey
+    AND l_suppkey = s_suppkey
+    AND c_nationkey = s_nationkey
+    AND s_nationkey = n_nationkey
+    AND n_regionkey = r_regionkey
+    AND r_name = 'ASIA'
+    AND o_orderDATE >= DATE '1994-01-01'
+    AND o_orderDATE < DATE '1994-01-01' + INTERVAL '1' YEAR
+GROUP BY
+    n_name
+ORDER BY
+    revenue DESC;
+----
+sort
+ ├── save-table-name: q5_sort_1
+ ├── columns: n_name:42(char!null) revenue:49(float)
+ ├── stats: [rows=5, distinct(42)=5, null(42)=0, distinct(49)=5, null(49)=0]
+ ├── key: (42)
+ ├── fd: (42)-->(49)
+ ├── ordering: -49
+ └── group-by
+      ├── save-table-name: q5_group_by_2
+      ├── columns: n_name:42(char!null) sum:49(float)
+      ├── grouping columns: n_name:42(char!null)
+      ├── stats: [rows=5, distinct(42)=5, null(42)=0, distinct(49)=5, null(49)=0]
+      ├── key: (42)
+      ├── fd: (42)-->(49)
+      ├── project
+      │    ├── save-table-name: q5_project_3
+      │    ├── columns: column48:48(float) n_name:42(char!null)
+      │    ├── stats: [rows=9729.11938, distinct(42)=5, null(42)=0, distinct(48)=9513.83496, null(48)=0]
+      │    ├── inner-join
+      │    │    ├── save-table-name: q5_inner_join_4
+      │    │    ├── columns: c_custkey:1(int!null) c_nationkey:4(int!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
+      │    │    ├── stats: [rows=9729.11938, distinct(1)=9729.11938, null(1)=0, distinct(4)=5, null(4)=0, distinct(9)=9450.59912, null(9)=0, distinct(10)=9729.11938, null(10)=0, distinct(13)=2363.81647, null(13)=0, distinct(18)=9450.59912, null(18)=0, distinct(20)=1835.35288, null(20)=0, distinct(23)=9499.54561, null(23)=0, distinct(24)=11, null(24)=0, distinct(34)=1835.35288, null(34)=0, distinct(37)=5, null(37)=0, distinct(41)=5, null(41)=0, distinct(42)=5, null(42)=0, distinct(43)=1, null(43)=0, distinct(45)=1, null(45)=0, distinct(46)=0.996222107, null(46)=0, distinct(23,24)=9513.83496, null(23,24)=0]
+      │    │    ├── fd: ()-->(46), (1)-->(4), (9)-->(10,13), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(4,41), (41)==(4,37), (20)==(34), (34)==(20), (9)==(18), (18)==(9), (1)==(10), (10)==(1), (4)==(37,41)
+      │    │    ├── inner-join
+      │    │    │    ├── save-table-name: q5_inner_join_5
+      │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
+      │    │    │    ├── stats: [rows=241303.24, distinct(9)=166666.667, null(9)=0, distinct(10)=78332.2968, null(10)=0, distinct(13)=2406, null(13)=0, distinct(18)=166666.667, null(18)=0, distinct(20)=1844.80594, null(20)=0, distinct(23)=202898.366, null(23)=0, distinct(24)=11, null(24)=0, distinct(34)=1844.80594, null(34)=0, distinct(37)=5, null(37)=0, distinct(41)=5, null(41)=0, distinct(42)=5, null(42)=0, distinct(43)=1, null(43)=0, distinct(45)=1, null(45)=0, distinct(46)=0.996222107, null(46)=0, distinct(23,24)=216582.447, null(23,24)=0]
+      │    │    │    ├── fd: ()-->(46), (9)-->(10,13), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (20)==(34), (34)==(20), (9)==(18), (18)==(9)
+      │    │    │    ├── inner-join
+      │    │    │    │    ├── save-table-name: q5_inner_join_6
+      │    │    │    │    ├── columns: l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
+      │    │    │    │    ├── stats: [rows=1209922.38, distinct(18)=835685.959, null(18)=0, distinct(20)=1844.80594, null(20)=0, distinct(23)=675298.21, null(23)=0, distinct(24)=11, null(24)=0, distinct(34)=1844.80594, null(34)=0, distinct(37)=5, null(37)=0, distinct(41)=5, null(41)=0, distinct(42)=5, null(42)=0, distinct(43)=1, null(43)=0, distinct(45)=1, null(45)=0, distinct(46)=0.996222107, null(46)=0, distinct(23,24)=1095803.99, null(23,24)=0]
+      │    │    │    │    ├── fd: ()-->(46), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (20)==(34), (34)==(20)
+      │    │    │    │    ├── scan lineitem
+      │    │    │    │    │    ├── save-table-name: q5_scan_7
+      │    │    │    │    │    ├── columns: l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null)
+      │    │    │    │    │    └── stats: [rows=6001215, distinct(18)=1527270, null(18)=0, distinct(20)=9920, null(20)=0, distinct(23)=925955, null(23)=0, distinct(24)=11, null(24)=0, distinct(23,24)=6001215, null(23,24)=0]
+      │    │    │    │    ├── inner-join (lookup supplier@s_nk)
+      │    │    │    │    │    ├── save-table-name: q5_lookup_join_8
+      │    │    │    │    │    ├── columns: s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
+      │    │    │    │    │    ├── key columns: [41] = [37]
+      │    │    │    │    │    ├── stats: [rows=2000, distinct(34)=1844.80594, null(34)=0, distinct(37)=5, null(37)=0, distinct(41)=5, null(41)=0, distinct(42)=5, null(42)=0, distinct(43)=1, null(43)=0, distinct(45)=1, null(45)=0, distinct(46)=0.996222107, null(46)=0]
+      │    │    │    │    │    ├── key: (34)
+      │    │    │    │    │    ├── fd: ()-->(46), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(41), (41)==(37)
+      │    │    │    │    │    ├── inner-join
+      │    │    │    │    │    │    ├── save-table-name: q5_inner_join_9
+      │    │    │    │    │    │    ├── columns: n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
+      │    │    │    │    │    │    ├── stats: [rows=5, distinct(41)=5, null(41)=0, distinct(42)=5, null(42)=0, distinct(43)=1, null(43)=0, distinct(45)=1, null(45)=0, distinct(46)=0.996222107, null(46)=0]
+      │    │    │    │    │    │    ├── key: (41)
+      │    │    │    │    │    │    ├── fd: ()-->(46), (41)-->(42,43), (43)==(45), (45)==(43)
+      │    │    │    │    │    │    ├── scan nation
+      │    │    │    │    │    │    │    ├── save-table-name: q5_scan_10
+      │    │    │    │    │    │    │    ├── columns: n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null)
+      │    │    │    │    │    │    │    ├── stats: [rows=25, distinct(41)=25, null(41)=0, distinct(42)=25, null(42)=0, distinct(43)=5, null(43)=0]
+      │    │    │    │    │    │    │    ├── key: (41)
+      │    │    │    │    │    │    │    └── fd: (41)-->(42,43)
+      │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    ├── save-table-name: q5_select_11
+      │    │    │    │    │    │    │    ├── columns: r_regionkey:45(int!null) r_name:46(char!null)
+      │    │    │    │    │    │    │    ├── stats: [rows=1, distinct(45)=1, null(45)=0, distinct(46)=1, null(46)=0]
+      │    │    │    │    │    │    │    ├── key: (45)
+      │    │    │    │    │    │    │    ├── fd: ()-->(46)
+      │    │    │    │    │    │    │    ├── scan region
+      │    │    │    │    │    │    │    │    ├── save-table-name: q5_scan_12
+      │    │    │    │    │    │    │    │    ├── columns: r_regionkey:45(int!null) r_name:46(char!null)
+      │    │    │    │    │    │    │    │    ├── stats: [rows=5, distinct(45)=5, null(45)=0, distinct(46)=5, null(46)=0]
+      │    │    │    │    │    │    │    │    ├── key: (45)
+      │    │    │    │    │    │    │    │    └── fd: (45)-->(46)
+      │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │         └── r_name = 'ASIA' [type=bool, outer=(46), constraints=(/46: [/'ASIA' - /'ASIA']; tight), fd=()-->(46)]
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         └── n_regionkey = r_regionkey [type=bool, outer=(43,45), constraints=(/43: (/NULL - ]; /45: (/NULL - ]), fd=(43)==(45), (45)==(43)]
+      │    │    │    │    │    └── filters (true)
+      │    │    │    │    └── filters
+      │    │    │    │         └── l_suppkey = s_suppkey [type=bool, outer=(20,34), constraints=(/20: (/NULL - ]; /34: (/NULL - ]), fd=(20)==(34), (34)==(20)]
+      │    │    │    ├── index-join orders
+      │    │    │    │    ├── save-table-name: q5_index_join_13
+      │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null)
+      │    │    │    │    ├── stats: [rows=166666.667, distinct(9)=166666.667, null(9)=0, distinct(10)=82829.9251, null(10)=0, distinct(13)=2406, null(13)=0]
+      │    │    │    │    ├── key: (9)
+      │    │    │    │    ├── fd: (9)-->(10,13)
+      │    │    │    │    └── scan orders@o_od
+      │    │    │    │         ├── save-table-name: q5_scan_14
+      │    │    │    │         ├── columns: o_orderkey:9(int!null) o_orderdate:13(date!null)
+      │    │    │    │         ├── constraint: /13/9: [/'1994-01-01' - /'1994-12-31']
+      │    │    │    │         ├── stats: [rows=166666.667, distinct(9)=166666.667, null(9)=0, distinct(13)=2406, null(13)=0]
+      │    │    │    │         ├── key: (9)
+      │    │    │    │         └── fd: (9)-->(13)
+      │    │    │    └── filters
+      │    │    │         └── l_orderkey = o_orderkey [type=bool, outer=(9,18), constraints=(/9: (/NULL - ]; /18: (/NULL - ]), fd=(9)==(18), (18)==(9)]
+      │    │    ├── scan customer@c_nk
+      │    │    │    ├── save-table-name: q5_scan_15
+      │    │    │    ├── columns: c_custkey:1(int!null) c_nationkey:4(int!null)
+      │    │    │    ├── stats: [rows=150000, distinct(1)=148813, null(1)=0, distinct(4)=25, null(4)=0]
+      │    │    │    ├── key: (1)
+      │    │    │    └── fd: (1)-->(4)
+      │    │    └── filters
+      │    │         ├── c_custkey = o_custkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+      │    │         └── c_nationkey = s_nationkey [type=bool, outer=(4,37), constraints=(/4: (/NULL - ]; /37: (/NULL - ]), fd=(4)==(37), (37)==(4)]
+      │    └── projections
+      │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(23,24)]
+      └── aggregations
+           └── sum [type=float, outer=(48)]
+                └── variable: column48 [type=float]
+
+stats table=q5_sort_1
+----
+column_names  row_count  distinct_count  null_count
+{n_name}      5          5               0
+{revenue}     5          5               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}      5.00           1.00           5.00                1.00                0.00            1.00
+{revenue}     5.00           1.00           5.00                1.00                0.00            1.00
+
+stats table=q5_group_by_2
+----
+column_names  row_count  distinct_count  null_count
+{n_name}      5          5               0
+{sum}         5          5               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}      5.00           1.00           5.00                1.00                0.00            1.00
+{sum}         5.00           1.00           5.00                1.00                0.00            1.00
+
+stats table=q5_project_3
+----
+column_names  row_count  distinct_count  null_count
+{column48}    7243       7245            0
+{n_name}      7243       5               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{column48}    9729.00        1.34           9514.00             1.31                0.00            1.00
+{n_name}      9729.00        1.34           5.00                1.00                0.00            1.00
+
+stats table=q5_inner_join_4
+----
+column_names       row_count  distinct_count  null_count
+{c_custkey}        7243       5557            0
+{c_nationkey}      7243       5               0
+{l_discount}       7243       11              0
+{l_extendedprice}  7243       7208            0
+{l_orderkey}       7243       6640            0
+{l_suppkey}        7243       1944            0
+{n_name}           7243       5               0
+{n_nationkey}      7243       5               0
+{n_regionkey}      7243       1               0
+{o_custkey}        7243       5557            0
+{o_orderdate}      7243       365             0
+{o_orderkey}       7243       6640            0
+{r_name}           7243       1               0
+{r_regionkey}      7243       1               0
+{s_nationkey}      7243       5               0
+{s_suppkey}        7243       1944            0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_custkey}        9729.00        1.34           9729.00             1.75                0.00            1.00
+{c_nationkey}      9729.00        1.34           5.00                1.00                0.00            1.00
+{l_discount}       9729.00        1.34           11.00               1.00                0.00            1.00
+{l_extendedprice}  9729.00        1.34           9500.00             1.32                0.00            1.00
+{l_orderkey}       9729.00        1.34           9451.00             1.42                0.00            1.00
+{l_suppkey}        9729.00        1.34           1835.00             1.06                0.00            1.00
+{n_name}           9729.00        1.34           5.00                1.00                0.00            1.00
+{n_nationkey}      9729.00        1.34           5.00                1.00                0.00            1.00
+{n_regionkey}      9729.00        1.34           1.00                1.00                0.00            1.00
+{o_custkey}        9729.00        1.34           9729.00             1.75                0.00            1.00
+{o_orderdate}      9729.00        1.34           2364.00             6.48 <==            0.00            1.00
+{o_orderkey}       9729.00        1.34           9451.00             1.42                0.00            1.00
+{r_name}           9729.00        1.34           1.00                1.00                0.00            1.00
+{r_regionkey}      9729.00        1.34           1.00                1.00                0.00            1.00
+{s_nationkey}      9729.00        1.34           5.00                1.00                0.00            1.00
+{s_suppkey}        9729.00        1.34           1835.00             1.06                0.00            1.00
+
+stats table=q5_inner_join_5
+----
+column_names       row_count  distinct_count  null_count
+{l_discount}       182183     11              0
+{l_extendedprice}  182183     164481          0
+{l_orderkey}       182183     123823          0
+{l_suppkey}        182183     2002            0
+{n_name}           182183     5               0
+{n_nationkey}      182183     5               0
+{n_regionkey}      182183     1               0
+{o_custkey}        182183     68395           0
+{o_orderdate}      182183     365             0
+{o_orderkey}       182183     123823          0
+{r_name}           182183     1               0
+{r_regionkey}      182183     1               0
+{s_nationkey}      182183     5               0
+{s_suppkey}        182183     2002            0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_discount}       241303.00      1.32           11.00               1.00                0.00            1.00
+{l_extendedprice}  241303.00      1.32           202898.00           1.23                0.00            1.00
+{l_orderkey}       241303.00      1.32           166667.00           1.35                0.00            1.00
+{l_suppkey}        241303.00      1.32           1845.00             1.09                0.00            1.00
+{n_name}           241303.00      1.32           5.00                1.00                0.00            1.00
+{n_nationkey}      241303.00      1.32           5.00                1.00                0.00            1.00
+{n_regionkey}      241303.00      1.32           1.00                1.00                0.00            1.00
+{o_custkey}        241303.00      1.32           78332.00            1.15                0.00            1.00
+{o_orderdate}      241303.00      1.32           2406.00             6.59 <==            0.00            1.00
+{o_orderkey}       241303.00      1.32           166667.00           1.35                0.00            1.00
+{r_name}           241303.00      1.32           1.00                1.00                0.00            1.00
+{r_regionkey}      241303.00      1.32           1.00                1.00                0.00            1.00
+{s_nationkey}      241303.00      1.32           5.00                1.00                0.00            1.00
+{s_suppkey}        241303.00      1.32           1845.00             1.09                0.00            1.00
+
+stats table=q5_inner_join_6
+----
+column_names       row_count  distinct_count  null_count
+{l_discount}       1201113    11              0
+{l_extendedprice}  1201113    634132          0
+{l_orderkey}       1201113    825141          0
+{l_suppkey}        1201113    2002            0
+{n_name}           1201113    5               0
+{n_nationkey}      1201113    5               0
+{n_regionkey}      1201113    1               0
+{r_name}           1201113    1               0
+{r_regionkey}      1201113    1               0
+{s_nationkey}      1201113    5               0
+{s_suppkey}        1201113    2002            0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_discount}       1209922.00     1.01           11.00               1.00                0.00            1.00
+{l_extendedprice}  1209922.00     1.01           675298.00           1.06                0.00            1.00
+{l_orderkey}       1209922.00     1.01           835686.00           1.01                0.00            1.00
+{l_suppkey}        1209922.00     1.01           1845.00             1.09                0.00            1.00
+{n_name}           1209922.00     1.01           5.00                1.00                0.00            1.00
+{n_nationkey}      1209922.00     1.01           5.00                1.00                0.00            1.00
+{n_regionkey}      1209922.00     1.01           1.00                1.00                0.00            1.00
+{r_name}           1209922.00     1.01           1.00                1.00                0.00            1.00
+{r_regionkey}      1209922.00     1.01           1.00                1.00                0.00            1.00
+{s_nationkey}      1209922.00     1.01           5.00                1.00                0.00            1.00
+{s_suppkey}        1209922.00     1.01           1845.00             1.09                0.00            1.00
+
+stats table=q5_scan_7
+----
+column_names       row_count  distinct_count  null_count
+{l_discount}       6001215    11              0
+{l_extendedprice}  6001215    925955          0
+{l_orderkey}       6001215    1527270         0
+{l_suppkey}        6001215    9920            0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_discount}       6001215.00     1.00           11.00               1.00                0.00            1.00
+{l_extendedprice}  6001215.00     1.00           925955.00           1.00                0.00            1.00
+{l_orderkey}       6001215.00     1.00           1527270.00          1.00                0.00            1.00
+{l_suppkey}        6001215.00     1.00           9920.00             1.00                0.00            1.00
+
+stats table=q5_lookup_join_8
+----
+column_names   row_count  distinct_count  null_count
+{n_name}       2003       5               0
+{n_nationkey}  2003       5               0
+{n_regionkey}  2003       1               0
+{r_name}       2003       1               0
+{r_regionkey}  2003       1               0
+{s_nationkey}  2003       5               0
+{s_suppkey}    2003       2002            0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}       2000.00        1.00           5.00                1.00                0.00            1.00
+{n_nationkey}  2000.00        1.00           5.00                1.00                0.00            1.00
+{n_regionkey}  2000.00        1.00           1.00                1.00                0.00            1.00
+{r_name}       2000.00        1.00           1.00                1.00                0.00            1.00
+{r_regionkey}  2000.00        1.00           1.00                1.00                0.00            1.00
+{s_nationkey}  2000.00        1.00           5.00                1.00                0.00            1.00
+{s_suppkey}    2000.00        1.00           1845.00             1.09                0.00            1.00
+
+stats table=q5_inner_join_9
+----
+column_names   row_count  distinct_count  null_count
+{n_name}       5          5               0
+{n_nationkey}  5          5               0
+{n_regionkey}  5          1               0
+{r_name}       5          1               0
+{r_regionkey}  5          1               0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}       5.00           1.00           5.00                1.00                0.00            1.00
+{n_nationkey}  5.00           1.00           5.00                1.00                0.00            1.00
+{n_regionkey}  5.00           1.00           1.00                1.00                0.00            1.00
+{r_name}       5.00           1.00           1.00                1.00                0.00            1.00
+{r_regionkey}  5.00           1.00           1.00                1.00                0.00            1.00
+
+stats table=q5_scan_10
+----
+column_names   row_count  distinct_count  null_count
+{n_name}       25         25              0
+{n_nationkey}  25         25              0
+{n_regionkey}  25         5               0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}       25.00          1.00           25.00               1.00                0.00            1.00
+{n_nationkey}  25.00          1.00           25.00               1.00                0.00            1.00
+{n_regionkey}  25.00          1.00           5.00                1.00                0.00            1.00
+
+stats table=q5_select_11
+----
+column_names   row_count  distinct_count  null_count
+{r_name}       1          1               0
+{r_regionkey}  1          1               0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{r_name}       1.00           1.00           1.00                1.00                0.00            1.00
+{r_regionkey}  1.00           1.00           1.00                1.00                0.00            1.00
+
+stats table=q5_scan_12
+----
+column_names   row_count  distinct_count  null_count
+{r_name}       5          5               0
+{r_regionkey}  5          5               0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{r_name}       5.00           1.00           5.00                1.00                0.00            1.00
+{r_regionkey}  5.00           1.00           5.00                1.00                0.00            1.00
+
+stats table=q5_index_join_13
+----
+column_names   row_count  distinct_count  null_count
+{o_custkey}    227597     86427           0
+{o_orderdate}  227597     365             0
+{o_orderkey}   227597     229152          0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{o_custkey}    166667.00      1.37           82830.00            1.04                0.00            1.00
+{o_orderdate}  166667.00      1.37           2406.00             6.59 <==            0.00            1.00
+{o_orderkey}   166667.00      1.37           166667.00           1.37                0.00            1.00
+
+stats table=q5_scan_15
+----
+column_names   row_count  distinct_count  null_count
+{c_custkey}    150000     148813          0
+{c_nationkey}  150000     25              0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_custkey}    150000.00      1.00           148813.00           1.00                0.00            1.00
+{c_nationkey}  150000.00      1.00           25.00               1.00                0.00            1.00
+
+# --------------------------------------------------
+# Q6
+# Forecasting Revenue Change
+# Quantifies the amount of revenue increase that would have resulted from
+# eliminating certain companywide discounts in a given percentage range in a
+# given year. Asking this type of "what if" query can be used to look for ways
+# to increase revenues.
+#
+# Considers all the lineitems shipped in a given year with discounts between
+# DISCOUNT-0.01 and DISCOUNT+0.01. The query lists the amount by which the total
+# revenue would have increased if these discounts had been eliminated for
+# lineitems with l_quantity less than quantity. Note that the potential revenue
+# increase is equal to the sum of [l_extendedprice * l_discount] for all
+# lineitems with discounts and quantities in the qualifying range.
+# --------------------------------------------------
+save-tables database=tpch save-tables-prefix=q6
+SELECT
+    sum(l_extendedprice * l_discount) AS revenue
+FROM
+    lineitem
+WHERE
+    l_shipdate >= DATE '1994-01-01'
+    AND l_shipdate < DATE '1994-01-01' + INTERVAL '1' YEAR
+    AND l_discount BETWEEN 0.06 - 0.01 AND 0.06 + 0.01
+    AND l_quantity < 24;
+----
+scalar-group-by
+ ├── save-table-name: q6_scalar_group_by_1
+ ├── columns: revenue:18(float)
+ ├── cardinality: [1 - 1]
+ ├── stats: [rows=1, distinct(18)=1, null(18)=0]
+ ├── key: ()
+ ├── fd: ()-->(18)
+ ├── project
+ │    ├── save-table-name: q6_project_2
+ │    ├── columns: column17:17(float)
+ │    ├── stats: [rows=24696.358, distinct(17)=24696.358, null(17)=0]
+ │    ├── select
+ │    │    ├── save-table-name: q6_select_3
+ │    │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
+ │    │    ├── stats: [rows=24696.358, distinct(5)=50, null(5)=0, distinct(6)=24419.5384, null(6)=0, distinct(7)=11, null(7)=0, distinct(11)=2525.85951, null(11)=0, distinct(6,7)=24696.358, null(6,7)=0]
+ │    │    ├── index-join lineitem
+ │    │    │    ├── save-table-name: q6_index_join_4
+ │    │    │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
+ │    │    │    ├── stats: [rows=666801.667, distinct(5)=50, null(5)=0, distinct(6)=494371.509, null(6)=0, distinct(7)=11, null(7)=0, distinct(11)=2526, null(11)=0, distinct(6,7)=666801.667, null(6,7)=0]
+ │    │    │    └── scan lineitem@l_sd
+ │    │    │         ├── save-table-name: q6_scan_5
+ │    │    │         ├── columns: l_orderkey:1(int!null) l_linenumber:4(int!null) l_shipdate:11(date!null)
+ │    │    │         ├── constraint: /11/1/4: [/'1994-01-01' - /'1994-12-31']
+ │    │    │         ├── stats: [rows=666801.667, distinct(1)=565838.316, null(1)=0, distinct(4)=7, null(4)=0, distinct(11)=2526, null(11)=0]
+ │    │    │         ├── key: (1,4)
+ │    │    │         └── fd: (1,4)-->(11)
+ │    │    └── filters
+ │    │         ├── (l_discount >= 0.05) AND (l_discount <= 0.07) [type=bool, outer=(7), constraints=(/7: [/0.05 - /0.07]; tight)]
+ │    │         └── l_quantity < 24.0 [type=bool, outer=(5), constraints=(/5: (/NULL - /23.999999999999996]; tight)]
+ │    └── projections
+ │         └── l_extendedprice * l_discount [type=float, outer=(6,7)]
+ └── aggregations
+      └── sum [type=float, outer=(17)]
+           └── variable: column17 [type=float]
+
+stats table=q6_scalar_group_by_1
+----
+column_names  row_count  distinct_count  null_count
+{revenue}     1          1               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{revenue}     1.00           1.00           1.00                1.00                0.00            1.00
+
+stats table=q6_project_2
+----
+column_names  row_count  distinct_count  null_count
+{column17}    114160     108866          0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{column17}    24696.00       4.62 <==       24696.00            4.41 <==            0.00            1.00
+
+stats table=q6_select_3
+----
+column_names       row_count  distinct_count  null_count
+{l_discount}       114160     3               0
+{l_extendedprice}  114160     98751           0
+{l_quantity}       114160     23              0
+{l_shipdate}       114160     365             0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_discount}       24696.00       4.62 <==       11.00               3.67 <==            0.00            1.00
+{l_extendedprice}  24696.00       4.62 <==       24420.00            4.04 <==            0.00            1.00
+{l_quantity}       24696.00       4.62 <==       50.00               2.17 <==            0.00            1.00
+{l_shipdate}       24696.00       4.62 <==       2526.00             6.92 <==            0.00            1.00
+
+stats table=q6_index_join_4
+----
+column_names       row_count  distinct_count  null_count
+{l_discount}       909455     11              0
+{l_extendedprice}  909455     565291          0
+{l_quantity}       909455     50              0
+{l_shipdate}       909455     365             0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_discount}       666802.00      1.36           11.00               1.00                0.00            1.00
+{l_extendedprice}  666802.00      1.36           494372.00           1.14                0.00            1.00
+{l_quantity}       666802.00      1.36           50.00               1.00                0.00            1.00
+{l_shipdate}       666802.00      1.36           2526.00             6.92 <==            0.00            1.00
+
+# --------------------------------------------------
+# Q7
+# Volume Shipping
+# Determines the value of goods shipped between certain nations to help in the
+# re-negotiation of shipping contracts.
+#
+# Finds, for two given nations, the gross discounted revenues derived from
+# lineitems in which parts were shipped from a supplier in either nation to a
+# customer in the other nation during 1995 and 1996. The query lists the
+# supplier nation, the customer nation, the year, and the revenue from shipments
+# that took place in that year. The query orders the answer by Supplier nation,
+# Customer nation, and year (all ascending).
+#
+# TODO:
+#   1. Join ordering
+# --------------------------------------------------
+save-tables database=tpch save-tables-prefix=q7
+SELECT
+    supp_nation,
+    cust_nation,
+    l_year, sum(volume) AS revenue
+FROM (
+    SELECT
+        n1.n_name AS supp_nation,
+        n2.n_name AS cust_nation,
+        extract(year FROM l_shipdate) AS l_year,
+        l_extendedprice * (1 - l_discount) AS volume
+    FROM
+        supplier,
+        lineitem,
+        orders,
+        customer,
+        nation n1,
+        nation n2
+    WHERE
+        s_suppkey = l_suppkey
+        AND o_orderkey = l_orderkey
+        AND c_custkey = o_custkey
+        AND s_nationkey = n1.n_nationkey
+        AND c_nationkey = n2.n_nationkey
+        AND (
+            (n1.n_name = 'FRANCE' AND n2.n_name = 'GERMANY')
+            or (n1.n_name = 'GERMANY' AND n2.n_name = 'FRANCE')
+        )
+        AND l_shipdate BETWEEN DATE '1995-01-01' AND DATE '1996-12-31'
+    ) AS shipping
+GROUP BY
+    supp_nation,
+    cust_nation,
+    l_year
+ORDER BY
+    supp_nation,
+    cust_nation,
+    l_year;
+----
+sort
+ ├── save-table-name: q7_sort_1
+ ├── columns: supp_nation:42(char!null) cust_nation:46(char!null) l_year:49(int) revenue:51(float)
+ ├── stats: [rows=183694.011, distinct(42)=24.9990099, null(42)=0, distinct(46)=24.9990099, null(46)=0, distinct(49)=2526, null(49)=0, distinct(51)=183694.011, null(51)=0, distinct(42,46,49)=183694.011, null(42,46,49)=0]
+ ├── key: (42,46,49)
+ ├── fd: (42,46,49)-->(51)
+ ├── ordering: +42,+46,+49
+ └── group-by
+      ├── save-table-name: q7_group_by_2
+      ├── columns: n1.n_name:42(char!null) n2.n_name:46(char!null) l_year:49(int) sum:51(float)
+      ├── grouping columns: n1.n_name:42(char!null) n2.n_name:46(char!null) l_year:49(int)
+      ├── stats: [rows=183694.011, distinct(42)=24.9990099, null(42)=0, distinct(46)=24.9990099, null(46)=0, distinct(49)=2526, null(49)=0, distinct(51)=183694.011, null(51)=0, distinct(42,46,49)=183694.011, null(42,46,49)=0]
+      ├── key: (42,46,49)
+      ├── fd: (42,46,49)-->(51)
+      ├── project
+      │    ├── save-table-name: q7_project_3
+      │    ├── columns: l_year:49(int) volume:50(float) n1.n_name:42(char!null) n2.n_name:46(char!null)
+      │    ├── stats: [rows=225940.387, distinct(42)=24.9990099, null(42)=0, distinct(46)=24.9990099, null(46)=0, distinct(49)=2526, null(49)=0, distinct(50)=191635.552, null(50)=0, distinct(42,46,49)=183694.011, null(42,46,49)=0]
+      │    ├── inner-join
+      │    │    ├── save-table-name: q7_inner_join_4
+      │    │    ├── columns: s_suppkey:1(int!null) s_nationkey:4(int!null) l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null) o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
+      │    │    ├── stats: [rows=225940.387, distinct(1)=9920, null(1)=0, distinct(4)=24.9990099, null(4)=0, distinct(8)=186281.027, null(8)=0, distinct(10)=9920, null(10)=0, distinct(13)=181353.002, null(13)=0, distinct(14)=11, null(14)=0, distinct(18)=2526, null(18)=0, distinct(24)=186281.027, null(24)=0, distinct(25)=89457.1229, null(25)=0, distinct(33)=89457.1229, null(33)=0, distinct(36)=24.9990099, null(36)=0, distinct(41)=24.9990099, null(41)=0, distinct(42)=24.9990099, null(42)=0, distinct(45)=24.9990099, null(45)=0, distinct(46)=24.9990099, null(46)=0, distinct(13,14)=191635.552, null(13,14)=0, distinct(18,42,46)=183694.011, null(18,42,46)=0]
+      │    │    ├── fd: (1)-->(4), (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25), (8)==(24), (24)==(8), (1)==(10), (10)==(1), (4)==(41), (41)==(4)
+      │    │    ├── inner-join
+      │    │    │    ├── save-table-name: q7_inner_join_5
+      │    │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null) o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
+      │    │    │    ├── stats: [rows=5603321.59, distinct(8)=565838.316, null(8)=0, distinct(10)=9920, null(10)=0, distinct(13)=494365.598, null(13)=0, distinct(14)=11, null(14)=0, distinct(18)=2526, null(18)=0, distinct(24)=565838.316, null(24)=0, distinct(25)=99846, null(25)=0, distinct(33)=99846, null(33)=0, distinct(36)=24.9990099, null(36)=0, distinct(41)=24.9990099, null(41)=0, distinct(42)=24.9990099, null(42)=0, distinct(45)=24.9990099, null(45)=0, distinct(46)=24.9990099, null(46)=0, distinct(13,14)=666652.216, null(13,14)=0, distinct(18,42,46)=526250, null(18,42,46)=0]
+      │    │    │    ├── fd: (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25), (8)==(24), (24)==(8)
+      │    │    │    ├── inner-join
+      │    │    │    │    ├── save-table-name: q7_inner_join_6
+      │    │    │    │    ├── columns: o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
+      │    │    │    │    ├── stats: [rows=12602090.7, distinct(24)=1499663.18, null(24)=0, distinct(25)=99846, null(25)=0, distinct(33)=99846, null(33)=0, distinct(36)=24.9990099, null(36)=0, distinct(41)=24.9990099, null(41)=0, distinct(42)=24.9990099, null(42)=0, distinct(45)=24.9990099, null(45)=0, distinct(46)=24.9990099, null(46)=0, distinct(42,46)=208.333333, null(42,46)=0]
+      │    │    │    │    ├── key: (24,41)
+      │    │    │    │    ├── fd: (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25)
+      │    │    │    │    ├── scan orders@o_ck
+      │    │    │    │    │    ├── save-table-name: q7_scan_7
+      │    │    │    │    │    ├── columns: o_orderkey:24(int!null) o_custkey:25(int!null)
+      │    │    │    │    │    ├── stats: [rows=1500000, distinct(24)=1500000, null(24)=0, distinct(25)=99846, null(25)=0]
+      │    │    │    │    │    ├── key: (24)
+      │    │    │    │    │    └── fd: (24)-->(25)
+      │    │    │    │    ├── inner-join (merge)
+      │    │    │    │    │    ├── save-table-name: q7_merge_join_8
+      │    │    │    │    │    ├── columns: c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
+      │    │    │    │    │    ├── left ordering: +36
+      │    │    │    │    │    ├── right ordering: +45
+      │    │    │    │    │    ├── stats: [rows=1250000, distinct(33)=148784.836, null(33)=0, distinct(36)=24.9990099, null(36)=0, distinct(41)=24.9990099, null(41)=0, distinct(42)=24.9990099, null(42)=0, distinct(45)=24.9990099, null(45)=0, distinct(46)=24.9990099, null(46)=0, distinct(42,46)=208.333333, null(42,46)=0]
+      │    │    │    │    │    ├── key: (33,41)
+      │    │    │    │    │    ├── fd: (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36)
+      │    │    │    │    │    ├── scan customer@c_nk
+      │    │    │    │    │    │    ├── save-table-name: q7_scan_9
+      │    │    │    │    │    │    ├── columns: c_custkey:33(int!null) c_nationkey:36(int!null)
+      │    │    │    │    │    │    ├── stats: [rows=150000, distinct(33)=148813, null(33)=0, distinct(36)=25, null(36)=0]
+      │    │    │    │    │    │    ├── key: (33)
+      │    │    │    │    │    │    ├── fd: (33)-->(36)
+      │    │    │    │    │    │    └── ordering: +36
+      │    │    │    │    │    ├── sort
+      │    │    │    │    │    │    ├── save-table-name: q7_sort_10
+      │    │    │    │    │    │    ├── columns: n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
+      │    │    │    │    │    │    ├── stats: [rows=208.333333, distinct(41)=24.9990099, null(41)=0, distinct(42)=24.9990099, null(42)=0, distinct(45)=24.9990099, null(45)=0, distinct(46)=24.9990099, null(46)=0, distinct(42,46)=208.333333, null(42,46)=0]
+      │    │    │    │    │    │    ├── key: (41,45)
+      │    │    │    │    │    │    ├── fd: (41)-->(42), (45)-->(46)
+      │    │    │    │    │    │    ├── ordering: +45
+      │    │    │    │    │    │    └── inner-join
+      │    │    │    │    │    │         ├── save-table-name: q7_inner_join_11
+      │    │    │    │    │    │         ├── columns: n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
+      │    │    │    │    │    │         ├── stats: [rows=208.333333, distinct(41)=24.9990099, null(41)=0, distinct(42)=24.9990099, null(42)=0, distinct(45)=24.9990099, null(45)=0, distinct(46)=24.9990099, null(46)=0, distinct(42,46)=208.333333, null(42,46)=0]
+      │    │    │    │    │    │         ├── key: (41,45)
+      │    │    │    │    │    │         ├── fd: (41)-->(42), (45)-->(46)
+      │    │    │    │    │    │         ├── scan n1
+      │    │    │    │    │    │         │    ├── save-table-name: q7_scan_12
+      │    │    │    │    │    │         │    ├── columns: n1.n_nationkey:41(int!null) n1.n_name:42(char!null)
+      │    │    │    │    │    │         │    ├── stats: [rows=25, distinct(41)=25, null(41)=0, distinct(42)=25, null(42)=0]
+      │    │    │    │    │    │         │    ├── key: (41)
+      │    │    │    │    │    │         │    └── fd: (41)-->(42)
+      │    │    │    │    │    │         ├── scan n2
+      │    │    │    │    │    │         │    ├── save-table-name: q7_scan_13
+      │    │    │    │    │    │         │    ├── columns: n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
+      │    │    │    │    │    │         │    ├── stats: [rows=25, distinct(45)=25, null(45)=0, distinct(46)=25, null(46)=0]
+      │    │    │    │    │    │         │    ├── key: (45)
+      │    │    │    │    │    │         │    └── fd: (45)-->(46)
+      │    │    │    │    │    │         └── filters
+      │    │    │    │    │    │              └── ((n1.n_name = 'FRANCE') AND (n2.n_name = 'GERMANY')) OR ((n1.n_name = 'GERMANY') AND (n2.n_name = 'FRANCE')) [type=bool, outer=(42,46)]
+      │    │    │    │    │    └── filters (true)
+      │    │    │    │    └── filters
+      │    │    │    │         └── c_custkey = o_custkey [type=bool, outer=(25,33), constraints=(/25: (/NULL - ]; /33: (/NULL - ]), fd=(25)==(33), (33)==(25)]
+      │    │    │    ├── index-join lineitem
+      │    │    │    │    ├── save-table-name: q7_index_join_14
+      │    │    │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null)
+      │    │    │    │    ├── stats: [rows=666801.667, distinct(8)=565838.316, null(8)=0, distinct(10)=9920, null(10)=0, distinct(13)=494371.509, null(13)=0, distinct(14)=11, null(14)=0, distinct(18)=2526, null(18)=0, distinct(13,14)=666801.667, null(13,14)=0]
+      │    │    │    │    └── scan lineitem@l_sd
+      │    │    │    │         ├── save-table-name: q7_scan_15
+      │    │    │    │         ├── columns: l_orderkey:8(int!null) l_linenumber:11(int!null) l_shipdate:18(date!null)
+      │    │    │    │         ├── constraint: /18/8/11: [/'1995-01-01' - /'1996-12-31']
+      │    │    │    │         ├── stats: [rows=666801.667, distinct(8)=565838.316, null(8)=0, distinct(11)=7, null(11)=0, distinct(18)=2526, null(18)=0]
+      │    │    │    │         ├── key: (8,11)
+      │    │    │    │         └── fd: (8,11)-->(18)
+      │    │    │    └── filters
+      │    │    │         └── o_orderkey = l_orderkey [type=bool, outer=(8,24), constraints=(/8: (/NULL - ]; /24: (/NULL - ]), fd=(8)==(24), (24)==(8)]
+      │    │    ├── scan supplier@s_nk
+      │    │    │    ├── save-table-name: q7_scan_16
+      │    │    │    ├── columns: s_suppkey:1(int!null) s_nationkey:4(int!null)
+      │    │    │    ├── stats: [rows=10000, distinct(1)=9920, null(1)=0, distinct(4)=25, null(4)=0]
+      │    │    │    ├── key: (1)
+      │    │    │    └── fd: (1)-->(4)
+      │    │    └── filters
+      │    │         ├── s_suppkey = l_suppkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+      │    │         └── s_nationkey = n1.n_nationkey [type=bool, outer=(4,41), constraints=(/4: (/NULL - ]; /41: (/NULL - ]), fd=(4)==(41), (41)==(4)]
+      │    └── projections
+      │         ├── extract('year', l_shipdate) [type=int, outer=(18)]
+      │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(13,14)]
+      └── aggregations
+           └── sum [type=float, outer=(50)]
+                └── variable: volume [type=float]
+
+stats table=q7_sort_1
+----
+column_names   row_count  distinct_count  null_count
+{cust_nation}  4          2               0
+{l_year}       4          2               0
+{revenue}      4          4               0
+{supp_nation}  4          2               0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{cust_nation}  183694.00      45923.50 <==   25.00               12.50 <==           0.00            1.00
+{l_year}       183694.00      45923.50 <==   2526.00             1263.00 <==         0.00            1.00
+{revenue}      183694.00      45923.50 <==   183694.00           45923.50 <==        0.00            1.00
+{supp_nation}  183694.00      45923.50 <==   25.00               12.50 <==           0.00            1.00
+
+stats table=q7_group_by_2
+----
+column_names  row_count  distinct_count  null_count
+{l_year}      4          2               0
+{n_name_1}    4          2               0
+{n_name}      4          2               0
+{sum}         4          4               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_year}      183694.00      45923.50 <==   2526.00             1263.00 <==         0.00            1.00
+{n_name}      183694.00      45923.50 <==   25.00               12.50 <==           0.00            1.00
+{n_name_1}    183694.00      45923.50 <==   25.00               12.50 <==           0.00            1.00
+{sum}         183694.00      45923.50 <==   183694.00           45923.50 <==        0.00            1.00
+
+stats table=q7_project_3
+----
+column_names  row_count  distinct_count  null_count
+{l_year}      5924       2               0
+{n_name_1}    5924       2               0
+{n_name}      5924       2               0
+{volume}      5924       5904            0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_year}      225940.00      38.14 <==      2526.00             1263.00 <==         0.00            1.00
+{n_name}      225940.00      38.14 <==      25.00               12.50 <==           0.00            1.00
+{n_name_1}    225940.00      38.14 <==      25.00               12.50 <==           0.00            1.00
+{volume}      225940.00      38.14 <==      191636.00           32.46 <==           0.00            1.00
+
+stats table=q7_inner_join_4
+----
+column_names       row_count  distinct_count  null_count
+{c_custkey}        5924       3902            0
+{c_nationkey}      5924       2               0
+{l_discount}       5924       11              0
+{l_extendedprice}  5924       5876            0
+{l_orderkey}       5924       5445            0
+{l_shipdate}       5924       731             0
+{l_suppkey}        5924       796             0
+{n_name_1}         5924       2               0
+{n_name}           5924       2               0
+{n_nationkey_1}    5924       2               0
+{n_nationkey}      5924       2               0
+{o_custkey}        5924       3902            0
+{o_orderkey}       5924       5445            0
+{s_nationkey}      5924       2               0
+{s_suppkey}        5924       796             0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_custkey}        225940.00      38.14 <==      89457.00            22.93 <==           0.00            1.00
+{c_nationkey}      225940.00      38.14 <==      25.00               12.50 <==           0.00            1.00
+{l_discount}       225940.00      38.14 <==      11.00               1.00                0.00            1.00
+{l_extendedprice}  225940.00      38.14 <==      181353.00           30.86 <==           0.00            1.00
+{l_orderkey}       225940.00      38.14 <==      186281.00           34.21 <==           0.00            1.00
+{l_shipdate}       225940.00      38.14 <==      2526.00             3.46 <==            0.00            1.00
+{l_suppkey}        225940.00      38.14 <==      9920.00             12.46 <==           0.00            1.00
+{n_name}           225940.00      38.14 <==      25.00               12.50 <==           0.00            1.00
+{n_name_1}         225940.00      38.14 <==      25.00               12.50 <==           0.00            1.00
+{n_nationkey}      225940.00      38.14 <==      25.00               12.50 <==           0.00            1.00
+{n_nationkey_1}    225940.00      38.14 <==      25.00               12.50 <==           0.00            1.00
+{o_custkey}        225940.00      38.14 <==      89457.00            22.93 <==           0.00            1.00
+{o_orderkey}       225940.00      38.14 <==      186281.00           34.21 <==           0.00            1.00
+{s_nationkey}      225940.00      38.14 <==      25.00               12.50 <==           0.00            1.00
+{s_suppkey}        225940.00      38.14 <==      9920.00             12.46 <==           0.00            1.00
+
+stats table=q7_inner_join_5
+----
+column_names       row_count  distinct_count  null_count
+{c_custkey}        148370     7980            0
+{c_nationkey}      148370     2               0
+{l_discount}       148370     11              0
+{l_extendedprice}  148370     135829          0
+{l_orderkey}       148370     39757           0
+{l_shipdate}       148370     731             0
+{l_suppkey}        148370     9920            0
+{n_name_1}         148370     2               0
+{n_name}           148370     2               0
+{n_nationkey_1}    148370     2               0
+{n_nationkey}      148370     2               0
+{o_custkey}        148370     7980            0
+{o_orderkey}       148370     39757           0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_custkey}        5603322.00     37.77 <==      99846.00            12.51 <==           0.00            1.00
+{c_nationkey}      5603322.00     37.77 <==      25.00               12.50 <==           0.00            1.00
+{l_discount}       5603322.00     37.77 <==      11.00               1.00                0.00            1.00
+{l_extendedprice}  5603322.00     37.77 <==      494366.00           3.64 <==            0.00            1.00
+{l_orderkey}       5603322.00     37.77 <==      565838.00           14.23 <==           0.00            1.00
+{l_shipdate}       5603322.00     37.77 <==      2526.00             3.46 <==            0.00            1.00
+{l_suppkey}        5603322.00     37.77 <==      9920.00             1.00                0.00            1.00
+{n_name}           5603322.00     37.77 <==      25.00               12.50 <==           0.00            1.00
+{n_name_1}         5603322.00     37.77 <==      25.00               12.50 <==           0.00            1.00
+{n_nationkey}      5603322.00     37.77 <==      25.00               12.50 <==           0.00            1.00
+{n_nationkey_1}    5603322.00     37.77 <==      25.00               12.50 <==           0.00            1.00
+{o_custkey}        5603322.00     37.77 <==      99846.00            12.51 <==           0.00            1.00
+{o_orderkey}       5603322.00     37.77 <==      565838.00           14.23 <==           0.00            1.00
+
+stats table=q7_inner_join_6
+----
+column_names     row_count  distinct_count  null_count
+{c_custkey}      121324     8132            0
+{c_nationkey}    121324     2               0
+{n_name_1}       121324     2               0
+{n_name}         121324     2               0
+{n_nationkey_1}  121324     2               0
+{n_nationkey}    121324     2               0
+{o_custkey}      121324     8132            0
+{o_orderkey}     121324     120984          0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_custkey}      12602091.00    103.87 <==     99846.00            12.28 <==           0.00            1.00
+{c_nationkey}    12602091.00    103.87 <==     25.00               12.50 <==           0.00            1.00
+{n_name}         12602091.00    103.87 <==     25.00               12.50 <==           0.00            1.00
+{n_name_1}       12602091.00    103.87 <==     25.00               12.50 <==           0.00            1.00
+{n_nationkey}    12602091.00    103.87 <==     25.00               12.50 <==           0.00            1.00
+{n_nationkey_1}  12602091.00    103.87 <==     25.00               12.50 <==           0.00            1.00
+{o_custkey}      12602091.00    103.87 <==     99846.00            12.28 <==           0.00            1.00
+{o_orderkey}     12602091.00    103.87 <==     1499663.00          12.40 <==           0.00            1.00
+
+stats table=q7_scan_7
+----
+column_names  row_count  distinct_count  null_count
+{o_custkey}   1500000    99846           0
+{o_orderkey}  1500000    1527270         0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{o_custkey}   1500000.00     1.00           99846.00            1.00                0.00            1.00
+{o_orderkey}  1500000.00     1.00           1500000.00          1.02                0.00            1.00
+
+stats table=q7_merge_join_8
+----
+column_names     row_count  distinct_count  null_count
+{c_custkey}      12008      12045           0
+{c_nationkey}    12008      2               0
+{n_name_1}       12008      2               0
+{n_name}         12008      2               0
+{n_nationkey_1}  12008      2               0
+{n_nationkey}    12008      2               0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_custkey}      1250000.00     104.10 <==     148785.00           12.35 <==           0.00            1.00
+{c_nationkey}    1250000.00     104.10 <==     25.00               12.50 <==           0.00            1.00
+{n_name}         1250000.00     104.10 <==     25.00               12.50 <==           0.00            1.00
+{n_name_1}       1250000.00     104.10 <==     25.00               12.50 <==           0.00            1.00
+{n_nationkey}    1250000.00     104.10 <==     25.00               12.50 <==           0.00            1.00
+{n_nationkey_1}  1250000.00     104.10 <==     25.00               12.50 <==           0.00            1.00
+
+stats table=q7_scan_9
+----
+column_names   row_count  distinct_count  null_count
+{c_custkey}    150000     148813          0
+{c_nationkey}  150000     25              0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_custkey}    150000.00      1.00           148813.00           1.00                0.00            1.00
+{c_nationkey}  150000.00      1.00           25.00               1.00                0.00            1.00
+
+stats table=q7_sort_10
+----
+column_names     row_count  distinct_count  null_count
+{n_name_1}       2          2               0
+{n_name}         2          2               0
+{n_nationkey_1}  2          2               0
+{n_nationkey}    2          2               0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}         208.00         104.00 <==     25.00               12.50 <==           0.00            1.00
+{n_name_1}       208.00         104.00 <==     25.00               12.50 <==           0.00            1.00
+{n_nationkey}    208.00         104.00 <==     25.00               12.50 <==           0.00            1.00
+{n_nationkey_1}  208.00         104.00 <==     25.00               12.50 <==           0.00            1.00
+
+stats table=q7_inner_join_11
+----
+column_names     row_count  distinct_count  null_count
+{n_name_1}       2          2               0
+{n_name}         2          2               0
+{n_nationkey_1}  2          2               0
+{n_nationkey}    2          2               0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}         208.00         104.00 <==     25.00               12.50 <==           0.00            1.00
+{n_name_1}       208.00         104.00 <==     25.00               12.50 <==           0.00            1.00
+{n_nationkey}    208.00         104.00 <==     25.00               12.50 <==           0.00            1.00
+{n_nationkey_1}  208.00         104.00 <==     25.00               12.50 <==           0.00            1.00
+
+stats table=q7_scan_12
+----
+column_names   row_count  distinct_count  null_count
+{n_name}       25         25              0
+{n_nationkey}  25         25              0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}       25.00          1.00           25.00               1.00                0.00            1.00
+{n_nationkey}  25.00          1.00           25.00               1.00                0.00            1.00
+
+stats table=q7_scan_13
+----
+column_names   row_count  distinct_count  null_count
+{n_name}       25         25              0
+{n_nationkey}  25         25              0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}       25.00          1.00           25.00               1.00                0.00            1.00
+{n_nationkey}  25.00          1.00           25.00               1.00                0.00            1.00
+
+stats table=q7_index_join_14
+----
+column_names       row_count  distinct_count  null_count
+{l_discount}       1828450    11              0
+{l_extendedprice}  1828450    780956          0
+{l_orderkey}       1828450    502162          0
+{l_shipdate}       1828450    731             0
+{l_suppkey}        1828450    9920            0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_discount}       666802.00      2.74 <==       11.00               1.00                0.00            1.00
+{l_extendedprice}  666802.00      2.74 <==       494372.00           1.58                0.00            1.00
+{l_orderkey}       666802.00      2.74 <==       565838.00           1.13                0.00            1.00
+{l_shipdate}       666802.00      2.74 <==       2526.00             3.46 <==            0.00            1.00
+{l_suppkey}        666802.00      2.74 <==       9920.00             1.00                0.00            1.00
+
+stats table=q7_scan_16
+----
+column_names   row_count  distinct_count  null_count
+{s_nationkey}  10000      25              0
+{s_suppkey}    10000      9920            0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{s_nationkey}  10000.00       1.00           25.00               1.00                0.00            1.00
+{s_suppkey}    10000.00       1.00           9920.00             1.00                0.00            1.00
+
+# --------------------------------------------------
+# Q8
+# National Market Share
+# Determines how the market share of a given nation within a given region has
+# changed over two years for a given part type.
+#
+# The market share for a given nation within a given region is defined as the
+# fraction of the revenue, the sum of [l_extendedprice * (1-l_discount)], from
+# the products of a specified type in that region that was supplied by suppliers
+# from the given nation. The query determines this for the years 1995 and 1996
+# presented in this order.
+#
+# TODO:
+#   1. Join ordering
+#   2. Push down equivalent column comparisons
+# --------------------------------------------------
+save-tables database=tpch save-tables-prefix=q8
+SELECT
+    o_year,
+    sum(CASE
+        WHEN nation = 'BRAZIL'
+            THEN volume
+        ELSE 0
+    END) / sum(volume) AS mkt_share
+FROM (
+    SELECT
+        extract(year FROM o_orderdate) AS o_year,
+        l_extendedprice * (1 - l_discount) AS volume,
+        n2.n_name AS nation
+    FROM
+        part,
+        supplier,
+        lineitem,
+        orders,
+        customer,
+        nation n1,
+        nation n2,
+        region
+    WHERE
+        p_partkey = l_partkey
+        AND s_suppkey = l_suppkey
+        AND l_orderkey = o_orderkey
+        AND o_custkey = c_custkey
+        AND c_nationkey = n1.n_nationkey
+        AND n1.n_regionkey = r_regionkey
+        AND r_name = 'AMERICA'
+        AND s_nationkey = n2.n_nationkey
+        AND o_orderdate BETWEEN DATE '1995-01-01' AND DATE '1996-12-31'
+        AND p_type = 'ECONOMY ANODIZED STEEL'
+    ) AS all_nations
+GROUP BY
+    o_year
+ORDER BY
+    o_year;
+----
+sort
+ ├── save-table-name: q8_sort_1
+ ├── columns: o_year:61(int) mkt_share:66(float)
+ ├── side-effects
+ ├── stats: [rows=1281.96374, distinct(61)=1281.96374, null(61)=0, distinct(66)=1281.96374, null(66)=0]
+ ├── key: (61)
+ ├── fd: (61)-->(66)
+ ├── ordering: +61
+ └── project
+      ├── save-table-name: q8_project_2
+      ├── columns: mkt_share:66(float) o_year:61(int)
+      ├── side-effects
+      ├── stats: [rows=1281.96374, distinct(61)=1281.96374, null(61)=0, distinct(66)=1281.96374, null(66)=0]
+      ├── key: (61)
+      ├── fd: (61)-->(66)
+      ├── group-by
+      │    ├── save-table-name: q8_group_by_3
+      │    ├── columns: o_year:61(int) sum:64(float) sum:65(float)
+      │    ├── grouping columns: o_year:61(int)
+      │    ├── stats: [rows=1281.96374, distinct(61)=1281.96374, null(61)=0, distinct(64)=1281.96374, null(64)=0, distinct(65)=1281.96374, null(65)=0, distinct(64,65)=1281.96374, null(64,65)=0]
+      │    ├── key: (61)
+      │    ├── fd: (61)-->(64,65)
+      │    ├── project
+      │    │    ├── save-table-name: q8_project_4
+      │    │    ├── columns: column63:63(float) o_year:61(int) volume:62(float)
+      │    │    ├── stats: [rows=1831.05189, distinct(61)=1281.96374, null(61)=0, distinct(62)=1818.26713, null(62)=0, distinct(63)=1818.34383, null(63)=0]
+      │    │    ├── project
+      │    │    │    ├── save-table-name: q8_project_5
+      │    │    │    ├── columns: o_year:61(int) volume:62(float) n2.n_name:55(char!null)
+      │    │    │    ├── stats: [rows=1831.05189, distinct(55)=24.9055527, null(55)=0, distinct(61)=1281.96374, null(61)=0, distinct(62)=1818.26713, null(62)=0, distinct(55,62)=1818.34383, null(55,62)=0]
+      │    │    │    ├── inner-join
+      │    │    │    │    ├── save-table-name: q8_inner_join_6
+      │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(varchar!null) s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
+      │    │    │    │    ├── stats: [rows=1831.05189, distinct(1)=1333.31636, null(1)=0, distinct(5)=1, null(5)=0, distinct(10)=1672.00508, null(10)=0, distinct(13)=24.9055527, null(13)=0, distinct(17)=1812.92406, null(17)=0, distinct(18)=1333.31636, null(18)=0, distinct(19)=1672.00508, null(19)=0, distinct(22)=1817.65055, null(22)=0, distinct(23)=11, null(23)=0, distinct(33)=1812.92406, null(33)=0, distinct(34)=1806.03581, null(34)=0, distinct(37)=1281.96374, null(37)=0, distinct(42)=1806.03581, null(42)=0, distinct(45)=24.9055527, null(45)=0, distinct(50)=24.9055527, null(50)=0, distinct(52)=1, null(52)=0, distinct(54)=24.9055527, null(54)=0, distinct(55)=24.9055527, null(55)=0, distinct(58)=1, null(58)=0, distinct(59)=1, null(59)=0, distinct(22,23)=1818.26713, null(22,23)=0, distinct(22,23,55)=1818.34383, null(22,23,55)=0]
+      │    │    │    │    ├── fd: ()-->(5,59), (10)-->(13), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (10)==(19), (19)==(10), (13)==(54), (54)==(13), (1)==(18), (18)==(1)
+      │    │    │    │    ├── inner-join
+      │    │    │    │    │    ├── save-table-name: q8_inner_join_7
+      │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
+      │    │    │    │    │    ├── stats: [rows=133870.058, distinct(10)=9920, null(10)=0, distinct(13)=24.9055527, null(13)=0, distinct(17)=91816.9257, null(17)=0, distinct(18)=97481.3502, null(18)=0, distinct(19)=9920, null(19)=0, distinct(22)=124392.739, null(22)=0, distinct(23)=11, null(23)=0, distinct(33)=91816.9257, null(33)=0, distinct(34)=66375.7026, null(34)=0, distinct(37)=2406, null(37)=0, distinct(42)=66375.7026, null(42)=0, distinct(45)=24.9055527, null(45)=0, distinct(50)=24.9055527, null(50)=0, distinct(52)=1, null(52)=0, distinct(54)=24.9055527, null(54)=0, distinct(55)=24.9055527, null(55)=0, distinct(58)=1, null(58)=0, distinct(59)=1, null(59)=0, distinct(22,23)=130416.966, null(22,23)=0, distinct(22,23,55)=131207.238, null(22,23,55)=0]
+      │    │    │    │    │    ├── fd: ()-->(59), (10)-->(13), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (10)==(19), (19)==(10), (13)==(54), (54)==(13)
+      │    │    │    │    │    ├── inner-join
+      │    │    │    │    │    │    ├── save-table-name: q8_inner_join_8
+      │    │    │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
+      │    │    │    │    │    │    ├── stats: [rows=3319977.44, distinct(17)=165619.065, null(17)=0, distinct(18)=199240.988, null(18)=0, distinct(19)=9920, null(19)=0, distinct(22)=900284.014, null(22)=0, distinct(23)=11, null(23)=0, distinct(33)=165619.065, null(33)=0, distinct(34)=82829.9251, null(34)=0, distinct(37)=2406, null(37)=0, distinct(42)=82829.9251, null(42)=0, distinct(45)=24.9055527, null(45)=0, distinct(50)=24.9055527, null(50)=0, distinct(52)=1, null(52)=0, distinct(54)=24.9055527, null(54)=0, distinct(55)=24.9055527, null(55)=0, distinct(58)=1, null(58)=0, distinct(59)=1, null(59)=0, distinct(22,23)=2549938.3, null(22,23)=0, distinct(22,23,55)=3319977.44, null(22,23,55)=0]
+      │    │    │    │    │    │    ├── fd: ()-->(59), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17)
+      │    │    │    │    │    │    ├── scan lineitem
+      │    │    │    │    │    │    │    ├── save-table-name: q8_scan_9
+      │    │    │    │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null)
+      │    │    │    │    │    │    │    └── stats: [rows=6001215, distinct(17)=1527270, null(17)=0, distinct(18)=199241, null(18)=0, distinct(19)=9920, null(19)=0, distinct(22)=925955, null(22)=0, distinct(23)=11, null(23)=0, distinct(22,23)=6001215, null(22,23)=0]
+      │    │    │    │    │    │    ├── inner-join
+      │    │    │    │    │    │    │    ├── save-table-name: q8_inner_join_10
+      │    │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
+      │    │    │    │    │    │    │    ├── stats: [rows=844912.563, distinct(33)=165619.065, null(33)=0, distinct(34)=82829.9251, null(34)=0, distinct(37)=2406, null(37)=0, distinct(42)=82829.9251, null(42)=0, distinct(45)=24.9055527, null(45)=0, distinct(50)=24.9055527, null(50)=0, distinct(52)=1, null(52)=0, distinct(54)=24.9055527, null(54)=0, distinct(55)=24.9055527, null(55)=0, distinct(58)=1, null(58)=0, distinct(59)=1, null(59)=0]
+      │    │    │    │    │    │    │    ├── key: (33,54)
+      │    │    │    │    │    │    │    ├── fd: ()-->(59), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34)
+      │    │    │    │    │    │    │    ├── inner-join
+      │    │    │    │    │    │    │    │    ├── save-table-name: q8_inner_join_11
+      │    │    │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
+      │    │    │    │    │    │    │    │    ├── stats: [rows=750000, distinct(42)=147944.303, null(42)=0, distinct(45)=24.9055527, null(45)=0, distinct(50)=24.9055527, null(50)=0, distinct(52)=1, null(52)=0, distinct(54)=24.9055527, null(54)=0, distinct(55)=24.9055527, null(55)=0, distinct(58)=1, null(58)=0, distinct(59)=1, null(59)=0]
+      │    │    │    │    │    │    │    │    ├── key: (42,54)
+      │    │    │    │    │    │    │    │    ├── fd: ()-->(59), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45)
+      │    │    │    │    │    │    │    │    ├── inner-join (lookup customer@c_nk)
+      │    │    │    │    │    │    │    │    │    ├── save-table-name: q8_lookup_join_12
+      │    │    │    │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) r_regionkey:58(int!null) r_name:59(char!null)
+      │    │    │    │    │    │    │    │    │    ├── key columns: [50] = [45]
+      │    │    │    │    │    │    │    │    │    ├── stats: [rows=30000, distinct(42)=27672.3293, null(42)=0, distinct(45)=5, null(45)=0, distinct(50)=5, null(50)=0, distinct(52)=1, null(52)=0, distinct(58)=1, null(58)=0, distinct(59)=0.996222107, null(59)=0]
+      │    │    │    │    │    │    │    │    │    ├── key: (42)
+      │    │    │    │    │    │    │    │    │    ├── fd: ()-->(59), (50)-->(52), (52)==(58), (58)==(52), (42)-->(45), (45)==(50), (50)==(45)
+      │    │    │    │    │    │    │    │    │    ├── inner-join (lookup nation@n_rk)
+      │    │    │    │    │    │    │    │    │    │    ├── save-table-name: q8_lookup_join_13
+      │    │    │    │    │    │    │    │    │    │    ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) r_regionkey:58(int!null) r_name:59(char!null)
+      │    │    │    │    │    │    │    │    │    │    ├── key columns: [58] = [52]
+      │    │    │    │    │    │    │    │    │    │    ├── stats: [rows=5, distinct(50)=5, null(50)=0, distinct(52)=1, null(52)=0, distinct(58)=1, null(58)=0, distinct(59)=0.996222107, null(59)=0]
+      │    │    │    │    │    │    │    │    │    │    ├── key: (50)
+      │    │    │    │    │    │    │    │    │    │    ├── fd: ()-->(59), (50)-->(52), (52)==(58), (58)==(52)
+      │    │    │    │    │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    │    │    │    │    ├── save-table-name: q8_select_14
+      │    │    │    │    │    │    │    │    │    │    │    ├── columns: r_regionkey:58(int!null) r_name:59(char!null)
+      │    │    │    │    │    │    │    │    │    │    │    ├── stats: [rows=1, distinct(58)=1, null(58)=0, distinct(59)=1, null(59)=0]
+      │    │    │    │    │    │    │    │    │    │    │    ├── key: (58)
+      │    │    │    │    │    │    │    │    │    │    │    ├── fd: ()-->(59)
+      │    │    │    │    │    │    │    │    │    │    │    ├── scan region
+      │    │    │    │    │    │    │    │    │    │    │    │    ├── save-table-name: q8_scan_15
+      │    │    │    │    │    │    │    │    │    │    │    │    ├── columns: r_regionkey:58(int!null) r_name:59(char!null)
+      │    │    │    │    │    │    │    │    │    │    │    │    ├── stats: [rows=5, distinct(58)=5, null(58)=0, distinct(59)=5, null(59)=0]
+      │    │    │    │    │    │    │    │    │    │    │    │    ├── key: (58)
+      │    │    │    │    │    │    │    │    │    │    │    │    └── fd: (58)-->(59)
+      │    │    │    │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │    │    │    │    │         └── r_name = 'AMERICA' [type=bool, outer=(59), constraints=(/59: [/'AMERICA' - /'AMERICA']; tight), fd=()-->(59)]
+      │    │    │    │    │    │    │    │    │    │    └── filters (true)
+      │    │    │    │    │    │    │    │    │    └── filters (true)
+      │    │    │    │    │    │    │    │    ├── scan n2
+      │    │    │    │    │    │    │    │    │    ├── save-table-name: q8_scan_16
+      │    │    │    │    │    │    │    │    │    ├── columns: n2.n_nationkey:54(int!null) n2.n_name:55(char!null)
+      │    │    │    │    │    │    │    │    │    ├── stats: [rows=25, distinct(54)=25, null(54)=0, distinct(55)=25, null(55)=0]
+      │    │    │    │    │    │    │    │    │    ├── key: (54)
+      │    │    │    │    │    │    │    │    │    └── fd: (54)-->(55)
+      │    │    │    │    │    │    │    │    └── filters (true)
+      │    │    │    │    │    │    │    ├── index-join orders
+      │    │    │    │    │    │    │    │    ├── save-table-name: q8_index_join_17
+      │    │    │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null)
+      │    │    │    │    │    │    │    │    ├── stats: [rows=166666.667, distinct(33)=166666.667, null(33)=0, distinct(34)=82829.9251, null(34)=0, distinct(37)=2406, null(37)=0]
+      │    │    │    │    │    │    │    │    ├── key: (33)
+      │    │    │    │    │    │    │    │    ├── fd: (33)-->(34,37)
+      │    │    │    │    │    │    │    │    └── scan orders@o_od
+      │    │    │    │    │    │    │    │         ├── save-table-name: q8_scan_18
+      │    │    │    │    │    │    │    │         ├── columns: o_orderkey:33(int!null) o_orderdate:37(date!null)
+      │    │    │    │    │    │    │    │         ├── constraint: /37/33: [/'1995-01-01' - /'1996-12-31']
+      │    │    │    │    │    │    │    │         ├── stats: [rows=166666.667, distinct(33)=166666.667, null(33)=0, distinct(37)=2406, null(37)=0]
+      │    │    │    │    │    │    │    │         ├── key: (33)
+      │    │    │    │    │    │    │    │         └── fd: (33)-->(37)
+      │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │         └── o_custkey = c_custkey [type=bool, outer=(34,42), constraints=(/34: (/NULL - ]; /42: (/NULL - ]), fd=(34)==(42), (42)==(34)]
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         └── l_orderkey = o_orderkey [type=bool, outer=(17,33), constraints=(/17: (/NULL - ]; /33: (/NULL - ]), fd=(17)==(33), (33)==(17)]
+      │    │    │    │    │    ├── scan supplier@s_nk
+      │    │    │    │    │    │    ├── save-table-name: q8_scan_19
+      │    │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null)
+      │    │    │    │    │    │    ├── stats: [rows=10000, distinct(10)=9920, null(10)=0, distinct(13)=25, null(13)=0]
+      │    │    │    │    │    │    ├── key: (10)
+      │    │    │    │    │    │    └── fd: (10)-->(13)
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         ├── s_suppkey = l_suppkey [type=bool, outer=(10,19), constraints=(/10: (/NULL - ]; /19: (/NULL - ]), fd=(10)==(19), (19)==(10)]
+      │    │    │    │    │         └── s_nationkey = n2.n_nationkey [type=bool, outer=(13,54), constraints=(/13: (/NULL - ]; /54: (/NULL - ]), fd=(13)==(54), (54)==(13)]
+      │    │    │    │    ├── select
+      │    │    │    │    │    ├── save-table-name: q8_select_20
+      │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(varchar!null)
+      │    │    │    │    │    ├── stats: [rows=1333.33333, distinct(1)=1333.31636, null(1)=0, distinct(5)=1, null(5)=0]
+      │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    ├── fd: ()-->(5)
+      │    │    │    │    │    ├── scan part
+      │    │    │    │    │    │    ├── save-table-name: q8_scan_21
+      │    │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(varchar!null)
+      │    │    │    │    │    │    ├── stats: [rows=200000, distinct(1)=199241, null(1)=0, distinct(5)=150, null(5)=0]
+      │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    └── fd: (1)-->(5)
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         └── p_type = 'ECONOMY ANODIZED STEEL' [type=bool, outer=(5), constraints=(/5: [/'ECONOMY ANODIZED STEEL' - /'ECONOMY ANODIZED STEEL']; tight), fd=()-->(5)]
+      │    │    │    │    └── filters
+      │    │    │    │         └── p_partkey = l_partkey [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+      │    │    │    └── projections
+      │    │    │         ├── extract('year', o_orderdate) [type=int, outer=(37)]
+      │    │    │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(22,23)]
+      │    │    └── projections
+      │    │         └── CASE WHEN n2.n_name = 'BRAZIL' THEN volume ELSE 0.0 END [type=float, outer=(55,62)]
+      │    └── aggregations
+      │         ├── sum [type=float, outer=(63)]
+      │         │    └── variable: column63 [type=float]
+      │         └── sum [type=float, outer=(62)]
+      │              └── variable: volume [type=float]
+      └── projections
+           └── sum / sum [type=float, outer=(64,65), side-effects]
+
+stats table=q8_sort_1
+----
+column_names  row_count  distinct_count  null_count
+{mkt_share}   2          2               0
+{o_year}      2          2               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{mkt_share}   1282.00        641.00 <==     1282.00             641.00 <==          0.00            1.00
+{o_year}      1282.00        641.00 <==     1282.00             641.00 <==          0.00            1.00
+
+stats table=q8_project_2
+----
+column_names  row_count  distinct_count  null_count
+{mkt_share}   2          2               0
+{o_year}      2          2               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{mkt_share}   1282.00        641.00 <==     1282.00             641.00 <==          0.00            1.00
+{o_year}      1282.00        641.00 <==     1282.00             641.00 <==          0.00            1.00
+
+stats table=q8_group_by_3
+----
+column_names  row_count  distinct_count  null_count
+{o_year}      2          2               0
+{sum_1}       2          2               0
+{sum}         2          2               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{o_year}      1282.00        641.00 <==     1282.00             641.00 <==          0.00            1.00
+{sum}         1282.00        641.00 <==     1282.00             641.00 <==          0.00            1.00
+{sum_1}       1282.00        641.00 <==     1282.00             641.00 <==          0.00            1.00
+
+stats table=q8_project_4
+----
+column_names  row_count  distinct_count  null_count
+{column63}    2603       108             0
+{o_year}      2603       2               0
+{volume}      2603       2599            0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{column63}    1831.00        1.42           1818.00             16.83 <==           0.00            1.00
+{o_year}      1831.00        1.42           1282.00             641.00 <==          0.00            1.00
+{volume}      1831.00        1.42           1818.00             1.43                0.00            1.00
+
+stats table=q8_project_5
+----
+column_names  row_count  distinct_count  null_count
+{n_name}      2603       25              0
+{o_year}      2603       2               0
+{volume}      2603       2599            0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}      1831.00        1.42           25.00               1.00                0.00            1.00
+{o_year}      1831.00        1.42           1282.00             641.00 <==          0.00            1.00
+{volume}      1831.00        1.42           1818.00             1.43                0.00            1.00
+
+stats table=q8_inner_join_6
+----
+column_names       row_count  distinct_count  null_count
+{c_custkey}        2603       2385            0
+{c_nationkey}      2603       5               0
+{l_discount}       2603       11              0
+{l_extendedprice}  2603       2540            0
+{l_orderkey}       2603       2567            0
+{l_partkey}        2603       1221            0
+{l_suppkey}        2603       1895            0
+{n_name}           2603       25              0
+{n_nationkey_1}    2603       25              0
+{n_nationkey}      2603       5               0
+{n_regionkey}      2603       1               0
+{o_custkey}        2603       2385            0
+{o_orderdate}      2603       708             0
+{o_orderkey}       2603       2567            0
+{p_partkey}        2603       1221            0
+{p_type}           2603       1               0
+{r_name}           2603       1               0
+{r_regionkey}      2603       1               0
+{s_nationkey}      2603       25              0
+{s_suppkey}        2603       1895            0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_custkey}        1831.00        1.42           1806.00             1.32                0.00            1.00
+{c_nationkey}      1831.00        1.42           25.00               5.00 <==            0.00            1.00
+{l_discount}       1831.00        1.42           11.00               1.00                0.00            1.00
+{l_extendedprice}  1831.00        1.42           1818.00             1.40                0.00            1.00
+{l_orderkey}       1831.00        1.42           1813.00             1.42                0.00            1.00
+{l_partkey}        1831.00        1.42           1333.00             1.09                0.00            1.00
+{l_suppkey}        1831.00        1.42           1672.00             1.13                0.00            1.00
+{n_name}           1831.00        1.42           25.00               1.00                0.00            1.00
+{n_nationkey}      1831.00        1.42           25.00               5.00 <==            0.00            1.00
+{n_nationkey_1}    1831.00        1.42           25.00               1.00                0.00            1.00
+{n_regionkey}      1831.00        1.42           1.00                1.00                0.00            1.00
+{o_custkey}        1831.00        1.42           1806.00             1.32                0.00            1.00
+{o_orderdate}      1831.00        1.42           1282.00             1.81                0.00            1.00
+{o_orderkey}       1831.00        1.42           1813.00             1.42                0.00            1.00
+{p_partkey}        1831.00        1.42           1333.00             1.09                0.00            1.00
+{p_type}           1831.00        1.42           1.00                1.00                0.00            1.00
+{r_name}           1831.00        1.42           1.00                1.00                0.00            1.00
+{r_regionkey}      1831.00        1.42           1.00                1.00                0.00            1.00
+{s_nationkey}      1831.00        1.42           25.00               1.00                0.00            1.00
+{s_suppkey}        1831.00        1.42           1672.00             1.13                0.00            1.00
+
+stats table=q8_inner_join_7
+----
+column_names       row_count  distinct_count  null_count
+{c_custkey}        365091     19542           0
+{c_nationkey}      365091     5               0
+{l_discount}       365091     11              0
+{l_extendedprice}  365091     299348          0
+{l_orderkey}       365091     92088           0
+{l_partkey}        365091     167385          0
+{l_suppkey}        365091     9920            0
+{n_name}           365091     25              0
+{n_nationkey_1}    365091     25              0
+{n_nationkey}      365091     5               0
+{n_regionkey}      365091     1               0
+{o_custkey}        365091     19542           0
+{o_orderdate}      365091     731             0
+{o_orderkey}       365091     92088           0
+{r_name}           365091     1               0
+{r_regionkey}      365091     1               0
+{s_nationkey}      365091     25              0
+{s_suppkey}        365091     9920            0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_custkey}        133870.00      2.73 <==       66376.00            3.40 <==            0.00            1.00
+{c_nationkey}      133870.00      2.73 <==       25.00               5.00 <==            0.00            1.00
+{l_discount}       133870.00      2.73 <==       11.00               1.00                0.00            1.00
+{l_extendedprice}  133870.00      2.73 <==       124393.00           2.41 <==            0.00            1.00
+{l_orderkey}       133870.00      2.73 <==       91817.00            1.00                0.00            1.00
+{l_partkey}        133870.00      2.73 <==       97481.00            1.72                0.00            1.00
+{l_suppkey}        133870.00      2.73 <==       9920.00             1.00                0.00            1.00
+{n_name}           133870.00      2.73 <==       25.00               1.00                0.00            1.00
+{n_nationkey}      133870.00      2.73 <==       25.00               5.00 <==            0.00            1.00
+{n_nationkey_1}    133870.00      2.73 <==       25.00               1.00                0.00            1.00
+{n_regionkey}      133870.00      2.73 <==       1.00                1.00                0.00            1.00
+{o_custkey}        133870.00      2.73 <==       66376.00            3.40 <==            0.00            1.00
+{o_orderdate}      133870.00      2.73 <==       2406.00             3.29 <==            0.00            1.00
+{o_orderkey}       133870.00      2.73 <==       91817.00            1.00                0.00            1.00
+{r_name}           133870.00      2.73 <==       1.00                1.00                0.00            1.00
+{r_regionkey}      133870.00      2.73 <==       1.00                1.00                0.00            1.00
+{s_nationkey}      133870.00      2.73 <==       25.00               1.00                0.00            1.00
+{s_suppkey}        133870.00      2.73 <==       9920.00             1.00                0.00            1.00
+
+stats table=q8_inner_join_8
+----
+column_names       row_count  distinct_count  null_count
+{c_custkey}        9127275    19542           0
+{c_nationkey}      9127275    5               0
+{l_discount}       9127275    11              0
+{l_extendedprice}  9127275    299348          0
+{l_orderkey}       9127275    92088           0
+{l_partkey}        9127275    167385          0
+{l_suppkey}        9127275    9920            0
+{n_name}           9127275    25              0
+{n_nationkey_1}    9127275    25              0
+{n_nationkey}      9127275    5               0
+{n_regionkey}      9127275    1               0
+{o_custkey}        9127275    19542           0
+{o_orderdate}      9127275    731             0
+{o_orderkey}       9127275    92088           0
+{r_name}           9127275    1               0
+{r_regionkey}      9127275    1               0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_custkey}        3319977.00     2.75 <==       82830.00            4.24 <==            0.00            1.00
+{c_nationkey}      3319977.00     2.75 <==       25.00               5.00 <==            0.00            1.00
+{l_discount}       3319977.00     2.75 <==       11.00               1.00                0.00            1.00
+{l_extendedprice}  3319977.00     2.75 <==       900284.00           3.01 <==            0.00            1.00
+{l_orderkey}       3319977.00     2.75 <==       165619.00           1.80                0.00            1.00
+{l_partkey}        3319977.00     2.75 <==       199241.00           1.19                0.00            1.00
+{l_suppkey}        3319977.00     2.75 <==       9920.00             1.00                0.00            1.00
+{n_name}           3319977.00     2.75 <==       25.00               1.00                0.00            1.00
+{n_nationkey}      3319977.00     2.75 <==       25.00               5.00 <==            0.00            1.00
+{n_nationkey_1}    3319977.00     2.75 <==       25.00               1.00                0.00            1.00
+{n_regionkey}      3319977.00     2.75 <==       1.00                1.00                0.00            1.00
+{o_custkey}        3319977.00     2.75 <==       82830.00            4.24 <==            0.00            1.00
+{o_orderdate}      3319977.00     2.75 <==       2406.00             3.29 <==            0.00            1.00
+{o_orderkey}       3319977.00     2.75 <==       165619.00           1.80                0.00            1.00
+{r_name}           3319977.00     2.75 <==       1.00                1.00                0.00            1.00
+{r_regionkey}      3319977.00     2.75 <==       1.00                1.00                0.00            1.00
+
+stats table=q8_scan_9
+----
+column_names       row_count  distinct_count  null_count
+{l_discount}       6001215    11              0
+{l_extendedprice}  6001215    925955          0
+{l_orderkey}       6001215    1527270         0
+{l_partkey}        6001215    199241          0
+{l_suppkey}        6001215    9920            0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_discount}       6001215.00     1.00           11.00               1.00                0.00            1.00
+{l_extendedprice}  6001215.00     1.00           925955.00           1.00                0.00            1.00
+{l_orderkey}       6001215.00     1.00           1527270.00          1.00                0.00            1.00
+{l_partkey}        6001215.00     1.00           199241.00           1.00                0.00            1.00
+{l_suppkey}        6001215.00     1.00           9920.00             1.00                0.00            1.00
+
+stats table=q8_inner_join_10
+----
+column_names     row_count  distinct_count  null_count
+{c_custkey}      2279475    19542           0
+{c_nationkey}    2279475    5               0
+{n_name}         2279475    25              0
+{n_nationkey_1}  2279475    25              0
+{n_nationkey}    2279475    5               0
+{n_regionkey}    2279475    1               0
+{o_custkey}      2279475    19542           0
+{o_orderdate}    2279475    731             0
+{o_orderkey}     2279475    92088           0
+{r_name}         2279475    1               0
+{r_regionkey}    2279475    1               0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_custkey}      844913.00      2.70 <==       82830.00            4.24 <==            0.00            1.00
+{c_nationkey}    844913.00      2.70 <==       25.00               5.00 <==            0.00            1.00
+{n_name}         844913.00      2.70 <==       25.00               1.00                0.00            1.00
+{n_nationkey}    844913.00      2.70 <==       25.00               5.00 <==            0.00            1.00
+{n_nationkey_1}  844913.00      2.70 <==       25.00               1.00                0.00            1.00
+{n_regionkey}    844913.00      2.70 <==       1.00                1.00                0.00            1.00
+{o_custkey}      844913.00      2.70 <==       82830.00            4.24 <==            0.00            1.00
+{o_orderdate}    844913.00      2.70 <==       2406.00             3.29 <==            0.00            1.00
+{o_orderkey}     844913.00      2.70 <==       165619.00           1.80                0.00            1.00
+{r_name}         844913.00      2.70 <==       1.00                1.00                0.00            1.00
+{r_regionkey}    844913.00      2.70 <==       1.00                1.00                0.00            1.00
+
+stats table=q8_inner_join_11
+----
+column_names     row_count  distinct_count  null_count
+{c_custkey}      748800     30253           0
+{c_nationkey}    748800     5               0
+{n_name}         748800     25              0
+{n_nationkey_1}  748800     25              0
+{n_nationkey}    748800     5               0
+{n_regionkey}    748800     1               0
+{r_name}         748800     1               0
+{r_regionkey}    748800     1               0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_custkey}      750000.00      1.00           147944.00           4.89 <==            0.00            1.00
+{c_nationkey}    750000.00      1.00           25.00               5.00 <==            0.00            1.00
+{n_name}         750000.00      1.00           25.00               1.00                0.00            1.00
+{n_nationkey}    750000.00      1.00           25.00               5.00 <==            0.00            1.00
+{n_nationkey_1}  750000.00      1.00           25.00               1.00                0.00            1.00
+{n_regionkey}    750000.00      1.00           1.00                1.00                0.00            1.00
+{r_name}         750000.00      1.00           1.00                1.00                0.00            1.00
+{r_regionkey}    750000.00      1.00           1.00                1.00                0.00            1.00
+
+stats table=q8_lookup_join_12
+----
+column_names   row_count  distinct_count  null_count
+{c_custkey}    29952      30253           0
+{c_nationkey}  29952      5               0
+{n_nationkey}  29952      5               0
+{n_regionkey}  29952      1               0
+{r_name}       29952      1               0
+{r_regionkey}  29952      1               0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_custkey}    30000.00       1.00           27672.00            1.09                0.00            1.00
+{c_nationkey}  30000.00       1.00           5.00                1.00                0.00            1.00
+{n_nationkey}  30000.00       1.00           5.00                1.00                0.00            1.00
+{n_regionkey}  30000.00       1.00           1.00                1.00                0.00            1.00
+{r_name}       30000.00       1.00           1.00                1.00                0.00            1.00
+{r_regionkey}  30000.00       1.00           1.00                1.00                0.00            1.00
+
+stats table=q8_lookup_join_13
+----
+column_names   row_count  distinct_count  null_count
+{n_nationkey}  5          5               0
+{n_regionkey}  5          1               0
+{r_name}       5          1               0
+{r_regionkey}  5          1               0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_nationkey}  5.00           1.00           5.00                1.00                0.00            1.00
+{n_regionkey}  5.00           1.00           1.00                1.00                0.00            1.00
+{r_name}       5.00           1.00           1.00                1.00                0.00            1.00
+{r_regionkey}  5.00           1.00           1.00                1.00                0.00            1.00
+
+stats table=q8_select_14
+----
+column_names   row_count  distinct_count  null_count
+{r_name}       1          1               0
+{r_regionkey}  1          1               0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{r_name}       1.00           1.00           1.00                1.00                0.00            1.00
+{r_regionkey}  1.00           1.00           1.00                1.00                0.00            1.00
+
+stats table=q8_scan_15
+----
+column_names   row_count  distinct_count  null_count
+{r_name}       5          5               0
+{r_regionkey}  5          5               0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{r_name}       5.00           1.00           5.00                1.00                0.00            1.00
+{r_regionkey}  5.00           1.00           5.00                1.00                0.00            1.00
+
+stats table=q8_scan_16
+----
+column_names   row_count  distinct_count  null_count
+{n_name}       25         25              0
+{n_nationkey}  25         25              0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}       25.00          1.00           25.00               1.00                0.00            1.00
+{n_nationkey}  25.00          1.00           25.00               1.00                0.00            1.00
+
+stats table=q8_index_join_17
+----
+column_names   row_count  distinct_count  null_count
+{o_custkey}    457263     97345           0
+{o_orderdate}  457263     731             0
+{o_orderkey}   457263     463903          0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{o_custkey}    166667.00      2.74 <==       82830.00            1.18                0.00            1.00
+{o_orderdate}  166667.00      2.74 <==       2406.00             3.29 <==            0.00            1.00
+{o_orderkey}   166667.00      2.74 <==       166667.00           2.78 <==            0.00            1.00
+
+stats table=q8_scan_19
+----
+column_names   row_count  distinct_count  null_count
+{s_nationkey}  10000      25              0
+{s_suppkey}    10000      9920            0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{s_nationkey}  10000.00       1.00           25.00               1.00                0.00            1.00
+{s_suppkey}    10000.00       1.00           9920.00             1.00                0.00            1.00
+
+stats table=q8_select_20
+----
+column_names  row_count  distinct_count  null_count
+{p_partkey}   1451       1451            0
+{p_type}      1451       1               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{p_partkey}   1333.00        1.09           1333.00             1.09                0.00            1.00
+{p_type}      1333.00        1.09           1.00                1.00                0.00            1.00
+
+stats table=q8_scan_21
+----
+column_names  row_count  distinct_count  null_count
+{p_partkey}   200000     199241          0
+{p_type}      200000     150             0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{p_partkey}   200000.00      1.00           199241.00           1.00                0.00            1.00
+{p_type}      200000.00      1.00           150.00              1.00                0.00            1.00
+
+# --------------------------------------------------
+# Q9
+# Product Type Profit Measure
+# Determines how much profit is made on a given line of parts, broken out by
+# supplier nation and year.
+#
+# Finds, for each nation and each year, the profit for all parts ordered in that
+# year that contain a specified substring in their names and that were filled by
+# a supplier in that nation. The profit is defined as the sum of:
+#
+#   [(l_extendedprice*(1-l_discount)) - (ps_supplycost * l_quantity)]
+#
+# for all lineitems describing parts in the specified line. The query lists the
+#  nations in ascending alphabetical order and, for each nation, the year and
+#  profit in descending order by year (most recent first).
+#
+# TODO:
+#   1. Join ordering
+#   2. Push down equivalent column comparisons
+# --------------------------------------------------
+save-tables database=tpch save-tables-prefix=q9
+SELECT
+    nation,
+    o_year,
+    sum(amount) AS sum_profit
+FROM (
+    SELECT
+        n_name AS nation,
+        extract(year FROM o_orderdate) AS o_year,
+        l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity AS amount
+    FROM
+        part,
+        supplier,
+        lineitem,
+        partsupp,
+        orders,
+        nation
+    WHERE
+        s_suppkey = l_suppkey
+        AND ps_suppkey = l_suppkey
+        AND ps_partkey = l_partkey
+        AND p_partkey = l_partkey
+        AND o_orderkey = l_orderkey
+        AND s_nationkey = n_nationkey
+        AND p_name LIKE '%green%'
+    ) AS profit
+GROUP BY
+    nation,
+    o_year
+ORDER BY
+    nation,
+    o_year DESC;
+----
+sort
+ ├── save-table-name: q9_sort_1
+ ├── columns: nation:48(char!null) o_year:51(int) sum_profit:53(float)
+ ├── stats: [rows=1500.68104, distinct(48)=25, null(48)=0, distinct(51)=1208.19298, null(51)=0, distinct(53)=1500.68104, null(53)=0, distinct(48,51)=1500.68104, null(48,51)=0]
+ ├── key: (48,51)
+ ├── fd: (48,51)-->(53)
+ ├── ordering: +48,-51
+ └── group-by
+      ├── save-table-name: q9_group_by_2
+      ├── columns: n_name:48(char!null) o_year:51(int) sum:53(float)
+      ├── grouping columns: n_name:48(char!null) o_year:51(int)
+      ├── stats: [rows=1500.68104, distinct(48)=25, null(48)=0, distinct(51)=1208.19298, null(51)=0, distinct(53)=1500.68104, null(53)=0, distinct(48,51)=1500.68104, null(48,51)=0]
+      ├── key: (48,51)
+      ├── fd: (48,51)-->(53)
+      ├── project
+      │    ├── save-table-name: q9_project_3
+      │    ├── columns: o_year:51(int) amount:52(float) n_name:48(char!null)
+      │    ├── stats: [rows=2406.66318, distinct(48)=25, null(48)=0, distinct(51)=1208.19298, null(51)=0, distinct(52)=1.98647072e-11, null(52)=0, distinct(48,51)=1500.68104, null(48,51)=0]
+      │    ├── inner-join (lookup part)
+      │    │    ├── save-table-name: q9_lookup_join_4
+      │    │    ├── columns: p_partkey:1(int!null) p_name:2(varchar!null) s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(char!null)
+      │    │    ├── key columns: [18] = [1]
+      │    │    ├── stats: [rows=2406.66318, distinct(1)=2357.09397, null(1)=0, distinct(2)=2363.68276, null(2)=0, distinct(10)=1520.84987, null(10)=0, distinct(13)=25, null(13)=0, distinct(17)=1508.01915, null(17)=0, distinct(18)=2357.09397, null(18)=0, distinct(19)=1520.84987, null(19)=0, distinct(21)=50, null(21)=0, distinct(22)=1507.67014, null(22)=0, distinct(23)=11, null(23)=0, distinct(33)=1508.01915, null(33)=0, distinct(34)=1443.61652, null(34)=0, distinct(36)=1503.89598, null(36)=0, distinct(38)=1508.01915, null(38)=0, distinct(42)=1208.19298, null(42)=0, distinct(47)=25, null(47)=0, distinct(48)=25, null(48)=0, distinct(42,48)=1500.68104, null(42,48)=0, distinct(21-23,36)=1.98647072e-11, null(21-23,36)=0]
+      │    │    ├── fd: (1)-->(2), (10)-->(13), (33,34)-->(36), (38)-->(42), (47)-->(48), (19)==(10,34), (34)==(10,19), (18)==(1,33), (33)==(1,18), (17)==(38), (38)==(17), (10)==(19,34), (13)==(47), (47)==(13), (1)==(18,33)
+      │    │    ├── inner-join
+      │    │    │    ├── save-table-name: q9_inner_join_5
+      │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(char!null)
+      │    │    │    ├── stats: [rows=2404.93063, distinct(10)=2404.93063, null(10)=0, distinct(13)=25, null(13)=0, distinct(17)=2357.09397, null(17)=0, distinct(18)=2357.09397, null(18)=0, distinct(19)=2404.93063, null(19)=0, distinct(21)=50, null(21)=0, distinct(22)=2355.81122, null(22)=0, distinct(23)=11, null(23)=0, distinct(33)=2357.09397, null(33)=0, distinct(34)=2135.61418, null(34)=0, distinct(36)=2342.00113, null(36)=0, distinct(38)=2357.09397, null(38)=0, distinct(42)=1520.49036, null(42)=0, distinct(47)=25, null(47)=0, distinct(48)=25, null(48)=0, distinct(42,48)=2330.3251, null(42,48)=0, distinct(21-23,36)=1.98647072e-11, null(21-23,36)=0]
+      │    │    │    ├── fd: (10)-->(13), (33,34)-->(36), (38)-->(42), (47)-->(48), (19)==(10,34), (34)==(10,19), (18)==(33), (33)==(18), (17)==(38), (38)==(17), (10)==(19,34), (13)==(47), (47)==(13)
+      │    │    │    ├── inner-join
+      │    │    │    │    ├── save-table-name: q9_inner_join_6
+      │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(char!null)
+      │    │    │    │    ├── stats: [rows=59642.2797, distinct(17)=59642.2797, null(17)=0, distinct(18)=59642.2797, null(18)=0, distinct(19)=9920, null(19)=0, distinct(21)=50, null(21)=0, distinct(22)=58063.808, null(22)=0, distinct(23)=11, null(23)=0, distinct(33)=59642.2797, null(33)=0, distinct(34)=9920, null(34)=0, distinct(36)=45145.1912, null(36)=0, distinct(38)=59642.2797, null(38)=0, distinct(42)=2406, null(42)=0, distinct(47)=25, null(47)=0, distinct(48)=25, null(48)=0, distinct(42,48)=37953.5881, null(42,48)=0, distinct(21-23,36)=1.98647072e-11, null(21-23,36)=0]
+      │    │    │    │    ├── fd: (33,34)-->(36), (38)-->(42), (47)-->(48), (19)==(34), (34)==(19), (18)==(33), (33)==(18), (17)==(38), (38)==(17)
+      │    │    │    │    ├── inner-join (lookup orders)
+      │    │    │    │    │    ├── save-table-name: q9_lookup_join_7
+      │    │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null)
+      │    │    │    │    │    ├── key columns: [17] = [38]
+      │    │    │    │    │    ├── stats: [rows=2385.69119, distinct(17)=2385.69119, null(17)=0, distinct(18)=2385.69119, null(18)=0, distinct(19)=2385.69119, null(19)=0, distinct(21)=50, null(21)=0, distinct(22)=2385.69119, null(22)=0, distinct(23)=11, null(23)=0, distinct(33)=2385.69119, null(33)=0, distinct(34)=2385.69119, null(34)=0, distinct(36)=2370.13724, null(36)=0, distinct(38)=2385.69119, null(38)=0, distinct(42)=1518.14352, null(42)=0, distinct(21-23,36)=1.21356077e-06, null(21-23,36)=0]
+      │    │    │    │    │    ├── fd: (38)-->(42), (33,34)-->(36), (19)==(34), (34)==(19), (18)==(33), (33)==(18), (17)==(38), (38)==(17)
+      │    │    │    │    │    ├── inner-join (lookup lineitem)
+      │    │    │    │    │    │    ├── save-table-name: q9_lookup_join_8
+      │    │    │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null)
+      │    │    │    │    │    │    ├── key columns: [17 20] = [17 20]
+      │    │    │    │    │    │    ├── stats: [rows=2429.06305, distinct(17)=2427.13263, null(17)=0, distinct(18)=2429.06305, null(18)=0, distinct(19)=2429.06305, null(19)=0, distinct(21)=50, null(21)=0, distinct(22)=2425.87997, null(22)=0, distinct(23)=11, null(23)=0, distinct(33)=2429.06305, null(33)=0, distinct(34)=2429.06305, null(34)=0, distinct(36)=2399.90856, null(36)=0, distinct(21-23,36)=54.3135038, null(21-23,36)=0]
+      │    │    │    │    │    │    ├── fd: (33,34)-->(36), (19)==(34), (34)==(19), (18)==(33), (33)==(18)
+      │    │    │    │    │    │    ├── inner-join (lookup lineitem@l_pk_sk)
+      │    │    │    │    │    │    │    ├── save-table-name: q9_lookup_join_9
+      │    │    │    │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_linenumber:20(int!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null)
+      │    │    │    │    │    │    │    ├── key columns: [33 34] = [18 19]
+      │    │    │    │    │    │    │    ├── stats: [rows=2429.06305, distinct(17)=2427.13263, null(17)=0, distinct(18)=2429.06305, null(18)=0, distinct(19)=2429.06305, null(19)=0, distinct(20)=7, null(20)=0, distinct(33)=2429.06305, null(33)=0, distinct(34)=2429.06305, null(34)=0, distinct(36)=2399.90856, null(36)=0]
+      │    │    │    │    │    │    │    ├── key: (17,20)
+      │    │    │    │    │    │    │    ├── fd: (33,34)-->(36), (17,20)-->(18,19), (18)==(33), (33)==(18), (19)==(34), (34)==(19)
+      │    │    │    │    │    │    │    ├── scan partsupp
+      │    │    │    │    │    │    │    │    ├── save-table-name: q9_scan_10
+      │    │    │    │    │    │    │    │    ├── columns: ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null)
+      │    │    │    │    │    │    │    │    ├── stats: [rows=800000, distinct(33)=199241, null(33)=0, distinct(34)=9920, null(34)=0, distinct(36)=100379, null(36)=0]
+      │    │    │    │    │    │    │    │    ├── key: (33,34)
+      │    │    │    │    │    │    │    │    └── fd: (33,34)-->(36)
+      │    │    │    │    │    │    │    └── filters (true)
+      │    │    │    │    │    │    └── filters (true)
+      │    │    │    │    │    └── filters (true)
+      │    │    │    │    ├── scan nation
+      │    │    │    │    │    ├── save-table-name: q9_scan_11
+      │    │    │    │    │    ├── columns: n_nationkey:47(int!null) n_name:48(char!null)
+      │    │    │    │    │    ├── stats: [rows=25, distinct(47)=25, null(47)=0, distinct(48)=25, null(48)=0]
+      │    │    │    │    │    ├── key: (47)
+      │    │    │    │    │    └── fd: (47)-->(48)
+      │    │    │    │    └── filters (true)
+      │    │    │    ├── scan supplier@s_nk
+      │    │    │    │    ├── save-table-name: q9_scan_12
+      │    │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null)
+      │    │    │    │    ├── stats: [rows=10000, distinct(10)=9920, null(10)=0, distinct(13)=25, null(13)=0]
+      │    │    │    │    ├── key: (10)
+      │    │    │    │    └── fd: (10)-->(13)
+      │    │    │    └── filters
+      │    │    │         ├── s_suppkey = l_suppkey [type=bool, outer=(10,19), constraints=(/10: (/NULL - ]; /19: (/NULL - ]), fd=(10)==(19), (19)==(10)]
+      │    │    │         └── s_nationkey = n_nationkey [type=bool, outer=(13,47), constraints=(/13: (/NULL - ]; /47: (/NULL - ]), fd=(13)==(47), (47)==(13)]
+      │    │    └── filters
+      │    │         └── p_name LIKE '%green%' [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
+      │    └── projections
+      │         ├── extract('year', o_orderdate) [type=int, outer=(42)]
+      │         └── (l_extendedprice * (1.0 - l_discount)) - (ps_supplycost * l_quantity) [type=float, outer=(21-23,36)]
+      └── aggregations
+           └── sum [type=float, outer=(52)]
+                └── variable: amount [type=float]
+
+stats table=q9_sort_1
+----
+column_names  row_count  distinct_count  null_count
+{nation}      175        25              0
+{o_year}      175        7               0
+{sum_profit}  175        175             0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{nation}      1501.00        8.58 <==       25.00               1.00                0.00            1.00
+{o_year}      1501.00        8.58 <==       1208.00             172.57 <==          0.00            1.00
+{sum_profit}  1501.00        8.58 <==       1501.00             8.58 <==            0.00            1.00
+
+stats table=q9_group_by_2
+----
+column_names  row_count  distinct_count  null_count
+{n_name}      175        25              0
+{o_year}      175        7               0
+{sum}  175        175             0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}      1501.00        8.58 <==       25.00               1.00                0.00            1.00
+{o_year}      1501.00        8.58 <==       1208.00             172.57 <==          0.00            1.00
+{sum}         1501.00        8.58 <==       1501.00             8.58 <==            0.00            1.00
+
+stats table=q9_project_3
+----
+column_names  row_count  distinct_count  null_count
+{amount}      319404     315234          0
+{n_name}      319404     25              0
+{o_year}      319404     7               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{amount}      2407.00        132.70 <==     0.00                +Inf <==            0.00            1.00
+{n_name}      2407.00        132.70 <==     25.00               1.00                0.00            1.00
+{o_year}      2407.00        132.70 <==     1208.00             172.57 <==          0.00            1.00
+
+stats table=q9_lookup_join_4
+----
+column_names       row_count  distinct_count  null_count
+{l_discount}       319404     11              0
+{l_extendedprice}  319404     212580          0
+{l_orderkey}       319404     288573          0
+{l_partkey}        319404     10632           0
+{l_quantity}       319404     50              0
+{l_suppkey}        319404     9799            0
+{n_name}           319404     25              0
+{n_nationkey}      319404     25              0
+{o_orderdate}      319404     2406            0
+{o_orderkey}       319404     288573          0
+{p_name}           319404     10680           0
+{p_partkey}        319404     10632           0
+{ps_partkey}       319404     10632           0
+{ps_suppkey}       319404     9799            0
+{ps_supplycost}    319404     34839           0
+{s_nationkey}      319404     25              0
+{s_suppkey}        319404     9799            0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_discount}       2407.00        132.70 <==     11.00               1.00                0.00            1.00
+{l_extendedprice}  2407.00        132.70 <==     1508.00             140.97 <==          0.00            1.00
+{l_orderkey}       2407.00        132.70 <==     1508.00             191.36 <==          0.00            1.00
+{l_partkey}        2407.00        132.70 <==     2357.00             4.51 <==            0.00            1.00
+{l_quantity}       2407.00        132.70 <==     50.00               1.00                0.00            1.00
+{l_suppkey}        2407.00        132.70 <==     1521.00             6.44 <==            0.00            1.00
+{n_name}           2407.00        132.70 <==     25.00               1.00                0.00            1.00
+{n_nationkey}      2407.00        132.70 <==     25.00               1.00                0.00            1.00
+{o_orderdate}      2407.00        132.70 <==     1208.00             1.99 <==            0.00            1.00
+{o_orderkey}       2407.00        132.70 <==     1508.00             191.36 <==          0.00            1.00
+{p_name}           2407.00        132.70 <==     2364.00             4.52 <==            0.00            1.00
+{p_partkey}        2407.00        132.70 <==     2357.00             4.51 <==            0.00            1.00
+{ps_partkey}       2407.00        132.70 <==     1508.00             7.05 <==            0.00            1.00
+{ps_suppkey}       2407.00        132.70 <==     1444.00             6.79 <==            0.00            1.00
+{ps_supplycost}    2407.00        132.70 <==     1504.00             23.16 <==           0.00            1.00
+{s_nationkey}      2407.00        132.70 <==     25.00               1.00                0.00            1.00
+{s_suppkey}        2407.00        132.70 <==     1521.00             6.44 <==            0.00            1.00
+
+stats table=q9_inner_join_5
+----
+column_names       row_count  distinct_count  null_count
+{l_discount}       6001215    11              0
+{l_extendedprice}  6001215    925955          0
+{l_orderkey}       6001215    1527272         0
+{l_partkey}        6001215    199241          0
+{l_quantity}       6001215    50              0
+{l_suppkey}        6001215    9920            0
+{n_name}           6001215    25              0
+{n_nationkey}      6001215    25              0
+{o_orderdate}      6001215    2406            0
+{o_orderkey}       6001215    1527272         0
+{ps_partkey}       6001215    199241          0
+{ps_suppkey}       6001215    9920            0
+{ps_supplycost}    6001215    100379          0
+{s_nationkey}      6001215    25              0
+{s_suppkey}        6001215    9920            0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_discount}       2405.00        2495.31 <==    11.00               1.00                0.00            1.00
+{l_extendedprice}  2405.00        2495.31 <==    2356.00             393.02 <==          0.00            1.00
+{l_orderkey}       2405.00        2495.31 <==    2357.00             647.97 <==          0.00            1.00
+{l_partkey}        2405.00        2495.31 <==    2357.00             84.53 <==           0.00            1.00
+{l_quantity}       2405.00        2495.31 <==    50.00               1.00                0.00            1.00
+{l_suppkey}        2405.00        2495.31 <==    2405.00             4.12 <==            0.00            1.00
+{n_name}           2405.00        2495.31 <==    25.00               1.00                0.00            1.00
+{n_nationkey}      2405.00        2495.31 <==    25.00               1.00                0.00            1.00
+{o_orderdate}      2405.00        2495.31 <==    1520.00             1.58                0.00            1.00
+{o_orderkey}       2405.00        2495.31 <==    2357.00             647.97 <==          0.00            1.00
+{ps_partkey}       2405.00        2495.31 <==    2357.00             84.53 <==           0.00            1.00
+{ps_suppkey}       2405.00        2495.31 <==    2136.00             4.64 <==            0.00            1.00
+{ps_supplycost}    2405.00        2495.31 <==    2342.00             42.86 <==           0.00            1.00
+{s_nationkey}      2405.00        2495.31 <==    25.00               1.00                0.00            1.00
+{s_suppkey}        2405.00        2495.31 <==    2405.00             4.12 <==            0.00            1.00
+
+stats table=q9_inner_join_6
+----
+column_names       row_count  distinct_count  null_count
+{l_discount}       150030375  11              0
+{l_extendedprice}  150030375  925955          0
+{l_orderkey}       150030375  1527272         0
+{l_partkey}        150030375  199241          0
+{l_quantity}       150030375  50              0
+{l_suppkey}        150030375  9920            0
+{n_name}           150030375  25              0
+{n_nationkey}      150030375  25              0
+{o_orderdate}      150030375  2406            0
+{o_orderkey}       150030375  1527272         0
+{ps_partkey}       150030375  199241          0
+{ps_suppkey}       150030375  9920            0
+{ps_supplycost}    150030375  100379          0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_discount}       59642.00       2515.52 <==    11.00               1.00                0.00            1.00
+{l_extendedprice}  59642.00       2515.52 <==    58064.00            15.95 <==           0.00            1.00
+{l_orderkey}       59642.00       2515.52 <==    59642.00            25.61 <==           0.00            1.00
+{l_partkey}        59642.00       2515.52 <==    59642.00            3.34 <==            0.00            1.00
+{l_quantity}       59642.00       2515.52 <==    50.00               1.00                0.00            1.00
+{l_suppkey}        59642.00       2515.52 <==    9920.00             1.00                0.00            1.00
+{n_name}           59642.00       2515.52 <==    25.00               1.00                0.00            1.00
+{n_nationkey}      59642.00       2515.52 <==    25.00               1.00                0.00            1.00
+{o_orderdate}      59642.00       2515.52 <==    2406.00             1.00                0.00            1.00
+{o_orderkey}       59642.00       2515.52 <==    59642.00            25.61 <==           0.00            1.00
+{ps_partkey}       59642.00       2515.52 <==    59642.00            3.34 <==            0.00            1.00
+{ps_suppkey}       59642.00       2515.52 <==    9920.00             1.00                0.00            1.00
+{ps_supplycost}    59642.00       2515.52 <==    45145.00            2.22 <==            0.00            1.00
+
+stats table=q9_lookup_join_7
+----
+column_names       row_count  distinct_count  null_count
+{l_discount}       6001215    11              0
+{l_extendedprice}  6001215    925955          0
+{l_orderkey}       6001215    1527272         0
+{l_partkey}        6001215    199241          0
+{l_quantity}       6001215    50              0
+{l_suppkey}        6001215    9920            0
+{o_orderdate}      6001215    2406            0
+{o_orderkey}       6001215    1527272         0
+{ps_partkey}       6001215    199241          0
+{ps_suppkey}       6001215    9920            0
+{ps_supplycost}    6001215    100379          0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_discount}       2386.00        2515.18 <==    11.00               1.00                0.00            1.00
+{l_extendedprice}  2386.00        2515.18 <==    2386.00             388.08 <==          0.00            1.00
+{l_orderkey}       2386.00        2515.18 <==    2386.00             640.10 <==          0.00            1.00
+{l_partkey}        2386.00        2515.18 <==    2386.00             83.50 <==           0.00            1.00
+{l_quantity}       2386.00        2515.18 <==    50.00               1.00                0.00            1.00
+{l_suppkey}        2386.00        2515.18 <==    2386.00             4.16 <==            0.00            1.00
+{o_orderdate}      2386.00        2515.18 <==    1518.00             1.58                0.00            1.00
+{o_orderkey}       2386.00        2515.18 <==    2386.00             640.10 <==          0.00            1.00
+{ps_partkey}       2386.00        2515.18 <==    2386.00             83.50 <==           0.00            1.00
+{ps_suppkey}       2386.00        2515.18 <==    2386.00             4.16 <==            0.00            1.00
+{ps_supplycost}    2386.00        2515.18 <==    2370.00             42.35 <==           0.00            1.00
+
+stats table=q9_lookup_join_8
+----
+column_names       row_count  distinct_count  null_count
+{l_discount}       6001215    11              0
+{l_extendedprice}  6001215    925955          0
+{l_orderkey}       6001215    1527272         0
+{l_partkey}        6001215    199241          0
+{l_quantity}       6001215    50              0
+{l_suppkey}        6001215    9920            0
+{ps_partkey}       6001215    199241          0
+{ps_suppkey}       6001215    9920            0
+{ps_supplycost}    6001215    100379          0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_discount}       2429.00        2470.65 <==    11.00               1.00                0.00            1.00
+{l_extendedprice}  2429.00        2470.65 <==    2426.00             381.68 <==          0.00            1.00
+{l_orderkey}       2429.00        2470.65 <==    2427.00             629.28 <==          0.00            1.00
+{l_partkey}        2429.00        2470.65 <==    2429.00             82.03 <==           0.00            1.00
+{l_quantity}       2429.00        2470.65 <==    50.00               1.00                0.00            1.00
+{l_suppkey}        2429.00        2470.65 <==    2429.00             4.08 <==            0.00            1.00
+{ps_partkey}       2429.00        2470.65 <==    2429.00             82.03 <==           0.00            1.00
+{ps_suppkey}       2429.00        2470.65 <==    2429.00             4.08 <==            0.00            1.00
+{ps_supplycost}    2429.00        2470.65 <==    2400.00             41.82 <==           0.00            1.00
+
+stats table=q9_lookup_join_9
+----
+column_names     row_count  distinct_count  null_count
+{l_linenumber}   6001215    7               0
+{l_orderkey}     6001215    1527272         0
+{l_partkey}      6001215    199241          0
+{l_suppkey}      6001215    9920            0
+{ps_partkey}     6001215    199241          0
+{ps_suppkey}     6001215    9920            0
+{ps_supplycost}  6001215    100379          0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_linenumber}   2429.00        2470.65 <==    7.00                1.00                0.00            1.00
+{l_orderkey}     2429.00        2470.65 <==    2427.00             629.28 <==          0.00            1.00
+{l_partkey}      2429.00        2470.65 <==    2429.00             82.03 <==           0.00            1.00
+{l_suppkey}      2429.00        2470.65 <==    2429.00             4.08 <==            0.00            1.00
+{ps_partkey}     2429.00        2470.65 <==    2429.00             82.03 <==           0.00            1.00
+{ps_suppkey}     2429.00        2470.65 <==    2429.00             4.08 <==            0.00            1.00
+{ps_supplycost}  2429.00        2470.65 <==    2400.00             41.82 <==           0.00            1.00
+
+stats table=q9_scan_10
+----
+column_names     row_count  distinct_count  null_count
+{ps_partkey}     800000     199241          0
+{ps_suppkey}     800000     9920            0
+{ps_supplycost}  800000     100379          0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{ps_partkey}     800000.00      1.00           199241.00           1.00                0.00            1.00
+{ps_suppkey}     800000.00      1.00           9920.00             1.00                0.00            1.00
+{ps_supplycost}  800000.00      1.00           100379.00           1.00                0.00            1.00
+
+stats table=q9_scan_11
+----
+column_names   row_count  distinct_count  null_count
+{n_name}       25         25              0
+{n_nationkey}  25         25              0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}       25.00          1.00           25.00               1.00                0.00            1.00
+{n_nationkey}  25.00          1.00           25.00               1.00                0.00            1.00
+
+stats table=q9_scan_12
+----
+column_names   row_count  distinct_count  null_count
+{s_nationkey}  10000      25              0
+{s_suppkey}    10000      9920            0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{s_nationkey}  10000.00       1.00           25.00               1.00                0.00            1.00
+{s_suppkey}    10000.00       1.00           9920.00             1.00                0.00            1.00
+
+# --------------------------------------------------
+# Q10
+# Returned Item Reporting
+# Identifies customers who might be having problems with the parts that are
+# shipped to them.
+#
+# Finds the top 20 customers, in terms of their effect on lost revenue for a
+# given quarter, who have returned parts. The query considers only parts that
+# were ordered in the specified quarter. The query lists the customer's name,
+# address, nation, phone number, account balance, comment information and
+# revenue lost. The customers are listed in descending order of lost revenue.
+# Revenue lost is defined as sum(l_extendedprice*(1-l_discount)) for all
+# qualifying lineitems.
+# --------------------------------------------------
+save-tables database=tpch save-tables-prefix=q10
+SELECT
+    c_custkey,
+    c_name,
+    sum(l_extendedprice * (1 - l_discount)) AS revenue,
+    c_acctbal,
+    n_name,
+    c_address,
+    c_phone,
+    c_comment
+FROM
+    customer,
+    orders,
+    lineitem,
+    nation
+WHERE
+    c_custkey = o_custkey
+    AND l_orderkey = o_orderkey
+    AND o_orderDATE >= DATE '1993-10-01'
+    AND o_orderDATE < DATE '1993-10-01' + INTERVAL '3' MONTH
+    AND l_returnflag = 'R'
+    AND c_nationkey = n_nationkey
+GROUP BY
+    c_custkey,
+    c_name,
+    c_acctbal,
+    c_phone,
+    n_name,
+    c_address,
+    c_comment
+ORDER BY
+    revenue DESC
+LIMIT 20;
+----
+limit
+ ├── save-table-name: q10_limit_1
+ ├── columns: c_custkey:1(int!null) c_name:2(varchar) revenue:39(float) c_acctbal:6(float) n_name:35(char) c_address:3(varchar) c_phone:5(char) c_comment:8(varchar)
+ ├── internal-ordering: -39
+ ├── cardinality: [0 - 20]
+ ├── stats: [rows=20, distinct(1)=20, null(1)=0, distinct(2)=20, null(2)=0, distinct(3)=20, null(3)=0, distinct(5)=20, null(5)=0, distinct(6)=20, null(6)=0, distinct(8)=20, null(8)=0, distinct(35)=20, null(35)=0, distinct(39)=20, null(39)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2,3,5,6,8,35,39)
+ ├── ordering: -39
+ ├── sort
+ │    ├── save-table-name: q10_sort_2
+ │    ├── columns: c_custkey:1(int!null) c_name:2(varchar) c_address:3(varchar) c_phone:5(char) c_acctbal:6(float) c_comment:8(varchar) n_name:35(char) sum:39(float)
+ │    ├── stats: [rows=82829.9251, distinct(1)=82829.9251, null(1)=0, distinct(2)=82829.9251, null(2)=0, distinct(3)=82829.9251, null(3)=0, distinct(5)=82829.9251, null(5)=0, distinct(6)=82829.9251, null(6)=0, distinct(8)=82829.9251, null(8)=0, distinct(35)=82829.9251, null(35)=0, distinct(39)=82829.9251, null(39)=0]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3,5,6,8,35,39)
+ │    ├── ordering: -39
+ │    └── group-by
+ │         ├── save-table-name: q10_group_by_3
+ │         ├── columns: c_custkey:1(int!null) c_name:2(varchar) c_address:3(varchar) c_phone:5(char) c_acctbal:6(float) c_comment:8(varchar) n_name:35(char) sum:39(float)
+ │         ├── grouping columns: c_custkey:1(int!null)
+ │         ├── stats: [rows=82829.9251, distinct(1)=82829.9251, null(1)=0, distinct(2)=82829.9251, null(2)=0, distinct(3)=82829.9251, null(3)=0, distinct(5)=82829.9251, null(5)=0, distinct(6)=82829.9251, null(6)=0, distinct(8)=82829.9251, null(8)=0, distinct(35)=82829.9251, null(35)=0, distinct(39)=82829.9251, null(39)=0]
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2,3,5,6,8,35,39)
+ │         ├── project
+ │         │    ├── save-table-name: q10_project_4
+ │         │    ├── columns: column38:38(float) c_custkey:1(int!null) c_name:2(varchar!null) c_address:3(varchar!null) c_phone:5(char!null) c_acctbal:6(float!null) c_comment:8(varchar!null) n_name:35(char!null)
+ │         │    ├── stats: [rows=276178.358, distinct(1)=82829.9251, null(1)=0, distinct(2)=126205.701, null(2)=0, distinct(3)=126171.088, null(3)=0, distinct(5)=126205.701, null(5)=0, distinct(6)=120896.334, null(6)=0, distinct(8)=125832.998, null(8)=0, distinct(35)=25, null(35)=0, distinct(38)=10827.3939, null(38)=0]
+ │         │    ├── fd: (1)-->(2,3,5,6,8,35)
+ │         │    ├── inner-join
+ │         │    │    ├── save-table-name: q10_inner_join_5
+ │         │    │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) c_address:3(varchar!null) c_nationkey:4(int!null) c_phone:5(char!null) c_acctbal:6(float!null) c_comment:8(varchar!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(char!null) n_nationkey:34(int!null) n_name:35(char!null)
+ │         │    │    ├── stats: [rows=276178.358, distinct(1)=82829.9251, null(1)=0, distinct(2)=126205.701, null(2)=0, distinct(3)=126171.088, null(3)=0, distinct(4)=25, null(4)=0, distinct(5)=126205.701, null(5)=0, distinct(6)=120896.334, null(6)=0, distinct(8)=125832.998, null(8)=0, distinct(9)=134883.861, null(9)=0, distinct(10)=82829.9251, null(10)=0, distinct(13)=2406, null(13)=0, distinct(18)=134883.861, null(18)=0, distinct(23)=236170.675, null(23)=0, distinct(24)=11, null(24)=0, distinct(26)=1, null(26)=0, distinct(34)=25, null(34)=0, distinct(35)=25, null(35)=0, distinct(23,24)=10827.3939, null(23,24)=0]
+ │         │    │    ├── fd: ()-->(26), (1)-->(2-6,8), (9)-->(10,13), (34)-->(35), (9)==(18), (18)==(9), (1)==(10), (10)==(1), (4)==(34), (34)==(4)
+ │         │    │    ├── inner-join (lookup lineitem)
+ │         │    │    │    ├── save-table-name: q10_lookup_join_6
+ │         │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(char!null)
+ │         │    │    │    ├── key columns: [9] = [18]
+ │         │    │    │    ├── stats: [rows=273992.867, distinct(9)=166666.667, null(9)=0, distinct(10)=79798.93, null(10)=0, distinct(13)=2406, null(13)=0, distinct(18)=166666.667, null(18)=0, distinct(23)=234596.457, null(23)=0, distinct(24)=11, null(24)=0, distinct(26)=1, null(26)=0, distinct(23,24)=273992.867, null(23,24)=0]
+ │         │    │    │    ├── fd: ()-->(26), (9)-->(10,13), (9)==(18), (18)==(9)
+ │         │    │    │    ├── index-join orders
+ │         │    │    │    │    ├── save-table-name: q10_index_join_7
+ │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null)
+ │         │    │    │    │    ├── stats: [rows=166666.667, distinct(9)=166666.667, null(9)=0, distinct(10)=82829.9251, null(10)=0, distinct(13)=2406, null(13)=0]
+ │         │    │    │    │    ├── key: (9)
+ │         │    │    │    │    ├── fd: (9)-->(10,13)
+ │         │    │    │    │    └── scan orders@o_od
+ │         │    │    │    │         ├── save-table-name: q10_scan_8
+ │         │    │    │    │         ├── columns: o_orderkey:9(int!null) o_orderdate:13(date!null)
+ │         │    │    │    │         ├── constraint: /13/9: [/'1993-10-01' - /'1993-12-31']
+ │         │    │    │    │         ├── stats: [rows=166666.667, distinct(9)=166666.667, null(9)=0, distinct(13)=2406, null(13)=0]
+ │         │    │    │    │         ├── key: (9)
+ │         │    │    │    │         └── fd: (9)-->(13)
+ │         │    │    │    └── filters
+ │         │    │    │         └── l_returnflag = 'R' [type=bool, outer=(26), constraints=(/26: [/'R' - /'R']; tight), fd=()-->(26)]
+ │         │    │    ├── inner-join
+ │         │    │    │    ├── save-table-name: q10_inner_join_9
+ │         │    │    │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) c_address:3(varchar!null) c_nationkey:4(int!null) c_phone:5(char!null) c_acctbal:6(float!null) c_comment:8(varchar!null) n_nationkey:34(int!null) n_name:35(char!null)
+ │         │    │    │    ├── stats: [rows=150000, distinct(1)=95616.0932, null(1)=0, distinct(2)=95940.4925, null(2)=0, distinct(3)=95923.3641, null(3)=0, distinct(4)=25, null(4)=0, distinct(5)=95940.4925, null(5)=0, distinct(6)=93278.5687, null(6)=0, distinct(8)=95755.9084, null(8)=0, distinct(34)=25, null(34)=0, distinct(35)=25, null(35)=0]
+ │         │    │    │    ├── key: (1)
+ │         │    │    │    ├── fd: (34)-->(35), (1)-->(2-6,8), (4)==(34), (34)==(4)
+ │         │    │    │    ├── scan customer
+ │         │    │    │    │    ├── save-table-name: q10_scan_10
+ │         │    │    │    │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) c_address:3(varchar!null) c_nationkey:4(int!null) c_phone:5(char!null) c_acctbal:6(float!null) c_comment:8(varchar!null)
+ │         │    │    │    │    ├── stats: [rows=150000, distinct(1)=148813, null(1)=0, distinct(2)=150000, null(2)=0, distinct(3)=149937, null(3)=0, distinct(4)=25, null(4)=0, distinct(5)=150000, null(5)=0, distinct(6)=140628, null(6)=0, distinct(8)=149323, null(8)=0]
+ │         │    │    │    │    ├── key: (1)
+ │         │    │    │    │    └── fd: (1)-->(2-6,8)
+ │         │    │    │    ├── scan nation
+ │         │    │    │    │    ├── save-table-name: q10_scan_11
+ │         │    │    │    │    ├── columns: n_nationkey:34(int!null) n_name:35(char!null)
+ │         │    │    │    │    ├── stats: [rows=25, distinct(34)=25, null(34)=0, distinct(35)=25, null(35)=0]
+ │         │    │    │    │    ├── key: (34)
+ │         │    │    │    │    └── fd: (34)-->(35)
+ │         │    │    │    └── filters
+ │         │    │    │         └── c_nationkey = n_nationkey [type=bool, outer=(4,34), constraints=(/4: (/NULL - ]; /34: (/NULL - ]), fd=(4)==(34), (34)==(4)]
+ │         │    │    └── filters
+ │         │    │         └── c_custkey = o_custkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+ │         │    └── projections
+ │         │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(23,24)]
+ │         └── aggregations
+ │              ├── sum [type=float, outer=(38)]
+ │              │    └── variable: column38 [type=float]
+ │              ├── const-agg [type=varchar, outer=(2)]
+ │              │    └── variable: c_name [type=varchar]
+ │              ├── const-agg [type=varchar, outer=(3)]
+ │              │    └── variable: c_address [type=varchar]
+ │              ├── const-agg [type=char, outer=(5)]
+ │              │    └── variable: c_phone [type=char]
+ │              ├── const-agg [type=float, outer=(6)]
+ │              │    └── variable: c_acctbal [type=float]
+ │              ├── const-agg [type=varchar, outer=(8)]
+ │              │    └── variable: c_comment [type=varchar]
+ │              └── const-agg [type=char, outer=(35)]
+ │                   └── variable: n_name [type=char]
+ └── const: 20 [type=int]
+
+stats table=q10_limit_1
+----
+column_names  row_count  distinct_count  null_count
+{c_acctbal}   20         20              0
+{c_address}   20         20              0
+{c_comment}   20         20              0
+{c_custkey}   20         20              0
+{c_name}      20         20              0
+{c_phone}     20         20              0
+{n_name}      20         13              0
+{revenue}     20         20              0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_acctbal}   20.00          1.00           20.00               1.00                0.00            1.00
+{c_address}   20.00          1.00           20.00               1.00                0.00            1.00
+{c_comment}   20.00          1.00           20.00               1.00                0.00            1.00
+{c_custkey}   20.00          1.00           20.00               1.00                0.00            1.00
+{c_name}      20.00          1.00           20.00               1.00                0.00            1.00
+{c_phone}     20.00          1.00           20.00               1.00                0.00            1.00
+{n_name}      20.00          1.00           20.00               1.54                0.00            1.00
+{revenue}     20.00          1.00           20.00               1.00                0.00            1.00
+
+stats table=q10_sort_2
+----
+column_names  row_count  distinct_count  null_count
+{c_acctbal}   0          0               0
+{c_address}   0          0               0
+{c_comment}   0          0               0
+{c_custkey}   0          0               0
+{c_name}      0          0               0
+{c_phone}     0          0               0
+{n_name}      0          0               0
+{sum}         0          0               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_acctbal}   82830.00       +Inf <==       82830.00            +Inf <==            0.00            1.00
+{c_address}   82830.00       +Inf <==       82830.00            +Inf <==            0.00            1.00
+{c_comment}   82830.00       +Inf <==       82830.00            +Inf <==            0.00            1.00
+{c_custkey}   82830.00       +Inf <==       82830.00            +Inf <==            0.00            1.00
+{c_name}      82830.00       +Inf <==       82830.00            +Inf <==            0.00            1.00
+{c_phone}     82830.00       +Inf <==       82830.00            +Inf <==            0.00            1.00
+{n_name}      82830.00       +Inf <==       82830.00            +Inf <==            0.00            1.00
+{sum}         82830.00       +Inf <==       82830.00            +Inf <==            0.00            1.00
+
+stats table=q10_group_by_3
+----
+column_names  row_count  distinct_count  null_count
+{c_acctbal}   37967      37658           0
+{c_address}   37967      38065           0
+{c_comment}   37967      38086           0
+{c_custkey}   37967      37904           0
+{c_name}      37967      37859           0
+{c_phone}     37967      38026           0
+{n_name}      37967      25              0
+{sum}         37967      37934           0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_acctbal}   82830.00       2.18 <==       82830.00            2.20 <==            0.00            1.00
+{c_address}   82830.00       2.18 <==       82830.00            2.18 <==            0.00            1.00
+{c_comment}   82830.00       2.18 <==       82830.00            2.17 <==            0.00            1.00
+{c_custkey}   82830.00       2.18 <==       82830.00            2.19 <==            0.00            1.00
+{c_name}      82830.00       2.18 <==       82830.00            2.19 <==            0.00            1.00
+{c_phone}     82830.00       2.18 <==       82830.00            2.18 <==            0.00            1.00
+{n_name}      82830.00       2.18 <==       82830.00            3313.20 <==         0.00            1.00
+{sum}         82830.00       2.18 <==       82830.00            2.18 <==            0.00            1.00
+
+stats table=q10_project_4
+----
+column_names  row_count  distinct_count  null_count
+{c_acctbal}   114705     37658           0
+{c_address}   114705     38065           0
+{c_comment}   114705     38086           0
+{c_custkey}   114705     37904           0
+{c_name}      114705     37859           0
+{c_phone}     114705     38026           0
+{column38}    114705     114608          0
+{n_name}      114705     25              0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_acctbal}   276178.00      2.41 <==       120896.00           3.21 <==            0.00            1.00
+{c_address}   276178.00      2.41 <==       126171.00           3.31 <==            0.00            1.00
+{c_comment}   276178.00      2.41 <==       125833.00           3.30 <==            0.00            1.00
+{c_custkey}   276178.00      2.41 <==       82830.00            2.19 <==            0.00            1.00
+{c_name}      276178.00      2.41 <==       126206.00           3.33 <==            0.00            1.00
+{c_phone}     276178.00      2.41 <==       126206.00           3.32 <==            0.00            1.00
+{column38}    276178.00      2.41 <==       10827.00            10.59 <==           0.00            1.00
+{n_name}      276178.00      2.41 <==       25.00               1.00                0.00            1.00
+
+stats table=q10_inner_join_5
+----
+column_names       row_count  distinct_count  null_count
+{c_acctbal}        114705     37658           0
+{c_address}        114705     38065           0
+{c_comment}        114705     38086           0
+{c_custkey}        114705     37904           0
+{c_name}           114705     37859           0
+{c_nationkey}      114705     25              0
+{c_phone}          114705     38026           0
+{l_discount}       114705     11              0
+{l_extendedprice}  114705     106228          0
+{l_orderkey}       114705     48516           0
+{l_returnflag}     114705     1               0
+{n_name}           114705     25              0
+{n_nationkey}      114705     25              0
+{o_custkey}        114705     37904           0
+{o_orderdate}      114705     92              0
+{o_orderkey}       114705     48516           0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_acctbal}        276178.00      2.41 <==       120896.00           3.21 <==            0.00            1.00
+{c_address}        276178.00      2.41 <==       126171.00           3.31 <==            0.00            1.00
+{c_comment}        276178.00      2.41 <==       125833.00           3.30 <==            0.00            1.00
+{c_custkey}        276178.00      2.41 <==       82830.00            2.19 <==            0.00            1.00
+{c_name}           276178.00      2.41 <==       126206.00           3.33 <==            0.00            1.00
+{c_nationkey}      276178.00      2.41 <==       25.00               1.00                0.00            1.00
+{c_phone}          276178.00      2.41 <==       126206.00           3.32 <==            0.00            1.00
+{l_discount}       276178.00      2.41 <==       11.00               1.00                0.00            1.00
+{l_extendedprice}  276178.00      2.41 <==       236171.00           2.22 <==            0.00            1.00
+{l_orderkey}       276178.00      2.41 <==       134884.00           2.78 <==            0.00            1.00
+{l_returnflag}     276178.00      2.41 <==       1.00                1.00                0.00            1.00
+{n_name}           276178.00      2.41 <==       25.00               1.00                0.00            1.00
+{n_nationkey}      276178.00      2.41 <==       25.00               1.00                0.00            1.00
+{o_custkey}        276178.00      2.41 <==       82830.00            2.19 <==            0.00            1.00
+{o_orderdate}      276178.00      2.41 <==       2406.00             26.15 <==           0.00            1.00
+{o_orderkey}       276178.00      2.41 <==       134884.00           2.78 <==            0.00            1.00
+
+stats table=q10_lookup_join_6
+----
+column_names       row_count  distinct_count  null_count
+{l_discount}       114705     11              0
+{l_extendedprice}  114705     106228          0
+{l_orderkey}       114705     48516           0
+{l_returnflag}     114705     1               0
+{o_custkey}        114705     37904           0
+{o_orderdate}      114705     92              0
+{o_orderkey}       114705     48516           0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_discount}       273993.00      2.39 <==       11.00               1.00                0.00            1.00
+{l_extendedprice}  273993.00      2.39 <==       234596.00           2.21 <==            0.00            1.00
+{l_orderkey}       273993.00      2.39 <==       166667.00           3.44 <==            0.00            1.00
+{l_returnflag}     273993.00      2.39 <==       1.00                1.00                0.00            1.00
+{o_custkey}        273993.00      2.39 <==       79799.00            2.11 <==            0.00            1.00
+{o_orderdate}      273993.00      2.39 <==       2406.00             26.15 <==           0.00            1.00
+{o_orderkey}       273993.00      2.39 <==       166667.00           3.44 <==            0.00            1.00
+
+stats table=q10_index_join_7
+----
+column_names   row_count  distinct_count  null_count
+{o_custkey}    57069      42598           0
+{o_orderdate}  57069      92              0
+{o_orderkey}   57069      56240           0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{o_custkey}    166667.00      2.92 <==       82830.00            1.94 <==            0.00            1.00
+{o_orderdate}  166667.00      2.92 <==       2406.00             26.15 <==           0.00            1.00
+{o_orderkey}   166667.00      2.92 <==       166667.00           2.96 <==            0.00            1.00
+
+stats table=q10_inner_join_9
+----
+column_names   row_count  distinct_count  null_count
+{c_acctbal}    150000     140628          0
+{c_address}    150000     149937          0
+{c_comment}    150000     149323          0
+{c_custkey}    150000     148813          0
+{c_name}       150000     151126          0
+{c_nationkey}  150000     25              0
+{c_phone}      150000     150872          0
+{n_name}       150000     25              0
+{n_nationkey}  150000     25              0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_acctbal}    150000.00      1.00           93279.00            1.51                0.00            1.00
+{c_address}    150000.00      1.00           95923.00            1.56                0.00            1.00
+{c_comment}    150000.00      1.00           95756.00            1.56                0.00            1.00
+{c_custkey}    150000.00      1.00           95616.00            1.56                0.00            1.00
+{c_name}       150000.00      1.00           95940.00            1.58                0.00            1.00
+{c_nationkey}  150000.00      1.00           25.00               1.00                0.00            1.00
+{c_phone}      150000.00      1.00           95940.00            1.57                0.00            1.00
+{n_name}       150000.00      1.00           25.00               1.00                0.00            1.00
+{n_nationkey}  150000.00      1.00           25.00               1.00                0.00            1.00
+
+stats table=q10_scan_10
+----
+column_names   row_count  distinct_count  null_count
+{c_acctbal}    150000     140628          0
+{c_address}    150000     149937          0
+{c_comment}    150000     149323          0
+{c_custkey}    150000     148813          0
+{c_name}       150000     151126          0
+{c_nationkey}  150000     25              0
+{c_phone}      150000     150872          0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_acctbal}    150000.00      1.00           140628.00           1.00                0.00            1.00
+{c_address}    150000.00      1.00           149937.00           1.00                0.00            1.00
+{c_comment}    150000.00      1.00           149323.00           1.00                0.00            1.00
+{c_custkey}    150000.00      1.00           148813.00           1.00                0.00            1.00
+{c_name}       150000.00      1.00           150000.00           1.01                0.00            1.00
+{c_nationkey}  150000.00      1.00           25.00               1.00                0.00            1.00
+{c_phone}      150000.00      1.00           150000.00           1.01                0.00            1.00
+
+stats table=q10_scan_11
+----
+column_names   row_count  distinct_count  null_count
+{n_name}       25         25              0
+{n_nationkey}  25         25              0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}       25.00          1.00           25.00               1.00                0.00            1.00
+{n_nationkey}  25.00          1.00           25.00               1.00                0.00            1.00
+
+# --------------------------------------------------
+# Q11
+# Important Stock Identification
+# Finds the most important subset of suppliers' stock in a given nation.
+#
+# Finds, from scanning the available stock of suppliers in a given nation, all
+# the parts that represent a significant percentage of the total value of all
+# available parts. The query displays the part number and the value of those
+# parts in descending order of value.
+# --------------------------------------------------
+save-tables database=tpch save-tables-prefix=q11
+SELECT
+    ps_partkey,
+    sum(ps_supplycost * ps_availqty::float) AS value
+FROM
+    partsupp,
+    supplier,
+    nation
+WHERE
+    ps_suppkey = s_suppkey
+    AND s_nationkey = n_nationkey
+    AND n_name = 'GERMANY'
+GROUP BY
+    ps_partkey HAVING
+        sum(ps_supplycost * ps_availqty::float) > (
+            SELECT
+                sum(ps_supplycost * ps_availqty::float) * 0.0001
+            FROM
+                partsupp,
+                supplier,
+                nation
+            WHERE
+                ps_suppkey = s_suppkey
+                AND s_nationkey = n_nationkey
+                AND n_name = 'GERMANY'
+        )
+ORDER BY
+    value DESC;
+----
+sort
+ ├── save-table-name: q11_sort_1
+ ├── columns: ps_partkey:1(int!null) value:18(float!null)
+ ├── stats: [rows=9927.82897, distinct(1)=9927.82897, null(1)=0, distinct(18)=9927.82897, null(18)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(18)
+ ├── ordering: -18
+ └── select
+      ├── save-table-name: q11_select_2
+      ├── columns: ps_partkey:1(int!null) sum:18(float!null)
+      ├── stats: [rows=9927.82897, distinct(1)=9927.82897, null(1)=0, distinct(18)=9927.82897, null(18)=0]
+      ├── key: (1)
+      ├── fd: (1)-->(18)
+      ├── group-by
+      │    ├── save-table-name: q11_group_by_3
+      │    ├── columns: ps_partkey:1(int!null) sum:18(float)
+      │    ├── grouping columns: ps_partkey:1(int!null)
+      │    ├── stats: [rows=29783.4869, distinct(1)=29783.4869, null(1)=0, distinct(18)=29783.4869, null(18)=0]
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(18)
+      │    ├── project
+      │    │    ├── save-table-name: q11_project_4
+      │    │    ├── columns: column17:17(float) ps_partkey:1(int!null)
+      │    │    ├── stats: [rows=32258.0645, distinct(1)=29783.4869, null(1)=0, distinct(17)=32258.0645, null(17)=0]
+      │    │    ├── inner-join (lookup partsupp)
+      │    │    │    ├── save-table-name: q11_lookup_join_5
+      │    │    │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null) ps_availqty:3(int!null) ps_supplycost:4(float!null) s_suppkey:6(int!null) s_nationkey:9(int!null) n_nationkey:13(int!null) n_name:14(char!null)
+      │    │    │    ├── key columns: [1 2] = [1 2]
+      │    │    │    ├── stats: [rows=32258.0645, distinct(1)=29783.4869, null(1)=0, distinct(2)=399.934613, null(2)=0, distinct(3)=9536.12259, null(3)=0, distinct(4)=27589.3232, null(4)=0, distinct(6)=399.934613, null(6)=0, distinct(9)=1, null(9)=0, distinct(13)=1, null(13)=0, distinct(14)=1, null(14)=0, distinct(3,4)=32258.0645, null(3,4)=0]
+      │    │    │    ├── key: (1,6)
+      │    │    │    ├── fd: ()-->(14), (1,2)-->(3,4), (6)-->(9), (9)==(13), (13)==(9), (2)==(6), (6)==(2)
+      │    │    │    ├── inner-join (lookup partsupp@ps_sk)
+      │    │    │    │    ├── save-table-name: q11_lookup_join_6
+      │    │    │    │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null) s_suppkey:6(int!null) s_nationkey:9(int!null) n_nationkey:13(int!null) n_name:14(char!null)
+      │    │    │    │    ├── key columns: [6] = [2]
+      │    │    │    │    ├── stats: [rows=32258.0645, distinct(1)=29783.4869, null(1)=0, distinct(2)=399.934613, null(2)=0, distinct(6)=399.934613, null(6)=0, distinct(9)=1, null(9)=0, distinct(13)=1, null(13)=0, distinct(14)=1, null(14)=0]
+      │    │    │    │    ├── key: (1,6)
+      │    │    │    │    ├── fd: ()-->(14), (6)-->(9), (9)==(13), (13)==(9), (2)==(6), (6)==(2)
+      │    │    │    │    ├── inner-join (lookup supplier@s_nk)
+      │    │    │    │    │    ├── save-table-name: q11_lookup_join_7
+      │    │    │    │    │    ├── columns: s_suppkey:6(int!null) s_nationkey:9(int!null) n_nationkey:13(int!null) n_name:14(char!null)
+      │    │    │    │    │    ├── key columns: [13] = [9]
+      │    │    │    │    │    ├── stats: [rows=400, distinct(6)=399.934613, null(6)=0, distinct(9)=1, null(9)=0, distinct(13)=1, null(13)=0, distinct(14)=1, null(14)=0]
+      │    │    │    │    │    ├── key: (6)
+      │    │    │    │    │    ├── fd: ()-->(14), (6)-->(9), (9)==(13), (13)==(9)
+      │    │    │    │    │    ├── select
+      │    │    │    │    │    │    ├── save-table-name: q11_select_8
+      │    │    │    │    │    │    ├── columns: n_nationkey:13(int!null) n_name:14(char!null)
+      │    │    │    │    │    │    ├── stats: [rows=1, distinct(13)=1, null(13)=0, distinct(14)=1, null(14)=0]
+      │    │    │    │    │    │    ├── key: (13)
+      │    │    │    │    │    │    ├── fd: ()-->(14)
+      │    │    │    │    │    │    ├── scan nation
+      │    │    │    │    │    │    │    ├── save-table-name: q11_scan_9
+      │    │    │    │    │    │    │    ├── columns: n_nationkey:13(int!null) n_name:14(char!null)
+      │    │    │    │    │    │    │    ├── stats: [rows=25, distinct(13)=25, null(13)=0, distinct(14)=25, null(14)=0]
+      │    │    │    │    │    │    │    ├── key: (13)
+      │    │    │    │    │    │    │    └── fd: (13)-->(14)
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         └── n_name = 'GERMANY' [type=bool, outer=(14), constraints=(/14: [/'GERMANY' - /'GERMANY']; tight), fd=()-->(14)]
+      │    │    │    │    │    └── filters (true)
+      │    │    │    │    └── filters (true)
+      │    │    │    └── filters (true)
+      │    │    └── projections
+      │    │         └── ps_supplycost * ps_availqty::FLOAT8 [type=float, outer=(3,4)]
+      │    └── aggregations
+      │         └── sum [type=float, outer=(17)]
+      │              └── variable: column17 [type=float]
+      └── filters
+           └── gt [type=bool, outer=(18), subquery, constraints=(/18: (/NULL - ])]
+                ├── variable: sum [type=float]
+                └── subquery [type=float]
+                     └── project
+                          ├── save-table-name: q11_project_10
+                          ├── columns: "?column?":37(float)
+                          ├── cardinality: [1 - 1]
+                          ├── stats: [rows=1, distinct(37)=1, null(37)=0]
+                          ├── key: ()
+                          ├── fd: ()-->(37)
+                          ├── scalar-group-by
+                          │    ├── save-table-name: q11_scalar_group_by_11
+                          │    ├── columns: sum:36(float)
+                          │    ├── cardinality: [1 - 1]
+                          │    ├── stats: [rows=1, distinct(36)=1, null(36)=0]
+                          │    ├── key: ()
+                          │    ├── fd: ()-->(36)
+                          │    ├── project
+                          │    │    ├── save-table-name: q11_project_12
+                          │    │    ├── columns: column35:35(float)
+                          │    │    ├── stats: [rows=32258.0645, distinct(35)=32258.0645, null(35)=0]
+                          │    │    ├── inner-join (lookup partsupp)
+                          │    │    │    ├── save-table-name: q11_lookup_join_13
+                          │    │    │    ├── columns: ps_suppkey:20(int!null) ps_availqty:21(int!null) ps_supplycost:22(float!null) s_suppkey:24(int!null) s_nationkey:27(int!null) n_nationkey:31(int!null) n_name:32(char!null)
+                          │    │    │    ├── key columns: [19 20] = [19 20]
+                          │    │    │    ├── stats: [rows=32258.0645, distinct(20)=399.934613, null(20)=0, distinct(21)=9536.12259, null(21)=0, distinct(22)=27589.3232, null(22)=0, distinct(24)=399.934613, null(24)=0, distinct(27)=1, null(27)=0, distinct(31)=1, null(31)=0, distinct(32)=1, null(32)=0, distinct(21,22)=32258.0645, null(21,22)=0]
+                          │    │    │    ├── fd: ()-->(32), (24)-->(27), (27)==(31), (31)==(27), (20)==(24), (24)==(20)
+                          │    │    │    ├── inner-join (lookup partsupp@ps_sk)
+                          │    │    │    │    ├── save-table-name: q11_lookup_join_14
+                          │    │    │    │    ├── columns: ps_partkey:19(int!null) ps_suppkey:20(int!null) s_suppkey:24(int!null) s_nationkey:27(int!null) n_nationkey:31(int!null) n_name:32(char!null)
+                          │    │    │    │    ├── key columns: [24] = [20]
+                          │    │    │    │    ├── stats: [rows=32258.0645, distinct(19)=29783.4869, null(19)=0, distinct(20)=399.934613, null(20)=0, distinct(24)=399.934613, null(24)=0, distinct(27)=1, null(27)=0, distinct(31)=1, null(31)=0, distinct(32)=1, null(32)=0]
+                          │    │    │    │    ├── key: (19,24)
+                          │    │    │    │    ├── fd: ()-->(32), (24)-->(27), (27)==(31), (31)==(27), (20)==(24), (24)==(20)
+                          │    │    │    │    ├── inner-join (lookup supplier@s_nk)
+                          │    │    │    │    │    ├── save-table-name: q11_lookup_join_15
+                          │    │    │    │    │    ├── columns: s_suppkey:24(int!null) s_nationkey:27(int!null) n_nationkey:31(int!null) n_name:32(char!null)
+                          │    │    │    │    │    ├── key columns: [31] = [27]
+                          │    │    │    │    │    ├── stats: [rows=400, distinct(24)=399.934613, null(24)=0, distinct(27)=1, null(27)=0, distinct(31)=1, null(31)=0, distinct(32)=1, null(32)=0]
+                          │    │    │    │    │    ├── key: (24)
+                          │    │    │    │    │    ├── fd: ()-->(32), (24)-->(27), (27)==(31), (31)==(27)
+                          │    │    │    │    │    ├── select
+                          │    │    │    │    │    │    ├── save-table-name: q11_select_16
+                          │    │    │    │    │    │    ├── columns: n_nationkey:31(int!null) n_name:32(char!null)
+                          │    │    │    │    │    │    ├── stats: [rows=1, distinct(31)=1, null(31)=0, distinct(32)=1, null(32)=0]
+                          │    │    │    │    │    │    ├── key: (31)
+                          │    │    │    │    │    │    ├── fd: ()-->(32)
+                          │    │    │    │    │    │    ├── scan nation
+                          │    │    │    │    │    │    │    ├── save-table-name: q11_scan_17
+                          │    │    │    │    │    │    │    ├── columns: n_nationkey:31(int!null) n_name:32(char!null)
+                          │    │    │    │    │    │    │    ├── stats: [rows=25, distinct(31)=25, null(31)=0, distinct(32)=25, null(32)=0]
+                          │    │    │    │    │    │    │    ├── key: (31)
+                          │    │    │    │    │    │    │    └── fd: (31)-->(32)
+                          │    │    │    │    │    │    └── filters
+                          │    │    │    │    │    │         └── n_name = 'GERMANY' [type=bool, outer=(32), constraints=(/32: [/'GERMANY' - /'GERMANY']; tight), fd=()-->(32)]
+                          │    │    │    │    │    └── filters (true)
+                          │    │    │    │    └── filters (true)
+                          │    │    │    └── filters (true)
+                          │    │    └── projections
+                          │    │         └── ps_supplycost * ps_availqty::FLOAT8 [type=float, outer=(21,22)]
+                          │    └── aggregations
+                          │         └── sum [type=float, outer=(35)]
+                          │              └── variable: column35 [type=float]
+                          └── projections
+                               └── sum * 0.0001 [type=float, outer=(36)]
+
+stats table=q11_sort_1
+----
+column_names  row_count  distinct_count  null_count
+{ps_partkey}  1048       1048            0
+{value}       1048       1048            0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{ps_partkey}  9928.00        9.47 <==       9928.00             9.47 <==            0.00            1.00
+{value}       9928.00        9.47 <==       9928.00             9.47 <==            0.00            1.00
+
+stats table=q11_select_2
+----
+column_names  row_count  distinct_count  null_count
+{ps_partkey}  1048       1048            0
+{sum}         1048       1048            0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{ps_partkey}  9928.00        9.47 <==       9928.00             9.47 <==            0.00            1.00
+{sum}         9928.00        9.47 <==       9928.00             9.47 <==            0.00            1.00
+
+stats table=q11_group_by_3
+----
+column_names  row_count  distinct_count  null_count
+{ps_partkey}  29818      29669           0
+{sum}         29818      29969           0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{ps_partkey}  29783.00       1.00           29783.00            1.00                0.00            1.00
+{sum}         29783.00       1.00           29783.00            1.01                0.00            1.00
+
+stats table=q11_project_4
+----
+column_names  row_count  distinct_count  null_count
+{column17}    31680      31888           0
+{ps_partkey}  31680      29669           0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{column17}    32258.00       1.02           32258.00            1.01                0.00            1.00
+{ps_partkey}  32258.00       1.02           29783.00            1.00                0.00            1.00
+
+stats table=q11_lookup_join_5
+----
+column_names     row_count  distinct_count  null_count
+{n_name}         31680      1               0
+{n_nationkey}    31680      1               0
+{ps_availqty}    31680      9556            0
+{ps_partkey}     31680      29669           0
+{ps_suppkey}     31680      396             0
+{ps_supplycost}  31680      27350           0
+{s_nationkey}    31680      1               0
+{s_suppkey}      31680      396             0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}         32258.00       1.02           1.00                1.00                0.00            1.00
+{n_nationkey}    32258.00       1.02           1.00                1.00                0.00            1.00
+{ps_availqty}    32258.00       1.02           9536.00             1.00                0.00            1.00
+{ps_partkey}     32258.00       1.02           29783.00            1.00                0.00            1.00
+{ps_suppkey}     32258.00       1.02           400.00              1.01                0.00            1.00
+{ps_supplycost}  32258.00       1.02           27589.00            1.01                0.00            1.00
+{s_nationkey}    32258.00       1.02           1.00                1.00                0.00            1.00
+{s_suppkey}      32258.00       1.02           400.00              1.01                0.00            1.00
+
+stats table=q11_lookup_join_6
+----
+column_names   row_count  distinct_count  null_count
+{n_name}       31680      1               0
+{n_nationkey}  31680      1               0
+{ps_partkey}   31680      29669           0
+{ps_suppkey}   31680      396             0
+{s_nationkey}  31680      1               0
+{s_suppkey}    31680      396             0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}       32258.00       1.02           1.00                1.00                0.00            1.00
+{n_nationkey}  32258.00       1.02           1.00                1.00                0.00            1.00
+{ps_partkey}   32258.00       1.02           29783.00            1.00                0.00            1.00
+{ps_suppkey}   32258.00       1.02           400.00              1.01                0.00            1.00
+{s_nationkey}  32258.00       1.02           1.00                1.00                0.00            1.00
+{s_suppkey}    32258.00       1.02           400.00              1.01                0.00            1.00
+
+stats table=q11_lookup_join_7
+----
+column_names   row_count  distinct_count  null_count
+{n_name}       396        1               0
+{n_nationkey}  396        1               0
+{s_nationkey}  396        1               0
+{s_suppkey}    396        396             0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}       400.00         1.01           1.00                1.00                0.00            1.00
+{n_nationkey}  400.00         1.01           1.00                1.00                0.00            1.00
+{s_nationkey}  400.00         1.01           1.00                1.00                0.00            1.00
+{s_suppkey}    400.00         1.01           400.00              1.01                0.00            1.00
+
+stats table=q11_select_8
+----
+column_names   row_count  distinct_count  null_count
+{n_name}       1          1               0
+{n_nationkey}  1          1               0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}       1.00           1.00           1.00                1.00                0.00            1.00
+{n_nationkey}  1.00           1.00           1.00                1.00                0.00            1.00
+
+stats table=q11_scan_9
+----
+column_names   row_count  distinct_count  null_count
+{n_name}       25         25              0
+{n_nationkey}  25         25              0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}       25.00          1.00           25.00               1.00                0.00            1.00
+{n_nationkey}  25.00          1.00           25.00               1.00                0.00            1.00
+
+stats table=q11_project_10
+----
+column_names  row_count  distinct_count  null_count
+{?column?}    1          1               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{?column?}    1.00           1.00           1.00                1.00                0.00            1.00
+
+stats table=q11_scalar_group_by_11
+----
+column_names  row_count  distinct_count  null_count
+{sum}         1          1               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{sum}         1.00           1.00           1.00                1.00                0.00            1.00
+
+stats table=q11_project_12
+----
+column_names  row_count  distinct_count  null_count
+{column35}    31680      31888           0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{column35}    32258.00       1.02           32258.00            1.01                0.00            1.00
+
+stats table=q11_lookup_join_13
+----
+column_names     row_count  distinct_count  null_count
+{n_name}         31680      1               0
+{n_nationkey}    31680      1               0
+{ps_availqty}    31680      9556            0
+{ps_suppkey}     31680      396             0
+{ps_supplycost}  31680      27350           0
+{s_nationkey}    31680      1               0
+{s_suppkey}      31680      396             0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}         32258.00       1.02           1.00                1.00                0.00            1.00
+{n_nationkey}    32258.00       1.02           1.00                1.00                0.00            1.00
+{ps_availqty}    32258.00       1.02           9536.00             1.00                0.00            1.00
+{ps_suppkey}     32258.00       1.02           400.00              1.01                0.00            1.00
+{ps_supplycost}  32258.00       1.02           27589.00            1.01                0.00            1.00
+{s_nationkey}    32258.00       1.02           1.00                1.00                0.00            1.00
+{s_suppkey}      32258.00       1.02           400.00              1.01                0.00            1.00
+
+stats table=q11_lookup_join_14
+----
+column_names   row_count  distinct_count  null_count
+{n_name}       31680      1               0
+{n_nationkey}  31680      1               0
+{ps_partkey}   31680      29669           0
+{ps_suppkey}   31680      396             0
+{s_nationkey}  31680      1               0
+{s_suppkey}    31680      396             0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}       32258.00       1.02           1.00                1.00                0.00            1.00
+{n_nationkey}  32258.00       1.02           1.00                1.00                0.00            1.00
+{ps_partkey}   32258.00       1.02           29783.00            1.00                0.00            1.00
+{ps_suppkey}   32258.00       1.02           400.00              1.01                0.00            1.00
+{s_nationkey}  32258.00       1.02           1.00                1.00                0.00            1.00
+{s_suppkey}    32258.00       1.02           400.00              1.01                0.00            1.00
+
+stats table=q11_lookup_join_15
+----
+column_names   row_count  distinct_count  null_count
+{n_name}       396        1               0
+{n_nationkey}  396        1               0
+{s_nationkey}  396        1               0
+{s_suppkey}    396        396             0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}       400.00         1.01           1.00                1.00                0.00            1.00
+{n_nationkey}  400.00         1.01           1.00                1.00                0.00            1.00
+{s_nationkey}  400.00         1.01           1.00                1.00                0.00            1.00
+{s_suppkey}    400.00         1.01           400.00              1.01                0.00            1.00
+
+stats table=q11_select_16
+----
+column_names   row_count  distinct_count  null_count
+{n_name}       1          1               0
+{n_nationkey}  1          1               0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}       1.00           1.00           1.00                1.00                0.00            1.00
+{n_nationkey}  1.00           1.00           1.00                1.00                0.00            1.00
+
+stats table=q11_scan_17
+----
+column_names   row_count  distinct_count  null_count
+{n_name}       25         25              0
+{n_nationkey}  25         25              0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}       25.00          1.00           25.00               1.00                0.00            1.00
+{n_nationkey}  25.00          1.00           25.00               1.00                0.00            1.00
+
+# --------------------------------------------------
+# Q12
+# Shipping Modes and Order Priority
+# Determines whether selecting less expensive modes of shipping is negatively
+# affecting the critical-priority orders by causing more parts to be received by
+# customers after the committed date.
+#
+# Counts, by ship mode, for lineitems actually received by customers in a given
+# year, the number of lineitems belonging to orders for which the l_receiptdate
+# exceeds the l_commitdate for two different specified ship modes. Only
+# lineitems that were actually shipped before the l_commitdate are considered.
+# The late lineitems are partitioned into two groups, those with priority URGENT
+# or HIGH, and those with a priority other than URGENT or HIGH.
+# --------------------------------------------------
+save-tables database=tpch save-tables-prefix=q12
+SELECT
+    l_shipmode,
+    sum(CASE
+        WHEN o_orderpriority = '1-URGENT'
+            OR o_orderpriority = '2-HIGH'
+            THEN 1
+        ELSE 0
+    END) AS high_line_count,
+    sum(CASE
+        WHEN o_orderpriority <> '1-URGENT'
+            AND o_orderpriority <> '2-HIGH'
+            THEN 1
+        ELSE 0
+    END) AS low_line_count
+FROM
+    orders,
+    lineitem
+WHERE
+    o_orderkey = l_orderkey
+    AND l_shipmode IN ('MAIL', 'SHIP')
+    AND l_commitdate < l_receiptdate
+    AND l_shipdate < l_commitdate
+    AND l_receiptdate >= DATE '1994-01-01'
+    AND l_receiptdate < DATE '1994-01-01' + INTERVAL '1' YEAR
+GROUP BY
+    l_shipmode
+ORDER BY
+    l_shipmode;
+----
+sort
+ ├── save-table-name: q12_sort_1
+ ├── columns: l_shipmode:24(char!null) high_line_count:27(decimal) low_line_count:29(decimal)
+ ├── stats: [rows=2, distinct(24)=2, null(24)=0, distinct(27)=2, null(27)=0, distinct(29)=2, null(29)=0]
+ ├── key: (24)
+ ├── fd: (24)-->(27,29)
+ ├── ordering: +24
+ └── group-by
+      ├── save-table-name: q12_group_by_2
+      ├── columns: l_shipmode:24(char!null) sum:27(decimal) sum:29(decimal)
+      ├── grouping columns: l_shipmode:24(char!null)
+      ├── stats: [rows=2, distinct(24)=2, null(24)=0, distinct(27)=2, null(27)=0, distinct(29)=2, null(29)=0]
+      ├── key: (24)
+      ├── fd: (24)-->(27,29)
+      ├── project
+      │    ├── save-table-name: q12_project_3
+      │    ├── columns: column26:26(int) column28:28(int) l_shipmode:24(char!null)
+      │    ├── stats: [rows=21168.3069, distinct(24)=2, null(24)=0, distinct(26)=5, null(26)=0, distinct(28)=5, null(28)=0]
+      │    ├── inner-join (lookup orders)
+      │    │    ├── save-table-name: q12_lookup_join_4
+      │    │    ├── columns: o_orderkey:1(int!null) o_orderpriority:6(char!null) l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(char!null)
+      │    │    ├── key columns: [10] = [1]
+      │    │    ├── stats: [rows=21168.3069, distinct(1)=21059.1899, null(1)=0, distinct(6)=5, null(6)=0, distinct(10)=21059.1899, null(10)=0, distinct(20)=2524.85097, null(20)=0, distinct(21)=2465.08517, null(21)=0, distinct(22)=2552.72645, null(22)=0, distinct(24)=2, null(24)=0]
+      │    │    ├── fd: (1)-->(6), (1)==(10), (10)==(1)
+      │    │    ├── select
+      │    │    │    ├── save-table-name: q12_select_5
+      │    │    │    ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(char!null)
+      │    │    │    ├── stats: [rows=21168.3069, distinct(10)=21059.1899, null(10)=0, distinct(20)=2525.42913, null(20)=0, distinct(21)=2465.54565, null(21)=0, distinct(22)=2553.36716, null(22)=0, distinct(24)=2, null(24)=0]
+      │    │    │    ├── index-join lineitem
+      │    │    │    │    ├── save-table-name: q12_index_join_6
+      │    │    │    │    ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(char!null)
+      │    │    │    │    ├── stats: [rows=666801.667, distinct(10)=565838.316, null(10)=0, distinct(20)=2526, null(20)=0, distinct(21)=2466, null(21)=0, distinct(22)=2554, null(22)=0, distinct(24)=7, null(24)=0]
+      │    │    │    │    └── scan lineitem@l_rd
+      │    │    │    │         ├── save-table-name: q12_scan_7
+      │    │    │    │         ├── columns: l_orderkey:10(int!null) l_linenumber:13(int!null) l_receiptdate:22(date!null)
+      │    │    │    │         ├── constraint: /22/10/13: [/'1994-01-01' - /'1994-12-31']
+      │    │    │    │         ├── stats: [rows=666801.667, distinct(10)=565838.316, null(10)=0, distinct(13)=7, null(13)=0, distinct(22)=2554, null(22)=0]
+      │    │    │    │         ├── key: (10,13)
+      │    │    │    │         └── fd: (10,13)-->(22)
+      │    │    │    └── filters
+      │    │    │         ├── l_shipmode IN ('MAIL', 'SHIP') [type=bool, outer=(24), constraints=(/24: [/'MAIL' - /'MAIL'] [/'SHIP' - /'SHIP']; tight)]
+      │    │    │         ├── l_commitdate < l_receiptdate [type=bool, outer=(21,22), constraints=(/21: (/NULL - ]; /22: (/NULL - ])]
+      │    │    │         └── l_shipdate < l_commitdate [type=bool, outer=(20,21), constraints=(/20: (/NULL - ]; /21: (/NULL - ])]
+      │    │    └── filters (true)
+      │    └── projections
+      │         ├── CASE WHEN (o_orderpriority = '1-URGENT') OR (o_orderpriority = '2-HIGH') THEN 1 ELSE 0 END [type=int, outer=(6)]
+      │         └── CASE WHEN (o_orderpriority != '1-URGENT') AND (o_orderpriority != '2-HIGH') THEN 1 ELSE 0 END [type=int, outer=(6)]
+      └── aggregations
+           ├── sum [type=decimal, outer=(26)]
+           │    └── variable: column26 [type=int]
+           └── sum [type=decimal, outer=(28)]
+                └── variable: column28 [type=int]
+
+stats table=q12_sort_1
+----
+column_names       row_count  distinct_count  null_count
+{high_line_count}  2          2               0
+{l_shipmode}       2          2               0
+{low_line_count}   2          2               0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{high_line_count}  2.00           1.00           2.00                1.00                0.00            1.00
+{l_shipmode}       2.00           1.00           2.00                1.00                0.00            1.00
+{low_line_count}   2.00           1.00           2.00                1.00                0.00            1.00
+
+stats table=q12_group_by_2
+----
+column_names  row_count  distinct_count  null_count
+{l_shipmode}  2          2               0
+{sum_1}       2          2               0
+{sum}         2          2               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_shipmode}  2.00           1.00           2.00                1.00                0.00            1.00
+{sum}         2.00           1.00           2.00                1.00                0.00            1.00
+{sum_1}       2.00           1.00           2.00                1.00                0.00            1.00
+
+stats table=q12_project_3
+----
+column_names  row_count  distinct_count  null_count
+{column26}    30988      2               0
+{column28}    30988      2               0
+{l_shipmode}  30988      2               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{column26}    21168.00       1.46           5.00                2.50 <==            0.00            1.00
+{column28}    21168.00       1.46           5.00                2.50 <==            0.00            1.00
+{l_shipmode}  21168.00       1.46           2.00                1.00                0.00            1.00
+
+stats table=q12_lookup_join_4
+----
+column_names       row_count  distinct_count  null_count
+{l_commitdate}     30988      392             0
+{l_orderkey}       30988      28828           0
+{l_receiptdate}    30988      365             0
+{l_shipdate}       30988      391             0
+{l_shipmode}       30988      2               0
+{o_orderkey}       30988      28828           0
+{o_orderpriority}  30988      5               0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_commitdate}     21168.00       1.46           2465.00             6.29 <==            0.00            1.00
+{l_orderkey}       21168.00       1.46           21059.00            1.37                0.00            1.00
+{l_receiptdate}    21168.00       1.46           2553.00             6.99 <==            0.00            1.00
+{l_shipdate}       21168.00       1.46           2525.00             6.46 <==            0.00            1.00
+{l_shipmode}       21168.00       1.46           2.00                1.00                0.00            1.00
+{o_orderkey}       21168.00       1.46           21059.00            1.37                0.00            1.00
+{o_orderpriority}  21168.00       1.46           5.00                1.00                0.00            1.00
+
+stats table=q12_select_5
+----
+column_names     row_count  distinct_count  null_count
+{l_commitdate}   30988      392             0
+{l_orderkey}     30988      28828           0
+{l_receiptdate}  30988      365             0
+{l_shipdate}     30988      391             0
+{l_shipmode}     30988      2               0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_commitdate}   21168.00       1.46           2466.00             6.29 <==            0.00            1.00
+{l_orderkey}     21168.00       1.46           21059.00            1.37                0.00            1.00
+{l_receiptdate}  21168.00       1.46           2553.00             6.99 <==            0.00            1.00
+{l_shipdate}     21168.00       1.46           2525.00             6.46 <==            0.00            1.00
+{l_shipmode}     21168.00       1.46           2.00                1.00                0.00            1.00
+
+stats table=q12_index_join_6
+----
+column_names     row_count  distinct_count  null_count
+{l_commitdate}   909844     560             0
+{l_orderkey}     909844     267788          0
+{l_receiptdate}  909844     365             0
+{l_shipdate}     909844     394             0
+{l_shipmode}     909844     7               0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_commitdate}   666802.00      1.36           2466.00             4.40 <==            0.00            1.00
+{l_orderkey}     666802.00      1.36           565838.00           2.11 <==            0.00            1.00
+{l_receiptdate}  666802.00      1.36           2554.00             7.00 <==            0.00            1.00
+{l_shipdate}     666802.00      1.36           2526.00             6.41 <==            0.00            1.00
+{l_shipmode}     666802.00      1.36           7.00                1.00                0.00            1.00
+
+# --------------------------------------------------
+# Q13
+# Customer Distribution
+# Seeks relationships between customers and the size of their orders.
+#
+# Determines the distribution of customers by the number of orders they have
+# made, including customers who have no record of orders, past or present. It
+# counts and reports how many customers have no orders, how many have 1, 2, 3,
+# etc. A check is made to ensure that the orders counted do not fall into one of
+# several special categories of orders. Special categories are identified in the
+# order comment column by looking for a particular pattern.
+# --------------------------------------------------
+save-tables database=tpch save-tables-prefix=q13
+SELECT
+    c_count, count(*) AS custdist
+FROM (
+    SELECT
+        c_custkey,
+        count(o_orderkey)
+    FROM
+        customer LEFT OUTER JOIN orders ON
+            c_custkey = o_custkey
+            AND o_comment NOT LIKE '%special%requests%'
+    GROUP BY
+        c_custkey
+    ) AS c_orders (c_custkey, c_count)
+GROUP BY
+    c_count
+ORDER BY
+    custdist DESC,
+    c_count DESC;
+----
+sort
+ ├── save-table-name: q13_sort_1
+ ├── columns: c_count:18(int) custdist:19(int)
+ ├── stats: [rows=148813, distinct(18)=148813, null(18)=0, distinct(19)=148813, null(19)=0]
+ ├── key: (18)
+ ├── fd: (18)-->(19)
+ ├── ordering: -19,-18
+ └── group-by
+      ├── save-table-name: q13_group_by_2
+      ├── columns: count:18(int) count_rows:19(int)
+      ├── grouping columns: count:18(int)
+      ├── stats: [rows=148813, distinct(18)=148813, null(18)=0, distinct(19)=148813, null(19)=0]
+      ├── key: (18)
+      ├── fd: (18)-->(19)
+      ├── group-by
+      │    ├── save-table-name: q13_group_by_3
+      │    ├── columns: c_custkey:1(int!null) count:18(int)
+      │    ├── grouping columns: c_custkey:1(int!null)
+      │    ├── stats: [rows=148813, distinct(1)=148813, null(1)=0, distinct(18)=148813, null(18)=0]
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(18)
+      │    ├── right-join
+      │    │    ├── save-table-name: q13_right_join_4
+      │    │    ├── columns: c_custkey:1(int!null) o_orderkey:9(int) o_custkey:10(int) o_comment:17(varchar)
+      │    │    ├── stats: [rows=503988.227, distinct(1)=148813, null(1)=0, distinct(9)=317522.248, null(9)=0, distinct(10)=99620.1148, null(10)=0, distinct(17)=316996.293, null(17)=0]
+      │    │    ├── key: (1,9)
+      │    │    ├── fd: (9)-->(10,17)
+      │    │    ├── select
+      │    │    │    ├── save-table-name: q13_select_5
+      │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_comment:17(varchar!null)
+      │    │    │    ├── stats: [rows=500000, distinct(9)=500000, null(9)=0, distinct(10)=99620.1148, null(10)=0, distinct(17)=498036.796, null(17)=0]
+      │    │    │    ├── key: (9)
+      │    │    │    ├── fd: (9)-->(10,17)
+      │    │    │    ├── scan orders
+      │    │    │    │    ├── save-table-name: q13_scan_6
+      │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_comment:17(varchar!null)
+      │    │    │    │    ├── stats: [rows=1500000, distinct(9)=1500000, null(9)=0, distinct(10)=99846, null(10)=0, distinct(17)=1469402, null(17)=0]
+      │    │    │    │    ├── key: (9)
+      │    │    │    │    └── fd: (9)-->(10,17)
+      │    │    │    └── filters
+      │    │    │         └── o_comment NOT LIKE '%special%requests%' [type=bool, outer=(17), constraints=(/17: (/NULL - ])]
+      │    │    ├── scan customer@c_nk
+      │    │    │    ├── save-table-name: q13_scan_7
+      │    │    │    ├── columns: c_custkey:1(int!null)
+      │    │    │    ├── stats: [rows=150000, distinct(1)=148813, null(1)=0]
+      │    │    │    └── key: (1)
+      │    │    └── filters
+      │    │         └── c_custkey = o_custkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+      │    └── aggregations
+      │         └── count [type=int, outer=(9)]
+      │              └── variable: o_orderkey [type=int]
+      └── aggregations
+           └── count-rows [type=int]
+
+stats table=q13_sort_1
+----
+column_names  row_count  distinct_count  null_count
+{c_count}     42         42              0
+{custdist}    42         41              0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_count}     148813.00      3543.17 <==    148813.00           3543.17 <==         0.00            1.00
+{custdist}    148813.00      3543.17 <==    148813.00           3629.59 <==         0.00            1.00
+
+stats table=q13_group_by_2
+----
+column_names  row_count  distinct_count  null_count
+{count_rows}  42         41              0
+{count}       42         42              0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{count}       148813.00      3543.17 <==    148813.00           3543.17 <==         0.00            1.00
+{count_rows}  148813.00      3543.17 <==    148813.00           3629.59 <==         0.00            1.00
+
+stats table=q13_group_by_3
+----
+column_names  row_count  distinct_count  null_count
+{c_custkey}   150000     148813          0
+{count}       150000     42              0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_custkey}   148813.00      1.01           148813.00           1.00                0.00            1.00
+{count}       148813.00      1.01           148813.00           3543.17 <==         0.00            1.00
+
+stats table=q13_right_join_4
+----
+column_names  row_count  distinct_count  null_count
+{c_custkey}   1533923    148813          0
+{o_comment}   1533923    1454164         50005
+{o_custkey}   1533923    99846           50005
+{o_orderkey}  1533923    1511432         50005
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_custkey}   503988.00      3.04 <==       148813.00           1.00                0.00            1.00
+{o_comment}   503988.00      3.04 <==       316996.00           4.59 <==            0.00            +Inf <==
+{o_custkey}   503988.00      3.04 <==       99620.00            1.00                0.00            +Inf <==
+{o_orderkey}  503988.00      3.04 <==       317522.00           4.76 <==            0.00            +Inf <==
+
+stats table=q13_select_5
+----
+column_names  row_count  distinct_count  null_count
+{o_comment}   1483918    1454164         0
+{o_custkey}   1483918    99846           0
+{o_orderkey}  1483918    1511432         0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{o_comment}   500000.00      2.97 <==       498037.00           2.92 <==            0.00            1.00
+{o_custkey}   500000.00      2.97 <==       99620.00            1.00                0.00            1.00
+{o_orderkey}  500000.00      2.97 <==       500000.00           3.02 <==            0.00            1.00
+
+stats table=q13_scan_6
+----
+column_names  row_count  distinct_count  null_count
+{o_comment}   1500000    1469402         0
+{o_custkey}   1500000    99846           0
+{o_orderkey}  1500000    1527270         0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{o_comment}   1500000.00     1.00           1469402.00          1.00                0.00            1.00
+{o_custkey}   1500000.00     1.00           99846.00            1.00                0.00            1.00
+{o_orderkey}  1500000.00     1.00           1500000.00          1.02                0.00            1.00
+
+stats table=q13_scan_7
+----
+column_names  row_count  distinct_count  null_count
+{c_custkey}   150000     148813          0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_custkey}   150000.00      1.00           148813.00           1.00                0.00            1.00
+
+# --------------------------------------------------
+# Q14
+# Promotion Effect
+# Monitors the market response to a promotion such as TV advertisements or a
+# special campaign.
+#
+# Determines what percentage of the revenue in a given year and month was
+# derived from promotional parts. The query considers only parts actually
+# shipped in that month and gives the percentage. Revenue is defined as
+# (l_extendedprice * (1-l_discount)).
+# --------------------------------------------------
+save-tables database=tpch save-tables-prefix=q14
+SELECT
+    100.00 * sum(CASE
+        WHEN p_type LIKE 'PROMO%'
+            THEN l_extendedprice * (1 - l_discount)
+        ELSE 0
+    END) / sum(l_extendedprice * (1 - l_discount)) AS promo_revenue
+FROM
+    lineitem,
+    part
+WHERE
+    l_partkey = p_partkey
+    AND l_shipdate >= DATE '1995-09-01'
+    AND l_shipdate < DATE '1995-09-01' + INTERVAL '1' MONTH;
+----
+project
+ ├── save-table-name: q14_project_1
+ ├── columns: promo_revenue:30(float)
+ ├── cardinality: [1 - 1]
+ ├── side-effects
+ ├── stats: [rows=1, distinct(30)=1, null(30)=0]
+ ├── key: ()
+ ├── fd: ()-->(30)
+ ├── scalar-group-by
+ │    ├── save-table-name: q14_scalar_group_by_2
+ │    ├── columns: sum:27(float) sum:29(float)
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1, distinct(27)=1, null(27)=0, distinct(29)=1, null(29)=0, distinct(27,29)=1, null(27,29)=0]
+ │    ├── key: ()
+ │    ├── fd: ()-->(27,29)
+ │    ├── project
+ │    │    ├── save-table-name: q14_project_3
+ │    │    ├── columns: column26:26(float) column28:28(float)
+ │    │    ├── stats: [rows=669341.819, distinct(26)=669341.819, null(26)=0, distinct(28)=422432.35, null(28)=0]
+ │    │    ├── inner-join
+ │    │    │    ├── save-table-name: q14_inner_join_4
+ │    │    │    ├── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null) p_partkey:17(int!null) p_type:21(varchar!null)
+ │    │    │    ├── stats: [rows=669341.819, distinct(2)=193504.524, null(2)=0, distinct(6)=366712.957, null(6)=0, distinct(7)=11, null(7)=0, distinct(11)=2526, null(11)=0, distinct(17)=193504.524, null(17)=0, distinct(21)=150, null(21)=0, distinct(6,7)=422432.35, null(6,7)=0, distinct(6,7,21)=669341.819, null(6,7,21)=0]
+ │    │    │    ├── fd: (17)-->(21), (2)==(17), (17)==(2)
+ │    │    │    ├── index-join lineitem
+ │    │    │    │    ├── save-table-name: q14_index_join_5
+ │    │    │    │    ├── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
+ │    │    │    │    ├── stats: [rows=666801.667, distinct(2)=193504.524, null(2)=0, distinct(6)=494371.509, null(6)=0, distinct(7)=11, null(7)=0, distinct(11)=2526, null(11)=0, distinct(6,7)=666801.667, null(6,7)=0]
+ │    │    │    │    └── scan lineitem@l_sd
+ │    │    │    │         ├── save-table-name: q14_scan_6
+ │    │    │    │         ├── columns: l_orderkey:1(int!null) l_linenumber:4(int!null) l_shipdate:11(date!null)
+ │    │    │    │         ├── constraint: /11/1/4: [/'1995-09-01' - /'1995-09-30']
+ │    │    │    │         ├── stats: [rows=666801.667, distinct(1)=565838.316, null(1)=0, distinct(4)=7, null(4)=0, distinct(11)=2526, null(11)=0]
+ │    │    │    │         ├── key: (1,4)
+ │    │    │    │         └── fd: (1,4)-->(11)
+ │    │    │    ├── scan part
+ │    │    │    │    ├── save-table-name: q14_scan_7
+ │    │    │    │    ├── columns: p_partkey:17(int!null) p_type:21(varchar!null)
+ │    │    │    │    ├── stats: [rows=200000, distinct(17)=199241, null(17)=0, distinct(21)=150, null(21)=0]
+ │    │    │    │    ├── key: (17)
+ │    │    │    │    └── fd: (17)-->(21)
+ │    │    │    └── filters
+ │    │    │         └── l_partkey = p_partkey [type=bool, outer=(2,17), constraints=(/2: (/NULL - ]; /17: (/NULL - ]), fd=(2)==(17), (17)==(2)]
+ │    │    └── projections
+ │    │         ├── CASE WHEN p_type LIKE 'PROMO%' THEN l_extendedprice * (1.0 - l_discount) ELSE 0.0 END [type=float, outer=(6,7,21)]
+ │    │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(6,7)]
+ │    └── aggregations
+ │         ├── sum [type=float, outer=(26)]
+ │         │    └── variable: column26 [type=float]
+ │         └── sum [type=float, outer=(28)]
+ │              └── variable: column28 [type=float]
+ └── projections
+      └── (sum * 100.0) / sum [type=float, outer=(27,29), side-effects]
+
+stats table=q14_project_1
+----
+column_names     row_count  distinct_count  null_count
+{promo_revenue}  1          1               0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{promo_revenue}  1.00           1.00           1.00                1.00                0.00            1.00
+
+stats table=q14_scalar_group_by_2
+----
+column_names  row_count  distinct_count  null_count
+{sum_1}       1          1               0
+{sum}         1          1               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{sum}         1.00           1.00           1.00                1.00                0.00            1.00
+{sum_1}       1.00           1.00           1.00                1.00                0.00            1.00
+
+stats table=q14_project_3
+----
+column_names  row_count  distinct_count  null_count
+{column26}    75983      12638           0
+{column28}    75983      76207           0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{column26}    669342.00      8.81 <==       669342.00           52.96 <==           0.00            1.00
+{column28}    669342.00      8.81 <==       422432.00           5.54 <==            0.00            1.00
+
+stats table=q14_inner_join_4
+----
+column_names       row_count  distinct_count  null_count
+{l_discount}       75983      11              0
+{l_extendedprice}  75983      72627           0
+{l_partkey}        75983      63035           0
+{l_shipdate}       75983      30              0
+{p_partkey}        75983      63035           0
+{p_type}           75983      150             0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_discount}       669342.00      8.81 <==       11.00               1.00                0.00            1.00
+{l_extendedprice}  669342.00      8.81 <==       366713.00           5.05 <==            0.00            1.00
+{l_partkey}        669342.00      8.81 <==       193505.00           3.07 <==            0.00            1.00
+{l_shipdate}       669342.00      8.81 <==       2526.00             84.20 <==           0.00            1.00
+{p_partkey}        669342.00      8.81 <==       193505.00           3.07 <==            0.00            1.00
+{p_type}           669342.00      8.81 <==       150.00              1.00                0.00            1.00
+
+stats table=q14_index_join_5
+----
+column_names       row_count  distinct_count  null_count
+{l_discount}       75983      11              0
+{l_extendedprice}  75983      72627           0
+{l_partkey}        75983      63035           0
+{l_shipdate}       75983      30              0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_discount}       666802.00      8.78 <==       11.00               1.00                0.00            1.00
+{l_extendedprice}  666802.00      8.78 <==       494372.00           6.81 <==            0.00            1.00
+{l_partkey}        666802.00      8.78 <==       193505.00           3.07 <==            0.00            1.00
+{l_shipdate}       666802.00      8.78 <==       2526.00             84.20 <==           0.00            1.00
+
+stats table=q14_scan_7
+----
+column_names  row_count  distinct_count  null_count
+{p_partkey}   200000     199241          0
+{p_type}      200000     150             0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{p_partkey}   200000.00      1.00           199241.00           1.00                0.00            1.00
+{p_type}      200000.00      1.00           150.00              1.00                0.00            1.00
+
+# --------------------------------------------------
+# Q15
+# Top Supplier
+# Determines the top supplier so it can be rewarded, given more business, or
+# identified for special recognition.
+#
+# Finds the supplier who contributed the most to the overall revenue for parts
+# shipped during a given quarter of a given year. In case of a tie, the query
+# lists all suppliers whose contribution was equal to the maximum, presented in
+# supplier number order.
+# --------------------------------------------------
+exec-ddl
+CREATE VIEW revenue0 (supplier_no, total_revenue) AS
+    SELECT
+        l_suppkey,
+        sum(l_extendedprice * (1 - l_discount))
+    FROM
+        lineitem
+    WHERE
+        l_shipdate >= DATE '1996-01-01'
+        AND l_shipdate < DATE '1996-01-01' + INTERVAL '3' MONTH
+    GROUP BY
+        l_suppkey;
+----
+VIEW revenue0 (supplier_no, total_revenue)
+ └── SELECT l_suppkey, sum(l_extendedprice * (1 - l_discount)) FROM lineitem WHERE (l_shipdate >= DATE '1996-01-01') AND (l_shipdate < (DATE '1996-01-01' + '3 mons':::INTERVAL)) GROUP BY l_suppkey
+
+save-tables database=tpch save-tables-prefix=q15
+SELECT
+    s_suppkey,
+    s_name,
+    s_address,
+    s_phone,
+    total_revenue
+FROM
+    supplier,
+    revenue0
+WHERE
+    s_suppkey = supplier_no
+    AND total_revenue = (
+        SELECT
+            max(total_revenue)
+        FROM
+            revenue0
+    )
+ORDER BY
+    s_suppkey;
+----
+project
+ ├── save-table-name: q15_project_1
+ ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_phone:5(char!null) total_revenue:25(float!null)
+ ├── stats: [rows=3333.33333, distinct(1)=3306.66667, null(1)=0, distinct(2)=2834.3606, null(2)=0, distinct(3)=2834.80729, null(3)=0, distinct(5)=2834.80729, null(5)=0, distinct(25)=2100.04396, null(25)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2,3,5,25)
+ ├── ordering: +1
+ └── inner-join (merge)
+      ├── save-table-name: q15_merge_join_2
+      ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_phone:5(char!null) l_suppkey:10(int!null) sum:25(float!null)
+      ├── left ordering: +1
+      ├── right ordering: +10
+      ├── stats: [rows=3333.33333, distinct(1)=3306.66667, null(1)=0, distinct(2)=2834.3606, null(2)=0, distinct(3)=2834.80729, null(3)=0, distinct(5)=2834.80729, null(5)=0, distinct(10)=3306.66667, null(10)=0, distinct(25)=2100.04396, null(25)=0]
+      ├── key: (10)
+      ├── fd: (1)-->(2,3,5), (10)-->(25), (1)==(10), (10)==(1)
+      ├── ordering: +(1|10) [actual: +1]
+      ├── scan supplier
+      │    ├── save-table-name: q15_scan_3
+      │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_phone:5(char!null)
+      │    ├── stats: [rows=10000, distinct(1)=9920, null(1)=0, distinct(2)=9990, null(2)=0, distinct(3)=10000, null(3)=0, distinct(5)=10000, null(5)=0]
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2,3,5)
+      │    └── ordering: +1
+      ├── sort
+      │    ├── save-table-name: q15_sort_4
+      │    ├── columns: l_suppkey:10(int!null) sum:25(float!null)
+      │    ├── stats: [rows=3306.66667, distinct(10)=3306.66667, null(10)=0, distinct(25)=3306.66667, null(25)=0]
+      │    ├── key: (10)
+      │    ├── fd: (10)-->(25)
+      │    ├── ordering: +10
+      │    └── select
+      │         ├── save-table-name: q15_select_5
+      │         ├── columns: l_suppkey:10(int!null) sum:25(float!null)
+      │         ├── stats: [rows=3306.66667, distinct(10)=3306.66667, null(10)=0, distinct(25)=3306.66667, null(25)=0]
+      │         ├── key: (10)
+      │         ├── fd: (10)-->(25)
+      │         ├── group-by
+      │         │    ├── save-table-name: q15_group_by_6
+      │         │    ├── columns: l_suppkey:10(int!null) sum:25(float)
+      │         │    ├── grouping columns: l_suppkey:10(int!null)
+      │         │    ├── stats: [rows=9920, distinct(10)=9920, null(10)=0, distinct(25)=9920, null(25)=0]
+      │         │    ├── key: (10)
+      │         │    ├── fd: (10)-->(25)
+      │         │    ├── project
+      │         │    │    ├── save-table-name: q15_project_7
+      │         │    │    ├── columns: column24:24(float) l_suppkey:10(int!null)
+      │         │    │    ├── stats: [rows=666801.667, distinct(10)=9920, null(10)=0, distinct(24)=666801.667, null(24)=0]
+      │         │    │    ├── index-join lineitem
+      │         │    │    │    ├── save-table-name: q15_index_join_8
+      │         │    │    │    ├── columns: l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null)
+      │         │    │    │    ├── stats: [rows=666801.667, distinct(10)=9920, null(10)=0, distinct(13)=494371.509, null(13)=0, distinct(14)=11, null(14)=0, distinct(18)=2526, null(18)=0, distinct(13,14)=666801.667, null(13,14)=0]
+      │         │    │    │    └── scan lineitem@l_sd
+      │         │    │    │         ├── save-table-name: q15_scan_9
+      │         │    │    │         ├── columns: l_orderkey:8(int!null) l_linenumber:11(int!null) l_shipdate:18(date!null)
+      │         │    │    │         ├── constraint: /18/8/11: [/'1996-01-01' - /'1996-03-31']
+      │         │    │    │         ├── stats: [rows=666801.667, distinct(8)=565838.316, null(8)=0, distinct(11)=7, null(11)=0, distinct(18)=2526, null(18)=0]
+      │         │    │    │         ├── key: (8,11)
+      │         │    │    │         └── fd: (8,11)-->(18)
+      │         │    │    └── projections
+      │         │    │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(13,14)]
+      │         │    └── aggregations
+      │         │         └── sum [type=float, outer=(24)]
+      │         │              └── variable: column24 [type=float]
+      │         └── filters
+      │              └── eq [type=bool, outer=(25), subquery, constraints=(/25: (/NULL - ])]
+      │                   ├── variable: sum [type=float]
+      │                   └── subquery [type=float]
+      │                        └── scalar-group-by
+      │                             ├── save-table-name: q15_scalar_group_by_10
+      │                             ├── columns: max:44(float)
+      │                             ├── cardinality: [1 - 1]
+      │                             ├── stats: [rows=1, distinct(44)=1, null(44)=0]
+      │                             ├── key: ()
+      │                             ├── fd: ()-->(44)
+      │                             ├── group-by
+      │                             │    ├── save-table-name: q15_group_by_11
+      │                             │    ├── columns: l_suppkey:28(int!null) sum:43(float)
+      │                             │    ├── grouping columns: l_suppkey:28(int!null)
+      │                             │    ├── stats: [rows=9920, distinct(28)=9920, null(28)=0, distinct(43)=9920, null(43)=0]
+      │                             │    ├── key: (28)
+      │                             │    ├── fd: (28)-->(43)
+      │                             │    ├── project
+      │                             │    │    ├── save-table-name: q15_project_12
+      │                             │    │    ├── columns: column42:42(float) l_suppkey:28(int!null)
+      │                             │    │    ├── stats: [rows=666801.667, distinct(28)=9920, null(28)=0, distinct(42)=666801.667, null(42)=0]
+      │                             │    │    ├── index-join lineitem
+      │                             │    │    │    ├── save-table-name: q15_index_join_13
+      │                             │    │    │    ├── columns: l_suppkey:28(int!null) l_extendedprice:31(float!null) l_discount:32(float!null) l_shipdate:36(date!null)
+      │                             │    │    │    ├── stats: [rows=666801.667, distinct(28)=9920, null(28)=0, distinct(31)=494371.509, null(31)=0, distinct(32)=11, null(32)=0, distinct(36)=2526, null(36)=0, distinct(31,32)=666801.667, null(31,32)=0]
+      │                             │    │    │    └── scan lineitem@l_sd
+      │                             │    │    │         ├── save-table-name: q15_scan_14
+      │                             │    │    │         ├── columns: l_orderkey:26(int!null) l_linenumber:29(int!null) l_shipdate:36(date!null)
+      │                             │    │    │         ├── constraint: /36/26/29: [/'1996-01-01' - /'1996-03-31']
+      │                             │    │    │         ├── stats: [rows=666801.667, distinct(26)=565838.316, null(26)=0, distinct(29)=7, null(29)=0, distinct(36)=2526, null(36)=0]
+      │                             │    │    │         ├── key: (26,29)
+      │                             │    │    │         └── fd: (26,29)-->(36)
+      │                             │    │    └── projections
+      │                             │    │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(31,32)]
+      │                             │    └── aggregations
+      │                             │         └── sum [type=float, outer=(42)]
+      │                             │              └── variable: column42 [type=float]
+      │                             └── aggregations
+      │                                  └── max [type=float, outer=(43)]
+      │                                       └── variable: sum [type=float]
+      └── filters (true)
+
+stats table=q15_project_1
+----
+column_names     row_count  distinct_count  null_count
+{s_address}      1          1               0
+{s_name}         1          1               0
+{s_phone}        1          1               0
+{s_suppkey}      1          1               0
+{total_revenue}  1          1               0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{s_address}      3333.00        3333.00 <==    2835.00             2835.00 <==         0.00            1.00
+{s_name}         3333.00        3333.00 <==    2834.00             2834.00 <==         0.00            1.00
+{s_phone}        3333.00        3333.00 <==    2835.00             2835.00 <==         0.00            1.00
+{s_suppkey}      3333.00        3333.00 <==    3307.00             3307.00 <==         0.00            1.00
+{total_revenue}  3333.00        3333.00 <==    2100.00             2100.00 <==         0.00            1.00
+
+stats table=q15_merge_join_2
+----
+column_names  row_count  distinct_count  null_count
+{l_suppkey}   1          1               0
+{s_address}   1          1               0
+{s_name}      1          1               0
+{s_phone}     1          1               0
+{s_suppkey}   1          1               0
+{sum}         1          1               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_suppkey}   3333.00        3333.00 <==    3307.00             3307.00 <==         0.00            1.00
+{s_address}   3333.00        3333.00 <==    2835.00             2835.00 <==         0.00            1.00
+{s_name}      3333.00        3333.00 <==    2834.00             2834.00 <==         0.00            1.00
+{s_phone}     3333.00        3333.00 <==    2835.00             2835.00 <==         0.00            1.00
+{s_suppkey}   3333.00        3333.00 <==    3307.00             3307.00 <==         0.00            1.00
+{sum}         3333.00        3333.00 <==    2100.00             2100.00 <==         0.00            1.00
+
+stats table=q15_scan_3
+----
+column_names  row_count  distinct_count  null_count
+{s_address}   10000      10027           0
+{s_name}      10000      9990            0
+{s_phone}     10000      10021           0
+{s_suppkey}   10000      9920            0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{s_address}   10000.00       1.00           10000.00            1.00                0.00            1.00
+{s_name}      10000.00       1.00           9990.00             1.00                0.00            1.00
+{s_phone}     10000.00       1.00           10000.00            1.00                0.00            1.00
+{s_suppkey}   10000.00       1.00           9920.00             1.00                0.00            1.00
+
+stats table=q15_sort_4
+----
+column_names  row_count  distinct_count  null_count
+{l_suppkey}   1          1               0
+{sum}         1          1               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_suppkey}   3307.00        3307.00 <==    3307.00             3307.00 <==         0.00            1.00
+{sum}         3307.00        3307.00 <==    3307.00             3307.00 <==         0.00            1.00
+
+stats table=q15_select_5
+----
+column_names  row_count  distinct_count  null_count
+{l_suppkey}   1          1               0
+{sum}         1          1               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_suppkey}   3307.00        3307.00 <==    3307.00             3307.00 <==         0.00            1.00
+{sum}         3307.00        3307.00 <==    3307.00             3307.00 <==         0.00            1.00
+
+stats table=q15_group_by_6
+----
+column_names  row_count  distinct_count  null_count
+{l_suppkey}   10000      9920            0
+{sum}         10000      10011           0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_suppkey}   9920.00        1.01           9920.00             1.00                0.00            1.00
+{sum}         9920.00        1.01           9920.00             1.01                0.00            1.00
+
+stats table=q15_project_7
+----
+column_names  row_count  distinct_count  null_count
+{column24}    225954     220864          0
+{l_suppkey}   225954     9920            0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{column24}    666802.00      2.95 <==       666802.00           3.02 <==            0.00            1.00
+{l_suppkey}   666802.00      2.95 <==       9920.00             1.00                0.00            1.00
+
+stats table=q15_index_join_8
+----
+column_names       row_count  distinct_count  null_count
+{l_discount}       225954     11              0
+{l_extendedprice}  225954     196692          0
+{l_shipdate}       225954     91              0
+{l_suppkey}        225954     9920            0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_discount}       666802.00      2.95 <==       11.00               1.00                0.00            1.00
+{l_extendedprice}  666802.00      2.95 <==       494372.00           2.51 <==            0.00            1.00
+{l_shipdate}       666802.00      2.95 <==       2526.00             27.76 <==           0.00            1.00
+{l_suppkey}        666802.00      2.95 <==       9920.00             1.00                0.00            1.00
+
+stats table=q15_scalar_group_by_10
+----
+column_names  row_count  distinct_count  null_count
+{max}         1          1               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{max}         1.00           1.00           1.00                1.00                0.00            1.00
+
+stats table=q15_group_by_11
+----
+column_names  row_count  distinct_count  null_count
+{l_suppkey}   10000      9920            0
+{sum}         10000      10011           0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_suppkey}   9920.00        1.01           9920.00             1.00                0.00            1.00
+{sum}         9920.00        1.01           9920.00             1.01                0.00            1.00
+
+stats table=q15_project_12
+----
+column_names  row_count  distinct_count  null_count
+{column42}    225954     220864          0
+{l_suppkey}   225954     9920            0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{column42}    666802.00      2.95 <==       666802.00           3.02 <==            0.00            1.00
+{l_suppkey}   666802.00      2.95 <==       9920.00             1.00                0.00            1.00
+
+stats table=q15_index_join_13
+----
+column_names       row_count  distinct_count  null_count
+{l_discount}       225954     11              0
+{l_extendedprice}  225954     196692          0
+{l_shipdate}       225954     91              0
+{l_suppkey}        225954     9920            0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_discount}       666802.00      2.95 <==       11.00               1.00                0.00            1.00
+{l_extendedprice}  666802.00      2.95 <==       494372.00           2.51 <==            0.00            1.00
+{l_shipdate}       666802.00      2.95 <==       2526.00             27.76 <==           0.00            1.00
+{l_suppkey}        666802.00      2.95 <==       9920.00             1.00                0.00            1.00
+
+# --------------------------------------------------
+# Q16
+# Parts/Supplier Relationship
+# Finds out how many suppliers can supply parts with given attributes. It might
+# be used, for example, to determine whether there is a sufficient number of
+# suppliers for heavily ordered parts.
+#
+# Counts the number of suppliers who can supply parts that satisfy a particular
+# customer's requirements. The customer is interested in parts of eight
+# different sizes as long as they are not of a given type, not of a given brand,
+# and not from a supplier who has had complaints registered at the Better
+# Business Bureau. Results must be presented in descending count and ascending
+# brand, type, and size.
+# --------------------------------------------------
+save-tables database=tpch save-tables-prefix=q16
+SELECT
+    p_brand,
+    p_type,
+    p_size,
+    count(DISTINCT ps_suppkey) AS supplier_cnt
+FROM
+    partsupp,
+    part
+WHERE
+    p_partkey = ps_partkey
+    AND p_brand <> 'Brand#45'
+    AND p_type NOT LIKE 'MEDIUM POLISHED %'
+    AND p_size IN (49, 14, 23, 45, 19, 3, 36, 9)
+    AND ps_suppkey NOT IN (
+        SELECT
+            s_suppkey
+        FROM
+            supplier
+        WHERE
+            s_comment LIKE '%Customer%Complaints%'
+    )
+GROUP BY
+    p_brand,
+    p_type,
+    p_size
+ORDER BY
+    supplier_cnt DESC,
+    p_brand,
+    p_type,
+    p_size;
+----
+sort
+ ├── save-table-name: q16_sort_1
+ ├── columns: p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null) supplier_cnt:22(int)
+ ├── stats: [rows=3489.49147, distinct(9)=25, null(9)=0, distinct(10)=150, null(10)=0, distinct(11)=8, null(11)=0, distinct(22)=3489.49147, null(22)=0, distinct(9-11)=3489.49147, null(9-11)=0]
+ ├── key: (9-11)
+ ├── fd: (9-11)-->(22)
+ ├── ordering: -22,+9,+10,+11
+ └── group-by
+      ├── save-table-name: q16_group_by_2
+      ├── columns: p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null) count:22(int)
+      ├── grouping columns: p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null)
+      ├── stats: [rows=3489.49147, distinct(9)=25, null(9)=0, distinct(10)=150, null(10)=0, distinct(11)=8, null(11)=0, distinct(22)=3489.49147, null(22)=0, distinct(9-11)=3489.49147, null(9-11)=0]
+      ├── key: (9-11)
+      ├── fd: (9-11)-->(22)
+      ├── inner-join
+      │    ├── save-table-name: q16_inner_join_3
+      │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null) p_partkey:6(int!null) p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null)
+      │    ├── stats: [rows=14276.4012, distinct(1)=3555.43444, null(1)=0, distinct(2)=7567.69437, null(2)=0, distinct(6)=3555.43444, null(6)=0, distinct(9)=25, null(9)=0, distinct(10)=150, null(10)=0, distinct(11)=8, null(11)=0, distinct(9-11)=3489.49147, null(9-11)=0]
+      │    ├── key: (2,6)
+      │    ├── fd: (6)-->(9-11), (1)==(6), (6)==(1)
+      │    ├── anti-join (merge)
+      │    │    ├── save-table-name: q16_merge_join_4
+      │    │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null)
+      │    │    ├── left ordering: +2
+      │    │    ├── right ordering: +15
+      │    │    ├── stats: [rows=800000, distinct(1)=199241, null(1)=0, distinct(2)=9920, null(2)=0]
+      │    │    ├── key: (1,2)
+      │    │    ├── scan partsupp@ps_sk
+      │    │    │    ├── save-table-name: q16_scan_5
+      │    │    │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null)
+      │    │    │    ├── stats: [rows=800000, distinct(1)=199241, null(1)=0, distinct(2)=9920, null(2)=0]
+      │    │    │    ├── key: (1,2)
+      │    │    │    └── ordering: +2
+      │    │    ├── select
+      │    │    │    ├── save-table-name: q16_select_6
+      │    │    │    ├── columns: s_suppkey:15(int!null) s_comment:21(varchar!null)
+      │    │    │    ├── stats: [rows=3333.33333, distinct(15)=3328.25616, null(15)=0, distinct(21)=3329.14979, null(21)=0]
+      │    │    │    ├── key: (15)
+      │    │    │    ├── fd: (15)-->(21)
+      │    │    │    ├── ordering: +15
+      │    │    │    ├── scan supplier
+      │    │    │    │    ├── save-table-name: q16_scan_7
+      │    │    │    │    ├── columns: s_suppkey:15(int!null) s_comment:21(varchar!null)
+      │    │    │    │    ├── stats: [rows=10000, distinct(15)=9920, null(15)=0, distinct(21)=9934, null(21)=0]
+      │    │    │    │    ├── key: (15)
+      │    │    │    │    ├── fd: (15)-->(21)
+      │    │    │    │    └── ordering: +15
+      │    │    │    └── filters
+      │    │    │         └── s_comment LIKE '%Customer%Complaints%' [type=bool, outer=(21), constraints=(/21: (/NULL - ])]
+      │    │    └── filters (true)
+      │    ├── select
+      │    │    ├── save-table-name: q16_select_8
+      │    │    ├── columns: p_partkey:6(int!null) p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null)
+      │    │    ├── stats: [rows=3555.55556, distinct(6)=3555.43444, null(6)=0, distinct(9)=25, null(9)=0, distinct(10)=150, null(10)=0, distinct(11)=8, null(11)=0, distinct(9-11)=3553.4368, null(9-11)=0]
+      │    │    ├── key: (6)
+      │    │    ├── fd: (6)-->(9-11)
+      │    │    ├── scan part
+      │    │    │    ├── save-table-name: q16_scan_9
+      │    │    │    ├── columns: p_partkey:6(int!null) p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null)
+      │    │    │    ├── stats: [rows=200000, distinct(6)=199241, null(6)=0, distinct(9)=25, null(9)=0, distinct(10)=150, null(10)=0, distinct(11)=50, null(11)=0, distinct(9-11)=187500, null(9-11)=0]
+      │    │    │    ├── key: (6)
+      │    │    │    └── fd: (6)-->(9-11)
+      │    │    └── filters
+      │    │         ├── p_brand != 'Brand#45' [type=bool, outer=(9), constraints=(/9: (/NULL - /'Brand#45') [/e'Brand#45\x00' - ]; tight)]
+      │    │         ├── p_type NOT LIKE 'MEDIUM POLISHED %' [type=bool, outer=(10), constraints=(/10: (/NULL - ])]
+      │    │         └── p_size IN (3, 9, 14, 19, 23, 36, 45, 49) [type=bool, outer=(11), constraints=(/11: [/3 - /3] [/9 - /9] [/14 - /14] [/19 - /19] [/23 - /23] [/36 - /36] [/45 - /45] [/49 - /49]; tight)]
+      │    └── filters
+      │         └── p_partkey = ps_partkey [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+      └── aggregations
+           └── count [type=int, outer=(2)]
+                └── agg-distinct [type=int]
+                     └── variable: ps_suppkey [type=int]
+
+stats table=q16_sort_1
+----
+column_names    row_count  distinct_count  null_count
+{p_brand}       18314      24              0
+{p_size}        18314      8               0
+{p_type}        18314      145             0
+{supplier_cnt}  18314      15              0
+~~~~
+column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{p_brand}       3489.00        5.25 <==       25.00               1.04                0.00            1.00
+{p_size}        3489.00        5.25 <==       8.00                1.00                0.00            1.00
+{p_type}        3489.00        5.25 <==       150.00              1.03                0.00            1.00
+{supplier_cnt}  3489.00        5.25 <==       3489.00             232.60 <==          0.00            1.00
+
+stats table=q16_group_by_2
+----
+column_names    row_count  distinct_count  null_count
+{p_brand}       18314      24              0
+{p_size}        18314      8               0
+{p_type}        18314      145             0
+{count}         18314      15              0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{count}       3489.00        5.25 <==       3489.00             232.60 <==          0.00            1.00
+{p_brand}     3489.00        5.25 <==       25.00               1.04                0.00            1.00
+{p_size}      3489.00        5.25 <==       8.00                1.00                0.00            1.00
+{p_type}      3489.00        5.25 <==       150.00              1.03                0.00            1.00
+
+stats table=q16_inner_join_3
+----
+column_names  row_count  distinct_count  null_count
+{p_brand}     118274     24              0
+{p_partkey}   118274     29433           0
+{p_size}      118274     8               0
+{p_type}      118274     145             0
+{ps_partkey}  118274     29433           0
+{ps_suppkey}  118274     9916            0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{p_brand}     14276.00       8.28 <==       25.00               1.04                0.00            1.00
+{p_partkey}   14276.00       8.28 <==       3555.00             8.28 <==            0.00            1.00
+{p_size}      14276.00       8.28 <==       8.00                1.00                0.00            1.00
+{p_type}      14276.00       8.28 <==       150.00              1.03                0.00            1.00
+{ps_partkey}  14276.00       8.28 <==       3555.00             8.28 <==            0.00            1.00
+{ps_suppkey}  14276.00       8.28 <==       7568.00             1.31                0.00            1.00
+
+stats table=q16_merge_join_4
+----
+column_names  row_count  distinct_count  null_count
+{ps_partkey}  799680     199241          0
+{ps_suppkey}  799680     9916            0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{ps_partkey}  800000.00      1.00           199241.00           1.00                0.00            1.00
+{ps_suppkey}  800000.00      1.00           9920.00             1.00                0.00            1.00
+
+stats table=q16_scan_5
+----
+column_names  row_count  distinct_count  null_count
+{ps_partkey}  800000     199241          0
+{ps_suppkey}  800000     9920            0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{ps_partkey}  800000.00      1.00           199241.00           1.00                0.00            1.00
+{ps_suppkey}  800000.00      1.00           9920.00             1.00                0.00            1.00
+
+stats table=q16_select_6
+----
+column_names  row_count  distinct_count  null_count
+{s_comment}   4          4               0
+{s_suppkey}   4          4               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{s_comment}   3333.00        833.25 <==     3329.00             832.25 <==          0.00            1.00
+{s_suppkey}   3333.00        833.25 <==     3328.00             832.00 <==          0.00            1.00
+
+stats table=q16_scan_7
+----
+column_names  row_count  distinct_count  null_count
+{s_comment}   10000      9934            0
+{s_suppkey}   10000      9920            0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{s_comment}   10000.00       1.00           9934.00             1.00                0.00            1.00
+{s_suppkey}   10000.00       1.00           9920.00             1.00                0.00            1.00
+
+stats table=q16_select_8
+----
+column_names  row_count  distinct_count  null_count
+{p_brand}     29581      24              0
+{p_partkey}   29581      29433           0
+{p_size}      29581      8               0
+{p_type}      29581      145             0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{p_brand}     3556.00        8.32 <==       25.00               1.04                0.00            1.00
+{p_partkey}   3556.00        8.32 <==       3555.00             8.28 <==            0.00            1.00
+{p_size}      3556.00        8.32 <==       8.00                1.00                0.00            1.00
+{p_type}      3556.00        8.32 <==       150.00              1.03                0.00            1.00
+
+stats table=q16_scan_9
+----
+column_names  row_count  distinct_count  null_count
+{p_brand}     200000     25              0
+{p_partkey}   200000     199241          0
+{p_size}      200000     50              0
+{p_type}      200000     150             0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{p_brand}     200000.00      1.00           25.00               1.00                0.00            1.00
+{p_partkey}   200000.00      1.00           199241.00           1.00                0.00            1.00
+{p_size}      200000.00      1.00           50.00               1.00                0.00            1.00
+{p_type}      200000.00      1.00           150.00              1.00                0.00            1.00
+
+# --------------------------------------------------
+# Q17
+# Small-Quantity-Order Revenue
+# Determines how much average yearly revenue would be lost if orders were no
+# longer filled for small quantities of certain parts. This may reduce overhead
+# expenses by concentrating sales on larger shipments.
+#
+# Considers parts of a given brand and with a given container type and
+# determines the average lineitem quantity of such parts ordered for all orders
+# (past and pending) in the 7-year database. What would be the average yearly
+# gross (undiscounted) loss in revenue if orders for these parts with a quantity
+# of less than 20% of this average were no longer taken?
+#
+# TODO:
+#   1. Allow Select to be pushed below Ordinality used to add key column
+# --------------------------------------------------
+save-tables database=tpch save-tables-prefix=q17
+SELECT
+    sum(l_extendedprice) / 7.0 AS avg_yearly
+FROM
+    lineitem,
+    part
+WHERE
+    p_partkey = l_partkey
+    AND p_brand = 'Brand#23'
+    AND p_container = 'MED BOX'
+    AND l_quantity < (
+        SELECT
+            0.2 * avg(l_quantity)
+        FROM
+            lineitem
+        WHERE
+            l_partkey = p_partkey
+    );
+----
+project
+ ├── save-table-name: q17_project_1
+ ├── columns: avg_yearly:45(float)
+ ├── cardinality: [1 - 1]
+ ├── side-effects
+ ├── stats: [rows=1, distinct(45)=1, null(45)=0]
+ ├── key: ()
+ ├── fd: ()-->(45)
+ ├── scalar-group-by
+ │    ├── save-table-name: q17_scalar_group_by_2
+ │    ├── columns: sum:44(float)
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1, distinct(44)=1, null(44)=0]
+ │    ├── key: ()
+ │    ├── fd: ()-->(44)
+ │    ├── inner-join (lookup lineitem)
+ │    │    ├── save-table-name: q17_lookup_join_3
+ │    │    ├── columns: l_partkey:2(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) p_partkey:17(int!null) "?column?":43(float!null)
+ │    │    ├── key columns: [1 4] = [1 4]
+ │    │    ├── stats: [rows=2008.02163, distinct(2)=199.999619, null(2)=0, distinct(5)=50, null(5)=0, distinct(6)=2005.84759, null(6)=0, distinct(17)=199.999619, null(17)=0, distinct(43)=199.990896, null(43)=0]
+ │    │    ├── fd: (17)-->(43), (2)==(17), (17)==(2)
+ │    │    ├── inner-join (lookup lineitem@l_pk)
+ │    │    │    ├── save-table-name: q17_lookup_join_4
+ │    │    │    ├── columns: l_orderkey:1(int!null) l_partkey:2(int!null) l_linenumber:4(int!null) p_partkey:17(int!null) "?column?":43(float)
+ │    │    │    ├── key columns: [17] = [2]
+ │    │    │    ├── stats: [rows=6024.06489, distinct(1)=6012.21509, null(1)=0, distinct(2)=199.999619, null(2)=0, distinct(4)=7, null(4)=0, distinct(17)=199.999619, null(17)=0, distinct(43)=199.999619, null(43)=0]
+ │    │    │    ├── key: (1,4)
+ │    │    │    ├── fd: (17)-->(43), (1,4)-->(2), (2)==(17), (17)==(2)
+ │    │    │    ├── project
+ │    │    │    │    ├── save-table-name: q17_project_5
+ │    │    │    │    ├── columns: "?column?":43(float) p_partkey:17(int!null)
+ │    │    │    │    ├── stats: [rows=199.999619, distinct(17)=199.999619, null(17)=0, distinct(43)=199.999619, null(43)=0]
+ │    │    │    │    ├── key: (17)
+ │    │    │    │    ├── fd: (17)-->(43)
+ │    │    │    │    ├── group-by
+ │    │    │    │    │    ├── save-table-name: q17_group_by_6
+ │    │    │    │    │    ├── columns: p_partkey:17(int!null) avg:42(float)
+ │    │    │    │    │    ├── grouping columns: p_partkey:17(int!null)
+ │    │    │    │    │    ├── internal-ordering: +17 opt(20,23)
+ │    │    │    │    │    ├── stats: [rows=199.999619, distinct(17)=199.999619, null(17)=0, distinct(42)=199.999619, null(42)=0]
+ │    │    │    │    │    ├── key: (17)
+ │    │    │    │    │    ├── fd: (17)-->(42)
+ │    │    │    │    │    ├── left-join (lookup lineitem)
+ │    │    │    │    │    │    ├── save-table-name: q17_lookup_join_7
+ │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(char!null) p_container:23(char!null) l_partkey:27(int) l_quantity:30(float)
+ │    │    │    │    │    │    ├── key columns: [26 29] = [26 29]
+ │    │    │    │    │    │    ├── stats: [rows=6024.07637, distinct(17)=199.999619, null(17)=0, distinct(20)=1, null(20)=0, distinct(23)=1, null(23)=0, distinct(27)=199.999619, null(27)=0, distinct(30)=50, null(30)=-175423.404]
+ │    │    │    │    │    │    ├── fd: ()-->(20,23)
+ │    │    │    │    │    │    ├── ordering: +17 opt(20,23) [actual: +17]
+ │    │    │    │    │    │    ├── left-join (lookup lineitem@l_pk)
+ │    │    │    │    │    │    │    ├── save-table-name: q17_lookup_join_8
+ │    │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(char!null) p_container:23(char!null) l_orderkey:26(int) l_partkey:27(int) l_linenumber:29(int)
+ │    │    │    │    │    │    │    ├── key columns: [17] = [27]
+ │    │    │    │    │    │    │    ├── stats: [rows=6024.07637, distinct(17)=199.999619, null(17)=0, distinct(20)=1, null(20)=0, distinct(23)=1, null(23)=0, distinct(26)=6012.22652, null(26)=0, distinct(27)=199.999619, null(27)=0, distinct(29)=7, null(29)=0]
+ │    │    │    │    │    │    │    ├── key: (17,26,29)
+ │    │    │    │    │    │    │    ├── fd: ()-->(20,23), (26,29)-->(27)
+ │    │    │    │    │    │    │    ├── ordering: +17 opt(20,23) [actual: +17]
+ │    │    │    │    │    │    │    ├── select
+ │    │    │    │    │    │    │    │    ├── save-table-name: q17_select_9
+ │    │    │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(char!null) p_container:23(char!null)
+ │    │    │    │    │    │    │    │    ├── stats: [rows=200, distinct(17)=199.999619, null(17)=0, distinct(20)=1, null(20)=0, distinct(23)=1, null(23)=0]
+ │    │    │    │    │    │    │    │    ├── key: (17)
+ │    │    │    │    │    │    │    │    ├── fd: ()-->(20,23)
+ │    │    │    │    │    │    │    │    ├── ordering: +17 opt(20,23) [actual: +17]
+ │    │    │    │    │    │    │    │    ├── scan part
+ │    │    │    │    │    │    │    │    │    ├── save-table-name: q17_scan_10
+ │    │    │    │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(char!null) p_container:23(char!null)
+ │    │    │    │    │    │    │    │    │    ├── stats: [rows=200000, distinct(17)=199241, null(17)=0, distinct(20)=25, null(20)=0, distinct(23)=40, null(23)=0]
+ │    │    │    │    │    │    │    │    │    ├── key: (17)
+ │    │    │    │    │    │    │    │    │    ├── fd: (17)-->(20,23)
+ │    │    │    │    │    │    │    │    │    └── ordering: +17 opt(20,23) [actual: +17]
+ │    │    │    │    │    │    │    │    └── filters
+ │    │    │    │    │    │    │    │         ├── p_brand = 'Brand#23' [type=bool, outer=(20), constraints=(/20: [/'Brand#23' - /'Brand#23']; tight), fd=()-->(20)]
+ │    │    │    │    │    │    │    │         └── p_container = 'MED BOX' [type=bool, outer=(23), constraints=(/23: [/'MED BOX' - /'MED BOX']; tight), fd=()-->(23)]
+ │    │    │    │    │    │    │    └── filters (true)
+ │    │    │    │    │    │    └── filters (true)
+ │    │    │    │    │    └── aggregations
+ │    │    │    │    │         └── avg [type=float, outer=(30)]
+ │    │    │    │    │              └── variable: l_quantity [type=float]
+ │    │    │    │    └── projections
+ │    │    │    │         └── avg * 0.2 [type=float, outer=(42)]
+ │    │    │    └── filters (true)
+ │    │    └── filters
+ │    │         └── l_quantity < ?column? [type=bool, outer=(5,43), constraints=(/5: (/NULL - ]; /43: (/NULL - ])]
+ │    └── aggregations
+ │         └── sum [type=float, outer=(6)]
+ │              └── variable: l_extendedprice [type=float]
+ └── projections
+      └── sum / 7.0 [type=float, outer=(44), side-effects]
+
+stats table=q17_project_1
+----
+column_names  row_count  distinct_count  null_count
+{avg_yearly}  1          1               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{avg_yearly}  1.00           1.00           1.00                1.00                0.00            1.00
+
+stats table=q17_scalar_group_by_2
+----
+column_names  row_count  distinct_count  null_count
+{sum}         1          1               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{sum}         1.00           1.00           1.00                1.00                0.00            1.00
+
+stats table=q17_lookup_join_3
+----
+column_names       row_count  distinct_count  null_count
+{?column?}         587        185             0
+{l_extendedprice}  587        430             0
+{l_partkey}        587        195             0
+{l_quantity}       587        6               0
+{p_partkey}        587        195             0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{?column?}         2008.00        3.42 <==       200.00              1.08                0.00            1.00
+{l_extendedprice}  2008.00        3.42 <==       2006.00             4.67 <==            0.00            1.00
+{l_partkey}        2008.00        3.42 <==       200.00              1.03                0.00            1.00
+{l_quantity}       2008.00        3.42 <==       50.00               8.33 <==            0.00            1.00
+{p_partkey}        2008.00        3.42 <==       200.00              1.03                0.00            1.00
+
+stats table=q17_lookup_join_4
+----
+column_names    row_count  distinct_count  null_count
+{?column?}      6088       194             0
+{l_linenumber}  6088       7               0
+{l_orderkey}    6088       6116            0
+{l_partkey}     6088       204             0
+{p_partkey}     6088       204             0
+~~~~
+column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{?column?}      6024.00        1.01           200.00              1.03                0.00            1.00
+{l_linenumber}  6024.00        1.01           7.00                1.00                0.00            1.00
+{l_orderkey}    6024.00        1.01           6012.00             1.02                0.00            1.00
+{l_partkey}     6024.00        1.01           200.00              1.02                0.00            1.00
+{p_partkey}     6024.00        1.01           200.00              1.02                0.00            1.00
+
+stats table=q17_project_5
+----
+column_names  row_count  distinct_count  null_count
+{?column?}    204        194             0
+{p_partkey}   204        204             0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{?column?}    200.00         1.02           200.00              1.03                0.00            1.00
+{p_partkey}   200.00         1.02           200.00              1.02                0.00            1.00
+
+stats table=q17_group_by_6
+----
+column_names  row_count  distinct_count  null_count
+{avg}         204        194             0
+{p_partkey}   204        204             0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{avg}         200.00         1.02           200.00              1.03                0.00            1.00
+{p_partkey}   200.00         1.02           200.00              1.02                0.00            1.00
+
+stats table=q17_lookup_join_7
+----
+column_names   row_count  distinct_count  null_count
+{l_partkey}    6088       204             0
+{l_quantity}   6088       50              0
+{p_brand}      6088       1               0
+{p_container}  6088       1               0
+{p_partkey}    6088       204             0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est           null_count_err
+{l_partkey}    6024.00        1.01           200.00              1.02                0.00                     1.00
+{l_quantity}   6024.00        1.01           50.00               1.00                18446744073709375488.00  +Inf <==
+{p_brand}      6024.00        1.01           1.00                1.00                0.00                     1.00
+{p_container}  6024.00        1.01           1.00                1.00                0.00                     1.00
+{p_partkey}    6024.00        1.01           200.00              1.02                0.00                     1.00
+
+stats table=q17_lookup_join_8
+----
+column_names    row_count  distinct_count  null_count
+{l_linenumber}  6088       7               0
+{l_orderkey}    6088       6116            0
+{l_partkey}     6088       204             0
+{p_brand}       6088       1               0
+{p_container}   6088       1               0
+{p_partkey}     6088       204             0
+~~~~
+column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_linenumber}  6024.00        1.01           7.00                1.00                0.00            1.00
+{l_orderkey}    6024.00        1.01           6012.00             1.02                0.00            1.00
+{l_partkey}     6024.00        1.01           200.00              1.02                0.00            1.00
+{p_brand}       6024.00        1.01           1.00                1.00                0.00            1.00
+{p_container}   6024.00        1.01           1.00                1.00                0.00            1.00
+{p_partkey}     6024.00        1.01           200.00              1.02                0.00            1.00
+
+stats table=q17_select_9
+----
+column_names   row_count  distinct_count  null_count
+{p_brand}      204        1               0
+{p_container}  204        1               0
+{p_partkey}    204        204             0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{p_brand}      200.00         1.02           1.00                1.00                0.00            1.00
+{p_container}  200.00         1.02           1.00                1.00                0.00            1.00
+{p_partkey}    200.00         1.02           200.00              1.02                0.00            1.00
+
+stats table=q17_scan_10
+----
+column_names   row_count  distinct_count  null_count
+{p_brand}      200000     25              0
+{p_container}  200000     40              0
+{p_partkey}    200000     199241          0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{p_brand}      200000.00      1.00           25.00               1.00                0.00            1.00
+{p_container}  200000.00      1.00           40.00               1.00                0.00            1.00
+{p_partkey}    200000.00      1.00           199241.00           1.00                0.00            1.00
+
+# --------------------------------------------------
+# Q18
+# Large Volume Customer
+# Ranks customers based on their having placed a large quantity order. Large
+# quantity orders are defined as those orders whose total quantity is above a
+# certain level.
+#
+# Finds a list of the top 100 customers who have ever placed large quantity
+# orders. The query lists the customer name, customer key, the order key, date
+# and total price and the quantity for the order.
+# --------------------------------------------------
+save-tables database=tpch save-tables-prefix=q18
+SELECT
+    c_name,
+    c_custkey,
+    o_orderkey,
+    o_orderdate,
+    o_totalprice,
+    sum(l_quantity)
+FROM
+    customer,
+    orders,
+    lineitem
+WHERE
+    o_orderkey IN (
+        SELECT
+            l_orderkey
+        FROM
+            lineitem
+        GROUP BY
+            l_orderkey HAVING
+                sum(l_quantity) > 300
+    )
+    AND c_custkey = o_custkey
+    AND o_orderkey = l_orderkey
+GROUP BY
+    c_name,
+    c_custkey,
+    o_orderkey,
+    o_orderdate,
+    o_totalprice
+ORDER BY
+    o_totalprice DESC,
+    o_orderdate
+LIMIT 100;
+----
+limit
+ ├── save-table-name: q18_limit_1
+ ├── columns: c_name:2(varchar) c_custkey:1(int) o_orderkey:9(int!null) o_orderdate:13(date) o_totalprice:12(float) sum:51(float)
+ ├── internal-ordering: -12,+13
+ ├── cardinality: [0 - 100]
+ ├── stats: [rows=100, distinct(1)=100, null(1)=0, distinct(2)=100, null(2)=0, distinct(9)=100, null(9)=0, distinct(12)=100, null(12)=0, distinct(13)=100, null(13)=0, distinct(51)=100, null(51)=0]
+ ├── key: (9)
+ ├── fd: (1)-->(2), (9)-->(1,2,12,13,51)
+ ├── ordering: -12,+13
+ ├── sort
+ │    ├── save-table-name: q18_sort_2
+ │    ├── columns: c_custkey:1(int) c_name:2(varchar) o_orderkey:9(int!null) o_totalprice:12(float) o_orderdate:13(date) sum:51(float)
+ │    ├── stats: [rows=1471426.19, distinct(1)=1471426.19, null(1)=0, distinct(2)=1471426.19, null(2)=0, distinct(9)=1471426.19, null(9)=0, distinct(12)=1471426.19, null(12)=0, distinct(13)=1471426.19, null(13)=0, distinct(51)=1471426.19, null(51)=0]
+ │    ├── key: (9)
+ │    ├── fd: (1)-->(2), (9)-->(1,2,12,13,51)
+ │    ├── ordering: -12,+13
+ │    └── group-by
+ │         ├── save-table-name: q18_group_by_3
+ │         ├── columns: c_custkey:1(int) c_name:2(varchar) o_orderkey:9(int!null) o_totalprice:12(float) o_orderdate:13(date) sum:51(float)
+ │         ├── grouping columns: o_orderkey:9(int!null)
+ │         ├── stats: [rows=1471426.19, distinct(1)=1471426.19, null(1)=0, distinct(2)=1471426.19, null(2)=0, distinct(9)=1471426.19, null(9)=0, distinct(12)=1471426.19, null(12)=0, distinct(13)=1471426.19, null(13)=0, distinct(51)=1471426.19, null(51)=0]
+ │         ├── key: (9)
+ │         ├── fd: (1)-->(2), (9)-->(1,2,12,13,51)
+ │         ├── inner-join
+ │         │    ├── save-table-name: q18_inner_join_4
+ │         │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_quantity:22(float!null)
+ │         │    ├── stats: [rows=5941074.68, distinct(1)=99846, null(1)=0, distinct(2)=150000, null(2)=0, distinct(9)=1471426.19, null(9)=0, distinct(10)=99846, null(10)=0, distinct(12)=1410750.85, null(12)=0, distinct(13)=2406, null(13)=0, distinct(18)=1471426.19, null(18)=0, distinct(22)=50, null(22)=0]
+ │         │    ├── fd: (1)-->(2), (9)-->(10,12,13), (9)==(18), (18)==(9), (1)==(10), (10)==(1)
+ │         │    ├── scan lineitem
+ │         │    │    ├── save-table-name: q18_scan_5
+ │         │    │    ├── columns: l_orderkey:18(int!null) l_quantity:22(float!null)
+ │         │    │    └── stats: [rows=6001215, distinct(18)=1527270, null(18)=0, distinct(22)=50, null(22)=0]
+ │         │    ├── inner-join
+ │         │    │    ├── save-table-name: q18_inner_join_6
+ │         │    │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null)
+ │         │    │    ├── stats: [rows=1511964.68, distinct(1)=99846, null(1)=0, distinct(2)=149993.712, null(2)=0, distinct(9)=952566.744, null(9)=0, distinct(10)=99846, null(10)=0, distinct(12)=941447.245, null(12)=0, distinct(13)=2406, null(13)=0]
+ │         │    │    ├── key: (9)
+ │         │    │    ├── fd: (9)-->(10,12,13), (1)-->(2), (1)==(10), (10)==(1)
+ │         │    │    ├── semi-join (merge)
+ │         │    │    │    ├── save-table-name: q18_merge_join_7
+ │         │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null)
+ │         │    │    │    ├── left ordering: +9
+ │         │    │    │    ├── right ordering: +34
+ │         │    │    │    ├── stats: [rows=1500000, distinct(9)=1500000, null(9)=0, distinct(10)=99846, null(10)=0, distinct(12)=1459167, null(12)=0, distinct(13)=2406, null(13)=0]
+ │         │    │    │    ├── key: (9)
+ │         │    │    │    ├── fd: (9)-->(10,12,13)
+ │         │    │    │    ├── scan orders
+ │         │    │    │    │    ├── save-table-name: q18_scan_8
+ │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null)
+ │         │    │    │    │    ├── stats: [rows=1500000, distinct(9)=1500000, null(9)=0, distinct(10)=99846, null(10)=0, distinct(12)=1459167, null(12)=0, distinct(13)=2406, null(13)=0]
+ │         │    │    │    │    ├── key: (9)
+ │         │    │    │    │    ├── fd: (9)-->(10,12,13)
+ │         │    │    │    │    └── ordering: +9
+ │         │    │    │    ├── select
+ │         │    │    │    │    ├── save-table-name: q18_select_9
+ │         │    │    │    │    ├── columns: l_orderkey:34(int!null) sum:50(float!null)
+ │         │    │    │    │    ├── stats: [rows=509090, distinct(34)=509090, null(34)=0, distinct(50)=509090, null(50)=0]
+ │         │    │    │    │    ├── key: (34)
+ │         │    │    │    │    ├── fd: (34)-->(50)
+ │         │    │    │    │    ├── ordering: +34
+ │         │    │    │    │    ├── group-by
+ │         │    │    │    │    │    ├── save-table-name: q18_group_by_10
+ │         │    │    │    │    │    ├── columns: l_orderkey:34(int!null) sum:50(float)
+ │         │    │    │    │    │    ├── grouping columns: l_orderkey:34(int!null)
+ │         │    │    │    │    │    ├── stats: [rows=1527270, distinct(34)=1527270, null(34)=0, distinct(50)=1527270, null(50)=0]
+ │         │    │    │    │    │    ├── key: (34)
+ │         │    │    │    │    │    ├── fd: (34)-->(50)
+ │         │    │    │    │    │    ├── ordering: +34
+ │         │    │    │    │    │    ├── scan lineitem
+ │         │    │    │    │    │    │    ├── save-table-name: q18_scan_11
+ │         │    │    │    │    │    │    ├── columns: l_orderkey:34(int!null) l_quantity:38(float!null)
+ │         │    │    │    │    │    │    ├── stats: [rows=6001215, distinct(34)=1527270, null(34)=0, distinct(38)=50, null(38)=0]
+ │         │    │    │    │    │    │    └── ordering: +34
+ │         │    │    │    │    │    └── aggregations
+ │         │    │    │    │    │         └── sum [type=float, outer=(38)]
+ │         │    │    │    │    │              └── variable: l_quantity [type=float]
+ │         │    │    │    │    └── filters
+ │         │    │    │    │         └── sum > 300.0 [type=bool, outer=(50), constraints=(/50: [/300.00000000000006 - ]; tight)]
+ │         │    │    │    └── filters (true)
+ │         │    │    ├── scan customer
+ │         │    │    │    ├── save-table-name: q18_scan_12
+ │         │    │    │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null)
+ │         │    │    │    ├── stats: [rows=150000, distinct(1)=148813, null(1)=0, distinct(2)=150000, null(2)=0]
+ │         │    │    │    ├── key: (1)
+ │         │    │    │    └── fd: (1)-->(2)
+ │         │    │    └── filters
+ │         │    │         └── c_custkey = o_custkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+ │         │    └── filters
+ │         │         └── o_orderkey = l_orderkey [type=bool, outer=(9,18), constraints=(/9: (/NULL - ]; /18: (/NULL - ]), fd=(9)==(18), (18)==(9)]
+ │         └── aggregations
+ │              ├── sum [type=float, outer=(22)]
+ │              │    └── variable: l_quantity [type=float]
+ │              ├── const-agg [type=int, outer=(1)]
+ │              │    └── variable: c_custkey [type=int]
+ │              ├── const-agg [type=varchar, outer=(2)]
+ │              │    └── variable: c_name [type=varchar]
+ │              ├── const-agg [type=float, outer=(12)]
+ │              │    └── variable: o_totalprice [type=float]
+ │              └── const-agg [type=date, outer=(13)]
+ │                   └── variable: o_orderdate [type=date]
+ └── const: 100 [type=int]
+
+stats table=q18_limit_1
+----
+column_names    row_count  distinct_count  null_count
+{c_custkey}     57         57              0
+{c_name}        57         57              0
+{o_orderdate}   57         57              0
+{o_orderkey}    57         57              0
+{o_totalprice}  57         57              0
+{sum}           57         18              0
+~~~~
+column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_custkey}     100.00         1.75           100.00              1.75                0.00            1.00
+{c_name}        100.00         1.75           100.00              1.75                0.00            1.00
+{o_orderdate}   100.00         1.75           100.00              1.75                0.00            1.00
+{o_orderkey}    100.00         1.75           100.00              1.75                0.00            1.00
+{o_totalprice}  100.00         1.75           100.00              1.75                0.00            1.00
+{sum}           100.00         1.75           100.00              5.56 <==            0.00            1.00
+
+stats table=q18_sort_2
+----
+column_names    row_count  distinct_count  null_count
+{c_custkey}     57         57              0
+{c_name}        57         57              0
+{o_orderdate}   57         57              0
+{o_orderkey}    57         57              0
+{o_totalprice}  57         57              0
+{sum}           57         18              0
+~~~~
+column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_custkey}     1471426.00     25814.49 <==   1471426.00          25814.49 <==        0.00            1.00
+{c_name}        1471426.00     25814.49 <==   1471426.00          25814.49 <==        0.00            1.00
+{o_orderdate}   1471426.00     25814.49 <==   1471426.00          25814.49 <==        0.00            1.00
+{o_orderkey}    1471426.00     25814.49 <==   1471426.00          25814.49 <==        0.00            1.00
+{o_totalprice}  1471426.00     25814.49 <==   1471426.00          25814.49 <==        0.00            1.00
+{sum}           1471426.00     25814.49 <==   1471426.00          81745.89 <==        0.00            1.00
+
+stats table=q18_group_by_3
+----
+column_names    row_count  distinct_count  null_count
+{c_custkey}     57         57              0
+{c_name}        57         57              0
+{o_orderdate}   57         57              0
+{o_orderkey}    57         57              0
+{o_totalprice}  57         57              0
+{sum}           57         18              0
+~~~~
+column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_custkey}     1471426.00     25814.49 <==   1471426.00          25814.49 <==        0.00            1.00
+{c_name}        1471426.00     25814.49 <==   1471426.00          25814.49 <==        0.00            1.00
+{o_orderdate}   1471426.00     25814.49 <==   1471426.00          25814.49 <==        0.00            1.00
+{o_orderkey}    1471426.00     25814.49 <==   1471426.00          25814.49 <==        0.00            1.00
+{o_totalprice}  1471426.00     25814.49 <==   1471426.00          25814.49 <==        0.00            1.00
+{sum}           1471426.00     25814.49 <==   1471426.00          81745.89 <==        0.00            1.00
+
+stats table=q18_inner_join_4
+----
+column_names    row_count  distinct_count  null_count
+{c_custkey}     399        57              0
+{c_name}        399        57              0
+{l_orderkey}    399        57              0
+{l_quantity}    399        27              0
+{o_custkey}     399        57              0
+{o_orderdate}   399        57              0
+{o_orderkey}    399        57              0
+{o_totalprice}  399        57              0
+~~~~
+column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_custkey}     5941075.00     14889.91 <==   99846.00            1751.68 <==         0.00            1.00
+{c_name}        5941075.00     14889.91 <==   150000.00           2631.58 <==         0.00            1.00
+{l_orderkey}    5941075.00     14889.91 <==   1471426.00          25814.49 <==        0.00            1.00
+{l_quantity}    5941075.00     14889.91 <==   50.00               1.85                0.00            1.00
+{o_custkey}     5941075.00     14889.91 <==   99846.00            1751.68 <==         0.00            1.00
+{o_orderdate}   5941075.00     14889.91 <==   2406.00             42.21 <==           0.00            1.00
+{o_orderkey}    5941075.00     14889.91 <==   1471426.00          25814.49 <==        0.00            1.00
+{o_totalprice}  5941075.00     14889.91 <==   1410751.00          24750.02 <==        0.00            1.00
+
+stats table=q18_scan_5
+----
+column_names  row_count  distinct_count  null_count
+{l_orderkey}  6001215    1527270         0
+{l_quantity}  6001215    50              0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_orderkey}  6001215.00     1.00           1527270.00          1.00                0.00            1.00
+{l_quantity}  6001215.00     1.00           50.00               1.00                0.00            1.00
+
+stats table=q18_inner_join_6
+----
+column_names    row_count  distinct_count  null_count
+{c_custkey}     57         57              0
+{c_name}        57         57              0
+{o_custkey}     57         57              0
+{o_orderdate}   57         57              0
+{o_orderkey}    57         57              0
+{o_totalprice}  57         57              0
+~~~~
+column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_custkey}     1511965.00     26525.70 <==   99846.00            1751.68 <==         0.00            1.00
+{c_name}        1511965.00     26525.70 <==   149994.00           2631.47 <==         0.00            1.00
+{o_custkey}     1511965.00     26525.70 <==   99846.00            1751.68 <==         0.00            1.00
+{o_orderdate}   1511965.00     26525.70 <==   2406.00             42.21 <==           0.00            1.00
+{o_orderkey}    1511965.00     26525.70 <==   952567.00           16711.70 <==        0.00            1.00
+{o_totalprice}  1511965.00     26525.70 <==   941447.00           16516.61 <==        0.00            1.00
+
+stats table=q18_merge_join_7
+----
+column_names    row_count  distinct_count  null_count
+{o_custkey}     57         57              0
+{o_orderdate}   57         57              0
+{o_orderkey}    57         57              0
+{o_totalprice}  57         57              0
+~~~~
+column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{o_custkey}     1500000.00     26315.79 <==   99846.00            1751.68 <==         0.00            1.00
+{o_orderdate}   1500000.00     26315.79 <==   2406.00             42.21 <==           0.00            1.00
+{o_orderkey}    1500000.00     26315.79 <==   1500000.00          26315.79 <==        0.00            1.00
+{o_totalprice}  1500000.00     26315.79 <==   1459167.00          25599.42 <==        0.00            1.00
+
+stats table=q18_scan_8
+----
+column_names    row_count  distinct_count  null_count
+{o_custkey}     1500000    99846           0
+{o_orderdate}   1500000    2406            0
+{o_orderkey}    1500000    1527270         0
+{o_totalprice}  1500000    1459167         0
+~~~~
+column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{o_custkey}     1500000.00     1.00           99846.00            1.00                0.00            1.00
+{o_orderdate}   1500000.00     1.00           2406.00             1.00                0.00            1.00
+{o_orderkey}    1500000.00     1.00           1500000.00          1.02                0.00            1.00
+{o_totalprice}  1500000.00     1.00           1459167.00          1.00                0.00            1.00
+
+stats table=q18_select_9
+----
+column_names  row_count  distinct_count  null_count
+{l_orderkey}  57         57              0
+{sum}         57         18              0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_orderkey}  509090.00      8931.40 <==    509090.00           8931.40 <==         0.00            1.00
+{sum}         509090.00      8931.40 <==    509090.00           28282.78 <==        0.00            1.00
+
+stats table=q18_group_by_10
+----
+column_names  row_count  distinct_count  null_count
+{l_orderkey}  1500000    1527270         0
+{sum}         1500000    318             0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_orderkey}  1527270.00     1.02           1527270.00          1.00                0.00            1.00
+{sum}         1527270.00     1.02           1527270.00          4802.74 <==         0.00            1.00
+
+stats table=q18_scan_11
+----
+column_names  row_count  distinct_count  null_count
+{l_orderkey}  6001215    1527270         0
+{l_quantity}  6001215    50              0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_orderkey}  6001215.00     1.00           1527270.00          1.00                0.00            1.00
+{l_quantity}  6001215.00     1.00           50.00               1.00                0.00            1.00
+
+stats table=q18_scan_12
+----
+column_names  row_count  distinct_count  null_count
+{c_custkey}   150000     148813          0
+{c_name}      150000     151126          0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_custkey}   150000.00      1.00           148813.00           1.00                0.00            1.00
+{c_name}      150000.00      1.00           150000.00           1.01                0.00            1.00
+
+# --------------------------------------------------
+# Q19
+# Discounted Revenue
+# Reports the gross discounted revenue attributed to the sale of selected parts
+# handled in a particular manner. This query is an example of code such as might
+# be produced programmatically by a data mining tool.
+#
+# The Discounted Revenue query finds the gross discounted revenue for all orders
+# for three different types of parts that were shipped by air and delivered in
+# person. Parts are selected based on the combination of specific brands, a list
+# of containers, and a range of sizes.
+# --------------------------------------------------
+save-tables database=tpch save-tables-prefix=q19
+SELECT
+    sum(l_extendedprice* (1 - l_discount)) AS revenue
+FROM
+    lineitem,
+    part
+WHERE
+    (
+        p_partkey = l_partkey
+        AND p_brand = 'Brand#12'
+        AND p_container IN ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+        AND l_quantity >= 1 AND l_quantity <= 1 + 10
+        AND p_size BETWEEN 1 AND 5
+        AND l_shipmode IN ('AIR', 'AIR REG')
+        AND l_shipinstruct = 'DELIVER IN PERSON'
+    )
+    OR
+    (
+        p_partkey = l_partkey
+        AND p_brand = 'Brand#23'
+        AND p_container IN ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+        AND l_quantity >= 10 AND l_quantity <= 10 + 10
+        AND p_size BETWEEN 1 AND 10
+        AND l_shipmode IN ('AIR', 'AIR REG')
+        AND l_shipinstruct = 'DELIVER IN PERSON'
+    )
+    OR
+    (
+        p_partkey = l_partkey
+        AND p_brand = 'Brand#34'
+        AND p_container IN ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+        AND l_quantity >= 20 AND l_quantity <= 20 + 10
+        AND p_size BETWEEN 1 AND 15
+        AND l_shipmode IN ('AIR', 'AIR REG')
+        AND l_shipinstruct = 'DELIVER IN PERSON'
+    );
+----
+scalar-group-by
+ ├── save-table-name: q19_scalar_group_by_1
+ ├── columns: revenue:27(float)
+ ├── cardinality: [1 - 1]
+ ├── stats: [rows=1, distinct(27)=1, null(27)=0]
+ ├── key: ()
+ ├── fd: ()-->(27)
+ ├── project
+ │    ├── save-table-name: q19_project_2
+ │    ├── columns: column26:26(float)
+ │    ├── stats: [rows=53556.554, distinct(26)=50346.0112, null(26)=0]
+ │    ├── inner-join
+ │    │    ├── save-table-name: q19_inner_join_3
+ │    │    ├── columns: l_partkey:2(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipinstruct:14(char!null) l_shipmode:15(char!null) p_partkey:17(int!null) p_brand:20(char!null) p_size:22(int!null) p_container:23(char!null)
+ │    │    ├── stats: [rows=53556.554, distinct(2)=53556.554, null(2)=0, distinct(5)=50, null(5)=0, distinct(6)=49693.434, null(6)=0, distinct(7)=11, null(7)=0, distinct(14)=1, null(14)=0, distinct(15)=2, null(15)=0, distinct(17)=53556.554, null(17)=0, distinct(20)=25, null(20)=0, distinct(22)=50, null(22)=0, distinct(23)=40, null(23)=0, distinct(6,7)=50346.0112, null(6,7)=0]
+ │    │    ├── fd: ()-->(14), (17)-->(20,22,23), (2)==(17), (17)==(2)
+ │    │    ├── select
+ │    │    │    ├── save-table-name: q19_select_4
+ │    │    │    ├── columns: l_partkey:2(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipinstruct:14(char!null) l_shipmode:15(char!null)
+ │    │    │    ├── stats: [rows=428658.214, distinct(2)=177863.163, null(2)=0, distinct(5)=50, null(5)=0, distinct(6)=353162.332, null(6)=0, distinct(7)=11, null(7)=0, distinct(14)=1, null(14)=0, distinct(15)=2, null(15)=0, distinct(6,7)=428658.214, null(6,7)=0]
+ │    │    │    ├── fd: ()-->(14)
+ │    │    │    ├── scan lineitem
+ │    │    │    │    ├── save-table-name: q19_scan_5
+ │    │    │    │    ├── columns: l_partkey:2(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipinstruct:14(char!null) l_shipmode:15(char!null)
+ │    │    │    │    └── stats: [rows=6001215, distinct(2)=199241, null(2)=0, distinct(5)=50, null(5)=0, distinct(6)=925955, null(6)=0, distinct(7)=11, null(7)=0, distinct(14)=4, null(14)=0, distinct(15)=7, null(15)=0, distinct(6,7)=6001215, null(6,7)=0]
+ │    │    │    └── filters
+ │    │    │         ├── l_shipmode IN ('AIR', 'AIR REG') [type=bool, outer=(15), constraints=(/15: [/'AIR' - /'AIR'] [/'AIR REG' - /'AIR REG']; tight)]
+ │    │    │         └── l_shipinstruct = 'DELIVER IN PERSON' [type=bool, outer=(14), constraints=(/14: [/'DELIVER IN PERSON' - /'DELIVER IN PERSON']; tight), fd=()-->(14)]
+ │    │    ├── select
+ │    │    │    ├── save-table-name: q19_select_6
+ │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(char!null) p_size:22(int!null) p_container:23(char!null)
+ │    │    │    ├── stats: [rows=66666.6667, distinct(17)=66618.6736, null(17)=0, distinct(20)=25, null(20)=0, distinct(22)=50, null(22)=0, distinct(23)=40, null(23)=0]
+ │    │    │    ├── key: (17)
+ │    │    │    ├── fd: (17)-->(20,22,23)
+ │    │    │    ├── scan part
+ │    │    │    │    ├── save-table-name: q19_scan_7
+ │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(char!null) p_size:22(int!null) p_container:23(char!null)
+ │    │    │    │    ├── stats: [rows=200000, distinct(17)=199241, null(17)=0, distinct(20)=25, null(20)=0, distinct(22)=50, null(22)=0, distinct(23)=40, null(23)=0]
+ │    │    │    │    ├── key: (17)
+ │    │    │    │    └── fd: (17)-->(20,22,23)
+ │    │    │    └── filters
+ │    │    │         └── p_size >= 1 [type=bool, outer=(22), constraints=(/22: [/1 - ]; tight)]
+ │    │    └── filters
+ │    │         ├── p_partkey = l_partkey [type=bool, outer=(2,17), constraints=(/2: (/NULL - ]; /17: (/NULL - ]), fd=(2)==(17), (17)==(2)]
+ │    │         └── ((((((p_brand = 'Brand#12') AND (p_container IN ('SM BOX', 'SM CASE', 'SM PACK', 'SM PKG'))) AND (l_quantity >= 1.0)) AND (l_quantity <= 11.0)) AND (p_size <= 5)) OR (((((p_brand = 'Brand#23') AND (p_container IN ('MED BAG', 'MED BOX', 'MED PACK', 'MED PKG'))) AND (l_quantity >= 10.0)) AND (l_quantity <= 20.0)) AND (p_size <= 10))) OR (((((p_brand = 'Brand#34') AND (p_container IN ('LG BOX', 'LG CASE', 'LG PACK', 'LG PKG'))) AND (l_quantity >= 20.0)) AND (l_quantity <= 30.0)) AND (p_size <= 15)) [type=bool, outer=(5,20,22,23)]
+ │    └── projections
+ │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(6,7)]
+ └── aggregations
+      └── sum [type=float, outer=(26)]
+           └── variable: column26 [type=float]
+
+stats table=q19_scalar_group_by_1
+----
+column_names  row_count  distinct_count  null_count
+{revenue}     1          1               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{revenue}     1.00           1.00           1.00                1.00                0.00            1.00
+
+stats table=q19_project_2
+----
+column_names  row_count  distinct_count  null_count
+{column26}    121        121             0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{column26}    53557.00       442.62 <==     50346.00            416.08 <==          0.00            1.00
+
+stats table=q19_inner_join_3
+----
+column_names       row_count  distinct_count  null_count
+{l_discount}       121        11              0
+{l_extendedprice}  121        118             0
+{l_partkey}        121        103             0
+{l_quantity}       121        29              0
+{l_shipinstruct}   121        1               0
+{l_shipmode}       121        1               0
+{p_brand}          121        3               0
+{p_container}      121        12              0
+{p_partkey}        121        103             0
+{p_size}           121        14              0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_discount}       53557.00       442.62 <==     11.00               1.00                0.00            1.00
+{l_extendedprice}  53557.00       442.62 <==     49693.00            421.13 <==          0.00            1.00
+{l_partkey}        53557.00       442.62 <==     53557.00            519.97 <==          0.00            1.00
+{l_quantity}       53557.00       442.62 <==     50.00               1.72                0.00            1.00
+{l_shipinstruct}   53557.00       442.62 <==     1.00                1.00                0.00            1.00
+{l_shipmode}       53557.00       442.62 <==     2.00                2.00 <==            0.00            1.00
+{p_brand}          53557.00       442.62 <==     25.00               8.33 <==            0.00            1.00
+{p_container}      53557.00       442.62 <==     40.00               3.33 <==            0.00            1.00
+{p_partkey}        53557.00       442.62 <==     53557.00            519.97 <==          0.00            1.00
+{p_size}           53557.00       442.62 <==     50.00               3.57 <==            0.00            1.00
+
+stats table=q19_select_4
+----
+column_names       row_count  distinct_count  null_count
+{l_discount}       214377     11              0
+{l_extendedprice}  214377     188952          0
+{l_partkey}        214377     131422          0
+{l_quantity}       214377     50              0
+{l_shipinstruct}   214377     1               0
+{l_shipmode}       214377     1               0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_discount}       428658.00      2.00 <==       11.00               1.00                0.00            1.00
+{l_extendedprice}  428658.00      2.00 <==       353162.00           1.87                0.00            1.00
+{l_partkey}        428658.00      2.00 <==       177863.00           1.35                0.00            1.00
+{l_quantity}       428658.00      2.00 <==       50.00               1.00                0.00            1.00
+{l_shipinstruct}   428658.00      2.00 <==       1.00                1.00                0.00            1.00
+{l_shipmode}       428658.00      2.00 <==       2.00                2.00 <==            0.00            1.00
+
+stats table=q19_scan_5
+----
+column_names       row_count  distinct_count  null_count
+{l_discount}       6001215    11              0
+{l_extendedprice}  6001215    925955          0
+{l_partkey}        6001215    199241          0
+{l_quantity}       6001215    50              0
+{l_shipinstruct}   6001215    4               0
+{l_shipmode}       6001215    7               0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_discount}       6001215.00     1.00           11.00               1.00                0.00            1.00
+{l_extendedprice}  6001215.00     1.00           925955.00           1.00                0.00            1.00
+{l_partkey}        6001215.00     1.00           199241.00           1.00                0.00            1.00
+{l_quantity}       6001215.00     1.00           50.00               1.00                0.00            1.00
+{l_shipinstruct}   6001215.00     1.00           4.00                1.00                0.00            1.00
+{l_shipmode}       6001215.00     1.00           7.00                1.00                0.00            1.00
+
+stats table=q19_select_6
+----
+column_names   row_count  distinct_count  null_count
+{p_brand}      200000     25              0
+{p_container}  200000     40              0
+{p_partkey}    200000     199241          0
+{p_size}       200000     50              0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{p_brand}      66667.00       3.00 <==       25.00               1.00                0.00            1.00
+{p_container}  66667.00       3.00 <==       40.00               1.00                0.00            1.00
+{p_partkey}    66667.00       3.00 <==       66619.00            2.99 <==            0.00            1.00
+{p_size}       66667.00       3.00 <==       50.00               1.00                0.00            1.00
+
+stats table=q19_scan_7
+----
+column_names   row_count  distinct_count  null_count
+{p_brand}      200000     25              0
+{p_container}  200000     40              0
+{p_partkey}    200000     199241          0
+{p_size}       200000     50              0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{p_brand}      200000.00      1.00           25.00               1.00                0.00            1.00
+{p_container}  200000.00      1.00           40.00               1.00                0.00            1.00
+{p_partkey}    200000.00      1.00           199241.00           1.00                0.00            1.00
+{p_size}       200000.00      1.00           50.00               1.00                0.00            1.00
+
+# --------------------------------------------------
+# Q20
+# Potential Part Promotion
+# Identifies suppliers in a particular nation having selected parts that may be
+# candidates for a promotional offer.
+#
+# Identifies suppliers who have an excess of a given part available; an excess
+# defined to be more than 50% of the parts like the given part that the supplier
+# shipped in a given year for a given nation. Only parts whose names share a
+# certain naming convention are considered.
+#
+# TODO:
+#   1. Push 'forest%' prefix filter down into Scan
+# --------------------------------------------------
+save-tables database=tpch save-tables-prefix=q20
+SELECT
+    s_name,
+    s_address
+FROM
+    supplier,
+    nation
+WHERE
+    s_suppkey IN (
+        SELECT
+            ps_suppkey
+        FROM
+            partsupp
+        WHERE
+            ps_partkey IN (
+                SELECT
+                    p_partkey
+                FROM
+                    part
+                WHERE
+                    p_name LIKE 'forest%'
+            )
+            AND ps_availqty > (
+                SELECT
+                    0.5 * sum(l_quantity)
+                FROM
+                    lineitem
+                WHERE
+                    l_partkey = ps_partkey
+                    AND l_suppkey = ps_suppkey
+                    AND l_shipdate >= DATE '1994-01-01'
+                    AND l_shipdate < DATE '1994-01-01' + INTERVAL '1' YEAR
+            )
+    )
+    AND s_nationkey = n_nationkey
+    AND n_name = 'CANADA'
+ORDER BY
+    s_name;
+----
+sort
+ ├── save-table-name: q20_sort_1
+ ├── columns: s_name:2(char!null) s_address:3(varchar!null)
+ ├── stats: [rows=400, distinct(2)=399.991883, null(2)=0, distinct(3)=400, null(3)=0]
+ ├── ordering: +2
+ └── project
+      ├── save-table-name: q20_project_2
+      ├── columns: s_name:2(char!null) s_address:3(varchar!null)
+      ├── stats: [rows=400, distinct(2)=399.991883, null(2)=0, distinct(3)=400, null(3)=0]
+      └── inner-join
+           ├── save-table-name: q20_inner_join_3
+           ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_nationkey:4(int!null) n_nationkey:8(int!null) n_name:9(char!null)
+           ├── stats: [rows=400, distinct(1)=399.934613, null(1)=0, distinct(2)=399.991883, null(2)=0, distinct(3)=400, null(3)=0, distinct(4)=1, null(4)=0, distinct(8)=1, null(8)=0, distinct(9)=1, null(9)=0]
+           ├── key: (1)
+           ├── fd: ()-->(9), (1)-->(2-4), (4)==(8), (8)==(4)
+           ├── semi-join
+           │    ├── save-table-name: q20_semi_join_4
+           │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_nationkey:4(int!null)
+           │    ├── stats: [rows=10000, distinct(1)=9920, null(1)=0, distinct(2)=9990, null(2)=0, distinct(3)=10000, null(3)=0, distinct(4)=25, null(4)=0]
+           │    ├── key: (1)
+           │    ├── fd: (1)-->(2-4)
+           │    ├── scan supplier
+           │    │    ├── save-table-name: q20_scan_5
+           │    │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_nationkey:4(int!null)
+           │    │    ├── stats: [rows=10000, distinct(1)=9920, null(1)=0, distinct(2)=9990, null(2)=0, distinct(3)=10000, null(3)=0, distinct(4)=25, null(4)=0]
+           │    │    ├── key: (1)
+           │    │    └── fd: (1)-->(2-4)
+           │    ├── semi-join
+           │    │    ├── save-table-name: q20_semi_join_6
+           │    │    ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null)
+           │    │    ├── stats: [rows=266666.667, distinct(12)=160127.162, null(12)=0, distinct(13)=9920, null(13)=0]
+           │    │    ├── key: (12,13)
+           │    │    ├── project
+           │    │    │    ├── save-table-name: q20_project_7
+           │    │    │    ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null)
+           │    │    │    ├── stats: [rows=266666.667, distinct(12)=160127.162, null(12)=0, distinct(13)=9920, null(13)=0]
+           │    │    │    ├── key: (12,13)
+           │    │    │    └── select
+           │    │    │         ├── save-table-name: q20_select_8
+           │    │    │         ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null) ps_availqty:14(int!null) sum:42(float)
+           │    │    │         ├── stats: [rows=266666.667, distinct(12)=160127.162, null(12)=0, distinct(13)=9920, null(13)=0, distinct(14)=266666.667, null(14)=0, distinct(42)=266666.667, null(42)=0]
+           │    │    │         ├── key: (12,13)
+           │    │    │         ├── fd: (12,13)-->(14,42)
+           │    │    │         ├── group-by
+           │    │    │         │    ├── save-table-name: q20_group_by_9
+           │    │    │         │    ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null) ps_availqty:14(int) sum:42(float)
+           │    │    │         │    ├── grouping columns: ps_partkey:12(int!null) ps_suppkey:13(int!null)
+           │    │    │         │    ├── stats: [rows=800000, distinct(12)=199241, null(12)=0, distinct(13)=9920, null(13)=0, distinct(14)=800000, null(14)=0, distinct(42)=800000, null(42)=0, distinct(12,13)=800000, null(12,13)=0]
+           │    │    │         │    ├── key: (12,13)
+           │    │    │         │    ├── fd: (12,13)-->(14,42)
+           │    │    │         │    ├── left-join
+           │    │    │         │    │    ├── save-table-name: q20_left_join_10
+           │    │    │         │    │    ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null) ps_availqty:14(int!null) l_partkey:27(int) l_suppkey:28(int) l_quantity:30(float) l_shipdate:36(date)
+           │    │    │         │    │    ├── stats: [rows=800000, distinct(12)=199241, null(12)=0, distinct(13)=9920, null(13)=0, distinct(14)=9920, null(14)=0, distinct(27)=269.895895, null(27)=799730.104, distinct(28)=269.895895, null(28)=799730.104, distinct(30)=49.7737004, null(30)=799730.104, distinct(36)=255.97722, null(36)=799730.104, distinct(12,13)=800000, null(12,13)=0]
+           │    │    │         │    │    ├── fd: (12,13)-->(14)
+           │    │    │         │    │    ├── scan partsupp
+           │    │    │         │    │    │    ├── save-table-name: q20_scan_11
+           │    │    │         │    │    │    ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null) ps_availqty:14(int!null)
+           │    │    │         │    │    │    ├── stats: [rows=800000, distinct(12)=199241, null(12)=0, distinct(13)=9920, null(13)=0, distinct(14)=9920, null(14)=0, distinct(12,13)=800000, null(12,13)=0]
+           │    │    │         │    │    │    ├── key: (12,13)
+           │    │    │         │    │    │    └── fd: (12,13)-->(14)
+           │    │    │         │    │    ├── index-join lineitem
+           │    │    │         │    │    │    ├── save-table-name: q20_index_join_12
+           │    │    │         │    │    │    ├── columns: l_partkey:27(int!null) l_suppkey:28(int!null) l_quantity:30(float!null) l_shipdate:36(date!null)
+           │    │    │         │    │    │    ├── stats: [rows=666801.667, distinct(27)=193504.524, null(27)=0, distinct(28)=9920, null(28)=0, distinct(30)=50, null(30)=0, distinct(36)=2526, null(36)=0]
+           │    │    │         │    │    │    └── scan lineitem@l_sd
+           │    │    │         │    │    │         ├── save-table-name: q20_scan_13
+           │    │    │         │    │    │         ├── columns: l_orderkey:26(int!null) l_linenumber:29(int!null) l_shipdate:36(date!null)
+           │    │    │         │    │    │         ├── constraint: /36/26/29: [/'1994-01-01' - /'1994-12-31']
+           │    │    │         │    │    │         ├── stats: [rows=666801.667, distinct(26)=565838.316, null(26)=0, distinct(29)=7, null(29)=0, distinct(36)=2526, null(36)=0]
+           │    │    │         │    │    │         ├── key: (26,29)
+           │    │    │         │    │    │         └── fd: (26,29)-->(36)
+           │    │    │         │    │    └── filters
+           │    │    │         │    │         ├── l_partkey = ps_partkey [type=bool, outer=(12,27), constraints=(/12: (/NULL - ]; /27: (/NULL - ]), fd=(12)==(27), (27)==(12)]
+           │    │    │         │    │         └── l_suppkey = ps_suppkey [type=bool, outer=(13,28), constraints=(/13: (/NULL - ]; /28: (/NULL - ]), fd=(13)==(28), (28)==(13)]
+           │    │    │         │    └── aggregations
+           │    │    │         │         ├── sum [type=float, outer=(30)]
+           │    │    │         │         │    └── variable: l_quantity [type=float]
+           │    │    │         │         └── const-agg [type=int, outer=(14)]
+           │    │    │         │              └── variable: ps_availqty [type=int]
+           │    │    │         └── filters
+           │    │    │              └── ps_availqty > (sum * 0.5) [type=bool, outer=(14,42), constraints=(/14: (/NULL - ])]
+           │    │    ├── select
+           │    │    │    ├── save-table-name: q20_select_14
+           │    │    │    ├── columns: p_partkey:17(int!null) p_name:18(varchar!null)
+           │    │    │    ├── stats: [rows=22222.2222, distinct(17)=22217.3354, null(17)=0, distinct(18)=22210.1238, null(18)=0]
+           │    │    │    ├── key: (17)
+           │    │    │    ├── fd: (17)-->(18)
+           │    │    │    ├── scan part
+           │    │    │    │    ├── save-table-name: q20_scan_15
+           │    │    │    │    ├── columns: p_partkey:17(int!null) p_name:18(varchar!null)
+           │    │    │    │    ├── stats: [rows=200000, distinct(17)=199241, null(17)=0, distinct(18)=198131, null(18)=0]
+           │    │    │    │    ├── key: (17)
+           │    │    │    │    └── fd: (17)-->(18)
+           │    │    │    └── filters
+           │    │    │         └── p_name LIKE 'forest%' [type=bool, outer=(18), constraints=(/18: [/'forest' - /'foresu'); tight)]
+           │    │    └── filters
+           │    │         └── ps_partkey = p_partkey [type=bool, outer=(12,17), constraints=(/12: (/NULL - ]; /17: (/NULL - ]), fd=(12)==(17), (17)==(12)]
+           │    └── filters
+           │         └── s_suppkey = ps_suppkey [type=bool, outer=(1,13), constraints=(/1: (/NULL - ]; /13: (/NULL - ]), fd=(1)==(13), (13)==(1)]
+           ├── select
+           │    ├── save-table-name: q20_select_16
+           │    ├── columns: n_nationkey:8(int!null) n_name:9(char!null)
+           │    ├── stats: [rows=1, distinct(8)=1, null(8)=0, distinct(9)=1, null(9)=0]
+           │    ├── key: (8)
+           │    ├── fd: ()-->(9)
+           │    ├── scan nation
+           │    │    ├── save-table-name: q20_scan_17
+           │    │    ├── columns: n_nationkey:8(int!null) n_name:9(char!null)
+           │    │    ├── stats: [rows=25, distinct(8)=25, null(8)=0, distinct(9)=25, null(9)=0]
+           │    │    ├── key: (8)
+           │    │    └── fd: (8)-->(9)
+           │    └── filters
+           │         └── n_name = 'CANADA' [type=bool, outer=(9), constraints=(/9: [/'CANADA' - /'CANADA']; tight), fd=()-->(9)]
+           └── filters
+                └── s_nationkey = n_nationkey [type=bool, outer=(4,8), constraints=(/4: (/NULL - ]; /8: (/NULL - ]), fd=(4)==(8), (8)==(4)]
+
+stats table=q20_sort_1
+----
+column_names  row_count  distinct_count  null_count
+{s_address}   186        186             0
+{s_name}      186        186             0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{s_address}   400.00         2.15 <==       400.00              2.15 <==            0.00            1.00
+{s_name}      400.00         2.15 <==       400.00              2.15 <==            0.00            1.00
+
+stats table=q20_project_2
+----
+column_names  row_count  distinct_count  null_count
+{s_address}   186        186             0
+{s_name}      186        186             0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{s_address}   400.00         2.15 <==       400.00              2.15 <==            0.00            1.00
+{s_name}      400.00         2.15 <==       400.00              2.15 <==            0.00            1.00
+
+stats table=q20_inner_join_3
+----
+column_names   row_count  distinct_count  null_count
+{n_name}       186        1               0
+{n_nationkey}  186        1               0
+{s_address}    186        186             0
+{s_name}       186        186             0
+{s_nationkey}  186        1               0
+{s_suppkey}    186        186             0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}       400.00         2.15 <==       1.00                1.00                0.00            1.00
+{n_nationkey}  400.00         2.15 <==       1.00                1.00                0.00            1.00
+{s_address}    400.00         2.15 <==       400.00              2.15 <==            0.00            1.00
+{s_name}       400.00         2.15 <==       400.00              2.15 <==            0.00            1.00
+{s_nationkey}  400.00         2.15 <==       1.00                1.00                0.00            1.00
+{s_suppkey}    400.00         2.15 <==       400.00              2.15 <==            0.00            1.00
+
+stats table=q20_semi_join_4
+----
+column_names   row_count  distinct_count  null_count
+{s_address}    4397       4369            0
+{s_name}       4397       4373            0
+{s_nationkey}  4397       25              0
+{s_suppkey}    4397       4434            0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{s_address}    10000.00       2.27 <==       10000.00            2.29 <==            0.00            1.00
+{s_name}       10000.00       2.27 <==       9990.00             2.28 <==            0.00            1.00
+{s_nationkey}  10000.00       2.27 <==       25.00               1.00                0.00            1.00
+{s_suppkey}    10000.00       2.27 <==       9920.00             2.24 <==            0.00            1.00
+
+stats table=q20_scan_5
+----
+column_names   row_count  distinct_count  null_count
+{s_address}    10000      10027           0
+{s_name}       10000      9990            0
+{s_nationkey}  10000      25              0
+{s_suppkey}    10000      9920            0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{s_address}    10000.00       1.00           10000.00            1.00                0.00            1.00
+{s_name}       10000.00       1.00           9990.00             1.00                0.00            1.00
+{s_nationkey}  10000.00       1.00           25.00               1.00                0.00            1.00
+{s_suppkey}    10000.00       1.00           9920.00             1.00                0.00            1.00
+
+stats table=q20_semi_join_6
+----
+column_names  row_count  distinct_count  null_count
+{ps_partkey}  5833       2106            0
+{ps_suppkey}  5833       4434            0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{ps_partkey}  266667.00      45.72 <==      160127.00           76.03 <==           0.00            1.00
+{ps_suppkey}  266667.00      45.72 <==      9920.00             2.24 <==            0.00            1.00
+
+stats table=q20_project_7
+----
+column_names  row_count  distinct_count  null_count
+{ps_partkey}  542095     197197          0
+{ps_suppkey}  542095     9920            0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{ps_partkey}  266667.00      2.03 <==       160127.00           1.23                0.00            1.00
+{ps_suppkey}  266667.00      2.03 <==       9920.00             1.00                0.00            1.00
+
+stats table=q20_select_8
+----
+column_names   row_count  distinct_count  null_count
+{ps_availqty}  542095     9920            0
+{ps_partkey}   542095     197197          0
+{ps_suppkey}   542095     9920            0
+{sum}          542095     246             0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{ps_availqty}  266667.00      2.03 <==       266667.00           26.88 <==           0.00            1.00
+{ps_partkey}   266667.00      2.03 <==       160127.00           1.23                0.00            1.00
+{ps_suppkey}   266667.00      2.03 <==       9920.00             1.00                0.00            1.00
+{sum}          266667.00      2.03 <==       266667.00           1084.01 <==         0.00            1.00
+
+stats table=q20_group_by_9
+----
+column_names   row_count  distinct_count  null_count
+{ps_availqty}  800000     9920            0
+{ps_partkey}   800000     199241          0
+{ps_suppkey}   800000     9920            0
+{sum}          800000     246             256790
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{ps_availqty}  800000.00      1.00           800000.00           80.65 <==           0.00            1.00
+{ps_partkey}   800000.00      1.00           199241.00           1.00                0.00            1.00
+{ps_suppkey}   800000.00      1.00           9920.00             1.00                0.00            1.00
+{sum}          800000.00      1.00           800000.00           3252.03 <==         0.00            +Inf <==
+
+stats table=q20_left_join_10
+----
+column_names   row_count  distinct_count  null_count
+{l_partkey}    1166245    197252          256790
+{l_quantity}   1166245    50              256790
+{l_shipdate}   1166245    365             256790
+{l_suppkey}    1166245    9920            256790
+{ps_availqty}  1166245    9920            0
+{ps_partkey}   1166245    199241          0
+{ps_suppkey}   1166245    9920            0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_partkey}    800000.00      1.46           270.00              730.56 <==          799730.00       3.11 <==
+{l_quantity}   800000.00      1.46           50.00               1.00                799730.00       3.11 <==
+{l_shipdate}   800000.00      1.46           256.00              1.43                799730.00       3.11 <==
+{l_suppkey}    800000.00      1.46           270.00              36.74 <==           799730.00       3.11 <==
+{ps_availqty}  800000.00      1.46           9920.00             1.00                0.00            1.00
+{ps_partkey}   800000.00      1.46           199241.00           1.00                0.00            1.00
+{ps_suppkey}   800000.00      1.46           9920.00             1.00                0.00            1.00
+
+stats table=q20_scan_11
+----
+column_names   row_count  distinct_count  null_count
+{ps_availqty}  800000     9920            0
+{ps_partkey}   800000     199241          0
+{ps_suppkey}   800000     9920            0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{ps_availqty}  800000.00      1.00           9920.00             1.00                0.00            1.00
+{ps_partkey}   800000.00      1.00           199241.00           1.00                0.00            1.00
+{ps_suppkey}   800000.00      1.00           9920.00             1.00                0.00            1.00
+
+stats table=q20_index_join_12
+----
+column_names  row_count  distinct_count  null_count
+{l_partkey}   909455     197252          0
+{l_quantity}  909455     50              0
+{l_shipdate}  909455     365             0
+{l_suppkey}   909455     9920            0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_partkey}   666802.00      1.36           193505.00           1.02                0.00            1.00
+{l_quantity}  666802.00      1.36           50.00               1.00                0.00            1.00
+{l_shipdate}  666802.00      1.36           2526.00             6.92 <==            0.00            1.00
+{l_suppkey}   666802.00      1.36           9920.00             1.00                0.00            1.00
+
+stats table=q20_select_14
+----
+column_names  row_count  distinct_count  null_count
+{p_name}      2127       2127            0
+{p_partkey}   2127       2127            0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{p_name}      22222.00       10.45 <==      22210.00            10.44 <==           0.00            1.00
+{p_partkey}   22222.00       10.45 <==      22217.00            10.45 <==           0.00            1.00
+
+stats table=q20_scan_15
+----
+column_names  row_count  distinct_count  null_count
+{p_name}      200000     198131          0
+{p_partkey}   200000     199241          0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{p_name}      200000.00      1.00           198131.00           1.00                0.00            1.00
+{p_partkey}   200000.00      1.00           199241.00           1.00                0.00            1.00
+
+stats table=q20_select_16
+----
+column_names   row_count  distinct_count  null_count
+{n_name}       1          1               0
+{n_nationkey}  1          1               0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}       1.00           1.00           1.00                1.00                0.00            1.00
+{n_nationkey}  1.00           1.00           1.00                1.00                0.00            1.00
+
+stats table=q20_scan_17
+----
+column_names   row_count  distinct_count  null_count
+{n_name}       25         25              0
+{n_nationkey}  25         25              0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}       25.00          1.00           25.00               1.00                0.00            1.00
+{n_nationkey}  25.00          1.00           25.00               1.00                0.00            1.00
+
+# --------------------------------------------------
+# Q21
+# Suppliers Who Kept Orders Waiting Query
+# Identifies certain suppliers who were not able to ship required parts in a
+#  timely manner.
+#
+# Identifies suppliers, for a given nation, whose product was part of a multi-
+# supplier order (with current status of 'F') where they were the only supplier
+# who failed to meet the committed delivery date.
+# --------------------------------------------------
+save-tables database=tpch save-tables-prefix=q21
+SELECT
+    s_name,
+    count(*) AS numwait
+FROM
+    supplier,
+    lineitem l1,
+    orders,
+    nation
+WHERE
+    s_suppkey = l1.l_suppkey
+    AND o_orderkey = l1.l_orderkey
+    AND o_orderstatus = 'F'
+    AND l1.l_receiptDATE > l1.l_commitdate
+    AND EXISTS (
+        SELECT
+            *
+        FROM
+            lineitem l2
+        WHERE
+            l2.l_orderkey = l1.l_orderkey
+            AND l2.l_suppkey <> l1.l_suppkey
+    )
+    AND NOT EXISTS (
+        SELECT
+            *
+        FROM
+            lineitem l3
+        WHERE
+            l3.l_orderkey = l1.l_orderkey
+            AND l3.l_suppkey <> l1.l_suppkey
+            AND l3.l_receiptDATE > l3.l_commitdate
+    )
+    AND s_nationkey = n_nationkey
+    AND n_name = 'SAUDI ARABIA'
+GROUP BY
+    s_name
+ORDER BY
+    numwait DESC,
+    s_name
+LIMIT 100;
+----
+limit
+ ├── save-table-name: q21_limit_1
+ ├── columns: s_name:2(char!null) numwait:69(int)
+ ├── internal-ordering: -69,+2
+ ├── cardinality: [0 - 100]
+ ├── stats: [rows=100, distinct(2)=100, null(2)=0, distinct(69)=100, null(69)=0]
+ ├── key: (2)
+ ├── fd: (2)-->(69)
+ ├── ordering: -69,+2
+ ├── sort
+ │    ├── save-table-name: q21_sort_2
+ │    ├── columns: s_name:2(char!null) count_rows:69(int)
+ │    ├── stats: [rows=9628.02122, distinct(2)=9628.02122, null(2)=0, distinct(69)=9628.02122, null(69)=0]
+ │    ├── key: (2)
+ │    ├── fd: (2)-->(69)
+ │    ├── ordering: -69,+2
+ │    └── group-by
+ │         ├── save-table-name: q21_group_by_3
+ │         ├── columns: s_name:2(char!null) count_rows:69(int)
+ │         ├── grouping columns: s_name:2(char!null)
+ │         ├── stats: [rows=9628.02122, distinct(2)=9628.02122, null(2)=0, distinct(69)=9628.02122, null(69)=0]
+ │         ├── key: (2)
+ │         ├── fd: (2)-->(69)
+ │         ├── inner-join (lookup orders)
+ │         │    ├── save-table-name: q21_lookup_join_4
+ │         │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_nationkey:4(int!null) l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null) o_orderkey:24(int!null) o_orderstatus:26(char!null) n_nationkey:33(int!null) n_name:34(char!null)
+ │         │    ├── key columns: [8] = [24]
+ │         │    ├── stats: [rows=33144.2984, distinct(1)=9920, null(1)=0, distinct(2)=9628.02122, null(2)=0, distinct(4)=1, null(4)=0, distinct(8)=32069.6931, null(8)=0, distinct(10)=9920, null(10)=0, distinct(19)=2465.99641, null(19)=0, distinct(20)=2553.9941, null(20)=0, distinct(24)=32069.6931, null(24)=0, distinct(26)=1, null(26)=0, distinct(33)=1, null(33)=0, distinct(34)=1, null(34)=0]
+ │         │    ├── fd: ()-->(26,34), (1)-->(2,4), (8)==(24), (24)==(8), (1)==(10), (10)==(1), (4)==(33), (33)==(4)
+ │         │    ├── inner-join
+ │         │    │    ├── save-table-name: q21_inner_join_5
+ │         │    │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_nationkey:4(int!null) l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null) n_nationkey:33(int!null) n_name:34(char!null)
+ │         │    │    ├── stats: [rows=80661.4919, distinct(1)=9920, null(1)=0, distinct(2)=9986.88851, null(2)=0, distinct(4)=1, null(4)=0, distinct(8)=78046.2829, null(8)=0, distinct(10)=9920, null(10)=0, distinct(19)=2466, null(19)=0, distinct(20)=2554, null(20)=0, distinct(33)=1, null(33)=0, distinct(34)=1, null(34)=0]
+ │         │    │    ├── fd: ()-->(34), (1)-->(2,4), (1)==(10), (10)==(1), (4)==(33), (33)==(4)
+ │         │    │    ├── semi-join (merge)
+ │         │    │    │    ├── save-table-name: q21_merge_join_6
+ │         │    │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null)
+ │         │    │    │    ├── left ordering: +8
+ │         │    │    │    ├── right ordering: +37
+ │         │    │    │    ├── stats: [rows=2000405, distinct(8)=1216823.04, null(8)=0, distinct(10)=9920, null(10)=0, distinct(19)=2466, null(19)=0, distinct(20)=2554, null(20)=0]
+ │         │    │    │    ├── anti-join (merge)
+ │         │    │    │    │    ├── save-table-name: q21_merge_join_7
+ │         │    │    │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null)
+ │         │    │    │    │    ├── left ordering: +8
+ │         │    │    │    │    ├── right ordering: +53
+ │         │    │    │    │    ├── stats: [rows=2000405, distinct(8)=1216823.04, null(8)=0, distinct(10)=9920, null(10)=0, distinct(19)=2466, null(19)=0, distinct(20)=2554, null(20)=0]
+ │         │    │    │    │    ├── ordering: +8
+ │         │    │    │    │    ├── select
+ │         │    │    │    │    │    ├── save-table-name: q21_select_8
+ │         │    │    │    │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null)
+ │         │    │    │    │    │    ├── stats: [rows=2000405, distinct(8)=1216823.04, null(8)=0, distinct(10)=9920, null(10)=0, distinct(19)=2466, null(19)=0, distinct(20)=2554, null(20)=0]
+ │         │    │    │    │    │    ├── ordering: +8
+ │         │    │    │    │    │    ├── scan l1
+ │         │    │    │    │    │    │    ├── save-table-name: q21_scan_9
+ │         │    │    │    │    │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null)
+ │         │    │    │    │    │    │    ├── stats: [rows=6001215, distinct(8)=1527270, null(8)=0, distinct(10)=9920, null(10)=0, distinct(19)=2466, null(19)=0, distinct(20)=2554, null(20)=0]
+ │         │    │    │    │    │    │    └── ordering: +8
+ │         │    │    │    │    │    └── filters
+ │         │    │    │    │    │         └── l1.l_receiptdate > l1.l_commitdate [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
+ │         │    │    │    │    ├── select
+ │         │    │    │    │    │    ├── save-table-name: q21_select_10
+ │         │    │    │    │    │    ├── columns: l3.l_orderkey:53(int!null) l3.l_partkey:54(int!null) l3.l_suppkey:55(int!null) l3.l_linenumber:56(int!null) l3.l_quantity:57(float!null) l3.l_extendedprice:58(float!null) l3.l_discount:59(float!null) l3.l_tax:60(float!null) l3.l_returnflag:61(char!null) l3.l_linestatus:62(char!null) l3.l_shipdate:63(date!null) l3.l_commitdate:64(date!null) l3.l_receiptdate:65(date!null) l3.l_shipinstruct:66(char!null) l3.l_shipmode:67(char!null) l3.l_comment:68(varchar!null)
+ │         │    │    │    │    │    ├── stats: [rows=2000405, distinct(53)=1216823.04, null(53)=0, distinct(54)=199240.01, null(54)=0, distinct(55)=9920, null(55)=0, distinct(56)=7, null(56)=0, distinct(57)=50, null(57)=0, distinct(58)=859070.838, null(58)=0, distinct(59)=11, null(59)=0, distinct(60)=9, null(60)=0, distinct(61)=3, null(61)=0, distinct(62)=2, null(62)=0, distinct(63)=2526, null(63)=0, distinct(64)=2466, null(64)=0, distinct(65)=2554, null(65)=0, distinct(66)=4, null(66)=0, distinct(67)=7, null(67)=0, distinct(68)=1893898.05, null(68)=0]
+ │         │    │    │    │    │    ├── key: (53,56)
+ │         │    │    │    │    │    ├── fd: (53,56)-->(54,55,57-68)
+ │         │    │    │    │    │    ├── ordering: +53
+ │         │    │    │    │    │    ├── scan l3
+ │         │    │    │    │    │    │    ├── save-table-name: q21_scan_11
+ │         │    │    │    │    │    │    ├── columns: l3.l_orderkey:53(int!null) l3.l_partkey:54(int!null) l3.l_suppkey:55(int!null) l3.l_linenumber:56(int!null) l3.l_quantity:57(float!null) l3.l_extendedprice:58(float!null) l3.l_discount:59(float!null) l3.l_tax:60(float!null) l3.l_returnflag:61(char!null) l3.l_linestatus:62(char!null) l3.l_shipdate:63(date!null) l3.l_commitdate:64(date!null) l3.l_receiptdate:65(date!null) l3.l_shipinstruct:66(char!null) l3.l_shipmode:67(char!null) l3.l_comment:68(varchar!null)
+ │         │    │    │    │    │    │    ├── stats: [rows=6001215, distinct(53)=1527270, null(53)=0, distinct(54)=199241, null(54)=0, distinct(55)=9920, null(55)=0, distinct(56)=7, null(56)=0, distinct(57)=50, null(57)=0, distinct(58)=925955, null(58)=0, distinct(59)=11, null(59)=0, distinct(60)=9, null(60)=0, distinct(61)=3, null(61)=0, distinct(62)=2, null(62)=0, distinct(63)=2526, null(63)=0, distinct(64)=2466, null(64)=0, distinct(65)=2554, null(65)=0, distinct(66)=4, null(66)=0, distinct(67)=7, null(67)=0, distinct(68)=4643303, null(68)=0]
+ │         │    │    │    │    │    │    ├── key: (53,56)
+ │         │    │    │    │    │    │    ├── fd: (53,56)-->(54,55,57-68)
+ │         │    │    │    │    │    │    └── ordering: +53
+ │         │    │    │    │    │    └── filters
+ │         │    │    │    │    │         └── l3.l_receiptdate > l3.l_commitdate [type=bool, outer=(64,65), constraints=(/64: (/NULL - ]; /65: (/NULL - ])]
+ │         │    │    │    │    └── filters
+ │         │    │    │    │         └── l3.l_suppkey != l1.l_suppkey [type=bool, outer=(10,55), constraints=(/10: (/NULL - ]; /55: (/NULL - ])]
+ │         │    │    │    ├── scan l2
+ │         │    │    │    │    ├── save-table-name: q21_scan_12
+ │         │    │    │    │    ├── columns: l2.l_orderkey:37(int!null) l2.l_partkey:38(int!null) l2.l_suppkey:39(int!null) l2.l_linenumber:40(int!null) l2.l_quantity:41(float!null) l2.l_extendedprice:42(float!null) l2.l_discount:43(float!null) l2.l_tax:44(float!null) l2.l_returnflag:45(char!null) l2.l_linestatus:46(char!null) l2.l_shipdate:47(date!null) l2.l_commitdate:48(date!null) l2.l_receiptdate:49(date!null) l2.l_shipinstruct:50(char!null) l2.l_shipmode:51(char!null) l2.l_comment:52(varchar!null)
+ │         │    │    │    │    ├── stats: [rows=6001215, distinct(37)=1527270, null(37)=0, distinct(38)=199241, null(38)=0, distinct(39)=9920, null(39)=0, distinct(40)=7, null(40)=0, distinct(41)=50, null(41)=0, distinct(42)=925955, null(42)=0, distinct(43)=11, null(43)=0, distinct(44)=9, null(44)=0, distinct(45)=3, null(45)=0, distinct(46)=2, null(46)=0, distinct(47)=2526, null(47)=0, distinct(48)=2466, null(48)=0, distinct(49)=2554, null(49)=0, distinct(50)=4, null(50)=0, distinct(51)=7, null(51)=0, distinct(52)=4643303, null(52)=0]
+ │         │    │    │    │    ├── key: (37,40)
+ │         │    │    │    │    ├── fd: (37,40)-->(38,39,41-52)
+ │         │    │    │    │    └── ordering: +37
+ │         │    │    │    └── filters
+ │         │    │    │         └── l2.l_suppkey != l1.l_suppkey [type=bool, outer=(10,39), constraints=(/10: (/NULL - ]; /39: (/NULL - ])]
+ │         │    │    ├── inner-join (lookup supplier)
+ │         │    │    │    ├── save-table-name: q21_lookup_join_13
+ │         │    │    │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_nationkey:4(int!null) n_nationkey:33(int!null) n_name:34(char!null)
+ │         │    │    │    ├── key columns: [1] = [1]
+ │         │    │    │    ├── stats: [rows=400, distinct(1)=399.934613, null(1)=0, distinct(2)=399.991883, null(2)=0, distinct(4)=1, null(4)=0, distinct(33)=1, null(33)=0, distinct(34)=1, null(34)=0]
+ │         │    │    │    ├── key: (1)
+ │         │    │    │    ├── fd: ()-->(34), (1)-->(2,4), (4)==(33), (33)==(4)
+ │         │    │    │    ├── inner-join (lookup supplier@s_nk)
+ │         │    │    │    │    ├── save-table-name: q21_lookup_join_14
+ │         │    │    │    │    ├── columns: s_suppkey:1(int!null) s_nationkey:4(int!null) n_nationkey:33(int!null) n_name:34(char!null)
+ │         │    │    │    │    ├── key columns: [33] = [4]
+ │         │    │    │    │    ├── stats: [rows=400, distinct(1)=399.934613, null(1)=0, distinct(4)=1, null(4)=0, distinct(33)=1, null(33)=0, distinct(34)=1, null(34)=0]
+ │         │    │    │    │    ├── key: (1)
+ │         │    │    │    │    ├── fd: ()-->(34), (1)-->(4), (4)==(33), (33)==(4)
+ │         │    │    │    │    ├── select
+ │         │    │    │    │    │    ├── save-table-name: q21_select_15
+ │         │    │    │    │    │    ├── columns: n_nationkey:33(int!null) n_name:34(char!null)
+ │         │    │    │    │    │    ├── stats: [rows=1, distinct(33)=1, null(33)=0, distinct(34)=1, null(34)=0]
+ │         │    │    │    │    │    ├── key: (33)
+ │         │    │    │    │    │    ├── fd: ()-->(34)
+ │         │    │    │    │    │    ├── scan nation
+ │         │    │    │    │    │    │    ├── save-table-name: q21_scan_16
+ │         │    │    │    │    │    │    ├── columns: n_nationkey:33(int!null) n_name:34(char!null)
+ │         │    │    │    │    │    │    ├── stats: [rows=25, distinct(33)=25, null(33)=0, distinct(34)=25, null(34)=0]
+ │         │    │    │    │    │    │    ├── key: (33)
+ │         │    │    │    │    │    │    └── fd: (33)-->(34)
+ │         │    │    │    │    │    └── filters
+ │         │    │    │    │    │         └── n_name = 'SAUDI ARABIA' [type=bool, outer=(34), constraints=(/34: [/'SAUDI ARABIA' - /'SAUDI ARABIA']; tight), fd=()-->(34)]
+ │         │    │    │    │    └── filters (true)
+ │         │    │    │    └── filters (true)
+ │         │    │    └── filters
+ │         │    │         └── s_suppkey = l1.l_suppkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+ │         │    └── filters
+ │         │         └── o_orderstatus = 'F' [type=bool, outer=(26), constraints=(/26: [/'F' - /'F']; tight), fd=()-->(26)]
+ │         └── aggregations
+ │              └── count-rows [type=int]
+ └── const: 100 [type=int]
+
+stats table=q21_limit_1
+----
+column_names  row_count  distinct_count  null_count
+{numwait}     100        8               0
+{s_name}      100        100             0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{numwait}     100.00         1.00           100.00              12.50 <==           0.00            1.00
+{s_name}      100.00         1.00           100.00              1.00                0.00            1.00
+
+stats table=q21_sort_2
+----
+column_names  row_count  distinct_count  null_count
+{count_rows}  100        8               0
+{s_name}      100        100             0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{count_rows}  9628.00        96.28 <==      9628.00             1203.50 <==         0.00            1.00
+{s_name}      9628.00        96.28 <==      9628.00             96.28 <==           0.00            1.00
+
+stats table=q21_group_by_3
+----
+column_names  row_count  distinct_count  null_count
+{count_rows}  411        17              0
+{s_name}      411        411             0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{count_rows}  9628.00        23.43 <==      9628.00             566.35 <==          0.00            1.00
+{s_name}      9628.00        23.43 <==      9628.00             23.43 <==           0.00            1.00
+
+stats table=q21_lookup_join_4
+----
+column_names     row_count  distinct_count  null_count
+{l_commitdate}   4141       1188            0
+{l_orderkey}     4141       4127            0
+{l_receiptdate}  4141       1174            0
+{l_suppkey}      4141       411             0
+{n_name}         4141       1               0
+{n_nationkey}    4141       1               0
+{o_orderkey}     4141       4127            0
+{o_orderstatus}  4141       1               0
+{s_name}         4141       411             0
+{s_nationkey}    4141       1               0
+{s_suppkey}      4141       411             0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_commitdate}   33144.00       8.00 <==       2466.00             2.08 <==            0.00            1.00
+{l_orderkey}     33144.00       8.00 <==       32070.00            7.77 <==            0.00            1.00
+{l_receiptdate}  33144.00       8.00 <==       2554.00             2.18 <==            0.00            1.00
+{l_suppkey}      33144.00       8.00 <==       9920.00             24.14 <==           0.00            1.00
+{n_name}         33144.00       8.00 <==       1.00                1.00                0.00            1.00
+{n_nationkey}    33144.00       8.00 <==       1.00                1.00                0.00            1.00
+{o_orderkey}     33144.00       8.00 <==       32070.00            7.77 <==            0.00            1.00
+{o_orderstatus}  33144.00       8.00 <==       1.00                1.00                0.00            1.00
+{s_name}         33144.00       8.00 <==       9628.00             23.43 <==           0.00            1.00
+{s_nationkey}    33144.00       8.00 <==       1.00                1.00                0.00            1.00
+{s_suppkey}      33144.00       8.00 <==       9920.00             24.14 <==           0.00            1.00
+
+stats table=q21_inner_join_5
+----
+column_names     row_count  distinct_count  null_count
+{l_commitdate}   8357       2357            0
+{l_orderkey}     8357       8343            0
+{l_receiptdate}  8357       2379            0
+{l_suppkey}      8357       411             0
+{n_name}         8357       1               0
+{n_nationkey}    8357       1               0
+{s_name}         8357       411             0
+{s_nationkey}    8357       1               0
+{s_suppkey}      8357       411             0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_commitdate}   80661.00       9.65 <==       2466.00             1.05                0.00            1.00
+{l_orderkey}     80661.00       9.65 <==       78046.00            9.35 <==            0.00            1.00
+{l_receiptdate}  80661.00       9.65 <==       2554.00             1.07                0.00            1.00
+{l_suppkey}      80661.00       9.65 <==       9920.00             24.14 <==           0.00            1.00
+{n_name}         80661.00       9.65 <==       1.00                1.00                0.00            1.00
+{n_nationkey}    80661.00       9.65 <==       1.00                1.00                0.00            1.00
+{s_name}         80661.00       9.65 <==       9987.00             24.30 <==           0.00            1.00
+{s_nationkey}    80661.00       9.65 <==       1.00                1.00                0.00            1.00
+{s_suppkey}      80661.00       9.65 <==       9920.00             24.14 <==           0.00            1.00
+
+stats table=q21_merge_join_6
+----
+column_names     row_count  distinct_count  null_count
+{l_commitdate}   202092     2465            0
+{l_orderkey}     202092     202357          0
+{l_receiptdate}  202092     2509            0
+{l_suppkey}      202092     9920            0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_commitdate}   2000405.00     9.90 <==       2466.00             1.00                0.00            1.00
+{l_orderkey}     2000405.00     9.90 <==       1216823.00          6.01 <==            0.00            1.00
+{l_receiptdate}  2000405.00     9.90 <==       2554.00             1.02                0.00            1.00
+{l_suppkey}      2000405.00     9.90 <==       9920.00             1.00                0.00            1.00
+
+stats table=q21_merge_join_7
+----
+column_names     row_count  distinct_count  null_count
+{l_commitdate}   337680     2465            0
+{l_orderkey}     337680     338428          0
+{l_receiptdate}  337680     2513            0
+{l_suppkey}      337680     9920            0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_commitdate}   2000405.00     5.92 <==       2466.00             1.00                0.00            1.00
+{l_orderkey}     2000405.00     5.92 <==       1216823.00          3.60 <==            0.00            1.00
+{l_receiptdate}  2000405.00     5.92 <==       2554.00             1.02                0.00            1.00
+{l_suppkey}      2000405.00     5.92 <==       9920.00             1.00                0.00            1.00
+
+stats table=q21_select_8
+----
+column_names     row_count  distinct_count  null_count
+{l_commitdate}   3793296    2466            0
+{l_orderkey}     3793296    1405723         0
+{l_receiptdate}  3793296    2525            0
+{l_suppkey}      3793296    9920            0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_commitdate}   2000405.00     1.90           2466.00             1.00                0.00            1.00
+{l_orderkey}     2000405.00     1.90           1216823.00          1.16                0.00            1.00
+{l_receiptdate}  2000405.00     1.90           2554.00             1.01                0.00            1.00
+{l_suppkey}      2000405.00     1.90           9920.00             1.00                0.00            1.00
+
+stats table=q21_scan_9
+----
+column_names     row_count  distinct_count  null_count
+{l_commitdate}   6001215    2466            0
+{l_orderkey}     6001215    1527270         0
+{l_receiptdate}  6001215    2554            0
+{l_suppkey}      6001215    9920            0
+~~~~
+column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_commitdate}   6001215.00     1.00           2466.00             1.00                0.00            1.00
+{l_orderkey}     6001215.00     1.00           1527270.00          1.00                0.00            1.00
+{l_receiptdate}  6001215.00     1.00           2554.00             1.00                0.00            1.00
+{l_suppkey}      6001215.00     1.00           9920.00             1.00                0.00            1.00
+
+stats table=q21_select_10
+----
+column_names       row_count  distinct_count  null_count
+{l_comment}        3793296    3017108         0
+{l_commitdate}     3793296    2466            0
+{l_discount}       3793296    11              0
+{l_extendedprice}  3793296    902869          0
+{l_linenumber}     3793296    7               0
+{l_linestatus}     3793296    2               0
+{l_orderkey}       3793296    1405723         0
+{l_partkey}        3793296    199241          0
+{l_quantity}       3793296    50              0
+{l_receiptdate}    3793296    2525            0
+{l_returnflag}     3793296    3               0
+{l_shipdate}       3793296    2520            0
+{l_shipinstruct}   3793296    4               0
+{l_shipmode}       3793296    7               0
+{l_suppkey}        3793296    9920            0
+{l_tax}            3793296    9               0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_comment}        2000405.00     1.90           1893898.00          1.59                0.00            1.00
+{l_commitdate}     2000405.00     1.90           2466.00             1.00                0.00            1.00
+{l_discount}       2000405.00     1.90           11.00               1.00                0.00            1.00
+{l_extendedprice}  2000405.00     1.90           859071.00           1.05                0.00            1.00
+{l_linenumber}     2000405.00     1.90           7.00                1.00                0.00            1.00
+{l_linestatus}     2000405.00     1.90           2.00                1.00                0.00            1.00
+{l_orderkey}       2000405.00     1.90           1216823.00          1.16                0.00            1.00
+{l_partkey}        2000405.00     1.90           199240.00           1.00                0.00            1.00
+{l_quantity}       2000405.00     1.90           50.00               1.00                0.00            1.00
+{l_receiptdate}    2000405.00     1.90           2554.00             1.01                0.00            1.00
+{l_returnflag}     2000405.00     1.90           3.00                1.00                0.00            1.00
+{l_shipdate}       2000405.00     1.90           2526.00             1.00                0.00            1.00
+{l_shipinstruct}   2000405.00     1.90           4.00                1.00                0.00            1.00
+{l_shipmode}       2000405.00     1.90           7.00                1.00                0.00            1.00
+{l_suppkey}        2000405.00     1.90           9920.00             1.00                0.00            1.00
+{l_tax}            2000405.00     1.90           9.00                1.00                0.00            1.00
+
+stats table=q21_scan_11
+----
+column_names       row_count  distinct_count  null_count
+{l_comment}        6001215    4643303         0
+{l_commitdate}     6001215    2466            0
+{l_discount}       6001215    11              0
+{l_extendedprice}  6001215    925955          0
+{l_linenumber}     6001215    7               0
+{l_linestatus}     6001215    2               0
+{l_orderkey}       6001215    1527270         0
+{l_partkey}        6001215    199241          0
+{l_quantity}       6001215    50              0
+{l_receiptdate}    6001215    2554            0
+{l_returnflag}     6001215    3               0
+{l_shipdate}       6001215    2526            0
+{l_shipinstruct}   6001215    4               0
+{l_shipmode}       6001215    7               0
+{l_suppkey}        6001215    9920            0
+{l_tax}            6001215    9               0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_comment}        6001215.00     1.00           4643303.00          1.00                0.00            1.00
+{l_commitdate}     6001215.00     1.00           2466.00             1.00                0.00            1.00
+{l_discount}       6001215.00     1.00           11.00               1.00                0.00            1.00
+{l_extendedprice}  6001215.00     1.00           925955.00           1.00                0.00            1.00
+{l_linenumber}     6001215.00     1.00           7.00                1.00                0.00            1.00
+{l_linestatus}     6001215.00     1.00           2.00                1.00                0.00            1.00
+{l_orderkey}       6001215.00     1.00           1527270.00          1.00                0.00            1.00
+{l_partkey}        6001215.00     1.00           199241.00           1.00                0.00            1.00
+{l_quantity}       6001215.00     1.00           50.00               1.00                0.00            1.00
+{l_receiptdate}    6001215.00     1.00           2554.00             1.00                0.00            1.00
+{l_returnflag}     6001215.00     1.00           3.00                1.00                0.00            1.00
+{l_shipdate}       6001215.00     1.00           2526.00             1.00                0.00            1.00
+{l_shipinstruct}   6001215.00     1.00           4.00                1.00                0.00            1.00
+{l_shipmode}       6001215.00     1.00           7.00                1.00                0.00            1.00
+{l_suppkey}        6001215.00     1.00           9920.00             1.00                0.00            1.00
+{l_tax}            6001215.00     1.00           9.00                1.00                0.00            1.00
+
+stats table=q21_scan_12
+----
+column_names       row_count  distinct_count  null_count
+{l_comment}        6001215    4643303         0
+{l_commitdate}     6001215    2466            0
+{l_discount}       6001215    11              0
+{l_extendedprice}  6001215    925955          0
+{l_linenumber}     6001215    7               0
+{l_linestatus}     6001215    2               0
+{l_orderkey}       6001215    1527270         0
+{l_partkey}        6001215    199241          0
+{l_quantity}       6001215    50              0
+{l_receiptdate}    6001215    2554            0
+{l_returnflag}     6001215    3               0
+{l_shipdate}       6001215    2526            0
+{l_shipinstruct}   6001215    4               0
+{l_shipmode}       6001215    7               0
+{l_suppkey}        6001215    9920            0
+{l_tax}            6001215    9               0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_comment}        6001215.00     1.00           4643303.00          1.00                0.00            1.00
+{l_commitdate}     6001215.00     1.00           2466.00             1.00                0.00            1.00
+{l_discount}       6001215.00     1.00           11.00               1.00                0.00            1.00
+{l_extendedprice}  6001215.00     1.00           925955.00           1.00                0.00            1.00
+{l_linenumber}     6001215.00     1.00           7.00                1.00                0.00            1.00
+{l_linestatus}     6001215.00     1.00           2.00                1.00                0.00            1.00
+{l_orderkey}       6001215.00     1.00           1527270.00          1.00                0.00            1.00
+{l_partkey}        6001215.00     1.00           199241.00           1.00                0.00            1.00
+{l_quantity}       6001215.00     1.00           50.00               1.00                0.00            1.00
+{l_receiptdate}    6001215.00     1.00           2554.00             1.00                0.00            1.00
+{l_returnflag}     6001215.00     1.00           3.00                1.00                0.00            1.00
+{l_shipdate}       6001215.00     1.00           2526.00             1.00                0.00            1.00
+{l_shipinstruct}   6001215.00     1.00           4.00                1.00                0.00            1.00
+{l_shipmode}       6001215.00     1.00           7.00                1.00                0.00            1.00
+{l_suppkey}        6001215.00     1.00           9920.00             1.00                0.00            1.00
+{l_tax}            6001215.00     1.00           9.00                1.00                0.00            1.00
+
+stats table=q21_lookup_join_13
+----
+column_names   row_count  distinct_count  null_count
+{n_name}       411        1               0
+{n_nationkey}  411        1               0
+{s_name}       411        411             0
+{s_nationkey}  411        1               0
+{s_suppkey}    411        411             0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}       400.00         1.03           1.00                1.00                0.00            1.00
+{n_nationkey}  400.00         1.03           1.00                1.00                0.00            1.00
+{s_name}       400.00         1.03           400.00              1.03                0.00            1.00
+{s_nationkey}  400.00         1.03           1.00                1.00                0.00            1.00
+{s_suppkey}    400.00         1.03           400.00              1.03                0.00            1.00
+
+stats table=q21_lookup_join_14
+----
+column_names   row_count  distinct_count  null_count
+{n_name}       411        1               0
+{n_nationkey}  411        1               0
+{s_nationkey}  411        1               0
+{s_suppkey}    411        411             0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}       400.00         1.03           1.00                1.00                0.00            1.00
+{n_nationkey}  400.00         1.03           1.00                1.00                0.00            1.00
+{s_nationkey}  400.00         1.03           1.00                1.00                0.00            1.00
+{s_suppkey}    400.00         1.03           400.00              1.03                0.00            1.00
+
+stats table=q21_select_15
+----
+column_names   row_count  distinct_count  null_count
+{n_name}       1          1               0
+{n_nationkey}  1          1               0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}       1.00           1.00           1.00                1.00                0.00            1.00
+{n_nationkey}  1.00           1.00           1.00                1.00                0.00            1.00
+
+stats table=q21_scan_16
+----
+column_names   row_count  distinct_count  null_count
+{n_name}       25         25              0
+{n_nationkey}  25         25              0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{n_name}       25.00          1.00           25.00               1.00                0.00            1.00
+{n_nationkey}  25.00          1.00           25.00               1.00                0.00            1.00
+
+# --------------------------------------------------
+# Q22
+# Global Sales Opportunity
+# Identifies geographies where there are customers who may be likely to make a
+# purchase.
+#
+# This query counts how many customers within a specific range of country codes
+# have not placed orders for 7 years but who have a greater than average
+# “positive” account balance. It also reflects the magnitude of that balance.
+# Country code is defined as the first two characters of c_phone.
+# --------------------------------------------------
+save-tables database=tpch save-tables-prefix=q22
+SELECT
+    cntrycode,
+    count(*) AS numcust,
+    sum(c_acctbal) AS totacctbal
+FROM (
+    SELECT
+        substring(c_phone FROM 1 FOR 2) AS cntrycode,
+        c_acctbal
+    FROM
+        customer
+    WHERE
+        substring(c_phone FROM 1 FOR 2) in
+            ('13', '31', '23', '29', '30', '18', '17')
+        AND c_acctbal > (
+            SELECT
+                avg(c_acctbal)
+            FROM
+                customer
+            WHERE
+                c_acctbal > 0.00
+                AND substring(c_phone FROM 1 FOR 2) in
+                    ('13', '31', '23', '29', '30', '18', '17')
+        )
+        AND NOT EXISTS (
+            SELECT
+                *
+            FROM
+                orders
+            WHERE
+                o_custkey = c_custkey
+        )
+    ) AS custsale
+GROUP BY
+    cntrycode
+ORDER BY
+    cntrycode;
+----
+group-by
+ ├── save-table-name: q22_group_by_1
+ ├── columns: cntrycode:27(string) numcust:28(int) totacctbal:29(float)
+ ├── grouping columns: cntrycode:27(string)
+ ├── stats: [rows=16666.6667, distinct(27)=16666.6667, null(27)=0, distinct(28)=16666.6667, null(28)=0, distinct(29)=16666.6667, null(29)=0]
+ ├── key: (27)
+ ├── fd: (27)-->(28,29)
+ ├── ordering: +27
+ ├── sort
+ │    ├── save-table-name: q22_sort_2
+ │    ├── columns: c_acctbal:6(float!null) cntrycode:27(string)
+ │    ├── stats: [rows=16666.6667, distinct(6)=16602.7036, null(6)=0, distinct(27)=16666.6667, null(27)=0]
+ │    ├── ordering: +27
+ │    └── project
+ │         ├── save-table-name: q22_project_3
+ │         ├── columns: cntrycode:27(string) c_acctbal:6(float!null)
+ │         ├── stats: [rows=16666.6667, distinct(6)=16602.7036, null(6)=0, distinct(27)=16666.6667, null(27)=0]
+ │         ├── anti-join (merge)
+ │         │    ├── save-table-name: q22_merge_join_4
+ │         │    ├── columns: c_custkey:1(int!null) c_phone:5(char!null) c_acctbal:6(float!null)
+ │         │    ├── left ordering: +1
+ │         │    ├── right ordering: +19
+ │         │    ├── stats: [rows=16666.6667, distinct(1)=16658.9936, null(1)=0, distinct(5)=16666.6667, null(5)=0, distinct(6)=16602.7036, null(6)=0]
+ │         │    ├── key: (1)
+ │         │    ├── fd: (1)-->(5,6)
+ │         │    ├── select
+ │         │    │    ├── save-table-name: q22_select_5
+ │         │    │    ├── columns: c_custkey:1(int!null) c_phone:5(char!null) c_acctbal:6(float!null)
+ │         │    │    ├── stats: [rows=16666.6667, distinct(1)=16658.9936, null(1)=0, distinct(5)=16666.6667, null(5)=0, distinct(6)=16602.7036, null(6)=0]
+ │         │    │    ├── key: (1)
+ │         │    │    ├── fd: (1)-->(5,6)
+ │         │    │    ├── ordering: +1
+ │         │    │    ├── scan customer
+ │         │    │    │    ├── save-table-name: q22_scan_6
+ │         │    │    │    ├── columns: c_custkey:1(int!null) c_phone:5(char!null) c_acctbal:6(float!null)
+ │         │    │    │    ├── stats: [rows=150000, distinct(1)=148813, null(1)=0, distinct(5)=150000, null(5)=0, distinct(6)=140628, null(6)=0]
+ │         │    │    │    ├── key: (1)
+ │         │    │    │    ├── fd: (1)-->(5,6)
+ │         │    │    │    └── ordering: +1
+ │         │    │    └── filters
+ │         │    │         ├── substring(c_phone, 1, 2) IN ('13', '17', '18', '23', '29', '30', '31') [type=bool, outer=(5)]
+ │         │    │         └── gt [type=bool, outer=(6), subquery, constraints=(/6: (/NULL - ])]
+ │         │    │              ├── variable: c_acctbal [type=float]
+ │         │    │              └── subquery [type=float]
+ │         │    │                   └── scalar-group-by
+ │         │    │                        ├── save-table-name: q22_scalar_group_by_7
+ │         │    │                        ├── columns: avg:17(float)
+ │         │    │                        ├── cardinality: [1 - 1]
+ │         │    │                        ├── stats: [rows=1, distinct(17)=1, null(17)=0]
+ │         │    │                        ├── key: ()
+ │         │    │                        ├── fd: ()-->(17)
+ │         │    │                        ├── select
+ │         │    │                        │    ├── save-table-name: q22_select_8
+ │         │    │                        │    ├── columns: c_phone:13(char!null) c_acctbal:14(float!null)
+ │         │    │                        │    ├── stats: [rows=16666.6667, distinct(13)=16666.6667, null(13)=0, distinct(14)=16602.7036, null(14)=0]
+ │         │    │                        │    ├── scan customer
+ │         │    │                        │    │    ├── save-table-name: q22_scan_9
+ │         │    │                        │    │    ├── columns: c_phone:13(char!null) c_acctbal:14(float!null)
+ │         │    │                        │    │    └── stats: [rows=150000, distinct(13)=150000, null(13)=0, distinct(14)=140628, null(14)=0]
+ │         │    │                        │    └── filters
+ │         │    │                        │         ├── c_acctbal > 0.0 [type=bool, outer=(14), constraints=(/14: [/5e-324 - ]; tight)]
+ │         │    │                        │         └── substring(c_phone, 1, 2) IN ('13', '17', '18', '23', '29', '30', '31') [type=bool, outer=(13)]
+ │         │    │                        └── aggregations
+ │         │    │                             └── avg [type=float, outer=(14)]
+ │         │    │                                  └── variable: c_acctbal [type=float]
+ │         │    ├── scan orders@o_ck
+ │         │    │    ├── save-table-name: q22_scan_10
+ │         │    │    ├── columns: o_custkey:19(int!null)
+ │         │    │    ├── stats: [rows=1500000, distinct(19)=99846, null(19)=0]
+ │         │    │    └── ordering: +19
+ │         │    └── filters (true)
+ │         └── projections
+ │              └── substring(c_phone, 1, 2) [type=string, outer=(5)]
+ └── aggregations
+      ├── count-rows [type=int]
+      └── sum [type=float, outer=(6)]
+           └── variable: c_acctbal [type=float]
+
+stats table=q22_group_by_1
+----
+column_names  row_count  distinct_count  null_count
+{cntrycode}   7          7               0
+{numcust}     7          7               0
+{totacctbal}  7          7               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{cntrycode}   16667.00       2381.00 <==    16667.00            2381.00 <==         0.00            1.00
+{numcust}     16667.00       2381.00 <==    16667.00            2381.00 <==         0.00            1.00
+{totacctbal}  16667.00       2381.00 <==    16667.00            2381.00 <==         0.00            1.00
+
+stats table=q22_sort_2
+----
+column_names  row_count  distinct_count  null_count
+{c_acctbal}   6384       6304            0
+{cntrycode}   6384       7               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_acctbal}   16667.00       2.61 <==       16603.00            2.63 <==            0.00            1.00
+{cntrycode}   16667.00       2.61 <==       16667.00            2381.00 <==         0.00            1.00
+
+stats table=q22_project_3
+----
+column_names  row_count  distinct_count  null_count
+{c_acctbal}   6384       6304            0
+{cntrycode}   6384       7               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_acctbal}   16667.00       2.61 <==       16603.00            2.63 <==            0.00            1.00
+{cntrycode}   16667.00       2.61 <==       16667.00            2381.00 <==         0.00            1.00
+
+stats table=q22_merge_join_4
+----
+column_names  row_count  distinct_count  null_count
+{c_acctbal}   6384       6304            0
+{c_custkey}   6384       6359            0
+{c_phone}     6384       6428            0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_acctbal}   16667.00       2.61 <==       16603.00            2.63 <==            0.00            1.00
+{c_custkey}   16667.00       2.61 <==       16659.00            2.62 <==            0.00            1.00
+{c_phone}     16667.00       2.61 <==       16667.00            2.59 <==            0.00            1.00
+
+stats table=q22_select_5
+----
+column_names  row_count  distinct_count  null_count
+{c_acctbal}   19000      18527           0
+{c_custkey}   19000      19097           0
+{c_phone}     19000      19095           0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_acctbal}   16667.00       1.14           16603.00            1.12                0.00            1.00
+{c_custkey}   16667.00       1.14           16659.00            1.15                0.00            1.00
+{c_phone}     16667.00       1.14           16667.00            1.15                0.00            1.00
+
+stats table=q22_scan_6
+----
+column_names  row_count  distinct_count  null_count
+{c_acctbal}   150000     140628          0
+{c_custkey}   150000     148813          0
+{c_phone}     150000     150872          0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_acctbal}   150000.00      1.00           140628.00           1.00                0.00            1.00
+{c_custkey}   150000.00      1.00           148813.00           1.00                0.00            1.00
+{c_phone}     150000.00      1.00           150000.00           1.01                0.00            1.00
+
+stats table=q22_scalar_group_by_7
+----
+column_names  row_count  distinct_count  null_count
+{avg}         1          1               0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{avg}         1.00           1.00           1.00                1.00                0.00            1.00
+
+stats table=q22_select_8
+----
+column_names  row_count  distinct_count  null_count
+{c_acctbal}   38120      37172           0
+{c_phone}     38120      38046           0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_acctbal}   16667.00       2.29 <==       16603.00            2.24 <==            0.00            1.00
+{c_phone}     16667.00       2.29 <==       16667.00            2.28 <==            0.00            1.00
+
+stats table=q22_scan_9
+----
+column_names  row_count  distinct_count  null_count
+{c_acctbal}   150000     140628          0
+{c_phone}     150000     150872          0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{c_acctbal}   150000.00      1.00           140628.00           1.00                0.00            1.00
+{c_phone}     150000.00      1.00           150000.00           1.01                0.00            1.00
+
+stats table=q22_scan_10
+----
+column_names  row_count  distinct_count  null_count
+{o_custkey}   1500000    99846           0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{o_custkey}   1500000.00     1.00           99846.00            1.00                0.00            1.00

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1559,9 +1559,9 @@ func (ef *execFactory) ConstructSequenceSelect(sequence cat.Sequence) (exec.Node
 
 // ConstructSaveTable is part of the exec.Factory interface.
 func (ef *execFactory) ConstructSaveTable(
-	input exec.Node, table *cat.DataSourceName,
+	input exec.Node, table *cat.DataSourceName, colNames []string,
 ) (exec.Node, error) {
-	return ef.planner.makeSaveTable(input.(planNode), table), nil
+	return ef.planner.makeSaveTable(input.(planNode), table, colNames), nil
 }
 
 // renderBuilder encapsulates the code to build a renderNode.


### PR DESCRIPTION
This commit adds all TPC-H queries to the statistics quality testing
infrastructure. In order to handle the full range of relational
expressions found in the TPC-H queries, this commit also includes a
few fixes to the existing infrastructure. In particular, it ensures
that the column names are always consistent between the table created
by `saveTableNode` and the corresponding test catalog table. It also
ensures that the test catalog includes saved tables from relational
expressions in subqueries.

Release note: None