### PR TITLE
roachtest: run TPCH queries only on v19.1.0 and after

### DIFF
--- a/pkg/cmd/roachtest/tpchbench.go
+++ b/pkg/cmd/roachtest/tpchbench.go
@@ -259,6 +259,7 @@ func registerTPCHBench(r *registry) {
 			ScaleFactor:     1,
 			benchType:       tpch,
 			numRunsPerQuery: 3,
+			minVersion:      `v19.1.0`,
 		},
 		{
 			Nodes:           3,


### PR DESCRIPTION
This change will skip execution of tpchbench/tpch roachtest on
releases before v19.1.0 (i.e. the test and the corresponding
benchmark won't be run on v2.1). This is needed since query 8
on 2.1 gets a terrible plan such that its execution runs out of
disk. (Also, we were using sql20 to guide our performance in 2.1
anyway.)

Fixes: #37919.

Release note: None