### PR TITLE
sql/sem/tree: fix DDate.Min to return ok=true

### DIFF
--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1781,7 +1781,7 @@ func (d *DDate) Max(_ *EvalContext) (Datum, bool) {
 
 // Min implements the Datum interface.
 func (d *DDate) Min(_ *EvalContext) (Datum, bool) {
-	return dMinDate, false
+	return dMinDate, true
 }
 
 // AmbiguousFormat implements the Datum interface.


### PR DESCRIPTION
Prior to this commit, `DDate.Min` was returning the valid minimum
date, `dMinDate`, but callers of the function would think the result
was invalid since it also returned `ok=false`. This commit fixes
function to return `dMinDate` and `ok=true`.

Release note: None