### PR TITLE
kv: remove double eviction policy in range cache

### DIFF
--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -3202,3 +3202,193 @@ func TestCanSendToFollower(t *testing.T) {
 		}
 	}
 }
+
+// TestEvictMetaRange tests that a query on a stale meta2 range should evict it
+// from the cache.
+func TestEvictMetaRange(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.TODO())
+
+	testutils.RunTrueAndFalse(t, "hasSuggestedRange", func(t *testing.T, hasSuggestedRange bool) {
+		splitKey := keys.RangeMetaKey(roachpb.RKey("b"))
+
+		testMeta1RangeDescriptor := testMetaRangeDescriptor
+		testMeta1RangeDescriptor.EndKey = roachpb.RKey(keys.Meta2Prefix)
+
+		testMeta2RangeDescriptor1 := testMetaRangeDescriptor
+		testMeta2RangeDescriptor1.RangeID = 2
+		testMeta2RangeDescriptor1.StartKey = roachpb.RKey(keys.Meta2Prefix)
+
+		testMeta2RangeDescriptor2 := testMetaRangeDescriptor
+		testMeta2RangeDescriptor2.RangeID = 3
+		testMeta2RangeDescriptor2.StartKey = roachpb.RKey(keys.Meta2Prefix)
+
+		testUserRangeDescriptor1 := roachpb.RangeDescriptor{
+			RangeID:  4,
+			StartKey: roachpb.RKey("a"),
+			EndKey:   roachpb.RKey("b"),
+			InternalReplicas: []roachpb.ReplicaDescriptor{
+				{
+					NodeID:  1,
+					StoreID: 1,
+				},
+			},
+		}
+
+		testUserRangeDescriptor2 := roachpb.RangeDescriptor{
+			RangeID:  5,
+			StartKey: roachpb.RKey("b"),
+			EndKey:   roachpb.RKey("c"),
+			InternalReplicas: []roachpb.ReplicaDescriptor{
+				{
+					NodeID:  1,
+					StoreID: 1,
+				},
+			},
+		}
+
+		clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+		rpcContext := rpc.NewInsecureTestingContext(clock, stopper)
+		g := makeGossip(t, stopper, rpcContext)
+		if err := g.AddInfoProto(gossip.KeyFirstRangeDescriptor, &testMeta1RangeDescriptor, time.Hour); err != nil {
+			t.Fatal(err)
+		}
+
+		isStale := false
+
+		var testFn simpleSendFn = func(
+			_ context.Context,
+			_ SendOptions,
+			_ ReplicaSlice,
+			ba roachpb.BatchRequest,
+		) (*roachpb.BatchResponse, error) {
+			rs, err := keys.Range(ba)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !client.TestingIsRangeLookup(ba) {
+				return ba.CreateReply(), nil
+			}
+
+			if bytes.HasPrefix(rs.Key, keys.Meta1Prefix) {
+				// Querying meta 1 range.
+				br := &roachpb.BatchResponse{}
+				r := &roachpb.ScanResponse{}
+				var kv roachpb.KeyValue
+				if rs.Key.Equal(keys.RangeMetaKey(keys.RangeMetaKey(roachpb.RKey("a")).Next()).Next()) {
+					// Scan request is [/Meta1/a - /Meta2), so return the first meta1
+					// range.
+					if err := kv.Value.SetProto(&testMeta2RangeDescriptor1); err != nil {
+						t.Fatal(err)
+					}
+				} else {
+					// Scan request is [/Meta1/b - /Meta2), so return the second meta1
+					// range. This is needed when no SuggestedRange is returned from the
+					// RangeKeyMismatch error and an additional lookup is needed to
+					// determine the correct meta2 range descriptor.
+					if err := kv.Value.SetProto(&testMeta2RangeDescriptor2); err != nil {
+						t.Fatal(err)
+					}
+				}
+				r.Rows = append(r.Rows, kv)
+				br.Add(r)
+				return br, nil
+			}
+			// Querying meta2 range.
+			br := &roachpb.BatchResponse{}
+			r := &roachpb.ScanResponse{}
+			var kv roachpb.KeyValue
+			if rs.Key.Equal(keys.RangeMetaKey(roachpb.RKey("a")).Next()) {
+				// Scan request is [/Meta2/a - /Meta2/b), so return the first
+				// user range descriptor.
+				if err := kv.Value.SetProto(&testUserRangeDescriptor1); err != nil {
+					t.Fatal(err)
+				}
+			} else if isStale {
+				// Scan request is [/Meta2/b - /Meta2/c). Since we simulate a split of
+				// [/Meta2 - /System) into [/Meta2 - /Meta2/a) and [/Meta2/b - /System)
+				// and we sent the batch request to the stale cached meta2 range
+				// descriptor [/Meta2 - /Meta2/a), we return a RangeKeyMismatchError. We
+				// test for two cases here:
+				// 1) The SuggestedRange is supplied and the correct meta2 range is
+				//    directly inserted into the cache.
+				// 2) The SuggestedRange is not supplied and we have to an additional
+				//    lookup in meta1 to determine the correct meta2 range.
+
+				// Simulate a split.
+				testMeta2RangeDescriptor1.EndKey = splitKey
+				testMeta2RangeDescriptor2.StartKey = splitKey
+				isStale = false
+
+				reply := ba.CreateReply()
+				// Return a RangeKeyMismatchError to simulate the range being stale.
+				err := &roachpb.RangeKeyMismatchError{
+					RequestStartKey: rs.Key.AsRawKey(),
+					RequestEndKey:   rs.EndKey.AsRawKey(),
+					MismatchedRange: &testMeta2RangeDescriptor1,
+				}
+				if hasSuggestedRange {
+					err.SuggestedRange = &testMeta2RangeDescriptor2
+				}
+				reply.Error = roachpb.NewError(err)
+				return reply, nil
+			} else {
+				// Scan request is [/Meta2/b - /Meta2/c) and the range descriptor is
+				// not stale, so return the second user range descriptor.
+				if err := kv.Value.SetProto(&testUserRangeDescriptor2); err != nil {
+					t.Fatal(err)
+				}
+			}
+			r.Rows = append(r.Rows, kv)
+			br.Add(r)
+			return br, nil
+		}
+
+		cfg := DistSenderConfig{
+			AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
+			Clock:      clock,
+			RPCContext: rpcContext,
+			TestingKnobs: ClientTestingKnobs{
+				TransportFactory: adaptSimpleTransport(testFn),
+			},
+			NodeDialer: nodedialer.New(rpcContext, gossip.AddressResolver(g)),
+		}
+		ds := NewDistSender(cfg, g)
+
+		scan := roachpb.NewScan(roachpb.Key("a"), roachpb.Key("b"))
+		if _, pErr := client.SendWrapped(context.Background(), ds, scan); pErr != nil {
+			t.Fatalf("scan encountered error: %s", pErr)
+		}
+
+		// Verify that there is one meta2 cached range.
+		if cachedRange, err := ds.rangeCache.GetCachedRangeDescriptor(keys.RangeMetaKey(roachpb.RKey("a")), false); err != nil {
+			t.Fatal(err)
+		} else if !cachedRange.StartKey.Equal(keys.Meta2Prefix) || !cachedRange.EndKey.Equal(testMetaEndKey) {
+			t.Fatalf("expected cached meta2 range to be [%s, %s), actual [%s, %s)",
+				keys.Meta2Prefix, testMetaEndKey, cachedRange.StartKey, cachedRange.EndKey)
+		}
+
+		// Simulate a split on the meta2 range and mark it as stale.
+		isStale = true
+
+		scan = roachpb.NewScan(roachpb.Key("b"), roachpb.Key("c"))
+		if _, pErr := client.SendWrapped(context.Background(), ds, scan); pErr != nil {
+			t.Fatalf("scan encountered error: %s", pErr)
+		}
+
+		// Verify that there are two meta2 cached ranges.
+		if cachedRange, err := ds.rangeCache.GetCachedRangeDescriptor(keys.RangeMetaKey(roachpb.RKey("a")), false); err != nil {
+			t.Fatal(err)
+		} else if !cachedRange.StartKey.Equal(keys.Meta2Prefix) || !cachedRange.EndKey.Equal(splitKey) {
+			t.Fatalf("expected cached meta2 range to be [%s, %s), actual [%s, %s)",
+				keys.Meta2Prefix, splitKey, cachedRange.StartKey, cachedRange.EndKey)
+		}
+		if cachedRange, err := ds.rangeCache.GetCachedRangeDescriptor(keys.RangeMetaKey(roachpb.RKey("b")), false); err != nil {
+			t.Fatal(err)
+		} else if !cachedRange.StartKey.Equal(splitKey) || !cachedRange.EndKey.Equal(testMetaEndKey) {
+			t.Fatalf("expected cached meta2 range to be [%s, %s), actual [%s, %s)",
+				splitKey, testMetaEndKey, cachedRange.StartKey, cachedRange.EndKey)
+		}
+	})
+}

