### PR TITLE
release-19.1: storage: remove dependency from replication queue to the split queue

### DIFF
--- a/pkg/base/constants.go
+++ b/pkg/base/constants.go
@@ -37,4 +37,7 @@ const (
 	// ChunkRaftCommandThresholdBytes is the threshold in bytes at which
 	// to chunk or otherwise limit commands being sent to Raft.
 	ChunkRaftCommandThresholdBytes = 256 * 1000
+
+	// MinRangeMaxBytes is the minimum value for range max bytes.
+	MinRangeMaxBytes = 64 << 10 // 64 KB
 )

--- a/pkg/config/zone.go
+++ b/pkg/config/zone.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
@@ -265,9 +266,6 @@ func (c *Constraint) FromString(short string) error {
 	return nil
 }
 
-// minRangeMaxBytes is the minimum value for range max bytes.
-const minRangeMaxBytes = 64 << 10 // 64 KB
-
 // defaultZoneConfig is the default zone configuration used when no custom
 // config has been specified.
 var defaultZoneConfig = &ZoneConfig{
@@ -435,9 +433,9 @@ func (z *ZoneConfig) Validate() error {
 		}
 	}
 
-	if z.RangeMaxBytes != nil && *z.RangeMaxBytes < minRangeMaxBytes {
+	if z.RangeMaxBytes != nil && *z.RangeMaxBytes < base.MinRangeMaxBytes {
 		return fmt.Errorf("RangeMaxBytes %d less than minimum allowed %d",
-			*z.RangeMaxBytes, minRangeMaxBytes)
+			*z.RangeMaxBytes, base.MinRangeMaxBytes)
 	}
 
 	if z.RangeMinBytes != nil && *z.RangeMinBytes < 0 {

--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -355,13 +355,6 @@ func (bq *baseQueue) SetDisabled(disabled bool) {
 	bq.mu.Unlock()
 }
 
-// Disabled returns true is the queue is currently disabled.
-func (bq *baseQueue) Disabled() bool {
-	bq.mu.Lock()
-	defer bq.mu.Unlock()
-	return bq.mu.disabled
-}
-
 // lockProcessing locks all processing in the baseQueue. It returns
 // a function to unlock processing.
 func (bq *baseQueue) lockProcessing() func() {

--- a/pkg/storage/replica_metrics.go
+++ b/pkg/storage/replica_metrics.go
@@ -237,14 +237,6 @@ func (r *Replica) WritesPerSecond() float64 {
 	return wps
 }
 
-// needsSplitBySize returns true if the size of the range requires it
-// to be split.
-func (r *Replica) needsSplitBySize() bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.needsSplitBySizeRLocked()
-}
-
 func (r *Replica) needsSplitBySizeRLocked() bool {
 	return r.exceedsMultipleOfSplitSizeRLocked(1)
 }

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -193,18 +193,6 @@ func newReplicateQueue(store *Store, g *gossip.Gossip, allocator Allocator) *rep
 func (rq *replicateQueue) shouldQueue(
 	ctx context.Context, now hlc.Timestamp, repl *Replica, sysCfg *config.SystemConfig,
 ) (shouldQ bool, priority float64) {
-	if !repl.store.splitQueue.Disabled() && repl.needsSplitBySize() {
-		// If the range exceeds the split threshold, let that finish first.
-		// Ranges must fit in memory on both sender and receiver nodes while
-		// being replicated. This supplements the check provided by
-		// acceptsUnsplitRanges, which looks at zone config boundaries rather
-		// than data size.
-		//
-		// This check is ignored if the split queue is disabled, since in that
-		// case, the split will never come.
-		return
-	}
-
 	// Get the descriptor and zone config for this range.
 	desc, zone := repl.DescAndZone()
 

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -38,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/pkg/errors"
 )
 
@@ -551,8 +551,18 @@ func (tc *TestCluster) findMemberStore(storeID roachpb.StoreID) (*storage.Store,
 
 // WaitForFullReplication waits until all stores in the cluster
 // have no ranges with replication pending.
+//
+// TODO(andrei): This method takes inexplicably long.
+// I think it shouldn't need any retries. See #38565.
 func (tc *TestCluster) WaitForFullReplication() error {
-	if int32(len(tc.Servers)) < *config.DefaultZoneConfig().NumReplicas {
+	start := timeutil.Now()
+	defer func() {
+		end := timeutil.Now()
+		log.Infof(context.TODO(), "WaitForFullReplication took: %s", end.Sub(start))
+	}()
+
+	if len(tc.Servers) < 3 {
+		// If we have less than three nodes, we will never have full replication.
 		return nil
 	}
 
@@ -565,19 +575,17 @@ func (tc *TestCluster) WaitForFullReplication() error {
 	notReplicated := true
 	for r := retry.Start(opts); r.Next() && notReplicated; {
 		notReplicated = false
-		for i, s := range tc.Servers {
+		for _, s := range tc.Servers {
 			err := s.Stores().VisitStores(func(s *storage.Store) error {
 				if n := s.ClusterNodeCount(); n != len(tc.Servers) {
 					log.Infof(context.TODO(), "%s only sees %d/%d available nodes", s, n, len(tc.Servers))
 					notReplicated = true
 					return nil
 				}
-				// Force the first node to upreplicate everything. Otherwise, if we rely
-				// on the scanner to do it, it'll take a while.
-				if i == 0 {
-					if err := s.ForceReplicationScanAndProcess(); err != nil {
-						return err
-					}
+				// Force upreplication. Otherwise, if we rely on the scanner to do it,
+				// it'll take a while.
+				if err := s.ForceReplicationScanAndProcess(); err != nil {
+					return err
 				}
 				if err := s.ComputeMetrics(context.TODO(), 0); err != nil {
 					// This can sometimes fail since ComputeMetrics calls


### PR DESCRIPTION
Backport 1/1 commits from #38529.

/cc @cockroachdb/release

---

Before this patch, the replication queue would refuse to process ranges
that it thought needed splits because of their size. The idea was to let
the split queue process them first. There's no reason for this,
particularly since we've introduced the write-backpressuring mechanism
which keeps ranges from getting too large.
The check had not considered unsplittable ranges (i.e. ranges with only
(versions of) one row or some system ranges). These can't be split but
the replication queue was disconsidering them none the less.

Release note (bug fix): Ranges consisting of only one row (and
historical versions of that row) are now correctly up-replicating.
