### PR TITLE
opt,distsqlrun: include null values in distinct count estimate

### DIFF
--- a/pkg/sql/distsqlrun/sample_aggregator_test.go
+++ b/pkg/sql/distsqlrun/sample_aggregator_test.go
@@ -178,7 +178,7 @@ func TestSampleAggregator(t *testing.T) {
 			name:          "a",
 			colIDs:        "{100}",
 			rowCount:      11,
-			distinctCount: 2,
+			distinctCount: 3,
 			nullCount:     2,
 		},
 		{
@@ -186,7 +186,7 @@ func TestSampleAggregator(t *testing.T) {
 			name:          "<NULL>",
 			colIDs:        "{101}",
 			rowCount:      11,
-			distinctCount: 8,
+			distinctCount: 9,
 			nullCount:     1,
 			buckets: []resultBucket{
 				{numEq: 2, numRange: 0, upper: 1},

--- a/pkg/sql/distsqlrun/sampler.go
+++ b/pkg/sql/distsqlrun/sampler.go
@@ -264,11 +264,11 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 			// columns.
 			col := s.sketches[i].spec.Columns[0]
 			s.sketches[i].numRows++
-			if row[col].IsNull() {
+			isNull := row[col].IsNull()
+			if isNull {
 				s.sketches[i].numNulls++
-				continue
 			}
-			if s.outTypes[col].Family() == types.IntFamily {
+			if s.outTypes[col].Family() == types.IntFamily && !isNull {
 				// Fast path for integers.
 				// TODO(radu): make this more general.
 				val, err := row[col].GetInt()

--- a/pkg/sql/distsqlrun/sampler_test.go
+++ b/pkg/sql/distsqlrun/sampler_test.go
@@ -151,7 +151,7 @@ func TestSamplerSketch(t *testing.T) {
 		{-1, 3},
 		{1, -1},
 	}
-	cardinalities := []int{2, 8}
+	cardinalities := []int{3, 9}
 	numNulls := []int{2, 1}
 
 	rows := sqlbase.GenEncDatumRowsInt(inputRows)

--- a/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
@@ -26,7 +26,7 @@ statistics_name  column_names  row_count  distinct_count  null_count
 __auto__         {a}           1000       10              0
 __auto__         {b}           1000       10              0
 __auto__         {c}           1000       10              0
-__auto__         {d}           1000       0               1000
+__auto__         {d}           1000       1               1000
 
 # Disable automatic stats
 statement ok
@@ -45,7 +45,7 @@ statistics_name  column_names  row_count  distinct_count  null_count
 __auto__         {a}           1000       10              0
 __auto__         {b}           1000       10              0
 __auto__         {c}           1000       10              0
-__auto__         {d}           1000       0               1000
+__auto__         {d}           1000       1               1000
 
 # Enable automatic stats
 statement ok
@@ -66,8 +66,8 @@ __auto__         {b}           1000       10              0
 __auto__         {b}           1000       10              0
 __auto__         {c}           1000       10              0
 __auto__         {c}           1000       10              0
-__auto__         {d}           1000       0               1000
-__auto__         {d}           1000       1               730
+__auto__         {d}           1000       1               1000
+__auto__         {d}           1000       2               730
 
 # Upsert more than 20% of the table.
 statement ok
@@ -90,9 +90,9 @@ __auto__         {b}           1050       10              0
 __auto__         {c}           1000       10              0
 __auto__         {c}           1000       10              0
 __auto__         {c}           1050       10              0
-__auto__         {d}           1000       0               1000
-__auto__         {d}           1000       1               730
-__auto__         {d}           1050       2               365
+__auto__         {d}           1000       1               1000
+__auto__         {d}           1000       2               730
+__auto__         {d}           1050       3               365
 
 # Delete more than 20% of the table.
 statement ok
@@ -115,9 +115,9 @@ __auto__         {c}           1000       10              0
 __auto__         {c}           1000       10              0
 __auto__         {c}           1050       10              0
 __auto__         {c}           550        5               0
-__auto__         {d}           1000       0               1000
-__auto__         {d}           1000       1               730
-__auto__         {d}           1050       2               365
+__auto__         {d}           1000       1               1000
+__auto__         {d}           1000       2               730
+__auto__         {d}           1050       3               365
 __auto__         {d}           550        1               0
 
 # Test CREATE TABLE ... AS

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -223,8 +223,8 @@ FROM [SHOW STATISTICS FOR TABLE simple]
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
 default_stat2    {rowid}       1          1               0
-default_stat2    {y}           1          0               1
-default_stat2    {x}           1          0               1
+default_stat2    {y}           1          1               1
+default_stat2    {x}           1          1               1
 
 #
 # Test numeric references
@@ -431,4 +431,4 @@ FROM [SHOW STATISTICS FOR TABLE arr] ORDER BY statistics_name, column_names::STR
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
 arr_stats        {rowid}       4          4               0
-arr_stats        {x}           4          2               1
+arr_stats        {x}           4          3               1

--- a/pkg/sql/opt/memo/testdata/format
+++ b/pkg/sql/opt/memo/testdata/format
@@ -13,24 +13,24 @@ SELECT a + 1, min(b) FROM t WHERE k + a > b GROUP BY a ORDER BY a
 ----
 sort
  ├── columns: "?column?":5(int) min:4(int)  [hidden: t.public.t.a:1(int)]
- ├── stats: [rows=99.1771622]
- ├── cost: 1098.07359
+ ├── stats: [rows=98.1771622]
+ ├── cost: 1097.86224
  ├── key: (1)
  ├── fd: (1)-->(4,5)
  ├── ordering: +1
  ├── prune: (1,4,5)
  └── project
       ├── columns: "?column?":5(int) t.public.t.a:1(int) min:4(int)
-      ├── stats: [rows=99.1771622]
-      ├── cost: 1082.92531
+      ├── stats: [rows=98.1771622]
+      ├── cost: 1082.89531
       ├── key: (1)
       ├── fd: (1)-->(4,5)
       ├── prune: (1,4,5)
       ├── group-by
       │    ├── columns: t.public.t.a:1(int) min:4(int)
       │    ├── grouping columns: t.public.t.a:1(int)
-      │    ├── stats: [rows=99.1771622, distinct(1)=98.1771622, null(1)=3.3]
-      │    ├── cost: 1080.93177
+      │    ├── stats: [rows=98.1771622, distinct(1)=98.1771622, null(1)=3.3]
+      │    ├── cost: 1080.92177
       │    ├── key: (1)
       │    ├── fd: (1)-->(4)
       │    ├── prune: (4)
@@ -68,18 +68,18 @@ SELECT a + 1, min(b) FROM t WHERE k + a > b GROUP BY a ORDER BY a
 ----
 sort
  ├── columns: "?column?":5(int) min:4(int)  [hidden: t.public.t.a:1(int)]
- ├── stats: [rows=99.1771622]
- ├── cost: 1098.07359
+ ├── stats: [rows=98.1771622]
+ ├── cost: 1097.86224
  ├── ordering: +1
  └── project
       ├── columns: "?column?":5(int) t.public.t.a:1(int) min:4(int)
-      ├── stats: [rows=99.1771622]
-      ├── cost: 1082.92531
+      ├── stats: [rows=98.1771622]
+      ├── cost: 1082.89531
       ├── group-by
       │    ├── columns: t.public.t.a:1(int) min:4(int)
       │    ├── grouping columns: t.public.t.a:1(int)
-      │    ├── stats: [rows=99.1771622, distinct(1)=98.1771622, null(1)=3.3]
-      │    ├── cost: 1080.93177
+      │    ├── stats: [rows=98.1771622, distinct(1)=98.1771622, null(1)=3.3]
+      │    ├── cost: 1080.92177
       │    ├── select
       │    │    ├── columns: t.public.t.a:1(int) t.public.t.b:2(int!null) t.public.t.k:3(int!null)
       │    │    ├── stats: [rows=330, distinct(1)=98.1771622, null(1)=3.3, distinct(2)=98.265847, null(2)=0, distinct(3)=330, null(3)=0]
@@ -184,20 +184,20 @@ opt format=(hide-miscprops,hide-orderings,hide-columns)
 SELECT a + 1, min(b) FROM t WHERE k + a > b GROUP BY a ORDER BY a
 ----
 sort
- ├── stats: [rows=99.1771622]
- ├── cost: 1098.07359
+ ├── stats: [rows=98.1771622]
+ ├── cost: 1097.86224
  ├── key: (1)
  ├── fd: (1)-->(4,5)
  ├── prune: (1,4,5)
  └── project
-      ├── stats: [rows=99.1771622]
-      ├── cost: 1082.92531
+      ├── stats: [rows=98.1771622]
+      ├── cost: 1082.89531
       ├── key: (1)
       ├── fd: (1)-->(4,5)
       ├── prune: (1,4,5)
       ├── group-by
-      │    ├── stats: [rows=99.1771622, distinct(1)=98.1771622, null(1)=3.3]
-      │    ├── cost: 1080.93177
+      │    ├── stats: [rows=98.1771622, distinct(1)=98.1771622, null(1)=3.3]
+      │    ├── cost: 1080.92177
       │    ├── key: (1)
       │    ├── fd: (1)-->(4)
       │    ├── prune: (4)

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -274,7 +274,7 @@ memo (optimized, ~4KB, required=[presentation: x:7,y:8])
  ├── G1: (union G2 G3)
  │    └── [presentation: x:7,y:8]
  │         ├── best: (union G2 G3)
- │         └── cost: 2150.06
+ │         └── cost: 2149.88
  ├── G2: (scan a)
  │    └── []
  │         ├── best: (scan a)
@@ -317,11 +317,11 @@ memo (optimized, ~3KB, required=[presentation: array_agg:3])
  ├── G1: (project G2 G3 array_agg)
  │    └── [presentation: array_agg:3]
  │         ├── best: (project G2 G3 array_agg)
- │         └── cost: 1072.06
+ │         └── cost: 1072.04
  ├── G2: (group-by G4 G5 cols=(2))
  │    └── []
  │         ├── best: (group-by G4 G5 cols=(2))
- │         └── cost: 1071.04
+ │         └── cost: 1071.03
  ├── G3: (projections)
  ├── G4: (scan a)
  │    └── []

--- a/pkg/sql/opt/memo/testdata/stats/groupby
+++ b/pkg/sql/opt/memo/testdata/stats/groupby
@@ -298,17 +298,17 @@ project
  └── group-by
       ├── columns: x:1(int!null) y:2(int)
       ├── grouping columns: x:1(int!null) y:2(int)
-      ├── stats: [rows=1001, distinct(1,2)=1000, null(1,2)=1000]
+      ├── stats: [rows=1001, distinct(1,2)=1001, null(1,2)=1000]
       ├── key: (1)
       ├── fd: (1)-->(2)
       └── project
            ├── columns: x:1(int!null) y:2(int)
-           ├── stats: [rows=2000, distinct(1,2)=1000, null(1,2)=1000]
+           ├── stats: [rows=2000, distinct(1,2)=1001, null(1,2)=1000]
            ├── key: (1)
            ├── fd: (1)-->(2)
            └── scan a
                 ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
-                ├── stats: [rows=2000, distinct(1,2)=1000, null(1,2)=1000]
+                ├── stats: [rows=2000, distinct(1,2)=1001, null(1,2)=1000]
                 ├── key: (1)
                 └── fd: (1)-->(2-4), (3,4)~~>(1,2)
 
@@ -346,7 +346,7 @@ SELECT y, sum(z) FROM a GROUP BY y
 group-by
  ├── columns: y:2(int) sum:5(float)
  ├── grouping columns: y:2(int)
- ├── stats: [rows=401, distinct(2)=400, null(2)=401]
+ ├── stats: [rows=400, distinct(2)=400, null(2)=400]
  ├── key: (2)
  ├── fd: (2)-->(5)
  ├── project
@@ -366,11 +366,11 @@ SELECT max(x) FROM a GROUP BY y, z, s
 ----
 project
  ├── columns: max:5(int)
- ├── stats: [rows=601]
+ ├── stats: [rows=600]
  └── group-by
       ├── columns: y:2(int) z:3(float!null) s:4(string) max:5(int)
       ├── grouping columns: y:2(int) z:3(float!null) s:4(string)
-      ├── stats: [rows=601, distinct(2-4)=600, null(2-4)=601]
+      ├── stats: [rows=600, distinct(2-4)=600, null(2-4)=600]
       ├── key: (2-4)
       ├── fd: (3,4)~~>(2), (2-4)-->(5)
       ├── scan a
@@ -413,16 +413,16 @@ SELECT max(x) FROM a GROUP BY y, z, s HAVING s IN ('a', 'b')
 ----
 project
  ├── columns: max:5(int)
- ├── stats: [rows=119.1]
+ ├── stats: [rows=119]
  └── select
       ├── columns: y:2(int) z:3(float!null) s:4(string!null) max:5(int)
-      ├── stats: [rows=119.1, distinct(3)=97.7141858, null(3)=0, distinct(4)=2, null(4)=0]
+      ├── stats: [rows=119, distinct(3)=97.6, null(3)=0, distinct(4)=2, null(4)=0]
       ├── key: (3,4)
       ├── fd: (3,4)-->(2), (2-4)-->(5)
       ├── group-by
       │    ├── columns: y:2(int) z:3(float!null) s:4(string) max:5(int)
       │    ├── grouping columns: y:2(int) z:3(float!null) s:4(string)
-      │    ├── stats: [rows=601, distinct(3)=200, null(3)=0, distinct(4)=10, null(4)=5.5, distinct(2-4)=600, null(2-4)=601]
+      │    ├── stats: [rows=600, distinct(3)=200, null(3)=0, distinct(4)=10, null(4)=5, distinct(2-4)=600, null(2-4)=600]
       │    ├── key: (2-4)
       │    ├── fd: (3,4)~~>(2), (2-4)-->(5)
       │    ├── scan a
@@ -442,13 +442,13 @@ SELECT sum(x), s FROM a GROUP BY s HAVING sum(x) = 5
 ----
 select
  ├── columns: sum:5(decimal!null) s:4(string)
- ├── stats: [rows=1, distinct(5)=1, null(5)=0]
+ ├── stats: [rows=0.9, distinct(5)=0.9, null(5)=0]
  ├── key: (4)
  ├── fd: ()-->(5)
  ├── group-by
  │    ├── columns: s:4(string) sum:5(decimal)
  │    ├── grouping columns: s:4(string)
- │    ├── stats: [rows=11, distinct(4)=10, null(4)=11, distinct(5)=10, null(5)=1]
+ │    ├── stats: [rows=10, distinct(4)=10, null(4)=10, distinct(5)=10, null(5)=1]
  │    ├── key: (4)
  │    ├── fd: (4)-->(5)
  │    ├── project
@@ -479,30 +479,30 @@ GROUP BY q.b
 project
  ├── columns: "?column?":4(int!null)
  ├── cardinality: [0 - 3]
- ├── stats: [rows=0.5]
+ ├── stats: [rows=0.22654092]
  ├── fd: ()-->(4)
  ├── select
  │    ├── columns: column2:2(int) bool_or:3(bool!null)
  │    ├── cardinality: [0 - 3]
- │    ├── stats: [rows=0.5, distinct(3)=0.5, null(3)=0]
+ │    ├── stats: [rows=0.22654092, distinct(3)=0.22654092, null(3)=0]
  │    ├── key: (2)
  │    ├── fd: ()-->(3)
  │    ├── group-by
  │    │    ├── columns: column2:2(int) bool_or:3(bool)
  │    │    ├── grouping columns: column2:2(int)
  │    │    ├── cardinality: [0 - 3]
- │    │    ├── stats: [rows=1.5, distinct(2)=0.875, null(2)=1, distinct(3)=0.875, null(3)=1]
+ │    │    ├── stats: [rows=1.29289322, distinct(2)=1.29289322, null(2)=1, distinct(3)=1.29289322, null(3)=1]
  │    │    ├── key: (2)
  │    │    ├── fd: (2)-->(3)
  │    │    ├── select
  │    │    │    ├── columns: column1:1(bool!null) column2:2(int)
  │    │    │    ├── cardinality: [0 - 3]
- │    │    │    ├── stats: [rows=1.5, distinct(1)=1, null(1)=0, distinct(2)=0.875, null(2)=1]
+ │    │    │    ├── stats: [rows=1.5, distinct(1)=1, null(1)=0, distinct(2)=1.29289322, null(2)=1]
  │    │    │    ├── fd: ()-->(1)
  │    │    │    ├── values
  │    │    │    │    ├── columns: column1:1(bool) column2:2(int)
  │    │    │    │    ├── cardinality: [3 - 3]
- │    │    │    │    ├── stats: [rows=3, distinct(1)=2, null(1)=0, distinct(2)=1, null(2)=2]
+ │    │    │    │    ├── stats: [rows=3, distinct(1)=2, null(1)=0, distinct(2)=2, null(2)=2]
  │    │    │    │    ├── (true, NULL) [type=tuple{bool, int}]
  │    │    │    │    ├── (false, NULL) [type=tuple{bool, int}]
  │    │    │    │    └── (true, 5) [type=tuple{bool, int}]

--- a/pkg/sql/opt/memo/testdata/stats/index-join
+++ b/pkg/sql/opt/memo/testdata/stats/index-join
@@ -200,7 +200,7 @@ select
  │    └── scan a@secondary
  │         ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
  │         ├── constraint: /-3/4: [/'foo' - /'foo']
- │         ├── stats: [rows=100, distinct(1)=100, null(1)=0, distinct(3)=1, null(3)=0, distinct(4)=100, null(4)=0, distinct(1,3)=97.5, null(1,3)=0]
+ │         ├── stats: [rows=100, distinct(1)=100, null(1)=0, distinct(3)=1, null(3)=0, distinct(4)=100, null(4)=0, distinct(1,3)=97.5049109, null(1,3)=0]
  │         ├── key: (1)
  │         └── fd: ()-->(3), (1)-->(4), (4)-->(1)
  └── filters
@@ -217,7 +217,7 @@ index-join a
  └── scan a@secondary
       ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
       ├── constraint: /-3/4: [/'foo' - /'foo']
-      ├── stats: [rows=100, distinct(1)=100, null(1)=0, distinct(3)=1, null(3)=0, distinct(4)=100, null(4)=0, distinct(1,3)=97.5, null(1,3)=0]
+      ├── stats: [rows=100, distinct(1)=100, null(1)=0, distinct(3)=1, null(3)=0, distinct(4)=100, null(4)=0, distinct(1,3)=97.5049109, null(1,3)=0]
       ├── key: (1)
       └── fd: ()-->(3), (1)-->(4), (4)-->(1)
 
@@ -240,13 +240,13 @@ index-join a
  ├── fd: (1)-->(2-4), (3,4)-->(1,2)
  └── select
       ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
-      ├── stats: [rows=66.6666667, distinct(1)=66.6666667, null(1)=0, distinct(3)=2, null(3)=0, distinct(4)=65.1739644, null(4)=0, distinct(1,3)=66.0077957, null(1,3)=0]
+      ├── stats: [rows=66.6666667, distinct(1)=66.6666667, null(1)=0, distinct(3)=2, null(3)=0, distinct(4)=65.1739644, null(4)=0, distinct(1,3)=66.0091248, null(1,3)=0]
       ├── key: (1)
       ├── fd: (1)-->(3,4), (3,4)-->(1)
       ├── scan a@secondary
       │    ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
       │    ├── constraint: /-3/4: [/'foo' - /'foo'] [/'bar' - /'bar']
-      │    ├── stats: [rows=200, distinct(1)=200, null(1)=0, distinct(3)=2, null(3)=0, distinct(4)=178.525164, null(4)=0, distinct(1,3)=190, null(1,3)=0]
+      │    ├── stats: [rows=200, distinct(1)=200, null(1)=0, distinct(3)=2, null(3)=0, distinct(4)=178.525164, null(4)=0, distinct(1,3)=190.019298, null(1,3)=0]
       │    ├── key: (1)
       │    └── fd: (1)-->(3,4), (3,4)-->(1)
       └── filters

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -523,11 +523,11 @@ GROUP BY y
 ----
 project
  ├── columns: count:8(int)
- ├── stats: [rows=400.903879]
+ ├── stats: [rows=399.903879]
  └── group-by
       ├── columns: y:2(int) count_rows:8(int)
       ├── grouping columns: y:2(int)
-      ├── stats: [rows=400.903879, distinct(2)=399.903879, null(2)=400.903879]
+      ├── stats: [rows=399.903879, distinct(2)=399.903879, null(2)=399.903879]
       ├── key: (2)
       ├── fd: (2)-->(8)
       ├── right-join
@@ -556,11 +556,11 @@ GROUP BY y
 ----
 project
  ├── columns: count:8(int)
- ├── stats: [rows=401]
+ ├── stats: [rows=400]
  └── group-by
       ├── columns: y:2(int) count_rows:8(int)
       ├── grouping columns: y:2(int)
-      ├── stats: [rows=401, distinct(2)=400, null(2)=401]
+      ├── stats: [rows=400, distinct(2)=400, null(2)=400]
       ├── key: (2)
       ├── fd: (2)-->(8)
       ├── full-join
@@ -712,7 +712,7 @@ inner-join
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6), (1)==(5), (5)==(1)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(4)=500, null(4)=0, distinct(1,2)=2500, null(1,2)=2500, distinct(2,3)=5000, null(2,3)=2525]
+ │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(4)=500, null(4)=0, distinct(1,2)=2501, null(1,2)=2500, distinct(2,3)=5000, null(2,3)=2525]
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── scan uv
@@ -733,7 +733,7 @@ left-join
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(4)=500, null(4)=0, distinct(1,2)=2500, null(1,2)=2500, distinct(2,3)=5000, null(2,3)=2525]
+ │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(4)=500, null(4)=0, distinct(1,2)=2501, null(1,2)=2500, distinct(2,3)=5000, null(2,3)=2525]
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── scan uv
@@ -754,7 +754,7 @@ right-join
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(1,2)=2500, null(1,2)=2500, distinct(2,3)=5000, null(2,3)=2525]
+ │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(1,2)=2501, null(1,2)=2500, distinct(2,3)=5000, null(2,3)=2525]
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── scan uv
@@ -775,7 +775,7 @@ full-join
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(1,2)=2500, null(1,2)=2500, distinct(2,3)=5000, null(2,3)=2525]
+ │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(1,2)=2501, null(1,2)=2500, distinct(2,3)=5000, null(2,3)=2525]
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── scan uv
@@ -802,7 +802,7 @@ select
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)
  │    ├── scan xysd
  │    │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(1,2)=2500, null(1,2)=2500, distinct(2,3)=5000, null(2,3)=2525]
