### PR TITLE
storage: specialize snapshot application methods

### DIFF
--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -994,16 +994,112 @@ func (r *Replica) changeReplicas(
 	return &updatedDesc, nil
 }
 
-// sendSnapshot sends a snapshot of the replica state to the specified
-// replica. This is used for both preemptive snapshots that are performed
-// before adding a replica to a range, and for Raft-initiated snapshots that
-// are used to bring a replica up to date that has fallen too far
-// behind. Currently only invoked from replicateQueue and raftSnapshotQueue. Be
-// careful about adding additional calls as generating a snapshot is moderately
+// sendSnapshot sends a snapshot of the replica state to the specified replica.
+// Currently only invoked from replicateQueue and raftSnapshotQueue. Be careful
+// about adding additional calls as generating a snapshot is moderately
 // expensive.
+//
+// A snapshot is a bulk transfer of all data in a range. It consists of a
+// consistent view of all the state needed to run some replica of a range as of
+// some applied index (not as of some mvcc-time). Snapshots are used by Raft
+// when a follower is far enough behind the leader that it can no longer be
+// caught up using incremental diffs (because the leader has already garbage
+// collected the diffs, in this case because it truncated the Raft log past
+// where the follower is).
+//
+// We also proactively send a snapshot when adding a new replica to bootstrap it
+// (this is called a "learner" snapshot and is a special case of a Raft
+// snapshot, we just speed the process along). It's called a learner snapshot
+// because it's sent to what Raft terms a learner replica. As of 19.2, when we
+// add a new replica, it's first added as a learner using a Raft ConfChange,
+// which means it accepts Raft traffic but doesn't vote or affect quorum. Then
+// we immediately send it a snapshot to catch it up. After the snapshot
+// successfully applies, we turn it into a normal voting replica using another
+// ConfChange. It then uses the normal mechanisms to catch up with whatever got
+// committed to the Raft log during the snapshot transfer. In contrast to adding
+// the voting replica directly, this avoids a period of fragility when the
+// replica would be a full member, but very far behind. [1]
+//
+// Snapshots are expensive and mostly unexpected (except learner snapshots
+// during rebalancing). The quota pool is responsible for keeping a leader from
+// getting too far ahead of any of the followers, so ideally they'd never be far
+// enough behind to need a snapshot.
+//
+// The snapshot process itself is broken into 3 parts: generating the snapshot,
+// transmitting it, and applying it.
+//
+// Generating the snapshot: The data contained in a snapshot is a full copy of
+// the replicated data plus everything the replica needs to be a healthy member
+// of a Raft group. The former is large, so we send it via streaming rpc instead
+// of keeping it all in memory at once. (Well, at least on the sender side. On
+// the recipient side, we do still buffer it, but we'll fix that at some point).
+// The `(Replica).GetSnapshot` method does the necessary locking and gathers the
+// various Raft state needed to run a replica. It also creates an iterator for
+// the range's data as it looked under those locks (this is powered by a RocksDB
+// snapshot, which is a different thing but a similar idea). Notably,
+// GetSnapshot does not do the data iteration.
+//
+// Transmitting the snapshot: The transfer itself happens over the grpc
+// `RaftSnapshot` method, which is a bi-directional stream of `SnapshotRequest`s
+// and `SnapshotResponse`s. The two sides are orchestrated by the
+// `(RaftTransport).SendSnapshot` and `(Store).receiveSnapshot` methods.
+//
+// `SendSnapshot` starts up the streaming rpc and first sends a header message
+// with everything but the range data and then blocks, waiting on the first
+// streaming response from the recipient. This lets us short-circuit sending the
+// range data if the recipient can't be contacted or if it can't use the
+// snapshot (which is usually the result of a race). The recipient's grpc
+// handler for RaftSnapshot sanity checks a few things and ends up calling down
+// into `receiveSnapshot`, which does the bulk of the work. `receiveSnapshot`
+// starts by waiting for a reservation in the snapshot rate limiter. It then
+// reads the header message and hands it to `shouldAcceptSnapshotData` to
+// determine if it can use the snapshot [2]. `shouldAcceptSnapshotData` is
+// advisory and can return false positives. If `shouldAcceptSnapshotData`
+// returns true, this is communicated back to the sender, which then proceeds to
+// call `kvBatchSnapshotStrategy.Send`. This uses the iterator captured earlier
+// to send the data in chunks, each chunk a streaming grpc message. The sender
+// then sends a final message with an indicaton that it's done and blocks again,
+// waiting for a second and final response from the recipient which indicates if
+// the snapshot was a success.
+//
+// Applying the snapshot: After the recipient has received the message
+// indicating it has all the data, it hands it all to
+// `(Store).processRaftSnapshotRequest` to be applied. First, this re-checks the
+// same things as `shouldAcceptSnapshotData` to make sure nothing has changed
+// while the snapshot was being transferred. It then guarantees that there is
+// either an initialized[3] replica or a `ReplicaPlaceholder`[4] to accept the
+// snapshot by creating a placeholder if necessary. Finally, a *Raft snapshot*
+// message is manually handed to the replica's Raft node (by calling
+// `stepRaftGroup` + `handleRaftReadyRaftMuLocked`), at which point the snapshot
+// has been applied.
+//
+// [1]: There is a third kind of snapshot, called "preemptive", which is how we
+// avoided the above fragility before learner replicas were introduced in the
+// 19.2 cycle. It's essentially a snapshot that we made very fast by staging it
+// on a remote node right before we added a replica on that node. However,
+// preemptive snapshots came with all sorts of complexity that we're delighted
+// to be rid of. They have to stay around for clusters with mixed 19.1 and 19.2
+// nodes, but after 19.2, we can remove them entirely.
+//
+// [2]: The largest class of rejections here is if the store contains a replica
+// that overlaps the snapshot but has a different id (we maintain an invariant
+// that replicas on a store never overlap). This usually happens when the
+// recipient has an old copy of a replica that is no longer part of a range and
+// the `replicaGCQueue` hasn't gotten around to collecting it yet. So if this
+// happens, `shouldAcceptSnapshotData` will queue it up for consideration.
+//
+// [3]: A uninitialized replica is created when a replica that's being added
+// gets traffic from its new peers before it gets a snapshot. It may be possible
+// to get rid of uninitialized replicas (by dropping all Raft traffic except
+// votes on the floor), but this is a cleanup that hasn't happened yet.
+//
+// [4]: The placeholder is essentially a snapshot lock, making any future
+// callers of `shouldAcceptSnapshotData` return an error so that we no longer
+// have to worry about racing with a second snapshot. See the comment on
+// ReplicaPlaceholder for details.
 func (r *Replica) sendSnapshot(
 	ctx context.Context,
-	repDesc roachpb.ReplicaDescriptor,
+	recipient roachpb.ReplicaDescriptor,
 	snapType SnapshotRequest_Type,
 	priority SnapshotRequest_Priority,
 ) error {
@@ -1014,7 +1110,7 @@ func (r *Replica) sendSnapshot(
 	defer snap.Close()
 	log.Event(ctx, "generated snapshot")
 
-	fromRepDesc, err := r.GetReplicaDescriptor()
+	sender, err := r.GetReplicaDescriptor()
 	if err != nil {
 		return errors.Wrapf(err, "%s: change replicas failed", r)
 	}
@@ -1065,12 +1161,12 @@ func (r *Replica) sendSnapshot(
 		UnreplicatedTruncatedState: !usesReplicatedTruncatedState,
 		RaftMessageRequest: RaftMessageRequest{
 			RangeID:     r.RangeID,
-			FromReplica: fromRepDesc,
-			ToReplica:   repDesc,
+			FromReplica: sender,
+			ToReplica:   recipient,
 			Message: raftpb.Message{
 				Type:     raftpb.MsgSnap,
-				To:       uint64(repDesc.ReplicaID),
-				From:     uint64(fromRepDesc.ReplicaID),
+				To:       uint64(recipient.ReplicaID),
+				From:     uint64(sender.ReplicaID),
 				Term:     status.Term,
 				Snapshot: snap.RaftSnap,
 			},

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -63,6 +63,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	crdberrors "github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/google/btree"
 	"github.com/pkg/errors"
@@ -3374,6 +3375,10 @@ func (s *Store) processRaftRequestWithReplica(
 func (s *Store) processRaftSnapshotRequest(
 	ctx context.Context, snapHeader *SnapshotRequest_Header, inSnap IncomingSnapshot,
 ) *roachpb.Error {
+	if snapHeader.IsPreemptive() {
+		return roachpb.NewError(crdberrors.AssertionFailedf(`expected a raft or learner snapshot`))
+	}
+
 	return s.withReplicaForRequest(ctx, &snapHeader.RaftMessageRequest, func(
 		ctx context.Context, r *Replica,
 	) (pErr *roachpb.Error) {
@@ -3390,7 +3395,7 @@ func (s *Store) processRaftSnapshotRequest(
 		if err := func() error {
 			s.mu.Lock()
 			defer s.mu.Unlock()
-			placeholder, err := s.canApplySnapshotLocked(ctx, snapHeader, true /* authoritative */)
+			placeholder, err := s.canApplySnapshotLocked(ctx, snapHeader)
 			if err != nil {
 				// If the storage cannot accept the snapshot, return an
 				// error before passing it to RawNode.Step, since our
@@ -3426,123 +3431,6 @@ func (s *Store) processRaftSnapshotRequest(
 					}
 				}
 			}()
-		}
-
-		if snapHeader.IsPreemptive() {
-			// Requiring that the Term is set in a message makes sure that we
-			// get all of Raft's internal safety checks (it confuses messages
-			// at term zero for internal messages). The sending side uses the
-			// term from the snapshot itself, but we'll just check nonzero.
-			if snapHeader.RaftMessageRequest.Message.Term == 0 {
-				return roachpb.NewErrorf(
-					"preemptive snapshot from term %d received with zero term",
-					snapHeader.RaftMessageRequest.Message.Snapshot.Metadata.Term,
-				)
-			}
-			// TODO(tschottdorf): A lot of locking of the individual Replica
-			// going on below as well. I think that's more easily refactored
-			// away; what really matters is that the Store doesn't do anything
-			// else with that same Replica (or one that might conflict with us
-			// while we still run). In effect, we'd want something like:
-			//
-			// 1. look up the snapshot's key range
-			// 2. get an exclusive lock for operations on that key range from
-			//    the store (or discard the snapshot)
-			//    (at the time of writing, we have checked the key range in
-			//    canApplySnapshotLocked above, but there are concerns about two
-			//    conflicting operations passing that check simultaneously,
-			//    see #7830)
-			// 3. do everything below (apply the snapshot through temp Raft group)
-			// 4. release the exclusive lock on the snapshot's key range
-			//
-			// There are two future outcomes: Either we begin receiving
-			// legitimate Raft traffic for this Range (hence learning the
-			// ReplicaID and becoming a real Replica), or the Replica GC queue
-			// decides that the ChangeReplicas as a part of which the
-			// preemptive snapshot was sent has likely failed and removes both
-			// in-memory and on-disk state.
-			r.mu.Lock()
-			// We are paranoid about applying preemptive snapshots (which
-			// were constructed via our code rather than raft) to the "real"
-			// raft group. Instead, we destroy the "real" raft group if one
-			// exists (this is rare in production, although it occurs in
-			// tests), apply the preemptive snapshot to a temporary raft
-			// group, then discard that one as well to be replaced by a real
-			// raft group when we get a new replica ID.
-			//
-			// It might be OK instead to apply preemptive snapshots just
-			// like normal ones (essentially switching between regular and
-			// preemptive mode based on whether or not we have a raft group,
-			// instead of based on the replica ID of the snapshot message).
-			// However, this is a risk that we're not yet willing to take.
-			// Additionally, without some additional plumbing work, doing so
-			// would limit the effectiveness of RaftTransport.SendSync for
-			// preemptive snapshots.
-			r.mu.internalRaftGroup = nil
-			needTombstone := r.mu.state.Desc.NextReplicaID != 0
-			r.mu.Unlock()
-
-			appliedIndex, _, err := r.raftMu.stateLoader.LoadAppliedIndex(ctx, r.store.Engine())
-			if err != nil {
-				return roachpb.NewError(err)
-			}
-			raftGroup, err := raft.NewRawNode(
-				newRaftConfig(
-					raft.Storage((*replicaRaftStorage)(r)),
-					preemptiveSnapshotRaftGroupID,
-					// We pass the "real" applied index here due to subtleties
-					// arising in the case in which Raft discards the snapshot:
-					// It would instruct us to apply entries, which would have
-					// crashing potential for any choice of dummy value below.
-					appliedIndex,
-					r.store.cfg,
-					&raftLogger{ctx: ctx},
-				), nil)
-			if err != nil {
-				return roachpb.NewError(err)
-			}
-			// We have a Raft group; feed it the message.
-			if err := raftGroup.Step(snapHeader.RaftMessageRequest.Message); err != nil {
-				return roachpb.NewError(errors.Wrap(err, "unable to process preemptive snapshot"))
-			}
-			// In the normal case, the group should ask us to apply a snapshot.
-			// If it doesn't, our snapshot was probably stale. In that case we
-			// still go ahead and apply a noop because we want that case to be
-			// counted by stats as a successful application.
-			var ready raft.Ready
-			if raftGroup.HasReady() {
-				ready = raftGroup.Ready()
-			}
-
-			if needTombstone {
-				// Bump the min replica ID, but don't write the tombstone key. The
-				// tombstone key is not expected to be present when normal replica data
-				// is present and applySnapshot would delete the key in most cases. If
-				// Raft has decided the snapshot shouldn't be applied we would be
-				// writing the tombstone key incorrectly.
-				r.mu.Lock()
-				if r.mu.state.Desc.NextReplicaID > r.mu.minReplicaID {
-					r.mu.minReplicaID = r.mu.state.Desc.NextReplicaID
-				}
-				r.mu.Unlock()
-			}
-
-			// Apply the snapshot, as Raft told us to. Preemptive snapshots never
-			// subsume replicas (this is guaranteed by Store.canApplySnapshot), so
-			// we can simply pass nil for the subsumedRepls parameter.
-			if err := r.applySnapshot(
-				ctx, inSnap, ready.Snapshot, ready.HardState, nil, /* subsumedRepls */
-			); err != nil {
-				return roachpb.NewError(err)
-			}
-			// applySnapshot has already removed the placeholder.
-			removePlaceholder = false
-
-			// At this point, the Replica has data but no ReplicaID. We hope
-			// that it turns into a "real" Replica by means of receiving Raft
-			// messages addressed to it with a ReplicaID, but if that doesn't
-			// happen, at some point the Replica GC queue will have to grab it.
-			return nil
 		}
 
 		if err := r.stepRaftGroup(&snapHeader.RaftMessageRequest); err != nil {

--- a/pkg/storage/store_snapshot.go
+++ b/pkg/storage/store_snapshot.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	crdberrors "github.com/cockroachdb/errors"
 	"github.com/pkg/errors"
 	"go.etcd.io/etcd/raft/raftpb"
 	"golang.org/x/time/rate"
@@ -408,143 +409,55 @@ func (s *Store) reserveSnapshot(
 	}, "", nil
 }
 
-// canApplySnapshot returns (_, nil) if the snapshot can be applied to
+// canApplySnapshotLocked returns (_, nil) if the snapshot can be applied to
 // this store's replica (i.e. the snapshot is not from an older incarnation of
 // the replica) and a placeholder can be added to the replicasByKey map (if
 // necessary). If a placeholder is required, it is returned as the first value.
-// The authoritative bool determines whether the check is carried out with the
-// intention of actually applying the snapshot (in which case an existing replica
-// must exist and have its raftMu locked) or as a preliminary check.
-func (s *Store) canApplySnapshot(
-	ctx context.Context, snapHeader *SnapshotRequest_Header, authoritative bool,
-) (*ReplicaPlaceholder, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.canApplySnapshotLocked(ctx, snapHeader, authoritative)
-}
-
+//
+// Both the store mu (and the raft mu for an existing replica if there is one)
+// must be held.
 func (s *Store) canApplySnapshotLocked(
-	ctx context.Context, snapHeader *SnapshotRequest_Header, authoritative bool,
+	ctx context.Context, snapHeader *SnapshotRequest_Header,
 ) (*ReplicaPlaceholder, error) {
+	if snapHeader.IsPreemptive() {
+		return nil, crdberrors.AssertionFailedf(`expected a raft or learner snapshot`)
+	}
+
 	// TODO(tbg): see the comment on desc.Generation for what seems to be a much
 	// saner way to handle overlap via generational semantics.
 	desc := *snapHeader.State.Desc
 
 	// First, check for an existing Replica.
-	//
-	// We call canApplySnapshotLocked twice for each snapshot application. In
-	// the first case, it's an optimization early before having received any
-	// data (and we don't use the placeholder if one is returned), and the
-	// replica may or may not be present.
-	//
-	// The second call happens right before we actually plan to apply the
-	// snapshot (and a Replica is always in place at that point). This means
-	// that without a Replica, we can have false positives, but if we have a
-	// replica it needs to take everything into account.
-	//
-	// TODO(tbg): untangle these two use cases.
-	if v, ok := s.mu.replicas.Load(
+	v, ok := s.mu.replicas.Load(
 		int64(desc.RangeID),
-	); !ok {
-		if authoritative {
-			return nil, errors.Errorf("authoritative call requires a replica present")
-		}
-	} else {
-		existingRepl := (*Replica)(v)
-		// The raftMu is held which allows us to use the existing replica as a
-		// placeholder when we decide that the snapshot can be applied. As long
-		// as the caller releases the raftMu only after feeding the snapshot
-		// into the replica, this is safe.
-		if authoritative {
-			existingRepl.raftMu.AssertHeld()
-		}
+	)
+	if !ok {
+		return nil, errors.Errorf("canApplySnapshotLocked requires a replica present")
+	}
+	existingRepl := (*Replica)(v)
+	// The raftMu is held which allows us to use the existing replica as a
+	// placeholder when we decide that the snapshot can be applied. As long
+	// as the caller releases the raftMu only after feeding the snapshot
+	// into the replica, this is safe.
+	existingRepl.raftMu.AssertHeld()
 
-		existingRepl.mu.RLock()
-		existingDesc := existingRepl.descRLocked()
-		existingIsInitialized := existingRepl.isInitializedRLocked()
-		existingIsPreemptive := existingRepl.mu.replicaID == 0
-		existingRepl.mu.RUnlock()
+	existingRepl.mu.RLock()
+	existingIsInitialized := existingRepl.isInitializedRLocked()
+	existingRepl.mu.RUnlock()
 
-		if existingIsInitialized {
-			if !snapHeader.IsPreemptive() {
-				// Regular Raft snapshots can't be refused at this point,
-				// even if they widen the existing replica. See the comments
-				// in Replica.maybeAcquireSnapshotMergeLock for how this is
-				// made safe.
-				//
-				// NB: we expect the replica to know its replicaID at this point
-				// (i.e. !existingIsPreemptive), though perhaps it's possible
-				// that this isn't true if the leader initiates a Raft snapshot
-				// (that would provide a range descriptor with this replica in
-				// it) but this node reboots (temporarily forgetting its
-				// replicaID) before the snapshot arrives.
-				return nil, nil
-			}
-
-			if existingIsPreemptive {
-				// Allow applying a preemptive snapshot on top of another
-				// preemptive snapshot. We only need to acquire a placeholder
-				// for the part (if any) of the new snapshot that extends past
-				// the old one. If there's no such overlap, return early; if
-				// there is, "forward" the descriptor's StartKey so that the
-				// later code will only check the overlap.
-				//
-				// NB: morally it would be cleaner to ask for the existing
-				// replica to be GC'ed first, but consider that the preemptive
-				// snapshot was likely left behind by a failed attempt to
-				// up-replicate. This is a relatively common scenario and not
-				// worth discarding and resending another snapshot for. Let the
-				// snapshot through, which means "pretending that it doesn't
-				// intersect the existing replica".
-				if !existingDesc.EndKey.Less(desc.EndKey) {
-					return nil, nil
-				}
-				desc.StartKey = existingDesc.EndKey
-			}
-			// NB: If the existing snapshot is *not* preemptive (i.e. the above
-			// branch wasn't taken), the overlap check below will hit an error.
-			// This path is hit after a rapid up-down-upreplication to the same
-			// store and will resolve as the replicaGCQueue removes the existing
-			// replica. We are pretty sure that the existing replica is gc'able,
-			// because a preemptive snapshot implies that someone is trying to
-			// add this replica to the group at the moment. (We are not however,
-			// sure enough that this couldn't happen by accident to GC the
-			// replica ourselves - the replica GC queue will perform the proper
-			// check).
-		} else if snapHeader.IsPreemptive() {
-			// Morally, the existing replica now has a nonzero replica ID
-			// because we already know that it is not initialized (i.e. has no
-			// data). Interestingly, the case in which it has a zero replica ID
-			// is also possible and should see the snapshot accepted as it
-			// occurs when a preemptive snapshot is handled: we first create a
-			// Replica in this state, run this check, and then apply the
-			// preemptive snapshot.
-			if !existingIsPreemptive {
-				// This is similar to the case of a preemptive snapshot hitting
-				// a fully initialized replica (i.e. not a preemptive snapshot)
-				// at the end of the last branch (which we don't allow), so we
-				// want to reject the snapshot. There is a tricky problem to
-				// to solve here, though: existingRepl doesn't know anything
-				// about its key bounds, and so to check whether it is actually
-				// gc'able would require a full scan of the meta2 entries (and
-				// we would also need to teach the queues how to deal with un-
-				// initialized replicas).
-				//
-				// So we let the snapshot through (by falling through to the
-				// overlap check, where it either picks up placeholders or
-				// fails). This is safe (or at least we assume so) because we
-				// carry out all snapshot decisions through Raft (though it
-				// still is an odd path that we would be wise to avoid if it
-				// weren't so difficult).
-				//
-				// A consequence of letting this snapshot through is opening this
-				// replica up to the possibility of erroneous replicaGC. This is
-				// because it will retain the replicaID of the current replica,
-				// which is going to be initialized after the snapshot (and thus
-				// gc'able).
-				_ = 0 // avoid staticcheck failure
-			}
-		}
+	if existingIsInitialized {
+		// Regular Raft snapshots can't be refused at this point,
+		// even if they widen the existing replica. See the comments
+		// in Replica.maybeAcquireSnapshotMergeLock for how this is
+		// made safe.
+		//
+		// NB: we expect the replica to know its replicaID at this point
+		// (i.e. !existingIsPreemptive), though perhaps it's possible
+		// that this isn't true if the leader initiates a Raft snapshot
+		// (that would provide a range descriptor with this replica in
+		// it) but this node reboots (temporarily forgetting its
+		// replicaID) before the snapshot arrives.
+		return nil, nil
 	}
 
 	// We have a key range [desc.StartKey,desc.EndKey) which we want to apply a
@@ -624,156 +537,56 @@ func (s *Store) checkSnapshotOverlapLocked(
 	return nil
 }
 
-// shouldAcceptSnapshotData returns (_, nil) if the snapshot can be applied to
-// this store's replica (i.e. the snapshot is not from an older incarnation of
-// the replica) and a placeholder can be added to the replicasByKey map (if
-// necessary). If a placeholder is required, it is returned as the first value.
-// The authoritative bool determines whether the check is carried out with the
-// intention of actually applying the snapshot (in which case an existing replica
-// must exist and have its raftMu locked) or as a preliminary check.
+// shouldAcceptSnapshotData is an optimization to check whether we should even
+// bother to read the data for an incoming snapshot. If the snapshot overlaps an
+// existing replica or placeholder, we'd error during application anyway, so do
+// it before transferring all the data. This method is a guess and may have
+// false positives. If the snapshot should be rejected, an error is returned
+// with a description of why. Otherwise, nil means we should accept the
+// snapshot.
 func (s *Store) shouldAcceptSnapshotData(
-	ctx context.Context, snapHeader *SnapshotRequest_Header, authoritative bool,
-) (*ReplicaPlaceholder, error) {
+	ctx context.Context, snapHeader *SnapshotRequest_Header,
+) error {
+	if snapHeader.IsPreemptive() {
+		return crdberrors.AssertionFailedf(`expected a raft or learner snapshot`)
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.shouldAcceptSnapshotDataLocked(ctx, snapHeader, authoritative)
-}
 
-func (s *Store) shouldAcceptSnapshotDataLocked(
-	ctx context.Context, snapHeader *SnapshotRequest_Header, authoritative bool,
-) (*ReplicaPlaceholder, error) {
 	// TODO(tbg): see the comment on desc.Generation for what seems to be a much
 	// saner way to handle overlap via generational semantics.
 	desc := *snapHeader.State.Desc
 
 	// First, check for an existing Replica.
-	//
-	// We call canApplySnapshotLocked twice for each snapshot application. In
-	// the first case, it's an optimization early before having received any
-	// data (and we don't use the placeholder if one is returned), and the
-	// replica may or may not be present.
-	//
-	// The second call happens right before we actually plan to apply the
-	// snapshot (and a Replica is always in place at that point). This means
-	// that without a Replica, we can have false positives, but if we have a
-	// replica it needs to take everything into account.
-	//
-	// TODO(tbg): untangle these two use cases.
 	if v, ok := s.mu.replicas.Load(
 		int64(desc.RangeID),
-	); !ok {
-		if authoritative {
-			return nil, errors.Errorf("authoritative call requires a replica present")
-		}
-	} else {
+	); ok {
 		existingRepl := (*Replica)(v)
-		// The raftMu is held which allows us to use the existing replica as a
-		// placeholder when we decide that the snapshot can be applied. As long
-		// as the caller releases the raftMu only after feeding the snapshot
-		// into the replica, this is safe.
-		if authoritative {
-			existingRepl.raftMu.AssertHeld()
-		}
-
 		existingRepl.mu.RLock()
-		existingDesc := existingRepl.descRLocked()
 		existingIsInitialized := existingRepl.isInitializedRLocked()
-		existingIsPreemptive := existingRepl.mu.replicaID == 0
 		existingRepl.mu.RUnlock()
 
 		if existingIsInitialized {
-			if !snapHeader.IsPreemptive() {
-				// Regular Raft snapshots can't be refused at this point,
-				// even if they widen the existing replica. See the comments
-				// in Replica.maybeAcquireSnapshotMergeLock for how this is
-				// made safe.
-				//
-				// NB: we expect the replica to know its replicaID at this point
-				// (i.e. !existingIsPreemptive), though perhaps it's possible
-				// that this isn't true if the leader initiates a Raft snapshot
-				// (that would provide a range descriptor with this replica in
-				// it) but this node reboots (temporarily forgetting its
-				// replicaID) before the snapshot arrives.
-				return nil, nil
-			}
-
-			if existingIsPreemptive {
-				// Allow applying a preemptive snapshot on top of another
-				// preemptive snapshot. We only need to acquire a placeholder
-				// for the part (if any) of the new snapshot that extends past
-				// the old one. If there's no such overlap, return early; if
-				// there is, "forward" the descriptor's StartKey so that the
-				// later code will only check the overlap.
-				//
-				// NB: morally it would be cleaner to ask for the existing
-				// replica to be GC'ed first, but consider that the preemptive
-				// snapshot was likely left behind by a failed attempt to
-				// up-replicate. This is a relatively common scenario and not
-				// worth discarding and resending another snapshot for. Let the
-				// snapshot through, which means "pretending that it doesn't
-				// intersect the existing replica".
-				if !existingDesc.EndKey.Less(desc.EndKey) {
-					return nil, nil
-				}
-				desc.StartKey = existingDesc.EndKey
-			}
-			// NB: If the existing snapshot is *not* preemptive (i.e. the above
-			// branch wasn't taken), the overlap check below will hit an error.
-			// This path is hit after a rapid up-down-upreplication to the same
-			// store and will resolve as the replicaGCQueue removes the existing
-			// replica. We are pretty sure that the existing replica is gc'able,
-			// because a preemptive snapshot implies that someone is trying to
-			// add this replica to the group at the moment. (We are not however,
-			// sure enough that this couldn't happen by accident to GC the
-			// replica ourselves - the replica GC queue will perform the proper
-			// check).
-		} else if snapHeader.IsPreemptive() {
-			// Morally, the existing replica now has a nonzero replica ID
-			// because we already know that it is not initialized (i.e. has no
-			// data). Interestingly, the case in which it has a zero replica ID
-			// is also possible and should see the snapshot accepted as it
-			// occurs when a preemptive snapshot is handled: we first create a
-			// Replica in this state, run this check, and then apply the
-			// preemptive snapshot.
-			if !existingIsPreemptive {
-				// This is similar to the case of a preemptive snapshot hitting
-				// a fully initialized replica (i.e. not a preemptive snapshot)
-				// at the end of the last branch (which we don't allow), so we
-				// want to reject the snapshot. There is a tricky problem to
-				// to solve here, though: existingRepl doesn't know anything
-				// about its key bounds, and so to check whether it is actually
-				// gc'able would require a full scan of the meta2 entries (and
-				// we would also need to teach the queues how to deal with un-
-				// initialized replicas).
-				//
-				// So we let the snapshot through (by falling through to the
-				// overlap check, where it either picks up placeholders or
-				// fails). This is safe (or at least we assume so) because we
-				// carry out all snapshot decisions through Raft (though it
-				// still is an odd path that we would be wise to avoid if it
-				// weren't so difficult).
-				//
-				// A consequence of letting this snapshot through is opening this
-				// replica up to the possibility of erroneous replicaGC. This is
-				// because it will retain the replicaID of the current replica,
-				// which is going to be initialized after the snapshot (and thus
-				// gc'able).
-				_ = 0 // avoid staticcheck failure
-			}
+			// Regular Raft snapshots can't be refused at this point,
+			// even if they widen the existing replica. See the comments
+			// in Replica.maybeAcquireSnapshotMergeLock for how this is
+			// made safe.
+			//
+			// NB: we expect the replica to know its replicaID at this point
+			// (i.e. !existingIsPreemptive), though perhaps it's possible
+			// that this isn't true if the leader initiates a Raft snapshot
+			// (that would provide a range descriptor with this replica in
+			// it) but this node reboots (temporarily forgetting its
+			// replicaID) before the snapshot arrives.
+			return nil
 		}
 	}
 
 	// We have a key range [desc.StartKey,desc.EndKey) which we want to apply a
 	// snapshot for. Is there a conflicting existing placeholder or an
 	// overlapping range?
-	if err := s.checkSnapshotOverlapLocked(ctx, snapHeader); err != nil {
-		return nil, err
-	}
-
-	placeholder := &ReplicaPlaceholder{
-		rangeDesc: desc,
-	}
-	return placeholder, nil
+	return s.checkSnapshotOverlapLocked(ctx, snapHeader)
 }
 
 // receiveSnapshot receives an incoming snapshot via a pre-opened GRPC stream.
@@ -804,7 +617,7 @@ func (s *Store) receiveSnapshot(
 			)
 		}
 	} else {
-		if _, err := s.shouldAcceptSnapshotData(ctx, header, false /* authoritative */); err != nil {
+		if err := s.shouldAcceptSnapshotData(ctx, header); err != nil {
 			return sendSnapshotError(stream,
 				errors.Wrapf(err, "%s,r%d: cannot apply snapshot", s, header.State.Desc.RangeID),
 			)

--- a/pkg/storage/store_snapshot_preemptive.go
+++ b/pkg/storage/store_snapshot_preemptive.go
@@ -1,14 +1,12 @@
 // Copyright 2019 The Cockroach Authors.
 //
-// Use of this software is governed by the Business Source License included
-// in the file licenses/BSL.txt and at www.mariadb.com/bsl11.
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
 //
-// Change Date: 2022-10-01
-//
-// On the date above, in accordance with the Business Source License, use
-// of this software will be governed by the Apache License, Version 2.0,
-// included in the file licenses/APL.txt and at
-// https://www.apache.org/licenses/LICENSE-2.0
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
 
 package storage
 

--- a/pkg/storage/store_snapshot_preemptive.go
+++ b/pkg/storage/store_snapshot_preemptive.go
@@ -1,0 +1,365 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL.txt and at www.mariadb.com/bsl11.
+//
+// Change Date: 2022-10-01
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt and at
+// https://www.apache.org/licenses/LICENSE-2.0
+
+package storage
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/pkg/errors"
+	"go.etcd.io/etcd/raft"
+	"go.etcd.io/etcd/raft/raftpb"
+)
+
+// canApplySnapshot returns (_, nil) if the snapshot can be applied to
+// this store's replica (i.e. the snapshot is not from an older incarnation of
+// the replica) and a placeholder can be added to the replicasByKey map (if
+// necessary). If a placeholder is required, it is returned as the first value.
+// The authoritative bool determines whether the check is carried out with the
+// intention of actually applying the snapshot (in which case an existing replica
+// must exist and have its raftMu locked) or as a preliminary check.
+func (s *Store) canApplyPreemptiveSnapshot(
+	ctx context.Context, snapHeader *SnapshotRequest_Header, authoritative bool,
+) (*ReplicaPlaceholder, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.canApplyPreemptiveSnapshotLocked(ctx, snapHeader, authoritative)
+}
+
+func (s *Store) canApplyPreemptiveSnapshotLocked(
+	ctx context.Context, snapHeader *SnapshotRequest_Header, authoritative bool,
+) (*ReplicaPlaceholder, error) {
+	// TODO(tbg): see the comment on desc.Generation for what seems to be a much
+	// saner way to handle overlap via generational semantics.
+	desc := *snapHeader.State.Desc
+
+	// First, check for an existing Replica.
+	//
+	// We call canApplySnapshotLocked twice for each snapshot application. In
+	// the first case, it's an optimization early before having received any
+	// data (and we don't use the placeholder if one is returned), and the
+	// replica may or may not be present.
+	//
+	// The second call happens right before we actually plan to apply the
+	// snapshot (and a Replica is always in place at that point). This means
+	// that without a Replica, we can have false positives, but if we have a
+	// replica it needs to take everything into account.
+	//
+	// TODO(tbg): untangle these two use cases.
+	if v, ok := s.mu.replicas.Load(
+		int64(desc.RangeID),
+	); !ok {
+		if authoritative {
+			return nil, errors.Errorf("authoritative call requires a replica present")
+		}
+	} else {
+		existingRepl := (*Replica)(v)
+		// The raftMu is held which allows us to use the existing replica as a
+		// placeholder when we decide that the snapshot can be applied. As long
+		// as the caller releases the raftMu only after feeding the snapshot
+		// into the replica, this is safe.
+		if authoritative {
+			existingRepl.raftMu.AssertHeld()
+		}
+
+		existingRepl.mu.RLock()
+		existingDesc := existingRepl.descRLocked()
+		existingIsInitialized := existingRepl.isInitializedRLocked()
+		existingIsPreemptive := existingRepl.mu.replicaID == 0
+		existingRepl.mu.RUnlock()
+
+		if existingIsInitialized {
+			if !snapHeader.IsPreemptive() {
+				// Regular Raft snapshots can't be refused at this point,
+				// even if they widen the existing replica. See the comments
+				// in Replica.maybeAcquireSnapshotMergeLock for how this is
+				// made safe.
+				//
+				// NB: we expect the replica to know its replicaID at this point
+				// (i.e. !existingIsPreemptive), though perhaps it's possible
+				// that this isn't true if the leader initiates a Raft snapshot
+				// (that would provide a range descriptor with this replica in
+				// it) but this node reboots (temporarily forgetting its
+				// replicaID) before the snapshot arrives.
+				return nil, nil
+			}
+
+			if existingIsPreemptive {
+				// Allow applying a preemptive snapshot on top of another
+				// preemptive snapshot. We only need to acquire a placeholder
+				// for the part (if any) of the new snapshot that extends past
+				// the old one. If there's no such overlap, return early; if
+				// there is, "forward" the descriptor's StartKey so that the
+				// later code will only check the overlap.
+				//
+				// NB: morally it would be cleaner to ask for the existing
+				// replica to be GC'ed first, but consider that the preemptive
+				// snapshot was likely left behind by a failed attempt to
+				// up-replicate. This is a relatively common scenario and not
+				// worth discarding and resending another snapshot for. Let the
+				// snapshot through, which means "pretending that it doesn't
+				// intersect the existing replica".
+				if !existingDesc.EndKey.Less(desc.EndKey) {
+					return nil, nil
+				}
+				desc.StartKey = existingDesc.EndKey
+			}
+			// NB: If the existing snapshot is *not* preemptive (i.e. the above
+			// branch wasn't taken), the overlap check below will hit an error.
+			// This path is hit after a rapid up-down-upreplication to the same
+			// store and will resolve as the replicaGCQueue removes the existing
+			// replica. We are pretty sure that the existing replica is gc'able,
+			// because a preemptive snapshot implies that someone is trying to
+			// add this replica to the group at the moment. (We are not however,
+			// sure enough that this couldn't happen by accident to GC the
+			// replica ourselves - the replica GC queue will perform the proper
+			// check).
+		} else if snapHeader.IsPreemptive() {
+			// Morally, the existing replica now has a nonzero replica ID
+			// because we already know that it is not initialized (i.e. has no
+			// data). Interestingly, the case in which it has a zero replica ID
+			// is also possible and should see the snapshot accepted as it
+			// occurs when a preemptive snapshot is handled: we first create a
+			// Replica in this state, run this check, and then apply the
+			// preemptive snapshot.
+			if !existingIsPreemptive {
+				// This is similar to the case of a preemptive snapshot hitting
+				// a fully initialized replica (i.e. not a preemptive snapshot)
+				// at the end of the last branch (which we don't allow), so we
+				// want to reject the snapshot. There is a tricky problem to
+				// to solve here, though: existingRepl doesn't know anything
+				// about its key bounds, and so to check whether it is actually
+				// gc'able would require a full scan of the meta2 entries (and
+				// we would also need to teach the queues how to deal with un-
+				// initialized replicas).
+				//
+				// So we let the snapshot through (by falling through to the
+				// overlap check, where it either picks up placeholders or
+				// fails). This is safe (or at least we assume so) because we
+				// carry out all snapshot decisions through Raft (though it
+				// still is an odd path that we would be wise to avoid if it
+				// weren't so difficult).
+				//
+				// A consequence of letting this snapshot through is opening this
+				// replica up to the possibility of erroneous replicaGC. This is
+				// because it will retain the replicaID of the current replica,
+				// which is going to be initialized after the snapshot (and thus
+				// gc'able).
+				_ = 0 // avoid staticcheck failure
+			}
+		}
+	}
+
+	// We have a key range [desc.StartKey,desc.EndKey) which we want to apply a
+	// snapshot for. Is there a conflicting existing placeholder or an
+	// overlapping range?
+	if err := s.checkSnapshotOverlapLocked(ctx, snapHeader); err != nil {
+		return nil, err
+	}
+
+	placeholder := &ReplicaPlaceholder{
+		rangeDesc: desc,
+	}
+	return placeholder, nil
+}
+
+// processSnapshotRequest processes the incoming snapshot Raft request on
+// the request's specified replica. This snapshot can be preemptive or not. If
+// not, the function makes sure to handle any updated Raft Ready state.
+func (s *Store) processPreemptiveSnapshotRequest(
+	ctx context.Context, snapHeader *SnapshotRequest_Header, inSnap IncomingSnapshot,
+) *roachpb.Error {
+	return s.withReplicaForRequest(ctx, &snapHeader.RaftMessageRequest, func(
+		ctx context.Context, r *Replica,
+	) (pErr *roachpb.Error) {
+		if snapHeader.RaftMessageRequest.Message.Type != raftpb.MsgSnap {
+			log.Fatalf(ctx, "expected snapshot: %+v", snapHeader.RaftMessageRequest)
+		}
+
+		// Check to see if a snapshot can be applied. Snapshots can always be applied
+		// to initialized replicas. Note that if we add a placeholder we need to
+		// already be holding Replica.raftMu in order to prevent concurrent
+		// raft-ready processing of uninitialized replicas.
+		var addedPlaceholder bool
+		var removePlaceholder bool
+		if err := func() error {
+			s.mu.Lock()
+			defer s.mu.Unlock()
+			placeholder, err := s.canApplyPreemptiveSnapshotLocked(ctx, snapHeader, true /* authoritative */)
+			if err != nil {
+				// If the storage cannot accept the snapshot, return an
+				// error before passing it to RawNode.Step, since our
+				// error handling options past that point are limited.
+				log.Infof(ctx, "cannot apply snapshot: %s", err)
+				return err
+			}
+
+			if placeholder != nil {
+				// NB: The placeholder added here is either removed below after a
+				// preemptive snapshot is applied or after the next call to
+				// Replica.handleRaftReady. Note that we can only get here if the
+				// replica doesn't exist or is uninitialized.
+				if err := s.addPlaceholderLocked(placeholder); err != nil {
+					log.Fatalf(ctx, "could not add vetted placeholder %s: %s", placeholder, err)
+				}
+				addedPlaceholder = true
+			}
+			return nil
+		}(); err != nil {
+			return roachpb.NewError(err)
+		}
+
+		if addedPlaceholder {
+			// If we added a placeholder remove it before we return unless some other
+			// part of the code takes ownership of the removal (indicated by setting
+			// removePlaceholder to false).
+			removePlaceholder = true
+			defer func() {
+				if removePlaceholder {
+					if s.removePlaceholder(ctx, snapHeader.RaftMessageRequest.RangeID) {
+						atomic.AddInt32(&s.counts.removedPlaceholders, 1)
+					}
+				}
+			}()
+		}
+
+		if snapHeader.IsPreemptive() {
+			// Requiring that the Term is set in a message makes sure that we
+			// get all of Raft's internal safety checks (it confuses messages
+			// at term zero for internal messages). The sending side uses the
+			// term from the snapshot itself, but we'll just check nonzero.
+			if snapHeader.RaftMessageRequest.Message.Term == 0 {
+				return roachpb.NewErrorf(
+					"preemptive snapshot from term %d received with zero term",
+					snapHeader.RaftMessageRequest.Message.Snapshot.Metadata.Term,
+				)
+			}
+			// TODO(tschottdorf): A lot of locking of the individual Replica
+			// going on below as well. I think that's more easily refactored
+			// away; what really matters is that the Store doesn't do anything
+			// else with that same Replica (or one that might conflict with us
+			// while we still run). In effect, we'd want something like:
+			//
+			// 1. look up the snapshot's key range
+			// 2. get an exclusive lock for operations on that key range from
+			//    the store (or discard the snapshot)
+			//    (at the time of writing, we have checked the key range in
+			//    canApplySnapshotLocked above, but there are concerns about two
+			//    conflicting operations passing that check simultaneously,
+			//    see #7830)
+			// 3. do everything below (apply the snapshot through temp Raft group)
+			// 4. release the exclusive lock on the snapshot's key range
+			//
+			// There are two future outcomes: Either we begin receiving
+			// legitimate Raft traffic for this Range (hence learning the
+			// ReplicaID and becoming a real Replica), or the Replica GC queue
+			// decides that the ChangeReplicas as a part of which the
+			// preemptive snapshot was sent has likely failed and removes both
+			// in-memory and on-disk state.
+			r.mu.Lock()
+			// We are paranoid about applying preemptive snapshots (which
+			// were constructed via our code rather than raft) to the "real"
+			// raft group. Instead, we destroy the "real" raft group if one
+			// exists (this is rare in production, although it occurs in
+			// tests), apply the preemptive snapshot to a temporary raft
+			// group, then discard that one as well to be replaced by a real
+			// raft group when we get a new replica ID.
+			//
+			// It might be OK instead to apply preemptive snapshots just
+			// like normal ones (essentially switching between regular and
+			// preemptive mode based on whether or not we have a raft group,
+			// instead of based on the replica ID of the snapshot message).
+			// However, this is a risk that we're not yet willing to take.
+			// Additionally, without some additional plumbing work, doing so
+			// would limit the effectiveness of RaftTransport.SendSync for
+			// preemptive snapshots.
+			r.mu.internalRaftGroup = nil
+			needTombstone := r.mu.state.Desc.NextReplicaID != 0
+			r.mu.Unlock()
+
+			appliedIndex, _, err := r.raftMu.stateLoader.LoadAppliedIndex(ctx, r.store.Engine())
+			if err != nil {
+				return roachpb.NewError(err)
+			}
+			raftGroup, err := raft.NewRawNode(
+				newRaftConfig(
+					raft.Storage((*replicaRaftStorage)(r)),
+					preemptiveSnapshotRaftGroupID,
+					// We pass the "real" applied index here due to subtleties
+					// arising in the case in which Raft discards the snapshot:
+					// It would instruct us to apply entries, which would have
+					// crashing potential for any choice of dummy value below.
+					appliedIndex,
+					r.store.cfg,
+					&raftLogger{ctx: ctx},
+				), nil)
+			if err != nil {
+				return roachpb.NewError(err)
+			}
+			// We have a Raft group; feed it the message.
+			if err := raftGroup.Step(snapHeader.RaftMessageRequest.Message); err != nil {
+				return roachpb.NewError(errors.Wrap(err, "unable to process preemptive snapshot"))
+			}
+			// In the normal case, the group should ask us to apply a snapshot.
+			// If it doesn't, our snapshot was probably stale. In that case we
+			// still go ahead and apply a noop because we want that case to be
+			// counted by stats as a successful application.
+			var ready raft.Ready
+			if raftGroup.HasReady() {
+				ready = raftGroup.Ready()
+			}
+
+			if needTombstone {
+				// Bump the min replica ID, but don't write the tombstone key. The
+				// tombstone key is not expected to be present when normal replica data
+				// is present and applySnapshot would delete the key in most cases. If
+				// Raft has decided the snapshot shouldn't be applied we would be
+				// writing the tombstone key incorrectly.
+				r.mu.Lock()
+				if r.mu.state.Desc.NextReplicaID > r.mu.minReplicaID {
+					r.mu.minReplicaID = r.mu.state.Desc.NextReplicaID
+				}
+				r.mu.Unlock()
+			}
+
+			// Apply the snapshot, as Raft told us to. Preemptive snapshots never
+			// subsume replicas (this is guaranteed by Store.canApplySnapshot), so
+			// we can simply pass nil for the subsumedRepls parameter.
+			if err := r.applySnapshot(
+				ctx, inSnap, ready.Snapshot, ready.HardState, nil, /* subsumedRepls */
+			); err != nil {
+				return roachpb.NewError(err)
+			}
+			// applySnapshot has already removed the placeholder.
+			removePlaceholder = false
+
+			// At this point, the Replica has data but no ReplicaID. We hope
+			// that it turns into a "real" Replica by means of receiving Raft
+			// messages addressed to it with a ReplicaID, but if that doesn't
+			// happen, at some point the Replica GC queue will have to grab it.
+			return nil
+		}
+
+		if err := r.stepRaftGroup(&snapHeader.RaftMessageRequest); err != nil {
+			return roachpb.NewError(err)
+		}
+
+		if _, expl, err := r.handleRaftReadyRaftMuLocked(ctx, inSnap); err != nil {
+			fatalOnRaftReadyErr(ctx, expl, err)
+		}
+		removePlaceholder = false
+		return nil
+	})
+}

--- a/pkg/storage/store_snapshot_test.go
+++ b/pkg/storage/store_snapshot_test.go
@@ -135,7 +135,7 @@ func TestSnapshotPreemptiveOnUninitializedReplica(t *testing.T) {
 		t.Fatal("mock snapshot isn't preemptive")
 	}
 
-	if _, err := store.canApplySnapshot(
+	if _, err := store.canApplyPreemptiveSnapshot(
 		ctx, header, true, /* authoritative */
 	); !testutils.IsError(err, "intersects existing range") {
 		t.Fatal(err)

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -2843,7 +2843,7 @@ func TestStoreRemovePlaceholderOnError(t *testing.T) {
 		},
 	}
 	const expected = "preemptive snapshot from term 0 received"
-	if err := s.processRaftSnapshotRequest(ctx, snapHeader,
+	if err := s.processPreemptiveSnapshotRequest(ctx, snapHeader,
 		IncomingSnapshot{
 			SnapUUID: uuid.MakeV4(),
 			State:    &storagepb.ReplicaState{Desc: repl1.Desc()},


### PR DESCRIPTION
We're moving away from preemptive snapshots in the 19.2 cycle in favor
of learner replicas. After 19.2, they'll be removed completely. In
preparation for this, I'm splitting out canApplySnapshot and
processSnapshotRequest to have preemptive-specific version to contain
the complexity.

While I'm in here, A _third_ copy of canApplySnapshot is specialized for
the old `authoritative` bool parameter, which added mental overhead to
understanding this code, especially given that the locking requirements
were different based on the value. This new copy is named
shouldAcceptSnapshotData and used for the old non-authoritative check,
leaving canApplySnapshot for the authoritative check.

Release note: None