### PR TITLE
storage: use `%+v` instead of `%s`/`%v` in fatals/errors and tests

### DIFF
--- a/pkg/storage/abortspan/abortspan_test.go
+++ b/pkg/storage/abortspan/abortspan_test.go
@@ -70,7 +70,7 @@ func TestAbortSpanPutGetClearData(t *testing.T) {
 		Priority:  testTxnPriority,
 	}
 	if err := sc.Put(context.Background(), e, nil, testTxnID, &entry); err != nil {
-		t.Errorf("unexpected error putting response: %s", err)
+		t.Errorf("unexpected error putting response: %+v", err)
 	}
 
 	tryHit := func(expAbort bool, expEntry roachpb.AbortSpanEntry) {
@@ -105,6 +105,6 @@ func TestAbortSpanEmptyParams(t *testing.T) {
 	}
 	// Put value for test response.
 	if err := sc.Put(context.Background(), e, nil, testTxnID, &entry); err != nil {
-		t.Errorf("unexpected error putting response: %s", err)
+		t.Errorf("unexpected error putting response: %+v", err)
 	}
 }

--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -441,7 +441,7 @@ func (a *Allocator) allocateTargetFromList(
 		details := decisionDetails{Target: target.compactString(options)}
 		detailsBytes, err := json.Marshal(details)
 		if err != nil {
-			log.Warningf(ctx, "failed to marshal details for choosing allocate target: %s", err)
+			log.Warningf(ctx, "failed to marshal details for choosing allocate target: %+v", err)
 		}
 		return &target.store, string(detailsBytes)
 	}
@@ -509,7 +509,7 @@ func (a Allocator) RemoveTarget(
 				details := decisionDetails{Target: bad.compactString(options)}
 				detailsBytes, err := json.Marshal(details)
 				if err != nil {
-					log.Warningf(ctx, "failed to marshal details for choosing remove target: %s", err)
+					log.Warningf(ctx, "failed to marshal details for choosing remove target: %+v", err)
 				}
 				return exist, string(detailsBytes), nil
 			}
