### PR TITLE
opt: use tags for scalars of const type

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -67,8 +67,10 @@ func init() {
 		opt.SubqueryOp: (*Builder).buildSubquery,
 	}
 
-	for _, op := range opt.BooleanOperators {
-		scalarBuildFuncMap[op] = (*Builder).buildBoolean
+	for _, op := range opt.BoolOperators {
+		if scalarBuildFuncMap[op] == nil {
+			scalarBuildFuncMap[op] = (*Builder).buildBoolean
+		}
 	}
 
 	for _, op := range opt.ComparisonOperators {

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -594,7 +594,9 @@ func (f *ExprFmtCtx) FormatScalarProps(scalar opt.ScalarExpr) {
 	// expression.
 	typ := scalar.DataType()
 	if typ == nil {
-		f.Buffer.WriteString(" [type=undefined]")
+		if scalar.Op() != opt.FKChecksItemOp {
+			f.Buffer.WriteString(" [type=undefined]")
+		}
 	} else {
 		first := true
 		writeProp := func(format string, args ...interface{}) {

--- a/pkg/sql/opt/memo/testdata/logprops/window
+++ b/pkg/sql/opt/memo/testdata/logprops/window
@@ -47,7 +47,7 @@ project
       │    │    └── interesting orderings: (+1)
       │    └── const: 10 [type=int]
       └── windows
-           └── rank [type=undefined]
+           └── rank [type=int]
 
 build
 SELECT k, rank() OVER (PARTITION BY v ORDER BY f) FROM (SELECT * FROM kv LIMIT 10)
@@ -79,7 +79,7 @@ project
       │    │    └── interesting orderings: (+1)
       │    └── const: 10 [type=int]
       └── windows
-           └── rank [type=undefined]
+           └── rank [type=int]
 
 # Outer cols.
 
@@ -134,7 +134,7 @@ project
                      │    │    └── projections
                      │    │         └── variable: k [type=int, outer=(1)]
                      │    └── windows
-                     │         └── rank [type=undefined]
+                     │         └── rank [type=int]
                      └── projections
                           └── plus [type=int, outer=(8,9)]
                                ├── variable: rank [type=int]

--- a/pkg/sql/opt/memo/testdata/stats/window
+++ b/pkg/sql/opt/memo/testdata/stats/window
@@ -41,4 +41,4 @@ project
       │    │    └── fd: (1)-->(2-7)
       │    └── const: 10 [type=int]
       └── windows
-           └── rank [type=undefined]
+           └── rank [type=int]

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -300,7 +300,7 @@ project
       │    └── filters
       │         └── k = u [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
       └── windows
-           └── rank [type=undefined]
+           └── rank [type=int]
 
 # TryDecorrelateWindow will trigger twice here: first to pull the window above
 # the non-apply join, and then again the pull it above the apply join.
@@ -393,7 +393,7 @@ project
       │    └── filters
       │         └── k = column1 [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
       └── windows
-           └── row-number [type=undefined]
+           └── row-number [type=int]
 
 norm expect=TryDecorrelateWindow
 SELECT
@@ -432,7 +432,7 @@ project
       │    │    └── columns: i:3(int)
       │    └── filters (true)
       └── windows
-           └── row-number [type=undefined]
+           └── row-number [type=int]
 
 # In this example, we introduce a key called rownum, and after TryDecorrelateWindow triggers
 # PARTITION BY x becomes PARTITION BY x, rownum. Then later, ReduceWindowPartitionCols triggers,
@@ -478,7 +478,7 @@ project
       │         └── filters
       │              └── k = column1 [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
       └── windows
-           └── row-number [type=undefined]
+           └── row-number [type=int]
 
 norm expect=TryDecorrelateWindow
 SELECT
@@ -520,7 +520,7 @@ project
       │         └── filters
       │              └── k = column1 [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
       └── windows
-           └── row-number [type=undefined]
+           └── row-number [type=int]
 
 norm expect=TryDecorrelateWindow
 SELECT
@@ -552,7 +552,7 @@ window partition=(1)
  │         └── filters
  │              └── k = u [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
  └── windows
-      └── row-number [type=undefined]
+      └── row-number [type=int]
 
 norm expect=TryDecorrelateWindow
 SELECT
@@ -584,7 +584,7 @@ project
       │    └── filters
       │         └── k = u [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
       └── windows
-           └── row-number [type=undefined]
+           └── row-number [type=int]
 
 norm expect=TryDecorrelateWindow
 SELECT
@@ -611,7 +611,7 @@ project
       │    └── filters
       │         └── i = u [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
       └── windows
-           └── row-number [type=undefined]
+           └── row-number [type=int]
 
 norm expect=TryDecorrelateWindow
 SELECT
@@ -650,9 +650,9 @@ project
       │    │    └── columns: i:4(int) f:5(float) s:6(string)
       │    └── filters (true)
       └── windows
-           └── windows-item: range from offset to unbounded [type=undefined]
-                └── window-from-offset [type=undefined]
-                     ├── row-number [type=undefined]
+           └── windows-item: range from offset to unbounded [type=int, outer=(1)]
+                └── window-from-offset [type=int]
+                     ├── row-number [type=int]
                      └── u::FLOAT8 [type=float]
 
 norm expect=TryDecorrelateWindow
@@ -692,9 +692,9 @@ project
       │    │    └── columns: i:4(int) f:5(float) s:6(string)
       │    └── filters (true)
       └── windows
-           └── windows-item: range from unbounded to offset [type=undefined]
-                └── window-to-offset [type=undefined]
-                     ├── row-number [type=undefined]
+           └── windows-item: range from unbounded to offset [type=int, outer=(1)]
+                └── window-to-offset [type=int]
+                     ├── row-number [type=int]
                      └── u::FLOAT8 [type=float]
 
 norm expect=TryDecorrelateWindow

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -1619,7 +1619,7 @@ window partition=()
  ├── columns: rank:5(int)
  ├── scan a
  └── windows
-      └── rank [type=undefined]
+      └── rank [type=int]
 
 norm expect=PruneWindowInputCols
 SELECT ntile(1) OVER () FROM a

--- a/pkg/sql/opt/norm/testdata/rules/window
+++ b/pkg/sql/opt/norm/testdata/rules/window
@@ -18,7 +18,7 @@ project
       │    ├── columns: k:1(int!null)
       │    └── key: (1)
       └── windows
-           └── rank [type=undefined]
+           └── rank [type=int]
 
 norm expect=ReduceWindowPartitionCols
 SELECT rank() OVER (PARTITION BY i, i+1) FROM a
@@ -30,7 +30,7 @@ project
       ├── scan a
       │    └── columns: i:2(int)
       └── windows
-           └── rank [type=undefined]
+           └── rank [type=int]
 
 # --------------------------------------------------
 # SimplifyWindowOrdering
@@ -48,7 +48,7 @@ project
       │    ├── columns: k:1(int!null)
       │    └── key: (1)
       └── windows
-           └── rank [type=undefined]
+           └── rank [type=int]
 
 # We can simplify the ordering with the knowledge that within any partition
 # the set of partition cols is held constant.
@@ -66,7 +66,7 @@ project
       │    ├── columns: k:1(int!null)
       │    └── key: (1)
       └── windows
-           └── rank [type=undefined]
+           └── rank [type=int]
 
 norm expect=SimplifyWindowOrdering
 SELECT rank() OVER (PARTITION BY i ORDER BY f, i+1) FROM a
@@ -78,7 +78,7 @@ project
       ├── scan a
       │    └── columns: i:2(int) f:3(float)
       └── windows
-           └── rank [type=undefined]
+           └── rank [type=int]
 
 norm expect=SimplifyWindowOrdering
 SELECT rank() OVER (PARTITION BY f ORDER BY i) FROM a
@@ -90,7 +90,7 @@ project
       ├── scan a
       │    └── columns: i:2(int) f:3(float)
       └── windows
-           └── rank [type=undefined]
+           └── rank [type=int]
 
 # PushSelectIntoWindow
 
@@ -106,7 +106,7 @@ window partition=(2)
  │    └── filters
  │         └── i > 4 [type=bool, outer=(2), constraints=(/2: [/5 - ]; tight)]
  └── windows
-      └── rank [type=undefined]
+      └── rank [type=int]
 
 # Only push down filters bound by the partition cols.
 norm expect=PushSelectIntoWindow
@@ -124,7 +124,7 @@ select
  │    │    └── filters
  │    │         └── i > 4 [type=bool, outer=(2), constraints=(/2: [/5 - ]; tight)]
  │    └── windows
- │         └── rank [type=undefined]
+ │         └── rank [type=int]
  └── filters
       └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
 
@@ -147,7 +147,7 @@ select
  │    │         ├── i > 4 [type=bool, outer=(2), constraints=(/2: [/5 - ]; tight)]
  │    │         └── f = 3.0 [type=bool, outer=(3), constraints=(/3: [/3.0 - /3.0]; tight), fd=()-->(3)]
  │    └── windows
- │         └── rank [type=undefined]
+ │         └── rank [type=int]
  └── filters
       └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
 
@@ -167,7 +167,7 @@ window partition=(2,3)
  │    └── filters
  │         └── random() < 0.5 [type=bool, side-effects]
  └── windows
-      └── rank [type=undefined]
+      └── rank [type=int]
 
 # Can't push down a filter on an ordering column.
 norm expect-not=PushSelectIntoWindow
@@ -182,7 +182,7 @@ project
       │    ├── scan a
       │    │    └── columns: i:2(int) f:3(float)
       │    └── windows
-      │         └── rank [type=undefined]
+      │         └── rank [type=int]
       └── filters
            └── f > 4.0 [type=bool, outer=(3), constraints=(/3: [/4.000000000000001 - ]; tight)]
 
@@ -201,7 +201,7 @@ project
       │    ├── scan a
       │    │    └── columns: i:2(int) f:3(float) s:4(string)
       │    └── windows
-      │         └── rank [type=undefined]
+      │         └── rank [type=int]
       └── filters
            └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
 
@@ -227,7 +227,7 @@ project
       │    └── filters
       │         └── i = 3 [type=bool, outer=(2), constraints=(/2: [/3 - /3]; tight), fd=()-->(2)]
       └── windows
-           └── rank [type=undefined]
+           └── rank [type=int]
 
 norm expect=PushSelectIntoWindow
 SELECT * FROM (SELECT i, f, rank() OVER (PARTITION BY k ORDER BY f) FROM a) WHERE i*f::int = 3
@@ -249,7 +249,7 @@ project
       │    └── filters
       │         └── (i * f::INT8) = 3 [type=bool, outer=(2,3)]
       └── windows
-           └── rank [type=undefined]
+           └── rank [type=int]
 
 norm expect-not=PushSelectIntoWindow
 SELECT * FROM (SELECT i, f, rank() OVER (PARTITION BY k ORDER BY f) AS rnk FROM a) WHERE rnk = 3
@@ -270,6 +270,6 @@ project
       │    │    ├── key: (1)
       │    │    └── fd: (1)-->(2,3)
       │    └── windows
-      │         └── rank [type=undefined]
+      │         └── rank [type=int]
       └── filters
            └── rank = 3 [type=bool, outer=(6), constraints=(/6: [/3 - /3]; tight), fd=()-->(6)]

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -74,7 +74,7 @@ define SubqueryPrivate {
 # Any expects the input subquery to return a single column of any data type. The
 # scalar value is compared with that column using the specified comparison
 # operator.
-[Scalar]
+[Scalar, Bool]
 define Any {
     Input  RelExpr
     Scalar ScalarExpr
@@ -84,7 +84,7 @@ define Any {
 
 # Exists takes a relational query as its input, and evaluates to true if the
 # query returns at least one row.
-[Scalar]
+[Scalar, Bool]
 define Exists {
     Input RelExpr
 
@@ -129,14 +129,14 @@ define Null {
 # True is the boolean true value that is equivalent to the tree.DBoolTrue datum
 # value. It is a separate operator to make matching and replacement simpler and
 # more efficient, as patterns can contain (True) expressions.
-[Scalar, Boolean, ConstValue]
+[Scalar, Bool, ConstValue]
 define True {
 }
 
 # False is the boolean false value that is equivalent to the tree.DBoolFalse
 # datum value. It is a separate operator to make matching and replacement
 # simpler and more efficient, as patterns can contain (False) expressions.
-[Scalar, Boolean, ConstValue]
+[Scalar, Bool, ConstValue]
 define False {
 }
 
@@ -227,7 +227,7 @@ define AggregationsItem {
 # filtered only if all conditions evaluate to true. If the set is empty, then
 # it never filters rows. See the Select and FiltersItem headers for more
 # details.
-[Scalar, Boolean, List]
+[Scalar, Bool, List]
 define Filters {
 }
 
@@ -236,7 +236,7 @@ define Filters {
 # set of scalar properties that are lazily calculated by traversing the
 # Condition scalar expression. This allows the properties for the entire
 # expression subtree to be calculated once and then repeatedly reused.
-[Scalar, Boolean, ListItem]
+[Scalar, Bool, ListItem]
 define FiltersItem {
     Condition ScalarExpr
 
@@ -294,7 +294,7 @@ define ZipItemPrivate {
 
 # And is the boolean conjunction operator that evalutes to true only if both of
 # its conditions evaluate to true.
-[Scalar, Boolean]
+[Scalar, Bool]
 define And {
     Left  ScalarExpr
     Right ScalarExpr
@@ -302,7 +302,7 @@ define And {
 
 # Or is the boolean disjunction operator that evaluates to true if either one of
 # its conditions evaluates to true.
-[Scalar, Boolean]
+[Scalar, Bool]
 define Or {
     Left  ScalarExpr
     Right ScalarExpr
@@ -316,157 +316,157 @@ define Or {
 #
 # Currently, Range expressions are only created by the ConsolidateSelectFilters
 # normalization rule.
-[Scalar, Boolean]
+[Scalar, Bool]
 define Range {
     And ScalarExpr
 }
 
 # Not is the boolean negation operator that evaluates to true if its input
 # evaluates to false.
-[Scalar, Boolean]
+[Scalar, Bool]
 define Not {
     Input ScalarExpr
 }
 
-[Scalar, Comparison]
+[Scalar, Bool, Comparison]
 define Eq {
    Left  ScalarExpr
    Right ScalarExpr
 }
 
-[Scalar, Comparison]
+[Scalar, Bool, Comparison]
 define Lt {
    Left  ScalarExpr
    Right ScalarExpr
 }
 
-[Scalar, Comparison]
+[Scalar, Bool, Comparison]
 define Gt {
    Left  ScalarExpr
    Right ScalarExpr
 }
 
-[Scalar, Comparison]
+[Scalar, Bool, Comparison]
 define Le {
    Left  ScalarExpr
    Right ScalarExpr
 }
 
-[Scalar, Comparison]
+[Scalar, Bool, Comparison]
 define Ge {
    Left  ScalarExpr
    Right ScalarExpr
 }
 
-[Scalar, Comparison]
+[Scalar, Bool, Comparison]
 define Ne {
    Left  ScalarExpr
    Right ScalarExpr
 }
 
-[Scalar, Comparison]
+[Scalar, Bool, Comparison]
 define In {
    Left  ScalarExpr
    Right ScalarExpr
 }
 
-[Scalar, Comparison]
+[Scalar, Bool, Comparison]
 define NotIn {
    Left  ScalarExpr
    Right ScalarExpr
 }
 
-[Scalar, Comparison]
+[Scalar, Bool, Comparison]
 define Like {
    Left  ScalarExpr
    Right ScalarExpr
 }
 
-[Scalar, Comparison]
+[Scalar, Bool, Comparison]
 define NotLike {
    Left  ScalarExpr
    Right ScalarExpr
 }
 
-[Scalar, Comparison]
+[Scalar, Bool, Comparison]
 define ILike {
    Left  ScalarExpr
    Right ScalarExpr
 }
 
-[Scalar, Comparison]
+[Scalar, Bool, Comparison]
 define NotILike {
    Left  ScalarExpr
    Right ScalarExpr
 }
 
-[Scalar, Comparison]
+[Scalar, Bool, Comparison]
 define SimilarTo {
    Left  ScalarExpr
    Right ScalarExpr
 }
 
-[Scalar, Comparison]
+[Scalar, Bool, Comparison]
 define NotSimilarTo {
    Left  ScalarExpr
    Right ScalarExpr
 }
 
-[Scalar, Comparison]
+[Scalar, Bool, Comparison]
 define RegMatch {
    Left  ScalarExpr
    Right ScalarExpr
 }
 
-[Scalar, Comparison]
+[Scalar, Bool, Comparison]
 define NotRegMatch {
    Left  ScalarExpr
    Right ScalarExpr
 }
 
-[Scalar, Comparison]
+[Scalar, Bool, Comparison]
 define RegIMatch {
    Left  ScalarExpr
    Right ScalarExpr
 }
 
-[Scalar, Comparison]
+[Scalar, Bool, Comparison]
 define NotRegIMatch {
    Left  ScalarExpr
    Right ScalarExpr
 }
 
-[Scalar, Comparison]
+[Scalar, Bool, Comparison]
 define Is {
    Left  ScalarExpr
    Right ScalarExpr
 }
 
-[Scalar, Comparison]
+[Scalar, Bool, Comparison]
 define IsNot {
    Left  ScalarExpr
    Right ScalarExpr
 }
 
-[Scalar, Comparison]
+[Scalar, Bool, Comparison]
 define Contains {
    Left  ScalarExpr
    Right ScalarExpr
 }
 
-[Scalar, Comparison]
+[Scalar, Bool, Comparison]
 define JsonExists {
    Left  ScalarExpr
    Right ScalarExpr
 }
 
-[Scalar, Comparison]
+[Scalar, Bool, Comparison]
 define JsonAllExists {
    Left  ScalarExpr
    Right ScalarExpr
 }
 
-[Scalar, Comparison]
+[Scalar, Bool, Comparison]
 define JsonSomeExists {
    Left  ScalarExpr
    Right ScalarExpr
@@ -474,7 +474,7 @@ define JsonSomeExists {
 
 # AnyScalar is the form of ANY which refers to an ANY operation on a
 # tuple or array, as opposed to Any which operates on a subquery.
-[Scalar]
+[Scalar, Bool]
 define AnyScalar {
    Left  ScalarExpr
    Right ScalarExpr
@@ -776,7 +776,7 @@ define Count {
     Input ScalarExpr
 }
 
-[Scalar, Aggregate]
+[Scalar, Int, Aggregate]
 define CountRows {
 }
 
@@ -956,35 +956,35 @@ define WindowsItemPrivate {
 
 # Rank computes the position of a row relative to an ordering, with same-valued
 # rows receiving the same value.
-[Scalar, Window]
+[Scalar, Int, Window]
 define Rank {
 }
 
 # RowNumber computes the position of a row relative to an ordering, with
 # same-valued rows having ties broken arbitrarily.
-[Scalar, Window]
+[Scalar, Int, Window]
 define RowNumber {
 }
 
 # DenseRank is like Rank, but without gaps. Instead of 1, 1, 3, it gives 1, 1, 2.
-[Scalar, Window]
+[Scalar, Int, Window]
 define DenseRank {
 }
 
 # PercentRank is (rank - 1) / (total rows - 1).
-[Scalar, Window]
+[Scalar, Float, Window]
 define PercentRank {
 }
 
 # CumeDist is the relative rank of the current row:
 # (number of rows preceding or peer with current row) / (total rows)
-[Scalar, Window]
+[Scalar, Float, Window]
 define CumeDist {
 }
 
 # Ntile builds a histogram with the specified number of buckets and evaluates
 # to which bucket the row falls in.
-[Scalar, Window]
+[Scalar, Int, Window]
 define Ntile {
     NumBuckets ScalarExpr
 }

--- a/pkg/sql/opt/optbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/optbuilder/testdata/distinct_on
@@ -324,7 +324,7 @@ distinct-on
  │         ├── scan xyz
  │         │    └── columns: x:1(int) y:2(int) z:3(int) pk1:4(int!null) pk2:5(int!null)
  │         └── windows
- │              └── row-number [type=undefined]
+ │              └── row-number [type=int]
  └── aggregations
       └── first-agg [type=int]
            └── variable: y [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
@@ -23,7 +23,7 @@ insert child
  │         ├── const: 200 [type=int]
  │         └── const: 1 [type=int]
  └── f-k-checks
-      └── f-k-checks-item [type=undefined]
+      └── f-k-checks-item
            └── anti-join
                 ├── columns: column2:4(int!null)
                 ├── project
@@ -67,7 +67,7 @@ insert child_nullable
  │         └── cast: INT8 [type=int]
  │              └── null [type=unknown]
  └── f-k-checks
-      └── f-k-checks-item [type=undefined]
+      └── f-k-checks-item
            └── anti-join
                 ├── columns: column2:4(int!null)
                 ├── select
@@ -113,7 +113,7 @@ insert child_nullable
  │         ├── const: 200 [type=int]
  │         └── const: 1 [type=int]
  └── f-k-checks
-      └── f-k-checks-item [type=undefined]
+      └── f-k-checks-item
            └── anti-join
                 ├── columns: column2:4(int!null)
                 ├── project
@@ -157,7 +157,7 @@ insert child_nullable_full
  │         └── cast: INT8 [type=int]
  │              └── null [type=unknown]
  └── f-k-checks
-      └── f-k-checks-item [type=undefined]
+      └── f-k-checks-item
            └── anti-join
                 ├── columns: column2:4(int!null)
                 ├── select
@@ -219,7 +219,7 @@ insert multi_col_child
  │         └── cast: INT8 [type=int]
  │              └── null [type=unknown]
  └── f-k-checks
-      └── f-k-checks-item [type=undefined]
+      └── f-k-checks-item
            └── anti-join
                 ├── columns: column2:6(int!null) column3:7(int!null) column4:8(int!null)
                 ├── select
@@ -285,7 +285,7 @@ insert multi_col_child
  │         │    └── null [type=unknown]
  │         └── const: 20 [type=int]
  └── f-k-checks
-      └── f-k-checks-item [type=undefined]
+      └── f-k-checks-item
            └── anti-join
                 ├── columns: column2:6(int!null) column3:7(int!null) column4:8(int!null)
                 ├── select
@@ -345,7 +345,7 @@ insert multi_col_child
  │         ├── const: 10 [type=int]
  │         └── const: 10 [type=int]
  └── f-k-checks
-      └── f-k-checks-item [type=undefined]
+      └── f-k-checks-item
            └── anti-join
                 ├── columns: column2:6(int!null) column3:7(int!null) column4:8(int!null)
                 ├── project
@@ -400,7 +400,7 @@ insert multi_col_child_full
  │         └── cast: INT8 [type=int]
  │              └── null [type=unknown]
  └── f-k-checks
-      └── f-k-checks-item [type=undefined]
+      └── f-k-checks-item
            └── anti-join
                 ├── columns: column2:6(int) column3:7(int) column4:8(int)
                 ├── select
@@ -468,7 +468,7 @@ insert multi_col_child_full
  │         │    └── null [type=unknown]
  │         └── const: 20 [type=int]
  └── f-k-checks
-      └── f-k-checks-item [type=undefined]
+      └── f-k-checks-item
            └── anti-join
                 ├── columns: column2:6(int) column3:7(int) column4:8(int!null)
                 ├── project
@@ -519,7 +519,7 @@ insert multi_col_child_full
  │         ├── const: 10 [type=int]
  │         └── const: 10 [type=int]
  └── f-k-checks
-      └── f-k-checks-item [type=undefined]
+      └── f-k-checks-item
            └── anti-join
                 ├── columns: column2:6(int!null) column3:7(int!null) column4:8(int!null)
                 ├── project
@@ -584,7 +584,7 @@ insert multi_ref_child
  │         └── cast: INT8 [type=int]
  │              └── null [type=unknown]
  └── f-k-checks
-      ├── f-k-checks-item [type=undefined]
+      ├── f-k-checks-item
       │    └── anti-join
       │         ├── columns: column2:6(int!null)
       │         ├── select
@@ -611,7 +611,7 @@ insert multi_ref_child
       │              └── eq [type=bool]
       │                   ├── variable: column2 [type=int]
       │                   └── variable: t.public.multi_ref_parent_a.a [type=int]
-      └── f-k-checks-item [type=undefined]
+      └── f-k-checks-item
            └── anti-join
                 ├── columns: column3:7(int!null) column4:8(int!null)
                 ├── select

--- a/pkg/sql/opt/optbuilder/testdata/window
+++ b/pkg/sql/opt/optbuilder/testdata/window
@@ -410,7 +410,7 @@ project
       ├── scan kv
       │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
       └── windows
-           └── rank [type=undefined]
+           └── rank [type=int]
 
 build
 SELECT k, v, first_value(v) OVER () FROM kv
@@ -447,7 +447,7 @@ project
  │    │         └── min [type=int]
  │    │              └── variable: w [type=int]
  │    └── windows
- │         └── row-number [type=undefined]
+ │         └── row-number [type=int]
  └── projections
       └── plus [type=int]
            ├── const: 2 [type=int]
@@ -463,10 +463,10 @@ project
       ├── scan kv
       │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
       └── windows
-           ├── rank [type=undefined]
-           ├── dense-rank [type=undefined]
-           ├── percent-rank [type=undefined]
-           └── cume-dist [type=undefined]
+           ├── rank [type=int]
+           ├── dense-rank [type=int]
+           ├── percent-rank [type=float]
+           └── cume-dist [type=float]
 
 build
 SELECT k, rank() OVER (), rank() OVER () FROM kv
@@ -478,7 +478,7 @@ project
       ├── scan kv
       │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
       └── windows
-           └── rank [type=undefined]
+           └── rank [type=int]
 
 build
 SELECT k, rank() OVER (), row_number() OVER () FROM kv
@@ -490,8 +490,8 @@ project
       ├── scan kv
       │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
       └── windows
-           ├── rank [type=undefined]
-           └── row-number [type=undefined]
+           ├── rank [type=int]
+           └── row-number [type=int]
 
 build
 SELECT k, rank() OVER (), row_number() OVER () FROM kv ORDER BY 1
@@ -506,8 +506,8 @@ sort
            ├── scan kv
            │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
            └── windows
-                ├── rank [type=undefined]
-                └── row-number [type=undefined]
+                ├── rank [type=int]
+                └── row-number [type=int]
 
 build
 SELECT k, v, rank() OVER (PARTITION BY v) FROM kv ORDER BY 1
@@ -522,7 +522,7 @@ sort
            ├── scan kv
            │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
            └── windows
-                └── rank [type=undefined]
+                └── rank [type=int]
 
 build
 SELECT k, row_number() OVER (PARTITION BY v), rank() OVER (PARTITION BY v) FROM kv ORDER BY 1
@@ -537,8 +537,8 @@ sort
            ├── scan kv
            │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
            └── windows
-                ├── row-number [type=undefined]
-                └── rank [type=undefined]
+                ├── row-number [type=int]
+                └── rank [type=int]
 
 build
 SELECT k, v, ntile(1) OVER () FROM kv
@@ -636,7 +636,7 @@ project
       ├── scan kv
       │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
       └── windows
-           └── row-number [type=undefined]
+           └── row-number [type=int]
 
 build
 SELECT v, row_number() OVER (PARTITION BY v) FROM kv
@@ -648,7 +648,7 @@ project
       ├── scan kv
       │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
       └── windows
-           └── row-number [type=undefined]
+           └── row-number [type=int]
 
 build
 SELECT v, row_number() OVER (PARTITION BY v+1) FROM kv
@@ -666,7 +666,7 @@ project
       │              ├── variable: v [type=int]
       │              └── const: 1 [type=int]
       └── windows
-           └── row-number [type=undefined]
+           └── row-number [type=int]
 
 build
 SELECT v, row_number() OVER (PARTITION BY avg(k)) FROM kv GROUP BY v
@@ -686,7 +686,7 @@ project
       │         └── avg [type=decimal]
       │              └── variable: k [type=int]
       └── windows
-           └── row-number [type=undefined]
+           └── row-number [type=int]
 
 # TODO(justin): expand these tuples.
 build
@@ -699,7 +699,7 @@ project
       ├── scan kv
       │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
       └── windows
-           └── row-number [type=undefined]
+           └── row-number [type=int]
 
 build
 SELECT k, row_number() OVER (PARTITION BY kv.*) FROM kv
@@ -711,7 +711,7 @@ project
       ├── scan kv
       │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
       └── windows
-           └── row-number [type=undefined]
+           └── row-number [type=int]
 
 build
 SELECT row_number() OVER (PARTITION BY v), rank() OVER (PARTITION BY v, f) FROM kv
@@ -725,9 +725,9 @@ project
       │    ├── scan kv
       │    │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
       │    └── windows
-      │         └── row-number [type=undefined]
+      │         └── row-number [type=int]
       └── windows
-           └── rank [type=undefined]
+           └── rank [type=int]
 
 # Ordering
 
@@ -741,7 +741,7 @@ project
       ├── scan kv
       │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
       └── windows
-           └── row-number [type=undefined]
+           └── row-number [type=int]
 
 build
 SELECT k, v, rank() OVER (ORDER BY k) FROM kv ORDER BY 1
@@ -756,7 +756,7 @@ sort
            ├── scan kv
            │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
            └── windows
-                └── rank [type=undefined]
+                └── rank [type=int]
 
 # Ensure tuples in orderings get expanded.
 
@@ -783,11 +783,11 @@ sort
            │    │    ├── scan kv
            │    │    │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
            │    │    └── windows
-           │    │         └── rank [type=undefined]
+           │    │         └── rank [type=int]
            │    └── windows
-           │         └── row-number [type=undefined]
+           │         └── row-number [type=int]
            └── windows
-                └── dense-rank [type=undefined]
+                └── dense-rank [type=int]
 
 build
 SELECT k, v, w, v - w + 2 + row_number() OVER (PARTITION BY v, k ORDER BY w) FROM kv ORDER BY 1
@@ -802,7 +802,7 @@ sort
       │    ├── scan kv
       │    │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
       │    └── windows
-      │         └── row-number [type=undefined]
+      │         └── row-number [type=int]
       └── projections
            └── plus [type=int]
                 ├── plus [type=int]
@@ -834,7 +834,7 @@ distinct-on
  │              ├── scan kv
  │              │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
  │              └── windows
- │                   └── row-number [type=undefined]
+ │                   └── row-number [type=int]
  └── aggregations
       └── first-agg [type=int]
            └── variable: w [type=int]
@@ -1435,7 +1435,7 @@ project
       ├── scan kv
       │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
       └── windows
-           └── rank [type=undefined]
+           └── rank [type=int]
 
 build
 SELECT
@@ -1449,7 +1449,7 @@ project
       ├── scan kv
       │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
       └── windows
-           └── rank [type=undefined]
+           └── rank [type=int]
 
 build
 SELECT
@@ -1471,13 +1471,13 @@ project
       │    │    ├── scan kv
       │    │    │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
       │    │    └── windows
-      │    │         ├── rank [type=undefined]
-      │    │         └── rank [type=undefined]
+      │    │         ├── rank [type=int]
+      │    │         └── rank [type=int]
       │    └── windows
-      │         ├── row-number [type=undefined]
-      │         └── row-number [type=undefined]
+      │         ├── row-number [type=int]
+      │         └── row-number [type=int]
       └── windows
-           └── row-number [type=undefined]
+           └── row-number [type=int]
 
 build
 SELECT
@@ -1491,7 +1491,7 @@ project
       ├── scan kv
       │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
       └── windows
-           └── rank [type=undefined]
+           └── rank [type=int]
 
 build
 SELECT
@@ -1509,7 +1509,7 @@ sort
            ├── scan kv
            │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
            └── windows
-                └── rank [type=undefined]
+                └── rank [type=int]
 
 build
 SELECT

--- a/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
@@ -315,8 +315,7 @@ func (g *exprsGen) genExprFuncs(define *lang.DefineExpr) {
 	if define.Tags.Contains("Scalar") {
 		// Generate the DataType method.
 		fmt.Fprintf(g.w, "func (e *%s) DataType() *types.T {\n", opTyp.name)
-		dataType := g.constDataType(define)
-		if dataType != "" {
+		if dataType, ok := g.constDataType(define); ok {
 			fmt.Fprintf(g.w, "  return %s\n", dataType)
 		} else {
 			fmt.Fprintf(g.w, "  return e.Typ\n")
@@ -818,23 +817,22 @@ func (g *exprsGen) scalarPropsFieldName(define *lang.DefineExpr) string {
 }
 
 func (g *exprsGen) needsDataTypeField(define *lang.DefineExpr) bool {
+	if _, ok := g.constDataType(define); ok {
+		return false
+	}
 	for _, field := range expandFields(g.compiled, define) {
 		if field.Name == "Typ" && field.Type == "Type" {
 			return false
 		}
 	}
-	return g.constDataType(define) == ""
+	return true
 }
 
-func (g *exprsGen) constDataType(define *lang.DefineExpr) string {
-	switch define.Name {
-	case "Exists", "Any", "AnyScalar":
-		return "types.Bool"
-	case "CountRows":
-		return "types.Int"
+func (g *exprsGen) constDataType(define *lang.DefineExpr) (_ string, ok bool) {
+	for _, typ := range []string{"Bool", "Int", "Float"} {
+		if define.Tags.Contains(typ) {
+			return "types." + typ, true
+		}
 	}
-	if define.Tags.Contains("Comparison") || define.Tags.Contains("Boolean") {
-		return "types.Bool"
-	}
-	return ""
+	return "", false
 }

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -1542,4 +1542,4 @@ sort
       ├── scan abc
       │    └── columns: a:1(int!null) b:2(int!null) c:3(int!null)
       └── windows
-           └── row-number [type=undefined]
+           └── row-number [type=int]


### PR DESCRIPTION
#### opt: use tags for scalars of const type

Certain scalars have a constant data type; we are currently splitting
this information between tags (like `Boolean`) and a hardcoded list in
optgen. This change moves this information to tags only: `Bool`,
`Int`, `Float` are recognized as indicating a constant type.

We also add constant types to a few scalars that were missing one.

Release note: None

#### opt: hide data type for FKChecksItem

Release note: None
