### PR TITLE
exec: template out INNER and LEFT OUTER merge joins

### DIFF
--- a/pkg/sql/distsqlrun/columnar_operators_test.go
+++ b/pkg/sql/distsqlrun/columnar_operators_test.go
@@ -130,8 +130,7 @@ func TestMergeJoinerAgainstProcessor(t *testing.T) {
 	}
 	for _, joinType := range []sqlbase.JoinType{
 		sqlbase.JoinType_INNER,
-		// TODO(yuzefovich): uncomment once ordered distinct handles nulls.
-		//sqlbase.JoinType_LEFT_OUTER,
+		sqlbase.JoinType_LEFT_OUTER,
 	} {
 		for nCols := 1; nCols <= maxCols; nCols++ {
 			inputTypes := typs[:nCols]

--- a/pkg/sql/exec/execgen/cmd/execgen/mergejoiner_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/mergejoiner_gen.go
@@ -40,6 +40,12 @@ type selPermutation struct {
 	RSelString string
 }
 
+type joinTypeInfo struct {
+	IsInner     bool
+	IsLeftOuter bool
+	String      string
+}
+
 func genMergeJoinOps(wr io.Writer) error {
 	d, err := ioutil.ReadFile("pkg/sql/exec/mergejoiner_tmpl.go")
 	if err != nil {
@@ -57,15 +63,38 @@ func genMergeJoinOps(wr io.Writer) error {
 	s = strings.Replace(s, "_IS_L_SEL", "{{$sel.IsLSel}}", -1)
 	s = strings.Replace(s, "_IS_R_SEL", "{{$sel.IsRSel}}", -1)
 	s = strings.Replace(s, "_SEL_ARG", "$sel", -1)
+	s = strings.Replace(s, "_JOIN_TYPE_STRING", "{{$joinType.String}}", -1)
+	s = strings.Replace(s, "_JOIN_TYPE", "$joinType", -1)
+	s = strings.Replace(s, "_MJ_OVERLOAD", "$mjOverload", -1)
+	s = strings.Replace(s, "_L_HAS_NULLS", "$.lHasNulls", -1)
+	s = strings.Replace(s, "_R_HAS_NULLS", "$.rHasNulls", -1)
 
-	probeSwitch := makeFunctionRegex("_PROBE_SWITCH", 4)
-	s = probeSwitch.ReplaceAllString(s, `{{template "probeSwitch" buildDict "Global" $ "Sel" $1 "LNull" $2 "RNull" $3 "Asc" $4}}`)
+	leftUnmatchedGroupSwitch := makeFunctionRegex("_LEFT_UNMATCHED_GROUP_SWITCH", 1)
+	s = leftUnmatchedGroupSwitch.ReplaceAllString(s, `{{template "leftUnmatchedGroupSwitch" buildDict "Global" $ "JoinType" $1}}`)
+
+	nullFromLeftSwitch := makeFunctionRegex("_NULL_FROM_LEFT_SWITCH", 1)
+	s = nullFromLeftSwitch.ReplaceAllString(s, `{{template "nullFromLeftSwitch" buildDict "Global" $ "JoinType" $1}}`)
+
+	incrementLeftSwitch := makeFunctionRegex("_INCREMENT_LEFT_SWITCH", 4)
+	s = incrementLeftSwitch.ReplaceAllString(s, `{{template "incrementLeftSwitch" buildDict "Global" $ "JoinType" $1 "Sel" $2 "MJOverload" $3 "lHasNulls" $4}}`)
+
+	processNotLastGroupInColumnSwitch := makeFunctionRegex("_PROCESS_NOT_LAST_GROUP_IN_COLUMN_SWITCH", 1)
+	s = processNotLastGroupInColumnSwitch.ReplaceAllString(s, `{{template "processNotLastGroupInColumnSwitch" buildDict "Global" $ "JoinType" $1}}`)
+
+	probeSwitch := makeFunctionRegex("_PROBE_SWITCH", 5)
+	s = probeSwitch.ReplaceAllString(s, `{{template "probeSwitch" buildDict "Global" $ "JoinType" $1 "Sel" $2 "lHasNulls" $3 "rHasNulls" $4 "Asc" $5}}`)
+
+	sourceFinishedSwitch := makeFunctionRegex("_SOURCE_FINISHED_SWITCH", 1)
+	s = sourceFinishedSwitch.ReplaceAllString(s, `{{template "sourceFinishedSwitch" buildDict "Global" $ "JoinType" $1}}`)
 
 	leftSwitch := makeFunctionRegex("_LEFT_SWITCH", 2)
 	s = leftSwitch.ReplaceAllString(s, `{{template "leftSwitch" buildDict "Global" $ "IsSel" $1 "HasNulls" $2 }}`)
 
 	rightSwitch := makeFunctionRegex("_RIGHT_SWITCH", 2)
 	s = rightSwitch.ReplaceAllString(s, `{{template "rightSwitch" buildDict "Global" $ "IsSel" $1  "HasNulls" $2 }}`)
+
+	nullInBufferedGroupSwitch := makeFunctionRegex("_NULL_IN_BUFFERED_GROUP_SWITCH", 1)
+	s = nullInBufferedGroupSwitch.ReplaceAllString(s, `{{template "nullInBufferedGroupSwitch" buildDict "Global" $ "JoinType" $1}}`)
 
 	assignEqRe := makeFunctionRegex("_ASSIGN_EQ", 3)
 	s = assignEqRe.ReplaceAllString(s, `{{.Eq.Assign $1 $2 $3}}`)
@@ -124,12 +153,25 @@ func genMergeJoinOps(wr io.Writer) error {
 		},
 	}
 
+	joinTypeInfos := []joinTypeInfo{
+		{
+			IsInner: true,
+			String:  "Inner",
+		},
+		{
+			IsLeftOuter: true,
+			String:      "LeftOuter",
+		},
+	}
+
 	return tmpl.Execute(wr, struct {
 		MJOverloads     interface{}
 		SelPermutations interface{}
+		JoinTypes       interface{}
 	}{
 		MJOverloads:     mjOverloads,
 		SelPermutations: selPermutations,
+		JoinTypes:       joinTypeInfos,
 	})
 }
 


### PR DESCRIPTION
This PR templates out the merge joiner so that two different
structs are generated.

I moved almost all of the code into the template, so now two new
generated structs duplicate what used to be `mergeJoinOp`. The
benchmarks show very minor (like 1%) improvement, so I'm not sure
whether it is better to keep the common logic with `mergeJoinOp` as
the receiver of the methods and to make two new structs wrap around
that common struct.

Addresses: #37166.