### PR TITLE
exec: add support for LEFT OUTER merge join

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -299,8 +299,8 @@ func newColOperator(
 		if !core.MergeJoiner.OnExpr.Empty() {
 			return nil, nil, errors.Newf("can't plan merge join with on expressions")
 		}
-		if core.MergeJoiner.Type != sqlbase.InnerJoin {
-			return nil, nil, errors.Newf("can plan only inner merge join")
+		if core.MergeJoiner.Type != sqlbase.InnerJoin && core.MergeJoiner.Type != sqlbase.LeftOuterJoin {
+			return nil, nil, errors.Newf("can plan only inner and left outer merge join")
 		}
 
 		leftTypes := conv.FromColumnTypes(spec.Input[0].ColumnTypes)
@@ -331,6 +331,7 @@ func newColOperator(
 		}
 
 		op, err = exec.NewMergeJoinOp(
+			core.MergeJoiner.Type,
 			inputs[0],
 			inputs[1],
 			leftOutCols,

--- a/pkg/sql/distsqlrun/columnar_utils_test.go
+++ b/pkg/sql/distsqlrun/columnar_utils_test.go
@@ -106,6 +106,8 @@ func verifyColOperator(
 
 	outProc.Start(ctx)
 	outColOp.Start(ctx)
+	defer outProc.ConsumerClosed()
+	defer outColOp.ConsumerClosed()
 
 	var procRows, colOpRows sqlbase.EncDatumRows
 	rowCount := 0

--- a/pkg/sql/exec/stats_test.go
+++ b/pkg/sql/exec/stats_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"
 )
@@ -78,6 +79,7 @@ func TestVectorizedStatsCollector(t *testing.T) {
 		rightInput.SetOutputWatch(mjInputWatch)
 
 		mergeJoiner, err := NewMergeJoinOp(
+			sqlbase.InnerJoin,
 			leftInput,
 			rightInput,
 			[]uint32{0},


### PR DESCRIPTION
We now support left outer merge join. Join type is introduced as
an argument but will be templated out later.

As expected, extra checks that are being added in this PR slow down the common INNER JOIN case:
```
name                                       old time/op    new time/op    delta
MergeJoiner/rows=1024-12                     34.9µs ± 3%    37.5µs ± 2%   +7.38%  (p=0.000 n=9+9)
MergeJoiner/rows=16384-12                     413µs ± 1%     473µs ± 3%  +14.48%  (p=0.000 n=9+9)
MergeJoiner/rows=1048576-12                  26.6ms ± 2%    30.9ms ± 4%  +16.04%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=1024-12       31.4µs ± 0%    36.9µs ± 3%  +17.74%  (p=0.000 n=8+10)
MergeJoiner/oneSideRepeat-rows=16384-12       416µs ± 4%     479µs ± 5%  +14.93%  (p=0.000 n=9+10)
MergeJoiner/oneSideRepeat-rows=1048576-12    26.8ms ± 2%    31.2ms ± 5%  +16.37%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=1024-12     30.6µs ± 1%    35.7µs ± 4%  +16.44%  (p=0.000 n=9+10)
MergeJoiner/bothSidesRepeat-rows=16384-12     702µs ± 2%     737µs ± 3%   +4.94%  (p=0.000 n=9+10)

name                                       old speed      new speed      delta
MergeJoiner/rows=1024-12                   1.88GB/s ± 3%  1.75GB/s ± 2%   -6.90%  (p=0.000 n=9+9)
MergeJoiner/rows=16384-12                  2.54GB/s ± 1%  2.22GB/s ± 3%  -12.63%  (p=0.000 n=9+9)
MergeJoiner/rows=1048576-12                2.52GB/s ± 2%  2.17GB/s ± 4%  -13.81%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=1024-12     2.09GB/s ± 0%  1.78GB/s ± 4%  -15.04%  (p=0.000 n=8+10)
MergeJoiner/oneSideRepeat-rows=16384-12    2.52GB/s ± 4%  2.19GB/s ± 5%  -12.98%  (p=0.000 n=9+10)
MergeJoiner/oneSideRepeat-rows=1048576-12  2.50GB/s ± 2%  2.15GB/s ± 5%  -14.03%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=1024-12   2.14GB/s ± 1%  1.84GB/s ± 4%  -14.09%  (p=0.000 n=9+10)
MergeJoiner/bothSidesRepeat-rows=16384-12  1.49GB/s ± 2%  1.42GB/s ± 3%   -4.69%  (p=0.000 n=9+10)

name                                       old alloc/op   new alloc/op   delta
MergeJoiner/rows=1024-12                       261B ± 0%      262B ± 0%   +0.38%  (p=0.000 n=10+10)
MergeJoiner/rows=16384-12                    4.19kB ± 0%    4.20kB ± 0%   +0.26%  (p=0.000 n=10+10)
MergeJoiner/rows=1048576-12                   268kB ± 0%     268kB ± 0%   +0.25%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=1024-12         261B ± 0%      262B ± 0%   +0.38%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=16384-12      4.18kB ± 1%    4.20kB ± 0%   +0.52%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=1048576-12     268kB ± 0%     268kB ± 0%   +0.25%  (p=0.000 n=10+9)
MergeJoiner/bothSidesRepeat-rows=1024-12       261B ± 0%      262B ± 0%   +0.38%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=16384-12    4.23kB ± 0%    4.25kB ± 0%   +0.38%  (p=0.000 n=10+10)

name                                       old allocs/op  new allocs/op  delta
MergeJoiner/rows=1024-12                       8.00 ± 0%      8.00 ± 0%     ~     (all equal)
MergeJoiner/rows=16384-12                       128 ± 0%       128 ± 0%     ~     (all equal)
MergeJoiner/rows=1048576-12                   8.19k ± 0%     8.19k ± 0%     ~     (all equal)
MergeJoiner/oneSideRepeat-rows=1024-12         8.00 ± 0%      8.00 ± 0%     ~     (all equal)
MergeJoiner/oneSideRepeat-rows=16384-12         128 ± 0%       128 ± 0%     ~     (all equal)
MergeJoiner/oneSideRepeat-rows=1048576-12     8.19k ± 0%     8.19k ± 0%     ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=1024-12       8.00 ± 0%      8.00 ± 0%     ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=16384-12       128 ± 0%       128 ± 0%     ~     (all equal)
```
but I want to merge this as is with adding the templating later since I want to shift my attention to simplifying the existing code first.

Release note: None