### PR TITLE
exec: bugfix to sort operator

### DIFF
--- a/pkg/sql/exec/sort.go
+++ b/pkg/sql/exec/sort.go
@@ -277,7 +277,7 @@ func (p *sortOp) Next(ctx context.Context) coldata.Batch {
 						Src:         p.input.getValues(j),
 						Sel64:       p.order,
 						SrcStartIdx: p.emitted,
-						SrcEndIdx:   uint64(p.output.Length()),
+						SrcEndIdx:   p.emitted + uint64(p.output.Length()),
 					},
 				)
 			}

--- a/pkg/sql/exec/sort_test.go
+++ b/pkg/sql/exec/sort_test.go
@@ -124,7 +124,7 @@ func TestSort(t *testing.T) {
 
 func TestSortRandomized(t *testing.T) {
 	rng, _ := randutil.NewPseudoRand()
-	nTups := 8
+	nTups := 1025
 	k := uint16(4)
 	maxCols := 5
 	// TODO(yuzefovich): randomize types as well.


### PR DESCRIPTION
Commit f0b661bc17 did an unsound refactor, introducing a slice out of
bounds error. Additionally, the randomized tests were insufficiently
large to catch the bug. This fixes the error and makes the randomized
tests use a larger input size that's sufficient to catch the problem.

Closes #38561.

Release note: None