### PR TITLE
ui: copy update for Login Page

### DIFF
--- a/pkg/ui/src/views/login/loginPage.styl
+++ b/pkg/ui/src/views/login/loginPage.styl
@@ -54,7 +54,7 @@
   .logo
     height 32px
     position relative
-    margin-bottom 80px
+    margin-bottom 74px
 
   .input-text
     width 100%
@@ -98,7 +98,7 @@
     margin 12px 0
 
   .info-box
-    margin-top 36px
+    margin-top 0px
 
 .login-note-box
   &__sql-command

--- a/pkg/ui/src/views/login/loginPage.tsx
+++ b/pkg/ui/src/views/login/loginPage.tsx
@@ -101,6 +101,10 @@ class LoginPage extends React.Component<LoginPageProps & WithRouterProps, LoginP
             <img className="logo" alt="CockroachDB" src={logo} />
             <InfoBox>
               <h4 className="login-note-box__heading">Note:</h4>
+              <p>
+                A user with a password is required to log in to the UI
+                on secure clusters.
+              </p>
               <p className="login-note-box__blurb">
                 Create a user with this SQL command:
               </p>


### PR DESCRIPTION
This is follow-up copy fixes from #38140:

* In #38140 [Version on Login Page], a helpful blurb was removed. This PR puts helpful blurb back into login page.

Login Page, Before:
<img width="500" alt="Login Before" src="https://user-images.githubusercontent.com/3051672/60745990-a66bf500-9f4a-11e9-8bdc-d950f3c1ce8a.png">

Login Page, After:
<img width="500" alt="Login After" src="https://user-images.githubusercontent.com/3051672/60745993-a7048b80-9f4a-11e9-9932-4fab7d5a60c3.png">
