### PR TITLE
opt: fix and improve Values optbuilding

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -416,11 +416,11 @@ render       ·              ·                           ("coalesce")        ·
 ·            row 0, expr 0  1                           ·                   ·
 ·            row 0, expr 1  2                           ·                   ·
 ·            row 1, expr 0  3                           ·                   ·
-·            row 1, expr 1  NULL                        ·                   ·
-·            row 2, expr 0  NULL                        ·                   ·
+·            row 1, expr 1  CAST(NULL AS INT8)          ·                   ·
+·            row 2, expr 0  CAST(NULL AS INT8)          ·                   ·
 ·            row 2, expr 1  4                           ·                   ·
-·            row 3, expr 0  NULL                        ·                   ·
-·            row 3, expr 1  NULL                        ·                   ·
+·            row 3, expr 0  CAST(NULL AS INT8)          ·                   ·
+·            row 3, expr 1  CAST(NULL AS INT8)          ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT COALESCE(a, b, c) FROM (VALUES (1, 2, 3), (NULL, 4, 5), (NULL, NULL, 6), (NULL, NULL, NULL)) AS v(a, b, c)
@@ -432,15 +432,15 @@ render       ·              ·                                    ("coalesce") 
 ·            row 0, expr 0  1                                    ·                            ·
 ·            row 0, expr 1  2                                    ·                            ·
 ·            row 0, expr 2  3                                    ·                            ·
-·            row 1, expr 0  NULL                                 ·                            ·
+·            row 1, expr 0  CAST(NULL AS INT8)                   ·                            ·
 ·            row 1, expr 1  4                                    ·                            ·
 ·            row 1, expr 2  5                                    ·                            ·
-·            row 2, expr 0  NULL                                 ·                            ·
-·            row 2, expr 1  NULL                                 ·                            ·
+·            row 2, expr 0  CAST(NULL AS INT8)                   ·                            ·
+·            row 2, expr 1  CAST(NULL AS INT8)                   ·                            ·
 ·            row 2, expr 2  6                                    ·                            ·
-·            row 3, expr 0  NULL                                 ·                            ·
-·            row 3, expr 1  NULL                                 ·                            ·
-·            row 3, expr 2  NULL                                 ·                            ·
+·            row 3, expr 0  CAST(NULL AS INT8)                   ·                            ·
+·            row 3, expr 1  CAST(NULL AS INT8)                   ·                            ·
+·            row 3, expr 2  CAST(NULL AS INT8)                   ·                            ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE a BETWEEN b AND d

--- a/pkg/sql/opt/memo/testdata/logprops/groupby
+++ b/pkg/sql/opt/memo/testdata/logprops/groupby
@@ -250,7 +250,8 @@ group-by
       ├── tuple [type=tuple{int}]
       │    └── const: 1 [type=int]
       └── tuple [type=tuple{int}]
-           └── null [type=unknown]
+           └── cast: INT8 [type=int]
+                └── null [type=unknown]
 
 # GroupBy with empty grouping columns.
 opt

--- a/pkg/sql/opt/memo/testdata/logprops/values
+++ b/pkg/sql/opt/memo/testdata/logprops/values
@@ -16,7 +16,8 @@ values
  │    ├── const: 3 [type=int]
  │    └── const: 4 [type=int]
  └── tuple [type=tuple{int, int}]
-      ├── null [type=unknown]
+      ├── cast: INT8 [type=int]
+      │    └── null [type=unknown]
       └── const: 5 [type=int]
 
 build
@@ -44,11 +45,13 @@ values
  ├── cardinality: [3 - 3]
  ├── prune: (1,2)
  ├── tuple [type=tuple{int, int}]
- │    ├── null [type=unknown]
+ │    ├── cast: INT8 [type=int]
+ │    │    └── null [type=unknown]
  │    └── const: 2 [type=int]
  ├── tuple [type=tuple{int, int}]
  │    ├── const: 3 [type=int]
- │    └── null [type=unknown]
+ │    └── cast: INT8 [type=int]
+ │         └── null [type=unknown]
  └── tuple [type=tuple{int, int}]
       ├── const: 5 [type=int]
       └── const: 6 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/union
+++ b/pkg/sql/opt/optbuilder/testdata/union
@@ -851,7 +851,8 @@ union
  │    │    ├── columns: column1:1(unknown) column2:2(string)
  │    │    ├── tuple [type=tuple{unknown, string}]
  │    │    │    ├── null [type=unknown]
- │    │    │    └── null [type=unknown]
+ │    │    │    └── cast: STRING [type=string]
+ │    │    │         └── null [type=unknown]
  │    │    └── tuple [type=tuple{unknown, string}]
  │    │         ├── null [type=unknown]
  │    │         └── const: 'x' [type=string]
@@ -878,9 +879,11 @@ intersect
  │    ├── columns: column1:1(int) column2:2(string)
  │    ├── tuple [type=tuple{int, string}]
  │    │    ├── const: 3 [type=int]
- │    │    └── null [type=unknown]
+ │    │    └── cast: STRING [type=string]
+ │    │         └── null [type=unknown]
  │    └── tuple [type=tuple{int, string}]
