### PR TITLE
workload/tpcc: pre-compute random data for initial data load strings

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -261,7 +261,7 @@ func TestDeterministicInitialData(t *testing.T) {
 		`roachmart`:  0xda5e73423dbdb2d9,
 		`sqlsmith`:   0xcbf29ce484222325,
 		`startrek`:   0xa0249fbdf612734c,
-		`tpcc`:       0x15c89d37aef774ba,
+		`tpcc`:       0xab32e4f5e899eb2f,
 		`ycsb`:       0x85dd34d8c07fd808,
 	}
 

--- a/pkg/workload/tpcc/random.go
+++ b/pkg/workload/tpcc/random.go
@@ -12,6 +12,7 @@ package tpcc
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
+	"github.com/cockroachdb/cockroach/pkg/workload/workloadimpl"
 	"golang.org/x/exp/rand"
 )
 
@@ -26,11 +27,27 @@ func (w *tpcc) initNonUniformRandomConstants() {
 	w.cCustomerID = rng.Intn(8192)
 }
 
+const precomputedLength = 10000
+const aCharsAlphabet = `abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890`
+const lettersAlphabet = `ABCDEFGHIJKLMNOPQRSTUVWXYZ`
+const numbersAlphabet = `1234567890`
+
+type tpccRand struct {
+	*rand.Rand
+
+	aChars, letters, numbers workloadimpl.PrecomputedRand
+}
+
+type aCharsOffset int
+type lettersOffset int
+type numbersOffset int
+
 func randStringFromAlphabet(
 	rng *rand.Rand,
 	a *bufalloc.ByteAllocator,
 	minLen, maxLen int,
-	randStringFn func(rand.Source, []byte),
+	pr workloadimpl.PrecomputedRand,
+	prOffset *int,
 ) []byte {
 	size := maxLen
 	if maxLen-minLen != 0 {
@@ -42,64 +59,73 @@ func randStringFromAlphabet(
 
 	var b []byte
 	*a, b = a.Alloc(size, 0 /* extraCap */)
-	// TODO(dan): According to the benchmark, it's faster to pass a
-	// *rand.PCGSource here than it is to pass a *rand.Rand. I tried doing the
-	// plumbing and didn't see a difference in BenchmarkInitTPCC, but I'm not
-	// convinced that I didn't mess something up.
-	//
-	// name                      old time/op    new time/op    delta
-	// RandStringFast/letters-8    86.2ns ± 2%    74.9ns ± 0%  -13.17%  (p=0.008 n=5+5)
-	// RandStringFast/numbers-8    86.8ns ± 7%    74.2ns ± 1%  -14.50%  (p=0.008 n=5+5)
-	// RandStringFast/aChars-8      101ns ± 2%      86ns ± 1%  -15.15%  (p=0.008 n=5+5)
-	//
-	// name                      old speed      new speed      delta
-	// RandStringFast/letters-8   302MB/s ± 2%   347MB/s ± 0%  +15.08%  (p=0.008 n=5+5)
-	// RandStringFast/numbers-8   300MB/s ± 7%   350MB/s ± 1%  +16.81%  (p=0.008 n=5+5)
-	// RandStringFast/aChars-8    256MB/s ± 2%   303MB/s ± 1%  +18.42%  (p=0.008 n=5+5)
-	randStringFn(rng, b)
+	*prOffset = pr.FillBytes(*prOffset, b)
 	return b
 }
 
-// randAString generates a random alphanumeric string of length between min and
-// max inclusive. See 4.3.2.2.
-func randAString(rng *rand.Rand, a *bufalloc.ByteAllocator, min, max int) []byte {
-	return randStringFromAlphabet(rng, a, min, max, randStringAChars)
+// randAStringInitialDataOnly generates a random alphanumeric string of length
+// between min and max inclusive. It uses a set of pregenerated random data,
+// which the spec allows only for initial data. See 4.3.2.2.
+//
+// For speed, this is done using precomputed random data, which is explicitly
+// allowed by the spec for initial data only. See 4.3.2.1.
+func randAStringInitialDataOnly(
+	rng *tpccRand, ao *aCharsOffset, a *bufalloc.ByteAllocator, min, max int,
+) []byte {
+	return randStringFromAlphabet(rng.Rand, a, min, max, rng.aChars, (*int)(ao))
 }
 
-// randOriginalString generates a random a-string[26..50] with 10% chance of
-// containing the string "ORIGINAL" somewhere in the middle of the string.
-// See 4.3.3.1.
-func randOriginalString(rng *rand.Rand, a *bufalloc.ByteAllocator) []byte {
-	if rng.Intn(9) == 0 {
-		l := int(randInt(rng, 26, 50))
-		off := int(randInt(rng, 0, l-8))
+// randNStringInitialDataOnly generates a random numeric string of length
+// between min and max inclusive. See 4.3.2.2.
+//
+// For speed, this is done using precomputed random data, which is explicitly
+// allowed by the spec for initial data only. See 4.3.2.1.
+func randNStringInitialDataOnly(
+	rng *tpccRand, no *numbersOffset, a *bufalloc.ByteAllocator, min, max int,
+) []byte {
+	return randStringFromAlphabet(rng.Rand, a, min, max, rng.numbers, (*int)(no))
+}
+
+// randStateInitialDataOnly produces a random US state. (spec just says 2
+// letters)
+//
+// For speed, this is done using precomputed random data, which is explicitly
+// allowed by the spec for initial data only. See 4.3.2.1.
+func randStateInitialDataOnly(rng *tpccRand, lo *lettersOffset, a *bufalloc.ByteAllocator) []byte {
+	return randStringFromAlphabet(rng.Rand, a, 2, 2, rng.letters, (*int)(lo))
+}
+
+// randOriginalStringInitialDataOnly generates a random a-string[26..50] with
+// 10% chance of containing the string "ORIGINAL" somewhere in the middle of the
+// string. See 4.3.3.1.
+//
+// For speed, this is done using precomputed random data, which is explicitly
+// allowed by the spec for initial data only. See 4.3.2.1.
+func randOriginalStringInitialDataOnly(
+	rng *tpccRand, ao *aCharsOffset, a *bufalloc.ByteAllocator,
+) []byte {
+	if rng.Rand.Intn(9) == 0 {
+		l := int(randInt(rng.Rand, 26, 50))
+		off := int(randInt(rng.Rand, 0, l-8))
 		var buf []byte
 		*a, buf = a.Alloc(l, 0 /* extraCap */)
-		copy(buf[:off], randAString(rng, a, off, off))
+		copy(buf[:off], randAStringInitialDataOnly(rng, ao, a, off, off))
 		copy(buf[off:off+8], originalString)
-		copy(buf[off+8:], randAString(rng, a, l-off-8, l-off-8))
+		copy(buf[off+8:], randAStringInitialDataOnly(rng, ao, a, l-off-8, l-off-8))
 		return buf
 	}
-	return randAString(rng, a, 26, 50)
-}
-
-// randNString generates a random numeric string of length between min and max
-// inclusive. See 4.3.2.2.
-func randNString(rng *rand.Rand, a *bufalloc.ByteAllocator, min, max int) []byte {
-	return randStringFromAlphabet(rng, a, min, max, randStringNumbers)
-}
-
-// randState produces a random US state. (spec just says 2 letters)
-func randState(rng *rand.Rand, a *bufalloc.ByteAllocator) []byte {
-	return randStringFromAlphabet(rng, a, 2, 2, randStringLetters)
+	return randAStringInitialDataOnly(rng, ao, a, 26, 50)
 }
 
 // randZip produces a random "zip code" - a 4-digit number plus the constant
 // "11111". See 4.3.2.7.
-func randZip(rng *rand.Rand, a *bufalloc.ByteAllocator) []byte {
+//
+// For speed, this is done using precomputed random data, which is explicitly
+// allowed by the spec for initial data only. See 4.3.2.1.
+func randZipInitialDataOnly(rng *tpccRand, no *numbersOffset, a *bufalloc.ByteAllocator) []byte {
 	var buf []byte
 	*a, buf = a.Alloc(9, 0 /* extraCap */)
-	copy(buf[:4], randNString(rng, a, 4, 4))
+	copy(buf[:4], randNStringInitialDataOnly(rng, no, a, 4, 4))
 	copy(buf[4:], `11111`)
 	return buf
 }
@@ -147,61 +173,4 @@ func (w *tpcc) randCustomerID(rng *rand.Rand) int {
 // Return a non-uniform random item ID. See 2.1.6.
 func (w *tpcc) randItemID(rng *rand.Rand) int {
 	return ((rng.Intn(8190) | (rng.Intn(100000) + 1) + w.cItemID) % 100000) + 1
-}
-
-// NOTE: The following are intentionally duplicated. They're a very hot path in
-// restoring a TPCC fixture and hardcoding alphabet, len(alphabet), and
-// charsPerRand seems to trigger some compiler optimizations that don't happen
-// if those things are params. Don't modify these without consulting
-// BenchmarkRandStringFast and BenchmarkInitTPCC.
-
-func randStringLetters(rng rand.Source, buf []byte) {
-	const letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-	const lettersLen = uint64(len(letters))
-	const lettersCharsPerRand = uint64(13) // floor(log(math.MaxUint64)/log(lettersLen))
-
-	var r, charsLeft uint64
-	for i := 0; i < len(buf); i++ {
-		if charsLeft == 0 {
-			r = rng.Uint64()
-			charsLeft = lettersCharsPerRand
-		}
-		buf[i] = letters[r%lettersLen]
-		r = r / lettersLen
-		charsLeft--
-	}
-}
-
-func randStringNumbers(rng rand.Source, buf []byte) {
-	const numbers = "1234567890"
-	const numbersLen = uint64(len(numbers))
-	const numbersCharsPerRand = uint64(19) // floor(log(math.MaxUint64)/log(numbersLen))
-
-	var r, charsLeft uint64
-	for i := 0; i < len(buf); i++ {
-		if charsLeft == 0 {
-			r = rng.Uint64()
-			charsLeft = numbersCharsPerRand
-		}
-		buf[i] = numbers[r%numbersLen]
-		r = r / numbersLen
-		charsLeft--
-	}
-}
-
-func randStringAChars(rng rand.Source, buf []byte) {
-	const aChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
-	const aCharsLen = uint64(len(aChars))
-	const aCharsCharsPerRand = uint64(10) // floor(log(math.MaxUint64)/log(aCharsLen))
-
-	var r, charsLeft uint64
-	for i := 0; i < len(buf); i++ {
-		if charsLeft == 0 {
-			r = rng.Uint64()
-			charsLeft = aCharsCharsPerRand
-		}
-		buf[i] = aChars[r%aCharsLen]
-		r = r / aCharsLen
-		charsLeft--
-	}
 }

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
+	"github.com/cockroachdb/cockroach/pkg/workload/workloadimpl"
 	"github.com/jackc/pgx"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
@@ -301,11 +302,22 @@ func (w *tpcc) Hooks() workload.Hooks {
 
 // Tables implements the Generator interface.
 func (w *tpcc) Tables() []workload.Table {
+	aCharsInit := workloadimpl.PrecomputedRandInit(rand.New(rand.NewSource(w.seed)), precomputedLength, aCharsAlphabet)
+	lettersInit := workloadimpl.PrecomputedRandInit(rand.New(rand.NewSource(w.seed)), precomputedLength, lettersAlphabet)
+	numbersInit := workloadimpl.PrecomputedRandInit(rand.New(rand.NewSource(w.seed)), precomputedLength, numbersAlphabet)
 	if w.localsPool == nil {
 		w.localsPool = &sync.Pool{
 			New: func() interface{} {
 				return &generateLocals{
-					rng: rand.New(rand.NewSource(uint64(timeutil.Now().UnixNano()))),
+					rng: tpccRand{
+						Rand: rand.New(rand.NewSource(uint64(timeutil.Now().UnixNano()))),
+						// Intentionally wait until here to initialize the precomputed rands
+						// so a caller of Tables that only wants schema doesn't compute
+						// them.
+						aChars:  aCharsInit(),
+						letters: lettersInit(),
+						numbers: numbersInit(),
+					},
 				}
 			},
 		}

--- a/pkg/workload/workloadimpl/doc.go
+++ b/pkg/workload/workloadimpl/doc.go
@@ -1,0 +1,13 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package workloadimpl provides dependency-light helpers for implementing
+// workload.Generators.
+package workloadimpl

--- a/pkg/workload/workloadimpl/precomputedrand.go
+++ b/pkg/workload/workloadimpl/precomputedrand.go
@@ -1,0 +1,61 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package workloadimpl
+
+import (
+	"sync"
+
+	"golang.org/x/exp/rand"
+)
+
+// PrecomputedRand is a precomputed sequence of random data in some alphabet.
+type PrecomputedRand []byte
+
+// PrecomputedRandInit returns a init function that lazily initializes and
+// returns a PrecomputedRand. This initialization work is done once and the
+// result is shared, subsequent calls to return this shared one. The init
+// function is concurrency safe.
+func PrecomputedRandInit(rng rand.Source, length int, alphabet string) func() PrecomputedRand {
+	var prOnce sync.Once
+	var pr PrecomputedRand
+	return func() PrecomputedRand {
+		prOnce.Do(func() {
+			pr = make(PrecomputedRand, length)
+			RandStringFast(rng, pr, alphabet)
+		})
+		return pr
+	}
+}
+
+// FillBytes fills the given buffer with precomputed random data, starting at
+// the given offset (which is like a seed) and returning a new offset to be used
+// on the next call. FillBytes is concurrency safe.
+func (pr PrecomputedRand) FillBytes(offset int, buf []byte) int {
+	if len(pr) == 0 {
+		panic(`cannot fill from empty precomputed rand`)
+	}
+	prIdx := offset
+	for bufIdx := 0; bufIdx < len(buf); {
+		if prIdx == len(pr) {
+			prIdx = 0
+		}
+		need, remaining := len(buf)-bufIdx, len(pr)-prIdx
+		copyLen := need
+		if copyLen > remaining {
+			copyLen = remaining
+		}
+		newBufIdx, newPRIdx := bufIdx+copyLen, prIdx+copyLen
+		copy(buf[bufIdx:newBufIdx], pr[prIdx:newPRIdx])
+		bufIdx = newBufIdx
+		prIdx = newPRIdx
+	}
+	return prIdx
+}

--- a/pkg/workload/workloadimpl/precomputedrand_test.go
+++ b/pkg/workload/workloadimpl/precomputedrand_test.go
@@ -1,0 +1,90 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package workloadimpl_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/workload/workloadimpl"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/rand"
+)
+
+const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func TestPrecomputedRand(t *testing.T) {
+	const precomputeLen = 100
+
+	seed0 := workloadimpl.PrecomputedRandInit(rand.NewSource(0), precomputeLen, alphabet)()
+	seed1 := workloadimpl.PrecomputedRandInit(rand.NewSource(1), precomputeLen, alphabet)()
+	numbers := workloadimpl.PrecomputedRandInit(rand.NewSource(0), precomputeLen, `0123456789`)()
+
+	const shorterThanPrecomputed, longerThanPrecomputed = precomputeLen / 10, precomputeLen + 7
+
+	offset := 0
+	fillBytes := func(pr workloadimpl.PrecomputedRand, length int) []byte {
+		buf := make([]byte, length)
+		offset = pr.FillBytes(offset, buf)
+		return buf
+	}
+
+	short0 := fillBytes(seed0, shorterThanPrecomputed)
+	long0 := fillBytes(seed0, longerThanPrecomputed)
+
+	// Offset has advanced, we should get a different result.
+	short0Different := fillBytes(seed0, shorterThanPrecomputed)
+	require.NotEqual(t, short0, short0Different)
+
+	// Reset the offset and verify that the results are repeatable
+	offset = 0
+	short0B := fillBytes(seed0, shorterThanPrecomputed)
+	long0B := fillBytes(seed0, longerThanPrecomputed)
+	require.Equal(t, short0, short0B)
+	require.Equal(t, long0, long0B)
+
+	// Reset the offset and verify that a different seed gets different results.
+	offset = 0
+	short1 := fillBytes(seed1, shorterThanPrecomputed)
+	long1 := fillBytes(seed1, longerThanPrecomputed)
+	require.NotEqual(t, short0, short1)
+	require.NotEqual(t, long0, long1)
+
+	// Reset the offset and verify that a different alphabet gets different
+	// results.
+	offset = 0
+	shortNumbers := fillBytes(numbers, shorterThanPrecomputed)
+	longNumbers := fillBytes(numbers, longerThanPrecomputed)
+	require.NotEqual(t, short0, shortNumbers)
+	require.NotEqual(t, long0, longNumbers)
+}
+
+func BenchmarkPrecomputedRand(b *testing.B) {
+	const precomputeLen = 10000
+	pr := workloadimpl.PrecomputedRandInit(
+		rand.NewSource(uint64(timeutil.Now().UnixNano())), precomputeLen, alphabet)()
+
+	const shortLen, mediumLen, longLen = 2, 100, 100000
+	scratch := make([]byte, longLen)
+	var randOffset int
+
+	for _, l := range []int{shortLen, mediumLen, longLen} {
+		b.Run(fmt.Sprintf(`len=%d`, l), func(b *testing.B) {
+			randOffset = 0
+			buf := scratch[:l]
+			for i := 0; i < b.N; i++ {
+				randOffset = pr.FillBytes(randOffset, buf)
+			}
+			b.SetBytes(int64(len(buf)))
+		})
+	}
+}

--- a/pkg/workload/workloadimpl/random.go
+++ b/pkg/workload/workloadimpl/random.go
@@ -1,0 +1,38 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package workloadimpl
+
+import (
+	"math"
+
+	"golang.org/x/exp/rand"
+)
+
+// RandStringFast is a non-specialized random string generator with an even
+// distribution of alphabet in the output.
+func RandStringFast(rng rand.Source, buf []byte, alphabet string) {
+	// We could pull these computations out to be done once per alphabet, but at
+	// that point, you likely should consider PrecomputedRand.
+	alphabetLen := uint64(len(alphabet))
+	// floor(log(math.MaxUint64)/log(alphabetLen))
+	lettersCharsPerRand := uint64(math.Log(float64(math.MaxUint64)) / math.Log(float64(alphabetLen)))
+
+	var r, charsLeft uint64
+	for i := 0; i < len(buf); i++ {
+		if charsLeft == 0 {
+			r = rng.Uint64()
+			charsLeft = lettersCharsPerRand
+		}
+		buf[i] = alphabet[r%alphabetLen]
+		r = r / alphabetLen
+		charsLeft--
+	}
+}

--- a/pkg/workload/workloadimpl/random_test.go
+++ b/pkg/workload/workloadimpl/random_test.go
@@ -8,12 +8,13 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package tpcc
+package workloadimpl_test
 
 import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/workload/workloadimpl"
 	"golang.org/x/exp/rand"
 )
 
@@ -22,22 +23,8 @@ func BenchmarkRandStringFast(b *testing.B) {
 	rng := rand.NewSource(uint64(timeutil.Now().UnixNano()))
 	buf := make([]byte, strLen)
 
-	b.Run(`letters`, func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			randStringLetters(rng, buf)
-		}
-		b.SetBytes(strLen)
-	})
-	b.Run(`numbers`, func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			randStringNumbers(rng, buf)
-		}
-		b.SetBytes(strLen)
-	})
-	b.Run(`aChars`, func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			randStringAChars(rng, buf)
-		}
-		b.SetBytes(strLen)
-	})
+	for i := 0; i < b.N; i++ {
+		workloadimpl.RandStringFast(rng, buf, `0123456789abcdefghijklmnopqrstuvwxyz`)
+	}
+	b.SetBytes(strLen)
 }


### PR DESCRIPTION
This is explictly allowed by the spec only for initial data load in
4.3.2.1:

For the purpose of populating the initial database only, random numbers
can be generated by selecting entries in sequence from a set of at least
10,000 pregenerated random numbers. This technique cannot be used for
the field O_OL_CNT.

    name                             old time/op    new time/op    delta
    InitialData/tpcc/warehouses=1-8     368ms ± 9%     229ms ± 1%  -37.77%  (p=0.000 n=15+15)

    name                             old speed      new speed      delta
    InitialData/tpcc/warehouses=1-8   299MB/s ± 9%   481MB/s ± 1%  +60.50%  (p=0.000 n=15+15)

    name                             old alloc/op   new alloc/op   delta
    InitialData/tpcc/warehouses=1-8     193kB ± 0%     126kB ± 0%  -34.80%  (p=0.000 n=14+14)

    name                             old allocs/op  new allocs/op  delta
    InitialData/tpcc/warehouses=1-8       592 ± 0%       458 ± 0%  -22.59%  (p=0.000 n=15+15)



Release note: None