### PR TITLE
workload/tpcc: make initial data generation totally deterministic

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -10,17 +10,26 @@ package allccl
 
 import (
 	"context"
+	"encoding/binary"
+	"hash"
+	"hash/fnv"
+	"math"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/workloadccl"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/cockroach/pkg/workload/workloadsql"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -177,6 +186,106 @@ func TestConsistentSchema(t *testing.T) {
 					t.Errorf("schema mismatch for table %s: %s, %s", name, schema1, schema2)
 				}
 			}
+		})
+	}
+}
+
+func hashTableInitialData(
+	h hash.Hash, data workload.BatchedTuples, a *bufalloc.ByteAllocator,
+) error {
+	var scratch [8]byte
+	b := coldata.NewMemBatchWithSize(nil, 0)
+	for batchIdx := 0; batchIdx < data.NumBatches; batchIdx++ {
+		*a = (*a)[:0]
+		data.FillBatch(batchIdx, b, a)
+		for _, col := range b.ColVecs() {
+			switch col.Type() {
+			case types.Bool:
+				for _, x := range col.Bool()[:b.Length()] {
+					if x {
+						scratch[0] = 1
+					} else {
+						scratch[0] = 0
+					}
+					_, _ = h.Write(scratch[:1])
+				}
+			case types.Int64:
+				for _, x := range col.Int64()[:b.Length()] {
+					binary.LittleEndian.PutUint64(scratch[:8], uint64(x))
+					_, _ = h.Write(scratch[:8])
+				}
+			case types.Float64:
+				for _, x := range col.Float64()[:b.Length()] {
+					bits := math.Float64bits(x)
+					binary.LittleEndian.PutUint64(scratch[:8], bits)
+					_, _ = h.Write(scratch[:8])
+				}
+			case types.Bytes:
+				for _, x := range col.Bytes()[:b.Length()] {
+					_, _ = h.Write(x)
+				}
+			default:
+				return errors.Errorf(`unhandled type %s`, col.Type())
+			}
+		}
+	}
+	return nil
+}
+
+func TestDeterministicInitialData(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// There are other tests that run initial data generation under race, so we
+	// don't get anything from running this one under race as well.
+	if util.RaceEnabled {
+		t.Skip(`uninteresting under race`)
+	}
+
+	// Hardcode goldens for the fingerprint of the initial data of generators with
+	// default flags. This lets us opt in generators known to be deterministic and
+	// also protects against initialized-once global state (which tpcc did have at
+	// one point).
+	//
+	// TODO(dan): We're starting to accumulate these various lists, bigInitialData
+	// is another. Consider moving them to be properties on the workload.Meta.
+	fingerprintGoldens := map[string]uint64{
+		`bank`:       0x1603d103c14d0364,
+		`bulkingest`: 0xcf3e4028ac084aea,
+		`indexes`:    0xcbf29ce484222325,
+		`intro`:      0x81c6a8cfd9c3452a,
+		`json`:       0xcbf29ce484222325,
+		`ledger`:     0xebe27d872d980271,
+		`movr`:       0x4f19a54c7e779f9c,
+		`queue`:      0xcbf29ce484222325,
+		`rand`:       0xcbf29ce484222325,
+		`roachmart`:  0xda5e73423dbdb2d9,
+		`sqlsmith`:   0xcbf29ce484222325,
+		`startrek`:   0xa0249fbdf612734c,
+		`tpcc`:       0x15c89d37aef774ba,
+		`ycsb`:       0x85dd34d8c07fd808,
+	}
+
+	var a bufalloc.ByteAllocator
+	for _, meta := range workload.Registered() {
+		fingerprintGolden, ok := fingerprintGoldens[meta.Name]
+		if !ok {
+			// TODO(dan): It'd be nice to eventually require that all registered
+			// workloads are deterministic, but given that tpcc was a legitimate
+			// exception for a while (for performance reasons), it's not clear right
+			// now that we should be strict about this.
+			continue
+		}
+		t.Run(meta.Name, func(t *testing.T) {
+			if bigInitialData(meta) && testing.Short() {
+				t.Skipf(`%s involves a lot of data`, meta.Name)
+			}
+
+			h := fnv.New64()
+			tables := meta.New().Tables()
+			for _, table := range tables {
+				require.NoError(t, hashTableInitialData(h, table.InitialRows, &a))
+			}
+			require.Equal(t, fingerprintGolden, h.Sum64())
 		})
 	}
 }

