### PR TITLE
opt: add segmented/chunk sort enforcer when appropriate

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
@@ -176,7 +176,7 @@ render               ·            ·            (a, c)     +a
       │              order key    a            ·          ·
       └── sort       ·            ·            (a, b, c)  +a,-c,+b
            │         order        +a,-c,+b     ·          ·
-           └── scan  ·            ·            (a, b, c)  ·
+           └── scan  ·            ·            (a, b, c)  +a
 ·                    table        abc@primary  ·          ·
 ·                    spans        ALL          ·          ·
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -660,12 +660,14 @@ sort
  ├── fd: ()-->(1)
  ├── ordering: +2 opt(1) [actual: +2]
  ├── prune: (2)
+ ├── interesting orderings: (+1)
  └── index-join tc
       ├── columns: a:1 b:2
       ├── stats: [rows=9.9, distinct(1)=1, null(1)=0]
       ├── cost: 51.401
       ├── fd: ()-->(1)
       ├── prune: (2)
+      ├── interesting orderings: (+1)
       └── scan tc@c
            ├── columns: a:1 rowid:3
            ├── constraint: /1/3: [/10 - /10]
@@ -684,12 +686,14 @@ sort
  ├── fd: ()-->(1)
  ├── ordering: +2 opt(1) [actual: +2]
  ├── prune: (2)
+ ├── interesting orderings: (+1)
  └── index-join tc
       ├── columns: a:1(int!null) b:2(int)
       ├── stats: [rows=9.9, distinct(1)=1, null(1)=0]
       ├── cost: 51.401
       ├── fd: ()-->(1)
       ├── prune: (2)
+      ├── interesting orderings: (+1)
       └── scan tc@c
            ├── columns: a:1(int!null) rowid:3(int!null)
            ├── constraint: /1/3: [/10 - /10]
@@ -720,21 +724,25 @@ sort
  ├── fd: (1,2)-->(4)
  ├── ordering: +4
  ├── prune: (1,2,4)
+ ├── interesting orderings: (+1)
  └── project
       ├── columns: column4:4 a:1 b:2
       ├── stats: [rows=333.333333]
       ├── cost: 1116.70667
       ├── fd: (1,2)-->(4)
       ├── prune: (1,2,4)
+      ├── interesting orderings: (+1)
       ├── select
       │    ├── columns: a:1 b:2
       │    ├── stats: [rows=333.333333]
       │    ├── cost: 1110.03
+      │    ├── interesting orderings: (+1)
       │    ├── scan tc
       │    │    ├── columns: a:1 b:2
       │    │    ├── stats: [rows=1000]
       │    │    ├── cost: 1100.02
-      │    │    └── prune: (1,2)
+      │    │    ├── prune: (1,2)
+      │    │    └── interesting orderings: (+1)
       │    └── filters
       │         └── (a + (b * 2)) > 1 [outer=(1,2)]
       └── projections
@@ -750,21 +758,25 @@ sort
  ├── fd: (1,2)-->(4)
  ├── ordering: +4
  ├── prune: (1,2,4)
+ ├── interesting orderings: (+1)
  └── project
       ├── columns: column4:4(int) a:1(int) b:2(int)
       ├── stats: [rows=333.333333]
       ├── cost: 1116.70667
       ├── fd: (1,2)-->(4)
       ├── prune: (1,2,4)
+      ├── interesting orderings: (+1)
       ├── select
       │    ├── columns: a:1(int) b:2(int)
       │    ├── stats: [rows=333.333333]
       │    ├── cost: 1110.03
+      │    ├── interesting orderings: (+1)
       │    ├── scan tc
       │    │    ├── columns: a:1(int) b:2(int)
       │    │    ├── stats: [rows=1000]
       │    │    ├── cost: 1100.02
-      │    │    └── prune: (1,2)
+      │    │    ├── prune: (1,2)
+      │    │    └── interesting orderings: (+1)
       │    └── filters
       │         └── gt [type=bool, outer=(1,2)]
       │              ├── plus [type=int]

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -231,7 +231,7 @@ render                ·      ·
       └── index-join  ·      ·
            │          table  abc@primary
            └── scan   ·      ·
-·                     table  abc@bc
+·                     table  abc@ba
 ·                     spans  /11-/30
 
 # An inequality should not be enough to force the use of the index.

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -191,6 +191,12 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		fmt.Fprintf(f.Buffer, "%v", e.Op())
 		FormatPrivate(f, e.Private(), required)
 
