### PR TITLE
errors: fix the formatting with %+v

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -376,7 +376,7 @@
   revision = "edce558372380347c6fef147e62f5559a9f8413d"
 
 [[projects]]
-  digest = "1:6b5e345345b4cf676295f7ab95b5f024ad24deac577882012abef561ae150daa"
+  digest = "1:89001b96f00cd27fe64ffca49eb6434e80677d9aa39a98d8e4eeab166c0a3d44"
   name = "github.com/cockroachdb/errors"
   packages = [
     ".",
@@ -399,8 +399,8 @@
     "withstack",
   ]
   pruneopts = "UT"
-  revision = "27e2233ae32c6bd067736ebb257682451b89cd76"
-  version = "v1.1.1"
+  revision = "733db073f39e36d451b4d1186edcf4005f6d7ac7"
+  version = "v1.2.1"
 
 [[projects]]
   digest = "1:cd936a7edd1897083994b6d397f9c975a5a8dc58e845f0cf3d1e5cf4717b918b"
@@ -2037,6 +2037,7 @@
     "google.golang.org/grpc/connectivity",
     "google.golang.org/grpc/credentials",
     "google.golang.org/grpc/encoding",
+    "google.golang.org/grpc/encoding/proto",
     "google.golang.org/grpc/grpclog",
     "google.golang.org/grpc/health/grpc_health_v1",
     "google.golang.org/grpc/keepalive",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -376,7 +376,7 @@
   revision = "edce558372380347c6fef147e62f5559a9f8413d"
 
 [[projects]]
-  digest = "1:89001b96f00cd27fe64ffca49eb6434e80677d9aa39a98d8e4eeab166c0a3d44"
+  digest = "1:a644806453a927ccc2812bcfecf67f5d5adc7ca2e5e582b6c799a3aabe988433"
   name = "github.com/cockroachdb/errors"
   packages = [
     ".",
@@ -399,8 +399,8 @@
     "withstack",
   ]
   pruneopts = "UT"
-  revision = "733db073f39e36d451b4d1186edcf4005f6d7ac7"
-  version = "v1.2.1"
+  revision = "cd8b61c67a5cb6d94573c7eacb27227cf169814f"
+  version = "v1.2.2"
 
 [[projects]]
   digest = "1:cd936a7edd1897083994b6d397f9c975a5a8dc58e845f0cf3d1e5cf4717b918b"
@@ -1896,11 +1896,7 @@
     "github.com/cockroachdb/crlfmt",
     "github.com/cockroachdb/datadriven",
     "github.com/cockroachdb/errors",
-    "github.com/cockroachdb/errors/assert",
-    "github.com/cockroachdb/errors/errbase",
     "github.com/cockroachdb/errors/errorspb",
