### PR TITLE
release-19.1: sql: don't allow failure to update job to fail schema change

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -383,7 +383,7 @@ func (sc *SchemaChanger) DropTableDesc(
 					b.DelRange(dbZoneKeyPrefix, dbZoneKeyPrefix.PrefixEnd(), false /* returnKeys */)
 					return nil
 				}); err != nil {
-				return errors.Wrapf(err, "failed to update job %d", tableDesc.GetDropJobID())
+				log.Warningf(ctx, "failed to update job %d: %+v", tableDesc.GetDropJobID(), err)
 			}
 		}
 		return txn.Run(ctx, b)


### PR DESCRIPTION
Backport 1/1 commits from #38617.

/cc @cockroachdb/release

---

In some cases a previous job seems to have suceeded but the schema change has not been marked completed.
In these cases the subsequent attempts to complete the job fail, which leaves the schema change in a loop.

Release note (sql change): ignore non-fatal errors updating jobs during drop table.
