### PR TITLE
*: auto-close PRs after >2 months of inactivity

### DIFF
--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -1,0 +1,12 @@
+# Number of days of inactivity before a PR becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale PR is closed
+daysUntilClose: 7
+staleLabel: []
+# Comment to post when marking a PR as stale.
+markComment: >
+  This PR has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Don't touch issues, limit to pull requests.
+only: pulls


### PR DESCRIPTION
We have 235 open PRs and most of them are abandoned. Closing a PR isn't
irrevocable: the branch remains and the PR can be reopened (unless the
branch is being force-pushed while the PR is closed).

As a result, auto-closing old PRs after a grace period is a cheap way to
keep our sanity and to make better use of tools like [PullReminders].

A free Github integration to close old PRs, [Stale], is available and
checking in this configuration file will activate it.

[PullReminders]: https://pullreminders.com/
[Stale]: https://github.com/apps/stale

Release note: None