### PR TITLE
sql: add UNSPLIT ALL

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1233,6 +1233,7 @@ alter_split_stmt ::=
 
 alter_unsplit_stmt ::=
 	'ALTER' 'TABLE' table_name 'UNSPLIT' 'AT' select_stmt
+	| 'ALTER' 'TABLE' table_name 'UNSPLIT' 'ALL'
 
 alter_scatter_stmt ::=
 	'ALTER' 'TABLE' table_name 'SCATTER'
@@ -1256,6 +1257,7 @@ alter_split_index_stmt ::=
 
 alter_unsplit_index_stmt ::=
 	'ALTER' 'INDEX' table_index_name 'UNSPLIT' 'AT' select_stmt
+	| 'ALTER' 'INDEX' table_index_name 'UNSPLIT' 'ALL'
 
 alter_scatter_index_stmt ::=
 	'ALTER' 'INDEX' table_index_name 'SCATTER'

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -683,6 +683,12 @@ ALTER TABLE nonexistent UNSPLIT AT VALUES (42)
 statement error pgcode 42P01 relation "nonexistent" does not exist
 ALTER INDEX nonexistent@noindex UNSPLIT AT VALUES (42)
 
+statement error pgcode 42P01 relation "nonexistent" does not exist
+ALTER TABLE nonexistent UNSPLIT ALL
+
+statement error pgcode 42P01 relation "nonexistent" does not exist
+ALTER INDEX nonexistent@noindex UNSPLIT ALL
+
 user root
 
 statement ok
@@ -696,6 +702,9 @@ ALTER TABLE privsview SPLIT AT VALUES (42)
 
 statement error pgcode 42809 "privsview" is not a table
 ALTER TABLE privsview UNSPLIT AT VALUES (42)
+
+statement error pgcode 42809 "privsview" is not a table
+ALTER TABLE privsview UNSPLIT ALL
 
 # Verify that impure defaults are evaluated separately on each row
 # (#14352)

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -370,6 +370,22 @@ SELECT start_pretty, end_pretty, split_enforced_until FROM crdb_internal.ranges_
 start_pretty   end_pretty  split_enforced_until
 /Table/56/1/2  /Max        2200-01-01 00:00:00 +0000 +0000
 
+statement ok
+ALTER TABLE foo SPLIT AT VALUES (1), (2), (3)
+
+statement ok
+ALTER TABLE foo UNSPLIT ALL
+
+query TT colnames
+SELECT start_pretty, end_pretty FROM crdb_internal.ranges WHERE split_enforced_until IS NOT NULL
+----
+start_pretty   end_pretty
+
+query TT colnames
+SELECT start_pretty, end_pretty FROM crdb_internal.ranges_no_leases WHERE split_enforced_until IS NOT NULL
+----
+start_pretty   end_pretty
+
 # Make sure that the cluster id isn't unset.
 query B
 select crdb_internal.cluster_id() != '00000000-0000-0000-0000-000000000000' FROM foo

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1110,6 +1110,7 @@ alter_ddl_stmt:
 //   ALTER TABLE ... VALIDATE CONSTRAINT <constraintname>
 //   ALTER TABLE ... SPLIT AT <selectclause> [WITH EXPIRATION <expr>]
 //   ALTER TABLE ... UNSPLIT AT <selectclause>
+//   ALTER TABLE ... UNSPLIT ALL
 //   ALTER TABLE ... SCATTER [ FROM ( <exprs...> ) TO ( <exprs...> ) ]
 //   ALTER TABLE ... INJECT STATISTICS ...  (experimental)
 //   ALTER TABLE ... PARTITION BY RANGE ( <name...> ) ( <rangespec> )
@@ -1230,6 +1231,7 @@ alter_range_stmt:
 //   ALTER INDEX ... RENAME TO <newname>
 //   ALTER INDEX ... SPLIT AT <selectclause> [WITH EXPIRATION <expr>]
 //   ALTER INDEX ... UNSPLIT AT <selectclause>
+//   ALTER INDEX ... UNSPLIT ALL
 //   ALTER INDEX ... SCATTER [ FROM ( <exprs...> ) TO ( <exprs...> ) ]
 //   ALTER PARTITION ... OF INDEX ... CONFIGURE ZONE <zoneconfig>
 //
@@ -1312,11 +1314,23 @@ alter_unsplit_stmt:
       Rows: $6.slct(),
     }
   }
+| ALTER TABLE table_name UNSPLIT ALL
+  {
+    name := $3.unresolvedObjectName().ToTableName()
+    $$.val = &tree.Unsplit {
+      TableOrIndex: tree.TableIndexName{Table: name},
+      All: true,
+    }
+  }
 
 alter_unsplit_index_stmt:
   ALTER INDEX table_index_name UNSPLIT AT select_stmt
   {
     $$.val = &tree.Unsplit{TableOrIndex: $3.tableIndexName(), Rows: $6.slct()}
+  }
+| ALTER INDEX table_index_name UNSPLIT ALL
+  {
+    $$.val = &tree.Unsplit{TableOrIndex: $3.tableIndexName(), All: true}
   }
 
 relocate_kw:

--- a/pkg/sql/sem/tree/split.go
+++ b/pkg/sql/sem/tree/split.go
@@ -46,6 +46,7 @@ type Unsplit struct {
 	// Each row contains values for the columns in the PK or index (or a prefix
 	// of the columns).
 	Rows *Select
+	All  bool
 }
 
 // Format implements the NodeFormatter interface.
@@ -57,8 +58,12 @@ func (node *Unsplit) Format(ctx *FmtCtx) {
 		ctx.WriteString("TABLE ")
 	}
 	ctx.FormatNode(&node.TableOrIndex)
