### PR TITLE
sqlsmith: improve desired type generation

### DIFF
--- a/pkg/internal/sqlsmith/random.go
+++ b/pkg/internal/sqlsmith/random.go
@@ -43,3 +43,39 @@ func (s *scope) d9() int {
 func (s *scope) d100() int {
 	return s.schema.d100()
 }
+
+// geom returns a sample from a geometric distribution whose mean is 1 / (1 -
+// p). Its return value is >= 1. p must satisfy 0 < p < 1. For example, pass
+// .5 to this function (whose mean would thus be 2), and 50% of the time this
+// function will return 1, 25% will return 2, 12.5% return 3, 6.25% will return
+// 4, etc. See: https://en.wikipedia.org/wiki/Geometric_distribution.
+func (s *Smither) geom(p float64) int {
+	if p <= 0 || p >= 1 {
+		panic("bad p")
+	}
+	count := 1
+	for s.rnd.Float64() < p {
+		count++
+	}
+	return count
+}
+
+// sample invokes fn mean number of times (but at most n times) with a
+// geometric distribution. The i argument to fn will be unique each time and
+// randomly chosen to be between 0 and n-1, inclusive. This can be used to pick
+// on average mean samples from a list. If n is <= 0, fn is never invoked.
+func (s *Smither) sample(n, mean int, fn func(i int)) {
+	if n <= 0 {
+		return
+	}
+	perms := s.rnd.Perm(n)
+	m := float64(mean)
+	p := (m - 1) / m
+	k := s.geom(p)
+	if k > n {
+		k = n
+	}
+	for ki := 0; ki < k; ki++ {
+		fn(perms[ki])
+	}
+}

--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -332,19 +332,18 @@ func (s *Smither) randStringComparison() tree.ComparisonOperator {
 // makeSelectTable returns a TableExpr of the form `(SELECT ...)`, which
 // would end up looking like `SELECT ... FROM (SELECT ...)`.
 func makeSelectTable(s *scope, refs colRefs, forJoin bool) (tree.TableExpr, colRefs, bool) {
-	desiredTypes := makeDesiredTypes(s)
-	stmt, _, ok := s.makeSelect(desiredTypes, refs)
+	stmt, stmtRefs, ok := s.makeSelect(nil /* desiredTypes */, refs)
 	if !ok {
 		return nil, nil, false
 	}
 
 	table := s.schema.name("tab")
-	names := make(tree.NameList, len(desiredTypes))
-	clauseRefs := make(colRefs, len(desiredTypes))
-	for i, typ := range desiredTypes {
+	names := make(tree.NameList, len(stmtRefs))
+	clauseRefs := make(colRefs, len(stmtRefs))
+	for i, ref := range stmtRefs {
 		names[i] = s.schema.name("col")
 		clauseRefs[i] = &colRef{
-			typ: typ,
+			typ: ref.typ,
 			item: tree.NewColumnItem(
 				tree.NewUnqualifiedTableName(table),
 				names[i],
@@ -487,11 +486,22 @@ func (s *scope) makeSelect(desiredTypes []*types.T, refs colRefs) (*tree.Select,
 	return &stmt, selectRefs, true
 }
 
+// makeSelectList generates SelectExprs corresponding to
+// desiredTypes. desiredTypes can be nil which causes types to be randomly
+// selected from refs, improving the chance they are chosen during
+// makeScalar. Especially useful with the AvoidConsts option.
 func (s *scope) makeSelectList(
 	ctx Context, desiredTypes []*types.T, refs colRefs,
 ) (tree.SelectExprs, colRefs, bool) {
+	// If we don't have any desired types, generate some from the given refs.
 	if len(desiredTypes) == 0 {
-		panic("expected desiredTypes")
+		s.schema.sample(len(refs), 6, func(i int) {
+			desiredTypes = append(desiredTypes, refs[i].typ)
+		})
+	}
+	// If we still don't have any then there weren't any refs.
+	if len(desiredTypes) == 0 {
+		desiredTypes = makeDesiredTypes(s)
 	}
 	result := make(tree.SelectExprs, len(desiredTypes))
 	selectRefs := make(colRefs, len(desiredTypes))


### PR DESCRIPTION
Teach SELECT to generate desired types from tables in the FROM clause
to increase the chance that the SELECT expressions are chosen from among
those columns. This prevents the super common problem of `SELECT [buncha
consts] FROM table1, table2` where none of the columns from table1 or
table2 are selected.

Consts are still generated with some frequency and so will still appear
at times.

In order for functions and binary operators where the inputs types aren't
the output type (which could cause certain binary ops or functions to
never be chosen), tables should contain all types (as our manual tests
do) or eventually generate all types (as the random table creator does).

Release note: None