### PR TITLE
roachprod: separate certificate distribution from roachprod start

### DIFF
--- a/pkg/cmd/roachprod/install/cassandra.go
+++ b/pkg/cmd/roachprod/install/cassandra.go
@@ -98,6 +98,11 @@ func (Cassandra) LogDir(c *SyncedCluster, index int) string {
 	panic("Cassandra.LogDir unimplemented")
 }
 
+// CertsDir implements the ClusterImpl.NodeDir interface.
+func (Cassandra) CertsDir(c *SyncedCluster, index int) string {
+	panic("Cassandra.CertsDir unimplemented")
+}
+
 // NodeURL implements the ClusterImpl.NodeDir interface.
 func (Cassandra) NodeURL(_ *SyncedCluster, host string, port int) string {
 	return fmt.Sprintf("'cassandra://%s:%d'", host, port)

--- a/pkg/cmd/roachprod/install/cluster_synced.go
+++ b/pkg/cmd/roachprod/install/cluster_synced.go
@@ -806,6 +806,12 @@ func (c *SyncedCluster) DistributeCerts() {
 			nodeNames = append(nodeNames, c.VMs...)
 			for i := range c.VMs {
 				nodeNames = append(nodeNames, fmt.Sprintf("%s-%04d", c.Name, i+1))
+				// On AWS nodes internally have a DNS name in the form ip-<ip address>
+				// where dots have been replaces with dashes.
+				// See https://docs.aws.amazon.com/vpc/latest/userguide/vpc-dns.html#vpc-dns-hostnames
+				if strings.Contains(c.Localities[i], "cloud=aws") {
+					nodeNames = append(nodeNames, "ip-"+strings.ReplaceAll(ips[i], ".", "-"))
+				}
 			}
 		}
 

--- a/pkg/cmd/roachprod/install/cluster_synced.go
+++ b/pkg/cmd/roachprod/install/cluster_synced.go
@@ -43,6 +43,7 @@ import (
 // ClusterImpl TODO(peter): document
 type ClusterImpl interface {
 	Start(c *SyncedCluster, extraArgs []string)
+	CertsDir(c *SyncedCluster, index int) string
 	NodeDir(c *SyncedCluster, index int) string
 	LogDir(c *SyncedCluster, index int) string
 	NodeURL(c *SyncedCluster, host string, port int) string

--- a/pkg/cmd/roachprod/install/cluster_synced.go
+++ b/pkg/cmd/roachprod/install/cluster_synced.go
@@ -739,6 +739,148 @@ fi
 	return nil
 }
 
+// DistributeCerts will generate and distribute certificates to all of the
+// nodes.
+func (c *SyncedCluster) DistributeCerts() {
+	dir := ""
+	if c.IsLocal() {
+		dir = `${HOME}/local/1`
+	}
+
+	// Check to see if the certs have already been initialized.
+	var existsErr error
+	display := fmt.Sprintf("%s: checking certs", c.Name)
+	c.Parallel(display, 1, 0, func(i int) ([]byte, error) {
+		sess, err := c.newSession(1)
+		if err != nil {
+			return nil, err
+		}
+		defer sess.Close()
+		_, existsErr = sess.CombinedOutput(`test -e ` + filepath.Join(dir, `certs.tar`))
+		return nil, nil
+	})
+
+	if existsErr == nil {
+		return
+	}
+
+	// Gather the internal IP addresses for every node in the cluster, even
+	// if it won't be added to the cluster itself we still add the IP address
+	// to the node cert.
+	var msg string
+	display = fmt.Sprintf("%s: initializing certs", c.Name)
+	nodes := allNodes(len(c.VMs))
+	var ips []string
+	if !c.IsLocal() {
+		ips = make([]string, len(nodes))
+		c.Parallel("", len(nodes), 0, func(i int) ([]byte, error) {
+			var err error
+			ips[i], err = c.GetInternalIP(nodes[i])
+			return nil, errors.Wrapf(err, "IPs")
+		})
+	}
+
+	// Generate the ca, client and node certificates on the first node.
+	c.Parallel(display, 1, 0, func(i int) ([]byte, error) {
+		sess, err := c.newSession(1)
+		if err != nil {
+			return nil, err
+		}
+		defer sess.Close()
+
+		var nodeNames []string
+		if c.IsLocal() {
+			// For local clusters, we only need to add one of the VM IP addresses.
+			nodeNames = append(nodeNames, "$(hostname)", c.VMs[0])
+		} else {
+			// Add both the local and external IP addresses, as well as the
+			// hostnames to the node certificate.
+			nodeNames = append(nodeNames, ips...)
+			nodeNames = append(nodeNames, c.VMs...)
+			for i := range c.VMs {
+				nodeNames = append(nodeNames, fmt.Sprintf("%s-%04d", c.Name, i+1))
+			}
+		}
+
+		var cmd string
+		if c.IsLocal() {
+			cmd = `cd ${HOME}/local/1 ; `
+		}
+		cmd += fmt.Sprintf(`
+rm -fr certs
+mkdir -p certs
+%[1]s cert create-ca --certs-dir=certs --ca-key=certs/ca.key
+%[1]s cert create-client root --certs-dir=certs --ca-key=certs/ca.key
+%[1]s cert create-node localhost %[2]s --certs-dir=certs --ca-key=certs/ca.key
+tar cvf certs.tar certs
+`, cockroachNodeBinary(c, 1), strings.Join(nodeNames, " "))
+		if out, err := sess.CombinedOutput(cmd); err != nil {
+			msg = fmt.Sprintf("%s: %v", out, err)
+		}
+		return nil, nil
+	})
+
+	if msg != "" {
+		fmt.Fprintln(os.Stderr, msg)
+		os.Exit(1)
+	}
+
+	var tmpfileName string
+	if c.IsLocal() {
+		tmpfileName = os.ExpandEnv(filepath.Join(dir, "certs.tar"))
+	} else {
+		// Retrieve the certs.tar that was created on the first node.
+		tmpfile, err := ioutil.TempFile("", "certs")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		_ = tmpfile.Close()
+		defer func() {
+			_ = os.Remove(tmpfile.Name()) // clean up
+		}()
+
+		if err := func() error {
+			return c.scp(fmt.Sprintf("%s@%s:certs.tar", c.user(1), c.host(1)), tmpfile.Name())
+		}(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+
+		tmpfileName = tmpfile.Name()
+	}
+
+	// Read the certs.tar file we just downloaded. We'll be piping it to the
+	// other nodes in the cluster.
+	certsTar, err := ioutil.ReadFile(tmpfileName)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	// Skip the the first node which is where we generated the certs.
+	display = c.Name + ": distributing certs"
+	nodes = nodes[1:]
+	c.Parallel(display, len(nodes), 0, func(i int) ([]byte, error) {
+		sess, err := c.newSession(nodes[i])
+		if err != nil {
+			return nil, err
+		}
+		defer sess.Close()
+
+		sess.SetStdin(bytes.NewReader(certsTar))
+		var cmd string
+		if c.IsLocal() {
+			cmd = fmt.Sprintf(`cd ${HOME}/local/%d ; `, nodes[i])
+		}
+		cmd += `tar xf -`
+		if out, err := sess.CombinedOutput(cmd); err != nil {
+			return nil, errors.Wrapf(err, "~ %s\n%s", cmd, out)
+		}
+		return nil, nil
+	})
+}
+
 const progressDone = "=======================================>"
 const progressTodo = "----------------------------------------"
 

--- a/pkg/cmd/roachprod/install/cockroach.go
+++ b/pkg/cmd/roachprod/install/cockroach.go
@@ -11,9 +11,7 @@
 package install
 
 import (
-	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -125,140 +123,7 @@ func (r Cockroach) Start(c *SyncedCluster, extraArgs []string) {
 	}
 
 	if c.Secure && bootstrapped {
-		dir := ""
-		if c.IsLocal() {
-			dir = `${HOME}/local/1`
-		}
-
-		// Check to see if the certs have already been initialized.
-		var existsErr error
-		display := fmt.Sprintf("%s: checking certs", c.Name)
-		c.Parallel(display, 1, 0, func(i int) ([]byte, error) {
-			sess, err := c.newSession(1)
-			if err != nil {
-				return nil, err
-			}
-			defer sess.Close()
-			_, existsErr = sess.CombinedOutput(`test -e ` + filepath.Join(dir, `certs.tar`))
-			return nil, nil
-		})
-
-		if existsErr != nil {
-			// Gather the internal IP addresses for every node in the cluster, even
-			// if it won't be added to the cluster itself we still add the IP address
-			// to the node cert.
-			var msg string
-			display := fmt.Sprintf("%s: initializing certs", c.Name)
-			nodes := allNodes(len(c.VMs))
-			var ips []string
-			if !c.IsLocal() {
-				ips = make([]string, len(nodes))
-				c.Parallel("", len(nodes), 0, func(i int) ([]byte, error) {
-					var err error
-					ips[i], err = c.GetInternalIP(nodes[i])
-					return nil, errors.Wrapf(err, "IPs")
-				})
-			}
-
-			// Generate the ca, client and node certificates on the first node.
-			c.Parallel(display, 1, 0, func(i int) ([]byte, error) {
-				sess, err := c.newSession(1)
-				if err != nil {
-					return nil, err
-				}
-				defer sess.Close()
-
-				var nodeNames []string
-				if c.IsLocal() {
-					// For local clusters, we only need to add one of the VM IP addresses.
-					nodeNames = append(nodeNames, "$(hostname)", c.VMs[0])
-				} else {
-					// Add both the local and external IP addresses, as well as the
-					// hostnames to the node certificate.
-					nodeNames = append(nodeNames, ips...)
-					nodeNames = append(nodeNames, c.VMs...)
-					for i := range c.VMs {
-						nodeNames = append(nodeNames, fmt.Sprintf("%s-%04d", c.Name, i+1))
-					}
-				}
-
-				var cmd string
-				if c.IsLocal() {
-					cmd = `cd ${HOME}/local/1 ; `
-				}
-				cmd += fmt.Sprintf(`
-rm -fr certs
-mkdir -p certs
-%[1]s cert create-ca --certs-dir=certs --ca-key=certs/ca.key
-%[1]s cert create-client root --certs-dir=certs --ca-key=certs/ca.key
-%[1]s cert create-node localhost %[2]s --certs-dir=certs --ca-key=certs/ca.key
-tar cvf certs.tar certs
-`, cockroachNodeBinary(c, 1), strings.Join(nodeNames, " "))
-				if out, err := sess.CombinedOutput(cmd); err != nil {
-					msg = fmt.Sprintf("%s: %v", out, err)
-				}
-				return nil, nil
-			})
-
-			if msg != "" {
-				fmt.Fprintln(os.Stderr, msg)
-				os.Exit(1)
-			}
-
-			var tmpfileName string
-			if c.IsLocal() {
-				tmpfileName = os.ExpandEnv(filepath.Join(dir, "certs.tar"))
-			} else {
-				// Retrieve the certs.tar that was created on the first node.
-				tmpfile, err := ioutil.TempFile("", "certs")
-				if err != nil {
-					fmt.Fprintln(os.Stderr, err)
-					os.Exit(1)
-				}
-				_ = tmpfile.Close()
-				defer func() {
-					_ = os.Remove(tmpfile.Name()) // clean up
-				}()
-
-				if err := func() error {
-					return c.scp(fmt.Sprintf("%s@%s:certs.tar", c.user(1), c.host(1)), tmpfile.Name())
-				}(); err != nil {
-					fmt.Fprintln(os.Stderr, err)
-					os.Exit(1)
-				}
-
-				tmpfileName = tmpfile.Name()
-			}
-
-			// Read the certs.tar file we just downloaded. We'll be piping it to the
-			// other nodes in the cluster.
-			certsTar, err := ioutil.ReadFile(tmpfileName)
-			if err != nil {
-				fmt.Fprintln(os.Stderr, err)
-				os.Exit(1)
-			}
-
-			// Skip the the first node which is where we generated the certs.
-			nodes = nodes[1:]
-			c.Parallel(display, len(nodes), 0, func(i int) ([]byte, error) {
-				sess, err := c.newSession(nodes[i])
-				if err != nil {
-					return nil, err
-				}
-				defer sess.Close()
-
-				sess.SetStdin(bytes.NewReader(certsTar))
-				var cmd string
-				if c.IsLocal() {
-					cmd = fmt.Sprintf(`cd ${HOME}/local/%d ; `, nodes[i])
-				}
-				cmd += `tar xf -`
-				if out, err := sess.CombinedOutput(cmd); err != nil {
-					return nil, errors.Wrapf(err, "~ %s\n%s", cmd, out)
-				}
-				return nil, nil
-			})
-		}
+		c.DistributeCerts()
 	}
 
 	display := fmt.Sprintf("%s: starting", c.Name)

--- a/pkg/cmd/roachprod/install/cockroach.go
+++ b/pkg/cmd/roachprod/install/cockroach.go
@@ -296,11 +296,7 @@ tar cvf certs.tar certs
 
 		var args []string
 		if c.Secure {
-			if c.IsLocal() {
-				args = append(args, fmt.Sprintf("--certs-dir=${HOME}/local/%d/certs", nodes[i]))
-			} else {
-				args = append(args, "--certs-dir=certs")
-			}
+			args = append(args, "--certs-dir="+c.Impl.CertsDir(c, nodes[i]))
 		} else {
 			args = append(args, "--insecure")
 		}
@@ -458,6 +454,15 @@ func (Cockroach) LogDir(c *SyncedCluster, index int) string {
 	dir := "${HOME}/logs"
 	if c.IsLocal() {
 		dir = os.ExpandEnv(fmt.Sprintf("${HOME}/local/%d/logs", index))
+	}
+	return dir
+}
+
+// CertsDir implements the ClusterImpl.NodeDir interface.
+func (Cockroach) CertsDir(c *SyncedCluster, index int) string {
+	dir := "${HOME}/certs"
+	if c.IsLocal() {
+		dir = os.ExpandEnv(fmt.Sprintf("${HOME}/local/%d/certs", index))
 	}
 	return dir
 }

--- a/pkg/cmd/roachprod/install/expander.go
+++ b/pkg/cmd/roachprod/install/expander.go
@@ -24,6 +24,7 @@ var pgPortRe = regexp.MustCompile(`{pgport(:[-,0-9]+)?}`)
 var uiPortRe = regexp.MustCompile(`{uiport(:[-,0-9]+)?}`)
 var storeDirRe = regexp.MustCompile(`{store-dir}`)
 var logDirRe = regexp.MustCompile(`{log-dir}`)
+var certsDirRe = regexp.MustCompile(`{certs-dir}`)
 
 // expander expands a string which contains templated parameters for cluster
 // attributes like pgurl, pgport, uiport, store-dir, and log-dir with the
@@ -52,6 +53,7 @@ func (e *expander) expand(c *SyncedCluster, arg string) (string, error) {
 			e.maybeExpandUIPort,
 			e.maybeExpandStoreDir,
 			e.maybeExpandLogDir,
+			e.maybeExpandCertsDir,
 		}
 		for _, f := range expanders {
 			v, expanded, fErr := f(c, s)
@@ -165,4 +167,12 @@ func (e *expander) maybeExpandLogDir(c *SyncedCluster, s string) (string, bool, 
 		return s, false, nil
 	}
 	return c.Impl.LogDir(c, e.node), true, nil
+}
+
+// maybeExpandCertsDir is an expanderFunc for "{certs-dir}"
+func (e *expander) maybeExpandCertsDir(c *SyncedCluster, s string) (string, bool, error) {
+	if !certsDirRe.MatchString(s) {
+		return s, false, nil
+	}
+	return c.Impl.CertsDir(c, e.node), true, nil
 }

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -1221,6 +1221,25 @@ Some examples of usage:
 	}),
 }
 
+var distributeCertsCmd = &cobra.Command{
+	Use:   "distribute-certs <cluster>",
+	Short: "distribute certificates to the nodes in a cluster",
+	Long: `Distribute certificates to the nodes in a cluster.
+If the certificates already exist, no action is taken. Note that this command is
+invoked automatically when a secure cluster is bootstrapped by "roachprod
+start."
+`,
+	Args: cobra.ExactArgs(1),
+	Run: wrap(func(cmd *cobra.Command, args []string) error {
+		c, err := newCluster(args[0])
+		if err != nil {
+			return err
+		}
+		c.DistributeCerts()
+		return nil
+	}),
+}
+
 var putCmd = &cobra.Command{
 	Use:   "put <cluster> <src> [<dest>]",
 	Short: "copy a local file to the nodes in a cluster",
@@ -1421,6 +1440,7 @@ func main() {
 		wipeCmd,
 		reformatCmd,
 		installCmd,
+		distributeCertsCmd,
 		putCmd,
 		getCmd,
 		stageCmd,

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -65,33 +65,34 @@ destroy the cluster.
 }
 
 var (
-	numNodes       int
-	numRacks       int
-	username       string
-	dryrun         bool
-	extendLifetime time.Duration
-	listDetails    bool
-	listJSON       bool
-	listMine       bool
-	clusterType    = "cockroach"
-	secure         = false
-	nodeEnv        = "COCKROACH_ENABLE_RPC_COMPRESSION=false"
-	nodeArgs       []string
-	tag            string
-	external       = false
-	adminurlOpen   = false
-	adminurlPath   = ""
-	adminurlIPs    = false
-	useTreeDist    = true
-	encrypt        = false
-	quiet          = false
-	sig            = 9
-	waitFlag       = false
-	logsDir        string
-	logsFilter     string
-	logsFrom       time.Time
-	logsTo         time.Time
-	logsInterval   time.Duration
+	numNodes          int
+	numRacks          int
+	username          string
+	dryrun            bool
+	extendLifetime    time.Duration
+	wipePreserveCerts bool
+	listDetails       bool
+	listJSON          bool
+	listMine          bool
+	clusterType       = "cockroach"
+	secure            = false
+	nodeEnv           = "COCKROACH_ENABLE_RPC_COMPRESSION=false"
+	nodeArgs          []string
+	tag               string
+	external          = false
+	adminurlOpen      = false
+	adminurlPath      = ""
+	adminurlIPs       = false
+	useTreeDist       = true
+	encrypt           = false
+	quiet             = false
+	sig               = 9
+	waitFlag          = false
+	logsDir           string
+	logsFilter        string
+	logsFrom          time.Time
+	logsTo            time.Time
+	logsInterval      time.Duration
 
 	monitorIgnoreEmptyNodes bool
 	monitorOneShot          bool
@@ -498,7 +499,7 @@ directory is removed.
 				if err != nil {
 					return err
 				}
-				c.Wipe()
+				c.Wipe(false)
 				for _, i := range c.Nodes {
 					err := os.RemoveAll(fmt.Sprintf(os.ExpandEnv("${HOME}/local/%d"), i))
 					if err != nil {
@@ -1058,7 +1059,7 @@ nodes.
 		if err != nil {
 			return err
 		}
-		c.Wipe()
+		c.Wipe(wipePreserveCerts)
 		return nil
 	}),
 }
@@ -1560,6 +1561,8 @@ func main() {
 
 	stopCmd.Flags().IntVar(&sig, "sig", sig, "signal to pass to kill")
 	stopCmd.Flags().BoolVar(&waitFlag, "wait", waitFlag, "wait for processes to exit")
+
+	wipeCmd.Flags().BoolVar(&wipePreserveCerts, "preserve-certs", false, "do not wipe certificates")
 
 	for _, cmd := range []*cobra.Command{
 		startCmd, statusCmd, stopCmd, runCmd,


### PR DESCRIPTION
This PR is derived from https://github.com/cockroachdb/roachprod/pull/206. It adds a new command `roachprod distribute-certs` which generates and distributes certificates to a cluster if none exist. The third commit adds a wipe option to preserve certificates. The fourth commit additionally appends AWS-style DNS names to allow AWS to work in `--secure` mode.

Fixes #38414.