### PR TITLE
exec: refactor runTests to remove some duplication

### DIFF
--- a/pkg/sql/exec/aggregator_test.go
+++ b/pkg/sql/exec/aggregator_test.go
@@ -285,22 +285,16 @@ func TestAggregatorOneFunc(t *testing.T) {
 			t.Run(fmt.Sprintf("Randomized"), func(t *testing.T) {
 				for _, agg := range aggTypes {
 					t.Run(agg.name, func(t *testing.T) {
-						runTests(t, []tuples{tc.input}, func(t *testing.T, input []Operator) {
-							a, err := agg.new(
-								input[0],
-								tc.colTypes,
-								tc.aggFns,
-								tc.groupCols,
-								tc.aggCols,
-							)
-							if err != nil {
-								t.Fatal(err)
-							}
-							out := newOpTestOutput(a, []int{0}, tc.expected)
-							if err := out.VerifyAnyOrder(); err != nil {
-								t.Fatal(err)
-							}
-						})
+						runTests(t, []tuples{tc.input}, tc.expected, unorderedVerifier, []int{0},
+							func(input []Operator) (Operator, error) {
+								return agg.new(
+									input[0],
+									tc.colTypes,
+									tc.aggFns,
+									tc.groupCols,
+									tc.aggCols,
+								)
+							})
 					})
 				}
 			})
@@ -372,22 +366,10 @@ func TestAggregatorMultiFunc(t *testing.T) {
 				if err := tc.init(); err != nil {
 					t.Fatal(err)
 				}
-				runTests(t, []tuples{tc.input}, func(t *testing.T, input []Operator) {
-					a, err := agg.new(
-						input[0],
-						tc.colTypes,
-						tc.aggFns,
-						tc.groupCols,
-						tc.aggCols,
-					)
-					if err != nil {
-						t.Fatal(err)
-					}
-					out := newOpTestOutput(a, []int{0, 1}, tc.expected)
-					if err := out.VerifyAnyOrder(); err != nil {
-						t.Fatal(err)
-					}
-				})
+				runTests(t, []tuples{tc.input}, tc.expected, unorderedVerifier, []int{0, 1},
+					func(input []Operator) (Operator, error) {
+						return agg.new(input[0], tc.colTypes, tc.aggFns, tc.groupCols, tc.aggCols)
+					})
 			})
 		}
 	}
@@ -432,16 +414,10 @@ func TestAggregatorAllFunctions(t *testing.T) {
 				if err := tc.init(); err != nil {
 					t.Fatal(err)
 				}
-				runTests(t, []tuples{tc.input}, func(t *testing.T, input []Operator) {
-					a, err := agg.new(input[0], tc.colTypes, tc.aggFns, tc.groupCols, tc.aggCols)
-					if err != nil {
-						t.Fatal(err)
-					}
-					out := newOpTestOutput(a, []int{0, 1, 2, 3, 4, 5, 6}, tc.expected)
-					if err := out.Verify(); err != nil {
-						t.Fatal(err)
-					}
-				})
+				runTests(t, []tuples{tc.input}, tc.expected, orderedVerifier, []int{0, 1, 2, 3, 4, 5, 6},
+					func(input []Operator) (Operator, error) {
+						return agg.new(input[0], tc.colTypes, tc.aggFns, tc.groupCols, tc.aggCols)
+					})
 			})
 		}
 	}
