### PR TITLE
release-2.0: ui: ignore engine check when adding jsdoc dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,7 +325,7 @@ $(YARN_INSTALLED_TARGET): $(UI_ROOT)/package.json $(UI_ROOT)/yarn.lock
 	# Additionally pin a known-good version of jsdoc.
 	# See: https://github.com/dcodeIO/protobuf.js/issues/716.
 	cp $(UI_ROOT)/node_modules/protobufjs/cli/{package.standalone.json,package.json}
-	$(NODE_RUN) -C $(UI_ROOT)/node_modules/protobufjs/cli yarn add jsdoc@3.4.3
+	$(NODE_RUN) -C $(UI_ROOT)/node_modules/protobufjs/cli yarn add --ignore-engines jsdoc@3.4.3
 	$(NODE_RUN) -C $(UI_ROOT)/node_modules/protobufjs/cli yarn install
 	@# We remove this broken dependency again in pkg/ui/webpack.config.js.
 	@# See the comment there for details.


### PR DESCRIPTION
`build/builder.sh make build TYPE=release-linux-gnu` was failing with the error:

```
2019-07-10T16:59:30.231-0700 error catharsis@0.8.10: The engine "node" is incompatible with this module. Expected version ">= 8".
2019-07-10T16:59:30.235-0700 error An unexpected error occurred: "Found incompatible module".
2019-07-10T16:59:30.236-0700 info If you think this is a bug, please open a bug report with the information provided in "/go/src/github.com/cockroachdb/cockroach/pkg/ui/node_modules/protobufjs/cli/yarn-error.log".
2019-07-10T16:59:30.236-0700 info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
2019-07-10T16:59:30.250-0700 Makefile:322: recipe for target 'pkg/ui/yarn.installed' failed
2019-07-10T16:59:30.250-0700 make: *** [pkg/ui/yarn.installed] Error 1
2019-07-10T16:59:30.250-0700 make: *** Waiting for unfinished jobs....```
```

This appears to be due to https://github.com/hegemonic/catharsis/commit/698ad6760a07a5578b0ea2fc205913bf84a34a44#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R23.

@vilterp I'm not very familiar with yarn. Could you double check that this is the correct fix?

Release note: None