--- a/pkg/kv/range_cache_test.go
+++ b/pkg/kv/range_cache_test.go
@@ -382,9 +382,12 @@ func TestRangeCache(t *testing.T) {
 	doLookup(ctx, t, db.cache, "vu")
 	db.assertLookupCountEq(t, 1, "vu")
 
-	// Evict clears one level 1 and one level 2 cache
-	//  Evicts [meta(min),meta(g)) and [d,e).
+	// Evicts [d,e).
 	if err := db.cache.EvictCachedRangeDescriptor(ctx, roachpb.RKey("da"), nil, false); err != nil {
+		t.Fatal(err)
+	}
+	// Evicts [meta(min),meta(g)).
+	if err := db.cache.EvictCachedRangeDescriptor(ctx, keys.RangeMetaKey(roachpb.RKey("da")), nil, false); err != nil {
 		t.Fatal(err)
 	}
 	doLookup(ctx, t, db.cache, "fa")
@@ -408,16 +411,16 @@ func TestRangeCache(t *testing.T) {
 	_, evictToken := doLookup(ctx, t, db.cache, "cz")
 	db.assertLookupCountEq(t, 0, "cz")
 	// Now evict with the actual descriptor. The cache should clear the
-	// descriptor and the cached meta key.
-	//  Evicts [meta(min),meta(g)) and [c,d).
+	// descriptor.
+	//  Evicts [c,d).
 	if err := evictToken.Evict(ctx); err != nil {
 		t.Fatal(err)
 	}
-	// Totally uncached range.
-	//  Retrieves [meta(min),meta(g)) and [c,d).
+	// Meta2 range is cached.
+	//  Retrieves [c,d).
 	//  Prefetches [c,e) and [e,f).
 	doLookup(ctx, t, db.cache, "cz")
-	db.assertLookupCountEq(t, 2, "cz")
+	db.assertLookupCountEq(t, 1, "cz")
 }
 
 // TestRangeCacheCoalescedRequests verifies that concurrent lookups for
@@ -591,7 +594,7 @@ func TestRangeCacheDetectSplit(t *testing.T) {
 	if err := evictToken.EvictAndReplace(ctx, mismatchErrRange); err != nil {
 		t.Fatal(err)
 	}
-	pauseLookupResumeAndAssert("az", 2, evictToken)
+	pauseLookupResumeAndAssert("az", 1, evictToken)
 
 	// Both sides of the split are now correctly cached.
 	doLookup(ctx, t, db.cache, "aa")
@@ -656,7 +659,7 @@ func TestRangeCacheDetectSplitReverseScan(t *testing.T) {
 	waitJoin.Wait()
 	db.resumeRangeLookups()
 	wg.Wait()
-	db.assertLookupCount(t, 3, 4, "a and az")
+	db.assertLookupCount(t, 2, 3, "a and az")
 
 	// Both are now correctly cached.
 	doLookupWithToken(ctx, t, db.cache, "a", nil, useReverseScan, nil)
@@ -713,7 +716,7 @@ func testRangeCacheHandleDoubleSplit(t *testing.T, useReverseScan bool) {
 	//   + will lookup the meta2 desc
 	//   + will lookup the ["at"-"b") desc
 	// - "az" will get the right range back
-	// - "at" will make a second lookup
+	// - "ao" and "at" will make a second lookup
 	//   + will lookup the ["an"-"at") desc
 	//
 	// [non-reverse case]
@@ -764,7 +767,7 @@ func testRangeCacheHandleDoubleSplit(t *testing.T, useReverseScan bool) {
 	db.resumeRangeLookups()
 
 	wg.Wait()
-	db.assertLookupCountEq(t, 3, "an and az")
+	db.assertLookupCountEq(t, 2, "an and az")
 	if numRetries == 0 {
 		t.Error("expected retry on desc lookup")
 	}
@@ -940,73 +943,6 @@ func TestRangeCacheClearOverlappingMeta(t *testing.T) {
 			t.Fatal(err)
 		}
 	}()
-}
-
-// TestRangeCacheEvictMetaDescriptors tests that regardless of the eviction key
-// provided to EvictCachedRangeDescriptor, the meta ranges that store the key's
-// descriptor and its meta descriptors are properly evicted. This is related to
-// #18032.
-func TestRangeCacheEvictMetaDescriptors(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	ctx := context.TODO()
-
-	meta1Desc := roachpb.RangeDescriptor{
-		StartKey: roachpb.RKeyMin,
-		EndKey:   keys.MustAddr(keys.Meta2Prefix),
-	}
-	meta2LeftDesc := roachpb.RangeDescriptor{
-		StartKey: meta1Desc.EndKey,
-		EndKey:   keys.RangeMetaKey(roachpb.RKey("m")),
-	}
-	meta2RightDesc := roachpb.RangeDescriptor{
-		StartKey: meta2LeftDesc.EndKey,
-		EndKey:   keys.RangeMetaKey(roachpb.RKey("zzz")).Next(),
-	}
-	restDesc := roachpb.RangeDescriptor{
-		StartKey: meta2RightDesc.EndKey,
-		EndKey:   roachpb.RKey("zzz"),
-	}
-
-	testCases := []struct {
-		evictKey roachpb.RKey
-	}{
-		{evictKey: roachpb.RKey("a")},
-		{evictKey: roachpb.RKey("m")},
-		{evictKey: roachpb.RKey("z")},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.evictKey.String(), func(t *testing.T) {
-			if !restDesc.ContainsKey(tc.evictKey) {
-				t.Fatalf("restDesc must contain evictKey, found %v", tc.evictKey)
-			}
-
-			st := cluster.MakeTestingClusterSettings()
-			cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10))
-			err := cache.InsertRangeDescriptors(ctx, meta1Desc, meta2LeftDesc, meta2RightDesc, restDesc)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			// Evict the user-space descriptor. This should result in the metaRightDesc
-			// being evicted as well, because that is where restDesc is stored. This
-			// is true even if meta(tc.evictKey) addresses into metaLeftDesc. In addition,
-			// the meta1Desc will be evicted, leaving only the meta2RightDesc.
-			err = cache.EvictCachedRangeDescriptor(ctx, tc.evictKey, nil, false)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			exp := []roachpb.RangeDescriptor{meta2LeftDesc}
-			found := []roachpb.RangeDescriptor{}
-			cache.rangeCache.cache.Do(func(k, v interface{}) bool {
-				found = append(found, *v.(*roachpb.RangeDescriptor))
-				return false
-			})
-			if !reflect.DeepEqual(exp, found) {
-				t.Errorf("expected remaining descriptors %v, found %v", exp, found)
-			}
-		})
-	}
 }
 
 // TestGetCachedRangeDescriptorInverted verifies the correctness of the result


