### PR TITLE
sql: remove foreign keys immediately during DROP INDEX

### DIFF
--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -250,6 +250,18 @@ func (p *planner) dropIndexByName(
 				}
 			}
 
+			// Remove all foreign key references and backreferences from the index.
+			// TODO (lucy): This is incorrect for two reasons: The first is that FKs
+			// won't be restored if the DROP INDEX is rolled back, and the second is
+			// that validated constraints should be dropped in the schema changer in
+			// multiple steps to avoid inconsistencies. We should be queuing a
+			// mutation to drop the FK instead. The reason why the FK is removed here
+			// is to keep the index state consistent with the earlier removal of the
+			// reference on the other table involved in the FK, in case of rollbacks
+			// (#38733).
+			idxEntry.ForeignKey = sqlbase.ForeignKeyReference{}
+			idxEntry.ReferencedBy = nil
+
 			// the idx we picked up with FindIndexByID at the top may not
 			// contain the same field any more due to other schema changes
 			// intervening since the initial lookup. So we send the recent

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1499,3 +1499,73 @@ COMMIT
 
 statement ok
 DROP TABLE t
+
+# Test that DROP INDEX on an index with dependent foreign keys is correctly
+# rolled back when there is an error
+subtest 38733
+
+statement ok
+CREATE TABLE x (a INT PRIMARY KEY, b INT, UNIQUE INDEX (b), c INT)
+
+statement ok
+CREATE TABLE y (a INT PRIMARY KEY, b INT, INDEX (b))
+
+statement ok
+INSERT INTO x VALUES (1, 1, 1), (2, 2, 1);
+
+statement ok
+INSERT INTO y VALUES (1, 1), (2, 1);
+
+# First, test dropping the index on the referencing side
+statement ok
+ALTER TABLE y ADD FOREIGN KEY (b) REFERENCES x (b)
+
+statement ok
+BEGIN
+
+# Drop the index that the FK reference depends on
+statement ok
+DROP INDEX y_b_idx CASCADE;
+
+# This will fail, causing the previous DROP INDEX to also be rolled back
+statement ok
+CREATE UNIQUE INDEX ON y (b);
+
+statement error pgcode XXA00 violates unique constraint
+COMMIT
+
+# Verify that table y is in a consistent state (otherwise, SHOW CONSTRAINTS
+# would fail with an error)
+query TTTTB
+SHOW CONSTRAINTS FROM y
+----
+y  primary  PRIMARY KEY  PRIMARY KEY (a ASC)  true
+
+# Also test dropping the index on the referenced side
+statement ok
+ALTER TABLE y ADD FOREIGN KEY (b) REFERENCES x (b)
+
+statement ok
+BEGIN
+
+# Drop the index that the FK reference depends on
+statement ok
+DROP INDEX x_b_key CASCADE;
+
+# This will fail, causing the previous DROP INDEX to also be rolled back
+statement ok
+CREATE UNIQUE INDEX ON x (c);
+
+statement error pgcode XXA00 violates unique constraint
+COMMIT
+
+# Verify that table x is in a consistent state (otherwise, SHOW CONSTRAINTS
+# would fail with an error).
+query TTTTB
+SHOW CONSTRAINTS FROM x
+----
+x  primary  PRIMARY KEY  PRIMARY KEY (a ASC)  true
+x  x_b_key  UNIQUE       UNIQUE (b ASC)       true
+
+statement ok
+DROP TABLE x, y


### PR DESCRIPTION
Currently, during `DROP INDEX`, if there is a foreign key that depends on that
index, we only remove foreign key references or backreferences on the other
table; the FK ref/backrefs on the index itself are left intact because it's
assumed that they'll go away when the index is dropped. This leaves a
permanently orphaned reference on the index if the schema change is rolled
back, which will prevent most DDL statements and `SHOW CONSTRAINTS`, etc. from
working.

This PR adds a quick fix by deleting the FK ref/backrefs on the index
immediately in the original user transaction, instead of waiting for the index
to successfully get dropped. This isn't a permanent fix; the correct solution
would be to queue a mutation to drop the FK in the schema changer with the same
mutation ID. This fix doesn't cause the FK to correctly be restored on
rollback.

Fixes #38733.
Dropping constraints in the schema changer is filed separately in #38025.

Release note (bug fix): Fix bug where dropping an index that a foreign key
depends on could cause an inconsistent table state if the schema change were
rolled back.