### PR TITLE
storage/engine: cleanup MapProvidingEngine interface

### DIFF
--- a/pkg/storage/diskmap/disk_map.go
+++ b/pkg/storage/diskmap/disk_map.go
@@ -14,6 +14,8 @@ import "context"
 
 // Factory is an interface that can produce SortedDiskMaps.
 type Factory interface {
+	// Close the factory, freeing up associated resources.
+	Close()
 	// NewSortedDiskMap returns a fresh SortedDiskMap with no contents.
 	NewSortedDiskMap() SortedDiskMap
 	// NewSortedDiskMultiMap returns a fresh SortedDiskMap with no contents that permits

--- a/pkg/storage/engine/disk_map_test.go
+++ b/pkg/storage/engine/disk_map_test.go
@@ -34,7 +34,7 @@ func TestRocksDBMap(t *testing.T) {
 	e := NewInMem(roachpb.Attributes{}, 1<<20)
 	defer e.Close()
 
-	diskMap := NewRocksDBMap(e)
+	diskMap := newRocksDBMap(e, false /* allowDuplicates */)
 	defer diskMap.Close(ctx)
 
 	batchWriter := diskMap.NewBatchWriterCapacity(64)
@@ -169,7 +169,7 @@ func TestRocksDBMapClose(t *testing.T) {
 		}
 	}
 
-	diskMap := NewRocksDBMap(e)
+	diskMap := newRocksDBMap(e, false /* allowDuplicates */)
 
 	// Put a small amount of data into the disk map.
 	const letters = "abcdefghijklmnopqrstuvwxyz"
@@ -222,9 +222,9 @@ func TestRocksDBMapSandbox(t *testing.T) {
 	e := NewInMem(roachpb.Attributes{}, 1<<20)
 	defer e.Close()
 
-	diskMaps := make([]*RocksDBMap, 3)
+	diskMaps := make([]*rocksDBMap, 3)
 	for i := 0; i < len(diskMaps); i++ {
-		diskMaps[i] = NewRocksDBMap(e)
+		diskMaps[i] = newRocksDBMap(e, false /* allowDuplicates */)
 	}
 
 	// Put [0,10) as a key into each diskMap with the value specifying which
@@ -340,11 +340,7 @@ func TestRocksDBStore(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("AllowDuplicates=%v", tc.allowDuplicates), func(t *testing.T) {
-			fn := NewRocksDBMap
-			if tc.allowDuplicates {
-				fn = NewRocksDBMultiMap
-			}
-			diskStore := fn(e)
+			diskStore := newRocksDBMap(e, tc.allowDuplicates)
 			defer diskStore.Close(ctx)
 
 			batchWriter := diskStore.NewBatchWriter()

--- a/pkg/storage/engine/disk_map_test.go
+++ b/pkg/storage/engine/disk_map_test.go
@@ -404,7 +404,7 @@ func BenchmarkRocksDBMapWrite(b *testing.B) {
 		b.Run(fmt.Sprintf("InputSize%d", inputSize), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				func() {
-					diskMap := NewRocksDBMap(tempEngine)
+					diskMap := tempEngine.NewSortedDiskMap()
 					defer diskMap.Close(ctx)
 					batchWriter := diskMap.NewBatchWriter()
 					// This Close() flushes writes.
@@ -445,7 +445,7 @@ func BenchmarkRocksDBMapIteration(b *testing.B) {
 	}
 	defer tempEngine.Close()
 
-	diskMap := NewRocksDBMap(tempEngine)
+	diskMap := tempEngine.NewSortedDiskMap()
 	defer diskMap.Close(context.Background())
 
 	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -14,7 +14,6 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/storage/diskmap"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -354,13 +353,6 @@ type Engine interface {
 	// which must not exist. The directory should be on the same file system so
 	// that hard links can be used.
 	CreateCheckpoint(dir string) error
-}
-
-// MapProvidingEngine is an Engine that also provides facilities for making a
-// sorted map that's persisted by the Engine.
-type MapProvidingEngine interface {
-	Engine
-	diskmap.Factory
 }
 
 // WithSSTables extends the Engine interface with a method to get info

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/storage/diskmap"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -3142,16 +3141,6 @@ func (r *RocksDB) LinkFile(oldname, newname string) error {
 		}
 	}
 	return nil
-}
-
-// NewSortedDiskMap implements the MapProvidingEngine interface.
-func (r *RocksDB) NewSortedDiskMap() diskmap.SortedDiskMap {
-	return NewRocksDBMap(r)
-}
-
-// NewSortedDiskMultiMap implements the MapProvidingEngine interface.
-func (r *RocksDB) NewSortedDiskMultiMap() diskmap.SortedDiskMap {
-	return NewRocksDBMultiMap(r)
 }
 
 // IsValidSplitKey returns whether the key is a valid split key. Certain key

--- a/pkg/storage/engine/temp_engine.go
+++ b/pkg/storage/engine/temp_engine.go
@@ -13,20 +13,41 @@ package engine
 import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/diskmap"
 )
+
+type rocksDBTempEngine struct {
+	db *RocksDB
+}
+
+// Close implements the diskmap.Factory interface.
+func (r *rocksDBTempEngine) Close() {
+	r.db.Close()
+}
+
+// NewSortedDiskMap implements the diskmap.Factory interface.
+func (r *rocksDBTempEngine) NewSortedDiskMap() diskmap.SortedDiskMap {
+	return NewRocksDBMap(r.db)
+}
+
+// NewSortedDiskMultiMap implements the diskmap.Factory interface.
+func (r *rocksDBTempEngine) NewSortedDiskMultiMap() diskmap.SortedDiskMap {
+	return NewRocksDBMultiMap(r.db)
+}
 
 // NewTempEngine creates a new engine for DistSQL processors to use when the
 // working set is larger than can be stored in memory.
 func NewTempEngine(
 	tempStorage base.TempStorageConfig, storeSpec base.StoreSpec,
-) (MapProvidingEngine, error) {
+) (diskmap.Factory, error) {
 	if tempStorage.InMemory {
 		// TODO(arjun): Limit the size of the store once #16750 is addressed.
 		// Technically we do not pass any attributes to temporary store.
-		return NewInMem(roachpb.Attributes{} /* attrs */, 0 /* cacheSize */), nil
+		db := NewInMem(roachpb.Attributes{} /* attrs */, 0 /* cacheSize */).RocksDB
+		return &rocksDBTempEngine{db: db}, nil
 	}
 
-	rocksDBCfg := RocksDBConfig{
+	cfg := RocksDBConfig{
 		Attrs: roachpb.Attributes{},
 		Dir:   tempStorage.Path,
 		// MaxSizeBytes doesn't matter for temp storage - it's not
@@ -36,11 +57,11 @@ func NewTempEngine(
 		UseFileRegistry: storeSpec.UseFileRegistry,
 		ExtraOptions:    storeSpec.ExtraOptions,
 	}
-	rocksDBCache := NewRocksDBCache(0)
-	rocksdb, err := NewRocksDB(rocksDBCfg, rocksDBCache)
+	cache := NewRocksDBCache(0)
+	db, err := NewRocksDB(cfg, cache)
 	if err != nil {
 		return nil, err
 	}
 
-	return rocksdb, nil
+	return &rocksDBTempEngine{db: db}, nil
 }

--- a/pkg/storage/engine/temp_engine.go
+++ b/pkg/storage/engine/temp_engine.go
@@ -27,12 +27,12 @@ func (r *rocksDBTempEngine) Close() {
 
 // NewSortedDiskMap implements the diskmap.Factory interface.
 func (r *rocksDBTempEngine) NewSortedDiskMap() diskmap.SortedDiskMap {
-	return NewRocksDBMap(r.db)
+	return newRocksDBMap(r.db, false /* allowDuplications */)
 }
 
 // NewSortedDiskMultiMap implements the diskmap.Factory interface.
 func (r *rocksDBTempEngine) NewSortedDiskMultiMap() diskmap.SortedDiskMap {
-	return NewRocksDBMultiMap(r.db)
+	return newRocksDBMap(r.db, true /* allowDuplicates */)
 }
 
 // NewTempEngine creates a new engine for DistSQL processors to use when the

--- a/pkg/storage/engine/temp_engine_test.go
+++ b/pkg/storage/engine/temp_engine_test.go
@@ -31,12 +31,9 @@ func TestNewTempEngine(t *testing.T) {
 	}
 	defer engine.Close()
 
-	tempEngine, ok := engine.(*RocksDB)
-	if !ok {
-		t.Fatalf("temp engine could not be asserted as a rocksdb instance")
-	}
 	// Temp engine initialized with the temporary directory.
-	if tempDir != tempEngine.cfg.Dir {
-		t.Fatalf("temp engine initialized with unexpected parent directory.\nexpected %s\nactual %s", tempDir, tempEngine.cfg.Dir)
+	if dir := engine.(*rocksDBTempEngine).db.cfg.Dir; tempDir != dir {
+		t.Fatalf("temp engine initialized with unexpected parent directory.\nexpected %s\nactual %s",
+			tempDir, dir)
 	}
 }


### PR DESCRIPTION
Remove the MapProvidingEngine interface which was not providing any
value as all of the users of MapProvidingEngine were only using the
diskmap.Factory interface.

Change the implementation of NewTempEngine to return a struct that
implements diskmap.Factory rather than having storage/engine.RocksDB
implement diskmap.Factory.

These changes pave the way for a non-RocksDB implementation of
diskmap.Factory via a temp engine.

Release note: None