### PR TITLE
opt: improve distinct count estimate for date range predicates

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -776,8 +776,7 @@ TABLE lineitem
       ├── l_orderkey int not null
       └── l_linenumber int not null
 
-# Regression test for #30226. The following two queries should have the same
-# estimate for number of rows.
+# We can determine that there are exactly 30 days for this range.
 opt
 SELECT *
 FROM lineitem
@@ -785,18 +784,21 @@ WHERE
     l_shipdate >= DATE '1995-09-01'
     AND l_shipdate < DATE '1995-10-01';
 ----
-index-join lineitem
+select
  ├── columns: l_orderkey:1(int!null) l_partkey:2(int!null) l_suppkey:3(int!null) l_linenumber:4(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_tax:8(float!null) l_returnflag:9(char!null) l_linestatus:10(char!null) l_shipdate:11(date!null) l_commitdate:12(date!null) l_receiptdate:13(date!null) l_shipinstruct:14(char!null) l_shipmode:15(char!null) l_comment:16(varchar!null)
- ├── stats: [rows=111.111111, distinct(1)=69.2053852, null(1)=0, distinct(2)=69.2053852, null(2)=0, distinct(3)=69.2053852, null(3)=0, distinct(4)=69.2053852, null(4)=0, distinct(5)=69.2053852, null(5)=0, distinct(6)=69.2053852, null(6)=0, distinct(7)=69.2053852, null(7)=0, distinct(8)=69.2053852, null(8)=0, distinct(9)=69.2053852, null(9)=0, distinct(10)=69.2053852, null(10)=0, distinct(11)=69.2053852, null(11)=0, distinct(12)=69.2053852, null(12)=0, distinct(13)=69.2053852, null(13)=0, distinct(14)=69.2053852, null(14)=0, distinct(15)=69.2053852, null(15)=0, distinct(16)=69.2053852, null(16)=0]
+ ├── stats: [rows=300, distinct(1)=97.1752475, null(1)=0, distinct(2)=97.1752475, null(2)=0, distinct(3)=97.1752475, null(3)=0, distinct(4)=97.1752475, null(4)=0, distinct(5)=97.1752475, null(5)=0, distinct(6)=97.1752475, null(6)=0, distinct(7)=97.1752475, null(7)=0, distinct(8)=97.1752475, null(8)=0, distinct(9)=97.1752475, null(9)=0, distinct(10)=97.1752475, null(10)=0, distinct(11)=30, null(11)=0, distinct(12)=97.1752475, null(12)=0, distinct(13)=97.1752475, null(13)=0, distinct(14)=97.1752475, null(14)=0, distinct(15)=97.1752475, null(15)=0, distinct(16)=97.1752475, null(16)=0]
  ├── key: (1,4)
  ├── fd: (1,4)-->(2,3,5-16)
- └── scan lineitem@l_sd
-      ├── columns: l_orderkey:1(int!null) l_linenumber:4(int!null) l_shipdate:11(date!null)
-      ├── constraint: /11/1/4: [/'1995-09-01' - /'1995-09-30']
-      ├── stats: [rows=111.111111, distinct(1)=69.2053852, null(1)=0, distinct(4)=69.2053852, null(4)=0, distinct(11)=69.2053852, null(11)=0]
-      ├── key: (1,4)
-      └── fd: (1,4)-->(11)
+ ├── scan lineitem
+ │    ├── columns: l_orderkey:1(int!null) l_partkey:2(int!null) l_suppkey:3(int!null) l_linenumber:4(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_tax:8(float!null) l_returnflag:9(char!null) l_linestatus:10(char!null) l_shipdate:11(date!null) l_commitdate:12(date!null) l_receiptdate:13(date!null) l_shipinstruct:14(char!null) l_shipmode:15(char!null) l_comment:16(varchar!null)
+ │    ├── stats: [rows=1000, distinct(1)=100, null(1)=0, distinct(2)=100, null(2)=0, distinct(3)=100, null(3)=0, distinct(4)=100, null(4)=0, distinct(5)=100, null(5)=0, distinct(6)=100, null(6)=0, distinct(7)=100, null(7)=0, distinct(8)=100, null(8)=0, distinct(9)=100, null(9)=0, distinct(10)=100, null(10)=0, distinct(11)=100, null(11)=0, distinct(12)=100, null(12)=0, distinct(13)=100, null(13)=0, distinct(14)=100, null(14)=0, distinct(15)=100, null(15)=0, distinct(16)=100, null(16)=0]
+ │    ├── key: (1,4)
+ │    └── fd: (1,4)-->(2,3,5-16)
+ └── filters
+      └── (l_shipdate >= '1995-09-01') AND (l_shipdate < '1995-10-01') [type=bool, outer=(11), constraints=(/11: [/'1995-09-01' - /'1995-09-30']; tight)]
 
+# We cannot determine the number of distinct values exactly since the upper
+# bound of the date range is compared to a timestamp rather than a date.
 opt
 SELECT *
 FROM lineitem
@@ -1408,3 +1410,84 @@ project
  │         └── variable: min [type=bool, outer=(4), constraints=(/4: [/true - /true]; tight), fd=()-->(4)]
  └── projections
       └── const: 1 [type=int]
+
+# Test that distinct count estimates are correct for date ranges.
+exec-ddl
+CREATE TABLE date_test (
+    k INT PRIMARY KEY,
+    d1 date NOT NULL,
+    d2 date NOT NULL,
+    d3 date NOT NULL,
+    INDEX d1_idx (d1 ASC),
+    INDEX d2_idx (d2 DESC)
+)
+----
+TABLE date_test
+ ├── k int not null
+ ├── d1 date not null
+ ├── d2 date not null
+ ├── d3 date not null
+ ├── INDEX primary
+ │    └── k int not null
+ ├── INDEX d1_idx
+ │    ├── d1 date not null
+ │    └── k int not null
+ └── INDEX d2_idx
+      ├── d2 date not null desc
+      └── k int not null
+
+opt
+SELECT d1 FROM date_test WHERE d1 > DATE '1995-10-01' AND d1 < DATE '1995-11-01'
+----
+scan date_test@d1_idx
+ ├── columns: d1:2(date!null)
+ ├── constraint: /2/1: [/'1995-10-02' - /'1995-10-31']
+ └── stats: [rows=300, distinct(2)=30, null(2)=0]
+
+opt
+SELECT d1 FROM date_test WHERE d1 >= DATE '1995-10-01' AND d1 <= DATE '1995-11-01'
+----
+scan date_test@d1_idx
+ ├── columns: d1:2(date!null)
+ ├── constraint: /2/1: [/'1995-10-01' - /'1995-11-01']
+ └── stats: [rows=320, distinct(2)=32, null(2)=0]
+
+opt
+SELECT d2 FROM date_test WHERE d2 > DATE '1903-10-01' AND d2 <= DATE '1903-11-01'
+----
+scan date_test@d2_idx
+ ├── columns: d2:3(date!null)
+ ├── constraint: /-3/1: [/'1903-11-01' - /'1903-10-02']
+ └── stats: [rows=310, distinct(3)=31, null(3)=0]
+
+opt
+SELECT d2 FROM date_test WHERE d2 >= DATE '2003-10-01' AND d2 < DATE '2003-11-01'
+----
+scan date_test@d2_idx
+ ├── columns: d2:3(date!null)
+ ├── constraint: /-3/1: [/'2003-10-31' - /'2003-10-01']
+ └── stats: [rows=310, distinct(3)=31, null(3)=0]
+
+opt
+SELECT d3 FROM date_test WHERE d3 >= DATE '2003-10-01' AND d3 < DATE '2003-11-01'
+----
+select
+ ├── columns: d3:4(date!null)
+ ├── stats: [rows=310, distinct(4)=31, null(4)=0]
+ ├── scan date_test
+ │    ├── columns: d3:4(date!null)
+ │    └── stats: [rows=1000, distinct(4)=100, null(4)=0]
+ └── filters
+      └── (d3 >= '2003-10-01') AND (d3 < '2003-11-01') [type=bool, outer=(4), constraints=(/4: [/'2003-10-01' - /'2003-10-31']; tight)]
+
+opt
+SELECT d3 FROM date_test WHERE d3 >= DATE '1903-10-01' AND d3 < DATE '2003-10-01'
+----
+select
+ ├── columns: d3:4(date!null)
+ ├── stats: [rows=1000, distinct(4)=100, null(4)=0]
+ ├── scan date_test
+ │    ├── columns: d3:4(date!null)
+ │    └── stats: [rows=1000, distinct(4)=100, null(4)=0]
+ └── filters
+      └── (d3 >= '1903-10-01') AND (d3 < '2003-10-01') [type=bool, outer=(4), constraints=(/4: [/'1903-10-01' - /'2003-09-30']; tight)]

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch
@@ -2031,20 +2031,20 @@ sort
       ├── semi-join
       │    ├── save-table-name: q4_semi_join_3
       │    ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null) o_orderpriority:6(char!null)
-      │    ├── stats: [rows=166666.667, distinct(1)=166666.667, null(1)=0, distinct(5)=2406, null(5)=0, distinct(6)=5, null(6)=0]
+      │    ├── stats: [rows=57356.6085, distinct(1)=57356.6085, null(1)=0, distinct(5)=92, null(5)=0, distinct(6)=5, null(6)=0]
       │    ├── key: (1)
       │    ├── fd: (1)-->(5,6)
       │    ├── index-join orders
       │    │    ├── save-table-name: q4_index_join_4
       │    │    ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null) o_orderpriority:6(char!null)
-      │    │    ├── stats: [rows=166666.667, distinct(1)=166666.667, null(1)=0, distinct(5)=2406, null(5)=0, distinct(6)=5, null(6)=0]
+      │    │    ├── stats: [rows=57356.6085, distinct(1)=57356.6085, null(1)=0, distinct(5)=92, null(5)=0, distinct(6)=5, null(6)=0]
       │    │    ├── key: (1)
       │    │    ├── fd: (1)-->(5,6)
       │    │    └── scan orders@o_od
       │    │         ├── save-table-name: q4_scan_5
       │    │         ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null)
       │    │         ├── constraint: /5/1: [/'1993-07-01' - /'1993-09-30']
-      │    │         ├── stats: [rows=166666.667, distinct(1)=166666.667, null(1)=0, distinct(5)=2406, null(5)=0]
+      │    │         ├── stats: [rows=57356.6085, distinct(1)=57356.6085, null(1)=0, distinct(5)=92, null(5)=0]
       │    │         ├── key: (1)
       │    │         └── fd: (1)-->(5)
       │    ├── select
@@ -2090,9 +2090,9 @@ column_names       row_count  distinct_count  null_count
 {o_orderpriority}  52523      5               0
 ~~~~
 column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{o_orderdate}      166667.00      3.17 <==       2406.00             26.15 <==           0.00            1.00
-{o_orderkey}       166667.00      3.17 <==       166667.00           3.18 <==            0.00            1.00
-{o_orderpriority}  166667.00      3.17 <==       5.00                1.00                0.00            1.00
+{o_orderdate}      57357.00       1.09           92.00               1.00                0.00            1.00
+{o_orderkey}       57357.00       1.09           57357.00            1.09                0.00            1.00
+{o_orderpriority}  57357.00       1.09           5.00                1.00                0.00            1.00
 
 stats table=q4_index_join_4
 ----
@@ -2102,9 +2102,9 @@ column_names       row_count  distinct_count  null_count
 {o_orderpriority}  57218      5               0
 ~~~~
 column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{o_orderdate}      166667.00      2.91 <==       2406.00             26.15 <==           0.00            1.00
-{o_orderkey}       166667.00      2.91 <==       166667.00           2.90 <==            0.00            1.00
-{o_orderpriority}  166667.00      2.91 <==       5.00                1.00                0.00            1.00
+{o_orderdate}      57357.00       1.00           92.00               1.00                0.00            1.00
+{o_orderkey}       57357.00       1.00           57357.00            1.00                0.00            1.00
+{o_orderpriority}  57357.00       1.00           5.00                1.00                0.00            1.00
 
 stats table=q4_select_6
 ----
@@ -2190,16 +2190,16 @@ sort
       ├── project
       │    ├── save-table-name: q5_project_3
       │    ├── columns: column48:48(float) n_name:42(char!null)
-      │    ├── stats: [rows=9729.11938, distinct(42)=5, null(42)=0, distinct(48)=9513.83496, null(48)=0]
+      │    ├── stats: [rows=13283.5233, distinct(42)=5, null(42)=0, distinct(48)=12978.2343, null(48)=0]
       │    ├── inner-join
       │    │    ├── save-table-name: q5_inner_join_4
       │    │    ├── columns: c_custkey:1(int!null) c_nationkey:4(int!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
-      │    │    ├── stats: [rows=9729.11938, distinct(1)=9729.11938, null(1)=0, distinct(4)=5, null(4)=0, distinct(9)=9450.59912, null(9)=0, distinct(10)=9729.11938, null(10)=0, distinct(13)=2363.81647, null(13)=0, distinct(18)=9450.59912, null(18)=0, distinct(20)=1835.35288, null(20)=0, distinct(23)=9499.54561, null(23)=0, distinct(24)=11, null(24)=0, distinct(34)=1835.35288, null(34)=0, distinct(37)=5, null(37)=0, distinct(41)=5, null(41)=0, distinct(42)=5, null(42)=0, distinct(43)=1, null(43)=0, distinct(45)=1, null(45)=0, distinct(46)=0.996222107, null(46)=0, distinct(23,24)=9513.83496, null(23,24)=0]
+      │    │    ├── stats: [rows=13283.5233, distinct(1)=13283.5233, null(1)=0, distinct(4)=5, null(4)=0, distinct(9)=12903.2494, null(9)=0, distinct(10)=13283.5233, null(10)=0, distinct(13)=365, null(13)=0, distinct(18)=12903.2494, null(18)=0, distinct(20)=1843.42933, null(20)=0, distinct(23)=12950.7961, null(23)=0, distinct(24)=11, null(24)=0, distinct(34)=1843.42933, null(34)=0, distinct(37)=5, null(37)=0, distinct(41)=5, null(41)=0, distinct(42)=5, null(42)=0, distinct(43)=1, null(43)=0, distinct(45)=1, null(45)=0, distinct(46)=0.996222107, null(46)=0, distinct(23,24)=12978.2343, null(23,24)=0]
       │    │    ├── fd: ()-->(46), (1)-->(4), (9)-->(10,13), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(4,41), (41)==(4,37), (20)==(34), (34)==(20), (9)==(18), (18)==(9), (1)==(10), (10)==(1), (4)==(37,41)
       │    │    ├── inner-join
       │    │    │    ├── save-table-name: q5_inner_join_5
       │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
-      │    │    │    ├── stats: [rows=241303.24, distinct(9)=166666.667, null(9)=0, distinct(10)=78332.2968, null(10)=0, distinct(13)=2406, null(13)=0, distinct(18)=166666.667, null(18)=0, distinct(20)=1844.80594, null(20)=0, distinct(23)=202898.366, null(23)=0, distinct(24)=11, null(24)=0, distinct(34)=1844.80594, null(34)=0, distinct(37)=5, null(37)=0, distinct(41)=5, null(41)=0, distinct(42)=5, null(42)=0, distinct(43)=1, null(43)=0, distinct(45)=1, null(45)=0, distinct(46)=0.996222107, null(46)=0, distinct(23,24)=216582.447, null(23,24)=0]
+      │    │    │    ├── stats: [rows=329460.16, distinct(9)=227556.11, null(9)=0, distinct(10)=88927.0358, null(10)=0, distinct(13)=365, null(13)=0, distinct(18)=227556.11, null(18)=0, distinct(20)=1844.80594, null(20)=0, distinct(23)=260712.179, null(23)=0, distinct(24)=11, null(24)=0, distinct(34)=1844.80594, null(34)=0, distinct(37)=5, null(37)=0, distinct(41)=5, null(41)=0, distinct(42)=5, null(42)=0, distinct(43)=1, null(43)=0, distinct(45)=1, null(45)=0, distinct(46)=0.996222107, null(46)=0, distinct(23,24)=284545.02, null(23,24)=0]
       │    │    │    ├── fd: ()-->(46), (9)-->(10,13), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (20)==(34), (34)==(20), (9)==(18), (18)==(9)
       │    │    │    ├── inner-join
       │    │    │    │    ├── save-table-name: q5_inner_join_6
@@ -2251,14 +2251,14 @@ sort
       │    │    │    ├── index-join orders
       │    │    │    │    ├── save-table-name: q5_index_join_13
       │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null)
-      │    │    │    │    ├── stats: [rows=166666.667, distinct(9)=166666.667, null(9)=0, distinct(10)=82829.9251, null(10)=0, distinct(13)=2406, null(13)=0]
+      │    │    │    │    ├── stats: [rows=227556.11, distinct(9)=227556.11, null(9)=0, distinct(10)=91414.8213, null(10)=0, distinct(13)=365, null(13)=0]
       │    │    │    │    ├── key: (9)
       │    │    │    │    ├── fd: (9)-->(10,13)
       │    │    │    │    └── scan orders@o_od
       │    │    │    │         ├── save-table-name: q5_scan_14
       │    │    │    │         ├── columns: o_orderkey:9(int!null) o_orderdate:13(date!null)
       │    │    │    │         ├── constraint: /13/9: [/'1994-01-01' - /'1994-12-31']
-      │    │    │    │         ├── stats: [rows=166666.667, distinct(9)=166666.667, null(9)=0, distinct(13)=2406, null(13)=0]
+      │    │    │    │         ├── stats: [rows=227556.11, distinct(9)=227556.11, null(9)=0, distinct(13)=365, null(13)=0]
       │    │    │    │         ├── key: (9)
       │    │    │    │         └── fd: (9)-->(13)
       │    │    │    └── filters
@@ -2305,8 +2305,8 @@ column_names  row_count  distinct_count  null_count
 {n_name}      7243       5               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{column48}    9729.00        1.34           9514.00             1.31                0.00            1.00
-{n_name}      9729.00        1.34           5.00                1.00                0.00            1.00
+{column48}    13284.00       1.83           12978.00            1.79                0.00            1.00
+{n_name}      13284.00       1.83           5.00                1.00                0.00            1.00
 
 stats table=q5_inner_join_4
 ----
@@ -2329,22 +2329,22 @@ column_names       row_count  distinct_count  null_count
 {s_suppkey}        7243       1944            0
 ~~~~
 column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{c_custkey}        9729.00        1.34           9729.00             1.75                0.00            1.00
-{c_nationkey}      9729.00        1.34           5.00                1.00                0.00            1.00
-{l_discount}       9729.00        1.34           11.00               1.00                0.00            1.00
-{l_extendedprice}  9729.00        1.34           9500.00             1.32                0.00            1.00
-{l_orderkey}       9729.00        1.34           9451.00             1.42                0.00            1.00
-{l_suppkey}        9729.00        1.34           1835.00             1.06                0.00            1.00
-{n_name}           9729.00        1.34           5.00                1.00                0.00            1.00
-{n_nationkey}      9729.00        1.34           5.00                1.00                0.00            1.00
-{n_regionkey}      9729.00        1.34           1.00                1.00                0.00            1.00
-{o_custkey}        9729.00        1.34           9729.00             1.75                0.00            1.00
-{o_orderdate}      9729.00        1.34           2364.00             6.48 <==            0.00            1.00
-{o_orderkey}       9729.00        1.34           9451.00             1.42                0.00            1.00
-{r_name}           9729.00        1.34           1.00                1.00                0.00            1.00
-{r_regionkey}      9729.00        1.34           1.00                1.00                0.00            1.00
-{s_nationkey}      9729.00        1.34           5.00                1.00                0.00            1.00
-{s_suppkey}        9729.00        1.34           1835.00             1.06                0.00            1.00
+{c_custkey}        13284.00       1.83           13284.00            2.39 <==            0.00            1.00
+{c_nationkey}      13284.00       1.83           5.00                1.00                0.00            1.00
+{l_discount}       13284.00       1.83           11.00               1.00                0.00            1.00
+{l_extendedprice}  13284.00       1.83           12951.00            1.80                0.00            1.00
+{l_orderkey}       13284.00       1.83           12903.00            1.94 <==            0.00            1.00
+{l_suppkey}        13284.00       1.83           1843.00             1.05                0.00            1.00
+{n_name}           13284.00       1.83           5.00                1.00                0.00            1.00
+{n_nationkey}      13284.00       1.83           5.00                1.00                0.00            1.00
+{n_regionkey}      13284.00       1.83           1.00                1.00                0.00            1.00
+{o_custkey}        13284.00       1.83           13284.00            2.39 <==            0.00            1.00
+{o_orderdate}      13284.00       1.83           365.00              1.00                0.00            1.00
+{o_orderkey}       13284.00       1.83           12903.00            1.94 <==            0.00            1.00
+{r_name}           13284.00       1.83           1.00                1.00                0.00            1.00
+{r_regionkey}      13284.00       1.83           1.00                1.00                0.00            1.00
+{s_nationkey}      13284.00       1.83           5.00                1.00                0.00            1.00
+{s_suppkey}        13284.00       1.83           1843.00             1.05                0.00            1.00
 
 stats table=q5_inner_join_5
 ----
@@ -2365,20 +2365,20 @@ column_names       row_count  distinct_count  null_count
 {s_suppkey}        182183     2002            0
 ~~~~
 column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{l_discount}       241303.00      1.32           11.00               1.00                0.00            1.00
-{l_extendedprice}  241303.00      1.32           202898.00           1.23                0.00            1.00
-{l_orderkey}       241303.00      1.32           166667.00           1.35                0.00            1.00
-{l_suppkey}        241303.00      1.32           1845.00             1.09                0.00            1.00
-{n_name}           241303.00      1.32           5.00                1.00                0.00            1.00
-{n_nationkey}      241303.00      1.32           5.00                1.00                0.00            1.00
-{n_regionkey}      241303.00      1.32           1.00                1.00                0.00            1.00
-{o_custkey}        241303.00      1.32           78332.00            1.15                0.00            1.00
-{o_orderdate}      241303.00      1.32           2406.00             6.59 <==            0.00            1.00
-{o_orderkey}       241303.00      1.32           166667.00           1.35                0.00            1.00
-{r_name}           241303.00      1.32           1.00                1.00                0.00            1.00
-{r_regionkey}      241303.00      1.32           1.00                1.00                0.00            1.00
-{s_nationkey}      241303.00      1.32           5.00                1.00                0.00            1.00
-{s_suppkey}        241303.00      1.32           1845.00             1.09                0.00            1.00
+{l_discount}       329460.00      1.81           11.00               1.00                0.00            1.00
+{l_extendedprice}  329460.00      1.81           260712.00           1.59                0.00            1.00
+{l_orderkey}       329460.00      1.81           227556.00           1.84                0.00            1.00
+{l_suppkey}        329460.00      1.81           1845.00             1.09                0.00            1.00
+{n_name}           329460.00      1.81           5.00                1.00                0.00            1.00
+{n_nationkey}      329460.00      1.81           5.00                1.00                0.00            1.00
+{n_regionkey}      329460.00      1.81           1.00                1.00                0.00            1.00
+{o_custkey}        329460.00      1.81           88927.00            1.30                0.00            1.00
+{o_orderdate}      329460.00      1.81           365.00              1.00                0.00            1.00
+{o_orderkey}       329460.00      1.81           227556.00           1.84                0.00            1.00
+{r_name}           329460.00      1.81           1.00                1.00                0.00            1.00
+{r_regionkey}      329460.00      1.81           1.00                1.00                0.00            1.00
+{s_nationkey}      329460.00      1.81           5.00                1.00                0.00            1.00
+{s_suppkey}        329460.00      1.81           1845.00             1.09                0.00            1.00
 
 stats table=q5_inner_join_6
 ----
