### PR TITLE
server: Improve macOS file descriptor limit detection

### DIFF
--- a/pkg/server/rlimit_darwin.go
+++ b/pkg/server/rlimit_darwin.go
@@ -30,25 +30,42 @@ func getRlimitNoFile(limits *rlimit) error {
 	if err := unix.Getrlimit(unix.RLIMIT_NOFILE, (*unix.Rlimit)(limits)); err != nil {
 		return err
 	}
+	// On macOS, the true hard open file limit is
+	// min(sysctl("kern.maxfiles"),
+	//     sysctl("kern.maxfilesperproc"),
+	//     getrlimit(RLIMIT_NOFILE))
+	// This does not appear to be documented and may be incomplete.
+	//
+	// See https://github.com/golang/go/issues/30401 for more context.
 	sysctlMaxFiles, err := getSysctlMaxFiles()
 	if err != nil {
 		return err
 	}
 	if limits.Max > sysctlMaxFiles {
-		// Per the setrlimit(2) manpage on macOS, the true hard open file limit is
-		// min(sysctl("kern.maxfiles"), getrlimit(RLIMIT_NOFILE)), so adjust the
-		// limit returned by getrlimit accordingly.
-		//
-		// See https://github.com/golang/go/issues/30401 for more context.
 		limits.Max = sysctlMaxFiles
+	}
+	sysctlMaxFilesPerProc, err := getSysctlMaxFilesPerProc()
+	if err != nil {
+		return err
+	}
+	if limits.Max > sysctlMaxFilesPerProc {
+		limits.Max = sysctlMaxFilesPerProc
 	}
 	return nil
 }
 
 func getSysctlMaxFiles() (uint64, error) {
+	return getSysctl(C.CTL_KERN, C.KERN_MAXFILES) // identifies the "kern.maxfiles" sysctl
+}
+
+func getSysctlMaxFilesPerProc() (uint64, error) {
+	return getSysctl(C.CTL_KERN, C.KERN_MAXFILESPERPROC) // identifies the "kern.maxfilesperproc" sysctl
+}
+
+func getSysctl(x, y C.int) (uint64, error) {
 	var out int32
 	outLen := C.size_t(unsafe.Sizeof(out))
-	sysctlMib := [...]C.int{C.CTL_KERN, C.KERN_MAXFILES} // identifies the "kern.maxfiles" sysctl
+	sysctlMib := [...]C.int{x, y}
 	r, errno := C.sysctl(&sysctlMib[0], C.u_int(len(sysctlMib)), unsafe.Pointer(&out), &outLen,
 		nil /* newp */, 0 /* newlen */)
 	if r != 0 {


### PR DESCRIPTION
The first commit improves our heuristics to incorporate a newly-discovered parameter. The second makes us more robust even if those heuristics fail in the future.

Fixes #38407 

cc @benesch 