### PR TITLE
exec: implement vectorized ordinality operator

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -225,6 +225,13 @@ func newColOperator(
 		typs := conv.FromColumnTypes(columnTypes)
 		op, err = exec.NewOrderedDistinct(inputs[0], core.Distinct.OrderedColumns, typs)
 
+	case core.Ordinality != nil:
+		if err := checkNumIn(inputs, 1); err != nil {
+			return nil, err
+		}
+		columnTypes = append(spec.Input[0].ColumnTypes, *semtypes.Int)
+		op = exec.NewOrdinalityOp(inputs[0])
+
 	case core.HashJoiner != nil:
 		if err := checkNumIn(inputs, 2); err != nil {
 			return nil, err

--- a/pkg/sql/exec/offset.go
+++ b/pkg/sql/exec/offset.go
@@ -23,8 +23,7 @@ import (
 type offsetOp struct {
 	input Operator
 
-	internalBatch coldata.Batch
-	offset        uint64
+	offset uint64
 
 	// seen is the number of tuples seen so far.
 	seen uint64
@@ -42,7 +41,6 @@ func NewOffsetOp(input Operator, offset uint64) Operator {
 }
 
 func (c *offsetOp) Init() {
-	c.internalBatch = coldata.NewMemBatch(nil)
 	c.input.Init()
 }
 

--- a/pkg/sql/exec/ordinality.go
+++ b/pkg/sql/exec/ordinality.go
@@ -1,0 +1,76 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL.txt and at www.mariadb.com/bsl11.
+//
+// Change Date: 2022-10-01
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt and at
+// https://www.apache.org/licenses/LICENSE-2.0
+
+package exec
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+// ordinalityOp is an operator that implements WITH ORDINALITY, which adds
+// an additional column to the result with an ordinal number.
+type ordinalityOp struct {
+	input Operator
+
+	// hasOrdinalityColumn is a flag to indicate if the ordinality column has
+	// already been added to the batch. It is needed because batches are reused
+	// between subsequent calls to Next().
+	hasOrdinalityColumn bool
+	// counter is the number of tuples seen so far.
+	counter int64
+}
+
+var _ Operator = &ordinalityOp{}
+
+// NewOrdinalityOp returns a new WITH ORDINALITY operator.
+func NewOrdinalityOp(input Operator) Operator {
+	c := &ordinalityOp{
+		input:               input,
+		hasOrdinalityColumn: false,
+		counter:             1,
+	}
+	return c
+}
+
+func (c *ordinalityOp) Init() {
+	c.input.Init()
+}
+
+func (c *ordinalityOp) Next(ctx context.Context) coldata.Batch {
+	bat := c.input.Next(ctx)
+	if !c.hasOrdinalityColumn {
+		bat.AppendCol(types.Int64)
+		c.hasOrdinalityColumn = true
+	}
+	vec := bat.ColVec(bat.Width() - 1).Int64()
+	sel := bat.Selection()
+
+	if sel != nil {
+		// Bounds check elimination.
+		for _, i := range sel[:bat.Length()] {
+			vec[i] = c.counter
+			c.counter++
+		}
+	} else {
+		// Bounds check elimination.
+		vec = vec[:bat.Length()]
+		for i := range vec {
+			vec[i] = c.counter
+			c.counter++
+		}
+	}
+
+	return bat
+}

--- a/pkg/sql/exec/ordinality_test.go
+++ b/pkg/sql/exec/ordinality_test.go
@@ -1,0 +1,73 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL.txt and at www.mariadb.com/bsl11.
+//
+// Change Date: 2022-10-01
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt and at
+// https://www.apache.org/licenses/LICENSE-2.0
+
+package exec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+func TestOrdinality(t *testing.T) {
+	tcs := []struct {
+		tuples   []tuple
+		expected []tuple
+	}{
+		{
+			tuples:   tuples{{1}},
+			expected: tuples{{1, 1}},
+		},
+		{
+			tuples:   tuples{{}, {}, {}, {}, {}},
+			expected: tuples{{1}, {2}, {3}, {4}, {5}},
+		},
+		{
+			tuples:   tuples{{5}, {6}, {7}, {8}},
+			expected: tuples{{5, 1}, {6, 2}, {7, 3}, {8, 4}},
+		},
+		{
+			tuples:   tuples{{5, 'a'}, {6, 'b'}, {7, 'c'}, {8, 'd'}},
+			expected: tuples{{5, 'a', 1}, {6, 'b', 2}, {7, 'c', 3}, {8, 'd', 4}},
+		},
+	}
+
+	for _, tc := range tcs {
+		runTests(t, []tuples{tc.tuples}, func(t *testing.T, input []Operator) {
+			numExpectedCols := len(tc.expected[0])
+			ordinality := NewOrdinalityOp(input[0])
+			out := newOpTestOutput(ordinality, []int{0, 1, 2}[:numExpectedCols], tc.expected)
+
+			if err := out.Verify(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func BenchmarkOrdinality(b *testing.B) {
+	ctx := context.Background()
+
+	batch := coldata.NewMemBatch([]types.T{types.Int64, types.Int64, types.Int64})
+	batch.SetLength(coldata.BatchSize)
+	source := NewRepeatableBatchSource(batch)
+	source.Init()
+
+	ordinality := NewOrdinalityOp(source)
+
+	b.SetBytes(int64(8 * coldata.BatchSize * batch.Width()))
+	for i := 0; i < b.N; i++ {
+		ordinality.Next(ctx)
+	}
+}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -249,6 +249,17 @@ SELECT c.d FROM c@sec JOIN d ON d.b = c.b
 0
 0
 
+# Ordinality operator with a filter and limit.
+query III
+SELECT * FROM a WITH ORDINALITY WHERE a > 1 LIMIT 6
+----
+2  4  5
+2  5  6
+3  6  7
+3  7  8
+4  8  9
+4  9  10
+
 # Ensure that lookup joins properly get their postprocessing to select needed
 # columns.
 


### PR DESCRIPTION
```
> make bench PKG=./pkg/sql/exec BENCHES=BenchmarkOrdinality TESTFLAGS=-benchmem
BenchmarkOrdinality-12    1527 ns/op    16086.94 MB/s
```

Release note: None