### PR TITLE
sql: prohibit offset with GROUPS containing vars

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -2832,6 +2832,9 @@ iPad             {"Microsoft Lumia","HTC One",Nexus,iPhone,"HP Elite","Lenovo Th
 Kindle Fire      {"Microsoft Lumia","HTC One",Nexus,iPhone,"HP Elite","Lenovo Thinkpad","Sony VAIO",Dell,iPad,"Kindle Fire"}
 Samsung          {"Microsoft Lumia","HTC One",Nexus,iPhone,"HP Elite","Lenovo Thinkpad","Sony VAIO",Dell,iPad,"Kindle Fire",Samsung}
 
+statement error GROUPS offset cannot contain variables
+SELECT avg(price) OVER (GROUPS group_id PRECEDING) FROM products
+
 statement error frame starting offset must not be null
 SELECT avg(price) OVER (GROUPS NULL PRECEDING) FROM products
 

--- a/pkg/sql/opt/optbuilder/testdata/window
+++ b/pkg/sql/opt/optbuilder/testdata/window
@@ -1548,3 +1548,8 @@ build
 SELECT rank() OVER (w) FROM kv WINDOW w as (ORDER BY v RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
 ----
 error (42P20): cannot copy window "w" because it has a frame clause
+
+build
+SELECT rank() OVER (ORDER BY k GROUPS k PRECEDING) FROM kv
+----
+error (42601): GROUPS offset cannot contain variables

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -693,6 +693,7 @@ func (expr *ComparisonExpr) TypeCheck(ctx *SemaContext, desired *types.T) (Typed
 
 var (
 	errOrderByIndexInWindow = pgerror.New(pgcode.FeatureNotSupported, "ORDER BY INDEX in window definition is not supported")
+	errVarOffsetGroups      = pgerror.New(pgcode.Syntax, fmt.Sprintf("GROUPS offset cannot contain variables"))
 	errStarNotAllowed       = pgerror.New(pgcode.Syntax, "cannot use \"*\" in this context")
 	errInvalidDefaultUsage  = pgerror.New(pgcode.Syntax, "DEFAULT can only appear in a VALUES list within INSERT or on the right side of a SET")
 	errInvalidMaxUsage      = pgerror.New(pgcode.Syntax, "MAXVALUE can only appear within a range partition expression")
@@ -998,6 +999,16 @@ func (f *WindowFrame) TypeCheck(ctx *SemaContext, windowDef *WindowDef) error {
 			}
 		}
 	case GROUPS:
+		if startBound != nil && startBound.HasOffset() {
+			if ContainsVars(startBound.OffsetExpr) {
+				return errVarOffsetGroups
+			}
+		}
+		if endBound != nil && endBound.HasOffset() {
+			if ContainsVars(endBound.OffsetExpr) {
+				return errVarOffsetGroups
+			}
+		}
 		// In GROUPS mode, offsets must be non-null, non-negative integers.
 		// Non-nullity and non-negativity will be checked later.
 		requiredType = types.Int


### PR DESCRIPTION
This commit adds a check during semantic analysis to verify that a
window function using GROUPS mode does not include an offset expression
containing variable references. This was handled by the heuristic planner
previously, but this places a check earlier so that it's also checked by the
optimizer.

Fixes #38090

Release note: None