### PR TITLE
opt: support ordered aggregations using window functions

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1978,8 +1978,8 @@ opt_interval ::=
 
 func_application ::=
 	func_name '(' ')'
-	| func_name '(' expr_list ')'
-	| func_name '(' 'ALL' expr_list ')'
+	| func_name '(' expr_list opt_sort_clause ')'
+	| func_name '(' 'ALL' expr_list opt_sort_clause ')'
 	| func_name '(' 'DISTINCT' expr_list ')'
 	| func_name '(' '*' ')'
 

--- a/pkg/sql/logictest/testdata/logic_test/aggregate-opt
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate-opt
@@ -1,0 +1,124 @@
+# LogicTest: local-opt fakedist-opt
+
+statement ok
+CREATE TABLE tab (
+  col1 INT PRIMARY KEY,
+  col2 INT,
+  col3 STRING
+)
+
+# Ordered aggregations when there are no rows.
+query I
+SELECT array_agg(col1 ORDER BY col2) FROM TAB
+----
+NULL
+
+statement ok
+INSERT INTO tab VALUES (-3, 7, 'a'), (-2, 6, 'a'), (-1, 5, 'a'), (0, 7, 'b'), (1, 5, 'b'), (2, 6, 'b')
+
+query T colnames
+SELECT array_agg(col1 ORDER BY col1) FROM tab
+----
+array_agg
+{-3,-2,-1,0,1,2}
+
+query T colnames
+SELECT json_agg(col1 ORDER BY col1) FROM tab
+----
+json_agg
+[-3, -2, -1, 0, 1, 2]
+
+query T colnames
+SELECT jsonb_agg(col1 ORDER BY col1) FROM tab
+----
+jsonb_agg
+[-3, -2, -1, 0, 1, 2]
+
+query T colnames
+SELECT jsonb_agg(col1 ORDER BY col2, col1) FROM tab
+----
+jsonb_agg
+[-1, 1, -2, 2, -3, 0]
+
+query T colnames
+SELECT concat_agg(col3 ORDER BY col1) FROM tab
+----
+concat_agg
+aaabbb
+
+query T colnames
+SELECT concat_agg(col3 ORDER BY col1 DESC) FROM tab
+----
+concat_agg
+bbbaaa
+
+query T colnames
+SELECT string_agg(col3, ', ' ORDER BY col3) FROM tab
+----
+string_agg
+a, a, a, b, b, b
+
+query T colnames
+SELECT string_agg(col3, ', ' ORDER BY col3 DESC) FROM tab
+----
+string_agg
+b, b, b, a, a, a
+
+query TTT colnames
+SELECT array_agg(col1 ORDER BY col1), array_agg(col1 ORDER BY col2, col1), array_agg(col1 ORDER BY col3, col1) FROM tab
+----
+array_agg         array_agg         array_agg
+{-3,-2,-1,0,1,2}  {-1,1,-2,2,-3,0}  {-3,-2,-1,0,1,2}
+
+query TTT colnames
+SELECT array_agg(col1 ORDER BY col1), array_agg(col1 ORDER BY col2, col1), col3 FROM tab GROUP BY col3 ORDER BY col3
+----
+array_agg   array_agg   col3
+{-3,-2,-1}  {-1,-2,-3}  a
+{0,1,2}     {1,2,0}     b
+
+query TTII colnames
+SELECT array_agg(col1 ORDER BY col1), array_agg(col1 ORDER BY col2, col1), count(col3), count(*) FROM tab
+----
+array_agg         array_agg         count  count
+{-3,-2,-1,0,1,2}  {-1,1,-2,2,-3,0}  6      6
+
+query TT colnames
+SELECT array_agg(col1 ORDER BY col1), array_agg(col1 ORDER BY col1) FILTER (WHERE col1 < 0) FROM tab
+----
+array_agg         array_agg
+{-3,-2,-1,0,1,2}  {-3,-2,-1}
+
+query TT colnames
+SELECT array_agg(col1 ORDER BY col3, col1) FILTER (WHERE col1 < 0), array_agg(col1 ORDER BY col3, col1) FROM tab
+----
+array_agg   array_agg
+{-3,-2,-1}  {-3,-2,-1,0,1,2}
+
+query IT
+SELECT count(1), concat_agg(col3 ORDER BY col1) from tab
+----
+6  aaabbb
+
+# Testing pre-projections. Tests when the GroupBy clause has a projection.
+query IIIT colnames
+SELECT
+    *
+FROM
+    (
+        SELECT
+            count(1) AS count_1,
+            count(lower(col3)) AS count_lower,
+            count(upper(col3)) AS count_upper,
+            concat_agg(col3 ORDER BY col1) AS concat
+        FROM
+            tab
+        GROUP BY
+            upper(col3)
+    )
+ORDER BY
+    concat
+----
+count_1  count_lower  count_upper  concat
+3        3            3            aaa
+3        3            3            bbb

--- a/pkg/sql/logictest/testdata/logic_test/orms
+++ b/pkg/sql/logictest/testdata/logic_test/orms
@@ -22,16 +22,16 @@ name   text    NULL            false  25  -1
 rowid  bigint  unique_rowid()  true   20  -1
 
 
+# Ordered aggregations are possible.
 # #12115
-# Skipped until #25148 is solved
-#query TT
-#SELECT t.typname enum_name, array_agg(e.enumlabel ORDER BY enumsortorder) enum_value
-#    FROM pg_type t
-#    JOIN pg_enum e ON t.oid = e.enumtypid
-#    JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
-#    WHERE n.nspname = 'public'
-#    GROUP BY 1
-#----
+query TT
+SELECT t.typname enum_name, array_agg(e.enumlabel ORDER BY enumsortorder) enum_value
+    FROM pg_type t
+    JOIN pg_enum e ON t.oid = e.enumtypid
+    JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+    WHERE n.nspname = 'public'
+    GROUP BY 1
+----
 
 
 ## 12207

