### PR TITLE
opt: plumb FK check information and improve error message

### DIFF
--- a/pkg/sql/lex/encode.go
+++ b/pkg/sql/lex/encode.go
@@ -140,7 +140,7 @@ func EncodeUnrestrictedSQLIdent(buf *bytes.Buffer, s string, flags EncodeFlags) 
 		buf.WriteString(s)
 		return
 	}
-	encodeEscapedSQLIdent(buf, s)
+	EncodeEscapedSQLIdent(buf, s)
 }
 
 // EncodeRestrictedSQLIdent writes the identifier in s to buf. The
@@ -152,13 +152,13 @@ func EncodeRestrictedSQLIdent(buf *bytes.Buffer, s string, flags EncodeFlags) {
 		buf.WriteString(s)
 		return
 	}
-	encodeEscapedSQLIdent(buf, s)
+	EncodeEscapedSQLIdent(buf, s)
 }
 
-// encodeEscapedSQLIdent writes the identifier in s to buf. The
+// EncodeEscapedSQLIdent writes the identifier in s to buf. The
 // identifier is always quoted. Double quotes inside the identifier
 // are escaped.
-func encodeEscapedSQLIdent(buf *bytes.Buffer, s string) {
+func EncodeEscapedSQLIdent(buf *bytes.Buffer, s string) {
 	buf.WriteByte('"')
 	start := 0
 	for i, n := 0, len(s); i < n; i++ {

--- a/pkg/sql/logictest/testdata/logic_test/fk_opt
+++ b/pkg/sql/logictest/testdata/logic_test/fk_opt
@@ -9,14 +9,13 @@ CREATE TABLE parent (p INT PRIMARY KEY, other INT)
 statement ok
 CREATE TABLE child (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(p))
 
-# TODO(radu): improve the error message and make the check more specific.
-statement error foreign key violation
+statement error insert or update on table "child" violates foreign key constraint "fk_p_ref_parent"\nDETAIL: Key \(p\)=\(1\) is not present in table "parent"\.
 INSERT INTO child VALUES (1,1)
 
 statement ok
 INSERT INTO parent VALUES (1), (2)
 
-statement error foreign key violation
+statement error insert or update on table "child" violates foreign key constraint "fk_p_ref_parent"\nDETAIL: Key \(p\)=\(3\) is not present in table "parent"\.
 INSERT INTO child VALUES (1,1), (2,2), (3,3)
 
 statement ok

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -282,6 +282,6 @@ func (f *stubFactory) ConstructSaveTable(
 
 func (f *stubFactory) ConstructErrorIfRows(
 	input exec.Node, mkErr func(tree.Datums) error,
-) (Node, error) {
+) (exec.Node, error) {
 	return struct{}{}, nil
 }

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -280,6 +280,8 @@ func (f *stubFactory) ConstructSaveTable(
 	return struct{}{}, nil
 }
 
-func (f *stubFactory) ConstructErrorIfRows(input exec.Node) (exec.Node, error) {
+func (f *stubFactory) ConstructErrorIfRows(
+	input exec.Node, mkErr func(tree.Datums) error,
+) (Node, error) {
 	return struct{}{}, nil
 }

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -11,13 +11,18 @@
 package execbuilder
 
 import (
+	"bytes"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/errors"
 )
 
 func (b *Builder) buildInsert(ins *memo.InsertExpr) (execPlan, error) {
@@ -334,16 +339,64 @@ func mutationOutputColMap(mutation memo.RelExpr) opt.ColMap {
 }
 
 func (b *Builder) buildFKChecks(checks memo.FKChecksExpr) error {
+	md := b.mem.Metadata()
 	for i := range checks {
+		c := &checks[i]
 		// Construct the query that returns FK violations.
-		query, err := b.buildRelational(checks[i].Check)
+		query, err := b.buildRelational(c.Check)
 		if err != nil {
 			return err
 		}
 		// Wrap the query in an error node.
 		mkErr := func(row tree.Datums) error {
-			// TODO(radu): improve the error message.
-			return pgerror.Newf(pgcode.ForeignKeyViolation, "foreign key violation: values %s", row)
+			origin := md.TableMeta(c.OriginTable)
+			referenced := md.TableMeta(c.ReferencedTable)
+			var fk cat.ForeignKeyConstraint
+			if c.FKOutbound {
+				fk = origin.Table.OutboundForeignKey(c.FKOrdinal)
+			} else {
+				fk = referenced.Table.InboundForeignKey(c.FKOrdinal)
+			}
+
+			var msg, details bytes.Buffer
+			if c.FKOutbound {
+				// Generate an error of the form:
+				//   ERROR:  insert or update on table "child" violates foreign key constraint "foo"
+				//   DETAIL: Key (child_p)=(2) is not present in table "parent".
+				msg.WriteString("insert or update on table ")
+				lex.EncodeEscapedSQLIdent(&msg, string(origin.Alias.TableName))
+				msg.WriteString(" violates foreign key constraint ")
+				lex.EncodeEscapedSQLIdent(&msg, fk.Name())
+
+				details.WriteString("Key (")
+				for i := 0; i < fk.ColumnCount(); i++ {
+					if i > 0 {
+						details.WriteString(" ,")
+					}
+					col := origin.Table.Column(fk.OriginColumnOrdinal(origin.Table, i))
+					details.WriteString(string(col.ColName()))
+				}
+				details.WriteString(")=(")
+				for i, col := range c.KeyCols {
+					if i > 0 {
+						details.WriteString(", ")
+					}
+					details.WriteString(row[query.getColumnOrdinal(col)].String())
+				}
+				details.WriteString(") is not present in table ")
+				lex.EncodeEscapedSQLIdent(&details, string(referenced.Alias.TableName))
+				details.WriteByte('.')
+			} else {
+				// Generate an error of the form:
+				//   ERROR:  update or delete on table "parent" violates foreign key constraint "child_child_p_fkey" on table "child"
+				//   DETAIL: Key (p)=(1) is still referenced from table "child".
+				panic(errors.AssertionFailedf("unimplemented"))
+			}
+
+			return errors.WithDetail(
+				pgerror.New(pgcode.ForeignKeyViolation, msg.String()),
+				details.String(),
+			)
 		}
 		node, err := b.factory.ConstructErrorIfRows(query.root, mkErr)
 		if err != nil {

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -398,9 +398,9 @@ type Factory interface {
 	ConstructSaveTable(input Node, table *cat.DataSourceName, colNames []string) (Node, error)
 
 	// ConstructErrorIfRows wraps the input into a node which itself returns no
-	// results, but errors out if the input returns any rows.
-	// TODO(radu): add a way to control the error message.
-	ConstructErrorIfRows(input Node) (Node, error)
+	// results, but errors out if the input returns any rows. The mkErr function
+	// is used to create the error.
+	ConstructErrorIfRows(input Node, mkErr func(tree.Datums) error) (Node, error)
 }
 
 // OutputOrdering indicates the required output ordering on a Node that is being

--- a/pkg/sql/opt/ops/mutation.opt
+++ b/pkg/sql/opt/ops/mutation.opt
@@ -187,5 +187,26 @@ define FKChecks {
 [Scalar, ListItem]
 define FKChecksItem {
     Check RelExpr
-    # TODO(radu): information for making a good error message.
+
+    _ FKChecksItemPrivate
+}
+
+[Private]
+define FKChecksItemPrivate {
+    OriginTable     TableID
+    ReferencedTable TableID
+
+    # If FKOutbound is true: this item checks that a new value in the origin
+    # table has a valid reference. The FK constraint is
+    # OutboundForeignKey(FKOrdinal) on the origin table.
+    #
+    # If FKOutbound is false: this item checks that a removed value from the
+    # referenced table doesn't orphan references to it from the origin table.
+    # The FK constraint is InboundForeignKey(FKOrdinal) on the referenced table.
+    FKOutbound bool
+    FKOrdinal  int
+
+    # KeyCols are the columns in the Check query that form the value tuple shown
+    # in the error message.
+    KeyCols ColList
 }

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -659,8 +659,7 @@ func (mb *mutationBuilder) buildInputForDoNothing(inScope *scope, onConflict *tr
 		// of the mutation table so that a different set of column IDs are used for
 		// the two tables in the self-join.
 		scanScope := mb.b.buildScan(
-			mb.tab,
-			&mb.alias,
+			mb.b.addTable(mb.tab, &mb.alias),
 			nil, /* ordinals */
 			nil, /* indexFlags */
 			excludeMutations,
@@ -742,8 +741,7 @@ func (mb *mutationBuilder) buildInputForUpsert(
 	// because they can be used by computed update expressions. Use a different
 	// instance of table metadata so that col IDs do not overlap.
 	fetchScope := mb.b.buildScan(
-		mb.tab,
-		&mb.alias,
+		mb.b.addTable(mb.tab, &mb.alias),
 		nil, /* ordinals */
 		nil, /* indexFlags */
 		includeMutations,

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
@@ -23,7 +23,7 @@ insert child
  │         ├── const: 200 [type=int]
  │         └── const: 1 [type=int]
  └── f-k-checks
-      └── f-k-checks-item
+      └── f-k-checks-item: child(p) -> parent(p)
            └── anti-join
                 ├── columns: column2:4(int!null)
                 ├── project
@@ -67,7 +67,7 @@ insert child_nullable
  │         └── cast: INT8 [type=int]
  │              └── null [type=unknown]
  └── f-k-checks
-      └── f-k-checks-item
+      └── f-k-checks-item: child_nullable(p) -> parent(p)
            └── anti-join
                 ├── columns: column2:4(int!null)
                 ├── select
@@ -113,7 +113,7 @@ insert child_nullable
  │         ├── const: 200 [type=int]
  │         └── const: 1 [type=int]
  └── f-k-checks
-      └── f-k-checks-item
+      └── f-k-checks-item: child_nullable(p) -> parent(p)
            └── anti-join
                 ├── columns: column2:4(int!null)
                 ├── project
@@ -157,7 +157,7 @@ insert child_nullable_full
  │         └── cast: INT8 [type=int]
  │              └── null [type=unknown]
  └── f-k-checks
-      └── f-k-checks-item
+      └── f-k-checks-item: child_nullable_full(p) -> parent(p)
            └── anti-join
                 ├── columns: column2:4(int!null)
                 ├── select
@@ -219,7 +219,7 @@ insert multi_col_child
  │         └── cast: INT8 [type=int]
  │              └── null [type=unknown]
  └── f-k-checks
-      └── f-k-checks-item
+      └── f-k-checks-item: multi_col_child(p,q,r) -> multi_col_parent(p,q,r)
            └── anti-join
                 ├── columns: column2:6(int!null) column3:7(int!null) column4:8(int!null)
                 ├── select
@@ -285,7 +285,7 @@ insert multi_col_child
  │         │    └── null [type=unknown]
  │         └── const: 20 [type=int]
  └── f-k-checks
-      └── f-k-checks-item
+      └── f-k-checks-item: multi_col_child(p,q,r) -> multi_col_parent(p,q,r)
            └── anti-join
                 ├── columns: column2:6(int!null) column3:7(int!null) column4:8(int!null)
                 ├── select
@@ -345,7 +345,7 @@ insert multi_col_child
  │         ├── const: 10 [type=int]
  │         └── const: 10 [type=int]
  └── f-k-checks
-      └── f-k-checks-item
+      └── f-k-checks-item: multi_col_child(p,q,r) -> multi_col_parent(p,q,r)
            └── anti-join
                 ├── columns: column2:6(int!null) column3:7(int!null) column4:8(int!null)
                 ├── project
@@ -400,7 +400,7 @@ insert multi_col_child_full
  │         └── cast: INT8 [type=int]
  │              └── null [type=unknown]
  └── f-k-checks
-      └── f-k-checks-item
+      └── f-k-checks-item: multi_col_child_full(p,q,r) -> multi_col_parent(p,q,r)
            └── anti-join
                 ├── columns: column2:6(int) column3:7(int) column4:8(int)
                 ├── select
@@ -468,7 +468,7 @@ insert multi_col_child_full
  │         │    └── null [type=unknown]
  │         └── const: 20 [type=int]
  └── f-k-checks
-      └── f-k-checks-item
+      └── f-k-checks-item: multi_col_child_full(p,q,r) -> multi_col_parent(p,q,r)
            └── anti-join
                 ├── columns: column2:6(int) column3:7(int) column4:8(int!null)
                 ├── project
@@ -519,7 +519,7 @@ insert multi_col_child_full
  │         ├── const: 10 [type=int]
  │         └── const: 10 [type=int]
  └── f-k-checks
-      └── f-k-checks-item
+      └── f-k-checks-item: multi_col_child_full(p,q,r) -> multi_col_parent(p,q,r)
            └── anti-join
                 ├── columns: column2:6(int!null) column3:7(int!null) column4:8(int!null)
                 ├── project
@@ -584,7 +584,7 @@ insert multi_ref_child
  │         └── cast: INT8 [type=int]
  │              └── null [type=unknown]
  └── f-k-checks
-      ├── f-k-checks-item
+      ├── f-k-checks-item: multi_ref_child(a) -> multi_ref_parent_a(a)
       │    └── anti-join
       │         ├── columns: column2:6(int!null)
       │         ├── select
@@ -611,7 +611,7 @@ insert multi_ref_child
       │              └── eq [type=bool]
       │                   ├── variable: column2 [type=int]
       │                   └── variable: t.public.multi_ref_parent_a.a [type=int]
-      └── f-k-checks-item
+      └── f-k-checks-item: multi_ref_child(b,c) -> multi_ref_parent_bc(b,c)
            └── anti-join
                 ├── columns: column3:7(int!null) column4:8(int!null)
                 ├── select

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1574,8 +1574,13 @@ func (ef *execFactory) ConstructSaveTable(
 }
 
 // ConstructErrorIfRows is part of the exec.Factory interface.
-func (ef *execFactory) ConstructErrorIfRows(input exec.Node) (exec.Node, error) {
-	return &errorIfRowsNode{plan: input.(planNode)}, nil
+func (ef *execFactory) ConstructErrorIfRows(
+	input exec.Node, mkErr func(tree.Datums) error,
+) (exec.Node, error) {
+	return &errorIfRowsNode{
+		plan:  input.(planNode),
+		mkErr: mkErr,
+	}, nil
 }
 
 // renderBuilder encapsulates the code to build a renderNode.


### PR DESCRIPTION
#### sql: control errorIfRows message

Allow execbuilder to control the `errorIfRows` message by moving the
generation of the message into a callback.

Release note: None

#### opt: plumb FK check information and improve error message

We add information to each `FKChecksItem` about the relevant FK
constraint. We use this information to improve the FK violation error
message; the message matches postgres and is more user-friendly than
our current message.

Release note: None
