### PR TITLE
[DO NOT MERGE] builder: go1.12-boringcrypto

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20190318-200038
+version=20190601-131333-boringcrypto
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -196,8 +196,8 @@ RUN git clone git://git.sv.gnu.org/sed \
 # releases of Go will no longer be run in CI once it is changed. Consider
 # bumping the minimum allowed version of Go in /build/go-version-chech.sh.
 RUN apt-get install -y --no-install-recommends golang \
- && curl -fsSL https://storage.googleapis.com/golang/go1.11.6.src.tar.gz -o golang.tar.gz \
- && echo 'a96da1425dcbec094736033a8a416316547f8100ab4b72c31d4824d761d3e133 golang.tar.gz' | sha256sum -c - \
+ && curl -fsSL https://go-boringcrypto.storage.googleapis.com/go1.12.5b4.src.tar.gz -o golang.tar.gz \
+ && echo '054d482896a77ae2d7d24c7adf08da5a4401b938871e61a5cdabc735c54cea9f golang.tar.gz' | sha256sum -c - \
  && tar -C /usr/local -xzf golang.tar.gz \
  && rm golang.tar.gz \
  && cd /usr/local/go/src \

--- a/pkg/util/growstack/growstack.go
+++ b/pkg/util/growstack/growstack.go
@@ -1,0 +1,24 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package growstack
+
+// Grow grows the goroutine stack by 16 KB. Goroutine stacks currently start
+// at 2 KB in size. The code paths through the storage package often need a
+// stack that is 32 KB in size. The stack growth is mildly expensive making it
+// useful to trick the runtime into growing the stack early. Since goroutine
+// stacks grow in multiples of 2 and start at 2 KB in size, by placing a 16 KB
+// object on the stack early in the lifetime of a goroutine we force the
+// runtime to use a 32 KB stack for the goroutine.
+func Grow()

--- a/pkg/util/growstack/growstack.s
+++ b/pkg/util/growstack/growstack.s
@@ -1,0 +1,19 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+#include "funcdata.h"
+
+TEXT ·Grow(SB),0,$16384-0
+        NO_LOCAL_POINTERS
+        RET


### PR DESCRIPTION
The `b<boring-crypto-version>` suffix on `go version` indicates a
boringcrypto toolchain:

  go version go1.12.5b4 linux/amd64

A binary can be examined to see if it was compiled with boringcrypto
support by doing:

  go tool nm <binary> | grep Cfunc__goboringcrypto

Release note: None