### PR TITLE
opt: remove unnecessary tree traversals when planning LIMIT and OFFSET

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -229,10 +229,12 @@ SELECT count(DISTINCT w) FROM kv GROUP BY 1
 query error aggregate functions are not allowed in RETURNING
 INSERT INTO kv (k, v) VALUES (99, 100) RETURNING sum(v)
 
-query error aggregate functions are not allowed in LIMIT
+# The HP and CBO have different errors.
+query error (aggregate functions are not allowed in LIMIT|column "v" does not exist)
 SELECT sum(v) FROM kv GROUP BY k LIMIT sum(v)
 
-query error aggregate functions are not allowed in OFFSET
+# The HP and CBO have different errors.
+query error (aggregate functions are not allowed in OFFSET|column "v" does not exist)
 SELECT sum(v) FROM kv GROUP BY k LIMIT 1 OFFSET sum(v)
 
 query error aggregate functions are not allowed in VALUES

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -33,10 +33,12 @@ SELECT count(w) OVER () FROM kv GROUP BY 1
 query error window functions are not allowed in RETURNING
 INSERT INTO kv (k, v) VALUES (99, 100) RETURNING sum(v) OVER ()
 
-query error window functions are not allowed in LIMIT
+# The HP and CBO have different errors.
+query error (window functions are not allowed in LIMIT|column "v" does not exist)
 SELECT sum(v) FROM kv GROUP BY k LIMIT sum(v) OVER ()
 
-query error window functions are not allowed in OFFSET
+# The HP and CBO have different errors.
+query error (window functions are not allowed in OFFSET|column "v" does not exist)
 SELECT sum(v) FROM kv GROUP BY k LIMIT 1 OFFSET sum(v) OVER ()
 
 query error window functions are not allowed in VALUES

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/exprgen"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
@@ -87,12 +86,11 @@ type Builder struct {
 	factory *norm.Factory
 	stmt    tree.Statement
 
-	ctx              context.Context
-	semaCtx          *tree.SemaContext
-	evalCtx          *tree.EvalContext
-	catalog          cat.Catalog
-	exprTransformCtx transform.ExprTransformContext
-	scopeAlloc       []scope
+	ctx        context.Context
+	semaCtx    *tree.SemaContext
+	evalCtx    *tree.EvalContext
+	catalog    cat.Catalog
+	scopeAlloc []scope
 
 	// If set, the planner will skip checking for the SELECT privilege when
 	// resolving data sources (tables, views, etc). This is used when compiling

--- a/pkg/sql/opt/optbuilder/limit.go
+++ b/pkg/sql/opt/optbuilder/limit.go
@@ -25,7 +25,6 @@ import (
 func (b *Builder) buildLimit(limit *tree.Limit, parentScope, inScope *scope) {
 	if limit.Offset != nil {
 		input := inScope.expr.(memo.RelExpr)
-		b.assertNoAggregationOrWindowing(limit.Offset, "OFFSET")
 		offset := b.resolveAndBuildScalar(
 			limit.Offset, types.Int, "OFFSET", tree.RejectSpecial, parentScope,
 		)
@@ -33,7 +32,6 @@ func (b *Builder) buildLimit(limit *tree.Limit, parentScope, inScope *scope) {
 	}
 	if limit.Count != nil {
 		input := inScope.expr.(memo.RelExpr)
-		b.assertNoAggregationOrWindowing(limit.Count, "LIMIT")
 		limit := b.resolveAndBuildScalar(
 			limit.Count, types.Int, "LIMIT", tree.RejectSpecial, parentScope,
 		)

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -316,12 +316,12 @@ error (42803): count(): aggregate functions are not allowed in GROUP BY
 build
 SELECT sum(v) FROM kv GROUP BY k LIMIT sum(v)
 ----
-error (42803): aggregate functions are not allowed in LIMIT
+error (42703): column "v" does not exist
 
 build
 SELECT sum(v) FROM kv GROUP BY k LIMIT 1 OFFSET sum(v)
 ----
-error (42803): aggregate functions are not allowed in OFFSET
+error (42703): column "v" does not exist
 
 build
 VALUES (99, count(1))

--- a/pkg/sql/opt/optbuilder/testdata/limit
+++ b/pkg/sql/opt/optbuilder/testdata/limit
@@ -311,3 +311,33 @@ build
 SELECT * FROM t OFFSET @1
 ----
 error (42703): column reference @1 not allowed in this context
+
+build
+SELECT * FROM t LIMIT count(*)
+----
+error (42803): count_rows(): aggregate functions are not allowed in LIMIT
+
+build
+SELECT * FROM t OFFSET count(*)
+----
+error (42803): count_rows(): aggregate functions are not allowed in OFFSET
+
+build
+SELECT * FROM t LIMIT count(w)
+----
+error (42703): column "w" does not exist
+
+build
+SELECT * FROM t OFFSET count(w)
+----
+error (42703): column "w" does not exist
+
+build
+SELECT sum(v) FROM t GROUP BY k LIMIT count(*) OVER ()
+----
+error (42P20): count_rows(): window functions are not allowed in LIMIT
+
+build
+SELECT sum(v) FROM t GROUP BY k OFFSET count(*) OVER ()
+----
+error (42P20): count_rows(): window functions are not allowed in OFFSET

--- a/pkg/sql/opt/optbuilder/testdata/window
+++ b/pkg/sql/opt/optbuilder/testdata/window
@@ -48,12 +48,12 @@ error (42P20): sum(): window functions are not allowed in RETURNING
 build
 SELECT sum(v) FROM kv GROUP BY k LIMIT sum(v) OVER ()
 ----
-error (42P20): window functions are not allowed in LIMIT
+error (42703): column "v" does not exist
 
 build
 SELECT sum(v) FROM kv GROUP BY k LIMIT 1 OFFSET sum(v) OVER ()
 ----
-error (42P20): window functions are not allowed in OFFSET
+error (42703): column "v" does not exist
 
 build
 INSERT INTO kv (k, v) VALUES (99, count(1) OVER ())

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -392,20 +392,7 @@ func colsToColList(cols []scopeColumn) opt.ColList {
 	return colList
 }
 
-func (b *Builder) assertNoAggregationOrWindowing(expr tree.Expr, op string) {
-	if b.exprTransformCtx.AggregateInExpr(expr, b.semaCtx.SearchPath) {
-		panic(builderError{
-			pgerror.Newf(pgcode.Grouping, "aggregate functions are not allowed in %s", op),
-		})
-	}
-	if b.exprTransformCtx.WindowFuncInExpr(expr) {
-		panic(builderError{
-			pgerror.Newf(pgcode.Windowing, "window functions are not allowed in %s", op),
-		})
-	}
-}
-
-// resooveAndBuildScalar is used to build a scalar with a required type.
+// resolveAndBuildScalar is used to build a scalar with a required type.
 func (b *Builder) resolveAndBuildScalar(
 	expr tree.Expr, requiredType *types.T, context string, flags tree.SemaRejectFlags, inScope *scope,
 ) opt.ScalarExpr {


### PR DESCRIPTION
This commit removes the unnecessary tree traversals to check for aggregates
and window functions when planning `LIMIT` and `OFFSET`, instead relying on the
new(ish) method to require certain properties during `TypeCheck`. As a result
of this change, the error message changes for aggregate and window functions
containing variable expressions.

Closes #26353

Release note: None