### PR TITLE
sql: fix ALTER PARTITION x OF INDEX

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -308,3 +308,33 @@ SHOW ZONE CONFIGURATION FOR PARTITION x1 OF TABLE t35756
           num_replicas = 3,
           constraints = '[]',
           lease_preferences = '[]'
+
+# Regression test for #38391: verify that altering an index's partition really
+# modifies the partition.
+
+statement ok
+CREATE TABLE t38391 (
+  x INT, y INT, z INT,
+  PRIMARY KEY(x, y),
+  INDEX foo (x, z) PARTITION BY LIST (x) (
+    PARTITION x1_idx VALUES IN (1),
+    PARTITION DEFAULT VALUES IN (DEFAULT)
+  ))
+  PARTITION BY LIST (x) (
+    PARTITION x1 VALUES IN (1),
+    PARTITION DEFAULT_idx VALUES IN (DEFAULT)
+  )
+
+statement ok
+ALTER PARTITION x1_idx OF INDEX t38391@foo CONFIGURE ZONE USING gc.ttlseconds = 31337
+
+query TT
+SHOW ZONE CONFIGURATION FOR PARTITION x1_idx OF TABLE t38391
+----
+test.t38391.x1_idx  ALTER PARTITION x1_idx OF INDEX t38391@foo CONFIGURE ZONE USING
+                    range_min_bytes = 16777216,
+                    range_max_bytes = 67108864,
+                    gc.ttlseconds = 31337,
+                    num_replicas = 3,
+                    constraints = '[]',
+                    lease_preferences = '[]'

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -262,8 +262,7 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 	// resolveSubzone determines the sub-parts of the zone
 	// specifier. This ought to succeed regardless of whether there is
 	// already a zone config.
-	index, partition, err := resolveSubzone(params.ctx, params.p.txn,
-		&n.zoneSpecifier, targetID, table)
+	index, partition, err := resolveSubzone(&n.zoneSpecifier, table)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/show_zone_config.go
+++ b/pkg/sql/show_zone_config.go
@@ -100,7 +100,7 @@ func getShowZoneConfigRow(
 		return nil, err
 	}
 
-	index, partition, err := resolveSubzone(ctx, p.txn, &zoneSpecifier, targetID, tblDesc)
+	index, partition, err := resolveSubzone(&zoneSpecifier, tblDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/zone_config.go
+++ b/pkg/sql/zone_config.go
@@ -12,6 +12,7 @@ package sql
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
@@ -302,22 +303,25 @@ func resolveZone(ctx context.Context, txn *client.Txn, zs *tree.ZoneSpecifier) (
 }
 
 func resolveSubzone(
-	ctx context.Context,
-	txn *client.Txn,
-	zs *tree.ZoneSpecifier,
-	targetID sqlbase.ID,
-	table *sqlbase.TableDescriptor,
+	zs *tree.ZoneSpecifier, table *sqlbase.TableDescriptor,
 ) (*sqlbase.IndexDescriptor, string, error) {
 	if !zs.TargetsTable() {
 		return nil, "", nil
 	}
+	partitionName := string(zs.Partition)
 	if indexName := string(zs.TableOrIndex.Index); indexName != "" {
 		index, _, err := table.FindIndexByName(indexName)
 		if err != nil {
 			return nil, "", err
 		}
-		return index, "", nil
-	} else if partitionName := string(zs.Partition); partitionName != "" {
+		if partitionName == "" {
+			return index, "", nil
+		}
+		if partitioning := index.FindPartitionByName(partitionName); partitioning == nil {
+			return nil, "", fmt.Errorf("partition %q does not exist on index %q", partitionName, indexName)
+		}
+		return index, partitionName, nil
+	} else if partitionName != "" {
 		_, index, err := table.FindNonDropPartitionByName(partitionName)
 		if err != nil {
 			return nil, "", err


### PR DESCRIPTION
Fixes #38391.

Previously, `ALTER PARTITION x OF INDEX y CONFIGURE ZONE USING` ignored
the passed-in partition name, and instead applied the given zone
configuration to the entire index.

Furthermore, `SHOW CREATE TABLE` output that syntax, which produced
un-roundtrippable partitioning syntax.

Now, the partition is actually respected as one would expect.

Release note (bug fix): the `ALTER PARTITION x OF INDEX y CONFIGURE ZONE USING`
syntax no longer erroneously modifies the entire index's zone
configuration.