### PR TITLE
distsqlrun: include StartScan stall time in EXPLAIN ANALYZE

### DIFF
--- a/pkg/sql/distsqlrun/indexjoiner.go
+++ b/pkg/sql/distsqlrun/indexjoiner.go
@@ -36,11 +36,9 @@ type indexJoiner struct {
 	input RowSource
 	desc  sqlbase.TableDescriptor
 
-	// fetcherInput wraps fetcher in a RowSource implementation and should be used
-	// to get rows from the fetcher. This enables the indexJoiner to wrap the
-	// fetcherInput with a stat collector when necessary.
-	fetcherInput RowSource
-	fetcher      row.Fetcher
+	// fetcher wraps the row.Fetcher used to perform lookups. This enables the
+	// indexJoiner to wrap the fetcher with a stat collector when necessary.
+	fetcher rowFetcher
 	// fetcherReady indicates that we have started an index scan and there are
 	// potentially more rows to retrieve.
 	fetcherReady bool
@@ -97,8 +95,9 @@ func newIndexJoiner(
 	); err != nil {
 		return nil, err
 	}
+	var fetcher row.Fetcher
 	if _, _, err := initRowFetcher(
-		&ij.fetcher,
+		&fetcher,
 		&ij.desc,
 		0, /* primary index */
 		ij.desc.ColumnIdxMapWithMutations(needMutations),
@@ -110,13 +109,14 @@ func newIndexJoiner(
 	); err != nil {
 		return nil, err
 	}
-	ij.fetcherInput = &rowFetcherWrapper{Fetcher: &ij.fetcher}
 
 	if sp := opentracing.SpanFromContext(flowCtx.EvalCtx.Ctx()); sp != nil && tracing.IsRecording(sp) {
 		// Enable stats collection.
 		ij.input = NewInputStatCollector(ij.input)
-		ij.fetcherInput = NewInputStatCollector(ij.fetcherInput)
+		ij.fetcher = newRowFetcherStatCollector(&fetcher)
 		ij.finishTrace = ij.outputStatsToTrace
+	} else {
+		ij.fetcher = &rowFetcherWrapper{Fetcher: &fetcher}
 	}
 
 	return ij, nil
@@ -125,7 +125,7 @@ func newIndexJoiner(
 // Start is part of the RowSource interface.
 func (ij *indexJoiner) Start(ctx context.Context) context.Context {
 	ij.input.Start(ctx)
-	ij.fetcherInput.Start(ctx)
+	ij.fetcher.Start(ctx)
 	return ij.StartInternal(ctx, indexJoinerProcName)
 }
 
@@ -168,7 +168,7 @@ func (ij *indexJoiner) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata)
 			ij.fetcherReady = true
 			ij.spans = ij.spans[:0]
 		}
-		row, meta := ij.fetcherInput.Next()
+		row, meta := ij.fetcher.Next()
 		if meta != nil {
 			ij.MoveToDraining(scrub.UnwrapScrubError(meta.Err))
 			return nil, ij.DrainHelper()
@@ -212,7 +212,7 @@ func (ij *indexJoiner) outputStatsToTrace() {
 	if !ok {
 		return
 	}
-	ils, ok := getInputStats(ij.flowCtx, ij.fetcherInput)
+	ils, ok := getFetcherInputStats(ij.flowCtx, ij.fetcher)
 	if !ok {
 		return
 	}

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -930,6 +930,22 @@ func getInputStats(flowCtx *FlowCtx, input RowSource) (InputStats, bool) {
 	return isc.InputStats, true
 }
 
+func getFetcherInputStats(flowCtx *FlowCtx, f rowFetcher) (InputStats, bool) {
+	rfsc, ok := f.(*rowFetcherStatCollector)
+	if !ok {
+		return InputStats{}, false
+	}
+	is, ok := getInputStats(flowCtx, rfsc.inputStatCollector)
+	if !ok {
+		return InputStats{}, false
+	}
+	// Add row fetcher start scan stall time to Next() stall time.
+	if !flowCtx.testingKnobs.DeterministicStats {
+		is.StallTime += rfsc.startScanStallTime
+	}
+	return is, true
+}
+
 // rowSourceBase provides common functionality for RowSource implementations
 // that need to track consumer status. It is intended to be used by RowSource
 // implementations into which data is pushed by a producer async, as opposed to

--- a/pkg/sql/distsqlrun/stats.go
+++ b/pkg/sql/distsqlrun/stats.go
@@ -13,11 +13,17 @@
 package distsqlrun
 
 import (
+	"context"
 	"fmt"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -86,4 +92,110 @@ func (is InputStats) StatsForQueryPlan(prefix string) []string {
 // time.Millisecond.
 func (is InputStats) RoundStallTime() time.Duration {
 	return is.StallTime.Round(time.Microsecond)
+}
+
+// rowFetcher is an interface used to abstract a row fetcher so that a stat
+// collector wrapper can be plugged in.
+type rowFetcher interface {
+	RowSource
+	StartScan(
+		_ context.Context, _ *client.Txn, _ roachpb.Spans, limitBatches bool, limitHint int64, traceKV bool,
+	) error
+	StartInconsistentScan(
+		_ context.Context,
+		_ *client.DB,
+		initialTimestamp hlc.Timestamp,
+		maxTimestampAge time.Duration,
+		spans roachpb.Spans,
+		limitBatches bool,
+		limitHint int64,
+		traceKV bool,
+	) error
+
+	// PartialKey is not stat-related but needs to be supported.
+	PartialKey(int) (roachpb.Key, error)
+	Reset()
+	GetBytesRead() int64
+	GetRangesInfo() []roachpb.RangeInfo
+	NextRowWithErrors(context.Context) (sqlbase.EncDatumRow, error)
+}
+
+// rowFetcherWrapper is used only by processors that need to wrap calls to
+// Fetcher.NextRow() in a RowSource implementation.
+type rowFetcherWrapper struct {
+	ctx context.Context
+	*row.Fetcher
+}
+
+var _ RowSource = &rowFetcherWrapper{}
+
+// Start is part of the RowSource interface.
+func (w *rowFetcherWrapper) Start(ctx context.Context) context.Context {
+	w.ctx = ctx
+	return ctx
+}
+
+// Next() calls NextRow() on the underlying Fetcher. If an error is encountered,
+// it is returned via a ProducerMetadata.
+func (w *rowFetcherWrapper) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata) {
+	row, _, _, err := w.NextRow(w.ctx)
+	if err != nil {
+		return row, &distsqlpb.ProducerMetadata{Err: err}
+	}
+	return row, nil
+}
+func (w rowFetcherWrapper) OutputTypes() []types.T { return nil }
+func (w rowFetcherWrapper) ConsumerDone()          {}
+func (w rowFetcherWrapper) ConsumerClosed()        {}
+
+type rowFetcherStatCollector struct {
+	*rowFetcherWrapper
+	inputStatCollector *InputStatCollector
+	startScanStallTime time.Duration
+}
+
+var _ rowFetcher = &rowFetcherStatCollector{}
+
+func newRowFetcherStatCollector(f *row.Fetcher) *rowFetcherStatCollector {
+	fWrapper := &rowFetcherWrapper{Fetcher: f}
+	return &rowFetcherStatCollector{
+		rowFetcherWrapper:  fWrapper,
+		inputStatCollector: NewInputStatCollector(fWrapper),
+	}
+}
+
+func (c *rowFetcherStatCollector) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata) {
+	return c.inputStatCollector.Next()
+}
+
+func (c *rowFetcherStatCollector) StartScan(
+	ctx context.Context,
+	txn *client.Txn,
+	spans roachpb.Spans,
+	limitBatches bool,
+	limitHint int64,
+	traceKV bool,
+) error {
+	start := timeutil.Now()
+	err := c.rowFetcherWrapper.StartScan(ctx, txn, spans, limitBatches, limitHint, traceKV)
+	c.startScanStallTime += timeutil.Since(start)
+	return err
+}
+
+func (c *rowFetcherStatCollector) StartInconsistentScan(
+	ctx context.Context,
+	db *client.DB,
+	initialTimestamp hlc.Timestamp,
+	maxTimestampAge time.Duration,
+	spans roachpb.Spans,
+	limitBatches bool,
+	limitHint int64,
+	traceKV bool,
+) error {
+	start := timeutil.Now()
+	err := c.rowFetcherWrapper.StartInconsistentScan(
+		ctx, db, initialTimestamp, maxTimestampAge, spans, limitBatches, limitHint, traceKV,
+	)
+	c.startScanStallTime += timeutil.Since(start)
+	return err
 }


### PR DESCRIPTION
We previously assumed that StartScan was a once-per-query operation so
would not include time spent there in total stall time.

However, that is not the case for lookup joins, where the bulk of the
work is performed in StartScan once per batch.

Release note: None

cc @jordanlewis 