### PR TITLE
exec: bail out on mixed type expressions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -400,3 +400,15 @@ query O
 SELECT * FROM t38754
 ----
 1
+
+# Test integer division. (Should fall back due to decimal result.)
+query T
+SELECT a/b FROM a WHERE b = 2
+----
+0.5
+
+# Test mixed types comparison. (Should also fall back.)
+query I
+SELECT b FROM a WHERE b < 0.5
+----
+0


### PR DESCRIPTION
Since our vectorized projection and selection operators currently only
handle homogeneous types, I added logic to the planner which detects
mixed types and errors out.

Fixes #38798

Release note: None