+	case *SortExpr:
+		if t.InputOrdering.Any() {
+			fmt.Fprintf(f.Buffer, "%v", e.Op())
+		} else {
+			fmt.Fprintf(f.Buffer, "%v (segmented)", e.Op())
+		}
 	default:
 		fmt.Fprintf(f.Buffer, "%v", e.Op())
 	}

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -338,4 +339,17 @@ func (m *Memo) IsOptimized() bool {
 func (m *Memo) NextID() opt.ScalarID {
 	m.curID++
 	return m.curID
+}
+
+// RequestColStat calculates and returns the column statistic calculated on the
+// relational expression.
+func (m *Memo) RequestColStat(
+	expr RelExpr, cols opt.ColSet,
+) (colStat *props.ColumnStatistic, ok bool) {
+	// When SetRoot is called, the statistics builder may have been cleared.
+	// If this happens, we can't serve the request anymore.
+	if m.logPropsBuilder.sb.md != nil {
+		return m.logPropsBuilder.sb.colStat(cols, expr), true
+	}
+	return nil, false
 }

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpcc
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpcc
@@ -1904,6 +1904,7 @@ sort
  ├── fd: (2,3)-->(11)
  ├── ordering: +3,+2
  ├── prune: (11)
+ ├── interesting orderings: (+3,+2)
  └── group-by
       ├── save-table-name: consistency_07_group_by_2
       ├── columns: ol_d_id:2(int!null) ol_w_id:3(int!null) count_rows:11(int)
@@ -1913,6 +1914,7 @@ sort
       ├── key: (2,3)
       ├── fd: (2,3)-->(11)
       ├── prune: (11)
+      ├── interesting orderings: (+3,+2)
       ├── scan order_line@order_line_fk
       │    ├── save-table-name: consistency_07_scan_3
       │    ├── columns: ol_d_id:2(int!null) ol_w_id:3(int!null)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch
@@ -3579,7 +3579,7 @@ sort
       │    │    │    │    │    │    │    ├── scan partsupp
       │    │    │    │    │    │    │    │    ├── save-table-name: q9_scan_10
       │    │    │    │    │    │    │    │    ├── columns: ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null)
-      │    │    │    │    │    │    │    │    ├── stats: [rows=800000, distinct(33)=199241, null(33)=0, distinct(34)=9920, null(34)=0, distinct(36)=100379, null(36)=0]
+      │    │    │    │    │    │    │    │    ├── stats: [rows=800000, distinct(33)=199241, null(33)=0, distinct(34)=9920, null(34)=0, distinct(36)=100379, null(36)=0, distinct(33,34)=800000, null(33,34)=0]
       │    │    │    │    │    │    │    │    ├── key: (33,34)
       │    │    │    │    │    │    │    │    └── fd: (33,34)-->(36)
       │    │    │    │    │    │    │    └── filters (true)

--- a/pkg/sql/opt/ops/enforcer.opt
+++ b/pkg/sql/opt/ops/enforcer.opt
@@ -17,4 +17,12 @@
 # PhysicalProps struct.
 [Enforcer]
 define Sort {
+    # InputOrdering specifies the ordering that the sort requires
+    # from its input. It allows the optimizer and DistSQL to plan
+    # the sort using the segmented/chunk sort strategy.
+    #
+    # For a regular sort, this is empty. If it is not empty, this
+    # is a segmented sort where the input is already sorted on the
+    # specified prefix of columns.
+    InputOrdering OrderingChoice
 }

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -1272,11 +1272,12 @@ update mutation
       │    │    ├── limit
       │    │    │    ├── columns: m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int)
       │    │    │    ├── internal-ordering: +6,+7
-      │    │    │    ├── sort
+      │    │    │    ├── sort (segmented)
       │    │    │    │    ├── columns: m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int)
       │    │    │    │    ├── ordering: +6,+7
       │    │    │    │    └── scan mutation
-      │    │    │    │         └── columns: m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int)
+      │    │    │    │         ├── columns: m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int)
+      │    │    │    │         └── ordering: +6
       │    │    │    └── const: 10 [type=int]
       │    │    └── projections
       │    │         └── const: 1 [type=int]

--- a/pkg/sql/opt/ordering/ordering.go
+++ b/pkg/sql/opt/ordering/ordering.go
@@ -159,7 +159,7 @@ func init() {
 	}
 	funcMap[opt.SortOp] = funcs{
 		canProvideOrdering:    nil, // should never get called
-		buildChildReqOrdering: noChildReqOrdering,
+		buildChildReqOrdering: sortBuildChildReqOrdering,
 		buildProvidedOrdering: sortBuildProvided,
 	}
 	funcMap[opt.InsertOp] = funcs{

--- a/pkg/sql/opt/ordering/sort.go
+++ b/pkg/sql/opt/ordering/sort.go
@@ -22,3 +22,9 @@ func sortBuildProvided(expr memo.RelExpr, required *physical.OrderingChoice) opt
 	// rules are off) so we may need to trim.
 	return trimProvided(provided, required, &expr.Relational().FuncDeps)
 }
