### PR TITLE
scripts: remove Windows link from generated release notes

### DIFF
--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -768,7 +768,6 @@ if not hidedownloads:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-""" + current_version + """.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-""" + current_version + """.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-""" + current_version + """.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-""" + current_version + """.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 """)


### PR DESCRIPTION
This is an extenson of https://github.com/cockroachdb/docs/issues/4935,
where we've de-emphasized running on Windows.

Fixes https://github.com/cockroachdb/docs/issues/5019.

Release note: None