### PR TITLE
sql: Fixing interleave check for loose index scan

### DIFF
--- a/pkg/sql/distsqlrun/index_skip_table_reader.go
+++ b/pkg/sql/distsqlrun/index_skip_table_reader.go
@@ -76,10 +76,8 @@ func newIndexSkipTableReader(
 
 	// as of now, we don't support interleaved tables, so
 	// error our if there is an index that is interleaved
-	for _, idx := range spec.Table.AllNonDropIndexes() {
-		if len(idx.InterleavedBy) > 0 {
-			return nil, errors.Errorf("Interleaved tables are not supported as of now.")
-		}
+	if spec.Table.IsInterleaved() {
+		return nil, errors.Errorf("Interleaved tables are not supported as of now.")
 	}
 
 	t := istrPool.Get().(*indexSkipTableReader)


### PR DESCRIPTION
Fixing the interleave check for the loose index scan while interleave support is in progress.