### PR TITLE
opt: add Index.PartitionByListPrefixes to catalog

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -1,4 +1,4 @@
-# LogicTest: local
+# LogicTest: local-opt
 
 statement error syntax
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST ()
@@ -399,6 +399,21 @@ ok1  CREATE TABLE ok1 (
    PARTITION p2 VALUES IN ((2))
 )
 
+query T
+EXPLAIN (OPT, CATALOG) SELECT * from ok1
+----
+TABLE ok1
+ ├── a int not null
+ ├── b int not null
+ ├── c int
+ └── INDEX primary
+      ├── a int not null
+      ├── b int not null
+      └── partition by list prefixes
+           ├── (1)
+           └── (2)
+scan ok1
+
 statement ok
 CREATE TABLE ok2 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN ((1)),
@@ -419,6 +434,21 @@ ok2  CREATE TABLE ok2 (
    PARTITION p2 VALUES IN ((2))
 )
 
+query T
+EXPLAIN (OPT, CATALOG) SELECT * from ok2
+----
+TABLE ok2
+ ├── a int not null
+ ├── b int not null
+ ├── c int
+ └── INDEX primary
+      ├── a int not null
+      ├── b int not null
+      └── partition by list prefixes
+           ├── (1)
+           └── (2)
+scan ok2
+
 statement ok
 CREATE TABLE ok3 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN (1),
@@ -438,6 +468,20 @@ ok3  CREATE TABLE ok3 (
    PARTITION p1 VALUES IN ((1)),
    PARTITION p2 VALUES IN ((DEFAULT))
 )
+
+query T
+EXPLAIN (OPT, CATALOG) SELECT * from ok3
+----
+TABLE ok3
+ ├── a int not null
+ ├── b int not null
+ ├── c int
+ └── INDEX primary
+      ├── a int not null
+      ├── b int not null
+      └── partition by list prefixes
+           └── (1)
+scan ok3
 
 statement ok
 CREATE TABLE ok4 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a, b) (
@@ -463,6 +507,22 @@ ok4  CREATE TABLE ok4 (
    PARTITION p4 VALUES IN ((DEFAULT, DEFAULT))
 )
 
+query T
+EXPLAIN (OPT, CATALOG) SELECT * from ok4
+----
+TABLE ok4
+ ├── a int not null
+ ├── b int not null
+ ├── c int
+ └── INDEX primary
+      ├── a int not null
+      ├── b int not null
+      └── partition by list prefixes
+           ├── (1, 1)
+           ├── (1)
+           └── (2, 3)
+scan ok4
+
 statement ok
 CREATE TABLE ok5 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN (1) PARTITION BY LIST (b) (
@@ -474,6 +534,21 @@ CREATE TABLE ok5 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a)
     ),
     PARTITION p3 VALUES IN (DEFAULT)
 )
+
+query T
+EXPLAIN (OPT, CATALOG) SELECT * from ok5
+----
+TABLE ok5
+ ├── a int not null
+ ├── b int not null
+ ├── c int
+ └── INDEX primary
+      ├── a int not null
+      ├── b int not null
+      └── partition by list prefixes
+           ├── (1)
+           └── (2)
+scan ok5
 
 query TT
 SHOW CREATE TABLE ok5
@@ -515,6 +590,18 @@ ok6  CREATE TABLE ok6 (
    PARTITION p2 VALUES FROM (1) TO (2)
 )
 
