### PR TITLE
pkg: Migrate RowConverter to sql/row

### DIFF
--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -288,7 +288,7 @@ func insertStmtToKVs(
 		return errors.Errorf("load insert: expected VALUES clause: %q", stmt)
 	}
 
-	b := sql.Inserter(f)
+	b := row.KVInserter(f)
 	computedIVarContainer := sqlbase.RowIndexedVarContainer{
 		Mapping: ri.InsertColIDtoRowIndex,
 		Cols:    tableDesc.Columns,
@@ -315,7 +315,7 @@ func insertStmtToKVs(
 		var computeExprs []tree.TypedExpr
 		var computedCols []sqlbase.ColumnDescriptor
 
-		insertRow, err := sql.GenerateInsertRow(
+		insertRow, err := row.GenerateInsertRow(
 			defaultExprs, computeExprs, cols, computedCols, evalCtx, tableDesc, insertRow, &computedIVarContainer,
 		)
 		if err != nil {

--- a/pkg/ccl/importccl/read_import_csv.go
+++ b/pkg/ccl/importccl/read_import_csv.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
@@ -162,7 +162,7 @@ func (c *csvInputReader) convertRecordWorker(ctx context.Context) error {
 	// Create a new evalCtx per converter so each go routine gets its own
 	// collationenv, which can't be accessed in parallel.
 	evalCtx := c.evalCtx.Copy()
-	conv, err := sql.NewRowConverter(c.tableDesc, evalCtx, c.kvCh)
+	conv, err := row.NewDatumRowConverter(c.tableDesc, evalCtx, c.kvCh)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/importccl/read_import_mysql.go
+++ b/pkg/ccl/importccl/read_import_mysql.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -42,7 +43,7 @@ import (
 // KVs using the mapped converter and sent to kvCh.
 type mysqldumpReader struct {
 	evalCtx  *tree.EvalContext
-	tables   map[string]*sql.RowConverter
+	tables   map[string]*row.DatumRowConverter
 	kvCh     chan []roachpb.KeyValue
 	debugRow func(tree.Datums)
 }
@@ -56,13 +57,13 @@ func newMysqldumpReader(
 ) (*mysqldumpReader, error) {
 	res := &mysqldumpReader{evalCtx: evalCtx, kvCh: kvCh}
 
-	converters := make(map[string]*sql.RowConverter, len(tables))
+	converters := make(map[string]*row.DatumRowConverter, len(tables))
 	for name, table := range tables {
 		if table == nil {
 			converters[name] = nil
 			continue
 		}
-		conv, err := sql.NewRowConverter(table, evalCtx, kvCh)
+		conv, err := row.NewDatumRowConverter(table, evalCtx, kvCh)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/importccl/read_import_mysqlout.go
+++ b/pkg/ccl/importccl/read_import_mysqlout.go
@@ -16,15 +16,15 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 )
 
 type mysqloutfileReader struct {
-	conv sql.RowConverter
+	conv row.DatumRowConverter
 	opts roachpb.MySQLOutfileOptions
 }
 
@@ -36,7 +36,7 @@ func newMysqloutfileReader(
 	tableDesc *sqlbase.TableDescriptor,
 	evalCtx *tree.EvalContext,
 ) (*mysqloutfileReader, error) {
-	conv, err := sql.NewRowConverter(tableDesc, evalCtx, kvCh)
+	conv, err := row.NewDatumRowConverter(tableDesc, evalCtx, kvCh)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/importccl/read_import_pgcopy.go
+++ b/pkg/ccl/importccl/read_import_pgcopy.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
@@ -32,7 +32,7 @@ import (
 const defaultScanBuffer = 1024 * 1024 * 4
 
 type pgCopyReader struct {
-	conv sql.RowConverter
+	conv row.DatumRowConverter
 	opts roachpb.PgCopyOptions
 }
 
@@ -44,7 +44,7 @@ func newPgCopyReader(
 	tableDesc *sqlbase.TableDescriptor,
 	evalCtx *tree.EvalContext,
 ) (*pgCopyReader, error) {
-	conv, err := sql.NewRowConverter(tableDesc, evalCtx, kvCh)
+	conv, err := row.NewDatumRowConverter(tableDesc, evalCtx, kvCh)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
@@ -391,7 +392,7 @@ func getTableName2(u *tree.UnresolvedObjectName) (string, error) {
 }
 
 type pgDumpReader struct {
-	tables map[string]*sql.RowConverter
+	tables map[string]*row.DatumRowConverter
 	descs  map[string]*sqlbase.TableDescriptor
 	kvCh   chan []roachpb.KeyValue
 	opts   roachpb.PgDumpOptions
@@ -406,10 +407,10 @@ func newPgDumpReader(
 	descs map[string]*sqlbase.TableDescriptor,
 	evalCtx *tree.EvalContext,
 ) (*pgDumpReader, error) {
-	converters := make(map[string]*sql.RowConverter, len(descs))
+	converters := make(map[string]*row.DatumRowConverter, len(descs))
 	for name, desc := range descs {
 		if desc.IsTable() {
-			conv, err := sql.NewRowConverter(desc, evalCtx, kvCh)
+			conv, err := row.NewDatumRowConverter(desc, evalCtx, kvCh)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/ccl/importccl/read_import_workload.go
+++ b/pkg/ccl/importccl/read_import_workload.go
@@ -21,9 +21,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	sqltypes "github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -231,7 +231,7 @@ func NewWorkloadKVConverter(
 func (w *WorkloadKVConverter) Worker(
 	ctx context.Context, evalCtx *tree.EvalContext, finishedBatchFn func(),
 ) error {
-	conv, err := sql.NewRowConverter(w.tableDesc, evalCtx, w.kvCh)
+	conv, err := row.NewDatumRowConverter(w.tableDesc, evalCtx, w.kvCh)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -364,7 +364,7 @@ func (n *upsertNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 	// Process the incoming row tuple and generate the full inserted
 	// row. This fills in the defaults, computes computed columns, and
 	// checks the data width complies with the schema constraints.
-	rowVals, err := GenerateInsertRow(
+	rowVals, err := row.GenerateInsertRow(
 		n.run.defaultExprs,
 		n.run.computeExprs,
 		n.run.insertCols,


### PR DESCRIPTION
There is no modification of logic, this is only a change of package
to allow access of the `RowConverter` from `distsqlrun`.
Also involves renaming RowConverter due to stutter lint.