### PR TITLE
exec: fix bug in ordered aggregate planning

### DIFF
--- a/pkg/sql/exec/aggregator.go
+++ b/pkg/sql/exec/aggregator.go
@@ -127,10 +127,9 @@ func NewOrderedAggregator(
 			)
 	}
 
-	groupTypes := extractGroupTypes(groupCols, colTypes)
 	aggTypes := extractAggTypes(aggCols, colTypes)
 
-	op, groupCol, err := OrderedDistinctColsToOperators(input, groupCols, groupTypes)
+	op, groupCol, err := OrderedDistinctColsToOperators(input, groupCols, colTypes)
 	if err != nil {
 		return nil, err
 	}
@@ -294,19 +293,6 @@ func (a *orderedAggregator) reset() {
 	for _, fn := range a.aggregateFuncs {
 		fn.Reset()
 	}
-}
-
-// extractGroupTypes returns an array representing the type corresponding to
-// each group column. This information is extracted from the group column
-// indices and their corresponding column types.
-func extractGroupTypes(groupCols []uint32, colTypes []types.T) []types.T {
-	groupTyps := make([]types.T, len(groupCols))
-
-	for i, colIdx := range groupCols {
-		groupTyps[i] = colTypes[colIdx]
-	}
-
-	return groupTyps
 }
 
 // extractAggTypes returns a nested array representing the input types

--- a/pkg/sql/exec/aggregator_test.go
+++ b/pkg/sql/exec/aggregator_test.go
@@ -235,6 +235,23 @@ func TestAggregatorOneFunc(t *testing.T) {
 			name:            "NoGroupingCols",
 			groupCols:       []uint32{},
 		},
+		{
+			input: tuples{
+				{1, 0, 0},
+				{2, 0, 0},
+				{3, 0, 0},
+				{4, 0, 0},
+			},
+			expected: tuples{
+				{10},
+			},
+			batchSize:       1,
+			outputBatchSize: 1,
+			name:            "UnusedInputColumns",
+			colTypes:        []types.T{types.Int64, types.Int64, types.Int64},
+			groupCols:       []uint32{1, 2},
+			aggCols:         [][]uint32{{0}},
+		},
 	}
 
 	// Run tests with deliberate batch sizes and no selection vectors.


### PR DESCRIPTION
Previously, there was a bug that caused ordered aggregations to not be
planned correctly when some columns weren't present in the grouping
columns.

Fixes #37332.

Release note: None