+ │    │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(1,2)=2501, null(1,2)=2500, distinct(2,3)=5000, null(2,3)=2525]
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── scan uv
@@ -822,12 +822,12 @@ SELECT *, rowid FROM xysd FULL JOIN uv ON u > 4 AND u < 2
 ----
 full-join
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) v:6(int) rowid:7(int)
- ├── stats: [rows=50000000, distinct(2)=400, null(2)=25000000, distinct(3)=500, null(3)=500000, distinct(5)=500, null(5)=25000000, distinct(2,3)=5000, null(2,3)=25250000, distinct(3,5)=250000, null(3,5)=25250000, distinct(1,2,7)=25000000, null(1,2,7)=25000000]
+ ├── stats: [rows=50000000, distinct(2)=400, null(2)=25000000, distinct(3)=500, null(3)=500000, distinct(5)=500, null(5)=25000000, distinct(2,3)=5000, null(2,3)=25250000, distinct(3,5)=250000, null(3,5)=25250000, distinct(1,2,7)=25010000, null(1,2,7)=25000000]
  ├── key: (1,7)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=5000, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(1,2)=2500, null(1,2)=2500, distinct(2,3)=5000, null(2,3)=2525]
+ │    ├── stats: [rows=5000, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(1,2)=2501, null(1,2)=2500, distinct(2,3)=5000, null(2,3)=2525]
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── scan uv
@@ -843,16 +843,16 @@ SELECT * FROM xysd, uv
 ----
 project
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int) v:6(int!null)
- ├── stats: [rows=50000000, distinct(2)=400, null(2)=25000000, distinct(1,2,7)=25000000, null(1,2,7)=25000000]
+ ├── stats: [rows=50000000, distinct(2)=400, null(2)=25000000, distinct(1,2,7)=25010000, null(1,2,7)=25000000]
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  └── inner-join
       ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int) v:6(int!null) rowid:7(int!null)
