### PR TITLE
opt: add typed ColSet wrapper

### DIFF
--- a/pkg/sql/opt/colset.go
+++ b/pkg/sql/opt/colset.go
@@ -1,0 +1,89 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL.txt and at www.mariadb.com/bsl11.
+//
+// Change Date: 2022-10-01
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt and at
+// https://www.apache.org/licenses/LICENSE-2.0
+
+package opt
+
+import "github.com/cockroachdb/cockroach/pkg/util"
+
+// ColSet efficiently stores an unordered set of column ids.
+type ColSet struct {
+	set util.FastIntSet
+}
+
+// MakeColSet returns a set initialized with the given values.
+func MakeColSet(vals ...ColumnID) ColSet {
+	var res ColSet
+	for _, v := range vals {
+		res.Add(v)
+	}
+	return res
+}
+
+// Add adds a column to the set. No-op if the column is already in the set.
+func (s *ColSet) Add(col ColumnID) { s.set.Add(int(col)) }
+
+// Remove removes a column from the set. No-op if the column is not in the set.
+func (s *ColSet) Remove(col ColumnID) { s.set.Remove(int(col)) }
+
+// Contains returns true if the set contains the column.
+func (s ColSet) Contains(col ColumnID) bool { return s.set.Contains(int(col)) }
+
+// Empty returns true if the set is empty.
+func (s ColSet) Empty() bool { return s.set.Empty() }
+
+// Len returns the number of the columns in the set.
+func (s ColSet) Len() int { return s.set.Len() }
+
+// Next returns the first value in the set which is >= startVal. If there is no
+// such column, the second return value is false.
+func (s ColSet) Next(startVal ColumnID) (ColumnID, bool) {
+	c, ok := s.set.Next(int(startVal))
+	return ColumnID(c), ok
+}
+
+// ForEach calls a function for each column in the set (in increasing order).
+func (s ColSet) ForEach(f func(col ColumnID)) { s.set.ForEach(func(i int) { f(ColumnID(i)) }) }
+
+// Copy returns a copy of s which can be modified independently.
+func (s ColSet) Copy() ColSet { return ColSet{set: s.set.Copy()} }
+
+// UnionWith adds all the columns from rhs to this set.
+func (s *ColSet) UnionWith(rhs ColSet) { s.set.UnionWith(rhs.set) }
+
+// Union returns the union of s and rhs as a new set.
+func (s ColSet) Union(rhs ColSet) ColSet { return ColSet{set: s.set.Union(rhs.set)} }
+
+// IntersectionWith removes any columns not in rhs from this set.
+func (s *ColSet) IntersectionWith(rhs ColSet) { s.set.IntersectionWith(rhs.set) }
+
+// Intersection returns the intersection of s and rhs as a new set.
+func (s ColSet) Intersection(rhs ColSet) ColSet { return ColSet{set: s.set.Intersection(rhs.set)} }
+
+// DifferenceWith removes any elements in rhs from this set.
+func (s *ColSet) DifferenceWith(rhs ColSet) { s.set.DifferenceWith(rhs.set) }
+
+// Difference returns the elements of s that are not in rhs as a new set.
+func (s ColSet) Difference(rhs ColSet) ColSet { return ColSet{set: s.set.Difference(rhs.set)} }
+
+// Intersects returns true if s has any elements in common with rhs.
+func (s ColSet) Intersects(rhs ColSet) bool { return s.set.Intersects(rhs.set) }
+
+// Equals returns true if the two sets are identical.
+func (s ColSet) Equals(rhs ColSet) bool { return s.set.Equals(rhs.set) }
+
+// SubsetOf returns true if rhs contains all the elements in s.
+func (s ColSet) SubsetOf(rhs ColSet) bool { return s.set.SubsetOf(rhs.set) }
+
+// String returns a list representation of elements. Sequential runs of positive
+// numbers are shown as ranges. For example, for the set {1, 2, 3  5, 6, 10},
+// the output is "(1-3,5,6,10)".
+func (s ColSet) String() string { return s.set.String() }

--- a/pkg/sql/opt/colset_test.go
+++ b/pkg/sql/opt/colset_test.go
@@ -1,0 +1,41 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL.txt and at www.mariadb.com/bsl11.
+//
+// Change Date: 2022-10-01
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt and at
+// https://www.apache.org/licenses/LICENSE-2.0
+
+package opt
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
+
+func BenchmarkColSet(b *testing.B) {
+	// Verify that the wrapper doesn't add overhead (as was the case with earlier
+	// go versions which couldn't do mid-stack inlining).
+	const n = 50
+	b.Run("fastintset", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			var c util.FastIntSet
+			for j := 0; j < n; j++ {
+				c.Add(j)
+			}
+		}
+	})
+	b.Run("colset", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			var c ColSet
+			for j := 0; j < n; j++ {
+				c.Add(ColumnID(j))
+			}
+		}
+	})
+}

--- a/pkg/sql/opt/column_meta.go
+++ b/pkg/sql/opt/column_meta.go
@@ -28,9 +28,6 @@ func (c ColumnID) index() int {
 	return int(c - 1)
 }
 
-// ColSet efficiently stores an unordered set of column ids.
-type ColSet = util.FastIntSet
-
 // ColList is a list of column ids.
 //
 // TODO(radu): perhaps implement a FastIntList with the same "small"
