### PR TITLE
opt: add EliminateOffset rule

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -246,7 +246,6 @@ ORDER BY a0.created_at
 ----
 limit                                 ·            ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)          +created_at
  │                                    count        10                         ·                                                                                        ·
- │                                    offset       0                          ·                                                                                        ·
  └── sort                             ·            ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)          +created_at
       │                               order        +created_at                ·                                                                                        ·
       └── group                       ·            ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)          ·

--- a/pkg/sql/opt/norm/rules/limit.opt
+++ b/pkg/sql/opt/norm/rules/limit.opt
@@ -14,6 +14,15 @@
 =>
 $input
 
+# EliminateOffset discards an Offset operator if its offset value is zero.
+[EliminateOffset, Normalize]
+(Offset
+    $input:*
+    (Const 0)
+)
+=>
+$input
+
 # PushLimitIntoProject pushes the Limit operator into its Project input. It is
 # desirable to push the Limit operator as low in the query as possible, in order
 # to minimize the number of rows that other operators need to process.

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -4720,60 +4720,52 @@ limit
  ├── key: (1)
  ├── fd: (1)-->(2-9)
  ├── ordering: +8
- ├── offset
+ ├── sort
  │    ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp)
- │    ├── internal-ordering: +8
  │    ├── side-effects
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-9)
  │    ├── ordering: +8
- │    ├── sort
- │    │    ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp)
- │    │    ├── side-effects
- │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2-9)
- │    │    ├── ordering: +8
- │    │    └── group-by
- │    │         ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp)
- │    │         ├── grouping columns: id:1(int!null)
- │    │         ├── side-effects
- │    │         ├── key: (1)
- │    │         ├── fd: (1)-->(2-9)
- │    │         ├── select
- │    │         │    ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp) unnest:10(string!null)
- │    │         │    ├── side-effects
- │    │         │    ├── fd: ()-->(10), (1)-->(2-9)
- │    │         │    ├── project-set
- │    │         │    │    ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp) unnest:10(string)
- │    │         │    │    ├── side-effects
- │    │         │    │    ├── fd: (1)-->(2-9)
- │    │         │    │    ├── scan a0
- │    │         │    │    │    ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp)
- │    │         │    │    │    ├── key: (1)
- │    │         │    │    │    └── fd: (1)-->(2-9)
- │    │         │    │    └── zip
- │    │         │    │         └── function: unnest [type=string, outer=(6), side-effects]
- │    │         │    │              └── variable: tag_list [type=string[]]
- │    │         │    └── filters
- │    │         │         └── unnest = 'dragons' [type=bool, outer=(10), constraints=(/10: [/'dragons' - /'dragons']; tight), fd=()-->(10)]
- │    │         └── aggregations
- │    │              ├── const-agg [type=string, outer=(2)]
- │    │              │    └── variable: body [type=string]
- │    │              ├── const-agg [type=string, outer=(3)]
- │    │              │    └── variable: description [type=string]
- │    │              ├── const-agg [type=string, outer=(4)]
- │    │              │    └── variable: title [type=string]
- │    │              ├── const-agg [type=string, outer=(5)]
- │    │              │    └── variable: slug [type=string]
- │    │              ├── const-agg [type=string[], outer=(6)]
- │    │              │    └── variable: tag_list [type=string[]]
- │    │              ├── const-agg [type=string, outer=(7)]
- │    │              │    └── variable: user_id [type=string]
- │    │              ├── const-agg [type=timestamp, outer=(8)]
- │    │              │    └── variable: created_at [type=timestamp]
- │    │              └── const-agg [type=timestamp, outer=(9)]
- │    │                   └── variable: updated_at [type=timestamp]
- │    └── const: 0 [type=int]
+ │    └── group-by
+ │         ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp)
+ │         ├── grouping columns: id:1(int!null)
+ │         ├── side-effects
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2-9)
+ │         ├── select
+ │         │    ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp) unnest:10(string!null)
+ │         │    ├── side-effects
+ │         │    ├── fd: ()-->(10), (1)-->(2-9)
+ │         │    ├── project-set
+ │         │    │    ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp) unnest:10(string)
+ │         │    │    ├── side-effects
+ │         │    │    ├── fd: (1)-->(2-9)
+ │         │    │    ├── scan a0
+ │         │    │    │    ├── columns: id:1(int!null) body:2(string) description:3(string) title:4(string) slug:5(string) tag_list:6(string[]) user_id:7(string) created_at:8(timestamp) updated_at:9(timestamp)
+ │         │    │    │    ├── key: (1)
+ │         │    │    │    └── fd: (1)-->(2-9)
+ │         │    │    └── zip
+ │         │    │         └── function: unnest [type=string, outer=(6), side-effects]
+ │         │    │              └── variable: tag_list [type=string[]]
+ │         │    └── filters
+ │         │         └── unnest = 'dragons' [type=bool, outer=(10), constraints=(/10: [/'dragons' - /'dragons']; tight), fd=()-->(10)]
+ │         └── aggregations
+ │              ├── const-agg [type=string, outer=(2)]
+ │              │    └── variable: body [type=string]
+ │              ├── const-agg [type=string, outer=(3)]
+ │              │    └── variable: description [type=string]
+ │              ├── const-agg [type=string, outer=(4)]
+ │              │    └── variable: title [type=string]
+ │              ├── const-agg [type=string, outer=(5)]
+ │              │    └── variable: slug [type=string]
+ │              ├── const-agg [type=string[], outer=(6)]
+ │              │    └── variable: tag_list [type=string[]]
+ │              ├── const-agg [type=string, outer=(7)]
+ │              │    └── variable: user_id [type=string]
+ │              ├── const-agg [type=timestamp, outer=(8)]
+ │              │    └── variable: created_at [type=timestamp]
+ │              └── const-agg [type=timestamp, outer=(9)]
+ │                   └── variable: updated_at [type=timestamp]
  └── const: 10 [type=int]
 
 # TODO(justin): figure out how to get this to decorrelate again.

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -89,6 +89,45 @@ limit
  └── const: -1 [type=int]
 
 # --------------------------------------------------
+# EliminateOffset
+# --------------------------------------------------
+opt expect=EliminateOffset
+SELECT * FROM a OFFSET 0
+----
+scan a
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── key: (1)
+ └── fd: (1)-->(2-5)
+
+opt expect=EliminateOffset
+SELECT * FROM a LIMIT 5 OFFSET 0
+----
+scan a
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── limit: 5
+ ├── key: (1)
+ └── fd: (1)-->(2-5)
+
+opt expect-not=EliminateOffset
+SELECT * FROM a LIMIT 5 OFFSET 1
+----
+limit
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── cardinality: [0 - 5]
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── offset
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-5)
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-5)
+ │    └── const: 1 [type=int]
+ └── const: 5 [type=int]
+
+# --------------------------------------------------
 # PushLimitIntoProject
 # --------------------------------------------------
 opt expect=PushLimitIntoProject

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -1175,4 +1175,3 @@ if-err [type=decimal]
  │    └── variable: @1 [type=decimal]
  └── err-code
       └── const: '10000' [type=string]
-


### PR DESCRIPTION
Realized we don't have this when I was taking a look at an old window
function query we were trying to optimize. A very special case, but I
suspect it's actually somewhat common in the scenario where people are
paginating with OFFSET and using placeholders.

Release note: None