-      ├── stats: [rows=50000000, distinct(2)=400, null(2)=25000000, distinct(1,2,7)=25000000, null(1,2,7)=25000000]
+      ├── stats: [rows=50000000, distinct(2)=400, null(2)=25000000, distinct(1,2,7)=25010000, null(1,2,7)=25000000]
       ├── key: (1,7)
       ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)
       ├── scan xysd
       │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
-      │    ├── stats: [rows=5000, distinct(2)=400, null(2)=2500, distinct(1,2)=2500, null(1,2)=2500]
+      │    ├── stats: [rows=5000, distinct(2)=400, null(2)=2500, distinct(1,2)=2501, null(1,2)=2500]
       │    ├── key: (1)
       │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
       ├── scan uv
@@ -886,7 +886,7 @@ inner-join (merge)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6), (1)==(5), (5)==(1)
  ├── scan t.public.xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(4)=500, null(4)=0, distinct(1,2)=2500, null(1,2)=2500, distinct(2,3)=5000, null(2,3)=2525]
+ │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(4)=500, null(4)=0, distinct(1,2)=2501, null(1,2)=2500, distinct(2,3)=5000, null(2,3)=2525]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    └── ordering: +1
@@ -927,7 +927,7 @@ left-join (merge)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)
  ├── scan t.public.xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(4)=500, null(4)=0, distinct(1,2)=2500, null(1,2)=2500, distinct(2,3)=5000, null(2,3)=2525]
