### PR TITLE
fix bug about crash issure when partition created with sub-partition

### DIFF
--- a/pkg/ccl/partitionccl/partition.go
+++ b/pkg/ccl/partitionccl/partition.go
@@ -179,6 +179,10 @@ func createPartitioningImpl(
 		cols = append(cols, col)
 		if string(partBy.Fields[i]) != col.Name {
 			n := colOffset + len(partBy.Fields)
+			// if n exceed the number of index column, set it to max number of index column
+			if n > len(indexDesc.ColumnNames) {
+				n = indexDesc.ColumnNames
+			}
 			return partDesc, fmt.Errorf(
 				"declared partition columns (%s) do not match first %d columns in index being partitioned (%s)",
 				partitioningString(), n, strings.Join(indexDesc.ColumnNames[:n], ", "))


### PR DESCRIPTION
this is a fix about issue #38389, it will meet a crash issue when create stmt as below:
create table st1(id string, name string, primary key(id, name))
partition by list(id) (
partition p1 values in ('us')
partition by list(id, name)(
partition p11 values in('la')))

the root reason is an overflow visit of index-column array.

Fixes #38389

Release note (sql change): fix bug