### PR TITLE
opt: push limit into offset

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -397,13 +397,14 @@ values  ·     ·
 query TTT
 SELECT tree, field, description FROM [EXPLAIN (VERBOSE) SELECT * FROM t WITH ORDINALITY LIMIT 1 OFFSET 1]
 ----
-limit            ·       ·
- │               count   1
- │               offset  1
- └── ordinality  ·       ·
-      └── scan   ·       ·
-·                table   t@primary
-·                spans   ALL
+limit                 ·       ·
+ │                    offset  1
+ └── limit            ·       ·
+      │               count   2
+      └── ordinality  ·       ·
+           └── scan   ·       ·
+·                     table   t@primary
+·                     spans   ALL
 
 query TTT
 EXPLAIN SELECT DISTINCT v FROM t
@@ -417,14 +418,15 @@ distinct   ·            ·
 query TTT
 SELECT tree, field, description FROM [EXPLAIN (VERBOSE) SELECT DISTINCT v FROM t LIMIT 1 OFFSET 1]
 ----
-limit           ·            ·
- │              count        1
- │              offset       1
- └── distinct   ·            ·
-      │         distinct on  v
-      └── scan  ·            ·
-·               table        t@primary
-·               spans        ALL
+limit                ·            ·
+ │                   offset       1
+ └── limit           ·            ·
+      │              count        2
+      └── distinct   ·            ·
+           │         distinct on  v
+           └── scan  ·            ·
+·                    table        t@primary
+·                    spans        ALL
 
 statement ok
 CREATE TABLE tc (a INT, b INT, INDEX c(a))

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -59,21 +59,21 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT k, v FROM t ORDER BY v LIMIT (1+4) OFFSET 1
 ----
 limit      ·       ·          (k, v)  +v
- │         count   5          ·       ·
  │         offset  1          ·       ·
  └── scan  ·       ·          (k, v)  +v
 ·          table   t@t_v_idx  ·       ·
 ·          spans   ALL        ·       ·
+·          limit   6          ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, v FROM t ORDER BY v DESC LIMIT (1+4) OFFSET 1
 ----
 limit         ·       ·          (k, v)  -v
- │            count   5          ·       ·
  │            offset  1          ·       ·
  └── revscan  ·       ·          (k, v)  -v
 ·             table   t@t_v_idx  ·       ·
 ·             spans   ALL        ·       ·
+·             limit   6          ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT sum(w) FROM t GROUP BY k, v ORDER BY v DESC LIMIT 10

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -1101,14 +1101,14 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM noncover ORDER BY c LIMIT 5 OFFSET 5
 ]
 ----
