### PR TITLE
logictest: don't run under stressrace

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -2083,6 +2083,10 @@ func RunLogicTest(t *testing.T, globs ...string) {
 	// Note: there is special code in teamcity-trigger/main.go to run this package
 	// with less concurrency in the nightly stress runs. If you see problems
 	// please make adjustments there.
+	// As of 6/4/2019, the logic tests never complete under race.
+	if testutils.NightlyStress() && util.RaceEnabled {
+		t.Skip("logic tests and race detector don't mix: #37993")
+	}
 
 	if skipLogicTests {
 		t.Skip("COCKROACH_LOGIC_TESTS_SKIP")


### PR DESCRIPTION
Logic tests don't complete under the race build. Disable until this is
investigated more.

Closes #37993.
Closes #37970.
Closes #37963.
Closes #37952.
Closes #37927.
Closes #37903.
Closes #37870.
Closes #37306.
Closes #37233.

Release note: None