### PR TITLE
exec: implement top K sorter

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -15,6 +15,7 @@ package distsqlrun
 import (
 	"context"
 	"fmt"
+	"math"
 	"reflect"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
@@ -376,15 +377,23 @@ func newColOperator(
 		if err := checkNumIn(inputs, 1); err != nil {
 			return nil, err
 		}
-		if core.Sorter.OrderingMatchLen > 0 {
-			op, err = exec.NewSortChunks(inputs[0],
-				conv.FromColumnTypes(spec.Input[0].ColumnTypes),
-				core.Sorter.OutputOrdering.Columns,
-				int(core.Sorter.OrderingMatchLen))
+		input := inputs[0]
+		inputTypes := conv.FromColumnTypes(spec.Input[0].ColumnTypes)
+		orderingCols := core.Sorter.OutputOrdering.Columns
+		matchLen := core.Sorter.OrderingMatchLen
+		if matchLen > 0 {
+			// The input is already partially ordered. Use a chunks sorter to avoid
+			// loading all the rows into memory.
+			op, err = exec.NewSortChunks(input, inputTypes, orderingCols, int(matchLen))
+		} else if post.Limit != 0 && post.Filter.Empty() && post.Limit+post.Offset < math.MaxUint16 {
+			// There is a limit specified with no post-process filter, so we know
+			// exactly how many rows the sorter should output. Choose a top K sorter,
+			// which uses a heap to avoid storing more rows than necessary.
+			k := uint16(post.Limit + post.Offset)
+			op = exec.NewTopKSorter(input, inputTypes, orderingCols, k)
 		} else {
-			op, err = exec.NewSorter(inputs[0],
-				conv.FromColumnTypes(spec.Input[0].ColumnTypes),
-				core.Sorter.OutputOrdering.Columns)
+			// No optimizations possible. Default to the standard sort operator.
+			op, err = exec.NewSorter(input, inputTypes, orderingCols)
 		}
 		columnTypes = spec.Input[0].ColumnTypes
 

--- a/pkg/sql/exec/orderedsynchronizer.go
+++ b/pkg/sql/exec/orderedsynchronizer.go
@@ -124,7 +124,7 @@ func (o *orderedSynchronizer) compareRow(batchIdx1 int, batchIdx2 int) int {
 			case encoding.Ascending:
 				return res
 			case encoding.Descending:
-				return res * -1
+				return -res
 			default:
 				panic(fmt.Sprintf("unexpected direction value %d", d))
 			}
@@ -138,6 +138,7 @@ func (o *orderedSynchronizer) compareRow(batchIdx1 int, batchIdx2 int) int {
 func (o *orderedSynchronizer) updateComparators(batchIdx int) {
 	batch := o.inputBatches[batchIdx]
 	for i := range o.ordering {
-		o.comparators[i].setVec(batchIdx, batch.ColVecs()[o.ordering[i].ColIdx])
+		vec := batch.ColVec(o.ordering[i].ColIdx)
+		o.comparators[i].setVec(batchIdx, vec)
 	}
 }

--- a/pkg/sql/exec/sort_test.go
+++ b/pkg/sql/exec/sort_test.go
@@ -135,6 +135,7 @@ func TestSort(t *testing.T) {
 func TestSortRandomized(t *testing.T) {
 	rng, _ := randutil.NewPseudoRand()
 	nTups := 8
+	k := uint16(4)
 	maxCols := 5
 	// TODO(yuzefovich): randomize types as well.
 	typs := make([]types.T, maxCols)
@@ -144,35 +145,49 @@ func TestSortRandomized(t *testing.T) {
 
 	for nCols := 1; nCols < maxCols; nCols++ {
 		for nOrderingCols := 1; nOrderingCols <= nCols; nOrderingCols++ {
-			ordCols := generateColumnOrdering(rng, nCols, nOrderingCols)
-			tups := make(tuples, nTups)
-			for i := range tups {
-				tups[i] = make(tuple, nCols)
-				for j := range tups[i] {
-					// Small range so we can test partitioning
-					tups[i][j] = rng.Int63() % 2048
-				}
+			for _, topK := range []bool{false, true} {
+				name := fmt.Sprintf("nCols=%d/nOrderingCols=%d/topK=%t", nCols, nOrderingCols, topK)
+				t.Run(name, func(t *testing.T) {
+					ordCols := generateColumnOrdering(rng, nCols, nOrderingCols)
+					tups := make(tuples, nTups)
+					for i := range tups {
+						tups[i] = make(tuple, nCols)
+						for j := range tups[i] {
+							// Small range so we can test partitioning
+							tups[i][j] = rng.Int63() % 2048
+						}
+					}
+
+					expected := make(tuples, nTups)
+					copy(expected, tups)
+					sort.Slice(expected, less(expected, ordCols))
+					if topK {
+						expected = expected[:k]
+					}
+
+					runTests(t, []tuples{tups}, func(t *testing.T, input []Operator) {
+						var sorter Operator
+						if topK {
+							sorter = NewTopKSorter(input[0], typs[:nCols], ordCols, k)
+						} else {
+							var err error
+							sorter, err = NewSorter(input[0], typs[:nCols], ordCols)
+							if err != nil {
+								t.Fatal(err)
+							}
+						}
+						cols := make([]int, nCols)
+						for i := range cols {
+							cols[i] = i
+						}
+						out := newOpTestOutput(sorter, cols, expected)
+
+						if err := out.Verify(); err != nil {
+							t.Fatalf("for input %v:\n%v", tups, err)
+						}
+					})
+				})
 			}
-
-			expected := make(tuples, nTups)
-			copy(expected, tups)
-			sort.Slice(expected, less(expected, ordCols))
-
-			runTests(t, []tuples{tups}, func(t *testing.T, input []Operator) {
-				sorter, err := NewSorter(input[0], typs[:nCols], ordCols)
-				if err != nil {
-					t.Fatal(err)
-				}
-				cols := make([]int, nCols)
-				for i := range cols {
-					cols[i] = i
-				}
-				out := newOpTestOutput(sorter, cols, expected)
-
-				if err := out.Verify(); err != nil {
-					t.Fatalf("for input %v:\n%v", tups, err)
-				}
-			})
 		}
 	}
 }
@@ -246,46 +261,58 @@ func TestAllSpooler(t *testing.T) {
 func BenchmarkSort(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
 	ctx := context.Background()
+	k := uint16(128)
 
 	for _, nBatches := range []int{1 << 1, 1 << 4, 1 << 8} {
 		for _, nCols := range []int{1, 2, 4} {
-			b.Run(fmt.Sprintf("rows=%d/cols=%d", nBatches*int(coldata.BatchSize), nCols), func(b *testing.B) {
-				// 8 (bytes / int64) * nBatches (number of batches) * coldata.BatchSize (rows /
-				// batch) * nCols (number of columns / row).
-				b.SetBytes(int64(8 * nBatches * int(coldata.BatchSize) * nCols))
-				typs := make([]types.T, nCols)
-				for i := range typs {
-					typs[i] = types.Int64
-				}
-				batch := coldata.NewMemBatch(typs)
-				batch.SetLength(coldata.BatchSize)
-				ordCols := make([]distsqlpb.Ordering_Column, nCols)
-				for i := range ordCols {
-					ordCols[i].ColIdx = uint32(i)
-					ordCols[i].Direction = distsqlpb.Ordering_Column_Direction(rng.Int() % 2)
-
-					col := batch.ColVec(i).Int64()
-					for j := 0; j < coldata.BatchSize; j++ {
-						col[j] = rng.Int63() % int64((i*1024)+1)
+			for _, topK := range []bool{false, true} {
+				name := fmt.Sprintf("rows=%d/cols=%d/topK=%t", nBatches*int(coldata.BatchSize), nCols, topK)
+				b.Run(name, func(b *testing.B) {
+					// 8 (bytes / int64) * nBatches (number of batches) * coldata.BatchSize (rows /
+					// batch) * nCols (number of columns / row).
+					b.SetBytes(int64(8 * nBatches * int(coldata.BatchSize) * nCols))
+					typs := make([]types.T, nCols)
+					for i := range typs {
+						typs[i] = types.Int64
 					}
-				}
-				b.ResetTimer()
-				for n := 0; n < b.N; n++ {
-					source := newFiniteBatchSource(batch, nBatches)
-					sort, err := NewSorter(source, typs, ordCols)
-					if err != nil {
-						b.Fatal(err)
-					}
+					batch := coldata.NewMemBatch(typs)
+					batch.SetLength(coldata.BatchSize)
+					ordCols := make([]distsqlpb.Ordering_Column, nCols)
+					for i := range ordCols {
+						ordCols[i].ColIdx = uint32(i)
+						ordCols[i].Direction = distsqlpb.Ordering_Column_Direction(rng.Int() % 2)
 
-					sort.Init()
-					for i := 0; i < nBatches; i++ {
-						out := sort.Next(ctx)
-						if out.Length() == 0 {
-							b.Fail()
+						col := batch.ColVec(i).Int64()
+						for j := 0; j < coldata.BatchSize; j++ {
+							col[j] = rng.Int63() % int64((i*1024)+1)
 						}
 					}
-				}
-			})
+					b.ResetTimer()
+					for n := 0; n < b.N; n++ {
+						source := newFiniteBatchSource(batch, nBatches)
+						var sorter Operator
+						var resultBatches int
+						if topK {
+							sorter = NewTopKSorter(source, typs, ordCols, k)
+							resultBatches = 1
+						} else {
+							var err error
+							sorter, err = NewSorter(source, typs, ordCols)
+							if err != nil {
+								b.Fatal(err)
+							}
+							resultBatches = nBatches
+						}
+						sorter.Init()
+						for i := 0; i < resultBatches; i++ {
+							out := sorter.Next(ctx)
+							if out.Length() == 0 {
+								b.Fail()
+							}
+						}
+					}
+				})
+			}
 		}
 	}
 }

--- a/pkg/sql/exec/sorttopk.go
+++ b/pkg/sql/exec/sorttopk.go
@@ -1,0 +1,255 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL.txt and at www.mariadb.com/bsl11.
+//
+// Change Date: 2022-10-01
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt and at
+// https://www.apache.org/licenses/LICENSE-2.0
+
+package exec
+
+import (
+	"container/heap"
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+const (
+	topKVecIdx  = 0
+	inputVecIdx = 1
+)
+
+// NewTopKSorter returns a new sort operator, which sorts its input on the
+// columns given in orderingCols and returns the first K rows. The inputTypes
+// must correspond 1-1 with the columns in the input operator.
+func NewTopKSorter(
+	input Operator, inputTypes []types.T, orderingCols []distsqlpb.Ordering_Column, k uint16,
+) Operator {
+	return &topKSorter{
+		input:        input,
+		inputTypes:   inputTypes,
+		orderingCols: orderingCols,
+		k:            k,
+	}
+}
+
+// topKSortState represents the state of the sort operator.
+type topKSortState int
+
+const (
+	// sortSpooling is the initial state of the operator, where it spools its
+	// input.
+	topKSortSpooling topKSortState = iota
+	// sortEmitting is the second state of the operator, indicating that each call
+	// to Next will return another batch of the sorted data.
+	topKSortEmitting
+)
+
+type topKSorter struct {
+	input        Operator
+	orderingCols []distsqlpb.Ordering_Column
+	inputTypes   []types.T
+	k            uint16 // TODO(solon): support larger k values
+
+	// state is the current state of the sort.
+	state topKSortState
+	// comparators stores one comparator per ordering column.
+	comparators []vecComparator
+	// topK stores the top K rows. It is not sorted internally.
+	topK coldata.Batch
+	// heap is a max heap which stores indices into topK.
+	heap []uint16
+	// sel is a selection vector which specifies an ordering on topK.
+	sel []uint16
+	// emitted is the count of rows which have been emitted so far.
+	emitted uint16
+	output  coldata.Batch
+}
+
+func (t *topKSorter) Init() {
+	t.input.Init()
+	t.topK = coldata.NewMemBatchWithSize(t.inputTypes, int(t.k))
+	t.comparators = make([]vecComparator, len(t.orderingCols))
+	for i := range t.orderingCols {
+		typ := t.inputTypes[t.orderingCols[i].ColIdx]
+		// one vec for output batch and one for current input batch
+		t.comparators[i] = GetVecComparator(typ, 2)
+	}
+	t.output = coldata.NewMemBatchWithSize(t.inputTypes, coldata.BatchSize)
+}
+
+func (t *topKSorter) Next(ctx context.Context) coldata.Batch {
+	switch t.state {
+	case topKSortSpooling:
+		t.spool(ctx)
+		t.state = topKSortEmitting
+		fallthrough
+	case topKSortEmitting:
+		return t.emit()
+	}
+	panic(fmt.Sprintf("invalid sort state %v", t.state))
+}
+
+// spool reads in the entire input, always storing the top K rows it has seen so
+// far in o.topK. This is done by maintaining a max heap of indices into o.topK.
+// Whenever we encounter a row which is smaller than the max row in the heap,
+// we replace the max with that row.
+//
+// After all the input has been read, we pop everything off the heap to
+// determine the final output ordering. This is used in emit() to output the rows
+// in sorted order.
+func (t *topKSorter) spool(ctx context.Context) {
+	// Fill up t.topK by spooling up to K rows from the input.
+	inputBatch := t.input.Next(ctx)
+	inputBatchIdx := uint16(0)
+	spooledRows := uint16(0)
+	remainingRows := t.k
+	for remainingRows > 0 && inputBatch.Length() > 0 {
+		toLength := uint64(spooledRows)
+		fromLength := inputBatch.Length()
+		if remainingRows < inputBatch.Length() {
+			// t.topK will be full after this batch.
+			fromLength = remainingRows
+			inputBatchIdx = fromLength
+		}
+		for i := range t.inputTypes {
+			destVec := t.topK.ColVec(i)
+			vec := inputBatch.ColVec(i)
+			colType := t.inputTypes[i]
+			if inputBatch.Selection() == nil {
+				destVec.Append(vec, colType, toLength, fromLength)
+			} else {
+				destVec.AppendWithSel(vec, inputBatch.Selection(), fromLength, colType, toLength)
+			}
+		}
+		spooledRows += fromLength
+		remainingRows -= fromLength
+		if fromLength == inputBatch.Length() {
+			inputBatch = t.input.Next(ctx)
+		}
+	}
+	t.topK.SetLength(spooledRows)
+	t.updateComparators(topKVecIdx, t.topK)
+
+	// Initialize the heap.
+	t.heap = make([]uint16, t.topK.Length())
+	for i := range t.heap {
+		t.heap[i] = uint16(i)
+	}
+	heap.Init(t)
+
+	// Read the remainder of the input. Whenever a row is less than the heap max,
+	// swap it in.
+	for inputBatch.Length() > 0 {
+		t.updateComparators(inputVecIdx, inputBatch)
+		sel := inputBatch.Selection()
+		for i := inputBatchIdx; i < inputBatch.Length(); i++ {
+			idx := i
+			if sel != nil {
+				idx = sel[i]
+			}
+			maxIdx := t.heap[0]
+			if t.compareRow(inputVecIdx, topKVecIdx, idx, maxIdx) < 0 {
+				for j := range t.inputTypes {
+					// TODO(solon): Make this copy more efficient, perhaps by adding a
+					// copy method to the vecComparator interface. This would avoid
+					// needing to switch on the column type every time.
+					t.topK.ColVec(j).AppendSlice(
+						inputBatch.ColVec(j), t.inputTypes[j], uint64(maxIdx), uint16(idx), uint16(idx)+1)
+
+				}
+				heap.Fix(t, 0)
+			}
+		}
+		inputBatch = t.input.Next(ctx)
+		inputBatchIdx = 0
+	}
+
+	// t.topK now contains the top K rows unsorted. Create a selection vector
+	// which specifies the rows in sorted order by popping everything off the
+	// heap. Note that it's a max heap so we need to fill the selection vector in
+	// reverse.
+	t.sel = make([]uint16, t.topK.Length())
+	for i := 0; i < int(t.topK.Length()); i++ {
+		t.sel[len(t.sel)-i-1] = heap.Pop(t).(uint16)
+	}
+}
+
+func (t *topKSorter) emit() coldata.Batch {
+	toEmit := t.topK.Length() - t.emitted
+	if toEmit == 0 {
+		// We're done.
+		t.output.SetLength(0)
+		return t.output
+	}
+	if toEmit > coldata.BatchSize {
+		toEmit = coldata.BatchSize
+	}
+	for i := range t.inputTypes {
+		vec := t.output.ColVec(i)
+		vec.CopyWithSelInt16(t.topK.ColVec(i), t.sel, toEmit, t.inputTypes[i])
+	}
+	t.output.SetLength(toEmit)
+	t.emitted += toEmit
+	return t.output
+}
+
+func (t *topKSorter) compareRow(vecIdx1, vecIdx2 int, rowIdx1, rowIdx2 uint16) int {
+	for i := range t.orderingCols {
+		info := t.orderingCols[i]
+		res := t.comparators[i].compare(vecIdx1, vecIdx2, rowIdx1, rowIdx2)
+		if res != 0 {
+			switch d := info.Direction; d {
+			case distsqlpb.Ordering_Column_ASC:
+				return res
+			case distsqlpb.Ordering_Column_DESC:
+				return -res
+			default:
+				panic(fmt.Sprintf("unexpected direction value %d", d))
+			}
+		}
+	}
+	return 0
+}
+
+func (t *topKSorter) updateComparators(vecIdx int, batch coldata.Batch) {
+	for i := range t.orderingCols {
+		vec := batch.ColVec(int(t.orderingCols[i].ColIdx))
+		t.comparators[i].setVec(vecIdx, vec)
+	}
+}
+
+// Len is part of heap.Interface and is only meant to be used internally.
+func (t *topKSorter) Len() int {
+	return len(t.heap)
+}
+
+// Less is part of heap.Interface and is only meant to be used internally.
+func (t *topKSorter) Less(i, j int) bool {
+	return t.compareRow(topKVecIdx, topKVecIdx, t.heap[i], t.heap[j]) > 0
+}
+
+// Swap is part of heap.Interface and is only meant to be used internally.
+func (t *topKSorter) Swap(i, j int) {
+	t.heap[i], t.heap[j] = t.heap[j], t.heap[i]
+}
+
+// Push is part of heap.Interface and is only meant to be used internally.
+func (t *topKSorter) Push(x interface{}) {
+	t.heap = append(t.heap, x.(uint16))
+}
+
+// Pop is part of heap.Interface and is only meant to be used internally.
+func (t *topKSorter) Pop() interface{} {
+	x := t.heap[len(t.heap)-1]
+	t.heap = t.heap[:len(t.heap)-1]
+	return x
+}

--- a/pkg/sql/exec/sorttopk_test.go
+++ b/pkg/sql/exec/sorttopk_test.go
@@ -1,0 +1,85 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL.txt and at www.mariadb.com/bsl11.
+//
+// Change Date: 2022-10-01
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt and at
+// https://www.apache.org/licenses/LICENSE-2.0
+
+package exec
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestTopKSorter(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tcs := []struct {
+		name     string
+		tuples   tuples
+		expected tuples
+		ordCols  []distsqlpb.Ordering_Column
+		typ      []types.T
+		k        uint16
+	}{
+		{
+			name:     "k < input length",
+			tuples:   tuples{{1}, {2}, {3}, {4}, {5}, {6}, {7}},
+			expected: tuples{{1}, {2}, {3}},
+			typ:      []types.T{types.Int64},
+			ordCols:  []distsqlpb.Ordering_Column{{ColIdx: 0}},
+			k:        3,
+		},
+		{
+			name:     "k > input length",
+			tuples:   tuples{{1}, {2}, {3}, {4}, {5}, {6}, {7}},
+			expected: tuples{{1}, {2}, {3}, {4}, {5}, {6}, {7}},
+			typ:      []types.T{types.Int64},
+			ordCols:  []distsqlpb.Ordering_Column{{ColIdx: 0}},
+			k:        10,
+		},
+		{
+			name:     "nulls",
+			tuples:   tuples{{1}, {2}, {3}, {4}, {5}, {6}, {7}, {nil}},
+			expected: tuples{{nil}, {1}, {2}},
+			typ:      []types.T{types.Int64},
+			ordCols:  []distsqlpb.Ordering_Column{{ColIdx: 0}},
+			k:        3,
+		},
+		{
+			name:     "descending",
+			tuples:   tuples{{0, 1}, {0, 2}, {0, 3}, {0, 4}, {0, 5}, {1, 5}},
+			expected: tuples{{0, 5}, {1, 5}, {0, 4}},
+			typ:      []types.T{types.Int64, types.Int64},
+			ordCols: []distsqlpb.Ordering_Column{
+				{ColIdx: 1, Direction: distsqlpb.Ordering_Column_DESC},
+				{ColIdx: 0, Direction: distsqlpb.Ordering_Column_ASC},
+			},
+			k: 3,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			runTests(t, []tuples{tc.tuples}, func(t *testing.T, input []Operator) {
+				sort := NewTopKSorter(input[0], tc.typ, tc.ordCols, tc.k)
+				cols := make([]int, len(tc.typ))
+				for i := range cols {
+					cols[i] = i
+				}
+				out := newOpTestOutput(sort, cols, tc.expected)
+				if err := out.Verify(); err != nil {
+					t.Fatal(err)
+				}
+			})
+		})
+	}
+}


### PR DESCRIPTION
I added a new sorter implementation for top K sorting. This can be used
when there is a limit on the sort and no post-process filters. The
implementation uses a heap to track the top K rows as data is streamed
in. Unfortunately it's slower than our existing sort implementation
unless K is significantly smaller than the input size. However, this
isn't really an apples-to-apples comparison because the top K
implementation handles nulls and the vanilla sorter does not.

Fixes #33589

Benchmarks with K=128:
```
BenchmarkSort/rows=2048/cols=1/topK=false-4         	  100000	     20837 ns/op	 786.29 MB/s
BenchmarkSort/rows=2048/cols=1/topK=true-4          	   50000	     34667 ns/op	 472.60 MB/s
BenchmarkSort/rows=2048/cols=2/topK=false-4         	   10000	    148299 ns/op	 220.96 MB/s
BenchmarkSort/rows=2048/cols=2/topK=true-4          	    5000	    293538 ns/op	 111.63 MB/s
BenchmarkSort/rows=2048/cols=4/topK=false-4         	    5000	    245972 ns/op	 266.44 MB/s
BenchmarkSort/rows=2048/cols=4/topK=true-4          	   10000	    207207 ns/op	 316.28 MB/s
BenchmarkSort/rows=16384/cols=1/topK=false-4        	   10000	    208962 ns/op	 627.25 MB/s
BenchmarkSort/rows=16384/cols=1/topK=true-4         	   10000	    216434 ns/op	 605.60 MB/s
BenchmarkSort/rows=16384/cols=2/topK=false-4        	    2000	   1189043 ns/op	 220.47 MB/s
BenchmarkSort/rows=16384/cols=2/topK=true-4         	    3000	    556010 ns/op	 471.47 MB/s
BenchmarkSort/rows=16384/cols=4/topK=false-4        	    1000	   2015352 ns/op	 260.15 MB/s
BenchmarkSort/rows=16384/cols=4/topK=true-4         	    3000	    584361 ns/op	 897.20 MB/s
BenchmarkSort/rows=262144/cols=1/topK=false-4       	     500	   3449735 ns/op	 607.92 MB/s
BenchmarkSort/rows=262144/cols=1/topK=true-4        	     500	   3323972 ns/op	 630.92 MB/s
BenchmarkSort/rows=262144/cols=2/topK=false-4       	     100	  17205148 ns/op	 243.78 MB/s
BenchmarkSort/rows=262144/cols=2/topK=true-4        	     300	   5208630 ns/op	 805.26 MB/s
BenchmarkSort/rows=262144/cols=4/topK=false-4       	      50	  39827343 ns/op	 210.62 MB/s
BenchmarkSort/rows=262144/cols=4/topK=true-4        	     300	   5353863 ns/op	1566.83 MB/s
```

Release note: None