-limit           ·       ·
- │              count   5
- │              offset  5
- └── sort       ·       ·
-      │         order   +c
-      └── scan  ·       ·
-·               table   noncover@primary
-·               spans   ALL
+limit            ·       ·
+ │               offset  5
+ └── index-join  ·       ·
+      │          table   noncover@primary
+      └── scan   ·       ·
+·                table   noncover@c
+·                spans   ALL
+·                limit   10
 
 query TTT
 SELECT tree, field, description FROM [

--- a/pkg/sql/opt/memo/testdata/stats/limit
+++ b/pkg/sql/opt/memo/testdata/stats/limit
@@ -208,17 +208,17 @@ CREATE TABLE b (x int)
 opt colstat=1
 SELECT * FROM b ORDER BY x LIMIT 1 OFFSET 9999
 ----
-limit
+offset
  ├── columns: x:1(int)
  ├── internal-ordering: +1
  ├── cardinality: [0 - 1]
  ├── stats: [rows=1, distinct(1)=0.995511979, null(1)=0.01]
- ├── key: ()
- ├── fd: ()-->(1)
- ├── offset
+ ├── ordering: +1
+ ├── limit
  │    ├── columns: x:1(int)
  │    ├── internal-ordering: +1
- │    ├── stats: [rows=1, distinct(1)=0.995511979, null(1)=0.01]
+ │    ├── cardinality: [0 - 10000]
+ │    ├── stats: [rows=1000, distinct(1)=100, null(1)=10]
  │    ├── ordering: +1
  │    ├── sort
  │    │    ├── columns: x:1(int)
@@ -227,5 +227,5 @@ limit
  │    │    └── scan b
  │    │         ├── columns: x:1(int)
  │    │         └── stats: [rows=1000, distinct(1)=100, null(1)=10]
- │    └── const: 9999 [type=int]
- └── const: 1 [type=int]
+ │    └── const: 10000 [type=int]
+ └── const: 9999 [type=int]

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -1063,12 +1063,25 @@ func (c *CustomFuncs) IsUnorderedGrouping(grouping *memo.GroupingPrivate) bool {
 //
 // ----------------------------------------------------------------------
 
+// IsPositiveLimit is true if the given limit value is greater than zero.
+func (c *CustomFuncs) IsPositiveLimit(limit tree.Datum) bool {
+	limitVal := int64(*limit.(*tree.DInt))
+	return limitVal > 0
+}
+
 // LimitGeMaxRows returns true if the given constant limit value is greater than
 // or equal to the max number of rows returned by the input expression.
 func (c *CustomFuncs) LimitGeMaxRows(limit tree.Datum, input memo.RelExpr) bool {
 	limitVal := int64(*limit.(*tree.DInt))
 	maxRows := input.Relational().Cardinality.Max
 	return limitVal >= 0 && maxRows < math.MaxUint32 && limitVal >= int64(maxRows)
+}
+
+// IsSameOrdering evaluates whether the two orderings are equal.
+func (c *CustomFuncs) IsSameOrdering(
+	first physical.OrderingChoice, other physical.OrderingChoice,
+) bool {
+	return first.Equals(&other)
 }
 
 // ----------------------------------------------------------------------
@@ -1673,4 +1686,11 @@ func (c *CustomFuncs) EqualsNumber(datum tree.Datum, value int64) bool {
 		return *t == tree.DInt(value)
 	}
 	return false
+}
+
+// AddConsts adds the numeric constants together.
+func (c *CustomFuncs) AddConsts(first tree.Datum, second tree.Datum) tree.Datum {
+	firstVal := int64(*first.(*tree.DInt))
+	secondVal := int64(*second.(*tree.DInt))
+	return tree.NewDInt(tree.DInt(firstVal + secondVal))
 }

--- a/pkg/sql/opt/norm/rules/limit.opt
+++ b/pkg/sql/opt/norm/rules/limit.opt
@@ -66,13 +66,14 @@ $input
         $offsetOrdering:*
     )
     (Const $limit:* & (IsPositiveLimit $limit))
-    $limitOrdering:* & (IsSameOrdering $offsetOrdering $limitOrdering)
+    $limitOrdering:* & (IsSameOrdering $offsetOrdering $limitOrdering) &
+        (CanAddConstInts $limit $offset)
 )
 =>
 (Offset
     (Limit
         $input
-        (Const (AddConsts $offset $limit))
+        (Const (AddConstInts $offset $limit))
         $limitOrdering
      )
     (Const $offset)

--- a/pkg/sql/opt/norm/rules/limit.opt
+++ b/pkg/sql/opt/norm/rules/limit.opt
@@ -54,3 +54,27 @@ $input
     $projections
     $passthrough
 )
+
+# PushLimitIntoOffset pushes the Limit operator into the offset. This should
+# not have a negative impact but it would allow the use of the GenerateLimitedScans
+# rule.
+[PushLimitIntoOffset, Normalize]
+(Limit
+    (Offset
+        $input:*
+        (Const $offset:* & (IsPositiveLimit $offset))
+        $offsetOrdering:*
+    )
+    (Const $limit:* & (IsPositiveLimit $limit))
+    $limitOrdering:* & (IsSameOrdering $offsetOrdering $limitOrdering)
+)
+=>
+(Offset
+    (Limit
+        $input
+        (Const (AddConsts $offset $limit))
+        $limitOrdering
+     )
+    (Const $offset)
+    $offsetOrdering
+)

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -383,7 +383,7 @@ project
 # PushLimitIntoOffset
 # --------------------------------------------------
 
