### PR TITLE
exec: better empty batch handling in ordered sync

### DIFF
--- a/pkg/sql/exec/orderedsynchronizer.go
+++ b/pkg/sql/exec/orderedsynchronizer.go
@@ -137,6 +137,9 @@ func (o *orderedSynchronizer) compareRow(batchIdx1 int, batchIdx2 int) int {
 // all the relevant vectors in o.comparators.
 func (o *orderedSynchronizer) updateComparators(batchIdx int) {
 	batch := o.inputBatches[batchIdx]
+	if batch.Length() == 0 {
+		return
+	}
 	for i := range o.ordering {
 		o.comparators[i].setVec(batchIdx, batch.ColVecs()[o.ordering[i].ColIdx])
 	}


### PR DESCRIPTION
Alfonso observed that the ordered synchronizer can blow up if it
receives an empty batch with no columns. I added a simple fix.

Release note: None