### PR TITLE
opt: support ALTER TABLE UNSPLIT and EXPERIMENTAL_RELOCATE

### DIFF
--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -295,3 +295,13 @@ func (f *stubFactory) ConstructAlterTableSplit(
 ) (exec.Node, error) {
 	return struct{}{}, nil
 }
+
+func (f *stubFactory) ConstructAlterTableUnsplit(
+	index cat.Index, input exec.Node,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructAlterTableUnsplitAll(index cat.Index) (exec.Node, error) {
+	return struct{}{}, nil
+}

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -305,3 +305,9 @@ func (f *stubFactory) ConstructAlterTableUnsplit(
 func (f *stubFactory) ConstructAlterTableUnsplitAll(index cat.Index) (exec.Node, error) {
 	return struct{}{}, nil
 }
+
+func (f *stubFactory) ConstructAlterTableRelocate(
+	index cat.Index, input exec.Node, relocateLease bool,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -253,6 +253,9 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 	case *memo.AlterTableUnsplitAllExpr:
 		ep, err = b.buildAlterTableUnsplitAll(t)
 
+	case *memo.AlterTableRelocateExpr:
+		ep, err = b.buildAlterTableRelocate(t)
+
 	default:
 		if opt.IsSetOp(e) {
 			ep, err = b.buildSetOp(e)

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -247,6 +247,12 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 	case *memo.AlterTableSplitExpr:
 		ep, err = b.buildAlterTableSplit(t)
 
+	case *memo.AlterTableUnsplitExpr:
+		ep, err = b.buildAlterTableUnsplit(t)
+
+	case *memo.AlterTableUnsplitAllExpr:
+		ep, err = b.buildAlterTableUnsplitAll(t)
+
 	default:
 		if opt.IsSetOp(e) {
 			ep, err = b.buildSetOp(e)

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -176,3 +176,24 @@ func (b *Builder) buildAlterTableUnsplitAll(
 	}
 	return ep, nil
 }
+
+func (b *Builder) buildAlterTableRelocate(relocate *memo.AlterTableRelocateExpr) (execPlan, error) {
+	input, err := b.buildRelational(relocate.Input)
+	if err != nil {
+		return execPlan{}, err
+	}
+	table := b.mem.Metadata().Table(relocate.Table)
+	node, err := b.factory.ConstructAlterTableRelocate(
+		table.Index(relocate.Index),
+		input.root,
+		relocate.RelocateLease,
+	)
+	if err != nil {
+		return execPlan{}, err
+	}
+	ep := execPlan{root: node}
+	for i, c := range relocate.Columns {
+		ep.outputCols.Set(int(c), i)
+	}
+	return ep, nil
+}

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -141,3 +141,38 @@ func (b *Builder) buildAlterTableSplit(split *memo.AlterTableSplitExpr) (execPla
 	}
 	return ep, nil
 }
+
+func (b *Builder) buildAlterTableUnsplit(unsplit *memo.AlterTableUnsplitExpr) (execPlan, error) {
+	input, err := b.buildRelational(unsplit.Input)
+	if err != nil {
+		return execPlan{}, err
+	}
+	table := b.mem.Metadata().Table(unsplit.Table)
+	node, err := b.factory.ConstructAlterTableUnsplit(
+		table.Index(unsplit.Index),
+		input.root,
+	)
+	if err != nil {
+		return execPlan{}, err
+	}
+	ep := execPlan{root: node}
+	for i, c := range unsplit.Columns {
+		ep.outputCols.Set(int(c), i)
+	}
+	return ep, nil
+}
+
+func (b *Builder) buildAlterTableUnsplitAll(
+	unsplitAll *memo.AlterTableUnsplitAllExpr,
+) (execPlan, error) {
+	table := b.mem.Metadata().Table(unsplitAll.Table)
+	node, err := b.factory.ConstructAlterTableUnsplitAll(table.Index(unsplitAll.Index))
+	if err != nil {
+		return execPlan{}, err
+	}
+	ep := execPlan{root: node}
+	for i, c := range unsplitAll.Columns {
+		ep.outputCols.Set(int(c), i)
+	}
+	return ep, nil
+}

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -416,6 +416,10 @@ type Factory interface {
 	// ConstructAlterTableUnsplitAll creates a node that implements ALTER TABLE/INDEX
 	// UNSPLIT ALL.
 	ConstructAlterTableUnsplitAll(index cat.Index) (Node, error)
+
+	// ConstructAlterTableRelocate creates a node that implements ALTER TABLE/INDEX
+	// UNSPLIT AT.
+	ConstructAlterTableRelocate(index cat.Index, input Node, relocateLease bool) (Node, error)
 }
 
 // OutputOrdering indicates the required output ordering on a Node that is being

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -408,6 +408,14 @@ type Factory interface {
 	// ConstructAlterTableSplit creates a node that implements ALTER TABLE/INDEX
 	// SPLIT AT.
 	ConstructAlterTableSplit(index cat.Index, input Node, expiration tree.TypedExpr) (Node, error)
+
+	// ConstructAlterTableUnsplit creates a node that implements ALTER TABLE/INDEX
+	// UNSPLIT AT.
+	ConstructAlterTableUnsplit(index cat.Index, input Node) (Node, error)
+
+	// ConstructAlterTableUnsplitAll creates a node that implements ALTER TABLE/INDEX
+	// UNSPLIT ALL.
+	ConstructAlterTableUnsplitAll(index cat.Index) (Node, error)
 }
 
 // OutputOrdering indicates the required output ordering on a Node that is being

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -187,7 +187,8 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 
 	case *ScanExpr, *VirtualScanExpr, *IndexJoinExpr, *ShowTraceForSessionExpr,
 		*InsertExpr, *UpdateExpr, *UpsertExpr, *DeleteExpr, *SequenceSelectExpr,
-		*WindowExpr, *OpaqueRelExpr:
+		*WindowExpr, *OpaqueRelExpr, *AlterTableSplitExpr, *AlterTableUnsplitExpr,
+		*AlterTableUnsplitAllExpr, *AlterTableRelocateExpr:
 		fmt.Fprintf(f.Buffer, "%v", e.Op())
 		FormatPrivate(f, e.Private(), required)
 
@@ -979,6 +980,12 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 			fmt.Fprintf(f.Buffer, " %s", tableAlias(f, t.Table))
 		} else {
 			fmt.Fprintf(f.Buffer, " %s@%s", tableAlias(f, t.Table), tab.Index(t.Index).Name())
+		}
+
+	case *AlterTableRelocatePrivate:
+		FormatPrivate(f, &t.AlterTableSplitPrivate, nil)
+		if t.RelocateLease {
+			f.Buffer.WriteString(" [lease]")
 		}
 
 	case *JoinPrivate:

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -739,6 +739,22 @@ func (b *logicalPropsBuilder) buildAlterTableSplitProps(
 	rel.CanMutate = true
 }
 
+func (b *logicalPropsBuilder) buildAlterTableUnsplitProps(
+	unsplit *AlterTableUnsplitExpr, rel *props.Relational,
+) {
+	b.buildBasicProps(unsplit, unsplit.Columns, rel)
+	rel.CanHaveSideEffects = true
+	rel.CanMutate = true
+}
+
+func (b *logicalPropsBuilder) buildAlterTableUnsplitAllProps(
+	unsplitAll *AlterTableUnsplitAllExpr, rel *props.Relational,
+) {
+	b.buildBasicProps(unsplitAll, unsplitAll.Columns, rel)
+	rel.CanHaveSideEffects = true
+	rel.CanMutate = true
+}
+
 func (b *logicalPropsBuilder) buildLimitProps(limit *LimitExpr, rel *props.Relational) {
 	BuildSharedProps(b.mem, limit, &rel.Shared)
 

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -755,6 +755,14 @@ func (b *logicalPropsBuilder) buildAlterTableUnsplitAllProps(
 	rel.CanMutate = true
 }
 
+func (b *logicalPropsBuilder) buildAlterTableRelocateProps(
+	relocate *AlterTableRelocateExpr, rel *props.Relational,
+) {
+	b.buildBasicProps(relocate, relocate.Columns, rel)
+	rel.CanHaveSideEffects = true
+	rel.CanMutate = true
+}
+
 func (b *logicalPropsBuilder) buildLimitProps(limit *LimitExpr, rel *props.Relational) {
 	BuildSharedProps(b.mem, limit, &rel.Shared)
 

--- a/pkg/sql/opt/ops/statement.opt
+++ b/pkg/sql/opt/ops/statement.opt
@@ -123,3 +123,18 @@ define AlterTableSplitPrivate {
     # Columns stores the column IDs for the statement result columns.
     Columns ColList
 }
+
+# AlterTableUnsplit represents an `ALTER TABLE/INDEX .. UNSPLIT AT ..`
+# statement.
+[Relational, DDL]
+define AlterTableUnsplit {
+    Input RelExpr
+
+    _ AlterTableSplitPrivate
+}
+
+# AlterTableUnsplit represents an `ALTER TABLE/INDEX .. UNSPLIT ALL` statement.
+[Relational, DDL]
+define AlterTableUnsplitAll {
+    _ AlterTableSplitPrivate
+}

--- a/pkg/sql/opt/ops/statement.opt
+++ b/pkg/sql/opt/ops/statement.opt
@@ -138,3 +138,20 @@ define AlterTableUnsplit {
 define AlterTableUnsplitAll {
     _ AlterTableSplitPrivate
 }
+
+# AlterTableRelocate represents an `ALTER TABLE/INDEX .. SPLIT AT ..` statement.
+[Relational, DDL]
+define AlterTableRelocate {
+    # The input expression provides values for the index columns (or a prefix of
+    # them).
+    Input RelExpr
+
+    _ AlterTableRelocatePrivate
+}
+
+[Private]
+define AlterTableRelocatePrivate {
+    RelocateLease bool
+
+    _ AlterTableSplitPrivate
+}

--- a/pkg/sql/opt/optbuilder/alter_table.go
+++ b/pkg/sql/opt/optbuilder/alter_table.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -41,29 +42,13 @@ func (b *Builder) buildAlterTableSplit(split *tree.Split, inScope *scope) (outSc
 
 	// Calculate the desired types for the select statement. It is OK if the
 	// select statement returns fewer columns (the relevant prefix is used).
-	desiredTypes := make([]*types.T, index.LaxKeyColumnCount())
-	for i := range desiredTypes {
-		desiredTypes[i] = index.Column(i).DatumType()
-	}
+	colNames, colTypes := getIndexColumnNamesAndTypes(index)
 
 	// We don't allow the input statement to reference outer columns, so we
 	// pass a "blank" scope rather than inScope.
 	emptyScope := &scope{builder: b}
-	stmtScope := b.buildStmt(split.Rows, desiredTypes, emptyScope)
-	if len(stmtScope.cols) == 0 {
-		panic(pgerror.Newf(pgcode.Syntax, "no columns in SPLIT AT data"))
-	}
-	if len(stmtScope.cols) > len(desiredTypes) {
-		panic(pgerror.Newf(pgcode.Syntax, "too many columns in SPLIT AT data"))
-	}
-	for i := range stmtScope.cols {
-		if !stmtScope.cols[i].typ.Equivalent(desiredTypes[i]) {
-			panic(pgerror.Newf(
-				pgcode.Syntax, "SPLIT AT data column %d (%s) must be of type %s, not type %s",
-				i+1, index.Column(i).ColName(), desiredTypes[i], stmtScope.cols[i].typ,
-			))
-		}
-	}
+	inputScope := b.buildStmt(split.Rows, colTypes, emptyScope)
+	checkInputColumns("SPLIT AT", inputScope, colNames, colTypes, 1)
 
 	// Build the expiration scalar.
 	var expiration opt.ScalarExpr
@@ -84,14 +69,99 @@ func (b *Builder) buildAlterTableSplit(split *tree.Split, inScope *scope) (outSc
 	outScope = inScope.push()
 	b.synthesizeResultColumns(outScope, sqlbase.AlterTableSplitColumns)
 	outScope.expr = b.factory.ConstructAlterTableSplit(
-		stmtScope.expr.(memo.RelExpr),
+		inputScope.expr.(memo.RelExpr),
 		expiration,
 		&memo.AlterTableSplitPrivate{
 			Table:   b.factory.Metadata().AddTable(table),
 			Index:   index.Ordinal(),
 			Columns: colsToColList(outScope.cols),
-			Props:   stmtScope.makePhysicalProps(),
+			Props:   inputScope.makePhysicalProps(),
 		},
 	)
 	return outScope
+}
+
+// buildAlterTableUnsplit builds an ALTER TABLE/INDEX .. UNSPLIT AT/ALL .. statement.
+func (b *Builder) buildAlterTableUnsplit(unsplit *tree.Unsplit, inScope *scope) (outScope *scope) {
+	flags := cat.Flags{
+		AvoidDescriptorCaches: true,
+		NoTableStats:          true,
+	}
+	index, err := cat.ResolveTableIndex(b.ctx, b.catalog, flags, &unsplit.TableOrIndex)
+	if err != nil {
+		panic(builderError{err})
+	}
+	table := index.Table()
+	if err := b.catalog.CheckPrivilege(b.ctx, table, privilege.INSERT); err != nil {
+		panic(builderError{err})
+	}
+
+	b.DisableMemoReuse = true
+
+	outScope = inScope.push()
+	b.synthesizeResultColumns(outScope, sqlbase.AlterTableUnsplitColumns)
+	private := &memo.AlterTableSplitPrivate{
+		Table:   b.factory.Metadata().AddTable(table),
+		Index:   index.Ordinal(),
+		Columns: colsToColList(outScope.cols),
+	}
+
+	if unsplit.All {
+		private.Props = physical.MinRequired
+		outScope.expr = b.factory.ConstructAlterTableUnsplitAll(private)
+		return outScope
+	}
+
+	// Calculate the desired types for the select statement. It is OK if the
+	// select statement returns fewer columns (the relevant prefix is used).
+	colNames, colTypes := getIndexColumnNamesAndTypes(index)
+
+	// We don't allow the input statement to reference outer columns, so we
+	// pass a "blank" scope rather than inScope.
+	inputScope := b.buildStmt(unsplit.Rows, colTypes, &scope{builder: b})
+	checkInputColumns("UNSPLIT AT", inputScope, colNames, colTypes, 1)
+	private.Props = inputScope.makePhysicalProps()
+
+	outScope.expr = b.factory.ConstructAlterTableUnsplit(
+		inputScope.expr.(memo.RelExpr),
+		private,
+	)
+	return outScope
+}
+
+// getIndexColumnNamesAndTypes returns the names and types of the index columns.
+func getIndexColumnNamesAndTypes(index cat.Index) (colNames []string, colTypes []*types.T) {
+	colNames = make([]string, index.LaxKeyColumnCount())
+	colTypes = make([]*types.T, index.LaxKeyColumnCount())
+	for i := range colNames {
+		c := index.Column(i)
+		colNames[i] = string(c.ColName())
+		colTypes[i] = c.DatumType()
+	}
+	return colNames, colTypes
+}
+
+// checkInputColumns verifies the types of the columns in the given scope. The
+// input must have at least minPrefix columns, and their types must match that
+// prefix of colTypes.
+func checkInputColumns(
+	context string, inputScope *scope, colNames []string, colTypes []*types.T, minPrefix int,
+) {
+	if len(inputScope.cols) < minPrefix {
+		if len(inputScope.cols) == 0 {
+			panic(pgerror.Newf(pgcode.Syntax, "no columns in %s data", context))
+		}
+		panic(pgerror.Newf(pgcode.Syntax, "too few columns in %s data", context))
+	}
+	if len(inputScope.cols) > len(colTypes) {
+		panic(pgerror.Newf(pgcode.Syntax, "too many columns in %s data", context))
+	}
+	for i := range inputScope.cols {
+		if !inputScope.cols[i].typ.Equivalent(colTypes[i]) {
+			panic(pgerror.Newf(
+				pgcode.Syntax, "%s data column %d (%s) must be of type %s, not type %s",
+				context, i+1, colNames[i], colTypes[i], inputScope.cols[i].typ,
+			))
+		}
+	}
 }

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -243,6 +243,9 @@ func (b *Builder) buildStmt(
 	case *tree.Unsplit:
 		return b.buildAlterTableUnsplit(stmt, inScope)
 
+	case *tree.Relocate:
+		return b.buildAlterTableRelocate(stmt, inScope)
+
 	default:
 		// See if this statement can be rewritten to another statement using the
 		// delegate functionality.

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -12,6 +12,7 @@ package optbuilder
 
 import (
 	"context"
+	"runtime"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/delegate"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
@@ -143,8 +144,10 @@ func (b *Builder) Build() (err error) {
 			// only possible because the code does not update shared state and does
 			// not manipulate locks.
 			if e, ok := r.(error); ok {
-				err = e
-				return
+				if _, x := r.(runtime.Error); !x {
+					err = e
+					return
+				}
 			}
 			// Other panic objects can't be considered "safe" and thus are
 			// propagated as crashes that terminate the session.
@@ -236,6 +239,9 @@ func (b *Builder) buildStmt(
 
 	case *tree.Split:
 		return b.buildAlterTableSplit(stmt, inScope)
+
+	case *tree.Unsplit:
+		return b.buildAlterTableUnsplit(stmt, inScope)
 
 	default:
 		// See if this statement can be rewritten to another statement using the

--- a/pkg/sql/opt/optbuilder/testdata/alter_table
+++ b/pkg/sql/opt/optbuilder/testdata/alter_table
@@ -2,10 +2,11 @@ exec-ddl
 CREATE TABLE abc (a INT PRIMARY KEY, b INT, c STRING, INDEX b (b), UNIQUE INDEX bc (b,c))
 ----
 
+# Tests for ALTER TABLE SPLIT AT.
 build
 ALTER TABLE abc SPLIT AT VALUES (1), (2)
 ----
-alter-table-split
+alter-table-split t.public.abc
  ├── columns: key:2(bytes) pretty:3(string) split_enforced_until:4(timestamp)
  ├── values
  │    ├── columns: column1:1(int!null)
@@ -18,7 +19,7 @@ alter-table-split
 build
 ALTER TABLE abc SPLIT AT VALUES (1), (2) WITH EXPIRATION '2200-01-01 00:00:00.0'
 ----
-alter-table-split
+alter-table-split t.public.abc
  ├── columns: key:2(bytes) pretty:3(string) split_enforced_until:4(timestamp)
  ├── values
  │    ├── columns: column1:1(int!null)
@@ -36,7 +37,7 @@ error (42601): too many columns in SPLIT AT data
 build
 ALTER INDEX abc@bc SPLIT AT VALUES (1), (2) WITH EXPIRATION '2200-01-01 00:00:00.0'
 ----
-alter-table-split
+alter-table-split t.public.abc@bc
  ├── columns: key:2(bytes) pretty:3(string) split_enforced_until:4(timestamp)
  ├── values
  │    ├── columns: column1:1(int!null)
@@ -49,7 +50,7 @@ alter-table-split
 build
 ALTER INDEX abc@bc SPLIT AT VALUES (1, 'foo'), (2, 'bar')
 ----
-alter-table-split
+alter-table-split t.public.abc@bc
  ├── columns: key:3(bytes) pretty:4(string) split_enforced_until:5(timestamp)
  ├── values
  │    ├── columns: column1:1(int!null) column2:2(string!null)
@@ -69,7 +70,7 @@ error (42601): SPLIT AT data column 2 (c) must be of type string, not type int
 build
 ALTER INDEX abc@bc SPLIT AT SELECT b FROM abc ORDER BY a
 ----
-alter-table-split
+alter-table-split t.public.abc@bc
  ├── columns: key:4(bytes) pretty:5(string) split_enforced_until:6(timestamp)
  ├── project
  │    ├── columns: b:2(int)  [hidden: abc.a:1(int!null)]
@@ -79,10 +80,11 @@ alter-table-split
  │         └── ordering: +1
  └── null [type=string]
 
+# Tests for ALTER TABLE UNSPLIT.
 build
 ALTER TABLE abc UNSPLIT AT VALUES (1), (2)
 ----
-alter-table-unsplit
+alter-table-unsplit t.public.abc
  ├── columns: key:1(bytes) pretty:2(string)
  └── values
       ├── columns: column1:6(int!null)
@@ -94,7 +96,7 @@ alter-table-unsplit
 build
 ALTER TABLE abc UNSPLIT ALL
 ----
-alter-table-unsplit-all
+alter-table-unsplit-all t.public.abc
  └── columns: key:1(bytes) pretty:2(string)
 
 build
@@ -105,13 +107,13 @@ error (42601): too many columns in UNSPLIT AT data
 build
 ALTER INDEX abc@bc UNSPLIT ALL
 ----
-alter-table-unsplit-all
+alter-table-unsplit-all t.public.abc@bc
  └── columns: key:1(bytes) pretty:2(string)
 
 build
 ALTER INDEX abc@bc UNSPLIT AT VALUES (1, 'foo'), (2, 'bar')
 ----
-alter-table-unsplit
+alter-table-unsplit t.public.abc@bc
  ├── columns: key:1(bytes) pretty:2(string)
  └── values
       ├── columns: column1:6(int!null) column2:7(string!null)
@@ -130,7 +132,7 @@ error (42601): UNSPLIT AT data column 2 (c) must be of type string, not type int
 build
 ALTER INDEX abc@bc UNSPLIT AT SELECT b FROM abc ORDER BY a
 ----
-alter-table-unsplit
+alter-table-unsplit t.public.abc@bc
  ├── columns: key:1(bytes) pretty:2(string)
  └── project
       ├── columns: b:7(int)  [hidden: abc.a:6(int!null)]
@@ -138,3 +140,88 @@ alter-table-unsplit
       └── scan abc
            ├── columns: abc.a:6(int!null) abc.b:7(int) abc.c:8(string)
            └── ordering: +6
+
+# Tests for ALTER TABLE EXPERIMENTAL_RELOCATE.
+build
+ALTER TABLE abc EXPERIMENTAL_RELOCATE VALUES (ARRAY[1,2,3], 1), (ARRAY[4], 2)
+----
+alter-table-relocate t.public.abc
+ ├── columns: key:1(bytes) pretty:2(string)
+ └── values
+      ├── columns: column1:3(int[]) column2:4(int!null)
+      ├── tuple [type=tuple{int[], int}]
+      │    ├── array: [type=int[]]
+      │    │    ├── const: 1 [type=int]
+      │    │    ├── const: 2 [type=int]
+      │    │    └── const: 3 [type=int]
+      │    └── const: 1 [type=int]
+      └── tuple [type=tuple{int[], int}]
+           ├── array: [type=int[]]
+           │    └── const: 4 [type=int]
+           └── const: 2 [type=int]
+
+build
+ALTER TABLE abc EXPERIMENTAL_RELOCATE LEASE VALUES (10), (11)
+----
+error (42601): less than 2 columns in EXPERIMENTAL_RELOCATE LEASE data
+
+build
+ALTER TABLE abc EXPERIMENTAL_RELOCATE LEASE VALUES (10, 1, 2), (11, 3, 4)
+----
+error (42601): too many columns in EXPERIMENTAL_RELOCATE LEASE data
+
+build
+ALTER INDEX abc@bc EXPERIMENTAL_RELOCATE VALUES (ARRAY[5], 1, 'foo'), (ARRAY[6,7,8], 2, 'bar')
+----
+alter-table-relocate t.public.abc@bc
+ ├── columns: key:1(bytes) pretty:2(string)
+ └── values
+      ├── columns: column1:3(int[]) column2:4(int!null) column3:5(string!null)
+      ├── tuple [type=tuple{int[], int, string}]
+      │    ├── array: [type=int[]]
+      │    │    └── const: 5 [type=int]
+      │    ├── const: 1 [type=int]
+      │    └── const: 'foo' [type=string]
+      └── tuple [type=tuple{int[], int, string}]
+           ├── array: [type=int[]]
+           │    ├── const: 6 [type=int]
+           │    ├── const: 7 [type=int]
+           │    └── const: 8 [type=int]
+           ├── const: 2 [type=int]
+           └── const: 'bar' [type=string]
+
+build
+ALTER INDEX abc@bc EXPERIMENTAL_RELOCATE VALUES (5, 1, 'foo'), (6, 2, 'bar')
+----
+error (42601): EXPERIMENTAL_RELOCATE data column 1 (relocation array) must be of type int[], not type int
+
+build
+ALTER INDEX abc@bc EXPERIMENTAL_RELOCATE LEASE VALUES (ARRAY[5], 1, 'foo'), (ARRAY[6,7,8], 2, 'bar')
+----
+error (42601): EXPERIMENTAL_RELOCATE LEASE data column 1 (target leaseholder) must be of type int, not type int[]
+
+build
+ALTER INDEX abc@bc EXPERIMENTAL_RELOCATE VALUES (1, 2), (3, 4)
+----
+error (42601): EXPERIMENTAL_RELOCATE data column 1 (relocation array) must be of type int[], not type int
+
+build
+ALTER INDEX abc@bc EXPERIMENTAL_RELOCATE VALUES (ARRAY[1,2], 1, 2), (ARRAY[3,4], 3, 4)
+----
+error (42601): EXPERIMENTAL_RELOCATE data column 3 (c) must be of type string, not type int
+
+build
+ALTER INDEX abc@bc EXPERIMENTAL_RELOCATE LEASE VALUES (10, 1, 'foo'), (11, 3, 'bar')
+----
+alter-table-relocate t.public.abc@bc [lease]
+ ├── columns: key:1(bytes) pretty:2(string)
+ └── values
+      ├── columns: column1:3(int!null) column2:4(int!null) column3:5(string!null)
+      ├── tuple [type=tuple{int, int, string}]
+      │    ├── const: 10 [type=int]
+      │    ├── const: 1 [type=int]
+      │    └── const: 'foo' [type=string]
+      └── tuple [type=tuple{int, int, string}]
+           ├── const: 11 [type=int]
+           ├── const: 3 [type=int]
+           └── const: 'bar' [type=string]

--- a/pkg/sql/opt/optbuilder/testdata/alter_table
+++ b/pkg/sql/opt/optbuilder/testdata/alter_table
@@ -78,3 +78,63 @@ alter-table-split
  │         ├── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(string)
  │         └── ordering: +1
  └── null [type=string]
+
+build
+ALTER TABLE abc UNSPLIT AT VALUES (1), (2)
+----
+alter-table-unsplit
+ ├── columns: key:1(bytes) pretty:2(string)
+ └── values
+      ├── columns: column1:6(int!null)
+      ├── tuple [type=tuple{int}]
+      │    └── const: 1 [type=int]
+      └── tuple [type=tuple{int}]
+           └── const: 2 [type=int]
+
+build
+ALTER TABLE abc UNSPLIT ALL
+----
+alter-table-unsplit-all
+ └── columns: key:1(bytes) pretty:2(string)
+
+build
+ALTER TABLE abc UNSPLIT AT VALUES (1, 2), (3, 4)
+----
+error (42601): too many columns in UNSPLIT AT data
+
+build
+ALTER INDEX abc@bc UNSPLIT ALL
+----
+alter-table-unsplit-all
+ └── columns: key:1(bytes) pretty:2(string)
+
+build
+ALTER INDEX abc@bc UNSPLIT AT VALUES (1, 'foo'), (2, 'bar')
+----
+alter-table-unsplit
+ ├── columns: key:1(bytes) pretty:2(string)
+ └── values
+      ├── columns: column1:6(int!null) column2:7(string!null)
+      ├── tuple [type=tuple{int, string}]
+      │    ├── const: 1 [type=int]
+      │    └── const: 'foo' [type=string]
+      └── tuple [type=tuple{int, string}]
+           ├── const: 2 [type=int]
+           └── const: 'bar' [type=string]
+
+build
+ALTER INDEX abc@bc UNSPLIT AT VALUES (1, 2), (3, 4)
+----
+error (42601): UNSPLIT AT data column 2 (c) must be of type string, not type int
+
+build
+ALTER INDEX abc@bc UNSPLIT AT SELECT b FROM abc ORDER BY a
+----
+alter-table-unsplit
+ ├── columns: key:1(bytes) pretty:2(string)
+ └── project
+      ├── columns: b:7(int)  [hidden: abc.a:6(int!null)]
+      ├── ordering: +6
+      └── scan abc
+           ├── columns: abc.a:6(int!null) abc.b:7(int) abc.c:8(string)
+           └── ordering: +6

--- a/pkg/sql/opt/ordering/ordering.go
+++ b/pkg/sql/opt/ordering/ordering.go
@@ -197,6 +197,11 @@ func init() {
 		buildChildReqOrdering: alterTableUnsplitBuildChildReqOrdering,
 		buildProvidedOrdering: noProvidedOrdering,
 	}
+	funcMap[opt.AlterTableRelocateOp] = funcs{
+		canProvideOrdering:    canNeverProvideOrdering,
+		buildChildReqOrdering: alterTableRelocateBuildChildReqOrdering,
+		buildProvidedOrdering: noProvidedOrdering,
+	}
 }
 
 func canNeverProvideOrdering(expr memo.RelExpr, required *physical.OrderingChoice) bool {

--- a/pkg/sql/opt/ordering/ordering.go
+++ b/pkg/sql/opt/ordering/ordering.go
@@ -192,6 +192,11 @@ func init() {
 		buildChildReqOrdering: alterTableSplitBuildChildReqOrdering,
 		buildProvidedOrdering: noProvidedOrdering,
 	}
+	funcMap[opt.AlterTableUnsplitOp] = funcs{
+		canProvideOrdering:    canNeverProvideOrdering,
+		buildChildReqOrdering: alterTableUnsplitBuildChildReqOrdering,
+		buildProvidedOrdering: noProvidedOrdering,
+	}
 }
 
 func canNeverProvideOrdering(expr memo.RelExpr, required *physical.OrderingChoice) bool {

--- a/pkg/sql/opt/ordering/statement.go
+++ b/pkg/sql/opt/ordering/statement.go
@@ -38,3 +38,12 @@ func alterTableUnsplitBuildChildReqOrdering(
 	}
 	return parent.(*memo.AlterTableUnsplitExpr).Props.Ordering
 }
+
+func alterTableRelocateBuildChildReqOrdering(
+	parent memo.RelExpr, required *physical.OrderingChoice, childIdx int,
+) physical.OrderingChoice {
+	if childIdx != 0 {
+		return physical.OrderingChoice{}
+	}
+	return parent.(*memo.AlterTableRelocateExpr).Props.Ordering
+}

--- a/pkg/sql/opt/ordering/statement.go
+++ b/pkg/sql/opt/ordering/statement.go
@@ -29,3 +29,12 @@ func alterTableSplitBuildChildReqOrdering(
 	}
 	return parent.(*memo.AlterTableSplitExpr).Props.Ordering
 }
+
+func alterTableUnsplitBuildChildReqOrdering(
+	parent memo.RelExpr, required *physical.OrderingChoice, childIdx int,
+) physical.OrderingChoice {
+	if childIdx != 0 {
+		return physical.OrderingChoice{}
+	}
+	return parent.(*memo.AlterTableUnsplitExpr).Props.Ordering
+}

--- a/pkg/sql/opt/xform/physical_props.go
+++ b/pkg/sql/opt/xform/physical_props.go
@@ -55,6 +55,8 @@ func BuildChildPhysicalProps(
 		childProps.Presentation = parent.(*memo.AlterTableSplitExpr).Props.Presentation
 	case opt.AlterTableUnsplitOp:
 		childProps.Presentation = parent.(*memo.AlterTableUnsplitExpr).Props.Presentation
+	case opt.AlterTableRelocateOp:
+		childProps.Presentation = parent.(*memo.AlterTableRelocateExpr).Props.Presentation
 	}
 
 	childProps.Ordering = ordering.BuildChildRequired(parent, &parentProps.Ordering, nth)

--- a/pkg/sql/opt/xform/physical_props.go
+++ b/pkg/sql/opt/xform/physical_props.go
@@ -53,6 +53,8 @@ func BuildChildPhysicalProps(
 		childProps.Presentation = parent.(*memo.ExplainExpr).Props.Presentation
 	case opt.AlterTableSplitOp:
 		childProps.Presentation = parent.(*memo.AlterTableSplitExpr).Props.Presentation
+	case opt.AlterTableUnsplitOp:
+		childProps.Presentation = parent.(*memo.AlterTableUnsplitExpr).Props.Presentation
 	}
 
 	childProps.Ordering = ordering.BuildChildRequired(parent, &parentProps.Ordering, nth)

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1610,6 +1610,25 @@ func (ef *execFactory) ConstructAlterTableSplit(
 	}, nil
 }
 
+// ConstructAlterTableUnsplit is part of the exec.Factory interface.
+func (ef *execFactory) ConstructAlterTableUnsplit(
+	index cat.Index, input exec.Node,
+) (exec.Node, error) {
+	return &unsplitNode{
+		tableDesc: &index.Table().(*optTable).desc.TableDescriptor,
+		index:     index.(*optIndex).desc,
+		rows:      input.(planNode),
+	}, nil
+}
+
+// ConstructAlterTableUnsplitAll is part of the exec.Factory interface.
+func (ef *execFactory) ConstructAlterTableUnsplitAll(index cat.Index) (exec.Node, error) {
+	return &unsplitAllNode{
+		tableDesc: &index.Table().(*optTable).desc.TableDescriptor,
+		index:     index.(*optIndex).desc,
+	}, nil
+}
+
 // renderBuilder encapsulates the code to build a renderNode.
 type renderBuilder struct {
 	r   *renderNode

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1629,6 +1629,18 @@ func (ef *execFactory) ConstructAlterTableUnsplitAll(index cat.Index) (exec.Node
 	}, nil
 }
 
+// ConstructAlterTableRelocate is part of the exec.Factory interface.
+func (ef *execFactory) ConstructAlterTableRelocate(
+	index cat.Index, input exec.Node, relocateLease bool,
+) (exec.Node, error) {
+	return &relocateNode{
+		relocateLease: relocateLease,
+		tableDesc:     &index.Table().(*optTable).desc.TableDescriptor,
+		index:         index.(*optIndex).desc,
+		rows:          input.(planNode),
+	}, nil
+}
+
 // renderBuilder encapsulates the code to build a renderNode.
 type renderBuilder struct {
 	r   *renderNode

--- a/pkg/sql/relocate.go
+++ b/pkg/sql/relocate.go
@@ -76,7 +76,7 @@ func (p *planner) Relocate(ctx context.Context, n *tree.Relocate) (planNode, err
 	}
 	cols := planColumns(rows)
 	if len(cols) < 2 {
-		return nil, errors.Errorf("less than two columns in %s data", cmdName)
+		return nil, errors.Errorf("less than 2 columns in %s data", cmdName)
 	}
 	if len(cols) > len(index.ColumnIDs)+1 {
 		return nil, errors.Errorf("too many columns in %s data", cmdName)
@@ -102,9 +102,6 @@ func (p *planner) Relocate(ctx context.Context, n *tree.Relocate) (planNode, err
 		tableDesc:     tableDesc.TableDesc(),
 		index:         index,
 		rows:          rows,
-		run: relocateRun{
-			storeMap: make(map[roachpb.StoreID]roachpb.NodeID),
-		},
 	}, nil
 }
 
@@ -119,6 +116,7 @@ type relocateRun struct {
 }
 
 func (n *relocateNode) startExec(runParams) error {
+	n.run.storeMap = make(map[roachpb.StoreID]roachpb.NodeID)
 	return nil
 }
 


### PR DESCRIPTION
#### opt: support ALTER TABLE UNSPLIT

Support for ALTER TABLE UNSPLIT (which has two variants).

Release note: None

#### opt: support EXPERIMENTAL_RELOCATE

Also fix the formatting of details for split/unsplit.

Release note: None


Informs #34848.