### PR TITLE
roachpb: don't consider replica type for lease equivalency

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1365,6 +1365,16 @@ func (l Lease) Equivalent(newL Lease) bool {
 	// Ignore sequence numbers, they are simply a reflection of
 	// the equivalency of other fields.
 	l.Sequence, newL.Sequence = 0, 0
+	// Ignore the ReplicaDescriptor's type. This shouldn't affect lease
+	// equivalency because Raft state shouldn't be factored into the state of a
+	// Replica's lease. We don't expect a leaseholder to ever become a LEARNER
+	// replica, but that also shouldn't prevent it from extending its lease. The
+	// code also avoids a potential bug where an unset ReplicaType and a set
+	// VOTER ReplicaType are considered distinct and non-equivalent.
+	//
+	// Change this line to the following when ReplicaType becomes non-nullable:
+	//  l.Replica.Type, newL.Replica.Type = 0, 0
+	l.Replica.Type, newL.Replica.Type = nil, nil
 	// If both leases are epoch-based, we must dereference the epochs
 	// and then set to nil.
 	switch l.Type() {

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -821,23 +821,32 @@ func TestLeaseEquivalence(t *testing.T) {
 	stasis1 := Lease{Replica: r1, Start: ts1, Epoch: 1, DeprecatedStartStasis: ts1.Clone()}
 	stasis2 := Lease{Replica: r1, Start: ts1, Epoch: 1, DeprecatedStartStasis: ts2.Clone()}
 
+	r1Voter, r1Learner := r1, r1
+	r1Voter.Type = newReplicaType(ReplicaType_VOTER)
+	r1Learner.Type = newReplicaType(ReplicaType_LEARNER)
+	epoch1Voter := Lease{Replica: r1Voter, Start: ts1, Epoch: 1}
+	epoch1Learner := Lease{Replica: r1Learner, Start: ts1, Epoch: 1}
+
 	testCases := []struct {
 		l, ol      Lease
 		expSuccess bool
 	}{
-		{epoch1, epoch1, true},        // same epoch lease
-		{expire1, expire1, true},      // same expiration lease
-		{epoch1, epoch2, false},       // different epoch leases
-		{epoch1, epoch2TS2, false},    // different epoch leases
-		{expire1, expire2TS2, false},  // different expiration leases
-		{expire1, expire2, true},      // same expiration lease, extended
-		{expire2, expire1, false},     // same expiration lease, extended but backwards
-		{epoch1, expire1, false},      // epoch and expiration leases
-		{expire1, epoch1, false},      // expiration and epoch leases
-		{proposed1, proposed1, true},  // exact leases with identical timestamps
-		{proposed1, proposed2, false}, // same proposed timestamps, but diff epochs
-		{proposed1, proposed3, true},  // different proposed timestamps, same lease
-		{stasis1, stasis2, true},      // same lease, different stasis timestamps
+		{epoch1, epoch1, true},             // same epoch lease
+		{expire1, expire1, true},           // same expiration lease
+		{epoch1, epoch2, false},            // different epoch leases
+		{epoch1, epoch2TS2, false},         // different epoch leases
+		{expire1, expire2TS2, false},       // different expiration leases
+		{expire1, expire2, true},           // same expiration lease, extended
+		{expire2, expire1, false},          // same expiration lease, extended but backwards
+		{epoch1, expire1, false},           // epoch and expiration leases
+		{expire1, epoch1, false},           // expiration and epoch leases
+		{proposed1, proposed1, true},       // exact leases with identical timestamps
+		{proposed1, proposed2, false},      // same proposed timestamps, but diff epochs
+		{proposed1, proposed3, true},       // different proposed timestamps, same lease
+		{stasis1, stasis2, true},           // same lease, different stasis timestamps
+		{epoch1, epoch1Voter, true},        // same epoch lease, different replica type
+		{epoch1, epoch1Learner, true},      // same epoch lease, different replica type
+		{epoch1Voter, epoch1Learner, true}, // same epoch lease, different replica type
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
Fixes #38513.

We saw a panic in a test cluster where a Lease with a nil replica type
was attempting to replace a lease with the same sequence number and a
VOTER replica type. This was presumably due to 97b8395, which made
ReplicaDescriptor.Type nullable.

That actual panic shouldn't happen in the wild because we never released
a version of Cockroach with ReplicaDescriptor.Type existing in a
non-nullable state, but it's still concerning. It's also likely that
we'll want to make the field non-nullable in the future and that will
only be possible if we collapse the null and zero value states in code
that can observe both (i.e. 19.2 code). This change addresses this by
simply ignoring the value for ReplicaDescriptor.Type in when checking
lease equivalency. Raft state like the replica's type shouldn't factor
in to lease decisions, so this seems like the right approach.

Here's the diff we'll need once we make this field non-nullable:
```
diff --git a/pkg/roachpb/data.go b/pkg/roachpb/data.go
index c8ba3eda01..32b92bf614 100644
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1368,7 +1368,7 @@ func (l Lease) Equivalent(newL Lease) bool {
        // Ignore the ReplicaDescriptor's type. This shouldn't affect lease
        // equivalency and also avoids a potential bug where an unset ReplicaType
        // and a set VOTER ReplicaType are considered distinct and non-equivalent.
-       l.Replica.Type, newL.Replica.Type = nil, nil
+       l.Replica.Type, newL.Replica.Type = 0, 0
        // If both leases are epoch-based, we must dereference the epochs
        // and then set to nil.
        switch l.Type() {
```

Release note: None