@@ -2498,9 +2498,9 @@ column_names   row_count  distinct_count  null_count
 {o_orderkey}   227597     229152          0
 ~~~~
 column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{o_custkey}    166667.00      1.37           82830.00            1.04                0.00            1.00
-{o_orderdate}  166667.00      1.37           2406.00             6.59 <==            0.00            1.00
-{o_orderkey}   166667.00      1.37           166667.00           1.37                0.00            1.00
+{o_custkey}    227556.00      1.00           91415.00            1.06                0.00            1.00
+{o_orderdate}  227556.00      1.00           365.00              1.00                0.00            1.00
+{o_orderkey}   227556.00      1.00           227556.00           1.01                0.00            1.00
 
 stats table=q5_scan_15
 ----
@@ -2548,20 +2548,20 @@ scalar-group-by
  ├── project
  │    ├── save-table-name: q6_project_2
  │    ├── columns: column17:17(float)
- │    ├── stats: [rows=24696.358, distinct(17)=24696.358, null(17)=0]
+ │    ├── stats: [rows=32116.9977, distinct(17)=32116.9977, null(17)=0]
  │    ├── select
  │    │    ├── save-table-name: q6_select_3
  │    │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
- │    │    ├── stats: [rows=24696.358, distinct(5)=50, null(5)=0, distinct(6)=24419.5384, null(6)=0, distinct(7)=11, null(7)=0, distinct(11)=2525.85951, null(11)=0, distinct(6,7)=24696.358, null(6,7)=0]
+ │    │    ├── stats: [rows=32116.9977, distinct(5)=50, null(5)=0, distinct(6)=31649.6934, null(6)=0, distinct(7)=11, null(7)=0, distinct(11)=365, null(11)=0, distinct(6,7)=32116.9977, null(6,7)=0]
  │    │    ├── index-join lineitem
  │    │    │    ├── save-table-name: q6_index_join_4
  │    │    │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
- │    │    │    ├── stats: [rows=666801.667, distinct(5)=50, null(5)=0, distinct(6)=494371.509, null(6)=0, distinct(7)=11, null(7)=0, distinct(11)=2526, null(11)=0, distinct(6,7)=666801.667, null(6,7)=0]
+ │    │    │    ├── stats: [rows=867158.937, distinct(5)=50, null(5)=0, distinct(6)=589203.498, null(6)=0, distinct(7)=11, null(7)=0, distinct(11)=365, null(11)=0, distinct(6,7)=867158.937, null(6,7)=0]
  │    │    │    └── scan lineitem@l_sd
  │    │    │         ├── save-table-name: q6_scan_5
  │    │    │         ├── columns: l_orderkey:1(int!null) l_linenumber:4(int!null) l_shipdate:11(date!null)
  │    │    │         ├── constraint: /11/1/4: [/'1994-01-01' - /'1994-12-31']
- │    │    │         ├── stats: [rows=666801.667, distinct(1)=565838.316, null(1)=0, distinct(4)=7, null(4)=0, distinct(11)=2526, null(11)=0]
+ │    │    │         ├── stats: [rows=867158.937, distinct(1)=700112.075, null(1)=0, distinct(4)=7, null(4)=0, distinct(11)=365, null(11)=0]
  │    │    │         ├── key: (1,4)
  │    │    │         └── fd: (1,4)-->(11)
  │    │    └── filters
@@ -2587,7 +2587,7 @@ column_names  row_count  distinct_count  null_count
 {column17}    114160     108866          0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{column17}    24696.00       4.62 <==       24696.00            4.41 <==            0.00            1.00
+{column17}    32117.00       3.55 <==       32117.00            3.39 <==            0.00            1.00
 
 stats table=q6_select_3
 ----
@@ -2598,10 +2598,10 @@ column_names       row_count  distinct_count  null_count
 {l_shipdate}       114160     365             0
 ~~~~
 column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{l_discount}       24696.00       4.62 <==       11.00               3.67 <==            0.00            1.00
-{l_extendedprice}  24696.00       4.62 <==       24420.00            4.04 <==            0.00            1.00
-{l_quantity}       24696.00       4.62 <==       50.00               2.17 <==            0.00            1.00
-{l_shipdate}       24696.00       4.62 <==       2526.00             6.92 <==            0.00            1.00
+{l_discount}       32117.00       3.55 <==       11.00               3.67 <==            0.00            1.00
+{l_extendedprice}  32117.00       3.55 <==       31650.00            3.12 <==            0.00            1.00
+{l_quantity}       32117.00       3.55 <==       50.00               2.17 <==            0.00            1.00
+{l_shipdate}       32117.00       3.55 <==       365.00              1.00                0.00            1.00
 
 stats table=q6_index_join_4
 ----
@@ -2612,10 +2612,10 @@ column_names       row_count  distinct_count  null_count
 {l_shipdate}       909455     365             0
 ~~~~
 column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{l_discount}       666802.00      1.36           11.00               1.00                0.00            1.00
-{l_extendedprice}  666802.00      1.36           494372.00           1.14                0.00            1.00
-{l_quantity}       666802.00      1.36           50.00               1.00                0.00            1.00
-{l_shipdate}       666802.00      1.36           2526.00             6.92 <==            0.00            1.00
+{l_discount}       867159.00      1.05           11.00               1.00                0.00            1.00
+{l_extendedprice}  867159.00      1.05           589203.00           1.04                0.00            1.00
+{l_quantity}       867159.00      1.05           50.00               1.00                0.00            1.00
+{l_shipdate}       867159.00      1.05           365.00              1.00                0.00            1.00
 
 # --------------------------------------------------
 # Q7
@@ -2675,7 +2675,7 @@ ORDER BY
 sort
  ├── save-table-name: q7_sort_1
  ├── columns: supp_nation:42(char!null) cust_nation:46(char!null) l_year:49(int) revenue:51(float)
- ├── stats: [rows=183694.011, distinct(42)=24.9990099, null(42)=0, distinct(46)=24.9990099, null(46)=0, distinct(49)=2526, null(49)=0, distinct(51)=183694.011, null(51)=0, distinct(42,46,49)=183694.011, null(42,46,49)=0]
+ ├── stats: [rows=149096.222, distinct(42)=24.9990099, null(42)=0, distinct(46)=24.9990099, null(46)=0, distinct(49)=731, null(49)=0, distinct(51)=149096.222, null(51)=0, distinct(42,46,49)=149096.222, null(42,46,49)=0]
  ├── key: (42,46,49)
  ├── fd: (42,46,49)-->(51)
  ├── ordering: +42,+46,+49
@@ -2683,22 +2683,22 @@ sort
       ├── save-table-name: q7_group_by_2
       ├── columns: n1.n_name:42(char!null) n2.n_name:46(char!null) l_year:49(int) sum:51(float)
       ├── grouping columns: n1.n_name:42(char!null) n2.n_name:46(char!null) l_year:49(int)
-      ├── stats: [rows=183694.011, distinct(42)=24.9990099, null(42)=0, distinct(46)=24.9990099, null(46)=0, distinct(49)=2526, null(49)=0, distinct(51)=183694.011, null(51)=0, distinct(42,46,49)=183694.011, null(42,46,49)=0]
+      ├── stats: [rows=149096.222, distinct(42)=24.9990099, null(42)=0, distinct(46)=24.9990099, null(46)=0, distinct(49)=731, null(49)=0, distinct(51)=149096.222, null(51)=0, distinct(42,46,49)=149096.222, null(42,46,49)=0]
       ├── key: (42,46,49)
       ├── fd: (42,46,49)-->(51)
       ├── project
       │    ├── save-table-name: q7_project_3
       │    ├── columns: l_year:49(int) volume:50(float) n1.n_name:42(char!null) n2.n_name:46(char!null)
-      │    ├── stats: [rows=225940.387, distinct(42)=24.9990099, null(42)=0, distinct(46)=24.9990099, null(46)=0, distinct(49)=2526, null(49)=0, distinct(50)=191635.552, null(50)=0, distinct(42,46,49)=183694.011, null(42,46,49)=0]
+      │    ├── stats: [rows=588464.689, distinct(42)=24.9990099, null(42)=0, distinct(46)=24.9990099, null(46)=0, distinct(49)=731, null(49)=0, distinct(50)=499117.299, null(50)=0, distinct(42,46,49)=149096.222, null(42,46,49)=0]
       │    ├── inner-join
       │    │    ├── save-table-name: q7_inner_join_4
       │    │    ├── columns: s_suppkey:1(int!null) s_nationkey:4(int!null) l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null) o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
-      │    │    ├── stats: [rows=225940.387, distinct(1)=9920, null(1)=0, distinct(4)=24.9990099, null(4)=0, distinct(8)=186281.027, null(8)=0, distinct(10)=9920, null(10)=0, distinct(13)=181353.002, null(13)=0, distinct(14)=11, null(14)=0, distinct(18)=2526, null(18)=0, distinct(24)=186281.027, null(24)=0, distinct(25)=89457.1229, null(25)=0, distinct(33)=89457.1229, null(33)=0, distinct(36)=24.9990099, null(36)=0, distinct(41)=24.9990099, null(41)=0, distinct(42)=24.9990099, null(42)=0, distinct(45)=24.9990099, null(45)=0, distinct(46)=24.9990099, null(46)=0, distinct(13,14)=191635.552, null(13,14)=0, distinct(18,42,46)=183694.011, null(18,42,46)=0]
+      │    │    ├── stats: [rows=588464.689, distinct(1)=9920, null(1)=0, distinct(4)=24.9990099, null(4)=0, distinct(8)=458543.889, null(8)=0, distinct(10)=9920, null(10)=0, distinct(13)=420694.205, null(13)=0, distinct(14)=11, null(14)=0, distinct(18)=731, null(18)=0, distinct(24)=458543.889, null(24)=0, distinct(25)=99570.7584, null(25)=0, distinct(33)=99570.7584, null(33)=0, distinct(36)=24.9990099, null(36)=0, distinct(41)=24.9990099, null(41)=0, distinct(42)=24.9990099, null(42)=0, distinct(45)=24.9990099, null(45)=0, distinct(46)=24.9990099, null(46)=0, distinct(13,14)=499117.299, null(13,14)=0, distinct(18,42,46)=149096.222, null(18,42,46)=0]
       │    │    ├── fd: (1)-->(4), (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25), (8)==(24), (24)==(8), (1)==(10), (10)==(1), (4)==(41), (41)==(4)
       │    │    ├── inner-join
       │    │    │    ├── save-table-name: q7_inner_join_5
       │    │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null) o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
-      │    │    │    ├── stats: [rows=5603321.59, distinct(8)=565838.316, null(8)=0, distinct(10)=9920, null(10)=0, distinct(13)=494365.598, null(13)=0, distinct(14)=11, null(14)=0, distinct(18)=2526, null(18)=0, distinct(24)=565838.316, null(24)=0, distinct(25)=99846, null(25)=0, distinct(33)=99846, null(33)=0, distinct(36)=24.9990099, null(36)=0, distinct(41)=24.9990099, null(41)=0, distinct(42)=24.9990099, null(42)=0, distinct(45)=24.9990099, null(45)=0, distinct(46)=24.9990099, null(46)=0, distinct(13,14)=666652.216, null(13,14)=0, distinct(18,42,46)=526250, null(18,42,46)=0]
+      │    │    │    ├── stats: [rows=14593924.3, distinct(8)=1128319.56, null(8)=0, distinct(10)=9920, null(10)=0, distinct(13)=824798.212, null(13)=0, distinct(14)=11, null(14)=0, distinct(18)=731, null(18)=0, distinct(24)=1128319.56, null(24)=0, distinct(25)=99846, null(25)=0, distinct(33)=99846, null(33)=0, distinct(36)=24.9990099, null(36)=0, distinct(41)=24.9990099, null(41)=0, distinct(42)=24.9990099, null(42)=0, distinct(45)=24.9990099, null(45)=0, distinct(46)=24.9990099, null(46)=0, distinct(13,14)=1736304.41, null(13,14)=0, distinct(18,42,46)=152291.667, null(18,42,46)=0]
       │    │    │    ├── fd: (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25), (8)==(24), (24)==(8)
       │    │    │    ├── inner-join
       │    │    │    │    ├── save-table-name: q7_inner_join_6
@@ -2757,17 +2757,16 @@ sort
       │    │    │    │    │    └── filters (true)
       │    │    │    │    └── filters
       │    │    │    │         └── c_custkey = o_custkey [type=bool, outer=(25,33), constraints=(/25: (/NULL - ]; /33: (/NULL - ]), fd=(25)==(33), (33)==(25)]
-      │    │    │    ├── index-join lineitem
-      │    │    │    │    ├── save-table-name: q7_index_join_14
+      │    │    │    ├── select
+      │    │    │    │    ├── save-table-name: q7_select_14
       │    │    │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null)
-      │    │    │    │    ├── stats: [rows=666801.667, distinct(8)=565838.316, null(8)=0, distinct(10)=9920, null(10)=0, distinct(13)=494371.509, null(13)=0, distinct(14)=11, null(14)=0, distinct(18)=2526, null(18)=0, distinct(13,14)=666801.667, null(13,14)=0]
-      │    │    │    │    └── scan lineitem@l_sd
-      │    │    │    │         ├── save-table-name: q7_scan_15
-      │    │    │    │         ├── columns: l_orderkey:8(int!null) l_linenumber:11(int!null) l_shipdate:18(date!null)
-      │    │    │    │         ├── constraint: /18/8/11: [/'1995-01-01' - /'1996-12-31']
-      │    │    │    │         ├── stats: [rows=666801.667, distinct(8)=565838.316, null(8)=0, distinct(11)=7, null(11)=0, distinct(18)=2526, null(18)=0]
-      │    │    │    │         ├── key: (8,11)
-      │    │    │    │         └── fd: (8,11)-->(18)
+      │    │    │    │    ├── stats: [rows=1736693.65, distinct(8)=1128319.56, null(8)=0, distinct(10)=9920, null(10)=0, distinct(13)=824798.229, null(13)=0, distinct(14)=11, null(14)=0, distinct(18)=731, null(18)=0, distinct(13,14)=1736693.65, null(13,14)=0]
+      │    │    │    │    ├── scan lineitem
+      │    │    │    │    │    ├── save-table-name: q7_scan_15
+      │    │    │    │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null)
+      │    │    │    │    │    └── stats: [rows=6001215, distinct(8)=1527270, null(8)=0, distinct(10)=9920, null(10)=0, distinct(13)=925955, null(13)=0, distinct(14)=11, null(14)=0, distinct(18)=2526, null(18)=0, distinct(13,14)=6001215, null(13,14)=0]
+      │    │    │    │    └── filters
+      │    │    │    │         └── (l_shipdate >= '1995-01-01') AND (l_shipdate <= '1996-12-31') [type=bool, outer=(18), constraints=(/18: [/'1995-01-01' - /'1996-12-31']; tight)]
       │    │    │    └── filters
       │    │    │         └── o_orderkey = l_orderkey [type=bool, outer=(8,24), constraints=(/8: (/NULL - ]; /24: (/NULL - ]), fd=(8)==(24), (24)==(8)]
       │    │    ├── scan supplier@s_nk
@@ -2795,10 +2794,10 @@ column_names   row_count  distinct_count  null_count
 {supp_nation}  4          2               0
 ~~~~
 column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{cust_nation}  183694.00      45923.50 <==   25.00               12.50 <==           0.00            1.00
-{l_year}       183694.00      45923.50 <==   2526.00             1263.00 <==         0.00            1.00
-{revenue}      183694.00      45923.50 <==   183694.00           45923.50 <==        0.00            1.00
-{supp_nation}  183694.00      45923.50 <==   25.00               12.50 <==           0.00            1.00
+{cust_nation}  149096.00      37274.00 <==   25.00               12.50 <==           0.00            1.00
+{l_year}       149096.00      37274.00 <==   731.00              365.50 <==          0.00            1.00
+{revenue}      149096.00      37274.00 <==   149096.00           37274.00 <==        0.00            1.00
+{supp_nation}  149096.00      37274.00 <==   25.00               12.50 <==           0.00            1.00
 
 stats table=q7_group_by_2
 ----
@@ -2809,10 +2808,10 @@ column_names  row_count  distinct_count  null_count
 {sum}         4          4               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{l_year}      183694.00      45923.50 <==   2526.00             1263.00 <==         0.00            1.00
-{n_name}      183694.00      45923.50 <==   25.00               12.50 <==           0.00            1.00
-{n_name_1}    183694.00      45923.50 <==   25.00               12.50 <==           0.00            1.00
-{sum}         183694.00      45923.50 <==   183694.00           45923.50 <==        0.00            1.00
+{l_year}      149096.00      37274.00 <==   731.00              365.50 <==          0.00            1.00
+{n_name}      149096.00      37274.00 <==   25.00               12.50 <==           0.00            1.00
+{n_name_1}    149096.00      37274.00 <==   25.00               12.50 <==           0.00            1.00
+{sum}         149096.00      37274.00 <==   149096.00           37274.00 <==        0.00            1.00
 
 stats table=q7_project_3
 ----
@@ -2823,10 +2822,10 @@ column_names  row_count  distinct_count  null_count
 {volume}      5924       5904            0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{l_year}      225940.00      38.14 <==      2526.00             1263.00 <==         0.00            1.00
-{n_name}      225940.00      38.14 <==      25.00               12.50 <==           0.00            1.00
-{n_name_1}    225940.00      38.14 <==      25.00               12.50 <==           0.00            1.00
-{volume}      225940.00      38.14 <==      191636.00           32.46 <==           0.00            1.00
+{l_year}      588465.00      99.34 <==      731.00              365.50 <==          0.00            1.00
+{n_name}      588465.00      99.34 <==      25.00               12.50 <==           0.00            1.00
+{n_name_1}    588465.00      99.34 <==      25.00               12.50 <==           0.00            1.00
+{volume}      588465.00      99.34 <==      499117.00           84.54 <==           0.00            1.00
 
 stats table=q7_inner_join_4
 ----
@@ -2848,21 +2847,21 @@ column_names       row_count  distinct_count  null_count
 {s_suppkey}        5924       796             0
 ~~~~
 column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{c_custkey}        225940.00      38.14 <==      89457.00            22.93 <==           0.00            1.00
-{c_nationkey}      225940.00      38.14 <==      25.00               12.50 <==           0.00            1.00
-{l_discount}       225940.00      38.14 <==      11.00               1.00                0.00            1.00
-{l_extendedprice}  225940.00      38.14 <==      181353.00           30.86 <==           0.00            1.00
-{l_orderkey}       225940.00      38.14 <==      186281.00           34.21 <==           0.00            1.00
-{l_shipdate}       225940.00      38.14 <==      2526.00             3.46 <==            0.00            1.00
-{l_suppkey}        225940.00      38.14 <==      9920.00             12.46 <==           0.00            1.00
-{n_name}           225940.00      38.14 <==      25.00               12.50 <==           0.00            1.00
-{n_name_1}         225940.00      38.14 <==      25.00               12.50 <==           0.00            1.00
-{n_nationkey}      225940.00      38.14 <==      25.00               12.50 <==           0.00            1.00
-{n_nationkey_1}    225940.00      38.14 <==      25.00               12.50 <==           0.00            1.00
-{o_custkey}        225940.00      38.14 <==      89457.00            22.93 <==           0.00            1.00
-{o_orderkey}       225940.00      38.14 <==      186281.00           34.21 <==           0.00            1.00
-{s_nationkey}      225940.00      38.14 <==      25.00               12.50 <==           0.00            1.00
-{s_suppkey}        225940.00      38.14 <==      9920.00             12.46 <==           0.00            1.00
+{c_custkey}        588465.00      99.34 <==      99571.00            25.52 <==           0.00            1.00
+{c_nationkey}      588465.00      99.34 <==      25.00               12.50 <==           0.00            1.00
+{l_discount}       588465.00      99.34 <==      11.00               1.00                0.00            1.00
+{l_extendedprice}  588465.00      99.34 <==      420694.00           71.60 <==           0.00            1.00
+{l_orderkey}       588465.00      99.34 <==      458544.00           84.21 <==           0.00            1.00
+{l_shipdate}       588465.00      99.34 <==      731.00              1.00                0.00            1.00
+{l_suppkey}        588465.00      99.34 <==      9920.00             12.46 <==           0.00            1.00
+{n_name}           588465.00      99.34 <==      25.00               12.50 <==           0.00            1.00
+{n_name_1}         588465.00      99.34 <==      25.00               12.50 <==           0.00            1.00
+{n_nationkey}      588465.00      99.34 <==      25.00               12.50 <==           0.00            1.00
+{n_nationkey_1}    588465.00      99.34 <==      25.00               12.50 <==           0.00            1.00
+{o_custkey}        588465.00      99.34 <==      99571.00            25.52 <==           0.00            1.00
+{o_orderkey}       588465.00      99.34 <==      458544.00           84.21 <==           0.00            1.00
+{s_nationkey}      588465.00      99.34 <==      25.00               12.50 <==           0.00            1.00
+{s_suppkey}        588465.00      99.34 <==      9920.00             12.46 <==           0.00            1.00
 
 stats table=q7_inner_join_5
 ----
@@ -2882,19 +2881,19 @@ column_names       row_count  distinct_count  null_count
 {o_orderkey}       148370     39757           0
 ~~~~
 column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{c_custkey}        5603322.00     37.77 <==      99846.00            12.51 <==           0.00            1.00
-{c_nationkey}      5603322.00     37.77 <==      25.00               12.50 <==           0.00            1.00
-{l_discount}       5603322.00     37.77 <==      11.00               1.00                0.00            1.00
-{l_extendedprice}  5603322.00     37.77 <==      494366.00           3.64 <==            0.00            1.00
-{l_orderkey}       5603322.00     37.77 <==      565838.00           14.23 <==           0.00            1.00
-{l_shipdate}       5603322.00     37.77 <==      2526.00             3.46 <==            0.00            1.00
-{l_suppkey}        5603322.00     37.77 <==      9920.00             1.00                0.00            1.00
-{n_name}           5603322.00     37.77 <==      25.00               12.50 <==           0.00            1.00
-{n_name_1}         5603322.00     37.77 <==      25.00               12.50 <==           0.00            1.00
-{n_nationkey}      5603322.00     37.77 <==      25.00               12.50 <==           0.00            1.00
-{n_nationkey_1}    5603322.00     37.77 <==      25.00               12.50 <==           0.00            1.00
-{o_custkey}        5603322.00     37.77 <==      99846.00            12.51 <==           0.00            1.00
-{o_orderkey}       5603322.00     37.77 <==      565838.00           14.23 <==           0.00            1.00
+{c_custkey}        14593924.00    98.36 <==      99846.00            12.51 <==           0.00            1.00
+{c_nationkey}      14593924.00    98.36 <==      25.00               12.50 <==           0.00            1.00
+{l_discount}       14593924.00    98.36 <==      11.00               1.00                0.00            1.00
+{l_extendedprice}  14593924.00    98.36 <==      824798.00           6.07 <==            0.00            1.00
+{l_orderkey}       14593924.00    98.36 <==      1128320.00          28.38 <==           0.00            1.00
+{l_shipdate}       14593924.00    98.36 <==      731.00              1.00                0.00            1.00
+{l_suppkey}        14593924.00    98.36 <==      9920.00             1.00                0.00            1.00
+{n_name}           14593924.00    98.36 <==      25.00               12.50 <==           0.00            1.00
+{n_name_1}         14593924.00    98.36 <==      25.00               12.50 <==           0.00            1.00
+{n_nationkey}      14593924.00    98.36 <==      25.00               12.50 <==           0.00            1.00
+{n_nationkey_1}    14593924.00    98.36 <==      25.00               12.50 <==           0.00            1.00
+{o_custkey}        14593924.00    98.36 <==      99846.00            12.51 <==           0.00            1.00
+{o_orderkey}       14593924.00    98.36 <==      1128320.00          28.38 <==           0.00            1.00
 
 stats table=q7_inner_join_6
 ----
