### PR TITLE
qos,rpc: introduce qos.Level and rpc middleware to propagate it

### DIFF
--- a/pkg/qos/context.go
+++ b/pkg/qos/context.go
@@ -1,0 +1,27 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package qos
+
+import "context"
+
+type levelContextKey struct{}
+
+// LevelFromContext extracts a Level from the passed context.
+func LevelFromContext(ctx context.Context) (Level, bool) {
+	l, ok := ctx.Value(levelContextKey{}).(Level)
+	return l, ok
+}
+
+// ContextWithLevel returns a context which is a child of ctx storing l to be
+// extracted later with LevelFromContext.
+func ContextWithLevel(ctx context.Context, l Level) context.Context {
+	return context.WithValue(ctx, levelContextKey{}, l)
+}

--- a/pkg/qos/context.go
+++ b/pkg/qos/context.go
@@ -10,6 +10,9 @@
 
 package qos
 
+// TODO(ajwerner): change this store the encoded value so that intermediate
+// servers of different versions do not mutate qos.Level values.
+
 import "context"
 
 type levelContextKey struct{}

--- a/pkg/qos/doc.go
+++ b/pkg/qos/doc.go
@@ -1,0 +1,30 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package qos defines quality of service, a best-effort mechanism to prioritize
+// traffic in cockroachdb.
+//
+// The quality of service Level is a request annotation which propagates through
+// the system generally via a context mechanism and gRPC middleware. Components
+// consult qos levels as part of providing mechanisms to mitigate overload and
+// protect higher Class traffic from the load due to lower Class traffic. Class
+// represents client intention to prioritize or deprioritize a request relative
+// to other traffic. Shard is a uniform property of the client connection from
+// which a Level originates.
+//
+// Shard helps the distributed system to mitigcate the challenges due to
+// "multiple overload" whereby the processing of a single client request may
+// require visiting more than downstream server which is overloaded. If traffic
+// of a given Class were uniformly affected then even if each individual server
+// were to only backpressure a small fraction of incident requests, a large
+// fraction could observe some backpressure. Using a Shard in conjunction with a
+// Class allows servers to agree on which traffic of a Class should experience
+// backpressure without explicit coordination.
+package qos

