### PR TITLE
sql: permit interleaved idxs in CREATE TABLE stmts

### DIFF
--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -487,11 +487,6 @@ func TestReportUsage(t *testing.T) {
 		) {
 			t.Fatal(err)
 		}
-		if _, err := db.Exec(`CREATE TABLE somestring.foo (a INT8 PRIMARY KEY, b INT8, INDEX (b) INTERLEAVE IN PARENT foo (b))`); !testutils.IsError(
-			err, "unimplemented: use CREATE INDEX to make interleaved indexes",
-		) {
-			t.Fatal(err)
-		}
 		// Even queries that don't use placeholders and contain literal strings
 		// should still not cause those strings to appear in reports.
 		for _, q := range []string{
@@ -707,7 +702,6 @@ func TestReportUsage(t *testing.T) {
 		"unimplemented.#33285.json_object_agg":          10,
 		"unimplemented.pg_catalog.pg_stat_wal_receiver": 10,
 		"unimplemented.syntax.#32564":                   10,
-		"unimplemented.#9148":                           10,
 		"othererror." +
 			pgcode.Uncategorized +
 			".crdb_internal.set_vmodule()": 10,
@@ -853,7 +847,6 @@ func TestReportUsage(t *testing.T) {
 		"[true,false,false] SELECT _::STRING::INET, _::JSONB - _, ARRAY (SELECT _)[_]",
 		`[true,false,false] UPDATE _ SET _ = _ + _`,
 		"[true,false,false] WITH _ AS (SELECT _) SELECT * FROM _",
-		`[true,false,true] CREATE TABLE _ (_ INT8 PRIMARY KEY, _ INT8, INDEX (_) INTERLEAVE IN PARENT _ (_))`,
 		`[true,false,true] SELECT _ / $1`,
 		`[true,false,true] SELECT _ / _`,
 		`[true,false,true] SELECT crdb_internal.force_assertion_error(_)`,
@@ -896,7 +889,6 @@ func TestReportUsage(t *testing.T) {
 			`CREATE DATABASE _`,
 			`CREATE TABLE _ (_ INT8, CONSTRAINT _ CHECK (_ > _))`,
 			`CREATE TABLE _ (_ INT8 NOT NULL DEFAULT unique_rowid())`,
-			`CREATE TABLE _ (_ INT8 PRIMARY KEY, _ INT8, INDEX (_) INTERLEAVE IN PARENT _ (_))`,
 			`INSERT INTO _ VALUES (length($1::STRING)), (__more1__)`,
 			`INSERT INTO _ VALUES (_), (__more2__)`,
 			`INSERT INTO _ SELECT unnest(ARRAY[_, _, __more2__])`,

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -117,7 +117,7 @@ func (n *createIndexNode) startExec(params runParams) error {
 	indexName := index.Name
 
 	if n.n.Interleave != nil {
-		if err := params.p.addInterleave(params.ctx, n.tableDesc, index, n.n.Interleave); err != nil {
+		if err := addInterleave(params.ctx, params.p, n.tableDesc, index, n.n.Interleave); err != nil {
 			return err
 		}
 		if err := params.p.finalizeInterleave(params.ctx, n.tableDesc, index); err != nil {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -184,12 +184,6 @@ func (n *createTableNode) startExec(params runParams) error {
 		}
 	}
 
-	// Descriptor written to store here.
-	if err := params.p.createDescriptorWithID(
-		params.ctx, key, id, &desc, params.EvalContext().Settings); err != nil {
-		return err
-	}
-
 	for _, updated := range affected {
 		if err := params.p.writeSchemaChange(params.ctx, updated, sqlbase.InvalidMutationID); err != nil {
 			return err
@@ -202,6 +196,12 @@ func (n *createTableNode) startExec(params runParams) error {
 				return err
 			}
 		}
+	}
+
+	// Descriptor written to store here.
+	if err := params.p.createDescriptorWithID(
+		params.ctx, key, id, &desc, params.EvalContext().Settings); err != nil {
+		return err
 	}
 
 	if err := desc.Validate(params.ctx, params.p.txn, params.EvalContext().Settings); err != nil {
@@ -738,20 +738,10 @@ func colNames(cols []sqlbase.ColumnDescriptor) string {
 	return s.String()
 }
 
-func (p *planner) addInterleave(
-	ctx context.Context,
-	desc *sqlbase.MutableTableDescriptor,
-	index *sqlbase.IndexDescriptor,
-	interleave *tree.InterleaveDef,
-) error {
-	return addInterleave(ctx, p.txn, p, desc, index, interleave)
-}
-
 // addInterleave marks an index as one that is interleaved in some parent data
 // according to the given definition.
 func addInterleave(
 	ctx context.Context,
-	txn *client.Txn,
 	vt SchemaResolver,
 	desc *sqlbase.MutableTableDescriptor,
 	index *sqlbase.IndexDescriptor,
@@ -835,8 +825,6 @@ func addInterleave(
 		intl.SharedPrefixLen -= ancestor.SharedPrefixLen
 	}
 	index.Interleave = sqlbase.InterleaveDescriptor{Ancestors: append(ancestorPrefix, intl)}
-
-	desc.State = sqlbase.TableDescriptor_ADD
 	return nil
 }
 
@@ -868,19 +856,7 @@ func (p *planner) finalizeInterleave(
 	ancestorIndex.InterleavedBy = append(ancestorIndex.InterleavedBy,
 		sqlbase.ForeignKeyReference{Table: desc.ID, Index: index.ID})
 
-	if err := p.writeSchemaChange(ctx, ancestorTable, sqlbase.InvalidMutationID); err != nil {
-		return err
-	}
-
-	if desc.State == sqlbase.TableDescriptor_ADD {
-		desc.State = sqlbase.TableDescriptor_PUBLIC
-
-		if err := p.writeSchemaChange(ctx, desc, sqlbase.InvalidMutationID); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return p.writeSchemaChange(ctx, ancestorTable, sqlbase.InvalidMutationID)
 }
 
 // CreatePartitioning constructs the partitioning descriptor for an index that
@@ -1038,6 +1014,14 @@ func dequalifyColumnRefs(
 	)
 }
 
+// interleaveToAdd is a helper struct that associates an interleave definition
+// with an index into an indexes array, to facilitate creating interleaved
+// indexes during CREATE TABLE.
+type interleaveToAdd struct {
+	def          *tree.InterleaveDef
+	indexOrdinal int
+}
+
 // MakeTableDesc creates a table descriptor from a CreateTable statement.
 //
 // txn and vt can be nil if the table to be created does not contain references
@@ -1142,6 +1126,11 @@ func MakeTableDesc(
 		}
 	}
 
+	// interleavesToAdd will accumulate all interleave definitions we're going to
+	// add. We delay creating the interleaves until after the indexes get their
+	// IDs allocated, since that information is necessary to create an interleave
+	// at all.
+	var interleavesToAdd []interleaveToAdd
 	var primaryIndexColumnSet map[string]struct{}
 	for _, def := range n.Defs {
 		switch d := def.(type) {
@@ -1170,7 +1159,10 @@ func MakeTableDesc(
 				return desc, err
 			}
 			if d.Interleave != nil {
-				return desc, unimplemented.NewWithIssue(9148, "use CREATE INDEX to make interleaved indexes")
+				interleavesToAdd = append(interleavesToAdd, interleaveToAdd{
+					def:          d.Interleave,
+					indexOrdinal: len(desc.Indexes) - 1,
+				})
 			}
 		case *tree.UniqueConstraintTableDef:
 			idx := sqlbase.IndexDescriptor{
@@ -1196,9 +1188,17 @@ func MakeTableDesc(
 				for _, c := range d.Columns {
 					primaryIndexColumnSet[string(c.Column)] = struct{}{}
 				}
+				if d.Interleave != nil {
+					return desc, errors.Errorf("can't interleave primary index directly: put the INTERLEAVE IN PARENT statement" +
+						" on the" +
+						" CREATE TABLE statement instead")
+				}
 			}
 			if d.Interleave != nil {
-				return desc, unimplemented.NewWithIssue(9148, "use CREATE INDEX to make interleaved indexes")
+				interleavesToAdd = append(interleavesToAdd, interleaveToAdd{
+					def:          d.Interleave,
+					indexOrdinal: len(desc.Indexes) - 1,
+				})
 			}
 		case *tree.CheckConstraintTableDef, *tree.ForeignKeyConstraintTableDef, *tree.FamilyTableDef:
 			// pass, handled below.
@@ -1235,7 +1235,17 @@ func MakeTableDesc(
 	}
 
 	if n.Interleave != nil {
-		if err := addInterleave(ctx, txn, vt, &desc, &desc.PrimaryIndex, n.Interleave); err != nil {
+		desc.State = sqlbase.TableDescriptor_ADD
+		if err := addInterleave(ctx, vt, &desc, &desc.PrimaryIndex, n.Interleave); err != nil {
+			return desc, err
+		}
+	}
+	// Add any interleaves to secondary indexes that we found. The backreferences
+	// will be created in the actual createTableNode, by finalizeInterleave.
+	for _, interleaveToAdd := range interleavesToAdd {
+		desc.State = sqlbase.TableDescriptor_ADD
+		indexDesc := &desc.Indexes[interleaveToAdd.indexOrdinal]
+		if err := addInterleave(ctx, vt, &desc, indexDesc, interleaveToAdd.def); err != nil {
 			return desc, err
 		}
 	}

--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -201,21 +201,14 @@ SELECT * FROM p0
 
 # Validation and descriptor bookkeeping
 
-# TODO(dan): Interleave these two indexes once we support the syntax.
 statement ok
 CREATE TABLE all_interleaves (
   b INT PRIMARY KEY,
   c INT,
   d INT,
-  INDEX (c),
-  UNIQUE INDEX (d)
+  INDEX (c, d) INTERLEAVE IN PARENT p1_1(c),
+  UNIQUE INDEX (d, c) INTERLEAVE IN PARENT p1_1 (d)
 ) INTERLEAVE IN PARENT p1_1 (b)
-
-statement ok
-CREATE INDEX ON all_interleaves (c, d) INTERLEAVE IN PARENT p1_1 (c)
-
-statement ok
-CREATE UNIQUE INDEX ON all_interleaves (d, c) INTERLEAVE IN PARENT p1_1 (d)
 
 query TT
 SHOW CREATE TABLE all_interleaves
@@ -225,8 +218,6 @@ all_interleaves                  CREATE TABLE all_interleaves (
                                  c INT8 NULL,
                                  d INT8 NULL,
                                  CONSTRAINT "primary" PRIMARY KEY (b ASC),
-                                 INDEX all_interleaves_c_idx (c ASC),
-                                 UNIQUE INDEX all_interleaves_d_key (d ASC),
                                  INDEX all_interleaves_c_d_idx (c ASC, d ASC) INTERLEAVE IN PARENT p1_1 (c),
                                  UNIQUE INDEX all_interleaves_d_c_key (d ASC, c ASC) INTERLEAVE IN PARENT p1_1 (d),
                                  FAMILY "primary" (b, c, d)
@@ -268,13 +259,6 @@ CREATE INDEX ON p1_0 (d) INTERLEAVE IN PARENT p1_1 (d)
 
 statement error pq: declared interleaved columns \(i\) must match type and sort direction of the parent's primary index \(i\)
 CREATE INDEX ON p1_0 (i DESC) INTERLEAVE IN PARENT p1_1 (i)
-
-
-statement error unimplemented
-CREATE TABLE err (i INT PRIMARY KEY, INDEX (i) INTERLEAVE IN PARENT p1_1 (i))
-
-statement error unimplemented
-CREATE TABLE err (i INT PRIMARY KEY, UNIQUE INDEX (i) INTERLEAVE IN PARENT p1_1 (i))
 
 statement error unimplemented: unsupported shorthand CASCADE
 CREATE TABLE err (i INT PRIMARY KEY) INTERLEAVE IN PARENT p1_1 (i) CASCADE


### PR DESCRIPTION
Closes #35462.
Closes #9148.

Previously, a CREATE TABLE statement that contained an INDEX definition
inline didn't permit making that INDEX definition an interleaved index.

This patch alleviates the problem. Now, you can do something like this:

```
CREATE TABLE a (a INT PRIMARY KEY);
CREATE TABLE b (b INT PRIMARY KEY, a INT, INDEX (a) INTERLEAVE IN PARENT a(a));
```

Release note (sql change): CREATE TABLE statements can now include
inline interleaved indexes.