### PR DESCRIPTION
Previously if we were evicting a user-space descriptor, meta range descriptors would also be evicted. Evicting meta range descriptors is expensive and we shouldn't do it until we have evidence that they're out-of-date and useless. We should just evict a descriptor when it's found to be stale whether it's a user-space descriptor during normal operation or a meta descriptor during a range lookup.

Fixes: #18988

Release note: None

I've collected metrics to compare this PR against master (`15d4329`) under two workloads while the cluster is running `kv50`.

1. Split workload: Two workers splitting random ranges: `ALTER TABLE kv.kv SPLIT AT VALUES (CAST(ROUND(RANDOM() * 9223372036854775808) AS INT)) WITH EXPIRATION '1s'`
2. Relocate workload: Two workers relocating random ranges: `ALTER TABLE kv.kv EXPERIMENTAL_RELOCATE SELECT ARRAY[%s, %s, %s], CAST(ROUND(RANDOM() * 9223372036854775808) AS INT)`. The new set of replicas is a random subset of the available replicas of size 3.

More details can be found in this [script](https://gist.github.com/jeffrey-xiao/2af9de98a56d8921dc7efa0cf7fb5b5e).

![image](https://user-images.githubusercontent.com/8853434/60835022-233be080-a190-11e9-9302-95eccc6d6acf.png)