@@ -3004,7 +3003,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {n_name}       25.00          1.00           25.00               1.00                0.00            1.00
 {n_nationkey}  25.00          1.00           25.00               1.00                0.00            1.00
 
-stats table=q7_index_join_14
+stats table=q7_select_14
 ----
 column_names       row_count  distinct_count  null_count
 {l_discount}       1828450    11              0
@@ -3014,11 +3013,27 @@ column_names       row_count  distinct_count  null_count
 {l_suppkey}        1828450    9920            0
 ~~~~
 column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{l_discount}       666802.00      2.74 <==       11.00               1.00                0.00            1.00
-{l_extendedprice}  666802.00      2.74 <==       494372.00           1.58                0.00            1.00
-{l_orderkey}       666802.00      2.74 <==       565838.00           1.13                0.00            1.00
-{l_shipdate}       666802.00      2.74 <==       2526.00             3.46 <==            0.00            1.00
-{l_suppkey}        666802.00      2.74 <==       9920.00             1.00                0.00            1.00
+{l_discount}       1736694.00     1.05           11.00               1.00                0.00            1.00
+{l_extendedprice}  1736694.00     1.05           824798.00           1.06                0.00            1.00
+{l_orderkey}       1736694.00     1.05           1128320.00          2.25 <==            0.00            1.00
+{l_shipdate}       1736694.00     1.05           731.00              1.00                0.00            1.00
+{l_suppkey}        1736694.00     1.05           9920.00             1.00                0.00            1.00
+
+stats table=q7_scan_15
+----
+column_names       row_count  distinct_count  null_count
+{l_discount}       6001215    11              0
+{l_extendedprice}  6001215    925955          0
+{l_orderkey}       6001215    1527270         0
+{l_shipdate}       6001215    2526            0
+{l_suppkey}        6001215    9920            0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_discount}       6001215.00     1.00           11.00               1.00                0.00            1.00
+{l_extendedprice}  6001215.00     1.00           925955.00           1.00                0.00            1.00
+{l_orderkey}       6001215.00     1.00           1527270.00          1.00                0.00            1.00
+{l_shipdate}       6001215.00     1.00           2526.00             1.00                0.00            1.00
+{l_suppkey}        6001215.00     1.00           9920.00             1.00                0.00            1.00
 
 stats table=q7_scan_16
 ----
@@ -3089,7 +3104,7 @@ sort
  ├── save-table-name: q8_sort_1
  ├── columns: o_year:61(int) mkt_share:66(float)
  ├── side-effects
- ├── stats: [rows=1281.96374, distinct(61)=1281.96374, null(61)=0, distinct(66)=1281.96374, null(66)=0]
+ ├── stats: [rows=717.421185, distinct(61)=717.421185, null(61)=0, distinct(66)=717.421185, null(66)=0]
  ├── key: (61)
  ├── fd: (61)-->(66)
  ├── ordering: +61
@@ -3097,38 +3112,38 @@ sort
       ├── save-table-name: q8_project_2
       ├── columns: mkt_share:66(float) o_year:61(int)
       ├── side-effects
-      ├── stats: [rows=1281.96374, distinct(61)=1281.96374, null(61)=0, distinct(66)=1281.96374, null(66)=0]
+      ├── stats: [rows=717.421185, distinct(61)=717.421185, null(61)=0, distinct(66)=717.421185, null(66)=0]
       ├── key: (61)
       ├── fd: (61)-->(66)
       ├── group-by
       │    ├── save-table-name: q8_group_by_3
       │    ├── columns: o_year:61(int) sum:64(float) sum:65(float)
       │    ├── grouping columns: o_year:61(int)
-      │    ├── stats: [rows=1281.96374, distinct(61)=1281.96374, null(61)=0, distinct(64)=1281.96374, null(64)=0, distinct(65)=1281.96374, null(65)=0, distinct(64,65)=1281.96374, null(64,65)=0]
+      │    ├── stats: [rows=717.421185, distinct(61)=717.421185, null(61)=0, distinct(64)=717.421185, null(64)=0, distinct(65)=717.421185, null(65)=0, distinct(64,65)=717.421185, null(64,65)=0]
       │    ├── key: (61)
       │    ├── fd: (61)-->(64,65)
       │    ├── project
       │    │    ├── save-table-name: q8_project_4
       │    │    ├── columns: column63:63(float) o_year:61(int) volume:62(float)
-      │    │    ├── stats: [rows=1831.05189, distinct(61)=1281.96374, null(61)=0, distinct(62)=1818.26713, null(62)=0, distinct(63)=1818.34383, null(63)=0]
+      │    │    ├── stats: [rows=2913.68612, distinct(61)=717.421185, null(61)=0, distinct(62)=2901.67246, null(62)=0, distinct(63)=2901.89538, null(63)=0]
       │    │    ├── project
       │    │    │    ├── save-table-name: q8_project_5
       │    │    │    ├── columns: o_year:61(int) volume:62(float) n2.n_name:55(char!null)
-      │    │    │    ├── stats: [rows=1831.05189, distinct(55)=24.9055527, null(55)=0, distinct(61)=1281.96374, null(61)=0, distinct(62)=1818.26713, null(62)=0, distinct(55,62)=1818.34383, null(55,62)=0]
+      │    │    │    ├── stats: [rows=2913.68612, distinct(55)=24.9055527, null(55)=0, distinct(61)=717.421185, null(61)=0, distinct(62)=2901.67246, null(62)=0, distinct(55,62)=2901.89538, null(55,62)=0]
       │    │    │    ├── inner-join
       │    │    │    │    ├── save-table-name: q8_inner_join_6
       │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(varchar!null) s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
-      │    │    │    │    ├── stats: [rows=1831.05189, distinct(1)=1333.31636, null(1)=0, distinct(5)=1, null(5)=0, distinct(10)=1672.00508, null(10)=0, distinct(13)=24.9055527, null(13)=0, distinct(17)=1812.92406, null(17)=0, distinct(18)=1333.31636, null(18)=0, distinct(19)=1672.00508, null(19)=0, distinct(22)=1817.65055, null(22)=0, distinct(23)=11, null(23)=0, distinct(33)=1812.92406, null(33)=0, distinct(34)=1806.03581, null(34)=0, distinct(37)=1281.96374, null(37)=0, distinct(42)=1806.03581, null(42)=0, distinct(45)=24.9055527, null(45)=0, distinct(50)=24.9055527, null(50)=0, distinct(52)=1, null(52)=0, distinct(54)=24.9055527, null(54)=0, distinct(55)=24.9055527, null(55)=0, distinct(58)=1, null(58)=0, distinct(59)=1, null(59)=0, distinct(22,23)=1818.26713, null(22,23)=0, distinct(22,23,55)=1818.34383, null(22,23,55)=0]
+      │    │    │    │    ├── stats: [rows=2913.68612, distinct(1)=1333.31636, null(1)=0, distinct(5)=1, null(5)=0, distinct(10)=2524.78118, null(10)=0, distinct(13)=24.9055527, null(13)=0, distinct(17)=2896.85285, null(17)=0, distinct(18)=1333.31636, null(18)=0, distinct(19)=2524.78118, null(19)=0, distinct(22)=2899.70087, null(22)=0, distinct(23)=11, null(23)=0, distinct(33)=2896.85285, null(33)=0, distinct(34)=2870.3294, null(34)=0, distinct(37)=717.421185, null(37)=0, distinct(42)=2870.3294, null(42)=0, distinct(45)=24.9055527, null(45)=0, distinct(50)=24.9055527, null(50)=0, distinct(52)=1, null(52)=0, distinct(54)=24.9055527, null(54)=0, distinct(55)=24.9055527, null(55)=0, distinct(58)=1, null(58)=0, distinct(59)=1, null(59)=0, distinct(22,23)=2901.67246, null(22,23)=0, distinct(22,23,55)=2901.89538, null(22,23,55)=0]
       │    │    │    │    ├── fd: ()-->(5,59), (10)-->(13), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (10)==(19), (19)==(10), (13)==(54), (54)==(13), (1)==(18), (18)==(1)
       │    │    │    │    ├── inner-join
       │    │    │    │    │    ├── save-table-name: q8_inner_join_7
       │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
-      │    │    │    │    │    ├── stats: [rows=133870.058, distinct(10)=9920, null(10)=0, distinct(13)=24.9055527, null(13)=0, distinct(17)=91816.9257, null(17)=0, distinct(18)=97481.3502, null(18)=0, distinct(19)=9920, null(19)=0, distinct(22)=124392.739, null(22)=0, distinct(23)=11, null(23)=0, distinct(33)=91816.9257, null(33)=0, distinct(34)=66375.7026, null(34)=0, distinct(37)=2406, null(37)=0, distinct(42)=66375.7026, null(42)=0, distinct(45)=24.9055527, null(45)=0, distinct(50)=24.9055527, null(50)=0, distinct(52)=1, null(52)=0, distinct(54)=24.9055527, null(54)=0, distinct(55)=24.9055527, null(55)=0, distinct(58)=1, null(58)=0, distinct(59)=1, null(59)=0, distinct(22,23)=130416.966, null(22,23)=0, distinct(22,23,55)=131207.238, null(22,23,55)=0]
+      │    │    │    │    │    ├── stats: [rows=366056.156, distinct(10)=9920, null(10)=0, distinct(13)=24.9055527, null(13)=0, distinct(17)=251065.484, null(17)=0, distinct(18)=167511.137, null(18)=0, distinct(19)=9920, null(19)=0, distinct(22)=302359.731, null(22)=0, distinct(23)=11, null(23)=0, distinct(33)=251065.484, null(33)=0, distinct(34)=96910.9844, null(34)=0, distinct(37)=731, null(37)=0, distinct(42)=96910.9844, null(42)=0, distinct(45)=24.9055527, null(45)=0, distinct(50)=24.9055527, null(50)=0, distinct(52)=1, null(52)=0, distinct(54)=24.9055527, null(54)=0, distinct(55)=24.9055527, null(55)=0, distinct(58)=1, null(58)=0, distinct(59)=1, null(59)=0, distinct(22,23)=352104.347, null(22,23)=0, distinct(22,23,55)=358774.904, null(22,23,55)=0]
       │    │    │    │    │    ├── fd: ()-->(59), (10)-->(13), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (10)==(19), (19)==(10), (13)==(54), (54)==(13)
       │    │    │    │    │    ├── inner-join
       │    │    │    │    │    │    ├── save-table-name: q8_inner_join_8
       │    │    │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
-      │    │    │    │    │    │    ├── stats: [rows=3319977.44, distinct(17)=165619.065, null(17)=0, distinct(18)=199240.988, null(18)=0, distinct(19)=9920, null(19)=0, distinct(22)=900284.014, null(22)=0, distinct(23)=11, null(23)=0, distinct(33)=165619.065, null(33)=0, distinct(34)=82829.9251, null(34)=0, distinct(37)=2406, null(37)=0, distinct(42)=82829.9251, null(42)=0, distinct(45)=24.9055527, null(45)=0, distinct(50)=24.9055527, null(50)=0, distinct(52)=1, null(52)=0, distinct(54)=24.9055527, null(54)=0, distinct(55)=24.9055527, null(55)=0, distinct(58)=1, null(58)=0, distinct(59)=1, null(59)=0, distinct(22,23)=2549938.3, null(22,23)=0, distinct(22,23,55)=3319977.44, null(22,23,55)=0]
+      │    │    │    │    │    │    ├── stats: [rows=9078192.67, distinct(17)=452871.085, null(17)=0, distinct(18)=199241, null(18)=0, distinct(19)=9920, null(19)=0, distinct(22)=925903.867, null(22)=0, distinct(23)=11, null(23)=0, distinct(33)=452871.085, null(33)=0, distinct(34)=99413.0082, null(34)=0, distinct(37)=731, null(37)=0, distinct(42)=99413.0082, null(42)=0, distinct(45)=24.9055527, null(45)=0, distinct(50)=24.9055527, null(50)=0, distinct(52)=1, null(52)=0, distinct(54)=24.9055527, null(54)=0, distinct(55)=24.9055527, null(55)=0, distinct(58)=1, null(58)=0, distinct(59)=1, null(59)=0, distinct(22,23)=4679096.11, null(22,23)=0, distinct(22,23,55)=9078192.67, null(22,23,55)=0]
       │    │    │    │    │    │    ├── fd: ()-->(59), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17)
       │    │    │    │    │    │    ├── scan lineitem
       │    │    │    │    │    │    │    ├── save-table-name: q8_scan_9
@@ -3137,7 +3152,7 @@ sort
       │    │    │    │    │    │    ├── inner-join
       │    │    │    │    │    │    │    ├── save-table-name: q8_inner_join_10
       │    │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
-      │    │    │    │    │    │    │    ├── stats: [rows=844912.563, distinct(33)=165619.065, null(33)=0, distinct(34)=82829.9251, null(34)=0, distinct(37)=2406, null(37)=0, distinct(42)=82829.9251, null(42)=0, distinct(45)=24.9055527, null(45)=0, distinct(50)=24.9055527, null(50)=0, distinct(52)=1, null(52)=0, distinct(54)=24.9055527, null(54)=0, distinct(55)=24.9055527, null(55)=0, distinct(58)=1, null(58)=0, distinct(59)=1, null(59)=0]
+      │    │    │    │    │    │    │    ├── stats: [rows=2310340.71, distinct(33)=452871.085, null(33)=0, distinct(34)=99413.0082, null(34)=0, distinct(37)=731, null(37)=0, distinct(42)=99413.0082, null(42)=0, distinct(45)=24.9055527, null(45)=0, distinct(50)=24.9055527, null(50)=0, distinct(52)=1, null(52)=0, distinct(54)=24.9055527, null(54)=0, distinct(55)=24.9055527, null(55)=0, distinct(58)=1, null(58)=0, distinct(59)=1, null(59)=0]
       │    │    │    │    │    │    │    ├── key: (33,54)
       │    │    │    │    │    │    │    ├── fd: ()-->(59), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34)
       │    │    │    │    │    │    │    ├── inner-join
@@ -3183,19 +3198,20 @@ sort
       │    │    │    │    │    │    │    │    │    ├── key: (54)
       │    │    │    │    │    │    │    │    │    └── fd: (54)-->(55)
       │    │    │    │    │    │    │    │    └── filters (true)
-      │    │    │    │    │    │    │    ├── index-join orders
-      │    │    │    │    │    │    │    │    ├── save-table-name: q8_index_join_17
+      │    │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    │    ├── save-table-name: q8_select_17
       │    │    │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null)
-      │    │    │    │    │    │    │    │    ├── stats: [rows=166666.667, distinct(33)=166666.667, null(33)=0, distinct(34)=82829.9251, null(34)=0, distinct(37)=2406, null(37)=0]
+      │    │    │    │    │    │    │    │    ├── stats: [rows=455735.661, distinct(33)=455735.661, null(33)=0, distinct(34)=99413.0082, null(34)=0, distinct(37)=731, null(37)=0]
       │    │    │    │    │    │    │    │    ├── key: (33)
       │    │    │    │    │    │    │    │    ├── fd: (33)-->(34,37)
-      │    │    │    │    │    │    │    │    └── scan orders@o_od
-      │    │    │    │    │    │    │    │         ├── save-table-name: q8_scan_18
-      │    │    │    │    │    │    │    │         ├── columns: o_orderkey:33(int!null) o_orderdate:37(date!null)
-      │    │    │    │    │    │    │    │         ├── constraint: /37/33: [/'1995-01-01' - /'1996-12-31']
-      │    │    │    │    │    │    │    │         ├── stats: [rows=166666.667, distinct(33)=166666.667, null(33)=0, distinct(37)=2406, null(37)=0]
-      │    │    │    │    │    │    │    │         ├── key: (33)
-      │    │    │    │    │    │    │    │         └── fd: (33)-->(37)
+      │    │    │    │    │    │    │    │    ├── scan orders
+      │    │    │    │    │    │    │    │    │    ├── save-table-name: q8_scan_18
+      │    │    │    │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null)
+      │    │    │    │    │    │    │    │    │    ├── stats: [rows=1500000, distinct(33)=1500000, null(33)=0, distinct(34)=99846, null(34)=0, distinct(37)=2406, null(37)=0]
+      │    │    │    │    │    │    │    │    │    ├── key: (33)
+      │    │    │    │    │    │    │    │    │    └── fd: (33)-->(34,37)
+      │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │    │         └── (o_orderdate >= '1995-01-01') AND (o_orderdate <= '1996-12-31') [type=bool, outer=(37), constraints=(/37: [/'1995-01-01' - /'1996-12-31']; tight)]
       │    │    │    │    │    │    │    └── filters
       │    │    │    │    │    │    │         └── o_custkey = c_custkey [type=bool, outer=(34,42), constraints=(/34: (/NULL - ]; /42: (/NULL - ]), fd=(34)==(42), (42)==(34)]
       │    │    │    │    │    │    └── filters
@@ -3245,8 +3261,8 @@ column_names  row_count  distinct_count  null_count
 {o_year}      2          2               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{mkt_share}   1282.00        641.00 <==     1282.00             641.00 <==          0.00            1.00
-{o_year}      1282.00        641.00 <==     1282.00             641.00 <==          0.00            1.00
+{mkt_share}   717.00         358.50 <==     717.00              358.50 <==          0.00            1.00
+{o_year}      717.00         358.50 <==     717.00              358.50 <==          0.00            1.00
 
 stats table=q8_project_2
 ----
@@ -3255,8 +3271,8 @@ column_names  row_count  distinct_count  null_count
 {o_year}      2          2               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{mkt_share}   1282.00        641.00 <==     1282.00             641.00 <==          0.00            1.00
-{o_year}      1282.00        641.00 <==     1282.00             641.00 <==          0.00            1.00
+{mkt_share}   717.00         358.50 <==     717.00              358.50 <==          0.00            1.00
+{o_year}      717.00         358.50 <==     717.00              358.50 <==          0.00            1.00
 
 stats table=q8_group_by_3
 ----
@@ -3266,9 +3282,9 @@ column_names  row_count  distinct_count  null_count
 {sum}         2          2               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{o_year}      1282.00        641.00 <==     1282.00             641.00 <==          0.00            1.00
-{sum}         1282.00        641.00 <==     1282.00             641.00 <==          0.00            1.00
-{sum_1}       1282.00        641.00 <==     1282.00             641.00 <==          0.00            1.00
+{o_year}      717.00         358.50 <==     717.00              358.50 <==          0.00            1.00
+{sum}         717.00         358.50 <==     717.00              358.50 <==          0.00            1.00
+{sum_1}       717.00         358.50 <==     717.00              358.50 <==          0.00            1.00
 
 stats table=q8_project_4
 ----
@@ -3278,9 +3294,9 @@ column_names  row_count  distinct_count  null_count
 {volume}      2603       2599            0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{column63}    1831.00        1.42           1818.00             16.83 <==           0.00            1.00
-{o_year}      1831.00        1.42           1282.00             641.00 <==          0.00            1.00
-{volume}      1831.00        1.42           1818.00             1.43                0.00            1.00
+{column63}    2914.00        1.12           2902.00             26.87 <==           0.00            1.00
+{o_year}      2914.00        1.12           717.00              358.50 <==          0.00            1.00
+{volume}      2914.00        1.12           2902.00             1.12                0.00            1.00
 
 stats table=q8_project_5
 ----
@@ -3290,9 +3306,9 @@ column_names  row_count  distinct_count  null_count
 {volume}      2603       2599            0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{n_name}      1831.00        1.42           25.00               1.00                0.00            1.00
-{o_year}      1831.00        1.42           1282.00             641.00 <==          0.00            1.00
-{volume}      1831.00        1.42           1818.00             1.43                0.00            1.00
+{n_name}      2914.00        1.12           25.00               1.00                0.00            1.00
+{o_year}      2914.00        1.12           717.00              358.50 <==          0.00            1.00
+{volume}      2914.00        1.12           2902.00             1.12                0.00            1.00
 
 stats table=q8_inner_join_6
 ----
@@ -3319,26 +3335,26 @@ column_names       row_count  distinct_count  null_count
 {s_suppkey}        2603       1895            0
 ~~~~
 column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{c_custkey}        1831.00        1.42           1806.00             1.32                0.00            1.00
-{c_nationkey}      1831.00        1.42           25.00               5.00 <==            0.00            1.00
-{l_discount}       1831.00        1.42           11.00               1.00                0.00            1.00
-{l_extendedprice}  1831.00        1.42           1818.00             1.40                0.00            1.00
-{l_orderkey}       1831.00        1.42           1813.00             1.42                0.00            1.00
-{l_partkey}        1831.00        1.42           1333.00             1.09                0.00            1.00
-{l_suppkey}        1831.00        1.42           1672.00             1.13                0.00            1.00
-{n_name}           1831.00        1.42           25.00               1.00                0.00            1.00
-{n_nationkey}      1831.00        1.42           25.00               5.00 <==            0.00            1.00
-{n_nationkey_1}    1831.00        1.42           25.00               1.00                0.00            1.00
-{n_regionkey}      1831.00        1.42           1.00                1.00                0.00            1.00
-{o_custkey}        1831.00        1.42           1806.00             1.32                0.00            1.00
-{o_orderdate}      1831.00        1.42           1282.00             1.81                0.00            1.00
-{o_orderkey}       1831.00        1.42           1813.00             1.42                0.00            1.00
-{p_partkey}        1831.00        1.42           1333.00             1.09                0.00            1.00
-{p_type}           1831.00        1.42           1.00                1.00                0.00            1.00
-{r_name}           1831.00        1.42           1.00                1.00                0.00            1.00
-{r_regionkey}      1831.00        1.42           1.00                1.00                0.00            1.00
-{s_nationkey}      1831.00        1.42           25.00               1.00                0.00            1.00
-{s_suppkey}        1831.00        1.42           1672.00             1.13                0.00            1.00
+{c_custkey}        2914.00        1.12           2870.00             1.20                0.00            1.00
+{c_nationkey}      2914.00        1.12           25.00               5.00 <==            0.00            1.00
+{l_discount}       2914.00        1.12           11.00               1.00                0.00            1.00
+{l_extendedprice}  2914.00        1.12           2900.00             1.14                0.00            1.00
+{l_orderkey}       2914.00        1.12           2897.00             1.13                0.00            1.00
+{l_partkey}        2914.00        1.12           1333.00             1.09                0.00            1.00
+{l_suppkey}        2914.00        1.12           2525.00             1.33                0.00            1.00
+{n_name}           2914.00        1.12           25.00               1.00                0.00            1.00
+{n_nationkey}      2914.00        1.12           25.00               5.00 <==            0.00            1.00
+{n_nationkey_1}    2914.00        1.12           25.00               1.00                0.00            1.00
+{n_regionkey}      2914.00        1.12           1.00                1.00                0.00            1.00
+{o_custkey}        2914.00        1.12           2870.00             1.20                0.00            1.00
+{o_orderdate}      2914.00        1.12           717.00              1.01                0.00            1.00
+{o_orderkey}       2914.00        1.12           2897.00             1.13                0.00            1.00
+{p_partkey}        2914.00        1.12           1333.00             1.09                0.00            1.00
+{p_type}           2914.00        1.12           1.00                1.00                0.00            1.00
+{r_name}           2914.00        1.12           1.00                1.00                0.00            1.00
+{r_regionkey}      2914.00        1.12           1.00                1.00                0.00            1.00
+{s_nationkey}      2914.00        1.12           25.00               1.00                0.00            1.00
+{s_suppkey}        2914.00        1.12           2525.00             1.33                0.00            1.00
 
 stats table=q8_inner_join_7
 ----
@@ -3363,24 +3379,24 @@ column_names       row_count  distinct_count  null_count
 {s_suppkey}        365091     9920            0
 ~~~~
 column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{c_custkey}        133870.00      2.73 <==       66376.00            3.40 <==            0.00            1.00
