### PR TITLE
rpc: improve sentry report on clock skew crashes

### DIFF
--- a/pkg/rpc/clock_offset.go
+++ b/pkg/rpc/clock_offset.go
@@ -21,8 +21,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 	"github.com/montanaflynn/stats"
-	"github.com/pkg/errors"
 )
 
 // RemoteClockMetrics is the collection of metrics for the clock monitor.


### PR DESCRIPTION
Switch a file to the new errors lib so we get the error message in
Sentry reports.

Release note: None