### PR TITLE
workload/ycsb: add --insert-start, --insert-count, --record-count options

### DIFF
--- a/pkg/cmd/roachtest/ycsb.go
+++ b/pkg/cmd/roachtest/ycsb.go
@@ -31,7 +31,7 @@ func registerYCSB(r *registry) {
 			ramp := " --ramp=" + ifLocal("0s", "1m")
 			duration := " --duration=" + ifLocal("10s", "10m")
 			cmd := fmt.Sprintf(
-				"./workload run ycsb --init --initial-rows=1000000 --splits=100"+
+				"./workload run ycsb --init --record-count=1000000 --splits=100"+
 					" --workload=%s --concurrency=64 --histograms=logs/stats.json"+
 					ramp+duration+" {pgurl:1-%d}",
 				wl, nodes)


### PR DESCRIPTION
These options allow the YCSB workload to be used in use cases where multiple clients are running workloads in parallel. The initial rows options is subsumed by these options.

I wasn't actually sure what use cases there would be for record count to be not equal to insert start + insert count as reads, scans, and updates might access a key that doesn't exist, but I've added the option to be consistent with the official YCSB implementation.

Example of executing two clients in parallel:

```
$ workload run ycsb --workload e --insert-start 0       --insert-count 500000 --record-count 500000  --max-ops 500000 --pprofport 33333 --drop
$ workload run ycsb --workload d --insert-start 1000000 --insert-count 500000 --record-count 1500000 --max-ops 500000 --pprofport 33334
```

Fixes #36799

cc @robert-s-lee @BramGruneir 

