### PR TITLE
exec: add BatchAllocator skeleton

### DIFF
--- a/pkg/sql/exec/aggregator_test.go
+++ b/pkg/sql/exec/aggregator_test.go
@@ -64,7 +64,14 @@ type aggType struct {
 
 var aggTypes = []aggType{
 	{
-		new:  NewHashAggregator,
+		new: func(input Operator,
+			colTypes []types.T,
+			aggFns []distsqlpb.AggregatorSpec_Func,
+			groupCols []uint32,
+			aggCols [][]uint32,
+		) (Operator, error) {
+			return NewHashAggregator(input, testAllocator, colTypes, aggFns, groupCols, aggCols)
+		},
 		name: "hash",
 	},
 	{
@@ -704,7 +711,8 @@ func TestHashAggregator(t *testing.T) {
 			t.Fatal(err)
 		}
 		runTests(t, []tuples{tc.input}, func(t *testing.T, sources []Operator) {
-			ag, err := NewHashAggregator(sources[0], tc.colTypes, tc.aggFns, tc.groupCols, tc.aggCols)
+			ag, err := NewHashAggregator(
+				sources[0], testAllocator, tc.colTypes, tc.aggFns, tc.groupCols, tc.aggCols)
 
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/sql/exec/coldata/batch.go
+++ b/pkg/sql/exec/coldata/batch.go
@@ -155,3 +155,30 @@ func (m *MemBatch) Reset(types []types.T, length int) {
 		col.Nulls().UnsetNulls()
 	}
 }
+
+// BatchAllocator is a memory management tool for vectorized operators. It
+// provides new batches (and appends to existing ones) within a fixed memory
+// budget. If the budget is exceeded, its methods return ok == false and the
+// caller must spill to disk or throw an error.
+//
+// In the future this can also be used to pool Vec allocations.
+//
+// TODO(solon): Add memory budget logic.
+type BatchAllocator struct{}
+
+// NewBatchAllocator constructs a new BatchAllocator instance.
+func NewBatchAllocator() BatchAllocator {
+	return BatchAllocator{}
+}
+
+// NewMemBatchWithSize allocates a new in-memory Batch with the given column
+// size.
+func (*BatchAllocator) NewMemBatchWithSize(types []types.T, size int) (batch Batch, ok bool) {
+	return NewMemBatchWithSize(types, size), true
+}
+
+// Append appends elements of a source Vec into dest according to AppendArgs.
+func (*BatchAllocator) Append(dest Vec, args AppendArgs) (ok bool) {
+	dest.Append(args)
+	return true
+}

--- a/pkg/sql/exec/hash_aggregator.go
+++ b/pkg/sql/exec/hash_aggregator.go
@@ -65,6 +65,7 @@ type hashAggregator struct {
 // the NewOrderedAggregator function.
 func NewHashAggregator(
 	input Operator,
+	allocator coldata.BatchAllocator,
 	colTypes []types.T,
 	aggFns []distsqlpb.AggregatorSpec_Func,
 	groupCols []uint32,
@@ -106,6 +107,7 @@ func NewHashAggregator(
 	}
 
 	ht := makeHashTable(
+		allocator,
 		hashTableBucketSize,
 		colTypes,
 		groupCols,

--- a/pkg/sql/exec/hashjoiner_test.go
+++ b/pkg/sql/exec/hashjoiner_test.go
@@ -711,6 +711,7 @@ func TestHashJoinerInt64(t *testing.T) {
 					leftSource, rightSource := sources[0], sources[1]
 
 					hj, err := NewEqHashJoinerOp(
+						testAllocator,
 						leftSource, rightSource,
 						tc.leftEqCols, tc.rightEqCols,
 						tc.leftOutCols, tc.rightOutCols,
@@ -816,7 +817,8 @@ func BenchmarkHashJoiner(b *testing.B) {
 										}
 
 										hj := &hashJoinEqOp{
-											spec: spec,
+											allocator: testAllocator,
+											spec:      spec,
 										}
 
 										hj.Init()

--- a/pkg/sql/exec/mergejoiner_test.go
+++ b/pkg/sql/exec/mergejoiner_test.go
@@ -775,7 +775,9 @@ func TestMergeJoiner(t *testing.T) {
 		}
 
 		runTests(t, []tuples{tc.leftTuples, tc.rightTuples}, func(t *testing.T, input []Operator) {
-			s, err := NewMergeJoinOp(input[0], input[1], tc.leftOutCols, tc.rightOutCols, tc.leftTypes, tc.rightTypes, lOrderings, rOrderings)
+			s, err := NewMergeJoinOp(
+				testAllocator, input[0], input[1], tc.leftOutCols, tc.rightOutCols, tc.leftTypes,
+				tc.rightTypes, lOrderings, rOrderings)
 			if err != nil {
 				t.Fatal("Error in merge join op constructor", err)
 			}
@@ -811,6 +813,7 @@ func TestMergeJoinerMultiBatch(t *testing.T) {
 						rightSource := newChunkingBatchSource(typs, cols, uint64(nTuples))
 
 						a, err := NewMergeJoinOp(
+							testAllocator,
 							leftSource,
 							rightSource,
 							[]uint32{0},
@@ -872,6 +875,7 @@ func TestMergeJoinerMultiBatchRuns(t *testing.T) {
 					rightSource := newChunkingBatchSource(typs, cols, uint64(nTuples))
 
 					a, err := NewMergeJoinOp(
+						testAllocator,
 						leftSource,
 						rightSource,
 						[]uint32{0},
@@ -934,6 +938,7 @@ func TestMergeJoinerLongMultiBatchCount(t *testing.T) {
 						rightSource := newChunkingBatchSource(typs, cols, uint64(nTuples))
 
 						a, err := NewMergeJoinOp(
+							testAllocator,
 							leftSource,
 							rightSource,
 							[]uint32{},
@@ -982,6 +987,7 @@ func TestMergeJoinerMultiBatchCountRuns(t *testing.T) {
 					rightSource := newChunkingBatchSource(typs, cols, uint64(nTuples))
 
 					a, err := NewMergeJoinOp(
+						testAllocator,
 						leftSource,
 						rightSource,
 						[]uint32{},
@@ -1095,6 +1101,7 @@ func TestMergeJoinerRandomized(t *testing.T) {
 							rightSource := newChunkingBatchSource(typs, rCols, uint64(nTuples))
 
 							a, err := NewMergeJoinOp(
+								testAllocator,
 								leftSource,
 								rightSource,
 								[]uint32{0},

--- a/pkg/sql/exec/partitioner.go
+++ b/pkg/sql/exec/partitioner.go
@@ -25,6 +25,7 @@ import (
 // every tuple that is the first within its partition.
 func NewWindowSortingPartitioner(
 	input Operator,
+	allocator coldata.BatchAllocator,
 	inputTyps []types.T,
 	partitionIdxs []uint32,
 	ordCols []distsqlpb.Ordering_Column,
@@ -39,7 +40,7 @@ func NewWindowSortingPartitioner(
 	for i := range ordCols {
 		orderingColsIdxs[i] = uint32(len(partitionIdxs) + i)
 	}
-	input, err = NewSorter(input, inputTyps, partitionAndOrderingCols)
+	input, err = NewSorter(input, allocator, inputTyps, partitionAndOrderingCols)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/sql/exec/sort_test.go
+++ b/pkg/sql/exec/sort_test.go
@@ -113,7 +113,7 @@ func TestSort(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		runTests(t, []tuples{tc.tuples}, func(t *testing.T, input []Operator) {
-			sort, err := NewSorter(input[0], tc.typ, tc.ordCols)
+			sort, err := NewSorter(input[0], testAllocator, tc.typ, tc.ordCols)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -169,10 +169,10 @@ func TestSortRandomized(t *testing.T) {
 					runTests(t, []tuples{tups}, func(t *testing.T, input []Operator) {
 						var sorter Operator
 						if topK {
-							sorter = NewTopKSorter(input[0], typs[:nCols], ordCols, k)
+							sorter = NewTopKSorter(input[0], testAllocator, typs[:nCols], ordCols, k)
 						} else {
 							var err error
-							sorter, err = NewSorter(input[0], typs[:nCols], ordCols)
+							sorter, err = NewSorter(input[0], testAllocator, typs[:nCols], ordCols)
 							if err != nil {
 								t.Fatal(err)
 							}
@@ -237,7 +237,7 @@ func TestAllSpooler(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		runTests(t, []tuples{tc.tuples}, func(t *testing.T, input []Operator) {
-			allSpooler := newAllSpooler(input[0], tc.typ)
+			allSpooler := newAllSpooler(input[0], testAllocator, tc.typ)
 			allSpooler.init()
 			allSpooler.spool(context.Background())
 			if len(tc.tuples) != int(allSpooler.getNumTuples()) {
@@ -294,11 +294,11 @@ func BenchmarkSort(b *testing.B) {
 						var sorter Operator
 						var resultBatches int
 						if topK {
-							sorter = NewTopKSorter(source, typs, ordCols, k)
+							sorter = NewTopKSorter(source, testAllocator, typs, ordCols, k)
 							resultBatches = 1
 						} else {
 							var err error
-							sorter, err = NewSorter(source, typs, ordCols)
+							sorter, err = NewSorter(source, testAllocator, typs, ordCols)
 							if err != nil {
 								b.Fatal(err)
 							}
@@ -343,7 +343,7 @@ func BenchmarkAllSpooler(b *testing.B) {
 				b.ResetTimer()
 				for n := 0; n < b.N; n++ {
 					source := newFiniteBatchSource(batch, nBatches)
-					allSpooler := newAllSpooler(source, typs)
+					allSpooler := newAllSpooler(source, testAllocator, typs)
 					allSpooler.init()
 					allSpooler.spool(ctx)
 				}

--- a/pkg/sql/exec/sorttopk_test.go
+++ b/pkg/sql/exec/sorttopk_test.go
@@ -68,7 +68,7 @@ func TestTopKSorter(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			runTests(t, []tuples{tc.tuples}, func(t *testing.T, input []Operator) {
-				sort := NewTopKSorter(input[0], tc.typ, tc.ordCols, tc.k)
+				sort := NewTopKSorter(input[0], testAllocator, tc.typ, tc.ordCols, tc.k)
 				cols := make([]int, len(tc.typ))
 				for i := range cols {
 					cols[i] = i

--- a/pkg/sql/exec/stats_test.go
+++ b/pkg/sql/exec/stats_test.go
@@ -78,6 +78,7 @@ func TestVectorizedStatsCollector(t *testing.T) {
 		rightInput.SetOutputWatch(mjInputWatch)
 
 		mergeJoiner, err := NewMergeJoinOp(
+			testAllocator,
 			leftInput,
 			rightInput,
 			[]uint32{0},

--- a/pkg/sql/exec/utils_test.go
+++ b/pkg/sql/exec/utils_test.go
@@ -24,6 +24,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+// testAllocator is a BatchAllocator with an unlimited budget for use in unit
+// tests.
+var testAllocator = coldata.NewBatchAllocator()
+
 // tuple represents a row with any-type columns.
 type tuple []interface{}
 


### PR DESCRIPTION
I created a new BatchAllocator type, which is responsible for doling out
batches to operators within a fixed budget. The budgeting logic doesn't
exist yet, but this commit adds the new type and plumbs it through
operators which use a variable amount of memory. Next step is to
actually measure the memory required when NewBatch or Append is called
and track that against a budget.

Fixes #38056

Release note: None