+ │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(4)=500, null(4)=0, distinct(1,2)=2501, null(1,2)=2500, distinct(2,3)=5000, null(2,3)=2525]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    └── ordering: +1

--- a/pkg/sql/opt/memo/testdata/stats/project
+++ b/pkg/sql/opt/memo/testdata/stats/project
@@ -281,11 +281,11 @@ SELECT NULL, NULLIF(x,y) FROM a
 ----
 project
  ├── columns: "?column?":5(unknown) nullif:6(int)
- ├── stats: [rows=2000, distinct(5)=0, null(5)=2000, distinct(6)=1000, null(6)=1000, distinct(5,6)=1000, null(5,6)=2000]
+ ├── stats: [rows=2000, distinct(5)=1, null(5)=2000, distinct(6)=1001, null(6)=1000, distinct(5,6)=1001, null(5,6)=2000]
  ├── fd: ()-->(5)
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=2000, distinct(1,2)=1000, null(1,2)=1000]
+ │    ├── stats: [rows=2000, distinct(1,2)=1001, null(1,2)=1000]
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
  └── projections

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -322,7 +322,7 @@ SELECT x,y,s FROM a
 ----
 scan a
  ├── columns: x:1(int!null) y:2(int) s:3(string)
- ├── stats: [rows=3000, distinct(1)=2000, null(1)=0, distinct(3)=2, null(3)=1000, distinct(5)=2, null(5)=1500, distinct(1,3)=2000, null(1,3)=1000, distinct(3,5)=4, null(3,5)=2000, distinct(1,3,5)=1000, null(1,3,5)=2000]
+ ├── stats: [rows=3000, distinct(1)=2000, null(1)=0, distinct(3)=2, null(3)=1000, distinct(5)=2, null(5)=1500, distinct(1,3)=2001, null(1,3)=1000, distinct(3,5)=4, null(3,5)=2000, distinct(1,3,5)=1001, null(1,3,5)=2000]
  ├── key: (1)
  └── fd: (1)-->(2,3)
 
