### PR TITLE
opt: fix panic recovery for error handling

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -376,7 +376,7 @@
   revision = "edce558372380347c6fef147e62f5559a9f8413d"
 
 [[projects]]
-  digest = "1:a644806453a927ccc2812bcfecf67f5d5adc7ca2e5e582b6c799a3aabe988433"
+  digest = "1:35ff61e02c035785971ac6ec04d54428307a986412e5d0aea86b8b7f45677d09"
   name = "github.com/cockroachdb/errors"
   packages = [
     ".",
@@ -399,8 +399,8 @@
     "withstack",
   ]
   pruneopts = "UT"
-  revision = "cd8b61c67a5cb6d94573c7eacb27227cf169814f"
-  version = "v1.2.2"
+  revision = "7ba395ace80575c71104187a222f77bf23c19326"
+  version = "v1.2.3"
 
 [[projects]]
   digest = "1:cd936a7edd1897083994b6d397f9c975a5a8dc58e845f0cf3d1e5cf4717b918b"

--- a/pkg/sql/opt/optbuilder/alter_table.go
+++ b/pkg/sql/opt/optbuilder/alter_table.go
@@ -31,11 +31,11 @@ func (b *Builder) buildAlterTableSplit(split *tree.Split, inScope *scope) (outSc
 	}
 	index, err := cat.ResolveTableIndex(b.ctx, b.catalog, flags, &split.TableOrIndex)
 	if err != nil {
-		panic(builderError{err})
+		panic(err)
 	}
 	table := index.Table()
 	if err := b.catalog.CheckPrivilege(b.ctx, table, privilege.INSERT); err != nil {
-		panic(builderError{err})
+		panic(err)
 	}
 
 	b.DisableMemoReuse = true
@@ -89,11 +89,11 @@ func (b *Builder) buildAlterTableUnsplit(unsplit *tree.Unsplit, inScope *scope) 
 	}
 	index, err := cat.ResolveTableIndex(b.ctx, b.catalog, flags, &unsplit.TableOrIndex)
 	if err != nil {
-		panic(builderError{err})
+		panic(err)
 	}
 	table := index.Table()
 	if err := b.catalog.CheckPrivilege(b.ctx, table, privilege.INSERT); err != nil {
-		panic(builderError{err})
+		panic(err)
 	}
 
 	b.DisableMemoReuse = true
@@ -139,11 +139,11 @@ func (b *Builder) buildAlterTableRelocate(
 	}
 	index, err := cat.ResolveTableIndex(b.ctx, b.catalog, flags, &relocate.TableOrIndex)
 	if err != nil {
-		panic(builderError{err})
+		panic(err)
 	}
 	table := index.Table()
 	if err := b.catalog.CheckPrivilege(b.ctx, table, privilege.INSERT); err != nil {
-		panic(builderError{err})
+		panic(err)
 	}
 
 	b.DisableMemoReuse = true

