### PR TITLE
exec: fix an error with vectorized testing infrastructure

### DIFF
--- a/pkg/sql/distsqlrun/columnar_utils_test.go
+++ b/pkg/sql/distsqlrun/columnar_utils_test.go
@@ -134,8 +134,8 @@ func verifyColOperator(
 		if anyOrder {
 			// We accumulate all the rows to be matched using set comparison when
 			// both "producers" are done.
-			procRows = append(procRows, rowProc)
-			colOpRows = append(colOpRows, rowColOp)
+			procRows = append(procRows, rowProc.Copy())
+			colOpRows = append(colOpRows, rowColOp.Copy())
 		} else {
 			// anyOrder is false, so the result rows must match in the same order.
 			expStr := rowProc.String(outputTypes)


### PR DESCRIPTION
Previously, when the output of an operator was compared against
the output of a processor as set comparison (i.e. with any order
of rows), we would accumulate the rows "as is" - without deep copy.
But because the underlying memory is almost certain to be reused,
we need to accumulate the copies of the output rows. Now this is
fixed.

Release note: None