### PR TITLE
release-19.1: sql/pgwire: prevent overflow during decimal decoding

### DIFF
--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -440,7 +440,7 @@ func DecodeOidDatum(
 			}
 
 			if alloc.pgNum.Ndigits > 0 {
-				decDigits := make([]byte, 0, alloc.pgNum.Ndigits*PGDecDigits)
+				decDigits := make([]byte, 0, int(alloc.pgNum.Ndigits)*PGDecDigits)
 				nextDigit := func() error {
 					if err := binary.Read(r, binary.BigEndian, &alloc.i16); err != nil {
 						return err


### PR DESCRIPTION
Backport 1/1 commits from #38304.

/cc @cockroachdb/release

---

All the binary decimal fields are int16s. When multiplying by 4
(PGDecDigits), a value that was greater than math.MaxInt16/4 could thus
overflow to negative, causing the make to panic. Converting to an int
before multiplying prevents the panic.

Fixes #38139

Release note (bug fix): Fix a panic that could occur when decoding
decimals as query parameters.
