### PR TITLE
opt: add PushLimitIntoWindow rule

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -3182,3 +3182,142 @@ SELECT a, b, avg(b) OVER (ROWS 0 PRECEDING) FROM t ORDER BY a
 1  1     1
 2  NULL  NULL
 3  3     3
+
+statement ok
+CREATE TABLE wxyz (w INT PRIMARY KEY, x INT, y INT, z INT)
+
+statement ok
+INSERT INTO wxyz VALUES
+  (1, 10, 1, 1),
+  (2, 10, 2, 0),
+  (3, 10, 1, 1),
+  (4, 10, 2, 0),
+  (5, 10, 2, 1),
+  (6, 10, 2, 0)
+
+# Cases involving interaction between limits and window functions.
+query IIIII rowsort
+SELECT *, rank() OVER (PARTITION BY z ORDER BY y) FROM wxyz ORDER BY y LIMIT 2
+----
+3  10  1  1  1
+1  10  1  1  1
+
+query IIIII rowsort
+SELECT *, dense_rank() OVER (PARTITION BY z ORDER BY y) FROM wxyz ORDER BY y LIMIT 2
+----
+3  10  1  1  1
+1  10  1  1  1
+
+query IIIIR rowsort
+SELECT *, avg(w) OVER (PARTITION BY z ORDER BY y) FROM wxyz ORDER BY y LIMIT 2
+----
+3  10  1  1  2
+1  10  1  1  2
+
+query IIIII rowsort
+SELECT *, rank() OVER (PARTITION BY w ORDER BY y) FROM wxyz ORDER BY y LIMIT 2
+----
+3  10  1  1  1
+1  10  1  1  1
+
+query IIIII rowsort
+SELECT *, dense_rank() OVER (PARTITION BY w ORDER BY y) FROM wxyz ORDER BY y LIMIT 2
+----
+3  10  1  1  1
+1  10  1  1  1
+
+query IIIIR rowsort
+SELECT *, avg(w) OVER (PARTITION BY w ORDER BY y) FROM wxyz ORDER BY y LIMIT 2
+----
+3  10  1  1  3
+1  10  1  1  1
+
+query IIIII rowsort
+SELECT *, rank() OVER (PARTITION BY w ORDER BY y) FROM wxyz ORDER BY w, y LIMIT 2
+----
+1  10  1  1  1
+2  10  2  0  1
+
+query IIIII rowsort
+SELECT *, dense_rank() OVER (PARTITION BY w ORDER BY y) FROM wxyz ORDER BY w, y LIMIT 2
+----
+1  10  1  1  1
+2  10  2  0  1
+
+query IIIIR rowsort
+SELECT *, avg(w) OVER (PARTITION BY w ORDER BY y) FROM wxyz ORDER BY w, y LIMIT 2
+----
+1  10  1  1  1
+2  10  2  0  2
+
+query IIIII rowsort
+SELECT *, rank() OVER (PARTITION BY w ORDER BY y) FROM wxyz ORDER BY w LIMIT 2
+----
+1  10  1  1  1
+2  10  2  0  1
+
+query IIIII rowsort
+SELECT *, dense_rank() OVER (PARTITION BY w ORDER BY y) FROM wxyz ORDER BY w LIMIT 2
+----
+1  10  1  1  1
+2  10  2  0  1
+
+query IIIIR rowsort
+SELECT *, avg(w) OVER (PARTITION BY w ORDER BY y) FROM wxyz ORDER BY w LIMIT 2
+----
+1  10  1  1  1
+2  10  2  0  2
+
+query IIIII rowsort
+SELECT *, rank() OVER (PARTITION BY w ORDER BY y) FROM wxyz ORDER BY y, w LIMIT 2
+----
+1  10  1  1  1
+3  10  1  1  1
+
+query IIIII rowsort
+SELECT *, dense_rank() OVER (PARTITION BY w ORDER BY y) FROM wxyz ORDER BY y, w LIMIT 2
+----
+1  10  1  1  1
+3  10  1  1  1
+
+query IIIIR rowsort
+SELECT *, avg(w) OVER (PARTITION BY w ORDER BY y) FROM wxyz ORDER BY y, w LIMIT 2
+----
+1  10  1  1  1
+3  10  1  1  3
+
+query IIIII rowsort
+SELECT *, rank() OVER (PARTITION BY w, z ORDER BY y) FROM wxyz ORDER BY w, z, y LIMIT 2
+----
+1  10  1  1  1
+2  10  2  0  1
+
+query IIIII rowsort
+SELECT *, dense_rank() OVER (PARTITION BY w, z ORDER BY y) FROM wxyz ORDER BY w, z, y LIMIT 2
+----
+1  10  1  1  1
+2  10  2  0  1
+
+query IIIIR rowsort
+SELECT *, avg(w) OVER (PARTITION BY w, z ORDER BY y) FROM wxyz ORDER BY w, z, y LIMIT 2
+----
+1  10  1  1  1
+2  10  2  0  2
+
+query IIIII rowsort
+SELECT *, rank() OVER (PARTITION BY w, z ORDER BY y) FROM wxyz ORDER BY z, w, y LIMIT 2
+----
+2  10  2  0  1
+4  10  2  0  1
+
+query IIIII rowsort
+SELECT *, dense_rank() OVER (PARTITION BY w, z ORDER BY y) FROM wxyz ORDER BY z, w, y LIMIT 2
+----
+2  10  2  0  1
+4  10  2  0  1
+
+query IIIIR rowsort
+SELECT *, avg(w) OVER (PARTITION BY w, z ORDER BY y) FROM wxyz ORDER BY z, w, y LIMIT 2
+----
+2  10  2  0  2
+4  10  2  0  4

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -378,6 +378,105 @@ func (c *CustomFuncs) EmptyOrdering() physical.OrderingChoice {
 	return physical.OrderingChoice{}
 }
 
