### PR TITLE
opt: early prototype for FK checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -765,7 +765,7 @@ EXECGEN_TARGETS = \
 EXECGEN_EXCLUSION_STRING = $(shell echo ${EXECGEN_TARGETS} | sed 's/ / -e /g')
 
 $(info Cleaning old generated files.)
-$(shell find ./pkg/sql/exec -type f -name '*.eg.go' | grep -v -e ${EXECGEN_EXCLUSION_STRING} | xargs rm)
+$(shell find ./pkg/sql/exec -type f -name '*.eg.go' | grep -v -e ${EXECGEN_EXCLUSION_STRING} | xargs --no-run-if-empty rm)
 
 OPTGEN_TARGETS = \
 	pkg/sql/opt/memo/expr.og.go \

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -245,15 +245,20 @@ func formatCatalogFKRef(
 	if inbound {
 		title = "REFERENCED BY " + title
 	}
+	match := ""
+	if fkRef.MatchMethod() != tree.MatchSimple {
+		match = fmt.Sprintf(" %s", fkRef.MatchMethod())
+	}
 
 	tp.Childf(
-		"%s %s FOREIGN KEY %v %s REFERENCES %v %s",
+		"%s %s FOREIGN KEY %v %s REFERENCES %v %s%s",
 		title,
 		fkRef.Name(),
 		originDS.Name(),
 		formatCols(originDS.(Table), fkRef.ColumnCount(), fkRef.OriginColumnOrdinal),
 		refDS.Name(),
 		formatCols(refDS.(Table), fkRef.ColumnCount(), fkRef.ReferencedColumnOrdinal),
+		match,
 	)
 }
 

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -548,6 +548,12 @@ func (f *ExprFmtCtx) formatScalar(scalar opt.ScalarExpr, tp treeprinter.Node) {
 		f.formatExpr(scalar.Child(1), tp.Child("filter"))
 
 		return
+
+	case opt.FKChecksOp:
+		if scalar.ChildCount() == 0 {
+			// Hide the FK checks field when there are no checks.
+			return
+		}
 	}
 
 	// Don't show scalar-list, as it's redundant with its parent.

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -563,6 +563,12 @@ func (h *hasher) HashZipExpr(val ZipExpr) {
 	}
 }
 