--- a/pkg/qos/level.go
+++ b/pkg/qos/level.go
@@ -1,0 +1,275 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package qos
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"math"
+	"strconv"
+)
+
+// Class indicates traffic of a certain quality.
+//
+// The values of Class are explicitly defined as ClassHigh, ClassDefault, and
+// ClassLow. Class represents a client intention to prioritize this request
+// relative to requests of different Classes. Class combines with Shard to form
+// a Level. This sharding enables the system to make finer granularity
+// admission control decisions than would be possible if decisions were made
+// solely based on Class. See the package comment for more information.
+type Class uint8
+
+const (
+	// ClassLow is the lowest quality of service class.
+	ClassLow Class = iota
+	// ClassDefault is the default quality of service class.
+	ClassDefault
+	// ClassHigh is the highest quality of service class.
+	ClassHigh
+
+	// NumClasses is the total number of levels.
+	NumClasses = iota // 3
+)
+
+// IsValid is true if Class is in [0, NumClasses).
+func (l Class) IsValid() bool {
+	return l < NumClasses
+}
+
+// Shard indicates a shard within a Class.
+//
+// A shard subdivides a class generally based on a constant property of the
+// client connection from which the corresponding request originates. Shard
+// provides the system with a finer granularity for admission control decisions.
+type Shard uint8
+
+// NumShards is the total number of logical shards.
+// The current value is arbitrary and could change over time. Given a small
+// number of classes, having a large number of shards gives the system the
+// most granularity on which to make qos decisions.
+const NumShards = 128
+
+// IsValid is true if Shard is in [0, NumShards).
+func (s Shard) IsValid() bool {
+	return s < NumShards
+}
+
+// Level represents a quality of service level.
+//
+// The quality of service space is broken up into explicit classes which are
+// subdivided into shards. This tuple space allows nodes to make indepedent
+// admission decisions which will cooperate to backpressure traffic in an
+// orderly manner without explicit coordination (see the package comment for
+// more details).
+type Level struct {
+
+	// Class indicates the level associated with this priority.
+	// For a valid Level its value lies in [0, NumClasses).
+	Class Class
+
+	// Shard indicates the priority shard within this level.
+	// For a valid Level its value lies in [0, NumShards).
+	Shard Shard
+}
+
+// Decode decodes a priority from a uint32.
+// The high 16 bits are ignored.
+// See Level.Encode() for more details on the expected structure.
+func Decode(p uint32) Level {
+	return Level{
+		Class: decodeClass(p),
+		Shard: decodeShard(p),
+	}
+}
+
+// IsValid return true if p has a valid value.
+func (l Level) IsValid() bool {
+	return l.Class.IsValid() && l.Shard.IsValid()
+}
+
+// Dec returns the next lower priority value unless p is the minimum value
+// in which case p is returned.
+func (l Level) Dec() Level {
+	if l.Shard > 0 {
+		l.Shard--
+	} else if l.Class > 0 {
+		l.Class--
+		l.Shard = NumShards - 1
+	}
+	return l
+}
+
+// Inc returns the next higher priority value unless p is the maximum value
+// in which case p is returned.
+func (l Level) Inc() Level {
+	if l.Shard < NumShards-1 {
+		l.Shard++
+	} else if l.Class < NumClasses-1 {
+		l.Class++
+		l.Shard = 0
+	}
+	return l
+}
+
+// Less returns true if p is less than other.
+// Levels are first compared by Class then by Shard.
+func (l Level) Less(other Level) bool {
+	if l.Class == other.Class {
+		return l.Shard < other.Shard
+	}
+	return l.Class < other.Class
+}
+
+// Encode encodes a priority to a uint32.
+// Encoded priorities can be compared using normal comparison operators.
+// Levels which are not valid will cause a panic during encoding.
+//
+// Encoded values Class and Shard values are spread over the uint8 space in
+// the second and first low-order bytes respectively of the returned uint32.
+// A uint32 is returned despite the fact that 16 high-order bits will always be
+// zero because uint32 is the smallest value which can be encoded in protocol
+// buffers or used with atomics.
+//
+// To demonstrate the way encoding works, consider the following example of
+// encoding the Class byte. If NumClasses == 3, Class values will map to an
+// encoded byte as follows:
+//
+//   [0 (ClassLow), 1 (ClassDefault), 2 (ClassHigh)] -(encode)-> [0x01, 0x80, 0xFF]
+//
+// Suppose a later version of CockroachDB were to support five Class values.
+// In that case the Class encodings will look like the following:
+//
+//   [0, 1, 2, 3, 4] -(encode)-> [0x03, 0x42, 0x81, 0xC0, 0xFF]
+//
+// If that newer version were then to communicate with an older binary which
+// only knows about the three classes then it will decode the above Classes as
+// follows:
+//
+//   [0x03, 0x42, 0x81, 0xC0, 0xFF] -(decode)-> [0, 1, 1, 2, 2]
+//
+// This encoding format allows binaries with different interpretations of Class
+// to interoperate while being able to rely on a uniform in-memory
+// representation of Level.
+func (l Level) Encode() uint32 {
+	return uint32(encodeClass(l.Class))<<8 | uint32(encodeShard(l.Shard))
+}
+
+// String returns a string formatted as Class:Shard where Shard is always an
+// integer and Class uses a shorthand string if it is valid or an integer if not.
+func (l Level) String() string {
+	if l.Class >= NumClasses {
+		return strconv.Itoa(int(l.Class)) + ":" + strconv.Itoa(int(l.Shard))
+	}
+	return classStrings[l.Class] + ":" + strconv.Itoa(int(l.Shard))
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (l Level) MarshalText() ([]byte, error) {
+	if !l.IsValid() {
+		return nil, fmt.Errorf("cannot marshal invalid Level (%d, %d) to text", l.Class, l.Shard)
+	}
+	return marshaledText[l.Class][l.Shard][:], nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (l *Level) UnmarshalText(data []byte) error {
+	if len(data) != textLen {
+		return fmt.Errorf("invalid data length %d, expected %d", len(data), textLen)
+	}
+	var decoded [2]byte
+	if _, err := hex.Decode(decoded[:], data); err != nil {
+		return err
+	}
+	*l = Decode(uint32(binary.BigEndian.Uint16(decoded[:])))
+	return nil
+}
+
+// classStep and shardStep are used in encoding a decoding.
+// When encoded the Class and Shard values are spread over the space of uint8
+// in order to accommodate later changes to NumClasses or NumShards.
+// See the comment on Level.Encode() for more details.
+const (
+	classStep = math.MaxUint8 / (NumClasses - 1)
+	shardStep = math.MaxUint8 / (NumShards - 1)
+)
+
+func encodeClass(l Class) uint8 {
+	if !l.IsValid() {
+		panic(fmt.Errorf("cannot encode invalid level %d", l))
+	}
+	const minEncodedClass = math.MaxUint8 % classStep
+	return minEncodedClass + uint8(l*classStep)
+}
+
+func encodeShard(s Shard) uint8 {
+	if !s.IsValid() {
+		panic(fmt.Errorf("cannot encode invalid shard %d", s))
+	}
+	const minEncodedShard = math.MaxUint8 % shardStep
+	return minEncodedShard + uint8(s*shardStep)
+}
+
+func decodeShard(e uint32) Shard {
+	// shardRange is used when decoding a encoded Shard value which does not
+	// exactly align with this binary's view of NumShards to determine whether the
+	// value should be rounded up.
+	const shardRange = (shardStep-1)/2 + 1
+	sv := uint8(e)
+	s := Shard(sv) / shardStep
+	if sv%shardStep > shardRange {
+		s++
+	}
+	return s
+}
+
+func decodeClass(e uint32) Class {
+	// classRange is used when decoding a encoded Class value which does not
+	// exactly align with this binary's view of NumClasses to determine whether the
+	// value should be rounded up.
+	const classRange = (classStep-1)/2 + 1
+	cv := uint8(e >> 8)
+	c := Class(cv) / classStep
+	if cv%classStep > classRange {
+		c++
+	}
+	return c
+}
+
+var classStrings = [NumClasses]string{
+	ClassHigh:    "h",
+	ClassDefault: "d",
+	ClassLow:     "l",
+}
+
+var marshaledText [NumClasses][NumShards][textLen]byte
+
+// textLen is the length of a hex-encoded Level.
+const textLen = 4 // 2 * 2 bytes = 4
+
+func init() {
+	for c := Class(0); c < NumClasses; c++ {
+		for s := Shard(0); s < NumShards; s++ {
+			marshaledText[c][s] = levelToText(Level{c, s})
+		}
+	}
+}
+
+func levelToText(l Level) [textLen]byte {
+	var data [2]byte
+	var out [4]byte
+	data[0] = encodeClass(l.Class)
+	data[1] = encodeShard(l.Shard)
+	if n := hex.Encode(out[:], data[:]); n != len(out) {
+		panic(fmt.Errorf("expected to encode %d bytes, got %d", n, len(out)))
+	}
+	return out
+}

--- a/pkg/qos/level_test.go
+++ b/pkg/qos/level_test.go
@@ -11,6 +11,7 @@
 package qos
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"math/rand"
@@ -290,4 +291,16 @@ func TestMarshalText(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestContext(t *testing.T) {
+	ctx := context.Background()
+	got, ok := LevelFromContext(ctx)
+	assert.Zero(t, got)
+	assert.False(t, ok)
+	l := Level{ClassHigh, 12}
+	ctx = ContextWithLevel(ctx, l)
+	got, ok = LevelFromContext(ctx)
+	assert.Equal(t, l, got)
+	assert.True(t, ok)
 }

--- a/pkg/qos/level_test.go
+++ b/pkg/qos/level_test.go
@@ -1,0 +1,293 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package qos
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLevelBuckets(t *testing.T) {
+	for _, tc := range []struct {
+		l       Level
+		encoded uint32
+		str     string
+		valid   bool
+	}{
+		{
+			Level{ClassHigh, 127},
+			0x0000FFFF,
+			"h:127",
+			true,
+		},
+		{
+			Level{ClassHigh, 126},
+			0x0000FFFD,
+			"h:126",
+			true,
+		},
+		{
+			Level{ClassHigh, 1},
+			0x0000FF03,
+			"h:1",
+			true,
+		},
+		{
+			Level{ClassHigh, 0},
+			0x0000FF01,
+			"h:0",
+			true,
+		},
+		{
+			Level{ClassDefault, 127},
+			0x000080FF,
+			"d:127",
+			true,
+		},
+		{
+			Level{ClassLow, 125},
+			0x000001FB,
+			"l:125",
+			true,
+		},
+		{
+			Level{ClassHigh, 128},
+			0x0000FFFF,
+			"h:128",
+			false,
+		},
+		{
+			Level{17, 2},
+			0x0000FF05,
+			"17:2",
+			false,
+		},
+	} {
+		t.Run(fmt.Sprintf("%s->%x", tc.l, tc.encoded), func(t *testing.T) {
+			assert.Equal(t, tc.valid, tc.l.IsValid())
+			assert.Equal(t, tc.str, tc.l.String())
+			l := tc.l
+			if !tc.l.IsValid() {
+				l = clampToValid(l)
+			}
+			assert.Equal(t, tc.encoded, l.Encode())
+			assert.Equal(t, l, Decode(tc.encoded))
+		})
+	}
+}
+
+func clampToValid(l Level) Level {
+	if l.Class >= NumClasses {
+		l.Class = NumClasses - 1
+	}
+	if l.Shard >= NumShards {
+		l.Shard = NumShards - 1
+	}
+	return l
+}
+
+func TestIncDec(t *testing.T) {
+	levels := make([]Level, 0, NumClasses*NumShards)
+	for c := Class(0); c < NumClasses; c++ {
+		for s := Shard(0); s < NumShards; s++ {
+			levels = append(levels, Level{Class: c, Shard: s})
+		}
+	}
+	randIncDecTest := func() {
+		start := rand.Intn(len(levels))
+		var incs, decs int
+		l := levels[start]
+		const N = 500
+		for i := 0; i < N; i++ {
+			var next Level
+			if inc := rand.Intn(2) == 1; inc {
+				if next = l.Inc(); next != l {
+					incs++
+				}
+			} else {
+				if next = l.Dec(); next != l {
+					decs++
+				}
+			}
+			l = next
+			end := start + incs - decs
+			assert.Equal(t, levels[end], l)
+		}
+	}
+	const trials = 100
+	for i := 0; i < trials; i++ {
+		randIncDecTest()
+	}
+}
+
+// TestOrdering ensures that Level provides a total ordering both using the
+// Less method as well as comparing values creates with Encode.
+func TestOrdering(t *testing.T) {
+	// Each test case is provided as a slice of Levels in sorted order.
+	// The test ensure that comparisons are valid both using the Less method
+	// as well as using the numerical comparison of encoded values.
+	cases := [][]Level{
+		{
+			{ClassDefault, 127},
+			{ClassHigh, 2},
+			{ClassHigh, 126},
+			{ClassHigh, 127},
+		},
+		{
+			{ClassLow, 0},
+			{ClassLow, 127},
+			{ClassDefault, 127},
+			{ClassHigh, 127},
+		},
+	}
+	// shuffled returns a shuffled copy of l.
+	shuffled := func(l []Level) []Level {
+		l = append([]Level{}, l...)
+		rand.Shuffle(len(l), func(i, j int) {
+			l[i], l[j] = l[j], l[i]
+		})
+		return l
+	}
+	lessLess := func(a, b Level) bool {
+		return a.Less(b)
+	}
+	lessEncoded := func(a, b Level) bool {
+		return a.Encode() < b.Encode()
+	}
+	test := func(sorted []Level, less func(a, b Level) bool) func(t *testing.T) {
+		return func(t *testing.T) {
+			l := shuffled(sorted)
+			sort.Slice(l, func(i, j int) bool {
+				return less(l[i], l[j])
+			})
+			assert.EqualValues(t, sorted, l)
+		}
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%v/Less", tc), test(tc, lessLess))
+		t.Run(fmt.Sprintf("%v/Encoded", tc), test(tc, lessEncoded))
+	}
+}
+
+// TestDecode tests that various encoded values decode as expected.
+func TestDecode(t *testing.T) {
+	for _, tc := range []struct {
+		encoded uint32
+		level   Level
+	}{
+		{0xFF00, Level{ClassHigh, 0}},
+		{0xFF01, Level{ClassHigh, 0}},
+		{0xFF02, Level{ClassHigh, 1}},
+		{0x1234FF02, Level{ClassHigh, 1}},
+		{0xF902, Level{ClassHigh, 1}},
+		{0xF902, Level{ClassHigh, 1}},
+		{0x4202, Level{ClassDefault, 1}},
+		{0x8102, Level{ClassDefault, 1}},
+		{0xC002, Level{ClassHigh, 1}},
+		{0xFFFFFF02, Level{ClassHigh, 1}},
+		{0xFFFFFFFE, Level{ClassHigh, 127}},
+		{0xFFFFFFFD, Level{ClassHigh, 126}},
+		{0xFFFD, Level{ClassHigh, 126}},
+	} {
+		assert.Equal(t, tc.level, Decode(tc.encoded))
+	}
+}
+
+// TestInvalidEncodePanics ensures that encoding an invalid Level leads to a
+// panic.
+func TestInvalidEncodePanics(t *testing.T) {
+	for _, tc := range []Level{
+		{NumClasses, 0},
+		{NumClasses + 1, 0},
+		{math.MaxUint8, math.MaxUint8},
+		{0, NumShards},
+		{0, NumShards + 1},
+		{0, math.MaxUint8},
+	} {
+		assert.Panics(t, func() {
+			tc.Encode()
+		}, "(%d, %d)", tc.Class, tc.Shard)
+	}
+}
+
+func TestUnmarshalText(t *testing.T) {
+	for _, tc := range []struct {
+		in  []byte
+		out Level
+		err string
+	}{
+		{
+			in:  []byte("ff05"),
+			out: Level{ClassHigh, 2},
+		},
+		{
+			in:  []byte(""),
+			err: "invalid data length 0, expected 4",
+		},
+		{
+			in:  []byte("000z"),
+			err: "encoding/hex: invalid byte:",
+		},
+		{
+			in:  []byte("0000"),
+			out: Level{ClassLow, 0},
+		},
+	} {
+		t.Run(fmt.Sprintf("%v", tc), func(t *testing.T) {
+			var l Level
+			err := l.UnmarshalText(tc.in)
+			if tc.err != "" {
+				if assert.Error(t, err) {
+					assert.Regexp(t, tc.err, err.Error())
+				}
+			} else {
+				assert.Equal(t, tc.out, l)
+			}
+		})
+	}
+}
+
+func TestMarshalText(t *testing.T) {
+	for _, tc := range []struct {
+		l   Level
+		out []byte
+		err string
+	}{
+		{
+			l:   Level{ClassHigh, 2},
+			out: []byte("ff05"),
+		},
+		{
+			l:   Level{4, 2},
+			err: "cannot marshal invalid Level",
+		},
+		{
+			l:   Level{ClassLow, math.MaxUint8},
+			err: "cannot marshal invalid Level",
+		},
+	} {
+		t.Run(fmt.Sprintf("%v", tc), func(t *testing.T) {
+			out, err := tc.l.MarshalText()
+			if tc.err != "" {
+				if assert.Error(t, err) {
+					assert.Regexp(t, tc.err, err.Error())
+				}
+			} else {
+				assert.Equal(t, tc.out, out)
+			}
+		})
+	}
+}

--- a/pkg/rpc/qos.go
+++ b/pkg/rpc/qos.go
@@ -1,0 +1,76 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rpc
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/qos"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+func qosClientInterceptor(
+	prevUnaryInterceptor grpc.UnaryClientInterceptor,
+) grpc.UnaryClientInterceptor {
+	return func(
+		goCtx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker, opts ...grpc.CallOption,
+	) error {
+		// Add a qos level header if the goCtx contains a qos level.
+		if l, haveLevel := qos.LevelFromContext(goCtx); haveLevel {
+			goCtx = metadata.AppendToOutgoingContext(goCtx, clientQosLevelKey, l.EncodeString())
+		}
+		// Chain the previous interceptor if there is one.
+		if prevUnaryInterceptor != nil {
+			return prevUnaryInterceptor(goCtx, method, req, reply, cc, invoker, opts...)
+		}
+		return invoker(goCtx, method, req, reply, cc, opts...)
+	}
+}
+
+func qosServerInterceptor(
+	prevUnaryInterceptor grpc.UnaryServerInterceptor,
+) grpc.UnaryServerInterceptor {
+	warnTooManyEvery := log.Every(time.Second)
+	errMalformedQosLevelEvery := log.Every(time.Second)
+	return func(
+		goCtx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
+	) (interface{}, error) {
+		if md, ok := metadata.FromIncomingContext(goCtx); ok {
+			if v := md.Get(clientQosLevelKey); len(v) > 0 {
+				// We don't expect more than one item; gRPC does not copy metadata
+				// from one incoming RPC to an outgoing RPC, so there should be a
+				// single qos level in the context put there by the interceptor on the
+				// client before calling this RPC. Nevertheless, having two is only
+				// logged and is not treated as an error.
+				if len(v) > 1 && warnTooManyEvery.ShouldLog() {
+					log.Warningf(goCtx, "unexpected multiple qos levels in client metadata: %s", v)
+				}
+				// If a qos level header exists but is malformed it is ignored but a
+				// message is logged with the corresponding error.
+				// TODO(ajwerner): consider if this behavior should be less lenient for
+				// malformed headers.
+				if l, err := qos.DecodeString(v[0]); err == nil {
+					goCtx = qos.ContextWithLevel(goCtx, l)
+				} else if errMalformedQosLevelEvery.ShouldLog() {
+					log.Errorf(goCtx, "malformed qos level %s header: %v", clientQosLevelKey, err)
+				}
+			}
+		}
+		if prevUnaryInterceptor != nil {
+			return prevUnaryInterceptor(goCtx, req, info, handler)
+		}
+		return handler(goCtx, req)
+	}
+}

--- a/pkg/rpc/qos_test.go
+++ b/pkg/rpc/qos_test.go
@@ -1,0 +1,196 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rpc
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/qos"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/netutil"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+type internalServerFunc func(
+	context.Context, *roachpb.BatchRequest,
+) (*roachpb.BatchResponse, error)
+
+func (f internalServerFunc) Batch(
+	ctx context.Context, ba *roachpb.BatchRequest,
+) (*roachpb.BatchResponse, error) {
+	return f(ctx, ba)
+}
+
+func (f internalServerFunc) RangeFeed(
+	_ *roachpb.RangeFeedRequest, _ roachpb.Internal_RangeFeedServer,
+) error {
+	panic("unimplemented")
+}
+
+// TestQosMiddleware tests that qos levels get properly transmitted.
+func TestQosMiddleware(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Can't be zero because that'd be an empty offset.
+	clock := hlc.NewClock(timeutil.Unix(0, 1).UnixNano, time.Nanosecond)
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.TODO())
+
+	// Shared cluster ID by all RPC peers (this ensures that the peers
+	// don't talk to servers from unrelated tests by accident).
+	clusterID := uuid.MakeV4()
+
+	serverCtx := newTestContext(clusterID, clock, stopper)
+	const serverNodeID = 1
+	serverCtx.NodeID.Set(context.TODO(), serverNodeID)
+	s := newTestServer(t, serverCtx,
+		grpc.UnaryInterceptor(qosServerInterceptor(nil /* prevUnaryInterceptor */)))
+
+	heartbeat := &ManualHeartbeatService{
+		ready:              make(chan error),
+		stopper:            stopper,
+		clock:              clock,
+		remoteClockMonitor: serverCtx.RemoteClocks,
+		version:            serverCtx.version,
+		nodeID:             &serverCtx.NodeID,
+	}
+	RegisterHeartbeatServer(s, heartbeat)
+	type qosLevel struct {
+		qos.Level
+		ok bool
+	}
+	qosLevelChan := make(chan qosLevel, 1)
+	batchFunc := internalServerFunc(func(
+		ctx context.Context, ba *roachpb.BatchRequest,
+	) (*roachpb.BatchResponse, error) {
+		l, ok := qos.LevelFromContext(ctx)
+		qosLevelChan <- qosLevel{l, ok}
+		return &roachpb.BatchResponse{}, nil
+	})
+	roachpb.RegisterInternalServer(s, batchFunc)
+
+	ln, err := netutil.ListenAndServeGRPC(serverCtx.Stopper, s, util.TestAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	remoteAddr := ln.Addr().String()
+
+	clientCtx := newTestContext(clusterID, clock, stopper)
+	// Make the interval shorter to speed up the test.
+	clientCtx.heartbeatInterval = 1 * time.Millisecond
+	go func() { heartbeat.ready <- nil }()
+	conn, err := clientCtx.GRPCDialNode(remoteAddr, serverNodeID).Connect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the connection & successful heartbeat.
+	testutils.SucceedsSoon(t, func() error {
+		err := clientCtx.TestingConnHealth(remoteAddr, serverNodeID)
+		if err != nil && err != ErrNotHeartbeated {
+			t.Fatal(err)
+		}
+		return err
+	})
+	clientConn := roachpb.NewInternalClient(conn)
+
+	t.Run("without", func(t *testing.T) {
+		ctx := context.Background()
+		if _, err = clientConn.Batch(ctx, &roachpb.BatchRequest{}); err != nil {
+			t.Fatal(err)
+		}
+		got := <-qosLevelChan
+		if got.ok {
+			t.Fatalf("received context should not have contained a qos level")
+		}
+	})
+	t.Run("with", func(t *testing.T) {
+		l := qos.Level{Class: qos.ClassLow, Shard: 12}
+		ctx := qos.ContextWithLevel(context.Background(), l)
+		if _, err = clientConn.Batch(ctx, &roachpb.BatchRequest{}); err != nil {
+			t.Fatal(err)
+		}
+		got := <-qosLevelChan
+		if !got.ok {
+			t.Fatalf("expected context to have contained a qos level")
+		} else if got.Level != l {
+			t.Fatalf("expected context to have qos level %v, got %v", l, got.Level)
+		}
+	})
+	t.Run("malformed header", func(t *testing.T) {
+		ctxWithMalformedHeader := metadata.AppendToOutgoingContext(context.Background(),
+			clientQosLevelKey, "foo")
+		var entry *log.Entry
+		log.Intercept(ctxWithMalformedHeader, func(le log.Entry) {
+			if entry == nil && le.Severity == log.Severity_ERROR {
+				entry = &le
+			}
+		})
+		if _, err = clientConn.Batch(ctxWithMalformedHeader, &roachpb.BatchRequest{}); err != nil {
+			t.Fatal(err)
+		}
+		log.Intercept(ctxWithMalformedHeader, nil)
+		got := <-qosLevelChan
+		if got.ok {
+			t.Fatalf("expected context to not have contained a qos level")
+		}
+		const msg = "malformed qos level c_qos header: "
+		if entry == nil {
+			t.Fatalf("expected a log entry to be captured")
+		} else if !strings.Contains(entry.Message, msg) {
+			t.Fatalf("Found log entry %q, expected a log entrying containing %q", entry.Message, msg)
+		}
+	})
+	t.Run("extra headers", func(t *testing.T) {
+		l1 := qos.Level{Class: qos.ClassLow, Shard: 1}
+		l2 := qos.Level{Class: qos.ClassHigh, Shard: 2}
+		ctxWithDuplicateInHeader := metadata.AppendToOutgoingContext(context.Background(),
+			clientQosLevelKey, l1.EncodeString())
+		ctxWithDuplicateInHeader = metadata.AppendToOutgoingContext(ctxWithDuplicateInHeader,
+			clientQosLevelKey, l2.EncodeString())
+		var entry *log.Entry
+		log.Intercept(ctxWithDuplicateInHeader, func(le log.Entry) {
+			if entry == nil && le.Severity == log.Severity_WARNING {
+				entry = &le
+			}
+		})
+		if _, err = clientConn.Batch(ctxWithDuplicateInHeader, &roachpb.BatchRequest{}); err != nil {
+			t.Fatal(err)
+		}
+		log.Intercept(ctxWithDuplicateInHeader, nil)
+		const msg = "unexpected multiple qos levels"
+		if entry == nil {
+			t.Fatalf("expected a log entry to be captured")
+		} else if !strings.Contains(entry.Message, msg) {
+			t.Fatalf("Found log entry %q, expected a log entrying containing %q", entry.Message, msg)
+		}
+		// Check that the used level corresponds to the first value, which in this
+		// case is l1.
+		got := <-qosLevelChan
+		if !got.ok {
+			t.Fatalf("expected context to have contained a qos level")
+		} else if got.Level != l1 {
+			t.Fatalf("expected context to have qos level %v, got %v", l1, got.Level)
+		}
+	})
+}


### PR DESCRIPTION
This set of commits introduces a qos package with definitions for a quality of service Level with is a (Class, Shard) tuple and functionality to encode, decode, and compare them.

This is part of a much larger piece of work in the admission control project but I've been holding on to code for too long and want to start getting commits out for more public accountability and discussion.

Additionally included in this draft PR is rpc middleware to propagate qos levels from a client context to the server using grpc metadata. The integration point in the conn_executor is intentionally simplistic and exists for benchmarking purposes only. A quick kv95 benchmark on 3x n1-standard-4's show no noticeable cost in propagating these qos levels:

```
name             old ops/s   new ops/s   delta
KV95-throughput  17.4k ± 2%  17.2k ± 2%   ~     (p=0.700 n=3+3)
```

Expect more PRs that build on this work to follow including but not limited to:

- Logic to mark executors as internal
- Logic for determining the qos level for query execution
- A read quota to the replica read path
- A read rejected roachpb error
- A qos controller implementation
- A qos controller to the replica read path which responds to queueing on the read quota
- A qos controller to the DistSender which responds to rejections coming from the server
- A qos controller in front of the flow scheduler
- A qos controller to the sql layer which responds to rejections at the DistSender layer
- An RFC that outlines how all of this fits together