+
+func sortBuildChildReqOrdering(
+	parent memo.RelExpr, required *physical.OrderingChoice, childIdx int,
+) physical.OrderingChoice {
+	return parent.(*memo.SortExpr).InputOrdering
+}

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -238,19 +238,34 @@ func (c *coster) ComputeCost(candidate memo.RelExpr, required *physical.Required
 }
 
 func (c *coster) computeSortCost(sort *memo.SortExpr, required *physical.Required) memo.Cost {
-	// We calculate a per-row cost and multiply by (1 + log2(rowCount)).
+	// We calculate the cost of a segmented sort. We assume each segment
+	// is of the same size of (rowCount / numSegments). We also calculate the
+	// per-row cost. The cost of the sort is:
+	//
+	// perRowCost * (rowCount + (segmentSize * log2(segmentSize) * numOrderedSegments))
+	//
 	// The constant term is necessary for cases where the estimated row count is
 	// very small.
 	// TODO(rytaft): This is the cost of a local, in-memory sort. When a
 	// certain amount of memory is used, distsql switches to a disk-based sort
 	// with a temp RocksDB store.
-	rowCount := sort.Relational().Stats.RowCount
-	perRowCost := c.rowSortCost(len(required.Ordering.Columns))
-	cost := memo.Cost(rowCount) * perRowCost
-	if rowCount > 1 {
-		cost *= (1 + memo.Cost(math.Log2(rowCount)))
+
+	numSegments := c.countSegments(sort)
+	cost := memo.Cost(0)
+	stats := sort.Relational().Stats
+	rowCount := stats.RowCount
+	perRowCost := c.rowSortCost(len(required.Ordering.Columns) - len(sort.InputOrdering.Columns))
+
+	if !sort.InputOrdering.Any() {
+		// Add the cost for finding the segments.
+		cost += memo.Cost(float64(len(sort.InputOrdering.Columns))*rowCount) * cpuCostFactor
 	}
 
+	segmentSize := rowCount / numSegments
+	if segmentSize > 1 {
+		cost += memo.Cost(segmentSize) * (memo.Cost(math.Log2(segmentSize)) * memo.Cost(numSegments))
+	}
+	cost = perRowCost * (memo.Cost(rowCount) + cost)
 	return cost
 }
 
@@ -499,6 +514,28 @@ func (c *coster) computeProjectSetCost(projectSet *memo.ProjectSetExpr) memo.Cos
 	// Add the CPU cost of emitting the rows.
 	cost := memo.Cost(projectSet.Relational().Stats.RowCount) * cpuCostFactor
 	return cost
+}
+
+// countSegments calculates the number of segments that will be used to execute
+// the sort. If no input ordering is provided, there's only one segment.
+func (c *coster) countSegments(sort *memo.SortExpr) float64 {
+	if sort.InputOrdering.Any() {
+		return 1
+	}
+	stats := sort.Relational().Stats
+	orderedCols := sort.InputOrdering.ColSet()
+	orderedStats, ok := stats.ColStats.Lookup(orderedCols)
+	if !ok {
+		orderedStats, ok = c.mem.RequestColStat(sort, orderedCols)
+		if !ok {
+			// I don't think we can ever get here. Since we don't allow the memo
+			// to be optimized twice, the coster should never be used after
+			// logPropsBuilder.clear() is called.
+			panic(errors.AssertionFailedf("could not request the stats for ColSet %v", orderedCols))
+		}
+	}
+
+	return orderedStats.DistinctCount
 }
 
 // rowSortCost is the CPU cost to sort one row, which depends on the number of

--- a/pkg/sql/opt/xform/testdata/coster/sort
+++ b/pkg/sql/opt/xform/testdata/coster/sort
@@ -33,3 +33,132 @@ values
  ├── cost: 0.01
  ├── key: ()
  └── fd: ()-->(2)
