### PR TITLE
sql: Tighter spans for column families in lookup and index joins

### DIFF
--- a/pkg/sql/distsqlrun/indexjoiner_test.go
+++ b/pkg/sql/distsqlrun/indexjoiner_test.go
@@ -52,7 +52,13 @@ func TestIndexJoiner(t *testing.T) {
 		99,
 		sqlutils.ToRowFn(aFn, bFn, sumFn, sqlutils.RowEnglishFn))
 
+	sqlutils.CreateTable(t, sqlDB, "t2",
+		"a INT, b INT, sum INT, s STRING, PRIMARY KEY (a,b), FAMILY f1 (a, b), FAMILY f2 (s), FAMILY f3 (sum), INDEX bs (b,s)",
+		99,
+		sqlutils.ToRowFn(aFn, bFn, sumFn, sqlutils.RowEnglishFn))
+
 	td := sqlbase.GetTableDescriptor(kvDB, "test", "t")
+	tdf := sqlbase.GetTableDescriptor(kvDB, "test", "t2")
 
 	v := [10]sqlbase.EncDatum{}
 	for i := range v {
@@ -61,6 +67,7 @@ func TestIndexJoiner(t *testing.T) {
 
 	testCases := []struct {
 		description string
+		desc        *sqlbase.TableDescriptor
 		post        distsqlpb.PostProcessSpec
 		input       sqlbase.EncDatumRows
 		outputTypes []types.T
@@ -68,6 +75,7 @@ func TestIndexJoiner(t *testing.T) {
 	}{
 		{
 			description: "Test selecting rows using the primary index",
+			desc:        td,
 			post: distsqlpb.PostProcessSpec{
 				Projection:    true,
 				OutputColumns: []uint32{0, 1, 2},
@@ -88,6 +96,7 @@ func TestIndexJoiner(t *testing.T) {
 		},
 		{
 			description: "Test a filter in the post process spec and using a secondary index",
+			desc:        td,
 			post: distsqlpb.PostProcessSpec{
 				Filter:        distsqlpb.Expression{Expr: "@3 <= 5"}, // sum <= 5
 				Projection:    true,
@@ -112,12 +121,33 @@ func TestIndexJoiner(t *testing.T) {
 				{sqlbase.StrEncDatum("five-zero")},
 			},
 		},
+		{
+			description: "Test selecting rows using the primary index with multiple family spans",
+			desc:        tdf,
+			post: distsqlpb.PostProcessSpec{
+				Projection:    true,
+				OutputColumns: []uint32{0, 1, 2},
+			},
+			input: sqlbase.EncDatumRows{
+				{v[0], v[2]},
+				{v[0], v[5]},
+				{v[1], v[0]},
+				{v[1], v[5]},
+			},
+			outputTypes: sqlbase.ThreeIntCols,
+			expected: sqlbase.EncDatumRows{
+				{v[0], v[2], v[2]},
+				{v[0], v[5], v[5]},
+				{v[1], v[0], v[1]},
+				{v[1], v[5], v[6]},
+			},
+		},
 	}
 
 	for _, c := range testCases {
 		t.Run(c.description, func(t *testing.T) {
 			spec := distsqlpb.JoinReaderSpec{
-				Table:    *td,
+				Table:    *c.desc,
 				IndexIdx: 0,
 			}
 			txn := client.NewTxn(context.Background(), s.DB(), s.NodeID(), client.RootTxn)

--- a/pkg/sql/distsqlrun/joinreader_test.go
+++ b/pkg/sql/distsqlrun/joinreader_test.go
@@ -133,6 +133,23 @@ func TestJoinReader(t *testing.T) {
 			expected:    "[[0 2 2] [0 2 2] [0 5 5] [1 0 0] [1 5 5]]",
 		},
 		{
+			description: "Test lookup join queries with separate families",
+			post: distsqlpb.PostProcessSpec{
+				Projection:    true,
+				OutputColumns: []uint32{0, 1, 3, 4},
+			},
+			input: [][]tree.Datum{
+				{aFn(2), bFn(2)},
+				{aFn(5), bFn(5)},
+				{aFn(10), bFn(10)},
+				{aFn(15), bFn(15)},
+			},
+			lookupCols:  []uint32{0, 1},
+			inputTypes:  sqlbase.TwoIntCols,
+			outputTypes: sqlbase.FourIntCols,
+			expected:    "[[0 2 2 2] [0 5 5 5] [1 0 0 1] [1 5 5 6]]",
+		},
+		{
 			description: "Test lookup joins preserve order of left input",
 			post: distsqlpb.PostProcessSpec{
 				Projection:    true,
@@ -404,7 +421,6 @@ func TestJoinReader(t *testing.T) {
 					Settings: st,
 					txn:      client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
 				}
-
 				encRows := make(sqlbase.EncDatumRows, len(c.input))
 				for rowIdx, row := range c.input {
 					encRow := make(sqlbase.EncDatumRow, len(row))

--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -561,3 +561,75 @@ SELECT a,b from small WHERE a+b<20 AND EXISTS (SELECT a FROM data WHERE small.a=
 4  8
 5  10
 6  12
+
+# The following tests check that if the joiners can separate a row request
+# into separate families that it does, and generates spans for each family
+# instead of reading the entire row when it doesn't need to.
+
+statement ok
+CREATE TABLE family_split_1 (x INT, PRIMARY KEY (x))
+
+statement ok
+INSERT INTO family_split_1 VALUES (1)
+
+statement ok
+CREATE TABLE family_split_2 (x INT, y INT, z INT, PRIMARY KEY (x), FAMILY f1 (x), FAMILY f2 (y), FAMILY f3 (z))
+
+statement ok
+INSERT INTO family_split_2 VALUES (1, 2, 3)
+
+statement ok
+SET tracing = on; SELECT family_split_2.x, family_split_2.z FROM family_split_1 INNER LOOKUP JOIN family_split_2 ON family_split_1.x = family_split_2.x; SET tracing = off
+
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE 'Scan /Table/70/1/1/{0-1}, /Table/70/1/1/2/{1-2}'
+----
+Scan /Table/70/1/1/{0-1}, /Table/70/1/1/2/{1-2}
+
+statement ok
+CREATE TABLE family_index_join (x INT PRIMARY KEY, y INT, z INT, w INT, INDEX (y), FAMILY f1 (x), FAMILY f2 (y), FAMILY f3 (z), FAMILY f4(w))
+
+statement ok
+INSERT INTO family_index_join VALUES (1, 2, 3, 4)
+
+statement ok
+SET tracing = on
+
+query II
+SELECT y,w FROM family_index_join@family_index_join_y_idx WHERE y = 2
+----
+2 4
+
+statement ok
+SET tracing = off
+
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE 'Scan /Table/71/1/1/1/{1-2}, /Table/71/1/1/3/{1-2}'
+----
+Scan /Table/71/1/1/1/{1-2}, /Table/71/1/1/3/{1-2}
+
+# Test generating tighter spans on interleaved tables.
+statement ok
+CREATE TABLE family_interleave_1 (x INT, y INT, z INT, PRIMARY KEY (x), FAMILY f1 (x), FAMILY f2 (y), FAMILY f3 (z))
+
+statement ok
+CREATE TABLE family_interleave_2 (x INT, y INT, PRIMARY KEY (x, y)) INTERLEAVE IN PARENT family_interleave_1 (x)
+
+statement ok
+INSERT INTO family_interleave_1 VALUES (1, 2, 3)
+
+statement ok
+INSERT INTO family_interleave_2 VALUES (1, 3)
+
+statement ok
+SET TRACING = on
+
+query II
+SELECT family_interleave_1.x, family_interleave_1.z FROM family_interleave_2 INNER LOOKUP JOIN family_interleave_1 ON family_interleave_1.x = family_interleave_2.x
+----
+1 3
+
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE 'Scan /Table/72/1/1/{0-1}, /Table/72/1/1/2/{1-2}'
+----
+Scan /Table/72/1/1/{0-1}, /Table/72/1/1/2/{1-2}

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -797,6 +797,8 @@ var (
 	TwoIntCols = []types.T{*types.Int, *types.Int}
 	// ThreeIntCols is a slice of three IntTypes.
 	ThreeIntCols = []types.T{*types.Int, *types.Int, *types.Int}
+	// FourIntCols is a slice of four IntTypes.
+	FourIntCols = []types.T{*types.Int, *types.Int, *types.Int, *types.Int}
 )
 
 // MakeIntCols makes a slice of numCols IntTypes.


### PR DESCRIPTION
When only specific families are needed for a query, point lookups
in joiners can issue family specific spans to retrieve only
the data that they need, instead of querying for an entire row.

Release note: None