--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -250,17 +250,6 @@ func BoolOperatorRequiresNotNullArgs(op Operator) bool {
 	return false
 }
 
-// AggregateIsOrderingSensitive returns true if the given aggregate operator is
-// non-commutative. That is, it can give different results based on the order
-// values are fed to it.
-func AggregateIsOrderingSensitive(op Operator) bool {
-	switch op {
-	case ArrayAggOp, ConcatAggOp, JsonAggOp, JsonbAggOp, StringAggOp:
-		return true
-	}
-	return false
-}
-
 // AggregateIgnoresNulls returns true if the given aggregate operator has a
 // single input, and if it always evaluates to the same result regardless of
 // how many NULL values are included in that input, in any order.

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -499,6 +499,21 @@ func (s *scope) findAggregate(agg aggregateInfo) *scopeColumn {
 						break
 					}
 				}
+
+				// If agg is ordering sensitive, check if the orders match as well.
+				if match && !agg.isCommutative() {
+					if len(a.OrderBy) != len(agg.OrderBy) {
+						match = false
+					} else {
+						for j := range a.OrderBy {
+							if !a.OrderBy[j].Equal(agg.OrderBy[j]) {
+								match = false
+								break
+							}
+						}
+					}
+				}
+
 				if match {
 					// Aggregate already exists, so return information about the
 					// existing column that computes it.

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -3093,3 +3093,262 @@ group-by
            ├── fd: (1)-->(2,3)
            ├── prune: (1-3)
            └── interesting orderings: (+1,+2) (+3,+2,+1)
+
+# Testing ordered aggregations.
+exec-ddl
+CREATE TABLE tab (col1 int NOT NULL, col2 int NOT NULL, col3 string)
+----
+
+build
+SELECT array_agg(col1 ORDER BY col1) FROM tab
+----
+scalar-group-by
+ ├── columns: array_agg:5(int[])
+ ├── window partition=() ordering=+1
+ │    ├── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null) array_agg:5(int[])
+ │    ├── scan tab
+ │    │    └── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null)
+ │    └── windows
+ │         └── windows-item: range from unbounded to unbounded [type=int[]]
+ │              └── array-agg [type=int[]]
+ │                   └── variable: col1 [type=int]
+ └── aggregations
+      └── const-agg [type=int[]]
+           └── variable: array_agg [type=int[]]
+
+# Ignore aggregate orderings for non commutative aggregates.
+build
+SELECT count(col1 ORDER BY col2) FROM tab
+----
+scalar-group-by
+ ├── columns: count:5(int)
+ ├── project
+ │    ├── columns: col1:1(int!null)
+ │    └── scan tab
+ │         └── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null)
+ └── aggregations
+      └── count [type=int]
+           └── variable: col1 [type=int]
+
+# Multiple ordered aggregations.
+build
+SELECT array_agg(col1 ORDER BY col1), array_agg(col1 ORDER BY col2) from tab
+----
+scalar-group-by
+ ├── columns: array_agg:5(int[]) array_agg:6(int[])
+ ├── window partition=() ordering=+2
+ │    ├── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null) array_agg:5(int[]) array_agg:6(int[])
+ │    ├── window partition=() ordering=+1
+ │    │    ├── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null) array_agg:5(int[])
+ │    │    ├── scan tab
+ │    │    │    └── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null)
+ │    │    └── windows
+ │    │         └── windows-item: range from unbounded to unbounded [type=int[]]
+ │    │              └── array-agg [type=int[]]
+ │    │                   └── variable: col1 [type=int]
+ │    └── windows
+ │         └── windows-item: range from unbounded to unbounded [type=int[]]
+ │              └── array-agg [type=int[]]
+ │                   └── variable: col1 [type=int]
+ └── aggregations
+      ├── const-agg [type=int[]]
+      │    └── variable: array_agg [type=int[]]
+      └── const-agg [type=int[]]
+           └── variable: array_agg [type=int[]]
+
+build
+SELECT concat_agg(col3 ORDER BY col1), array_agg(col1) FROM tab
+----
+scalar-group-by
+ ├── columns: concat_agg:5(string) array_agg:6(int[])
+ ├── window partition=()
+ │    ├── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null) concat_agg:5(string) array_agg:6(int[])
+ │    ├── window partition=() ordering=+1
+ │    │    ├── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null) concat_agg:5(string)
+ │    │    ├── scan tab
+ │    │    │    └── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null)
+ │    │    └── windows
+ │    │         └── windows-item: range from unbounded to unbounded [type=string]
+ │    │              └── concat-agg [type=string]
+ │    │                   └── variable: col3 [type=string]
+ │    └── windows
+ │         └── windows-item: range from unbounded to unbounded [type=int[]]
+ │              └── array-agg [type=int[]]
+ │                   └── variable: col1 [type=int]
+ └── aggregations
+      ├── const-agg [type=string]
+      │    └── variable: concat_agg [type=string]
+      └── const-agg [type=int[]]
+           └── variable: array_agg [type=int[]]
+
+build
+SELECT concat_agg(col3 ORDER BY col1), sum(col1 ORDER BY col2) FROM tab
+----
+scalar-group-by
+ ├── columns: concat_agg:5(string) sum:6(decimal)
+ ├── window partition=()
+ │    ├── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null) concat_agg:5(string) sum:6(decimal)
+ │    ├── window partition=() ordering=+1
+ │    │    ├── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null) concat_agg:5(string)
+ │    │    ├── scan tab
+ │    │    │    └── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null)
+ │    │    └── windows
+ │    │         └── windows-item: range from unbounded to unbounded [type=string]
+ │    │              └── concat-agg [type=string]
+ │    │                   └── variable: col3 [type=string]
+ │    └── windows
+ │         └── windows-item: range from unbounded to unbounded [type=decimal]
+ │              └── sum [type=decimal]
+ │                   └── variable: col1 [type=int]
+ └── aggregations
+      ├── const-agg [type=string]
+      │    └── variable: concat_agg [type=string]
+      └── const-agg [type=decimal]
+           └── variable: sum [type=decimal]
+
+build
+SELECT array_agg(col1 ORDER BY col1) FROM tab GROUP BY col2
+----
+project
+ ├── columns: array_agg:5(int[])
+ └── group-by
+      ├── columns: col2:2(int!null) array_agg:5(int[])
+      ├── grouping columns: col2:2(int!null)
+      ├── window partition=(2) ordering=+1
+      │    ├── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null) array_agg:5(int[])
+      │    ├── scan tab
+      │    │    └── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null)
+      │    └── windows
+      │         └── windows-item: range from unbounded to unbounded [type=int[]]
+      │              └── array-agg [type=int[]]
+      │                   └── variable: col1 [type=int]
+      └── aggregations
+           └── const-agg [type=int[]]
+                └── variable: array_agg [type=int[]]
+
+build
+SELECT array_agg(col1 ORDER BY col1), array_agg(col3 ORDER BY col1) FROM tab GROUP BY col2
+----
+project
+ ├── columns: array_agg:5(int[]) array_agg:6(string[])
+ └── group-by
+      ├── columns: col2:2(int!null) array_agg:5(int[]) array_agg:6(string[])
+      ├── grouping columns: col2:2(int!null)
+      ├── window partition=(2) ordering=+1
+      │    ├── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null) array_agg:5(int[]) array_agg:6(string[])
+      │    ├── scan tab
+      │    │    └── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null)
+      │    └── windows
+      │         ├── windows-item: range from unbounded to unbounded [type=int[]]
+      │         │    └── array-agg [type=int[]]
+      │         │         └── variable: col1 [type=int]
+      │         └── windows-item: range from unbounded to unbounded [type=string[]]
+      │              └── array-agg [type=string[]]
+      │                   └── variable: col3 [type=string]
+      └── aggregations
+           ├── const-agg [type=int[]]
+           │    └── variable: array_agg [type=int[]]
+           └── const-agg [type=string[]]
+                └── variable: array_agg [type=string[]]
+
+build
+SELECT array_agg(col1 ORDER BY col1), array_agg(col3 ORDER BY col1) FROM tab GROUP BY col2 HAVING col2 > 1
+----
+project
+ ├── columns: array_agg:5(int[]) array_agg:6(string[])
+ └── select
+      ├── columns: col2:2(int!null) array_agg:5(int[]) array_agg:6(string[])
+      ├── group-by
+      │    ├── columns: col2:2(int!null) array_agg:5(int[]) array_agg:6(string[])
+      │    ├── grouping columns: col2:2(int!null)
+      │    ├── window partition=(2) ordering=+1
+      │    │    ├── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null) array_agg:5(int[]) array_agg:6(string[])
+      │    │    ├── scan tab
+      │    │    │    └── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null)
+      │    │    └── windows
+      │    │         ├── windows-item: range from unbounded to unbounded [type=int[]]
+      │    │         │    └── array-agg [type=int[]]
+      │    │         │         └── variable: col1 [type=int]
+      │    │         └── windows-item: range from unbounded to unbounded [type=string[]]
+      │    │              └── array-agg [type=string[]]
+      │    │                   └── variable: col3 [type=string]
+      │    └── aggregations
+      │         ├── const-agg [type=int[]]
+      │         │    └── variable: array_agg [type=int[]]
+      │         └── const-agg [type=string[]]
+      │              └── variable: array_agg [type=string[]]
+      └── filters
+           └── gt [type=bool]
+                ├── variable: col2 [type=int]
+                └── const: 1 [type=int]
+
+# Testing aggregations as window when group by has a projection.
+build
+SELECT array_agg(col1 ORDER BY col1) FROM tab GROUP BY upper(col3)
+----
+project
+ ├── columns: array_agg:5(int[])
+ └── group-by
+      ├── columns: array_agg:5(int[]) column6:6(string)
+      ├── grouping columns: column6:6(string)
+      ├── window partition=(6) ordering=+1
+      │    ├── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null) array_agg:5(int[]) column6:6(string)
+      │    ├── project
+      │    │    ├── columns: column6:6(string) col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null)
+      │    │    ├── scan tab
+      │    │    │    └── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null)
+      │    │    └── projections
+      │    │         └── function: upper [type=string]
+      │    │              └── variable: col3 [type=string]
+      │    └── windows
+      │         └── windows-item: range from unbounded to unbounded [type=int[]]
+      │              └── array-agg [type=int[]]
+      │                   └── variable: col1 [type=int]
+      └── aggregations
+           └── const-agg [type=int[]]
+                └── variable: array_agg [type=int[]]
+
+build
+SELECT array_agg(col1 ORDER BY col1), upper(col3) FROM tab GROUP BY upper(col3)
+----
+group-by
+ ├── columns: array_agg:5(int[]) upper:6(string)
+ ├── grouping columns: column6:6(string)
+ ├── window partition=(6) ordering=+1
+ │    ├── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null) array_agg:5(int[]) column6:6(string)
+ │    ├── project
+ │    │    ├── columns: column6:6(string) col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null)
+ │    │    ├── scan tab
+ │    │    │    └── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null)
+ │    │    └── projections
+ │    │         └── function: upper [type=string]
+ │    │              └── variable: col3 [type=string]
+ │    └── windows
+ │         └── windows-item: range from unbounded to unbounded [type=int[]]
+ │              └── array-agg [type=int[]]
+ │                   └── variable: col1 [type=int]
+ └── aggregations
+      └── const-agg [type=int[]]
+           └── variable: array_agg [type=int[]]
+
+build
+SELECT array_agg(lower(col3)) FROM tab GROUP BY upper(col3)
+----
+project
+ ├── columns: array_agg:6(string[])
+ └── group-by
+      ├── columns: array_agg:6(string[]) column7:7(string)
+      ├── grouping columns: column7:7(string)
+      ├── project
+      │    ├── columns: column5:5(string) column7:7(string)
+      │    ├── scan tab
+      │    │    └── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null)
+      │    └── projections
+      │         ├── function: lower [type=string]
+      │         │    └── variable: col3 [type=string]
+      │         └── function: upper [type=string]
+      │              └── variable: col3 [type=string]
+      └── aggregations
+           └── array-agg [type=string[]]
+                └── variable: column5 [type=string]
+>>>>>>> Stashed changes

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -3282,6 +3282,57 @@ project
                 ├── variable: col2 [type=int]
                 └── const: 1 [type=int]
 
