### PR TITLE
opt: wire up execution for FK checks

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1807,6 +1807,10 @@ func (m *sessionDataMutator) SetOptimizerMode(val sessiondata.OptimizerMode) {
 	m.data.OptimizerMode = val
 }
 
+func (m *sessionDataMutator) SetOptimizerFKs(val bool) {
+	m.data.OptimizerFKs = val
+}
+
 func (m *sessionDataMutator) SetSerialNormalizationMode(val sessiondata.SerialNormalizationMode) {
 	m.data.SerialNormalizationMode = val
 }

--- a/pkg/sql/logictest/testdata/logic_test/fk_opt
+++ b/pkg/sql/logictest/testdata/logic_test/fk_opt
@@ -1,0 +1,23 @@
+# LogicTest: local-opt fakedist-opt
+
+statement ok
+SET experimental_optimizer_foreign_keys = true
+
+statement ok
+CREATE TABLE parent (p INT PRIMARY KEY, other INT)
+
+statement ok
+CREATE TABLE child (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(p))
+
+# TODO(radu): improve the error message and make the check more specific.
+statement error foreign key violation
+INSERT INTO child VALUES (1,1)
+
+statement ok
+INSERT INTO parent VALUES (1), (2)
+
+statement error foreign key violation
+INSERT INTO child VALUES (1,1), (2,2), (3,3)
+
+statement ok
+INSERT INTO child VALUES (1,1), (2,2)

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1500,6 +1500,7 @@ default_transaction_read_only        off           NULL      NULL        NULL   
 distsql                              off           NULL      NULL        NULL        string
 experimental_enable_zigzag_join      on            NULL      NULL        NULL        string
 experimental_force_split_at          off           NULL      NULL        NULL        string
+experimental_optimizer_foreign_keys  off           NULL      NULL        NULL        string
 experimental_serial_normalization    rowid         NULL      NULL        NULL        string
 experimental_vectorize               off           NULL      NULL        NULL        string
 extra_float_digits                   0             NULL      NULL        NULL        string
@@ -1551,6 +1552,7 @@ default_transaction_read_only        off           NULL  user     NULL      off 
 distsql                              off           NULL  user     NULL      off           off
 experimental_enable_zigzag_join      on            NULL  user     NULL      on            on
 experimental_force_split_at          off           NULL  user     NULL      off           off
+experimental_optimizer_foreign_keys  off           NULL  user     NULL      off           off
 experimental_serial_normalization    rowid         NULL  user     NULL      rowid         rowid
 experimental_vectorize               off           NULL  user     NULL      off           off
 extra_float_digits                   0             NULL  user     NULL      0             2
@@ -1598,6 +1600,7 @@ default_transaction_read_only        NULL    NULL     NULL     NULL        NULL
 distsql                              NULL    NULL     NULL     NULL        NULL
 experimental_enable_zigzag_join      NULL    NULL     NULL     NULL        NULL
 experimental_force_split_at          NULL    NULL     NULL     NULL        NULL
+experimental_optimizer_foreign_keys  NULL    NULL     NULL     NULL        NULL
 experimental_serial_normalization    NULL    NULL     NULL     NULL        NULL
 experimental_vectorize               NULL    NULL     NULL     NULL        NULL
 extra_float_digits                   NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -39,6 +39,7 @@ default_transaction_read_only        off
 distsql                              off
 experimental_enable_zigzag_join      on
 experimental_force_split_at          off
+experimental_optimizer_foreign_keys  off
 experimental_serial_normalization    rowid
 experimental_vectorize               off
 extra_float_digits                   0

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -195,7 +195,9 @@ func (f *stubFactory) RenameColumns(input exec.Node, colNames []string) (exec.No
 	return struct{}{}, nil
 }
 
