### PR TITLE
kv: use evictionToken to coalesce RangeLookups on SendError

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -1420,11 +1420,12 @@ func (ds *DistSender) sendPartialBatch(
 			} else {
 				descKey = rs.Key
 			}
-			// TODO(nvanbenschoten): shouldn't we be passing an eviction token
-			// here from the previous iteration? See #28967.
-			desc, evictToken, err = ds.getDescriptor(ctx, descKey, nil, isReverse)
+			desc, evictToken, err = ds.getDescriptor(ctx, descKey, evictToken, isReverse)
 			if err != nil {
 				log.VErrEventf(ctx, 1, "range descriptor re-lookup failed: %s", err)
+				// We set pErr if we encountered an error getting the descriptor in
+				// order to return the most recent error when we are out of retries.
+				pErr = roachpb.NewError(err)
 				continue
 			}
 		}

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -3391,4 +3392,129 @@ func TestEvictMetaRange(t *testing.T) {
 				splitKey, testMetaEndKey, cachedRange.StartKey, cachedRange.EndKey)
 		}
 	})
+}
+
+// TestEvictionTokenCoalesce tests when two separate batch requests are a part
+// of the same stale range descriptor, they are coalesced when the range lookup
+// is retried.
+func TestEvictionTokenCoalesce(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.TODO())
+
+	testUserRangeDescriptor := roachpb.RangeDescriptor{
+		RangeID:  2,
+		StartKey: roachpb.RKey("a"),
+		EndKey:   roachpb.RKey("d"),
+		InternalReplicas: []roachpb.ReplicaDescriptor{
+			{
+				NodeID:  1,
+				StoreID: 1,
+			},
+		},
+	}
+
+	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+	rpcContext := rpc.NewInsecureTestingContext(clock, stopper)
+	g := makeGossip(t, stopper, rpcContext)
+	if err := g.AddInfoProto(gossip.KeyFirstRangeDescriptor, &testMetaRangeDescriptor, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+
+	sendErrors := int32(0)
+	var queriedMetaKeys sync.Map
+
+	var ds *DistSender
+	var testFn simpleSendFn = func(
+		_ context.Context,
+		_ SendOptions,
+		_ ReplicaSlice,
+		ba roachpb.BatchRequest,
+	) (*roachpb.BatchResponse, error) {
+		rs, err := keys.Range(ba)
+		br := ba.CreateReply()
+		if err != nil {
+			br.Error = roachpb.NewError(err)
+			return br, nil
+		}
+		if !client.TestingIsRangeLookup(ba) {
+			// Return a SendError so DistSender retries the first range lookup in the
+			// user key-space for both batches.
+			if atomic.AddInt32(&sendErrors, 1) <= 2 {
+				br.Error = roachpb.NewError(&roachpb.SendError{})
+				return br, nil
+			}
+			return br, nil
+		}
+
+		if bytes.HasPrefix(rs.Key, keys.Meta1Prefix) {
+			// Querying meta 1 range.
+			br = &roachpb.BatchResponse{}
+			r := &roachpb.ScanResponse{}
+			var kv roachpb.KeyValue
+			if err := kv.Value.SetProto(&testMetaRangeDescriptor); err != nil {
+				br.Error = roachpb.NewError(err)
+				return br, nil
+			}
+			r.Rows = append(r.Rows, kv)
+			br.Add(r)
+			return br, nil
+		}
+		// Querying meta2 range.
+		br = &roachpb.BatchResponse{}
+		r := &roachpb.ScanResponse{}
+		var kv roachpb.KeyValue
+		if err := kv.Value.SetProto(&testUserRangeDescriptor); err != nil {
+			br.Error = roachpb.NewError(err)
+			return br, nil
+		}
+		r.Rows = append(r.Rows, kv)
+		br.Add(r)
+		// The first query for each batch request key of the meta1 range should be
+		// in separate requests because there is no prior eviction token.
+		if _, ok := queriedMetaKeys.Load(string(rs.Key)); ok {
+			// Wait until we have two in-flight requests.
+			if err := testutils.SucceedsSoonError(t, func() error {
+				// Since the previously fetched RangeDescriptor was ["a", "d"), the request keys
+				// would be coalesced to "a".
+				numCalls := ds.rangeCache.lookupRequests.NumCalls(string(roachpb.RKey("a")) + ":false")
+				if numCalls != 2 {
+					return errors.Errorf("expected %d in-flight requests, got %d", 2, numCalls)
+				}
+				return nil
+			}); err != nil {
+				br.Error = roachpb.NewError(err)
+				return br, nil
+			}
+		}
+		queriedMetaKeys.Store(string(rs.Key), struct{}{})
+		return br, nil
+	}
+
+	cfg := DistSenderConfig{
+		AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
+		Clock:      clock,
+		RPCContext: rpcContext,
+		TestingKnobs: ClientTestingKnobs{
+			TransportFactory: adaptSimpleTransport(testFn),
+		},
+		NodeDialer: nodedialer.New(rpcContext, gossip.AddressResolver(g)),
+		RPCRetryOptions: &retry.Options{
+			MaxRetries: 1,
+		},
+	}
+	ds = NewDistSender(cfg, g)
+
+	var batchWaitGroup sync.WaitGroup
+	putFn := func(key, value string) {
+		defer batchWaitGroup.Done()
+		put := roachpb.NewPut(roachpb.Key(key), roachpb.MakeValueFromString("c"))
+		if _, pErr := client.SendWrapped(context.Background(), ds, put); pErr != nil {
+			t.Errorf("put encountered error: %s", pErr)
+		}
+	}
+	batchWaitGroup.Add(2)
+	go putFn("b", "b")
+	go putFn("c", "c")
+	batchWaitGroup.Wait()
 }

