### PR TITLE
sqlbase: don't panic in EncDatum.EnsureDecoded

### DIFF
--- a/pkg/sql/sqlbase/encoded_datum.go
+++ b/pkg/sql/sqlbase/encoded_datum.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"unsafe"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/pkg/errors"
@@ -216,7 +217,7 @@ func (ed *EncDatum) EnsureDecoded(typ *ColumnType, a *DatumAlloc) error {
 		return nil
 	}
 	if ed.encoded == nil {
-		panic("decoding unset EncDatum")
+		return pgerror.NewAssertionErrorf("decoding unset EncDatum")
 	}
 	datType := typ.ToDatumType()
 	var err error


### PR DESCRIPTION
This was added to master, but not to release-19.1.

Closes #38138

Release note: None