### PR TITLE
exec: handle nulls in SUM aggregator

### DIFF
--- a/pkg/sql/exec/aggregator_test.go
+++ b/pkg/sql/exec/aggregator_test.go
@@ -414,18 +414,20 @@ func TestAggregatorAllFunctions(t *testing.T) {
 				distsqlpb.AggregatorSpec_ANY_NOT_NULL,
 				distsqlpb.AggregatorSpec_COUNT_ROWS,
 				distsqlpb.AggregatorSpec_COUNT,
+				distsqlpb.AggregatorSpec_SUM,
+				distsqlpb.AggregatorSpec_SUM_INT,
 			},
-			aggCols:  [][]uint32{{0}, {1}, {}, {1}},
-			colTypes: []types.T{types.Int64, types.Decimal},
+			aggCols:  [][]uint32{{0}, {1}, {}, {1}, {1}, {2}},
+			colTypes: []types.T{types.Int64, types.Decimal, types.Int64},
 			input: tuples{
-				{0, nil},
-				{0, 3.1},
-				{1, nil},
-				{1, nil},
+				{0, nil, nil},
+				{0, 3.1, 5},
+				{1, nil, nil},
+				{1, nil, nil},
 			},
 			expected: tuples{
-				{0, 3.1, 2, 1},
-				{1, nil, 2, 0},
+				{0, 3.1, 2, 1, 3.1, 5},
+				{1, nil, 2, 0, nil, nil},
 			},
 			convToDecimal: true,
 		},
@@ -587,12 +589,12 @@ func BenchmarkAggregator(b *testing.B) {
 										case types.Int64:
 											vals := cols[1].Int64()
 											for i := range vals {
-												vals[i] = rng.Int63()
+												vals[i] = rng.Int63() % 1024
 											}
 										case types.Decimal:
 											vals := cols[1].Decimal()
 											for i := range vals {
-												vals[i].SetInt64(rng.Int63())
+												vals[i].SetInt64(rng.Int63() % 1024)
 											}
 										}
 										source := newChunkingBatchSource(colTypes, cols, uint64(nTuples))

--- a/pkg/sql/exec/execgen/cmd/execgen/sum_agg_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/sum_agg_gen.go
@@ -34,9 +34,12 @@ func genSumAgg(wr io.Writer) error {
 	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
 
 	assignAddRe := regexp.MustCompile(`_ASSIGN_ADD\((.*),(.*),(.*)\)`)
-	s = assignAddRe.ReplaceAllString(s, "{{.Assign $1 $2 $3}}")
+	s = assignAddRe.ReplaceAllString(s, "{{.Global.Assign $1 $2 $3}}")
 
-	tmpl, err := template.New("sum_agg").Parse(s)
+	accumulateSum := makeFunctionRegex("_ACCUMULATE_SUM", 4)
+	s = accumulateSum.ReplaceAllString(s, `{{template "accumulateSum" buildDict "Global" . "HasNulls" $4}}`)
+
+	tmpl, err := template.New("sum_agg").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)
 	if err != nil {
 		return err
 	}

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -111,7 +111,7 @@ func TestLint(t *testing.T) {
 		}
 
 		cmd, stderr, filter, err := dirCmd(crdb.Dir,
-			"git", "grep", "-nE", fmt.Sprintf(`[^a-zA-Z](%s)\(`, strings.Join(names, "|")),
+			"git", "grep", "-nE", fmt.Sprintf(`[^_a-zA-Z](%s)\(`, strings.Join(names, "|")),
 			"--", "pkg")
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
#37738

This also fixes a bug in the linter that disallowed function names that ended in "_SUM" (or any other SQL builtin).

