### PR TITLE
storage: use raft learners in replica addition, defaulted off

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -38,6 +38,7 @@
 <tr><td><code>kv.closed_timestamp.target_duration</code></td><td>duration</td><td><code>30s</code></td><td>if nonzero, attempt to provide closed timestamp notifications for timestamps trailing cluster time by approximately this duration</td></tr>
 <tr><td><code>kv.follower_read.target_multiple</code></td><td>float</td><td><code>3</code></td><td>if above 1, encourages the distsender to perform a read against the closest replica if a request is older than kv.closed_timestamp.target_duration * (1 + kv.closed_timestamp.close_fraction * this) less a clock uncertainty interval. This value also is used to create follower_timestamp(). (WARNING: may compromise cluster stability or correctness; do not edit without supervision)</td></tr>
 <tr><td><code>kv.import.batch_size</code></td><td>byte size</td><td><code>32 MiB</code></td><td>the maximum size of the payload in an AddSSTable request (WARNING: may compromise cluster stability or correctness; do not edit without supervision)</td></tr>
+<tr><td><code>kv.learner_replicas.enabled</code></td><td>boolean</td><td><code>false</code></td><td>use learner replicas for replica addition</td></tr>
 <tr><td><code>kv.raft.command.max_size</code></td><td>byte size</td><td><code>64 MiB</code></td><td>maximum size of a raft command</td></tr>
 <tr><td><code>kv.raft_log.disable_synchronization_unsafe</code></td><td>boolean</td><td><code>false</code></td><td>set to true to disable synchronization on Raft log writes to persistent storage. Setting to true risks data loss or data corruption on server crashes. The setting is meant for internal testing only and SHOULD NOT be used in production.</td></tr>
 <tr><td><code>kv.range.backpressure_range_size_multiplier</code></td><td>float</td><td><code>2</code></td><td>multiple of range_max_bytes that a range is allowed to grow to without splitting before writes to that range are blocked, or 0 to disable</td></tr>
