### PR TITLE
[dnm] tree: permit numeric constants to become strings

### DIFF
--- a/pkg/sql/sem/tree/overload_test.go
+++ b/pkg/sql/sem/tree/overload_test.go
@@ -247,7 +247,7 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 		{nil, []Expr{placeholder(0), intConst("1")}, []overloadImpl{binaryArrayIntFn}, unsupported, true},
 	}
 	for i, d := range testData {
-		t.Run(fmt.Sprintf("%v/%v", d.exprs, d.overloads), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%d-%v/%v", i, d.exprs, d.overloads), func(t *testing.T) {
 			ctx := MakeSemaContext()
 			if err := ctx.Placeholders.Init(2 /* numPlaceholders */, nil /* typeHints */); err != nil {
 				t.Fatal(err)

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -211,7 +211,7 @@ func TestTypeCheckError(t *testing.T) {
 		{`NOT 1`, `incompatible NOT argument type: int`},
 		{`lower()`, `unknown signature: lower()`},
 		{`lower(1, 2)`, `unknown signature: lower(int, int)`},
-		{`lower(1)`, `unknown signature: lower(int)`},
+		{`lower(1::int)`, `unknown signature: lower(int)`},
 		{`lower('FOO') OVER ()`, `OVER specified, but lower() is neither a window function nor an aggregate function`},
 		{`count(1) FILTER (WHERE 1) OVER ()`, `incompatible FILTER expression type: int`},
 		{`CASE 'one' WHEN 1 THEN 1 WHEN 'two' THEN 2 END`, `incompatible condition type`},


### PR DESCRIPTION
This commit adds the string and bytes types to the list of allowable
types that numeric constants can resolve to, so that situations like:

```
CREATE TABLE t (a STRING);
INSERT INTO t (a) VALUES (123);
```

can work. Note that this doesn't add any ambiguity, since numeric
constants can always become strings without loss of precision. Note also
that this doesn't add any "implicit casting" anywhere - it merely
permits user-entered numeric literals to become strings instead of
numeric types.

Release note (sql change): numeric literals are now automatically
coerced to strings when the context dictates it.