### PR TITLE
ui: Add devtool setting into webpack

### DIFF
--- a/pkg/ui/webpack.app.js
+++ b/pkg/ui/webpack.app.js
@@ -144,6 +144,7 @@ module.exports = (env) => {
       chunks: false,
     },
 
+    devtool: 'source-map',
     devServer: {
       contentBase: path.join(__dirname, `dist${env.dist}`),
       index: "",


### PR DESCRIPTION
This allows users to can track down their frontend code in a debugger.