@@ -120,6 +121,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>19.1-5</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>19.1-6</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1163,8 +1163,9 @@ func removeDeadReplicas(
 	err = storage.IterateRangeDescriptors(ctx, db, func(desc roachpb.RangeDescriptor) (bool, error) {
 		hasSelf := false
 		numDeadPeers := 0
-		numReplicas := len(desc.Replicas().Unwrap())
-		for _, rep := range desc.Replicas().Unwrap() {
+		allReplicas := desc.Replicas().All()
+		numReplicas := len(allReplicas)
+		for _, rep := range allReplicas {
 			if rep.StoreID == storeIdent.StoreID {
 				hasSelf = true
 			}

--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -487,8 +487,10 @@ func (ds *DistSender) getDescriptor(
 func (ds *DistSender) sendSingleRange(
 	ctx context.Context, ba roachpb.BatchRequest, desc *roachpb.RangeDescriptor, withCommit bool,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
-	// Try to send the call.
-	replicas := NewReplicaSlice(ds.gossip, desc)
+	// Try to send the call. Learner replicas won't serve reads/writes, so send
+	// only to the `Voters` replicas. This is just an optimization to save a
+	// network hop, everything would still work if we had `All` here.
+	replicas := NewReplicaSlice(ds.gossip, desc.Replicas().Voters())
 
 	// If this request needs to go to a lease holder and we know who that is, move
 	// it to the front.

--- a/pkg/kv/dist_sender_rangefeed.go
+++ b/pkg/kv/dist_sender_rangefeed.go
@@ -222,7 +222,10 @@ func (ds *DistSender) singleRangeFeed(
 	if ds.rpcContext != nil {
 		latencyFn = ds.rpcContext.RemoteClocks.Latency
 	}
-	replicas := NewReplicaSlice(ds.gossip, desc)
+	// Learner replicas won't serve reads/writes, so send only to the `Voters`
+	// replicas. This is just an optimization to save a network hop, everything
+	// would still work if we had `All` here.
+	replicas := NewReplicaSlice(ds.gossip, desc.Replicas().Voters())
 	replicas.OptimizeReplicaOrder(ds.getNodeDescriptor(), latencyFn)
 
 	transport, err := ds.transportFactory(SendOptions{}, ds.nodeDialer, replicas)

--- a/pkg/kv/replica_slice.go
+++ b/pkg/kv/replica_slice.go
@@ -42,12 +42,12 @@ type ReplicaSlice []ReplicaInfo
 // NewReplicaSlice creates a ReplicaSlice from the replicas listed in the range
 // descriptor and using gossip to lookup node descriptors. Replicas on nodes
 // that are not gossiped are omitted from the result.
-func NewReplicaSlice(gossip *gossip.Gossip, desc *roachpb.RangeDescriptor) ReplicaSlice {
+func NewReplicaSlice(gossip *gossip.Gossip, replicas []roachpb.ReplicaDescriptor) ReplicaSlice {
 	if gossip == nil {
 		return nil
 	}
-	replicas := make(ReplicaSlice, 0, len(desc.Replicas().Unwrap()))
-	for _, r := range desc.Replicas().Unwrap() {
+	rs := make(ReplicaSlice, 0, len(replicas))
+	for _, r := range replicas {
 		nd, err := gossip.GetNodeDescriptor(r.NodeID)
 		if err != nil {
 			if log.V(1) {
@@ -55,12 +55,12 @@ func NewReplicaSlice(gossip *gossip.Gossip, desc *roachpb.RangeDescriptor) Repli
 			}
 			continue
 		}
-		replicas = append(replicas, ReplicaInfo{
+		rs = append(rs, ReplicaInfo{
 			ReplicaDescriptor: r,
 			NodeDesc:          nd,
 		})
 	}
-	return replicas
+	return rs
 }
 
 // ReplicaSlice implements shuffle.Interface.

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -270,6 +270,20 @@ func (r ReplicationTarget) String() string {
 	return fmt.Sprintf("n%d,s%d", r.NodeID, r.StoreID)
 }
 
+// ReplicaTypeLearner returns a ReplicaType_LEARNER pointer suitable for use in
+// a nullable proto field.
+func ReplicaTypeLearner() *ReplicaType {
+	t := ReplicaType_LEARNER
+	return &t
+}
+
+// ReplicaTypeVoter returns a ReplicaType_VOTER pointer suitable for use in a
+// nullable proto field.
+func ReplicaTypeVoter() *ReplicaType {
+	t := ReplicaType_VOTER
+	return &t
+}
+
 func (r ReplicaDescriptor) String() string {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "(n%d,s%d):", r.NodeID, r.StoreID)

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -220,7 +220,7 @@ func (r *RangeDescriptor) Validate() error {
 		return errors.Errorf("NextReplicaID must be non-zero")
 	}
 	seen := map[ReplicaID]struct{}{}
-	for i, rep := range r.Replicas().Unwrap() {
+	for i, rep := range r.Replicas().All() {
 		if err := rep.Validate(); err != nil {
 			return errors.Errorf("replica %d is invalid: %s", i, err)
 		}
@@ -247,8 +247,8 @@ func (r *RangeDescriptor) String() string {
 	}
 	buf.WriteString(" [")
 
-	if len(r.Replicas().Unwrap()) > 0 {
-		for i, rep := range r.Replicas().Unwrap() {
+	if allReplicas := r.Replicas().All(); len(allReplicas) > 0 {
+		for i, rep := range allReplicas {
 			if i > 0 {
 				buf.WriteString(", ")
 			}

--- a/pkg/roachpb/metadata_replicas.go
+++ b/pkg/roachpb/metadata_replicas.go
@@ -59,7 +59,7 @@ func (d ReplicaDescriptors) Unwrap() []ReplicaDescriptor {
 }
 
 // All returns every replica in the set, including both voter replicas and
-// learner replicas.
+// learner replicas. Voter replicas are ordered first in the returned slice.
 func (d ReplicaDescriptors) All() []ReplicaDescriptor {
 	return d.wrapped
 }

--- a/pkg/roachpb/metadata_replicas.go
+++ b/pkg/roachpb/metadata_replicas.go
@@ -76,6 +76,77 @@ func (d ReplicaDescriptors) Voters() []ReplicaDescriptor {
 }
 
 // Learners returns the learner replicas in the set.
+//
+// A learner is a participant in a raft group that accepts messages but doesn't
+// vote. This means it doesn't affect raft quorum and thus doesn't affect the
+// fragility of the range, even if it's very far behind or many learners are
+// down.
+//
+// At the time of writing, learners are used in CockroachDB as an interim state
+// while adding a replica. A learner replica is added to the range via raft
+// ConfChange, a raft snapshot (of type LEARNER) is sent to catch it up, and
+// then a second ConfChange promotes it to a full replica.
+//
+// This means that learners are currently always expected to have a short
+// lifetime, approximately the time it takes to send a snapshot. Ideas have been
+// kicked around to use learners with follower reads, which could be a cheap way
+// to allow many geographies to have local reads without affecting write
+// latencies. If implemented, these learners would have long lifetimes.
+//
+// For simplicity, CockroachDB treats learner replicas the same as voter
+// replicas as much as possible, but there are a few exceptions:
+//
+// - Learner replicas are not considered when calculating quorum size, and thus
+//   do not affect the computation of which ranges are under-replicated for
+//   upreplication/alerting/debug/etc purposes. Ditto for over-replicated.
+// - Learner replicas cannot become raft leaders, so we also don't allow them to
+//   become leaseholders. As a result, DistSender and the various oracles don't
+//   try to send them traffic.
+// - The raft snapshot queue does not send snapshots to learners for reasons
+//   described below.
+// - Merges won't run while a learner replica is present.
+//
+// Replicas are now added in two ConfChange transactions. The first creates the
+// learner and the second promotes it to a voter. If the node that is
+// coordinating this dies in the middle, we're left with an orphaned learner.
+// For this reason, the replicate queue always first removes any learners it
+// sees before doing anything else. We could instead try to finish off the
+// learner snapshot and promotion, but this is more complicated and it's not yet
+// clear the efficiency win is worth it.
+//
+// This introduces some rare races between the replicate queue and
+// AdminChangeReplicas or if a range's lease is moved to a new owner while the
+// old leaseholder is still processing it in the replicate queue. These races
+// are handled by retrying if a learner disappears during the
+// snapshot/promotion.
+//
+// If the coordinator otherwise encounters an error while sending the learner
+// snapshot or promoting it (which can happen for a number of reasons, including
+// the node getting the learner going away), it tries to clean up after itself
+// by rolling back the addition of the learner.
+//
+// There is another race between the learner snapshot being sent and the raft
+// snapshot queue happening to check the replica at the same time, also sending
+// it a snapshot. This is safe but wasteful, so the raft snapshot queue won't
+// try to send snapshots to learners.
+//
+// Merges are blocked if either side has a learner (to avoid working out the
+// edge cases) but it's historically turned out to be a bad idea to get in the
+// way of splits, so we allow them even when some of the replicas are learners.
+// This orphans a learner on each side of the split (the original coordinator
+// will not be able to finish either of them), but the replication queue will
+// eventually clean them up.
+//
+// Learner replicas don't affect quorum but they do affect the system in other
+// ways. The most obvious way is that the leader sends them the raft traffic it
+// would send to any follower, consuming resources. More surprising is that once
+// the learner has received a snapshot, it's considered by the quota pool that
+// prevents the raft leader from getting too far ahead of the followers. This is
+// because a learner (especially one that already has a snapshot) is expected to
+// very soon be a voter, so we treat it like one. However, it means a slow
+// learner can slow down regular traffic, which is possibly counterintuitive.
+//
+// For some related mega-comments, see Replica.sendSnapshot.
 func (d ReplicaDescriptors) Learners() []ReplicaDescriptor {
 	// Note that the wrapped replicas are sorted first by type.
 	for i := range d.wrapped {
@@ -85,8 +156,6 @@ func (d ReplicaDescriptors) Learners() []ReplicaDescriptor {
 	}
 	return nil
 }
-
-var _, _ = ReplicaDescriptors.All, ReplicaDescriptors.Learners
 
 // AsProto returns the protobuf representation of these replicas, suitable for
 // setting the InternalReplicas field of a RangeDescriptor. When possible the

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -683,7 +683,7 @@ func (s *adminServer) statsForSpan(
 		if err := kv.Value.GetProto(&rng); err != nil {
 			return nil, s.serverError(err)
 		}
-		for _, repl := range rng.Replicas().Unwrap() {
+		for _, repl := range rng.Replicas().All() {
 			nodeIDs[repl.NodeID] = struct{}{}
 		}
 	}

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1125,7 +1125,7 @@ func (s *statusServer) RaftDebug(
 			desc := node.Range.State.Desc
 			// Check for whether replica should be GCed.
 			containsNode := false
-			for _, replica := range desc.Replicas().Unwrap() {
+			for _, replica := range desc.Replicas().All() {
 				if replica.NodeID == node.NodeID {
 					containsNode = true
 				}

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -40,6 +40,7 @@ const (
 	VersionStickyBit
 	VersionParallelCommits
 	VersionGenerationComparable
+	VersionLearnerReplicas
 
 	// Add new versions here (step one of two).
 
@@ -482,6 +483,11 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// VersionGenerationComparable is https://github.com/cockroachdb/cockroach/pull/38334.
 		Key:     VersionGenerationComparable,
 		Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 5},
+	},
+	{
+		// VersionLearnerReplicas is https://github.com/cockroachdb/cockroach/pull/38149.
+		Key:     VersionLearnerReplicas,
+		Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 6},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/settings/cluster/versionkey_string.go
+++ b/pkg/settings/cluster/versionkey_string.go
@@ -17,11 +17,12 @@ func _() {
 	_ = x[VersionStickyBit-6]
 	_ = x[VersionParallelCommits-7]
 	_ = x[VersionGenerationComparable-8]
+	_ = x[VersionLearnerReplicas-9]
 }
 
-const _VersionKey_name = "Version2_1VersionUnreplicatedRaftTruncatedStateVersionSideloadedStorageNoReplicaIDVersion19_1VersionStart19_2VersionQueryTxnTimestampVersionStickyBitVersionParallelCommitsVersionGenerationComparable"
+const _VersionKey_name = "Version2_1VersionUnreplicatedRaftTruncatedStateVersionSideloadedStorageNoReplicaIDVersion19_1VersionStart19_2VersionQueryTxnTimestampVersionStickyBitVersionParallelCommitsVersionGenerationComparableVersionLearnerReplicas"
 
-var _VersionKey_index = [...]uint8{0, 10, 47, 82, 93, 109, 133, 149, 171, 198}
+var _VersionKey_index = [...]uint8{0, 10, 47, 82, 93, 109, 133, 149, 171, 198, 220}
 
 func (i VersionKey) String() string {
 	if i < 0 || i >= VersionKey(len(_VersionKey_index)-1) {

--- a/pkg/sql/ambiguous_commit_test.go
+++ b/pkg/sql/ambiguous_commit_test.go
@@ -158,7 +158,7 @@ func TestAmbiguousCommit(t *testing.T) {
 		tableStartKey.Store(keys.MakeTablePrefix(tableID))
 
 		// Wait for new table to split & replication.
-		if err := tc.WaitForSplitAndReplication(tableStartKey.Load().([]byte)); err != nil {
+		if err := tc.WaitForSplitAndInitialization(tableStartKey.Load().([]byte)); err != nil {
 			t.Fatal(err)
 		}
 

--- a/pkg/sql/distsqlplan/replicaoracle/oracle.go
+++ b/pkg/sql/distsqlplan/replicaoracle/oracle.go
@@ -268,11 +268,15 @@ func (o *binPackingOracle) ChoosePreferredReplica(
 // is available in gossip. If no nodes are available, a RangeUnavailableError is
 // returned.
 func replicaSliceOrErr(desc roachpb.RangeDescriptor, gsp *gossip.Gossip) (kv.ReplicaSlice, error) {
-	replicas := kv.NewReplicaSlice(gsp, &desc)
+	// Learner replicas won't serve reads/writes, so send only to the `Voters`
+	// replicas. This is just an optimization to save a network hop, everything
+	// would still work if we had `All` here.
+	voterReplicas := desc.Replicas().Voters()
+	replicas := kv.NewReplicaSlice(gsp, voterReplicas)
 	if len(replicas) == 0 {
 		// We couldn't get node descriptors for any replicas.
 		var nodeIDs []roachpb.NodeID
-		for _, r := range desc.Replicas().Unwrap() {
+		for _, r := range voterReplicas {
 			nodeIDs = append(nodeIDs, r.NodeID)
 		}
 		return kv.ReplicaSlice{}, sqlbase.NewRangeUnavailableError(

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -207,15 +207,15 @@ SELECT * FROM crdb_internal.zones WHERE false
 ----
 zone_id  zone_name cli_specifier  config_yaml  config_sql  config_protobuf
 
-query ITTTTTTTTTT colnames
+query ITTTTTTTTTTT colnames
 SELECT * FROM crdb_internal.ranges WHERE range_id < 0
 ----
-range_id  start_key  start_pretty  end_key  end_pretty  database_name  table_name  index_name  replicas  split_enforced_until  lease_holder
+range_id  start_key  start_pretty  end_key  end_pretty  database_name  table_name  index_name  replicas  learner_replicas  split_enforced_until  lease_holder
 
-query ITTTTTTTTT colnames
+query ITTTTTTTTTT colnames
 SELECT * FROM crdb_internal.ranges_no_leases WHERE range_id < 0
 ----
-range_id  start_key  start_pretty  end_key  end_pretty  database_name  table_name  index_name  replicas  split_enforced_until
+range_id  start_key  start_pretty  end_key  end_pretty  database_name  table_name  index_name  replicas  learner_replicas  split_enforced_until
 
 statement ok
 INSERT INTO system.zones (id, config) VALUES

--- a/pkg/storage/batcheval/cmd_lease_request.go
+++ b/pkg/storage/batcheval/cmd_lease_request.go
@@ -32,9 +32,25 @@ func init() {
 func RequestLease(
 	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
+	// When returning an error from this method, must always return a
+	// newFailedLeaseTrigger() to satisfy stats.
 	args := cArgs.Args.(*roachpb.RequestLeaseRequest)
-	// When returning an error from this method, must always return
-	// a newFailedLeaseTrigger() to satisfy stats.
+
+	// For now, don't allow replicas of type LEARNER to be leaseholders. There's
+	// no reason this wouldn't work in principle, but it seems inadvisable. In
+	// particular, learners can't become raft leaders, so we wouldn't be able to
+	// co-locate the leaseholder + raft leader, which is going to affect tail
+	// latencies. Additionally, as of the time of writing, learner replicas are
+	// only used for a short time in replica addition, so it's not worth working
+	// out the edge cases. If we decide to start using long-lived learners at some
+	// point, that math may change.
+	//
+	// If this check is removed at some point, the filtering of learners on the
+	// sending side would have to be removed as well.
+	if err := checkNotLearnerReplica(cArgs.EvalCtx); err != nil {
+		return newFailedLeaseTrigger(false /* isTransfer */), err
+	}
+
 	prevLease, _ := cArgs.EvalCtx.GetLease()
 
 	rErr := &roachpb.LeaseRejectedError{

--- a/pkg/storage/batcheval/cmd_lease_test.go
+++ b/pkg/storage/batcheval/cmd_lease_test.go
@@ -16,9 +16,11 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
 )
 
 // TestLeaseTransferWithPipelinedWrite verifies that pipelined writes
@@ -103,4 +105,33 @@ func TestLeaseTransferWithPipelinedWrite(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestLeaseCommandLearnerReplica(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	const voterStoreID, learnerStoreID roachpb.StoreID = 1, 2
+	replicas := []roachpb.ReplicaDescriptor{
+		{StoreID: voterStoreID, Type: roachpb.ReplicaTypeVoter()},
+		{StoreID: learnerStoreID, Type: roachpb.ReplicaTypeLearner()},
+	}
+	desc := roachpb.RangeDescriptor{}
+	desc.SetReplicas(roachpb.MakeReplicaDescriptors(&replicas))
+	cArgs := CommandArgs{
+		EvalCtx: &mockEvalCtx{
+			storeID: learnerStoreID,
+			desc:    &desc,
+		},
+		Args: &roachpb.TransferLeaseRequest{},
+	}
+
+	// Learners are not allowed to become leaseholders for now, see the comments
+	// in TransferLease and RequestLease.
+	_, err := TransferLease(ctx, nil, cArgs, nil)
+	require.EqualError(t, err, `cannot transfer lease to replica of type LEARNER`)
+
+	cArgs.Args = &roachpb.RequestLeaseRequest{}
+	_, err = RequestLease(ctx, nil, cArgs, nil)
+	require.EqualError(t, err, `cannot transfer lease to replica of type LEARNER`)
 }

--- a/pkg/storage/batcheval/cmd_lease_transfer.go
+++ b/pkg/storage/batcheval/cmd_lease_transfer.go
@@ -31,10 +31,25 @@ func init() {
 func TransferLease(
 	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
-	args := cArgs.Args.(*roachpb.TransferLeaseRequest)
-
 	// When returning an error from this method, must always return
 	// a newFailedLeaseTrigger() to satisfy stats.
+	args := cArgs.Args.(*roachpb.TransferLeaseRequest)
+
+	// For now, don't allow replicas of type LEARNER to be leaseholders. There's
+	// no reason this wouldn't work in principle, but it seems inadvisable. In
+	// particular, learners can't become raft leaders, so we wouldn't be able to
+	// co-locate the leaseholder + raft leader, which is going to affect tail
+	// latencies. Additionally, as of the time of writing, learner replicas are
+	// only used for a short time in replica addition, so it's not worth working
+	// out the edge cases. If we decide to start using long-lived learners at some
+	// point, that math may change.
+	//
+	// If this check is removed at some point, the filtering of learners on the
+	// sending side would have to be removed as well.
+	if err := checkNotLearnerReplica(cArgs.EvalCtx); err != nil {
+		return newFailedLeaseTrigger(true /* isTransfer */), err
+	}
+
 	prevLease, _ := cArgs.EvalCtx.GetLease()
 	if log.V(2) {
 		log.Infof(ctx, "lease transfer: prev lease: %+v, new lease: %+v", prevLease, args.Lease)

--- a/pkg/storage/batcheval/cmd_resolve_intent_test.go
+++ b/pkg/storage/batcheval/cmd_resolve_intent_test.go
@@ -34,6 +34,7 @@ import (
 type mockEvalCtx struct {
 	clusterSettings  *cluster.Settings
 	desc             *roachpb.RangeDescriptor
+	storeID          roachpb.StoreID
 	clock            *hlc.Clock
 	stats            enginepb.MVCCStats
 	qps              float64
@@ -74,7 +75,7 @@ func (m *mockEvalCtx) NodeID() roachpb.NodeID {
 	panic("unimplemented")
 }
 func (m *mockEvalCtx) StoreID() roachpb.StoreID {
-	panic("unimplemented")
+	return m.storeID
 }
 func (m *mockEvalCtx) GetRangeID() roachpb.RangeID {
 	return m.desc.RangeID

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -1326,7 +1326,7 @@ func TestLeaseInfoRequest(t *testing.T) {
 	// right answer immediately, since the old holder has definitely applied the
 	// transfer before TransferRangeLease returned.
 	leaseHolderReplica := LeaseInfo(t, kvDB0, rangeDesc, roachpb.INCONSISTENT).Lease.Replica
-	if leaseHolderReplica != replicas[1] {
+	if !leaseHolderReplica.Equal(replicas[1]) {
 		t.Fatalf("lease holder should be replica %+v, but is: %+v",
 			replicas[1], leaseHolderReplica)
 	}
@@ -1339,7 +1339,7 @@ func TestLeaseInfoRequest(t *testing.T) {
 		// unaware of the new lease and so the request might bounce around for a
 		// while (see #8816).
 		leaseHolderReplica = LeaseInfo(t, kvDB1, rangeDesc, roachpb.INCONSISTENT).Lease.Replica
-		if leaseHolderReplica != replicas[1] {
+		if !leaseHolderReplica.Equal(replicas[1]) {
 			return errors.Errorf("lease holder should be replica %+v, but is: %+v",
 				replicas[1], leaseHolderReplica)
 		}
@@ -1378,7 +1378,7 @@ func TestLeaseInfoRequest(t *testing.T) {
 	resp := *(reply.(*roachpb.LeaseInfoResponse))
 	leaseHolderReplica = resp.Lease.Replica
 
-	if leaseHolderReplica != replicas[2] {
+	if !leaseHolderReplica.Equal(replicas[2]) {
 		t.Fatalf("lease holder should be replica %s, but is: %s", replicas[2], leaseHolderReplica)
 	}
 

--- a/pkg/storage/consistency_queue.go
+++ b/pkg/storage/consistency_queue.go
@@ -82,7 +82,7 @@ func (q *consistencyQueue) shouldQueue(
 	}
 	// Check if all replicas are live. Some tests run without a NodeLiveness configured.
 	if repl.store.cfg.NodeLiveness != nil {
-		for _, rep := range repl.Desc().Replicas().Unwrap() {
+		for _, rep := range repl.Desc().Replicas().All() {
 			if live, err := repl.store.cfg.NodeLiveness.IsLive(rep.NodeID); err != nil {
 				log.VErrEventf(ctx, 3, "node %d liveness failed: %s", rep.NodeID, err)
 				return false, 0

--- a/pkg/storage/intentresolver/intent_resolver.go
+++ b/pkg/storage/intentresolver/intent_resolver.go
@@ -607,7 +607,7 @@ func (ir *IntentResolver) CleanupTxnIntentsAsync(
 			intents := roachpb.AsIntents(et.Txn.IntentSpans, &et.Txn)
 			if err := ir.cleanupFinishedTxnIntents(ctx, rangeID, &et.Txn, intents, now, et.Poison, nil); err != nil {
 				if ir.every.ShouldLog() {
-					log.Warningf(ctx, "failed to cleanup transaction intents: %+v", err)
+					log.Warningf(ctx, "failed to cleanup transaction intents: %v", err)
 				}
 			}
 		}); err != nil {
@@ -815,7 +815,7 @@ func (ir *IntentResolver) cleanupFinishedTxnIntents(
 			}
 			if err != nil {
 				if ir.every.ShouldLog() {
-					log.Warningf(ctx, "failed to gc transaction record: %+v", err)
+					log.Warningf(ctx, "failed to gc transaction record: %v", err)
 				}
 			}
 		})

--- a/pkg/storage/raft_snapshot_queue.go
+++ b/pkg/storage/raft_snapshot_queue.go
@@ -65,8 +65,15 @@ func (rq *raftSnapshotQueue) shouldQueue(
 	// If a follower needs a snapshot, enqueue at the highest priority.
 	if status := repl.RaftStatus(); status != nil {
 		// raft.Status.Progress is only populated on the Raft group leader.
-		for _, p := range status.Progress {
+		for id, p := range status.Progress {
 			if p.State == tracker.StateSnapshot {
+				// We refuse to send a snapshot of type RAFT to a learner for reasons
+				// described in processRaftSnapshot, so don't bother queueing.
+				for _, r := range repl.Desc().Replicas().Learners() {
+					if r.ReplicaID == roachpb.ReplicaID(id) {
+						continue
+					}
+				}
 				if log.V(2) {
 					log.Infof(ctx, "raft snapshot needed, enqueuing")
 				}
@@ -105,6 +112,21 @@ func (rq *raftSnapshotQueue) processRaftSnapshot(
 	if !ok {
 		return errors.Errorf("%s: replica %d not present in %v", repl, id, desc.Replicas())
 	}
+
+	// A learner replica is either getting a snapshot of type LEARNER by the node
+	// that's adding it or it's been orphaned and it's about to be cleaned up by
+	// the replicate queue. Either way, no point in also sending it a snapshot of
+	// type RAFT.
+	//
+	// TODO(dan): Reconsider this. If the learner coordinator fails before sending
+	// it a snap, then until the replication queue collects it, any proposals sent
+	// to it will get stuck indefinitely. At the moment, nothing should be sending
+	// it such a proposal, but this is brittle and could change easily.
+	if repDesc.GetType() == roachpb.ReplicaType_LEARNER {
+		log.Eventf(ctx, "not sending snapshot type RAFT to learner: %s", repDesc)
+		return nil
+	}
+
 	err := repl.sendSnapshot(ctx, repDesc, SnapshotRequest_RAFT, SnapshotRequest_RECOVERY)
 
 	// NB: if the snapshot fails because of an overlapping replica on the

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -727,12 +727,14 @@ func (r *Replica) GetGCThreshold() hlc.Timestamp {
 	return *r.mu.state.GCThreshold
 }
 
+// maxReplicaID returns the maximum ReplicaID of any replica, including voters
+// and learners.
 func maxReplicaID(desc *roachpb.RangeDescriptor) roachpb.ReplicaID {
 	if desc == nil || !desc.IsInitialized() {
 		return 0
 	}
 	var maxID roachpb.ReplicaID
-	for _, repl := range desc.Replicas().Unwrap() {
+	for _, repl := range desc.Replicas().All() {
 		if repl.ReplicaID > maxID {
 			maxID = repl.ReplicaID
 		}
@@ -904,7 +906,9 @@ func (r *Replica) State() storagepb.RangeInfo {
 	}
 	ri.RangeMaxBytes = *r.mu.zone.RangeMaxBytes
 	if desc := ri.ReplicaState.Desc; desc != nil {
-		for _, replDesc := range desc.Replicas().Unwrap() {
+		// Learner replicas don't serve follower reads, but they still receive
+		// closed timestamp updates, so include them here.
+		for _, replDesc := range desc.Replicas().All() {
 			r.store.cfg.ClosedTimestamp.Storage.VisitDescending(replDesc.NodeID, func(e ctpb.Entry) (done bool) {
 				mlai, found := e.MLAI[r.RangeID]
 				if !found {

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
@@ -34,12 +35,21 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/logtags"
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"go.etcd.io/etcd/raft"
 	"go.etcd.io/etcd/raft/raftpb"
 	"go.etcd.io/etcd/raft/tracker"
 )
+
+// useLearnerReplicas specifies whether to use learner replicas for replica
+// addition or whether to fall back to the previous method of a preemptive
+// snapshot followed by going straight to a voter replica.
+var useLearnerReplicas = settings.RegisterBoolSetting(
+	"kv.learner_replicas.enabled",
+	"use learner replicas for replica addition",
+	false)
 
 // AdminSplit divides the range into into two ranges using args.SplitKey.
 func (r *Replica) AdminSplit(
@@ -849,18 +859,194 @@ func (r *Replica) ChangeReplicas(
 	reason storagepb.RangeLogEventReason,
 	details string,
 ) (updatedDesc *roachpb.RangeDescriptor, _ error) {
-	return r.changeReplicas(ctx, changeType, target, desc, SnapshotRequest_REBALANCE, reason, details)
+	if desc == nil {
+		return nil, errors.Errorf("%s: the current RangeDescriptor must not be nil", r)
+	}
+
+	switch changeType {
+	case roachpb.ADD_REPLICA:
+		return r.addReplica(ctx, target, desc, SnapshotRequest_REBALANCE, reason, details)
+	case roachpb.REMOVE_REPLICA:
+		return r.removeReplica(ctx, target, desc, SnapshotRequest_REBALANCE, reason, details)
+	default:
+		return nil, errors.Errorf(`unknown change type: %s`, changeType)
+	}
 }
 
-func (r *Replica) changeReplicas(
+func (r *Replica) addReplica(
 	ctx context.Context,
-	changeType roachpb.ReplicaChangeType,
 	target roachpb.ReplicationTarget,
 	desc *roachpb.RangeDescriptor,
 	priority SnapshotRequest_Priority,
 	reason storagepb.RangeLogEventReason,
 	details string,
-) (_ *roachpb.RangeDescriptor, _ error) {
+) (*roachpb.RangeDescriptor, error) {
+	for _, rDesc := range desc.Replicas().All() {
+		if rDesc.NodeID == target.NodeID {
+			// Two replicas from the same range are not allowed on the same node, even
+			// in different stores.
+			if rDesc.StoreID != target.StoreID {
+				return nil, errors.Errorf("%s: unable to add replica %v; node already has a replica", r, target)
+			}
+
+			// Looks like we found a replica with the same store and node id. If the
+			// replica is already a learner, then either some previous leaseholder was
+			// trying to add it with the learner+snapshot+voter cycle and got
+			// interrupted or else we hit a race between the replicate queue and
+			// AdminChangeReplicas.
+			if rDesc.GetType() == roachpb.ReplicaType_LEARNER {
+				return nil, errors.Errorf(
+					"%s: unable to add replica %v which is already present as a learner", r, target)
+			}
+
+			// Otherwise, we already had a full voter replica. Can't add another to
+			// this store.
+			return nil, errors.Errorf("%s: unable to add replica %v which is already present", r, target)
+		}
+	}
+
+	settings := r.ClusterSettings()
+	useLearners := useLearnerReplicas.Get(&settings.SV)
+	useLearners = useLearners && settings.Version.IsActive(cluster.VersionLearnerReplicas)
+	if !useLearners {
+		return r.addReplicaLegacyPreemptiveSnapshot(ctx, target, desc, priority, reason, details)
+	}
+
+	// First add the replica as a raft learner. This means it accepts raft traffic
+	// (so it can catch up) but doesn't vote (so it doesn't affect quorum and thus
+	// doesn't introduce fragility into the system). For details see
+	_ = roachpb.ReplicaDescriptors.Learners
+	learnerDesc, err := addLearnerReplica(ctx, r.store, desc, target, reason, details)
+	if err != nil {
+		return nil, err
+	}
+
+	// Now move it to be a full voter (waiting on it to get a raft snapshot first,
+	// so it's not immediately way behind).
+	voterDesc, err := r.promoteLearnerReplicaToVoter(ctx, learnerDesc, target, priority, reason, details)
+	if err != nil {
+		// Don't leave a learner replica lying around if we didn't succeed in
+		// promoting it to a voter.
+		r.rollbackLearnerReplica(ctx, learnerDesc, target, reason, details)
+		return nil, err
+	}
+	return voterDesc, nil
+}
+
+func addLearnerReplica(
+	ctx context.Context,
+	store *Store,
+	desc *roachpb.RangeDescriptor,
+	target roachpb.ReplicationTarget,
+	reason storagepb.RangeLogEventReason,
+	details string,
+) (*roachpb.RangeDescriptor, error) {
+	newDesc := *desc
+	newDesc.SetReplicas(desc.Replicas().DeepCopy())
+	replDesc := roachpb.ReplicaDescriptor{
+		NodeID:    target.NodeID,
+		StoreID:   target.StoreID,
+		ReplicaID: desc.NextReplicaID,
+		Type:      roachpb.ReplicaTypeLearner(),
+	}
+	newDesc.NextReplicaID++
+	newDesc.AddReplica(replDesc)
+	err := execChangeReplicasTxn(
+		ctx, store, roachpb.ADD_REPLICA, desc, replDesc, &newDesc, reason, details,
+	)
+	return &newDesc, err
+}
+
+func (r *Replica) promoteLearnerReplicaToVoter(
+	ctx context.Context,
+	desc *roachpb.RangeDescriptor,
+	target roachpb.ReplicationTarget,
+	priority SnapshotRequest_Priority,
+	reason storagepb.RangeLogEventReason,
+	details string,
+) (*roachpb.RangeDescriptor, error) {
+	// TODO(dan): We allow ranges with learner replicas to split, so in theory
+	// this may want to detect that and retry, sending a snapshot and promoting
+	// both sides.
+
+	newReplicas := desc.Replicas().DeepCopy().All()
+	for i, rDesc := range newReplicas {
+		if rDesc.NodeID != target.NodeID || rDesc.StoreID != target.StoreID {
+			continue
+		}
+		if rDesc.GetType() != roachpb.ReplicaType_LEARNER {
+			return nil, errors.Errorf(`%s: cannot promote replica of type %s`, r, rDesc.Type)
+		}
+		rDesc.Type = roachpb.ReplicaTypeVoter()
+		newReplicas[i] = rDesc
+
+		// Note that raft snapshot queue refuses to send snapshots, so this is the
+		// only one a learner can get.
+		if err := r.sendSnapshot(ctx, rDesc, SnapshotRequest_LEARNER, priority); err != nil {
+			return nil, err
+		}
+
+		if fn := r.store.cfg.TestingKnobs.ReplicaAddStopAfterLearnerSnapshot; fn != nil {
+			if fn() {
+				return desc, nil
+			}
+		}
+
+		updatedDesc := *desc
+		updatedDesc.SetReplicas(roachpb.MakeReplicaDescriptors(&newReplicas))
+		err := execChangeReplicasTxn(ctx, r.store, roachpb.ADD_REPLICA, desc, rDesc, &updatedDesc, reason, details)
+		return &updatedDesc, err
+	}
+	return nil, errors.Errorf(`%s: could not find replica to promote %s`, r, target)
+}
+
+func (r *Replica) rollbackLearnerReplica(
+	ctx context.Context,
+	desc *roachpb.RangeDescriptor,
+	target roachpb.ReplicationTarget,
+	reason storagepb.RangeLogEventReason,
+	details string,
+) {
+	newDesc := *desc
+	newDesc.SetReplicas(desc.Replicas().DeepCopy())
+	replDesc, ok := newDesc.RemoveReplica(target.NodeID, target.StoreID)
+	if !ok {
+		// This is a programming error if it happens. Why are we rolling back
+		// something that's not present?
+		log.Warningf(ctx, "failed to rollback learner %s, missing from descriptor %s", target, desc)
+		return
+	}
+
+	// If (for example) the promotion failed because of a context deadline
+	// exceeded, we do still want to clean up after ourselves, so always use a new
+	// context (but with the old tags and with some timeout to save this from
+	// blocking the caller indefinitely).
+	const rollbackTimeout = 10 * time.Second
+	rollbackFn := func(ctx context.Context) error {
+		return execChangeReplicasTxn(
+			ctx, r.store, roachpb.REMOVE_REPLICA, desc, replDesc, &newDesc, reason, details,
+		)
+	}
+	rollbackCtx := logtags.WithTags(context.Background(), logtags.FromContext(ctx))
+	if err := contextutil.RunWithTimeout(
+		rollbackCtx, "learner rollback", rollbackTimeout, rollbackFn,
+	); err != nil {
+		log.Infof(ctx,
+			"failed to rollback learner %s, abandoning it for the replicate queue %v", target, err)
+		r.store.replicateQueue.MaybeAddAsync(ctx, r, r.store.Clock().Now())
+	} else {
+		log.Infof(ctx, "rolled back learner %s to %s", replDesc, &newDesc)
+	}
+}
+
+func (r *Replica) addReplicaLegacyPreemptiveSnapshot(
+	ctx context.Context,
+	target roachpb.ReplicationTarget,
+	desc *roachpb.RangeDescriptor,
+	priority SnapshotRequest_Priority,
+	reason storagepb.RangeLogEventReason,
+	details string,
+) (*roachpb.RangeDescriptor, error) {
 	if desc == nil {
 		return nil, errors.Errorf("%s: the current RangeDescriptor must not be nil", r)
 	}
@@ -882,70 +1068,93 @@ func (r *Replica) changeReplicas(
 		}
 	}
 
-	generationComparableEnabled := r.store.ClusterSettings().Version.IsActive(cluster.VersionGenerationComparable)
-	rangeID := desc.RangeID
 	updatedDesc := *desc
+	updatedDesc.SetReplicas(desc.Replicas().DeepCopy())
+
+	// If the replica exists on the remote node, no matter in which store,
+	// abort the replica add.
+	if nodeUsed {
+		if repDescIdx != -1 {
+			return nil, errors.Errorf("%s: unable to add replica %v which is already present", r, repDesc)
+		}
+		return nil, errors.Errorf("%s: unable to add replica %v; node already has a replica", r, repDesc)
+	}
+
+	// Send a pre-emptive snapshot. Note that the replica to which this
+	// snapshot is addressed has not yet had its replica ID initialized; this
+	// is intentional, and serves to avoid the following race with the replica
+	// GC queue:
+	//
+	// - snapshot received, a replica is lazily created with the "real" replica ID
+	// - the replica is eligible for GC because it is not yet a member of the range
+	// - GC queue runs, creating a raft tombstone with the replica's ID
+	// - the replica is added to the range
+	// - lazy creation of the replica fails due to the raft tombstone
+	//
+	// Instead, the replica GC queue will create a tombstone with replica ID
+	// zero, which is never legitimately used, and thus never interferes with
+	// raft operations. Racing with the replica GC queue can still partially
+	// negate the benefits of pre-emptive snapshots, but that is a recoverable
+	// degradation, not a catastrophic failure.
+	//
+	// NB: A closure is used here so that we can release the snapshot as soon
+	// as it has been applied on the remote and before the ChangeReplica
+	// operation is processed. This is important to allow other ranges to make
+	// progress which might be required for this ChangeReplicas operation to
+	// complete. See #10409.
+	if err := r.sendSnapshot(ctx, repDesc, SnapshotRequest_PREEMPTIVE, priority); err != nil {
+		return nil, err
+	}
+
+	repDesc.ReplicaID = updatedDesc.NextReplicaID
+	updatedDesc.NextReplicaID++
+	updatedDesc.AddReplica(repDesc)
+
+	err := execChangeReplicasTxn(ctx, r.store, roachpb.ADD_REPLICA, desc, repDesc, &updatedDesc, reason, details)
+	return &updatedDesc, err
+}
+
+func (r *Replica) removeReplica(
+	ctx context.Context,
+	target roachpb.ReplicationTarget,
+	desc *roachpb.RangeDescriptor,
+	priority SnapshotRequest_Priority,
+	reason storagepb.RangeLogEventReason,
+	details string,
+) (*roachpb.RangeDescriptor, error) {
+	if desc == nil {
+		return nil, errors.Errorf("%s: the current RangeDescriptor must not be nil", r)
+	}
+	updatedDesc := *desc
+	updatedDesc.SetReplicas(desc.Replicas().DeepCopy())
+	// If that exact node-store combination does not have the replica,
+	// abort the removal.
+	removed, ok := updatedDesc.RemoveReplica(target.NodeID, target.StoreID)
+	if !ok {
+		return nil, errors.Errorf("%s: unable to remove replica %v which is not present", r, target)
+	}
+	err := execChangeReplicasTxn(ctx, r.store, roachpb.REMOVE_REPLICA, desc, removed, &updatedDesc, reason, details)
+	return &updatedDesc, err
+}
+
+func execChangeReplicasTxn(
+	ctx context.Context,
+	store *Store,
+	changeType roachpb.ReplicaChangeType,
+	desc *roachpb.RangeDescriptor,
+	repDesc roachpb.ReplicaDescriptor,
+	updatedDesc *roachpb.RangeDescriptor,
+	reason storagepb.RangeLogEventReason,
+	details string,
+) error {
+	generationComparableEnabled := store.ClusterSettings().Version.IsActive(cluster.VersionGenerationComparable)
 	if generationComparableEnabled {
 		updatedDesc.IncrementGeneration()
 		updatedDesc.GenerationComparable = proto.Bool(true)
 	}
-	updatedDesc.SetReplicas(desc.Replicas().DeepCopy())
-
-	switch changeType {
-	case roachpb.ADD_REPLICA:
-		// If the replica exists on the remote node, no matter in which store,
-		// abort the replica add.
-		if nodeUsed {
-			if repDescIdx != -1 {
-				return nil, errors.Errorf("%s: unable to add replica %v which is already present", r, repDesc)
-			}
-			return nil, errors.Errorf("%s: unable to add replica %v; node already has a replica", r, repDesc)
-		}
-
-		// Send a pre-emptive snapshot. Note that the replica to which this
-		// snapshot is addressed has not yet had its replica ID initialized; this
-		// is intentional, and serves to avoid the following race with the replica
-		// GC queue:
-		//
-		// - snapshot received, a replica is lazily created with the "real" replica ID
-		// - the replica is eligible for GC because it is not yet a member of the range
-		// - GC queue runs, creating a raft tombstone with the replica's ID
-		// - the replica is added to the range
-		// - lazy creation of the replica fails due to the raft tombstone
-		//
-		// Instead, the replica GC queue will create a tombstone with replica ID
-		// zero, which is never legitimately used, and thus never interferes with
-		// raft operations. Racing with the replica GC queue can still partially
-		// negate the benefits of pre-emptive snapshots, but that is a recoverable
-		// degradation, not a catastrophic failure.
-		//
-		// NB: A closure is used here so that we can release the snapshot as soon
-		// as it has been applied on the remote and before the ChangeReplica
-		// operation is processed. This is important to allow other ranges to make
-		// progress which might be required for this ChangeReplicas operation to
-		// complete. See #10409.
-		if err := r.sendSnapshot(ctx, repDesc, SnapshotRequest_PREEMPTIVE, priority); err != nil {
-			return nil, err
-		}
-
-		repDesc.ReplicaID = updatedDesc.NextReplicaID
-		updatedDesc.NextReplicaID++
-		updatedDesc.AddReplica(repDesc)
-
-	case roachpb.REMOVE_REPLICA:
-		// If that exact node-store combination does not have the replica,
-		// abort the removal.
-		if repDescIdx == -1 {
-			return nil, errors.Errorf("%s: unable to remove replica %v which is not present", r, repDesc)
-		}
-		if _, ok := updatedDesc.RemoveReplica(repDesc.NodeID, repDesc.StoreID); !ok {
-			return nil, errors.Errorf("%s: unable to remove replica %v which is not present", r, repDesc)
-		}
-	}
 
 	descKey := keys.RangeDescriptorKey(desc.StartKey)
-
-	if err := r.store.DB().Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+	if err := store.DB().Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		log.Event(ctx, "attempting txn")
 		txn.SetDebugName(replicaChangeTxnName)
 		dbDescValue, err := conditionalGetDescValueFromDB(ctx, txn, desc)
@@ -959,7 +1168,7 @@ func (r *Replica) changeReplicas(
 
 			// Important: the range descriptor must be the first thing touched in the transaction
 			// so the transaction record is co-located with the range being modified.
-			if err := updateRangeDescriptor(b, descKey, dbDescValue, &updatedDesc); err != nil {
+			if err := updateRangeDescriptor(b, descKey, dbDescValue, updatedDesc); err != nil {
 				return err
 			}
 
@@ -970,8 +1179,8 @@ func (r *Replica) changeReplicas(
 		}
 
 		// Log replica change into range event log.
-		if err := r.store.logChange(
-			ctx, txn, changeType, repDesc, updatedDesc, reason, details,
+		if err := store.logChange(
+			ctx, txn, changeType, repDesc, *updatedDesc, reason, details,
 		); err != nil {
 			return err
 		}
@@ -981,7 +1190,7 @@ func (r *Replica) changeReplicas(
 		b := txn.NewBatch()
 
 		// Update range descriptor addressing record(s).
-		if err := updateRangeAddressing(b, &updatedDesc); err != nil {
+		if err := updateRangeAddressing(b, updatedDesc); err != nil {
 			return err
 		}
 
@@ -991,7 +1200,7 @@ func (r *Replica) changeReplicas(
 				ChangeReplicasTrigger: &roachpb.ChangeReplicasTrigger{
 					ChangeType: changeType,
 					Replica:    repDesc,
-					Desc:       &updatedDesc,
+					Desc:       updatedDesc,
 				},
 			},
 		})
@@ -1006,10 +1215,10 @@ func (r *Replica) changeReplicas(
 		if msg, ok := maybeDescriptorChangedError(desc, err); ok {
 			err = &benignError{errors.New(msg)}
 		}
-		return nil, errors.Wrapf(err, "change replicas of r%d failed", rangeID)
+		return errors.Wrapf(err, "change replicas of r%d failed", desc.RangeID)
 	}
 	log.Event(ctx, "txn complete")
-	return &updatedDesc, nil
+	return nil
 }
 
 // sendSnapshot sends a snapshot of the replica state to the specified replica.

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -871,7 +871,7 @@ func (r *Replica) changeReplicas(
 	}
 	repDescIdx := -1  // tracks NodeID && StoreID
 	nodeUsed := false // tracks NodeID only
-	for i, existingRep := range desc.Replicas().Unwrap() {
+	for i, existingRep := range desc.Replicas().All() {
 		nodeUsedByExistingRep := existingRep.NodeID == repDesc.NodeID
 		nodeUsed = nodeUsed || nodeUsedByExistingRep
 
@@ -1350,7 +1350,7 @@ func (s *Store) AdminRelocateRange(
 	var addTargets []roachpb.ReplicaDescriptor
 	for _, t := range targets {
 		found := false
-		for _, replicaDesc := range rangeDesc.Replicas().Unwrap() {
+		for _, replicaDesc := range rangeDesc.Replicas().All() {
 			if replicaDesc.StoreID == t.StoreID && replicaDesc.NodeID == t.NodeID {
 				found = true
 				break
@@ -1365,7 +1365,7 @@ func (s *Store) AdminRelocateRange(
 	}
 
 	var removeTargets []roachpb.ReplicaDescriptor
-	for _, replicaDesc := range rangeDesc.Replicas().Unwrap() {
+	for _, replicaDesc := range rangeDesc.Replicas().All() {
 		found := false
 		for _, t := range targets {
 			if replicaDesc.StoreID == t.StoreID && replicaDesc.NodeID == t.NodeID {
@@ -1421,7 +1421,7 @@ func (s *Store) AdminRelocateRange(
 			})
 			desc.NextReplicaID++
 		case roachpb.REMOVE_REPLICA:
-			newReplicas := removeTargetFromSlice(desc.Replicas().Unwrap(), target)
+			newReplicas := removeTargetFromSlice(desc.Replicas().All(), target)
 			desc.SetReplicas(roachpb.MakeReplicaDescriptors(&newReplicas))
 		default:
 			panic(errors.Errorf("unknown ReplicaChangeType %v", changeType))
@@ -1481,7 +1481,7 @@ func (s *Store) AdminRelocateRange(
 				ctx,
 				storeList,
 				zone,
-				rangeInfo.Desc.Replicas().Unwrap(),
+				rangeInfo.Desc.Replicas().All(),
 				rangeInfo,
 				s.allocator.scorerOptions())
 			if targetStore == nil {
@@ -1619,8 +1619,11 @@ func (r *Replica) adminScatter(
 	// probability 1/N of choosing each.
 	if args.RandomizeLeases && r.OwnsValidLease(r.store.Clock().Now()) {
 		desc := r.Desc()
-		newLeaseholderIdx := rand.Intn(len(desc.Replicas().Unwrap()))
-		targetStoreID := desc.Replicas().Unwrap()[newLeaseholderIdx].StoreID
+		// Learner replicas aren't allowed to become the leaseholder or raft leader,
+		// so only consider the `Voters` replicas.
+		voterReplicas := desc.Replicas().Voters()
+		newLeaseholderIdx := rand.Intn(len(voterReplicas))
+		targetStoreID := voterReplicas[newLeaseholderIdx].StoreID
 		if targetStoreID != r.store.StoreID() {
 			if err := r.AdminTransferLease(ctx, targetStoreID); err != nil {
 				log.Warningf(ctx, "failed to scatter lease to s%d: %+v", targetStoreID, err)

--- a/pkg/storage/replica_learner_test.go
+++ b/pkg/storage/replica_learner_test.go
@@ -1,0 +1,576 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package storage_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/raft/tracker"
+)
+
+// TODO(dan): Test learners and quota pool.
+// TODO(dan): Grep the codebase for "preemptive" and audit.
+// TODO(dan): Write a test like TestLearnerAdminChangeReplicasRace for the
+//   replicate queue leadership transfer race.
+
+type learnerTestKnobs struct {
+	storeKnobs                       storage.StoreTestingKnobs
+	replicaAddStopAfterLearnerAtomic int64
+}
+
+func makeLearnerTestKnobs() (base.TestingKnobs, *learnerTestKnobs) {
+	var k learnerTestKnobs
+	k.storeKnobs.ReplicaAddStopAfterLearnerSnapshot = func() bool {
+		return atomic.LoadInt64(&k.replicaAddStopAfterLearnerAtomic) > 0
+	}
+	return base.TestingKnobs{Store: &k.storeKnobs}, &k
+}
+
+func getFirstStoreReplica(
+	t *testing.T, s serverutils.TestServerInterface, key roachpb.Key,
+) (*storage.Store, *storage.Replica) {
+	t.Helper()
+	store, err := s.GetStores().(*storage.Stores).GetStore(s.GetFirstStoreID())
+	require.NoError(t, err)
+	var repl *storage.Replica
+	testutils.SucceedsSoon(t, func() error {
+		repl = store.LookupReplica(roachpb.RKey(key))
+		if repl == nil {
+			return errors.New(`could not find replica`)
+		}
+		return nil
+	})
+	return store, repl
+}
+
+// Some of the metrics used in these tests live on the queue objects and are
+// registered with of storage.StoreMetrics instead of living on it. Example:
+// queue.replicate.removelearnerreplica.
+//
+// TODO(dan): Move things like ReplicateQueueMetrics to be a field on
+// storage.StoreMetrics and just keep a reference in newReplicateQueue. Ditto
+// for other queues that do this.
+func getFirstStoreMetric(t *testing.T, s serverutils.TestServerInterface, name string) int64 {
+	t.Helper()
+	store, err := s.GetStores().(*storage.Stores).GetStore(s.GetFirstStoreID())
+	require.NoError(t, err)
+
+	var c int64
+	var found bool
+	store.Registry().Each(func(n string, v interface{}) {
+		if name == n {
+			switch t := v.(type) {
+			case *metric.Counter:
+				c = t.Count()
+				found = true
+			case *metric.Gauge:
+				c = t.Value()
+				found = true
+			}
+		}
+	})
+	if !found {
+		panic(fmt.Sprintf("couldn't find metric %s", name))
+	}
+	return c
+}
+
+func TestAddReplicaViaLearner(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	// The happy case! \o/
+
+	blockUntilSnapshotCh := make(chan struct{})
+	blockSnapshotsCh := make(chan struct{})
+	knobs, ltk := makeLearnerTestKnobs()
+	ltk.storeKnobs.ReceiveSnapshot = func(h *storage.SnapshotRequest_Header) error {
+		close(blockUntilSnapshotCh)
+		select {
+		case <-blockSnapshotsCh:
+		case <-time.After(10 * time.Second):
+			return errors.New(`test timed out`)
+		}
+		return nil
+	}
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 2, base.TestClusterArgs{
+		ServerArgs:      base.TestServerArgs{Knobs: knobs},
+		ReplicationMode: base.ReplicationManual,
+	})
+	defer tc.Stopper().Stop(ctx)
+	db := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	db.Exec(t, `SET CLUSTER SETTING kv.learner_replicas.enabled = true`)
+
+	scratchStartKey := tc.ScratchRange(t)
+
+	g := ctxgroup.WithContext(ctx)
+	g.GoCtx(func(ctx context.Context) error {
+		_, err := tc.AddReplicas(scratchStartKey, tc.Target(1))
+		return err
+	})
+
+	// Wait until the snapshot starts, which happens after the learner has been
+	// added.
+	<-blockUntilSnapshotCh
+	desc := tc.LookupRangeOrFatal(t, scratchStartKey)
+	require.Len(t, desc.Replicas().Voters(), 1)
+	require.Len(t, desc.Replicas().Learners(), 1)
+
+	var voters, nonVoters string
+	db.QueryRow(t,
+		`SELECT array_to_string(replicas, ','), array_to_string(learner_replicas, ',') FROM crdb_internal.ranges_no_leases WHERE range_id = $1`,
+		desc.RangeID,
+	).Scan(&voters, &nonVoters)
+	require.Equal(t, `1`, voters)
+	require.Equal(t, `2`, nonVoters)
+
+	// Unblock the snapshot and let the learner get promoted to a voter.
+	close(blockSnapshotsCh)
+	require.NoError(t, g.Wait())
+
+	desc = tc.LookupRangeOrFatal(t, scratchStartKey)
+	require.Len(t, desc.Replicas().Voters(), 2)
+	require.Len(t, desc.Replicas().Learners(), 0)
+	require.Equal(t, int64(1), getFirstStoreMetric(t, tc.Server(1), `range.snapshots.learner-applied`))
+}
+
+func TestLearnerRaftConfState(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	verifyLearnerInRaftOnNodes := func(
+		key roachpb.Key, id roachpb.ReplicaID, servers []*server.TestServer,
+	) {
+		t.Helper()
+		var repls []*storage.Replica
+		for _, s := range servers {
+			_, repl := getFirstStoreReplica(t, s, key)
+			repls = append(repls, repl)
+		}
+		testutils.SucceedsSoon(t, func() error {
+			for _, repl := range repls {
+				status := repl.RaftStatus()
+				if status == nil {
+					return errors.Errorf(`%s is still waking up`, repl)
+				}
+				if _, ok := status.Config.Learners[uint64(id)]; !ok {
+					return errors.Errorf(`%s thinks %d is not a learner`, repl, id)
+				}
+			}
+			return nil
+		})
+	}
+
+	// Run the TestCluster with a known datadir so we can shut it down and start a
+	// new one on top of the existing data as part of the test.
+	dir, cleanup := testutils.TempDir(t)
+	defer cleanup()
+
+	knobs, ltk := makeLearnerTestKnobs()
+	ctx := context.Background()
+	const numNodes = 2
+	serverArgsPerNode := make(map[int]base.TestServerArgs)
+	for i := 0; i < numNodes; i++ {
+		path := filepath.Join(dir, "testserver", strconv.Itoa(i))
+		serverArgsPerNode[i] = base.TestServerArgs{
+			Knobs:      knobs,
+			StoreSpecs: []base.StoreSpec{{InMemory: false, Path: path}},
+		}
+	}
+	tc := testcluster.StartTestCluster(t, numNodes, base.TestClusterArgs{
+		ServerArgsPerNode: serverArgsPerNode,
+		ReplicationMode:   base.ReplicationManual,
+	})
+	defer func() {
+		// We modify the value of `tc` below to start up a second cluster, so in
+		// contrast to other tests, run this `defer Stop` in an anonymous func.
+		tc.Stopper().Stop(ctx)
+	}()
+	db := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	db.Exec(t, `SET CLUSTER SETTING kv.learner_replicas.enabled = true`)
+
+	// Add a learner replica, send a snapshot so that it's materialized as a
+	// Replica on the Store, but don't promote it to a voter.
+	scratchStartKey := tc.ScratchRange(t)
+	atomic.StoreInt64(&ltk.replicaAddStopAfterLearnerAtomic, 1)
+	desc := tc.AddReplicasOrFatal(t, scratchStartKey, tc.Target(1))
+	atomic.StoreInt64(&ltk.replicaAddStopAfterLearnerAtomic, 0)
+	require.Len(t, desc.Replicas().Learners(), 1)
+	learnerReplicaID := desc.Replicas().Learners()[0].ReplicaID
+
+	// Verify that raft on every node thinks it's a learner. This checks that we
+	// use ConfChangeAddLearnerNode in the ConfChange and also checks that we
+	// correctly generate the ConfState for the snapshot.
+	verifyLearnerInRaftOnNodes(scratchStartKey, learnerReplicaID, tc.Servers)
+
+	// Shut down the cluster and restart it, then verify again that raft on every
+	// node thinks our learner is a learner. This checks that we generate the
+	// initial ConfState correctly.
+	tc.Stopper().Stop(ctx)
+	tc = testcluster.StartTestCluster(t, numNodes, base.TestClusterArgs{
+		ServerArgsPerNode: serverArgsPerNode,
+		ReplicationMode:   base.ReplicationManual,
+	})
+	{
+		// Ping the raft group to wake it up.
+		_, err := tc.Server(0).DB().Get(ctx, scratchStartKey)
+		require.NoError(t, err)
+	}
+	verifyLearnerInRaftOnNodes(scratchStartKey, learnerReplicaID, tc.Servers)
+}
+
+func TestLearnerSnapshotFailsRollback(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	var rejectSnapshots int64
+	knobs, ltk := makeLearnerTestKnobs()
+	ltk.storeKnobs.ReceiveSnapshot = func(h *storage.SnapshotRequest_Header) error {
+		if atomic.LoadInt64(&rejectSnapshots) > 0 {
+			return errors.New(`nope`)
+		}
+		return nil
+	}
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 2, base.TestClusterArgs{
+		ServerArgs:      base.TestServerArgs{Knobs: knobs},
+		ReplicationMode: base.ReplicationManual,
+	})
+	defer tc.Stopper().Stop(ctx)
+	db := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	db.Exec(t, `SET CLUSTER SETTING kv.learner_replicas.enabled = true`)
+
+	scratchStartKey := tc.ScratchRange(t)
+	atomic.StoreInt64(&rejectSnapshots, 1)
+	_, err := tc.AddReplicas(scratchStartKey, tc.Target(1))
+	// TODO(dan): It'd be nice if we could cancel the `AddReplicas` context before
+	// returning the error from the `ReceiveSnapshot` knob to test the codepath
+	// that uses a new context for the rollback, but plumbing that context is
+	// annoying.
+	if !testutils.IsError(err, `remote couldn't accept LEARNER snapshot`) {
+		t.Fatalf(`expected "remote couldn't accept LEARNER snapshot" error got: %+v`, err)
+	}
+
+	// Make sure we cleaned up after ourselves (by removing the learner).
+	desc := tc.LookupRangeOrFatal(t, scratchStartKey)
+	require.Empty(t, desc.Replicas().Learners())
+}
+
+func TestSplitWithLearner(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	knobs, ltk := makeLearnerTestKnobs()
+	tc := testcluster.StartTestCluster(t, 2, base.TestClusterArgs{
+		ServerArgs:      base.TestServerArgs{Knobs: knobs},
+		ReplicationMode: base.ReplicationManual,
+	})
+	defer tc.Stopper().Stop(ctx)
+	db := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	db.Exec(t, `SET CLUSTER SETTING kv.learner_replicas.enabled = true`)
+
+	// Add a learner replica, send a snapshot so that it's materialized as a
+	// Replica on the Store, but don't promote it to a voter.
+	scratchStartKey := tc.ScratchRange(t)
+	atomic.StoreInt64(&ltk.replicaAddStopAfterLearnerAtomic, 1)
+	_ = tc.AddReplicasOrFatal(t, scratchStartKey, tc.Target(1))
+	atomic.StoreInt64(&ltk.replicaAddStopAfterLearnerAtomic, 0)
+
+	// Splitting a learner is allowed. This orphans the two learners, but the
+	// replication queue will eventually clean this up.
+	left, right, err := tc.SplitRange(scratchStartKey.Next())
+	require.NoError(t, err)
+	require.Len(t, left.Replicas().Learners(), 1)
+	require.Len(t, right.Replicas().Learners(), 1)
+}
+
+func TestReplicateQueueSeesLearner(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	// NB also see TestAllocatorRemoveLearner for a lower-level test.
+
+	ctx := context.Background()
+	knobs, ltk := makeLearnerTestKnobs()
+	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
+		ServerArgs:      base.TestServerArgs{Knobs: knobs},
+		ReplicationMode: base.ReplicationManual,
+	})
+	defer tc.Stopper().Stop(ctx)
+	db := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	db.Exec(t, `SET CLUSTER SETTING kv.learner_replicas.enabled = true`)
+
+	// Add a learner replica, send a snapshot so that it's materialized as a
+	// Replica on the Store, but don't promote it to a voter.
+	scratchStartKey := tc.ScratchRange(t)
+	atomic.StoreInt64(&ltk.replicaAddStopAfterLearnerAtomic, 1)
+	_ = tc.AddReplicasOrFatal(t, scratchStartKey, tc.Target(1))
+	atomic.StoreInt64(&ltk.replicaAddStopAfterLearnerAtomic, 0)
+
+	// Run the replicate queue.
+	store, repl := getFirstStoreReplica(t, tc.Server(0), scratchStartKey)
+	require.Equal(t, int64(0), getFirstStoreMetric(t, tc.Server(0), `queue.replicate.removelearnerreplica`))
+	_, errMsg, err := store.ManuallyEnqueue(ctx, "replicate", repl, true /* skipShouldQueue */)
+	require.NoError(t, err)
+	require.Equal(t, ``, errMsg)
+	require.Equal(t, int64(1), getFirstStoreMetric(t, tc.Server(0), `queue.replicate.removelearnerreplica`))
+
+	// Make sure it deleted the learner.
+	desc := tc.LookupRangeOrFatal(t, scratchStartKey)
+	require.Empty(t, desc.Replicas().Learners())
+
+	// Bonus points: the replicate queue keeps processing until there is nothing
+	// to do, so it should have upreplicated the range to 3.
+	require.Len(t, desc.Replicas().Voters(), 3)
+}
+
+func TestGCQueueSeesLearner(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	knobs, ltk := makeLearnerTestKnobs()
+	tc := testcluster.StartTestCluster(t, 2, base.TestClusterArgs{
+		ServerArgs:      base.TestServerArgs{Knobs: knobs},
+		ReplicationMode: base.ReplicationManual,
+	})
+	defer tc.Stopper().Stop(ctx)
+	db := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	db.Exec(t, `SET CLUSTER SETTING kv.learner_replicas.enabled = true`)
+
+	// Add a learner replica, send a snapshot so that it's materialized as a
+	// Replica on the Store, but don't promote it to a voter.
+	scratchStartKey := tc.ScratchRange(t)
+	atomic.StoreInt64(&ltk.replicaAddStopAfterLearnerAtomic, 1)
+	_ = tc.AddReplicasOrFatal(t, scratchStartKey, tc.Target(1))
+	atomic.StoreInt64(&ltk.replicaAddStopAfterLearnerAtomic, 0)
+
+	// Run the replicaGC queue.
+	store, repl := getFirstStoreReplica(t, tc.Server(1), scratchStartKey)
+	trace, errMsg, err := store.ManuallyEnqueue(ctx, "replicaGC", repl, true /* skipShouldQueue */)
+	require.NoError(t, err)
+	require.Equal(t, ``, errMsg)
+	const msg = `not gc'able, replica is still in range descriptor: (n2,s2):2LEARNER`
+	require.Contains(t, tracing.FormatRecordedSpans(trace), msg)
+
+	// Make sure it didn't collect the learner.
+	desc := tc.LookupRangeOrFatal(t, scratchStartKey)
+	require.NotEmpty(t, desc.Replicas().Learners())
+}
+
+func TestRaftSnapshotQueueSeesLearner(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	blockSnapshotsCh := make(chan struct{})
+	knobs, ltk := makeLearnerTestKnobs()
+	ltk.storeKnobs.ReceiveSnapshot = func(h *storage.SnapshotRequest_Header) error {
+		select {
+		case <-blockSnapshotsCh:
+		case <-time.After(10 * time.Second):
+			return errors.New(`test timed out`)
+		}
+		return nil
+	}
+	tc := testcluster.StartTestCluster(t, 2, base.TestClusterArgs{
+		ServerArgs:      base.TestServerArgs{Knobs: knobs},
+		ReplicationMode: base.ReplicationManual,
+	})
+	defer tc.Stopper().Stop(ctx)
+	db := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	db.Exec(t, `SET CLUSTER SETTING kv.learner_replicas.enabled = true`)
+
+	// Create a learner replica.
+	scratchStartKey := tc.ScratchRange(t)
+	g := ctxgroup.WithContext(ctx)
+	g.GoCtx(func(ctx context.Context) error {
+		_, err := tc.AddReplicas(scratchStartKey, tc.Target(1))
+		return err
+	})
+
+	// Wait until raft knows that the learner needs a snapshot.
+	store, repl := getFirstStoreReplica(t, tc.Server(0), scratchStartKey)
+	testutils.SucceedsSoon(t, func() error {
+		for _, p := range repl.RaftStatus().Progress {
+			if p.State == tracker.StateSnapshot {
+				return nil
+			}
+		}
+		return errors.New(`expected some replica to need a snapshot`)
+	})
+
+	// Note the value of the metrics before.
+	generatedBefore := getFirstStoreMetric(t, tc.Server(0), `range.snapshots.generated`)
+	raftAppliedBefore := getFirstStoreMetric(t, tc.Server(0), `range.snapshots.normal-applied`)
+
+	// Run the raftsnapshot queue.
+	trace, errMsg, err := store.ManuallyEnqueue(ctx, "raftsnapshot", repl, true /* skipShouldQueue */)
+	require.NoError(t, err)
+	require.Equal(t, ``, errMsg)
+	const msg = `not sending snapshot type RAFT to learner: (n2,s2):2LEARNER`
+	require.Contains(t, tracing.FormatRecordedSpans(trace), msg)
+
+	// Make sure it didn't send any RAFT snapshots.
+	require.Equal(t, generatedBefore, getFirstStoreMetric(t, tc.Server(0), `range.snapshots.generated`))
+	require.Equal(t, raftAppliedBefore, getFirstStoreMetric(t, tc.Server(0), `range.snapshots.normal-applied`))
+
+	close(blockSnapshotsCh)
+	require.NoError(t, g.Wait())
+}
+
+// This test verifies the result of a race between the replicate queue running
+// while an AdminChangeReplicas is adding a replica.
+func TestLearnerAdminChangeReplicasRace(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	blockUntilSnapshotCh := make(chan struct{}, 2)
+	blockSnapshotsCh := make(chan struct{})
+	knobs, ltk := makeLearnerTestKnobs()
+	ltk.storeKnobs.ReceiveSnapshot = func(h *storage.SnapshotRequest_Header) error {
+		blockUntilSnapshotCh <- struct{}{}
+		<-blockSnapshotsCh
+		return nil
+	}
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 2, base.TestClusterArgs{
+		ServerArgs:      base.TestServerArgs{Knobs: knobs},
+		ReplicationMode: base.ReplicationManual,
+	})
+	defer tc.Stopper().Stop(ctx)
+	db := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	db.Exec(t, `SET CLUSTER SETTING kv.learner_replicas.enabled = true`)
+
+	// Add the learner.
+	scratchStartKey := tc.ScratchRange(t)
+	g := ctxgroup.WithContext(ctx)
+	g.GoCtx(func(ctx context.Context) error {
+		_, err := tc.AddReplicas(scratchStartKey, tc.Target(1))
+		return err
+	})
+
+	// Wait until the snapshot starts, which happens after the learner has been
+	// added.
+	<-blockUntilSnapshotCh
+
+	// Removes the learner out from under the coordinator running on behalf of
+	// AddReplicas.
+	_, err := tc.RemoveReplicas(scratchStartKey, tc.Target(1))
+	require.NoError(t, err)
+	desc := tc.LookupRangeOrFatal(t, scratchStartKey)
+	require.Len(t, desc.Replicas().Voters(), 1)
+	require.Len(t, desc.Replicas().Learners(), 0)
+
+	// Unblock the snapshot, and surprise AddReplicas. It should retry and error
+	// that the descriptor has changed since the AdminChangeReplicas command
+	// started.
+	close(blockSnapshotsCh)
+	if err := g.Wait(); !testutils.IsError(err, `descriptor changed`) {
+		t.Fatalf(`expected "descriptor changed" error got: %+v`, err)
+	}
+	desc = tc.LookupRangeOrFatal(t, scratchStartKey)
+	require.Len(t, desc.Replicas().Voters(), 1)
+	require.Len(t, desc.Replicas().Learners(), 0)
+}
+
+func TestLearnerNoAcceptLease(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	knobs, ltk := makeLearnerTestKnobs()
+	tc := testcluster.StartTestCluster(t, 2, base.TestClusterArgs{
+		ServerArgs:      base.TestServerArgs{Knobs: knobs},
+		ReplicationMode: base.ReplicationManual,
+	})
+	defer tc.Stopper().Stop(ctx)
+	db := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	db.Exec(t, `SET CLUSTER SETTING kv.learner_replicas.enabled = true`)
+
+	// Add a learner replica, send a snapshot so that it's materialized as a
+	// Replica on the Store, but don't promote it to a voter.
+	scratchStartKey := tc.ScratchRange(t)
+	atomic.StoreInt64(&ltk.replicaAddStopAfterLearnerAtomic, 1)
+	_ = tc.AddReplicasOrFatal(t, scratchStartKey, tc.Target(1))
+	atomic.StoreInt64(&ltk.replicaAddStopAfterLearnerAtomic, 0)
+
+	desc := tc.LookupRangeOrFatal(t, scratchStartKey)
+	err := tc.TransferRangeLease(desc, tc.Target(1))
+	if !testutils.IsError(err, `cannot transfer lease to replica of type LEARNER`) {
+		t.Fatalf(`expected "cannot transfer lease to replica of type LEARNER" error got: %+v`, err)
+	}
+}
+
+func TestLearnerFollowerRead(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	if util.RaceEnabled {
+		// Limiting how long transactions can run does not work well with race
+		// unless we're extremely lenient, which drives up the test duration.
+		t.Skip("skipping under race")
+	}
+
+	ctx := context.Background()
+	knobs, ltk := makeLearnerTestKnobs()
+	tc := testcluster.StartTestCluster(t, 2, base.TestClusterArgs{
+		ServerArgs:      base.TestServerArgs{Knobs: knobs},
+		ReplicationMode: base.ReplicationManual,
+	})
+	defer tc.Stopper().Stop(ctx)
+	db := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	db.Exec(t, `SET CLUSTER SETTING kv.learner_replicas.enabled = true`)
+	db.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = $1`, testingTargetDuration)
+	db.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.close_fraction = $1`, closeFraction)
+	db.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.follower_reads_enabled = true`)
+
+	scratchStartKey := tc.ScratchRange(t)
+	atomic.StoreInt64(&ltk.replicaAddStopAfterLearnerAtomic, 1)
+	scratchDesc := tc.AddReplicasOrFatal(t, scratchStartKey, tc.Target(1))
+	atomic.StoreInt64(&ltk.replicaAddStopAfterLearnerAtomic, 0)
+
+	req := roachpb.BatchRequest{Header: roachpb.Header{
+		RangeID:   scratchDesc.RangeID,
+		Timestamp: tc.Server(0).Clock().Now(),
+	}}
+	req.Add(&roachpb.ScanRequest{RequestHeader: roachpb.RequestHeader{
+		Key: scratchDesc.StartKey.AsRawKey(), EndKey: scratchDesc.EndKey.AsRawKey(),
+	}})
+
+	_, repl := getFirstStoreReplica(t, tc.Server(1), scratchStartKey)
+	testutils.SucceedsSoon(t, func() error {
+		// Trace the Send call so we can verify that it hit the exact `learner
+		// replicas cannot serve follower reads` branch that we're trying to test.
+		sendCtx, collect, cancel := tracing.ContextWithRecordingSpan(ctx, "manual read request")
+		defer cancel()
+		_, pErr := repl.Send(sendCtx, req)
+		err := pErr.GoError()
+		if !testutils.IsError(err, `not lease holder`) {
+			return errors.Errorf(`expected "not lease holder" error got: %+v`, err)
+		}
+		const msg = `learner replicas cannot serve follower reads`
+		formattedTrace := tracing.FormatRecordedSpans(collect())
+		if !strings.Contains(formattedTrace, msg) {
+			return errors.Errorf("expected a trace with `%s` got:\n%s", msg, formattedTrace)
+		}
+		return nil
+	})
+}

--- a/pkg/storage/replica_metrics.go
+++ b/pkg/storage/replica_metrics.go
@@ -156,7 +156,10 @@ func calcRangeCounter(
 	numReplicas int32,
 	clusterNodes int,
 ) (rangeCounter, unavailable, underreplicated, overreplicated bool) {
-	for _, rd := range desc.Replicas().Unwrap() {
+	// It seems unlikely that a learner replica would be the first live one, but
+	// there's no particular reason to exclude them. Note that `All` returns the
+	// voters first.
+	for _, rd := range desc.Replicas().All() {
 		if livenessMap[rd.NodeID].IsLive {
 			rangeCounter = rd.StoreID == storeID
 			break
@@ -165,25 +168,27 @@ func calcRangeCounter(
 	// We also compute an estimated per-range count of under-replicated and
 	// unavailable ranges for each range based on the liveness table.
 	if rangeCounter {
-		liveReplicas := calcLiveReplicas(desc, livenessMap)
-		if liveReplicas < desc.Replicas().QuorumSize() {
+		liveVoterReplicas := calcLiveVoterReplicas(desc, livenessMap)
+		if liveVoterReplicas < desc.Replicas().QuorumSize() {
 			unavailable = true
 		}
 		needed := GetNeededReplicas(numReplicas, clusterNodes)
-		if needed > liveReplicas {
+		if needed > liveVoterReplicas {
 			underreplicated = true
-		} else if needed < liveReplicas {
+		} else if needed < liveVoterReplicas {
 			overreplicated = true
 		}
 	}
 	return
 }
 
-// calcLiveReplicas returns a count of the live replicas; a live replica is
-// determined by checking its node in the provided liveness map.
-func calcLiveReplicas(desc *roachpb.RangeDescriptor, livenessMap IsLiveMap) int {
+// calcLiveVoterReplicas returns a count of the live voter replicas; a live
+// replica is determined by checking its node in the provided liveness map. This
+// method is used when indicating under-replication so only voter replicas are
+// considered.
+func calcLiveVoterReplicas(desc *roachpb.RangeDescriptor, livenessMap IsLiveMap) int {
 	var live int
-	for _, rd := range desc.Replicas().Unwrap() {
+	for _, rd := range desc.Replicas().Voters() {
 		if livenessMap[rd.NodeID].IsLive {
 			live++
 		}

--- a/pkg/storage/replica_raft_quiesce.go
+++ b/pkg/storage/replica_raft_quiesce.go
@@ -255,7 +255,7 @@ func shouldReplicaQuiesce(
 	}
 
 	var foundSelf bool
-	for _, rep := range q.descRLocked().Replicas().Unwrap() {
+	for _, rep := range q.descRLocked().Replicas().All() {
 		if uint64(rep.ReplicaID) == status.ID {
 			foundSelf = true
 		}

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -66,7 +66,7 @@ func (r *replicaRaftStorage) InitialState() (raftpb.HardState, raftpb.ConfState,
 		return raftpb.HardState{}, raftpb.ConfState{}, err
 	}
 	var cs raftpb.ConfState
-	for _, rep := range r.mu.state.Desc.Replicas().Unwrap() {
+	for _, rep := range r.mu.state.Desc.Replicas().All() {
 		cs.Nodes = append(cs.Nodes, uint64(rep.ReplicaID))
 	}
 
@@ -536,7 +536,7 @@ func snapshot(
 
 	// Synthesize our raftpb.ConfState from desc.
 	var cs raftpb.ConfState
-	for _, rep := range desc.Replicas().Unwrap() {
+	for _, rep := range desc.Replicas().All() {
 		cs.Nodes = append(cs.Nodes, uint64(rep.ReplicaID))
 	}
 

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -66,8 +66,11 @@ func (r *replicaRaftStorage) InitialState() (raftpb.HardState, raftpb.ConfState,
 		return raftpb.HardState{}, raftpb.ConfState{}, err
 	}
 	var cs raftpb.ConfState
-	for _, rep := range r.mu.state.Desc.Replicas().All() {
+	for _, rep := range r.mu.state.Desc.Replicas().Voters() {
 		cs.Nodes = append(cs.Nodes, uint64(rep.ReplicaID))
+	}
+	for _, rep := range r.mu.state.Desc.Replicas().Learners() {
+		cs.Learners = append(cs.Learners, uint64(rep.ReplicaID))
 	}
 
 	return hs, cs, nil
@@ -536,8 +539,11 @@ func snapshot(
 
 	// Synthesize our raftpb.ConfState from desc.
 	var cs raftpb.ConfState
-	for _, rep := range desc.Replicas().All() {
+	for _, rep := range desc.Replicas().Voters() {
 		cs.Nodes = append(cs.Nodes, uint64(rep.ReplicaID))
+	}
+	for _, rep := range desc.Replicas().Learners() {
+		cs.Learners = append(cs.Learners, uint64(rep.ReplicaID))
 	}
 
 	term, err := term(ctx, rsl, snap, rangeID, eCache, appliedIndex)

--- a/pkg/storage/replica_range_lease.go
+++ b/pkg/storage/replica_range_lease.go
@@ -675,6 +675,18 @@ func (r *Replica) AdminTransferLease(ctx context.Context, target roachpb.StoreID
 			return nil, nil, errors.Errorf("unable to find store %d in range %+v", target, desc)
 		}
 
+		// For now, don't allow replicas of type LEARNER to be leaseholders, see
+		// comments in RequestLease and TransferLease for why.
+		//
+		// TODO(dan): We shouldn't need this, the checks in RequestLease and
+		// TransferLease are the canonical ones and should be sufficient. Sadly, the
+		// `r.mu.minLeaseProposedTS = status.Timestamp` line below will likely play
+		// badly with that. This would be an issue even without learners, but
+		// omitting this check would make it worse. Fixme.
+		if t := nextLeaseHolder.GetType(); t != roachpb.ReplicaType_VOTER {
+			return nil, nil, errors.Errorf(`cannot transfer lease to replica of type %s`, t)
+		}
+
 		if nextLease, ok := r.mu.pendingLeaseRequest.RequestPending(); ok &&
 			nextLease.Replica != nextLeaseHolder {
 			repDesc, err := r.getReplicaDescriptorRLocked()

--- a/pkg/storage/storagepb/log.go
+++ b/pkg/storage/storagepb/log.go
@@ -22,4 +22,5 @@ const (
 	ReasonStoreDecommissioning RangeLogEventReason = "store decommissioning"
 	ReasonRebalance            RangeLogEventReason = "rebalance"
 	ReasonAdminRequest         RangeLogEventReason = "admin request"
+	ReasonAbandonedLearner     RangeLogEventReason = "abandoned learner replica"
 )

--- a/pkg/storage/store_snapshot.go
+++ b/pkg/storage/store_snapshot.go
@@ -588,6 +588,12 @@ func (s *Store) shouldAcceptSnapshotData(
 func (s *Store) receiveSnapshot(
 	ctx context.Context, header *SnapshotRequest_Header, stream incomingSnapshotStream,
 ) error {
+	if fn := s.cfg.TestingKnobs.ReceiveSnapshot; fn != nil {
+		if err := fn(header); err != nil {
+			return sendSnapshotError(stream, err)
+		}
+	}
+
 	cleanup, rejectionMsg, err := s.reserveSnapshot(ctx, header)
 	if err != nil {
 		return err

--- a/pkg/storage/testing_knobs.go
+++ b/pkg/storage/testing_knobs.go
@@ -181,6 +181,17 @@ type StoreTestingKnobs struct {
 	// TraceAllRaftEvents enables raft event tracing even when the current
 	// vmodule would not have enabled it.
 	TraceAllRaftEvents bool
+
+	// ReceiveSnapshot is run after receiving a snapshot header but before
+	// acquiring snapshot quota or doing shouldAcceptSnapshotData checks. If an
+	// error is returned from the hook, it's sent as an ERROR SnapshotResponse.
+	ReceiveSnapshot func(*SnapshotRequest_Header) error
+	// ReplicaAddStopAfterLearnerSnapshot causes replica addition to return early
+	// if the func returns true. Specifically, after the learner txn is successful
+	// and after the LEARNER type snapshot, but before promoting it to a voter.
+	// This ensures the `*Replica` will be materialized on the Store when it
+	// returns.
+	ReplicaAddStopAfterLearnerSnapshot func() bool
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/testutils/serverutils/test_cluster_shim.go
+++ b/pkg/testutils/serverutils/test_cluster_shim.go
@@ -52,6 +52,12 @@ type TestClusterInterface interface {
 		startKey roachpb.Key, targets ...roachpb.ReplicationTarget,
 	) (roachpb.RangeDescriptor, error)
 
+	// AddReplicasOrFatal is the same as AddReplicas but will Fatal the test on
+	// error.
+	AddReplicasOrFatal(
+		t testing.TB, startKey roachpb.Key, targets ...roachpb.ReplicationTarget,
+	) roachpb.RangeDescriptor
+
 	// RemoveReplicas removes one or more replicas from a range.
 	RemoveReplicas(
 		startKey roachpb.Key, targets ...roachpb.ReplicationTarget,
@@ -85,6 +91,10 @@ type TestClusterInterface interface {
 
 	// LookupRange returns the descriptor of the range containing key.
 	LookupRange(key roachpb.Key) (roachpb.RangeDescriptor, error)
+
+	// LookupRangeOrFatal is the same as LookupRange but will Fatal the test on
+	// error.
+	LookupRangeOrFatal(t testing.TB, key roachpb.Key) roachpb.RangeDescriptor
 
 	// Target returns a roachpb.ReplicationTarget for the specified server.
 	Target(serverIdx int) roachpb.ReplicationTarget

--- a/pkg/testutils/soon.go
+++ b/pkg/testutils/soon.go
@@ -47,7 +47,7 @@ func SucceedsSoonError(t testing.TB, fn func() error) error {
 	wrappedFn := func() error {
 		err := fn()
 		if timeutil.Since(tBegin) > 3*time.Second && err != nil {
-			log.InfoDepth(context.Background(), 3, errors.Wrap(err, "SucceedsSoon"))
+			log.InfoDepth(context.Background(), 4, errors.Wrap(err, "SucceedsSoon"))
 		}
 		return err
 	}

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -451,8 +451,8 @@ func (tc *TestCluster) FindRangeLease(
 		}
 	} else {
 		hint = &roachpb.ReplicationTarget{
-			NodeID:  rangeDesc.Replicas().Unwrap()[0].NodeID,
-			StoreID: rangeDesc.Replicas().Unwrap()[0].StoreID}
+			NodeID:  rangeDesc.Replicas().All()[0].NodeID,
+			StoreID: rangeDesc.Replicas().All()[0].StoreID}
 	}
 
 	// Find the server indicated by the hint and send a LeaseInfoRequest through
@@ -510,7 +510,7 @@ func (tc *TestCluster) WaitForSplitAndReplication(startKey roachpb.Key) error {
 				startKey, desc.StartKey)
 		}
 		// Once we've verified the split, make sure that replicas exist.
-		for _, rDesc := range desc.Replicas().Unwrap() {
+		for _, rDesc := range desc.Replicas().All() {
 			store, err := tc.findMemberStore(rDesc.StoreID)
 			if err != nil {
 				return err

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
+	"math"
 	"sync"
 	"testing"
 	"time"
@@ -44,6 +45,7 @@ type TestCluster struct {
 	Conns           []*gosql.DB
 	stopper         *stop.Stopper
 	replicationMode base.TestClusterReplicationMode
+	scratchRangeID  roachpb.RangeID
 	mu              struct {
 		syncutil.Mutex
 		serverStoppers []*stop.Stopper
@@ -333,6 +335,16 @@ func (tc *TestCluster) LookupRange(key roachpb.Key) (roachpb.RangeDescriptor, er
 	return tc.Servers[0].LookupRange(key)
 }
 
+// LookupRangeOrFatal is part of TestClusterInterface.
+func (tc *TestCluster) LookupRangeOrFatal(t testing.TB, key roachpb.Key) roachpb.RangeDescriptor {
+	t.Helper()
+	desc, err := tc.LookupRange(key)
+	if err != nil {
+		t.Fatalf(`looking up range for %s: %+v`, key, err)
+	}
+	return desc
+}
+
 // SplitRange splits the range containing splitKey.
 // The right range created by the split starts at the split key and extends to the
 // original range's end key.
@@ -418,6 +430,19 @@ func (tc *TestCluster) AddReplicas(
 	}
 }
 
+// AddReplicasOrFatal is part of TestClusterInterface.
+func (tc *TestCluster) AddReplicasOrFatal(
+	t testing.TB, startKey roachpb.Key, targets ...roachpb.ReplicationTarget,
+) roachpb.RangeDescriptor {
+	t.Helper()
+	desc, err := tc.AddReplicas(startKey, targets...)
+	if err != nil {
+		t.Fatalf(`could not add %v replicas to range containing %s: %+v`,
+			targets, startKey, err)
+	}
+	return desc
+}
+
 // RemoveReplicas is part of the TestServerInterface.
 func (tc *TestCluster) RemoveReplicas(
 	startKey roachpb.Key, targets ...roachpb.ReplicationTarget,
@@ -495,10 +520,28 @@ func (tc *TestCluster) FindRangeLeaseHolder(
 	return roachpb.ReplicationTarget{NodeID: replicaDesc.NodeID, StoreID: replicaDesc.StoreID}, nil
 }
 
-// WaitForSplitAndReplication waits for a range which starts with
-// startKey and then verifies that each replica in the range
-// descriptor has been created.
-func (tc *TestCluster) WaitForSplitAndReplication(startKey roachpb.Key) error {
+// ScratchRange returns the start key of a span of keyspace suitable for use as
+// kv scratch space (it doesn't overlap system spans or SQL tables). The range
+// is lazily split off on the first call to ScratchRange.
+func (tc *TestCluster) ScratchRange(t testing.TB) roachpb.Key {
+	scratchKey := keys.MakeTablePrefix(math.MaxUint32)
+	if tc.scratchRangeID > 0 {
+		return scratchKey
+	}
+	_, right, err := tc.SplitRange(scratchKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tc.scratchRangeID = right.RangeID
+	return scratchKey
+}
+
+// WaitForSplitAndInitialization waits for a range which starts with startKey
+// and then verifies that each replica in the range descriptor has been created.
+//
+// NB: This doesn't actually wait for full upreplication to whatever the zone
+// config specifies.
+func (tc *TestCluster) WaitForSplitAndInitialization(startKey roachpb.Key) error {
 	return retry.ForDuration(testutils.DefaultSucceedsSoonDuration, func() error {
 		desc, err := tc.LookupRange(startKey)
 		if err != nil {

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1292,6 +1292,7 @@ var charts = []sectionDescription{
 				Metrics: []string{
 					"queue.replicate.removedeadreplica",
 					"queue.replicate.removereplica",
+					"queue.replicate.removelearnerreplica",
 				},
 			},
 			{

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/queues.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/queues.tsx
@@ -65,6 +65,7 @@ export default function (props: GraphDashboardProps) {
         <Metric name="cr.store.queue.replicate.addreplica" title="Replicas Added / sec" nonNegativeRate />
         <Metric name="cr.store.queue.replicate.removereplica" title="Replicas Removed / sec" nonNegativeRate />
         <Metric name="cr.store.queue.replicate.removedeadreplica" title="Dead Replicas Removed / sec" nonNegativeRate />
+        <Metric name="cr.store.queue.replicate.removelearnerreplica" title="Learner Replicas Removed / sec" nonNegativeRate />
         <Metric name="cr.store.queue.replicate.rebalancereplica" title="Replicas Rebalanced / sec" nonNegativeRate />
         <Metric name="cr.store.queue.replicate.transferlease" title="Leases Transferred / sec" nonNegativeRate />
         <Metric name="cr.store.queue.replicate.purgatory" title="Replicas in Purgatory" downsampleMax />


### PR DESCRIPTION
A learner is a participant in a raft group that accepts messages but doesn't
vote. This means it doesn't affect raft quorum and thus doesn't affect
the fragility of the range, even if it's very far behind or many
learners are down.

At the time of writing, learners are used in CockroachDB as an interim
state while adding a replica. A learner replica is added to the range
via raft ConfChange, a raft snapshot (of type LEARNER) is sent to catch
it up, and then a second ConfChange promotes it to a full replica.

This means that learners are currently always expected to have a short
lifetime, approximately the time it takes to send a snapshot. Ideas have
been kicked around to use learners with follower reads, which could be a
cheap way to allow many geographies to have local reads without
affecting write latencies. If implemented, these learners would have
long lifetimes.

For simplicity, CockroachDB treats learner replicas the same as voter
replicas as much as possible, but there are a few exceptions:

- Learner replicas are not considered when calculating quorum size, and
  thus do not affect the computation of which ranges are
  under-replicated for upreplication/alerting/debug/etc purposes. Ditto
  for over-replicated.
- Learner replicas cannot become raft leaders, so we also don't allow
  them to become leaseholders. As a result, DistSender and the various
  oracles don't try to send them traffic.
- The raft snapshot queue does not send snapshots to learners for
  reasons described below.
- Merges won't run while a learner replica is present.

Replicas are now added in two ConfChange transactions. The first creates
the learner and the second promotes it to a voter. If the node that is
coordinating this dies in the middle, we're left with an orphaned
learner. For this reason, the replicate queue always first removes any
learners it sees before doing anything else. We could instead try to
finish off the learner snapshot and promotion, but this is more
complicated and it's not yet clear the efficiency win is worth it.

This introduces some rare races between the replicate queue and
AdminChangeReplicas or if a range's lease is moved to a new owner while
the old leaseholder is still processing it in the replicate queue. These
races are handled by retrying if a learner disappears during the
snapshot/promotion.

If the coordinator otherwise encounters an error while sending the
learner snapshot or promoting it (which can happen for a number of
reasons, including the node getting the learner going away), it tries to
clean up after itself by rolling back the addition of the learner.

There is another race between the learner snapshot being sent and the
raft snapshot queue happening to check the replica at the same time,
also sending it a snapshot. This is safe but wasteful, so the raft
snapshot queue won't try to send snapshots to learners.

Merges are blocked if either side has a learner (to avoid working out
the edge cases) but it's historically turned out to be a bad idea to get
in the way of splits, so we allow them even when some of the replicas
are learners. This orphans a learner on each side of the split (the
original coordinator will not be able to finish either of them), but the
replication queue will eventually clean them up.

Learner replicas don't affect quorum but they do affect the system in
other ways. The most obvious way is that the leader sends them the raft
traffic it would send to any follower, consuming resources. More
surprising is that once the learner has received a snapshot, it's
considered by the quota pool that prevents the raft leader from getting
too far ahead of the followers. This is because a learner (especially
one that already has a snapshot) is expected to very soon be a voter, so
we treat it like one. However, it means a slow learner can slow down
regular traffic, which is possibly counterintuitive.

Release note (general change): Replicas are now added using a raft
learner and going through the normal raft snapshot process to catch them
up, eliminating technical debt. No user facing changes are expected.