### PR TITLE
release-19.1:  backupccl: allow rewriting spans keys that may not decode as keys

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach-go/crdb"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl"
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/partitionccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl/sampledataccl"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
@@ -1039,6 +1040,12 @@ func TestBackupRestoreInterleaved(t *testing.T) {
 	// `db.table` syntax. Fix that and use it here instead of `SET DATABASE`.
 	_ = sqlDB.Exec(t, `SET DATABASE = data`)
 
+	_ = sqlDB.Exec(t, `CREATE TABLE strpk (id string, v int, primary key (id, v)) PARTITION BY LIST (id) ( PARTITION ab VALUES IN (('a'), ('b')), PARTITION xy VALUES IN (('x'), ('y')) );`)
+	_ = sqlDB.Exec(t, `ALTER PARTITION ab OF TABLE strpk CONFIGURE ZONE USING gc.ttlseconds = 60`)
+	_ = sqlDB.Exec(t, `INSERT INTO strpk VALUES ('a', 1), ('a', 2), ('x', 100), ('y', 101)`)
+	const numStrPK = 4
+	_ = sqlDB.Exec(t, `CREATE TABLE strpkchild (a string, b int, c int, primary key (a, b, c)) INTERLEAVE IN PARENT strpk (a, b)`)
+
 	// i0 interleaves in parent with a, and has a multi-col PK of its own b, c
 	_ = sqlDB.Exec(t, `CREATE TABLE i0 (a INT, b INT, c INT, PRIMARY KEY (a, b, c)) INTERLEAVE IN PARENT bank (a)`)
 	// Split at at a _strict prefix_ of the cols in i_0's PK
@@ -1051,7 +1058,7 @@ func TestBackupRestoreInterleaved(t *testing.T) {
 
 	// The bank table has numAccounts accounts, put 2x that in i0, 3x in i0_0,
 	// and 4x in i1.
-	totalRows := numAccounts
+	totalRows := numAccounts + numStrPK
 	for i := 0; i < numAccounts; i++ {
 		_ = sqlDB.Exec(t, `INSERT INTO i0 VALUES ($1, 1, 1), ($1, 2, 2)`, i)
 		totalRows += 2

--- a/pkg/ccl/backupccl/restore.go
+++ b/pkg/ccl/backupccl/restore.go
@@ -970,7 +970,7 @@ func restoreJobDescription(
 // same interleave parent row) we'll generate some no-op splits and route the
 // work to the same range, but the actual imported data is unaffected.
 func rewriteBackupSpanKey(kr *storageccl.KeyRewriter, key roachpb.Key) (roachpb.Key, error) {
-	newKey, rewritten, err := kr.RewriteKey(append([]byte(nil), key...))
+	newKey, rewritten, err := kr.RewriteKey(append([]byte(nil), key...), true /* isFromSpan */)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not rewrite span start key: %s", key)
 	}

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -919,9 +919,6 @@ func doDistributedCSVTransform(
 		walltime,
 		sstSize,
 		oversample,
-		func(descs map[sqlbase.ID]*sqlbase.TableDescriptor) (sql.KeyRewriter, error) {
-			return storageccl.MakeKeyRewriter(descs)
-		},
 	); err != nil {
 
 		// Check if this was a context canceled error and restart if it was.

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -176,7 +176,7 @@ func evalImport(ctx context.Context, cArgs batcheval.CommandArgs) (*roachpb.Impo
 		value := roachpb.Value{RawBytes: valueScratch}
 		iter.NextKey()
 
-		key.Key, ok, err = kr.RewriteKey(key.Key)
+		key.Key, ok, err = kr.RewriteKey(key.Key, false /* isFromSpan */)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/storageccl/key_rewriter_test.go
+++ b/pkg/ccl/storageccl/key_rewriter_test.go
@@ -67,6 +67,8 @@ func TestKeyRewriter(t *testing.T) {
 		},
 	}
 
+	const notSpan = false
+
 	kr, err := MakeKeyRewriterFromRekeys(rekeys)
 	if err != nil {
 		t.Fatal(err)
@@ -74,7 +76,7 @@ func TestKeyRewriter(t *testing.T) {
 
 	t.Run("normal", func(t *testing.T) {
 		key := sqlbase.MakeIndexKeyPrefix(&sqlbase.NamespaceTable, desc.PrimaryIndex.ID)
-		newKey, ok, err := kr.RewriteKey(key)
+		newKey, ok, err := kr.RewriteKey(key, notSpan)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -92,7 +94,7 @@ func TestKeyRewriter(t *testing.T) {
 
 	t.Run("prefix end", func(t *testing.T) {
 		key := roachpb.Key(sqlbase.MakeIndexKeyPrefix(&sqlbase.NamespaceTable, desc.PrimaryIndex.ID)).PrefixEnd()
-		newKey, ok, err := kr.RewriteKey(key)
+		newKey, ok, err := kr.RewriteKey(key, notSpan)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -121,7 +123,7 @@ func TestKeyRewriter(t *testing.T) {
 		}
 
 		key := sqlbase.MakeIndexKeyPrefix(&sqlbase.NamespaceTable, desc.PrimaryIndex.ID)
-		newKey, ok, err := newKr.RewriteKey(key)
+		newKey, ok, err := newKr.RewriteKey(key, notSpan)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/ccl/utilccl/sampledataccl/bankdata.go
+++ b/pkg/ccl/utilccl/sampledataccl/bankdata.go
@@ -155,7 +155,7 @@ func (b *Backup) NextKeyValues(
 			b.iterIdx = iterIdx
 
 			key := it.Key()
-			key.Key, ok, err = kr.RewriteKey(key.Key)
+			key.Key, ok, err = kr.RewriteKey(key.Key, false /* isFromSpan */)
 			if err != nil {
 				return nil, roachpb.Span{}, err
 			}

--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -183,7 +183,6 @@ func LoadCSV(
 	walltime int64,
 	splitSize int64,
 	oversample int64,
-	makeRewriter func(map[sqlbase.ID]*sqlbase.TableDescriptor) (KeyRewriter, error),
 ) error {
 	ctx = logtags.AddTag(ctx, "import-distsql", nil)
 	dsp := phs.DistSQLPlanner()

--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -164,11 +164,6 @@ func (c *callbackResultWriter) Err() error {
 
 var colTypeBytes = sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_BYTES}
 
-// KeyRewriter describes helpers that can rewrite keys (possibly in-place).
-type KeyRewriter interface {
-	RewriteKey(key []byte) (res []byte, ok bool, err error)
-}
-
 // LoadCSV performs a distributed transformation of the CSV files at from
 // and stores them in enterprise backup format at to.
 func LoadCSV(


### PR DESCRIPTION
Backport 2/2 commits from #38341.

/cc @cockroachdb/release

---

backupccl: allow rewriting spans keys that may not decode as keys

When rewriting the spans to pre-split and distribute work in RESTORE, we
use the _key_ rewriter to rewrite _span_ boundaries. This usually works
well, but in a few cases, valid span boundaries may no longer be
entirely made of valid value encodings. For example, .PrefixEnd alters
the trailing bytes to increment them, but this will break decoding of
byte string that assumes a very specific trailing terminator.

 PeekLength, and key decoding in general, can fail when reading the last
value from a key that is coming from a span. Keys in spans are often
altered e.g. by calling Next() or PrefixEnd() to ensure a given span is
inclusive or for other reasons, but the manipulations sometimes change
the encoded bytes, meaning they can no longer successfully decode as
back to the original values. This is OK when span boundaries mostly are
only required to be even divisions of keyspace, but when we try to go
back to interpreting them as keys, it can fall apart. Partitioning a
table (and applying zone configs) eagerly creates splits at the defined
partition boundaries, using PrefixEnd for their ends, resulting in such
spans.

Fortunately, the only common span manipulations are to the trailing byte
of a key (e.g. incrementing or appending a null) so for our needs here,
if we fail to decode because of one fo those manipulations, we can
assume that we are at the end of the key as far as fields where a table
ID which needs to be replaced can appear and consider the rewrite of
this key as being completed successfully.

Finally unlike key rewrites of actual row-data, span rewrites do not
need to be perfect: spans are only rewritten for use in pre-splitting
and work distribution, so even if it turned out that this assumption was
incorrect, it could cause a performance degradation but does not pose a
correctness risk.

Release note (bug fix): fix an issue that prevented restoring some
backups if they included tables that were partitioned by columns of a
certain types while also interleaved by child tables.
