### PR TITLE
distsqlplan: bugfix to planning offsets on top of limits

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/limit
+++ b/pkg/sql/logictest/testdata/logic_test/limit
@@ -151,3 +151,15 @@ query I
 SELECT SPAN FROM [SHOW TRACE FOR SESSION] WHERE span = 1 LIMIT 1
 ----
 1
+
+# Regression test for #38659: offset on top of limit was broken.
+
+query I
+SELECT * FROM (select * from generate_series(1,10) a LIMIT 5) OFFSET 3
+----
+4
+5
+
+query I
+SELECT * FROM (select * from generate_series(1,10) a LIMIT 5) OFFSET 6
+----


### PR DESCRIPTION
Fixes #38659.

DistSQL physical planning removes limitNodes when it can, by pushing the
embedded limit and offset into the most recent processor's
PostProcessSpec when possible.

This was previously buggy, when trying to plan an offset on top of a
processor that already had a limit inside, because the code simply set
the offset on the processor without regard for the fact that offsets are
always applied first at runtime, before limits.

Release note (bug fix): correct issue that caused certain plans that
contained both offsets and limits to return more rows than desired.