-{c_nationkey}      133870.00      2.73 <==       25.00               5.00 <==            0.00            1.00
-{l_discount}       133870.00      2.73 <==       11.00               1.00                0.00            1.00
-{l_extendedprice}  133870.00      2.73 <==       124393.00           2.41 <==            0.00            1.00
-{l_orderkey}       133870.00      2.73 <==       91817.00            1.00                0.00            1.00
-{l_partkey}        133870.00      2.73 <==       97481.00            1.72                0.00            1.00
-{l_suppkey}        133870.00      2.73 <==       9920.00             1.00                0.00            1.00
-{n_name}           133870.00      2.73 <==       25.00               1.00                0.00            1.00
-{n_nationkey}      133870.00      2.73 <==       25.00               5.00 <==            0.00            1.00
-{n_nationkey_1}    133870.00      2.73 <==       25.00               1.00                0.00            1.00
-{n_regionkey}      133870.00      2.73 <==       1.00                1.00                0.00            1.00
-{o_custkey}        133870.00      2.73 <==       66376.00            3.40 <==            0.00            1.00
-{o_orderdate}      133870.00      2.73 <==       2406.00             3.29 <==            0.00            1.00
-{o_orderkey}       133870.00      2.73 <==       91817.00            1.00                0.00            1.00
-{r_name}           133870.00      2.73 <==       1.00                1.00                0.00            1.00
-{r_regionkey}      133870.00      2.73 <==       1.00                1.00                0.00            1.00
-{s_nationkey}      133870.00      2.73 <==       25.00               1.00                0.00            1.00
-{s_suppkey}        133870.00      2.73 <==       9920.00             1.00                0.00            1.00
+{c_custkey}        366056.00      1.00           96911.00            4.96 <==            0.00            1.00
+{c_nationkey}      366056.00      1.00           25.00               5.00 <==            0.00            1.00
+{l_discount}       366056.00      1.00           11.00               1.00                0.00            1.00
+{l_extendedprice}  366056.00      1.00           302360.00           1.01                0.00            1.00
+{l_orderkey}       366056.00      1.00           251065.00           2.73 <==            0.00            1.00
+{l_partkey}        366056.00      1.00           167511.00           1.00                0.00            1.00
+{l_suppkey}        366056.00      1.00           9920.00             1.00                0.00            1.00
+{n_name}           366056.00      1.00           25.00               1.00                0.00            1.00
+{n_nationkey}      366056.00      1.00           25.00               5.00 <==            0.00            1.00
+{n_nationkey_1}    366056.00      1.00           25.00               1.00                0.00            1.00
+{n_regionkey}      366056.00      1.00           1.00                1.00                0.00            1.00
+{o_custkey}        366056.00      1.00           96911.00            4.96 <==            0.00            1.00
+{o_orderdate}      366056.00      1.00           731.00              1.00                0.00            1.00
+{o_orderkey}       366056.00      1.00           251065.00           2.73 <==            0.00            1.00
+{r_name}           366056.00      1.00           1.00                1.00                0.00            1.00
+{r_regionkey}      366056.00      1.00           1.00                1.00                0.00            1.00
+{s_nationkey}      366056.00      1.00           25.00               1.00                0.00            1.00
+{s_suppkey}        366056.00      1.00           9920.00             1.00                0.00            1.00
 
 stats table=q8_inner_join_8
 ----
@@ -3403,22 +3419,22 @@ column_names       row_count  distinct_count  null_count
 {r_regionkey}      9127275    1               0
 ~~~~
 column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{c_custkey}        3319977.00     2.75 <==       82830.00            4.24 <==            0.00            1.00
-{c_nationkey}      3319977.00     2.75 <==       25.00               5.00 <==            0.00            1.00
-{l_discount}       3319977.00     2.75 <==       11.00               1.00                0.00            1.00
-{l_extendedprice}  3319977.00     2.75 <==       900284.00           3.01 <==            0.00            1.00
-{l_orderkey}       3319977.00     2.75 <==       165619.00           1.80                0.00            1.00
-{l_partkey}        3319977.00     2.75 <==       199241.00           1.19                0.00            1.00
-{l_suppkey}        3319977.00     2.75 <==       9920.00             1.00                0.00            1.00
-{n_name}           3319977.00     2.75 <==       25.00               1.00                0.00            1.00
-{n_nationkey}      3319977.00     2.75 <==       25.00               5.00 <==            0.00            1.00
-{n_nationkey_1}    3319977.00     2.75 <==       25.00               1.00                0.00            1.00
-{n_regionkey}      3319977.00     2.75 <==       1.00                1.00                0.00            1.00
-{o_custkey}        3319977.00     2.75 <==       82830.00            4.24 <==            0.00            1.00
-{o_orderdate}      3319977.00     2.75 <==       2406.00             3.29 <==            0.00            1.00
-{o_orderkey}       3319977.00     2.75 <==       165619.00           1.80                0.00            1.00
-{r_name}           3319977.00     2.75 <==       1.00                1.00                0.00            1.00
-{r_regionkey}      3319977.00     2.75 <==       1.00                1.00                0.00            1.00
+{c_custkey}        9078193.00     1.01           99413.00            5.09 <==            0.00            1.00
+{c_nationkey}      9078193.00     1.01           25.00               5.00 <==            0.00            1.00
+{l_discount}       9078193.00     1.01           11.00               1.00                0.00            1.00
+{l_extendedprice}  9078193.00     1.01           925904.00           3.09 <==            0.00            1.00
+{l_orderkey}       9078193.00     1.01           452871.00           4.92 <==            0.00            1.00
+{l_partkey}        9078193.00     1.01           199241.00           1.19                0.00            1.00
+{l_suppkey}        9078193.00     1.01           9920.00             1.00                0.00            1.00
+{n_name}           9078193.00     1.01           25.00               1.00                0.00            1.00
+{n_nationkey}      9078193.00     1.01           25.00               5.00 <==            0.00            1.00
+{n_nationkey_1}    9078193.00     1.01           25.00               1.00                0.00            1.00
+{n_regionkey}      9078193.00     1.01           1.00                1.00                0.00            1.00
+{o_custkey}        9078193.00     1.01           99413.00            5.09 <==            0.00            1.00
+{o_orderdate}      9078193.00     1.01           731.00              1.00                0.00            1.00
+{o_orderkey}       9078193.00     1.01           452871.00           4.92 <==            0.00            1.00
+{r_name}           9078193.00     1.01           1.00                1.00                0.00            1.00
+{r_regionkey}      9078193.00     1.01           1.00                1.00                0.00            1.00
 
 stats table=q8_scan_9
 ----
@@ -3452,17 +3468,17 @@ column_names     row_count  distinct_count  null_count
 {r_regionkey}    2279475    1               0
 ~~~~
 column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{c_custkey}      844913.00      2.70 <==       82830.00            4.24 <==            0.00            1.00
-{c_nationkey}    844913.00      2.70 <==       25.00               5.00 <==            0.00            1.00
-{n_name}         844913.00      2.70 <==       25.00               1.00                0.00            1.00
-{n_nationkey}    844913.00      2.70 <==       25.00               5.00 <==            0.00            1.00
-{n_nationkey_1}  844913.00      2.70 <==       25.00               1.00                0.00            1.00
-{n_regionkey}    844913.00      2.70 <==       1.00                1.00                0.00            1.00
-{o_custkey}      844913.00      2.70 <==       82830.00            4.24 <==            0.00            1.00
-{o_orderdate}    844913.00      2.70 <==       2406.00             3.29 <==            0.00            1.00
-{o_orderkey}     844913.00      2.70 <==       165619.00           1.80                0.00            1.00
-{r_name}         844913.00      2.70 <==       1.00                1.00                0.00            1.00
-{r_regionkey}    844913.00      2.70 <==       1.00                1.00                0.00            1.00
+{c_custkey}      2310341.00     1.01           99413.00            5.09 <==            0.00            1.00
+{c_nationkey}    2310341.00     1.01           25.00               5.00 <==            0.00            1.00
+{n_name}         2310341.00     1.01           25.00               1.00                0.00            1.00
+{n_nationkey}    2310341.00     1.01           25.00               5.00 <==            0.00            1.00
+{n_nationkey_1}  2310341.00     1.01           25.00               1.00                0.00            1.00
+{n_regionkey}    2310341.00     1.01           1.00                1.00                0.00            1.00
+{o_custkey}      2310341.00     1.01           99413.00            5.09 <==            0.00            1.00
+{o_orderdate}    2310341.00     1.01           731.00              1.00                0.00            1.00
+{o_orderkey}     2310341.00     1.01           452871.00           4.92 <==            0.00            1.00
+{r_name}         2310341.00     1.01           1.00                1.00                0.00            1.00
+{r_regionkey}    2310341.00     1.01           1.00                1.00                0.00            1.00
 
 stats table=q8_inner_join_11
 ----
@@ -3548,7 +3564,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {n_name}       25.00          1.00           25.00               1.00                0.00            1.00
 {n_nationkey}  25.00          1.00           25.00               1.00                0.00            1.00
 
-stats table=q8_index_join_17
+stats table=q8_select_17
 ----
 column_names   row_count  distinct_count  null_count
 {o_custkey}    457263     97345           0
@@ -3556,9 +3572,21 @@ column_names   row_count  distinct_count  null_count
 {o_orderkey}   457263     463903          0
 ~~~~
 column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{o_custkey}    166667.00      2.74 <==       82830.00            1.18                0.00            1.00
-{o_orderdate}  166667.00      2.74 <==       2406.00             3.29 <==            0.00            1.00
-{o_orderkey}   166667.00      2.74 <==       166667.00           2.78 <==            0.00            1.00
+{o_custkey}    455736.00      1.00           99413.00            1.02                0.00            1.00
+{o_orderdate}  455736.00      1.00           731.00              1.00                0.00            1.00
+{o_orderkey}   455736.00      1.00           455736.00           1.02                0.00            1.00
+
+stats table=q8_scan_18
+----
+column_names   row_count  distinct_count  null_count
+{o_custkey}    1500000    99846           0
+{o_orderdate}  1500000    2406            0
+{o_orderkey}   1500000    1527270         0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{o_custkey}    1500000.00     1.00           99846.00            1.00                0.00            1.00
+{o_orderdate}  1500000.00     1.00           2406.00             1.00                0.00            1.00
+{o_orderkey}   1500000.00     1.00           1500000.00          1.02                0.00            1.00
 
 stats table=q8_scan_19
 ----
@@ -4038,7 +4066,7 @@ limit
  ├── sort
  │    ├── save-table-name: q10_sort_2
  │    ├── columns: c_custkey:1(int!null) c_name:2(varchar) c_address:3(varchar) c_phone:5(char) c_acctbal:6(float) c_comment:8(varchar) n_name:35(char) sum:39(float)
- │    ├── stats: [rows=82829.9251, distinct(1)=82829.9251, null(1)=0, distinct(2)=82829.9251, null(2)=0, distinct(3)=82829.9251, null(3)=0, distinct(5)=82829.9251, null(5)=0, distinct(6)=82829.9251, null(6)=0, distinct(8)=82829.9251, null(8)=0, distinct(35)=82829.9251, null(35)=0, distinct(39)=82829.9251, null(39)=0]
+ │    ├── stats: [rows=44261.346, distinct(1)=44261.346, null(1)=0, distinct(2)=44261.346, null(2)=0, distinct(3)=44261.346, null(3)=0, distinct(5)=44261.346, null(5)=0, distinct(6)=44261.346, null(6)=0, distinct(8)=44261.346, null(8)=0, distinct(35)=44261.346, null(35)=0, distinct(39)=44261.346, null(39)=0]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3,5,6,8,35,39)
  │    ├── ordering: -39
@@ -4046,62 +4074,61 @@ limit
  │         ├── save-table-name: q10_group_by_3
  │         ├── columns: c_custkey:1(int!null) c_name:2(varchar) c_address:3(varchar) c_phone:5(char) c_acctbal:6(float) c_comment:8(varchar) n_name:35(char) sum:39(float)
  │         ├── grouping columns: c_custkey:1(int!null)
- │         ├── stats: [rows=82829.9251, distinct(1)=82829.9251, null(1)=0, distinct(2)=82829.9251, null(2)=0, distinct(3)=82829.9251, null(3)=0, distinct(5)=82829.9251, null(5)=0, distinct(6)=82829.9251, null(6)=0, distinct(8)=82829.9251, null(8)=0, distinct(35)=82829.9251, null(35)=0, distinct(39)=82829.9251, null(39)=0]
+ │         ├── stats: [rows=44261.346, distinct(1)=44261.346, null(1)=0, distinct(2)=44261.346, null(2)=0, distinct(3)=44261.346, null(3)=0, distinct(5)=44261.346, null(5)=0, distinct(6)=44261.346, null(6)=0, distinct(8)=44261.346, null(8)=0, distinct(35)=44261.346, null(35)=0, distinct(39)=44261.346, null(39)=0]
  │         ├── key: (1)
  │         ├── fd: (1)-->(2,3,5,6,8,35,39)
  │         ├── project
  │         │    ├── save-table-name: q10_project_4
  │         │    ├── columns: column38:38(float) c_custkey:1(int!null) c_name:2(varchar!null) c_address:3(varchar!null) c_phone:5(char!null) c_acctbal:6(float!null) c_comment:8(varchar!null) n_name:35(char!null)
- │         │    ├── stats: [rows=276178.358, distinct(1)=82829.9251, null(1)=0, distinct(2)=126205.701, null(2)=0, distinct(3)=126171.088, null(3)=0, distinct(5)=126205.701, null(5)=0, distinct(6)=120896.334, null(6)=0, distinct(8)=125832.998, null(8)=0, distinct(35)=25, null(35)=0, distinct(38)=10827.3939, null(38)=0]
+ │         │    ├── stats: [rows=95043.9237, distinct(1)=44261.346, null(1)=0, distinct(2)=70400.4013, null(2)=0, distinct(3)=70392.0136, null(3)=0, distinct(5)=70400.4013, null(5)=0, distinct(6)=69087.4422, null(6)=0, distinct(8)=70309.9705, null(8)=0, distinct(35)=25, null(35)=0, distinct(38)=0.638676927, null(38)=0]
  │         │    ├── fd: (1)-->(2,3,5,6,8,35)
  │         │    ├── inner-join
  │         │    │    ├── save-table-name: q10_inner_join_5
  │         │    │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) c_address:3(varchar!null) c_nationkey:4(int!null) c_phone:5(char!null) c_acctbal:6(float!null) c_comment:8(varchar!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(char!null) n_nationkey:34(int!null) n_name:35(char!null)
- │         │    │    ├── stats: [rows=276178.358, distinct(1)=82829.9251, null(1)=0, distinct(2)=126205.701, null(2)=0, distinct(3)=126171.088, null(3)=0, distinct(4)=25, null(4)=0, distinct(5)=126205.701, null(5)=0, distinct(6)=120896.334, null(6)=0, distinct(8)=125832.998, null(8)=0, distinct(9)=134883.861, null(9)=0, distinct(10)=82829.9251, null(10)=0, distinct(13)=2406, null(13)=0, distinct(18)=134883.861, null(18)=0, distinct(23)=236170.675, null(23)=0, distinct(24)=11, null(24)=0, distinct(26)=1, null(26)=0, distinct(34)=25, null(34)=0, distinct(35)=25, null(35)=0, distinct(23,24)=10827.3939, null(23,24)=0]
+ │         │    │    ├── stats: [rows=95043.9237, distinct(1)=44261.346, null(1)=0, distinct(2)=70400.4013, null(2)=0, distinct(3)=70392.0136, null(3)=0, distinct(4)=25, null(4)=0, distinct(5)=70400.4013, null(5)=0, distinct(6)=69087.4422, null(6)=0, distinct(8)=70309.9705, null(8)=0, distinct(9)=46418.8849, null(9)=0, distinct(10)=44261.346, null(10)=0, distinct(13)=92, null(13)=0, distinct(18)=46418.8849, null(18)=0, distinct(23)=89640.0074, null(23)=0, distinct(24)=11, null(24)=0, distinct(26)=1, null(26)=0, distinct(34)=25, null(34)=0, distinct(35)=25, null(35)=0, distinct(23,24)=0.638676927, null(23,24)=0]
  │         │    │    ├── fd: ()-->(26), (1)-->(2-6,8), (9)-->(10,13), (34)-->(35), (9)==(18), (18)==(9), (1)==(10), (10)==(1), (4)==(34), (34)==(4)
- │         │    │    ├── inner-join (lookup lineitem)
- │         │    │    │    ├── save-table-name: q10_lookup_join_6
- │         │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(char!null)
- │         │    │    │    ├── key columns: [9] = [18]
- │         │    │    │    ├── stats: [rows=273992.867, distinct(9)=166666.667, null(9)=0, distinct(10)=79798.93, null(10)=0, distinct(13)=2406, null(13)=0, distinct(18)=166666.667, null(18)=0, distinct(23)=234596.457, null(23)=0, distinct(24)=11, null(24)=0, distinct(26)=1, null(26)=0, distinct(23,24)=273992.867, null(23,24)=0]
- │         │    │    │    ├── fd: ()-->(26), (9)-->(10,13), (9)==(18), (18)==(9)
- │         │    │    │    ├── index-join orders
- │         │    │    │    │    ├── save-table-name: q10_index_join_7
- │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null)
- │         │    │    │    │    ├── stats: [rows=166666.667, distinct(9)=166666.667, null(9)=0, distinct(10)=82829.9251, null(10)=0, distinct(13)=2406, null(13)=0]
- │         │    │    │    │    ├── key: (9)
- │         │    │    │    │    ├── fd: (9)-->(10,13)
- │         │    │    │    │    └── scan orders@o_od
- │         │    │    │    │         ├── save-table-name: q10_scan_8
- │         │    │    │    │         ├── columns: o_orderkey:9(int!null) o_orderdate:13(date!null)
- │         │    │    │    │         ├── constraint: /13/9: [/'1993-10-01' - /'1993-12-31']
- │         │    │    │    │         ├── stats: [rows=166666.667, distinct(9)=166666.667, null(9)=0, distinct(13)=2406, null(13)=0]
- │         │    │    │    │         ├── key: (9)
- │         │    │    │    │         └── fd: (9)-->(13)
- │         │    │    │    └── filters
- │         │    │    │         └── l_returnflag = 'R' [type=bool, outer=(26), constraints=(/26: [/'R' - /'R']; tight), fd=()-->(26)]
  │         │    │    ├── inner-join
- │         │    │    │    ├── save-table-name: q10_inner_join_9
- │         │    │    │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) c_address:3(varchar!null) c_nationkey:4(int!null) c_phone:5(char!null) c_acctbal:6(float!null) c_comment:8(varchar!null) n_nationkey:34(int!null) n_name:35(char!null)
- │         │    │    │    ├── stats: [rows=150000, distinct(1)=95616.0932, null(1)=0, distinct(2)=95940.4925, null(2)=0, distinct(3)=95923.3641, null(3)=0, distinct(4)=25, null(4)=0, distinct(5)=95940.4925, null(5)=0, distinct(6)=93278.5687, null(6)=0, distinct(8)=95755.9084, null(8)=0, distinct(34)=25, null(34)=0, distinct(35)=25, null(35)=0]
- │         │    │    │    ├── key: (1)
- │         │    │    │    ├── fd: (34)-->(35), (1)-->(2-6,8), (4)==(34), (34)==(4)
+ │         │    │    │    ├── save-table-name: q10_inner_join_6
+ │         │    │    │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) c_address:3(varchar!null) c_nationkey:4(int!null) c_phone:5(char!null) c_acctbal:6(float!null) c_comment:8(varchar!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(char!null)
+ │         │    │    │    ├── stats: [rows=95043.9237, distinct(1)=39003.2512, null(1)=0, distinct(2)=70400.564, null(2)=0, distinct(3)=70392.1763, null(3)=0, distinct(4)=25, null(4)=0, distinct(5)=70400.564, null(5)=0, distinct(6)=69087.5981, null(6)=0, distinct(8)=70310.1327, null(8)=0, distinct(9)=46418.9433, null(9)=0, distinct(10)=39003.2512, null(10)=0, distinct(13)=92, null(13)=0, distinct(18)=46418.9433, null(18)=0, distinct(23)=58495.4099, null(23)=0, distinct(24)=11, null(24)=0, distinct(26)=1, null(26)=0, distinct(23,24)=59879.4946, null(23,24)=0]
+ │         │    │    │    ├── fd: ()-->(26), (9)-->(10,13), (9)==(18), (18)==(9), (1)-->(2-6,8), (1)==(10), (10)==(1)
  │         │    │    │    ├── scan customer
- │         │    │    │    │    ├── save-table-name: q10_scan_10
+ │         │    │    │    │    ├── save-table-name: q10_scan_7
  │         │    │    │    │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) c_address:3(varchar!null) c_nationkey:4(int!null) c_phone:5(char!null) c_acctbal:6(float!null) c_comment:8(varchar!null)
  │         │    │    │    │    ├── stats: [rows=150000, distinct(1)=148813, null(1)=0, distinct(2)=150000, null(2)=0, distinct(3)=149937, null(3)=0, distinct(4)=25, null(4)=0, distinct(5)=150000, null(5)=0, distinct(6)=140628, null(6)=0, distinct(8)=149323, null(8)=0]
  │         │    │    │    │    ├── key: (1)
  │         │    │    │    │    └── fd: (1)-->(2-6,8)
- │         │    │    │    ├── scan nation
- │         │    │    │    │    ├── save-table-name: q10_scan_11
- │         │    │    │    │    ├── columns: n_nationkey:34(int!null) n_name:35(char!null)
- │         │    │    │    │    ├── stats: [rows=25, distinct(34)=25, null(34)=0, distinct(35)=25, null(35)=0]
- │         │    │    │    │    ├── key: (34)
- │         │    │    │    │    └── fd: (34)-->(35)
+ │         │    │    │    ├── inner-join (lookup lineitem)
+ │         │    │    │    │    ├── save-table-name: q10_lookup_join_8
+ │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(char!null)
+ │         │    │    │    │    ├── key columns: [9] = [18]
+ │         │    │    │    │    ├── stats: [rows=94291.8095, distinct(9)=57356.6085, null(9)=0, distinct(10)=39003.2512, null(10)=0, distinct(13)=92, null(13)=0, distinct(18)=57356.6085, null(18)=0, distinct(23)=89301.3429, null(23)=0, distinct(24)=11, null(24)=0, distinct(26)=1, null(26)=0, distinct(23,24)=94291.8095, null(23,24)=0]
+ │         │    │    │    │    ├── fd: ()-->(26), (9)-->(10,13), (9)==(18), (18)==(9)
+ │         │    │    │    │    ├── index-join orders
+ │         │    │    │    │    │    ├── save-table-name: q10_index_join_9
+ │         │    │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null)
+ │         │    │    │    │    │    ├── stats: [rows=57356.6085, distinct(9)=57356.6085, null(9)=0, distinct(10)=44261.346, null(10)=0, distinct(13)=92, null(13)=0]
+ │         │    │    │    │    │    ├── key: (9)
+ │         │    │    │    │    │    ├── fd: (9)-->(10,13)
+ │         │    │    │    │    │    └── scan orders@o_od
+ │         │    │    │    │    │         ├── save-table-name: q10_scan_10
+ │         │    │    │    │    │         ├── columns: o_orderkey:9(int!null) o_orderdate:13(date!null)
+ │         │    │    │    │    │         ├── constraint: /13/9: [/'1993-10-01' - /'1993-12-31']
+ │         │    │    │    │    │         ├── stats: [rows=57356.6085, distinct(9)=57356.6085, null(9)=0, distinct(13)=92, null(13)=0]
+ │         │    │    │    │    │         ├── key: (9)
+ │         │    │    │    │    │         └── fd: (9)-->(13)
+ │         │    │    │    │    └── filters
+ │         │    │    │    │         └── l_returnflag = 'R' [type=bool, outer=(26), constraints=(/26: [/'R' - /'R']; tight), fd=()-->(26)]
  │         │    │    │    └── filters
