### PR TITLE
release-19.1: cli: fix use of IPv6 addresses with RPC client commands

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -72,6 +72,7 @@ type cliTestParams struct {
 	noServer   bool
 	storeSpecs []base.StoreSpec
 	locality   roachpb.Locality
+	addr       string
 }
 
 func (c *cliTest) fail(err interface{}) {
@@ -135,6 +136,7 @@ func newCLITest(params cliTestParams) cliTest {
 			SSLCertsDir: c.certsDir,
 			StoreSpecs:  params.storeSpecs,
 			Locality:    params.locality,
+			Addr:        params.addr,
 		})
 		if err != nil {
 			c.fail(err)
@@ -370,7 +372,7 @@ func (c cliTest) runWithArgsUnredirected(origArgs []string) {
 				args = append(args, "--insecure=false")
 				args = append(args, fmt.Sprintf("--certs-dir=%s", c.certsDir))
 			}
-			args = append(args, fmt.Sprintf("--host=%s:%s", h, p))
+			args = append(args, fmt.Sprintf("--host=%s", net.JoinHostPort(h, p)))
 		}
 		args = append(args, origArgs[1:]...)
 

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -1103,9 +1103,6 @@ func addrWithDefaultHost(addr string) (string, error) {
 	if host == "" {
 		host = "localhost"
 	}
-	if strings.Contains(host, ":") {
-		host = "[" + host + "]"
-	}
 	return net.JoinHostPort(host, port), nil
 }
 

--- a/pkg/cli/start_test.go
+++ b/pkg/cli/start_test.go
@@ -174,3 +174,25 @@ func TestGCProfiles(t *testing.T) {
 		sum -= len(data[:i])
 	}
 }
+
+func TestAddrWithDefaultHost(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testData := []struct {
+		inAddr  string
+		outAddr string
+	}{
+		{"localhost:123", "localhost:123"},
+		{":123", "localhost:123"},
+		{"[::1]:123", "[::1]:123"},
+	}
+
+	for _, test := range testData {
+		addr, err := addrWithDefaultHost(test.inAddr)
+		if err != nil {
+			t.Error(err)
+		} else if addr != test.outAddr {
+			t.Errorf("expected %q, got %q", test.outAddr, addr)
+		}
+	}
+}


### PR DESCRIPTION
Backport 1/1 commits from #37977.

/cc @cockroachdb/release
