### PR TITLE
sql: use pool of producer metadata throughout the code

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -93,7 +93,7 @@ func newChangeAggregatorProcessor(
 		output,
 		memMonitor,
 		distsqlrun.ProcStateOpts{
-			TrailingMetaCallback: func(context.Context) []distsqlpb.ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []*distsqlpb.ProducerMetadata {
 				ca.close()
 				return nil
 			},
@@ -382,7 +382,7 @@ func newChangeFrontierProcessor(
 		output,
 		memMonitor,
 		distsqlrun.ProcStateOpts{
-			TrailingMetaCallback: func(context.Context) []distsqlpb.ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []*distsqlpb.ProducerMetadata {
 				cf.close()
 				return nil
 			},

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -527,8 +527,8 @@ func (r *DistSQLReceiver) Push(
 			r.bytesRead += meta.Metrics.BytesRead
 			r.rowsRead += meta.Metrics.RowsRead
 			meta.Metrics.Release()
-			meta.Release()
 		}
+		meta.Release()
 		return r.status
 	}
 	if r.resultWriter.Err() == nil && r.txnAbortedErr.Load() != nil {

--- a/pkg/sql/distsqlpb/data.go
+++ b/pkg/sql/distsqlpb/data.go
@@ -216,8 +216,6 @@ type ProducerMetadata struct {
 }
 
 var (
-	// TODO(yuzefovich): use this pool in other places apart from metrics
-	// collection.
 	// producerMetadataPool is a pool of producer metadata objects.
 	producerMetadataPool = sync.Pool{
 		New: func() interface{} {
@@ -262,7 +260,7 @@ func GetMetricsMeta() *RemoteProducerMetadata_Metrics {
 // ProducerMetadata and returns whether the conversion was successful or not.
 func RemoteProducerMetaToLocalMeta(
 	ctx context.Context, rpm RemoteProducerMetadata,
-) (ProducerMetadata, bool) {
+) (*ProducerMetadata, bool) {
 	meta := GetProducerMeta()
 	switch v := rpm.Value.(type) {
 	case *RemoteProducerMetadata_RangeInfo:
@@ -280,15 +278,15 @@ func RemoteProducerMetaToLocalMeta(
 	case *RemoteProducerMetadata_Metrics_:
 		meta.Metrics = v.Metrics
 	default:
-		return *meta, false
+		return meta, false
 	}
-	return *meta, true
+	return meta, true
 }
 
 // LocalMetaToRemoteProducerMeta converts a ProducerMetadata struct to
 // RemoteProducerMetadata.
 func LocalMetaToRemoteProducerMeta(
-	ctx context.Context, meta ProducerMetadata,
+	ctx context.Context, meta *ProducerMetadata,
 ) RemoteProducerMetadata {
 	var rpm RemoteProducerMetadata
 	if meta.Ranges != nil {
@@ -336,5 +334,5 @@ type MetadataSource interface {
 	// Implementers can choose what to do on subsequent calls (if such occur).
 	// TODO(yuzefovich): modify the contract to require returning nil on all
 	// calls after the first one.
-	DrainMeta(context.Context) []ProducerMetadata
+	DrainMeta(context.Context) []*ProducerMetadata
 }

--- a/pkg/sql/distsqlpb/testutils.go
+++ b/pkg/sql/distsqlpb/testutils.go
@@ -17,10 +17,10 @@ import "context"
 // CallbackMetadataSource is a utility struct that implements the MetadataSource
 // interface by calling a provided callback.
 type CallbackMetadataSource struct {
-	DrainMetaCb func(context.Context) []ProducerMetadata
+	DrainMetaCb func(context.Context) []*ProducerMetadata
 }
 
 // DrainMeta is part of the MetadataSource interface.
-func (s CallbackMetadataSource) DrainMeta(ctx context.Context) []ProducerMetadata {
+func (s CallbackMetadataSource) DrainMeta(ctx context.Context) []*ProducerMetadata {
 	return s.DrainMetaCb(ctx)
 }

--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -146,7 +146,7 @@ func (ag *aggregatorBase) init(
 	input RowSource,
 	post *distsqlpb.PostProcessSpec,
 	output RowReceiver,
-	trailingMetaCallback func(context.Context) []distsqlpb.ProducerMetadata,
+	trailingMetaCallback func(context.Context) []*distsqlpb.ProducerMetadata,
 ) error {
 	ctx := flowCtx.EvalCtx.Ctx()
 	memMonitor := NewMonitor(ctx, flowCtx.EvalCtx.Mon, "aggregator-mem")
@@ -348,7 +348,7 @@ func newAggregator(
 		input,
 		post,
 		output,
-		func(context.Context) []distsqlpb.ProducerMetadata {
+		func(context.Context) []*distsqlpb.ProducerMetadata {
 			ag.close()
 			return nil
 		},
@@ -377,7 +377,7 @@ func newOrderedAggregator(
 		input,
 		post,
 		output,
-		func(context.Context) []distsqlpb.ProducerMetadata {
+		func(context.Context) []*distsqlpb.ProducerMetadata {
 			ag.close()
 			return nil
 		},

--- a/pkg/sql/distsqlrun/backfiller.go
+++ b/pkg/sql/distsqlrun/backfiller.go
@@ -86,7 +86,9 @@ func (b *backfiller) Run(ctx context.Context) {
 	defer tracing.FinishSpan(span)
 
 	if err := b.mainLoop(ctx); err != nil {
-		b.output.Push(nil /* row */, &distsqlpb.ProducerMetadata{Err: err})
+		meta := distsqlpb.GetProducerMeta()
+		meta.Err = err
+		b.output.Push(nil /* row */, meta)
 	}
 	sendTraceData(ctx, b.output)
 	b.output.ProducerDone()

--- a/pkg/sql/distsqlrun/base.go
+++ b/pkg/sql/distsqlrun/base.go
@@ -245,7 +245,9 @@ func getTraceData(ctx context.Context) []tracing.RecordedSpan {
 // each one gets its own trace "recording group".
 func sendTraceData(ctx context.Context, dst RowReceiver) {
 	if rec := getTraceData(ctx); rec != nil {
-		dst.Push(nil /* row */, &distsqlpb.ProducerMetadata{TraceData: rec})
+		meta := distsqlpb.GetProducerMeta()
+		meta.TraceData = rec
+		dst.Push(nil /* row */, meta)
 	}
 }
 
@@ -293,7 +295,9 @@ func DrainAndClose(
 	if cause != nil {
 		// We ignore the returned ConsumerStatus and rely on the
 		// DrainAndForwardMetadata() calls below to close srcs in all cases.
-		_ = dst.Push(nil /* row */, &distsqlpb.ProducerMetadata{Err: cause})
+		meta := distsqlpb.GetProducerMeta()
+		meta.Err = cause
+		_ = dst.Push(nil /* row */, meta)
 	}
 	if len(srcs) > 0 {
 		var wg sync.WaitGroup

--- a/pkg/sql/distsqlrun/colbatch_scan.go
+++ b/pkg/sql/distsqlrun/colbatch_scan.go
@@ -36,6 +36,7 @@ type colBatchScan struct {
 }
 
 var _ exec.Operator = &colBatchScan{}
+var _ distsqlpb.MetadataSource = &colBatchScan{}
 
 func (s *colBatchScan) Init() {
 	s.ctx = context.Background()
@@ -57,16 +58,20 @@ func (s *colBatchScan) Next(ctx context.Context) coldata.Batch {
 }
 
 // DrainMeta is part of the MetadataSource interface.
-func (s *colBatchScan) DrainMeta(ctx context.Context) []distsqlpb.ProducerMetadata {
-	var trailingMeta []distsqlpb.ProducerMetadata
+func (s *colBatchScan) DrainMeta(ctx context.Context) []*distsqlpb.ProducerMetadata {
+	var trailingMeta []*distsqlpb.ProducerMetadata
 	if !s.flowCtx.local {
 		ranges := misplannedRanges(ctx, s.rf.GetRangesInfo(), s.flowCtx.nodeID)
 		if ranges != nil {
-			trailingMeta = append(trailingMeta, distsqlpb.ProducerMetadata{Ranges: ranges})
+			meta := distsqlpb.GetProducerMeta()
+			meta.Ranges = ranges
+			trailingMeta = append(trailingMeta, meta)
 		}
 	}
-	if meta := getTxnCoordMeta(ctx, s.flowCtx.txn); meta != nil {
-		trailingMeta = append(trailingMeta, distsqlpb.ProducerMetadata{TxnCoordMeta: meta})
+	if txnCoordMeta := getTxnCoordMeta(ctx, s.flowCtx.txn); txnCoordMeta != nil {
+		meta := distsqlpb.GetProducerMeta()
+		meta.TxnCoordMeta = txnCoordMeta
+		trailingMeta = append(trailingMeta, meta)
 	}
 	return trailingMeta
 }

--- a/pkg/sql/distsqlrun/distinct.go
+++ b/pkg/sql/distsqlrun/distinct.go
@@ -117,7 +117,7 @@ func NewDistinct(
 		d, post, d.types, flowCtx, processorID, output, memMonitor, /* memMonitor */
 		ProcStateOpts{
 			InputsToDrain: []RowSource{d.input},
-			TrailingMetaCallback: func(context.Context) []distsqlpb.ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []*distsqlpb.ProducerMetadata {
 				d.close()
 				return nil
 			},

--- a/pkg/sql/distsqlrun/flow_registry.go
+++ b/pkg/sql/distsqlrun/flow_registry.go
@@ -229,9 +229,9 @@ func (fr *flowRegistry) RegisterFlow(
 			}
 			for _, r := range timedOutReceivers {
 				go func(r RowReceiver) {
-					r.Push(
-						nil, /* row */
-						&distsqlpb.ProducerMetadata{Err: errNoInboundStreamConnection})
+					meta := distsqlpb.GetProducerMeta()
+					meta.Err = errNoInboundStreamConnection
+					r.Push(nil /* row */, meta)
 					r.ProducerDone()
 				}(r)
 			}

--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -162,7 +162,7 @@ func newHashJoiner(
 		output,
 		ProcStateOpts{
 			InputsToDrain: []RowSource{h.leftSource, h.rightSource},
-			TrailingMetaCallback: func(context.Context) []distsqlpb.ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []*distsqlpb.ProducerMetadata {
 				h.close()
 				return nil
 			},

--- a/pkg/sql/distsqlrun/inbound.go
+++ b/pkg/sql/distsqlrun/inbound.go
@@ -63,7 +63,9 @@ func processInboundStreamHelper(
 
 	sendErrToConsumer := func(err error) {
 		if err != nil {
-			dst.Push(nil, &distsqlpb.ProducerMetadata{Err: err})
+			meta := distsqlpb.GetProducerMeta()
+			meta.Err = err
+			dst.Push(nil, meta)
 		}
 		dst.ProducerDone()
 	}

--- a/pkg/sql/distsqlrun/indexjoiner.go
+++ b/pkg/sql/distsqlrun/indexjoiner.go
@@ -87,7 +87,7 @@ func newIndexJoiner(
 		nil, /* memMonitor */
 		ProcStateOpts{
 			InputsToDrain: []RowSource{ij.input},
-			TrailingMetaCallback: func(ctx context.Context) []distsqlpb.ProducerMetadata {
+			TrailingMetaCallback: func(ctx context.Context) []*distsqlpb.ProducerMetadata {
 				ij.InternalClose()
 				return ij.generateMeta(ctx)
 			},
@@ -225,14 +225,16 @@ func (ij *indexJoiner) outputStatsToTrace() {
 	}
 }
 
-func (ij *indexJoiner) generateMeta(ctx context.Context) []distsqlpb.ProducerMetadata {
+func (ij *indexJoiner) generateMeta(ctx context.Context) []*distsqlpb.ProducerMetadata {
 	if meta := getTxnCoordMeta(ctx, ij.flowCtx.txn); meta != nil {
-		return []distsqlpb.ProducerMetadata{{TxnCoordMeta: meta}}
+		producerMeta := distsqlpb.GetProducerMeta()
+		producerMeta.TxnCoordMeta = meta
+		return []*distsqlpb.ProducerMetadata{producerMeta}
 	}
 	return nil
 }
 
 // DrainMeta is part of the MetadataSource interface.
-func (ij *indexJoiner) DrainMeta(ctx context.Context) []distsqlpb.ProducerMetadata {
+func (ij *indexJoiner) DrainMeta(ctx context.Context) []*distsqlpb.ProducerMetadata {
 	return ij.generateMeta(ctx)
 }

--- a/pkg/sql/distsqlrun/input_sync.go
+++ b/pkg/sql/distsqlrun/input_sync.go
@@ -282,7 +282,9 @@ func (s *orderedSynchronizer) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMe
 	if s.state == notInitialized {
 		if err := s.initHeap(); err != nil {
 			s.ConsumerDone()
-			return nil, &distsqlpb.ProducerMetadata{Err: err}
+			meta := distsqlpb.GetProducerMeta()
+			meta.Err = err
+			return nil, meta
 		}
 		s.state = returningRows
 	} else if s.state == returningRows && s.needsAdvance {
@@ -290,7 +292,9 @@ func (s *orderedSynchronizer) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMe
 		// the next row for that source.
 		if err := s.advanceRoot(); err != nil {
 			s.ConsumerDone()
-			return nil, &distsqlpb.ProducerMetadata{Err: err}
+			meta := distsqlpb.GetProducerMeta()
+			meta.Err = err
+			return nil, meta
 		}
 	}
 

--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -169,7 +169,7 @@ func newJoinReader(
 		output,
 		ProcStateOpts{
 			InputsToDrain: []RowSource{jr.input},
-			TrailingMetaCallback: func(ctx context.Context) []distsqlpb.ProducerMetadata {
+			TrailingMetaCallback: func(ctx context.Context) []*distsqlpb.ProducerMetadata {
 				jr.InternalClose()
 				return jr.generateMeta(ctx)
 			},
@@ -565,14 +565,16 @@ func (jr *joinReader) outputStatsToTrace() {
 	}
 }
 
-func (jr *joinReader) generateMeta(ctx context.Context) []distsqlpb.ProducerMetadata {
-	if meta := getTxnCoordMeta(ctx, jr.flowCtx.txn); meta != nil {
-		return []distsqlpb.ProducerMetadata{{TxnCoordMeta: meta}}
+func (jr *joinReader) generateMeta(ctx context.Context) []*distsqlpb.ProducerMetadata {
+	if txnCoordMeta := getTxnCoordMeta(ctx, jr.flowCtx.txn); txnCoordMeta != nil {
+		meta := distsqlpb.GetProducerMeta()
+		meta.TxnCoordMeta = txnCoordMeta
+		return []*distsqlpb.ProducerMetadata{meta}
 	}
 	return nil
 }
 
 // DrainMeta is part of the MetadataSource interface.
-func (jr *joinReader) DrainMeta(ctx context.Context) []distsqlpb.ProducerMetadata {
+func (jr *joinReader) DrainMeta(ctx context.Context) []*distsqlpb.ProducerMetadata {
 	return jr.generateMeta(ctx)
 }

--- a/pkg/sql/distsqlrun/materializer.go
+++ b/pkg/sql/distsqlrun/materializer.go
@@ -80,8 +80,8 @@ func newMaterializer(
 		output,
 		nil, /* memMonitor */
 		ProcStateOpts{
-			TrailingMetaCallback: func(ctx context.Context) []distsqlpb.ProducerMetadata {
-				var trailingMeta []distsqlpb.ProducerMetadata
+			TrailingMetaCallback: func(ctx context.Context) []*distsqlpb.ProducerMetadata {
+				var trailingMeta []*distsqlpb.ProducerMetadata
 				for _, src := range metadataSourcesQueue {
 					trailingMeta = append(trailingMeta, src.DrainMeta(ctx)...)
 				}

--- a/pkg/sql/distsqlrun/ordinality.go
+++ b/pkg/sql/distsqlrun/ordinality.go
@@ -61,7 +61,7 @@ func newOrdinalityProcessor(
 		nil, /* memMonitor */
 		ProcStateOpts{
 			InputsToDrain: []RowSource{o.input},
-			TrailingMetaCallback: func(context.Context) []distsqlpb.ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []*distsqlpb.ProducerMetadata {
 				o.ConsumerClosed()
 				return nil
 			}},

--- a/pkg/sql/distsqlrun/sampler.go
+++ b/pkg/sql/distsqlrun/sampler.go
@@ -204,9 +204,10 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 		if rowCount%SamplerProgressInterval == 0 {
 			// Send a metadata record to check that the consumer is still alive and
 			// report number of rows processed since the last update.
-			meta := &distsqlpb.ProducerMetadata{SamplerProgress: &distsqlpb.RemoteProducerMetadata_SamplerProgress{
+			meta := distsqlpb.GetProducerMeta()
+			meta.SamplerProgress = &distsqlpb.RemoteProducerMetadata_SamplerProgress{
 				RowsProcessed: uint64(SamplerProgressInterval),
-			}}
+			}
 			if !emitHelper(ctx, &s.out, nil /* row */, meta, s.pushTrailingMeta, s.input) {
 				return true, nil
 			}
@@ -341,9 +342,10 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 	}
 
 	// Send one last progress update to the consumer.
-	meta := &distsqlpb.ProducerMetadata{SamplerProgress: &distsqlpb.RemoteProducerMetadata_SamplerProgress{
+	meta := distsqlpb.GetProducerMeta()
+	meta.SamplerProgress = &distsqlpb.RemoteProducerMetadata_SamplerProgress{
 		RowsProcessed: uint64(rowCount % SamplerProgressInterval),
-	}}
+	}
 	if !emitHelper(ctx, &s.out, nil /* row */, meta, s.pushTrailingMeta, s.input) {
 		return true, nil
 	}

--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -267,7 +267,7 @@ func newSortAllProcessor(
 		spec.OrderingMatchLen,
 		ProcStateOpts{
 			InputsToDrain: []RowSource{input},
-			TrailingMetaCallback: func(context.Context) []distsqlpb.ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []*distsqlpb.ProducerMetadata {
 				proc.close()
 				return nil
 			},
@@ -304,7 +304,7 @@ func (s *sortAllProcessor) fill() (ok bool, _ error) {
 	for {
 		row, meta := s.input.Next()
 		if meta != nil {
-			s.trailingMeta = append(s.trailingMeta, *meta)
+			s.trailingMeta = append(s.trailingMeta, meta)
 			if meta.Err != nil {
 				return false, nil
 			}
@@ -385,7 +385,7 @@ func newSortTopKProcessor(
 		ordering, spec.OrderingMatchLen,
 		ProcStateOpts{
 			InputsToDrain: []RowSource{input},
-			TrailingMetaCallback: func(context.Context) []distsqlpb.ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []*distsqlpb.ProducerMetadata {
 				proc.close()
 				return nil
 			},
@@ -408,7 +408,7 @@ func (s *sortTopKProcessor) Start(ctx context.Context) context.Context {
 	for {
 		row, meta := s.input.Next()
 		if meta != nil {
-			s.trailingMeta = append(s.trailingMeta, *meta)
+			s.trailingMeta = append(s.trailingMeta, meta)
 			if meta.Err != nil {
 				s.MoveToDraining(nil /* err */)
 				break
@@ -488,7 +488,7 @@ func newSortChunksProcessor(
 		proc, flowCtx, processorID, input, post, out, ordering, spec.OrderingMatchLen,
 		ProcStateOpts{
 			InputsToDrain: []RowSource{input},
-			TrailingMetaCallback: func(context.Context) []distsqlpb.ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []*distsqlpb.ProducerMetadata {
 				proc.close()
 				return nil
 			},
@@ -532,7 +532,7 @@ func (s *sortChunksProcessor) fill() (bool, error) {
 	for nextChunkRow == nil {
 		nextChunkRow, meta = s.input.Next()
 		if meta != nil {
-			s.trailingMeta = append(s.trailingMeta, *meta)
+			s.trailingMeta = append(s.trailingMeta, meta)
 			if meta.Err != nil {
 				return false, nil
 			}
@@ -555,7 +555,7 @@ func (s *sortChunksProcessor) fill() (bool, error) {
 		nextChunkRow, meta = s.input.Next()
 
 		if meta != nil {
-			s.trailingMeta = append(s.trailingMeta, *meta)
+			s.trailingMeta = append(s.trailingMeta, meta)
 			if meta.Err != nil {
 				return false, nil
 			}

--- a/pkg/sql/distsqlrun/stats.go
+++ b/pkg/sql/distsqlrun/stats.go
@@ -140,7 +140,9 @@ func (w *rowFetcherWrapper) Start(ctx context.Context) context.Context {
 func (w *rowFetcherWrapper) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata) {
 	row, _, _, err := w.NextRow(w.ctx)
 	if err != nil {
-		return row, &distsqlpb.ProducerMetadata{Err: err}
+		meta := distsqlpb.GetProducerMeta()
+		meta.Err = err
+		return row, meta
 	}
 	return row, nil
 }

--- a/pkg/sql/distsqlrun/stream_data_test.go
+++ b/pkg/sql/distsqlrun/stream_data_test.go
@@ -69,7 +69,7 @@ func testRowStream(tb testing.TB, rng *rand.Rand, types []types.T, records []row
 				}
 				numRows++
 			} else {
-				se.AddMetadata(context.TODO(), records[rowIdx].meta)
+				se.AddMetadata(context.TODO(), &records[rowIdx].meta)
 				numMeta++
 			}
 		}

--- a/pkg/sql/distsqlrun/stream_decoder.go
+++ b/pkg/sql/distsqlrun/stream_decoder.go
@@ -48,7 +48,7 @@ type StreamDecoder struct {
 	typing       []distsqlpb.DatumInfo
 	data         []byte
 	numEmptyRows int
-	metadata     []distsqlpb.ProducerMetadata
+	metadata     []*distsqlpb.ProducerMetadata
 	rowAlloc     sqlbase.EncDatumRowAlloc
 
 	headerReceived bool
@@ -124,7 +124,7 @@ func (sd *StreamDecoder) GetRow(
 	rowBuf sqlbase.EncDatumRow,
 ) (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata, error) {
 	if len(sd.metadata) != 0 {
-		r := &sd.metadata[0]
+		r := sd.metadata[0]
 		sd.metadata = sd.metadata[1:]
 		return nil, r, nil
 	}

--- a/pkg/sql/distsqlrun/stream_encoder.go
+++ b/pkg/sql/distsqlrun/stream_encoder.go
@@ -77,7 +77,7 @@ func (se *StreamEncoder) init(types []types.T) {
 // that the StreamDecoder will return them first, before the data rows, thus
 // ensuring that rows produced _after_ an error are not received _before_ the
 // error.
-func (se *StreamEncoder) AddMetadata(ctx context.Context, meta distsqlpb.ProducerMetadata) {
+func (se *StreamEncoder) AddMetadata(ctx context.Context, meta *distsqlpb.ProducerMetadata) {
 	se.metadata = append(se.metadata, distsqlpb.LocalMetaToRemoteProducerMeta(ctx, meta))
 }
 

--- a/pkg/sql/distsqlrun/stream_merger.go
+++ b/pkg/sql/distsqlrun/stream_merger.go
@@ -82,7 +82,9 @@ func (sm *streamMerger) NextBatch(
 		sm.nullEquality, &sm.datumAlloc, evalCtx,
 	)
 	if err != nil {
-		return nil, nil, &distsqlpb.ProducerMetadata{Err: err}
+		meta := distsqlpb.GetProducerMeta()
+		meta.Err = err
+		return nil, nil, meta
 	}
 	var leftGroup, rightGroup []sqlbase.EncDatumRow
 	if cmp <= 0 {

--- a/pkg/sql/distsqlrun/windower.go
+++ b/pkg/sql/distsqlrun/windower.go
@@ -231,7 +231,7 @@ func newWindower(
 		output,
 		memMonitor,
 		ProcStateOpts{InputsToDrain: []RowSource{w.input},
-			TrailingMetaCallback: func(context.Context) []distsqlpb.ProducerMetadata {
+			TrailingMetaCallback: func(context.Context) []*distsqlpb.ProducerMetadata {
 				w.close()
 				return nil
 			}},

--- a/pkg/sql/exec/colrpc/colrpc_test.go
+++ b/pkg/sql/exec/colrpc/colrpc_test.go
@@ -372,7 +372,7 @@ func TestOutboxInboxMetadataPropagation(t *testing.T) {
 		numBatches int
 		// test is the body of the test to be run. Metadata should be returned to
 		// be verified.
-		test func(context.Context, *Inbox) []distsqlpb.ProducerMetadata
+		test func(context.Context, *Inbox) []*distsqlpb.ProducerMetadata
 	}{
 		{
 			// ExplicitDrainRequest verifies that an Outbox responds to an explicit drain
@@ -381,7 +381,7 @@ func TestOutboxInboxMetadataPropagation(t *testing.T) {
 			// Set a high number of batches to ensure that the Outbox is very far
 			// from being finished when it receives a DrainRequest.
 			numBatches: math.MaxInt64,
-			test: func(ctx context.Context, inbox *Inbox) []distsqlpb.ProducerMetadata {
+			test: func(ctx context.Context, inbox *Inbox) []*distsqlpb.ProducerMetadata {
 				// Simulate the inbox flow calling Next an arbitrary amount of times
 				// (including none).
 				for i := 0; i < numNextsBeforeDrain; i++ {
@@ -395,7 +395,7 @@ func TestOutboxInboxMetadataPropagation(t *testing.T) {
 			// Next has returned a zero batch.
 			name:       "AfterSuccessfulCompletion",
 			numBatches: 4,
-			test: func(ctx context.Context, inbox *Inbox) []distsqlpb.ProducerMetadata {
+			test: func(ctx context.Context, inbox *Inbox) []*distsqlpb.ProducerMetadata {
 				for {
 					b := inbox.Next(ctx)
 					if b.Length() == 0 {
@@ -434,8 +434,8 @@ func TestOutboxInboxMetadataPropagation(t *testing.T) {
 				typs,
 				[]distsqlpb.MetadataSource{
 					distsqlpb.CallbackMetadataSource{
-						DrainMetaCb: func(context.Context) []distsqlpb.ProducerMetadata {
-							return []distsqlpb.ProducerMetadata{{Err: errors.New(expectedMeta)}}
+						DrainMetaCb: func(context.Context) []*distsqlpb.ProducerMetadata {
+							return []*distsqlpb.ProducerMetadata{{Err: errors.New(expectedMeta)}}
 						},
 					},
 				},

--- a/pkg/sql/exec/colrpc/outbox_test.go
+++ b/pkg/sql/exec/colrpc/outbox_test.go
@@ -90,7 +90,7 @@ func TestOutboxDrainsMetadataSources(t *testing.T) {
 			typs,
 			[]distsqlpb.MetadataSource{
 				distsqlpb.CallbackMetadataSource{
-					DrainMetaCb: func(context.Context) []distsqlpb.ProducerMetadata {
+					DrainMetaCb: func(context.Context) []*distsqlpb.ProducerMetadata {
 						atomic.StoreUint32(&sourceDrained, 1)
 						return nil
 					},

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -210,5 +210,5 @@ func (p *planNodeToRowSource) IsException() bool {
 // metadata through local processors, so they instead add the metadata to our
 // trailing metadata and expect us to forward it further.
 func (p *planNodeToRowSource) forwardMetadata(metadata *distsqlpb.ProducerMetadata) {
-	p.ProcessorBase.AppendTrailingMeta(*metadata)
+	p.ProcessorBase.AppendTrailingMeta(metadata)
 }


### PR DESCRIPTION
As well as switching to slices of pointers. There doesn't appear to
be any noticeable performance differences, but this commit unifies
our handling of ProducerMetadata objects.

Release note: None