@@ -62,7 +59,7 @@ type ColumnMeta struct {
 func (cl ColList) ToSet() ColSet {
 	var r ColSet
 	for _, col := range cl {
-		r.Add(int(col))
+		r.Add(col)
 	}
 	return r
 }
@@ -95,8 +92,8 @@ func (cl ColList) Equals(other ColList) bool {
 // ColSetToList converts a column id set to a list, in column id order.
 func ColSetToList(set ColSet) ColList {
 	res := make(ColList, 0, set.Len())
-	set.ForEach(func(x int) {
-		res = append(res, ColumnID(x))
+	set.ForEach(func(x ColumnID) {
+		res = append(res, x)
 	})
 	return res
 }

--- a/pkg/sql/opt/constraint/columns.go
+++ b/pkg/sql/opt/constraint/columns.go
@@ -116,9 +116,9 @@ func (c *Columns) IsStrictSuffixOf(other *Columns) bool {
 // ColSet returns the columns as a ColSet.
 func (c *Columns) ColSet() opt.ColSet {
 	var r opt.ColSet
-	r.Add(int(c.firstCol.ID()))
+	r.Add(c.firstCol.ID())
 	for _, c := range c.otherCols {
-		r.Add(int(c.ID()))
+		r.Add(c.ID())
 	}
 	return r
 }

--- a/pkg/sql/opt/constraint/constraint.go
+++ b/pkg/sql/opt/constraint/constraint.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 // Constraint specifies the possible set of values that one or more columns
@@ -502,7 +501,7 @@ func (c *Constraint) ExtractConstCols(evalCtx *tree.EvalContext) opt.ColSet {
 	var res opt.ColSet
 	pre := c.ExactPrefix(evalCtx)
 	for i := 0; i < pre; i++ {
-		res.Add(int(c.Columns.Get(i).ID()))
+		res.Add(c.Columns.Get(i).ID())
 	}
 	return res
 }
@@ -536,7 +535,7 @@ func (c *Constraint) ExtractNotNullCols(evalCtx *tree.EvalContext) opt.ColSet {
 			hasNull = hasNull || start.Value(i) == tree.DNull
 		}
 		if !hasNull {
-			res.Add(int(c.Columns.Get(i).ID()))
+			res.Add(c.Columns.Get(i).ID())
 		}
 	}
 	if prefix == c.Columns.Count() {
@@ -561,7 +560,7 @@ func (c *Constraint) ExtractNotNullCols(evalCtx *tree.EvalContext) opt.ColSet {
 		}
 	}
 	// All spans constrain col to be not-null.
-	res.Add(int(col.ID()))
+	res.Add(col.ID())
 	return res
 }
 
@@ -579,7 +578,7 @@ func (c *Constraint) ExtractNotNullCols(evalCtx *tree.EvalContext) opt.ColSet {
 // planner and optimizer need this logic, due to the heuristic planner planning
 // mutations. Once the optimizer plans mutations, this method can go away.
 func (c *Constraint) CalculateMaxResults(
-	evalCtx *tree.EvalContext, indexCols util.FastIntSet, notNullCols util.FastIntSet,
+	evalCtx *tree.EvalContext, indexCols opt.ColSet, notNullCols opt.ColSet,
 ) uint64 {
 	// Ensure that if we have nullable columns, we are only reading non-null
 	// values, given that a unique index allows an arbitrary number of duplicate

--- a/pkg/sql/opt/constraint/constraint_set_test.go
+++ b/pkg/sql/opt/constraint/constraint_set_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 func TestConstraintSetIntersect(t *testing.T) {
@@ -231,7 +230,7 @@ func TestExtractCols(t *testing.T) {
 		expected    opt.ColSet
 	}
 
-	cols := util.MakeFastIntSet
+	cols := opt.MakeColSet
 
 	cases := []testCase{
 		{
@@ -278,7 +277,7 @@ func TestExtractConstCols(t *testing.T) {
 		expected    opt.ColSet
 	}
 
-	cols := util.MakeFastIntSet
+	cols := opt.MakeColSet
 
 	cases := []testCase{
 		{[]string{`/1: [/10 - /10]`}, cols(1)},

--- a/pkg/sql/opt/constraint/constraint_test.go
+++ b/pkg/sql/opt/constraint/constraint_test.go
@@ -17,8 +17,8 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
@@ -459,67 +459,67 @@ func TestExtractNotNullCols(t *testing.T) {
 
 	testData := []struct {
 		c string
-		e []int
+		e []opt.ColumnID
 	}{
 		{ // 0
 			c: "/1: [/2 - ]",
-			e: []int{1},
+			e: []opt.ColumnID{1},
 		},
 		{ // 1
 			c: "/1: [ - /2]",
-			e: []int{},
+			e: []opt.ColumnID{},
 		},
 		{ // 2
 			c: "/1: [/NULL - /4]",
-			e: []int{},
+			e: []opt.ColumnID{},
 		},
 		{ // 3
 			c: "/1: (/NULL - /4]",
-			e: []int{1},
+			e: []opt.ColumnID{1},
 		},
 		{ // 4
 			c: "/-1: [ - /2]",
-			e: []int{1},
+			e: []opt.ColumnID{1},
 		},
 		{ // 5
 			c: "/-1: [/2 - ]",
-			e: []int{},
+			e: []opt.ColumnID{},
 		},
 		{ // 6
 			c: "/-1: [/4 - /NULL]",
-			e: []int{},
+			e: []opt.ColumnID{},
 		},
 		{ // 7
 			c: "/-1: [/4 - /NULL)",
-			e: []int{1},
+			e: []opt.ColumnID{1},
 		},
 		{ // 8
 			c: "/1/2/3: [/1/1/1 - /1/1/2] [/3/3/3 - /3/3/4]",
-			e: []int{1, 2, 3},
+			e: []opt.ColumnID{1, 2, 3},
 		},
 		{ // 9
 			c: "/1/2/3/4: [/1/1/1/1 - /1/1/2/1] [/3/3/3/1 - /3/3/4/1]",
-			e: []int{1, 2, 3},
+			e: []opt.ColumnID{1, 2, 3},
 		},
 		{ // 10
 			c: "/1/2/3: [/1/1 - /1/1/2] [/3/3/3 - /3/3/4]",
-			e: []int{1, 2},
+			e: []opt.ColumnID{1, 2},
 		},
 		{ // 11
 			c: "/1/-2/-3: [/1/1/2 - /1/1] [/3/3/4 - /3/3/3]",
-			e: []int{1, 2},
+			e: []opt.ColumnID{1, 2},
 		},
 		{ // 12
 			c: "/1/2/3: [/1/1/1 - /1/1/2] [/3/3/3 - /3/3/4] [/4/4/1 - /5]",
-			e: []int{1},
+			e: []opt.ColumnID{1},
 		},
 		{ // 13
 			c: "/1/2/3: [/1/1/NULL - /1/1/2] [/3/3/3 - /3/3/4]",
-			e: []int{1, 2},
+			e: []opt.ColumnID{1, 2},
 		},
 		{ // 13
 			c: "/1/2/3: [/1/1/1 - /1/1/1] [/2/NULL/2 - /2/NULL/3]",
-			e: []int{1, 3},
+			e: []opt.ColumnID{1, 3},
 		},
 	}
 
@@ -527,7 +527,7 @@ func TestExtractNotNullCols(t *testing.T) {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			c := ParseConstraint(&evalCtx, tc.c)
 			cols := c.ExtractNotNullCols(&evalCtx)
-			if exp := util.MakeFastIntSet(tc.e...); !cols.Equals(exp) {
+			if exp := opt.MakeColSet(tc.e...); !cols.Equals(exp) {
 				t.Errorf("expected %s; got %s", exp, cols)
 			}
 		})

--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -1211,7 +1211,7 @@ func (c *indexConstraintCtx) isIndexColumn(nd opt.Expr, offset int) bool {
 
 // isNullable returns true if the index column <offset> is nullable.
 func (c *indexConstraintCtx) isNullable(offset int) bool {
-	return !c.notNullCols.Contains(int(c.columns[offset].ID()))
+	return !c.notNullCols.Contains(c.columns[offset].ID())
 }
 
 // colType returns the type of the index column <offset>.

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -309,7 +309,7 @@ func parseIndexColumns(
 				if len(fields) < 2 || strings.ToLower(fields[1]) != "null" {
 					tb.Fatalf("unknown column attribute %s", fields)
 				}
-				notNullCols.Add(id)
+				notNullCols.Add(opt.ColumnID(id))
 				fields = fields[2:]
 			default:
 				tb.Fatalf("unknown column attribute %s", fields)

--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -78,7 +78,7 @@ func (m *Memo) checkExpr(e opt.Expr) {
 			}
 
 			// Check that column is not both passthrough and synthesized.
-			if t.Passthrough.Contains(int(item.Col)) {
+			if t.Passthrough.Contains(item.Col) {
 				panic(pgerror.AssertionFailedf("both passthrough and synthesized have column %d", log.Safe(item.Col)))
 			}
 
@@ -235,7 +235,7 @@ func (m *Memo) checkMutationExpr(rel RelExpr, private *MutationPrivate) {
 	tab := m.Metadata().Table(private.Table)
 	var mutCols opt.ColSet
 	for i, n := tab.ColumnCount(), tab.DeletableColumnCount(); i < n; i++ {
-		mutCols.Add(int(private.Table.ColumnID(i)))
+		mutCols.Add(private.Table.ColumnID(i))
 	}
 	if rel.Relational().OutputCols.Intersects(mutCols) {
 		panic(pgerror.AssertionFailedf("output columns cannot include mutation columns"))

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -226,7 +226,7 @@ func (n *FiltersExpr) RetainCommonFilters(other FiltersExpr) {
 func (n AggregationsExpr) OutputCols() opt.ColSet {
 	var colSet opt.ColSet
 	for i := range n {
-		colSet.Add(int(n[i].Col))
+		colSet.Add(n[i].Col)
 	}
 	return colSet
 }
@@ -246,7 +246,7 @@ func (n ZipExpr) OutputCols() opt.ColSet {
 	var colSet opt.ColSet
 	for i := range n {
 		for _, col := range n[i].Cols {
-			colSet.Add(int(col))
+			colSet.Add(col)
 		}
 	}
 	return colSet
@@ -381,12 +381,12 @@ func (m *MutationPrivate) MapToInputID(tabColID opt.ColumnID) opt.ColumnID {
 // input columns using the MapToInputID function.
 func (m *MutationPrivate) MapToInputCols(tabCols opt.ColSet) opt.ColSet {
 	var inCols opt.ColSet
-	tabCols.ForEach(func(t int) {
-		id := m.MapToInputID(opt.ColumnID(t))
+	tabCols.ForEach(func(t opt.ColumnID) {
+		id := m.MapToInputID(t)
 		if id == 0 {
 			panic(pgerror.AssertionFailedf("could not find input column for %d", log.Safe(t)))
 		}
-		inCols.Add(int(id))
+		inCols.Add(id)
 	})
 	return inCols
 }
@@ -417,7 +417,7 @@ func (m *MutationPrivate) AddEquivTableCols(md *opt.Metadata, fdset *props.FuncD
 func ExprIsNeverNull(e opt.ScalarExpr, notNullCols opt.ColSet) bool {
 	switch t := e.(type) {
 	case *VariableExpr:
-		return notNullCols.Contains(int(t.Col))
+		return notNullCols.Contains(t.Col)
 
 	case *TrueExpr, *FalseExpr, *ConstExpr, *IsExpr, *IsNotExpr:
 		return true

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -218,8 +218,8 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		}
 
 		// Add pass-through columns.
-		t.Passthrough.ForEach(func(i int) {
-			colList = append(colList, opt.ColumnID(i))
+		t.Passthrough.ForEach(func(i opt.ColumnID) {
+			colList = append(colList, i)
 		})
 
 	case *ValuesExpr:
@@ -700,13 +700,13 @@ func (f *ExprFmtCtx) formatColumns(
 	f.Buffer.Reset()
 	f.Buffer.WriteString("columns:")
 	for _, col := range presentation {
-		hidden.Remove(int(col.ID))
+		hidden.Remove(col.ID)
 		formatCol(f, col.Alias, col.ID, notNullCols, false /* omitType */)
 	}
 	if !hidden.Empty() {
 		f.Buffer.WriteString("  [hidden:")
 		for _, col := range cols {
-			if hidden.Contains(int(col)) {
+			if hidden.Contains(col) {
 				formatCol(f, "" /* label */, col, notNullCols, false /* omitType */)
 			}
 		}
@@ -794,7 +794,7 @@ func formatCol(
 		f.Buffer.WriteByte('(')
 		f.Buffer.WriteString(colMeta.Type.String())
 
-		if notNullCols.Contains(int(id)) {
+		if notNullCols.Contains(id) {
 			f.Buffer.WriteString("!null")
 		}
 		f.Buffer.WriteByte(')')

--- a/pkg/sql/opt/memo/expr_test.go
+++ b/pkg/sql/opt/memo/expr_test.go
@@ -77,7 +77,7 @@ func TestExprIsNeverNull(t *testing.T) {
 						for i := 0; i < len(vals); i++ {
 							if strings.HasSuffix(strings.ToLower(vals[i]), "!null") {
 								vals[i] = strings.TrimSuffix(strings.ToLower(vals[i]), "!null")
-								notNullCols.Add(i + 1)
+								notNullCols.Add(opt.ColumnID(i + 1))
 							}
 						}
 						varTypes, err = exprgen.ParseTypes(vals)

--- a/pkg/sql/opt/memo/extract.go
+++ b/pkg/sql/opt/memo/extract.go
@@ -122,14 +122,14 @@ func ExtractAggInputColumns(e opt.ScalarExpr) opt.ColSet {
 	arg := e.Child(0)
 	var res opt.ColSet
 	if filter, ok := arg.(*AggFilterExpr); ok {
-		res.Add(int(filter.Filter.(*VariableExpr).Col))
+		res.Add(filter.Filter.(*VariableExpr).Col)
 		arg = filter.Input
 	}
 	if distinct, ok := arg.(*AggDistinctExpr); ok {
 		arg = distinct.Input
 	}
 	if variable, ok := arg.(*VariableExpr); ok {
-		res.Add(int(variable.Col))
+		res.Add(variable.Col)
 		return res
 	}
 	panic(pgerror.AssertionFailedf("unhandled aggregate input %T", log.Safe(arg)))
@@ -204,10 +204,10 @@ func isJoinEquality(
 		return false, 0, 0
 	}
 
-	if leftCols.Contains(int(lvar.Col)) && rightCols.Contains(int(rvar.Col)) {
+	if leftCols.Contains(lvar.Col) && rightCols.Contains(rvar.Col) {
 		return true, lvar.Col, rvar.Col
 	}
-	if leftCols.Contains(int(rvar.Col)) && rightCols.Contains(int(lvar.Col)) {
+	if leftCols.Contains(rvar.Col) && rightCols.Contains(lvar.Col) {
 		return true, rvar.Col, lvar.Col
 	}
 
@@ -276,7 +276,7 @@ func ExtractValuesFromFilter(on FiltersExpr, cols opt.ColSet) map[opt.ColumnID]t
 
 // extractConstEquality extracts a column that's being equated to a constant
 // value if possible.
-func extractConstEquality(condition opt.ScalarExpr) (bool, int, tree.Datum) {
+func extractConstEquality(condition opt.ScalarExpr) (bool, opt.ColumnID, tree.Datum) {
 	// TODO(justin): this is error-prone because this logic is different from the
 	// constraint logic. Extract these values directly from the constraints.
 	switch condition.(type) {
@@ -285,7 +285,7 @@ func extractConstEquality(condition opt.ScalarExpr) (bool, int, tree.Datum) {
 		// due to the CommuteVar norm rule.
 		if leftVar, ok := condition.Child(0).(*VariableExpr); ok {
 			if CanExtractConstDatum(condition.Child(1)) {
-				return true, int(leftVar.Col), ExtractConstDatum(condition.Child(1))
+				return true, leftVar.Col, ExtractConstDatum(condition.Child(1))
 			}
 		}
 	}

--- a/pkg/sql/opt/memo/interner_test.go
+++ b/pkg/sql/opt/memo/interner_test.go
@@ -295,9 +295,9 @@ func TestInterner(t *testing.T) {
 		}},
 
 		{hashFn: in.hasher.HashColSet, eqFn: in.hasher.IsColSetEqual, variations: []testVariation{
-			{val1: util.MakeFastIntSet(), val2: util.MakeFastIntSet(), equal: true},
-			{val1: util.MakeFastIntSet(1, 2, 3), val2: util.MakeFastIntSet(3, 2, 1), equal: true},
-			{val1: util.MakeFastIntSet(1, 2, 3), val2: util.MakeFastIntSet(1, 2), equal: false},
+			{val1: opt.MakeColSet(), val2: opt.MakeColSet(), equal: true},
+			{val1: opt.MakeColSet(1, 2, 3), val2: opt.MakeColSet(3, 2, 1), equal: true},
+			{val1: opt.MakeColSet(1, 2, 3), val2: opt.MakeColSet(1, 2), equal: false},
 		}},
 
 		{hashFn: in.hasher.HashColList, eqFn: in.hasher.IsColListEqual, variations: []testVariation{

--- a/pkg/sql/opt/memo/statistics_builder_test.go
+++ b/pkg/sql/opt/memo/statistics_builder_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 // Most of the functionality in statistics.go is tested by the data-driven
@@ -101,7 +100,7 @@ func TestGetStatsFromConstraint(t *testing.T) {
 
 		var cols opt.ColSet
 		for i := 0; i < tab.ColumnCount(); i++ {
-			cols.Add(int(tabID.ColumnID(i)))
+			cols.Add(tabID.ColumnID(i))
 		}
 
 		sb := &statisticsBuilder{}
@@ -258,21 +257,21 @@ func TestTranslateColSet(t *testing.T) {
 		}
 	}
 
-	colSetIn, from, to := util.MakeFastIntSet(1, 2, 3), opt.ColList{1, 2, 3}, opt.ColList{4, 5, 6}
-	test(t, colSetIn, from, to, util.MakeFastIntSet(4, 5, 6))
+	colSetIn, from, to := opt.MakeColSet(1, 2, 3), opt.ColList{1, 2, 3}, opt.ColList{4, 5, 6}
+	test(t, colSetIn, from, to, opt.MakeColSet(4, 5, 6))
 
-	colSetIn, from, to = util.MakeFastIntSet(2, 3), opt.ColList{1, 2, 3}, opt.ColList{4, 5, 6}
-	test(t, colSetIn, from, to, util.MakeFastIntSet(5, 6))
+	colSetIn, from, to = opt.MakeColSet(2, 3), opt.ColList{1, 2, 3}, opt.ColList{4, 5, 6}
+	test(t, colSetIn, from, to, opt.MakeColSet(5, 6))
 
 	// colSetIn and colSetOut might not be the same length.
-	colSetIn, from, to = util.MakeFastIntSet(1, 2), opt.ColList{1, 1, 2}, opt.ColList{4, 5, 6}
-	test(t, colSetIn, from, to, util.MakeFastIntSet(4, 5, 6))
+	colSetIn, from, to = opt.MakeColSet(1, 2), opt.ColList{1, 1, 2}, opt.ColList{4, 5, 6}
+	test(t, colSetIn, from, to, opt.MakeColSet(4, 5, 6))
 
-	colSetIn, from, to = util.MakeFastIntSet(1, 2, 3), opt.ColList{1, 2, 3}, opt.ColList{4, 5, 4}
-	test(t, colSetIn, from, to, util.MakeFastIntSet(4, 5))
+	colSetIn, from, to = opt.MakeColSet(1, 2, 3), opt.ColList{1, 2, 3}, opt.ColList{4, 5, 4}
+	test(t, colSetIn, from, to, opt.MakeColSet(4, 5))
 
-	colSetIn, from, to = util.MakeFastIntSet(2), opt.ColList{1, 2, 2}, opt.ColList{4, 5, 6}
-	test(t, colSetIn, from, to, util.MakeFastIntSet(5, 6))
+	colSetIn, from, to = opt.MakeColSet(2), opt.ColList{1, 2, 2}, opt.ColList{4, 5, 6}
+	test(t, colSetIn, from, to, opt.MakeColSet(5, 6))
 }
 
 func testStats(

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 func TestMetadata(t *testing.T) {
@@ -197,17 +196,17 @@ func TestIndexColumns(t *testing.T) {
 	var md opt.Metadata
 	a := md.AddTable(cat.Table(tree.NewUnqualifiedTableName("a")))
 
-	k := int(a.ColumnID(0))
-	i := int(a.ColumnID(1))
-	s := int(a.ColumnID(2))
-	f := int(a.ColumnID(3))
+	k := a.ColumnID(0)
+	i := a.ColumnID(1)
+	s := a.ColumnID(2)
+	f := a.ColumnID(3)
 
 	testCases := []struct {
 		index        int
 		expectedCols opt.ColSet
 	}{
-		{1, util.MakeFastIntSet(k, i)},
-		{2, util.MakeFastIntSet(s, f, k)},
+		{1, opt.MakeColSet(k, i)},
+		{2, opt.MakeColSet(s, f, k)},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/sql/opt/norm/decorrelate.go
+++ b/pkg/sql/opt/norm/decorrelate.go
@@ -467,7 +467,7 @@ func (c *CustomFuncs) EnsureCanaryCol(in memo.RelExpr, aggs memo.AggregationsExp
 //
 // See the TryDecorrelateScalarGroupBy rule comment for more details.
 func (c *CustomFuncs) EnsureCanary(in memo.RelExpr, canaryCol opt.ColumnID) memo.RelExpr {
-	if canaryCol == 0 || c.OutputCols(in).Contains(int(canaryCol)) {
+	if canaryCol == 0 || c.OutputCols(in).Contains(canaryCol) {
 		return in
 	}
 	result := c.ProjectExtraCol(in, c.f.ConstructTrue(), canaryCol)
@@ -479,7 +479,7 @@ func (c *CustomFuncs) EnsureCanary(in memo.RelExpr, canaryCol opt.ColumnID) memo
 func (c *CustomFuncs) CanaryColSet(canaryCol opt.ColumnID) opt.ColSet {
 	var colSet opt.ColSet
 	if canaryCol != 0 {
-		colSet.Add(int(canaryCol))
+		colSet.Add(canaryCol)
 	}
 	return colSet
 }
@@ -538,7 +538,7 @@ func (c *CustomFuncs) TranslateNonIgnoreAggs(
 ) memo.RelExpr {
 	var aggCanaryVar opt.ScalarExpr
 	passthrough := c.OutputCols(newIn).Copy()
-	passthrough.Remove(int(canaryCol))
+	passthrough.Remove(canaryCol)
 
 	var projections memo.ProjectionsExpr
 	for i := range newAggs {
@@ -573,7 +573,7 @@ func (c *CustomFuncs) TranslateNonIgnoreAggs(
 				Element:    c.constructCanaryChecker(aggCanaryVar, newAggs[i].Col),
 				ColPrivate: memo.ColPrivate{Col: oldAggs[i].Col},
 			})
-			passthrough.Remove(int(newAggs[i].Col))
+			passthrough.Remove(newAggs[i].Col)
 		}
 	}
 

--- a/pkg/sql/opt/norm/groupby.go
+++ b/pkg/sql/opt/norm/groupby.go
@@ -217,7 +217,7 @@ func (c *CustomFuncs) hasRemovableAggDistinct(
 	}
 
 	cols := groupingCols.Copy()
-	cols.Add(int(v.Col))
+	cols.Add(v.Col)
 	if !inputFDs.ColsAreStrictKey(cols) {
 		return false, nil
 	}
@@ -248,7 +248,7 @@ func (c *CustomFuncs) ConstructProjectionFromDistinctOn(
 		inputCol := varExpr.Col
 		outputCol := aggs[i].Col
 		if inputCol == outputCol {
-			passthrough.Add(int(inputCol))
+			passthrough.Add(inputCol)
 		} else {
 			projections = append(projections, memo.ProjectionsItem{
 				Element:    varExpr,

--- a/pkg/sql/opt/norm/inline.go
+++ b/pkg/sql/opt/norm/inline.go
@@ -28,14 +28,14 @@ func (c *CustomFuncs) FindInlinableConstants(input memo.RelExpr) opt.ColSet {
 		for i := range project.Projections {
 			item := &project.Projections[i]
 			if opt.IsConstValueOp(item.Element) {
-				cols.Add(int(item.Col))
+				cols.Add(item.Col)
 			}
 		}
 	} else if values, ok := input.(*memo.ValuesExpr); ok && len(values.Rows) == 1 {
 		tup := values.Rows[0].(*memo.TupleExpr)
 		for i, scalar := range tup.Elems {
 			if opt.IsConstValueOp(scalar) {
-				cols.Add(int(values.Cols[i]))
+				cols.Add(values.Cols[i])
 			}
 		}
 	}
@@ -81,7 +81,7 @@ func (c *CustomFuncs) inlineConstants(
 	replace = func(e opt.Expr) opt.Expr {
 		switch t := e.(type) {
 		case *memo.VariableExpr:
-			if constCols.Contains(int(t.Col)) {
+			if constCols.Contains(t.Col) {
 				return c.extractColumn(input, t.Col)
 			}
 			return t
@@ -145,15 +145,15 @@ func (c *CustomFuncs) HasDuplicateRefs(
 			switch t := e.(type) {
 			case *memo.VariableExpr:
 				// Ignore references to non-target columns.
-				if !targetCols.Contains(int(t.Col)) {
+				if !targetCols.Contains(t.Col) {
 					return false
 				}
 
 				// Count Variable references.
-				if refs.Contains(int(t.Col)) {
+				if refs.Contains(t.Col) {
 					return true
 				}
-				refs.Add(int(t.Col))
+				refs.Add(t.Col)
 				return false
 
 			case memo.RelExpr:
@@ -249,9 +249,9 @@ func (c *CustomFuncs) InlineProjectProject(
 	if !newPassthrough.Empty() {
 		for i := range innerProjections {
 			item := &innerProjections[i]
-			if newPassthrough.Contains(int(item.Col)) {
+			if newPassthrough.Contains(item.Col) {
 				newProjections = append(newProjections, *item)
-				newPassthrough.Remove(int(item.Col))
+				newPassthrough.Remove(item.Col)
 			}
 		}
 	}

--- a/pkg/sql/opt/norm/prune_cols.go
+++ b/pkg/sql/opt/norm/prune_cols.go
@@ -51,7 +51,7 @@ func (c *CustomFuncs) NeededMutationCols(private *memo.MutationPrivate) opt.ColS
 	addCols := func(list opt.ColList) {
 		for _, id := range list {
 			if id != 0 {
-				cols.Add(int(id))
+				cols.Add(id)
 			}
 		}
 	}
@@ -62,7 +62,7 @@ func (c *CustomFuncs) NeededMutationCols(private *memo.MutationPrivate) opt.ColS
 	addCols(private.CheckCols)
 	addCols(private.ReturnCols)
 	if private.CanaryCol != 0 {
-		cols.Add(int(private.CanaryCol))
+		cols.Add(private.CanaryCol)
 	}
 
 	return cols
@@ -84,7 +84,7 @@ func (c *CustomFuncs) NeededMutationFetchCols(
 		var colSet opt.ColSet
 		for i, n := 0, fam.ColumnCount(); i < n; i++ {
 			id := tabMeta.MetaID.ColumnID(fam.Column(i).Ordinal)
-			colSet.Add(int(id))
+			colSet.Add(id)
 		}
 		return colSet
 	}
@@ -114,7 +114,7 @@ func (c *CustomFuncs) NeededMutationFetchCols(
 	for ord, col := range private.ReturnCols {
 		if col != 0 {
 			if op == opt.DeleteOp || len(private.UpdateCols) == 0 || private.UpdateCols[ord] == 0 {
-				cols.Add(int(tabMeta.MetaID.ColumnID(ord)))
+				cols.Add(tabMeta.MetaID.ColumnID(ord))
 			}
 		}
 	}
@@ -125,7 +125,7 @@ func (c *CustomFuncs) NeededMutationFetchCols(
 		var updateCols opt.ColSet
 		for ord, col := range private.UpdateCols {
 			if col != 0 {
-				updateCols.Add(int(tabMeta.MetaID.ColumnID(ord)))
+				updateCols.Add(tabMeta.MetaID.ColumnID(ord))
 			}
 		}
 
@@ -192,7 +192,7 @@ func (c *CustomFuncs) CanPruneMutationFetchCols(
 ) bool {
 	tabMeta := c.mem.Metadata().TableMeta(private.Table)
 	for ord, col := range private.FetchCols {
-		if col != 0 && !neededCols.Contains(int(tabMeta.MetaID.ColumnID(ord))) {
+		if col != 0 && !neededCols.Contains(tabMeta.MetaID.ColumnID(ord)) {
 			return true
 		}
 	}
@@ -219,7 +219,7 @@ func (c *CustomFuncs) PruneCols(target memo.RelExpr, neededCols opt.ColSet) memo
 		projections := make(memo.ProjectionsExpr, 0, len(t.Projections))
 		for i := range t.Projections {
 			item := &t.Projections[i]
-			if neededCols.Contains(int(item.Col)) {
+			if neededCols.Contains(item.Col) {
 				projections = append(projections, *item)
 			}
 		}
@@ -245,7 +245,7 @@ func (c *CustomFuncs) PruneAggCols(
 	aggs := make(memo.AggregationsExpr, 0, len(target))
 	for i := range target {
 		item := &target[i]
-		if neededCols.Contains(int(item.Col)) {
+		if neededCols.Contains(item.Col) {
 			aggs = append(aggs, *item)
 		}
 	}
@@ -273,7 +273,7 @@ func (c *CustomFuncs) filterMutationList(
 ) opt.ColList {
 	newList := make(opt.ColList, len(inList))
 	for i, c := range inList {
-		if !neededCols.Contains(int(tabID.ColumnID(i))) {
+		if !neededCols.Contains(tabID.ColumnID(i)) {
 			newList[i] = 0
 		} else {
 			newList[i] = c
@@ -298,7 +298,7 @@ func (c *CustomFuncs) pruneValuesCols(values *memo.ValuesExpr, neededCols opt.Co
 	// Create new list of columns that only contains needed columns.
 	newCols := make(opt.ColList, 0, neededCols.Len())
 	for _, colID := range values.Cols {
-		if !neededCols.Contains(int(colID)) {
+		if !neededCols.Contains(colID) {
 			continue
 		}
 		newCols = append(newCols, colID)
@@ -313,7 +313,7 @@ func (c *CustomFuncs) pruneValuesCols(values *memo.ValuesExpr, neededCols opt.Co
 		newElems := make(memo.ScalarListExpr, len(newCols))
 		nelem := 0
 		for ielem, elem := range tuple.Elems {
-			if !neededCols.Contains(int(values.Cols[ielem])) {
+			if !neededCols.Contains(values.Cols[ielem]) {
 				continue
 			}
 			newContents[nelem] = typ.TupleContents()[ielem]
@@ -378,7 +378,7 @@ func (c *CustomFuncs) NeededWindowCols(windows memo.WindowsExpr, p *memo.WindowP
 // which is not included in needed, meaning that it can be pruned.
 func (c *CustomFuncs) CanPruneWindows(needed opt.ColSet, windows memo.WindowsExpr) bool {
 	for _, w := range windows {
-		if !needed.Contains(int(w.Col)) {
+		if !needed.Contains(w.Col) {
 			return true
 		}
 	}
@@ -391,7 +391,7 @@ func (c *CustomFuncs) CanPruneWindows(needed opt.ColSet, windows memo.WindowsExp
 func (c *CustomFuncs) PruneWindows(needed opt.ColSet, windows memo.WindowsExpr) memo.WindowsExpr {
 	result := make(memo.WindowsExpr, 0, len(windows))
 	for _, w := range windows {
-		if needed.Contains(int(w.Col)) {
+		if needed.Contains(w.Col) {
 			result = append(result, w)
 		}
 	}
@@ -499,7 +499,7 @@ func DerivePruneCols(e memo.RelExpr) opt.ColSet {
 		relProps.Rule.PruneCols.DifferenceWith(win.Partition)
 		relProps.Rule.PruneCols.DifferenceWith(win.Ordering.ColSet())
 		for _, w := range win.Windows {
-			relProps.Rule.PruneCols.Add(int(w.Col))
+			relProps.Rule.PruneCols.Add(w.Col)
 			relProps.Rule.PruneCols.DifferenceWith(w.ScalarProps(e.Memo()).OuterCols)
 		}
 

--- a/pkg/sql/opt/norm/reject_nulls.go
+++ b/pkg/sql/opt/norm/reject_nulls.go
@@ -55,7 +55,7 @@ func (c *CustomFuncs) NullRejectAggVar(
 	aggs memo.AggregationsExpr, nullRejectCols opt.ColSet,
 ) *memo.VariableExpr {
 	for i := range aggs {
-		if nullRejectCols.Contains(int(aggs[i].Col)) {
+		if nullRejectCols.Contains(aggs[i].Col) {
 			return memo.ExtractVarFromAggInput(aggs[i].Agg.Child(0).(opt.ScalarExpr))
 		}
 	}
@@ -159,7 +159,7 @@ func deriveGroupByRejectNullCols(in memo.RelExpr) opt.ColSet {
 		}
 		savedInColID = inColID
 
-		if !DeriveRejectNullCols(input).Contains(int(inColID)) {
+		if !DeriveRejectNullCols(input).Contains(inColID) {
 			// Input has not requested null rejection on the input column.
 			return opt.ColSet{}
 		}
@@ -167,7 +167,7 @@ func deriveGroupByRejectNullCols(in memo.RelExpr) opt.ColSet {
 		// Can possibly reject column, but keep searching, since if
 		// multiple columns are used by aggregate functions, then nulls
 		// can't be rejected on any column.
-		rejectNullCols.Add(int(aggs[i].Col))
+		rejectNullCols.Add(aggs[i].Col)
 	}
 	return rejectNullCols
 }

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -166,7 +166,7 @@ func (b *Builder) constructGroupBy(
 	// multiple times.
 	colSet := opt.ColSet{}
 	for i := range aggCols {
-		if id, scalar := aggCols[i].id, aggCols[i].scalar; !colSet.Contains(int(id)) {
+		if id, scalar := aggCols[i].id, aggCols[i].scalar; !colSet.Contains(id) {
 			if scalar == nil {
 				// A "pass through" column (i.e. a VariableOp) is not legal as an
 				// aggregation.
@@ -176,7 +176,7 @@ func (b *Builder) constructGroupBy(
 				Agg:        scalar,
 				ColPrivate: memo.ColPrivate{Col: id},
 			})
-			colSet.Add(int(id))
+			colSet.Add(id)
 		}
 	}
 
@@ -256,7 +256,7 @@ func (b *Builder) buildAggregation(
 	// Build ColSet of grouping columns.
 	var groupingColSet opt.ColSet
 	for i := range groupingCols {
-		groupingColSet.Add(int(groupingCols[i].id))
+		groupingColSet.Add(groupingCols[i].id)
 	}
 
 	// If there are any aggregates that are ordering sensitive, build the aggregations

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -396,7 +396,7 @@ func (mb *mutationBuilder) checkPrimaryKeyForInsert() {
 		}
 
 		colID := mb.tabID.ColumnID(col.Ordinal)
-		if mb.targetColSet.Contains(int(colID)) {
+		if mb.targetColSet.Contains(colID) {
 			// The column is explicitly specified in the target name list.
 			continue
 		}
@@ -447,7 +447,7 @@ func (mb *mutationBuilder) checkForeignKeysForInsert() {
 			}
 
 			colID := mb.tabID.ColumnID(ord)
-			if mb.targetColSet.Contains(int(colID)) {
+			if mb.targetColSet.Contains(colID) {
 				// The column is explicitly specified in the target name list.
 				allMissing = false
 				continue

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -247,11 +247,11 @@ func (mb *mutationBuilder) addTargetCol(ord int) {
 
 	// Ensure that the name list does not contain duplicates.
 	colID := mb.tabID.ColumnID(ord)
-	if mb.targetColSet.Contains(int(colID)) {
+	if mb.targetColSet.Contains(colID) {
 		panic(pgerror.Newf(pgerror.CodeSyntaxError,
 			"multiple assignments to the same column %q", tabCol.ColName()))
 	}
-	mb.targetColSet.Add(int(colID))
+	mb.targetColSet.Add(colID)
 
 	mb.targetColList = append(mb.targetColList, colID)
 }
@@ -393,7 +393,7 @@ func (mb *mutationBuilder) addSynthesizedCols(
 
 		// Add corresponding target column.
 		mb.targetColList = append(mb.targetColList, tabColID)
-		mb.targetColSet.Add(int(tabColID))
+		mb.targetColSet.Add(tabColID)
 	}
 
 	if projectionsScope != nil {

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -43,16 +43,16 @@ func (b *Builder) constructProject(input memo.RelExpr, cols []scopeColumn) memo.
 	colSet := opt.ColSet{}
 	for i := range cols {
 		id, scalar := cols[i].id, cols[i].scalar
-		if !colSet.Contains(int(id)) {
+		if !colSet.Contains(id) {
 			if scalar == nil {
-				passthrough.Add(int(id))
+				passthrough.Add(id)
 			} else {
 				projections = append(projections, memo.ProjectionsItem{
 					Element:    scalar,
 					ColPrivate: memo.ColPrivate{Col: id},
 				})
 			}
-			colSet.Add(int(id))
+			colSet.Add(id)
 		}
 	}
 
@@ -249,13 +249,13 @@ func (b *Builder) finishBuildScalarRef(
 ) (out opt.ScalarExpr) {
 	// Update the sets of column references and outer columns if needed.
 	if colRefs != nil {
-		colRefs.Add(int(col.id))
+		colRefs.Add(col.id)
 	}
 
 	// Collect the outer columns of the current subquery, if any.
 	isOuterColumn := inScope == nil || inScope.isOuterColumn(col.id)
 	if isOuterColumn && b.subquery != nil {
-		b.subquery.outerCols.Add(int(col.id))
+		b.subquery.outerCols.Add(col.id)
 	}
 
 	// If this is not a projection context, then wrap the column reference with

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -539,7 +539,7 @@ func (b *Builder) checkSubqueryOuterCols(
 	if b.semaCtx.Properties.IsSet(tree.RejectAggregates) && inScope.groupby.aggOutScope != nil {
 		aggCols := inScope.groupby.aggOutScope.getAggregateCols()
 		for i := range aggCols {
-			if subqueryOuterCols.Contains(int(aggCols[i].id)) {
+			if subqueryOuterCols.Contains(aggCols[i].id) {
 				panic(builderError{
 					tree.NewInvalidFunctionUsageError(tree.AggregateClass, inScope.context),
 				})

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -184,7 +184,7 @@ func (s *scope) appendColumn(col *scopeColumn) {
 func (s *scope) addExtraColumns(cols []scopeColumn) {
 	existing := s.colSetWithExtraCols()
 	for i := range cols {
-		if !existing.Contains(int(cols[i].id)) {
+		if !existing.Contains(cols[i].id) {
 			s.extraCols = append(s.extraCols, cols[i])
 		}
 	}
@@ -207,7 +207,7 @@ func (s *scope) copyOrdering(src *scope) {
 	// Copy any columns that the scope doesn't already have.
 	existing := s.colSetWithExtraCols()
 	for _, ordCol := range src.ordering {
-		if !existing.Contains(int(ordCol.ID())) {
+		if !existing.Contains(ordCol.ID()) {
 			col := *src.getColumn(ordCol.ID())
 			// We want to reset the group, as this becomes a pass-through column in
 			// the new scope.
@@ -375,7 +375,7 @@ func (s *scope) isOuterColumn(id opt.ColumnID) bool {
 func (s *scope) colSet() opt.ColSet {
 	var colSet opt.ColSet
 	for i := range s.cols {
-		colSet.Add(int(s.cols[i].id))
+		colSet.Add(s.cols[i].id)
 	}
 	return colSet
 }
@@ -385,7 +385,7 @@ func (s *scope) colSet() opt.ColSet {
 func (s *scope) colSetWithExtraCols() opt.ColSet {
 	colSet := s.colSet()
 	for i := range s.extraCols {
-		colSet.Add(int(s.extraCols[i].id))
+		colSet.Add(s.extraCols[i].id)
 	}
 	return colSet
 }

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -337,7 +337,7 @@ func (b *Builder) buildScan(
 
 		col := tab.Column(ord)
 		colID := tabID.ColumnID(ord)
-		tabColIDs.Add(int(colID))
+		tabColIDs.Add(colID)
 		name := col.ColName()
 		isMutation := cat.IsMutationColumn(tab, ord)
 		outScope.cols = append(outScope.cols, scopeColumn{

--- a/pkg/sql/opt/optbuilder/window.go
+++ b/pkg/sql/opt/optbuilder/window.go
@@ -371,7 +371,7 @@ func (b *Builder) buildWindowPartition(
 				b.buildScalar(e, inScope, nil, nil, nil),
 			)
 		}
-		windowPartition.Add(int(col.id))
+		windowPartition.Add(col.id)
 	}
 	return windowPartition
 }
@@ -559,7 +559,7 @@ func (b *Builder) constructScalarWindowGroup(
 			Agg:        varExpr,
 			ColPrivate: memo.ColPrivate{Col: aggregateCol.id},
 		})
-		passthrough.Add(int(aggInfos[i].col.id))
+		passthrough.Add(aggInfos[i].col.id)
 
 		// Add projection to replace default NULL value.
 		if requiresProjection {
@@ -570,7 +570,7 @@ func (b *Builder) constructScalarWindowGroup(
 					defaultNullVal),
 				ColPrivate: memo.ColPrivate{Col: aggInfos[i].col.id},
 			})
-			passthrough.Remove(int(aggInfos[i].col.id))
+			passthrough.Remove(aggInfos[i].col.id)
 		}
 	}
 

--- a/pkg/sql/opt/optgen/exprgen/expr_gen.go
+++ b/pkg/sql/opt/optgen/exprgen/expr_gen.go
@@ -231,7 +231,7 @@ func (eg *exprGen) castToDesiredType(arg interface{}, desiredType reflect.Type) 
 				if !ok {
 					return nil
 				}
-				set.Add(int(col))
+				set.Add(col)
 			}
 			return set
 		}

--- a/pkg/sql/opt/optgen/exprgen/private.go
+++ b/pkg/sql/opt/optgen/exprgen/private.go
@@ -202,7 +202,7 @@ func (eg *exprGen) statsFromStr(str string) props.Statistics {
 	for i := range stats {
 		var cols opt.ColSet
 		for _, colStr := range stats[i].Columns {
-			cols.Add(int(eg.LookupColumn(colStr)))
+			cols.Add(eg.LookupColumn(colStr))
 		}
 		s, added := result.ColStats.Add(cols)
 		if !added {

--- a/pkg/sql/opt/ordering.go
+++ b/pkg/sql/opt/ordering.go
@@ -96,7 +96,7 @@ func (o Ordering) Format(buf *bytes.Buffer) {
 func (o Ordering) ColSet() ColSet {
 	var colSet ColSet
 	for _, col := range o {
-		colSet.Add(int(col.ID()))
+		colSet.Add(col.ID())
 	}
 	return colSet
 }
@@ -193,7 +193,7 @@ func (os *OrderingSet) RestrictToCols(cols ColSet) {
 		// only columns in the set.
 		prefix := 0
 		for _, c := range o {
-			if !cols.Contains(int(c.ID())) {
+			if !cols.Contains(c.ID()) {
 				break
 			}
 			prefix++

--- a/pkg/sql/opt/ordering/group_by.go
+++ b/pkg/sql/opt/ordering/group_by.go
@@ -67,7 +67,7 @@ func groupByBuildProvided(expr memo.RelExpr, required *physical.OrderingChoice) 
 	// longest prefix of grouping columns (or columns equivalent to any of them).
 	groupingCols := inputFDs.ComputeEquivClosure(groupBy.GroupingCols)
 	for i := range provided {
-		if !groupingCols.Contains(int(provided[i].ID())) {
+		if !groupingCols.Contains(provided[i].ID()) {
 			provided = provided[:i]
 			break
 		}

--- a/pkg/sql/opt/ordering/lookup_join.go
+++ b/pkg/sql/opt/ordering/lookup_join.go
@@ -66,7 +66,7 @@ func lookupJoinBuildProvided(expr memo.RelExpr, required *physical.OrderingChoic
 	// First check if we need to.
 	needsRemap := false
 	for i := range childProvided {
-		if !lookupJoin.Cols.Contains(int(childProvided[i].ID())) {
+		if !lookupJoin.Cols.Contains(childProvided[i].ID()) {
 			needsRemap = true
 			break
 		}

--- a/pkg/sql/opt/ordering/lookup_join_test.go
+++ b/pkg/sql/opt/ordering/lookup_join_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 func TestLookupJoinProvided(t *testing.T) {
@@ -45,8 +44,8 @@ func TestLookupJoinProvided(t *testing.T) {
 		t.Fatalf("unexpected ID for column c1: %d\n", c1)
 	}
 
-	c := func(cols ...int) opt.ColSet {
-		return util.MakeFastIntSet(cols...)
+	c := func(cols ...opt.ColumnID) opt.ColSet {
+		return opt.MakeColSet(cols...)
 	}
 
 	testCases := []struct {

--- a/pkg/sql/opt/ordering/ordering.go
+++ b/pkg/sql/opt/ordering/ordering.go
@@ -225,7 +225,7 @@ func remapProvided(provided opt.Ordering, fds *props.FuncDepSet, outCols opt.Col
 	closure := fds.ComputeClosure(opt.ColSet{})
 	for i := range provided {
 		col := provided[i].ID()
-		if closure.Contains(int(col)) {
+		if closure.Contains(col) {
 			// At the level of the new operator, this column is redundant.
 			if result == nil {
 				result = make(opt.Ordering, i, len(provided))
@@ -233,12 +233,12 @@ func remapProvided(provided opt.Ordering, fds *props.FuncDepSet, outCols opt.Col
 			}
 			continue
 		}
-		if outCols.Contains(int(col)) {
+		if outCols.Contains(col) {
 			if result != nil {
 				result = append(result, provided[i])
 			}
 		} else {
-			equivCols := fds.ComputeEquivClosure(util.MakeFastIntSet(int(col)))
+			equivCols := fds.ComputeEquivClosure(opt.MakeColSet(col))
 			remappedCol, ok := equivCols.Intersection(outCols).Next(0)
 			if !ok {
 				panic(pgerror.AssertionFailedf("no output column equivalent to %d", log.Safe(col)))
@@ -251,7 +251,7 @@ func remapProvided(provided opt.Ordering, fds *props.FuncDepSet, outCols opt.Col
 				opt.ColumnID(remappedCol), provided[i].Descending(),
 			))
 		}
-		closure.Add(int(col))
+		closure.Add(col)
 		closure = fds.ComputeClosure(closure)
 	}
 	if result == nil {
@@ -281,7 +281,7 @@ func trimProvided(
 		// Consume columns from the provided ordering until their closure intersects
 		// the required group.
 		for !closure.Intersects(c.Group) {
-			closure.Add(int(provided[provIdx].ID()))
+			closure.Add(provided[provIdx].ID())
 			closure = fds.ComputeClosure(closure)
 			provIdx++
 			if provIdx == len(provided) {

--- a/pkg/sql/opt/ordering/ordering_test.go
+++ b/pkg/sql/opt/ordering/ordering_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
-	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 func TestTrimProvided(t *testing.T) {
@@ -68,8 +67,8 @@ func TestTrimProvided(t *testing.T) {
 
 func TestRemapProvided(t *testing.T) {
 	emptyFD, equivFD, constFD := testFDs()
-	c := func(cols ...int) opt.ColSet {
-		return util.MakeFastIntSet(cols...)
+	c := func(cols ...opt.ColumnID) opt.ColSet {
+		return opt.MakeColSet(cols...)
 	}
 	testCases := []struct {
 		prov string
@@ -127,7 +126,7 @@ func testFDs() (emptyFD, equivFD, constFD props.FuncDepSet) {
 	equivFD.AddEquivalency(1, 2)
 	equivFD.AddEquivalency(3, 4)
 
-	constFD.AddConstants(util.MakeFastIntSet(1, 2))
+	constFD.AddConstants(opt.MakeColSet(1, 2))
 
 	return emptyFD, equivFD, constFD
 }

--- a/pkg/sql/opt/ordering/project_test.go
+++ b/pkg/sql/opt/ordering/project_test.go
@@ -15,22 +15,22 @@ package ordering
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testexpr"
-	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 func TestProject(t *testing.T) {
 	var fds props.FuncDepSet
 	fds.AddEquivalency(2, 3)
-	fds.AddConstants(util.MakeFastIntSet(4))
+	fds.AddConstants(opt.MakeColSet(4))
 
 	project := &memo.ProjectExpr{
 		Input: &testexpr.Instance{
 			Rel: &props.Relational{
-				OutputCols: util.MakeFastIntSet(1, 2, 3, 4),
+				OutputCols: opt.MakeColSet(1, 2, 3, 4),
 				FuncDeps:   fds,
 			},
 		},

--- a/pkg/sql/opt/ordering/row_number_test.go
+++ b/pkg/sql/opt/ordering/row_number_test.go
@@ -16,13 +16,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 func TestOrdinalityProvided(t *testing.T) {
@@ -78,7 +78,7 @@ func TestOrdinalityProvided(t *testing.T) {
 			var f norm.Factory
 			f.Init(evalCtx)
 			input := &testexpr.Instance{
-				Rel: &props.Relational{OutputCols: util.MakeFastIntSet(1, 2, 3, 4, 5)},
+				Rel: &props.Relational{OutputCols: opt.MakeColSet(1, 2, 3, 4, 5)},
 				Provided: &physical.Provided{
 					Ordering: physical.ParseOrdering(tc.input),
 				},

--- a/pkg/sql/opt/ordering/scan.go
+++ b/pkg/sql/opt/ordering/scan.go
@@ -88,12 +88,12 @@ func ScanPrivateCanProvide(
 		}
 		indexCol := index.Column(left)
 		indexColID := s.Table.ColumnID(indexCol.Ordinal)
-		if required.Optional.Contains(int(indexColID)) {
+		if required.Optional.Contains(indexColID) {
 			left++
 			continue
 		}
 		reqCol := &required.Columns[right]
-		if !reqCol.Group.Contains(int(indexColID)) {
+		if !reqCol.Group.Contains(indexColID) {
 			return false, false
 		}
 		// The directions of the index column and the required column impose either
@@ -133,11 +133,11 @@ func scanBuildProvided(expr memo.RelExpr, required *physical.OrderingChoice) opt
 	for i := 0; i < numCols; i++ {
 		indexCol := index.Column(i)
 		colID := scan.Table.ColumnID(indexCol.Ordinal)
-		if !scan.Cols.Contains(int(colID)) {
+		if !scan.Cols.Contains(colID) {
 			// Column not in output; we are done.
 			break
 		}
-		if constCols.Contains(int(colID)) {
+		if constCols.Contains(colID) {
 			// Column constrained to a constant, ignore.
 			continue
 		}

--- a/pkg/sql/opt/ordering/scan_test.go
+++ b/pkg/sql/opt/ordering/scan_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 func TestScan(t *testing.T) {
@@ -75,7 +74,7 @@ func TestScan(t *testing.T) {
 			p: memo.ScanPrivate{
 				Table: tab,
 				Index: cat.PrimaryIndex,
-				Cols:  util.MakeFastIntSet(1, 2, 3, 4),
+				Cols:  opt.MakeColSet(1, 2, 3, 4),
 			},
 			cases: []testCase{
 				{req: "", exp: "fwd", prov: ""},               // case 1
@@ -94,7 +93,7 @@ func TestScan(t *testing.T) {
 			p: memo.ScanPrivate{
 				Table: tab,
 				Index: 1,
-				Cols:  util.MakeFastIntSet(1, 2, 3, 4),
+				Cols:  opt.MakeColSet(1, 2, 3, 4),
 			},
 			cases: []testCase{
 				{req: "", exp: "fwd", prov: ""},                          // case 1
@@ -113,7 +112,7 @@ func TestScan(t *testing.T) {
 			p: memo.ScanPrivate{
 				Table:     tab,
 				Index:     cat.PrimaryIndex,
-				Cols:      util.MakeFastIntSet(1, 2, 3, 4),
+				Cols:      opt.MakeColSet(1, 2, 3, 4),
 				HardLimit: +10,
 			},
 			cases: []testCase{
@@ -133,7 +132,7 @@ func TestScan(t *testing.T) {
 			p: memo.ScanPrivate{
 				Table:     tab,
 				Index:     cat.PrimaryIndex,
-				Cols:      util.MakeFastIntSet(1, 2, 3, 4),
+				Cols:      opt.MakeColSet(1, 2, 3, 4),
 				HardLimit: -10,
 			},
 			cases: []testCase{
@@ -153,7 +152,7 @@ func TestScan(t *testing.T) {
 			p: memo.ScanPrivate{
 				Table:      tab,
 				Index:      1,
-				Cols:       util.MakeFastIntSet(1, 2, 3, 4),
+				Cols:       opt.MakeColSet(1, 2, 3, 4),
 				Constraint: &c,
 			},
 			cases: []testCase{

--- a/pkg/sql/opt/ordering_test.go
+++ b/pkg/sql/opt/ordering_test.go
@@ -17,7 +17,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
-	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 func TestOrdering(t *testing.T) {
@@ -44,7 +43,7 @@ func TestOrdering(t *testing.T) {
 		t.Error("ordering should provide the empty ordering")
 	}
 
-	if !ordering.ColSet().Equals(util.MakeFastIntSet(1, 5)) {
+	if !ordering.ColSet().Equals(opt.MakeColSet(1, 5)) {
 		t.Error("ordering colset should equal the ordering columns")
 	}
 
@@ -112,22 +111,22 @@ func TestOrderingSet(t *testing.T) {
 	expect(s2, "")
 
 	s2 = s.Copy()
-	s2.RestrictToCols(util.MakeFastIntSet(1, 2, 3, 5))
+	s2.RestrictToCols(opt.MakeColSet(1, 2, 3, 5))
 	expect(s2, "(+1,+2,+5) (+1,-2,+3)")
 
 	s2 = s.Copy()
-	s2.RestrictToCols(util.MakeFastIntSet(1, 2, 3))
+	s2.RestrictToCols(opt.MakeColSet(1, 2, 3))
 	expect(s2, "(+1,+2) (+1,-2,+3)")
 
 	s2 = s.Copy()
-	s2.RestrictToCols(util.MakeFastIntSet(1, 2))
+	s2.RestrictToCols(opt.MakeColSet(1, 2))
 	expect(s2, "(+1,+2) (+1,-2)")
 
 	s2 = s.Copy()
-	s2.RestrictToCols(util.MakeFastIntSet(1, 3))
+	s2.RestrictToCols(opt.MakeColSet(1, 3))
 	expect(s2, "(+1)")
 
 	s2 = s.Copy()
-	s2.RestrictToCols(util.MakeFastIntSet(2, 3))
+	s2.RestrictToCols(opt.MakeColSet(2, 3))
 	expect(s2, "")
 }

--- a/pkg/sql/opt/props/col_stats_map.go
+++ b/pkg/sql/opt/props/col_stats_map.go
@@ -129,7 +129,7 @@ func (m *ColStatsMap) Lookup(cols opt.ColSet) (colStat *ColumnStatistic, ok bool
 
 	// Use the prefix tree index to look up the column statistic.
 	val := colStatVal{prefix: 0, pos: -1}
-	curr := 0
+	curr := opt.ColumnID(0)
 	for {
 		curr, ok = cols.Next(curr + 1)
 		if !ok {
@@ -246,7 +246,7 @@ func (m *ColStatsMap) addToIndex(cols opt.ColSet, pos int) {
 	}
 
 	prefix := prefixID(0)
-	prev := 0
+	prev := opt.ColumnID(0)
 	curr, _ := cols.Next(prev)
 	for {
 		key := colStatKey{prefix: prefix, id: opt.ColumnID(curr)}

--- a/pkg/sql/opt/props/func_dep.go
+++ b/pkg/sql/opt/props/func_dep.go
@@ -731,8 +731,8 @@ func (f *FuncDepSet) AddEquivalency(a, b opt.ColumnID) {
 	}
 
 	var equiv opt.ColSet
-	equiv.Add(int(a))
-	equiv.Add(int(b))
+	equiv.Add(a)
+	equiv.Add(b)
 	f.addEquivalency(equiv)
 }
 
@@ -811,12 +811,12 @@ func (f *FuncDepSet) AddConstants(cols opt.ColSet) {
 //   ()-->(c)
 //
 func (f *FuncDepSet) AddSynthesizedCol(from opt.ColSet, col opt.ColumnID) {
-	if from.Contains(int(col)) {
+	if from.Contains(col) {
 		panic(pgerror.AssertionFailedf("synthesized column cannot depend upon itself"))
 	}
 
 	var colSet opt.ColSet
-	colSet.Add(int(col))
+	colSet.Add(col)
 	f.addDependency(from, colSet, true /* strict */, false /* equiv */)
 }
 
@@ -937,7 +937,7 @@ func (f *FuncDepSet) ProjectCols(cols opt.ColSet) {
 				if id, foundAll = equivMap[opt.ColumnID(c)]; !foundAll {
 					break
 				}
-				afterCols.Add(int(id))
+				afterCols.Add(id)
 			}
 			if foundAll {
 				// Dependency can be remapped using equivalencies.
@@ -1204,7 +1204,7 @@ func (f *FuncDepSet) EquivReps() opt.ColSet {
 // ComputeEquivGroup returns the group of columns that are equivalent to the
 // given column. See ComputeEquivClosure for more details.
 func (f *FuncDepSet) ComputeEquivGroup(rep opt.ColumnID) opt.ColSet {
-	return f.ComputeEquivClosure(util.MakeFastIntSet(int(rep)))
+	return f.ComputeEquivClosure(opt.MakeColSet(rep))
 }
 
 // ensureKeyClosure checks whether the closure for this FD set's key (if there

--- a/pkg/sql/opt/props/func_dep_test.go
+++ b/pkg/sql/opt/props/func_dep_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
-	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 // Other tests also exercise the ColsAreKey methods.
@@ -125,20 +124,20 @@ func TestFuncDeps_InClosureOf(t *testing.T) {
 	verifyFD(t, fd, "()-->(2,3), ()~~>(1), (1)~~>(4), (2)==(3), (3)==(2), (4)-->(5)")
 
 	testcases := []struct {
-		cols     []int
-		in       []int
+		cols     []opt.ColumnID
+		in       []opt.ColumnID
 		expected bool
 	}{
-		{cols: []int{}, in: []int{}, expected: true},
-		{cols: []int{}, in: []int{1}, expected: true},
-		{cols: []int{2, 3}, in: []int{}, expected: true},
-		{cols: []int{2}, in: []int{3}, expected: true},
-		{cols: []int{3}, in: []int{2}, expected: true},
-		{cols: []int{3, 5}, in: []int{2, 4}, expected: true},
+		{cols: []opt.ColumnID{}, in: []opt.ColumnID{}, expected: true},
+		{cols: []opt.ColumnID{}, in: []opt.ColumnID{1}, expected: true},
+		{cols: []opt.ColumnID{2, 3}, in: []opt.ColumnID{}, expected: true},
+		{cols: []opt.ColumnID{2}, in: []opt.ColumnID{3}, expected: true},
+		{cols: []opt.ColumnID{3}, in: []opt.ColumnID{2}, expected: true},
+		{cols: []opt.ColumnID{3, 5}, in: []opt.ColumnID{2, 4}, expected: true},
 
-		{cols: []int{1}, in: []int{}, expected: false},
-		{cols: []int{4}, in: []int{5}, expected: false},
-		{cols: []int{2, 3, 4}, in: []int{1, 2, 3}, expected: false},
+		{cols: []opt.ColumnID{1}, in: []opt.ColumnID{}, expected: false},
+		{cols: []opt.ColumnID{4}, in: []opt.ColumnID{5}, expected: false},
+		{cols: []opt.ColumnID{2, 3, 4}, in: []opt.ColumnID{1, 2, 3}, expected: false},
 	}
 
 	for _, tc := range testcases {
@@ -1161,6 +1160,6 @@ func testColsAreLaxKey(t *testing.T, f *props.FuncDepSet, cols opt.ColSet, expec
 	}
 }
 
-func c(cols ...int) opt.ColSet {
-	return util.MakeFastIntSet(cols...)
+func c(cols ...opt.ColumnID) opt.ColSet {
+	return opt.MakeColSet(cols...)
 }

--- a/pkg/sql/opt/props/physical/ordering_choice_test.go
+++ b/pkg/sql/opt/props/physical/ordering_choice_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
-	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 func TestOrderingChoice_FromOrdering(t *testing.T) {
@@ -28,7 +27,7 @@ func TestOrderingChoice_FromOrdering(t *testing.T) {
 		t.Errorf("expected %s, got %s", exp, actual)
 	}
 
-	oc.FromOrderingWithOptCols(opt.Ordering{1, -2, 3, 4, -5}, util.MakeFastIntSet(1, 3, 5))
+	oc.FromOrderingWithOptCols(opt.Ordering{1, -2, 3, 4, -5}, opt.MakeColSet(1, 3, 5))
 	if exp, actual := "-2,+4 opt(1,3,5)", oc.String(); exp != actual {
 		t.Errorf("expected %s, got %s", exp, actual)
 	}
@@ -65,10 +64,10 @@ func TestOrderingChoice_ColSet(t *testing.T) {
 		s  string
 		cs opt.ColSet
 	}{
-		{s: "", cs: util.MakeFastIntSet()},
-		{s: "+1", cs: util.MakeFastIntSet(1)},
-		{s: "-1,+(2|3) opt(4,5)", cs: util.MakeFastIntSet(1, 2, 3)},
-		{s: "+(1|2),-(3|4),+5", cs: util.MakeFastIntSet(1, 2, 3, 4, 5)},
+		{s: "", cs: opt.MakeColSet()},
+		{s: "+1", cs: opt.MakeColSet(1)},
+		{s: "-1,+(2|3) opt(4,5)", cs: opt.MakeColSet(1, 2, 3)},
+		{s: "+(1|2),-(3|4),+5", cs: opt.MakeColSet(1, 2, 3, 4, 5)},
 	}
 
 	for _, tc := range testcases {
@@ -233,17 +232,17 @@ func TestOrderingChoice_SubsetOfCols(t *testing.T) {
 		cs       opt.ColSet
 		expected bool
 	}{
-		{s: "", cs: util.MakeFastIntSet(), expected: true},
-		{s: "", cs: util.MakeFastIntSet(1), expected: true},
-		{s: "+1", cs: util.MakeFastIntSet(1), expected: true},
-		{s: "-1", cs: util.MakeFastIntSet(1, 2), expected: true},
-		{s: "+1 opt(2)", cs: util.MakeFastIntSet(1), expected: false},
-		{s: "+1 opt(2)", cs: util.MakeFastIntSet(1, 2), expected: true},
-		{s: "+(1|2)", cs: util.MakeFastIntSet(1, 2, 3), expected: true},
-		{s: "+(1|2)", cs: util.MakeFastIntSet(2), expected: false},
-		{s: "+1,-(2|3),-4 opt(4,5)", cs: util.MakeFastIntSet(1, 3, 4), expected: false},
-		{s: "+1,-(2|3),-4 opt(4,5)", cs: util.MakeFastIntSet(1, 2, 3, 4), expected: false},
-		{s: "+1,-(2|3),-4 opt(4,5)", cs: util.MakeFastIntSet(1, 2, 3, 4, 5), expected: true},
+		{s: "", cs: opt.MakeColSet(), expected: true},
+		{s: "", cs: opt.MakeColSet(1), expected: true},
+		{s: "+1", cs: opt.MakeColSet(1), expected: true},
+		{s: "-1", cs: opt.MakeColSet(1, 2), expected: true},
+		{s: "+1 opt(2)", cs: opt.MakeColSet(1), expected: false},
+		{s: "+1 opt(2)", cs: opt.MakeColSet(1, 2), expected: true},
+		{s: "+(1|2)", cs: opt.MakeColSet(1, 2, 3), expected: true},
+		{s: "+(1|2)", cs: opt.MakeColSet(2), expected: false},
+		{s: "+1,-(2|3),-4 opt(4,5)", cs: opt.MakeColSet(1, 3, 4), expected: false},
+		{s: "+1,-(2|3),-4 opt(4,5)", cs: opt.MakeColSet(1, 2, 3, 4), expected: false},
+		{s: "+1,-(2|3),-4 opt(4,5)", cs: opt.MakeColSet(1, 2, 3, 4, 5), expected: true},
 	}
 
 	for _, tc := range testcases {
@@ -264,18 +263,18 @@ func TestOrderingChoice_CanProjectCols(t *testing.T) {
 		cs       opt.ColSet
 		expected bool
 	}{
-		{s: "", cs: util.MakeFastIntSet(), expected: true},
-		{s: "", cs: util.MakeFastIntSet(1), expected: true},
-		{s: "+1", cs: util.MakeFastIntSet(1), expected: true},
-		{s: "-1", cs: util.MakeFastIntSet(1, 2), expected: true},
-		{s: "+1 opt(2)", cs: util.MakeFastIntSet(1), expected: true},
-		{s: "+(1|2)", cs: util.MakeFastIntSet(1), expected: true},
-		{s: "+(1|2)", cs: util.MakeFastIntSet(2), expected: true},
-		{s: "+1,-(2|3),-4 opt(4,5)", cs: util.MakeFastIntSet(1, 3, 4), expected: true},
+		{s: "", cs: opt.MakeColSet(), expected: true},
+		{s: "", cs: opt.MakeColSet(1), expected: true},
+		{s: "+1", cs: opt.MakeColSet(1), expected: true},
+		{s: "-1", cs: opt.MakeColSet(1, 2), expected: true},
+		{s: "+1 opt(2)", cs: opt.MakeColSet(1), expected: true},
+		{s: "+(1|2)", cs: opt.MakeColSet(1), expected: true},
+		{s: "+(1|2)", cs: opt.MakeColSet(2), expected: true},
+		{s: "+1,-(2|3),-4 opt(4,5)", cs: opt.MakeColSet(1, 3, 4), expected: true},
 
-		{s: "+1", cs: util.MakeFastIntSet(), expected: false},
-		{s: "+1,+2", cs: util.MakeFastIntSet(1), expected: false},
-		{s: "+(1|2)", cs: util.MakeFastIntSet(3), expected: false},
+		{s: "+1", cs: opt.MakeColSet(), expected: false},
+		{s: "+1,+2", cs: opt.MakeColSet(1), expected: false},
+		{s: "+(1|2)", cs: opt.MakeColSet(3), expected: false},
 	}
 
 	for _, tc := range testcases {
@@ -340,14 +339,14 @@ func TestOrderingChoice_MatchesAt(t *testing.T) {
 func TestOrderingChoice_Copy(t *testing.T) {
 	ordering := physical.ParseOrderingChoice("+1,-(2|3) opt(4,5)")
 	copied := ordering.Copy()
-	col := physical.OrderingColumnChoice{Group: util.MakeFastIntSet(6, 7), Descending: true}
+	col := physical.OrderingColumnChoice{Group: opt.MakeColSet(6, 7), Descending: true}
 	copied.Columns = append(copied.Columns, col)
 
 	// ()-->(8)
 	// (3)==(9)
 	// (9)==(3)
 	var fd props.FuncDepSet
-	fd.AddConstants(util.MakeFastIntSet(8))
+	fd.AddConstants(opt.MakeColSet(8))
 	fd.AddEquivalency(3, 9)
 	copied.Simplify(&fd)
 
@@ -366,7 +365,7 @@ func TestOrderingChoice_Simplify(t *testing.T) {
 	// (2)==(1)
 	// (3)==(1)
 	var fd1 props.FuncDepSet
-	fd1.AddConstants(util.MakeFastIntSet(4, 5))
+	fd1.AddConstants(opt.MakeColSet(4, 5))
 	fd1.AddEquivalency(1, 2)
 	fd1.AddEquivalency(1, 3)
 
@@ -376,9 +375,9 @@ func TestOrderingChoice_Simplify(t *testing.T) {
 	// (2)==(3)
 	// (3)==(2)
 	var fd2 props.FuncDepSet
-	fd2.AddStrictKey(util.MakeFastIntSet(1), util.MakeFastIntSet(1, 2, 3, 4, 5))
-	fd2.AddSynthesizedCol(util.MakeFastIntSet(2), 4)
-	fd2.AddSynthesizedCol(util.MakeFastIntSet(4), 5)
+	fd2.AddStrictKey(opt.MakeColSet(1), opt.MakeColSet(1, 2, 3, 4, 5))
+	fd2.AddSynthesizedCol(opt.MakeColSet(2), 4)
+	fd2.AddSynthesizedCol(opt.MakeColSet(4), 5)
 	fd2.AddEquivalency(2, 3)
 
 	testcases := []struct {
@@ -453,20 +452,20 @@ func TestOrderingChoice_Truncate(t *testing.T) {
 func TestOrderingChoice_ProjectCols(t *testing.T) {
 	testcases := []struct {
 		s        string
-		cols     []int
+		cols     []opt.ColumnID
 		expected string
 	}{
-		{s: "", cols: []int{}, expected: ""},
-		{s: "+1,+(2|3),-4 opt(5,6)", cols: []int{1, 2, 3, 4, 5, 6}, expected: "+1,+(2|3),-4 opt(5,6)"},
-		{s: "+1,+(2|3),-4 opt(5,6)", cols: []int{1, 2, 4, 5, 6}, expected: "+1,+2,-4 opt(5,6)"},
-		{s: "+1,+(2|3),-4 opt(5,6)", cols: []int{1, 3, 4, 5, 6}, expected: "+1,+3,-4 opt(5,6)"},
-		{s: "+1,+(2|3),-4 opt(5,6)", cols: []int{1, 2, 4, 5}, expected: "+1,+2,-4 opt(5)"},
-		{s: "+1,+(2|3),-4 opt(5,6)", cols: []int{1, 2, 4}, expected: "+1,+2,-4"},
+		{s: "", cols: []opt.ColumnID{}, expected: ""},
+		{s: "+1,+(2|3),-4 opt(5,6)", cols: []opt.ColumnID{1, 2, 3, 4, 5, 6}, expected: "+1,+(2|3),-4 opt(5,6)"},
+		{s: "+1,+(2|3),-4 opt(5,6)", cols: []opt.ColumnID{1, 2, 4, 5, 6}, expected: "+1,+2,-4 opt(5,6)"},
+		{s: "+1,+(2|3),-4 opt(5,6)", cols: []opt.ColumnID{1, 3, 4, 5, 6}, expected: "+1,+3,-4 opt(5,6)"},
+		{s: "+1,+(2|3),-4 opt(5,6)", cols: []opt.ColumnID{1, 2, 4, 5}, expected: "+1,+2,-4 opt(5)"},
+		{s: "+1,+(2|3),-4 opt(5,6)", cols: []opt.ColumnID{1, 2, 4}, expected: "+1,+2,-4"},
 	}
 
 	for _, tc := range testcases {
 		choice := physical.ParseOrderingChoice(tc.s)
-		choice.ProjectCols(util.MakeFastIntSet(tc.cols...))
+		choice.ProjectCols(opt.MakeColSet(tc.cols...))
 		if choice.String() != tc.expected {
 			t.Errorf("%s: cols=%v, expected: %s, actual: %s", tc.s, tc.cols, tc.expected, choice.String())
 		}

--- a/pkg/sql/opt/props/physical/required.go
+++ b/pkg/sql/opt/props/physical/required.go
@@ -61,7 +61,7 @@ func (p *Required) Defined() bool {
 func (p *Required) ColSet() opt.ColSet {
 	colSet := p.Ordering.ColSet()
 	for _, col := range p.Presentation {
-		colSet.Add(int(col.ID))
+		colSet.Add(col.ID)
 	}
 	return colSet
 }

--- a/pkg/sql/opt/props/statistics.go
+++ b/pkg/sql/opt/props/statistics.go
@@ -182,7 +182,7 @@ func (c ColumnStatistics) Less(i, j int) bool {
 		return c[i].Cols.Len() < c[j].Cols.Len()
 	}
 
-	prev := 0
+	prev := opt.ColumnID(0)
 	for {
 		nextI, ok := c[i].Cols.Next(prev)
 		if !ok {

--- a/pkg/sql/opt/table_meta.go
+++ b/pkg/sql/opt/table_meta.go
@@ -161,7 +161,7 @@ func (tm *TableMeta) IndexColumns(indexOrd int) ColSet {
 	var indexCols ColSet
 	for i, n := 0, index.ColumnCount(); i < n; i++ {
 		ord := index.Column(i).Ordinal
-		indexCols.Add(int(tm.MetaID.ColumnID(ord)))
+		indexCols.Add(tm.MetaID.ColumnID(ord))
 	}
 	return indexCols
 }
@@ -174,7 +174,7 @@ func (tm *TableMeta) IndexKeyColumns(indexOrd int) ColSet {
 	var indexCols ColSet
 	for i, n := 0, index.KeyColumnCount(); i < n; i++ {
 		ord := index.Column(i).Ordinal
-		indexCols.Add(int(tm.MetaID.ColumnID(ord)))
+		indexCols.Add(tm.MetaID.ColumnID(ord))
 	}
 	return indexCols
 }

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -586,7 +586,7 @@ func (f *Flags) Set(arg datadriven.CmdArg) error {
 			if err != nil {
 				return fmt.Errorf("invalid colstat column %v", v)
 			}
-			cols.Add(col)
+			cols.Add(opt.ColumnID(col))
 		}
 		f.ColStats = append(f.ColStats, cols)
 
@@ -1127,7 +1127,7 @@ func (ot *OptTester) createTableAs(name tree.TableName, rel memo.RelExpr) (*test
 		}
 
 		// Make sure we have estimated stats for this column.
-		colSet := util.MakeFastIntSet(col)
+		colSet := opt.MakeColSet(col)
 		memo.RequestColStat(&ot.evalCtx, rel, colSet)
 		stat, ok := relProps.Stats.ColStats.Lookup(colSet)
 		if !ok {

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -170,7 +170,7 @@ func (c *CustomFuncs) checkConstraintFilters(tabID opt.TableID) memo.FiltersExpr
 	var notNullCols opt.ColSet
 	for i := 0; i < tab.ColumnCount(); i++ {
 		if !tab.Column(i).IsNullable() {
-			notNullCols.Add(int(tabID.ColumnID(i)))
+			notNullCols.Add(tabID.ColumnID(i))
 		}
 	}
 
@@ -407,7 +407,7 @@ func (c *CustomFuncs) initIdxConstraintForIndex(
 		colID := tabID.ColumnID(col.Ordinal)
 		columns[i] = opt.MakeOrderingColumn(colID, col.Descending)
 		if !col.IsNullable() {
-			notNullCols.Add(int(colID))
+			notNullCols.Add(colID)
 		}
 	}
 
@@ -484,7 +484,7 @@ func (c *CustomFuncs) canMaybeConstrainIndex(
 		// If the filter involves the first index column, then the index can
 		// possibly be constrained.
 		firstIndexCol := tabID.ColumnID(index.Column(0).Ordinal)
-		if filterProps.OuterCols.Contains(int(firstIndexCol)) {
+		if filterProps.OuterCols.Contains(firstIndexCol) {
 			return true
 		}
 
@@ -856,7 +856,7 @@ func (c *CustomFuncs) GenerateLookupJoins(
 		indexCols := iter.indexCols()
 		lookupJoin.Cols = scanPrivate.Cols.Intersection(indexCols)
 		for i := range pkCols {
-			lookupJoin.Cols.Add(int(pkCols[i]))
+			lookupJoin.Cols.Add(pkCols[i])
 		}
 		lookupJoin.Cols.UnionWith(inputProps.OutputCols)
 
@@ -951,13 +951,13 @@ func eqColsForZigzag(
 	j, rightCnt := 0, rightIndex.LaxKeyColumnCount()
 	for ; i < leftCnt; i++ {
 		colID := tabID.ColumnID(leftIndex.Column(i).Ordinal)
-		if !fixedCols.Contains(int(colID)) {
+		if !fixedCols.Contains(colID) {
 			break
 		}
 	}
 	for ; j < rightCnt; j++ {
 		colID := tabID.ColumnID(rightIndex.Column(j).Ordinal)
-		if !fixedCols.Contains(int(colID)) {
+		if !fixedCols.Contains(colID) {
 			break
 		}
 	}
@@ -1077,7 +1077,7 @@ func (c *CustomFuncs) GenerateZigzagJoins(
 		}
 		// Short-circuit quickly if the first column in the index is not a fixed
 		// column.
-		if !fixedCols.Contains(int(scanPrivate.Table.ColumnID(iter.index.Column(0).Ordinal))) {
+		if !fixedCols.Contains(scanPrivate.Table.ColumnID(iter.index.Column(0).Ordinal)) {
 			continue
 		}
 
@@ -1086,7 +1086,7 @@ func (c *CustomFuncs) GenerateZigzagJoins(
 		iter2.indexOrdinal = iter.indexOrdinal
 
 		for iter2.next() {
-			if !fixedCols.Contains(int(scanPrivate.Table.ColumnID(iter2.index.Column(0).Ordinal))) {
+			if !fixedCols.Contains(scanPrivate.Table.ColumnID(iter2.index.Column(0).Ordinal)) {
 				continue
 			}
 			// Columns that are in both indexes are, by definition, equal.
@@ -1215,7 +1215,7 @@ func (c *CustomFuncs) GenerateZigzagJoins(
 			// Ensure the zigzag join returns pk columns.
 			zigzagJoin.Cols = scanPrivate.Cols.Intersection(zigzagCols)
 			for i := range pkCols {
-				zigzagJoin.Cols.Add(int(pkCols[i]))
+				zigzagJoin.Cols.Add(pkCols[i])
 			}
 
 			if c.FiltersBoundBy(zigzagJoin.On, zigzagCols) {
@@ -1356,7 +1356,7 @@ func (c *CustomFuncs) GenerateInvertedIndexZigzagJoins(
 		zigzagCols := iter.indexCols()
 		for i, cnt := 0, iter.index.KeyColumnCount(); i < cnt; i++ {
 			colID := scanPrivate.Table.ColumnID(iter.index.Column(i).Ordinal)
-			zigzagCols.Remove(int(colID))
+			zigzagCols.Remove(colID)
 		}
 
 		pkIndex := iter.tab.Index(cat.PrimaryIndex)
@@ -1365,7 +1365,7 @@ func (c *CustomFuncs) GenerateInvertedIndexZigzagJoins(
 			pkCols[i] = scanPrivate.Table.ColumnID(pkIndex.Column(i).Ordinal)
 			// Ensure primary key columns are always retrieved from the zigzag
 			// join.
-			zigzagCols.Add(int(pkCols[i]))
+			zigzagCols.Add(pkCols[i])
 		}
 
 		// Case 1 (zigzagged indexes contain all requested columns).
@@ -1385,7 +1385,7 @@ func (c *CustomFuncs) GenerateInvertedIndexZigzagJoins(
 		// Ensure the zigzag join returns pk columns.
 		zigzagJoin.Cols = scanPrivate.Cols.Intersection(zigzagCols)
 		for i := range pkCols {
-			zigzagJoin.Cols.Add(int(pkCols[i]))
+			zigzagJoin.Cols.Add(pkCols[i])
 		}
 
 		if c.FiltersBoundBy(zigzagJoin.On, zigzagCols) {
@@ -1480,13 +1480,13 @@ func (c *CustomFuncs) GenerateStreamingGroupBy(
 		oIdx, intraIdx := 0, 0
 		for ; oIdx < len(o); oIdx++ {
 			oCol := o[oIdx].ID()
-			if private.GroupingCols.Contains(int(oCol)) || intraOrd.Optional.Contains(int(oCol)) {
+			if private.GroupingCols.Contains(oCol) || intraOrd.Optional.Contains(oCol) {
 				// Grouping or optional column.
 				continue
 			}
 
 			if intraIdx < len(intraOrd.Columns) &&
-				intraOrd.Columns[intraIdx].Group.Contains(int(oCol)) &&
+				intraOrd.Columns[intraIdx].Group.Contains(oCol) &&
 				intraOrd.Columns[intraIdx].Descending == o[oIdx].Descending() {
 				// Column matches the one in the ordering.
 				intraIdx++

--- a/pkg/sql/opt/xform/index_scan_builder.go
+++ b/pkg/sql/opt/xform/index_scan_builder.go
@@ -63,7 +63,7 @@ func (b *indexScanBuilder) primaryKeyCols() opt.ColSet {
 	if b.pkCols.Empty() {
 		primaryIndex := b.c.e.mem.Metadata().Table(b.tabID).Index(cat.PrimaryIndex)
 		for i, cnt := 0, primaryIndex.KeyColumnCount(); i < cnt; i++ {
-			b.pkCols.Add(int(b.tabID.ColumnID(primaryIndex.Column(i).Ordinal)))
+			b.pkCols.Add(b.tabID.ColumnID(primaryIndex.Column(i).Ordinal))
 		}
 	}
 	return b.pkCols

--- a/pkg/sql/opt/xform/interesting_orderings.go
+++ b/pkg/sql/opt/xform/interesting_orderings.go
@@ -73,7 +73,7 @@ func interestingOrderingsForScan(scan *memo.ScanExpr) opt.OrderingSet {
 		for j := 0; j < numIndexCols; j++ {
 			indexCol := index.Column(j)
 			colID := scan.Table.ColumnID(indexCol.Ordinal)
-			if !scan.Cols.Contains(int(colID)) {
+			if !scan.Cols.Contains(colID) {
 				break
 			}
 			if o == nil {

--- a/pkg/sql/opt/xform/memo_format.go
+++ b/pkg/sql/opt/xform/memo_format.go
@@ -300,8 +300,8 @@ func (mf *memoFormatter) formatPrivate(e opt.Expr, physProps *physical.Required)
 		}
 
 	case *memo.ProjectExpr:
-		t.Passthrough.ForEach(func(i int) {
-			fmt.Fprintf(mf.buf, " %s", m.Metadata().ColumnMeta(opt.ColumnID(i)).Alias)
+		t.Passthrough.ForEach(func(i opt.ColumnID) {
+			fmt.Fprintf(mf.buf, " %s", m.Metadata().ColumnMeta(i).Alias)
 		})
 	}
 }

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -320,10 +320,10 @@ func calculateMaxResults(
 		if col, err := t.FindColumnByID(id); err != nil {
 			return 0
 		} else if !col.IsNullable() {
-			notNullCols.Add(int(id))
+			notNullCols.Add(opt.ColumnID(id))
 		}
 
-		indexCols.Add(int(id))
+		indexCols.Add(opt.ColumnID(id))
 	}
 
 	return c.CalculateMaxResults(evalCtx, indexCols, notNullCols)
@@ -504,7 +504,7 @@ func (v *indexInfo) makeIndexConstraints(
 		col := opt.MakeOrderingColumn(opt.ColumnID(idx+1), dir == encoding.Descending)
 		columns = append(columns, col)
 		if !v.desc.Columns[idx].Nullable {
-			notNullCols.Add(idx + 1)
+			notNullCols.Add(opt.ColumnID(idx + 1))
 		}
 	}
 	v.ic.Init(filters, columns, notNullCols, isInverted, evalCtx, optimizer.Factory())


### PR DESCRIPTION
Changing `ColSet` from an alias to a properly typed wrapper. We didn't
do this from the start because previous Go versions didn't do
mid-stack inlining. I verified that with go 1.12 the wrapper gets
inlined.

Release note: None