### PR TITLE
server: fix TestReportUsage

### DIFF
--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"io/ioutil"
 	"math/rand"
+	"net"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -454,7 +455,19 @@ func (s *Server) reportDiagnostics(ctx context.Context) {
 		return
 	}
 	addInfoToURL(ctx, reportingURL, s, report.Node)
-	res, err := http.Post(reportingURL.String(), "application/x-protobuf", bytes.NewReader(b))
+
+	const timeout = 3 * time.Second
+	client := &http.Client{
+		Transport: &http.Transport{
+			// Don't leak a goroutine on OSX (the TCP level timeout is probably
+			// much higher than on linux) when the connection fails in weird ways.
+			DialContext:       (&net.Dialer{Timeout: timeout}).DialContext,
+			DisableKeepAlives: true,
+		},
+		Timeout: timeout,
+	}
+
+	res, err := client.Post(reportingURL.String(), "application/x-protobuf", bytes.NewReader(b))
 	if err != nil {
 		if log.V(2) {
 			// This is probably going to be relatively common in production
@@ -464,9 +477,8 @@ func (s *Server) reportDiagnostics(ctx context.Context) {
 		return
 	}
 	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		b, err := ioutil.ReadAll(res.Body)
+	b, err = ioutil.ReadAll(res.Body)
+	if err != nil || res.StatusCode != http.StatusOK {
 		log.Warningf(ctx, "failed to report node usage metrics: status: %s, body: %s, "+
 			"error: %v", res.Status, b, err)
 	}


### PR DESCRIPTION
- Fixes a goroutine leak under darwin (when dialing
tcp://instance-data.ec2.internal:80 as we happen to try we end up with
TCP-level timeouts, and that apparently takes long on OSX unless we
override the default)

- Works around a gossip-related flake.

Fixes #38174.
Fixes #38176.

Release note: None