--- a/pkg/workload/faker/address.go
+++ b/pkg/workload/faker/address.go
@@ -54,9 +54,9 @@ func (f *addressFaker) firstOrLastName(rng *rand.Rand) string {
 func secondaryAddress(rng *rand.Rand) string {
 	switch rng.Intn(2) {
 	case 0:
-		return fmt.Sprintf(`Apt. %d`, rand.Intn(100))
+		return fmt.Sprintf(`Apt. %d`, rng.Intn(100))
 	case 1:
-		return fmt.Sprintf(`Suite %d`, rand.Intn(100))
+		return fmt.Sprintf(`Suite %d`, rng.Intn(100))
 	}
 	panic(`unreachable`)
 }

--- a/pkg/workload/faker/faker.go
+++ b/pkg/workload/faker/faker.go
@@ -12,11 +12,7 @@
 
 package faker
 
-import (
-	"sort"
-
-	"golang.org/x/exp/rand"
-)
+import "golang.org/x/exp/rand"
 
 // This is a rough go port of https://github.com/joke2k/faker.
 
@@ -57,7 +53,6 @@ func makeWeightedEntries(entriesAndWeights ...interface{}) *weightedEntries {
 		we = append(we, weightedEntry{weight: w, entry: e})
 		totalWeight += w
 	}
-	sort.Slice(we, func(i, j int) bool { return we[i].weight < we[j].weight })
 	return &weightedEntries{entries: we, totalWeight: totalWeight}
 }
 

