### PR TITLE
storage: skip TestNewTruncateDecision

### DIFF
--- a/pkg/storage/raft_log_queue_test.go
+++ b/pkg/storage/raft_log_queue_test.go
@@ -463,6 +463,9 @@ func TestNewTruncateDecisionMaxSize(t *testing.T) {
 // removed.
 func TestNewTruncateDecision(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	t.Skip("https://github.com/cockroachdb/cockroach/issues/38584")
+
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t,


### PR DESCRIPTION
We've identified the root cause, but some cleanup presents itself, and
in the meantime the test is too flaky to leave unskipped.

See #38652.

Touches #38584.

Release note: None