+// ImpliesOrdering returns true if every ordering valid for the left ordering
+// is also valid for the right ordering.
+func (c *CustomFuncs) ImpliesOrdering(left, right physical.OrderingChoice) bool {
+	return left.Implies(&right)
+}
+
+// PrependColsToOrdering returns an ordering choice with the given ColSet as a
+// prefix to the given ordering choice, in an arbitrary ordering, with arbitrary
+// directions. referenceOrdering is used to pick an order to prepend the
+// columns from the ColSet in which is likely to work well.
+// TODO(justin): this is overly restrictive, since the columns in the colset
+// should be allowed to occur in any order, and it doesn't matter if they're
+// ascending or descending. We could use an interesting ordering to attempt to
+// find a good choice here.
+func (c *CustomFuncs) PrependColsToOrdering(
+	cols opt.ColSet, ordering physical.OrderingChoice, referenceOrdering physical.OrderingChoice,
+) physical.OrderingChoice {
+	if cols.Empty() {
+		return ordering
+	}
+	var oc physical.OrderingChoice
+	oc.Optional = ordering.Optional.Copy()
+
+	cpy := cols.Copy()
+	// We're allowed to prepend the columns from the set in any order, but we're
+	// more likely to be successful in making the ordering "work" if we try to
+	// prepend them in the order and direction they occur in the reference
+	// ordering.
+	//
+	// We do this by first adding in any columns that occur in both the set and
+	// the reference ordering in the order they occur in the reference ordering,
+	// and then after we add any from the set that didn't get added in that way.
+	for _, col := range referenceOrdering.Columns {
+		id := col.AnyID()
+		// If this column is one of the ones we're going to be prepending, do it
+		// now, so that the ordering is more likely to agree with the reference
+		// ordering.
+		if cpy.Contains(id) {
+			cpy.Remove(id)
+			oc.AppendCol(id, col.Descending)
+		}
+	}
+
+	// Add any remaining columns.
+	for col, ok := cpy.Next(0); ok; col, ok = cpy.Next(col + 1) {
+		oc.AppendCol(opt.ColumnID(col), false /* descending */)
+	}
+	oc.Columns = append(oc.Columns, ordering.Columns...)
+
+	return oc
+}
+
+// AllArePrefixSafe returns whether every window function in the list satisfies
+// the "prefix-safe" property.
+//
+// Being prefix-safe means that the computation of a window function on a given
+// row does not depend on any of the rows that come after it. It's also
+// precisely the property that lets us push limit operators below window
+// functions:
+//
+//		(Limit (Window $input) n) = (Window (Limit $input n))
+//
+// Note that the frame affects whether a given window function is prefix-safe or not.
+// rank() is prefix-safe under any frame, but avg():
+//  * is not prefix-safe under RANGE BETWEEN UNBOUNDED PRECEDING TO CURRENT ROW
+//    (the default), because we might cut off mid-peer group. If we can
+//    guarantee that the ordering is over a key, then this becomes safe.
+//  * is not prefix-safe under ROWS BETWEEN UNBOUNDED PRECEDING TO UNBOUNDED
+//    FOLLOWING, because it needs to look at the entire partition.
+//  * is prefix-safe under ROWS BETWEEN UNBOUNDED PRECEDING TO CURRENT ROW,
+//    because it only needs to look at the rows up to any given row.
+// (We don't currently handle this case).
+//
+// This function is best-effort. It's OK to report a function not as
+// prefix-safe, even if it is.
+func (c *CustomFuncs) AllArePrefixSafe(fns memo.WindowsExpr) bool {
+	for i := range fns {
+		if !c.isPrefixSafe(&fns[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// isPrefixSafe returns whether or not the given window function satisfies the
+// "prefix-safe" property. See the comment above AllArePrefixSafe for more
+// details.
+func (c *CustomFuncs) isPrefixSafe(fn *memo.WindowsItem) bool {
+	switch fn.Function.Op() {
+	case opt.RankOp, opt.RowNumberOp, opt.DenseRankOp:
+		return true
+	}
+	// TODO(justin): Add other cases. I think aggregates are valid here if the
+	// upper bound is CURRENT ROW, and either:
+	// * the mode is ROWS, or
+	// * the mode is RANGE and the ordering is over a key.
+	return false
+}
+
 // -----------------------------------------------------------------------
 //
 // Filter functions
@@ -1158,6 +1257,11 @@ func (c *CustomFuncs) ReduceWindowPartitionCols(
 // partition.
 func (c *CustomFuncs) WindowPartition(priv *memo.WindowPrivate) opt.ColSet {
 	return priv.Partition
+}
+
+// WindowOrdering returns the ordering used by the window function.
+func (c *CustomFuncs) WindowOrdering(private *memo.WindowPrivate) physical.OrderingChoice {
+	return private.Ordering
 }
 
 // ----------------------------------------------------------------------

--- a/pkg/sql/opt/norm/rules/window.opt
+++ b/pkg/sql/opt/norm/rules/window.opt
@@ -74,3 +74,90 @@ $input
     )
     (ExtractUndeterminedConditions $filters $partitionCols $input)
 )
+
+# PushLimitIntoWindow moves a Limit below a Window when able. This is
+# all-or-nothing. Even if we could push the limit below *some* of the window
+# functions, if there are any we cannot, then we don't. This is because
+# computing additional window functions is not that expensive, and the
+# expensive part is doing the sorting and partitioning. Once exec supports
+# passing orderings through and does not require re-partitioning and re-sorting
+# of window functions, pushing past some-but-not-all of the window functions
+# might be profitable.
+# 
+# SELECT rank() OVER (ORDER BY c) FROM abc ORDER BY c LIMIT 10
+# => 
+# SELECT
+#     rank() OVER (ORDER BY c)
+# FROM
+#     (SELECT c FROM abc ORDER BY c LIMIT 10)
+# 
+# SELECT rank() OVER (PARTITION BY b ORDER BY c) FROM abc LIMIT 10
+# => 
+# SELECT
+#     rank() OVER (PARTITION BY b ORDER BY c)
+# FROM
+#     (SELECT b, c FROM abc ORDER BY b, c LIMIT 10)
+# 
+# First, we construct a "segmented ordering" consisting of the Window's
+# partition columns followed by its ordering columns (the relative positions of
+# the partition columns are arbitrary). This ordering is useful because it
+# performs the partitioning and then the ordering within each partition.  If
+# this ordering does not imply the Limit's ordering, we do not proceed.
+# 
+# Since we now know that the segmented ordering is stronger than the Limit's
+# ordering, it's safe to replace the limit's ordering with it.
+# 
+# The Limit having the segmented ordering means that there are three kinds of
+# partitions:
+#   1. those that are completely contained within the limited set of rows,
+#   2. those that are completely excluded from the set of rows, and
+#   3. *at most one* partition which is "cut off" partway through.
+# Including the window function's ordering in the Limit's ordering does not
+# matter for (1)- and (2)-style partitions (since the window function itself
+# will re-sort them), but for the (3)-style partition, we need to ensure that
+# the limit operator allows through a prefix of it, rather than an arbitrary
+# subset.
+# 
+# Finally, we require that every window function+frame pair being computed has
+# the "prefix-safe" property. A window function is prefix safe if it can be
+# correctly computed over only a prefix of a partition. For example, rank() has
+# this property because rows that come later in the ordering don't affect the
+# rank of the rows before, but avg()+UNBOUNDED {PRECEDING,FOLLOWING} doesn't,
+# because we must see the entire partition to compute the average over it.
+#
+# TODO(justin): Add a rule that translates a limit with an ordering on rank()
+# or dense_rank() into one using the ordering of the window function. This will
+# allow us to push down limits in cases like:
+#
+# SELECT rank() OVER (ORDER BY f) rnk FROM a ORDER BY rnk LIMIT 10
+# =>
+# SELECT rank() OVER (ORDER BY f) rnk FROM a ORDER BY f LIMIT 10
+# =>
+# SELECT rank() OVER (ORDER BY f) rnk FROM (SELECT * FROM a ORDER BY f LIMIT 10)
+[PushLimitIntoWindow, Normalize]
+(Limit
+    (Window
+        $input:*
+        $fns:* & (AllArePrefixSafe $fns)
+        $private:*
+    )
+    $limit:*
+    $ordering:* & (ImpliesOrdering
+        $newOrdering:(PrependColsToOrdering
+            (WindowPartition $private)
+            (WindowOrdering $private)
+            $ordering
+        )
+        $ordering
+    )
+)
+=>
+(Window
+    (Limit
+        $input
+        $limit
+        $newOrdering
+    )
+    $fns
+    $private
+)

--- a/pkg/sql/opt/norm/rules/window.opt
+++ b/pkg/sql/opt/norm/rules/window.opt
@@ -142,13 +142,13 @@ $input
         $private:*
     )
     $limit:*
-    $ordering:* & (ImpliesOrdering
-        $newOrdering:(PrependColsToOrdering
+    $ordering:* &
+        (OrderingSucceeded $newOrdering:(MakeSegmentedOrdering
+            $input
             (WindowPartition $private)
             (WindowOrdering $private)
             $ordering
         )
-        $ordering
     )
 )
 =>
@@ -156,7 +156,7 @@ $input
     (Limit
         $input
         $limit
-        $newOrdering
+        (DerefOrderingChoice $newOrdering)
     )
     $fns
     $private

--- a/pkg/sql/opt/norm/testdata/rules/window
+++ b/pkg/sql/opt/norm/testdata/rules/window
@@ -273,3 +273,525 @@ project
       │         └── rank [type=int]
       └── filters
            └── rank = 3 [type=bool, outer=(6), constraints=(/6: [/3 - /3]; tight), fd=()-->(6)]
+
+# --------------------------------------------------
+# PushLimitIntoWindow
+# --------------------------------------------------
+
+norm
+SELECT rank() OVER () FROM a LIMIT 10
+----
+window partition=()
+ ├── columns: rank:6(int)
+ ├── cardinality: [0 - 10]
+ ├── limit
+ │    ├── cardinality: [0 - 10]
+ │    ├── scan a
+ │    └── const: 10 [type=int]
+ └── windows
+      └── rank [type=undefined]
+
+norm
+SELECT rank() OVER (PARTITION BY i) FROM a LIMIT 10
+----
+project
+ ├── columns: rank:6(int)
+ ├── cardinality: [0 - 10]
+ └── window partition=(2)
+      ├── columns: i:2(int) rank:6(int)
+      ├── cardinality: [0 - 10]
+      ├── limit
+      │    ├── columns: i:2(int)
+      │    ├── internal-ordering: +2
+      │    ├── cardinality: [0 - 10]
+      │    ├── sort
+      │    │    ├── columns: i:2(int)
+      │    │    ├── ordering: +2
+      │    │    └── scan a
+      │    │         └── columns: i:2(int)
+      │    └── const: 10 [type=int]
+      └── windows
+           └── rank [type=undefined]
+
+norm
+SELECT rank() OVER (PARTITION BY i ORDER BY f) FROM a LIMIT 10
+----
+project
+ ├── columns: rank:6(int)
+ ├── cardinality: [0 - 10]
+ └── window partition=(2) ordering=+3 opt(2)
+      ├── columns: i:2(int) f:3(float) rank:6(int)
+      ├── cardinality: [0 - 10]
+      ├── limit
+      │    ├── columns: i:2(int) f:3(float)
+      │    ├── internal-ordering: +2,+3
+      │    ├── cardinality: [0 - 10]
+      │    ├── sort
+      │    │    ├── columns: i:2(int) f:3(float)
+      │    │    ├── ordering: +2,+3
+      │    │    └── scan a
+      │    │         └── columns: i:2(int) f:3(float)
+      │    └── const: 10 [type=int]
+      └── windows
+           └── rank [type=undefined]
+
+norm
+SELECT
+  rank() OVER (PARTITION BY i ORDER BY f),
+  dense_rank() OVER (PARTITION BY i ORDER BY f)
+FROM a LIMIT 10
+----
+project
+ ├── columns: rank:6(int) dense_rank:7(int)
+ ├── cardinality: [0 - 10]
+ └── window partition=(2) ordering=+3 opt(2)
+      ├── columns: i:2(int) f:3(float) rank:6(int) dense_rank:7(int)
+      ├── cardinality: [0 - 10]
+      ├── limit
+      │    ├── columns: i:2(int) f:3(float)
+      │    ├── internal-ordering: +2,+3
+      │    ├── cardinality: [0 - 10]
+      │    ├── sort
+      │    │    ├── columns: i:2(int) f:3(float)
+      │    │    ├── ordering: +2,+3
+      │    │    └── scan a
+      │    │         └── columns: i:2(int) f:3(float)
+      │    └── const: 10 [type=int]
+      └── windows
+           ├── rank [type=undefined]
+           └── dense-rank [type=undefined]
+
+# Can't push the limit down, because the window function used is not
+# "prefix-safe".
+norm expect-not=PushLimitIntoWindow
+SELECT avg(k) OVER () FROM a LIMIT 10
+----
+project
+ ├── columns: avg:6(decimal)
+ ├── cardinality: [0 - 10]
+ └── limit
+      ├── columns: k:1(int!null) avg:6(decimal)
+      ├── cardinality: [0 - 10]
+      ├── key: (1)
+      ├── window partition=()
+      │    ├── columns: k:1(int!null) avg:6(decimal)
+      │    ├── key: (1)
+      │    ├── scan a
+      │    │    ├── columns: k:1(int!null)
+      │    │    └── key: (1)
+      │    └── windows
+      │         └── avg [type=decimal, outer=(1)]
+      │              └── variable: k [type=int]
+      └── const: 10 [type=int]
+
+# Can't push the limit down, because the limit operator's ordering does not
+# agree with the window function's ordering.
+norm expect-not=PushLimitIntoWindow
+SELECT rank() OVER (ORDER BY i) FROM a ORDER BY f LIMIT 10
+----
+project
+ ├── columns: rank:6(int)  [hidden: f:3(float)]
+ ├── cardinality: [0 - 10]
+ ├── ordering: +3
+ └── limit
+      ├── columns: i:2(int) f:3(float) rank:6(int)
+      ├── internal-ordering: +3
+      ├── cardinality: [0 - 10]
+      ├── ordering: +3
+      ├── sort
+      │    ├── columns: i:2(int) f:3(float) rank:6(int)
+      │    ├── ordering: +3
+      │    └── window partition=() ordering=+2
+      │         ├── columns: i:2(int) f:3(float) rank:6(int)
+      │         ├── scan a
+      │         │    └── columns: i:2(int) f:3(float)
+      │         └── windows
+      │              └── rank [type=undefined]
+      └── const: 10 [type=int]
+
+# The limit should become stronger as it gets pushed down (going from +f to
+# +f,+i), because the new limit needs to match the window function's ordering,
+# rather than its own (weaker) ordering.
+norm
+SELECT rank() OVER (ORDER BY f, i) FROM a ORDER BY f LIMIT 10
+----
+sort
+ ├── columns: rank:6(int)  [hidden: f:3(float)]
+ ├── cardinality: [0 - 10]
+ ├── ordering: +3
+ └── project
+      ├── columns: f:3(float) rank:6(int)
+      ├── cardinality: [0 - 10]
+      └── window partition=() ordering=+3,+2
+           ├── columns: i:2(int) f:3(float) rank:6(int)
+           ├── cardinality: [0 - 10]
+           ├── limit
+           │    ├── columns: i:2(int) f:3(float)
+           │    ├── internal-ordering: +3,+2
+           │    ├── cardinality: [0 - 10]
+           │    ├── sort
+           │    │    ├── columns: i:2(int) f:3(float)
+           │    │    ├── ordering: +3,+2
+           │    │    └── scan a
+           │    │         └── columns: i:2(int) f:3(float)
+           │    └── const: 10 [type=int]
+           └── windows
+                └── rank [type=undefined]
+
+# Here we would only be able to push below the rank(), and not the avg(k). This
+# is not profitable because we still have to do the partitioning and ordering
+# for the one we were unable to push the limit below, which is the expensive
+# part.
+norm
+SELECT
+    rank() OVER (PARTITION BY i ORDER BY f),
+    avg(k) OVER (PARTITION BY i ORDER BY f)
+FROM
+    a
+LIMIT
+    10
+----
+project
+ ├── columns: rank:6(int) avg:7(decimal)
+ ├── cardinality: [0 - 10]
+ └── limit
+      ├── columns: k:1(int!null) i:2(int) f:3(float) rank:6(int) avg:7(decimal)
+      ├── cardinality: [0 - 10]
+      ├── key: (1)
+      ├── fd: (1)-->(2,3)
+      ├── window partition=(2) ordering=+3 opt(2)
+      │    ├── columns: k:1(int!null) i:2(int) f:3(float) rank:6(int) avg:7(decimal)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2,3)
+      │    ├── scan a
+      │    │    ├── columns: k:1(int!null) i:2(int) f:3(float)
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2,3)
+      │    └── windows
+      │         ├── rank [type=undefined]
+      │         └── avg [type=decimal, outer=(1)]
+      │              └── variable: k [type=int]
+      └── const: 10 [type=int]
+
+exec-ddl
+CREATE TABLE wxyz (w INT PRIMARY KEY, x INT, y INT, z INT)
+----
+
+norm expect-not=PushLimitIntoWindow
+SELECT *, rank() OVER (PARTITION BY z ORDER BY y) FROM wxyz ORDER BY y LIMIT 2
+----
+limit
+ ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+ ├── internal-ordering: +3
+ ├── cardinality: [0 - 2]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── ordering: +3
+ ├── sort
+ │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    ├── ordering: +3
+ │    └── window partition=(4) ordering=+3 opt(4)
+ │         ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2-4)
+ │         ├── scan wxyz
+ │         │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+ │         │    ├── key: (1)
+ │         │    └── fd: (1)-->(2-4)
+ │         └── windows
+ │              └── rank [type=undefined]
+ └── const: 2 [type=int]
+
+norm expect-not=PushLimitIntoWindow
+SELECT *, rank() OVER (PARTITION BY w ORDER BY y) FROM wxyz ORDER BY y LIMIT 2
+----
+limit
+ ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+ ├── internal-ordering: +3
+ ├── cardinality: [0 - 2]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── ordering: +3
+ ├── sort
+ │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    ├── ordering: +3
+ │    └── window partition=(1)
+ │         ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2-4)
+ │         ├── scan wxyz
+ │         │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+ │         │    ├── key: (1)
+ │         │    └── fd: (1)-->(2-4)
+ │         └── windows
+ │              └── rank [type=undefined]
+ └── const: 2 [type=int]
+
+norm expect=PushLimitIntoWindow
+SELECT *, rank() OVER (PARTITION BY w ORDER BY y) FROM wxyz ORDER BY w, y LIMIT 2
+----
+sort
+ ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+ ├── cardinality: [0 - 2]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── ordering: +1
+ └── window partition=(1)
+      ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+      ├── cardinality: [0 - 2]
+      ├── key: (1)
+      ├── fd: (1)-->(2-4)
+      ├── limit
+      │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+      │    ├── internal-ordering: +1
+      │    ├── cardinality: [0 - 2]
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-4)
+      │    ├── scan wxyz
+      │    │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-4)
+      │    │    └── ordering: +1
+      │    └── const: 2 [type=int]
+      └── windows
+           └── rank [type=undefined]
+
+norm expect=PushLimitIntoWindow
+SELECT *, rank() OVER (PARTITION BY w ORDER BY y) FROM wxyz ORDER BY w LIMIT 2
+----
+sort
+ ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+ ├── cardinality: [0 - 2]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── ordering: +1
+ └── window partition=(1)
+      ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+      ├── cardinality: [0 - 2]
+      ├── key: (1)
+      ├── fd: (1)-->(2-4)
+      ├── limit
+      │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+      │    ├── internal-ordering: +1
+      │    ├── cardinality: [0 - 2]
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-4)
+      │    ├── scan wxyz
+      │    │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-4)
+      │    │    └── ordering: +1
+      │    └── const: 2 [type=int]
+      └── windows
+           └── rank [type=undefined]
+
+norm expect-not=PushLimitIntoWindow
+SELECT *, rank() OVER (PARTITION BY w ORDER BY y) FROM wxyz ORDER BY y, w LIMIT 2
+----
+limit
+ ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+ ├── internal-ordering: +3,+1
+ ├── cardinality: [0 - 2]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── ordering: +3,+1
+ ├── sort
+ │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    ├── ordering: +3,+1
+ │    └── window partition=(1)
+ │         ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2-4)
+ │         ├── scan wxyz
+ │         │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+ │         │    ├── key: (1)
+ │         │    └── fd: (1)-->(2-4)
+ │         └── windows
+ │              └── rank [type=undefined]
+ └── const: 2 [type=int]
+
+norm expect=PushLimitIntoWindow
+SELECT *, rank() OVER (PARTITION BY w, z ORDER BY y) FROM wxyz ORDER BY w, z LIMIT 2
+----
+sort
+ ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+ ├── cardinality: [0 - 2]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── ordering: +1
+ └── window partition=(1)
+      ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+      ├── cardinality: [0 - 2]
+      ├── key: (1)
+      ├── fd: (1)-->(2-4)
+      ├── limit
+      │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+      │    ├── internal-ordering: +1
+      │    ├── cardinality: [0 - 2]
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-4)
+      │    ├── scan wxyz
+      │    │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-4)
+      │    │    └── ordering: +1
+      │    └── const: 2 [type=int]
+      └── windows
+           └── rank [type=undefined]
+
+norm
+SELECT *, rank() OVER (PARTITION BY x, z ORDER BY y) FROM wxyz ORDER BY z, x LIMIT 2
+----
+sort
+ ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+ ├── cardinality: [0 - 2]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── ordering: +4,+2
+ └── window partition=(2,4) ordering=+3 opt(2,4)
+      ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+      ├── cardinality: [0 - 2]
+      ├── key: (1)
+      ├── fd: (1)-->(2-4)
+      ├── limit
+      │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+      │    ├── internal-ordering: +4,+2,+3
+      │    ├── cardinality: [0 - 2]
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-4)
+      │    ├── sort
+      │    │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-4)
+      │    │    ├── ordering: +4,+2,+3
+      │    │    └── scan wxyz
+      │    │         ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+      │    │         ├── key: (1)
+      │    │         └── fd: (1)-->(2-4)
+      │    └── const: 2 [type=int]
+      └── windows
+           └── rank [type=undefined]
+
+norm expect=PushLimitIntoWindow
+SELECT *, rank() OVER (PARTITION BY z ORDER BY y) FROM wxyz ORDER BY z, y LIMIT 2
+----
+sort
+ ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+ ├── cardinality: [0 - 2]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── ordering: +4,+3
+ └── window partition=(4) ordering=+3 opt(4)
+      ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+      ├── cardinality: [0 - 2]
+      ├── key: (1)
+      ├── fd: (1)-->(2-4)
+      ├── limit
+      │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+      │    ├── internal-ordering: +4,+3
+      │    ├── cardinality: [0 - 2]
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-4)
+      │    ├── sort
+      │    │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-4)
+      │    │    ├── ordering: +4,+3
+      │    │    └── scan wxyz
+      │    │         ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+      │    │         ├── key: (1)
+      │    │         └── fd: (1)-->(2-4)
+      │    └── const: 2 [type=int]
+      └── windows
+           └── rank [type=undefined]
+
+norm expect-not=PushLimitIntoWindow
+SELECT *, rank() OVER (PARTITION BY z ORDER BY y) FROM wxyz ORDER BY y LIMIT 2
+----
+limit
+ ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+ ├── internal-ordering: +3
+ ├── cardinality: [0 - 2]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── ordering: +3
+ ├── sort
+ │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    ├── ordering: +3
+ │    └── window partition=(4) ordering=+3 opt(4)
+ │         ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2-4)
+ │         ├── scan wxyz
+ │         │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+ │         │    ├── key: (1)
+ │         │    └── fd: (1)-->(2-4)
+ │         └── windows
+ │              └── rank [type=undefined]
+ └── const: 2 [type=int]
+
+norm expect=PushLimitIntoWindow
+SELECT *, rank() OVER (PARTITION BY w, z ORDER BY y) FROM wxyz ORDER BY w, z, y LIMIT 2
+----
+sort
+ ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+ ├── cardinality: [0 - 2]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── ordering: +1
+ └── window partition=(1)
+      ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+      ├── cardinality: [0 - 2]
+      ├── key: (1)
+      ├── fd: (1)-->(2-4)
+      ├── limit
+      │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+      │    ├── internal-ordering: +1
+      │    ├── cardinality: [0 - 2]
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-4)
+      │    ├── scan wxyz
+      │    │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-4)
+      │    │    └── ordering: +1
+      │    └── const: 2 [type=int]
+      └── windows
+           └── rank [type=undefined]
+
+# TODO(justin): This one should be pushed down, but it isn't because we can't
+# specify that z,w can occur in either order.
+norm
+SELECT *, rank() OVER (PARTITION BY w, z ORDER BY y) FROM wxyz ORDER BY z, w, y LIMIT 2
+----
+limit
+ ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+ ├── internal-ordering: +4,+1
+ ├── cardinality: [0 - 2]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── ordering: +4,+1
+ ├── sort
+ │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    ├── ordering: +4,+1
+ │    └── window partition=(1)
+ │         ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2-4)
+ │         ├── scan wxyz
+ │         │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+ │         │    ├── key: (1)
+ │         │    └── fd: (1)-->(2-4)
+ │         └── windows
+ │              └── rank [type=undefined]
+ └── const: 2 [type=int]

