### PR TITLE
exec: handle nulls in ANY_NOT_NULL aggregator

### DIFF
--- a/pkg/sql/exec/execgen/cmd/execgen/any_not_null_agg_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/any_not_null_agg_gen.go
@@ -32,7 +32,10 @@ func genAnyNotNullAgg(wr io.Writer) error {
 	s = strings.Replace(s, "_TYPE", "{{.}}", -1)
 	s = strings.Replace(s, "_TemplateType", "{{.}}", -1)
 
-	tmpl, err := template.New("any_not_null_agg").Parse(s)
+	findAnyNotNull := makeFunctionRegex("_FIND_ANY_NOT_NULL", 4)
+	s = findAnyNotNull.ReplaceAllString(s, `{{template "findAnyNotNull" buildDict "Global" . "HasNulls" $4}}`)
+
+	tmpl, err := template.New("any_not_null_agg").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#37738

```
BenchmarkAggregator/ANY_NOT_NULL/hash/Int64/groupSize=1/hasNulls=false/numInputBatches=64-12         	     200	   6083231 ns/op	  86.19 MB/s
BenchmarkAggregator/ANY_NOT_NULL/hash/Int64/groupSize=1/hasNulls=true/numInputBatches=64-12          	     200	   6450350 ns/op	  81.28 MB/s
BenchmarkAggregator/ANY_NOT_NULL/hash/Int64/groupSize=2/hasNulls=false/numInputBatches=64-12         	     300	   5091136 ns/op	 102.98 MB/s
BenchmarkAggregator/ANY_NOT_NULL/hash/Int64/groupSize=2/hasNulls=true/numInputBatches=64-12          	     300	   5187819 ns/op	 101.06 MB/s
BenchmarkAggregator/ANY_NOT_NULL/hash/Int64/groupSize=512/hasNulls=false/numInputBatches=64-12       	     300	   4566485 ns/op	 114.81 MB/s
BenchmarkAggregator/ANY_NOT_NULL/hash/Int64/groupSize=512/hasNulls=true/numInputBatches=64-12        	     300	   4882619 ns/op	 107.38 MB/s
BenchmarkAggregator/ANY_NOT_NULL/hash/Int64/groupSize=1024/hasNulls=false/numInputBatches=64-12      	     300	   5011178 ns/op	 104.62 MB/s
BenchmarkAggregator/ANY_NOT_NULL/hash/Int64/groupSize=1024/hasNulls=true/numInputBatches=64-12       	     300	   5446185 ns/op	  96.27 MB/s
BenchmarkAggregator/ANY_NOT_NULL/hash/Decimal/groupSize=1/hasNulls=false/numInputBatches=64-12       	     200	   6751428 ns/op	  77.66 MB/s
BenchmarkAggregator/ANY_NOT_NULL/hash/Decimal/groupSize=1/hasNulls=true/numInputBatches=64-12        	     200	   7379802 ns/op	  71.04 MB/s
BenchmarkAggregator/ANY_NOT_NULL/hash/Decimal/groupSize=2/hasNulls=false/numInputBatches=64-12       	     300	   5306643 ns/op	  98.80 MB/s
BenchmarkAggregator/ANY_NOT_NULL/hash/Decimal/groupSize=2/hasNulls=true/numInputBatches=64-12        	     200	   6576398 ns/op	  79.72 MB/s
BenchmarkAggregator/ANY_NOT_NULL/hash/Decimal/groupSize=512/hasNulls=false/numInputBatches=64-12     	     300	   5586031 ns/op	  93.86 MB/s
BenchmarkAggregator/ANY_NOT_NULL/hash/Decimal/groupSize=512/hasNulls=true/numInputBatches=64-12      	     300	   5348373 ns/op	  98.03 MB/s
BenchmarkAggregator/ANY_NOT_NULL/hash/Decimal/groupSize=1024/hasNulls=false/numInputBatches=64-12    	     300	   6136956 ns/op	  85.43 MB/s
BenchmarkAggregator/ANY_NOT_NULL/hash/Decimal/groupSize=1024/hasNulls=true/numInputBatches=64-12     	     300	   5724826 ns/op	  91.58 MB/s
BenchmarkAggregator/ANY_NOT_NULL/ordered/Int64/groupSize=1/hasNulls=false/numInputBatches=64-12      	   10000	    194387 ns/op	2697.13 MB/s
BenchmarkAggregator/ANY_NOT_NULL/ordered/Int64/groupSize=1/hasNulls=true/numInputBatches=64-12       	    5000	    397104 ns/op	1320.28 MB/s
BenchmarkAggregator/ANY_NOT_NULL/ordered/Int64/groupSize=2/hasNulls=false/numInputBatches=64-12      	   10000	    149615 ns/op	3504.23 MB/s
BenchmarkAggregator/ANY_NOT_NULL/ordered/Int64/groupSize=2/hasNulls=true/numInputBatches=64-12       	    5000	    234929 ns/op	2231.68 MB/s
BenchmarkAggregator/ANY_NOT_NULL/ordered/Int64/groupSize=512/hasNulls=false/numInputBatches=64-12    	   10000	    113549 ns/op	4617.26 MB/s
BenchmarkAggregator/ANY_NOT_NULL/ordered/Int64/groupSize=512/hasNulls=true/numInputBatches=64-12     	   10000	    154650 ns/op	3390.15 MB/s
BenchmarkAggregator/ANY_NOT_NULL/ordered/Int64/groupSize=1024/hasNulls=false/numInputBatches=64-12   	   10000	    114422 ns/op	4582.05 MB/s
BenchmarkAggregator/ANY_NOT_NULL/ordered/Int64/groupSize=1024/hasNulls=true/numInputBatches=64-12    	   10000	    161362 ns/op	3249.13 MB/s
BenchmarkAggregator/ANY_NOT_NULL/ordered/Decimal/groupSize=1/hasNulls=false/numInputBatches=64-12    	    3000	    414491 ns/op	1264.89 MB/s
BenchmarkAggregator/ANY_NOT_NULL/ordered/Decimal/groupSize=1/hasNulls=true/numInputBatches=64-12     	    2000	    615989 ns/op	 851.13 MB/s
BenchmarkAggregator/ANY_NOT_NULL/ordered/Decimal/groupSize=2/hasNulls=false/numInputBatches=64-12    	    5000	    253762 ns/op	2066.06 MB/s
BenchmarkAggregator/ANY_NOT_NULL/ordered/Decimal/groupSize=2/hasNulls=true/numInputBatches=64-12     	    5000	    351237 ns/op	1492.69 MB/s
BenchmarkAggregator/ANY_NOT_NULL/ordered/Decimal/groupSize=512/hasNulls=false/numInputBatches=64-12  	   10000	    127400 ns/op	4115.26 MB/s
BenchmarkAggregator/ANY_NOT_NULL/ordered/Decimal/groupSize=512/hasNulls=true/numInputBatches=64-12   	   10000	    153427 ns/op	3417.17 MB/s
BenchmarkAggregator/ANY_NOT_NULL/ordered/Decimal/groupSize=1024/hasNulls=false/numInputBatches=64-12 	   10000	    127370 ns/op	4116.23 MB/s
BenchmarkAggregator/ANY_NOT_NULL/ordered/Decimal/groupSize=1024/hasNulls=true/numInputBatches=64-12  	   10000	    154861 ns/op	3385.52 MB/s

```

Release note: None