-    "github.com/cockroachdb/errors/issuelink",
-    "github.com/cockroachdb/errors/markers",
     "github.com/cockroachdb/errors/testutils",
     "github.com/cockroachdb/gostdlib/cmd/gofmt",
     "github.com/cockroachdb/gostdlib/x/tools/cmd/goimports",

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -35,9 +35,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
-	"github.com/cockroachdb/errors/markers"
-	"github.com/opentracing/opentracing-go"
-	"github.com/pkg/errors"
+	"github.com/cockroachdb/errors"
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 // To allow queries to send out flow RPCs in parallel, we use a pool of workers
@@ -169,7 +168,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 		// into the local flow.
 	}
 	if firstErr != nil {
-		if _, ok := markers.If(firstErr, func(err error) (v interface{}, ok bool) {
+		if _, ok := errors.If(firstErr, func(err error) (v interface{}, ok bool) {
 			v, ok = err.(*distsqlrun.VectorizedSetupError)
 			return v, ok
 		}); ok && evalCtx.SessionData.Vectorize == sessiondata.VectorizeOn {

--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -946,13 +946,24 @@ type VectorizedSetupError struct {
 	cause error
 }
 
-// Error is part of the error interface.
-func (e *VectorizedSetupError) Error() string {
-	return e.cause.Error()
-}
+var _ error = (*VectorizedSetupError)(nil)
+var _ fmt.Formatter = (*VectorizedSetupError)(nil)
+var _ errors.Formatter = (*VectorizedSetupError)(nil)
 
-// Unwrap is part of the Wrapper interface.
-func (e *VectorizedSetupError) Unwrap() error {
+// Error implemented the error interface.
+func (e *VectorizedSetupError) Error() string { return e.cause.Error() }
+
+// Cause implements the causer interface.
+func (e *VectorizedSetupError) Cause() error { return e.cause }
+
+// Format implements the fmt.Formatter interface.
+func (e *VectorizedSetupError) Format(s fmt.State, verb rune) { errors.FormatError(e, s, verb) }
+
+// FormatError implements the errors.Formatter interface.
+func (e *VectorizedSetupError) FormatError(p errors.Printer) error {
+	if p.Detail() {
+		p.Print("error while setting up columnar execution")
+	}
 	return e.cause
 }
 

--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/errors/errbase"
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
@@ -974,7 +973,7 @@ func decodeVectorizedSetupError(
 }
 
 func init() {
-	errors.RegisterWrapperDecoder(errbase.GetTypeKey((*VectorizedSetupError)(nil)), decodeVectorizedSetupError)
+	errors.RegisterWrapperDecoder(errors.GetTypeKey((*VectorizedSetupError)(nil)), decodeVectorizedSetupError)
 }
 
 func (f *Flow) setupVectorized(ctx context.Context) error {

--- a/pkg/sql/distsqlrun/scrub_tablereader.go
+++ b/pkg/sql/distsqlrun/scrub_tablereader.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/pkg/errors"
+	"github.com/cockroachdb/errors"
 )
 
 // ScrubTypes is the schema for TableReaders that are doing a SCRUB
@@ -250,8 +250,8 @@ func (tr *scrubTableReader) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMeta
 		//
 		// NB: Cases 3 and 4 are handled further below, in the standard
 		// table scanning code path.
-		err = errors.Cause(err)
-		if v, ok := err.(*scrub.Error); ok {
+		var v *scrub.Error
+		if errors.As(err, &v) {
 			row, err = tr.generateScrubErrorRow(row, v)
 		} else if err == nil && row != nil {
 			continue

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -12,6 +12,7 @@ package optbuilder
 
 import (
 	"context"
+	"fmt"
 	"runtime"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/delegate"
@@ -21,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+	"github.com/cockroachdb/errors"
 )
 
 // Builder holds the context needed for building a memo structure from a SQL
@@ -181,6 +183,9 @@ func (b builderError) Error() string { return b.error.Error() }
 // Cause implements the causer interface. This is used so that builderErrors
 // can be peeked through by the common error facilities.
 func (b builderError) Cause() error { return b.error }
+
+// Format implements the fmt.Formatter interface.
+func (b builderError) Format(s fmt.State, verb rune) { errors.FormatError(b, s, verb) }
 
 // unimplementedWithIssueDetailf formats according to a format
 // specifier and returns a Postgres error with the

--- a/pkg/sql/pgwire/pgerror/errors.go
+++ b/pkg/sql/pgwire/pgerror/errors.go
@@ -20,13 +20,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/errors/hintdetail"
 	"github.com/lib/pq"
 )
 
 var _ error = (*Error)(nil)
-var _ hintdetail.ErrorHinter = (*Error)(nil)
-var _ hintdetail.ErrorDetailer = (*Error)(nil)
+var _ errors.ErrorHinter = (*Error)(nil)
+var _ errors.ErrorDetailer = (*Error)(nil)
 var _ errors.SafeDetailer = (*Error)(nil)
 var _ fmt.Formatter = (*Error)(nil)
 

--- a/pkg/sql/pgwire/pgerror/errors.go
+++ b/pkg/sql/pgwire/pgerror/errors.go
@@ -20,10 +20,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/errors/hintdetail"
 	"github.com/lib/pq"
 )
 
-var _ error = &Error{}
+var _ error = (*Error)(nil)
+var _ hintdetail.ErrorHinter = (*Error)(nil)
+var _ hintdetail.ErrorDetailer = (*Error)(nil)
+var _ errors.SafeDetailer = (*Error)(nil)
+var _ fmt.Formatter = (*Error)(nil)
 
 // Error implements the error interface.
 func (pg *Error) Error() string { return pg.Message }
@@ -119,7 +124,7 @@ var _ fmt.Formatter = &Error{}
 
 // Format implements the fmt.Formatter interface.
 //
-// %v/%s prints the rror as usual.
+// %v/%s prints the error as usual.
 // %#v adds the pg error code at the beginning.
 // %+v prints all the details, including the embedded stack traces.
 func (pg *Error) Format(s fmt.State, verb rune) {

--- a/pkg/sql/pgwire/pgerror/internal_errors_test.go
+++ b/pkg/sql/pgwire/pgerror/internal_errors_test.go
@@ -94,7 +94,7 @@ func TestInternalError(t *testing.T) {
 				{"safedetail", func(t *testing.T, e *Error) {
 					m(t, e.SafeDetail[0].SafeMessage, `.*TestInternalError.*`)
 					m(t, e.SafeDetail[1].SafeMessage, `woo %s`)
-					m(t, e.SafeDetail[2].SafeMessage, `arg 0: string`)
+					m(t, e.SafeDetail[2].SafeMessage, `arg 1: <string>`)
 				}},
 
 				// Verify that formatting works.
@@ -109,7 +109,7 @@ func TestInternalError(t *testing.T) {
 							ie+"woo waa")
 					// Safe message.
 					m(t, vErr, "woo %s")
-					m(t, vErr, "arg 0: string")
+					m(t, vErr, "arg 1: <string>")
 				}},
 			},
 		},
@@ -119,7 +119,7 @@ func TestInternalError(t *testing.T) {
 				// Verify that safe details are preserved.
 				{"safedetail", func(t *testing.T, e *Error) {
 					m(t, e.SafeDetail[1].SafeMessage, `safe %s`)
-					m(t, e.SafeDetail[2].SafeMessage, `arg 0: waa`)
+					m(t, e.SafeDetail[2].SafeMessage, `arg 1: waa`)
 				}},
 			},
 		},
@@ -262,7 +262,7 @@ func TestInternalError(t *testing.T) {
 					)
 					m(t, e.SafeDetail[0].SafeMessage, pgcode.AdminShutdown)
 					m(t, e.SafeDetail[2].SafeMessage, `wrap %s`)
-					m(t, e.SafeDetail[3].SafeMessage, `arg 0: string`)
+					m(t, e.SafeDetail[3].SafeMessage, `arg 1: <string>`)
 					m(t, e.SafeDetail[5].SafeMessage, `boo`)
 				}},
 			},
