### PR TITLE
cli: skip flaky TestNodeStatus

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1941,6 +1941,8 @@ pq: query execution canceled due to statement timeout
 func TestNodeStatus(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	t.Skip("currently flaky: #38151")
+
 	start := timeutil.Now()
 	c := newCLITest(cliTestParams{})
 	defer c.cleanup()


### PR DESCRIPTION
Release note: None

#38151