### PR TITLE
exec: Add memory calculation interface for Batches

### DIFF
--- a/pkg/sql/exec/coldata/batch.go
+++ b/pkg/sql/exec/coldata/batch.go
@@ -45,6 +45,9 @@ type Batch interface {
 	// columns and allocations, invalidating existing references to the Batch or
 	// its Vecs. However, Reset does _not_ zero out the column data.
 	Reset(types []types.T, length int)
+	// SizeBytes returns an approximation of the amount of memory used to
+	// represent this batch.
+	SizeBytes() int64
 }
 
 var _ Batch = &MemBatch{}
@@ -154,4 +157,13 @@ func (m *MemBatch) Reset(types []types.T, length int) {
 	for _, col := range m.ColVecs() {
 		col.Nulls().UnsetNulls()
 	}
+}
+
+// SizeBytes implements the Batch interface
+func (m *MemBatch) SizeBytes() int64 {
+	size := int64(0)
+	for _, vec := range m.ColVecs() {
+		size += vec.SizeBytes()
+	}
+	return size
 }

--- a/pkg/sql/exec/mergejoiner_groups_buffer.go
+++ b/pkg/sql/exec/mergejoiner_groups_buffer.go
@@ -226,6 +226,12 @@ func (bg *mjBufferedGroup) Reset(types []types.T, length int) {
 	panic("Reset([]types.T, int) should not be called on mjBufferedGroup")
 }
 
+// SizeBytes is not implemented because it is not being used right now
+// on mjBufferedGroups.
+func (bg *mjBufferedGroup) SizeBytes() int64 {
+	panic("SizeBytes() should not be called on mjBufferedGroup")
+}
+
 // reset resets the state of the buffered group so that we can reuse the
 // underlying memory.
 func (bg *mjBufferedGroup) reset() {


### PR DESCRIPTION
To easily monitor static memory usage of operators, coldata.Batch implements a function to easily estimate the space usage of the batch itself.