### PR TITLE
sql: fix swallowing Unsplit error

### DIFF
--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -244,7 +244,7 @@ func (p *planner) dropIndexByName(
 					// Swallow "key is not the start of a range" errors because it would
 					// mean that the sticky bit was removed and merged concurrently. DROP
 					// INDEX should not fail because of this.
-					if err := p.ExecCfg().DB.AdminUnsplit(ctx, desc.StartKey); err != nil && strings.Contains(err.Error(), "is not the start of a range") {
+					if err := p.ExecCfg().DB.AdminUnsplit(ctx, desc.StartKey); err != nil && !strings.Contains(err.Error(), "is not the start of a range") {
 						return err
 					}
 				}

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -368,7 +368,7 @@ func (p *planner) initiateDropTable(
 			// Swallow "key is not the start of a range" errors because it would mean
 			// that the sticky bit was removed and merged concurrently. DROP TABLE
 			// should not fail because of this.
-			if err := p.ExecCfg().DB.AdminUnsplit(ctx, desc.StartKey); err != nil && strings.Contains(err.Error(), "is not the start of a range") {
+			if err := p.ExecCfg().DB.AdminUnsplit(ctx, desc.StartKey); err != nil && !strings.Contains(err.Error(), "is not the start of a range") {
 				return err
 			}
 		}


### PR DESCRIPTION
Realized this condition should be negated.

Fixes #38131, #38095.

Release note: None