```
BenchmarkAggregator/SUM/hash/Int64/groupSize=1/hasNulls=false/numInputBatches=64-12         	     200	   6095258 ns/op	  86.02 MB/s
BenchmarkAggregator/SUM/hash/Int64/groupSize=1/hasNulls=true/numInputBatches=64-12          	     200	   6465476 ns/op	  81.09 MB/s
BenchmarkAggregator/SUM/hash/Int64/groupSize=2/hasNulls=false/numInputBatches=64-12         	     300	   4837380 ns/op	 108.38 MB/s
BenchmarkAggregator/SUM/hash/Int64/groupSize=2/hasNulls=true/numInputBatches=64-12          	     300	   5151080 ns/op	 101.78 MB/s
BenchmarkAggregator/SUM/hash/Int64/groupSize=512/hasNulls=false/numInputBatches=64-12       	     300	   4322493 ns/op	 121.29 MB/s
BenchmarkAggregator/SUM/hash/Int64/groupSize=512/hasNulls=true/numInputBatches=64-12        	     300	   4526874 ns/op	 115.82 MB/s
BenchmarkAggregator/SUM/hash/Int64/groupSize=1024/hasNulls=false/numInputBatches=64-12      	     300	   4917740 ns/op	 106.61 MB/s
BenchmarkAggregator/SUM/hash/Int64/groupSize=1024/hasNulls=true/numInputBatches=64-12       	     300	   5160806 ns/op	 101.59 MB/s
BenchmarkAggregator/SUM/hash/Decimal/groupSize=1/hasNulls=false/numInputBatches=64-12       	     100	  12126844 ns/op	  43.23 MB/s
BenchmarkAggregator/SUM/hash/Decimal/groupSize=1/hasNulls=true/numInputBatches=64-12        	     100	  12072660 ns/op	  43.43 MB/s
BenchmarkAggregator/SUM/hash/Decimal/groupSize=2/hasNulls=false/numInputBatches=64-12       	     100	  11360138 ns/op	  46.15 MB/s
BenchmarkAggregator/SUM/hash/Decimal/groupSize=2/hasNulls=true/numInputBatches=64-12        	     100	  10978747 ns/op	  47.75 MB/s
BenchmarkAggregator/SUM/hash/Decimal/groupSize=512/hasNulls=false/numInputBatches=64-12     	     200	   8444183 ns/op	  62.09 MB/s
BenchmarkAggregator/SUM/hash/Decimal/groupSize=512/hasNulls=true/numInputBatches=64-12      	     200	   8336102 ns/op	  62.89 MB/s
BenchmarkAggregator/SUM/hash/Decimal/groupSize=1024/hasNulls=false/numInputBatches=64-12    	     200	   8827151 ns/op	  59.39 MB/s
BenchmarkAggregator/SUM/hash/Decimal/groupSize=1024/hasNulls=true/numInputBatches=64-12     	     200	   8888790 ns/op	  58.98 MB/s
BenchmarkAggregator/SUM/ordered/Int64/groupSize=1/hasNulls=false/numInputBatches=64-12      	    5000	    228665 ns/op	2292.81 MB/s
BenchmarkAggregator/SUM/ordered/Int64/groupSize=1/hasNulls=true/numInputBatches=64-12       	    3000	    422119 ns/op	1242.04 MB/s
BenchmarkAggregator/SUM/ordered/Int64/groupSize=2/hasNulls=false/numInputBatches=64-12      	   10000	    177137 ns/op	2959.77 MB/s
BenchmarkAggregator/SUM/ordered/Int64/groupSize=2/hasNulls=true/numInputBatches=64-12       	    5000	    272328 ns/op	1925.20 MB/s
BenchmarkAggregator/SUM/ordered/Int64/groupSize=512/hasNulls=false/numInputBatches=64-12    	   10000	    141346 ns/op	3709.24 MB/s
BenchmarkAggregator/SUM/ordered/Int64/groupSize=512/hasNulls=true/numInputBatches=64-12     	   10000	    205630 ns/op	2549.67 MB/s
BenchmarkAggregator/SUM/ordered/Int64/groupSize=1024/hasNulls=false/numInputBatches=64-12   	   10000	    141788 ns/op	3697.68 MB/s
BenchmarkAggregator/SUM/ordered/Int64/groupSize=1024/hasNulls=true/numInputBatches=64-12    	   10000	    208656 ns/op	2512.69 MB/s
BenchmarkAggregator/SUM/ordered/Decimal/groupSize=1/hasNulls=false/numInputBatches=64-12    	     300	   5815546 ns/op	  90.15 MB/s
BenchmarkAggregator/SUM/ordered/Decimal/groupSize=1/hasNulls=true/numInputBatches=64-12     	     300	   5522915 ns/op	  94.93 MB/s
BenchmarkAggregator/SUM/ordered/Decimal/groupSize=2/hasNulls=false/numInputBatches=64-12    	     200	   5997226 ns/op	  87.42 MB/s
BenchmarkAggregator/SUM/ordered/Decimal/groupSize=2/hasNulls=true/numInputBatches=64-12     	     300	   5557627 ns/op	  94.34 MB/s
BenchmarkAggregator/SUM/ordered/Decimal/groupSize=512/hasNulls=false/numInputBatches=64-12  	     500	   3785368 ns/op	 138.50 MB/s
BenchmarkAggregator/SUM/ordered/Decimal/groupSize=512/hasNulls=true/numInputBatches=64-12   	     500	   3514339 ns/op	 149.19 MB/s
BenchmarkAggregator/SUM/ordered/Decimal/groupSize=1024/hasNulls=false/numInputBatches=64-12 	     500	   3738858 ns/op	 140.23 MB/s
BenchmarkAggregator/SUM/ordered/Decimal/groupSize=1024/hasNulls=true/numInputBatches=64-12  	     500	   3390263 ns/op	 154.65 MB/s
```

Release note: None