-opt expect=(PushLimitIntoOffset)
+opt expect=PushLimitIntoOffset
 SELECT k, i FROM a LIMIT 10 OFFSET 10
 ----
 offset
@@ -414,7 +414,7 @@ offset
  └── const: 10 [type=int]
 
 # Limit can be pushed into the ordering if they have the same ordering.
-opt expect=(PushLimitIntoOffset)
+opt expect=PushLimitIntoOffset
 SELECT k, i FROM (SELECT k, i FROM a ORDER BY i OFFSET 20) ORDER BY i LIMIT 10
 ----
 offset
@@ -443,7 +443,7 @@ offset
  │    └── const: 30 [type=int]
  └── const: 20 [type=int]
 
-opt expect-not=(PushLimitIntoOffset)
+opt expect-not=PushLimitIntoOffset
 SELECT k, i FROM (SELECT k, i FROM a ORDER BY i OFFSET 20) ORDER BY i DESC LIMIT 10
 ----
 limit
@@ -474,3 +474,22 @@ limit
  │         │         └── fd: (1)-->(2)
  │         └── const: 20 [type=int]
  └── const: 10 [type=int]
+
+# Using MaxInt64. Do not apply rule when sum overflows.
+opt expect-not=PushLimitIntoOffset
+SELECT k, i FROM a LIMIT 9223372036854775807 OFFSET 9223372036854775807
+----
+limit
+ ├── columns: k:1(int!null) i:2(int)
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── offset
+ │    ├── columns: k:1(int!null) i:2(int)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2)
+ │    └── const: 9223372036854775807 [type=int]
+ └── const: 9223372036854775807 [type=int]

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -98,21 +98,17 @@ scan a
 opt expect-not=EliminateOffset
 SELECT * FROM a LIMIT 5 OFFSET 1
 ----
-limit
+offset
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── cardinality: [0 - 5]
  ├── key: (1)
  ├── fd: (1)-->(2-5)
- ├── offset
+ ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── limit: 6
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    ├── scan a
- │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    │    ├── key: (1)
- │    │    └── fd: (1)-->(2-5)
- │    └── const: 1 [type=int]
- └── const: 5 [type=int]
+ │    └── fd: (1)-->(2-5)
+ └── const: 1 [type=int]
 
 # --------------------------------------------------
 # PushLimitIntoProject
@@ -335,21 +331,17 @@ project
  ├── cardinality: [0 - 10]
  ├── key: (1)
  ├── fd: (1)-->(6)
- ├── limit
+ ├── offset
  │    ├── columns: k:1(int!null) f:3(float)
  │    ├── cardinality: [0 - 10]
  │    ├── key: (1)
  │    ├── fd: (1)-->(3)
- │    ├── offset
+ │    ├── scan a
  │    │    ├── columns: k:1(int!null) f:3(float)
+ │    │    ├── limit: 15
  │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(3)
- │    │    ├── scan a
- │    │    │    ├── columns: k:1(int!null) f:3(float)
- │    │    │    ├── key: (1)
- │    │    │    └── fd: (1)-->(3)
- │    │    └── const: 5 [type=int]
- │    └── const: 10 [type=int]
+ │    │    └── fd: (1)-->(3)
+ │    └── const: 5 [type=int]
  └── projections
       └── f * 2.0 [type=float, outer=(3)]
 
@@ -360,15 +352,16 @@ project
  ├── columns: f:3(float) r:6(float)
  ├── cardinality: [0 - 10]
  ├── ordering: +3
- ├── limit
+ ├── offset
  │    ├── columns: i:2(int) f:3(float)
  │    ├── internal-ordering: +3
  │    ├── cardinality: [0 - 10]
  │    ├── key: (2,3)
  │    ├── ordering: +3