--- a/pkg/sql/opt/norm/testdata/rules/window
+++ b/pkg/sql/opt/norm/testdata/rules/window
@@ -289,7 +289,7 @@ window partition=()
  │    ├── scan a
  │    └── const: 10 [type=int]
  └── windows
-      └── rank [type=undefined]
+      └── rank [type=int]
 
 norm
 SELECT rank() OVER (PARTITION BY i) FROM a LIMIT 10
@@ -311,7 +311,7 @@ project
       │    │         └── columns: i:2(int)
       │    └── const: 10 [type=int]
       └── windows
-           └── rank [type=undefined]
+           └── rank [type=int]
 
 norm
 SELECT rank() OVER (PARTITION BY i ORDER BY f) FROM a LIMIT 10
@@ -333,7 +333,7 @@ project
       │    │         └── columns: i:2(int) f:3(float)
       │    └── const: 10 [type=int]
       └── windows
-           └── rank [type=undefined]
+           └── rank [type=int]
 
 norm
 SELECT
@@ -358,8 +358,8 @@ project
       │    │         └── columns: i:2(int) f:3(float)
       │    └── const: 10 [type=int]
       └── windows
-           ├── rank [type=undefined]
-           └── dense-rank [type=undefined]
+           ├── rank [type=int]
+           └── dense-rank [type=int]
 
 # Can't push the limit down, because the window function used is not
 # "prefix-safe".
