### PR TITLE
release-2.1: security: only perform strict validation on first certificate.

### DIFF
--- a/pkg/security/certificate_loader.go
+++ b/pkg/security/certificate_loader.go
@@ -416,11 +416,13 @@ func parseCertificate(ci *CertInfo) error {
 			return makeErrorf(err, "failed to parse certificate %d in file %s", i, ci.Filename)
 		}
 
-		if err := validateCockroachCertificate(ci, x509Cert); err != nil {
-			return makeErrorf(err, "failed to validate certificate %d in file %s", i, ci.Filename)
-		}
 		if i == 0 {
-			// The first certificate is the effective one; use its expiration time.
+			// Only check details of the first certificate.
+			if err := validateCockroachCertificate(ci, x509Cert); err != nil {
+				return makeErrorf(err, "failed to validate certificate %d in file %s", i, ci.Filename)
+			}
+
+			// Expiration from the first certificate.
 			expires = x509Cert.NotAfter
 		}
 		certs[i] = x509Cert

--- a/pkg/security/certificate_loader_test.go
+++ b/pkg/security/certificate_loader_test.go
@@ -133,7 +133,7 @@ func countLoadedCertificates(certsDir string) (int, error) {
 // Generate a x509 cert with specific fields.
 func makeTestCert(
 	t *testing.T, commonName string, keyUsage x509.KeyUsage, extUsages []x509.ExtKeyUsage,
-) []byte {
+) (*x509.Certificate, []byte) {
 	// Make smallest rsa key possible: not saved.
 	key, err := rsa.GenerateKey(rand.Reader, 512)
 	if err != nil {
@@ -158,8 +158,14 @@ func makeTestCert(
 		t.Fatalf("error on CreateCertificate for CN=%s: %v", commonName, err)
 	}
 
+	// parse it back.
+	parsedCert, err := x509.ParseCertificate(certBytes)
+	if err != nil {
+		t.Fatalf("error on ParseCertificate for CN=%s: %v", commonName, err)
+	}
+
 	certBlock := &pem.Block{Type: "CERTIFICATE", Bytes: certBytes}
-	return pem.EncodeToMemory(certBlock)
+	return parsedCert, pem.EncodeToMemory(certBlock)
 }
 
 func TestNamingScheme(t *testing.T) {
@@ -168,13 +174,13 @@ func TestNamingScheme(t *testing.T) {
 	fullKeyUsage := x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature
 	// Build a few certificates. These are barebones since we only need to check our custom validation,
 	// not chain verification.
-	caCert := makeTestCert(t, "", 0, nil)
+	parsedCACert, caCert := makeTestCert(t, "", 0, nil)
 
-	goodNodeCert := makeTestCert(t, "node", fullKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth})
-	badUserNodeCert := makeTestCert(t, "notnode", fullKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth})
+	parsedGoodNodeCert, goodNodeCert := makeTestCert(t, "node", fullKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth})
+	_, badUserNodeCert := makeTestCert(t, "notnode", fullKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth})
 
