### PR TITLE
exec: consolidate all Append{...} methods into one

### DIFF
--- a/pkg/sql/exec/coalescer.go
+++ b/pkg/sql/exec/coalescer.go
@@ -69,18 +69,29 @@ func (p *coalescerOp) Next(ctx context.Context) coldata.Batch {
 			fromCol := batch.ColVec(i)
 
 			if batchSize <= leftover {
-				if sel != nil {
-					toCol.AppendWithSel(fromCol, sel, batchSize, t, uint64(p.group.Length()))
-				} else {
-					toCol.Append(fromCol, t, uint64(p.group.Length()), batchSize)
-				}
+				toCol.Append(
+					coldata.AppendArgs{
+						ColType:   t,
+						Src:       fromCol,
+						Sel:       sel,
+						DestIdx:   uint64(p.group.Length()),
+						SrcEndIdx: batchSize,
+					},
+				)
 			} else {
 				bufferCol := p.buffer.ColVec(i)
+				toCol.Append(
+					coldata.AppendArgs{
+						ColType:   t,
+						Src:       fromCol,
+						Sel:       sel,
+						DestIdx:   uint64(p.group.Length()),
+						SrcEndIdx: leftover,
+					},
+				)
 				if sel != nil {
-					toCol.AppendWithSel(fromCol, sel, leftover, t, uint64(p.group.Length()))
 					bufferCol.CopyWithSelInt16(fromCol, sel[leftover:batchSize], batchSize-leftover, t)
 				} else {
-					toCol.Append(fromCol, t, uint64(p.group.Length()), leftover)
 					bufferCol.Copy(fromCol, uint64(leftover), uint64(batchSize), t)
 				}
 			}

--- a/pkg/sql/exec/coldata/vec.go
+++ b/pkg/sql/exec/coldata/vec.go
@@ -22,6 +22,26 @@ import (
 // column is an interface that represents a raw array of a Go native type.
 type column interface{}
 
+// AppendArgs represents the arguments passed in to Vec.Append.
+type AppendArgs struct {
+	// ColType is the type of both the destination and source slices.
+	ColType types.T
+	// Src is the data being appended.
+	Src Vec
+	// Sel is an optional slice specifying indices to append to the destination
+	// slice. Note that Src{Start,End}Idx apply to Sel.
+	Sel []uint16
+	// DestIdx is the first index that Append will append to.
+	DestIdx uint64
+	// SrcStartIdx is the index of the first element in Src that Append will
+	// append.
+	SrcStartIdx uint16
+	// SrcEndIdx is the exclusive end index of Src. i.e. the element in the index
+	// before SrcEndIdx is the last element appended to the destination slice,
+	// similar to Src[SrcStartIdx:SrcEndIdx].
+	SrcEndIdx uint16
+}
+
 // Vec is an interface that represents a column vector that's accessible by
 // Go native types.
 type Vec interface {
@@ -59,22 +79,13 @@ type Vec interface {
 	// Do not call this from normal code - it'll always panic.
 	_TemplateType() []interface{}
 
-	// Append appends fromLength elements of the given Vec to toLength
-	// elements of this Vec, assuming that both Vecs are of type colType.
-	Append(vec Vec, colType types.T, toLength uint64, fromLength uint16)
-
-	// AppendSlice appends vec[srcStartIdx:srcEndIdx] elements to
-	// this Vec starting at destStartIdx.
-	AppendSlice(vec Vec, colType types.T, destStartIdx uint64, srcStartIdx uint16, srcEndIdx uint16)
-
-	// AppendWithSel appends into itself another column vector from a Batch with
-	// maximum size of BatchSize, filtered by the given selection vector.
-	AppendWithSel(vec Vec, sel []uint16, batchSize uint16, colType types.T, toLength uint64)
-
-	// AppendSliceWithSel appends srcEndIdx - srcStartIdx elements to this Vec starting
-	// at destStartIdx. These elements come from vec, filtered by the selection
-	// vector sel.
-	AppendSliceWithSel(vec Vec, colType types.T, destStartIdx uint64, srcStartIdx uint16, srcEndIdx uint16, sel []uint16)
+	// Append uses AppendArgs to append elements of a source Vec into this Vec.
+	// It is logically equivalent to:
+	// destVec = append(destVec[:args.DestIdx], args.Src[args.SrcStartIdx:args.SrcEndIdx])
+	// An optional Sel slice can also be provided to apply a filter on the source
+	// Vec.
+	// Refer to the AppendArgs comment for specifics and TestAppend for examples.
+	Append(AppendArgs)
 
 	// Copy copies src[srcStartIdx:srcEndIdx] into this Vec.
 	Copy(src Vec, srcStartIdx, srcEndIdx uint64, typ types.T)

--- a/pkg/sql/exec/coldata/vec.go
+++ b/pkg/sql/exec/coldata/vec.go
@@ -79,6 +79,9 @@ type Vec interface {
 	// Copy copies src[srcStartIdx:srcEndIdx] into this Vec.
 	Copy(src Vec, srcStartIdx, srcEndIdx uint64, typ types.T)
 
+	// CopyAt copies src[srcStartIdx:srcEndIdx] into this Vec starting at destStartIdx.
+	CopyAt(src Vec, destStartIdx, srcStartIdx, srcEndIdx uint64, typ types.T)
+
 	// CopyWithSelInt64 copies vec, filtered by sel, into this Vec. It replaces
 	// the contents of this Vec.
 	CopyWithSelInt64(vec Vec, sel []uint64, nSel uint16, colType types.T)

--- a/pkg/sql/exec/coldata/vec_tmpl.go
+++ b/pkg/sql/exec/coldata/vec_tmpl.go
@@ -39,88 +39,32 @@ const _TYPES_T = types.Unhandled
 
 // */}}
 
-func (m *memColumn) Append(vec Vec, colType types.T, toLength uint64, fromLength uint16) {
-	switch colType {
+func (m *memColumn) Append(args AppendArgs) {
+	switch args.ColType {
 	// {{range .}}
 	case _TYPES_T:
-		m.col = append(m._TemplateType()[:toLength], vec._TemplateType()[:fromLength]...)
-		// {{end}}
-	default:
-		panic(fmt.Sprintf("unhandled type %d", colType))
-	}
-
-	if fromLength > 0 {
-		m.nulls.Extend(vec.Nulls(), toLength, 0 /* srcStartIdx */, fromLength)
-	}
-}
-
-func (m *memColumn) AppendSlice(
-	vec Vec, colType types.T, destStartIdx uint64, srcStartIdx uint16, srcEndIdx uint16,
-) {
-	batchSize := srcEndIdx - srcStartIdx
-	outputLen := destStartIdx + uint64(batchSize)
-
-	switch colType {
-	// {{range .}}
-	case _TYPES_T:
-		if outputLen > uint64(len(m._TemplateType())) {
-			m.col = append(m._TemplateType()[:destStartIdx], vec._TemplateType()[srcStartIdx:srcEndIdx]...)
+		fromCol := args.Src._TemplateType()
+		toCol := m._TemplateType()
+		numToAppend := args.SrcEndIdx - args.SrcStartIdx
+		if args.Sel == nil {
+			toCol = append(toCol[:args.DestIdx], fromCol[args.SrcStartIdx:args.SrcEndIdx]...)
+			m.nulls.Extend(args.Src.Nulls(), args.DestIdx, args.SrcStartIdx, numToAppend)
 		} else {
-			copy(m._TemplateType()[destStartIdx:], vec._TemplateType()[srcStartIdx:srcEndIdx])
+			sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
+			appendVals := make([]_GOTYPE, len(sel))
+			for i, selIdx := range sel {
+				appendVals[i] = fromCol[selIdx]
+			}
+			toCol = append(toCol[:args.DestIdx], appendVals...)
+			// TODO(asubiotto): Change Extend* signatures to allow callers to pass in
+			// SrcEndIdx instead of numToAppend.
+			m.nulls.ExtendWithSel(args.Src.Nulls(), args.DestIdx, args.SrcStartIdx, numToAppend, args.Sel)
 		}
-	// {{end}}
-	default:
-		panic(fmt.Sprintf("unhandled type %d", colType))
-	}
-
-	m.nulls.Extend(vec.Nulls(), destStartIdx, srcStartIdx, batchSize)
-}
-
-func (m *memColumn) AppendWithSel(
-	vec Vec, sel []uint16, batchSize uint16, colType types.T, toLength uint64,
-) {
-	switch colType {
-	// {{range .}}
-	case _TYPES_T:
-		toCol := append(m._TemplateType()[:toLength], make([]_GOTYPE, batchSize)...)
-		fromCol := vec._TemplateType()
-
-		for i := uint16(0); i < batchSize; i++ {
-			toCol[uint64(i)+toLength] = fromCol[sel[i]]
-		}
-
-		m.col = toCol
-		// {{end}}
-	default:
-		panic(fmt.Sprintf("unhandled type %d", colType))
-	}
-
-	if batchSize > 0 {
-		m.nulls.ExtendWithSel(vec.Nulls(), toLength, 0 /* srcStartIdx */, batchSize, sel)
-	}
-}
-
-func (m *memColumn) AppendSliceWithSel(
-	vec Vec, colType types.T, destStartIdx uint64, srcStartIdx uint16, srcEndIdx uint16, sel []uint16,
-) {
-	batchSize := srcEndIdx - srcStartIdx
-	switch colType {
-	// {{range .}}
-	case _TYPES_T:
-		toCol := append(m._TemplateType()[:destStartIdx], make([]_GOTYPE, batchSize)...)
-		fromCol := vec._TemplateType()
-
-		for i := 0; i < int(batchSize); i++ {
-			toCol[uint64(i)+destStartIdx] = fromCol[sel[i+int(srcStartIdx)]]
-		}
-
 		m.col = toCol
 	// {{end}}
 	default:
-		panic(fmt.Sprintf("unhandled type %d", colType))
+		panic(fmt.Sprintf("unhandled type %s", args.ColType))
 	}
-
-	m.nulls.ExtendWithSel(vec.Nulls(), destStartIdx, srcStartIdx, batchSize, sel)
 }
 
 func (m *memColumn) Copy(src Vec, srcStartIdx, srcEndIdx uint64, typ types.T) {

--- a/pkg/sql/exec/colrpc/colrpc_test.go
+++ b/pkg/sql/exec/colrpc/colrpc_test.go
@@ -270,7 +270,13 @@ func TestOutboxInbox(t *testing.T) {
 				// Copy batch since it's not safe to reuse after calling Next.
 				batchCopy := coldata.NewMemBatchWithSize(typs, int(outputBatch.Length()))
 				for i := range typs {
-					batchCopy.ColVec(i).Append(outputBatch.ColVec(i), typs[i], 0, outputBatch.Length())
+					batchCopy.ColVec(i).Append(
+						coldata.AppendArgs{
+							ColType:   typs[i],
+							Src:       outputBatch.ColVec(i),
+							SrcEndIdx: outputBatch.Length(),
+						},
+					)
 				}
 				batchCopy.SetLength(outputBatch.Length())
 				outputBatches.Add(batchCopy)

--- a/pkg/sql/exec/hashjoiner.go
+++ b/pkg/sql/exec/hashjoiner.go
@@ -467,14 +467,16 @@ func makeHashTable(
 // output columns.
 func (ht *hashTable) loadBatch(batch coldata.Batch) {
 	batchSize := batch.Length()
-	sel := batch.Selection()
-
 	for i, colIdx := range ht.valCols {
-		if sel != nil {
-			ht.vals[i].AppendWithSel(batch.ColVec(int(colIdx)), sel, batchSize, ht.valTypes[i], ht.size)
-		} else {
-			ht.vals[i].Append(batch.ColVec(int(colIdx)), ht.valTypes[i], ht.size, batchSize)
-		}
+		ht.vals[i].Append(
+			coldata.AppendArgs{
+				ColType:   ht.valTypes[i],
+				Src:       batch.ColVec(int(colIdx)),
+				Sel:       batch.Selection(),
+				DestIdx:   ht.size,
+				SrcEndIdx: batchSize,
+			},
+		)
 	}
 
 	ht.size += uint64(batchSize)

--- a/pkg/sql/exec/mergejoiner.go
+++ b/pkg/sql/exec/mergejoiner.go
@@ -430,14 +430,17 @@ func (o *mergeJoinOp) saveGroupToState(
 	destStartIdx *int,
 ) {
 	endIdx := idx + groupLength
-	if sel != nil {
-		for cIdx, cType := range src.sourceTypes {
-			destBatch.ColVec(cIdx).AppendSliceWithSel(bat.ColVec(cIdx), cType, uint64(*destStartIdx), uint16(idx), uint16(endIdx), sel)
-		}
-	} else {
-		for cIdx, cType := range src.sourceTypes {
-			destBatch.ColVec(cIdx).AppendSlice(bat.ColVec(cIdx), cType, uint64(*destStartIdx), uint16(idx), uint16(endIdx))
-		}
+	for cIdx, cType := range src.sourceTypes {
+		destBatch.ColVec(cIdx).Append(
+			coldata.AppendArgs{
+				ColType:     cType,
+				Src:         bat.ColVec(cIdx),
+				Sel:         sel,
+				DestIdx:     uint64(*destStartIdx),
+				SrcStartIdx: uint16(idx),
+				SrcEndIdx:   uint16(endIdx),
+			},
+		)
 	}
 
 	*destStartIdx += groupLength

--- a/pkg/sql/exec/orderedsynchronizer.go
+++ b/pkg/sql/exec/orderedsynchronizer.go
@@ -73,8 +73,15 @@ func (o *orderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 			if sel := batch.Selection(); sel != nil {
 				srcStartIdx = sel[srcStartIdx]
 			}
-			o.output.ColVec(i).AppendSlice(
-				vec, o.columnTypes[i], uint64(outputIdx), srcStartIdx, srcStartIdx+1)
+			o.output.ColVec(i).Append(
+				coldata.AppendArgs{
+					ColType:     o.columnTypes[i],
+					Src:         vec,
+					DestIdx:     uint64(outputIdx),
+					SrcStartIdx: srcStartIdx,
+					SrcEndIdx:   srcStartIdx + 1,
+				},
+			)
 		}
 
 		// Advance the input batch, fetching a new batch if necessary.

--- a/pkg/sql/exec/routers.go
+++ b/pkg/sql/exec/routers.go
@@ -195,7 +195,15 @@ func (o *routerOutputOp) addBatch(batch coldata.Batch, selection []uint16) bool 
 		}
 
 		for i, t := range o.types {
-			dst.ColVec(i).AppendWithSel(batch.ColVec(i), selection, numAppended, t, uint64(dst.Length()))
+			dst.ColVec(i).Append(
+				coldata.AppendArgs{
+					ColType:   t,
+					Src:       batch.ColVec(i),
+					Sel:       selection,
+					DestIdx:   uint64(dst.Length()),
+					SrcEndIdx: uint16(len(selection)),
+				},
+			)
 		}
 
 		selection = selection[numAppended:]

--- a/pkg/sql/exec/sort_chunks.go
+++ b/pkg/sql/exec/sort_chunks.go
@@ -347,12 +347,14 @@ func (s *chunker) prepareNextChunks(ctx context.Context) chunkerReadingState {
 // buffered tuples.
 func (s *chunker) buffer(start uint16, end uint16) {
 	for i := 0; i < len(s.bufferedColumns); i++ {
-		s.bufferedColumns[i].AppendSlice(
-			s.batch.ColVec(i),
-			s.inputTypes[i],
-			s.buffered,
-			start,
-			end,
+		s.bufferedColumns[i].Append(
+			coldata.AppendArgs{
+				ColType:     s.inputTypes[i],
+				Src:         s.batch.ColVec(i),
+				DestIdx:     s.buffered,
+				SrcStartIdx: start,
+				SrcEndIdx:   end,
+			},
 		)
 	}
 	s.buffered += uint64(end - start)

--- a/pkg/sql/exec/sorttopk.go
+++ b/pkg/sql/exec/sorttopk.go
@@ -162,9 +162,7 @@ func (t *topKSorter) spool(ctx context.Context) {
 					// TODO(solon): Make this copy more efficient, perhaps by adding a
 					// copy method to the vecComparator interface. This would avoid
 					// needing to switch on the column type every time.
-					t.topK.ColVec(j).AppendSlice(
-						inputBatch.ColVec(j), t.inputTypes[j], uint64(maxIdx), uint16(idx), uint16(idx)+1)
-
+					t.topK.ColVec(j).CopyAt(inputBatch.ColVec(j), uint64(maxIdx), uint64(idx), uint64(idx+1), t.inputTypes[j])
 				}
 				heap.Fix(t, 0)
 			}

--- a/pkg/sql/exec/sorttopk.go
+++ b/pkg/sql/exec/sorttopk.go
@@ -124,11 +124,15 @@ func (t *topKSorter) spool(ctx context.Context) {
 			destVec := t.topK.ColVec(i)
 			vec := inputBatch.ColVec(i)
 			colType := t.inputTypes[i]
-			if inputBatch.Selection() == nil {
-				destVec.Append(vec, colType, toLength, fromLength)
-			} else {
-				destVec.AppendWithSel(vec, inputBatch.Selection(), fromLength, colType, toLength)
-			}
+			destVec.Append(
+				coldata.AppendArgs{
+					ColType:   colType,
+					Src:       vec,
+					Sel:       inputBatch.Selection(),
+					DestIdx:   toLength,
+					SrcEndIdx: fromLength,
+				},
+			)
 		}
 		spooledRows += fromLength
 		remainingRows -= fromLength


### PR DESCRIPTION
This makes the code much easier to work with.

```
name                    old time/op    new time/op    delta
Append/SimpleAppend-8      199ns ± 4%     190ns ± 1%   -4.51%  (p=0.000 n=9+9)
Append/AppendWithSel-8    2.45µs ± 1%    2.13µs ± 2%  -13.04%  (p=0.000 n=9+9)

name                    old speed      new speed      delta
Append/SimpleAppend-8   41.0GB/s ± 4%  42.9GB/s ± 2%   +4.64%  (p=0.000 n=9+9)
Append/AppendWithSel-8  3.34GB/s ± 1%  3.84GB/s ± 2%  +14.99%  (p=0.000 n=9+9)
```

I'm not sure why this is faster in the SimpleAppend case (it's possible
it's just noise given the variance), but the AppendWithSel case benefits
from less index arithmetic and bounds checks.

Release note: None