### PR TITLE
sql: move UNSPLIT ALL internal query to startExec

### DIFF
--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -391,6 +391,7 @@ func doExpandPlan(
 	case *showFingerprintsNode:
 	case *showTraceNode:
 	case *scatterNode:
+	case *unsplitAllNode:
 	case nil:
 
 	default:
@@ -908,6 +909,7 @@ func (p *planner) simplifyOrderings(plan planNode, usefulOrdering sqlbase.Column
 	case *showTraceNode:
 	case *scanBufferNode:
 	case *scatterNode:
+	case *unsplitAllNode:
 
 	default:
 		panic(fmt.Sprintf("unhandled node type: %T", plan))

--- a/pkg/sql/opt_filters.go
+++ b/pkg/sql/opt_filters.go
@@ -409,6 +409,7 @@ func (p *planner) propagateFilters(
 	case *showTraceNode:
 	case *scanBufferNode:
 	case *scatterNode:
+	case *unsplitAllNode:
 
 	default:
 		panic(fmt.Sprintf("unhandled node type: %T", plan))

--- a/pkg/sql/opt_limits.go
+++ b/pkg/sql/opt_limits.go
@@ -240,6 +240,7 @@ func (p *planner) applyLimit(plan planNode, numRows int64, soft bool) {
 	case *showTraceNode:
 	case *scatterNode:
 	case *scanBufferNode:
+	case *unsplitAllNode:
 
 	case *applyJoinNode, *lookupJoinNode, *zigzagJoinNode, *saveTableNode:
 		// These nodes are only planned by the optimizer.

--- a/pkg/sql/opt_needed.go
+++ b/pkg/sql/opt_needed.go
@@ -296,6 +296,7 @@ func setNeededColumns(plan planNode, needed []bool) {
 	case *showTraceNode:
 	case *scatterNode:
 	case *scanBufferNode:
+	case *unsplitAllNode:
 
 	default:
 		panic(fmt.Sprintf("unhandled node type: %T", plan))

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -219,6 +219,7 @@ var _ planNode = &showTraceNode{}
 var _ planNode = &sortNode{}
 var _ planNode = &splitNode{}
 var _ planNode = &unsplitNode{}
+var _ planNode = &unsplitAllNode{}
 var _ planNode = &truncateNode{}
 var _ planNode = &unaryNode{}
 var _ planNode = &unionNode{}

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -109,6 +109,8 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		return n.getColumns(mut, splitNodeColumns)
 	case *unsplitNode:
 		return n.getColumns(mut, unsplitNodeColumns)
+	case *unsplitAllNode:
+		return n.getColumns(mut, unsplitNodeColumns)
 	case *showTraceReplicaNode:
 		return n.getColumns(mut, sqlbase.ShowReplicaTraceColumns)
 	case *sequenceSelectNode:

--- a/pkg/sql/plan_physical_props.go
+++ b/pkg/sql/plan_physical_props.go
@@ -139,6 +139,7 @@ func planPhysicalProps(plan planNode) physicalProps {
 	case *showTraceReplicaNode:
 	case *splitNode:
 	case *unsplitNode:
+	case *unsplitAllNode:
 	case *truncateNode:
 	case *unaryNode:
 	case *valuesNode:

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -773,6 +773,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&sortNode{}):                 "sort",
 	reflect.TypeOf(&splitNode{}):                "split",
 	reflect.TypeOf(&unsplitNode{}):              "unsplit",
+	reflect.TypeOf(&unsplitAllNode{}):           "unsplit all",
 	reflect.TypeOf(&spoolNode{}):                "spool",
 	reflect.TypeOf(&truncateNode{}):             "truncate",
 	reflect.TypeOf(&unaryNode{}):                "emptyrow",


### PR DESCRIPTION
We now execute the internal query during execution, not planning. To
make the code cleaner (and easier to integrate with the optimizer), we
split the functionality off to a separate `unsplitAllNode`.

Release note: None.