+
+# Testing costing for segmented sort.
+exec-ddl
+CREATE TABLE abc (
+  a INT,
+  b INT,
+  c INT,
+  INDEX cb (c, b) STORING (a),
+  INDEX ab (a, b) STORING (c)
+)
+----
+
+# The ordering cannot take advantage of any interesting orderings
+# the scan can provide.
+opt
+SELECT * FROM abc ORDER BY b, c, a
+----
+sort
+ ├── columns: a:1(int) b:2(int) c:3(int)
+ ├── stats: [rows=1000]
+ ├── cost: 1301.40805
+ ├── ordering: +2,+3,+1
+ └── scan abc
+      ├── columns: a:1(int) b:2(int) c:3(int)
+      ├── stats: [rows=1000]
+      └── cost: 1070.02
+
+# The sort ordering has a common prefix with the ordering provided with index ab
+opt
+SELECT * FROM abc ORDER BY a, b, c
+----
+sort (segmented)
+ ├── columns: a:1(int) b:2(int) c:3(int)
+ ├── stats: [rows=1000, distinct(1,2)=1000, null(1,2)=19.9]
+ ├── cost: 1090.43
+ ├── ordering: +1,+2,+3
+ └── scan abc@ab
+      ├── columns: a:1(int) b:2(int) c:3(int)
+      ├── stats: [rows=1000, distinct(1,2)=1000, null(1,2)=19.9]
+      ├── cost: 1070.02
+      └── ordering: +1,+2
+
+# The sort ordering has a common prefix with the ordering provided with index cb
+opt
+SELECT * FROM abc ORDER BY c, b, a
+----
+sort (segmented)
+ ├── columns: a:1(int) b:2(int) c:3(int)
+ ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=19.9]
+ ├── cost: 1090.43
+ ├── ordering: +3,+2,+1
+ └── scan abc@cb
+      ├── columns: a:1(int) b:2(int) c:3(int)
+      ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=19.9]
+      ├── cost: 1070.02
+      └── ordering: +3,+2
+
+# Testing segmented sort cost with only one common prefix column (c).
+opt
+SELECT * FROM abc ORDER BY c, a, b
+----
+sort (segmented)
+ ├── columns: a:1(int) b:2(int) c:3(int)
+ ├── stats: [rows=1000, distinct(3)=100, null(3)=10]
+ ├── cost: 1161.00049
+ ├── ordering: +3,+1,+2
+ └── scan abc@cb
+      ├── columns: a:1(int) b:2(int) c:3(int)
+      ├── stats: [rows=1000, distinct(3)=100, null(3)=10]
+      ├── cost: 1070.02
+      └── ordering: +3
+
+# Reduce the number of segments/chunks.
+exec-ddl
+ALTER TABLE abc INJECT STATISTICS '[
+  {
+    "columns": ["a"],
+    "created_at": "2018-01-01 1:30:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 5
+  },
+  {
+    "columns": ["b"],
+    "created_at": "2018-01-01 1:30:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 2
+  }
+]'
+----
+
+# Even with a few chunks (10 in the above case), segmented sort is useful.
+opt
+SELECT * FROM abc ORDER BY a, b, c
+----
+sort (segmented)
+ ├── columns: a:1(int) b:2(int) c:3(int)
+ ├── stats: [rows=10000, distinct(1,2)=10, null(1,2)=0]
+ ├── cost: 12897.1869
+ ├── ordering: +1,+2,+3
+ └── scan abc@ab
+      ├── columns: a:1(int) b:2(int) c:3(int)
+      ├── stats: [rows=10000, distinct(1,2)=10, null(1,2)=0]
+      ├── cost: 10700.02
+      └── ordering: +1,+2
+
+# Segmented sort should still be chosen with if equality columns help provide the required ordering.
+opt
+SELECT * FROM abc  WHERE a = b ORDER BY b, a, c
+----
+sort (segmented)
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int)
+ ├── stats: [rows=2000, distinct(1)=2, null(1)=0, distinct(2)=2, null(2)=0]
+ ├── cost: 11239.0614
+ ├── fd: (1)==(2), (2)==(1)
+ ├── ordering: +(1|2),+3 [actual: +1,+3]
+ └── select
+      ├── columns: a:1(int!null) b:2(int!null) c:3(int)
+      ├── stats: [rows=2000, distinct(1)=2, null(1)=0, distinct(2)=2, null(2)=0]
+      ├── cost: 10800.02
+      ├── fd: (1)==(2), (2)==(1)
+      ├── ordering: +1
+      ├── scan abc@ab
+      │    ├── columns: a:1(int!null) b:2(int) c:3(int)
+      │    ├── constraint: /1/2/4: (/NULL - ]
+      │    ├── stats: [rows=10000, distinct(1)=5, null(1)=0]
+      │    ├── cost: 10700.01
+      │    └── ordering: +1
+      └── filters
+           └── a = b [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -1505,6 +1505,7 @@ sort
  ├── fd: (2,3)-->(11)
  ├── ordering: +3,+2
  ├── prune: (11)
+ ├── interesting orderings: (+3,+2)
  └── group-by
       ├── columns: ol_d_id:2(int!null) ol_w_id:3(int!null) count_rows:11(int)
       ├── grouping columns: ol_d_id:2(int!null) ol_w_id:3(int!null)
@@ -1513,6 +1514,7 @@ sort
       ├── key: (2,3)
       ├── fd: (2,3)-->(11)
       ├── prune: (11)
+      ├── interesting orderings: (+3,+2)
       ├── scan order_line@order_line_stock_fk_idx
       │    ├── columns: ol_d_id:2(int!null) ol_w_id:3(int!null)
       │    ├── stats: [rows=30005985, distinct(2,3)=1000, null(2,3)=0]
@@ -3136,6 +3138,7 @@ sort
  ├── fd: (2,3)-->(11)
  ├── ordering: +3,+2
  ├── prune: (11)
+ ├── interesting orderings: (+3,+2)
  └── group-by
       ├── columns: ol_d_id:2(int!null) ol_w_id:3(int!null) count_rows:11(int)
       ├── grouping columns: ol_d_id:2(int!null) ol_w_id:3(int!null)
@@ -3144,6 +3147,7 @@ sort
       ├── key: (2,3)
       ├── fd: (2,3)-->(11)
       ├── prune: (11)
+      ├── interesting orderings: (+3,+2)
       ├── scan order_line@order_line_stock_fk_idx
       │    ├── columns: ol_d_id:2(int!null) ol_w_id:3(int!null)
       │    ├── stats: [rows=646903924, distinct(2,3)=100, null(2,3)=0]

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -121,13 +121,15 @@ project
 opt
 SELECT y, x, z+1 AS r FROM a ORDER BY x, y
 ----
-sort
+sort (segmented)
  ├── columns: y:2(float!null) x:1(int!null) r:5(decimal)
  ├── ordering: +1,+2
  └── project
       ├── columns: r:5(decimal) x:1(int!null) y:2(float!null)
+      ├── ordering: +1
       ├── scan a
-      │    └── columns: x:1(int!null) y:2(float!null) z:3(decimal)
+      │    ├── columns: x:1(int!null) y:2(float!null) z:3(decimal)
+      │    └── ordering: +1
       └── projections
            └── z + 1 [type=decimal]
 
@@ -135,13 +137,15 @@ sort
 opt
 SELECT x, y+1 AS computed, y FROM a ORDER BY x, computed
 ----
-sort
+sort (segmented)
  ├── columns: x:1(int!null) computed:5(float) y:2(float!null)
  ├── ordering: +1,+5
  └── project
       ├── columns: computed:5(float) x:1(int!null) y:2(float!null)
+      ├── ordering: +1
       ├── scan a
-      │    └── columns: x:1(int!null) y:2(float!null)
+      │    ├── columns: x:1(int!null) y:2(float!null)
+      │    └── ordering: +1
       └── projections
            └── y + 1.0 [type=float]
 
@@ -342,13 +346,14 @@ group-by
 opt
 SELECT a, b, min(c) AS m FROM abc GROUP BY a, b ORDER BY a, m
 ----
-sort
+sort (segmented)
  ├── columns: a:1(int!null) b:2(int!null) m:4(int)
  ├── ordering: +1,+4
  └── group-by
       ├── columns: a:1(int!null) b:2(int!null) min:4(int)
       ├── grouping columns: a:1(int!null) b:2(int!null)
       ├── internal-ordering: +1,+2
+      ├── ordering: +1
       ├── scan abc
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
       │    └── ordering: +1,+2
@@ -1029,11 +1034,12 @@ distinct-on
  ├── grouping columns: a:1(int!null)
  ├── internal-ordering: -3,+2 opt(1)
  ├── ordering: +1
- ├── sort
+ ├── sort (segmented)
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  │    ├── ordering: +1,-3,+2
  │    └── scan abc
- │         └── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │         ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │         └── ordering: +1
  └── aggregations
       └── first-agg [type=int]
            └── variable: c [type=int]
@@ -1296,7 +1302,7 @@ project
            ├── fd: (10)-->(6-9), (7)-->(11)
            ├── ordering: +8,+9
            ├── prune: (6-11)
-           ├── interesting orderings: (+10) (+6,+7,+10) (+8,+9,+10)
+           ├── interesting orderings: (+8,+9,+10)
            ├── scan abcd@cd
            │    ├── columns: a:6(int) b:7(int) c:8(int) d:9(int) rowid:10(int!null)
            │    ├── limit: 10
@@ -1304,7 +1310,7 @@ project
            │    ├── fd: (10)-->(6-9)
            │    ├── ordering: +8,+9
            │    ├── prune: (6-10)
-           │    └── interesting orderings: (+10) (+6,+7,+10) (+8,+9,+10)
+           │    └── interesting orderings: (+8,+9,+10)
            └── projections
                 └── b + 1 [type=int, outer=(7)]
 
@@ -1350,14 +1356,14 @@ sort
            │         ├── key: (10)
            │         ├── fd: (10)-->(6-9), (7)-->(11)
            │         ├── prune: (6-11)
-           │         ├── interesting orderings: (+10) (+6,+7,+10) (+8,+9,+10)
+           │         ├── interesting orderings: (+8,+9,+10)
            │         ├── scan abcd@cd
            │         │    ├── columns: a:6(int) b:7(int) c:8(int) d:9(int) rowid:10(int!null)
            │         │    ├── limit: 10
            │         │    ├── key: (10)
            │         │    ├── fd: (10)-->(6-9)
            │         │    ├── prune: (6-10)
-           │         │    └── interesting orderings: (+10) (+6,+7,+10) (+8,+9,+10)
+           │         │    └── interesting orderings: (+8,+9,+10)
            │         └── projections
            │              └── b + 1 [type=int, outer=(7)]
            └── filters
@@ -1463,7 +1469,7 @@ project
            ├── fd: (10)-->(6-9)
            ├── ordering: +8,+9
            ├── prune: (6,7,9,10)
-           └── interesting orderings: (+10) (+6,+7,+10) (+8,+9,+10)
+           └── interesting orderings: (+8,+9,+10)
 
 # Verify that provided orderings are derived correctly with equivalence FD.
 # TODO(radu): Use interesting orderings to get rid of top-level sort.
@@ -1505,7 +1511,7 @@ sort
            │         ├── key: (10)
            │         ├── fd: (10)-->(6-9)
            │         ├── prune: (6,7,10)
-           │         └── interesting orderings: (+10) (+6,+7,+10) (+8,+9,+10)
+           │         └── interesting orderings: (+8,+9,+10)
            └── filters
                 └── b = c [type=bool, outer=(2,3), fd=(2)==(3), (3)==(2)]
 

--- a/pkg/sql/opt/xform/testdata/ruleprops/orderings
+++ b/pkg/sql/opt/xform/testdata/ruleprops/orderings
@@ -191,7 +191,7 @@ index-join abc
  ├── fd: (3)~~>(1,2)
  ├── ordering: +1
  ├── prune: (2,3)
- ├── interesting orderings: (+4) (+1,+2,+4)
+ ├── interesting orderings: (+1,+2)
  └── scan abc@secondary
       ├── columns: a:1(int) b:2(int) rowid:4(int!null)
       ├── limit: 10
@@ -219,11 +219,13 @@ limit
  │    ├── fd: (3)~~>(1,2)
  │    ├── ordering: +2
  │    ├── prune: (1-3)
+ │    ├── interesting orderings: (+1,+2) (+3)
  │    └── scan abc
  │         ├── columns: a:1(int) b:2(int) c:3(int)
  │         ├── lax-key: (1-3)
  │         ├── fd: (3)~~>(1,2)
- │         └── prune: (1-3)
+ │         ├── prune: (1-3)
+ │         └── interesting orderings: (+1,+2) (+3)
  └── const: 10 [type=int]
 
 opt
@@ -236,18 +238,20 @@ offset
  ├── fd: (3)~~>(1,2)
  ├── ordering: +1
  ├── prune: (2,3)
- ├── interesting orderings: (+1)
+ ├── interesting orderings: (+1,+2)
  ├── sort
  │    ├── columns: a:1(int) b:2(int) c:3(int)
  │    ├── lax-key: (1-3)
  │    ├── fd: (3)~~>(1,2)
  │    ├── ordering: +1
  │    ├── prune: (1-3)
+ │    ├── interesting orderings: (+1,+2) (+3)
  │    └── scan abc
  │         ├── columns: a:1(int) b:2(int) c:3(int)
  │         ├── lax-key: (1-3)
  │         ├── fd: (3)~~>(1,2)
- │         └── prune: (1-3)
+ │         ├── prune: (1-3)
+ │         └── interesting orderings: (+1,+2) (+3)
  └── const: 10 [type=int]
 
 exec-ddl

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -788,6 +788,9 @@ memo (optimized, ~5KB, required=[presentation: array_agg:5])
  │    ├── [ordering: +2,+4 opt(3)]
  │    │    ├── best: (scan kuvw@uvw,cols=(2-4))
  │    │    └── cost: 1070.02
+ │    ├── [ordering: +2]
+ │    │    ├── best: (scan kuvw@uvw,cols=(2-4))
+ │    │    └── cost: 1070.02
  │    └── []
  │         ├── best: (scan kuvw,cols=(2-4))
  │         └── cost: 1070.02
@@ -831,14 +834,17 @@ memo (optimized, ~8KB, required=[presentation: array_agg:5])
  │    │    ├── best: (scan kuvw@uvw)
  │    │    └── cost: 1080.02
  │    ├── [ordering: +2,+4]
- │    │    ├── best: (sort G6)
- │    │    └── cost: 1310.31
+ │    │    ├── best: (sort G6="[ordering: +2]")
+ │    │    └── cost: 1166.67
  │    ├── [ordering: +2]
  │    │    ├── best: (scan kuvw@uvw)
  │    │    └── cost: 1080.02
  │    ├── [ordering: +4,+2]
- │    │    ├── best: (sort G6)
- │    │    └── cost: 1310.31
+ │    │    ├── best: (sort G6="[ordering: +4]")
+ │    │    └── cost: 1166.67
+ │    ├── [ordering: +4]
+ │    │    ├── best: (scan kuvw@wvu)
+ │    │    └── cost: 1080.02
  │    └── []
  │         ├── best: (scan kuvw)
  │         └── cost: 1080.02
@@ -848,14 +854,17 @@ memo (optimized, ~8KB, required=[presentation: array_agg:5])
  │    │    ├── best: (scan kuvw@uvw,constrained)
  │    │    └── cost: 1069.21
  │    ├── [ordering: +2,+4]
- │    │    ├── best: (sort G8)
- │    │    └── cost: 1296.90
+ │    │    ├── best: (sort G8="[ordering: +2]")
+ │    │    └── cost: 1154.71
  │    ├── [ordering: +2]
  │    │    ├── best: (scan kuvw@uvw,constrained)
  │    │    └── cost: 1069.21
  │    ├── [ordering: +4,+2]
  │    │    ├── best: (sort G8)
  │    │    └── cost: 1296.90
+ │    ├── [ordering: +4]
+ │    │    ├── best: (sort G8)
+ │    │    └── cost: 1286.06
  │    └── []
  │         ├── best: (scan kuvw@uvw,constrained)
  │         └── cost: 1069.21
@@ -872,6 +881,9 @@ memo (optimized, ~8KB, required=[presentation: array_agg:5])
  │    ├── [ordering: +4,+2]
  │    │    ├── best: (sort G9)
  │    │    └── cost: 1296.90
+ │    ├── [ordering: +4]
+ │    │    ├── best: (sort G9)
+ │    │    └── cost: 1286.06
  │    └── []
  │         ├── best: (scan kuvw@vw,constrained)
  │         └── cost: 1069.21
@@ -1095,8 +1107,11 @@ memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4] [ordering: +2])
  │         └── cost: 1111.03
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: +2,+4]
- │    │    ├── best: (sort G2)
- │    │    └── cost: 1300.31
+ │    │    ├── best: (sort G2="[ordering: +2]")
+ │    │    └── cost: 1156.67
+ │    ├── [ordering: +2]
+ │    │    ├── best: (scan kuvw@uvw,cols=(2-4))
+ │    │    └── cost: 1070.02
  │    ├── [ordering: +4 opt(2)]
  │    │    ├── best: (scan kuvw@wvu,cols=(2-4))
  │    │    └── cost: 1070.02
