### PR TITLE
exec: Add support for projection of the IN operator

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -670,7 +670,17 @@ func planProjectionExpr(
 		// The projection result will be outputted to a new column which is appended
 		// to the input batch.
 		resultIdx = len(ct)
-		op, err = exec.GetProjectionRConstOperator(typ, binOp, leftOp, leftIdx, rConstArg, resultIdx)
+		if binOp == tree.In || binOp == tree.NotIn {
+			negate := binOp == tree.NotIn
+			datumTuple, ok := tree.AsDTuple(rConstArg)
+			if !ok {
+				err = errors.Errorf("IN operator supported only on constant expressions")
+				return nil, resultIdx, ct, err
+			}
+			op, err = exec.GetInProjectionOperator(typ, leftOp, leftIdx, resultIdx, datumTuple, negate)
+		} else {
+			op, err = exec.GetProjectionRConstOperator(typ, binOp, leftOp, leftIdx, rConstArg, resultIdx)
+		}
 		ct = append(ct, *typ)
 		return op, resultIdx, ct, err
 	}

--- a/pkg/sql/exec/select_in_test.go
+++ b/pkg/sql/exec/select_in_test.go
@@ -136,3 +136,80 @@ func BenchmarkSelectInInt64(b *testing.B) {
 		}
 	}
 }
+
+func TestProjectInInt64(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		inputTuples  tuples
+		outputTuples tuples
+		filterRow    []int64
+		hasNulls     bool
+		negate       bool
+	}{
+		{
+			desc:         "Simple in test",
+			inputTuples:  tuples{{0}, {1}},
+			outputTuples: tuples{{true}, {true}},
+			filterRow:    []int64{0, 1},
+			hasNulls:     false,
+			negate:       false,
+		},
+		{
+			desc:         "Simple not in test",
+			inputTuples:  tuples{{2}},
+			outputTuples: tuples{{true}},
+			filterRow:    []int64{0, 1},
+			hasNulls:     false,
+			negate:       true,
+		},
+		{
+			desc:         "In test with NULLs",
+			inputTuples:  tuples{{1}, {2}, {nil}},
+			outputTuples: tuples{{true}, {nil}, {nil}},
+			filterRow:    []int64{1},
+			hasNulls:     true,
+			negate:       false,
+		},
+		{
+			desc:         "Not in test with NULLs",
+			inputTuples:  tuples{{1}, {2}, {nil}},
+			outputTuples: tuples{{false}, {nil}, {nil}},
+			filterRow:    []int64{1},
+			hasNulls:     true,
+			negate:       true,
+		},
+		{
+			desc:         "Not in test with NULLs and no nulls in filter",
+			inputTuples:  tuples{{1}, {2}, {nil}},
+			outputTuples: tuples{{false}, {true}, {nil}},
+			filterRow:    []int64{1},
+			hasNulls:     false,
+			negate:       true,
+		},
+		{
+			desc:         "Test with false values",
+			inputTuples:  tuples{{1}, {2}},
+			outputTuples: tuples{{false}, {false}},
+			filterRow:    []int64{3},
+			hasNulls:     false,
+			negate:       false,
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.desc, func(t *testing.T) {
+			runTests(t, []tuples{c.inputTuples}, c.outputTuples, orderedVerifier, []int{1},
+				func(input []Operator) (Operator, error) {
+					op := projectInOpInt64{
+						input:     input[0],
+						colIdx:    0,
+						outputIdx: 1,
+						filterRow: c.filterRow,
+						negate:    c.negate,
+						hasNulls:  c.hasNulls,
+					}
+					return &op, nil
+				})
+		})
+	}
+}

--- a/pkg/sql/exec/select_in_tmpl.go
+++ b/pkg/sql/exec/select_in_tmpl.go
@@ -61,6 +61,30 @@ const (
 	siNull
 )
 
