### PR TITLE
build: update README to include TeamCity config param changes

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -48,6 +48,7 @@ Process:
 - edit `build/Dockerfile` as desired
 - run `build/builder.sh init` to test -- this will build the image locally. Beware this can take a lot of time. The result of `init` is a docker image version which you can subsequently stick into the `version` variable inside the `builder.sh` script for testing locally.
 - Once you are happy with the result, run `build/builder.sh push` which pushes your image towards Docker hub, so that it becomes available to others. The result is again a version number, which you then *must* copy back into `builder.sh`. Then commit the change to both Dockerfile and `builder.sh` and submit a PR.
+- Finally, use this version number to update the `builder.dockerImage` configuration parameter in TeamCity under the [`Cockroach`](https://teamcity.cockroachdb.com/admin/editProject.html?projectId=Cockroach&tab=projectParams) and [`Internal`](https://teamcity.cockroachdb.com/admin/editProject.html?projectId=Internal&tab=projectParams) projects.
 
 #  Dependencies
 


### PR DESCRIPTION
This commit updates the "Upgrading / extending the Docker image" section
of the README to include guidance on updating the `builder.dockerImage`
configuration parameter in TeamCity, which all tests have been adjusted
to look at.

Release note: None