### PR TITLE
sql: publish FK reference and backreference in same txn

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -241,52 +241,90 @@ func (sc *SchemaChanger) runBackfill(
 func (sc *SchemaChanger) AddConstraints(
 	ctx context.Context, constraints []sqlbase.ConstraintToUpdate,
 ) error {
-	_, err := sc.leaseMgr.Publish(ctx, sc.tableID,
-		func(desc *sqlbase.MutableTableDescriptor) error {
-			for i, added := range constraints {
-				switch added.ConstraintType {
-				case sqlbase.ConstraintToUpdate_CHECK:
-					found := false
-					for _, c := range desc.Checks {
-						if c.Name == added.Name {
-							log.VEventf(
-								ctx, 2,
-								"backfiller tried to add constraint %+v but found existing constraint %+v, presumably due to a retry",
-								added, c,
-							)
-							found = true
-							break
+	fksByBackrefTable := make(map[sqlbase.ID][]*sqlbase.ConstraintToUpdate)
+	for i := range constraints {
+		c := &constraints[i]
+		if c.ConstraintType == sqlbase.ConstraintToUpdate_FOREIGN_KEY && c.ForeignKey.Table != sc.tableID {
+			fksByBackrefTable[c.ForeignKey.Table] = append(fksByBackrefTable[c.ForeignKey.Table], c)
+		}
+	}
+
+	// Create map of update closures for the table and all other tables with backreferences
+	updates := make(map[sqlbase.ID]func(descriptor *sqlbase.MutableTableDescriptor) error)
+	updates[sc.tableID] = func(desc *sqlbase.MutableTableDescriptor) error {
+		for i := range constraints {
+			added := &constraints[i]
+			switch added.ConstraintType {
+			case sqlbase.ConstraintToUpdate_CHECK:
+				found := false
+				for _, c := range desc.Checks {
+					if c.Name == added.Name {
+						log.VEventf(
+							ctx, 2,
+							"backfiller tried to add constraint %+v but found existing constraint %+v, presumably due to a retry",
+							added, c,
+						)
+						found = true
+						break
+					}
+				}
+				if !found {
+					desc.Checks = append(desc.Checks, &constraints[i].Check)
+				}
+			case sqlbase.ConstraintToUpdate_FOREIGN_KEY:
+				idx, err := desc.FindIndexByID(added.ForeignKeyIndex)
+				if err != nil {
+					return err
+				}
+				if idx.ForeignKey.IsSet() {
+					if log.V(2) {
+						log.VEventf(
+							ctx, 2,
+							"backfiller tried to add constraint %+v but found existing constraint %+v, presumably due to a retry",
+							added, idx.ForeignKey,
+						)
+					}
+				} else {
+					idx.ForeignKey = added.ForeignKey
+					// If there are any backreferences to be added to the same table, add them here
+					if added.ForeignKey.Table == sc.tableID {
+						backref := sqlbase.ForeignKeyReference{Table: sc.tableID, Index: added.ForeignKeyIndex}
+						idx, err := desc.FindIndexByID(added.ForeignKey.Index)
+						if err != nil {
+							return err
 						}
-					}
-					if !found {
-						desc.Checks = append(desc.Checks, &constraints[i].Check)
-					}
-				case sqlbase.ConstraintToUpdate_FOREIGN_KEY:
-					idx, err := desc.FindIndexByID(added.ForeignKeyIndex)
-					if err != nil {
-						return err
-					}
-					if idx.ForeignKey.IsSet() {
-						if log.V(2) {
-							log.VEventf(
-								ctx, 2,
-								"backfiller tried to add constraint %+v but found existing constraint %+v, presumably due to a retry",
-								added, idx.ForeignKey,
-							)
-						}
-					} else {
-						idx.ForeignKey = added.ForeignKey
+						idx.ReferencedBy = append(idx.ReferencedBy, backref)
 					}
 				}
 			}
+		}
+		return nil
+	}
+	for id := range fksByBackrefTable {
+		updates[id] = func(desc *sqlbase.MutableTableDescriptor) error {
+			for _, c := range fksByBackrefTable[id] {
+				backref := sqlbase.ForeignKeyReference{Table: sc.tableID, Index: c.ForeignKeyIndex}
+				idx, err := desc.FindIndexByID(c.ForeignKey.Index)
+				if err != nil {
+					return err
+				}
+				idx.ReferencedBy = append(idx.ReferencedBy, backref)
+			}
 			return nil
-		},
-		nil,
-	)
-	if err != nil {
+		}
+	}
+	if _, err := sc.leaseMgr.PublishMultiple(ctx, updates, nil); err != nil {
 		return err
 	}
-	return sc.waitToUpdateLeases(ctx, sc.tableID)
+	if err := sc.waitToUpdateLeases(ctx, sc.tableID); err != nil {
+		return err
+	}
+	for id := range fksByBackrefTable {
+		if err := sc.waitToUpdateLeases(ctx, id); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (sc *SchemaChanger) validateConstraints(

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -618,10 +618,13 @@ func ResolveFK(
 		backref.Index = added
 	}
 
-	if targetIdxIndex > -1 {
-		target.Indexes[targetIdxIndex].ReferencedBy = append(target.Indexes[targetIdxIndex].ReferencedBy, backref)
-	} else {
-		target.PrimaryIndex.ReferencedBy = append(target.PrimaryIndex.ReferencedBy, backref)
+	// TODO (lucy): Should the IsNewTable() case be handled in runSchemaChangesInTxn instead?
+	if ts == NewTable || tbl.IsNewTable() {
+		if targetIdxIndex > -1 {
+			target.Indexes[targetIdxIndex].ReferencedBy = append(target.Indexes[targetIdxIndex].ReferencedBy, backref)
+		} else {
+			target.PrimaryIndex.ReferencedBy = append(target.PrimaryIndex.ReferencedBy, backref)
+		}
 	}
 
 	// Multiple FKs from the same column would potentially result in ambiguous or

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -337,68 +337,77 @@ func (s LeaseStore) WaitForOneVersion(
 
 var errDidntUpdateDescriptor = errors.New("didn't update the table descriptor")
 
-// Publish updates a table descriptor. It also maintains the invariant that
-// there are at most two versions of the descriptor out in the wild at any time
-// by first waiting for all nodes to be on the current (pre-update) version of
-// the table desc.
-// The update closure is called after the wait, and it provides the new version
-// of the descriptor to be written. In a multi-step schema operation, this
-// update should perform a single step.
-// The closure may be called multiple times if retries occur; make sure it does
+// PublishMultiple updates multiple table descriptors, maintaining the invariant
+// that there are at most two versions of each descriptor out in the wild at any
+// time by first waiting for all nodes to be on the current (pre-update) version
+// of the table desc.
+//
+// The update closure for each table ID is called after the wait, and it
+// provides the new version of the descriptor to be written.
+//
+// The closures may be called multiple times if retries occur; make sure they do
 // not have side effects.
-// Returns the updated version of the descriptor.
-func (s LeaseStore) Publish(
+//
+// Returns the updated versions of the descriptors.
+func (s LeaseStore) PublishMultiple(
 	ctx context.Context,
-	tableID sqlbase.ID,
-	update func(*sqlbase.MutableTableDescriptor) error,
+	updates map[sqlbase.ID]func(descriptor *sqlbase.MutableTableDescriptor) error,
 	logEvent func(*client.Txn) error,
-) (*sqlbase.ImmutableTableDescriptor, error) {
+) (map[sqlbase.ID]*sqlbase.ImmutableTableDescriptor, error) {
 	errLeaseVersionChanged := errors.New("lease version changed")
 	// Retry while getting errLeaseVersionChanged.
 	for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
-		// Wait until there are no unexpired leases on the previous version
-		// of the table.
-		expectedVersion, err := s.WaitForOneVersion(ctx, tableID, base.DefaultRetryOptions())
-		if err != nil {
-			return nil, err
+		// Wait until there are no unexpired leases on the previous versions
+		// of the tables.
+		expectedVersions := make(map[sqlbase.ID]sqlbase.DescriptorVersion)
+		for id := range updates {
+			expected, err := s.WaitForOneVersion(ctx, id, base.DefaultRetryOptions())
+			if err != nil {
+				return nil, err
+			}
+			expectedVersions[id] = expected
 		}
 
-		var tableDesc *sqlbase.MutableTableDescriptor
+		tableDescs := make(map[sqlbase.ID]*sqlbase.MutableTableDescriptor)
 		// There should be only one version of the descriptor, but it's
 		// a race now to update to the next version.
-		err = s.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-			// Re-read the current version of the table descriptor, this time
-			// transactionally.
-			var err error
-			tableDesc, err = sqlbase.GetMutableTableDescFromID(ctx, txn, tableID)
-			if err != nil {
-				return err
-			}
-
-			if expectedVersion != tableDesc.Version {
-				// The version changed out from under us. Someone else must be
-				// performing a schema change operation.
-				if log.V(3) {
-					log.Infof(ctx, "publish (version changed): %d != %d", expectedVersion, tableDesc.Version)
+		err := s.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+			for id, update := range updates {
+				// Re-read the current versions of the table descriptor, this time
+				// transactionally.
+				var err error
+				tableDesc, err := sqlbase.GetMutableTableDescFromID(ctx, txn, id)
+				if err != nil {
+					return err
 				}
-				return errLeaseVersionChanged
-			}
 
-			// Run the update closure.
-			version := tableDesc.Version
-			if err := update(tableDesc); err != nil {
-				return err
-			}
-			if version != tableDesc.Version {
-				return errors.Errorf("updated version to: %d, expected: %d",
-					tableDesc.Version, version)
-			}
+				if expectedVersions[id] != tableDesc.Version {
+					// The version changed out from under us. Someone else must be
+					// performing a schema change operation.
+					if log.V(3) {
+						log.Infof(ctx, "publish (version changed): %d != %d", expectedVersions[id], tableDesc.Version)
+					}
+					return errLeaseVersionChanged
+				}
 
-			if err := tableDesc.MaybeIncrementVersion(ctx, txn); err != nil {
-				return err
-			}
-			if err := tableDesc.ValidateTable(s.settings); err != nil {
-				return err
+				// Run the update closure.
+				version := tableDesc.Version
+				if err := update(tableDesc); err != nil {
+					return err
+				}
+				if version != tableDesc.Version {
+					return errors.Errorf("updated version to: %d, expected: %d",
+						tableDesc.Version, version)
+				}
+
+				if err := tableDesc.MaybeIncrementVersion(ctx, txn); err != nil {
+					return err
+				}
+				if err := tableDesc.ValidateTable(s.settings); err != nil {
+					return err
+				}
+
+				tableDescs[id] = tableDesc
 			}
 
 			// Write the updated descriptor.
@@ -406,7 +415,9 @@ func (s LeaseStore) Publish(
 				return err
 			}
 			b := txn.NewBatch()
-			b.Put(sqlbase.MakeDescMetadataKey(tableID), sqlbase.WrapDescriptor(tableDesc))
+			for tableID, tableDesc := range tableDescs {
+				b.Put(sqlbase.MakeDescMetadataKey(tableID), sqlbase.WrapDescriptor(tableDesc))
+			}
 			if logEvent != nil {
 				// If an event log is required for this update, ensure that the
 				// descriptor change occurs first in the transaction. This is
@@ -428,7 +439,11 @@ func (s LeaseStore) Publish(
 
 		switch err {
 		case nil, errDidntUpdateDescriptor:
-			return sqlbase.NewImmutableTableDescriptor(tableDesc.TableDescriptor), nil
+			immutTableDescs := make(map[sqlbase.ID]*ImmutableTableDescriptor)
+			for id, tableDesc := range tableDescs {
+				immutTableDescs[id] = sqlbase.NewImmutableTableDescriptor(tableDesc.TableDescriptor)
+			}
+			return immutTableDescs, nil
 		case errLeaseVersionChanged:
 			// will loop around to retry
 		default:
@@ -437,6 +452,35 @@ func (s LeaseStore) Publish(
 	}
 
 	panic("not reached")
+}
+
+// Publish updates a table descriptor. It also maintains the invariant that
+// there are at most two versions of the descriptor out in the wild at any time
+// by first waiting for all nodes to be on the current (pre-update) version of
+// the table desc.
+//
+// The update closure is called after the wait, and it provides the new version
+// of the descriptor to be written. In a multi-step schema operation, this
+// update should perform a single step.
+//
+// The closure may be called multiple times if retries occur; make sure it does
+// not have side effects.
+//
+// Returns the updated version of the descriptor.
+func (s LeaseStore) Publish(
+	ctx context.Context,
+	tableID sqlbase.ID,
+	update func(*sqlbase.MutableTableDescriptor) error,
+	logEvent func(*client.Txn) error,
+) (*sqlbase.ImmutableTableDescriptor, error) {
+	updates := make(map[sqlbase.ID]func(descriptor *sqlbase.MutableTableDescriptor) error)
+	updates[tableID] = update
+
+	results, err := s.PublishMultiple(ctx, updates, logEvent)
+	if err != nil {
+		return nil, err
+	}
+	return results[tableID], nil
 }
 
 // IDVersion represents a descriptor ID, version pair that are

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1220,18 +1220,47 @@ func (sc *SchemaChanger) refreshStats() {
 func (sc *SchemaChanger) reverseMutations(ctx context.Context, causingError error) error {
 	// Reverse the flow of the state machine.
 	var scJob *jobs.Job
+
+	// Get the other tables whose foreign key backreferences need to be removed.
+	var fksByBackrefTable map[sqlbase.ID][]*sqlbase.ConstraintToUpdate
+	err := sc.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+		fksByBackrefTable = make(map[sqlbase.ID][]*sqlbase.ConstraintToUpdate)
+		var err error
+		desc, err := sqlbase.GetTableDescFromID(ctx, txn, sc.tableID)
+		if err != nil {
+			return err
+		}
+		for _, mutation := range desc.Mutations {
+			if mutation.MutationID != sc.mutationID {
+				break
+			}
+			if constraint := mutation.GetConstraint(); constraint != nil &&
+				constraint.ConstraintType == sqlbase.ConstraintToUpdate_FOREIGN_KEY &&
+				mutation.Direction == sqlbase.DescriptorMutation_ADD {
+				fk := &constraint.ForeignKey
+				if fk.Table != desc.ID {
+					fksByBackrefTable[constraint.ForeignKey.Table] = append(fksByBackrefTable[constraint.ForeignKey.Table], constraint)
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Create map of update closures for the table and all other tables with backreferences
+	updates := make(map[sqlbase.ID]func(descriptor *sqlbase.MutableTableDescriptor) error)
 	// All the mutations dropped by the reversal of the schema change.
 	// This is created by traversing the mutations list like a graph
 	// where the indexes refer columns. Whenever a column schema change
 	// is reversed, any index mutation referencing it is also reversed.
 	var droppedMutations map[sqlbase.MutationID]struct{}
-	var backrefs map[sqlbase.ID][]*sqlbase.ConstraintToUpdate
-	_, err := sc.leaseMgr.Publish(ctx, sc.tableID, func(desc *sqlbase.MutableTableDescriptor) error {
+	updates[sc.tableID] = func(desc *sqlbase.MutableTableDescriptor) error {
 		// Keep track of the column mutations being reversed so that indexes
 		// referencing them can be dropped.
 		columns := make(map[string]struct{})
 		droppedMutations = nil
-		backrefs = make(map[sqlbase.ID][]*sqlbase.ConstraintToUpdate)
 
 		for i, mutation := range desc.Mutations {
 			if mutation.MutationID != sc.mutationID {
@@ -1267,8 +1296,6 @@ func (sc *SchemaChanger) reverseMutations(ctx context.Context, causingError erro
 						if err := removeFKBackReferenceFromTable(desc, fk.Index, desc.ID, constraint.ForeignKeyIndex); err != nil {
 							return err
 						}
-					} else {
-						backrefs[constraint.ForeignKey.Table] = append(backrefs[constraint.ForeignKey.Table], constraint)
 					}
 				}
 			}
@@ -1286,9 +1313,21 @@ func (sc *SchemaChanger) reverseMutations(ctx context.Context, causingError erro
 			}
 		}
 
-		// Publish() will increment the version.
+		// PublishMultiple() will increment the version.
 		return nil
-	}, func(txn *client.Txn) error {
+	}
+	for id := range fksByBackrefTable {
+		updates[id] = func(desc *sqlbase.MutableTableDescriptor) error {
+			for _, c := range fksByBackrefTable[id] {
+				if err := removeFKBackReferenceFromTable(desc, c.ForeignKey.Index, sc.tableID, c.ForeignKeyIndex); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+	}
+
+	_, err = sc.leaseMgr.PublishMultiple(ctx, updates, func(txn *client.Txn) error {
 		// Read the table descriptor from the store. The Version of the
 		// descriptor has already been incremented in the transaction and
 		// this descriptor can be modified without incrementing the version.
@@ -1330,18 +1369,11 @@ func (sc *SchemaChanger) reverseMutations(ctx context.Context, causingError erro
 		return err
 	}
 
-	// Drop foreign key backreferences on other tables
-	for tbl, refs := range backrefs {
-		_, err = sc.leaseMgr.Publish(ctx, tbl, func(desc *sqlbase.MutableTableDescriptor) error {
-			for _, ref := range refs {
-				if err := removeFKBackReferenceFromTable(desc, ref.ForeignKey.Index, sc.tableID, ref.ForeignKeyIndex); err != nil {
-					return err
-				}
-			}
-			return nil
-		}, nil,
-		)
-		if err != nil {
+	if err := sc.waitToUpdateLeases(ctx, sc.tableID); err != nil {
+		return err
+	}
+	for id := range fksByBackrefTable {
+		if err := sc.waitToUpdateLeases(ctx, id); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -4286,6 +4286,92 @@ func TestCreateStatsAfterSchemaChange(t *testing.T) {
 		})
 }
 
+func TestTableValidityWhileAddingFK(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	params, _ := tests.CreateTestServerParams()
+
+	publishWriteNotification := make(chan struct{})
+	continuePublishWriteNotification := make(chan struct{})
+
+	backfillNotification := make(chan struct{})
+	continueBackfillNotification := make(chan struct{})
+
+	params.Knobs = base.TestingKnobs{
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+			RunBeforePublishWriteAndDelete: func() {
+				if publishWriteNotification != nil {
+					// Notify before the delete and write only state is published.
+					close(publishWriteNotification)
+					publishWriteNotification = nil
+					<-continuePublishWriteNotification
+				}
+			},
+			RunBeforeBackfill: func() error {
+				if backfillNotification != nil {
+					// Notify before the backfill begins.
+					close(backfillNotification)
+					backfillNotification = nil
+					<-continueBackfillNotification
+				}
+				return nil
+			},
+		},
+		// Disable backfill migrations, we still need the jobs table migration.
+		SQLMigrationManager: &sqlmigrations.MigrationManagerTestingKnobs{
+			DisableBackfillMigrations: true,
+		},
+	}
+
+	server, sqlDB, _ := serverutils.StartServer(t, params)
+	defer server.Stopper().Stop(context.TODO())
+
+	if _, err := sqlDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.child (a INT PRIMARY KEY, b INT, INDEX (b));
+CREATE TABLE t.parent (a INT PRIMARY KEY);
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	n1 := publishWriteNotification
+	n2 := backfillNotification
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		if _, err := sqlDB.Exec(`ALTER TABLE t.child ADD FOREIGN KEY (b) REFERENCES t.child (a), ADD FOREIGN KEY (a) REFERENCES t.parent (a)`); err != nil {
+			t.Error(err)
+		}
+		wg.Done()
+	}()
+
+	<-n1
+	if _, err := sqlDB.Query(`SHOW CONSTRAINTS FROM t.child`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Query(`SHOW CONSTRAINTS FROM t.parent`); err != nil {
+		t.Fatal(err)
+	}
+	close(continuePublishWriteNotification)
+
+	<-n2
+	if _, err := sqlDB.Query(`SHOW CONSTRAINTS FROM t.child`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Query(`SHOW CONSTRAINTS FROM t.parent`); err != nil {
+		t.Fatal(err)
+	}
+	close(continueBackfillNotification)
+
+	wg.Wait()
+
+	if err := sqlutils.RunScrub(sqlDB, "t", "child"); err != nil {
+		t.Fatal(err)
+	}
+	if err := sqlutils.RunScrub(sqlDB, "t", "parent"); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // TestWritesWithChecksBeforeDefaultColumnBackfill tests that when a check on a
 // column being added references a different public column, writes to the public
 // column ignore the constraint before the backfill for the non-public column


### PR DESCRIPTION
This PR adds a function `PublishMultiple` to the lease manager, which publishes
multiple table descriptor updates in a single transaction, and uses it to fix
some problems with adding foreign key constraints:

* When adding a FK, the backreference would be added in the user transaction,
  but the reference itself would be added in a later transaction in the final
  step in the schema changer, so there was a period of time during which the
  backreference would have no corresponding forward reference. As of this PR,
  they're added in the same transaction in the schema changer. This also has
  the benefit of ensuring that FK enforcement only begins after any new indexes
  (for now, only in the case when a new index is auto-added for an empty table)
  have been backfilled.
* Likewise, FK references and backreferences are now removed in the same
  transaction during rollback.
* We now wait for every node to have the latest version of the table
  descriptors with newly added backreferences before starting the validation
  step.

Release note: None