### PR TITLE
exec: temporarily stop using 5node-dist-vec config

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/dist_vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/dist_vectorize
@@ -1,4 +1,10 @@
-# LogicTest: 5node-dist-vec
+# LogicTest: 5node-dist
+
+# Temporary until #38458 is fixed. This test fails under stress with the
+# 5node-dist-vec config, but not with the 5node-dist config and then setting
+# experimental_vectorize=on, which should be equivalent.
+statement ok
+SET experimental_vectorize=on;
 
 statement ok
 CREATE TABLE kv (k INT PRIMARY KEY, v INT)


### PR DESCRIPTION
Fixes test flakes but warrants further investigation as to why the
dist_vectorize logic test passes under an equivalent configuration.

Release note: None

Addresses #38458 