### PR TITLE
roachtest: fix test skip message for teamcity

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -389,7 +389,7 @@ func testsToRun(ctx context.Context, r testRegistry, filter *testFilter) []testS
 		} else {
 			if teamCity {
 				fmt.Fprintf(os.Stdout, "##teamcity[testIgnored name='%s' message='%s']\n",
-					s.Name, s.Skip)
+					s.Name, teamCityEscape(s.Skip))
 			}
 			fmt.Fprintf(os.Stdout, "--- SKIP: %s (%s)\n\t%s\n", s.Name, "0.00s", s.Skip)
 		}


### PR DESCRIPTION
We weren't escaping a part of a teamcity directive causing it to fail to
parse the skip message for some tests.

Release note: None