@@ -750,24 +726,13 @@ func TestHashAggregator(t *testing.T) {
 		if err := tc.init(); err != nil {
 			t.Fatal(err)
 		}
-		runTests(t, []tuples{tc.input}, func(t *testing.T, sources []Operator) {
-			ag, err := NewHashAggregator(sources[0], tc.colTypes, tc.aggFns, tc.groupCols, tc.aggCols)
-
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			nOutput := len(tc.aggCols)
-			cols := make([]int, nOutput)
-			for i := 0; i < nOutput; i++ {
-				cols[i] = i
-			}
-
-			out := newOpTestOutput(ag, cols, tc.expected)
-
-			if err := out.VerifyAnyOrder(); err != nil {
-				t.Fatal(err)
-			}
+		nOutput := len(tc.aggCols)
+		cols := make([]int, nOutput)
+		for i := 0; i < nOutput; i++ {
+			cols[i] = i
+		}
+		runTests(t, []tuples{tc.input}, tc.expected, unorderedVerifier, cols, func(sources []Operator) (Operator, error) {
+			return NewHashAggregator(sources[0], tc.colTypes, tc.aggFns, tc.groupCols, tc.aggCols)
 		})
 	}
 }

--- a/pkg/sql/exec/bool_vec_to_sel_test.go
+++ b/pkg/sql/exec/bool_vec_to_sel_test.go
@@ -25,12 +25,8 @@ func TestBoolVecToSelOp(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
-		runTests(t, []tuples{tc.tuples}, func(t *testing.T, input []Operator) {
-			op := NewBoolVecToSelOp(input[0], 0)
-			out := newOpTestOutput(op, []int{0}, tc.expected)
-			if err := out.Verify(); err != nil {
-				t.Fatal(err)
-			}
+		runTests(t, []tuples{tc.tuples}, tc.expected, orderedVerifier, []int{0}, func(input []Operator) (Operator, error) {
+			return NewBoolVecToSelOp(input[0], 0), nil
 		})
 	}
 }

--- a/pkg/sql/exec/coalescer_test.go
+++ b/pkg/sql/exec/coalescer_test.go
@@ -51,19 +51,12 @@ func TestCoalescer(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		runTests(t, []tuples{tc.tuples}, func(t *testing.T, input []Operator) {
-			coalescer := NewCoalescerOp(input[0], tc.colTypes)
-
-			colIndices := make([]int, len(tc.colTypes))
-			for i := 0; i < len(colIndices); i++ {
-				colIndices[i] = i
-			}
-
-			out := newOpTestOutput(coalescer, colIndices, tc.tuples)
-
-			if err := out.Verify(); err != nil {
-				t.Fatal(err)
-			}
+		colIndices := make([]int, len(tc.colTypes))
+		for i := 0; i < len(colIndices); i++ {
+			colIndices[i] = i
+		}
+		runTests(t, []tuples{tc.tuples}, tc.tuples, orderedVerifier, colIndices, func(input []Operator) (Operator, error) {
+			return NewCoalescerOp(input[0], tc.colTypes), nil
 		})
 	}
 }

--- a/pkg/sql/exec/count_test.go
+++ b/pkg/sql/exec/count_test.go
@@ -27,13 +27,8 @@ func TestCount(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
-		runTests(t, []tuples{tc.tuples}, func(t *testing.T, input []Operator) {
-			count := NewCountOp(input[0])
-			out := newOpTestOutput(count, []int{0}, tc.expected)
-
-			if err := out.VerifyAnyOrder(); err != nil {
-				t.Fatal(err)
-			}
+		runTests(t, []tuples{tc.tuples}, tc.expected, orderedVerifier, []int{0}, func(input []Operator) (Operator, error) {
+			return NewCountOp(input[0]), nil
 		})
 	}
 }

--- a/pkg/sql/exec/distinct_test.go
+++ b/pkg/sql/exec/distinct_test.go
@@ -68,17 +68,10 @@ func TestSortedDistinct(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		runTests(t, []tuples{tc.tuples}, func(t *testing.T, input []Operator) {
-			distinct, err := NewOrderedDistinct(input[0], tc.distinctCols, tc.colTypes)
-			if err != nil {
-				t.Fatal(err)
-			}
-			out := newOpTestOutput(distinct, []int{0, 1, 2, 3}, tc.expected)
-
-			if err := out.VerifyAnyOrder(); err != nil {
-				t.Fatal(err)
-			}
-		})
+		runTests(t, []tuples{tc.tuples}, tc.expected, orderedVerifier, []int{0, 1, 2, 3},
+			func(input []Operator) (Operator, error) {
+				return NewOrderedDistinct(input[0], tc.distinctCols, tc.colTypes)
+			})
 	}
 }
 

--- a/pkg/sql/exec/like_ops_test.go
+++ b/pkg/sql/exec/like_ops_test.go
@@ -23,33 +23,23 @@ import (
 
 func TestSelPrefixBytesBytesConstOp(t *testing.T) {
 	tups := tuples{{"abc"}, {"def"}, {"ghi"}}
-	runTests(t, []tuples{tups}, func(t *testing.T, input []Operator) {
-		op := selPrefixBytesBytesConstOp{
+	runTests(t, []tuples{tups}, tuples{{"def"}}, orderedVerifier, []int{0}, func(input []Operator) (Operator, error) {
+		return &selPrefixBytesBytesConstOp{
 			input:    input[0],
 			colIdx:   0,
 			constArg: []byte("de"),
-		}
-		op.Init()
-		out := newOpTestOutput(&op, []int{0}, tuples{{"def"}})
-		if err := out.Verify(); err != nil {
-			t.Error(err)
-		}
+		}, nil
 	})
 }
 
 func TestSelSuffixBytesBytesConstOp(t *testing.T) {
 	tups := tuples{{"abc"}, {"def"}, {"ghi"}}
-	runTests(t, []tuples{tups}, func(t *testing.T, input []Operator) {
-		op := selSuffixBytesBytesConstOp{
+	runTests(t, []tuples{tups}, tuples{{"def"}}, orderedVerifier, []int{0}, func(input []Operator) (Operator, error) {
+		return &selSuffixBytesBytesConstOp{
 			input:    input[0],
 			colIdx:   0,
 			constArg: []byte("ef"),
-		}
-		op.Init()
-		out := newOpTestOutput(&op, []int{0}, tuples{{"def"}})
-		if err := out.Verify(); err != nil {
-			t.Error(err)
-		}
+		}, nil
 	})
 }
 
@@ -59,17 +49,12 @@ func TestSelRegexpBytesBytesConstOp(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	runTests(t, []tuples{tups}, func(t *testing.T, input []Operator) {
-		op := selRegexpBytesBytesConstOp{
+	runTests(t, []tuples{tups}, tuples{{"def"}}, orderedVerifier, []int{0}, func(input []Operator) (Operator, error) {
+		return &selRegexpBytesBytesConstOp{
 			input:    input[0],
 			colIdx:   0,
 			constArg: pattern,
-		}
-		op.Init()
-		out := newOpTestOutput(&op, []int{0}, tuples{{"def"}})
-		if err := out.Verify(); err != nil {
-			t.Error(err)
-		}
+		}, nil
 	})
 }
 

--- a/pkg/sql/exec/limit_test.go
+++ b/pkg/sql/exec/limit_test.go
@@ -56,13 +56,8 @@ func TestLimit(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		runTests(t, []tuples{tc.tuples}, func(t *testing.T, input []Operator) {
-			limit := NewLimitOp(input[0], tc.limit)
-			out := newOpTestOutput(limit, []int{0}, tc.expected)
-
-			if err := out.VerifyAnyOrder(); err != nil {
-				t.Fatal(err)
-			}
+		runTests(t, []tuples{tc.tuples}, tc.expected, unorderedVerifier, []int{0}, func(input []Operator) (Operator, error) {
+			return NewLimitOp(input[0], tc.limit), nil
 		})
 	}
 }

--- a/pkg/sql/exec/offset_test.go
+++ b/pkg/sql/exec/offset_test.go
@@ -52,13 +52,8 @@ func TestOffset(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		runTests(t, []tuples{tc.tuples}, func(t *testing.T, input []Operator) {
-			s := NewOffsetOp(input[0], tc.offset)
-			out := newOpTestOutput(s, []int{0}, tc.expected)
-
-			if err := out.VerifyAnyOrder(); err != nil {
-				t.Fatal(err)
-			}
+		runTests(t, []tuples{tc.tuples}, tc.expected, unorderedVerifier, []int{0}, func(input []Operator) (Operator, error) {
+			return NewOffsetOp(input[0], tc.offset), nil
 		})
 	}
 }

--- a/pkg/sql/exec/ordinality_test.go
+++ b/pkg/sql/exec/ordinality_test.go
@@ -42,15 +42,11 @@ func TestOrdinality(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		runTests(t, []tuples{tc.tuples}, func(t *testing.T, input []Operator) {
-			numExpectedCols := len(tc.expected[0])
-			ordinality := NewOrdinalityOp(input[0])
-			out := newOpTestOutput(ordinality, []int{0, 1, 2}[:numExpectedCols], tc.expected)
-
-			if err := out.Verify(); err != nil {
-				t.Fatal(err)
-			}
-		})
+		numExpectedCols := len(tc.expected[0])
+		runTests(t, []tuples{tc.tuples}, tc.expected, orderedVerifier, []int{0, 1, 2}[:numExpectedCols],
+			func(input []Operator) (Operator, error) {
+				return NewOrdinalityOp(input[0]), nil
+			})
 	}
 }
 

--- a/pkg/sql/exec/projection_ops_test.go
+++ b/pkg/sql/exec/projection_ops_test.go
@@ -24,35 +24,28 @@ import (
 )
 
 func TestProjPlusInt64Int64ConstOp(t *testing.T) {
-	runTests(t, []tuples{{{1}, {2}, {nil}}}, func(t *testing.T, input []Operator) {
-		op := projPlusInt64Int64ConstOp{
-			input:     input[0],
-			colIdx:    0,
-			constArg:  1,
-			outputIdx: 1,
-		}
-		op.Init()
-		out := newOpTestOutput(&op, []int{0, 1}, tuples{{1, 2}, {2, 3}, {nil, nil}})
-		if err := out.Verify(); err != nil {
-			t.Error(err)
-		}
-	})
+	runTests(t, []tuples{{{1}, {2}, {nil}}}, tuples{{1, 2}, {2, 3}, {nil, nil}}, orderedVerifier,
+		[]int{0, 1}, func(input []Operator) (Operator, error) {
+			return &projPlusInt64Int64ConstOp{
+				input:     input[0],
+				colIdx:    0,
+				constArg:  1,
+				outputIdx: 1,
+			}, nil
+		})
 }
 
 func TestProjPlusInt64Int64Op(t *testing.T) {
-	runTests(t, []tuples{{{1, 2}, {3, 4}, {5, nil}}}, func(t *testing.T, input []Operator) {
-		op := projPlusInt64Int64Op{
-			input:     input[0],
-			col1Idx:   0,
-			col2Idx:   1,
-			outputIdx: 2,
-		}
-		op.Init()
-		out := newOpTestOutput(&op, []int{0, 1, 2}, tuples{{1, 2, 3}, {3, 4, 7}, {5, nil, nil}})
-		if err := out.Verify(); err != nil {
-			t.Error(err)
-		}
-	})
+	runTests(t, []tuples{{{1, 2}, {3, 4}, {5, nil}}}, tuples{{1, 2, 3}, {3, 4, 7}, {5, nil, nil}},
+		orderedVerifier, []int{0, 1, 2},
+		func(input []Operator) (Operator, error) {
+			return &projPlusInt64Int64Op{
+				input:     input[0],
+				col1Idx:   0,
+				col2Idx:   1,
+				outputIdx: 2,
+			}, nil
+		})
 }
 
 func benchmarkProjPlusInt64Int64ConstOp(b *testing.B, useSelectionVector bool, hasNulls bool) {

--- a/pkg/sql/exec/routers_test.go
+++ b/pkg/sql/exec/routers_test.go
@@ -322,7 +322,7 @@ func TestRouterOutputRandom(t *testing.T) {
 		"blockedThreshold=%d/outputSize=%d/totalInputSize=%d", blockedThreshold, outputSize, len(data),
 	)
 	t.Run(testName, func(t *testing.T) {
-		runTests(t, []tuples{data}, func(t *testing.T, inputs []Operator) {
+		runTestsWithFn(t, []tuples{data}, func(t *testing.T, inputs []Operator) {
 			var wg sync.WaitGroup
 			unblockedEventsChans := make(chan struct{}, 2)
 			o := newRouterOutputOpWithBlockedThresholdAndBatchSize(
@@ -695,7 +695,7 @@ func TestHashRouterRandom(t *testing.T) {
 	// same data to the same number of outputs.
 	var expectedDistribution []int
 	t.Run(testName, func(t *testing.T) {
-		runTests(t, []tuples{data}, func(t *testing.T, inputs []Operator) {
+		runTestsWithFn(t, []tuples{data}, func(t *testing.T, inputs []Operator) {
 			unblockEventsChan := make(chan struct{}, 2*numOutputs)
 			outputs := make([]routerOutput, numOutputs)
 			outputsAsOps := make([]Operator, numOutputs)

--- a/pkg/sql/exec/selection_ops_test.go
+++ b/pkg/sql/exec/selection_ops_test.go
@@ -31,17 +31,12 @@ const (
 
 func TestSelLTInt64Int64ConstOp(t *testing.T) {
 	tups := tuples{{0}, {1}, {2}, {nil}}
-	runTests(t, []tuples{tups}, func(t *testing.T, input []Operator) {
-		op := selLTInt64Int64ConstOp{
+	runTests(t, []tuples{tups}, tuples{{0}, {1}}, orderedVerifier, []int{0}, func(input []Operator) (Operator, error) {
+		return &selLTInt64Int64ConstOp{
 			input:    input[0],
 			colIdx:   0,
 			constArg: 2,
-		}
-		op.Init()
-		out := newOpTestOutput(&op, []int{0}, tuples{{0}, {1}})
-		if err := out.Verify(); err != nil {
-			t.Error(err)
-		}
+		}, nil
 	})
 }
 
@@ -55,17 +50,12 @@ func TestSelLTInt64Int64(t *testing.T) {
 		{-1, nil},
 		{nil, nil},
 	}
-	runTests(t, []tuples{tups}, func(t *testing.T, input []Operator) {
-		op := selLTInt64Int64Op{
+	runTests(t, []tuples{tups}, tuples{{0, 1}}, orderedVerifier, []int{0, 1}, func(input []Operator) (Operator, error) {
+		return &selLTInt64Int64Op{
 			input:   input[0],
 			col1Idx: 0,
 			col2Idx: 1,
-		}
-		op.Init()
-		out := newOpTestOutput(&op, []int{0, 1}, tuples{{0, 1}})
-		if err := out.Verify(); err != nil {
-			t.Error(err)
-		}
+		}, nil
 	})
 }
 

--- a/pkg/sql/exec/simple_project_test.go
+++ b/pkg/sql/exec/simple_project_test.go
@@ -53,22 +53,14 @@ func TestSimpleProjectOp(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
-		runTests(t, []tuples{tc.tuples}, func(t *testing.T, input []Operator) {
-			count := NewSimpleProjectOp(input[0], tc.colsToKeep)
-			out := newOpTestOutput(count, []int{0, 1}, tc.expected)
-
-			if err := out.Verify(); err != nil {
-				t.Fatal(err)
-			}
+		runTests(t, []tuples{tc.tuples}, tc.expected, orderedVerifier, []int{0, 1}, func(input []Operator) (Operator, error) {
+			return NewSimpleProjectOp(input[0], tc.colsToKeep), nil
 		})
 	}
 
 	// Empty projection.
-	runTests(t, []tuples{{{1, 2, 3}, {1, 2, 3}}}, func(t *testing.T, input []Operator) {
-		count := NewSimpleProjectOp(input[0], nil)
-		out := newOpTestOutput(count, []int{}, tuples{{}, {}})
-		if err := out.Verify(); err != nil {
-			t.Fatal(err)
-		}
-	})
+	runTests(t, []tuples{{{1, 2, 3}, {1, 2, 3}}}, tuples{{}, {}}, orderedVerifier, []int{},
+		func(input []Operator) (Operator, error) {
+			return NewSimpleProjectOp(input[0], nil), nil
+		})
 }

--- a/pkg/sql/exec/sort_chunks_test.go
+++ b/pkg/sql/exec/sort_chunks_test.go
@@ -176,20 +176,12 @@ func TestSortChunks(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
-		runTests(t, []tuples{tc.tuples}, func(t *testing.T, input []Operator) {
-			sorter, err := NewSortChunks(input[0], tc.typ, tc.ordCols, tc.matchLen)
-			if err != nil {
-				t.Fatal(err)
-			}
-			cols := make([]int, len(tc.typ))
-			for i := range cols {
-				cols[i] = i
-			}
-			out := newOpTestOutput(sorter, cols, tc.expected)
-
-			if err := out.Verify(); err != nil {
-				t.Fatalf("Test case description: '%s'\n%v", tc.description, err)
-			}
+		cols := make([]int, len(tc.typ))
+		for i := range cols {
+			cols[i] = i
+		}
+		runTests(t, []tuples{tc.tuples}, tc.expected, orderedVerifier, cols, func(input []Operator) (Operator, error) {
+			return NewSortChunks(input[0], tc.typ, tc.ordCols, tc.matchLen)
 		})
 	}
 }
@@ -228,20 +220,12 @@ func TestSortChunksRandomized(t *testing.T) {
 				copy(expected, tups)
 				sort.Slice(expected, less(expected, ordCols))
 
-				runTests(t, []tuples{sortedTups}, func(t *testing.T, input []Operator) {
-					sorter, err := NewSortChunks(input[0], typs[:nCols], ordCols, matchLen)
-					if err != nil {
-						t.Fatal(err)
-					}
-					cols := make([]int, nCols)
-					for i := range cols {
-						cols[i] = i
-					}
-					out := newOpTestOutput(sorter, cols, expected)
-
-					if err := out.Verify(); err != nil {
-						t.Fatalf("for input %v:\n%v", sortedTups, err)
-					}
+				cols := make([]int, nCols)
+				for i := range cols {
+					cols[i] = i
+				}
+				runTests(t, []tuples{sortedTups}, expected, orderedVerifier, cols, func(input []Operator) (Operator, error) {
+					return NewSortChunks(input[0], typs[:nCols], ordCols, matchLen)
 				})
 			}
 		}

--- a/pkg/sql/exec/sorttopk_test.go
+++ b/pkg/sql/exec/sorttopk_test.go
@@ -67,16 +67,12 @@ func TestTopKSorter(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			runTests(t, []tuples{tc.tuples}, func(t *testing.T, input []Operator) {
-				sort := NewTopKSorter(input[0], tc.typ, tc.ordCols, tc.k)
-				cols := make([]int, len(tc.typ))
-				for i := range cols {
-					cols[i] = i
-				}
-				out := newOpTestOutput(sort, cols, tc.expected)
-				if err := out.Verify(); err != nil {
-					t.Fatal(err)
-				}
+			cols := make([]int, len(tc.typ))
+			for i := range cols {
+				cols[i] = i
+			}
+			runTests(t, []tuples{tc.tuples}, tc.expected, orderedVerifier, cols, func(input []Operator) (Operator, error) {
+				return NewTopKSorter(input[0], tc.typ, tc.ordCols, tc.k), nil
 			})
 		})
 	}


### PR DESCRIPTION
runTests now takes in the expected results, the verification method
(ordered or unordered), and the list of columns to check. Its input
function was changed from a test function to a constructor.

This way, the test callers don't have to repeat themselves as much. It
also opens up runTests to perform further verification downstream of the
operator under test.

Release note: None