- │    ├── offset
+ │    ├── limit
  │    │    ├── columns: i:2(int) f:3(float)
  │    │    ├── internal-ordering: +3
+ │    │    ├── cardinality: [0 - 15]
  │    │    ├── key: (2,3)
  │    │    ├── ordering: +3
  │    │    ├── distinct-on
@@ -381,7 +374,103 @@ project
  │    │    │         ├── ordering: +3
  │    │    │         └── scan a
  │    │    │              └── columns: i:2(int) f:3(float)
- │    │    └── const: 5 [type=int]
- │    └── const: 10 [type=int]
+ │    │    └── const: 15 [type=int]
+ │    └── const: 5 [type=int]
  └── projections
       └── f + 1.1 [type=float, outer=(3)]
+
+# --------------------------------------------------
+# PushLimitIntoOffset
+# --------------------------------------------------
+
+opt expect=(PushLimitIntoOffset)
+SELECT k, i FROM a LIMIT 10 OFFSET 10
+----
+offset
+ ├── columns: k:1(int!null) i:2(int)
+ ├── cardinality: [0 - 10]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int)
+ │    ├── limit: 20
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ └── const: 10 [type=int]
+
+opt expect=(PushLimitIntoOffset)
+SELECT k, i FROM a OFFSET 10 LIMIT 10
+----
+offset
+ ├── columns: k:1(int!null) i:2(int)
+ ├── cardinality: [0 - 10]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int)
+ │    ├── limit: 20
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ └── const: 10 [type=int]
+
+# Limit can be pushed into the ordering if they have the same ordering.
+opt expect=(PushLimitIntoOffset)
+SELECT k, i FROM (SELECT k, i FROM a ORDER BY i OFFSET 20) ORDER BY i LIMIT 10
+----
+offset
+ ├── columns: k:1(int!null) i:2(int)
+ ├── internal-ordering: +2
+ ├── cardinality: [0 - 10]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── ordering: +2
+ ├── limit
+ │    ├── columns: k:1(int!null) i:2(int)
+ │    ├── internal-ordering: +2
+ │    ├── cardinality: [0 - 30]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    ├── ordering: +2
+ │    ├── sort
+ │    │    ├── columns: k:1(int!null) i:2(int)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2)
+ │    │    ├── ordering: +2
+ │    │    └── scan a
+ │    │         ├── columns: k:1(int!null) i:2(int)
+ │    │         ├── key: (1)
+ │    │         └── fd: (1)-->(2)
+ │    └── const: 30 [type=int]
+ └── const: 20 [type=int]
+
+opt expect-not=(PushLimitIntoOffset)
+SELECT k, i FROM (SELECT k, i FROM a ORDER BY i OFFSET 20) ORDER BY i DESC LIMIT 10
+----
+limit
+ ├── columns: k:1(int!null) i:2(int)
+ ├── internal-ordering: -2
+ ├── cardinality: [0 - 10]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── ordering: -2
+ ├── sort
+ │    ├── columns: k:1(int!null) i:2(int)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    ├── ordering: -2
+ │    └── offset
+ │         ├── columns: k:1(int!null) i:2(int)
+ │         ├── internal-ordering: +2
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2)
+ │         ├── sort
+ │         │    ├── columns: k:1(int!null) i:2(int)
+ │         │    ├── key: (1)
+ │         │    ├── fd: (1)-->(2)
+ │         │    ├── ordering: +2
+ │         │    └── scan a
+ │         │         ├── columns: k:1(int!null) i:2(int)
+ │         │         ├── key: (1)
+ │         │         └── fd: (1)-->(2)
+ │         └── const: 20 [type=int]
+ └── const: 10 [type=int]

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -538,15 +538,16 @@ project
  ├── columns: k:1(int!null)
  ├── cardinality: [0 - 10]
  ├── key: (1)
- └── limit
+ └── offset
       ├── columns: k:1(int!null) i:2(int)
       ├── internal-ordering: +2
       ├── cardinality: [0 - 10]
       ├── key: (1)
       ├── fd: (1)-->(2)
