### PR TITLE
opt: use SQLString for histogram data type

### DIFF
--- a/pkg/sql/stats/json.go
+++ b/pkg/sql/stats/json.go
@@ -53,7 +53,7 @@ type JSONHistoBucket struct {
 // SetHistogram fills in the HistogramColumnType and HistogramBuckets fields.
 func (js *JSONStatistic) SetHistogram(h *HistogramData) error {
 	typ := &h.ColumnType
-	js.HistogramColumnType = typ.String()
+	js.HistogramColumnType = typ.SQLString()
 	js.HistogramBuckets = make([]JSONHistoBucket, len(h.Buckets))
 	var a sqlbase.DatumAlloc
 	for i := range h.Buckets {


### PR DESCRIPTION
The json histogram representation stores (in `HistogramColumnType`)
the data type as a SQL string, later parsed using `ParseType`. The
correct method to generate such a string is `SQLString`; use it
instead of `String` (which drops information such as width,
precision).

Closes #28941.

Release note: None