### PR TITLE
enhance create table partition stmt with located zone feature

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -2081,6 +2081,7 @@ signed_iconst64 ::=
 
 list_partition ::=
 	partition 'VALUES' 'IN' '(' expr_list ')' opt_partition_by
+	| partition 'VALUES' 'IN' '(' expr_list ')' 'CONFIGURE' 'ZONE' 'USING' '(' var_set_list ')' opt_partition_by
 
 range_partition ::=
 	partition 'VALUES' 'FROM' '(' expr_list ')' 'TO' '(' expr_list ')' opt_partition_by

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4079,14 +4079,24 @@ list_partitions:
   }
 
 list_partition:
-  partition VALUES IN '(' expr_list ')' opt_partition_by
-  {
-    $$.val = tree.ListPartition{
-      Name: tree.UnrestrictedName($1),
-      Exprs: $5.exprs(),
-      Subpartition: $7.partitionBy(),
+    partition VALUES IN '(' expr_list ')' opt_partition_by
+    {
+      $$.val = tree.ListPartition{
+        Name: tree.UnrestrictedName($1),
+        Exprs: $5.exprs(),
+        Subpartition: $7.partitionBy(),
+       }
     }
-  }
+  // enhance create partition feature with locate zone
+  | partition VALUES IN '(' expr_list ')' CONFIGURE ZONE USING '('var_set_list')' opt_partition_by
+    {
+      $$.val = tree.ListPartition{
+        Name: tree.UnrestrictedName($1),
+        Exprs: $5.exprs(),
+        Location: $11.kvOptions(),
+        Subpartition: $13.partitionBy(),
+      }
+    }
 
 range_partitions:
   range_partition

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -836,8 +836,10 @@ func (node *PartitionBy) Format(ctx *FmtCtx) {
 
 // ListPartition represents a PARTITION definition within a PARTITION BY LIST.
 type ListPartition struct {
-	Name         UnrestrictedName
-	Exprs        Exprs
+	Name  UnrestrictedName
+	Exprs Exprs
+	// enhance create partition feature with locate zone
+	Location     KVOptions
 	Subpartition *PartitionBy
 }
 
@@ -890,6 +892,18 @@ type CreateTable struct {
 // false otherwise.
 func (node *CreateTable) As() bool {
 	return node.AsSource != nil
+}
+
+// enhance create partition feature with locate zone
+// return true if this create table's partition has Location setting
+func (node *CreateTable) PartitionHasLocation() bool {
+	list := node.PartitionBy.List
+	for _, ptb := range list {
+		if ptb.Location != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // Format implements the NodeFormatter interface.

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -31,7 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/gogo/protobuf/proto"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 type optionValue struct {
@@ -44,7 +44,8 @@ type setZoneConfigNode struct {
 	yamlConfig    tree.TypedExpr
 	options       map[tree.Name]optionValue
 	setDefault    bool
-
+	// enhance create partition feature with locate zone
+	sourcePlan			planNode
 	run setZoneConfigRun
 }
 

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -599,6 +599,10 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 		if v.observer.expr != nil {
 			v.metadataExpr(name, "yaml", -1, n.yamlConfig)
 		}
+		// enhance create partition feature with locate zone
+		if n.sourcePlan != nil {
+			n.sourcePlan = v.visit(n.sourcePlan)
+		}
 
 	case *projectSetNode:
 		if v.observer.expr != nil {


### PR DESCRIPTION
As using creating stmt with partition can not specify location of
related partition,So we enhance the create table with partiton stmt
by combine  seting of location zone node planner with orignal create
table node planner. As a result, table's partition will be split into
different range when table is created immediately. User will simply
write statement in one single SQL to create partition which data
distributed in different nodes instead of serveral DDL stmts.

Fixes #37878
see also #37429.

Release note (sql change): enhancement of create stmt.

Signed-off-by: Tomas Ji (季业)-云服务集团 <jiye01@inspur.com>