### PR TITLE
sql/delegate: move delegateShowDatabaseIndexes to its own file

### DIFF
--- a/pkg/sql/delegate/show_database_indexes.go
+++ b/pkg/sql/delegate/show_database_indexes.go
@@ -1,0 +1,37 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package delegate
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+func (d *delegator) delegateShowDatabaseIndexes(
+	n *tree.ShowDatabaseIndexes,
+) (tree.Statement, error) {
+	const getAllIndexesQuery = `
+    SELECT table_name,
+           index_name,
+           non_unique::BOOL,
+           seq_in_index,
+           column_name,
+           direction,
+           storing::BOOL,
+           implicit::BOOL
+      FROM %s.information_schema.statistics`
+	return parse(fmt.Sprintf(getAllIndexesQuery, n.Database.String()))
+}

--- a/pkg/sql/delegate/show_table.go
+++ b/pkg/sql/delegate/show_table.go
@@ -34,22 +34,6 @@ func (d *delegator) delegateShowCreate(n *tree.ShowCreate) (tree.Statement, erro
 	return d.showTableDetails(n.Name, showCreateQuery)
 }
 
-func (d *delegator) delegateShowDatabaseIndexes(
-	n *tree.ShowDatabaseIndexes,
-) (tree.Statement, error) {
-	const getAllIndexesQuery = `
-    SELECT table_name,
-           index_name,
-           non_unique::BOOL,
-           seq_in_index,
-           column_name,
-           direction,
-           storing::BOOL,
-           implicit::BOOL
-    FROM %s.information_schema.statistics`
-	return parse(fmt.Sprintf(getAllIndexesQuery, n.Database.String()))
-}
-
 func (d *delegator) delegateShowIndexes(n *tree.ShowIndexes) (tree.Statement, error) {
 	const getIndexesQuery = `
     SELECT table_name,


### PR DESCRIPTION
(we generally try to use different files for different concerns)

Release note: None