### PR TITLE
sql: handle database_name and composite primary key for UNSPLIT ALL

### DIFF
--- a/pkg/sql/unsplit.go
+++ b/pkg/sql/unsplit.go
@@ -72,14 +72,20 @@ func (p *planner) Unsplit(ctx context.Context, n *tree.Unsplit) (planNode, error
 			FROM
 				crdb_internal.ranges_no_leases
 			WHERE
-				table_name=$1::string AND index_name=$2::string AND split_enforced_until IS NOT NULL
+				database_name=$1::string AND table_name=$2::string AND index_name=$3::string AND split_enforced_until IS NOT NULL
 		`
-		ranges, err := p.ExtendedEvalContext().InternalExecutor.Query(
-			ctx, "split points query", p.txn, statement, n.TableOrIndex.Table.String(), n.TableOrIndex.Index)
+		dbDesc, err := sqlbase.GetDatabaseDescFromID(ctx, p.txn, tableDesc.ParentID)
 		if err != nil {
 			return nil, err
 		}
-		v := p.newContainerValuesNode(columns, 0)
+		ranges, err := p.ExtendedEvalContext().InternalExecutor.Query(
+			ctx, "split points query", p.txn, statement, dbDesc.Name, tableDesc.Name, n.TableOrIndex.Index)
+		if err != nil {
+			return nil, err
+		}
+		rawColumns := make(sqlbase.ResultColumns, 1)
+		rawColumns[0].Typ = types.Bytes
+		v := p.newContainerValuesNode(rawColumns, 0)
 		for _, d := range ranges {
 			if _, err := v.rows.AddRow(ctx, d); err != nil {
 				return nil, err

--- a/pkg/sql/unsplit_test.go
+++ b/pkg/sql/unsplit_test.go
@@ -16,9 +16,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -29,6 +31,19 @@ func TestUnsplitAt(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	params, _ := tests.CreateTestServerParams()
+	// TODO(jeffreyxiao): Disable the merge queue due to a race condition. The
+	// merge queue might issue an AdminMerge and before the actual merge happens,
+	// the LHS of the merge is manually split and is later merged even though a
+	// sticky bit has been set on the new RHS. This race condition happens
+	// because there is two independent fetches of the RHS during a merge
+	// operation (one in the merge queue and another in the actual merge). The
+	// merge queue should pass the expected descriptor of the RHS into the
+	// AdminMerge request.
+	params.Knobs = base.TestingKnobs{
+		Store: &storage.StoreTestingKnobs{
+			DisableMergeQueue: true,
+		},
+	}
 	s, db, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 
@@ -42,110 +57,165 @@ func TestUnsplitAt(t *testing.T) {
 		INDEX s_idx (s)
 	)`)
 	r.Exec(t, `CREATE TABLE d.i (k INT PRIMARY KEY)`)
