### PR TITLE
exec: fix TestSortRandomized flakes

### DIFF
--- a/pkg/sql/exec/sort_test.go
+++ b/pkg/sql/exec/sort_test.go
@@ -156,6 +156,9 @@ func TestSortRandomized(t *testing.T) {
 							// Small range so we can test partitioning
 							tups[i][j] = rng.Int63() % 2048
 						}
+						// Enforce that the last ordering column is always unique. Otherwise
+						// there would be multiple valid sort orders.
+						tups[i][ordCols[nOrderingCols-1].ColIdx] = int64(i)
 					}
 
 					expected := make(tuples, nTups)


### PR DESCRIPTION
TestSortRandomized was failing under stress because sometimes it would
randomly generate duplicate sort keys, so there was more than one
correct result. I made the final sort column unique so this can't
happen.

Fixes #38113

Release note: None