### PR TITLE
libroach: Prepare for RocksDB 6.2 upgrade

### DIFF
--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -870,7 +870,7 @@ DBStatus DBSstFileWriterFinish(DBSstFileWriter* fw, DBString* data) {
   }
 
   const rocksdb::EnvOptions soptions;
-  rocksdb::unique_ptr<rocksdb::SequentialFile> sst;
+  std::unique_ptr<rocksdb::SequentialFile> sst;
   status = fw->memenv->NewSequentialFile("sst", &sst, soptions);
   if (!status.ok()) {
     return ToDBStatus(status);

--- a/c-deps/libroach/engine.cc
+++ b/c-deps/libroach/engine.cc
@@ -351,7 +351,7 @@ DBStatus DBImpl::EnvWriteFile(DBSlice path, DBSlice contents) {
   rocksdb::Status s;
 
   const rocksdb::EnvOptions soptions;
-  rocksdb::unique_ptr<rocksdb::WritableFile> destfile;
+  std::unique_ptr<rocksdb::WritableFile> destfile;
   s = this->rep->GetEnv()->NewWritableFile(ToString(path), &destfile, soptions);
   if (!s.ok()) {
     return ToDBStatus(s);
@@ -369,7 +369,7 @@ DBStatus DBImpl::EnvWriteFile(DBSlice path, DBSlice contents) {
 DBStatus DBImpl::EnvOpenFile(DBSlice path, rocksdb::WritableFile** file) {
   rocksdb::Status status;
   const rocksdb::EnvOptions soptions;
-  rocksdb::unique_ptr<rocksdb::WritableFile> rocksdb_file;
+  std::unique_ptr<rocksdb::WritableFile> rocksdb_file;
 
   // Create the file.
   status = this->rep->GetEnv()->NewWritableFile(ToString(path), &rocksdb_file, soptions);


### PR DESCRIPTION
In our current RocksDB version (5.17), there are using-declarations for
`std::unique_ptr` inside a `namespace rocksdb` block in some header
files. Those were rightfully removed in the version we are about to
upgrade to (6.2). So we need to change libroach to not reference
`rocksdb::unique_ptr`.

Release note: None