@@ -406,7 +406,7 @@ project
       │         ├── scan a
       │         │    └── columns: i:2(int) f:3(float)
       │         └── windows
-      │              └── rank [type=undefined]
+      │              └── rank [type=int]
       └── const: 10 [type=int]
 
 # The limit should become stronger as it gets pushed down (going from +f to
@@ -436,7 +436,7 @@ sort
            │    │         └── columns: i:2(int) f:3(float)
            │    └── const: 10 [type=int]
            └── windows
-                └── rank [type=undefined]
+                └── rank [type=int]
 
 # Here we would only be able to push below the rank(), and not the avg(k). This
 # is not profitable because we still have to do the partitioning and ordering
@@ -468,7 +468,7 @@ project
       │    │    ├── key: (1)
       │    │    └── fd: (1)-->(2,3)
       │    └── windows
-      │         ├── rank [type=undefined]
+      │         ├── rank [type=int]
       │         └── avg [type=decimal, outer=(1)]
       │              └── variable: k [type=int]
       └── const: 10 [type=int]
@@ -501,35 +501,41 @@ limit
  │         │    ├── key: (1)
  │         │    └── fd: (1)-->(2-4)
  │         └── windows
- │              └── rank [type=undefined]
+ │              └── rank [type=int]
  └── const: 2 [type=int]
 
