### PR TITLE
sql: special case lowercase "utc" as alias to "UTC".

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -1378,3 +1378,11 @@ ORDER BY
 1 day                  12:00:00          2 days                  12:00:00          2 days                  4 days 05:36:31.701948          05:40:07.68
 1 mon                  15 days           2 mons                  15 days           2 mons                  4 mons 7 days 00:15:51.058425   7 days 02:03:50.4
 1 mon 2 days 04:00:00  16 days 02:00:00  2 mons 4 days 08:00:00  16 days 02:00:00  2 mons 4 days 08:00:00  4 mons 15 days 28:24:59.745978  7 days 14:20:47.04
+
+subtest tz_utc_normalization
+
+# This is a special case, pending resolution of #36864.
+query T
+SET timezone = 'utc'; SHOW timezone
+----
+UTC

--- a/pkg/util/timeutil/zoneinfo.go
+++ b/pkg/util/timeutil/zoneinfo.go
@@ -34,6 +34,11 @@ func LoadLocation(name string) (*time.Location, error) {
 	switch strings.ToLower(name) {
 	case "local", "default":
 		name = "UTC"
+	case "utc":
+		// TODO(knz): See #36864. This code is a crutch, and should be
+		// removed in favor of a cache of available locations with
+		// case-insensitive lookup.
+		name = "UTC"
 	}
 	l, err := time.LoadLocation(name)
 	if err != nil && strings.Contains(err.Error(), "zoneinfo.zip") {


### PR DESCRIPTION
Informs #36864.
Informs (and perhaps closes) #14988.

This patch is a crutch to support the special case of `"utc"` by
popular demand. For more details and guidance towards a better
solution, see issue #36864.

Release note (sql change): CockroachDB now supports the special case
`set timezone = 'utc'` as a special alias for `set timezone =
'UTC'`. The other time zone names are still case-sensitive as
previously, pending resolution of issue #36864.