### PR TITLE
opt: project constant columns so lookup joiner can use them

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -269,7 +269,7 @@ render          ·         ·               (title, edition, shelf, title, editi
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM authors INNER JOIN books2 ON books2.edition = 1 WHERE books2.title = authors.book]
 ----
-https://cockroachdb.github.io/distsqlplan/decode.html#eJyUkVFLwzAQx9_9FOGeb6zpNpCAkNeJdDL3Jn3I2mPWbbmQpKCMfndpI7iJq_p4_7vf5UfuBJZrKsyRAqhnkICwgBLBea4oBPZ9nIaW9RuoDKGxro19XCJU7AnUCWITDwQKCp6wm-aAUFM0zWEY6xC4jV9QiGZHoGYdni2W44s3ZnugNZma_DS7WA_ON0fj37Vp40vvi_DkjA1KTABh1UYltESdwzUP-R-Pe27sp4b8WWPLvA_9Dzww71snXrmxgq0Sug9XhdBzcSekUmpZbG4vFFHPUM9RL6665heuvxxjTcGxDfSna2RdiUD1jtLBA7e-okfP1fBMKlcDNwQ1hZi6s1QsbWr1guewHIXzcTgfhbNvcNndfAQAAP__24voVg==
+https://cockroachdb.github.io/distsqlplan/decode.html#eJyUkU9LMzEQh-_vpwhzntLN9q1ITrlWpJXam-wh3Qx1bZsJSRaUst9dsivYil31OH-eyUN-J3BsaWmOFEE9gQSEOVQIPnBNMXLI7WFpYV9BFQiN823K7Qqh5kCgTpCadCBQsOQJ-2kJCJaSaQ79WofAbfqEYjI7AjXr8OywHD-8MdsDrclYCtPi4jz40BxNeNOmTc_ZF-HRGxeVmADCmpyloIRUSi2Wm1sUWqLQJVyzkn-xuuPGfUjJ76W2zPuY_-Oeed968cKNE-yU0DPUmVm1SQldYq7_o56jvrnqVl64_RDFmqJnF-lXWRRdhUB2R0PckdtQ00Pgun9mKFc91zcsxTRMZ0OxcMMoC57DchQux-FyFC6-wFX37z0AAP__kSzobw==
 
 ####################################
 #  LOOKUP JOIN ON SECONDARY INDEX  #

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -221,6 +221,25 @@ func (n *FiltersExpr) RetainCommonFilters(other FiltersExpr) {
 	*n = common
 }
 
+// RemoveCommonFilters removes the filters found in other from n.
+func (n *FiltersExpr) RemoveCommonFilters(other FiltersExpr) {
+	// TODO(ridwanmsharif): Faster intersection using a map
+	common := (*n)[:0]
+	for _, filter := range *n {
+		found := false
+		for _, otherFilter := range other {
+			if filter.Condition == otherFilter.Condition {
+				found = true
+				break
+			}
+		}
+		if !found {
+			common = append(common, filter)
+		}
+	}
+	*n = common
+}
+
 // OutputCols returns the set of columns constructed by the Aggregations
 // expression.
 func (n AggregationsExpr) OutputCols() opt.ColSet {

--- a/pkg/sql/opt/memo/extract.go
+++ b/pkg/sql/opt/memo/extract.go
@@ -274,6 +274,20 @@ func ExtractValuesFromFilter(on FiltersExpr, cols opt.ColSet) map[opt.ColumnID]t
 	return vals
 }
 