-norm expect-not=PushLimitIntoWindow
+norm expect=PushLimitIntoWindow
 SELECT *, rank() OVER (PARTITION BY w ORDER BY y) FROM wxyz ORDER BY y LIMIT 2
 ----
-limit
+sort
  ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
- ├── internal-ordering: +3
  ├── cardinality: [0 - 2]
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── ordering: +3
- ├── sort
- │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
- │    ├── key: (1)
- │    ├── fd: (1)-->(2-4)
- │    ├── ordering: +3
- │    └── window partition=(1)
- │         ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
- │         ├── key: (1)
- │         ├── fd: (1)-->(2-4)
- │         ├── scan wxyz
- │         │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
- │         │    ├── key: (1)
- │         │    └── fd: (1)-->(2-4)
- │         └── windows
- │              └── rank [type=undefined]
- └── const: 2 [type=int]
+ └── window partition=(1)
+      ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+      ├── cardinality: [0 - 2]
+      ├── key: (1)
+      ├── fd: (1)-->(2-4)
+      ├── limit
+      │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+      │    ├── internal-ordering: +3,+1
+      │    ├── cardinality: [0 - 2]
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-4)
+      │    ├── sort
+      │    │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-4)
+      │    │    ├── ordering: +3,+1
+      │    │    └── scan wxyz
+      │    │         ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+      │    │         ├── key: (1)
+      │    │         └── fd: (1)-->(2-4)
+      │    └── const: 2 [type=int]
+      └── windows
+           └── rank [type=int]
 
 norm expect=PushLimitIntoWindow
 SELECT *, rank() OVER (PARTITION BY w ORDER BY y) FROM wxyz ORDER BY w, y LIMIT 2
