### PR TITLE
quotapool: add fast path to Acquire

### DIFF
--- a/pkg/util/quotapool/intpool.go
+++ b/pkg/util/quotapool/intpool.go
@@ -194,10 +194,7 @@ func (p *IntPool) Len() int {
 }
 
 // ApproximateQuota will report approximately the amount of quota available in
-// the pool. It is precise if there are no ongoing acquisitions. If there are,
-// the return value can be up to 'v' less than actual available quota where 'v'
-// is the value the acquisition goroutine first in line is attempting to
-// acquire.
+// the pool.
 func (p *IntPool) ApproximateQuota() (q uint64) {
 	p.qp.ApproximateQuota(func(r Resource) {
 		if ia, ok := r.(*intAlloc); ok {

--- a/pkg/util/quotapool/intpool_test.go
+++ b/pkg/util/quotapool/intpool_test.go
@@ -462,6 +462,7 @@ func BenchmarkConcurrentIntQuotaPool(b *testing.B) {
 		{128, 4},
 		{512, 128},
 		{512, 513},
+		{512, 511},
 	} {
 		b.Run(test(c.workers, c.quota))
 	}

--- a/pkg/util/quotapool/notify_queue_test.go
+++ b/pkg/util/quotapool/notify_queue_test.go
@@ -36,7 +36,9 @@ func testNotifyQueue(t testing.TB, N int) {
 	b, _ := t.(*testing.B)
 	var q notifyQueue
 	initializeNotifyQueue(&q)
-	assert.Nil(t, q.dequeue())
+	n := q.peek()
+	assert.Nil(t, n)
+	q.dequeue()
 	assert.Equal(t, 0, int(q.len))
 	chans := make([]chan struct{}, N)
 	for i := 0; i < N; i++ {
@@ -66,21 +68,23 @@ func testNotifyQueue(t testing.TB, N int) {
 		case dequeue:
 			// Only test Peek if we're not benchmarking.
 			if b == nil {
-				if c := q.peek(); c != nil {
-					out = append(out, c)
-					assert.Equal(t, c, q.dequeue())
+				if n := q.peek(); n != nil {
+					out = append(out, n.c)
+					q.dequeue()
 					l--
 					assert.Equal(t, l, int(q.len))
 				}
 			} else {
-				if c := q.dequeue(); c != nil {
-					out = append(out, c)
+				if n := q.peek(); n != nil {
+					out = append(out, n.c)
+					q.dequeue()
 				}
 			}
 		}
 	}
-	for c := q.dequeue(); c != nil; c = q.dequeue() {
-		out = append(out, c)
+	for n := q.peek(); n != nil; n = q.peek() {
+		out = append(out, n.c)
+		q.dequeue()
 	}
 	if b != nil {
 		b.StopTimer()

--- a/pkg/util/quotapool/quotapool.go
+++ b/pkg/util/quotapool/quotapool.go
@@ -94,13 +94,6 @@ type QuotaPool struct {
 	// goroutines waiting in Acquire.
 	chanSyncPool sync.Pool
 
-	// We use a channel to 'park' our quota value for easier composition with
-	// context cancellation and quotaPool closing (see quotaPool.Acquire).
-	//
-	// Resource additions push a value into the channel whereas the acquisition
-	// first in line waits on the channel itself.
-	quota chan Resource
-
 	// Ongoing acquisitions listen on done which is closed when the quota
 	// pool is closed (see QuotaPool.Close).
 	done chan struct{}
@@ -110,6 +103,9 @@ type QuotaPool struct {
 
 	mu struct {
 		syncutil.Mutex
+
+		// quota stores the current quantity of quota available in the pool.
+		quota Resource
 
 		// We service quota acquisitions in a first come, first serve basis. This
 		// is done in order to prevent starvations of large acquisitions by a
@@ -138,9 +134,8 @@ type QuotaPool struct {
 // acquired without ever making more than the quota capacity available.
 func New(name string, initialResource Resource, options ...Option) *QuotaPool {
 	qp := &QuotaPool{
-		name:  name,
-		quota: make(chan Resource, 1),
-		done:  make(chan struct{}),
+		name: name,
+		done: make(chan struct{}),
 		chanSyncPool: sync.Pool{
 			New: func() interface{} { return make(chan struct{}, 1) },
 		},
@@ -148,211 +143,17 @@ func New(name string, initialResource Resource, options ...Option) *QuotaPool {
 	for _, o := range options {
 		o.apply(&qp.config)
 	}
+	qp.mu.quota = initialResource
 	initializeNotifyQueue(&qp.mu.q)
-	qp.quota <- initialResource
 	return qp
 }
 
-// Add adds the provided Alloc back to the pool. The value will be merged with
-// the existing resources in the QuotaPool if there are any.
-//
-// Safe for concurrent use.
-func (qp *QuotaPool) Add(v Resource) {
-	qp.mu.Lock()
-	defer qp.mu.Unlock()
-	qp.addLocked(v)
-}
-
-func (qp *QuotaPool) addLocked(r Resource) {
-	select {
-	case q := <-qp.quota:
-		r.Merge(q)
-	default:
-	}
-	qp.quota <- r
-}
-
-// Acquire attempts to fulfill the Request with Resource from the qp.
-// Requests are serviced in a FIFO order; only a single request is ever
-// being offered resources at a time. A Request will be offered the pool's
-// current quantity of Resource until it is fulfilled or its context is
-// canceled.
-//
-// Safe for concurrent use.
-func (qp *QuotaPool) Acquire(ctx context.Context, r Request) (err error) {
-	notifyCh := qp.chanSyncPool.Get().(chan struct{})
-	qp.mu.Lock()
-	var closeErr error
-	if qp.mu.closed {
-		closeErr = qp.closeErr
-	} else {
-		qp.mu.q.enqueue(notifyCh)
-		// If we're first in line, we notify ourself immediately.
-		if qp.mu.q.len == 1 {
-			notifyCh <- struct{}{}
-		}
-	}
-	qp.mu.Unlock()
-	if closeErr != nil {
-		return closeErr
-	}
-	start := timeutil.Now()
-	// Set up onAcquisition if we have one.
-	if qp.config.onAcquisition != nil {
-		defer func() {
-			if err == nil {
-				qp.config.onAcquisition(ctx, qp.name, r, start)
-			}
-		}()
-	}
-
-	// Set up the infrastructure to report slow requests.
-	var slowTimer *timeutil.Timer
-	var slowTimerC <-chan time.Time
-	if qp.onSlowAcquisition != nil {
-		slowTimer = timeutil.NewTimer()
-		defer slowTimer.Stop()
-		// Intentionally reset only once, for we care more about the select duration in
-		// goroutine profiles than periodic logging.
-		slowTimer.Reset(qp.slowAcquisitionThreshold)
-		slowTimerC = slowTimer.C
-	}
-	for {
-		select {
-		case <-slowTimerC:
-			slowTimer.Read = true
-			defer qp.onSlowAcquisition(ctx, qp.name, r, start)()
-			continue
-		case <-ctx.Done():
-			qp.mu.Lock()
-			// We no longer need to be notified but we need to be careful and check
-			// whether or not we're first in queue. If so, we need to notify the
-			// next acquisition goroutine and clean up the waiting queue while
-			// doing so.
-			//
-			// Else we simply 'unregister' ourselves from the queue by filling
-			// up the channel buffer. This is what is checked when a goroutine
-			// wishes to notify the next in line.
-			if qp.mu.q.peek() == notifyCh {
-				// It is possible that we were notified before we grabbed the mutex but
-				// after the context cancellation in which case we must clear notifyCh
-				// so that qp.notifyNextLocked() can put it back into the pool.
-				select {
-				case <-notifyCh:
-				default:
-				}
-				qp.notifyNextLocked()
-			} else {
-				// NB: Notifying the channel before moving it to the head of the
-				// queue is safe because the queue itself is guarded by a lock.
-				// Goroutines are not a risk of getting notified and finding
-				// out they're not first in line.
-				notifyCh <- struct{}{}
-				qp.mu.numCanceled++
-			}
-			qp.mu.Unlock()
-			return ctx.Err()
-		case <-qp.done:
-			// We don't need to 'unregister' ourselves as in the case when the
-			// context is canceled. In fact, we want others waiters to only
-			// receive on qp.done and signaling them would work against that.
-			return qp.closeErr // always non-nil when qp.done is closed
-		case <-notifyCh:
-
-		}
-		break
-	}
-
-	// We're first in line to receive quota, we keep accumulating quota until
-	// we've acquired enough or determine we no longer need the acquisition.
-	// If we have acquired the quota needed or our context gets canceled,
-	// we're sure to remove ourselves from the queue and notify the goroutine
-	// next in line (if any).
-	var alloc, unused Resource
-	var fulfilled bool
-	for !fulfilled {
-		select {
-		case <-slowTimerC:
-			slowTimer.Read = true
-			defer qp.onSlowAcquisition(ctx, qp.name, r, start)()
-		case <-ctx.Done():
-			qp.mu.Lock()
-			if alloc != nil {
-				qp.addLocked(alloc)
-			}
-			qp.notifyNextLocked()
-			qp.mu.Unlock()
-			return ctx.Err()
-		case <-qp.done:
-			// We don't need to release quota back as all ongoing and
-			// subsequent acquisitions will succeed immediately.
-			return qp.closeErr // always non-nil when qp.done is closed
-		case more := <-qp.quota:
-			if alloc == nil {
-				alloc = more
-			} else {
-				alloc.Merge(more)
-			}
-			fulfilled, unused = r.Acquire(ctx, alloc)
-		}
-	}
-	qp.mu.Lock()
-	if unused != nil {
-		qp.addLocked(unused)
-	}
-	qp.notifyNextLocked()
-	qp.mu.Unlock()
-	return nil
-}
-
-// notifyNextLocked notifies the waiting acquisition goroutine next in line (if
-// any). It requires that qp.mu.Mutex is held.
-func (qp *QuotaPool) notifyNextLocked() {
-	// We're at the head of the queue. In all cases we ensure that the channel
-	// at the head of the queue has already been notified.
-	qp.chanSyncPool.Put(qp.mu.q.dequeue())
-	// We traverse until we find a goroutine waiting to be notified, notify the
-	// goroutine and truncate our queue so to ensure the said goroutine is at the
-	// head of the queue. Normally the next lined up waiter is the one waiting for
-	// notification, but if others behind us have also gotten their context
-	// canceled, they will leave behind waiters that we would skip below.
-	//
-	// If we determine there are no goroutines waiting, we simply truncate the
-	// queue to reflect this.
-	for ch := qp.mu.q.peek(); ch != nil; ch = qp.mu.q.peek() {
-		select {
-		case ch <- struct{}{}:
-		default:
-			// When requests are canceled by their context, they ensure that they
-			// cannot be notified by sending a message on their own queued notify
-			// channel. The default case here deals with canceled queued channels
-			// by clearing the channel before putting it back in the pool and then
-			// shifting the queue.
-			<-ch
-			qp.chanSyncPool.Put(qp.mu.q.dequeue())
-			qp.mu.numCanceled--
-			continue
-		}
-		break
-	}
-}
-
 // ApproximateQuota will report approximately the amount of quota available
-// in the pool to f. It is accurate only if there are no ongoing acquisition
-// goroutines. If there are, the passed value can be nil if there is an ongoing
-// acquisition or if non-nil may contain a value up to 'v' less than actual
-// available quota where 'v' is the value the acquisition goroutine first in
-// line is attempting to acquire. The provided Resource must not be mutated.
+// in the pool to f. The provided Resource must not be mutated.
 func (qp *QuotaPool) ApproximateQuota(f func(Resource)) {
 	qp.mu.Lock()
 	defer qp.mu.Unlock()
-	select {
-	case q := <-qp.quota:
-		f(q)
-		qp.quota <- q
-	default:
-		f(nil)
-	}
+	f(qp.mu.quota)
 }
 
 // Len returns the current length of the queue for this QuotaPool.
@@ -370,12 +171,191 @@ func (qp *QuotaPool) Len() int {
 func (qp *QuotaPool) Close(reason string) {
 	qp.mu.Lock()
 	defer qp.mu.Unlock()
-	if qp.closeErr == nil {
-		qp.mu.closed = true
-		qp.closeErr = &ErrClosed{
-			poolName: qp.name,
-			reason:   reason,
+	if qp.mu.closed {
+		return
+	}
+	qp.mu.closed = true
+	qp.closeErr = &ErrClosed{
+		poolName: qp.name,
+		reason:   reason,
+	}
+	close(qp.done)
+}
+
+// Add adds the provided Alloc back to the pool. The value will be merged with
+// the existing resources in the QuotaPool if there are any.
+//
+// Safe for concurrent use.
+func (qp *QuotaPool) Add(v Resource) {
+	qp.mu.Lock()
+	defer qp.mu.Unlock()
+	qp.addLocked(v)
+}
+
+func (qp *QuotaPool) addLocked(r Resource) {
+	if qp.mu.quota != nil {
+		r.Merge(qp.mu.quota)
+	}
+	qp.mu.quota = r
+	// Notify the head of the queue if there is one waiting.
+	if n := qp.mu.q.peek(); n != nil && n.c != nil {
+		select {
+		case n.c <- struct{}{}:
+		default:
 		}
-		close(qp.done)
+	}
+}
+
+// Acquire attempts to fulfill the Request with Resource from the qp.
+// Requests are serviced in a FIFO order; only a single request is ever
+// being offered resources at a time. A Request will be offered the pool's
+// current quantity of Resource until it is fulfilled or its context is
+// canceled.
+//
+// Safe for concurrent use.
+func (qp *QuotaPool) Acquire(ctx context.Context, r Request) (err error) {
+	// Set up onAcquisition if we have one.
+	start := timeutil.Now()
+	if qp.config.onAcquisition != nil {
+		defer func() {
+			if err == nil {
+				qp.config.onAcquisition(ctx, qp.name, r, start)
+			}
+		}()
+	}
+	// Attempt to acquire quota on the fast path.
+	fulfilled, n, err := qp.acquireFastPath(ctx, r)
+	if fulfilled || err != nil {
+		return err
+	}
+	// Set up the infrastructure to report slow requests.
+	var slowTimer *timeutil.Timer
+	var slowTimerC <-chan time.Time
+	if qp.onSlowAcquisition != nil {
+		slowTimer = timeutil.NewTimer()
+		defer slowTimer.Stop()
+		// Intentionally reset only once, for we care more about the select duration in
+		// goroutine profiles than periodic logging.
+		slowTimer.Reset(qp.slowAcquisitionThreshold)
+		slowTimerC = slowTimer.C
+	}
+	for {
+		select {
+		case <-slowTimerC:
+			slowTimer.Read = true
+			slowTimerC = nil
+			defer qp.onSlowAcquisition(ctx, qp.name, r, start)()
+			continue
+		case <-n.c:
+			if fulfilled := qp.tryAcquireOnNotify(ctx, r, n); fulfilled {
+				return nil
+			}
+		case <-ctx.Done():
+			qp.cleanupOnCancel(n)
+			return ctx.Err()
+		case <-qp.done:
+			// We don't need to 'unregister' ourselves as in the case when the
+			// context is canceled. In fact, we want others waiters to only
+			// receive on qp.done and signaling them would work against that.
+			return qp.closeErr // always non-nil when qp.done is closed
+		}
+	}
+}
+
+// acquireFastPath attempts to acquire quota if nobody is waiting and returns a
+// notifyee if the request is not immediately fulfilled.
+func (qp *QuotaPool) acquireFastPath(
+	ctx context.Context, r Request,
+) (fulfilled bool, _ *notifyee, _ error) {
+	qp.mu.Lock()
+	defer qp.mu.Unlock()
+	if qp.mu.closed {
+		return false, nil, qp.closeErr
+	}
+	if qp.mu.q.len == 0 {
+		if fulfilled, unused := r.Acquire(ctx, qp.mu.quota); fulfilled {
+			qp.mu.quota = unused
+			return true, nil, nil
+		}
+	}
+	c := qp.chanSyncPool.Get().(chan struct{})
+	return false, qp.mu.q.enqueue(c), nil
+}
+
+func (qp *QuotaPool) tryAcquireOnNotify(
+	ctx context.Context, r Request, n *notifyee,
+) (fulfilled bool) {
+	// Release the notify channel back into the sync pool if we're fulfilled.
+	// Capture nc's value because it's not safe to avoid a race accessing n after
+	// it has been released back to the notifyQueue.
+	defer func(nc chan struct{}) {
+		if fulfilled {
+			qp.chanSyncPool.Put(nc)
+		}
+	}(n.c)
+
+	qp.mu.Lock()
+	defer qp.mu.Unlock()
+	// Make sure nobody already notified us again between the last receive and grabbing
+	// the mutex.
+	if len(n.c) > 0 {
+		<-n.c
+	}
+	var unused Resource
+	if fulfilled, unused = r.Acquire(ctx, qp.mu.quota); fulfilled {
+		n.c = nil
+		qp.mu.quota = unused
+		qp.notifyNextLocked()
+	}
+	return fulfilled
+}
+
+func (qp *QuotaPool) cleanupOnCancel(n *notifyee) {
+	// No matter what, we're going to want to put our notify channel back in to
+	// the sync pool. Note that this defer call evaluates n.c here and is not
+	// affected by later code that sets n.c to nil.
+	defer qp.chanSyncPool.Put(n.c)
+
+	qp.mu.Lock()
+	defer qp.mu.Unlock()
+
+	// It we're not the head, prevent ourselves from being notified and move
+	// along.
+	if n != qp.mu.q.peek() {
+		n.c = nil
+		qp.mu.numCanceled++
+		return
+	}
+
+	// If we're the head, make sure nobody already notified us before we notify the
+	// next waiting notifyee.
+	if len(n.c) > 0 {
+		<-n.c
+	}
+	qp.notifyNextLocked()
+}
+
+// notifyNextLocked notifies the waiting acquisition goroutine next in line (if
+// any). It requires that qp.mu.Mutex is held.
+func (qp *QuotaPool) notifyNextLocked() {
+	// Pop ourselves off the front of the queue.
+	qp.mu.q.dequeue()
+	// We traverse until we find a goroutine waiting to be notified, notify the
+	// goroutine and truncate our queue to ensure the said goroutine is at the
+	// head of the queue. Normally the next lined up waiter is the one waiting for
+	// notification, but if others behind us have also gotten their context
+	// canceled, they will leave behind notifyees with nil channels that we skip
+	// below.
+	//
+	// If we determine there are no goroutines waiting, we simply truncate the
+	// queue to reflect this.
+	for n := qp.mu.q.peek(); n != nil; n = qp.mu.q.peek() {
+		if n.c == nil {
+			qp.mu.numCanceled--
+			qp.mu.q.dequeue()
+			continue
+		}
+		n.c <- struct{}{}
+		break
 	}
 }


### PR DESCRIPTION
In recent admission control work it was determined that the inefficiency of the
acquisition path was artificially limiting throughput. This change is
especially critical to make the common case where there is a large amount of
traffic but generally enough quota. When applied to a current admission control
prototype it moves changes the impact of the read quota from having a ~30%
overhead on peak throughput of KV95 on 16-core machines to not having any
affect on peak throughput and not or detecting overload until the system
reaches a concurrency where throughput has already fallen by over 10%.

```
name                                            old time/op    new time/op    delta
ConcurrentIntQuotaPool/workers=512,quota=511-8    3.76µs ±28%    2.14µs ±70%  -43.12%  (p=0.001 n=10+10)
```

```
name                                            old time/op    new time/op    delta
IntQuotaPool-8                                     625ns ± 9%     238ns ±11%   -61.97%  (p=0.000 n=10+9)
ConcurrentIntQuotaPool/workers=1,quota=1-8        1.08µs ± 1%    0.37µs ± 5%   -65.73%  (p=0.000 n=8+10)
ConcurrentIntQuotaPool/workers=2,quota=2-8        1.49µs ±19%    0.42µs ± 5%   -72.08%  (p=0.000 n=10+9)
ConcurrentIntQuotaPool/workers=8,quota=4-8        2.69µs ± 1%    2.73µs ± 8%      ~     (p=1.000 n=7+10)
ConcurrentIntQuotaPool/workers=128,quota=4-8      3.43µs ±50%    2.76µs ±20%   -19.58%  (p=0.019 n=10+10)
ConcurrentIntQuotaPool/workers=512,quota=128-8    3.13µs ±24%    3.35µs ±53%      ~     (p=0.842 n=9+10)
ConcurrentIntQuotaPool/workers=512,quota=513-8    4.00µs ±37%    0.87µs ± 4%   -78.31%  (p=0.000 n=10+9)
IntQuotaPoolFunc-8                                1.02µs ± 6%    0.32µs ± 5%   -68.58%  (p=0.000 n=8+9)

name                                            old alloc/op   new alloc/op   delta
IntQuotaPool-8                                     0.00B          0.00B           ~     (all equal)
ConcurrentIntQuotaPool/workers=1,quota=1-8         0.00B          0.00B           ~     (all equal)
ConcurrentIntQuotaPool/workers=2,quota=2-8         0.00B          0.00B           ~     (all equal)
ConcurrentIntQuotaPool/workers=8,quota=4-8         0.00B          0.00B           ~     (all equal)
ConcurrentIntQuotaPool/workers=128,quota=4-8       0.00B          0.00B           ~     (all equal)
ConcurrentIntQuotaPool/workers=512,quota=128-8     1.00B ± 0%     1.00B ± 0%      ~     (all equal)
ConcurrentIntQuotaPool/workers=512,quota=513-8     3.60B ±94%     0.00B       -100.00%  (p=0.000 n=10+10)
IntQuotaPoolFunc-8                                 16.0B ± 0%     16.0B ± 0%      ~     (all equal)

name                                            old allocs/op  new allocs/op  delta
IntQuotaPool-8                                      0.00           0.00           ~     (all equal)
ConcurrentIntQuotaPool/workers=1,quota=1-8          0.00           0.00           ~     (all equal)
ConcurrentIntQuotaPool/workers=2,quota=2-8          0.00           0.00           ~     (all equal)
ConcurrentIntQuotaPool/workers=8,quota=4-8          0.00           0.00           ~     (all equal)
ConcurrentIntQuotaPool/workers=128,quota=4-8        0.00           0.00           ~     (all equal)
ConcurrentIntQuotaPool/workers=512,quota=128-8      0.00           0.00           ~     (all equal)
ConcurrentIntQuotaPool/workers=512,quota=513-8      0.00           0.00           ~     (all equal)
IntQuotaPoolFunc-8                                  1.00 ± 0%      1.00 ± 0%      ~     (all equal)
```

Release note: None