### PR TITLE
batcheval: refactor split trigger stats computation

### DIFF
--- a/pkg/storage/batcheval/cmd_end_transaction.go
+++ b/pkg/storage/batcheval/cmd_end_transaction.go
@@ -830,20 +830,46 @@ func splitTrigger(
 			split.RightDesc.StartKey, split.RightDesc.EndKey, desc)
 	}
 
-	// Preserve stats for pre-split range, excluding the current batch.
-	origBothMS := rec.GetMVCCStats()
+	// Compute the absolute stats for the (post-split) LHS. No more
+	// modifications to it are allowed after this line.
 
-	// TODO(d4l3k): we should check which side of the split is smaller
-	// and compute stats for it instead of having a constraint that the
-	// left hand side is smaller.
-
-	// Compute (absolute) stats for LHS range. Don't write to the LHS below;
-	// this needs to happen before this step.
 	leftMS, err := rditer.ComputeStatsForRange(&split.LeftDesc, batch, ts.WallTime)
 	if err != nil {
 		return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to compute stats for LHS range after split")
 	}
 	log.Event(ctx, "computed stats for left hand side range")
+
+	h := SplitStatsHelperInput{
+		AbsPreSplitBothEstimated: rec.GetMVCCStats(),
+		DeltaBatchEstimated:      bothDeltaMS,
+		AbsPostSplitLeft:         leftMS,
+		AbsPostSplitRightFn: func() (enginepb.MVCCStats, error) {
+			rightMS, err := rditer.ComputeStatsForRange(
+				&split.RightDesc, batch, ts.WallTime,
+			)
+			return rightMS, errors.Wrap(
+				err,
+				"unable to compute stats for RHS range after split",
+			)
+		},
+	}
+	return splitTriggerHelper(ctx, rec, batch, h, split, ts)
+}
+
+func splitTriggerHelper(
+	ctx context.Context,
+	rec EvalContext,
+	batch engine.Batch,
+	statsInput SplitStatsHelperInput,
+	split *roachpb.SplitTrigger,
+	ts hlc.Timestamp,
+) (enginepb.MVCCStats, result.Result, error) {
+	// TODO(d4l3k): we should check which side of the split is smaller
+	// and compute stats for it instead of having a constraint that the
+	// left hand side is smaller.
+
+	// NB: the replicated post-split left hand keyspace is frozen at this point.
+	// Only the RHS can be mutated (and we do so to seed its state).
 
 	// Copy the last replica GC timestamp. This value is unreplicated,
 	// which is why the MVCC stats are set to nil on calls to
@@ -856,45 +882,16 @@ func splitTrigger(
 		return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to copy last replica GC timestamp")
 	}
 
-	// Initialize the RHS range's AbortSpan by copying the LHS's.
-	if err := rec.AbortSpan().CopyTo(
-		ctx, batch, batch, &bothDeltaMS, ts, split.RightDesc.RangeID,
-	); err != nil {
+	h, err := MakeSplitStatsHelper(statsInput)
+	if err != nil {
 		return enginepb.MVCCStats{}, result.Result{}, err
 	}
 
-	// Compute (absolute) stats for RHS range.
-	var rightMS enginepb.MVCCStats
-	if origBothMS.ContainsEstimates || bothDeltaMS.ContainsEstimates {
-		// Because either the original stats or the delta stats contain
-		// estimate values, we cannot perform arithmetic to determine the
-		// new range's stats. Instead, we must recompute by iterating
-		// over the keys and counting.
-		rightMS, err = rditer.ComputeStatsForRange(&split.RightDesc, batch, ts.WallTime)
-		if err != nil {
-			return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to compute stats for RHS range after split")
-		}
-	} else {
-		// Because neither the original stats nor the delta stats contain
-		// estimate values, we can safely perform arithmetic to determine the
-		// new range's stats. The calculation looks like:
-		//   rhs_ms = orig_both_ms - orig_left_ms + right_delta_ms
-		//          = orig_both_ms - left_ms + left_delta_ms + right_delta_ms
-		//          = orig_both_ms - left_ms + delta_ms
-		// where the following extra helper variables are used:
-		// - orig_left_ms: the left-hand side key range, before the split
-		// - (left|right)_delta_ms: the contributions to bothDeltaMS in this batch,
-		//   itemized by the side of the split.
-		//
-		// Note that the result of that computation never has ContainsEstimates
-		// set due to none of the inputs having it.
-
-		// Start with the full stats before the split.
-		rightMS = origBothMS
-		// Remove stats from the left side of the split, at the same time adding
-		// the batch contributions for the right-hand side.
-		rightMS.Subtract(leftMS)
-		rightMS.Add(bothDeltaMS)
+	// Initialize the RHS range's AbortSpan by copying the LHS's.
+	if err := rec.AbortSpan().CopyTo(
+		ctx, batch, batch, h.AbsPostSplitRight(), ts, split.RightDesc.RangeID,
+	); err != nil {
+		return enginepb.MVCCStats{}, result.Result{}, err
 	}
 
 	// Note: we don't copy the queue last processed times. This means
@@ -908,8 +905,6 @@ func splitTrigger(
 	// initial state. Additionally, since bothDeltaMS is tracking writes to
 	// both sides, we need to update it as well.
 	{
-		preRightMS := rightMS // for bothDeltaMS
-
 		// Various pieces of code rely on a replica's lease never being unitialized,
 		// but it's more than that - it ensures that we properly initialize the
 		// timestamp cache, which is only populated on the lease holder, from that
@@ -1014,8 +1009,9 @@ func splitTrigger(
 		// HardState via a call to synthesizeRaftState. Here, we only call
 		// writeInitialReplicaState which essentially writes a ReplicaState
 		// only.
-		rightMS, err = stateloader.WriteInitialReplicaState(
-			ctx, batch, rightMS, split.RightDesc,
+
+		*h.AbsPostSplitRight(), err = stateloader.WriteInitialReplicaState(
+			ctx, batch, *h.AbsPostSplitRight(), split.RightDesc,
 			rightLease, *gcThreshold, *txnSpanGCThreshold,
 			rec.ClusterSettings().Version.Version().Version,
 			truncStateType,
@@ -1023,33 +1019,27 @@ func splitTrigger(
 		if err != nil {
 			return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to write initial Replica state")
 		}
-
-		bothDeltaMS.Subtract(preRightMS)
-		bothDeltaMS.Add(rightMS)
 	}
 
-	// Compute how much data the left-hand side has shed by splitting.
-	// We've already recomputed that in absolute terms, so all we need to do is
-	// to turn it into a delta so the upstream machinery can digest it.
-	leftDeltaMS := leftMS // start with new left-hand side absolute stats
-	recStats := rec.GetMVCCStats()
-	leftDeltaMS.Subtract(recStats)        // subtract pre-split absolute stats
-	leftDeltaMS.ContainsEstimates = false // if there were any, recomputation removed them
-
-	// Perform a similar computation for the right hand side. The difference
-	// is that there isn't yet a Replica which could apply these stats, so
-	// they will go into the trigger to make the Store (which keeps running
-	// counters) aware.
-	rightDeltaMS := bothDeltaMS
-	rightDeltaMS.Subtract(leftDeltaMS)
 	var pd result.Result
 	// This makes sure that no reads are happening in parallel; see #3148.
 	pd.Replicated.BlockReads = true
 	pd.Replicated.Split = &storagepb.Split{
 		SplitTrigger: *split,
-		RHSDelta:     rightDeltaMS,
+		// NB: the RHSDelta is identical to the stats for the newly created right
+		// hand side range (i.e. it goes from zero to its stats).
+		RHSDelta: *h.AbsPostSplitRight(),
 	}
-	return leftDeltaMS, pd, nil
+
+	// HACK(tbg): ContainsEstimates isn't an additive group (there isn't a
+	// -true), and instead of "-true" we'll emit a "true". This will all be
+	// fixed when #37583 lands (and the version is active). For now hard-code
+	// false and there's also code below Raft that interprets this (coming from
+	// a split) as a signal to reset the ContainsEstimates field to false (see
+	// applyRaftCommand).
+	deltaPostSplitLeft := h.DeltaPostSplitLeft()
+	deltaPostSplitLeft.ContainsEstimates = false
+	return deltaPostSplitLeft, pd, nil
 }
 
 // mergeTrigger is called on a successful commit of an AdminMerge transaction.

--- a/pkg/storage/batcheval/split_stats_helper.go
+++ b/pkg/storage/batcheval/split_stats_helper.go
@@ -1,0 +1,177 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL.txt and at www.mariadb.com/bsl11.
+//
+// Change Date: 2022-10-01
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt and at
+// https://www.apache.org/licenses/LICENSE-2.0
+
+package batcheval
+
+import "github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+
+// SplitStatsHelper codifies and explains the stats computations related to a
+// split. The quantities known during a split (i.e. while the split trigger
+// is evaluating) are
+//
+// - AbsPreSplitBothEstimated: the stats of the range before the split trigger,
+//   i.e. without accounting for any writes in the batch. This can have
+//   ContainsEstimates set.
+// - DeltaBatchEstimated: the writes in the batch, i.e. the stats delta accrued
+//   from the evaluation of the EndTransaction so far (this is mostly the write
+//   to the transaction record, as well as resolving the intent on the range
+//   descriptor, but nothing in this code relies on that). Since we have no
+//   reason to introduce ContainsEstimates in a split trigger, this typically
+//   has ContainsEstimates unset, but the results will be estimate free either
+//   way.
+// - AbsPostSplitLeft: the stats of the range after applying the split, i.e.
+//   accounting both for the shrinking as well as for the writes in DeltaBatch
+//   related to the shrunk keyrange.
+//   In practice, we obtain this by recomputing the stats, and so we don't
+//   expect ContainsEstimates to be set in them.
+//
+// We are interested in computing from this the quantities
+//
+// - AbsPostSplitRight(): the stats of the right hand side created by the split,
+//   i.e. the data taken over from the left hand side plus whatever was written to
+//   the right hand side in the process (metadata etc). We can recompute this, but
+//   try to avoid it unless necessary (when CombinedErrorDelta below is nonzero).
+// - DeltaPostSplitLeft(): the stats delta that should be emitted by the split
+//   trigger itself, i.e. the data which the left hand side (initially comprising
+//   both halves) loses by moving data into the right hand side (including whatever
+//   DeltaBatch contained in contributions attributable to the keyspace on the
+//   left).
+// - CombinedErrorDelta: the difference between (AbsPreSplitBoth+DeltaBatch) and
+//   the recomputation of the pre-split range including the batch. This is zero if
+//   neither of the inputs contains estimates. If it's not zero, we need to
+//   recompute from scratch to obtain AbsPostSplitRight. What's interesting about
+//   this quantity is that we never care what exactly it is, but we do care
+//   whether it's zero or not because if it's zero we get to do less work.
+//
+// Moreover, we want both neither of AbsPostSplit{Right,Left} to end up with
+// estimates. The way splits are set up right now, we sort of get this "for
+// free" for the left hand side (since we recompute that unconditionally; there
+// is a guarantee that the left hand side is never too large). We also don't
+// want to create new ranges that start out with estimates (just to prevent the
+// unbounded proliferation of estimates).
+//
+// The two unknown quantities can be expressed in terms of the known quantities
+// because
+//
+// (1) AbsPreSplitBoth + DeltaBatch
+// 	                   - CombinedErrorDelta = AbsPostSplitLeft + AbsPostSplitRight
+//
+// In words, this corresponds to "all bytes are accounted for": from the initial
+// stats that we have (accounting for the fact that AbsPreSplitBoth+DeltaBatch
+// may contain estimates), everything we add/remove during the split ends up
+// tracked either on the left and on the right, and nothing is created out of
+// thin air.
+//
+// (2) AbsPreSplitBoth + DeltaPostSplitLeft() = AbsPostSplitLeft
+//
+// This expresses the fact that is always true whenever a command applies on a
+// range without introducing an estimate: the stats before the command plus the
+// delta emitted by the command equal the stats after the command. In this case,
+// the stats before the command are that of the range before the split (remember
+// that the split shrinks the range towards the start key, i.e. the left hand
+// side is the same range as the pre-split one).
+//
+// These two equations are easily solved for the unknowns. First, we can express
+// DeltaPostSplitLeft() in known quantities via (2) as
+//
+//     DeltaPostSplitLeft() = AbsPostSplitLeft - AbsPreSplitBothEstimated.
+//
+// Note that if we start out with estimates, DeltaPostSplitLeft() will wipe out
+// those estimates when added to the absolute stats.
+//
+// For AbsPostSplitRight(), there are two cases. First, due to the identity
+//
+//     CombinedErrorDelta =   AbsPreSplitBothEstimated + DeltaBatchEstimated
+//                          -(AbsPostSplitLeft + AbsPostSplitRight)
+//
+// and the fact that the second line coontains no estimates, we know that
+// CombinedErrorDelta is zero if the first line contains no estimates. Using
+// this, we can rearrange as
+//
+//     AbsPostSplitRight() = AbsPreSplitBoth + DeltaBatch - AbsPostSplitLeft.
+//
+// where all quantities on the right are known. If CombinedErrorDelta is
+// nonzero, we effectively have one more unknown in our linear system and we
+// need to recompute AbsPostSplitRight from scratch. (As fallout, we can in
+// principle compute CombinedError, but we don't care).
+type SplitStatsHelper struct {
+	in SplitStatsHelperInput
+
+	absPostSplitRight *enginepb.MVCCStats
+}
+
+// SplitStatsHelperInput is passed to MakeSplitStatsHelper.
+type SplitStatsHelperInput struct {
+	AbsPreSplitBothEstimated enginepb.MVCCStats
+	DeltaBatchEstimated      enginepb.MVCCStats
+	AbsPostSplitLeft         enginepb.MVCCStats
+	// AbsPostSplitRightFn returns the stats for the right hand side of the
+	// split. This is only called (and only once) when either of the first two
+	// fields above contains estimates, so that we can guarantee that the
+	// post-splits stats don't.
+	AbsPostSplitRightFn func() (enginepb.MVCCStats, error)
+}
+
+// MakeSplitStatsHelper initializes a SplitStatsHelper. The values in the input
+// are assumed to not change outside of the helper and must no longer be used.
+// The provided AbsPostSplitRightFn recomputes the right hand side of the split
+// after accounting for the split trigger batch. This is only invoked at most
+// once, and only when necessary.
+func MakeSplitStatsHelper(input SplitStatsHelperInput) (SplitStatsHelper, error) {
+	h := SplitStatsHelper{
+		in: input,
+	}
+
+	if !h.in.AbsPreSplitBothEstimated.ContainsEstimates &&
+		!h.in.DeltaBatchEstimated.ContainsEstimates {
+		// We have CombinedErrorDelta zero, so use arithmetic to compute
+		// AbsPostSplitRight().
+		ms := h.in.AbsPreSplitBothEstimated
+		ms.Subtract(h.in.AbsPostSplitLeft)
+		ms.Add(h.in.DeltaBatchEstimated)
+		h.absPostSplitRight = &ms
+		return h, nil
+	}
+	// Estimates are contained in the input, so ask the oracle for
+	// AbsPostSplitRight().
+	ms, err := input.AbsPostSplitRightFn()
+	if err != nil {
+		return SplitStatsHelper{}, err
+	}
+	h.absPostSplitRight = &ms
+	return h, nil
+}
+
+// AbsPostSplitRight returns the stats of the right hand side created by the
+// split. The result is returned as a pointer because the caller can freely
+// modify it, assuming they're adding only stats corresponding to mutations that
+// they know only affect the right hand side. (If estimates are introduced in
+// the process, the right hand side will start out with estimates). Implicitly
+// this changes the DeltaBatchEstimated supplied to MakeSplitStatsHelper, but
+// the contract assumes that that value will no longer be used.
+func (h SplitStatsHelper) AbsPostSplitRight() *enginepb.MVCCStats {
+	return h.absPostSplitRight
+}
+
+// DeltaPostSplitLeft return the stats delta to be emitted on the left hand side
+// as the result of the split. It accounts for the data moved to the right hand
+// side as well as any mutations to the left hand side carried out during the
+// split, and additionally removes any estimates present in the pre-split stats.
+func (h SplitStatsHelper) DeltaPostSplitLeft() enginepb.MVCCStats {
+	// NB: if we ever wanted to also write to the left hand side after init'ing
+	// the helper, we can make that work, too.
+	// NB: note how none of this depends on mutations to absPostSplitRight.
+	ms := h.in.AbsPostSplitLeft
+	ms.Subtract(h.in.AbsPreSplitBothEstimated)
+
+	return ms
+}


### PR DESCRIPTION
Pulling out the stats-related computations into a helper taylored
exactly to what happens during a split provides a convenient venue for
lengthy rumination on the finer points of said stats computations, while
decluttering the split trigger's main method.

This was motivated by #37583, which needs to adjust some of this code.
Now that it's (hopefully) more accessible, it should be more straight-
forward to figure out what exactly to do.

Release note: None