@@ -1151,14 +1166,17 @@ memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: +4,+2])
  ├── G1: (distinct-on G2 G3 cols=(2,4),ordering=-3 opt(2,4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +4,+2]
  │    │    ├── best: (distinct-on G2="[ordering: +4,+2,-3]" G3 cols=(2,4),ordering=-3 opt(2,4))
- │    │    └── cost: 1341.42
+ │    │    └── cost: 1201.01
  │    └── []
  │         ├── best: (distinct-on G2="[ordering: -3 opt(2,4)]" G3 cols=(2,4),ordering=-3 opt(2,4))
  │         └── cost: 1219.69
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: +4,+2,-3]
- │    │    ├── best: (sort G2)
- │    │    └── cost: 1301.41
+ │    │    ├── best: (sort G2="[ordering: +4]")
+ │    │    └── cost: 1161.00
+ │    ├── [ordering: +4]
+ │    │    ├── best: (scan kuvw@wvu,cols=(2-4))
+ │    │    └── cost: 1070.02
  │    ├── [ordering: -3 opt(2,4)]
  │    │    ├── best: (scan kuvw@uvw,rev,cols=(2-4))
  │    │    └── cost: 1169.68
@@ -1176,14 +1194,17 @@ memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
  ├── G1: (distinct-on G2 G3 cols=(4),ordering=-2,+3 opt(4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +4]
  │    │    ├── best: (distinct-on G2="[ordering: +4,-2,+3]" G3 cols=(4),ordering=-2,+3 opt(4))
- │    │    └── cost: 1332.42
+ │    │    └── cost: 1192.01
  │    └── []
  │         ├── best: (distinct-on G2="[ordering: -2,+3 opt(4)]" G3 cols=(4),ordering=-2,+3 opt(4))
  │         └── cost: 1341.32
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: +4,-2,+3]
- │    │    ├── best: (sort G2)
- │    │    └── cost: 1301.41
+ │    │    ├── best: (sort G2="[ordering: +4]")
+ │    │    └── cost: 1161.00
+ │    ├── [ordering: +4]
+ │    │    ├── best: (scan kuvw@wvu,cols=(2-4))
+ │    │    └── cost: 1070.02
  │    ├── [ordering: -2,+3 opt(4)]
  │    │    ├── best: (sort G2)
  │    │    └── cost: 1300.31