- │         │    │    │         └── c_nationkey = n_nationkey [type=bool, outer=(4,34), constraints=(/4: (/NULL - ]; /34: (/NULL - ]), fd=(4)==(34), (34)==(4)]
+ │         │    │    │         └── c_custkey = o_custkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+ │         │    │    ├── scan nation
+ │         │    │    │    ├── save-table-name: q10_scan_11
+ │         │    │    │    ├── columns: n_nationkey:34(int!null) n_name:35(char!null)
+ │         │    │    │    ├── stats: [rows=25, distinct(34)=25, null(34)=0, distinct(35)=25, null(35)=0]
+ │         │    │    │    ├── key: (34)
+ │         │    │    │    └── fd: (34)-->(35)
  │         │    │    └── filters
- │         │    │         └── c_custkey = o_custkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+ │         │    │         └── c_nationkey = n_nationkey [type=bool, outer=(4,34), constraints=(/4: (/NULL - ]; /34: (/NULL - ]), fd=(4)==(34), (34)==(4)]
  │         │    └── projections
  │         │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(23,24)]
  │         └── aggregations
@@ -4156,14 +4183,14 @@ column_names  row_count  distinct_count  null_count
 {sum}         0          0               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{c_acctbal}   82830.00       +Inf <==       82830.00            +Inf <==            0.00            1.00
-{c_address}   82830.00       +Inf <==       82830.00            +Inf <==            0.00            1.00
-{c_comment}   82830.00       +Inf <==       82830.00            +Inf <==            0.00            1.00
-{c_custkey}   82830.00       +Inf <==       82830.00            +Inf <==            0.00            1.00
-{c_name}      82830.00       +Inf <==       82830.00            +Inf <==            0.00            1.00
-{c_phone}     82830.00       +Inf <==       82830.00            +Inf <==            0.00            1.00
-{n_name}      82830.00       +Inf <==       82830.00            +Inf <==            0.00            1.00
-{sum}         82830.00       +Inf <==       82830.00            +Inf <==            0.00            1.00
+{c_acctbal}   44261.00       +Inf <==       44261.00            +Inf <==            0.00            1.00
+{c_address}   44261.00       +Inf <==       44261.00            +Inf <==            0.00            1.00
+{c_comment}   44261.00       +Inf <==       44261.00            +Inf <==            0.00            1.00
+{c_custkey}   44261.00       +Inf <==       44261.00            +Inf <==            0.00            1.00
+{c_name}      44261.00       +Inf <==       44261.00            +Inf <==            0.00            1.00
+{c_phone}     44261.00       +Inf <==       44261.00            +Inf <==            0.00            1.00
+{n_name}      44261.00       +Inf <==       44261.00            +Inf <==            0.00            1.00
+{sum}         44261.00       +Inf <==       44261.00            +Inf <==            0.00            1.00
 
 stats table=q10_group_by_3
 ----
@@ -4178,14 +4205,14 @@ column_names  row_count  distinct_count  null_count
 {sum}         37967      37934           0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{c_acctbal}   82830.00       2.18 <==       82830.00            2.20 <==            0.00            1.00
-{c_address}   82830.00       2.18 <==       82830.00            2.18 <==            0.00            1.00
-{c_comment}   82830.00       2.18 <==       82830.00            2.17 <==            0.00            1.00
-{c_custkey}   82830.00       2.18 <==       82830.00            2.19 <==            0.00            1.00
-{c_name}      82830.00       2.18 <==       82830.00            2.19 <==            0.00            1.00
-{c_phone}     82830.00       2.18 <==       82830.00            2.18 <==            0.00            1.00
-{n_name}      82830.00       2.18 <==       82830.00            3313.20 <==         0.00            1.00
-{sum}         82830.00       2.18 <==       82830.00            2.18 <==            0.00            1.00
+{c_acctbal}   44261.00       1.17           44261.00            1.18                0.00            1.00
+{c_address}   44261.00       1.17           44261.00            1.16                0.00            1.00
+{c_comment}   44261.00       1.17           44261.00            1.16                0.00            1.00
+{c_custkey}   44261.00       1.17           44261.00            1.17                0.00            1.00
+{c_name}      44261.00       1.17           44261.00            1.17                0.00            1.00
+{c_phone}     44261.00       1.17           44261.00            1.16                0.00            1.00
+{n_name}      44261.00       1.17           44261.00            1770.44 <==         0.00            1.00
+{sum}         44261.00       1.17           44261.00            1.17                0.00            1.00
 
 stats table=q10_project_4
 ----
@@ -4200,14 +4227,14 @@ column_names  row_count  distinct_count  null_count
 {n_name}      114705     25              0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{c_acctbal}   276178.00      2.41 <==       120896.00           3.21 <==            0.00            1.00
-{c_address}   276178.00      2.41 <==       126171.00           3.31 <==            0.00            1.00
-{c_comment}   276178.00      2.41 <==       125833.00           3.30 <==            0.00            1.00
-{c_custkey}   276178.00      2.41 <==       82830.00            2.19 <==            0.00            1.00
-{c_name}      276178.00      2.41 <==       126206.00           3.33 <==            0.00            1.00
-{c_phone}     276178.00      2.41 <==       126206.00           3.32 <==            0.00            1.00
-{column38}    276178.00      2.41 <==       10827.00            10.59 <==           0.00            1.00
-{n_name}      276178.00      2.41 <==       25.00               1.00                0.00            1.00
+{c_acctbal}   95044.00       1.21           69087.00            1.83                0.00            1.00
+{c_address}   95044.00       1.21           70392.00            1.85                0.00            1.00
+{c_comment}   95044.00       1.21           70310.00            1.85                0.00            1.00
+{c_custkey}   95044.00       1.21           44261.00            1.17                0.00            1.00
+{c_name}      95044.00       1.21           70400.00            1.86                0.00            1.00
+{c_phone}     95044.00       1.21           70400.00            1.85                0.00            1.00
+{column38}    95044.00       1.21           1.00                114608.00 <==       0.00            1.00
+{n_name}      95044.00       1.21           25.00               1.00                0.00            1.00
 
 stats table=q10_inner_join_5
 ----
@@ -4230,26 +4257,33 @@ column_names       row_count  distinct_count  null_count
 {o_orderkey}       114705     48516           0
 ~~~~
 column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{c_acctbal}        276178.00      2.41 <==       120896.00           3.21 <==            0.00            1.00
-{c_address}        276178.00      2.41 <==       126171.00           3.31 <==            0.00            1.00
-{c_comment}        276178.00      2.41 <==       125833.00           3.30 <==            0.00            1.00
-{c_custkey}        276178.00      2.41 <==       82830.00            2.19 <==            0.00            1.00
-{c_name}           276178.00      2.41 <==       126206.00           3.33 <==            0.00            1.00
-{c_nationkey}      276178.00      2.41 <==       25.00               1.00                0.00            1.00
-{c_phone}          276178.00      2.41 <==       126206.00           3.32 <==            0.00            1.00
-{l_discount}       276178.00      2.41 <==       11.00               1.00                0.00            1.00
-{l_extendedprice}  276178.00      2.41 <==       236171.00           2.22 <==            0.00            1.00
-{l_orderkey}       276178.00      2.41 <==       134884.00           2.78 <==            0.00            1.00
-{l_returnflag}     276178.00      2.41 <==       1.00                1.00                0.00            1.00
-{n_name}           276178.00      2.41 <==       25.00               1.00                0.00            1.00
-{n_nationkey}      276178.00      2.41 <==       25.00               1.00                0.00            1.00
-{o_custkey}        276178.00      2.41 <==       82830.00            2.19 <==            0.00            1.00
-{o_orderdate}      276178.00      2.41 <==       2406.00             26.15 <==           0.00            1.00
-{o_orderkey}       276178.00      2.41 <==       134884.00           2.78 <==            0.00            1.00
+{c_acctbal}        95044.00       1.21           69087.00            1.83                0.00            1.00
+{c_address}        95044.00       1.21           70392.00            1.85                0.00            1.00
+{c_comment}        95044.00       1.21           70310.00            1.85                0.00            1.00
+{c_custkey}        95044.00       1.21           44261.00            1.17                0.00            1.00
+{c_name}           95044.00       1.21           70400.00            1.86                0.00            1.00
+{c_nationkey}      95044.00       1.21           25.00               1.00                0.00            1.00
+{c_phone}          95044.00       1.21           70400.00            1.85                0.00            1.00
+{l_discount}       95044.00       1.21           11.00               1.00                0.00            1.00
+{l_extendedprice}  95044.00       1.21           89640.00            1.19                0.00            1.00
+{l_orderkey}       95044.00       1.21           46419.00            1.05                0.00            1.00
+{l_returnflag}     95044.00       1.21           1.00                1.00                0.00            1.00
+{n_name}           95044.00       1.21           25.00               1.00                0.00            1.00
+{n_nationkey}      95044.00       1.21           25.00               1.00                0.00            1.00
+{o_custkey}        95044.00       1.21           44261.00            1.17                0.00            1.00
+{o_orderdate}      95044.00       1.21           92.00               1.00                0.00            1.00
+{o_orderkey}       95044.00       1.21           46419.00            1.05                0.00            1.00
 
-stats table=q10_lookup_join_6
+stats table=q10_inner_join_6
 ----
 column_names       row_count  distinct_count  null_count
+{c_acctbal}        114705     37658           0
+{c_address}        114705     38065           0
+{c_comment}        114705     38086           0
+{c_custkey}        114705     37904           0
+{c_name}           114705     37859           0
+{c_nationkey}      114705     25              0
+{c_phone}          114705     38026           0
 {l_discount}       114705     11              0
 {l_extendedprice}  114705     106228          0
 {l_orderkey}       114705     48516           0
@@ -4259,51 +4293,22 @@ column_names       row_count  distinct_count  null_count
 {o_orderkey}       114705     48516           0
 ~~~~
 column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{l_discount}       273993.00      2.39 <==       11.00               1.00                0.00            1.00
-{l_extendedprice}  273993.00      2.39 <==       234596.00           2.21 <==            0.00            1.00
-{l_orderkey}       273993.00      2.39 <==       166667.00           3.44 <==            0.00            1.00
-{l_returnflag}     273993.00      2.39 <==       1.00                1.00                0.00            1.00
-{o_custkey}        273993.00      2.39 <==       79799.00            2.11 <==            0.00            1.00
-{o_orderdate}      273993.00      2.39 <==       2406.00             26.15 <==           0.00            1.00
-{o_orderkey}       273993.00      2.39 <==       166667.00           3.44 <==            0.00            1.00
+{c_acctbal}        95044.00       1.21           69088.00            1.83                0.00            1.00
+{c_address}        95044.00       1.21           70392.00            1.85                0.00            1.00
+{c_comment}        95044.00       1.21           70310.00            1.85                0.00            1.00
+{c_custkey}        95044.00       1.21           39003.00            1.03                0.00            1.00
+{c_name}           95044.00       1.21           70401.00            1.86                0.00            1.00
+{c_nationkey}      95044.00       1.21           25.00               1.00                0.00            1.00
+{c_phone}          95044.00       1.21           70401.00            1.85                0.00            1.00
+{l_discount}       95044.00       1.21           11.00               1.00                0.00            1.00
+{l_extendedprice}  95044.00       1.21           58495.00            1.82                0.00            1.00
+{l_orderkey}       95044.00       1.21           46419.00            1.05                0.00            1.00
+{l_returnflag}     95044.00       1.21           1.00                1.00                0.00            1.00
+{o_custkey}        95044.00       1.21           39003.00            1.03                0.00            1.00
+{o_orderdate}      95044.00       1.21           92.00               1.00                0.00            1.00
+{o_orderkey}       95044.00       1.21           46419.00            1.05                0.00            1.00
 
-stats table=q10_index_join_7
-----
-column_names   row_count  distinct_count  null_count
-{o_custkey}    57069      42598           0
-{o_orderdate}  57069      92              0
-{o_orderkey}   57069      56240           0
-~~~~
-column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{o_custkey}    166667.00      2.92 <==       82830.00            1.94 <==            0.00            1.00
-{o_orderdate}  166667.00      2.92 <==       2406.00             26.15 <==           0.00            1.00
-{o_orderkey}   166667.00      2.92 <==       166667.00           2.96 <==            0.00            1.00
-
-stats table=q10_inner_join_9
-----
-column_names   row_count  distinct_count  null_count
-{c_acctbal}    150000     140628          0
-{c_address}    150000     149937          0
-{c_comment}    150000     149323          0
-{c_custkey}    150000     148813          0
-{c_name}       150000     151126          0
-{c_nationkey}  150000     25              0
-{c_phone}      150000     150872          0
-{n_name}       150000     25              0
-{n_nationkey}  150000     25              0
-~~~~
-column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{c_acctbal}    150000.00      1.00           93279.00            1.51                0.00            1.00
-{c_address}    150000.00      1.00           95923.00            1.56                0.00            1.00
-{c_comment}    150000.00      1.00           95756.00            1.56                0.00            1.00
-{c_custkey}    150000.00      1.00           95616.00            1.56                0.00            1.00
-{c_name}       150000.00      1.00           95940.00            1.58                0.00            1.00
-{c_nationkey}  150000.00      1.00           25.00               1.00                0.00            1.00
-{c_phone}      150000.00      1.00           95940.00            1.57                0.00            1.00
-{n_name}       150000.00      1.00           25.00               1.00                0.00            1.00
-{n_nationkey}  150000.00      1.00           25.00               1.00                0.00            1.00
-
-stats table=q10_scan_10
+stats table=q10_scan_7
 ----
 column_names   row_count  distinct_count  null_count
 {c_acctbal}    150000     140628          0
@@ -4322,6 +4327,38 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {c_name}       150000.00      1.00           150000.00           1.01                0.00            1.00
 {c_nationkey}  150000.00      1.00           25.00               1.00                0.00            1.00
 {c_phone}      150000.00      1.00           150000.00           1.01                0.00            1.00
+
+stats table=q10_lookup_join_8
+----
+column_names       row_count  distinct_count  null_count
+{l_discount}       114705     11              0
+{l_extendedprice}  114705     106228          0
+{l_orderkey}       114705     48516           0
+{l_returnflag}     114705     1               0
+{o_custkey}        114705     37904           0
+{o_orderdate}      114705     92              0
+{o_orderkey}       114705     48516           0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_discount}       94292.00       1.22           11.00               1.00                0.00            1.00
+{l_extendedprice}  94292.00       1.22           89301.00            1.19                0.00            1.00
+{l_orderkey}       94292.00       1.22           57357.00            1.18                0.00            1.00
+{l_returnflag}     94292.00       1.22           1.00                1.00                0.00            1.00
+{o_custkey}        94292.00       1.22           39003.00            1.03                0.00            1.00
+{o_orderdate}      94292.00       1.22           92.00               1.00                0.00            1.00
+{o_orderkey}       94292.00       1.22           57357.00            1.18                0.00            1.00
+
+stats table=q10_index_join_9
+----
+column_names   row_count  distinct_count  null_count
+{o_custkey}    57069      42598           0
+{o_orderdate}  57069      92              0
+{o_orderkey}   57069      56240           0
+~~~~
+column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{o_custkey}    57357.00       1.01           44261.00            1.04                0.00            1.00
+{o_orderdate}  57357.00       1.01           92.00               1.00                0.00            1.00
+{o_orderkey}   57357.00       1.01           57357.00            1.02                0.00            1.00
 
 stats table=q10_scan_11
 ----
@@ -4777,26 +4814,26 @@ sort
       ├── project
       │    ├── save-table-name: q12_project_3
       │    ├── columns: column26:26(int) column28:28(int) l_shipmode:24(char!null)
-      │    ├── stats: [rows=21168.3069, distinct(24)=2, null(24)=0, distinct(26)=5, null(26)=0, distinct(28)=5, null(28)=0]
+      │    ├── stats: [rows=27227.0509, distinct(24)=2, null(24)=0, distinct(26)=5, null(26)=0, distinct(28)=5, null(28)=0]
       │    ├── inner-join (lookup orders)
       │    │    ├── save-table-name: q12_lookup_join_4
       │    │    ├── columns: o_orderkey:1(int!null) o_orderpriority:6(char!null) l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(char!null)
       │    │    ├── key columns: [10] = [1]
-      │    │    ├── stats: [rows=21168.3069, distinct(1)=21059.1899, null(1)=0, distinct(6)=5, null(6)=0, distinct(10)=21059.1899, null(10)=0, distinct(20)=2524.85097, null(20)=0, distinct(21)=2465.08517, null(21)=0, distinct(22)=2552.72645, null(22)=0, distinct(24)=2, null(24)=0]
+      │    │    ├── stats: [rows=27227.0509, distinct(1)=27046.6499, null(1)=0, distinct(6)=5, null(6)=0, distinct(10)=27046.6499, null(10)=0, distinct(20)=2525.89601, null(20)=0, distinct(21)=2465.92192, null(21)=0, distinct(22)=365, null(22)=0, distinct(24)=2, null(24)=0]
       │    │    ├── fd: (1)-->(6), (1)==(10), (10)==(1)
       │    │    ├── select
       │    │    │    ├── save-table-name: q12_select_5
       │    │    │    ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(char!null)
-      │    │    │    ├── stats: [rows=21168.3069, distinct(10)=21059.1899, null(10)=0, distinct(20)=2525.42913, null(20)=0, distinct(21)=2465.54565, null(21)=0, distinct(22)=2553.36716, null(22)=0, distinct(24)=2, null(24)=0]
+      │    │    │    ├── stats: [rows=27227.0509, distinct(10)=27046.6499, null(10)=0, distinct(20)=2525.94864, null(20)=0, distinct(21)=2465.96145, null(21)=0, distinct(22)=365, null(22)=0, distinct(24)=2, null(24)=0]
       │    │    │    ├── index-join lineitem
       │    │    │    │    ├── save-table-name: q12_index_join_6
       │    │    │    │    ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(char!null)
-      │    │    │    │    ├── stats: [rows=666801.667, distinct(10)=565838.316, null(10)=0, distinct(20)=2526, null(20)=0, distinct(21)=2466, null(21)=0, distinct(22)=2554, null(22)=0, distinct(24)=7, null(24)=0]
+      │    │    │    │    ├── stats: [rows=857652.105, distinct(10)=694077.25, null(10)=0, distinct(20)=2526, null(20)=0, distinct(21)=2466, null(21)=0, distinct(22)=365, null(22)=0, distinct(24)=7, null(24)=0]
       │    │    │    │    └── scan lineitem@l_rd
       │    │    │    │         ├── save-table-name: q12_scan_7
       │    │    │    │         ├── columns: l_orderkey:10(int!null) l_linenumber:13(int!null) l_receiptdate:22(date!null)
       │    │    │    │         ├── constraint: /22/10/13: [/'1994-01-01' - /'1994-12-31']
-      │    │    │    │         ├── stats: [rows=666801.667, distinct(10)=565838.316, null(10)=0, distinct(13)=7, null(13)=0, distinct(22)=2554, null(22)=0]
+      │    │    │    │         ├── stats: [rows=857652.105, distinct(10)=694077.25, null(10)=0, distinct(13)=7, null(13)=0, distinct(22)=365, null(22)=0]
       │    │    │    │         ├── key: (10,13)
       │    │    │    │         └── fd: (10,13)-->(22)
       │    │    │    └── filters
@@ -4845,9 +4882,9 @@ column_names  row_count  distinct_count  null_count
 {l_shipmode}  30988      2               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{column26}    21168.00       1.46           5.00                2.50 <==            0.00            1.00
-{column28}    21168.00       1.46           5.00                2.50 <==            0.00            1.00
-{l_shipmode}  21168.00       1.46           2.00                1.00                0.00            1.00
+{column26}    27227.00       1.14           5.00                2.50 <==            0.00            1.00
+{column28}    27227.00       1.14           5.00                2.50 <==            0.00            1.00
+{l_shipmode}  27227.00       1.14           2.00                1.00                0.00            1.00
 
 stats table=q12_lookup_join_4
 ----
@@ -4861,13 +4898,13 @@ column_names       row_count  distinct_count  null_count
 {o_orderpriority}  30988      5               0
 ~~~~
 column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{l_commitdate}     21168.00       1.46           2465.00             6.29 <==            0.00            1.00
-{l_orderkey}       21168.00       1.46           21059.00            1.37                0.00            1.00
-{l_receiptdate}    21168.00       1.46           2553.00             6.99 <==            0.00            1.00
-{l_shipdate}       21168.00       1.46           2525.00             6.46 <==            0.00            1.00
-{l_shipmode}       21168.00       1.46           2.00                1.00                0.00            1.00
-{o_orderkey}       21168.00       1.46           21059.00            1.37                0.00            1.00
-{o_orderpriority}  21168.00       1.46           5.00                1.00                0.00            1.00
+{l_commitdate}     27227.00       1.14           2466.00             6.29 <==            0.00            1.00
+{l_orderkey}       27227.00       1.14           27047.00            1.07                0.00            1.00
+{l_receiptdate}    27227.00       1.14           365.00              1.00                0.00            1.00
+{l_shipdate}       27227.00       1.14           2526.00             6.46 <==            0.00            1.00
+{l_shipmode}       27227.00       1.14           2.00                1.00                0.00            1.00
+{o_orderkey}       27227.00       1.14           27047.00            1.07                0.00            1.00
+{o_orderpriority}  27227.00       1.14           5.00                1.00                0.00            1.00
 
 stats table=q12_select_5
 ----
@@ -4879,11 +4916,11 @@ column_names     row_count  distinct_count  null_count
 {l_shipmode}     30988      2               0
 ~~~~
 column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{l_commitdate}   21168.00       1.46           2466.00             6.29 <==            0.00            1.00
-{l_orderkey}     21168.00       1.46           21059.00            1.37                0.00            1.00
-{l_receiptdate}  21168.00       1.46           2553.00             6.99 <==            0.00            1.00
-{l_shipdate}     21168.00       1.46           2525.00             6.46 <==            0.00            1.00
-{l_shipmode}     21168.00       1.46           2.00                1.00                0.00            1.00
+{l_commitdate}   27227.00       1.14           2466.00             6.29 <==            0.00            1.00
+{l_orderkey}     27227.00       1.14           27047.00            1.07                0.00            1.00
+{l_receiptdate}  27227.00       1.14           365.00              1.00                0.00            1.00
+{l_shipdate}     27227.00       1.14           2526.00             6.46 <==            0.00            1.00
+{l_shipmode}     27227.00       1.14           2.00                1.00                0.00            1.00
 
 stats table=q12_index_join_6
 ----
@@ -4895,11 +4932,11 @@ column_names     row_count  distinct_count  null_count
 {l_shipmode}     909844     7               0
 ~~~~
 column_names     row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{l_commitdate}   666802.00      1.36           2466.00             4.40 <==            0.00            1.00
-{l_orderkey}     666802.00      1.36           565838.00           2.11 <==            0.00            1.00
-{l_receiptdate}  666802.00      1.36           2554.00             7.00 <==            0.00            1.00
-{l_shipdate}     666802.00      1.36           2526.00             6.41 <==            0.00            1.00
-{l_shipmode}     666802.00      1.36           7.00                1.00                0.00            1.00
+{l_commitdate}   857652.00      1.06           2466.00             4.40 <==            0.00            1.00
+{l_orderkey}     857652.00      1.06           694077.00           2.59 <==            0.00            1.00
+{l_receiptdate}  857652.00      1.06           365.00              1.00                0.00            1.00
+{l_shipdate}     857652.00      1.06           2526.00             6.41 <==            0.00            1.00
+{l_shipmode}     857652.00      1.06           7.00                1.00                0.00            1.00
 
 # --------------------------------------------------
 # Q13