@@ -558,7 +564,7 @@ sort
       │    │    └── ordering: +1
       │    └── const: 2 [type=int]
       └── windows
-           └── rank [type=undefined]
+           └── rank [type=int]
 
 norm expect=PushLimitIntoWindow
 SELECT *, rank() OVER (PARTITION BY w ORDER BY y) FROM wxyz ORDER BY w LIMIT 2
@@ -587,34 +593,40 @@ sort
       │    │    └── ordering: +1
       │    └── const: 2 [type=int]
       └── windows
-           └── rank [type=undefined]
+           └── rank [type=int]
 
-norm expect-not=PushLimitIntoWindow
+norm expect=PushLimitIntoWindow
 SELECT *, rank() OVER (PARTITION BY w ORDER BY y) FROM wxyz ORDER BY y, w LIMIT 2
 ----
-limit
+sort
  ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
- ├── internal-ordering: +3,+1
  ├── cardinality: [0 - 2]
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── ordering: +3,+1
- ├── sort
- │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
- │    ├── key: (1)
- │    ├── fd: (1)-->(2-4)
- │    ├── ordering: +3,+1
- │    └── window partition=(1)
- │         ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
- │         ├── key: (1)
- │         ├── fd: (1)-->(2-4)
- │         ├── scan wxyz
- │         │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
- │         │    ├── key: (1)
- │         │    └── fd: (1)-->(2-4)
- │         └── windows
- │              └── rank [type=undefined]
- └── const: 2 [type=int]
+ └── window partition=(1)
+      ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+      ├── cardinality: [0 - 2]
+      ├── key: (1)
+      ├── fd: (1)-->(2-4)
+      ├── limit
+      │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+      │    ├── internal-ordering: +3,+1
+      │    ├── cardinality: [0 - 2]
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-4)
+      │    ├── sort
+      │    │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-4)
+      │    │    ├── ordering: +3,+1
+      │    │    └── scan wxyz
+      │    │         ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+      │    │         ├── key: (1)
+      │    │         └── fd: (1)-->(2-4)
+      │    └── const: 2 [type=int]
+      └── windows
+           └── rank [type=int]
 
 norm expect=PushLimitIntoWindow
 SELECT *, rank() OVER (PARTITION BY w, z ORDER BY y) FROM wxyz ORDER BY w, z LIMIT 2
@@ -643,7 +655,7 @@ sort
       │    │    └── ordering: +1
       │    └── const: 2 [type=int]
       └── windows
-           └── rank [type=undefined]
+           └── rank [type=int]
 
 norm
 SELECT *, rank() OVER (PARTITION BY x, z ORDER BY y) FROM wxyz ORDER BY z, x LIMIT 2
@@ -676,7 +688,7 @@ sort
       │    │         └── fd: (1)-->(2-4)
       │    └── const: 2 [type=int]
       └── windows
-           └── rank [type=undefined]
+           └── rank [type=int]
 
 norm expect=PushLimitIntoWindow
 SELECT *, rank() OVER (PARTITION BY z ORDER BY y) FROM wxyz ORDER BY z, y LIMIT 2
@@ -709,7 +721,7 @@ sort
       │    │         └── fd: (1)-->(2-4)
       │    └── const: 2 [type=int]
       └── windows
-           └── rank [type=undefined]
+           └── rank [type=int]
 
 norm expect-not=PushLimitIntoWindow
 SELECT *, rank() OVER (PARTITION BY z ORDER BY y) FROM wxyz ORDER BY y LIMIT 2
@@ -735,7 +747,7 @@ limit
  │         │    ├── key: (1)
  │         │    └── fd: (1)-->(2-4)
  │         └── windows
- │              └── rank [type=undefined]
+ │              └── rank [type=int]
  └── const: 2 [type=int]
 
 norm expect=PushLimitIntoWindow
