### PR TITLE
exec: protect against unset syncFlowConsumer

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -1076,6 +1076,9 @@ func (f *Flow) setupVectorized(ctx context.Context) error {
 				}
 				metadataSourcesQueue = metadataSourcesQueue[:0]
 			case distsqlpb.StreamEndpointSpec_SYNC_RESPONSE:
+				if f.syncFlowConsumer == nil {
+					return errors.New("syncFlowConsumer unset, unable to create materializer")
+				}
 				// Make the materializer, which will write to the given receiver.
 				columnTypes := f.syncFlowConsumer.Types()
 				outputToInputColIdx := make([]int, len(columnTypes))


### PR DESCRIPTION
This should never happen since it implies that the receiver isn't
connected correctly. These happen when a node sends a SetupFlow request
to a remote node where the spec specifies that the response is on that
remote node. We don't see panics in the row execution engine due to
wrapping the syncFlowConsumer with a copyingRowReceiver, but this state
can cause setupVectorized to panic.

This commit protects against this state pending further investigation.

Release note: None