### PR TITLE
opt: Add additional commentary for canary columns

### DIFF
--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -88,11 +88,24 @@ func init() {
 //   3. Computed columns which will be updated when a conflict is detected and
 //      that are dependent on one or more updated columns.
 //
-// In addition, the insert and update column expressions are merged into a
-// single set of upsert column expressions that toggle between the insert and
-// update values depending on whether the canary column is null.
+// A LEFT OUTER JOIN associates each row to insert with the corresponding
+// existing row (#1 above). If the row does not exist, then the existing columns
+// will be null-extended, per the semantics of LEFT OUTER JOIN. This behavior
+// allows the execution engine to test whether a given insert row conflicts with
+// an existing row in the table. One of the existing columns that is declared as
+// NOT NULL in the table schema is designated as a "canary column". When the
+// canary column is null after the join step, then it must have been null-
+// extended by the LEFT OUTER JOIN. Therefore, there is no existing row, and no
+// conflict. If the canary column is not null, then there is an existing row,
+// and a conflict.
 //
-// For example, if this is the schema and INSERT..ON CONFLICT statement:
+// The canary column is used in CASE statements to toggle between the insert and
+// update values for each row. If there is no conflict, the insert value is
+// used. Otherwise, the update value is used (or the existing value if there is
+// no update value for that column).
+//
+// Putting it all together, if this is the schema and INSERT..ON CONFLICT
+// statement:
 //
 //   CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT)
 //   INSERT INTO abc VALUES (1, 2) ON CONFLICT (a) DO UPDATE SET b=10
@@ -109,6 +122,10 @@ func init() {
 //   FROM (VALUES (1, 2, NULL)) AS ins(ins_a, ins_b, ins_c)
 //   LEFT OUTER JOIN abc AS fetch(fetch_a, fetch_b, fetch_c)
 //   ON ins_a = fetch_a
+//
+// Here, the fetch_a column has been designated as the canary column, since it
+// is NOT NULL in the schema. It is used as the CASE condition to decide between
+// the insert and update values for each row.
 //
 // The CASE expressions will often prevent the unnecessary evaluation of the
 // update expression in the case where an insertion needs to occur. In addition,

--- a/pkg/sql/tablewriter_upsert_opt.go
+++ b/pkg/sql/tablewriter_upsert_opt.go
@@ -41,6 +41,9 @@ import (
 // The other non-CBO upserters perform custom left lookup joins. However, that
 // doesn't allow sharing of optimization rules and doesn't work with correlated
 // SET expressions.
+//
+// For more details on how the CBO compiles UPSERT statements, see the block
+// comment on Builder.buildInsert in opt/optbuilder/insert.go.
 type optTableUpserter struct {
 	tableUpserterBase
 
@@ -100,7 +103,9 @@ func (tu *optTableUpserter) row(ctx context.Context, row tree.Datums, traceKV bo
 	tu.batchSize++
 	tu.resultCount++
 
-	// Consult the canary column to determine whether to insert or update.
+	// Consult the canary column to determine whether to insert or update. For
+	// more details on how canary columns work, see the block comment on
+	// Builder.buildInsert in opt/optbuilder/insert.go.
 	insertEnd := len(tu.ri.InsertCols)
 	if tu.canaryOrdinal == -1 {
 		// No canary column means that existing row should be overwritten (i.e.


### PR DESCRIPTION
Canary columns are used in UPSERT and INSERT ON CONFLICT statements to
choose whether to perform an insert or an update. This commit adds some
additional explanation for how they work.

Release note: None