### PR TITLE
storage: deflake TestStoreRangeMergeDuringShutdown

### DIFF
--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -3149,8 +3149,12 @@ func TestStoreRangeMergeDuringShutdown(t *testing.T) {
 		_, err := store.DB().Get(ctx, "dummy-rhs-key")
 		return err
 	})
-	if exp := "not lease holder"; !testutils.IsError(err, exp) {
-		t.Fatalf("expected %q error, but got %v", err, exp)
+	// We really don't expect "node unavailable" here but it does seem to happen
+	// occasionally. It was investigated some in #36086 and we eventually decided
+	// it wasn't worth the time it would time to figure out. Perhaps revist at
+	// some point.
+	if exp := "not lease holder|node unavailable"; !testutils.IsError(err, exp) {
+		t.Fatalf("expected %q error, but got %v", exp, err)
 	}
 }
 


### PR DESCRIPTION
On release-19.1, but not master, this test occasionally gets a "node
unavailable" error instead of a "not leaseholder" error and flakes. This
can happen in two ways.

One is that a NotLeaseHolderError is returned from the
`transport.SendNext` call in `(*DistSender).sendToReplicas`. This seems
to be coming as a result of the race described where
`MergeInProgressError` is returned from `(*Replica).beginCmds`.

The other is a NotLeaseHolderError _is_ returned from
`transport.SendNext`, but it has a hint set, which causes `SendNext` to
be called again. This second time always returns NodeUnavailableError.

The comment on the test mentioned that it was added as a regression for
a fatal error that was fixed, so while it'd be nice to always get the
more specific "not leaseholder" error, "node unavailable" also works.
Add it to the whitelist.

I'm still curious why this doesn't seem to happen on master, but at this
point, I don't believe it's currently worth the time it would take to
figure out what's different

Closes #36086

Release note: None