### PR TITLE
release-19.1: sql: report anonymized query with internal errors

### DIFF
--- a/pkg/util/log/crash_reporting.go
+++ b/pkg/util/log/crash_reporting.go
@@ -602,3 +602,19 @@ func ErrorSource(i interface{}) string {
 	}
 	return ""
 }
+
+// GetRegisteredTagsString returns a string with the values of registered tags
+// in the context. The format is "key1: val1; key2: val2".
+func GetRegisteredTagsString(ctx context.Context) string {
+	var buf bytes.Buffer
+	for _, f := range tagFns {
+		v := f.value(ctx)
+		if v != "" {
+			if buf.Len() > 0 {
+				buf.WriteString("; ")
+			}
+			fmt.Fprintf(&buf, "%s: %s", f.key, maybeTruncate(v))
+		}
+	}
+	return buf.String()
+}


### PR DESCRIPTION
When we hit an internal error (`AssertionFailedf`), a Sentry report is
generated but in 19.1 it does not include the anonymized query. This
change adds this information to internal errors (as a detail).

Informs #37514.

Release note: None

/cc @cockroachdb/release