+// ExtractConstantFilter returns a map of columns to the filters that constrain
+// value to a constant.
+func ExtractConstantFilter(on FiltersExpr, cols opt.ColSet) map[opt.ColumnID]FiltersItem {
+	vals := make(map[opt.ColumnID]FiltersItem)
+	for i := range on {
+		ok, col, _ := extractConstEquality(on[i].Condition)
+		if !ok || !cols.Contains(col) {
+			continue
+		}
+		vals[opt.ColumnID(col)] = on[i]
+	}
+	return vals
+}
+
 // extractConstEquality extracts a column that's being equated to a constant
 // value if possible.
 func extractConstEquality(condition opt.ScalarExpr) (bool, opt.ColumnID, tree.Datum) {

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -13,6 +13,8 @@
 package xform
 
 import (
+	"fmt"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
@@ -803,33 +805,81 @@ func (c *CustomFuncs) GenerateLookupJoins(
 	var iter scanIndexIter
 	iter.init(c.e.mem, scanPrivate)
 	for iter.next() {
+		idxCols := iter.indexCols()
+
+		// Find the longest prefix of index key columns that are constrained by
+		// an equality with another column or a constant.
+		numIndexKeyCols := iter.index.LaxKeyColumnCount()
+		constValMap := memo.ExtractValuesFromFilter(on, idxCols)
+		constFilterMap := memo.ExtractConstantFilter(on, idxCols)
+
+		var projections memo.ProjectionsExpr
+		var constFilters memo.FiltersExpr
+		if len(constValMap) > 0 {
+			projections = make(memo.ProjectionsExpr, 0, numIndexKeyCols)
+			constFilters = make(memo.FiltersExpr, 0, numIndexKeyCols)
+		}
+
 		// Check if the first column in the index has an equality constraint.
 		firstIdxCol := scanPrivate.Table.ColumnID(iter.index.Column(0).Ordinal)
 		if _, ok := rightEq.Find(firstIdxCol); !ok {
-			continue
+			if _, ok := constValMap[firstIdxCol]; !ok {
+				continue
+			}
 		}
 
-		lookupJoin := memo.LookupJoinExpr{Input: input, On: on}
+		lookupJoin := memo.LookupJoinExpr{Input: input}
 		lookupJoin.JoinPrivate = *joinPrivate
 		lookupJoin.JoinType = joinType
 		lookupJoin.Table = scanPrivate.Table
 		lookupJoin.Index = iter.indexOrdinal
 
-		// Find the longest prefix of index key columns that are equality columns.
-		numIndexKeyCols := iter.index.LaxKeyColumnCount()
 		lookupJoin.KeyCols = make(opt.ColList, 0, numIndexKeyCols)
 		rightSideCols := make(opt.ColList, 0, numIndexKeyCols)
+		needProjection := false
+
+		// All the lookup conditions must apply to the prefix of the index and so
+		// the projected columns created must be created in order.
 		for j := 0; j < numIndexKeyCols; j++ {
 			idxCol := scanPrivate.Table.ColumnID(iter.index.Column(j).Ordinal)
-			eqIdx, ok := rightEq.Find(idxCol)
+			if eqIdx, ok := rightEq.Find(idxCol); ok {
+				lookupJoin.KeyCols = append(lookupJoin.KeyCols, leftEq[eqIdx])
+				rightSideCols = append(rightSideCols, idxCol)
+				continue
+			}
+
+			// Project a new column with a constant value if that allows the
+			// index column to be constrained and used by the lookup joiner.
+			filter, ok := constFilterMap[idxCol]
 			if !ok {
 				break
 			}
-			lookupJoin.KeyCols = append(lookupJoin.KeyCols, leftEq[eqIdx])
+			condition, ok := filter.Condition.(*memo.EqExpr)
+			if !ok {
+				break
+			}
+			constColID := c.e.f.Metadata().AddColumn(
+				fmt.Sprintf("project_const_col_@%d", idxCol),
+				condition.Right.(*memo.ConstExpr).Typ)
+			projections = append(projections, memo.ProjectionsItem{
+				Element:    c.e.f.ConstructConst(constValMap[idxCol]),
+				ColPrivate: memo.ColPrivate{Col: constColID},
+			})
+
+			needProjection = true
+			lookupJoin.KeyCols = append(lookupJoin.KeyCols, constColID)
 			rightSideCols = append(rightSideCols, idxCol)
+			constFilters = append(constFilters, filter)
 		}
 
+		// Construct the projections for the constant columns.
+		if needProjection {
+			lookupJoin.Input = c.e.f.ConstructProject(input, projections, input.Relational().OutputCols)
+		}
+
+		// Remove the redundant filters and update the lookup condition.
 		lookupJoin.On = memo.ExtractRemainingJoinFilters(on, lookupJoin.KeyCols, rightSideCols)
+		lookupJoin.On.RemoveCommonFilters(constFilters)
 
 		if iter.isCovering() {
 			// Case 1 (see function comment).

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -789,6 +789,10 @@ CREATE TABLE abcd (a INT, b INT, c INT, INDEX (a,b))
 ----
 
 exec-ddl
+CREATE TABLE abcde (a INT, b INT, c INT, d INT, e INT, INDEX (a,b,c))
+----
+
+exec-ddl
 CREATE TABLE small (m INT, n INT)
 ----
 
@@ -1179,7 +1183,7 @@ memo (optimized, ~7KB, required=[presentation: a:4,b:5,n:2,m:1])
 # --------------------------------------------------
 # GenerateLookupJoinsWithFilter
 # --------------------------------------------------
-# 
+#
 # The rule and cases are similar to GenerateLookupJoins, except that we have a
 # filter that was pushed down to the lookup side (which needs to be pulled back
 # into the ON condition).
@@ -1320,9 +1324,133 @@ right-join
       ├── a = m [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
       └── c > n [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ])]
 
-# --------------------------
-# GenerateZigzagJoins
-# --------------------------
+# Constant columns are projected and used by lookup joiner.
+opt
+SELECT * FROM small INNER JOIN abcde ON a=m AND b=10
+----
+inner-join (lookup abcde)
+ ├── columns: m:1(int!null) n:2(int) a:4(int!null) b:5(int!null) c:6(int) d:7(int) e:8(int)
+ ├── key columns: [9] = [9]
+ ├── fd: ()-->(5), (1)==(4), (4)==(1)
+ ├── inner-join (lookup abcde@secondary)
+ │    ├── columns: m:1(int!null) n:2(int) a:4(int!null) b:5(int!null) c:6(int) abcde.rowid:9(int!null)
+ │    ├── key columns: [1 10] = [4 5]
+ │    ├── fd: ()-->(5), (9)-->(4,6), (1)==(4), (4)==(1)
+ │    ├── project
+ │    │    ├── columns: "project_const_col_@5":10(int!null) m:1(int) n:2(int)
+ │    │    ├── fd: ()-->(10)
+ │    │    ├── scan small
+ │    │    │    └── columns: m:1(int) n:2(int)
+ │    │    └── projections
+ │    │         └── const: 10 [type=int]
+ │    └── filters (true)
+ └── filters (true)
+
+# Constant columns not projected if not prefix of an index.
+opt
+SELECT * FROM small INNER JOIN abcde ON a=m AND c=10
+----
+inner-join (lookup abcde)
+ ├── columns: m:1(int!null) n:2(int) a:4(int!null) b:5(int) c:6(int!null) d:7(int) e:8(int)
+ ├── key columns: [9] = [9]
+ ├── fd: ()-->(6), (1)==(4), (4)==(1)
+ ├── inner-join (lookup abcde@secondary)
+ │    ├── columns: m:1(int!null) n:2(int) a:4(int!null) b:5(int) c:6(int!null) abcde.rowid:9(int!null)
+ │    ├── key columns: [1] = [4]
+ │    ├── fd: ()-->(6), (9)-->(4,5), (1)==(4), (4)==(1)
+ │    ├── scan small
+ │    │    └── columns: m:1(int) n:2(int)
+ │    └── filters
+ │         └── c = 10 [type=bool, outer=(6), constraints=(/6: [/10 - /10]; tight), fd=()-->(6)]
+ └── filters (true)
+
+# Multiple constant columns projected and used by lookup joiner.
+opt
+SELECT * FROM small INNER JOIN abcde ON a=m AND b=10 AND c=10
+----
+inner-join (lookup abcde)
+ ├── columns: m:1(int!null) n:2(int) a:4(int!null) b:5(int!null) c:6(int!null) d:7(int) e:8(int)
+ ├── key columns: [9] = [9]
+ ├── fd: ()-->(5,6), (1)==(4), (4)==(1)
+ ├── inner-join (lookup abcde@secondary)
+ │    ├── columns: m:1(int!null) n:2(int) a:4(int!null) b:5(int!null) c:6(int!null) abcde.rowid:9(int!null)
+ │    ├── key columns: [1 10 11] = [4 5 6]
+ │    ├── fd: ()-->(5,6), (9)-->(4), (1)==(4), (4)==(1)
+ │    ├── project
+ │    │    ├── columns: "project_const_col_@5":10(int!null) "project_const_col_@6":11(int!null) m:1(int) n:2(int)
+ │    │    ├── fd: ()-->(10,11)
+ │    │    ├── scan small
+ │    │    │    └── columns: m:1(int) n:2(int)
+ │    │    └── projections
+ │    │         ├── const: 10 [type=int]
+ │    │         └── const: 10 [type=int]
+ │    └── filters (true)
+ └── filters (true)
+
+# Filters are reduced properly as constant filters are extracted.
+opt
+SELECT * FROM small INNER JOIN abcde ON a=m AND b=10 AND c=10 AND d=10
+----
+inner-join (lookup abcde)
+ ├── columns: m:1(int!null) n:2(int) a:4(int!null) b:5(int!null) c:6(int!null) d:7(int!null) e:8(int)
+ ├── key columns: [9] = [9]
+ ├── fd: ()-->(5-7), (1)==(4), (4)==(1)
+ ├── inner-join (lookup abcde@secondary)
+ │    ├── columns: m:1(int!null) n:2(int) a:4(int!null) b:5(int!null) c:6(int!null) abcde.rowid:9(int!null)
+ │    ├── key columns: [1 10 11] = [4 5 6]
+ │    ├── fd: ()-->(5,6), (9)-->(4), (1)==(4), (4)==(1)
+ │    ├── project
+ │    │    ├── columns: "project_const_col_@5":10(int!null) "project_const_col_@6":11(int!null) m:1(int) n:2(int)
+ │    │    ├── fd: ()-->(10,11)
+ │    │    ├── scan small
+ │    │    │    └── columns: m:1(int) n:2(int)
+ │    │    └── projections
+ │    │         ├── const: 10 [type=int]
+ │    │         └── const: 10 [type=int]
+ │    └── filters (true)
+ └── filters
+      └── d = 10 [type=bool, outer=(7), constraints=(/7: [/10 - /10]; tight), fd=()-->(7)]
+
+# Non equality filters don't trigger constant projection.
+opt
+SELECT * FROM small INNER JOIN abcde ON a=m AND b<10
+----
+inner-join (lookup abcde)
+ ├── columns: m:1(int!null) n:2(int) a:4(int!null) b:5(int!null) c:6(int) d:7(int) e:8(int)
+ ├── key columns: [9] = [9]
+ ├── fd: (1)==(4), (4)==(1)
+ ├── inner-join (lookup abcde@secondary)
+ │    ├── columns: m:1(int!null) n:2(int) a:4(int!null) b:5(int!null) c:6(int) abcde.rowid:9(int!null)
+ │    ├── key columns: [1] = [4]
+ │    ├── fd: (9)-->(4-6), (1)==(4), (4)==(1)
+ │    ├── scan small
+ │    │    └── columns: m:1(int) n:2(int)
+ │    └── filters
+ │         └── b < 10 [type=bool, outer=(5), constraints=(/5: (/NULL - /9]; tight)]
+ └── filters (true)
+
+# Lookup Joiner uses the constant equality columns at the same time as the explicit
+# column equalities.
+opt
+SELECT a, b, c FROM small INNER LOOKUP JOIN abcde ON m=b AND a=10 AND c=10
+----
+project
+ ├── columns: a:4(int!null) b:5(int!null) c:6(int!null)
+ ├── fd: ()-->(4,6)
+ └── inner-join (lookup abcde@secondary)
+      ├── columns: m:1(int!null) a:4(int!null) b:5(int!null) c:6(int!null)
+      ├── flags: no-merge-join;no-hash-join
+      ├── key columns: [10 1 11] = [4 5 6]
+      ├── fd: ()-->(4,6), (1)==(5), (5)==(1)
+      ├── project
+      │    ├── columns: "project_const_col_@4":10(int!null) "project_const_col_@6":11(int!null) m:1(int)
+      │    ├── fd: ()-->(10,11)
+      │    ├── scan small
+      │    │    └── columns: m:1(int)
+      │    └── projections
+      │         ├── const: 10 [type=int]
+      │         └── const: 10 [type=int]
+      └── filters (true)
 
 # Simple zigzag case - where all requested columns are in the indexes being
 # joined.

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -127,8 +127,8 @@ inner-join (lookup bx)
 memo join-limit=3
 SELECT * FROM bx, cy, abc WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
-memo (optimized, ~17KB, required=[presentation: b:1,x:2,c:3,y:4,a:5,b:6,c:7,d:8])
- ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+6) (lookup-join G3 G5 bx,keyCols=[6],outCols=(1-8)) (inner-join G6 G7 G8) (inner-join G9 G10 G11) (inner-join G7 G6 G8) (merge-join G6 G7 G5 inner-join,+3,+7) (inner-join G10 G9 G11) (lookup-join G7 G5 cy,keyCols=[7],outCols=(1-8))
+memo (optimized, ~23KB, required=[presentation: b:1,x:2,c:3,y:4,a:5,b:6,c:7,d:8])
+ ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+6) (lookup-join G3 G5 bx,keyCols=[6],outCols=(1-8)) (inner-join G6 G7 G8) (inner-join G9 G10 G11) (inner-join G7 G6 G8) (merge-join G6 G7 G5 inner-join,+3,+7) (inner-join G10 G9 G11) (lookup-join G7 G5 cy,keyCols=[7],outCols=(1-8)) (lookup-join G12 G11 abc,keyCols=[11],outCols=(1-8))
  │    └── [presentation: b:1,x:2,c:3,y:4,a:5,b:6,c:7,d:8]
  │         ├── best: (lookup-join G3 G5 bx,keyCols=[6],outCols=(1-8))
  │         └── cost: 13.19
@@ -139,11 +139,11 @@ memo (optimized, ~17KB, required=[presentation: b:1,x:2,c:3,y:4,a:5,b:6,c:7,d:8]
  │    └── []
  │         ├── best: (scan bx)
  │         └── cost: 1040.02
- ├── G3: (inner-join G6 G9 G8) (inner-join G9 G6 G8) (merge-join G6 G9 G5 inner-join,+3,+7) (lookup-join G9 G5 cy,keyCols=[7],outCols=(3-8))
+ ├── G3: (inner-join G6 G9 G8) (inner-join G9 G6 G8) (merge-join G6 G9 G5 inner-join,+3,+7) (lookup-join G13 G8 abc,keyCols=[9],outCols=(3-8)) (lookup-join G9 G5 cy,keyCols=[7],outCols=(3-8))
  │    └── []
  │         ├── best: (lookup-join G9 G5 cy,keyCols=[7],outCols=(3-8))
  │         └── cost: 7.14
- ├── G4: (filters G12)
+ ├── G4: (filters G14)
  ├── G5: (filters)
  ├── G6: (scan cy)
  │    ├── [ordering: +3]
@@ -152,12 +152,12 @@ memo (optimized, ~17KB, required=[presentation: b:1,x:2,c:3,y:4,a:5,b:6,c:7,d:8]
  │    └── []
  │         ├── best: (scan cy)
  │         └── cost: 1040.02
- ├── G7: (inner-join G9 G2 G4) (inner-join G2 G9 G4) (lookup-join G9 G5 bx,keyCols=[6],outCols=(1,2,5-8)) (merge-join G2 G9 G5 inner-join,+1,+6)
+ ├── G7: (inner-join G9 G2 G4) (inner-join G2 G9 G4) (lookup-join G9 G5 bx,keyCols=[6],outCols=(1,2,5-8)) (merge-join G2 G9 G5 inner-join,+1,+6) (lookup-join G15 G4 abc,keyCols=[10],outCols=(1,2,5-8))
  │    └── []
  │         ├── best: (lookup-join G9 G5 bx,keyCols=[6],outCols=(1,2,5-8))
  │         └── cost: 7.14
- ├── G8: (filters G13)
- ├── G9: (select G14 G15) (scan abc,constrained)
+ ├── G8: (filters G16)
+ ├── G9: (select G17 G18) (scan abc,constrained)
  │    └── []
  │         ├── best: (scan abc,constrained)
  │         └── cost: 1.09
@@ -165,21 +165,34 @@ memo (optimized, ~17KB, required=[presentation: b:1,x:2,c:3,y:4,a:5,b:6,c:7,d:8]
  │    └── []
  │         ├── best: (inner-join G6 G2 G5)
  │         └── cost: 12110.05
- ├── G11: (filters G12 G13)
- ├── G12: (eq G16 G17)
- ├── G13: (eq G18 G19)
- ├── G14: (scan abc)
+ ├── G11: (filters G14 G16)
+ ├── G12: (project G10 G19 b x c y)
+ │    └── []
+ │         ├── best: (project G10 G19 b x c y)
+ │         └── cost: 32110.06
+ ├── G13: (project G6 G19 c y)
+ │    └── []
+ │         ├── best: (project G6 G19 c y)
+ │         └── cost: 1060.03
+ ├── G14: (eq G20 G21)
+ ├── G15: (project G2 G19 b x)
+ │    └── []
+ │         ├── best: (project G2 G19 b x)
+ │         └── cost: 1060.03
+ ├── G16: (eq G22 G23)
+ ├── G17: (scan abc)
  │    └── []
  │         ├── best: (scan abc)
  │         └── cost: 1080.02
- ├── G15: (filters G20)
- ├── G16: (variable abc.b)
- ├── G17: (variable bx.b)
- ├── G18: (variable abc.c)
- ├── G19: (variable cy.c)
- ├── G20: (eq G21 G22)
- ├── G21: (variable a)
- └── G22: (const 1)
+ ├── G18: (filters G24)
+ ├── G19: (projections G25)
+ ├── G20: (variable abc.b)
+ ├── G21: (variable bx.b)
+ ├── G22: (variable abc.c)
+ ├── G23: (variable cy.c)
+ ├── G24: (eq G26 G25)
+ ├── G25: (const 1)
+ └── G26: (variable a)
 
 opt join-limit=4
 SELECT * FROM bx, cy, dz, abc WHERE a = 1


### PR DESCRIPTION
Fixes #37727.

This change adds projection columns for constant values so
the lookup joiner can use them as part of the lookup condition.

Release note: None