- │         ├── null [type=unknown]
+ │         ├── cast: INT8 [type=int]
+ │         │    └── null [type=unknown]
  │         └── const: 'x' [type=string]
  └── project
       ├── columns: column2:5(string) column1:3(int!null)
@@ -909,7 +912,8 @@ union-all
  │    │    ├── columns: column1:1(unknown) column2:2(string)
  │    │    ├── tuple [type=tuple{unknown, string}]
  │    │    │    ├── null [type=unknown]
- │    │    │    └── null [type=unknown]
+ │    │    │    └── cast: STRING [type=string]
+ │    │    │         └── null [type=unknown]
  │    │    └── tuple [type=tuple{unknown, string}]
  │    │         ├── null [type=unknown]
  │    │         └── const: 'x' [type=string]

--- a/pkg/sql/opt/optbuilder/testdata/values
+++ b/pkg/sql/opt/optbuilder/testdata/values
@@ -108,11 +108,13 @@ VALUES (NULL, 1), (2, NULL)
 values
  ├── columns: column1:1(int) column2:2(int)
  ├── tuple [type=tuple{int, int}]
- │    ├── null [type=unknown]
+ │    ├── cast: INT8 [type=int]
+ │    │    └── null [type=unknown]
  │    └── const: 1 [type=int]
  └── tuple [type=tuple{int, int}]
       ├── const: 2 [type=int]
-      └── null [type=unknown]
+      └── cast: INT8 [type=int]
+           └── null [type=unknown]
 
 build
 VALUES (NULL, 1), (2, NULL)
@@ -120,11 +122,13 @@ VALUES (NULL, 1), (2, NULL)
 values
  ├── columns: column1:1(int) column2:2(int)
  ├── tuple [type=tuple{int, int}]
- │    ├── null [type=unknown]
+ │    ├── cast: INT8 [type=int]
+ │    │    └── null [type=unknown]
  │    └── const: 1 [type=int]
  └── tuple [type=tuple{int, int}]
       ├── const: 2 [type=int]
-      └── null [type=unknown]
+      └── cast: INT8 [type=int]
+           └── null [type=unknown]
 
 build
 VALUES (NULL, 1), (2, NULL), (NULL, 'a')
@@ -143,13 +147,17 @@ project
  │    │    └── const: 2 [type=int]
  │    ├── tuple [type=tuple{int, int}]
  │    │    ├── const: 3 [type=int]
- │    │    └── null [type=unknown]
+ │    │    └── cast: INT8 [type=int]
+ │    │         └── null [type=unknown]
  │    ├── tuple [type=tuple{int, int}]
- │    │    ├── null [type=unknown]
+ │    │    ├── cast: INT8 [type=int]
+ │    │    │    └── null [type=unknown]
  │    │    └── const: 4 [type=int]
  │    └── tuple [type=tuple{int, int}]
- │         ├── null [type=unknown]
- │         └── null [type=unknown]
+ │         ├── cast: INT8 [type=int]
+ │         │    └── null [type=unknown]
+ │         └── cast: INT8 [type=int]
+ │              └── null [type=unknown]
  └── projections
       └── coalesce [type=int]
            ├── variable: column1 [type=int]

