### PR TITLE
roachpb: avoid advertising UnhandledRetryableError as client-visible

### DIFF
--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -40,10 +40,6 @@ func (e *UnhandledRetryableError) Error() string {
 	return e.PErr.Message
 }
 
-// ClientVisibleRetryError implements the ClientVisibleRetryError interface.
-func (e *UnhandledRetryableError) ClientVisibleRetryError() {}
-
-var _ ClientVisibleRetryError = &UnhandledRetryableError{}
 var _ error = &UnhandledRetryableError{}
 
 // ErrorUnexpectedlySet creates a string to panic with when a response (typically

--- a/pkg/sql/pgwire/pgerror/wrap_test.go
+++ b/pkg/sql/pgwire/pgerror/wrap_test.go
@@ -28,7 +28,6 @@ func TestWrap(t *testing.T) {
 		expectWrap bool
 	}{
 		{errors.New("woo"), true},
-		{&roachpb.UnhandledRetryableError{}, false},
 		{&roachpb.TransactionRetryWithProtoRefreshError{}, false},
 		{&roachpb.AmbiguousResultError{}, false},
 	}


### PR DESCRIPTION
Requested by @andreimatei: the "client-visible" retry errors are those
that trigger a SQL code 40001. Since `UnhandledRetryableError` does
not flow back through SQL, it needs not be marked by this interface.

Release note: None