-
-	// Create initial splits
-	splitStmts := []string{
-		"ALTER TABLE d.t SPLIT AT VALUES (2, 'b'), (3, 'c'), (4, 'd'), (5, 'd'), (6, 'e'), (7, 'f')",
-		"ALTER TABLE d.t SPLIT AT VALUES (10)",
-		"ALTER TABLE d.i SPLIT AT VALUES (1), (8)",
-		"ALTER INDEX d.t@s_idx SPLIT AT VALUES ('f')",
-	}
-
-	for _, splitStmt := range splitStmts {
-		var key roachpb.Key
-		var pretty string
-		var expirationTimestamp gosql.NullString
-		if err := db.QueryRow(splitStmt).Scan(&key, &pretty, &expirationTimestamp); err != nil {
-			t.Fatalf("unexpected error setting up test: %s", err)
-		}
-	}
+	r.Exec(t, `CREATE TABLE i (k INT PRIMARY KEY)`)
 
 	tests := []struct {
-		in    string
+		splitStmt   string
+		unsplitStmt string
+		// Number of unsplits expected.
+		count int
 		error string
 		args  []interface{}
 	}{
 		{
-			in: "ALTER TABLE d.t UNSPLIT AT VALUES (2, 'b')",
+			splitStmt:   "ALTER TABLE d.t SPLIT AT VALUES (2, 'b')",
+			unsplitStmt: "ALTER TABLE d.t UNSPLIT AT VALUES (2, 'b')",
+			count:       1,
 		},
 		{
-			in: "ALTER TABLE d.t UNSPLIT AT VALUES (3, 'c'), (4, 'd')",
+			splitStmt:   "ALTER TABLE d.t SPLIT AT VALUES (3, 'c'), (4, 'd')",
+			unsplitStmt: "ALTER TABLE d.t UNSPLIT AT VALUES (3, 'c'), (4, 'd')",
+			count:       2,
 		},
 		{
-			in: "ALTER TABLE d.t UNSPLIT AT SELECT 5, 'd'",
+			splitStmt:   "ALTER TABLE d.t SPLIT AT VALUES (5, 'd')",
+			unsplitStmt: "ALTER TABLE d.t UNSPLIT AT SELECT 5, 'd'",
+			count:       1,
 		},
 		{
-			in: "ALTER TABLE d.t UNSPLIT AT SELECT * FROM (VALUES (6, 'e'), (7, 'f')) AS a",
+			splitStmt:   "ALTER TABLE d.t SPLIT AT VALUES (6, 'e'), (7, 'f')",
+			unsplitStmt: "ALTER TABLE d.t UNSPLIT AT SELECT * FROM (VALUES (6, 'e'), (7, 'f')) AS a",
+			count:       2,
 		},
 		{
-			in: "ALTER TABLE d.t UNSPLIT AT VALUES (10)",
+			splitStmt:   "ALTER TABLE d.t SPLIT AT VALUES (10)",
+			unsplitStmt: "ALTER TABLE d.t UNSPLIT AT VALUES (10)",
+			count:       1,
 		},
 		{
-			in:   "ALTER TABLE d.i UNSPLIT AT VALUES ($1)",
-			args: []interface{}{8},
+			splitStmt:   "ALTER TABLE d.i SPLIT AT VALUES (1)",
+			unsplitStmt: "ALTER TABLE d.i UNSPLIT AT VALUES ((SELECT 1))",
+			count:       1,
 		},
 		{
-			in: "ALTER TABLE d.i UNSPLIT AT VALUES ((SELECT 1))",
+			splitStmt:   "ALTER TABLE d.i SPLIT AT VALUES (8)",
+			unsplitStmt: "ALTER TABLE d.i UNSPLIT AT VALUES ($1)",
+			args:        []interface{}{8},
+			count:       1,
 		},
 		{
-			in: "ALTER INDEX d.t@s_idx UNSPLIT AT VALUES ('f')",
+			splitStmt:   "ALTER INDEX d.t@s_idx SPLIT AT VALUES ('f')",
+			unsplitStmt: "ALTER INDEX d.t@s_idx UNSPLIT AT VALUES ('f')",
+			count:       1,
 		},
 		{
-			in:    "ALTER TABLE d.t UNSPLIT AT VALUES (1, 'non-existent')",
-			error: "could not UNSPLIT AT (1, 'non-existent')",
+			splitStmt:   "ALTER TABLE d.t SPLIT AT VALUES (8, 'g'), (9, 'h'), (10, 'i')",
+			unsplitStmt: "ALTER TABLE d.t UNSPLIT ALL",
+			count:       3,
 		},
 		{
-			in:    "ALTER TABLE d.t UNSPLIT AT VALUES ('c', 3)",
-			error: "could not parse \"c\" as type int",
+			splitStmt:   "ALTER INDEX d.t@s_idx SPLIT AT VALUES ('g'), ('h'), ('i')",
+			unsplitStmt: "ALTER INDEX d.t@s_idx UNSPLIT ALL",
+			count:       3,
 		},
 		{
-			in:    "ALTER TABLE d.t UNSPLIT AT VALUES (i, s)",
-			error: `column "i" does not exist`,
+			splitStmt:   "ALTER TABLE d.i SPLIT AT VALUES (10), (11), (12)",
+			unsplitStmt: "ALTER TABLE d.i UNSPLIT ALL",
+			count:       3,
 		},
 		{
-			in:    "ALTER INDEX d.t@not_present UNSPLIT AT VALUES ('g')",
-			error: `index "not_present" does not exist`,
+			splitStmt:   "ALTER TABLE i SPLIT AT VALUES (10), (11), (12)",
+			unsplitStmt: "ALTER TABLE i UNSPLIT ALL",
+			count:       3,
 		},
 		{
-			in:    "ALTER TABLE d.i UNSPLIT AT VALUES (avg(1::float))",
-			error: "aggregate functions are not allowed in VALUES",
+			unsplitStmt: "ALTER TABLE d.t UNSPLIT AT VALUES (1, 'non-existent')",
+			error:       "could not UNSPLIT AT (1, 'non-existent')",
 		},
 		{
-			in:    "ALTER TABLE d.i UNSPLIT AT VALUES ($1)",
-			error: "no value provided for placeholder: $1",
+			unsplitStmt: "ALTER TABLE d.t UNSPLIT AT VALUES ('c', 3)",
+			error:       "could not parse \"c\" as type int",
 		},
 		{
-			in:    "ALTER TABLE d.i UNSPLIT AT VALUES ($1)",
-			args:  []interface{}{"blah"},
-			error: "error in argument for $1: strconv.ParseInt",
+			unsplitStmt: "ALTER TABLE d.t UNSPLIT AT VALUES (i, s)",
+			error:       `column "i" does not exist`,
 		},
 		{
-			in:    "ALTER TABLE d.i UNSPLIT AT VALUES ($1::string)",
-			args:  []interface{}{"1"},
-			error: "UNSPLIT AT data column 1 (k) must be of type int, not type string",
+			unsplitStmt: "ALTER INDEX d.t@not_present UNSPLIT AT VALUES ('g')",
+			error:       `index "not_present" does not exist`,
+		},
+		{
+			unsplitStmt: "ALTER TABLE d.i UNSPLIT AT VALUES (avg(1::float))",
+			error:       "aggregate functions are not allowed in VALUES",
+		},
+		{
+			unsplitStmt: "ALTER TABLE d.i UNSPLIT AT VALUES ($1)",
+			error:       "no value provided for placeholder: $1",
+		},
+		{
+			unsplitStmt: "ALTER TABLE d.i UNSPLIT AT VALUES ($1)",
+			args:        []interface{}{"blah"},
+			error:       "error in argument for $1: strconv.ParseInt",
+		},
+		{
+			unsplitStmt: "ALTER TABLE d.i UNSPLIT AT VALUES ($1::string)",
+			args:        []interface{}{"1"},
+			error:       "UNSPLIT AT data column 1 (k) must be of type int, not type string",
 		},
 	}
 
 	for _, tt := range tests {
 		var key roachpb.Key
 		var pretty string
-		err := db.QueryRow(tt.in, tt.args...).Scan(&key, &pretty)
+		var expirationTimestamp gosql.NullString
+
+		if tt.splitStmt != "" {
+			rows, err := db.Query(tt.splitStmt)
+			if err != nil {
+				t.Fatalf("%s: unexpected error setting up test: %s", tt.splitStmt, err)
+			}
+			for rows.Next() {
+				if err := rows.Scan(&key, &pretty, &expirationTimestamp); err != nil {
+					t.Fatalf("%s: unexpected error setting up test: %s", tt.splitStmt, err)
+				}
+			}
+			if err := rows.Err(); err != nil {
+				t.Fatalf("%s: unexpected error setting up test: %s", tt.splitStmt, err)
+			}
+		}
+
+		rows, err := db.Query(tt.unsplitStmt, tt.args...)
 		if err != nil && tt.error == "" {
-			t.Fatalf("%s: unexpected error: %s", tt.in, err)
+			t.Fatalf("%s: unexpected error: %s", tt.unsplitStmt, err)
 		} else if tt.error != "" && err == nil {
-			t.Fatalf("%s: expected error: %s", tt.in, tt.error)
+			t.Fatalf("%s: expected error: %s", tt.unsplitStmt, tt.error)
 		} else if err != nil && tt.error != "" {
 			if !strings.Contains(err.Error(), tt.error) {
-				t.Fatalf("%s: unexpected error: %s", tt.in, err)
+				t.Fatalf("%s: unexpected error: %s", tt.unsplitStmt, err)
 			}
 		} else {
-			// Successful unsplit, verify it happened.
-			rng, err := s.(*server.TestServer).LookupRange(key)
-			if err != nil {
-				t.Fatal(err)
+			actualCount := 0
+			for rows.Next() {
+				actualCount++
+				err := rows.Scan(&key, &pretty)
+				if err != nil {
+					t.Fatalf("%s: unexpected error: %s", tt.unsplitStmt, err)
+				}
+				// Successful unsplit, verify it happened.
+				rng, err := s.(*server.TestServer).LookupRange(key)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if (rng.GetStickyBit() != hlc.Timestamp{}) {
+					t.Fatalf("%s: expected range sticky bit to be hlc.MinTimestamp, got %s", tt.unsplitStmt, rng.GetStickyBit())
+				}
 			}
-			if (rng.GetStickyBit() != hlc.Timestamp{}) {
-				t.Fatalf("%s: expected range sticky bit to be hlc.MinTimestamp, got %s", tt.in, pretty)
+			if err := rows.Err(); err != nil {
+				t.Fatalf("%s: unexpected error: %s", tt.unsplitStmt, err)
+			}
+
+			if tt.count != actualCount {
+				t.Fatalf("%s: expected %d unsplits, got %d", tt.unsplitStmt, tt.count, actualCount)
 			}
 		}
 	}

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -430,6 +430,7 @@ func (r *Replica) adminUnsplitWithDescriptor(
 			// look at the root cause to sniff out the changed descriptor.
 			err = &benignError{errors.Wrap(err, msg)}
 		}
+		return reply, err
 	}
 	return reply, nil
 }


### PR DESCRIPTION
UNSPLIT ALL was not using database in the query to crdb_internal.ranges_no_leases. Additionally, it was not handling composite keys correctly as the result column is a single column of bytes.

Release note (bug fix): Handle database_name and composite primary for UNSPLIT ALL.

@jordanlewis Are there any other edge cases I'm missing here?