### PR TITLE
row: bugfixes to cfetcher

### DIFF
--- a/docs/tech-notes/encoding.md
+++ b/docs/tech-notes/encoding.md
@@ -126,6 +126,13 @@ the KV value has other data, to guarantee that primary keys appear in at
 least one KV pair. (Even if there are other column families, their KV
 pairs may be suppressed; see subsection NULL below.)
 
+Note that in system tables that use multiple column families, such as
+system.zones or system.namespace, there may not be any sentinel KV pair at all.
+This is because of the fact that the database writes to these system tables
+using raw KV puts and does not include the logic to write a sentinel KV. KV
+decoding code that needs to understand system tables must be aware of this
+possibility.
+
 ### Single-column column families
 
 Before column families (i.e., in format version 1), non-sentinel KV keys

--- a/pkg/sql/colencoding/key_encoding.go
+++ b/pkg/sql/colencoding/key_encoding.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -63,7 +64,8 @@ func DecodeIndexKeyToCols(
 			}
 
 			length := int(ancestor.SharedPrefixLen)
-			key, err = DecodeKeyValsToCols(vecs, idx, indexColIdx[:length], types[:length], colDirs[:length], key)
+			key, err = DecodeKeyValsToCols(vecs, idx, indexColIdx[:length], types[:length], colDirs[:length],
+				nil /* unseen */, key)
 			if err != nil {
 				return nil, false, err
 			}
@@ -94,7 +96,7 @@ func DecodeIndexKeyToCols(
 		}
 	}
 
-	key, err = DecodeKeyValsToCols(vecs, idx, indexColIdx, types, colDirs, key)
+	key, err = DecodeKeyValsToCols(vecs, idx, indexColIdx, types, colDirs, nil /* unseen */, key)
 	if err != nil {
 		return nil, false, err
 	}
@@ -115,6 +117,9 @@ func DecodeIndexKeyToCols(
 // result to the idx'th slot of the input slice of exec.ColVecs. If the
 // directions slice is nil, the direction used will default to
 // encoding.Ascending.
+// If the unseen int set is non-nil, upon decoding the column with ordinal i,
+// i will be removed from the set to facilitate tracking whether or not columns
+// have been observed during decoding.
 // See the analog in sqlbase/index_encoding.go.
 func DecodeKeyValsToCols(
 	vecs []coldata.Vec,
@@ -122,6 +127,7 @@ func DecodeKeyValsToCols(
 	indexColIdx []int,
 	types []types.T,
 	directions []sqlbase.IndexDescriptor_Direction,
+	unseen *util.FastIntSet,
 	key []byte,
 ) ([]byte, error) {
 	for j := range types {
@@ -135,6 +141,9 @@ func DecodeKeyValsToCols(
 			// Don't need the coldata - skip it.
 			key, err = skipTableKey(&types[j], key, enc)
 		} else {
+			if unseen != nil {
+				unseen.Remove(i)
+			}
 			key, err = decodeTableKeyToCol(vecs[i], idx, &types[j], key, enc)
 		}
 		if err != nil {
@@ -146,7 +155,7 @@ func DecodeKeyValsToCols(
 
 // decodeTableKeyToCol decodes a value encoded by EncodeTableKey, writing the result
 // to the idx'th slot of the input exec.Vec.
-// See the analog, DecodeTableKey, in
+// See the analog, DecodeTableKey, in sqlbase/column_type_encoding.go.
 func decodeTableKeyToCol(
 	vec coldata.Vec, idx uint16, valType *types.T, key []byte, dir sqlbase.IndexDescriptor_Direction,
 ) ([]byte, error) {

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -434,3 +434,13 @@ query ITI
 SELECT * FROM system.namespace LIMIT 1
 ----
 0  defaultdb  50
+
+# Regression test for issue with fetching from unique indexes with embedded
+# nulls.
+statement ok
+CREATE TABLE t38753 (x INT PRIMARY KEY, y INT, UNIQUE INDEX (y)); INSERT INTO t38753 VALUES (0, NULL)
+
+query II
+SELECT * FROM t38753 ORDER BY y;
+----
+0  NULL

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -422,3 +422,15 @@ INSERT INTO t38626 VALUES (1, 'hello')
 
 statement ok
 EXPERIMENTAL SCRUB TABLE t38626
+
+# Regression test for issue with reading from system tables that have no
+# sentinel keys.
+query T
+SELECT "hashedPassword" FROM system.users LIMIT 1
+----
+·
+
+query ITI
+SELECT * FROM system.namespace LIMIT 1
+----
+0  defaultdb  50

--- a/pkg/sql/row/cfetcher.go
+++ b/pkg/sql/row/cfetcher.go
@@ -840,6 +840,7 @@ func (rf *CFetcher) processValue(
 				table.extraValColOrdinals,
 				table.extraTypes,
 				nil,
+				&rf.machine.remainingValueColsByIdx,
 				valueBytes,
 			)
 			if err != nil {


### PR DESCRIPTION
Fixes #38755.
Fixes #38611.
Fixes #38609.

Two bugfixes to the cfetcher.
- row: teach cfetcher about missing sentinel kvs
System tables are special in that they might be missing their "sentinel
kv": the kv that's marked as column family 0. Previously, cfetcher
assumed that a sentinel kv would always exist. This led to the inability
of decoding system tables correctly.
Now, if the table being read has more than one column family, we always
actively decode the column family id from the first key in a row to make
sure we know what values will be available in the kv.

- row: cfetcher bugfix to unique idxs w/ nulls
Previously, the cfetcher misbehaved when decoding unique secondary
indexes that had null values in one or more of their index columns. This
was because the encoding of the "extra columns" in a unique index (the
columns that are in the primary index but missing from the secondary) is
performed using the key encoding, not the value encoding, and the key
decoding routines in the cfetcher hadn't been taught to keep track of
which needed columns hadn't been seen in the current row yet.
This commit corrects the problem by teaching the key decoding routine to
optionally remove the decoded keys from the set of unseen column values
so far.

Release note: None