### PR TITLE
[WIP] Infrastructure for operations on all operators

### DIFF
--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -497,7 +497,7 @@ func (f *Flow) setup(ctx context.Context, spec *distsqlpb.FlowSpec) error {
 	f.spec = spec
 
 	if f.EvalCtx.SessionData.Vectorize != sessiondata.VectorizeOff {
-		err := f.setupVectorized(ctx)
+		_, err := f.setupVectorized(ctx)
 		if err == nil {
 			log.VEventf(ctx, 1, "vectorized flow.")
 			return nil


### PR DESCRIPTION
Based on discussions with @jordanlewis, it would be useful to be able to iterate over all operators within a flow without needing to update the interface for all existing operators to expose parent/child pointers. One solution is to maintain a tree structure of the operators during translation of a distsql plan into a vectorized plan. Please let me know what you think of this approach! I plan on using it to then calculate memory usage of a vectorized plan.