### PR TITLE
release-19.1: opt: fix data race when building filters item props

### DIFF
--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1075,9 +1075,13 @@ func (b *logicalPropsBuilder) buildFiltersItemProps(item *FiltersItem, scalar *p
 	// Constraints
 	// -----------
 	cb := constraintsBuilder{md: b.mem.Metadata(), evalCtx: b.evalCtx}
-	scalar.Constraints, scalar.TightConstraints = cb.buildConstraints(item.Condition)
-	if scalar.Constraints.IsUnconstrained() {
+	// TODO(rytaft): Using local variables here to avoid a data race. It would be
+	// better to avoid lazy building of props altogether.
+	constraints, tightConstraints := cb.buildConstraints(item.Condition)
+	if constraints.IsUnconstrained() {
 		scalar.Constraints, scalar.TightConstraints = nil, false
+	} else {
+		scalar.Constraints, scalar.TightConstraints = constraints, tightConstraints
 	}
 
 	// Functional Dependencies


### PR DESCRIPTION
Backport 1/1 commits from #37972.

/cc @cockroachdb/release

---

This commit fixes a race condition where two threads could be
simultaneously trying to build the logical properties of a filters
item and stepping on each others toes. In particular, one thread
could set `scalar.Constraints` to nil, causing a panic when another
thread tries to check whether `scalar.Constraints.IsUnconstrained()`.
This commit fixes the issue by using a local variable to check whether
the constraint set is unconstrained.

Fixes #37951
Informs #37073
Informs #36148

Release note (bug fix): Fixed a race condition that could cause a
panic during query planning.
