### PR TITLE
sql: fix scrub on tables with mixed case

### DIFF
--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -350,7 +350,7 @@ func tableColumnsIsNullPredicate(
 			buf.WriteString(conjunction)
 			buf.WriteByte(' ')
 		}
-		fmt.Fprintf(&buf, "%[1]s.%[2]s IS %[3]s", tableName, col, nullCheck)
+		fmt.Fprintf(&buf, "%[1]q.%[2]q IS %[3]s", tableName, col, nullCheck)
 	}
 	return buf.String()
 }
@@ -377,7 +377,7 @@ func tableColumnsEQ(
 		if i > 0 {
 			buf.WriteString(" AND ")
 		}
-		fmt.Fprintf(&buf, `%[1]s.%[3]s = %[2]s.%[4]s`,
+		fmt.Fprintf(&buf, `%[1]q.%[3]q = %[2]q.%[4]q`,
 			tableName, otherTableName, columns[i], otherColumns[i])
 	}
 	return buf.String()
@@ -395,7 +395,7 @@ func tableColumnsProjection(tableName string, columns []string) string {
 		if i > 0 {
 			buf.WriteString(", ")
 		}
-		fmt.Fprintf(&buf, "%[1]s.%[2]s", tableName, col)
+		fmt.Fprintf(&buf, "%[1]q.%[2]q", tableName, col)
 	}
 	return buf.String()
 }

--- a/pkg/sql/scrub_index.go
+++ b/pkg/sql/scrub_index.go
@@ -314,16 +314,17 @@ func createIndexCheckQuery(
 					ON %[6]s
 				WHERE (%[7]s) OR
 							(%[8]s)`
+	columnNamesList := fmt.Sprintf(`"%s"`, strings.Join(columnNames, `","`))
 	return fmt.Sprintf(checkIndexQuery,
 		tableColumnsProjection("leftside", columnNames),  // 1
 		tableColumnsProjection("rightside", columnNames), // 2
-		tableName.String(),             // 3
-		indexDesc.ID,                   // 4
-		strings.Join(columnNames, ","), // 5
+		tableName.String(), // 3
+		indexDesc.ID,       // 4
+		columnNamesList,    // 5
 		tableColumnsEQ("leftside", "rightside", columnNames, columnNames),                                      // 6
 		tableColumnsIsNullPredicate("leftside", tableDesc.PrimaryIndex.ColumnNames, "AND", true /* isNull */),  // 7
 		tableColumnsIsNullPredicate("rightside", tableDesc.PrimaryIndex.ColumnNames, "AND", true /* isNull */), // 8
-		strings.Join(columnNames, ","), // 9
-		asOfClauseStr,                  // 10
+		columnNamesList, // 9
+		asOfClauseStr,   // 10
 	)
 }

--- a/pkg/sql/scrub_test.go
+++ b/pkg/sql/scrub_test.go
@@ -43,18 +43,19 @@ func TestScrubIndexMissingIndexEntry(t *testing.T) {
 	defer s.Stopper().Stop(context.TODO())
 
 	// Create the table and the row entry.
+	// We use a table with mixed as a regression case for #38184.
 	if _, err := db.Exec(`
 CREATE DATABASE t;
-CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
-CREATE INDEX secondary ON t.test (v);
-INSERT INTO t.test VALUES (10, 20);
+CREATE TABLE t."tEst" ("K" INT PRIMARY KEY, v INT);
+CREATE INDEX secondary ON t."tEst" (v);
+INSERT INTO t."tEst" VALUES (10, 20);
 `); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
 	// Construct datums for our row values (k, v).
 	values := []tree.Datum{tree.NewDInt(10), tree.NewDInt(20)}
-	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
+	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "tEst")
 	secondaryIndex := &tableDesc.Indexes[0]
 
 	colIDtoRowIndex := make(map[sqlbase.ColumnID]int)
@@ -79,7 +80,7 @@ INSERT INTO t.test VALUES (10, 20);
 	}
 
 	// Run SCRUB and find the index errors we created.
-	rows, err := db.Query(`EXPERIMENTAL SCRUB TABLE t.test WITH OPTIONS INDEX ALL`)
+	rows, err := db.Query(`EXPERIMENTAL SCRUB TABLE t."tEst" WITH OPTIONS INDEX ALL`)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -97,8 +98,8 @@ INSERT INTO t.test VALUES (10, 20);
 			scrub.MissingIndexEntryError, result.ErrorType)
 	} else if result.Database != "t" {
 		t.Fatalf("expected database %q, got %q", "t", result.Database)
-	} else if result.Table != "test" {
-		t.Fatalf("expected table %q, got %q", "test", result.Table)
+	} else if result.Table != "tEst" {
+		t.Fatalf("expected table %q, got %q", "tEst", result.Table)
 	} else if result.PrimaryKey != "(10)" {
 		t.Fatalf("expected primaryKey %q, got %q", "(10)", result.PrimaryKey)
 	} else if result.Repaired {


### PR DESCRIPTION
There was insufficient quoting in the generated queries to prevent
issues with tables or columns with mixed case. This was causing issues
with the random syntax generator, which tends to produce the query
EXPERIMENTAL SCRUB DATABASE system, since the system database contains
tables with columns with mixed case.

Release note: None