@@ -292,7 +292,7 @@ func TestInternalError(t *testing.T) {
 					)
 					m(t, e.SafeDetail[0].SafeMessage, "TestInternalError")
 					m(t, e.SafeDetail[1].SafeMessage, `iewrap %s`)
-					m(t, e.SafeDetail[2].SafeMessage, `arg 0: string`)
+					m(t, e.SafeDetail[2].SafeMessage, `arg 1: <string>`)
 				}},
 			},
 		},

--- a/pkg/sql/pgwire/pgerror/pgcode.go
+++ b/pkg/sql/pgwire/pgerror/pgcode.go
@@ -14,10 +14,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
-	"github.com/cockroachdb/errors/assert"
-	"github.com/cockroachdb/errors/errbase"
-	"github.com/cockroachdb/errors/issuelink"
-	"github.com/cockroachdb/errors/markers"
+	"github.com/cockroachdb/errors"
 )
 
 // WithCandidateCode decorates the error with a candidate postgres
@@ -42,7 +39,7 @@ func IsCandidateCode(err error) bool {
 // HasCandidateCode returns tue iff the error or one of its causes
 // has a candidate pg error code.
 func HasCandidateCode(err error) bool {
-	_, ok := markers.If(err, func(err error) (v interface{}, ok bool) {
+	_, ok := errors.If(err, func(err error) (v interface{}, ok bool) {
 		v, ok = err.(*withCandidateCode)
 		return
 	})
@@ -80,7 +77,7 @@ func GetPGCodeInternal(err error, computeDefaultCode func(err error) (code strin
 		code = newCode
 	}
 
-	if c := errbase.UnwrapOnce(err); c != nil {
+	if c := errors.UnwrapOnce(err); c != nil {
 		innerCode := GetPGCodeInternal(c, computeDefaultCode)
 		code = combineCodes(innerCode, code)
 	}
@@ -107,10 +104,10 @@ func ComputeDefaultCode(err error) string {
 		return pgcode.StatementCompletionUnknown
 	}
 
-	if assert.IsAssertionFailure(err) {
+	if errors.IsAssertionFailure(err) {
 		return pgcode.Internal
 	}
-	if issuelink.IsUnimplementedError(err) {
+	if errors.IsUnimplementedError(err) {
 		return pgcode.FeatureNotSupported
 	}
 	return ""

--- a/pkg/sql/pgwire/pgerror/with_candidate_code.go
+++ b/pkg/sql/pgwire/pgerror/with_candidate_code.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/errors/errbase"
 )
 
 type withCandidateCode struct {
@@ -55,5 +54,5 @@ func decodeWithCandidateCode(
 }
 
 func init() {
-	errbase.RegisterWrapperDecoder(errbase.GetTypeKey((*withCandidateCode)(nil)), decodeWithCandidateCode)
+	errors.RegisterWrapperDecoder(errors.GetTypeKey((*withCandidateCode)(nil)), decodeWithCandidateCode)
 }

--- a/pkg/sql/pgwire/pgerror/with_candidate_code.go
+++ b/pkg/sql/pgwire/pgerror/with_candidate_code.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/errbase"
 )
 
@@ -24,23 +25,23 @@ type withCandidateCode struct {
 	code  string
 }
 
+var _ error = (*withCandidateCode)(nil)
+var _ errors.SafeDetailer = (*withCandidateCode)(nil)
+var _ fmt.Formatter = (*withCandidateCode)(nil)
+var _ errors.Formatter = (*withCandidateCode)(nil)
+
 func (w *withCandidateCode) Error() string         { return w.cause.Error() }
 func (w *withCandidateCode) Cause() error          { return w.cause }
 func (w *withCandidateCode) Unwrap() error         { return w.cause }
 func (w *withCandidateCode) SafeDetails() []string { return []string{w.code} }
 
-func (w *withCandidateCode) Format(s fmt.State, verb rune) {
-	switch verb {
-	case 'v':
-		if s.Flag('+') {
-			fmt.Fprintf(s, "%+v", w.cause)
-			fmt.Fprintf(s, "\n-- candidate pg code: %s", w.code)
-			return
-		}
-		fallthrough
-	case 's', 'q':
-		errbase.FormatError(s, verb, w.cause)
+func (w *withCandidateCode) Format(s fmt.State, verb rune) { errors.FormatError(w, s, verb) }
+
+func (w *withCandidateCode) FormatError(p errors.Printer) (next error) {
+	if p.Detail() {
+		p.Printf("candidate pg code: %s", w.code)
 	}
+	return w.cause
 }
 
 func decodeWithCandidateCode(

--- a/pkg/sql/scrub/errors.go
+++ b/pkg/sql/scrub/errors.go
@@ -10,7 +10,11 @@
 
 package scrub
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/cockroachdb/errors"
+)
 
 const (
 	// MissingIndexEntryError occurs when a primary k/v is missing a
@@ -49,6 +53,14 @@ type Error struct {
 func (s *Error) Error() string {
 	return fmt.Sprintf("%s: %+v", s.Code, s.underlying)
 }
+
+// Cause unwraps the error.
+func (s *Error) Cause() error {
+	return s.underlying
+}
+
+// Format implements fmt.Formatter.
+func (s *Error) Format(st fmt.State, verb rune) { errors.FormatError(s, st, verb) }
 
 // WrapError wraps an error with a Error.
 func WrapError(code string, err error) *Error {

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1126,13 +1126,26 @@ func TestLint(t *testing.T) {
 
 		// forbiddenImportPkg -> permittedReplacementPkg
 		forbiddenImports := map[string]string{
-			"golang.org/x/net/context":         "context",
-			"log":                              "util/log",
-			"path":                             "path/filepath",
-			"github.com/golang/protobuf/proto": "github.com/gogo/protobuf/proto",
-			"github.com/satori/go.uuid":        "util/uuid",
-			"golang.org/x/sync/singleflight":   "github.com/cockroachdb/cockroach/pkg/util/syncutil/singleflight",
-			"syscall":                          "sysutil",
+			"golang.org/x/net/context":                    "context",
+			"log":                                         "util/log",
+			"path":                                        "path/filepath",
+			"github.com/golang/protobuf/proto":            "github.com/gogo/protobuf/proto",
+			"github.com/satori/go.uuid":                   "util/uuid",
+			"golang.org/x/sync/singleflight":              "github.com/cockroachdb/cockroach/pkg/util/syncutil/singleflight",
+			"syscall":                                     "sysutil",
+			"github.com/cockroachdb/errors/assert":        "github.com/cockroachdb/errors",
+			"github.com/cockroachdb/errors/barriers":      "github.com/cockroachdb/errors",
+			"github.com/cockroachdb/errors/contexttags":   "github.com/cockroachdb/errors",
+			"github.com/cockroachdb/errors/domains":       "github.com/cockroachdb/errors",
+			"github.com/cockroachdb/errors/errbase":       "github.com/cockroachdb/errors",
+			"github.com/cockroachdb/errors/errutil":       "github.com/cockroachdb/errors",
+			"github.com/cockroachdb/errors/issuelink":     "github.com/cockroachdb/errors",
+			"github.com/cockroachdb/errors/markers":       "github.com/cockroachdb/errors",
+			"github.com/cockroachdb/errors/report":        "github.com/cockroachdb/errors",
+			"github.com/cockroachdb/errors/safedetails":   "github.com/cockroachdb/errors",
+			"github.com/cockroachdb/errors/secondary":     "github.com/cockroachdb/errors",
+			"github.com/cockroachdb/errors/telemetrykeys": "github.com/cockroachdb/errors",
+			"github.com/cockroachdb/errors/withstack":     "github.com/cockroachdb/errors",
 		}
 
 		// grepBuf creates a grep string that matches any forbidden import pkgs.

--- a/pkg/util/contextutil/context_test.go
+++ b/pkg/util/contextutil/context_test.go
@@ -53,8 +53,9 @@ func TestRunWithTimeout(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 		return errors.Wrap(ctx.Err(), "custom error")
 	})
-	if err.Error() != expectedMsg {
-		t.Fatalf("expected %s, actual %s", expectedMsg, err.Error())
+	expExtended := expectedMsg + ": custom error: context deadline exceeded"
+	if err.Error() != expExtended {
+		t.Fatalf("expected %s, actual %s", expExtended, err.Error())
 	}
 	netError, ok = err.(net.Error)
 	if !ok {

--- a/pkg/util/encoding/csv/reader_test.go
+++ b/pkg/util/encoding/csv/reader_test.go
@@ -413,6 +413,11 @@ x,,,
 			} else if !reflect.DeepEqual(out, tt.Output) {
 				t.Errorf("ReadAll() output:\ngot  %q\nwant %q", out, tt.Output)
 			}
+
+			// Check that the error can be rendered.
+			if err != nil {
+				_ = err.Error()
+			}
 		})
 	}
 }

--- a/pkg/util/errorutil/error_test.go
+++ b/pkg/util/errorutil/error_test.go
@@ -39,7 +39,7 @@ func TestUnexpectedWithIssueErrorf(t *testing.T) {
 	}
 
 	// Check that the issue number is present in the safe details.
-	exp = "-- safe details:\nissue #%d\n-- arg 0: 1234"
+	exp = "safe details: issue #%d\n    -- arg 1: 1234"
 	if !strings.Contains(safeMsg, exp) {
 		t.Errorf("expected substring in error\n%s\ngot:\n%s", exp, safeMsg)
 	}

--- a/pkg/util/errorutil/unimplemented/unimplemented_test.go
+++ b/pkg/util/errorutil/unimplemented/unimplemented_test.go
@@ -16,7 +16,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/errors/issuelink"
 )
 
 func TestUnimplemented(t *testing.T) {
@@ -51,12 +50,12 @@ func TestUnimplemented(t *testing.T) {
 				}
 				if test.expIssue != 0 {
 					ref := fmt.Sprintf("%s\nSee: %s",
-						issuelink.UnimplementedErrorHint, makeURL(test.expIssue))
+						errors.UnimplementedErrorHint, makeURL(test.expIssue))
 					if hint == ref {
 						found |= 2
 					}
 				}
-				if strings.HasPrefix(hint, issuelink.UnimplementedErrorHint) {
+				if strings.HasPrefix(hint, errors.UnimplementedErrorHint) {
 					found |= 4
 				}
 			}
@@ -68,7 +67,7 @@ func TestUnimplemented(t *testing.T) {
 			}
 			if found&4 == 0 {
 				t.Errorf("expected standard hint introduction %q, not found\n%+v",
-					issuelink.UnimplementedErrorHint, hints)
+					errors.UnimplementedErrorHint, hints)
 			}
 
 			links := errors.GetAllIssueLinks(test.err)

--- a/pkg/util/grpcutil/grpc_util.go
+++ b/pkg/util/grpcutil/grpc_util.go
@@ -84,7 +84,7 @@ func RequestDidNotStart(err error) bool {
 	if _, ok := err.(connectionNotReadyError); ok {
 		return true
 	}
-	if _, ok := err.(netutil.InitialHeartbeatFailedError); ok {
+	if _, ok := err.(*netutil.InitialHeartbeatFailedError); ok {
 		return true
 	}
 	s, ok := status.FromError(err)

--- a/pkg/util/log/crash_reporting_packet_test.go
+++ b/pkg/util/log/crash_reporting_packet_test.go
@@ -220,7 +220,7 @@ func TestInternalErrorReporting(t *testing.T) {
 		key   string
 		reVal string
 	}{
-		{"1: details", "%s\n.*string"},
+		{"1: details", "%s\n.*<string>"},
 		{"2: stacktrace", `.*builtins.go.*\n.*eval.go.*Eval`},
 		{"3: details", `%s\(\).*\n.*force_assertion_error`},
 		{"4: stacktrace", ".*eval.go.*Eval"},
@@ -255,7 +255,7 @@ func TestInternalErrorReporting(t *testing.T) {
 					`\*safedetails.withSafeDetails: %s \(1\)\n`+
 					`builtins.go:\d+: \*withstack.withStack \(2\)\n`+
 					`\*assert.withAssertionFailure\n`+
-					`\*errors.withMessage\n`+
+					`\*errutil.withMessage\n`+
 					`\*safedetails.withSafeDetails: %s\(\) \(3\)\n`+
 					`eval.go:\d+: \*withstack.withStack \(4\)\n`+
 					`\*telemetrykeys.withTelemetry: crdb_internal.force_assertion_error\(\) \(5\)\n`+

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -19,14 +19,14 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/cockroachdb/errors/errbase"
+	"github.com/cockroachdb/errors"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/petermattis/goid"
 )
 
 func init() {
 	copyStandardLogTo("INFO")
-	errbase.WarningFn = Warningf
+	errors.SetWarningFn(Warningf)
 }
 
 // FatalOnPanic recovers from a panic and exits the process with a

--- a/pkg/util/netutil/net.go
+++ b/pkg/util/netutil/net.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
 )
@@ -162,8 +163,24 @@ type InitialHeartbeatFailedError struct {
 	WrappedErr error
 }
 
-func (e InitialHeartbeatFailedError) Error() string {
-	return fmt.Sprintf("initial connection heartbeat failed: %s", e.WrappedErr)
+var _ error = (*InitialHeartbeatFailedError)(nil)
+var _ fmt.Formatter = (*InitialHeartbeatFailedError)(nil)
+var _ errors.Formatter = (*InitialHeartbeatFailedError)(nil)
+
+// Note: Error is not a causer. If this is changed to implement
+// Cause()/Unwrap(), change the type assertions in package cli and
+// elsewhere to use errors.As() or equivalent.
+
+// Error implements error.
+func (e *InitialHeartbeatFailedError) Error() string { return fmt.Sprintf("%v", e) }
+
+// Format implements fmt.Formatter.
+func (e *InitialHeartbeatFailedError) Format(s fmt.State, verb rune) { errors.FormatError(e, s, verb) }
+
+// FormatError implements errors.FormatError.
+func (e *InitialHeartbeatFailedError) FormatError(p errors.Printer) error {
+	p.Print("initial connection heartbeat failed")
+	return e.WrappedErr
 }
 
 // NewInitialHeartBeatFailedError creates a new InitialHeartbeatFailedError.


### PR DESCRIPTION
(found by @RaduBerinde; needed to complete #38570)

The new library `github.com/cockroachdb/errors` was not implementing
`%+v` formatting properly for assertion and unimplemented errors.
The wrong implementation was hiding the details of the cause
of these two error types from the formatting logic.

Fixing this bug comprehensively required completing the investigation
of the Go 2 / `xerrors` error proposal. This revealed that the
implementation of `fmt.Formatter` for wrapper errors (a `Format()`
method) is required in all cases, at least until Go's stdlib
learns about `errors.Formatter`. More details at
https://github.com/golang/go/issues/29934 and this commit message: https://github.com/cockroachdb/errors/commit/78b6caa8a0455b5fa93f17d4b4c3132597342c0e.

This patch bumps the dependency `github.com/cockroachdb/errors` to
pick up the fixes to assertion failures and unimplemented errors.

The new definition of `errors.FormatError()` subsequently required
re-implemening `Format)` for `pgerros.withCandidateCode`, which is
also done here.

Finally, this patch also picks up `errors.As()` and the new
streamlined `fmt.Formatter` / `errors.Formatter` interaction, so this
patch also simplifies a few custom error types in CockroachDB
accordingly.

Release note: None