-      ├── offset
+      ├── limit
       │    ├── columns: k:1(int!null) i:2(int)
       │    ├── internal-ordering: +2
+      │    ├── cardinality: [0 - 20]
       │    ├── key: (1)
       │    ├── fd: (1)-->(2)
       │    ├── ordering: +2
@@ -559,7 +560,7 @@ project
       │    │         ├── columns: k:1(int!null) i:2(int)
       │    │         ├── key: (1)
       │    │         └── fd: (1)-->(2)
-      │    └── const: 10 [type=int]
+      │    └── const: 20 [type=int]
       └── const: 10 [type=int]
 
 # We should scan k, i, s.
@@ -569,15 +570,16 @@ SELECT s FROM (SELECT k, i, f, s FROM a ORDER BY i, k LIMIT 10 OFFSET 10)
 project
  ├── columns: s:4(string)
  ├── cardinality: [0 - 10]
- └── limit
+ └── offset
       ├── columns: k:1(int!null) i:2(int) s:4(string)
       ├── internal-ordering: +2,+1
       ├── cardinality: [0 - 10]
       ├── key: (1)
       ├── fd: (1)-->(2,4)
-      ├── offset
+      ├── limit
       │    ├── columns: k:1(int!null) i:2(int) s:4(string)
       │    ├── internal-ordering: +2,+1
+      │    ├── cardinality: [0 - 20]
       │    ├── key: (1)
       │    ├── fd: (1)-->(2,4)
       │    ├── ordering: +2,+1
@@ -590,7 +592,7 @@ project
       │    │         ├── columns: k:1(int!null) i:2(int) s:4(string)
       │    │         ├── key: (1)
       │    │         └── fd: (1)-->(2,4)
-      │    └── const: 10 [type=int]
+      │    └── const: 20 [type=int]
       └── const: 10 [type=int]
 
 # We should scan k, i, s.
@@ -602,15 +604,16 @@ project
  ├── cardinality: [0 - 10]
  ├── key: (1)
  ├── fd: (1)-->(4)
- └── limit
+ └── offset
       ├── columns: k:1(int!null) i:2(int) s:4(string)
       ├── internal-ordering: +2,+1
       ├── cardinality: [0 - 10]
       ├── key: (1)
       ├── fd: (1)-->(2,4)
-      ├── offset
+      ├── limit
       │    ├── columns: k:1(int!null) i:2(int) s:4(string)
       │    ├── internal-ordering: +2,+1
+      │    ├── cardinality: [0 - 20]
       │    ├── key: (1)
       │    ├── fd: (1)-->(2,4)
       │    ├── ordering: +2,+1
@@ -623,7 +626,7 @@ project
       │    │         ├── columns: k:1(int!null) i:2(int) s:4(string)
       │    │         ├── key: (1)
       │    │         └── fd: (1)-->(2,4)
-      │    └── const: 10 [type=int]
+      │    └── const: 20 [type=int]
       └── const: 10 [type=int]
 
 # Project filter offset/limit columns, but can't push all the way down to scan.
@@ -633,12 +636,13 @@ SELECT f, f*2.0 AS r FROM (SELECT f, s FROM a GROUP BY f, s OFFSET 5 LIMIT 5) a
 project
  ├── columns: f:3(float) r:5(float)
  ├── cardinality: [0 - 5]
- ├── limit
+ ├── offset
  │    ├── columns: f:3(float) s:4(string)
  │    ├── cardinality: [0 - 5]
  │    ├── key: (3,4)
- │    ├── offset
+ │    ├── limit
  │    │    ├── columns: f:3(float) s:4(string)
+ │    │    ├── cardinality: [0 - 10]
  │    │    ├── key: (3,4)
  │    │    ├── distinct-on
  │    │    │    ├── columns: f:3(float) s:4(string)
@@ -646,7 +650,7 @@ project
  │    │    │    ├── key: (3,4)
  │    │    │    └── scan a
  │    │    │         └── columns: f:3(float) s:4(string)