+func GetInProjectionOperator(
+	ct *semtypes.T, input Operator, colIdx int, resultIdx int, datumTuple *tree.DTuple, negate bool,
+) (Operator, error) {
+	var err error
+	switch t := conv.FromColumnType(ct); t {
+	// {{range .}}
+	case types._TYPE:
+		obj := &projectInOp_TYPE{
+			input:     input,
+			colIdx:    colIdx,
+			outputIdx: resultIdx,
+			negate:    negate,
+		}
+		obj.filterRow, obj.hasNulls, err = fillDatumRow_TYPE(ct, datumTuple)
+		if err != nil {
+			return nil, err
+		}
+		return obj, nil
+	// {{end}}
+	default:
+		return nil, errors.Errorf("unhandled type: %s", t)
+	}
+}
+
 func GetInOperator(
 	ct *semtypes.T, input Operator, colIdx int, datumTuple *tree.DTuple, negate bool,
 ) (Operator, error) {
@@ -94,6 +118,15 @@ type selectInOp_TYPE struct {
 	negate    bool
 }
 
+type projectInOp_TYPE struct {
+	input     Operator
+	colIdx    int
+	outputIdx int
+	filterRow []_GOTYPE
+	hasNulls  bool
+	negate    bool
+}
+
 func fillDatumRow_TYPE(ct *semtypes.T, datumTuple *tree.DTuple) ([]_GOTYPE, bool, error) {
 	conv := conv.GetDatumToPhysicalFn(ct)
 	var result []_GOTYPE
@@ -113,15 +146,15 @@ func fillDatumRow_TYPE(ct *semtypes.T, datumTuple *tree.DTuple) ([]_GOTYPE, bool
 	return result, hasNulls, nil
 }
 
-func (si *selectInOp_TYPE) cmpIn_TYPE(target _GOTYPE) comparisonResult {
-	for i := range si.filterRow {
+func cmpIn_TYPE(target _GOTYPE, filterRow []_GOTYPE, hasNulls bool) comparisonResult {
+	for i := range filterRow {
 		var cmp bool
-		_ASSIGN_EQ(cmp, target, si.filterRow[i])
+		_ASSIGN_EQ(cmp, target, filterRow[i])
 		if cmp {
 			return siTrue
 		}
 	}
-	if si.hasNulls {
+	if hasNulls {
 		return siNull
 	} else {
 		return siFalse
@@ -130,6 +163,10 @@ func (si *selectInOp_TYPE) cmpIn_TYPE(target _GOTYPE) comparisonResult {
 
 func (si *selectInOp_TYPE) Init() {
 	si.input.Init()
+}
+
+func (pi *projectInOp_TYPE) Init() {
+	pi.input.Init()
 }
 
 func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
@@ -154,7 +191,7 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !nulls.NullAt(uint16(i)) && si.cmpIn_TYPE(col[i]) == compVal {
+					if !nulls.NullAt(uint16(i)) && cmpIn_TYPE(col[i], si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = uint16(i)
 						idx++
 					}
@@ -164,7 +201,7 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 				sel := batch.Selection()
 				col = col[:n]
 				for i := range col {
-					if !nulls.NullAt(uint16(i)) && si.cmpIn_TYPE(col[i]) == compVal {
+					if !nulls.NullAt(uint16(i)) && cmpIn_TYPE(col[i], si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = uint16(i)
 						idx++
 					}
@@ -174,7 +211,7 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if si.cmpIn_TYPE(col[i]) == compVal {
+					if cmpIn_TYPE(col[i], si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = uint16(i)
 						idx++
 					}
@@ -184,7 +221,7 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 				sel := batch.Selection()
 				col = col[:n]
 				for i := range col {
-					if si.cmpIn_TYPE(col[i]) == compVal {
+					if cmpIn_TYPE(col[i], si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = uint16(i)
 						idx++
 					}
@@ -197,6 +234,87 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
+}
+
+func (pi *projectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
+	batch := pi.input.Next(ctx)
+	if batch.Length() == 0 {
+		return batch
+	}
+
+	if pi.outputIdx == batch.Width() {
+		batch.AppendCol(types.Bool)
+	}
+
+	vec := batch.ColVec(pi.colIdx)
+	col := vec._TemplateType()[:coldata.BatchSize]
+
+	projVec := batch.ColVec(pi.outputIdx)
+	projCol := projVec.Bool()[:coldata.BatchSize]
+	projNulls := projVec.Nulls()
+
+	n := batch.Length()
+
+	cmpVal := siTrue
+	if pi.negate {
+		cmpVal = siFalse
+	}
+
+	if vec.HasNulls() {
+		nulls := vec.Nulls()
+		if sel := batch.Selection(); sel != nil {
+			sel = sel[:n]
+			for _, i := range sel {
+				if nulls.NullAt(uint16(i)) {
+					projNulls.SetNull(uint16(i))
+				} else {
+					cmpRes := cmpIn_TYPE(col[i], pi.filterRow, pi.hasNulls)
+					if cmpRes == siNull {
+						projNulls.SetNull(uint16(i))
+					} else {
+						projCol[i] = cmpRes == cmpVal
+					}
+				}
+			}
+		} else {
+			col = col[:n]
+			for i := range col {
+				if nulls.NullAt(uint16(i)) {
+					projNulls.SetNull(uint16(i))
+				} else {
+					cmpRes := cmpIn_TYPE(col[i], pi.filterRow, pi.hasNulls)
+					if cmpRes == siNull {
+						projNulls.SetNull(uint16(i))
+					} else {
+						projCol[i] = cmpRes == cmpVal
+					}
+				}
+			}
+		}
+	} else {
+		if sel := batch.Selection(); sel != nil {
+			sel = sel[:n]
+			for _, i := range sel {
+				cmpRes := cmpIn_TYPE(col[i], pi.filterRow, pi.hasNulls)
+				if cmpRes == siNull {
+					projNulls.SetNull(uint16(i))
+				} else {
+					projCol[i] = cmpRes == cmpVal
+				}
+			}
+		} else {
+			col = col[:n]
+			for i := range col {
+				cmpRes := cmpIn_TYPE(col[i], pi.filterRow, pi.hasNulls)
+				if cmpRes == siNull {
+					projNulls.SetNull(uint16(i))
+				} else {
+					projCol[i] = cmpRes == cmpVal
+				}
+			}
+		}
+	}
+	return batch
 }
 
 // {{end}}


### PR DESCRIPTION
vectorized execution now supports statements of the form

```
select x, x IN (1,2,3) from t;
```