### PR TITLE
opt: use verbose error reporting

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -138,8 +138,10 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 	isDDL := opt.IsDDLOp(e)
 	if isDDL {
 		if err := b.evalCtx.Txn.SetSystemConfigTrigger(); err != nil {
-			return execPlan{}, unimplemented.NewWithIssuef(26508,
-				"schema change statement cannot follow a statement that has written in the same transaction: %v", err)
+			return execPlan{}, errors.WithSecondaryError(
+				unimplemented.NewWithIssuef(26508,
+					"schema change statement cannot follow a statement that has written in the same transaction"),
+				err)
 		}
 	}
 

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -142,7 +142,7 @@ func (b *Builder) indexedVar(
 		if b.nullifyMissingVarExprs > 0 {
 			expr, err := tree.ReType(tree.DNull, md.ColumnMeta(colID).Type)
 			if err != nil {
-				panic(errors.AssertionFailedf("unexpected failure during ReType: %v", err))
+				panic(errors.NewAssertionErrorWithWrappedErrf(err, "unexpected failure during ReType"))
 			}
 			return expr
 		}

--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -794,14 +794,14 @@ func (c *indexConstraintCtx) makeInvertedIndexSpansForExpr(
 			// First, check if there's more than one path through the datum.
 			paths, err := json.AllPaths(rd)
 			if err != nil {
-				log.Errorf(context.TODO(), "unexpected JSON error: %v", err)
+				log.Errorf(context.TODO(), "unexpected JSON error: %+v", err)
 				c.unconstrained(0 /* offset */, out)
 				return false, append(constraints, out)
 			}
 			for i := range paths {
 				hasContainerLeaf, err := paths[i].HasContainerLeaf()
 				if err != nil {
-					log.Errorf(context.TODO(), "unexpected JSON error: %v", err)
+					log.Errorf(context.TODO(), "unexpected JSON error: %+v", err)
 					c.unconstrained(0 /* offset */, out)
 					return false, append(constraints, out)
 				}
@@ -811,7 +811,7 @@ func (c *indexConstraintCtx) makeInvertedIndexSpansForExpr(
 				}
 				pathDatum, err := tree.MakeDJSON(paths[i])
 				if err != nil {
-					log.Errorf(context.TODO(), "unexpected JSON error: %v", err)
+					log.Errorf(context.TODO(), "unexpected JSON error: %+v", err)
 					c.unconstrained(0 /* offset */, out)
 					return false, append(constraints, out)
 				}

--- a/pkg/sql/opt/optgen/exprgen/expr_gen.go
+++ b/pkg/sql/opt/optgen/exprgen/expr_gen.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/errors"
 )
 
 // Build generates an expression from an optgen string (the kind of expression
@@ -122,6 +123,10 @@ type exprGenErr struct {
 
 func errorf(format string, a ...interface{}) error {
 	return exprGenErr{fmt.Errorf(format, a...)}
+}
+
+func wrapf(err error, format string, a ...interface{}) error {
+	return exprGenErr{errors.WrapWithDepthf(1, err, format, a...)}
 }
 
 // Parses the input (with replace-side rule syntax) into an optgen expression

--- a/pkg/sql/opt/optgen/exprgen/parse_type.go
+++ b/pkg/sql/opt/optgen/exprgen/parse_type.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/errors"
 )
 
 // ParseType parses a string describing a type.
@@ -32,7 +33,7 @@ func ParseType(typeStr string) (*types.T, error) {
 		// some special syntax.
 		parsed, err := parser.ParseOne(fmt.Sprintf("PREPARE x ( %s ) AS SELECT 1", s))
 		if err != nil {
-			return nil, fmt.Errorf("cannot parse %s as a type: %s", typeStr, err)
+			return nil, errors.Wrapf(err, "cannot parse %s as a type", typeStr)
 		}
 		colTypes := parsed.AST.(*tree.Prepare).Types
 		contents := make([]types.T, len(colTypes))

--- a/pkg/sql/opt/optgen/exprgen/private.go
+++ b/pkg/sql/opt/optgen/exprgen/private.go
@@ -178,7 +178,7 @@ func (eg *exprGen) cardinalityFromStr(str string) props.Cardinality {
 func (eg *exprGen) intFromStr(str string) int {
 	val, err := strconv.Atoi(str)
 	if err != nil {
-		panic(errorf("expected number: %s (error: %v)", str, err))
+		panic(wrapf(err, "expected number: %s", str))
 	}
 	return val
 }
@@ -186,7 +186,7 @@ func (eg *exprGen) intFromStr(str string) int {
 func (eg *exprGen) statsFromStr(str string) props.Statistics {
 	var stats []stats.JSONStatistic
 	if err := json.Unmarshal([]byte(str), &stats); err != nil {
-		panic(errorf("error unmarshaling statistics: %v", err))
+		panic(wrapf(err, "error unmarshaling statistics"))
 	}
 	var result props.Statistics
 	if len(stats) == 0 {

--- a/pkg/sql/opt/testutils/testcat/vtable.go
+++ b/pkg/sql/opt/testutils/testcat/vtable.go
@@ -11,11 +11,10 @@
 package testcat
 
 import (
-	"fmt"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/vtable"
+	"github.com/cockroachdb/errors"
 )
 
 var informationSchemaMap = map[string]*tree.CreateTable{}
@@ -35,12 +34,12 @@ func init() {
 	for _, table := range informationSchemaTables {
 		parsed, err := parser.ParseOne(table)
 		if err != nil {
-			panic(fmt.Sprintf("error initializing virtual table map: %s", err))
+			panic(errors.Wrap(err, "error initializing virtual table map"))
 		}
 
 		ct, ok := parsed.AST.(*tree.CreateTable)
 		if !ok {
-			panic("virtual table schemas must be CREATE TABLE statements")
+			panic(errors.New("virtual table schemas must be CREATE TABLE statements"))
 		}
 
 		ct.Table.SchemaName = tree.Name("information_schema")


### PR DESCRIPTION
(Discussed with @RaduBerinde)
(I am sending this as a strawman limited to the `opt` package. If we collectively find this useful, we can extend the idea to other packages and eventually add a linter to enforce.)

Preserving the error structure and formatting using `%+v` makes
troubleshooting easier.

Release note: None