### PR TITLE
roachtest: don't post issues from the unit tests

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -548,7 +548,8 @@ func (r *testRunner) runTest(
 			}
 
 			shout(ctx, l, stdout, "--- FAIL: %s %s\n%s", t.Name(), durationStr, output)
-			if issues.CanPost() && t.spec.Run != nil {
+			// NB: check NodeCount > 0 to avoid posting issues from this pkg's unit tests.
+			if issues.CanPost() && t.spec.Run != nil && t.spec.Cluster.NodeCount > 0 {
 				authorEmail := getAuthorEmail(failLoc.file, failLoc.line)
 				branch := "<unknown branch>"
 				if b := os.Getenv("TC_BUILD_BRANCH"); b != "" {


### PR DESCRIPTION
The pkg/cmd/roachtest unit tests exercise the test runner on clusters
with zero nodes. The recent roachtest rewrite accidentally enabled the
issue posting code when these unit tests would simulate failed
roachtests. As a result, when this was run under nightly stress, we
ended up with hundreds of comments posted on issues.

The unit tests are careful to never create actual nodes, so special
case zero-node clusters and don't post issues for them.

Touches #38501.

Release note: None