### PR TITLE
roachtest: fix teamcity artifacts dir

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -575,8 +575,8 @@ func (r *testRunner) runTest(
 		if teamCity {
 			shout(ctx, l, stdout, "##teamcity[testFinished name='%s' flowId='%s']", t.Name(), t.Name())
 
+			artifactsGlobPath := filepath.Join(artifactsDir, "**")
 			escapedTestName := teamCityNameEscape(t.Name())
-			artifactsGlobPath := filepath.Join(artifactsDir, escapedTestName, "**")
 			artifactsSpec := fmt.Sprintf("%s => %s", artifactsGlobPath, escapedTestName)
 			shout(ctx, l, stdout, "##teamcity[publishArtifacts '%s']", artifactsSpec)
 		}


### PR DESCRIPTION
The path we published in the teamcity artifacts collection directive was
wrong (included the test name twice) and so we weren't collecting any
artifacts.

Release note: None