### PR TITLE
ccl: Move rowConverter to OSS

### DIFF
--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -288,7 +288,7 @@ func insertStmtToKVs(
 		return errors.Errorf("load insert: expected VALUES clause: %q", stmt)
 	}
 
-	b := inserter(f)
+	b := sql.Inserter(f)
 	computedIVarContainer := sqlbase.RowIndexedVarContainer{
 		Mapping: ri.InsertColIDtoRowIndex,
 		Cols:    tableDesc.Columns,
@@ -328,30 +328,6 @@ func insertStmtToKVs(
 		}
 	}
 	return nil
-}
-
-type inserter func(roachpb.KeyValue)
-
-func (i inserter) CPut(key, value, expValue interface{}) {
-	panic("unimplemented")
-}
-
-func (i inserter) Del(key ...interface{}) {
-	panic("unimplemented")
-}
-
-func (i inserter) Put(key, value interface{}) {
-	i(roachpb.KeyValue{
-		Key:   *key.(*roachpb.Key),
-		Value: *value.(*roachpb.Value),
-	})
-}
-
-func (i inserter) InitPut(key, value interface{}, failOnTombstones bool) {
-	i(roachpb.KeyValue{
-		Key:   *key.(*roachpb.Key),
-		Value: *value.(*roachpb.Value),
-	})
 }
 
 func writeSST(

--- a/pkg/ccl/importccl/read_import_workload.go
+++ b/pkg/ccl/importccl/read_import_workload.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -225,7 +226,7 @@ func NewWorkloadKVConverter(
 func (w *WorkloadKVConverter) Worker(
 	ctx context.Context, evalCtx *tree.EvalContext, finishedBatchFn func(),
 ) error {
-	conv, err := newRowConverter(w.tableDesc, evalCtx, w.kvCh)
+	conv, err := sql.NewRowConverter(w.tableDesc, evalCtx, w.kvCh)
 	if err != nil {
 		return err
 	}
@@ -246,13 +247,13 @@ func (w *WorkloadKVConverter) Worker(
 				// TODO(dan): This does a type switch once per-datum. Reduce this to
 				// a one-time switch per column.
 				converted, err := makeDatumFromColOffset(
-					&alloc, conv.visibleColTypes[colIdx], evalCtx, col, rowIdx)
+					&alloc, conv.VisibleColTypes[colIdx], evalCtx, col, rowIdx)
 				if err != nil {
 					return err
 				}
-				conv.datums[colIdx] = converted
+				conv.Datums[colIdx] = converted
 			}
-			// `conv.row` uses these as arguments to GenerateUniqueID to generate
+			// `conv.Row` uses these as arguments to GenerateUniqueID to generate
 			// hidden primary keys, when necessary. We want them to be ascending per
 			// batch (to reduce overlap in the resulting kvs) and non-conflicting
 			// (because of primary key uniqueness). The ids that come out of
@@ -261,11 +262,11 @@ func (w *WorkloadKVConverter) Worker(
 			// within the table and the index of the row within the batch should do
 			// what we want.
 			fileIdx, timestamp := int32(batchIdx), int64(rowIdx)
-			if err := conv.row(ctx, fileIdx, timestamp); err != nil {
+			if err := conv.Row(ctx, fileIdx, timestamp); err != nil {
 				return err
 			}
 		}
 		finishedBatchFn()
 	}
-	return conv.sendBatch(ctx)
+	return conv.SendBatch(ctx)
 }

--- a/pkg/sql/row_converter.go
+++ b/pkg/sql/row_converter.go
@@ -1,0 +1,208 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/pkg/errors"
+)
+
+// Inserter implements the putter interface.
+type Inserter func(roachpb.KeyValue)
+
+// CPut is not implmented.
+func (i Inserter) CPut(key, value, expValue interface{}) {
+	panic("unimplemented")
+}
+
+// Del is not implemented.
+func (i Inserter) Del(key ...interface{}) {
+	panic("unimplemented")
+}
+
+// Put method of the putter interface.
+func (i Inserter) Put(key, value interface{}) {
+	i(roachpb.KeyValue{
+		Key:   *key.(*roachpb.Key),
+		Value: *value.(*roachpb.Value),
+	})
+}
+
+// InitPut method of the putter interface.
+func (i Inserter) InitPut(key, value interface{}, failOnTombstones bool) {
+	i(roachpb.KeyValue{
+		Key:   *key.(*roachpb.Key),
+		Value: *value.(*roachpb.Value),
+	})
+}
+
+// RowConverter converts Datums into kvs and streams it to the destination
+// channel.
+type RowConverter struct {
+	// current row buf
+	Datums []tree.Datum
+
+	// kv destination and current batch
+	KvCh     chan<- []roachpb.KeyValue
+	KvBatch  []roachpb.KeyValue
+	BatchCap int
+
+	tableDesc *sqlbase.ImmutableTableDescriptor
+
+	// The rest of these are derived from tableDesc, just cached here.
+	hidden                int
+	ri                    row.Inserter
+	EvalCtx               *tree.EvalContext
+	cols                  []sqlbase.ColumnDescriptor
+	VisibleCols           []sqlbase.ColumnDescriptor
+	VisibleColTypes       []*types.T
+	defaultExprs          []tree.TypedExpr
+	computedIVarContainer sqlbase.RowIndexedVarContainer
+}
+
+const kvRowConverterBatchSize = 5000
+
+// NewRowConverter returns an instance of a RowConverter.
+func NewRowConverter(
+	tableDesc *sqlbase.TableDescriptor, evalCtx *tree.EvalContext, kvCh chan<- []roachpb.KeyValue,
+) (*RowConverter, error) {
+	immutDesc := sqlbase.NewImmutableTableDescriptor(*tableDesc)
+	c := &RowConverter{
+		tableDesc: immutDesc,
+		KvCh:      kvCh,
+		EvalCtx:   evalCtx,
+	}
+
+	ri, err := row.MakeInserter(nil /* txn */, immutDesc, nil, /* fkTables */
+		immutDesc.Columns, false /* checkFKs */, &sqlbase.DatumAlloc{})
+	if err != nil {
+		return nil, errors.Wrap(err, "make row inserter")
+	}
+	c.ri = ri
+
+	var txCtx transform.ExprTransformContext
+	// Although we don't yet support DEFAULT expressions on visible columns,
+	// we do on hidden columns (which is only the default _rowid one). This
+	// allows those expressions to run.
+	cols, defaultExprs, err := sqlbase.ProcessDefaultColumns(immutDesc.Columns, immutDesc, &txCtx, c.EvalCtx)
+	if err != nil {
+		return nil, errors.Wrap(err, "process default columns")
+	}
+	c.cols = cols
+	c.defaultExprs = defaultExprs
+
+	c.VisibleCols = immutDesc.VisibleColumns()
+	c.VisibleColTypes = make([]*types.T, len(c.VisibleCols))
+	for i := range c.VisibleCols {
+		c.VisibleColTypes[i] = c.VisibleCols[i].DatumType()
+	}
+	c.Datums = make([]tree.Datum, len(c.VisibleCols), len(cols))
+
+	// Check for a hidden column. This should be the unique_rowid PK if present.
+	c.hidden = -1
+	for i := range cols {
+		col := &cols[i]
+		if col.Hidden {
+			if col.DefaultExpr == nil || *col.DefaultExpr != "unique_rowid()" || c.hidden != -1 {
+				return nil, errors.New("unexpected hidden column")
+			}
+			c.hidden = i
+			c.Datums = append(c.Datums, nil)
+		}
+	}
+	if len(c.Datums) != len(cols) {
+		return nil, errors.New("unexpected hidden column")
+	}
+
+	padding := 2 * (len(immutDesc.Indexes) + len(immutDesc.Families))
+	c.BatchCap = kvRowConverterBatchSize + padding
+	c.KvBatch = make([]roachpb.KeyValue, 0, c.BatchCap)
+
+	c.computedIVarContainer = sqlbase.RowIndexedVarContainer{
+		Mapping: ri.InsertColIDtoRowIndex,
+		Cols:    immutDesc.Columns,
+	}
+	return c, nil
+}
+
+// Row inserts kv operations into the current kv batch, and triggers a SendBatch
+// if necessary.
+func (c *RowConverter) Row(ctx context.Context, fileIndex int32, rowIndex int64) error {
+	if c.hidden >= 0 {
+		// We don't want to call unique_rowid() for the hidden PK column because
+		// it is not idempotent. The sampling from the first stage will be useless
+		// during the read phase, producing a single range split with all of the
+		// data. Instead, we will call our own function that mimics that function,
+		// but more-or-less guarantees that it will not interfere with the numbers
+		// that will be produced by it. The lower 15 bits mimic the node id, but as
+		// the CSV file number. The upper 48 bits are the line number and mimic the
+		// timestamp. It would take a file with many more than 2**32 lines to even
+		// begin approaching what unique_rowid would return today, so we assume it
+		// to be safe. Since the timestamp is won't overlap, it is safe to use any
+		// number in the node id portion. The 15 bits in that portion should account
+		// for up to 32k CSV files in a single IMPORT. In the case of > 32k files,
+		// the data is xor'd so the final bits are flipped instead of set.
+		c.Datums[c.hidden] = tree.NewDInt(builtins.GenerateUniqueID(fileIndex, uint64(rowIndex)))
+	}
+
+	// TODO(justin): we currently disallow computed columns in import statements.
+	var computeExprs []tree.TypedExpr
+	var computedCols []sqlbase.ColumnDescriptor
+
+	insertRow, err := GenerateInsertRow(
+		c.defaultExprs, computeExprs, c.cols, computedCols, c.EvalCtx, c.tableDesc, c.Datums, &c.computedIVarContainer)
+	if err != nil {
+		return errors.Wrap(err, "generate insert row")
+	}
+	if err := c.ri.InsertRow(
+		ctx,
+		Inserter(func(kv roachpb.KeyValue) {
+			kv.Value.InitChecksum(kv.Key)
+			c.KvBatch = append(c.KvBatch, kv)
+		}),
+		insertRow,
+		true, /* ignoreConflicts */
+		row.SkipFKs,
+		false, /* traceKV */
+	); err != nil {
+		return errors.Wrap(err, "insert row")
+	}
+	// If our batch is full, flush it and start a new one.
+	if len(c.KvBatch) >= kvRowConverterBatchSize {
+		if err := c.SendBatch(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SendBatch streams kv operations from the current KvBatch to the destination
+// channel, and resets the KvBatch to empty.
+func (c *RowConverter) SendBatch(ctx context.Context) error {
+	if len(c.KvBatch) == 0 {
+		return nil
+	}
+	select {
+	case c.KvCh <- c.KvBatch:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	c.KvBatch = make([]roachpb.KeyValue, 0, c.BatchCap)
+	return nil
+}


### PR DESCRIPTION
`rowConverter` was previosuly in the `importccl` package. This change
moves it into its own file in `pkg/sql`.

This change is setup for the new CTAS processor which will require
the `RowConverter` to stream KVs, which can then be written to the
newly created table via AddSSTable.

Release note: None