### PR TITLE
enhance create table partition stmt with located zone feature

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -2081,6 +2081,7 @@ signed_iconst64 ::=
 
 list_partition ::=
 	partition 'VALUES' 'IN' '(' expr_list ')' opt_partition_by
+	| partition 'VALUES' 'IN' '(' expr_list ')' 'CONFIGURE' 'ZONE' 'USING' '(' var_set_list ')' opt_partition_by
 
 range_partition ::=
 	partition 'VALUES' 'FROM' '(' expr_list ')' 'TO' '(' expr_list ')' opt_partition_by

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1506,6 +1506,33 @@ func (ef *execFactory) ConstructCreateTable(
 	if input != nil {
 		nd.sourcePlan = input.(planNode)
 	}
+	// enhance create partition feature with locate zone
+	if ct.PartitionBy != nil {
+		if ct.PartitionHasLocation() {
+			var res *setZoneConfigNode
+			for _, pb := range ct.PartitionBy.List {
+				n := &tree.SetZoneConfig{
+					ZoneSpecifier: tree.ZoneSpecifier{
+						TableOrIndex: tree.TableIndexName{Table: ct.Table},
+						Partition:    tree.Name(pb.Name),
+					},
+					Options: pb.Location,
+				}
+				// try to find a ctx
+				plnode, err := ef.planner.SetZoneConfig(ef.planner.extendedEvalCtx.Context, n)
+				if err != nil {
+					return nil, err
+				}
+				if res == nil {
+					plnode.(*setZoneConfigNode).sourcePlan = nd
+				} else {
+					plnode.(*setZoneConfigNode).sourcePlan = res
+				}
+				res = plnode.(*setZoneConfigNode)
+			}
+			return res, nil
+		}
+	}
 	return nd, nil
 }
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4079,14 +4079,24 @@ list_partitions:
   }
 
 list_partition:
-  partition VALUES IN '(' expr_list ')' opt_partition_by
-  {
-    $$.val = tree.ListPartition{
-      Name: tree.UnrestrictedName($1),
-      Exprs: $5.exprs(),
-      Subpartition: $7.partitionBy(),
+    partition VALUES IN '(' expr_list ')' opt_partition_by
+    {
+      $$.val = tree.ListPartition{
+        Name: tree.UnrestrictedName($1),
+        Exprs: $5.exprs(),
+        Subpartition: $7.partitionBy(),
+       }
     }
-  }
+  // enhance create partition feature with locate zone
+  | partition VALUES IN '(' expr_list ')' CONFIGURE ZONE USING '('var_set_list')' opt_partition_by
+    {
+      $$.val = tree.ListPartition{
+        Name: tree.UnrestrictedName($1),
+        Exprs: $5.exprs(),
+        Location: $11.kvOptions(),
+        Subpartition: $13.partitionBy(),
+      }
+    }
 
 range_partitions:
   range_partition

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -836,8 +836,10 @@ func (node *PartitionBy) Format(ctx *FmtCtx) {
 
 // ListPartition represents a PARTITION definition within a PARTITION BY LIST.
 type ListPartition struct {
-	Name         UnrestrictedName
-	Exprs        Exprs
+	Name  UnrestrictedName
+	Exprs Exprs
+	// enhance create partition feature with locate zone
+	Location     KVOptions
 	Subpartition *PartitionBy
 }
 
@@ -890,6 +892,18 @@ type CreateTable struct {
 // false otherwise.
 func (node *CreateTable) As() bool {
 	return node.AsSource != nil
+}
+
+// PartitionHasLocation return true if this create table's partition has Location setting
+// enhance create partition feature with locate zone
+func (node *CreateTable) PartitionHasLocation() bool {
+	list := node.PartitionBy.List
+	for _, ptb := range list {
+		if ptb.Location != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // Format implements the NodeFormatter interface.

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/gogo/protobuf/proto"
-	yaml "gopkg.in/yaml.v2"
 )
 
 type optionValue struct {
@@ -44,8 +43,9 @@ type setZoneConfigNode struct {
 	yamlConfig    tree.TypedExpr
 	options       map[tree.Name]optionValue
 	setDefault    bool
-
-	run setZoneConfigRun
+	// enhance create partition feature with locate zone
+	sourcePlan planNode
+	run        setZoneConfigRun
 }
 
 // supportedZoneConfigOptions indicates how to translate SQL variable

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -599,6 +599,10 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 		if v.observer.expr != nil {
 			v.metadataExpr(name, "yaml", -1, n.yamlConfig)
 		}
+		// enhance create partition feature with locate zone
+		if n.sourcePlan != nil {
+			n.sourcePlan = v.visit(n.sourcePlan)
+		}
 
 	case *projectSetNode:
 		if v.observer.expr != nil {


### PR DESCRIPTION
Here's some explanation.
As using creating stmt with partition can not specify location of
related partition,So we enhance the create table with partiton stmt
by combine  seting of location zone node planner with orignal create
table node planner. As a result, table's partition will be split into
different range when table is created immediately. User will simply
write statement in one single SQL to create partition which data
distributed in different nodes instead of serveral DDL stmts.

Fixes #37878
see also #37429.

Release note (sql change): enhancement of create stmt.Please enter the commit message for your changes. Lines starting