### PR TITLE
release-19.1: sql: fix null handling by MIN, SUM, and AVG when used as window functions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -273,6 +273,16 @@ SELECT avg(avg(k)) OVER () FROM kv ORDER BY 1
 ----
 5
 
+query RR
+SELECT avg(k) OVER (), avg(v) OVER () FROM kv ORDER BY 1
+----
+5  2.8
+5  2.8
+5  2.8
+5  2.8
+5  2.8
+5  2.8
+
 query error OVER specified, but now\(\) is neither a window function nor an aggregate function
 SELECT now() OVER () FROM kv ORDER BY 1
 
@@ -3026,3 +3036,41 @@ FROM
     (SELECT 1 AS a)
 ----
 1 1
+
+# Regression tests for #38103
+statement ok
+DROP TABLE IF EXISTS t
+
+statement ok
+CREATE TABLE t (a INT PRIMARY KEY, b INT)
+
+statement ok
+INSERT INTO t VALUES (1, 1), (2, NULL), (3, 3)
+
+query I
+SELECT min(b) OVER () FROM t
+----
+1
+1
+1
+
+query IIR
+SELECT a, b, sum(b) OVER (ROWS 0 PRECEDING) FROM t ORDER BY a
+----
+1 1    1
+2 NULL NULL
+3 3    3
+
+query IIR
+SELECT a, b, avg(b) OVER () FROM t ORDER BY a
+----
+1  1    2
+2  NULL 2
+3  3    2
+
+query IIR
+SELECT a, b, avg(b) OVER (ROWS 0 PRECEDING) FROM t ORDER BY a
+----
+1  1     1
+2  NULL  NULL
+3  3     3

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -359,16 +359,16 @@ func makeAggOverloadWithReturnType(
 				})
 				return max
 			case *intSumAggregate:
-				return &slidingWindowSumFunc{agg: aggWindowFunc}
+				return newSlidingWindowSumFunc(aggWindowFunc)
 			case *decimalSumAggregate:
-				return &slidingWindowSumFunc{agg: aggWindowFunc}
+				return newSlidingWindowSumFunc(aggWindowFunc)
 			case *floatSumAggregate:
-				return &slidingWindowSumFunc{agg: aggWindowFunc}
+				return newSlidingWindowSumFunc(aggWindowFunc)
 			case *intervalSumAggregate:
-				return &slidingWindowSumFunc{agg: aggWindowFunc}
+				return newSlidingWindowSumFunc(aggWindowFunc)
 			case *avgAggregate:
 				// w.agg is a sum aggregate.