--- a/pkg/testutils/soon.go
+++ b/pkg/testutils/soon.go
@@ -31,6 +31,17 @@ const DefaultSucceedsSoonDuration = 45 * time.Second
 // function is invoked immediately at first and then successively with
 // an exponential backoff starting at 1ns and ending at around 1s.
 func SucceedsSoon(t testing.TB, fn func() error) {
+	if err := SucceedsSoonError(t, fn); err != nil {
+		t.Fatalf("condition failed to evaluate within %s: %s\n%s",
+			DefaultSucceedsSoonDuration, err, string(debug.Stack()))
+	}
+}
+
+// SucceedsSoonError returns an error unless the supplied function runs without
+// error within a preset maximum duration. The function is invoked immediately
+// at first and then successively with an exponential backoff starting at 1ns
+// and ending at around 1s.
+func SucceedsSoonError(t testing.TB, fn func() error) error {
 	t.Helper()
 	tBegin := timeutil.Now()
 	wrappedFn := func() error {
@@ -40,8 +51,5 @@ func SucceedsSoon(t testing.TB, fn func() error) {
 		}
 		return err
 	}
-	if err := retry.ForDuration(DefaultSucceedsSoonDuration, wrappedFn); err != nil {
-		t.Fatalf("condition failed to evaluate within %s: %s\n%s",
-			DefaultSucceedsSoonDuration, err, string(debug.Stack()))
-	}
+	return retry.ForDuration(DefaultSucceedsSoonDuration, wrappedFn)
 }

--- a/pkg/util/syncutil/singleflight/singleflight.go
+++ b/pkg/util/syncutil/singleflight/singleflight.go
@@ -146,3 +146,13 @@ func (g *Group) Forget(key string) {
 	delete(g.m, key)
 	g.mu.Unlock()
 }
+
+// NumCalls returns the number of in-flight calls for a given key.
+func (g *Group) NumCalls(key string) int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if c, ok := g.m[key]; ok {
+		return c.dups + 1
+	}
+	return 0
+}


### PR DESCRIPTION
Also fixes an issue where a meta2 range lookup could be coalesced with a
meta1 range lookup and cause a deadlock.

Fixes #28967

Release note: None

I've collected metrics to compare this PR against master (`15d4329`) under two workloads while the cluster is running `kv50`.

1. Split workload: Two workers splitting random ranges: `ALTER TABLE kv.kv SPLIT AT VALUES (CAST(ROUND(RANDOM() * 9223372036854775808) AS INT)) WITH EXPIRATION '1s'`
2. Relocate workload: Two workers relocating random ranges: `ALTER TABLE kv.kv EXPERIMENTAL_RELOCATE SELECT ARRAY[%s, %s, %s], CAST(ROUND(RANDOM() * 9223372036854775808) AS INT)`. The new set of replicas is a random subset of the available replicas of size 3.

More details can be found in this [script](https://gist.github.com/jeffrey-xiao/2af9de98a56d8921dc7efa0cf7fb5b5e).

![image](https://user-images.githubusercontent.com/8853434/60836298-592e9400-a193-11e9-9c46-920cc2539982.png)