### PR TITLE
cliccl: fix erroneous "experimental" help text

### DIFF
--- a/pkg/ccl/cliccl/cliflagsccl/flags.go
+++ b/pkg/ccl/cliccl/cliflagsccl/flags.go
@@ -15,14 +15,10 @@ var (
 	EnterpriseEncryption = cliflags.FlagInfo{
 		Name: "enterprise-encryption",
 		Description: `
-<PRE>
-*** Valid enterprise licenses only ***
+<PRE>Specify encryption options for one of the stores on a node. If multiple
+stores exist, the flag must be specified for each store.
 
-WARNING: encryption at rest is an experimental feature.
-
-Enable encryption at rest for a store.
-
-TODO(mberhault): fill in description.
+A valid enterprise license is required to use this functionality.
 
 </PRE>
 Key files must be of size 32 bytes + AES key size, such as:


### PR DESCRIPTION
Fixes outdated help text in `cockroach start --help` which had
erroneously indicated that Encryption at Rest is an experimental
feature.

Release note (enterprise change): Fixes help text that
erroneously labeled Encryption at Rest as experimental.