### PR TITLE
batcheval: unexport splitStatsHelper

### DIFF
--- a/pkg/storage/batcheval/cmd_end_transaction.go
+++ b/pkg/storage/batcheval/cmd_end_transaction.go
@@ -856,6 +856,9 @@ func splitTrigger(
 	return splitTriggerHelper(ctx, rec, batch, h, split, ts)
 }
 
+// splitTriggerHelper continues the work begun by splitTrigger, but has a
+// reduced scope that has all stats-related concerns bundled into a
+// splitStatsHelper.
 func splitTriggerHelper(
 	ctx context.Context,
 	rec EvalContext,

--- a/pkg/storage/batcheval/cmd_end_transaction.go
+++ b/pkg/storage/batcheval/cmd_end_transaction.go
@@ -839,7 +839,7 @@ func splitTrigger(
 	}
 	log.Event(ctx, "computed stats for left hand side range")
 
-	h := SplitStatsHelperInput{
+	h := splitStatsHelperInput{
 		AbsPreSplitBothEstimated: rec.GetMVCCStats(),
 		DeltaBatchEstimated:      bothDeltaMS,
 		AbsPostSplitLeft:         leftMS,
@@ -860,7 +860,7 @@ func splitTriggerHelper(
 	ctx context.Context,
 	rec EvalContext,
 	batch engine.Batch,
-	statsInput SplitStatsHelperInput,
+	statsInput splitStatsHelperInput,
 	split *roachpb.SplitTrigger,
 	ts hlc.Timestamp,
 ) (enginepb.MVCCStats, result.Result, error) {
@@ -882,7 +882,7 @@ func splitTriggerHelper(
 		return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to copy last replica GC timestamp")
 	}
 
-	h, err := MakeSplitStatsHelper(statsInput)
+	h, err := makeSplitStatsHelper(statsInput)
 	if err != nil {
 		return enginepb.MVCCStats{}, result.Result{}, err
 	}


### PR DESCRIPTION
This struct is only accessed from within the package. It retains some
"exported" methods to give some notion of contract between the type and its
users.

Release note: None