### PR TITLE
sql/exec: detail error objects when printing out warnings

### DIFF
--- a/pkg/sql/exec/colrpc/inbox.go
+++ b/pkg/sql/exec/colrpc/inbox.go
@@ -269,12 +269,12 @@ func (i *Inbox) DrainMeta(ctx context.Context) []distsqlpb.ProducerMetadata {
 
 	defer i.close()
 	if err := i.maybeInit(ctx); err != nil {
-		log.Warningf(ctx, "Inbox unable to initialize stream while draining metadata: %s", err)
+		log.Warningf(ctx, "Inbox unable to initialize stream while draining metadata: %+v", err)
 		return allMeta
 	}
 	log.VEvent(ctx, 2, "Inbox sending drain signal to Outbox")
 	if err := i.stream.Send(&distsqlpb.ConsumerSignal{DrainRequest: &distsqlpb.DrainRequest{}}); err != nil {
-		log.Warningf(ctx, "Inbox unable to send drain signal to Outbox: %s", err)
+		log.Warningf(ctx, "Inbox unable to send drain signal to Outbox: %+v", err)
 		return allMeta
 	}
 	for {
@@ -283,7 +283,7 @@ func (i *Inbox) DrainMeta(ctx context.Context) []distsqlpb.ProducerMetadata {
 			if err == io.EOF {
 				break
 			}
-			log.Warningf(ctx, "Inbox Recv connection error while draining metadata: %s", err)
+			log.Warningf(ctx, "Inbox Recv connection error while draining metadata: %+v", err)
 			return allMeta
 		}
 		for _, remoteMeta := range msg.Data.Metadata {

--- a/pkg/sql/exec/colrpc/outbox.go
+++ b/pkg/sql/exec/colrpc/outbox.go
@@ -109,7 +109,7 @@ func (o *Outbox) Run(
 	if err != nil {
 		log.Warningf(
 			ctx,
-			"Outbox Dial connection error, distributed query will fail: %s",
+			"Outbox Dial connection error, distributed query will fail: %+v",
 			err,
 		)
 		return
@@ -120,7 +120,7 @@ func (o *Outbox) Run(
 	if err != nil {
 		log.Warningf(
 			ctx,
-			"Outbox FlowStream connection error, distributed query will fail: %s",
+			"Outbox FlowStream connection error, distributed query will fail: %+v",
 			err,
 		)
 		return
@@ -133,7 +133,7 @@ func (o *Outbox) Run(
 	); err != nil {
 		log.Warningf(
 			ctx,
-			"Outbox Send header error, distributed query will fail: %s",
+			"Outbox Send header error, distributed query will fail: %+v",
 			err,
 		)
 		return
@@ -153,7 +153,7 @@ func (o *Outbox) handleStreamErr(
 		log.Infof(ctx, "Outbox calling cancelFn after %s EOF", opName)
 		cancelFn()
 	} else {
-		log.Errorf(ctx, "Outbox %s connection error: %s", opName, err)
+		log.Errorf(ctx, "Outbox %s connection error: %+v", opName, err)
 	}
 }
 
@@ -190,7 +190,7 @@ func (o *Outbox) sendBatches(
 		}
 		var b coldata.Batch
 		if err := exec.CatchVectorizedRuntimeError(func() { b = o.input.Next(ctx) }); err != nil {
-			log.Errorf(ctx, "Outbox Next error: %s", err)
+			log.Errorf(ctx, "Outbox Next error: %+v", err)
 			return false, err
 		}
 		if b.Length() == 0 {
@@ -200,11 +200,11 @@ func (o *Outbox) sendBatches(
 		o.scratch.buf.Reset()
 		d, err := o.converter.BatchToArrow(b)
 		if err != nil {
-			log.Errorf(ctx, "Outbox BatchToArrow data serialization error: %s", err)
+			log.Errorf(ctx, "Outbox BatchToArrow data serialization error: %+v", err)
 			return false, err
 		}
 		if err := o.serializer.Serialize(o.scratch.buf, d); err != nil {
-			log.Errorf(ctx, "Outbox Serialize data error: %s", err)
+			log.Errorf(ctx, "Outbox Serialize data error: %+v", err)
 			return false, err
 		}
 		o.scratch.msg.Data.RawBytes = o.scratch.buf.Bytes()
@@ -255,7 +255,7 @@ func (o *Outbox) runWithStream(
 			msg, err := stream.Recv()
 			if err != nil {
 				if err != io.EOF {
-					log.Errorf(ctx, "Outbox Recv connection error: %s", err)
+					log.Errorf(ctx, "Outbox Recv connection error: %+v", err)
 				}
 				break
 			}

--- a/pkg/sql/exec/error.go
+++ b/pkg/sql/exec/error.go
@@ -58,7 +58,8 @@ func CatchVectorizedRuntimeError(operation func()) (retErr error) {
 						retErr = e
 					} else {
 						// Not an error object. Definitely unexpected.
-						retErr = errors.AssertionFailedf("unexpected error from the vectorized runtime: %v", err)
+						surprisingObject := err
+						retErr = errors.AssertionFailedf("unexpected error from the vectorized runtime: %+v", surprisingObject)
 					}
 				} else {
 					// Do not recover from the panic not related to the vectorized


### PR DESCRIPTION
(I am sending this as a strawman limited to the `sql/exec` package. If we collectively find this useful, we can extend the idea to other packages and eventually add a linter to enforce.)

Formatting with `%+v` reveals the internal structure of error objects
and makes troubleshooting easier.

Release note: None