@@ -765,33 +777,70 @@ sort
       │    │    └── ordering: +1
       │    └── const: 2 [type=int]
       └── windows
-           └── rank [type=undefined]
+           └── rank [type=int]
 
-# TODO(justin): This one should be pushed down, but it isn't because we can't
-# specify that z,w can occur in either order.
 norm
 SELECT *, rank() OVER (PARTITION BY w, z ORDER BY y) FROM wxyz ORDER BY z, w, y LIMIT 2
 ----
-limit
+sort
  ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
- ├── internal-ordering: +4,+1
  ├── cardinality: [0 - 2]
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── ordering: +4,+1
- ├── sort
- │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
- │    ├── key: (1)
- │    ├── fd: (1)-->(2-4)
- │    ├── ordering: +4,+1
- │    └── window partition=(1)
- │         ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
- │         ├── key: (1)
- │         ├── fd: (1)-->(2-4)
- │         ├── scan wxyz
- │         │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
- │         │    ├── key: (1)
- │         │    └── fd: (1)-->(2-4)
- │         └── windows
- │              └── rank [type=undefined]
- └── const: 2 [type=int]
+ └── window partition=(1)
+      ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+      ├── cardinality: [0 - 2]
+      ├── key: (1)
+      ├── fd: (1)-->(2-4)
+      ├── limit
+      │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+      │    ├── internal-ordering: +4,+1
+      │    ├── cardinality: [0 - 2]
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-4)
+      │    ├── sort
+      │    │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-4)
+      │    │    ├── ordering: +4,+1
+      │    │    └── scan wxyz
+      │    │         ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+      │    │         ├── key: (1)
+      │    │         └── fd: (1)-->(2-4)
+      │    └── const: 2 [type=int]
+      └── windows
+           └── rank [type=int]
+
+norm
+SELECT *, rank() OVER (PARTITION BY w ORDER BY y) FROM wxyz ORDER BY z LIMIT 2
+----
+sort
+ ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+ ├── cardinality: [0 - 2]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── ordering: +4
+ └── window partition=(1)
+      ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int) rank:5(int)
+      ├── cardinality: [0 - 2]
+      ├── key: (1)
+      ├── fd: (1)-->(2-4)
+      ├── limit
+      │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+      │    ├── internal-ordering: +4,+1
+      │    ├── cardinality: [0 - 2]
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-4)
+      │    ├── sort
+      │    │    ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-4)
+      │    │    ├── ordering: +4,+1
+      │    │    └── scan wxyz
+      │    │         ├── columns: w:1(int!null) x:2(int) y:3(int) z:4(int)
+      │    │         ├── key: (1)
+      │    │         └── fd: (1)-->(2-4)
+      │    └── const: 2 [type=int]
+      └── windows
+           └── rank [type=int]

--- a/pkg/sql/opt/props/physical/ordering_choice.go
+++ b/pkg/sql/opt/props/physical/ordering_choice.go
@@ -472,6 +472,7 @@ func (oc *OrderingChoice) MatchesAt(index int, col opt.OrderingColumn) bool {
 func (oc *OrderingChoice) AppendCol(id opt.ColumnID, descending bool) {
 	ordCol := OrderingColumnChoice{Descending: descending}
 	ordCol.Group.Add(id)
+	oc.Optional.Remove(id)
 	oc.Columns = append(oc.Columns, ordCol)
 }
 

--- a/pkg/sql/opt/props/physical/ordering_choice.go
+++ b/pkg/sql/opt/props/physical/ordering_choice.go
@@ -629,6 +629,72 @@ func (oc *OrderingChoice) ProjectCols(cols opt.ColSet) {
 	}
 }
 
