### PR TITLE
sql: deflake TestLogic//crdb_internal/max_retry_counter

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -421,7 +421,7 @@ statement ok
 SET application_name = 'test_max_retry'
 
 statement OK
-SELECT crdb_internal.force_retry('2ms'::INTERVAL)
+SELECT crdb_internal.force_retry('50ms'::INTERVAL)
 
 statement OK
 RESET application_name
@@ -429,9 +429,11 @@ RESET application_name
 # Note: two rows of output are expected: one for the statement that
 # failed with a retry error, and one for the final retry attempt that
 # succeeded without an error.
-# Wel also expect the RESET statement to not have any retry.
+# We also expect the RESET statement to not have any retry.
+# This tests that the retry counter is properly reset to 0
+# between statements.
 query TBB
-SELECT key, (max_retries > 1), flags LIKE '!%' AS f
+SELECT key, (max_retries > 0), flags LIKE '!%' AS f
   FROM crdb_internal.node_statement_statistics
  WHERE application_name = 'test_max_retry'
 ORDER BY key, f


### PR DESCRIPTION
Fixes #38045.

The retry timeout was too short for `make stress`.
Instead this patch copies the timeout already used in the other
logic test file `txn`. I verified manually that `make stress`
is pleased with the new timeout.

Also fix a typo in the test comment.

Release note: None