### PR TITLE
stats: don't try to make stats for dropped tables

### DIFF
--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -309,7 +309,11 @@ func (r *Refresher) ensureAllTables(
 
 	// Use a historical read so as to disable txn contention resolution.
 	getAllTablesQuery := fmt.Sprintf(
-		`SELECT table_id FROM crdb_internal.tables AS OF SYSTEM TIME '-%s' WHERE schema_name = 'public'`,
+		`
+SELECT table_id FROM crdb_internal.tables AS OF SYSTEM TIME '-%s'
+WHERE schema_name = 'public'
+AND drop_time IS NULL
+`,
 		initialTableCollectionDelay)
 
 	rows, err := r.ex.Query(


### PR DESCRIPTION
Previously, statistics collection would schedule checks for all tables
at startup, including tables that have already been dropped. This was
harmless but polluted the logs and lease caches.

Now, statistics collection doesn't try to schedule checks for tables
that are known to have been dropped already.

Release note: None