### PR TITLE
exec: fallback to distsql on aggregator with no aggregate functions

### DIFF
--- a/pkg/sql/exec/operator.go
+++ b/pkg/sql/exec/operator.go
@@ -92,3 +92,33 @@ func (s *zeroOperator) Next(ctx context.Context) coldata.Batch {
 	next.SetLength(0)
 	return next
 }
+
+type singleTupleNoInputOperator struct {
+	batch  coldata.Batch
+	nexted bool
+}
+
+var _ Operator = &singleTupleNoInputOperator{}
+
+// NewSingleTupleNoInputOp creates a new Operator which returns a batch of
+// length 1 with no actual columns on the first call to Next() and zero-length
+// batches on all consecutive calls.
+func NewSingleTupleNoInputOp() Operator {
+	return &singleTupleNoInputOperator{
+		batch: coldata.NewMemBatchWithSize(nil, 1),
+	}
+}
+
+func (s *singleTupleNoInputOperator) Init() {
+}
+
+func (s *singleTupleNoInputOperator) Next(ctx context.Context) coldata.Batch {
+	s.batch.SetSelection(false)
+	if s.nexted {
+		s.batch.SetLength(0)
+		return s.batch
+	}
+	s.nexted = true
+	s.batch.SetLength(1)
+	return s.batch
+}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -473,3 +473,9 @@ SELECT * FROM t38908 WHERE x IN (1, 2)
 
 statement ok
 RESET experimental_vectorize
+
+# Test that an aggregate with no aggregate functions is handled correctly.
+query III
+SELECT 0, 1 + 2, 3 * 4 FROM a HAVING true
+----
+0 3 12


### PR DESCRIPTION
It is possible for an aggregator to be planned without aggregate
functions, for example, in the query like:
SELECT 1 FROM t HAVING true.
It is quite tricky to make this work through vectorize, so we
should just fall back to distsql. The difficulty arises from the
fact that we need to introduce an operator that produces a batch
and takes no input (like colBatchScan) but actually does no work
(like noop) except for emitting a single batch with non-zero length.

Release note: None