+# Add projection on top to ensure the default NULL values are set correctly.
+build
+SELECT count(DISTINCT col1), count(*), array_agg(col1 ORDER BY col2) FROM tab
+----
+project
+ ├── columns: count:5(int) count:6(int) array_agg:7(int[])
+ └── project
+      ├── columns: count:5(int) count_rows:6(int) col1:1(int) col2:2(int) col3:3(string) rowid:4(int) array_agg:7(int[])
+      ├── scalar-group-by
+      │    ├── columns: array_agg:7(int[]) count:8(int) count_rows:9(int)
+      │    ├── window partition=() ordering=+2
+      │    │    ├── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null) count:5(int) count_rows:6(int) array_agg:7(int[])
+      │    │    ├── window partition=()
+      │    │    │    ├── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null) count:5(int) count_rows:6(int)
+      │    │    │    ├── scan tab
+      │    │    │    │    └── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null)
+      │    │    │    └── windows
+      │    │    │         ├── windows-item: range from unbounded to unbounded [type=int]
+      │    │    │         │    └── count [type=int]
+      │    │    │         │         └── variable: col1 [type=int]
+      │    │    │         └── windows-item: range from unbounded to unbounded [type=int]
+      │    │    │              └── count-rows [type=int]
+      │    │    └── windows
+      │    │         └── windows-item: range from unbounded to unbounded [type=int[]]
+      │    │              └── array-agg [type=int[]]
+      │    │                   └── variable: col1 [type=int]
+      │    └── aggregations
+      │         ├── const-agg [type=int]
+      │         │    └── variable: count [type=int]
+      │         ├── const-agg [type=int]
+      │         │    └── variable: count_rows [type=int]
+      │         └── const-agg [type=int[]]
+      │              └── variable: array_agg [type=int[]]
+      └── projections
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: count [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── const: 0 [type=int]
+           │    └── variable: count [type=int]
+           └── case [type=int]
+                ├── true [type=bool]
+                ├── when [type=int]
+                │    ├── is [type=bool]
+                │    │    ├── variable: count_rows [type=int]
+                │    │    └── null [type=unknown]
+                │    └── const: 0 [type=int]
+                └── variable: count_rows [type=int]
+
 # Testing aggregations as window when group by has a projection.
 build
 SELECT array_agg(col1 ORDER BY col1) FROM tab GROUP BY upper(col3)
@@ -3351,4 +3402,3 @@ project
       └── aggregations
            └── array-agg [type=string[]]
                 └── variable: column5 [type=string]
->>>>>>> Stashed changes

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -15,6 +15,7 @@ package optbuilder
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -27,6 +28,24 @@ func checkFrom(expr tree.Expr, inScope *scope) {
 		panic(pgerror.Newf(pgerror.CodeInvalidNameError,
 			"cannot use %q without a FROM clause", tree.ErrString(expr)))
 	}
+}
+
+// windowAggregateFrame() returns a frame that any aggregate built as a window
+// can use.
+func windowAggregateFrame() memo.WindowFrame {
+	return memo.WindowFrame{
+		StartBoundType: unboundedStartBound.BoundType,
+		EndBoundType:   unboundedEndBound.BoundType,
+	}
+}
+
+// getTypedExprs casts the exprs into TypedExps and returns them.
+func getTypedExprs(exprs []tree.Expr) []tree.TypedExpr {
+	argExprs := make([]tree.TypedExpr, len(exprs))
+	for i, expr := range exprs {
+		argExprs[i] = expr.(tree.TypedExpr)
+	}
+	return argExprs
 }
 
 // expandStar expands expr into a list of columns if expr