-	goodRootCert := makeTestCert(t, "root", fullKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
-	notRootCert := makeTestCert(t, "notroot", fullKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
+	parsedGoodRootCert, goodRootCert := makeTestCert(t, "root", fullKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
+	_, notRootCert := makeTestCert(t, "notroot", fullKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
 
 	// Do not use embedded certs.
 	security.ResetAssetLoader()
@@ -273,25 +279,6 @@ func TestNamingScheme(t *testing.T) {
 			skipWindows: true,
 		},
 		{
-			// Bad cert files.
-			files: []testFile{
-				{"ca.crt", 0777, []byte{}},
-				{"ca.key", 0777, []byte{}},
-				{"node.crt", 0777, []byte("foo")},
-				{"node.key", 0700, []byte{}},
-				{"client.root.crt", 0777, append(goodRootCert, []byte("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----")...)},
-				{"client.root.key", 0700, []byte{}},
-			},
-			certs: []security.CertInfo{
-				{FileUsage: security.CAPem, Filename: "ca.crt",
-					Error: errors.New("empty certificate file: ca.crt")},
-				{FileUsage: security.ClientPem, Filename: "client.root.crt", Name: "root",
-					Error: errors.New("failed to parse certificate 1 in file client.root.crt")},
-				{FileUsage: security.NodePem, Filename: "node.crt",
-					Error: errors.New("no certificates found in node.crt")},
-			},
-		},
-		{
 			// Bad CommonName: this is checked later in the CertificateManager.
 			files: []testFile{
 				{"node.crt", 0777, badUserNodeCert},
@@ -322,6 +309,26 @@ func TestNamingScheme(t *testing.T) {
 					Name: "root", FileContents: goodRootCert, KeyFileContents: []byte("client.root.key")},
 				{FileUsage: security.NodePem, Filename: "node.crt", KeyFilename: "node.key",
 					FileContents: goodNodeCert, KeyFileContents: []byte("node.key")},
+			},
+		},
+		{
+			// Certificates contain the CA: everything loads.
+			files: []testFile{
+				{"ca.crt", 0777, caCert},
+				{"ca.key", 0700, []byte("ca.key")},
+				{"node.crt", 0777, append(goodNodeCert, caCert...)},
+				{"node.key", 0700, []byte("node.key")},
+				{"client.root.crt", 0777, append(goodRootCert, caCert...)},
+				{"client.root.key", 0700, []byte("client.root.key")},
+			},
+			certs: []security.CertInfo{
+				{FileUsage: security.CAPem, Filename: "ca.crt", FileContents: caCert},
+				{FileUsage: security.ClientPem, Filename: "client.root.crt", KeyFilename: "client.root.key",
+					Name: "root", FileContents: append(goodRootCert, caCert...), KeyFileContents: []byte("client.root.key"),
+					ParsedCertificates: []*x509.Certificate{parsedGoodRootCert, parsedCACert}},
+				{FileUsage: security.NodePem, Filename: "node.crt", KeyFilename: "node.key",
+					FileContents: append(goodNodeCert, caCert...), KeyFileContents: []byte("node.key"),
+					ParsedCertificates: []*x509.Certificate{parsedGoodNodeCert, parsedCACert}},
 			},
 		},
 		{
@@ -401,9 +408,24 @@ func TestNamingScheme(t *testing.T) {
 					t.Errorf("#%d: bad file contents: expected %s, got %s", testNum, expected.FileContents, actual.FileContents)
 					continue
 				}
-				if a, e := len(actual.ParsedCertificates), 1; a != e {
-					t.Errorf("#%d: expected %d certificates, found: %d", testNum, e, a)
-					continue
+				if expected.ParsedCertificates != nil {
+					// ParsedCertificates was specified in the expected test output, check against it.
+					if a, e := len(actual.ParsedCertificates), len(expected.ParsedCertificates); a != e {
+						t.Errorf("#%d: expected %d certificates, found: %d", testNum, e, a)
+						continue
+					}
+					for certIndex := range actual.ParsedCertificates {
+						if a, e := actual.ParsedCertificates[certIndex], expected.ParsedCertificates[certIndex]; !a.Equal(e) {
+							t.Errorf("#%d: certificate %d does not match: got %v, expected %v", testNum, certIndex, a, e)
+							continue
+						}
+					}
+				} else {
+					// No ParsedCertificates specified, we expect just 1.
+					if a, e := len(actual.ParsedCertificates), 1; a != e {
+						t.Errorf("#%d: expected %d certificates, found: %d", testNum, e, a)
+						continue
+					}
 				}
 			}
 			if actual.KeyFilename != "" && !bytes.Equal(actual.KeyFileContents, expected.KeyFileContents) {


### PR DESCRIPTION
Backport 1/1 commits from #38163.

/cc @cockroachdb/release

---

Fixes #38146.

If a client or node certificate includes intermediates, we used to
apply the same strict validation to the intermediates as well. This
will fail on invalid CommonName.

Now also return error when part of the certificate file could not be
parsed.

Release note: (security): only check CN on first certificate in file
