### PR TITLE
ui: show unintended flatten graph in better way

### DIFF
--- a/pkg/ui/src/views/cluster/util/graphs.ts
+++ b/pkg/ui/src/views/cluster/util/graphs.ts
@@ -91,7 +91,7 @@ class AxisDomain {
   }
 }
 
-const countIncrementTable = [0.1, 0.2, 0.25, 0.3, 0.4, 0.5, 0.6, 0.7, 0.75, 0.8, 0.9, 1.0];
+const countIncrementTable = [0.01, 0.1, 0.2, 0.25, 0.3, 0.4, 0.5, 0.6, 0.7, 0.75, 0.8, 0.9, 1.0];
 
 // computeNormalizedIncrement computes a human-friendly increment between tick
 // values on an axis with a range of the given size. The provided size is taken
@@ -134,7 +134,11 @@ function computeAxisDomain(extent: Extent, factor: number = 1): AxisDomain {
   // but with a metric prefix for large numbers (i.e. 1000 will display as "1k")
   let unitFormat: (v: number) => string;
   if (Math.floor(increment) !== increment) {
-    unitFormat = d3.format(".1f");
+    if (increment < 0.1) {
+      unitFormat = d3.format(".2f");
+    } else {
+      unitFormat = d3.format(".1f");
+    }
   } else {
     unitFormat = d3.format("s");
   }
@@ -257,7 +261,7 @@ function ComputeTimeAxisDomain(extent: Extent): AxisDomain {
 function calculateYAxisDomain(axisUnits: AxisUnits, data: TSResponse): AxisDomain {
   const resultDatapoints = _.flatMap(data.results, (result) => _.map(result.datapoints, (dp) => dp.value));
   // TODO(couchand): Remove these random datapoints when NVD3 is gone.
-  const allDatapoints = resultDatapoints.concat([0, 1]);
+  const allDatapoints = resultDatapoints.concat((_.max(resultDatapoints) == 0 && _.min(resultDatapoints) == 0) ? [0, 1] : [0]);
   const yExtent = d3.extent(allDatapoints);
 
   switch (axisUnits) {


### PR DESCRIPTION
Like `RocksDB Compactions/Flushs` graphs, they have < 1 values at all.
Thus their graph always would be displayed flatten to zero. It makes hard to distinguish when it occurred or not.

This patch lower the `countIncrementTable` from 0.1 to 0.01 and modify `calculateYAxisDomain` not to align its legend to `[0, 1]`.

Ref:
This fixes https://github.com/cockroachdb/cockroach/issues/27094

After:
<img width="977" alt="Screen Shot 2019-06-29 at 4 00 42 PM" src="https://user-images.githubusercontent.com/579366/60380989-ef263880-9a88-11e9-87bb-1292ebed04f5.png">
