### PR TITLE
tracing: be more efficient when nothing's going on

### DIFF
--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -314,6 +314,10 @@ func (ds *ServerImpl) setupFlow(
 	if parentSpan == nil {
 		sp = ds.Tracer.(*tracing.Tracer).StartRootSpan(
 			opName, logtags.FromContext(ctx), tracing.NonRecordableSpan)
+	} else if localState.IsLocal {
+		// If we're a local flow, we don't need a "follows from" relationship: we're
+		// going to run this flow synchronously.
+		sp = tracing.StartChildSpan(opName, parentSpan, logtags.FromContext(ctx), false /* separateRecording */)
 	} else {
 		// We use FollowsFrom because the flow's span outlives the SetupFlow request.
 		// TODO(andrei): We should use something more efficient than StartSpan; we

--- a/pkg/util/tracing/shadow.go
+++ b/pkg/util/tracing/shadow.go
@@ -89,6 +89,15 @@ func linkShadowSpan(
 	var opts []opentracing.StartSpanOption
 	// Replicate the options, using the lightstep context in the reference.
 	opts = append(opts, opentracing.StartTime(s.startTime))
+	if s.startTags != nil {
+		startTags := make(opentracing.Tags)
+		tags := s.startTags.Get()
+		for i := range tags {
+			tag := &tags[i]
+			startTags[tag.Key()] = tag.Value()
+		}
+		opts = append(opts, startTags)
+	}
 	if s.mu.tags != nil {
 		opts = append(opts, s.mu.tags)
 	}

--- a/pkg/util/tracing/tracer_span.go
+++ b/pkg/util/tracing/tracer_span.go
@@ -18,6 +18,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/util/log/logtags"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	proto "github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
@@ -107,6 +108,12 @@ type span struct {
 	operation string
 	startTime time.Time
 
+	// startTags are set to the log tags that were available when this span was
+	// created, so that there's no need to eagerly copy all of those log tags
+	// into this span's tags. If the span's tags are actually requested, these
+	// startTags will be copied out at that point.
+	startTags *logtags.Buffer
+
 	// Atomic flag used to avoid taking the mutex in the hot path.
 	recording int32
 
@@ -118,7 +125,10 @@ type span struct {
 		recordingGroup *spanGroup
 		recordingType  RecordingType
 		recordedLogs   []opentracing.LogRecord
-		// tags are only set when recording.
+		// tags are only set when recording. These are tags that have been added to
+		// this span, and will be appended to the tags in startTags when someone
+		// needs to actually observe the total set of tags that is a part of this
+		// span.
 		// TODO(radu): perhaps we want a recording to capture all the tags (even
 		// those that were set before recording started)?
 		tags opentracing.Tags
@@ -535,8 +545,18 @@ func (ss *spanGroup) getSpans() []RecordedSpan {
 				rs.Baggage[k] = v
 			}
 		}
-		if len(s.mu.tags) > 0 {
+		if s.startTags != nil {
 			rs.Tags = make(map[string]string)
+			tags := s.startTags.Get()
+			for i := range tags {
+				tag := &tags[i]
+				rs.Tags[tag.Key()] = tag.ValueStr()
+			}
+		}
+		if len(s.mu.tags) > 0 {
+			if rs.Tags == nil {
+				rs.Tags = make(map[string]string)
+			}
 			for k, v := range s.mu.tags {
 				// We encode the tag values as strings.
 				rs.Tags[k] = fmt.Sprint(v)


### PR DESCRIPTION
This commit improves the efficiency of tracing infrastructure when
there's no tracing going on, removing two very hot allocation paths from
a simple kv workload.

Release note: None