### PR TITLE
exec: make sure to reset selection on owned batches

### DIFF
--- a/pkg/sql/exec/aggregator.go
+++ b/pkg/sql/exec/aggregator.go
@@ -236,6 +236,7 @@ func (a *orderedAggregator) Init() {
 }
 
 func (a *orderedAggregator) Next(ctx context.Context) coldata.Batch {
+	a.scratch.SetSelection(false)
 	if a.done {
 		a.scratch.SetLength(0)
 		return a.scratch

--- a/pkg/sql/exec/count.go
+++ b/pkg/sql/exec/count.go
@@ -49,6 +49,7 @@ func (c *countOp) Init() {
 }
 
 func (c *countOp) Next(ctx context.Context) coldata.Batch {
+	c.internalBatch.SetSelection(false)
 	if c.done {
 		c.internalBatch.SetLength(0)
 		return c.internalBatch

--- a/pkg/sql/exec/deselector.go
+++ b/pkg/sql/exec/deselector.go
@@ -51,6 +51,7 @@ func (p *deselectorOp) Next(ctx context.Context) coldata.Batch {
 	}
 
 	p.output.SetLength(batch.Length())
+	p.output.SetSelection(false)
 	sel := batch.Selection()
 	for i, t := range p.inputTypes {
 		toCol := p.output.ColVec(i)

--- a/pkg/sql/exec/hashjoiner.go
+++ b/pkg/sql/exec/hashjoiner.go
@@ -241,9 +241,11 @@ func (hj *hashJoinEqOp) Next(ctx context.Context) coldata.Batch {
 			return hj.Next(ctx)
 		}
 
+		hj.prober.batch.SetSelection(false)
 		return hj.prober.batch
 	case hjEmittingUnmatched:
 		hj.emitUnmatched()
+		hj.prober.batch.SetSelection(false)
 		return hj.prober.batch
 	default:
 		panic("hash joiner in unhandled state")

--- a/pkg/sql/exec/limit_test.go
+++ b/pkg/sql/exec/limit_test.go
@@ -56,7 +56,7 @@ func TestLimit(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		runTests(t, []tuples{tc.tuples}, tc.expected, unorderedVerifier, []int{0}, func(input []Operator) (Operator, error) {
+		runTests(t, []tuples{tc.tuples}, tc.expected, orderedVerifier, []int{0}, func(input []Operator) (Operator, error) {
 			return NewLimitOp(input[0], tc.limit), nil
 		})
 	}

--- a/pkg/sql/exec/mergejoiner.go
+++ b/pkg/sql/exec/mergejoiner.go
@@ -661,6 +661,7 @@ func (o *mergeJoinOp) Next(ctx context.Context) coldata.Batch {
 			}
 
 			if o.proberState.inputDone || o.builderState.outCount == o.outputCeil {
+				o.output.SetSelection(false)
 				o.output.SetLength(o.builderState.outCount)
 				// Reset builder out count.
 				o.builderState.outCount = uint16(0)

--- a/pkg/sql/exec/orderedsynchronizer.go
+++ b/pkg/sql/exec/orderedsynchronizer.go
@@ -105,6 +105,7 @@ func (o *OrderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 
 		outputIdx++
 	}
+	o.output.SetSelection(false)
 	o.output.SetLength(outputIdx)
 	return o.output
 }

--- a/pkg/sql/exec/sort.go
+++ b/pkg/sql/exec/sort.go
@@ -253,6 +253,7 @@ func (p *sortOp) Next(ctx context.Context) coldata.Batch {
 		if newEmitted > p.input.getNumTuples() {
 			newEmitted = p.input.getNumTuples()
 		}
+		p.output.SetSelection(false)
 		p.output.SetLength(uint16(newEmitted - p.emitted))
 		if p.output.Length() == 0 {
 			return p.output

--- a/pkg/sql/exec/sort_chunks.go
+++ b/pkg/sql/exec/sort_chunks.go
@@ -174,7 +174,6 @@ type chunker struct {
 	bufferedColumns []coldata.Vec
 
 	readFrom chunkerReadingState
-	output   coldata.Batch
 	state    chunkerState
 }
 
@@ -202,7 +201,6 @@ func newChunker(
 
 func (s *chunker) init() {
 	s.input.Init()
-	s.output = coldata.NewMemBatch(s.inputTypes)
 	s.bufferedColumns = make([]coldata.Vec, len(s.inputTypes))
 	for i := 0; i < len(s.inputTypes); i++ {
 		s.bufferedColumns[i] = coldata.NewMemColumn(s.inputTypes[i], 0)

--- a/pkg/sql/exec/sorttopk.go
+++ b/pkg/sql/exec/sorttopk.go
@@ -192,6 +192,7 @@ func (t *topKSorter) spool(ctx context.Context) {
 }
 
 func (t *topKSorter) emit() coldata.Batch {
+	t.output.SetSelection(false)
 	toEmit := t.topK.Length() - t.emitted
 	if toEmit == 0 {
 		// We're done.

--- a/pkg/sql/exec/utils_test.go
+++ b/pkg/sql/exec/utils_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 )
 
 // tuple represents a row with any-type columns.
@@ -64,10 +65,43 @@ func runTests(
 			t.Fatal(err)
 		}
 	})
+
+	t.Run("verifySelResets", func(t *testing.T) {
+		// Verify that all operators have an unset selection vector even if an
+		// operator later in the chain sets one. This test ensures that operators
+		// that "own their own batches", such as any operator that has to reshape
+		// its output, always reset their selection vectors before returning a fresh
+		// batch.
+		inputSources := make([]Operator, len(tups))
+		for i, tup := range tups {
+			inputSources[i] = newOpTestInput(1 /* batchSize */, tup)
+		}
+		op, err := constructor(inputSources)
+		if err != nil {
+			t.Fatal(err)
+		}
+		op.Init()
+		ctx := context.Background()
+		b := op.Next(ctx)
+		if b.Selection() != nil {
+			// We're testing an operator that needs to set a selection vector for some
+			// reason already, so we can't test the condition we're looking for.
+			return
+		}
+		// Set the selection vector by hand.
+		b.SetSelection(true)
+		b = op.Next(ctx)
+		// Make sure that the next time we call the operator, it has an empty
+		// selection vector.
+		assert.Nil(t, b.Selection())
+	})
 }
 
 // runTestsWithFn is like runTests, but the input function is responsible for
-// performing any required tests.
+// performing any required tests. Please note that runTestsWithFn is a worse
+// testing facility than runTests, because it can't get a handle on the operator
+// under test and therefore can't perform as many extra checks. You should
+// always prefer using runTests over runTestsWithFn.
 // tups is the set of input tuples.
 // test is a function that takes a list of input Operators and performs testing
 // with t.
@@ -187,6 +221,7 @@ func (s *opTestInput) Init() {
 }
 
 func (s *opTestInput) Next(context.Context) coldata.Batch {
+	s.batch.SetSelection(false)
 	if len(s.tuples) == 0 {
 		s.batch.SetLength(0)
 		return s.batch
@@ -229,8 +264,6 @@ func (s *opTestInput) Next(context.Context) coldata.Batch {
 
 		s.batch.SetSelection(true)
 		copy(s.batch.Selection(), s.selection)
-	} else {
-		s.batch.SetSelection(false)
 	}
 
 	for i := range s.typs {


### PR DESCRIPTION
Closes #38526.

Previously, many operators that owned their own batches (ones that
reshape output or maintain internal buffered batches that are later
returned to their output)  were failing to unset the selection vector of
those owned batches. It's not immediately obvious that this is
necessary, but since the batches are reused across multiple invocations
of `Next`, if there's a downstream operator (like a filter) that sets
the selection vector, that selection vector will remain set until
somebody unsets it. This leads to incorrect output in some cases.

This commit corrects the problem, and adds a test case to `runTests`
that ensures that every operator behaves correctly in one fell swoop. I
verified that the tests failed for the operators I changed.

Release note: None