### PR TITLE
exec: handle nulls in ordered distinct

### DIFF
--- a/pkg/sql/exec/distinct_test.go
+++ b/pkg/sql/exec/distinct_test.go
@@ -12,6 +12,7 @@ package exec
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
@@ -32,6 +33,9 @@ func TestSortedDistinct(t *testing.T) {
 			colTypes:     []types.T{types.Float64, types.Int64, types.Bytes},
 			numCols:      4,
 			tuples: tuples{
+				{nil, nil, nil, nil},
+				{nil, nil, nil, nil},
+				{nil, nil, "30", nil},
 				{1.0, 2, "30", 4},
 				{1.0, 2, "30", 5},
 				{2.0, 2, "30", 4},
@@ -40,6 +44,8 @@ func TestSortedDistinct(t *testing.T) {
 				{2.0, 3, "40", 4},
 			},
 			expected: tuples{
+				{nil, nil, nil, nil},
+				{nil, nil, "30", nil},
 				{1.0, 2, "30", 4},
 				{2.0, 2, "30", 4},
 				{2.0, 3, "30", 4},
@@ -51,6 +57,9 @@ func TestSortedDistinct(t *testing.T) {
 			colTypes:     []types.T{types.Float64, types.Int64, types.Bytes},
 			numCols:      4,
 			tuples: tuples{
+				{nil, nil, nil, nil},
+				{nil, nil, nil, nil},
+				{nil, nil, "30", nil},
 				{1.0, 2, "30", 4},
 				{1.0, 2, "30", 5},
 				{2.0, 2, "30", 4},
@@ -59,9 +68,35 @@ func TestSortedDistinct(t *testing.T) {
 				{2.0, 3, "40", 4},
 			},
 			expected: tuples{
+				{nil, nil, nil, nil},
+				{nil, nil, "30", nil},
 				{1.0, 2, "30", 4},
 				{2.0, 2, "30", 4},
 				{2.0, 3, "30", 4},
+				{2.0, 3, "40", 4},
+			},
+		},
+		{
+			distinctCols: []uint32{0, 1, 2},
+			colTypes:     []types.T{types.Float64, types.Int64, types.Bytes},
+			numCols:      4,
+			tuples: tuples{
+				{1.0, 2, "30", 4},
+				{1.0, 2, "30", 5},
+				{nil, nil, nil, nil},
+				{nil, nil, nil, nil},
+				{2.0, 2, "30", 4},
+				{2.0, 3, "30", 4},
+				{nil, nil, "30", nil},
+				{2.0, 3, "40", 4},
+				{2.0, 3, "40", 4},
+			},
+			expected: tuples{
+				{1.0, 2, "30", 4},
+				{nil, nil, nil, nil},
+				{2.0, 2, "30", 4},
+				{2.0, 3, "30", 4},
+				{nil, nil, "30", nil},
 				{2.0, 3, "40", 4},
 			},
 		},
@@ -105,8 +140,20 @@ func BenchmarkSortedDistinct(b *testing.B) {
 	}
 
 	// don't count the artificial zeroOp'd column in the throughput
-	b.SetBytes(int64(8 * coldata.BatchSize * 3))
-	for i := 0; i < b.N; i++ {
-		distinct.Next(ctx)
+	for _, nulls := range []bool{false, true} {
+		b.Run(fmt.Sprintf("nulls=%t", nulls), func(b *testing.B) {
+			if nulls {
+				n := coldata.NewNulls(coldata.BatchSize)
+				// Setting one value to null is enough to trigger the null handling
+				// logic for the entire batch.
+				n.SetNull(0)
+				batch.ColVec(1).SetNulls(&n)
+				batch.ColVec(2).SetNulls(&n)
+			}
+			b.SetBytes(int64(8 * coldata.BatchSize * 3))
+			for i := 0; i < b.N; i++ {
+				distinct.Next(ctx)
+			}
+		})
 	}
 }

--- a/pkg/sql/exec/execgen/cmd/execgen/distinct_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/distinct_gen.go
@@ -40,6 +40,9 @@ func genDistinctOps(wr io.Writer) error {
 	innerLoopRe := regexp.MustCompile(`_CHECK_DISTINCT\(.*\)`)
 	s = innerLoopRe.ReplaceAllString(s, `{{template "checkDistinct" .}}`)
 
+	innerLoopNullsRe := regexp.MustCompile(`_CHECK_DISTINCT_WITH_NULLS\(.*\)`)
+	s = innerLoopNullsRe.ReplaceAllString(s, `{{template "checkDistinctWithNulls" .}}`)
+
 	// Now, generate the op, from the template.
 	tmpl, err := template.New("distinct_op").Parse(s)
 	if err != nil {


### PR DESCRIPTION
The ordered distinct operator previously did not take nulls into
account. I added logic to handle this, which takes into account whether
the previous and current values are null. To avoid an unnecessary
performance hit, this logic is only used when the current batch has
nulls.

Fixes #36881

Release note: None