### PR TITLE
cli/haproxy: default 'timeout check' to 5s

### DIFF
--- a/pkg/cli/haproxy.go
+++ b/pkg/cli/haproxy.go
@@ -242,6 +242,7 @@ defaults
     timeout connect     10s
     timeout client      1m
     timeout server      1m
+    timeout check       5s
     # TCP keep-alive on client side. Server already enables them.
     option              clitcpka
 


### PR DESCRIPTION
Fixes #31742.

The default for `timeout check` haproxy configuration (the amount of
time tolerated to receive a response from a check command) is,
reportedly (per #31742), lower than 3ms. A value this low is
admittedly too short for an overloaded server. This patch increases
it to 5s.

Release note (cli change): The example haproxy configuration produced
by `cockroach gen haproxy` now contains a default value for `timeout
check` of 5 seconds.