### PR TITLE
storage: fix flake in TestEntries

### DIFF
--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -6567,9 +6567,13 @@ func TestQuotaPoolAccessOnDestroyedReplica(t *testing.T) {
 func TestEntries(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
+	cfg := TestStoreConfig(nil)
+	// Disable ticks to avoid quiescence, which can result in empty
+	// entries being proposed and causing the test to flake.
+	cfg.RaftTickInterval = math.MaxInt32
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
-	tc.Start(t, stopper)
+	tc.StartWithStoreConfig(t, stopper, cfg)
 	tc.repl.store.SetRaftLogQueueActive(false)
 
 	repl := tc.repl


### PR DESCRIPTION
Fixes #38481.

We were seeing the test occasionally fail when stressraced with failures like:
```
replica_test.go:6700: 22: expected cache count 30, got 31
```

I tracked this down to replicas quiescing and unquiescing, at which point they
propose an empty entry that messes up the test's accounting.

This seems to have been triggered somehow by 1ff3556910. I'm not sure what in
that change made this more frequent, but I am able to reproduce it easily before
and after if I drop the `RaftTickInterval` from 100ms (the default) to 20ms. I'm
also only able to reproduce this with a large amount of stressrace concurrency.
With `STRESSFLAGS=-p=1`, I can't cause it to trigger. Based on some logging that
I added when debugging, this looks like a timing issue with goroutine scheduling
under heavy load and I've looked at it enough to convince myself that this isn't
a problem with 1ff3556910.

Release note: None