### PR TITLE
opt: opaque relational operator

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/statement_statistics
+++ b/pkg/sql/logictest/testdata/logic_test/statement_statistics
@@ -127,7 +127,7 @@ SET CLUSTER SETTING "debug.panic_on_failed_assertions" = DEFAULT  -
 SET CLUSTER SETTING "debug.panic_on_failed_assertions" = _        -
 SET application_name = _                                          -
 SET distsql = "on"                                                -
-SHOW CLUSTER SETTING "debug.panic_on_failed_assertions"           -
+SHOW CLUSTER SETTING "debug.panic_on_failed_assertions"           ·
 SHOW application_name                                             ·
 
 # Check that names are anonymized properly:

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -1,0 +1,86 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+	"reflect"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/errors"
+)
+
+type opaqueMetadata struct {
+	info string
+	plan planNode
+}
+
+var _ opt.OpaqueMetadata = &opaqueMetadata{}
+
+func (o *opaqueMetadata) ImplementsOpaqueMetadata() {}
+func (o *opaqueMetadata) String() string            { return o.info }
+
+func buildOpaque(
+	ctx context.Context, semaCtx *tree.SemaContext, evalCtx *tree.EvalContext, stmt tree.Statement,
+) (opt.OpaqueMetadata, sqlbase.ResultColumns, error) {
+	p := evalCtx.Planner.(*planner)
+
+	var plan planNode
+	var err error
+	switch n := stmt.(type) {
+	case *tree.ShowClusterSetting:
+		plan, err = p.ShowClusterSetting(ctx, n)
+
+	case *tree.ShowHistogram:
+		plan, err = p.ShowHistogram(ctx, n)
+
+	case *tree.ShowTableStats:
+		plan, err = p.ShowTableStats(ctx, n)
+
+	case *tree.ShowTraceForSession:
+		plan, err = p.ShowTrace(ctx, n)
+
+	case *tree.ShowZoneConfig:
+		plan, err = p.ShowZoneConfig(ctx, n)
+
+	case *tree.ShowFingerprints:
+		plan, err = p.ShowFingerprints(ctx, n)
+
+	default:
+		return nil, nil, errors.AssertionFailedf("unknown opaque statement %T", stmt)
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	res := &opaqueMetadata{
+		info: strings.TrimPrefix(reflect.TypeOf(stmt).String(), "*tree."),
+		plan: plan,
+	}
+	return res, planColumns(plan), nil
+}
+
+func init() {
+	opaqueStmts := []reflect.Type{
+		reflect.TypeOf(&tree.ShowClusterSetting{}),
+		reflect.TypeOf(&tree.ShowHistogram{}),
+		reflect.TypeOf(&tree.ShowTableStats{}),
+		reflect.TypeOf(&tree.ShowTraceForSession{}),
+		reflect.TypeOf(&tree.ShowZoneConfig{}),
+		reflect.TypeOf(&tree.ShowFingerprints{}),
+	}
+	for _, t := range opaqueStmts {
+		optbuilder.RegisterOpaque(t, buildOpaque)
+	}
+}

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -285,3 +285,7 @@ func (f *stubFactory) ConstructErrorIfRows(
 ) (exec.Node, error) {
 	return struct{}{}, nil
 }
+
+func (f *stubFactory) ConstructOpaque(metadata opt.OpaqueMetadata) (exec.Node, error) {
+	return struct{}{}, nil
+}

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -401,6 +401,9 @@ type Factory interface {
 	// results, but errors out if the input returns any rows. The mkErr function
 	// is used to create the error.
 	ConstructErrorIfRows(input Node, mkErr func(tree.Datums) error) (Node, error)
+
+	// ConstructOpaque creates a node for an opaque operator.
+	ConstructOpaque(metadata opt.OpaqueMetadata) (Node, error)
 }
 
 // OutputOrdering indicates the required output ordering on a Node that is being

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -187,7 +187,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 
 	case *ScanExpr, *VirtualScanExpr, *IndexJoinExpr, *ShowTraceForSessionExpr,
 		*InsertExpr, *UpdateExpr, *UpsertExpr, *DeleteExpr, *SequenceSelectExpr,
-		*WindowExpr:
+		*WindowExpr, *OpaqueRelExpr:
 		fmt.Fprintf(f.Buffer, "%v", e.Op())
 		FormatPrivate(f, e.Private(), required)
 
@@ -962,6 +962,10 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 		if !t.Any() {
 			fmt.Fprintf(f.Buffer, " ordering=%s", t)
 		}
+
+	case *OpaqueRelPrivate:
+		f.Buffer.WriteByte(' ')
+		f.Buffer.WriteString(t.Metadata.String())
 
 	case *JoinPrivate:
 		// Nothing to show; flags are shown separately.

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -575,6 +575,10 @@ func (h *hasher) HashPresentation(val physical.Presentation) {
 	}
 }
 
