### PR TITLE
opt: test catalog improvements, fixes, tests

### DIFF
--- a/pkg/sql/opt/cat/index.go
+++ b/pkg/sql/opt/cat/index.go
@@ -121,7 +121,7 @@ type Index interface {
 	// information will also be inherited.
 	//
 	// NOTE: This zone always applies to the entire index and never to any
-	// partifular partition of the index.
+	// particular partition of the index.
 	Zone() Zone
 
 	// Span returns the KV span associated with the index.

--- a/pkg/sql/opt/cat/zone.go
+++ b/pkg/sql/opt/cat/zone.go
@@ -89,6 +89,9 @@ type Constraint interface {
 // FormatZone nicely formats a catalog zone using a treeprinter for debugging
 // and testing.
 func FormatZone(zone Zone, tp treeprinter.Node) {
+	if zone.ReplicaConstraintsCount() == 0 && zone.LeasePreferenceCount() == 0 {
+		return
+	}
 	zoneChild := tp.Childf("ZONE")
 
 	replicaChild := zoneChild

--- a/pkg/sql/opt/memo/testdata/format
+++ b/pkg/sql/opt/memo/testdata/format
@@ -1,12 +1,6 @@
 exec-ddl
 CREATE TABLE t (a INT, b INT, k INT PRIMARY KEY)
 ----
-TABLE t
- ├── a int
- ├── b int
- ├── k int not null
- └── INDEX primary
-      └── k int not null
 
 opt format=show-all
 SELECT a + 1, min(b) FROM t WHERE k + a > b GROUP BY a ORDER BY a

--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -1,22 +1,10 @@
 exec-ddl
 CREATE TABLE a (x INT, y INT)
 ----
-TABLE a
- ├── x int
- ├── y int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE kuv (k INT PRIMARY KEY, u FLOAT, v STRING)
 ----
-TABLE kuv
- ├── k int not null
- ├── u float
- ├── v string
- └── INDEX primary
-      └── k int not null
 
 opt
 SELECT * FROM a WHERE x > 1
@@ -491,13 +479,6 @@ select
 exec-ddl
 CREATE TABLE abc (a INT, b BOOL, c STRING)
 ----
-TABLE abc
- ├── a int
- ├── b bool
- ├── c string
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 opt
 SELECT * FROM abc WHERE a != 5
@@ -685,16 +666,6 @@ CREATE TABLE c
     INDEX v (v, u)
 )
 ----
-TABLE c
- ├── k int not null
- ├── u int
- ├── v int
- ├── INDEX primary
- │    └── k int not null
- └── INDEX v
-      ├── v int
-      ├── u int
-      └── k int not null
 
 opt
 SELECT * FROM c WHERE (v, u) IN ((1, 2), (3, 50), (5, 100))
@@ -906,12 +877,6 @@ CREATE TABLE d
     q INT
 )
 ----
-TABLE d
- ├── k int not null
- ├── p int
- ├── q int
- └── INDEX primary
-      └── k int not null
 
 opt format=hide-qual
 SELECT * FROM d WHERE (p, q) IN ((1, 2), (1, 3), (1, 4))
@@ -993,18 +958,6 @@ CREATE TABLE e
     INDEX (d)
 )
 ----
-TABLE e
- ├── k int not null
- ├── t timestamp
- ├── d timestamp
- ├── INDEX primary
- │    └── k int not null
- ├── INDEX secondary
- │    ├── t timestamp
- │    └── k int not null
- └── INDEX secondary
-      ├── d timestamp
-      └── k int not null
 
 opt
 SELECT k FROM e WHERE d > '2018-07-01' AND d < '2018-07-01'::DATE + '1w'::INTERVAL

--- a/pkg/sql/opt/memo/testdata/logprops/constraints-null
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints-null
@@ -1,13 +1,6 @@
 exec-ddl
 CREATE TABLE t (a INT, b BOOL, c STRING)
 ----
-TABLE t
- ├── a int
- ├── b bool
- ├── c string
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 opt
 SELECT * FROM t WHERE a = NULL
@@ -99,12 +92,6 @@ CREATE TABLE xy (
   y INT
 )
 ----
-TABLE xy
- ├── x int
- ├── y int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 # Test that we get a not-NULL constraint on x.
 opt

--- a/pkg/sql/opt/memo/testdata/logprops/delete
+++ b/pkg/sql/opt/memo/testdata/logprops/delete
@@ -7,15 +7,6 @@ CREATE TABLE abcde (
     "e:write-only" INT NOT NULL
 )
 ----
-TABLE abcde
- ├── a int not null
- ├── b int
- ├── c int not null
- ├── d int
- ├── rowid int not null (hidden)
- ├── e int not null (mutation)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE xyz (
@@ -24,12 +15,6 @@ CREATE TABLE xyz (
     z FLOAT8
 )
 ----
-TABLE xyz
- ├── x string not null
- ├── y int not null
- ├── z float
- └── INDEX primary
-      └── x string not null
 
 # Properties with no RETURNING clause.
 build

--- a/pkg/sql/opt/memo/testdata/logprops/groupby
+++ b/pkg/sql/opt/memo/testdata/logprops/groupby
@@ -1,27 +1,10 @@
 exec-ddl
 CREATE TABLE xyzs (x INT PRIMARY KEY, y INT, z FLOAT NOT NULL, s STRING, UNIQUE (s DESC, z))
 ----
-TABLE xyzs
- ├── x int not null
- ├── y int
- ├── z float not null
- ├── s string
- ├── INDEX primary
- │    └── x int not null
- └── INDEX secondary
-      ├── s string desc
-      ├── z float not null
-      └── x int not null (storing)
 
 exec-ddl
 CREATE TABLE kuv (k INT PRIMARY KEY, u FLOAT, v STRING)
 ----
-TABLE kuv
- ├── k int not null
- ├── u float
- ├── v string
- └── INDEX primary
-      └── k int not null
 
 build
 SELECT y, sum(z), x, False FROM xyzs GROUP BY x, y

--- a/pkg/sql/opt/memo/testdata/logprops/index-join
+++ b/pkg/sql/opt/memo/testdata/logprops/index-join
@@ -8,21 +8,6 @@ CREATE TABLE a (
   UNIQUE (y, s)
 )
 ----
-TABLE a
- ├── x int not null
- ├── y int
- ├── s string
- ├── d decimal not null
- ├── INDEX primary
- │    └── x int not null
- ├── INDEX secondary
- │    ├── s string desc
- │    ├── d decimal not null
- │    └── x int not null (storing)
- └── INDEX secondary
-      ├── y int
-      ├── s string
-      └── x int not null (storing)
 
 exec-ddl
 CREATE TABLE abc (
@@ -34,18 +19,6 @@ CREATE TABLE abc (
   INDEX (c)
 )
 ----
-TABLE abc
- ├── a int not null
- ├── b int not null
- ├── c int
- ├── d int
- ├── INDEX primary
- │    ├── a int not null
- │    └── b int not null
- └── INDEX secondary
-      ├── c int
-      ├── a int not null
-      └── b int not null
 
 # In order to actually create new logical props for the index join, we need to
 # call ConstructLookupJoin, which only happens when where is a remaining filter.

--- a/pkg/sql/opt/memo/testdata/logprops/insert
+++ b/pkg/sql/opt/memo/testdata/logprops/insert
@@ -7,15 +7,6 @@ CREATE TABLE abcde (
     "e:write-only" INT
 )
 ----
-TABLE abcde
- ├── a int not null
- ├── b int
- ├── c int not null
- ├── d int
- ├── rowid int not null (hidden)
- ├── e int (mutation)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE xyz (
@@ -24,12 +15,6 @@ CREATE TABLE xyz (
     z FLOAT8
 )
 ----
-TABLE xyz
- ├── x string not null
- ├── y int not null
- ├── z float
- └── INDEX primary
-      └── x string not null
 
 # Properties with no RETURNING clause.
 build

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -1,39 +1,14 @@
 exec-ddl
 CREATE TABLE xysd (x INT PRIMARY KEY, y INT, s STRING, d DECIMAL NOT NULL, UNIQUE (s DESC, d))
 ----
-TABLE xysd
- ├── x int not null
- ├── y int
- ├── s string
- ├── d decimal not null
- ├── INDEX primary
- │    └── x int not null
- └── INDEX secondary
-      ├── s string desc
-      ├── d decimal not null
-      └── x int not null (storing)
 
 exec-ddl
 CREATE TABLE uv (u INT, v INT NOT NULL)
 ----
-TABLE uv
- ├── u int
- ├── v int not null
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE mn (m INT PRIMARY KEY, n INT, UNIQUE (n))
 ----
-TABLE mn
- ├── m int not null
- ├── n int
- ├── INDEX primary
- │    └── m int not null
- └── INDEX secondary
-      ├── n int
-      └── m int not null (storing)
 
 # Inner-join.
 build

--- a/pkg/sql/opt/memo/testdata/logprops/limit
+++ b/pkg/sql/opt/memo/testdata/logprops/limit
@@ -1,27 +1,10 @@
 exec-ddl
 CREATE TABLE xyzs (x INT PRIMARY KEY, y INT, z FLOAT NOT NULL, s STRING, UNIQUE (s DESC, z))
 ----
-TABLE xyzs
- ├── x int not null
- ├── y int
- ├── z float not null
- ├── s string
- ├── INDEX primary
- │    └── x int not null
- └── INDEX secondary
-      ├── s string desc
-      ├── z float not null
-      └── x int not null (storing)
 
 exec-ddl
 CREATE TABLE kuv (k INT PRIMARY KEY, u FLOAT, v STRING)
 ----
-TABLE kuv
- ├── k int not null
- ├── u float
- ├── v string
- └── INDEX primary
-      └── k int not null
 
 build
 SELECT * FROM xyzs LIMIT 1

--- a/pkg/sql/opt/memo/testdata/logprops/lookup-join
+++ b/pkg/sql/opt/memo/testdata/logprops/lookup-join
@@ -1,27 +1,10 @@
 exec-ddl
 CREATE TABLE abcd (a INT, b INT, c INT, INDEX (a,b))
 ----
-TABLE abcd
- ├── a int
- ├── b int
- ├── c int
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- └── INDEX secondary
-      ├── a int
-      ├── b int
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE small (m INT, n INT)
 ----
-TABLE small
- ├── m int
- ├── n int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 ALTER TABLE small INJECT STATISTICS '[

--- a/pkg/sql/opt/memo/testdata/logprops/max1row
+++ b/pkg/sql/opt/memo/testdata/logprops/max1row
@@ -1,27 +1,10 @@
 exec-ddl
 CREATE TABLE xyzs (x INT PRIMARY KEY, y INT, z FLOAT NOT NULL, s STRING, UNIQUE (s DESC, z))
 ----
-TABLE xyzs
- ├── x int not null
- ├── y int
- ├── z float not null
- ├── s string
- ├── INDEX primary
- │    └── x int not null
- └── INDEX secondary
-      ├── s string desc
-      ├── z float not null
-      └── x int not null (storing)
 
 exec-ddl
 CREATE TABLE kuv (k INT PRIMARY KEY, u FLOAT, v STRING)
 ----
-TABLE kuv
- ├── k int not null
- ├── u float
- ├── v string
- └── INDEX primary
-      └── k int not null
 
 build
 SELECT * FROM xyzs WHERE (SELECT v FROM kuv) = 'foo'

--- a/pkg/sql/opt/memo/testdata/logprops/offset
+++ b/pkg/sql/opt/memo/testdata/logprops/offset
@@ -1,27 +1,10 @@
 exec-ddl
 CREATE TABLE xyzs (x INT PRIMARY KEY, y INT, z FLOAT NOT NULL, s STRING, UNIQUE (s DESC, z))
 ----
-TABLE xyzs
- ├── x int not null
- ├── y int
- ├── z float not null
- ├── s string
- ├── INDEX primary
- │    └── x int not null
- └── INDEX secondary
-      ├── s string desc
-      ├── z float not null
-      └── x int not null (storing)
 
 exec-ddl
 CREATE TABLE kuv (k INT PRIMARY KEY, u FLOAT, v STRING)
 ----
-TABLE kuv
- ├── k int not null
- ├── u float
- ├── v string
- └── INDEX primary
-      └── k int not null
 
 build
 SELECT * FROM xyzs OFFSET 1

--- a/pkg/sql/opt/memo/testdata/logprops/project
+++ b/pkg/sql/opt/memo/testdata/logprops/project
@@ -1,41 +1,14 @@
 exec-ddl
 CREATE TABLE xysd (x INT PRIMARY KEY, y INT, s STRING, d DECIMAL NOT NULL, UNIQUE (s DESC, d))
 ----
-TABLE xysd
- ├── x int not null
- ├── y int
- ├── s string
- ├── d decimal not null
- ├── INDEX primary
- │    └── x int not null
- └── INDEX secondary
-      ├── s string desc
-      ├── d decimal not null
-      └── x int not null (storing)
 
 exec-ddl
 CREATE TABLE kuv (k INT PRIMARY KEY, u FLOAT, v STRING)
 ----
-TABLE kuv
- ├── k int not null
- ├── u float
- ├── v string
- └── INDEX primary
-      └── k int not null
 
 exec-ddl
 CREATE TABLE ab (a INT, b INT, UNIQUE (a, b))
 ----
-TABLE ab
- ├── a int
- ├── b int
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- └── INDEX secondary
-      ├── a int
-      ├── b int
-      └── rowid int not null (hidden) (storing)
 
 build
 SELECT y, x+1 AS a, 1 AS b, x FROM xysd

--- a/pkg/sql/opt/memo/testdata/logprops/rownumber
+++ b/pkg/sql/opt/memo/testdata/logprops/rownumber
@@ -1,11 +1,6 @@
 exec-ddl
 CREATE TABLE xy (x INT PRIMARY KEY, y INT)
 ----
-TABLE xy
- ├── x int not null
- ├── y int
- └── INDEX primary
-      └── x int not null
 
 build
 SELECT * FROM xy WITH ORDINALITY

--- a/pkg/sql/opt/memo/testdata/logprops/scalar
+++ b/pkg/sql/opt/memo/testdata/logprops/scalar
@@ -1,21 +1,10 @@
 exec-ddl
 CREATE TABLE xy (x INT PRIMARY KEY, y INT)
 ----
-TABLE xy
- ├── x int not null
- ├── y int
- └── INDEX primary
-      └── x int not null
 
 exec-ddl
 CREATE TABLE uv (u INT, v INT NOT NULL)
 ----
-TABLE uv
- ├── u int
- ├── v int not null
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 build
 SELECT * FROM xy WHERE x < 5

--- a/pkg/sql/opt/memo/testdata/logprops/scan
+++ b/pkg/sql/opt/memo/testdata/logprops/scan
@@ -1,27 +1,10 @@
 exec-ddl
 CREATE TABLE a (x INT PRIMARY KEY, y INT, s STRING, d DECIMAL NOT NULL, UNIQUE (s DESC, d))
 ----
-TABLE a
- ├── x int not null
- ├── y int
- ├── s string
- ├── d decimal not null
- ├── INDEX primary
- │    └── x int not null
- └── INDEX secondary
-      ├── s string desc
-      ├── d decimal not null
-      └── x int not null (storing)
 
 exec-ddl
 CREATE TABLE b (x INT, z INT NOT NULL)
 ----
-TABLE b
- ├── x int
- ├── z int not null
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 build
 SELECT * FROM a
@@ -119,29 +102,6 @@ CREATE TABLE t (
   FAMILY (d)
 )
 ----
-TABLE t
- ├── a int not null
- ├── b char not null
- ├── c int
- ├── d char
- ├── INDEX primary
- │    ├── a int not null
- │    └── b char not null
- ├── INDEX bc
- │    ├── b char not null
- │    ├── c int
- │    └── a int not null
- ├── INDEX dc
- │    ├── d char
- │    ├── c int
- │    ├── a int not null
- │    └── b char not null
- ├── INDEX a_desc
- │    ├── a int not null desc
- │    └── b char not null
- ├── FAMILY family1 (a, b)
- ├── FAMILY family2 (c)
- └── FAMILY family3 (d)
 
 opt
 SELECT 1 FROM t WHERE a > 1 AND a < 2

--- a/pkg/sql/opt/memo/testdata/logprops/select
+++ b/pkg/sql/opt/memo/testdata/logprops/select
@@ -1,21 +1,10 @@
 exec-ddl
 CREATE TABLE xy (x INT PRIMARY KEY, y INT)
 ----
-TABLE xy
- ├── x int not null
- ├── y int
- └── INDEX primary
-      └── x int not null
 
 exec-ddl
 CREATE TABLE kuv (k INT PRIMARY KEY, u FLOAT, v STRING)
 ----
-TABLE kuv
- ├── k int not null
- ├── u float
- ├── v string
- └── INDEX primary
-      └── k int not null
 
 build
 SELECT * FROM xy WHERE x=1
@@ -167,14 +156,6 @@ ordinality
 exec-ddl
 CREATE TABLE abcd (a INT NOT NULL, b INT NOT NULL, c INT, d INT)
 ----
-TABLE abcd
- ├── a int not null
- ├── b int not null
- ├── c int
- ├── d int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 build
 SELECT * FROM abcd WHERE true
@@ -361,7 +342,6 @@ project
 exec-ddl
 CREATE SEQUENCE x
 ----
-SEQUENCE t.public.x
 
 build
 SELECT * FROM x

--- a/pkg/sql/opt/memo/testdata/logprops/set
+++ b/pkg/sql/opt/memo/testdata/logprops/set
@@ -1,21 +1,10 @@
 exec-ddl
 CREATE TABLE xy (x INT PRIMARY KEY, y INT)
 ----
-TABLE xy
- ├── x int not null
- ├── y int
- └── INDEX primary
-      └── x int not null
 
 exec-ddl
 CREATE TABLE uv (u INT, v INT NOT NULL)
 ----
-TABLE uv
- ├── u int
- ├── v int not null
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 build
 SELECT * FROM xy UNION SELECT * FROM uv

--- a/pkg/sql/opt/memo/testdata/logprops/srfs
+++ b/pkg/sql/opt/memo/testdata/logprops/srfs
@@ -1,21 +1,10 @@
 exec-ddl
 CREATE TABLE xy (x INT PRIMARY KEY, y INT)
 ----
-TABLE xy
- ├── x int not null
- ├── y int
- └── INDEX primary
-      └── x int not null
 
 exec-ddl
 CREATE TABLE uv (u INT, v INT NOT NULL)
 ----
-TABLE uv
- ├── u int
- ├── v int not null
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 opt
 SELECT generate_series(0,1) FROM (SELECT * FROM xy LIMIT 0)

--- a/pkg/sql/opt/memo/testdata/logprops/update
+++ b/pkg/sql/opt/memo/testdata/logprops/update
@@ -7,15 +7,6 @@ CREATE TABLE abcde (
     "e:write-only" INT NOT NULL
 )
 ----
-TABLE abcde
- ├── a int not null
- ├── b int
- ├── c int not null
- ├── d int
- ├── rowid int not null (hidden)
- ├── e int not null (mutation)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE xyz (
@@ -24,12 +15,6 @@ CREATE TABLE xyz (
     z FLOAT8
 )
 ----
-TABLE xyz
- ├── x string not null
- ├── y int not null
- ├── z float
- └── INDEX primary
-      └── x string not null
 
 # Properties with no RETURNING clause.
 build

--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -7,20 +7,6 @@ CREATE TABLE abc (
     UNIQUE(b, c)
 )
 ----
-TABLE abc
- ├── a int not null
- ├── b int
- ├── c int
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- ├── INDEX secondary
- │    ├── a int not null
- │    └── rowid int not null (hidden) (storing)
- └── INDEX secondary
-      ├── b int
-      ├── c int
-      └── rowid int not null (hidden) (storing)
 
 exec-ddl
 CREATE TABLE xyz (
@@ -31,20 +17,6 @@ CREATE TABLE xyz (
     UNIQUE (z, y)
 )
 ----
-TABLE xyz
- ├── x int not null
- ├── y int
- ├── z int
- ├── INDEX primary
- │    └── x int not null
- ├── INDEX secondary
- │    ├── y int
- │    ├── z int
- │    └── x int not null (storing)
- └── INDEX secondary
-      ├── z int
-      ├── y int
-      └── x int not null (storing)
 
 # INSERT..ON CONFLICT case. Don't inherit FDs.
 build

--- a/pkg/sql/opt/memo/testdata/logprops/values
+++ b/pkg/sql/opt/memo/testdata/logprops/values
@@ -1,11 +1,6 @@
 exec-ddl
 CREATE TABLE xy (x INT PRIMARY KEY, y INT)
 ----
-TABLE xy
- ├── x int not null
- ├── y int
- └── INDEX primary
-      └── x int not null
 
 build
 SELECT * FROM (VALUES (1, 2), (3, 4), (NULL, 5))

--- a/pkg/sql/opt/memo/testdata/logprops/window
+++ b/pkg/sql/opt/memo/testdata/logprops/window
@@ -14,19 +14,6 @@ CREATE TABLE kv (
   FAMILY (s)
 )
 ----
-TABLE kv
- ├── k int not null
- ├── v int
- ├── w int
- ├── f float
- ├── d decimal
- ├── s string
- ├── b bool
- ├── INDEX primary
- │    └── k int not null
- ├── FAMILY family1 (k, v, w, f, b)
- ├── FAMILY family2 (d)
- └── FAMILY family3 (s)
 
 # FDs + Cardinality + Not Null cols.
 

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -1,20 +1,10 @@
 exec-ddl
 CREATE TABLE a (x INT PRIMARY KEY, y INT)
 ----
-TABLE a
- ├── x int not null
- ├── y int
- └── INDEX primary
-      └── x int not null
 
 exec-ddl
 CREATE TABLE b (x STRING PRIMARY KEY, z DECIMAL NOT NULL)
 ----
-TABLE b
- ├── x string not null
- ├── z decimal not null
- └── INDEX primary
-      └── x string not null
 
 build
 SELECT y, b.x, y+1 AS c

--- a/pkg/sql/opt/memo/testdata/stats/delete
+++ b/pkg/sql/opt/memo/testdata/stats/delete
@@ -5,13 +5,6 @@ CREATE TABLE abc (
     c FLOAT AS (a::float) STORED
 )
 ----
-TABLE abc
- ├── a int not null
- ├── b string
- ├── c float
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 ALTER TABLE abc INJECT STATISTICS '[
@@ -37,12 +30,6 @@ CREATE TABLE xyz (
     z FLOAT8
 )
 ----
-TABLE xyz
- ├── x string not null
- ├── y int not null
- ├── z float
- └── INDEX primary
-      └── x string not null
 
 # Statistics should be derived from DELETE input columns and transferred to
 # RETURNING columns.

--- a/pkg/sql/opt/memo/testdata/stats/groupby
+++ b/pkg/sql/opt/memo/testdata/stats/groupby
@@ -1,17 +1,6 @@
 exec-ddl
 CREATE TABLE a (x INT PRIMARY KEY, y INT, z FLOAT NOT NULL, s STRING, UNIQUE (s DESC, z))
 ----
-TABLE a
- ├── x int not null
- ├── y int
- ├── z float not null
- ├── s string
- ├── INDEX primary
- │    └── x int not null
- └── INDEX secondary
-      ├── s string desc
-      ├── z float not null
-      └── x int not null (storing)
 
 exec-ddl
 ALTER TABLE a INJECT STATISTICS '[

--- a/pkg/sql/opt/memo/testdata/stats/index-join
+++ b/pkg/sql/opt/memo/testdata/stats/index-join
@@ -1,17 +1,6 @@
 exec-ddl
 CREATE TABLE a (x INT PRIMARY KEY, y INT, s STRING, d DECIMAL NOT NULL, UNIQUE (s DESC, d))
 ----
-TABLE a
- ├── x int not null
- ├── y int
- ├── s string
- ├── d decimal not null
- ├── INDEX primary
- │    └── x int not null
- └── INDEX secondary
-      ├── s string desc
-      ├── d decimal not null
-      └── x int not null (storing)
 
 exec-ddl
 ALTER TABLE a INJECT STATISTICS '[

--- a/pkg/sql/opt/memo/testdata/stats/insert
+++ b/pkg/sql/opt/memo/testdata/stats/insert
@@ -5,13 +5,6 @@ CREATE TABLE abc (
     c FLOAT AS (a::float) STORED
 )
 ----
-TABLE abc
- ├── a int not null
- ├── b string
- ├── c float
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 ALTER TABLE abc INJECT STATISTICS '[
@@ -37,12 +30,6 @@ CREATE TABLE xyz (
     z FLOAT8
 )
 ----
-TABLE xyz
- ├── x string not null
- ├── y int not null
- ├── z float
- └── INDEX primary
-      └── x string not null
 
 # Statistics should be derived from INSERT input columns and transferred to
 # RETURNING columns.

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -1,27 +1,10 @@
 exec-ddl
 CREATE TABLE xysd (x INT PRIMARY KEY, y INT, s STRING, d DECIMAL NOT NULL, UNIQUE (s DESC, d))
 ----
-TABLE xysd
- ├── x int not null
- ├── y int
- ├── s string
- ├── d decimal not null
- ├── INDEX primary
- │    └── x int not null
- └── INDEX secondary
-      ├── s string desc
-      ├── d decimal not null
-      └── x int not null (storing)
 
 exec-ddl
 CREATE TABLE uv (u INT, v INT NOT NULL)
 ----
-TABLE uv
- ├── u int
- ├── v int not null
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 ALTER TABLE xysd INJECT STATISTICS '[
@@ -584,24 +567,10 @@ project
 exec-ddl
 CREATE TABLE uvw (u INT, v INT, w INT)
 ----
-TABLE uvw
- ├── u int
- ├── v int
- ├── w int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE xyz (x INT, y INT, z INT)
 ----
-TABLE xyz
- ├── x int
- ├── y int
- ├── z int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 # Verify that two equivalent formulations of a join lead to similar statistics.
 # In the first case, x=10 is pushed down; in the second case it is part of the

--- a/pkg/sql/opt/memo/testdata/stats/limit
+++ b/pkg/sql/opt/memo/testdata/stats/limit
@@ -1,17 +1,6 @@
 exec-ddl
 CREATE TABLE a (x INT PRIMARY KEY, y INT, s STRING, d DECIMAL NOT NULL, UNIQUE (s DESC, d))
 ----
-TABLE a
- ├── x int not null
- ├── y int
- ├── s string
- ├── d decimal not null
- ├── INDEX primary
- │    └── x int not null
- └── INDEX secondary
-      ├── s string desc
-      ├── d decimal not null
-      └── x int not null (storing)
 
 exec-ddl
 ALTER TABLE a INJECT STATISTICS '[
@@ -213,11 +202,6 @@ limit
 exec-ddl
 CREATE TABLE b (x int)
 ----
-TABLE b
- ├── x int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 # Regression test for #32578. Ensure that we don't estimate 0 rows for the
 # offset.

--- a/pkg/sql/opt/memo/testdata/stats/lookup-join
+++ b/pkg/sql/opt/memo/testdata/stats/lookup-join
@@ -1,27 +1,10 @@
 exec-ddl
 CREATE TABLE abcd (a INT, b INT, c INT, INDEX (a,b))
 ----
-TABLE abcd
- ├── a int
- ├── b int
- ├── c int
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- └── INDEX secondary
-      ├── a int
-      ├── b int
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE small (m INT, n INT)
 ----
-TABLE small
- ├── m int
- ├── n int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 ALTER TABLE small INJECT STATISTICS '[
@@ -150,28 +133,10 @@ inner-join (lookup abcd)
 exec-ddl
 CREATE TABLE abc (a INT, b INT, c INT, PRIMARY KEY (a, c))
 ----
-TABLE abc
- ├── a int not null
- ├── b int
- ├── c int not null
- └── INDEX primary
-      ├── a int not null
-      └── c int not null
 
 exec-ddl
 CREATE TABLE def (d INT, e INT, f INT, PRIMARY KEY (f, e), INDEX e_idx (e) STORING (d))
 ----
-TABLE def
- ├── d int
- ├── e int not null
- ├── f int not null
- ├── INDEX primary
- │    ├── f int not null
- │    └── e int not null
- └── INDEX e_idx
-      ├── e int not null
-      ├── f int not null
-      └── d int (storing)
 
 # Set up the statistics as if the first table is much smaller than the second.
 exec-ddl

--- a/pkg/sql/opt/memo/testdata/stats/ordinality
+++ b/pkg/sql/opt/memo/testdata/stats/ordinality
@@ -1,11 +1,6 @@
 exec-ddl
 CREATE TABLE a (x INT PRIMARY KEY, y INT)
 ----
-TABLE a
- ├── x int not null
- ├── y int
- └── INDEX primary
-      └── x int not null
 
 exec-ddl
 ALTER TABLE a INJECT STATISTICS '[

--- a/pkg/sql/opt/memo/testdata/stats/project
+++ b/pkg/sql/opt/memo/testdata/stats/project
@@ -1,17 +1,6 @@
 exec-ddl
 CREATE TABLE a (x INT PRIMARY KEY, y INT, s STRING, d DECIMAL NOT NULL, UNIQUE (s DESC, d))
 ----
-TABLE a
- ├── x int not null
- ├── y int
- ├── s string
- ├── d decimal not null
- ├── INDEX primary
- │    └── x int not null
- └── INDEX secondary
-      ├── s string desc
-      ├── d decimal not null
-      └── x int not null (storing)
 
 exec-ddl
 ALTER TABLE a INJECT STATISTICS '[
@@ -159,12 +148,6 @@ select
 exec-ddl
 CREATE TABLE kuv (k INT PRIMARY KEY, u FLOAT, v STRING)
 ----
-TABLE kuv
- ├── k int not null
- ├── u float
- ├── v string
- └── INDEX primary
-      └── k int not null
 
 exec-ddl
 ALTER TABLE kuv INJECT STATISTICS '[

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -1,18 +1,6 @@
 exec-ddl
 CREATE TABLE a (x INT PRIMARY KEY, y INT, s STRING, d DECIMAL NOT NULL, b BOOL, UNIQUE (s DESC, d))
 ----
-TABLE a
- ├── x int not null
- ├── y int
- ├── s string
- ├── d decimal not null
- ├── b bool
- ├── INDEX primary
- │    └── x int not null
- └── INDEX secondary
-      ├── s string desc
-      ├── d decimal not null
-      └── x int not null (storing)
 
 exec-ddl
 ALTER TABLE a INJECT STATISTICS '[
@@ -433,23 +421,6 @@ CREATE TABLE abcde (
   INDEX good(b, c, d)
 )
 ----
-TABLE abcde
- ├── a int not null
- ├── b int
- ├── c string
- ├── d int
- ├── e int
- ├── INDEX primary
- │    └── a int not null
- ├── INDEX bad
- │    ├── b int
- │    ├── d int
- │    └── a int not null
- └── INDEX good
-      ├── b int
-      ├── c string
-      ├── d int
-      └── a int not null
 
 # Regression test for #31929. Ensure that the good index is chosen.
 opt
@@ -470,7 +441,6 @@ index-join abcde
 exec-ddl
 CREATE SEQUENCE seq
 ----
-SEQUENCE t.public.seq
 
 opt
 SELECT * FROM seq
@@ -485,11 +455,6 @@ sequence-select t.public.seq
 exec-ddl
 CREATE TABLE empty (x INT)
 ----
-TABLE empty
- ├── x int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 ALTER TABLE empty INJECT STATISTICS '[
@@ -538,20 +503,6 @@ CREATE TABLE t37953 (
     j FLOAT8 NOT NULL
 )
 ----
-TABLE t37953
- ├── a uuid not null
- ├── b float not null
- ├── c time not null
- ├── d uuid not null
- ├── e varchar
- ├── f "char"
- ├── g int4 not null
- ├── h varchar
- ├── i regproc
- ├── j float not null
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 norm
 WITH

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -1,21 +1,10 @@
 exec-ddl
 CREATE TABLE a (x INT PRIMARY KEY, y INT)
 ----
-TABLE a
- ├── x int not null
- ├── y int
- └── INDEX primary
-      └── x int not null
 
 exec-ddl
 CREATE TABLE b (x INT, z INT NOT NULL)
 ----
-TABLE b
- ├── x int
- ├── z int not null
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 ALTER TABLE a INJECT STATISTICS '[
@@ -181,16 +170,6 @@ project
 exec-ddl
 CREATE TABLE idx (x INT PRIMARY KEY, y INT, z INT, INDEX yz (y DESC, z))
 ----
-TABLE idx
- ├── x int not null
- ├── y int
- ├── z int
- ├── INDEX primary
- │    └── x int not null
- └── INDEX yz
-      ├── y int desc
-      ├── z int
-      └── x int not null
 
 opt
 SELECT y FROM idx WHERE y < 5 AND z < 10
@@ -212,16 +191,6 @@ project
 exec-ddl
 CREATE TABLE tab0(pk INTEGER PRIMARY KEY, col0 INTEGER, col1 FLOAT, col2 TEXT, col3 INTEGER, col4 FLOAT, col5 TEXT)
 ----
-TABLE tab0
- ├── pk int not null
- ├── col0 int
- ├── col1 float
- ├── col2 string
- ├── col3 int
- ├── col4 float
- ├── col5 string
- └── INDEX primary
-      └── pk int not null
 
 # Note: it's not clear that this still tests the above issue, but I have left
 # it here anyway as an interesting test case. I've added another query below
@@ -286,35 +255,14 @@ project
 exec-ddl
 CREATE TABLE customers (id INT PRIMARY KEY, name STRING, state STRING)
 ----
-TABLE customers
- ├── id int not null
- ├── name string
- ├── state string
- └── INDEX primary
-      └── id int not null
 
 exec-ddl
 CREATE TABLE order_history (order_id INT, item_id INT, customer_id INT, year INT)
 ----
-TABLE order_history
- ├── order_id int
- ├── item_id int
- ├── customer_id int
- ├── year int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE district (d_id INT, d_w_id INT, d_name STRING, PRIMARY KEY(d_id, d_w_id))
 ----
-TABLE district
- ├── d_id int not null
- ├── d_w_id int not null
- ├── d_name string
- └── INDEX primary
-      ├── d_id int not null
-      └── d_w_id int not null
 
 exec-ddl
 ALTER TABLE district INJECT STATISTICS '[
@@ -599,15 +547,6 @@ select
 exec-ddl
 CREATE TABLE c (x INT, z INT NOT NULL, UNIQUE INDEX x_idx (x))
 ----
-TABLE c
- ├── x int
- ├── z int not null
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- └── INDEX x_idx
-      ├── x int
-      └── rowid int not null (hidden) (storing)
 
 # Test that the distinct and null counts for x are estimated correctly (since it's a weak
 # key).
@@ -630,13 +569,6 @@ select
 exec-ddl
 CREATE TABLE uvw (u INT, v INT, w INT)
 ----
-TABLE uvw
- ├── u int
- ├── v int
- ├── w int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 # Test selectivity calculations by applying the two constraints in different
 # orders.
@@ -722,59 +654,6 @@ CREATE TABLE lineitem
     INDEX l_sk_pk (l_suppkey ASC, l_partkey ASC)
 );
 ----
-TABLE lineitem
- ├── l_orderkey int not null
- ├── l_partkey int not null
- ├── l_suppkey int not null
- ├── l_linenumber int not null
- ├── l_quantity float not null
- ├── l_extendedprice float not null
- ├── l_discount float not null
- ├── l_tax float not null
- ├── l_returnflag char not null
- ├── l_linestatus char not null
- ├── l_shipdate date not null
- ├── l_commitdate date not null
- ├── l_receiptdate date not null
- ├── l_shipinstruct char not null
- ├── l_shipmode char not null
- ├── l_comment varchar not null
- ├── INDEX primary
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_ok
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_pk
- │    ├── l_partkey int not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_sk
- │    ├── l_suppkey int not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_sd
- │    ├── l_shipdate date not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_cd
- │    ├── l_commitdate date not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_rd
- │    ├── l_receiptdate date not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_pk_sk
- │    ├── l_partkey int not null
- │    ├── l_suppkey int not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- └── INDEX l_sk_pk
-      ├── l_suppkey int not null
-      ├── l_partkey int not null
-      ├── l_orderkey int not null
-      └── l_linenumber int not null
 
 # We can determine that there are exactly 30 days for this range.
 opt
@@ -924,15 +803,6 @@ select
 exec-ddl
 CREATE TABLE tjson (a INT PRIMARY KEY, b JSON, c JSON, INVERTED INDEX b_idx (b))
 ----
-TABLE tjson
- ├── a int not null
- ├── b jsonb
- ├── c jsonb
- ├── INDEX primary
- │    └── a int not null
- └── INVERTED INDEX b_idx
-      ├── b jsonb
-      └── a int not null
 
 exec-ddl
 ALTER TABLE tjson INJECT STATISTICS '[
@@ -1284,12 +1154,6 @@ select
 exec-ddl
 CREATE TABLE nulls (x INT, y INT);
 ----
-TABLE nulls
- ├── x int
- ├── y int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 ALTER TABLE nulls INJECT STATISTICS '[
@@ -1422,19 +1286,6 @@ CREATE TABLE date_test (
     INDEX d2_idx (d2 DESC)
 )
 ----
-TABLE date_test
- ├── k int not null
- ├── d1 date not null
- ├── d2 date not null
- ├── d3 date not null
- ├── INDEX primary
- │    └── k int not null
- ├── INDEX d1_idx
- │    ├── d1 date not null
- │    └── k int not null
- └── INDEX d2_idx
-      ├── d2 date not null desc
-      └── k int not null
 
 opt
 SELECT d1 FROM date_test WHERE d1 > DATE '1995-10-01' AND d1 < DATE '1995-11-01'

--- a/pkg/sql/opt/memo/testdata/stats/set
+++ b/pkg/sql/opt/memo/testdata/stats/set
@@ -1,34 +1,14 @@
 exec-ddl
 CREATE TABLE a (x INT PRIMARY KEY, y INT, s STRING)
 ----
-TABLE a
- ├── x int not null
- ├── y int
- ├── s string
- └── INDEX primary
-      └── x int not null
 
 exec-ddl
 CREATE TABLE b (x INT, z INT NOT NULL, s STRING)
 ----
-TABLE b
- ├── x int
- ├── z int not null
- ├── s string
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE c (x INT, z INT NOT NULL, s STRING)
 ----
-TABLE c
- ├── x int
- ├── z int not null
- ├── s string
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 ALTER TABLE a INJECT STATISTICS '[

--- a/pkg/sql/opt/memo/testdata/stats/srfs
+++ b/pkg/sql/opt/memo/testdata/stats/srfs
@@ -1,11 +1,6 @@
 exec-ddl
 CREATE TABLE xy (x INT PRIMARY KEY, y INT)
 ----
-TABLE xy
- ├── x int not null
- ├── y int
- └── INDEX primary
-      └── x int not null
 
 opt colstat=1 colstat=2 colstat=3 colstat=4 colstat=5
 SELECT a.*, b.*, c.* FROM upper('abc') a
@@ -154,18 +149,6 @@ CREATE TABLE articles (
   updated_at TIMESTAMP
 )
 ----
-TABLE articles
- ├── id int not null
- ├── body string
- ├── description string
- ├── title string
- ├── slug string
- ├── tag_list string[]
- ├── user_id string
- ├── created_at timestamp
- ├── updated_at timestamp
- └── INDEX primary
-      └── id int not null
 
 # The following queries test the statistics for four different types of Zip
 # functions:

--- a/pkg/sql/opt/memo/testdata/stats/update
+++ b/pkg/sql/opt/memo/testdata/stats/update
@@ -5,13 +5,6 @@ CREATE TABLE abc (
     c FLOAT AS (a::float) STORED
 )
 ----
-TABLE abc
- ├── a int not null
- ├── b string
- ├── c float
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 ALTER TABLE abc INJECT STATISTICS '[
@@ -37,12 +30,6 @@ CREATE TABLE xyz (
     z FLOAT8
 )
 ----
-TABLE xyz
- ├── x string not null
- ├── y int not null
- ├── z float
- └── INDEX primary
-      └── x string not null
 
 # Statistics should be derived from UPDATE input columns and transferred to
 # RETURNING columns.

--- a/pkg/sql/opt/memo/testdata/stats/upsert
+++ b/pkg/sql/opt/memo/testdata/stats/upsert
@@ -5,13 +5,6 @@ CREATE TABLE abc (
     c FLOAT AS (a::float) STORED
 )
 ----
-TABLE abc
- ├── a int not null
- ├── b string
- ├── c float
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 ALTER TABLE abc INJECT STATISTICS '[
@@ -37,12 +30,6 @@ CREATE TABLE xyz (
     z FLOAT8
 )
 ----
-TABLE xyz
- ├── x string not null
- ├── y int not null
- ├── z float
- └── INDEX primary
-      └── x string not null
 
 # Statistics should be derived from input columns and transferred to RETURNING
 # columns.

--- a/pkg/sql/opt/memo/testdata/stats/window
+++ b/pkg/sql/opt/memo/testdata/stats/window
@@ -12,19 +12,6 @@ CREATE TABLE kv (
   FAMILY (s)
 )
 ----
-TABLE kv
- ├── k int not null
- ├── v int
- ├── w int
- ├── f float
- ├── d decimal
- ├── s string
- ├── b bool
- ├── INDEX primary
- │    └── k int not null
- ├── FAMILY family1 (k, v, w, f, b)
- ├── FAMILY family2 (d)
- └── FAMILY family3 (s)
 
 build colstat=8
 SELECT k, rank() OVER () FROM (SELECT * FROM kv LIMIT 10)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpcc
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpcc
@@ -12,18 +12,6 @@ CREATE TABLE warehouse
     w_ytd       decimal(12,2)
 )
 ----
-TABLE warehouse
- ├── w_id int not null
- ├── w_name varchar
- ├── w_street_1 varchar
- ├── w_street_2 varchar
- ├── w_city varchar
- ├── w_state char
- ├── w_zip char
- ├── w_tax decimal
- ├── w_ytd decimal
- └── INDEX primary
-      └── w_id int not null
 
 exec-ddl
 ALTER TABLE warehouse INJECT STATISTICS '[
@@ -111,22 +99,6 @@ CREATE TABLE district
     foreign key (d_w_id) references warehouse (w_id)
 ) interleave in parent warehouse (d_w_id)
 ----
-TABLE district
- ├── d_id int not null
- ├── d_w_id int not null
- ├── d_name varchar
- ├── d_street_1 varchar
- ├── d_street_2 varchar
- ├── d_city varchar
- ├── d_state char
- ├── d_zip char
- ├── d_tax decimal
- ├── d_ytd decimal
- ├── d_next_o_id int
- ├── INDEX primary
- │    ├── d_w_id int not null
- │    └── d_id int not null
- └── CONSTRAINT fk_d_w_id_ref_warehouse FOREIGN KEY (d_w_id) REFERENCES t.public.warehouse (w_id)
 
 exec-ddl
 ALTER TABLE district INJECT STATISTICS '[
@@ -239,39 +211,6 @@ CREATE TABLE customer
     foreign key (c_w_id, c_d_id) references district (d_w_id, d_id)
 ) interleave in parent district (c_w_id, c_d_id)
 ----
-TABLE customer
- ├── c_id int not null
- ├── c_d_id int not null
- ├── c_w_id int not null
- ├── c_first varchar
- ├── c_middle char
- ├── c_last varchar
- ├── c_street_1 varchar
- ├── c_street_2 varchar
- ├── c_city varchar
- ├── c_state char
- ├── c_zip char
- ├── c_phone char
- ├── c_since timestamp
- ├── c_credit char
- ├── c_credit_lim decimal
- ├── c_discount decimal
- ├── c_balance decimal
- ├── c_ytd_payment decimal
- ├── c_payment_cnt int
- ├── c_delivery_cnt int
- ├── c_data varchar
- ├── INDEX primary
- │    ├── c_w_id int not null
- │    ├── c_d_id int not null
- │    └── c_id int not null
- ├── INDEX customer_idx
- │    ├── c_w_id int not null
- │    ├── c_d_id int not null
- │    ├── c_last varchar
- │    ├── c_first varchar
- │    └── c_id int not null
- └── CONSTRAINT fk_c_w_id_ref_district FOREIGN KEY (c_w_id, c_d_id) REFERENCES t.public.district (d_w_id, d_id)
 
 exec-ddl
 ALTER TABLE customer INJECT STATISTICS '[
@@ -443,29 +382,6 @@ CREATE TABLE history
     foreign key (h_w_id, h_d_id) references district (d_w_id, d_id)
 )
 ----
