### PR TITLE
rpc,server: move growstack.Grow into rpc below the handler

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -933,8 +933,6 @@ func (n *Node) batchInternal(
 func (n *Node) Batch(
 	ctx context.Context, args *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, error) {
-	growstack.Grow()
-
 	// NB: Node.Batch is called directly for "local" calls. We don't want to
 	// carry the associated log tags forward as doing so makes adding additional
 	// log tags more expensive and makes local calls differ from remote calls.

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -815,7 +815,7 @@ func TestLint(t *testing.T) {
 
 		if err := stream.ForEach(stream.Sequence(
 			filter,
-			stream.GrepNot(`(json|jsonpb|yaml|xml|protoutil|toml)\.Unmarshal\(`),
+			stream.GrepNot(`(json|jsonpb|yaml|xml|protoutil|toml|Codec)\.Unmarshal\(`),
 		), func(s string) {
 			t.Errorf("\n%s <- forbidden; use 'protoutil.Unmarshal' instead", s)
 		}); err != nil {


### PR DESCRIPTION
This change prevents stack growth which can happen when unmarshaling BatchRequest protos
request. Now that growStack is reasonably attributed in CPU profiles I
noticed that we were spending time copying the stack before we got into
the Batch handler. This change seems to have a pretty major win on throughput
when pushing a high concurrency in a CPU-bound setting. In particular I was running
on a 3-node AWS m5d.xlarge cluster using kv95 with 32.
The win is much less pronounced at lower concurrencies but it definitely doesn't seem to hurt.

Concurrency=256
```
name             old ops/s   new ops/s   delta
KV95-throughput  24.4k ± 3%  25.9k ± 1%   +6.31%  (p=0.008 n=5+5)

name             old ms/s    new ms/s    delta
KV95-P50          32.1 ± 5%   28.3 ± 4%  -11.71%  (p=0.008 n=5+5)
KV95-Avg          7.76 ± 6%   7.92 ± 4%     ~     (p=0.532 n=5+5)
```
Concurrency=128
```
name             old ops/s   new ops/s   delta
KV95-throughput  22.5k ± 3%  23.2k ± 2%   ~     (p=0.095 n=5+5)

name             old ms/s    new ms/s    delta
KV95-P50          17.0 ± 5%   16.4 ± 4%   ~     (p=0.333 n=5+5)
KV95-Avg          4.10 ± 0%   3.98 ± 5%   ~     (p=0.333 n=4+5)
```
Before:
![Screenshot_2019-06-07 cockroach-base cpu](https://user-images.githubusercontent.com/1839234/59137207-8dc0ed00-8954-11e9-87c7-bd733b97e9e9.png)


After:
![Screenshot_2019-06-07 cockroach-with cpu(1)](https://user-images.githubusercontent.com/1839234/59137247-d5477900-8954-11e9-9040-c82cef8079f7.png)



Release note: None