@@ -5107,29 +5144,29 @@ project
  │    ├── project
  │    │    ├── save-table-name: q14_project_3
  │    │    ├── columns: column26:26(float) column28:28(float)
- │    │    ├── stats: [rows=669341.819, distinct(26)=669341.819, null(26)=0, distinct(28)=422432.35, null(28)=0]
+ │    │    ├── stats: [rows=71544.85, distinct(26)=71544.85, null(26)=0, distinct(28)=45153.1015, null(28)=0]
  │    │    ├── inner-join
  │    │    │    ├── save-table-name: q14_inner_join_4
  │    │    │    ├── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null) p_partkey:17(int!null) p_type:21(varchar!null)
- │    │    │    ├── stats: [rows=669341.819, distinct(2)=193504.524, null(2)=0, distinct(6)=366712.957, null(6)=0, distinct(7)=11, null(7)=0, distinct(11)=2526, null(11)=0, distinct(17)=193504.524, null(17)=0, distinct(21)=150, null(21)=0, distinct(6,7)=422432.35, null(6,7)=0, distinct(6,7,21)=669341.819, null(6,7,21)=0]
+ │    │    │    ├── stats: [rows=71544.85, distinct(2)=60216.5699, null(2)=0, distinct(6)=44533.9293, null(6)=0, distinct(7)=11, null(7)=0, distinct(11)=30, null(11)=0, distinct(17)=60216.5699, null(17)=0, distinct(21)=150, null(21)=0, distinct(6,7)=45153.1015, null(6,7)=0, distinct(6,7,21)=71544.85, null(6,7,21)=0]
  │    │    │    ├── fd: (17)-->(21), (2)==(17), (17)==(2)
- │    │    │    ├── index-join lineitem
- │    │    │    │    ├── save-table-name: q14_index_join_5
- │    │    │    │    ├── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
- │    │    │    │    ├── stats: [rows=666801.667, distinct(2)=193504.524, null(2)=0, distinct(6)=494371.509, null(6)=0, distinct(7)=11, null(7)=0, distinct(11)=2526, null(11)=0, distinct(6,7)=666801.667, null(6,7)=0]
- │    │    │    │    └── scan lineitem@l_sd
- │    │    │    │         ├── save-table-name: q14_scan_6
- │    │    │    │         ├── columns: l_orderkey:1(int!null) l_linenumber:4(int!null) l_shipdate:11(date!null)
- │    │    │    │         ├── constraint: /11/1/4: [/'1995-09-01' - /'1995-09-30']
- │    │    │    │         ├── stats: [rows=666801.667, distinct(1)=565838.316, null(1)=0, distinct(4)=7, null(4)=0, distinct(11)=2526, null(11)=0]
- │    │    │    │         ├── key: (1,4)
- │    │    │    │         └── fd: (1,4)-->(11)
  │    │    │    ├── scan part
- │    │    │    │    ├── save-table-name: q14_scan_7
+ │    │    │    │    ├── save-table-name: q14_scan_5
  │    │    │    │    ├── columns: p_partkey:17(int!null) p_type:21(varchar!null)
  │    │    │    │    ├── stats: [rows=200000, distinct(17)=199241, null(17)=0, distinct(21)=150, null(21)=0]
  │    │    │    │    ├── key: (17)
  │    │    │    │    └── fd: (17)-->(21)
+ │    │    │    ├── index-join lineitem
+ │    │    │    │    ├── save-table-name: q14_index_join_6
+ │    │    │    │    ├── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
+ │    │    │    │    ├── stats: [rows=71273.3373, distinct(2)=60216.5699, null(2)=0, distinct(6)=68994.2524, null(6)=0, distinct(7)=11, null(7)=0, distinct(11)=30, null(11)=0, distinct(6,7)=71273.3373, null(6,7)=0]
+ │    │    │    │    └── scan lineitem@l_sd
+ │    │    │    │         ├── save-table-name: q14_scan_7
+ │    │    │    │         ├── columns: l_orderkey:1(int!null) l_linenumber:4(int!null) l_shipdate:11(date!null)
+ │    │    │    │         ├── constraint: /11/1/4: [/'1995-09-01' - /'1995-09-30']
+ │    │    │    │         ├── stats: [rows=71273.3373, distinct(1)=70042.9576, null(1)=0, distinct(4)=7, null(4)=0, distinct(11)=30, null(11)=0]
+ │    │    │    │         ├── key: (1,4)
+ │    │    │    │         └── fd: (1,4)-->(11)
  │    │    │    └── filters
  │    │    │         └── l_partkey = p_partkey [type=bool, outer=(2,17), constraints=(/2: (/NULL - ]; /17: (/NULL - ]), fd=(2)==(17), (17)==(2)]
  │    │    └── projections
@@ -5168,8 +5205,8 @@ column_names  row_count  distinct_count  null_count
 {column28}    75983      76207           0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{column26}    669342.00      8.81 <==       669342.00           52.96 <==           0.00            1.00
-{column28}    669342.00      8.81 <==       422432.00           5.54 <==            0.00            1.00
+{column26}    71545.00       1.06           71545.00            5.66 <==            0.00            1.00
+{column28}    71545.00       1.06           45153.00            1.69                0.00            1.00
 
 stats table=q14_inner_join_4
 ----
@@ -5182,28 +5219,14 @@ column_names       row_count  distinct_count  null_count
 {p_type}           75983      150             0
 ~~~~
 column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{l_discount}       669342.00      8.81 <==       11.00               1.00                0.00            1.00
-{l_extendedprice}  669342.00      8.81 <==       366713.00           5.05 <==            0.00            1.00
-{l_partkey}        669342.00      8.81 <==       193505.00           3.07 <==            0.00            1.00
-{l_shipdate}       669342.00      8.81 <==       2526.00             84.20 <==           0.00            1.00
-{p_partkey}        669342.00      8.81 <==       193505.00           3.07 <==            0.00            1.00
-{p_type}           669342.00      8.81 <==       150.00              1.00                0.00            1.00
+{l_discount}       71545.00       1.06           11.00               1.00                0.00            1.00
+{l_extendedprice}  71545.00       1.06           44534.00            1.63                0.00            1.00
+{l_partkey}        71545.00       1.06           60217.00            1.05                0.00            1.00
+{l_shipdate}       71545.00       1.06           30.00               1.00                0.00            1.00
+{p_partkey}        71545.00       1.06           60217.00            1.05                0.00            1.00
+{p_type}           71545.00       1.06           150.00              1.00                0.00            1.00
 
-stats table=q14_index_join_5
-----
-column_names       row_count  distinct_count  null_count
-{l_discount}       75983      11              0
-{l_extendedprice}  75983      72627           0
-{l_partkey}        75983      63035           0
-{l_shipdate}       75983      30              0
-~~~~
-column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{l_discount}       666802.00      8.78 <==       11.00               1.00                0.00            1.00
-{l_extendedprice}  666802.00      8.78 <==       494372.00           6.81 <==            0.00            1.00
-{l_partkey}        666802.00      8.78 <==       193505.00           3.07 <==            0.00            1.00
-{l_shipdate}       666802.00      8.78 <==       2526.00             84.20 <==           0.00            1.00
-
-stats table=q14_scan_7
+stats table=q14_scan_5
 ----
 column_names  row_count  distinct_count  null_count
 {p_partkey}   200000     199241          0
@@ -5212,6 +5235,20 @@ column_names  row_count  distinct_count  null_count
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {p_partkey}   200000.00      1.00           199241.00           1.00                0.00            1.00
 {p_type}      200000.00      1.00           150.00              1.00                0.00            1.00
+
+stats table=q14_index_join_6
+----
+column_names       row_count  distinct_count  null_count
+{l_discount}       75983      11              0
+{l_extendedprice}  75983      72627           0
+{l_partkey}        75983      63035           0
+{l_shipdate}       75983      30              0
+~~~~
+column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_discount}       71273.00       1.07           11.00               1.00                0.00            1.00
+{l_extendedprice}  71273.00       1.07           68994.00            1.05                0.00            1.00
+{l_partkey}        71273.00       1.07           60217.00            1.05                0.00            1.00
+{l_shipdate}       71273.00       1.07           30.00               1.00                0.00            1.00
 
 # --------------------------------------------------
 # Q15
@@ -5307,16 +5344,16 @@ project
       │         │    ├── project
       │         │    │    ├── save-table-name: q15_project_7
       │         │    │    ├── columns: column24:24(float) l_suppkey:10(int!null)
-      │         │    │    ├── stats: [rows=666801.667, distinct(10)=9920, null(10)=0, distinct(24)=666801.667, null(24)=0]
+      │         │    │    ├── stats: [rows=216195.79, distinct(10)=9920, null(10)=0, distinct(24)=216195.79, null(24)=0]
       │         │    │    ├── index-join lineitem
       │         │    │    │    ├── save-table-name: q15_index_join_8
       │         │    │    │    ├── columns: l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null)
-      │         │    │    │    ├── stats: [rows=666801.667, distinct(10)=9920, null(10)=0, distinct(13)=494371.509, null(13)=0, distinct(14)=11, null(14)=0, distinct(18)=2526, null(18)=0, distinct(13,14)=666801.667, null(13,14)=0]
+      │         │    │    │    ├── stats: [rows=216195.79, distinct(10)=9920, null(10)=0, distinct(13)=195964.131, null(13)=0, distinct(14)=11, null(14)=0, distinct(18)=91, null(18)=0, distinct(13,14)=216195.79, null(13,14)=0]
       │         │    │    │    └── scan lineitem@l_sd
       │         │    │    │         ├── save-table-name: q15_scan_9
       │         │    │    │         ├── columns: l_orderkey:8(int!null) l_linenumber:11(int!null) l_shipdate:18(date!null)
       │         │    │    │         ├── constraint: /18/8/11: [/'1996-01-01' - /'1996-03-31']
-      │         │    │    │         ├── stats: [rows=666801.667, distinct(8)=565838.316, null(8)=0, distinct(11)=7, null(11)=0, distinct(18)=2526, null(18)=0]
+      │         │    │    │         ├── stats: [rows=216195.79, distinct(8)=205050.127, null(8)=0, distinct(11)=7, null(11)=0, distinct(18)=91, null(18)=0]
       │         │    │    │         ├── key: (8,11)
       │         │    │    │         └── fd: (8,11)-->(18)
       │         │    │    └── projections
@@ -5345,16 +5382,16 @@ project
       │                             │    ├── project
       │                             │    │    ├── save-table-name: q15_project_12
       │                             │    │    ├── columns: column42:42(float) l_suppkey:28(int!null)
-      │                             │    │    ├── stats: [rows=666801.667, distinct(28)=9920, null(28)=0, distinct(42)=666801.667, null(42)=0]
+      │                             │    │    ├── stats: [rows=216195.79, distinct(28)=9920, null(28)=0, distinct(42)=216195.79, null(42)=0]
       │                             │    │    ├── index-join lineitem
       │                             │    │    │    ├── save-table-name: q15_index_join_13
       │                             │    │    │    ├── columns: l_suppkey:28(int!null) l_extendedprice:31(float!null) l_discount:32(float!null) l_shipdate:36(date!null)
-      │                             │    │    │    ├── stats: [rows=666801.667, distinct(28)=9920, null(28)=0, distinct(31)=494371.509, null(31)=0, distinct(32)=11, null(32)=0, distinct(36)=2526, null(36)=0, distinct(31,32)=666801.667, null(31,32)=0]
+      │                             │    │    │    ├── stats: [rows=216195.79, distinct(28)=9920, null(28)=0, distinct(31)=195964.131, null(31)=0, distinct(32)=11, null(32)=0, distinct(36)=91, null(36)=0, distinct(31,32)=216195.79, null(31,32)=0]
       │                             │    │    │    └── scan lineitem@l_sd
       │                             │    │    │         ├── save-table-name: q15_scan_14
       │                             │    │    │         ├── columns: l_orderkey:26(int!null) l_linenumber:29(int!null) l_shipdate:36(date!null)
       │                             │    │    │         ├── constraint: /36/26/29: [/'1996-01-01' - /'1996-03-31']
-      │                             │    │    │         ├── stats: [rows=666801.667, distinct(26)=565838.316, null(26)=0, distinct(29)=7, null(29)=0, distinct(36)=2526, null(36)=0]
+      │                             │    │    │         ├── stats: [rows=216195.79, distinct(26)=205050.127, null(26)=0, distinct(29)=7, null(29)=0, distinct(36)=91, null(36)=0]
       │                             │    │    │         ├── key: (26,29)
       │                             │    │    │         └── fd: (26,29)-->(36)
       │                             │    │    └── projections
@@ -5452,8 +5489,8 @@ column_names  row_count  distinct_count  null_count
 {l_suppkey}   225954     9920            0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{column24}    666802.00      2.95 <==       666802.00           3.02 <==            0.00            1.00
-{l_suppkey}   666802.00      2.95 <==       9920.00             1.00                0.00            1.00
+{column24}    216196.00      1.05           216196.00           1.02                0.00            1.00
+{l_suppkey}   216196.00      1.05           9920.00             1.00                0.00            1.00
 
 stats table=q15_index_join_8
 ----
@@ -5464,10 +5501,10 @@ column_names       row_count  distinct_count  null_count
 {l_suppkey}        225954     9920            0
 ~~~~
 column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{l_discount}       666802.00      2.95 <==       11.00               1.00                0.00            1.00
-{l_extendedprice}  666802.00      2.95 <==       494372.00           2.51 <==            0.00            1.00
-{l_shipdate}       666802.00      2.95 <==       2526.00             27.76 <==           0.00            1.00
-{l_suppkey}        666802.00      2.95 <==       9920.00             1.00                0.00            1.00
+{l_discount}       216196.00      1.05           11.00               1.00                0.00            1.00
+{l_extendedprice}  216196.00      1.05           195964.00           1.00                0.00            1.00
+{l_shipdate}       216196.00      1.05           91.00               1.00                0.00            1.00
+{l_suppkey}        216196.00      1.05           9920.00             1.00                0.00            1.00
 
 stats table=q15_scalar_group_by_10
 ----
@@ -5494,8 +5531,8 @@ column_names  row_count  distinct_count  null_count
 {l_suppkey}   225954     9920            0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{column42}    666802.00      2.95 <==       666802.00           3.02 <==            0.00            1.00
-{l_suppkey}   666802.00      2.95 <==       9920.00             1.00                0.00            1.00
+{column42}    216196.00      1.05           216196.00           1.02                0.00            1.00
+{l_suppkey}   216196.00      1.05           9920.00             1.00                0.00            1.00
 
 stats table=q15_index_join_13
 ----
@@ -5506,10 +5543,10 @@ column_names       row_count  distinct_count  null_count
 {l_suppkey}        225954     9920            0
 ~~~~
 column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{l_discount}       666802.00      2.95 <==       11.00               1.00                0.00            1.00
-{l_extendedprice}  666802.00      2.95 <==       494372.00           2.51 <==            0.00            1.00
-{l_shipdate}       666802.00      2.95 <==       2526.00             27.76 <==           0.00            1.00
-{l_suppkey}        666802.00      2.95 <==       9920.00             1.00                0.00            1.00
+{l_discount}       216196.00      1.05           11.00               1.00                0.00            1.00
+{l_extendedprice}  216196.00      1.05           195964.00           1.00                0.00            1.00
+{l_shipdate}       216196.00      1.05           91.00               1.00                0.00            1.00
+{l_suppkey}        216196.00      1.05           9920.00             1.00                0.00            1.00
 
 # --------------------------------------------------
 # Q16
@@ -6624,28 +6661,28 @@ sort
            │    │    │         │    ├── stats: [rows=800000, distinct(12)=199241, null(12)=0, distinct(13)=9920, null(13)=0, distinct(14)=800000, null(14)=0, distinct(42)=800000, null(42)=0, distinct(12,13)=800000, null(12,13)=0]
            │    │    │         │    ├── key: (12,13)
            │    │    │         │    ├── fd: (12,13)-->(14,42)
-           │    │    │         │    ├── left-join
-           │    │    │         │    │    ├── save-table-name: q20_left_join_10
+           │    │    │         │    ├── right-join
+           │    │    │         │    │    ├── save-table-name: q20_right_join_10
            │    │    │         │    │    ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null) ps_availqty:14(int!null) l_partkey:27(int) l_suppkey:28(int) l_quantity:30(float) l_shipdate:36(date)
-           │    │    │         │    │    ├── stats: [rows=800000, distinct(12)=199241, null(12)=0, distinct(13)=9920, null(13)=0, distinct(14)=9920, null(14)=0, distinct(27)=269.895895, null(27)=799730.104, distinct(28)=269.895895, null(28)=799730.104, distinct(30)=49.7737004, null(30)=799730.104, distinct(36)=255.97722, null(36)=799730.104, distinct(12,13)=800000, null(12,13)=0]
+           │    │    │         │    │    ├── stats: [rows=800000, distinct(12)=199241, null(12)=0, distinct(13)=9920, null(13)=0, distinct(14)=9920, null(14)=0, distinct(27)=350.99288, null(27)=799649.007, distinct(28)=350.99288, null(28)=799649.007, distinct(30)=49.9553024, null(30)=799649.007, distinct(36)=225.470934, null(36)=799649.007, distinct(12,13)=800000, null(12,13)=0]
            │    │    │         │    │    ├── fd: (12,13)-->(14)
+           │    │    │         │    │    ├── index-join lineitem
+           │    │    │         │    │    │    ├── save-table-name: q20_index_join_11
+           │    │    │         │    │    │    ├── columns: l_partkey:27(int!null) l_suppkey:28(int!null) l_quantity:30(float!null) l_shipdate:36(date!null)
+           │    │    │         │    │    │    ├── stats: [rows=867158.937, distinct(27)=197430.235, null(27)=0, distinct(28)=9920, null(28)=0, distinct(30)=50, null(30)=0, distinct(36)=365, null(36)=0]
+           │    │    │         │    │    │    └── scan lineitem@l_sd
+           │    │    │         │    │    │         ├── save-table-name: q20_scan_12
+           │    │    │         │    │    │         ├── columns: l_orderkey:26(int!null) l_linenumber:29(int!null) l_shipdate:36(date!null)
+           │    │    │         │    │    │         ├── constraint: /36/26/29: [/'1994-01-01' - /'1994-12-31']
+           │    │    │         │    │    │         ├── stats: [rows=867158.937, distinct(26)=700112.075, null(26)=0, distinct(29)=7, null(29)=0, distinct(36)=365, null(36)=0]
+           │    │    │         │    │    │         ├── key: (26,29)
+           │    │    │         │    │    │         └── fd: (26,29)-->(36)
            │    │    │         │    │    ├── scan partsupp
-           │    │    │         │    │    │    ├── save-table-name: q20_scan_11
+           │    │    │         │    │    │    ├── save-table-name: q20_scan_13
            │    │    │         │    │    │    ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null) ps_availqty:14(int!null)
            │    │    │         │    │    │    ├── stats: [rows=800000, distinct(12)=199241, null(12)=0, distinct(13)=9920, null(13)=0, distinct(14)=9920, null(14)=0, distinct(12,13)=800000, null(12,13)=0]
            │    │    │         │    │    │    ├── key: (12,13)
            │    │    │         │    │    │    └── fd: (12,13)-->(14)
-           │    │    │         │    │    ├── index-join lineitem
-           │    │    │         │    │    │    ├── save-table-name: q20_index_join_12
-           │    │    │         │    │    │    ├── columns: l_partkey:27(int!null) l_suppkey:28(int!null) l_quantity:30(float!null) l_shipdate:36(date!null)
-           │    │    │         │    │    │    ├── stats: [rows=666801.667, distinct(27)=193504.524, null(27)=0, distinct(28)=9920, null(28)=0, distinct(30)=50, null(30)=0, distinct(36)=2526, null(36)=0]
-           │    │    │         │    │    │    └── scan lineitem@l_sd
-           │    │    │         │    │    │         ├── save-table-name: q20_scan_13
-           │    │    │         │    │    │         ├── columns: l_orderkey:26(int!null) l_linenumber:29(int!null) l_shipdate:36(date!null)
-           │    │    │         │    │    │         ├── constraint: /36/26/29: [/'1994-01-01' - /'1994-12-31']
-           │    │    │         │    │    │         ├── stats: [rows=666801.667, distinct(26)=565838.316, null(26)=0, distinct(29)=7, null(29)=0, distinct(36)=2526, null(36)=0]
-           │    │    │         │    │    │         ├── key: (26,29)
-           │    │    │         │    │    │         └── fd: (26,29)-->(36)
            │    │    │         │    │    └── filters
            │    │    │         │    │         ├── l_partkey = ps_partkey [type=bool, outer=(12,27), constraints=(/12: (/NULL - ]; /27: (/NULL - ]), fd=(12)==(27), (27)==(12)]
            │    │    │         │    │         └── l_suppkey = ps_suppkey [type=bool, outer=(13,28), constraints=(/13: (/NULL - ]; /28: (/NULL - ]), fd=(13)==(28), (28)==(13)]
@@ -6805,7 +6842,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {ps_suppkey}   800000.00      1.00           9920.00             1.00                0.00            1.00
 {sum}          800000.00      1.00           800000.00           3252.03 <==         0.00            +Inf <==
 
-stats table=q20_left_join_10
+stats table=q20_right_join_10
 ----
 column_names   row_count  distinct_count  null_count
 {l_partkey}    1166245    197252          256790
@@ -6817,15 +6854,29 @@ column_names   row_count  distinct_count  null_count
 {ps_suppkey}   1166245    9920            0
 ~~~~
 column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{l_partkey}    800000.00      1.46           270.00              730.56 <==          799730.00       3.11 <==
-{l_quantity}   800000.00      1.46           50.00               1.00                799730.00       3.11 <==
-{l_shipdate}   800000.00      1.46           256.00              1.43                799730.00       3.11 <==
-{l_suppkey}    800000.00      1.46           270.00              36.74 <==           799730.00       3.11 <==
+{l_partkey}    800000.00      1.46           351.00              561.97 <==          799649.00       3.11 <==
+{l_quantity}   800000.00      1.46           50.00               1.00                799649.00       3.11 <==
+{l_shipdate}   800000.00      1.46           225.00              1.62                799649.00       3.11 <==
+{l_suppkey}    800000.00      1.46           351.00              28.26 <==           799649.00       3.11 <==
 {ps_availqty}  800000.00      1.46           9920.00             1.00                0.00            1.00
 {ps_partkey}   800000.00      1.46           199241.00           1.00                0.00            1.00
 {ps_suppkey}   800000.00      1.46           9920.00             1.00                0.00            1.00
 
-stats table=q20_scan_11
+stats table=q20_index_join_11
+----
+column_names  row_count  distinct_count  null_count
+{l_partkey}   909455     197252          0
+{l_quantity}  909455     50              0
+{l_shipdate}  909455     365             0
+{l_suppkey}   909455     9920            0
+~~~~
+column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{l_partkey}   867159.00      1.05           197430.00           1.00                0.00            1.00
+{l_quantity}  867159.00      1.05           50.00               1.00                0.00            1.00
+{l_shipdate}  867159.00      1.05           365.00              1.00                0.00            1.00
+{l_suppkey}   867159.00      1.05           9920.00             1.00                0.00            1.00
+
+stats table=q20_scan_13
 ----
 column_names   row_count  distinct_count  null_count
 {ps_availqty}  800000     9920            0
@@ -6836,20 +6887,6 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {ps_availqty}  800000.00      1.00           9920.00             1.00                0.00            1.00
 {ps_partkey}   800000.00      1.00           199241.00           1.00                0.00            1.00
 {ps_suppkey}   800000.00      1.00           9920.00             1.00                0.00            1.00