-TABLE history
- ├── rowid uuid not null
- ├── h_c_id int
- ├── h_c_d_id int
- ├── h_c_w_id int
- ├── h_d_id int
- ├── h_w_id int
- ├── h_date timestamp
- ├── h_amount decimal
- ├── h_data varchar
- ├── INDEX primary
- │    └── rowid uuid not null
- ├── INDEX secondary
- │    ├── h_w_id int
- │    ├── h_d_id int
- │    └── rowid uuid not null
- ├── INDEX secondary
- │    ├── h_c_w_id int
- │    ├── h_c_d_id int
- │    ├── h_c_id int
- │    └── rowid uuid not null
- ├── CONSTRAINT fk_h_c_w_id_ref_customer FOREIGN KEY (h_c_w_id, h_c_d_id, h_c_id) REFERENCES t.public.customer (c_w_id, c_d_id, c_id)
- └── CONSTRAINT fk_h_w_id_ref_district FOREIGN KEY (h_w_id, h_d_id) REFERENCES t.public.district (d_w_id, d_id)
 
 exec-ddl
 ALTER TABLE history INJECT STATISTICS '[
@@ -552,30 +468,6 @@ CREATE TABLE "order"
     foreign key (o_w_id, o_d_id, o_c_id) references customer (c_w_id, c_d_id, c_id)
 ) interleave in parent district (o_w_id, o_d_id)
 ----
-TABLE order
- ├── o_id int not null
- ├── o_d_id int not null
- ├── o_w_id int not null
- ├── o_c_id int
- ├── o_entry_d timestamp
- ├── o_carrier_id int
- ├── o_ol_cnt int
- ├── o_all_local int
- ├── INDEX primary
- │    ├── o_w_id int not null
- │    ├── o_d_id int not null
- │    └── o_id int not null desc
- ├── INDEX order_idx
- │    ├── o_w_id int not null
- │    ├── o_d_id int not null
- │    ├── o_carrier_id int
- │    └── o_id int not null
- ├── INDEX secondary
- │    ├── o_w_id int not null
- │    ├── o_d_id int not null
- │    ├── o_c_id int
- │    └── o_id int not null
- └── CONSTRAINT fk_o_w_id_ref_customer FOREIGN KEY (o_w_id, o_d_id, o_c_id) REFERENCES t.public.customer (c_w_id, c_d_id, c_id)
 
 exec-ddl
 ALTER TABLE "order" INJECT STATISTICS '[
@@ -646,14 +538,6 @@ CREATE TABLE new_order
     primary key (no_w_id, no_d_id, no_o_id DESC)
 ) interleave in parent "order" (no_w_id, no_d_id, no_o_id)
 ----
-TABLE new_order
- ├── no_o_id int not null
- ├── no_d_id int not null
- ├── no_w_id int not null
- └── INDEX primary
-      ├── no_w_id int not null
-      ├── no_d_id int not null
-      └── no_o_id int not null desc
 
 exec-ddl
 ALTER TABLE new_order INJECT STATISTICS '[
@@ -692,14 +576,6 @@ CREATE TABLE item
     primary key (i_id)
 )
 ----
-TABLE item
- ├── i_id int not null
- ├── i_im_id int
- ├── i_name varchar
- ├── i_price decimal
- ├── i_data varchar
- └── INDEX primary
-      └── i_id int not null
 
 exec-ddl
 ALTER TABLE item INJECT STATISTICS '[
@@ -767,32 +643,6 @@ CREATE TABLE stock
     foreign key (s_i_id) references item (i_id)
 ) interleave in parent warehouse (s_w_id)
 ----
-TABLE stock
- ├── s_i_id int not null
- ├── s_w_id int not null
- ├── s_quantity int
- ├── s_dist_01 char
- ├── s_dist_02 char
- ├── s_dist_03 char
- ├── s_dist_04 char
- ├── s_dist_05 char
- ├── s_dist_06 char
- ├── s_dist_07 char
- ├── s_dist_08 char
- ├── s_dist_09 char
- ├── s_dist_10 char
- ├── s_ytd int
- ├── s_order_cnt int
- ├── s_remote_cnt int
- ├── s_data varchar
- ├── INDEX primary
- │    ├── s_w_id int not null
- │    └── s_i_id int not null
- ├── INDEX secondary
- │    ├── s_i_id int not null
- │    └── s_w_id int not null
- ├── CONSTRAINT fk_s_w_id_ref_warehouse FOREIGN KEY (s_w_id) REFERENCES t.public.warehouse (w_id)
- └── CONSTRAINT fk_s_i_id_ref_item FOREIGN KEY (s_i_id) REFERENCES t.public.item (i_id)
 
 exec-ddl
 ALTER TABLE stock INJECT STATISTICS '[
@@ -937,30 +787,6 @@ CREATE TABLE order_line
     foreign key (ol_supply_w_id, ol_d_id) references stock (s_w_id, s_i_id)
 ) interleave in parent "order" (ol_w_id, ol_d_id, ol_o_id)
 ----
-TABLE order_line
- ├── ol_o_id int not null
- ├── ol_d_id int not null
- ├── ol_w_id int not null
- ├── ol_number int not null
- ├── ol_i_id int not null
- ├── ol_supply_w_id int
- ├── ol_delivery_d timestamp
- ├── ol_quantity int
- ├── ol_amount decimal
- ├── ol_dist_info char
- ├── INDEX primary
- │    ├── ol_w_id int not null
- │    ├── ol_d_id int not null
- │    ├── ol_o_id int not null desc
- │    └── ol_number int not null
- ├── INDEX order_line_fk
- │    ├── ol_supply_w_id int
- │    ├── ol_d_id int not null
- │    ├── ol_w_id int not null
- │    ├── ol_o_id int not null
- │    └── ol_number int not null
- ├── CONSTRAINT fk_ol_w_id_ref_order FOREIGN KEY (ol_w_id, ol_d_id, ol_o_id) REFERENCES t.public."order" (o_w_id, o_d_id, o_id)
- └── CONSTRAINT fk_ol_supply_w_id_ref_stock FOREIGN KEY (ol_supply_w_id, ol_d_id) REFERENCES t.public.stock (s_w_id, s_i_id)
 
 exec-ddl
 ALTER TABLE order_line INJECT STATISTICS '[

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch
@@ -6,12 +6,6 @@ CREATE TABLE public.region
     r_comment varchar(152)
 );
 ----
-TABLE region
- ├── r_regionkey int not null
- ├── r_name char not null
- ├── r_comment varchar
- └── INDEX primary
-      └── r_regionkey int not null
 
 exec-ddl
 ALTER TABLE region INJECT STATISTICS '[
@@ -50,17 +44,6 @@ CREATE TABLE public.nation
     CONSTRAINT nation_fkey_region FOREIGN KEY (n_regionkey) references public.region (r_regionkey)
 );
 ----
-TABLE nation
- ├── n_nationkey int not null
- ├── n_name char not null
- ├── n_regionkey int not null
- ├── n_comment varchar
- ├── INDEX primary
- │    └── n_nationkey int not null
- ├── INDEX n_rk
- │    ├── n_regionkey int not null
- │    └── n_nationkey int not null
- └── CONSTRAINT nation_fkey_region FOREIGN KEY (n_regionkey) REFERENCES t.public.region (r_regionkey)
 
 exec-ddl
 ALTER TABLE nation INJECT STATISTICS '[
@@ -109,20 +92,6 @@ CREATE TABLE public.supplier
     CONSTRAINT supplier_fkey_nation FOREIGN KEY (s_nationkey) references public.nation (n_nationkey)
 );
 ----
-TABLE supplier
- ├── s_suppkey int not null
- ├── s_name char not null
- ├── s_address varchar not null
- ├── s_nationkey int not null
- ├── s_phone char not null
- ├── s_acctbal float not null
- ├── s_comment varchar not null
- ├── INDEX primary
- │    └── s_suppkey int not null
- ├── INDEX s_nk
- │    ├── s_nationkey int not null
- │    └── s_suppkey int not null
- └── CONSTRAINT supplier_fkey_nation FOREIGN KEY (s_nationkey) REFERENCES t.public.nation (n_nationkey)
 
 exec-ddl
 ALTER TABLE supplier INJECT STATISTICS '[
@@ -192,18 +161,6 @@ CREATE TABLE public.part
     p_comment varchar(23) NOT NULL
 );
 ----
-TABLE part
- ├── p_partkey int not null
- ├── p_name varchar not null
- ├── p_mfgr char not null
- ├── p_brand char not null
- ├── p_type varchar not null
- ├── p_size int not null
- ├── p_container char not null
- ├── p_retailprice float not null
- ├── p_comment varchar not null
- └── INDEX primary
-      └── p_partkey int not null
 
 exec-ddl
 ALTER TABLE part INJECT STATISTICS '[
@@ -287,20 +244,6 @@ CREATE TABLE public.partsupp
     CONSTRAINT partsupp_fkey_supplier FOREIGN KEY (ps_suppkey) references public.supplier (s_suppkey)
 );
 ----
-TABLE partsupp
- ├── ps_partkey int not null
- ├── ps_suppkey int not null
- ├── ps_availqty int not null
- ├── ps_supplycost float not null
- ├── ps_comment varchar not null
- ├── INDEX primary
- │    ├── ps_partkey int not null
- │    └── ps_suppkey int not null
- ├── INDEX ps_sk
- │    ├── ps_suppkey int not null
- │    └── ps_partkey int not null
- ├── CONSTRAINT partsupp_fkey_part FOREIGN KEY (ps_partkey) REFERENCES t.public.part (p_partkey)
- └── CONSTRAINT partsupp_fkey_supplier FOREIGN KEY (ps_suppkey) REFERENCES t.public.supplier (s_suppkey)
 
 exec-ddl
 ALTER TABLE partsupp INJECT STATISTICS '[
@@ -357,21 +300,6 @@ CREATE TABLE public.customer
     CONSTRAINT customer_fkey_nation FOREIGN KEY (c_nationkey) references public.nation (n_nationkey)
 );
 ----
-TABLE customer
- ├── c_custkey int not null
- ├── c_name varchar not null
- ├── c_address varchar not null
- ├── c_nationkey int not null
- ├── c_phone char not null
- ├── c_acctbal float not null
- ├── c_mktsegment char not null
- ├── c_comment varchar not null
- ├── INDEX primary
- │    └── c_custkey int not null
- ├── INDEX c_nk
- │    ├── c_nationkey int not null
- │    └── c_custkey int not null
- └── CONSTRAINT customer_fkey_nation FOREIGN KEY (c_nationkey) REFERENCES t.public.nation (n_nationkey)
 
 exec-ddl
 ALTER TABLE customer INJECT STATISTICS '[
@@ -451,25 +379,6 @@ CREATE TABLE public.orders
     CONSTRAINT orders_fkey_customer FOREIGN KEY (o_custkey) references public.customer (c_custkey)
 );
 ----
-TABLE orders
- ├── o_orderkey int not null
- ├── o_custkey int not null
- ├── o_orderstatus char not null
- ├── o_totalprice float not null
- ├── o_orderdate date not null
- ├── o_orderpriority char not null
- ├── o_clerk char not null
- ├── o_shippriority int not null
- ├── o_comment varchar not null
- ├── INDEX primary
- │    └── o_orderkey int not null
- ├── INDEX o_ck
- │    ├── o_custkey int not null
- │    └── o_orderkey int not null
- ├── INDEX o_od
- │    ├── o_orderdate date not null
- │    └── o_orderkey int not null
- └── CONSTRAINT orders_fkey_customer FOREIGN KEY (o_custkey) REFERENCES t.public.customer (c_custkey)
 
 exec-ddl
 ALTER TABLE orders INJECT STATISTICS '[
@@ -573,63 +482,6 @@ CREATE TABLE public.lineitem
     CONSTRAINT lineitem_fkey_partsupp FOREIGN KEY (l_partkey, l_suppkey) references public.partsupp (ps_partkey, ps_suppkey)
 );
 ----
-TABLE lineitem
- ├── l_orderkey int not null
- ├── l_partkey int not null
- ├── l_suppkey int not null
- ├── l_linenumber int not null
- ├── l_quantity float not null
- ├── l_extendedprice float not null
- ├── l_discount float not null
- ├── l_tax float not null
- ├── l_returnflag char not null
- ├── l_linestatus char not null
- ├── l_shipdate date not null
- ├── l_commitdate date not null
- ├── l_receiptdate date not null
- ├── l_shipinstruct char not null
- ├── l_shipmode char not null
- ├── l_comment varchar not null
- ├── INDEX primary
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_ok
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_pk
- │    ├── l_partkey int not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_sk
- │    ├── l_suppkey int not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_sd
- │    ├── l_shipdate date not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_cd
- │    ├── l_commitdate date not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_rd
- │    ├── l_receiptdate date not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_pk_sk
- │    ├── l_partkey int not null
- │    ├── l_suppkey int not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_sk_pk
- │    ├── l_suppkey int not null
- │    ├── l_partkey int not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── CONSTRAINT lineitem_fkey_orders FOREIGN KEY (l_orderkey) REFERENCES t.public.orders (o_orderkey)
- ├── CONSTRAINT lineitem_fkey_part FOREIGN KEY (l_partkey) REFERENCES t.public.part (p_partkey)
- ├── CONSTRAINT lineitem_fkey_supplier FOREIGN KEY (l_suppkey) REFERENCES t.public.supplier (s_suppkey)
- └── CONSTRAINT lineitem_fkey_partsupp FOREIGN KEY (l_partkey, l_suppkey) REFERENCES t.public.partsupp (ps_partkey, ps_suppkey)
 
 exec-ddl
 ALTER TABLE lineitem INJECT STATISTICS '[
@@ -5274,8 +5126,6 @@ CREATE VIEW revenue0 (supplier_no, total_revenue) AS
     GROUP BY
         l_suppkey;
 ----
-VIEW revenue0 (supplier_no, total_revenue)
- └── SELECT l_suppkey, sum(l_extendedprice * (1 - l_discount)) FROM lineitem WHERE (l_shipdate >= DATE '1996-01-01') AND (l_shipdate < (DATE '1996-01-01' + '3 mons':::INTERVAL)) GROUP BY l_suppkey
 
 save-tables database=tpch save-tables-prefix=q15
 SELECT

--- a/pkg/sql/opt/memo/testdata/typing
+++ b/pkg/sql/opt/memo/testdata/typing
@@ -1,29 +1,14 @@
 exec-ddl
 CREATE TABLE a (x INT PRIMARY KEY, y INT)
 ----
-TABLE a
- ├── x int not null
- ├── y int
- └── INDEX primary
-      └── x int not null
 
 exec-ddl
 CREATE TABLE b (x STRING PRIMARY KEY, z DECIMAL NOT NULL)
 ----
-TABLE b
- ├── x string not null
- ├── z decimal not null
- └── INDEX primary
-      └── x string not null
 
 exec-ddl
 CREATE TABLE unusual (x INT PRIMARY KEY, arr INT[])
 ----
-TABLE unusual
- ├── x int not null
- ├── arr int[]
- └── INDEX primary
-      └── x int not null
 
 # Variable
 build

--- a/pkg/sql/opt/norm/testdata/rules/agg
+++ b/pkg/sql/opt/norm/testdata/rules/agg
@@ -1,15 +1,6 @@
 exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON, arr int[])
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── f float
- ├── s string
- ├── j jsonb
- ├── arr int[]
- └── INDEX primary
-      └── k int not null
 
 # --------------------------------------------------
 # EliminateAggDistinct

--- a/pkg/sql/opt/norm/testdata/rules/bool
+++ b/pkg/sql/opt/norm/testdata/rules/bool
@@ -1,36 +1,14 @@
 exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON)
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── f float
- ├── s string
- ├── j jsonb
- └── INDEX primary
-      └── k int not null
 
 exec-ddl
 CREATE TABLE b (x INT PRIMARY KEY, z INT)
 ----
-TABLE b
- ├── x int not null
- ├── z int
- └── INDEX primary
-      └── x int not null
 
 exec-ddl
 CREATE TABLE c (a BOOL, b BOOL, c BOOL, d BOOL, e BOOL)
 ----
-TABLE c
- ├── a bool
- ├── b bool
- ├── c bool
- ├── d bool
- ├── e bool
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 
 # --------------------------------------------------

--- a/pkg/sql/opt/norm/testdata/rules/combo
+++ b/pkg/sql/opt/norm/testdata/rules/combo
@@ -8,28 +8,10 @@ CREATE TABLE a (
     UNIQUE INDEX (s DESC, f) STORING (j)
 )
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── f float
- ├── s string
- ├── j jsonb
- ├── INDEX primary
- │    └── k int not null
- └── INDEX secondary
-      ├── s string desc
-      ├── f float
-      ├── k int not null (storing)
-      └── j jsonb (storing)
 
 exec-ddl
 CREATE TABLE t.xy (x INT PRIMARY KEY, y INT)
 ----
-TABLE xy
- ├── x int not null
- ├── y int
- └── INDEX primary
-      └── x int not null
 
 # --------------------------------------------------
 # Use optsteps.

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -1,15 +1,6 @@
 exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON, d DATE)
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── f float
- ├── s string
- ├── j jsonb
- ├── d date
- └── INDEX primary
-      └── k int not null
 
 # --------------------------------------------------
 # CommuteVarInequality

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -1,41 +1,18 @@
 exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON)
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── f float
- ├── s string
- ├── j jsonb
- └── INDEX primary
-      └── k int not null
 
 exec-ddl
 CREATE TABLE xy (x INT PRIMARY KEY, y INT)
 ----
-TABLE xy
- ├── x int not null
- ├── y int
- └── INDEX primary
-      └── x int not null
 
 exec-ddl
 CREATE TABLE uv (u INT PRIMARY KEY, v INT)
 ----
-TABLE uv
- ├── u int not null
- ├── v int
- └── INDEX primary
-      └── u int not null
 
 exec-ddl
 CREATE TABLE cd (c INT PRIMARY KEY, d INT NOT NULL)
 ----
-TABLE cd
- ├── c int not null
- ├── d int not null
- └── INDEX primary
-      └── c int not null
 
 # --------------------------------------------------
 # DecorrelateJoin
@@ -4803,18 +4780,6 @@ CREATE TABLE articles (
   updated_at TIMESTAMP
 )
 ----
-TABLE articles
- ├── id int not null
- ├── body string
- ├── description string
- ├── title string
- ├── slug string
- ├── tag_list string[]
- ├── user_id string
- ├── created_at timestamp
- ├── updated_at timestamp
- └── INDEX primary
-      └── id int not null
 
 # Regression test for #31706.
 opt expect=(TryDecorrelateSemiJoin,TryDecorrelateProjectSet)

--- a/pkg/sql/opt/norm/testdata/rules/fold_constants
+++ b/pkg/sql/opt/norm/testdata/rules/fold_constants
@@ -1,25 +1,12 @@
 exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON, arr int[])
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── f float
- ├── s string
- ├── j jsonb
- ├── arr int[]
- └── INDEX primary
-      └── k int not null
 
 exec-ddl
 CREATE TABLE t (
   x INT PRIMARY KEY
 )
 ----
-TABLE t
- ├── x int not null
- └── INDEX primary
-      └── x int not null
 
 # --------------------------------------------------
 # FoldNullCast

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -10,23 +10,6 @@ CREATE TABLE a
     UNIQUE INDEX fi_idx (f, i)
 )
 ----
-TABLE a
- ├── k int not null
- ├── i int not null
- ├── f float
- ├── s string not null
- ├── j jsonb
- ├── INDEX primary
- │    └── k int not null
- ├── INDEX si_idx
- │    ├── s string not null desc
- │    ├── i int not null
- │    ├── k int not null (storing)
- │    └── j jsonb (storing)
- └── INDEX fi_idx
-      ├── f float
-      ├── i int not null
-      └── k int not null (storing)
 
 exec-ddl
 CREATE TABLE xy
@@ -35,11 +18,6 @@ CREATE TABLE xy
     y INT
 )
 ----
-TABLE xy
- ├── x int not null
- ├── y int
- └── INDEX primary
-      └── x int not null
 
 exec-ddl
 CREATE TABLE abc
@@ -50,14 +28,6 @@ CREATE TABLE abc
     PRIMARY KEY (a,b,c)
 )
 ----
-TABLE abc
- ├── a int not null
- ├── b int not null
- ├── c int not null
- └── INDEX primary
-      ├── a int not null
-      ├── b int not null
-      └── c int not null
 
 exec-ddl
 CREATE TABLE uvwz
