### PR TITLE
storage: improving queue logging

### DIFF
--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -545,6 +545,7 @@ func (bq *baseQueue) AddAsync(ctx context.Context, repl replicaInQueue, prio flo
 }
 
 func (bq *baseQueue) maybeAdd(ctx context.Context, repl replicaInQueue, now hlc.Timestamp) {
+	ctx = repl.AnnotateCtx(ctx)
 	// Load the system config if it's needed.
 	var cfg *config.SystemConfig
 	if bq.needsSystemConfig {


### PR DESCRIPTION
Add replica log tags to baseQueue.maybeAdd().
The processing half of the queue already had this annotation, but not
the enqueuing half.

Release note: None