@@ -332,7 +332,7 @@ SELECT y, s FROM a GROUP BY y, s
 distinct-on
  ├── columns: y:2(int) s:3(string)
  ├── grouping columns: y:2(int) s:3(string)
- ├── stats: [rows=1001, distinct(2,3)=1000, null(2,3)=1001]
+ ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=1000]
  ├── key: (2,3)
  └── scan a
       ├── columns: y:2(int) s:3(string)

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -263,11 +263,11 @@ SELECT count(*) FROM (SELECT * FROM tab0 WHERE col3 = 10) GROUP BY col0
 ----
 project
  ├── columns: count:8(int)
- ├── stats: [rows=1.99997344]
+ ├── stats: [rows=0.999973439]
  └── group-by
       ├── columns: col0:2(int) count_rows:8(int)
       ├── grouping columns: col0:2(int)
-      ├── stats: [rows=1.99997344, distinct(2)=0.999973439, null(2)=1.99997344]
+      ├── stats: [rows=0.999973439, distinct(2)=0.999973439, null(2)=0.999973439]
       ├── key: (2)
       ├── fd: (2)-->(8)
       ├── select
@@ -616,12 +616,12 @@ SELECT * FROM c WHERE x >= 0 AND x < 100
 ----
 select
  ├── columns: x:1(int!null) z:2(int!null)
- ├── stats: [rows=100, distinct(1)=100, null(1)=0, distinct(2)=65.5215193, null(2)=0]
+ ├── stats: [rows=99.8990918, distinct(1)=99.8990918, null(1)=0, distinct(2)=65.4824076, null(2)=0]
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── scan c
  │    ├── columns: x:1(int) z:2(int!null)
- │    ├── stats: [rows=1000, distinct(1)=990, null(1)=10, distinct(2)=100, null(2)=0]
+ │    ├── stats: [rows=1000, distinct(1)=991, null(1)=10, distinct(2)=100, null(2)=0]
  │    ├── lax-key: (1,2)
  │    └── fd: (1)~~>(2)
  └── filters
@@ -1382,25 +1382,25 @@ HAVING
 project
  ├── columns: "?column?":5(int!null)
  ├── cardinality: [0 - 2]
- ├── stats: [rows=1]
+ ├── stats: [rows=0.5]
  ├── fd: ()-->(5)
  ├── select
  │    ├── columns: column2:2(string) column3:3(varbit) min:4(bool!null)
  │    ├── cardinality: [0 - 2]
- │    ├── stats: [rows=1, distinct(4)=1, null(4)=0]
+ │    ├── stats: [rows=0.5, distinct(4)=0.5, null(4)=0]
  │    ├── key: (2,3)
  │    ├── fd: ()-->(4)
  │    ├── group-by
  │    │    ├── columns: column2:2(string) column3:3(varbit) min:4(bool)
  │    │    ├── grouping columns: column2:2(string) column3:3(varbit)
  │    │    ├── cardinality: [1 - 2]
- │    │    ├── stats: [rows=1, distinct(4)=0, null(4)=1, distinct(2,3)=0, null(2,3)=1]
+ │    │    ├── stats: [rows=2, distinct(4)=2, null(4)=2, distinct(2,3)=2, null(2,3)=2]
  │    │    ├── key: (2,3)
  │    │    ├── fd: (2,3)-->(4)
  │    │    ├── values
  │    │    │    ├── columns: column1:1(bool) column2:2(string) column3:3(varbit)
  │    │    │    ├── cardinality: [2 - 2]
- │    │    │    ├── stats: [rows=2, distinct(2,3)=0, null(2,3)=2]
+ │    │    │    ├── stats: [rows=2, distinct(2,3)=2, null(2,3)=2]
  │    │    │    ├── (true, NULL, B'001000101101110') [type=tuple{bool, string, varbit}]
  │    │    │    └── (true, e'19\x1e', NULL) [type=tuple{bool, string, varbit}]
  │    │    └── aggregations

--- a/pkg/sql/opt/memo/testdata/stats/set
+++ b/pkg/sql/opt/memo/testdata/stats/set
@@ -712,7 +712,7 @@ union
  ├── columns: x:9(int)
  ├── left columns: b.x:1(int)
  ├── right columns: c.x:5(int)
- ├── stats: [rows=10002, distinct(9)=10000, null(9)=2]
+ ├── stats: [rows=10000, distinct(9)=10000, null(9)=2]
  ├── key: (9)
  ├── project
  │    ├── columns: b.x:1(int)
@@ -738,7 +738,7 @@ intersect
  ├── columns: x:1(int)
  ├── left columns: b.x:1(int)
  ├── right columns: c.x:5(int)
- ├── stats: [rows=5001, distinct(1)=5000, null(1)=1]
+ ├── stats: [rows=5000, distinct(1)=5000, null(1)=1]
  ├── key: (1)
  ├── project
  │    ├── columns: b.x:1(int)
@@ -764,7 +764,7 @@ except
  ├── columns: x:1(int)
  ├── left columns: b.x:1(int)
  ├── right columns: c.x:5(int)
- ├── stats: [rows=5001, distinct(1)=5000, null(1)=1]
+ ├── stats: [rows=5000, distinct(1)=5000, null(1)=1]
  ├── key: (1)
  ├── project
  │    ├── columns: b.x:1(int)
@@ -869,12 +869,12 @@ except
  ├── left columns: column1:5(int) column2:2(bool)
  ├── right columns: column1:3(int) column2:6(bool)
  ├── cardinality: [1 - 1]
- ├── stats: [rows=1, distinct(2,5)=0, null(2,5)=1]
+ ├── stats: [rows=1, distinct(2,5)=1, null(2,5)=1]
  ├── key: (2,5)
  ├── values
  │    ├── columns: column2:2(bool) column1:5(int)
  │    ├── cardinality: [1 - 1]
- │    ├── stats: [rows=1, distinct(2,5)=0, null(2,5)=1]
+ │    ├── stats: [rows=1, distinct(2,5)=1, null(2,5)=1]
  │    ├── key: ()
  │    ├── fd: ()-->(2,5)
  │    └── (true, NULL) [type=tuple{bool, int}]
@@ -896,17 +896,17 @@ except
  ├── left columns: column1:1(int) column2:2(int)
  ├── right columns: column1:3(int) column2:4(int)
  ├── cardinality: [0 - 3]
- ├── stats: [rows=3, distinct(1,2)=0, null(1,2)=3]
+ ├── stats: [rows=1.25, distinct(1,2)=1.25, null(1,2)=1.25]
  ├── key: (1,2)
  ├── select
  │    ├── columns: column1:1(int) column2:2(int)
  │    ├── cardinality: [0 - 3]
