### PR TITLE
release-2.1: opt: fix issue with dangling pointer in statisticsBuilder

### DIFF
--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -344,6 +344,8 @@ func (sb *statisticsBuilder) colStatLeaf(
 		colSet.ForEach(func(i int) {
 			distinctCount *= sb.colStatLeaf(util.MakeFastIntSet(i), s, fd).DistinctCount
 		})
+		// Fetch the colStat again since it may now have a different address.
+		colStat, _ = s.ColStats.Lookup(colSet)
 		colStat.DistinctCount = min(distinctCount, s.RowCount)
 	}
 

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -318,3 +318,95 @@ scan a
  ├── stats: [rows=10]
  ├── key: (1)
  └── ordering: +1
+
+# Regression test for #37953.
+exec-ddl
+CREATE TABLE t37953 (
+    a UUID NOT NULL,
+    b FLOAT8 NOT NULL,
+    c TIME NOT NULL,
+    d UUID NOT NULL,
+    e VARCHAR,
+    f "char" NULL,
+    g INT4 NOT NULL,
+    h VARCHAR NULL,
+    i REGPROC NULL,
+    j FLOAT8 NOT NULL
+)
+----
+TABLE t37953
+ ├── a uuid not null
+ ├── b float not null
+ ├── c time not null
+ ├── d uuid not null
+ ├── e string
+ ├── f string
+ ├── g int not null
+ ├── h string
+ ├── i regproc
+ ├── j float not null
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+norm
+WITH
+  subq (col0, col1)
+    AS (
+      SELECT
+        tab1.g AS col0,
+        CASE
+        WHEN ilike_escape(
+          regexp_replace(
+            tab0.h,
+            tab1.e,
+            tab0.f,
+            tab0.e::STRING
+          ),
+          tab1.f,
+          ''
+        )
+        THEN true
+        ELSE false
+        END
+          AS col1
+      FROM
+        t37953 AS tab0, t37953 AS tab1
+      WHERE
+        tab0.j IN (tab1.j,)
+    )
+SELECT
+  1
+FROM
+  subq
+WHERE
+  subq.col1;
+----
+project
+ ├── columns: "?column?":24(int!null)
+ ├── stats: [rows=1]
+ ├── fd: ()-->(24)
+ ├── select
+ │    ├── columns: col1:23(bool!null)
+ │    ├── stats: [rows=1, distinct(23)=1]
+ │    ├── fd: ()-->(23)
+ │    ├── project
+ │    │    ├── columns: col1:23(bool)
+ │    │    ├── stats: [rows=333333.333, distinct(23)=333333.333]
+ │    │    ├── inner-join
+ │    │    │    ├── columns: t37953.e:5(string) t37953.f:6(string) t37953.h:8(string) t37953.j:10(float!null) t37953.e:16(string) t37953.f:17(string) t37953.j:21(float!null)
+ │    │    │    ├── stats: [rows=333333.333, distinct(5,6,8,16,17)=333333.333]
+ │    │    │    ├── scan t37953
+ │    │    │    │    ├── columns: t37953.e:5(string) t37953.f:6(string) t37953.h:8(string) t37953.j:10(float!null)
+ │    │    │    │    └── stats: [rows=1000, distinct(5,6,8)=1000]
+ │    │    │    ├── scan t37953
+ │    │    │    │    ├── columns: t37953.e:16(string) t37953.f:17(string) t37953.j:21(float!null)
+ │    │    │    │    └── stats: [rows=1000, distinct(16,17)=1000]
+ │    │    │    └── filters [type=bool, outer=(10,21)]
+ │    │    │         └── t37953.j IN (t37953.j,) [type=bool, outer=(10,21)]
+ │    │    └── projections [outer=(5,6,8,16,17)]
+ │    │         └── CASE WHEN ilike_escape(regexp_replace(t37953.h, t37953.e, t37953.f, t37953.e), t37953.f, '') THEN true ELSE false END [type=bool, outer=(5,6,8,16,17)]
+ │    └── filters [type=bool, outer=(23), constraints=(/23: [/true - /true]; tight), fd=()-->(23)]
+ │         └── variable: col1 [type=bool, outer=(23), constraints=(/23: [/true - /true]; tight)]
+ └── projections
+      └── const: 1 [type=int]

--- a/pkg/sql/opt/props/col_stats_map.go
+++ b/pkg/sql/opt/props/col_stats_map.go
@@ -99,6 +99,10 @@ func (m *ColStatsMap) Count() int {
 
 // Get returns the nth statistic in the map, by its ordinal position. This
 // position is stable across calls to Get or Add (but not RemoveIntersecting).
+// NOTE: The returned *ColumnStatistic is only valid until this ColStatsMap is
+//       updated via a call to Add() or RemoveIntersecting(). At that point,
+//       the address of the statistic may have changed, so it must be fetched
+//       again using another call to Get() or Lookup().
 func (m *ColStatsMap) Get(nth int) *ColumnStatistic {
 	if nth < initialColStatsCap {
 		return &m.initial[nth]
@@ -108,6 +112,10 @@ func (m *ColStatsMap) Get(nth int) *ColumnStatistic {
 
 // Lookup returns the column statistic indexed by the given column set. If no
 // such statistic exists in the map, then ok=false.
+// NOTE: The returned *ColumnStatistic is only valid until this ColStatsMap is
+//       updated via a call to Add() or RemoveIntersecting(). At that point,
+//       the address of the statistic may have changed, so it must be fetched
+//       again using another call to Lookup() or Get().
 func (m *ColStatsMap) Lookup(cols opt.ColSet) (colStat *ColumnStatistic, ok bool) {
 	// Scan the inlined statistics if there are only a few statistics in the map.
 	if m.count <= initialColStatsCap {
@@ -151,6 +159,10 @@ func (m *ColStatsMap) Lookup(cols opt.ColSet) (colStat *ColumnStatistic, ok bool
 // it does not yet exist in the map, then Add adds a new blank ColumnStatistic
 // and returns it, along with added=true. Otherwise, Add returns the existing
 // ColumnStatistic with added=false.
+// NOTE: The returned *ColumnStatistic is only valid until this ColStatsMap is
+//       updated via another call to Add() or RemoveIntersecting(). At that
+//       point, the address of the statistic may have changed, so it must be
+//       fetched again using Lookup() or Get().
 func (m *ColStatsMap) Add(cols opt.ColSet) (_ *ColumnStatistic, added bool) {
 	// Only add column set if it is not already present in the map.
 	colStat, ok := m.Lookup(cols)


### PR DESCRIPTION
Backport 1/1 commits from #37983.

/cc @cockroachdb/release

---

This commit fixes an issue where the `statisticsBuilder` was using
an invalid pointer to update statistics for some multi-column stats
in the local table statistics cache. The fix is to re-fetch the
pointer to the stats just before updating them, in case the
previously fetched address is no longer valid.

This problem is very hard to reproduce, so I had to use the somewhat
complex query from the issue for a regression test.

Fixes #37953

Release note: None
