### PR TITLE
release-19.1: storage: don't double test shouldQueue for GC

### DIFF
--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -465,41 +465,6 @@ func processAbortSpan(
 	return gcKeys
 }
 
-// process iterates through all keys in a replica's range, calling the garbage
-// collector for each key and associated set of values. GC'd keys are batched
-// into GC calls. Extant intents are resolved if intents are older than
-// intentAgeThreshold. The transaction and AbortSpan records are also
-// scanned and old entries evicted. During normal operation, both of these
-// records are cleaned up when their respective transaction finishes, so the
-// amount of work done here is expected to be small.
-//
-// Some care needs to be taken to avoid cyclic recreation of entries during GC:
-// * a Push initiated due to an intent may recreate a transaction entry
-// * resolving an intent may write a new AbortSpan entry
-// * obtaining the transaction for a AbortSpan entry requires a Push
-//
-// The following order is taken below:
-// 1) collect all intents with sufficiently old txn record
-// 2) collect these intents' transactions
-// 3) scan the transaction table, collecting abandoned or completed txns
-// 4) push all of these transactions (possibly recreating entries)
-// 5) resolve all intents (unless the txn is still PENDING), which will recreate
-//    AbortSpan entries (but with the txn timestamp; i.e. likely GC'able)
-// 6) scan the AbortSpan table for old entries
-// 7) push these transactions (again, recreating txn entries).
-// 8) send a GCRequest.
-func (gcq *gcQueue) process(ctx context.Context, repl *Replica, sysCfg *config.SystemConfig) error {
-	now := repl.store.Clock().Now()
-	r := makeGCQueueScore(ctx, repl, now, sysCfg)
-	if !r.ShouldQueue {
-		log.Eventf(ctx, "skipping replica; low score %s", r)
-		return nil
-	}
-
-	log.Eventf(ctx, "processing replica with score %s", r)
-	return gcq.processImpl(ctx, repl, sysCfg, now)
-}
-
 // NoopGCer implements GCer by doing nothing.
 type NoopGCer struct{}
 
@@ -561,9 +526,34 @@ func (r *replicaGCer) GC(ctx context.Context, keys []roachpb.GCRequest_GCKey) er
 	return r.send(ctx, req)
 }
 
