### PR TITLE
release-2.1: build: clean old generated files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -694,6 +694,9 @@ PROTOBUF_TARGETS := bin/.go_protobuf_sources bin/.gw_protobuf_sources bin/.cpp_p
 
 DOCGEN_TARGETS := bin/.docgen_bnfs bin/.docgen_functions
 
+
+$(info Cleaning old generated files.)
+$(shell find ./pkg/sql/exec -type f -name '*.eg.go' -exec rm {} +)
 OPTGEN_TARGETS = \
 	pkg/sql/opt/memo/expr.og.go \
 	pkg/sql/opt/operator.og.go \
@@ -1353,9 +1356,13 @@ unsafe-clean-c-deps:
 	git -C $(SNAPPY_SRC_DIR)   clean -dxf
 	git -C $(LIBROACH_SRC_DIR) clean -dxf
 
+.PHONY: clean-execgen-files
+clean-execgen-files:
+	find ./pkg/sql/exec -type f -name '*.eg.go' -exec rm {} +
+
 .PHONY: clean
 clean: ## Remove build artifacts.
-clean: clean-c-deps
+clean: clean-c-deps clean-execgen-files
 	rm -rf bin/.go_protobuf_sources bin/.gw_protobuf_sources bin/.cpp_protobuf_sources build/defs.mk*
 	$(GO) clean $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -i -cache github.com/cockroachdb/cockroach...
 	$(FIND_RELEVANT) -type f \( -name 'zcgo_flags*.go' -o -name '*.test' \) -exec rm {} +


### PR DESCRIPTION
Backport 1/1 commits from #38054.

/cc @cockroachdb/release

---

This commit adds an unconditional search-and-destroy for untracked
execgen files, so that switching between branches that have new
generated code or not won't cause build errors.

Release note: None
