### PR TITLE
pkg: Add check disallowing IMPORT INTO a table with secondary indexes.

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -406,6 +406,12 @@ func importPlanHook(
 				return err
 			}
 
+			// The IMPORT INTO prototype currently breaks secondary indexes in the
+			// target table, as explained in issue #38044.
+			if len(found.AllNonDropIndexes()) != 0 {
+				return errors.Errorf("cannot IMPORT INTO a table with secondary indexes.")
+			}
+
 			if len(found.Mutations) > 0 {
 				return errors.Errorf("cannot IMPORT INTO a table with schema changes in progress -- try again later (pending mutation %s)", found.Mutations[0].String())
 			}

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1335,6 +1335,15 @@ func TestImportCSVStmt(t *testing.T) {
 			)
 		})
 	})
+
+	//TODO(adityamaru): Remove once issue #38044 is resolved.
+	t.Run("import-into-table-with-secondary-index", func(t *testing.T) {
+		sqlDB.Exec(t, "CREATE DATABASE s; USE s; CREATE TABLE t (a int8 primary key, b string, index (b))")
+		sqlDB.ExpectErr(
+			t, `cannot IMPORT INTO a table with secondary indexes.`,
+			fmt.Sprintf(`IMPORT INTO t(a, b) CSV DATA (%s)`, files[0]),
+		)
+	})
 }
 
 func BenchmarkImport(b *testing.B) {


### PR DESCRIPTION
IMPORT INTO will break secondary indexes in the target table as
described in issue #38044. This check prevents users from
running into this issue until it is resolved.

Release note: None