### PR TITLE
backupccl,rpc,server: Update some skipped tests

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -846,7 +846,7 @@ func getHighWaterMark(jobID int64, sqlDB *gosql.DB) (roachpb.Key, error) {
 // work as intended on backup and restore jobs.
 func TestBackupRestoreControlJob(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#24637")
+	t.Skip("#24136")
 
 	// force every call to update
 	defer jobs.TestingSetProgressThresholds()()

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"math"
 	"net"
-	"runtime"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -439,10 +438,6 @@ func (ln *interceptingListener) Accept() (net.Conn, error) {
 // heartbeats succeed or fail due to transport failures.
 func TestHeartbeatHealthTransport(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-
-	if runtime.GOOS == "windows" {
-		t.Skip("TODO(tamird): remove in Go 1.9; https://github.com/golang/go/commit/03d1aa6")
-	}
 
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())

--- a/pkg/server/diagnosticspb/dep_test.go
+++ b/pkg/server/diagnosticspb/dep_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestNoLinkForbidden(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#30001")
+
 	buildutil.VerifyNoImports(t,
 		"github.com/cockroachdb/cockroach/pkg/server/diagnosticspb", true, []string{"c-deps"}, nil,
 	)


### PR DESCRIPTION
Unskips two tests and updates the issue referenced by a third. 