### PR TITLE
opt: fix another floating point precision error in statisticsBuilder

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -1246,12 +1246,12 @@ HAVING
 project
  ├── columns: "?column?":5(int!null)
  ├── cardinality: [0 - 2]
- ├── stats: [rows=1e-07]
+ ├── stats: [rows=1e-10]
  ├── fd: ()-->(5)
  ├── select
  │    ├── columns: column2:2(string) column3:3(varbit) min:4(bool!null)
  │    ├── cardinality: [0 - 2]
- │    ├── stats: [rows=1e-07, distinct(4)=1e-07, null(4)=0]
+ │    ├── stats: [rows=1e-10, distinct(4)=1e-10, null(4)=0]
  │    ├── key: (2,3)
  │    ├── fd: ()-->(4)
  │    ├── group-by
@@ -1369,7 +1369,7 @@ SELECT x FROM t WHERE x
 ----
 select
  ├── columns: x:5(bool!null)
- ├── stats: [rows=4e+13, distinct(5)=1, null(5)=0]
+ ├── stats: [rows=4e+10, distinct(5)=1, null(5)=0]
  ├── fd: ()-->(5)
  ├── project
  │    ├── columns: x:5(bool)
@@ -1388,3 +1388,40 @@ select
  │         └── (t1.x::INT8 << 5533)::BOOL OR t2.x [type=bool, outer=(1,3)]
  └── filters
       └── variable: x [type=bool, outer=(5), constraints=(/5: [/true - /true]; tight), fd=()-->(5)]
+
+# Regression test for #38375. Avoid floating point precision errors.
+exec-ddl
+CREATE TABLE t38375 (x INT, y INT)
+----
+
+exec-ddl
+ALTER TABLE t38375 INJECT STATISTICS '[
+  {
+    "columns": ["x"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 20000000000,
+    "distinct_count": 20000000000,
+    "null_count": 20000000000
+  },
+  {
+    "columns": ["y"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 20000000000,
+    "distinct_count": 10,
+    "null_count": 0
+  }
+]'
+----
+
+opt colstat=2
+SELECT * FROM t38375 WHERE x = 1
+----
+select
+ ├── columns: x:1(int!null) y:2(int)
+ ├── stats: [rows=1e-10, distinct(1)=1e-10, null(1)=0, distinct(2)=1e-10, null(2)=0]
+ ├── fd: ()-->(1)
+ ├── scan t38375
+ │    ├── columns: x:1(int) y:2(int)
+ │    └── stats: [rows=2e+10, distinct(1)=2e+10, null(1)=2e+10, distinct(2)=10, null(2)=0]
+ └── filters
+      └── x = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]

--- a/pkg/sql/opt/props/statistics.go
+++ b/pkg/sql/opt/props/statistics.go
@@ -189,6 +189,13 @@ func (c *ColumnStatistic) ApplySelectivity(selectivity, inputRows float64) {
 	// This formula returns d * selectivity when d=n but is closer to d
 	// when d << n.
 	c.DistinctCount = d - d*math.Pow(1-selectivity, n/d)
+	const epsilon = 1e-10
+	if c.DistinctCount < epsilon {
+		// Avoid setting the distinct count to 0 (since the row count is
+		// non-zero).
+		c.DistinctCount = epsilon
+	}
+
 }
 
 // ColumnStatistics is a slice of pointers to ColumnStatistic values.


### PR DESCRIPTION
This commit fixes a floating point precision error in the
statisticsBuilder code for estimating the distinct count of an
unconstrained column in a `SELECT` or `JOIN` expression.

Prior to this commit, the code was estimating that the probability
of a row being filtered out was 1-selectivity. If the selectivity is
very small, however, this results in probability=1. This commit changes
the logic so now we set the probability equal to 0.9999999 if it would
otherwise be equal to 1. This ensures that the estimated distinct count
is always greater than 0 if the row count is greater than 0.

Fixes #38375

Release note: None