### PR TITLE
 backupccl: allow rewriting spans keys that may not decode as keys

### DIFF
--- a/pkg/ccl/backupccl/restore.go
+++ b/pkg/ccl/backupccl/restore.go
@@ -1001,7 +1001,7 @@ func restoreJobDescription(
 // same interleave parent row) we'll generate some no-op splits and route the
 // work to the same range, but the actual imported data is unaffected.
 func rewriteBackupSpanKey(kr *storageccl.KeyRewriter, key roachpb.Key) (roachpb.Key, error) {
-	newKey, rewritten, err := kr.RewriteKey(append([]byte(nil), key...))
+	newKey, rewritten, err := kr.RewriteKey(append([]byte(nil), key...), true /* isFromSpan */)
 	if err != nil {
 		return nil, errors.NewAssertionErrorWithWrappedErrf(err,
 			"could not rewrite span start key: %s", key)

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -665,9 +665,6 @@ func doDistributedCSVTransform(
 		walltime,
 		sstSize,
 		oversample,
-		func(descs map[sqlbase.ID]*sqlbase.TableDescriptor) (sql.KeyRewriter, error) {
-			return storageccl.MakeKeyRewriter(descs)
-		},
 	); err != nil {
 
 		// Check if this was a context canceled error and restart if it was.

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -176,7 +176,7 @@ func evalImport(ctx context.Context, cArgs batcheval.CommandArgs) (*roachpb.Impo
 		value := roachpb.Value{RawBytes: valueScratch}
 		iter.NextKey()
 
-		key.Key, ok, err = kr.RewriteKey(key.Key)
+		key.Key, ok, err = kr.RewriteKey(key.Key, false /* isFromSpan */)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/storageccl/key_rewriter_test.go
+++ b/pkg/ccl/storageccl/key_rewriter_test.go
@@ -67,6 +67,8 @@ func TestKeyRewriter(t *testing.T) {
 		},
 	}
 
+	const notSpan = false
+
 	kr, err := MakeKeyRewriterFromRekeys(rekeys)
 	if err != nil {
 		t.Fatal(err)
@@ -74,7 +76,7 @@ func TestKeyRewriter(t *testing.T) {
 
 	t.Run("normal", func(t *testing.T) {
 		key := sqlbase.MakeIndexKeyPrefix(&sqlbase.NamespaceTable, desc.PrimaryIndex.ID)
-		newKey, ok, err := kr.RewriteKey(key)
+		newKey, ok, err := kr.RewriteKey(key, notSpan)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -92,7 +94,7 @@ func TestKeyRewriter(t *testing.T) {
 
 	t.Run("prefix end", func(t *testing.T) {
 		key := roachpb.Key(sqlbase.MakeIndexKeyPrefix(&sqlbase.NamespaceTable, desc.PrimaryIndex.ID)).PrefixEnd()
-		newKey, ok, err := kr.RewriteKey(key)
+		newKey, ok, err := kr.RewriteKey(key, notSpan)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -121,7 +123,7 @@ func TestKeyRewriter(t *testing.T) {
 		}
 
 		key := sqlbase.MakeIndexKeyPrefix(&sqlbase.NamespaceTable, desc.PrimaryIndex.ID)
-		newKey, ok, err := newKr.RewriteKey(key)
+		newKey, ok, err := newKr.RewriteKey(key, notSpan)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/ccl/utilccl/sampledataccl/bankdata.go
+++ b/pkg/ccl/utilccl/sampledataccl/bankdata.go
@@ -156,7 +156,7 @@ func (b *Backup) NextKeyValues(
 			b.iterIdx = iterIdx
 
 			key := it.Key()
-			key.Key, ok, err = kr.RewriteKey(key.Key)
+			key.Key, ok, err = kr.RewriteKey(key.Key, false /* isFromSpan */)
 			if err != nil {
 				return nil, roachpb.Span{}, err
 			}

--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -161,11 +161,6 @@ func (c *callbackResultWriter) Err() error {
 	return c.err
 }
 
-// KeyRewriter describes helpers that can rewrite keys (possibly in-place).
-type KeyRewriter interface {
-	RewriteKey(key []byte) (res []byte, ok bool, err error)
-}
-
 // LoadCSV performs a distributed transformation of the CSV files at from
 // and stores them in enterprise backup format at to.
 func LoadCSV(

--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -179,7 +179,6 @@ func LoadCSV(
 	walltime int64,
 	splitSize int64,
 	oversample int64,
-	makeRewriter func(map[sqlbase.ID]*sqlbase.TableDescriptor) (KeyRewriter, error),
 ) error {
 	ctx = logtags.AddTag(ctx, "import-distsql", nil)
 	dsp := phs.DistSQLPlanner()


### PR DESCRIPTION
backupccl: allow rewriting spans keys that may not decode as keys

When rewriting the spans to pre-split and distribute work in RESTORE, we
use the _key_ rewriter to rewrite _span_ boundaries. This usually works
well, but in a few cases, valid span boundaries may no longer be
entirely made of valid value encodings. For example, .PrefixEnd alters
the trailing bytes to increment them, but this will break decoding of
byte string that assumes a very specific trailing terminator.

 PeekLength, and key decoding in general, can fail when reading the last
value from a key that is coming from a span. Keys in spans are often
altered e.g. by calling Next() or PrefixEnd() to ensure a given span is
inclusive or for other reasons, but the manipulations sometimes change
the encoded bytes, meaning they can no longer successfully decode as
back to the original values. This is OK when span boundaries mostly are
only required to be even divisions of keyspace, but when we try to go
back to interpreting them as keys, it can fall apart. Partitioning a
table (and applying zone configs) eagerly creates splits at the defined
partition boundaries, using PrefixEnd for their ends, resulting in such
spans.

Fortunately, the only common span manipulations are to the trailing byte
of a key (e.g. incrementing or appending a null) so for our needs here,
if we fail to decode because of one fo those manipulations, we can
assume that we are at the end of the key as far as fields where a table
ID which needs to be replaced can appear and consider the rewrite of
this key as being completed successfully.

Finally unlike key rewrites of actual row-data, span rewrites do not
need to be perfect: spans are only rewritten for use in pre-splitting
and work distribution, so even if it turned out that this assumption was
incorrect, it could cause a performance degradation but does not pose a
correctness risk.

Release note (bug fix): fix an issue that prevented restoring some
backups if they included tables that were partitioned by columns of a
certain types while also interleaved by child tables.