-	ctx.WriteString(" UNSPLIT AT ")
-	ctx.FormatNode(node.Rows)
+	if node.All {
+		ctx.WriteString(" UNSPLIT ALL")
+	} else {
+		ctx.WriteString(" UNSPLIT AT ")
+		ctx.FormatNode(node.Rows)
+	}
 }
 
 // Relocate represents an `ALTER TABLE/INDEX .. EXPERIMENTAL_RELOCATE ..`

--- a/pkg/sql/unsplit.go
+++ b/pkg/sql/unsplit.go
@@ -30,8 +30,13 @@ type unsplitNode struct {
 
 	tableDesc *sqlbase.TableDescriptor
 	index     *sqlbase.IndexDescriptor
-	rows      planNode
 	run       unsplitRun
+	rows      planNode
+	// If set, the source for rows produces "raw" keys that address a row in kv.
+	// Otherwise, the source produces primary key tuples. In particular, this
+	// option is set when performing UNSPLIT ALL because the split points are
+	// read from crdb_internal.ranges as raw keys.
+	raw bool
 }
 
 // Unsplit executes a KV unsplit.
@@ -41,44 +46,72 @@ func (p *planner) Unsplit(ctx context.Context, n *tree.Unsplit) (planNode, error
 	if err != nil {
 		return nil, err
 	}
+	ret := &unsplitNode{
+		tableDesc: tableDesc.TableDesc(),
+		index:     index,
+		raw:       n.All,
+	}
 	// Calculate the desired types for the select statement. It is OK if the
 	// select statement returns fewer columns (the relevant prefix is used).
 	desiredTypes := make([]*types.T, len(index.ColumnIDs))
+	columns := make(sqlbase.ResultColumns, len(index.ColumnIDs))
 	for i, colID := range index.ColumnIDs {
 		c, err := tableDesc.FindColumnByID(colID)
 		if err != nil {
 			return nil, err
 		}
 		desiredTypes[i] = &c.Type
+		columns[i].Typ = &c.Type
+		columns[i].Name = c.Name
 	}
 
 	// Create the plan for the unsplit rows source.
-	rows, err := p.newPlan(ctx, n.Rows, desiredTypes)
-	if err != nil {
-		return nil, err
-	}
-
-	cols := planColumns(rows)
-	if len(cols) == 0 {
-		return nil, errors.Errorf("no columns in UNSPLIT AT data")
-	}
-	if len(cols) > len(index.ColumnIDs) {
-		return nil, errors.Errorf("too many columns in UNSPLIT AT data")
-	}
-	for i := range cols {
-		if !cols[i].Typ.Equivalent(desiredTypes[i]) {
-			return nil, errors.Errorf(
-				"UNSPLIT AT data column %d (%s) must be of type %s, not type %s",
-				i+1, index.ColumnNames[i], desiredTypes[i], cols[i].Typ,
-			)
+	if n.All {
+		statement := `
+			SELECT
+				start_key
+			FROM
+				crdb_internal.ranges_no_leases
+			WHERE
+				table_name=$1::string AND index_name=$2::string AND split_enforced_until IS NOT NULL
+		`
+		ranges, err := p.ExtendedEvalContext().InternalExecutor.Query(
+			ctx, "split points query", p.txn, statement, n.TableOrIndex.Table.String(), n.TableOrIndex.Index)
+		if err != nil {
+			return nil, err
 		}
+		v := p.newContainerValuesNode(columns, 0)
+		for _, d := range ranges {
+			if _, err := v.rows.AddRow(ctx, d); err != nil {
+				return nil, err
+			}
+		}
+		ret.rows = v
+	} else {
+		rows, err := p.newPlan(ctx, n.Rows, desiredTypes)
+		if err != nil {
+			return nil, err
+		}
+
+		cols := planColumns(rows)
+		if len(cols) == 0 {
+			return nil, errors.Errorf("no columns in UNSPLIT AT data")
+		}
+		if len(cols) > len(index.ColumnIDs) {
+			return nil, errors.Errorf("too many columns in UNSPLIT AT data")
+		}
+		for i := range cols {
+			if !cols[i].Typ.Equivalent(desiredTypes[i]) {
+				return nil, errors.Errorf(
+					"UNSPLIT AT data column %d (%s) must be of type %s, not type %s",
+					i+1, index.ColumnNames[i], desiredTypes[i], cols[i].Typ,
+				)
+			}
+		}
+		ret.rows = rows
 	}
 
-	return &unsplitNode{
-		tableDesc: tableDesc.TableDesc(),
-		index:     index,
-		rows:      rows,
-	}, nil
+	return ret, nil
 }
 
 var unsplitNodeColumns = sqlbase.ResultColumns{
@@ -115,9 +148,17 @@ func (n *unsplitNode) Next(params runParams) (bool, error) {
 	}
 
 	row := n.rows.Values()
-	rowKey, err := getRowKey(n.tableDesc, n.index, row)
-	if err != nil {
-		return false, err
+	var rowKey []byte
+	var err error
+	// If raw is set, we don't have to convert the primary key tuples to a "raw"
+	// split point.
+	if n.raw {
+		rowKey = []byte(*row[0].(*tree.DBytes))
+	} else {
+		rowKey, err = getRowKey(n.tableDesc, n.index, row)
+		if err != nil {
+			return false, err
+		}
 	}
 
 	if err := params.extendedEvalCtx.ExecCfg.DB.AdminUnsplit(params.ctx, rowKey); err != nil {


### PR DESCRIPTION
This PR adds `ALTER TABLE .. UNSPLIT ALL` which can be used for unsplitting all ranges in DROP, TRUNCATE, and IMPORT.

Just wanted to get some feedback on this current approach. It is a bit hacky so please let me know if there are better approaches. cc @jordanlewis 