### PR TITLE
release-2.1: sql: fix null handling by MIN, SUM, and AVG when used as window functions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -273,6 +273,16 @@ SELECT avg(avg(k)) OVER () FROM kv ORDER BY 1
 ----
 5
 
+query RR
+SELECT avg(k) OVER (), avg(v) OVER () FROM kv ORDER BY 1
+----
+5  2.8
+5  2.8
+5  2.8
+5  2.8
+5  2.8
+5  2.8
+
 query error OVER specified, but now\(\) is neither a window function nor an aggregate function
 SELECT now() OVER () FROM kv ORDER BY 1
 
@@ -2958,3 +2968,41 @@ Laptop      Dell             800.00   NULL  800.00
 Tablet      iPad             700.00   NULL  700.00
 Tablet      Kindle Fire      150.00   NULL  150.00
 Tablet      Samsung          200.00   NULL  200.00
+
+# Regression tests for #38103
+statement ok
+DROP TABLE IF EXISTS t
+
+statement ok
+CREATE TABLE t (a INT PRIMARY KEY, b INT)
+
+statement ok
+INSERT INTO t VALUES (1, 1), (2, NULL), (3, 3)
+
+query I
+SELECT min(b) OVER () FROM t
+----
+1
+1
+1
+
+query IIR
+SELECT a, b, sum(b) OVER (ROWS 0 PRECEDING) FROM t ORDER BY a
+----
+1 1    1
+2 NULL NULL
+3 3    3
+
+query IIR
+SELECT a, b, avg(b) OVER () FROM t ORDER BY a
+----
+1  1    2
+2  NULL 2
+3  3    2
+
+query IIR
+SELECT a, b, avg(b) OVER (ROWS 0 PRECEDING) FROM t ORDER BY a
+----
+1  1     1
+2  NULL  NULL
+3  3     3

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -355,16 +355,16 @@ func makeAggOverloadWithReturnType(
 				})
 				return max
 			case *intSumAggregate:
-				return &slidingWindowSumFunc{agg: aggWindowFunc}
+				return newSlidingWindowSumFunc(aggWindowFunc)
 			case *decimalSumAggregate:
-				return &slidingWindowSumFunc{agg: aggWindowFunc}
+				return newSlidingWindowSumFunc(aggWindowFunc)
 			case *floatSumAggregate:
-				return &slidingWindowSumFunc{agg: aggWindowFunc}
+				return newSlidingWindowSumFunc(aggWindowFunc)
 			case *intervalSumAggregate:
-				return &slidingWindowSumFunc{agg: aggWindowFunc}
+				return newSlidingWindowSumFunc(aggWindowFunc)
 			case *avgAggregate:
 				// w.agg is a sum aggregate.
-				return &avgWindowFunc{sum: slidingWindowSumFunc{agg: w.agg}}
+				return &avgWindowFunc{sum: newSlidingWindowSumFunc(w.agg)}
 			}
 
 			return newFramableAggregateWindow(

--- a/pkg/sql/sem/builtins/window_frame_builtins_test.go
+++ b/pkg/sql/sem/builtins/window_frame_builtins_test.go
@@ -149,7 +149,7 @@ func testSumAndAvg(t *testing.T, evalCtx *tree.EvalContext, wfr *tree.WindowFram
 		wfr.StartBoundOffset = tree.NewDInt(tree.DInt(offset))
 		wfr.EndBoundOffset = tree.NewDInt(tree.DInt(offset))
 		sum := &slidingWindowSumFunc{agg: &intSumAggregate{}}
-		avg := &avgWindowFunc{sum: slidingWindowSumFunc{agg: &intSumAggregate{}}}
+		avg := &avgWindowFunc{sum: newSlidingWindowSumFunc(&intSumAggregate{})}
 		for wfr.RowIdx = 0; wfr.RowIdx < wfr.PartitionSize(); wfr.RowIdx++ {
 			res, err := sum.Compute(evalCtx.Ctx(), evalCtx, wfr)
 			if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #38110.

/cc @cockroachdb/release

---

Previously, nulls were incorrectly handled by window functions MIN,
SUM, and AVG. For MIN - since we treat nulls as smaller than any
other value, in a window frame with non-null values we got NULL as
the minimum which is incorrect; for SUM - when only nulls are in the
frame, then we returned 0 but should have returned NULL; for AVG -
nulls were counted in when figuring out the count of elements (i.e.
in the denominator of the average). Now, this all is fixed.
Incidentally, MAX was computed correctly due to our treatment of
nulls as the smallest value.

Fixes: #38103.

Release note (bug fix): nulls are now correctly handled by MIN, SUM,
and AVG when used as window functions.
