### PR TITLE
opt: reject srfs in aggregates

### DIFF
--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -990,7 +990,7 @@ func (s *scope) replaceAggregate(f *tree.FuncExpr, def *tree.FunctionDefinition)
 	defer s.builder.semaCtx.Properties.Restore(s.builder.semaCtx.Properties)
 
 	s.builder.semaCtx.Properties.Require("aggregate",
-		tree.RejectNestedAggregates|tree.RejectWindowApplications)
+		tree.RejectNestedAggregates|tree.RejectWindowApplications|tree.RejectGenerators)
 
 	expr := f.Walk(s)
 

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -3402,3 +3402,9 @@ project
       └── aggregations
            └── array-agg [type=string[]]
                 └── variable: column5 [type=string]
+
+# Regression test for #38551.
+build
+SELECT * FROM ROWS FROM (count(json_each('[]')))
+----
+error (0A000): count(): json_each(): generator functions are not allowed in aggregate


### PR DESCRIPTION
Fixes #38551. This panics in 2.1 so I think I will backport it.

Release note (bug fix): Fixed a panic where generators in an aggregate
function were not appropriately rejected.