+// PrefixIntersection computes an OrderingChoice which:
+//  - implies <oc> (this instance), and
+//  - implies a "segmented ordering", which is any ordering which starts with a
+//    permutation of all columns in <prefix> followed by the <suffix> ordering.
+//
+// Note that <prefix> and <suffix> cannot have any columns in common.
+//
+// Such an ordering can be computed via the following rules:
+//
+//  - if <prefix> and <suffix> are empty: return this instance.
+//
+//  - if <oc> is empty: generate an arbitrary segmented ordering.
+//
+//  - if the first column of <oc> is either in <prefix> or is the first column
+//    of <suffix> while <prefix> is empty: this column is the first column of
+//    the result; calculate the rest recursively.
+//
+func (oc OrderingChoice) PrefixIntersection(
+	prefix opt.ColSet, suffix []OrderingColumnChoice,
+) (_ OrderingChoice, ok bool) {
+	var result OrderingChoice
+	oc = oc.Copy()
+
+	prefix = prefix.Copy()
+
+	for {
+		switch {
+		case prefix.Empty() && len(suffix) == 0:
+			// Any ordering is allowed by <prefix>+<suffix>, so use <oc> directly.
+			result.Columns = append(result.Columns, oc.Columns...)
+			return result, true
+		case len(oc.Columns) == 0:
+			// Any ordering is allowed by <oc>, so pick an arbitrary ordering of the
+			// columns in <prefix> then append suffix.
+			// TODO(justin): investigate picking an order more intelligently here.
+			for col, ok := prefix.Next(0); ok; col, ok = prefix.Next(col + 1) {
+				result.AppendCol(col, false /* descending */)
+			}
+
+			result.Columns = append(result.Columns, suffix...)
+			return result, true
+		case prefix.Empty() && len(oc.Columns) > 0 && len(suffix) > 0 &&
+			oc.Columns[0].Group.Intersects(suffix[0].Group) &&
+			oc.Columns[0].Descending == suffix[0].Descending:
+			// <prefix> is empty, and <suffix> and <oc> agree on the first column, so
+			// emit that column, remove it from both, and loop.
+			newCol := oc.Columns[0]
+			newCol.Group = oc.Columns[0].Group.Intersection(suffix[0].Group)
+			result.Columns = append(result.Columns, newCol)
+
+			oc.Columns = oc.Columns[1:]
+			suffix = suffix[1:]
+		case len(oc.Columns) > 0 && prefix.Intersects(oc.Columns[0].Group):
+			// <prefix> contains the first column in <oc>, so emit it and remove it
+			// from both.
+			result.Columns = append(result.Columns, oc.Columns[0])
+
+			prefix.DifferenceWith(oc.Columns[0].Group)
+			oc.Columns = oc.Columns[1:]
+		default:
+			// If no rule applied, fail.
+			return OrderingChoice{}, false
+		}
+	}
+}
+
 // Equals returns true if the set of orderings matched by this instance is the
 // same as the set matched by the given instance.
 func (oc *OrderingChoice) Equals(rhs *OrderingChoice) bool {
@@ -641,12 +707,12 @@ func (oc *OrderingChoice) Equals(rhs *OrderingChoice) bool {
 
 	for i := range oc.Columns {
 		left := &oc.Columns[i]
-		right := &rhs.Columns[i]
+		y := &rhs.Columns[i]
 
-		if left.Descending != right.Descending {
+		if left.Descending != y.Descending {
 			return false
 		}
-		if !left.Group.Equals(right.Group) {
+		if !left.Group.Equals(y.Group) {
 			return false
 		}
 	}

--- a/pkg/sql/opt/props/physical/ordering_choice_test.go
+++ b/pkg/sql/opt/props/physical/ordering_choice_test.go
@@ -502,3 +502,55 @@ func TestOrderingChoice_Equals(t *testing.T) {
 		}
 	}
 }
+
+func TestOrderingChoice_PrefixIntersection(t *testing.T) {
+	testcases := []struct {
+		x        string
+		prefix   opt.ColList
+		y        string
+		expected string
+	}{
+		{x: "+1", prefix: opt.ColList{}, y: "+2", expected: "fail"},
+		{x: "", prefix: opt.ColList{}, y: "+1", expected: "+1"},
+		{x: "", prefix: opt.ColList{}, y: "+1,+2", expected: "+1,+2"},
+		{x: "+(1|2)", prefix: opt.ColList{}, y: "+(1|2)", expected: "+(1|2)"},
+		{x: "+(1|2)", prefix: opt.ColList{}, y: "+1", expected: "+1"},
+		{x: "+(1|2)", prefix: opt.ColList{}, y: "+2", expected: "+2"},
+		{x: "+1,+2", prefix: opt.ColList{3}, y: "", expected: "fail"},
+		{x: "", prefix: opt.ColList{3}, y: "+1,+2", expected: "+3,+1,+2"},
+		{x: "+1,+2", prefix: opt.ColList{3, 4}, y: "", expected: "fail"},
+		{x: "", prefix: opt.ColList{3, 4}, y: "+1,+2", expected: "+3,+4,+1,+2"},
+		{x: "+1", prefix: opt.ColList{}, y: "+1", expected: "+1"},
+		{x: "+1,+2", prefix: opt.ColList{}, y: "+1", expected: "+1,+2"},
+		{x: "+1", prefix: opt.ColList{}, y: "+1,+2", expected: "+1,+2"},
+		{x: "+1,+2", prefix: opt.ColList{}, y: "+1,+2", expected: "+1,+2"},
+		{x: "+1,+2", prefix: opt.ColList{1}, y: "+2", expected: "+1,+2"},
+		{x: "+2", prefix: opt.ColList{3}, y: "+1,+2", expected: "fail"},
+		{x: "+1,+2", prefix: opt.ColList{}, y: "+1,+2", expected: "+1,+2"},
+		{x: "+1,+2", prefix: opt.ColList{1}, y: "+2,+3", expected: "+1,+2,+3"},
+		{x: "+1,+2", prefix: opt.ColList{1, 2}, y: "+3", expected: "+1,+2,+3"},
+		{x: "+1,+2", prefix: opt.ColList{1, 2}, y: "", expected: "+1,+2"},
+		{x: "+2,+1", prefix: opt.ColList{1, 2}, y: "", expected: "+2,+1"},
+		{x: "+2,+3", prefix: opt.ColList{3}, y: "+1,+2", expected: "fail"},
+		{x: "", prefix: opt.ColList{1, 2}, y: "", expected: "+1,+2"},
+		{x: "", prefix: opt.ColList{2}, y: "+3 opt(2)", expected: "+2,+3"},
+		{x: "", prefix: opt.ColList{2}, y: "+3", expected: "+2,+3"},
+	}
+
+	for _, tc := range testcases {
+		left := physical.ParseOrderingChoice(tc.x)
+		right := physical.ParseOrderingChoice(tc.y)
+
+		cols := tc.prefix.ToSet()
+
+		result, ok := left.PrefixIntersection(cols, right.Columns)
+		s := "fail"
+		if ok {
+			s = result.String()
+		}
+
+		if s != tc.expected {
+			t.Errorf("%q.PrefixIntersection(%q, %q): expected %q, got %q", left, cols, right, tc.expected, s)
+		}
+	}
+}


### PR DESCRIPTION
This commit adds PushLimitIntoWindow, which is a rule for moving Limit
operators below Window operators. This can be very beneficial in some
cases, since there are many common window functions (such as rank())
which can be computed this way, and this can vastly reduce the amount of
data the window function needs to process.

The rules for when this transformation is legal are quite subtle (and I
wrote several broken versions before arriving at this, which I believe
is correct). I've tried to be as detailed as possible in the explanation
of when and how we can do this, but I probably missed some details, so
let me know if any of it is unclear.

Here is the comment included above the rule:

```
PushLimitIntoWindow moves a Limit below a Window when able.  This is
all-or-nothing. Even if we could push the limit below *some* of the window
functions, if there are any we cannot, then we don't. This is because
computing additional window functions is not that expensive, and the
expensive part is doing the sorting and partitioning. Once exec supports
passing orderings through and does not require re-partitioning and re-sorting
of window functions, pushing past some-but-not-all of the window functions
might be profitable.

SELECT rank() OVER (ORDER BY c) FROM abc ORDER BY c LIMIT 10
=>
SELECT
    rank() OVER (ORDER BY c)
FROM
    (SELECT c FROM abc ORDER BY c LIMIT 10)

SELECT rank() OVER (PARTITION BY b ORDER BY c) FROM abc LIMIT 10
=>
SELECT
    rank() OVER (PARTITION BY b ORDER BY c)
FROM
    (SELECT b, c FROM abc ORDER BY b, c LIMIT 10)

First, we construct a "segmented ordering" consisting of the Window's
partition columns followed by its ordering columns (the relative positions of
the partition columns are arbitrary). This ordering is useful because it
performs the partitioning and then the ordering within each partition.  If
this ordering is not stronger than the Limit's ordering, we do not proceed.

Since we now know that the segmented ordering is stronger than the Limit's
ordering, it's safe to replace the limit with it.

The Limit having the segmented ordering means that the Limit will then "cut
off" at most one partition, the one which is ordered last. The window
function's ordering does not matter for all of the not-cut-off partitions,
but the one that *does* get cut off, we need to ensure that the limit
operator allows through a prefix of it, rather than an arbitrary ordering.

Finally, we require that every window function being computed has the
"prefix-safe" property.  A window function is prefix safe if it can be
correctly computed over only a prefix of a partition. For example,
rank() has this property because rows that come later in the ordering
don't affect the rank of the rows before, but avg() doesn't, because we
must see the entire partition to compute the average over it.
```

Release note: None