### PR TITLE
log: use prefix in std loggers

### DIFF
--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -1381,8 +1381,10 @@ func (lb logBridge) Write(b []byte) (n int, err error) {
 
 // NewStdLogger creates a *stdLog.Logger that forwards messages to the
 // CockroachDB logs with the specified severity.
-func NewStdLogger(severity Severity) *stdLog.Logger {
-	return stdLog.New(logBridge(severity), "", stdLog.Lshortfile)
+//
+// The prefix appears at the beginning of each generated log line.
+func NewStdLogger(severity Severity, prefix string) *stdLog.Logger {
+	return stdLog.New(logBridge(severity), prefix, stdLog.Lshortfile)
 }
 
 // setV computes and remembers the V level for a given PC

--- a/pkg/util/netutil/net.go
+++ b/pkg/util/netutil/net.go
@@ -55,7 +55,7 @@ func ListenAndServeGRPC(
 	return ln, nil
 }
 
-var httpLogger = log.NewStdLogger(log.Severity_ERROR)
+var httpLogger = log.NewStdLogger(log.Severity_ERROR, "httpLogger")
 
 // Server is a thin wrapper around http.Server. See MakeServer for more detail.
 type Server struct {


### PR DESCRIPTION
Distinguish loggers we inject into stdlib packages by prepending a
custom prefix to all their lines. Otherwise it's very confusing looking
at the file:line tags on their lines as they don't seem to make sense.

Release note: None