@@ -1230,17 +1251,23 @@ memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
  ├── G1: (distinct-on G2 G3 cols=(4),ordering=+2,-3 opt(4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +4]
  │    │    ├── best: (distinct-on G2="[ordering: +4,+2,-3]" G3 cols=(4),ordering=+2,-3 opt(4))
- │    │    └── cost: 1332.42
+ │    │    └── cost: 1192.01
  │    └── []
  │         ├── best: (distinct-on G2="[ordering: +2,-3 opt(4)]" G3 cols=(4),ordering=+2,-3 opt(4))
- │         └── cost: 1341.32
+ │         └── cost: 1197.68
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: +2,-3 opt(4)]
- │    │    ├── best: (sort G2)
- │    │    └── cost: 1300.31
+ │    │    ├── best: (sort G2="[ordering: +2]")
+ │    │    └── cost: 1156.67
+ │    ├── [ordering: +2]
+ │    │    ├── best: (scan kuvw@uvw,cols=(2-4))
+ │    │    └── cost: 1070.02
  │    ├── [ordering: +4,+2,-3]
- │    │    ├── best: (sort G2)
- │    │    └── cost: 1301.41
+ │    │    ├── best: (sort G2="[ordering: +4]")
+ │    │    └── cost: 1161.00
+ │    ├── [ordering: +4]
+ │    │    ├── best: (scan kuvw@wvu,cols=(2-4))
+ │    │    └── cost: 1070.02
  │    └── []
  │         ├── best: (scan kuvw,cols=(2-4))
  │         └── cost: 1070.02

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -615,17 +615,18 @@ SELECT * FROM stu LEFT OUTER JOIN abc ON (c,b,a) = (s,t,u)
 ----
 left-join (merge)
  ├── columns: s:1(int!null) t:2(int!null) u:3(int!null) a:4(int) b:5(int) c:6(int)
