### PR TITLE
jobs: use hlc timestamp, not timeutil.Now

### DIFF
--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -136,7 +136,7 @@ func (j *Job) Started(ctx context.Context) error {
 			return nil
 		}
 		ju.UpdateStatus(StatusRunning)
-		md.Payload.StartedMicros = timeutil.ToUnixMicros(timeutil.Now())
+		md.Payload.StartedMicros = timeutil.ToUnixMicros(j.registry.clock.Now().GoTime())
 		ju.UpdatePayload(md.Payload)
 		return nil
 	})
@@ -325,7 +325,7 @@ func (j *Job) canceled(ctx context.Context, fn func(context.Context, *client.Txn
 			}
 		}
 		ju.UpdateStatus(StatusCanceled)
-		md.Payload.FinishedMicros = timeutil.ToUnixMicros(timeutil.Now())
+		md.Payload.FinishedMicros = timeutil.ToUnixMicros(j.registry.clock.Now().GoTime())
 		ju.UpdatePayload(md.Payload)
 		return nil
 	})
@@ -349,7 +349,7 @@ func (j *Job) Failed(
 		}
 		ju.UpdateStatus(StatusFailed)
 		md.Payload.Error = err.Error()
-		md.Payload.FinishedMicros = timeutil.ToUnixMicros(timeutil.Now())
+		md.Payload.FinishedMicros = timeutil.ToUnixMicros(j.registry.clock.Now().GoTime())
 		ju.UpdatePayload(md.Payload)
 		return nil
 	})
@@ -367,7 +367,7 @@ func (j *Job) Succeeded(ctx context.Context, fn func(context.Context, *client.Tx
 			return err
 		}
 		ju.UpdateStatus(StatusSucceeded)
-		md.Payload.FinishedMicros = timeutil.ToUnixMicros(timeutil.Now())
+		md.Payload.FinishedMicros = timeutil.ToUnixMicros(j.registry.clock.Now().GoTime())
 		ju.UpdatePayload(md.Payload)
 		md.Progress.Progress = &jobspb.Progress_FractionCompleted{
 			FractionCompleted: 1.0,

--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -173,7 +173,7 @@ func (j *Job) Update(ctx context.Context, updateFn UpdateFn) error {
 
 		if ju.md.Progress != nil {
 			progress = ju.md.Progress
-			progress.ModifiedMicros = timeutil.ToUnixMicros(timeutil.Now())
+			progress.ModifiedMicros = timeutil.ToUnixMicros(txn.OrigTimestamp().GoTime())
 			progressBytes, err := protoutil.Marshal(progress)
 			if err != nil {
 				return err


### PR DESCRIPTION
Closes #38226.

Previously, the jobs infrastructure was inconsistent about whether to
use hlc or physical clocks to timestamp its updates, creations and
deletes. This led to some test flakiness and likely some small real life
issues.

Now, we only use hlc timestamps.

Release note: None