### PR TITLE
exec: Add memory estimation and monitoring for streaming operators.

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -28,6 +28,7 @@ import (
 	semtypes "github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -95,11 +96,9 @@ func wrapRowSource(
 // The operator and its output types are returned if there was no error.
 func newColOperator(
 	ctx context.Context, flowCtx *FlowCtx, spec *distsqlpb.ProcessorSpec, inputs []exec.Operator,
-) (exec.Operator, []types.T, error) {
+) (op exec.Operator, ct []types.T, memUsage int, err error) {
 	core := &spec.Core
 	post := &spec.Post
-	var err error
-	var op exec.Operator
 
 	// Planning additional operators for the PostProcessSpec (filters and render
 	// expressions) requires knowing the operator's output column types. Currently
@@ -111,16 +110,16 @@ func newColOperator(
 	switch {
 	case core.Noop != nil:
 		if err := checkNumIn(inputs, 1); err != nil {
-			return nil, nil, err
+			return nil, nil, memUsage, err
 		}
 		op = exec.NewNoop(inputs[0])
 		columnTypes = spec.Input[0].ColumnTypes
 	case core.TableReader != nil:
 		if err := checkNumIn(inputs, 0); err != nil {
-			return nil, nil, err
+			return nil, nil, memUsage, err
 		}
 		if core.TableReader.IsCheck {
-			return nil, nil, errors.Newf("scrub table reader is unsupported in vectorized")
+			return nil, nil, memUsage, errors.Newf("scrub table reader is unsupported in vectorized")
 		}
 		op, err = newColBatchScan(flowCtx, core.TableReader, post)
 		// We want to check for cancellation once per input batch, and wrapping
@@ -134,7 +133,7 @@ func newColOperator(
 		columnTypes = core.TableReader.Table.ColumnTypesWithMutations(returnMutations)
 	case core.Aggregator != nil:
 		if err := checkNumIn(inputs, 1); err != nil {
-			return nil, nil, err
+			return nil, nil, memUsage, err
 		}
 		aggSpec := core.Aggregator
 		if len(aggSpec.Aggregations) == 0 {
@@ -173,7 +172,7 @@ func newColOperator(
 			groupCols.Add(int(col))
 		}
 		if !orderedCols.SubsetOf(groupCols) {
-			return nil, nil, errors.AssertionFailedf("ordered cols must be a subset of grouping cols")
+			return nil, nil, memUsage, errors.AssertionFailedf("ordered cols must be a subset of grouping cols")
 		}
 
 		aggTyps := make([][]semtypes.T, len(aggSpec.Aggregations))
@@ -182,13 +181,13 @@ func newColOperator(
 		columnTypes = make([]semtypes.T, len(aggSpec.Aggregations))
 		for i, agg := range aggSpec.Aggregations {
 			if agg.Distinct {
-				return nil, nil, errors.Newf("distinct aggregation not supported")
+				return nil, nil, memUsage, errors.Newf("distinct aggregation not supported")
 			}
 			if agg.FilterColIdx != nil {
-				return nil, nil, errors.Newf("filtering aggregation not supported")
+				return nil, nil, memUsage, errors.Newf("filtering aggregation not supported")
 			}
 			if len(agg.Arguments) > 0 {
-				return nil, nil, errors.Newf("aggregates with arguments not supported")
+				return nil, nil, memUsage, errors.Newf("aggregates with arguments not supported")
 			}
 			aggTyps[i] = make([]semtypes.T, len(agg.ColIdx))
 			for j, colIdx := range agg.ColIdx {
@@ -203,12 +202,12 @@ func newColOperator(
 					// TODO(alfonso): plan ordinary SUM on integer types by casting to DECIMAL
 					// at the end, mod issues with overflow. Perhaps to avoid the overflow
 					// issues, at first, we could plan SUM for all types besides Int64.
-					return nil, nil, errors.Newf("sum on int cols not supported (use sum_int)")
+					return nil, nil, memUsage, errors.Newf("sum on int cols not supported (use sum_int)")
 				}
 			}
 			_, retType, err := GetAggregateInfo(agg.Func, aggTyps[i]...)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, memUsage, err
 			}
 			columnTypes[i] = *retType
 		}
@@ -224,7 +223,7 @@ func newColOperator(
 
 	case core.Distinct != nil:
 		if err := checkNumIn(inputs, 1); err != nil {
-			return nil, nil, err
+			return nil, nil, memUsage, err
 		}
 
 		var distinctCols, orderedCols util.FastIntSet
@@ -234,12 +233,12 @@ func newColOperator(
 		}
 		for _, col := range core.Distinct.DistinctColumns {
 			if !orderedCols.Contains(int(col)) {
-				return nil, nil, errors.Newf("unsorted distinct not supported")
+				return nil, nil, memUsage, errors.Newf("unsorted distinct not supported")
 			}
 			distinctCols.Add(int(col))
 		}
 		if !orderedCols.SubsetOf(distinctCols) {
-			return nil, nil, errors.AssertionFailedf("ordered cols must be a subset of distinct cols")
+			return nil, nil, memUsage, errors.AssertionFailedf("ordered cols must be a subset of distinct cols")
 		}
 
 		columnTypes = spec.Input[0].ColumnTypes
@@ -248,18 +247,18 @@ func newColOperator(
 
 	case core.Ordinality != nil:
 		if err := checkNumIn(inputs, 1); err != nil {
-			return nil, nil, err
+			return nil, nil, memUsage, err
 		}
 		columnTypes = append(spec.Input[0].ColumnTypes, *semtypes.Int)
 		op = exec.NewOrdinalityOp(inputs[0])
 
 	case core.HashJoiner != nil:
 		if err := checkNumIn(inputs, 2); err != nil {
-			return nil, nil, err
+			return nil, nil, memUsage, err
 		}
 
 		if !core.HashJoiner.OnExpr.Empty() {
-			return nil, nil, errors.Newf("can't plan hash join with on expressions")
+			return nil, nil, memUsage, errors.Newf("can't plan hash join with on expressions")
 		}
 
 		leftTypes := conv.FromColumnTypes(spec.Input[0].ColumnTypes)
@@ -309,15 +308,15 @@ func newColOperator(
 
 	case core.MergeJoiner != nil:
 		if err := checkNumIn(inputs, 2); err != nil {
-			return nil, nil, err
+			return nil, nil, memUsage, err
 		}
 
 		if !core.MergeJoiner.OnExpr.Empty() {
-			return nil, nil, errors.Newf("can't plan merge join with on expressions")
+			return nil, nil, memUsage, errors.Newf("can't plan merge join with on expressions")
 		}
 		if core.MergeJoiner.Type == sqlbase.JoinType_INTERSECT_ALL ||
 			core.MergeJoiner.Type == sqlbase.JoinType_EXCEPT_ALL {
-			return nil, nil, errors.AssertionFailedf("unexpectedly %s merge join was planned", core.MergeJoiner.Type.String())
+			return nil, nil, memUsage, errors.AssertionFailedf("unexpectedly %s merge join was planned", core.MergeJoiner.Type.String())
 		}
 
 		leftTypes := conv.FromColumnTypes(spec.Input[0].ColumnTypes)
@@ -374,7 +373,7 @@ func newColOperator(
 
 	case core.JoinReader != nil:
 		if err := checkNumIn(inputs, 1); err != nil {
-			return nil, nil, err
+			return nil, nil, memUsage, err
 		}
 
 		op, err = wrapRowSource(flowCtx, inputs[0], spec.Input[0].ColumnTypes, func(input RowSource) (RowSource, error) {
@@ -405,7 +404,7 @@ func newColOperator(
 
 	case core.Sorter != nil:
 		if err := checkNumIn(inputs, 1); err != nil {
-			return nil, nil, err
+			return nil, nil, memUsage, err
 		}
 		input := inputs[0]
 		inputTypes := conv.FromColumnTypes(spec.Input[0].ColumnTypes)
@@ -429,20 +428,20 @@ func newColOperator(
 
 	case core.Windower != nil:
 		if err := checkNumIn(inputs, 1); err != nil {
-			return nil, nil, err
+			return nil, nil, memUsage, err
 		}
 		if len(core.Windower.WindowFns) != 1 {
-			return nil, nil, errors.Newf("only a single window function is currently supported")
+			return nil, nil, memUsage, errors.Newf("only a single window function is currently supported")
 		}
 		wf := core.Windower.WindowFns[0]
 		if wf.Frame != nil &&
 			(wf.Frame.Mode != distsqlpb.WindowerSpec_Frame_RANGE ||
 				wf.Frame.Bounds.Start.BoundType != distsqlpb.WindowerSpec_Frame_UNBOUNDED_PRECEDING ||
 				(wf.Frame.Bounds.End != nil && wf.Frame.Bounds.End.BoundType != distsqlpb.WindowerSpec_Frame_CURRENT_ROW)) {
-			return nil, nil, errors.Newf("window functions with non-default window frames are not supported")
+			return nil, nil, memUsage, errors.Newf("window functions with non-default window frames are not supported")
 		}
 		if wf.Func.AggregateFunc != nil {
-			return nil, nil, errors.Newf("aggregate functions used as window functions are not supported")
+			return nil, nil, memUsage, errors.Newf("aggregate functions used as window functions are not supported")
 		}
 
 		input := inputs[0]
@@ -460,7 +459,7 @@ func newColOperator(
 			}
 		}
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, memUsage, err
 		}
 
 		orderingCols := make([]uint32, len(wf.Ordering.Columns))
@@ -475,7 +474,7 @@ func newColOperator(
 		case distsqlpb.WindowerSpec_DENSE_RANK:
 			op, err = vecbuiltins.NewRankOperator(input, typs, true /* dense */, orderingCols, int(wf.OutputColIdx)+tempPartitionColOffset, partitionColIdx)
 		default:
-			return nil, nil, errors.Newf("window function %s is not supported", wf.String())
+			return nil, nil, memUsage, errors.Newf("window function %s is not supported", wf.String())
 		}
 
 		if partitionColIdx != -1 {
@@ -492,30 +491,40 @@ func newColOperator(
 		columnTypes = append(spec.Input[0].ColumnTypes, *semtypes.Int)
 
 	default:
-		return nil, nil, errors.Newf("unsupported processor core %s", core)
+		return nil, nil, memUsage, errors.Newf("unsupported processor core %s", core)
 	}
+
+	// After constructing the base operator, calculate the memory usage
+	// of the operator.
+	if sMemOp, ok := op.(exec.StaticMemoryOperator); ok {
+		memUsage += sMemOp.EstimateStaticMemoryUsage()
+	}
+
 	log.VEventf(ctx, 1, "Made op %T\n", op)
 
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, memUsage, err
 	}
 
 	if columnTypes == nil {
-		return nil, nil, errors.AssertionFailedf("output columnTypes unset after planning %T", op)
+		return nil, nil, memUsage, errors.AssertionFailedf("output columnTypes unset after planning %T", op)
 	}
 
 	if !post.Filter.Empty() {
-		var helper exprHelper
+		var (
+			helper       exprHelper
+			selectionMem int
+		)
 		err := helper.init(post.Filter, columnTypes, flowCtx.EvalCtx)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, memUsage, err
 		}
 		var filterColumnTypes []semtypes.T
-		op, _, filterColumnTypes, err = planSelectionOperators(
-			flowCtx.NewEvalCtx(), helper.expr, columnTypes, op)
+		op, _, filterColumnTypes, selectionMem, err = planSelectionOperators(flowCtx.NewEvalCtx(), helper.expr, columnTypes, op)
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "unable to columnarize filter expression %q", post.Filter.Expr)
+			return nil, nil, memUsage, errors.Wrapf(err, "unable to columnarize filter expression %q", post.Filter.Expr)
 		}
+		memUsage += selectionMem
 		if len(filterColumnTypes) > len(columnTypes) {
 			// Additional columns were appended to store projection results while
 			// evaluating the filter. Project them away.
@@ -537,20 +546,23 @@ func newColOperator(
 	} else if post.RenderExprs != nil {
 		var renderedCols []uint32
 		for _, expr := range post.RenderExprs {
-			var helper exprHelper
+			var (
+				helper    exprHelper
+				renderMem int
+			)
 			err := helper.init(expr, columnTypes, flowCtx.EvalCtx)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, memUsage, err
 			}
 			var outputIdx int
-			op, outputIdx, columnTypes, err = planProjectionOperators(
-				flowCtx.NewEvalCtx(), helper.expr, columnTypes, op)
+			op, outputIdx, columnTypes, renderMem, err = planProjectionOperators(flowCtx.NewEvalCtx(), helper.expr, columnTypes, op)
 			if err != nil {
-				return nil, nil, errors.Wrapf(err, "unable to columnarize render expression %q", expr)
+				return nil, nil, memUsage, errors.Wrapf(err, "unable to columnarize render expression %q", expr)
 			}
 			if outputIdx < 0 {
-				return nil, nil, errors.AssertionFailedf("missing outputIdx")
+				return nil, nil, memUsage, errors.AssertionFailedf("missing outputIdx")
 			}
+			memUsage += renderMem
 			renderedCols = append(renderedCols, uint32(outputIdx))
 		}
 		op = exec.NewSimpleProjectOp(op, renderedCols)
@@ -561,29 +573,29 @@ func newColOperator(
 	if post.Limit != 0 {
 		op = exec.NewLimitOp(op, post.Limit)
 	}
-	return op, conv.FromColumnTypes(columnTypes), nil
+	return op, conv.FromColumnTypes(columnTypes), memUsage, nil
 }
 
 func planSelectionOperators(
 	ctx *tree.EvalContext, expr tree.TypedExpr, columnTypes []semtypes.T, input exec.Operator,
-) (op exec.Operator, resultIdx int, ct []semtypes.T, err error) {
+) (op exec.Operator, resultIdx int, ct []semtypes.T, memUsed int, err error) {
 	if err := assertHomogeneousTypes(expr); err != nil {
-		return op, resultIdx, ct, err
+		return op, resultIdx, ct, memUsed, err
 	}
 	switch t := expr.(type) {
 	case *tree.IndexedVar:
-		return exec.NewBoolVecToSelOp(input, t.Idx), -1, columnTypes, nil
+		return exec.NewBoolVecToSelOp(input, t.Idx), -1, columnTypes, memUsed, nil
 	case *tree.AndExpr:
-		leftOp, _, ct, err := planSelectionOperators(ctx, t.TypedLeft(), columnTypes, input)
+		leftOp, _, ct, memUsage, err := planSelectionOperators(ctx, t.TypedLeft(), columnTypes, input)
 		if err != nil {
-			return nil, resultIdx, ct, err
+			return nil, resultIdx, ct, memUsage, err
 		}
 		return planSelectionOperators(ctx, t.TypedRight(), ct, leftOp)
 	case *tree.ComparisonExpr:
 		cmpOp := t.Operator
-		leftOp, leftIdx, ct, err := planProjectionOperators(ctx, t.TypedLeft(), columnTypes, input)
+		leftOp, leftIdx, ct, memUsageLeft, err := planProjectionOperators(ctx, t.TypedLeft(), columnTypes, input)
 		if err != nil {
-			return nil, resultIdx, ct, err
+			return nil, resultIdx, ct, memUsageLeft, err
 		}
 		typ := &ct[leftIdx]
 		if constArg, ok := t.Right.(tree.Datum); ok {
@@ -591,29 +603,29 @@ func planSelectionOperators(
 				negate := t.Operator == tree.NotLike
 				op, err := exec.GetLikeOperator(
 					ctx, leftOp, leftIdx, string(tree.MustBeDString(constArg)), negate)
-				return op, resultIdx, ct, err
+				return op, resultIdx, ct, memUsageLeft, err
 			}
 			if t.Operator == tree.In || t.Operator == tree.NotIn {
 				negate := t.Operator == tree.NotIn
 				datumTuple, ok := tree.AsDTuple(constArg)
 				if !ok {
 					err = errors.Errorf("IN is only supported for constant expressions")
-					return nil, resultIdx, ct, err
+					return nil, resultIdx, ct, memUsed, err
 				}
 				op, err := exec.GetInOperator(typ, leftOp, leftIdx, datumTuple, negate)
-				return op, resultIdx, ct, err
+				return op, resultIdx, ct, memUsageLeft, err
 			}
 			op, err := exec.GetSelectionConstOperator(typ, cmpOp, leftOp, leftIdx, constArg)
-			return op, resultIdx, ct, err
+			return op, resultIdx, ct, memUsageLeft, err
 		}
-		rightOp, rightIdx, ct, err := planProjectionOperators(ctx, t.TypedRight(), ct, leftOp)
+		rightOp, rightIdx, ct, memUsageRight, err := planProjectionOperators(ctx, t.TypedRight(), ct, leftOp)
 		if err != nil {
-			return nil, resultIdx, ct, err
+			return nil, resultIdx, ct, memUsageLeft + memUsageRight, err
 		}
 		op, err := exec.GetSelectionOperator(typ, cmpOp, rightOp, leftIdx, rightIdx)
-		return op, resultIdx, ct, err
+		return op, resultIdx, ct, memUsageLeft + memUsageRight, err
 	default:
-		return nil, resultIdx, nil, errors.Errorf("unhandled selection expression type: %s", reflect.TypeOf(t))
+		return nil, resultIdx, nil, memUsed, errors.Errorf("unhandled selection expression type: %s", reflect.TypeOf(t))
 	}
 }
 
@@ -623,14 +635,14 @@ func planSelectionOperators(
 // resulting batches.
 func planProjectionOperators(
 	ctx *tree.EvalContext, expr tree.TypedExpr, columnTypes []semtypes.T, input exec.Operator,
-) (op exec.Operator, resultIdx int, ct []semtypes.T, err error) {
+) (op exec.Operator, resultIdx int, ct []semtypes.T, memUsed int, err error) {
 	if err := assertHomogeneousTypes(expr); err != nil {
-		return op, resultIdx, ct, err
+		return op, resultIdx, ct, memUsed, err
 	}
 	resultIdx = -1
 	switch t := expr.(type) {
 	case *tree.IndexedVar:
-		return input, t.Idx, columnTypes, nil
+		return input, t.Idx, columnTypes, memUsed, nil
 	case *tree.ComparisonExpr:
 		return planProjectionExpr(ctx, t.Operator, t.TypedLeft(), t.TypedRight(), columnTypes, input)
 	case *tree.BinaryExpr:
@@ -641,20 +653,20 @@ func planProjectionOperators(
 		resultIdx = len(ct)
 		ct = append(ct, *datumType)
 		if datumType.Family() == semtypes.UnknownFamily {
-			return exec.NewConstNullOp(input, resultIdx), resultIdx, ct, nil
+			return exec.NewConstNullOp(input, resultIdx), resultIdx, ct, memUsed, nil
 		}
 		typ := conv.FromColumnType(datumType)
 		constVal, err := conv.GetDatumToPhysicalFn(datumType)(t)
 		if err != nil {
-			return nil, resultIdx, ct, err
+			return nil, resultIdx, ct, memUsed, err
 		}
 		op, err := exec.NewConstOp(input, typ, constVal, resultIdx)
 		if err != nil {
-			return nil, resultIdx, ct, err
+			return nil, resultIdx, ct, memUsed, err
 		}
-		return op, resultIdx, ct, nil
+		return op, resultIdx, ct, memUsed, nil
 	default:
-		return nil, resultIdx, nil, errors.Errorf("unhandled projection expression type: %s", reflect.TypeOf(t))
+		return nil, resultIdx, nil, memUsed, errors.Errorf("unhandled projection expression type: %s", reflect.TypeOf(t))
 	}
 }
 
@@ -664,7 +676,7 @@ func planProjectionExpr(
 	left, right tree.TypedExpr,
 	columnTypes []semtypes.T,
 	input exec.Operator,
-) (op exec.Operator, resultIdx int, ct []semtypes.T, err error) {
+) (op exec.Operator, resultIdx int, ct []semtypes.T, memUsed int, err error) {
 	resultIdx = -1
 	// There are 3 cases. Either the left is constant, the right is constant,
 	// or neither are constant.
@@ -676,9 +688,9 @@ func planProjectionExpr(
 		// operators such as - and /, though, so we still need this case.
 		var rightOp exec.Operator
 		var rightIdx int
-		rightOp, rightIdx, ct, err = planProjectionOperators(ctx, right, columnTypes, input)
+		rightOp, rightIdx, ct, memUsed, err = planProjectionOperators(ctx, right, columnTypes, input)
 		if err != nil {
-			return nil, resultIdx, ct, err
+			return nil, resultIdx, ct, memUsed, err
 		}
 		resultIdx = len(ct)
 		typ := &ct[rightIdx]
@@ -686,11 +698,14 @@ func planProjectionExpr(
 		// to the input batch.
 		op, err = exec.GetProjectionLConstOperator(typ, binOp, rightOp, rightIdx, lConstArg, resultIdx)
 		ct = append(ct, *typ)
-		return op, resultIdx, ct, err
+		if sMem, ok := op.(exec.StaticMemoryOperator); ok {
+			memUsed += sMem.EstimateStaticMemoryUsage()
+		}
+		return op, resultIdx, ct, memUsed, err
 	}
-	leftOp, leftIdx, ct, err := planProjectionOperators(ctx, left, columnTypes, input)
+	leftOp, leftIdx, ct, leftMem, err := planProjectionOperators(ctx, left, columnTypes, input)
 	if err != nil {
-		return nil, resultIdx, ct, err
+		return nil, resultIdx, ct, leftMem, err
 	}
 	typ := &ct[leftIdx]
 	if rConstArg, rConst := right.(tree.Datum); rConst {
@@ -703,24 +718,30 @@ func planProjectionExpr(
 			datumTuple, ok := tree.AsDTuple(rConstArg)
 			if !ok {
 				err = errors.Errorf("IN operator supported only on constant expressions")
-				return nil, resultIdx, ct, err
+				return nil, resultIdx, ct, leftMem, err
 			}
 			op, err = exec.GetInProjectionOperator(typ, leftOp, leftIdx, resultIdx, datumTuple, negate)
 		} else {
 			op, err = exec.GetProjectionRConstOperator(typ, binOp, leftOp, leftIdx, rConstArg, resultIdx)
 		}
 		ct = append(ct, *typ)
-		return op, resultIdx, ct, err
+		if sMem, ok := op.(exec.StaticMemoryOperator); ok {
+			memUsed += sMem.EstimateStaticMemoryUsage()
+		}
+		return op, resultIdx, ct, leftMem + memUsed, err
 	}
 	// Case 3: neither are constant.
-	rightOp, rightIdx, ct, err := planProjectionOperators(ctx, right, ct, leftOp)
+	rightOp, rightIdx, ct, rightMem, err := planProjectionOperators(ctx, right, ct, leftOp)
 	if err != nil {
-		return nil, resultIdx, nil, err
+		return nil, resultIdx, nil, leftMem + rightMem, err
 	}
 	resultIdx = len(ct)
 	op, err = exec.GetProjectionOperator(typ, binOp, rightOp, leftIdx, rightIdx, resultIdx)
 	ct = append(ct, *typ)
-	return op, resultIdx, ct, err
+	if sMem, ok := op.(exec.StaticMemoryOperator); ok {
+		memUsed += sMem.EstimateStaticMemoryUsage()
+	}
+	return op, resultIdx, ct, leftMem + rightMem + memUsed, err
 }
 
 // assertHomogeneousTypes checks that the left and right sides of an expression
@@ -936,7 +957,8 @@ func (f *Flow) setupVectorizedInputSynchronizer(
 	input distsqlpb.InputSyncSpec,
 	streamIDToInputOp map[distsqlpb.StreamID]exec.Operator,
 	recordingStats bool,
-) (exec.Operator, []distsqlpb.MetadataSource, error) {
+) (exec.Operator, []distsqlpb.MetadataSource, int, error) {
+	var memUsed int
 	inputStreamOps := make([]exec.Operator, 0, len(input.Streams))
 	metaSources := make([]distsqlpb.MetadataSource, 0, len(input.Streams))
 	for _, inputStream := range input.Streams {
@@ -947,11 +969,11 @@ func (f *Flow) setupVectorizedInputSynchronizer(
 			// If the input is remote, the input operator does not exist in
 			// streamIDToInputOp. Create an inbox.
 			if err := f.checkInboundStreamID(inputStream.StreamID); err != nil {
-				return nil, nil, err
+				return nil, nil, memUsed, err
 			}
 			inbox, err := colrpc.NewInbox(conv.FromColumnTypes(input.ColumnTypes))
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, memUsed, err
 			}
 			f.inboundStreams[inputStream.StreamID] = &inboundStreamInfo{
 				receiver:  vectorizedInboundStreamHandler{inbox},
@@ -959,6 +981,7 @@ func (f *Flow) setupVectorizedInputSynchronizer(
 			}
 			metaSources = append(metaSources, inbox)
 			op := exec.Operator(inbox)
+			memUsed += op.(exec.StaticMemoryOperator).EstimateStaticMemoryUsage()
 			if recordingStats {
 				op, err = wrapWithVectorizedStatsCollector(
 					inbox,
@@ -971,12 +994,12 @@ func (f *Flow) setupVectorizedInputSynchronizer(
 					},
 				)
 				if err != nil {
-					return nil, nil, err
+					return nil, nil, memUsed, err
 				}
 			}
 			inputStreamOps = append(inputStreamOps, op)
 		default:
-			return nil, nil, errors.Errorf("unsupported input stream type %s", inputStream.Type)
+			return nil, nil, memUsed, errors.Errorf("unsupported input stream type %s", inputStream.Type)
 		}
 	}
 	op := inputStreamOps[0]
@@ -986,6 +1009,7 @@ func (f *Flow) setupVectorizedInputSynchronizer(
 			op = exec.NewOrderedSynchronizer(
 				inputStreamOps, conv.FromColumnTypes(input.ColumnTypes), distsqlpb.ConvertToColumnOrdering(input.Ordering),
 			)
+			memUsed += op.(exec.StaticMemoryOperator).EstimateStaticMemoryUsage()
 		} else {
 			op = exec.NewUnorderedSynchronizer(inputStreamOps, conv.FromColumnTypes(input.ColumnTypes), &f.waitGroup)
 			// Don't use the unordered synchronizer's inputs for stats collection
@@ -999,11 +1023,11 @@ func (f *Flow) setupVectorizedInputSynchronizer(
 			var err error
 			op, err = wrapWithVectorizedStatsCollector(op, statsInputs, &distsqlpb.ProcessorSpec{ProcessorID: -1})
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, memUsed, err
 			}
 		}
 	}
-	return op, metaSources, nil
+	return op, metaSources, memUsed, nil
 }
 
 // VectorizedSetupError is a wrapper for any error that happens during
@@ -1043,7 +1067,7 @@ func init() {
 	errors.RegisterWrapperDecoder(errors.GetTypeKey((*VectorizedSetupError)(nil)), decodeVectorizedSetupError)
 }
 
-func (f *Flow) setupVectorized(ctx context.Context) error {
+func (f *Flow) setupVectorized(ctx context.Context, acc *mon.BoundAccount) error {
 	streamIDToInputOp := make(map[distsqlpb.StreamID]exec.Operator)
 	streamIDToSpecIdx := make(map[distsqlpb.StreamID]int)
 	// queue is a queue of indices into f.spec.Processors, for topologically
@@ -1088,17 +1112,23 @@ func (f *Flow) setupVectorized(ctx context.Context) error {
 		}
 		inputs = inputs[:0]
 		for i := range pspec.Input {
-			synchronizer, metadataSources, err := f.setupVectorizedInputSynchronizer(pspec.Input[i], streamIDToInputOp, recordingStats)
+			synchronizer, metadataSources, memUsed, err := f.setupVectorizedInputSynchronizer(pspec.Input[i], streamIDToInputOp, recordingStats)
 			if err != nil {
 				return err
+			}
+			if err = acc.Grow(ctx, int64(memUsed)); err != nil {
+				return errors.Wrapf(err, "not enough memory to setup vectorized plan.")
 			}
 			metadataSourcesQueue = append(metadataSourcesQueue, metadataSources...)
 			inputs = append(inputs, synchronizer)
 		}
 
-		op, outputTypes, err := newColOperator(ctx, &f.FlowCtx, pspec, inputs)
+		op, outputTypes, memUsage, err := newColOperator(ctx, &f.FlowCtx, pspec, inputs)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "unable to vectorize execution plan.")
+		}
+		if err = acc.Grow(ctx, int64(memUsage)); err != nil {
+			return errors.Wrapf(err, "not enough memory to setup vectorized plan.")
 		}
 		if metaSource, ok := op.(distsqlpb.MetadataSource); ok {
 			metadataSourcesQueue = append(metadataSourcesQueue, metaSource)

--- a/pkg/sql/distsqlrun/columnar_utils_test.go
+++ b/pkg/sql/distsqlrun/columnar_utils_test.go
@@ -80,7 +80,7 @@ func verifyColOperator(
 		columnarizers[i] = c
 	}
 
-	colOp, _, err := newColOperator(ctx, flowCtx, pspec, columnarizers)
+	colOp, _, _, err := newColOperator(ctx, flowCtx, pspec, columnarizers)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/distsqlrun/columnarizer.go
+++ b/pkg/sql/distsqlrun/columnarizer.go
@@ -35,6 +35,7 @@ type columnarizer struct {
 }
 
 var _ exec.Operator = &columnarizer{}
+var _ exec.StaticMemoryOperator = &columnarizer{}
 
 // newColumnarizer returns a new columnarizer.
 func newColumnarizer(flowCtx *FlowCtx, processorID int32, input RowSource) (*columnarizer, error) {
@@ -54,7 +55,12 @@ func newColumnarizer(flowCtx *FlowCtx, processorID int32, input RowSource) (*col
 		return nil, err
 	}
 	c.Init()
+
 	return c, nil
+}
+
+func (c *columnarizer) EstimateStaticMemoryUsage() int {
+	return exec.EstimateBatchSizeBytes(conv.FromColumnTypes(c.OutputTypes()), coldata.BatchSize)
 }
 
 func (c *columnarizer) Init() {

--- a/pkg/sql/distsqlrun/flow_vectorize_space_test.go
+++ b/pkg/sql/distsqlrun/flow_vectorize_space_test.go
@@ -1,0 +1,143 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package distsqlrun
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+)
+
+func TestVectorizeSpaceError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+
+	flowCtx := &FlowCtx{
+		Settings: st,
+		EvalCtx:  &evalCtx,
+	}
+
+	// Without a limit, the default sorter creates a vectorized operater
+	// that we don't know memory usage of statically.
+	sorterCore := &distsqlpb.SorterSpec{
+		OutputOrdering: distsqlpb.Ordering{
+			Columns: []distsqlpb.Ordering_Column{
+				{
+					ColIdx:    0,
+					Direction: distsqlpb.Ordering_Column_ASC,
+				},
+			},
+		},
+	}
+
+	aggregatorCore := &distsqlpb.AggregatorSpec{
+		Type: distsqlpb.AggregatorSpec_SCALAR,
+		Aggregations: []distsqlpb.AggregatorSpec_Aggregation{
+			{
+				Func:   distsqlpb.AggregatorSpec_MAX,
+				ColIdx: []uint32{0},
+			},
+		},
+	}
+
+	input := []distsqlpb.InputSyncSpec{{
+		ColumnTypes: []types.T{*types.Int},
+	}}
+
+	testCases := []struct {
+		desc string
+		spec *distsqlpb.ProcessorSpec
+	}{
+		{
+			desc: "topk",
+			spec: &distsqlpb.ProcessorSpec{
+				Input: input,
+				Core: distsqlpb.ProcessorCoreUnion{
+					Sorter: sorterCore,
+				},
+				Post: distsqlpb.PostProcessSpec{
+					Limit: 5,
+				},
+			},
+		},
+		{
+			desc: "projection",
+			spec: &distsqlpb.ProcessorSpec{
+				Input: input,
+				Core: distsqlpb.ProcessorCoreUnion{
+					Sorter: sorterCore,
+				},
+				Post: distsqlpb.PostProcessSpec{
+					RenderExprs: []distsqlpb.Expression{{Expr: "@1 + 1"}},
+				},
+			},
+		},
+		{
+			desc: "in_projection",
+			spec: &distsqlpb.ProcessorSpec{
+				Input: input,
+				Core: distsqlpb.ProcessorCoreUnion{
+					Sorter: sorterCore,
+				},
+				Post: distsqlpb.PostProcessSpec{
+					RenderExprs: []distsqlpb.Expression{{Expr: "@1 IN (1, 2)"}},
+				},
+			},
+		},
+		{
+			desc: "aggregation",
+			spec: &distsqlpb.ProcessorSpec{
+				Input: input,
+				Core: distsqlpb.ProcessorCoreUnion{
+					Aggregator: aggregatorCore,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		for _, succ := range []bool{true, false} {
+			t.Run(fmt.Sprintf("%s-success-expected-%t", tc.desc, succ), func(t *testing.T) {
+				inputs := []exec.Operator{exec.NewZeroOp(nil)}
+				memMon := mon.MakeMonitor("MemoryMonitor", mon.MemoryResource, nil, nil, 0, math.MaxInt64, st)
+				if succ {
+					memMon.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+				} else {
+					memMon.Start(ctx, nil, mon.MakeStandaloneBudget(1))
+				}
+				acc := memMon.MakeBoundAccount()
+				_, _, memUsed, err := newColOperator(ctx, flowCtx, tc.spec, inputs)
+				if err != nil {
+					t.Fatal(err)
+				}
+				err = acc.Grow(ctx, int64(memUsed))
+				if succ && err != nil {
+					t.Fatal("Expected success, found:", err)
+				}
+				if !succ && err == nil {
+					t.Fatal("Expected memory error, found nothing.")
+				}
+			})
+		}
+	}
+}

--- a/pkg/sql/exec/aggregator.go
+++ b/pkg/sql/exec/aggregator.go
@@ -106,6 +106,7 @@ type orderedAggregator struct {
 }
 
 var _ Operator = &orderedAggregator{}
+var _ StaticMemoryOperator = &orderedAggregator{}
 
 // NewOrderedAggregator creates an ordered aggregator on the given grouping
 // columns. aggCols is a slice where each index represents a new aggregation
@@ -216,6 +217,10 @@ func makeAggregateFuncs(
 	}
 
 	return funcs, outTyps, nil
+}
+
+func (a *orderedAggregator) EstimateStaticMemoryUsage() int {
+	return EstimateBatchSizeBytes(a.outputTypes, coldata.BatchSize*2)
 }
 
 func (a *orderedAggregator) initWithBatchSize(inputSize, outputSize int) {

--- a/pkg/sql/exec/coalescer.go
+++ b/pkg/sql/exec/coalescer.go
@@ -28,6 +28,7 @@ type coalescerOp struct {
 }
 
 var _ Operator = &coalescerOp{}
+var _ StaticMemoryOperator = &coalescerOp{}
 
 // NewCoalescerOp creates a new coalescer operator on the given input operator
 // with the given column types.
@@ -36,6 +37,10 @@ func NewCoalescerOp(input Operator, colTypes []types.T) Operator {
 		input:      input,
 		inputTypes: colTypes,
 	}
+}
+
+func (p *coalescerOp) EstimateStaticMemoryUsage() int {
+	return 2 * EstimateBatchSizeBytes(p.inputTypes, coldata.BatchSize)
 }
 
 func (p *coalescerOp) Init() {

--- a/pkg/sql/exec/colrpc/inbox.go
+++ b/pkg/sql/exec/colrpc/inbox.go
@@ -84,6 +84,7 @@ type Inbox struct {
 }
 
 var _ exec.Operator = &Inbox{}
+var _ exec.StaticMemoryOperator = &Inbox{}
 
 // NewInbox creates a new Inbox.
 func NewInbox(typs []types.T) (*Inbox, error) {
@@ -110,6 +111,11 @@ func NewInbox(typs []types.T) (*Inbox, error) {
 	i.scratch.data = make([]*array.Data, len(typs))
 	i.scratch.b = coldata.NewMemBatch(typs)
 	return i, nil
+}
+
+// EstimateStaticMemoryUsage implements the StaticMemoryOperator interface.
+func (i *Inbox) EstimateStaticMemoryUsage() int {
+	return exec.EstimateBatchSizeBytes(i.typs, coldata.BatchSize)
 }
 
 // maybeInit calls Inbox.init if the inbox is not initialized and returns an

--- a/pkg/sql/exec/count.go
+++ b/pkg/sql/exec/count.go
@@ -30,6 +30,7 @@ type countOp struct {
 }
 
 var _ Operator = &countOp{}
+var _ StaticMemoryOperator = &countOp{}
 
 // NewCountOp returns a new count operator that counts the rows in its input.
 func NewCountOp(input Operator) Operator {
@@ -38,6 +39,10 @@ func NewCountOp(input Operator) Operator {
 	}
 	c.internalBatch = coldata.NewMemBatchWithSize([]types.T{types.Int64}, 1)
 	return c
+}
+
+func (c *countOp) EstimateStaticMemoryUsage() int {
+	return EstimateBatchSizeBytes([]types.T{types.Int64}, 1)
 }
 
 func (c *countOp) Init() {

--- a/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
@@ -51,6 +51,10 @@ type {{template "opRConstName" .}} struct {
 	outputIdx int
 }
 
+func (p {{template "opRConstName" .}}) EstimateStaticMemoryUsage() int {
+	return EstimateBatchSizeBytes([]types.T{types.{{.RetTyp}}}, coldata.BatchSize)
+}
+
 func (p {{template "opRConstName" .}}) Next(ctx context.Context) coldata.Batch {
 	batch := p.input.Next(ctx)
 	n := batch.Length()
@@ -95,6 +99,10 @@ type {{template "opLConstName" .}} struct {
 	outputIdx int
 }
 
+func (p {{template "opLConstName" .}}) EstimateStaticMemoryUsage() int {
+	return EstimateBatchSizeBytes([]types.T{types.{{.RetTyp}}}, coldata.BatchSize)
+}
+
 func (p {{template "opLConstName" .}}) Next(ctx context.Context) coldata.Batch {
 	batch := p.input.Next(ctx)
 	n := batch.Length()
@@ -137,6 +145,10 @@ type {{template "opName" .}} struct {
 	col2Idx int
 
 	outputIdx int
+}
+
+func (p {{template "opName" .}}) EstimateStaticMemoryUsage() int {
+	return EstimateBatchSizeBytes([]types.T{types.{{.RetTyp}}}, coldata.BatchSize)
 }
 
 func (p {{template "opName" .}}) Next(ctx context.Context) coldata.Batch {

--- a/pkg/sql/exec/mem_estimation.go
+++ b/pkg/sql/exec/mem_estimation.go
@@ -1,0 +1,68 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package exec
+
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+const (
+	sizeOfBool    = int(unsafe.Sizeof(true))
+	sizeOfInt8    = int(unsafe.Sizeof(int8(0)))
+	sizeOfInt16   = int(unsafe.Sizeof(int16(0)))
+	sizeOfInt32   = int(unsafe.Sizeof(int32(0)))
+	sizeOfInt64   = int(unsafe.Sizeof(int64(0)))
+	sizeOfFloat32 = int(unsafe.Sizeof(float32(0)))
+	sizeOfFloat64 = int(unsafe.Sizeof(float64(0)))
+)
+
+// EstimateBatchSizeBytes returns an estimated amount of bytes needed to
+// store a batch in memory that has column types vecTypes.
+// WARNING: This only is correct for fixed width types, and returns an
+// estimate for non fixed width types. In future it might be possible to
+// remove the need for estimation by specifying batch sizes in terms of bytes.
+func EstimateBatchSizeBytes(vecTypes []types.T, batchLength int) int {
+	// acc represents the number of bytes to represent a row in the batch.
+	acc := 0
+	for _, t := range vecTypes {
+		switch t {
+		case types.Bool:
+			acc += sizeOfBool
+		case types.Bytes:
+			// We don't know without looking at the data in a batch to see how
+			// much space each byte array takes up. Use some default value as a
+			// heuristic right now.
+			acc += 100
+		case types.Int8:
+			acc += sizeOfInt8
+		case types.Int16:
+			acc += sizeOfInt16
+		case types.Int32:
+			acc += sizeOfInt32
+		case types.Int64:
+			acc += sizeOfInt64
+		case types.Float32:
+			acc += sizeOfFloat32
+		case types.Float64:
+			acc += sizeOfFloat64
+		case types.Decimal:
+			// Similar to byte arrays, we can't tell how much space is used
+			// to hold the arbitrary precision decimal objects.
+			acc += 50
+		default:
+			panic(fmt.Sprintf("unhandled type %s", t))
+		}
+	}
+	return acc * batchLength
+}

--- a/pkg/sql/exec/operator.go
+++ b/pkg/sql/exec/operator.go
@@ -34,6 +34,14 @@ type Operator interface {
 	Next(context.Context) coldata.Batch
 }
 
+// StaticMemoryOperator is an interface that streaming operators can implement
+// if they are able to declare their memory usage upfront.
+type StaticMemoryOperator interface {
+	// EstimateStaticMemoryUsage estimates the memory usage (in bytes)
+	// of an operator.
+	EstimateStaticMemoryUsage() int
+}
+
 // resetter is an interface that operators can implement if they can be reset
 // either for reusing (to keep the already allocated memory) or during tests.
 type resetter interface {

--- a/pkg/sql/exec/orderedsynchronizer.go
+++ b/pkg/sql/exec/orderedsynchronizer.go
@@ -20,6 +20,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 )
 
+var _ StaticMemoryOperator = &OrderedSynchronizer{}
+
 // OrderedSynchronizer receives rows from multiple inputs and produces a single
 // stream of rows, ordered according to a set of columns. The rows in each input
 // stream are assumed to be ordered according to the same set of columns.
@@ -46,6 +48,11 @@ func NewOrderedSynchronizer(
 		ordering:    ordering,
 		columnTypes: typs,
 	}
+}
+
+// EstimateStaticMemoryUsage implements the StaticMemoryOperator interface.
+func (o *OrderedSynchronizer) EstimateStaticMemoryUsage() int {
+	return EstimateBatchSizeBytes(o.columnTypes, coldata.BatchSize)
 }
 
 // Next is part of the Operator interface.

--- a/pkg/sql/exec/select_in_tmpl.go
+++ b/pkg/sql/exec/select_in_tmpl.go
@@ -127,6 +127,12 @@ type projectInOp_TYPE struct {
 	negate    bool
 }
 
+var _ StaticMemoryOperator = &projectInOp_TYPE{}
+
+func (p *projectInOp_TYPE) EstimateStaticMemoryUsage() int {
+	return EstimateBatchSizeBytes([]types.T{types.Bool}, coldata.BatchSize)
+}
+
 func fillDatumRow_TYPE(ct *semtypes.T, datumTuple *tree.DTuple) ([]_GOTYPE, bool, error) {
 	conv := conv.GetDatumToPhysicalFn(ct)
 	var result []_GOTYPE

--- a/pkg/sql/exec/sorttopk.go
+++ b/pkg/sql/exec/sorttopk.go
@@ -39,6 +39,12 @@ func NewTopKSorter(
 	}
 }
 
+var _ StaticMemoryOperator = &topKSorter{}
+
+func (t *topKSorter) EstimateStaticMemoryUsage() int {
+	return EstimateBatchSizeBytes(t.inputTypes, int(t.k))
+}
+
 // topKSortState represents the state of the sort operator.
 type topKSortState int
 


### PR DESCRIPTION
We want to error out early of our vectorized execution if there is not enough memory available to run the query, especially if we can tell upfront that this is the case. Some streaming operators always use a static amount of memory, so we can monitor this memory during construction of the vectorized plan. Due to difficulties with traversing the vectorized flow once it is constructed, we monitor memory during construction of each operator, and have streaming operators estimate how much memory they will use during construction. This PR adds memory estimation to the following operators:

* CountOp
* Aggregate operators
* TopK sorter
* Columnarizer
* Coalescer
* OrderedSynchronizer
* Projection operators

Release note: None