- ├── left ordering: +1,+2,+3
- ├── right ordering: +6,+5,+4
- ├── scan stu
+ ├── left ordering: +3,+2,+1
+ ├── right ordering: +4,+5,+6
+ ├── scan stu@uts
  │    ├── columns: s:1(int!null) t:2(int!null) u:3(int!null)
  │    ├── key: (1-3)
- │    └── ordering: +1,+2,+3
- ├── sort
+ │    └── ordering: +3,+2,+1
+ ├── sort (segmented)
  │    ├── columns: a:4(int) b:5(int) c:6(int)
- │    ├── ordering: +6,+5,+4
- │    └── scan abc
- │         └── columns: a:4(int) b:5(int) c:6(int)
+ │    ├── ordering: +4,+5,+6
+ │    └── scan abc@ab
+ │         ├── columns: a:4(int) b:5(int) c:6(int)
+ │         └── ordering: +4,+5
  └── filters (true)
 
 # The ordering is coming from the right side.
@@ -634,17 +635,18 @@ SELECT * FROM abc RIGHT OUTER JOIN stu ON (c,b,a) = (s,t,u)
 ----
 left-join (merge)
  ├── columns: a:1(int) b:2(int) c:3(int) s:5(int!null) t:6(int!null) u:7(int!null)
- ├── left ordering: +5,+6,+7
- ├── right ordering: +3,+2,+1
- ├── scan stu
+ ├── left ordering: +7,+6,+5
+ ├── right ordering: +1,+2,+3
+ ├── scan stu@uts
  │    ├── columns: s:5(int!null) t:6(int!null) u:7(int!null)
  │    ├── key: (5-7)
- │    └── ordering: +5,+6,+7
- ├── sort
+ │    └── ordering: +7,+6,+5
+ ├── sort (segmented)
  │    ├── columns: a:1(int) b:2(int) c:3(int)
- │    ├── ordering: +3,+2,+1
- │    └── scan abc
- │         └── columns: a:1(int) b:2(int) c:3(int)
+ │    ├── ordering: +1,+2,+3
+ │    └── scan abc@ab
+ │         ├── columns: a:1(int) b:2(int) c:3(int)
+ │         └── ordering: +1,+2
  └── filters (true)
 
 # In these cases, we shouldn't pick up equivalencies.

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -55,13 +55,14 @@ limit
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(2,4)
- ├── sort
+ ├── sort (segmented)
  │    ├── columns: i:2(int) s:4(string)
  │    ├── cardinality: [0 - 10]
  │    ├── ordering: +4,+2
  │    └── scan a@s_idx
  │         ├── columns: i:2(int) s:4(string)
