### PR TITLE
contextutil: always apply a timeout in RunWithTimeout even when non-positive

### DIFF
--- a/pkg/util/contextutil/context.go
+++ b/pkg/util/contextutil/context.go
@@ -119,9 +119,6 @@ var _ net.Error = TimeoutError{}
 func RunWithTimeout(
 	ctx context.Context, op string, timeout time.Duration, fn func(ctx context.Context) error,
 ) error {
-	if timeout <= 0 {
-		return fn(ctx)
-	}
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	err := fn(ctx)


### PR DESCRIPTION
This change was motivated by the flakiness it introduces to
requestbatcher.TestBatchTimeout. The behavior as it existed was unintuitive and
could lead to no timeout being applied when a called might expect the context
to be immediately canceled. The new behavior now matches the behavior of
`context.WithTimeout` as the function's documentation implies. 

Fixes #38119.

Release note: None