### PR TITLE
roachtest: add ycsbbench

### DIFF
--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -83,4 +83,5 @@ func registerBenchmarks(r *registry) {
 	registerIndexesBench(r)
 	registerTPCCBench(r)
 	registerTPCHBench(r)
+	registerYCSBBenchUniformA(r)
 }


### PR DESCRIPTION
This PR comes in two commits. The first adds support for EBS nodes on AWS and the second adds a benchmark for YCSB workload A with a uniform request distribution on a single node. The results after 6 runs are as follows:

```
name                                        op/s
ycsbbench/uniform/A/nodes=1/cpu=2/total-8   2.86k ± 3%
ycsbbench/uniform/A/nodes=1/cpu=4/total-8   6.16k ± 4%
ycsbbench/uniform/A/nodes=1/cpu=8/total-8   12.8k ± 1%
ycsbbench/uniform/A/nodes=1/cpu=16/total-8  22.0k ± 1%
ycsbbench/uniform/A/nodes=1/cpu=32/total-8  35.3k ±22%

name                                        ms/op
ycsbbench/uniform/A/nodes=1/cpu=2/total-8    5.60 ± 4%
ycsbbench/uniform/A/nodes=1/cpu=4/total-8    5.19 ± 4%
ycsbbench/uniform/A/nodes=1/cpu=8/total-8    5.03 ± 3%
ycsbbench/uniform/A/nodes=1/cpu=16/total-8   5.85 ± 1%
ycsbbench/uniform/A/nodes=1/cpu=32/total-8   7.03 ±12%
```

The analysis of the raw data was done with [this bash script](https://gist.github.com/ajwerner/ba5df47bcf2bdfd00f28f1f78a104800).