### PR TITLE
cli: override system zone config in `cockroach demo`

### DIFF
--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -99,12 +99,16 @@ func setupTransientServer(
 	cfg := config.DefaultZoneConfig()
 	cfg.NumReplicas = proto.Int32(1)
 
+	sysCfg := config.DefaultSystemZoneConfig()
+	sysCfg.NumReplicas = proto.Int32(1)
+
 	// Create the transient server.
 	args := base.TestServerArgs{
 		Insecure: true,
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
-				DefaultZoneConfigOverride: &cfg,
+				DefaultZoneConfigOverride:       &cfg,
+				DefaultSystemZoneConfigOverride: &sysCfg,
 			},
 		},
 	}


### PR DESCRIPTION
The demo is known to be a single-node cluster, so set the default number of replicas in the system zone config to 1.

Fixes #38239

Release note: None