### PR TITLE
opt: set not-null columns for ValuesOp

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -632,7 +632,7 @@ query T
 EXPLAIN (OPT,TYPES) SELECT 1 AS r
 ----
 values
- ├── columns: r:1(int)
+ ├── columns: r:1(int!null)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
  ├── cost: 0.02

--- a/pkg/sql/opt/memo/testdata/logprops/constraints-null
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints-null
@@ -13,7 +13,7 @@ opt
 SELECT * FROM t WHERE a = NULL
 ----
 values
- ├── columns: a:1(int) b:2(bool) c:3(string)
+ ├── columns: a:1(int!null) b:2(bool!null) c:3(string!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  ├── fd: ()-->(1-3)
@@ -23,7 +23,7 @@ opt
 SELECT * FROM t WHERE a < NULL
 ----
 values
- ├── columns: a:1(int) b:2(bool) c:3(string)
+ ├── columns: a:1(int!null) b:2(bool!null) c:3(string!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  ├── fd: ()-->(1-3)

--- a/pkg/sql/opt/memo/testdata/logprops/insert
+++ b/pkg/sql/opt/memo/testdata/logprops/insert
@@ -214,7 +214,7 @@ build
 INSERT INTO abcde (a, b) (VALUES (1, 2)) RETURNING *, rowid;
 ----
 insert abcde
- ├── columns: a:1(int!null) b:2(int) c:3(int!null) d:4(int) rowid:5(int!null)
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int) rowid:5(int!null)
  ├── insert-mapping:
  │    ├──  column1:7 => a:1
  │    ├──  column2:8 => b:2
@@ -227,21 +227,21 @@ insert abcde
  ├── key: ()
  ├── fd: ()-->(1-5)
  └── project
-      ├── columns: column12:12(int) column1:7(int) column2:8(int) column9:9(int!null) column10:10(int) column11:11(int)
+      ├── columns: column12:12(int) column1:7(int!null) column2:8(int!null) column9:9(int!null) column10:10(int) column11:11(int)
       ├── cardinality: [1 - 1]
       ├── side-effects
       ├── key: ()
       ├── fd: ()-->(7-12)
       ├── prune: (7-12)
       ├── project
-      │    ├── columns: column9:9(int!null) column10:10(int) column11:11(int) column1:7(int) column2:8(int)
+      │    ├── columns: column9:9(int!null) column10:10(int) column11:11(int) column1:7(int!null) column2:8(int!null)
       │    ├── cardinality: [1 - 1]
       │    ├── side-effects
       │    ├── key: ()
       │    ├── fd: ()-->(7-11)
       │    ├── prune: (7-11)
       │    ├── values
-      │    │    ├── columns: column1:7(int) column2:8(int)
+      │    │    ├── columns: column1:7(int!null) column2:8(int!null)
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(7,8)

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -841,10 +841,10 @@ opt
 SELECT * FROM (SELECT * FROM (VALUES (1), (2))) WHERE NOT EXISTS(SELECT * FROM uv WHERE u=column1)
 ----
 anti-join
- ├── columns: column1:1(int)
+ ├── columns: column1:1(int!null)
  ├── cardinality: [0 - 2]
  ├── values
- │    ├── columns: column1:1(int)
+ │    ├── columns: column1:1(int!null)
  │    ├── cardinality: [2 - 2]
  │    ├── prune: (1)
  │    ├── tuple [type=tuple{int}]
@@ -903,11 +903,11 @@ build
 SELECT * FROM (VALUES (1), (2)) INNER JOIN (SELECT * FROM uv LIMIT 2) ON True
 ----
 inner-join
- ├── columns: column1:1(int) u:2(int) v:3(int!null)
+ ├── columns: column1:1(int!null) u:2(int) v:3(int!null)
  ├── cardinality: [0 - 4]
  ├── prune: (1-3)
  ├── values
- │    ├── columns: column1:1(int)
+ │    ├── columns: column1:1(int!null)
  │    ├── cardinality: [2 - 2]
  │    ├── prune: (1)
  │    ├── tuple [type=tuple{int}]
@@ -936,12 +936,12 @@ build
 SELECT * FROM (VALUES (1), (2), (3)) LEFT JOIN (SELECT * FROM uv LIMIT 2) ON True
 ----
 left-join
- ├── columns: column1:1(int) u:2(int) v:3(int)
+ ├── columns: column1:1(int!null) u:2(int) v:3(int)
  ├── cardinality: [3 - 6]
  ├── prune: (1-3)
  ├── reject-nulls: (2,3)
  ├── values
- │    ├── columns: column1:1(int)
+ │    ├── columns: column1:1(int!null)
  │    ├── cardinality: [3 - 3]
  │    ├── prune: (1)
  │    ├── tuple [type=tuple{int}]
@@ -972,7 +972,7 @@ build
 SELECT * FROM (SELECT * FROM uv LIMIT 2) RIGHT JOIN (VALUES (1), (2), (3)) ON True
 ----
 right-join
- ├── columns: u:1(int) v:2(int) column1:4(int)
+ ├── columns: u:1(int) v:2(int) column1:4(int!null)
  ├── cardinality: [3 - 6]
  ├── prune: (1,2,4)
  ├── reject-nulls: (1,2)
@@ -991,7 +991,7 @@ right-join
  │    │         └── interesting orderings: (+3)
  │    └── const: 2 [type=int]
  ├── values
- │    ├── columns: column1:4(int)
+ │    ├── columns: column1:4(int!null)
  │    ├── cardinality: [3 - 3]
  │    ├── prune: (4)
  │    ├── tuple [type=tuple{int}]
@@ -1078,7 +1078,7 @@ full-join
  │    ├── prune: (1-4)
  │    └── interesting orderings: (+1) (-3,+4,+1)
  ├── values
- │    ├── columns: column1:5(int)
+ │    ├── columns: column1:5(int!null)
  │    ├── cardinality: [2 - 2]
  │    ├── prune: (5)
  │    ├── tuple [type=tuple{int}]
@@ -1527,7 +1527,7 @@ project
  │    │    ├── columns: u:1(int)
  │    │    └── prune: (1)
  │    ├── inner-join
- │    │    ├── columns: u:4(int) v:5(int!null) rowid:6(int!null) mn.m:13(int!null)
+ │    │    ├── columns: u:4(int!null) v:5(int!null) rowid:6(int!null) mn.m:13(int!null)
  │    │    ├── outer: (1)
  │    │    ├── cardinality: [0 - 0]
  │    │    ├── side-effects, mutations
@@ -1535,13 +1535,13 @@ project
  │    │    ├── fd: ()-->(4-6)
  │    │    ├── prune: (13)
  │    │    ├── select
- │    │    │    ├── columns: u:4(int) v:5(int!null) rowid:6(int!null)
+ │    │    │    ├── columns: u:4(int!null) v:5(int!null) rowid:6(int!null)
  │    │    │    ├── cardinality: [0 - 0]
  │    │    │    ├── side-effects, mutations
  │    │    │    ├── key: ()
  │    │    │    ├── fd: ()-->(4-6)
  │    │    │    ├── insert uv
- │    │    │    │    ├── columns: u:4(int) v:5(int!null) rowid:6(int!null)
+ │    │    │    │    ├── columns: u:4(int!null) v:5(int!null) rowid:6(int!null)
  │    │    │    │    ├── insert-mapping:
  │    │    │    │    │    ├──  column1:7 => u:4
  │    │    │    │    │    ├──  column2:8 => v:5
@@ -1551,7 +1551,7 @@ project
  │    │    │    │    ├── key: ()
  │    │    │    │    ├── fd: ()-->(4-6)
  │    │    │    │    └── values
- │    │    │    │         ├── columns: column1:7(int) column2:8(int) column9:9(int)
+ │    │    │    │         ├── columns: column1:7(int!null) column2:8(int!null) column9:9(int)
  │    │    │    │         ├── cardinality: [1 - 1]
  │    │    │    │         ├── side-effects
  │    │    │    │         ├── key: ()
@@ -1564,7 +1564,7 @@ project
  │    │    │    └── filters
  │    │    │         └── false [type=bool]
  │    │    ├── values
- │    │    │    ├── columns: mn.m:13(int)
+ │    │    │    ├── columns: mn.m:13(int!null)
  │    │    │    ├── cardinality: [0 - 0]
  │    │    │    ├── key: ()
  │    │    │    ├── fd: ()-->(13)

--- a/pkg/sql/opt/memo/testdata/logprops/offset
+++ b/pkg/sql/opt/memo/testdata/logprops/offset
@@ -139,10 +139,10 @@ FROM ((SELECT x FROM xyzs LIMIT 10) UNION ALL (SELECT * FROM (VALUES (1), (2), (
 OFFSET 2
 ----
 offset
- ├── columns: x:6(int)
+ ├── columns: x:6(int!null)
  ├── cardinality: [1 - 11]
  ├── union-all
- │    ├── columns: x:6(int)
+ │    ├── columns: x:6(int!null)
  │    ├── left columns: xyzs.x:1(int)
  │    ├── right columns: column1:5(int)
  │    ├── cardinality: [3 - 13]
@@ -165,7 +165,7 @@ offset
  │    │    │         └── interesting orderings: (+1) (-4,+3,+1)
  │    │    └── const: 10 [type=int]
  │    └── values
- │         ├── columns: column1:5(int)
+ │         ├── columns: column1:5(int!null)
  │         ├── cardinality: [3 - 3]
  │         ├── prune: (5)
  │         ├── tuple [type=tuple{int}]
@@ -181,7 +181,7 @@ opt
 SELECT s, x FROM (SELECT * FROM xyzs LIMIT 100) WHERE s='foo' OFFSET 4294967296
 ----
 values
- ├── columns: s:4(string) x:1(int)
+ ├── columns: s:4(string!null) x:1(int!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  ├── fd: ()-->(1,4)

--- a/pkg/sql/opt/memo/testdata/logprops/scan
+++ b/pkg/sql/opt/memo/testdata/logprops/scan
@@ -147,7 +147,7 @@ opt
 SELECT 1 FROM t WHERE a > 1 AND a < 2
 ----
 values
- ├── columns: "?column?":5(int)
+ ├── columns: "?column?":5(int!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  ├── fd: ()-->(5)

--- a/pkg/sql/opt/memo/testdata/logprops/set
+++ b/pkg/sql/opt/memo/testdata/logprops/set
@@ -184,18 +184,18 @@ UNION
 SELECT * FROM (VALUES (6), (7), (8))
 ----
 union
- ├── columns: column1:5(int)
+ ├── columns: column1:5(int!null)
  ├── left columns: column1:3(int)
  ├── right columns: column1:4(int)
  ├── cardinality: [1 - 8]
  ├── key: (5)
  ├── union-all
- │    ├── columns: column1:3(int)
+ │    ├── columns: column1:3(int!null)
  │    ├── left columns: column1:1(int)
  │    ├── right columns: column1:2(int)
  │    ├── cardinality: [5 - 5]
  │    ├── values
- │    │    ├── columns: column1:1(int)
+ │    │    ├── columns: column1:1(int!null)
  │    │    ├── cardinality: [3 - 3]
  │    │    ├── prune: (1)
  │    │    ├── tuple [type=tuple{int}]
@@ -205,7 +205,7 @@ union
  │    │    └── tuple [type=tuple{int}]
  │    │         └── const: 3 [type=int]
  │    └── values
- │         ├── columns: column1:2(int)
+ │         ├── columns: column1:2(int!null)
  │         ├── cardinality: [2 - 2]
  │         ├── prune: (2)
  │         ├── tuple [type=tuple{int}]
@@ -213,7 +213,7 @@ union
  │         └── tuple [type=tuple{int}]
  │              └── const: 5 [type=int]
  └── values
-      ├── columns: column1:4(int)
+      ├── columns: column1:4(int!null)
       ├── cardinality: [3 - 3]
       ├── prune: (4)
       ├── tuple [type=tuple{int}]
@@ -232,18 +232,18 @@ INTERSECT
 SELECT * FROM (VALUES (6), (7), (8))
 ----
 intersect
- ├── columns: column1:1(int)
- ├── left columns: column1:1(int)
+ ├── columns: column1:1(int!null)
+ ├── left columns: column1:1(int!null)
  ├── right columns: column1:3(int)
  ├── cardinality: [0 - 2]
  ├── key: (1)
  ├── intersect-all
- │    ├── columns: column1:1(int)
- │    ├── left columns: column1:1(int)
+ │    ├── columns: column1:1(int!null)
+ │    ├── left columns: column1:1(int!null)
  │    ├── right columns: column1:2(int)
  │    ├── cardinality: [0 - 2]
  │    ├── values
- │    │    ├── columns: column1:1(int)
+ │    │    ├── columns: column1:1(int!null)
  │    │    ├── cardinality: [3 - 3]
  │    │    ├── prune: (1)
  │    │    ├── tuple [type=tuple{int}]
@@ -253,7 +253,7 @@ intersect
  │    │    └── tuple [type=tuple{int}]
  │    │         └── const: 3 [type=int]
  │    └── values
- │         ├── columns: column1:2(int)
+ │         ├── columns: column1:2(int!null)
  │         ├── cardinality: [2 - 2]
  │         ├── prune: (2)
  │         ├── tuple [type=tuple{int}]
@@ -261,7 +261,7 @@ intersect
  │         └── tuple [type=tuple{int}]
  │              └── const: 5 [type=int]
  └── values
-      ├── columns: column1:3(int)
+      ├── columns: column1:3(int!null)
       ├── cardinality: [3 - 3]
       ├── prune: (3)
       ├── tuple [type=tuple{int}]
@@ -280,18 +280,18 @@ EXCEPT
 SELECT * FROM (VALUES (6), (7), (8), (9))
 ----
 except
- ├── columns: column1:1(int)
- ├── left columns: column1:1(int)
+ ├── columns: column1:1(int!null)
+ ├── left columns: column1:1(int!null)
  ├── right columns: column1:3(int)
  ├── cardinality: [0 - 3]
  ├── key: (1)
  ├── except-all
- │    ├── columns: column1:1(int)
- │    ├── left columns: column1:1(int)
+ │    ├── columns: column1:1(int!null)
+ │    ├── left columns: column1:1(int!null)
  │    ├── right columns: column1:2(int)
  │    ├── cardinality: [1 - 3]
  │    ├── values
- │    │    ├── columns: column1:1(int)
+ │    │    ├── columns: column1:1(int!null)
  │    │    ├── cardinality: [3 - 3]
  │    │    ├── prune: (1)
  │    │    ├── tuple [type=tuple{int}]
@@ -301,7 +301,7 @@ except
  │    │    └── tuple [type=tuple{int}]
  │    │         └── const: 3 [type=int]
  │    └── values
- │         ├── columns: column1:2(int)
+ │         ├── columns: column1:2(int!null)
  │         ├── cardinality: [2 - 2]
  │         ├── prune: (2)
  │         ├── tuple [type=tuple{int}]
@@ -309,7 +309,7 @@ except
  │         └── tuple [type=tuple{int}]
  │              └── const: 5 [type=int]
  └── values
-      ├── columns: column1:3(int)
+      ├── columns: column1:3(int!null)
       ├── cardinality: [4 - 4]
       ├── prune: (3)
       ├── tuple [type=tuple{int}]

--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -400,21 +400,21 @@ project
  │    ├── cardinality: [2 - ]
  │    ├── side-effects, mutations
  │    └── project
- │         ├── columns: upsert_b:14(int) upsert_c:15(int) upsert_rowid:16(int) column1:5(int) column6:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int)
+ │         ├── columns: upsert_b:14(int) upsert_c:15(int) upsert_rowid:16(int) column1:5(int!null) column6:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int)
  │         ├── cardinality: [2 - ]
  │         ├── side-effects
  │         ├── fd: ()-->(6,8), (12)-->(9-11), (9)-->(10-12), (10,11)~~>(9,12), (10)-->(13), (10,12)-->(14), (12,13)-->(15), (7,12)-->(16)
  │         ├── prune: (5-16)
  │         ├── interesting orderings: (+12) (+9) (+10,+11,+12)
  │         ├── project
- │         │    ├── columns: column13:13(int) column1:5(int) column6:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+ │         │    ├── columns: column13:13(int) column1:5(int!null) column6:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
  │         │    ├── cardinality: [2 - ]
  │         │    ├── side-effects
  │         │    ├── fd: ()-->(6,8), (12)-->(9-11), (9)-->(10-12), (10,11)~~>(9,12), (10)-->(13)
  │         │    ├── prune: (5-13)
  │         │    ├── interesting orderings: (+12) (+9) (+10,+11,+12)
  │         │    ├── left-join
- │         │    │    ├── columns: column1:5(int) column6:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+ │         │    │    ├── columns: column1:5(int!null) column6:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
  │         │    │    ├── cardinality: [2 - ]
  │         │    │    ├── side-effects
  │         │    │    ├── fd: ()-->(6,8), (12)-->(9-11), (9)-->(10-12), (10,11)~~>(9,12)
@@ -422,19 +422,19 @@ project
  │         │    │    ├── reject-nulls: (9-12)
  │         │    │    ├── interesting orderings: (+12) (+9) (+10,+11,+12)
  │         │    │    ├── project
- │         │    │    │    ├── columns: column8:8(int) column1:5(int) column6:6(int!null) column7:7(int)
+ │         │    │    │    ├── columns: column8:8(int) column1:5(int!null) column6:6(int!null) column7:7(int)
  │         │    │    │    ├── cardinality: [2 - 2]
  │         │    │    │    ├── side-effects
  │         │    │    │    ├── fd: ()-->(6,8)
  │         │    │    │    ├── prune: (5-8)
  │         │    │    │    ├── project
- │         │    │    │    │    ├── columns: column6:6(int!null) column7:7(int) column1:5(int)
+ │         │    │    │    │    ├── columns: column6:6(int!null) column7:7(int) column1:5(int!null)
  │         │    │    │    │    ├── cardinality: [2 - 2]
  │         │    │    │    │    ├── side-effects
  │         │    │    │    │    ├── fd: ()-->(6)
  │         │    │    │    │    ├── prune: (5-7)
  │         │    │    │    │    ├── values
- │         │    │    │    │    │    ├── columns: column1:5(int)
+ │         │    │    │    │    │    ├── columns: column1:5(int!null)
  │         │    │    │    │    │    ├── cardinality: [2 - 2]
  │         │    │    │    │    │    ├── prune: (5)
  │         │    │    │    │    │    ├── tuple [type=tuple{int}]

--- a/pkg/sql/opt/memo/testdata/logprops/values
+++ b/pkg/sql/opt/memo/testdata/logprops/values
@@ -11,7 +11,7 @@ build
 SELECT * FROM (VALUES (1, 2), (3, 4), (NULL, 5))
 ----
 values
- ├── columns: column1:1(int) column2:2(int)
+ ├── columns: column1:1(int) column2:2(int!null)
  ├── cardinality: [3 - 3]
  ├── prune: (1,2)
  ├── tuple [type=tuple{int, int}]
@@ -23,6 +23,40 @@ values
  └── tuple [type=tuple{int, int}]
       ├── null [type=unknown]
       └── const: 5 [type=int]
+
+build
+SELECT * FROM (VALUES (1, 2), (3, 4), (5, 6))
+----
+values
+ ├── columns: column1:1(int!null) column2:2(int!null)
+ ├── cardinality: [3 - 3]
+ ├── prune: (1,2)
+ ├── tuple [type=tuple{int, int}]
+ │    ├── const: 1 [type=int]
+ │    └── const: 2 [type=int]
+ ├── tuple [type=tuple{int, int}]
+ │    ├── const: 3 [type=int]
+ │    └── const: 4 [type=int]
+ └── tuple [type=tuple{int, int}]
+      ├── const: 5 [type=int]
+      └── const: 6 [type=int]
+
+build
+SELECT * FROM (VALUES (NULL, 2), (3, NULL), (5, 6))
+----
+values
+ ├── columns: column1:1(int) column2:2(int)
+ ├── cardinality: [3 - 3]
+ ├── prune: (1,2)
+ ├── tuple [type=tuple{int, int}]
+ │    ├── null [type=unknown]
+ │    └── const: 2 [type=int]
+ ├── tuple [type=tuple{int, int}]
+ │    ├── const: 3 [type=int]
+ │    └── null [type=unknown]
+ └── tuple [type=tuple{int, int}]
+      ├── const: 5 [type=int]
+      └── const: 6 [type=int]
 
 # Propagate outer columns.
 build
@@ -62,7 +96,7 @@ build
 SELECT * FROM (VALUES (1, 2))
 ----
 values
- ├── columns: column1:1(int) column2:2(int)
+ ├── columns: column1:1(int!null) column2:2(int!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1,2)

--- a/pkg/sql/opt/memo/testdata/stats/groupby
+++ b/pkg/sql/opt/memo/testdata/stats/groupby
@@ -500,7 +500,7 @@ project
  │    │    │    ├── stats: [rows=1.5, distinct(1)=1, null(1)=0, distinct(2)=1.29289322, null(2)=1]
  │    │    │    ├── fd: ()-->(1)
  │    │    │    ├── values
- │    │    │    │    ├── columns: column1:1(bool) column2:2(int)
+ │    │    │    │    ├── columns: column1:1(bool!null) column2:2(int)
  │    │    │    │    ├── cardinality: [3 - 3]
  │    │    │    │    ├── stats: [rows=3, distinct(1)=2, null(1)=0, distinct(2)=2, null(2)=2]
  │    │    │    │    ├── (true, NULL) [type=tuple{bool, int}]

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -101,7 +101,7 @@ norm
 SELECT * FROM xysd JOIN uv ON false
 ----
 values
- ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) v:6(int)
+ ├── columns: x:1(int!null) y:2(int!null) s:3(string!null) d:4(decimal!null) u:5(int!null) v:6(int!null)
  ├── cardinality: [0 - 0]
  ├── stats: [rows=0]
  ├── key: ()
@@ -950,7 +950,7 @@ norm
 SELECT * FROM (SELECT 1) JOIN (SELECT 1 WHERE false) ON true
 ----
 values
- ├── columns: "?column?":1(int) "?column?":2(int)
+ ├── columns: "?column?":1(int!null) "?column?":2(int!null)
  ├── cardinality: [0 - 0]
  ├── stats: [rows=0]
  ├── key: ()
@@ -960,20 +960,20 @@ norm
 SELECT * FROM (SELECT 1) LEFT JOIN (SELECT 1 WHERE false) ON true
 ----
 left-join
- ├── columns: "?column?":1(int) "?column?":2(int)
+ ├── columns: "?column?":1(int!null) "?column?":2(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
  ├── key: ()
  ├── fd: ()-->(1,2)
  ├── values
- │    ├── columns: "?column?":1(int)
+ │    ├── columns: "?column?":1(int!null)
  │    ├── cardinality: [1 - 1]
  │    ├── stats: [rows=1]
  │    ├── key: ()
  │    ├── fd: ()-->(1)
  │    └── (1,) [type=tuple{int}]
  ├── values
- │    ├── columns: "?column?":2(int)
+ │    ├── columns: "?column?":2(int!null)
  │    ├── cardinality: [0 - 0]
  │    ├── stats: [rows=0]
  │    ├── key: ()
@@ -984,7 +984,7 @@ norm
 SELECT * FROM (SELECT 1) RIGHT JOIN (SELECT 1 WHERE false) ON true
 ----
 values
- ├── columns: "?column?":1(int) "?column?":2(int)
+ ├── columns: "?column?":1(int!null) "?column?":2(int!null)
  ├── cardinality: [0 - 0]
  ├── stats: [rows=0]
  ├── key: ()
@@ -994,20 +994,20 @@ norm
 SELECT * FROM (SELECT 1) FULL JOIN (SELECT 1 WHERE false) ON true
 ----
 left-join
- ├── columns: "?column?":1(int) "?column?":2(int)
+ ├── columns: "?column?":1(int!null) "?column?":2(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
  ├── key: ()
  ├── fd: ()-->(1,2)
  ├── values
- │    ├── columns: "?column?":1(int)
+ │    ├── columns: "?column?":1(int!null)
  │    ├── cardinality: [1 - 1]
  │    ├── stats: [rows=1]
  │    ├── key: ()
  │    ├── fd: ()-->(1)
  │    └── (1,) [type=tuple{int}]
  ├── values
- │    ├── columns: "?column?":2(int)
+ │    ├── columns: "?column?":2(int!null)
  │    ├── cardinality: [0 - 0]
  │    ├── stats: [rows=0]
  │    ├── key: ()
@@ -1018,7 +1018,7 @@ norm
 SELECT * FROM (SELECT 1 WHERE false) JOIN (SELECT 1) ON true
 ----
 values
- ├── columns: "?column?":1(int) "?column?":2(int)
+ ├── columns: "?column?":1(int!null) "?column?":2(int!null)
  ├── cardinality: [0 - 0]
  ├── stats: [rows=0]
  ├── key: ()
@@ -1028,7 +1028,7 @@ norm
 SELECT * FROM (SELECT 1 WHERE false) LEFT JOIN (SELECT 1) ON true
 ----
 values
- ├── columns: "?column?":1(int) "?column?":2(int)
+ ├── columns: "?column?":1(int!null) "?column?":2(int!null)
  ├── cardinality: [0 - 0]
  ├── stats: [rows=0]
  ├── key: ()
@@ -1038,19 +1038,19 @@ norm
 SELECT * FROM (SELECT 1 WHERE false) RIGHT JOIN (SELECT 1) ON true
 ----
 right-join
- ├── columns: "?column?":1(int) "?column?":2(int)
+ ├── columns: "?column?":1(int) "?column?":2(int!null)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
  ├── key: ()
  ├── fd: ()-->(1,2)
  ├── values
- │    ├── columns: "?column?":1(int)
+ │    ├── columns: "?column?":1(int!null)
  │    ├── cardinality: [0 - 0]
  │    ├── stats: [rows=0]
  │    ├── key: ()
  │    └── fd: ()-->(1)
  ├── values
- │    ├── columns: "?column?":2(int)
+ │    ├── columns: "?column?":2(int!null)
  │    ├── cardinality: [1 - 1]
  │    ├── stats: [rows=1]
  │    ├── key: ()
@@ -1062,19 +1062,19 @@ norm
 SELECT * FROM (SELECT 1 WHERE false) FULL JOIN (SELECT 1) ON true
 ----
 right-join
- ├── columns: "?column?":1(int) "?column?":2(int)
+ ├── columns: "?column?":1(int) "?column?":2(int!null)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
  ├── key: ()
  ├── fd: ()-->(1,2)
  ├── values
- │    ├── columns: "?column?":1(int)
+ │    ├── columns: "?column?":1(int!null)
  │    ├── cardinality: [0 - 0]
  │    ├── stats: [rows=0]
  │    ├── key: ()
  │    └── fd: ()-->(1)
  ├── values
- │    ├── columns: "?column?":2(int)
+ │    ├── columns: "?column?":2(int!null)
  │    ├── cardinality: [1 - 1]
  │    ├── stats: [rows=1]
  │    ├── key: ()
@@ -1086,19 +1086,19 @@ norm
 SELECT * FROM (SELECT 1) FULL JOIN (VALUES (1), (2)) ON true
 ----
 inner-join
- ├── columns: "?column?":1(int) column1:2(int)
+ ├── columns: "?column?":1(int!null) column1:2(int!null)
  ├── cardinality: [2 - 2]
  ├── stats: [rows=2]
  ├── fd: ()-->(1)
  ├── values
- │    ├── columns: "?column?":1(int)
+ │    ├── columns: "?column?":1(int!null)
  │    ├── cardinality: [1 - 1]
  │    ├── stats: [rows=1]
  │    ├── key: ()
  │    ├── fd: ()-->(1)
  │    └── (1,) [type=tuple{int}]
  ├── values
- │    ├── columns: column1:2(int)
+ │    ├── columns: column1:2(int!null)
  │    ├── cardinality: [2 - 2]
  │    ├── stats: [rows=2]
  │    ├── (1,) [type=tuple{int}]

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -70,7 +70,7 @@ norm
 SELECT * FROM a WHERE false
 ----
 values
- ├── columns: x:1(int) y:2(int)
+ ├── columns: x:1(int!null) y:2(int!null)
  ├── cardinality: [0 - 0]
  ├── stats: [rows=0]
  ├── key: ()
@@ -234,7 +234,7 @@ SELECT pk FROM tab0 WHERE
   (col0 = 1 OR col0 IN (SELECT col3 FROM tab0))
 ----
 values
- ├── columns: pk:1(int)
+ ├── columns: pk:1(int!null)
  ├── cardinality: [0 - 0]
  ├── stats: [rows=0]
  ├── key: ()
@@ -1398,7 +1398,7 @@ project
  │    │    ├── key: (2,3)
  │    │    ├── fd: (2,3)-->(4)
  │    │    ├── values
- │    │    │    ├── columns: column1:1(bool) column2:2(string) column3:3(varbit)
+ │    │    │    ├── columns: column1:1(bool!null) column2:2(string) column3:3(varbit)
  │    │    │    ├── cardinality: [2 - 2]
  │    │    │    ├── stats: [rows=2, distinct(2,3)=2, null(2,3)=2]
  │    │    │    ├── (true, NULL, B'001000101101110') [type=tuple{bool, string, varbit}]

--- a/pkg/sql/opt/memo/testdata/stats/set
+++ b/pkg/sql/opt/memo/testdata/stats/set
@@ -865,21 +865,21 @@ SELECT * FROM
 WHERE a IS NULL and b
 ----
 except
- ├── columns: a:5(int) b:2(bool)
- ├── left columns: column1:5(int) column2:2(bool)
+ ├── columns: a:5(int) b:2(bool!null)
+ ├── left columns: column1:5(int) column2:2(bool!null)
  ├── right columns: column1:3(int) column2:6(bool)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1, distinct(2,5)=1, null(2,5)=1]
  ├── key: (2,5)
  ├── values
- │    ├── columns: column2:2(bool) column1:5(int)
+ │    ├── columns: column2:2(bool!null) column1:5(int)
  │    ├── cardinality: [1 - 1]
  │    ├── stats: [rows=1, distinct(2,5)=1, null(2,5)=1]
  │    ├── key: ()
  │    ├── fd: ()-->(2,5)
  │    └── (true, NULL) [type=tuple{bool, int}]
  └── values
-      ├── columns: column1:3(int) column2:6(bool)
+      ├── columns: column1:3(int!null) column2:6(bool!null)
       ├── cardinality: [0 - 0]
       ├── stats: [rows=0, distinct(3,6)=0, null(3,6)=0]
       ├── key: ()
@@ -913,14 +913,14 @@ except
  │    └── filters
  │         └── column1 IS NULL [type=bool, outer=(1), constraints=(/1: [/NULL - /NULL]; tight), fd=()-->(1)]
  └── select
-      ├── columns: column1:3(int) column2:4(int)
+      ├── columns: column1:3(int!null) column2:4(int!null)
       ├── cardinality: [0 - 3]
-      ├── stats: [rows=1, distinct(3)=1, null(3)=0, distinct(3,4)=1, null(3,4)=0]
+      ├── stats: [rows=1, distinct(3)=1, null(3)=0, distinct(4)=1, null(4)=0, distinct(3,4)=1, null(3,4)=0]
       ├── fd: ()-->(3)
       ├── values
-      │    ├── columns: column1:3(int) column2:4(int)
+      │    ├── columns: column1:3(int!null) column2:4(int!null)
       │    ├── cardinality: [3 - 3]
-      │    ├── stats: [rows=3, distinct(3)=3, null(3)=0, distinct(3,4)=3, null(3,4)=0]
+      │    ├── stats: [rows=3, distinct(3)=3, null(3)=0, distinct(4)=3, null(4)=0, distinct(3,4)=3, null(3,4)=0]
       │    ├── (1, 2) [type=tuple{int, int}]
       │    ├── (2, 3) [type=tuple{int, int}]
       │    └── (3, 4) [type=tuple{int, int}]
@@ -945,7 +945,7 @@ sort
       ├── stats: [rows=1, distinct(1)=1, null(1)=0]
       ├── key: (1)
       ├── values
-      │    ├── columns: column1:1(int)
+      │    ├── columns: column1:1(int!null)
       │    ├── cardinality: [1 - 1]
       │    ├── stats: [rows=1, distinct(1)=1, null(1)=0]
       │    ├── key: ()

--- a/pkg/sql/opt/memo/testdata/stats/values
+++ b/pkg/sql/opt/memo/testdata/stats/values
@@ -7,7 +7,7 @@ select
  ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0]
  ├── fd: ()-->(1,2)
  ├── values
- │    ├── columns: column1:1(int) column2:2(int)
+ │    ├── columns: column1:1(int!null) column2:2(int!null)
  │    ├── cardinality: [4 - 4]
  │    ├── stats: [rows=4, distinct(1)=2, null(1)=0, distinct(2)=2, null(2)=0]
  │    ├── (1, 2) [type=tuple{int, int}]
@@ -22,13 +22,13 @@ norm
 SELECT x, y FROM (VALUES (1, 2), (1, 2), (1, 3), (2, 3)) AS q(x, y) GROUP BY x, y
 ----
 distinct-on
- ├── columns: x:1(int) y:2(int)
- ├── grouping columns: column1:1(int) column2:2(int)
+ ├── columns: x:1(int!null) y:2(int!null)
+ ├── grouping columns: column1:1(int!null) column2:2(int!null)
  ├── cardinality: [1 - 4]
  ├── stats: [rows=3, distinct(1,2)=3, null(1,2)=0]
  ├── key: (1,2)
  └── values
-      ├── columns: column1:1(int) column2:2(int)
+      ├── columns: column1:1(int!null) column2:2(int!null)
       ├── cardinality: [4 - 4]
       ├── stats: [rows=4, distinct(1,2)=3, null(1,2)=0]
       ├── (1, 2) [type=tuple{int, int}]
@@ -40,7 +40,7 @@ norm
 SELECT * FROM (VALUES (1), (1), (1), (2))
 ----
 values
- ├── columns: column1:1(int)
+ ├── columns: column1:1(int!null)
  ├── cardinality: [4 - 4]
  ├── stats: [rows=4]
  ├── (1,) [type=tuple{int}]
@@ -57,7 +57,7 @@ select
  ├── stats: [rows=2, distinct(1)=1, null(1)=0]
  ├── fd: ()-->(1)
  ├── values
- │    ├── columns: column1:1(int)
+ │    ├── columns: column1:1(int!null)
  │    ├── cardinality: [4 - 4]
  │    ├── stats: [rows=4, distinct(1)=2, null(1)=0]
  │    ├── (1,) [type=tuple{int}]
@@ -108,7 +108,7 @@ norm colstat=1 colstat=2
 SELECT * FROM (VALUES (NULL, 1))
 ----
 values
- ├── columns: column1:1(unknown) column2:2(int)
+ ├── columns: column1:1(unknown) column2:2(int!null)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1, distinct(1)=1, null(1)=1, distinct(2)=1, null(2)=0]
  ├── key: ()

--- a/pkg/sql/opt/norm/testdata/rules/bool
+++ b/pkg/sql/opt/norm/testdata/rules/bool
@@ -226,7 +226,7 @@ opt expect=SimplifyFalseOr
 SELECT * FROM a WHERE false OR false OR false
 ----
 values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(1-5)
@@ -313,7 +313,7 @@ opt expect=(FoldNotTrue,FoldNotFalse)
 SELECT NOT(1=1), NOT(1=2)
 ----
 values
- ├── columns: "?column?":1(bool) "?column?":2(bool)
+ ├── columns: "?column?":1(bool!null) "?column?":2(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1,2)

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -302,7 +302,7 @@ WHERE
     null::jsonb ?& ARRAY['foo'] OR '{}' ?& null::string[]
 ----
 values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) d:6(date)
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb!null) d:6(date!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(1-6)
@@ -314,7 +314,7 @@ opt expect=FoldIsNull
 SELECT NULL IS NULL AS r
 ----
 values
- ├── columns: r:1(bool)
+ ├── columns: r:1(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -327,7 +327,7 @@ opt expect=FoldNonNullIsNull
 SELECT 1 IS NULL AS r
 ----
 values
- ├── columns: r:1(bool)
+ ├── columns: r:1(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -337,7 +337,7 @@ opt expect=FoldNonNullIsNull
 SELECT (1, 2, 3) IS NULL AS r
 ----
 values
- ├── columns: r:1(bool)
+ ├── columns: r:1(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -350,7 +350,7 @@ opt expect=FoldIsNotNull
 SELECT NULL IS NOT NULL AS r, NULL IS NOT TRUE AS s
 ----
 values
- ├── columns: r:1(bool) s:2(bool)
+ ├── columns: r:1(bool!null) s:2(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1,2)
@@ -381,7 +381,7 @@ opt expect=FoldNonNullIsNotNull
 SELECT (1, 2, 3) IS NOT NULL AS r
 ----
 values
- ├── columns: r:1(bool)
+ ├── columns: r:1(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -394,7 +394,7 @@ opt expect=CommuteNullIs
 SELECT NULL IS NOT TRUE AS r, NULL IS TRUE AS s
 ----
 values
- ├── columns: r:1(bool) s:2(bool)
+ ├── columns: r:1(bool!null) s:2(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1,2)

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -134,21 +134,21 @@ upsert xy
  ├── cardinality: [2 - ]
  ├── side-effects, mutations
  └── project
-      ├── columns: upsert_x:9(int) upsert_y:10(int) column1:3(int) column2:4(int) x:5(int) y:6(int)
+      ├── columns: upsert_x:9(int) upsert_y:10(int) column1:3(int!null) column2:4(int!null) x:5(int) y:6(int)
       ├── cardinality: [2 - ]
       ├── fd: (5)-->(6)
       ├── left-join (lookup uv)
-      │    ├── columns: column1:3(int) column2:4(int) x:5(int) y:6(int) u:7(int) v:8(int)
+      │    ├── columns: column1:3(int!null) column2:4(int!null) x:5(int) y:6(int) u:7(int) v:8(int)
       │    ├── key columns: [3] = [7]
       │    ├── cardinality: [2 - ]
       │    ├── fd: (5)-->(6), (7)-->(8)
       │    ├── left-join (lookup xy)
-      │    │    ├── columns: column1:3(int) column2:4(int) x:5(int) y:6(int)
+      │    │    ├── columns: column1:3(int!null) column2:4(int!null) x:5(int) y:6(int)
       │    │    ├── key columns: [3] = [5]
       │    │    ├── cardinality: [2 - ]
       │    │    ├── fd: (5)-->(6)
       │    │    ├── values
-      │    │    │    ├── columns: column1:3(int) column2:4(int)
+      │    │    │    ├── columns: column1:3(int!null) column2:4(int!null)
       │    │    │    ├── cardinality: [2 - 2]
       │    │    │    ├── (1, 2) [type=tuple{int, int}]
       │    │    │    └── (3, 4) [type=tuple{int, int}]
@@ -399,12 +399,12 @@ project
       │    ├── key: (8)
       │    ├── fd: (8)-->(1), (2)-->(3), (1)==(2), (2)==(1)
       │    ├── ordinality
-      │    │    ├── columns: column1:1(int) rownum:8(int!null)
+      │    │    ├── columns: column1:1(int!null) rownum:8(int!null)
       │    │    ├── cardinality: [3 - 3]
       │    │    ├── key: (8)
       │    │    ├── fd: (8)-->(1)
       │    │    └── values
-      │    │         ├── columns: column1:1(int)
+      │    │         ├── columns: column1:1(int!null)
       │    │         ├── cardinality: [3 - 3]
       │    │         ├── (1,) [type=tuple{int}]
       │    │         ├── (1,) [type=tuple{int}]
@@ -439,12 +439,12 @@ project
       │    │    ├── key: (8)
       │    │    ├── fd: (8)-->(1)
       │    │    ├── ordinality
-      │    │    │    ├── columns: column1:1(int) rownum:8(int!null)
+      │    │    │    ├── columns: column1:1(int!null) rownum:8(int!null)
       │    │    │    ├── cardinality: [3 - 3]
       │    │    │    ├── key: (8)
       │    │    │    ├── fd: (8)-->(1)
       │    │    │    └── values
-      │    │    │         ├── columns: column1:1(int)
+      │    │    │         ├── columns: column1:1(int!null)
       │    │    │         ├── cardinality: [3 - 3]
       │    │    │         ├── (1,) [type=tuple{int}]
       │    │    │         ├── (1,) [type=tuple{int}]
@@ -484,12 +484,12 @@ project
       │         ├── key: (9)
       │         ├── fd: (9)-->(1), (2)-->(3), (1)==(2), (2)==(1)
       │         ├── ordinality
-      │         │    ├── columns: column1:1(int) rownum:9(int!null)
+      │         │    ├── columns: column1:1(int!null) rownum:9(int!null)
       │         │    ├── cardinality: [3 - 3]
       │         │    ├── key: (9)
       │         │    ├── fd: (9)-->(1)
       │         │    └── values
-      │         │         ├── columns: column1:1(int)
+      │         │         ├── columns: column1:1(int!null)
       │         │         ├── cardinality: [3 - 3]
       │         │         ├── (1,) [type=tuple{int}]
       │         │         ├── (1,) [type=tuple{int}]
@@ -511,27 +511,27 @@ FROM
     LATERAL (SELECT row_number() OVER (PARTITION BY x ORDER BY y), i FROM (SELECT * FROM a WHERE k = x))
 ----
 project
- ├── columns: x:1(int!null) y:2(int) row_number:8(int) i:4(int)
+ ├── columns: x:1(int!null) y:2(int!null) row_number:8(int) i:4(int)
  ├── fd: (1)-->(4)
  └── window partition=(11)
-      ├── columns: column1:1(int!null) column2:2(int) i:4(int) row_number:8(int) rownum:11(int!null)
+      ├── columns: column1:1(int!null) column2:2(int!null) i:4(int) row_number:8(int) rownum:11(int!null)
       ├── key: (11)
       ├── fd: (11)-->(1,2), (1)-->(4)
       ├── project
-      │    ├── columns: column1:1(int!null) column2:2(int) i:4(int) rownum:11(int!null)
+      │    ├── columns: column1:1(int!null) column2:2(int!null) i:4(int) rownum:11(int!null)
       │    ├── key: (11)
       │    ├── fd: (11)-->(1,2), (1)-->(4)
       │    └── inner-join
-      │         ├── columns: column1:1(int!null) column2:2(int) k:3(int!null) i:4(int) rownum:11(int!null)
+      │         ├── columns: column1:1(int!null) column2:2(int!null) k:3(int!null) i:4(int) rownum:11(int!null)
       │         ├── key: (11)
       │         ├── fd: (11)-->(1,2), (3)-->(4), (1)==(3), (3)==(1)
       │         ├── ordinality
-      │         │    ├── columns: column1:1(int) column2:2(int) rownum:11(int!null)
+      │         │    ├── columns: column1:1(int!null) column2:2(int!null) rownum:11(int!null)
       │         │    ├── cardinality: [3 - 3]
       │         │    ├── key: (11)
       │         │    ├── fd: (11)-->(1,2)
       │         │    └── values
-      │         │         ├── columns: column1:1(int) column2:2(int)
+      │         │         ├── columns: column1:1(int!null) column2:2(int!null)
       │         │         ├── cardinality: [3 - 3]
       │         │         ├── (1, 2) [type=tuple{int, int}]
       │         │         ├── (1, 3) [type=tuple{int, int}]
@@ -1670,10 +1670,10 @@ WHERE EXISTS(
 )
 ----
 semi-join-apply
- ├── columns: v1:1(int)
+ ├── columns: v1:1(int!null)
  ├── cardinality: [0 - 2]
  ├── values
- │    ├── columns: column1:1(int)
+ │    ├── columns: column1:1(int!null)
  │    ├── cardinality: [2 - 2]
  │    ├── (1,) [type=tuple{int}]
  │    └── (2,) [type=tuple{int}]
@@ -4708,20 +4708,20 @@ opt expect=HoistProjectSetSubquery
 SELECT a, generate_series(1, (SELECT a)) FROM (VALUES (1)) AS v (a)
 ----
 project
- ├── columns: a:1(int) generate_series:3(int)
+ ├── columns: a:1(int!null) generate_series:3(int)
  ├── side-effects
  ├── fd: ()-->(1)
  └── project-set
-      ├── columns: column1:1(int) a:2(int) generate_series:3(int)
+      ├── columns: column1:1(int!null) a:2(int) generate_series:3(int)
       ├── side-effects
       ├── fd: ()-->(1,2)
       ├── inner-join-apply
-      │    ├── columns: column1:1(int) a:2(int)
+      │    ├── columns: column1:1(int!null) a:2(int)
       │    ├── cardinality: [1 - 1]
       │    ├── key: ()
       │    ├── fd: ()-->(1,2)
       │    ├── values
-      │    │    ├── columns: column1:1(int)
+      │    │    ├── columns: column1:1(int!null)
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(1)
@@ -4743,25 +4743,25 @@ opt expect=HoistProjectSetSubquery
 SELECT a, generate_series(1, (SELECT a)), generate_series(1, (SELECT a)) FROM (VALUES (1)) AS v (a)
 ----
 project
- ├── columns: a:1(int) generate_series:3(int) generate_series:5(int)
+ ├── columns: a:1(int!null) generate_series:3(int) generate_series:5(int)
  ├── side-effects
  ├── fd: ()-->(1)
  └── project-set
-      ├── columns: column1:1(int) a:2(int) generate_series:3(int) a:4(int) generate_series:5(int)
+      ├── columns: column1:1(int!null) a:2(int) generate_series:3(int) a:4(int) generate_series:5(int)
       ├── side-effects
       ├── fd: ()-->(1,2,4)
       ├── inner-join-apply
-      │    ├── columns: column1:1(int) a:2(int) a:4(int)
+      │    ├── columns: column1:1(int!null) a:2(int) a:4(int)
       │    ├── cardinality: [1 - 1]
       │    ├── key: ()
       │    ├── fd: ()-->(1,2,4)
       │    ├── inner-join-apply
-      │    │    ├── columns: column1:1(int) a:2(int)
+      │    │    ├── columns: column1:1(int!null) a:2(int)
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(1,2)
       │    │    ├── values
-      │    │    │    ├── columns: column1:1(int)
+      │    │    │    ├── columns: column1:1(int!null)
       │    │    │    ├── cardinality: [1 - 1]
       │    │    │    ├── key: ()
       │    │    │    ├── fd: ()-->(1)

--- a/pkg/sql/opt/norm/testdata/rules/fold_constants
+++ b/pkg/sql/opt/norm/testdata/rules/fold_constants
@@ -173,7 +173,7 @@ opt expect=FoldArray
 SELECT ARRAY['foo', 'bar']
 ----
 values
- ├── columns: array:1(string[])
+ ├── columns: array:1(string[]!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -187,7 +187,7 @@ opt expect=FoldBinary
 SELECT 1::INT + 2::DECIMAL
 ----
 values
- ├── columns: "?column?":1(decimal)
+ ├── columns: "?column?":1(decimal!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -209,7 +209,7 @@ opt expect=FoldBinary
 SELECT 1::INT - 2::INT
 ----
 values
- ├── columns: "?column?":1(int)
+ ├── columns: "?column?":1(int!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -231,7 +231,7 @@ opt expect=FoldBinary
 SELECT 4::INT * 2::INT
 ----
 values
- ├── columns: "?column?":1(int)
+ ├── columns: "?column?":1(int!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -253,7 +253,7 @@ opt expect=FoldBinary
 SELECT 1::FLOAT / 2::FLOAT
 ----
 values
- ├── columns: "?column?":1(float)
+ ├── columns: "?column?":1(float!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -276,7 +276,7 @@ opt expect=FoldBinary
 SELECT B'01' # B'11'
 ----
 values
- ├── columns: "?column?":1(varbit)
+ ├── columns: "?column?":1(varbit!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -298,7 +298,7 @@ opt expect=FoldBinary
 SELECT B'01' | B'11'
 ----
 values
- ├── columns: "?column?":1(varbit)
+ ├── columns: "?column?":1(varbit!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -320,7 +320,7 @@ opt expect=FoldBinary
 SELECT '2000-05-05 10:00:00+03':::TIMESTAMP - '2000-05-06 10:00:00+03':::TIMESTAMP
 ----
 values
- ├── columns: "?column?":1(interval)
+ ├── columns: "?column?":1(interval!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -331,7 +331,7 @@ opt expect=FoldBinary
 SELECT '2000-05-05 10:00:00+03':::TIMESTAMP - '2000-05-06 10:00:00+03':::TIMESTAMPTZ
 ----
 values
- ├── columns: "?column?":1(interval)
+ ├── columns: "?column?":1(interval!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -342,7 +342,7 @@ opt expect=FoldBinary
 SELECT ARRAY['a','b','c'] || 'd'
 ----
 values
- ├── columns: "?column?":1(string[])
+ ├── columns: "?column?":1(string[]!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -353,7 +353,7 @@ opt expect=FoldBinary
 SELECT ARRAY['a','b','c'] || ARRAY['d','e','f']
 ----
 values
- ├── columns: "?column?":1(string[])
+ ├── columns: "?column?":1(string[]!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -364,7 +364,7 @@ opt expect=FoldBinary
 SELECT ARRAY[1,2,3] || NULL
 ----
 values
- ├── columns: "?column?":1(int[])
+ ├── columns: "?column?":1(int[]!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -388,7 +388,7 @@ opt expect=FoldUnary
 SELECT -(1:::int)
 ----
 values
- ├── columns: "?column?":1(int)
+ ├── columns: "?column?":1(int!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -398,7 +398,7 @@ opt expect=FoldUnary
 SELECT -(1:::float)
 ----
 values
- ├── columns: "?column?":1(float)
+ ├── columns: "?column?":1(float!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -425,7 +425,7 @@ opt expect=FoldUnary format=show-all
 SELECT -(1:::decimal)
 ----
 values
- ├── columns: "?column?":1(decimal)
+ ├── columns: "?column?":1(decimal!null)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
  ├── cost: 0.02
@@ -439,7 +439,7 @@ opt expect=FoldUnary format=show-all
 SELECT -('-1d'::interval);
 ----
 values
- ├── columns: "?column?":1(interval)
+ ├── columns: "?column?":1(interval!null)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
  ├── cost: 0.02
@@ -455,7 +455,7 @@ opt expect=FoldUnary
 SELECT -('-9223372036854775808d'::interval);
 ----
 values
- ├── columns: "?column?":1(interval)
+ ├── columns: "?column?":1(interval!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -466,7 +466,7 @@ opt expect=FoldUnary
 SELECT ~(500::INT)
 ----
 values
- ├── columns: "?column?":1(int)
+ ├── columns: "?column?":1(int!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -477,7 +477,7 @@ opt expect=FoldUnary
 SELECT ~('35.231.178.195'::INET)
 ----
 values
- ├── columns: "?column?":1(inet)
+ ├── columns: "?column?":1(inet!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -490,7 +490,7 @@ opt expect=FoldComparison
 SELECT 1::INT < 2::INT
 ----
 values
- ├── columns: "?column?":1(bool)
+ ├── columns: "?column?":1(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -500,7 +500,7 @@ opt expect=FoldComparison
 SELECT 1::INT > 2::INT
 ----
 values
- ├── columns: "?column?":1(bool)
+ ├── columns: "?column?":1(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -510,7 +510,7 @@ opt expect=FoldComparison
 SELECT 10.0::FLOAT <= 20.0::FLOAT
 ----
 values
- ├── columns: "?column?":1(bool)
+ ├── columns: "?column?":1(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -520,7 +520,7 @@ opt expect=FoldComparison
 SELECT 10.0::FLOAT >= 20.0::FLOAT
 ----
 values
- ├── columns: "?column?":1(bool)
+ ├── columns: "?column?":1(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -530,7 +530,7 @@ opt expect=FoldComparison
 SELECT 2.0::DECIMAL = 2::INT
 ----
 values
- ├── columns: "?column?":1(bool)
+ ├── columns: "?column?":1(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -540,7 +540,7 @@ opt expect=FoldComparison
 SELECT 2.0::DECIMAL != 2::INT
 ----
 values
- ├── columns: "?column?":1(bool)
+ ├── columns: "?column?":1(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -550,7 +550,7 @@ opt expect=FoldComparison
 SELECT 100 IS NOT DISTINCT FROM 200
 ----
 values
- ├── columns: "?column?":1(bool)
+ ├── columns: "?column?":1(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -560,7 +560,7 @@ opt expect=FoldComparison
 SELECT 100 IS DISTINCT FROM 200
 ----
 values
- ├── columns: "?column?":1(bool)
+ ├── columns: "?column?":1(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -570,7 +570,7 @@ opt expect=FoldComparison
 SELECT 'foo' IN ('a', 'b', 'c')
 ----
 values
- ├── columns: "?column?":1(bool)
+ ├── columns: "?column?":1(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -580,7 +580,7 @@ opt expect=FoldComparison
 SELECT 'foo' NOT IN ('a', 'b', 'c')
 ----
 values
- ├── columns: "?column?":1(bool)
+ ├── columns: "?column?":1(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -590,7 +590,7 @@ opt expect=FoldComparison
 SELECT 'foo' LIKE 'foobar'
 ----
 values
- ├── columns: "?column?":1(bool)
+ ├── columns: "?column?":1(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -600,7 +600,7 @@ opt expect=FoldComparison
 SELECT 'foo' NOT LIKE 'foobar'
 ----
 values
- ├── columns: "?column?":1(bool)
+ ├── columns: "?column?":1(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -610,7 +610,7 @@ opt expect=FoldComparison
 SELECT 'foo' ILIKE 'FOO%'
 ----
 values
- ├── columns: "?column?":1(bool)
+ ├── columns: "?column?":1(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -620,7 +620,7 @@ opt expect=FoldComparison
 SELECT 'foo' NOT ILIKE 'FOO%'
 ----
 values
- ├── columns: "?column?":1(bool)
+ ├── columns: "?column?":1(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -630,7 +630,7 @@ opt expect=FoldComparison
 SELECT 'monday' SIMILAR TO '_onday'
 ----
 values
- ├── columns: "?column?":1(bool)
+ ├── columns: "?column?":1(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -640,7 +640,7 @@ opt expect=FoldComparison
 SELECT 'monday' NOT SIMILAR TO '_onday'
 ----
 values
- ├── columns: "?column?":1(bool)
+ ├── columns: "?column?":1(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -650,7 +650,7 @@ opt expect=FoldComparison
 SELECT 'tuEsday' ~ 't[uU][eE]sday'
 ----
 values
- ├── columns: "?column?":1(bool)
+ ├── columns: "?column?":1(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -660,7 +660,7 @@ opt expect=FoldComparison
 SELECT 'tuEsday' !~ 't[uU][eE]sday'
 ----
 values
- ├── columns: "?column?":1(bool)
+ ├── columns: "?column?":1(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -670,7 +670,7 @@ opt expect=FoldComparison
 SELECT 'wednesday' ~* 'W.*y'
 ----
 values
- ├── columns: "?column?":1(bool)
+ ├── columns: "?column?":1(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -680,7 +680,7 @@ opt expect=FoldComparison
 SELECT 'wednesday' !~* 'W.*y'
 ----
 values
- ├── columns: "?column?":1(bool)
+ ├── columns: "?column?":1(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -690,7 +690,7 @@ opt expect=FoldComparison
 SELECT '[1, 2]'::JSONB <@ '[1, 2, 3]'::JSONB
 ----
 values
- ├── columns: "?column?":1(bool)
+ ├── columns: "?column?":1(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -700,7 +700,7 @@ opt expect=FoldComparison
 SELECT ('a', 'b', 'c') = ('d', 'e', 'f')
 ----
 values
- ├── columns: "?column?":1(bool)
+ ├── columns: "?column?":1(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -713,7 +713,7 @@ opt expect=FoldCast
 SELECT 1::int/1
 ----
 values
- ├── columns: "?column?":1(decimal)
+ ├── columns: "?column?":1(decimal!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -726,7 +726,7 @@ opt expect=FoldFunction
 SELECT length('abc'), upper('xyz'), lower('DEF')
 ----
 values
- ├── columns: length:1(int) upper:2(string) lower:3(string)
+ ├── columns: length:1(int!null) upper:2(string!null) lower:3(string!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1-3)
@@ -736,7 +736,7 @@ opt expect=FoldFunction
 SELECT encode('abc', 'hex'), decode('616263', 'hex')
 ----
 values
- ├── columns: encode:1(string) decode:2(bytes)
+ ├── columns: encode:1(string!null) decode:2(bytes!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1,2)
@@ -746,7 +746,7 @@ opt expect=FoldFunction locality=(region=east,dc=east1-b)
 SELECT crdb_internal.locality_value('dc')
 ----
 values
- ├── columns: crdb_internal.locality_value:1(string)
+ ├── columns: crdb_internal.locality_value:1(string!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -881,7 +881,7 @@ opt expect=FoldColumnAccess
 SELECT (ARRAY[(('foo', 'bar') AS foo, bar)][1]).foo
 ----
 values
- ├── columns: foo:1(string)
+ ├── columns: foo:1(string!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -130,7 +130,7 @@ project
  ├── columns: "?column?":3(int)
  ├── cardinality: [2 - 2]
  ├── values
- │    ├── columns: column1:1(int) column2:2(int)
+ │    ├── columns: column1:1(int!null) column2:2(int!null)
  │    ├── cardinality: [2 - 2]
  │    ├── (1, 2) [type=tuple{int, int}]
  │    └── (3, 4) [type=tuple{int, int}]
@@ -159,13 +159,13 @@ FROM (VALUES ($1:::int, 1, $2:::float, 2)) AS t(one, two, three, four)
 WHERE one = two OR three = four
 ----
 select
- ├── columns: one:1(int) two:2(int) three:3(float) four:4(int)
+ ├── columns: one:1(int) two:2(int!null) three:3(float) four:4(int!null)
  ├── cardinality: [0 - 1]
  ├── has-placeholder
  ├── key: ()
  ├── fd: ()-->(1-4)
  ├── values
- │    ├── columns: column1:1(int) column2:2(int) column3:3(float) column4:4(int)
+ │    ├── columns: column1:1(int) column2:2(int!null) column3:3(float) column4:4(int!null)
  │    ├── cardinality: [1 - 1]
  │    ├── has-placeholder
  │    ├── key: ()
@@ -210,7 +210,7 @@ select
  ├── cardinality: [0 - 2]
  ├── fd: (1)==(2), (2)==(1)
  ├── values
- │    ├── columns: column1:1(int) column2:2(int)
+ │    ├── columns: column1:1(int!null) column2:2(int!null)
  │    ├── cardinality: [2 - 2]
  │    ├── (1, 2) [type=tuple{int, int}]
  │    └── (3, 4) [type=tuple{int, int}]
@@ -224,12 +224,12 @@ opt expect=InlineJoinConstantsLeft
 SELECT * FROM (SELECT 1 AS one) LEFT JOIN a ON k=one
 ----
 left-join
- ├── columns: one:1(int) k:2(int) i:3(int) f:4(float) s:5(string) j:6(jsonb)
+ ├── columns: one:1(int!null) k:2(int) i:3(int) f:4(float) s:5(string) j:6(jsonb)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1-6)
  ├── values
- │    ├── columns: one:1(int)
+ │    ├── columns: one:1(int!null)
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(1)
@@ -246,7 +246,7 @@ opt expect=InlineJoinConstantsRight
 SELECT * FROM a RIGHT JOIN (SELECT 1 AS one) ON k=one
 ----
 right-join
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) one:6(int)
+ ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) one:6(int!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1-6)
@@ -257,7 +257,7 @@ right-join
  │    ├── key: ()
  │    └── fd: ()-->(1-5)
  ├── values
- │    ├── columns: one:6(int)
+ │    ├── columns: one:6(int!null)
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(6)
@@ -268,7 +268,7 @@ opt expect=(InlineJoinConstantsLeft,InlineJoinConstantsRight)
 SELECT * FROM (SELECT 1 AS one) INNER JOIN (SELECT 2 AS two) ON one=two
 ----
 values
- ├── columns: one:1(int) two:2(int)
+ ├── columns: one:1(int!null) two:2(int!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(1,2)

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -95,7 +95,7 @@ opt expect=DetectJoinContradiction
 SELECT * FROM a INNER JOIN b ON k IN ()
 ----
 values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb!null) x:6(int!null) y:7(int!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(1-7)
@@ -112,7 +112,7 @@ left-join
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  ├── values
- │    ├── columns: x:6(int) y:7(int)
+ │    ├── columns: x:6(int!null) y:7(int!null)
  │    ├── cardinality: [0 - 0]
  │    ├── key: ()
  │    └── fd: ()-->(6,7)
@@ -830,15 +830,15 @@ inner-join
  ├── cardinality: [0 - 4]
  ├── fd: (1)==(2), (2)==(1)
  ├── values
- │    ├── columns: column1:2(decimal)
+ │    ├── columns: column1:2(decimal!null)
  │    ├── cardinality: [2 - 2]
  │    ├── (1.00,) [type=tuple{decimal}]
  │    └── (2.00,) [type=tuple{decimal}]
  ├── select
- │    ├── columns: column1:1(decimal)
+ │    ├── columns: column1:1(decimal!null)
  │    ├── cardinality: [0 - 2]
  │    ├── values
- │    │    ├── columns: column1:1(decimal)
+ │    │    ├── columns: column1:1(decimal!null)
  │    │    ├── cardinality: [2 - 2]
  │    │    ├── (1.0,) [type=tuple{decimal}]
  │    │    └── (2.0,) [type=tuple{decimal}]
@@ -2106,7 +2106,7 @@ norm expect=SimplifyJoinNotNullEquality
 SELECT * FROM a INNER JOIN b ON (a.k=b.x) IS Null
 ----
 values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb!null) x:6(int!null) y:7(int!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(1-7)

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -76,13 +76,13 @@ opt
 SELECT * FROM (SELECT * FROM a LIMIT 0) LIMIT -1
 ----
 limit
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb!null)
  ├── cardinality: [0 - 0]
  ├── side-effects
  ├── key: ()
  ├── fd: ()-->(1-5)
  ├── values
- │    ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb!null)
  │    ├── cardinality: [0 - 0]
  │    ├── key: ()
  │    └── fd: ()-->(1-5)

--- a/pkg/sql/opt/norm/testdata/rules/max1row
+++ b/pkg/sql/opt/norm/testdata/rules/max1row
@@ -73,7 +73,7 @@ values
       └── gt [type=bool]
            ├── subquery [type=int]
            │    └── values
-           │         ├── columns: i:2(int)
+           │         ├── columns: i:2(int!null)
            │         ├── cardinality: [0 - 0]
            │         ├── key: ()
            │         └── fd: ()-->(2)

--- a/pkg/sql/opt/norm/testdata/rules/numeric
+++ b/pkg/sql/opt/norm/testdata/rules/numeric
@@ -93,7 +93,7 @@ opt expect-not=FoldMinusZero
 SELECT '[123]'::jsonb - 0
 ----
 values
- ├── columns: "?column?":1(jsonb)
+ ├── columns: "?column?":1(jsonb!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)

--- a/pkg/sql/opt/norm/testdata/rules/ordering
+++ b/pkg/sql/opt/norm/testdata/rules/ordering
@@ -230,7 +230,7 @@ project
  └── explain
       ├── columns: tree:2(string) field:3(string) description:4(string)
       └── values
-           ├── columns: k:1(int)
+           ├── columns: k:1(int!null)
            ├── cardinality: [1 - 1]
            ├── key: ()
            ├── fd: ()-->(1)

--- a/pkg/sql/opt/norm/testdata/rules/project
+++ b/pkg/sql/opt/norm/testdata/rules/project
@@ -168,7 +168,7 @@ opt expect=MergeProjectWithValues
 SELECT column1, 3 FROM (VALUES (1, 2))
 ----
 values
- ├── columns: column1:1(int) "?column?":3(int)
+ ├── columns: column1:1(int!null) "?column?":3(int!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1,3)
@@ -179,7 +179,7 @@ opt expect=MergeProjectWithValues
 SELECT column1, column3 FROM (VALUES (1, 2, 3))
 ----
 values
- ├── columns: column1:1(int) column3:3(int)
+ ├── columns: column1:1(int!null) column3:3(int!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1,3)
@@ -190,7 +190,7 @@ opt expect=MergeProjectWithValues
 SELECT 4, 5 FROM (VALUES (1, 2, 3))
 ----
 values
- ├── columns: "?column?":4(int) "?column?":5(int)
+ ├── columns: "?column?":4(int!null) "?column?":5(int!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(4,5)
@@ -201,11 +201,11 @@ opt expect-not=MergeProjectWithValues
 SELECT column1, 3 FROM (VALUES (1, 2), (1, 4))
 ----
 project
- ├── columns: column1:1(int) "?column?":3(int!null)
+ ├── columns: column1:1(int!null) "?column?":3(int!null)
  ├── cardinality: [2 - 2]
  ├── fd: ()-->(3)
  ├── values
- │    ├── columns: column1:1(int)
+ │    ├── columns: column1:1(int!null)
  │    ├── cardinality: [2 - 2]
  │    ├── (1,) [type=tuple{int}]
  │    └── (1,) [type=tuple{int}]

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -1461,7 +1461,7 @@ opt expect=PruneValuesCols
 SELECT column1 FROM (VALUES (1, 2), (3, 4)) a
 ----
 values
- ├── columns: column1:1(int)
+ ├── columns: column1:1(int!null)
  ├── cardinality: [2 - 2]
  ├── (1,) [type=tuple{int}]
  └── (3,) [type=tuple{int}]
@@ -1471,7 +1471,7 @@ opt expect=PruneValuesCols
 SELECT column2 FROM (VALUES (1, 2, 3), (4, 5, 6)) a
 ----
 values
- ├── columns: column2:2(int)
+ ├── columns: column2:2(int!null)
  ├── cardinality: [2 - 2]
  ├── (2,) [type=tuple{int}]
  └── (5,) [type=tuple{int}]
@@ -1481,7 +1481,7 @@ opt expect=PruneValuesCols
 SELECT column3 FROM (VALUES ('foo', 'bar', 'baz'), ('apple', 'banana', 'cherry')) a
 ----
 values
- ├── columns: column3:3(string)
+ ├── columns: column3:3(string!null)
  ├── cardinality: [2 - 2]
  ├── ('baz',) [type=tuple{string}]
  └── ('cherry',) [type=tuple{string}]
@@ -2038,17 +2038,17 @@ upsert a
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project
-      ├── columns: upsert_i:15(int) column1:5(int) column2:6(string) column7:7(int) column8:8(float) k:9(int) i:10(int) f:11(float) s:12(string)
+      ├── columns: upsert_i:15(int) column1:5(int!null) column2:6(string!null) column7:7(int) column8:8(float) k:9(int) i:10(int) f:11(float) s:12(string)
       ├── cardinality: [1 - 1]
       ├── key: ()
       ├── fd: ()-->(5-12,15)
       ├── left-join
-      │    ├── columns: column1:5(int) column2:6(string) column7:7(int) column8:8(float) k:9(int) i:10(int) f:11(float) s:12(string)
+      │    ├── columns: column1:5(int!null) column2:6(string!null) column7:7(int) column8:8(float) k:9(int) i:10(int) f:11(float) s:12(string)
       │    ├── cardinality: [1 - 1]
       │    ├── key: ()
       │    ├── fd: ()-->(5-12)
       │    ├── values
-      │    │    ├── columns: column1:5(int) column2:6(string) column7:7(int) column8:8(float)
+      │    │    ├── columns: column1:5(int!null) column2:6(string!null) column7:7(int) column8:8(float)
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(5-8)
@@ -2089,17 +2089,17 @@ upsert a
  ├── key: ()
  ├── fd: ()-->(1-4)
  └── project
-      ├── columns: upsert_k:14(int) upsert_i:15(int) upsert_f:16(float) upsert_s:17(string) column1:5(int) column2:6(string) column7:7(int) column8:8(float) k:9(int) i:10(int) f:11(float) s:12(string)
+      ├── columns: upsert_k:14(int) upsert_i:15(int) upsert_f:16(float) upsert_s:17(string) column1:5(int!null) column2:6(string!null) column7:7(int) column8:8(float) k:9(int) i:10(int) f:11(float) s:12(string)
       ├── cardinality: [1 - 1]
       ├── key: ()
       ├── fd: ()-->(5-12,14-17)
       ├── left-join
-      │    ├── columns: column1:5(int) column2:6(string) column7:7(int) column8:8(float) k:9(int) i:10(int) f:11(float) s:12(string)
+      │    ├── columns: column1:5(int!null) column2:6(string!null) column7:7(int) column8:8(float) k:9(int) i:10(int) f:11(float) s:12(string)
       │    ├── cardinality: [1 - 1]
       │    ├── key: ()
       │    ├── fd: ()-->(5-12)
       │    ├── values
-      │    │    ├── columns: column1:5(int) column2:6(string) column7:7(int) column8:8(float)
+      │    │    ├── columns: column1:5(int!null) column2:6(string!null) column7:7(int) column8:8(float)
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(5-8)
@@ -2136,12 +2136,12 @@ upsert "family"
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── left-join
-      ├── columns: column1:6(int) column2:7(int) column8:8(int) a:9(int) b:10(int)
+      ├── columns: column1:6(int!null) column2:7(int!null) column8:8(int) a:9(int) b:10(int)
       ├── cardinality: [1 - 1]
       ├── key: ()
       ├── fd: ()-->(6-10)
       ├── values
-      │    ├── columns: column1:6(int) column2:7(int) column8:8(int)
+      │    ├── columns: column1:6(int!null) column2:7(int!null) column8:8(int)
       │    ├── cardinality: [1 - 1]
       │    ├── key: ()
       │    ├── fd: ()-->(6-8)
@@ -2186,17 +2186,17 @@ project
       ├── key: ()
       ├── fd: ()-->(1-5)
       └── project
-           ├── columns: upsert_a:17(int) upsert_b:18(int) upsert_c:19(int) upsert_d:20(int) upsert_e:21(int) column1:6(int) column2:7(int) column3:8(int) column4:9(int) column5:10(int) a:11(int) b:12(int) c:13(int) d:14(int) e:15(int)
+           ├── columns: upsert_a:17(int) upsert_b:18(int) upsert_c:19(int) upsert_d:20(int) upsert_e:21(int) column1:6(int!null) column2:7(int!null) column3:8(int!null) column4:9(int!null) column5:10(int!null) a:11(int) b:12(int) c:13(int) d:14(int) e:15(int)
            ├── cardinality: [1 - 1]
            ├── key: ()
            ├── fd: ()-->(6-15,17-21)
            ├── left-join
-           │    ├── columns: column1:6(int) column2:7(int) column3:8(int) column4:9(int) column5:10(int) a:11(int) b:12(int) c:13(int) d:14(int) e:15(int)
+           │    ├── columns: column1:6(int!null) column2:7(int!null) column3:8(int!null) column4:9(int!null) column5:10(int!null) a:11(int) b:12(int) c:13(int) d:14(int) e:15(int)
            │    ├── cardinality: [1 - 1]
            │    ├── key: ()
            │    ├── fd: ()-->(6-15)
            │    ├── values
-           │    │    ├── columns: column1:6(int) column2:7(int) column3:8(int) column4:9(int) column5:10(int)
+           │    │    ├── columns: column1:6(int!null) column2:7(int!null) column3:8(int!null) column4:9(int!null) column5:10(int!null)
            │    │    ├── cardinality: [1 - 1]
            │    │    ├── key: ()
            │    │    ├── fd: ()-->(6-10)
@@ -2236,17 +2236,17 @@ upsert "family"
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project
-      ├── columns: upsert_d:20(int) column1:6(int) column2:7(int) column3:8(int) column4:9(int) column10:10(int) a:11(int) c:13(int) d:14(int)
+      ├── columns: upsert_d:20(int) column1:6(int!null) column2:7(int!null) column3:8(int!null) column4:9(int!null) column10:10(int) a:11(int) c:13(int) d:14(int)
       ├── cardinality: [1 - 1]
       ├── key: ()
       ├── fd: ()-->(6-11,13,14,20)
       ├── left-join
-      │    ├── columns: column1:6(int) column2:7(int) column3:8(int) column4:9(int) column10:10(int) a:11(int) c:13(int) d:14(int)
+      │    ├── columns: column1:6(int!null) column2:7(int!null) column3:8(int!null) column4:9(int!null) column10:10(int) a:11(int) c:13(int) d:14(int)
       │    ├── cardinality: [1 - 1]
       │    ├── key: ()
       │    ├── fd: ()-->(6-11,13,14)
       │    ├── values
-      │    │    ├── columns: column1:6(int) column2:7(int) column3:8(int) column4:9(int) column10:10(int)
+      │    │    ├── columns: column1:6(int!null) column2:7(int!null) column3:8(int!null) column4:9(int!null) column10:10(int)
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(6-10)
@@ -2279,17 +2279,17 @@ upsert mutation
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project
-      ├── columns: upsert_b:17(int) column1:6(int) column2:7(int) column3:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) d:13(int) e:14(int)
+      ├── columns: upsert_b:17(int) column1:6(int!null) column2:7(int!null) column3:8(int!null) column9:9(int) a:10(int) b:11(int) c:12(int) d:13(int) e:14(int)
       ├── cardinality: [1 - 1]
       ├── key: ()
       ├── fd: ()-->(6-14,17)
       ├── left-join
-      │    ├── columns: column1:6(int) column2:7(int) column3:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) d:13(int) e:14(int)
+      │    ├── columns: column1:6(int!null) column2:7(int!null) column3:8(int!null) column9:9(int) a:10(int) b:11(int) c:12(int) d:13(int) e:14(int)
       │    ├── cardinality: [1 - 1]
       │    ├── key: ()
       │    ├── fd: ()-->(6-14)
       │    ├── values
-      │    │    ├── columns: column1:6(int) column2:7(int) column3:8(int) column9:9(int)
+      │    │    ├── columns: column1:6(int!null) column2:7(int!null) column3:8(int!null) column9:9(int)
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(6-9)

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -300,7 +300,7 @@ select
                 ├── key: ()
                 ├── fd: ()-->(13)
                 ├── values
-                │    ├── columns: s:10(string)
+                │    ├── columns: s:10(string!null)
                 │    ├── cardinality: [0 - 0]
                 │    ├── key: ()
                 │    └── fd: ()-->(10)
@@ -468,7 +468,7 @@ opt expect=SimplifyCaseWhenConstValue
 SELECT CASE 1 WHEN 1 THEN 'one' END
 ----
 values
- ├── columns: case:1(string)
+ ├── columns: case:1(string!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -478,7 +478,7 @@ opt expect=SimplifyCaseWhenConstValue
 SELECT CASE WHEN 1 = 1 THEN 'one' END
 ----
 values
- ├── columns: case:1(string)
+ ├── columns: case:1(string!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -488,7 +488,7 @@ opt expect=SimplifyCaseWhenConstValue
 SELECT CASE false WHEN 0 = 1 THEN 'one' END
 ----
 values
- ├── columns: case:1(string)
+ ├── columns: case:1(string!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -582,7 +582,7 @@ opt expect=SimplifyCaseWhenConstValue
 SELECT CASE 1 WHEN 2 THEN 'one' ELSE 'three' END
 ----
 values
- ├── columns: case:1(string)
+ ├── columns: case:1(string!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -617,7 +617,7 @@ SELECT
     END
 ----
 values
- ├── columns: case:1(string)
+ ├── columns: case:1(string!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -633,7 +633,7 @@ SELECT
     END
 ----
 values
- ├── columns: case:1(string)
+ ├── columns: case:1(string!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -643,7 +643,7 @@ opt expect=SimplifyCaseWhenConstValue
 SELECT CASE WHEN false THEN 'one' WHEN true THEN 'two' END
 ----
 values
- ├── columns: case:1(string)
+ ├── columns: case:1(string!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -904,7 +904,7 @@ opt
 SELECT k FROM e WHERE tz > NULL::TIMESTAMP
 ----
 values
- ├── columns: k:1(int)
+ ├── columns: k:1(int!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(1)
@@ -938,7 +938,7 @@ opt expect=SimplifyEqualsAnyTuple
 SELECT k FROM a WHERE k = ANY ()
 ----
 values
- ├── columns: k:1(int)
+ ├── columns: k:1(int!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(1)
@@ -1004,7 +1004,7 @@ opt expect=(SimplifyAnyScalarArray,SimplifyEqualsAnyTuple)
 SELECT k FROM a WHERE k = ANY ARRAY[]:::INT[]
 ----
 values
- ├── columns: k:1(int)
+ ├── columns: k:1(int!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(1)
@@ -1026,7 +1026,7 @@ norm expect=FoldCollate
 SELECT 'hello' COLLATE en_u_ks_level1
 ----
 values
- ├── columns: "?column?":1(collatedstring{en_u_ks_level1})
+ ├── columns: "?column?":1(collatedstring{en_u_ks_level1}!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -1036,7 +1036,7 @@ norm expect=FoldCollate
 SELECT ('hello' COLLATE en_u_ks_level1) COLLATE en_u_ks_level1
 ----
 values
- ├── columns: "?column?":1(collatedstring{en_u_ks_level1})
+ ├── columns: "?column?":1(collatedstring{en_u_ks_level1}!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
@@ -1046,7 +1046,7 @@ norm expect=FoldCollate
 SELECT ('hello' COLLATE en) COLLATE en_u_ks_level1
 ----
 values
- ├── columns: "?column?":1(collatedstring{en_u_ks_level1})
+ ├── columns: "?column?":1(collatedstring{en_u_ks_level1}!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -67,7 +67,7 @@ opt expect=SimplifySelectFilters
 SELECT * FROM a WHERE Null
 ----
 values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(1-5)
@@ -76,7 +76,7 @@ opt expect=SimplifyJoinFilters
 SELECT * FROM a INNER JOIN xy ON NULL
 ----
 values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb!null) x:6(int!null) y:7(int!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(1-7)
@@ -85,7 +85,7 @@ opt expect=SimplifySelectFilters
 SELECT * FROM a WHERE i=1 AND Null
 ----
 values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(1-5)
@@ -310,7 +310,7 @@ opt expect=MergeSelects
 SELECT * FROM (SELECT * FROM a WHERE i=1) WHERE False
 ----
 values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(1-5)
@@ -904,7 +904,7 @@ opt expect=MergeSelectInnerJoin
 SELECT * FROM a INNER JOIN xy ON a.k=xy.x WHERE False
 ----
 values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb!null) x:6(int!null) y:7(int!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(1-7)
@@ -1294,7 +1294,7 @@ opt expect=DetectSelectContradiction
 SELECT k FROM b WHERE k IN ()
 ----
 values
- ├── columns: k:1(int)
+ ├── columns: k:1(int!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(1)
@@ -1303,7 +1303,7 @@ opt expect=DetectSelectContradiction
 SELECT k FROM b WHERE i=5 AND k IN () AND s='foo'
 ----
 values
- ├── columns: k:1(int)
+ ├── columns: k:1(int!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(1)

--- a/pkg/sql/opt/norm/testdata/rules/set
+++ b/pkg/sql/opt/norm/testdata/rules/set
@@ -65,7 +65,7 @@ SELECT k FROM
   (SELECT k FROM b WHERE i IN ())
 ----
 values
- ├── columns: k:11(int)
+ ├── columns: k:11(int!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(11)
@@ -422,26 +422,26 @@ SELECT * FROM ((values (1,2))
 WHERE 1 / column1 > 0
 ----
 except
- ├── columns: column1:1(int) column2:2(int)
- ├── left columns: column1:1(int) column2:2(int)
+ ├── columns: column1:1(int!null) column2:2(int!null)
+ ├── left columns: column1:1(int!null) column2:2(int!null)
  ├── right columns: column1:3(int) column2:4(int)
  ├── cardinality: [0 - 1]
  ├── side-effects
  ├── key: (1,2)
  ├── values
- │    ├── columns: column1:1(int) column2:2(int)
+ │    ├── columns: column1:1(int!null) column2:2(int!null)
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(1,2)
  │    └── (1, 2) [type=tuple{int, int}]
  └── select
-      ├── columns: column1:3(int) column2:4(int)
+      ├── columns: column1:3(int!null) column2:4(int!null)
       ├── cardinality: [0 - 1]
       ├── side-effects
       ├── key: ()
       ├── fd: ()-->(3,4)
       ├── values
-      │    ├── columns: column1:3(int) column2:4(int)
+      │    ├── columns: column1:3(int!null) column2:4(int!null)
       │    ├── cardinality: [1 - 1]
       │    ├── key: ()
       │    ├── fd: ()-->(3,4)
@@ -453,23 +453,23 @@ opt
 SELECT * FROM ((values (1.0::decimal)) EXCEPT (values (1.00::decimal))) WHERE column1::string != '1.00';
 ----
 select
- ├── columns: column1:1(decimal)
+ ├── columns: column1:1(decimal!null)
  ├── cardinality: [0 - 1]
  ├── key: (1)
  ├── except
- │    ├── columns: column1:1(decimal)
- │    ├── left columns: column1:1(decimal)
+ │    ├── columns: column1:1(decimal!null)
+ │    ├── left columns: column1:1(decimal!null)
  │    ├── right columns: column1:2(decimal)
  │    ├── cardinality: [0 - 1]
  │    ├── key: (1)
  │    ├── values
- │    │    ├── columns: column1:1(decimal)
+ │    │    ├── columns: column1:1(decimal!null)
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1)
  │    │    └── (1.0,) [type=tuple{decimal}]
  │    └── values
- │         ├── columns: column1:2(decimal)
+ │         ├── columns: column1:2(decimal!null)
  │         ├── cardinality: [1 - 1]
  │         ├── key: ()
  │         ├── fd: ()-->(2)

--- a/pkg/sql/opt/norm/testdata/rules/zero_cardinality
+++ b/pkg/sql/opt/norm/testdata/rules/zero_cardinality
@@ -18,7 +18,7 @@ opt expect=SimplifyZeroCardinalityGroup
 SELECT k FROM b WHERE false
 ----
 values
- ├── columns: k:1(int)
+ ├── columns: k:1(int!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(1)
@@ -27,7 +27,7 @@ opt expect=SimplifyZeroCardinalityGroup
 SELECT * FROM (VALUES (1) OFFSET 1)
 ----
 values
- ├── columns: column1:1(int)
+ ├── columns: column1:1(int!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(1)
@@ -36,7 +36,7 @@ opt expect=SimplifyZeroCardinalityGroup
 SELECT * FROM b INNER JOIN b b2 ON False
 ----
 values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) k:6(int) i:7(int) f:8(float) s:9(string) j:10(jsonb)
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb!null) k:6(int!null) i:7(int!null) f:8(float!null) s:9(string!null) j:10(jsonb!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(1-10)
@@ -45,7 +45,7 @@ opt expect=SimplifyZeroCardinalityGroup
 SELECT * FROM b LIMIT 0
 ----
 values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(1-5)
@@ -54,7 +54,7 @@ opt expect=SimplifyZeroCardinalityGroup
 SELECT * FROM (SELECT * FROM b WHERE i=1) WHERE False
 ----
 values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(1-5)
@@ -63,7 +63,7 @@ opt expect=SimplifyZeroCardinalityGroup
 SELECT * FROM (SELECT * FROM b WHERE False) WHERE s='foo'
 ----
 values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(1-5)
@@ -72,7 +72,7 @@ opt expect=SimplifyZeroCardinalityGroup
 SELECT * FROM (SELECT * FROM b WHERE False) WHERE s='foo'
 ----
 values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
  └── fd: ()-->(1-5)
@@ -87,7 +87,7 @@ project
  ├── key: ()
  ├── fd: ()-->(6)
  ├── values
- │    ├── columns: k:1(int)
+ │    ├── columns: k:1(int!null)
  │    ├── cardinality: [0 - 0]
  │    ├── key: ()
  │    └── fd: ()-->(1)

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -1902,7 +1902,7 @@ SELECT xor_agg(i) FROM (VALUES (b'\x01'), (b'\x01\x01')) AS a(i)
 scalar-group-by
  ├── columns: xor_agg:2(bytes)
  ├── values
- │    ├── columns: column1:1(bytes)
+ │    ├── columns: column1:1(bytes!null)
  │    ├── tuple [type=tuple{bytes}]
  │    │    └── const: '\x01' [type=bytes]
  │    └── tuple [type=tuple{bytes}]

--- a/pkg/sql/opt/optbuilder/testdata/explain
+++ b/pkg/sql/opt/optbuilder/testdata/explain
@@ -60,11 +60,11 @@ explain
  ├── columns: tree:5(string) field:8(string) description:9(string) columns:10(string) ordering:11(string)  [hidden: level:6(int) node_type:7(string)]
  ├── mode: verbose
  └── inner-join
-      ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int)
+      ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int!null)
       ├── scan xy
       │    └── columns: x:1(int!null) y:2(int)
       ├── values
-      │    ├── columns: column1:3(int) column2:4(int)
+      │    ├── columns: column1:3(int!null) column2:4(int!null)
       │    ├── tuple [type=tuple{int, int}]
       │    │    ├── const: 1 [type=int]
       │    │    └── const: 2 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -125,11 +125,11 @@ insert abcde
  │    ├──  column1:7 => e:5
  │    └──  column10:10 => rowid:6
  └── project
-      ├── columns: column11:11(int) column1:7(int) column2:8(int) column3:9(int) column10:10(int)
+      ├── columns: column11:11(int) column1:7(int!null) column2:8(int!null) column3:9(int!null) column10:10(int)
       ├── project
-      │    ├── columns: column10:10(int) column1:7(int) column2:8(int) column3:9(int)
+      │    ├── columns: column10:10(int) column1:7(int!null) column2:8(int!null) column3:9(int!null)
       │    ├── values
-      │    │    ├── columns: column1:7(int) column2:8(int) column3:9(int)
+      │    │    ├── columns: column1:7(int!null) column2:8(int!null) column3:9(int!null)
       │    │    └── tuple [type=tuple{int, int, int}]
       │    │         ├── const: 1 [type=int]
       │    │         ├── const: 2 [type=int]
@@ -157,11 +157,11 @@ insert abcde
  │    ├──  column1:7 => e:5
  │    └──  column10:10 => rowid:6
  └── project
-      ├── columns: column11:11(int) column1:7(int) column8:8(int) column9:9(int!null) column10:10(int)
+      ├── columns: column11:11(int) column1:7(int!null) column8:8(int) column9:9(int!null) column10:10(int)
       ├── project
-      │    ├── columns: column8:8(int) column9:9(int!null) column10:10(int) column1:7(int)
+      │    ├── columns: column8:8(int) column9:9(int!null) column10:10(int) column1:7(int!null)
       │    ├── values
-      │    │    ├── columns: column1:7(int)
+      │    │    ├── columns: column1:7(int!null)
       │    │    └── tuple [type=tuple{int}]
       │    │         └── const: 1 [type=int]
       │    └── projections
@@ -280,11 +280,11 @@ insert abcde
  │    ├──  column1:7 => e:5
  │    └──  column10:10 => rowid:6
  └── project
-      ├── columns: column11:11(int) column1:7(int) column2:8(int) column3:9(int) column10:10(int)
+      ├── columns: column11:11(int) column1:7(int!null) column2:8(int) column3:9(int) column10:10(int)
       ├── project
-      │    ├── columns: column10:10(int) column1:7(int) column2:8(int) column3:9(int)
+      │    ├── columns: column10:10(int) column1:7(int!null) column2:8(int) column3:9(int)
       │    ├── values
-      │    │    ├── columns: column1:7(int) column2:8(int) column3:9(int)
+      │    │    ├── columns: column1:7(int!null) column2:8(int) column3:9(int)
       │    │    └── tuple [type=tuple{int, int, int}]
       │    │         ├── const: 2 [type=int]
       │    │         ├── cast: INT8 [type=int]
@@ -370,11 +370,11 @@ insert abcde
  │    ├──  column1:7 => e:5
  │    └──  column10:10 => rowid:6
  └── project
-      ├── columns: column11:11(int) column1:7(int) column2:8(int) column3:9(int) column10:10(int)
+      ├── columns: column11:11(int) column1:7(int!null) column2:8(int) column3:9(int!null) column10:10(int)
       ├── project
-      │    ├── columns: column10:10(int) column1:7(int) column2:8(int) column3:9(int)
+      │    ├── columns: column10:10(int) column1:7(int!null) column2:8(int) column3:9(int!null)
       │    ├── values
-      │    │    ├── columns: column1:7(int) column2:8(int) column3:9(int)
+      │    │    ├── columns: column1:7(int!null) column2:8(int) column3:9(int!null)
       │    │    ├── tuple [type=tuple{int, int, int}]
       │    │    │    ├── const: 1 [type=int]
       │    │    │    ├── cast: INT8 [type=int]
@@ -500,9 +500,9 @@ build
 SELECT * FROM [INSERT INTO abcde VALUES (1) RETURNING *]
 ----
 project
- ├── columns: a:1(int!null) b:2(int) c:3(int!null) d:4(int) e:5(int)
+ ├── columns: a:1(int!null) b:2(int) c:3(int!null) d:4(int) e:5(int!null)
  └── insert abcde
-      ├── columns: a:1(int!null) b:2(int) c:3(int!null) d:4(int) e:5(int) rowid:6(int!null)
+      ├── columns: a:1(int!null) b:2(int) c:3(int!null) d:4(int) e:5(int!null) rowid:6(int!null)
       ├── insert-mapping:
       │    ├──  column1:7 => a:1
       │    ├──  column8:8 => b:2
@@ -511,11 +511,11 @@ project
       │    ├──  column1:7 => e:5
       │    └──  column10:10 => rowid:6
       └── project
-           ├── columns: column11:11(int) column1:7(int) column8:8(int) column9:9(int!null) column10:10(int)
+           ├── columns: column11:11(int) column1:7(int!null) column8:8(int) column9:9(int!null) column10:10(int)
            ├── project
-           │    ├── columns: column8:8(int) column9:9(int!null) column10:10(int) column1:7(int)
+           │    ├── columns: column8:8(int) column9:9(int!null) column10:10(int) column1:7(int!null)
            │    ├── values
-           │    │    ├── columns: column1:7(int)
+           │    │    ├── columns: column1:7(int!null)
            │    │    └── tuple [type=tuple{int}]
            │    │         └── const: 1 [type=int]
            │    └── projections
@@ -709,11 +709,11 @@ insert abcde
  │    ├──  column3:9 => e:5
  │    └──  column10:10 => rowid:6
  └── project
-      ├── columns: column11:11(int) column1:7(int) column2:8(int) column3:9(int) column10:10(int)
+      ├── columns: column11:11(int) column1:7(int!null) column2:8(int!null) column3:9(int!null) column10:10(int)
       ├── project
-      │    ├── columns: column10:10(int) column1:7(int) column2:8(int) column3:9(int)
+      │    ├── columns: column10:10(int) column1:7(int!null) column2:8(int!null) column3:9(int!null)
       │    ├── values
-      │    │    ├── columns: column1:7(int) column2:8(int) column3:9(int)
+      │    │    ├── columns: column1:7(int!null) column2:8(int!null) column3:9(int!null)
       │    │    └── tuple [type=tuple{int, int, int}]
       │    │         ├── const: 1 [type=int]
       │    │         ├── const: 2 [type=int]
@@ -741,11 +741,11 @@ insert abcde
  │    ├──  column1:7 => e:5
  │    └──  column10:10 => rowid:6
  └── project
-      ├── columns: column11:11(int) column1:7(int) column8:8(int) column9:9(int!null) column10:10(int)
+      ├── columns: column11:11(int) column1:7(int!null) column8:8(int) column9:9(int!null) column10:10(int)
       ├── project
-      │    ├── columns: column8:8(int) column9:9(int!null) column10:10(int) column1:7(int)
+      │    ├── columns: column8:8(int) column9:9(int!null) column10:10(int) column1:7(int!null)
       │    ├── values
-      │    │    ├── columns: column1:7(int)
+      │    │    ├── columns: column1:7(int!null)
       │    │    └── tuple [type=tuple{int}]
       │    │         └── const: 1 [type=int]
       │    └── projections
@@ -765,9 +765,9 @@ build
 INSERT INTO abcde (a, rowid) VALUES (1, 2) RETURNING *
 ----
 project
- ├── columns: a:1(int!null) b:2(int) c:3(int!null) d:4(int) e:5(int)
+ ├── columns: a:1(int!null) b:2(int) c:3(int!null) d:4(int) e:5(int!null)
  └── insert abcde
-      ├── columns: a:1(int!null) b:2(int) c:3(int!null) d:4(int) e:5(int) rowid:6(int!null)
+      ├── columns: a:1(int!null) b:2(int) c:3(int!null) d:4(int) e:5(int!null) rowid:6(int!null)
       ├── insert-mapping:
       │    ├──  column1:7 => a:1
       │    ├──  column9:9 => b:2
@@ -776,11 +776,11 @@ project
       │    ├──  column1:7 => e:5
       │    └──  column2:8 => rowid:6
       └── project
-           ├── columns: column11:11(int) column1:7(int) column2:8(int) column9:9(int) column10:10(int!null)
+           ├── columns: column11:11(int) column1:7(int!null) column2:8(int!null) column9:9(int) column10:10(int!null)
            ├── project
-           │    ├── columns: column9:9(int) column10:10(int!null) column1:7(int) column2:8(int)
+           │    ├── columns: column9:9(int) column10:10(int!null) column1:7(int!null) column2:8(int!null)
            │    ├── values
-           │    │    ├── columns: column1:7(int) column2:8(int)
+           │    │    ├── columns: column1:7(int!null) column2:8(int!null)
            │    │    └── tuple [type=tuple{int, int}]
            │    │         ├── const: 1 [type=int]
            │    │         └── const: 2 [type=int]
@@ -802,7 +802,7 @@ VALUES (DEFAULT, DEFAULT, 1, DEFAULT), (3, 2, 1, DEFAULT), (DEFAULT, DEFAULT, 2,
 RETURNING *, rowid
 ----
 insert abcde
- ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int) e:5(int) rowid:6(int!null)
+ ├── columns: a:1(int!null) b:2(int) c:3(int!null) d:4(int) e:5(int!null) rowid:6(int!null)
  ├── insert-mapping:
  │    ├──  column3:9 => a:1
  │    ├──  column2:8 => b:2
@@ -811,9 +811,9 @@ insert abcde
  │    ├──  column3:9 => e:5
  │    └──  column4:10 => rowid:6
  └── project
-      ├── columns: column11:11(int) column1:7(int) column2:8(int) column3:9(int) column4:10(int)
+      ├── columns: column11:11(int) column1:7(int!null) column2:8(int) column3:9(int!null) column4:10(int)
       ├── values
-      │    ├── columns: column1:7(int) column2:8(int) column3:9(int) column4:10(int)
+      │    ├── columns: column1:7(int!null) column2:8(int) column3:9(int!null) column4:10(int)
       │    ├── tuple [type=tuple{int, int, int, int}]
       │    │    ├── const: 10 [type=int]
       │    │    ├── cast: INT8 [type=int]
@@ -956,7 +956,7 @@ build
 INSERT INTO abcde (rowid, a) VALUES (1, 2) RETURNING *, rowid
 ----
 insert abcde
- ├── columns: a:1(int!null) b:2(int) c:3(int!null) d:4(int) e:5(int) rowid:6(int!null)
+ ├── columns: a:1(int!null) b:2(int) c:3(int!null) d:4(int) e:5(int!null) rowid:6(int!null)
  ├── insert-mapping:
  │    ├──  column2:8 => a:1
  │    ├──  column9:9 => b:2
@@ -965,11 +965,11 @@ insert abcde
  │    ├──  column2:8 => e:5
  │    └──  column1:7 => rowid:6
  └── project
-      ├── columns: column11:11(int) column1:7(int) column2:8(int) column9:9(int) column10:10(int!null)
+      ├── columns: column11:11(int) column1:7(int!null) column2:8(int!null) column9:9(int) column10:10(int!null)
       ├── project
-      │    ├── columns: column9:9(int) column10:10(int!null) column1:7(int) column2:8(int)
+      │    ├── columns: column9:9(int) column10:10(int!null) column1:7(int!null) column2:8(int!null)
       │    ├── values
-      │    │    ├── columns: column1:7(int) column2:8(int)
+      │    │    ├── columns: column1:7(int!null) column2:8(int!null)
       │    │    └── tuple [type=tuple{int, int}]
       │    │         ├── const: 1 [type=int]
       │    │         └── const: 2 [type=int]
@@ -1208,13 +1208,13 @@ insert mutation
  │    └──  column9:9 => p:4
  ├── check columns: check1:10(bool)
  └── project
-      ├── columns: check1:10(bool) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int)
+      ├── columns: check1:10(bool) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int)
       ├── project
-      │    ├── columns: column9:9(int) column1:6(int) column2:7(int) column8:8(int!null)
+      │    ├── columns: column9:9(int) column1:6(int!null) column2:7(int!null) column8:8(int!null)
       │    ├── project
-      │    │    ├── columns: column8:8(int!null) column1:6(int) column2:7(int)
+      │    │    ├── columns: column8:8(int!null) column1:6(int!null) column2:7(int!null)
       │    │    ├── values
-      │    │    │    ├── columns: column1:6(int) column2:7(int)
+      │    │    │    ├── columns: column1:6(int!null) column2:7(int!null)
       │    │    │    └── tuple [type=tuple{int, int}]
       │    │    │         ├── const: 1 [type=int]
       │    │    │         └── const: 2 [type=int]
@@ -1234,7 +1234,7 @@ build
 INSERT INTO mutation (m, n) VALUES (1, 2) RETURNING *
 ----
 insert mutation
- ├── columns: m:1(int!null) n:2(int)
+ ├── columns: m:1(int!null) n:2(int!null)
  ├── insert-mapping:
  │    ├──  column1:6 => m:1
  │    ├──  column2:7 => n:2
@@ -1242,13 +1242,13 @@ insert mutation
  │    └──  column9:9 => p:4
  ├── check columns: check1:10(bool)
  └── project
-      ├── columns: check1:10(bool) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int)
+      ├── columns: check1:10(bool) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int)
       ├── project
-      │    ├── columns: column9:9(int) column1:6(int) column2:7(int) column8:8(int!null)
+      │    ├── columns: column9:9(int) column1:6(int!null) column2:7(int!null) column8:8(int!null)
       │    ├── project
-      │    │    ├── columns: column8:8(int!null) column1:6(int) column2:7(int)
+      │    │    ├── columns: column8:8(int!null) column1:6(int!null) column2:7(int!null)
       │    │    ├── values
-      │    │    │    ├── columns: column1:6(int) column2:7(int)
+      │    │    │    ├── columns: column1:6(int!null) column2:7(int!null)
       │    │    │    └── tuple [type=tuple{int, int}]
       │    │    │         ├── const: 1 [type=int]
       │    │    │         └── const: 2 [type=int]
@@ -1298,11 +1298,11 @@ insert checks
  │    └──  column8:8 => d:4
  ├── check columns: check1:9(bool) check2:10(bool)
  └── project
-      ├── columns: check1:9(bool) check2:10(bool) column1:5(int) column2:6(int) column3:7(int) column8:8(int)
+      ├── columns: check1:9(bool) check2:10(bool) column1:5(int!null) column2:6(int!null) column3:7(int!null) column8:8(int)
       ├── project
-      │    ├── columns: column8:8(int) column1:5(int) column2:6(int) column3:7(int)
+      │    ├── columns: column8:8(int) column1:5(int!null) column2:6(int!null) column3:7(int!null)
       │    ├── values
-      │    │    ├── columns: column1:5(int) column2:6(int) column3:7(int)
+      │    │    ├── columns: column1:5(int!null) column2:6(int!null) column3:7(int!null)
       │    │    └── tuple [type=tuple{int, int, int}]
       │    │         ├── const: 1 [type=int]
       │    │         ├── const: 2 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -377,7 +377,7 @@ limit
  │         │    └── scan onecolumn
  │         │         └── columns: x:1(int) rowid:2(int!null)
  │         ├── values
- │         │    ├── columns: column1:3(int)
+ │         │    ├── columns: column1:3(int!null)
  │         │    └── tuple [type=tuple{int}]
  │         │         └── const: 42 [type=int]
  │         └── filters
@@ -1089,7 +1089,7 @@ project
       ├── scan onecolumn
       │    └── columns: x:1(int) rowid:2(int!null)
       ├── values
-      │    ├── columns: column1:3(int)
+      │    ├── columns: column1:3(int!null)
       │    ├── tuple [type=tuple{int}]
       │    │    └── const: 41 [type=int]
       │    ├── tuple [type=tuple{int}]
@@ -1349,14 +1349,14 @@ SELECT * FROM (SELECT * FROM (VALUES (9, 1), (8, 2)) AS a (u, k) ORDER BY k)
   INNER JOIN (VALUES (1, 1), (2, 2)) AS b (k, w) USING (k) ORDER BY u
 ----
 sort
- ├── columns: k:2(int!null) u:1(int) w:4(int)
+ ├── columns: k:2(int!null) u:1(int!null) w:4(int!null)
  ├── ordering: +1
  └── project
-      ├── columns: column1:1(int) column2:2(int!null) column2:4(int)
+      ├── columns: column1:1(int!null) column2:2(int!null) column2:4(int!null)
       └── inner-join
-           ├── columns: column1:1(int) column2:2(int!null) column1:3(int!null) column2:4(int)
+           ├── columns: column1:1(int!null) column2:2(int!null) column1:3(int!null) column2:4(int!null)
            ├── values
-           │    ├── columns: column1:1(int) column2:2(int)
+           │    ├── columns: column1:1(int!null) column2:2(int!null)
            │    ├── tuple [type=tuple{int, int}]
            │    │    ├── const: 9 [type=int]
            │    │    └── const: 1 [type=int]
@@ -1364,7 +1364,7 @@ sort
            │         ├── const: 8 [type=int]
            │         └── const: 2 [type=int]
            ├── values
-           │    ├── columns: column1:3(int) column2:4(int)
+           │    ├── columns: column1:3(int!null) column2:4(int!null)
            │    ├── tuple [type=tuple{int, int}]
            │    │    ├── const: 1 [type=int]
            │    │    └── const: 1 [type=int]
@@ -3118,7 +3118,7 @@ project
       │    │         ├── null [type=unknown]
       │    │         └── null [type=unknown]
       │    ├── values
-      │    │    ├── columns: column1:3(int) column2:4(int)
+      │    │    ├── columns: column1:3(int!null) column2:4(int!null)
       │    │    └── tuple [type=tuple{int, int}]
       │    │         ├── const: 1 [type=int]
       │    │         └── const: 1 [type=int]
@@ -3161,7 +3161,7 @@ project
  │         │    │         ├── null [type=unknown]
  │         │    │         └── null [type=unknown]
  │         │    ├── values
- │         │    │    ├── columns: column1:3(int) column2:4(int)
+ │         │    │    ├── columns: column1:3(int!null) column2:4(int!null)
  │         │    │    └── tuple [type=tuple{int, int}]
  │         │    │         ├── const: 1 [type=int]
  │         │    │         └── const: 1 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/limit
+++ b/pkg/sql/opt/optbuilder/testdata/limit
@@ -177,14 +177,14 @@ build
 VALUES (1,1), (2,2) ORDER BY 1 LIMIT 1
 ----
 limit
- ├── columns: column1:1(int) column2:2(int)
+ ├── columns: column1:1(int!null) column2:2(int!null)
  ├── internal-ordering: +1
  ├── ordering: +1
  ├── sort
- │    ├── columns: column1:1(int) column2:2(int)
+ │    ├── columns: column1:1(int!null) column2:2(int!null)
  │    ├── ordering: +1
  │    └── values
- │         ├── columns: column1:1(int) column2:2(int)
+ │         ├── columns: column1:1(int!null) column2:2(int!null)
  │         ├── tuple [type=tuple{int, int}]
  │         │    ├── const: 1 [type=int]
  │         │    └── const: 1 [type=int]
@@ -197,18 +197,18 @@ build
 (VALUES (1), (1), (1), (2), (2) UNION ALL VALUES (1), (3), (1)) ORDER BY 1 DESC LIMIT 2
 ----
 limit
- ├── columns: column1:3(int)
+ ├── columns: column1:3(int!null)
  ├── internal-ordering: -3
  ├── ordering: -3
  ├── sort
- │    ├── columns: column1:3(int)
+ │    ├── columns: column1:3(int!null)
  │    ├── ordering: -3
  │    └── union-all
- │         ├── columns: column1:3(int)
+ │         ├── columns: column1:3(int!null)
  │         ├── left columns: column1:1(int)
  │         ├── right columns: column1:2(int)
  │         ├── values
- │         │    ├── columns: column1:1(int)
+ │         │    ├── columns: column1:1(int!null)
  │         │    ├── tuple [type=tuple{int}]
  │         │    │    └── const: 1 [type=int]
  │         │    ├── tuple [type=tuple{int}]
@@ -220,7 +220,7 @@ limit
  │         │    └── tuple [type=tuple{int}]
  │         │         └── const: 2 [type=int]
  │         └── values
- │              ├── columns: column1:2(int)
+ │              ├── columns: column1:2(int!null)
  │              ├── tuple [type=tuple{int}]
  │              │    └── const: 1 [type=int]
  │              ├── tuple [type=tuple{int}]
@@ -234,18 +234,18 @@ build
 VALUES (1), (1), (1), (2), (2) UNION ALL VALUES (1), (3), (1) ORDER BY 1 DESC LIMIT 2
 ----
 limit
- ├── columns: column1:3(int)
+ ├── columns: column1:3(int!null)
  ├── internal-ordering: -3
  ├── ordering: -3
  ├── sort
- │    ├── columns: column1:3(int)
+ │    ├── columns: column1:3(int!null)
  │    ├── ordering: -3
  │    └── union-all
- │         ├── columns: column1:3(int)
+ │         ├── columns: column1:3(int!null)
  │         ├── left columns: column1:1(int)
  │         ├── right columns: column1:2(int)
  │         ├── values
- │         │    ├── columns: column1:1(int)
+ │         │    ├── columns: column1:1(int!null)
  │         │    ├── tuple [type=tuple{int}]
  │         │    │    └── const: 1 [type=int]
  │         │    ├── tuple [type=tuple{int}]
@@ -257,7 +257,7 @@ limit
  │         │    └── tuple [type=tuple{int}]
  │         │         └── const: 2 [type=int]
  │         └── values
- │              ├── columns: column1:2(int)
+ │              ├── columns: column1:2(int!null)
  │              ├── tuple [type=tuple{int}]
  │              │    └── const: 1 [type=int]
  │              ├── tuple [type=tuple{int}]

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -871,10 +871,10 @@ build
 SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x
 ----
 sort
- ├── columns: x:1(string)
+ ├── columns: x:1(string!null)
  ├── ordering: +1
  └── values
-      ├── columns: column1:1(string)
+      ├── columns: column1:1(string!null)
       ├── tuple [type=tuple{string}]
       │    └── const: 'a' [type=string]
       ├── tuple [type=tuple{string}]
@@ -886,7 +886,7 @@ build
 SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x)
 ----
 values
- ├── columns: x:1(string)
+ ├── columns: x:1(string!null)
  ├── tuple [type=tuple{string}]
  │    └── const: 'a' [type=string]
  ├── tuple [type=tuple{string}]

--- a/pkg/sql/opt/optbuilder/testdata/ordinality
+++ b/pkg/sql/opt/optbuilder/testdata/ordinality
@@ -23,9 +23,9 @@ build
 SELECT * FROM (VALUES ('a'), ('b')) WITH ORDINALITY AS X(name, i)
 ----
 ordinality
- ├── columns: name:1(string) i:2(int!null)
+ ├── columns: name:1(string!null) i:2(int!null)
  └── values
-      ├── columns: column1:1(string)
+      ├── columns: column1:1(string!null)
       ├── tuple [type=tuple{string}]
       │    └── const: 'a' [type=string]
       └── tuple [type=tuple{string}]

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -847,7 +847,7 @@ project
  └── projections
       └── array-flatten [type=string[]]
            └── values
-                ├── columns: column1:1(string)
+                ├── columns: column1:1(string!null)
                 ├── tuple [type=tuple{string}]
                 │    └── const: 'foo' [type=string]
                 ├── tuple [type=tuple{string}]

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -720,7 +720,7 @@ project
  └── projections
       └── any: eq [type=bool]
            ├── values
-           │    ├── columns: column1:1(int)
+           │    ├── columns: column1:1(int!null)
            │    └── tuple [type=tuple{int}]
            │         └── const: 1 [type=int]
            └── cast: INT8 [type=int]
@@ -738,7 +738,7 @@ project
            ├── project
            │    ├── columns: column3:3(tuple{int, int})
            │    ├── values
-           │    │    ├── columns: column1:1(int) column2:2(int)
+           │    │    ├── columns: column1:1(int!null) column2:2(int!null)
            │    │    └── tuple [type=tuple{int, int}]
            │    │         ├── const: 1 [type=int]
            │    │         └── const: 1 [type=int]
@@ -762,7 +762,7 @@ project
       └── not [type=bool]
            └── any: eq [type=bool]
                 ├── values
-                │    ├── columns: column1:1(int)
+                │    ├── columns: column1:1(int!null)
                 │    └── tuple [type=tuple{int}]
                 │         └── const: 1 [type=int]
                 └── cast: INT8 [type=int]
@@ -781,7 +781,7 @@ project
                 ├── project
                 │    ├── columns: column3:3(tuple{int, int})
                 │    ├── values
-                │    │    ├── columns: column1:1(int) column2:2(int)
+                │    │    ├── columns: column1:1(int!null) column2:2(int!null)
                 │    │    └── tuple [type=tuple{int, int}]
                 │    │         ├── const: 1 [type=int]
                 │    │         └── const: 1 [type=int]
@@ -807,7 +807,7 @@ project
            ├── select
            │    ├── columns: column1:1(int!null)
            │    ├── values
-           │    │    ├── columns: column1:1(int)
+           │    │    ├── columns: column1:1(int!null)
            │    │    └── tuple [type=tuple{int}]
            │    │         └── const: 1 [type=int]
            │    └── filters
@@ -829,9 +829,9 @@ project
            ├── project
            │    ├── columns: column3:3(tuple{int, int})
            │    ├── select
-           │    │    ├── columns: column1:1(int!null) column2:2(int)
+           │    │    ├── columns: column1:1(int!null) column2:2(int!null)
            │    │    ├── values
-           │    │    │    ├── columns: column1:1(int) column2:2(int)
+           │    │    │    ├── columns: column1:1(int!null) column2:2(int!null)
            │    │    │    └── tuple [type=tuple{int, int}]
            │    │    │         ├── const: 1 [type=int]
            │    │    │         └── const: 1 [type=int]
@@ -861,7 +861,7 @@ project
                 ├── select
                 │    ├── columns: column1:1(int!null)
                 │    ├── values
-                │    │    ├── columns: column1:1(int)
+                │    │    ├── columns: column1:1(int!null)
                 │    │    └── tuple [type=tuple{int}]
                 │    │         └── const: 1 [type=int]
                 │    └── filters
@@ -884,9 +884,9 @@ project
                 ├── project
                 │    ├── columns: column3:3(tuple{int, int})
                 │    ├── select
-                │    │    ├── columns: column1:1(int!null) column2:2(int)
+                │    │    ├── columns: column1:1(int!null) column2:2(int!null)
                 │    │    ├── values
-                │    │    │    ├── columns: column1:1(int) column2:2(int)
+                │    │    │    ├── columns: column1:1(int!null) column2:2(int!null)
                 │    │    │    └── tuple [type=tuple{int, int}]
                 │    │    │         ├── const: 1 [type=int]
                 │    │    │         └── const: 1 [type=int]
@@ -916,7 +916,7 @@ project
                 ├── select
                 │    ├── columns: column1:1(int!null)
                 │    ├── values
-                │    │    ├── columns: column1:1(int)
+                │    │    ├── columns: column1:1(int!null)
                 │    │    └── tuple [type=tuple{int}]
                 │    │         └── const: 1 [type=int]
                 │    └── filters
@@ -939,9 +939,9 @@ project
                 ├── project
                 │    ├── columns: column3:3(tuple{int, int})
                 │    ├── select
-                │    │    ├── columns: column1:1(int!null) column2:2(int)
+                │    │    ├── columns: column1:1(int!null) column2:2(int!null)
                 │    │    ├── values
-                │    │    │    ├── columns: column1:1(int) column2:2(int)
+                │    │    │    ├── columns: column1:1(int!null) column2:2(int!null)
                 │    │    │    └── tuple [type=tuple{int, int}]
                 │    │    │         ├── const: 1 [type=int]
                 │    │    │         └── const: 1 [type=int]
@@ -971,7 +971,7 @@ project
                 ├── select
                 │    ├── columns: column1:1(int!null)
                 │    ├── values
-                │    │    ├── columns: column1:1(int)
+                │    │    ├── columns: column1:1(int!null)
                 │    │    └── tuple [type=tuple{int}]
                 │    │         └── const: 1 [type=int]
                 │    └── filters
@@ -994,9 +994,9 @@ project
                 ├── project
                 │    ├── columns: column3:3(tuple{int, int})
                 │    ├── select
-                │    │    ├── columns: column1:1(int!null) column2:2(int)
+                │    │    ├── columns: column1:1(int!null) column2:2(int!null)
                 │    │    ├── values
-                │    │    │    ├── columns: column1:1(int) column2:2(int)
+                │    │    │    ├── columns: column1:1(int!null) column2:2(int!null)
                 │    │    │    └── tuple [type=tuple{int, int}]
                 │    │    │         ├── const: 1 [type=int]
                 │    │    │         └── const: 1 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -65,7 +65,7 @@ project
       └── indirection [type=int]
            ├── array-flatten [type=int[]]
            │    └── values
-           │         ├── columns: column1:1(int)
+           │         ├── columns: column1:1(int!null)
            │         ├── tuple [type=tuple{int}]
            │         │    └── const: 1 [type=int]
            │         └── tuple [type=tuple{int}]
@@ -797,7 +797,7 @@ build
 VALUES (1, (SELECT (2) AS a))
 ----
 values
- ├── columns: column1:2(int) column2:3(int)
+ ├── columns: column1:2(int!null) column2:3(int)
  └── tuple [type=tuple{int, int}]
       ├── const: 1 [type=int]
       └── subquery [type=int]
@@ -992,7 +992,7 @@ build
 SELECT * FROM (VALUES (1, 2)) AS foo
 ----
 values
- ├── columns: column1:1(int) column2:2(int)
+ ├── columns: column1:1(int!null) column2:2(int!null)
  └── tuple [type=tuple{int, int}]
       ├── const: 1 [type=int]
       └── const: 2 [type=int]
@@ -1001,7 +1001,7 @@ build
 SELECT * FROM (VALUES (1, 2))
 ----
 values
- ├── columns: column1:1(int) column2:2(int)
+ ├── columns: column1:1(int!null) column2:2(int!null)
  └── tuple [type=tuple{int, int}]
       ├── const: 1 [type=int]
       └── const: 2 [type=int]
@@ -1010,7 +1010,7 @@ build
 SELECT * FROM (VALUES (1, 'one'), (2, 'two'), (3, 'three')) AS foo
 ----
 values
- ├── columns: column1:1(int) column2:2(string)
+ ├── columns: column1:1(int!null) column2:2(string!null)
  ├── tuple [type=tuple{int, string}]
  │    ├── const: 1 [type=int]
  │    └── const: 'one' [type=string]
@@ -1025,7 +1025,7 @@ build
 SELECT * FROM (VALUES (1, 2, 3), (4, 5, 6)) AS foo
 ----
 values
- ├── columns: column1:1(int) column2:2(int) column3:3(int)
+ ├── columns: column1:1(int!null) column2:2(int!null) column3:3(int!null)
  ├── tuple [type=tuple{int, int, int}]
  │    ├── const: 1 [type=int]
  │    ├── const: 2 [type=int]
@@ -1039,7 +1039,7 @@ build
 SELECT * FROM (VALUES (1, 2, 3), (4, 5, 6)) AS foo (foo1, foo2, foo3)
 ----
 values
- ├── columns: foo1:1(int) foo2:2(int) foo3:3(int)
+ ├── columns: foo1:1(int!null) foo2:2(int!null) foo3:3(int!null)
  ├── tuple [type=tuple{int, int, int}]
  │    ├── const: 1 [type=int]
  │    ├── const: 2 [type=int]
@@ -1053,7 +1053,7 @@ build
 SELECT * FROM (VALUES (1, 2, 3), (4, 5, 6)) AS foo (foo1, foo2)
 ----
 values
- ├── columns: foo1:1(int) foo2:2(int) column3:3(int)
+ ├── columns: foo1:1(int!null) foo2:2(int!null) column3:3(int!null)
  ├── tuple [type=tuple{int, int, int}]
  │    ├── const: 1 [type=int]
  │    ├── const: 2 [type=int]
@@ -1130,9 +1130,9 @@ build
 SELECT * FROM (SELECT * FROM (VALUES (1, 2, 3), (4, 5, 6)) AS moo (moo1, moo2, moo3) WHERE moo1 = 4) as foo (foo1)
 ----
 select
- ├── columns: foo1:1(int!null) moo2:2(int) moo3:3(int)
+ ├── columns: foo1:1(int!null) moo2:2(int!null) moo3:3(int!null)
  ├── values
- │    ├── columns: column1:1(int) column2:2(int) column3:3(int)
+ │    ├── columns: column1:1(int!null) column2:2(int!null) column3:3(int!null)
  │    ├── tuple [type=tuple{int, int, int}]
  │    │    ├── const: 1 [type=int]
  │    │    ├── const: 2 [type=int]
@@ -1150,10 +1150,10 @@ build
 SELECT * FROM (SELECT * FROM (VALUES (1, 8, 8), (3, 1, 1), (2, 4, 4)) AS moo (moo1, moo2, moo3) ORDER BY moo2) as foo (foo1) ORDER BY foo1
 ----
 sort
- ├── columns: foo1:1(int) moo2:2(int) moo3:3(int)
+ ├── columns: foo1:1(int!null) moo2:2(int!null) moo3:3(int!null)
  ├── ordering: +1
  └── values
-      ├── columns: column1:1(int) column2:2(int) column3:3(int)
+      ├── columns: column1:1(int!null) column2:2(int!null) column3:3(int!null)
       ├── tuple [type=tuple{int, int, int}]
       │    ├── const: 1 [type=int]
       │    ├── const: 8 [type=int]
@@ -1171,11 +1171,11 @@ build
 SELECT a, b FROM (VALUES (1, 2, 3), (3, 4, 7), (5, 6, 10)) AS foo (a, b, c) WHERE a + b = c
 ----
 project
- ├── columns: a:1(int) b:2(int)
+ ├── columns: a:1(int!null) b:2(int!null)
  └── select
-      ├── columns: column1:1(int) column2:2(int) column3:3(int)
+      ├── columns: column1:1(int!null) column2:2(int!null) column3:3(int!null)
       ├── values
-      │    ├── columns: column1:1(int) column2:2(int) column3:3(int)
+      │    ├── columns: column1:1(int!null) column2:2(int!null) column3:3(int!null)
       │    ├── tuple [type=tuple{int, int, int}]
       │    │    ├── const: 1 [type=int]
       │    │    ├── const: 2 [type=int]
@@ -1199,7 +1199,7 @@ build
 SELECT foo.a FROM (VALUES (1), (2), (3)) AS foo (a)
 ----
 values
- ├── columns: a:1(int)
+ ├── columns: a:1(int!null)
  ├── tuple [type=tuple{int}]
  │    └── const: 1 [type=int]
  ├── tuple [type=tuple{int}]
@@ -1211,7 +1211,7 @@ build
 SELECT foo.a, a, column2, foo.column2 FROM (VALUES (1, 'one'), (2, 'two'), (3, 'three')) AS foo (a)
 ----
 values
- ├── columns: a:1(int) a:1(int) column2:2(string) column2:2(string)
+ ├── columns: a:1(int!null) a:1(int!null) column2:2(string!null) column2:2(string!null)
  ├── tuple [type=tuple{int, string}]
  │    ├── const: 1 [type=int]
  │    └── const: 'one' [type=string]

--- a/pkg/sql/opt/optbuilder/testdata/union
+++ b/pkg/sql/opt/optbuilder/testdata/union
@@ -4,11 +4,11 @@ build
 VALUES (1), (1), (1), (2), (2) UNION VALUES (1), (3), (1)
 ----
 union
- ├── columns: column1:3(int)
+ ├── columns: column1:3(int!null)
  ├── left columns: column1:1(int)
  ├── right columns: column1:2(int)
  ├── values
- │    ├── columns: column1:1(int)
+ │    ├── columns: column1:1(int!null)
  │    ├── tuple [type=tuple{int}]
  │    │    └── const: 1 [type=int]
  │    ├── tuple [type=tuple{int}]
@@ -20,7 +20,7 @@ union
  │    └── tuple [type=tuple{int}]
  │         └── const: 2 [type=int]
  └── values
-      ├── columns: column1:2(int)
+      ├── columns: column1:2(int!null)
       ├── tuple [type=tuple{int}]
       │    └── const: 1 [type=int]
       ├── tuple [type=tuple{int}]
@@ -32,11 +32,11 @@ build
 VALUES (1), (1), (1), (2), (2) UNION ALL VALUES (1), (3), (1)
 ----
 union-all
- ├── columns: column1:3(int)
+ ├── columns: column1:3(int!null)
  ├── left columns: column1:1(int)
  ├── right columns: column1:2(int)
  ├── values
- │    ├── columns: column1:1(int)
+ │    ├── columns: column1:1(int!null)
  │    ├── tuple [type=tuple{int}]
  │    │    └── const: 1 [type=int]
  │    ├── tuple [type=tuple{int}]
@@ -48,7 +48,7 @@ union-all
  │    └── tuple [type=tuple{int}]
  │         └── const: 2 [type=int]
  └── values
-      ├── columns: column1:2(int)
+      ├── columns: column1:2(int!null)
       ├── tuple [type=tuple{int}]
       │    └── const: 1 [type=int]
       ├── tuple [type=tuple{int}]
@@ -60,11 +60,11 @@ build
 VALUES (1), (1), (1), (2), (2) INTERSECT VALUES (1), (3), (1)
 ----
 intersect
- ├── columns: column1:1(int)
- ├── left columns: column1:1(int)
+ ├── columns: column1:1(int!null)
+ ├── left columns: column1:1(int!null)
  ├── right columns: column1:2(int)
  ├── values
- │    ├── columns: column1:1(int)
+ │    ├── columns: column1:1(int!null)
  │    ├── tuple [type=tuple{int}]
  │    │    └── const: 1 [type=int]
  │    ├── tuple [type=tuple{int}]
@@ -76,7 +76,7 @@ intersect
  │    └── tuple [type=tuple{int}]
  │         └── const: 2 [type=int]
  └── values
-      ├── columns: column1:2(int)
+      ├── columns: column1:2(int!null)
       ├── tuple [type=tuple{int}]
       │    └── const: 1 [type=int]
       ├── tuple [type=tuple{int}]
@@ -88,11 +88,11 @@ build
 VALUES (1), (1), (1), (2), (2) INTERSECT ALL VALUES (1), (3), (1)
 ----
 intersect-all
- ├── columns: column1:1(int)
- ├── left columns: column1:1(int)
+ ├── columns: column1:1(int!null)
+ ├── left columns: column1:1(int!null)
  ├── right columns: column1:2(int)
  ├── values
- │    ├── columns: column1:1(int)
+ │    ├── columns: column1:1(int!null)
  │    ├── tuple [type=tuple{int}]
  │    │    └── const: 1 [type=int]
  │    ├── tuple [type=tuple{int}]
@@ -104,7 +104,7 @@ intersect-all
  │    └── tuple [type=tuple{int}]
  │         └── const: 2 [type=int]
  └── values
-      ├── columns: column1:2(int)
+      ├── columns: column1:2(int!null)
       ├── tuple [type=tuple{int}]
       │    └── const: 1 [type=int]
       ├── tuple [type=tuple{int}]
@@ -116,11 +116,11 @@ build
 VALUES (1), (1), (1), (2), (2) EXCEPT VALUES (1), (3), (1)
 ----
 except
- ├── columns: column1:1(int)
- ├── left columns: column1:1(int)
+ ├── columns: column1:1(int!null)
+ ├── left columns: column1:1(int!null)
  ├── right columns: column1:2(int)
  ├── values
- │    ├── columns: column1:1(int)
+ │    ├── columns: column1:1(int!null)
  │    ├── tuple [type=tuple{int}]
  │    │    └── const: 1 [type=int]
  │    ├── tuple [type=tuple{int}]
@@ -132,7 +132,7 @@ except
  │    └── tuple [type=tuple{int}]
  │         └── const: 2 [type=int]
  └── values
-      ├── columns: column1:2(int)
+      ├── columns: column1:2(int!null)
       ├── tuple [type=tuple{int}]
       │    └── const: 1 [type=int]
       ├── tuple [type=tuple{int}]
@@ -144,11 +144,11 @@ build
 VALUES (1), (1), (1), (2), (2) EXCEPT ALL VALUES (1), (3), (1)
 ----
 except-all
- ├── columns: column1:1(int)
- ├── left columns: column1:1(int)
+ ├── columns: column1:1(int!null)
+ ├── left columns: column1:1(int!null)
  ├── right columns: column1:2(int)
  ├── values
- │    ├── columns: column1:1(int)
+ │    ├── columns: column1:1(int!null)
  │    ├── tuple [type=tuple{int}]
  │    │    └── const: 1 [type=int]
  │    ├── tuple [type=tuple{int}]
@@ -160,7 +160,7 @@ except-all
  │    └── tuple [type=tuple{int}]
  │         └── const: 2 [type=int]
  └── values
-      ├── columns: column1:2(int)
+      ├── columns: column1:2(int!null)
       ├── tuple [type=tuple{int}]
       │    └── const: 1 [type=int]
       ├── tuple [type=tuple{int}]
@@ -172,11 +172,11 @@ build
 VALUES (1, 2), (1, 1), (1, 2), (2, 1), (2, 1) UNION VALUES (1, 3), (3, 4), (1, 1)
 ----
 union
- ├── columns: column1:5(int) column2:6(int)
+ ├── columns: column1:5(int!null) column2:6(int!null)
  ├── left columns: column1:1(int) column2:2(int)
  ├── right columns: column1:3(int) column2:4(int)
  ├── values
- │    ├── columns: column1:1(int) column2:2(int)
+ │    ├── columns: column1:1(int!null) column2:2(int!null)
  │    ├── tuple [type=tuple{int, int}]
  │    │    ├── const: 1 [type=int]
  │    │    └── const: 2 [type=int]
@@ -193,7 +193,7 @@ union
  │         ├── const: 2 [type=int]
  │         └── const: 1 [type=int]
  └── values
-      ├── columns: column1:3(int) column2:4(int)
+      ├── columns: column1:3(int!null) column2:4(int!null)
       ├── tuple [type=tuple{int, int}]
       │    ├── const: 1 [type=int]
       │    └── const: 3 [type=int]
@@ -208,18 +208,18 @@ build
 (VALUES (1), (1), (1), (2), (2) UNION ALL VALUES (1), (3), (1)) ORDER BY 1 DESC LIMIT 2
 ----
 limit
- ├── columns: column1:3(int)
+ ├── columns: column1:3(int!null)
  ├── internal-ordering: -3
  ├── ordering: -3
  ├── sort
- │    ├── columns: column1:3(int)
+ │    ├── columns: column1:3(int!null)
  │    ├── ordering: -3
  │    └── union-all
- │         ├── columns: column1:3(int)
+ │         ├── columns: column1:3(int!null)
  │         ├── left columns: column1:1(int)
  │         ├── right columns: column1:2(int)
  │         ├── values
- │         │    ├── columns: column1:1(int)
+ │         │    ├── columns: column1:1(int!null)
  │         │    ├── tuple [type=tuple{int}]
  │         │    │    └── const: 1 [type=int]
  │         │    ├── tuple [type=tuple{int}]
@@ -231,7 +231,7 @@ limit
  │         │    └── tuple [type=tuple{int}]
  │         │         └── const: 2 [type=int]
  │         └── values
- │              ├── columns: column1:2(int)
+ │              ├── columns: column1:2(int!null)
  │              ├── tuple [type=tuple{int}]
  │              │    └── const: 1 [type=int]
  │              ├── tuple [type=tuple{int}]
@@ -245,18 +245,18 @@ build
 VALUES (1), (1), (1), (2), (2) UNION ALL VALUES (1), (3), (1) ORDER BY 1 DESC LIMIT 2
 ----
 limit
- ├── columns: column1:3(int)
+ ├── columns: column1:3(int!null)
  ├── internal-ordering: -3
  ├── ordering: -3
  ├── sort
- │    ├── columns: column1:3(int)
+ │    ├── columns: column1:3(int!null)
  │    ├── ordering: -3
  │    └── union-all
- │         ├── columns: column1:3(int)
+ │         ├── columns: column1:3(int!null)
  │         ├── left columns: column1:1(int)
  │         ├── right columns: column1:2(int)
  │         ├── values
- │         │    ├── columns: column1:1(int)
+ │         │    ├── columns: column1:1(int!null)
  │         │    ├── tuple [type=tuple{int}]
  │         │    │    └── const: 1 [type=int]
  │         │    ├── tuple [type=tuple{int}]
@@ -268,7 +268,7 @@ limit
  │         │    └── tuple [type=tuple{int}]
  │         │         └── const: 2 [type=int]
  │         └── values
- │              ├── columns: column1:2(int)
+ │              ├── columns: column1:2(int!null)
  │              ├── tuple [type=tuple{int}]
  │              │    └── const: 1 [type=int]
  │              ├── tuple [type=tuple{int}]
@@ -298,7 +298,7 @@ sort
       │         └── cast: INT8 [type=int]
       │              └── variable: column1 [type=unknown]
       └── values
-           ├── columns: column1:2(int)
+           ├── columns: column1:2(int!null)
            └── tuple [type=tuple{int}]
                 └── const: 1 [type=int]
 
@@ -672,21 +672,21 @@ build
 SELECT * FROM (SELECT * FROM (VALUES (1)) a LEFT JOIN (VALUES (1) UNION VALUES (2)) b on a.column1 = b.column1);
 ----
 left-join
- ├── columns: column1:1(int) column1:4(int)
+ ├── columns: column1:1(int!null) column1:4(int)
  ├── values
- │    ├── columns: column1:1(int)
+ │    ├── columns: column1:1(int!null)
  │    └── tuple [type=tuple{int}]
  │         └── const: 1 [type=int]
  ├── union
- │    ├── columns: column1:4(int)
+ │    ├── columns: column1:4(int!null)
  │    ├── left columns: column1:2(int)
  │    ├── right columns: column1:3(int)
  │    ├── values
- │    │    ├── columns: column1:2(int)
+ │    │    ├── columns: column1:2(int!null)
  │    │    └── tuple [type=tuple{int}]
  │    │         └── const: 1 [type=int]
  │    └── values
- │         ├── columns: column1:3(int)
+ │         ├── columns: column1:3(int!null)
  │         └── tuple [type=tuple{int}]
  │              └── const: 2 [type=int]
  └── filters
@@ -698,21 +698,21 @@ build
 SELECT * FROM (VALUES (1)) a LEFT JOIN (VALUES (1) UNION VALUES (2)) b on a.column1 = b.column1;
 ----
 left-join
- ├── columns: column1:1(int) column1:4(int)
+ ├── columns: column1:1(int!null) column1:4(int)
  ├── values
- │    ├── columns: column1:1(int)
+ │    ├── columns: column1:1(int!null)
  │    └── tuple [type=tuple{int}]
  │         └── const: 1 [type=int]
  ├── union
- │    ├── columns: column1:4(int)
+ │    ├── columns: column1:4(int!null)
  │    ├── left columns: column1:2(int)
  │    ├── right columns: column1:3(int)
  │    ├── values
- │    │    ├── columns: column1:2(int)
+ │    │    ├── columns: column1:2(int!null)
  │    │    └── tuple [type=tuple{int}]
  │    │         └── const: 1 [type=int]
  │    └── values
- │         ├── columns: column1:3(int)
+ │         ├── columns: column1:3(int!null)
  │         └── tuple [type=tuple{int}]
  │              └── const: 2 [type=int]
  └── filters
@@ -878,7 +878,7 @@ union
  │         └── cast: INT8 [type=int]
  │              └── variable: column1 [type=unknown]
  └── values
-      ├── columns: column1:3(int) column2:4(string)
+      ├── columns: column1:3(int!null) column2:4(string!null)
       ├── tuple [type=tuple{int, string}]
       │    ├── const: 1 [type=int]
       │    └── const: 'a' [type=string]
@@ -902,9 +902,9 @@ intersect
  │         ├── null [type=unknown]
  │         └── const: 'x' [type=string]
  └── project
-      ├── columns: column2:5(string) column1:3(int)
+      ├── columns: column2:5(string) column1:3(int!null)
       ├── values
-      │    ├── columns: column1:3(int) column2:4(unknown)
+      │    ├── columns: column1:3(int!null) column2:4(unknown)
       │    ├── tuple [type=tuple{int, unknown}]
       │    │    ├── const: 1 [type=int]
       │    │    └── null [type=unknown]
@@ -936,9 +936,9 @@ union-all
  │         └── cast: INT8 [type=int]
  │              └── variable: column1 [type=unknown]
  └── project
-      ├── columns: column2:8(string) column1:3(int)
+      ├── columns: column2:8(string) column1:3(int!null)
       ├── values
-      │    ├── columns: column1:3(int) column2:4(unknown)
+      │    ├── columns: column1:3(int!null) column2:4(unknown)
       │    ├── tuple [type=tuple{int, unknown}]
       │    │    ├── const: 1 [type=int]
       │    │    └── null [type=unknown]

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -449,19 +449,19 @@ sort
            │    ├──  upsert_c:17 => c:3
            │    └──  upsert_rowid:18 => rowid:4
            └── project
-                ├── columns: upsert_a:15(int) upsert_b:16(int) upsert_c:17(int) upsert_rowid:18(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int!null) column14:14(int)
+                ├── columns: upsert_a:15(int) upsert_b:16(int) upsert_c:17(int) upsert_rowid:18(int) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int!null) column14:14(int)
                 ├── project
-                │    ├── columns: column14:14(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int!null)
+                │    ├── columns: column14:14(int) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int!null)
                 │    ├── project
-                │    │    ├── columns: column13:13(int!null) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+                │    │    ├── columns: column13:13(int!null) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
                 │    │    ├── left-join
-                │    │    │    ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+                │    │    │    ├── columns: column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
                 │    │    │    ├── project
-                │    │    │    │    ├── columns: column8:8(int) column1:5(int) column2:6(int) column7:7(int)
+                │    │    │    │    ├── columns: column8:8(int) column1:5(int!null) column2:6(int!null) column7:7(int)
                 │    │    │    │    ├── project
-                │    │    │    │    │    ├── columns: column7:7(int) column1:5(int) column2:6(int)
+                │    │    │    │    │    ├── columns: column7:7(int) column1:5(int!null) column2:6(int!null)
                 │    │    │    │    │    ├── values
-                │    │    │    │    │    │    ├── columns: column1:5(int) column2:6(int)
+                │    │    │    │    │    │    ├── columns: column1:5(int!null) column2:6(int!null)
                 │    │    │    │    │    │    ├── tuple [type=tuple{int, int}]
                 │    │    │    │    │    │    │    ├── const: 1 [type=int]
                 │    │    │    │    │    │    │    └── const: 2 [type=int]
@@ -540,19 +540,19 @@ upsert tab
  │    ├──  upsert_a:15 => a:1
  │    └──  upsert_c:17 => c:3
  └── project
-      ├── columns: upsert_a:15(int) upsert_b:16(int) upsert_c:17(int) upsert_rowid:18(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int) column14:14(int)
+      ├── columns: upsert_a:15(int) upsert_b:16(int) upsert_c:17(int) upsert_rowid:18(int) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int) column14:14(int)
       ├── project
-      │    ├── columns: column14:14(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int)
+      │    ├── columns: column14:14(int) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int)
       │    ├── project
-      │    │    ├── columns: column13:13(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+      │    │    ├── columns: column13:13(int) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
       │    │    ├── left-join
-      │    │    │    ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+      │    │    │    ├── columns: column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
       │    │    │    ├── project
-      │    │    │    │    ├── columns: column8:8(int) column1:5(int) column2:6(int) column7:7(int)
+      │    │    │    │    ├── columns: column8:8(int) column1:5(int!null) column2:6(int!null) column7:7(int)
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column7:7(int) column1:5(int) column2:6(int)
+      │    │    │    │    │    ├── columns: column7:7(int) column1:5(int!null) column2:6(int!null)
       │    │    │    │    │    ├── values
-      │    │    │    │    │    │    ├── columns: column1:5(int) column2:6(int)
+      │    │    │    │    │    │    ├── columns: column1:5(int!null) column2:6(int!null)
       │    │    │    │    │    │    └── tuple [type=tuple{int, int}]
       │    │    │    │    │    │         ├── const: 1 [type=int]
       │    │    │    │    │    │         └── const: 2 [type=int]
@@ -654,25 +654,25 @@ insert xyz
  │    ├──  column2:5 => y:2
  │    └──  column3:6 => z:3
  └── project
-      ├── columns: column1:4(int) column2:5(int) column3:6(int)
+      ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
       └── select
-           ├── columns: column1:4(int) column2:5(int) column3:6(int) x:13(int) y:14(int) z:15(int)
+           ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null) x:13(int) y:14(int) z:15(int)
            ├── left-join
-           │    ├── columns: column1:4(int) column2:5(int) column3:6(int) x:13(int) y:14(int) z:15(int)
+           │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null) x:13(int) y:14(int) z:15(int)
            │    ├── project
-           │    │    ├── columns: column1:4(int) column2:5(int) column3:6(int)
+           │    │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
            │    │    └── select
-           │    │         ├── columns: column1:4(int) column2:5(int) column3:6(int) x:10(int) y:11(int) z:12(int)
+           │    │         ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null) x:10(int) y:11(int) z:12(int)
            │    │         ├── left-join
-           │    │         │    ├── columns: column1:4(int) column2:5(int) column3:6(int) x:10(int) y:11(int) z:12(int)
+           │    │         │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null) x:10(int) y:11(int) z:12(int)
            │    │         │    ├── project
-           │    │         │    │    ├── columns: column1:4(int) column2:5(int) column3:6(int)
+           │    │         │    │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
            │    │         │    │    └── select
-           │    │         │    │         ├── columns: column1:4(int) column2:5(int) column3:6(int) x:7(int) y:8(int) z:9(int)
+           │    │         │    │         ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null) x:7(int) y:8(int) z:9(int)
            │    │         │    │         ├── left-join
-           │    │         │    │         │    ├── columns: column1:4(int) column2:5(int) column3:6(int) x:7(int) y:8(int) z:9(int)
+           │    │         │    │         │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null) x:7(int) y:8(int) z:9(int)
            │    │         │    │         │    ├── values
-           │    │         │    │         │    │    ├── columns: column1:4(int) column2:5(int) column3:6(int)
+           │    │         │    │         │    │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
            │    │         │    │         │    │    ├── tuple [type=tuple{int, int, int}]
            │    │         │    │         │    │    │    ├── const: 1 [type=int]
            │    │         │    │         │    │    │    ├── const: 2 [type=int]
@@ -731,13 +731,13 @@ insert xyz
  │    ├──  column2:5 => y:2
  │    └──  column3:6 => z:3
  └── project
-      ├── columns: column1:4(int) column2:5(int) column3:6(int)
+      ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
       └── select
-           ├── columns: column1:4(int) column2:5(int) column3:6(int) x:7(int) y:8(int) z:9(int)
+           ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null) x:7(int) y:8(int) z:9(int)
            ├── left-join
-           │    ├── columns: column1:4(int) column2:5(int) column3:6(int) x:7(int) y:8(int) z:9(int)
+           │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null) x:7(int) y:8(int) z:9(int)
            │    ├── values
-           │    │    ├── columns: column1:4(int) column2:5(int) column3:6(int)
+           │    │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
            │    │    ├── tuple [type=tuple{int, int, int}]
            │    │    │    ├── const: 1 [type=int]
            │    │    │    ├── const: 2 [type=int]
@@ -791,15 +791,15 @@ project
  │    │    ├──  upsert_y:14 => y:2
  │    │    └──  upsert_z:15 => z:3
  │    └── project
- │         ├── columns: upsert_x:13(int) upsert_y:14(int) upsert_z:15(int) column1:4(int) column2:5(int) column3:6(int) x:7(int) y:8(int) z:9(int) column10:10(int) column11:11(int) column12:12(int)
+ │         ├── columns: upsert_x:13(int) upsert_y:14(int) upsert_z:15(int) column1:4(int!null) column2:5(int!null) column3:6(int!null) x:7(int) y:8(int) z:9(int) column10:10(int) column11:11(int) column12:12(int)
  │         ├── project
- │         │    ├── columns: column10:10(int) column11:11(int) column12:12(int) column1:4(int) column2:5(int) column3:6(int) x:7(int) y:8(int) z:9(int)
+ │         │    ├── columns: column10:10(int) column11:11(int) column12:12(int) column1:4(int!null) column2:5(int!null) column3:6(int!null) x:7(int) y:8(int) z:9(int)
  │         │    ├── select
- │         │    │    ├── columns: column1:4(int) column2:5(int) column3:6(int) x:7(int) y:8(int) z:9(int)
+ │         │    │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null) x:7(int) y:8(int) z:9(int)
  │         │    │    ├── left-join
- │         │    │    │    ├── columns: column1:4(int) column2:5(int) column3:6(int) x:7(int) y:8(int) z:9(int)
+ │         │    │    │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null) x:7(int) y:8(int) z:9(int)
  │         │    │    │    ├── values
- │         │    │    │    │    ├── columns: column1:4(int) column2:5(int) column3:6(int)
+ │         │    │    │    │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
  │         │    │    │    │    ├── tuple [type=tuple{int, int, int}]
  │         │    │    │    │    │    ├── const: 1 [type=int]
  │         │    │    │    │    │    ├── const: 2 [type=int]
@@ -912,19 +912,19 @@ upsert abc
  │    ├──  upsert_b:19 => b:2
  │    └──  upsert_c:20 => c:3
  └── project
-      ├── columns: upsert_a:18(int) upsert_b:19(int) upsert_c:20(int) upsert_rowid:21(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) x:13(int) "?column?":16(int) column17:17(int)
+      ├── columns: upsert_a:18(int) upsert_b:19(int) upsert_c:20(int) upsert_rowid:21(int) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) x:13(int) "?column?":16(int) column17:17(int)
       ├── project
-      │    ├── columns: column17:17(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) x:13(int) "?column?":16(int)
+      │    ├── columns: column17:17(int) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) x:13(int) "?column?":16(int)
       │    ├── left-join-apply
-      │    │    ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) x:13(int) "?column?":16(int)
+      │    │    ├── columns: column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) x:13(int) "?column?":16(int)
       │    │    ├── left-join
-      │    │    │    ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+      │    │    │    ├── columns: column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
       │    │    │    ├── project
-      │    │    │    │    ├── columns: column8:8(int) column1:5(int) column2:6(int) column7:7(int)
+      │    │    │    │    ├── columns: column8:8(int) column1:5(int!null) column2:6(int!null) column7:7(int)
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column7:7(int) column1:5(int) column2:6(int)
+      │    │    │    │    │    ├── columns: column7:7(int) column1:5(int!null) column2:6(int!null)
       │    │    │    │    │    ├── values
-      │    │    │    │    │    │    ├── columns: column1:5(int) column2:6(int)
+      │    │    │    │    │    │    ├── columns: column1:5(int!null) column2:6(int!null)
       │    │    │    │    │    │    └── tuple [type=tuple{int, int}]
       │    │    │    │    │    │         ├── const: 1 [type=int]
       │    │    │    │    │    │         └── const: 2 [type=int]
@@ -1016,19 +1016,19 @@ upsert abc
  │    ├──  upsert_b:17 => b:2
  │    └──  upsert_c:18 => c:3
  └── project
-      ├── columns: upsert_a:16(int) upsert_b:17(int) upsert_c:18(int) upsert_rowid:19(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int) column14:14(int!null) column15:15(int)
+      ├── columns: upsert_a:16(int) upsert_b:17(int) upsert_c:18(int) upsert_rowid:19(int) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int) column14:14(int!null) column15:15(int)
       ├── project
-      │    ├── columns: column15:15(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int) column14:14(int!null)
+      │    ├── columns: column15:15(int) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int) column14:14(int!null)
       │    ├── project
-      │    │    ├── columns: column13:13(int) column14:14(int!null) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+      │    │    ├── columns: column13:13(int) column14:14(int!null) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
       │    │    ├── left-join
-      │    │    │    ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+      │    │    │    ├── columns: column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
       │    │    │    ├── project
-      │    │    │    │    ├── columns: column8:8(int) column1:5(int) column2:6(int) column7:7(int)
+      │    │    │    │    ├── columns: column8:8(int) column1:5(int!null) column2:6(int!null) column7:7(int)
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column7:7(int) column1:5(int) column2:6(int)
+      │    │    │    │    │    ├── columns: column7:7(int) column1:5(int!null) column2:6(int!null)
       │    │    │    │    │    ├── values
-      │    │    │    │    │    │    ├── columns: column1:5(int) column2:6(int)
+      │    │    │    │    │    │    ├── columns: column1:5(int!null) column2:6(int!null)
       │    │    │    │    │    │    └── tuple [type=tuple{int, int}]
       │    │    │    │    │    │         ├── const: 1 [type=int]
       │    │    │    │    │    │         └── const: 2 [type=int]
@@ -1110,21 +1110,21 @@ upsert mutation
  │    └──  upsert_p:20 => p:4
  ├── check columns: check1:21(bool)
  └── project
-      ├── columns: check1:21(bool) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int) column16:16(int) upsert_m:17(int) upsert_n:18(int) upsert_o:19(int) upsert_p:20(int)
+      ├── columns: check1:21(bool) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int) column16:16(int) upsert_m:17(int) upsert_n:18(int) upsert_o:19(int) upsert_p:20(int)
       ├── project
-      │    ├── columns: upsert_m:17(int) upsert_n:18(int) upsert_o:19(int) upsert_p:20(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int) column16:16(int)
+      │    ├── columns: upsert_m:17(int) upsert_n:18(int) upsert_o:19(int) upsert_p:20(int) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int) column16:16(int)
       │    ├── project
-      │    │    ├── columns: column16:16(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int)
+      │    │    ├── columns: column16:16(int) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int)
       │    │    ├── project
-      │    │    │    ├── columns: column15:15(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    │    │    ├── columns: column15:15(int) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
       │    │    │    ├── left-join
-      │    │    │    │    ├── columns: column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    │    │    │    ├── columns: column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column9:9(int) column1:6(int) column2:7(int) column8:8(int!null)
+      │    │    │    │    │    ├── columns: column9:9(int) column1:6(int!null) column2:7(int!null) column8:8(int!null)
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: column8:8(int!null) column1:6(int) column2:7(int)
+      │    │    │    │    │    │    ├── columns: column8:8(int!null) column1:6(int!null) column2:7(int!null)
       │    │    │    │    │    │    ├── values
-      │    │    │    │    │    │    │    ├── columns: column1:6(int) column2:7(int)
+      │    │    │    │    │    │    │    ├── columns: column1:6(int!null) column2:7(int!null)
       │    │    │    │    │    │    │    └── tuple [type=tuple{int, int}]
       │    │    │    │    │    │    │         ├── const: 1 [type=int]
       │    │    │    │    │    │    │         └── const: 2 [type=int]
@@ -1206,13 +1206,13 @@ upsert xyz
  │    ├──  column5:5 => y:2
  │    └──  column5:5 => z:3
  └── project
-      ├── columns: upsert_x:9(int) column1:4(int) column5:5(int) x:6(int) y:7(int) z:8(int)
+      ├── columns: upsert_x:9(int) column1:4(int!null) column5:5(int) x:6(int) y:7(int) z:8(int)
       ├── left-join
-      │    ├── columns: column1:4(int) column5:5(int) x:6(int) y:7(int) z:8(int)
+      │    ├── columns: column1:4(int!null) column5:5(int) x:6(int) y:7(int) z:8(int)
       │    ├── project
-      │    │    ├── columns: column5:5(int) column1:4(int)
+      │    │    ├── columns: column5:5(int) column1:4(int!null)
       │    │    ├── values
-      │    │    │    ├── columns: column1:4(int)
+      │    │    │    ├── columns: column1:4(int!null)
       │    │    │    └── tuple [type=tuple{int}]
       │    │    │         └── const: 1 [type=int]
       │    │    └── projections
@@ -1244,7 +1244,7 @@ upsert uv
  │    ├──  column1:3 => u:1
  │    └──  column2:4 => v:2
  └── values
-      ├── columns: column1:3(int) column2:4(int)
+      ├── columns: column1:3(int!null) column2:4(int!null)
       └── tuple [type=tuple{int, int}]
            ├── const: 1 [type=int]
            └── const: 2 [type=int]
@@ -1254,9 +1254,9 @@ build
 SELECT * FROM [UPSERT INTO abc VALUES (1, 2) RETURNING *]
 ----
 project
- ├── columns: a:1(int!null) b:2(int) c:3(int)
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int)
  └── upsert abc
-      ├── columns: a:1(int!null) b:2(int) c:3(int) rowid:4(int!null)
+      ├── columns: a:1(int!null) b:2(int!null) c:3(int) rowid:4(int!null)
       ├── canary column: 12
       ├── fetch columns: a:9(int) b:10(int) c:11(int) rowid:12(int)
       ├── insert-mapping:
@@ -1274,15 +1274,15 @@ project
       │    ├──  column8:8 => c:3
       │    └──  upsert_rowid:13 => rowid:4
       └── project
-           ├── columns: upsert_rowid:13(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+           ├── columns: upsert_rowid:13(int) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
            ├── left-join
-           │    ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+           │    ├── columns: column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
            │    ├── project
-           │    │    ├── columns: column8:8(int) column1:5(int) column2:6(int) column7:7(int)
+           │    │    ├── columns: column8:8(int) column1:5(int!null) column2:6(int!null) column7:7(int)
            │    │    ├── project
-           │    │    │    ├── columns: column7:7(int) column1:5(int) column2:6(int)
+           │    │    │    ├── columns: column7:7(int) column1:5(int!null) column2:6(int!null)
            │    │    │    ├── values
-           │    │    │    │    ├── columns: column1:5(int) column2:6(int)
+           │    │    │    │    ├── columns: column1:5(int!null) column2:6(int!null)
            │    │    │    │    └── tuple [type=tuple{int, int}]
            │    │    │    │         ├── const: 1 [type=int]
            │    │    │    │         └── const: 2 [type=int]
@@ -1325,11 +1325,11 @@ upsert xyz
  │    ├──  column3:6 => y:2
  │    └──  column1:4 => z:3
  └── project
-      ├── columns: upsert_x:10(int) column1:4(int) column2:5(int) column3:6(int) x:7(int) y:8(int) z:9(int)
+      ├── columns: upsert_x:10(int) column1:4(int!null) column2:5(int!null) column3:6(int!null) x:7(int) y:8(int) z:9(int)
       ├── left-join
-      │    ├── columns: column1:4(int) column2:5(int) column3:6(int) x:7(int) y:8(int) z:9(int)
+      │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null) x:7(int) y:8(int) z:9(int)
       │    ├── values
-      │    │    ├── columns: column1:4(int) column2:5(int) column3:6(int)
+      │    │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
       │    │    └── tuple [type=tuple{int, int, int}]
       │    │         ├── const: 1 [type=int]
       │    │         ├── const: 2 [type=int]
@@ -1362,7 +1362,7 @@ upsert noindex
  │    ├──  column2:5 => y:2
  │    └──  column3:6 => z:3
  └── values
-      ├── columns: column1:4(int) column2:5(int) column3:6(int)
+      ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
       └── tuple [type=tuple{int, int, int}]
            ├── const: 1 [type=int]
            ├── const: 2 [type=int]
@@ -1389,15 +1389,15 @@ upsert checks
  │    └──  column8:8 => d:4
  ├── check columns: check1:14(bool) check2:15(bool)
  └── project
-      ├── columns: check1:14(bool) check2:15(bool) column1:5(int) column2:6(int) column3:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int) upsert_a:13(int)
+      ├── columns: check1:14(bool) check2:15(bool) column1:5(int!null) column2:6(int!null) column3:7(int!null) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int) upsert_a:13(int)
       ├── project
-      │    ├── columns: upsert_a:13(int) column1:5(int) column2:6(int) column3:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
+      │    ├── columns: upsert_a:13(int) column1:5(int!null) column2:6(int!null) column3:7(int!null) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
       │    ├── left-join
-      │    │    ├── columns: column1:5(int) column2:6(int) column3:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
+      │    │    ├── columns: column1:5(int!null) column2:6(int!null) column3:7(int!null) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
       │    │    ├── project
-      │    │    │    ├── columns: column8:8(int) column1:5(int) column2:6(int) column3:7(int)
+      │    │    │    ├── columns: column8:8(int) column1:5(int!null) column2:6(int!null) column3:7(int!null)
       │    │    │    ├── values
-      │    │    │    │    ├── columns: column1:5(int) column2:6(int) column3:7(int)
+      │    │    │    │    ├── columns: column1:5(int!null) column2:6(int!null) column3:7(int!null)
       │    │    │    │    └── tuple [type=tuple{int, int, int}]
       │    │    │    │         ├── const: 1 [type=int]
       │    │    │    │         ├── const: 2 [type=int]
@@ -1448,19 +1448,19 @@ upsert mutation
  │    └──  upsert_p:18 => p:4
  ├── check columns: check1:19(bool)
  └── project
-      ├── columns: check1:19(bool) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int) upsert_m:16(int) upsert_o:17(int) upsert_p:18(int)
+      ├── columns: check1:19(bool) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int) upsert_m:16(int) upsert_o:17(int) upsert_p:18(int)
       ├── project
-      │    ├── columns: upsert_m:16(int) upsert_o:17(int) upsert_p:18(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int)
+      │    ├── columns: upsert_m:16(int) upsert_o:17(int) upsert_p:18(int) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int)
       │    ├── project
-      │    │    ├── columns: column15:15(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    │    ├── columns: column15:15(int) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
       │    │    ├── left-join
-      │    │    │    ├── columns: column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    │    │    ├── columns: column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
       │    │    │    ├── project
-      │    │    │    │    ├── columns: column9:9(int) column1:6(int) column2:7(int) column8:8(int!null)
+      │    │    │    │    ├── columns: column9:9(int) column1:6(int!null) column2:7(int!null) column8:8(int!null)
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column8:8(int!null) column1:6(int) column2:7(int)
+      │    │    │    │    │    ├── columns: column8:8(int!null) column1:6(int!null) column2:7(int!null)
       │    │    │    │    │    ├── values
-      │    │    │    │    │    │    ├── columns: column1:6(int) column2:7(int)
+      │    │    │    │    │    │    ├── columns: column1:6(int!null) column2:7(int!null)
       │    │    │    │    │    │    └── tuple [type=tuple{int, int}]
       │    │    │    │    │    │         ├── const: 1 [type=int]
       │    │    │    │    │    │         └── const: 2 [type=int]
@@ -1529,19 +1529,19 @@ upsert mutation
  │    └──  upsert_p:18 => p:4
  ├── check columns: check1:19(bool)
  └── project
-      ├── columns: check1:19(bool) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int) upsert_m:16(int) upsert_o:17(int) upsert_p:18(int)
+      ├── columns: check1:19(bool) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int) upsert_m:16(int) upsert_o:17(int) upsert_p:18(int)
       ├── project
-      │    ├── columns: upsert_m:16(int) upsert_o:17(int) upsert_p:18(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int)
+      │    ├── columns: upsert_m:16(int) upsert_o:17(int) upsert_p:18(int) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int)
       │    ├── project
-      │    │    ├── columns: column15:15(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    │    ├── columns: column15:15(int) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
       │    │    ├── left-join
-      │    │    │    ├── columns: column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    │    │    ├── columns: column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
       │    │    │    ├── project
-      │    │    │    │    ├── columns: column9:9(int) column1:6(int) column2:7(int) column8:8(int!null)
+      │    │    │    │    ├── columns: column9:9(int) column1:6(int!null) column2:7(int!null) column8:8(int!null)
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column8:8(int!null) column1:6(int) column2:7(int)
+      │    │    │    │    │    ├── columns: column8:8(int!null) column1:6(int!null) column2:7(int!null)
       │    │    │    │    │    ├── values
-      │    │    │    │    │    │    ├── columns: column1:6(int) column2:7(int)
+      │    │    │    │    │    │    ├── columns: column1:6(int!null) column2:7(int!null)
       │    │    │    │    │    │    └── tuple [type=tuple{int, int}]
       │    │    │    │    │    │         ├── const: 1 [type=int]
       │    │    │    │    │    │         └── const: 2 [type=int]
@@ -1620,21 +1620,21 @@ upsert checks
  │    └──  upsert_d:19 => d:4
  ├── check columns: check1:20(bool) check2:21(bool)
  └── project
-      ├── columns: check1:20(bool) check2:21(bool) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int) column13:13(int!null) column14:14(int!null) column15:15(int) upsert_a:16(int) upsert_b:17(int) upsert_c:18(int) upsert_d:19(int)
+      ├── columns: check1:20(bool) check2:21(bool) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int) column13:13(int!null) column14:14(int!null) column15:15(int) upsert_a:16(int) upsert_b:17(int) upsert_c:18(int) upsert_d:19(int)
       ├── project
-      │    ├── columns: upsert_a:16(int) upsert_b:17(int) upsert_c:18(int) upsert_d:19(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int) column13:13(int!null) column14:14(int!null) column15:15(int)
+      │    ├── columns: upsert_a:16(int) upsert_b:17(int) upsert_c:18(int) upsert_d:19(int) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int) column13:13(int!null) column14:14(int!null) column15:15(int)
       │    ├── project
-      │    │    ├── columns: column15:15(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int) column13:13(int!null) column14:14(int!null)
+      │    │    ├── columns: column15:15(int) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int) column13:13(int!null) column14:14(int!null)
       │    │    ├── project
-      │    │    │    ├── columns: column13:13(int!null) column14:14(int!null) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
+      │    │    │    ├── columns: column13:13(int!null) column14:14(int!null) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
       │    │    │    ├── left-join
-      │    │    │    │    ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
+      │    │    │    │    ├── columns: column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column8:8(int) column1:5(int) column2:6(int) column7:7(int)
+      │    │    │    │    │    ├── columns: column8:8(int) column1:5(int!null) column2:6(int!null) column7:7(int)
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: column7:7(int) column1:5(int) column2:6(int)
+      │    │    │    │    │    │    ├── columns: column7:7(int) column1:5(int!null) column2:6(int!null)
       │    │    │    │    │    │    ├── values
-      │    │    │    │    │    │    │    ├── columns: column1:5(int) column2:6(int)
+      │    │    │    │    │    │    │    ├── columns: column1:5(int!null) column2:6(int!null)
       │    │    │    │    │    │    │    └── tuple [type=tuple{int, int}]
       │    │    │    │    │    │    │         ├── const: 1 [type=int]
       │    │    │    │    │    │    │         └── const: 2 [type=int]
@@ -1712,19 +1712,19 @@ insert checks
  │    └──  column8:8 => d:4
  ├── check columns: check1:13(bool) check2:14(bool)
  └── project
-      ├── columns: check1:13(bool) check2:14(bool) column1:5(int) column2:6(int) column7:7(int) column8:8(int)
+      ├── columns: check1:13(bool) check2:14(bool) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int)
       ├── project
-      │    ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int)
+      │    ├── columns: column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int)
       │    └── select
-      │         ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
+      │         ├── columns: column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
       │         ├── left-join
-      │         │    ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
+      │         │    ├── columns: column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
       │         │    ├── project
-      │         │    │    ├── columns: column8:8(int) column1:5(int) column2:6(int) column7:7(int)
+      │         │    │    ├── columns: column8:8(int) column1:5(int!null) column2:6(int!null) column7:7(int)
       │         │    │    ├── project
-      │         │    │    │    ├── columns: column7:7(int) column1:5(int) column2:6(int)
+      │         │    │    │    ├── columns: column7:7(int) column1:5(int!null) column2:6(int!null)
       │         │    │    │    ├── values
-      │         │    │    │    │    ├── columns: column1:5(int) column2:6(int)
+      │         │    │    │    │    ├── columns: column1:5(int!null) column2:6(int!null)
       │         │    │    │    │    └── tuple [type=tuple{int, int}]
       │         │    │    │    │         ├── const: 1 [type=int]
       │         │    │    │    │         └── const: 2 [type=int]
@@ -1771,19 +1771,19 @@ upsert checks
  │    └──  upsert_d:16 => d:4
  ├── check columns: check1:17(bool) check2:18(bool)
  └── project
-      ├── columns: check1:17(bool) check2:18(bool) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int) column13:13(int) upsert_a:14(int) upsert_c:15(int) upsert_d:16(int)
+      ├── columns: check1:17(bool) check2:18(bool) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int) column13:13(int) upsert_a:14(int) upsert_c:15(int) upsert_d:16(int)
       ├── project
-      │    ├── columns: upsert_a:14(int) upsert_c:15(int) upsert_d:16(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int) column13:13(int)
+      │    ├── columns: upsert_a:14(int) upsert_c:15(int) upsert_d:16(int) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int) column13:13(int)
       │    ├── project
-      │    │    ├── columns: column13:13(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
+      │    │    ├── columns: column13:13(int) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
       │    │    ├── left-join
-      │    │    │    ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
+      │    │    │    ├── columns: column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
       │    │    │    ├── project
-      │    │    │    │    ├── columns: column8:8(int) column1:5(int) column2:6(int) column7:7(int)
+      │    │    │    │    ├── columns: column8:8(int) column1:5(int!null) column2:6(int!null) column7:7(int)
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column7:7(int) column1:5(int) column2:6(int)
+      │    │    │    │    │    ├── columns: column7:7(int) column1:5(int!null) column2:6(int!null)
       │    │    │    │    │    ├── values
-      │    │    │    │    │    │    ├── columns: column1:5(int) column2:6(int)
+      │    │    │    │    │    │    ├── columns: column1:5(int!null) column2:6(int!null)
       │    │    │    │    │    │    └── tuple [type=tuple{int, int}]
       │    │    │    │    │    │         ├── const: 1 [type=int]
       │    │    │    │    │    │         └── const: 2 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/values
+++ b/pkg/sql/opt/optbuilder/testdata/values
@@ -4,7 +4,7 @@ build
 VALUES (1)
 ----
 values
- ├── columns: column1:1(int)
+ ├── columns: column1:1(int!null)
  └── tuple [type=tuple{int}]
       └── const: 1 [type=int]
 
@@ -12,7 +12,7 @@ build
 VALUES (1, 2, 3), (4, 5, 6)
 ----
 values
- ├── columns: column1:1(int) column2:2(int) column3:3(int)
+ ├── columns: column1:1(int!null) column2:2(int!null) column3:3(int!null)
  ├── tuple [type=tuple{int, int, int}]
  │    ├── const: 1 [type=int]
  │    ├── const: 2 [type=int]
@@ -31,14 +31,14 @@ build
 VALUES (1), (1), (2), (3) ORDER BY 1 DESC LIMIT 3
 ----
 limit
- ├── columns: column1:1(int)
+ ├── columns: column1:1(int!null)
  ├── internal-ordering: -1
  ├── ordering: -1
  ├── sort
- │    ├── columns: column1:1(int)
+ │    ├── columns: column1:1(int!null)
  │    ├── ordering: -1
  │    └── values
- │         ├── columns: column1:1(int)
+ │         ├── columns: column1:1(int!null)
  │         ├── tuple [type=tuple{int}]
  │         │    └── const: 1 [type=int]
  │         ├── tuple [type=tuple{int}]
@@ -63,7 +63,7 @@ build
 VALUES ('one', 1, 1.0), ('two', 2, 2.0)
 ----
 values
- ├── columns: column1:1(string) column2:2(int) column3:3(decimal)
+ ├── columns: column1:1(string!null) column2:2(int!null) column3:3(decimal!null)
  ├── tuple [type=tuple{string, int, decimal}]
  │    ├── const: 'one' [type=string]
  │    ├── const: 1 [type=int]
@@ -77,7 +77,7 @@ build
 VALUES (true), (true), (false)
 ----
 values
- ├── columns: column1:1(bool)
+ ├── columns: column1:1(bool!null)
  ├── tuple [type=tuple{bool}]
  │    └── true [type=bool]
  ├── tuple [type=tuple{bool}]
@@ -97,7 +97,7 @@ build
 VALUES (NULL, 1)
 ----
 values
- ├── columns: column1:1(unknown) column2:2(int)
+ ├── columns: column1:1(unknown) column2:2(int!null)
  └── tuple [type=tuple{unknown, int}]
       ├── null [type=unknown]
       └── const: 1 [type=int]

--- a/pkg/sql/opt/optgen/exprgen/testdata/values
+++ b/pkg/sql/opt/optgen/exprgen/testdata/values
@@ -8,7 +8,7 @@ expr
 )
 ----
 values
- ├── columns: a:1(int) b:2(int)
+ ├── columns: a:1(int!null) b:2(int!null)
  ├── cardinality: [2 - 2]
  ├── stats: [rows=2]
  ├── cost: 0.03
@@ -31,7 +31,7 @@ expr
 )
 ----
 project
- ├── columns: y:2(int) x:1(int)
+ ├── columns: y:2(int) x:1(int!null)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
  ├── cost: 0.05
@@ -39,7 +39,7 @@ project
  ├── fd: ()-->(1,2)
  ├── prune: (1,2)
  ├── values
- │    ├── columns: x:1(int)
+ │    ├── columns: x:1(int!null)
  │    ├── cardinality: [1 - 1]
  │    ├── stats: [rows=1]
  │    ├── cost: 0.02

--- a/pkg/sql/opt/xform/testdata/coster/perturb-cost
+++ b/pkg/sql/opt/xform/testdata/coster/perturb-cost
@@ -59,7 +59,7 @@ opt perturb-cost=(0.9)
 SELECT 1
 ----
 values
- ├── columns: "?column?":1(int)
+ ├── columns: "?column?":1(int!null)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
  ├── cost: 0.02
@@ -71,7 +71,7 @@ opt perturb-cost=(2.5)
 SELECT 1
 ----
 values
- ├── columns: "?column?":1(int)
+ ├── columns: "?column?":1(int!null)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
  ├── cost: 0.02

--- a/pkg/sql/opt/xform/testdata/coster/sort
+++ b/pkg/sql/opt/xform/testdata/coster/sort
@@ -35,7 +35,7 @@ opt
 SELECT f FROM a WHERE k IN () ORDER BY f DESC
 ----
 values
- ├── columns: f:2(float)
+ ├── columns: f:2(float!null)
  ├── cardinality: [0 - 0]
  ├── stats: [rows=0]
  ├── cost: 0.01

--- a/pkg/sql/opt/xform/testdata/coster/values
+++ b/pkg/sql/opt/xform/testdata/coster/values
@@ -2,7 +2,7 @@ opt
 SELECT * FROM (VALUES (1, 2, 3), (4, 5, 6))
 ----
 values
- ├── columns: column1:1(int) column2:2(int) column3:3(int)
+ ├── columns: column1:1(int!null) column2:2(int!null) column3:3(int!null)
  ├── cardinality: [2 - 2]
  ├── stats: [rows=2]
  ├── cost: 0.03

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -833,22 +833,22 @@ insert check_test.public.alias_test
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project
-      ├── columns: check1:4(bool) check2:5(bool) check3:6(bool) column1:2(int)
+      ├── columns: check1:4(bool) check2:5(bool) check3:6(bool) column1:2(int!null)
       ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(2,4-6)
       ├── select
-      │    ├── columns: column1:2(int) a:3(int)
+      │    ├── columns: column1:2(int!null) a:3(int)
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    ├── fd: ()-->(2,3)
       │    ├── left-join
-      │    │    ├── columns: column1:2(int) a:3(int)
+      │    │    ├── columns: column1:2(int!null) a:3(int)
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(2,3)
       │    │    ├── values
-      │    │    │    ├── columns: column1:2(int)
+      │    │    │    ├── columns: column1:2(int!null)
       │    │    │    ├── cardinality: [1 - 1]
       │    │    │    ├── key: ()
       │    │    │    ├── fd: ()-->(2)


### PR DESCRIPTION
Improve the logical props builder to set not null columns on ValuesOp
for those columns that have only non-null constants. This will be
helpful with FK checks in common cases (NULLs in referencing FK
columns require special treatment which we can avoid if columns are
known to be not-nullable).

Release note: None