- │         └── limit: 10
+ │         ├── limit: 10
+ │         └── ordering: +4
  └── const: 1 [type=int]
 
 # Don't push when scan doesn't satisfy limit's ordering.
@@ -155,7 +156,7 @@ limit
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  ├── ordering: +2,+3
- ├── sort
+ ├── sort (segmented)
  │    ├── columns: k:1(int!null) u:2(int!null) v:3(int)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3)
@@ -164,11 +165,13 @@ limit
  │         ├── columns: k:1(int!null) u:2(int!null) v:3(int)
  │         ├── key: (1)
  │         ├── fd: (1)-->(2,3)
+ │         ├── ordering: +2
  │         └── scan kuv@secondary
  │              ├── columns: k:1(int!null) u:2(int!null)
  │              ├── constraint: /2/1: [/2 - /9]
  │              ├── key: (1)
- │              └── fd: (1)-->(2)
+ │              ├── fd: (1)-->(2)
+ │              └── ordering: +2
  └── const: 5 [type=int]
 
 exec-ddl

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -109,7 +109,7 @@ scan a@si_idx
 opt
 SELECT s,i,k,j FROM a ORDER BY s DESC, i DESC, k DESC
 ----
-sort
+sort (segmented)
  ├── columns: s:4(string) i:2(int) k:1(int!null) j:5(jsonb)
  ├── key: (1)
  ├── fd: (1)-->(2,4,5)
@@ -117,14 +117,15 @@ sort
  └── scan a@si_idx
       ├── columns: k:1(int!null) i:2(int) s:4(string) j:5(jsonb)
       ├── key: (1)
-      └── fd: (1)-->(2,4,5)
+      ├── fd: (1)-->(2,4,5)
+      └── ordering: -4,-2
 
 # Revscan node won't be used because ordering is
 # only partial (reverse) match with existing indices
 opt
 SELECT s,i,k,j FROM a ORDER BY s DESC, i ASC, k DESC
 ----
-sort
+sort (segmented)
  ├── columns: s:4(string) i:2(int) k:1(int!null) j:5(jsonb)
  ├── key: (1)
  ├── fd: (1)-->(2,4,5)
@@ -132,7 +133,8 @@ sort
  └── scan a@si_idx
       ├── columns: k:1(int!null) i:2(int) s:4(string) j:5(jsonb)
       ├── key: (1)
-      └── fd: (1)-->(2,4,5)
+      ├── fd: (1)-->(2,4,5)
+      └── ordering: -4
 
 opt
 SELECT s,i,k,j FROM a ORDER BY s ASC, i ASC, k DESC
@@ -275,8 +277,11 @@ SELECT s, i, f FROM a ORDER BY s DESC, i
 memo (optimized, ~2KB, required=[presentation: s:4,i:2,f:3] [ordering: -4,+2])
  └── G1: (scan a,cols=(2-4)) (scan a@s_idx,cols=(2-4))
       ├── [presentation: s:4,i:2,f:3] [ordering: -4,+2]
-      │    ├── best: (sort G1)
-      │    └── cost: 1300.31
+      │    ├── best: (sort G1="[ordering: -4]")
+      │    └── cost: 1256.33
+      ├── [ordering: -4]
+      │    ├── best: (scan a@s_idx,rev,cols=(2-4))
+      │    └── cost: 1169.68
       └── []
            ├── best: (scan a@s_idx,cols=(2-4))
            └── cost: 1070.02
@@ -431,15 +436,16 @@ memo (optimized, ~2KB, required=[presentation: s:4,j:5] [ordering: +4])
 opt
 SELECT i, k FROM a ORDER BY s DESC, i, k
 ----
-sort
+sort (segmented)
  ├── columns: i:2(int) k:1(int!null)  [hidden: s:4(string)]
  ├── key: (1)
  ├── fd: (1)-->(2,4)
  ├── ordering: -4,+2,+1
- └── scan a@s_idx
+ └── scan a@si_idx
       ├── columns: k:1(int!null) i:2(int) s:4(string)
       ├── key: (1)
-      └── fd: (1)-->(2,4)
+      ├── fd: (1)-->(2,4)
+      └── ordering: -4
 
 memo
 SELECT i, k FROM a ORDER BY s DESC, i, k
@@ -447,8 +453,11 @@ SELECT i, k FROM a ORDER BY s DESC, i, k
 memo (optimized, ~2KB, required=[presentation: i:2,k:1] [ordering: -4,+2,+1])
  └── G1: (scan a,cols=(1,2,4)) (scan a@s_idx,cols=(1,2,4)) (scan a@si_idx,cols=(1,2,4))
       ├── [presentation: i:2,k:1] [ordering: -4,+2,+1]
-      │    ├── best: (sort G1)
-      │    └── cost: 1301.41
+      │    ├── best: (sort G1="[ordering: -4]")
+      │    └── cost: 1161.00
+      ├── [ordering: -4]
+      │    ├── best: (scan a@si_idx,cols=(1,2,4))
+      │    └── cost: 1070.02
       └── []
            ├── best: (scan a@s_idx,cols=(1,2,4))
            └── cost: 1070.02


### PR DESCRIPTION
This change adds a segmented/chunk sort enforcer when possible.
Currently, because the sort operator doesn't require any ordeing from
its input, DistSQL never plans a sort using the segmented/chunk sort
algorithm. This change fixes that. Furthermore, the optimizer can now
pick better indexes for scans (when under a sort) based on how much
the sort benefits from the ordering the index provides.

Release note: None