### PR TITLE
[WIP] exec: Framework for static memory usage monitoring for vectorized operators

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -1016,6 +1016,8 @@ func (f *Flow) setupVectorized(ctx context.Context) error {
 	inputs := make([]exec.Operator, 0, 2)
 	metadataSourcesQueue := make([]distsqlpb.MetadataSource, 0, 1)
 
+	vectorizedFlowAcct := f.EvalCtx.Mon.MakeBoundAccount()
+
 	recordingStats := false
 	if sp := opentracing.SpanFromContext(ctx); sp != nil && tracing.IsRecording(sp) {
 		recordingStats = true
@@ -1043,6 +1045,13 @@ func (f *Flow) setupVectorized(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+
+		if staticMemOp, ok := op.(exec.StaticMemOperator); ok {
+			if err := vectorizedFlowAcct.Grow(ctx, staticMemOp.DeclareStaticMemoryUsage()); err != nil {
+				return errors.Wrap(err, "not enough memory to construct vectorized operator")
+			}
+		}
+
 		if metaSource, ok := op.(distsqlpb.MetadataSource); ok {
 			metadataSourcesQueue = append(metadataSourcesQueue, metaSource)
 		}

--- a/pkg/sql/exec/aggregator.go
+++ b/pkg/sql/exec/aggregator.go
@@ -106,6 +106,7 @@ type orderedAggregator struct {
 }
 
 var _ Operator = &orderedAggregator{}
+var _ StaticMemOperator = &orderedAggregator{}
 
 // NewOrderedAggregator creates an ordered aggregator on the given grouping
 // columns. aggCols is a slice where each index represents a new aggregation
@@ -317,4 +318,8 @@ func extractAggTypes(aggCols [][]uint32, colTypes []types.T) [][]types.T {
 	}
 
 	return aggTyps
+}
+
+func (a *orderedAggregator) DeclareStaticMemoryUsage() int64 {
+	return a.scratch.Batch.SizeBytes()
 }

--- a/pkg/sql/exec/coldata/batch.go
+++ b/pkg/sql/exec/coldata/batch.go
@@ -45,6 +45,9 @@ type Batch interface {
 	// columns and allocations, invalidating existing references to the Batch or
 	// its Vecs. However, Reset does _not_ zero out the column data.
 	Reset(types []types.T, length int)
+	// SizeBytes returns an approximation of the amount of memory used to
+	// represent this batch.
+	SizeBytes() int64
 }
 
 var _ Batch = &MemBatch{}
@@ -154,4 +157,13 @@ func (m *MemBatch) Reset(types []types.T, length int) {
 	for _, col := range m.ColVecs() {
 		col.Nulls().UnsetNulls()
 	}
+}
+
+// SizeBytes implements the Batch interface
+func (m *MemBatch) SizeBytes() int64 {
+	size := int64(0)
+	for _, vec := range m.ColVecs() {
+		size += vec.SizeBytes()
+	}
+	return size
 }

--- a/pkg/sql/exec/coldata/vec.go
+++ b/pkg/sql/exec/coldata/vec.go
@@ -141,6 +141,9 @@ type Vec interface {
 
 	// SetNulls sets the nulls vector for this column.
 	SetNulls(*Nulls)
+
+	// SizeBytes returns how many bytes of memory are used to store this object.
+	SizeBytes() int64
 }
 
 var _ Vec = &memColumn{}
@@ -243,4 +246,32 @@ func (m *memColumn) Nulls() *Nulls {
 
 func (m *memColumn) SetNulls(n *Nulls) {
 	m.nulls = *n
+}
+
+func (m *memColumn) SizeBytes() int64 {
+	switch m.t {
+	case types.Bool:
+		return int64(1 * len(m.Bool()))
+	case types.Bytes:
+		// We don't know right now what to use as the size
+		// for a byte array. Use some default value right now!
+		return int64(500 * len(m.Bytes()))
+	case types.Int8:
+		return int64(8 * len(m.Int8()))
+	case types.Int16:
+		return int64(16 * len(m.Int16()))
+	case types.Int32:
+		return int64(32 * len(m.Int32()))
+	case types.Int64:
+		return int64(64 * len(m.Int64()))
+	case types.Float32:
+		return int64(32 * len(m.Float32()))
+	case types.Float64:
+		return int64(32 * len(m.Float64()))
+	case types.Decimal:
+		// TODO: how much space does one decimal take up?
+		return int64(50 * len(m.Decimal()))
+	default:
+		panic(fmt.Sprintf("unhandled type %s", m.t))
+	}
 }

--- a/pkg/sql/exec/count.go
+++ b/pkg/sql/exec/count.go
@@ -30,6 +30,7 @@ type countOp struct {
 }
 
 var _ Operator = &countOp{}
+var _ StaticMemOperator = &countOp{}
 
 // NewCountOp returns a new count operator that counts the rows in its input.
 func NewCountOp(input Operator) Operator {
@@ -64,4 +65,8 @@ func (c *countOp) Next(ctx context.Context) coldata.Batch {
 		}
 		c.count += int64(length)
 	}
+}
+
+func (c *countOp) DeclareStaticMemoryUsage() int64 {
+	return c.internalBatch.SizeBytes()
 }

--- a/pkg/sql/exec/mergejoiner_groups_buffer.go
+++ b/pkg/sql/exec/mergejoiner_groups_buffer.go
@@ -226,6 +226,12 @@ func (bg *mjBufferedGroup) Reset(types []types.T, length int) {
 	panic("Reset([]types.T, int) should not be called on mjBufferedGroup")
 }
 
+// SizeBytes is not implemented because it is not being used right now
+// on mjBufferedGroups.
+func (bg *mjBufferedGroup) SizeBytes() int64 {
+	panic("SizeBytes() should not be called on mjBufferedGroup")
+}
+
 // reset resets the state of the buffered group so that we can reuse the
 // underlying memory.
 func (bg *mjBufferedGroup) reset() {

--- a/pkg/sql/exec/operator.go
+++ b/pkg/sql/exec/operator.go
@@ -46,6 +46,16 @@ type resettableOperator interface {
 	resetter
 }
 
+// StaticMemOperator is an interface that operators can implement if they know
+// what their static memory usage is.
+type StaticMemOperator interface {
+	Operator
+
+	// DeclareStaticMemory can be used by operators to declare upfront
+	// their memory usage when it is known.
+	DeclareStaticMemoryUsage() int64
+}
+
 type noopOperator struct {
 	input Operator
 }


### PR DESCRIPTION
Operators declare their memory usage by implementing the
StaticMemOperator interface function DeclareStaticMemoryUsage().
Operators that have this method defined will have this memory
usage value added into the memory monitor performing the
translation from a distsql plan into a vectorized plan.

Release note: None