### PR TITLE
wip: ui: don't pass version info back from server at all

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -921,9 +921,7 @@ Binary built without web UI.
 			expected := fmt.Sprintf(
 				htmlTemplate,
 				fmt.Sprintf(
-					`{"ExperimentalUseLogin":false,"LoginEnabled":false,"LoggedInUser":null,"Tag":"%s","Version":"%s","NodeID":"%d"}`,
-					build.GetInfo().Tag,
-					build.VersionPrefix(),
+					`{"ExperimentalUseLogin":false,"LoginEnabled":false,"LoggedInUser":null,"NodeID":"%d"}`,
 					1,
 				),
 			)
@@ -956,18 +954,14 @@ Binary built without web UI.
 			{
 				loggedInClient,
 				fmt.Sprintf(
-					`{"ExperimentalUseLogin":true,"LoginEnabled":true,"LoggedInUser":"authentic_user","Tag":"%s","Version":"%s","NodeID":"%d"}`,
-					build.GetInfo().Tag,
-					build.VersionPrefix(),
+					`{"ExperimentalUseLogin":true,"LoginEnabled":true,"LoggedInUser":"authentic_user","NodeID":"%d"}`,
 					1,
 				),
 			},
 			{
 				loggedOutClient,
 				fmt.Sprintf(
-					`{"ExperimentalUseLogin":true,"LoginEnabled":true,"LoggedInUser":null,"Tag":"%s","Version":"%s","NodeID":"%d"}`,
-					build.GetInfo().Tag,
-					build.VersionPrefix(),
+					`{"ExperimentalUseLogin":true,"LoginEnabled":true,"LoggedInUser":null,"NodeID":"%d"}`,
 					1,
 				),
 			},

--- a/pkg/ui/src/util/dataFromServer.ts
+++ b/pkg/ui/src/util/dataFromServer.ts
@@ -15,7 +15,6 @@ export interface DataFromServer {
   LoginEnabled: boolean;
   LoggedInUser: string;
   Tag: string;
-  Version: string;
   NodeID: string;
 }
 

--- a/pkg/ui/src/util/docs.ts
+++ b/pkg/ui/src/util/docs.ts
@@ -10,22 +10,13 @@
 // included in the file licenses/APL.txt and at
 // https://www.apache.org/licenses/LICENSE-2.0
 
-import { getDataFromServer } from "src/util/dataFromServer";
-
-const stable = "stable";
-const version = getDataFromServer().Version || stable;
-const docsURLBase = "https://www.cockroachlabs.com/docs/" + version;
-const docsURLBaseNoVersion = "https://www.cockroachlabs.com/docs/" + stable;
+const docsURLBaseNoVersion = "https://www.cockroachlabs.com/docs/stable";
 
 function docsURL(pageName: string): string {
-  return `${docsURLBase}/${pageName}`;
-}
-
-function docsURLNoVersion(pageName: string): string {
   return `${docsURLBaseNoVersion}/${pageName}`;
 }
 
-export const adminUILoginNoVersion = docsURLNoVersion("admin-ui-access-and-navigate.html#secure-the-admin-ui");
+export const adminUILoginNoVersion = docsURL("admin-ui-access-and-navigate.html#secure-the-admin-ui");
 export const startFlags = docsURL("start-a-node.html#flags");
 export const pauseJob = docsURL("pause-job.html");
 export const cancelJob = docsURL("cancel-job.html");

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -93,7 +93,6 @@ type indexHTMLArgs struct {
 	LoginEnabled         bool
 	LoggedInUser         *string
 	Tag                  string
-	Version              string
 	NodeID               string
 }
 
@@ -140,7 +139,6 @@ func Handler(cfg Config) http.Handler {
 			LoginEnabled:         cfg.LoginEnabled,
 			LoggedInUser:         cfg.GetUser(r.Context()),
 			Tag:                  buildInfo.Tag,
-			Version:              build.VersionPrefix(),
 			NodeID:               cfg.NodeID.String(),
 		}); err != nil {
 			err = errors.Wrap(err, "templating index.html")


### PR DESCRIPTION
Follow up to #38140, which removed this from being rendered but still passed it back from the server.