### PR TITLE
coldata: rename HasNulls -> MaybeHasNulls; other Null improvements

### DIFF
--- a/pkg/sql/distsqlrun/materializer.go
+++ b/pkg/sql/distsqlrun/materializer.go
@@ -134,7 +134,7 @@ func (m *materializer) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata)
 			col := m.batch.ColVec(cIdx)
 			// TODO(asubiotto): we shouldn't have to do this check. Figure out who's
 			// not setting nulls.
-			if col.HasNulls() {
+			if col.MaybeHasNulls() {
 				if col.Nulls().NullAt(rowIdx) {
 					m.row[outIdx].Datum = tree.DNull
 					continue

--- a/pkg/sql/exec/coldata/nulls_test.go
+++ b/pkg/sql/exec/coldata/nulls_test.go
@@ -99,6 +99,19 @@ func TestNullsTruncate(t *testing.T) {
 	}
 }
 
+func TestUnsetNullsAfter(t *testing.T) {
+	for _, size := range pos {
+		n := NewNulls(BatchSize)
+		n.SetNulls()
+		n.UnsetNullsAfter(uint16(size))
+		for i := uint16(0); i < BatchSize; i++ {
+			expected := uint64(i) < size
+			require.Equal(t, expected, n.NullAt(i),
+				"NullAt(%d) should be %t after UnsetNullsAfter(%d)", i, expected, size)
+		}
+	}
+}
+
 func TestSetAndUnsetNulls(t *testing.T) {
 	n := NewNulls(BatchSize)
 	for i := uint16(0); i < BatchSize; i++ {
@@ -218,7 +231,7 @@ func TestNullsOr(t *testing.T) {
 	n1 := nulls3.Slice(0, length1)
 	n2 := nulls5.Slice(0, length2)
 	or := n1.Or(&n2)
-	require.True(t, or.hasNulls)
+	require.True(t, or.maybeHasNulls)
 	for i := uint64(0); i < length2; i++ {
 		if i < length1 && n1.NullAt64(i) || i < length2 && n2.NullAt64(i) {
 			require.True(t, or.NullAt64(i), "or.NullAt64(%d) should be true", i)

--- a/pkg/sql/exec/coldata/vec.go
+++ b/pkg/sql/exec/coldata/vec.go
@@ -133,8 +133,9 @@ type Vec interface {
 	// It uses the reflect package and is not suitable for calling in hot paths.
 	PrettyValueAt(idx uint16, colType types.T) string
 
-	// HasNulls returns true if the column has any null values.
-	HasNulls() bool
+	// MaybeHasNulls returns true if the column possibly has any null values, and
+	// returns false if the column definitely has no null values.
+	MaybeHasNulls() bool
 
 	// Nulls returns the nulls vector for the column.
 	Nulls() *Nulls
@@ -233,8 +234,8 @@ func (m *memColumn) _TemplateType() []interface{} {
 	panic("don't call this from non template code")
 }
 
-func (m *memColumn) HasNulls() bool {
-	return m.nulls.hasNulls
+func (m *memColumn) MaybeHasNulls() bool {
+	return m.nulls.maybeHasNulls
 }
 
 func (m *memColumn) Nulls() *Nulls {

--- a/pkg/sql/exec/coldata/vec_tmpl.go
+++ b/pkg/sql/exec/coldata/vec_tmpl.go
@@ -81,7 +81,7 @@ func (m *memColumn) Copy(args CopyArgs) {
 			sel := args.Sel64
 			// TODO(asubiotto): Template this and the uint16 case below.
 			if args.Nils != nil {
-				if args.Src.HasNulls() {
+				if args.Src.MaybeHasNulls() {
 					nulls := args.Src.Nulls()
 					toColSliced := toCol[args.DestIdx:]
 					for i, selIdx := range sel[args.SrcStartIdx:args.SrcEndIdx] {
@@ -105,7 +105,7 @@ func (m *memColumn) Copy(args CopyArgs) {
 				return
 			}
 			// No Nils.
-			if args.Src.HasNulls() {
+			if args.Src.MaybeHasNulls() {
 				nulls := args.Src.Nulls()
 				toColSliced := toCol[args.DestIdx:]
 				for i, selIdx := range sel[args.SrcStartIdx:args.SrcEndIdx] {
@@ -125,7 +125,7 @@ func (m *memColumn) Copy(args CopyArgs) {
 			return
 		} else if args.Sel != nil {
 			sel := args.Sel
-			if args.Src.HasNulls() {
+			if args.Src.MaybeHasNulls() {
 				nulls := args.Src.Nulls()
 				toColSliced := toCol[args.DestIdx:]
 				for i, selIdx := range sel[args.SrcStartIdx:args.SrcEndIdx] {
@@ -146,7 +146,7 @@ func (m *memColumn) Copy(args CopyArgs) {
 		}
 		// No Sel or Sel64.
 		copy(toCol[args.DestIdx:], fromCol[args.SrcStartIdx:args.SrcEndIdx])
-		if args.Src.HasNulls() {
+		if args.Src.MaybeHasNulls() {
 			// TODO(asubiotto): This should use Extend but Extend only takes uint16
 			// arguments.
 			srcNulls := args.Src.Nulls()

--- a/pkg/sql/exec/colserde/arrowbatchconverter.go
+++ b/pkg/sql/exec/colserde/arrowbatchconverter.go
@@ -90,7 +90,7 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]*array.Data, 
 		vec := batch.ColVec(i)
 
 		var arrowBitmap []byte
-		if vec.HasNulls() {
+		if vec.MaybeHasNulls() {
 			n := vec.Nulls()
 			// To conform to the Arrow spec, zero out all trailing null values.
 			n.Truncate(batch.Length())

--- a/pkg/sql/exec/count_agg.go
+++ b/pkg/sql/exec/count_agg.go
@@ -73,7 +73,7 @@ func (a *countAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 	// If this is a COUNT(col) aggregator and there are nulls in this batch,
 	// we must check each value for nullity. Note that it is only legal to do a
 	// COUNT aggregate on a single column.
-	if !a.countRow && b.ColVec(int(inputIdxs[0])).HasNulls() {
+	if !a.countRow && b.ColVec(int(inputIdxs[0])).MaybeHasNulls() {
 		nulls := b.ColVec(int(inputIdxs[0])).Nulls()
 		if sel != nil {
 			sel = sel[:inputLen]

--- a/pkg/sql/exec/distinct_tmpl.go
+++ b/pkg/sql/exec/distinct_tmpl.go
@@ -178,7 +178,7 @@ func (p *sortedDistinct_TYPEOp) Next(ctx context.Context) coldata.Batch {
 	outputCol := p.outputCol
 	vec := batch.ColVec(p.sortedDistinctCol)
 	var nulls *coldata.Nulls
-	if vec.HasNulls() {
+	if vec.MaybeHasNulls() {
 		nulls = vec.Nulls()
 	}
 	col := vec._TemplateType()
@@ -246,7 +246,7 @@ func (p partitioner_TYPE) partition(colVec coldata.Vec, outputCol []bool, n uint
 	var lastVal _GOTYPE
 	var lastValNull bool
 	var nulls *coldata.Nulls
-	if colVec.HasNulls() {
+	if colVec.MaybeHasNulls() {
 		nulls = colVec.Nulls()
 	}
 

--- a/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
@@ -75,7 +75,7 @@ func (p {{template "opRConstName" .}}) Next(ctx context.Context) coldata.Batch {
 			{{(.Assign "projCol[i]" "col[i]" "p.constArg")}}
 		}
 	}
-	if vec.Nulls().HasNulls() {
+	if vec.Nulls().MaybeHasNulls() {
 		nulls := vec.Nulls().Copy()
 		projVec.SetNulls(&nulls)
 	}
@@ -119,7 +119,7 @@ func (p {{template "opLConstName" .}}) Next(ctx context.Context) coldata.Batch {
 			{{(.Assign "projCol[i]" "p.constArg" "col[i]")}}
 		}
 	}
-	if vec.Nulls().HasNulls() {
+	if vec.Nulls().MaybeHasNulls() {
 		nulls := vec.Nulls().Copy()
 		projVec.SetNulls(&nulls)
 	}
@@ -166,7 +166,7 @@ func (p {{template "opName" .}}) Next(ctx context.Context) coldata.Batch {
 			{{(.Assign "projCol[i]" "col1[i]" "col2[i]")}}
 		}
 	}
-	if vec1.Nulls().HasNulls() || vec2.Nulls().HasNulls() {
+	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 		projVec.SetNulls(vec1.Nulls().Or(vec2.Nulls()))
 	}
 	return batch

--- a/pkg/sql/exec/execgen/cmd/execgen/selection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/selection_ops_gen.go
@@ -108,7 +108,7 @@ func (p *{{template "opConstName" .}}) Next(ctx context.Context) coldata.Batch {
 		col := vec.{{.LTyp}}()[:coldata.BatchSize]
 		var idx uint16
 		n := batch.Length()
-		if vec.HasNulls() {
+		if vec.MaybeHasNulls() {
 			nulls := vec.Nulls()
 			{{template "selConstLoop" buildDict "Global" . "HasNulls" true }}
 		} else {
@@ -148,7 +148,7 @@ func (p *{{template "opName" .}}) Next(ctx context.Context) coldata.Batch {
 		n := batch.Length()
 
 		var idx uint16
-		if vec1.HasNulls() || vec2.HasNulls() {
+		if vec1.MaybeHasNulls() || vec2.MaybeHasNulls() {
 			nulls := vec1.Nulls().Or(vec2.Nulls())
 			{{template "selLoop" buildDict "Global" . "HasNulls" true }}
 		} else {

--- a/pkg/sql/exec/hashjoiner_tmpl.go
+++ b/pkg/sql/exec/hashjoiner_tmpl.go
@@ -119,14 +119,14 @@ func _CHECK_COL_WITH_NULLS(
 	_SEL_STRING string,
 ) { // */}}
 	// {{define "checkColWithNulls"}}
-	if probeVec.HasNulls() {
-		if buildVec.HasNulls() {
+	if probeVec.MaybeHasNulls() {
+		if buildVec.MaybeHasNulls() {
 			_CHECK_COL_BODY(ht, probeVec, buildVec, buildKeys, probeKeys, nToCheck, true, true)
 		} else {
 			_CHECK_COL_BODY(ht, probeVec, buildVec, buildKeys, probeKeys, nToCheck, true, false)
 		}
 	} else {
-		if buildVec.HasNulls() {
+		if buildVec.MaybeHasNulls() {
 			_CHECK_COL_BODY(ht, probeVec, buildVec, buildKeys, probeKeys, nToCheck, false, true)
 		} else {
 			_CHECK_COL_BODY(ht, probeVec, buildVec, buildKeys, probeKeys, nToCheck, false, false)

--- a/pkg/sql/exec/mergejoiner_tmpl.go
+++ b/pkg/sql/exec/mergejoiner_tmpl.go
@@ -273,8 +273,8 @@ EqLoop:
 		lVec := o.proberState.lBatch.ColVec(int(o.left.eqCols[eqColIdx]))
 		rVec := o.proberState.rBatch.ColVec(int(o.right.eqCols[eqColIdx]))
 		colType := o.left.sourceTypes[int(o.left.eqCols[eqColIdx])]
-		if lVec.HasNulls() {
-			if rVec.HasNulls() {
+		if lVec.MaybeHasNulls() {
+			if rVec.MaybeHasNulls() {
 				if o.left.directions[eqColIdx] == distsqlpb.Ordering_Column_ASC {
 					_PROBE_SWITCH(_SEL_ARG, true, true, true)
 				} else {
@@ -288,7 +288,7 @@ EqLoop:
 				}
 			}
 		} else {
-			if rVec.HasNulls() {
+			if rVec.MaybeHasNulls() {
 				if o.left.directions[eqColIdx] == distsqlpb.Ordering_Column_ASC {
 					_PROBE_SWITCH(_SEL_ARG, false, true, true)
 				} else {
@@ -428,13 +428,13 @@ LeftColLoop:
 		colType := input.sourceTypes[colIdx]
 
 		if sel != nil {
-			if src.HasNulls() {
+			if src.MaybeHasNulls() {
 				_LEFT_SWITCH(true, true)
 			} else {
 				_LEFT_SWITCH(true, false)
 			}
 		} else {
-			if src.HasNulls() {
+			if src.MaybeHasNulls() {
 				_LEFT_SWITCH(false, true)
 			} else {
 				_LEFT_SWITCH(false, false)
@@ -568,13 +568,13 @@ RightColLoop:
 		colType := input.sourceTypes[colIdx]
 
 		if sel != nil {
-			if src.HasNulls() {
+			if src.MaybeHasNulls() {
 				_RIGHT_SWITCH(true, true)
 			} else {
 				_RIGHT_SWITCH(true, false)
 			}
 		} else {
-			if src.HasNulls() {
+			if src.MaybeHasNulls() {
 				_RIGHT_SWITCH(false, true)
 			} else {
 				_RIGHT_SWITCH(false, false)
@@ -623,13 +623,13 @@ func (o *mergeJoinOp) isBufferedGroupFinished(
 			var curVal _GOTYPE
 			if sel != nil {
 				// TODO (georgeutsin): Potentially update this logic for non INNER joins.
-				if batch.ColVec(int(colIdx)).HasNulls() && batch.ColVec(int(colIdx)).Nulls().NullAt64(uint64(sel[rowIdx])) {
+				if batch.ColVec(int(colIdx)).MaybeHasNulls() && batch.ColVec(int(colIdx)).Nulls().NullAt64(uint64(sel[rowIdx])) {
 					return true
 				}
 				curVal = batch.ColVec(int(colIdx))._TemplateType()[sel[rowIdx]]
 			} else {
 				// TODO (georgeutsin): Potentially update this logic for non INNER joins.
-				if batch.ColVec(int(colIdx)).HasNulls() && batch.ColVec(int(colIdx)).Nulls().NullAt64(uint64(rowIdx)) {
+				if batch.ColVec(int(colIdx)).MaybeHasNulls() && batch.ColVec(int(colIdx)).Nulls().NullAt64(uint64(rowIdx)) {
 					return true
 				}
 				curVal = batch.ColVec(int(colIdx))._TemplateType()[rowIdx]

--- a/pkg/sql/exec/select_in_tmpl.go
+++ b/pkg/sql/exec/select_in_tmpl.go
@@ -186,7 +186,7 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 			compVal = siFalse
 		}
 
-		if vec.HasNulls() {
+		if vec.MaybeHasNulls() {
 			nulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -260,7 +260,7 @@ func (pi *projectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 		cmpVal = siFalse
 	}
 
-	if vec.HasNulls() {
+	if vec.MaybeHasNulls() {
 		nulls := vec.Nulls()
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]

--- a/pkg/sql/exec/vec_comparators_tmpl.go
+++ b/pkg/sql/exec/vec_comparators_tmpl.go
@@ -57,8 +57,8 @@ type _TYPEVecComparator struct {
 }
 
 func (c *_TYPEVecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 uint16) int {
-	n1 := c.nulls[vecIdx1].HasNulls() && c.nulls[vecIdx1].NullAt(valIdx1)
-	n2 := c.nulls[vecIdx2].HasNulls() && c.nulls[vecIdx2].NullAt(valIdx2)
+	n1 := c.nulls[vecIdx1].MaybeHasNulls() && c.nulls[vecIdx1].NullAt(valIdx1)
+	n2 := c.nulls[vecIdx2].MaybeHasNulls() && c.nulls[vecIdx2].NullAt(valIdx2)
 	if n1 && n2 {
 		return 0
 	} else if n1 {
@@ -79,7 +79,7 @@ func (c *_TYPEVecComparator) setVec(idx int, vec coldata.Vec) {
 }
 
 func (c *_TYPEVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx uint16) {
-	if c.nulls[srcVecIdx].HasNulls() && c.nulls[srcVecIdx].NullAt(srcIdx) {
+	if c.nulls[srcVecIdx].MaybeHasNulls() && c.nulls[srcVecIdx].NullAt(srcIdx) {
 		c.nulls[dstVecIdx].SetNull(dstIdx)
 	} else {
 		c.nulls[dstVecIdx].UnsetNull(dstIdx)


### PR DESCRIPTION
- The HasNulls() function and the corresponding hasNulls field currently
    allows false positives. This rename makes this contract more clear, and
    there also is documentation for it now.
- Also add UnsetNullsAfter function. It's a convenience wrapper around
    UnsetNullRange that will be used by all the aggregators, in order to
    correctly handle nulls.
- Add a small optimization to UnsetNullRange -- it can short-circuit if
    maybeHasNulls is false.
- Clarify comments on Truncate().

Release note: None