### PR TITLE
exec: consolidate all Copy{...} methods into one

### DIFF
--- a/pkg/sql/exec/aggregator.go
+++ b/pkg/sql/exec/aggregator.go
@@ -246,8 +246,14 @@ func (a *orderedAggregator) Next(ctx context.Context) coldata.Batch {
 		for i := 0; i < len(a.outputTypes); i++ {
 			// According to the aggregate function interface contract, the value at
 			// the current index must also be copied.
-			a.scratch.ColVec(i).Copy(a.scratch.ColVec(i), uint64(a.scratch.outputSize),
-				uint64(a.scratch.resumeIdx+1), a.outputTypes[i])
+			a.scratch.ColVec(i).Copy(
+				coldata.CopyArgs{
+					Src:         a.scratch.ColVec(i),
+					ColType:     a.outputTypes[i],
+					SrcStartIdx: uint64(a.scratch.outputSize),
+					SrcEndIdx:   uint64(a.scratch.resumeIdx + 1),
+				},
+			)
 			a.aggregateFuncs[i].SetOutputIndex(newResumeIdx)
 		}
 		a.scratch.resumeIdx = newResumeIdx

--- a/pkg/sql/exec/coalescer.go
+++ b/pkg/sql/exec/coalescer.go
@@ -87,11 +87,15 @@ func (p *coalescerOp) Next(ctx context.Context) coldata.Batch {
 						SrcEndIdx: leftover,
 					},
 				)
-				if sel != nil {
-					bufferCol.CopyWithSelInt16(fromCol, sel[leftover:batchSize], batchSize-leftover, t)
-				} else {
-					bufferCol.Copy(fromCol, uint64(leftover), uint64(batchSize), t)
-				}
+				bufferCol.Copy(
+					coldata.CopyArgs{
+						ColType:     t,
+						Src:         fromCol,
+						Sel:         sel,
+						SrcStartIdx: uint64(leftover),
+						SrcEndIdx:   uint64(batchSize),
+					},
+				)
 			}
 		}
 

--- a/pkg/sql/exec/coldata/vec.go
+++ b/pkg/sql/exec/coldata/vec.go
@@ -40,6 +40,38 @@ type AppendArgs struct {
 	SrcEndIdx uint16
 }
 