@@ -71,32 +41,12 @@ CREATE TABLE uvwz
     UNIQUE INDEX (v,w)
 )
 ----
-TABLE uvwz
- ├── u int not null
- ├── v int not null
- ├── w int not null
- ├── z int not null
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- ├── INDEX secondary
- │    ├── u int not null
- │    ├── v int not null
- │    └── rowid int not null (hidden) (storing)
- └── INDEX secondary
-      ├── v int not null
-      ├── w int not null
-      └── rowid int not null (hidden) (storing)
 
 exec-ddl
 CREATE TABLE s (
     s STRING PRIMARY KEY
 )
 ----
-TABLE s
- ├── s string not null
- └── INDEX primary
-      └── s string not null
 
 # --------------------------------------------------
 # ConvertGroupByToDistinct

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -1,33 +1,14 @@
 exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON)
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── f float
- ├── s string
- ├── j jsonb
- └── INDEX primary
-      └── k int not null
 
 exec-ddl
 CREATE TABLE xy (x INT PRIMARY KEY, y INT)
 ----
-TABLE xy
- ├── x int not null
- ├── y int
- └── INDEX primary
-      └── x int not null
 
 exec-ddl
 CREATE TABLE computed (a INT PRIMARY KEY, b INT, c INT AS (a+b+1) STORED)
 ----
-TABLE computed
- ├── a int not null
- ├── b int
- ├── c int
- └── INDEX primary
-      └── a int not null
 
 # --------------------------------------------------
 # InlineProjectConstants
@@ -401,14 +382,6 @@ CREATE TABLE crdb_internal.zones (
     config_protobuf BYTES NOT NULL
 )
 ----
-TABLE zones
- ├── zone_id int not null
- ├── cli_specifier string
- ├── config_yaml bytes not null
- ├── config_protobuf bytes not null
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 # Regression test for #28827. Ensure that inlining is not applied when there
 # is a correlated subquery in the filter.

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -1,73 +1,26 @@
 exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT NOT NULL, s STRING, j JSON)
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── f float not null
- ├── s string
- ├── j jsonb
- └── INDEX primary
-      └── k int not null
 
 exec-ddl
 CREATE TABLE t.b (x INT PRIMARY KEY, y INT)
 ----
-TABLE b
- ├── x int not null
- ├── y int
- └── INDEX primary
-      └── x int not null
 
 exec-ddl
 CREATE TABLE c (x INT PRIMARY KEY, y INT NOT NULL REFERENCES a(k), z INT NOT NULL, UNIQUE (x,z))
 ----
-TABLE c
- ├── x int not null
- ├── y int not null
- ├── z int not null
- ├── INDEX primary
- │    └── x int not null
- ├── INDEX secondary
- │    ├── x int not null
- │    └── z int not null
- ├── INDEX c_auto_index_fk_y_ref_a
- │    ├── y int not null
- │    └── x int not null
- └── CONSTRAINT fk_y_ref_a FOREIGN KEY (y) REFERENCES t.public.a (k)
 
 exec-ddl
 CREATE TABLE d (x INT PRIMARY KEY, y INT NOT NULL, z INT NOT NULL, FOREIGN KEY (y,z) REFERENCES c(x,z))
 ----
-TABLE d
- ├── x int not null
- ├── y int not null
- ├── z int not null
- ├── INDEX primary
- │    └── x int not null
- ├── INDEX d_auto_index_fk_y_ref_c
- │    ├── y int not null
- │    ├── z int not null
- │    └── x int not null
- └── CONSTRAINT fk_y_ref_c FOREIGN KEY (y, z) REFERENCES t.public.c (x, z)
 
 exec-ddl
 CREATE TABLE xy (x INT PRIMARY KEY, y INT)
 ----
-TABLE xy
- ├── x int not null
- ├── y int
- └── INDEX primary
-      └── x int not null
 
 exec-ddl
 CREATE TABLE uv (u INT PRIMARY KEY, v INT)
 ----
-TABLE uv
- ├── u int not null
- ├── v int
- └── INDEX primary
-      └── u int not null
 
 opt
 SELECT * FROM a INNER JOIN b ON a.s='foo' OR b.y<10
@@ -991,20 +944,10 @@ project
 exec-ddl
 CREATE TABLE t1 (a DATE)
 ----
-TABLE t1
- ├── a date
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE t2 (b TIMESTAMPTZ)
 ----
-TABLE t2
- ├── b timestamptz
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 # Make sure that we do not create invalid filters due to substituting columns
 # with different types.

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -1,23 +1,10 @@
 exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON)
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── f float
- ├── s string
- ├── j jsonb
- └── INDEX primary
-      └── k int not null
 
 exec-ddl
 CREATE TABLE t.b (x INT PRIMARY KEY, y INT)
 ----
-TABLE b
- ├── x int not null
- ├── y int
- └── INDEX primary
-      └── x int not null
 
 # --------------------------------------------------
 # EliminateLimit

--- a/pkg/sql/opt/norm/testdata/rules/max1row
+++ b/pkg/sql/opt/norm/testdata/rules/max1row
@@ -1,23 +1,10 @@
 exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON)
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── f float
- ├── s string
- ├── j jsonb
- └── INDEX primary
-      └── k int not null
 
 exec-ddl
 CREATE TABLE t.b (x INT PRIMARY KEY, y INT)
 ----
-TABLE b
- ├── x int not null
- ├── y int
- └── INDEX primary
-      └── x int not null
 
 # --------------------------------------------------
 # EliminateMax1Row

--- a/pkg/sql/opt/norm/testdata/rules/numeric
+++ b/pkg/sql/opt/norm/testdata/rules/numeric
@@ -1,14 +1,6 @@
 exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, d DECIMAL, t TIME)
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── f float
- ├── d decimal
- ├── t time
- └── INDEX primary
-      └── k int not null
 
 # --------------------------------------------------
 # FoldPlusZero, FoldZeroPlus

--- a/pkg/sql/opt/norm/testdata/rules/ordering
+++ b/pkg/sql/opt/norm/testdata/rules/ordering
@@ -8,18 +8,6 @@ CREATE TABLE abcde (
     UNIQUE INDEX bc (b, c)
 )
 ----
-TABLE abcde
- ├── a int not null
- ├── b int
- ├── c int
- ├── d int
- ├── e int
- ├── INDEX primary
- │    └── a int not null
- └── INDEX bc
-      ├── b int
-      ├── c int
-      └── a int not null (storing)
 
 exec-ddl
 CREATE TABLE xyz (
@@ -28,12 +16,6 @@ CREATE TABLE xyz (
     z FLOAT8
 )
 ----
-TABLE xyz
- ├── x string not null
- ├── y int
- ├── z float
- └── INDEX primary
-      └── x string not null
 
 # --------------------------------------------------
 # SimplifyLimitOrdering

--- a/pkg/sql/opt/norm/testdata/rules/project
+++ b/pkg/sql/opt/norm/testdata/rules/project
@@ -1,22 +1,10 @@
 exec-ddl
 CREATE TABLE a (x INT PRIMARY KEY, y INT, f FLOAT, s STRING)
 ----
-TABLE a
- ├── x int not null
- ├── y int
- ├── f float
- ├── s string
- └── INDEX primary
-      └── x int not null
 
 exec-ddl
 CREATE TABLE b (x INT PRIMARY KEY, z INT)
 ----
-TABLE b
- ├── x int not null
- ├── z int
- └── INDEX primary
-      └── x int not null
 
 # --------------------------------------------------
 # EliminateProject

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -1,22 +1,10 @@
 exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING)
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── f float
- ├── s string
- └── INDEX primary
-      └── k int not null
 
 exec-ddl
 CREATE TABLE xy (x INT PRIMARY KEY, y INT)
 ----
-TABLE xy
- ├── x int not null
- ├── y int
- └── INDEX primary
-      └── x int not null
 
 exec-ddl
 CREATE TABLE abcde (
@@ -28,18 +16,6 @@ CREATE TABLE abcde (
     UNIQUE INDEX bc (b, c)
 )
 ----
-TABLE abcde
- ├── a int not null
- ├── b int
- ├── c int
- ├── d int
- ├── e int
- ├── INDEX primary
- │    └── a int not null
- └── INDEX bc
-      ├── b int
-      ├── c int
-      └── a int not null (storing)
 
 exec-ddl
 CREATE TABLE mutation (
@@ -52,21 +28,6 @@ CREATE TABLE mutation (
     INDEX "idx2:delete-only" (e)
 )
 ----
-TABLE mutation
- ├── a int not null
- ├── b int
- ├── c int
- ├── d int (mutation)
- ├── e int (mutation)
- ├── INDEX primary
- │    └── a int not null
- ├── INDEX idx1 (mutation)
- │    ├── b int
- │    ├── d int
- │    └── a int not null (storing)
- └── INDEX idx2 (mutation)
-      ├── e int
-      └── a int not null
 
 exec-ddl
 CREATE TABLE family (
@@ -81,20 +42,6 @@ CREATE TABLE family (
     INDEX (d)
 )
 ----
-TABLE family
- ├── a int not null
- ├── b int
- ├── c int
- ├── d int
- ├── e int
- ├── INDEX primary
- │    └── a int not null
- ├── INDEX secondary
- │    ├── d int
- │    └── a int not null
- ├── FAMILY family1 (a, b)
- ├── FAMILY family2 (c, d)
- └── FAMILY family3 (e)
 
 # --------------------------------------------------
 # PruneProjectCols

--- a/pkg/sql/opt/norm/testdata/rules/reject_nulls
+++ b/pkg/sql/opt/norm/testdata/rules/reject_nulls
@@ -1,31 +1,14 @@
 exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING)
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── f float
- ├── s string
- └── INDEX primary
-      └── k int not null
 
 exec-ddl
 CREATE TABLE xy (x INT PRIMARY KEY, y INT)
 ----
-TABLE xy
- ├── x int not null
- ├── y int
- └── INDEX primary
-      └── x int not null
 
 exec-ddl
 CREATE TABLE uv (u INT PRIMARY KEY, v INT)
 ----
-TABLE uv
- ├── u int not null
- ├── v int
- └── INDEX primary
-      └── u int not null
 
 # ----------------------------------------------------------
 # RejectNullsLeftJoin + RejectNullsRightJoin

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -1,15 +1,6 @@
 exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON, arr int[])
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── f float
- ├── s string
- ├── j jsonb
- ├── arr int[]
- └── INDEX primary
-      └── k int not null
 
 # --------------------------------------------------
 # CommuteVar
@@ -667,26 +658,6 @@ CREATE TABLE e
     INDEX (d)
 )
 ----
-TABLE e
- ├── k int not null
- ├── i int
- ├── t timestamp
- ├── tz timestamptz
- ├── d date
- ├── INDEX primary
- │    └── k int not null
- ├── INDEX secondary
- │    ├── i int
- │    └── k int not null
- ├── INDEX secondary
- │    ├── t timestamp
- │    └── k int not null
- ├── INDEX secondary
- │    ├── tz timestamptz
- │    └── k int not null
- └── INDEX secondary
-      ├── d date
-      └── k int not null
 
 ## --------------------------------------------------
 ## INT / FLOAT / DECIMAL

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -1,45 +1,18 @@
 exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON)
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── f float
- ├── s string
- ├── j jsonb
- └── INDEX primary
-      └── k int not null
 
 exec-ddl
 CREATE TABLE xy (x INT PRIMARY KEY, y INT)
 ----
-TABLE xy
- ├── x int not null
- ├── y int
- └── INDEX primary
-      └── x int not null
 
 exec-ddl
 CREATE TABLE uv (u INT PRIMARY KEY, v INT)
 ----
-TABLE uv
- ├── u int not null
- ├── v int
- └── INDEX primary
-      └── u int not null
 
 exec-ddl
 CREATE TABLE c (a BOOL, b BOOL, c BOOL, d BOOL, e BOOL)
 ----
-TABLE c
- ├── a bool
- ├── b bool
- ├── c bool
- ├── d bool
- ├── e bool
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE e
@@ -51,14 +24,6 @@ CREATE TABLE e
     d DATE
 )
 ----
-TABLE e
- ├── k int not null
- ├── i int
- ├── t timestamp
- ├── tz timestamptz
- ├── d date
- └── INDEX primary
-      └── k int not null
 
 # --------------------------------------------------
 # SimplifyFilters
@@ -1192,14 +1157,6 @@ select
 exec-ddl
 CREATE TABLE b (k INT PRIMARY KEY, i INT, f FLOAT, s STRING NOT NULL, j JSON)
 ----
-TABLE b
- ├── k int not null
- ├── i int
- ├── f float
- ├── s string not null
- ├── j jsonb
- └── INDEX primary
-      └── k int not null
 
 opt expect=RemoveNotNullCondition
 SELECT k FROM b WHERE k IS NOT NULL AND k > 4

--- a/pkg/sql/opt/norm/testdata/rules/set
+++ b/pkg/sql/opt/norm/testdata/rules/set
@@ -1,26 +1,10 @@
 exec-ddl
 CREATE TABLE b (k INT PRIMARY KEY, i INT, f FLOAT, s STRING NOT NULL, j JSON)
 ----
-TABLE b
- ├── k int not null
- ├── i int
- ├── f float
- ├── s string not null
- ├── j jsonb
- └── INDEX primary
-      └── k int not null
 
 exec-ddl
 CREATE TABLE a (v INT PRIMARY KEY, w INT, x FLOAT, y STRING NOT NULL, z JSON)
 ----
-TABLE a
- ├── v int not null
- ├── w int
- ├── x float
- ├── y string not null
- ├── z jsonb
- └── INDEX primary
-      └── v int not null
 
 # --------------------------------------------------
 # EliminateUnionAllLeft

--- a/pkg/sql/opt/norm/testdata/rules/side_effects
+++ b/pkg/sql/opt/norm/testdata/rules/side_effects
@@ -3,32 +3,14 @@
 exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON)
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── f float
- ├── s string
- ├── j jsonb
- └── INDEX primary
-      └── k int not null
 
 exec-ddl
 CREATE TABLE xy (x INT PRIMARY KEY, y INT)
 ----
-TABLE xy
- ├── x int not null
- ├── y int
- └── INDEX primary
-      └── x int not null
 
 exec-ddl
 CREATE TABLE uv (u INT PRIMARY KEY, v INT)
 ----
-TABLE uv
- ├── u int not null
- ├── v int
- └── INDEX primary
-      └── u int not null
 
 # Don't allow ORDER BY column to be eliminated if it has a side effect.
 opt

--- a/pkg/sql/opt/norm/testdata/rules/window
+++ b/pkg/sql/opt/norm/testdata/rules/window
@@ -1,14 +1,6 @@
 exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON)
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── f float
- ├── s string
- ├── j jsonb
- └── INDEX primary
-      └── k int not null
 
 # --------------------------------------------------
 # ReduceWindowPartitionCols

--- a/pkg/sql/opt/norm/testdata/rules/zero_cardinality
+++ b/pkg/sql/opt/norm/testdata/rules/zero_cardinality
@@ -1,14 +1,6 @@
 exec-ddl
 CREATE TABLE b (k INT PRIMARY KEY, i INT, f FLOAT, s STRING NOT NULL, j JSON)
 ----
-TABLE b
- ├── k int not null
- ├── i int
- ├── f float
- ├── s string not null
- ├── j jsonb
- └── INDEX primary
-      └── k int not null
 
 # --------------------------------------------------
 # SimplifyZeroCardinalityGroup

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -8,13 +8,6 @@ CREATE TABLE kv (
   s STRING
 )
 ----
-TABLE kv
- ├── k int not null
- ├── v int
- ├── w int
- ├── s string
- └── INDEX primary
-      └── k int not null
 
 build
 SELECT min(1), max(1), count(1), sum_int(1), avg(1), sum(1), stddev(1),
@@ -1249,13 +1242,6 @@ CREATE TABLE abc (
   d DECIMAL
 )
 ----
-TABLE abc
- ├── a char not null
- ├── b float
- ├── c bool
- ├── d decimal
- └── INDEX primary
-      └── a char not null
 
 build
 SELECT min(a), min(b), min(c), min(d) FROM abc
@@ -1316,10 +1302,6 @@ CREATE TABLE intervals (
   a INTERVAL PRIMARY KEY
 )
 ----
-TABLE intervals
- ├── a interval not null
- └── INDEX primary
-      └── a interval not null
 
 build
 SELECT sum(a) FROM intervals
@@ -1374,22 +1356,6 @@ CREATE TABLE xyz (
   FAMILY (z)
 )
 ----
-TABLE xyz
- ├── x int not null
- ├── y int
- ├── z float
- ├── INDEX primary
- │    └── x int not null
- ├── INDEX xy
- │    ├── x int not null
- │    └── y int
- ├── INDEX zyx
- │    ├── z float
- │    ├── y int
- │    └── x int not null
- ├── FAMILY family1 (x)
- ├── FAMILY family2 (y)
- └── FAMILY family3 (z)
 
 build
 SELECT min(x) FROM xyz
@@ -1803,11 +1769,6 @@ limit
 exec-ddl
 CREATE TABLE bools (b BOOL)
 ----
-TABLE bools
- ├── b bool
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 build
 SELECT bool_and(b), bool_or(b) FROM bools
@@ -1842,13 +1803,6 @@ project
 exec-ddl
 CREATE TABLE xor_bytes (a bytes, b int, c int)
 ----
-TABLE xor_bytes
- ├── a bytes
- ├── b int
- ├── c int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 build
 SELECT to_hex(xor_agg(a)), xor_agg(c) FROM xor_bytes
@@ -1984,23 +1938,10 @@ CREATE TABLE ab (
   FAMILY (b)
 )
 ----
-TABLE ab
- ├── a int not null
- ├── b int
- ├── INDEX primary
- │    └── a int not null
- ├── FAMILY family1 (a)
- └── FAMILY family2 (b)
 
 exec-ddl
 CREATE TABLE xy(x STRING, y STRING);
 ----
-TABLE xy
- ├── x string
- ├── y string
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 # Grouping and rendering tuples.
 build
@@ -2323,12 +2264,6 @@ error (42803): column "k" must appear in the GROUP BY clause or be used in an ag
 exec-ddl
 CREATE TABLE foo (bar JSON, baz JSON)
 ----
-TABLE foo
- ├── bar jsonb
- ├── baz jsonb
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 build
 SELECT a.bar @> b.baz AND b.baz @> b.baz AS r FROM foo AS a, foo AS b GROUP BY a.bar @> b.baz, b.baz
@@ -2394,10 +2329,6 @@ project
 exec-ddl
 CREATE TABLE times (t time PRIMARY KEY)
 ----
-TABLE times
- ├── t time not null
- └── INDEX primary
-      └── t time not null
 
 build
 SELECT date_trunc('second', a.t) - date_trunc('minute', b.t) AS r FROM times a, times b

--- a/pkg/sql/opt/optbuilder/testdata/delete
+++ b/pkg/sql/opt/optbuilder/testdata/delete
@@ -7,15 +7,6 @@ CREATE TABLE abcde (
     e INT AS (a) STORED
 )
 ----
