### PR TITLE
sql: fill in relam column of pg_class and pg_index

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -276,18 +276,18 @@ FROM pg_catalog.pg_class c
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'public'
 ----
-oid         relname       relnamespace  reltype  relowner  relam  relfilenode  reltablespace
-55          t1            2332901747    0        NULL      NULL   0            0
-450499963   primary       2332901747    0        NULL      NULL   0            0
-450499960   t1_a_key      2332901747    0        NULL      NULL   0            0
-450499961   index_key     2332901747    0        NULL      NULL   0            0
-56          t2            2332901747    0        NULL      NULL   0            0
-2315049508  primary       2332901747    0        NULL      NULL   0            0
-2315049511  t2_t1_id_idx  2332901747    0        NULL      NULL   0            0
-57          t3            2332901747    0        NULL      NULL   0            0
-969972501   primary       2332901747    0        NULL      NULL   0            0
-969972502   t3_a_b_idx    2332901747    0        NULL      NULL   0            0
-58          v1            2332901747    0        NULL      NULL   0            0
+oid         relname       relnamespace  reltype  relowner  relam       relfilenode  reltablespace
+55          t1            2332901747    0        NULL      2631952481  0            0
+450499963   primary       2332901747    0        NULL      2631952481  0            0
+450499960   t1_a_key      2332901747    0        NULL      2631952481  0            0
+450499961   index_key     2332901747    0        NULL      2631952481  0            0
+56          t2            2332901747    0        NULL      2631952481  0            0
+2315049508  primary       2332901747    0        NULL      2631952481  0            0
+2315049511  t2_t1_id_idx  2332901747    0        NULL      2631952481  0            0
+57          t3            2332901747    0        NULL      2631952481  0            0
+969972501   primary       2332901747    0        NULL      2631952481  0            0
+969972502   t3_a_b_idx    2332901747    0        NULL      2631952481  0            0
+58          v1            2332901747    0        NULL      2631952481  0            0
 
 query TIRIOBBT colnames
 SELECT relname, relpages, reltuples, relallvisible, reltoastrelid, relhasindex, relisshared, relpersistence

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -47,6 +47,14 @@ const (
 	defaultCollationTag    = "en-US"
 )
 
+var cockroachIndexEncodingOid *tree.DOid
+
+func init() {
+	h := makeOidHasher()
+	h.writeStr(cockroachIndexEncoding)
+	cockroachIndexEncodingOid = h.getOid()
+}
+
 // pgCatalog contains a set of system tables mirroring PostgreSQL's pg_catalog schema.
 // This code attempts to comply as closely as possible to the system catalogs documented
 // in https://www.postgresql.org/docs/9.6/static/catalogs.html.
@@ -269,10 +277,8 @@ CREATE TABLE pg_catalog.pg_am (
 	amtype CHAR
 )`,
 	populate: func(_ context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		h := makeOidHasher()
-		h.writeStr(cockroachIndexEncoding)
 		return addRow(
-			h.getOid(),                            // oid - all versions
+			cockroachIndexEncodingOid,             // oid - all versions
 			tree.NewDName(cockroachIndexEncoding), // amname - all versions
 			zeroVal,                               // amstrategies - < v9.6
 			zeroVal,                               // amsupport - < v9.6
@@ -524,7 +530,7 @@ CREATE TABLE pg_catalog.pg_class (
 					namespaceOid,              // relnamespace
 					oidZero,                   // reltype (PG creates a composite type in pg_type for each table)
 					tree.DNull,                // relowner
-					tree.DNull,                // relam
+					cockroachIndexEncodingOid, // relam
 					oidZero,                   // relfilenode
 					oidZero,                   // reltablespace
 					tree.DNull,                // relpages
@@ -565,7 +571,7 @@ CREATE TABLE pg_catalog.pg_class (
 						namespaceOid,                         // relnamespace
 						oidZero,                              // reltype
 						tree.DNull,                           // relowner
-						tree.DNull,                           // relam
+						cockroachIndexEncodingOid,            // relam
 						oidZero,                              // relfilenode
 						oidZero,                              // reltablespace
 						tree.DNull,                           // relpages


### PR DESCRIPTION
Previously, every index and relation was reported to have a NULL `relam`
column. The `relam` column contains the oid of an entry in the `pg_am`
table, which is supposed to represent an index "access method". We
support just one "access method", which we define as our sorted key list
representation that kv supports.

This NULL `relam` column made all metadata queries that tried to join
`pg_am` with other tables return no rows (unless outer join was used),
which could cause issues with various tools, including Liquibase.

Release note (sql change): the relam column of the pg_catalog tables
pg_class and pg_index is now filled in correctly.