### PR TITLE
build: update to go 1.12.7 in bootstrap-debian.sh

### DIFF
--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -38,9 +38,9 @@ echo '. ~/.bashrc_bootstrap' >> ~/.bashrc
 
 # Install Go.
 trap 'rm -f /tmp/go.tgz' EXIT
-curl https://dl.google.com/go/go1.11.6.linux-amd64.tar.gz > /tmp/go.tgz
+curl https://dl.google.com/go/go1.12.7.linux-amd64.tar.gz > /tmp/go.tgz
 sha256sum -c - <<EOF
-4e1864282d8d20010d6385a12a1e35641783a380a7c57907bfb46a5499c5eb49  /tmp/go.tgz
+66d83bfb5a9ede000e33c6579a91a29e6b101829ad41fffb5c5bb6c900e109d9  /tmp/go.tgz
 EOF
 sudo tar -C /usr/local -zxf /tmp/go.tgz
 


### PR DESCRIPTION
The minimum compiler version for building CRDB is now go 1.12, so when
creating a new worker, we need this version.

See #38379

Release note: None