+func (h *hasher) HashOpaqueMetadata(val opt.OpaqueMetadata) {
+	h.HashUint64(uint64(reflect.ValueOf(val).Pointer()))
+}
+
 func (h *hasher) HashPointer(val unsafe.Pointer) {
 	h.HashUint64(uint64(uintptr(val)))
 }
@@ -894,6 +898,10 @@ func (h *hasher) IsPresentationEqual(l, r physical.Presentation) bool {
 		}
 	}
 	return true
+}
+
+func (h *hasher) IsOpaqueMetadataEqual(l, r opt.OpaqueMetadata) bool {
+	return l == r
 }
 
 // encodeDatum turns the given datum into an encoded string of bytes. If two

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -712,7 +712,7 @@ func (b *logicalPropsBuilder) buildExplainProps(explain *ExplainExpr, rel *props
 	// Statistics
 	// ----------
 	if !b.disableStats {
-		b.sb.buildExplain(rel)
+		b.sb.buildUnknown(rel)
 	}
 }
 
@@ -746,7 +746,7 @@ func (b *logicalPropsBuilder) buildShowTraceForSessionProps(
 	// Statistics
 	// ----------
 	if !b.disableStats {
-		b.sb.buildShowTrace(rel)
+		b.sb.buildUnknown(rel)
 	}
 
 }
@@ -1782,6 +1782,39 @@ func (h *joinPropsHelper) cardinality() props.Cardinality {
 
 	default:
 		return innerJoinCard
+	}
+}
+
+func (b *logicalPropsBuilder) buildOpaqueRelProps(op *OpaqueRelExpr, rel *props.Relational) {
+	BuildSharedProps(b.mem, op, &rel.Shared)
+	rel.CanHaveSideEffects = true
+	rel.CanMutate = true
+
+	// Output Columns
+	// --------------
+	rel.OutputCols = op.Columns.ToSet()
+
+	// Not Null Columns
+	// ----------------
+	// All columns are assumed to be nullable.
+
+	// Outer Columns
+	// -------------
+	// No outer columns.
+
+	// Functional Dependencies
+	// -----------------------
+	// None.
+
+	// Cardinality
+	// -----------
+	// Any.
+	rel.Cardinality = props.AnyCardinality
+
+	// Statistics
+	// ----------
+	if !b.disableStats {
+		b.sb.buildUnknown(rel)
 	}
 }
 

--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -276,6 +276,16 @@ func AggregateIsNullOnEmpty(op Operator) bool {
 	return false
 }
 