--- a/pkg/workload/faker/faker_test.go
+++ b/pkg/workload/faker/faker_test.go
@@ -24,27 +24,27 @@ func TestFaker(t *testing.T) {
 	f := NewFaker()
 
 	names := []string{
-		`Tony Johnson`,
-		`Jennifer Shaw`,
-		`Dr. Andrew Roberts`,
+		`Daniel Nixon`,
+		`Whitney Jimenez`,
+		`Brandon Carr`,
 	}
 	for i, name := range names {
 		assert.Equal(t, name, f.Name(rng), `testcase %d`, i)
 	}
 
 	streetAddresses := []string{
-		`87890 Coffey Via Apt. 51`,
-		`67941 Andrew Station Suite 21`,
-		`75031 Samuel Trail`,
+		`8339 Gary Burgs Apt. 6`,
+		`67941 Lawrence Station Suite 29`,
+		`29657 Ware Haven`,
 	}
 	for i, streetAddress := range streetAddresses {
 		assert.Equal(t, streetAddress, f.StreetAddress(rng), `testcase %d`, i)
 	}
 
 	wordsets := [][]string{
-		{`fly`},
-		{`until`, `figure`},
-		{`after`, `suddenly`, `heavy`},
+		{`until`},
+		{`figure`, `after`},
+		{`suddenly`, `heavy`, `time`},
 	}
 	for i, words := range wordsets {
 		assert.Equal(t, words, f.Words(rng, i+1), `testcase %d`, i)
@@ -52,11 +52,11 @@ func TestFaker(t *testing.T) {
 
 	sentences := [][]string{
 		{
-			`Back especially claim rather town human bag.`,
+			`Especially claim rather town.`,
 		},
 		{
-			`Follow play agreement develop.`,
-			`Mind deal great national yard various mouth.`,
+			`Bag other follow play agreement develop sing.`,
+			`Deal great national yard various mouth.`,
 		},
 		{
 			`During talk direction set clear direction.`,

--- a/pkg/workload/tpcc/generate.go
+++ b/pkg/workload/tpcc/generate.go
@@ -78,6 +78,7 @@ var itemColTypes = []types.T{
 func (w *tpcc) tpccItemInitialRowBatch(rowIdx int, cb coldata.Batch, a *bufalloc.ByteAllocator) {
 	l := w.localsPool.Get().(*generateLocals)
 	defer w.localsPool.Put(l)
+	l.rng.Seed(w.seed + uint64(rowIdx))
 
 	iID := rowIdx + 1
 
@@ -119,6 +120,7 @@ func (w *tpcc) tpccWarehouseInitialRowBatch(
 ) {
 	l := w.localsPool.Get().(*generateLocals)
 	defer w.localsPool.Put(l)
+	l.rng.Seed(w.seed + uint64(rowIdx))
 
 	wID := rowIdx // warehouse ids are 0-indexed. every other table is 1-indexed
 
@@ -174,6 +176,7 @@ var stockColTypes = []types.T{
 func (w *tpcc) tpccStockInitialRowBatch(rowIdx int, cb coldata.Batch, a *bufalloc.ByteAllocator) {
 	l := w.localsPool.Get().(*generateLocals)
 	defer w.localsPool.Put(l)
+	l.rng.Seed(w.seed + uint64(rowIdx))
 
 	sID := (rowIdx % numStockPerWarehouse) + 1
 	wID := (rowIdx / numStockPerWarehouse)
@@ -244,6 +247,7 @@ func (w *tpcc) tpccDistrictInitialRowBatch(
 ) {
 	l := w.localsPool.Get().(*generateLocals)
 	defer w.localsPool.Put(l)
+	l.rng.Seed(w.seed + uint64(rowIdx))
 
 	dID := (rowIdx % numDistrictsPerWarehouse) + 1
 	wID := (rowIdx / numDistrictsPerWarehouse)
@@ -313,6 +317,7 @@ func (w *tpcc) tpccCustomerInitialRowBatch(
 ) {
 	l := w.localsPool.Get().(*generateLocals)
 	defer w.localsPool.Put(l)
+	l.rng.Seed(w.seed + uint64(rowIdx))
 
 	cID := (rowIdx % numCustomersPerDistrict) + 1
 	dID := ((rowIdx / numCustomersPerDistrict) % numDistrictsPerWarehouse) + 1
@@ -331,7 +336,7 @@ func (w *tpcc) tpccCustomerInitialRowBatch(
 	if cID <= 1000 {
 		lastName = randCLastSyllables(cID-1, a)
 	} else {
-		lastName = randCLast(l.rng, a)
+		lastName = w.randCLast(l.rng, a)
 	}
 
 	cb.Reset(customerColTypes, 1)
@@ -407,6 +412,7 @@ var historyColTypes = []types.T{
 func (w *tpcc) tpccHistoryInitialRowBatch(rowIdx int, cb coldata.Batch, a *bufalloc.ByteAllocator) {
 	l := w.localsPool.Get().(*generateLocals)
 	defer w.localsPool.Put(l)
+	l.rng.Seed(w.seed + uint64(rowIdx))
 
 	// This used to be a V4 uuid made through the normal `uuid.MakeV4`
 	// constructor, but we 1) want them to be deterministic and 2) want these rows

--- a/pkg/workload/tpcc/new_order.go
+++ b/pkg/workload/tpcc/new_order.go
@@ -139,7 +139,7 @@ func (n *newOrder) run(ctx context.Context, wID int) (interface{}, error) {
 	d := newOrderData{
 		wID:    wID,
 		dID:    int(randInt(rng, 1, 10)),
-		cID:    randCustomerID(rng),
+		cID:    n.config.randCustomerID(rng),
 		oOlCnt: int(randInt(rng, 5, 15)),
 	}
 	d.items = make([]orderItem, d.oOlCnt)
@@ -174,7 +174,7 @@ func (n *newOrder) run(ctx context.Context, wID int) (interface{}, error) {
 		} else {
 			// Loop until we find a unique item ID.
 			for {
-				item.olIID = randItemID(rng)
+				item.olIID = n.config.randItemID(rng)
 				if _, ok := itemIDs[item.olIID]; !ok {
 					itemIDs[item.olIID] = struct{}{}
 					break

--- a/pkg/workload/tpcc/order_status.go
+++ b/pkg/workload/tpcc/order_status.go
@@ -136,10 +136,10 @@ func (o *orderStatus) run(ctx context.Context, wID int) (interface{}, error) {
 	// 2.6.1.2: The customer is randomly selected 60% of the time by last name
 	// and 40% by number.
 	if rng.Intn(100) < 60 {
-		d.cLast = string(randCLast(rng, &o.a))
+		d.cLast = string(o.config.randCLast(rng, &o.a))
 		atomic.AddUint64(&o.config.auditor.orderStatusByLastName, 1)
 	} else {
-		d.cID = randCustomerID(rng)
+		d.cID = o.config.randCustomerID(rng)
 	}
 
 	tx, err := o.mcp.Get().BeginEx(ctx, o.config.txOpts)

--- a/pkg/workload/tpcc/payment.go
+++ b/pkg/workload/tpcc/payment.go
@@ -190,10 +190,10 @@ func (p *payment) run(ctx context.Context, wID int) (interface{}, error) {
 	// 2.5.1.2: The customer is randomly selected 60% of the time by last name
 	// and 40% by number.
 	if rng.Intn(100) < 60 {
-		d.cLast = string(randCLast(rng, &p.a))
+		d.cLast = string(p.config.randCLast(rng, &p.a))
 		atomic.AddUint64(&p.config.auditor.paymentsByLastName, 1)
 	} else {
-		d.cID = randCustomerID(rng)
+		d.cID = p.config.randCustomerID(rng)
 	}
 
 	tx, err := p.mcp.Get().BeginEx(ctx, p.config.txOpts)

--- a/pkg/workload/tpcc/random.go
+++ b/pkg/workload/tpcc/random.go
@@ -14,7 +14,6 @@ package tpcc
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"golang.org/x/exp/rand"
 )
 
@@ -22,21 +21,11 @@ var cLastTokens = [...]string{
 	"BAR", "OUGHT", "ABLE", "PRI", "PRES",
 	"ESE", "ANTI", "CALLY", "ATION", "EING"}
 
-// cLoad is the value of C at load time. See 2.1.6.1.
-// It's used for the non-uniform random generator.
-var cLoad int
-
-// cCustomerID is the value of C for the customer id generator. 2.1.6.
-var cCustomerID int
-
-// cCustomerID is the value of C for the item id generator. 2.1.6.
-var cItemID int
-
-func init() {
-	rand.Seed(uint64(timeutil.Now().UnixNano()))
-	cLoad = rand.Intn(256)
-	cItemID = rand.Intn(1024)
-	cCustomerID = rand.Intn(8192)
+func (w *tpcc) initNonUniformRandomConstants() {
+	rng := rand.New(rand.NewSource(w.seed))
+	w.cLoad = rng.Intn(256)
+	w.cItemID = rng.Intn(1024)
+	w.cCustomerID = rng.Intn(8192)
 }
 
 func randStringFromAlphabet(
@@ -148,18 +137,18 @@ func randCLastSyllables(n int, a *bufalloc.ByteAllocator) []byte {
 }
 
 // See 4.3.2.3.
-func randCLast(rng *rand.Rand, a *bufalloc.ByteAllocator) []byte {
-	return randCLastSyllables(((rng.Intn(256)|rng.Intn(1000))+cLoad)%1000, a)
+func (w *tpcc) randCLast(rng *rand.Rand, a *bufalloc.ByteAllocator) []byte {
+	return randCLastSyllables(((rng.Intn(256)|rng.Intn(1000))+w.cLoad)%1000, a)
 }
 
 // Return a non-uniform random customer ID. See 2.1.6.
-func randCustomerID(rng *rand.Rand) int {
-	return ((rng.Intn(1024) | (rng.Intn(3000) + 1) + cCustomerID) % 3000) + 1
+func (w *tpcc) randCustomerID(rng *rand.Rand) int {
+	return ((rng.Intn(1024) | (rng.Intn(3000) + 1) + w.cCustomerID) % 3000) + 1
 }
 
 // Return a non-uniform random item ID. See 2.1.6.
-func randItemID(rng *rand.Rand) int {
-	return ((rng.Intn(8190) | (rng.Intn(100000) + 1) + cItemID) % 100000) + 1
+func (w *tpcc) randItemID(rng *rand.Rand) int {
+	return ((rng.Intn(8190) | (rng.Intn(100000) + 1) + w.cItemID) % 100000) + 1
 }
 
 // NOTE: The following are intentionally duplicated. They're a very hot path in

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -44,6 +44,11 @@ type tpcc struct {
 	nowString        []byte
 	numConns         int
 
+	// Used in non-uniform random data generation. cLoad is the value of C at load
+	// time. cCustomerID is the value of C for the customer id generator. cItemID
+	// is the value of C for the item id generator. See 2.1.6.
+	cLoad, cCustomerID, cItemID int
+
 	mix        string
 	doWaits    bool
 	workers    int
@@ -184,6 +189,8 @@ func (w *tpcc) Hooks() workload.Hooks {
 			if len(w.zoneCfg.zones) > 0 && (len(w.zoneCfg.zones) != w.partitions) {
 				return errors.Errorf(`--zones should have the sames length as --partitions.`)
 			}
+
+			w.initNonUniformRandomConstants()
 
 			if w.workers == 0 {
 				w.workers = w.activeWarehouses * numWorkersPerWarehouse


### PR DESCRIPTION
Ideally, each workload's initial data set would be totally deterministic
from the flags. We didn't do this originally for tpcc because random
number seeding was so expensive that it was showing up as a significant
cpu user in profiles. The golang.org/x/exp/rand package has much faster
seeding though, so get this property back.

Tiny slowdown in benchmarks, but at this point, initial data is nowhere
near the bottleneck for fixtures import. I'm totally okay with a 1-2%
hit for deterministic data.

    name                             old time/op    new time/op    delta
    InitialData/tpcc/warehouses=1-8     357ms ± 2%     361ms ± 2%  +1.19%  (p=0.000 n=25+25)

    name                             old speed      new speed      delta
    InitialData/tpcc/warehouses=1-8   309MB/s ± 2%   305MB/s ± 2%  -1.16%  (p=0.000 n=25+25)

    name                             old alloc/op   new alloc/op   delta
    InitialData/tpcc/warehouses=1-8     193kB ± 0%     193kB ± 0%    ~     (all equal)

    name                             old allocs/op  new allocs/op  delta
    InitialData/tpcc/warehouses=1-8       592 ± 0%       592 ± 0%    ~     (all equal)

Release note: None