--- a/pkg/sql/opt/optbuilder/values.go
+++ b/pkg/sql/opt/optbuilder/values.go
@@ -30,16 +30,11 @@ import (
 func (b *Builder) buildValuesClause(
 	values *tree.ValuesClause, desiredTypes []*types.T, inScope *scope,
 ) (outScope *scope) {
-	var numCols int
-	if len(values.Rows) > 0 {
+	numRows := len(values.Rows)
+	numCols := 0
+	if numRows > 0 {
 		numCols = len(values.Rows[0])
 	}
-
-	colTypes := make([]types.T, numCols)
-	for i := range colTypes {
-		colTypes[i] = *types.Unknown
-	}
-	rows := make(memo.ScalarListExpr, 0, len(values.Rows))
 
 	// We need to save and restore the previous value of the field in
 	// semaCtx in case we are recursively called within a subquery
@@ -50,44 +45,83 @@ func (b *Builder) buildValuesClause(
 	b.semaCtx.Properties.Require("VALUES", tree.RejectSpecial)
 	inScope.context = "VALUES"
 
-	for _, tuple := range values.Rows {
-		if numCols != len(tuple) {
-			reportValuesLenError(numCols, len(tuple))
-		}
+	// Typing a VALUES clause is not trivial; consider:
+	//   VALUES (NULL), (1)
+	// We want to type the entire column as INT. For this, we must find the first
+	// expression that resolves to a definite type. Moreover, we want the NULL to
+	// be typed correctly; so once we figure out the type, we must go back and
+	// add casts as necessary. We do this column by column and store the groups in
+	// a linearized matrix.
 
-		elems := make(memo.ScalarListExpr, numCols)
-		for i, expr := range tuple {
-			desired := types.Any
-			if i < len(desiredTypes) {
-				desired = desiredTypes[i]
+	// Bulk allocate ScalarListExpr slices: we need a matrix of size numRows by
+	// numCols and one slice of length numRows for the tuples.
+	elems := make(memo.ScalarListExpr, numRows*numCols+numRows)
+	tuples, elems := elems[:numRows], elems[numRows:]
+
+	colTypes := make([]types.T, numCols)
+	for colIdx := range colTypes {
+		desired := types.Any
+		if colIdx < len(desiredTypes) {
+			desired = desiredTypes[colIdx]
+		}
+		colTypes[colIdx] = *types.Unknown
+
+		elemPos := colIdx
+		for _, tuple := range values.Rows {
+			if numCols != len(tuple) {
+				reportValuesLenError(numCols, len(tuple))
 			}
 
-			texpr := inScope.resolveType(expr, desired)
-			typ := texpr.ResolvedType()
-			elems[i] = b.buildScalar(texpr, inScope, nil, nil, nil)
-
-			// Verify that types of each tuple match one another.
-			if colTypes[i].Family() == types.UnknownFamily {
-				colTypes[i] = *typ
-			} else if typ.Family() != types.UnknownFamily && !typ.Equivalent(&colTypes[i]) {
-				panic(pgerror.Newf(pgcode.DatatypeMismatch,
-					"VALUES types %s and %s cannot be matched", typ, &colTypes[i]))
+			expr := inScope.walkExprTree(tuple[colIdx])
+			texpr, err := tree.TypeCheck(expr, b.semaCtx, desired)
+			if err != nil {
+				panic(builderError{err})
 			}
+			if typ := texpr.ResolvedType(); typ.Family() != types.UnknownFamily {
+				if colTypes[colIdx].Family() == types.UnknownFamily {
+					colTypes[colIdx] = *typ
+				} else if !typ.Equivalent(&colTypes[colIdx]) {
+					panic(pgerror.Newf(pgcode.DatatypeMismatch,
+						"VALUES types %s and %s cannot be matched", typ, &colTypes[colIdx]))
+				}
+			}
+			elems[elemPos] = b.buildScalar(texpr, inScope, nil, nil, nil)
+			elemPos += numCols
 		}
 
-		tupleTyp := types.MakeTuple(colTypes)
-		rows = append(rows, b.factory.ConstructTuple(elems, tupleTyp))
+		// If we still don't have a type for the column, set it to the desired type.
+		if colTypes[colIdx].Family() == types.UnknownFamily && desired.Family() != types.AnyFamily {
+			colTypes[colIdx] = *desired
+		}
+
+		// Add casts to NULL values if necessary.
+		if colTypes[colIdx].Family() != types.UnknownFamily {
+			elemPos := colIdx
+			for range values.Rows {
+				if elems[elemPos].DataType().Family() == types.UnknownFamily {
+					elems[elemPos] = b.factory.ConstructCast(elems[elemPos], &colTypes[colIdx])
+				}
+				elemPos += numCols
+			}
+		}
+	}
+
+	// Build the tuples.
+	tupleTyp := types.MakeTuple(colTypes)
+	for rowIdx := range tuples {
+		tuples[rowIdx] = b.factory.ConstructTuple(elems[:numCols], tupleTyp)
+		elems = elems[numCols:]
 	}
 
 	outScope = inScope.push()
-	for i := 0; i < numCols; i++ {
+	for colIdx := 0; colIdx < numCols; colIdx++ {
 		// The column names for VALUES are column1, column2, etc.
-		alias := fmt.Sprintf("column%d", i+1)
-		b.synthesizeColumn(outScope, alias, &colTypes[i], nil, nil /* scalar */)
+		alias := fmt.Sprintf("column%d", colIdx+1)
+		b.synthesizeColumn(outScope, alias, &colTypes[colIdx], nil, nil /* scalar */)
 	}
 
 	colList := colsToColList(outScope.cols)
-	outScope.expr = b.factory.ConstructValues(rows, &memo.ValuesPrivate{
+	outScope.expr = b.factory.ConstructValues(tuples, &memo.ValuesPrivate{
 		Cols: colList,
 		ID:   b.factory.Metadata().NextValuesID(),
 	})

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -675,9 +675,13 @@ func MakeArray(typ *T) *T {
 
 // MakeTuple constructs a new instance of a TupleFamily type with the given
 // field types (some/all of which may be other TupleFamily types).
+//
+// Warning: the contents slice is used directly; the caller should not modify it
+// after calling this function.
 func MakeTuple(contents []T) *T {
 	return &T{InternalType: InternalType{
-		Family: TupleFamily, Oid: oid.T_record, TupleContents: contents, Locale: &emptyLocale}}
+		Family: TupleFamily, Oid: oid.T_record, TupleContents: contents, Locale: &emptyLocale,
+	}}
 }
 
 // MakeLabeledTuple constructs a new instance of a TupleFamily type with the


### PR DESCRIPTION
The way we currently build Values has a subtle bug - we are mutating
the types slice after creating the tuple type (and interning
expressions that use it). This is actually why we get a consistent
tuple type across all rows.

This commit fixes this by reorganizing this code. We go column by
column, generate all typed expressions, and only then create the tuple
type and add casts as necessary. This improves the typing of NULLs
inside Values.

Fixes #38274

Release note: None