-func (gcq *gcQueue) processImpl(
-	ctx context.Context, repl *Replica, sysCfg *config.SystemConfig, now hlc.Timestamp,
-) error {
+// process iterates through all keys in a replica's range, calling the garbage
+// collector for each key and associated set of values. GC'd keys are batched
+// into GC calls. Extant intents are resolved if intents are older than
+// intentAgeThreshold. The transaction and AbortSpan records are also
+// scanned and old entries evicted. During normal operation, both of these
+// records are cleaned up when their respective transaction finishes, so the
+// amount of work done here is expected to be small.
+//
+// Some care needs to be taken to avoid cyclic recreation of entries during GC:
+// * a Push initiated due to an intent may recreate a transaction entry
+// * resolving an intent may write a new AbortSpan entry
+// * obtaining the transaction for a AbortSpan entry requires a Push
+//
+// The following order is taken below:
+// 1) collect all intents with sufficiently old txn record
+// 2) collect these intents' transactions
+// 3) scan the transaction table, collecting abandoned or completed txns
+// 4) push all of these transactions (possibly recreating entries)
+// 5) resolve all intents (unless the txn is still PENDING), which will recreate
+//    AbortSpan entries (but with the txn timestamp; i.e. likely GC'able)
+// 6) scan the AbortSpan table for old entries
+// 7) push these transactions (again, recreating txn entries).
+// 8) send a GCRequest.
+func (gcq *gcQueue) process(ctx context.Context, repl *Replica, sysCfg *config.SystemConfig) error {
+	now := repl.store.Clock().Now()
+	r := makeGCQueueScore(ctx, repl, now, sysCfg)
+	log.VEventf(ctx, 2, "processing replica %s with score %s", repl.String(), r)
+
 	snap := repl.store.Engine().NewSnapshot()
 	defer snap.Close()
 

--- a/pkg/storage/gc_queue_test.go
+++ b/pkg/storage/gc_queue_test.go
@@ -368,9 +368,10 @@ func TestGCQueueMakeGCScoreRealistic(t *testing.T) {
 // scales and verifies that scan queue process properly GCs test data.
 func TestGCQueueProcess(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
+	defer stopper.Stop(ctx)
 	tc.Start(t, stopper)
 
 	tc.manualClock.Increment(48 * 60 * 60 * 1E9) // 2d past the epoch
@@ -504,7 +505,6 @@ func TestGCQueueProcess(t *testing.T) {
 			t.Fatalf("could not find zone config for range %s: %s", tc.repl, err)
 		}
 
-		ctx := context.Background()
 		now := tc.Clock().Now()
 		return RunGC(ctx, desc, snap, now, *zone.GC,
 			NoopGCer{},
@@ -527,7 +527,7 @@ func TestGCQueueProcess(t *testing.T) {
 
 	// Process through a scan queue.
 	gcQ := newGCQueue(tc.store, tc.gossip)
-	if err := gcQ.processImpl(context.Background(), tc.repl, cfg, tc.Clock().Now()); err != nil {
+	if err := gcQ.process(ctx, tc.repl, cfg); err != nil {
 		t.Fatal(err)
 	}
 
@@ -568,9 +568,7 @@ func TestGCQueueProcess(t *testing.T) {
 			return err
 		}
 		for i, kv := range kvs {
-			if log.V(1) {
-				log.Infof(context.Background(), "%d: %s", i, kv.Key)
-			}
+			log.VEventf(ctx, 1, "%d: %s", i, kv.Key)
 		}
 		if len(kvs) != len(expKVs) {
 			return fmt.Errorf("expected length %d; got %d", len(expKVs), len(kvs))
@@ -582,9 +580,7 @@ func TestGCQueueProcess(t *testing.T) {
 			if kv.Key.Timestamp != expKVs[i].ts {
 				return fmt.Errorf("%d: expected ts=%s; got %s", i, expKVs[i].ts, kv.Key.Timestamp)
 			}
-			if log.V(1) {
-				log.Infof(context.Background(), "%d: %s", i, kv.Key)
-			}
+			log.VEventf(ctx, 2, "%d: %s", i, kv.Key)
 		}
 		return nil
 	})
@@ -592,6 +588,7 @@ func TestGCQueueProcess(t *testing.T) {
 
 func TestGCQueueTransactionTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
 
 	manual := hlc.NewManualClock(123)
 	tsc := TestStoreConfig(hlc.NewClock(manual.UnixNano, time.Nanosecond))
@@ -706,7 +703,7 @@ func TestGCQueueTransactionTable(t *testing.T) {
 		}
 	tc := testContext{manualClock: manual}
 	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
+	defer stopper.Stop(ctx)
 	tc.StartWithStoreConfig(t, stopper, tsc)
 
 	outsideKey := tc.repl.Desc().EndKey.Next().AsRawKey()
@@ -725,12 +722,12 @@ func TestGCQueueTransactionTable(t *testing.T) {
 		txns[strKey] = *txn
 		for _, addrKey := range []roachpb.Key{baseKey, outsideKey} {
 			key := keys.TransactionKey(addrKey, txn.ID)
-			if err := engine.MVCCPutProto(context.Background(), tc.engine, nil, key, hlc.Timestamp{}, nil, txn); err != nil {
+			if err := engine.MVCCPutProto(ctx, tc.engine, nil, key, hlc.Timestamp{}, nil, txn); err != nil {
 				t.Fatal(err)
 			}
 		}
 		entry := roachpb.AbortSpanEntry{Key: txn.Key, Timestamp: txn.LastActive()}
-		if err := tc.repl.abortSpan.Put(context.Background(), tc.engine, nil, txn.ID, &entry); err != nil {
+		if err := tc.repl.abortSpan.Put(ctx, tc.engine, nil, txn.ID, &entry); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -742,7 +739,7 @@ func TestGCQueueTransactionTable(t *testing.T) {
 		t.Fatal("config not set")
 	}
 
-	if err := gcQ.processImpl(context.Background(), tc.repl, cfg, tc.Clock().Now()); err != nil {
+	if err := gcQ.process(ctx, tc.repl, cfg); err != nil {
 		t.Fatal(err)
 	}
 
@@ -750,7 +747,7 @@ func TestGCQueueTransactionTable(t *testing.T) {
 		for strKey, sp := range testCases {
 			txn := &roachpb.Transaction{}
 			key := keys.TransactionKey(roachpb.Key(strKey), txns[strKey].ID)
-			ok, err := engine.MVCCGetProto(context.Background(), tc.engine, key, hlc.Timestamp{}, txn,
+			ok, err := engine.MVCCGetProto(ctx, tc.engine, key, hlc.Timestamp{}, txn,
 				engine.MVCCGetOptions{})
 			if err != nil {
 				return err
@@ -775,7 +772,7 @@ func TestGCQueueTransactionTable(t *testing.T) {
 				return fmt.Errorf("%s: unexpected intent resolutions:\nexpected: %s\nobserved: %s", strKey, expIntents, spans)
 			}
 			entry := &roachpb.AbortSpanEntry{}
-			abortExists, err := tc.repl.abortSpan.Get(context.Background(), tc.store.Engine(), txns[strKey].ID, entry)
+			abortExists, err := tc.repl.abortSpan.Get(ctx, tc.store.Engine(), txns[strKey].ID, entry)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -789,7 +786,7 @@ func TestGCQueueTransactionTable(t *testing.T) {
 	outsideTxnPrefix := keys.TransactionKey(outsideKey, uuid.UUID{})
 	outsideTxnPrefixEnd := keys.TransactionKey(outsideKey.Next(), uuid.UUID{})
 	var count int
-	if _, err := engine.MVCCIterate(context.Background(), tc.store.Engine(), outsideTxnPrefix, outsideTxnPrefixEnd, hlc.Timestamp{},
+	if _, err := engine.MVCCIterate(ctx, tc.store.Engine(), outsideTxnPrefix, outsideTxnPrefixEnd, hlc.Timestamp{},
 		engine.MVCCScanOptions{}, func(roachpb.KeyValue) (bool, error) {
 			count++
 			return false, nil
@@ -805,7 +802,7 @@ func TestGCQueueTransactionTable(t *testing.T) {
 	defer batch.Close()
 	tc.repl.raftMu.Lock()
 	tc.repl.mu.Lock()
-	tc.repl.assertStateLocked(context.TODO(), batch) // check that in-mem and on-disk state were updated
+	tc.repl.assertStateLocked(ctx, batch) // check that in-mem and on-disk state were updated
 	tc.repl.mu.Unlock()
 	tc.repl.raftMu.Unlock()
 
@@ -824,9 +821,10 @@ func TestGCQueueTransactionTable(t *testing.T) {
 // intents spanning just two transactions.
 func TestGCQueueIntentResolution(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
+	defer stopper.Stop(ctx)
 	tc.Start(t, stopper)
 
 	tc.manualClock.Set(48 * 60 * 60 * 1E9) // 2d past the epoch
@@ -862,7 +860,7 @@ func TestGCQueueIntentResolution(t *testing.T) {
 		t.Fatal("config not set")
 	}
 	gcQ := newGCQueue(tc.store, tc.gossip)
-	if err := gcQ.processImpl(context.Background(), tc.repl, cfg, tc.Clock().Now()); err != nil {
+	if err := gcQ.process(ctx, tc.repl, cfg); err != nil {
 		t.Fatal(err)
 	}
 
@@ -888,9 +886,10 @@ func TestGCQueueIntentResolution(t *testing.T) {
 
 func TestGCQueueLastProcessedTimestamps(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
+	defer stopper.Stop(ctx)
 	tc.Start(t, stopper)
 
 	// Create two last processed times both at the range start key and
@@ -908,7 +907,7 @@ func TestGCQueueLastProcessedTimestamps(t *testing.T) {
 
 	ts := tc.Clock().Now()
 	for _, lpv := range lastProcessedVals {
-		if err := engine.MVCCPutProto(context.Background(), tc.engine, nil, lpv.key, hlc.Timestamp{}, nil, &ts); err != nil {
+		if err := engine.MVCCPutProto(ctx, tc.engine, nil, lpv.key, hlc.Timestamp{}, nil, &ts); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -920,14 +919,14 @@ func TestGCQueueLastProcessedTimestamps(t *testing.T) {
 
 	// Process through a scan queue.
 	gcQ := newGCQueue(tc.store, tc.gossip)
-	if err := gcQ.processImpl(context.Background(), tc.repl, cfg, tc.Clock().Now()); err != nil {
+	if err := gcQ.process(ctx, tc.repl, cfg); err != nil {
 		t.Fatal(err)
 	}
 
 	// Verify GC.
 	testutils.SucceedsSoon(t, func() error {
 		for _, lpv := range lastProcessedVals {
-			ok, err := engine.MVCCGetProto(context.Background(), tc.engine, lpv.key, hlc.Timestamp{}, &ts,
+			ok, err := engine.MVCCGetProto(ctx, tc.engine, lpv.key, hlc.Timestamp{}, &ts,
 				engine.MVCCGetOptions{})
 			if err != nil {
 				return err
@@ -945,6 +944,7 @@ func TestGCQueueLastProcessedTimestamps(t *testing.T) {
 // keys and also for many different versions of keys.
 func TestGCQueueChunkRequests(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
 
 	var gcRequests int32
 	manual := hlc.NewManualClock(123)
@@ -959,7 +959,7 @@ func TestGCQueueChunkRequests(t *testing.T) {
 		}
 	tc := testContext{manualClock: manual}
 	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
+	defer stopper.Stop(ctx)
 	tc.StartWithStoreConfig(t, stopper, tsc)
 
 	const keyCount = 100
@@ -984,11 +984,11 @@ func TestGCQueueChunkRequests(t *testing.T) {
 		ba2.Add(&pArgs)
 	}
 	ba1.Header = roachpb.Header{Timestamp: tc.Clock().Now()}
-	if _, pErr := tc.Sender().Send(context.Background(), ba1); pErr != nil {
+	if _, pErr := tc.Sender().Send(ctx, ba1); pErr != nil {
 		t.Fatal(pErr)
 	}
 	ba2.Header = roachpb.Header{Timestamp: tc.Clock().Now()}
-	if _, pErr := tc.Sender().Send(context.Background(), ba2); pErr != nil {
+	if _, pErr := tc.Sender().Send(ctx, ba2); pErr != nil {
 		t.Fatal(pErr)
 	}
 
@@ -1008,7 +1008,7 @@ func TestGCQueueChunkRequests(t *testing.T) {
 		pArgs2 := putArgs(key2, []byte(fmt.Sprintf("value%04d", i)))
 		ba.Add(&pArgs2)
 		ba.Header = roachpb.Header{Timestamp: tc.Clock().Now()}
-		if _, pErr := tc.Sender().Send(context.Background(), ba); pErr != nil {
+		if _, pErr := tc.Sender().Send(ctx, ba); pErr != nil {
 			t.Fatal(pErr)
 		}
 	}
@@ -1024,7 +1024,7 @@ func TestGCQueueChunkRequests(t *testing.T) {
 	}
 	tc.manualClock.Increment(int64(zone.GC.TTLSeconds)*1E9 + 1)
 	gcQ := newGCQueue(tc.store, tc.gossip)
-	if err := gcQ.processImpl(context.Background(), tc.repl, cfg, tc.Clock().Now()); err != nil {
+	if err := gcQ.process(ctx, tc.repl, cfg); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #38249.

/cc @cockroachdb/release

---

Before this patch, gcqueue.process() would test shouldQueue(), even
though that was already tested by the queue infra before calling
process.
Besides being wasteful, this rendered the "skip should queue" checkbox in the
Manual Enqueue debug page useless for this queue.

Release note: Checking the "skip should queue" checkbox in the Manual
Enqueue Range advanced debuggging page now works for the GC Queue.
