### PR TITLE
release-19.1: sql: fix inverted index validation on null values

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -681,3 +681,17 @@ SELECT * from update_cascade_test ORDER BY update_cascade;
 2  {"a": "b", "c": "d"}
 3  ["b", "c"]
 5  ["a", "b"]
+
+# Test that inverted index validation correctly handles NULL values on creation (#38714)
+
+statement ok
+CREATE TABLE table_with_nulls (a JSON)
+
+statement ok
+INSERT INTO table_with_nulls VALUES (NULL)
+
+statement ok
+CREATE INVERTED INDEX ON table_with_nulls (a)
+
+statement ok
+DROP TABLE table_with_nulls

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2977,13 +2977,18 @@ may increase either contention or retry errors, or both.`,
 	// Returns the number of distinct inverted index entries that would be generated for a JSON value.
 	"crdb_internal.json_num_index_entries": makeBuiltin(
 		tree.FunctionProperties{
-			Category: categorySystemInfo,
+			Category:     categorySystemInfo,
+			NullableArgs: true,
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.JSON}},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				n, err := json.NumInvertedIndexEntries(tree.MustBeDJSON(args[0]).JSON)
+				arg := args[0]
+				if arg == tree.DNull {
+					return tree.NewDInt(tree.DInt(1)), nil
+				}
+				n, err := json.NumInvertedIndexEntries(tree.MustBeDJSON(arg).JSON)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
Backport 1/1 commits from #38738.

/cc @cockroachdb/release

---

There was a bug where creating inverted indexes would fail at the validation
step for columns containing null values, since we neglected to include nulls
when counting the expected index entries. This PR fixes the builtin function
being used to count expected index entries.

Fixes #38714.

Release note (bug fix): Fix bug that prevented inverted indexes from being
created on JSON columns containing NULL values.