+// CopyArgs represents the arguments passed in to Vec.Copy.
+type CopyArgs struct {
+	// ColType is the type of both the destination and source slices.
+	ColType types.T
+	// Src is the data being copied.
+	Src Vec
+	// Sel is an optional slice specifying indices to copy to the destination
+	// slice. Note that Src{Start,End}Idx apply to Sel.
+	Sel []uint16
+	// Sel64 overrides Sel. Used when the amount of data being copied exceeds the
+	// representation capabilities of a []uint16.
+	Sel64 []uint64
+	// DestIdx is the first index that Copy will copy to.
+	DestIdx uint64
+	// SrcStartIdx is the index of the first element in Src that Copy will copy.
+	SrcStartIdx uint64
+	// SrcEndIdx is the exclusive end index of Src. i.e. the element in the index
+	// before SrcEndIdx is the last element copied into the destination slice,
+	// similar to Src[SrcStartIdx:SrcEndIdx].
+	SrcEndIdx uint64
+
+	// Nils exists to support the hashJoiner's use case of Copy before the
+	// migration to a single Copy method. It overrides the use of a selection
+	// vector only in the Sel64 case and simply sets the destination slice's value
+	// to NULL if the index is true, otherwise defaulting to using the selection
+	// vector.
+	// TODO(asubiotto): Get rid of this.
+	// DEPRECATED: DO NOT USE, it should not be Copy's responsibility to care
+	// about this.
+	Nils []bool
+}
+
 // Vec is an interface that represents a column vector that's accessible by
 // Go native types.
 type Vec interface {
@@ -85,23 +117,13 @@ type Vec interface {
 	// Refer to the AppendArgs comment for specifics and TestAppend for examples.
 	Append(AppendArgs)
 
-	// Copy copies src[srcStartIdx:srcEndIdx] into this Vec.
-	Copy(src Vec, srcStartIdx, srcEndIdx uint64, typ types.T)
-
-	// CopyAt copies src[srcStartIdx:srcEndIdx] into this Vec starting at destStartIdx.
-	CopyAt(src Vec, destStartIdx, srcStartIdx, srcEndIdx uint64, typ types.T)
-
-	// CopyWithSelInt64 copies vec, filtered by sel, into this Vec. It replaces
-	// the contents of this Vec.
-	CopyWithSelInt64(vec Vec, sel []uint64, nSel uint16, colType types.T)
-
-	// CopyWithSelInt16 copies vec, filtered by sel, into this Vec. It replaces
-	// the contents of this Vec.
-	CopyWithSelInt16(vec Vec, sel []uint16, nSel uint16, colType types.T)
-
-	// CopyWithSelAndNilsInt64 copies vec, filtered by sel, unless nils is set,
-	// into Vec. It replaces the contents of this Vec.
-	CopyWithSelAndNilsInt64(vec Vec, sel []uint64, nSel uint16, nils []bool, colType types.T)
+	// Copy uses CopyArgs to copy elements of a source Vec into this Vec. It is
+	// logically equivalent to:
+	// copy(destVec[args.DestIdx:], args.Src[args.SrcStartIdx:args.SrcEndIdx])
+	// An optional Sel slice can also be provided to apply a filter on the source
+	// Vec.
+	// Refer to the CopyArgs comment for specifics and TestCopy for examples.
+	Copy(CopyArgs)
 
 	// Slice returns a new Vec representing a slice of the current Vec from
 	// [start, end).

--- a/pkg/sql/exec/coldata/vec_test.go
+++ b/pkg/sql/exec/coldata/vec_test.go
@@ -132,6 +132,7 @@ func TestNullRanges(t *testing.T) {
 }
 
 func TestAppend(t *testing.T) {
+	// TODO(asubiotto): Test nulls.
 	const typ = types.Int64
 
 	src := NewMemColumn(typ, BatchSize)
@@ -214,6 +215,90 @@ func TestAppend(t *testing.T) {
 	}
 }
 
+func TestCopy(t *testing.T) {
+	// TODO(asubiotto): Test nulls.
+	const typ = types.Int64
+
+	src := NewMemColumn(typ, BatchSize)
+	srcInts := src.Int64()
+	for i := range srcInts {
+		srcInts[i] = int64(i + 1)
+	}
+	sel := make([]uint16, len(src.Int64()))
+	for i := range sel {
+		sel[i] = uint16(i)
+	}
+	sel64 := make([]uint64, len(src.Int64()))
+	for i := range sel64 {
+		sel64[i] = uint64(i)
+	}
+
+	sum := func(ints []int64) int {
+		s := 0
+		for _, i := range ints {
+			s += int(i)
+		}
+		return s
+	}
+
+	testCases := []struct {
+		name        string
+		args        CopyArgs
+		expectedSum int
+	}{
+		{
+			name:        "CopyNothing",
+			args:        CopyArgs{},
+			expectedSum: 0,
+		},
+		{
+			name: "CopyBatchSizeMinus1WithOffset1",
+			args: CopyArgs{
+				// Use DestIdx 1 to make sure that it is respected.
+				DestIdx:   1,
+				SrcEndIdx: BatchSize - 1,
+			},
+			// expectedSum uses sum of positive integers formula.
+			expectedSum: ((BatchSize - 1) * (BatchSize)) / 2,
+		},
+		{
+			name: "CopyWithSel",
+			args: CopyArgs{
+				// Set sel, but this should be ignored in favor of Sel64.
+				Sel: sel,
+				// Since sel64 and sel refer to the same indices, slice sel64 to be able
+				// to tell which sel was used.
+				Sel64:       sel64[1:],
+				DestIdx:     25,
+				SrcStartIdx: 1,
+				SrcEndIdx:   2,
+			},
+			// We'll have just the third element in the resulting slice.
+			expectedSum: 3,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc.args.Src = src
+		tc.args.ColType = typ
+		t.Run(tc.name, func(t *testing.T) {
+			dest := NewMemColumn(typ, BatchSize)
+			dest.Copy(tc.args)
+			destInts := dest.Int64()
+			firstNonZero := 0
+			for i := range destInts {
+				if destInts[i] != 0 {
+					firstNonZero = i
+					break
+				}
+			}
+			// Verify that Copy started copying where we expected it to.
+			require.Equal(t, tc.args.DestIdx, uint64(firstNonZero))
+			require.Equal(t, tc.expectedSum, sum(destInts))
+		})
+	}
+}
+
 func BenchmarkAppend(b *testing.B) {
 	const typ = types.Int64
 
@@ -247,6 +332,42 @@ func BenchmarkAppend(b *testing.B) {
 				dest.Append(bc.args)
 				// "Reset" dest for another round.
 				dest.SetCol(dest.Int64()[:BatchSize])
+			}
+		})
+	}
+}
+
+func BenchmarkCopy(b *testing.B) {
+	const typ = types.Int64
+
+	src := NewMemColumn(typ, BatchSize)
+	sel := make([]uint16, len(src.Int64()))
+
+	benchCases := []struct {
+		name string
+		args CopyArgs
+	}{
+		{
+			name: "CopySimple",
+			args: CopyArgs{},
+		},
+		{
+			name: "CopyWithSel",
+			args: CopyArgs{
+				Sel: sel,
+			},
+		},
+	}
+
+	for _, bc := range benchCases {
+		bc.args.Src = src
+		bc.args.ColType = typ
+		bc.args.SrcEndIdx = BatchSize
+		dest := NewMemColumn(typ, BatchSize)
+		b.Run(bc.name, func(b *testing.B) {
+			b.SetBytes(8 * BatchSize)
+			for i := 0; i < b.N; i++ {
+				dest.Copy(bc.args)
 			}
 		})
 	}

--- a/pkg/sql/exec/colserde/arrowbatchconverter_test.go
+++ b/pkg/sql/exec/colserde/arrowbatchconverter_test.go
@@ -53,7 +53,13 @@ func TestArrowBatchConverterRandom(t *testing.T) {
 	expectedColVecs := make([]coldata.Vec, len(b.ColVecs()))
 	for i := range typs {
 		expectedColVecs[i] = coldata.NewMemColumn(typs[i], int(b.Length()))
-		expectedColVecs[i].Copy(b.ColVec(i), 0, uint64(b.Length()), typs[i])
+		expectedColVecs[i].Copy(
+			coldata.CopyArgs{
+				ColType:   typs[i],
+				Src:       b.ColVec(i),
+				SrcEndIdx: uint64(b.Length()),
+			},
+		)
 	}
 
 	arrowData, err := c.BatchToArrow(b)

--- a/pkg/sql/exec/deselector.go
+++ b/pkg/sql/exec/deselector.go
@@ -55,7 +55,14 @@ func (p *deselectorOp) Next(ctx context.Context) coldata.Batch {
 	for i, t := range p.inputTypes {
 		toCol := p.output.ColVec(i)
 		fromCol := batch.ColVec(i)
-		toCol.CopyWithSelInt16(fromCol, sel, batch.Length(), t)
+		toCol.Copy(
+			coldata.CopyArgs{
+				ColType:   t,
+				Src:       fromCol,
+				Sel:       sel,
+				SrcEndIdx: uint64(batch.Length()),
+			},
+		)
 	}
 	return p.output
 }

--- a/pkg/sql/exec/hash_aggregator.go
+++ b/pkg/sql/exec/hash_aggregator.go
@@ -285,7 +285,15 @@ func (op *hashAggregatorBatchOp) Next(context.Context) coldata.Batch {
 	for i, colIdx := range op.ht.outCols {
 		toCol := op.batch.ColVec(i)
 		fromCol := op.ht.vals[colIdx]
-		toCol.CopyWithSelInt64(fromCol, op.sel[op.batchStart:batchEnd], nSelected, op.ht.valTypes[op.ht.outCols[i]])
+		toCol.Copy(
+			coldata.CopyArgs{
+				ColType:     op.ht.valTypes[op.ht.outCols[i]],
+				Src:         fromCol,
+				Sel64:       op.sel,
+				SrcStartIdx: op.batchStart,
+				SrcEndIdx:   batchEnd,
+			},
+		)
 	}
 
 	op.batchStart = batchEnd


### PR DESCRIPTION
This makes the code easier to work with.
```
name                old time/op    new time/op    delta
Copy/CopySimple-8      158ns ± 0%     115ns ± 1%   -27.05%  (p=0.000 n=8+9)
Copy/CopyWithSel-8     790ns ± 0%     668ns ± 2%   -15.47%  (p=0.000 n=8+10)

name                old speed      new speed      delta
Copy/CopySimple-8   51.6GB/s ± 0%  70.6GB/s ± 1%   +36.83%  (p=0.000 n=8+9)
Copy/CopyWithSel-8  10.4GB/s ± 0%  12.3GB/s ± 2%   +18.28%  (p=0.000 n=8+10)

name                old alloc/op   new alloc/op   delta
Copy/CopySimple-8       128B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Copy/CopyWithSel-8     0.00B          0.00B           ~     (all equal)
```
Release note: None