### PR TITLE
release-19.1: sql: prevent crash during logging with empty statement

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1200,6 +1200,12 @@ func (ex *connExecutor) run(
 				res = ex.clientComm.CreateErrorResult(pos)
 				break
 			}
+
+			if portal.Stmt.AST == nil {
+				res = ex.clientComm.CreateEmptyQueryResult(pos)
+				break
+			}
+
 			if log.ExpensiveLogEnabled(ex.Ctx(), 2) {
 				log.VEventf(ex.Ctx(), 2, "portal resolved to: %s", portal.Stmt.AST.String())
 			}
@@ -1220,11 +1226,6 @@ func (ex *connExecutor) run(
 			// parsing took no time.
 			ex.phaseTimes[sessionStartParse] = time.Time{}
 			ex.phaseTimes[sessionEndParse] = time.Time{}
-
-			if portal.Stmt.AST == nil {
-				res = ex.clientComm.CreateEmptyQueryResult(pos)
-				break
-			}
 
 			stmtRes := ex.clientComm.CreateStatementResult(
 				portal.Stmt.AST,

--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -143,7 +143,12 @@ func (ExecStmt) command() {}
 func (e ExecStmt) String() string {
 	// We have the original SQL, but we still use String() because it obfuscates
 	// passwords.
-	return fmt.Sprintf("ExecStmt: %s", e.AST.String())
+	s := "(empty)"
+	// e.AST could be nil in the case of a completely empty query.
+	if e.AST != nil {
+		s = e.AST.String()
+	}
+	return fmt.Sprintf("ExecStmt: %s", s)
 }
 
 var _ Command = ExecStmt{}
@@ -192,7 +197,12 @@ func (PrepareStmt) command() {}
 func (p PrepareStmt) String() string {
 	// We have the original SQL, but we still use String() because it obfuscates
 	// passwords.
-	return fmt.Sprintf("PrepareStmt: %s", p.AST.String())
+	s := "(empty)"
+	// p.AST could be nil in the case of a completely empty query.
+	if p.AST != nil {
+		s = p.AST.String()
+	}
+	return fmt.Sprintf("PrepareStmt: %s", s)
 }
 
 var _ Command = PrepareStmt{}


### PR DESCRIPTION
Backport 1/1 commits from #37104.

Fixes #37461.

/cc @cockroachdb/release

---

Previously, the database would crash if a client sent an empty prepare
statement when we had high verbosity on for the conn_executor.

Release note: None
