### PR TITLE
roachtest: make offsetInjector deployment idempotent

### DIFF
--- a/pkg/cmd/roachtest/clock_util.go
+++ b/pkg/cmd/roachtest/clock_util.go
@@ -41,6 +41,7 @@ type offsetInjector struct {
 // deploy installs ntp and downloads / compiles bumptime used to create a clock offset
 func (oi *offsetInjector) deploy(ctx context.Context, l *logger) error {
 	if err := oi.c.RunE(ctx, oi.c.All(), "test -x ./bumptime"); err == nil {
+		oi.deployed = true
 		return nil
 	}
 


### PR DESCRIPTION
offsetInjector.deploy was trying to detect if it had already been
deployed on a cluster, but it was doing the opposite - it was detecting
it had been deployed but then preventing further uses of it.

Fixes #38646
Fixes #38647
Fixes #38648
Fixes #38649
Fixes #38650

Release note: None