@@ -643,7 +643,7 @@ func (a Allocator) RebalanceTarget(
 			replicaCandidates,
 			rangeInfo)
 		if err != nil {
-			log.Warningf(ctx, "simulating RemoveTarget failed: %s", err)
+			log.Warningf(ctx, "simulating RemoveTarget failed: %+v", err)
 			return nil, ""
 		}
 		if target.store.StoreID != removeReplica.StoreID {
@@ -663,7 +663,7 @@ func (a Allocator) RebalanceTarget(
 	}
 	detailsBytes, err := json.Marshal(details)
 	if err != nil {
-		log.Warningf(ctx, "failed to marshal details for choosing rebalance target: %s", err)
+		log.Warningf(ctx, "failed to marshal details for choosing rebalance target: %+v", err)
 	}
 
 	return &target.store, string(detailsBytes)
@@ -949,7 +949,7 @@ func (a Allocator) shouldTransferLeaseUsingStats(
 	for requestLocalityStr, qps := range qpsStats {
 		var requestLocality roachpb.Locality
 		if err := requestLocality.Set(requestLocalityStr); err != nil {
-			log.Errorf(ctx, "unable to parse locality string %q: %s", requestLocalityStr, err)
+			log.Errorf(ctx, "unable to parse locality string %q: %+v", requestLocalityStr, err)
 			continue
 		}
 		for nodeID, replicaLocality := range replicaLocalities {
@@ -979,7 +979,7 @@ func (a Allocator) shouldTransferLeaseUsingStats(
 		}
 		addr, err := a.storePool.gossip.GetNodeIDAddress(repl.NodeID)
 		if err != nil {
-			log.Errorf(ctx, "missing address for n%d: %s", repl.NodeID, err)
+			log.Errorf(ctx, "missing address for n%d: %+v", repl.NodeID, err)
 			continue
 		}
 		remoteLatency, ok := a.nodeLatencyFn(addr.String())

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -402,7 +402,7 @@ func TestAllocatorSimpleRetrieval(t *testing.T) {
 		firstRangeInfo,
 	)
 	if err != nil {
-		t.Fatalf("Unable to perform allocation: %v", err)
+		t.Fatalf("Unable to perform allocation: %+v", err)
 	}
 	if result.Node.NodeID != 1 || result.StoreID != 1 {
 		t.Errorf("expected NodeID 1 and StoreID 1: %+v", result)
@@ -442,7 +442,7 @@ func TestAllocatorTwoDatacenters(t *testing.T) {
 		firstRangeInfo,
 	)
 	if err != nil {
-		t.Fatalf("Unable to perform allocation: %v", err)
+		t.Fatalf("Unable to perform allocation: %+v", err)
 	}
 	result2, _, err := a.AllocateTarget(
 		ctx,
@@ -454,7 +454,7 @@ func TestAllocatorTwoDatacenters(t *testing.T) {
 		firstRangeInfo,
 	)
 	if err != nil {
-		t.Fatalf("Unable to perform allocation: %v", err)
+		t.Fatalf("Unable to perform allocation: %+v", err)
 	}
 	ids := []int{int(result1.Node.NodeID), int(result2.Node.NodeID)}
 	sort.Ints(ids)
@@ -510,7 +510,7 @@ func TestAllocatorExistingReplica(t *testing.T) {
 		firstRangeInfo,
 	)
 	if err != nil {
-		t.Fatalf("Unable to perform allocation: %v", err)
+		t.Fatalf("Unable to perform allocation: %+v", err)
 	}
 	if !(result.StoreID == 3 || result.StoreID == 4) {
 		t.Errorf("expected result to have store ID 3 or 4: %+v", result)
@@ -5080,7 +5080,7 @@ func TestAllocatorThrottled(t *testing.T) {
 		firstRangeInfo,
 	)
 	if _, ok := err.(purgatoryError); !ok {
-		t.Fatalf("expected a purgatory error, got: %v", err)
+		t.Fatalf("expected a purgatory error, got: %+v", err)
 	}
 
 	// Second, test the normal case in which we can allocate to the store.
@@ -5092,7 +5092,7 @@ func TestAllocatorThrottled(t *testing.T) {
 		firstRangeInfo,
 	)
 	if err != nil {
-		t.Fatalf("unable to perform allocation: %v", err)
+		t.Fatalf("unable to perform allocation: %+v", err)
 	}
 	if result.Node.NodeID != 1 || result.StoreID != 1 {
 		t.Errorf("expected NodeID 1 and StoreID 1: %+v", result)
@@ -5114,7 +5114,7 @@ func TestAllocatorThrottled(t *testing.T) {
 		firstRangeInfo,
 	)
 	if _, ok := err.(purgatoryError); ok {
-		t.Fatalf("expected a non purgatory error, got: %v", err)
+		t.Fatalf("expected a non purgatory error, got: %+v", err)
 	}
 }
 

--- a/pkg/storage/batch_spanset_test.go
+++ b/pkg/storage/batch_spanset_test.go
@@ -42,10 +42,10 @@ func TestSpanSetBatch(t *testing.T) {
 
 	// Write values outside the range that we can try to read later.
 	if err := eng.Put(outsideKey, []byte("value")); err != nil {
-		t.Fatalf("direct write failed: %s", err)
+		t.Fatalf("direct write failed: %+v", err)
 	}
 	if err := eng.Put(outsideKey3, []byte("value")); err != nil {
-		t.Fatalf("direct write failed: %s", err)
+		t.Fatalf("direct write failed: %+v", err)
 	}
 
 	batch := spanset.NewBatch(eng.NewBatch(), &ss)
@@ -53,10 +53,10 @@ func TestSpanSetBatch(t *testing.T) {
 
 	// Writes inside the range work. Write twice for later read testing.
 	if err := batch.Put(insideKey, []byte("value")); err != nil {
-		t.Fatalf("failed to write inside the range: %s", err)
+		t.Fatalf("failed to write inside the range: %+v", err)
 	}
 	if err := batch.Put(insideKey2, []byte("value2")); err != nil {
-		t.Fatalf("failed to write inside the range: %s", err)
+		t.Fatalf("failed to write inside the range: %+v", err)
 	}
 
 	// Writes outside the range fail. We try to cover all write methods
@@ -90,7 +90,7 @@ func TestSpanSetBatch(t *testing.T) {
 	// Reads inside the range work.
 	//lint:ignore SA1019 historical usage of deprecated batch.Get is OK
 	if value, err := batch.Get(insideKey); err != nil {
-		t.Errorf("failed to read inside the range: %s", err)
+		t.Errorf("failed to read inside the range: %+v", err)
 	} else if !bytes.Equal(value, []byte("value")) {
 		t.Errorf("failed to read previously written value, got %q", value)
 	}
@@ -145,7 +145,7 @@ func TestSpanSetBatch(t *testing.T) {
 			t.Fatalf("expected invalid iterator; found valid at key %s", iter.Key())
 		} else if err != nil {
 			// Scanning out of bounds sets Valid() to false but is not an error.
-			t.Errorf("unexpected error on iterator: %s", err)
+			t.Errorf("unexpected error on iterator: %+v", err)
 		}
 	}()
 
@@ -181,7 +181,7 @@ func TestSpanSetBatch(t *testing.T) {
 	if ok, err := iter.Valid(); ok {
 		t.Fatalf("expected invalid iterator; found valid at key %s", iter.Key())
 	} else if err != nil {
-		t.Errorf("unexpected error on iterator: %s", err)
+		t.Errorf("unexpected error on iterator: %+v", err)
 	}
 	// Seeking back in bounds restores validity.
 	iter.SeekReverse(insideKey)

--- a/pkg/storage/batcheval/cmd_add_sstable_test.go
+++ b/pkg/storage/batcheval/cmd_add_sstable_test.go
@@ -124,7 +124,7 @@ func runTestDBAddSSTable(ctx context.Context, t *testing.T, db *client.DB, store
 			// The on-disk paths have `.ingested` appended unlike in-memory.
 			suffix := ".ingested"
 			if _, err := os.Stat(strings.TrimSuffix(match[1], suffix)); err != nil {
-				t.Fatalf("%q file missing after ingest: %v", match[1], err)
+				t.Fatalf("%q file missing after ingest: %+v", match[1], err)
 			}
 		}
 		if r, err := db.Get(ctx, "bb"); err != nil {

--- a/pkg/storage/batcheval/cmd_lease_test.go
+++ b/pkg/storage/batcheval/cmd_lease_test.go
@@ -60,7 +60,7 @@ func TestLeaseTransferWithPipelinedWrite(t *testing.T) {
 					defer func() {
 						if tx != nil {
 							if err := tx.Rollback(); err != nil {
-								log.Warningf(ctx, "error rolling back: %s", err)
+								log.Warningf(ctx, "error rolling back: %+v", err)
 							}
 						}
 					}()
@@ -99,7 +99,7 @@ func TestLeaseTransferWithPipelinedWrite(t *testing.T) {
 			t.Fatal("timed out")
 		case err := <-workerErrCh:
 			if err != nil {
-				t.Fatalf("worker failed: %s", err)
+				t.Fatalf("worker failed: %+v", err)
 			}
 		}
 	}

--- a/pkg/storage/bulk/sst_batcher.go
+++ b/pkg/storage/bulk/sst_batcher.go
@@ -136,7 +136,7 @@ func (b *SSTBatcher) shouldFlush(ctx context.Context, nextKey roachpb.Key) bool 
 		} else {
 			r, err := b.rc.GetCachedRangeDescriptor(k, false /* inverted */)
 			if err != nil {
-				log.Warningf(ctx, "failed to determine where to split SST: %v", err)
+				log.Warningf(ctx, "failed to determine where to split SST: %+v", err)
 			} else if r != nil {
 				b.flushKey = r.EndKey.AsRawKey()
 				log.VEventf(ctx, 3, "building sstable that will flush before %v", b.flushKey)

--- a/pkg/storage/client_lease_test.go
+++ b/pkg/storage/client_lease_test.go
@@ -102,7 +102,7 @@ func TestStoreRangeLeaseSwitcheroo(t *testing.T) {
 	// re-acquire, then check types again.
 	mtc.advanceClock(context.TODO())
 	if _, err := mtc.dbs[0].Inc(context.TODO(), splitKey, 1); err != nil {
-		t.Fatalf("failed to increment: %s", err)
+		t.Fatalf("failed to increment: %+v", err)
 	}
 
 	// We started with epoch ranges enabled, so verify we have an epoch lease.
@@ -119,7 +119,7 @@ func TestStoreRangeLeaseSwitcheroo(t *testing.T) {
 
 	mtc.advanceClock(context.TODO())
 	if _, err := mtc.dbs[0].Inc(context.TODO(), splitKey, 1); err != nil {
-		t.Fatalf("failed to increment: %s", err)
+		t.Fatalf("failed to increment: %+v", err)
 	}
 
 	// Verify we end up with an expiration lease on restart.
@@ -136,7 +136,7 @@ func TestStoreRangeLeaseSwitcheroo(t *testing.T) {
 
 	mtc.advanceClock(context.TODO())
 	if _, err := mtc.dbs[0].Inc(context.TODO(), splitKey, 1); err != nil {
-		t.Fatalf("failed to increment: %s", err)
+		t.Fatalf("failed to increment: %+v", err)
 	}
 
 	// Verify we end up with an epoch lease on restart.
@@ -164,7 +164,7 @@ func TestStoreGossipSystemData(t *testing.T) {
 		t.Fatal(pErr)
 	}
 	if _, err := mtc.dbs[0].Inc(context.TODO(), splitKey, 1); err != nil {
-		t.Fatalf("failed to increment: %s", err)
+		t.Fatalf("failed to increment: %+v", err)
 	}
 
 	mtc.stopStore(0)

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -930,10 +930,10 @@ func TestStoreRangeMergeStats(t *testing.T) {
 
 	// Stats should agree with recomputation.
 	if err := verifyRecomputedStats(snap, lhsDesc, msA, mtc.manualClock.UnixNano()); err != nil {
-		t.Fatalf("failed to verify range A's stats before split: %v", err)
+		t.Fatalf("failed to verify range A's stats before split: %+v", err)
 	}
 	if err := verifyRecomputedStats(snap, rhsDesc, msB, mtc.manualClock.UnixNano()); err != nil {
-		t.Fatalf("failed to verify range B's stats before split: %v", err)
+		t.Fatalf("failed to verify range B's stats before split: %+v", err)
 	}
 
 	mtc.manualClock.Increment(100)
@@ -957,7 +957,7 @@ func TestStoreRangeMergeStats(t *testing.T) {
 	nowNanos := mtc.manualClock.UnixNano()
 	msMerged.AgeTo(nowNanos)
 	if err := verifyRecomputedStats(snap, replMerged.Desc(), msMerged, nowNanos); err != nil {
-		t.Errorf("failed to verify range's stats after merge: %v", err)
+		t.Errorf("failed to verify range's stats after merge: %+v", err)
 	}
 }
 

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -470,7 +470,7 @@ func TestFailedReplicaChange(t *testing.T) {
 		storagepb.ReasonRangeUnderReplicated,
 		"",
 	); !testutils.IsError(err, "boom") {
-		t.Fatalf("did not get expected error: %v", err)
+		t.Fatalf("did not get expected error: %+v", err)
 	}
 
 	// After the aborted transaction, r.Desc was not updated.
@@ -1621,7 +1621,7 @@ func getRangeMetadata(
 	rs, _, err := client.RangeLookup(context.TODO(), sender, key.AsRawKey(),
 		roachpb.CONSISTENT, 0 /* prefetchNum */, false /* reverse */)
 	if err != nil {
-		t.Fatalf("error getting range metadata: %s", err)
+		t.Fatalf("error getting range metadata: %+v", err)
 	}
 	return rs[0]
 }
@@ -1709,7 +1709,7 @@ func TestChangeReplicasDescriptorInvariant(t *testing.T) {
 	// This should fail because the descriptor is stale.
 	expectedErr := `change replicas of r1 failed: descriptor changed: \[expected\]`
 	if err := addReplica(2, origDesc); !testutils.IsError(err, expectedErr) {
-		t.Fatalf("got unexpected error: %v", err)
+		t.Fatalf("got unexpected error: %+v", err)
 	}
 
 	testutils.SucceedsSoon(t, func() error {
@@ -3793,7 +3793,7 @@ func TestFailedPreemptiveSnapshot(t *testing.T) {
 	); !testutils.IsError(err, expErr) {
 		t.Fatalf("expected %s; got %v", expErr, err)
 	} else if !storage.IsSnapshotError(err) {
-		t.Fatalf("expected preemptive snapshot failed error; got %T: %v", err, err)
+		t.Fatalf("expected preemptive snapshot failed error; got %T: %+v", err, err)
 	}
 }
 
@@ -4212,7 +4212,7 @@ func TestStoreRangeWaitForApplication(t *testing.T) {
 			LeaseIndex:         leaseIndex0,
 		})
 		if err != nil {
-			t.Fatalf("%d: %s", i, err)
+			t.Fatalf("%d: %+v", i, err)
 		}
 	}
 
@@ -4259,7 +4259,7 @@ func TestStoreRangeWaitForApplication(t *testing.T) {
 	}
 	for i, errCh := range errChs {
 		if err := <-errCh; err != nil {
-			t.Fatalf("%d: %s", i, err)
+			t.Fatalf("%d: %+v", i, err)
 		}
 	}
 

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -237,7 +237,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 	initVal := []byte("initVal")
 	err := store.DB().Put(context.TODO(), key, initVal)
 	if err != nil {
-		t.Fatalf("failed to put: %s", err)
+		t.Fatalf("failed to put: %+v", err)
 	}
 
 	waitPut := make(chan struct{})
@@ -268,7 +268,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 
 			updatedVal := []byte("updatedVal")
 			if err := txn.CPut(ctx, key, updatedVal, "initVal"); err != nil {
-				log.Errorf(context.TODO(), "failed put value: %s", err)
+				log.Errorf(context.TODO(), "failed put value: %+v", err)
 				return err
 			}
 
@@ -319,7 +319,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 	if _, err := client.SendWrappedWith(
 		context.Background(), store.TestSender(), h, &roachpb.GetRequest{RequestHeader: requestHeader},
 	); err != nil {
-		t.Fatalf("failed to get: %s", err)
+		t.Fatalf("failed to get: %+v", err)
 	}
 	// Write to the restart key so that the Writer's txn must restart.
 	putReq := &roachpb.PutRequest{
@@ -327,7 +327,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 		Value:         roachpb.MakeValueFromBytes([]byte("restart-value")),
 	}
 	if _, err := client.SendWrappedWith(context.Background(), store.TestSender(), h, putReq); err != nil {
-		t.Fatalf("failed to put: %s", err)
+		t.Fatalf("failed to put: %+v", err)
 	}
 
 	// Wait until the writer restarts the txn.
@@ -347,7 +347,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 		t.Fatal("unexpected success of get")
 	}
 	if _, err := client.SendWrappedWith(context.Background(), store.TestSender(), h, putReq); err != nil {
-		t.Fatalf("failed to put: %s", err)
+		t.Fatalf("failed to put: %+v", err)
 	}
 
 	close(waitSecondGet)
@@ -475,7 +475,7 @@ func TestRangeLookupUseReverse(t *testing.T) {
 			rs, preRs, err := client.RangeLookup(context.Background(), store.TestSender(),
 				test.key.AsRawKey(), roachpb.READ_UNCOMMITTED, test.maxResults-1, true /* prefetchReverse */)
 			if err != nil {
-				t.Fatalf("LookupRange error: %s", err)
+				t.Fatalf("LookupRange error: %+v", err)
 			}
 
 			// Checks the results count.
@@ -805,10 +805,10 @@ func TestRangeTransferLeaseExpirationBased(t *testing.T) {
 		l.setFilter(false, nil)
 
 		if err := <-renewalErrCh; err != nil {
-			t.Errorf("unexpected error from lease renewal: %s", err)
+			t.Errorf("unexpected error from lease renewal: %+v", err)
 		}
 		if err := <-transferErrCh; err != nil {
-			t.Errorf("unexpected error from lease transfer: %s", err)
+			t.Errorf("unexpected error from lease transfer: %+v", err)
 		}
 	})
 
@@ -879,7 +879,7 @@ func TestRangeTransferLeaseExpirationBased(t *testing.T) {
 		l.setFilter(false, nil)
 
 		if err := <-renewalErrCh; err != nil {
-			t.Errorf("unexpected error from lease renewal: %s", err)
+			t.Errorf("unexpected error from lease renewal: %+v", err)
 		}
 	})
 }
@@ -1009,7 +1009,7 @@ func TestLeaseMetricsOnSplitAndTransfer(t *testing.T) {
 	if err := mtc.dbs[0].AdminTransferLease(
 		context.TODO(), keyMinReplica0.Desc().StartKey.AsRawKey(), mtc.stores[1].StoreID(),
 	); err != nil {
-		t.Fatalf("unable to transfer lease to replica 1: %s", err)
+		t.Fatalf("unable to transfer lease to replica 1: %+v", err)
 	}
 	// Wait for all replicas to process.
 	testutils.SucceedsSoon(t, func() error {
@@ -1588,7 +1588,7 @@ func TestRangeInfo(t *testing.T) {
 		}
 		if err = mtc.dbs[0].AdminTransferLease(context.TODO(),
 			r.Desc().StartKey.AsRawKey(), replDesc.StoreID); err != nil {
-			t.Fatalf("unable to transfer lease to replica %s: %s", r, err)
+			t.Fatalf("unable to transfer lease to replica %s: %+v", r, err)
 		}
 	}
 	reply, pErr = client.SendWrappedWith(context.Background(), mtc.distSenders[0], h, &scanArgs)
@@ -1641,7 +1641,7 @@ func TestDrainRangeRejection(t *testing.T) {
 		storagepb.ReasonRangeUnderReplicated,
 		"",
 	); !testutils.IsError(err, "store is draining") {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %+v", err)
 	}
 }
 

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -372,7 +372,7 @@ func TestStoreRangeSplitIntents(t *testing.T) {
 		if _, _, err := engine.MVCCGet(
 			context.Background(), store.Engine(), key, store.Clock().Now(), engine.MVCCGetOptions{},
 		); err != nil {
-			t.Errorf("failed to read consistent range descriptor for key %s: %s", key, err)
+			t.Errorf("failed to read consistent range descriptor for key %s: %+v", key, err)
 		}
 	}
 
@@ -714,7 +714,7 @@ func TestStoreRangeSplitStats(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := verifyRecomputedStats(snap, repl.Desc(), ms, manual.UnixNano()); err != nil {
-		t.Fatalf("failed to verify range's stats before split: %v", err)
+		t.Fatalf("failed to verify range's stats before split: %+v", err)
 	}
 	if inMemMS := repl.GetMVCCStats(); inMemMS != ms {
 		t.Fatalf("in-memory and on-disk diverged:\n%+v\n!=\n%+v", inMemMS, ms)
@@ -770,10 +770,10 @@ func TestStoreRangeSplitStats(t *testing.T) {
 
 	// Stats should agree with recomputation.
 	if err := verifyRecomputedStats(snap, repl.Desc(), msLeft, now); err != nil {
-		t.Fatalf("failed to verify left range's stats after split: %v", err)
+		t.Fatalf("failed to verify left range's stats after split: %+v", err)
 	}
 	if err := verifyRecomputedStats(snap, replRight.Desc(), msRight, now); err != nil {
-		t.Fatalf("failed to verify right range's stats after split: %v", err)
+		t.Fatalf("failed to verify right range's stats after split: %+v", err)
 	}
 }
 
@@ -938,10 +938,10 @@ func TestStoreRangeSplitStatsWithMerges(t *testing.T) {
 
 	// Stats should agree with recomputation.
 	if err := verifyRecomputedStats(snap, repl.Desc(), msLeft, now); err != nil {
-		t.Fatalf("failed to verify left range's stats after split: %v", err)
+		t.Fatalf("failed to verify left range's stats after split: %+v", err)
 	}
 	if err := verifyRecomputedStats(snap, replRight.Desc(), msRight, now); err != nil {
-		t.Fatalf("failed to verify right range's stats after split: %v", err)
+		t.Fatalf("failed to verify right range's stats after split: %+v", err)
 	}
 }
 
@@ -1721,7 +1721,7 @@ func TestStoreSplitTimestampCacheDifferentLeaseHolder(t *testing.T) {
 	}
 
 	if err := txnOld.Commit(ctx); err != nil {
-		t.Fatalf("unexpected txn commit err: %s", err)
+		t.Fatalf("unexpected txn commit err: %+v", err)
 	}
 
 	// Verify that the txn's safe timestamp was set.
@@ -1850,7 +1850,7 @@ func TestStoreSplitOnRemovedReplica(t *testing.T) {
 	// where it will succeed.
 	close(finishBlockingSplit)
 	if err = <-splitRes; err != nil {
-		t.Errorf("AdminSplit returned error: %v", err)
+		t.Errorf("AdminSplit returned error: %+v", err)
 	}
 }
 
@@ -1917,7 +1917,7 @@ func TestStoreSplitFailsAfterMaxRetries(t *testing.T) {
 	// retry a few times before exiting unsuccessfully.
 	_, _, err := tc.SplitRange(splitKey)
 	if !testutils.IsError(err, "split at key .* failed: result is ambiguous") {
-		t.Errorf("unexpected error from SplitRange: %v", err)
+		t.Errorf("unexpected error from SplitRange: %+v", err)
 	}
 
 	const expAttempts = 11 // 10 retries
@@ -2768,7 +2768,7 @@ func TestTxnWaitQueueDependencyCycleWithRangeSplit(t *testing.T) {
 		// Verify that both complete.
 		for i, ch := range []chan error{txnACh, txnBCh} {
 			if err := <-ch; err != nil {
-				t.Fatalf("%d: txn failure: %v", i, err)
+				t.Fatalf("%d: txn failure: %+v", i, err)
 			}
 		}
 	})

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -1239,7 +1239,7 @@ func (m *multiTestContext) readIntFromEngines(key roachpb.Key) []int64 {
 		} else {
 			results[i], err = val.GetInt()
 			if err != nil {
-				log.Errorf(context.TODO(), "engine %d: error decoding %s from key %s: %s", i, val, key, err)
+				log.Errorf(context.TODO(), "engine %d: error decoding %s from key %s: %+v", i, val, key, err)
 			}
 		}
 	}

--- a/pkg/storage/closed_timestamp_test.go
+++ b/pkg/storage/closed_timestamp_test.go
@@ -210,17 +210,17 @@ func TestClosedTimestampCanServeAfterSplitAndMerges(t *testing.T) {
 	// Manually split the table to have easier access to descriptors.
 	tableID, err := getTableID(db0, "cttest", "kv")
 	if err != nil {
-		t.Fatalf("failed to lookup ids: %v", err)
+		t.Fatalf("failed to lookup ids: %+v", err)
 	}
 	// Split the table at key 2.
 	k, err := sqlbase.EncodeTableKey(sqlbase.EncodeTableIDIndexID(nil, tableID, 1),
 		tree.NewDInt(2), encoding.Ascending)
 	if err != nil {
-		t.Fatalf("failed to encode key: %v", err)
+		t.Fatalf("failed to encode key: %+v", err)
 	}
 	lr, rr, err := tc.Server(0).SplitRange(k)
 	if err != nil {
-		t.Fatalf("failed to split range at key %v: %v", roachpb.Key(k), err)
+		t.Fatalf("failed to split range at key %v: %+v", roachpb.Key(k), err)
 	}
 
 	// Ensure that we can perform follower reads from all replicas.

--- a/pkg/storage/closedts/provider/provider.go
+++ b/pkg/storage/closedts/provider/provider.go
@@ -147,7 +147,7 @@ func (p *Provider) runCloser(ctx context.Context) {
 		next.WallTime -= int64(targetDuration)
 		if err != nil {
 			if p.everyClockLog.ShouldLog() {
-				log.Warningf(ctx, "unable to move closed timestamp forward: %s", err)
+				log.Warningf(ctx, "unable to move closed timestamp forward: %+v", err)
 			}
 			// Broadcast even if nothing new was queued, so that the subscribers
 			// loop to check their client's context.

--- a/pkg/storage/closedts/transport/clients.go
+++ b/pkg/storage/closedts/transport/clients.go
@@ -121,7 +121,7 @@ func (pr *Clients) getOrCreateClient(nodeID roachpb.NodeID) *client {
 		c, err := pr.cfg.Dialer.Dial(ctx, nodeID)
 		if err != nil {
 			if log.V(1) {
-				log.Warningf(ctx, "error opening closed timestamp stream to n%d: %s", nodeID, err)
+				log.Warningf(ctx, "error opening closed timestamp stream to n%d: %+v", nodeID, err)
 			}
 			return
 		}

--- a/pkg/storage/compactor/compactor.go
+++ b/pkg/storage/compactor/compactor.go
@@ -128,7 +128,7 @@ func (c *Compactor) Start(ctx context.Context, stopper *stop.Stopper) {
 					// A new suggestion was made. Examine the compaction queue,
 					// which returns the number of bytes queued.
 					if bytesQueued, err := c.examineQueue(ctx); err != nil {
-						log.Warningf(ctx, "failed check whether compaction suggestions exist: %s", err)
+						log.Warningf(ctx, "failed check whether compaction suggestions exist: %+v", err)
 					} else if bytesQueued > 0 {
 						log.VEventf(ctx, 3, "compactor starting in %s as there are suggested compactions pending", c.minInterval())
 					} else {
@@ -145,7 +145,7 @@ func (c *Compactor) Start(ctx context.Context, stopper *stop.Stopper) {
 					timer.Read = true
 					ok, err := c.processSuggestions(ctx)
 					if err != nil {
-						log.Warningf(ctx, "failed processing suggested compactions: %s", err)
+						log.Warningf(ctx, "failed processing suggested compactions: %+v", err)
 					}
 					if ok {
 						// The queue was processed, so either it's empty or contains suggestions
@@ -262,7 +262,7 @@ func (c *Compactor) processSuggestions(ctx context.Context) (bool, error) {
 		if done := c.aggregateCompaction(ctx, ssti, &aggr, sc); done {
 			processedBytes, err := c.processCompaction(ctx, aggr, capacity)
 			if err != nil {
-				log.Errorf(ctx, "failed processing suggested compactions %+v: %s", aggr, err)
+				log.Errorf(ctx, "failed processing suggested compactions %+v: %+v", aggr, err)
 			} else if err := updateBytesQueued(processedBytes); err != nil {
 				log.Errorf(ctx, "failed updating bytes queued metric %+v", err)
 			}
@@ -340,7 +340,7 @@ func (c *Compactor) fetchSuggestions(
 		return nil, 0, err
 	}
 	if err := delBatch.Commit(true); err != nil {
-		log.Warningf(ctx, "unable to delete suggested compaction records: %s", err)
+		log.Warningf(ctx, "unable to delete suggested compaction records: %+v", err)
 	}
 	return suggestions, totalBytes, nil
 }
@@ -408,7 +408,7 @@ func (c *Compactor) processCompaction(
 	}
 
 	if err := delBatch.Commit(true); err != nil {
-		log.Warningf(ctx, "unable to delete suggested compaction records: %s", err)
+		log.Warningf(ctx, "unable to delete suggested compaction records: %+v", err)
 	}
 	delBatch.Close()
 
@@ -507,7 +507,7 @@ func (c *Compactor) Suggest(ctx context.Context, sc storagepb.SuggestedCompactio
 	// Store the new compaction.
 	//lint:ignore SA1019 historical usage of deprecated engine.PutProto is OK
 	if _, _, err = engine.PutProto(c.eng, engine.MVCCKey{Key: key}, &sc.Compaction); err != nil {
-		log.Warningf(ctx, "unable to record suggested compaction: %s", err)
+		log.Warningf(ctx, "unable to record suggested compaction: %+v", err)
 	}
 
 	// Poke the compactor goroutine to reconsider compaction in light of

--- a/pkg/storage/compactor/compactor_test.go
+++ b/pkg/storage/compactor/compactor_test.go
@@ -575,7 +575,7 @@ func TestCompactorThresholds(t *testing.T) {
 					func(kv engine.MVCCKeyValue) (bool, error) {
 						start, end, err := keys.DecodeStoreSuggestedCompactionKey(kv.Key.Key)
 						if err != nil {
-							t.Fatalf("failed to decode suggested compaction key: %s", err)
+							t.Fatalf("failed to decode suggested compaction key: %+v", err)
 						}
 						if idx >= len(test.expUncompacted) {
 							return true, fmt.Errorf("found unexpected uncompacted span %s-%s", start, end)

--- a/pkg/storage/engine/batch_test.go
+++ b/pkg/storage/engine/batch_test.go
@@ -528,7 +528,7 @@ func TestBatchProto(t *testing.T) {
 	getVal := &roachpb.Value{}
 	ok, keySize, valSize, err := b.GetProto(mvccKey("proto"), getVal)
 	if !ok || err != nil {
-		t.Fatalf("expected GetProto to success ok=%t: %s", ok, err)
+		t.Fatalf("expected GetProto to success ok=%t: %+v", ok, err)
 	}
 	if keySize != 6 {
 		t.Errorf("expected key size 6; got %d", keySize)
@@ -545,14 +545,14 @@ func TestBatchProto(t *testing.T) {
 	}
 	// Before commit, proto will not be available via engine.
 	if ok, _, _, err := e.GetProto(mvccKey("proto"), getVal); ok || err != nil {
-		t.Fatalf("expected GetProto to fail ok=%t: %s", ok, err)
+		t.Fatalf("expected GetProto to fail ok=%t: %+v", ok, err)
 	}
 	// Commit and verify the proto can be read directly from the engine.
 	if err := b.Commit(false /* sync */); err != nil {
 		t.Fatal(err)
 	}
 	if ok, _, _, err := e.GetProto(mvccKey("proto"), getVal); !ok || err != nil {
-		t.Fatalf("expected GetProto to success ok=%t: %s", ok, err)
+		t.Fatalf("expected GetProto to success ok=%t: %+v", ok, err)
 	}
 	if !proto.Equal(getVal, &val) {
 		t.Errorf("expected %v; got %v", &val, getVal)

--- a/pkg/storage/engine/bench_rocksdb_test.go
+++ b/pkg/storage/engine/bench_rocksdb_test.go
@@ -36,7 +36,7 @@ func setupMVCCRocksDB(b testing.TB, dir string) Engine {
 		cache,
 	)
 	if err != nil {
-		b.Fatalf("could not create new rocksdb db instance at %s: %v", dir, err)
+		b.Fatalf("could not create new rocksdb db instance at %s: %+v", dir, err)
 	}
 	return rocksdb
 }

--- a/pkg/storage/engine/bench_test.go
+++ b/pkg/storage/engine/bench_test.go
@@ -244,7 +244,7 @@ func runMVCCScan(ctx context.Context, b *testing.B, emk engineMaker, opts benchS
 			Reverse: opts.reverse,
 		})
 		if err != nil {
-			b.Fatalf("failed scan: %s", err)
+			b.Fatalf("failed scan: %+v", err)
 		}
 		if len(kvs) != opts.numRows {
 			b.Fatalf("failed to scan: %d != %d", len(kvs), opts.numRows)
@@ -280,7 +280,7 @@ func runMVCCGet(ctx context.Context, b *testing.B, emk engineMaker, opts benchDa
 		walltime := int64(5 * (rand.Int31n(int32(opts.numVersions)) + 1))
 		ts := hlc.Timestamp{WallTime: walltime}
 		if v, _, err := MVCCGet(ctx, eng, key, ts, MVCCGetOptions{}); err != nil {
-			b.Fatalf("failed get: %s", err)
+			b.Fatalf("failed get: %+v", err)
 		} else if v == nil {
 			b.Fatalf("failed get (key not found): %d@%d", keyIdx, walltime)
 		} else if valueBytes, err := v.GetBytes(); err != nil {
@@ -308,7 +308,7 @@ func runMVCCPut(ctx context.Context, b *testing.B, emk engineMaker, valueSize in
 		key := roachpb.Key(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(i)))
 		ts := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
 		if err := MVCCPut(ctx, eng, nil, key, ts, value, nil); err != nil {
-			b.Fatalf("failed put: %s", err)
+			b.Fatalf("failed put: %+v", err)
 		}
 	}
 
@@ -330,7 +330,7 @@ func runMVCCBlindPut(ctx context.Context, b *testing.B, emk engineMaker, valueSi
 		key := roachpb.Key(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(i)))
 		ts := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
 		if err := MVCCBlindPut(ctx, eng, nil, key, ts, value, nil); err != nil {
-			b.Fatalf("failed put: %s", err)
+			b.Fatalf("failed put: %+v", err)
 		}
 	}
 
@@ -354,7 +354,7 @@ func runMVCCConditionalPut(
 			key := roachpb.Key(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(i)))
 			ts := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
 			if err := MVCCPut(ctx, eng, nil, key, ts, value, nil); err != nil {
-				b.Fatalf("failed put: %s", err)
+				b.Fatalf("failed put: %+v", err)
 			}
 		}
 		expected = &value
@@ -366,7 +366,7 @@ func runMVCCConditionalPut(
 		key := roachpb.Key(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(i)))
 		ts := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
 		if err := MVCCConditionalPut(ctx, eng, nil, key, ts, value, expected, CPutFailIfMissing, nil); err != nil {
-			b.Fatalf("failed put: %s", err)
+			b.Fatalf("failed put: %+v", err)
 		}
 	}
 
@@ -388,7 +388,7 @@ func runMVCCBlindConditionalPut(ctx context.Context, b *testing.B, emk engineMak
 		key := roachpb.Key(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(i)))
 		ts := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
 		if err := MVCCBlindConditionalPut(ctx, eng, nil, key, ts, value, nil, CPutFailIfMissing, nil); err != nil {
-			b.Fatalf("failed put: %s", err)
+			b.Fatalf("failed put: %+v", err)
 		}
 	}
 
@@ -410,7 +410,7 @@ func runMVCCInitPut(ctx context.Context, b *testing.B, emk engineMaker, valueSiz
 		key := roachpb.Key(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(i)))
 		ts := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
 		if err := MVCCInitPut(ctx, eng, nil, key, ts, value, false, nil); err != nil {
-			b.Fatalf("failed put: %s", err)
+			b.Fatalf("failed put: %+v", err)
 		}
 	}
 
@@ -432,7 +432,7 @@ func runMVCCBlindInitPut(ctx context.Context, b *testing.B, emk engineMaker, val
 		key := roachpb.Key(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(i)))
 		ts := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
 		if err := MVCCBlindInitPut(ctx, eng, nil, key, ts, value, false, nil); err != nil {
-			b.Fatalf("failed put: %s", err)
+			b.Fatalf("failed put: %+v", err)
 		}
 	}
 
@@ -462,7 +462,7 @@ func runMVCCBatchPut(ctx context.Context, b *testing.B, emk engineMaker, valueSi
 			key := roachpb.Key(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(j)))
 			ts := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
 			if err := MVCCPut(ctx, batch, nil, key, ts, value, nil); err != nil {
-				b.Fatalf("failed put: %s", err)
+				b.Fatalf("failed put: %+v", err)
 			}
 		}
 
@@ -513,7 +513,7 @@ func runMVCCBatchTimeSeries(ctx context.Context, b *testing.B, emk engineMaker, 
 		for j := 0; j < batchSize; j++ {
 			ts.Logical++
 			if err := MVCCMerge(ctx, batch, nil, keys[j], ts, value); err != nil {
-				b.Fatalf("failed put: %s", err)
+				b.Fatalf("failed put: %+v", err)
 			}
 		}
 

--- a/pkg/storage/engine/engine_test.go
+++ b/pkg/storage/engine/engine_test.go
@@ -274,7 +274,7 @@ func TestEngineBatch(t *testing.T) {
 			// Run it once with individual operations and remember the result.
 			for i, op := range currentBatch {
 				if err := apply(engine, op); err != nil {
-					t.Errorf("%d: op %v: %v", i, op, err)
+					t.Errorf("%d: op %v: %+v", i, op, err)
 					continue
 				}
 			}
@@ -320,7 +320,7 @@ func TestEngineBatch(t *testing.T) {
 			iter.Close()
 			// Commit the batch and try getting the value from the engine.
 			if err := b.Commit(false /* sync */); err != nil {
-				t.Errorf("%d: %v", i, err)
+				t.Errorf("%d: %+v", i, err)
 				continue
 			}
 			actualValue = get(engine, key)
@@ -448,7 +448,7 @@ func TestEngineMerge(t *testing.T) {
 		for _, tc := range testcases {
 			for i, update := range tc.merges {
 				if err := engine.Merge(tc.testKey, update); err != nil {
-					t.Fatalf("%d: %v", i, err)
+					t.Fatalf("%d: %+v", i, err)
 				}
 			}
 			result, _ := engine.Get(tc.testKey)
@@ -483,7 +483,7 @@ func TestEngineScan1(t *testing.T) {
 		keyMap := map[string][]byte{}
 		for _, c := range testCases {
 			if err := engine.Put(c.key, c.value); err != nil {
-				t.Errorf("could not put key %q: %v", c.key, err)
+				t.Errorf("could not put key %q: %+v", c.key, err)
 			}
 			keyMap[string(c.key.Key)] = c.value
 		}
@@ -495,20 +495,20 @@ func TestEngineScan1(t *testing.T) {
 
 		keyvals, err := Scan(engine, mvccKey("chinese"), mvccKey("german"), 0)
 		if err != nil {
-			t.Fatalf("could not run scan: %v", err)
+			t.Fatalf("could not run scan: %+v", err)
 		}
 		ensureRangeEqual(t, sortedKeys[1:4], keyMap, keyvals)
 
 		// Check an end of range which does not equal an existing key.
 		keyvals, err = Scan(engine, mvccKey("chinese"), mvccKey("german1"), 0)
 		if err != nil {
-			t.Fatalf("could not run scan: %v", err)
+			t.Fatalf("could not run scan: %+v", err)
 		}
 		ensureRangeEqual(t, sortedKeys[1:5], keyMap, keyvals)
 
 		keyvals, err = Scan(engine, mvccKey("chinese"), mvccKey("german"), 2)
 		if err != nil {
-			t.Fatalf("could not run scan: %v", err)
+			t.Fatalf("could not run scan: %+v", err)
 		}
 		ensureRangeEqual(t, sortedKeys[1:3], keyMap, keyvals)
 
@@ -519,7 +519,7 @@ func TestEngineScan1(t *testing.T) {
 		for _, startKey := range startKeys {
 			keyvals, err = Scan(engine, startKey, mvccKey(roachpb.RKeyMax), 0)
 			if err != nil {
-				t.Fatalf("could not run scan: %v", err)
+				t.Fatalf("could not run scan: %+v", err)
 			}
 			ensureRangeEqual(t, sortedKeys, keyMap, keyvals)
 		}

--- a/pkg/storage/engine/merge_test.go
+++ b/pkg/storage/engine/merge_test.go
@@ -197,7 +197,7 @@ func TestGoMerge(t *testing.T) {
 	for i, c := range testCasesAppender {
 		result, err := goMerge(c.existing, c.update)
 		if err != nil {
-			t.Errorf("goMerge error: %d: %v", i, err)
+			t.Errorf("goMerge error: %d: %+v", i, err)
 			continue
 		}
 		var resultV, expectedV enginepb.MVCCMetadata

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -2553,7 +2553,7 @@ func MVCCResolveWriteIntentRangeUsingIter(
 			)
 		}
 		if err != nil {
-			log.Warningf(ctx, "failed to resolve intent for key %q: %v", key.Key, err)
+			log.Warningf(ctx, "failed to resolve intent for key %q: %+v", key.Key, err)
 		} else if ok {
 			num++
 		}

--- a/pkg/storage/engine/rocksdb_error_test.go
+++ b/pkg/storage/engine/rocksdb_error_test.go
@@ -49,7 +49,7 @@ func TestRocksDBErrorSafeMessage(t *testing.T) {
 	}
 	rErr, ok := errors.Cause(err).(*RocksDBError)
 	if !ok {
-		t.Fatalf("unexpected error of cause %T: %s", errors.Cause(err), err)
+		t.Fatalf("unexpected error of cause %T: %+v", errors.Cause(err), err)
 	}
 
 	for _, test := range []struct {

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -654,7 +654,7 @@ func TestConcurrentBatch(t *testing.T) {
 		RocksDBCache{},
 	)
 	if err != nil {
-		t.Fatalf("could not create new rocksdb db instance at %s: %v", dir, err)
+		t.Fatalf("could not create new rocksdb db instance at %s: %+v", dir, err)
 	}
 	defer db.Close()
 
@@ -848,7 +848,7 @@ func TestRocksDBTimeBound(t *testing.T) {
 		RocksDBCache{},
 	)
 	if err != nil {
-		t.Fatalf("could not create new rocksdb db instance at %s: %v", dir, err)
+		t.Fatalf("could not create new rocksdb db instance at %s: %+v", dir, err)
 	}
 	defer rocksdb.Close()
 
@@ -1040,7 +1040,7 @@ func TestRocksDBDeleteRangeBug(t *testing.T) {
 		RocksDBCache{},
 	)
 	if err != nil {
-		t.Fatalf("could not create new rocksdb db instance at %s: %v", dir, err)
+		t.Fatalf("could not create new rocksdb db instance at %s: %+v", dir, err)
 	}
 	defer db.Close()
 
@@ -1254,7 +1254,7 @@ func TestRocksDBFileNotFoundError(t *testing.T) {
 		RocksDBCache{},
 	)
 	if err != nil {
-		t.Fatalf("could not create new rocksdb db instance at %s: %v", dir, err)
+		t.Fatalf("could not create new rocksdb db instance at %s: %+v", dir, err)
 	}
 	defer db.Close()
 

--- a/pkg/storage/engine/temp_engine_test.go
+++ b/pkg/storage/engine/temp_engine_test.go
@@ -27,7 +27,7 @@ func TestNewTempEngine(t *testing.T) {
 
 	engine, err := NewTempEngine(base.TempStorageConfig{Path: tempDir}, base.StoreSpec{Path: tempDir})
 	if err != nil {
-		t.Fatalf("error encountered when invoking NewTempEngine: %v", err)
+		t.Fatalf("error encountered when invoking NewTempEngine: %+v", err)
 	}
 	defer engine.Close()
 

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -732,7 +732,7 @@ func RunGC(
 		if len(keys) > 1 {
 			meta := &enginepb.MVCCMetadata{}
 			if err := protoutil.Unmarshal(vals[0], meta); err != nil {
-				log.Errorf(ctx, "unable to unmarshal MVCC metadata for key %q: %s", keys[0], err)
+				log.Errorf(ctx, "unable to unmarshal MVCC metadata for key %q: %+v", keys[0], err)
 			} else {
 				// In the event that there's an active intent, send for
 				// intent resolution if older than the threshold.

--- a/pkg/storage/gc_queue_test.go
+++ b/pkg/storage/gc_queue_test.go
@@ -452,7 +452,7 @@ func TestGCQueueProcess(t *testing.T) {
 				Timestamp: datum.ts,
 				Txn:       txn,
 			}, &dArgs); err != nil {
-				t.Fatalf("%d: could not delete data: %s", i, err)
+				t.Fatalf("%d: could not delete data: %+v", i, err)
 			}
 		} else {
 			pArgs := putArgs(datum.key, []byte("value"))
@@ -467,7 +467,7 @@ func TestGCQueueProcess(t *testing.T) {
 				Timestamp: datum.ts,
 				Txn:       txn,
 			}, &pArgs); err != nil {
-				t.Fatalf("%d: could not put data: %s", i, err)
+				t.Fatalf("%d: could not put data: %+v", i, err)
 			}
 		}
 	}
@@ -498,7 +498,7 @@ func TestGCQueueProcess(t *testing.T) {
 
 		zone, err := cfg.GetZoneConfigForKey(desc.StartKey)
 		if err != nil {
-			t.Fatalf("could not find zone config for range %s: %s", tc.repl, err)
+			t.Fatalf("could not find zone config for range %s: %+v", tc.repl, err)
 		}
 
 		now := tc.Clock().Now()
@@ -869,7 +869,7 @@ func TestGCQueueIntentResolution(t *testing.T) {
 			if _, err := tc.SendWrappedWith(roachpb.Header{
 				Txn: txns[i],
 			}, &pArgs); err != nil {
-				t.Fatalf("%d: could not put data: %s", i, err)
+				t.Fatalf("%d: could not put data: %+v", i, err)
 			}
 		}
 	}

--- a/pkg/storage/gossip_test.go
+++ b/pkg/storage/gossip_test.go
@@ -186,7 +186,7 @@ func TestGossipHandlesReplacedNode(t *testing.T) {
 		}
 		kvClient := server.DB()
 		if err := kvClient.Put(ctx, fmt.Sprintf("%d", i), i); err != nil {
-			t.Errorf("failed Put to node %d: %s", i, err)
+			t.Errorf("failed Put to node %d: %+v", i, err)
 		}
 	}
 }

--- a/pkg/storage/idalloc/id_alloc.go
+++ b/pkg/storage/idalloc/id_alloc.go
@@ -106,7 +106,7 @@ func (ia *Allocator) start() {
 					break
 				}
 
-				log.Warningf(ctx, "unable to allocate %d ids from %s: %s", ia.blockSize, idKey, err)
+				log.Warningf(ctx, "unable to allocate %d ids from %s: %+v", ia.blockSize, idKey, err)
 			}
 			if err != nil {
 				panic(fmt.Sprintf("unexpectedly exited id allocation retry loop: %s", err))

--- a/pkg/storage/idalloc/id_alloc_test.go
+++ b/pkg/storage/idalloc/id_alloc_test.go
@@ -48,7 +48,7 @@ func newTestAllocator(t testing.TB) (*localtestcluster.LocalTestCluster, *idallo
 	)
 	if err != nil {
 		s.Stop()
-		t.Errorf("failed to create idAllocator: %v", err)
+		t.Errorf("failed to create idAllocator: %+v", err)
 	}
 	return s, idAlloc
 }
@@ -110,7 +110,7 @@ func TestNewAllocatorInvalidBlockSize(t *testing.T) {
 		nil /* idKey */, nil, /* db */
 		0 /* blockSize */, nil, /* stopper */
 	); !testutils.IsError(err, expErr) {
-		t.Errorf("expected err: %s, got: %v", expErr, err)
+		t.Errorf("expected err: %s, got: %+v", expErr, err)
 	}
 }
 
@@ -225,6 +225,6 @@ func TestAllocateWithStopper(t *testing.T) {
 	s.Stop() // not deferred.
 
 	if _, err := idAlloc.Allocate(context.Background()); !testutils.IsError(err, "system is draining") {
-		t.Errorf("unexpected error: %v", err)
+		t.Errorf("unexpected error: %+v", err)
 	}
 }

--- a/pkg/storage/intentresolver/intent_resolver.go
+++ b/pkg/storage/intentresolver/intent_resolver.go
@@ -605,7 +605,7 @@ func (ir *IntentResolver) CleanupTxnIntentsAsync(
 			intents := roachpb.AsIntents(et.Txn.IntentSpans, &et.Txn)
 			if err := ir.cleanupFinishedTxnIntents(ctx, rangeID, &et.Txn, intents, now, et.Poison, nil); err != nil {
 				if ir.every.ShouldLog() {
-					log.Warningf(ctx, "failed to cleanup transaction intents: %s", err)
+					log.Warningf(ctx, "failed to cleanup transaction intents: %+v", err)
 				}
 			}
 		}); err != nil {
@@ -720,7 +720,7 @@ func (ir *IntentResolver) CleanupTxnIntentsOnGCAsync(
 			err := ir.cleanupFinishedTxnIntents(ctx, rangeID, txn, intents, now, false /* poison */, onCleanupComplete)
 			if err != nil {
 				if ir.every.ShouldLog() {
-					log.Warningf(ctx, "failed to cleanup transaction intents: %s", err)
+					log.Warningf(ctx, "failed to cleanup transaction intents: %+v", err)
 				}
 			}
 		},
@@ -813,7 +813,7 @@ func (ir *IntentResolver) cleanupFinishedTxnIntents(
 			}
 			if err != nil {
 				if ir.every.ShouldLog() {
-					log.Warningf(ctx, "failed to gc transaction record: %v", err)
+					log.Warningf(ctx, "failed to gc transaction record: %+v", err)
 				}
 			}
 		})
@@ -844,14 +844,14 @@ func (ir *IntentResolver) lookupRangeID(ctx context.Context, key roachpb.Key) ro
 	rKey, err := keys.Addr(key)
 	if err != nil {
 		if ir.every.ShouldLog() {
-			log.Warningf(ctx, "failed to resolve addr for key %q: %v", key, err)
+			log.Warningf(ctx, "failed to resolve addr for key %q: %+v", key, err)
 		}
 		return 0
 	}
 	rDesc, err := ir.rdc.LookupRangeDescriptor(ctx, rKey)
 	if err != nil {
 		if ir.every.ShouldLog() {
-			log.Warningf(ctx, "failed to look up range descriptor for key %q: %v", key, err)
+			log.Warningf(ctx, "failed to look up range descriptor for key %q: %+v", key, err)
 		}
 		return 0
 	}

--- a/pkg/storage/intentresolver/intent_resolver_test.go
+++ b/pkg/storage/intentresolver/intent_resolver_test.go
@@ -554,7 +554,7 @@ func TestCleanupIntentsAsyncThrottled(t *testing.T) {
 			wg.Done()
 			<-blocker
 		}); err != nil {
-			t.Fatalf("Failed to run blocking async task: %v", err)
+			t.Fatalf("Failed to run blocking async task: %+v", err)
 		}
 	}
 	wg.Wait()

--- a/pkg/storage/log_test.go
+++ b/pkg/storage/log_test.go
@@ -94,7 +94,7 @@ func TestLogSplits(t *testing.T) {
 		}
 		var info storagepb.RangeLogEvent_Info
 		if err := json.Unmarshal([]byte(infoStr.String), &info); err != nil {
-			t.Errorf("error unmarshalling info string for split of range %d: %s", rangeID, err)
+			t.Errorf("error unmarshalling info string for split of range %d: %+v", rangeID, err)
 			continue
 		}
 		if int64(info.UpdatedDesc.RangeID) != rangeID {
@@ -218,7 +218,7 @@ func TestLogMerges(t *testing.T) {
 		}
 		var info storagepb.RangeLogEvent_Info
 		if err := json.Unmarshal([]byte(infoStr.String), &info); err != nil {
-			t.Errorf("error unmarshalling info string for merge of range %d: %s", rangeID, err)
+			t.Errorf("error unmarshalling info string for merge of range %d: %+v", rangeID, err)
 			continue
 		}
 		if int64(info.UpdatedDesc.RangeID) != rangeID {
@@ -315,7 +315,7 @@ func TestLogRebalances(t *testing.T) {
 		}
 		var info storagepb.RangeLogEvent_Info
 		if err := json.Unmarshal([]byte(infoStr.String), &info); err != nil {
-			t.Errorf("error unmarshalling info string for add replica %d: %s", rangeID, err)
+			t.Errorf("error unmarshalling info string for add replica %d: %+v", rangeID, err)
 			continue
 		}
 		if int64(info.UpdatedDesc.RangeID) != rangeID {
@@ -367,7 +367,7 @@ func TestLogRebalances(t *testing.T) {
 		}
 		var info storagepb.RangeLogEvent_Info
 		if err := json.Unmarshal([]byte(infoStr.String), &info); err != nil {
-			t.Errorf("error unmarshalling info string for remove replica %d: %s", rangeID, err)
+			t.Errorf("error unmarshalling info string for remove replica %d: %+v", rangeID, err)
 			continue
 		}
 		if int64(info.UpdatedDesc.RangeID) != rangeID {

--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -231,7 +231,7 @@ func (nl *NodeLiveness) SetDraining(ctx context.Context, drain bool) {
 	for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
 		liveness, err := nl.Self()
 		if err != nil && err != ErrNoLivenessRecord {
-			log.Errorf(ctx, "unexpected error getting liveness: %s", err)
+			log.Errorf(ctx, "unexpected error getting liveness: %+v", err)
 		}
 		if err := nl.setDrainingInternal(ctx, liveness, drain); err == nil {
 			return
@@ -467,7 +467,7 @@ func (nl *NodeLiveness) StartHeartbeat(
 					for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
 						liveness, err := nl.Self()
 						if err != nil && err != ErrNoLivenessRecord {
-							log.Errorf(ctx, "unexpected error getting liveness: %v", err)
+							log.Errorf(ctx, "unexpected error getting liveness: %+v", err)
 						}
 						if err := nl.heartbeatInternal(ctx, liveness, incrementEpoch); err != nil {
 							if err == ErrEpochIncremented {
@@ -481,7 +481,7 @@ func (nl *NodeLiveness) StartHeartbeat(
 					}
 					return nil
 				}); err != nil {
-				log.Warningf(ctx, "failed node liveness heartbeat: %v", err)
+				log.Warningf(ctx, "failed node liveness heartbeat: %+v", err)
 			}
 
 			nl.heartbeatToken <- struct{}{}
@@ -1001,7 +1001,7 @@ func (nl *NodeLiveness) numLiveNodes() int64 {
 		return 0
 	}
 	if err != nil {
-		log.Warningf(ctx, "looking up own liveness: %s", err)
+		log.Warningf(ctx, "looking up own liveness: %+v", err)
 		return 0
 	}
 	// If this node isn't live, we don't want to report its view of node liveness

--- a/pkg/storage/node_liveness_test.go
+++ b/pkg/storage/node_liveness_test.go
@@ -280,13 +280,13 @@ func TestNodeLivenessEpochIncrement(t *testing.T) {
 	}
 	if err := mtc.nodeLivenesses[0].IncrementEpoch(
 		context.Background(), oldLiveness); !testutils.IsError(err, "cannot increment epoch on live node") {
-		t.Fatalf("expected error incrementing a live node: %v", err)
+		t.Fatalf("expected error incrementing a live node: %+v", err)
 	}
 
 	// Advance clock past liveness threshold & increment epoch.
 	mtc.manualClock.Increment(mtc.nodeLivenesses[0].GetLivenessThreshold().Nanoseconds() + 1)
 	if err := mtc.nodeLivenesses[0].IncrementEpoch(context.Background(), oldLiveness); err != nil {
-		t.Fatalf("unexpected error incrementing a non-live node: %s", err)
+		t.Fatalf("unexpected error incrementing a non-live node: %+v", err)
 	}
 
 	// Verify that the epoch has been advanced.
@@ -314,14 +314,14 @@ func TestNodeLivenessEpochIncrement(t *testing.T) {
 
 	// Verify error on incrementing an already-incremented epoch.
 	if err := mtc.nodeLivenesses[0].IncrementEpoch(context.Background(), oldLiveness); err != storage.ErrEpochAlreadyIncremented {
-		t.Fatalf("unexpected error incrementing a non-live node: %s", err)
+		t.Fatalf("unexpected error incrementing a non-live node: %+v", err)
 	}
 
 	// Verify error incrementing with a too-high expectation for liveness epoch.
 	oldLiveness.Epoch = 3
 	if err := mtc.nodeLivenesses[0].IncrementEpoch(
 		context.Background(), oldLiveness); !testutils.IsError(err, "unexpected liveness epoch 2; expected >= 3") {
-		t.Fatalf("expected error incrementing with a too-high expected epoch: %v", err)
+		t.Fatalf("expected error incrementing with a too-high expected epoch: %+v", err)
 	}
 }
 
@@ -574,7 +574,7 @@ func TestNodeLivenessConcurrentHeartbeats(t *testing.T) {
 	}
 	for i := 0; i < concurrency; i++ {
 		if err := <-errCh; err != nil {
-			t.Fatalf("concurrent heartbeat %d failed: %s", i, err)
+			t.Fatalf("concurrent heartbeat %d failed: %+v", i, err)
 		}
 	}
 }
@@ -607,7 +607,7 @@ func TestNodeLivenessConcurrentIncrementEpochs(t *testing.T) {
 	}
 	for i := 0; i < concurrency; i++ {
 		if err := <-errCh; err != nil && err != storage.ErrEpochAlreadyIncremented {
-			t.Fatalf("concurrent increment epoch %d failed: %s", i, err)
+			t.Fatalf("concurrent increment epoch %d failed: %+v", i, err)
 		}
 	}
 }

--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -596,7 +596,7 @@ func (bq *baseQueue) maybeAdd(ctx context.Context, repl replicaInQueue, now hlc.
 		return
 	}
 	if _, err := bq.addInternal(ctx, repl.Desc(), priority); !isExpectedQueueError(err) {
-		log.Errorf(ctx, "unable to add: %s", err)
+		log.Errorf(ctx, "unable to add: %+v", err)
 	}
 }
 

--- a/pkg/storage/raft_transport.go
+++ b/pkg/storage/raft_transport.go
@@ -570,7 +570,7 @@ func (t *RaftTransport) startProcessNewQueue(
 
 		stream, err := client.RaftMessageBatch(batchCtx) // closed via cancellation
 		if err != nil {
-			log.Warningf(ctx, "creating batch client for node %d failed: %s", toNodeID, err)
+			log.Warningf(ctx, "creating batch client for node %d failed: %+v", toNodeID, err)
 			return
 		}
 
@@ -633,7 +633,7 @@ func (t *RaftTransport) SendSnapshot(
 
 	defer func() {
 		if err := stream.CloseSend(); err != nil {
-			log.Warningf(ctx, "failed to close snapshot stream: %s", err)
+			log.Warningf(ctx, "failed to close snapshot stream: %+v", err)
 		}
 	}()
 	return sendSnapshot(ctx, raftCfg, t.st, stream, storePool, header, snap, newBatch, sent)

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1467,7 +1467,7 @@ func (r *Replica) maybeWatchForMerge(ctx context.Context) error {
 					// transaction was probably caused by the shutdown, so ignore it.
 					return
 				default:
-					log.Warningf(ctx, "error while watching for merge to complete: PushTxn: %s", err)
+					log.Warningf(ctx, "error while watching for merge to complete: PushTxn: %+v", err)
 					// We can't safely unblock traffic until we can prove that the merge
 					// transaction is committed or aborted. Nothing to do but try again.
 					continue

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1391,7 +1391,7 @@ func (s *Store) AdminRelocateRange(
 		if err := s.DB().AdminTransferLease(
 			ctx, startKey, targets[0].StoreID,
 		); err != nil {
-			log.Warningf(ctx, "while transferring lease: %s", err)
+			log.Warningf(ctx, "while transferring lease: %+v", err)
 		}
 	}
 
@@ -1529,7 +1529,7 @@ func (s *Store) AdminRelocateRange(
 			newDesc, err := s.DB().AdminChangeReplicas(ctx, startKey, roachpb.REMOVE_REPLICA,
 				[]roachpb.ReplicationTarget{target}, *rangeInfo.Desc)
 			if err != nil {
-				log.Warningf(ctx, "while removing target %v: %s", target, err)
+				log.Warningf(ctx, "while removing target %v: %+v", target, err)
 				if !canRetry(err) {
 					return err
 				}
@@ -1616,7 +1616,7 @@ func (r *Replica) adminScatter(
 		targetStoreID := desc.Replicas().Unwrap()[newLeaseholderIdx].StoreID
 		if targetStoreID != r.store.StoreID() {
 			if err := r.AdminTransferLease(ctx, targetStoreID); err != nil {
-				log.Warningf(ctx, "failed to scatter lease to s%d: %s", targetStoreID, err)
+				log.Warningf(ctx, "failed to scatter lease to s%d: %+v", targetStoreID, err)
 			}
 		}
 	}

--- a/pkg/storage/replica_evaluate.go
+++ b/pkg/storage/replica_evaluate.go
@@ -100,7 +100,7 @@ func optimizePuts(
 	if ok, err := iter.Valid(); err != nil {
 		// TODO(bdarnell): return an error here instead of silently
 		// running without the optimization?
-		log.Errorf(context.TODO(), "Seek returned error; disabling blind-put optimization: %s", err)
+		log.Errorf(context.TODO(), "Seek returned error; disabling blind-put optimization: %+v", err)
 		return origReqs
 	} else if ok && bytes.Compare(iter.Key().Key, maxKey) <= 0 {
 		iterKey = iter.Key().Key

--- a/pkg/storage/replica_gc_queue.go
+++ b/pkg/storage/replica_gc_queue.go
@@ -117,7 +117,7 @@ func (rgcq *replicaGCQueue) shouldQueue(
 ) (bool, float64) {
 	lastCheck, err := repl.GetLastReplicaGCTimestamp(ctx)
 	if err != nil {
-		log.Errorf(ctx, "could not read last replica GC timestamp: %s", err)
+		log.Errorf(ctx, "could not read last replica GC timestamp: %+v", err)
 		return false, 0
 	}
 

--- a/pkg/storage/replica_gossip.go
+++ b/pkg/storage/replica_gossip.go
@@ -39,7 +39,7 @@ func (r *Replica) gossipFirstRange(ctx context.Context) {
 	if err := r.store.Gossip().AddInfo(
 		gossip.KeySentinel, r.store.ClusterID().GetBytes(),
 		r.store.cfg.SentinelGossipTTL()); err != nil {
-		log.Errorf(ctx, "failed to gossip sentinel: %s", err)
+		log.Errorf(ctx, "failed to gossip sentinel: %+v", err)
 	}
 	if log.V(1) {
 		log.Infof(ctx, "gossiping first range from store %d, r%d: %s",
@@ -47,7 +47,7 @@ func (r *Replica) gossipFirstRange(ctx context.Context) {
 	}
 	if err := r.store.Gossip().AddInfoProto(
 		gossip.KeyFirstRangeDescriptor, r.mu.state.Desc, configGossipTTL); err != nil {
-		log.Errorf(ctx, "failed to gossip first range metadata: %s", err)
+		log.Errorf(ctx, "failed to gossip first range metadata: %+v", err)
 	}
 }
 
@@ -258,7 +258,7 @@ func (r *Replica) maybeGossipFirstRange(ctx context.Context) *roachpb.Error {
 			r.store.StoreID(), r.RangeID)
 	}
 	if err := r.store.Gossip().AddClusterID(r.store.ClusterID()); err != nil {
-		log.Errorf(ctx, "failed to gossip cluster ID: %s", err)
+		log.Errorf(ctx, "failed to gossip cluster ID: %+v", err)
 	}
 
 	if r.store.cfg.TestingKnobs.DisablePeriodicGossips {

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -200,7 +200,7 @@ func (r *Replica) computeChecksumPostApply(ctx context.Context, cc storagepb.Com
 		// NB: the names here will match on all nodes, which is nice for debugging.
 		checkpointDir := filepath.Join(checkpointBase, fmt.Sprintf("r%d_at_%d", r.RangeID, rai))
 		if err := r.store.engine.CreateCheckpoint(checkpointDir); err != nil {
-			log.Warningf(ctx, "unable to create checkpoint %s: %s", checkpointDir, err)
+			log.Warningf(ctx, "unable to create checkpoint %s: %+v", checkpointDir, err)
 		} else {
 			log.Infof(ctx, "created checkpoint %s", checkpointDir)
 		}
@@ -514,18 +514,18 @@ func addSSTablePreApply(
 			// command as committed). Just unlink the file (RocksDB created a
 			// hard link); after that we're free to write it again.
 			if err := os.Remove(path); err != nil {
-				log.Fatalf(ctx, "while removing existing file during ingestion of %s: %s", path, err)
+				log.Fatalf(ctx, "while removing existing file during ingestion of %s: %+v", path, err)
 			}
 		}
 
 		if err := writeFileSyncing(ctx, path, sst.Data, eng, 0600, st, limiter); err != nil {
-			log.Fatalf(ctx, "while ingesting %s: %s", path, err)
+			log.Fatalf(ctx, "while ingesting %s: %+v", path, err)
 		}
 		copied = true
 	}
 
 	if err := eng.IngestExternalFiles(ctx, []string{path}, canSkipSeqNo, modify); err != nil {
-		log.Fatalf(ctx, "while ingesting %s: %s", path, err)
+		log.Fatalf(ctx, "while ingesting %s: %+v", path, err)
 	}
 	log.Eventf(ctx, "ingested SSTable at index %d, term %d: %s", index, term, path)
 	return copied
@@ -611,7 +611,7 @@ func (r *Replica) handleReplicatedEvalResult(
 				if size, _, err := r.raftMu.sideloaded.TruncateTo(ctx, newTruncState.Index+1); err != nil {
 					// We don't *have* to remove these entries for correctness. Log a
 					// loud error, but keep humming along.
-					log.Errorf(ctx, "while removing sideloaded files during log truncation: %s", err)
+					log.Errorf(ctx, "while removing sideloaded files during log truncation: %+v", err)
 				} else {
 					rResult.RaftLogDelta -= size
 				}
@@ -706,7 +706,7 @@ func (r *Replica) handleReplicatedEvalResult(
 			ctx, r, rResult.Merge.LeftDesc, rResult.Merge.RightDesc, rResult.Merge.FreezeStart,
 		); err != nil {
 			// Our in-memory state has diverged from the on-disk state.
-			log.Fatalf(ctx, "failed to update store after merging range: %s", err)
+			log.Fatalf(ctx, "failed to update store after merging range: %+v", err)
 		}
 		rResult.Merge = nil
 	}

--- a/pkg/storage/replica_proposal_buf.go
+++ b/pkg/storage/replica_proposal_buf.go
@@ -514,7 +514,7 @@ func proposeBatch(raftGroup *raft.RawNode, replID roachpb.ReplicaID, ents []raft
 // into the proposals map before canceling all proposals.
 func (b *propBuf) FlushLockedWithoutProposing() {
 	if err := b.FlushLockedWithRaftGroup(nil /* raftGroup */); err != nil {
-		log.Fatalf(context.Background(), "unexpected error: %v", err)
+		log.Fatalf(context.Background(), "unexpected error: %+v", err)
 	}
 }
 

--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -828,7 +828,7 @@ func splitMsgApps(msgs []raftpb.Message) (msgApps, otherMsgs []raftpb.Message) {
 
 func fatalOnRaftReadyErr(ctx context.Context, expl string, err error) {
 	// Mimic the behavior in processRaft.
-	log.Fatalf(ctx, "%s: %s", log.Safe(expl), err) // TODO(bdarnell)
+	log.Fatalf(ctx, "%s: %+v", log.Safe(expl), err) // TODO(bdarnell)
 }
 
 // tick the Raft group, returning true if the raft group exists and is
@@ -1835,7 +1835,7 @@ func (r *Replica) processRaftCommand(
 			// corruption/out-of-space issue. Make sure that these fail with
 			// descriptive message so that we can differentiate the root causes.
 			if err != nil {
-				log.Errorf(ctx, "unable to update the state machine: %s", err)
+				log.Errorf(ctx, "unable to update the state machine: %+v", err)
 				// Report the fatal error separately and only with the error, as that
 				// triggers an optimization for which we directly report the error to
 				// sentry (which in turn allows sentry to distinguish different error
@@ -2167,7 +2167,7 @@ func (r *Replica) applyRaftCommand(
 		// intentionally doesn't track the origin of the writes.
 		mutationCount, err := engine.RocksDBBatchCount(writeBatch.Data)
 		if err != nil {
-			log.Errorf(ctx, "unable to read header of committed WriteBatch: %s", err)
+			log.Errorf(ctx, "unable to read header of committed WriteBatch: %+v", err)
 		} else {
 			r.writeStats.recordCount(float64(mutationCount), 0 /* nodeID */)
 		}

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -433,7 +433,7 @@ func (r *Replica) GetSnapshot(
 		snap, rangeID, r.store.raftEntryCache, withSideloaded, startKey,
 	)
 	if err != nil {
-		log.Errorf(ctx, "error generating snapshot: %s", err)
+		log.Errorf(ctx, "error generating snapshot: %+v", err)
 		return nil, err
 	}
 	snapData.onClose = release
@@ -943,7 +943,7 @@ func (r *Replica) applySnapshot(
 		// We removed sr's data when we committed the batch. Finish subsumption by
 		// updating the in-memory bookkeping.
 		if err := sr.postDestroyRaftMuLocked(ctx, sr.GetMVCCStats()); err != nil {
-			log.Fatalf(ctx, "unable to finish destroying %s while applying snapshot: %s", sr, err)
+			log.Fatalf(ctx, "unable to finish destroying %s while applying snapshot: %+v", sr, err)
 		}
 		// We already hold sr's raftMu, so we must call removeReplicaImpl directly.
 		// Note that it's safe to update the store's metadata for sr's removal
@@ -955,7 +955,7 @@ func (r *Replica) applySnapshot(
 		if err := r.store.removeReplicaImpl(ctx, sr, subsumedNextReplicaID, RemoveOptions{
 			DestroyData: false, // data is already destroyed
 		}); err != nil {
-			log.Fatalf(ctx, "unable to remove %s while applying snapshot: %s", sr, err)
+			log.Fatalf(ctx, "unable to remove %s while applying snapshot: %+v", sr, err)
 		}
 	}
 
@@ -967,7 +967,7 @@ func (r *Replica) applySnapshot(
 	}
 	r.setDesc(ctx, s.Desc)
 	if err := r.store.maybeMarkReplicaInitializedLocked(ctx, r); err != nil {
-		log.Fatalf(ctx, "unable to mark replica initialized while applying snapshot: %s", err)
+		log.Fatalf(ctx, "unable to mark replica initialized while applying snapshot: %+v", err)
 	}
 	r.store.mu.Unlock()
 
@@ -1013,7 +1013,7 @@ func (r *Replica) applySnapshot(
 	// config is not available, in which case we rely on the next gossip update
 	// to perform the update.
 	if err := r.updateRangeInfo(s.Desc); err != nil {
-		log.Fatalf(ctx, "unable to update range info while applying snapshot: %s", err)
+		log.Fatalf(ctx, "unable to update range info while applying snapshot: %+v", err)
 	}
 
 	return nil

--- a/pkg/storage/replica_range_lease.go
+++ b/pkg/storage/replica_range_lease.go
@@ -551,7 +551,7 @@ func (r *Replica) leaseStatus(
 			// use the lease nor do we want to attempt to acquire it.
 			if err != nil {
 				if leaseStatusLogLimiter.ShouldLog() {
-					log.Warningf(context.TODO(), "can't determine lease status due to node liveness error: %s", err)
+					log.Warningf(context.TODO(), "can't determine lease status due to node liveness error: %+v", err)
 				}
 			}
 			status.State = storagepb.LeaseState_ERROR

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -637,7 +637,7 @@ func TestReplicaReadConsistency(t *testing.T) {
 	// Try consistent read and verify success.
 
 	if _, err := tc.SendWrapped(&gArgs); err != nil {
-		t.Errorf("expected success on consistent read: %s", err)
+		t.Errorf("expected success on consistent read: %+v", err)
 	}
 
 	// Try a read commmitted read and an inconsistent read, both within a
@@ -987,7 +987,7 @@ func TestReplicaLease(t *testing.T) {
 					Lease: lease,
 				},
 			}, &roachpb.RequestLeaseResponse{}); !testutils.IsError(err, "illegal lease") {
-			t.Fatalf("unexpected error: %v", err)
+			t.Fatalf("unexpected error: %+v", err)
 		}
 	}
 
@@ -2777,7 +2777,7 @@ func TestReplicaTSCacheForwardsIntentTS(t *testing.T) {
 			iter.Seek(mvccKey)
 			var keyMeta enginepb.MVCCMetadata
 			if ok, err := iter.Valid(); !ok || !iter.UnsafeKey().Equal(mvccKey) {
-				t.Fatalf("missing mvcc metadata for %q: %v", mvccKey, err)
+				t.Fatalf("missing mvcc metadata for %q: %+v", mvccKey, err)
 			} else if err := iter.ValueProto(&keyMeta); err != nil {
 				t.Fatalf("failed to unmarshal metadata for %q", mvccKey)
 			}
@@ -4151,7 +4151,7 @@ func TestBatchRetryCantCommitIntents(t *testing.T) {
 	ok, err := engine.MVCCGetProto(context.Background(), tc.repl.store.Engine(), txnKey,
 		hlc.Timestamp{}, &readTxn, engine.MVCCGetOptions{})
 	if err != nil || ok {
-		t.Errorf("expected transaction record to be cleared (%t): %s", ok, err)
+		t.Errorf("expected transaction record to be cleared (%t): %+v", ok, err)
 	}
 
 	// Now replay begin & put. BeginTransaction should fail with a
@@ -4502,7 +4502,7 @@ func TestEndTransactionDirectGC_1PC(t *testing.T) {
 			ba.Add(&bt, &put, &et)
 			br, err := tc.Sender().Send(context.Background(), ba)
 			if err != nil {
-				t.Fatalf("commit=%t: %s", commit, err)
+				t.Fatalf("commit=%t: %+v", commit, err)
 			}
 			etArgs, ok := br.Responses[len(br.Responses)-1].GetInner().(*roachpb.EndTransactionResponse)
 			if !ok || (!etArgs.OnePhaseCommit && commit) {
@@ -5204,13 +5204,13 @@ func TestResolveIntentPushTxnReplyTxn(t *testing.T) {
 	h := roachpb.Header{Txn: txn, Timestamp: tc.Clock().Now()}
 	// Should not be able to push or resolve in a transaction.
 	if _, err := batcheval.PushTxn(ctx, b, batcheval.CommandArgs{Stats: &ms, Header: h, Args: &pa}, &roachpb.PushTxnResponse{}); !testutils.IsError(err, batcheval.ErrTransactionUnsupported.Error()) {
-		t.Fatalf("transactional PushTxn returned unexpected error: %v", err)
+		t.Fatalf("transactional PushTxn returned unexpected error: %+v", err)
 	}
 	if _, err := batcheval.ResolveIntent(ctx, b, batcheval.CommandArgs{Stats: &ms, Header: h, Args: &ra}, &roachpb.ResolveIntentResponse{}); !testutils.IsError(err, batcheval.ErrTransactionUnsupported.Error()) {
-		t.Fatalf("transactional ResolveIntent returned unexpected error: %v", err)
+		t.Fatalf("transactional ResolveIntent returned unexpected error: %+v", err)
 	}
 	if _, err := batcheval.ResolveIntentRange(ctx, b, batcheval.CommandArgs{Stats: &ms, Header: h, Args: &rra}, &roachpb.ResolveIntentRangeResponse{}); !testutils.IsError(err, batcheval.ErrTransactionUnsupported.Error()) {
-		t.Fatalf("transactional ResolveIntentRange returned unexpected error: %v", err)
+		t.Fatalf("transactional ResolveIntentRange returned unexpected error: %+v", err)
 	}
 
 	// Should not get a transaction back from PushTxn. It used to erroneously
@@ -7740,7 +7740,7 @@ func TestReplicaRefreshMultiple(t *testing.T) {
 	if resp, pErr := client.SendWrapped(ctx, tc.Sender(), &get); pErr != nil {
 		t.Fatal(pErr)
 	} else if x, err := resp.(*roachpb.GetResponse).Value.GetInt(); err != nil {
-		t.Fatalf("returned non-int: %s", err)
+		t.Fatalf("returned non-int: %+v", err)
 	} else if x != 3 {
 		t.Fatalf("expected 3, got %d", x)
 	}
@@ -7825,7 +7825,7 @@ func TestReplicaRefreshMultiple(t *testing.T) {
 	if resp, pErr := client.SendWrapped(ctx, tc.Sender(), &get); pErr != nil {
 		t.Fatal(pErr)
 	} else if x, err := resp.(*roachpb.GetResponse).Value.GetInt(); err != nil {
-		t.Fatalf("returned non-int: %s", err)
+		t.Fatalf("returned non-int: %+v", err)
 	} else if x != 4 {
 		t.Fatalf("expected 4, got %d", x)
 	}
@@ -7883,7 +7883,7 @@ func TestGCWithoutThreshold(t *testing.T) {
 					Args:    &gc,
 					EvalCtx: NewReplicaEvalContext(tc.repl, &spans),
 				}, &resp); err != nil {
-					t.Fatalf("at (%s,%s): %s", keyThresh, txnThresh, err)
+					t.Fatalf("at (%s,%s): %+v", keyThresh, txnThresh, err)
 				}
 			}()
 		}
@@ -7985,13 +7985,13 @@ func TestCommandTimeThreshold(t *testing.T) {
 	if _, err := tc.SendWrappedWith(roachpb.Header{
 		Timestamp: ts1,
 	}, &gArgs); err != nil {
-		t.Fatalf("could not get data: %s", err)
+		t.Fatalf("could not get data: %+v", err)
 	}
 	// Verify a later Get works.
 	if _, err := tc.SendWrappedWith(roachpb.Header{
 		Timestamp: ts3,
 	}, &gArgs); err != nil {
-		t.Fatalf("could not get data: %s", err)
+		t.Fatalf("could not get data: %+v", err)
 	}
 
 	// Put some data for use with CP later on.
@@ -7999,7 +7999,7 @@ func TestCommandTimeThreshold(t *testing.T) {
 	if _, err := tc.SendWrappedWith(roachpb.Header{
 		Timestamp: ts1,
 	}, &pArgs); err != nil {
-		t.Fatalf("could not put data: %s", err)
+		t.Fatalf("could not put data: %+v", err)
 	}
 
 	// Do a GC.
@@ -9651,7 +9651,7 @@ func TestReplicaPushed1PC(t *testing.T) {
 	tc.manualClock.Increment(10)
 	ts2 := tc.Clock().Now()
 	if err := engine.MVCCPut(ctx, tc.engine, nil, k, ts2, roachpb.MakeValueFromString("one"), nil); err != nil {
-		t.Fatalf("writing interfering value: %s", err)
+		t.Fatalf("writing interfering value: %+v", err)
 	}
 
 	// Push the transaction's timestamp. In real-world situations,
@@ -11394,7 +11394,7 @@ func TestTxnRecordLifecycleTransitions(t *testing.T) {
 			runTs := tc.Clock().Now()
 			if c.setup != nil {
 				if err := c.setup(txn, runTs); err != nil {
-					t.Fatalf("failed during test setup: %v", err)
+					t.Fatalf("failed during test setup: %+v", err)
 				}
 			}
 

--- a/pkg/storage/spanset/spanset_test.go
+++ b/pkg/storage/spanset/spanset_test.go
@@ -70,7 +70,7 @@ func TestSpanSetCheckAllowedBoundaries(t *testing.T) {
 	}
 	for _, span := range allowed {
 		if err := ss.CheckAllowed(SpanReadOnly, span); err != nil {
-			t.Errorf("expected %s to be allowed, but got error: %s", span, err)
+			t.Errorf("expected %s to be allowed, but got error: %+v", span, err)
 		}
 	}
 
@@ -116,15 +116,15 @@ func TestSpanSetWriteImpliesRead(t *testing.T) {
 	ss.Add(SpanReadWrite, rwSpan)
 
 	if err := ss.CheckAllowed(SpanReadOnly, roSpan); err != nil {
-		t.Errorf("expected to be allowed to read roSpan, error: %s", err)
+		t.Errorf("expected to be allowed to read roSpan, error: %+v", err)
 	}
 	if err := ss.CheckAllowed(SpanReadWrite, roSpan); err == nil {
 		t.Errorf("expected not to be allowed to write roSpan")
 	}
 	if err := ss.CheckAllowed(SpanReadOnly, rwSpan); err != nil {
-		t.Errorf("expected to be allowed to read rwSpan, error: %s", err)
+		t.Errorf("expected to be allowed to read rwSpan, error: %+v", err)
 	}
 	if err := ss.CheckAllowed(SpanReadWrite, rwSpan); err != nil {
-		t.Errorf("expected to be allowed to read rwSpan, error: %s", err)
+		t.Errorf("expected to be allowed to read rwSpan, error: %+v", err)
 	}
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1087,7 +1087,7 @@ func (s *Store) SetDraining(drain bool) {
 					}
 				}); err != nil {
 				if log.V(1) {
-					log.Errorf(ctx, "error running draining task: %s", err)
+					log.Errorf(ctx, "error running draining task: %+v", err)
 				}
 				wg.Done()
 				return false
@@ -1122,7 +1122,7 @@ func (s *Store) SetDraining(drain bool) {
 		}); err != nil {
 		// You expect this message when shutting down a server in an unhealthy
 		// cluster. If we see it on healthy ones, there's likely something to fix.
-		log.Warningf(ctx, "unable to drain cleanly within %s, service might briefly deteriorate: %s", raftLeadershipTransferWait, err)
+		log.Warningf(ctx, "unable to drain cleanly within %s, service might briefly deteriorate: %+v", raftLeadershipTransferWait, err)
 	}
 }
 
@@ -1532,7 +1532,7 @@ func (s *Store) startGossip() {
 					if repl := s.LookupReplica(roachpb.RKey(gossipFn.key)); repl != nil {
 						annotatedCtx := repl.AnnotateCtx(ctx)
 						if err := gossipFn.fn(annotatedCtx, repl); err != nil {
-							log.Warningf(annotatedCtx, "could not gossip %s: %s", gossipFn.description, err)
+							log.Warningf(annotatedCtx, "could not gossip %s: %+v", gossipFn.description, err)
 							if err != errPeriodicGossipsDisabled {
 								continue
 							}
@@ -1718,10 +1718,10 @@ func (s *Store) asyncGossipStore(ctx context.Context, reason string, useCached b
 		ctx, fmt.Sprintf("storage.Store: gossip on %s", reason),
 		func(ctx context.Context) {
 			if err := s.GossipStore(ctx, useCached); err != nil {
-				log.Warningf(ctx, "error gossiping on %s: %s", reason, err)
+				log.Warningf(ctx, "error gossiping on %s: %+v", reason, err)
 			}
 		}); err != nil {
-		log.Warningf(ctx, "unable to gossip on %s: %s", reason, err)
+		log.Warningf(ctx, "unable to gossip on %s: %+v", reason, err)
 	}
 }
 
@@ -2115,7 +2115,7 @@ func splitPostApply(
 	// acquired) in Replica.acquireSplitLock. It must be present here.
 	rightRng, err := r.store.GetReplica(split.RightDesc.RangeID)
 	if err != nil {
-		log.Fatalf(ctx, "unable to find RHS replica: %s", err)
+		log.Fatalf(ctx, "unable to find RHS replica: %+v", err)
 	}
 	{
 		rightRng.mu.Lock()
@@ -2162,7 +2162,7 @@ func splitPostApply(
 	if err := rightRng.withRaftGroup(true, func(r *raft.RawNode) (unquiesceAndWakeLeader bool, _ error) {
 		return true, nil
 	}); err != nil {
-		log.Fatalf(ctx, "unable to create raft group for right-hand range in split: %s", err)
+		log.Fatalf(ctx, "unable to create raft group for right-hand range in split: %+v", err)
 	}
 
 	// Invoke the leasePostApply method to ensure we properly initialize
@@ -2175,7 +2175,7 @@ func splitPostApply(
 	// to the store's replica map.
 	if err := r.store.SplitRange(ctx, r, rightRng, split.LeftDesc); err != nil {
 		// Our in-memory state has diverged from the on-disk state.
-		log.Fatalf(ctx, "%s: failed to update Store after split: %s", r, err)
+		log.Fatalf(ctx, "%s: failed to update Store after split: %+v", r, err)
 	}
 
 	// Update store stats with difference in stats before and after split.
@@ -3393,7 +3393,7 @@ func (s *Store) processRaftSnapshotRequest(
 				// Replica.handleRaftReady. Note that we can only get here if the
 				// replica doesn't exist or is uninitialized.
 				if err := s.addPlaceholderLocked(placeholder); err != nil {
-					log.Fatalf(ctx, "could not add vetted placeholder %s: %s", placeholder, err)
+					log.Fatalf(ctx, "could not add vetted placeholder %s: %+v", placeholder, err)
 				}
 				addedPlaceholder = true
 			}
@@ -3601,7 +3601,7 @@ func (s *Store) processReady(ctx context.Context, rangeID roachpb.RangeID) {
 	start := timeutil.Now()
 	stats, expl, err := r.handleRaftReady(ctx, noSnap)
 	if err != nil {
-		log.Fatalf(ctx, "%s: %s", log.Safe(expl), err) // TODO(bdarnell)
+		log.Fatalf(ctx, "%s: %+v", log.Safe(expl), err) // TODO(bdarnell)
 	}
 	elapsed := timeutil.Since(start)
 	s.metrics.RaftWorkingDurationNanos.Inc(elapsed.Nanoseconds())

--- a/pkg/storage/store_pool_test.go
+++ b/pkg/storage/store_pool_test.go
@@ -543,7 +543,7 @@ func TestStorePoolUpdateLocalStoreBeforeGossip(t *testing.T) {
 	}
 	replica, err := NewReplica(&rg, store, roachpb.ReplicaID(0))
 	if err != nil {
-		t.Fatalf("make replica error : %s", err)
+		t.Fatalf("make replica error : %+v", err)
 	}
 	replica.leaseholderStats = newReplicaStats(store.Clock(), nil)
 

--- a/pkg/storage/store_rebalancer.go
+++ b/pkg/storage/store_rebalancer.go
@@ -247,7 +247,7 @@ func (sr *StoreRebalancer) rebalanceStore(
 		if err := contextutil.RunWithTimeout(ctx, "transfer lease", sr.rq.processTimeout, func(ctx context.Context) error {
 			return sr.rq.transferLease(ctx, replWithStats.repl, target, replWithStats.qps)
 		}); err != nil {
-			log.Errorf(ctx, "unable to transfer lease to s%d: %v", target.StoreID, err)
+			log.Errorf(ctx, "unable to transfer lease to s%d: %+v", target.StoreID, err)
 			continue
 		}
 		sr.metrics.LeaseTransferCount.Inc(1)
@@ -306,7 +306,7 @@ func (sr *StoreRebalancer) rebalanceStore(
 		if err := contextutil.RunWithTimeout(ctx, "relocate range", sr.rq.processTimeout, func(ctx context.Context) error {
 			return sr.rq.store.AdminRelocateRange(ctx, *descBeforeRebalance, targets)
 		}); err != nil {
-			log.Errorf(ctx, "unable to relocate range to %v: %v", targets, err)
+			log.Errorf(ctx, "unable to relocate range to %v: %+v", targets, err)
 			continue
 		}
 		sr.metrics.RangeRebalanceCount.Inc(1)

--- a/pkg/storage/store_snapshot_preemptive.go
+++ b/pkg/storage/store_snapshot_preemptive.go
@@ -202,7 +202,7 @@ func (s *Store) processPreemptiveSnapshotRequest(
 				// Replica.handleRaftReady. Note that we can only get here if the
 				// replica doesn't exist or is uninitialized.
 				if err := s.addPlaceholderLocked(placeholder); err != nil {
-					log.Fatalf(ctx, "could not add vetted placeholder %s: %s", placeholder, err)
+					log.Fatalf(ctx, "could not add vetted placeholder %s: %+v", placeholder, err)
 				}
 				addedPlaceholder = true
 			}

--- a/pkg/storage/store_snapshot_test.go
+++ b/pkg/storage/store_snapshot_test.go
@@ -91,7 +91,7 @@ func TestSnapshotRaftLogLimit(t *testing.T) {
 			err = ss.Send(ctx, stream, header, outSnap)
 			if snapType == SnapshotRequest_PREEMPTIVE {
 				if !testutils.IsError(err, "aborting snapshot because raft log is too large") {
-					t.Fatalf("unexpected error: %v", err)
+					t.Fatalf("unexpected error: %+v", err)
 				}
 			} else {
 				if err != nil {

--- a/pkg/storage/stores.go
+++ b/pkg/storage/stores.go
@@ -104,7 +104,7 @@ func (ls *Stores) AddStore(s *Store) {
 	if ls.mu.biLatestTS != (hlc.Timestamp{}) {
 		if err := ls.updateBootstrapInfoLocked(ls.mu.latestBI); err != nil {
 			ctx := ls.AnnotateCtx(context.TODO())
-			log.Errorf(ctx, "failed to update bootstrap info on newly added store: %s", err)
+			log.Errorf(ctx, "failed to update bootstrap info on newly added store: %+v", err)
 		}
 	}
 }

--- a/pkg/storage/stores_test.go
+++ b/pkg/storage/stores_test.go
@@ -143,7 +143,7 @@ func TestStoresGetReplicaForRangeID(t *testing.T) {
 
 		replica, err := NewReplica(desc, store, 0)
 		if err != nil {
-			t.Fatalf("unexpected error when creating replica: %v", err)
+			t.Fatalf("unexpected error when creating replica: %+v", err)
 		}
 		err2 := store.AddReplica(replica)
 		if err2 != nil {
@@ -518,7 +518,7 @@ func TestStoresClusterVersionIncompatible(t *testing.T) {
 				t.Fatal(err)
 			}
 			if _, err := ls.SynthesizeClusterVersion(ctx); !testutils.IsError(err, expErr) {
-				t.Fatalf("unexpected error: %v", err)
+				t.Fatalf("unexpected error: %+v", err)
 			}
 		})
 	}

--- a/pkg/storage/ts_maintenance_queue_test.go
+++ b/pkg/storage/ts_maintenance_queue_test.go
@@ -325,7 +325,7 @@ func TestTimeSeriesMaintenanceQueueServer(t *testing.T) {
 	storeID := roachpb.StoreID(1)
 	store, err := tsrv.Stores().GetStore(roachpb.StoreID(1))
 	if err != nil {
-		t.Fatalf("error retrieving store %d: %s", storeID, err)
+		t.Fatalf("error retrieving store %d: %+v", storeID, err)
 	}
 	if err := store.ForceTimeSeriesMaintenanceQueueProcess(); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
(I am sending this as a strawman limited to the `storage` package. If we collectively find this useful, we can extend the idea to other packages and eventually add a linter to enforce.)

The `%+v` formatting is able to reveal the internal structure of error
objects, including their causes and embedded stack traces. This
additional detail is useful during troubleshooting.

This change was obtained using the following perl invocation:

```
perl -pi -ne 's/((?:log\.|\b[tb]\.)(?:Fatalf|Errorf|Warningf|Logf)\(.*: )%[sv](".*, err\))/\1%+v\2/g'
```

ie it is not exhaustive: it is limited to `log.Warningf`,
`log.Fatalf`, and `t.Errorf`/`t.Fatalf`/`t.Logf` calls that do not
span multiple lines.

Release note: None