- │    │    └── const: 5 [type=int]
+ │    │    └── const: 10 [type=int]
  │    └── const: 5 [type=int]
  └── projections
       └── f * 2.0 [type=float, outer=(3)]

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -516,12 +516,6 @@ func (c *CustomFuncs) canMaybeConstrainIndex(
 //
 // ----------------------------------------------------------------------
 
-// IsPositiveLimit is true if the given limit value is greater than zero.
-func (c *CustomFuncs) IsPositiveLimit(limit tree.Datum) bool {
-	limitVal := int64(*limit.(*tree.DInt))
-	return limitVal > 0
-}
-
 // LimitScanPrivate constructs a new ScanPrivate value that is based on the
 // given ScanPrivate. The new private's HardLimit is set to the given limit,
 // which must be a constant int datum value. The other fields are inherited from

--- a/pkg/sql/opt/xform/testdata/external/customer
+++ b/pkg/sql/opt/xform/testdata/external/customer
@@ -416,23 +416,18 @@ EXPLAIN SELECT id FROM test ORDER BY id asc LIMIT 10 offset 10000;
 ----
 explain
  ├── columns: tree:4(string) field:5(string) description:6(string)
- └── limit
+ └── offset
       ├── columns: id:1(int!null)
       ├── internal-ordering: +1
       ├── cardinality: [0 - 10]
       ├── key: (1)
       ├── ordering: +1
-      ├── offset
+      ├── scan test
       │    ├── columns: id:1(int!null)
-      │    ├── internal-ordering: +1
+      │    ├── limit: 10010
       │    ├── key: (1)
-      │    ├── ordering: +1
-      │    ├── scan test
-      │    │    ├── columns: id:1(int!null)
-      │    │    ├── key: (1)
-      │    │    └── ordering: +1
-      │    └── const: 10000 [type=int]
-      └── const: 10 [type=int]
+      │    └── ordering: +1
+      └── const: 10000 [type=int]
 
 # ------------------------------------------------------------------------------
 # Github Issue 17270: Use the o_ok index rather than the primary index, since

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -430,3 +430,59 @@ Final best expression
         │         └── filters
         │              └── (a >= 20) AND (a <= 30) [type=bool, outer=(1), constraints=(/1: [/20 - /30]; tight)]
         └── const: 5 [type=int]
+
+# --------------------------------------------------
+# PushLimitIntoOffset + GenerateLimitedScans
+# --------------------------------------------------
+
+# Regression testing for #30416.
+# The limit is pushed down the offset and so an appropriate index scan is used
+# over a primary key scan.
+opt
+SELECT * from a ORDER BY s LIMIT 10 OFFSET 10
+----
+offset
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── internal-ordering: +4
+ ├── cardinality: [0 - 10]
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── ordering: +4
+ ├── index-join a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── cardinality: [0 - 20]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-5)
+ │    ├── ordering: +4
+ │    └── scan a@s_idx
+ │         ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
+ │         ├── limit: 20
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2-4)
+ │         └── ordering: +4
+ └── const: 10 [type=int]
+
+# The right index is used for the limited scan based on the order.
+opt
+SELECT * from a ORDER BY s DESC LIMIT 10 OFFSET 10
+----
+offset
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── internal-ordering: -4
+ ├── cardinality: [0 - 10]
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── ordering: -4
+ ├── index-join a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── cardinality: [0 - 20]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-5)
+ │    ├── ordering: -4
+ │    └── scan a@si_idx
+ │         ├── columns: k:1(int!null) i:2(int) s:4(string) j:5(jsonb)
+ │         ├── limit: 20
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2,4,5)
+ │         └── ordering: -4
+ └── const: 10 [type=int]


### PR DESCRIPTION
This change pushes the limit into an offset whenever possible.
This shouldn't worsen any plan but does allow the `GetLimitedScans`
rule to fire in more scenarios.

Fixes #30416.
~~This is currently blocked on #38659.~~

Release note: None