### PR TITLE
exec: fix planning of count operator

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -142,7 +142,9 @@ func newColOperator(
 			aggSpec.Aggregations[0].FilterColIdx == nil &&
 			aggSpec.Aggregations[0].Func == distsqlpb.AggregatorSpec_COUNT_ROWS &&
 			!aggSpec.Aggregations[0].Distinct {
-			return exec.NewCountOp(inputs[0]), []types.T{types.Int64}, nil
+			op, err = exec.NewCountOp(inputs[0]), nil
+			columnTypes = []semtypes.T{*semtypes.Int}
+			break
 		}
 
 		var groupCols, orderedCols util.FastIntSet

--- a/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
@@ -61,9 +61,9 @@ func (p {{template "opRConstName" .}}) Next(ctx context.Context) coldata.Batch {
 		batch.AppendCol(types.{{.RetTyp}})
 	}
 	vec := batch.ColVec(p.colIdx)
-	col := vec.{{.LTyp}}()[:coldata.BatchSize]
+	col := vec.{{.LTyp}}()
 	projVec := batch.ColVec(p.outputIdx)
-	projCol := projVec.{{.RetTyp}}()[:coldata.BatchSize]
+	projCol := projVec.{{.RetTyp}}()
 	if sel := batch.Selection(); sel != nil {
 		for _, i := range sel {
 			{{(.Assign "projCol[i]" "col[i]" "p.constArg")}}
@@ -105,9 +105,9 @@ func (p {{template "opLConstName" .}}) Next(ctx context.Context) coldata.Batch {
 		batch.AppendCol(types.{{.RetTyp}})
 	}
 	vec := batch.ColVec(p.colIdx)
-	col := vec.{{.RTyp}}()[:coldata.BatchSize]
+	col := vec.{{.RTyp}}()
 	projVec := batch.ColVec(p.outputIdx)
-	projCol := projVec.{{.RetTyp}}()[:coldata.BatchSize]
+	projCol := projVec.{{.RetTyp}}()
 	if sel := batch.Selection(); sel != nil {
 		for _, i := range sel {
 			{{(.Assign "projCol[i]" "p.constArg" "col[i]")}}
@@ -149,11 +149,11 @@ func (p {{template "opName" .}}) Next(ctx context.Context) coldata.Batch {
 		batch.AppendCol(types.{{.RetTyp}})
 	}
 	projVec := batch.ColVec(p.outputIdx)
-	projCol := projVec.{{.RetTyp}}()[:coldata.BatchSize]
+	projCol := projVec.{{.RetTyp}}()
 	vec1 := batch.ColVec(p.col1Idx)
 	vec2 := batch.ColVec(p.col2Idx)
-	col1 := vec1.{{.LTyp}}()[:coldata.BatchSize]
-	col2 := vec2.{{.RTyp}}()[:coldata.BatchSize]
+	col1 := vec1.{{.LTyp}}()
+	col2 := vec2.{{.RTyp}}()
 	if sel := batch.Selection(); sel != nil {
 		for _, i := range sel {
 			{{(.Assign "projCol[i]" "col1[i]" "col2[i]")}}

--- a/pkg/sql/exec/execgen/cmd/execgen/selection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/selection_ops_gen.go
@@ -105,7 +105,7 @@ func (p *{{template "opConstName" .}}) Next(ctx context.Context) coldata.Batch {
 		}
 
 		vec := batch.ColVec(p.colIdx)
-		col := vec.{{.LTyp}}()[:coldata.BatchSize]
+		col := vec.{{.LTyp}}()
 		var idx uint16
 		n := batch.Length()
 		if vec.MaybeHasNulls() {
@@ -143,8 +143,8 @@ func (p *{{template "opName" .}}) Next(ctx context.Context) coldata.Batch {
 
 		vec1 := batch.ColVec(p.col1Idx)
 		vec2 := batch.ColVec(p.col2Idx)
-		col1 := vec1.{{.LTyp}}()[:coldata.BatchSize]
-		col2 := vec2.{{.RTyp}}()[:coldata.BatchSize]
+		col1 := vec1.{{.LTyp}}()
+		col2 := vec2.{{.RTyp}}()
 		n := batch.Length()
 
 		var idx uint16

--- a/pkg/sql/exec/select_in_tmpl.go
+++ b/pkg/sql/exec/select_in_tmpl.go
@@ -177,7 +177,7 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 		}
 
 		vec := batch.ColVec(si.colIdx)
-		col := vec._TemplateType()[:coldata.BatchSize]
+		col := vec._TemplateType()
 		var idx uint16
 		n := batch.Length()
 
@@ -247,10 +247,10 @@ func (pi *projectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 	}
 
 	vec := batch.ColVec(pi.colIdx)
-	col := vec._TemplateType()[:coldata.BatchSize]
+	col := vec._TemplateType()
 
 	projVec := batch.ColVec(pi.outputIdx)
-	projCol := projVec.Bool()[:coldata.BatchSize]
+	projCol := projVec.Bool()
 	projNulls := projVec.Nulls()
 
 	n := batch.Length()

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -444,3 +444,14 @@ query II
 SELECT * FROM t38753 ORDER BY y;
 ----
 0  NULL
+
+# Regression test for #38752.
+query IIBB
+SELECT count(*), count(*) + 1, count(*) > 4, count(*) + 1 > 4 FROM b
+----
+4  5  false  true
+
+query I
+SELECT * FROM (SELECT count(*) AS x FROM b) WHERE x > 0;
+----
+4


### PR DESCRIPTION
Previously, when planning a count operator, we would add it to the
flow and would ignore any post-operator planning (like projections).
Now, this is fixed.

Additionally, this commit fixes slicing within projections operators -
previously, we would always slice up to BatchSize, but the underlying
memory not always has sufficient capacity (for example, count operator
uses a batch with a capacity of 1) which would cause an index out of
bounds.

Fixes: #38752.

Release note: None