- │    ├── stats: [rows=3, distinct(1)=1, null(1)=2, distinct(1,2)=0, null(1,2)=3]
+ │    ├── stats: [rows=1.25, distinct(1)=1, null(1)=1.25, distinct(1,2)=1.25, null(1,2)=1.25]
  │    ├── fd: ()-->(1)
  │    ├── values
  │    │    ├── columns: column1:1(int) column2:2(int)
  │    │    ├── cardinality: [3 - 3]
- │    │    ├── stats: [rows=3, distinct(1)=1, null(1)=2, distinct(1,2)=0, null(1,2)=3]
+ │    │    ├── stats: [rows=3, distinct(1)=2, null(1)=2, distinct(1,2)=3, null(1,2)=3]
  │    │    ├── (NULL, NULL) [type=tuple{int, int}]
  │    │    ├── (NULL, 1) [type=tuple{int, int}]
  │    │    └── (2, NULL) [type=tuple{int, int}]
@@ -954,7 +954,7 @@ sort
       └── values
            ├── columns: column1:3(int)
            ├── cardinality: [1 - 1]
-           ├── stats: [rows=1, distinct(3)=0, null(3)=1]
+           ├── stats: [rows=1, distinct(3)=1, null(3)=1]
            ├── key: ()
            ├── fd: ()-->(3)
            └── (NULL,) [type=tuple{int}]

--- a/pkg/sql/opt/memo/testdata/stats/srfs
+++ b/pkg/sql/opt/memo/testdata/stats/srfs
@@ -68,7 +68,7 @@ distinct-on
  ├── columns: a:1(string) b:2(int)
  ├── grouping columns: upper:1(string) generate_series:2(int)
  ├── side-effects
- ├── stats: [rows=7.1, distinct(1,2)=7, null(1,2)=0.1]
+ ├── stats: [rows=7, distinct(1,2)=7, null(1,2)=0.1]
  ├── key: (1,2)
  └── inner-join
       ├── columns: upper:1(string) generate_series:2(int)
@@ -113,7 +113,7 @@ project
       ├── fd: (1)-->(2)
       ├── scan xy
       │    ├── columns: x:1(int!null) y:2(int)
-      │    ├── stats: [rows=1000, distinct(1,2)=990, null(1,2)=10]
+      │    ├── stats: [rows=1000, distinct(1,2)=991, null(1,2)=10]
       │    ├── key: (1)
       │    └── fd: (1)-->(2)
       └── zip

--- a/pkg/sql/opt/memo/testdata/stats/values
+++ b/pkg/sql/opt/memo/testdata/stats/values
@@ -73,7 +73,7 @@ SELECT * FROM (VALUES (1), (NULL), (NULL), (2))
 values
  ├── columns: column1:1(int)
  ├── cardinality: [4 - 4]
- ├── stats: [rows=4, distinct(1)=2, null(1)=2]
+ ├── stats: [rows=4, distinct(1)=3, null(1)=2]
  ├── (1,) [type=tuple{int}]
  ├── (NULL,) [type=tuple{int}]
  ├── (NULL,) [type=tuple{int}]
@@ -85,7 +85,7 @@ SELECT * FROM (VALUES (NULL), (NULL), (NULL), (NULL))
 values
  ├── columns: column1:1(unknown)
  ├── cardinality: [4 - 4]
- ├── stats: [rows=4, distinct(1)=0, null(1)=4]
+ ├── stats: [rows=4, distinct(1)=1, null(1)=4]
  ├── (NULL,) [type=tuple{unknown}]
  ├── (NULL,) [type=tuple{unknown}]
  ├── (NULL,) [type=tuple{unknown}]
@@ -97,7 +97,7 @@ SELECT * FROM (VALUES (NULL,1), (1,NULL), (NULL,NULL), (1,2))
 values
  ├── columns: column1:1(int) column2:2(int)
  ├── cardinality: [4 - 4]
- ├── stats: [rows=4, distinct(1,2)=1, null(1,2)=3]
+ ├── stats: [rows=4, distinct(1,2)=4, null(1,2)=3]
  ├── (NULL, 1) [type=tuple{int, int}]
  ├── (1, NULL) [type=tuple{int, int}]
  ├── (NULL, NULL) [type=tuple{int, int}]
@@ -110,7 +110,7 @@ SELECT * FROM (VALUES (NULL, 1))
 values
  ├── columns: column1:1(unknown) column2:2(int)
  ├── cardinality: [1 - 1]
- ├── stats: [rows=1, distinct(1)=0, null(1)=1, distinct(2)=1, null(2)=0]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=1, distinct(2)=1, null(2)=0]
  ├── key: ()
  ├── fd: ()-->(1,2)
  └── (NULL, 1) [type=tuple{unknown, int}]
@@ -121,6 +121,6 @@ SELECT * FROM (VALUES (NULL, 2), (2, NULL))
 values
  ├── columns: column1:1(int) column2:2(int)
  ├── cardinality: [2 - 2]
- ├── stats: [rows=2, distinct(1)=1, null(1)=1, distinct(2)=1, null(2)=1, distinct(1,2)=0, null(1,2)=2]
+ ├── stats: [rows=2, distinct(1)=2, null(1)=1, distinct(2)=2, null(2)=1, distinct(1,2)=2, null(1,2)=2]
  ├── (NULL, 2) [type=tuple{int, int}]
  └── (2, NULL) [type=tuple{int, int}]

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -3141,14 +3141,14 @@ firstCol, secondCol, thirdCol;
 group-by
  ├── columns: firstcol:1(int!null) secondcol:2(int) thirdcol:2(int)
  ├── grouping columns: t.public.xyz.x:1(int!null) t.public.xyz.y:2(int)
- ├── stats: [rows=991, distinct(1,2)=990, null(1,2)=10]
+ ├── stats: [rows=991, distinct(1,2)=991, null(1,2)=10]
  ├── cost: 1109.95
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── interesting orderings: (+1,+2)
  └── project
       ├── columns: t.public.xyz.x:1(int!null) t.public.xyz.y:2(int)
-      ├── stats: [rows=1000, distinct(1,2)=990, null(1,2)=10]
+      ├── stats: [rows=1000, distinct(1,2)=991, null(1,2)=10]
       ├── cost: 1070.03
       ├── key: (1)
       ├── fd: (1)-->(2)
@@ -3156,7 +3156,7 @@ group-by
       ├── interesting orderings: (+1,+2)
       └── scan t.public.xyz
            ├── columns: t.public.xyz.x:1(int!null) t.public.xyz.y:2(int) t.public.xyz.z:3(float)
-           ├── stats: [rows=1000, distinct(1,2)=990, null(1,2)=10]
+           ├── stats: [rows=1000, distinct(1,2)=991, null(1,2)=10]
            ├── cost: 1060.02
            ├── key: (1)
            ├── fd: (1)-->(2,3)

--- a/pkg/sql/opt/xform/testdata/coster/set
+++ b/pkg/sql/opt/xform/testdata/coster/set
@@ -26,12 +26,12 @@ union
  ├── columns: k:8(int) i:9(int)
  ├── left columns: a.k:1(int) a.i:2(int)
  ├── right columns: x:5(int) z:6(int)