--- a/pkg/sql/opt/optbuilder/create_table.go
+++ b/pkg/sql/opt/optbuilder/create_table.go
@@ -44,10 +44,10 @@ func (b *Builder) buildCreateTable(ct *tree.CreateTable, inScope *scope) (outSco
 		numColNames := len(ct.AsColumnNames)
 		numColumns := len(outScope.cols)
 		if numColNames != 0 && numColNames != numColumns {
-			panic(builderError{sqlbase.NewSyntaxError(fmt.Sprintf(
+			panic(sqlbase.NewSyntaxError(fmt.Sprintf(
 				"CREATE TABLE specifies %d column name%s, but data source has %d column%s",
 				numColNames, util.Pluralize(int64(numColNames)),
-				numColumns, util.Pluralize(int64(numColumns))))})
+				numColumns, util.Pluralize(int64(numColumns)))))
 		}
 
 		// Synthesize rowid column, and append to end of column list.

--- a/pkg/sql/opt/optbuilder/explain.go
+++ b/pkg/sql/opt/optbuilder/explain.go
@@ -23,7 +23,7 @@ import (
 func (b *Builder) buildExplain(explain *tree.Explain, inScope *scope) (outScope *scope) {
 	opts, err := explain.ParseOptions()
 	if err != nil {
-		panic(builderError{err})
+		panic(err)
 	}
 
 	// We don't allow the statement under Explain to reference outer columns, so we

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -228,7 +228,7 @@ func (mb *mutationBuilder) addTargetColsByName(names tree.NameList) {
 			mb.addTargetCol(ord)
 			continue
 		}
-		panic(builderError{sqlbase.NewUndefinedColumnError(string(name))})
+		panic(sqlbase.NewUndefinedColumnError(string(name)))
 	}
 }
 
@@ -240,12 +240,12 @@ func (mb *mutationBuilder) addTargetCol(ord int) {
 
 	// Don't allow targeting of mutation columns.
 	if cat.IsMutationColumn(mb.tab, ord) {
-		panic(builderError{makeBackfillError(tabCol.ColName())})
+		panic(makeBackfillError(tabCol.ColName()))
 	}
 
 	// Computed columns cannot be targeted with input values.
 	if tabCol.IsComputed() {
-		panic(builderError{sqlbase.CannotWriteToComputedColError(string(tabCol.ColName()))})
+		panic(sqlbase.CannotWriteToComputedColError(string(tabCol.ColName())))
 	}
 
 	// Ensure that the name list does not contain duplicates.
@@ -521,7 +521,7 @@ func (mb *mutationBuilder) addCheckConstraintCols() {
 		for i, n := 0, mb.tab.CheckCount(); i < n; i++ {
 			expr, err := parser.ParseExpr(string(mb.tab.Check(i).Constraint))
 			if err != nil {
-				panic(builderError{err})
+				panic(err)
 			}
 
 			alias := fmt.Sprintf("check%d", i+1)
@@ -732,7 +732,7 @@ func (mb *mutationBuilder) parseDefaultOrComputedExpr(colID opt.ColumnID) tree.E
 
 	expr, err := parser.ParseExpr(exprStr)
 	if err != nil {
-		panic(builderError{err})
+		panic(err)
 	}
 
 	mb.parsedExprs[ord] = expr
@@ -765,7 +765,7 @@ func (mb *mutationBuilder) buildFKChecks() {
 
 		refTab, err := mb.b.catalog.ResolveDataSourceByID(mb.b.ctx, fk.ReferencedTableID())
 		if err != nil {
-			panic(builderError{err})
+			panic(err)
 		}
 		refOrdinals := make([]int, numCols)
 		for j := range refOrdinals {

--- a/pkg/sql/opt/optbuilder/opaque.go
+++ b/pkg/sql/opt/optbuilder/opaque.go
@@ -39,7 +39,7 @@ func (b *Builder) tryBuildOpaque(stmt tree.Statement, inScope *scope) (outScope 
 	}
 	obj, cols, err := fn(b.ctx, b.semaCtx, b.evalCtx, stmt)
 	if err != nil {
-		panic(builderError{err})
+		panic(err)
 	}
 	outScope = inScope.push()
 	b.synthesizeResultColumns(outScope, cols)

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -116,7 +116,7 @@ func (b *Builder) analyzeOrderByIndex(
 	tab, _ := b.resolveTable(&order.Table, privilege.SELECT)
 	index, err := b.findIndexByName(tab, order.Index)
 	if err != nil {
-		panic(builderError{err})
+		panic(err)
 	}
 
 	// Append each key column from the index (including the implicit primary key
@@ -125,7 +125,7 @@ func (b *Builder) analyzeOrderByIndex(
 		// Columns which are indexable are always orderable.
 		col := index.Column(i)
 		if err != nil {
-			panic(builderError{err})
+			panic(err)
 		}
 
 		desc := col.Descending

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -112,7 +112,7 @@ func (b *Builder) analyzeSelectList(
 			// Fall back to slow path. Pre-normalize any VarName so the work is
 			// not done twice below.
 			if err := e.NormalizeTopLevelVarName(); err != nil {
-				panic(builderError{err})
+				panic(err)
 			}
 
 			// Special handling for "*", "<table>.*" and "(Expr).*".
@@ -177,7 +177,7 @@ func (b *Builder) resolveColRef(e tree.Expr, inScope *scope) tree.TypedExpr {
 		colName := unresolved.Parts[0]
 		_, srcMeta, _, err := inScope.FindSourceProvidingColumn(b.ctx, tree.Name(colName))
 		if err != nil {
-			panic(builderError{err})
+			panic(err)
 		}
 		return srcMeta.(tree.TypedExpr)
 	}
@@ -188,7 +188,7 @@ func (b *Builder) resolveColRef(e tree.Expr, inScope *scope) tree.TypedExpr {
 func (b *Builder) getColName(expr tree.SelectExpr) string {
 	s, err := tree.GetRenderColName(b.semaCtx.SearchPath, expr)
 	if err != nil {
-		panic(builderError{err})
+		panic(err)
 	}
 	return s
 }

--- a/pkg/sql/opt/optbuilder/srfs.go
+++ b/pkg/sql/opt/optbuilder/srfs.go
@@ -87,14 +87,14 @@ func (b *Builder) buildZip(exprs tree.Exprs, inScope *scope) (outScope *scope) {
 		// checking.
 		_, alias, err := tree.ComputeColNameInternal(b.semaCtx.SearchPath, expr)
 		if err != nil {
-			panic(builderError{err})
+			panic(err)
 		}
 		texpr := inScope.resolveType(expr, types.Any)
 
 		var def *tree.FunctionDefinition
 		if funcExpr, ok := texpr.(*tree.FuncExpr); ok {
 			if def, err = funcExpr.Func.Resolve(b.semaCtx.SearchPath); err != nil {
-				panic(builderError{err})
+				panic(err)
 			}
 		}
 

--- a/pkg/sql/opt/optbuilder/values.go
+++ b/pkg/sql/opt/optbuilder/values.go
@@ -73,7 +73,7 @@ func (b *Builder) buildValuesClause(
 			expr := inScope.walkExprTree(tuple[colIdx])
 			texpr, err := tree.TypeCheck(expr, b.semaCtx, desired)
 			if err != nil {
-				panic(builderError{err})
+				panic(err)
 			}
 			if typ := texpr.ResolvedType(); typ.Family() != types.UnknownFamily {
 				if colTypes[colIdx].Family() == types.UnknownFamily {

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -43,7 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/datadriven"
-	"github.com/pkg/errors"
+	"github.com/cockroachdb/errors"
 	"github.com/pmezard/go-difflib/difflib"
 )
 
@@ -330,6 +330,9 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 	case "build":
 		e, err := ot.OptBuild()
 		if err != nil {
+			if errors.HasAssertionFailure(err) {
+				d.Fatalf(tb, "%+v", err)
+			}
 			pgerr := pgerror.Flatten(err)
 			text := strings.TrimSpace(pgerr.Error())
 			if pgerr.Code != pgcode.Uncategorized {
@@ -344,6 +347,9 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 	case "norm":
 		e, err := ot.OptNorm()
 		if err != nil {
+			if errors.HasAssertionFailure(err) {
+				d.Fatalf(tb, "%+v", err)
+			}
 			pgerr := pgerror.Flatten(err)
 			text := strings.TrimSpace(pgerr.Error())
 			if pgerr.Code != pgcode.Uncategorized {

--- a/pkg/util/errorutil/catch.go
+++ b/pkg/util/errorutil/catch.go
@@ -1,0 +1,33 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package errorutil
+
+import (
+	"runtime"
+
+	"github.com/cockroachdb/errors"
+)
+
+// ShouldCatch is used for catching errors thrown as panics. Its argument is the
+// object returned by recover(); it succeeds if the object is an error. If the
+// error is a runtime.Error, it is converted to an internal error (see
+// errors.AssertionFailedf).
+func ShouldCatch(obj interface{}) (ok bool, err error) {
+	err, ok = obj.(error)
+	if ok {
+		if _, isRuntime := err.(runtime.Error); isRuntime {
+			// Convert runtime errors to internal errors, which display the stack and
+			// get reported to Sentry.
+			err = errors.HandleAsAssertionFailure(err)
+		}
+	}
+	return ok, err
+}


### PR DESCRIPTION
The major entry points in the optimizer catch all panics that throw an
error and converts them to errors. Unfortunately, this also catches
runtime errors (in which case we convert them to errors and lose the
stack trace).

This change adds a `ShouldCatch` helper which determines if we should
return a thrown object as an error. If the object is a
`runtime.Error`, it gets wrapped by an AssertionFailed error which
will cause correct error handling (stack trace, sentry reporting, etc).

As part of this change, we are also removing wrappers like
`builderError`, which are no longer useful. We fix the opt tester to
fail with the full error information (using `%+v`) for assertion
errors.

Release note: None