### PR TITLE
kv: prioritize severe errors when merging partial batches in DistSender

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1217,6 +1217,9 @@ func PrepareTransactionForRetry(
 		log.Fatalf(ctx, "invalid retryable err (%T): %s", pErr.GetDetail(), pErr)
 	}
 	if !aborted {
+		if txn.Status.IsFinalized() {
+			log.Fatalf(ctx, "transaction unexpectedly finalized in (%T): %s", pErr.GetDetail(), pErr)
+		}
 		txn.Restart(pri, txn.Priority, txn.Timestamp)
 	}
 	return txn

--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -39,16 +39,56 @@ func (e *UnhandledRetryableError) Error() string {
 
 var _ error = &UnhandledRetryableError{}
 
+// transactionRestartError is an interface implemented by errors that cause
+// a transaction to be restarted.
+type transactionRestartError interface {
+	canRestartTransaction() TransactionRestart
+}
+
 // ErrorUnexpectedlySet creates a string to panic with when a response (typically
 // a roachpb.BatchResponse) unexpectedly has Error set in its response header.
 func ErrorUnexpectedlySet(culprit, response interface{}) string {
 	return fmt.Sprintf("error is unexpectedly set, culprit is %T:\n%+v", culprit, response)
 }
 
-// transactionRestartError is an interface implemented by errors that cause
-// a transaction to be restarted.
-type transactionRestartError interface {
-	canRestartTransaction() TransactionRestart
+// ErrorPriority is used to rank errors such that the "best" one is chosen to be
+// presented as the batch result when a batch is split up and observes multiple
+// errors. Higher values correspond to higher priorities.
+type ErrorPriority int
+
+const (
+	_ ErrorPriority = iota
+	// ErrorScoreTxnRestart indicates that the transaction should be restarted
+	// with an incremented epoch.
+	ErrorScoreTxnRestart
+	// ErrorScoreTxnAbort indicates that the transaction is aborted. The
+	// operation can only try again under the purview of a new transaction.
+	ErrorScoreTxnAbort
+	// ErrorScoreNonRetriable indicates that the transaction performed an
+	// operation that does not warrant a retry. Often this indicates that the
+	// operation ran into a logic error. The error should be propagated to the
+	// client and the transaction should terminate immediately.
+	ErrorScoreNonRetriable
+)
+
+// ErrPriority computes the priority of the given error.
+func ErrPriority(err error) ErrorPriority {
+	if err == nil {
+		return 0
+	}
+	switch v := err.(type) {
+	case *UnhandledRetryableError:
+		if _, ok := v.PErr.GetDetail().(*TransactionAbortedError); ok {
+			return ErrorScoreTxnAbort
+		}
+		return ErrorScoreTxnRestart
+	case *TransactionRetryWithProtoRefreshError:
+		if v.PrevTxnAborted() {
+			return ErrorScoreTxnAbort
+		}
+		return ErrorScoreTxnRestart
+	}
+	return ErrorScoreNonRetriable
 }
 
 // NewError creates an Error from the given error.

--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -267,6 +267,10 @@ func (r *Replica) propose(ctx context.Context, p *ProposalData) (_ int64, pErr *
 		log.VEvent(p.ctx, 4, "sideloadable proposal detected")
 		version = raftVersionSideloaded
 		r.store.metrics.AddSSTableProposals.Inc(1)
+
+		if p.command.ReplicatedEvalResult.AddSSTable.Data == nil {
+			return 0, roachpb.NewErrorf("cannot sideload empty SSTable")
+		}
 	} else if log.V(4) {
 		log.Infof(p.ctx, "proposing command %x: %s", p.idKey, p.Request.Summary())
 	}


### PR DESCRIPTION
Fixes #36024.
Fixes #36094.

8b5bafb ensured that all transaction state was propagated by `DistSender` on errors. In doing so, it touched that fact that `DistSender` drops all but the first error that it sees. It ensured that even though this was the case, the error metadata from these dropped errors would still be propagated (see `pErr.UpdateTxn(resp.pErr.GetTxn())`).

This has an unintended consequence where it was now possible for a non-aborting transaction retry error to be updated with an ABORTED transaction proto. This caused confusion in the `TxnCoordSender`, triggering panics like the ones we see in #36024 and #36094.

This change fixes this by being smarter about which errors get dropped when concurrent partial batches each hit an error in `DistSender`. It does this by prioritizing the most severe errors and merging transaction state into those. In a lot of ways, this is the `DistSender` equivalent of 574e805, which is why they now share code.