--- a/pkg/sql/opt/optbuilder/window.go
+++ b/pkg/sql/opt/optbuilder/window.go
@@ -54,6 +54,8 @@ func (w *windowInfo) Eval(_ *tree.EvalContext) (tree.Datum, error) {
 var _ tree.Expr = &windowInfo{}
 var _ tree.TypedExpr = &windowInfo{}
 
+var unboundedStartBound = &tree.WindowFrameBound{BoundType: tree.UnboundedPreceding}
+var unboundedEndBound = &tree.WindowFrameBound{BoundType: tree.UnboundedFollowing}
 var defaultStartBound = &tree.WindowFrameBound{BoundType: tree.UnboundedPreceding}
 var defaultEndBound = &tree.WindowFrameBound{BoundType: tree.CurrentRow}
 
@@ -71,6 +73,7 @@ func (b *Builder) buildWindow(outScope *scope, inScope *scope) {
 	windowFrames := make([]tree.WindowFrame, len(inScope.windows))
 	argScope := outScope.push()
 	argScope.appendColumnsFromScope(outScope)
+
 	// The arguments to a given window function need to be columns in the input
 	// relation. Build a projection that produces those values to go underneath
 	// the window functions.
@@ -86,61 +89,14 @@ func (b *Builder) buildWindow(outScope *scope, inScope *scope) {
 
 		argExprs := b.getTypedWindowArgs(w)
 
-		argLists[i] = make(memo.ScalarListExpr, len(argExprs))
-		for j, a := range argExprs {
-			col := argScope.findExistingCol(a)
-			if col == nil {
-				col = b.synthesizeColumn(
-					argScope,
-					fmt.Sprintf("%s_%d_arg%d", w.def.Name, i+1, j+1),
-					a.ResolvedType(),
-					a,
-					b.buildScalar(a, inScope, nil, nil, nil),
-				)
-			}
-			argLists[i][j] = b.factory.ConstructVariable(col.id)
-		}
+		// Build the appropriate arguments.
+		argLists[i] = b.buildWindowArgs(argExprs, i, w.def.Name, inScope, argScope)
 
-		partition := make([]tree.TypedExpr, len(def.Partitions))
-		for i := range partition {
-			partition[i] = def.Partitions[i].(tree.TypedExpr)
-		}
+		// Build appropriate partitions.
+		partitions[i] = b.buildWindowPartition(def.Partitions, i, w.def.Name, inScope, argScope)
 
-		// PARTITION BY (a, b) => PARTITION BY a, b
-		cols := flattenTuples(partition)
-		for j, e := range cols {
-			col := argScope.findExistingCol(e)
-			if col == nil {
-				col = b.synthesizeColumn(
-					argScope,
-					fmt.Sprintf("%s_%d_partition_%d", w.def.Name, i+1, j+1),
-					e.ResolvedType(),
-					e,
-					b.buildScalar(e, inScope, nil, nil, nil),
-				)
-			}
-			partitions[i].Add(int(col.id))
-		}
-
-		ord := make(opt.Ordering, 0, len(def.OrderBy))
-		for j, t := range def.OrderBy {
-			// ORDER BY (a, b) => ORDER BY a, b
-			cols := flattenTuples([]tree.TypedExpr{t.Expr.(tree.TypedExpr)})
-
-			for _, e := range cols {
-				col := argScope.findExistingCol(e)
-				if col == nil {
-					col = b.synthesizeColumn(
-						argScope,
-						fmt.Sprintf("%s_%d_orderby_%d", w.def.Name, i+1, j+1),
-						e.ResolvedType(),
-						e,
-						b.buildScalar(e, inScope, nil, nil, nil),
-					)
-				}
-				ord = append(ord, opt.MakeOrderingColumn(col.id, t.Direction == tree.Descending))
-			}
-		}
+		// Build appropriate orderings.
+		ord := b.buildWindowOrdering(def.OrderBy, i, w.def.Name, inScope, argScope)
 		orderings[i].FromOrdering(ord)
 
 		if def.Frame != nil {
@@ -148,21 +104,7 @@ func (b *Builder) buildWindow(outScope *scope, inScope *scope) {
 		}
 
 		if w.Filter != nil {
-			defer b.semaCtx.Properties.Restore(b.semaCtx.Properties)
-			b.semaCtx.Properties.Require("FILTER", tree.RejectSpecial)
-
-			te := inScope.resolveAndRequireType(w.Filter, types.Bool)
-
-			col := argScope.findExistingCol(te)
-			if col == nil {
-				col = b.synthesizeColumn(
-					argScope,
-					fmt.Sprintf("%s_%d_filter", w.def.Name, i+1),
-					te.ResolvedType(),
-					te,
-					b.buildScalar(te, inScope, nil, nil, nil),
-				)
-			}
+			col := b.buildFilterCol(w.Filter, i, w.def.Name, inScope, argScope)
 			filterCols[i] = col.id
 		}
 
@@ -192,31 +134,7 @@ func (b *Builder) buildWindow(outScope *scope, inScope *scope) {
 	for i := range inScope.windows {
 		w := inScope.windows[i].expr.(*windowInfo)
 
-		frameIdx := -1
-
-		// The number of window functions is probably fairly small, so do an O(n^2)
-		// loop.
-		// TODO(justin): make this faster.
-		// TODO(justin): consider coalescing frames with compatible orderings.
-		for j := range frames {
-			if partitions[i].Equals(frames[j].Partition) &&
-				orderings[i].Equals(&frames[j].Ordering) {
-				frameIdx = j
-				break
-			}
-		}
-
-		// If we can't reuse an existing frame, make a new one.
-		if frameIdx == -1 {
-			frames = append(frames, memo.WindowExpr{
-				WindowPrivate: memo.WindowPrivate{
-					Partition: partitions[i],
-					Ordering:  orderings[i],
-				},
-				Windows: memo.WindowsExpr{},
-			})
-			frameIdx = len(frames) - 1
-		}
+		frameIdx := b.findMatchingFrameIndex(&frames, partitions[i], orderings[i])
 
 		fn := b.constructWindowFn(w.def.Name, argLists[i])
 
@@ -269,6 +187,116 @@ func (b *Builder) buildWindow(outScope *scope, inScope *scope) {
 	}
 }
 
+// buildAggregationAsWindow builds the aggregation operators as window functions.
+// Returns the output scope for the aggregation operation.
+// Consider the following query that uses an ordered aggregation:
+//
+// SELECT array_agg(col1 ORDER BY col1) FROM tab
+//
+// To support this ordering, we build the aggregate as a window function like below:
+//
+// scalar-group-by
+//  ├── columns: array_agg:2(int[])
+//  ├── window partition=() ordering=+1
+//  │    ├── columns: col1:1(int!null) array_agg:2(int[])
+//  │    ├── scan tab
+//  │    │    └── columns: col1:1(int!null)
+//  │    └── windows
+//  │         └── windows-item: range from unbounded to unbounded [type=int[]]
+//  │              └── array-agg [type=int[]]
+//  │                   └── variable: col1 [type=int]
+//  └── aggregations
+//       └── const-agg [type=int[]]
+//            └── variable: array_agg [type=int[]]
+func (b *Builder) buildAggregationAsWindow(
+	groupingColSet opt.ColSet, having opt.ScalarExpr, fromScope *scope,
+) *scope {
+	aggInScope := fromScope.groupby.aggInScope
+	aggOutScope := fromScope.groupby.aggOutScope
+	aggInfos := aggOutScope.groupby.aggs
+
+	// Create the window frames based on the orderings and groupings specified.
+	argLists := make([][]opt.ScalarExpr, len(aggInfos))
+	partitions := make([]opt.ColSet, len(aggInfos))
+	orderings := make([]physical.OrderingChoice, len(aggInfos))
+	filterCols := make([]opt.ColumnID, len(aggInfos))
+
+	// Construct the pre-projection, which renders the grouping columns and the
+	// aggregate arguments, as well as any additional order by columns.
+	aggInScope.appendColumnsFromScope(fromScope)
+	b.constructProjectForScope(fromScope, aggInScope)
+
+	// Build the arguments, partitions and orderings for each aggregate.
+	for i, agg := range aggInfos {
+		argExprs := getTypedExprs(agg.Exprs)
+
+		// Build the appropriate arguments.
+		argLists[i] = b.buildWindowArgs(argExprs, i, agg.def.Name, fromScope, aggInScope)
+
+		// Build appropriate partitions.
+		partitions[i] = groupingColSet.Copy()
+
+		// Build appropriate orderings.
+		if !agg.isCommutative() {
+			ord := b.buildWindowOrdering(agg.OrderBy, i, agg.def.Name, fromScope, aggInScope)
+			orderings[i].FromOrdering(ord)
+		}
+
+		if agg.Filter != nil {
+			col := b.buildFilterCol(agg.Filter, i, agg.def.Name, fromScope, aggInScope)
+			filterCols[i] = col.id
+		}
+	}
+
+	// Initialize the aggregate expression.
+	aggregateExpr := aggInScope.expr
+
+	// frames accumulates the set of distinct window frames we're computing over
+	// so that we can group functions over the same partition and ordering.
+	frames := make([]memo.WindowExpr, 0, len(aggInfos))
+	for i, agg := range aggInfos {
+		// Using this instead of constructAggregate so we can have non-constant second
+		// arguments for string_agg.
+		fn := b.constructWindowFn(agg.def.Name, argLists[i])
+		if filterCols[i] != 0 {
+			fn = b.factory.ConstructAggFilter(
+				fn,
+				b.factory.ConstructVariable(filterCols[i]),
+			)
+		}
+
+		frameIdx := b.findMatchingFrameIndex(&frames, partitions[i], orderings[i])
+
+		frames[frameIdx].Windows = append(frames[frameIdx].Windows,
+			memo.WindowsItem{
+				Function: fn,
+				WindowsItemPrivate: memo.WindowsItemPrivate{
+					Frame:      windowAggregateFrame(),
+					ColPrivate: memo.ColPrivate{Col: agg.col.id},
+				},
+			},
+		)
+	}
+
+	for _, f := range frames {
+		aggregateExpr = b.factory.ConstructWindow(aggregateExpr, f.Windows, &f.WindowPrivate)
+	}
+
+	// Construct a grouping so the values per group are squashed down. Each of the
+	// aggregations built as window functions emit an aggregated value for each row
+	// instead of each group. To rectify this, we must 'squash' the values down by
+	// wrapping it with a GroupBy or ScalarGroupBy.
+	aggOutScope.expr = b.constructWindowGroup(aggregateExpr, groupingColSet, aggInfos, aggOutScope)
+
+	// Wrap with having filter if it exists.
+	if having != nil {
+		input := aggOutScope.expr.(memo.RelExpr)
+		filters := memo.FiltersExpr{{Condition: having}}
+		aggOutScope.expr = b.factory.ConstructSelect(input, filters)
+	}
+	return aggOutScope
+}
+
 // getTypedWindowArgs returns the arguments to the window function as
 // a []tree.TypedExpr. In the case of arguments with default values, it
 // fills in the values if they are missing.
@@ -278,10 +306,7 @@ func (b *Builder) buildWindow(outScope *scope, inScope *scope) {
 // projecting the default argument to some window functions when we could just
 // not do that projection.
 func (b *Builder) getTypedWindowArgs(w *windowInfo) []tree.TypedExpr {
-	argExprs := make([]tree.TypedExpr, len(w.Exprs))
-	for i, pexpr := range w.Exprs {
-		argExprs[i] = pexpr.(tree.TypedExpr)
-	}
+	argExprs := getTypedExprs(w.Exprs)
 
 	switch w.def.Name {
 	// The second argument of {lead,lag} is 1 by default, and the third argument
@@ -300,4 +325,177 @@ func (b *Builder) getTypedWindowArgs(w *windowInfo) []tree.TypedExpr {
 	}
 
 	return argExprs
+}
+
+// buildWindowArgs builds the argExprs into a memo.ScalarListExpr.
+func (b *Builder) buildWindowArgs(
+	argExprs []tree.TypedExpr, windowIndex int, funcName string, inScope, outScope *scope,
+) memo.ScalarListExpr {
+	argList := make(memo.ScalarListExpr, len(argExprs))
+	for j, a := range argExprs {
+		col := outScope.findExistingCol(a)
+		if col == nil {
+			col = b.synthesizeColumn(
+				outScope,
+				fmt.Sprintf("%s_%d_arg%d", funcName, windowIndex+1, j+1),
+				a.ResolvedType(),
+				a,
+				b.buildScalar(a, inScope, nil, nil, nil),
+			)
+		}
+		argList[j] = b.factory.ConstructVariable(col.id)
+	}
+	return argList
+}
+
+// buildWindowPartition builds the appropriate partitions for window functions.
+func (b *Builder) buildWindowPartition(
+	partitions []tree.Expr, windowIndex int, funcName string, inScope, outScope *scope,
+) opt.ColSet {
+	partition := make([]tree.TypedExpr, len(partitions))
+	for i := range partition {
+		partition[i] = partitions[i].(tree.TypedExpr)
+	}
+
+	// PARTITION BY (a, b) => PARTITION BY a, b
+	var windowPartition opt.ColSet
+	cols := flattenTuples(partition)
+	for j, e := range cols {
+		col := outScope.findExistingCol(e)
+		if col == nil {
+			col = b.synthesizeColumn(
+				outScope,
+				fmt.Sprintf("%s_%d_partition_%d", funcName, windowIndex+1, j+1),
+				e.ResolvedType(),
+				e,
+				b.buildScalar(e, inScope, nil, nil, nil),
+			)
+		}
+		windowPartition.Add(int(col.id))
+	}
+	return windowPartition
+}
+
+// buildWindowOrdering builds the appropriate orderings for window functions.
+func (b *Builder) buildWindowOrdering(
+	orderBy tree.OrderBy, windowIndex int, funcName string, inScope, outScope *scope,
+) opt.Ordering {
+	ord := make(opt.Ordering, 0, len(orderBy))
+	for j, t := range orderBy {
+		// ORDER BY (a, b) => ORDER BY a, b.
+		te := inScope.resolveType(t.Expr, types.Any)
+		cols := flattenTuples([]tree.TypedExpr{te})
+
+		for _, e := range cols {
+			col := outScope.findExistingCol(e)
+			if col == nil {
+				col = b.synthesizeColumn(
+					outScope,
+					fmt.Sprintf("%s_%d_orderby_%d", funcName, windowIndex+1, j+1),
+					te.ResolvedType(),
+					te,
+					b.buildScalar(e, inScope, nil, nil, nil),
+				)
+			}
+			ord = append(ord, opt.MakeOrderingColumn(col.id, t.Direction == tree.Descending))
+		}
+	}
+	return ord
+}
+
+// buildFilterCol builds the filter column from the filter Expr.
+func (b *Builder) buildFilterCol(
+	filter tree.Expr, windowIndex int, funcName string, inScope, outScope *scope,
+) *scopeColumn {
+	defer b.semaCtx.Properties.Restore(b.semaCtx.Properties)
+	b.semaCtx.Properties.Require("FILTER", tree.RejectSpecial)
+
+	te := inScope.resolveAndRequireType(filter, types.Bool)
+
+	col := outScope.findExistingCol(te)
+	if col == nil {
+		col = b.synthesizeColumn(
+			outScope,
+			fmt.Sprintf("%s_%d_filter", funcName, windowIndex+1),
+			te.ResolvedType(),
+			te,
+			b.buildScalar(te, inScope, nil, nil, nil),
+		)
+	}
+
+	return col
+}
+
+// findMatchingFrameIndex finds a frame position to which a window of the
+// given partition and ordering can be added to. If no such frame is found, a
+// new one is made.
+func (b *Builder) findMatchingFrameIndex(
+	frames *[]memo.WindowExpr, partition opt.ColSet, ordering physical.OrderingChoice,
+) int {
+	frameIdx := -1
+
+	// The number of window functions is probably fairly small, so do an O(n^2)
+	// loop.
+	// TODO(justin): make this faster.
+	// TODO(justin): consider coalescing frames with compatible orderings.
+	for j := range *frames {
+		if partition.Equals((*frames)[j].Partition) &&
+			ordering.Equals(&(*frames)[j].Ordering) {
+			frameIdx = j
+			break
+		}
+	}
+
+	// If we can't reuse an existing frame, make a new one.
+	if frameIdx == -1 {
+		*frames = append(*frames, memo.WindowExpr{
+			WindowPrivate: memo.WindowPrivate{
+				Partition: partition,
+				Ordering:  ordering,
+			},
+			Windows: memo.WindowsExpr{},
+		})
+		frameIdx = len(*frames) - 1
+	}
+
+	return frameIdx
+}
+
+// constructWindowGroup wraps the input window expression with an appropriate
+// grouping so the results of each window column are squashed down.
+func (b *Builder) constructWindowGroup(
+	input memo.RelExpr, groupingColSet opt.ColSet, aggInfos []aggregateInfo, outScope *scope,
+) memo.RelExpr {
+	if groupingColSet.Empty() {
+		private := memo.GroupingPrivate{GroupingCols: groupingColSet}
+		private.Ordering.FromOrderingWithOptCols(nil, groupingColSet)
+		aggs := make(memo.AggregationsExpr, 0, len(aggInfos))
+
+		// Deduplicate the columns; we don't need to produce the same aggregation
+		// multiple times.
+		colSet := opt.ColSet{}
+		for i := range aggInfos {
+			if !colSet.Contains(int(aggInfos[i].col.id)) {
+				aggs = append(aggs, memo.AggregationsItem{
+					Agg:        b.factory.ConstructConstAgg(b.factory.ConstructVariable(aggInfos[i].col.id)),
+					ColPrivate: memo.ColPrivate{Col: aggInfos[i].col.id},
+				})
+				colSet.Add(int(aggInfos[i].col.id))
+			}
+		}
+		return b.factory.ConstructScalarGroupBy(input, aggs, &private)
+	}
+
+	// Construct a GroupBy using the groupingColSet. Use the ConstAgg aggregate for
+	// the window columns.
+	private := memo.GroupingPrivate{GroupingCols: groupingColSet}
+	private.Ordering.FromOrderingWithOptCols(nil, groupingColSet)
+	aggs := make(memo.AggregationsExpr, 0, len(aggInfos))
+	for i := range aggInfos {
+		aggs = append(aggs, memo.AggregationsItem{
+			Agg:        b.factory.ConstructConstAgg(b.factory.ConstructVariable(aggInfos[i].col.id)),
+			ColPrivate: memo.ColPrivate{Col: aggInfos[i].col.id},
+		})
+	}
+	return b.factory.ConstructGroupBy(input, aggs, &private)
 }

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -2940,8 +2940,6 @@ func TestUnimplementedSyntax(t *testing.T) {
 		{`INSERT INTO foo(a, a.b) VALUES (1,2)`, 27792, ``},
 		{`INSERT INTO foo VALUES (1,2) ON CONFLICT ON CONSTRAINT a DO NOTHING`, 28161, ``},
 
-		{`SELECT max(a ORDER BY b) FROM ab`, 23620, ``},
-
 		{`SELECT * FROM a FOR UPDATE`, 6583, ``},
 		{`SELECT * FROM ROWS FROM (a(b) AS (d))`, 0, `ROWS FROM with col_def_list`},
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -5775,10 +5775,6 @@ opt_all_clause:
   ALL {}
 | /* EMPTY */ {}
 
-opt_sort_clause_err:
-  sort_clause { return unimplementedWithIssue(sqllex, 23620) }
-| /* EMPTY */ {}
-
 opt_sort_clause:
   sort_clause
   {
@@ -7572,7 +7568,7 @@ d_expr:
     if err != nil { return setErr(sqllex, err) }
     $$.val = d
   }
-| func_name '(' expr_list opt_sort_clause_err ')' SCONST { return unimplemented(sqllex, $1.unresolvedName().String() + "(...) SCONST") }
+| func_name '(' expr_list opt_sort_clause ')' SCONST { return unimplemented(sqllex, $1.unresolvedName().String() + "(...) SCONST") }
 | const_typename SCONST
   {
     $$.val = &tree.CastExpr{Expr: tree.NewStrVal($2), Type: $1.colType(), SyntaxMode: tree.CastPrepend}
@@ -7654,17 +7650,19 @@ func_application:
   {
     $$.val = &tree.FuncExpr{Func: $1.resolvableFuncRefFromName()}
   }
-| func_name '(' expr_list opt_sort_clause_err ')'
+| func_name '(' expr_list opt_sort_clause ')'
   {
-    $$.val = &tree.FuncExpr{Func: $1.resolvableFuncRefFromName(), Exprs: $3.exprs()}
+    $$.val = &tree.FuncExpr{Func: $1.resolvableFuncRefFromName(), Exprs: $3.exprs(), OrderBy: $4.orderBy()}
   }
-| func_name '(' VARIADIC a_expr opt_sort_clause_err ')' { return unimplemented(sqllex, "variadic") }
-| func_name '(' expr_list ',' VARIADIC a_expr opt_sort_clause_err ')' { return unimplemented(sqllex, "variadic") }
-| func_name '(' ALL expr_list opt_sort_clause_err ')'
+| func_name '(' VARIADIC a_expr opt_sort_clause ')' { return unimplemented(sqllex, "variadic") }
+| func_name '(' expr_list ',' VARIADIC a_expr opt_sort_clause ')' { return unimplemented(sqllex, "variadic") }
+| func_name '(' ALL expr_list opt_sort_clause ')'
   {
-    $$.val = &tree.FuncExpr{Func: $1.resolvableFuncRefFromName(), Type: tree.AllFuncType, Exprs: $4.exprs()}
+    $$.val = &tree.FuncExpr{Func: $1.resolvableFuncRefFromName(), Type: tree.AllFuncType, Exprs: $4.exprs(), OrderBy: $5.orderBy()}
   }
-| func_name '(' DISTINCT expr_list opt_sort_clause_err ')'
+// TODO(ridwanmsharif): Once DISTINCT is supported by window aggregates,
+// allow ordering to be specified below.
+| func_name '(' DISTINCT expr_list ')'
   {
     $$.val = &tree.FuncExpr{Func: $1.resolvableFuncRefFromName(), Type: tree.DistinctFuncType, Exprs: $4.exprs()}
   }

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1233,6 +1233,9 @@ type FuncExpr struct {
 	Filter    Expr
 	WindowDef *WindowDef
 
+	// OrderBy is used for aggregations that specify an order:
+	// array_agg(col1 ORDER BY col2)
+	OrderBy OrderBy
 	typeAnnotation
 	fnProps *FunctionProperties
 	fn      *Overload

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -656,6 +656,12 @@ func (node *Order) Format(ctx *FmtCtx) {
 	}
 }
 
+// Equal checks if the node ordering is equivalent to other.
+func (node *Order) Equal(other *Order) bool {
+	return node.Expr.String() == other.Expr.String() && node.Direction == other.Direction &&
+		node.Table == other.Table && node.OrderType == other.OrderType
+}
+
 // Limit represents a LIMIT clause.
 type Limit struct {
 	Offset, Count Expr


### PR DESCRIPTION
Fixes #23620.

This change adds functionality to support ordered aggregations.
If any aggregation is non-commutative (array_agg, concat_agg) and
it specifies an ordering of results, they are now supported.
We do this by building all the aggregations as window functions
where we specify the ordering as part of the window expression.

For example:
Consider Table `tab` with the following composition:
```
col1 | col2
+------+------+
    10 |    2
    20 |    1
(2 rows)
```

The query `SELECT array_agg(col1 ORDER BY col1), array_agg(col1
ORDER BY col2) FROM tab` will return the following row preserving
the user specified orderings:
```
  array_agg | array_agg
+-----------+-----------+
  {10,20}   | {20,10}
(1 row)
```

Release note: None