-
-stats table=q20_index_join_12
-----
-column_names  row_count  distinct_count  null_count
-{l_partkey}   909455     197252          0
-{l_quantity}  909455     50              0
-{l_shipdate}  909455     365             0
-{l_suppkey}   909455     9920            0
-~~~~
-column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{l_partkey}   666802.00      1.36           193505.00           1.02                0.00            1.00
-{l_quantity}  666802.00      1.36           50.00               1.00                0.00            1.00
-{l_shipdate}  666802.00      1.36           2526.00             6.92 <==            0.00            1.00
-{l_suppkey}   666802.00      1.36           9920.00             1.00                0.00            1.00
 
 stats table=q20_select_14
 ----

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -1198,13 +1198,12 @@ sort
       │    │    │    │    │    └── filters (true)
       │    │    │    │    └── filters
       │    │    │    │         └── c_custkey = o_custkey [type=bool, outer=(25,33), constraints=(/25: (/NULL - ]; /33: (/NULL - ]), fd=(25)==(33), (33)==(25)]
-      │    │    │    ├── index-join lineitem
+      │    │    │    ├── select
       │    │    │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null)
-      │    │    │    │    └── scan lineitem@l_sd
-      │    │    │    │         ├── columns: l_orderkey:8(int!null) l_linenumber:11(int!null) l_shipdate:18(date!null)
-      │    │    │    │         ├── constraint: /18/8/11: [/'1995-01-01' - /'1996-12-31']
-      │    │    │    │         ├── key: (8,11)
-      │    │    │    │         └── fd: (8,11)-->(18)
+      │    │    │    │    ├── scan lineitem
+      │    │    │    │    │    └── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null)
+      │    │    │    │    └── filters
+      │    │    │    │         └── (l_shipdate >= '1995-01-01') AND (l_shipdate <= '1996-12-31') [type=bool, outer=(18), constraints=(/18: [/'1995-01-01' - /'1996-12-31']; tight)]
       │    │    │    └── filters
       │    │    │         └── o_orderkey = l_orderkey [type=bool, outer=(8,24), constraints=(/8: (/NULL - ]; /24: (/NULL - ]), fd=(8)==(24), (24)==(8)]
       │    │    ├── scan supplier@s_nk
@@ -1276,134 +1275,136 @@ GROUP BY
 ORDER BY
     o_year;
 ----
-project
+sort
  ├── columns: o_year:61(int) mkt_share:66(float)
  ├── side-effects
  ├── key: (61)
  ├── fd: (61)-->(66)
  ├── ordering: +61
- ├── group-by
- │    ├── columns: o_year:61(int) sum:64(float) sum:65(float)
- │    ├── grouping columns: o_year:61(int)
- │    ├── key: (61)
- │    ├── fd: (61)-->(64,65)
- │    ├── ordering: +61
- │    ├── sort
- │    │    ├── columns: o_year:61(int) volume:62(float) column63:63(float)
- │    │    ├── ordering: +61
- │    │    └── project
- │    │         ├── columns: column63:63(float) o_year:61(int) volume:62(float)
- │    │         ├── project
- │    │         │    ├── columns: o_year:61(int) volume:62(float) n2.n_name:55(char!null)
- │    │         │    ├── inner-join
- │    │         │    │    ├── columns: p_partkey:1(int!null) p_type:5(varchar!null) s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
- │    │         │    │    ├── fd: ()-->(5,59), (10)-->(13), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (10)==(19), (19)==(10), (13)==(54), (54)==(13), (1)==(18), (18)==(1)
- │    │         │    │    ├── inner-join
- │    │         │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
- │    │         │    │    │    ├── fd: ()-->(59), (10)-->(13), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (10)==(19), (19)==(10), (13)==(54), (54)==(13)
- │    │         │    │    │    ├── inner-join
- │    │         │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
- │    │         │    │    │    │    ├── fd: ()-->(59), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17)
- │    │         │    │    │    │    ├── scan lineitem
- │    │         │    │    │    │    │    └── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null)
- │    │         │    │    │    │    ├── inner-join
- │    │         │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
- │    │         │    │    │    │    │    ├── key: (33,54)
- │    │         │    │    │    │    │    ├── fd: ()-->(59), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34)
- │    │         │    │    │    │    │    ├── inner-join (merge)
- │    │         │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
- │    │         │    │    │    │    │    │    ├── left ordering: +45
- │    │         │    │    │    │    │    │    ├── right ordering: +50
- │    │         │    │    │    │    │    │    ├── key: (42,54)
- │    │         │    │    │    │    │    │    ├── fd: ()-->(59), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45)
- │    │         │    │    │    │    │    │    ├── scan customer@c_nk
- │    │         │    │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null)
- │    │         │    │    │    │    │    │    │    ├── key: (42)
- │    │         │    │    │    │    │    │    │    ├── fd: (42)-->(45)
- │    │         │    │    │    │    │    │    │    └── ordering: +45
- │    │         │    │    │    │    │    │    ├── sort
- │    │         │    │    │    │    │    │    │    ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
- │    │         │    │    │    │    │    │    │    ├── key: (50,54)
- │    │         │    │    │    │    │    │    │    ├── fd: ()-->(59), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52)
- │    │         │    │    │    │    │    │    │    ├── ordering: +50 opt(59) [actual: +50]
- │    │         │    │    │    │    │    │    │    └── inner-join
- │    │         │    │    │    │    │    │    │         ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
- │    │         │    │    │    │    │    │    │         ├── key: (50,54)
- │    │         │    │    │    │    │    │    │         ├── fd: ()-->(59), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52)
- │    │         │    │    │    │    │    │    │         ├── scan n2
- │    │         │    │    │    │    │    │    │         │    ├── columns: n2.n_nationkey:54(int!null) n2.n_name:55(char!null)
- │    │         │    │    │    │    │    │    │         │    ├── key: (54)
- │    │         │    │    │    │    │    │    │         │    └── fd: (54)-->(55)
- │    │         │    │    │    │    │    │    │         ├── inner-join (merge)
- │    │         │    │    │    │    │    │    │         │    ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) r_regionkey:58(int!null) r_name:59(char!null)
- │    │         │    │    │    │    │    │    │         │    ├── left ordering: +58
- │    │         │    │    │    │    │    │    │         │    ├── right ordering: +52
- │    │         │    │    │    │    │    │    │         │    ├── key: (50)
- │    │         │    │    │    │    │    │    │         │    ├── fd: ()-->(59), (50)-->(52), (52)==(58), (58)==(52)
- │    │         │    │    │    │    │    │    │         │    ├── select
- │    │         │    │    │    │    │    │    │         │    │    ├── columns: r_regionkey:58(int!null) r_name:59(char!null)
- │    │         │    │    │    │    │    │    │         │    │    ├── key: (58)
- │    │         │    │    │    │    │    │    │         │    │    ├── fd: ()-->(59)
- │    │         │    │    │    │    │    │    │         │    │    ├── ordering: +58 opt(59) [actual: +58]
- │    │         │    │    │    │    │    │    │         │    │    ├── scan region
- │    │         │    │    │    │    │    │    │         │    │    │    ├── columns: r_regionkey:58(int!null) r_name:59(char!null)
- │    │         │    │    │    │    │    │    │         │    │    │    ├── key: (58)
- │    │         │    │    │    │    │    │    │         │    │    │    ├── fd: (58)-->(59)
- │    │         │    │    │    │    │    │    │         │    │    │    └── ordering: +58 opt(59) [actual: +58]
- │    │         │    │    │    │    │    │    │         │    │    └── filters
- │    │         │    │    │    │    │    │    │         │    │         └── r_name = 'AMERICA' [type=bool, outer=(59), constraints=(/59: [/'AMERICA' - /'AMERICA']; tight), fd=()-->(59)]
- │    │         │    │    │    │    │    │    │         │    ├── scan n1@n_rk
- │    │         │    │    │    │    │    │    │         │    │    ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null)
- │    │         │    │    │    │    │    │    │         │    │    ├── key: (50)
- │    │         │    │    │    │    │    │    │         │    │    ├── fd: (50)-->(52)
- │    │         │    │    │    │    │    │    │         │    │    └── ordering: +52
- │    │         │    │    │    │    │    │    │         │    └── filters (true)
- │    │         │    │    │    │    │    │    │         └── filters (true)
- │    │         │    │    │    │    │    │    └── filters (true)
- │    │         │    │    │    │    │    ├── index-join orders
- │    │         │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null)
- │    │         │    │    │    │    │    │    ├── key: (33)
- │    │         │    │    │    │    │    │    ├── fd: (33)-->(34,37)
- │    │         │    │    │    │    │    │    └── scan orders@o_od
- │    │         │    │    │    │    │    │         ├── columns: o_orderkey:33(int!null) o_orderdate:37(date!null)
- │    │         │    │    │    │    │    │         ├── constraint: /37/33: [/'1995-01-01' - /'1996-12-31']
- │    │         │    │    │    │    │    │         ├── key: (33)
- │    │         │    │    │    │    │    │         └── fd: (33)-->(37)
- │    │         │    │    │    │    │    └── filters
- │    │         │    │    │    │    │         └── o_custkey = c_custkey [type=bool, outer=(34,42), constraints=(/34: (/NULL - ]; /42: (/NULL - ]), fd=(34)==(42), (42)==(34)]
- │    │         │    │    │    │    └── filters
- │    │         │    │    │    │         └── l_orderkey = o_orderkey [type=bool, outer=(17,33), constraints=(/17: (/NULL - ]; /33: (/NULL - ]), fd=(17)==(33), (33)==(17)]
- │    │         │    │    │    ├── scan supplier@s_nk
- │    │         │    │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null)
- │    │         │    │    │    │    ├── key: (10)
- │    │         │    │    │    │    └── fd: (10)-->(13)
- │    │         │    │    │    └── filters
- │    │         │    │    │         ├── s_suppkey = l_suppkey [type=bool, outer=(10,19), constraints=(/10: (/NULL - ]; /19: (/NULL - ]), fd=(10)==(19), (19)==(10)]
- │    │         │    │    │         └── s_nationkey = n2.n_nationkey [type=bool, outer=(13,54), constraints=(/13: (/NULL - ]; /54: (/NULL - ]), fd=(13)==(54), (54)==(13)]
- │    │         │    │    ├── select
- │    │         │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(varchar!null)
- │    │         │    │    │    ├── key: (1)
- │    │         │    │    │    ├── fd: ()-->(5)
- │    │         │    │    │    ├── scan part
- │    │         │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(varchar!null)
- │    │         │    │    │    │    ├── key: (1)
- │    │         │    │    │    │    └── fd: (1)-->(5)
- │    │         │    │    │    └── filters
- │    │         │    │    │         └── p_type = 'ECONOMY ANODIZED STEEL' [type=bool, outer=(5), constraints=(/5: [/'ECONOMY ANODIZED STEEL' - /'ECONOMY ANODIZED STEEL']; tight), fd=()-->(5)]
- │    │         │    │    └── filters
- │    │         │    │         └── p_partkey = l_partkey [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
- │    │         │    └── projections
- │    │         │         ├── extract('year', o_orderdate) [type=int, outer=(37)]
- │    │         │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(22,23)]
- │    │         └── projections
- │    │              └── CASE WHEN n2.n_name = 'BRAZIL' THEN volume ELSE 0.0 END [type=float, outer=(55,62)]
- │    └── aggregations
- │         ├── sum [type=float, outer=(63)]
- │         │    └── variable: column63 [type=float]
- │         └── sum [type=float, outer=(62)]
- │              └── variable: volume [type=float]
- └── projections
-      └── sum / sum [type=float, outer=(64,65), side-effects]
+ └── project
+      ├── columns: mkt_share:66(float) o_year:61(int)
+      ├── side-effects
+      ├── key: (61)
+      ├── fd: (61)-->(66)
+      ├── group-by
+      │    ├── columns: o_year:61(int) sum:64(float) sum:65(float)
+      │    ├── grouping columns: o_year:61(int)
+      │    ├── key: (61)
+      │    ├── fd: (61)-->(64,65)
+      │    ├── project
+      │    │    ├── columns: column63:63(float) o_year:61(int) volume:62(float)
+      │    │    ├── project
+      │    │    │    ├── columns: o_year:61(int) volume:62(float) n2.n_name:55(char!null)
+      │    │    │    ├── inner-join
+      │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(varchar!null) s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
+      │    │    │    │    ├── fd: ()-->(5,59), (10)-->(13), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (10)==(19), (19)==(10), (13)==(54), (54)==(13), (1)==(18), (18)==(1)
+      │    │    │    │    ├── inner-join
+      │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
+      │    │    │    │    │    ├── fd: ()-->(59), (10)-->(13), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (10)==(19), (19)==(10), (13)==(54), (54)==(13)
+      │    │    │    │    │    ├── inner-join
+      │    │    │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
+      │    │    │    │    │    │    ├── fd: ()-->(59), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17)
+      │    │    │    │    │    │    ├── inner-join
+      │    │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
+      │    │    │    │    │    │    │    ├── key: (33,54)
+      │    │    │    │    │    │    │    ├── fd: ()-->(59), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34)
+      │    │    │    │    │    │    │    ├── inner-join (merge)
+      │    │    │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
+      │    │    │    │    │    │    │    │    ├── left ordering: +45
+      │    │    │    │    │    │    │    │    ├── right ordering: +50
+      │    │    │    │    │    │    │    │    ├── key: (42,54)
+      │    │    │    │    │    │    │    │    ├── fd: ()-->(59), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45)
+      │    │    │    │    │    │    │    │    ├── scan customer@c_nk
+      │    │    │    │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null)
+      │    │    │    │    │    │    │    │    │    ├── key: (42)
+      │    │    │    │    │    │    │    │    │    ├── fd: (42)-->(45)
+      │    │    │    │    │    │    │    │    │    └── ordering: +45
+      │    │    │    │    │    │    │    │    ├── sort
+      │    │    │    │    │    │    │    │    │    ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
+      │    │    │    │    │    │    │    │    │    ├── key: (50,54)
+      │    │    │    │    │    │    │    │    │    ├── fd: ()-->(59), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52)
+      │    │    │    │    │    │    │    │    │    ├── ordering: +50 opt(59) [actual: +50]
+      │    │    │    │    │    │    │    │    │    └── inner-join
+      │    │    │    │    │    │    │    │    │         ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
+      │    │    │    │    │    │    │    │    │         ├── key: (50,54)
+      │    │    │    │    │    │    │    │    │         ├── fd: ()-->(59), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52)
+      │    │    │    │    │    │    │    │    │         ├── scan n2
+      │    │    │    │    │    │    │    │    │         │    ├── columns: n2.n_nationkey:54(int!null) n2.n_name:55(char!null)
+      │    │    │    │    │    │    │    │    │         │    ├── key: (54)
+      │    │    │    │    │    │    │    │    │         │    └── fd: (54)-->(55)
+      │    │    │    │    │    │    │    │    │         ├── inner-join (merge)
+      │    │    │    │    │    │    │    │    │         │    ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) r_regionkey:58(int!null) r_name:59(char!null)
+      │    │    │    │    │    │    │    │    │         │    ├── left ordering: +58
+      │    │    │    │    │    │    │    │    │         │    ├── right ordering: +52
+      │    │    │    │    │    │    │    │    │         │    ├── key: (50)
+      │    │    │    │    │    │    │    │    │         │    ├── fd: ()-->(59), (50)-->(52), (52)==(58), (58)==(52)
+      │    │    │    │    │    │    │    │    │         │    ├── select
+      │    │    │    │    │    │    │    │    │         │    │    ├── columns: r_regionkey:58(int!null) r_name:59(char!null)
+      │    │    │    │    │    │    │    │    │         │    │    ├── key: (58)
+      │    │    │    │    │    │    │    │    │         │    │    ├── fd: ()-->(59)
+      │    │    │    │    │    │    │    │    │         │    │    ├── ordering: +58 opt(59) [actual: +58]
+      │    │    │    │    │    │    │    │    │         │    │    ├── scan region
+      │    │    │    │    │    │    │    │    │         │    │    │    ├── columns: r_regionkey:58(int!null) r_name:59(char!null)
+      │    │    │    │    │    │    │    │    │         │    │    │    ├── key: (58)
+      │    │    │    │    │    │    │    │    │         │    │    │    ├── fd: (58)-->(59)
+      │    │    │    │    │    │    │    │    │         │    │    │    └── ordering: +58 opt(59) [actual: +58]
+      │    │    │    │    │    │    │    │    │         │    │    └── filters
+      │    │    │    │    │    │    │    │    │         │    │         └── r_name = 'AMERICA' [type=bool, outer=(59), constraints=(/59: [/'AMERICA' - /'AMERICA']; tight), fd=()-->(59)]
+      │    │    │    │    │    │    │    │    │         │    ├── scan n1@n_rk
+      │    │    │    │    │    │    │    │    │         │    │    ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null)
+      │    │    │    │    │    │    │    │    │         │    │    ├── key: (50)
+      │    │    │    │    │    │    │    │    │         │    │    ├── fd: (50)-->(52)
+      │    │    │    │    │    │    │    │    │         │    │    └── ordering: +52
+      │    │    │    │    │    │    │    │    │         │    └── filters (true)
+      │    │    │    │    │    │    │    │    │         └── filters (true)
+      │    │    │    │    │    │    │    │    └── filters (true)
+      │    │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null)
+      │    │    │    │    │    │    │    │    ├── key: (33)
+      │    │    │    │    │    │    │    │    ├── fd: (33)-->(34,37)
+      │    │    │    │    │    │    │    │    ├── scan orders
+      │    │    │    │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null)
+      │    │    │    │    │    │    │    │    │    ├── key: (33)
+      │    │    │    │    │    │    │    │    │    └── fd: (33)-->(34,37)
+      │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │    │         └── (o_orderdate >= '1995-01-01') AND (o_orderdate <= '1996-12-31') [type=bool, outer=(37), constraints=(/37: [/'1995-01-01' - /'1996-12-31']; tight)]
+      │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │         └── o_custkey = c_custkey [type=bool, outer=(34,42), constraints=(/34: (/NULL - ]; /42: (/NULL - ]), fd=(34)==(42), (42)==(34)]
+      │    │    │    │    │    │    ├── scan lineitem
+      │    │    │    │    │    │    │    └── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null)
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         └── l_orderkey = o_orderkey [type=bool, outer=(17,33), constraints=(/17: (/NULL - ]; /33: (/NULL - ]), fd=(17)==(33), (33)==(17)]
+      │    │    │    │    │    ├── scan supplier@s_nk
+      │    │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null)
+      │    │    │    │    │    │    ├── key: (10)
+      │    │    │    │    │    │    └── fd: (10)-->(13)
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         ├── s_suppkey = l_suppkey [type=bool, outer=(10,19), constraints=(/10: (/NULL - ]; /19: (/NULL - ]), fd=(10)==(19), (19)==(10)]
+      │    │    │    │    │         └── s_nationkey = n2.n_nationkey [type=bool, outer=(13,54), constraints=(/13: (/NULL - ]; /54: (/NULL - ]), fd=(13)==(54), (54)==(13)]
+      │    │    │    │    ├── select
+      │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(varchar!null)
+      │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    ├── fd: ()-->(5)
+      │    │    │    │    │    ├── scan part
+      │    │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(varchar!null)
+      │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    └── fd: (1)-->(5)
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         └── p_type = 'ECONOMY ANODIZED STEEL' [type=bool, outer=(5), constraints=(/5: [/'ECONOMY ANODIZED STEEL' - /'ECONOMY ANODIZED STEEL']; tight), fd=()-->(5)]
+      │    │    │    │    └── filters
+      │    │    │    │         └── p_partkey = l_partkey [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+      │    │    │    └── projections
+      │    │    │         ├── extract('year', o_orderdate) [type=int, outer=(37)]
+      │    │    │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(22,23)]
+      │    │    └── projections
+      │    │         └── CASE WHEN n2.n_name = 'BRAZIL' THEN volume ELSE 0.0 END [type=float, outer=(55,62)]
+      │    └── aggregations
+      │         ├── sum [type=float, outer=(63)]
+      │         │    └── variable: column63 [type=float]
+      │         └── sum [type=float, outer=(62)]
+      │              └── variable: volume [type=float]
+      └── projections
+           └── sum / sum [type=float, outer=(64,65), side-effects]
 
 # --------------------------------------------------
 # Q9
@@ -1968,6 +1969,10 @@ project
  │    │    ├── inner-join
  │    │    │    ├── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null) p_partkey:17(int!null) p_type:21(varchar!null)
  │    │    │    ├── fd: (17)-->(21), (2)==(17), (17)==(2)
+ │    │    │    ├── scan part
+ │    │    │    │    ├── columns: p_partkey:17(int!null) p_type:21(varchar!null)
+ │    │    │    │    ├── key: (17)
+ │    │    │    │    └── fd: (17)-->(21)
  │    │    │    ├── index-join lineitem
  │    │    │    │    ├── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
  │    │    │    │    └── scan lineitem@l_sd
@@ -1975,10 +1980,6 @@ project
  │    │    │    │         ├── constraint: /11/1/4: [/'1995-09-01' - /'1995-09-30']
  │    │    │    │         ├── key: (1,4)
  │    │    │    │         └── fd: (1,4)-->(11)
- │    │    │    ├── scan part
- │    │    │    │    ├── columns: p_partkey:17(int!null) p_type:21(varchar!null)
- │    │    │    │    ├── key: (17)
- │    │    │    │    └── fd: (17)-->(21)
  │    │    │    └── filters
  │    │    │         └── l_partkey = p_partkey [type=bool, outer=(2,17), constraints=(/2: (/NULL - ]; /17: (/NULL - ]), fd=(2)==(17), (17)==(2)]
  │    │    └── projections
@@ -2610,13 +2611,9 @@ sort
            │    │    │         │    ├── grouping columns: ps_partkey:12(int!null) ps_suppkey:13(int!null)
            │    │    │         │    ├── key: (12,13)
            │    │    │         │    ├── fd: (12,13)-->(14,42)
-           │    │    │         │    ├── left-join
+           │    │    │         │    ├── right-join
            │    │    │         │    │    ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null) ps_availqty:14(int!null) l_partkey:27(int) l_suppkey:28(int) l_quantity:30(float) l_shipdate:36(date)
            │    │    │         │    │    ├── fd: (12,13)-->(14)
-           │    │    │         │    │    ├── scan partsupp
-           │    │    │         │    │    │    ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null) ps_availqty:14(int!null)
-           │    │    │         │    │    │    ├── key: (12,13)
-           │    │    │         │    │    │    └── fd: (12,13)-->(14)
            │    │    │         │    │    ├── index-join lineitem
            │    │    │         │    │    │    ├── columns: l_partkey:27(int!null) l_suppkey:28(int!null) l_quantity:30(float!null) l_shipdate:36(date!null)
            │    │    │         │    │    │    └── scan lineitem@l_sd
@@ -2624,6 +2621,10 @@ sort
            │    │    │         │    │    │         ├── constraint: /36/26/29: [/'1994-01-01' - /'1994-12-31']
            │    │    │         │    │    │         ├── key: (26,29)
            │    │    │         │    │    │         └── fd: (26,29)-->(36)
+           │    │    │         │    │    ├── scan partsupp
+           │    │    │         │    │    │    ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null) ps_availqty:14(int!null)
+           │    │    │         │    │    │    ├── key: (12,13)
+           │    │    │         │    │    │    └── fd: (12,13)-->(14)
            │    │    │         │    │    └── filters
            │    │    │         │    │         ├── l_partkey = ps_partkey [type=bool, outer=(12,27), constraints=(/12: (/NULL - ]; /27: (/NULL - ]), fd=(12)==(27), (27)==(12)]
            │    │    │         │    │         └── l_suppkey = ps_suppkey [type=bool, outer=(13,28), constraints=(/13: (/NULL - ]; /28: (/NULL - ]), fd=(13)==(28), (28)==(13)]

--- a/pkg/sql/opt/xform/testdata/external/tpch-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpch-no-stats
@@ -712,27 +712,33 @@ sort
       ├── grouping columns: o_orderpriority:6(char!null)
       ├── key: (6)
       ├── fd: (6)-->(26)
