### PR TITLE
storage/tscache: save 4 bytes per encoded tscache value

### DIFF
--- a/pkg/storage/tscache/interval_skl.go
+++ b/pkg/storage/tscache/interval_skl.go
@@ -91,7 +91,7 @@ const (
 )
 
 const (
-	encodedTsSize      = int(unsafe.Sizeof(hlc.Timestamp{}))
+	encodedTsSize      = int(unsafe.Sizeof(int64(0)) + unsafe.Sizeof(int32(0)))
 	encodedTxnIDSize   = int(unsafe.Sizeof(uuid.UUID{}))
 	encodedValSize     = encodedTsSize + encodedTxnIDSize
 	defaultMinSklPages = 2


### PR DESCRIPTION
`unsafe.Sizeof(hlc.Timestamp{})` was including XXX_sizecache, which was bloating
the struct size even though it didn't have an effect on the encoded size of the
timestamps, which we control in `encodeValue`.

Even once we remove `XXX_sizecache` (#37706), it looks like `unsafe.Sizeof` will
still include padding which we don't want to capture in the `encodedTsSize` constant,
so this seems like the best approach. See https://play.golang.org/p/5swJSSbP6J4.

Release note: None