-TABLE abcde
- ├── a int not null
- ├── b int
- ├── c int
- ├── d int
- ├── e int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE xyz (
@@ -24,12 +15,6 @@ CREATE TABLE xyz (
     z FLOAT8
 )
 ----
-TABLE xyz
- ├── x string not null
- ├── y int
- ├── z float
- └── INDEX primary
-      └── x string not null
 
 exec-ddl
 CREATE TABLE uv (
@@ -37,12 +22,6 @@ CREATE TABLE uv (
     v BYTES
 )
 ----
-TABLE uv
- ├── u decimal
- ├── v bytes
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE mutation (
@@ -52,13 +31,6 @@ CREATE TABLE mutation (
     "p:delete-only" INT AS (o + n) STORED
 )
 ----
-TABLE mutation
- ├── m int not null
- ├── n int
- ├── o int (mutation)
- ├── p int (mutation)
- └── INDEX primary
-      └── m int not null
 
 # ------------------------------------------------------------------------------
 # Basic tests.

--- a/pkg/sql/opt/optbuilder/testdata/distinct
+++ b/pkg/sql/opt/optbuilder/testdata/distinct
@@ -12,22 +12,6 @@ CREATE TABLE xyz (
   FAMILY (z)
 )
 ----
-TABLE xyz
- ├── x int not null
- ├── y int
- ├── z float
- ├── INDEX primary
- │    └── x int not null
- ├── INDEX xy
- │    ├── x int not null
- │    └── y int
- ├── INDEX zyx
- │    ├── z float
- │    ├── y int
- │    └── x int not null
- ├── FAMILY family1 (x)
- ├── FAMILY family2 (y)
- └── FAMILY family3 (z)
 
 build
 SELECT y, z FROM xyz
@@ -335,20 +319,6 @@ CREATE TABLE abcd (
   UNIQUE INDEX (d, b)
 )
 ----
-TABLE abcd
- ├── a int not null
- ├── b int not null
- ├── c int not null
- ├── d int not null
- ├── INDEX primary
- │    ├── a int not null
- │    ├── b int not null
- │    └── c int not null
- └── INDEX secondary
-      ├── d int not null
-      ├── b int not null
-      ├── a int not null (storing)
-      └── c int not null (storing)
 
 build
 SELECT DISTINCT 1 AS x, d, b FROM abcd ORDER BY d, b

--- a/pkg/sql/opt/optbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/optbuilder/testdata/distinct_on
@@ -10,15 +10,6 @@ CREATE TABLE xyz (
   PRIMARY KEY (pk1, pk2)
 )
 ----
-TABLE xyz
- ├── x int
- ├── y int
- ├── z int
- ├── pk1 int not null
- ├── pk2 int not null
- └── INDEX primary
-      ├── pk1 int not null
-      └── pk2 int not null
 
 exec-ddl
 CREATE TABLE abc (
@@ -28,14 +19,6 @@ CREATE TABLE abc (
   PRIMARY KEY (a, b, c)
 )
 ----
-TABLE abc
- ├── a string not null
- ├── b string not null
- ├── c string not null
- └── INDEX primary
-      ├── a string not null
-      ├── b string not null
-      └── c string not null
 
 ##################
 # Simple queries #

--- a/pkg/sql/opt/optbuilder/testdata/explain
+++ b/pkg/sql/opt/optbuilder/testdata/explain
@@ -1,11 +1,6 @@
 exec-ddl
 CREATE TABLE xy (x INT PRIMARY KEY, y INT)
 ----
-TABLE xy
- ├── x int not null
- ├── y int
- └── INDEX primary
-      └── x int not null
 
 build
 EXPLAIN SELECT * FROM xy

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -8,13 +8,6 @@ CREATE TABLE kv (
   s STRING
 )
 ----
-TABLE kv
- ├── k int not null
- ├── v int
- ├── w int
- ├── s string
- └── INDEX primary
-      └── k int not null
 
 # Presence of HAVING triggers aggregation, reducing results to one row (even without GROUP BY).
 build

--- a/pkg/sql/opt/optbuilder/testdata/inner-join
+++ b/pkg/sql/opt/optbuilder/testdata/inner-join
@@ -1,36 +1,14 @@
 exec-ddl
 CREATE TABLE a (x INT PRIMARY KEY, y FLOAT)
 ----
-TABLE a
- ├── x int not null
- ├── y float
- └── INDEX primary
-      └── x int not null
 
 exec-ddl
 CREATE TABLE b (x INT, y FLOAT)
 ----
-TABLE b
- ├── x int
- ├── y float
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE c (x INT, y FLOAT, z VARCHAR, CONSTRAINT fk_x_ref_a FOREIGN KEY (x) REFERENCES a (x))
 ----
-TABLE c
- ├── x int
- ├── y float
- ├── z varchar
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- ├── INDEX c_auto_index_fk_x_ref_a
- │    ├── x int
- │    └── rowid int not null (hidden)
- └── CONSTRAINT fk_x_ref_a FOREIGN KEY (x) REFERENCES t.public.a (x)
 
 build
 SELECT * FROM a, b
@@ -95,21 +73,10 @@ project
 exec-ddl
 CREATE TABLE db1.a (x INT PRIMARY KEY, y FLOAT, z STRING)
 ----
-TABLE a
- ├── x int not null
- ├── y float
- ├── z string
- └── INDEX primary
-      └── x int not null
 
 exec-ddl
 CREATE TABLE db2.a (x INT PRIMARY KEY, y FLOAT)
 ----
-TABLE a
- ├── x int not null
- ├── y float
- └── INDEX primary
-      └── x int not null
 
 build fully-qualify-names
 SELECT a.x FROM db1.a, db2.a

--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -7,15 +7,6 @@ CREATE TABLE abcde (
     e INT AS (a) STORED
 )
 ----
-TABLE abcde
- ├── a int not null
- ├── b int
- ├── c int
- ├── d int
- ├── e int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE xyz (
@@ -24,12 +15,6 @@ CREATE TABLE xyz (
     z FLOAT8
 )
 ----
-TABLE xyz
- ├── x string not null
- ├── y int
- ├── z float
- └── INDEX primary
-      └── x string not null
 
 exec-ddl
 CREATE TABLE uv (
@@ -37,12 +22,6 @@ CREATE TABLE uv (
     v BYTES
 )
 ----
-TABLE uv
- ├── u decimal
- ├── v bytes
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE mutation (
@@ -54,15 +33,6 @@ CREATE TABLE mutation (
     CHECK (m > 0)
 )
 ----
-TABLE mutation
- ├── m int not null
- ├── n int
- ├── o int (mutation)
- ├── p int (mutation)
- ├── q int (mutation)
- ├── INDEX primary
- │    └── m int not null
- └── CHECK (m > 0)
 
 exec-ddl
 CREATE TABLE checks (
@@ -73,15 +43,6 @@ CREATE TABLE checks (
     CHECK (checks.b < d)
 )
 ----
-TABLE checks
- ├── a int not null
- ├── b int
- ├── c int
- ├── d int
- ├── INDEX primary
- │    └── a int not null
- ├── CHECK (checks.b < d)
- └── CHECK (a > 0)
 
 exec-ddl
 CREATE TABLE decimals (
@@ -91,15 +52,6 @@ CREATE TABLE decimals (
     d DECIMAL(10,1) AS (a+c) STORED
 )
 ----
-TABLE decimals
- ├── a decimal not null
- ├── b decimal[]
- ├── c decimal
- ├── d decimal
- ├── INDEX primary
- │    └── a decimal not null
- ├── CHECK (round(a) = a)
- └── CHECK (b[0] > 1)
 
 # Unknown target table.
 build

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -3,11 +3,6 @@
 exec-ddl
 CREATE TABLE onecolumn (x INT)
 ----
-TABLE onecolumn
- ├── x int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 build
 SELECT * FROM onecolumn AS a(x) CROSS JOIN onecolumn AS b(y)
@@ -237,11 +232,6 @@ project
 exec-ddl
 CREATE TABLE onecolumn_w(w INT)
 ----
-TABLE onecolumn_w
- ├── w int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 build
 SELECT * FROM onecolumn AS a NATURAL JOIN onecolumn_w as b
@@ -259,11 +249,6 @@ project
 exec-ddl
 CREATE TABLE othercolumn (x INT)
 ----
-TABLE othercolumn
- ├── x int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 build
 SELECT * FROM onecolumn AS a FULL OUTER JOIN othercolumn AS b ON a.x = b.x ORDER BY a.x,b.x
@@ -389,11 +374,6 @@ limit
 exec-ddl
 CREATE TABLE empty (x INT)
 ----
-TABLE empty
- ├── x int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 build
 SELECT * FROM onecolumn AS a(x) CROSS JOIN empty AS b(y)
@@ -678,12 +658,6 @@ sort
 exec-ddl
 CREATE TABLE twocolumn (x INT, y INT)
 ----
-TABLE twocolumn
- ├── x int
- ├── y int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 # Natural joins with partial match
 build
@@ -896,21 +870,10 @@ error (42P01): no data source matches prefix: a
 exec-ddl
 CREATE TABLE a (i int)
 ----
-TABLE a
- ├── i int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE b (i int, b bool)
 ----
-TABLE b
- ├── i int
- ├── b bool
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 build
 SELECT * FROM a INNER JOIN b ON a.i = b.i
@@ -1196,11 +1159,6 @@ error (42701): column "x" appears more than once in USING clause
 exec-ddl
 CREATE TABLE othertype (x TEXT)
 ----
-TABLE othertype
- ├── x string
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 build
 SELECT * FROM (onecolumn AS a JOIN othertype AS b USING(x))
@@ -1381,21 +1339,10 @@ sort
 exec-ddl
 CREATE TABLE square (n INT PRIMARY KEY, sq INT)
 ----
-TABLE square
- ├── n int not null
- ├── sq int
- └── INDEX primary
-      └── n int not null
 
 exec-ddl
 CREATE TABLE pairs (a INT, b INT)
 ----
-TABLE pairs
- ├── a int
- ├── b int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 # The filter expression becomes an equality constraint.
 build
@@ -1665,26 +1612,10 @@ select
 exec-ddl
 CREATE TABLE t1 (col1 INT, x INT, col2 INT, y INT)
 ----
-TABLE t1
- ├── col1 int
- ├── x int
- ├── col2 int
- ├── y int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE t2 (col3 INT, y INT, x INT, col4 INT)
 ----
-TABLE t2
- ├── col3 int
- ├── y int
- ├── x int
- ├── col4 int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 build
 SELECT * FROM t1 JOIN t2 USING(x)
@@ -1938,52 +1869,18 @@ project
 exec-ddl
 CREATE TABLE pkBA (a INT, b INT, c INT, d INT, PRIMARY KEY(b,a))
 ----
-TABLE pkba
- ├── a int not null
- ├── b int not null
- ├── c int
- ├── d int
- └── INDEX primary
-      ├── b int not null
-      └── a int not null
 
 exec-ddl
 CREATE TABLE pkBC (a INT, b INT, c INT, d INT, PRIMARY KEY(b,c))
 ----
-TABLE pkbc
- ├── a int
- ├── b int not null
- ├── c int not null
- ├── d int
- └── INDEX primary
-      ├── b int not null
-      └── c int not null
 
 exec-ddl
 CREATE TABLE pkBAC (a INT, b INT, c INT, d INT, PRIMARY KEY(b,a,c))
 ----
-TABLE pkbac
- ├── a int not null
- ├── b int not null
- ├── c int not null
- ├── d int
- └── INDEX primary
-      ├── b int not null
-      ├── a int not null
-      └── c int not null
 
 exec-ddl
 CREATE TABLE pkBAD (a INT, b INT, c INT, d INT, PRIMARY KEY(b,a,d))
 ----
-TABLE pkbad
- ├── a int not null
- ├── b int not null
- ├── c int
- ├── d int not null
- └── INDEX primary
-      ├── b int not null
-      ├── a int not null
-      └── d int not null
 
 build
 SELECT * FROM pkBA AS l JOIN pkBC AS r ON l.a = r.a AND l.b = r.b AND l.c = r.c
@@ -2080,20 +1977,10 @@ inner-join
 exec-ddl
 CREATE TABLE str1 (a INT PRIMARY KEY, s STRING COLLATE en_u_ks_level1)
 ----
-TABLE str1
- ├── a int not null
- ├── s collatedstring{en_u_ks_level1}
- └── INDEX primary
-      └── a int not null
 
 exec-ddl
 CREATE TABLE str2 (a INT PRIMARY KEY, s STRING COLLATE en_u_ks_level1)
 ----
-TABLE str2
- ├── a int not null
- ├── s collatedstring{en_u_ks_level1}
- └── INDEX primary
-      └── a int not null
 
 build
 SELECT s, str1.s, str2.s FROM str1 INNER JOIN str2 USING(s)
@@ -2202,26 +2089,10 @@ project
 exec-ddl
 CREATE TABLE xyu (x INT, y INT, u INT, PRIMARY KEY(x,y,u))
 ----
-TABLE xyu
- ├── x int not null
- ├── y int not null
- ├── u int not null
- └── INDEX primary
-      ├── x int not null
-      ├── y int not null
-      └── u int not null
 
 exec-ddl
 CREATE TABLE xyv (x INT, y INT, v INT, PRIMARY KEY(x,y,v))
 ----
-TABLE xyv
- ├── x int not null
- ├── y int not null
- ├── v int not null
- └── INDEX primary
-      ├── x int not null
-      ├── y int not null
-      └── v int not null
 
 build
 SELECT * FROM xyu INNER JOIN xyv USING(x, y) WHERE x > 2
@@ -2616,18 +2487,10 @@ project
 exec-ddl
 CREATE TABLE l (a INT PRIMARY KEY)
 ----
-TABLE l
- ├── a int not null
- └── INDEX primary
-      └── a int not null
 
 exec-ddl
 CREATE TABLE r (a INT PRIMARY KEY)
 ----
-TABLE r
- ├── a int not null
- └── INDEX primary
-      └── a int not null
 
 build
 SELECT * FROM l LEFT OUTER JOIN r ON l.a = r.a WHERE l.a = 3;
@@ -2725,18 +2588,6 @@ CREATE TABLE abcdef (
   PRIMARY KEY (a ASC, b ASC, c DESC, d ASC)
 )
 ----
-TABLE abcdef
- ├── a int not null
- ├── b int not null
- ├── c int not null
- ├── d int not null
- ├── e int
- ├── f int
- └── INDEX primary
-      ├── a int not null
-      ├── b int not null
-      ├── c int not null desc
-      └── d int not null
 
 exec-ddl
 CREATE TABLE abg (
@@ -2746,13 +2597,6 @@ CREATE TABLE abg (
   PRIMARY KEY (a ASC, b ASC)
 );
 ----
-TABLE abg
- ├── a int not null
- ├── b int not null
- ├── g int
- └── INDEX primary
-      ├── a int not null
-      └── b int not null
 
 build
 SELECT * FROM abcdef join (select * from abg) USING (a,b) WHERE ((a,b)>(1,2) OR ((a,b)=(1,2) AND c < 6) OR ((a,b,c)=(1,2,6) AND d > 8))
@@ -2818,14 +2662,6 @@ CREATE TABLE foo (
   d FLOAT
 )
 ----
-TABLE foo
- ├── a int
- ├── b int
- ├── c float
- ├── d float
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE bar (
@@ -2835,14 +2671,6 @@ CREATE TABLE bar (
   d INT
 )
 ----
-TABLE bar
- ├── a int
- ├── b float
- ├── c float
- ├── d int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 # Only a and c can be equality columns.
 build
@@ -3049,13 +2877,6 @@ CREATE TABLE t.kv (
   s STRING
 )
 ----
-TABLE kv
- ├── k int not null
- ├── v int
- ├── w int
- ├── s string
- └── INDEX primary
-      └── k int not null
 
 build
 SELECT k FROM kv, (SELECT 1 AS k)

--- a/pkg/sql/opt/optbuilder/testdata/lateral
+++ b/pkg/sql/opt/optbuilder/testdata/lateral
@@ -1,26 +1,14 @@
 exec-ddl
 CREATE TABLE x (a INT PRIMARY KEY)
 ----
-TABLE x
- ├── a int not null
- └── INDEX primary
-      └── a int not null
 
 exec-ddl
 CREATE TABLE y (b INT PRIMARY KEY)
 ----
-TABLE y
- ├── b int not null
- └── INDEX primary
-      └── b int not null
 
 exec-ddl
 CREATE TABLE z (c INT PRIMARY KEY)
 ----
-TABLE z
- ├── c int not null
- └── INDEX primary
-      └── c int not null
 
 build
 SELECT * FROM x, y, z
@@ -180,11 +168,6 @@ CREATE TABLE j (
   j JSONB
 )
 ----
-TABLE j
- ├── id int not null
- ├── j jsonb
- └── INDEX primary
-      └── id int not null
 
 build
 SELECT * FROM j, jsonb_array_elements(j.j->'foo')

--- a/pkg/sql/opt/optbuilder/testdata/limit
+++ b/pkg/sql/opt/optbuilder/testdata/limit
@@ -3,15 +3,6 @@
 exec-ddl
 CREATE TABLE t (k INT PRIMARY KEY, v INT, w INT, INDEX(v))
 ----
-TABLE t
- ├── k int not null
- ├── v int
- ├── w int
- ├── INDEX primary
- │    └── k int not null
- └── INDEX secondary
-      ├── v int
-      └── k int not null
 
 build
 SELECT k, v FROM t ORDER BY k LIMIT 5

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -7,12 +7,6 @@ CREATE TABLE t (
   c BOOLEAN
 )
 ----
-TABLE t
- ├── a int not null
- ├── b int
- ├── c bool
- └── INDEX primary
-      └── a int not null
 
 build
 SELECT c FROM t ORDER BY c
@@ -596,31 +590,10 @@ CREATE TABLE abc (
   FAMILY (d)
 )
 ----
-TABLE abc
- ├── a int not null
- ├── b int not null
- ├── c int not null
- ├── d char
- ├── INDEX primary
- │    ├── a int not null
- │    ├── b int not null
- │    └── c int not null
- ├── INDEX bc
- │    ├── b int not null
- │    ├── c int not null
- │    └── a int not null (storing)
- ├── INDEX ba
- │    ├── b int not null
- │    ├── a int not null
- │    └── c int not null
- ├── FAMILY family1 (a, b, c)
- └── FAMILY family2 (d)
 
 exec-ddl
 CREATE VIEW abcview AS SELECT * FROM abc
 ----
-VIEW abcview
- └── SELECT * FROM abc
 
 build
 SELECT d FROM abc ORDER BY lower(d)
@@ -795,14 +768,6 @@ error (42809): "abcview" is not a table
 exec-ddl
 CREATE TABLE bar (id INT PRIMARY KEY, baz STRING, UNIQUE INDEX i_bar (baz))
 ----
-TABLE bar
- ├── id int not null
- ├── baz string
- ├── INDEX primary
- │    └── id int not null
- └── INDEX i_bar
-      ├── baz string
-      └── id int not null (storing)
 
 build
 SELECT * FROM bar ORDER BY baz, id
@@ -823,22 +788,6 @@ CREATE TABLE abcd (
   INDEX bcd (b, c DESC, d)
 )
 ----
-TABLE abcd
- ├── a int not null
- ├── b int
- ├── c int
- ├── d int
- ├── INDEX primary
- │    └── a int not null
- ├── INDEX abc
- │    ├── a int not null
- │    ├── b int
- │    └── c int
- └── INDEX bcd
-      ├── b int
-      ├── c int desc
-      ├── d int
-      └── a int not null
 
 # Verify that projections after ORDER BY perform correctly (i.e., the outer
 # expression does not guarantee it will apply the ORDER BY).
@@ -903,15 +852,6 @@ CREATE TABLE blocks (
   PRIMARY KEY (block_id, writer_id, block_num)
 )
 ----
-TABLE blocks
- ├── block_id int not null
- ├── writer_id string not null
- ├── block_num int not null
- ├── raw_bytes bytes
- └── INDEX primary
-      ├── block_id int not null
-      ├── writer_id string not null
-      └── block_num int not null
 
 # Regression test for #13696.
 build
@@ -1049,13 +989,6 @@ CREATE TABLE abcd (
   d INT
 )
 ----
-TABLE abcd
- ├── a int not null
- ├── b int
- ├── c int
- ├── d int
- └── INDEX primary
-      └── a int not null
 
 build
 SELECT a, b FROM abcd ORDER BY b, c

--- a/pkg/sql/opt/optbuilder/testdata/ordinality
+++ b/pkg/sql/opt/optbuilder/testdata/ordinality
@@ -7,17 +7,6 @@ CREATE TABLE abcd (
   INDEX abc (a, b, c)
 )
 ----
-TABLE abcd
- ├── a int not null
- ├── b int
- ├── c int
- ├── d int
- ├── INDEX primary
- │    └── a int not null
- └── INDEX abc
-      ├── a int not null
-      ├── b int
-      └── c int
 
 build
 SELECT * FROM (VALUES ('a'), ('b')) WITH ORDINALITY AS X(name, i)

--- a/pkg/sql/opt/optbuilder/testdata/project
+++ b/pkg/sql/opt/optbuilder/testdata/project
@@ -1,21 +1,10 @@
 exec-ddl
 CREATE TABLE a (x INT PRIMARY KEY, y FLOAT)
 ----
-TABLE a
- ├── x int not null
- ├── y float
- └── INDEX primary
-      └── x int not null
 
 exec-ddl
 CREATE TABLE b (x INT, y FLOAT)
 ----
-TABLE b
- ├── x int
- ├── y float
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 build
 SELECT 5 r
@@ -166,12 +155,6 @@ project
 exec-ddl
 CREATE TABLE c (x INT, y FLOAT)
 ----
-TABLE c
- ├── x int
- ├── y float
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 build
 SELECT rowid FROM b, c
@@ -222,12 +205,6 @@ error (42846): invalid cast: int -> int[]
 exec-ddl
 CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT)
 ----
-TABLE abc
- ├── a int not null
- ├── b int
- ├── c int
- └── INDEX primary
-      └── a int not null
 
 build
 SELECT c FROM (SELECT a FROM abc)
@@ -252,11 +229,6 @@ error (42P01): no data source matches prefix: t.kv
 exec-ddl
 CREATE TABLE kv (k INT PRIMARY KEY, v INT)
 ----
-TABLE kv
- ├── k int not null
- ├── v int
- └── INDEX primary
-      └── k int not null
 
 build fully-qualify-names
 SELECT t.kv.k FROM kv

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -793,18 +793,10 @@ project
 exec-ddl
 CREATE TABLE x (a INT PRIMARY KEY)
 ----
-TABLE x
- ├── a int not null
- └── INDEX primary
-      └── a int not null
 
 exec-ddl
 CREATE TABLE y (b INT PRIMARY KEY)
 ----
-TABLE y
- ├── b int not null
- └── INDEX primary
-      └── b int not null
 
 build
 SELECT b, ARRAY(SELECT a FROM x WHERE x.a = y.b) FROM y
@@ -1061,20 +1053,10 @@ collate [type=collatedstring{en}]
 exec-ddl
 CREATE TABLE u (x INT)
 ----
-TABLE u
- ├── x int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE v (y INT[])
 ----
-TABLE v
- ├── y int[]
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 build
 SELECT ARRAY(SELECT x FROM u ORDER BY x)

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -5,27 +5,10 @@
 exec-ddl
 CREATE TABLE numeric_references (a INT PRIMARY KEY, y INT, b INT, c INT, INDEX bc (b,c))
 ----
-TABLE numeric_references
- ├── a int not null
- ├── y int
- ├── b int
- ├── c int
- ├── INDEX primary
- │    └── a int not null
- └── INDEX bc
-      ├── b int
-      ├── c int
-      └── a int not null
 
 exec-ddl
 CREATE TABLE num_ref_hidden (x INT, y INT)
 ----
-TABLE num_ref_hidden
- ├── x int
- ├── y int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 # SELECT with no table.
 
@@ -65,12 +48,6 @@ project
 exec-ddl
 CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT)
 ----
-TABLE abc
- ├── a int not null
- ├── b int
- ├── c int
- └── INDEX primary
-      └── a int not null
 
 build
 SELECT * FROM abc WHERE 'hello'
@@ -187,11 +164,6 @@ project
 exec-ddl
 CREATE TABLE kv (k CHAR PRIMARY KEY, v CHAR)
 ----
-TABLE kv
- ├── k char not null
- ├── v char
- └── INDEX primary
-      └── k char not null
 
 build
 SELECT * FROM kv
@@ -322,10 +294,6 @@ project
 exec-ddl
 CREATE TABLE kw ("from" INT PRIMARY KEY)
 ----
-TABLE kw
- ├── from int not null
- └── INDEX primary
-      └── from int not null
 
 build
 SELECT *, "from", kw."from" FROM kw
@@ -342,17 +310,6 @@ CREATE TABLE xyzw (
   INDEX foo (z, y)
 )
 ----
-TABLE xyzw
- ├── x int not null
- ├── y int
- ├── z int
- ├── w int
- ├── INDEX primary
- │    └── x int not null
- └── INDEX foo
-      ├── z int
-      ├── y int
-      └── x int not null
 
 # SELECT with index hints.
 
@@ -602,11 +559,6 @@ CREATE TABLE boolean_table (
   value BOOLEAN
 )
 ----
-TABLE boolean_table
- ├── id int not null
- ├── value bool
- └── INDEX primary
-      └── id int not null
 
 build
 SELECT value FROM boolean_table
@@ -1016,11 +968,6 @@ project
 exec-ddl
 CREATE TABLE a (x INT PRIMARY KEY, y FLOAT)
 ----
-TABLE a
- ├── x int not null
- ├── y float
- └── INDEX primary
-      └── x int not null
 
 build
 SELECT * FROM a
@@ -1263,10 +1210,6 @@ scan t
 exec-ddl
 CREATE TABLE no_cols_table ()
 ----
-TABLE no_cols_table
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 build
 SELECT * FROM no_cols_table

--- a/pkg/sql/opt/optbuilder/testdata/sequence
+++ b/pkg/sql/opt/optbuilder/testdata/sequence
@@ -1,12 +1,10 @@
 exec-ddl
 CREATE SEQUENCE x
 ----
-SEQUENCE t.public.x
 
 exec-ddl
 CREATE SEQUENCE y
 ----
-SEQUENCE t.public.y
 
 build
 SELECT * FROM x

--- a/pkg/sql/opt/optbuilder/testdata/srfs
+++ b/pkg/sql/opt/optbuilder/testdata/srfs
@@ -100,20 +100,10 @@ project-set
 exec-ddl
 CREATE TABLE t (a string)
 ----
-TABLE t
- ├── a string
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE u (b string)
 ----
-TABLE u
- ├── b string
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 build
 SELECT t.*, u.*, a.*, b.* FROM t, u, generate_series(1, 2) AS a, generate_series(3, 4) AS b
@@ -921,14 +911,6 @@ project
 exec-ddl
 CREATE TABLE a (x INT PRIMARY KEY, j JSON, k JSON, m JSON, n JSON)
 ----
-TABLE a
- ├── x int not null
- ├── j jsonb
- ├── k jsonb
- ├── m jsonb
- ├── n jsonb
- └── INDEX primary
-      └── x int not null
 
 build
 SELECT

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -644,12 +644,6 @@ error (22023): unsupported comparison operator: <tuple{int, int}> IN <tuple{int}
 exec-ddl
 CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT)
 ----
-TABLE abc
- ├── a int not null
- ├── b int
- ├── c int
- └── INDEX primary
-      └── a int not null
 
 build
 SELECT (1, 2) IN (SELECT * FROM abc) AS r
@@ -782,11 +776,6 @@ project
 exec-ddl
 CREATE TABLE kv (k INT PRIMARY KEY, v INT)
 ----
-TABLE kv
- ├── k int not null
- ├── v int
- └── INDEX primary
-      └── k int not null
 
 build
 SELECT (SELECT abc.k FROM abc) FROM kv AS abc
@@ -825,12 +814,6 @@ select
 exec-ddl
 CREATE TABLE xyz (x INT PRIMARY KEY, y INT, z INT)
 ----
-TABLE xyz
- ├── x int not null
- ├── y int
- ├── z int
- └── INDEX primary
-      └── x int not null
 
 build
 SELECT * FROM xyz
@@ -907,11 +890,6 @@ DROP TABLE kv
 exec-ddl
 CREATE TABLE kv (k INT PRIMARY KEY, v STRING)
 ----
-TABLE kv
- ├── k int not null
- ├── v string
- └── INDEX primary
-      └── k int not null
 
 build
 SELECT * FROM kv WHERE k = (SELECT k FROM kv WHERE (k, v) = (1, 'one'))
@@ -1325,18 +1303,6 @@ project
 exec-ddl
 CREATE TABLE tab4 (col0 INTEGER, col1 FLOAT, col3 INTEGER, col4 FLOAT, INDEX idx_tab4_0 (col4,col0))
 ----
-TABLE tab4
- ├── col0 int
- ├── col1 float
- ├── col3 int
- ├── col4 float
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- └── INDEX idx_tab4_0
-      ├── col4 float
-      ├── col0 int
-      └── rowid int not null (hidden)
 
 build
 SELECT col0 FROM tab4 WHERE (col0 <= 0 AND col4 <= 5.38) OR (col4 IN (SELECT col1 FROM tab4 WHERE col1 > 8.27)) AND (col3 <= 5 AND (col3 BETWEEN 7 AND 9))
@@ -1493,11 +1459,6 @@ project
 exec-ddl
 CREATE TABLE db1.kv (k INT PRIMARY KEY, v INT)
 ----
-TABLE kv
- ├── k int not null
- ├── v int
- └── INDEX primary
-      └── k int not null
 
 build fully-qualify-names
 SELECT (SELECT t.kv.k) FROM db1.kv, kv
@@ -1623,32 +1584,14 @@ project
 exec-ddl
 CREATE TABLE t1 (a INT, b INT)
 ----
-TABLE t1
- ├── a int
- ├── b int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE t2 (a INT, b INT)
 ----
-TABLE t2
- ├── a int
- ├── b int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE t3 (a INT, b INT)
 ----
-TABLE t3
- ├── a int
- ├── b int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 build
 SELECT (SELECT (SELECT DISTINCT t3.a FROM t1) FROM t2) FROM t3
@@ -1871,14 +1814,6 @@ project
 exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON)
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── f float
- ├── s string
- ├── j jsonb
- └── INDEX primary
-      └── k int not null
 
 # Regression test for #27330. Ensure that the subquery only returns one column
 # and is correctly typed.
@@ -1920,20 +1855,10 @@ select
 exec-ddl
 CREATE TABLE t (a string)
 ----
-TABLE t
- ├── a string
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE u (b string)
 ----
-TABLE u
- ├── b string
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 # Regression test for #27846. Ensure that an aggregate combined with ANY does
 # not cause a panic.
@@ -2418,20 +2343,10 @@ project
 exec-ddl
 CREATE TABLE v (x INT)
 ----
-TABLE v
- ├── x int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE w (y INT[])
 ----
-TABLE w
- ├── y int[]
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 # Regression test for #30191. Ensure ArrayFlatten returns correct type.
 build
@@ -2499,27 +2414,10 @@ group-by
 exec-ddl
 CREATE TABLE xyzs (x INT PRIMARY KEY, y INT, z FLOAT NOT NULL, s STRING, UNIQUE (s DESC, z));
 ----
-TABLE xyzs
- ├── x int not null
- ├── y int
- ├── z float not null
- ├── s string
- ├── INDEX primary
- │    └── x int not null
- └── INDEX secondary
-      ├── s string desc
-      ├── z float not null
-      └── x int not null (storing)
 
 exec-ddl
 CREATE TABLE kuv (k INT PRIMARY KEY, u FLOAT, v STRING);
 ----
-TABLE kuv
- ├── k int not null
- ├── u float
- ├── v string
- └── INDEX primary
-      └── k int not null
 
 # Regression test for #29114.
 build

--- a/pkg/sql/opt/optbuilder/testdata/union
+++ b/pkg/sql/opt/optbuilder/testdata/union
@@ -388,12 +388,6 @@ CREATE TABLE uniontest (
   v INT
 )
 ----
-TABLE uniontest
- ├── k int
- ├── v int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 build
 SELECT v FROM uniontest WHERE k = 1 UNION SELECT v FROM uniontest WHERE k = 2
@@ -763,12 +757,6 @@ error (42804): UNION types int[] and string[] cannot be matched
 exec-ddl
 CREATE TABLE t.xy (x STRING NOT NULL, y STRING NOT NULL)
 ----
-TABLE xy
- ├── x string not null
- ├── y string not null
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE t.abc (
@@ -777,13 +765,6 @@ CREATE TABLE t.abc (
   c string NOT NULL
 )
 ----
-TABLE abc
- ├── a string
- ├── b string not null
- ├── c string not null
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 build
 (SELECT x, x, y FROM xy) UNION (SELECT a, b, c FROM abc)
@@ -976,10 +957,6 @@ union-all
 exec-ddl
 CREATE TABLE a (a INT PRIMARY KEY)
 ----
-TABLE a
- ├── a int not null
- └── INDEX primary
-      └── a int not null
 
 # Regression test for #34524.
 build

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -7,15 +7,6 @@ CREATE TABLE abcde (
     e INT AS (a) STORED
 )
 ----
-TABLE abcde
- ├── a int not null
- ├── b int
- ├── c int
- ├── d int
- ├── e int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE xyz (
@@ -24,12 +15,6 @@ CREATE TABLE xyz (
     z FLOAT8
 )
 ----
-TABLE xyz
- ├── x string not null
- ├── y int
- ├── z float
- └── INDEX primary
-      └── x string not null
 
 exec-ddl
 CREATE TABLE uv (
@@ -37,12 +22,6 @@ CREATE TABLE uv (
     v BYTES
 )
 ----
-TABLE uv
- ├── u decimal
- ├── v bytes
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE mutation (
@@ -54,15 +33,6 @@ CREATE TABLE mutation (
     CHECK (m > 0)
 )
 ----
-TABLE mutation
- ├── m int not null
- ├── n int
- ├── o int (mutation)
- ├── p int (mutation)
- ├── q int (mutation)
- ├── INDEX primary
- │    └── m int not null
- └── CHECK (m > 0)
 
 exec-ddl
 CREATE TABLE checks (
@@ -73,15 +43,6 @@ CREATE TABLE checks (
     CHECK (checks.b < d)
 )
 ----
-TABLE checks
- ├── a int not null
- ├── b int
- ├── c int
- ├── d int
- ├── INDEX primary
- │    └── a int not null
- ├── CHECK (checks.b < d)
- └── CHECK (a > 0)
 
 exec-ddl
 CREATE TABLE decimals (
@@ -91,15 +52,6 @@ CREATE TABLE decimals (
     d DECIMAL(10,1) AS (a+c) STORED
 )
 ----
-TABLE decimals
- ├── a decimal not null
- ├── b decimal[]
- ├── c decimal
- ├── d decimal
- ├── INDEX primary
- │    └── a decimal not null
- ├── CHECK (round(a) = a)
- └── CHECK (b[0] > 1)
 
 # ------------------------------------------------------------------------------
 # Basic tests.

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -7,20 +7,6 @@ CREATE TABLE abc (
     UNIQUE(b, c)
 )
 ----
-TABLE abc
- ├── a int not null
- ├── b int
- ├── c int
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- ├── INDEX secondary
- │    ├── a int not null
- │    └── rowid int not null (hidden) (storing)
- └── INDEX secondary
-      ├── b int
-      ├── c int
-      └── rowid int not null (hidden) (storing)
 
 exec-ddl
 CREATE TABLE xyz (
@@ -32,23 +18,6 @@ CREATE TABLE xyz (
     INDEX (y DESC)
 )
 ----
-TABLE xyz
- ├── x int not null
- ├── y int
- ├── z int
- ├── INDEX primary
- │    └── x int not null
- ├── INDEX secondary
- │    ├── y int
- │    ├── z int
- │    └── x int not null (storing)
- ├── INDEX secondary
- │    ├── z int
- │    ├── y int
- │    └── x int not null (storing)
- └── INDEX secondary
-      ├── y int desc
-      └── x int not null
 
 exec-ddl
 CREATE TABLE uv (
@@ -57,12 +26,6 @@ CREATE TABLE uv (
     PRIMARY KEY (u, v)
 )
 ----
-TABLE uv
- ├── u int not null
- ├── v int not null
- └── INDEX primary
-      ├── u int not null
-      └── v int not null
 
 exec-ddl
 CREATE TABLE noindex (
@@ -71,12 +34,6 @@ CREATE TABLE noindex (
     z INT
 )
 ----
-TABLE noindex
- ├── x int not null
- ├── y int
- ├── z int
- └── INDEX primary
-      └── x int not null
 
 exec-ddl
 CREATE TABLE mutation (
@@ -88,15 +45,6 @@ CREATE TABLE mutation (
     CHECK (m > 0)
 )
 ----
-TABLE mutation
- ├── m int not null
- ├── n int
- ├── o int (mutation)
- ├── p int (mutation)
- ├── q int (mutation)
- ├── INDEX primary
- │    └── m int not null
- └── CHECK (m > 0)
 
 exec-ddl
 CREATE TABLE checks (
@@ -107,15 +55,6 @@ CREATE TABLE checks (
     CHECK (checks.b < d)
 )
 ----
-TABLE checks
- ├── a int not null
- ├── b int
- ├── c int
- ├── d int
- ├── INDEX primary
- │    └── a int not null
- ├── CHECK (checks.b < d)
- └── CHECK (a > 0)
 
 exec-ddl
 CREATE TABLE decimals (
@@ -125,15 +64,6 @@ CREATE TABLE decimals (
     d DECIMAL(10,1) AS (a+c) STORED
 )
 ----
-TABLE decimals
- ├── a decimal not null
- ├── b decimal[]
- ├── c decimal
- ├── d decimal
- ├── INDEX primary
- │    └── a decimal not null
- ├── CHECK (round(a) = a)
- └── CHECK (b[0] > 1)
 
 # ------------------------------------------------------------------------------
 # Basic tests.

--- a/pkg/sql/opt/optbuilder/testdata/view
+++ b/pkg/sql/opt/optbuilder/testdata/view
@@ -1,20 +1,10 @@
 exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON)
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── f float
- ├── s string
- ├── j jsonb
- └── INDEX primary
-      └── k int not null
 
 exec-ddl
 CREATE VIEW av AS SELECT k, i, s FROM a
 ----
-VIEW av
- └── SELECT k, i, s FROM a
 
 build
 SELECT * FROM av
@@ -62,8 +52,6 @@ project
 exec-ddl
 CREATE VIEW av2 (x, y) AS SELECT k, f FROM a WHERE i=10 ORDER BY s
 ----
-VIEW av2 (x, y)
- └── SELECT k, f FROM a WHERE i = 10 ORDER BY s
 
 # Result is not ordered.
 build

--- a/pkg/sql/opt/optbuilder/testdata/where
+++ b/pkg/sql/opt/optbuilder/testdata/where
@@ -6,11 +6,6 @@ CREATE TABLE kv (
   v INT
 )
 ----
-TABLE kv
- ├── k int not null
- ├── v int
- └── INDEX primary
-      └── k int not null
 
 exec-ddl
 CREATE TABLE kvString (
@@ -18,11 +13,6 @@ CREATE TABLE kvString (
   v STRING
 )
 ----
-TABLE kvstring
- ├── k string not null
- ├── v string
- └── INDEX primary
-      └── k string not null
 
 build
 SELECT * FROM kv WHERE k IN (1, 3)
@@ -179,12 +169,6 @@ select
 exec-ddl
 CREATE TABLE ab (a INT, b INT)
 ----
-TABLE ab
- ├── a int
- ├── b int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 build
 SELECT * FROM ab WHERE a IN (1, 3, 4)

--- a/pkg/sql/opt/optbuilder/testdata/window
+++ b/pkg/sql/opt/optbuilder/testdata/window
@@ -14,19 +14,6 @@ CREATE TABLE kv (
   FAMILY (s)
 )
 ----
-TABLE kv
- ├── k int not null
- ├── v int
- ├── w int
- ├── f float
- ├── d decimal
- ├── s string
- ├── b bool
- ├── INDEX primary
- │    └── k int not null
- ├── FAMILY family1 (k, v, w, f, b)
- ├── FAMILY family2 (d)
- └── FAMILY family3 (s)
 
 build
 SELECT * FROM kv GROUP BY v, rank() OVER ()

--- a/pkg/sql/opt/optbuilder/testdata/with
+++ b/pkg/sql/opt/optbuilder/testdata/with
@@ -1,20 +1,10 @@
 exec-ddl
 CREATE TABLE x(a INT)
 ----
-TABLE x
- ├── a int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE y(a INT)
 ----
-TABLE y
- ├── a int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 build
 WITH t AS (SELECT a FROM y WHERE a < 3)

--- a/pkg/sql/opt/optgen/exprgen/testdata/explain
+++ b/pkg/sql/opt/optgen/exprgen/testdata/explain
@@ -1,17 +1,6 @@
 exec-ddl
 CREATE TABLE abc (a INT, b INT, c INT, INDEX ab(a, b))
 ----
-TABLE abc
- ├── a int
- ├── b int
- ├── c int
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- └── INDEX ab
-      ├── a int
-      ├── b int
-      └── rowid int not null (hidden)
 
 expr
 (Explain

--- a/pkg/sql/opt/optgen/exprgen/testdata/join
+++ b/pkg/sql/opt/optgen/exprgen/testdata/join
@@ -1,28 +1,10 @@
 exec-ddl
 CREATE TABLE abc (a INT, b INT, c INT, INDEX ab(a, b))
 ----
-TABLE abc
- ├── a int
- ├── b int
- ├── c int
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- └── INDEX ab
-      ├── a int
-      ├── b int
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE def (d INT, e INT, f INT)
 ----
-TABLE def
- ├── d int
- ├── e int
- ├── f int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 expr
 (InnerJoin

--- a/pkg/sql/opt/optgen/exprgen/testdata/limit
+++ b/pkg/sql/opt/optgen/exprgen/testdata/limit
@@ -1,17 +1,6 @@
 exec-ddl
 CREATE TABLE abc (a INT, b INT, c INT, INDEX ab(a, b))
 ----
-TABLE abc
- ├── a int
- ├── b int
- ├── c int
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- └── INDEX ab
-      ├── a int
-      ├── b int
-      └── rowid int not null (hidden)
 
 expr
 (Limit

--- a/pkg/sql/opt/optgen/exprgen/testdata/scan
+++ b/pkg/sql/opt/optgen/exprgen/testdata/scan
@@ -1,17 +1,6 @@
 exec-ddl
 CREATE TABLE abc (a INT, b INT, c INT, INDEX ab(a, b))
 ----
-TABLE abc
- ├── a int
- ├── b int
- ├── c int
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- └── INDEX ab
-      ├── a int
-      ├── b int
-      └── rowid int not null (hidden)
 
 expr
 (Scan [ (Table "abc") (Cols "a") ])

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -273,10 +273,10 @@ func (tc *Catalog) resolveFK(tab *Table, d *tree.ForeignKeyConstraintTableDef) {
 	// columns. If strict is false, it is acceptable if the given columns are a
 	// prefix of the index key columns.
 	matches := func(idx *Index, cols []int, strict bool) bool {
-		if idx.KeyColumnCount() < len(cols) {
+		if idx.LaxKeyColumnCount() < len(cols) {
 			return false
 		}
-		if strict && idx.KeyColumnCount() > len(cols) {
+		if strict && idx.LaxKeyColumnCount() > len(cols) {
 			return false
 		}
 		for i := range cols {

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -160,6 +160,17 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 
 		case *tree.FamilyTableDef:
 			tab.addFamily(def)
+
+		case *tree.ColumnTableDef:
+			if def.Unique {
+				tab.addIndex(
+					&tree.IndexTableDef{
+						Name:    tree.Name(fmt.Sprintf("%s_%s_key", stmt.Table.TableName, def.Name)),
+						Columns: tree.IndexElemList{{Column: def.Name}},
+					},
+					uniqueIndex,
+				)
+			}
 		}
 	}
 

--- a/pkg/sql/opt/testutils/testcat/test_catalog_test.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog_test.go
@@ -1,0 +1,35 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL.txt and at www.mariadb.com/bsl11.
+//
+// Change Date: 2022-10-01
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt and at
+// https://www.apache.org/licenses/LICENSE-2.0
+
+package testcat_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/opttester"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/datadriven"
+)
+
+func TestCatalog(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	datadriven.Walk(t, "testdata", func(t *testing.T, path string) {
+		catalog := testcat.New()
+
+		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
+			tester := opttester.New(catalog, d.Input)
+			return tester.RunCommand(t, d)
+		})
+	})
+}

--- a/pkg/sql/opt/testutils/testcat/testdata/foreign_keys
+++ b/pkg/sql/opt/testutils/testcat/testdata/foreign_keys
@@ -1,0 +1,30 @@
+
+exec-ddl
+CREATE TABLE parent (p INT PRIMARY KEY)
+----
+
+exec-ddl
+CREATE TABLE child (c INT PRIMARY KEY, p INT REFERENCES parent(p))
+----
+
+exec-ddl
+SHOW CREATE parent
+----
+TABLE parent
+ ├── p int not null
+ ├── INDEX primary
+ │    └── p int not null
+ └── REFERENCED BY CONSTRAINT fk_p_ref_parent FOREIGN KEY t.public.child (p) REFERENCES t.public.parent (p)
+
+exec-ddl
+SHOW CREATE child
+----
+TABLE child
+ ├── c int not null
+ ├── p int
+ ├── INDEX primary
+ │    └── c int not null
+ ├── INDEX child_auto_index_fk_p_ref_parent
+ │    ├── p int
+ │    └── c int not null
+ └── CONSTRAINT fk_p_ref_parent FOREIGN KEY t.public.child (p) REFERENCES t.public.parent (p)

--- a/pkg/sql/opt/testutils/testcat/testdata/foreign_keys
+++ b/pkg/sql/opt/testutils/testcat/testdata/foreign_keys
@@ -28,3 +28,37 @@ TABLE child
  │    ├── p int
  │    └── c int not null
  └── CONSTRAINT fk_p_ref_parent FOREIGN KEY t.public.child (p) REFERENCES t.public.parent (p)
+
+exec-ddl
+CREATE TABLE parent2 (p INT UNIQUE)
+----
+
+exec-ddl
+CREATE TABLE child2 (c INT PRIMARY KEY, p INT REFERENCES parent2(p))
+----
+
+exec-ddl
+SHOW CREATE parent2
+----
+TABLE parent2
+ ├── p int
+ ├── rowid int not null default (unique_rowid()) [hidden]
+ ├── INDEX primary
+ │    └── rowid int not null default (unique_rowid()) [hidden]
+ ├── INDEX parent2_p_key
+ │    ├── p int
+ │    └── rowid int not null default (unique_rowid()) [hidden] (storing)
+ └── REFERENCED BY CONSTRAINT fk_p_ref_parent2 FOREIGN KEY t.public.child2 (p) REFERENCES t.public.parent2 (p)
+
+exec-ddl
+SHOW CREATE child2
+----
+TABLE child2
+ ├── c int not null
+ ├── p int
+ ├── INDEX primary
+ │    └── c int not null
+ ├── INDEX child2_auto_index_fk_p_ref_parent2
+ │    ├── p int
+ │    └── c int not null
+ └── CONSTRAINT fk_p_ref_parent2 FOREIGN KEY t.public.child2 (p) REFERENCES t.public.parent2 (p)

--- a/pkg/sql/opt/testutils/testcat/testdata/table
+++ b/pkg/sql/opt/testutils/testcat/testdata/table
@@ -70,3 +70,19 @@ TABLE uvwxy
  └── INDEX primary
       ├── u int not null
       └── v int not null
+
+exec-ddl
+CREATE TABLE a (a INT UNIQUE)
+----
+
+exec-ddl
+SHOW CREATE a
+----
+TABLE a
+ ├── a int
+ ├── rowid int not null default (unique_rowid()) [hidden]
+ ├── INDEX primary
+ │    └── rowid int not null default (unique_rowid()) [hidden]
+ └── INDEX a_a_key
+      ├── a int
+      └── rowid int not null default (unique_rowid()) [hidden] (storing)

--- a/pkg/sql/opt/testutils/testcat/testdata/table
+++ b/pkg/sql/opt/testutils/testcat/testdata/table
@@ -1,0 +1,72 @@
+exec-ddl
+CREATE TABLE kv (
+    k INT PRIMARY KEY,
+    v INT
+)
+----
+
+exec-ddl
+SHOW CREATE kv
+----
+TABLE kv
+ ├── k int not null
+ ├── v int
+ └── INDEX primary
+      └── k int not null
+
+exec-ddl
+CREATE TABLE abcdef (
+    a INT NOT NULL,
+    b INT,
+    c INT DEFAULT (10),
+    d INT AS (abcde.b + c + 1) STORED,
+    e INT AS (a) STORED,
+    f INT CHECK (f > 2)
+)
+----
+
+exec-ddl
+SHOW CREATE abcdef
+----
+TABLE abcdef
+ ├── a int not null
+ ├── b int
+ ├── c int default ((10))
+ ├── d int as ((abcde.b + c) + 1) stored
+ ├── e int as (a) stored
+ ├── f int
+ ├── rowid int not null default (unique_rowid()) [hidden]
+ ├── CHECK (f > 2)
+ └── INDEX primary
+      └── rowid int not null default (unique_rowid()) [hidden]
+
+exec-ddl
+CREATE TABLE uvwxy (
+    u INT,
+    v INT,
+    w INT,
+    x INT,
+    y INT,
+    PRIMARY KEY (u,v),
+    FAMILY (u,v,w),
+    FAMILY (x),
+    FAMILY (y)
+)
+----
+
+
+exec-ddl
+SHOW CREATE uvwxy
+----
+TABLE uvwxy
+ ├── u int not null
+ ├── v int not null
+ ├── w int
+ ├── x int
+ ├── y int
+ ├── FAMILY family1 (u, v, w)
+ ├── FAMILY family2 (x)
+ ├── FAMILY family3 (y)
+ └── INDEX primary
+      ├── u int not null
+      └── v int not null

--- a/pkg/sql/opt/testutils/testcat/testdata/zone
+++ b/pkg/sql/opt/testutils/testcat/testdata/zone
@@ -1,0 +1,171 @@
+exec-ddl
+CREATE TABLE abc (
+    a INT PRIMARY KEY,
+    b INT,
+    c STRING,
+    UNIQUE INDEX bc1 (b, c),
+    UNIQUE INDEX bc2 (b, c)
+)
+----
+
+exec-ddl
+ALTER TABLE abc CONFIGURE ZONE USING constraints='[+region=central]'
+----
+
+exec-ddl
+SHOW CREATE abc
+----
+TABLE abc
+ ├── a int not null
+ ├── b int
+ ├── c string
+ ├── INDEX primary
+ │    ├── a int not null
+ │    └── ZONE
+ │         └── constraints: [+region=central]
+ ├── INDEX bc1
+ │    ├── b int
+ │    ├── c string
+ │    └── a int not null (storing)
+ └── INDEX bc2
+      ├── b int
+      ├── c string
+      └── a int not null (storing)
+
+exec-ddl
+ALTER INDEX abc@bc1 CONFIGURE ZONE USING constraints='[+region=east]'
+----
+
+exec-ddl
+SHOW CREATE abc
+----
+TABLE abc
+ ├── a int not null
+ ├── b int
+ ├── c string
+ ├── INDEX primary
+ │    ├── a int not null
+ │    └── ZONE
+ │         └── constraints: [+region=central]
+ ├── INDEX bc1
+ │    ├── b int
+ │    ├── c string
+ │    ├── a int not null (storing)
+ │    └── ZONE
+ │         └── constraints: [+region=east]
+ └── INDEX bc2
+      ├── b int
+      ├── c string
+      └── a int not null (storing)
+
+exec-ddl
+ALTER INDEX abc@bc2 CONFIGURE ZONE USING constraints='[+region=west]'
+----
+
+exec-ddl
+SHOW CREATE abc
+----
+TABLE abc
+ ├── a int not null
+ ├── b int
+ ├── c string
+ ├── INDEX primary
+ │    ├── a int not null
+ │    └── ZONE
+ │         └── constraints: [+region=central]
+ ├── INDEX bc1
+ │    ├── b int
+ │    ├── c string
+ │    ├── a int not null (storing)
+ │    └── ZONE
+ │         └── constraints: [+region=east]
+ └── INDEX bc2
+      ├── b int
+      ├── c string
+      ├── a int not null (storing)
+      └── ZONE
+           └── constraints: [+region=west]
+
+exec-ddl
+ALTER TABLE abc CONFIGURE ZONE USING constraints='[+region=us,+dc=central,+rack=1]'
+----
+
+exec-ddl
+SHOW CREATE abc
+----
+TABLE abc
+ ├── a int not null
+ ├── b int
+ ├── c string
+ ├── INDEX primary
+ │    ├── a int not null
+ │    └── ZONE
+ │         └── constraints: [+region=us,+dc=central,+rack=1]
+ ├── INDEX bc1
+ │    ├── b int
+ │    ├── c string
+ │    ├── a int not null (storing)
+ │    └── ZONE
+ │         └── constraints: [+region=east]
+ └── INDEX bc2
+      ├── b int
+      ├── c string
+      ├── a int not null (storing)
+      └── ZONE
+           └── constraints: [+region=west]
+
+exec-ddl
+ALTER INDEX abc@bc1 CONFIGURE ZONE USING constraints='[+region=us,+dc=east,+rack=1]'
+----
+
+exec-ddl
+SHOW CREATE abc
+----
+TABLE abc
+ ├── a int not null
+ ├── b int
+ ├── c string
+ ├── INDEX primary
+ │    ├── a int not null
+ │    └── ZONE
+ │         └── constraints: [+region=us,+dc=central,+rack=1]
+ ├── INDEX bc1
+ │    ├── b int
+ │    ├── c string
+ │    ├── a int not null (storing)
+ │    └── ZONE
+ │         └── constraints: [+region=us,+dc=east,+rack=1]
+ └── INDEX bc2
+      ├── b int
+      ├── c string
+      ├── a int not null (storing)
+      └── ZONE
+           └── constraints: [+region=west]
+
+exec-ddl
+ALTER INDEX abc@bc2 CONFIGURE ZONE USING constraints='[+dc=west]'
+----
+
+exec-ddl
+SHOW CREATE abc
+----
+TABLE abc
+ ├── a int not null
+ ├── b int
+ ├── c string
+ ├── INDEX primary
+ │    ├── a int not null
+ │    └── ZONE
+ │         └── constraints: [+region=us,+dc=central,+rack=1]
+ ├── INDEX bc1
+ │    ├── b int
+ │    ├── c string
+ │    ├── a int not null (storing)
+ │    └── ZONE
+ │         └── constraints: [+region=us,+dc=east,+rack=1]
+ └── INDEX bc2
+      ├── b int
+      ├── c string
+      ├── a int not null (storing)
+      └── ZONE
+           └── constraints: [+dc=west]

--- a/pkg/sql/opt/xform/testdata/coster/groupby
+++ b/pkg/sql/opt/xform/testdata/coster/groupby
@@ -1,13 +1,6 @@
 exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, s STRING, d DECIMAL NOT NULL)
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── s string
- ├── d decimal not null
- └── INDEX primary
-      └── k int not null
 
 opt
 SELECT max(k), min(k), i, s FROM a GROUP BY i, s

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -1,23 +1,10 @@
 exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, s STRING, d DECIMAL NOT NULL)
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── s string
- ├── d decimal not null
- └── INDEX primary
-      └── k int not null
 
 exec-ddl
 CREATE TABLE b (x INT, z INT NOT NULL)
 ----
-TABLE b
- ├── x int
- ├── z int not null
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 opt
 SELECT k, x FROM a INNER JOIN b ON k=x WHERE d=1.0
@@ -128,15 +115,6 @@ inner-join
 exec-ddl
 CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT, INDEX c_idx (c))
 ----
-TABLE abc
- ├── a int not null
- ├── b int
- ├── c int
- ├── INDEX primary
- │    └── a int not null
- └── INDEX c_idx
-      ├── c int
-      └── a int not null
 
 exec-ddl
 ALTER TABLE abc INJECT STATISTICS '[
@@ -182,26 +160,6 @@ CREATE TABLE abcde (
   UNIQUE INDEX idx_abcd (a, b, c, d)
 )
 ----
-TABLE abcde
- ├── a string not null
- ├── b uuid not null
- ├── c uuid not null
- ├── d varchar not null
- ├── e string not null
- ├── INDEX primary
- │    ├── a string not null
- │    ├── b uuid not null
- │    └── c uuid not null
- ├── INDEX idx_abd
- │    ├── a string not null
- │    ├── b uuid not null
- │    ├── d varchar not null
- │    └── c uuid not null (storing)
- └── INDEX idx_abcd
-      ├── a string not null
-      ├── b uuid not null
-      ├── c uuid not null
-      └── d varchar not null
 
 exec-ddl
 ALTER TABLE abcde INJECT STATISTICS '[
@@ -236,16 +194,6 @@ CREATE TABLE wxyz (
   CONSTRAINT "foreign" FOREIGN KEY (w, x, y) REFERENCES abcde (a, b, c)
 )
 ----
-TABLE wxyz
- ├── w string not null
- ├── x uuid not null
- ├── y uuid not null
- ├── z string not null
- ├── INDEX primary
- │    ├── w string not null
- │    ├── x uuid not null
- │    └── y uuid not null
- └── CONSTRAINT foreign FOREIGN KEY (w, x, y) REFERENCES t.public.abcde (a, b, c)
 
 exec-ddl
 ALTER TABLE wxyz INJECT STATISTICS '[

--- a/pkg/sql/opt/xform/testdata/coster/perturb-cost
+++ b/pkg/sql/opt/xform/testdata/coster/perturb-cost
@@ -11,19 +11,10 @@
 exec-ddl
 CREATE TABLE a (x INT PRIMARY KEY, y INT)
 ----
-TABLE a
- ├── x int not null
- ├── y int
- └── INDEX primary
-      └── x int not null
 
 exec-ddl
 CREATE TABLE b (x INT PRIMARY KEY)
 ----
-TABLE b
- ├── x int not null
- └── INDEX primary
-      └── x int not null
 
 norm perturb-cost=(0.5)
 SELECT * FROM a JOIN b ON a.x=b.x ORDER BY a.y

--- a/pkg/sql/opt/xform/testdata/coster/project
+++ b/pkg/sql/opt/xform/testdata/coster/project
@@ -1,13 +1,6 @@
 exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, s STRING, d DECIMAL NOT NULL)
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── s string
- ├── d decimal not null
- └── INDEX primary
-      └── k int not null
 
 opt
 SELECT k, i, s || 'foo' FROM a

--- a/pkg/sql/opt/xform/testdata/coster/scan
+++ b/pkg/sql/opt/xform/testdata/coster/scan
@@ -1,13 +1,6 @@
 exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, s STRING, d DECIMAL NOT NULL)
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── s string
- ├── d decimal not null
- └── INDEX primary
-      └── k int not null
 
 opt
 SELECT k, s FROM a
@@ -23,10 +16,6 @@ scan a
 exec-ddl
 CREATE TABLE speed_test (id INT PRIMARY KEY DEFAULT unique_rowid())
 ----
-TABLE speed_test
- ├── id int not null
- └── INDEX primary
-      └── id int not null
 
 opt
 SELECT id FROM speed_test@primary WHERE id BETWEEN 1 AND 1000 AND ((id % 16) = 0)

--- a/pkg/sql/opt/xform/testdata/coster/select
+++ b/pkg/sql/opt/xform/testdata/coster/select
@@ -1,13 +1,6 @@
 exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, s STRING, d DECIMAL NOT NULL)
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── s string
- ├── d decimal not null
- └── INDEX primary
-      └── k int not null
 
 opt
 SELECT k, s FROM a WHERE s >= 'foo'

--- a/pkg/sql/opt/xform/testdata/coster/set
+++ b/pkg/sql/opt/xform/testdata/coster/set
@@ -1,23 +1,10 @@
 exec-ddl
 CREATE TABLE a (k INT PRIMARY KEY, i INT, s STRING, d DECIMAL NOT NULL)
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── s string
- ├── d decimal not null
- └── INDEX primary
-      └── k int not null
 
 exec-ddl
 CREATE TABLE b (x INT, z INT NOT NULL)
 ----
-TABLE b
- ├── x int
- ├── z int not null
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 opt
 SELECT k, i FROM a UNION SELECT * FROM b

--- a/pkg/sql/opt/xform/testdata/coster/sort
+++ b/pkg/sql/opt/xform/testdata/coster/sort
@@ -8,14 +8,6 @@ CREATE TABLE t.a
     PRIMARY KEY (k, f DESC)
 )
 ----
-TABLE a
- ├── k int not null
- ├── f float not null
- ├── z decimal
- ├── s string not null
- └── INDEX primary
-      ├── k int not null
-      └── f float not null desc
 
 opt
 SELECT f FROM a ORDER BY f DESC

--- a/pkg/sql/opt/xform/testdata/coster/zone
+++ b/pkg/sql/opt/xform/testdata/coster/zone
@@ -7,20 +7,6 @@ CREATE TABLE abc (
     UNIQUE INDEX bc2 (b, c)
 )
 ----
-TABLE abc
- ├── a int not null
- ├── b int
- ├── c string
- ├── INDEX primary
- │    └── a int not null
- ├── INDEX bc1
- │    ├── b int
- │    ├── c string
- │    └── a int not null (storing)
- └── INDEX bc2
-      ├── b int
-      ├── c string
-      └── a int not null (storing)
 
 exec-ddl
 CREATE TABLE xy (
@@ -30,17 +16,6 @@ CREATE TABLE xy (
     INDEX y2 (y)
 )
 ----
-TABLE xy
- ├── x int not null
- ├── y int
- ├── INDEX primary
- │    └── x int not null
- ├── INDEX y1
- │    ├── y int
- │    └── x int not null
- └── INDEX y2
-      ├── y int
-      └── x int not null
 
 # --------------------------------------------------
 # Single constraints.
@@ -49,20 +24,14 @@ TABLE xy
 exec-ddl
 ALTER TABLE abc CONFIGURE ZONE USING constraints='[+region=central]'
 ----
-ZONE
- └── constraints: [+region=central]
 
 exec-ddl
 ALTER INDEX abc@bc1 CONFIGURE ZONE USING constraints='[+region=east]'
 ----
-ZONE
- └── constraints: [+region=east]
 
 exec-ddl
 ALTER INDEX abc@bc2 CONFIGURE ZONE USING constraints='[+region=west]'
 ----
-ZONE
- └── constraints: [+region=west]
 
 # With locality in central, use primary index.
 opt format=show-all locality=(region=central)
@@ -154,21 +123,15 @@ scan t.public.abc@bc1
 exec-ddl
 ALTER TABLE abc CONFIGURE ZONE USING constraints='[+region=us,+dc=central,+rack=1]'
 ----
-ZONE
- └── constraints: [+region=us,+dc=central,+rack=1]
 
 exec-ddl
 ALTER INDEX abc@bc1 CONFIGURE ZONE USING constraints='[+region=us,+dc=east,+rack=1]'
 ----
-ZONE
- └── constraints: [+region=us,+dc=east,+rack=1]
 
 # Do not specify region constraint.
 exec-ddl
 ALTER INDEX abc@bc2 CONFIGURE ZONE USING constraints='[+dc=west]'
 ----
-ZONE
- └── constraints: [+dc=west]
 
 # With locality in us + central, use primary index.
 opt format=show-all locality=(region=us,dc=central)
@@ -233,16 +196,10 @@ scan t.public.abc@bc2
 exec-ddl
 ALTER INDEX abc@bc1 CONFIGURE ZONE USING constraints='{"+region=us,+dc=east":2, "+region=us,+dc=west":1}'
 ----
-ZONE
- └── replica constraints
-      ├── 2 replicas: [+region=us,+dc=east]
-      └── 1 replicas: [+region=us,+dc=west]
 
 exec-ddl
 ALTER INDEX abc@bc2 CONFIGURE ZONE USING constraints='[+dc=east]'
 ----
-ZONE
- └── constraints: [+dc=east]
 
 # With locality in us, use bc1 index, since only one tier matches in case of
 # both indexes.
@@ -281,14 +238,10 @@ scan t.public.abc@bc2
 exec-ddl
 ALTER INDEX abc@bc1 CONFIGURE ZONE USING constraints='[+region=us,-region=eu,+region=ap]'
 ----
-ZONE
- └── constraints: [+region=us,-region=eu,+region=ap]
 
 exec-ddl
 ALTER INDEX abc@bc2 CONFIGURE ZONE USING constraints='[+region=eu,+region=us,+dc=east]'
 ----
-ZONE
- └── constraints: [+region=eu,+region=us,+dc=east]
 
 # With locality in us, use bc1, since it's first in order.
 opt format=show-all locality=(region=us)
@@ -351,14 +304,10 @@ scan t.public.abc@bc1
 exec-ddl
 ALTER INDEX abc@bc1 CONFIGURE ZONE USING constraints='[-region=eu,+dc=east]'
 ----
-ZONE
- └── constraints: [-region=eu,+dc=east]
 
 exec-ddl
 ALTER INDEX abc@bc2 CONFIGURE ZONE USING constraints='[+dc=east]'
 ----
-ZONE
- └── constraints: [+dc=east]
 
 # With locality in us + east, use bc1, since it's first in order.
 opt format=show-all locality=(region=us,dc=east)
@@ -395,26 +344,18 @@ scan t.public.abc@bc2
 exec-ddl
 ALTER INDEX abc@bc1 CONFIGURE ZONE USING constraints='[+region=us,+dc=east]'
 ----
-ZONE
- └── constraints: [+region=us,+dc=east]
 
 exec-ddl
 ALTER INDEX abc@bc2 CONFIGURE ZONE USING constraints='[+region=us,+dc=west]'
 ----
-ZONE
- └── constraints: [+region=us,+dc=west]
 
 exec-ddl
 ALTER INDEX xy@y1 CONFIGURE ZONE USING constraints='[+region=us,+dc=east]'
 ----
-ZONE
- └── constraints: [+region=us,+dc=east]
 
 exec-ddl
 ALTER INDEX xy@y2 CONFIGURE ZONE USING constraints='[+region=us,+dc=west]'
 ----
-ZONE
- └── constraints: [+region=us,+dc=west]
 
 # Ensure that both indexes involved in the lookup join are selected from the
 # "west" data center.
@@ -450,14 +391,10 @@ inner-join (lookup xy@y2)
 exec-ddl
 ALTER INDEX xy@y1 CONFIGURE ZONE USING constraints='[+region=us,+dc=west]'
 ----
-ZONE
- └── constraints: [+region=us,+dc=west]
 
 exec-ddl
 ALTER INDEX xy@y2 CONFIGURE ZONE USING constraints='[+region=us,+dc=east]'
 ----
-ZONE
- └── constraints: [+region=us,+dc=east]
 
 # Should use other index now.
 opt format=show-all locality=(region=us,dc=west)
@@ -494,20 +431,14 @@ inner-join (lookup xy@y1)
 exec-ddl
 ALTER TABLE abc CONFIGURE ZONE USING lease_preferences='[[+region=central]]'
 ----
-ZONE
- └── lease preference: [+region=central]
 
 exec-ddl
 ALTER INDEX abc@bc1 CONFIGURE ZONE USING lease_preferences='[[+region=east]]'
 ----
-ZONE
- └── lease preference: [+region=east]
 
 exec-ddl
 ALTER INDEX abc@bc2 CONFIGURE ZONE USING lease_preferences='[[+region=west]]'
 ----
-ZONE
- └── lease preference: [+region=west]
 
 # With locality in us + central, use primary index.
 opt format=show-all locality=(region=central)
@@ -571,20 +502,14 @@ scan t.public.abc@bc2
 exec-ddl
 ALTER TABLE abc CONFIGURE ZONE USING lease_preferences='[[+region=us,+dc=central,+rack=1]]'
 ----
-ZONE
- └── lease preference: [+region=us,+dc=central,+rack=1]
 
 exec-ddl
 ALTER INDEX abc@bc1 CONFIGURE ZONE USING lease_preferences='[[+region=us,+dc=east,+rack=1]]'
 ----
-ZONE
- └── lease preference: [+region=us,+dc=east,+rack=1]
 
 exec-ddl
 ALTER INDEX abc@bc2 CONFIGURE ZONE USING lease_preferences='[[+region=us,+dc=west,+rack=1]]'
 ----
-ZONE
- └── lease preference: [+region=us,+dc=west,+rack=1]
 
 # With locality in us + central, use primary index.
 opt format=show-all locality=(region=us,dc=central)
@@ -649,25 +574,16 @@ exec-ddl
 ALTER TABLE abc CONFIGURE ZONE
 USING constraints='[+region=us]', lease_preferences='[[+region=us,+dc=central]]'
 ----
-ZONE
- ├── constraints: [+region=us]
- └── lease preference: [+region=us,+dc=central]
 
 exec-ddl
 ALTER INDEX abc@bc1 CONFIGURE ZONE
 USING constraints='[+region=us]', lease_preferences='[[+region=us,+dc=east]]'
 ----
-ZONE
- ├── constraints: [+region=us]
- └── lease preference: [+region=us,+dc=east]
 
 exec-ddl
 ALTER INDEX abc@bc2 CONFIGURE ZONE
 USING constraints='[+region=us]', lease_preferences='[[+region=us,+dc=west]]'
 ----
-ZONE
- ├── constraints: [+region=us]
- └── lease preference: [+region=us,+dc=west]
 
 # With locality in us + central, use primary index.
 opt format=show-all locality=(region=us,dc=central)
@@ -727,23 +643,16 @@ scan t.public.abc@bc2
 exec-ddl
 ALTER TABLE abc CONFIGURE ZONE USING constraints='[+region=us]'
 ----
-ZONE
- └── constraints: [+region=us]
 
 exec-ddl
 ALTER INDEX abc@bc1 CONFIGURE ZONE
 USING constraints='[+region=us]', lease_preferences='[[+region=us,+dc=east]]'
 ----
-ZONE
- ├── constraints: [+region=us]
- └── lease preference: [+region=us,+dc=east]
 
 exec-ddl
 ALTER INDEX abc@bc2 CONFIGURE ZONE
 USING constraints='[+region=us,+dc=east]'
 ----
-ZONE
- └── constraints: [+region=us,+dc=east]
 
 # With locality in the east, prefer the index with the constraints over the
 # index with just the lease preferences.

--- a/pkg/sql/opt/xform/testdata/external/activerecord
+++ b/pkg/sql/opt/xform/testdata/external/activerecord
@@ -25,35 +25,6 @@ CREATE TABLE pg_attribute (
     UNIQUE INDEX pg_attribute_relid_attnam_index (attrelid, attname)
 );
 ----
-TABLE pg_attribute
- ├── attrelid oid not null
- ├── attname string not null
- ├── atttypid oid not null
- ├── attstattarget int not null
- ├── attlen int not null
- ├── attnum int not null
- ├── attndims int not null
- ├── attcacheoff int not null
- ├── atttypmod int not null
- ├── attbyval bool not null
- ├── attstorage string not null
- ├── attalign string not null
- ├── attnotnull bool not null
- ├── atthasdef bool not null
- ├── attisdropped bool not null
- ├── attislocal bool not null
- ├── attinhcount int not null
- ├── attcollation oid not null
- ├── attacl string[]
- ├── attoptions string[]
- ├── attfdwoptions string[]
- ├── INDEX primary
- │    ├── attrelid oid not null
- │    └── attnum int not null
- └── INDEX pg_attribute_relid_attnam_index
-      ├── attrelid oid not null
-      ├── attname string not null
-      └── attnum int not null (storing)
 
 exec-ddl
 CREATE TABLE pg_attrdef (
@@ -65,18 +36,6 @@ CREATE TABLE pg_attrdef (
     UNIQUE INDEX pg_attrdef_adrelid_adnum_index (adrelid, adnum)
 );
 ----
-TABLE pg_attrdef
- ├── oid oid not null
- ├── adrelid oid not null
- ├── adnum int not null
- ├── adbin string
- ├── adsrc string
- ├── INDEX primary
- │    └── oid oid not null
- └── INDEX pg_attrdef_adrelid_adnum_index
-      ├── adrelid oid not null
-      ├── adnum int not null
-      └── oid oid not null (storing)
 
 exec-ddl
 CREATE TABLE pg_collation (
@@ -90,21 +49,6 @@ CREATE TABLE pg_collation (
     UNIQUE INDEX pg_collation_name_enc_nsp_index (collname, collencoding, collnamespace)
 );
 ----
-TABLE pg_collation
- ├── oid oid not null
- ├── collname string not null
- ├── collnamespace oid not null
- ├── collowner oid not null
- ├── collencoding int not null
- ├── collcollate string not null
- ├── collctype string not null
- ├── INDEX primary
- │    └── oid oid not null
- └── INDEX pg_collation_name_enc_nsp_index
-      ├── collname string not null
-      ├── collencoding int not null
-      ├── collnamespace oid not null
-      └── oid oid not null (storing)
 
 exec-ddl
 CREATE TABLE pg_type (
@@ -142,44 +86,6 @@ CREATE TABLE pg_type (
     UNIQUE INDEX pg_type_typname_nsp_index (typname, typnamespace)
 );
 ----
-TABLE pg_type
- ├── oid oid not null
- ├── typname string not null
- ├── typnamespace oid not null
- ├── typowner oid not null
- ├── typlen int not null
- ├── typbyval bool not null
- ├── typtype string not null
- ├── typcategory string not null
- ├── typispreferred bool not null
- ├── typisdefined bool not null
- ├── typdelim string not null
- ├── typrelid oid not null
- ├── typelem oid not null
- ├── typarray oid not null
- ├── typinput oid not null
- ├── typoutput oid not null
- ├── typreceive oid not null
- ├── typsend oid not null
- ├── typmodin oid not null
- ├── typmodout oid not null
- ├── typanalyze oid not null
- ├── typalign string not null
- ├── typstorage string not null
- ├── typnotnull bool not null
- ├── typbasetype oid not null
- ├── typtypmod int not null
- ├── typndims int not null
- ├── typcollation oid not null
- ├── typdefaultbin string
- ├── typdefault string
- ├── typacl string[]
- ├── INDEX primary
- │    └── oid oid not null
- └── INDEX pg_type_typname_nsp_index
-      ├── typname string not null
-      ├── typnamespace oid not null
-      └── oid oid not null (storing)
 
 opt
 SELECT a.attname,

--- a/pkg/sql/opt/xform/testdata/external/customer
+++ b/pkg/sql/opt/xform/testdata/external/customer
@@ -19,11 +19,6 @@ CREATE TABLE nodes (
 	FAMILY "primary" (id, payload)
 )
 ----
-TABLE nodes
- ├── id int not null
- ├── payload string
- └── INDEX primary
-      └── id int not null
 
 exec-ddl
 CREATE TABLE edges (
@@ -37,18 +32,6 @@ CREATE TABLE edges (
 	FAMILY "primary" (src, dst, payload)
 )
 ----
-TABLE edges
- ├── src int not null
- ├── dst int not null
- ├── payload string
- ├── INDEX primary
- │    ├── src int not null
- │    └── dst int not null
- ├── INDEX edges_auto_index_fk_dst_ref_nodes
- │    ├── dst int not null
- │    └── src int not null
- ├── CONSTRAINT fk_dst_ref_nodes FOREIGN KEY (dst) REFERENCES t.public.nodes (id)
- └── CONSTRAINT fk_src_ref_nodes FOREIGN KEY (src) REFERENCES t.public.nodes (id)
 
 opt
 select nodes.id,dst from nodes join edges on edges.dst=nodes.id
@@ -91,36 +74,6 @@ CREATE TABLE article (
 	FAMILY "primary" (id, feed, folder, hash, title, summary, content, link, read, date, retrieved)
 ) INTERLEAVE IN PARENT feed (folder, feed)
 ----
-TABLE article
- ├── id int not null
- ├── feed int not null
- ├── folder int not null
- ├── hash string
- ├── title string
- ├── summary string
- ├── content string
- ├── link string
- ├── read bool
- ├── date timestamptz
- ├── retrieved timestamptz
- ├── INDEX primary
- │    ├── folder int not null
- │    ├── feed int not null
- │    └── id int not null
- ├── INDEX article_id_key
- │    ├── id int not null
- │    ├── folder int not null (storing)
- │    └── feed int not null (storing)
- ├── INDEX article_hash_key
- │    ├── hash string
- │    ├── folder int not null (storing)
- │    ├── feed int not null (storing)
- │    └── id int not null (storing)
- └── INDEX article_idx_read_key
-      ├── id int not null
-      ├── folder int not null (storing)
-      ├── feed int not null (storing)
-      └── read bool (storing)
 
 opt
 SELECT id, feed, folder, title, summary, content, link, date
@@ -258,42 +211,6 @@ CREATE TABLE IF NOT EXISTS leaderboard_record (
     INDEX test_idx(leaderboard_id, expires_at, score, updated_at_inverse, id)
 );
 ----
-TABLE leaderboard_record
- ├── id bytes not null
- ├── leaderboard_id bytes not null
- ├── owner_id bytes not null
- ├── handle varchar not null
- ├── lang varchar not null
- ├── location varchar
- ├── timezone varchar
- ├── rank_value int not null
- ├── score int not null
- ├── num_score int not null
- ├── metadata bytes not null
- ├── ranked_at int not null
- ├── updated_at int not null
- ├── updated_at_inverse int not null
- ├── expires_at int not null
- ├── banned_at int not null
- ├── INDEX primary
- │    ├── leaderboard_id bytes not null
- │    ├── expires_at int not null
- │    └── owner_id bytes not null
- ├── INDEX test_idx
- │    ├── leaderboard_id bytes not null
- │    ├── expires_at int not null
- │    ├── score int not null
- │    ├── updated_at_inverse int not null
- │    ├── id bytes not null
- │    └── owner_id bytes not null
- ├── CHECK (rank_value >= 0)
- ├── CHECK (num_score >= 0)
- ├── CHECK (length(metadata) < 16000)
- ├── CHECK (ranked_at >= 0)
- ├── CHECK (updated_at > 0)
- ├── CHECK (updated_at > 0)
- ├── CHECK (expires_at >= 0)
- └── CHECK (expires_at >= 0)
 
 opt
 SELECT score, expires_at
@@ -336,20 +253,6 @@ CREATE TABLE rides (
     end_address, start_time, end_time, revenue)
 )
 ----
-TABLE rides
- ├── id uuid not null
- ├── rider_id uuid
- ├── vehicle_id uuid
- ├── start_address string
- ├── end_address string
- ├── start_time timestamp
- ├── end_time timestamp
- ├── revenue float
- ├── INDEX primary
- │    └── id uuid not null
- └── INDEX rides_vehicle_id_idx
-      ├── vehicle_id uuid
-      └── id uuid not null
 
 exec-ddl
 CREATE TABLE vehicles (
@@ -365,21 +268,6 @@ CREATE TABLE vehicles (
     FAMILY "primary" (id, type, city, owner_id, creation_time, status, ext)
 )
 ----
-TABLE vehicles
- ├── id uuid not null
- ├── type string
- ├── city string not null
- ├── owner_id uuid
- ├── creation_time timestamp
- ├── status string
- ├── ext jsonb
- ├── INDEX primary
- │    ├── city string not null
- │    └── id uuid not null
- └── INDEX vehicles_id_idx
-      ├── id uuid not null
-      ├── city string not null
-      └── owner_id uuid (storing)
 
 opt
 select v.owner_id, count(*) from rides r, vehicles v where v.id = r.vehicle_id group by v.owner_id
@@ -424,26 +312,6 @@ CREATE TABLE data (
   INDEX foo (id ASC) STORING (value)
 )
 ----
-TABLE data
- ├── id uuid
- ├── value int
- ├── col1 int
- ├── col2 int
- ├── col3 int
- ├── col4 int
- ├── col5 int
- ├── col6 int
- ├── col7 int
- ├── col8 int
- ├── col9 int
- ├── col10 int
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- └── INDEX foo
-      ├── id uuid
-      ├── rowid int not null (hidden)
-      └── value int (storing)
 
 opt
 SELECT id, sum(value) FROM data GROUP BY id
@@ -489,41 +357,6 @@ CREATE TABLE t_sync_data (
     INDEX index3 (last_sync_id)
 )
 ----
-TABLE t_sync_data
- ├── remote_id uuid not null
- ├── conflict_remote_id uuid
- ├── user_id uuid not null
- ├── last_sync_id int not null
- ├── data_type string not null
- ├── sync_data string
- ├── deleted bool not null
- ├── create_device_id string not null
- ├── original_data_id string not null
- ├── create_time int not null
- ├── last_update_time int not null
- ├── INDEX “primary”
- │    └── remote_id uuid not null
- ├── INDEX t_sync_data_user_id_data_type_idx
- │    ├── user_id uuid not null
- │    ├── data_type string not null
- │    └── remote_id uuid not null
- ├── INDEX t_sync_data_last_sync_id_idx
- │    ├── last_sync_id int not null
- │    └── remote_id uuid not null
- ├── INDEX index1
- │    ├── last_sync_id int not null
- │    ├── user_id uuid not null
- │    ├── data_type string not null
- │    └── remote_id uuid not null
- ├── INDEX index2
- │    ├── user_id uuid not null
- │    ├── data_type string not null
- │    └── remote_id uuid not null
- ├── INDEX index3
- │    ├── last_sync_id int not null
- │    └── remote_id uuid not null
- ├── FAMILY f_meta (remote_id, conflict_remote_id, user_id, last_sync_id, data_type, deleted, create_device_id, original_data_id, create_time, last_update_time)
- └── FAMILY f_data (sync_data)
 
 opt
 SELECT *
@@ -576,15 +409,6 @@ CREATE TABLE test (
     FAMILY "primary" (id, midname, name)
 )
 ----
-TABLE test
- ├── id int not null
- ├── midname string
- ├── name string
- ├── INDEX primary
- │    └── id int not null
- └── INDEX test_name_idx
-      ├── name string
-      └── id int not null
 
 opt
 EXPLAIN SELECT id FROM test ORDER BY id asc LIMIT 10 offset 10000;
@@ -630,28 +454,6 @@ CREATE TABLE orders (
     FAMILY "primary" (o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment, rowid)
 )
 ----
-TABLE orders
- ├── o_orderkey int not null
- ├── o_custkey int not null
- ├── o_orderstatus string not null
- ├── o_totalprice decimal not null
- ├── o_orderdate date not null
- ├── o_orderpriority string not null
- ├── o_clerk string not null
- ├── o_shippriority int not null
- ├── o_comment string not null
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- ├── INDEX o_ok
- │    ├── o_orderkey int not null
- │    └── rowid int not null (hidden) (storing)
- ├── INDEX o_ck
- │    ├── o_custkey int not null
- │    └── rowid int not null (hidden)
- └── INDEX o_od
-      ├── o_orderdate date not null
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE lineitem (
@@ -682,52 +484,6 @@ CREATE TABLE lineitem (
     FAMILY "primary" (l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment, rowid)
 )
 ----
-TABLE lineitem
- ├── l_orderkey int not null
- ├── l_partkey int not null
- ├── l_suppkey int not null
- ├── l_linenumber int not null
- ├── l_quantity decimal not null
- ├── l_extendedprice decimal not null
- ├── l_discount decimal not null
- ├── l_tax decimal not null
- ├── l_returnflag string not null
- ├── l_linestatus string not null
- ├── l_shipdate date not null
- ├── l_commitdate date not null
- ├── l_receiptdate date not null
- ├── l_shipinstruct string not null
- ├── l_shipmode string not null
- ├── l_comment string not null
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- ├── INDEX l_ok
- │    ├── l_orderkey int not null
- │    └── rowid int not null (hidden)
- ├── INDEX l_pk
- │    ├── l_partkey int not null
- │    └── rowid int not null (hidden)
- ├── INDEX l_sk
- │    ├── l_suppkey int not null
- │    └── rowid int not null (hidden)
- ├── INDEX l_sd
- │    ├── l_shipdate date not null
- │    └── rowid int not null (hidden)
- ├── INDEX l_cd
- │    ├── l_commitdate date not null
- │    └── rowid int not null (hidden)
- ├── INDEX l_rd
- │    ├── l_receiptdate date not null
- │    └── rowid int not null (hidden)
- ├── INDEX l_pk_sk
- │    ├── l_partkey int not null
- │    ├── l_suppkey int not null
- │    └── rowid int not null (hidden)
- └── INDEX l_sk_pk
-      ├── l_suppkey int not null
-      ├── l_partkey int not null
-      └── rowid int not null (hidden)
 
 opt
 SELECT count(l_orderkey) FROM orders, lineitem WHERE orders.o_orderkey = lineitem.l_orderkey
@@ -767,15 +523,6 @@ CREATE TABLE idtable (
   INDEX secondary_id (secondary_id)
 )
 ----
-TABLE idtable
- ├── primary_id uuid not null
- ├── secondary_id uuid not null
- ├── data jsonb not null
- ├── INDEX primary
- │    └── primary_id uuid not null
- └── INDEX secondary_id
-      ├── secondary_id uuid not null
-      └── primary_id uuid not null
 
 opt
 SELECT

--- a/pkg/sql/opt/xform/testdata/external/customer
+++ b/pkg/sql/opt/xform/testdata/external/customer
@@ -230,7 +230,8 @@ project
       ├── columns: id:1(bytes!null) leaderboard_id:2(bytes!null) score:9(int!null) updated_at_inverse:14(int!null) expires_at:15(int!null)
       ├── constraint: /2/15/9/14/1/3: [/'\x74657374'/0 - /'\x74657374'/0/100/500/'\x736f6d655f6964')
       ├── limit: 50(rev)
-      ├── fd: ()-->(2,15)
+      ├── key: (1)
+      ├── fd: ()-->(2,15), (1)-->(9,14)
       └── ordering: -9,-14 opt(2,15) [actual: -9,-14]
 
 # ------------------------------------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -12,10 +12,6 @@ create table Person (
   primary key (id)
 )
 ----
-TABLE person
- ├── id int not null
- └── INDEX primary
-      └── id int not null
 
 exec-ddl
 create table Phone (
@@ -26,13 +22,6 @@ create table Phone (
   primary key (id)
 )
 ----
-TABLE phone
- ├── id int not null
- ├── number varchar
- ├── since timestamp
- ├── type int4
- └── INDEX primary
-      └── id int not null
 
 exec-ddl
 create table phone_register (
@@ -44,17 +33,6 @@ create table phone_register (
   unique (person_id)
 )
 ----
-TABLE phone_register
- ├── phone_id int not null
- ├── person_id int not null
- ├── INDEX primary
- │    ├── phone_id int not null
- │    └── person_id int not null
- ├── INDEX secondary
- │    ├── person_id int not null
- │    └── phone_id int not null (storing)
- ├── CONSTRAINT fk_person_id_ref_phone FOREIGN KEY (person_id) REFERENCES t.public.phone (id)
- └── CONSTRAINT fk_phone_id_ref_person FOREIGN KEY (phone_id) REFERENCES t.public.person (id)
 
 opt
 select
@@ -122,15 +100,6 @@ create table Person (
     primary key (id)
 )
 ----
-TABLE person
- ├── id int not null
- ├── address varchar
- ├── createdon timestamp
- ├── name varchar
- ├── nickname varchar
- ├── version int4 not null
- └── INDEX primary
-      └── id int not null
 
 exec-ddl
 create table Person_addresses (
@@ -140,13 +109,6 @@ create table Person_addresses (
     primary key (Person_id, addresses_KEY)
 )
 ----
-TABLE person_addresses
- ├── person_id int not null
- ├── addresses varchar
- ├── addresses_key varchar not null
- └── INDEX primary
-      ├── person_id int not null
-      └── addresses_key varchar not null
 
 exec-ddl
 create table Phone (
@@ -158,14 +120,6 @@ create table Phone (
     primary key (id)
 )
 ----
-TABLE phone
- ├── id int not null
- ├── phone_number varchar
- ├── phone_type varchar
- ├── person_id int
- ├── order_id int4
- └── INDEX primary
-      └── id int not null
 
 exec-ddl
 create table phone_call (
@@ -176,13 +130,6 @@ create table phone_call (
     primary key (id)
 )
 ----
-TABLE phone_call
- ├── id int not null
- ├── duration int4 not null
- ├── call_timestamp timestamp
- ├── phone_id int
- └── INDEX primary
-      └── id int not null
 
 exec-ddl
 create table Partner (
@@ -192,12 +139,6 @@ create table Partner (
     primary key (id)
 )
 ----
-TABLE partner
- ├── id int not null
- ├── name varchar
- ├── version int4 not null
- └── INDEX primary
-      └── id int not null
 
 opt
 select
@@ -425,16 +366,6 @@ create table Customer_AUD (
     primary key (id, REV)
 )
 ----
-TABLE customer_aud
- ├── id int not null
- ├── rev int4 not null
- ├── revtype int2
- ├── created_on timestamp
- ├── firstname varchar
- ├── lastname varchar
- └── INDEX primary
-      ├── id int not null
-      └── rev int4 not null
 
 opt
 select
@@ -541,18 +472,6 @@ create table Customer_AUD (
     primary key (id, REV)
 )
 ----
-TABLE customer_aud
- ├── id int not null
- ├── rev int4 not null
- ├── revtype int2
- ├── revend int4
- ├── created_on timestamp
- ├── firstname varchar
- ├── lastname varchar
- ├── address_id int
- └── INDEX primary
-      ├── id int not null
-      └── rev int4 not null
 
 opt
 select
@@ -680,14 +599,6 @@ create table Phone (
     primary key (id)
 )
 ----
-TABLE phone
- ├── id int not null
- ├── phone_number varchar
- ├── phone_type varchar
- ├── person_id int
- ├── order_id int4
- └── INDEX primary
-      └── id int not null
 
 exec-ddl
 create table phone_call (
@@ -698,13 +609,6 @@ create table phone_call (
     primary key (id)
 )
 ----
-TABLE phone_call
- ├── id int not null
- ├── duration int4 not null
- ├── call_timestamp timestamp
- ├── phone_id int
- └── INDEX primary
-      └── id int not null
 
 exec-ddl
 create table Person (
@@ -717,15 +621,6 @@ create table Person (
     primary key (id)
 )
 ----
-TABLE person
- ├── id int not null
- ├── address varchar
- ├── createdon timestamp
- ├── name varchar
- ├── nickname varchar
- ├── version int4 not null
- └── INDEX primary
-      └── id int not null
 
 exec-ddl
 create table Phone_repairTimestamps (
@@ -733,12 +628,6 @@ create table Phone_repairTimestamps (
    repairTimestamps timestamp
 )
 ----
-TABLE phone_repairtimestamps
- ├── phone_id int not null
- ├── repairtimestamps timestamp
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 create table Person_addresses (
@@ -748,13 +637,6 @@ create table Person_addresses (
     primary key (Person_id, addresses_KEY)
 )
 ----
-TABLE person_addresses
- ├── person_id int not null
- ├── addresses varchar
- ├── addresses_key varchar not null
- └── INDEX primary
-      ├── person_id int not null
-      └── addresses_key varchar not null
 
 opt
 select
@@ -1555,12 +1437,6 @@ create table EMPLOYEE (
     primary key (id)
 )
 ----
-TABLE employee
- ├── id int not null
- ├── email varchar
- ├── currentproject_id int
- └── INDEX primary
-      └── id int not null
 
 exec-ddl
 create table Employee_phones (
@@ -1568,12 +1444,6 @@ create table Employee_phones (
     phone_number varchar(255)
 )
 ----
-TABLE employee_phones
- ├── employee_id int not null
- ├── phone_number varchar
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 opt
 select
@@ -1640,11 +1510,6 @@ create table Company (
     primary key (id)
 )
 ----
-TABLE company
- ├── id int not null
- ├── location_id int
- └── INDEX primary
-      └── id int not null
 
 exec-ddl
 create table Company_Employee (
@@ -1653,12 +1518,6 @@ create table Company_Employee (
     primary key (Company_id, employees_id)
 )
 ----
-TABLE company_employee
- ├── company_id int not null
- ├── employees_id int not null
- └── INDEX primary
-      ├── company_id int not null
-      └── employees_id int not null
 
 exec-ddl
 create table Employee (
@@ -1666,10 +1525,6 @@ create table Employee (
     primary key (id)
 )
 ----
-TABLE employee
- ├── id int not null
- └── INDEX primary
-      └── id int not null
 
 exec-ddl
 create table Manager (
@@ -1677,10 +1532,6 @@ create table Manager (
     primary key (id)
 )
 ----
-TABLE manager
- ├── id int not null
- └── INDEX primary
-      └── id int not null
 
 exec-ddl
 create table Location (
@@ -1690,12 +1541,6 @@ create table Location (
     primary key (id)
 )
 ----
-TABLE location
- ├── id int not null
- ├── address varchar
- ├── zip int4 not null
- └── INDEX primary
-      └── id int not null
 
 opt
 select
@@ -1797,12 +1642,6 @@ create table News (
     primary key (news_id)
 )
 ----
-TABLE news
- ├── news_id int4 not null
- ├── detail varchar
- ├── title varchar
- └── INDEX primary
-      └── news_id int4 not null
 
 exec-ddl
 create table Newspaper (
@@ -1811,11 +1650,6 @@ create table Newspaper (
     primary key (id)
 )
 ----
-TABLE newspaper
- ├── id int4 not null
- ├── name varchar
- └── INDEX primary
-      └── id int4 not null
 
 exec-ddl
 create table Newspaper_News (
@@ -1824,12 +1658,6 @@ create table Newspaper_News (
     primary key (Newspaper_id, news_news_id)
 )
 ----
-TABLE newspaper_news
- ├── newspaper_id int4 not null
- ├── news_news_id int4 not null
- └── INDEX primary
-      ├── newspaper_id int4 not null
-      └── news_news_id int4 not null
 
 opt
 select
@@ -1892,13 +1720,6 @@ create table GenerationGroup (
     primary key (id)
 )
 ----
-TABLE generationgroup
- ├── id int4 not null
- ├── age varchar
- ├── culture varchar
- ├── description varchar
- └── INDEX primary
-      └── id int4 not null
 
 exec-ddl
 create table GenerationUser (
@@ -1906,10 +1727,6 @@ create table GenerationUser (
     primary key (id)
 )
 ----
-TABLE generationuser
- ├── id int4 not null
- └── INDEX primary
-      └── id int4 not null
 
 exec-ddl
 create table GenerationUser_GenerationGroup (
@@ -1918,12 +1735,6 @@ create table GenerationUser_GenerationGroup (
     primary key (GenerationUser_id, ref_id)
 )
 ----
-TABLE generationuser_generationgroup
- ├── generationuser_id int4 not null
- ├── ref_id int4 not null
- └── INDEX primary
-      ├── generationuser_id int4 not null
-      └── ref_id int4 not null
 
 opt
 SELECT ref0_.generationuser_id AS generati1_2_0_
@@ -2000,13 +1811,6 @@ create table TAuction2 (
     primary key (id)
 )
 ----
-TABLE tauction2
- ├── id int not null
- ├── description varchar
- ├── enddatetime timestamp
- ├── successfulbid int
- └── INDEX primary
-      └── id int not null
 
 exec-ddl
 create table TBid2 (
@@ -2017,13 +1821,6 @@ create table TBid2 (
     primary key (id)
 )
 ----
-TABLE tbid2
- ├── id int not null
- ├── amount decimal
- ├── createddatetime timestamp
- ├── auctionid int
- └── INDEX primary
-      └── id int not null
 
 opt
 select
@@ -2107,12 +1904,6 @@ CREATE TABLE customer (
   PRIMARY KEY (customerid)
 );
 ----
-TABLE customer
- ├── customerid varchar not null
- ├── name varchar not null
- ├── address varchar not null
- └── INDEX primary
-      └── customerid varchar not null
 
 exec-ddl
 CREATE TABLE customerorder (
@@ -2122,13 +1913,6 @@ CREATE TABLE customerorder (
   PRIMARY KEY (customerid, ordernumber)
 );
 ----
-TABLE customerorder
- ├── customerid varchar not null
- ├── ordernumber int4 not null
- ├── orderdate date not null
- └── INDEX primary
-      ├── customerid varchar not null
-      └── ordernumber int4 not null
 
 exec-ddl
 CREATE TABLE lineitem (
@@ -2139,15 +1923,6 @@ CREATE TABLE lineitem (
   PRIMARY KEY (customerid, ordernumber, productid)
 );
 ----
-TABLE lineitem
- ├── customerid varchar not null
- ├── ordernumber int4 not null
- ├── productid varchar not null
- ├── quantity int4
- └── INDEX primary
-      ├── customerid varchar not null
-      ├── ordernumber int4 not null
-      └── productid varchar not null
 
 exec-ddl
 CREATE TABLE product (
@@ -2158,13 +1933,6 @@ CREATE TABLE product (
   PRIMARY KEY (productid)
 );
 ----
-TABLE product
- ├── productid varchar not null
- ├── description varchar not null
- ├── cost decimal
- ├── numberavailable int4
- └── INDEX primary
-      └── productid varchar not null
 
 opt
 SELECT
@@ -2625,14 +2393,6 @@ CREATE TABLE student (
   PRIMARY KEY (studentid)
 );
 ----
-TABLE student
- ├── studentid int not null
- ├── name varchar not null
- ├── address_city varchar
- ├── address_state varchar
- ├── preferredcoursecode varchar
- └── INDEX primary
-      └── studentid int not null
 
 exec-ddl
 CREATE TABLE enrolment (
@@ -2643,14 +2403,6 @@ CREATE TABLE enrolment (
   PRIMARY KEY (studentid, coursecode)
 );
 ----
-TABLE enrolment
- ├── studentid int not null
- ├── coursecode varchar not null
- ├── semester int2 not null
- ├── year int2 not null
- └── INDEX primary
-      ├── studentid int not null
-      └── coursecode varchar not null
 
 opt
 SELECT
@@ -2749,11 +2501,6 @@ drop table student, enrolment
 exec-ddl
 CREATE TABLE t_name (id INT4 NOT NULL, c_name VARCHAR(255), PRIMARY KEY (id));
 ----
-TABLE t_name
- ├── id int4 not null
- ├── c_name varchar
- └── INDEX primary
-      └── id int4 not null
 
 opt
 SELECT

--- a/pkg/sql/opt/xform/testdata/external/liquibase
+++ b/pkg/sql/opt/xform/testdata/external/liquibase
@@ -31,44 +31,6 @@ CREATE TABLE pg_class (
     INDEX pg_class_tblspc_relfilenode_index (reltablespace, relfilenode)
 );
 ----
-TABLE pg_class
- ├── oid oid not null
- ├── relname string not null
- ├── relnamespace oid not null
- ├── reltype oid not null
- ├── relowner oid not null
- ├── relam oid not null
- ├── relfilenode oid not null
- ├── reltablespace oid not null
- ├── relpages int not null
- ├── reltuples float not null
- ├── relallvisible int not null
- ├── reltoastrelid oid not null
- ├── relhasindex bool not null
- ├── relisshared bool not null
- ├── relpersistence string not null
- ├── relistemp bool not null
- ├── relkind string not null
- ├── relnatts int not null
- ├── relchecks int not null
- ├── relhasoids bool not null
- ├── relhaspkey bool not null
- ├── relhasrules bool not null
- ├── relhastriggers bool not null
- ├── relhassubclass bool not null
- ├── relfrozenxid int not null
- ├── relacl string[]
- ├── reloptions string[]
- ├── INDEX primary
- │    └── oid oid not null
- ├── INDEX pg_class_relname_nsp_index
- │    ├── relname string not null
- │    ├── relnamespace oid not null
- │    └── oid oid not null (storing)
- └── INDEX pg_class_tblspc_relfilenode_index
-      ├── reltablespace oid not null
-      ├── relfilenode oid not null
-      └── oid oid not null
 
 exec-ddl
 CREATE TABLE pg_namespace (
@@ -79,16 +41,6 @@ CREATE TABLE pg_namespace (
     UNIQUE INDEX pg_namespace_nspname_index (nspname)
 );
 ----
-TABLE pg_namespace
- ├── oid oid not null
- ├── nspname string not null
- ├── nspowner oid not null
- ├── nspacl string[]
- ├── INDEX primary
- │    └── oid oid not null
- └── INDEX pg_namespace_nspname_index
-      ├── nspname string not null
-      └── oid oid not null (storing)
 
 exec-ddl
 CREATE TABLE pg_tablespace (
@@ -101,18 +53,6 @@ CREATE TABLE pg_tablespace (
     UNIQUE INDEX pg_tablespace_spcname_index (spcname)
 );
 ----
-TABLE pg_tablespace
- ├── oid oid not null
- ├── spcname string not null
- ├── spcowner oid not null
- ├── spclocation string not null
- ├── spcacl string[]
- ├── spcoptions string[]
- ├── INDEX primary
- │    └── oid oid not null
- └── INDEX pg_tablespace_spcname_index
-      ├── spcname string not null
-      └── oid oid not null (storing)
 
 exec-ddl
 CREATE TABLE pg_inherits (
@@ -123,17 +63,6 @@ CREATE TABLE pg_inherits (
     INDEX pg_inherits_parent_index (inhparent)
 );
 ----
-TABLE pg_inherits
- ├── inhrelid oid not null
- ├── inhparent oid not null
- ├── inhseqno int not null
- ├── INDEX primary
- │    ├── inhrelid oid not null
- │    └── inhseqno int not null
- └── INDEX pg_inherits_parent_index
-      ├── inhparent oid not null
-      ├── inhrelid oid not null
-      └── inhseqno int not null
 
 exec-ddl
 CREATE TABLE pg_index (
@@ -159,31 +88,6 @@ CREATE TABLE pg_index (
     INDEX pg_index_indrelid_index (indrelid)
 )
 ----
-TABLE pg_index
- ├── indexrelid oid not null
- ├── indrelid oid not null
- ├── indnatts int not null
- ├── indisunique bool not null
- ├── indisprimary bool not null
- ├── indisexclusion bool not null
- ├── indimmediate bool not null
- ├── indisclustered bool not null
- ├── indisvalid bool not null
- ├── indcheckxmin bool not null
- ├── indisready bool not null
- ├── indislive bool not null
- ├── indisreplident bool not null
- ├── indkey int[] not null
- ├── indcollation int not null
- ├── indclass int not null
- ├── indoption int not null
- ├── indexprs string
- ├── indpred string
- ├── INDEX primary
- │    └── indexrelid oid not null
- └── INDEX pg_index_indrelid_index
-      ├── indrelid oid not null
-      └── indexrelid oid not null
 
 exec-ddl
 CREATE TABLE pg_foreign_table (
@@ -192,12 +96,6 @@ CREATE TABLE pg_foreign_table (
     ftoptions text[]
 );
 ----
-TABLE pg_foreign_table
- ├── ftrelid oid not null
- ├── ftserver oid not null
- ├── ftoptions string[]
- └── INDEX primary
-      └── ftrelid oid not null
 
 exec-ddl
 CREATE TABLE pg_foreign_server (
@@ -212,20 +110,6 @@ CREATE TABLE pg_foreign_server (
     UNIQUE INDEX pg_foreign_server_name_index (srvname)
 );
 ----
-TABLE pg_foreign_server
- ├── oid oid not null
- ├── srvname string not null
- ├── srvowner oid not null
- ├── srvfdw oid not null
- ├── srvtype string
- ├── srvversion string
- ├── srvacl string[]
- ├── srvoptions string[]
- ├── INDEX primary
- │    └── oid oid not null
- └── INDEX pg_foreign_server_name_index
-      ├── srvname string not null
-      └── oid oid not null (storing)
 
 opt
 SELECT c.oid,

--- a/pkg/sql/opt/xform/testdata/external/navicat
+++ b/pkg/sql/opt/xform/testdata/external/navicat
@@ -31,44 +31,6 @@ CREATE TABLE pg_class (
     INDEX pg_class_tblspc_relfilenode_index (reltablespace, relfilenode)
 );
 ----
-TABLE pg_class
- ├── oid oid not null
- ├── relname string not null
- ├── relnamespace oid not null
- ├── reltype oid not null
- ├── relowner oid not null
- ├── relam oid not null
- ├── relfilenode oid not null
- ├── reltablespace oid not null
- ├── relpages int not null
- ├── reltuples float not null
- ├── relallvisible int not null
- ├── reltoastrelid oid not null
- ├── relhasindex bool not null
- ├── relisshared bool not null
- ├── relpersistence string not null
- ├── relistemp bool not null
- ├── relkind string not null
- ├── relnatts int not null
- ├── relchecks int not null
- ├── relhasoids bool not null
- ├── relhaspkey bool not null
- ├── relhasrules bool not null
- ├── relhastriggers bool not null
- ├── relhassubclass bool not null
- ├── relfrozenxid int not null
- ├── relacl string[]
- ├── reloptions string[]
- ├── INDEX primary
- │    └── oid oid not null
- ├── INDEX pg_class_relname_nsp_index
- │    ├── relname string not null
- │    ├── relnamespace oid not null
- │    └── oid oid not null (storing)
- └── INDEX pg_class_tblspc_relfilenode_index
-      ├── reltablespace oid not null
-      ├── relfilenode oid not null
-      └── oid oid not null
 
 exec-ddl
 CREATE TABLE pg_namespace (
@@ -79,16 +41,6 @@ CREATE TABLE pg_namespace (
     UNIQUE INDEX pg_namespace_nspname_index (nspname)
 );
 ----
-TABLE pg_namespace
- ├── oid oid not null
- ├── nspname string not null
- ├── nspowner oid not null
- ├── nspacl string[]
- ├── INDEX primary
- │    └── oid oid not null
- └── INDEX pg_namespace_nspname_index
-      ├── nspname string not null
-      └── oid oid not null (storing)
 
 exec-ddl
 CREATE TABLE pg_tablespace (
@@ -101,18 +53,6 @@ CREATE TABLE pg_tablespace (
     UNIQUE INDEX pg_tablespace_spcname_index (spcname)
 );
 ----
-TABLE pg_tablespace
- ├── oid oid not null
- ├── spcname string not null
- ├── spcowner oid not null
- ├── spclocation string not null
- ├── spcacl string[]
- ├── spcoptions string[]
- ├── INDEX primary
- │    └── oid oid not null
- └── INDEX pg_tablespace_spcname_index
-      ├── spcname string not null
-      └── oid oid not null (storing)
 
 exec-ddl
 CREATE TABLE pg_inherits (
@@ -123,17 +63,6 @@ CREATE TABLE pg_inherits (
     INDEX pg_inherits_parent_index (inhparent)
 );
 ----
-TABLE pg_inherits
- ├── inhrelid oid not null
- ├── inhparent oid not null
- ├── inhseqno int not null
- ├── INDEX primary
- │    ├── inhrelid oid not null
- │    └── inhseqno int not null
- └── INDEX pg_inherits_parent_index
-      ├── inhparent oid not null
-      ├── inhrelid oid not null
-      └── inhseqno int not null
 
 exec-ddl
 CREATE TABLE pg_index (
@@ -159,31 +88,6 @@ CREATE TABLE pg_index (
     INDEX pg_index_indrelid_index (indrelid)
 )
 ----
-TABLE pg_index
- ├── indexrelid oid not null
- ├── indrelid oid not null
- ├── indnatts int not null
- ├── indisunique bool not null
- ├── indisprimary bool not null
- ├── indisexclusion bool not null
- ├── indimmediate bool not null
- ├── indisclustered bool not null
- ├── indisvalid bool not null
- ├── indcheckxmin bool not null
- ├── indisready bool not null
- ├── indislive bool not null
- ├── indisreplident bool not null
- ├── indkey int[] not null
- ├── indcollation int not null
- ├── indclass int not null
- ├── indoption int not null
- ├── indexprs string
- ├── indpred string
- ├── INDEX primary
- │    └── indexrelid oid not null
- └── INDEX pg_index_indrelid_index
-      ├── indrelid oid not null
-      └── indexrelid oid not null
 
 exec-ddl
 CREATE TABLE pg_foreign_table (
@@ -192,12 +96,6 @@ CREATE TABLE pg_foreign_table (
     ftoptions text[]
 );
 ----
-TABLE pg_foreign_table
- ├── ftrelid oid not null
- ├── ftserver oid not null
- ├── ftoptions string[]
- └── INDEX primary
-      └── ftrelid oid not null
 
 exec-ddl
 CREATE TABLE pg_foreign_server (
@@ -212,20 +110,6 @@ CREATE TABLE pg_foreign_server (
     UNIQUE INDEX pg_foreign_server_name_index (srvname)
 );
 ----
-TABLE pg_foreign_server
- ├── oid oid not null
- ├── srvname string not null
- ├── srvowner oid not null
- ├── srvfdw oid not null
- ├── srvtype string
- ├── srvversion string
- ├── srvacl string[]
- ├── srvoptions string[]
- ├── INDEX primary
- │    └── oid oid not null
- └── INDEX pg_foreign_server_name_index
-      ├── srvname string not null
-      └── oid oid not null (storing)
 
 opt
 SELECT

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -23,30 +23,6 @@ create table flavors
 	unique (name)
 )
 ----
-TABLE flavors
- ├── id int not null
- ├── name string not null
- ├── memory_mb int not null
- ├── vcpus int not null
- ├── root_gb int
- ├── ephemeral_gb int
- ├── flavorid string not null
- ├── swap int not null
- ├── rxtx_factor float
- ├── vcpu_weight int
- ├── disabled bool
- ├── is_public bool
- ├── description string
- ├── created_at timestamp
- ├── updated_at timestamp
- ├── INDEX primary
- │    └── id int not null
- ├── INDEX secondary
- │    ├── flavorid string not null
- │    └── id int not null (storing)
- └── INDEX secondary
-      ├── name string not null
-      └── id int not null (storing)
 
 exec-ddl
 create table flavor_projects
@@ -60,19 +36,6 @@ create table flavor_projects
     unique (flavor_id, project_id)
 )
 ----
-TABLE flavor_projects
- ├── id int not null
- ├── flavor_id int not null
- ├── project_id string not null
- ├── created_at timestamp
- ├── updated_at timestamp
- ├── INDEX primary
- │    └── id int not null
- ├── INDEX secondary
- │    ├── flavor_id int not null
- │    ├── project_id string not null
- │    └── id int not null (storing)
- └── CONSTRAINT fk_flavor_id_ref_flavors FOREIGN KEY (flavor_id) REFERENCES t.public.flavors (id)
 
 exec-ddl
 create table flavor_extra_specs
@@ -87,20 +50,6 @@ create table flavor_extra_specs
     unique index flavor_extra_specs_flavor_id_key_idx (flavor_id, key)
 )
 ----
-TABLE flavor_extra_specs
- ├── id int not null
- ├── key string not null
- ├── value string
- ├── flavor_id int not null
- ├── created_at timestamp
- ├── updated_at timestamp
- ├── INDEX primary
- │    └── id int not null
- ├── INDEX flavor_extra_specs_flavor_id_key_idx
- │    ├── flavor_id int not null
- │    ├── key string not null
- │    └── id int not null (storing)
- └── CONSTRAINT fk_flavor_id_ref_flavors FOREIGN KEY (flavor_id) REFERENCES t.public.flavors (id)
 
 exec-ddl
 create table instance_types
@@ -125,33 +74,6 @@ create table instance_types
     unique (name, deleted)
 )
 ----
-TABLE instance_types
- ├── id int not null
- ├── name string
- ├── memory_mb int not null
- ├── vcpus int not null
- ├── root_gb int
- ├── ephemeral_gb int
- ├── flavorid string
- ├── swap int not null
- ├── rxtx_factor float
- ├── vcpu_weight int
- ├── disabled bool
- ├── is_public bool
- ├── deleted bool
- ├── deleted_at timestamp
- ├── created_at timestamp
- ├── updated_at timestamp
- ├── INDEX primary
- │    └── id int not null
- ├── INDEX secondary
- │    ├── flavorid string
- │    ├── deleted bool
- │    └── id int not null (storing)
- └── INDEX secondary
-      ├── name string
-      ├── deleted bool
-      └── id int not null (storing)
 
 exec-ddl
 create table instance_type_projects
@@ -167,22 +89,6 @@ create table instance_type_projects
     unique (instance_type_id, project_id, deleted)
 )
 ----
-TABLE instance_type_projects
- ├── id int not null
- ├── instance_type_id int not null
- ├── project_id string
- ├── deleted bool
- ├── deleted_at timestamp
- ├── created_at timestamp
- ├── updated_at timestamp
- ├── INDEX primary
- │    └── id int not null
- ├── INDEX secondary
- │    ├── instance_type_id int not null
- │    ├── project_id string
- │    ├── deleted bool
- │    └── id int not null (storing)
- └── CONSTRAINT fk_instance_type_id_ref_instance_types FOREIGN KEY (instance_type_id) REFERENCES t.public.instance_types (id)
 
 exec-ddl
 create table instance_type_extra_specs
@@ -200,27 +106,6 @@ create table instance_type_extra_specs
     unique (instance_type_id, key, deleted)
 )
 ----
-TABLE instance_type_extra_specs
- ├── id int not null
- ├── key string
- ├── value string
- ├── instance_type_id int not null
- ├── deleted bool
- ├── deleted_at timestamp
- ├── created_at timestamp
- ├── updated_at timestamp
- ├── INDEX primary
- │    └── id int not null
- ├── INDEX instance_type_extra_specs_instance_type_id_key_idx
- │    ├── instance_type_id int not null
- │    ├── key string
- │    └── id int not null
- ├── INDEX secondary
- │    ├── instance_type_id int not null
- │    ├── key string
- │    ├── deleted bool
- │    └── id int not null (storing)
- └── CONSTRAINT fk_instance_type_id_ref_instance_types FOREIGN KEY (instance_type_id) REFERENCES t.public.instance_types (id)
 
 opt
 select anon_1.flavors_created_at as anon_1_flavors_created_at,

--- a/pkg/sql/opt/xform/testdata/external/pgadmin
+++ b/pkg/sql/opt/xform/testdata/external/pgadmin
@@ -24,29 +24,6 @@ CREATE TABLE pg_stat_activity (
     query STRING NULL
 )
 ----
-TABLE pg_stat_activity
- ├── datid oid
- ├── datname name
- ├── pid int
- ├── usesysid oid
- ├── username name
- ├── application_name string
- ├── client_addr inet
- ├── client_hostname string
- ├── client_port int
- ├── backend_start timestamptz
- ├── xact_start timestamptz
- ├── query_start timestamptz
- ├── state_change timestamptz
- ├── wait_event_type string
- ├── wait_event string
- ├── state string
- ├── backend_xid int
- ├── backend_xmin int
- ├── query string
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE pg_roles (
@@ -66,24 +43,6 @@ CREATE TABLE pg_roles (
     rolconfig STRING[] NULL
 )
 ----
-TABLE pg_roles
- ├── oid oid
- ├── rolname name
- ├── rolsuper bool
- ├── rolinherit bool
- ├── rolcreaterole bool
- ├── rolcreatedb bool
- ├── rolcatupdate bool
- ├── rolcanlogin bool
- ├── rolreplication bool
- ├── rolconnlimit int
- ├── rolpassword string
- ├── rolvaliduntil timestamptz
- ├── rolbypassrls bool
- ├── rolconfig string[]
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 opt
 SELECT

--- a/pkg/sql/opt/xform/testdata/external/pgjdbc
+++ b/pkg/sql/opt/xform/testdata/external/pgjdbc
@@ -37,41 +37,6 @@ CREATE TABLE pg_type (
     typacl STRING[] NULL
 )
 ----
-TABLE pg_type
- ├── oid oid
- ├── typname name not null
- ├── typnamespace oid
- ├── typowner oid
- ├── typlen int
- ├── typbyval bool
- ├── typtype string
- ├── typcategory string
- ├── typispreferred bool
- ├── typisdefined bool
- ├── typdelim string
- ├── typrelid oid
- ├── typelem oid
- ├── typarray oid
- ├── typinput oid
- ├── typoutput oid
- ├── typreceive oid
- ├── typsend oid
- ├── typmodin oid
- ├── typmodout oid
- ├── typanalyze oid
- ├── typalign string
- ├── typstorage string
- ├── typnotnull bool
- ├── typbasetype oid
- ├── typtypmod int
- ├── typndims int
- ├── typcollation oid
- ├── typdefaultbin string
- ├── typdefault string
- ├── typacl string[]
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE pg_namespace (
@@ -81,14 +46,6 @@ CREATE TABLE pg_namespace (
     nspacl STRING[] NULL
 )
 ----
-TABLE pg_namespace
- ├── oid oid
- ├── nspname name not null
- ├── nspowner oid
- ├── nspacl string[]
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 opt
 SELECT

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -12,18 +12,6 @@ CREATE TABLE warehouse
     w_ytd       decimal(12,2)
 )
 ----
-TABLE warehouse
- ├── w_id int not null
- ├── w_name varchar
- ├── w_street_1 varchar
- ├── w_street_2 varchar
- ├── w_city varchar
- ├── w_state char
- ├── w_zip char
- ├── w_tax decimal
- ├── w_ytd decimal
- └── INDEX primary
-      └── w_id int not null
 
 exec-ddl
 ALTER TABLE warehouse INJECT STATISTICS '[
@@ -111,22 +99,6 @@ CREATE TABLE district
     foreign key (d_w_id) references warehouse (w_id)
 ) interleave in parent warehouse (d_w_id)
 ----
-TABLE district
- ├── d_id int not null
- ├── d_w_id int not null
- ├── d_name varchar
- ├── d_street_1 varchar
- ├── d_street_2 varchar
- ├── d_city varchar
- ├── d_state char
- ├── d_zip char
- ├── d_tax decimal
- ├── d_ytd decimal
- ├── d_next_o_id int
- ├── INDEX primary
- │    ├── d_w_id int not null
- │    └── d_id int not null
- └── CONSTRAINT fk_d_w_id_ref_warehouse FOREIGN KEY (d_w_id) REFERENCES t.public.warehouse (w_id)
 
 exec-ddl
 ALTER TABLE district INJECT STATISTICS '[
@@ -239,39 +211,6 @@ CREATE TABLE customer
     foreign key (c_w_id, c_d_id) references district (d_w_id, d_id)
 ) interleave in parent district (c_w_id, c_d_id)
 ----
-TABLE customer
- ├── c_id int not null
- ├── c_d_id int not null
- ├── c_w_id int not null
- ├── c_first varchar
- ├── c_middle char
- ├── c_last varchar
- ├── c_street_1 varchar
- ├── c_street_2 varchar
- ├── c_city varchar
- ├── c_state char
- ├── c_zip char
- ├── c_phone char
- ├── c_since timestamp
- ├── c_credit char
- ├── c_credit_lim decimal
- ├── c_discount decimal
- ├── c_balance decimal
- ├── c_ytd_payment decimal
- ├── c_payment_cnt int
- ├── c_delivery_cnt int
- ├── c_data varchar
- ├── INDEX primary
- │    ├── c_w_id int not null
- │    ├── c_d_id int not null
- │    └── c_id int not null
- ├── INDEX customer_idx
- │    ├── c_w_id int not null
- │    ├── c_d_id int not null
- │    ├── c_last varchar
- │    ├── c_first varchar
- │    └── c_id int not null
- └── CONSTRAINT fk_c_w_id_ref_district FOREIGN KEY (c_w_id, c_d_id) REFERENCES t.public.district (d_w_id, d_id)
 
 exec-ddl
 ALTER TABLE customer INJECT STATISTICS '[
@@ -444,31 +383,6 @@ CREATE TABLE history
     foreign key (h_w_id, h_d_id) references district (d_w_id, d_id)
 )
 ----
-TABLE history
- ├── rowid uuid not null
- ├── h_c_id int not null
- ├── h_c_d_id int not null
- ├── h_c_w_id int not null
- ├── h_d_id int not null
- ├── h_w_id int not null
- ├── h_date timestamp
- ├── h_amount decimal
- ├── h_data varchar
- ├── INDEX primary
- │    ├── h_w_id int not null
- │    └── rowid uuid not null
- ├── INDEX history_customer_fk_idx
- │    ├── h_c_w_id int not null
- │    ├── h_c_d_id int not null
- │    ├── h_c_id int not null
- │    ├── h_w_id int not null
- │    └── rowid uuid not null
- ├── INDEX history_district_fk_idx
- │    ├── h_w_id int not null
- │    ├── h_d_id int not null
- │    └── rowid uuid not null
- ├── CONSTRAINT fk_h_c_w_id_ref_customer FOREIGN KEY (h_c_w_id, h_c_d_id, h_c_id) REFERENCES t.public.customer (c_w_id, c_d_id, c_id)
- └── CONSTRAINT fk_h_w_id_ref_district FOREIGN KEY (h_w_id, h_d_id) REFERENCES t.public.district (d_w_id, d_id)
 
 exec-ddl
 ALTER TABLE history INJECT STATISTICS '[
@@ -554,25 +468,6 @@ CREATE TABLE "order"
     foreign key (o_w_id, o_d_id, o_c_id) references customer (c_w_id, c_d_id, c_id)
 ) interleave in parent district (o_w_id, o_d_id)
 ----
-TABLE order
- ├── o_id int not null
- ├── o_d_id int not null
- ├── o_w_id int not null
- ├── o_c_id int
- ├── o_entry_d timestamp
- ├── o_carrier_id int
- ├── o_ol_cnt int
- ├── o_all_local int
- ├── INDEX primary
- │    ├── o_w_id int not null
- │    ├── o_d_id int not null
- │    └── o_id int not null desc
- ├── INDEX order_idx
- │    ├── o_w_id int not null
- │    ├── o_d_id int not null
- │    ├── o_c_id int
- │    └── o_id int not null desc
- └── CONSTRAINT fk_o_w_id_ref_customer FOREIGN KEY (o_w_id, o_d_id, o_c_id) REFERENCES t.public.customer (c_w_id, c_d_id, c_id)
 
 exec-ddl
 ALTER TABLE "order" INJECT STATISTICS '[
@@ -645,15 +540,6 @@ CREATE TABLE new_order
     foreign key (no_w_id, no_d_id, no_o_id) references "order" (o_w_id, o_d_id, o_id)
 ) interleave in parent "order" (no_w_id, no_d_id, no_o_id)
 ----
-TABLE new_order
- ├── no_o_id int not null
- ├── no_d_id int not null
- ├── no_w_id int not null
- ├── INDEX primary
- │    ├── no_w_id int not null
- │    ├── no_d_id int not null
- │    └── no_o_id int not null
- └── CONSTRAINT fk_no_w_id_ref_order FOREIGN KEY (no_w_id, no_d_id, no_o_id) REFERENCES t.public."order" (o_w_id, o_d_id, o_id)
 
 exec-ddl
 ALTER TABLE new_order INJECT STATISTICS '[
@@ -692,14 +578,6 @@ CREATE TABLE item
     primary key (i_id)
 )
 ----
-TABLE item
- ├── i_id int not null
- ├── i_im_id int
- ├── i_name varchar
- ├── i_price decimal
- ├── i_data varchar
- └── INDEX primary
-      └── i_id int not null
 
 exec-ddl
 ALTER TABLE item INJECT STATISTICS '[
@@ -767,32 +645,6 @@ CREATE TABLE stock
     foreign key (s_i_id) references item (i_id)
 ) interleave in parent warehouse (s_w_id)
 ----
-TABLE stock
- ├── s_i_id int not null
- ├── s_w_id int not null
- ├── s_quantity int
- ├── s_dist_01 char
- ├── s_dist_02 char
- ├── s_dist_03 char
- ├── s_dist_04 char
- ├── s_dist_05 char
- ├── s_dist_06 char
- ├── s_dist_07 char
- ├── s_dist_08 char
- ├── s_dist_09 char
- ├── s_dist_10 char
- ├── s_ytd int
- ├── s_order_cnt int
- ├── s_remote_cnt int
- ├── s_data varchar
- ├── INDEX primary
- │    ├── s_w_id int not null
- │    └── s_i_id int not null
- ├── INDEX stock_item_fk_idx
- │    ├── s_i_id int not null
- │    └── s_w_id int not null
- ├── CONSTRAINT fk_s_w_id_ref_warehouse FOREIGN KEY (s_w_id) REFERENCES t.public.warehouse (w_id)
- └── CONSTRAINT fk_s_i_id_ref_item FOREIGN KEY (s_i_id) REFERENCES t.public.item (i_id)
 
 exec-ddl
 ALTER TABLE stock INJECT STATISTICS '[
@@ -937,31 +789,6 @@ CREATE TABLE order_line
     foreign key (ol_supply_w_id, ol_i_id) references stock (s_w_id, s_i_id)
 ) interleave in parent "order" (ol_w_id, ol_d_id, ol_o_id)
 ----
-TABLE order_line
- ├── ol_o_id int not null
- ├── ol_d_id int not null
- ├── ol_w_id int not null
- ├── ol_number int not null
- ├── ol_i_id int not null
- ├── ol_supply_w_id int
- ├── ol_delivery_d timestamp
- ├── ol_quantity int
- ├── ol_amount decimal
- ├── ol_dist_info char
- ├── INDEX primary
- │    ├── ol_w_id int not null
- │    ├── ol_d_id int not null
- │    ├── ol_o_id int not null desc
- │    └── ol_number int not null
- ├── INDEX order_line_stock_fk_idx
- │    ├── ol_supply_w_id int
- │    ├── ol_i_id int not null
- │    ├── ol_w_id int not null
- │    ├── ol_d_id int not null
- │    ├── ol_o_id int not null
- │    └── ol_number int not null
- ├── CONSTRAINT fk_ol_w_id_ref_order FOREIGN KEY (ol_w_id, ol_d_id, ol_o_id) REFERENCES t.public."order" (o_w_id, o_d_id, o_id)
- └── CONSTRAINT fk_ol_supply_w_id_ref_stock FOREIGN KEY (ol_supply_w_id, ol_i_id) REFERENCES t.public.stock (s_w_id, s_i_id)
 
 exec-ddl
 ALTER TABLE order_line INJECT STATISTICS '[

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -12,18 +12,6 @@ CREATE TABLE warehouse
     w_ytd       decimal(12,2)
 )
 ----
-TABLE warehouse
- ├── w_id int not null
- ├── w_name varchar
- ├── w_street_1 varchar
- ├── w_street_2 varchar
- ├── w_city varchar
- ├── w_state char
- ├── w_zip char
- ├── w_tax decimal
- ├── w_ytd decimal
- └── INDEX primary
-      └── w_id int not null
 
 exec-ddl
 CREATE TABLE district
@@ -43,22 +31,6 @@ CREATE TABLE district
     foreign key (d_w_id) references warehouse (w_id)
 ) interleave in parent warehouse (d_w_id)
 ----
-TABLE district
- ├── d_id int not null
- ├── d_w_id int not null
- ├── d_name varchar
- ├── d_street_1 varchar
- ├── d_street_2 varchar
- ├── d_city varchar
- ├── d_state char
- ├── d_zip char
- ├── d_tax decimal
- ├── d_ytd decimal
- ├── d_next_o_id int
- ├── INDEX primary
- │    ├── d_w_id int not null
- │    └── d_id int not null
- └── CONSTRAINT fk_d_w_id_ref_warehouse FOREIGN KEY (d_w_id) REFERENCES t.public.warehouse (w_id)
 
 exec-ddl
 CREATE TABLE customer
@@ -89,39 +61,6 @@ CREATE TABLE customer
     foreign key (c_w_id, c_d_id) references district (d_w_id, d_id)
 ) interleave in parent district (c_w_id, c_d_id)
 ----
-TABLE customer
- ├── c_id int not null
- ├── c_d_id int not null
- ├── c_w_id int not null
- ├── c_first varchar
- ├── c_middle char
- ├── c_last varchar
- ├── c_street_1 varchar
- ├── c_street_2 varchar
- ├── c_city varchar
- ├── c_state char
- ├── c_zip char
- ├── c_phone char
- ├── c_since timestamp
- ├── c_credit char
- ├── c_credit_lim decimal
- ├── c_discount decimal
- ├── c_balance decimal
- ├── c_ytd_payment decimal
- ├── c_payment_cnt int
- ├── c_delivery_cnt int
- ├── c_data varchar
- ├── INDEX primary
- │    ├── c_w_id int not null
- │    ├── c_d_id int not null
- │    └── c_id int not null
- ├── INDEX customer_idx
- │    ├── c_w_id int not null
- │    ├── c_d_id int not null
- │    ├── c_last varchar
- │    ├── c_first varchar
- │    └── c_id int not null
- └── CONSTRAINT fk_c_w_id_ref_district FOREIGN KEY (c_w_id, c_d_id) REFERENCES t.public.district (d_w_id, d_id)
 
 exec-ddl
 CREATE TABLE history
@@ -142,31 +81,6 @@ CREATE TABLE history
     foreign key (h_w_id, h_d_id) references district (d_w_id, d_id)
 )
 ----
-TABLE history
- ├── rowid uuid not null
- ├── h_c_id int not null
- ├── h_c_d_id int not null
- ├── h_c_w_id int not null
- ├── h_d_id int not null
- ├── h_w_id int not null
- ├── h_date timestamp
- ├── h_amount decimal
- ├── h_data varchar
- ├── INDEX primary
- │    ├── h_w_id int not null
- │    └── rowid uuid not null
- ├── INDEX history_customer_fk_idx
- │    ├── h_c_w_id int not null
- │    ├── h_c_d_id int not null
- │    ├── h_c_id int not null
- │    ├── h_w_id int not null
- │    └── rowid uuid not null
- ├── INDEX history_district_fk_idx
- │    ├── h_w_id int not null
- │    ├── h_d_id int not null
- │    └── rowid uuid not null
- ├── CONSTRAINT fk_h_c_w_id_ref_customer FOREIGN KEY (h_c_w_id, h_c_d_id, h_c_id) REFERENCES t.public.customer (c_w_id, c_d_id, c_id)
- └── CONSTRAINT fk_h_w_id_ref_district FOREIGN KEY (h_w_id, h_d_id) REFERENCES t.public.district (d_w_id, d_id)
 
 exec-ddl
 CREATE TABLE "order"
@@ -184,25 +98,6 @@ CREATE TABLE "order"
     foreign key (o_w_id, o_d_id, o_c_id) references customer (c_w_id, c_d_id, c_id)
 ) interleave in parent district (o_w_id, o_d_id)
 ----
-TABLE order
- ├── o_id int not null
- ├── o_d_id int not null
- ├── o_w_id int not null
- ├── o_c_id int
- ├── o_entry_d timestamp
- ├── o_carrier_id int
- ├── o_ol_cnt int
- ├── o_all_local int
- ├── INDEX primary
- │    ├── o_w_id int not null
- │    ├── o_d_id int not null
- │    └── o_id int not null desc
- ├── INDEX order_idx
- │    ├── o_w_id int not null
- │    ├── o_d_id int not null
- │    ├── o_c_id int
- │    └── o_id int not null desc
- └── CONSTRAINT fk_o_w_id_ref_customer FOREIGN KEY (o_w_id, o_d_id, o_c_id) REFERENCES t.public.customer (c_w_id, c_d_id, c_id)
 
 exec-ddl
 CREATE TABLE new_order
@@ -214,15 +109,6 @@ CREATE TABLE new_order
     foreign key (no_w_id, no_d_id, no_o_id) references "order" (o_w_id, o_d_id, o_id)
 ) interleave in parent "order" (no_w_id, no_d_id, no_o_id)
 ----
-TABLE new_order
- ├── no_o_id int not null
- ├── no_d_id int not null
- ├── no_w_id int not null
- ├── INDEX primary
- │    ├── no_w_id int not null
- │    ├── no_d_id int not null
- │    └── no_o_id int not null
- └── CONSTRAINT fk_no_w_id_ref_order FOREIGN KEY (no_w_id, no_d_id, no_o_id) REFERENCES t.public."order" (o_w_id, o_d_id, o_id)
 
 exec-ddl
 CREATE TABLE item
@@ -235,14 +121,6 @@ CREATE TABLE item
     primary key (i_id)
 )
 ----
-TABLE item
- ├── i_id int not null
- ├── i_im_id int
- ├── i_name varchar
- ├── i_price decimal
- ├── i_data varchar
- └── INDEX primary
-      └── i_id int not null
 
 exec-ddl
 CREATE TABLE stock
@@ -270,32 +148,6 @@ CREATE TABLE stock
     foreign key (s_i_id) references item (i_id)
 ) interleave in parent warehouse (s_w_id)
 ----
-TABLE stock
- ├── s_i_id int not null
- ├── s_w_id int not null
- ├── s_quantity int
- ├── s_dist_01 char
- ├── s_dist_02 char
- ├── s_dist_03 char
- ├── s_dist_04 char
- ├── s_dist_05 char
- ├── s_dist_06 char
- ├── s_dist_07 char
- ├── s_dist_08 char
- ├── s_dist_09 char
- ├── s_dist_10 char
- ├── s_ytd int
- ├── s_order_cnt int
- ├── s_remote_cnt int
- ├── s_data varchar
- ├── INDEX primary
- │    ├── s_w_id int not null
- │    └── s_i_id int not null
- ├── INDEX stock_item_fk_idx
- │    ├── s_i_id int not null
- │    └── s_w_id int not null
- ├── CONSTRAINT fk_s_w_id_ref_warehouse FOREIGN KEY (s_w_id) REFERENCES t.public.warehouse (w_id)
- └── CONSTRAINT fk_s_i_id_ref_item FOREIGN KEY (s_i_id) REFERENCES t.public.item (i_id)
 
 exec-ddl
 CREATE TABLE order_line
@@ -316,31 +168,6 @@ CREATE TABLE order_line
     foreign key (ol_supply_w_id, ol_i_id) references stock (s_w_id, s_i_id)
 ) interleave in parent "order" (ol_w_id, ol_d_id, ol_o_id)
 ----
-TABLE order_line
- ├── ol_o_id int not null
- ├── ol_d_id int not null
- ├── ol_w_id int not null
- ├── ol_number int not null
- ├── ol_i_id int not null
- ├── ol_supply_w_id int
- ├── ol_delivery_d timestamp
- ├── ol_quantity int
- ├── ol_amount decimal
- ├── ol_dist_info char
- ├── INDEX primary
- │    ├── ol_w_id int not null
- │    ├── ol_d_id int not null
- │    ├── ol_o_id int not null desc
- │    └── ol_number int not null
- ├── INDEX order_line_stock_fk_idx
- │    ├── ol_supply_w_id int
- │    ├── ol_i_id int not null
- │    ├── ol_w_id int not null
- │    ├── ol_d_id int not null
- │    ├── ol_o_id int not null
- │    └── ol_number int not null
- ├── CONSTRAINT fk_ol_w_id_ref_order FOREIGN KEY (ol_w_id, ol_d_id, ol_o_id) REFERENCES t.public."order" (o_w_id, o_d_id, o_id)
- └── CONSTRAINT fk_ol_supply_w_id_ref_stock FOREIGN KEY (ol_supply_w_id, ol_i_id) REFERENCES t.public.stock (s_w_id, s_i_id)
 
 # --------------------------------------------------
 # 2.4 The New Order Transaction

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -6,12 +6,6 @@ CREATE TABLE public.region
     r_comment varchar(152)
 );
 ----
-TABLE region
- ├── r_regionkey int not null
- ├── r_name char not null
- ├── r_comment varchar
- └── INDEX primary
-      └── r_regionkey int not null
 
 exec-ddl
 ALTER TABLE region INJECT STATISTICS '[
@@ -35,17 +29,6 @@ CREATE TABLE public.nation
     CONSTRAINT nation_fkey_region FOREIGN KEY (n_regionkey) references public.region (r_regionkey)
 );
 ----
-TABLE nation
- ├── n_nationkey int not null
- ├── n_name char not null
- ├── n_regionkey int not null
- ├── n_comment varchar
- ├── INDEX primary
- │    └── n_nationkey int not null
- ├── INDEX n_rk
- │    ├── n_regionkey int not null
- │    └── n_nationkey int not null
- └── CONSTRAINT nation_fkey_region FOREIGN KEY (n_regionkey) REFERENCES t.public.region (r_regionkey)
 
 exec-ddl
 ALTER TABLE nation INJECT STATISTICS '[
@@ -78,20 +61,6 @@ CREATE TABLE public.supplier
     CONSTRAINT supplier_fkey_nation FOREIGN KEY (s_nationkey) references public.nation (n_nationkey)
 );
 ----
-TABLE supplier
- ├── s_suppkey int not null
- ├── s_name char not null
- ├── s_address varchar not null
- ├── s_nationkey int not null
- ├── s_phone char not null
- ├── s_acctbal float not null
- ├── s_comment varchar not null
- ├── INDEX primary
- │    └── s_suppkey int not null
- ├── INDEX s_nk
- │    ├── s_nationkey int not null
- │    └── s_suppkey int not null
- └── CONSTRAINT supplier_fkey_nation FOREIGN KEY (s_nationkey) REFERENCES t.public.nation (n_nationkey)
 
 exec-ddl
 ALTER TABLE supplier INJECT STATISTICS '[
@@ -124,18 +93,6 @@ CREATE TABLE public.part
     p_comment varchar(23) NOT NULL
 );
 ----
-TABLE part
- ├── p_partkey int not null
- ├── p_name varchar not null
- ├── p_mfgr char not null
- ├── p_brand char not null
- ├── p_type varchar not null
- ├── p_size int not null
- ├── p_container char not null
- ├── p_retailprice float not null
- ├── p_comment varchar not null
- └── INDEX primary
-      └── p_partkey int not null
 
 exec-ddl
 ALTER TABLE part INJECT STATISTICS '[
@@ -162,20 +119,6 @@ CREATE TABLE public.partsupp
     CONSTRAINT partsupp_fkey_supplier FOREIGN KEY (ps_suppkey) references public.supplier (s_suppkey)
 );
 ----
-TABLE partsupp
- ├── ps_partkey int not null
- ├── ps_suppkey int not null
- ├── ps_availqty int not null
- ├── ps_supplycost float not null
- ├── ps_comment varchar not null
- ├── INDEX primary
- │    ├── ps_partkey int not null
- │    └── ps_suppkey int not null
- ├── INDEX ps_sk
- │    ├── ps_suppkey int not null
- │    └── ps_partkey int not null
- ├── CONSTRAINT partsupp_fkey_part FOREIGN KEY (ps_partkey) REFERENCES t.public.part (p_partkey)
- └── CONSTRAINT partsupp_fkey_supplier FOREIGN KEY (ps_suppkey) REFERENCES t.public.supplier (s_suppkey)
 
 exec-ddl
 ALTER TABLE partsupp INJECT STATISTICS '[
@@ -209,21 +152,6 @@ CREATE TABLE public.customer
     CONSTRAINT customer_fkey_nation FOREIGN KEY (c_nationkey) references public.nation (n_nationkey)
 );
 ----
-TABLE customer
- ├── c_custkey int not null
- ├── c_name varchar not null
- ├── c_address varchar not null
- ├── c_nationkey int not null
- ├── c_phone char not null
- ├── c_acctbal float not null
- ├── c_mktsegment char not null
- ├── c_comment varchar not null
- ├── INDEX primary
- │    └── c_custkey int not null
- ├── INDEX c_nk
- │    ├── c_nationkey int not null
- │    └── c_custkey int not null
- └── CONSTRAINT customer_fkey_nation FOREIGN KEY (c_nationkey) REFERENCES t.public.nation (n_nationkey)
 
 exec-ddl
 ALTER TABLE customer INJECT STATISTICS '[
@@ -259,25 +187,6 @@ CREATE TABLE public.orders
     CONSTRAINT orders_fkey_customer FOREIGN KEY (o_custkey) references public.customer (c_custkey)
 );
 ----
-TABLE orders
- ├── o_orderkey int not null
- ├── o_custkey int not null
- ├── o_orderstatus char not null
- ├── o_totalprice float not null
- ├── o_orderdate date not null
- ├── o_orderpriority char not null
- ├── o_clerk char not null
- ├── o_shippriority int not null
- ├── o_comment varchar not null
- ├── INDEX primary
- │    └── o_orderkey int not null
- ├── INDEX o_ck
- │    ├── o_custkey int not null
- │    └── o_orderkey int not null
- ├── INDEX o_od
- │    ├── o_orderdate date not null
- │    └── o_orderkey int not null
- └── CONSTRAINT orders_fkey_customer FOREIGN KEY (o_custkey) REFERENCES t.public.customer (c_custkey)
 
 exec-ddl
 ALTER TABLE orders INJECT STATISTICS '[
@@ -336,63 +245,6 @@ CREATE TABLE public.lineitem
     CONSTRAINT lineitem_fkey_partsupp FOREIGN KEY (l_partkey, l_suppkey) references public.partsupp (ps_partkey, ps_suppkey)
 );
 ----
-TABLE lineitem
- ├── l_orderkey int not null
- ├── l_partkey int not null
- ├── l_suppkey int not null
- ├── l_linenumber int not null
- ├── l_quantity float not null
- ├── l_extendedprice float not null
- ├── l_discount float not null
- ├── l_tax float not null
- ├── l_returnflag char not null
- ├── l_linestatus char not null
- ├── l_shipdate date not null
- ├── l_commitdate date not null
- ├── l_receiptdate date not null
- ├── l_shipinstruct char not null
- ├── l_shipmode char not null
- ├── l_comment varchar not null
- ├── INDEX primary
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_ok
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_pk
- │    ├── l_partkey int not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_sk
- │    ├── l_suppkey int not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_sd
- │    ├── l_shipdate date not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_cd
- │    ├── l_commitdate date not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_rd
- │    ├── l_receiptdate date not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_pk_sk
- │    ├── l_partkey int not null
- │    ├── l_suppkey int not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_sk_pk
- │    ├── l_suppkey int not null
- │    ├── l_partkey int not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── CONSTRAINT lineitem_fkey_orders FOREIGN KEY (l_orderkey) REFERENCES t.public.orders (o_orderkey)
- ├── CONSTRAINT lineitem_fkey_part FOREIGN KEY (l_partkey) REFERENCES t.public.part (p_partkey)
- ├── CONSTRAINT lineitem_fkey_supplier FOREIGN KEY (l_suppkey) REFERENCES t.public.supplier (s_suppkey)
- └── CONSTRAINT lineitem_fkey_partsupp FOREIGN KEY (l_partkey, l_suppkey) REFERENCES t.public.partsupp (ps_partkey, ps_suppkey)
 
 exec-ddl
 ALTER TABLE lineitem INJECT STATISTICS '[
@@ -2017,8 +1869,6 @@ CREATE VIEW revenue0 (supplier_no, total_revenue) AS
     GROUP BY
         l_suppkey;
 ----
-VIEW revenue0 (supplier_no, total_revenue)
- └── SELECT l_suppkey, sum(l_extendedprice * (1 - l_discount)) FROM lineitem WHERE (l_shipdate >= DATE '1996-01-01') AND (l_shipdate < (DATE '1996-01-01' + '3 mons':::INTERVAL)) GROUP BY l_suppkey
 
 opt
 SELECT

--- a/pkg/sql/opt/xform/testdata/external/tpch-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpch-no-stats
@@ -6,12 +6,6 @@ CREATE TABLE public.region
     r_comment varchar(152)
 );
 ----
-TABLE region
- ├── r_regionkey int not null
- ├── r_name char not null
- ├── r_comment varchar
- └── INDEX primary
-      └── r_regionkey int not null
 
 exec-ddl
 CREATE TABLE public.nation
@@ -24,17 +18,6 @@ CREATE TABLE public.nation
     CONSTRAINT nation_fkey_region FOREIGN KEY (n_regionkey) references public.region (r_regionkey)
 );
 ----
-TABLE nation
- ├── n_nationkey int not null
- ├── n_name char not null
- ├── n_regionkey int not null
- ├── n_comment varchar
- ├── INDEX primary
- │    └── n_nationkey int not null
- ├── INDEX n_rk
- │    ├── n_regionkey int not null
- │    └── n_nationkey int not null
- └── CONSTRAINT nation_fkey_region FOREIGN KEY (n_regionkey) REFERENCES t.public.region (r_regionkey)
 
 exec-ddl
 CREATE TABLE public.supplier
@@ -50,20 +33,6 @@ CREATE TABLE public.supplier
     CONSTRAINT supplier_fkey_nation FOREIGN KEY (s_nationkey) references public.nation (n_nationkey)
 );
 ----
-TABLE supplier
- ├── s_suppkey int not null
- ├── s_name char not null
- ├── s_address varchar not null
- ├── s_nationkey int not null
- ├── s_phone char not null
- ├── s_acctbal float not null
- ├── s_comment varchar not null
- ├── INDEX primary
- │    └── s_suppkey int not null
- ├── INDEX s_nk
- │    ├── s_nationkey int not null
- │    └── s_suppkey int not null
- └── CONSTRAINT supplier_fkey_nation FOREIGN KEY (s_nationkey) REFERENCES t.public.nation (n_nationkey)
 
 exec-ddl
 CREATE TABLE public.part
@@ -79,18 +48,6 @@ CREATE TABLE public.part
     p_comment varchar(23) NOT NULL
 );
 ----
-TABLE part
- ├── p_partkey int not null
- ├── p_name varchar not null
- ├── p_mfgr char not null
- ├── p_brand char not null
- ├── p_type varchar not null
- ├── p_size int not null
- ├── p_container char not null
- ├── p_retailprice float not null
- ├── p_comment varchar not null
- └── INDEX primary
-      └── p_partkey int not null
 
 exec-ddl
 CREATE TABLE public.partsupp
@@ -106,20 +63,6 @@ CREATE TABLE public.partsupp
     CONSTRAINT partsupp_fkey_supplier FOREIGN KEY (ps_suppkey) references public.supplier (s_suppkey)
 );
 ----
-TABLE partsupp
- ├── ps_partkey int not null
- ├── ps_suppkey int not null
- ├── ps_availqty int not null
- ├── ps_supplycost float not null
- ├── ps_comment varchar not null
- ├── INDEX primary
- │    ├── ps_partkey int not null
- │    └── ps_suppkey int not null
- ├── INDEX ps_sk
- │    ├── ps_suppkey int not null
- │    └── ps_partkey int not null
- ├── CONSTRAINT partsupp_fkey_part FOREIGN KEY (ps_partkey) REFERENCES t.public.part (p_partkey)
- └── CONSTRAINT partsupp_fkey_supplier FOREIGN KEY (ps_suppkey) REFERENCES t.public.supplier (s_suppkey)
 
 exec-ddl
 CREATE TABLE public.customer
@@ -136,21 +79,6 @@ CREATE TABLE public.customer
     CONSTRAINT customer_fkey_nation FOREIGN KEY (c_nationkey) references public.nation (n_nationkey)
 );
 ----
-TABLE customer
- ├── c_custkey int not null
- ├── c_name varchar not null
- ├── c_address varchar not null
- ├── c_nationkey int not null
- ├── c_phone char not null
- ├── c_acctbal float not null
- ├── c_mktsegment char not null
- ├── c_comment varchar not null
- ├── INDEX primary
- │    └── c_custkey int not null
- ├── INDEX c_nk
- │    ├── c_nationkey int not null
- │    └── c_custkey int not null
- └── CONSTRAINT customer_fkey_nation FOREIGN KEY (c_nationkey) REFERENCES t.public.nation (n_nationkey)
 
 exec-ddl
 CREATE TABLE public.orders
@@ -169,25 +97,6 @@ CREATE TABLE public.orders
     CONSTRAINT orders_fkey_customer FOREIGN KEY (o_custkey) references public.customer (c_custkey)
 );
 ----
-TABLE orders
- ├── o_orderkey int not null
- ├── o_custkey int not null
- ├── o_orderstatus char not null
- ├── o_totalprice float not null
- ├── o_orderdate date not null
- ├── o_orderpriority char not null
- ├── o_clerk char not null
- ├── o_shippriority int not null
- ├── o_comment varchar not null
- ├── INDEX primary
- │    └── o_orderkey int not null
- ├── INDEX o_ck
- │    ├── o_custkey int not null
- │    └── o_orderkey int not null
- ├── INDEX o_od
- │    ├── o_orderdate date not null
- │    └── o_orderkey int not null
- └── CONSTRAINT orders_fkey_customer FOREIGN KEY (o_custkey) REFERENCES t.public.customer (c_custkey)
 
 exec-ddl
 CREATE TABLE public.lineitem
@@ -223,63 +132,6 @@ CREATE TABLE public.lineitem
     CONSTRAINT lineitem_fkey_partsupp FOREIGN KEY (l_partkey, l_suppkey) references public.partsupp (ps_partkey, ps_suppkey)
 );
 ----
-TABLE lineitem
- ├── l_orderkey int not null
- ├── l_partkey int not null
- ├── l_suppkey int not null
- ├── l_linenumber int not null
- ├── l_quantity float not null
- ├── l_extendedprice float not null
- ├── l_discount float not null
- ├── l_tax float not null
- ├── l_returnflag char not null
- ├── l_linestatus char not null
- ├── l_shipdate date not null
- ├── l_commitdate date not null
- ├── l_receiptdate date not null
- ├── l_shipinstruct char not null
- ├── l_shipmode char not null
- ├── l_comment varchar not null
- ├── INDEX primary
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_ok
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_pk
- │    ├── l_partkey int not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_sk
- │    ├── l_suppkey int not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_sd
- │    ├── l_shipdate date not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_cd
- │    ├── l_commitdate date not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_rd
- │    ├── l_receiptdate date not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_pk_sk
- │    ├── l_partkey int not null
- │    ├── l_suppkey int not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── INDEX l_sk_pk
- │    ├── l_suppkey int not null
- │    ├── l_partkey int not null
- │    ├── l_orderkey int not null
- │    └── l_linenumber int not null
- ├── CONSTRAINT lineitem_fkey_orders FOREIGN KEY (l_orderkey) REFERENCES t.public.orders (o_orderkey)
- ├── CONSTRAINT lineitem_fkey_part FOREIGN KEY (l_partkey) REFERENCES t.public.part (p_partkey)
- ├── CONSTRAINT lineitem_fkey_supplier FOREIGN KEY (l_suppkey) REFERENCES t.public.supplier (s_suppkey)
- └── CONSTRAINT lineitem_fkey_partsupp FOREIGN KEY (l_partkey, l_suppkey) REFERENCES t.public.partsupp (ps_partkey, ps_suppkey)
 
 # --------------------------------------------------
 # Q1
@@ -1803,8 +1655,6 @@ CREATE VIEW revenue0 (supplier_no, total_revenue) AS
     GROUP BY
         l_suppkey;
 ----
-VIEW revenue0 (supplier_no, total_revenue)
- └── SELECT l_suppkey, sum(l_extendedprice * (1 - l_discount)) FROM lineitem WHERE (l_shipdate >= DATE '1996-01-01') AND (l_shipdate < (DATE '1996-01-01' + '3 mons':::INTERVAL)) GROUP BY l_suppkey
 
 opt
 SELECT

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -8,62 +8,18 @@ CREATE TABLE a
     PRIMARY KEY (x, y DESC)
 )
 ----
-TABLE a
- ├── x int not null
- ├── y float not null
- ├── z decimal
- ├── s string not null
- └── INDEX primary
-      ├── x int not null
-      └── y float not null desc
 
 exec-ddl
 CREATE TABLE abc (a INT, b INT, c INT, PRIMARY KEY (a, b, c))
 ----
-TABLE abc
- ├── a int not null
- ├── b int not null
- ├── c int not null
- └── INDEX primary
-      ├── a int not null
-      ├── b int not null
-      └── c int not null
 
 exec-ddl
 CREATE TABLE xyz (x INT, y INT, z INT, PRIMARY KEY (x, y, z))
 ----
-TABLE xyz
- ├── x int not null
- ├── y int not null
- ├── z int not null
- └── INDEX primary
-      ├── x int not null
-      ├── y int not null
-      └── z int not null
 
 exec-ddl
 CREATE TABLE abcd (a INT, b INT, c INT, d INT, INDEX ab(a, b) STORING (c, d), INDEX cd(c, d) STORING (a, b))
 ----
-TABLE abcd
- ├── a int
- ├── b int
- ├── c int
- ├── d int
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- ├── INDEX ab
- │    ├── a int
- │    ├── b int
- │    ├── rowid int not null (hidden)
- │    ├── c int (storing)
- │    └── d int (storing)
- └── INDEX cd
-      ├── c int
-      ├── d int
-      ├── rowid int not null (hidden)
-      ├── a int (storing)
-      └── b int (storing)
 
 # --------------------------------------------------
 # Scan operator.

--- a/pkg/sql/opt/xform/testdata/physprops/presentation
+++ b/pkg/sql/opt/xform/testdata/physprops/presentation
@@ -1,21 +1,10 @@
 exec-ddl
 CREATE TABLE a (x INT PRIMARY KEY, y INT)
 ----
-TABLE a
- ├── x int not null
- ├── y int
- └── INDEX primary
-      └── x int not null
 
 exec-ddl
 CREATE TABLE t.b (x INT, y FLOAT)
 ----
-TABLE b
- ├── x int
- ├── y float
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 # Scan operator.
 opt

--- a/pkg/sql/opt/xform/testdata/ruleprops/orderings
+++ b/pkg/sql/opt/xform/testdata/ruleprops/orderings
@@ -3,20 +3,6 @@
 exec-ddl
 CREATE TABLE abc (a INT, b INT, c INT, INDEX (a, b), UNIQUE INDEX (c))
 ----
-TABLE abc
- ├── a int
- ├── b int
- ├── c int
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- ├── INDEX secondary
- │    ├── a int
- │    ├── b int
- │    └── rowid int not null (hidden)
- └── INDEX secondary
-      ├── c int
-      └── rowid int not null (hidden) (storing)
 
 # Scan operator.
 opt
@@ -267,20 +253,6 @@ offset
 exec-ddl
 CREATE TABLE xyz (x INT, y INT, z INT, INDEX(z), UNIQUE INDEX(x,y))
 ----
-TABLE xyz
- ├── x int
- ├── y int
- ├── z int
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- ├── INDEX secondary
- │    ├── z int
- │    └── rowid int not null (hidden)
- └── INDEX secondary
-      ├── x int
-      ├── y int
-      └── rowid int not null (hidden) (storing)
 
 # Join operator.
 opt

--- a/pkg/sql/opt/xform/testdata/rules/combo
+++ b/pkg/sql/opt/xform/testdata/rules/combo
@@ -7,18 +7,6 @@ CREATE TABLE abc
     INDEX ab (a,b) STORING (c)
 )
 ----
-TABLE abc
- ├── a int
- ├── b int
- ├── c int
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- └── INDEX ab
-      ├── a int
-      ├── b int
-      ├── rowid int not null (hidden)
-      └── c int (storing)
 
 exec-ddl
 CREATE TABLE xyz
@@ -29,18 +17,6 @@ CREATE TABLE xyz
     INDEX xy (x,y) STORING (z)
 )
 ----
-TABLE xyz
- ├── x int
- ├── y int
- ├── z int
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- └── INDEX xy
-      ├── x int
-      ├── y int
-      ├── rowid int not null (hidden)
-      └── z int (storing)
 
 # --------------------------------------------------
 # Use exploretrace.

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -6,13 +6,6 @@ CREATE TABLE abc (
   d DECIMAL
 )
 ----
-TABLE abc
- ├── a char not null
- ├── b float
- ├── c bool
- ├── d decimal
- └── INDEX primary
-      └── a char not null
 
 exec-ddl
 CREATE TABLE xyz (
@@ -24,22 +17,6 @@ CREATE TABLE xyz (
   INDEX yy (y)
 )
 ----
-TABLE xyz
- ├── x int not null
- ├── y int
- ├── z float
- ├── INDEX primary
- │    └── x int not null
- ├── INDEX xy
- │    ├── x int not null
- │    └── y int
- ├── INDEX zyx
- │    ├── z float
- │    ├── y int
- │    └── x int not null
- └── INDEX yy
-      ├── y int
-      └── x int not null
 
 exec-ddl
 CREATE TABLE kuvw (
@@ -54,33 +31,6 @@ CREATE TABLE kuvw (
   INDEX w(w) STORING (u,v)
 )
 ----
-TABLE kuvw
- ├── k int not null
- ├── u int
- ├── v int
- ├── w int
- ├── INDEX primary
- │    └── k int not null
- ├── INDEX uvw
- │    ├── u int
- │    ├── v int
- │    ├── w int
- │    └── k int not null
- ├── INDEX wvu
- │    ├── w int
- │    ├── v int
- │    ├── u int
- │    └── k int not null
- ├── INDEX vw
- │    ├── v int
- │    ├── w int
- │    ├── k int not null
- │    └── u int (storing)
- └── INDEX w
-      ├── w int
-      ├── k int not null
-      ├── u int (storing)
-      └── v int (storing)
 
 # --------------------------------------------------
 # ReplaceMinWithLimit

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -8,23 +8,6 @@ CREATE TABLE abc
     INDEX bc (b,c) STORING (a)
 )
 ----
-TABLE abc
- ├── a int
- ├── b int
- ├── c int
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- ├── INDEX ab
- │    ├── a int
- │    ├── b int
- │    ├── rowid int not null (hidden)
- │    └── c int (storing)
- └── INDEX bc
-      ├── b int
-      ├── c int
-      ├── rowid int not null (hidden)
-      └── a int (storing)
 
 exec-ddl
 CREATE TABLE stu
@@ -36,18 +19,6 @@ CREATE TABLE stu
     INDEX uts (u,t,s)
 )
 ----
-TABLE stu
- ├── s int not null
- ├── t int not null
- ├── u int not null
- ├── INDEX primary
- │    ├── s int not null
- │    ├── t int not null
- │    └── u int not null
- └── INDEX uts
-      ├── u int not null
-      ├── t int not null
-      └── s int not null
 
 exec-ddl
 CREATE TABLE xyz
@@ -59,23 +30,6 @@ CREATE TABLE xyz
     INDEX yz (y,z) STORING (x)
 )
 ----
-TABLE xyz
- ├── x int
- ├── y int
- ├── z int
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- ├── INDEX xy
- │    ├── x int
- │    ├── y int
- │    ├── rowid int not null (hidden)
- │    └── z int (storing)
- └── INDEX yz
-      ├── y int
-      ├── z int
-      ├── rowid int not null (hidden)
-      └── x int (storing)
 
 exec-ddl
 CREATE TABLE pqr
@@ -92,32 +46,6 @@ CREATE TABLE pqr
     INDEX ts (t,s)
 )
 ----
-TABLE pqr
- ├── p int not null
- ├── q int
- ├── r int
- ├── s string
- ├── t string
- ├── INDEX primary
- │    └── p int not null
- ├── INDEX q
- │    ├── q int
- │    └── p int not null
- ├── INDEX r
- │    ├── r int
- │    └── p int not null
- ├── INDEX s
- │    ├── s string
- │    ├── p int not null
- │    └── r int (storing)
- ├── INDEX rs
- │    ├── r int
- │    ├── s string
- │    └── p int not null
- └── INDEX ts
-      ├── t string
-      ├── s string
-      └── p int not null
 
 exec-ddl
 CREATE TABLE zz (
@@ -128,18 +56,6 @@ CREATE TABLE zz (
     CONSTRAINT idx_c UNIQUE (c)
 )
 ----
-TABLE zz
- ├── a int not null
- ├── b int
- ├── c int
- ├── INDEX primary
- │    └── a int not null
- ├── INDEX idx_b
- │    ├── b int
- │    └── a int not null
- └── INDEX idx_c
-      ├── c int
-      └── a int not null (storing)
 
 # --------------------------------------------------
 # CommuteJoin
@@ -769,10 +685,6 @@ memo (optimized, ~12KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
 exec-ddl
 CREATE TABLE kfloat (k FLOAT PRIMARY KEY)
 ----
-TABLE kfloat
- ├── k float not null
- └── INDEX primary
-      └── k float not null
 
 memo
 SELECT * FROM abc JOIN kfloat ON a=k
@@ -875,27 +787,10 @@ left-join (merge)
 exec-ddl
 CREATE TABLE abcd (a INT, b INT, c INT, INDEX (a,b))
 ----
-TABLE abcd
- ├── a int
- ├── b int
- ├── c int
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- └── INDEX secondary
-      ├── a int
-      ├── b int
-      └── rowid int not null (hidden)
 
 exec-ddl
 CREATE TABLE small (m INT, n INT)
 ----
-TABLE small
- ├── m int
- ├── n int
- ├── rowid int not null (hidden)
- └── INDEX primary
-      └── rowid int not null (hidden)
 
 exec-ddl
 ALTER TABLE small INJECT STATISTICS '[
@@ -1883,15 +1778,6 @@ CREATE TABLE t5 (
     INVERTED INDEX b_idx(b)
 )
 ----
-TABLE t5
- ├── a int not null
- ├── b jsonb
- ├── c int
- ├── INDEX primary
- │    └── a int not null
- └── INVERTED INDEX b_idx
-      ├── b jsonb
-      └── a int not null
 
 # One path. Should generate a scan constrained on the inverted index.
 opt

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -4,11 +4,6 @@ CREATE TABLE bx (
   x INT
 )
 ----
-TABLE bx
- ├── b int not null
- ├── x int
- └── INDEX primary
-      └── b int not null
 
 exec-ddl
 CREATE TABLE cy (
@@ -16,11 +11,6 @@ CREATE TABLE cy (
   y INT
 )
 ----
-TABLE cy
- ├── c int not null
- ├── y int
- └── INDEX primary
-      └── c int not null
 
 exec-ddl
 CREATE TABLE dz (
@@ -28,11 +18,6 @@ CREATE TABLE dz (
   z INT
 )
 ----
-TABLE dz
- ├── d int not null
- ├── z int
- └── INDEX primary
-      └── d int not null
 
 exec-ddl
 CREATE TABLE abc (
@@ -42,13 +27,6 @@ CREATE TABLE abc (
   d INT
 )
 ----
-TABLE abc
- ├── a int not null
- ├── b int
- ├── c int
- ├── d int
- └── INDEX primary
-      └── a int not null
 
 opt join-limit=3
 SELECT * FROM abc, bx, cy WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
@@ -430,10 +408,6 @@ memo (optimized, ~26KB, required=[presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,
 exec-ddl
 CREATE TABLE a (id INT8 PRIMARY KEY)
 ----
-TABLE a
- ├── id int not null
- └── INDEX primary
-      └── id int not null
 
 opt join-limit=4
 SELECT
@@ -515,10 +489,6 @@ project
 exec-ddl
 CREATE TABLE x (a INT8 PRIMARY KEY)
 ----
-TABLE x
- ├── a int not null
- └── INDEX primary
-      └── a int not null
 
 memo join-limit=4
 SELECT

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -10,24 +10,6 @@ CREATE TABLE a
     INDEX si_idx (s DESC, i) STORING (j)
 )
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── f float
- ├── s string
- ├── j jsonb
- ├── INDEX primary
- │    └── k int not null
- ├── INDEX s_idx
- │    ├── s string
- │    ├── k int not null
- │    ├── i int (storing)
- │    └── f float (storing)
- └── INDEX si_idx
-      ├── s string desc
-      ├── i int
-      ├── k int not null
-      └── j jsonb (storing)
 
 # --------------------------------------------------
 # PushLimitIntoScan
@@ -144,15 +126,6 @@ memo (optimized, ~6KB, required=[presentation: s:4])
 exec-ddl
 CREATE TABLE kuv (k INT PRIMARY KEY, u INT, v INT, INDEX (u))
 ----
-TABLE kuv
- ├── k int not null
- ├── u int
- ├── v int
- ├── INDEX primary
- │    └── k int not null
- └── INDEX secondary
-      ├── u int
-      └── k int not null
 
 opt
 SELECT * FROM kuv ORDER BY u LIMIT 5
@@ -209,25 +182,6 @@ CREATE TABLE abcd (
   UNIQUE INDEX bcd (b,c,d)
 )
 ----
-TABLE abcd
- ├── a int not null
- ├── b int
- ├── c int
- ├── d int
- ├── INDEX primary
- │    └── a int not null
- ├── INDEX b
- │    ├── b int
- │    └── a int not null
- ├── INDEX cd
- │    ├── c int
- │    ├── d int
- │    └── a int not null
- └── INDEX bcd
-      ├── b int
-      ├── c int
-      ├── d int
-      └── a int not null (storing)
 
 opt
 EXPLAIN SELECT * FROM abcd@b WHERE a >= 20 AND a <= 30 ORDER BY b DESC LIMIT 5

--- a/pkg/sql/opt/xform/testdata/rules/manual
+++ b/pkg/sql/opt/xform/testdata/rules/manual
@@ -8,18 +8,6 @@ CREATE TABLE abcde (
     UNIQUE INDEX bc (b, c)
 )
 ----
-TABLE abcde
- ├── a int not null
- ├── b int
- ├── c int
- ├── d int
- ├── e int
- ├── INDEX primary
- │    └── a int not null
- └── INDEX bc
-      ├── b int
-      ├── c int
-      └── a int not null (storing)
 
 # --------------------------------------------------
 # SimplifyRootOrdering

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -11,27 +11,6 @@ CREATE TABLE a
     INVERTED INDEX inv_idx_j (j)
 )
 ----
-TABLE a
- ├── k int not null
- ├── i int
- ├── f float
- ├── s string
- ├── j jsonb
- ├── INDEX primary
- │    └── k int not null
- ├── INDEX s_idx
- │    ├── s string
- │    ├── k int not null
- │    ├── i int (storing)
- │    └── f float (storing)
- ├── INDEX si_idx
- │    ├── s string desc
- │    ├── i int desc
- │    ├── k int not null
- │    └── j jsonb (storing)
- └── INVERTED INDEX inv_idx_j
-      ├── j jsonb
-      └── k int not null
 
 # --------------------------------------------------
 # GenerateIndexScans
@@ -359,25 +338,6 @@ CREATE TABLE abc (
   FAMILY (d)
 )
 ----
-TABLE abc
- ├── a int not null
- ├── b int not null
- ├── c int not null
- ├── d char
- ├── INDEX primary
- │    ├── a int not null
- │    ├── b int not null
- │    └── c int not null
- ├── INDEX bc
- │    ├── b int not null
- │    ├── c int not null
- │    └── a int not null (storing)
- ├── INDEX ba
- │    ├── b int not null
- │    ├── a int not null
- │    └── c int not null
- ├── FAMILY family1 (a, b, c)
- └── FAMILY family2 (d)
 
 memo
 SELECT d FROM abc ORDER BY lower(d)
@@ -519,10 +479,6 @@ memo (optimized, ~5KB, required=[presentation: i:2,k:1])
 exec-ddl
 CREATE TABLE x (s STRING COLLATE en_u_ks_level1 PRIMARY KEY)
 ----
-TABLE x
- ├── s collatedstring{en_u_ks_level1} not null
- └── INDEX primary
-      └── s collatedstring{en_u_ks_level1} not null
 
 opt
 SELECT s FROM x WHERE s < 'hello' COLLATE en_u_ks_level1
@@ -567,20 +523,6 @@ CREATE TABLE "orders" (
   CHECK (region IN ('us-east1', 'us-west1', 'europe-west2'))
 )
 ----
-TABLE orders
- ├── region string not null
- ├── id int not null
- ├── total decimal not null
- ├── created_at timestamp not null
- ├── INDEX primary
- │    ├── region string not null
- │    └── id int not null
- ├── INDEX orders_by_created_at
- │    ├── region string not null
- │    ├── created_at timestamp not null
- │    ├── id int not null
- │    └── total decimal not null (storing)
- └── CHECK (region IN ('us-east1', 'us-west1', 'europe-west2'))
 
 exec-ddl
 ALTER TABLE "orders" INJECT STATISTICS '[
@@ -641,22 +583,6 @@ CREATE TABLE xyz (
   INDEX secondary (y, x),
   INDEX tertiary (z, y, x))
 ----
-TABLE xyz
- ├── x int not null
- ├── y int not null
- ├── z string not null
- ├── INDEX primary
- │    └── x int not null
- ├── INDEX secondary
- │    ├── y int not null
- │    └── x int not null
- ├── INDEX tertiary
- │    ├── z string not null
- │    ├── y int not null
- │    └── x int not null
- ├── CHECK ((x < 10) AND (x > 1))
- ├── CHECK ((y < 10) AND (y > 1))
- └── CHECK (z IN ('first', 'second'))
 
 opt
 SELECT x, y  FROM xyz WHERE x > 5
@@ -699,18 +625,6 @@ CREATE TABLE xy (
   CHECK (y < 10 AND y > 1),
   INDEX secondary (y, x))
 ----
-TABLE xy
- ├── x int
- ├── y int not null
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- ├── INDEX secondary
- │    ├── y int not null
- │    ├── x int
- │    └── rowid int not null (hidden)
- ├── CHECK ((x < 10) AND (x > 1))
- └── CHECK ((y < 10) AND (y > 1))
 
 opt
 SELECT x, y FROM xy WHERE x > 5
@@ -730,15 +644,6 @@ CREATE TABLE null_constraint (
   CHECK (y IN (1, 2, NULL)),
   INDEX index_1 (y))
 ----
-TABLE null_constraint
- ├── y int not null
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- ├── INDEX index_1
- │    ├── y int not null
- │    └── rowid int not null (hidden)
- └── CHECK (y IN (1, 2, NULL))
 
 opt
 SELECT y FROM null_constraint WHERE y > 0
@@ -754,16 +659,6 @@ CREATE TABLE null_constraint_2 (
   CHECK (y < 15),
   INDEX index_1 (y))
 ----
-TABLE null_constraint_2
- ├── y int not null
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- ├── INDEX index_1
- │    ├── y int not null
- │    └── rowid int not null (hidden)
- ├── CHECK ((y IN (1, 2, NULL)) AND (y > 10))
- └── CHECK (y < 15)
 
 opt
 SELECT y FROM null_constraint_2 WHERE y > 0
@@ -780,16 +675,6 @@ CREATE TABLE check_constraint_validity (
  CONSTRAINT "check:unvalidated" CHECK (a < 10),
  CONSTRAINT "check:validated" CHECK (a < 20))
 ----
-TABLE check_constraint_validity
- ├── a int not null
- ├── rowid int not null (hidden)
- ├── INDEX primary
- │    └── rowid int not null (hidden)
- ├── INDEX secondary
- │    ├── a int not null
- │    └── rowid int not null (hidden)
- ├── CHECK (a < 10)
- └── CHECK (a < 20)
 
 opt
 SELECT * FROM check_constraint_validity WHERE a > 6
@@ -806,13 +691,6 @@ CREATE TABLE check_test.alias_test (
   CHECK (check_test.alias_test.a > 4)
 )
 ----
-TABLE alias_test
- ├── a int not null
- ├── INDEX primary
- │    └── a int not null
- ├── CHECK (a > 0)
- ├── CHECK (alias_test.a > 2)
- └── CHECK (check_test.alias_test.a > 4)
 
 opt
 SELECT * FROM check_test.alias_test WHERE a < 10

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -8,20 +8,6 @@ CREATE TABLE a
     UNIQUE INDEX v(v) STORING (u)
 )
 ----
-TABLE a
- ├── k int not null
- ├── u int
- ├── v int
- ├── INDEX primary
- │    └── k int not null
- ├── INDEX u
- │    ├── u int
- │    ├── k int not null
- │    └── v int (storing)
- └── INDEX v
-      ├── v int
-      ├── k int not null (storing)
-      └── u int (storing)
 
 exec-ddl
 CREATE TABLE b
@@ -35,22 +21,6 @@ CREATE TABLE b
     INVERTED INDEX inv_idx(j)
 )
 ----
-TABLE b
- ├── k int not null
- ├── u int
- ├── v int
- ├── j jsonb
- ├── INDEX primary
- │    └── k int not null
- ├── INDEX u
- │    ├── u int
- │    └── k int not null
- ├── INDEX v
- │    ├── v int
- │    └── k int not null (storing)
- └── INVERTED INDEX inv_idx
-      ├── j jsonb
-      └── k int not null
 
 # --------------------------------------------------
 # GenerateConstrainedScans

--- a/pkg/sql/opt/xform/testdata/rules/stats
+++ b/pkg/sql/opt/xform/testdata/rules/stats
@@ -1,34 +1,10 @@
 exec-ddl
 CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT, INDEX b(b), UNIQUE INDEX c(c))
 ----
-TABLE abc
- ├── a int not null
- ├── b int
- ├── c int
- ├── INDEX primary
- │    └── a int not null
- ├── INDEX b
- │    ├── b int
- │    └── a int not null
- └── INDEX c
-      ├── c int
-      └── a int not null (storing)
 
 exec-ddl
 CREATE TABLE xyz (x INT PRIMARY KEY, y INT, z INT, INDEX y(y), UNIQUE INDEX z(z))
 ----
-TABLE xyz
- ├── x int not null
- ├── y int
- ├── z int
- ├── INDEX primary
- │    └── x int not null
- ├── INDEX y
- │    ├── y int
- │    └── x int not null
- └── INDEX z
-      ├── z int
-      └── x int not null (storing)
 
 rulestats
 SELECT * FROM abc JOIN xyz ON a=x

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -935,9 +935,9 @@ func (node *CreateTable) FormatBody(ctx *FmtCtx) {
 	}
 }
 
-// HoistConstraints finds column constraints defined inline with their columns
-// and makes them table-level constraints, stored in n.Defs. For example, the
-// foreign key constraint in
+// HoistConstraints finds column check and foreign key constraints defined
+// inline with their columns and makes them table-level constraints, stored in
+// n.Defs. For example, the foreign key constraint in
 //
 //     CREATE TABLE foo (a INT REFERENCES bar(a))
 //
@@ -960,6 +960,8 @@ func (node *CreateTable) FormatBody(ctx *FmtCtx) {
 // CockroachDB and Postgres, but not necessarily other SQL databases:
 //
 //    CREATE TABLE foo (a INT CHECK (a < b), b INT)
+//
+// Unique constraints are not hoisted.
 //
 func (node *CreateTable) HoistConstraints() {
 	for _, d := range node.Defs {


### PR DESCRIPTION
#### opt: test catalog improvements

This commit makes the following changes to the test catalog:

 - `exec-ddl` now supports `SHOW CREATE` which prints information
   about a table; the information is extended to include
   column default/computed values, inbound foreign keys, zones.

 - we add specific datadriven tests for the test catalog.

 - other `exec-ddl` statements no longer output any information;
   outside of debugging the test catalog itself (for which
   `SHOW CREATE` can be used), this is unnecessary clutter.

This change was motivated by some bugs in the catalog (which will be
fixed in subsequent commits).

Release note: None

#### opt: update tests

Update test files with the catalog changes.

Release note: None

#### opt: fix UNIQUE column handling in test catalog

The test catalog was ignoring a UNIQUE specifier for a column. It now
creates a unique index as expected.

Release note: None

#### opt: fix foreign key issue in test catalog

The test catalog was incorrectly failing when the referenced column is
unique but can be null (in this case the index has the PK as extra key
columns).

Release note: None
