### PR TITLE
exec: Handle NULLS in TopK sorter

### DIFF
--- a/pkg/sql/exec/coldata/nulls.go
+++ b/pkg/sql/exec/coldata/nulls.go
@@ -70,6 +70,11 @@ func (n *Nulls) SetNull(i uint16) {
 	n.SetNull64(uint64(i))
 }
 
+// UnsetNull unsets the ith value of the column.
+func (n *Nulls) UnsetNull(i uint16) {
+	n.UnsetNull64(uint64(i))
+}
+
 // SetNullRange sets all the values in [start, end) to null.
 func (n *Nulls) SetNullRange(start uint64, end uint64) {
 	if start >= end {
@@ -144,6 +149,11 @@ func (n *Nulls) NullAt64(i uint64) bool {
 func (n *Nulls) SetNull64(i uint64) {
 	n.hasNulls = true
 	n.nulls[i/8] &= flippedBitMask[i%8]
+}
+
+// UnsetNull64 unsets the ith values of the column.
+func (n *Nulls) UnsetNull64(i uint64) {
+	n.nulls[i/8] |= bitMask[i%8]
 }
 
 // Extend extends the nulls vector with the next toAppend values from src,

--- a/pkg/sql/exec/coldata/nulls_test.go
+++ b/pkg/sql/exec/coldata/nulls_test.go
@@ -93,6 +93,18 @@ func TestSetAndUnsetNulls(t *testing.T) {
 	for i := uint16(0); i < BatchSize; i++ {
 		require.True(t, n.NullAt(i))
 	}
+
+	for i := uint16(0); i < BatchSize; i += 3 {
+		n.UnsetNull(i)
+	}
+	for i := uint16(0); i < BatchSize; i++ {
+		if i%3 == 0 {
+			require.False(t, n.NullAt(i))
+		} else {
+			require.True(t, n.NullAt(i))
+		}
+	}
+
 	n.UnsetNulls()
 	for i := uint16(0); i < BatchSize; i++ {
 		require.False(t, n.NullAt(i))

--- a/pkg/sql/exec/sorttopk_test.go
+++ b/pkg/sql/exec/sorttopk_test.go
@@ -47,8 +47,8 @@ func TestTopKSorter(t *testing.T) {
 		},
 		{
 			name:     "nulls",
-			tuples:   tuples{{1}, {2}, {3}, {4}, {5}, {6}, {7}, {nil}},
-			expected: tuples{{nil}, {1}, {2}},
+			tuples:   tuples{{1}, {2}, {nil}, {3}, {4}, {5}, {6}, {7}, {nil}},
+			expected: tuples{{nil}, {nil}, {1}},
 			typ:      []types.T{types.Int64},
 			ordCols:  []distsqlpb.Ordering_Column{{ColIdx: 0}},
 			k:        3,

--- a/pkg/sql/exec/vec_comparators.go
+++ b/pkg/sql/exec/vec_comparators.go
@@ -21,6 +21,10 @@ type vecComparator interface {
 	// 0, or 1.
 	compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 uint16) int
 
+	// set sets the value of the vector at dstVecIdx at index dstValIdx to the value
+	// at the vector at srcVecIdx at index srcValIdx.
+	set(srcVecIdx, dstVecIdx int, srcValIdx, dstValIdx uint16)
+
 	// setVec updates the vector at idx.
 	setVec(idx int, vec coldata.Vec)
 }

--- a/pkg/sql/exec/vec_comparators_tmpl.go
+++ b/pkg/sql/exec/vec_comparators_tmpl.go
@@ -78,6 +78,15 @@ func (c *_TYPEVecComparator) setVec(idx int, vec coldata.Vec) {
 	c.nulls[idx] = vec.Nulls()
 }
 
+func (c *_TYPEVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx uint16) {
+	if c.nulls[srcVecIdx].HasNulls() && c.nulls[srcVecIdx].NullAt(srcIdx) {
+		c.nulls[dstVecIdx].SetNull(dstIdx)
+	} else {
+		c.nulls[dstVecIdx].UnsetNull(dstIdx)
+		c.vecs[dstVecIdx][dstIdx] = c.vecs[srcVecIdx][srcIdx]
+	}
+}
+
 // {{end}}
 
 func GetVecComparator(t types.T, numVecs int) vecComparator {


### PR DESCRIPTION
This commit fixes NULLs in the TopK sorter by avoiding use
of the vec copy method, which has a bug. Instead, we add
a set method to the vec comparator, and use the templatized
comparator to perform the sets that the TopK sorter needs.

To facilitate this, we add an UnsetNull method to the Nulls
object. However, use of this method results in HasNull()
maybe returning true even if the vector doesn't have nulls.
This behavior already occurs when selection vectors are used.
Based on discussions with @solongordon and @asubiotto, this behavior
is OK, and future PR's will attempt to make this behavior better, and address
the bugs within the Vec Copy method.