### PR TITLE
sql: fix upsert in the presence of column mutations

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1912,8 +1912,9 @@ func (dsp *DistSQLPlanner) createPlanForLookupJoin(
 	}
 
 	joinReaderSpec := distsqlpb.JoinReaderSpec{
-		Table: *n.table.desc.TableDesc(),
-		Type:  n.joinType,
+		Table:      *n.table.desc.TableDesc(),
+		Type:       n.joinType,
+		Visibility: n.table.colCfg.visibility.toDistSQLScanVisibility(),
 	}
 	joinReaderSpec.IndexIdx, err = getIndexIdx(n.table)
 	if err != nil {

--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -125,10 +125,6 @@ func newJoinReader(
 	post *distsqlpb.PostProcessSpec,
 	output RowReceiver,
 ) (*joinReader, error) {
-	if spec.Visibility != distsqlpb.ScanVisibility_PUBLIC {
-		return nil, errors.AssertionFailedf("joinReader specified with visibility %+v", spec.Visibility)
-	}
-
 	jr := &joinReader{
 		desc:                 spec.Table,
 		input:                input,
@@ -144,13 +140,14 @@ func newJoinReader(
 	if err != nil {
 		return nil, err
 	}
-	jr.colIdxMap = jr.desc.ColumnIdxMap()
+	returnMutations := spec.Visibility == distsqlpb.ScanVisibility_PUBLIC_AND_NOT_PUBLIC
+	jr.colIdxMap = jr.desc.ColumnIdxMapWithMutations(returnMutations)
 
 	var columnIDs []sqlbase.ColumnID
 	columnIDs, jr.indexDirs = jr.index.FullColumnIDs()
 	indexCols := make([]uint32, len(columnIDs))
 	jr.indexTypes = make([]types.T, len(columnIDs))
-	columnTypes := jr.desc.ColumnTypesWithMutations(true)
+	columnTypes := jr.desc.ColumnTypesWithMutations(returnMutations)
 	for i, columnID := range columnIDs {
 		indexCols[i] = uint32(columnID)
 		jr.indexTypes[i] = columnTypes[jr.colIdxMap[columnID]]
@@ -188,15 +185,15 @@ func newJoinReader(
 		collectingStats = true
 	}
 
-	if isSecondary && !jr.neededRightCols().SubsetOf(getIndexColSet(jr.index, jr.colIdxMap)) {
+	neededRightCols := jr.neededRightCols()
+	if isSecondary && !neededRightCols.SubsetOf(getIndexColSet(jr.index, jr.colIdxMap)) {
 		return nil, errors.Errorf("joinreader index does not cover all columns")
 	}
 
 	var fetcher row.Fetcher
 	_, _, err = initRowFetcher(
 		&fetcher, &jr.desc, int(spec.IndexIdx), jr.colIdxMap, false, /* reverse */
-		jr.neededRightCols(), false /* isCheck */, &jr.alloc,
-		distsqlpb.ScanVisibility_PUBLIC,
+		neededRightCols, false /* isCheck */, &jr.alloc, spec.Visibility,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -959,3 +959,30 @@ DO UPDATE SET c = table35970.a+1
 RETURNING b
 ----
 NULL
+
+# ------------------------------------------------------------------------------
+# Regression for #38627: make sure that UPSERTs in the presence of column
+# mutations don't cause problems.
+# ------------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE table38627 (a INT PRIMARY KEY, b INT); INSERT INTO table38627 VALUES(1,1)
+
+statement ok
+BEGIN; ALTER TABLE table38627 ADD COLUMN c INT NOT NULL DEFAULT 5
+
+statement ok
+UPSERT INTO table38627 SELECT * FROM table38627 WHERE a=1
+
+query II
+SELECT * from table38627
+----
+1  1
+
+statement ok
+COMMIT
+
+query III
+SELECT * from table38627
+----
+1  1  5

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -378,3 +378,42 @@ INSERT INTO t35364 (x) VALUES (1.5) ON CONFLICT (x) DO UPDATE SET x=2.5 RETURNIN
 
 statement error pq: failed to satisfy CHECK constraint \(z >= 7\)
 UPSERT INTO t35364 (x) VALUES (0)
+
+# ------------------------------------------------------------------------------
+# Regression for #38627. Combined with the equivalent logic test, make sure that
+# UPSERT in the presence of column mutations uses a lookup join without a
+# problem.
+# ------------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE table38627 (a INT PRIMARY KEY, b INT); INSERT INTO table38627 VALUES(1,1)
+
+statement ok
+BEGIN; ALTER TABLE table38627 ADD COLUMN c INT NOT NULL DEFAULT 5
+
+query TTTTT
+EXPLAIN (VERBOSE) UPSERT INTO table38627 SELECT * FROM table38627 WHERE a=1
+----
+count                       ·                      ·                   ()                     ·
+ └── upsert                 ·                      ·                   ()                     ·
+      │                     into                   table38627(a, b)    ·                      ·
+      │                     strategy               opt upserter        ·                      ·
+      └── render            ·                      ·                   (a, b, a, b, c, b, a)  ·
+           │                render 0               a                   ·                      ·
+           │                render 1               b                   ·                      ·
+           │                render 2               a                   ·                      ·
+           │                render 3               b                   ·                      ·
+           │                render 4               c                   ·                      ·
+           │                render 5               b                   ·                      ·
+           │                render 6               a                   ·                      ·
+           └── lookup-join  ·                      ·                   (a, b, a, b, c)        ·
+                │           table                  table38627@primary  ·                      ·
+                │           type                   inner               ·                      ·
+                │           equality               (a) = (a)           ·                      ·
+                │           equality cols are key  ·                   ·                      ·
+                └── scan    ·                      ·                   (a, b)                 ·
+·                           table                  table38627@primary  ·                      ·
+·                           spans                  /1-/1/#             ·                      ·
+
+statement ok
+COMMIT


### PR DESCRIPTION
Fixes #38627.

Previously, UPSERT behaved incorrectly and could cause crashes when
planned with lookup join during a column mutation event.

Now, lookup joins are planned with an explicit visibility flag, which
prevents this issue.

Release note (bug fix): Fix issue where CBO-planned upserts that used
lookup join that were run during column mutations on the table being
upserted into could cause crashes or other issues.