+query T
+EXPLAIN (OPT, CATALOG) SELECT * from ok6
+----
+TABLE ok6
+ ├── a int not null
+ ├── b int not null
+ ├── c int
+ └── INDEX primary
+      ├── a int not null
+      └── b int not null
+scan ok6
+
 statement ok
 CREATE TABLE ok7 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a) (
     PARTITION p1 VALUES FROM ((0)) TO (((1)))
@@ -532,6 +619,18 @@ ok7  CREATE TABLE ok7 (
 ) PARTITION BY RANGE (a) (
    PARTITION p1 VALUES FROM (0) TO (1)
 )
+
+query T
+EXPLAIN (OPT, CATALOG) SELECT * from ok7
+----
+TABLE ok7
+ ├── a int not null
+ ├── b int not null
+ ├── c int
+ └── INDEX primary
+      ├── a int not null
+      └── b int not null
+scan ok7
 
 statement ok
 CREATE TABLE ok8 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a) (
@@ -554,6 +653,18 @@ ok8  CREATE TABLE ok8 (
    PARTITION p2 VALUES FROM (1) TO (2),
    PARTITION p3 VALUES FROM (2) TO (MAXVALUE)
 )
+
+query T
+EXPLAIN (OPT, CATALOG) SELECT * from ok8
+----
+TABLE ok8
+ ├── a int not null
+ ├── b int not null
+ ├── c int
+ └── INDEX primary
+      ├── a int not null
+      └── b int not null
+scan ok8
 
 statement ok
 CREATE TABLE ok9 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a, b) (
@@ -578,6 +689,18 @@ ok9  CREATE TABLE ok9 (
    PARTITION p3 VALUES FROM (3, MINVALUE) TO (3, MAXVALUE),
    PARTITION p4 VALUES FROM (3, MAXVALUE) TO (MAXVALUE, MAXVALUE)
 )
+
+query T
+EXPLAIN (OPT, CATALOG) SELECT * from ok9
+----
+TABLE ok9
+ ├── a int not null
+ ├── b int not null
+ ├── c int
+ └── INDEX primary
+      ├── a int not null
+      └── b int not null
+scan ok9
 
 statement ok
 CREATE TABLE ok10 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a, b) (
@@ -604,6 +727,18 @@ ok10  CREATE TABLE ok10 (
    PARTITION p4 VALUES FROM (2, MAXVALUE) TO (3, 4),
    PARTITION p5 VALUES FROM (3, 4) TO (MAXVALUE, MAXVALUE)
 )
+
+query T
+EXPLAIN (OPT, CATALOG) SELECT * from ok10
+----
+TABLE ok10
+ ├── a int not null
+ ├── b int not null
+ ├── c int
+ └── INDEX primary
+      ├── a int not null
+      └── b int not null
+scan ok10
 
 statement ok
 CREATE TABLE ok11 (a INT, b INT, c INT, PRIMARY KEY (a, b, c)) PARTITION BY LIST (a) (
@@ -639,6 +774,22 @@ ok11  CREATE TABLE ok11 (
    )
 )
 
+query T
+EXPLAIN (OPT, CATALOG) SELECT * from ok11
+----
+TABLE ok11
+ ├── a int not null
+ ├── b int not null
+ ├── c int not null
+ └── INDEX primary
+      ├── a int not null
+      ├── b int not null
+      ├── c int not null
+      └── partition by list prefixes
+           ├── (1)
+           └── (6)
+scan ok11
+
 statement ok
 CREATE TABLE IF NOT EXISTS ok12 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION pu VALUES IN (NULL),
@@ -661,6 +812,22 @@ ok12  CREATE TABLE ok12 (
    PARTITION p1 VALUES IN ((1)),
    PARTITION p2 VALUES IN ((2))
 )
+
+query T
+EXPLAIN (OPT, CATALOG) SELECT * from ok12
+----
+TABLE ok12
+ ├── a int not null
+ ├── b int not null
+ ├── c int
+ └── INDEX primary
+      ├── a int not null
+      ├── b int not null
+      └── partition by list prefixes
+           ├── (NULL)
+           ├── (1)
+           └── (2)
+scan ok12
 
 # Verify that creating a partition that includes NULL does not change the
 # implicit NOT NULL contrainst of a primary key.

--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -30,6 +30,28 @@ scan  ·      ·
 ·     table  t@secondary
 ·     spans  /10-/11
 
+query T
+EXPLAIN (OPT, CATALOG) SELECT * FROM t
+----
+TABLE t
+ ├── k int not null
+ ├── v string
+ ├── INDEX primary
+ │    ├── k int not null
+ │    └── ZONE
+ │         └── constraints: [+region=test,+dc=dc2]
+ ├── INDEX secondary
+ │    ├── k int not null
+ │    ├── v string (storing)
+ │    └── ZONE
+ │         └── constraints: [+region=test,+dc=dc1]
+ └── INDEX tertiary
+      ├── k int not null
+      ├── v string (storing)
+      └── ZONE
+           └── constraints: [+region=test,+dc=dc2]
+scan t@secondary
+
 # ------------------------------------------------------------------------------
 # Move secondary to dc3 and put tertiary in dc1 and ensure that gateway matches
 # tertiary instead of secondary. Regression for #35546.
@@ -47,6 +69,28 @@ EXPLAIN SELECT * FROM t WHERE k=10
 scan  ·      ·
 ·     table  t@tertiary
 ·     spans  /10-/11
+
+query T
+EXPLAIN (OPT, CATALOG) SELECT * FROM t
+----
+TABLE t
+ ├── k int not null
+ ├── v string
+ ├── INDEX primary
+ │    ├── k int not null
+ │    └── ZONE
+ │         └── constraints: [+region=test,+dc=dc2]
+ ├── INDEX secondary
+ │    ├── k int not null
+ │    ├── v string (storing)
+ │    └── ZONE
+ │         └── constraints: [+region=test,+dc=dc3]
+ └── INDEX tertiary
+      ├── k int not null
+      ├── v string (storing)
+      └── ZONE
+           └── constraints: [+region=test,+dc=dc1]
+scan t@tertiary
 
 # ------------------------------------------------------------------------------
 # Swap secondary and tertiary localities and ensure invalidation occurs.
@@ -83,6 +127,28 @@ EXPLAIN SELECT * FROM t WHERE k=10
 scan  ·      ·
 ·     table  t@primary
 ·     spans  /10-/10/#
+
+query T
+EXPLAIN (OPT, CATALOG) SELECT * FROM t
+----
+TABLE t
+ ├── k int not null
+ ├── v string
+ ├── INDEX primary
+ │    ├── k int not null
+ │    └── ZONE
+ │         └── constraints: [+region=test,+dc=dc1]
+ ├── INDEX secondary
+ │    ├── k int not null
+ │    ├── v string (storing)
+ │    └── ZONE
+ │         └── constraints: [+region=test,+dc=dc2]
+ └── INDEX tertiary
+      ├── k int not null
+      ├── v string (storing)
+      └── ZONE
+           └── constraints: [+region=test,+dc=dc3]
+scan t
 
 # ------------------------------------------------------------------------------
 # Use PREPARE to make sure that the prepared plan is invalidated when the
@@ -155,6 +221,31 @@ scan  ·      ·
 ·     table  t@tertiary
 ·     spans  /10-/11
 
+query T
+EXPLAIN (OPT, CATALOG) SELECT * FROM t
+----
+TABLE t
+ ├── k int not null
+ ├── v string
+ ├── INDEX primary
+ │    ├── k int not null
+ │    └── ZONE
+ │         ├── constraints: [+region=test]
+ │         └── lease preference: [+region=test,+dc=dc2]
+ ├── INDEX secondary
+ │    ├── k int not null
+ │    ├── v string (storing)
+ │    └── ZONE
+ │         ├── constraints: [+region=test]
+ │         └── lease preference: [+region=test,+dc=dc3]
+ └── INDEX tertiary
+      ├── k int not null
+      ├── v string (storing)
+      └── ZONE
+           ├── constraints: [+region=test]
+           └── lease preference: [+region=test,+dc=dc1]
+scan t@tertiary
+
 # ------------------------------------------------------------------------------
 # Ensure that an index constrained to a region is preferred over an index that
 # merely has a lease preference in that region (since lease preferences can
@@ -179,6 +270,31 @@ EXPLAIN SELECT * FROM t WHERE k=10
 scan  ·      ·
 ·     table  t@secondary
 ·     spans  /10-/11
+
+query T
+EXPLAIN (OPT, CATALOG) SELECT * FROM t
+----
+TABLE t
+ ├── k int not null
+ ├── v string
+ ├── INDEX primary
+ │    ├── k int not null
+ │    └── ZONE
+ │         ├── constraints: [+region=test]
+ │         └── lease preference: [+region=test,+dc=dc1]
+ ├── INDEX secondary
+ │    ├── k int not null
+ │    ├── v string (storing)
+ │    └── ZONE
+ │         ├── constraints: [+region=test,+dc=dc1]
+ │         └── lease preference: [+region=test,+dc=dc3]
+ └── INDEX tertiary
+      ├── k int not null
+      ├── v string (storing)
+      └── ZONE
+           ├── constraints: [+region=test]
+           └── lease preference: [+region=test,+dc=dc1]
+scan t@secondary
 
 # ------------------------------------------------------------------------------
 # Use PREPARE to make sure that the prepared plan is invalidated when the
@@ -245,6 +361,31 @@ EXPLAIN SELECT * FROM t36642 WHERE k=10
 scan  ·      ·
 ·     table  t36642@tertiary
 ·     spans  /10-/11
+
+query T
+EXPLAIN (OPT, CATALOG) SELECT * FROM t
+----
+TABLE t
+ ├── k int not null
+ ├── v string
+ ├── INDEX primary
+ │    ├── k int not null
+ │    └── ZONE
+ │         ├── constraints: [+region=test]
+ │         └── lease preference: [+region=test,+dc=dc1]
+ ├── INDEX secondary
+ │    ├── k int not null
+ │    ├── v string (storing)
+ │    └── ZONE
+ │         ├── constraints: [+region=test]
+ │         └── lease preference: [+region=test,+dc=dc2]
+ └── INDEX tertiary
+      ├── k int not null
+      ├── v string (storing)
+      └── ZONE
+           ├── constraints: [+region=test]
+           └── lease preference: [+region=test,+dc=dc1]
+scan t
 
 
 # ------------------------------------------------------------------------------

--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -262,7 +262,7 @@ func (a *applyJoinNode) Next(params runParams) (bool, error) {
 		}
 
 		execFactory := makeExecFactory(params.p)
-		eb := execbuilder.New(&execFactory, factory.Memo(), newRightSide, params.EvalContext())
+		eb := execbuilder.New(&execFactory, factory.Memo(), nil /* catalog */, newRightSide, params.EvalContext())
 		eb.DisableTelemetry()
 		p, err := eb.Build()
 		if err != nil {

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -584,7 +584,8 @@ func (h *harness) runUsingAPI(tb testing.TB, bmType BenchmarkType, usePrepared b
 
 	root := execMemo.RootExpr()
 	execFactory := stubFactory{}
-	if _, err = execbuilder.New(&execFactory, execMemo, root, &h.evalCtx).Build(); err != nil {
+	eb := execbuilder.New(&execFactory, execMemo, nil /* catalog */, root, &h.evalCtx)
+	if _, err = eb.Build(); err != nil {
 		tb.Fatalf("%v", err)
 	}
 }

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -133,6 +133,9 @@ func FindTableColumnByName(tab Table, name tree.Name) int {
 // and testing.
 func FormatTable(cat Catalog, tab Table, tp treeprinter.Node) {
 	child := tp.Childf("TABLE %s", tab.Name().TableName)
+	if tab.IsVirtualTable() {
+		child.Child("virtual table")
+	}
 
 	var buf bytes.Buffer
 	for i := 0; i < tab.DeletableColumnCount(); i++ {
@@ -207,6 +210,14 @@ func formatCatalogIndex(tab Table, ord int, tp treeprinter.Node) {
 	}
 
 	FormatZone(idx.Zone(), child)
+
+	partPrefixes := idx.PartitionByListPrefixes()
+	if len(partPrefixes) != 0 {
+		c := child.Child("partition by list prefixes")
+		for i := range partPrefixes {
+			c.Child(partPrefixes[i].String())
+		}
+	}
 }
 
 // formatColPrefix returns a string representation of a list of columns. The

--- a/pkg/sql/opt/exec/execbuilder/format.go
+++ b/pkg/sql/opt/exec/execbuilder/format.go
@@ -49,7 +49,7 @@ func fmtInterceptor(f *memo.ExprFmtCtx, tp treeprinter.Node, nd opt.Expr) bool {
 	}
 
 	// Build the scalar expression and format it as a single tree node.
-	bld := New(nil /* factory */, f.Memo, nd, nil /* evalCtx */)
+	bld := New(nil /* factory */, f.Memo, nil /* catalog */, nd, nil /* evalCtx */)
 	md := f.Memo.Metadata()
 	ivh := tree.MakeIndexedVarHelper(nil /* container */, md.NumColumns())
 	expr, err := bld.BuildScalar(&ivh)

--- a/pkg/sql/opt/exec/execbuilder/testdata/catalog
+++ b/pkg/sql/opt/exec/execbuilder/testdata/catalog
@@ -1,0 +1,80 @@
+# LogicTest: local-opt
+
+statement ok
+CREATE TABLE xyz (
+  x INT PRIMARY KEY,
+  y INT,
+  z INT,
+  INDEX foo (z, y)
+)
+
+query T
+EXPLAIN (OPT, CATALOG) SELECT * from xyz
+----
+TABLE xyz
+ ├── x int not null
+ ├── y int
+ ├── z int
+ ├── INDEX primary
+ │    └── x int not null
+ └── INDEX foo
+      ├── z int
+      ├── y int
+      └── x int not null
+scan xyz
+
+statement ok
+CREATE TABLE abcdef (
+    a INT NOT NULL,
+    b INT,
+    c INT DEFAULT (10),
+    d INT AS (abcdef.b + c + 1) STORED,
+    e INT AS (a) STORED,
+    f INT CHECK (f > 2)
+)
+
+query T
+EXPLAIN (OPT, CATALOG) SELECT * from abcdef
+----
+TABLE abcdef
+ ├── a int not null
+ ├── b int
+ ├── c int default (10:::INT8)
+ ├── d int as ((b + c) + 1) stored
+ ├── e int as (a) stored
+ ├── f int
+ ├── rowid int not null default (unique_rowid()) [hidden]
+ ├── CHECK (f > 2)
+ └── INDEX primary
+      └── rowid int not null default (unique_rowid()) [hidden]
+scan abcdef
+
+statement ok
+CREATE TABLE uvwxy (
+    u INT,
+    v INT,
+    w INT,
+    x INT,
+    y INT,
+    PRIMARY KEY (u,v),
+    FAMILY (u,v,w),
+    FAMILY (x),
+    FAMILY (y)
+)
+
+query T
+EXPLAIN (OPT, CATALOG) SELECT * from uvwxy
+----
+TABLE uvwxy
+ ├── u int not null
+ ├── v int not null
+ ├── w int
+ ├── x int
+ ├── y int
+ ├── FAMILY fam_0_u_v_w (u, v, w)
+ ├── FAMILY fam_1_x (x)
+ ├── FAMILY fam_2_y (y)
+ └── INDEX primary
+      ├── u int not null
+      └── v int not null
+scan uvwxy

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -705,6 +705,63 @@ sort
            └── fd: ()-->(1)
 
 query T
+EXPLAIN (OPT,CATALOG) SELECT * FROM tc WHERE a = 10 ORDER BY b
+----
+TABLE tc
+ ├── a int
+ ├── b int
+ ├── rowid int not null default (unique_rowid()) [hidden]
+ ├── INDEX primary
+ │    └── rowid int not null default (unique_rowid()) [hidden]
+ └── INDEX c
+      ├── a int
+      └── rowid int not null default (unique_rowid()) [hidden]
+sort
+ └── index-join tc
+      └── scan tc@c
+           └── constraint: /1/3: [/10 - /10]
+
+query T
+EXPLAIN (OPT,VERBOSE,CATALOG) SELECT * FROM tc JOIN t ON k=a
+----
+TABLE tc
+ ├── a int
+ ├── b int
+ ├── rowid int not null default (unique_rowid()) [hidden]
+ ├── INDEX primary
+ │    └── rowid int not null default (unique_rowid()) [hidden]
+ └── INDEX c
+      ├── a int
+      └── rowid int not null default (unique_rowid()) [hidden]
+TABLE t
+ ├── k int not null
+ ├── v int
+ └── INDEX primary
+      └── k int not null
+inner-join (hash)
+ ├── columns: a:1 b:2 k:4 v:5
+ ├── stats: [rows=1000, distinct(1)=100, null(1)=0, distinct(4)=100, null(4)=0]
+ ├── cost: 2220.05
+ ├── fd: (4)-->(5), (1)==(4), (4)==(1)
+ ├── prune: (2,5)
+ ├── scan tc
+ │    ├── columns: a:1 b:2
+ │    ├── stats: [rows=1000, distinct(1)=100, null(1)=10]
+ │    ├── cost: 1100.02
+ │    ├── prune: (1,2)
+ │    └── interesting orderings: (+1)
+ ├── scan t
+ │    ├── columns: k:4 v:5
+ │    ├── stats: [rows=1000, distinct(4)=1000, null(4)=0]
+ │    ├── cost: 1080.02
+ │    ├── key: (4)
+ │    ├── fd: (4)-->(5)
+ │    ├── prune: (4,5)
+ │    └── interesting orderings: (+4)
+ └── filters
+      └── k = a [outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
+
+query T
 EXPLAIN (OPT) SELECT * FROM tc WHERE a + 2 * b > 1 ORDER BY a*b
 ----
 sort

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -161,7 +161,7 @@ func TestIndexConstraints(t *testing.T) {
 				}
 				remainingFilter := ic.RemainingFilters()
 				if !remainingFilter.IsTrue() {
-					execBld := execbuilder.New(nil /* execFactory */, f.Memo(), &remainingFilter, &evalCtx)
+					execBld := execbuilder.New(nil /* execFactory */, f.Memo(), nil /* catalog */, &remainingFilter, &evalCtx)
 					expr, err := execBld.BuildScalar(&iVarHelper)
 					if err != nil {
 						return fmt.Sprintf("error: %v\n", err)

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -690,6 +690,10 @@ type Index struct {
 
 	// table is a back reference to the table this index is on.
 	table *Table
+
+	// partitionBy is the partitioning clause that corresponds to this index. Used
+	// to implement PartitionByListPrefixes.
+	partitionBy *tree.PartitionBy
 }
 
 // ID is part of the cat.Index interface.
@@ -750,6 +754,66 @@ func (ti *Index) Zone() cat.Zone {
 // Span is part of the cat.Index interface.
 func (ti *Index) Span() roachpb.Span {
 	panic("not implemented")
+}
+
+// PartitionByListPrefixes is part of the cat.Index interface.
+func (ti *Index) PartitionByListPrefixes() []tree.Datums {
+	p := ti.partitionBy
+	if p == nil {
+		return nil
+	}
+	if len(p.List) == 0 {
+		return nil
+	}
+	var res []tree.Datums
+	semaCtx := tree.MakeSemaContext()
+	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	for i := range p.Fields {
+		if i >= len(ti.Columns) || p.Fields[i] != ti.Columns[i].ColName() {
+			panic("partition by columns must be a prefix of the index columns")
+		}
+	}
+	for i := range p.List {
+		// Exprs contains a list of values.
+		for _, e := range p.List[i].Exprs {
+			var vals []tree.Expr
+			switch t := e.(type) {
+			case *tree.Tuple:
+				vals = t.Exprs
+			default:
+				vals = []tree.Expr{e}
+			}
+
+			// Cut off at DEFAULT, if present.
+			for i := range vals {
+				if _, ok := vals[i].(tree.DefaultVal); ok {
+					vals = vals[:i]
+				}
+			}
+			if len(vals) == 0 {
+				continue
+			}
+			d := make(tree.Datums, len(vals))
+			for i := range vals {
+				c := tree.CastExpr{Expr: vals[i], Type: ti.Columns[i].DatumType()}
+				cTyped, err := c.TypeCheck(&semaCtx, nil)
+				if err != nil {
+					panic(err)
+				}
+				d[i], err = cTyped.Eval(&evalCtx)
+				if err != nil {
+					panic(err)
+				}
+			}
+
+			// TODO(radu): split into multiple prefixes if Subpartition is also by list.
+			// Note that this functionality should be kept in sync with the real catalog
+			// implementation (opt_catalog.go).
+
+			res = append(res, d)
+		}
+	}
+	return res
 }
 
 // Column implements the cat.Column interface for testing purposes.

--- a/pkg/sql/opt/testutils/testcat/testdata/table
+++ b/pkg/sql/opt/testutils/testcat/testdata/table
@@ -86,3 +86,79 @@ TABLE a
  └── INDEX a_a_key
       ├── a int
       └── rowid int not null default (unique_rowid()) [hidden] (storing)
+
+exec-ddl
+CREATE TABLE system.vtable (a INT, b INT)
+----
+
+exec-ddl
+SHOW CREATE system.vtable
+----
+TABLE vtable
+ ├── virtual table
+ ├── a int
+ └── b int
+
+exec-ddl
+CREATE TABLE part1 (a INT PRIMARY KEY, b INT) PARTITION BY LIST (a) (
+  PARTITION p1 VALUES IN (1),
+  PARTITION p2 VALUES IN (3, 4, 5),
+  PARTITION p3 VALUES IN (DEFAULT)
+)
+----
+
+exec-ddl
+SHOW CREATE part1
+----
+TABLE part1
+ ├── a int not null
+ ├── b int
+ └── INDEX primary
+      ├── a int not null
+      └── partition by list prefixes
+           ├── (1)
+           ├── (3)
+           ├── (4)
+           └── (5)
+
+exec-ddl
+CREATE TABLE part2 (
+  a STRING,
+  b STRING,
+  c INT,
+  PRIMARY KEY(a,b,c),
+  INDEX (c) PARTITION BY LIST (c) (
+    PARTITION pi1 VALUES IN (1),
+    PARTITION pi2 VALUES IN (3, 4)
+  )
+) PARTITION BY LIST (a, b) (
+  PARTITION p1 VALUES IN (('foo', 'bar'), ('foo', 'baz'), ('qux', 'qux')),
+  PARTITION p2 VALUES IN (('waldo', DEFAULT)),
+  PARTITION p3 VALUES IN (DEFAULT)
+)
+----
+
+exec-ddl
+SHOW CREATE part2
+----
+TABLE part2
+ ├── a string not null
+ ├── b string not null
+ ├── c int not null
+ ├── INDEX primary
+ │    ├── a string not null
+ │    ├── b string not null
+ │    ├── c int not null
+ │    └── partition by list prefixes
+ │         ├── ('foo', 'bar')
+ │         ├── ('foo', 'baz')
+ │         ├── ('qux', 'qux')
+ │         └── ('waldo')
+ └── INDEX secondary
+      ├── c int not null
+      ├── a string not null
+      ├── b string not null
+      └── partition by list prefixes
+           ├── (1)
+           ├── (3)
+           └── (4)

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -249,7 +249,7 @@ func (p *planner) selectIndex(
 		if rem.IsTrue() {
 			s.filter = nil
 		} else {
-			execBld := execbuilder.New(nil /* execFactory */, optimizer.Memo(), &rem, nil /* evalCtx */)
+			execBld := execbuilder.New(nil /* execFactory */, optimizer.Memo(), nil /* catalog */, &rem, nil /* evalCtx */)
 			s.filter, err = execBld.BuildScalar(&s.filterVars)
 			if err != nil {
 				return nil, err

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -149,7 +149,7 @@ func (p *planner) makeOptimizerPlan(ctx context.Context) (_ *planTop, isCorrelat
 	// Build the plan tree.
 	root := execMemo.RootExpr()
 	execFactory := makeExecFactory(p)
-	plan, err := execbuilder.New(&execFactory, execMemo, root, p.EvalContext()).Build()
+	plan, err := execbuilder.New(&execFactory, execMemo, &opc.catalog, root, p.EvalContext()).Build()
 	if err != nil {
 		return nil, isCorrelated, err
 	}

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -156,9 +156,11 @@ type TableDef interface {
 	SetName(name Name)
 }
 
-func (*ColumnTableDef) tableDef() {}
-func (*IndexTableDef) tableDef()  {}
-func (*FamilyTableDef) tableDef() {}
+func (*ColumnTableDef) tableDef()               {}
+func (*IndexTableDef) tableDef()                {}
+func (*FamilyTableDef) tableDef()               {}
+func (*ForeignKeyConstraintTableDef) tableDef() {}
+func (*CheckConstraintTableDef) tableDef()      {}
 
 // TableDefs represents a list of table definitions.
 type TableDefs []TableDef
@@ -569,7 +571,9 @@ type ConstraintTableDef interface {
 	constraintTableDef()
 }
 
-func (*UniqueConstraintTableDef) constraintTableDef() {}
+func (*UniqueConstraintTableDef) constraintTableDef()     {}
+func (*ForeignKeyConstraintTableDef) constraintTableDef() {}
+func (*CheckConstraintTableDef) constraintTableDef()      {}
 
 // UniqueConstraintTableDef represents a unique constraint within a CREATE
 // TABLE statement.
@@ -714,12 +718,6 @@ func (node *ForeignKeyConstraintTableDef) Format(ctx *FmtCtx) {
 func (node *ForeignKeyConstraintTableDef) SetName(name Name) {
 	node.Name = name
 }
-
-func (*ForeignKeyConstraintTableDef) tableDef()           {}
-func (*ForeignKeyConstraintTableDef) constraintTableDef() {}
-
-func (*CheckConstraintTableDef) tableDef()           {}
-func (*CheckConstraintTableDef) constraintTableDef() {}
 
 // CheckConstraintTableDef represents a check constraint within a CREATE
 // TABLE statement.

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -85,7 +85,7 @@ func optBuildScalar(evalCtx *tree.EvalContext, e tree.TypedExpr) (tree.TypedExpr
 		return nil, err
 	}
 
-	bld := execbuilder.New(nil /* factory */, o.Memo(), o.Memo().RootExpr(), evalCtx)
+	bld := execbuilder.New(nil /* factory */, o.Memo(), nil /* catalog */, o.Memo().RootExpr(), evalCtx)
 	ivh := tree.MakeIndexedVarHelper(nil /* container */, 0)
 
 	expr, err := bld.BuildScalar(&ivh)

--- a/pkg/sql/sem/tree/explain.go
+++ b/pkg/sql/sem/tree/explain.go
@@ -112,6 +112,7 @@ const (
 	ExplainFlagNoOptimize
 	ExplainFlagAnalyze
 	ExplainFlagEnv
+	ExplainFlagCatalog
 )
 
 var explainFlagStrings = map[string]int{
@@ -123,6 +124,7 @@ var explainFlagStrings = map[string]int{
 	"nooptimize":  ExplainFlagNoOptimize,
 	"analyze":     ExplainFlagAnalyze,
 	"env":         ExplainFlagEnv,
+	"catalog":     ExplainFlagCatalog,
 }
 
 // ParseOptions parses the options for an EXPLAIN statement.


### PR DESCRIPTION
#### opt: add EXPLAIN (OPT, CATALOG)

Adding a `CATALOG` flag to `EXPLAIN (OPT)` which also formats all the
cat.Table objects. This is useful for testing the opt_catalog
implementation.

Release note: None

#### opt: add Index.PartitionByListPrefixes to catalog

Add a catalog function that returns index regions of interest based on
PARTITION BY LIST values. This information will be used for an "index
skip scan".

Informs #38031.

Release note: None
