### PR TITLE
exec: support COUNT aggregate function

### DIFF
--- a/pkg/sql/exec/aggregator.go
+++ b/pkg/sql/exec/aggregator.go
@@ -189,6 +189,8 @@ func makeAggregateFuncs(
 		case distsqlpb.AggregatorSpec_SUM, distsqlpb.AggregatorSpec_SUM_INT:
 			funcs[i], err = newSumAgg(aggTyps[i][0])
 		case distsqlpb.AggregatorSpec_COUNT_ROWS:
+			funcs[i] = newCountRowAgg()
+		case distsqlpb.AggregatorSpec_COUNT:
 			funcs[i] = newCountAgg()
 		case distsqlpb.AggregatorSpec_MIN:
 			funcs[i], err = newMinAgg(aggTyps[i][0])
@@ -200,7 +202,7 @@ func makeAggregateFuncs(
 
 		// Set the output type of the aggregate.
 		switch aggFns[i] {
-		case distsqlpb.AggregatorSpec_COUNT_ROWS:
+		case distsqlpb.AggregatorSpec_COUNT_ROWS, distsqlpb.AggregatorSpec_COUNT:
 			// TODO(jordan): this is a somewhat of a hack. The aggregate functions
 			// should come with their own output types, somehow.
 			outTyps[i] = types.Int64

--- a/pkg/sql/exec/utils_test.go
+++ b/pkg/sql/exec/utils_test.go
@@ -708,6 +708,7 @@ func (c *chunkingBatchSource) Init() {
 	c.batch = coldata.NewMemBatch(c.typs)
 	for i := range c.cols {
 		c.batch.ColVec(i).SetCol(c.cols[i].Col())
+		c.batch.ColVec(i).SetNulls(c.cols[i].Nulls())
 	}
 }
 
@@ -721,6 +722,8 @@ func (c *chunkingBatchSource) Next(context.Context) coldata.Batch {
 	}
 	for i, vec := range c.batch.ColVecs() {
 		vec.SetCol(c.cols[i].Slice(c.typs[i], c.curIdx, lastIdx).Col())
+		nullsSlice := c.cols[i].Nulls().Slice(c.curIdx, lastIdx)
+		vec.SetNulls(&nullsSlice)
 	}
 	c.batch.SetLength(uint16(lastIdx - c.curIdx))
 	c.curIdx = lastIdx


### PR DESCRIPTION
The COUNT_ROWS aggregator was already supported. That function counts
each row, whereas this new COUNT aggregator counts all non-null values
for a particular column.

fixes #38063

```
BenchmarkAggregator/COUNT/hash/Int64/groupSize=1/nullProbability=0.0/numInputBatches=64-12           5947226 ns/op	  88.16 MB/s	 2366354 B/op	  132171 allocs/op
BenchmarkAggregator/COUNT/hash/Int64/groupSize=1/nullProbability=0.3/numInputBatches=64-12           6615310 ns/op	  79.25 MB/s	 2375999 B/op	  132171 allocs/op
BenchmarkAggregator/COUNT/hash/Int64/groupSize=2/nullProbability=0.0/numInputBatches=64-12           4777319 ns/op	 109.75 MB/s	 2357138 B/op	  132107 allocs/op
BenchmarkAggregator/COUNT/hash/Int64/groupSize=2/nullProbability=0.3/numInputBatches=64-12           5357787 ns/op	  97.86 MB/s	 2357138 B/op	  132107 allocs/op
BenchmarkAggregator/COUNT/hash/Int64/groupSize=512/nullProbability=0.0/numInputBatches=64-12         4206313 ns/op	 124.64 MB/s	 2348207 B/op	  132045 allocs/op
BenchmarkAggregator/COUNT/hash/Int64/groupSize=512/nullProbability=0.3/numInputBatches=64-12         4999094 ns/op	 104.88 MB/s	 2348210 B/op	  132045 allocs/op
BenchmarkAggregator/COUNT/hash/Int64/groupSize=1024/nullProbability=0.0/numInputBatches=64-12        4789078 ns/op	 109.48 MB/s	 2348207 B/op	  132045 allocs/op
BenchmarkAggregator/COUNT/hash/Int64/groupSize=1024/nullProbability=0.3/numInputBatches=64-12        5434444 ns/op	  96.47 MB/s	 2348209 B/op	  132045 allocs/op
BenchmarkAggregator/COUNT/hash/Decimal/groupSize=1/nullProbability=0.0/numInputBatches=64-12         6404536 ns/op	  81.86 MB/s	 2450794 B/op	  132171 allocs/op
BenchmarkAggregator/COUNT/hash/Decimal/groupSize=1/nullProbability=0.3/numInputBatches=64-12         6916696 ns/op	  75.80 MB/s	 2450793 B/op	  132171 allocs/op
BenchmarkAggregator/COUNT/hash/Decimal/groupSize=2/nullProbability=0.0/numInputBatches=64-12         5132505 ns/op	 102.15 MB/s	 2406999 B/op	  132107 allocs/op
BenchmarkAggregator/COUNT/hash/Decimal/groupSize=2/nullProbability=0.3/numInputBatches=64-12         5694782 ns/op	  92.06 MB/s	 2441578 B/op	  132107 allocs/op
BenchmarkAggregator/COUNT/hash/Decimal/groupSize=512/nullProbability=0.0/numInputBatches=64-12       4577982 ns/op	 114.52 MB/s	 2398072 B/op	  132045 allocs/op
BenchmarkAggregator/COUNT/hash/Decimal/groupSize=512/nullProbability=0.3/numInputBatches=64-12       5434474 ns/op	  96.47 MB/s	 2398071 B/op	  132045 allocs/op
BenchmarkAggregator/COUNT/hash/Decimal/groupSize=1024/nullProbability=0.0/numInputBatches=64-12      5854729 ns/op	  89.55 MB/s	 2398071 B/op	  132045 allocs/op
BenchmarkAggregator/COUNT/hash/Decimal/groupSize=1024/nullProbability=0.3/numInputBatches=64-12      6148217 ns/op	  85.27 MB/s	 2398071 B/op	  132045 allocs/op
BenchmarkAggregator/COUNT/ordered/Int64/groupSize=1/nullProbability=0.0/numInputBatches=64-12        180225 ns/op	2909.06 MB/s	   67616 B/op	     774 allocs/op
BenchmarkAggregator/COUNT/ordered/Int64/groupSize=1/nullProbability=0.3/numInputBatches=64-12        208066 ns/op	2519.81 MB/s	   67616 B/op	     774 allocs/op
BenchmarkAggregator/COUNT/ordered/Int64/groupSize=2/nullProbability=0.0/numInputBatches=64-12        164913 ns/op	3179.17 MB/s	   58400 B/op	     710 allocs/op
BenchmarkAggregator/COUNT/ordered/Int64/groupSize=2/nullProbability=0.3/numInputBatches=64-12        206657 ns/op	2536.99 MB/s	   58400 B/op	     710 allocs/op
BenchmarkAggregator/COUNT/ordered/Int64/groupSize=512/nullProbability=0.0/numInputBatches=64-12      161315 ns/op	3250.08 MB/s	   49472 B/op	     648 allocs/op
BenchmarkAggregator/COUNT/ordered/Int64/groupSize=512/nullProbability=0.3/numInputBatches=64-12      185349 ns/op	2828.65 MB/s	   49472 B/op	     648 allocs/op
BenchmarkAggregator/COUNT/ordered/Int64/groupSize=1024/nullProbability=0.0/numInputBatches=64-12     158268 ns/op	3312.65 MB/s	   49472 B/op	     648 allocs/op
BenchmarkAggregator/COUNT/ordered/Int64/groupSize=1024/nullProbability=0.3/numInputBatches=64-12     189441 ns/op	2767.55 MB/s	   49472 B/op	     648 allocs/op
BenchmarkAggregator/COUNT/ordered/Decimal/groupSize=1/nullProbability=0.0/numInputBatches=64-12      176632 ns/op	2968.24 MB/s	   67616 B/op	     774 allocs/op
BenchmarkAggregator/COUNT/ordered/Decimal/groupSize=1/nullProbability=0.3/numInputBatches=64-12      205669 ns/op	2549.17 MB/s	   67616 B/op	     774 allocs/op
BenchmarkAggregator/COUNT/ordered/Decimal/groupSize=2/nullProbability=0.0/numInputBatches=64-12      166801 ns/op	3143.19 MB/s	   58400 B/op	     710 allocs/op
BenchmarkAggregator/COUNT/ordered/Decimal/groupSize=2/nullProbability=0.3/numInputBatches=64-12      193412 ns/op	2710.72 MB/s	   58400 B/op	     710 allocs/op
BenchmarkAggregator/COUNT/ordered/Decimal/groupSize=512/nullProbability=0.0/numInputBatches=64-12    155513 ns/op	3371.33 MB/s	   49472 B/op	     648 allocs/op
BenchmarkAggregator/COUNT/ordered/Decimal/groupSize=512/nullProbability=0.3/numInputBatches=64-12    182854 ns/op	2867.24 MB/s	   49472 B/op	     648 allocs/op
BenchmarkAggregator/COUNT/ordered/Decimal/groupSize=1024/nullProbability=0.0/numInputBatches=64-12   154837 ns/op	3386.06 MB/s	   49472 B/op	     648 allocs/op
BenchmarkAggregator/COUNT/ordered/Decimal/groupSize=1024/nullProbability=0.3/numInputBatches=64-12   183776 ns/op	2852.86 MB/s	   49472 B/op	     648 allocs/op
```

Release note: None