### PR TITLE
pgtest: teach ErrorResponse about response codes

### DIFF
--- a/pkg/sql/pgwire/testdata/pgtest/array
+++ b/pkg/sql/pgwire/testdata/pgtest/array
@@ -10,5 +10,5 @@ ErrorResponse
 ReadyForQuery
 ----
 {"Type":"ParseComplete"}
-{"Type":"ErrorResponse"}
+{"Type":"ErrorResponse","Code":"42804"}
 {"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/testdata/pgtest/inet
+++ b/pkg/sql/pgwire/testdata/pgtest/inet
@@ -10,7 +10,7 @@ ErrorResponse
 ReadyForQuery
 ----
 {"Type":"ParseComplete"}
-{"Type":"ErrorResponse"}
+{"Type":"ErrorResponse","Code":"08P01"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 # IPv4family
@@ -23,7 +23,7 @@ until
 ErrorResponse
 ReadyForQuery
 ----
-{"Type":"ErrorResponse"}
+{"Type":"ErrorResponse","Code":"22P03"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 # IPv6family
@@ -36,5 +36,18 @@ until
 ErrorResponse
 ReadyForQuery
 ----
-{"Type":"ErrorResponse"}
+{"Type":"ErrorResponse","Code":"22P03"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Unknown family
+send
+Bind {"ParameterFormatCodes": [1], "Parameters": [[6, 0, 0, 0, 0, 0]]}
+Sync
+----
+
+until
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ErrorResponse","Code":"22P03"}
 {"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/testdata/pgtest/json
+++ b/pkg/sql/pgwire/testdata/pgtest/json
@@ -10,7 +10,7 @@ ErrorResponse
 ReadyForQuery
 ----
 {"Type":"ParseComplete"}
-{"Type":"ErrorResponse"}
+{"Type":"ErrorResponse","Code":"08P01"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 # JSONB version 2 followed by two double quotes (ASCII 34). This is a
@@ -21,9 +21,9 @@ Bind {"ParameterFormatCodes": [1], "Parameters": [[2, 34, 34]]}
 Sync
 ----
 
-until
+until mapError=(XX000, 08P01)
 ErrorResponse
 ReadyForQuery
 ----
-{"Type":"ErrorResponse"}
+{"Type":"ErrorResponse","Code":"08P01"}
 {"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/testdata/pgtest/portals
+++ b/pkg/sql/pgwire/testdata/pgtest/portals
@@ -25,7 +25,7 @@ until
 ErrorResponse
 ReadyForQuery
 ----
-{"Type":"ErrorResponse"}
+{"Type":"ErrorResponse","Code":"34000"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 # Verify that closing a bound portal prevents execution.
@@ -46,7 +46,7 @@ ReadyForQuery
 {"Type":"ParseComplete"}
 {"Type":"BindComplete"}
 {"Type":"CloseComplete"}
-{"Type":"ErrorResponse"}
+{"Type":"ErrorResponse","Code":"34000"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 # The spec says that closing a prepared statement also closes its portals,

--- a/pkg/sql/pgwire/testdata/pgtest/varbit
+++ b/pkg/sql/pgwire/testdata/pgtest/varbit
@@ -10,7 +10,7 @@ ErrorResponse
 ReadyForQuery
 ----
 {"Type":"ParseComplete"}
-{"Type":"ErrorResponse"}
+{"Type":"ErrorResponse","Code":"08P01"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 # bitlen = 82 (4 bytes), with 17 0-bytes following.
@@ -23,5 +23,5 @@ until
 ErrorResponse
 ReadyForQuery
 ----
-{"Type":"ErrorResponse"}
+{"Type":"ErrorResponse","Code":"22P03"}
 {"Type":"ReadyForQuery","TxStatus":"I"}


### PR DESCRIPTION
Make error response codes match for existing tests. These aren't
exhaustive, and maybe we can do more in the future, but this is a
good start.

Release note (sql change): Make some pgwire error codes for binary
parameter decoding better match Postgres.