### PR TITLE
storage: avoid data race in TestSnapshotRaftLogLimit

### DIFF
--- a/pkg/storage/store_snapshot_test.go
+++ b/pkg/storage/store_snapshot_test.go
@@ -57,7 +57,7 @@ func TestSnapshotRaftLogLimit(t *testing.T) {
 
 	for _, snapType := range []SnapshotRequest_Type{SnapshotRequest_PREEMPTIVE, SnapshotRequest_RAFT} {
 		t.Run(snapType.String(), func(t *testing.T) {
-			lastIndex, err := (*replicaRaftStorage)(repl).LastIndex()
+			lastIndex, err := repl.GetLastIndex()
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
I saw the following race in https://teamcity.cockroachdb.com/viewLog.html?buildId=1356733:

```
Race detected!

------- Stdout: -------
==================
Write at 0x00c001d9c2a8 by goroutine 63:
  github.com/cockroachdb/cockroach/pkg/storage.(*Replica).handleRaftReadyRaftMuLocked()
      /go/src/github.com/cockroachdb/cockroach/pkg/storage/replica_raft.go:637 +0x77a
  github.com/cockroachdb/cockroach/pkg/storage.(*Replica).handleRaftReady()
      /go/src/github.com/cockroachdb/cockroach/pkg/storage/replica_raft.go:386 +0x16a
  github.com/cockroachdb/cockroach/pkg/storage.(*Store).processReady()
      /go/src/github.com/cockroachdb/cockroach/pkg/storage/store.go:3742 +0x171
  github.com/cockroachdb/cockroach/pkg/storage.(*raftScheduler).worker()
      /go/src/github.com/cockroachdb/cockroach/pkg/storage/scheduler.go:227 +0x33e
  github.com/cockroachdb/cockroach/pkg/storage.(*raftScheduler).Start.func2()
      /go/src/github.com/cockroachdb/cockroach/pkg/storage/scheduler.go:161 +0x55
  github.com/cockroachdb/cockroach/pkg/util/stop.(*Stopper).RunWorker.func1()
      /go/src/github.com/cockroachdb/cockroach/pkg/util/stop/stopper.go:196 +0x15f

Previous read at 0x00c001d9c2a8 by goroutine 154:
  github.com/cockroachdb/cockroach/pkg/storage.TestSnapshotRaftLogLimit.func1()
      /go/src/github.com/cockroachdb/cockroach/pkg/storage/replica_raftstorage.go:299 +0xa1
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:865 +0x163
```

I don't see an obvious reason why #38343 would have caused this, but maybe
it caused a new handleRaftReady iteration that allowed the race detector
to observe the issue. Either way, the test was broken and this fixes it.

Release note: None