### PR TITLE
kv: consider IntentMissingErrors as retryable

### DIFF
--- a/pkg/kv/txn_interceptor_committer.go
+++ b/pkg/kv/txn_interceptor_committer.go
@@ -106,7 +106,6 @@ var parallelCommitsEnabled = settings.RegisterBoolSetting(
 // If it is unknown whether all of the requests in the final batch succeeded
 // (e.g. due to a network error) then an AmbiguousResultError is returned. The
 // logic to enforce this is in DistSender.
-// TODO(nvanbenschoten): merge this logic.
 //
 // In all cases, the interceptor abstracts away the details of this from all
 // interceptors above it in the coordinator interceptor stack.


### PR DESCRIPTION
Fixes #38599.

This change implements the transactionRestartError on IntentMissingErrors. This
fixes the referenced issue by ensuring that these errors be prioritized below
TransactionAbortedErrors. This avoids losing context about the cause of the
TransactionAbortedError, which any solution that fixes this above the DistSender
level would do.

The change also adds validation to `roachpb.Error` which ensures that transaction
retry errors are never wrapped around finalized transactions. We might want to
expand the scope of this assertion in the future.