### PR TITLE
testutils/pgtest: add new pgtest package

### DIFF
--- a/pkg/sql/pgwire/pgtest_test.go
+++ b/pkg/sql/pgwire/pgtest_test.go
@@ -1,0 +1,49 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL.txt and at www.mariadb.com/bsl11.
+//
+// Change Date: 2022-10-01
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt and at
+// https://www.apache.org/licenses/LICENSE-2.0
+
+package pgwire
+
+import (
+	"context"
+	"flag"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/testutils/pgtest"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+var (
+	flagAddr = flag.String("addr", "", "pass a custom postgres address to TestWalk instead of starting an in-memory node")
+	flagUser = flag.String("user", "postgres", "username used if -addr is specified")
+)
+
+func TestPGTest(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	addr := *flagAddr
+	user := *flagUser
+	if addr == "" {
+		ctx := context.Background()
+		s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+			Insecure: true,
+		})
+		defer s.Stopper().Stop(ctx)
+
+		addr = s.Addr()
+		user = security.RootUser
+	}
+
+	pgtest.Walk(t, "testdata/pgtest", addr, user)
+}

--- a/pkg/sql/pgwire/testdata/pgtest/simple
+++ b/pkg/sql/pgwire/testdata/pgtest/simple
@@ -1,0 +1,11 @@
+send
+Query {"String": "SELECT 2::int8"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"RowDescription","Fields":[{"Name":"int8","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"2"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/testdata/pgtest/update_limit
+++ b/pkg/sql/pgwire/testdata/pgtest/update_limit
@@ -1,0 +1,43 @@
+send
+Query {"String": "DROP TABLE IF EXISTS t; CREATE TABLE t (i int8); INSERT INTO t VALUES (1), (2);"}
+----
+
+# drop sometimes produces a notice
+until ignore=NoticeResponse
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DROP TABLE"}
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"CommandComplete","CommandTag":"INSERT 0 2"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Run an update that will affect multiple rows, but Execute with only 1 row
+# specified. The spec says maxrows should be ignored in this case, so we
+# expected both rows to be updated.
+send
+Parse {"Query": "UPDATE t SET i = -i"}
+Bind
+Execute {"MaxRows": 1}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"UPDATE 2"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "SELECT * FROM t"}
+----
+
+# ignore row desc due to oid mismatch
+until ignore=RowDescription
+ReadyForQuery
+----
+{"Type":"DataRow","Values":[{"text":"-1"}]}
+{"Type":"DataRow","Values":[{"text":"-2"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 2"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/testutils/pgtest/datadriven.go
+++ b/pkg/testutils/pgtest/datadriven.go
@@ -1,0 +1,144 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL.txt and at www.mariadb.com/bsl11.
+//
+// Change Date: 2022-10-01
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt and at
+// https://www.apache.org/licenses/LICENSE-2.0
+
+package pgtest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/datadriven"
+	"github.com/jackc/pgx/pgproto3"
+)
+
+// Walk walks path for datadriven files and calls RunTest on them.
+func Walk(t *testing.T, path, addr, user string) {
+	datadriven.Walk(t, path, func(t *testing.T, path string) {
+		RunTest(t, path, addr, user)
+	})
+}
+
+// RunTest executes PGTest commands, connecting to the database specified by
+// addr and user. Supported commands:
+//
+// "send": Sends messages to a server. Takes a newline-delimited list of
+// pgproto3.FrontendMessage types. Can fill in values by adding a space then
+// a JSON object. No output.
+//
+// "until": Receives all messages from a server until messages of the given
+// types have been seen. Converts them to JSON one per line as output. Takes
+// a newline-delimited list of pgproto3.BackendMessage types. An ignore option
+// can be used to specify types to ignore.
+//
+// "receive": Like "until", but only output matching messages instead of all
+// messages.
+func RunTest(t *testing.T, path, addr, user string) {
+	p, err := NewPGTest(context.Background(), addr, user)
+	if err != nil {
+		t.Fatal(err)
+	}
+	datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
+		switch d.Cmd {
+		case "send":
+			for _, line := range strings.Split(d.Input, "\n") {
+				sp := strings.SplitN(line, " ", 2)
+				msg := toMessage(sp[0])
+				if len(sp) == 2 {
+					if err := json.Unmarshal([]byte(sp[1]), msg); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if err := p.Send(msg.(pgproto3.FrontendMessage)); err != nil {
+					t.Fatalf("%s: send %s: %v", d.Pos, line, err)
+				}
+			}
+			return ""
+		case "receive":
+			until := parseMessages(d.Input)
+			msgs, err := p.Receive(until...)
+			if err != nil {
+				t.Fatalf("%s: %+v", d.Pos, err)
+			}
+			return msgsToJSONWithIgnore(msgs, d)
+		case "until":
+			until := parseMessages(d.Input)
+			msgs, err := p.Until(until...)
+			if err != nil {
+				t.Fatalf("%s: %+v", d.Pos, err)
+			}
+			return msgsToJSONWithIgnore(msgs, d)
+		default:
+			t.Fatalf("unknown command %s", d.Cmd)
+			return ""
+		}
+	})
+	if err := p.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+func parseMessages(s string) []pgproto3.BackendMessage {
+	var msgs []pgproto3.BackendMessage
+	for _, typ := range strings.Split(s, "\n") {
+		msgs = append(msgs, toMessage(typ).(pgproto3.BackendMessage))
+	}
+	return msgs
+}
+
+func msgsToJSONWithIgnore(msgs []pgproto3.BackendMessage, args *datadriven.TestData) string {
+	ignore := map[string]bool{}
+	for _, arg := range args.CmdArgs {
+		if arg.Key == "ignore" {
+			for _, typ := range arg.Vals {
+				ignore[fmt.Sprintf("*pgproto3.%s", typ)] = true
+			}
+		}
+	}
+	var sb strings.Builder
+	enc := json.NewEncoder(&sb)
+	for _, msg := range msgs {
+		if ignore[fmt.Sprintf("%T", msg)] {
+			continue
+		}
+		if err := enc.Encode(msg); err != nil {
+			panic(err)
+		}
+	}
+	return sb.String()
+}
+
+func toMessage(typ string) interface{} {
+	switch typ {
+	case "Bind":
+		return &pgproto3.Bind{}
+	case "CommandComplete":
+		return &pgproto3.CommandComplete{}
+	case "DataRow":
+		return &pgproto3.DataRow{}
+	case "Execute":
+		return &pgproto3.Execute{}
+	case "Parse":
+		return &pgproto3.Parse{}
+	case "Query":
+		return &pgproto3.Query{}
+	case "ReadyForQuery":
+		return &pgproto3.ReadyForQuery{}
+	case "Sync":
+		return &pgproto3.Sync{}
+	default:
+		panic(fmt.Errorf("unknown type %s", typ))
+	}
+}

--- a/pkg/testutils/pgtest/pgtest.go
+++ b/pkg/testutils/pgtest/pgtest.go
@@ -1,0 +1,125 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL.txt and at www.mariadb.com/bsl11.
+//
+// Change Date: 2022-10-01
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt and at
+// https://www.apache.org/licenses/LICENSE-2.0
+
+package pgtest
+
+import (
+	"context"
+	"net"
+	"reflect"
+
+	"github.com/jackc/pgx/pgproto3"
+	"github.com/pkg/errors"
+)
+
+// PGTest can be used to send and receive arbitrary pgwire messages on
+// Postgres-compatible servers.
+type PGTest struct {
+	fe   *pgproto3.Frontend
+	conn net.Conn
+}
+
+// NewPGTest connects to a Postgres server at addr with username user.
+func NewPGTest(ctx context.Context, addr, user string) (*PGTest, error) {
+	var d net.Dialer
+	conn, err := d.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, errors.Wrap(err, "dial")
+	}
+	success := false
+	defer func() {
+		if !success {
+			conn.Close()
+		}
+	}()
+	fe, err := pgproto3.NewFrontend(conn, conn)
+	if err != nil {
+		return nil, errors.Wrap(err, "new frontend")
+	}
+	if err := fe.Send(&pgproto3.StartupMessage{
+		ProtocolVersion: 196608, // Version 3.0
+		Parameters: map[string]string{
+			"user": user,
+		},
+	}); err != nil {
+		return nil, errors.Wrap(err, "startup")
+	}
+	if msg, err := fe.Receive(); err != nil {
+		return nil, errors.Wrap(err, "receive")
+	} else if auth, ok := msg.(*pgproto3.Authentication); !ok || auth.Type != 0 {
+		return nil, errors.Errorf("unexpected: %#v", msg)
+	}
+	p := &PGTest{
+		fe:   fe,
+		conn: conn,
+	}
+	_, err = p.Until(&pgproto3.ReadyForQuery{})
+	success = err == nil
+	return p, err
+}
+
+// Close sends a Terminate message and closes the connection.
+func (p *PGTest) Close() error {
+	defer p.conn.Close()
+	return p.fe.Send(&pgproto3.Terminate{})
+}
+
+// Send sends msg to the serrver.
+func (p *PGTest) Send(msg pgproto3.FrontendMessage) error {
+	return p.fe.Send(msg)
+}
+
+// Receive reads messages until messages of the given types have been found
+// in the specified order (with any number of messages in between). It returns
+// matched messages.
+func (p *PGTest) Receive(typs ...pgproto3.BackendMessage) ([]pgproto3.BackendMessage, error) {
+	var matched []pgproto3.BackendMessage
+	for len(typs) > 0 {
+		msgs, err := p.Until(typs[0])
+		if err != nil {
+			return nil, err
+		}
+		matched = append(matched, msgs[len(msgs)-1])
+		typs = typs[1:]
+	}
+	return matched, nil
+}
+
+// Until is like Receive except all messages are returned instead of only
+// matched messages.
+func (p *PGTest) Until(typs ...pgproto3.BackendMessage) ([]pgproto3.BackendMessage, error) {
+	var msgs []pgproto3.BackendMessage
+	for len(typs) > 0 {
+		// Receive messages and make copies of them.
+		recv, err := p.fe.Receive()
+		if err != nil {
+			return nil, errors.Wrap(err, "receive")
+		}
+		if errmsg, ok := recv.(*pgproto3.ErrorResponse); ok {
+			return nil, errors.Errorf("waiting for %T, got %#v", typs[0], errmsg)
+		}
+		data := recv.Encode(nil)
+		// Trim off message type and length.
+		data = data[5:]
+
+		x := reflect.New(reflect.ValueOf(recv).Elem().Type())
+		msg := x.Interface().(pgproto3.BackendMessage)
+		if err := msg.Decode(data); err != nil {
+			return nil, errors.Wrap(err, "decode")
+		}
+		msgs = append(msgs, msg)
+		if reflect.TypeOf(typs[0]) == reflect.TypeOf(msg) {
+			typs = typs[1:]
+		}
+	}
+	return msgs, nil
+}


### PR DESCRIPTION
pgtest is a new package to enable pgwire protocol message tests to be written
in a datadriven way from Postgres. The package provides some functions to do
this and functions that work with the datadriven package as helpers.

Release note: None