### PR TITLE
exec: don't panic on unhandled datum conversion

### DIFF
--- a/pkg/sql/exec/types/conv/conv.go
+++ b/pkg/sql/exec/types/conv/conv.go
@@ -163,5 +163,11 @@ func GetDatumToPhysicalFn(ct *semtypes.T) func(tree.Datum) (interface{}, error) 
 			return d.Decimal, nil
 		}
 	}
-	panic(fmt.Sprintf("unhandled type %s", ct.DebugString()))
+	// It would probably be more correct to return an error here, rather than a
+	// function which always returns an error. But since the function tends to be
+	// invoked immediately after GetDatumToPhysicalFn is called, this works just
+	// as well and makes the error handling less messy for the caller.
+	return func(datum tree.Datum) (interface{}, error) {
+		return nil, errors.Errorf("unhandled type %s", ct.DebugString())
+	}
 }

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -382,3 +382,9 @@ NULL
 1
 1.0
 1.00
+
+# Test unhandled type conversion. (Should fall back to distsql.)
+query T
+SELECT ARRAY(SELECT 1) FROM a LIMIT 1
+----
+{1}


### PR DESCRIPTION
Previously GetDatumToPhysicalFn panicked if it encountered an unhandled
Datum type. This could cause server panics during vectorized planning. I
changed it to return an error instead so that the planner can gracefully
fall back in these scenarios.

Release note: None