### PR TITLE
release-19.1: changefeedccl: enable abort and split nemeses in TestNemeses

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/nemeses.go
+++ b/pkg/ccl/changefeedccl/cdctest/nemeses.go
@@ -75,11 +75,11 @@ func RunNemesis(f TestFeedFactory, db *gosql.DB) (Validator, error) {
 
 			// eventAbort aborts every open transaction by running a high priority
 			// DELETE.
-			// TODO(dan): This deadlocks eventAbort{}: 5,
+			eventAbort{}: 5,
 
 			// eventSplit splits between two random rows (the split is a no-op if it
 			// already exists).
-			// TODO(dan): This deadlocks eventSplit{}: 5,
+			eventSplit{}: 5,
 		},
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #38210.

/cc @cockroachdb/release

---

These deadlocked when the test was written but seems like they've been
fixed sometime since. \o/

On a gceworker:

    17846 runs so far, 0 failures, over 2h9m40s

Release note: None
