### PR TITLE
storage: remove dependency from replication queue to the split queue

### DIFF
--- a/pkg/base/constants.go
+++ b/pkg/base/constants.go
@@ -37,4 +37,7 @@ const (
 	// HeapProfileDir is the directory name where the heap profiler stores profiles
 	// when there is a potential OOM situation.
 	HeapProfileDir = "heap_profiler"
+
+	// MinRangeMaxBytes is the minimum value for range max bytes.
+	MinRangeMaxBytes = 64 << 10 // 64 KB
 )

--- a/pkg/config/zone.go
+++ b/pkg/config/zone.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
@@ -261,9 +262,6 @@ func (c *Constraint) FromString(short string) error {
 	return nil
 }
 
-// minRangeMaxBytes is the minimum value for range max bytes.
-const minRangeMaxBytes = 64 << 10 // 64 KB
-
 // NewZoneConfig is the zone configuration used when no custom
 // config has been specified.
 func NewZoneConfig() *ZoneConfig {
@@ -396,9 +394,9 @@ func (z *ZoneConfig) Validate() error {
 		}
 	}
 
-	if z.RangeMaxBytes != nil && *z.RangeMaxBytes < minRangeMaxBytes {
+	if z.RangeMaxBytes != nil && *z.RangeMaxBytes < base.MinRangeMaxBytes {
 		return fmt.Errorf("RangeMaxBytes %d less than minimum allowed %d",
-			*z.RangeMaxBytes, minRangeMaxBytes)
+			*z.RangeMaxBytes, base.MinRangeMaxBytes)
 	}
 
 	if z.RangeMinBytes != nil && *z.RangeMinBytes < 0 {

--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -454,13 +454,6 @@ func (bq *baseQueue) SetDisabled(disabled bool) {
 	bq.mu.Unlock()
 }
 
-// Disabled returns true is the queue is currently disabled.
-func (bq *baseQueue) Disabled() bool {
-	bq.mu.Lock()
-	defer bq.mu.Unlock()
-	return bq.mu.disabled
-}
-
 // lockProcessing locks all processing in the baseQueue. It returns
 // a function to unlock processing.
 func (bq *baseQueue) lockProcessing() func() {

--- a/pkg/storage/replica_metrics.go
+++ b/pkg/storage/replica_metrics.go
@@ -233,14 +233,6 @@ func (r *Replica) WritesPerSecond() float64 {
 	return wps
 }
 
-// needsSplitBySize returns true if the size of the range requires it
-// to be split.
-func (r *Replica) needsSplitBySize() bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.needsSplitBySizeRLocked()
-}
-
 func (r *Replica) needsSplitBySizeRLocked() bool {
 	return r.exceedsMultipleOfSplitSizeRLocked(1)
 }

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -189,18 +189,6 @@ func newReplicateQueue(store *Store, g *gossip.Gossip, allocator Allocator) *rep
 func (rq *replicateQueue) shouldQueue(
 	ctx context.Context, now hlc.Timestamp, repl *Replica, sysCfg *config.SystemConfig,
 ) (shouldQ bool, priority float64) {
-	if !repl.store.splitQueue.Disabled() && repl.needsSplitBySize() {
-		// If the range exceeds the split threshold, let that finish first.
-		// Ranges must fit in memory on both sender and receiver nodes while
-		// being replicated. This supplements the check provided by
-		// acceptsUnsplitRanges, which looks at zone config boundaries rather
-		// than data size.
-		//
-		// This check is ignored if the split queue is disabled, since in that
-		// case, the split will never come.
-		return
-	}
-
 	// Get the descriptor and zone config for this range.
 	desc, zone := repl.DescAndZone()
 


### PR DESCRIPTION
Before this patch, the replication queue would refuse to process ranges
that it thought needed splits because of their size. The idea was to let
the split queue process them first. There's no reason for this,
particularly since we've introduced the write-backpressuring mechanism
which keeps ranges from getting too large.
The check had not considered unsplittable ranges (i.e. ranges with only
(versions of) one row or some system ranges). These can't be split but
the replication queue was disconsidering them none the less.

Release note (bug fix): Ranges consisting of only one row (and
historical versions of that row) are now correctly up-replicating.