-func (f *stubFactory) ConstructPlan(root exec.Node, subqueries []exec.Subquery) (exec.Plan, error) {
+func (f *stubFactory) ConstructPlan(
+	root exec.Node, subqueries []exec.Subquery, postqueries []exec.Node,
+) (exec.Plan, error) {
 	return struct{}{}, nil
 }
 
@@ -221,6 +223,7 @@ func (f *stubFactory) ConstructInsert(
 	insertCols exec.ColumnOrdinalSet,
 	checks exec.CheckOrdinalSet,
 	rowsNeeded bool,
+	skipFKChecks bool,
 ) (exec.Node, error) {
 	return struct{}{}, nil
 }
@@ -274,5 +277,9 @@ func (f *stubFactory) ConstructSequenceSelect(seq cat.Sequence) (exec.Node, erro
 func (f *stubFactory) ConstructSaveTable(
 	input exec.Node, table *cat.DataSourceName, colNames []string,
 ) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructErrorIfRows(input exec.Node) (exec.Node, error) {
 	return struct{}{}, nil
 }

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -34,6 +34,9 @@ type Builder struct {
 	// expression node.
 	subqueries []exec.Subquery
 
+	// postqueries accumulates check queries that are run after the main query.
+	postqueries []exec.Node
+
 	// nullifyMissingVarExprs, if greater than 0, tells the builder to replace
 	// VariableExprs that have no bindings with DNull. This is useful for apply
 	// join, which needs to be able to create a plan that has outer columns.
@@ -85,7 +88,7 @@ func (b *Builder) Build() (_ exec.Plan, err error) {
 	if err != nil {
 		return nil, err
 	}
-	return b.factory.ConstructPlan(root, b.subqueries)
+	return b.factory.ConstructPlan(root, b.subqueries, b.postqueries)
 }
 
 func (b *Builder) build(e opt.Expr) (exec.Node, error) {

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -83,7 +83,7 @@ func (b *Builder) buildExplain(explain *memo.ExplainExpr) (execPlan, error) {
 			return execPlan{}, err
 		}
 
-		plan, err := b.factory.ConstructPlan(input.root, b.subqueries)
+		plan, err := b.factory.ConstructPlan(input.root, b.subqueries, b.postqueries)
 		if err != nil {
 			return execPlan{}, err
 		}

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -262,8 +262,14 @@ type Factory interface {
 	RenameColumns(input Node, colNames []string) (Node, error)
 
 	// ConstructPlan creates a plan enclosing the given plan and (optionally)
-	// subqueries.
-	ConstructPlan(root Node, subqueries []Subquery) (Plan, error)
+	// subqueries and postqueries.
+	//
+	// Subqueries are executed before the root tree, which can refer to subquery
+	// results using tree.Subquery nodes.
+	//
+	// Postqueries are executed after the root tree. They don't return results but
+	// can generate errors (e.g. foreign key check failures).
+	ConstructPlan(root Node, subqueries []Subquery, postqueries []Node) (Plan, error)
 
 	// ConstructExplain returns a node that implements EXPLAIN (OPT), showing
 	// information about the given plan.
@@ -284,15 +290,21 @@ type Factory interface {
 	// same order they're defined. The insertCols set contains the ordinal
 	// positions of columns in the table into which values are inserted. All
 	// columns are expected to be present except delete-only mutation columns,
-	// since those do not need to participate in an insert operation. The
-	// rowsNeeded parameter is true if a RETURNING clause needs the inserted
+	// since those do not need to participate in an insert operation.
+	//
+	// The rowsNeeded parameter is true if a RETURNING clause needs the inserted
 	// row(s) as output.
+	//
+	// If skipFKChecks is set, foreign keys are not checked as part of the
+	// execution of the insertion. This is used when the FK checks are planned by
+	// the optimizer and are run separately as plan postqueries.
 	ConstructInsert(
 		input Node,
 		table cat.Table,
 		insertCols ColumnOrdinalSet,
 		checks CheckOrdinalSet,
 		rowsNeeded bool,
+		skipFKChecks bool,
 	) (Node, error)
 
 	// ConstructUpdate creates a node that implements an UPDATE statement. The
@@ -384,6 +396,11 @@ type Factory interface {
 	// ConstructSaveTable wraps the input into a node that passes through all the
 	// rows, but also creates a table and inserts all the rows into it.
 	ConstructSaveTable(input Node, table *cat.DataSourceName, colNames []string) (Node, error)
+
+	// ConstructErrorIfRows wraps the input into a node which itself returns no
+	// results, but errors out if the input returns any rows.
+	// TODO(radu): add a way to control the error message.
+	ConstructErrorIfRows(input Node) (Node, error)
 }
 
 // OutputOrdering indicates the required output ordering on a Node that is being

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -134,6 +134,7 @@ type Memo struct {
 	dataConversion    sessiondata.DataConversionConfig
 	reorderJoinsLimit int
 	zigzagJoinEnabled bool
+	optimizerFKs      bool
 	safeUpdates       bool
 	saveTablesPrefix  string
 
@@ -160,6 +161,7 @@ func (m *Memo) Init(evalCtx *tree.EvalContext) {
 	m.dataConversion = evalCtx.SessionData.DataConversion
 	m.reorderJoinsLimit = evalCtx.SessionData.ReorderJoinsLimit
 	m.zigzagJoinEnabled = evalCtx.SessionData.ZigzagJoinEnabled
+	m.optimizerFKs = evalCtx.SessionData.OptimizerFKs
 	m.safeUpdates = evalCtx.SessionData.SafeUpdates
 	m.saveTablesPrefix = evalCtx.SessionData.SaveTablesPrefix
 
@@ -260,6 +262,7 @@ func (m *Memo) IsStale(
 	if !m.dataConversion.Equals(&evalCtx.SessionData.DataConversion) ||
 		m.reorderJoinsLimit != evalCtx.SessionData.ReorderJoinsLimit ||
 		m.zigzagJoinEnabled != evalCtx.SessionData.ZigzagJoinEnabled ||
+		m.optimizerFKs != evalCtx.SessionData.OptimizerFKs ||
 		m.safeUpdates != evalCtx.SessionData.SafeUpdates ||
 		m.saveTablesPrefix != evalCtx.SessionData.SaveTablesPrefix {
 		return true, nil

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -169,6 +169,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData.ZigzagJoinEnabled = false
 	notStale()
 
+	// Stale optimizer FK planning enable.
+	evalCtx.SessionData.OptimizerFKs = true
+	stale()
+	evalCtx.SessionData.OptimizerFKs = false
+	notStale()
+
 	// Stale safe updates.
 	evalCtx.SessionData.SafeUpdates = true
 	stale()

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -66,10 +66,6 @@ type Builder struct {
 	// This is used when re-preparing invalidated queries.
 	KeepPlaceholders bool
 
-	// BuildFKChecks is a control knob: if set, we build foreign key checks (see
-	// the ForeignKeys operator).
-	BuildFKChecks bool
-
 	// -- Results --
 	//
 	// These fields are set during the building process and can be used after

--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -63,7 +63,6 @@ func TestBuilder(t *testing.T) {
 			var err error
 
 			tester := opttester.New(catalog, d.Input)
-			tester.Flags.BuildFKChecks = true
 			tester.Flags.ExprFormat = memo.ExprFmtHideMiscProps |
 				memo.ExprFmtHideConstraints |
 				memo.ExprFmtHideFuncDeps |
@@ -100,6 +99,7 @@ func TestBuilder(t *testing.T) {
 				ctx := context.Background()
 				semaCtx := tree.MakeSemaContext()
 				evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+				evalCtx.SessionData.OptimizerFKs = true
 
 				var o xform.Optimizer
 				o.Init(&evalCtx)

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -743,7 +743,7 @@ func (mb *mutationBuilder) parseDefaultOrComputedExpr(colID opt.ColumnID) tree.E
 // buildFKChecks populates mb.checks with queries that check the integrity of
 // foreign key relations that involve modified rows.
 func (mb *mutationBuilder) buildFKChecks() {
-	if !mb.b.BuildFKChecks {
+	if !mb.b.evalCtx.SessionData.OptimizerFKs {
 		return
 	}
 

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -104,9 +104,6 @@ type Flags struct {
 	// the old planning code.
 	AllowUnsupportedExpr bool
 
-	// BuildFKChecks: if set, the optbuilder builds foreign key checks.
-	BuildFKChecks bool
-
 	// FullyQualifyNames if set: when building a query, the optbuilder fully
 	// qualifies all column names before adding them to the metadata. This flag
 	// allows us to test that name resolution works correctly, and avoids
@@ -180,9 +177,8 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 
 	// Set any OptTester-wide session flags here.
 
-	// Enable zigzag joins for all opt tests. Execbuilder tests exercise
-	// cases where this flag is false.
 	ot.evalCtx.SessionData.ZigzagJoinEnabled = true
+	ot.evalCtx.SessionData.OptimizerFKs = true
 	ot.evalCtx.SessionData.ReorderJoinsLimit = opt.DefaultJoinOrderLimit
 
 	return ot
@@ -1202,7 +1198,6 @@ func (ot *OptTester) buildExpr(factory *norm.Factory) error {
 	ot.semaCtx.Annotations = tree.MakeAnnotations(stmt.NumAnnotations)
 	b := optbuilder.New(ot.ctx, &ot.semaCtx, &ot.evalCtx, ot.catalog, factory, stmt.AST)
 	b.AllowUnsupportedExpr = ot.Flags.AllowUnsupportedExpr
-	b.BuildFKChecks = ot.Flags.BuildFKChecks
 	return b.Build()
 }
 

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -38,9 +38,11 @@ type SessionData struct {
 	// ForceSplitAt indicates whether checks to prevent incorrect usage of ALTER
 	// TABLE ... SPLIT AT should be skipped.
 	ForceSplitAt bool
-	// OptimizerMode indicates whether to use the experimental optimizer for
-	// query planning.
+	// OptimizerMode indicates whether to use the optimizer for query planning.
 	OptimizerMode OptimizerMode
+	// OptimizerFKs indicates whether we should use the new paths to plan foreign
+	// key checks in the optimizer.
+	OptimizerFKs bool
 	// SerialNormalizationMode indicates how to handle the SERIAL pseudo-type.
 	SerialNormalizationMode SerialNormalizationMode
 	// SearchPath is a list of namespaces to search builtins in.

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -420,6 +420,23 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`experimental_optimizer_foreign_keys`: {
+		GetStringVal: makeBoolGetStringValFn(`experimental_optimizer_foreign_keys`),
+		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
+			b, err := parsePostgresBool(s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerFKs(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) string {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData.OptimizerFKs)
+		},
+		GlobalDefault: globalFalse,
+	},
+
+	// CockroachDB extension.
 	`experimental_serial_normalization`: {
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
 			mode, ok := sessiondata.SerialNormalizationModeFromString(s)


### PR DESCRIPTION
This change sets up execution of FK checks from the optimizer side. We
now have a very simple case (INSERT with constant values) working in
the new framework.

Release note: None