-				return &avgWindowFunc{sum: slidingWindowSumFunc{agg: w.agg}}
+				return &avgWindowFunc{sum: newSlidingWindowSumFunc(w.agg)}
 			}
 
 			return newFramableAggregateWindow(

--- a/pkg/sql/sem/builtins/window_frame_builtins.go
+++ b/pkg/sql/sem/builtins/window_frame_builtins.go
@@ -130,7 +130,14 @@ func (w *slidingWindowFunc) Compute(
 		if err != nil {
 			return nil, err
 		}
-		w.sw.add(&indexedValue{value: args[0], idx: idx})
+		value := args[0]
+		if value == tree.DNull {
+			// Null value can neither be minimum nor maximum over a window frame with
+			// non-null values, so we're not adding them to the sliding window. The
+			// case of a window frame with no non-null values is handled below.
+			continue
+		}
+		w.sw.add(&indexedValue{value: value, idx: idx})
 	}
 	w.prevEnd = frameEndIdx
 
@@ -162,6 +169,20 @@ func (w *slidingWindowFunc) Close(context.Context, *tree.EvalContext) {
 type slidingWindowSumFunc struct {
 	agg                tree.AggregateFunc // one of the four SumAggregates
 	prevStart, prevEnd int
+
+	// lastNonNullIdx is the index of the latest non-null value seen in the
+	// sliding window so far. noNonNullSeen indicates non-null values are yet to
+	// be seen.
+	lastNonNullIdx int
+}
+
+const noNonNullSeen = -1
+
+func newSlidingWindowSumFunc(agg tree.AggregateFunc) *slidingWindowSumFunc {
+	return &slidingWindowSumFunc{
+		agg:            agg,
+		lastNonNullIdx: noNonNullSeen,
+	}
 }
 
 // removeAllBefore subtracts the values from all the rows that are no longer in
@@ -192,6 +213,11 @@ func (w *slidingWindowSumFunc) removeAllBefore(
 			return err
 		}
 		value := args[0]
+		if value == tree.DNull {
+			// Null values do not contribute to the running sum, so there is nothing
+			// to subtract once they leave the window frame.
+			continue
+		}
 		switch v := value.(type) {
 		case *tree.DInt:
 			err = w.agg.Add(ctx, tree.NewDInt(-*v))
@@ -251,16 +277,24 @@ func (w *slidingWindowSumFunc) Compute(
 		if err != nil {
 			return nil, err
 		}
-		err = w.agg.Add(ctx, args[0])
-		if err != nil {
-			return nil, err
+		if args[0] != tree.DNull {
+			w.lastNonNullIdx = idx
+			err = w.agg.Add(ctx, args[0])
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
 	w.prevStart = frameStartIdx
 	w.prevEnd = frameEndIdx
-	if frameStartIdx == frameEndIdx {
-		// Spec: the frame is empty, so we return NULL.
+	// If last non-null value has index smaller than the start of the window
+	// frame, then only nulls can be in the frame. This holds true as well for
+	// the special noNonNullsSeen index.
+	onlyNulls := w.lastNonNullIdx < frameStartIdx
+	if frameStartIdx == frameEndIdx || onlyNulls {
+		// Either the window frame is empty or only null values are in the frame,
+		// so we return NULL as per spec.
 		return tree.DNull, nil
 	}
 	return w.agg.Result()
@@ -273,16 +307,14 @@ func (w *slidingWindowSumFunc) Close(ctx context.Context, _ *tree.EvalContext) {
 
 // avgWindowFunc uses slidingWindowSumFunc to compute average over a frame.
 type avgWindowFunc struct {
-	sum slidingWindowSumFunc
+	sum *slidingWindowSumFunc
 }
 
 // Compute implements WindowFunc interface.
 func (w *avgWindowFunc) Compute(
 	ctx context.Context, evalCtx *tree.EvalContext, wfr *tree.WindowFrameRun,
 ) (tree.Datum, error) {
-	var sum tree.Datum
-	var err error
-	sum, err = w.sum.Compute(ctx, evalCtx, wfr)
+	sum, err := w.sum.Compute(ctx, evalCtx, wfr)
 	if err != nil {
 		return nil, err
 	}
@@ -291,17 +323,17 @@ func (w *avgWindowFunc) Compute(
 		return tree.DNull, nil
 	}
 
-	var frameSize int
-	if wfr.FilterColIdx != noFilterIdx {
-		frameStartIdx, err := wfr.FrameStartIdx(ctx, evalCtx)
-		if err != nil {
-			return nil, err
-		}
-		frameEndIdx, err := wfr.FrameEndIdx(ctx, evalCtx)
-		if err != nil {
-			return nil, err
-		}
-		for idx := frameStartIdx; idx < frameEndIdx; idx++ {
+	frameSize := 0
+	frameStartIdx, err := wfr.FrameStartIdx(ctx, evalCtx)
+	if err != nil {
+		return nil, err
+	}
+	frameEndIdx, err := wfr.FrameEndIdx(ctx, evalCtx)
+	if err != nil {
+		return nil, err
+	}
+	for idx := frameStartIdx; idx < frameEndIdx; idx++ {
+		if wfr.FilterColIdx != noFilterIdx {
 			row, err := wfr.Rows.GetRow(ctx, idx)
 			if err != nil {
 				return nil, err
@@ -313,12 +345,17 @@ func (w *avgWindowFunc) Compute(
 			if datum != tree.DBoolTrue {
 				continue
 			}
-			frameSize++
 		}
-	} else {
-		if frameSize, err = wfr.FrameSize(ctx, evalCtx); err != nil {
+		args, err := wfr.ArgsByRowIdx(ctx, idx)
+		if err != nil {
 			return nil, err
 		}
+		if args[0] == tree.DNull {
+			// Null values do not count towards the number of rows that contribute
+			// to the sum, so we're omitting them from the frame.
+			continue
+		}
+		frameSize++
 	}
 
 	switch t := sum.(type) {

--- a/pkg/sql/sem/builtins/window_frame_builtins_test.go
+++ b/pkg/sql/sem/builtins/window_frame_builtins_test.go
@@ -165,7 +165,7 @@ func testSumAndAvg(t *testing.T, evalCtx *tree.EvalContext, wfr *tree.WindowFram
 		wfr.StartBoundOffset = tree.NewDInt(tree.DInt(offset))
 		wfr.EndBoundOffset = tree.NewDInt(tree.DInt(offset))
 		sum := &slidingWindowSumFunc{agg: &intSumAggregate{}}
-		avg := &avgWindowFunc{sum: slidingWindowSumFunc{agg: &intSumAggregate{}}}
+		avg := &avgWindowFunc{sum: newSlidingWindowSumFunc(&intSumAggregate{})}
 		for wfr.RowIdx = 0; wfr.RowIdx < wfr.PartitionSize(); wfr.RowIdx++ {
 			res, err := sum.Compute(evalCtx.Ctx(), evalCtx, wfr)
 			if err != nil {


### PR DESCRIPTION
Previously, nulls were incorrectly handled by window functions MIN,
SUM, and AVG. For MIN - since we treat nulls as smaller than any
other value, in a window frame with non-null values we got NULL as
the minimum which is incorrect; for SUM - when only nulls are in the
frame, then we returned 0 but should have returned NULL; for AVG -
nulls were counted in when figuring out the count of elements (i.e.
in the denominator of the average). Now, this all is fixed.
Incidentally, MAX was computed correctly due to our treatment of
nulls as the smallest value.

Release note (bug fix): nulls are now correctly handled by MIN, SUM,
and AVG when used as window functions.