+// OpaqueMetadata is an object stored in OpaqueRelExpr and passed
+// through to the exec factory.
+type OpaqueMetadata interface {
+	ImplementsOpaqueMetadata()
+
+	// String is used when printing optimizer trees and should contain a short
+	// description of the statement.
+	String() string
+}
+
 func init() {
 	for optOp, treeOp := range ComparisonOpReverseMap {
 		ComparisonOpMap[treeOp] = optOp

--- a/pkg/sql/opt/ops/statement.opt
+++ b/pkg/sql/opt/ops/statement.opt
@@ -69,3 +69,24 @@ define ShowTracePrivate {
     # ColList stores the column IDs for the SHOW TRACE columns.
     ColList ColList
 }
+
+# OpaqueRel is an opaque relational operator which is planned outside of the
+# optimizer. The operator contains an opaque metadata which is passed to the
+# exec factory.
+#
+# This is used for statements that are not directly supported by the optimizer,
+# and which don't use the result of other relational expressions (in other
+# words, they are a "leaf" operator).
+#
+# OpaqueRel can produce data and can be used as a data source as part of a
+# larger enclosing query.
+[Relational, DDL, Mutation]
+define OpaqueRel {
+    _ OpaqueRelPrivate
+}
+
+[Private]
+define OpaqueRelPrivate {
+    Columns ColList
+    Metadata OpaqueMetadata 
+}

--- a/pkg/sql/opt/optbuilder/opaque.go
+++ b/pkg/sql/opt/optbuilder/opaque.go
@@ -1,0 +1,54 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package optbuilder
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+)
+
+// BuildOpaqueFn is a handler for building the metadata for an opaque statement.
+type BuildOpaqueFn func(
+	context.Context, *tree.SemaContext, *tree.EvalContext, tree.Statement,
+) (opt.OpaqueMetadata, sqlbase.ResultColumns, error)
+
+// RegisterOpaque registers an opaque handler for a specific statement type.
+func RegisterOpaque(stmtType reflect.Type, fn BuildOpaqueFn) {
+	opaqueStatements[stmtType] = fn
+}
+
+var opaqueStatements = make(map[reflect.Type]BuildOpaqueFn)
+
+func (b *Builder) tryBuildOpaque(stmt tree.Statement, inScope *scope) (outScope *scope) {
+	fn, ok := opaqueStatements[reflect.TypeOf(stmt)]
+	if !ok {
+		return nil
+	}
+	obj, cols, err := fn(b.ctx, b.semaCtx, b.evalCtx, stmt)
+	if err != nil {
+		panic(builderError{err})
+	}
+	outScope = inScope.push()
+	for i := range cols {
+		col := b.synthesizeColumn(outScope, cols[i].Name, cols[i].Typ, nil /* expr */, nil /* scalar */)
+		col.hidden = cols[i].Hidden
+	}
+	outScope.expr = b.factory.ConstructOpaqueRel(&memo.OpaqueRelPrivate{
+		Columns:  colsToColList(outScope.cols),
+		Metadata: obj,
+	})
+	return outScope
+}

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -166,8 +166,7 @@ func (b *Builder) expandStarAndResolveType(
 //        the AS keyword).
 // typ    The type of the column.
 // expr   The expression this column refers to (if any).
-// group  The memo group ID of this column/expression (if any). This parameter
-//        is optional and can be set later in the returned scopeColumn.
+// scalar The scalar expression associated with this column (if any).
 //
 // The new column is returned as a scopeColumn object.
 func (b *Builder) synthesizeColumn(

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/validate
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/validate
@@ -10,23 +10,13 @@ define True {}
 test.opt:3:1: Name rule is missing "Normalize" or "Explore" tag
 
 #
-# Ensure that types are defined.
-#
-optgen compile test.opt
-define Not {
-    Input Node
-}
-----
-test.opt:2:5: Node is not registered as a valid type in metadata.go
-
-#
 # Ensure that there is only one private field in define, and that it is the
 # last field.
 #
 optgen compile test.opt
 define Op {
     Private Type
-    Other   Node
+    Other   RelExpr
 }
 
 define Op2 {

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1583,6 +1583,15 @@ func (ef *execFactory) ConstructErrorIfRows(
 	}, nil
 }
 
+// ConstructOpaque is part of the exec.Factory interface.
+func (ef *execFactory) ConstructOpaque(metadata opt.OpaqueMetadata) (exec.Node, error) {
+	o, ok := metadata.(*opaqueMetadata)
+	if !ok {
+		return nil, errors.AssertionFailedf("unexpected OpaqueMetadata object type %T", metadata)
+	}
+	return o.plan, nil
+}
+
 // renderBuilder encapsulates the code to build a renderNode.
 type renderBuilder struct {
 	r   *renderNode


### PR DESCRIPTION
#### optgen: panic early on unknown type

I had a case where adding an unknown type to a private resulted in a
cryptic segmentation violation. Normally an unknown type would
generate an error in the validator but in this case we don't get that
far.

This change makes optgen panic immediately when it encounters an
unknown type.

Release note: None

#### opt: opaque relational operator

We introduce `OpaqueRel`: a relational operator which contains a plan
generated outside of the optimizer.

External code registers an "opaque handler" for a specific AST node
type; the opaque handler generates the plan and returns it as "opaque
metadata". The opaque metadata is later passed to the exec factory.

In this change we add opaque handlers for all remaining SHOW variants
which use a custom planNode (and thus cannot be `delegate`d).

Informs #34848.

Release note: None