- ├── stats: [rows=2000, distinct(8,9)=1990, null(8,9)=20]
- ├── cost: 2150.05
+ ├── stats: [rows=1991, distinct(8,9)=1991, null(8,9)=20]
+ ├── cost: 2149.96
  ├── key: (8,9)
  ├── scan a
  │    ├── columns: a.k:1(int!null) a.i:2(int)
- │    ├── stats: [rows=1000, distinct(1,2)=990, null(1,2)=10]
+ │    ├── stats: [rows=1000, distinct(1,2)=991, null(1,2)=10]
  │    ├── cost: 1060.02
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
@@ -67,12 +67,12 @@ intersect
  ├── columns: k:1(int) i:2(int)
  ├── left columns: k:1(int) i:2(int)
  ├── right columns: x:5(int) z:6(int)
- ├── stats: [rows=1000, distinct(1,2)=990, null(1,2)=10]
- ├── cost: 2140.05
+ ├── stats: [rows=991, distinct(1,2)=991, null(1,2)=10]
+ ├── cost: 2139.96
  ├── key: (1,2)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int)
- │    ├── stats: [rows=1000, distinct(1,2)=990, null(1,2)=10]
+ │    ├── stats: [rows=1000, distinct(1,2)=991, null(1,2)=10]
  │    ├── cost: 1060.02
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
@@ -108,12 +108,12 @@ except
  ├── columns: k:1(int) i:2(int)
  ├── left columns: k:1(int) i:2(int)
  ├── right columns: x:5(int) z:6(int)
- ├── stats: [rows=1000, distinct(1,2)=990, null(1,2)=10]
- ├── cost: 2140.05
+ ├── stats: [rows=991, distinct(1,2)=991, null(1,2)=10]
+ ├── cost: 2139.96
  ├── key: (1,2)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int)
- │    ├── stats: [rows=1000, distinct(1,2)=990, null(1,2)=10]
+ │    ├── stats: [rows=1000, distinct(1,2)=991, null(1,2)=10]
  │    ├── cost: 1060.02
  │    ├── key: (1)
  │    └── fd: (1)-->(2)

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -800,11 +800,11 @@ memo (optimized, ~5KB, required=[presentation: sum:5])
  ├── G1: (project G2 G3 sum)
  │    └── [presentation: sum:5]
  │         ├── best: (project G2 G3 sum)
- │         └── cost: 1082.06
+ │         └── cost: 1082.04
  ├── G2: (group-by G4 G5 cols=(3)) (group-by G4 G5 cols=(3),ordering=+3)
  │    └── []
  │         ├── best: (group-by G4="[ordering: +3]" G5 cols=(3),ordering=+3)
- │         └── cost: 1081.04
+ │         └── cost: 1081.03
  ├── G3: (projections)
  ├── G4: (scan kuvw,cols=(3,4)) (scan kuvw@uvw,cols=(3,4)) (scan kuvw@wvu,cols=(3,4)) (scan kuvw@vw,cols=(3,4)) (scan kuvw@w,cols=(3,4))
  │    ├── [ordering: +3]
@@ -825,11 +825,11 @@ memo (optimized, ~5KB, required=[presentation: array_agg:5])
  ├── G1: (project G2 G3 array_agg)
  │    └── [presentation: array_agg:5]
  │         ├── best: (project G2 G3 array_agg)
- │         └── cost: 1102.06
+ │         └── cost: 1102.04
  ├── G2: (group-by G4 G5 cols=(3),ordering=+2,+4 opt(3)) (group-by G4 G5 cols=(3),ordering=+2,+3,+4)
  │    └── []
  │         ├── best: (group-by G4="[ordering: +2,+4 opt(3)]" G5 cols=(3),ordering=+2,+4 opt(3))
- │         └── cost: 1101.04
+ │         └── cost: 1101.03
  ├── G3: (projections)
  ├── G4: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: +2,+3,+4]
@@ -1073,7 +1073,7 @@ memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4])
  ├── G1: (distinct-on G2 G3 cols=(2)) (distinct-on G2 G3 cols=(2),ordering=+2)
  │    └── [presentation: u:2,v:3,w:4]
  │         ├── best: (distinct-on G2="[ordering: +2]" G3 cols=(2),ordering=+2)
- │         └── cost: 1101.04
+ │         └── cost: 1101.03
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: +2]
  │    │    ├── best: (scan kuvw@uvw,cols=(2-4))
@@ -1095,7 +1095,7 @@ memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4])
  ├── G1: (distinct-on G2 G3 cols=(3)) (distinct-on G2 G3 cols=(3),ordering=+3)
  │    └── [presentation: u:2,v:3,w:4]
  │         ├── best: (distinct-on G2="[ordering: +3]" G3 cols=(3),ordering=+3)
- │         └── cost: 1101.04
+ │         └── cost: 1101.03
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: +3]
  │    │    ├── best: (scan kuvw@vw,cols=(2-4))
@@ -1117,7 +1117,7 @@ memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4])
  ├── G1: (distinct-on G2 G3 cols=(4)) (distinct-on G2 G3 cols=(4),ordering=+4)
  │    └── [presentation: u:2,v:3,w:4]
  │         ├── best: (distinct-on G2="[ordering: +4]" G3 cols=(4),ordering=+4)
- │         └── cost: 1101.04
+ │         └── cost: 1101.03
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: +4]
  │    │    ├── best: (scan kuvw@wvu,cols=(2-4))
@@ -1139,10 +1139,10 @@ memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4] [ordering: +2])
  ├── G1: (distinct-on G2 G3 cols=(2),ordering=+4 opt(2)) (distinct-on G2 G3 cols=(2),ordering=+4)
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +2]
  │    │    ├── best: (sort G1)
- │    │    └── cost: 1126.52
+ │    │    └── cost: 1126.33
  │    └── []
  │         ├── best: (distinct-on G2="[ordering: +4 opt(2)]" G3 cols=(2),ordering=+4 opt(2))
- │         └── cost: 1111.04
+ │         └── cost: 1111.03
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: +2,+4]
  │    │    ├── best: (sort G2)
@@ -1170,10 +1170,10 @@ memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4] [ordering: +2])
  ├── G1: (distinct-on G2 G3 cols=(2),ordering=+3,+4 opt(2)) (distinct-on G2 G3 cols=(2),ordering=+2,+3,+4) (distinct-on G2 G3 cols=(2),ordering=+3,+4)
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +2]
  │    │    ├── best: (distinct-on G2="[ordering: +2,+3,+4]" G3 cols=(2),ordering=+3,+4 opt(2))
- │    │    └── cost: 1101.04
+ │    │    └── cost: 1101.03
  │    └── []
  │         ├── best: (distinct-on G2="[ordering: +2,+3,+4]" G3 cols=(2),ordering=+2,+3,+4)
- │         └── cost: 1101.04
+ │         └── cost: 1101.03
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: +2,+3,+4]
  │    │    ├── best: (scan kuvw@uvw,cols=(2-4))
