### PR TITLE
opt: remove AddSchemaDependency

### DIFF
--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -80,13 +80,13 @@ type Metadata struct {
 	// values is the highest id for a Values clause that has been assigned.
 	values ValuesID
 
-	// deps stores information about all catalog objects depended on by the query,
-	// as well as the privileges required to access those objects. The objects are
+	// deps stores information about all data source objects depended on by the
+	// query, as well as the privileges required to access them. The objects are
 	// deduplicated: any name/object pair shows up at most once.
-	// Note: the same object can appear multiple times if different names were
-	// used. For example, in the query `SELECT * from t, db.t` the two tables
-	// might resolve to the same object now but to different objects later; we
-	// want to verify the resolution of both names.
+	// Note: the same data source object can appear multiple times if different
+	// names were used. For example, in the query `SELECT * from t, db.t` the two
+	// tables might resolve to the same object now but to different objects later;
+	// we want to verify the resolution of both names.
 	deps []mdDep
 
 	// views stores the list of referenced views. This information is only
@@ -97,23 +97,14 @@ type Metadata struct {
 }
 
 type mdDep struct {
-	object cat.Object
+	ds cat.DataSource
 
 	// name is the unresolved name from the query that was used to resolve the
-	// object. It stores either a cat.DataSourceName, or cat.SchemaName in its
-	// TablePrefix portion, depending on the type of the object.
-	name tree.TableName
+	// object.
+	name cat.DataSourceName
 
 	// privileges is the union of all required privileges.
 	privileges privilegeBitmap
-}
-
-func (d *mdDep) dsName() *cat.DataSourceName {
-	return &d.name
-}
-
-func (d *mdDep) schemaName() *cat.SchemaName {
-	return &d.name.TableNamePrefix
 }
 
 // Init prepares the metadata for use (or reuse).
@@ -161,51 +152,33 @@ func (md *Metadata) CopyFrom(from *Metadata) {
 	md.deps = append(md.deps, from.deps...)
 }
 
-// AddDataSourceDependency tracks one of the catalog data sources on which the
-// query depends, as well as the privilege required to access that data source.
-// If the Memo using this metadata is cached, then a call to CheckDependencies
-// can detect if the name resolves to a different data source now, or if changes
-// to schema or permissions on the data source has invalidated the cached metadata.
-func (md *Metadata) AddDataSourceDependency(
+// AddDependency tracks one of the catalog data sources on which the query
+// depends, as well as the privilege required to access that data source. If
+// the Memo using this metadata is cached, then a call to CheckDependencies can
+// detect if the name resolves to a different data source now, or if changes to
+// schema or permissions on the data source has invalidated the cached metadata.
+func (md *Metadata) AddDependency(
 	name *cat.DataSourceName, ds cat.DataSource, priv privilege.Kind,
 ) {
 	// Search for the same name / object pair.
 	for i := range md.deps {
-		if md.deps[i].object == ds && md.deps[i].dsName().Equals(name) {
+		if md.deps[i].ds == ds && md.deps[i].name.Equals(name) {
 			md.deps[i].privileges |= (1 << priv)
 			return
 		}
 	}
 	md.deps = append(md.deps, mdDep{
-		object:     ds,
+		ds:         ds,
 		name:       *name,
 		privileges: (1 << priv),
 	})
 }
 
-// AddSchemaDependency tracks one of the catalog schemas on which the query depends,
-// as well as the privilege required to access that schema. If the Memo using
-// this metadata is cached, then a call to CheckDependencies can detect if
-// the name resolves to a different schema, or if the permissions on the schema
-// are no longer sufficient.
-func (md *Metadata) AddSchemaDependency(name *cat.SchemaName, s cat.Schema, priv privilege.Kind) {
-	// Search for the same name / object pair.
-	for i := range md.deps {
-		if md.deps[i].object == s && md.deps[i].schemaName().Equals(name) {
-			md.deps[i].privileges |= (1 << priv)
-			return
-		}
-	}
-	d := mdDep{object: s, privileges: (1 << priv)}
-	d.name.TableNamePrefix = *name
-	md.deps = append(md.deps, d)
-}
-
-// CheckDependencies resolves each data source and schema on which this metadata
-// depends, in order to check that the fully qualified object names still
-// resolve to the same version of the same objects, and that the user still has
-// sufficient privileges to access the objects. If the dependencies are no
-// longer up-to-date, then CheckDependencies returns false.
+// CheckDependencies resolves (again) each data source on which this metadata
+// depends, in order to check that all data source names resolve to the same
+// objects, and that the user still has sufficient privileges to access the
+// objects. If the dependencies are no longer up-to-date, then CheckDependencies
+// returns false.
 //
 // This function cannot swallow errors and return only a boolean, as it may
 // perform KV operations on behalf of the transaction associated with the
@@ -214,34 +187,16 @@ func (md *Metadata) CheckDependencies(
 	ctx context.Context, catalog cat.Catalog,
 ) (upToDate bool, err error) {
 	for i := range md.deps {
-		obj := md.deps[i].object
-		var toCheck cat.Object
-		switch obj.(type) {
-		case cat.DataSource:
-			name := *md.deps[i].dsName()
-			// Resolve data source object.
-			new, _, err := catalog.ResolveDataSource(ctx, cat.Flags{}, &name)
-			if err != nil {
-				return false, err
-			}
-			toCheck = new
-
-		case cat.Schema:
-			name := *md.deps[i].schemaName()
-			// Resolve schema object.
-			new, _, err := catalog.ResolveSchema(ctx, cat.Flags{}, &name)
-			if err != nil {
-				return false, err
-			}
-			toCheck = new
-
-		default:
-			return false, errors.AssertionFailedf("unknown dependency type: %v", obj)
+		name := md.deps[i].name
+		// Resolve data source object.
+		toCheck, _, err := catalog.ResolveDataSource(ctx, cat.Flags{}, &name)
+		if err != nil {
+			return false, err
 		}
 
 		// Ensure that it's the same object, and there were no schema or table
 		// statistics changes.
-		if !toCheck.Equals(obj) {
+		if !toCheck.Equals(md.deps[i].ds) {
 			return false, nil
 		}
 

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -44,7 +44,7 @@ func TestMetadata(t *testing.T) {
 		t.Fatalf("unexpected table id")
 	}
 
-	md.AddDataSourceDependency(tab.Name(), tab, privilege.CREATE)
+	md.AddDependency(tab.Name(), tab, privilege.CREATE)
 	depsUpToDate, err := md.CheckDependencies(context.TODO(), testCat)
 	if err == nil || depsUpToDate {
 		t.Fatalf("expected table privilege to be revoked")

--- a/pkg/sql/opt/optbuilder/create_table.go
+++ b/pkg/sql/opt/optbuilder/create_table.go
@@ -25,6 +25,7 @@ import (
 // buildCreateTable constructs a CreateTable operator based on the CREATE TABLE
 // statement.
 func (b *Builder) buildCreateTable(ct *tree.CreateTable, inScope *scope) (outScope *scope) {
+	b.DisableMemoReuse = true
 	sch, resName := b.resolveSchemaForCreate(&ct.Table)
 	// TODO(radu): we are modifying the AST in-place here. We should be storing
 	// the resolved name separately.

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -438,9 +438,6 @@ func (b *Builder) resolveSchemaForCreate(name *tree.TableName) (cat.Schema, cat.
 		panic(err)
 	}
 
-	// Add dependency on this schema to the metadata, so that the metadata can be
-	// cached and later checked for freshness.
-	b.factory.Metadata().AddSchemaDependency(&name.TableNamePrefix, sch, privilege.CREATE)
 	return sch, resName
 }
 
@@ -505,5 +502,5 @@ func (b *Builder) checkPrivilege(
 
 	// Add dependency on this object to the metadata, so that the metadata can be
 	// cached and later checked for freshness.
-	b.factory.Metadata().AddDataSourceDependency(origName, ds, priv)
+	b.factory.Metadata().AddDependency(origName, ds, priv)
 }

--- a/pkg/sql/sem/tree/table_name.go
+++ b/pkg/sql/sem/tree/table_name.go
@@ -73,12 +73,6 @@ func (tp *TableNamePrefix) Catalog() string {
 	return string(tp.CatalogName)
 }
 
-// Equals returns true if the two table name prefixes are identical (including
-// the ExplicitSchema/ExplicitCatalog flags).
-func (tp *TableNamePrefix) Equals(other *TableNamePrefix) bool {
-	return *tp == *other
-}
-
 // Format implements the NodeFormatter interface.
 func (t *TableName) Format(ctx *FmtCtx) {
 	if ctx.tableNameFormatter != nil {


### PR DESCRIPTION
The infrastructure for keeping track of cat.Schema dependencies is
only useful when reusing a memo for CREATE TABLE. This is not a
statement for which memo reuse is important. This change disables memo
reuse for this statement and simplifies the metadata management.

Release note: None