### PR TITLE
cli/dump: more clearly inform the user upon tables with no visible columns

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -67,7 +67,15 @@ func Main() {
 
 	errCode := 0
 	if err := Run(os.Args[1:]); err != nil {
+		// Display the error and its details/hints.
+		fmt.Fprintln(stderr, "Error:", err.Error())
+		maybeShowErrorDetails(stderr, err, false /* printNewline */)
+
+		// Remind the user of which command was being run.
 		fmt.Fprintf(stderr, "Failed running %q\n", cmdName)
+
+		// Finally, extract the error code, as optionally specified
+		// by the sub-command.
 		errCode = 1
 		if ec, ok := errors.Cause(err).(*cliError); ok {
 			errCode = ec.exitCode
@@ -145,6 +153,10 @@ var cockroachCmd = &cobra.Command{
 	// Commands should manually print usage information when the error is,
 	// in fact, a result of a bad invocation, e.g. too many arguments.
 	SilenceUsage: true,
+	// Disable automatic printing of the error. We want to also print
+	// details and hints, which cobra does not do for us. Instead
+	// we do the printing in Main().
+	SilenceErrors: true,
 }
 
 func init() {

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1859,8 +1859,11 @@ Use "cockroach [command] --help" for more information about a command.
 				done <- err
 			}()
 
-			if err := Run(test.flags); err != nil && !test.expErr {
-				t.Error(err)
+			if err := Run(test.flags); err != nil {
+				fmt.Fprintln(w, "Error:", err)
+				if !test.expErr {
+					t.Error(err)
+				}
 			}
 
 			// back to normal state


### PR DESCRIPTION
Informs #37768.
Informs #28948.
This is coming up quite often on support, lately again on gitter and forum https://forum.cockroachlabs.com/t/error-while-dumping-core-backup/2901/3.

This PR aims to lessen the burden on support and propose a clear "next action" for the user.

Before:

```
kena@kenax ~/cockroach % ./cockroach dump --insecure defaultdb
CREATE TABLE t (,
        FAMILY "primary" (rowid)
);
Error: pq: at or near "from": syntax error
Failed running "dump"
```

After:

```
kena@kenax ~/cockroach % ./cockroach dump --insecure defaultdb
CREATE TABLE t (,
        FAMILY "primary" (rowid)
);
Error: table "defaultdb.public.t" has no visible columns
HINT: To proceed with the dump, either omit this table from the list of tables to dump, drop the table, or add some visible columns.
--
See: https://github.com/cockroachdb/cockroach/issues/37768
Failed running "dump"
```

Release note (cli change): `cockroach dump` will now more clearly
refer to issue #37768 when it encounters a table with no visible
columns, which (currently) cannot be dumped successfully.