@@ -1226,10 +1226,10 @@ memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
  ├── G1: (distinct-on G2 G3 cols=(4),ordering=-2,+3 opt(4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +4]
  │    │    ├── best: (distinct-on G2="[ordering: +4,-2,+3]" G3 cols=(4),ordering=-2,+3 opt(4))
- │    │    └── cost: 1332.43
+ │    │    └── cost: 1332.42
  │    └── []
  │         ├── best: (distinct-on G2="[ordering: -2,+3 opt(4)]" G3 cols=(4),ordering=-2,+3 opt(4))
- │         └── cost: 1341.33
+ │         └── cost: 1341.32
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: +4,-2,+3]
  │    │    ├── best: (sort G2)
@@ -1253,10 +1253,10 @@ memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: -4])
  ├── G1: (distinct-on G2 G3 cols=(4),ordering=-2,+3 opt(4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: -4]
  │    │    ├── best: (distinct-on G2="[ordering: -4,-2,+3]" G3 cols=(4),ordering=-2,+3 opt(4))
- │    │    └── cost: 1332.43
+ │    │    └── cost: 1332.42
  │    └── []
  │         ├── best: (distinct-on G2="[ordering: -2,+3 opt(4)]" G3 cols=(4),ordering=-2,+3 opt(4))
- │         └── cost: 1341.33
+ │         └── cost: 1341.32
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: -2,+3 opt(4)]
  │    │    ├── best: (sort G2)
@@ -1280,10 +1280,10 @@ memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
  ├── G1: (distinct-on G2 G3 cols=(4),ordering=+2,-3 opt(4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +4]
  │    │    ├── best: (distinct-on G2="[ordering: +4,+2,-3]" G3 cols=(4),ordering=+2,-3 opt(4))
- │    │    └── cost: 1332.43
+ │    │    └── cost: 1332.42
  │    └── []
  │         ├── best: (distinct-on G2="[ordering: +2,-3 opt(4)]" G3 cols=(4),ordering=+2,-3 opt(4))
- │         └── cost: 1341.33
+ │         └── cost: 1341.32
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: +2,-3 opt(4)]
  │    │    ├── best: (sort G2)

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -330,7 +330,7 @@ memo (optimized, ~3KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G1: (select G2 G3) (index-join G4 b,cols=(1-4))
  │    └── [presentation: k:1,u:2,v:3,j:4]
  │         ├── best: (index-join G4 b,cols=(1-4))
- │         └── cost: 51.32
+ │         └── cost: 51.27
  ├── G2: (scan b)
  │    └── []
  │         ├── best: (scan b)
@@ -339,7 +339,7 @@ memo (optimized, ~3KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G4: (scan b@v,cols=(1,3),constrained)
  │    └── []
  │         ├── best: (scan b@v,cols=(1,3),constrained)
- │         └── cost: 10.41
+ │         └── cost: 10.40
  ├── G5: (range G6)
  ├── G6: (and G7 G8)
  ├── G7: (ge G9 G10)
@@ -389,7 +389,7 @@ memo (optimized, ~5KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G1: (select G2 G3) (select G4 G5) (index-join G6 b,cols=(1-4))
  │    └── [presentation: k:1,u:2,v:3,j:4]
  │         ├── best: (index-join G6 b,cols=(1-4))
- │         └── cost: 24.16
+ │         └── cost: 24.14
  ├── G2: (scan b)
  │    └── []
  │         ├── best: (scan b)
@@ -403,13 +403,13 @@ memo (optimized, ~5KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G6: (select G9 G10)
  │    └── []
  │         ├── best: (select G9 G10)
- │         └── cost: 10.52
+ │         └── cost: 10.51
  ├── G7: (range G11)
  ├── G8: (gt G12 G13)
  ├── G9: (scan b@v,cols=(1,3),constrained)
  │    └── []
  │         ├── best: (scan b@v,cols=(1,3),constrained)
- │         └── cost: 10.41
+ │         └── cost: 10.40
  ├── G10: (filters G8)
  ├── G11: (and G14 G15)
  ├── G12: (variable k)
@@ -483,7 +483,7 @@ memo (optimized, ~4KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G1: (select G2 G3) (select G4 G5)
  │    └── [presentation: k:1,u:2,v:3,j:4]
  │         ├── best: (select G4 G5)
- │         └── cost: 51.43
+ │         └── cost: 51.38
  ├── G2: (scan b)
  │    └── []
  │         ├── best: (scan b)
@@ -492,14 +492,14 @@ memo (optimized, ~4KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G4: (index-join G8 b,cols=(1-4))
  │    └── []
  │         ├── best: (index-join G8 b,cols=(1-4))
- │         └── cost: 51.32
+ │         └── cost: 51.27
  ├── G5: (filters G7)
  ├── G6: (range G9)
  ├── G7: (eq G10 G11)
  ├── G8: (scan b@v,cols=(1,3),constrained)
  │    └── []
  │         ├── best: (scan b@v,cols=(1,3),constrained)
- │         └── cost: 10.41
+ │         └── cost: 10.40
  ├── G9: (and G12 G13)
  ├── G10: (plus G14 G15)
  ├── G11: (const 1)
@@ -542,7 +542,7 @@ memo (optimized, ~7KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7)
  │    └── [presentation: k:1,u:2,v:3,j:4]
  │         ├── best: (select G6 G7)
- │         └── cost: 24.21
+ │         └── cost: 24.18
  ├── G2: (scan b)
  │    └── []
  │         ├── best: (scan b)
@@ -556,7 +556,7 @@ memo (optimized, ~7KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G6: (index-join G11 b,cols=(1-4))
  │    └── []
  │         ├── best: (index-join G11 b,cols=(1-4))
- │         └── cost: 24.16
+ │         └── cost: 24.14
  ├── G7: (filters G9)
  ├── G8: (range G12)
  ├── G9: (eq G13 G14)
@@ -564,7 +564,7 @@ memo (optimized, ~7KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G11: (select G17 G18)
  │    └── []
  │         ├── best: (select G17 G18)
- │         └── cost: 10.52
+ │         └── cost: 10.51
  ├── G12: (and G19 G20)
  ├── G13: (plus G15 G21)
  ├── G14: (const 1)
@@ -573,7 +573,7 @@ memo (optimized, ~7KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G17: (scan b@v,cols=(1,3),constrained)
  │    └── []
  │         ├── best: (scan b@v,cols=(1,3),constrained)
- │         └── cost: 10.41
+ │         └── cost: 10.40
  ├── G18: (filters G10)
  ├── G19: (ge G22 G14)
  ├── G20: (le G22 G23)


### PR DESCRIPTION
**distsqlrun: include nulls in distinct count for table statistics**

This commit changes the sampler processor so that null values are
added to the HyperLogLog sketch, and therefore counted as a distinct
value in the calculated table statistics.

**opt: change distinct count estimate to include null values**

This commit updates the logic in statisticsBuilder to include null
values in the distinct count estimate for each relational expression.
This simplifies the statistics logic for some expressions and results
in more accurate stats in general.