-      ├── semi-join
+      ├── semi-join (merge)
       │    ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null) o_orderpriority:6(char!null)
+      │    ├── left ordering: +1
+      │    ├── right ordering: +10
       │    ├── key: (1)
       │    ├── fd: (1)-->(5,6)
-      │    ├── index-join orders
+      │    ├── select
       │    │    ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null) o_orderpriority:6(char!null)
       │    │    ├── key: (1)
       │    │    ├── fd: (1)-->(5,6)
-      │    │    └── scan orders@o_od
-      │    │         ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null)
-      │    │         ├── constraint: /5/1: [/'1993-07-01' - /'1993-09-30']
-      │    │         ├── key: (1)
-      │    │         └── fd: (1)-->(5)
+      │    │    ├── ordering: +1
+      │    │    ├── scan orders
+      │    │    │    ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null) o_orderpriority:6(char!null)
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: (1)-->(5,6)
+      │    │    │    └── ordering: +1
+      │    │    └── filters
+      │    │         └── (o_orderdate >= '1993-07-01') AND (o_orderdate < '1993-10-01') [type=bool, outer=(5), constraints=(/5: [/'1993-07-01' - /'1993-09-30']; tight)]
       │    ├── select
       │    │    ├── columns: l_orderkey:10(int!null) l_commitdate:21(date!null) l_receiptdate:22(date!null)
+      │    │    ├── ordering: +10
       │    │    ├── scan lineitem
-      │    │    │    └── columns: l_orderkey:10(int!null) l_commitdate:21(date!null) l_receiptdate:22(date!null)
+      │    │    │    ├── columns: l_orderkey:10(int!null) l_commitdate:21(date!null) l_receiptdate:22(date!null)
+      │    │    │    └── ordering: +10
       │    │    └── filters
       │    │         └── l_commitdate < l_receiptdate [type=bool, outer=(21,22), constraints=(/21: (/NULL - ]; /22: (/NULL - ])]
-      │    └── filters
-      │         └── l_orderkey = o_orderkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+      │    └── filters (true)
       └── aggregations
            └── count-rows [type=int]
 
@@ -836,15 +842,16 @@ sort
       │    │    │    │    │         └── s_nationkey = n_nationkey [type=bool, outer=(37,41), constraints=(/37: (/NULL - ]; /41: (/NULL - ]), fd=(37)==(41), (41)==(37)]
       │    │    │    │    └── filters
       │    │    │    │         └── l_suppkey = s_suppkey [type=bool, outer=(20,34), constraints=(/20: (/NULL - ]; /34: (/NULL - ]), fd=(20)==(34), (34)==(20)]
-      │    │    │    ├── index-join orders
+      │    │    │    ├── select
       │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null)
       │    │    │    │    ├── key: (9)
       │    │    │    │    ├── fd: (9)-->(10,13)
-      │    │    │    │    └── scan orders@o_od
-      │    │    │    │         ├── columns: o_orderkey:9(int!null) o_orderdate:13(date!null)
-      │    │    │    │         ├── constraint: /13/9: [/'1994-01-01' - /'1994-12-31']
-      │    │    │    │         ├── key: (9)
-      │    │    │    │         └── fd: (9)-->(13)
+      │    │    │    │    ├── scan orders
+      │    │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null)
+      │    │    │    │    │    ├── key: (9)
+      │    │    │    │    │    └── fd: (9)-->(10,13)
+      │    │    │    │    └── filters
+      │    │    │    │         └── (o_orderdate >= '1994-01-01') AND (o_orderdate < '1995-01-01') [type=bool, outer=(13), constraints=(/13: [/'1994-01-01' - /'1994-12-31']; tight)]
       │    │    │    └── filters
       │    │    │         └── l_orderkey = o_orderkey [type=bool, outer=(9,18), constraints=(/9: (/NULL - ]; /18: (/NULL - ]), fd=(9)==(18), (18)==(9)]
       │    │    ├── scan customer@c_nk
@@ -895,15 +902,11 @@ scalar-group-by
  │    ├── columns: column17:17(float)
  │    ├── select
  │    │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
- │    │    ├── index-join lineitem
- │    │    │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
- │    │    │    └── scan lineitem@l_sd
- │    │    │         ├── columns: l_orderkey:1(int!null) l_linenumber:4(int!null) l_shipdate:11(date!null)
- │    │    │         ├── constraint: /11/1/4: [/'1994-01-01' - /'1994-12-31']
- │    │    │         ├── key: (1,4)
- │    │    │         └── fd: (1,4)-->(11)
+ │    │    ├── scan lineitem
+ │    │    │    └── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
  │    │    └── filters
  │    │         ├── (l_discount >= 0.05) AND (l_discount <= 0.07) [type=bool, outer=(7), constraints=(/7: [/0.05 - /0.07]; tight)]
+ │    │         ├── (l_shipdate >= '1994-01-01') AND (l_shipdate < '1995-01-01') [type=bool, outer=(11), constraints=(/11: [/'1994-01-01' - /'1994-12-31']; tight)]
  │    │         └── l_quantity < 24.0 [type=bool, outer=(5), constraints=(/5: (/NULL - /23.999999999999996]; tight)]
  │    └── projections
  │         └── l_extendedprice * l_discount [type=float, outer=(6,7)]
@@ -1020,13 +1023,12 @@ group-by
  │         │    │    │    │    └── fd: (41)-->(42)
  │         │    │    │    └── filters
  │         │    │    │         └── ((n1.n_name = 'FRANCE') AND (n2.n_name = 'GERMANY')) OR ((n1.n_name = 'GERMANY') AND (n2.n_name = 'FRANCE')) [type=bool, outer=(42,46)]
- │         │    │    ├── index-join lineitem
+ │         │    │    ├── select
  │         │    │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null)
- │         │    │    │    └── scan lineitem@l_sd
- │         │    │    │         ├── columns: l_orderkey:8(int!null) l_linenumber:11(int!null) l_shipdate:18(date!null)
- │         │    │    │         ├── constraint: /18/8/11: [/'1995-01-01' - /'1996-12-31']
- │         │    │    │         ├── key: (8,11)
- │         │    │    │         └── fd: (8,11)-->(18)
+ │         │    │    │    ├── scan lineitem
+ │         │    │    │    │    └── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null)
+ │         │    │    │    └── filters
+ │         │    │    │         └── (l_shipdate >= '1995-01-01') AND (l_shipdate <= '1996-12-31') [type=bool, outer=(18), constraints=(/18: [/'1995-01-01' - /'1996-12-31']; tight)]
  │         │    │    └── filters
  │         │    │         └── o_orderkey = l_orderkey [type=bool, outer=(8,24), constraints=(/8: (/NULL - ]; /24: (/NULL - ]), fd=(8)==(24), (24)==(8)]
  │         │    ├── scan supplier@s_nk
@@ -1167,15 +1169,16 @@ sort
       │    │    │    │    │    │    │    │    │    └── filters
       │    │    │    │    │    │    │    │    │         └── c_nationkey = n1.n_nationkey [type=bool, outer=(45,50), constraints=(/45: (/NULL - ]; /50: (/NULL - ]), fd=(45)==(50), (50)==(45)]
       │    │    │    │    │    │    │    │    └── filters (true)
-      │    │    │    │    │    │    │    ├── index-join orders
+      │    │    │    │    │    │    │    ├── select
       │    │    │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null)
       │    │    │    │    │    │    │    │    ├── key: (33)
       │    │    │    │    │    │    │    │    ├── fd: (33)-->(34,37)
-      │    │    │    │    │    │    │    │    └── scan orders@o_od
-      │    │    │    │    │    │    │    │         ├── columns: o_orderkey:33(int!null) o_orderdate:37(date!null)
-      │    │    │    │    │    │    │    │         ├── constraint: /37/33: [/'1995-01-01' - /'1996-12-31']
-      │    │    │    │    │    │    │    │         ├── key: (33)
-      │    │    │    │    │    │    │    │         └── fd: (33)-->(37)
+      │    │    │    │    │    │    │    │    ├── scan orders
+      │    │    │    │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null)
+      │    │    │    │    │    │    │    │    │    ├── key: (33)
+      │    │    │    │    │    │    │    │    │    └── fd: (33)-->(34,37)
+      │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │    │         └── (o_orderdate >= '1995-01-01') AND (o_orderdate <= '1996-12-31') [type=bool, outer=(37), constraints=(/37: [/'1995-01-01' - /'1996-12-31']; tight)]
       │    │    │    │    │    │    │    └── filters
       │    │    │    │    │    │    │         └── o_custkey = c_custkey [type=bool, outer=(34,42), constraints=(/34: (/NULL - ]; /42: (/NULL - ]), fd=(34)==(42), (42)==(34)]
       │    │    │    │    │    │    ├── scan lineitem
@@ -1393,21 +1396,19 @@ limit
  │         │    │    │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) c_address:3(varchar!null) c_nationkey:4(int!null) c_phone:5(char!null) c_acctbal:6(float!null) c_comment:8(varchar!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(char!null)
  │         │    │    │    ├── key columns: [10] = [1]
  │         │    │    │    ├── fd: ()-->(26), (9)-->(10,13), (9)==(18), (18)==(9), (1)-->(2-6,8), (1)==(10), (10)==(1)
- │         │    │    │    ├── inner-join (lookup lineitem)
+ │         │    │    │    ├── inner-join (lookup orders)
  │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(char!null)
- │         │    │    │    │    ├── key columns: [9] = [18]
+ │         │    │    │    │    ├── key columns: [18] = [9]
  │         │    │    │    │    ├── fd: ()-->(26), (9)-->(10,13), (9)==(18), (18)==(9)
- │         │    │    │    │    ├── index-join orders
- │         │    │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null)
- │         │    │    │    │    │    ├── key: (9)
- │         │    │    │    │    │    ├── fd: (9)-->(10,13)
- │         │    │    │    │    │    └── scan orders@o_od
- │         │    │    │    │    │         ├── columns: o_orderkey:9(int!null) o_orderdate:13(date!null)
- │         │    │    │    │    │         ├── constraint: /13/9: [/'1993-10-01' - /'1993-12-31']
- │         │    │    │    │    │         ├── key: (9)
- │         │    │    │    │    │         └── fd: (9)-->(13)
+ │         │    │    │    │    ├── select
+ │         │    │    │    │    │    ├── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(char!null)
+ │         │    │    │    │    │    ├── fd: ()-->(26)
+ │         │    │    │    │    │    ├── scan lineitem
+ │         │    │    │    │    │    │    └── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(char!null)
+ │         │    │    │    │    │    └── filters
+ │         │    │    │    │    │         └── l_returnflag = 'R' [type=bool, outer=(26), constraints=(/26: [/'R' - /'R']; tight), fd=()-->(26)]
  │         │    │    │    │    └── filters
- │         │    │    │    │         └── l_returnflag = 'R' [type=bool, outer=(26), constraints=(/26: [/'R' - /'R']; tight), fd=()-->(26)]
+ │         │    │    │    │         └── (o_orderdate >= '1993-10-01') AND (o_orderdate < '1994-01-01') [type=bool, outer=(13), constraints=(/13: [/'1993-10-01' - /'1993-12-31']; tight)]
  │         │    │    │    └── filters (true)
  │         │    │    └── filters (true)
  │         │    └── projections
@@ -1606,45 +1607,40 @@ GROUP BY
 ORDER BY
     l_shipmode;
 ----
-group-by
+sort
  ├── columns: l_shipmode:24(char!null) high_line_count:27(decimal) low_line_count:29(decimal)
- ├── grouping columns: l_shipmode:24(char!null)
  ├── key: (24)
  ├── fd: (24)-->(27,29)
  ├── ordering: +24
- ├── project
- │    ├── columns: column26:26(int) column28:28(int) l_shipmode:24(char!null)
- │    ├── ordering: +24
- │    ├── inner-join (lookup orders)
- │    │    ├── columns: o_orderkey:1(int!null) o_orderpriority:6(char!null) l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(char!null)
- │    │    ├── key columns: [10] = [1]
- │    │    ├── fd: (1)-->(6), (1)==(10), (10)==(1)
- │    │    ├── ordering: +24
- │    │    ├── sort
- │    │    │    ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(char!null)
- │    │    │    ├── ordering: +24
- │    │    │    └── select
- │    │    │         ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(char!null)
- │    │    │         ├── index-join lineitem
- │    │    │         │    ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(char!null)
- │    │    │         │    └── scan lineitem@l_rd
- │    │    │         │         ├── columns: l_orderkey:10(int!null) l_linenumber:13(int!null) l_receiptdate:22(date!null)
- │    │    │         │         ├── constraint: /22/10/13: [/'1994-01-01' - /'1994-12-31']
- │    │    │         │         ├── key: (10,13)
- │    │    │         │         └── fd: (10,13)-->(22)
- │    │    │         └── filters
- │    │    │              ├── l_shipmode IN ('MAIL', 'SHIP') [type=bool, outer=(24), constraints=(/24: [/'MAIL' - /'MAIL'] [/'SHIP' - /'SHIP']; tight)]
- │    │    │              ├── l_commitdate < l_receiptdate [type=bool, outer=(21,22), constraints=(/21: (/NULL - ]; /22: (/NULL - ])]
- │    │    │              └── l_shipdate < l_commitdate [type=bool, outer=(20,21), constraints=(/20: (/NULL - ]; /21: (/NULL - ])]
- │    │    └── filters (true)
- │    └── projections
- │         ├── CASE WHEN (o_orderpriority = '1-URGENT') OR (o_orderpriority = '2-HIGH') THEN 1 ELSE 0 END [type=int, outer=(6)]
- │         └── CASE WHEN (o_orderpriority != '1-URGENT') AND (o_orderpriority != '2-HIGH') THEN 1 ELSE 0 END [type=int, outer=(6)]
- └── aggregations
-      ├── sum [type=decimal, outer=(26)]
-      │    └── variable: column26 [type=int]
-      └── sum [type=decimal, outer=(28)]
-           └── variable: column28 [type=int]
+ └── group-by
+      ├── columns: l_shipmode:24(char!null) sum:27(decimal) sum:29(decimal)
+      ├── grouping columns: l_shipmode:24(char!null)
+      ├── key: (24)
+      ├── fd: (24)-->(27,29)
+      ├── project
+      │    ├── columns: column26:26(int) column28:28(int) l_shipmode:24(char!null)
+      │    ├── inner-join (lookup orders)
+      │    │    ├── columns: o_orderkey:1(int!null) o_orderpriority:6(char!null) l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(char!null)
+      │    │    ├── key columns: [10] = [1]
+      │    │    ├── fd: (1)-->(6), (1)==(10), (10)==(1)
+      │    │    ├── select
+      │    │    │    ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(char!null)
+      │    │    │    ├── scan lineitem
+      │    │    │    │    └── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(char!null)
+      │    │    │    └── filters
+      │    │    │         ├── (l_receiptdate >= '1994-01-01') AND (l_receiptdate < '1995-01-01') [type=bool, outer=(22), constraints=(/22: [/'1994-01-01' - /'1994-12-31']; tight)]
+      │    │    │         ├── l_shipmode IN ('MAIL', 'SHIP') [type=bool, outer=(24), constraints=(/24: [/'MAIL' - /'MAIL'] [/'SHIP' - /'SHIP']; tight)]
+      │    │    │         ├── l_commitdate < l_receiptdate [type=bool, outer=(21,22), constraints=(/21: (/NULL - ]; /22: (/NULL - ])]
+      │    │    │         └── l_shipdate < l_commitdate [type=bool, outer=(20,21), constraints=(/20: (/NULL - ]; /21: (/NULL - ])]
+      │    │    └── filters (true)
+      │    └── projections
+      │         ├── CASE WHEN (o_orderpriority = '1-URGENT') OR (o_orderpriority = '2-HIGH') THEN 1 ELSE 0 END [type=int, outer=(6)]
+      │         └── CASE WHEN (o_orderpriority != '1-URGENT') AND (o_orderpriority != '2-HIGH') THEN 1 ELSE 0 END [type=int, outer=(6)]
+      └── aggregations
+           ├── sum [type=decimal, outer=(26)]
+           │    └── variable: column26 [type=int]
+           └── sum [type=decimal, outer=(28)]
+                └── variable: column28 [type=int]
 
 # --------------------------------------------------
 # Q13
@@ -1757,18 +1753,21 @@ project
  │    ├── fd: ()-->(27,29)
  │    ├── project
  │    │    ├── columns: column26:26(float) column28:28(float)
- │    │    ├── inner-join (lookup part)
+ │    │    ├── inner-join
  │    │    │    ├── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null) p_partkey:17(int!null) p_type:21(varchar!null)
- │    │    │    ├── key columns: [2] = [17]
  │    │    │    ├── fd: (17)-->(21), (2)==(17), (17)==(2)
- │    │    │    ├── index-join lineitem
+ │    │    │    ├── scan part
+ │    │    │    │    ├── columns: p_partkey:17(int!null) p_type:21(varchar!null)
+ │    │    │    │    ├── key: (17)
+ │    │    │    │    └── fd: (17)-->(21)
+ │    │    │    ├── select
  │    │    │    │    ├── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
- │    │    │    │    └── scan lineitem@l_sd
- │    │    │    │         ├── columns: l_orderkey:1(int!null) l_linenumber:4(int!null) l_shipdate:11(date!null)
- │    │    │    │         ├── constraint: /11/1/4: [/'1995-09-01' - /'1995-09-30']
- │    │    │    │         ├── key: (1,4)
- │    │    │    │         └── fd: (1,4)-->(11)
- │    │    │    └── filters (true)
+ │    │    │    │    ├── scan lineitem
+ │    │    │    │    │    └── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
+ │    │    │    │    └── filters
+ │    │    │    │         └── (l_shipdate >= '1995-09-01') AND (l_shipdate < '1995-10-01') [type=bool, outer=(11), constraints=(/11: [/'1995-09-01' - /'1995-09-30']; tight)]
+ │    │    │    └── filters
+ │    │    │         └── l_partkey = p_partkey [type=bool, outer=(2,17), constraints=(/2: (/NULL - ]; /17: (/NULL - ]), fd=(2)==(17), (17)==(2)]
  │    │    └── projections
  │    │         ├── CASE WHEN p_type LIKE 'PROMO%' THEN l_extendedprice * (1.0 - l_discount) ELSE 0.0 END [type=float, outer=(6,7,21)]
  │    │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(6,7)]
@@ -1853,13 +1852,12 @@ sort
            │    │    ├── fd: (10)-->(25)
            │    │    ├── project
            │    │    │    ├── columns: column24:24(float) l_suppkey:10(int!null)
-           │    │    │    ├── index-join lineitem
+           │    │    │    ├── select
            │    │    │    │    ├── columns: l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null)
-           │    │    │    │    └── scan lineitem@l_sd
-           │    │    │    │         ├── columns: l_orderkey:8(int!null) l_linenumber:11(int!null) l_shipdate:18(date!null)
-           │    │    │    │         ├── constraint: /18/8/11: [/'1996-01-01' - /'1996-03-31']
-           │    │    │    │         ├── key: (8,11)
-           │    │    │    │         └── fd: (8,11)-->(18)
+           │    │    │    │    ├── scan lineitem
+           │    │    │    │    │    └── columns: l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null)
+           │    │    │    │    └── filters
+           │    │    │    │         └── (l_shipdate >= '1996-01-01') AND (l_shipdate < '1996-04-01') [type=bool, outer=(18), constraints=(/18: [/'1996-01-01' - /'1996-03-31']; tight)]
            │    │    │    └── projections
            │    │    │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(13,14)]
            │    │    └── aggregations
@@ -1881,13 +1879,12 @@ sort
            │                        │    ├── fd: (28)-->(43)
            │                        │    ├── project
            │                        │    │    ├── columns: column42:42(float) l_suppkey:28(int!null)
-           │                        │    │    ├── index-join lineitem
+           │                        │    │    ├── select
            │                        │    │    │    ├── columns: l_suppkey:28(int!null) l_extendedprice:31(float!null) l_discount:32(float!null) l_shipdate:36(date!null)
-           │                        │    │    │    └── scan lineitem@l_sd
-           │                        │    │    │         ├── columns: l_orderkey:26(int!null) l_linenumber:29(int!null) l_shipdate:36(date!null)
-           │                        │    │    │         ├── constraint: /36/26/29: [/'1996-01-01' - /'1996-03-31']
-           │                        │    │    │         ├── key: (26,29)
-           │                        │    │    │         └── fd: (26,29)-->(36)
+           │                        │    │    │    ├── scan lineitem
+           │                        │    │    │    │    └── columns: l_suppkey:28(int!null) l_extendedprice:31(float!null) l_discount:32(float!null) l_shipdate:36(date!null)
+           │                        │    │    │    └── filters
+           │                        │    │    │         └── (l_shipdate >= '1996-01-01') AND (l_shipdate < '1996-04-01') [type=bool, outer=(36), constraints=(/36: [/'1996-01-01' - /'1996-03-31']; tight)]
            │                        │    │    └── projections
            │                        │    │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(31,32)]
            │                        │    └── aggregations
@@ -2399,13 +2396,12 @@ sort
            │    │    │         │    │    │    ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null) ps_availqty:14(int!null)
            │    │    │         │    │    │    ├── key: (12,13)
            │    │    │         │    │    │    └── fd: (12,13)-->(14)
-           │    │    │         │    │    ├── index-join lineitem
+           │    │    │         │    │    ├── select
            │    │    │         │    │    │    ├── columns: l_partkey:27(int!null) l_suppkey:28(int!null) l_quantity:30(float!null) l_shipdate:36(date!null)
-           │    │    │         │    │    │    └── scan lineitem@l_sd
-           │    │    │         │    │    │         ├── columns: l_orderkey:26(int!null) l_linenumber:29(int!null) l_shipdate:36(date!null)
-           │    │    │         │    │    │         ├── constraint: /36/26/29: [/'1994-01-01' - /'1994-12-31']
-           │    │    │         │    │    │         ├── key: (26,29)
-           │    │    │         │    │    │         └── fd: (26,29)-->(36)
+           │    │    │         │    │    │    ├── scan lineitem
+           │    │    │         │    │    │    │    └── columns: l_partkey:27(int!null) l_suppkey:28(int!null) l_quantity:30(float!null) l_shipdate:36(date!null)
+           │    │    │         │    │    │    └── filters
+           │    │    │         │    │    │         └── (l_shipdate >= '1994-01-01') AND (l_shipdate < '1995-01-01') [type=bool, outer=(36), constraints=(/36: [/'1994-01-01' - /'1994-12-31']; tight)]
            │    │    │         │    │    └── filters
            │    │    │         │    │         ├── l_partkey = ps_partkey [type=bool, outer=(12,27), constraints=(/12: (/NULL - ]; /27: (/NULL - ]), fd=(12)==(27), (27)==(12)]
            │    │    │         │    │         └── l_suppkey = ps_suppkey [type=bool, outer=(13,28), constraints=(/13: (/NULL - ]; /28: (/NULL - ]), fd=(13)==(28), (28)==(13)]


### PR DESCRIPTION
This commit improves the estimated distinct count for date ranges
by taking advantage of the fact that dates are discrete, rather
than continuous (unlike timestamps). This means that we can be
certain that a date range of a month, such as
`[/'1996-01-01' - /'1996-01-31']`, has no more than 31 distinct
values.

This new estimate causes us to choose a different plan for 5 of the
TPC-H queries:
```
     | Old time (s) | New time (s) | % Change
-----+--------------+--------------+----------
Q7   | 65.50        | 11.17        | -82.94%
Q8   | 56.01        | 40.15        | -28.30%
Q10  | 4.24         | 4.32         | +1.81%
Q14  | 3.18         | 3.18         | +0.05%
Q20  | 41.01        | 40.92        | -0.23%
```
Notice the improvement in Q7 and Q8! 🎉

Release note: None