### PR TITLE
opt: add preliminary support for histograms in the optimizer 

### DIFF
--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -167,8 +167,7 @@ type TableStatistic interface {
 
 	// DistinctCount returns the estimated number of distinct values on the
 	// columns of the statistic. If there are multiple columns, each "value" is a
-	// tuple with the values on each column. Rows where any statistic column have
-	// a NULL don't contribute to this count.
+	// tuple with the values on each column.
 	DistinctCount() uint64
 
 	// NullCount returns the estimated number of rows which have a NULL value on

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -174,7 +174,29 @@ type TableStatistic interface {
 	// any column in the statistic.
 	NullCount() uint64
 
-	// TODO(radu): add Histogram().
+	// Histogram returns a slice of histogram buckets, sorted by UpperBound.
+	// It is only used for single-column stats (i.e., when ColumnCount() = 1),
+	// and it represents the distribution of values for that column.
+	// See HistogramBucket for more details.
+	Histogram() []HistogramBucket
+}
+
+// HistogramBucket contains the data for a single histogram bucket.
+type HistogramBucket struct {
+	// NumEq is the estimated number of values equal to UpperBound.
+	NumEq uint64
+
+	// NumRange is the estimated number of values between the lower bound of the
+	// bucket and UpperBound (both boundaries are exclusive).
+	//
+	// The lower bound is inferred based on the location of this bucket in a
+	// slice of buckets. If it is the first bucket, the lower bound is the minimum
+	// possible value for the given data type. Otherwise, the lower bound is equal
+	// to the upper bound of the previous bucket.
+	NumRange uint64
+
+	// UpperBound is the upper bound of the bucket.
+	UpperBound tree.Datum
 }
 
 // ForeignKeyConstraint represents a foreign key constraint. A foreign key

--- a/pkg/sql/opt/constraint/constraint_test.go
+++ b/pkg/sql/opt/constraint/constraint_test.go
@@ -189,13 +189,13 @@ func TestConstraintContainsSpan(t *testing.T) {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			c := ParseConstraint(&evalCtx, tc.constraint)
 
-			spans := parseSpans(tc.containedSpans)
+			spans := parseSpans(&evalCtx, tc.containedSpans)
 			for i := 0; i < spans.Count(); i++ {
 				if sp := spans.Get(i); !c.ContainsSpan(&evalCtx, sp) {
 					t.Errorf("%s should contain span %s", c, sp)
 				}
 			}
-			spans = parseSpans(tc.notContainedSpans)
+			spans = parseSpans(&evalCtx, tc.notContainedSpans)
 			for i := 0; i < spans.Count(); i++ {
 				if sp := spans.Get(i); c.ContainsSpan(&evalCtx, sp) {
 					t.Errorf("%s should not contain span %s", c, sp)
@@ -258,6 +258,8 @@ func TestConstraintCombine(t *testing.T) {
 
 func TestConsolidateSpans(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
 
 	testData := []struct {
 		s string
@@ -301,7 +303,7 @@ func TestConsolidateSpans(t *testing.T) {
 	kc := testKeyContext(1, 2, -3)
 	for i, tc := range testData {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			spans := parseSpans(tc.s)
+			spans := parseSpans(&evalCtx, tc.s)
 			var c Constraint
 			c.Init(kc, &spans)
 			c.ConsolidateSpans(kc.EvalCtx)
@@ -314,6 +316,8 @@ func TestConsolidateSpans(t *testing.T) {
 
 func TestExactPrefix(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
 
 	testData := []struct {
 		s string
@@ -361,7 +365,7 @@ func TestExactPrefix(t *testing.T) {
 	kc := testKeyContext(1, 2, 3)
 	for i, tc := range testData {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			spans := parseSpans(tc.s)
+			spans := parseSpans(&evalCtx, tc.s)
 			var c Constraint
 			c.Init(kc, &spans)
 			if res := c.ExactPrefix(kc.EvalCtx); res != tc.e {

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -461,6 +461,11 @@ func (sb *statisticsBuilder) makeTableStatistics(tabID opt.TableID) *props.Stati
 			if colStat, ok := stats.ColStats.Add(cols); ok {
 				colStat.DistinctCount = float64(stat.DistinctCount())
 				colStat.NullCount = float64(stat.NullCount())
+				if cols.Len() == 1 && stat.Histogram() != nil {
+					col, _ := cols.Next(0)
+					colStat.Histogram = &props.Histogram{}
+					colStat.Histogram.Init(sb.evalCtx, col, stat.Histogram())
+				}
 
 				// Make sure the distinct count is at least 1, for the same reason as
 				// the row count above.
@@ -496,10 +501,10 @@ func (sb *statisticsBuilder) buildScan(scan *ScanExpr, relProps *props.Relationa
 	s.RowCount = inputStats.RowCount
 
 	if scan.Constraint != nil {
-		// Calculate distinct counts for constrained columns
-		// -------------------------------------------------
+		// Calculate distinct counts and histograms for constrained columns
+		// ----------------------------------------------------------------
 		var numUnappliedConjuncts float64
-		var cols opt.ColSet
+		var constrainedCols, histCols opt.ColSet
 		// Inverted indexes are a special case; a constraint like:
 		// /1: [/'{"a": "b"}' - /'{"a": "b"}']
 		// does not necessarily mean there is only going to be one distinct
@@ -513,20 +518,21 @@ func (sb *statisticsBuilder) buildScan(scan *ScanExpr, relProps *props.Relationa
 				numUnappliedConjuncts += sb.numConjunctsInConstraint(scan.Constraint, i)
 			}
 		} else {
-			cols = sb.applyIndexConstraint(scan.Constraint, scan, relProps)
+			constrainedCols, histCols = sb.applyIndexConstraint(scan.Constraint, scan, relProps)
 		}
 
 		// Calculate row count and selectivity
 		// -----------------------------------
 		inputRowCount := s.RowCount
-		s.ApplySelectivity(sb.selectivityFromDistinctCounts(cols, scan, s))
+		s.ApplySelectivity(sb.selectivityFromHistograms(histCols, scan, s))
+		s.ApplySelectivity(sb.selectivityFromDistinctCounts(constrainedCols.Difference(histCols), scan, s))
 		s.ApplySelectivity(sb.selectivityFromUnappliedConjuncts(numUnappliedConjuncts))
 
 		// Set null counts to 0 for non-nullable columns
 		// -------------------------------------------------
 		sb.updateNullCountsFromProps(scan, relProps, inputStats.RowCount)
 
-		s.ApplySelectivity(sb.selectivityFromNullCounts(cols, scan, s, inputRowCount))
+		s.ApplySelectivity(sb.selectivityFromNullCounts(constrainedCols, scan, s, inputRowCount))
 	}
 
 	sb.finalizeFromCardinality(relProps)
@@ -604,9 +610,9 @@ func (sb *statisticsBuilder) buildSelect(sel *SelectExpr, relProps *props.Relati
 	}
 	equivReps := equivFD.EquivReps()
 
-	// Calculate distinct counts for constrained columns
-	// -------------------------------------------------
-	numUnappliedConjuncts, constrainedCols := sb.applyFilter(sel.Filters, sel, relProps)
+	// Calculate distinct counts and histograms for constrained columns
+	// ----------------------------------------------------------------
+	numUnappliedConjuncts, constrainedCols, histCols := sb.applyFilter(sel.Filters, sel, relProps)
 
 	// Try to reduce the number of columns used for selectivity
 	// calculation based on functional dependencies.
@@ -619,7 +625,8 @@ func (sb *statisticsBuilder) buildSelect(sel *SelectExpr, relProps *props.Relati
 	inputStats := &sel.Input.Relational().Stats
 	s.RowCount = inputStats.RowCount
 	inputRowCount := s.RowCount
-	s.ApplySelectivity(sb.selectivityFromDistinctCounts(constrainedCols, sel, s))
+	s.ApplySelectivity(sb.selectivityFromHistograms(histCols, sel, s))
+	s.ApplySelectivity(sb.selectivityFromDistinctCounts(constrainedCols.Difference(histCols), sel, s))
 	s.ApplySelectivity(sb.selectivityFromEquivalencies(equivReps, &relProps.FuncDeps, sel, s))
 	s.ApplySelectivity(sb.selectivityFromUnappliedConjuncts(numUnappliedConjuncts))
 
@@ -831,7 +838,8 @@ func (sb *statisticsBuilder) buildJoin(
 
 	// Calculate distinct counts for constrained columns in the ON conditions
 	// ----------------------------------------------------------------------
-	numUnappliedConjuncts, constrainedCols := sb.applyFilter(h.filters, join, relProps)
+	// TODO(rytaft): use histogram for joins.
+	numUnappliedConjuncts, constrainedCols, _ := sb.applyFilter(h.filters, join, relProps)
 
 	// Try to reduce the number of columns used for selectivity
 	// calculation based on functional dependencies.
@@ -1310,7 +1318,8 @@ func (sb *statisticsBuilder) buildZigzagJoin(
 	// still have corresponding filters in zigzag.On. So we don't need
 	// to iterate through FixedCols here if we are already processing the ON
 	// clause.
-	numUnappliedConjuncts, constrainedCols := sb.applyFilter(zigzag.On, zigzag, relProps)
+	// TODO(rytaft): use histogram for zig zag join.
+	numUnappliedConjuncts, constrainedCols, _ := sb.applyFilter(zigzag.On, zigzag, relProps)
 
 	// Application of constraints on inverted indexes needs to be handled a
 	// little differently since a constraint on an inverted index key column
@@ -2108,6 +2117,9 @@ func (sb *statisticsBuilder) copyColStat(
 	colStat, _ := s.ColStats.Add(colSet)
 	colStat.DistinctCount = inputColStat.DistinctCount
 	colStat.NullCount = inputColStat.NullCount
+	if inputColStat.Histogram != nil {
+		colStat.Histogram = inputColStat.Histogram.Copy()
+	}
 	return colStat
 }
 
@@ -2185,6 +2197,15 @@ func (sb *statisticsBuilder) finalizeFromRowCount(
 	// The distinct and null counts should be no larger than the row count.
 	colStat.DistinctCount = min(colStat.DistinctCount, rowCount)
 	colStat.NullCount = min(colStat.NullCount, rowCount)
+
+	// Uniformly reduce the size of each histogram bucket so the number of values
+	// is no larger than the row count.
+	if colStat.Histogram != nil {
+		valuesCount := colStat.Histogram.ValuesCount()
+		if valuesCount > rowCount {
+			colStat.Histogram.ApplySelectivity(rowCount / valuesCount)
+		}
+	}
 }
 
 func min(a float64, b float64) float64 {
@@ -2261,9 +2282,10 @@ func countJSONPaths(conjunct *FiltersItem) int {
 	return len(paths)
 }
 
-// applyFilter uses constraints to update the distinct counts for the
-// constrained columns in the filter. The changes in the distinct counts will be
-// used later to determine the selectivity of the filter.
+// applyFilter uses constraints to update the distinct counts and histograms
+// for the constrained columns in the filter. The changes in the distinct
+// counts and histograms will be used later to determine the selectivity of
+// the filter.
 //
 // Some filters can be translated directly to distinct counts using the
 // constraint set. For example, the tight constraint `/a: [/1 - /1]` indicates
@@ -2280,7 +2302,7 @@ func countJSONPaths(conjunct *FiltersItem) int {
 //
 func (sb *statisticsBuilder) applyFilter(
 	filters FiltersExpr, e RelExpr, relProps *props.Relational,
-) (numUnappliedConjuncts float64, constrainedCols opt.ColSet) {
+) (numUnappliedConjuncts float64, constrainedCols, histCols opt.ColSet) {
 	applyConjunct := func(conjunct *FiltersItem) {
 		if isEqualityWithTwoVars(conjunct.Condition) {
 			// We'll handle equalities later.
@@ -2316,7 +2338,8 @@ func (sb *statisticsBuilder) applyFilter(
 		scalarProps := conjunct.ScalarProps(e.Memo())
 		constrainedCols.UnionWith(scalarProps.OuterCols)
 		if scalarProps.Constraints != nil {
-			sb.applyConstraintSet(scalarProps.Constraints, e, relProps)
+			histColsLocal := sb.applyConstraintSet(scalarProps.Constraints, e, relProps)
+			histCols.UnionWith(histColsLocal)
 			if !scalarProps.TightConstraints {
 				numUnappliedConjuncts++
 			}
@@ -2329,12 +2352,15 @@ func (sb *statisticsBuilder) applyFilter(
 		applyConjunct(&filters[i])
 	}
 
-	return numUnappliedConjuncts, constrainedCols
+	return numUnappliedConjuncts, constrainedCols, histCols
 }
 
+// applyIndexConstraint is used to update the distinct counts and histograms
+// for the constrained columns in an index constraint. Returns the set of
+// constrained columns and the set of columns with a filtered histogram.
 func (sb *statisticsBuilder) applyIndexConstraint(
 	c *constraint.Constraint, e RelExpr, relProps *props.Relational,
-) (constrainedCols opt.ColSet) {
+) (constrainedCols, histCols opt.ColSet) {
 	// If unconstrained, then no constraint could be derived from the expression,
 	// so fall back to estimate.
 	// If a contradiction, then optimizations must not be enabled (say for
@@ -2343,6 +2369,7 @@ func (sb *statisticsBuilder) applyIndexConstraint(
 		return
 	}
 
+	// Calculate distinct counts.
 	applied := sb.updateDistinctCountsFromConstraint(c, e, relProps)
 	for i, n := 0, c.ConstrainedColumns(sb.evalCtx); i < n; i++ {
 		col := c.Columns.Get(i).ID()
@@ -2361,20 +2388,35 @@ func (sb *statisticsBuilder) applyIndexConstraint(
 		sb.updateDistinctCountFromUnappliedConjuncts(col, e, relProps, numConjuncts)
 	}
 
-	return constrainedCols
+	// Calculate histogram.
+	inputStat := sb.colStatFromInput(constrainedCols, e)
+	inputHist := inputStat.Histogram
+	if inputHist != nil && inputHist.CanFilter(c) {
+		s := &relProps.Stats
+		if colStat, ok := s.ColStats.Lookup(constrainedCols); ok {
+			colStat.Histogram = inputHist.Filter(c)
+			histCols = constrainedCols
+		}
+	}
+
+	return constrainedCols, histCols
 }
 
+// applyConstraintSet is used to update the distinct counts and histograms
+// for the constrained columns in a constraint set. Returns the set of
+// columns with a filtered histogram.
 func (sb *statisticsBuilder) applyConstraintSet(
 	cs *constraint.Set, e RelExpr, relProps *props.Relational,
-) {
+) (histCols opt.ColSet) {
 	// If unconstrained, then no constraint could be derived from the expression,
 	// so fall back to estimate.
 	// If a contradiction, then optimizations must not be enabled (say for
 	// testing), or else this would have been reduced.
 	if cs.IsUnconstrained() || cs == constraint.Contradiction {
-		return
+		return opt.ColSet{}
 	}
 
+	s := &relProps.Stats
 	for i := 0; i < cs.Length(); i++ {
 		c := cs.Constraint(i)
 		col := c.Columns.Get(0).ID()
@@ -2393,7 +2435,20 @@ func (sb *statisticsBuilder) applyConstraintSet(
 			// according to unknownDistinctCountRatio.
 			sb.updateDistinctCountFromUnappliedConjuncts(col, e, relProps, numConjuncts)
 		}
+
+		// Calculate histogram.
+		cols := opt.MakeColSet(col)
+		inputStat := sb.colStatFromInput(cols, e)
+		inputHist := inputStat.Histogram
+		if inputHist != nil && inputHist.CanFilter(c) {
+			if colStat, ok := s.ColStats.Lookup(cols); ok {
+				colStat.Histogram = inputHist.Filter(c)
+				histCols.UnionWith(cols)
+			}
+		}
 	}
+
+	return histCols
 }
 
 // updateNullCountsFromProps zeroes null counts for columns that cannot
@@ -2632,11 +2687,48 @@ func (sb *statisticsBuilder) selectivityFromDistinctCounts(
 		newDistinct := colStat.DistinctCount
 		oldDistinct := inputStat.DistinctCount
 
-		if oldDistinct != 0 && newDistinct < oldDistinct {
+		if newDistinct < oldDistinct {
 			selectivity *= newDistinct / oldDistinct
 		}
 	}
 
+	return selectivity
+}
+
+// selectivityFromHistograms is similar to selectivityFromDistinctCounts, in
+// that it calculates the selectivity of a filter by taking the product of
+// selectivities of each constrained column.
+//
+// For histograms, the selectivity of a constrained column is calculated as
+// (# values in histogram after filter) / (# values in histogram before filter).
+func (sb *statisticsBuilder) selectivityFromHistograms(
+	cols opt.ColSet, e RelExpr, s *props.Statistics,
+) (selectivity float64) {
+	selectivity = 1.0
+	for col, ok := cols.Next(0); ok; col, ok = cols.Next(col + 1) {
+		colStat, ok := s.ColStats.Lookup(opt.MakeColSet(col))
+		if !ok {
+			continue
+		}
+
+		inputStat := sb.colStatFromInput(colStat.Cols, e)
+		newHist := colStat.Histogram
+		oldHist := inputStat.Histogram
+		if newHist == nil || oldHist == nil {
+			continue
+		}
+
+		newCount := newHist.ValuesCount()
+		oldCount := oldHist.ValuesCount()
+		if newCount == 0 {
+			// Make sure the count is non-zero. The stats may be stale, and we
+			// can end up with weird and inefficient plans if we estimate 0 rows.
+			newCount = min(1, oldCount)
+		}
+		if newCount < oldCount {
+			selectivity *= newCount / oldCount
+		}
+	}
 	return selectivity
 }
 

--- a/pkg/sql/opt/memo/statistics_builder_test.go
+++ b/pkg/sql/opt/memo/statistics_builder_test.go
@@ -116,13 +116,12 @@ func TestGetStatsFromConstraint(t *testing.T) {
 		s.Init(relProps)
 
 		// Calculate distinct counts.
-		numUnappliedConjuncts := sb.applyConstraintSet(cs, sel, relProps)
+		sb.applyConstraintSet(cs, sel, relProps)
 
 		// Calculate row count and selectivity.
 		s.RowCount = scan.Relational().Stats.RowCount
 		savedRowCount := s.RowCount
 		s.ApplySelectivity(sb.selectivityFromDistinctCounts(cols, sel, s))
-		s.ApplySelectivity(sb.selectivityFromUnappliedConjuncts(numUnappliedConjuncts))
 
 		// Update null counts.
 		sb.updateNullCountsFromProps(sel, relProps, savedRowCount)
@@ -163,7 +162,7 @@ func TestGetStatsFromConstraint(t *testing.T) {
 	cs2 := constraint.SingleConstraint(&c2)
 	statsFunc(
 		cs2,
-		"[rows=3.33333333e+09, distinct(2)=500, null(2)=0]",
+		"[rows=3.33333333e+09, distinct(2)=166.666667, null(2)=0]",
 		1.0/3,
 	)
 

--- a/pkg/sql/opt/memo/testdata/format
+++ b/pkg/sql/opt/memo/testdata/format
@@ -30,7 +30,7 @@ sort
       │    ├── prune: (4)
       │    ├── select
       │    │    ├── columns: t.public.t.a:1(int) t.public.t.b:2(int!null) t.public.t.k:3(int!null)
-      │    │    ├── stats: [rows=330, distinct(1)=98.1771622, null(1)=3.3, distinct(2)=98.265847, null(2)=0, distinct(3)=330, null(3)=0]
+      │    │    ├── stats: [rows=330, distinct(1)=98.1771622, null(1)=3.3, distinct(2)=100, null(2)=0, distinct(3)=330, null(3)=0]
       │    │    ├── cost: 1070.03
       │    │    ├── key: (3)
       │    │    ├── fd: (3)-->(1,2)
@@ -76,7 +76,7 @@ sort
       │    ├── cost: 1080.92177
       │    ├── select
       │    │    ├── columns: t.public.t.a:1(int) t.public.t.b:2(int!null) t.public.t.k:3(int!null)
-      │    │    ├── stats: [rows=330, distinct(1)=98.1771622, null(1)=3.3, distinct(2)=98.265847, null(2)=0, distinct(3)=330, null(3)=0]
+      │    │    ├── stats: [rows=330, distinct(1)=98.1771622, null(1)=3.3, distinct(2)=100, null(2)=0, distinct(3)=330, null(3)=0]
       │    │    ├── cost: 1070.03
       │    │    ├── scan t.public.t
       │    │    │    ├── columns: t.public.t.a:1(int) t.public.t.b:2(int) t.public.t.k:3(int!null)
@@ -196,7 +196,7 @@ sort
       │    ├── fd: (1)-->(4)
       │    ├── prune: (4)
       │    ├── select
-      │    │    ├── stats: [rows=330, distinct(1)=98.1771622, null(1)=3.3, distinct(2)=98.265847, null(2)=0, distinct(3)=330, null(3)=0]
+      │    │    ├── stats: [rows=330, distinct(1)=98.1771622, null(1)=3.3, distinct(2)=100, null(2)=0, distinct(3)=330, null(3)=0]
       │    │    ├── cost: 1070.03
       │    │    ├── key: (3)
       │    │    ├── fd: (3)-->(1,2)

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -195,7 +195,7 @@ SELECT 1 AS a, 1+z AS b, left(x, 10)::TIMESTAMP AS c, left(x, 10)::TIMESTAMPTZ A
 FROM b
 WHERE z=1 AND concat(x, 'foo', x)=concat(x, 'foo', x)
 ----
-memo (optimized, ~3KB, required=[presentation: a:3,b:4,c:5,d:6])
+memo (optimized, ~4KB, required=[presentation: a:3,b:4,c:5,d:6])
  ├── G1: (project G2 G3)
  │    └── [presentation: a:3,b:4,c:5,d:6]
  │         ├── best: (project G2 G3)
@@ -365,7 +365,7 @@ memo (optimized, ~5KB, required=[presentation: field:3])
 memo
 SELECT DISTINCT tag FROM [SHOW TRACE FOR SESSION]
 ----
-memo (optimized, ~2KB, required=[presentation: tag:4])
+memo (optimized, ~3KB, required=[presentation: tag:4])
  ├── G1: (distinct-on G2 G3 cols=(4))
  │    └── [presentation: tag:4]
  │         ├── best: (distinct-on G2 G3 cols=(4))

--- a/pkg/sql/opt/memo/testdata/stats/insert
+++ b/pkg/sql/opt/memo/testdata/stats/insert
@@ -41,7 +41,7 @@ WHERE z > 1.0
 select
  ├── columns: x:1(string!null) y:2(int!null) z:3(float!null)
  ├── side-effects, mutations
- ├── stats: [rows=66, distinct(1)=1, null(1)=0, distinct(2)=66, null(2)=0, distinct(3)=60.3661899, null(3)=0]
+ ├── stats: [rows=66, distinct(1)=1, null(1)=0, distinct(2)=66, null(2)=0, distinct(3)=43.4214373, null(3)=0]
  ├── fd: ()-->(1)
  ├── insert xyz
  │    ├── columns: x:1(string!null) y:2(int!null) z:3(float)

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -891,7 +891,7 @@ left-join (merge)
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int) v:6(int) rowid:7(int)
  ├── left ordering: +1
  ├── right ordering: +5
- ├── stats: [rows=5000, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(5)=500, null(5)=1666.66667, distinct(2,3)=5000, null(2,3)=2525, distinct(3,5)=5000, null(3,5)=2525, distinct(1,2,7)=5000, null(1,2,7)=2500]
+ ├── stats: [rows=5000, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(5)=500, null(5)=1666.66667, distinct(6)=100, null(6)=1666.66667, distinct(2,3)=5000, null(2,3)=2525, distinct(3,5)=5000, null(3,5)=2525, distinct(1,2,7)=5000, null(1,2,7)=2500]
  ├── key: (1,7)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)
  ├── scan t.public.xysd
@@ -902,13 +902,13 @@ left-join (merge)
  │    └── ordering: +1
  ├── sort
  │    ├── columns: u:5(int) v:6(int!null) rowid:7(int!null)
- │    ├── stats: [rows=10000, distinct(5)=500, null(5)=5000, distinct(7)=10000, null(7)=0]
+ │    ├── stats: [rows=10000, distinct(5)=500, null(5)=5000, distinct(6)=100, null(6)=0, distinct(7)=10000, null(7)=0]
  │    ├── key: (7)
  │    ├── fd: (7)-->(5,6)
  │    ├── ordering: +5
  │    └── scan t.public.uv
  │         ├── columns: u:5(int) v:6(int!null) rowid:7(int!null)
- │         ├── stats: [rows=10000, distinct(5)=500, null(5)=5000, distinct(7)=10000, null(7)=0]
+ │         ├── stats: [rows=10000, distinct(5)=500, null(5)=5000, distinct(6)=100, null(6)=0, distinct(7)=10000, null(7)=0]
  │         ├── key: (7)
  │         └── fd: (7)-->(5,6)
  └── filters

--- a/pkg/sql/opt/memo/testdata/stats/lookup-join
+++ b/pkg/sql/opt/memo/testdata/stats/lookup-join
@@ -48,16 +48,16 @@ SELECT * FROM small JOIN abcd ON a=m WHERE n > 2
 inner-join (lookup abcd)
  ├── columns: m:1(int!null) n:2(int!null) a:4(int!null) b:5(int) c:6(int)
  ├── key columns: [7] = [7]
- ├── stats: [rows=33, distinct(1)=3.3, null(1)=0, distinct(2)=0.98265847, null(2)=0, distinct(4)=3.3, null(4)=0]
+ ├── stats: [rows=33, distinct(1)=3.3, null(1)=0, distinct(2)=0.333333333, null(2)=0, distinct(4)=3.3, null(4)=0]
  ├── fd: (1)==(4), (4)==(1)
  ├── inner-join (lookup abcd@secondary)
  │    ├── columns: m:1(int!null) n:2(int!null) a:4(int!null) b:5(int) abcd.rowid:7(int!null)
  │    ├── key columns: [1] = [4]
- │    ├── stats: [rows=33, distinct(1)=3.3, null(1)=0, distinct(2)=0.98265847, null(2)=0, distinct(4)=3.3, null(4)=0, distinct(7)=32.6221433, null(7)=0]
+ │    ├── stats: [rows=33, distinct(1)=3.3, null(1)=0, distinct(2)=0.333333333, null(2)=0, distinct(4)=3.3, null(4)=0, distinct(7)=32.6221433, null(7)=0]
  │    ├── fd: (7)-->(4,5), (1)==(4), (4)==(1)
  │    ├── select
  │    │    ├── columns: m:1(int) n:2(int!null)
- │    │    ├── stats: [rows=3.3, distinct(1)=3.3, null(1)=0, distinct(2)=0.98265847, null(2)=0]
+ │    │    ├── stats: [rows=3.3, distinct(1)=3.3, null(1)=0, distinct(2)=0.333333333, null(2)=0]
  │    │    ├── scan small
  │    │    │    ├── columns: m:1(int) n:2(int)
  │    │    │    └── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(2)=1, null(2)=0.1]
@@ -74,12 +74,12 @@ SELECT * FROM small JOIN abcd ON a=m WHERE b > 2
 inner-join (lookup abcd)
  ├── columns: m:1(int!null) n:2(int) a:4(int!null) b:5(int!null) c:6(int)
  ├── key columns: [7] = [7]
- ├── stats: [rows=33.6127051, distinct(1)=10, null(1)=0, distinct(4)=10, null(4)=0, distinct(5)=28.5893063, null(5)=0]
+ ├── stats: [rows=33.6127051, distinct(1)=10, null(1)=0, distinct(4)=10, null(4)=0, distinct(5)=21.2357454, null(5)=0]
  ├── fd: (1)==(4), (4)==(1)
  ├── inner-join (lookup abcd@secondary)
  │    ├── columns: m:1(int!null) n:2(int) a:4(int!null) b:5(int!null) abcd.rowid:7(int!null)
  │    ├── key columns: [1] = [4]
- │    ├── stats: [rows=33.3333333, distinct(1)=10, null(1)=0, distinct(4)=10, null(4)=0, distinct(5)=28.3867538, null(5)=0, distinct(7)=32.837752, null(7)=0]
+ │    ├── stats: [rows=33.3333333, distinct(1)=10, null(1)=0, distinct(4)=10, null(4)=0, distinct(5)=33.3333333, null(5)=0, distinct(7)=32.837752, null(7)=0]
  │    ├── fd: (7)-->(4,5), (1)==(4), (4)==(1)
  │    ├── scan small
  │    │    ├── columns: m:1(int) n:2(int)
@@ -95,7 +95,7 @@ SELECT * FROM small JOIN abcd ON a=m WHERE c>2
 inner-join (lookup abcd)
  ├── columns: m:1(int!null) n:2(int) a:4(int!null) b:5(int) c:6(int!null)
  ├── key columns: [7] = [7]
- ├── stats: [rows=33.6127051, distinct(1)=10, null(1)=0, distinct(4)=10, null(4)=0, distinct(6)=28.5893063, null(6)=0]
+ ├── stats: [rows=33.6127051, distinct(1)=10, null(1)=0, distinct(4)=10, null(4)=0, distinct(6)=21.2357454, null(6)=0]
  ├── fd: (1)==(4), (4)==(1)
  ├── inner-join (lookup abcd@secondary)
  │    ├── columns: m:1(int!null) n:2(int) a:4(int!null) b:5(int) abcd.rowid:7(int!null)
@@ -116,7 +116,7 @@ SELECT * FROM small JOIN abcd ON a=m AND b=n WHERE c>2
 inner-join (lookup abcd)
  ├── columns: m:1(int!null) n:2(int!null) a:4(int!null) b:5(int!null) c:6(int!null)
  ├── key columns: [7] = [7]
- ├── stats: [rows=0.342367862, distinct(1)=0.342367862, null(1)=0, distinct(2)=0.342367862, null(2)=0, distinct(4)=0.342367862, null(4)=0, distinct(5)=0.342367862, null(5)=0, distinct(6)=0.341789832, null(6)=0]
+ ├── stats: [rows=0.342367862, distinct(1)=0.342367862, null(1)=0, distinct(2)=0.342367862, null(2)=0, distinct(4)=0.342367862, null(4)=0, distinct(5)=0.342367862, null(5)=0, distinct(6)=0.340633209, null(6)=0]
  ├── fd: (1)==(4), (4)==(1), (2)==(5), (5)==(2)
  ├── inner-join (lookup abcd@secondary)
  │    ├── columns: m:1(int!null) n:2(int!null) a:4(int!null) b:5(int!null) abcd.rowid:7(int!null)

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -153,7 +153,7 @@ select
  ├── scan a@secondary
  │    ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
  │    ├── constraint: /-3/4: [/'foo' - /'bar'] [/'aaa' - /NULL)
- │    ├── stats: [rows=1000, distinct(1)=911.337892, null(1)=0, distinct(3)=2, null(3)=0, distinct(4)=294.797541, null(4)=0]
+ │    ├── stats: [rows=1000, distinct(1)=911.337892, null(1)=0, distinct(3)=0.666666667, null(3)=0, distinct(4)=294.797541, null(4)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(3,4), (3,4)-->(1)
  └── filters
@@ -170,7 +170,7 @@ select
  ├── scan a@secondary
  │    ├── columns: x:1(int!null) s:3(string) d:4(decimal!null)
  │    ├── constraint: /-3/4: [/'foo' - /'bar'] [/'aaa' - /NULL]
- │    ├── stats: [rows=1000, distinct(1)=911.337892, null(1)=0, distinct(4)=294.797541, null(4)=0]
+ │    ├── stats: [rows=1000, distinct(1)=911.337892, null(1)=0, distinct(3)=0.666666667, null(3)=0, distinct(4)=294.797541, null(4)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(3,4), (3,4)~~>(1)
  └── filters
@@ -197,7 +197,7 @@ select
  ├── scan a@secondary
  │    ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
  │    ├── constraint: /-3/4: [ - /'foobar'] [/'foo' - /'bar']
- │    ├── stats: [rows=1000, distinct(1)=911.337892, null(1)=0, distinct(3)=2, null(3)=0, distinct(4)=294.797541, null(4)=0]
+ │    ├── stats: [rows=1000, distinct(1)=911.337892, null(1)=0, distinct(3)=0.666666667, null(3)=0, distinct(4)=294.797541, null(4)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(3,4), (3,4)-->(1)
  └── filters
@@ -208,18 +208,18 @@ SELECT * FROM a WHERE ((s >= 'bar' AND s <= 'foo') OR (s >= 'foobar')) AND d > 5
 ----
 index-join a
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) b:5(bool)
- ├── stats: [rows=333.333333, distinct(1)=323.895037, null(1)=0, distinct(4)=207.616156, null(4)=0]
+ ├── stats: [rows=333.333333, distinct(1)=323.895037, null(1)=0, distinct(4)=100, null(4)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-5), (3,4)~~>(1,2,5)
  └── select
       ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
-      ├── stats: [rows=111.111111, distinct(1)=110.489355, null(1)=0, distinct(3)=2, null(3)=0, distinct(4)=97.0976681, null(4)=0]
+      ├── stats: [rows=111.111111, distinct(1)=110.489355, null(1)=0, distinct(3)=0.666666667, null(3)=0, distinct(4)=100, null(4)=0]
       ├── key: (1)
       ├── fd: (1)-->(3,4), (3,4)-->(1)
       ├── scan a@secondary
       │    ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
       │    ├── constraint: /-3/4: [ - /'foobar'] (/'foo'/5.0 - /'bar']
-      │    ├── stats: [rows=1000, distinct(1)=911.337892, null(1)=0, distinct(3)=2, null(3)=0, distinct(4)=294.797541, null(4)=0]
+      │    ├── stats: [rows=1000, distinct(1)=911.337892, null(1)=0, distinct(3)=0.666666667, null(3)=0, distinct(4)=300, null(4)=0]
       │    ├── key: (1)
       │    └── fd: (1)-->(3,4), (3,4)-->(1)
       └── filters
@@ -231,18 +231,18 @@ SELECT * FROM a WHERE ((s >= 'bar' AND s <= 'foo') OR (s >= 'foobar')) AND d <= 
 ----
 index-join a
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null) b:5(bool)
- ├── stats: [rows=333.333333, distinct(1)=323.895037, null(1)=0, distinct(3)=2, null(3)=0, distinct(4)=207.616156, null(4)=0]
+ ├── stats: [rows=333.333333, distinct(1)=323.895037, null(1)=0, distinct(3)=2, null(3)=0, distinct(4)=100, null(4)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-5), (3,4)-->(1,2,5)
  └── select
       ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
-      ├── stats: [rows=37.037037, distinct(1)=36.9747958, null(1)=0, distinct(3)=1.99999999, null(3)=0, distinct(4)=35.7721483, null(4)=0]
+      ├── stats: [rows=37.037037, distinct(1)=36.9747958, null(1)=0, distinct(3)=0.666666667, null(3)=0, distinct(4)=33.3333333, null(4)=0]
       ├── key: (1)
       ├── fd: (1)-->(3,4), (3,4)-->(1)
       ├── scan a@secondary
       │    ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
       │    ├── constraint: /-3/4: [ - /'foobar'/5.0] [/'foo' - /'bar'/5.0]
-      │    ├── stats: [rows=333.333333, distinct(1)=323.895037, null(1)=0, distinct(3)=2, null(3)=0, distinct(4)=207.616156, null(4)=0]
+      │    ├── stats: [rows=333.333333, distinct(1)=323.895037, null(1)=0, distinct(3)=0.666666667, null(3)=0, distinct(4)=100, null(4)=0]
       │    ├── key: (1)
       │    └── fd: (1)-->(3,4), (3,4)-->(1)
       └── filters
@@ -337,7 +337,7 @@ select
  ├── scan a@secondary
  │    ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
  │    ├── constraint: /-3/4: [/'foo' - /'bar'] [/'aaa' - /NULL)
- │    ├── stats: [rows=666.666667, distinct(1)=666.666667, null(1)=0, distinct(3)=2, null(3)=0, distinct(4)=294.797541, null(4)=0]
+ │    ├── stats: [rows=666.666667, distinct(1)=666.666667, null(1)=0, distinct(3)=0.666666667, null(3)=0, distinct(4)=294.797541, null(4)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(3,4), (3,4)-->(1)
  └── filters
@@ -354,7 +354,7 @@ select
  ├── scan a@secondary
  │    ├── columns: x:1(int!null) s:3(string) d:4(decimal!null)
  │    ├── constraint: /-3/4: [/'foo' - /'bar'] [/'aaa' - /NULL]
- │    ├── stats: [rows=1000, distinct(1)=911.337892, null(1)=0, distinct(4)=294.797541, null(4)=0]
+ │    ├── stats: [rows=1000, distinct(1)=911.337892, null(1)=0, distinct(3)=0.666666667, null(3)=1000, distinct(4)=294.797541, null(4)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(3,4), (3,4)~~>(1)
  └── filters
@@ -381,7 +381,7 @@ select
  ├── scan a@secondary
  │    ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
  │    ├── constraint: /-3/4: [ - /'foobar'] [/'foo' - /'bar']
- │    ├── stats: [rows=666.666667, distinct(1)=666.666667, null(1)=0, distinct(3)=2, null(3)=0, distinct(4)=294.797541, null(4)=0]
+ │    ├── stats: [rows=666.666667, distinct(1)=666.666667, null(1)=0, distinct(3)=0.666666667, null(3)=0, distinct(4)=294.797541, null(4)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(3,4), (3,4)-->(1)
  └── filters
@@ -392,18 +392,18 @@ SELECT * FROM a WHERE ((s >= 'bar' AND s <= 'foo') OR (s >= 'foobar')) AND d <= 
 ----
 index-join a
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null) b:5(bool)
- ├── stats: [rows=222.222222, distinct(1)=222.222222, null(1)=0, distinct(3)=2, null(3)=0, distinct(4)=207.616156, null(4)=0]
+ ├── stats: [rows=222.222222, distinct(1)=222.222222, null(1)=0, distinct(3)=2, null(3)=0, distinct(4)=100, null(4)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-5), (3,4)-->(1,2,5)
  └── select
       ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
-      ├── stats: [rows=24.691358, distinct(1)=24.691358, null(1)=0, distinct(3)=1.99999586, null(3)=0, distinct(4)=24.5913408, null(4)=0]
+      ├── stats: [rows=24.691358, distinct(1)=24.691358, null(1)=0, distinct(3)=0.666666667, null(3)=0, distinct(4)=24.691358, null(4)=0]
       ├── key: (1)
       ├── fd: (1)-->(3,4), (3,4)-->(1)
       ├── scan a@secondary
       │    ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
       │    ├── constraint: /-3/4: [ - /'foobar'/5.0] [/'foo' - /'bar'/5.0]
-      │    ├── stats: [rows=222.222222, distinct(1)=222.222222, null(1)=0, distinct(3)=2, null(3)=0, distinct(4)=207.616156, null(4)=0]
+      │    ├── stats: [rows=222.222222, distinct(1)=222.222222, null(1)=0, distinct(3)=0.666666667, null(3)=0, distinct(4)=100, null(4)=0]
       │    ├── key: (1)
       │    └── fd: (1)-->(3,4), (3,4)-->(1)
       └── filters

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -565,3 +565,331 @@ project
  │         └── variable: col1 [type=bool, outer=(23), constraints=(/23: [/true - /true]; tight), fd=()-->(23)]
  └── projections
       └── const: 1 [type=int]
+
+# ---------------------
+# Tests with Histograms
+# ---------------------
+
+exec-ddl
+CREATE TABLE hist (
+  a INT,
+  b DATE,
+  c DECIMAL,
+  d FLOAT,
+  e TIMESTAMP,
+  f TIMESTAMPTZ,
+  g STRING,
+  INDEX idx_a (a),
+  INDEX idx_b (b),
+  INDEX idx_c (c),
+  INDEX idx_d (d),
+  INDEX idx_e (e),
+  INDEX idx_f (f),
+  INDEX idx_g (g)
+)
+----
+
+exec-ddl
+ALTER TABLE hist INJECT STATISTICS '[
+  {
+    "columns": ["a"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "upper_bound": "0"},
+      {"num_eq": 10, "num_range": 90, "upper_bound": "10"},
+      {"num_eq": 20, "num_range": 180, "upper_bound": "20"},
+      {"num_eq": 30, "num_range": 270, "upper_bound": "30"},
+      {"num_eq": 40, "num_range": 360, "upper_bound": "40"}
+    ]
+  },
+  {
+    "columns": ["b"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "histo_col_type": "date",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "upper_bound": "2018-06-30"},
+      {"num_eq": 10, "num_range": 90, "upper_bound": "2018-07-31"},
+      {"num_eq": 20, "num_range": 180, "upper_bound": "2018-08-31"},
+      {"num_eq": 30, "num_range": 270, "upper_bound": "2018-09-30"},
+      {"num_eq": 40, "num_range": 360, "upper_bound": "2018-10-31"}
+    ]
+  },
+  {
+    "columns": ["c"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "histo_col_type": "decimal",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "upper_bound": "0"},
+      {"num_eq": 10, "num_range": 90, "upper_bound": "10"},
+      {"num_eq": 20, "num_range": 180, "upper_bound": "20"},
+      {"num_eq": 30, "num_range": 270, "upper_bound": "30"},
+      {"num_eq": 40, "num_range": 360, "upper_bound": "40"}
+    ]
+  },
+  {
+    "columns": ["d"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "histo_col_type": "float",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "upper_bound": "0"},
+      {"num_eq": 10, "num_range": 90, "upper_bound": "10"},
+      {"num_eq": 20, "num_range": 180, "upper_bound": "20"},
+      {"num_eq": 30, "num_range": 270, "upper_bound": "30"},
+      {"num_eq": 40, "num_range": 360, "upper_bound": "40"}
+    ]
+  },
+  {
+    "columns": ["e"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "histo_col_type": "timestamp",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "upper_bound": "2018-06-30"},
+      {"num_eq": 10, "num_range": 90, "upper_bound": "2018-07-31"},
+      {"num_eq": 20, "num_range": 180, "upper_bound": "2018-08-31"},
+      {"num_eq": 30, "num_range": 270, "upper_bound": "2018-09-30"},
+      {"num_eq": 40, "num_range": 360, "upper_bound": "2018-10-31"}
+    ]
+  },
+  {
+    "columns": ["f"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "histo_col_type": "timestamptz",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "upper_bound": "2018-06-30"},
+      {"num_eq": 10, "num_range": 90, "upper_bound": "2018-07-31"},
+      {"num_eq": 20, "num_range": 180, "upper_bound": "2018-08-31"},
+      {"num_eq": 30, "num_range": 270, "upper_bound": "2018-09-30"},
+      {"num_eq": 40, "num_range": 360, "upper_bound": "2018-10-31"}
+    ]
+  },
+  {
+    "columns": ["g"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "histo_col_type": "string",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "upper_bound": "apple"},
+      {"num_eq": 10, "num_range": 90, "upper_bound": "banana"},
+      {"num_eq": 20, "num_range": 180, "upper_bound": "cherry"},
+      {"num_eq": 30, "num_range": 270, "upper_bound": "mango"},
+      {"num_eq": 40, "num_range": 360, "upper_bound": "pineapple"}
+    ]
+  }
+]'
+----
+
+# An index join is worthwhile for a < 10.
+opt
+SELECT * FROM hist WHERE a < 10
+----
+index-join hist
+ ├── columns: a:1(int!null) b:2(date) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
+ ├── stats: [rows=90, distinct(1)=0.333333333, null(1)=0]
+ │   histogram(1)=  0  0  80 10
+ │                <--- 0 ---- 9
+ └── scan hist@idx_a
+      ├── columns: a:1(int!null) rowid:8(int!null)
+      ├── constraint: /1/8: (/NULL - /9]
+      ├── stats: [rows=90, distinct(1)=0.333333333, null(1)=0, distinct(8)=90, null(8)=0]
+      │   histogram(1)=  0  0  80 10
+      │                <--- 0 ---- 9
+      ├── key: (8)
+      └── fd: (8)-->(1)
+
+# An index join is not worthwhile for a > 30.
+opt
+SELECT * FROM hist WHERE a > 30
+----
+select
+ ├── columns: a:1(int!null) b:2(date) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
+ ├── stats: [rows=400, distinct(1)=0.333333333, null(1)=0]
+ │   histogram(1)=  0  0   360  40
+ │                <--- 30 ----- 40
+ ├── scan hist
+ │    ├── columns: a:1(int) b:2(date) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
+ │    └── stats: [rows=1000, distinct(1)=1, null(1)=0]
+ │        histogram(1)=  0  0  90  10  180  20  270  30  360  40
+ │                     <--- 0 ---- 10 ----- 20 ----- 30 ----- 40
+ └── filters
+      └── a > 30 [type=bool, outer=(1), constraints=(/1: [/31 - ]; tight)]
+
+opt
+SELECT * FROM hist WHERE b > '2018-07-31'::DATE AND b < '2018-08-05'::DATE
+----
+index-join hist
+ ├── columns: a:1(int) b:2(date!null) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
+ ├── stats: [rows=24, distinct(2)=1, null(2)=0]
+ │   histogram(2)=  0       0        18       6
+ │                <--- '2018-07-31' ---- '2018-08-04'
+ └── scan hist@idx_b
+      ├── columns: b:2(date!null) rowid:8(int!null)
+      ├── constraint: /2/8: [/'2018-08-01' - /'2018-08-04']
+      ├── stats: [rows=24, distinct(2)=1, null(2)=0, distinct(8)=24, null(8)=0]
+      │   histogram(2)=  0       0        18       6
+      │                <--- '2018-07-31' ---- '2018-08-04'
+      ├── key: (8)
+      └── fd: (8)-->(2)
+
+opt
+SELECT * FROM hist WHERE c = 20 OR (c < 10)
+----
+index-join hist
+ ├── columns: a:1(int) b:2(date) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
+ ├── stats: [rows=333.333333]
+ └── scan hist@idx_c
+      ├── columns: c:3(decimal!null) rowid:8(int!null)
+      ├── constraint: /3/8: (/NULL - /10) [/20 - /20]
+      ├── stats: [rows=110, distinct(3)=0.333333333, null(3)=0, distinct(8)=110, null(8)=0]
+      │   histogram(3)=  0  0  90  0   0  20
+      │                <--- 0 ---- 10 --- 20
+      ├── key: (8)
+      └── fd: (8)-->(3)
+
+opt
+SELECT * FROM hist WHERE c = 20 OR (c <= 10)
+----
+index-join hist
+ ├── columns: a:1(int) b:2(date) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
+ ├── stats: [rows=333.333333]
+ └── scan hist@idx_c
+      ├── columns: c:3(decimal!null) rowid:8(int!null)
+      ├── constraint: /3/8: (/NULL - /10] [/20 - /20]
+      ├── stats: [rows=120, distinct(3)=0.333333333, null(3)=0, distinct(8)=120, null(8)=0]
+      │   histogram(3)=  0  0  90  10  0  20
+      │                <--- 0 ---- 10 --- 20
+      ├── key: (8)
+      └── fd: (8)-->(3)
+
+opt
+SELECT * FROM hist WHERE (d >= 5 AND d < 15) OR d >= 40
+----
+index-join hist
+ ├── columns: a:1(int) b:2(date) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
+ ├── stats: [rows=333.333333]
+ └── select
+      ├── columns: d:4(float!null) rowid:8(int!null)
+      ├── stats: [rows=61.6666667, distinct(4)=0.333333333, null(4)=0, distinct(8)=61.6666667, null(8)=0]
+      │   histogram(4)=  0          0          15 3.3333 30          0           0 13.333
+      │                <--- 4.999999999999999 ---- 10.0 ---- 14.999999999999998 --- 40.0
+      ├── key: (8)
+      ├── fd: (8)-->(4)
+      ├── scan hist@idx_d
+      │    ├── columns: d:4(float!null) rowid:8(int!null)
+      │    ├── constraint: /4/8: [/5.0 - /14.999999999999998] [/40.0 - ]
+      │    ├── stats: [rows=185, distinct(4)=0.333333333, null(4)=0, distinct(8)=185, null(8)=0]
+      │    │   histogram(4)=  0          0          45   10   90          0           0   40
+      │    │                <--- 4.999999999999999 ---- 10.0 ---- 14.999999999999998 --- 40.0
+      │    ├── key: (8)
+      │    └── fd: (8)-->(4)
+      └── filters
+           └── (d < 15.0) OR (d >= 40.0) [type=bool, outer=(4)]
+
+opt
+SELECT * FROM hist WHERE e < '2018-07-31 23:00:00'::TIMESTAMP
+----
+index-join hist
+ ├── columns: a:1(int) b:2(date) c:3(decimal) d:4(float) e:5(timestamp!null) f:6(timestamptz) g:7(string)
+ ├── stats: [rows=105.564516, distinct(5)=0.333333333, null(5)=0]
+ │   histogram(5)=  0               0               90              10               5.5645                  0
+ │                <--- '2018-06-30 00:00:00+00:00' ---- '2018-07-31 00:00:00+00:00' -------- '2018-07-31 22:59:59.999999+00:00'
+ └── scan hist@idx_e
+      ├── columns: e:5(timestamp!null) rowid:8(int!null)
+      ├── constraint: /5/8: (/NULL - /'2018-07-31 22:59:59.999999+00:00']
+      ├── stats: [rows=105.564516, distinct(5)=0.333333333, null(5)=0, distinct(8)=105.564516, null(8)=0]
+      │   histogram(5)=  0               0               90              10               5.5645                  0
+      │                <--- '2018-06-30 00:00:00+00:00' ---- '2018-07-31 00:00:00+00:00' -------- '2018-07-31 22:59:59.999999+00:00'
+      ├── key: (8)
+      └── fd: (8)-->(5)
+
+opt
+SELECT * FROM hist WHERE f = '2019-10-30 23:00:00'::TIMESTAMPTZ
+----
+index-join hist
+ ├── columns: a:1(int) b:2(date) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz!null) g:7(string)
+ ├── stats: [rows=1, distinct(6)=1, null(6)=0]
+ │   histogram(6)=  0               0
+ │                <--- '2018-10-31 00:00:00+00:00'
+ ├── fd: ()-->(6)
+ └── scan hist@idx_f
+      ├── columns: f:6(timestamptz!null) rowid:8(int!null)
+      ├── constraint: /6/8: [/'2019-10-30 23:00:00+00:00' - /'2019-10-30 23:00:00+00:00']
+      ├── stats: [rows=1, distinct(6)=1, null(6)=0, distinct(8)=1, null(8)=0]
+      │   histogram(6)=  0               0
+      │                <--- '2018-10-31 00:00:00+00:00'
+      ├── key: (8)
+      └── fd: ()-->(6)
+
+opt
+SELECT * FROM hist WHERE g = 'mango' OR g = 'foo'
+----
+index-join hist
+ ├── columns: a:1(int) b:2(date) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
+ ├── stats: [rows=333.333333]
+ └── scan hist@idx_g
+      ├── columns: g:7(string!null) rowid:8(int!null)
+      ├── constraint: /7/8: [/'foo' - /'foo'] [/'mango' - /'mango']
+      ├── stats: [rows=165, distinct(7)=1, null(7)=0, distinct(8)=165, null(8)=0]
+      │   histogram(7)=  0   135   0    30
+      │                <--- 'foo' --- 'mango'
+      ├── key: (8)
+      └── fd: (8)-->(7)
+
+# Select the correct index depending on which predicate is more selective.
+opt
+SELECT * FROM hist WHERE a = 10 AND b = '2018-08-31'::DATE
+----
+select
+ ├── columns: a:1(int!null) b:2(date!null) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
+ ├── stats: [rows=0.2, distinct(1)=0.2, null(1)=0, distinct(2)=0.2, null(2)=0]
+ │   histogram(1)=  0 0.2
+ │                <--- 10
+ │   histogram(2)=  0      0.2
+ │                <--- '2018-08-31'
+ ├── fd: ()-->(1,2)
+ ├── index-join hist
+ │    ├── columns: a:1(int) b:2(date) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
+ │    ├── stats: [rows=10]
+ │    ├── fd: ()-->(1)
+ │    └── scan hist@idx_a
+ │         ├── columns: a:1(int!null) rowid:8(int!null)
+ │         ├── constraint: /1/8: [/10 - /10]
+ │         ├── stats: [rows=10, distinct(1)=1, null(1)=0, distinct(8)=10, null(8)=0]
+ │         │   histogram(1)=  0  10
+ │         │                <--- 10
+ │         ├── key: (8)
+ │         └── fd: ()-->(1)
+ └── filters
+      └── b = '2018-08-31' [type=bool, outer=(2), constraints=(/2: [/'2018-08-31' - /'2018-08-31']; tight), fd=()-->(2)]
+
+opt
+SELECT * FROM hist WHERE a = 20 AND b = '2018-07-31'::DATE
+----
+select
+ ├── columns: a:1(int!null) b:2(date!null) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
+ ├── stats: [rows=0.2, distinct(1)=0.2, null(1)=0, distinct(2)=0.2, null(2)=0]
+ │   histogram(1)=  0 0.2
+ │                <--- 20
+ │   histogram(2)=  0      0.2
+ │                <--- '2018-07-31'
+ ├── fd: ()-->(1,2)
+ ├── index-join hist
+ │    ├── columns: a:1(int) b:2(date) c:3(decimal) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
+ │    ├── stats: [rows=10]
+ │    ├── fd: ()-->(2)
+ │    └── scan hist@idx_b
+ │         ├── columns: b:2(date!null) rowid:8(int!null)
+ │         ├── constraint: /2/8: [/'2018-07-31' - /'2018-07-31']
+ │         ├── stats: [rows=10, distinct(2)=1, null(2)=0, distinct(8)=10, null(8)=0]
+ │         │   histogram(2)=  0       10
+ │         │                <--- '2018-07-31'
+ │         ├── key: (8)
+ │         └── fd: ()-->(2)
+ └── filters
+      └── a = 20 [type=bool, outer=(1), constraints=(/1: [/20 - /20]; tight), fd=()-->(1)]

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -179,11 +179,11 @@ project
  ├── stats: [rows=108.9]
  └── select
       ├── columns: y:2(int!null) z:3(int!null)
-      ├── stats: [rows=108.9, distinct(2)=69.2053852, null(2)=0, distinct(3)=69.2053852, null(3)=0]
+      ├── stats: [rows=108.9, distinct(2)=33.3333333, null(2)=0, distinct(3)=33.3333333, null(3)=0]
       ├── scan idx@yz
       │    ├── columns: y:2(int!null) z:3(int)
       │    ├── constraint: /-2/3/1: (/4/NULL - /NULL)
-      │    └── stats: [rows=330, distinct(2)=98.265847, null(2)=0]
+      │    └── stats: [rows=330, distinct(2)=33.3333333, null(2)=0, distinct(3)=100, null(3)=10]
       └── filters
            └── z < 10 [type=bool, outer=(3), constraints=(/3: (/NULL - /9]; tight)]
 
@@ -687,18 +687,18 @@ WHERE
 ----
 index-join lineitem
  ├── columns: l_orderkey:1(int!null) l_partkey:2(int!null) l_suppkey:3(int!null) l_linenumber:4(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_tax:8(float!null) l_returnflag:9(char!null) l_linestatus:10(char!null) l_shipdate:11(date!null) l_commitdate:12(date!null) l_receiptdate:13(date!null) l_shipinstruct:14(char!null) l_shipmode:15(char!null) l_comment:16(varchar!null)
- ├── stats: [rows=111.111111, distinct(1)=69.2053852, null(1)=0, distinct(2)=69.2053852, null(2)=0, distinct(3)=69.2053852, null(3)=0, distinct(4)=69.2053852, null(4)=0, distinct(5)=69.2053852, null(5)=0, distinct(6)=69.2053852, null(6)=0, distinct(7)=69.2053852, null(7)=0, distinct(8)=69.2053852, null(8)=0, distinct(9)=69.2053852, null(9)=0, distinct(10)=69.2053852, null(10)=0, distinct(11)=69.2053852, null(11)=0, distinct(12)=69.2053852, null(12)=0, distinct(13)=69.2053852, null(13)=0, distinct(14)=69.2053852, null(14)=0, distinct(15)=69.2053852, null(15)=0, distinct(16)=69.2053852, null(16)=0]
+ ├── stats: [rows=111.111111, distinct(1)=69.2053852, null(1)=0, distinct(2)=69.2053852, null(2)=0, distinct(3)=69.2053852, null(3)=0, distinct(4)=69.2053852, null(4)=0, distinct(5)=69.2053852, null(5)=0, distinct(6)=69.2053852, null(6)=0, distinct(7)=69.2053852, null(7)=0, distinct(8)=69.2053852, null(8)=0, distinct(9)=69.2053852, null(9)=0, distinct(10)=69.2053852, null(10)=0, distinct(11)=33.3333333, null(11)=0, distinct(12)=69.2053852, null(12)=0, distinct(13)=69.2053852, null(13)=0, distinct(14)=69.2053852, null(14)=0, distinct(15)=69.2053852, null(15)=0, distinct(16)=69.2053852, null(16)=0]
  ├── key: (1,4)
  ├── fd: (1,4)-->(2,3,5-16)
  └── select
       ├── columns: l_orderkey:1(int!null) l_linenumber:4(int!null) l_shipdate:11(date!null)
-      ├── stats: [rows=111.111111, distinct(1)=73.4303342, null(1)=0, distinct(4)=73.4303342, null(4)=0, distinct(11)=73.4303342, null(11)=0]
+      ├── stats: [rows=111.111111, distinct(1)=73.4303342, null(1)=0, distinct(4)=73.4303342, null(4)=0, distinct(11)=32.7552823, null(11)=0]
       ├── key: (1,4)
       ├── fd: (1,4)-->(11)
       ├── scan lineitem@l_sd
       │    ├── columns: l_orderkey:1(int!null) l_linenumber:4(int!null) l_shipdate:11(date!null)
       │    ├── constraint: /11/1/4: [/'1995-09-01' - ]
-      │    ├── stats: [rows=333.333333, distinct(1)=98.265847, null(1)=0, distinct(4)=98.265847, null(4)=0, distinct(11)=98.265847, null(11)=0]
+      │    ├── stats: [rows=333.333333, distinct(1)=98.265847, null(1)=0, distinct(4)=98.265847, null(4)=0, distinct(11)=33.3333333, null(11)=0]
       │    ├── key: (1,4)
       │    └── fd: (1,4)-->(11)
       └── filters

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpcc
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpcc
@@ -1470,7 +1470,7 @@ scalar-group-by
  │    ├── save-table-name: stock_level_02_lookup_join_2
  │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_i_id:5(int!null) s_i_id:11(int!null) s_w_id:12(int!null) s_quantity:13(int!null)
  │    ├── key columns: [3 5] = [12 11]
- │    ├── stats: [rows=231.860988, distinct(1)=19.9998154, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(5)=199.806787, null(5)=0, distinct(11)=199.806787, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=83.8801101, null(13)=0]
+ │    ├── stats: [rows=231.860988, distinct(1)=19.9998154, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(5)=199.806787, null(5)=0, distinct(11)=199.806787, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=30.318805, null(13)=0]
  │    ├── cost: 1542.75139
  │    ├── fd: ()-->(2,3,12), (11)-->(13), (5)==(11), (11)==(5), (3)==(12), (12)==(3)
  │    ├── interesting orderings: (+3,+2,-1)
@@ -1526,7 +1526,7 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 {ol_o_id}     232.00         38.67 <==      20.00               3.33 <==            0.00            1.00
 {ol_w_id}     232.00         38.67 <==      1.00                1.00                0.00            1.00
 {s_i_id}      232.00         38.67 <==      200.00              33.33 <==           0.00            1.00
-{s_quantity}  232.00         38.67 <==      84.00               28.00 <==           0.00            1.00
+{s_quantity}  232.00         38.67 <==      30.00               10.00 <==           0.00            1.00
 {s_w_id}      232.00         38.67 <==      1.00                1.00                0.00            1.00
 
 stats table=stock_level_02_scalar_group_by_1
@@ -1569,7 +1569,7 @@ scalar-group-by
  │    ├── columns: w_id:1(int!null) w_ytd:9(decimal!null) d_w_id:11(int!null) sum:21(decimal!null)
  │    ├── left ordering: +1
  │    ├── right ordering: +11
- │    ├── stats: [rows=3.33333333, distinct(1)=3.33333333, null(1)=0, distinct(9)=0.966296553, null(9)=0, distinct(11)=3.33333333, null(11)=0, distinct(21)=2.87528606, null(21)=0]
+ │    ├── stats: [rows=3.33333333, distinct(1)=3.33333333, null(1)=0, distinct(9)=1, null(9)=0, distinct(11)=3.33333333, null(11)=0, distinct(21)=3.33333333, null(21)=0]
  │    ├── cost: 126.493333
  │    ├── key: (11)
  │    ├── fd: (1)-->(9), (11)-->(21), (1)==(11), (11)==(1)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch
@@ -658,7 +658,7 @@ sort
       │    ├── select
       │    │    ├── save-table-name: q1_select_4
       │    │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_tax:8(float!null) l_returnflag:9(char!null) l_linestatus:10(char!null) l_shipdate:11(date!null)
-      │    │    ├── stats: [rows=2000405, distinct(5)=50, null(5)=0, distinct(6)=859070.838, null(6)=0, distinct(7)=11, null(7)=0, distinct(8)=9, null(8)=0, distinct(9)=3, null(9)=0, distinct(10)=2, null(10)=0, distinct(11)=2526, null(11)=0, distinct(6,7)=2000405, null(6,7)=0, distinct(9,10)=6, null(9,10)=0, distinct(6-8)=2000405, null(6-8)=0]
+      │    │    ├── stats: [rows=2000405, distinct(5)=50, null(5)=0, distinct(6)=859070.838, null(6)=0, distinct(7)=11, null(7)=0, distinct(8)=9, null(8)=0, distinct(9)=3, null(9)=0, distinct(10)=2, null(10)=0, distinct(11)=842, null(11)=0, distinct(6,7)=2000405, null(6,7)=0, distinct(9,10)=6, null(9,10)=0, distinct(6-8)=2000405, null(6-8)=0]
       │    │    ├── scan lineitem
       │    │    │    ├── save-table-name: q1_scan_5
       │    │    │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_tax:8(float!null) l_returnflag:9(char!null) l_linestatus:10(char!null) l_shipdate:11(date!null)
@@ -774,7 +774,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {l_linestatus}     2000405.00     2.96 <==       2.00                1.00                0.00            1.00
 {l_quantity}       2000405.00     2.96 <==       50.00               1.00                0.00            1.00
 {l_returnflag}     2000405.00     2.96 <==       3.00                1.00                0.00            1.00
-{l_shipdate}       2000405.00     2.96 <==       2526.00             1.04                0.00            1.00
+{l_shipdate}       2000405.00     2.96 <==       842.00              2.89 <==            0.00            1.00
 {l_tax}            2000405.00     2.96 <==       9.00                1.00                0.00            1.00
 
 stats table=q1_scan_5
@@ -902,7 +902,7 @@ project
       │         │    ├── inner-join
       │         │    │    ├── save-table-name: q2_inner_join_6
       │         │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(char!null) p_type:5(varchar!null) p_size:6(int!null) s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null) ps_partkey:29(int!null) ps_suppkey:30(int!null) ps_supplycost:32(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
-      │         │    │    ├── stats: [rows=2837.30948, distinct(1)=1333.31636, null(1)=0, distinct(3)=5, null(3)=0, distinct(5)=149.979569, null(5)=0, distinct(6)=1, null(6)=0, distinct(10)=1411.92479, null(10)=0, distinct(11)=1412.48485, null(11)=0, distinct(12)=1412.56423, null(12)=0, distinct(13)=5, null(13)=0, distinct(14)=1412.56423, null(14)=0, distinct(15)=1412.30169, null(15)=0, distinct(16)=1412.03742, null(16)=0, distinct(17)=1174.55443, null(17)=0, distinct(18)=1411.92479, null(18)=0, distinct(20)=1482.68691, null(20)=0, distinct(22)=5, null(22)=0, distinct(23)=5, null(23)=0, distinct(24)=1, null(24)=0, distinct(26)=1, null(26)=0, distinct(27)=0.996222107, null(27)=0, distinct(29)=1333.31636, null(29)=0, distinct(30)=1448.52495, null(30)=0, distinct(32)=2787.75127, null(32)=0, distinct(34)=1448.52495, null(34)=0, distinct(37)=5, null(37)=0, distinct(41)=5, null(41)=0, distinct(43)=1, null(43)=0, distinct(45)=1, null(45)=0, distinct(46)=0.996222107, null(46)=0, distinct(17,18)=1487.22799, null(17,18)=0]
+      │         │    │    ├── stats: [rows=2837.30948, distinct(1)=1333.31636, null(1)=0, distinct(3)=5, null(3)=0, distinct(5)=149.999649, null(5)=0, distinct(6)=1, null(6)=0, distinct(10)=1411.92479, null(10)=0, distinct(11)=1412.48485, null(11)=0, distinct(12)=1412.56423, null(12)=0, distinct(13)=5, null(13)=0, distinct(14)=1412.56423, null(14)=0, distinct(15)=1412.30169, null(15)=0, distinct(16)=1412.03742, null(16)=0, distinct(17)=1174.55443, null(17)=0, distinct(18)=1411.92479, null(18)=0, distinct(20)=1482.68691, null(20)=0, distinct(22)=5, null(22)=0, distinct(23)=5, null(23)=0, distinct(24)=1, null(24)=0, distinct(26)=1, null(26)=0, distinct(27)=0.996222107, null(27)=0, distinct(29)=1333.31636, null(29)=0, distinct(30)=1448.52495, null(30)=0, distinct(32)=2787.75127, null(32)=0, distinct(34)=1448.52495, null(34)=0, distinct(37)=5, null(37)=0, distinct(41)=5, null(41)=0, distinct(43)=1, null(43)=0, distinct(45)=1, null(45)=0, distinct(46)=0.996222107, null(46)=0, distinct(17,18)=1487.22799, null(17,18)=0]
       │         │    │    ├── key: (18,29,34)
       │         │    │    ├── fd: ()-->(6,27,46), (1)-->(3,5), (10)-->(11-16), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24), (10)==(18), (18)==(10), (13)==(22), (22)==(13), (1)==(17,29), (17)==(1,29), (29,30)-->(32), (34)-->(37), (41)-->(43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (30)==(34), (34)==(30), (29)==(1,17)
       │         │    │    ├── inner-join
@@ -952,7 +952,7 @@ project
       │         │    │    ├── inner-join
       │         │    │    │    ├── save-table-name: q2_inner_join_13
       │         │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(char!null) p_type:5(varchar!null) p_size:6(int!null) s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null)
-      │         │    │    │    ├── stats: [rows=1945.04451, distinct(1)=1333.31636, null(1)=0, distinct(3)=5, null(3)=0, distinct(5)=149.97957, null(5)=0, distinct(6)=1, null(6)=0, distinct(10)=1766.2414, null(10)=0, distinct(11)=1767.4156, null(11)=0, distinct(12)=1767.58209, null(12)=0, distinct(13)=5, null(13)=0, distinct(14)=1767.58209, null(14)=0, distinct(15)=1767.03149, null(15)=0, distinct(16)=1766.47747, null(16)=0, distinct(17)=1333.31636, null(17)=0, distinct(18)=1766.2414, null(18)=0, distinct(20)=1921.6712, null(20)=0, distinct(22)=5, null(22)=0, distinct(23)=5, null(23)=0, distinct(24)=1, null(24)=0, distinct(26)=1, null(26)=0, distinct(27)=0.996222107, null(27)=0, distinct(17,18)=1932.16064, null(17,18)=0]
+      │         │    │    │    ├── stats: [rows=1945.04451, distinct(1)=1333.31636, null(1)=0, distinct(3)=5, null(3)=0, distinct(5)=149.99965, null(5)=0, distinct(6)=1, null(6)=0, distinct(10)=1766.2414, null(10)=0, distinct(11)=1767.4156, null(11)=0, distinct(12)=1767.58209, null(12)=0, distinct(13)=5, null(13)=0, distinct(14)=1767.58209, null(14)=0, distinct(15)=1767.03149, null(15)=0, distinct(16)=1766.47747, null(16)=0, distinct(17)=1333.31636, null(17)=0, distinct(18)=1766.2414, null(18)=0, distinct(20)=1921.6712, null(20)=0, distinct(22)=5, null(22)=0, distinct(23)=5, null(23)=0, distinct(24)=1, null(24)=0, distinct(26)=1, null(26)=0, distinct(27)=0.996222107, null(27)=0, distinct(17,18)=1932.16064, null(17,18)=0]
       │         │    │    │    ├── key: (17,18)
       │         │    │    │    ├── fd: ()-->(6,27), (1)-->(3,5), (10)-->(11-16), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24), (10)==(18), (18)==(10), (13)==(22), (22)==(13), (1)==(17), (17)==(1)
       │         │    │    │    ├── inner-join
@@ -1014,7 +1014,7 @@ project
       │         │    │    │    ├── select
       │         │    │    │    │    ├── save-table-name: q2_select_22
       │         │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(char!null) p_type:5(varchar!null) p_size:6(int!null)
-      │         │    │    │    │    ├── stats: [rows=1333.33333, distinct(1)=1333.31636, null(1)=0, distinct(3)=5, null(3)=0, distinct(5)=149.97992, null(5)=0, distinct(6)=1, null(6)=0]
+      │         │    │    │    │    ├── stats: [rows=1333.33333, distinct(1)=1333.31636, null(1)=0, distinct(3)=5, null(3)=0, distinct(5)=150, null(5)=0, distinct(6)=1, null(6)=0]
       │         │    │    │    │    ├── key: (1)
       │         │    │    │    │    ├── fd: ()-->(6), (1)-->(3,5)
       │         │    │    │    │    ├── scan part
@@ -1627,24 +1627,24 @@ limit
  │         ├── project
  │         │    ├── save-table-name: q3_project_4
  │         │    ├── columns: column34:34(float) o_orderdate:13(date!null) o_shippriority:16(int!null) l_orderkey:18(int!null)
- │         │    ├── stats: [rows=247598.539, distinct(13)=2406, null(13)=0, distinct(16)=1, null(16)=0, distinct(18)=195275.364, null(18)=0, distinct(34)=207215.808, null(34)=0]
+ │         │    ├── stats: [rows=247598.539, distinct(13)=802, null(13)=0, distinct(16)=1, null(16)=0, distinct(18)=195275.364, null(18)=0, distinct(34)=207215.808, null(34)=0]
  │         │    ├── fd: (18)-->(13,16)
  │         │    ├── inner-join (lookup lineitem)
  │         │    │    ├── save-table-name: q3_lookup_join_5
  │         │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(char!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_shipdate:28(date!null)
  │         │    │    ├── key columns: [9] = [18]
- │         │    │    ├── stats: [rows=247598.539, distinct(1)=29974.3087, null(1)=0, distinct(7)=1, null(7)=0, distinct(9)=195275.364, null(9)=0, distinct(10)=29974.3087, null(10)=0, distinct(13)=2406, null(13)=0, distinct(16)=1, null(16)=0, distinct(18)=195275.364, null(18)=0, distinct(23)=197736.715, null(23)=0, distinct(24)=11, null(24)=0, distinct(28)=2526, null(28)=0, distinct(23,24)=207215.808, null(23,24)=0]
+ │         │    │    ├── stats: [rows=247598.539, distinct(1)=29974.3087, null(1)=0, distinct(7)=1, null(7)=0, distinct(9)=195275.364, null(9)=0, distinct(10)=29974.3087, null(10)=0, distinct(13)=802, null(13)=0, distinct(16)=1, null(16)=0, distinct(18)=195275.364, null(18)=0, distinct(23)=197736.715, null(23)=0, distinct(24)=11, null(24)=0, distinct(28)=842, null(28)=0, distinct(23,24)=207215.808, null(23,24)=0]
  │         │    │    ├── fd: ()-->(7), (9)-->(10,13,16), (9)==(18), (18)==(9), (1)==(10), (10)==(1)
  │         │    │    ├── inner-join
  │         │    │    │    ├── save-table-name: q3_inner_join_6
  │         │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(char!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null)
- │         │    │    │    ├── stats: [rows=150572.001, distinct(1)=29974.3087, null(1)=0, distinct(7)=1, null(7)=0, distinct(9)=130014.955, null(9)=0, distinct(10)=29974.3087, null(10)=0, distinct(13)=2406, null(13)=0, distinct(16)=1, null(16)=0]
+ │         │    │    │    ├── stats: [rows=150572.001, distinct(1)=29974.3087, null(1)=0, distinct(7)=1, null(7)=0, distinct(9)=130014.955, null(9)=0, distinct(10)=29974.3087, null(10)=0, distinct(13)=802, null(13)=0, distinct(16)=1, null(16)=0]
  │         │    │    │    ├── key: (9)
  │         │    │    │    ├── fd: ()-->(7), (9)-->(10,13,16), (1)==(10), (10)==(1)
  │         │    │    │    ├── select
  │         │    │    │    │    ├── save-table-name: q3_select_7
  │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null)
- │         │    │    │    │    ├── stats: [rows=500000, distinct(9)=500000, null(9)=0, distinct(10)=99620.1148, null(10)=0, distinct(13)=2406, null(13)=0, distinct(16)=1, null(16)=0]
+ │         │    │    │    │    ├── stats: [rows=500000, distinct(9)=500000, null(9)=0, distinct(10)=99620.1148, null(10)=0, distinct(13)=802, null(13)=0, distinct(16)=1, null(16)=0]
  │         │    │    │    │    ├── key: (9)
  │         │    │    │    │    ├── fd: (9)-->(10,13,16)
  │         │    │    │    │    ├── scan orders
@@ -1737,7 +1737,7 @@ column_names      row_count  distinct_count  null_count
 column_names      row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {column34}        247599.00      8.11 <==       207216.00           6.81 <==            0.00            1.00
 {l_orderkey}      247599.00      8.11 <==       195275.00           16.82 <==           0.00            1.00
-{o_orderdate}     247599.00      8.11 <==       2406.00             20.05 <==           0.00            1.00
+{o_orderdate}     247599.00      8.11 <==       802.00              6.68 <==            0.00            1.00
 {o_shippriority}  247599.00      8.11 <==       1.00                1.00                0.00            1.00
 
 stats table=q3_lookup_join_5
@@ -1760,9 +1760,9 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {l_discount}       247599.00      8.11 <==       11.00               1.00                0.00            1.00
 {l_extendedprice}  247599.00      8.11 <==       197737.00           6.58 <==            0.00            1.00
 {l_orderkey}       247599.00      8.11 <==       195275.00           16.82 <==           0.00            1.00
-{l_shipdate}       247599.00      8.11 <==       2526.00             21.05 <==           0.00            1.00
+{l_shipdate}       247599.00      8.11 <==       842.00              7.02 <==            0.00            1.00
 {o_custkey}        247599.00      8.11 <==       29974.00            3.47 <==            0.00            1.00
-{o_orderdate}      247599.00      8.11 <==       2406.00             20.05 <==           0.00            1.00
+{o_orderdate}      247599.00      8.11 <==       802.00              6.68 <==            0.00            1.00
 {o_orderkey}       247599.00      8.11 <==       195275.00           16.82 <==           0.00            1.00
 {o_shippriority}   247599.00      8.11 <==       1.00                1.00                0.00            1.00
 
@@ -1780,7 +1780,7 @@ column_names      row_count_est  row_count_err  distinct_count_est  distinct_cou
 {c_custkey}       150572.00      1.02           29974.00            1.49                0.00            1.00
 {c_mktsegment}    150572.00      1.02           1.00                1.00                0.00            1.00
 {o_custkey}       150572.00      1.02           29974.00            1.49                0.00            1.00
-{o_orderdate}     150572.00      1.02           2406.00             2.06 <==            0.00            1.00
+{o_orderdate}     150572.00      1.02           802.00              1.46                0.00            1.00
 {o_orderkey}      150572.00      1.02           130015.00           1.12                0.00            1.00
 {o_shippriority}  150572.00      1.02           1.00                1.00                0.00            1.00
 
@@ -1794,7 +1794,7 @@ column_names      row_count  distinct_count  null_count
 ~~~~
 column_names      row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {o_custkey}       500000.00      1.45           99620.00            1.00                0.00            1.00
-{o_orderdate}     500000.00      1.45           2406.00             2.06 <==            0.00            1.00
+{o_orderdate}     500000.00      1.45           802.00              1.46                0.00            1.00
 {o_orderkey}      500000.00      1.45           500000.00           1.46                0.00            1.00
 {o_shippriority}  500000.00      1.45           1.00                1.00                0.00            1.00
 
@@ -2404,7 +2404,7 @@ scalar-group-by
  │    ├── select
  │    │    ├── save-table-name: q6_select_3
  │    │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
- │    │    ├── stats: [rows=32116.9977, distinct(5)=50, null(5)=0, distinct(6)=31649.6934, null(6)=0, distinct(7)=11, null(7)=0, distinct(11)=365, null(11)=0, distinct(6,7)=32116.9977, null(6,7)=0]
+ │    │    ├── stats: [rows=32116.9977, distinct(5)=16.6666667, null(5)=0, distinct(6)=31649.6934, null(6)=0, distinct(7)=1.22222222, null(7)=0, distinct(11)=365, null(11)=0, distinct(6,7)=32116.9977, null(6,7)=0]
  │    │    ├── index-join lineitem
  │    │    │    ├── save-table-name: q6_index_join_4
  │    │    │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
@@ -2450,9 +2450,9 @@ column_names       row_count  distinct_count  null_count
 {l_shipdate}       114160     365             0
 ~~~~
 column_names       row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{l_discount}       32117.00       3.55 <==       11.00               3.67 <==            0.00            1.00
+{l_discount}       32117.00       3.55 <==       1.00                3.00 <==            0.00            1.00
 {l_extendedprice}  32117.00       3.55 <==       31650.00            3.12 <==            0.00            1.00
-{l_quantity}       32117.00       3.55 <==       50.00               2.17 <==            0.00            1.00
+{l_quantity}       32117.00       3.55 <==       17.00               1.35                0.00            1.00
 {l_shipdate}       32117.00       3.55 <==       365.00              1.00                0.00            1.00
 
 stats table=q6_index_join_4
@@ -3545,7 +3545,7 @@ sort
       │    │    ├── save-table-name: q9_lookup_join_4
       │    │    ├── columns: p_partkey:1(int!null) p_name:2(varchar!null) s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(char!null)
       │    │    ├── key columns: [18] = [1]
-      │    │    ├── stats: [rows=2406.66318, distinct(1)=2357.09397, null(1)=0, distinct(2)=2363.68276, null(2)=0, distinct(10)=1520.84987, null(10)=0, distinct(13)=25, null(13)=0, distinct(17)=1508.01915, null(17)=0, distinct(18)=2357.09397, null(18)=0, distinct(19)=1520.84987, null(19)=0, distinct(21)=50, null(21)=0, distinct(22)=1507.67014, null(22)=0, distinct(23)=11, null(23)=0, distinct(33)=1508.01915, null(33)=0, distinct(34)=1443.61652, null(34)=0, distinct(36)=1503.89598, null(36)=0, distinct(38)=1508.01915, null(38)=0, distinct(42)=1208.19298, null(42)=0, distinct(47)=25, null(47)=0, distinct(48)=25, null(48)=0, distinct(42,48)=1500.68104, null(42,48)=0, distinct(21-23,36)=1508.01915, null(21-23,36)=0]
+      │    │    ├── stats: [rows=2406.66318, distinct(1)=2357.09397, null(1)=0, distinct(2)=2363.75844, null(2)=0, distinct(10)=1520.84987, null(10)=0, distinct(13)=25, null(13)=0, distinct(17)=1508.01915, null(17)=0, distinct(18)=2357.09397, null(18)=0, distinct(19)=1520.84987, null(19)=0, distinct(21)=50, null(21)=0, distinct(22)=1507.67014, null(22)=0, distinct(23)=11, null(23)=0, distinct(33)=1508.01915, null(33)=0, distinct(34)=1443.61652, null(34)=0, distinct(36)=1503.89598, null(36)=0, distinct(38)=1508.01915, null(38)=0, distinct(42)=1208.19298, null(42)=0, distinct(47)=25, null(47)=0, distinct(48)=25, null(48)=0, distinct(42,48)=1500.68104, null(42,48)=0, distinct(21-23,36)=1508.01915, null(21-23,36)=0]
       │    │    ├── fd: (1)-->(2), (10)-->(13), (33,34)-->(36), (38)-->(42), (47)-->(48), (19)==(10,34), (34)==(10,19), (18)==(1,33), (33)==(1,18), (17)==(38), (38)==(17), (10)==(19,34), (13)==(47), (47)==(13), (1)==(18,33)
       │    │    ├── inner-join
       │    │    │    ├── save-table-name: q9_inner_join_5
@@ -4671,12 +4671,12 @@ sort
       │    │    ├── save-table-name: q12_lookup_join_4
       │    │    ├── columns: o_orderkey:1(int!null) o_orderpriority:6(char!null) l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(char!null)
       │    │    ├── key columns: [10] = [1]
-      │    │    ├── stats: [rows=27227.0509, distinct(1)=27046.6499, null(1)=0, distinct(6)=5, null(6)=0, distinct(10)=27046.6499, null(10)=0, distinct(20)=2525.89601, null(20)=0, distinct(21)=2465.92192, null(21)=0, distinct(22)=365, null(22)=0, distinct(24)=2, null(24)=0]
+      │    │    ├── stats: [rows=27227.0509, distinct(1)=27046.6499, null(1)=0, distinct(6)=5, null(6)=0, distinct(10)=27046.6499, null(10)=0, distinct(20)=2525.94736, null(20)=0, distinct(21)=2465.96047, null(21)=0, distinct(22)=365, null(22)=0, distinct(24)=2, null(24)=0]
       │    │    ├── fd: (1)-->(6), (1)==(10), (10)==(1)
       │    │    ├── select
       │    │    │    ├── save-table-name: q12_select_5
       │    │    │    ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(char!null)
-      │    │    │    ├── stats: [rows=27227.0509, distinct(10)=27046.6499, null(10)=0, distinct(20)=2525.94864, null(20)=0, distinct(21)=2465.96145, null(21)=0, distinct(22)=365, null(22)=0, distinct(24)=2, null(24)=0]
+      │    │    │    ├── stats: [rows=27227.0509, distinct(10)=27046.6499, null(10)=0, distinct(20)=2526, null(20)=0, distinct(21)=2466, null(21)=0, distinct(22)=365, null(22)=0, distinct(24)=2, null(24)=0]
       │    │    │    ├── index-join lineitem
       │    │    │    │    ├── save-table-name: q12_index_join_6
       │    │    │    │    ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(char!null)
@@ -4846,13 +4846,13 @@ sort
       │    ├── right-join
       │    │    ├── save-table-name: q13_right_join_4
       │    │    ├── columns: c_custkey:1(int!null) o_orderkey:9(int) o_custkey:10(int) o_comment:17(varchar)
-      │    │    ├── stats: [rows=503988.227, distinct(1)=148813, null(1)=0, distinct(9)=317522.248, null(9)=0, distinct(10)=99620.1148, null(10)=0, distinct(17)=316996.293, null(17)=0]
+      │    │    ├── stats: [rows=503988.227, distinct(1)=148813, null(1)=0, distinct(9)=317522.248, null(9)=0, distinct(10)=99620.1148, null(10)=0, distinct(17)=317522.248, null(17)=0]
       │    │    ├── key: (1,9)
       │    │    ├── fd: (9)-->(10,17)
       │    │    ├── select
       │    │    │    ├── save-table-name: q13_select_5
       │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_comment:17(varchar!null)
-      │    │    │    ├── stats: [rows=500000, distinct(9)=500000, null(9)=0, distinct(10)=99620.1148, null(10)=0, distinct(17)=498036.796, null(17)=0]
+      │    │    │    ├── stats: [rows=500000, distinct(9)=500000, null(9)=0, distinct(10)=99620.1148, null(10)=0, distinct(17)=500000, null(17)=0]
       │    │    │    ├── key: (9)
       │    │    │    ├── fd: (9)-->(10,17)
       │    │    │    ├── scan orders
@@ -4916,7 +4916,7 @@ column_names  row_count  distinct_count  null_count
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {c_custkey}   503988.00      3.04 <==       148813.00           1.00                0.00            1.00
-{o_comment}   503988.00      3.04 <==       316996.00           4.59 <==            0.00            +Inf <==
+{o_comment}   503988.00      3.04 <==       317522.00           4.58 <==            0.00            +Inf <==
 {o_custkey}   503988.00      3.04 <==       99620.00            1.00                0.00            +Inf <==
 {o_orderkey}  503988.00      3.04 <==       317522.00           4.76 <==            0.00            +Inf <==
 
@@ -4928,7 +4928,7 @@ column_names  row_count  distinct_count  null_count
 {o_orderkey}  1483918    1511432         0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{o_comment}   500000.00      2.97 <==       498037.00           2.92 <==            0.00            1.00
+{o_comment}   500000.00      2.97 <==       500000.00           2.91 <==            0.00            1.00
 {o_custkey}   500000.00      2.97 <==       99620.00            1.00                0.00            1.00
 {o_orderkey}  500000.00      2.97 <==       500000.00           3.02 <==            0.00            1.00
 
@@ -5447,7 +5447,7 @@ ORDER BY
 sort
  ├── save-table-name: q16_sort_1
  ├── columns: p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null) supplier_cnt:22(int)
- ├── stats: [rows=3489.49147, distinct(9)=25, null(9)=0, distinct(10)=150, null(10)=0, distinct(11)=8, null(11)=0, distinct(22)=3489.49147, null(22)=0, distinct(9-11)=3489.49147, null(9-11)=0]
+ ├── stats: [rows=3489.49147, distinct(9)=8.33333333, null(9)=0, distinct(10)=150, null(10)=0, distinct(11)=8, null(11)=0, distinct(22)=3489.49147, null(22)=0, distinct(9-11)=3489.49147, null(9-11)=0]
  ├── key: (9-11)
  ├── fd: (9-11)-->(22)
  ├── ordering: -22,+9,+10,+11
@@ -5455,13 +5455,13 @@ sort
       ├── save-table-name: q16_group_by_2
       ├── columns: p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null) count:22(int)
       ├── grouping columns: p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null)
-      ├── stats: [rows=3489.49147, distinct(9)=25, null(9)=0, distinct(10)=150, null(10)=0, distinct(11)=8, null(11)=0, distinct(22)=3489.49147, null(22)=0, distinct(9-11)=3489.49147, null(9-11)=0]
+      ├── stats: [rows=3489.49147, distinct(9)=8.33333333, null(9)=0, distinct(10)=150, null(10)=0, distinct(11)=8, null(11)=0, distinct(22)=3489.49147, null(22)=0, distinct(9-11)=3489.49147, null(9-11)=0]
       ├── key: (9-11)
       ├── fd: (9-11)-->(22)
       ├── inner-join
       │    ├── save-table-name: q16_inner_join_3
       │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null) p_partkey:6(int!null) p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null)
-      │    ├── stats: [rows=14276.4012, distinct(1)=3555.43444, null(1)=0, distinct(2)=7567.69437, null(2)=0, distinct(6)=3555.43444, null(6)=0, distinct(9)=25, null(9)=0, distinct(10)=150, null(10)=0, distinct(11)=8, null(11)=0, distinct(9-11)=3489.49147, null(9-11)=0]
+      │    ├── stats: [rows=14276.4012, distinct(1)=3555.43444, null(1)=0, distinct(2)=7567.69437, null(2)=0, distinct(6)=3555.43444, null(6)=0, distinct(9)=8.33333333, null(9)=0, distinct(10)=150, null(10)=0, distinct(11)=8, null(11)=0, distinct(9-11)=3489.49147, null(9-11)=0]
       │    ├── key: (2,6)
       │    ├── fd: (6)-->(9-11), (1)==(6), (6)==(1)
       │    ├── anti-join (merge)
@@ -5480,7 +5480,7 @@ sort
       │    │    ├── select
       │    │    │    ├── save-table-name: q16_select_6
       │    │    │    ├── columns: s_suppkey:15(int!null) s_comment:21(varchar!null)
-      │    │    │    ├── stats: [rows=3333.33333, distinct(15)=3328.25616, null(15)=0, distinct(21)=3329.14979, null(21)=0]
+      │    │    │    ├── stats: [rows=3333.33333, distinct(15)=3328.25616, null(15)=0, distinct(21)=3333.33333, null(21)=0]
       │    │    │    ├── key: (15)
       │    │    │    ├── fd: (15)-->(21)
       │    │    │    ├── ordering: +15
@@ -5497,7 +5497,7 @@ sort
       │    ├── select
       │    │    ├── save-table-name: q16_select_8
       │    │    ├── columns: p_partkey:6(int!null) p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null)
-      │    │    ├── stats: [rows=3555.55556, distinct(6)=3555.43444, null(6)=0, distinct(9)=25, null(9)=0, distinct(10)=150, null(10)=0, distinct(11)=8, null(11)=0, distinct(9-11)=3553.4368, null(9-11)=0]
+      │    │    ├── stats: [rows=3555.55556, distinct(6)=3555.43444, null(6)=0, distinct(9)=8.33333333, null(9)=0, distinct(10)=150, null(10)=0, distinct(11)=8, null(11)=0, distinct(9-11)=3553.4368, null(9-11)=0]
       │    │    ├── key: (6)
       │    │    ├── fd: (6)-->(9-11)
       │    │    ├── scan part
@@ -5526,7 +5526,7 @@ column_names    row_count  distinct_count  null_count
 {supplier_cnt}  18314      15              0
 ~~~~
 column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{p_brand}       3489.00        5.25 <==       25.00               1.04                0.00            1.00
+{p_brand}       3489.00        5.25 <==       8.00                3.00 <==            0.00            1.00
 {p_size}        3489.00        5.25 <==       8.00                1.00                0.00            1.00
 {p_type}        3489.00        5.25 <==       150.00              1.03                0.00            1.00
 {supplier_cnt}  3489.00        5.25 <==       3489.00             232.60 <==          0.00            1.00
@@ -5541,7 +5541,7 @@ column_names    row_count  distinct_count  null_count
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {count}       3489.00        5.25 <==       3489.00             232.60 <==          0.00            1.00
-{p_brand}     3489.00        5.25 <==       25.00               1.04                0.00            1.00
+{p_brand}     3489.00        5.25 <==       8.00                3.00 <==            0.00            1.00
 {p_size}      3489.00        5.25 <==       8.00                1.00                0.00            1.00
 {p_type}      3489.00        5.25 <==       150.00              1.03                0.00            1.00
 
@@ -5556,7 +5556,7 @@ column_names  row_count  distinct_count  null_count
 {ps_suppkey}  118274     9916            0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{p_brand}     14276.00       8.28 <==       25.00               1.04                0.00            1.00
+{p_brand}     14276.00       8.28 <==       8.00                3.00 <==            0.00            1.00
 {p_partkey}   14276.00       8.28 <==       3555.00             8.28 <==            0.00            1.00
 {p_size}      14276.00       8.28 <==       8.00                1.00                0.00            1.00
 {p_type}      14276.00       8.28 <==       150.00              1.03                0.00            1.00
@@ -5590,7 +5590,7 @@ column_names  row_count  distinct_count  null_count
 {s_suppkey}   4          4               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{s_comment}   3333.00        833.25 <==     3329.00             832.25 <==          0.00            1.00
+{s_comment}   3333.00        833.25 <==     3333.00             833.25 <==          0.00            1.00
 {s_suppkey}   3333.00        833.25 <==     3328.00             832.00 <==          0.00            1.00
 
 stats table=q16_scan_7
@@ -5612,7 +5612,7 @@ column_names  row_count  distinct_count  null_count
 {p_type}      29581      145             0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{p_brand}     3556.00        8.32 <==       25.00               1.04                0.00            1.00
+{p_brand}     3556.00        8.32 <==       8.00                3.00 <==            0.00            1.00
 {p_partkey}   3556.00        8.32 <==       3555.00             8.28 <==            0.00            1.00
 {p_size}      3556.00        8.32 <==       8.00                1.00                0.00            1.00
 {p_type}      3556.00        8.32 <==       150.00              1.03                0.00            1.00
@@ -5685,7 +5685,7 @@ project
  │    │    ├── save-table-name: q17_lookup_join_3
  │    │    ├── columns: l_partkey:2(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) p_partkey:17(int!null) "?column?":43(float!null)
  │    │    ├── key columns: [1 4] = [1 4]
- │    │    ├── stats: [rows=2008.02163, distinct(2)=199.999619, null(2)=0, distinct(5)=50, null(5)=0, distinct(6)=2005.84759, null(6)=0, distinct(17)=199.999619, null(17)=0, distinct(43)=199.990896, null(43)=0]
+ │    │    ├── stats: [rows=2008.02163, distinct(2)=199.999619, null(2)=0, distinct(5)=50, null(5)=0, distinct(6)=2005.84759, null(6)=0, distinct(17)=199.999619, null(17)=0, distinct(43)=199.999619, null(43)=0]
  │    │    ├── fd: (17)-->(43), (2)==(17), (17)==(2)
  │    │    ├── inner-join (lookup lineitem@l_pk)
  │    │    │    ├── save-table-name: q17_lookup_join_4
@@ -6265,7 +6265,7 @@ scalar-group-by
  │    ├── inner-join
  │    │    ├── save-table-name: q19_inner_join_3
  │    │    ├── columns: l_partkey:2(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipinstruct:14(char!null) l_shipmode:15(char!null) p_partkey:17(int!null) p_brand:20(char!null) p_size:22(int!null) p_container:23(char!null)
- │    │    ├── stats: [rows=53556.554, distinct(2)=53556.554, null(2)=0, distinct(5)=50, null(5)=0, distinct(6)=49693.434, null(6)=0, distinct(7)=11, null(7)=0, distinct(14)=1, null(14)=0, distinct(15)=2, null(15)=0, distinct(17)=53556.554, null(17)=0, distinct(20)=25, null(20)=0, distinct(22)=50, null(22)=0, distinct(23)=40, null(23)=0, distinct(6,7)=50346.0112, null(6,7)=0]
+ │    │    ├── stats: [rows=53556.554, distinct(2)=53556.554, null(2)=0, distinct(5)=50, null(5)=0, distinct(6)=49693.434, null(6)=0, distinct(7)=11, null(7)=0, distinct(14)=1, null(14)=0, distinct(15)=2, null(15)=0, distinct(17)=53556.554, null(17)=0, distinct(20)=25, null(20)=0, distinct(22)=16.6666667, null(22)=0, distinct(23)=40, null(23)=0, distinct(6,7)=50346.0112, null(6,7)=0]
  │    │    ├── fd: ()-->(14), (17)-->(20,22,23), (2)==(17), (17)==(2)
  │    │    ├── select
  │    │    │    ├── save-table-name: q19_select_4
@@ -6282,7 +6282,7 @@ scalar-group-by
  │    │    ├── select
  │    │    │    ├── save-table-name: q19_select_6
  │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(char!null) p_size:22(int!null) p_container:23(char!null)
- │    │    │    ├── stats: [rows=66666.6667, distinct(17)=66618.6736, null(17)=0, distinct(20)=25, null(20)=0, distinct(22)=50, null(22)=0, distinct(23)=40, null(23)=0]
+ │    │    │    ├── stats: [rows=66666.6667, distinct(17)=66618.6736, null(17)=0, distinct(20)=25, null(20)=0, distinct(22)=16.6666667, null(22)=0, distinct(23)=40, null(23)=0]
  │    │    │    ├── key: (17)
  │    │    │    ├── fd: (17)-->(20,22,23)
  │    │    │    ├── scan part
@@ -6342,7 +6342,7 @@ column_names       row_count_est  row_count_err  distinct_count_est  distinct_co
 {p_brand}          53557.00       442.62 <==     25.00               8.33 <==            0.00            1.00
 {p_container}      53557.00       442.62 <==     40.00               3.33 <==            0.00            1.00
 {p_partkey}        53557.00       442.62 <==     53557.00            519.97 <==          0.00            1.00
-{p_size}           53557.00       442.62 <==     50.00               3.57 <==            0.00            1.00
+{p_size}           53557.00       442.62 <==     17.00               1.21                0.00            1.00
 
 stats table=q19_select_4
 ----
@@ -6392,7 +6392,7 @@ column_names   row_count_est  row_count_err  distinct_count_est  distinct_count_
 {p_brand}      66667.00       3.00 <==       25.00               1.00                0.00            1.00
 {p_container}  66667.00       3.00 <==       40.00               1.00                0.00            1.00
 {p_partkey}    66667.00       3.00 <==       66619.00            2.99 <==            0.00            1.00
-{p_size}       66667.00       3.00 <==       50.00               1.00                0.00            1.00
+{p_size}       66667.00       3.00 <==       17.00               2.94 <==            0.00            1.00
 
 stats table=q19_scan_7
 ----
@@ -6546,7 +6546,7 @@ sort
            │    │    ├── select
            │    │    │    ├── save-table-name: q20_select_14
            │    │    │    ├── columns: p_partkey:17(int!null) p_name:18(varchar!null)
-           │    │    │    ├── stats: [rows=22222.2222, distinct(17)=22217.3354, null(17)=0, distinct(18)=22210.1238, null(18)=0]
+           │    │    │    ├── stats: [rows=22222.2222, distinct(17)=22217.3354, null(17)=0, distinct(18)=22014.5556, null(18)=0]
            │    │    │    ├── key: (17)
            │    │    │    ├── fd: (17)-->(18)
            │    │    │    ├── scan part
@@ -6745,7 +6745,7 @@ column_names  row_count  distinct_count  null_count
 {p_partkey}   2127       2127            0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{p_name}      22222.00       10.45 <==      22210.00            10.44 <==           0.00            1.00
+{p_name}      22222.00       10.45 <==      22015.00            10.35 <==           0.00            1.00
 {p_partkey}   22222.00       10.45 <==      22217.00            10.45 <==           0.00            1.00
 
 stats table=q20_scan_15
@@ -7316,24 +7316,24 @@ group-by
  ├── sort
  │    ├── save-table-name: q22_sort_2
  │    ├── columns: c_acctbal:6(float!null) cntrycode:27(string)
- │    ├── stats: [rows=16666.6667, distinct(6)=16602.7036, null(6)=0, distinct(27)=16666.6667, null(27)=0]
+ │    ├── stats: [rows=16666.6667, distinct(6)=16666.6667, null(6)=0, distinct(27)=16666.6667, null(27)=0]
  │    ├── ordering: +27
  │    └── project
  │         ├── save-table-name: q22_project_3
  │         ├── columns: cntrycode:27(string) c_acctbal:6(float!null)
- │         ├── stats: [rows=16666.6667, distinct(6)=16602.7036, null(6)=0, distinct(27)=16666.6667, null(27)=0]
+ │         ├── stats: [rows=16666.6667, distinct(6)=16666.6667, null(6)=0, distinct(27)=16666.6667, null(27)=0]
  │         ├── anti-join (merge)
  │         │    ├── save-table-name: q22_merge_join_4
  │         │    ├── columns: c_custkey:1(int!null) c_phone:5(char!null) c_acctbal:6(float!null)
  │         │    ├── left ordering: +1
  │         │    ├── right ordering: +19
- │         │    ├── stats: [rows=16666.6667, distinct(1)=16658.9936, null(1)=0, distinct(5)=16666.6667, null(5)=0, distinct(6)=16602.7036, null(6)=0]
+ │         │    ├── stats: [rows=16666.6667, distinct(1)=16658.9936, null(1)=0, distinct(5)=16666.6667, null(5)=0, distinct(6)=16666.6667, null(6)=0]
  │         │    ├── key: (1)
  │         │    ├── fd: (1)-->(5,6)
  │         │    ├── select
  │         │    │    ├── save-table-name: q22_select_5
  │         │    │    ├── columns: c_custkey:1(int!null) c_phone:5(char!null) c_acctbal:6(float!null)
- │         │    │    ├── stats: [rows=16666.6667, distinct(1)=16658.9936, null(1)=0, distinct(5)=16666.6667, null(5)=0, distinct(6)=16602.7036, null(6)=0]
+ │         │    │    ├── stats: [rows=16666.6667, distinct(1)=16658.9936, null(1)=0, distinct(5)=16666.6667, null(5)=0, distinct(6)=16666.6667, null(6)=0]
  │         │    │    ├── key: (1)
  │         │    │    ├── fd: (1)-->(5,6)
  │         │    │    ├── ordering: +1
@@ -7359,7 +7359,7 @@ group-by
  │         │    │                        ├── select
  │         │    │                        │    ├── save-table-name: q22_select_8
  │         │    │                        │    ├── columns: c_phone:13(char!null) c_acctbal:14(float!null)
- │         │    │                        │    ├── stats: [rows=16666.6667, distinct(13)=16666.6667, null(13)=0, distinct(14)=16602.7036, null(14)=0]
+ │         │    │                        │    ├── stats: [rows=16666.6667, distinct(13)=16666.6667, null(13)=0, distinct(14)=16666.6667, null(14)=0]
  │         │    │                        │    ├── scan customer
  │         │    │                        │    │    ├── save-table-name: q22_scan_9
  │         │    │                        │    │    ├── columns: c_phone:13(char!null) c_acctbal:14(float!null)
@@ -7402,7 +7402,7 @@ column_names  row_count  distinct_count  null_count
 {cntrycode}   6384       7               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{c_acctbal}   16667.00       2.61 <==       16603.00            2.63 <==            0.00            1.00
+{c_acctbal}   16667.00       2.61 <==       16667.00            2.64 <==            0.00            1.00
 {cntrycode}   16667.00       2.61 <==       16667.00            2381.00 <==         0.00            1.00
 
 stats table=q22_project_3
@@ -7412,7 +7412,7 @@ column_names  row_count  distinct_count  null_count
 {cntrycode}   6384       7               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{c_acctbal}   16667.00       2.61 <==       16603.00            2.63 <==            0.00            1.00
+{c_acctbal}   16667.00       2.61 <==       16667.00            2.64 <==            0.00            1.00
 {cntrycode}   16667.00       2.61 <==       16667.00            2381.00 <==         0.00            1.00
 
 stats table=q22_merge_join_4
@@ -7423,7 +7423,7 @@ column_names  row_count  distinct_count  null_count
 {c_phone}     6384       6428            0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{c_acctbal}   16667.00       2.61 <==       16603.00            2.63 <==            0.00            1.00
+{c_acctbal}   16667.00       2.61 <==       16667.00            2.64 <==            0.00            1.00
 {c_custkey}   16667.00       2.61 <==       16659.00            2.62 <==            0.00            1.00
 {c_phone}     16667.00       2.61 <==       16667.00            2.59 <==            0.00            1.00
 
@@ -7435,7 +7435,7 @@ column_names  row_count  distinct_count  null_count
 {c_phone}     19000      19095           0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{c_acctbal}   16667.00       1.14           16603.00            1.12                0.00            1.00
+{c_acctbal}   16667.00       1.14           16667.00            1.11                0.00            1.00
 {c_custkey}   16667.00       1.14           16659.00            1.15                0.00            1.00
 {c_phone}     16667.00       1.14           16667.00            1.15                0.00            1.00
 
@@ -7466,7 +7466,7 @@ column_names  row_count  distinct_count  null_count
 {c_phone}     38120      38046           0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{c_acctbal}   16667.00       2.29 <==       16603.00            2.24 <==            0.00            1.00
+{c_acctbal}   16667.00       2.29 <==       16667.00            2.23 <==            0.00            1.00
 {c_phone}     16667.00       2.29 <==       16667.00            2.28 <==            0.00            1.00
 
 stats table=q22_scan_9

--- a/pkg/sql/opt/optgen/exprgen/testdata/join
+++ b/pkg/sql/opt/optgen/exprgen/testdata/join
@@ -47,11 +47,11 @@ expr
 left-join (lookup abc@ab)
  ├── columns: t.public.abc.a:5(int) t.public.abc.b:6(int)
  ├── key columns: [5] = [5]
- ├── stats: [rows=333333.333]
+ ├── stats: [rows=333333.333, distinct(5)=100, null(5)=3333.33333]
  ├── cost: 691726.697
  ├── scan t.public.def
  │    ├── columns: t.public.def.d:1(int) t.public.def.e:2(int)
- │    ├── stats: [rows=1000]
+ │    ├── stats: [rows=1000, distinct(2)=100, null(2)=10]
  │    ├── cost: 1060.02
  │    └── prune: (1,2)
  └── filters
@@ -127,7 +127,7 @@ inner-join-apply
  ├── select
  │    ├── columns: t.public.def.d:5(int) t.public.def.e:6(int) t.public.def.f:7(int)
  │    ├── outer: (1)
- │    ├── stats: [rows=333.333333]
+ │    ├── stats: [rows=333.333333, distinct(1)=1, null(1)=0]
  │    ├── cost: 1080.03
  │    ├── prune: (7)
  │    ├── scan t.public.def

--- a/pkg/sql/opt/props/histogram.go
+++ b/pkg/sql/opt/props/histogram.go
@@ -1,0 +1,469 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package props
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/errors"
+	"github.com/olekukonko/tablewriter"
+)
+
+// Histogram captures the distribution of values for a particular column within
+// a relational expression.
+type Histogram struct {
+	evalCtx *tree.EvalContext
+	col     opt.ColumnID
+	buckets []HistogramBucket
+}
+
+// HistogramBucket contains the data for a single bucket in a Histogram. Note
+// that NumEq and NumRange are floats so the statisticsBuilder can apply
+// filters to the histogram.
+type HistogramBucket struct {
+	// NumEq is the estimated number of values equal to UpperBound.
+	NumEq float64
+
+	// NumRange is the estimated number of values in this bucket not equal to
+	// UpperBound.
+	NumRange float64
+
+	// UpperBound is the largest value in this bucket. The lower bound can be
+	// inferred based on the upper bound of the previous bucket in the histogram.
+	UpperBound tree.Datum
+}
+
+func (h *Histogram) String() string {
+	w := histogramWriter{}
+	w.init(h.buckets)
+	var buf bytes.Buffer
+	w.write(&buf)
+	return buf.String()
+}
+
+// Init initializes the histogram with data from the catalog.
+func (h *Histogram) Init(
+	evalCtx *tree.EvalContext, col opt.ColumnID, buckets []cat.HistogramBucket,
+) {
+	h.evalCtx = evalCtx
+	h.col = col
+	if len(buckets) == 0 {
+		return
+	}
+	h.buckets = make([]HistogramBucket, len(buckets))
+	for i := range buckets {
+		h.buckets[i].NumEq = float64(buckets[i].NumEq)
+		h.buckets[i].NumRange = float64(buckets[i].NumRange)
+		h.buckets[i].UpperBound = buckets[i].UpperBound
+	}
+}
+
+// Copy returns a deep copy of the histogram.
+func (h *Histogram) Copy() *Histogram {
+	buckets := make([]HistogramBucket, len(h.buckets))
+	copy(buckets, h.buckets)
+	return &Histogram{
+		evalCtx: h.evalCtx,
+		col:     h.col,
+		buckets: buckets,
+	}
+}
+
+// BucketCount returns the number of buckets in the histogram.
+func (h *Histogram) BucketCount() int {
+	return len(h.buckets)
+}
+
+// Bucket returns a pointer to the ith bucket in the histogram.
+// i must be greater than or equal to 0 and less than BucketCount.
+func (h *Histogram) Bucket(i int) *HistogramBucket {
+	return &h.buckets[i]
+}
+
+// ValuesCount returns the total number of values in the histogram. It can
+// be used to estimate the selectivity of a predicate by comparing the values
+// count before and after calling Filter on the histogram.
+func (h *Histogram) ValuesCount() float64 {
+	var count float64
+	for i := range h.buckets {
+		count += h.buckets[i].NumRange
+		count += h.buckets[i].NumEq
+	}
+	return count
+}
+
+// CanFilter returns true if the given constraint can filter the histogram.
+// This is the case if there is only one constrained column in c, it is
+// ascending, and it matches the column of the histogram.
+func (h *Histogram) CanFilter(c *constraint.Constraint) bool {
+	if c.ConstrainedColumns(h.evalCtx) != 1 || c.Columns.Get(0).ID() != h.col {
+		return false
+	}
+	if c.Columns.Get(0).Descending() {
+		return false
+	}
+	return true
+}
+
+// Filter filters the histogram according to the given constraint, and returns
+// a new histogram with the results. CanFilter should be called first to
+// validate that c can filter the histogram.
+func (h *Histogram) Filter(c *constraint.Constraint) *Histogram {
+	// TODO(rytaft): add support for index constraints with multiple ascending
+	// or descending columns.
+	if c.ConstrainedColumns(h.evalCtx) != 1 && c.Columns.Get(0).ID() != h.col {
+		panic(errors.AssertionFailedf("column mismatch"))
+	}
+	if c.Columns.Get(0).Descending() {
+		panic(errors.AssertionFailedf("histogram filter with descending constraint not yet supported"))
+	}
+
+	filtered := &Histogram{
+		evalCtx: h.evalCtx,
+		col:     h.col,
+		buckets: make([]HistogramBucket, 0, len(h.buckets)),
+	}
+	if len(h.buckets) == 0 {
+		return filtered
+	}
+
+	// The lower bound for the first bucket is the smallest possible value for
+	// the data type.
+	// TODO(rytaft): Ensure that the first bucket has a zero value for NumRange,
+	// at least for types that don't have a Min.
+	lowerBound, ok := h.buckets[0].UpperBound.Min(h.evalCtx)
+	if !ok {
+		lowerBound = h.buckets[0].UpperBound
+	}
+
+	// Use variation on merge sort, because both sets of buckets and spans are
+	// ordered and non-overlapping.
+	// TODO(rytaft): use binary search to find the first bucket.
+
+	bucIndex := 0
+	spanIndex := 0
+	keyCtx := constraint.KeyContext{EvalCtx: h.evalCtx}
+	keyCtx.Columns.InitSingle(opt.MakeOrderingColumn(h.col, false /* descending */))
+
+	for bucIndex < h.BucketCount() && spanIndex < c.Spans.Count() {
+		bucket := h.Bucket(bucIndex)
+		// Convert the bucket to a span in order to take advantage of the
+		// constraint library.
+		var left constraint.Span
+		left.Init(
+			constraint.MakeKey(lowerBound),
+			constraint.IncludeBoundary,
+			constraint.MakeKey(bucket.UpperBound),
+			constraint.IncludeBoundary,
+		)
+
+		right := c.Spans.Get(spanIndex)
+
+		if left.StartsAfter(&keyCtx, right) {
+			spanIndex++
+			continue
+		}
+
+		filteredSpan := left
+		if !filteredSpan.TryIntersectWith(&keyCtx, right) {
+			filtered.addEmptyBucket(bucket.UpperBound)
+			lowerBound = h.getNextLowerBound(bucket.UpperBound)
+			bucIndex++
+			continue
+		}
+
+		filteredBucket := bucket
+		if filteredSpan.Compare(&keyCtx, &left) != 0 {
+			// The bucket was cut off in the middle. Get the resulting filtered
+			// bucket.
+			filteredBucket = bucket.getFilteredBucket(&keyCtx, &filteredSpan, lowerBound)
+			if filteredSpan.CompareStarts(&keyCtx, &left) != 0 {
+				// We need to add an empty bucket before the new bucket.
+				emptyBucketUpperBound := filteredSpan.StartKey().Value(0)
+				if filteredSpan.StartBoundary() == constraint.IncludeBoundary {
+					if prev, ok := emptyBucketUpperBound.Prev(h.evalCtx); ok {
+						emptyBucketUpperBound = prev
+					}
+				}
+				filtered.addEmptyBucket(emptyBucketUpperBound)
+			}
+		}
+		filtered.addBucket(filteredBucket)
+
+		// Skip past whichever span ends first, or skip past both if they have
+		// the same endpoint.
+		cmp := left.CompareEnds(&keyCtx, right)
+		if cmp <= 0 {
+			lowerBound = h.getNextLowerBound(bucket.UpperBound)
+			bucIndex++
+		}
+		if cmp >= 0 {
+			spanIndex++
+		}
+	}
+
+	return filtered
+}
+
+func (h *Histogram) getNextLowerBound(currentUpperBound tree.Datum) tree.Datum {
+	nextLowerBound, ok := currentUpperBound.Next(h.evalCtx)
+	if !ok {
+		nextLowerBound = currentUpperBound
+	}
+	return nextLowerBound
+}
+
+func (h *Histogram) addEmptyBucket(upperBound tree.Datum) {
+	h.addBucket(&HistogramBucket{UpperBound: upperBound})
+}
+
+func (h *Histogram) addBucket(bucket *HistogramBucket) {
+	// Check whether we can combine this bucket with the previous bucket.
+	if len(h.buckets) != 0 {
+		lastBucket := &h.buckets[len(h.buckets)-1]
+		if lastBucket.NumRange == 0 && lastBucket.NumEq == 0 && bucket.NumRange == 0 {
+			lastBucket.NumEq = bucket.NumEq
+			lastBucket.UpperBound = bucket.UpperBound
+			return
+		}
+		if lastBucket.UpperBound.Compare(h.evalCtx, bucket.UpperBound) == 0 {
+			lastBucket.NumEq += bucket.NumRange + bucket.NumEq
+			return
+		}
+	}
+	h.buckets = append(h.buckets, *bucket)
+}
+
+// ApplySelectivity reduces the size of each histogram bucket according to
+// the given selectivity.
+func (h *Histogram) ApplySelectivity(selectivity float64) {
+	for i := range h.buckets {
+		h.buckets[i].NumEq *= selectivity
+		h.buckets[i].NumRange *= selectivity
+	}
+}
+
+// getFilteredBucket filters the histogram bucket according to the given span,
+// and returns a new bucket with the results. The span represents the maximum
+// range of values that remain in the bucket after filtering. The span must
+// be fully contained within the bucket, or else getFilteredBucket will throw
+// an error.
+//
+// For example, suppose a bucket initially has lower bound 0 (inclusive) and
+// contains the following data: {NumEq: 5, NumRange: 10, UpperBound: 10} (all
+// values are integers).
+//
+// The following spans will filter the bucket as shown:
+//   [/0 - /5]   => {NumEq: 1, NumRange: 5, UpperBound: 5}
+//   [/2 - /10]  => {NumEq: 5, NumRange: 8, UpperBound: 10}
+//   [/20 - /30] => error
+//
+// Note that the calculations for NumEq and NumRange depend on the data type.
+// For discrete data types such as integers and dates, it is always possible
+// to assign a non-zero value for NumEq as long as NumEq and NumRange were
+// non-zero in the original bucket. For continuous types such as floats,
+// NumEq will be zero unless the filtered bucket includes the original upper
+// bound. For example, given the same bucket as in the above example, but with
+// floating point values instead of integers:
+//
+//   [/0 - /5]   => {NumEq: 0, NumRange: 5, UpperBound: 5.0}
+//   [/2 - /10]  => {NumEq: 5, NumRange: 8, UpperBound: 10.0}
+//   [/20 - /30] => error
+//
+// For non-numeric types such as strings, it is not possible to estimate
+// the size of NumRange if the bucket is cut off in the middle. In this case,
+// we use the heuristic that NumRange is reduced by half.
+//
+func (b *HistogramBucket) getFilteredBucket(
+	keyCtx *constraint.KeyContext, filteredSpan *constraint.Span, bucketLowerBound tree.Datum,
+) *HistogramBucket {
+	spanLowerBound := filteredSpan.StartKey().Value(0)
+	spanUpperBound := filteredSpan.EndKey().Value(0)
+
+	// Check that the given span is contained in the bucket.
+	cmpSpanStartBucketStart := spanLowerBound.Compare(keyCtx.EvalCtx, bucketLowerBound)
+	cmpSpanEndBucketEnd := spanUpperBound.Compare(keyCtx.EvalCtx, b.UpperBound)
+	if cmpSpanStartBucketStart < 0 || cmpSpanEndBucketEnd > 0 {
+		panic(errors.AssertionFailedf("span must be fully contained in the bucket"))
+	}
+
+	var rangeBefore, rangeAfter float64
+	isDiscrete := false
+	ok := true
+	// TODO(rytaft): handle more types here.
+	// Note: the calculations below assume that bucketLowerBound is inclusive and
+	// Span.PreferInclusive() has been called on the span.
+	switch spanLowerBound.ResolvedType().Family() {
+	case types.IntFamily:
+		rangeBefore = float64(*b.UpperBound.(*tree.DInt)) - float64(*bucketLowerBound.(*tree.DInt))
+		rangeAfter = float64(*spanUpperBound.(*tree.DInt)) - float64(*spanLowerBound.(*tree.DInt))
+		isDiscrete = true
+
+	case types.DateFamily:
+		lowerBefore := bucketLowerBound.(*tree.DDate)
+		upperBefore := b.UpperBound.(*tree.DDate)
+		lowerAfter := spanLowerBound.(*tree.DDate)
+		upperAfter := spanUpperBound.(*tree.DDate)
+		if lowerBefore.IsFinite() && upperBefore.IsFinite() &&
+			lowerAfter.IsFinite() && upperAfter.IsFinite() {
+			rangeBefore = float64(upperBefore.PGEpochDays()) - float64(lowerBefore.PGEpochDays())
+			rangeAfter = float64(upperAfter.PGEpochDays()) - float64(lowerAfter.PGEpochDays())
+			isDiscrete = true
+		} else {
+			ok = false
+		}
+
+	case types.DecimalFamily:
+		lowerBefore, err := bucketLowerBound.(*tree.DDecimal).Float64()
+		if err != nil {
+			ok = false
+			break
+		}
+		upperBefore, err := b.UpperBound.(*tree.DDecimal).Float64()
+		if err != nil {
+			ok = false
+			break
+		}
+		lowerAfter, err := spanLowerBound.(*tree.DDecimal).Float64()
+		if err != nil {
+			ok = false
+			break
+		}
+		upperAfter, err := spanUpperBound.(*tree.DDecimal).Float64()
+		if err != nil {
+			ok = false
+			break
+		}
+		rangeBefore = upperBefore - lowerBefore
+		rangeAfter = upperAfter - lowerAfter
+
+	case types.FloatFamily:
+		rangeBefore = float64(*b.UpperBound.(*tree.DFloat)) - float64(*bucketLowerBound.(*tree.DFloat))
+		rangeAfter = float64(*spanUpperBound.(*tree.DFloat)) - float64(*spanLowerBound.(*tree.DFloat))
+
+	case types.TimestampFamily:
+		lowerBefore := bucketLowerBound.(*tree.DTimestamp).Time
+		upperBefore := b.UpperBound.(*tree.DTimestamp).Time
+		lowerAfter := spanLowerBound.(*tree.DTimestamp).Time
+		upperAfter := spanUpperBound.(*tree.DTimestamp).Time
+		rangeBefore = float64(upperBefore.Sub(lowerBefore))
+		rangeAfter = float64(upperAfter.Sub(lowerAfter))
+
+	case types.TimestampTZFamily:
+		lowerBefore := bucketLowerBound.(*tree.DTimestampTZ).Time
+		upperBefore := b.UpperBound.(*tree.DTimestampTZ).Time
+		lowerAfter := spanLowerBound.(*tree.DTimestampTZ).Time
+		upperAfter := spanUpperBound.(*tree.DTimestampTZ).Time
+		rangeBefore = float64(upperBefore.Sub(lowerBefore))
+		rangeAfter = float64(upperAfter.Sub(lowerAfter))
+
+	default:
+		ok = false
+	}
+
+	var numEq float64
+	isSpanEndBoundaryInclusive := filteredSpan.EndBoundary() == constraint.IncludeBoundary
+	includesOriginalUpperBound := isSpanEndBoundaryInclusive && cmpSpanEndBucketEnd == 0
+	if includesOriginalUpperBound {
+		numEq = b.NumEq
+	}
+
+	var numRange float64
+	if ok && rangeBefore > 0 {
+		if isDiscrete && !includesOriginalUpperBound {
+			// The data type is discrete (e.g., integer or date) and the new upper
+			// bound falls within the original range, so we can assign some of the
+			// old NumRange to the new NumEq.
+			numEq = b.NumRange / rangeBefore
+		}
+		numRange = b.NumRange * rangeAfter / rangeBefore
+	} else if b.UpperBound.Compare(keyCtx.EvalCtx, spanLowerBound) == 0 {
+		// This span represents an equality condition with the upper bound.
+		numRange = 0
+	} else {
+		// In the absence of any information, assume we reduced the size of the
+		// bucket by half.
+		numRange = 0.5 * b.NumRange
+	}
+
+	return &HistogramBucket{
+		NumEq:      numEq,
+		NumRange:   numRange,
+		UpperBound: spanUpperBound,
+	}
+}
+
+// histogramWriter prints histograms with the following formatting:
+//   NumRange1    NumEq1     NumRange2    NumEq2    ....
+// <----------- UpperBound1 ----------- UpperBound2 ....
+//
+// For example:
+//   0  1  90  10   0  20
+// <--- 0 ---- 100 --- 200
+//
+// This describes a histogram with 3 buckets. The first bucket contains 1 value
+// equal to 0. The second bucket contains 90 values between 0 and 100 and
+// 10 values equal to 100. Finally, the third bucket contains 20 values equal
+// to 200.
+type histogramWriter struct {
+	cells     [][]string
+	colWidths []int
+}
+
+const (
+	// These constants describe the two rows that are printed.
+	counts = iota
+	boundaries
+)
+
+func (w *histogramWriter) init(buckets []HistogramBucket) {
+	w.cells = [][]string{
+		make([]string, len(buckets)*2),
+		make([]string, len(buckets)*2),
+	}
+	w.colWidths = make([]int, len(buckets)*2)
+
+	for i, b := range buckets {
+		w.cells[counts][i*2] = fmt.Sprintf(" %.5g ", b.NumRange)
+		w.cells[counts][i*2+1] = fmt.Sprintf("%.5g", b.NumEq)
+		// TODO(rytaft): truncate large strings.
+		w.cells[boundaries][i*2+1] = fmt.Sprintf(" %s ", b.UpperBound.String())
+		if width := tablewriter.DisplayWidth(w.cells[counts][i*2]); width > w.colWidths[i*2] {
+			w.colWidths[i*2] = width
+		}
+		if width := tablewriter.DisplayWidth(w.cells[counts][i*2+1]); width > w.colWidths[i*2+1] {
+			w.colWidths[i*2+1] = width
+		}
+		if width := tablewriter.DisplayWidth(w.cells[boundaries][i*2+1]); width > w.colWidths[i*2+1] {
+			w.colWidths[i*2+1] = width
+		}
+	}
+}
+
+func (w *histogramWriter) write(out io.Writer) {
+	// Print a space to match up with the "<" character below.
+	fmt.Fprint(out, " ")
+	for i := range w.cells[counts] {
+		fmt.Fprintf(out, "%s", tablewriter.Pad(w.cells[counts][i], " ", w.colWidths[i]))
+	}
+	fmt.Fprint(out, "\n")
+	fmt.Fprint(out, "<")
+	for i := range w.cells[boundaries] {
+		fmt.Fprintf(out, "%s", tablewriter.Pad(w.cells[boundaries][i], "-", w.colWidths[i]))
+	}
+}

--- a/pkg/sql/opt/props/histogram_test.go
+++ b/pkg/sql/opt/props/histogram_test.go
@@ -1,0 +1,360 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package props
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+)
+
+func TestHistogram(t *testing.T) {
+	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+
+	//   0  1  3  3   4  5   0  0   40  35
+	// <--- 1 --- 10 --- 25 --- 30 ---- 42
+	histData := []cat.HistogramBucket{
+		{NumRange: 0, NumEq: 1, UpperBound: tree.NewDInt(1)},
+		{NumRange: 3, NumEq: 3, UpperBound: tree.NewDInt(10)},
+		{NumRange: 4, NumEq: 5, UpperBound: tree.NewDInt(25)},
+		{NumRange: 0, NumEq: 0, UpperBound: tree.NewDInt(30)},
+		{NumRange: 40, NumEq: 35, UpperBound: tree.NewDInt(42)},
+	}
+	h := &Histogram{}
+	h.Init(&evalCtx, opt.ColumnID(1), histData)
+
+	testData := []struct {
+		constraint string
+		buckets    []HistogramBucket
+		count      float64
+	}{
+		{
+			constraint: "/1: [/0 - /0]",
+			//   0  0
+			// <--- 0
+			buckets: []HistogramBucket{
+				{NumRange: 0, NumEq: 0, UpperBound: tree.NewDInt(0)},
+			},
+			count: 0,
+		},
+		{
+			constraint: "/1: [/50 - /100]",
+			//   0  0
+			// <--- 42
+			buckets: []HistogramBucket{
+				{NumRange: 0, NumEq: 0, UpperBound: tree.NewDInt(42)},
+			},
+			count: 0,
+		},
+		{
+			constraint: "/1: [ - /1] [/11 - /24] [/30 - /45]",
+			//   0  1  0  0   3.7143 0.28571 0  0   40  35
+			// <--- 1 --- 10 --------- 24 ----- 30 ---- 42
+			buckets: []HistogramBucket{
+				{NumRange: 0, NumEq: 1, UpperBound: tree.NewDInt(1)},
+				{NumRange: 0, NumEq: 0, UpperBound: tree.NewDInt(10)},
+				{NumRange: 4 * 13.0 / 14.0, NumEq: 4 * 1.0 / 14.0, UpperBound: tree.NewDInt(24)},
+				{NumRange: 0, NumEq: 0, UpperBound: tree.NewDInt(30)},
+				{NumRange: 40, NumEq: 35, UpperBound: tree.NewDInt(42)},
+			},
+			count: 80,
+		},
+		{
+			constraint: "/1: [/5 - /10] [/15 - /32] [/34 - /36] [/38 - ]",
+			//   0  0  1.875  3   0  0   2.8571  5   0  0   3.6364 3.6364 0  0   7.2727 3.6364 0  0   14.545  35
+			// <--- 4 ------- 10 --- 14 -------- 25 --- 30 --------- 32 ---- 33 --------- 36 ---- 37 -------- 42
+			buckets: []HistogramBucket{
+				{NumRange: 0, NumEq: 0, UpperBound: tree.NewDInt(4)},
+				{NumRange: 3 * 5.0 / 8.0, NumEq: 3, UpperBound: tree.NewDInt(10)},
+				{NumRange: 0, NumEq: 0, UpperBound: tree.NewDInt(14)},
+				{NumRange: 4 * 10.0 / 14.0, NumEq: 5, UpperBound: tree.NewDInt(25)},
+				{NumRange: 0, NumEq: 0, UpperBound: tree.NewDInt(30)},
+				{NumRange: 40.0 / 11.0, NumEq: 40.0 / 11.0, UpperBound: tree.NewDInt(32)},
+				{NumRange: 0, NumEq: 0, UpperBound: tree.NewDInt(33)},
+				{NumRange: 2 * 40.0 / 11.0, NumEq: 40.0 / 11.0, UpperBound: tree.NewDInt(36)},
+				{NumRange: 0, NumEq: 0, UpperBound: tree.NewDInt(37)},
+				{NumRange: 4 * 40.0 / 11.0, NumEq: 35, UpperBound: tree.NewDInt(42)},
+			},
+			count: 3*5.0/8.0 + 4*10.0/14.0 + 9*40.0/11 + 43,
+		},
+		{
+			constraint: "/1: [ - /41]",
+			//   0  1  3  3   4  5   0  0   36.364 3.6364
+			// <--- 1 --- 10 --- 25 --- 30 --------- 41 -
+			buckets: []HistogramBucket{
+				{NumRange: 0, NumEq: 1, UpperBound: tree.NewDInt(1)},
+				{NumRange: 3, NumEq: 3, UpperBound: tree.NewDInt(10)},
+				{NumRange: 4, NumEq: 5, UpperBound: tree.NewDInt(25)},
+				{NumRange: 0, NumEq: 0, UpperBound: tree.NewDInt(30)},
+				{NumRange: 10 * 40.0 / 11.0, NumEq: 40.0 / 11.0, UpperBound: tree.NewDInt(41)},
+			},
+			count: 56,
+		},
+		{
+			constraint: "/1: [/1 - ]",
+			//   0  1  3  3   4  5   0  0   40  35
+			// <--- 1 --- 10 --- 25 --- 30 ---- 42
+			buckets: []HistogramBucket{
+				{NumRange: 0, NumEq: 1, UpperBound: tree.NewDInt(1)},
+				{NumRange: 3, NumEq: 3, UpperBound: tree.NewDInt(10)},
+				{NumRange: 4, NumEq: 5, UpperBound: tree.NewDInt(25)},
+				{NumRange: 0, NumEq: 0, UpperBound: tree.NewDInt(30)},
+				{NumRange: 40, NumEq: 35, UpperBound: tree.NewDInt(42)},
+			},
+			count: 91,
+		},
+	}
+
+	for i := range testData {
+		c := constraint.ParseConstraint(&evalCtx, testData[i].constraint)
+		if !h.CanFilter(&c) {
+			t.Fatalf("constraint %s cannot filter histogram %v", c.String(), *h)
+		}
+		filtered := h.Filter(&c)
+		if !reflect.DeepEqual(testData[i].buckets, filtered.buckets) {
+			t.Fatalf("expected %v but found %v", testData[i].buckets, filtered.buckets)
+		}
+		count := filtered.ValuesCount()
+		if testData[i].count != count {
+			t.Fatalf("expected %f but found %f", testData[i].count, count)
+		}
+	}
+}
+
+func TestFilterBucket(t *testing.T) {
+	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	keyCtx := constraint.KeyContext{EvalCtx: &evalCtx}
+	keyCtx.Columns.InitSingle(opt.MakeOrderingColumn(opt.ColumnID(1), false /* descending */))
+
+	type testCase struct {
+		span     string
+		expected *HistogramBucket
+		isError  bool
+	}
+	runTestCase := func(
+		bucket *HistogramBucket, lowerBound tree.Datum, span *constraint.Span,
+	) (actual *HistogramBucket, err error) {
+		defer func() {
+			// Any errors will be propagated as panics.
+			if r := recover(); r != nil {
+				if e, ok := r.(error); ok {
+					err = e
+					return
+				}
+				panic(r)
+			}
+		}()
+
+		return bucket.getFilteredBucket(&keyCtx, span, lowerBound), nil
+	}
+
+	runTest := func(
+		bucket *HistogramBucket, lowerBound tree.Datum, testData []testCase, typ types.Family,
+	) {
+		for _, testCase := range testData {
+			span := constraint.ParseSpan(&evalCtx, testCase.span, typ)
+			actual, err := runTestCase(bucket, lowerBound, &span)
+			if err != nil && !testCase.isError {
+				t.Fatal(err)
+			} else if err == nil && testCase.isError {
+				t.Fatal("expected an error")
+			} else if !reflect.DeepEqual(testCase.expected, actual) {
+				t.Fatalf("exected %v but found %v", testCase.expected, actual)
+			}
+		}
+	}
+
+	t.Run("int", func(t *testing.T) {
+		bucket := &HistogramBucket{NumEq: 5, NumRange: 10, UpperBound: tree.NewDInt(10)}
+		lowerBound := tree.NewDInt(0)
+		testData := []testCase{
+			{
+				span:     "[/0 - /0]",
+				expected: &HistogramBucket{NumEq: 1, NumRange: 0, UpperBound: tree.NewDInt(0)},
+			},
+			{
+				span:     "[/0 - /5]",
+				expected: &HistogramBucket{NumEq: 1, NumRange: 5, UpperBound: tree.NewDInt(5)},
+			},
+			{
+				span:     "[/2 - /9]",
+				expected: &HistogramBucket{NumEq: 1, NumRange: 7, UpperBound: tree.NewDInt(9)},
+			},
+			{
+				span:     "[/2 - /10]",
+				expected: &HistogramBucket{NumEq: 5, NumRange: 8, UpperBound: tree.NewDInt(10)},
+			},
+			{
+				span:     "[/10 - /10]",
+				expected: &HistogramBucket{NumEq: 5, NumRange: 0, UpperBound: tree.NewDInt(10)},
+			},
+			{
+				span:    "[/20 - /30]",
+				isError: true,
+			},
+		}
+
+		runTest(bucket, lowerBound, testData, types.IntFamily)
+	})
+
+	t.Run("float", func(t *testing.T) {
+		bucket := &HistogramBucket{NumEq: 5, NumRange: 10, UpperBound: tree.NewDFloat(10)}
+		lowerBound := tree.NewDFloat(0)
+
+		testData := []testCase{
+			{
+				span:     "[/0 - /0]",
+				expected: &HistogramBucket{NumEq: 0, NumRange: 0, UpperBound: tree.NewDFloat(0)},
+			},
+			{
+				span:     "(/0 - /5]",
+				expected: &HistogramBucket{NumEq: 0, NumRange: 5, UpperBound: tree.NewDFloat(5)},
+			},
+			{
+				span:     "[/2.5 - /9)",
+				expected: &HistogramBucket{NumEq: 0, NumRange: 6.5, UpperBound: tree.NewDFloat(9)},
+			},
+			{
+				span:     "[/2 - /10]",
+				expected: &HistogramBucket{NumEq: 5, NumRange: 8, UpperBound: tree.NewDFloat(10)},
+			},
+			{
+				span:     "[/10 - /10]",
+				expected: &HistogramBucket{NumEq: 5, NumRange: 0, UpperBound: tree.NewDFloat(10)},
+			},
+			{
+				span:    "[/10 - /20]",
+				isError: true,
+			},
+		}
+
+		runTest(bucket, lowerBound, testData, types.FloatFamily)
+	})
+
+	t.Run("decimal", func(t *testing.T) {
+		upperBound, err := tree.ParseDDecimal("10")
+		if err != nil {
+			t.Fatal(err)
+		}
+		bucket := &HistogramBucket{NumEq: 5, NumRange: 10, UpperBound: upperBound}
+		lowerBound, err := tree.ParseDDecimal("0")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ub1, err := tree.ParseDDecimal("9")
+		if err != nil {
+			t.Fatal(err)
+		}
+		ub2, err := tree.ParseDDecimal("10.00")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		testData := []testCase{
+			{
+				span:     "[/2.50 - /9)",
+				expected: &HistogramBucket{NumEq: 0, NumRange: 6.5, UpperBound: ub1},
+			},
+			{
+				span:     "[/2 - /10.00]",
+				expected: &HistogramBucket{NumEq: 5, NumRange: 8, UpperBound: ub2},
+			},
+		}
+
+		runTest(bucket, lowerBound, testData, types.DecimalFamily)
+	})
+
+	t.Run("date", func(t *testing.T) {
+		upperBound, err := tree.ParseDDate(&evalCtx, "2019-08-01")
+		if err != nil {
+			t.Fatal(err)
+		}
+		bucket := &HistogramBucket{NumEq: 1, NumRange: 62, UpperBound: upperBound}
+		lowerBound, err := tree.ParseDDate(&evalCtx, "2019-07-01")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ub1, err := tree.ParseDDate(&evalCtx, "2019-07-02")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		testData := []testCase{
+			{
+				span:     "[/2019-07-01 - /2019-07-02]",
+				expected: &HistogramBucket{NumEq: 2, NumRange: 2, UpperBound: ub1},
+			},
+			{
+				span:     "[/2019-07-05 - /2019-08-01]",
+				expected: &HistogramBucket{NumEq: 1, NumRange: 54, UpperBound: upperBound},
+			},
+		}
+
+		runTest(bucket, lowerBound, testData, types.DateFamily)
+	})
+
+	t.Run("timestamp", func(t *testing.T) {
+		upperBound, err := tree.ParseDTimestamp(&evalCtx, "2019-08-01 12:00:00.000000", time.Microsecond)
+		if err != nil {
+			t.Fatal(err)
+		}
+		bucket := &HistogramBucket{NumEq: 1, NumRange: 62, UpperBound: upperBound}
+		lowerBound, err := tree.ParseDTimestamp(&evalCtx, "2019-07-01 12:00:00.000000", time.Microsecond)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ub1, err := tree.ParseDTimestamp(&evalCtx, "2019-07-02 00:00:00.000000", time.Microsecond)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		testData := []testCase{
+			{
+				span:     "[/2019-07-01 12:00:00.000000 - /2019-07-02 00:00:00.000000)",
+				expected: &HistogramBucket{NumEq: 0, NumRange: 1, UpperBound: ub1},
+			},
+			{
+				span:     "[/2019-07-05 12:00:00.000000 - /2019-08-01 12:00:00.000000)",
+				expected: &HistogramBucket{NumEq: 0, NumRange: 54, UpperBound: upperBound},
+			},
+		}
+
+		runTest(bucket, lowerBound, testData, types.TimestampFamily)
+	})
+
+	t.Run("string", func(t *testing.T) {
+		bucket := &HistogramBucket{NumEq: 5, NumRange: 10, UpperBound: tree.NewDString("foo")}
+		lowerBound := tree.NewDString("bar")
+		testData := []testCase{
+			{
+				span:     "[/bar - /baz]",
+				expected: &HistogramBucket{NumEq: 0, NumRange: 5, UpperBound: tree.NewDString("baz")},
+			},
+			{
+				span:     "[/baz - /foo]",
+				expected: &HistogramBucket{NumEq: 5, NumRange: 5, UpperBound: tree.NewDString("foo")},
+			},
+		}
+
+		runTest(bucket, lowerBound, testData, types.StringFamily)
+	})
+
+}

--- a/pkg/sql/opt/props/statistics.go
+++ b/pkg/sql/opt/props/statistics.go
@@ -128,9 +128,7 @@ type ColumnStatistic struct {
 	Cols opt.ColSet
 
 	// DistinctCount is the estimated number of distinct values of this
-	// set of columns for this expression. Excludes values containing
-	// a null in one of the cols - those are counted in NullCount.
-	// TODO(itsbilal): Count null values as a distinct value as well.
+	// set of columns for this expression. Includes null values.
 	DistinctCount float64
 
 	// NullCount is the estimated number of null values of this set of

--- a/pkg/sql/opt/props/statistics.go
+++ b/pkg/sql/opt/props/statistics.go
@@ -15,8 +15,10 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/olekukonko/tablewriter"
 )
 
 // Statistics is a collection of measurements and statistics that is used by
@@ -113,6 +115,20 @@ func (s *Statistics) String() string {
 		fmt.Fprintf(&buf, ", null%s=%.9g", col.Cols.String(), col.NullCount)
 	}
 	buf.WriteString("]")
+	for _, col := range colStats {
+		if col.Histogram != nil {
+			label := fmt.Sprintf("histogram%s=", col.Cols.String())
+			indent := strings.Repeat(" ", tablewriter.DisplayWidth(label))
+			fmt.Fprintf(&buf, "\n%s", label)
+			histLines := strings.Split(strings.TrimRight(col.Histogram.String(), "\n"), "\n")
+			for i, line := range histLines {
+				if i != 0 {
+					fmt.Fprintf(&buf, "\n%s", indent)
+				}
+				fmt.Fprintf(&buf, "%s", strings.TrimRight(line, " "))
+			}
+		}
+	}
 
 	return buf.String()
 }
@@ -136,14 +152,23 @@ type ColumnStatistic struct {
 	// count tracks all instances of at least one null value in the
 	// column set.
 	NullCount float64
+
+	// Histogram is only used when the size of Cols is one. It contains
+	// the approximate distribution of values for that column, represented
+	// by a slice of histogram buckets.
+	Histogram *Histogram
 }
 
-// ApplySelectivity updates the distinct count and null count according to a
-// given selectivity.
+// ApplySelectivity updates the distinct count, null count, and histogram
+// according to a given selectivity.
 func (c *ColumnStatistic) ApplySelectivity(selectivity, inputRows float64) {
 	// Since the null count is a simple count of all null rows, we can
 	// just multiply the selectivity with it.
 	c.NullCount *= selectivity
+
+	if c.Histogram != nil {
+		c.Histogram.ApplySelectivity(selectivity)
+	}
 
 	if selectivity == 1 || c.DistinctCount == 0 {
 		return

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -877,6 +878,32 @@ func (ts *TableStat) DistinctCount() uint64 {
 // NullCount is part of the cat.TableStatistic interface.
 func (ts *TableStat) NullCount() uint64 {
 	return ts.js.NullCount
+}
+
+// Histogram is part of the cat.TableStatistic interface.
+func (ts *TableStat) Histogram() []cat.HistogramBucket {
+	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	if ts.js.HistogramColumnType == "" {
+		return nil
+	}
+	colType, err := parser.ParseType(ts.js.HistogramColumnType)
+	if err != nil {
+		panic(err)
+	}
+	histogram := make([]cat.HistogramBucket, len(ts.js.HistogramBuckets))
+	for i := range histogram {
+		bucket := &ts.js.HistogramBuckets[i]
+		datum, err := tree.ParseStringAs(colType, bucket.UpperBound, &evalCtx)
+		if err != nil {
+			panic(err)
+		}
+		histogram[i] = cat.HistogramBucket{
+			NumEq:      uint64(bucket.NumEq),
+			NumRange:   uint64(bucket.NumRange),
+			UpperBound: datum,
+		}
+	}
+	return histogram
 }
 
 // TableStats is a slice of TableStat pointers.

--- a/pkg/sql/opt/xform/testdata/coster/select
+++ b/pkg/sql/opt/xform/testdata/coster/select
@@ -7,7 +7,7 @@ SELECT k, s FROM a WHERE s >= 'foo'
 ----
 select
  ├── columns: k:1(int!null) s:3(string!null)
- ├── stats: [rows=330, distinct(1)=330, null(1)=0, distinct(3)=98.265847, null(3)=0]
+ ├── stats: [rows=330, distinct(1)=330, null(1)=0, distinct(3)=33.3333333, null(3)=0]
  ├── cost: 1070.03
  ├── key: (1)
  ├── fd: (1)-->(3)

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -1239,7 +1239,7 @@ scalar-group-by
  ├── inner-join (lookup stock)
  │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_i_id:5(int!null) s_i_id:11(int!null) s_w_id:12(int!null) s_quantity:13(int!null)
  │    ├── key columns: [3 5] = [12 11]
- │    ├── stats: [rows=234.432912, distinct(1)=19.9998377, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(5)=199.843131, null(5)=0, distinct(11)=199.843131, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=84.0785286, null(13)=0]
+ │    ├── stats: [rows=234.432912, distinct(1)=19.9998377, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(5)=199.843131, null(5)=0, distinct(11)=199.843131, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=30.3199861, null(13)=0]
  │    ├── cost: 1548.66615
  │    ├── fd: ()-->(2,3,12), (11)-->(13), (5)==(11), (11)==(5), (3)==(12), (12)==(3)
  │    ├── interesting orderings: (+3,+2,-1)
@@ -1293,7 +1293,7 @@ scalar-group-by
  │    ├── columns: w_id:1(int!null) w_ytd:9(decimal!null) d_w_id:11(int!null) sum:21(decimal!null)
  │    ├── left ordering: +1
  │    ├── right ordering: +11
- │    ├── stats: [rows=33.3333333, distinct(1)=33.3333333, null(1)=0, distinct(9)=1, null(9)=0, distinct(11)=33.3333333, null(11)=0, distinct(21)=28.3867538, null(21)=0]
+ │    ├── stats: [rows=33.3333333, distinct(1)=33.3333333, null(1)=0, distinct(9)=1, null(9)=0, distinct(11)=33.3333333, null(11)=0, distinct(21)=33.3333333, null(21)=0]
  │    ├── cost: 1264.39333
  │    ├── key: (11)
  │    ├── fd: (1)-->(9), (11)-->(21), (1)==(11), (11)==(1)
@@ -2872,7 +2872,7 @@ scalar-group-by
  ├── inner-join (lookup stock)
  │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_i_id:5(int!null) s_i_id:11(int!null) s_w_id:12(int!null) s_quantity:13(int!null)
  │    ├── key columns: [3 5] = [12 11]
- │    ├── stats: [rows=229.899982, distinct(1)=19.9997964, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(5)=198.51294, null(5)=0, distinct(11)=198.51294, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=83.7250115, null(13)=0]
+ │    ├── stats: [rows=229.899982, distinct(1)=19.9997964, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(5)=198.51294, null(5)=0, distinct(11)=198.51294, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=30.3178347, null(13)=0]
  │    ├── cost: 1531.75566
  │    ├── fd: ()-->(2,3,12), (11)-->(13), (5)==(11), (11)==(5), (3)==(12), (12)==(3)
  │    ├── interesting orderings: (+3,+2,-1)
@@ -2926,7 +2926,7 @@ scalar-group-by
  │    ├── columns: w_id:1(int!null) w_ytd:9(decimal!null) d_w_id:11(int!null) sum:21(decimal!null)
  │    ├── left ordering: +1
  │    ├── right ordering: +11
- │    ├── stats: [rows=3.33333333, distinct(1)=3.33333333, null(1)=0, distinct(9)=2.87528606, null(9)=0, distinct(11)=3.33333333, null(11)=0, distinct(21)=2.87528606, null(21)=0]
+ │    ├── stats: [rows=3.33333333, distinct(1)=3.33333333, null(1)=0, distinct(9)=3.33333333, null(9)=0, distinct(11)=3.33333333, null(11)=0, distinct(21)=3.33333333, null(21)=0]
  │    ├── cost: 126.493333
  │    ├── key: (11)
  │    ├── fd: (1)-->(9), (11)-->(21), (1)==(11), (11)==(1)

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -596,7 +596,7 @@ scalar-group-by
  ├── inner-join (lookup warehouse)
  │    ├── columns: w_id:1(int!null) w_ytd:9(decimal!null) d_w_id:11(int!null) sum:21(decimal!null)
  │    ├── key columns: [11] = [1]
- │    ├── stats: [rows=33, distinct(1)=33, null(1)=0, distinct(9)=28.3508504, null(9)=0, distinct(11)=33, null(11)=0, distinct(21)=28.3508504, null(21)=0]
+ │    ├── stats: [rows=33, distinct(1)=33, null(1)=0, distinct(9)=33, null(9)=0, distinct(11)=33, null(11)=0, distinct(21)=33, null(21)=0]
  │    ├── cost: 1621
  │    ├── key: (11)
  │    ├── fd: (1)-->(9), (11)-->(21), (1)==(11), (11)==(1)

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -223,7 +223,7 @@ sort
 memo
 SELECT y, z FROM a WHERE x>y ORDER BY y
 ----
-memo (optimized, ~4KB, required=[presentation: y:2,z:3] [ordering: +2])
+memo (optimized, ~5KB, required=[presentation: y:2,z:3] [ordering: +2])
  ├── G1: (project G2 G3 y z)
  │    ├── [presentation: y:2,z:3] [ordering: +2]
  │    │    ├── best: (sort G1)
@@ -512,7 +512,7 @@ memo (optimized, ~2KB, required=[presentation: tree:5,field:8,description:9,colu
 memo
 SELECT y FROM a WITH ORDINALITY ORDER BY ordinality
 ----
-memo (optimized, ~3KB, required=[presentation: y:2] [ordering: +5])
+memo (optimized, ~4KB, required=[presentation: y:2] [ordering: +5])
  ├── G1: (ordinality G2)
  │    ├── [presentation: y:2] [ordering: +5]
  │    │    ├── best: (ordinality G2)
@@ -551,7 +551,7 @@ memo (optimized, ~5KB, required=[presentation: y:2] [ordering: +6])
 memo
 SELECT y FROM a WITH ORDINALITY ORDER BY ordinality, x
 ----
-memo (optimized, ~5KB, required=[presentation: y:2] [ordering: +5])
+memo (optimized, ~6KB, required=[presentation: y:2] [ordering: +5])
  ├── G1: (ordinality G2)
  │    ├── [presentation: y:2] [ordering: +5]
  │    │    ├── best: (ordinality G2)
@@ -567,7 +567,7 @@ memo (optimized, ~5KB, required=[presentation: y:2] [ordering: +5])
 memo
 SELECT y FROM (SELECT * FROM a ORDER BY y) WITH ORDINALITY ORDER BY y, ordinality
 ----
-memo (optimized, ~3KB, required=[presentation: y:2] [ordering: +2,+5])
+memo (optimized, ~4KB, required=[presentation: y:2] [ordering: +2,+5])
  ├── G1: (ordinality G2 ordering=+2)
  │    ├── [presentation: y:2] [ordering: +2,+5]
  │    │    ├── best: (ordinality G2="[ordering: +2]" ordering=+2)
@@ -586,7 +586,7 @@ memo (optimized, ~3KB, required=[presentation: y:2] [ordering: +2,+5])
 memo
 SELECT y FROM (SELECT * FROM a ORDER BY y) WITH ORDINALITY ORDER BY ordinality, y
 ----
-memo (optimized, ~3KB, required=[presentation: y:2] [ordering: +5])
+memo (optimized, ~4KB, required=[presentation: y:2] [ordering: +5])
  ├── G1: (ordinality G2 ordering=+2)
  │    ├── [presentation: y:2] [ordering: +5]
  │    │    ├── best: (ordinality G2="[ordering: +2]" ordering=+2)
@@ -605,7 +605,7 @@ memo (optimized, ~3KB, required=[presentation: y:2] [ordering: +5])
 memo
 SELECT y FROM a WITH ORDINALITY ORDER BY ordinality DESC
 ----
-memo (optimized, ~3KB, required=[presentation: y:2] [ordering: -5])
+memo (optimized, ~4KB, required=[presentation: y:2] [ordering: -5])
  ├── G1: (ordinality G2)
  │    ├── [presentation: y:2] [ordering: -5]
  │    │    ├── best: (sort G1)

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -802,7 +802,7 @@ memo (optimized, ~5KB, required=[presentation: array_agg:5])
 memo
 SELECT array_agg(k) FROM (SELECT * FROM kuvw WHERE u=v ORDER BY u) GROUP BY w
 ----
-memo (optimized, ~8KB, required=[presentation: array_agg:5])
+memo (optimized, ~9KB, required=[presentation: array_agg:5])
  ├── G1: (project G2 G3 array_agg)
  │    └── [presentation: array_agg:5]
  │         ├── best: (project G2 G3 array_agg)
@@ -896,7 +896,7 @@ memo (optimized, ~8KB, required=[presentation: array_agg:5])
 memo
 SELECT sum(k) FROM (SELECT * FROM kuvw WHERE u=v) GROUP BY u,w
 ----
-memo (optimized, ~8KB, required=[presentation: sum:5])
+memo (optimized, ~9KB, required=[presentation: sum:5])
  ├── G1: (project G2 G3 sum)
  │    └── [presentation: sum:5]
  │         ├── best: (project G2 G3 sum)
@@ -958,7 +958,7 @@ memo (optimized, ~8KB, required=[presentation: sum:5])
 memo
 SELECT array_agg(w) FROM (SELECT * FROM kuvw ORDER BY w DESC) GROUP BY u,v
 ----
-memo (optimized, ~4KB, required=[presentation: array_agg:5])
+memo (optimized, ~5KB, required=[presentation: array_agg:5])
  ├── G1: (project G2 G3 array_agg)
  │    └── [presentation: array_agg:5]
  │         ├── best: (project G2 G3 array_agg)
@@ -1162,7 +1162,7 @@ memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4] [ordering: +2])
 memo
 SELECT DISTINCT ON (w, u) u, v, w FROM kuvw ORDER BY w, u, v DESC
 ----
-memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: +4,+2])
+memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4] [ordering: +4,+2])
  ├── G1: (distinct-on G2 G3 cols=(2,4),ordering=-3 opt(2,4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +4,+2]
  │    │    ├── best: (distinct-on G2="[ordering: +4,+2,-3]" G3 cols=(2,4),ordering=-3 opt(2,4))
@@ -1190,7 +1190,7 @@ memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: +4,+2])
 memo
 SELECT DISTINCT ON (w) u, v, w FROM kuvw ORDER BY w, u DESC, v
 ----
-memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
+memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
  ├── G1: (distinct-on G2 G3 cols=(4),ordering=-2,+3 opt(4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +4]
  │    │    ├── best: (distinct-on G2="[ordering: +4,-2,+3]" G3 cols=(4),ordering=-2,+3 opt(4))
@@ -1220,7 +1220,7 @@ memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
 memo
 SELECT DISTINCT ON (w) u, v, w FROM kuvw ORDER BY w DESC, u DESC, v
 ----
-memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: -4])
+memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4] [ordering: -4])
  ├── G1: (distinct-on G2 G3 cols=(4),ordering=-2,+3 opt(4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: -4]
  │    │    ├── best: (distinct-on G2="[ordering: -4,-2,+3]" G3 cols=(4),ordering=-2,+3 opt(4))
@@ -1247,7 +1247,7 @@ memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: -4])
 memo
 SELECT DISTINCT ON (w) u, v, w FROM kuvw ORDER BY w, u, v DESC
 ----
-memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
+memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
  ├── G1: (distinct-on G2 G3 cols=(4),ordering=+2,-3 opt(4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +4]
  │    │    ├── best: (distinct-on G2="[ordering: +4,+2,-3]" G3 cols=(4),ordering=+2,-3 opt(4))

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -158,7 +158,7 @@ full-join
 memo
 SELECT * FROM abc INNER HASH JOIN xyz ON a=z
 ----
-memo (optimized, ~7KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
+memo (optimized, ~8KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
  ├── G1: (inner-join G2 G3 G4)
  │    └── [presentation: a:1,b:2,c:3,x:5,y:6,z:7]
  │         ├── best: (inner-join G2 G3 G4)
@@ -303,7 +303,7 @@ left-join
 memo
 SELECT * FROM abc RIGHT HASH JOIN xyz ON a=z
 ----
-memo (optimized, ~7KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
+memo (optimized, ~8KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
  ├── G1: (right-join G2 G3 G4)
  │    └── [presentation: a:1,b:2,c:3,x:5,y:6,z:7]
  │         ├── best: (right-join G2 G3 G4)
@@ -345,7 +345,7 @@ inner-join (merge)
 memo
 SELECT * FROM abc JOIN xyz ON a=x
 ----
-memo (optimized, ~10KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
+memo (optimized, ~11KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+5) (lookup-join G2 G5 xyz@xy,keyCols=[1],outCols=(1-3,5-7)) (merge-join G3 G2 G5 inner-join,+5,+1) (lookup-join G3 G5 abc@ab,keyCols=[5],outCols=(1-3,5-7))
  │    └── [presentation: a:1,b:2,c:3,x:5,y:6,z:7]
  │         ├── best: (merge-join G2="[ordering: +1]" G3="[ordering: +5]" G5 inner-join,+1,+5)
@@ -374,7 +374,7 @@ memo (optimized, ~10KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
 memo
 SELECT * FROM abc INNER HASH JOIN xyz ON a=x
 ----
-memo (optimized, ~7KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
+memo (optimized, ~8KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
  ├── G1: (inner-join G2 G3 G4)
  │    └── [presentation: a:1,b:2,c:3,x:5,y:6,z:7]
  │         ├── best: (inner-join G2 G3 G4)
@@ -1485,7 +1485,7 @@ inner-join (zigzag pqr@q pqr@r)
 memo
 SELECT q,r FROM pqr WHERE q = 1 AND r = 2
 ----
-memo (optimized, ~12KB, required=[presentation: q:2,r:3])
+memo (optimized, ~13KB, required=[presentation: q:2,r:3])
  ├── G1: (select G2 G3) (zigzag-join G3 pqr@q pqr@r) (select G4 G5) (select G6 G7) (select G8 G7)
  │    └── [presentation: q:2,r:3]
  │         ├── best: (zigzag-join G3 pqr@q pqr@r)
@@ -1670,7 +1670,7 @@ inner-join (zigzag pqr@rs pqr@ts)
 memo
 SELECT r,t FROM pqr WHERE r = 1 AND t = 'foo'
 ----
-memo (optimized, ~12KB, required=[presentation: r:3,t:5])
+memo (optimized, ~13KB, required=[presentation: r:3,t:5])
  ├── G1: (select G2 G3) (zigzag-join G3 pqr@rs pqr@ts) (select G4 G5) (select G6 G5) (select G7 G8)
  │    └── [presentation: r:3,t:5]
  │         ├── best: (zigzag-join G3 pqr@rs pqr@ts)
@@ -1761,7 +1761,7 @@ select
 memo
 SELECT p,q,r,s FROM pqr WHERE q = 1 AND r = 1 AND s = 'foo'
 ----
-memo (optimized, ~32KB, required=[presentation: p:1,q:2,r:3,s:4])
+memo (optimized, ~33KB, required=[presentation: p:1,q:2,r:3,s:4])
  ├── G1: (select G2 G3) (lookup-join G4 G5 pqr,keyCols=[1],outCols=(1-4)) (zigzag-join G3 pqr@q pqr@s) (zigzag-join G3 pqr@q pqr@rs) (lookup-join G6 G7 pqr,keyCols=[1],outCols=(1-4)) (lookup-join G8 G7 pqr,keyCols=[1],outCols=(1-4)) (lookup-join G9 G7 pqr,keyCols=[1],outCols=(1-4)) (select G10 G11) (select G12 G13) (select G14 G7) (select G15 G7)
  │    └── [presentation: p:1,q:2,r:3,s:4]
  │         ├── best: (zigzag-join G3 pqr@q pqr@s)
@@ -1955,7 +1955,7 @@ inner-join (lookup t5)
 memo
 SELECT a FROM t5 WHERE b @> '{"a":1, "c":2}'
 ----
-memo (optimized, ~10KB, required=[presentation: a:1])
+memo (optimized, ~11KB, required=[presentation: a:1])
  ├── G1: (project G2 G3 a)
  │    └── [presentation: a:1]
  │         ├── best: (project G2 G3 a)
@@ -2059,7 +2059,7 @@ SELECT 1 FROM (VALUES (1), (1)) JOIN (VALUES (1), (1), (1)) ON true
 UNION ALL
 SELECT 1 FROM (VALUES (1), (1), (1)) JOIN (VALUES (1), (1)) ON true
 ----
-memo (optimized, ~17KB, required=[presentation: ?column?:7])
+memo (optimized, ~18KB, required=[presentation: ?column?:7])
  ├── G1: (union-all G2 G3)
  │    └── [presentation: ?column?:7]
  │         ├── best: (union-all G2 G3)

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -127,7 +127,7 @@ inner-join (lookup bx)
 memo join-limit=3
 SELECT * FROM bx, cy, abc WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
-memo (optimized, ~23KB, required=[presentation: b:1,x:2,c:3,y:4,a:5,b:6,c:7,d:8])
+memo (optimized, ~24KB, required=[presentation: b:1,x:2,c:3,y:4,a:5,b:6,c:7,d:8])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+6) (lookup-join G3 G5 bx,keyCols=[6],outCols=(1-8)) (inner-join G6 G7 G8) (inner-join G9 G10 G11) (inner-join G7 G6 G8) (merge-join G6 G7 G5 inner-join,+3,+7) (inner-join G10 G9 G11) (lookup-join G7 G5 cy,keyCols=[7],outCols=(1-8)) (lookup-join G12 G11 abc,keyCols=[11],outCols=(1-8))
  │    └── [presentation: b:1,x:2,c:3,y:4,a:5,b:6,c:7,d:8]
  │         ├── best: (lookup-join G3 G5 bx,keyCols=[6],outCols=(1-8))
@@ -304,7 +304,7 @@ inner-join
 memo join-limit=1
 SELECT * FROM bx, cy, dz, abc WHERE a = 1
 ----
-memo (optimized, ~11KB, required=[presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,c:9,d:10])
+memo (optimized, ~12KB, required=[presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,c:9,d:10])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4)
  │    └── [presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,c:9,d:10]
  │         ├── best: (inner-join G3 G2 G4)
@@ -346,7 +346,7 @@ memo (optimized, ~11KB, required=[presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,
 memo join-limit=4
 SELECT * FROM bx, cy, dz, abc WHERE a = 1
 ----
-memo (optimized, ~26KB, required=[presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,c:9,d:10])
+memo (optimized, ~27KB, required=[presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,c:9,d:10])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G4) (inner-join G7 G8 G4) (inner-join G9 G10 G4) (inner-join G11 G12 G4) (inner-join G13 G14 G4) (inner-join G15 G16 G4) (inner-join G6 G5 G4) (inner-join G8 G7 G4) (inner-join G10 G9 G4) (inner-join G12 G11 G4) (inner-join G14 G13 G4) (inner-join G16 G15 G4)
  │    └── [presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,c:9,d:10]
  │         ├── best: (inner-join G3 G2 G4)
@@ -512,7 +512,7 @@ FROM
     JOIN x ON true
     JOIN [UPDATE x SET a = 1 RETURNING 1] ON true
 ----
-memo (optimized, ~56KB, required=[presentation: a:1,?column?:5,a:6,?column?:10])
+memo (optimized, ~58KB, required=[presentation: a:1,?column?:5,a:6,?column?:10])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G4) (inner-join G7 G8 G4) (inner-join G9 G10 G4) (inner-join G11 G12 G4) (inner-join G13 G14 G4) (inner-join G15 G16 G4) (inner-join G11 G17 G4) (inner-join G18 G16 G4) (inner-join G6 G5 G4) (inner-join G11 G19 G4) (inner-join G8 G7 G4) (inner-join G10 G9 G4) (inner-join G12 G11 G4) (inner-join G14 G13 G4) (inner-join G11 G20 G4) (inner-join G16 G15 G4) (inner-join G17 G11 G4) (inner-join G16 G18 G4) (inner-join G19 G11 G4) (inner-join G16 G21 G4) (inner-join G16 G22 G4) (inner-join G20 G11 G4) (inner-join G3 G23 G4) (inner-join G24 G16 G4) (inner-join G21 G16 G4) (inner-join G11 G25 G4) (inner-join G3 G26 G4) (inner-join G22 G16 G4) (inner-join G11 G27 G4) (inner-join G3 G28 G4) (inner-join G3 G29 G4) (inner-join G30 G16 G4) (inner-join G23 G3 G4) (inner-join G16 G24 G4) (inner-join G25 G11 G4) (inner-join G26 G3 G4) (inner-join G27 G11 G4) (inner-join G28 G3 G4) (inner-join G29 G3 G4) (inner-join G16 G30 G4)
  │    └── [presentation: a:1,?column?:5,a:6,?column?:10]
  │         ├── best: (inner-join G3 G2 G4)

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -105,7 +105,7 @@ project
 memo
 SELECT k FROM a WHERE u = 1 AND k = 5
 ----
-memo (optimized, ~6KB, required=[presentation: k:1])
+memo (optimized, ~7KB, required=[presentation: k:1])
  ├── G1: (project G2 G3 k)
  │    └── [presentation: k:1]
  │         ├── best: (project G2 G3 k)
@@ -154,7 +154,7 @@ project
 memo
 SELECT k FROM a WHERE u = 1 AND k+u = 1
 ----
-memo (optimized, ~6KB, required=[presentation: k:1])
+memo (optimized, ~7KB, required=[presentation: k:1])
  ├── G1: (project G2 G3 k)
  │    └── [presentation: k:1]
  │         ├── best: (project G2 G3 k)
@@ -206,7 +206,7 @@ project
 memo
 SELECT k FROM a WHERE u = 1 AND v = 5
 ----
-memo (optimized, ~5KB, required=[presentation: k:1])
+memo (optimized, ~6KB, required=[presentation: k:1])
  ├── G1: (project G2 G3 k)
  │    └── [presentation: k:1]
  │         ├── best: (project G2 G3 k)
@@ -355,7 +355,7 @@ index-join b
 memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k > 5
 ----
-memo (optimized, ~5KB, required=[presentation: k:1,u:2,v:3,j:4])
+memo (optimized, ~6KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G1: (select G2 G3) (select G4 G5) (index-join G6 b,cols=(1-4))
  │    └── [presentation: k:1,u:2,v:3,j:4]
  │         ├── best: (index-join G6 b,cols=(1-4))
@@ -575,7 +575,7 @@ select
 memo
 SELECT * FROM b WHERE (u, k, v) > (1, 2, 3) AND (u, k, v) < (8, 9, 10)
 ----
-memo (optimized, ~4KB, required=[presentation: k:1,u:2,v:3,j:4])
+memo (optimized, ~5KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G1: (select G2 G3) (select G4 G3)
  │    └── [presentation: k:1,u:2,v:3,j:4]
  │         ├── best: (select G4 G3)

--- a/pkg/sql/stats/json.go
+++ b/pkg/sql/stats/json.go
@@ -102,9 +102,6 @@ func (js *JSONStatistic) GetHistogram(evalCtx *tree.EvalContext) (*HistogramData
 		return nil, err
 	}
 	h.ColumnType = *colType
-	if err != nil {
-		return nil, err
-	}
 	h.Buckets = make([]HistogramData_Bucket, len(js.HistogramBuckets))
 	for i := range h.Buckets {
 		hb := &js.HistogramBuckets[i]


### PR DESCRIPTION
**opt: fix distinct count estimate for columns with inequality predicates**

In preparation for adding histograms, this commit simplifies some of the
`statisticsBuilder` code so that all filters for which a non-inverted-index
constraint can be inferred are treated the same.

In particular, the `statisticsBuilder` now calculates selectivity of inequality
predicates (e.g., `x < 1`) by updating the distinct count of the affected
column using `unknownFilterSelectivity` (i.e., multiplying the distinct count
by 1/3), and then calling `selectivityFromDistinctCounts`. Previously, the
`statisticsBuilder` maintained a separate count of such predicates, and
used the count to update the selectivity estimation by calling
`selectivityFromUnappliedConjuncts`. Now all predicates that can be represented
by a constraint (excluding inverted index constraints) are accounted for by
updating the distinct count of the affected columns. This also somewhat
improves the accuracy of the distinct count estimate for those columns.


**opt: add preliminary support for histograms in the optimizer**

This commit adds preliminary support for histograms within the optimizer.
In particular, it adds a new `props.Histogram` type, which supports filtering
based on a constraint. This allows the `statisticsBuilder` to use histograms
to estimate the selectivity of filters that can be represented by a
constraint. These selectivity estimates should be much more accurate than
the estimates using only distinct counts. I have not yet updated the stats
quality tests to show the accuracy improvement, but that will follow in a
later commit.

This commit does not include support for histograms outside of the `Scan` and
`Select` operators in `statisticsBuilder`.

Histogram collection during `CREATE STATISTICS` is still disabled, so this
functionality can only be exercised at the moment using `INJECT STATISTICS`.