+func (h *hasher) HashFKChecksExpr(val FKChecksExpr) {
+	for i := range val {
+		h.HashRelExpr(val[i].Check)
+	}
+}
+
 func (h *hasher) HashPresentation(val physical.Presentation) {
 	for i := range val {
 		col := &val[i]
@@ -862,6 +868,18 @@ func (h *hasher) IsZipExprEqual(l, r ZipExpr) bool {
 	}
 	for i := range l {
 		if !l[i].Cols.Equals(r[i].Cols) || l[i].Func != r[i].Func {
+			return false
+		}
+	}
+	return true
+}
+
+func (h *hasher) IsFKChecksExprEqual(l, r FKChecksExpr) bool {
+	if len(l) != len(r) {
+		return false
+	}
+	for i := range l {
+		if l[i].Check != r[i].Check {
 			return false
 		}
 	}

--- a/pkg/sql/opt/norm/rules/prune_cols.opt
+++ b/pkg/sql/opt/norm/rules/prune_cols.opt
@@ -433,6 +433,7 @@
 [PruneMutationFetchCols, Normalize]
 (Update | Upsert | Delete
     $input:*
+    $checks:*
     $mutationPrivate:* &
         (CanPruneMutationFetchCols
             $mutationPrivate
@@ -442,6 +443,7 @@
 =>
 ((OpName)
     $input
+    $checks
     (PruneMutationFetchCols $mutationPrivate $needed)
 )
 
@@ -450,11 +452,13 @@
 [PruneMutationInputCols, Normalize]
 (Insert | Update | Upsert | Delete
     $input:*
+    $checks:*
     $mutationPrivate:* &
         (CanPruneCols $input $needed:(NeededMutationCols $mutationPrivate))
 )
 =>
 ((OpName)
     (PruneCols $input $needed)
+    $checks
     $mutationPrivate
 )

--- a/pkg/sql/opt/ops/statement.opt
+++ b/pkg/sql/opt/ops/statement.opt
@@ -23,6 +23,7 @@
 [Relational, Mutation]
 define Insert {
     Input RelExpr
+    Checks FKChecksExpr
 
     _ MutationPrivate
 }
@@ -136,6 +137,7 @@ define MutationPrivate {
 [Relational, Mutation]
 define Update {
     Input RelExpr
+    Checks FKChecksExpr
 
     _ MutationPrivate
 }
@@ -159,6 +161,7 @@ define Update {
 [Relational, Mutation]
 define Upsert {
     Input RelExpr
+    Checks FKChecksExpr
 
     _ MutationPrivate
 }
@@ -171,8 +174,23 @@ define Upsert {
 [Relational, Mutation]
 define Delete {
     Input RelExpr
+    Checks FKChecksExpr
 
     _ MutationPrivate
+}
+
+# FKChecks is a list of foreign key check queries, to be run after the main
+# query.
+[Scalar, List]
+define FKChecks {
+}
+
+# FKChecksItem is a foreign key check query, to be run after the main query.
+# An execution error will be generated if the query returns any results.
+[Scalar, ListItem]
+define FKChecksItem {
+    Check RelExpr
+    # TODO(radu): information for making a good error message.
 }
 
 # CreateTable represents a CREATE TABLE statement.

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -51,6 +51,12 @@ import (
 // See factory.go and memo.go inside the opt/xform package for more details
 // about the memo structure.
 type Builder struct {
+
+	// -- Control knobs --
+	//
+	// These fields can be set before calling Build to control various aspects of
+	// the building process.
+
 	// AllowUnsupportedExpr is a control knob: if set, when building a scalar, the
 	// builder takes any TypedExpr node that it doesn't recognize and wraps that
 	// expression in an UnsupportedExpr node. This is temporary; it is used for
@@ -61,6 +67,15 @@ type Builder struct {
 	// a placeholder operator with its assigned value, even when it is available.
 	// This is used when re-preparing invalidated queries.
 	KeepPlaceholders bool
+
+	// BuildFKChecks is a control knob: if set, we build foreign key checks (see
+	// the ForeignKeys operator).
+	BuildFKChecks bool
+
+	// -- Results --
+	//
+	// These fields are set during the building process and can be used after
+	// Build is called.
 
 	// IsCorrelated is set to true during semantic analysis if a scalar variable was
 	// pulled from an outer scope, that is, if the query was found to be correlated.

--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -65,6 +65,7 @@ func TestBuilder(t *testing.T) {
 			var err error
 
 			tester := opttester.New(catalog, d.Input)
+			tester.Flags.BuildFKChecks = true
 			tester.Flags.ExprFormat = memo.ExprFmtHideMiscProps |
 				memo.ExprFmtHideConstraints |
 				memo.ExprFmtHideFuncDeps |

--- a/pkg/sql/opt/optbuilder/delete.go
+++ b/pkg/sql/opt/optbuilder/delete.go
@@ -86,7 +86,7 @@ func (b *Builder) buildDelete(del *tree.Delete, inScope *scope) (outScope *scope
 // operator that corresponds to the given RETURNING clause.
 func (mb *mutationBuilder) buildDelete(returning tree.ReturningExprs) {
 	private := mb.makeMutationPrivate(returning != nil)
-	mb.outScope.expr = mb.b.factory.ConstructDelete(mb.outScope.expr, private)
+	mb.outScope.expr = mb.b.factory.ConstructDelete(mb.outScope.expr, mb.checks, private)
 
 	mb.buildReturning(returning)
 }

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -617,8 +617,10 @@ func (mb *mutationBuilder) buildInsert(returning tree.ReturningExprs) {
 	// Add any check constraint boolean columns to the input.
 	mb.addCheckConstraintCols()
 
+	mb.buildFKChecks()
+
 	private := mb.makeMutationPrivate(returning != nil)
-	mb.outScope.expr = mb.b.factory.ConstructInsert(mb.outScope.expr, private)
+	mb.outScope.expr = mb.b.factory.ConstructInsert(mb.outScope.expr, mb.checks, private)
 
 	mb.buildReturning(returning)
 }
@@ -871,7 +873,7 @@ func (mb *mutationBuilder) buildUpsert(returning tree.ReturningExprs) {
 	mb.addCheckConstraintCols()
 
 	private := mb.makeMutationPrivate(returning != nil)
-	mb.outScope.expr = mb.b.factory.ConstructUpsert(mb.outScope.expr, private)
+	mb.outScope.expr = mb.b.factory.ConstructUpsert(mb.outScope.expr, mb.checks, private)
 
 	mb.buildReturning(returning)
 }

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -123,6 +123,9 @@ type mutationBuilder struct {
 	// parsedExprs is a cached set of parsed default and computed expressions
 	// from the table schema. These are parsed once and cached for reuse.
 	parsedExprs []tree.Expr
+
+	// checks contains foreign key check queries; see buildFKChecks.
+	checks memo.FKChecksExpr
 }
 
 func (mb *mutationBuilder) init(b *Builder, op opt.Operator, tab cat.Table, alias tree.TableName) {
@@ -737,6 +740,147 @@ func (mb *mutationBuilder) parseDefaultOrComputedExpr(colID opt.ColumnID) tree.E
 
 	mb.parsedExprs[ord] = expr
 	return expr
+}
+
+// buildFKChecks populates mb.checks with queries that check the integrity of
+// foreign key relations that involve modified rows.
+func (mb *mutationBuilder) buildFKChecks() {
+	if !mb.b.BuildFKChecks {
+		return
+	}
+
+	// TODO(radu): only insert supported for now.
+	if mb.op != opt.InsertOp {
+		return
+	}
+
+	for i, n := 0, mb.tab.OutboundForeignKeyCount(); i < n; i++ {
+		fk := mb.tab.OutboundForeignKey(i)
+		numCols := fk.ColumnCount()
+
+		// Build an anti-join, with the origin FK columns on the left and the
+		// referenced columns on the right.
+
+		refTab, err := mb.b.catalog.ResolveDataSourceByID(mb.b.ctx, fk.ReferencedTableID())
+		if err != nil {
+			panic(builderError{err})
+		}
+		refOrdinals := make([]int, numCols)
+		for j := range refOrdinals {
+			refOrdinals[j] = fk.ReferencedColumnOrdinal(refTab.(cat.Table), j)
+		}
+
+		scanScope := mb.b.buildScan(
+			refTab.(cat.Table),
+			refTab.Name(),
+			refOrdinals,
+			&tree.IndexFlags{IgnoreForeignKeys: true},
+			includeMutations,
+			mb.b.allocScope(),
+		)
+
+		antiJoinFilters := make(memo.FiltersExpr, numCols)
+
+		var originCols opt.ColSet
+		var nullableOriginCols opt.ColSet
+		for j := 0; j < numCols; j++ {
+			ord := fk.OriginColumnOrdinal(mb.tab, j)
+			inputColID := mb.insertColID(ord)
+			if inputColID == 0 {
+				// There shouldn't be any FK relations involving delete-only mutation
+				// columns.
+				panic(errors.AssertionFailedf("no value for FK column %d", ord))
+			}
+			originCols.Add(inputColID)
+
+			// If a table column is not nullable, NULLs cannot be inserted (the
+			// mutation will fail).
+			if mb.tab.Column(ord).IsNullable() &&
+				!mb.outScope.expr.Relational().NotNullCols.Contains(inputColID) {
+				nullableOriginCols.Add(inputColID)
+			}
+
+			antiJoinFilters[j].Condition = mb.b.factory.ConstructEq(
+				mb.b.factory.ConstructVariable(inputColID),
+				mb.b.factory.ConstructVariable(scanScope.cols[j].id),
+			)
+		}
+
+		// TODO(radu): this is a major hack; we should be using a reference to a
+		// buffer instead of reusing the expression directly. This is for
+		// prototyping purposes (should work ok with constant inputs). Note that
+		// the column IDs in the FK check query aren't exposed by the ForeignKeys
+		// operator so using the same column IDs shouldn't cause issues.
+		left := mb.b.factory.ConstructProject(mb.outScope.expr,
+			memo.EmptyProjectionsExpr, originCols)
+
+		if !nullableOriginCols.Empty() {
+			// The columns we are inserting might have NULLs. These require special
+			// handling, depending on the match method:
+			//  - MATCH SIMPLE: allows any column(s) to be NULL and the row doesn't
+			//                  need to have a match in the referenced table.
+			//  - MATCH FULL: only the case where *all* the columns are NULL is
+			//                allowed, and the row doesn't need to have a match in the
+			//                referenced table.
+			//
+			// Note that rows that have NULLs will never have a match in the anti
+			// join and will generate errors. To handle these cases, we filter the
+			// mutated rows (before the anti join) to remove those which don't need a
+			// match.
+			//
+			// For SIMPLE, we filter out any rows which have a NULL. For FULL, we
+			// filter out any rows where all the columns are NULL (rows which have
+			// NULLs a subset of columns are let through and will generate FK errors
+			// because they will never have a match in the anti join).
+			switch m := fk.MatchMethod(); m {
+			case tree.MatchSimple:
+				// Filter out any rows which have a NULL; build filters of the form
+				//   (a IS NOT NULL) AND (b IS NOT NULL) ...
+				filters := make(memo.FiltersExpr, 0, nullableOriginCols.Len())
+				for col, ok := nullableOriginCols.Next(0); ok; col, ok = nullableOriginCols.Next(col + 1) {
+					filters = append(filters, memo.FiltersItem{
+						Condition: mb.b.factory.ConstructIsNot(
+							mb.b.factory.ConstructVariable(col),
+							memo.NullSingleton,
+						),
+					})
+				}
+				left = mb.b.factory.ConstructSelect(left, filters)
+
+			case tree.MatchFull:
+				// Filter out any rows which have NULLs on all referencing columns.
+				if !nullableOriginCols.Equals(originCols) {
+					// We statically know that some of the referencing columns can't be
+					// NULL. In this case, we don't need to filter anything.
+					break
+				}
+				// Build a filter of the form
+				//   (a IS NOT NULL) OR (b IS NOT NULL) ...
+				var condition opt.ScalarExpr
+				for col, ok := originCols.Next(0); ok; col, ok = originCols.Next(col + 1) {
+					is := mb.b.factory.ConstructIsNot(
+						mb.b.factory.ConstructVariable(col),
+						memo.NullSingleton,
+					)
+					if condition == nil {
+						condition = is
+					} else {
+						condition = mb.b.factory.ConstructOr(condition, is)
+					}
+				}
+				left = mb.b.factory.ConstructSelect(left, memo.FiltersExpr{{Condition: condition}})
+
+			default:
+				panic(errors.AssertionFailedf("match method %s not supported", m))
+			}
+		}
+
+		expr := mb.b.factory.ConstructAntiJoin(
+			left, scanScope.expr, antiJoinFilters, &memo.JoinPrivate{},
+		)
+
+		mb.checks = append(mb.checks, memo.FKChecksItem{Check: expr})
+	}
 }
 
 // findNotNullIndexCol finds the first not-null column in the given index and

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
@@ -1,0 +1,646 @@
+exec-ddl
+CREATE TABLE parent (p INT PRIMARY KEY, other INT)
+----
+
+exec-ddl
+CREATE TABLE child (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(p))
+----
+
+build
+INSERT INTO child VALUES (100, 1), (200, 1)
+----
+insert child
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├──  column1:3 => c:1
+ │    └──  column2:4 => child.p:2
+ ├── values
+ │    ├── columns: column1:3(int!null) column2:4(int!null)
+ │    ├── tuple [type=tuple{int, int}]
+ │    │    ├── const: 100 [type=int]
+ │    │    └── const: 1 [type=int]
+ │    └── tuple [type=tuple{int, int}]
+ │         ├── const: 200 [type=int]
+ │         └── const: 1 [type=int]
+ └── f-k-checks
+      └── f-k-checks-item [type=undefined]
+           └── anti-join
+                ├── columns: column2:4(int!null)
+                ├── project
+                │    ├── columns: column2:4(int!null)
+                │    └── values
+                │         ├── columns: column1:3(int!null) column2:4(int!null)
+                │         ├── tuple [type=tuple{int, int}]
+                │         │    ├── const: 100 [type=int]
+                │         │    └── const: 1 [type=int]
+                │         └── tuple [type=tuple{int, int}]
+                │              ├── const: 200 [type=int]
+                │              └── const: 1 [type=int]
+                ├── scan t.public.parent
+                │    └── columns: t.public.parent.p:5(int!null)
+                └── filters
+                     └── eq [type=bool]
+                          ├── variable: column2 [type=int]
+                          └── variable: t.public.parent.p [type=int]
+
+exec-ddl
+CREATE TABLE child_nullable (c INT PRIMARY KEY, p INT REFERENCES parent(p));
+----
+
+# Because the input column can be NULL (in which case it requires no FK match),
+# we have to add an extra filter.
+build
+INSERT INTO child_nullable VALUES (100, 1), (200, NULL)
+----
+insert child_nullable
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├──  column1:3 => c:1
+ │    └──  column2:4 => child_nullable.p:2
+ ├── values
+ │    ├── columns: column1:3(int!null) column2:4(int)
+ │    ├── tuple [type=tuple{int, int}]
+ │    │    ├── const: 100 [type=int]
+ │    │    └── const: 1 [type=int]
+ │    └── tuple [type=tuple{int, int}]
+ │         ├── const: 200 [type=int]
+ │         └── cast: INT8 [type=int]
+ │              └── null [type=unknown]
+ └── f-k-checks
+      └── f-k-checks-item [type=undefined]
+           └── anti-join
+                ├── columns: column2:4(int!null)
+                ├── select
+                │    ├── columns: column2:4(int!null)
+                │    ├── project
+                │    │    ├── columns: column2:4(int)
+                │    │    └── values
+                │    │         ├── columns: column1:3(int!null) column2:4(int)
+                │    │         ├── tuple [type=tuple{int, int}]
+                │    │         │    ├── const: 100 [type=int]
+                │    │         │    └── const: 1 [type=int]
+                │    │         └── tuple [type=tuple{int, int}]
+                │    │              ├── const: 200 [type=int]
+                │    │              └── cast: INT8 [type=int]
+                │    │                   └── null [type=unknown]
+                │    └── filters
+                │         └── is-not [type=bool]
+                │              ├── variable: column2 [type=int]
+                │              └── null [type=unknown]
+                ├── scan t.public.parent
+                │    └── columns: t.public.parent.p:5(int!null)
+                └── filters
+                     └── eq [type=bool]
+                          ├── variable: column2 [type=int]
+                          └── variable: t.public.parent.p [type=int]
+
+# The column is nullable but we know that the input is not null, so we don't
+# need to plan the filter.
+build
+INSERT INTO child_nullable VALUES (100, 1), (200, 1)
+----
+insert child_nullable
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├──  column1:3 => c:1
+ │    └──  column2:4 => child_nullable.p:2
+ ├── values
+ │    ├── columns: column1:3(int!null) column2:4(int!null)
+ │    ├── tuple [type=tuple{int, int}]
+ │    │    ├── const: 100 [type=int]
+ │    │    └── const: 1 [type=int]
+ │    └── tuple [type=tuple{int, int}]
+ │         ├── const: 200 [type=int]
+ │         └── const: 1 [type=int]
+ └── f-k-checks
+      └── f-k-checks-item [type=undefined]
+           └── anti-join
+                ├── columns: column2:4(int!null)
+                ├── project
+                │    ├── columns: column2:4(int!null)
+                │    └── values
+                │         ├── columns: column1:3(int!null) column2:4(int!null)
+                │         ├── tuple [type=tuple{int, int}]
+                │         │    ├── const: 100 [type=int]
+                │         │    └── const: 1 [type=int]
+                │         └── tuple [type=tuple{int, int}]
+                │              ├── const: 200 [type=int]
+                │              └── const: 1 [type=int]
+                ├── scan t.public.parent
+                │    └── columns: t.public.parent.p:5(int!null)
+                └── filters
+                     └── eq [type=bool]
+                          ├── variable: column2 [type=int]
+                          └── variable: t.public.parent.p [type=int]
+
+# Check planning of filter with FULL match (which should be the same on a
+# single column).
+exec-ddl
+CREATE TABLE child_nullable_full (c INT PRIMARY KEY, p INT REFERENCES parent(p) MATCH FULL)
+----
+
+build
+INSERT INTO child_nullable_full VALUES (100, 1), (200, NULL)
+----
+insert child_nullable_full
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├──  column1:3 => c:1
+ │    └──  column2:4 => child_nullable_full.p:2
+ ├── values
+ │    ├── columns: column1:3(int!null) column2:4(int)
+ │    ├── tuple [type=tuple{int, int}]
+ │    │    ├── const: 100 [type=int]
+ │    │    └── const: 1 [type=int]
+ │    └── tuple [type=tuple{int, int}]
+ │         ├── const: 200 [type=int]
+ │         └── cast: INT8 [type=int]
+ │              └── null [type=unknown]
+ └── f-k-checks
+      └── f-k-checks-item [type=undefined]
+           └── anti-join
+                ├── columns: column2:4(int!null)
+                ├── select
+                │    ├── columns: column2:4(int!null)
+                │    ├── project
+                │    │    ├── columns: column2:4(int)
+                │    │    └── values
+                │    │         ├── columns: column1:3(int!null) column2:4(int)
+                │    │         ├── tuple [type=tuple{int, int}]
+                │    │         │    ├── const: 100 [type=int]
+                │    │         │    └── const: 1 [type=int]
+                │    │         └── tuple [type=tuple{int, int}]
+                │    │              ├── const: 200 [type=int]
+                │    │              └── cast: INT8 [type=int]
+                │    │                   └── null [type=unknown]
+                │    └── filters
+                │         └── is-not [type=bool]
+                │              ├── variable: column2 [type=int]
+                │              └── null [type=unknown]
+                ├── scan t.public.parent
+                │    └── columns: t.public.parent.p:5(int!null)
+                └── filters
+                     └── eq [type=bool]
+                          ├── variable: column2 [type=int]
+                          └── variable: t.public.parent.p [type=int]
+
+# Tests with multicolumn FKs.
+exec-ddl
+CREATE TABLE multi_col_parent (p INT, q INT, r INT, other INT, PRIMARY KEY (p, q, r))
+----
+
+exec-ddl
+CREATE TABLE multi_col_child  (
+  c INT PRIMARY KEY,
+  p INT, q INT, r INT,
+  CONSTRAINT fk FOREIGN KEY (p,q,r) REFERENCES multi_col_parent(p,q,r) MATCH SIMPLE
+)
+----
+
+# All columns are nullable and must be part of the filter.
+build
+INSERT INTO multi_col_child VALUES (4, NULL, NULL, NULL)
+----
+insert multi_col_child
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├──  column1:5 => c:1
+ │    ├──  column2:6 => multi_col_child.p:2
+ │    ├──  column3:7 => multi_col_child.q:3
+ │    └──  column4:8 => multi_col_child.r:4
+ ├── values
+ │    ├── columns: column1:5(int!null) column2:6(int) column3:7(int) column4:8(int)
+ │    └── tuple [type=tuple{int, int, int, int}]
+ │         ├── const: 4 [type=int]
+ │         ├── cast: INT8 [type=int]
+ │         │    └── null [type=unknown]
+ │         ├── cast: INT8 [type=int]
+ │         │    └── null [type=unknown]
+ │         └── cast: INT8 [type=int]
+ │              └── null [type=unknown]
+ └── f-k-checks
+      └── f-k-checks-item [type=undefined]
+           └── anti-join
+                ├── columns: column2:6(int!null) column3:7(int!null) column4:8(int!null)
+                ├── select
+                │    ├── columns: column2:6(int!null) column3:7(int!null) column4:8(int!null)
+                │    ├── project
+                │    │    ├── columns: column2:6(int) column3:7(int) column4:8(int)
+                │    │    └── values
+                │    │         ├── columns: column1:5(int!null) column2:6(int) column3:7(int) column4:8(int)
+                │    │         └── tuple [type=tuple{int, int, int, int}]
+                │    │              ├── const: 4 [type=int]
+                │    │              ├── cast: INT8 [type=int]
+                │    │              │    └── null [type=unknown]
+                │    │              ├── cast: INT8 [type=int]
+                │    │              │    └── null [type=unknown]
+                │    │              └── cast: INT8 [type=int]
+                │    │                   └── null [type=unknown]
+                │    └── filters
+                │         ├── is-not [type=bool]
+                │         │    ├── variable: column2 [type=int]
+                │         │    └── null [type=unknown]
+                │         ├── is-not [type=bool]
+                │         │    ├── variable: column3 [type=int]
+                │         │    └── null [type=unknown]
+                │         └── is-not [type=bool]
+                │              ├── variable: column4 [type=int]
+                │              └── null [type=unknown]
+                ├── scan t.public.multi_col_parent
+                │    └── columns: t.public.multi_col_parent.p:9(int!null) t.public.multi_col_parent.q:10(int!null) t.public.multi_col_parent.r:11(int!null)
+                └── filters
+                     ├── eq [type=bool]
+                     │    ├── variable: column2 [type=int]
+                     │    └── variable: t.public.multi_col_parent.p [type=int]
+                     ├── eq [type=bool]
+                     │    ├── variable: column3 [type=int]
+                     │    └── variable: t.public.multi_col_parent.q [type=int]
+                     └── eq [type=bool]
+                          ├── variable: column4 [type=int]
+                          └── variable: t.public.multi_col_parent.r [type=int]
+
+# Only p and q are nullable.
+build
+INSERT INTO multi_col_child VALUES (2, NULL, 20, 20), (3, 20, NULL, 20)
+----
+insert multi_col_child
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├──  column1:5 => c:1
+ │    ├──  column2:6 => multi_col_child.p:2
+ │    ├──  column3:7 => multi_col_child.q:3
+ │    └──  column4:8 => multi_col_child.r:4
+ ├── values
+ │    ├── columns: column1:5(int!null) column2:6(int) column3:7(int) column4:8(int!null)
+ │    ├── tuple [type=tuple{int, int, int, int}]
+ │    │    ├── const: 2 [type=int]
+ │    │    ├── cast: INT8 [type=int]
+ │    │    │    └── null [type=unknown]
+ │    │    ├── const: 20 [type=int]
+ │    │    └── const: 20 [type=int]
+ │    └── tuple [type=tuple{int, int, int, int}]
+ │         ├── const: 3 [type=int]
+ │         ├── const: 20 [type=int]
+ │         ├── cast: INT8 [type=int]
+ │         │    └── null [type=unknown]
+ │         └── const: 20 [type=int]
+ └── f-k-checks
+      └── f-k-checks-item [type=undefined]
+           └── anti-join
+                ├── columns: column2:6(int!null) column3:7(int!null) column4:8(int!null)
+                ├── select
+                │    ├── columns: column2:6(int!null) column3:7(int!null) column4:8(int!null)
+                │    ├── project
+                │    │    ├── columns: column2:6(int) column3:7(int) column4:8(int!null)
+                │    │    └── values
+                │    │         ├── columns: column1:5(int!null) column2:6(int) column3:7(int) column4:8(int!null)
+                │    │         ├── tuple [type=tuple{int, int, int, int}]
+                │    │         │    ├── const: 2 [type=int]
+                │    │         │    ├── cast: INT8 [type=int]
+                │    │         │    │    └── null [type=unknown]
+                │    │         │    ├── const: 20 [type=int]
+                │    │         │    └── const: 20 [type=int]
+                │    │         └── tuple [type=tuple{int, int, int, int}]
+                │    │              ├── const: 3 [type=int]
+                │    │              ├── const: 20 [type=int]
+                │    │              ├── cast: INT8 [type=int]
+                │    │              │    └── null [type=unknown]
+                │    │              └── const: 20 [type=int]
+                │    └── filters
+                │         ├── is-not [type=bool]
+                │         │    ├── variable: column2 [type=int]
+                │         │    └── null [type=unknown]
+                │         └── is-not [type=bool]
+                │              ├── variable: column3 [type=int]
+                │              └── null [type=unknown]
+                ├── scan t.public.multi_col_parent
+                │    └── columns: t.public.multi_col_parent.p:9(int!null) t.public.multi_col_parent.q:10(int!null) t.public.multi_col_parent.r:11(int!null)
+                └── filters
+                     ├── eq [type=bool]
+                     │    ├── variable: column2 [type=int]
+                     │    └── variable: t.public.multi_col_parent.p [type=int]
+                     ├── eq [type=bool]
+                     │    ├── variable: column3 [type=int]
+                     │    └── variable: t.public.multi_col_parent.q [type=int]
+                     └── eq [type=bool]
+                          ├── variable: column4 [type=int]
+                          └── variable: t.public.multi_col_parent.r [type=int]
+
+# All the FK columns are not-null; no filter necessary.
+build
+INSERT INTO multi_col_child VALUES (1, 10, 10, 10)
+----
+insert multi_col_child
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├──  column1:5 => c:1
+ │    ├──  column2:6 => multi_col_child.p:2
+ │    ├──  column3:7 => multi_col_child.q:3
+ │    └──  column4:8 => multi_col_child.r:4
+ ├── values
+ │    ├── columns: column1:5(int!null) column2:6(int!null) column3:7(int!null) column4:8(int!null)
+ │    └── tuple [type=tuple{int, int, int, int}]
+ │         ├── const: 1 [type=int]
+ │         ├── const: 10 [type=int]
+ │         ├── const: 10 [type=int]
+ │         └── const: 10 [type=int]
+ └── f-k-checks
+      └── f-k-checks-item [type=undefined]
+           └── anti-join
+                ├── columns: column2:6(int!null) column3:7(int!null) column4:8(int!null)
+                ├── project
+                │    ├── columns: column2:6(int!null) column3:7(int!null) column4:8(int!null)
+                │    └── values
+                │         ├── columns: column1:5(int!null) column2:6(int!null) column3:7(int!null) column4:8(int!null)
+                │         └── tuple [type=tuple{int, int, int, int}]
+                │              ├── const: 1 [type=int]
+                │              ├── const: 10 [type=int]
+                │              ├── const: 10 [type=int]
+                │              └── const: 10 [type=int]
+                ├── scan t.public.multi_col_parent
+                │    └── columns: t.public.multi_col_parent.p:9(int!null) t.public.multi_col_parent.q:10(int!null) t.public.multi_col_parent.r:11(int!null)
+                └── filters
+                     ├── eq [type=bool]
+                     │    ├── variable: column2 [type=int]
+                     │    └── variable: t.public.multi_col_parent.p [type=int]
+                     ├── eq [type=bool]
+                     │    ├── variable: column3 [type=int]
+                     │    └── variable: t.public.multi_col_parent.q [type=int]
+                     └── eq [type=bool]
+                          ├── variable: column4 [type=int]
+                          └── variable: t.public.multi_col_parent.r [type=int]
+
+exec-ddl
+CREATE TABLE multi_col_child_full  (
+  c INT PRIMARY KEY,
+  p INT, q INT, r INT,
+  CONSTRAINT fk FOREIGN KEY (p,q,r) REFERENCES multi_col_parent(p,q,r) MATCH FULL
+)
+----
+
+# All columns are nullable and must be part of the filter.
+build
+INSERT INTO multi_col_child_full VALUES (4, NULL, NULL, NULL)
+----
+insert multi_col_child_full
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├──  column1:5 => c:1
+ │    ├──  column2:6 => multi_col_child_full.p:2
+ │    ├──  column3:7 => multi_col_child_full.q:3
+ │    └──  column4:8 => multi_col_child_full.r:4
+ ├── values
+ │    ├── columns: column1:5(int!null) column2:6(int) column3:7(int) column4:8(int)
+ │    └── tuple [type=tuple{int, int, int, int}]
+ │         ├── const: 4 [type=int]
+ │         ├── cast: INT8 [type=int]
+ │         │    └── null [type=unknown]
+ │         ├── cast: INT8 [type=int]
+ │         │    └── null [type=unknown]
+ │         └── cast: INT8 [type=int]
+ │              └── null [type=unknown]
+ └── f-k-checks
+      └── f-k-checks-item [type=undefined]
+           └── anti-join
+                ├── columns: column2:6(int) column3:7(int) column4:8(int)
+                ├── select
+                │    ├── columns: column2:6(int) column3:7(int) column4:8(int)
+                │    ├── project
+                │    │    ├── columns: column2:6(int) column3:7(int) column4:8(int)
+                │    │    └── values
+                │    │         ├── columns: column1:5(int!null) column2:6(int) column3:7(int) column4:8(int)
+                │    │         └── tuple [type=tuple{int, int, int, int}]
+                │    │              ├── const: 4 [type=int]
+                │    │              ├── cast: INT8 [type=int]
+                │    │              │    └── null [type=unknown]
+                │    │              ├── cast: INT8 [type=int]
+                │    │              │    └── null [type=unknown]
+                │    │              └── cast: INT8 [type=int]
+                │    │                   └── null [type=unknown]
+                │    └── filters
+                │         └── or [type=bool]
+                │              ├── or [type=bool]
+                │              │    ├── is-not [type=bool]
+                │              │    │    ├── variable: column2 [type=int]
+                │              │    │    └── null [type=unknown]
+                │              │    └── is-not [type=bool]
+                │              │         ├── variable: column3 [type=int]
+                │              │         └── null [type=unknown]
+                │              └── is-not [type=bool]
+                │                   ├── variable: column4 [type=int]
+                │                   └── null [type=unknown]
+                ├── scan t.public.multi_col_parent
+                │    └── columns: t.public.multi_col_parent.p:9(int!null) t.public.multi_col_parent.q:10(int!null) t.public.multi_col_parent.r:11(int!null)
+                └── filters
+                     ├── eq [type=bool]
+                     │    ├── variable: column2 [type=int]
+                     │    └── variable: t.public.multi_col_parent.p [type=int]
+                     ├── eq [type=bool]
+                     │    ├── variable: column3 [type=int]
+                     │    └── variable: t.public.multi_col_parent.q [type=int]
+                     └── eq [type=bool]
+                          ├── variable: column4 [type=int]
+                          └── variable: t.public.multi_col_parent.r [type=int]
+
+# Only p and q are nullable; no filter necessary.
+build
+INSERT INTO multi_col_child_full VALUES (2, NULL, 20, 20), (3, 20, NULL, 20)
+----
+insert multi_col_child_full
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├──  column1:5 => c:1
+ │    ├──  column2:6 => multi_col_child_full.p:2
+ │    ├──  column3:7 => multi_col_child_full.q:3
+ │    └──  column4:8 => multi_col_child_full.r:4
+ ├── values
+ │    ├── columns: column1:5(int!null) column2:6(int) column3:7(int) column4:8(int!null)
+ │    ├── tuple [type=tuple{int, int, int, int}]
+ │    │    ├── const: 2 [type=int]
+ │    │    ├── cast: INT8 [type=int]
+ │    │    │    └── null [type=unknown]
+ │    │    ├── const: 20 [type=int]
+ │    │    └── const: 20 [type=int]
+ │    └── tuple [type=tuple{int, int, int, int}]
+ │         ├── const: 3 [type=int]
+ │         ├── const: 20 [type=int]
+ │         ├── cast: INT8 [type=int]
+ │         │    └── null [type=unknown]
+ │         └── const: 20 [type=int]
+ └── f-k-checks
+      └── f-k-checks-item [type=undefined]
+           └── anti-join
+                ├── columns: column2:6(int) column3:7(int) column4:8(int!null)
+                ├── project
+                │    ├── columns: column2:6(int) column3:7(int) column4:8(int!null)
+                │    └── values
+                │         ├── columns: column1:5(int!null) column2:6(int) column3:7(int) column4:8(int!null)
+                │         ├── tuple [type=tuple{int, int, int, int}]
+                │         │    ├── const: 2 [type=int]
+                │         │    ├── cast: INT8 [type=int]
+                │         │    │    └── null [type=unknown]
+                │         │    ├── const: 20 [type=int]
+                │         │    └── const: 20 [type=int]
+                │         └── tuple [type=tuple{int, int, int, int}]
+                │              ├── const: 3 [type=int]
+                │              ├── const: 20 [type=int]
+                │              ├── cast: INT8 [type=int]
+                │              │    └── null [type=unknown]
+                │              └── const: 20 [type=int]
+                ├── scan t.public.multi_col_parent
+                │    └── columns: t.public.multi_col_parent.p:9(int!null) t.public.multi_col_parent.q:10(int!null) t.public.multi_col_parent.r:11(int!null)
+                └── filters
+                     ├── eq [type=bool]
+                     │    ├── variable: column2 [type=int]
+                     │    └── variable: t.public.multi_col_parent.p [type=int]
+                     ├── eq [type=bool]
+                     │    ├── variable: column3 [type=int]
+                     │    └── variable: t.public.multi_col_parent.q [type=int]
+                     └── eq [type=bool]
+                          ├── variable: column4 [type=int]
+                          └── variable: t.public.multi_col_parent.r [type=int]
+
+# All the FK columns are not-null; no filter necessary.
+build
+INSERT INTO multi_col_child_full VALUES (1, 10, 10, 10)
+----
+insert multi_col_child_full
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├──  column1:5 => c:1
+ │    ├──  column2:6 => multi_col_child_full.p:2
+ │    ├──  column3:7 => multi_col_child_full.q:3
+ │    └──  column4:8 => multi_col_child_full.r:4
+ ├── values
+ │    ├── columns: column1:5(int!null) column2:6(int!null) column3:7(int!null) column4:8(int!null)
+ │    └── tuple [type=tuple{int, int, int, int}]
+ │         ├── const: 1 [type=int]
+ │         ├── const: 10 [type=int]
+ │         ├── const: 10 [type=int]
+ │         └── const: 10 [type=int]
+ └── f-k-checks
+      └── f-k-checks-item [type=undefined]
+           └── anti-join
+                ├── columns: column2:6(int!null) column3:7(int!null) column4:8(int!null)
+                ├── project
+                │    ├── columns: column2:6(int!null) column3:7(int!null) column4:8(int!null)
+                │    └── values
+                │         ├── columns: column1:5(int!null) column2:6(int!null) column3:7(int!null) column4:8(int!null)
+                │         └── tuple [type=tuple{int, int, int, int}]
+                │              ├── const: 1 [type=int]
+                │              ├── const: 10 [type=int]
+                │              ├── const: 10 [type=int]
+                │              └── const: 10 [type=int]
+                ├── scan t.public.multi_col_parent
+                │    └── columns: t.public.multi_col_parent.p:9(int!null) t.public.multi_col_parent.q:10(int!null) t.public.multi_col_parent.r:11(int!null)
+                └── filters
+                     ├── eq [type=bool]
+                     │    ├── variable: column2 [type=int]
+                     │    └── variable: t.public.multi_col_parent.p [type=int]
+                     ├── eq [type=bool]
+                     │    ├── variable: column3 [type=int]
+                     │    └── variable: t.public.multi_col_parent.q [type=int]
+                     └── eq [type=bool]
+                          ├── variable: column4 [type=int]
+                          └── variable: t.public.multi_col_parent.r [type=int]
+
+exec-ddl
+CREATE TABLE multi_ref_parent_a (a INT PRIMARY KEY, other INT)
+----
+
+exec-ddl
+CREATE TABLE multi_ref_parent_bc (b INT, c INT, PRIMARY KEY (b,c), other INT)
+----
+
+exec-ddl
+CREATE TABLE multi_ref_child (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  c INT,
+  CONSTRAINT fk FOREIGN KEY (a) REFERENCES multi_ref_parent_a(a),
+  CONSTRAINT fk FOREIGN KEY (b,c) REFERENCES multi_ref_parent_bc(b,c)
+)
+----
+
+build
+INSERT INTO multi_ref_child VALUES (1, NULL, NULL, NULL)
+----
+insert multi_ref_child
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├──  column1:5 => k:1
+ │    ├──  column2:6 => multi_ref_child.a:2
+ │    ├──  column3:7 => multi_ref_child.b:3
+ │    └──  column4:8 => multi_ref_child.c:4
+ ├── values
+ │    ├── columns: column1:5(int!null) column2:6(int) column3:7(int) column4:8(int)
+ │    └── tuple [type=tuple{int, int, int, int}]
+ │         ├── const: 1 [type=int]
+ │         ├── cast: INT8 [type=int]
+ │         │    └── null [type=unknown]
+ │         ├── cast: INT8 [type=int]
+ │         │    └── null [type=unknown]
+ │         └── cast: INT8 [type=int]
+ │              └── null [type=unknown]
+ └── f-k-checks
+      ├── f-k-checks-item [type=undefined]
+      │    └── anti-join
+      │         ├── columns: column2:6(int!null)
+      │         ├── select
+      │         │    ├── columns: column2:6(int!null)
+      │         │    ├── project
+      │         │    │    ├── columns: column2:6(int)
+      │         │    │    └── values
+      │         │    │         ├── columns: column1:5(int!null) column2:6(int) column3:7(int) column4:8(int)
+      │         │    │         └── tuple [type=tuple{int, int, int, int}]
+      │         │    │              ├── const: 1 [type=int]
+      │         │    │              ├── cast: INT8 [type=int]
+      │         │    │              │    └── null [type=unknown]
+      │         │    │              ├── cast: INT8 [type=int]
+      │         │    │              │    └── null [type=unknown]
+      │         │    │              └── cast: INT8 [type=int]
+      │         │    │                   └── null [type=unknown]
+      │         │    └── filters
+      │         │         └── is-not [type=bool]
+      │         │              ├── variable: column2 [type=int]
+      │         │              └── null [type=unknown]
+      │         ├── scan t.public.multi_ref_parent_a
+      │         │    └── columns: t.public.multi_ref_parent_a.a:9(int!null)
+      │         └── filters
+      │              └── eq [type=bool]
+      │                   ├── variable: column2 [type=int]
+      │                   └── variable: t.public.multi_ref_parent_a.a [type=int]
+      └── f-k-checks-item [type=undefined]
+           └── anti-join
+                ├── columns: column3:7(int!null) column4:8(int!null)
+                ├── select
+                │    ├── columns: column3:7(int!null) column4:8(int!null)
+                │    ├── project
+                │    │    ├── columns: column3:7(int) column4:8(int)
+                │    │    └── values
+                │    │         ├── columns: column1:5(int!null) column2:6(int) column3:7(int) column4:8(int)
+                │    │         └── tuple [type=tuple{int, int, int, int}]
+                │    │              ├── const: 1 [type=int]
+                │    │              ├── cast: INT8 [type=int]
+                │    │              │    └── null [type=unknown]
+                │    │              ├── cast: INT8 [type=int]
+                │    │              │    └── null [type=unknown]
+                │    │              └── cast: INT8 [type=int]
+                │    │                   └── null [type=unknown]
+                │    └── filters
+                │         ├── is-not [type=bool]
+                │         │    ├── variable: column3 [type=int]
+                │         │    └── null [type=unknown]
+                │         └── is-not [type=bool]
+                │              ├── variable: column4 [type=int]
+                │              └── null [type=unknown]
+                ├── scan t.public.multi_ref_parent_bc
+                │    └── columns: t.public.multi_ref_parent_bc.b:11(int!null) t.public.multi_ref_parent_bc.c:12(int!null)
+                └── filters
+                     ├── eq [type=bool]
+                     │    ├── variable: column3 [type=int]
+                     │    └── variable: t.public.multi_ref_parent_bc.b [type=int]
+                     └── eq [type=bool]
+                          ├── variable: column4 [type=int]
+                          └── variable: t.public.multi_ref_parent_bc.c [type=int]

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -325,7 +325,7 @@ func (mb *mutationBuilder) buildUpdate(returning tree.ReturningExprs) {
 	mb.addCheckConstraintCols()
 
 	private := mb.makeMutationPrivate(returning != nil)
-	mb.outScope.expr = mb.b.factory.ConstructUpdate(mb.outScope.expr, private)
+	mb.outScope.expr = mb.b.factory.ConstructUpdate(mb.outScope.expr, mb.checks, private)
 
 	mb.buildReturning(returning)
 }

--- a/pkg/sql/opt/ordering/mutation.go
+++ b/pkg/sql/opt/ordering/mutation.go
@@ -27,6 +27,10 @@ func mutationCanProvideOrdering(expr memo.RelExpr, required *physical.OrderingCh
 func mutationBuildChildReqOrdering(
 	parent memo.RelExpr, required *physical.OrderingChoice, childIdx int,
 ) physical.OrderingChoice {
+	if childIdx != 0 {
+		return physical.OrderingChoice{}
+	}
+
 	// Remap each of the required columns to corresponding input columns.
 	private := parent.Private().(*memo.MutationPrivate)
 

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -106,6 +106,9 @@ type Flags struct {
 	// the old planning code.
 	AllowUnsupportedExpr bool
 
+	// BuildFKChecks: if set, the optbuilder builds foreign key checks.
+	BuildFKChecks bool
+
 	// FullyQualifyNames if set: when building a query, the optbuilder fully
 	// qualifies all column names before adding them to the metadata. This flag
 	// allows us to test that name resolution works correctly, and avoids
@@ -1201,6 +1204,7 @@ func (ot *OptTester) buildExpr(factory *norm.Factory) error {
 	ot.semaCtx.Annotations = tree.MakeAnnotations(stmt.NumAnnotations)
 	b := optbuilder.New(ot.ctx, &ot.semaCtx, &ot.evalCtx, ot.catalog, factory, stmt.AST)
 	b.AllowUnsupportedExpr = ot.Flags.AllowUnsupportedExpr
+	b.BuildFKChecks = ot.Flags.BuildFKChecks
 	return b.Build()
 }
 

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -330,7 +330,7 @@ func (tc *Catalog) resolveFK(tab *Table, d *tree.ForeignKeyConstraintTableDef) {
 		originColumnOrdinals:     fromCols,
 		referencedColumnOrdinals: toCols,
 		validated:                true,
-		matchMethod:              tree.MatchSimple,
+		matchMethod:              d.Match,
 	}
 	tab.outboundFKs = append(tab.outboundFKs, fk)
 	targetTable.inboundFKs = append(targetTable.inboundFKs, fk)

--- a/pkg/sql/opt/testutils/testcat/testdata/foreign_keys
+++ b/pkg/sql/opt/testutils/testcat/testdata/foreign_keys
@@ -62,3 +62,67 @@ TABLE child2
  │    ├── p int
  │    └── c int not null
  └── CONSTRAINT fk_p_ref_parent2 FOREIGN KEY t.public.child2 (p) REFERENCES t.public.parent2 (p)
+
+exec-ddl
+CREATE TABLE parent_multicol (p INT, q INT, r INT, PRIMARY KEY (p,q,r))
+----
+
+exec-ddl
+CREATE TABLE child_multicol (
+  p INT,
+  q INT,
+  r INT,
+  PRIMARY KEY (p,q,r),
+  CONSTRAINT fk FOREIGN KEY (p,q,r) REFERENCES parent_multicol(p,q,r)
+)
+----
+
+exec-ddl
+CREATE TABLE child_multicol_full (
+  p INT,
+  q INT,
+  r INT,
+  PRIMARY KEY (p,q,r),
+  CONSTRAINT fk FOREIGN KEY (p,q,r) REFERENCES parent_multicol(p,q,r) MATCH FULL
+)
+----
+
+exec-ddl
+SHOW CREATE parent_multicol
+----
+TABLE parent_multicol
+ ├── p int not null
+ ├── q int not null
+ ├── r int not null
+ ├── INDEX primary
+ │    ├── p int not null
+ │    ├── q int not null
+ │    └── r int not null
+ ├── REFERENCED BY CONSTRAINT fk FOREIGN KEY t.public.child_multicol (p, q, r) REFERENCES t.public.parent_multicol (p, q, r)
+ └── REFERENCED BY CONSTRAINT fk FOREIGN KEY t.public.child_multicol_full (p, q, r) REFERENCES t.public.parent_multicol (p, q, r) MATCH FULL
+
+exec-ddl
+SHOW CREATE child_multicol
+----
+TABLE child_multicol
+ ├── p int not null
+ ├── q int not null
+ ├── r int not null
+ ├── INDEX primary
+ │    ├── p int not null
+ │    ├── q int not null
+ │    └── r int not null
+ └── CONSTRAINT fk FOREIGN KEY t.public.child_multicol (p, q, r) REFERENCES t.public.parent_multicol (p, q, r)
+
+exec-ddl
+SHOW CREATE child_multicol_full
+----
+TABLE child_multicol_full
+ ├── p int not null
+ ├── q int not null
+ ├── r int not null
+ ├── INDEX primary
+ │    ├── p int not null
+ │    ├── q int not null
+ │    └── r int not null
+ └── CONSTRAINT fk FOREIGN KEY t.public.child_multicol_full (p, q, r) REFERENCES t.public.parent_multicol (p, q, r) MATCH FULL

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -512,7 +512,7 @@ FROM
     JOIN x ON true
     JOIN [UPDATE x SET a = 1 RETURNING 1] ON true
 ----
-memo (optimized, ~55KB, required=[presentation: a:1,?column?:5,a:6,?column?:10])
+memo (optimized, ~56KB, required=[presentation: a:1,?column?:5,a:6,?column?:10])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G4) (inner-join G7 G8 G4) (inner-join G9 G10 G4) (inner-join G11 G12 G4) (inner-join G13 G14 G4) (inner-join G15 G16 G4) (inner-join G11 G17 G4) (inner-join G18 G16 G4) (inner-join G6 G5 G4) (inner-join G11 G19 G4) (inner-join G8 G7 G4) (inner-join G10 G9 G4) (inner-join G12 G11 G4) (inner-join G14 G13 G4) (inner-join G11 G20 G4) (inner-join G16 G15 G4) (inner-join G17 G11 G4) (inner-join G16 G18 G4) (inner-join G19 G11 G4) (inner-join G16 G21 G4) (inner-join G16 G22 G4) (inner-join G20 G11 G4) (inner-join G3 G23 G4) (inner-join G24 G16 G4) (inner-join G21 G16 G4) (inner-join G11 G25 G4) (inner-join G3 G26 G4) (inner-join G22 G16 G4) (inner-join G11 G27 G4) (inner-join G3 G28 G4) (inner-join G3 G29 G4) (inner-join G30 G16 G4) (inner-join G23 G3 G4) (inner-join G16 G24 G4) (inner-join G25 G11 G4) (inner-join G26 G3 G4) (inner-join G27 G11 G4) (inner-join G28 G3 G4) (inner-join G29 G3 G4) (inner-join G16 G30 G4)
  │    └── [presentation: a:1,?column?:5,a:6,?column?:10]
  │         ├── best: (inner-join G3 G2 G4)
@@ -630,38 +630,39 @@ memo (optimized, ~55KB, required=[presentation: a:1,?column?:5,a:6,?column?:10])
  │    └── []
  │         ├── best: (values G33 id=v5)
  │         └── cost: 0.01
- ├── G31: (update G35 x)
+ ├── G31: (update G35 G36 x)
  │    └── []
- │         ├── best: (update G35 x)
+ │         ├── best: (update G35 G36 x)
  │         └── cost: 1040.04
- ├── G32: (projections G36)
+ ├── G32: (projections G37)
  ├── G33: (scalar-list)
- ├── G34: (select G37 G38)
+ ├── G34: (select G38 G39)
  │    └── []
- │         ├── best: (select G37 G38)
+ │         ├── best: (select G38 G39)
  │         └── cost: 1040.05
- ├── G35: (project G39 G32 a)
+ ├── G35: (project G40 G32 a)
  │    └── []
- │         ├── best: (project G39 G32 a)
+ │         ├── best: (project G40 G32 a)
  │         └── cost: 1040.03
- ├── G36: (const 1)
- ├── G37: (insert G40 x)
+ ├── G36: (f-k-checks)
+ ├── G37: (const 1)
+ ├── G38: (insert G41 G36 x)
  │    └── []
- │         ├── best: (insert G40 x)
+ │         ├── best: (insert G41 G36 x)
  │         └── cost: 1030.04
- ├── G38: (filters G41)
- ├── G39: (scan x)
+ ├── G39: (filters G42)
+ ├── G40: (scan x)
  │    └── []
  │         ├── best: (scan x)
  │         └── cost: 1020.02
- ├── G40: (project G42 G43)
+ ├── G41: (project G43 G44)
  │    └── []
- │         ├── best: (project G42 G43)
+ │         ├── best: (project G43 G44)
  │         └── cost: 1030.03
- ├── G41: (false)
- ├── G42: (scan x,cols=())
+ ├── G42: (false)
+ ├── G43: (scan x,cols=())
  │    └── []
  │         ├── best: (scan x,cols=())
  │         └── cost: 1010.02
- ├── G43: (projections G44)
- └── G44: (null)
+ ├── G44: (projections G45)
+ └── G45: (null)


### PR DESCRIPTION
This is an early prototype for planning FK checks. The idea is that
the input of a mutation is wrapped into a `ForeignKeys` operator which
conceptually passes through the input unchanged; the FK check queries
hang off this operator.

The prototype comes with the following caveats:
 - only enabled in optbuilder tests
 - only INSERTs are supported
 - the FK check queries "alias" the same expression used as the
   mutation input. This is illegal in general but should be ok in
   practice when the input is a constant VALUES. The intention here
   is that `ForeignKeys` will act like the upcoming `With` operator
   and the FK checks will use a reference to that saved buffer.

Release note: None