### PR TITLE
exec: clean up supported window functions

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -410,8 +410,8 @@ func newColOperator(
 		}
 		wf := core.Windower.WindowFns[0]
 		if wf.Frame != nil &&
-			wf.Frame.Mode != distsqlpb.WindowerSpec_Frame_RANGE &&
-			(wf.Frame.Bounds.Start.BoundType != distsqlpb.WindowerSpec_Frame_UNBOUNDED_PRECEDING ||
+			(wf.Frame.Mode != distsqlpb.WindowerSpec_Frame_RANGE ||
+				wf.Frame.Bounds.Start.BoundType != distsqlpb.WindowerSpec_Frame_UNBOUNDED_PRECEDING ||
 				(wf.Frame.Bounds.End != nil && wf.Frame.Bounds.End.BoundType != distsqlpb.WindowerSpec_Frame_CURRENT_ROW)) {
 			return nil, nil, errors.Newf("window functions with non-default window frames are not supported")
 		}

--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -409,8 +409,11 @@ func newColOperator(
 			return nil, nil, errors.Newf("only a single window function is currently supported")
 		}
 		wf := core.Windower.WindowFns[0]
-		if wf.Frame != nil {
-			return nil, nil, errors.Newf("window functions with window frames are not supported")
+		if wf.Frame != nil &&
+			wf.Frame.Mode != distsqlpb.WindowerSpec_Frame_RANGE &&
+			(wf.Frame.Bounds.Start.BoundType != distsqlpb.WindowerSpec_Frame_UNBOUNDED_PRECEDING ||
+				(wf.Frame.Bounds.End != nil && wf.Frame.Bounds.End.BoundType != distsqlpb.WindowerSpec_Frame_CURRENT_ROW)) {
+			return nil, nil, errors.Newf("window functions with non-default window frames are not supported")
 		}
 		if wf.Func.AggregateFunc != nil {
 			return nil, nil, errors.Newf("aggregate functions used as window functions are not supported")
@@ -418,27 +421,26 @@ func newColOperator(
 
 		input := inputs[0]
 		typs := conv.FromColumnTypes(spec.Input[0].ColumnTypes)
-		var orderingCols []uint32
 		tempPartitionColOffset, partitionColIdx := 0, -1
 		if len(core.Windower.PartitionBy) > 0 {
 			// TODO(yuzefovich): add support for hashing partitioner (probably by
 			// leveraging hash routers once we can distribute). The decision about
 			// which kind of partitioner to use should come from the optimizer.
-			input, orderingCols, err = exec.NewWindowSortingPartitioner(input, typs, core.Windower.PartitionBy, wf.Ordering.Columns, int(wf.OutputColIdx))
+			input, err = exec.NewWindowSortingPartitioner(input, typs, core.Windower.PartitionBy, wf.Ordering.Columns, int(wf.OutputColIdx))
 			tempPartitionColOffset, partitionColIdx = 1, int(wf.OutputColIdx)
 		} else {
 			if len(wf.Ordering.Columns) > 0 {
 				input, err = exec.NewSorter(input, typs, wf.Ordering.Columns)
-			}
-			orderingCols = make([]uint32, len(wf.Ordering.Columns))
-			for i, col := range wf.Ordering.Columns {
-				orderingCols[i] = col.ColIdx
 			}
 		}
 		if err != nil {
 			return nil, nil, err
 		}
 
+		orderingCols := make([]uint32, len(wf.Ordering.Columns))
+		for i, col := range wf.Ordering.Columns {
+			orderingCols[i] = col.ColIdx
+		}
 		switch *wf.Func.WindowFunc {
 		case distsqlpb.WindowerSpec_ROW_NUMBER:
 			op = vecbuiltins.NewRowNumberOperator(input, int(wf.OutputColIdx)+tempPartitionColOffset, partitionColIdx)

--- a/pkg/sql/exec/execgen/cmd/execgen/rank_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/rank_gen.go
@@ -22,6 +22,7 @@ import (
 type rankTmplInfo struct {
 	Dense        bool
 	HasPartition bool
+	String       string
 }
 
 // UpdateRank is used to encompass the different logic between DENSE_RANK and
@@ -65,8 +66,7 @@ func genRankOps(wr io.Writer) error {
 
 	s := string(d)
 
-	s = strings.Replace(s, "_DENSE", "{{.Dense}}", -1)
-	s = strings.Replace(s, "_PARTITION", "{{.HasPartition}}", -1)
+	s = strings.Replace(s, "_RANK_STRING", "{{.String}}", -1)
 
 	updateRankRe := regexp.MustCompile(`_UPDATE_RANK_\(\)`)
 	s = updateRankRe.ReplaceAllString(s, "{{.UpdateRank}}")
@@ -80,10 +80,10 @@ func genRankOps(wr io.Writer) error {
 	}
 
 	rankTmplInfos := []rankTmplInfo{
-		{Dense: false, HasPartition: false},
-		{Dense: false, HasPartition: true},
-		{Dense: true, HasPartition: false},
-		{Dense: true, HasPartition: true},
+		{Dense: false, HasPartition: false, String: "rankNoPartition"},
+		{Dense: false, HasPartition: true, String: "rankWithPartition"},
+		{Dense: true, HasPartition: false, String: "denseRankNoPartition"},
+		{Dense: true, HasPartition: true, String: "denseRankWithPartition"},
 	}
 	return tmpl.Execute(wr, rankTmplInfos)
 }

--- a/pkg/sql/exec/execgen/cmd/execgen/row_number_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/row_number_gen.go
@@ -43,7 +43,6 @@ func genRowNumberOp(wr io.Writer) error {
 		{HasPartition: true, String: "rowNumberWithPartition"},
 	}
 	return tmpl.Execute(wr, rankTmplInfos)
-
 }
 
 func init() {

--- a/pkg/sql/exec/partitioner.go
+++ b/pkg/sql/exec/partitioner.go
@@ -29,28 +29,24 @@ func NewWindowSortingPartitioner(
 	partitionIdxs []uint32,
 	ordCols []distsqlpb.Ordering_Column,
 	partitionColIdx int,
-) (op Operator, orderingColsIdxs []uint32, err error) {
+) (op Operator, err error) {
 	partitionAndOrderingCols := make([]distsqlpb.Ordering_Column, len(partitionIdxs)+len(ordCols))
 	for i, idx := range partitionIdxs {
 		partitionAndOrderingCols[i] = distsqlpb.Ordering_Column{ColIdx: idx}
 	}
 	copy(partitionAndOrderingCols[len(partitionIdxs):], ordCols)
-	orderingColsIdxs = make([]uint32, len(ordCols))
-	for i := range ordCols {
-		orderingColsIdxs[i] = uint32(len(partitionIdxs) + i)
-	}
 	input, err = NewSorter(input, inputTyps, partitionAndOrderingCols)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	var distinctCol []bool
 	input, distinctCol, err = OrderedDistinctColsToOperators(input, partitionIdxs, inputTyps)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return &windowSortingPartitioner{input: input, distinctCol: distinctCol, partitionColIdx: partitionColIdx}, orderingColsIdxs, nil
+	return &windowSortingPartitioner{input: input, distinctCol: distinctCol, partitionColIdx: partitionColIdx}, nil
 }
 
 type windowSortingPartitioner struct {

--- a/pkg/sql/exec/vecbuiltins/rank.go
+++ b/pkg/sql/exec/vecbuiltins/rank.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 )
 
-// TODO(yuzefovich): add randomized tests.
 // TODO(yuzefovich): add benchmarks.
 
 // NewRankOperator creates a new exec.Operator that computes window function

--- a/pkg/sql/exec/vecbuiltins/rank.go
+++ b/pkg/sql/exec/vecbuiltins/rank.go
@@ -46,12 +46,12 @@ func NewRankOperator(
 	}
 	if dense {
 		if partitionColIdx != -1 {
-			return &rankDense_true_HasPartition_true_Op{rankInitFields: initFields}, nil
+			return &denseRankWithPartitionOp{rankInitFields: initFields}, nil
 		}
-		return &rankDense_true_HasPartition_false_Op{rankInitFields: initFields}, nil
+		return &denseRankNoPartitionOp{rankInitFields: initFields}, nil
 	}
 	if partitionColIdx != -1 {
-		return &rankDense_false_HasPartition_true_Op{rankInitFields: initFields}, nil
+		return &rankWithPartitionOp{rankInitFields: initFields}, nil
 	}
-	return &rankDense_false_HasPartition_false_Op{rankInitFields: initFields}, nil
+	return &rankNoPartitionOp{rankInitFields: initFields}, nil
 }

--- a/pkg/sql/exec/vecbuiltins/rank_tmpl.go
+++ b/pkg/sql/exec/vecbuiltins/rank_tmpl.go
@@ -55,7 +55,7 @@ type rankInitFields struct {
 
 // {{range .}}
 
-type rankDense__DENSE_HasPartition__PARTITION_Op struct {
+type _RANK_STRINGOp struct {
 	rankInitFields
 
 	// rank indicates which rank should be assigned to the next tuple.
@@ -66,9 +66,9 @@ type rankDense__DENSE_HasPartition__PARTITION_Op struct {
 	rankIncrement int64
 }
 
-var _ exec.Operator = &rankDense__DENSE_HasPartition__PARTITION_Op{}
+var _ exec.Operator = &_RANK_STRINGOp{}
 
-func (r *rankDense__DENSE_HasPartition__PARTITION_Op) Init() {
+func (r *_RANK_STRINGOp) Init() {
 	r.input.Init()
 	// RANK and DENSE_RANK start counting from 1. Before we assign the rank to a
 	// tuple in the batch, we first increment r.rank, so setting this
@@ -77,7 +77,7 @@ func (r *rankDense__DENSE_HasPartition__PARTITION_Op) Init() {
 	r.rankIncrement = 1
 }
 
-func (r *rankDense__DENSE_HasPartition__PARTITION_Op) Next(ctx context.Context) coldata.Batch {
+func (r *_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 	batch := r.input.Next(ctx)
 	if batch.Length() == 0 {
 		return batch

--- a/pkg/sql/exec/vecbuiltins/row_number.go
+++ b/pkg/sql/exec/vecbuiltins/row_number.go
@@ -12,7 +12,6 @@ package vecbuiltins
 
 import "github.com/cockroachdb/cockroach/pkg/sql/exec"
 
-// TODO(yuzefovich): add randomized tests.
 // TODO(yuzefovich): add benchmarks.
 
 // NewRowNumberOperator creates a new exec.Operator that computes window
@@ -22,21 +21,21 @@ import "github.com/cockroachdb/cockroach/pkg/sql/exec"
 func NewRowNumberOperator(
 	input exec.Operator, outputColIdx int, partitionColIdx int,
 ) exec.Operator {
-	rowNumberInternal := rowNumberInternal{
+	base := rowNumberBase{
 		input:           input,
 		outputColIdx:    outputColIdx,
 		partitionColIdx: partitionColIdx,
 	}
 	if partitionColIdx == -1 {
-		return &rowNumberNoPartitionOp{rowNumberInternal}
+		return &rowNumberNoPartitionOp{base}
 	}
-	return &rowNumberWithPartitionOp{rowNumberInternal}
+	return &rowNumberWithPartitionOp{base}
 }
 
-// rowNumberInternal extracts common fields and common initialization of two
+// rowNumberBase extracts common fields and common initialization of two
 // variations of row number operators. Note that it is not an operator itself
 // and should not be used directly.
-type rowNumberInternal struct {
+type rowNumberBase struct {
 	input           exec.Operator
 	outputColIdx    int
 	partitionColIdx int
@@ -44,6 +43,6 @@ type rowNumberInternal struct {
 	rowNumber int64
 }
 
-func (r *rowNumberInternal) Init() {
+func (r *rowNumberBase) Init() {
 	r.input.Init()
 }

--- a/pkg/sql/exec/vecbuiltins/row_number_tmpl.go
+++ b/pkg/sql/exec/vecbuiltins/row_number_tmpl.go
@@ -30,7 +30,7 @@ import (
 // {{ range . }}
 
 type _ROW_NUMBER_STRINGOp struct {
-	rowNumberInternal
+	rowNumberBase
 }
 
 var _ exec.Operator = &_ROW_NUMBER_STRINGOp{}

--- a/pkg/sql/logictest/testdata/logic_test/exec_window
+++ b/pkg/sql/logictest/testdata/logic_test/exec_window
@@ -1,95 +1,87 @@
 # LogicTest: local-vec
 
 statement ok
-CREATE TABLE t (a INT, b STRING, PRIMARY KEY (b,a))
+CREATE TABLE t (a INT, b INT, c INT PRIMARY KEY)
 
 statement ok
 INSERT INTO t VALUES
-  (0, 'a'),
-  (1, 'a'),
-  (0, 'b'),
-  (1, 'b')
+  (0, 1, 0),
+  (1, 1, 1),
+  (0, 2, 2),
+  (1, 2, 3)
 
 statement ok
 SET experimental_vectorize=always
 
 # We sort the output on all queries to get deterministic results.
-query ITI
-SELECT a, b, row_number() OVER () FROM t ORDER BY b, a
+query III
+SELECT a, b, row_number() OVER (ORDER BY a, b) FROM t ORDER BY a, b
 ----
-0 a 1
-1 a 2
-0 b 3
-1 b 4
+0 1 1
+0 2 2
+1 1 3
+1 2 4
 
-query ITI
-SELECT a, b, row_number() OVER (ORDER BY a, b) FROM t ORDER BY b, a
+query III
+SELECT a, b, row_number() OVER (PARTITION BY a ORDER BY b) FROM t ORDER BY a, b
 ----
-0 a 1
-1 a 3
-0 b 2
-1 b 4
+0 1 1
+0 2 2
+1 1 1
+1 2 2
 
-query ITI
-SELECT a, b, row_number() OVER (PARTITION BY a) FROM t ORDER BY b, a
+query III
+SELECT a, b, row_number() OVER (PARTITION BY a, b) FROM t ORDER BY a, b
 ----
-0 a 1
-1 a 1
-0 b 2
-1 b 2
+0 1 1
+0 2 1
+1 1 1
+1 2 1
 
-query ITI
-SELECT a, b, row_number() OVER (PARTITION BY a, b) FROM t ORDER BY b, a
+query III
+SELECT a, b, rank() OVER () FROM t ORDER BY a, b
 ----
-0 a 1
-1 a 1
-0 b 1
-1 b 1
+0 1 1
+0 2 1
+1 1 1
+1 2 1
 
-query ITI
-SELECT a, b, rank() OVER () FROM t ORDER BY b, a
+query III
+SELECT a, b, rank() OVER (ORDER BY a) FROM t ORDER BY a, b
 ----
-0 a 1
-1 a 1
-0 b 1
-1 b 1
+0 1 1
+0 2 1
+1 1 3
+1 2 3
 
-query ITI
-SELECT a, b, rank() OVER (ORDER BY a) FROM t ORDER BY b, a
+query IIII
+SELECT a, b, c, rank() OVER (PARTITION BY a ORDER BY c) FROM t ORDER BY a, b
 ----
-0 a 1
-1 a 3
-0 b 1
-1 b 3
+0 1 0 1
+0 2 2 2
+1 1 1 1
+1 2 3 2
 
-query ITI
-SELECT a, b, rank() OVER (PARTITION BY a ORDER BY b) FROM t ORDER BY b, a
+query III
+SELECT a, b, dense_rank() OVER () FROM t ORDER BY a, b
 ----
-0 a 1
-1 a 1
-0 b 2
-1 b 2
+0 1 1
+0 2 1
+1 1 1
+1 2 1
 
-query ITI
-SELECT a, b, dense_rank() OVER () FROM t ORDER BY b, a
+query III
+SELECT a, b, dense_rank() OVER (ORDER BY a) FROM t ORDER BY a, b
 ----
-0 a 1
-1 a 1
-0 b 1
-1 b 1
+0 1 1
+0 2 1
+1 1 2
+1 2 2
 
-query ITI
-SELECT a, b, dense_rank() OVER (ORDER BY a) FROM t ORDER BY b, a
+query IIII
+SELECT a, b, c, dense_rank() OVER (PARTITION BY a ORDER BY c) FROM t ORDER BY a, b
 ----
-0 a 1
-1 a 2
-0 b 1
-1 b 2
-
-query ITI
-SELECT a, b, dense_rank() OVER (PARTITION BY a ORDER BY b) FROM t ORDER BY b, a
-----
-0 a 1
-1 a 1
-0 b 2
-1 b 2
+0 1 0 1
+0 2 2 2
+1 1 1 1
+1 2 3 2

--- a/pkg/sql/logictest/testdata/logic_test/exec_window
+++ b/pkg/sql/logictest/testdata/logic_test/exec_window
@@ -13,6 +13,16 @@ INSERT INTO t VALUES
 statement ok
 SET experimental_vectorize=always
 
+# Test that non-default window frames are not supported.
+statement error window functions with non-default window frames are not supported
+SELECT rank() OVER (ROWS UNBOUNDED PRECEDING) FROM t
+
+statement error window functions with non-default window frames are not supported
+SELECT rank() OVER (RANGE CURRENT ROW) FROM t
+
+statement error window functions with non-default window frames are not supported
+SELECT rank() OVER (ORDER BY a RANGE BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) FROM t
+
 # We sort the output on all queries to get deterministic results.
 query III
 SELECT a, b, row_number() OVER (ORDER BY a, b) FROM t ORDER BY a, b


### PR DESCRIPTION
First commit unifies the way we generate code for row_number and
rank window functions as well as cleans up the generated names.

Second commit message:
At some point, window sorting partitioner was looking into ORDER BY
clause of a window function to find an intersection of columns with
PARTITION BY clause in order to be "smart" about planning. Now that
the optimizer takes care of that case, so that "smartness" was
removed, but a remnant of it remained, and it was actually messing
up the indices of ordering columns.

The logic test has been cleaned up a little and updated to catch
such error.

Third commit adds a randomized test of window functions.