### PR TITLE
distsqlrun: bump index joiner batch size from 100 to 10k

### DIFF
--- a/pkg/sql/distsqlrun/indexjoiner.go
+++ b/pkg/sql/distsqlrun/indexjoiner.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-const indexJoinerBatchSize = 100
+const indexJoinerBatchSize = 10000
 
 // indexJoiner performs a join between a secondary index, the `input`, and the
 // primary index of the same table, `desc`, to retrieve columns which are not


### PR DESCRIPTION
To amortize the cost of looking up rows, we create a batch of 100 rows
to use in one lookup request. Since the relationship is 1:1 in the index
joiner (we're doing a lookup on the primary index), the result size is
the same size as the request batch.

This commit increases the size of this batch to 10k, increasing the
result size for each lookup to 10k. This results in some significant
performance gains: e.g. tpch query 6 drops to a fifth of its original
runtime on a scalefactor 10 dataset due to amortizing lookups. Note that
this comes with increased memory usage per request. However, the
tableReader limits results for its scans to 10k as well, and there is no
good reason to allow normal scans to use more memory than index joiner
lookups. In the absence of proper accounting for KV responses, the
strategy of allowing index lookups to use the same resources and have
the same limitations as normal scans makes sense.

Release note: None