### PR TITLE
security: only perform strict validation on first certificate.

### DIFF
--- a/pkg/security/certificate_loader.go
+++ b/pkg/security/certificate_loader.go
@@ -414,11 +414,13 @@ func parseCertificate(ci *CertInfo) error {
 			return makeErrorf(err, "failed to parse certificate %d in file %s", i, ci.Filename)
 		}
 
-		if err := validateCockroachCertificate(ci, x509Cert); err != nil {
-			return makeErrorf(err, "failed to validate certificate %d in file %s", i, ci.Filename)
-		}
 		if i == 0 {
-			// The first certificate is the effective one; use its expiration time.
+			// Only check details of the first certificate.
+			if err := validateCockroachCertificate(ci, x509Cert); err != nil {
+				return makeErrorf(err, "failed to validate certificate %d in file %s", i, ci.Filename)
+			}
+
+			// Expiration from the first certificate.
 			expires = x509Cert.NotAfter
 		}
 		certs[i] = x509Cert


### PR DESCRIPTION
Fixes #38146.

If a client or node certificate includes intermediates, we used to
apply the same strict validation to the intermediates as well. This
will fail on invalid CommonName.

Now also return error when part of the certificate file could not be
parsed.

Release note: (security): only check CN on first certificate in file