### PR TITLE
opt: specify hash joins in EXPLAIN (OPT)

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_env
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_env
@@ -148,7 +148,7 @@ ALTER TABLE test.public.y INJECT STATISTICS '[]';
 ·
 SELECT text FROM [EXPLAIN (OPT, ENV) SELECT * FROM x, y WHERE b = 3] WHERE (text NOT LIKE '%Version%') OR (text LIKE '%EXPLAIN%');
 ----
-inner-join
+inner-join (hash)
  ├── scan y
  ├── scan x@x_b_idx
  │    └── constraint: /2/1: [/3 - /3]
@@ -197,7 +197,7 @@ ALTER TABLE test.public.x INJECT STATISTICS '[
 ·
 SELECT text FROM [EXPLAIN (OPT, ENV) SELECT * FROM x AS one, x AS two] WHERE (text NOT LIKE '%Version%') OR (text LIKE '%EXPLAIN%');
 ----
-inner-join
+inner-join (hash)
  ├── scan one
  ├── scan two
  └── filters (true)
@@ -347,7 +347,7 @@ CREATE VIEW v (a, b, u, v) AS SELECT a, b, u, v FROM test.public.x, test.public.
 ·
 SELECT text FROM [EXPLAIN (OPT, ENV) SELECT * FROM v] WHERE (text NOT LIKE '%Version%') OR (text LIKE '%EXPLAIN%');
 ----
-inner-join
+inner-join (hash)
  ├── scan test.public.y
  ├── scan test.public.x@x_b_idx
  │    └── constraint: /2/1: [/3 - /3]

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -200,6 +200,10 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		}
 	default:
 		fmt.Fprintf(f.Buffer, "%v", e.Op())
+		if opt.IsJoinNonApplyOp(t) {
+			// All join ops that weren't handled above execute as a hash join.
+			f.Buffer.WriteString(" (hash)")
+		}
 	}
 
 	tp = tp.Child(f.Buffer.String())

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -14,7 +14,7 @@ CREATE TABLE mn (m INT PRIMARY KEY, n INT, UNIQUE (n))
 build
 SELECT *, rowid FROM xysd INNER JOIN uv ON x=u
 ----
-inner-join
+inner-join (hash)
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int!null) v:6(int!null) rowid:7(int!null)
  ├── key: (7)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6), (1)==(5), (5)==(1)
@@ -126,7 +126,7 @@ project
       │         ├── outer: (1)
       │         ├── fd: ()-->(6)
       │         ├── prune: (6)
-      │         └── inner-join
+      │         └── inner-join (hash)
       │              ├── columns: v:6(int!null) n:9(int!null)
       │              ├── outer: (1)
       │              ├── fd: ()-->(6,9)
@@ -184,7 +184,7 @@ project
       │         ├── columns: v:6(int!null)
       │         ├── outer: (1,2)
       │         ├── prune: (6)
-      │         └── inner-join
+      │         └── inner-join (hash)
       │              ├── columns: v:6(int!null) m:8(int!null)
       │              ├── outer: (1,2)
       │              ├── fd: ()-->(8)
@@ -214,7 +214,7 @@ project
 build
 SELECT *, rowid FROM xysd LEFT JOIN uv ON x=u
 ----
-left-join
+left-join (hash)
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int) v:6(int) rowid:7(int)
  ├── key: (1,7)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)
@@ -294,7 +294,7 @@ project
 build
 SELECT *, rowid FROM xysd RIGHT JOIN uv ON x=u
 ----
-right-join
+right-join (hash)
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) v:6(int!null) rowid:7(int!null)
  ├── key: (1,7)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)
@@ -322,7 +322,7 @@ right-join
 opt
 SELECT * FROM xysd RIGHT JOIN uv ON (SELECT u FROM uv WHERE u=x OFFSET 1) IS NULL
 ----
-right-join
+right-join (hash)
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) v:6(int!null)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (1-6)
@@ -389,7 +389,7 @@ right-join
 build
 SELECT *, rowid FROM xysd FULL JOIN uv ON x=u
 ----
-full-join
+full-join (hash)
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) v:6(int) rowid:7(int)
  ├── key: (1,7)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)
@@ -434,7 +434,7 @@ project
       │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
       │    ├── prune: (1-4)
       │    └── interesting orderings: (+1) (-3,+4,+1)
-      ├── left-join
+      ├── left-join (hash)
       │    ├── columns: u:5(int) v:6(int!null) u:8(int)
       │    ├── outer: (1)
       │    ├── fd: ()~~>(8)
@@ -475,7 +475,7 @@ project
 opt
 SELECT * FROM xysd WHERE EXISTS(SELECT * FROM uv WHERE x=u)
 ----
-semi-join
+semi-join (hash)
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
@@ -547,7 +547,7 @@ semi-join-apply
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
  │    └── interesting orderings: (+1) (-3,+4,+1)
- ├── semi-join
+ ├── semi-join (hash)
  │    ├── columns: u:5(int) v:6(int!null)
  │    ├── outer: (1)
  │    ├── fd: ()-->(6)
@@ -574,7 +574,7 @@ semi-join-apply
 opt
 SELECT * FROM xysd WHERE NOT EXISTS(SELECT * FROM uv WHERE x=u)
 ----
-anti-join
+anti-join (hash)
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
@@ -639,7 +639,7 @@ project
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (1-6)
  ├── interesting orderings: (+1) (-3,+4,+1)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int) v:6(int!null) rowid:7(int!null)
       ├── key: (1,7)
       ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)
@@ -663,7 +663,7 @@ project
 build
 SELECT * FROM xysd, xysd AS xysd
 ----
-inner-join
+inner-join (hash)
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) x:5(int!null) y:6(int) s:7(string) d:8(decimal!null)
  ├── key: (1,5)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (5)-->(6-8), (7,8)~~>(5,6)
@@ -701,7 +701,7 @@ select
  │    └── interesting orderings: (+1) (-3,+4,+1)
  └── filters
       └── exists [type=bool, outer=(1-3), correlated-subquery]
-           └── inner-join
+           └── inner-join (hash)
                 ├── columns: x:5(int) y:6(int)
                 ├── outer: (1-3)
                 ├── cardinality: [0 - 1]
@@ -744,7 +744,7 @@ select
 opt
 SELECT * FROM (SELECT count(*) cnt FROM xysd) WHERE EXISTS(SELECT * FROM uv WHERE cnt=1)
 ----
-semi-join
+semi-join (hash)
  ├── columns: cnt:5(int!null)
  ├── cardinality: [0 - 1]
  ├── key: ()
@@ -815,7 +815,7 @@ semi-join-apply
 opt
 SELECT * FROM (SELECT * FROM (VALUES (1), (2))) WHERE NOT EXISTS(SELECT * FROM uv WHERE u=column1)
 ----
-anti-join
+anti-join (hash)
  ├── columns: column1:1(int!null)
  ├── cardinality: [0 - 2]
  ├── values
@@ -877,7 +877,7 @@ anti-join-apply
 build
 SELECT * FROM (VALUES (1), (2)) INNER JOIN (SELECT * FROM uv LIMIT 2) ON True
 ----
-inner-join
+inner-join (hash)
  ├── columns: column1:1(int!null) u:2(int) v:3(int!null)
  ├── cardinality: [0 - 4]
  ├── prune: (1-3)
@@ -910,7 +910,7 @@ inner-join
 build
 SELECT * FROM (VALUES (1), (2), (3)) LEFT JOIN (SELECT * FROM uv LIMIT 2) ON True
 ----
-left-join
+left-join (hash)
  ├── columns: column1:1(int!null) u:2(int) v:3(int)
  ├── cardinality: [3 - 6]
  ├── prune: (1-3)
@@ -946,7 +946,7 @@ left-join
 build
 SELECT * FROM (SELECT * FROM uv LIMIT 2) RIGHT JOIN (VALUES (1), (2), (3)) ON True
 ----
-right-join
+right-join (hash)
  ├── columns: u:1(int) v:2(int) column1:4(int!null)
  ├── cardinality: [3 - 6]
  ├── prune: (1,2,4)
@@ -982,7 +982,7 @@ right-join
 build
 SELECT * FROM (VALUES (NULL), (NULL)) a FULL JOIN (VALUES (NULL), (NULL)) b ON True
 ----
-full-join
+full-join (hash)
  ├── columns: column1:1(unknown) column1:2(unknown)
  ├── cardinality: [2 - 4]
  ├── prune: (1,2)
@@ -1010,7 +1010,7 @@ full-join
 build
 SELECT * FROM (VALUES (NULL), (NULL)) a FULL JOIN (VALUES (NULL), (NULL)) b ON a.column1=b.column1
 ----
-full-join
+full-join (hash)
  ├── columns: column1:1(unknown) column1:2(unknown)
  ├── cardinality: [2 - 4]
  ├── prune: (1,2)
@@ -1039,7 +1039,7 @@ full-join
 build
 SELECT * FROM xysd FULL JOIN (SELECT * FROM (VALUES (1), (2))) ON True
 ----
-full-join
+full-join (hash)
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) column1:5(int)
  ├── cardinality: [2 - ]
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
@@ -1067,7 +1067,7 @@ full-join
 build
 SELECT * FROM (SELECT * FROM xysd LIMIT 1) FULL JOIN (SELECT * FROM xysd LIMIT 1) ON True
 ----
-full-join
+full-join (hash)
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) x:5(int) y:6(int) s:7(string) d:8(decimal)
  ├── cardinality: [0 - 1]
  ├── key: ()
@@ -1110,7 +1110,7 @@ full-join
 build
 SELECT * FROM xysd LEFT JOIN (SELECT u, sum(v) FROM uv GROUP BY u) ON u IS NOT NULL
 ----
-left-join
+left-join (hash)
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int) sum:8(decimal)
  ├── key: (1,5)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (5)~~>(8), (1,5)-->(8)
@@ -1150,7 +1150,7 @@ left-join
 build
 SELECT * FROM xysd LEFT JOIN (SELECT u, sum(v) FROM uv WHERE u IS NOT NULL GROUP BY u) ON True
 ----
-left-join
+left-join (hash)
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int) sum:8(decimal)
  ├── key: (1,5)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (5)-->(8)
@@ -1198,7 +1198,7 @@ left-join
 build
 SELECT * FROM (SELECT u, sum(v) FROM uv GROUP BY u) RIGHT JOIN xysd ON u IS NOT NULL
 ----
-right-join
+right-join (hash)
  ├── columns: u:1(int) sum:4(decimal) x:5(int!null) y:6(int) s:7(string) d:8(decimal!null)
  ├── key: (1,5)
  ├── fd: (5)-->(6-8), (7,8)~~>(5,6), (1)~~>(4), (1,5)-->(4)
@@ -1238,7 +1238,7 @@ right-join
 build
 SELECT * FROM (SELECT u, sum(v) FROM uv WHERE u IS NOT NULL GROUP BY u) RIGHT JOIN xysd ON True
 ----
-right-join
+right-join (hash)
  ├── columns: u:1(int) sum:4(decimal) x:5(int!null) y:6(int) s:7(string) d:8(decimal!null)
  ├── key: (1,5)
  ├── fd: (1)-->(4), (5)-->(6-8), (7,8)~~>(5,6)
@@ -1286,7 +1286,7 @@ right-join
 build
 SELECT * FROM xysd FULL JOIN (SELECT u, sum(v) FROM uv GROUP BY u) ON u IS NOT NULL
 ----
-full-join
+full-join (hash)
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) sum:8(decimal)
  ├── key: (1,5)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (5)~~>(8), (1,5)-->(8)
@@ -1326,7 +1326,7 @@ full-join
 build
 SELECT * FROM (SELECT u, sum(v) FROM uv GROUP BY u) FULL JOIN xysd ON u IS NOT NULL
 ----
-full-join
+full-join (hash)
  ├── columns: u:1(int) sum:4(decimal) x:5(int) y:6(int) s:7(string) d:8(decimal)
  ├── key: (1,5)
  ├── fd: (5)-->(6-8), (7,8)~~>(5,6), (1)~~>(4), (1,5)-->(4)
@@ -1501,7 +1501,7 @@ project
  │    ├── scan uv
  │    │    ├── columns: u:1(int)
  │    │    └── prune: (1)
- │    ├── inner-join
+ │    ├── inner-join (hash)
  │    │    ├── columns: u:4(int!null) v:5(int!null) rowid:6(int!null) mn.m:13(int!null)
  │    │    ├── outer: (1)
  │    │    ├── cardinality: [0 - 0]

--- a/pkg/sql/opt/memo/testdata/logprops/scalar
+++ b/pkg/sql/opt/memo/testdata/logprops/scalar
@@ -32,7 +32,7 @@ SELECT xy.x + 1 = length('foo') + xy.y AS a, uv.rowid * xy.x AS b FROM xy, uv
 project
  ├── columns: a:6(bool) b:7(int)
  ├── prune: (6,7)
- ├── inner-join
+ ├── inner-join (hash)
  │    ├── columns: x:1(int!null) y:2(int) u:3(int) v:4(int!null) rowid:5(int!null)
  │    ├── key: (1,5)
  │    ├── fd: (1)-->(2), (5)-->(3,4)
@@ -196,7 +196,7 @@ group-by
  │    ├── fd: (1)-->(3)
  │    ├── prune: (1,3)
  │    ├── interesting orderings: (+1)
- │    └── inner-join
+ │    └── inner-join (hash)
  │         ├── columns: x:1(int!null) y:2(int) div:3(decimal) u:4(int!null) v:5(int!null)
  │         ├── side-effects
  │         ├── fd: (1)-->(2,3), (1)==(4), (4)==(1)

--- a/pkg/sql/opt/memo/testdata/logprops/select
+++ b/pkg/sql/opt/memo/testdata/logprops/select
@@ -36,7 +36,7 @@ select
  ├── fd: (1)-->(2), (3)-->(4,5), (1)==(3), (3)==(1)
  ├── prune: (2,4,5)
  ├── interesting orderings: (+1) (+3)
- ├── inner-join
+ ├── inner-join (hash)
  │    ├── columns: x:1(int!null) y:2(int) k:3(int!null) u:4(float) v:5(string)
  │    ├── key: (1,3)
  │    ├── fd: (1)-->(2), (3)-->(4,5)

--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -70,7 +70,7 @@ project
            │    │    ├── fd: ()-->(6,9,14), (5)-->(8), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13), (12)-->(15)
            │    │    ├── prune: (5,6,8-15)
            │    │    ├── interesting orderings: (+5) (+6) (+13) (+10) (+11,+12,+13)
-           │    │    ├── left-join
+           │    │    ├── left-join (hash)
            │    │    │    ├── columns: x:5(int!null) y:6(int!null) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
            │    │    │    ├── side-effects
            │    │    │    ├── key: (5,13)
@@ -213,7 +213,7 @@ project
                 ├── fd: ()-->(18-21), (5)-->(6,8), (6)-->(9)
                 ├── prune: (5,8,18)
                 ├── interesting orderings: (+5) (+6) (+21) (+18) (+19,+20,+21)
-                ├── left-join
+                ├── left-join (hash)
                 │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:18(int) b:19(int) c:20(int) rowid:21(int)
                 │    ├── side-effects
                 │    ├── key: (5,21)
@@ -235,7 +235,7 @@ project
                 │    │         ├── fd: ()-->(14-17), (5)-->(6,8), (6)-->(9)
                 │    │         ├── prune: (6,8,9,15-17)
                 │    │         ├── interesting orderings: (+5) (+6) (+17) (+14) (+15,+16,+17)
-                │    │         ├── left-join
+                │    │         ├── left-join (hash)
                 │    │         │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:14(int) b:15(int) c:16(int) rowid:17(int)
                 │    │         │    ├── side-effects
                 │    │         │    ├── key: (5,17)
@@ -257,7 +257,7 @@ project
                 │    │         │    │         ├── fd: ()-->(10-13), (5)-->(6,8), (6)-->(9)
                 │    │         │    │         ├── prune: (5,6,9-12)
                 │    │         │    │         ├── interesting orderings: (+5) (+6) (+13) (+10) (+11,+12,+13)
-                │    │         │    │         ├── left-join
+                │    │         │    │         ├── left-join (hash)
                 │    │         │    │         │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
                 │    │         │    │         │    ├── side-effects
                 │    │         │    │         │    ├── key: (5,13)
@@ -385,7 +385,7 @@ project
  │         │    ├── fd: ()-->(6,8), (12)-->(9-11), (9)-->(10-12), (10,11)~~>(9,12), (10)-->(13)
  │         │    ├── prune: (5-13)
  │         │    ├── interesting orderings: (+12) (+9) (+10,+11,+12)
- │         │    ├── left-join
+ │         │    ├── left-join (hash)
  │         │    │    ├── columns: column1:5(int!null) column6:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
  │         │    │    ├── cardinality: [2 - ]
  │         │    │    ├── side-effects

--- a/pkg/sql/opt/memo/testdata/logprops/virtual-scan
+++ b/pkg/sql/opt/memo/testdata/logprops/virtual-scan
@@ -7,7 +7,7 @@ ON CATALOG_NAME=TABLE_CATALOG AND SCHEMA_NAME=TABLE_SCHEMA
 project
  ├── columns: catalog_name:1(string) sql_path:4(string)
  ├── prune: (1,4)
- └── left-join
+ └── left-join (hash)
       ├── columns: catalog_name:1(string) schema_name:2(string!null) default_character_set_name:3(string) sql_path:4(string) table_catalog:5(string) table_schema:6(string) table_name:7(string) table_type:8(string) is_insertable_into:9(string) version:10(int)
       ├── fd: ()-->(2)
       ├── reject-nulls: (5-10)

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -30,7 +30,7 @@ limit
  │         │    ├── columns: a.x:1(int!null) y:2(int!null) b.x:3(string!null) z:4(decimal!null)
  │         │    ├── key: (1,3)
  │         │    ├── fd: (1)-->(2), (3)-->(4)
- │         │    ├── inner-join
+ │         │    ├── inner-join (hash)
  │         │    │    ├── columns: a.x:1(int!null) y:2(int) b.x:3(string!null) z:4(decimal!null)
  │         │    │    ├── key: (1,3)
  │         │    │    ├── fd: (1)-->(2), (3)-->(4)
@@ -80,7 +80,7 @@ project
  │    │    ├── columns: y:2(int!null) b.x:3(string!null) column5:5(string!null)
  │    │    ├── fd: (3)==(5), (5)==(3)
  │    │    ├── ordering: +2
- │    │    └── inner-join
+ │    │    └── inner-join (hash)
  │    │         ├── columns: y:2(int!null) b.x:3(string!null) column5:5(string!null)
  │    │         ├── fd: (3)==(5), (5)==(3)
  │    │         ├── scan b

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -49,7 +49,7 @@ ALTER TABLE uv INJECT STATISTICS '[
 norm
 SELECT * FROM xysd JOIN uv ON true
 ----
-inner-join
+inner-join (hash)
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int) v:6(int!null)
  ├── stats: [rows=50000000]
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
@@ -66,7 +66,7 @@ inner-join
 norm colstat=1 colstat=2 colstat=3 colstat=4 colstat=5 colstat=6 colstat=(2,5,6)
 SELECT * FROM xysd JOIN uv ON true
 ----
-inner-join
+inner-join (hash)
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int) v:6(int!null)
  ├── stats: [rows=50000000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=0, distinct(3)=500, null(3)=500000, distinct(4)=500, null(4)=0, distinct(5)=500, null(5)=0, distinct(6)=100, null(6)=0, distinct(2,5,6)=4000000, null(2,5,6)=0]
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
@@ -93,7 +93,7 @@ values
 build colstat=2
 SELECT *, rowid FROM xysd INNER JOIN uv ON x=u
 ----
-inner-join
+inner-join (hash)
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int!null) v:6(int!null) rowid:7(int!null)
  ├── stats: [rows=10000, distinct(1)=500, null(1)=0, distinct(2)=400, null(2)=0, distinct(4)=499.999999, null(4)=0, distinct(5)=500, null(5)=0, distinct(6)=100, null(6)=0, distinct(7)=6321.5735, null(7)=0]
  ├── key: (7)
@@ -114,7 +114,7 @@ inner-join
 build
 SELECT *, rowid FROM xysd LEFT JOIN uv ON x=u
 ----
-left-join
+left-join (hash)
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int) v:6(int) rowid:7(int)
  ├── stats: [rows=10000, distinct(5)=500, null(5)=0]
  ├── key: (1,7)
@@ -135,7 +135,7 @@ left-join
 build
 SELECT *, rowid FROM xysd RIGHT JOIN uv ON x=u
 ----
-right-join
+right-join (hash)
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) v:6(int!null) rowid:7(int!null)
  ├── stats: [rows=10000, distinct(1)=500, null(1)=0]
  ├── key: (1,7)
@@ -156,7 +156,7 @@ right-join
 build
 SELECT *, rowid FROM xysd FULL JOIN uv ON x=u
 ----
-full-join
+full-join (hash)
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) v:6(int) rowid:7(int)
  ├── stats: [rows=10000]
  ├── key: (1,7)
@@ -181,7 +181,7 @@ project
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int) v:6(int!null)
  ├── stats: [rows=50000000]
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int) v:6(int!null) rowid:7(int!null)
       ├── stats: [rows=50000000]
       ├── key: (1,7)
@@ -201,7 +201,7 @@ project
 build
 SELECT * FROM xysd, xysd AS xysd
 ----
-inner-join
+inner-join (hash)
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) x:5(int!null) y:6(int) s:7(string) d:8(decimal!null)
  ├── stats: [rows=25000000]
  ├── key: (1,5)
@@ -230,7 +230,7 @@ project
       ├── stats: [rows=500000, distinct(1)=5000, null(1)=0, distinct(4)=500, null(4)=0, distinct(6)=1, null(6)=0, distinct(7)=10000, null(7)=0]
       ├── key: (1,7)
       ├── fd: ()-->(6), (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5)
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int) v:6(int!null) rowid:7(int!null)
       │    ├── stats: [rows=50000000, distinct(1)=5000, null(1)=0, distinct(4)=500, null(4)=0, distinct(6)=100, null(6)=0, distinct(7)=10000, null(7)=0]
       │    ├── key: (1,7)
@@ -263,7 +263,7 @@ group-by
  ├── project
  │    ├── columns: x:1(int!null) v:6(int!null)
  │    ├── stats: [rows=50000000, distinct(1,6)=500000, null(1,6)=0]
- │    └── inner-join
+ │    └── inner-join (hash)
  │         ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int) v:6(int!null) rowid:7(int!null)
  │         ├── stats: [rows=50000000, distinct(1,6)=500000, null(1,6)=0]
  │         ├── key: (1,7)
@@ -293,7 +293,7 @@ group-by
  ├── stats: [rows=10000, distinct(1,6)=10000, null(1,6)=0]
  ├── key: (1,6)
  ├── fd: (1,6)-->(8)
- ├── inner-join
+ ├── inner-join (hash)
  │    ├── columns: x:1(int!null) u:5(int!null) v:6(int!null)
  │    ├── stats: [rows=10000, distinct(1)=500, null(1)=0, distinct(5)=500, null(5)=0, distinct(6)=100, null(6)=0, distinct(1,6)=10000, null(1,6)=0]
  │    ├── fd: (1)==(5), (5)==(1)
@@ -314,7 +314,7 @@ group-by
 norm
 SELECT * FROM xysd WHERE EXISTS (SELECT * FROM uv WHERE x=u)
 ----
-semi-join
+semi-join (hash)
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
  ├── stats: [rows=5000]
  ├── key: (1)
@@ -334,7 +334,7 @@ semi-join
 norm
 SELECT * FROM xysd WHERE NOT EXISTS (SELECT * FROM uv WHERE x=u)
 ----
-anti-join
+anti-join (hash)
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
  ├── stats: [rows=5000]
  ├── key: (1)
@@ -354,7 +354,7 @@ anti-join
 norm
 SELECT * FROM xysd JOIN uv ON x=u AND y=v
 ----
-inner-join
+inner-join (hash)
  ├── columns: x:1(int!null) y:2(int!null) s:3(string) d:4(decimal!null) u:5(int!null) v:6(int!null)
  ├── stats: [rows=25, distinct(1)=25, null(1)=0, distinct(2)=25, null(2)=0, distinct(4)=24.3852937, null(4)=0, distinct(5)=25, null(5)=0, distinct(6)=25, null(6)=0]
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (1)==(5), (5)==(1), (2)==(6), (6)==(2)
@@ -374,7 +374,7 @@ inner-join
 norm
 SELECT * FROM xysd JOIN uv ON x=u AND y+v=5 AND y > 0 AND y < 300
 ----
-inner-join
+inner-join (hash)
  ├── columns: x:1(int!null) y:2(int!null) s:3(string) d:4(decimal!null) u:5(int!null) v:6(int!null)
  ├── stats: [rows=3333.33333, distinct(1)=500, null(1)=0, distinct(2)=298.995696, null(2)=0, distinct(4)=499.363351, null(4)=0, distinct(5)=500, null(5)=0, distinct(6)=100, null(6)=0]
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (1)==(5), (5)==(1)
@@ -412,7 +412,7 @@ project
       ├── stats: [rows=400, distinct(2)=400, null(2)=0]
       ├── key: (2)
       ├── fd: (2)-->(8)
-      ├── semi-join
+      ├── semi-join (hash)
       │    ├── columns: x:1(int!null) y:2(int)
       │    ├── stats: [rows=5000, distinct(2)=400, null(2)=0]
       │    ├── key: (1)
@@ -446,7 +446,7 @@ project
       ├── stats: [rows=400, distinct(2)=400, null(2)=0]
       ├── key: (2)
       ├── fd: (2)-->(8)
-      ├── anti-join
+      ├── anti-join (hash)
       │    ├── columns: x:1(int!null) y:2(int)
       │    ├── stats: [rows=5000, distinct(2)=400, null(2)=0]
       │    ├── key: (1)
@@ -480,7 +480,7 @@ project
       ├── stats: [rows=400, distinct(2)=400, null(2)=0]
       ├── key: (2)
       ├── fd: (2)-->(8)
-      ├── left-join
+      ├── left-join (hash)
       │    ├── columns: x:1(int!null) y:2(int) u:5(int) v:6(int)
       │    ├── stats: [rows=5000, distinct(2)=400, null(2)=0, distinct(5)=500, null(5)=1666.66667]
       │    ├── fd: (1)-->(2)
@@ -513,7 +513,7 @@ project
       ├── stats: [rows=399.903879, distinct(2)=399.903879, null(2)=399.903879]
       ├── key: (2)
       ├── fd: (2)-->(8)
-      ├── right-join
+      ├── right-join (hash)
       │    ├── columns: x:1(int) y:2(int) u:5(int) v:6(int!null)
       │    ├── stats: [rows=10000, distinct(1)=500, null(1)=6666.66667, distinct(2)=399.903879, null(2)=6666.66667]
       │    ├── fd: (1)-->(2)
@@ -546,7 +546,7 @@ project
       ├── stats: [rows=400, distinct(2)=400, null(2)=400]
       ├── key: (2)
       ├── fd: (2)-->(8)
-      ├── full-join
+      ├── full-join (hash)
       │    ├── columns: x:1(int) y:2(int) u:5(int) v:6(int)
       │    ├── stats: [rows=11666.6667, distinct(2)=400, null(2)=6666.66667]
       │    ├── fd: (1)-->(2)
@@ -580,7 +580,7 @@ CREATE TABLE xyz (x INT, y INT, z INT)
 norm disable=(PushFilterIntoJoinLeftAndRight,PushFilterIntoJoinLeft,PushFilterIntoJoinRight,MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
 SELECT * FROM (SELECT * FROM uvw WHERE w=1) JOIN (SELECT * FROM xyz WHERE x=10) ON u=x
 ----
-inner-join
+inner-join (hash)
  ├── columns: u:1(int!null) v:2(int) w:3(int!null) x:5(int!null) y:6(int) z:7(int)
  ├── stats: [rows=10.3490885, distinct(1)=1, null(1)=0, distinct(3)=0.999982217, null(3)=0, distinct(5)=1, null(5)=0]
  ├── fd: ()-->(1,3,5), (1)==(5), (5)==(1)
@@ -608,7 +608,7 @@ inner-join
 norm disable=(PushFilterIntoJoinLeftAndRight,PushFilterIntoJoinLeft,PushFilterIntoJoinRight,MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
 SELECT * FROM (SELECT * FROM uvw WHERE w=1) JOIN xyz ON u=x AND x=10
 ----
-inner-join
+inner-join (hash)
  ├── columns: u:1(int!null) v:2(int) w:3(int!null) x:5(int!null) y:6(int) z:7(int)
  ├── stats: [rows=10.4536248, distinct(1)=1, null(1)=0, distinct(3)=0.999971315, null(3)=0, distinct(5)=1, null(5)=0]
  ├── fd: ()-->(1,3,5), (1)==(5), (5)==(1)
@@ -674,7 +674,7 @@ ALTER TABLE uv INJECT STATISTICS '[
 build colstat=2 colstat=(1,2,7) colstat=(2,3) colstat=3 colstat=(3,5) colstat=5
 SELECT *, rowid FROM xysd INNER JOIN uv ON x=u
 ----
-inner-join
+inner-join (hash)
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int!null) v:6(int!null) rowid:7(int!null)
  ├── stats: [rows=10000, distinct(1)=500, null(1)=0, distinct(2)=400, null(2)=5000, distinct(3)=499.999999, null(3)=100, distinct(4)=499.999999, null(4)=0, distinct(5)=500, null(5)=0, distinct(6)=100, null(6)=0, distinct(7)=6321.5735, null(7)=0, distinct(2,3)=4323.45892, null(2,3)=5050, distinct(3,5)=10000, null(3,5)=5050, distinct(1,2,7)=10000, null(1,2,7)=5000]
  ├── key: (7)
@@ -695,7 +695,7 @@ inner-join
 build colstat=2 colstat=(1,2,7) colstat=(2,3) colstat=3 colstat=(3,5) colstat=5
 SELECT *, rowid FROM xysd LEFT JOIN uv ON x=u
 ----
-left-join
+left-join (hash)
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int) v:6(int) rowid:7(int)
  ├── stats: [rows=10000, distinct(2)=400, null(2)=5000, distinct(3)=500, null(3)=100, distinct(5)=500, null(5)=0, distinct(2,3)=5000, null(2,3)=5050, distinct(3,5)=10000, null(3,5)=5050, distinct(1,2,7)=10000, null(1,2,7)=5000]
  ├── key: (1,7)
@@ -716,7 +716,7 @@ left-join
 build colstat=2 colstat=(1,2,7) colstat=(2,3) colstat=3 colstat=(3,5) colstat=5
 SELECT *, rowid FROM xysd RIGHT JOIN uv ON x=u
 ----
-right-join
+right-join (hash)
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) v:6(int!null) rowid:7(int!null)
  ├── stats: [rows=10000, distinct(1)=500, null(1)=0, distinct(2)=400, null(2)=5000, distinct(3)=499.999999, null(3)=100, distinct(5)=500, null(5)=5000, distinct(2,3)=4323.45892, null(2,3)=5050, distinct(3,5)=10000, null(3,5)=5050, distinct(1,2,7)=10000, null(1,2,7)=5000]
  ├── key: (1,7)
@@ -737,7 +737,7 @@ right-join
 build colstat=2 colstat=(1,2,7) colstat=(2,3) colstat=3 colstat=(3,5) colstat=5
 SELECT *, rowid FROM xysd FULL JOIN uv ON x=u
 ----
-full-join
+full-join (hash)
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) v:6(int) rowid:7(int)
  ├── stats: [rows=10000, distinct(2)=400, null(2)=5000, distinct(3)=500, null(3)=100, distinct(5)=500, null(5)=5000, distinct(2,3)=5000, null(2,3)=5050, distinct(3,5)=10000, null(3,5)=5050, distinct(1,2,7)=10000, null(1,2,7)=5000]
  ├── key: (1,7)
@@ -764,7 +764,7 @@ select
  ├── stats: [rows=9900, distinct(2)=400, null(2)=4950, distinct(3)=500, null(3)=0, distinct(5)=500, null(5)=4950, distinct(2,3)=4999.5, null(2,3)=4999.5, distinct(3,5)=9900, null(3,5)=4999.5, distinct(1,2,7)=9900, null(1,2,7)=4950]
  ├── key: (1,7)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)
- ├── full-join
+ ├── full-join (hash)
  │    ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) v:6(int) rowid:7(int)
  │    ├── stats: [rows=10000, distinct(2)=400, null(2)=5000, distinct(3)=500, null(3)=100, distinct(5)=500, null(5)=5000, distinct(2,3)=5000, null(2,3)=5050, distinct(3,5)=10000, null(3,5)=5050, distinct(1,2,7)=10000, null(1,2,7)=5000]
  │    ├── key: (1,7)
@@ -789,7 +789,7 @@ select
 build colstat=2 colstat=(1,2,7) colstat=(2,3) colstat=3 colstat=(3,5) colstat=5
 SELECT *, rowid FROM xysd FULL JOIN uv ON u > 4 AND u < 2
 ----
-full-join
+full-join (hash)
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) v:6(int) rowid:7(int)
  ├── stats: [rows=50000000, distinct(2)=400, null(2)=25000000, distinct(3)=500, null(3)=500000, distinct(5)=500, null(5)=25000000, distinct(2,3)=5000, null(2,3)=25250000, distinct(3,5)=250000, null(3,5)=25250000, distinct(1,2,7)=25010000, null(1,2,7)=25000000]
  ├── key: (1,7)
@@ -814,7 +814,7 @@ project
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int) v:6(int!null)
  ├── stats: [rows=50000000, distinct(2)=400, null(2)=25000000, distinct(1,2,7)=25010000, null(1,2,7)=25000000]
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int) v:6(int!null) rowid:7(int!null)
       ├── stats: [rows=50000000, distinct(2)=400, null(2)=25000000, distinct(1,2,7)=25010000, null(1,2,7)=25000000]
       ├── key: (1,7)
@@ -928,7 +928,7 @@ values
 norm
 SELECT * FROM (SELECT 1) LEFT JOIN (SELECT 1 WHERE false) ON true
 ----
-left-join
+left-join (hash)
  ├── columns: "?column?":1(int!null) "?column?":2(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
@@ -962,7 +962,7 @@ values
 norm
 SELECT * FROM (SELECT 1) FULL JOIN (SELECT 1 WHERE false) ON true
 ----
-left-join
+left-join (hash)
  ├── columns: "?column?":1(int!null) "?column?":2(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
@@ -1006,7 +1006,7 @@ values
 norm
 SELECT * FROM (SELECT 1 WHERE false) RIGHT JOIN (SELECT 1) ON true
 ----
-right-join
+right-join (hash)
  ├── columns: "?column?":1(int) "?column?":2(int!null)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
@@ -1030,7 +1030,7 @@ right-join
 norm
 SELECT * FROM (SELECT 1 WHERE false) FULL JOIN (SELECT 1) ON true
 ----
-right-join
+right-join (hash)
  ├── columns: "?column?":1(int) "?column?":2(int!null)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
@@ -1054,7 +1054,7 @@ right-join
 norm
 SELECT * FROM (SELECT 1) FULL JOIN (VALUES (1), (2)) ON true
 ----
-inner-join
+inner-join (hash)
  ├── columns: "?column?":1(int!null) column1:2(int!null)
  ├── cardinality: [2 - 2]
  ├── stats: [rows=2]
@@ -1120,7 +1120,7 @@ project
  │    │         ├── outer: (2)
  │    │         ├── stats: [rows=1000]
  │    │         ├── fd: ()-->(15)
- │    │         ├── left-join
+ │    │         ├── left-join (hash)
  │    │         │    ├── outer: (2)
  │    │         │    ├── stats: [rows=1000, distinct(2)=1, null(2)=0]
  │    │         │    ├── scan table1
@@ -1140,7 +1140,7 @@ project
 norm colstat=1 colstat=2
 SELECT * FROM (SELECT 1) AS a(x) LEFT JOIN (SELECT 2) AS b(x) ON a.x = b.x
 ----
-left-join
+left-join (hash)
  ├── columns: x:1(int!null) x:2(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=1]

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -548,7 +548,7 @@ project
  │    ├── project
  │    │    ├── columns: col1:23(bool)
  │    │    ├── stats: [rows=333333.333, distinct(23)=333333.333, null(23)=16336.65]
- │    │    ├── inner-join
+ │    │    ├── inner-join (hash)
  │    │    │    ├── columns: tab0.e:5(varchar) tab0.f:6("char") tab0.h:8(varchar) tab0.j:10(float!null) tab1.e:16(varchar) tab1.f:17("char") tab1.j:21(float!null)
  │    │    │    ├── stats: [rows=333333.333, distinct(10)=100, null(10)=0, distinct(21)=100, null(21)=0, distinct(5,6,8,16,17)=333333.333, null(5,6,8,16,17)=16336.65]
  │    │    │    ├── scan tab0

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -414,7 +414,7 @@ select
  │         ├── stats: [rows=1000, distinct(1)=100, null(1)=0, distinct(2)=432.339125, null(2)=0, distinct(6)=100, null(6)=0, distinct(8)=632.138954, null(8)=0]
  │         ├── key: (8)
  │         ├── fd: (1)-->(2,3), (8)-->(4-7), (1)==(6), (6)==(1)
- │         ├── inner-join
+ │         ├── inner-join (hash)
  │         │    ├── columns: id:1(int!null) name:2(string) state:3(string) order_id:4(int) item_id:5(int) customer_id:6(int) year:7(int) rowid:8(int!null)
  │         │    ├── stats: [rows=10000000, distinct(1)=10000, null(1)=0, distinct(2)=500, null(2)=0, distinct(6)=100, null(6)=100000, distinct(8)=1000, null(8)=0]
  │         │    ├── key: (1,8)
@@ -462,7 +462,7 @@ select
  │         ├── stats: [rows=1000, distinct(1)=100, null(1)=0, distinct(2)=432.339125, null(2)=0, distinct(6)=100, null(6)=0, distinct(8)=632.138954, null(8)=0]
  │         ├── key: (8)
  │         ├── fd: (1)-->(2,3), (8)-->(4-7), (1)==(6), (6)==(1)
- │         ├── inner-join
+ │         ├── inner-join (hash)
  │         │    ├── columns: id:1(int!null) name:2(string) state:3(string) order_id:4(int) item_id:5(int) customer_id:6(int) year:7(int) rowid:8(int!null)
  │         │    ├── stats: [rows=10000000, distinct(1)=10000, null(1)=0, distinct(2)=500, null(2)=0, distinct(6)=100, null(6)=100000, distinct(8)=1000, null(8)=0]
  │         │    ├── key: (1,8)
@@ -1082,7 +1082,7 @@ select
  │         ├── stats: [rows=1000, distinct(1)=100, null(1)=0, distinct(2)=432.339125, null(2)=200, distinct(6)=100, null(6)=0, distinct(8)=632.138954, null(8)=0]
  │         ├── key: (8)
  │         ├── fd: (1)-->(2,3), (8)-->(4-7), (1)==(6), (6)==(1)
- │         ├── inner-join
+ │         ├── inner-join (hash)
  │         │    ├── columns: id:1(int!null) name:2(string) state:3(string) order_id:4(int) item_id:5(int) customer_id:6(int) year:7(int) rowid:8(int!null)
  │         │    ├── stats: [rows=10000000, distinct(1)=10000, null(1)=0, distinct(2)=500, null(2)=2000000, distinct(6)=100, null(6)=100000, distinct(8)=1000, null(8)=0]
  │         │    ├── key: (1,8)
@@ -1130,7 +1130,7 @@ select
  │         ├── stats: [rows=1000, distinct(1)=100, null(1)=0, distinct(2)=432.339125, null(2)=200, distinct(6)=100, null(6)=0, distinct(8)=632.138954, null(8)=0]
  │         ├── key: (8)
  │         ├── fd: (1)-->(2,3), (8)-->(4-7), (1)==(6), (6)==(1)
- │         ├── inner-join
+ │         ├── inner-join (hash)
  │         │    ├── columns: id:1(int!null) name:2(string) state:3(string) order_id:4(int) item_id:5(int) customer_id:6(int) year:7(int) rowid:8(int!null)
  │         │    ├── stats: [rows=10000000, distinct(1)=10000, null(1)=0, distinct(2)=500, null(2)=2000000, distinct(6)=100, null(6)=100000, distinct(8)=1000, null(8)=0]
  │         │    ├── key: (1,8)
@@ -1374,7 +1374,7 @@ select
  ├── project
  │    ├── columns: x:5(bool)
  │    ├── stats: [rows=4e+20, distinct(5)=1, null(5)=4e+20]
- │    ├── left-join
+ │    ├── left-join (hash)
  │    │    ├── columns: t1.x:1(bool) t2.x:3(bool)
  │    │    ├── stats: [rows=4e+20, distinct(1,3)=1, null(1,3)=4e+20]
  │    │    ├── scan t1

--- a/pkg/sql/opt/memo/testdata/stats/srfs
+++ b/pkg/sql/opt/memo/testdata/stats/srfs
@@ -7,11 +7,11 @@ SELECT a.*, b.*, c.* FROM upper('abc') a
 JOIN ROWS FROM (upper('def'), generate_series(1, 3), upper('ghi')) b ON true
 JOIN generate_series(1, 4) c ON true
 ----
-inner-join
+inner-join (hash)
  ├── columns: a:1(string) upper:2(string) generate_series:3(int) upper:4(string) c:5(int)
  ├── side-effects
  ├── stats: [rows=100, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=90, distinct(3)=7, null(3)=1, distinct(4)=1, null(4)=90, distinct(5)=7, null(5)=1]
- ├── inner-join
+ ├── inner-join (hash)
  │    ├── columns: upper:1(string) upper:2(string) generate_series:3(int) upper:4(string)
  │    ├── side-effects
  │    ├── stats: [rows=10, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=9, distinct(3)=7, null(3)=0.1, distinct(4)=1, null(4)=9]
@@ -65,7 +65,7 @@ distinct-on
  ├── side-effects
  ├── stats: [rows=7, distinct(1,2)=7, null(1,2)=0.1]
  ├── key: (1,2)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: upper:1(string) generate_series:2(int)
       ├── side-effects
       ├── stats: [rows=10, distinct(1,2)=7, null(1,2)=0.1]

--- a/pkg/sql/opt/memo/testdata/stats/upsert
+++ b/pkg/sql/opt/memo/testdata/stats/upsert
@@ -73,7 +73,7 @@ select
  │         │    ├── columns: column12:12(int!null) a:4(int!null) b:5(string!null) column8:8(float) x:9(string) y:10(int) z:11(float)
  │         │    ├── stats: [rows=200, distinct(5,9)=181.351171, null(5,9)=0, distinct(4,9,12)=200, null(4,9,12)=0]
  │         │    ├── fd: ()-->(5,8,12), (9)-->(10,11)
- │         │    ├── left-join
+ │         │    ├── left-join (hash)
  │         │    │    ├── columns: a:4(int!null) b:5(string!null) column8:8(float) x:9(string) y:10(int) z:11(float)
  │         │    │    ├── stats: [rows=200, distinct(9)=1, null(9)=0, distinct(4,9)=200, null(4,9)=0, distinct(5,9)=181.351171, null(5,9)=0]
  │         │    │    ├── fd: ()-->(5,8), (9)-->(10,11)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpcc
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpcc
@@ -2251,7 +2251,7 @@ scalar-group-by
  │    ├── stats: [rows=1000000, distinct(1)=2999.92032, null(1)=920000, distinct(2)=10, null(2)=920000, distinct(3)=10, null(3)=920000, distinct(9)=3000, null(9)=0, distinct(10)=10, null(10)=0, distinct(11)=10, null(11)=0]
  │    ├── cost: 3905160.1
  │    ├── interesting orderings: (+11,+10,-9) (+3,+2,-1)
- │    ├── full-join
+ │    ├── full-join (hash)
  │    │    ├── save-table-name: consistency_12_full_join_3
  │    │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:9(int) ol_d_id:10(int) ol_w_id:11(int)
  │    │    ├── stats: [rows=3000000, distinct(1)=2999.92032, null(1)=2760000, distinct(2)=10, null(2)=2760000, distinct(3)=10, null(3)=2760000, distinct(9)=3000, null(9)=0, distinct(10)=10, null(10)=0, distinct(11)=10, null(11)=0]

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch
@@ -899,13 +899,13 @@ project
       │         │    ├── stats: [rows=1487.22799, distinct(1)=1487.22799, null(1)=0, distinct(3)=1487.22799, null(3)=0, distinct(11)=1487.22799, null(11)=0, distinct(12)=1487.22799, null(12)=0, distinct(14)=1487.22799, null(14)=0, distinct(15)=1487.22799, null(15)=0, distinct(16)=1487.22799, null(16)=0, distinct(17)=1174.55443, null(17)=0, distinct(18)=1411.92479, null(18)=0, distinct(20)=1487.22799, null(20)=0, distinct(23)=1487.22799, null(23)=0, distinct(48)=1487.22799, null(48)=0, distinct(17,18)=1487.22799, null(17,18)=0]
       │         │    ├── key: (17,18)
       │         │    ├── fd: (1)-->(3), (17,18)-->(1,3,11,12,14-16,20,23,48), (1)==(17), (17)==(1), (18)-->(11,12,14-16,23)
-      │         │    ├── inner-join
+      │         │    ├── inner-join (hash)
       │         │    │    ├── save-table-name: q2_inner_join_6
       │         │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(char!null) p_type:5(varchar!null) p_size:6(int!null) s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null) ps_partkey:29(int!null) ps_suppkey:30(int!null) ps_supplycost:32(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │         │    │    ├── stats: [rows=2837.30948, distinct(1)=1333.31636, null(1)=0, distinct(3)=5, null(3)=0, distinct(5)=149.999649, null(5)=0, distinct(6)=1, null(6)=0, distinct(10)=1411.92479, null(10)=0, distinct(11)=1412.48485, null(11)=0, distinct(12)=1412.56423, null(12)=0, distinct(13)=5, null(13)=0, distinct(14)=1412.56423, null(14)=0, distinct(15)=1412.30169, null(15)=0, distinct(16)=1412.03742, null(16)=0, distinct(17)=1174.55443, null(17)=0, distinct(18)=1411.92479, null(18)=0, distinct(20)=1482.68691, null(20)=0, distinct(22)=5, null(22)=0, distinct(23)=5, null(23)=0, distinct(24)=1, null(24)=0, distinct(26)=1, null(26)=0, distinct(27)=0.996222107, null(27)=0, distinct(29)=1333.31636, null(29)=0, distinct(30)=1448.52495, null(30)=0, distinct(32)=2787.75127, null(32)=0, distinct(34)=1448.52495, null(34)=0, distinct(37)=5, null(37)=0, distinct(41)=5, null(41)=0, distinct(43)=1, null(43)=0, distinct(45)=1, null(45)=0, distinct(46)=0.996222107, null(46)=0, distinct(17,18)=1487.22799, null(17,18)=0]
       │         │    │    ├── key: (18,29,34)
       │         │    │    ├── fd: ()-->(6,27,46), (1)-->(3,5), (10)-->(11-16), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24), (10)==(18), (18)==(10), (13)==(22), (22)==(13), (1)==(17,29), (17)==(1,29), (29,30)-->(32), (34)-->(37), (41)-->(43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (30)==(34), (34)==(30), (29)==(1,17)
-      │         │    │    ├── inner-join
+      │         │    │    ├── inner-join (hash)
       │         │    │    │    ├── save-table-name: q2_inner_join_7
       │         │    │    │    ├── columns: ps_partkey:29(int!null) ps_suppkey:30(int!null) ps_supplycost:32(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │         │    │    │    ├── stats: [rows=161290.323, distinct(29)=110568.431, null(29)=0, distinct(30)=1844.80594, null(30)=0, distinct(32)=80252.0719, null(32)=0, distinct(34)=1844.80594, null(34)=0, distinct(37)=5, null(37)=0, distinct(41)=5, null(41)=0, distinct(43)=1, null(43)=0, distinct(45)=1, null(45)=0, distinct(46)=0.996222107, null(46)=0]
@@ -949,13 +949,13 @@ project
       │         │    │    │    │    └── filters (true)
       │         │    │    │    └── filters
       │         │    │    │         └── s_suppkey = ps_suppkey [type=bool, outer=(30,34), constraints=(/30: (/NULL - ]; /34: (/NULL - ]), fd=(30)==(34), (34)==(30)]
-      │         │    │    ├── inner-join
+      │         │    │    ├── inner-join (hash)
       │         │    │    │    ├── save-table-name: q2_inner_join_13
       │         │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(char!null) p_type:5(varchar!null) p_size:6(int!null) s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null)
       │         │    │    │    ├── stats: [rows=1945.04451, distinct(1)=1333.31636, null(1)=0, distinct(3)=5, null(3)=0, distinct(5)=149.99965, null(5)=0, distinct(6)=1, null(6)=0, distinct(10)=1766.2414, null(10)=0, distinct(11)=1767.4156, null(11)=0, distinct(12)=1767.58209, null(12)=0, distinct(13)=5, null(13)=0, distinct(14)=1767.58209, null(14)=0, distinct(15)=1767.03149, null(15)=0, distinct(16)=1766.47747, null(16)=0, distinct(17)=1333.31636, null(17)=0, distinct(18)=1766.2414, null(18)=0, distinct(20)=1921.6712, null(20)=0, distinct(22)=5, null(22)=0, distinct(23)=5, null(23)=0, distinct(24)=1, null(24)=0, distinct(26)=1, null(26)=0, distinct(27)=0.996222107, null(27)=0, distinct(17,18)=1932.16064, null(17,18)=0]
       │         │    │    │    ├── key: (17,18)
       │         │    │    │    ├── fd: ()-->(6,27), (1)-->(3,5), (10)-->(11-16), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24), (10)==(18), (18)==(10), (13)==(22), (22)==(13), (1)==(17), (17)==(1)
-      │         │    │    │    ├── inner-join
+      │         │    │    │    ├── inner-join (hash)
       │         │    │    │    │    ├── save-table-name: q2_inner_join_14
       │         │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null)
       │         │    │    │    │    ├── stats: [rows=161290.323, distinct(10)=9920, null(10)=0, distinct(11)=9989.99903, null(11)=0, distinct(12)=9999.99901, null(12)=0, distinct(13)=5, null(13)=0, distinct(14)=9999.99901, null(14)=0, distinct(15)=9966.99907, null(15)=0, distinct(16)=9933.99912, null(16)=0, distinct(17)=110564.957, null(17)=0, distinct(18)=9920, null(18)=0, distinct(20)=80250.5069, null(20)=0, distinct(22)=5, null(22)=0, distinct(23)=5, null(23)=0, distinct(24)=1, null(24)=0, distinct(26)=1, null(26)=0, distinct(27)=0.996222107, null(27)=0, distinct(17,18)=146071.239, null(17,18)=0]
@@ -967,7 +967,7 @@ project
       │         │    │    │    │    │    ├── stats: [rows=800000, distinct(17)=199241, null(17)=0, distinct(18)=9920, null(18)=0, distinct(20)=100379, null(20)=0, distinct(17,18)=800000, null(17,18)=0]
       │         │    │    │    │    │    ├── key: (17,18)
       │         │    │    │    │    │    └── fd: (17,18)-->(20)
-      │         │    │    │    │    ├── inner-join
+      │         │    │    │    │    ├── inner-join (hash)
       │         │    │    │    │    │    ├── save-table-name: q2_inner_join_16
       │         │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null) n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null)
       │         │    │    │    │    │    ├── stats: [rows=2000, distinct(10)=1844.80594, null(10)=0, distinct(11)=1846.09084, null(11)=0, distinct(12)=1846.27302, null(12)=0, distinct(13)=5, null(13)=0, distinct(14)=1846.27302, null(14)=0, distinct(15)=1845.67052, null(15)=0, distinct(16)=1845.06427, null(16)=0, distinct(22)=5, null(22)=0, distinct(23)=5, null(23)=0, distinct(24)=1, null(24)=0, distinct(26)=1, null(26)=0, distinct(27)=0.996222107, null(27)=0]
@@ -979,7 +979,7 @@ project
       │         │    │    │    │    │    │    ├── stats: [rows=10000, distinct(10)=9920, null(10)=0, distinct(11)=9990, null(11)=0, distinct(12)=10000, null(12)=0, distinct(13)=25, null(13)=0, distinct(14)=10000, null(14)=0, distinct(15)=9967, null(15)=0, distinct(16)=9934, null(16)=0]
       │         │    │    │    │    │    │    ├── key: (10)
       │         │    │    │    │    │    │    └── fd: (10)-->(11-16)
-      │         │    │    │    │    │    ├── inner-join
+      │         │    │    │    │    │    ├── inner-join (hash)
       │         │    │    │    │    │    │    ├── save-table-name: q2_inner_join_18
       │         │    │    │    │    │    │    ├── columns: n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null)
       │         │    │    │    │    │    │    ├── stats: [rows=5, distinct(22)=5, null(22)=0, distinct(23)=5, null(23)=0, distinct(24)=1, null(24)=0, distinct(26)=1, null(26)=0, distinct(27)=0.996222107, null(27)=0]
@@ -1635,7 +1635,7 @@ limit
  │         │    │    ├── key columns: [9] = [18]
  │         │    │    ├── stats: [rows=247598.539, distinct(1)=29974.3087, null(1)=0, distinct(7)=1, null(7)=0, distinct(9)=195275.364, null(9)=0, distinct(10)=29974.3087, null(10)=0, distinct(13)=802, null(13)=0, distinct(16)=1, null(16)=0, distinct(18)=195275.364, null(18)=0, distinct(23)=197736.715, null(23)=0, distinct(24)=11, null(24)=0, distinct(28)=842, null(28)=0, distinct(23,24)=207215.808, null(23,24)=0]
  │         │    │    ├── fd: ()-->(7), (9)-->(10,13,16), (9)==(18), (18)==(9), (1)==(10), (10)==(1)
- │         │    │    ├── inner-join
+ │         │    │    ├── inner-join (hash)
  │         │    │    │    ├── save-table-name: q3_inner_join_6
  │         │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(char!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null)
  │         │    │    │    ├── stats: [rows=150572.001, distinct(1)=29974.3087, null(1)=0, distinct(7)=1, null(7)=0, distinct(9)=130014.955, null(9)=0, distinct(10)=29974.3087, null(10)=0, distinct(13)=802, null(13)=0, distinct(16)=1, null(16)=0]
@@ -1880,7 +1880,7 @@ sort
       ├── stats: [rows=5, distinct(6)=5, null(6)=0, distinct(26)=5, null(26)=0]
       ├── key: (6)
       ├── fd: (6)-->(26)
-      ├── semi-join
+      ├── semi-join (hash)
       │    ├── save-table-name: q4_semi_join_3
       │    ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null) o_orderpriority:6(char!null)
       │    ├── stats: [rows=57356.6085, distinct(1)=57356.6085, null(1)=0, distinct(5)=92, null(5)=0, distinct(6)=5, null(6)=0]
@@ -2043,17 +2043,17 @@ sort
       │    ├── save-table-name: q5_project_3
       │    ├── columns: column48:48(float) n_name:42(char!null)
       │    ├── stats: [rows=13283.5233, distinct(42)=5, null(42)=0, distinct(48)=12978.2343, null(48)=0]
-      │    ├── inner-join
+      │    ├── inner-join (hash)
       │    │    ├── save-table-name: q5_inner_join_4
       │    │    ├── columns: c_custkey:1(int!null) c_nationkey:4(int!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │    │    ├── stats: [rows=13283.5233, distinct(1)=13283.5233, null(1)=0, distinct(4)=5, null(4)=0, distinct(9)=12903.2494, null(9)=0, distinct(10)=13283.5233, null(10)=0, distinct(13)=365, null(13)=0, distinct(18)=12903.2494, null(18)=0, distinct(20)=1843.42933, null(20)=0, distinct(23)=12950.7961, null(23)=0, distinct(24)=11, null(24)=0, distinct(34)=1843.42933, null(34)=0, distinct(37)=5, null(37)=0, distinct(41)=5, null(41)=0, distinct(42)=5, null(42)=0, distinct(43)=1, null(43)=0, distinct(45)=1, null(45)=0, distinct(46)=0.996222107, null(46)=0, distinct(23,24)=12978.2343, null(23,24)=0]
       │    │    ├── fd: ()-->(46), (1)-->(4), (9)-->(10,13), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(4,41), (41)==(4,37), (20)==(34), (34)==(20), (9)==(18), (18)==(9), (1)==(10), (10)==(1), (4)==(37,41)
-      │    │    ├── inner-join
+      │    │    ├── inner-join (hash)
       │    │    │    ├── save-table-name: q5_inner_join_5
       │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │    │    │    ├── stats: [rows=329460.16, distinct(9)=227556.11, null(9)=0, distinct(10)=88927.0358, null(10)=0, distinct(13)=365, null(13)=0, distinct(18)=227556.11, null(18)=0, distinct(20)=1844.80594, null(20)=0, distinct(23)=260712.179, null(23)=0, distinct(24)=11, null(24)=0, distinct(34)=1844.80594, null(34)=0, distinct(37)=5, null(37)=0, distinct(41)=5, null(41)=0, distinct(42)=5, null(42)=0, distinct(43)=1, null(43)=0, distinct(45)=1, null(45)=0, distinct(46)=0.996222107, null(46)=0, distinct(23,24)=284545.02, null(23,24)=0]
       │    │    │    ├── fd: ()-->(46), (9)-->(10,13), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (20)==(34), (34)==(20), (9)==(18), (18)==(9)
-      │    │    │    ├── inner-join
+      │    │    │    ├── inner-join (hash)
       │    │    │    │    ├── save-table-name: q5_inner_join_6
       │    │    │    │    ├── columns: l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │    │    │    │    ├── stats: [rows=1209922.38, distinct(18)=835685.959, null(18)=0, distinct(20)=1844.80594, null(20)=0, distinct(23)=675298.21, null(23)=0, distinct(24)=11, null(24)=0, distinct(34)=1844.80594, null(34)=0, distinct(37)=5, null(37)=0, distinct(41)=5, null(41)=0, distinct(42)=5, null(42)=0, distinct(43)=1, null(43)=0, distinct(45)=1, null(45)=0, distinct(46)=0.996222107, null(46)=0, distinct(23,24)=1095803.99, null(23,24)=0]
@@ -2069,7 +2069,7 @@ sort
       │    │    │    │    │    ├── stats: [rows=2000, distinct(34)=1844.80594, null(34)=0, distinct(37)=5, null(37)=0, distinct(41)=5, null(41)=0, distinct(42)=5, null(42)=0, distinct(43)=1, null(43)=0, distinct(45)=1, null(45)=0, distinct(46)=0.996222107, null(46)=0]
       │    │    │    │    │    ├── key: (34)
       │    │    │    │    │    ├── fd: ()-->(46), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(41), (41)==(37)
-      │    │    │    │    │    ├── inner-join
+      │    │    │    │    │    ├── inner-join (hash)
       │    │    │    │    │    │    ├── save-table-name: q5_inner_join_9
       │    │    │    │    │    │    ├── columns: n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │    │    │    │    │    │    ├── stats: [rows=5, distinct(41)=5, null(41)=0, distinct(42)=5, null(42)=0, distinct(43)=1, null(43)=0, distinct(45)=1, null(45)=0, distinct(46)=0.996222107, null(46)=0]
@@ -2542,17 +2542,17 @@ sort
       │    ├── save-table-name: q7_project_3
       │    ├── columns: l_year:49(int) volume:50(float) n1.n_name:42(char!null) n2.n_name:46(char!null)
       │    ├── stats: [rows=588464.689, distinct(42)=24.9990099, null(42)=0, distinct(46)=24.9990099, null(46)=0, distinct(49)=731, null(49)=0, distinct(50)=499117.299, null(50)=0, distinct(42,46,49)=149096.222, null(42,46,49)=0]
-      │    ├── inner-join
+      │    ├── inner-join (hash)
       │    │    ├── save-table-name: q7_inner_join_4
       │    │    ├── columns: s_suppkey:1(int!null) s_nationkey:4(int!null) l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null) o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
       │    │    ├── stats: [rows=588464.689, distinct(1)=9920, null(1)=0, distinct(4)=24.9990099, null(4)=0, distinct(8)=458543.889, null(8)=0, distinct(10)=9920, null(10)=0, distinct(13)=420694.205, null(13)=0, distinct(14)=11, null(14)=0, distinct(18)=731, null(18)=0, distinct(24)=458543.889, null(24)=0, distinct(25)=99570.7584, null(25)=0, distinct(33)=99570.7584, null(33)=0, distinct(36)=24.9990099, null(36)=0, distinct(41)=24.9990099, null(41)=0, distinct(42)=24.9990099, null(42)=0, distinct(45)=24.9990099, null(45)=0, distinct(46)=24.9990099, null(46)=0, distinct(13,14)=499117.299, null(13,14)=0, distinct(18,42,46)=149096.222, null(18,42,46)=0]
       │    │    ├── fd: (1)-->(4), (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25), (8)==(24), (24)==(8), (1)==(10), (10)==(1), (4)==(41), (41)==(4)
-      │    │    ├── inner-join
+      │    │    ├── inner-join (hash)
       │    │    │    ├── save-table-name: q7_inner_join_5
       │    │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null) o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
       │    │    │    ├── stats: [rows=14593924.3, distinct(8)=1128319.56, null(8)=0, distinct(10)=9920, null(10)=0, distinct(13)=824798.212, null(13)=0, distinct(14)=11, null(14)=0, distinct(18)=731, null(18)=0, distinct(24)=1128319.56, null(24)=0, distinct(25)=99846, null(25)=0, distinct(33)=99846, null(33)=0, distinct(36)=24.9990099, null(36)=0, distinct(41)=24.9990099, null(41)=0, distinct(42)=24.9990099, null(42)=0, distinct(45)=24.9990099, null(45)=0, distinct(46)=24.9990099, null(46)=0, distinct(13,14)=1736304.41, null(13,14)=0, distinct(18,42,46)=152291.667, null(18,42,46)=0]
       │    │    │    ├── fd: (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25), (8)==(24), (24)==(8)
-      │    │    │    ├── inner-join
+      │    │    │    ├── inner-join (hash)
       │    │    │    │    ├── save-table-name: q7_inner_join_6
       │    │    │    │    ├── columns: o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
       │    │    │    │    ├── stats: [rows=12602090.7, distinct(24)=1499663.18, null(24)=0, distinct(25)=99846, null(25)=0, distinct(33)=99846, null(33)=0, distinct(36)=24.9990099, null(36)=0, distinct(41)=24.9990099, null(41)=0, distinct(42)=24.9990099, null(42)=0, distinct(45)=24.9990099, null(45)=0, distinct(46)=24.9990099, null(46)=0, distinct(42,46)=208.333333, null(42,46)=0]
@@ -2586,7 +2586,7 @@ sort
       │    │    │    │    │    │    ├── key: (41,45)
       │    │    │    │    │    │    ├── fd: (41)-->(42), (45)-->(46)
       │    │    │    │    │    │    ├── ordering: +45
-      │    │    │    │    │    │    └── inner-join
+      │    │    │    │    │    │    └── inner-join (hash)
       │    │    │    │    │    │         ├── save-table-name: q7_inner_join_11
       │    │    │    │    │    │         ├── columns: n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
       │    │    │    │    │    │         ├── stats: [rows=208.333333, distinct(41)=24.9990099, null(41)=0, distinct(42)=24.9990099, null(42)=0, distinct(45)=24.9990099, null(45)=0, distinct(46)=24.9990099, null(46)=0, distinct(42,46)=208.333333, null(42,46)=0]
@@ -2982,17 +2982,17 @@ sort
       │    │    │    ├── save-table-name: q8_project_5
       │    │    │    ├── columns: o_year:61(int) volume:62(float) n2.n_name:55(char!null)
       │    │    │    ├── stats: [rows=2913.68612, distinct(55)=24.9055527, null(55)=0, distinct(61)=717.421185, null(61)=0, distinct(62)=2901.67246, null(62)=0, distinct(55,62)=2901.89538, null(55,62)=0]
-      │    │    │    ├── inner-join
+      │    │    │    ├── inner-join (hash)
       │    │    │    │    ├── save-table-name: q8_inner_join_6
       │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(varchar!null) s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
       │    │    │    │    ├── stats: [rows=2913.68612, distinct(1)=1333.31636, null(1)=0, distinct(5)=1, null(5)=0, distinct(10)=2524.78118, null(10)=0, distinct(13)=24.9055527, null(13)=0, distinct(17)=2896.85285, null(17)=0, distinct(18)=1333.31636, null(18)=0, distinct(19)=2524.78118, null(19)=0, distinct(22)=2899.70087, null(22)=0, distinct(23)=11, null(23)=0, distinct(33)=2896.85285, null(33)=0, distinct(34)=2870.3294, null(34)=0, distinct(37)=717.421185, null(37)=0, distinct(42)=2870.3294, null(42)=0, distinct(45)=24.9055527, null(45)=0, distinct(50)=24.9055527, null(50)=0, distinct(52)=1, null(52)=0, distinct(54)=24.9055527, null(54)=0, distinct(55)=24.9055527, null(55)=0, distinct(58)=1, null(58)=0, distinct(59)=1, null(59)=0, distinct(22,23)=2901.67246, null(22,23)=0, distinct(22,23,55)=2901.89538, null(22,23,55)=0]
       │    │    │    │    ├── fd: ()-->(5,59), (10)-->(13), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (10)==(19), (19)==(10), (13)==(54), (54)==(13), (1)==(18), (18)==(1)
-      │    │    │    │    ├── inner-join
+      │    │    │    │    ├── inner-join (hash)
       │    │    │    │    │    ├── save-table-name: q8_inner_join_7
       │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
       │    │    │    │    │    ├── stats: [rows=366056.156, distinct(10)=9920, null(10)=0, distinct(13)=24.9055527, null(13)=0, distinct(17)=251065.484, null(17)=0, distinct(18)=167511.137, null(18)=0, distinct(19)=9920, null(19)=0, distinct(22)=302359.731, null(22)=0, distinct(23)=11, null(23)=0, distinct(33)=251065.484, null(33)=0, distinct(34)=96910.9844, null(34)=0, distinct(37)=731, null(37)=0, distinct(42)=96910.9844, null(42)=0, distinct(45)=24.9055527, null(45)=0, distinct(50)=24.9055527, null(50)=0, distinct(52)=1, null(52)=0, distinct(54)=24.9055527, null(54)=0, distinct(55)=24.9055527, null(55)=0, distinct(58)=1, null(58)=0, distinct(59)=1, null(59)=0, distinct(22,23)=352104.347, null(22,23)=0, distinct(22,23,55)=358774.904, null(22,23,55)=0]
       │    │    │    │    │    ├── fd: ()-->(59), (10)-->(13), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (10)==(19), (19)==(10), (13)==(54), (54)==(13)
-      │    │    │    │    │    ├── inner-join
+      │    │    │    │    │    ├── inner-join (hash)
       │    │    │    │    │    │    ├── save-table-name: q8_inner_join_8
       │    │    │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
       │    │    │    │    │    │    ├── stats: [rows=9078192.67, distinct(17)=452871.085, null(17)=0, distinct(18)=199241, null(18)=0, distinct(19)=9920, null(19)=0, distinct(22)=925903.867, null(22)=0, distinct(23)=11, null(23)=0, distinct(33)=452871.085, null(33)=0, distinct(34)=99413.0082, null(34)=0, distinct(37)=731, null(37)=0, distinct(42)=99413.0082, null(42)=0, distinct(45)=24.9055527, null(45)=0, distinct(50)=24.9055527, null(50)=0, distinct(52)=1, null(52)=0, distinct(54)=24.9055527, null(54)=0, distinct(55)=24.9055527, null(55)=0, distinct(58)=1, null(58)=0, distinct(59)=1, null(59)=0, distinct(22,23)=4679096.11, null(22,23)=0, distinct(22,23,55)=9078192.67, null(22,23,55)=0]
@@ -3001,13 +3001,13 @@ sort
       │    │    │    │    │    │    │    ├── save-table-name: q8_scan_9
       │    │    │    │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null)
       │    │    │    │    │    │    │    └── stats: [rows=6001215, distinct(17)=1527270, null(17)=0, distinct(18)=199241, null(18)=0, distinct(19)=9920, null(19)=0, distinct(22)=925955, null(22)=0, distinct(23)=11, null(23)=0, distinct(22,23)=6001215, null(22,23)=0]
-      │    │    │    │    │    │    ├── inner-join
+      │    │    │    │    │    │    ├── inner-join (hash)
       │    │    │    │    │    │    │    ├── save-table-name: q8_inner_join_10
       │    │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
       │    │    │    │    │    │    │    ├── stats: [rows=2310340.71, distinct(33)=452871.085, null(33)=0, distinct(34)=99413.0082, null(34)=0, distinct(37)=731, null(37)=0, distinct(42)=99413.0082, null(42)=0, distinct(45)=24.9055527, null(45)=0, distinct(50)=24.9055527, null(50)=0, distinct(52)=1, null(52)=0, distinct(54)=24.9055527, null(54)=0, distinct(55)=24.9055527, null(55)=0, distinct(58)=1, null(58)=0, distinct(59)=1, null(59)=0]
       │    │    │    │    │    │    │    ├── key: (33,54)
       │    │    │    │    │    │    │    ├── fd: ()-->(59), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34)
-      │    │    │    │    │    │    │    ├── inner-join
+      │    │    │    │    │    │    │    ├── inner-join (hash)
       │    │    │    │    │    │    │    │    ├── save-table-name: q8_inner_join_11
       │    │    │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
       │    │    │    │    │    │    │    │    ├── stats: [rows=750000, distinct(42)=147944.303, null(42)=0, distinct(45)=24.9055527, null(45)=0, distinct(50)=24.9055527, null(50)=0, distinct(52)=1, null(52)=0, distinct(54)=24.9055527, null(54)=0, distinct(55)=24.9055527, null(55)=0, distinct(58)=1, null(58)=0, distinct(59)=1, null(59)=0]
@@ -3547,12 +3547,12 @@ sort
       │    │    ├── key columns: [18] = [1]
       │    │    ├── stats: [rows=2406.66318, distinct(1)=2357.09397, null(1)=0, distinct(2)=2363.75844, null(2)=0, distinct(10)=1520.84987, null(10)=0, distinct(13)=25, null(13)=0, distinct(17)=1508.01915, null(17)=0, distinct(18)=2357.09397, null(18)=0, distinct(19)=1520.84987, null(19)=0, distinct(21)=50, null(21)=0, distinct(22)=1507.67014, null(22)=0, distinct(23)=11, null(23)=0, distinct(33)=1508.01915, null(33)=0, distinct(34)=1443.61652, null(34)=0, distinct(36)=1503.89598, null(36)=0, distinct(38)=1508.01915, null(38)=0, distinct(42)=1208.19298, null(42)=0, distinct(47)=25, null(47)=0, distinct(48)=25, null(48)=0, distinct(42,48)=1500.68104, null(42,48)=0, distinct(21-23,36)=1508.01915, null(21-23,36)=0]
       │    │    ├── fd: (1)-->(2), (10)-->(13), (33,34)-->(36), (38)-->(42), (47)-->(48), (19)==(10,34), (34)==(10,19), (18)==(1,33), (33)==(1,18), (17)==(38), (38)==(17), (10)==(19,34), (13)==(47), (47)==(13), (1)==(18,33)
-      │    │    ├── inner-join
+      │    │    ├── inner-join (hash)
       │    │    │    ├── save-table-name: q9_inner_join_5
       │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(char!null)
       │    │    │    ├── stats: [rows=2404.93063, distinct(10)=2404.93063, null(10)=0, distinct(13)=25, null(13)=0, distinct(17)=2357.09397, null(17)=0, distinct(18)=2357.09397, null(18)=0, distinct(19)=2404.93063, null(19)=0, distinct(21)=50, null(21)=0, distinct(22)=2355.81122, null(22)=0, distinct(23)=11, null(23)=0, distinct(33)=2357.09397, null(33)=0, distinct(34)=2135.61418, null(34)=0, distinct(36)=2342.00113, null(36)=0, distinct(38)=2357.09397, null(38)=0, distinct(42)=1520.49036, null(42)=0, distinct(47)=25, null(47)=0, distinct(48)=25, null(48)=0, distinct(42,48)=2330.3251, null(42,48)=0, distinct(21-23,36)=2357.09397, null(21-23,36)=0]
       │    │    │    ├── fd: (10)-->(13), (33,34)-->(36), (38)-->(42), (47)-->(48), (19)==(10,34), (34)==(10,19), (18)==(33), (33)==(18), (17)==(38), (38)==(17), (10)==(19,34), (13)==(47), (47)==(13)
-      │    │    │    ├── inner-join
+      │    │    │    ├── inner-join (hash)
       │    │    │    │    ├── save-table-name: q9_inner_join_6
       │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(char!null)
       │    │    │    │    ├── stats: [rows=59642.2797, distinct(17)=59642.2797, null(17)=0, distinct(18)=59642.2797, null(18)=0, distinct(19)=9920, null(19)=0, distinct(21)=50, null(21)=0, distinct(22)=58063.808, null(22)=0, distinct(23)=11, null(23)=0, distinct(33)=59642.2797, null(33)=0, distinct(34)=9920, null(34)=0, distinct(36)=45145.1912, null(36)=0, distinct(38)=59642.2797, null(38)=0, distinct(42)=2406, null(42)=0, distinct(47)=25, null(47)=0, distinct(48)=25, null(48)=0, distinct(42,48)=37953.5881, null(42,48)=0, distinct(21-23,36)=59642.2797, null(21-23,36)=0]
@@ -3934,12 +3934,12 @@ limit
  │         │    ├── columns: column38:38(float) c_custkey:1(int!null) c_name:2(varchar!null) c_address:3(varchar!null) c_phone:5(char!null) c_acctbal:6(float!null) c_comment:8(varchar!null) n_name:35(char!null)
  │         │    ├── stats: [rows=95043.9237, distinct(1)=44261.346, null(1)=0, distinct(2)=70400.4013, null(2)=0, distinct(3)=70392.0136, null(3)=0, distinct(5)=70400.4013, null(5)=0, distinct(6)=69087.4422, null(6)=0, distinct(8)=70309.9705, null(8)=0, distinct(35)=25, null(35)=0, distinct(38)=91855.5595, null(38)=0]
  │         │    ├── fd: (1)-->(2,3,5,6,8,35)
- │         │    ├── inner-join
+ │         │    ├── inner-join (hash)
  │         │    │    ├── save-table-name: q10_inner_join_5
  │         │    │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) c_address:3(varchar!null) c_nationkey:4(int!null) c_phone:5(char!null) c_acctbal:6(float!null) c_comment:8(varchar!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(char!null) n_nationkey:34(int!null) n_name:35(char!null)
  │         │    │    ├── stats: [rows=95043.9237, distinct(1)=44261.346, null(1)=0, distinct(2)=70400.4013, null(2)=0, distinct(3)=70392.0136, null(3)=0, distinct(4)=25, null(4)=0, distinct(5)=70400.4013, null(5)=0, distinct(6)=69087.4422, null(6)=0, distinct(8)=70309.9705, null(8)=0, distinct(9)=46418.8849, null(9)=0, distinct(10)=44261.346, null(10)=0, distinct(13)=92, null(13)=0, distinct(18)=46418.8849, null(18)=0, distinct(23)=89640.0074, null(23)=0, distinct(24)=11, null(24)=0, distinct(26)=1, null(26)=0, distinct(34)=25, null(34)=0, distinct(35)=25, null(35)=0, distinct(23,24)=91855.5595, null(23,24)=0]
  │         │    │    ├── fd: ()-->(26), (1)-->(2-6,8), (9)-->(10,13), (34)-->(35), (9)==(18), (18)==(9), (1)==(10), (10)==(1), (4)==(34), (34)==(4)
- │         │    │    ├── inner-join
+ │         │    │    ├── inner-join (hash)
  │         │    │    │    ├── save-table-name: q10_inner_join_6
  │         │    │    │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) c_address:3(varchar!null) c_nationkey:4(int!null) c_phone:5(char!null) c_acctbal:6(float!null) c_comment:8(varchar!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(char!null)
  │         │    │    │    ├── stats: [rows=95043.9237, distinct(1)=39003.2512, null(1)=0, distinct(2)=70400.564, null(2)=0, distinct(3)=70392.1763, null(3)=0, distinct(4)=25, null(4)=0, distinct(5)=70400.564, null(5)=0, distinct(6)=69087.5981, null(6)=0, distinct(8)=70310.1327, null(8)=0, distinct(9)=46418.9433, null(9)=0, distinct(10)=39003.2512, null(10)=0, distinct(13)=92, null(13)=0, distinct(18)=46418.9433, null(18)=0, distinct(23)=58495.4099, null(23)=0, distinct(24)=11, null(24)=0, distinct(26)=1, null(26)=0]
@@ -4843,7 +4843,7 @@ sort
       │    ├── stats: [rows=148813, distinct(1)=148813, null(1)=0, distinct(18)=148813, null(18)=0]
       │    ├── key: (1)
       │    ├── fd: (1)-->(18)
-      │    ├── right-join
+      │    ├── right-join (hash)
       │    │    ├── save-table-name: q13_right_join_4
       │    │    ├── columns: c_custkey:1(int!null) o_orderkey:9(int) o_custkey:10(int) o_comment:17(varchar)
       │    │    ├── stats: [rows=503988.227, distinct(1)=148813, null(1)=0, distinct(9)=317522.248, null(9)=0, distinct(10)=99620.1148, null(10)=0, distinct(17)=317522.248, null(17)=0]
@@ -4997,7 +4997,7 @@ project
  │    │    ├── save-table-name: q14_project_3
  │    │    ├── columns: column26:26(float) column28:28(float)
  │    │    ├── stats: [rows=71544.85, distinct(26)=71544.85, null(26)=0, distinct(28)=45153.1015, null(28)=0]
- │    │    ├── inner-join
+ │    │    ├── inner-join (hash)
  │    │    │    ├── save-table-name: q14_inner_join_4
  │    │    │    ├── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null) p_partkey:17(int!null) p_type:21(varchar!null)
  │    │    │    ├── stats: [rows=71544.85, distinct(2)=60216.5699, null(2)=0, distinct(6)=44533.9293, null(6)=0, distinct(7)=11, null(7)=0, distinct(11)=30, null(11)=0, distinct(17)=60216.5699, null(17)=0, distinct(21)=150, null(21)=0, distinct(6,7)=45153.1015, null(6,7)=0, distinct(6,7,21)=71544.85, null(6,7,21)=0]
@@ -5458,7 +5458,7 @@ sort
       ├── stats: [rows=3489.49147, distinct(9)=8.33333333, null(9)=0, distinct(10)=150, null(10)=0, distinct(11)=8, null(11)=0, distinct(22)=3489.49147, null(22)=0, distinct(9-11)=3489.49147, null(9-11)=0]
       ├── key: (9-11)
       ├── fd: (9-11)-->(22)
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── save-table-name: q16_inner_join_3
       │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null) p_partkey:6(int!null) p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null)
       │    ├── stats: [rows=14276.4012, distinct(1)=3555.43444, null(1)=0, distinct(2)=7567.69437, null(2)=0, distinct(6)=3555.43444, null(6)=0, distinct(9)=8.33333333, null(9)=0, distinct(10)=150, null(10)=0, distinct(11)=8, null(11)=0, distinct(9-11)=3489.49147, null(9-11)=0]
@@ -5951,7 +5951,7 @@ limit
  │         ├── stats: [rows=1471426.19, distinct(1)=1471426.19, null(1)=0, distinct(2)=1471426.19, null(2)=0, distinct(9)=1471426.19, null(9)=0, distinct(12)=1471426.19, null(12)=0, distinct(13)=1471426.19, null(13)=0, distinct(51)=1471426.19, null(51)=0]
  │         ├── key: (9)
  │         ├── fd: (1)-->(2), (9)-->(1,2,12,13,51)
- │         ├── inner-join
+ │         ├── inner-join (hash)
  │         │    ├── save-table-name: q18_inner_join_4
  │         │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_quantity:22(float!null)
  │         │    ├── stats: [rows=5941074.68, distinct(1)=99846, null(1)=0, distinct(2)=150000, null(2)=0, distinct(9)=1471426.19, null(9)=0, distinct(10)=99846, null(10)=0, distinct(12)=1410750.85, null(12)=0, distinct(13)=2406, null(13)=0, distinct(18)=1471426.19, null(18)=0, distinct(22)=50, null(22)=0]
@@ -5960,7 +5960,7 @@ limit
  │         │    │    ├── save-table-name: q18_scan_5
  │         │    │    ├── columns: l_orderkey:18(int!null) l_quantity:22(float!null)
  │         │    │    └── stats: [rows=6001215, distinct(18)=1527270, null(18)=0, distinct(22)=50, null(22)=0]
- │         │    ├── inner-join
+ │         │    ├── inner-join (hash)
  │         │    │    ├── save-table-name: q18_inner_join_6
  │         │    │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null)
  │         │    │    ├── stats: [rows=1511964.68, distinct(1)=99846, null(1)=0, distinct(2)=149993.712, null(2)=0, distinct(9)=952566.744, null(9)=0, distinct(10)=99846, null(10)=0, distinct(12)=941447.245, null(12)=0, distinct(13)=2406, null(13)=0]
@@ -6262,7 +6262,7 @@ scalar-group-by
  │    ├── save-table-name: q19_project_2
  │    ├── columns: column26:26(float)
  │    ├── stats: [rows=53556.554, distinct(26)=50346.0112, null(26)=0]
- │    ├── inner-join
+ │    ├── inner-join (hash)
  │    │    ├── save-table-name: q19_inner_join_3
  │    │    ├── columns: l_partkey:2(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipinstruct:14(char!null) l_shipmode:15(char!null) p_partkey:17(int!null) p_brand:20(char!null) p_size:22(int!null) p_container:23(char!null)
  │    │    ├── stats: [rows=53556.554, distinct(2)=53556.554, null(2)=0, distinct(5)=50, null(5)=0, distinct(6)=49693.434, null(6)=0, distinct(7)=11, null(7)=0, distinct(14)=1, null(14)=0, distinct(15)=2, null(15)=0, distinct(17)=53556.554, null(17)=0, distinct(20)=25, null(20)=0, distinct(22)=16.6666667, null(22)=0, distinct(23)=40, null(23)=0, distinct(6,7)=50346.0112, null(6,7)=0]
@@ -6470,13 +6470,13 @@ sort
       ├── save-table-name: q20_project_2
       ├── columns: s_name:2(char!null) s_address:3(varchar!null)
       ├── stats: [rows=400, distinct(2)=399.991883, null(2)=0, distinct(3)=400, null(3)=0]
-      └── inner-join
+      └── inner-join (hash)
            ├── save-table-name: q20_inner_join_3
            ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_nationkey:4(int!null) n_nationkey:8(int!null) n_name:9(char!null)
            ├── stats: [rows=400, distinct(1)=399.934613, null(1)=0, distinct(2)=399.991883, null(2)=0, distinct(3)=400, null(3)=0, distinct(4)=1, null(4)=0, distinct(8)=1, null(8)=0, distinct(9)=1, null(9)=0]
            ├── key: (1)
            ├── fd: ()-->(9), (1)-->(2-4), (4)==(8), (8)==(4)
-           ├── semi-join
+           ├── semi-join (hash)
            │    ├── save-table-name: q20_semi_join_4
            │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_nationkey:4(int!null)
            │    ├── stats: [rows=10000, distinct(1)=9920, null(1)=0, distinct(2)=9990, null(2)=0, distinct(3)=10000, null(3)=0, distinct(4)=25, null(4)=0]
@@ -6488,7 +6488,7 @@ sort
            │    │    ├── stats: [rows=10000, distinct(1)=9920, null(1)=0, distinct(2)=9990, null(2)=0, distinct(3)=10000, null(3)=0, distinct(4)=25, null(4)=0]
            │    │    ├── key: (1)
            │    │    └── fd: (1)-->(2-4)
-           │    ├── semi-join
+           │    ├── semi-join (hash)
            │    │    ├── save-table-name: q20_semi_join_6
            │    │    ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null)
            │    │    ├── stats: [rows=266666.667, distinct(12)=160127.162, null(12)=0, distinct(13)=9920, null(13)=0]
@@ -6511,7 +6511,7 @@ sort
            │    │    │         │    ├── stats: [rows=800000, distinct(12)=199241, null(12)=0, distinct(13)=9920, null(13)=0, distinct(14)=800000, null(14)=0, distinct(42)=800000, null(42)=0, distinct(12,13)=800000, null(12,13)=0]
            │    │    │         │    ├── key: (12,13)
            │    │    │         │    ├── fd: (12,13)-->(14,42)
-           │    │    │         │    ├── right-join
+           │    │    │         │    ├── right-join (hash)
            │    │    │         │    │    ├── save-table-name: q20_right_join_10
            │    │    │         │    │    ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null) ps_availqty:14(int!null) l_partkey:27(int) l_suppkey:28(int) l_quantity:30(float) l_shipdate:36(date)
            │    │    │         │    │    ├── stats: [rows=800000, distinct(12)=199241, null(12)=0, distinct(13)=9920, null(13)=0, distinct(14)=9920, null(14)=0, distinct(27)=350.99288, null(27)=799649.007, distinct(28)=350.99288, null(28)=799649.007, distinct(30)=49.9553024, null(30)=799649.007, distinct(36)=225.470934, null(36)=799649.007, distinct(12,13)=800000, null(12,13)=0]
@@ -6859,7 +6859,7 @@ limit
  │         │    ├── key columns: [8] = [24]
  │         │    ├── stats: [rows=33144.2984, distinct(1)=9920, null(1)=0, distinct(2)=9628.02122, null(2)=0, distinct(4)=1, null(4)=0, distinct(8)=32069.6931, null(8)=0, distinct(10)=9920, null(10)=0, distinct(19)=2465.99641, null(19)=0, distinct(20)=2553.9941, null(20)=0, distinct(24)=32069.6931, null(24)=0, distinct(26)=1, null(26)=0, distinct(33)=1, null(33)=0, distinct(34)=1, null(34)=0]
  │         │    ├── fd: ()-->(26,34), (1)-->(2,4), (8)==(24), (24)==(8), (1)==(10), (10)==(1), (4)==(33), (33)==(4)
- │         │    ├── inner-join
+ │         │    ├── inner-join (hash)
  │         │    │    ├── save-table-name: q21_inner_join_5
  │         │    │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_nationkey:4(int!null) l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null) n_nationkey:33(int!null) n_name:34(char!null)
  │         │    │    ├── stats: [rows=80661.4919, distinct(1)=9920, null(1)=0, distinct(2)=9986.88851, null(2)=0, distinct(4)=1, null(4)=0, distinct(8)=78046.2829, null(8)=0, distinct(10)=9920, null(10)=0, distinct(19)=2466, null(19)=0, distinct(20)=2554, null(20)=0, distinct(33)=1, null(33)=0, distinct(34)=1, null(34)=0]

--- a/pkg/sql/opt/memo/testdata/typing
+++ b/pkg/sql/opt/memo/testdata/typing
@@ -370,7 +370,7 @@ project
  │    ├── group-by
  │    │    ├── columns: a.x:1(int!null) y:2(int) max:6(string)
  │    │    ├── grouping columns: a.x:1(int!null)
- │    │    ├── inner-join
+ │    │    ├── inner-join (hash)
  │    │    │    ├── columns: a.x:1(int!null) y:2(int!null) b.x:4(string!null) column7:7(int!null)
  │    │    │    ├── scan a
  │    │    │    │    └── columns: a.x:1(int!null) y:2(int)
@@ -401,7 +401,7 @@ project
  ├── group-by
  │    ├── columns: true_agg:8(bool) rownum:10(int!null)
  │    ├── grouping columns: rownum:10(int!null)
- │    ├── left-join
+ │    ├── left-join (hash)
  │    │    ├── columns: expr:3(int) true:7(bool) rownum:10(int!null)
  │    │    ├── ordinality
  │    │    │    ├── columns: expr:3(int) rownum:10(int!null)

--- a/pkg/sql/opt/norm/testdata/rules/combo
+++ b/pkg/sql/opt/norm/testdata/rules/combo
@@ -25,7 +25,7 @@ Initial expression
 ================================================================================
   project
    ├── columns: s:4(string)
-   └── inner-join
+   └── inner-join (hash)
         ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
         ├── key: (1,6)
         ├── fd: (1)-->(2-5), (3,4)~~>(1,2,5), (6)-->(7)
@@ -45,7 +45,7 @@ NormalizeCmpPlusConst
 ================================================================================
    project
     ├── columns: s:4(string)
-    └── inner-join
+    └── inner-join (hash)
   -      ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
   +      ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
          ├── key: (1,6)
@@ -67,7 +67,7 @@ FoldBinary
 ================================================================================
    project
     ├── columns: s:4(string)
-    └── inner-join
+    └── inner-join (hash)
          ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
          ├── key: (1,6)
   -      ├── fd: (1)-->(2-5), (3,4)~~>(1,2,5), (6)-->(7)
@@ -89,7 +89,7 @@ SimplifyJoinFilters
 ================================================================================
    project
     ├── columns: s:4(string)
-    └── inner-join
+    └── inner-join (hash)
          ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
   -      ├── key: (1,6)
   -      ├── fd: ()-->(2), (1)-->(3-5), (3,4)~~>(1,5), (6)-->(7)
@@ -113,7 +113,7 @@ PushFilterIntoJoinLeft
 ================================================================================
    project
     ├── columns: s:4(string)
-    └── inner-join
+    └── inner-join (hash)
          ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
          ├── key: (6)
          ├── fd: ()-->(2), (1)-->(3-5), (3,4)~~>(1,5), (6)-->(7), (1)==(6), (6)==(1)
@@ -144,7 +144,7 @@ PruneJoinLeftCols
 ================================================================================
    project
     ├── columns: s:4(string)
-    └── inner-join
+    └── inner-join (hash)
   -      ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
   +      ├── columns: k:1(int!null) i:2(int!null) s:4(string) x:6(int!null) y:7(int)
          ├── key: (6)
@@ -185,7 +185,7 @@ PruneSelectCols
 ================================================================================
    project
     ├── columns: s:4(string)
-    └── inner-join
+    └── inner-join (hash)
          ├── columns: k:1(int!null) i:2(int!null) s:4(string) x:6(int!null) y:7(int)
          ├── key: (6)
          ├── fd: ()-->(2), (1)-->(4), (6)-->(7), (1)==(6), (6)==(1)
@@ -219,7 +219,7 @@ EliminateProject
 ================================================================================
    project
     ├── columns: s:4(string)
-    └── inner-join
+    └── inner-join (hash)
          ├── columns: k:1(int!null) i:2(int!null) s:4(string) x:6(int!null) y:7(int)
          ├── key: (6)
          ├── fd: ()-->(2), (1)-->(4), (6)-->(7), (1)==(6), (6)==(1)
@@ -256,7 +256,7 @@ PruneJoinRightCols
 ================================================================================
    project
     ├── columns: s:4(string)
-    └── inner-join
+    └── inner-join (hash)
   -      ├── columns: k:1(int!null) i:2(int!null) s:4(string) x:6(int!null) y:7(int)
   +      ├── columns: k:1(int!null) i:2(int!null) s:4(string) x:6(int!null)
          ├── key: (6)
@@ -298,7 +298,7 @@ CommuteJoin
 ================================================================================
    project
     ├── columns: s:4(string)
-    └── inner-join
+    └── inner-join (hash)
          ├── columns: k:1(int!null) i:2(int!null) s:4(string) x:6(int!null)
          ├── key: (6)
          ├── fd: ()-->(2), (1)-->(4), (1)==(6), (6)==(1)
@@ -326,7 +326,7 @@ GenerateMergeJoins
 ================================================================================
    project
     ├── columns: s:4(string)
-  - └── inner-join
+  - └── inner-join (hash)
   + └── inner-join (merge)
          ├── columns: k:1(int!null) i:2(int!null) s:4(string) x:6(int!null)
   +      ├── left ordering: +1
@@ -664,7 +664,7 @@ DecorrelateJoin
     ├── fd: (1)-->(2-5), (3,4)~~>(1,2,5)
   - ├── semi-join-apply
   - │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
-  + ├── semi-join
+  + ├── semi-join (hash)
   + │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
     │    ├── key: (1)
     │    ├── fd: (1)-->(2-5), (3,4)~~>(1,2,5)
@@ -684,11 +684,11 @@ EliminateSelect
   Cost: 2180.05
 ================================================================================
   -select
-  +semi-join
+  +semi-join (hash)
     ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
     ├── key: (1)
     ├── fd: (1)-->(2-5), (3,4)~~>(1,2,5)
-  - ├── semi-join
+  - ├── semi-join (hash)
   + ├── scan a
     │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
     │    ├── key: (1)
@@ -727,7 +727,7 @@ GenerateLookupJoins (no changes)
 Final best expression
   Cost: 2180.05
 ================================================================================
-  semi-join
+  semi-join (hash)
    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
    ├── key: (1)
    ├── fd: (1)-->(2-5), (3,4)~~>(1,2,5)
@@ -1708,7 +1708,7 @@ DecorrelateJoin
     │    │    │    │    ├── project
     │    │    │    │    │    ├── columns: x:1(int!null) notnull:9(bool)
   - │    │    │    │    │    └── left-join-apply
-  + │    │    │    │    │    └── left-join
+  + │    │    │    │    │    └── left-join (hash)
     │    │    │    │    │         ├── columns: x:1(int!null) k:3(int) i:4(int) notnull:9(bool)
     │    │    │    │    │         ├── key: (1,3)
   - │    │    │    │    │         ├── fd: (1,3)-->(4,9)
@@ -1763,7 +1763,7 @@ PushFilterIntoJoinRight
     │    │    │    │    ├── fd: (1)-->(10)
     │    │    │    │    ├── project
     │    │    │    │    │    ├── columns: x:1(int!null) notnull:9(bool)
-    │    │    │    │    │    └── left-join
+    │    │    │    │    │    └── left-join (hash)
     │    │    │    │    │         ├── columns: x:1(int!null) k:3(int) i:4(int) notnull:9(bool)
     │    │    │    │    │         ├── key: (1,3)
     │    │    │    │    │         ├── fd: (3)-->(4), (4)~~>(9), (1,3)-->(9)
@@ -1831,7 +1831,7 @@ PushSelectIntoProject
     │    │    │    │    ├── fd: (1)-->(10)
     │    │    │    │    ├── project
     │    │    │    │    │    ├── columns: x:1(int!null) notnull:9(bool)
-    │    │    │    │    │    └── left-join
+    │    │    │    │    │    └── left-join (hash)
     │    │    │    │    │         ├── columns: x:1(int!null) k:3(int) i:4(int) notnull:9(bool)
     │    │    │    │    │         ├── key: (1,3)
     │    │    │    │    │         ├── fd: (3)-->(4), (4)~~>(9), (1,3)-->(9)
@@ -1899,7 +1899,7 @@ EliminateSelect
     │    │    │    │    ├── fd: (1)-->(10)
     │    │    │    │    ├── project
     │    │    │    │    │    ├── columns: x:1(int!null) notnull:9(bool)
-    │    │    │    │    │    └── left-join
+    │    │    │    │    │    └── left-join (hash)
     │    │    │    │    │         ├── columns: x:1(int!null) k:3(int) i:4(int) notnull:9(bool)
     │    │    │    │    │         ├── key: (1,3)
     │    │    │    │    │         ├── fd: (3)-->(4), (4)~~>(9), (1,3)-->(9)
@@ -1974,7 +1974,7 @@ PruneJoinRightCols
     │    │    │    │    ├── fd: (1)-->(10)
     │    │    │    │    ├── project
     │    │    │    │    │    ├── columns: x:1(int!null) notnull:9(bool)
-    │    │    │    │    │    └── left-join
+    │    │    │    │    │    └── left-join (hash)
   - │    │    │    │    │         ├── columns: x:1(int!null) k:3(int) i:4(int) notnull:9(bool)
   + │    │    │    │    │         ├── columns: x:1(int!null) k:3(int) notnull:9(bool)
     │    │    │    │    │         ├── key: (1,3)
@@ -2037,7 +2037,7 @@ EliminateGroupByProject
     │    │    │    │    ├── fd: (1)-->(10)
   - │    │    │    │    ├── project
   - │    │    │    │    │    ├── columns: x:1(int!null) notnull:9(bool)
-  - │    │    │    │    │    └── left-join
+  - │    │    │    │    │    └── left-join (hash)
   - │    │    │    │    │         ├── columns: x:1(int!null) k:3(int) notnull:9(bool)
   - │    │    │    │    │         ├── key: (1,3)
   - │    │    │    │    │         ├── fd: (3)-->(9)
@@ -2062,7 +2062,7 @@ EliminateGroupByProject
   - │    │    │    │    │         │         └── i IS NOT NULL [type=bool, outer=(4)]
   - │    │    │    │    │         └── filters
   - │    │    │    │    │              └── k = x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
-  + │    │    │    │    ├── left-join
+  + │    │    │    │    ├── left-join (hash)
   + │    │    │    │    │    ├── columns: x:1(int!null) k:3(int) notnull:9(bool)
   + │    │    │    │    │    ├── key: (1,3)
   + │    │    │    │    │    ├── fd: (3)-->(9)
@@ -2121,10 +2121,10 @@ EliminateSelect
   - │    │    │    │    ├── grouping columns: x:1(int!null)
   - │    │    │    │    ├── key: (1)
   - │    │    │    │    ├── fd: (1)-->(10)
-  - │    │    │    │    ├── left-join
+  - │    │    │    │    ├── left-join (hash)
   - │    │    │    │    │    ├── columns: x:1(int!null) k:3(int) notnull:9(bool)
   - │    │    │    │    │    ├── key: (1,3)
-  + │    │    │    ├── left-join
+  + │    │    │    ├── left-join (hash)
   + │    │    │    │    ├── columns: x:1(int!null) k:3(int) notnull:9(bool)
   + │    │    │    │    ├── key: (1,3)
   + │    │    │    │    ├── fd: (3)-->(9)
@@ -2203,11 +2203,11 @@ EliminateSelect
   - │    │    │    ├── grouping columns: x:1(int!null)
   - │    │    │    ├── key: (1)
   - │    │    │    ├── fd: (1)-->(10)
-  - │    │    │    ├── left-join
+  - │    │    │    ├── left-join (hash)
   - │    │    │    │    ├── columns: x:1(int!null) k:3(int) notnull:9(bool)
   - │    │    │    │    ├── key: (1,3)
   + │    │    ├── fd: (1)-->(10)
-  + │    │    ├── left-join
+  + │    │    ├── left-join (hash)
   + │    │    │    ├── columns: x:1(int!null) k:3(int) notnull:9(bool)
   + │    │    │    ├── key: (1,3)
   + │    │    │    ├── fd: (3)-->(9)
@@ -2279,7 +2279,7 @@ PruneProjectCols
     │    │    ├── grouping columns: x:1(int!null)
     │    │    ├── key: (1)
     │    │    ├── fd: (1)-->(10)
-    │    │    ├── left-join
+    │    │    ├── left-join (hash)
     │    │    │    ├── columns: x:1(int!null) k:3(int) notnull:9(bool)
     │    │    │    ├── key: (1,3)
     │    │    │    ├── fd: (3)-->(9)
@@ -2324,7 +2324,7 @@ InlineProjectInProject
   - │    │    ├── grouping columns: x:1(int!null)
   - │    │    ├── key: (1)
   - │    │    ├── fd: (1)-->(10)
-  - │    │    ├── left-join
+  - │    │    ├── left-join (hash)
   - │    │    │    ├── columns: x:1(int!null) k:3(int) notnull:9(bool)
   - │    │    │    ├── key: (1,3)
   + ├── group-by
@@ -2332,7 +2332,7 @@ InlineProjectInProject
   + │    ├── grouping columns: x:1(int!null)
   + │    ├── key: (1)
   + │    ├── fd: (1)-->(10)
-  + │    ├── left-join
+  + │    ├── left-join (hash)
   + │    │    ├── columns: x:1(int!null) k:3(int) notnull:9(bool)
   + │    │    ├── key: (1,3)
   + │    │    ├── fd: (3)-->(9)
@@ -2412,7 +2412,7 @@ GenerateMergeJoins
     │    ├── grouping columns: x:1(int!null)
     │    ├── key: (1)
     │    ├── fd: (1)-->(10)
-  - │    ├── left-join
+  - │    ├── left-join (hash)
   + │    ├── left-join (merge)
     │    │    ├── columns: x:1(int!null) k:3(int) notnull:9(bool)
   + │    │    ├── left ordering: +1

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -167,7 +167,7 @@ delete xy
 opt expect=DecorrelateProjectSet
 SELECT generate_series(0, 5) FROM xy
 ----
-inner-join
+inner-join (hash)
  ├── columns: generate_series:3(int)
  ├── side-effects
  ├── scan xy
@@ -196,7 +196,7 @@ semi-join-apply
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
- ├── inner-join
+ ├── inner-join (hash)
  │    ├── columns: generate_series:8(int)
  │    ├── outer: (1,2)
  │    ├── side-effects
@@ -220,7 +220,7 @@ semi-join-apply
 opt expect=DecorrelateProjectSet
 SELECT generate_series(0, (SELECT generate_series(1,0) FROM xy)) FROM uv
 ----
-inner-join
+inner-join (hash)
  ├── columns: generate_series:6(int)
  ├── side-effects
  ├── scan uv
@@ -241,7 +241,7 @@ inner-join
  │                        ├── side-effects
  │                        ├── key: ()
  │                        ├── fd: ()-->(5)
- │                        └── inner-join
+ │                        └── inner-join (hash)
  │                             ├── columns: generate_series:5(int)
  │                             ├── side-effects
  │                             ├── scan xy
@@ -279,7 +279,7 @@ project
       ├── columns: u:1(int!null) v:2(int) k:3(int!null) i:4(int!null) rank:8(int)
       ├── key: (3)
       ├── fd: ()-->(4), (1)-->(2), (1)==(3), (3)==(1)
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── columns: u:1(int!null) v:2(int) k:3(int!null) i:4(int!null)
       │    ├── key: (3)
       │    ├── fd: ()-->(4), (1)-->(2), (1)==(3), (3)==(1)
@@ -330,14 +330,14 @@ project
       │    ├── project
       │    │    ├── columns: ntile_1_arg1:11(int) u:1(int!null) v:2(int) x:3(int!null) i:6(int)
       │    │    ├── fd: (1)-->(2,11)
-      │    │    ├── inner-join
+      │    │    ├── inner-join (hash)
       │    │    │    ├── columns: u:1(int!null) v:2(int) x:3(int!null) i:6(int)
       │    │    │    ├── fd: (1)-->(2)
       │    │    │    ├── scan uv
       │    │    │    │    ├── columns: u:1(int!null) v:2(int)
       │    │    │    │    ├── key: (1)
       │    │    │    │    └── fd: (1)-->(2)
-      │    │    │    ├── inner-join
+      │    │    │    ├── inner-join (hash)
       │    │    │    │    ├── columns: x:3(int!null) i:6(int)
       │    │    │    │    ├── scan xy
       │    │    │    │    │    ├── columns: x:3(int!null)
@@ -371,7 +371,7 @@ project
       ├── columns: column1:1(int!null) k:2(int!null) i:3(int) row_number:7(int) rownum:8(int!null)
       ├── key: (8)
       ├── fd: (8)-->(1), (2)-->(3), (1)==(2), (2)==(1)
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── columns: column1:1(int!null) k:2(int!null) i:3(int) rownum:8(int!null)
       │    ├── key: (8)
       │    ├── fd: (8)-->(1), (2)-->(3), (1)==(2), (2)==(1)
@@ -407,7 +407,7 @@ project
  └── window partition=(8) ordering=+3 opt(1,8)
       ├── columns: column1:1(int!null) i:3(int) row_number:7(int) rownum:8(int!null)
       ├── fd: (8)-->(1)
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── columns: column1:1(int!null) i:3(int) rownum:8(int!null)
       │    ├── fd: (8)-->(1)
       │    ├── select
@@ -456,7 +456,7 @@ project
       │    ├── columns: column1:1(int!null) i:3(int) rownum:9(int!null)
       │    ├── key: (9)
       │    ├── fd: (9)-->(1), (1)-->(3)
-      │    └── inner-join
+      │    └── inner-join (hash)
       │         ├── columns: column1:1(int!null) k:2(int!null) i:3(int) rownum:9(int!null)
       │         ├── key: (9)
       │         ├── fd: (9)-->(1), (2)-->(3), (1)==(2), (2)==(1)
@@ -498,7 +498,7 @@ project
       │    ├── columns: column1:1(int!null) column2:2(int!null) i:4(int) rownum:11(int!null)
       │    ├── key: (11)
       │    ├── fd: (11)-->(1,2), (1)-->(4)
-      │    └── inner-join
+      │    └── inner-join (hash)
       │         ├── columns: column1:1(int!null) column2:2(int!null) k:3(int!null) i:4(int) rownum:11(int!null)
       │         ├── key: (11)
       │         ├── fd: (11)-->(1,2), (3)-->(4), (1)==(3), (3)==(1)
@@ -537,7 +537,7 @@ window partition=(1)
  │    ├── columns: u:1(int!null) v:2(int) i:4(int)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,4)
- │    └── inner-join
+ │    └── inner-join (hash)
  │         ├── columns: u:1(int!null) v:2(int) k:3(int!null) i:4(int)
  │         ├── key: (3)
  │         ├── fd: (1)-->(2), (3)-->(4), (1)==(3), (3)==(1)
@@ -569,7 +569,7 @@ project
       ├── columns: u:1(int!null) v:2(int) k:3(int!null) i:4(int) row_number:8(int)
       ├── key: (3)
       ├── fd: (1)-->(2), (3)-->(4), (1)==(3), (3)==(1)
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── columns: u:1(int!null) v:2(int) k:3(int!null) i:4(int)
       │    ├── key: (3)
       │    ├── fd: (1)-->(2), (3)-->(4), (1)==(3), (3)==(1)
@@ -599,7 +599,7 @@ project
  └── window partition=(1,6)
       ├── columns: u:1(int!null) v:2(int) i:4(int!null) s:6(string) row_number:8(int)
       ├── fd: (1)-->(2), (1)==(4), (4)==(1)
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── columns: u:1(int!null) v:2(int) i:4(int!null) s:6(string)
       │    ├── fd: (1)-->(2), (1)==(4), (4)==(1)
       │    ├── scan uv
@@ -639,7 +639,7 @@ project
  └── window partition=(1,6) ordering=+5 opt(1,2,6)
       ├── columns: u:1(int!null) v:2(int) i:4(int) f:5(float) s:6(string) row_number:8(int)
       ├── fd: (1)-->(2)
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── columns: u:1(int!null) v:2(int) i:4(int) f:5(float) s:6(string)
       │    ├── fd: (1)-->(2)
       │    ├── scan uv
@@ -681,7 +681,7 @@ project
  └── window partition=(1,6) ordering=+5 opt(1,2,6)
       ├── columns: u:1(int!null) v:2(int) i:4(int) f:5(float) s:6(string) row_number:8(int)
       ├── fd: (1)-->(2)
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── columns: u:1(int!null) v:2(int) i:4(int) f:5(float) s:6(string)
       │    ├── fd: (1)-->(2)
       │    ├── scan uv
@@ -709,7 +709,7 @@ project
       ├── project
       │    ├── columns: avg_1_filter:9(bool) u:1(int!null) v:2(int) i:4(int) f:5(float)
       │    ├── fd: (1)-->(2,9)
-      │    ├── inner-join
+      │    ├── inner-join (hash)
       │    │    ├── columns: u:1(int!null) v:2(int) i:4(int) f:5(float)
       │    │    ├── fd: (1)-->(2)
       │    │    ├── scan uv
@@ -846,7 +846,7 @@ project
  ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
  ├── key: (1)
  ├── fd: (1)-->(2-5)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int!null)
       ├── key: (1)
       ├── fd: (1)-->(2-5), (2)==(6), (6)==(2)
@@ -911,7 +911,7 @@ semi-join-apply
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
- ├── semi-join
+ ├── semi-join (hash)
  │    ├── columns: x:6(int!null) y:7(int)
  │    ├── outer: (4)
  │    ├── key: (6)
@@ -1192,11 +1192,11 @@ distinct-on
       ├── project
       │    ├── columns: div:10(decimal) k:1(int!null) x:6(int!null)
       │    ├── side-effects
-      │    ├── inner-join
+      │    ├── inner-join (hash)
       │    │    ├── columns: k:1(int!null) i:2(int!null) x:6(int!null) u:8(int!null)
       │    │    ├── key: (1,6,8)
       │    │    ├── fd: ()-->(2)
-      │    │    ├── inner-join
+      │    │    ├── inner-join (hash)
       │    │    │    ├── columns: k:1(int!null) i:2(int!null) u:8(int!null)
       │    │    │    ├── key: (1,8)
       │    │    │    ├── fd: ()-->(2)
@@ -1244,7 +1244,7 @@ project
       │    ├── columns: k:1(int!null) i:2(int)
       │    ├── key: (1)
       │    └── fd: (1)-->(2)
-      ├── right-join
+      ├── right-join (hash)
       │    ├── columns: x:6(int) div:10(decimal)
       │    ├── outer: (2)
       │    ├── side-effects
@@ -1291,7 +1291,7 @@ project
       │    ├── columns: k:1(int!null) i:2(int)
       │    ├── key: (1)
       │    └── fd: (1)-->(2)
-      ├── left-join
+      ├── left-join (hash)
       │    ├── columns: x:6(int!null) plus:10(int)
       │    ├── outer: (2)
       │    ├── scan xy
@@ -1334,7 +1334,7 @@ project
       │    ├── columns: k:1(int!null) i:2(int)
       │    ├── key: (1)
       │    └── fd: (1)-->(2)
-      ├── full-join
+      ├── full-join (hash)
       │    ├── columns: x:6(int) plus:10(int)
       │    ├── outer: (2)
       │    ├── scan xy
@@ -1605,7 +1605,7 @@ semi-join-apply
  ├── scan a
  │    ├── columns: k:1(int!null)
  │    └── key: (1)
- ├── semi-join
+ ├── semi-join (hash)
  │    ├── columns: x:6(int!null) y:7(int)
  │    ├── outer: (1)
  │    ├── key: (6)
@@ -1614,7 +1614,7 @@ semi-join-apply
  │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    ├── key: (6)
  │    │    └── fd: (6)-->(7)
- │    ├── inner-join
+ │    ├── inner-join (hash)
  │    │    ├── columns: uv.u:8(int!null) uv.v:9(int) uv2.u:10(int!null) uv2.v:11(int)
  │    │    ├── key: (8,10)
  │    │    ├── fd: (8)-->(9), (10)-->(11)
@@ -1654,12 +1654,12 @@ semi-join-apply
  │    ├── cardinality: [2 - 2]
  │    ├── (1,) [type=tuple{int}]
  │    └── (2,) [type=tuple{int}]
- ├── left-join
+ ├── left-join (hash)
  │    ├── columns: k:2(int!null) i:3(int!null) x:7(int!null) y:8(int!null) v1:11(int)
  │    ├── outer: (1)
  │    ├── key: (7)
  │    ├── fd: (2)-->(3), (7)-->(8,11), (2)==(7), (7)==(2), (3)==(8), (8)==(3), ()~~>(11)
- │    ├── inner-join
+ │    ├── inner-join (hash)
  │    │    ├── columns: k:2(int!null) i:3(int!null) x:7(int!null) y:8(int!null)
  │    │    ├── key: (7)
  │    │    ├── fd: (2)-->(3), (7)-->(8), (2)==(7), (7)==(2), (3)==(8), (8)==(3)
@@ -1701,11 +1701,11 @@ project
       ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int) k:5(int) i:6(int)
       ├── key: (1,3,5)
       ├── fd: (1)-->(2), (3)-->(4), (5)-->(6)
-      ├── left-join
+      ├── left-join (hash)
       │    ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int) k:5(int) i:6(int)
       │    ├── key: (1,3,5)
       │    ├── fd: (1)-->(2), (3)-->(4), (5)-->(6)
-      │    ├── inner-join
+      │    ├── inner-join (hash)
       │    │    ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int)
       │    │    ├── key: (1,3)
       │    │    ├── fd: (1)-->(2), (3)-->(4)
@@ -1752,10 +1752,10 @@ group-by
  │    │    ├── grouping columns: k:1(int!null) x:6(int!null) v:9(int)
  │    │    ├── key: (1,6,9)
  │    │    ├── fd: ()-->(2), (1)-->(3-5), (1,6,9)-->(2-5,10)
- │    │    ├── inner-join
+ │    │    ├── inner-join (hash)
  │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) v:9(int)
  │    │    │    ├── fd: ()-->(2), (1)-->(3-5)
- │    │    │    ├── inner-join
+ │    │    │    ├── inner-join (hash)
  │    │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) v:9(int)
  │    │    │    │    ├── fd: ()-->(2), (1)-->(3-5)
  │    │    │    │    ├── scan uv
@@ -1819,10 +1819,10 @@ group-by
  │    │    ├── grouping columns: k:1(int!null) x:6(int!null) v:9(int)
  │    │    ├── key: (1,6,9)
  │    │    ├── fd: ()-->(2), (1)-->(3-5), (1,6,9)-->(2-5,10)
- │    │    ├── inner-join
+ │    │    ├── inner-join (hash)
  │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) v:9(int)
  │    │    │    ├── fd: ()-->(2), (1)-->(3-5)
- │    │    │    ├── inner-join
+ │    │    │    ├── inner-join (hash)
  │    │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) v:9(int)
  │    │    │    │    ├── fd: ()-->(2), (1)-->(3-5)
  │    │    │    │    ├── scan uv
@@ -1885,7 +1885,7 @@ project
       │    ├── grouping columns: u:3(int!null)
       │    ├── key: (3)
       │    ├── fd: (1)-->(2), (3)-->(1,2,4,10), (1)==(4), (4)==(1)
-      │    ├── inner-join
+      │    ├── inner-join (hash)
       │    │    ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int!null) k:5(int!null) i:6(int!null)
       │    │    ├── key: (3)
       │    │    ├── fd: (1)-->(2), (3)-->(4), (1)==(4,5), (4)==(1,5), (5)-->(6), (5)==(1,4)
@@ -1951,11 +1951,11 @@ project
       │    ├── grouping columns: u:3(int!null)
       │    ├── key: (3)
       │    ├── fd: (1)-->(2), (3)-->(1,2,4,10), (1)==(4), (4)==(1)
-      │    ├── left-join
+      │    ├── left-join (hash)
       │    │    ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int!null) k:5(int) i:6(int)
       │    │    ├── key: (3,5)
       │    │    ├── fd: (1)-->(2), (3)-->(4), (1)==(4), (4)==(1), (5)-->(6)
-      │    │    ├── inner-join
+      │    │    ├── inner-join (hash)
       │    │    │    ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int!null)
       │    │    │    ├── key: (3)
       │    │    │    ├── fd: (1)-->(2), (3)-->(4), (1)==(4), (4)==(1)
@@ -2008,7 +2008,7 @@ project
  │    │    ├── grouping columns: rownum:10(int!null)
  │    │    ├── key: (10)
  │    │    ├── fd: ()-->(2), (10)-->(2,9)
- │    │    ├── inner-join
+ │    │    ├── inner-join (hash)
  │    │    │    ├── columns: y:2(int!null) k:4(int!null) s:7(string) rownum:10(int!null)
  │    │    │    ├── key: (10)
  │    │    │    ├── fd: ()-->(2,4,7), (2)==(4), (4)==(2)
@@ -2060,11 +2060,11 @@ group-by
  │    │    ├── grouping columns: k:1(int!null) x:6(int!null) v:9(int)
  │    │    ├── key: (1,6,8)
  │    │    ├── fd: ()-->(2), (1)-->(3-5), (8)-->(9), (1,6,9)-->(2-5,8)
- │    │    ├── inner-join
+ │    │    ├── inner-join (hash)
  │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) u:8(int!null) v:9(int)
  │    │    │    ├── key: (1,6,8)
  │    │    │    ├── fd: ()-->(2), (1)-->(3-5), (8)-->(9)
- │    │    │    ├── inner-join
+ │    │    │    ├── inner-join (hash)
  │    │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) u:8(int!null) v:9(int)
  │    │    │    │    ├── key: (1,8)
  │    │    │    │    ├── fd: ()-->(2), (8)-->(9), (1)-->(3-5)
@@ -2135,10 +2135,10 @@ group-by
  │    │    ├── grouping columns: k:1(int!null) x:6(int!null)
  │    │    ├── key: (1,6)
  │    │    ├── fd: (1)-->(2-5), (1,6)-->(2-5,11)
- │    │    ├── left-join
+ │    │    ├── left-join (hash)
  │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) canary:12(bool)
  │    │    │    ├── fd: (1)-->(2-5), ()~~>(12)
- │    │    │    ├── inner-join
+ │    │    │    ├── inner-join (hash)
  │    │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null)
  │    │    │    │    ├── key: (1,6)
  │    │    │    │    ├── fd: (1)-->(2-5)
@@ -2197,7 +2197,7 @@ project
  │    │    ├── grouping columns: rownum:10(int!null)
  │    │    ├── key: (10)
  │    │    ├── fd: (10)-->(2,9)
- │    │    ├── inner-join
+ │    │    ├── inner-join (hash)
  │    │    │    ├── columns: i:2(int!null) x:7(int!null) y:8(int!null) rownum:10(int!null)
  │    │    │    ├── key: (10)
  │    │    │    ├── fd: (10)-->(2), (7)-->(8), (2)==(7), (7)==(2)
@@ -2243,7 +2243,7 @@ project
  │    ├── grouping columns: k:1(int!null)
  │    ├── key: (1)
  │    ├── fd: (1)-->(7,10)
- │    ├── left-join
+ │    ├── left-join (hash)
  │    │    ├── columns: k:1(int!null) y:7(int)
  │    │    ├── scan a
  │    │    │    ├── columns: k:1(int!null)
@@ -2273,7 +2273,7 @@ project
  │    ├── grouping columns: k:1(int!null)
  │    ├── key: (1)
  │    ├── fd: (1)-->(7,9,12)
- │    ├── left-join
+ │    ├── left-join (hash)
  │    │    ├── columns: k:1(int!null) y:7(int)
  │    │    ├── scan a
  │    │    │    ├── columns: k:1(int!null)
@@ -2306,7 +2306,7 @@ project
  │    ├── grouping columns: k:1(int!null)
  │    ├── key: (1)
  │    ├── fd: ()~~>(10), (1)-->(10,11)
- │    ├── left-join
+ │    ├── left-join (hash)
  │    │    ├── columns: k:1(int!null) i:2(int) y:7(int) canary:10(bool)
  │    │    ├── fd: (1)-->(2), ()~~>(10)
  │    │    ├── scan a
@@ -2346,7 +2346,7 @@ project
  │    │    ├── columns: k:1(int!null) i:2(int) y:7(int) canary:10(bool)
  │    │    ├── fd: (1)-->(2), ()~~>(10)
  │    │    ├── ordering: +7
- │    │    └── left-join
+ │    │    └── left-join (hash)
  │    │         ├── columns: k:1(int!null) i:2(int) y:7(int) canary:10(bool)
  │    │         ├── fd: (1)-->(2), ()~~>(10)
  │    │         ├── scan a
@@ -2414,7 +2414,7 @@ project
       │    │    │    ├── outer: (1)
       │    │    │    ├── key: (6)
       │    │    │    ├── fd: (6)-->(7,10)
-      │    │    │    ├── left-join
+      │    │    │    ├── left-join (hash)
       │    │    │    │    ├── columns: x:6(int!null) y:7(int) u:8(int) v:9(int)
       │    │    │    │    ├── outer: (1)
       │    │    │    │    ├── key: (6,8)
@@ -2478,7 +2478,7 @@ project
       │    │    ├── grouping columns: c:1(int!null)
       │    │    ├── key: (1)
       │    │    ├── fd: (1)-->(2,3,6)
-      │    │    ├── left-join
+      │    │    ├── left-join (hash)
       │    │    │    ├── columns: c:1(int!null) d:2(int!null) x:3(int) y:4(int)
       │    │    │    ├── key: (1,3)
       │    │    │    ├── fd: (1)-->(2), (3)-->(4)
@@ -2524,7 +2524,7 @@ project
       │    │    ├── grouping columns: k:1(int!null)
       │    │    ├── key: (1)
       │    │    ├── fd: (1)-->(2-5,10,11), ()~~>(10)
-      │    │    ├── left-join
+      │    │    ├── left-join (hash)
       │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) column8:8(string) canary:10(bool)
       │    │    │    ├── key: (1,6)
       │    │    │    ├── fd: (1)-->(2-5), (6)-->(8), ()~~>(10), (1,6)-->(10)
@@ -2590,10 +2590,10 @@ group-by
  │    │    ├── grouping columns: x:1(int!null) k:3(int!null)
  │    │    ├── key: (1,3)
  │    │    ├── fd: (1)-->(2), (3)-->(4), (1,3)-->(2,4,13)
- │    │    ├── inner-join
+ │    │    ├── inner-join (hash)
  │    │    │    ├── columns: x:1(int!null) y:2(int) k:3(int!null) i:4(int) i:9(int!null) f:10(float!null) column14:14(float!null)
  │    │    │    ├── fd: (1)-->(2), (2)-->(14), (3)-->(4), (10)==(14), (14)==(10)
- │    │    │    ├── inner-join
+ │    │    │    ├── inner-join (hash)
  │    │    │    │    ├── columns: x:1(int!null) y:2(int) i:9(int!null) f:10(float!null) column14:14(float!null)
  │    │    │    │    ├── fd: (1)-->(2), (2)-->(14), (10)==(14), (14)==(10)
  │    │    │    │    ├── project
@@ -2655,7 +2655,7 @@ group-by
  │    │    ├── grouping columns: x:1(int!null) f:5(float!null)
  │    │    ├── key: (1,5)
  │    │    ├── fd: (1)-->(2), (1,5)-->(2,4)
- │    │    ├── inner-join
+ │    │    ├── inner-join (hash)
  │    │    │    ├── columns: x:1(int!null) y:2(int!null) i:4(int) f:5(float!null)
  │    │    │    ├── fd: (1)-->(2)
  │    │    │    ├── scan xy
@@ -2696,14 +2696,14 @@ project
       │    ├── columns: computed:10(int) k:1(int!null) x:6(int!null)
       │    ├── key: (1,6)
       │    ├── fd: (1)-->(10)
-      │    ├── inner-join
+      │    ├── inner-join (hash)
       │    │    ├── columns: k:1(int!null) i:2(int!null) x:6(int!null) u:8(int!null)
       │    │    ├── key: (1,6)
       │    │    ├── fd: (1)-->(2), (2)==(8), (8)==(2)
       │    │    ├── scan xy
       │    │    │    ├── columns: x:6(int!null)
       │    │    │    └── key: (6)
-      │    │    ├── inner-join
+      │    │    ├── inner-join (hash)
       │    │    │    ├── columns: k:1(int!null) i:2(int!null) u:8(int!null)
       │    │    │    ├── key: (1)
       │    │    │    ├── fd: (1)-->(2), (2)==(8), (8)==(2)
@@ -2767,7 +2767,7 @@ WHERE EXISTS
     ON x=u
 )
 ----
-semi-join
+semi-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── key: (1)
  ├── fd: (1)-->(2-5)
@@ -2805,7 +2805,7 @@ project
  │    ├── grouping columns: rownum:9(int!null)
  │    ├── key: (9)
  │    ├── fd: (9)-->(6)
- │    ├── left-join
+ │    ├── left-join (hash)
  │    │    ├── columns: i:2(int) xy.x:6(int) y:7(int) rownum:9(int!null)
  │    │    ├── key: (6,9)
  │    │    ├── fd: (9)-->(2), (6)-->(7)
@@ -2844,7 +2844,7 @@ project
       │    ├── grouping columns: k:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-5,8)
-      │    ├── right-join
+      │    ├── right-join (hash)
       │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) u:8(int) v:9(int)
       │    │    ├── key: (1,8)
       │    │    ├── fd: (1)-->(2-5), (1)==(6), (6)==(1), (8)-->(9)
@@ -2861,7 +2861,7 @@ project
       │    │    │    │    ├── grouping columns: k:1(int!null)
       │    │    │    │    ├── key: (1)
       │    │    │    │    ├── fd: (1)-->(2-6)
-      │    │    │    │    ├── left-join
+      │    │    │    │    ├── left-join (hash)
       │    │    │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
       │    │    │    │    │    ├── key: (1,6)
       │    │    │    │    │    ├── fd: (1)-->(2-5), (6)-->(7)
@@ -2932,7 +2932,7 @@ project
       │    ├── grouping columns: k:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-6)
-      │    ├── left-join
+      │    ├── left-join (hash)
       │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int) u:8(int)
       │    │    ├── key: (1,6)
       │    │    ├── fd: (1)-->(2-5), (6)-->(7), (6)==(8), (8)==(6)
@@ -2949,7 +2949,7 @@ project
       │    │    │    │    ├── grouping columns: x:6(int!null)
       │    │    │    │    ├── key: (6)
       │    │    │    │    ├── fd: (6)-->(7,8)
-      │    │    │    │    ├── left-join
+      │    │    │    │    ├── left-join (hash)
       │    │    │    │    │    ├── columns: x:6(int!null) y:7(int) u:8(int) v:9(int)
       │    │    │    │    │    ├── key: (6,8)
       │    │    │    │    │    ├── fd: (6)-->(7), (8)-->(9)
@@ -3005,7 +3005,7 @@ project
  │    ├── grouping columns: x:1(int!null)
  │    ├── key: (1)
  │    ├── fd: (1)-->(4)
- │    ├── left-join
+ │    ├── left-join (hash)
  │    │    ├── columns: x:1(int!null) u:3(int) uv.v:4(int) k:5(int) i:6(int)
  │    │    ├── key: (1,5)
  │    │    ├── fd: (3)-->(4), (5)-->(6), (3)==(5), (5)==(3)
@@ -3060,7 +3060,7 @@ project
       │    │    ├── key: (1,3)
       │    │    ├── fd: (1)-->(2), (3)-->(4-6)
       │    │    ├── ordering: +5,+6 opt(4) [actual: +5,+6]
-      │    │    └── left-join
+      │    │    └── left-join (hash)
       │    │         ├── columns: x:1(int!null) y:2(int) k:3(int) i:4(int) f:5(float) s:6(string)
       │    │         ├── key: (1,3)
       │    │         ├── fd: (1)-->(2), (3)-->(4-6)
@@ -3132,11 +3132,11 @@ semi-join (lookup xy)
 opt expect=HoistSelectExists
 SELECT * FROM a WHERE EXISTS(SELECT * FROM xy WHERE x=k) AND EXISTS(SELECT * FROM xy WHERE x=i)
 ----
-semi-join
+semi-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── key: (1)
  ├── fd: (1)-->(2-5)
- ├── semi-join
+ ├── semi-join (hash)
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
@@ -3264,11 +3264,11 @@ SELECT *
 FROM a
 WHERE NOT EXISTS(SELECT * FROM xy WHERE x=k) AND NOT EXISTS(SELECT * FROM xy WHERE x=i)
 ----
-anti-join
+anti-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── key: (1)
  ├── fd: (1)-->(2-5)
- ├── anti-join
+ ├── anti-join (hash)
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
@@ -3316,11 +3316,11 @@ select
 opt expect=(HoistSelectExists,HoistSelectNotExists)
 SELECT * FROM a WHERE EXISTS(SELECT * FROM xy WHERE x=k) AND NOT EXISTS(SELECT * FROM xy WHERE x=i)
 ----
-semi-join
+semi-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── key: (1)
  ├── fd: (1)-->(2-5)
- ├── anti-join
+ ├── anti-join (hash)
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
@@ -3360,7 +3360,7 @@ project
       │    ├── grouping columns: k:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-5,7)
-      │    ├── left-join
+      │    ├── left-join (hash)
       │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) y:7(int)
       │    │    ├── fd: (1)-->(2-5)
       │    │    ├── scan a
@@ -3469,7 +3469,7 @@ project
       │    ├── grouping columns: k:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-5,10)
-      │    ├── right-join
+      │    ├── right-join (hash)
       │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) count_rows:8(int!null) y:10(int)
       │    │    ├── fd: (1)-->(2-5,8)
       │    │    ├── scan xy
@@ -3483,7 +3483,7 @@ project
       │    │    │    │    ├── grouping columns: k:1(int!null)
       │    │    │    │    ├── key: (1)
       │    │    │    │    ├── fd: (1)-->(2-5,8)
-      │    │    │    │    ├── left-join
+      │    │    │    │    ├── left-join (hash)
       │    │    │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) y:7(int)
       │    │    │    │    │    ├── fd: (1)-->(2-5)
       │    │    │    │    │    ├── scan a
@@ -3590,7 +3590,7 @@ project
       │    ├── grouping columns: k:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-5,9)
-      │    ├── left-join
+      │    ├── left-join (hash)
       │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) y:7(int) true:8(bool)
       │    │    ├── fd: (1)-->(2-5), ()~~>(8)
       │    │    ├── scan a
@@ -3871,7 +3871,7 @@ project
  │    ├── grouping columns: k:1(int!null) xy.x:6(int)
  │    ├── key: (1,6)
  │    ├── fd: (1,6)-->(16)
- │    ├── left-join
+ │    ├── left-join (hash)
  │    │    ├── columns: k:1(int!null) xy.x:6(int) xy.y:15(int)
  │    │    ├── left-join (merge)
  │    │    │    ├── columns: k:1(int!null) xy.x:6(int)
@@ -3962,7 +3962,7 @@ project
  │    ├── grouping columns: rownum:12(int!null)
  │    ├── key: (12)
  │    ├── fd: (12)-->(10)
- │    ├── left-join
+ │    ├── left-join (hash)
  │    │    ├── columns: i:2(int) y:7(int) true:9(bool) rownum:12(int!null)
  │    │    ├── fd: (12)-->(2), ()~~>(9)
  │    │    ├── ordinality
@@ -3997,7 +3997,7 @@ project
  │    ├── grouping columns: rownum:12(int!null)
  │    ├── key: (12)
  │    ├── fd: (12)-->(10)
- │    ├── left-join
+ │    ├── left-join (hash)
  │    │    ├── columns: i:2(int) y:7(int) notnull:9(bool) rownum:12(int!null)
  │    │    ├── fd: (12)-->(2), (7)~~>(9)
  │    │    ├── ordinality
@@ -4041,7 +4041,7 @@ values
                 ├── cardinality: [0 - 1]
                 ├── key: ()
                 ├── fd: ()-->(2,7,9,12)
-                ├── left-join
+                ├── left-join (hash)
                 │    ├── columns: i:2(int) y:7(int) true:9(bool) rownum:12(int!null)
                 │    ├── fd: (12)-->(2), ()~~>(9)
                 │    ├── ordinality
@@ -4091,7 +4091,7 @@ project
       │    ├── columns: k:1(int!null) i:2(int)
       │    ├── key: (1)
       │    └── fd: (1)-->(2)
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── columns: x:6(int!null) y:7(int) "?column?":8(int)
       │    ├── outer: (1)
       │    ├── key: (6)
@@ -4129,7 +4129,7 @@ project
       │    ├── outer: (1)
       │    ├── key: (6)
       │    ├── fd: ()-->(8), (6)-->(7,9)
-      │    ├── inner-join
+      │    ├── inner-join (hash)
       │    │    ├── columns: x:6(int!null) y:7(int) "?column?":8(int)
       │    │    ├── outer: (1)
       │    │    ├── key: (6)
@@ -4163,7 +4163,7 @@ SELECT s, x FROM a FULL JOIN xy ON EXISTS(SELECT * FROM uv WHERE u=y) OR k=x
 ----
 project
  ├── columns: s:4(string) x:6(int)
- └── full-join
+ └── full-join (hash)
       ├── columns: k:1(int) s:4(string) x:6(int) exists:12(bool)
       ├── key: (1,6)
       ├── fd: (1)-->(4), (6)-->(12)
@@ -4180,7 +4180,7 @@ project
       │    │    ├── grouping columns: x:6(int!null)
       │    │    ├── key: (6)
       │    │    ├── fd: (6)-->(11)
-      │    │    ├── left-join
+      │    │    ├── left-join (hash)
       │    │    │    ├── columns: x:6(int!null) y:7(int) u:8(int) true:10(bool)
       │    │    │    ├── key: (6,8)
       │    │    │    ├── fd: (6)-->(7), ()~~>(10), (6,8)-->(10)
@@ -4224,11 +4224,11 @@ project
       │    │    ├── grouping columns: k:1(int!null) x:6(int!null)
       │    │    ├── key: (1,6)
       │    │    ├── fd: (1)-->(5), (6)-->(7), (1,6)-->(5,7,11)
-      │    │    ├── left-join
+      │    │    ├── left-join (hash)
       │    │    │    ├── columns: k:1(int!null) i:2(int) j:5(jsonb) x:6(int!null) y:7(int) u:8(int) v:9(int) notnull:10(bool)
       │    │    │    ├── key: (1,6,8)
       │    │    │    ├── fd: (1)-->(2,5), (6)-->(7), (8)-->(9), (9)~~>(10), (1,6,8)-->(10)
-      │    │    │    ├── inner-join
+      │    │    │    ├── inner-join (hash)
       │    │    │    │    ├── columns: k:1(int!null) i:2(int) j:5(jsonb) x:6(int!null) y:7(int)
       │    │    │    │    ├── key: (1,6)
       │    │    │    │    ├── fd: (1)-->(2,5), (6)-->(7)
@@ -4299,7 +4299,7 @@ project
  │    │              ├── outer: (1,2)
  │    │              ├── cardinality: [3 - 3]
  │    │              ├── fd: ()-->(6,7)
- │    │              ├── inner-join
+ │    │              ├── inner-join (hash)
  │    │              │    ├── columns: r:6(int) s:7(int)
  │    │              │    ├── outer: (1,2)
  │    │              │    ├── cardinality: [1 - 1]
@@ -4363,7 +4363,7 @@ project
  │    │    │    │    ├── cardinality: [1 - 1]
  │    │    │    │    ├── key: ()
  │    │    │    │    ├── fd: ()-->(10)
- │    │    │    │    ├── left-join
+ │    │    │    │    ├── left-join (hash)
  │    │    │    │    │    ├── columns: true:9(bool)
  │    │    │    │    │    ├── outer: (1)
  │    │    │    │    │    ├── cardinality: [1 - 1]
@@ -4441,7 +4441,7 @@ project
  │    │    │    │    ├── cardinality: [1 - 1]
  │    │    │    │    ├── key: ()
  │    │    │    │    ├── fd: ()-->(10)
- │    │    │    │    ├── left-join
+ │    │    │    │    ├── left-join (hash)
  │    │    │    │    │    ├── columns: notnull:9(bool)
  │    │    │    │    │    ├── outer: (1)
  │    │    │    │    │    ├── cardinality: [1 - 1]
@@ -4960,7 +4960,7 @@ distinct-on
 opt expect=NormalizeSelectAnyFilter
 SELECT * FROM a WHERE i IN (SELECT y FROM xy)
 ----
-semi-join
+semi-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── key: (1)
  ├── fd: (1)-->(2-5)
@@ -4977,7 +4977,7 @@ semi-join
 opt expect=NormalizeSelectAnyFilter
 SELECT * FROM a WHERE k=10 AND i < ANY(SELECT y FROM xy) AND s='foo'
 ----
-semi-join
+semi-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string!null) j:5(jsonb)
  ├── cardinality: [0 - 1]
  ├── key: ()
@@ -5004,11 +5004,11 @@ semi-join
 opt expect=NormalizeSelectAnyFilter
 SELECT * FROM a WHERE i < ANY(SELECT y FROM xy) AND s = ANY(SELECT y::string FROM xy)
 ----
-semi-join
+semi-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── key: (1)
  ├── fd: (1)-->(2-5)
- ├── semi-join
+ ├── semi-join (hash)
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
@@ -5061,11 +5061,11 @@ select
 opt expect=NormalizeJoinAnyFilter
 SELECT * FROM a INNER JOIN xy ON i IN (SELECT v FROM uv) AND k=x
 ----
-inner-join
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
  ├── key: (6)
  ├── fd: (1)-->(2-5), (6)-->(7), (1)==(6), (6)==(1)
- ├── semi-join
+ ├── semi-join (hash)
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
@@ -5090,7 +5090,7 @@ inner-join
 opt expect=NormalizeSelectNotAnyFilter
 SELECT * FROM a WHERE i NOT IN (SELECT y FROM xy)
 ----
-anti-join
+anti-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── key: (1)
  ├── fd: (1)-->(2-5)
@@ -5108,7 +5108,7 @@ anti-join
 opt expect=NormalizeSelectNotAnyFilter
 SELECT * FROM a WHERE k > 1 AND k < 5 AND i > ALL(SELECT y FROM xy)
 ----
-anti-join
+anti-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── key: (1)
  ├── fd: (1)-->(2-5)
@@ -5126,11 +5126,11 @@ anti-join
 opt expect=NormalizeSelectNotAnyFilter
 SELECT * FROM a WHERE i < ALL(SELECT y FROM xy) AND s <> ALL(SELECT y::string FROM xy)
 ----
-anti-join
+anti-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── key: (1)
  ├── fd: (1)-->(2-5)
- ├── anti-join
+ ├── anti-join (hash)
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
@@ -5183,11 +5183,11 @@ select
 opt expect=NormalizeJoinNotAnyFilter
 SELECT * FROM a INNER JOIN xy ON i NOT IN (SELECT v FROM uv) AND k=x
 ----
-inner-join
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
  ├── key: (6)
  ├── fd: (1)-->(2-5), (6)-->(7), (1)==(6), (6)==(1)
- ├── anti-join
+ ├── anti-join (hash)
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
@@ -5212,11 +5212,11 @@ inner-join
 opt expect=(NormalizeSelectAnyFilter,NormalizeSelectNotAnyFilter)
 SELECT * FROM a WHERE i = ANY(SELECT y FROM xy) AND s <> ALL(SELECT y::string FROM xy)
 ----
-semi-join
+semi-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── key: (1)
  ├── fd: (1)-->(2-5)
- ├── anti-join
+ ├── anti-join (hash)
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -273,7 +273,7 @@ group-by
  ├── grouping columns: k:1(int!null)
  ├── key: (1)
  ├── fd: (1)-->(3,4,8)
- ├── inner-join
+ ├── inner-join (hash)
  │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string!null)
  │    ├── fd: (1)-->(2-4), (2,4)-->(1,3), (2,3)~~>(1,4)
  │    ├── scan a
@@ -339,7 +339,7 @@ distinct-on
  ├── grouping columns: k:1(int!null)
  ├── key: (1)
  ├── fd: (1)-->(2,3,6), (2,3)~~>(1), (6)-->(2)
- ├── inner-join
+ ├── inner-join (hash)
  │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) x:6(int!null) y:7(int!null)
  │    ├── key: (1,6)
  │    ├── fd: (1)-->(2,3), (2,3)~~>(1), (6)-->(7), (2)==(7), (7)==(2)

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -204,7 +204,7 @@ select
 opt expect=InlineJoinConstantsLeft
 SELECT * FROM (SELECT 1 AS one) LEFT JOIN a ON k=one
 ----
-left-join
+left-join (hash)
  ├── columns: one:1(int!null) k:2(int) i:3(int) f:4(float) s:5(string) j:6(jsonb)
  ├── cardinality: [1 - 1]
  ├── key: ()
@@ -226,7 +226,7 @@ left-join
 opt expect=InlineJoinConstantsRight
 SELECT * FROM a RIGHT JOIN (SELECT 1 AS one) ON k=one
 ----
-right-join
+right-join (hash)
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) one:6(int!null)
  ├── cardinality: [1 - 1]
  ├── key: ()
@@ -258,7 +258,7 @@ values
 opt expect-not=(InlineJoinConstantsLeft,InlineJoinConstantsRight)
 SELECT * FROM a INNER JOIN (SELECT 1 AS one, y FROM xy) ON k=y
 ----
-inner-join
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) one:8(int!null) y:7(int!null)
  ├── fd: ()-->(8), (1)-->(2-5), (1)==(7), (7)==(1)
  ├── scan a
@@ -360,7 +360,7 @@ project
 opt expect=PushSelectIntoInlinableProject
 SELECT * FROM a WHERE EXISTS(SELECT * FROM (SELECT (x-i) AS expr FROM xy) WHERE expr > i*i)
 ----
-semi-join
+semi-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── key: (1)
  ├── fd: (1)-->(2-5)
@@ -584,7 +584,7 @@ project
  │    ├── grouping columns: rownum:13(int!null)
  │    ├── key: (13)
  │    ├── fd: (13)-->(11)
- │    ├── left-join
+ │    ├── left-join (hash)
  │    │    ├── columns: expr:6(int) true:10(bool) rownum:13(int!null)
  │    │    ├── fd: (13)-->(6), ()~~>(10)
  │    │    ├── ordinality

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -25,7 +25,7 @@ CREATE TABLE uv (u INT PRIMARY KEY, v INT)
 opt
 SELECT * FROM a INNER JOIN b ON a.s='foo' OR b.y<10
 ----
-inner-join
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7)
@@ -56,7 +56,7 @@ values
 opt expect=DetectJoinContradiction
 SELECT * FROM a LEFT JOIN b ON i=5 AND k IN () AND s='foo'
 ----
-left-join
+left-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int) y:7(int)
  ├── key: (1)
  ├── fd: (1)-->(2-7), ()~~>(6,7)
@@ -74,7 +74,7 @@ left-join
 opt expect=DetectJoinContradiction
 SELECT * FROM a FULL JOIN b ON i=5 AND k IN () AND s='foo'
 ----
-full-join
+full-join (hash)
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7)
@@ -738,7 +738,7 @@ project
       │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
       │    ├── key: (1)
       │    └── fd: (1)-->(2-5)
-      ├── left-join
+      ├── left-join (hash)
       │    ├── columns: x:6(int!null) y:7(int) "?column?":10(int)
       │    ├── outer: (1)
       │    ├── key: (6)
@@ -770,7 +770,7 @@ opt expect-not=(PushFilterIntoJoinLeftAndRight,MapFilterIntoJoinLeft,MapFilterIn
 SELECT *
 FROM (VALUES (1.0), (2.0)) AS t1(x), (VALUES (1.00), (2.00)) AS t2(y)WHERE x=y AND x::text = '1.0'
 ----
-inner-join
+inner-join (hash)
  ├── columns: x:1(decimal!null) y:2(decimal!null)
  ├── cardinality: [0 - 4]
  ├── fd: (1)==(2), (2)==(1)
@@ -796,7 +796,7 @@ inner-join
 opt expect-not=(PushFilterIntoJoinLeftAndRight,MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
 SELECT * FROM a INNER JOIN b ON b.y=b.x AND a.k=a.i AND a.k + b.y > 5 AND b.x * a.i = 3
 ----
-inner-join
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string) j:5(jsonb) x:6(int!null) y:7(int!null)
  ├── key: (1,6)
  ├── fd: (1)-->(3-5), (1)==(2), (2)==(1), (6)==(7), (7)==(6)
@@ -852,11 +852,11 @@ project
  │    │    └── project
  │    │         ├── columns: b.x:4(int!null)
  │    │         ├── outer: (1)
- │    │         └── inner-join
+ │    │         └── inner-join (hash)
  │    │              ├── columns: b.x:4(int!null) k:8(int!null)
  │    │              ├── outer: (1)
  │    │              ├── fd: (4)==(8), (8)==(4)
- │    │              ├── full-join
+ │    │              ├── full-join (hash)
  │    │              │    ├── columns: b.x:4(int)
  │    │              │    ├── outer: (1)
  │    │              │    ├── scan b
@@ -906,11 +906,11 @@ project
  │    │    └── project
  │    │         ├── columns: b.x:9(int!null)
  │    │         ├── outer: (1)
- │    │         └── inner-join
+ │    │         └── inner-join (hash)
  │    │              ├── columns: k:4(int!null) b.x:9(int!null)
  │    │              ├── outer: (1)
  │    │              ├── fd: (4)==(9), (9)==(4)
- │    │              ├── full-join
+ │    │              ├── full-join (hash)
  │    │              │    ├── columns: b.x:9(int)
  │    │              │    ├── outer: (1)
  │    │              │    ├── scan b
@@ -946,7 +946,7 @@ CREATE TABLE t2 (b TIMESTAMPTZ)
 opt
 SELECT * FROM t1, t2 WHERE a = b AND age(b, TIMESTAMPTZ '2017-01-01') > INTERVAL '1 day'
 ----
-inner-join
+inner-join (hash)
  ├── columns: a:1(date!null) b:3(timestamptz!null)
  ├── side-effects
  ├── fd: (1)==(3), (3)==(1)
@@ -1007,10 +1007,10 @@ project
  │         │    │    │    │    ├── columns: k:1(int!null) s:4(string)
  │         │    │    │    │    ├── key: (1)
  │         │    │    │    │    └── fd: (1)-->(4)
- │         │    │    │    ├── inner-join
+ │         │    │    │    ├── inner-join (hash)
  │         │    │    │    │    ├── columns: xy.x:6(int!null) u:8(int!null)
  │         │    │    │    │    ├── outer: (4)
- │         │    │    │    │    ├── inner-join
+ │         │    │    │    │    ├── inner-join (hash)
  │         │    │    │    │    │    ├── columns: u:8(int!null)
  │         │    │    │    │    │    ├── outer: (4)
  │         │    │    │    │    │    ├── select
@@ -1177,7 +1177,7 @@ semi-join-apply
  │    ├── columns: x:1(int!null) y:2(int)
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
- ├── anti-join
+ ├── anti-join (hash)
  │    ├── columns: k:3(int!null) i:4(int) f:5(float!null) s:6(string!null) j:7(jsonb)
  │    ├── outer: (2)
  │    ├── key: (3)
@@ -1213,7 +1213,7 @@ semi-join-apply
 opt expect=SimplifyLeftJoinWithoutFilters
 SELECT * FROM a LEFT JOIN (SELECT count(*) FROM b) ON True
 ----
-inner-join
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) count:8(int)
  ├── key: (1)
  ├── fd: ()-->(8), (1)-->(2-5)
@@ -1235,7 +1235,7 @@ inner-join
 opt expect=SimplifyLeftJoinWithoutFilters
 SELECT * FROM a FULL JOIN (SELECT count(*) FROM b) ON True
 ----
-right-join
+right-join (hash)
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) count:8(int)
  ├── cardinality: [1 - ]
  ├── key: (1)
@@ -1303,7 +1303,7 @@ project
 opt expect-not=SimplifyLeftJoinWithoutFilters
 SELECT * FROM a RIGHT JOIN (SELECT count(*) FROM b) ON True
 ----
-right-join
+right-join (hash)
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) count:8(int)
  ├── cardinality: [1 - ]
  ├── key: (1)
@@ -1328,7 +1328,7 @@ right-join
 opt expect=SimplifyRightJoinWithoutFilters
 SELECT * FROM (SELECT count(*) FROM b) RIGHT JOIN a ON True
 ----
-inner-join
+inner-join (hash)
  ├── columns: count:3(int) k:4(int!null) i:5(int) f:6(float!null) s:7(string) j:8(jsonb)
  ├── key: (4)
  ├── fd: ()-->(3), (4)-->(5-8)
@@ -1350,7 +1350,7 @@ inner-join
 opt expect=SimplifyRightJoinWithoutFilters
 SELECT * FROM (SELECT count(*) FROM b) FULL JOIN a ON True
 ----
-right-join
+right-join (hash)
  ├── columns: count:3(int) k:4(int) i:5(int) f:6(float) s:7(string) j:8(jsonb)
  ├── cardinality: [1 - ]
  ├── key: (4)
@@ -1373,7 +1373,7 @@ right-join
 opt expect-not=SimplifyRightJoinWithoutFilters
 SELECT * FROM (SELECT count(*) FROM b) LEFT JOIN a ON True
 ----
-right-join
+right-join (hash)
  ├── columns: count:3(int) k:4(int) i:5(int) f:6(float) s:7(string) j:8(jsonb)
  ├── cardinality: [1 - ]
  ├── key: (4)
@@ -1443,7 +1443,7 @@ left-join (merge)
 opt expect=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM a FULL JOIN a AS a2 ON a.k=a2.k AND a.k=a2.k AND a2.f=a.f
 ----
-inner-join
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) k:6(int!null) i:7(int) f:8(float!null) s:9(string) j:10(jsonb)
  ├── key: (6)
  ├── fd: (1)-->(2-5), (6)-->(7-10), (1)==(6), (6)==(1), (3)==(8), (8)==(3)
@@ -1464,7 +1464,7 @@ inner-join
 opt expect=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM (SELECT length(s), f FROM a) AS a FULL JOIN a AS a2 ON a.f=a2.f
 ----
-inner-join
+inner-join (hash)
  ├── columns: length:6(int) f:3(float!null) k:7(int!null) i:8(int) f:9(float!null) s:10(string) j:11(jsonb)
  ├── fd: (7)-->(8-11), (3)==(9), (9)==(3)
  ├── project
@@ -1484,7 +1484,7 @@ inner-join
 opt expect=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM a FULL JOIN (SELECT * FROM a INNER JOIN a AS a2 ON a.k=a2.k) AS a2 ON a.f=a2.f
 ----
-inner-join
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) k:6(int!null) i:7(int) f:8(float!null) s:9(string) j:10(jsonb) k:11(int!null) i:12(int) f:13(float!null) s:14(string) j:15(jsonb)
  ├── key: (1,11)
  ├── fd: (1)-->(2-5), (6)-->(7-10), (11)-->(12-15), (6)==(11), (11)==(6), (3)==(8), (8)==(3)
@@ -1519,7 +1519,7 @@ FROM c
 LEFT OUTER JOIN a
 ON c.y = a.k
 ----
-inner-join
+inner-join (hash)
  ├── columns: x:1(int!null) y:2(int!null) z:3(int!null) k:4(int!null) i:5(int) f:6(float!null) s:7(string) j:8(jsonb)
  ├── key: (1)
  ├── fd: (1)-->(2,3), (4)-->(5-8), (2)==(4), (4)==(2)
@@ -1567,7 +1567,7 @@ FROM d
 LEFT OUTER JOIN c
 ON d.z = c.z
 ----
-inner-join
+inner-join (hash)
  ├── columns: x:1(int!null) y:2(int!null) z:3(int!null) x:4(int!null) y:5(int!null) z:6(int!null)
  ├── key: (1,4)
  ├── fd: (1)-->(2,3), (4)-->(5,6), (3)==(6), (6)==(3)
@@ -1589,7 +1589,7 @@ FROM c
 LEFT OUTER JOIN a
 ON c.z = a.k
 ----
-left-join
+left-join (hash)
  ├── columns: x:1(int!null) y:2(int!null) z:3(int!null) k:4(int) i:5(int) f:6(float) s:7(string) j:8(jsonb)
  ├── key: (1,4)
  ├── fd: (1)-->(2,3), (4)-->(5-8)
@@ -1633,7 +1633,7 @@ left-join (merge)
 opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM a FULL JOIN a AS a2 ON a.k<a2.k
 ----
-full-join
+full-join (hash)
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) k:6(int) i:7(int) f:8(float) s:9(string) j:10(jsonb)
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7-10)
@@ -1652,7 +1652,7 @@ full-join
 opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM a FULL JOIN a AS a2 ON a.f=1 AND a.f=a2.f
 ----
-full-join
+full-join (hash)
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) k:6(int) i:7(int) f:8(float) s:9(string) j:10(jsonb)
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7-10)
@@ -1672,7 +1672,7 @@ full-join
 opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM a FULL JOIN a AS a2 ON a.s=a2.s
 ----
-full-join
+full-join (hash)
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) k:6(int) i:7(int) f:8(float) s:9(string) j:10(jsonb)
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7-10)
@@ -1691,7 +1691,7 @@ full-join
 opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM a FULL JOIN (SELECT k+1 AS k FROM a) AS a2 ON a.k=a2.k
 ----
-full-join
+full-join (hash)
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) k:11(int)
  ├── fd: (1)-->(2-5)
  ├── scan a
@@ -1712,7 +1712,7 @@ full-join
 opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM a FULL JOIN a AS a2 ON a.k=a2.f
 ----
-full-join
+full-join (hash)
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) k:6(int) i:7(int) f:8(float) s:9(string) j:10(jsonb)
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7-10)
@@ -1755,11 +1755,11 @@ full-join (merge)
 opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM (SELECT * FROM a, b) AS a FULL JOIN a AS a2 ON a.k=a2.k AND a.x=a2.k
 ----
-full-join
+full-join (hash)
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int) k:8(int) i:9(int) f:10(float) s:11(string) j:12(jsonb)
  ├── key: (1,6,8)
  ├── fd: (1)-->(2-5), (6)-->(7), (8)-->(9-12)
- ├── inner-join
+ ├── inner-join (hash)
  │    ├── columns: a.k:1(int!null) a.i:2(int) a.f:3(float!null) a.s:4(string) a.j:5(jsonb) x:6(int!null) y:7(int)
  │    ├── key: (1,6)
  │    ├── fd: (1)-->(2-5), (6)-->(7)
@@ -1784,11 +1784,11 @@ full-join
 opt expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)
 SELECT * FROM a LEFT JOIN (SELECT * FROM a, b) AS a2 ON a.k=a2.x
 ----
-right-join
+right-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) k:6(int) i:7(int) f:8(float) s:9(string) j:10(jsonb) x:11(int) y:12(int)
  ├── key: (1,6,11)
  ├── fd: (1)-->(2-5), (6)-->(7-10), (11)-->(12)
- ├── inner-join
+ ├── inner-join (hash)
  │    ├── columns: k:6(int!null) i:7(int) f:8(float!null) s:9(string) j:10(jsonb) x:11(int!null) y:12(int)
  │    ├── key: (6,11)
  │    ├── fd: (6)-->(7-10), (11)-->(12)
@@ -1815,7 +1815,7 @@ FROM c@{IGNORE_FOREIGN_KEYS}
 LEFT OUTER JOIN a
 ON c.y = a.k
 ----
-left-join
+left-join (hash)
  ├── columns: x:1(int!null) y:2(int!null) z:3(int!null) k:4(int) i:5(int) f:6(float) s:7(string) j:8(jsonb)
  ├── key: (1,4)
  ├── fd: (1)-->(2,3), (4)-->(5-8)
@@ -2004,7 +2004,7 @@ project
 norm expect=SimplifyJoinNotNullEquality
 SELECT * FROM a INNER JOIN b ON (a.k=b.x) IS True
 ----
-inner-join
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
  ├── key: (6)
  ├── fd: (1)-->(2-5), (6)-->(7), (1)==(6), (6)==(1)
@@ -2022,7 +2022,7 @@ inner-join
 norm expect=SimplifyJoinNotNullEquality
 SELECT * FROM a INNER JOIN b ON (a.k=b.x) IS False
 ----
-inner-join
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7)
@@ -2049,7 +2049,7 @@ values
 norm expect=SimplifyJoinNotNullEquality
 SELECT * FROM a INNER JOIN b ON (a.k=b.x) IS NOT True
 ----
-inner-join
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7)
@@ -2067,7 +2067,7 @@ inner-join
 norm expect=SimplifyJoinNotNullEquality
 SELECT * FROM a INNER JOIN b ON (a.k=b.x) IS NOT False
 ----
-inner-join
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
  ├── key: (6)
  ├── fd: (1)-->(2-5), (6)-->(7), (1)==(6), (6)==(1)
@@ -2085,7 +2085,7 @@ inner-join
 norm expect=SimplifyJoinNotNullEquality
 SELECT * FROM a INNER JOIN b ON (a.k=b.x) IS NOT Null
 ----
-inner-join
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7)
@@ -2106,7 +2106,7 @@ FROM (SELECT * FROM a WHERE i>0) AS a
 INNER JOIN (SELECT x, y, y+1 AS z FROM b WHERE y>10) AS b
 ON a.f>=b.z::float AND (a.k=b.x) IS True AND a.f>=b.z::float AND (a.i=b.y) IS NOT False
 ----
-inner-join
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string) j:5(jsonb) x:6(int!null) y:7(int!null) z:8(int)
  ├── key: (6)
  ├── fd: (1)-->(2-5), (6)-->(7), (7)-->(8), (1)==(6), (6)==(1), (2)==(7), (7)==(2)
@@ -2146,7 +2146,7 @@ inner-join
 norm expect-not=SimplifyJoinNotNullEquality
 SELECT * FROM a INNER JOIN b ON (a.k=b.y) IS True AND (a.i=b.x) IS False
 ----
-inner-join
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7)
@@ -2173,7 +2173,7 @@ project
  ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int)
  ├── key: (1)
  ├── fd: (1)-->(2), (1,2)-->(3,4), (3)-->(4)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int) column5:5(int!null)
       ├── key: (1)
       ├── fd: (1)-->(2), (1,2)-->(5), (3)-->(4), (3)==(5), (5)==(3)
@@ -2201,7 +2201,7 @@ project
  ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int)
  ├── key: (1)
  ├── fd: (1)-->(2), (1,2)-->(3,4), (3)-->(4)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int) column5:5(int!null)
       ├── key: (1)
       ├── fd: (1)-->(2), (1,2)-->(5), (3)-->(4), (3)==(5), (5)==(3)
@@ -2229,7 +2229,7 @@ project
  ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int)
  ├── key: (3)
  ├── fd: (1)-->(2), (3)-->(4), (3,4)-->(1,2)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int) column5:5(int!null)
       ├── key: (3)
       ├── fd: (1)-->(2), (3)-->(4), (3,4)-->(5), (1)==(5), (5)==(1)
@@ -2257,7 +2257,7 @@ project
  ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int)
  ├── key: (3)
  ├── fd: (1)-->(2), (3)-->(4), (3,4)-->(1,2)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int) column5:5(int!null)
       ├── key: (3)
       ├── fd: (1)-->(2), (3)-->(4), (3,4)-->(5), (1)==(5), (5)==(1)
@@ -2285,7 +2285,7 @@ project
  ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int)
  ├── key: (1,3)
  ├── fd: (1)-->(2), (3)-->(4)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int) column5:5(int!null) column6:6(int!null)
       ├── key: (1,3)
       ├── fd: (1)-->(2), (1,2)-->(5), (3)-->(4), (3,4)-->(6), (5)==(6), (6)==(5)
@@ -2320,7 +2320,7 @@ project
  ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int)
  ├── key: (1)
  ├── fd: (1)-->(2), (1,2)-->(3,4), (3)-->(4), (3,4)-->(1,2)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int) column5:5(int!null) column6:6(int!null) column7:7(int!null) column8:8(int!null)
       ├── key: (1)
       ├── fd: (1)-->(2), (1,2)-->(5,7), (3)-->(4), (3,4)-->(6,8), (3)==(5), (5)==(3), (1)==(6), (6)==(1), (7)==(8), (8)==(7)
@@ -2359,7 +2359,7 @@ project
  ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int!null)
  ├── key: (1)
  ├── fd: (1)-->(2), (1,2)-->(3,4), (3)-->(4)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int!null) column5:5(int!null)
       ├── key: (1)
       ├── fd: (1)-->(2), (1,2)-->(5), (3)-->(4), (3)==(5), (5)==(3)
@@ -2406,7 +2406,7 @@ full-join (merge)
 opt expect-not=ExtractJoinEqualities
 SELECT * FROM xy FULL OUTER JOIN uv ON x+y=1
 ----
-full-join
+full-join (hash)
  ├── columns: x:1(int) y:2(int) u:3(int) v:4(int)
  ├── key: (1,3)
  ├── fd: (1)-->(2), (3)-->(4)
@@ -2424,7 +2424,7 @@ full-join
 opt expect-not=ExtractJoinEqualities
 SELECT * FROM xy FULL OUTER JOIN uv ON 1=u+v
 ----
-full-join
+full-join (hash)
  ├── columns: x:1(int) y:2(int) u:3(int) v:4(int)
  ├── key: (1,3)
  ├── fd: (1)-->(2), (3)-->(4)
@@ -2454,7 +2454,7 @@ project
       │    ├── columns: x:1(int!null) y:2(int)
       │    ├── key: (1)
       │    └── fd: (1)-->(2)
-      ├── left-join
+      ├── left-join (hash)
       │    ├── columns: u:3(int!null) v:4(int) k:5(int)
       │    ├── outer: (1)
       │    ├── key: (3)
@@ -2495,7 +2495,7 @@ project
  ├── columns: x:1(int) y:2(int) u:3(int) v:4(int)
  ├── key: (1,3)
  ├── fd: (1)-->(2), (3)-->(4)
- └── full-join
+ └── full-join (hash)
       ├── columns: x:1(int) y:2(int) u:3(int) v:4(int) k:5(int)
       ├── key: (1,3)
       ├── fd: (1)-->(2), (3)-->(4,5)

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -739,7 +739,7 @@ SELECT a.k+1 AS r, xy.* FROM a FULL JOIN xy ON True
 project
  ├── columns: r:7(int) x:5(int) y:6(int)
  ├── fd: (5)-->(6)
- ├── full-join
+ ├── full-join (hash)
  │    ├── columns: k:1(int) x:5(int) y:6(int)
  │    ├── key: (1,5)
  │    ├── fd: (5)-->(6)
@@ -758,7 +758,7 @@ project
 opt expect=PruneJoinLeftCols
 SELECT xy.* FROM a, xy
 ----
-inner-join
+inner-join (hash)
  ├── columns: x:5(int!null) y:6(int)
  ├── fd: (5)-->(6)
  ├── scan a
@@ -776,7 +776,7 @@ project
  ├── columns: r:8(int) s:9(decimal) x:5(int!null) y:6(int)
  ├── side-effects
  ├── fd: (5)-->(6)
- ├── inner-join
+ ├── inner-join (hash)
  │    ├── columns: k:1(int!null) i:2(int) x:5(int!null) y:6(int) column7:7(int!null)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,7), (5)-->(6), (5)==(7), (7)==(5)
@@ -820,7 +820,7 @@ project
  ├── columns: k:1(int!null) x:7(int!null) y:8(int!null)
  ├── key: (1,7)
  ├── fd: (7)-->(8)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: k:1(int!null) i:2(int!null) x:5(int!null) x:7(int!null) y:8(int!null)
       ├── key: (5,7)
       ├── fd: (1)-->(2), (1)==(5), (5)==(1), (7)-->(8)
@@ -1058,7 +1058,7 @@ SELECT xy.*, a.k+1 AS r FROM xy FULL JOIN a ON True
 project
  ├── columns: x:1(int) y:2(int) r:7(int)
  ├── fd: (1)-->(2)
- ├── full-join
+ ├── full-join (hash)
  │    ├── columns: x:1(int) y:2(int) k:3(int)
  │    ├── key: (1,3)
  │    ├── fd: (1)-->(2)
@@ -1077,7 +1077,7 @@ project
 opt expect=PruneJoinRightCols
 SELECT xy.* FROM xy, a
 ----
-inner-join
+inner-join (hash)
  ├── columns: x:1(int!null) y:2(int)
  ├── fd: (1)-->(2)
  ├── scan xy
@@ -1095,7 +1095,7 @@ project
  ├── columns: x:1(int!null) y:2(int) r:8(int) s:9(decimal)
  ├── side-effects
  ├── fd: (1)-->(2)
- ├── inner-join
+ ├── inner-join (hash)
  │    ├── columns: x:1(int!null) y:2(int) k:3(int!null) i:4(int) column7:7(int!null)
  │    ├── key: (3)
  │    ├── fd: (1)-->(2), (3)-->(4,7), (1)==(7), (7)==(1)
@@ -1139,7 +1139,7 @@ project
  ├── columns: k:3(int!null) x:1(int!null) y:2(int!null)
  ├── key: (1,3)
  ├── fd: (1)-->(2)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: x:1(int!null) y:2(int!null) k:3(int!null) x:7(int!null) y:8(int!null)
       ├── key: (1,7)
       ├── fd: (1)-->(2), (7)-->(8), (3)==(7), (7)==(3)
@@ -1177,7 +1177,7 @@ SELECT 1 r FROM a,xy
 project
  ├── columns: r:7(int!null)
  ├── fd: ()-->(7)
- ├── inner-join
+ ├── inner-join (hash)
  │    ├── scan a
  │    ├── scan xy
  │    └── filters (true)
@@ -1993,7 +1993,7 @@ upsert a
       ├── cardinality: [1 - 1]
       ├── key: ()
       ├── fd: ()-->(5-12,15)
-      ├── left-join
+      ├── left-join (hash)
       │    ├── columns: column1:5(int!null) column2:6(string!null) column7:7(int) column8:8(float) k:9(int) i:10(int) f:11(float) s:12(string)
       │    ├── cardinality: [1 - 1]
       │    ├── key: ()
@@ -2044,7 +2044,7 @@ upsert a
       ├── cardinality: [1 - 1]
       ├── key: ()
       ├── fd: ()-->(5-12,14-17)
-      ├── left-join
+      ├── left-join (hash)
       │    ├── columns: column1:5(int!null) column2:6(string!null) column7:7(int) column8:8(float) k:9(int) i:10(int) f:11(float) s:12(string)
       │    ├── cardinality: [1 - 1]
       │    ├── key: ()
@@ -2086,7 +2086,7 @@ upsert "family"
  │    └──  column2:7 => b:2
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
- └── left-join
+ └── left-join (hash)
       ├── columns: column1:6(int!null) column2:7(int!null) column8:8(int) a:9(int) b:10(int)
       ├── cardinality: [1 - 1]
       ├── key: ()
@@ -2141,7 +2141,7 @@ project
            ├── cardinality: [1 - 1]
            ├── key: ()
            ├── fd: ()-->(6-15,17-21)
-           ├── left-join
+           ├── left-join (hash)
            │    ├── columns: column1:6(int!null) column2:7(int!null) column3:8(int!null) column4:9(int!null) column5:10(int!null) a:11(int) b:12(int) c:13(int) d:14(int) e:15(int)
            │    ├── cardinality: [1 - 1]
            │    ├── key: ()
@@ -2191,7 +2191,7 @@ upsert "family"
       ├── cardinality: [1 - 1]
       ├── key: ()
       ├── fd: ()-->(6-11,13,14,20)
-      ├── left-join
+      ├── left-join (hash)
       │    ├── columns: column1:6(int!null) column2:7(int!null) column3:8(int!null) column4:9(int!null) column10:10(int) a:11(int) c:13(int) d:14(int)
       │    ├── cardinality: [1 - 1]
       │    ├── key: ()
@@ -2234,7 +2234,7 @@ upsert mutation
       ├── cardinality: [1 - 1]
       ├── key: ()
       ├── fd: ()-->(6-14,17)
-      ├── left-join
+      ├── left-join (hash)
       │    ├── columns: column1:6(int!null) column2:7(int!null) column3:8(int!null) column9:9(int) a:10(int) b:11(int) c:12(int) d:13(int) e:14(int)
       │    ├── cardinality: [1 - 1]
       │    ├── key: ()

--- a/pkg/sql/opt/norm/testdata/rules/reject_nulls
+++ b/pkg/sql/opt/norm/testdata/rules/reject_nulls
@@ -17,7 +17,7 @@ CREATE TABLE uv (u INT PRIMARY KEY, v INT)
 opt expect=RejectNullsRightJoin
 SELECT * FROM a FULL JOIN xy ON true WHERE a.k IS NOT NULL
 ----
-left-join
+left-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) x:5(int) y:6(int)
  ├── key: (1,5)
  ├── fd: (1)-->(2-4), (5)-->(6)
@@ -34,7 +34,7 @@ left-join
 opt expect=RejectNullsLeftJoin
 SELECT * FROM a FULL JOIN xy ON true WHERE xy.x > 5
 ----
-right-join
+right-join (hash)
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) x:5(int!null) y:6(int)
  ├── key: (1,5)
  ├── fd: (1)-->(2-4), (5)-->(6)
@@ -56,11 +56,11 @@ FROM (SELECT * FROM a LEFT JOIN uv ON True) AS l
 INNER JOIN (SELECT * FROM a LEFT JOIN uv ON True) AS r
 ON l.u=1 AND r.v>2
 ----
-inner-join
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) u:5(int!null) v:6(int) k:7(int!null) i:8(int) f:9(float) s:10(string) u:11(int!null) v:12(int!null)
  ├── key: (1,7,11)
  ├── fd: ()-->(5,6), (1)-->(2-4), (7)-->(8-10), (11)-->(12)
- ├── inner-join
+ ├── inner-join (hash)
  │    ├── columns: u:5(int!null) v:6(int) k:7(int!null) i:8(int) f:9(float) s:10(string) u:11(int!null) v:12(int!null)
  │    ├── key: (7,11)
  │    ├── fd: ()-->(5,6), (7)-->(8-10), (11)-->(12)
@@ -68,7 +68,7 @@ inner-join
  │    │    ├── columns: k:7(int!null) i:8(int) f:9(float) s:10(string)
  │    │    ├── key: (7)
  │    │    └── fd: (7)-->(8-10)
- │    ├── inner-join
+ │    ├── inner-join (hash)
  │    │    ├── columns: u:5(int!null) v:6(int) u:11(int!null) v:12(int!null)
  │    │    ├── key: (11)
  │    │    ├── fd: ()-->(5,6), (11)-->(12)
@@ -122,7 +122,7 @@ inner-join (merge)
 opt expect=RejectNullsRightJoin
 SELECT * FROM a RIGHT JOIN xy ON true WHERE a.k > xy.y
 ----
-inner-join
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) x:5(int!null) y:6(int!null)
  ├── key: (1,5)
  ├── fd: (1)-->(2-4), (5)-->(6)
@@ -141,7 +141,7 @@ inner-join
 opt expect=(RejectNullsLeftJoin,RejectNullsRightJoin)
 SELECT * FROM a FULL JOIN xy ON true WHERE a.k IS NOT NULL AND xy.x > 5
 ----
-inner-join
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) x:5(int!null) y:6(int)
  ├── key: (1,5)
  ├── fd: (1)-->(2-4), (5)-->(6)
@@ -166,7 +166,7 @@ project
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) x:5(int) y:6(int)
  ├── key: (1,5)
  ├── fd: (1)-->(2-4), (5)-->(6)
- └── right-join
+ └── right-join (hash)
       ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) x:5(int) y:6(int) u:7(int!null)
       ├── key: (1,5)
       ├── fd: (1)-->(2-4,7), (2)==(7), (7)==(2), (5)-->(6)
@@ -232,7 +232,7 @@ project
       │    ├── grouping columns: k:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(7)
-      │    ├── inner-join
+      │    ├── inner-join (hash)
       │    │    ├── columns: k:1(int!null) x:5(int!null)
       │    │    ├── key: (1,5)
       │    │    ├── scan a
@@ -269,7 +269,7 @@ project
       │    ├── grouping columns: k:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(7)
-      │    ├── inner-join
+      │    ├── inner-join (hash)
       │    │    ├── columns: k:1(int!null) y:6(int!null)
       │    │    ├── scan a
       │    │    │    ├── columns: k:1(int!null)
@@ -306,7 +306,7 @@ select
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(7)
- │    ├── inner-join
+ │    ├── inner-join (hash)
  │    │    ├── columns: x:5(int!null)
  │    │    ├── scan a
  │    │    ├── scan xy
@@ -340,7 +340,7 @@ project
       │    ├── grouping columns: k:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(7,8)
-      │    ├── inner-join
+      │    ├── inner-join (hash)
       │    │    ├── columns: k:1(int!null) x:5(int!null)
       │    │    ├── key: (1,5)
       │    │    ├── scan a
@@ -379,7 +379,7 @@ project
       │    ├── grouping columns: k:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(7,8)
-      │    ├── inner-join
+      │    ├── inner-join (hash)
       │    │    ├── columns: k:1(int!null) y:6(int!null)
       │    │    ├── scan a
       │    │    │    ├── columns: k:1(int!null)
@@ -434,7 +434,7 @@ select
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(5,6)
- │    ├── inner-join
+ │    ├── inner-join (hash)
  │    │    ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int!null)
  │    │    ├── key: (1,3)
  │    │    ├── fd: (1)-->(2), (3)-->(4)
@@ -482,7 +482,7 @@ project
       │    ├── grouping columns: k:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(7,8)
-      │    ├── left-join
+      │    ├── left-join (hash)
       │    │    ├── columns: k:1(int!null) x:5(int) y:6(int)
       │    │    ├── key: (1,5)
       │    │    ├── fd: (5)-->(6)
@@ -524,7 +524,7 @@ project
       │    ├── grouping columns: k:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(7)
-      │    ├── left-join
+      │    ├── left-join (hash)
       │    │    ├── columns: k:1(int!null) x:5(int)
       │    │    ├── key: (1,5)
       │    │    ├── scan a
@@ -564,7 +564,7 @@ project
  │    │    │    ├── outer: (4)
  │    │    │    ├── key: (5)
  │    │    │    ├── fd: (5)-->(15)
- │    │    │    ├── left-join
+ │    │    │    ├── left-join (hash)
  │    │    │    │    ├── columns: ref_1.k:5(int!null) true:14(bool)
  │    │    │    │    ├── outer: (4)
  │    │    │    │    ├── fd: ()~~>(14)

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -1047,7 +1047,7 @@ project
  │    ├── grouping columns: b.k:1(int!null)
  │    ├── key: (7)
  │    ├── fd: (1)==(7), (7)==(1), (7)-->(15), (1)-->(7,15)
- │    ├── inner-join
+ │    ├── inner-join (hash)
  │    │    ├── columns: b.k:1(int!null) a.k:7(int!null)
  │    │    ├── key: (7)
  │    │    ├── fd: (1)==(7), (7)==(1)
@@ -1084,7 +1084,7 @@ project
  │    │    ├── key: (7,15)
  │    │    ├── fd: (15)-->(2), (7)-->(8)
  │    │    ├── ordering: +7 opt(8) [actual: +7]
- │    │    └── left-join
+ │    │    └── left-join (hash)
  │    │         ├── columns: b.i:2(int) a.k:7(int) a.i:8(int) rownum:15(int!null)
  │    │         ├── key: (7,15)
  │    │         ├── fd: (15)-->(2), (7)-->(8)
@@ -1170,7 +1170,7 @@ project
  │    ├── grouping columns: c.k:1(int!null)
  │    ├── key: (1)
  │    ├── fd: ()-->(22), (1)-->(22,23)
- │    ├── inner-join
+ │    ├── inner-join (hash)
  │    │    ├── columns: c.k:1(int!null) b.k:7(int!null) array:19(int) canary:22(bool!null)
  │    │    ├── key: (7)
  │    │    ├── fd: ()-->(19,22), (1)==(7), (7)==(1)
@@ -1232,7 +1232,7 @@ project
  │    │    │    │    ├── cardinality: [0 - 1]
  │    │    │    │    ├── key: ()
  │    │    │    │    ├── fd: ()-->(13,21)
- │    │    │    │    ├── inner-join
+ │    │    │    │    ├── inner-join (hash)
  │    │    │    │    │    ├── columns: b.k:7(int!null) a.k:13(int!null)
  │    │    │    │    │    ├── outer: (1)
  │    │    │    │    │    ├── cardinality: [0 - 1]

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -211,7 +211,7 @@ project
 norm expect=ConsolidateSelectFilters
 SELECT * FROM (SELECT * FROM a WHERE k = 5) AS a, e WHERE a.k = e.k AND a.k > 1 AND e.k < 10
 ----
-inner-join
+inner-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) k:6(int!null) i:7(int) t:8(timestamp) tz:9(timestamptz) d:10(date)
  ├── cardinality: [0 - 1]
  ├── key: ()
@@ -567,7 +567,7 @@ select
 norm expect=PushSelectIntoJoinLeft
 SELECT * FROM a LEFT JOIN xy ON True WHERE a.i=100 AND $1>'2000-01-01T1:00:00'
 ----
-left-join
+left-join (hash)
  ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
  ├── has-placeholder
  ├── key: (1,6)
@@ -866,7 +866,7 @@ select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7)
- ├── left-join
+ ├── left-join (hash)
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
  │    ├── key: (1,6)
  │    ├── fd: (1)-->(2-5), (6)-->(7)
@@ -890,7 +890,7 @@ select
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7)
- ├── right-join
+ ├── right-join (hash)
  │    ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
  │    ├── key: (1,6)
  │    ├── fd: (1)-->(2-5), (6)-->(7)
@@ -914,7 +914,7 @@ select
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7)
- ├── full-join
+ ├── full-join (hash)
  │    ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
  │    ├── key: (1,6)
  │    ├── fd: (1)-->(2-5), (6)-->(7)
@@ -1085,7 +1085,7 @@ distinct-on
  ├── grouping columns: k:1(int!null)
  ├── key: (1)
  ├── fd: (1)-->(2,3,6), (6)-->(2)
- ├── inner-join
+ ├── inner-join (hash)
  │    ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) x:6(int!null) y:7(int!null)
  │    ├── key: (1,6)
  │    ├── fd: (1)-->(2,3), (6)-->(7), (2)==(7), (7)==(2)

--- a/pkg/sql/opt/norm/testdata/rules/side_effects
+++ b/pkg/sql/opt/norm/testdata/rules/side_effects
@@ -115,7 +115,7 @@ SELECT CASE WHEN i<0 THEN (SELECT y FROM xy WHERE x=i LIMIT 1) ELSE 5 END FROM a
 ----
 project
  ├── columns: case:8(int)
- ├── left-join
+ ├── left-join (hash)
  │    ├── columns: i:2(int) x:6(int) y:7(int)
  │    ├── fd: (6)-->(7)
  │    ├── scan a
@@ -140,7 +140,7 @@ project
       ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
       ├── key: (1,6)
       ├── fd: (1)-->(2-5), (6)-->(7)
-      ├── left-join
+      ├── left-join (hash)
       │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
       │    ├── key: (1,6)
       │    ├── fd: (1)-->(2-5), (6)-->(7)
@@ -303,7 +303,7 @@ project
       ├── side-effects
       ├── key: (1,6)
       ├── fd: (1)-->(2-5), (6)-->(8)
-      ├── left-join
+      ├── left-join (hash)
       │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:8(decimal)
       │    ├── key: (1,6)
       │    ├── fd: (1)-->(2-5), (6)-->(8)

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -883,7 +883,7 @@ SELECT count(*) FROM kv a, kv b
 scalar-group-by
  ├── columns: count:9(int)
  ├── project
- │    └── inner-join
+ │    └── inner-join (hash)
  │         ├── columns: a.k:1(int!null) a.v:2(int) a.w:3(int) a.s:4(string) b.k:5(int!null) b.v:6(int) b.w:7(int) b.s:8(string)
  │         ├── scan a
  │         │    └── columns: a.k:1(int!null) a.v:2(int) a.w:3(int) a.s:4(string)
@@ -1970,7 +1970,7 @@ project
  │    ├── grouping columns: a:1(int!null) b:2(int) x:3(string)
  │    ├── project
  │    │    ├── columns: a:1(int!null) b:2(int) x:3(string) y:4(string)
- │    │    └── inner-join
+ │    │    └── inner-join (hash)
  │    │         ├── columns: a:1(int!null) b:2(int) x:3(string) y:4(string) rowid:5(int!null)
  │    │         ├── scan ab
  │    │         │    └── columns: a:1(int!null) b:2(int)
@@ -2119,11 +2119,11 @@ project
  │    ├── grouping columns: b2.b:3(bool) column9:9(bool)
  │    └── project
  │         ├── columns: column9:9(bool) b2.b:3(bool)
- │         ├── inner-join
+ │         ├── inner-join (hash)
  │         │    ├── columns: b1.b:1(bool) b1.rowid:2(int!null) b2.b:3(bool) b2.rowid:4(int!null) a:5(char!null) abc.b:6(float) c:7(bool) d:8(decimal)
  │         │    ├── scan b1
  │         │    │    └── columns: b1.b:1(bool) b1.rowid:2(int!null)
- │         │    ├── inner-join
+ │         │    ├── inner-join (hash)
  │         │    │    ├── columns: b2.b:3(bool) b2.rowid:4(int!null) a:5(char!null) abc.b:6(float) c:7(bool) d:8(decimal)
  │         │    │    ├── scan b2
  │         │    │    │    └── columns: b2.b:3(bool) b2.rowid:4(int!null)
@@ -2155,11 +2155,11 @@ project
  │    ├── grouping columns: b2.b:3(bool) column9:9(bool)
  │    └── project
  │         ├── columns: column9:9(bool) b2.b:3(bool)
- │         ├── inner-join
+ │         ├── inner-join (hash)
  │         │    ├── columns: b1.b:1(bool) b1.rowid:2(int!null) b2.b:3(bool) b2.rowid:4(int!null) a:5(char!null) abc.b:6(float) c:7(bool) d:8(decimal)
  │         │    ├── scan b1
  │         │    │    └── columns: b1.b:1(bool) b1.rowid:2(int!null)
- │         │    ├── inner-join
+ │         │    ├── inner-join (hash)
  │         │    │    ├── columns: b2.b:3(bool) b2.rowid:4(int!null) a:5(char!null) abc.b:6(float) c:7(bool) d:8(decimal)
  │         │    │    ├── scan b2
  │         │    │    │    └── columns: b2.b:3(bool) b2.rowid:4(int!null)
@@ -2212,7 +2212,7 @@ project
  │    ├── grouping columns: a:5(char!null) column9:9(string)
  │    └── project
  │         ├── columns: column9:9(string) a:5(char!null)
- │         ├── inner-join
+ │         ├── inner-join (hash)
  │         │    ├── columns: k:1(int!null) v:2(int) w:3(int) s:4(string) a:5(char!null) b:6(float) c:7(bool) d:8(decimal)
  │         │    ├── scan kv
  │         │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
@@ -2275,7 +2275,7 @@ project
  │    ├── grouping columns: b.baz:5(jsonb) column7:7(bool)
  │    └── project
  │         ├── columns: column7:7(bool) b.baz:5(jsonb)
- │         ├── inner-join
+ │         ├── inner-join (hash)
  │         │    ├── columns: a.bar:1(jsonb) a.baz:2(jsonb) a.rowid:3(int!null) b.bar:4(jsonb) b.baz:5(jsonb) b.rowid:6(int!null)
  │         │    ├── scan a
  │         │    │    └── columns: a.bar:1(jsonb) a.baz:2(jsonb) a.rowid:3(int!null)
@@ -2308,7 +2308,7 @@ project
  │    ├── grouping columns: b.baz:5(jsonb) column7:7(bool)
  │    └── project
  │         ├── columns: column7:7(bool) b.baz:5(jsonb)
- │         ├── inner-join
+ │         ├── inner-join (hash)
  │         │    ├── columns: a.bar:1(jsonb) a.baz:2(jsonb) a.rowid:3(int!null) b.bar:4(jsonb) b.baz:5(jsonb) b.rowid:6(int!null)
  │         │    ├── scan a
  │         │    │    └── columns: a.bar:1(jsonb) a.baz:2(jsonb) a.rowid:3(int!null)
@@ -2341,7 +2341,7 @@ project
  │    ├── grouping columns: column3:3(interval) column4:4(interval)
  │    └── project
  │         ├── columns: column3:3(interval) column4:4(interval)
- │         ├── inner-join
+ │         ├── inner-join (hash)
  │         │    ├── columns: a.t:1(time!null) b.t:2(time!null)
  │         │    ├── scan a
  │         │    │    └── columns: a.t:1(time!null)
@@ -2530,7 +2530,7 @@ project
       ├── grouping columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
       ├── project
       │    ├── columns: k:1(int!null) v:2(int) w:3(int) s:4(string) d:8(decimal!null)
-      │    └── inner-join
+      │    └── inner-join (hash)
       │         ├── columns: k:1(int!null) v:2(int) w:3(int) s:4(string) a:5(char!null) b:6(float) c:7(bool) d:8(decimal!null)
       │         ├── scan kv
       │         │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)

--- a/pkg/sql/opt/optbuilder/testdata/explain
+++ b/pkg/sql/opt/optbuilder/testdata/explain
@@ -54,7 +54,7 @@ EXPLAIN (VERBOSE) SELECT * FROM xy INNER JOIN (VALUES (1, 2), (3, 4)) AS t(u,v) 
 explain
  ├── columns: tree:5(string) field:8(string) description:9(string) columns:10(string) ordering:11(string)  [hidden: level:6(int) node_type:7(string)]
  ├── mode: verbose
- └── inner-join
+ └── inner-join (hash)
       ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int!null)
       ├── scan xy
       │    └── columns: x:1(int!null) y:2(int)

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
@@ -24,7 +24,7 @@ insert child
  │         └── const: 1 [type=int]
  └── f-k-checks
       └── f-k-checks-item: child(p) -> parent(p)
-           └── anti-join
+           └── anti-join (hash)
                 ├── columns: column2:4(int!null)
                 ├── project
                 │    ├── columns: column2:4(int!null)
@@ -68,7 +68,7 @@ insert child_nullable
  │              └── null [type=unknown]
  └── f-k-checks
       └── f-k-checks-item: child_nullable(p) -> parent(p)
-           └── anti-join
+           └── anti-join (hash)
                 ├── columns: column2:4(int!null)
                 ├── select
                 │    ├── columns: column2:4(int!null)
@@ -114,7 +114,7 @@ insert child_nullable
  │         └── const: 1 [type=int]
  └── f-k-checks
       └── f-k-checks-item: child_nullable(p) -> parent(p)
-           └── anti-join
+           └── anti-join (hash)
                 ├── columns: column2:4(int!null)
                 ├── project
                 │    ├── columns: column2:4(int!null)
@@ -158,7 +158,7 @@ insert child_nullable_full
  │              └── null [type=unknown]
  └── f-k-checks
       └── f-k-checks-item: child_nullable_full(p) -> parent(p)
-           └── anti-join
+           └── anti-join (hash)
                 ├── columns: column2:4(int!null)
                 ├── select
                 │    ├── columns: column2:4(int!null)
@@ -220,7 +220,7 @@ insert multi_col_child
  │              └── null [type=unknown]
  └── f-k-checks
       └── f-k-checks-item: multi_col_child(p,q,r) -> multi_col_parent(p,q,r)
-           └── anti-join
+           └── anti-join (hash)
                 ├── columns: column2:6(int!null) column3:7(int!null) column4:8(int!null)
                 ├── select
                 │    ├── columns: column2:6(int!null) column3:7(int!null) column4:8(int!null)
@@ -286,7 +286,7 @@ insert multi_col_child
  │         └── const: 20 [type=int]
  └── f-k-checks
       └── f-k-checks-item: multi_col_child(p,q,r) -> multi_col_parent(p,q,r)
-           └── anti-join
+           └── anti-join (hash)
                 ├── columns: column2:6(int!null) column3:7(int!null) column4:8(int!null)
                 ├── select
                 │    ├── columns: column2:6(int!null) column3:7(int!null) column4:8(int!null)
@@ -346,7 +346,7 @@ insert multi_col_child
  │         └── const: 10 [type=int]
  └── f-k-checks
       └── f-k-checks-item: multi_col_child(p,q,r) -> multi_col_parent(p,q,r)
-           └── anti-join
+           └── anti-join (hash)
                 ├── columns: column2:6(int!null) column3:7(int!null) column4:8(int!null)
                 ├── project
                 │    ├── columns: column2:6(int!null) column3:7(int!null) column4:8(int!null)
@@ -401,7 +401,7 @@ insert multi_col_child_full
  │              └── null [type=unknown]
  └── f-k-checks
       └── f-k-checks-item: multi_col_child_full(p,q,r) -> multi_col_parent(p,q,r)
-           └── anti-join
+           └── anti-join (hash)
                 ├── columns: column2:6(int) column3:7(int) column4:8(int)
                 ├── select
                 │    ├── columns: column2:6(int) column3:7(int) column4:8(int)
@@ -469,7 +469,7 @@ insert multi_col_child_full
  │         └── const: 20 [type=int]
  └── f-k-checks
       └── f-k-checks-item: multi_col_child_full(p,q,r) -> multi_col_parent(p,q,r)
-           └── anti-join
+           └── anti-join (hash)
                 ├── columns: column2:6(int) column3:7(int) column4:8(int!null)
                 ├── project
                 │    ├── columns: column2:6(int) column3:7(int) column4:8(int!null)
@@ -520,7 +520,7 @@ insert multi_col_child_full
  │         └── const: 10 [type=int]
  └── f-k-checks
       └── f-k-checks-item: multi_col_child_full(p,q,r) -> multi_col_parent(p,q,r)
-           └── anti-join
+           └── anti-join (hash)
                 ├── columns: column2:6(int!null) column3:7(int!null) column4:8(int!null)
                 ├── project
                 │    ├── columns: column2:6(int!null) column3:7(int!null) column4:8(int!null)
@@ -585,7 +585,7 @@ insert multi_ref_child
  │              └── null [type=unknown]
  └── f-k-checks
       ├── f-k-checks-item: multi_ref_child(a) -> multi_ref_parent_a(a)
-      │    └── anti-join
+      │    └── anti-join (hash)
       │         ├── columns: column2:6(int!null)
       │         ├── select
       │         │    ├── columns: column2:6(int!null)
@@ -612,7 +612,7 @@ insert multi_ref_child
       │                   ├── variable: column2 [type=int]
       │                   └── variable: t.public.multi_ref_parent_a.a [type=int]
       └── f-k-checks-item: multi_ref_child(b,c) -> multi_ref_parent_bc(b,c)
-           └── anti-join
+           └── anti-join (hash)
                 ├── columns: column3:7(int!null) column4:8(int!null)
                 ├── select
                 │    ├── columns: column3:7(int!null) column4:8(int!null)

--- a/pkg/sql/opt/optbuilder/testdata/inner-join
+++ b/pkg/sql/opt/optbuilder/testdata/inner-join
@@ -15,7 +15,7 @@ SELECT * FROM a, b
 ----
 project
  ├── columns: x:1(int!null) y:2(float) x:3(int) y:4(float)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: a.x:1(int!null) a.y:2(float) b.x:3(int) b.y:4(float) rowid:5(int!null)
       ├── scan a
       │    └── columns: a.x:1(int!null) a.y:2(float)
@@ -30,7 +30,7 @@ project
  ├── columns: x:1(int!null) y:4(float)
  └── select
       ├── columns: a.x:1(int!null) a.y:2(float) b.x:3(int!null) b.y:4(float) rowid:5(int!null)
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── columns: a.x:1(int!null) a.y:2(float) b.x:3(int) b.y:4(float) rowid:5(int!null)
       │    ├── scan a
       │    │    └── columns: a.x:1(int!null) a.y:2(float)
@@ -49,11 +49,11 @@ project
  ├── columns: x:1(int!null) y:2(float) z:3(varchar) x:5(int!null) y:6(float) x:8(int!null) y:9(float)
  └── select
       ├── columns: c.x:1(int!null) c.y:2(float) z:3(varchar) c.rowid:4(int!null) b.x:5(int!null) b.y:6(float) b.rowid:7(int!null) a.x:8(int!null) a.y:9(float)
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── columns: c.x:1(int) c.y:2(float) z:3(varchar) c.rowid:4(int!null) b.x:5(int) b.y:6(float) b.rowid:7(int!null) a.x:8(int!null) a.y:9(float)
       │    ├── scan c
       │    │    └── columns: c.x:1(int) c.y:2(float) z:3(varchar) c.rowid:4(int!null)
-      │    ├── inner-join
+      │    ├── inner-join (hash)
       │    │    ├── columns: b.x:5(int) b.y:6(float) b.rowid:7(int!null) a.x:8(int!null) a.y:9(float)
       │    │    ├── scan b
       │    │    │    └── columns: b.x:5(int) b.y:6(float) b.rowid:7(int!null)
@@ -91,7 +91,7 @@ error (42702): column reference "x" is ambiguous (candidates: a.x, b.x)
 build fully-qualify-names
 SELECT * FROM db1.a, db2.a
 ----
-inner-join
+inner-join (hash)
  ├── columns: x:1(int!null) y:2(float) z:3(string) x:4(int!null) y:5(float)
  ├── scan db1.public.a
  │    └── columns: db1.public.a.x:1(int!null) db1.public.a.y:2(float) db1.public.a.z:3(string)
@@ -108,7 +108,7 @@ error (42712): source name "a" specified more than once (missing AS clause)
 build fully-qualify-names
 SELECT * FROM a, (SELECT * FROM a) AS a
 ----
-inner-join
+inner-join (hash)
  ├── columns: x:1(int!null) y:2(float) x:3(int!null) y:4(float)
  ├── scan t.public.a
  │    └── columns: t.public.a.x:1(int!null) t.public.a.y:2(float)
@@ -124,7 +124,7 @@ error (42712): source name "a" specified more than once (missing AS clause)
 build fully-qualify-names
 SELECT * FROM t.a, a AS a
 ----
-inner-join
+inner-join (hash)
  ├── columns: x:1(int!null) y:2(float) x:3(int!null) y:4(float)
  ├── scan t.public.a
  │    └── columns: t.public.a.x:1(int!null) t.public.a.y:2(float)

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -9,7 +9,7 @@ SELECT * FROM onecolumn AS a(x) CROSS JOIN onecolumn AS b(y)
 ----
 project
  ├── columns: x:1(int) y:3(int)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: x:1(int) a.rowid:2(int!null) y:3(int) b.rowid:4(int!null)
       ├── scan a
       │    └── columns: x:1(int) a.rowid:2(int!null)
@@ -32,7 +32,7 @@ SELECT x FROM (SELECT 1 AS x), onecolumn AS a, onecolumn AS b
 ----
 project
  ├── columns: x:1(int!null)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: x:1(int!null) a.x:2(int) a.rowid:3(int!null) b.x:4(int) b.rowid:5(int!null)
       ├── project
       │    ├── columns: x:1(int!null)
@@ -40,7 +40,7 @@ project
       │    │    └── tuple [type=tuple]
       │    └── projections
       │         └── const: 1 [type=int]
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── columns: a.x:2(int) a.rowid:3(int!null) b.x:4(int) b.rowid:5(int!null)
       │    ├── scan a
       │    │    └── columns: a.x:2(int) a.rowid:3(int!null)
@@ -54,7 +54,7 @@ SELECT * FROM onecolumn AS a(x) JOIN onecolumn AS b(y) ON a.x = b.y
 ----
 project
  ├── columns: x:1(int!null) y:3(int!null)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: x:1(int!null) a.rowid:2(int!null) y:3(int!null) b.rowid:4(int!null)
       ├── scan a
       │    └── columns: x:1(int) a.rowid:2(int!null)
@@ -73,7 +73,7 @@ sort
  ├── ordering: +1
  └── project
       ├── columns: a.x:1(int!null)
-      └── inner-join
+      └── inner-join (hash)
            ├── columns: a.x:1(int!null) a.rowid:2(int!null) b.x:3(int!null) b.rowid:4(int!null)
            ├── scan a
            │    └── columns: a.x:1(int) a.rowid:2(int!null)
@@ -89,7 +89,7 @@ SELECT * FROM onecolumn AS a NATURAL JOIN onecolumn as b
 ----
 project
  ├── columns: x:1(int!null)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: a.x:1(int!null) a.rowid:2(int!null) b.x:3(int!null) b.rowid:4(int!null)
       ├── scan a
       │    └── columns: a.x:1(int) a.rowid:2(int!null)
@@ -105,7 +105,7 @@ SELECT * FROM onecolumn AS a(x) LEFT OUTER JOIN onecolumn AS b(y) ON a.x = b.y
 ----
 project
  ├── columns: x:1(int) y:3(int)
- └── left-join
+ └── left-join (hash)
       ├── columns: x:1(int) a.rowid:2(int!null) y:3(int) b.rowid:4(int)
       ├── scan a
       │    └── columns: x:1(int) a.rowid:2(int!null)
@@ -124,7 +124,7 @@ sort
  ├── ordering: +1
  └── project
       ├── columns: a.x:1(int)
-      └── left-join
+      └── left-join (hash)
            ├── columns: a.x:1(int) a.rowid:2(int!null) b.x:3(int) b.rowid:4(int)
            ├── scan a
            │    └── columns: a.x:1(int) a.rowid:2(int!null)
@@ -167,7 +167,7 @@ SELECT * FROM onecolumn AS a NATURAL LEFT OUTER JOIN onecolumn AS b
 ----
 project
  ├── columns: x:1(int)
- └── left-join
+ └── left-join (hash)
       ├── columns: a.x:1(int) a.rowid:2(int!null) b.x:3(int) b.rowid:4(int)
       ├── scan a
       │    └── columns: a.x:1(int) a.rowid:2(int!null)
@@ -183,7 +183,7 @@ SELECT * FROM onecolumn AS a(x) RIGHT OUTER JOIN onecolumn AS b(y) ON a.x = b.y
 ----
 project
  ├── columns: x:1(int) y:3(int)
- └── right-join
+ └── right-join (hash)
       ├── columns: x:1(int) a.rowid:2(int) y:3(int) b.rowid:4(int!null)
       ├── scan a
       │    └── columns: x:1(int) a.rowid:2(int!null)
@@ -202,7 +202,7 @@ sort
  ├── ordering: +3
  └── project
       ├── columns: b.x:3(int)
-      └── right-join
+      └── right-join (hash)
            ├── columns: a.x:1(int) a.rowid:2(int) b.x:3(int) b.rowid:4(int!null)
            ├── scan a
            │    └── columns: a.x:1(int) a.rowid:2(int!null)
@@ -218,7 +218,7 @@ SELECT * FROM onecolumn AS a NATURAL RIGHT OUTER JOIN onecolumn AS b
 ----
 project
  ├── columns: x:3(int)
- └── right-join
+ └── right-join (hash)
       ├── columns: a.x:1(int) a.rowid:2(int) b.x:3(int) b.rowid:4(int!null)
       ├── scan a
       │    └── columns: a.x:1(int) a.rowid:2(int!null)
@@ -238,7 +238,7 @@ SELECT * FROM onecolumn AS a NATURAL JOIN onecolumn_w as b
 ----
 project
  ├── columns: x:1(int) w:3(int)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: x:1(int) a.rowid:2(int!null) w:3(int) b.rowid:4(int!null)
       ├── scan a
       │    └── columns: x:1(int) a.rowid:2(int!null)
@@ -258,7 +258,7 @@ sort
  ├── ordering: +1,+3
  └── project
       ├── columns: a.x:1(int) b.x:3(int)
-      └── full-join
+      └── full-join (hash)
            ├── columns: a.x:1(int) a.rowid:2(int) b.x:3(int) b.rowid:4(int)
            ├── scan a
            │    └── columns: a.x:1(int) a.rowid:2(int!null)
@@ -279,7 +279,7 @@ sort
       ├── columns: x:5(int)
       └── project
            ├── columns: x:5(int) a.x:1(int) a.rowid:2(int) b.x:3(int) b.rowid:4(int)
-           ├── full-join
+           ├── full-join (hash)
            │    ├── columns: a.x:1(int) a.rowid:2(int) b.x:3(int) b.rowid:4(int)
            │    ├── scan a
            │    │    └── columns: a.x:1(int) a.rowid:2(int!null)
@@ -306,7 +306,7 @@ sort
       ├── columns: a.x:1(int) b.x:3(int) x:5(int)
       └── project
            ├── columns: x:5(int) a.x:1(int) a.rowid:2(int) b.x:3(int) b.rowid:4(int)
-           ├── full-join
+           ├── full-join (hash)
            │    ├── columns: a.x:1(int) a.rowid:2(int) b.x:3(int) b.rowid:4(int)
            │    ├── scan a
            │    │    └── columns: a.x:1(int) a.rowid:2(int!null)
@@ -331,7 +331,7 @@ sort
       ├── columns: x:5(int)
       └── project
            ├── columns: x:5(int) a.x:1(int) a.rowid:2(int) b.x:3(int) b.rowid:4(int)
-           ├── full-join
+           ├── full-join (hash)
            │    ├── columns: a.x:1(int) a.rowid:2(int) b.x:3(int) b.rowid:4(int)
            │    ├── scan a
            │    │    └── columns: a.x:1(int) a.rowid:2(int!null)
@@ -355,7 +355,7 @@ limit
  ├── columns: x:1(int!null)
  ├── project
  │    ├── columns: x:1(int!null)
- │    └── inner-join
+ │    └── inner-join (hash)
  │         ├── columns: x:1(int!null) column1:3(int!null)
  │         ├── project
  │         │    ├── columns: x:1(int)
@@ -380,7 +380,7 @@ SELECT * FROM onecolumn AS a(x) CROSS JOIN empty AS b(y)
 ----
 project
  ├── columns: x:1(int) y:3(int)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: x:1(int) a.rowid:2(int!null) y:3(int) b.rowid:4(int!null)
       ├── scan a
       │    └── columns: x:1(int) a.rowid:2(int!null)
@@ -393,7 +393,7 @@ SELECT * FROM empty AS a CROSS JOIN onecolumn AS b
 ----
 project
  ├── columns: x:1(int) x:3(int)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: a.x:1(int) a.rowid:2(int!null) b.x:3(int) b.rowid:4(int!null)
       ├── scan a
       │    └── columns: a.x:1(int) a.rowid:2(int!null)
@@ -406,7 +406,7 @@ SELECT * FROM onecolumn AS a(x) JOIN empty AS b(y) ON a.x = b.y
 ----
 project
  ├── columns: x:1(int!null) y:3(int!null)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: x:1(int!null) a.rowid:2(int!null) y:3(int!null) b.rowid:4(int!null)
       ├── scan a
       │    └── columns: x:1(int) a.rowid:2(int!null)
@@ -422,7 +422,7 @@ SELECT * FROM onecolumn AS a JOIN empty AS b USING(x)
 ----
 project
  ├── columns: x:1(int!null)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: a.x:1(int!null) a.rowid:2(int!null) b.x:3(int!null) b.rowid:4(int!null)
       ├── scan a
       │    └── columns: a.x:1(int) a.rowid:2(int!null)
@@ -438,7 +438,7 @@ SELECT * FROM empty AS a(x) JOIN onecolumn AS b(y) ON a.x = b.y
 ----
 project
  ├── columns: x:1(int!null) y:3(int!null)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: x:1(int!null) a.rowid:2(int!null) y:3(int!null) b.rowid:4(int!null)
       ├── scan a
       │    └── columns: x:1(int) a.rowid:2(int!null)
@@ -454,7 +454,7 @@ SELECT * FROM empty AS a JOIN onecolumn AS b USING(x)
 ----
 project
  ├── columns: x:1(int!null)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: a.x:1(int!null) a.rowid:2(int!null) b.x:3(int!null) b.rowid:4(int!null)
       ├── scan a
       │    └── columns: a.x:1(int) a.rowid:2(int!null)
@@ -473,7 +473,7 @@ sort
  ├── ordering: +1
  └── project
       ├── columns: x:1(int) y:3(int)
-      └── left-join
+      └── left-join (hash)
            ├── columns: x:1(int) a.rowid:2(int!null) y:3(int) b.rowid:4(int)
            ├── scan a
            │    └── columns: x:1(int) a.rowid:2(int!null)
@@ -492,7 +492,7 @@ sort
  ├── ordering: +1
  └── project
       ├── columns: a.x:1(int)
-      └── left-join
+      └── left-join (hash)
            ├── columns: a.x:1(int) a.rowid:2(int!null) b.x:3(int) b.rowid:4(int)
            ├── scan a
            │    └── columns: a.x:1(int) a.rowid:2(int!null)
@@ -508,7 +508,7 @@ SELECT * FROM empty AS a(x) LEFT OUTER JOIN onecolumn AS b(y) ON a.x = b.y
 ----
 project
  ├── columns: x:1(int) y:3(int)
- └── left-join
+ └── left-join (hash)
       ├── columns: x:1(int) a.rowid:2(int!null) y:3(int) b.rowid:4(int)
       ├── scan a
       │    └── columns: x:1(int) a.rowid:2(int!null)
@@ -524,7 +524,7 @@ SELECT * FROM empty AS a LEFT OUTER JOIN onecolumn AS b USING(x)
 ----
 project
  ├── columns: x:1(int)
- └── left-join
+ └── left-join (hash)
       ├── columns: a.x:1(int) a.rowid:2(int!null) b.x:3(int) b.rowid:4(int)
       ├── scan a
       │    └── columns: a.x:1(int) a.rowid:2(int!null)
@@ -540,7 +540,7 @@ SELECT * FROM onecolumn AS a(x) RIGHT OUTER JOIN empty AS b(y) ON a.x = b.y
 ----
 project
  ├── columns: x:1(int) y:3(int)
- └── right-join
+ └── right-join (hash)
       ├── columns: x:1(int) a.rowid:2(int) y:3(int) b.rowid:4(int!null)
       ├── scan a
       │    └── columns: x:1(int) a.rowid:2(int!null)
@@ -556,7 +556,7 @@ SELECT * FROM onecolumn AS a RIGHT OUTER JOIN empty AS b USING(x)
 ----
 project
  ├── columns: x:3(int)
- └── right-join
+ └── right-join (hash)
       ├── columns: a.x:1(int) a.rowid:2(int) b.x:3(int) b.rowid:4(int!null)
       ├── scan a
       │    └── columns: a.x:1(int) a.rowid:2(int!null)
@@ -575,7 +575,7 @@ sort
  ├── ordering: +3
  └── project
       ├── columns: x:1(int) y:3(int)
-      └── full-join
+      └── full-join (hash)
            ├── columns: x:1(int) a.rowid:2(int) y:3(int) b.rowid:4(int)
            ├── scan a
            │    └── columns: x:1(int) a.rowid:2(int!null)
@@ -596,7 +596,7 @@ sort
       ├── columns: x:5(int)
       └── project
            ├── columns: x:5(int) a.x:1(int) a.rowid:2(int) b.x:3(int) b.rowid:4(int)
-           ├── full-join
+           ├── full-join (hash)
            │    ├── columns: a.x:1(int) a.rowid:2(int) b.x:3(int) b.rowid:4(int)
            │    ├── scan a
            │    │    └── columns: a.x:1(int) a.rowid:2(int!null)
@@ -619,7 +619,7 @@ sort
  ├── ordering: +1
  └── project
       ├── columns: x:1(int) y:3(int)
-      └── full-join
+      └── full-join (hash)
            ├── columns: x:1(int) a.rowid:2(int) y:3(int) b.rowid:4(int)
            ├── scan a
            │    └── columns: x:1(int) a.rowid:2(int!null)
@@ -640,7 +640,7 @@ sort
       ├── columns: x:5(int)
       └── project
            ├── columns: x:5(int) a.x:1(int) a.rowid:2(int) b.x:3(int) b.rowid:4(int)
-           ├── full-join
+           ├── full-join (hash)
            │    ├── columns: a.x:1(int) a.rowid:2(int) b.x:3(int) b.rowid:4(int)
            │    ├── scan a
            │    │    └── columns: a.x:1(int) a.rowid:2(int!null)
@@ -665,7 +665,7 @@ SELECT * FROM onecolumn NATURAL JOIN twocolumn
 ----
 project
  ├── columns: x:1(int!null) y:4(int)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: onecolumn.x:1(int!null) onecolumn.rowid:2(int!null) twocolumn.x:3(int!null) y:4(int) twocolumn.rowid:5(int!null)
       ├── scan onecolumn
       │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
@@ -681,7 +681,7 @@ SELECT * FROM onecolumn JOIN twocolumn USING(x)
 ----
 project
  ├── columns: x:1(int!null) y:4(int)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: onecolumn.x:1(int!null) onecolumn.rowid:2(int!null) twocolumn.x:3(int!null) y:4(int) twocolumn.rowid:5(int!null)
       ├── scan onecolumn
       │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
@@ -697,7 +697,7 @@ SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
 ----
 project
  ├── columns: x:1(int!null) y:2(int) x:4(int) y:5(int!null)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: a.x:1(int!null) a.y:2(int) a.rowid:3(int!null) b.x:4(int) b.y:5(int!null) b.rowid:6(int!null)
       ├── scan a
       │    └── columns: a.x:1(int) a.y:2(int) a.rowid:3(int!null)
@@ -713,7 +713,7 @@ SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = a.y
 ----
 project
  ├── columns: x:1(int!null) y:2(int!null) x:4(int) y:5(int)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: a.x:1(int!null) a.y:2(int!null) a.rowid:3(int!null) b.x:4(int) b.y:5(int) b.rowid:6(int!null)
       ├── scan a
       │    └── columns: a.x:1(int) a.y:2(int) a.rowid:3(int!null)
@@ -729,7 +729,7 @@ SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b.y))
 ----
 project
  ├── columns: x:1(int!null) x:3(int) y:4(int!null)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: a.x:1(int!null) a.rowid:2(int!null) b.x:3(int) y:4(int!null) b.rowid:5(int!null)
       ├── scan a
       │    └── columns: a.x:1(int) a.rowid:2(int!null)
@@ -745,7 +745,7 @@ SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn.y
 ----
 project
  ├── columns: x:1(int!null) x:3(int) y:4(int!null)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: onecolumn.x:1(int!null) onecolumn.rowid:2(int!null) twocolumn.x:3(int) y:4(int!null) twocolumn.rowid:5(int!null)
       ├── scan onecolumn
       │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
@@ -762,7 +762,7 @@ SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
 ----
 project
  ├── columns: x:1(int!null) y:2(int) x:4(int) y:5(int)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: a.x:1(int!null) a.y:2(int) a.rowid:3(int!null) b.x:4(int) b.y:5(int) b.rowid:6(int!null)
       ├── scan a
       │    └── columns: a.x:1(int) a.y:2(int) a.rowid:3(int!null)
@@ -778,7 +778,7 @@ SELECT o.x, t.y FROM onecolumn o INNER JOIN twocolumn t ON (o.x=t.x AND t.y=53)
 ----
 project
  ├── columns: x:1(int!null) y:4(int!null)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: o.x:1(int!null) o.rowid:2(int!null) t.x:3(int!null) y:4(int!null) t.rowid:5(int!null)
       ├── scan o
       │    └── columns: o.x:1(int) o.rowid:2(int!null)
@@ -799,7 +799,7 @@ SELECT o.x, t.y FROM onecolumn o LEFT OUTER JOIN twocolumn t ON (o.x=t.x AND t.y
 ----
 project
  ├── columns: x:1(int) y:4(int)
- └── left-join
+ └── left-join (hash)
       ├── columns: o.x:1(int) o.rowid:2(int!null) t.x:3(int) y:4(int) t.rowid:5(int)
       ├── scan o
       │    └── columns: o.x:1(int) o.rowid:2(int!null)
@@ -819,7 +819,7 @@ SELECT o.x, t.y FROM onecolumn o LEFT OUTER JOIN twocolumn t ON (o.x=t.x AND o.x
 ----
 project
  ├── columns: x:1(int) y:4(int)
- └── left-join
+ └── left-join (hash)
       ├── columns: o.x:1(int) o.rowid:2(int!null) t.x:3(int) y:4(int) t.rowid:5(int)
       ├── scan o
       │    └── columns: o.x:1(int) o.rowid:2(int!null)
@@ -839,7 +839,7 @@ SELECT o.x, t.y FROM onecolumn o LEFT OUTER JOIN twocolumn t ON (o.x=t.x AND t.x
 ----
 project
  ├── columns: x:1(int) y:4(int)
- └── left-join
+ └── left-join (hash)
       ├── columns: o.x:1(int) o.rowid:2(int!null) t.x:3(int) y:4(int) t.rowid:5(int)
       ├── scan o
       │    └── columns: o.x:1(int) o.rowid:2(int!null)
@@ -880,7 +880,7 @@ SELECT * FROM a INNER JOIN b ON a.i = b.i
 ----
 project
  ├── columns: i:1(int!null) i:3(int!null) b:4(bool)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: a.i:1(int!null) a.rowid:2(int!null) b.i:3(int!null) b:4(bool) b.rowid:5(int!null)
       ├── scan a
       │    └── columns: a.i:1(int) a.rowid:2(int!null)
@@ -896,7 +896,7 @@ SELECT * FROM a LEFT OUTER JOIN b ON a.i = b.i
 ----
 project
  ├── columns: i:1(int) i:3(int) b:4(bool)
- └── left-join
+ └── left-join (hash)
       ├── columns: a.i:1(int) a.rowid:2(int!null) b.i:3(int) b:4(bool) b.rowid:5(int)
       ├── scan a
       │    └── columns: a.i:1(int) a.rowid:2(int!null)
@@ -915,7 +915,7 @@ sort
  ├── ordering: +3,+4
  └── project
       ├── columns: a.i:1(int) b.i:3(int) b:4(bool)
-      └── right-join
+      └── right-join (hash)
            ├── columns: a.i:1(int) a.rowid:2(int) b.i:3(int) b:4(bool) b.rowid:5(int!null)
            ├── scan a
            │    └── columns: a.i:1(int) a.rowid:2(int!null)
@@ -934,7 +934,7 @@ sort
  ├── ordering: +3,+4
  └── project
       ├── columns: a.i:1(int) b.i:3(int) b:4(bool)
-      └── full-join
+      └── full-join (hash)
            ├── columns: a.i:1(int) a.rowid:2(int) b.i:3(int) b:4(bool) b.rowid:5(int)
            ├── scan a
            │    └── columns: a.i:1(int) a.rowid:2(int!null)
@@ -954,7 +954,7 @@ sort
  ├── ordering: +1,+3
  └── project
       ├── columns: a.i:1(int) b.i:3(int) b:4(bool)
-      └── full-join
+      └── full-join (hash)
            ├── columns: a.i:1(int) a.rowid:2(int) b.i:3(int) b:4(bool) b.rowid:5(int)
            ├── scan a
            │    └── columns: a.i:1(int) a.rowid:2(int!null)
@@ -982,11 +982,11 @@ limit
  │    ├── ordering: +1
  │    └── project
  │         ├── columns: onecolumn.x:1(int!null) twocolumn.x:3(int!null) y:4(int) b:6(int!null) d:8(int!null) e:9(int)
- │         └── inner-join
+ │         └── inner-join (hash)
  │              ├── columns: onecolumn.x:1(int!null) onecolumn.rowid:2(int!null) twocolumn.x:3(int!null) y:4(int) twocolumn.rowid:5(int!null) b:6(int!null) a.rowid:7(int!null) d:8(int!null) e:9(int) c.rowid:10(int!null)
- │              ├── inner-join
+ │              ├── inner-join (hash)
  │              │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int!null) y:4(int) twocolumn.rowid:5(int!null) b:6(int!null) a.rowid:7(int!null)
- │              │    ├── inner-join
+ │              │    ├── inner-join (hash)
  │              │    │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) y:4(int) twocolumn.rowid:5(int!null)
  │              │    │    ├── scan onecolumn
  │              │    │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
@@ -1017,7 +1017,7 @@ SELECT * FROM onecolumn JOIN twocolumn ON twocolumn.x = onecolumn.x AND onecolum
 ----
 project
  ├── columns: x:1(int!null) x:3(int!null) y:4(int)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: onecolumn.x:1(int!null) onecolumn.rowid:2(int!null) twocolumn.x:3(int!null) y:4(int) twocolumn.rowid:5(int!null)
       ├── scan onecolumn
       │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
@@ -1047,7 +1047,7 @@ SELECT * FROM onecolumn JOIN (VALUES (41),(42),(43)) AS a(x) USING(x)
 ----
 project
  ├── columns: x:1(int!null)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: x:1(int!null) rowid:2(int!null) column1:3(int!null)
       ├── scan onecolumn
       │    └── columns: x:1(int) rowid:2(int!null)
@@ -1069,7 +1069,7 @@ SELECT * FROM onecolumn JOIN (SELECT x + 2 AS x FROM onecolumn) USING(x)
 ----
 project
  ├── columns: x:1(int!null)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: onecolumn.x:1(int!null) rowid:2(int!null) x:5(int!null)
       ├── scan onecolumn
       │    └── columns: onecolumn.x:1(int) rowid:2(int!null)
@@ -1099,9 +1099,9 @@ limit
  │    ├── ordering: +1
  │    └── project
  │         ├── columns: a.x:1(int!null) a.y:2(int) b.y:5(int) c.y:8(int)
- │         └── inner-join
+ │         └── inner-join (hash)
  │              ├── columns: a.x:1(int!null) a.y:2(int) a.rowid:3(int!null) b.x:4(int!null) b.y:5(int) b.rowid:6(int!null) c.x:7(int!null) c.y:8(int) c.rowid:9(int!null)
- │              ├── inner-join
+ │              ├── inner-join (hash)
  │              │    ├── columns: a.x:1(int!null) a.y:2(int) a.rowid:3(int!null) b.x:4(int!null) b.y:5(int) b.rowid:6(int!null)
  │              │    ├── scan a
  │              │    │    └── columns: a.x:1(int) a.y:2(int) a.rowid:3(int!null)
@@ -1127,9 +1127,9 @@ sort
  ├── ordering: +1
  └── project
       ├── columns: a.x:1(int!null) a.y:2(int) b.x:4(int!null) b.y:5(int) c.x:7(int!null) c.y:8(int)
-      └── inner-join
+      └── inner-join (hash)
            ├── columns: a.x:1(int!null) a.y:2(int) a.rowid:3(int!null) b.x:4(int!null) b.y:5(int) b.rowid:6(int!null) c.x:7(int!null) c.y:8(int) c.rowid:9(int!null)
-           ├── inner-join
+           ├── inner-join (hash)
            │    ├── columns: a.x:1(int!null) a.y:2(int) a.rowid:3(int!null) b.x:4(int!null) b.y:5(int) b.rowid:6(int!null)
            │    ├── scan a
            │    │    └── columns: a.x:1(int) a.y:2(int) a.rowid:3(int!null)
@@ -1179,7 +1179,7 @@ error (42712): source name "onecolumn" specified more than once (missing AS clau
 build
 SELECT * FROM (SELECT * FROM onecolumn), (SELECT * FROM onecolumn)
 ----
-inner-join
+inner-join (hash)
  ├── columns: x:1(int) x:3(int)
  ├── project
  │    ├── columns: x:1(int)
@@ -1197,9 +1197,9 @@ SELECT x FROM (onecolumn JOIN othercolumn USING (x)) JOIN (onecolumn AS a JOIN o
 ----
 project
  ├── columns: x:1(int!null)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: onecolumn.x:1(int!null) onecolumn.rowid:2(int!null) othercolumn.x:3(int!null) othercolumn.rowid:4(int!null) a.x:5(int!null) a.rowid:6(int!null) b.x:7(int!null) b.rowid:8(int!null)
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── columns: onecolumn.x:1(int!null) onecolumn.rowid:2(int!null) othercolumn.x:3(int!null) othercolumn.rowid:4(int!null)
       │    ├── scan onecolumn
       │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
@@ -1209,7 +1209,7 @@ project
       │         └── eq [type=bool]
       │              ├── variable: onecolumn.x [type=int]
       │              └── variable: othercolumn.x [type=int]
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── columns: a.x:5(int!null) a.rowid:6(int!null) b.x:7(int!null) b.rowid:8(int!null)
       │    ├── scan a
       │    │    └── columns: a.x:5(int) a.rowid:6(int!null)
@@ -1246,7 +1246,7 @@ SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
 ----
 project
  ├── columns: x:1(int) y:5(int)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: a.x:1(int) a.y:2(int) a.rowid:3(int!null) b.x:4(int) b.y:5(int) b.rowid:6(int!null)
       ├── scan a
       │    └── columns: a.x:1(int) a.y:2(int) a.rowid:3(int!null)
@@ -1259,7 +1259,7 @@ SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
 ----
 project
  ├── columns: y:5(int)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: a.x:1(int!null) a.y:2(int) a.rowid:3(int!null) b.x:4(int!null) b.y:5(int) b.rowid:6(int!null)
       ├── scan a
       │    └── columns: a.x:1(int) a.y:2(int) a.rowid:3(int!null)
@@ -1275,7 +1275,7 @@ SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = b.x)
 ----
 project
  ├── columns: y:5(int)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: a.x:1(int!null) a.y:2(int) a.rowid:3(int!null) b.x:4(int!null) b.y:5(int) b.rowid:6(int!null)
       ├── scan a
       │    └── columns: a.x:1(int) a.y:2(int) a.rowid:3(int!null)
@@ -1291,7 +1291,7 @@ SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b.y)
 ----
 project
  ├── columns: x:1(int!null)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: a.x:1(int!null) a.y:2(int) a.rowid:3(int!null) b.x:4(int) b.y:5(int!null) b.rowid:6(int!null)
       ├── scan a
       │    └── columns: a.x:1(int) a.y:2(int) a.rowid:3(int!null)
@@ -1311,7 +1311,7 @@ sort
  ├── ordering: +1
  └── project
       ├── columns: column1:1(int!null) column2:2(int!null) column2:4(int!null)
-      └── inner-join
+      └── inner-join (hash)
            ├── columns: column1:1(int!null) column2:2(int!null) column1:3(int!null) column2:4(int!null)
            ├── values
            │    ├── columns: column1:1(int!null) column2:2(int!null)
@@ -1352,7 +1352,7 @@ project
  ├── columns: a:1(int) b:2(int!null) n:4(int!null) sq:5(int)
  └── select
       ├── columns: a:1(int) b:2(int!null) rowid:3(int!null) n:4(int!null) sq:5(int)
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── columns: a:1(int) b:2(int) rowid:3(int!null) n:4(int!null) sq:5(int)
       │    ├── scan pairs
       │    │    └── columns: a:1(int) b:2(int) rowid:3(int!null)
@@ -1372,7 +1372,7 @@ project
  ├── columns: a:1(int) b:2(int) n:4(int!null) sq:5(int)
  └── select
       ├── columns: a:1(int) b:2(int) rowid:3(int!null) n:4(int!null) sq:5(int)
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── columns: a:1(int) b:2(int) rowid:3(int!null) n:4(int!null) sq:5(int)
       │    ├── scan pairs
       │    │    └── columns: a:1(int) b:2(int) rowid:3(int!null)
@@ -1398,7 +1398,7 @@ project
       ├── columns: a:1(int) b:2(int) n:4(int!null) sq:5(int!null) sum:6(int!null)
       ├── project
       │    ├── columns: sum:6(int) a:1(int) b:2(int) n:4(int!null) sq:5(int)
-      │    ├── inner-join
+      │    ├── inner-join (hash)
       │    │    ├── columns: a:1(int) b:2(int) rowid:3(int!null) n:4(int!null) sq:5(int)
       │    │    ├── scan pairs
       │    │    │    └── columns: a:1(int) b:2(int) rowid:3(int!null)
@@ -1420,7 +1420,7 @@ SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq
 ----
 project
  ├── columns: a:1(int) b:2(int) n:4(int) sq:5(int)
- └── full-join
+ └── full-join (hash)
       ├── columns: a:1(int) b:2(int) rowid:3(int) n:4(int) sq:5(int)
       ├── scan pairs
       │    └── columns: a:1(int) b:2(int) rowid:3(int!null)
@@ -1440,7 +1440,7 @@ project
  ├── columns: a:1(int) b:2(int) n:4(int) sq:5(int)
  └── select
       ├── columns: a:1(int) b:2(int) rowid:3(int) n:4(int) sq:5(int)
-      ├── full-join
+      ├── full-join (hash)
       │    ├── columns: a:1(int) b:2(int) rowid:3(int) n:4(int) sq:5(int)
       │    ├── scan pairs
       │    │    └── columns: a:1(int) b:2(int) rowid:3(int!null)
@@ -1472,7 +1472,7 @@ select
  ├── columns: a:1(int) b:2(int!null) n:4(int) sq:5(int)
  ├── project
  │    ├── columns: a:1(int) b:2(int) n:4(int) sq:5(int)
- │    └── left-join
+ │    └── left-join (hash)
  │         ├── columns: a:1(int) b:2(int) rowid:3(int!null) n:4(int) sq:5(int)
  │         ├── scan pairs
  │         │    └── columns: a:1(int) b:2(int) rowid:3(int!null)
@@ -1520,7 +1520,7 @@ select
  ├── columns: a:1(int) b:2(int) n:4(int!null) sq:5(int)
  ├── project
  │    ├── columns: a:1(int) b:2(int) n:4(int!null) sq:5(int)
- │    └── right-join
+ │    └── right-join (hash)
  │         ├── columns: a:1(int) b:2(int) rowid:3(int) n:4(int!null) sq:5(int)
  │         ├── scan pairs
  │         │    └── columns: a:1(int) b:2(int) rowid:3(int!null)
@@ -1569,7 +1569,7 @@ select
  ├── columns: a:1(int!null) b:2(int!null) n:4(int!null) sq:5(int!null)
  ├── project
  │    ├── columns: a:1(int!null) b:2(int!null) n:4(int!null) sq:5(int!null)
- │    └── inner-join
+ │    └── inner-join (hash)
  │         ├── columns: a:1(int!null) b:2(int!null) rowid:3(int!null) n:4(int!null) sq:5(int!null)
  │         ├── scan pairs
  │         │    └── columns: a:1(int) b:2(int) rowid:3(int!null)
@@ -1622,7 +1622,7 @@ SELECT * FROM t1 JOIN t2 USING(x)
 ----
 project
  ├── columns: x:2(int!null) col1:1(int) col2:3(int) y:4(int) col3:6(int) y:7(int) col4:9(int)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: col1:1(int) t1.x:2(int!null) col2:3(int) t1.y:4(int) t1.rowid:5(int!null) col3:6(int) t2.y:7(int) t2.x:8(int!null) col4:9(int) t2.rowid:10(int!null)
       ├── scan t1
       │    └── columns: col1:1(int) t1.x:2(int) col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
@@ -1638,7 +1638,7 @@ SELECT * FROM t1 NATURAL JOIN t2
 ----
 project
  ├── columns: x:2(int!null) y:4(int!null) col1:1(int) col2:3(int) col3:6(int) col4:9(int)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: col1:1(int) t1.x:2(int!null) col2:3(int) t1.y:4(int!null) t1.rowid:5(int!null) col3:6(int) t2.y:7(int!null) t2.x:8(int!null) col4:9(int) t2.rowid:10(int!null)
       ├── scan t1
       │    └── columns: col1:1(int) t1.x:2(int) col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
@@ -1657,7 +1657,7 @@ SELECT x, t1.x, t2.x FROM t1 NATURAL JOIN t2
 ----
 project
  ├── columns: x:2(int!null) x:2(int!null) x:8(int!null)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: col1:1(int) t1.x:2(int!null) col2:3(int) t1.y:4(int!null) t1.rowid:5(int!null) col3:6(int) t2.y:7(int!null) t2.x:8(int!null) col4:9(int) t2.rowid:10(int!null)
       ├── scan t1
       │    └── columns: col1:1(int) t1.x:2(int) col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
@@ -1676,7 +1676,7 @@ SELECT t1.*, t2.* FROM t1 NATURAL JOIN t2
 ----
 project
  ├── columns: x:2(int!null) y:4(int!null) col1:1(int) col2:3(int) col3:6(int) col4:9(int)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: col1:1(int) t1.x:2(int!null) col2:3(int) t1.y:4(int!null) t1.rowid:5(int!null) col3:6(int) t2.y:7(int!null) t2.x:8(int!null) col4:9(int) t2.rowid:10(int!null)
       ├── scan t1
       │    └── columns: col1:1(int) t1.x:2(int) col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
@@ -1695,7 +1695,7 @@ SELECT * FROM t1 JOIN t2 ON t2.x=t1.x
 ----
 project
  ├── columns: col1:1(int) x:2(int!null) col2:3(int) y:4(int) col3:6(int) y:7(int) x:8(int!null) col4:9(int)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: col1:1(int) t1.x:2(int!null) col2:3(int) t1.y:4(int) t1.rowid:5(int!null) col3:6(int) t2.y:7(int) t2.x:8(int!null) col4:9(int) t2.rowid:10(int!null)
       ├── scan t1
       │    └── columns: col1:1(int) t1.x:2(int) col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
@@ -1713,7 +1713,7 @@ project
  ├── columns: x:11(int) col1:1(int) col2:3(int) y:4(int) col3:6(int) y:7(int) col4:9(int)
  └── project
       ├── columns: x:11(int) col1:1(int) t1.x:2(int) col2:3(int) t1.y:4(int) t1.rowid:5(int) col3:6(int) t2.y:7(int) t2.x:8(int) col4:9(int) t2.rowid:10(int)
-      ├── full-join
+      ├── full-join (hash)
       │    ├── columns: col1:1(int) t1.x:2(int) col2:3(int) t1.y:4(int) t1.rowid:5(int) col3:6(int) t2.y:7(int) t2.x:8(int) col4:9(int) t2.rowid:10(int)
       │    ├── scan t1
       │    │    └── columns: col1:1(int) t1.x:2(int) col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
@@ -1735,7 +1735,7 @@ project
  ├── columns: x:11(int) y:12(int) col1:1(int) col2:3(int) col3:6(int) col4:9(int)
  └── project
       ├── columns: x:11(int) y:12(int) col1:1(int) t1.x:2(int) col2:3(int) t1.y:4(int) t1.rowid:5(int) col3:6(int) t2.y:7(int) t2.x:8(int) col4:9(int) t2.rowid:10(int)
-      ├── full-join
+      ├── full-join (hash)
       │    ├── columns: col1:1(int) t1.x:2(int) col2:3(int) t1.y:4(int) t1.rowid:5(int) col3:6(int) t2.y:7(int) t2.x:8(int) col4:9(int) t2.rowid:10(int)
       │    ├── scan t1
       │    │    └── columns: col1:1(int) t1.x:2(int) col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
@@ -1764,7 +1764,7 @@ project
  ├── columns: x:13(int) plus1:6(int) two:12(int)
  └── project
       ├── columns: x:13(int) t1.x:2(int) plus1:6(int) t2.x:9(int) two:12(int)
-      ├── full-join
+      ├── full-join (hash)
       │    ├── columns: t1.x:2(int) plus1:6(int) t2.x:9(int) two:12(int)
       │    ├── project
       │    │    ├── columns: plus1:6(int) t1.x:2(int)
@@ -1794,7 +1794,7 @@ SELECT * FROM t1 FULL OUTER JOIN t2 ON t1.x=t2.x
 ----
 project
  ├── columns: col1:1(int) x:2(int) col2:3(int) y:4(int) col3:6(int) y:7(int) x:8(int) col4:9(int)
- └── full-join
+ └── full-join (hash)
       ├── columns: col1:1(int) t1.x:2(int) col2:3(int) t1.y:4(int) t1.rowid:5(int) col3:6(int) t2.y:7(int) t2.x:8(int) col4:9(int) t2.rowid:10(int)
       ├── scan t1
       │    └── columns: col1:1(int) t1.x:2(int) col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
@@ -1810,7 +1810,7 @@ SELECT t2.x, t1.x, x FROM t1 JOIN t2 USING(x)
 ----
 project
  ├── columns: x:8(int!null) x:2(int!null) x:2(int!null)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: col1:1(int) t1.x:2(int!null) col2:3(int) t1.y:4(int) t1.rowid:5(int!null) col3:6(int) t2.y:7(int) t2.x:8(int!null) col4:9(int) t2.rowid:10(int!null)
       ├── scan t1
       │    └── columns: col1:1(int) t1.x:2(int) col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
@@ -1828,7 +1828,7 @@ project
  ├── columns: x:8(int) x:2(int) x:11(int)
  └── project
       ├── columns: x:11(int) col1:1(int) t1.x:2(int) col2:3(int) t1.y:4(int) t1.rowid:5(int) col3:6(int) t2.y:7(int) t2.x:8(int) col4:9(int) t2.rowid:10(int)
-      ├── full-join
+      ├── full-join (hash)
       │    ├── columns: col1:1(int) t1.x:2(int) col2:3(int) t1.y:4(int) t1.rowid:5(int) col3:6(int) t2.y:7(int) t2.x:8(int) col4:9(int) t2.rowid:10(int)
       │    ├── scan t1
       │    │    └── columns: col1:1(int) t1.x:2(int) col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
@@ -1849,7 +1849,7 @@ SELECT x FROM t1 NATURAL JOIN (SELECT * FROM t2)
 ----
 project
  ├── columns: x:2(int!null)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: col1:1(int) t1.x:2(int!null) col2:3(int) t1.y:4(int!null) t1.rowid:5(int!null) col3:6(int) t2.y:7(int!null) t2.x:8(int!null) col4:9(int)
       ├── scan t1
       │    └── columns: col1:1(int) t1.x:2(int) col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
@@ -1885,7 +1885,7 @@ CREATE TABLE pkBAD (a INT, b INT, c INT, d INT, PRIMARY KEY(b,a,d))
 build
 SELECT * FROM pkBA AS l JOIN pkBC AS r ON l.a = r.a AND l.b = r.b AND l.c = r.c
 ----
-inner-join
+inner-join (hash)
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int) a:5(int!null) b:6(int!null) c:7(int!null) d:8(int)
  ├── scan l
  │    └── columns: l.a:1(int!null) l.b:2(int!null) l.c:3(int) l.d:4(int)
@@ -1909,7 +1909,7 @@ SELECT * FROM pkBA NATURAL JOIN pkBAD
 ----
 project
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int!null)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: pkba.a:1(int!null) pkba.b:2(int!null) pkba.c:3(int!null) pkba.d:4(int!null) pkbad.a:5(int!null) pkbad.b:6(int!null) pkbad.c:7(int!null) pkbad.d:8(int!null)
       ├── scan pkba
       │    └── columns: pkba.a:1(int!null) pkba.b:2(int!null) pkba.c:3(int) pkba.d:4(int)
@@ -1934,7 +1934,7 @@ SELECT * FROM pkBAC AS l JOIN pkBAC AS r USING(a, b, c)
 ----
 project
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int) d:8(int)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: l.a:1(int!null) l.b:2(int!null) l.c:3(int!null) l.d:4(int) r.a:5(int!null) r.b:6(int!null) r.c:7(int!null) r.d:8(int)
       ├── scan l
       │    └── columns: l.a:1(int!null) l.b:2(int!null) l.c:3(int!null) l.d:4(int)
@@ -1954,7 +1954,7 @@ project
 build
 SELECT * FROM pkBAC AS l JOIN pkBAD AS r ON l.c = r.d AND l.a = r.a AND l.b = r.b
 ----
-inner-join
+inner-join (hash)
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int) a:5(int!null) b:6(int!null) c:7(int) d:8(int!null)
  ├── scan l
  │    └── columns: l.a:1(int!null) l.b:2(int!null) l.c:3(int!null) l.d:4(int)
@@ -1987,7 +1987,7 @@ SELECT s, str1.s, str2.s FROM str1 INNER JOIN str2 USING(s)
 ----
 project
  ├── columns: s:2(collatedstring{en_u_ks_level1}!null) s:2(collatedstring{en_u_ks_level1}!null) s:4(collatedstring{en_u_ks_level1}!null)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: str1.a:1(int!null) str1.s:2(collatedstring{en_u_ks_level1}!null) str2.a:3(int!null) str2.s:4(collatedstring{en_u_ks_level1}!null)
       ├── scan str1
       │    └── columns: str1.a:1(int!null) str1.s:2(collatedstring{en_u_ks_level1})
@@ -2003,7 +2003,7 @@ SELECT s, str1.s, str2.s FROM str1 LEFT OUTER JOIN str2 USING(s)
 ----
 project
  ├── columns: s:2(collatedstring{en_u_ks_level1}) s:2(collatedstring{en_u_ks_level1}) s:4(collatedstring{en_u_ks_level1})
- └── left-join
+ └── left-join (hash)
       ├── columns: str1.a:1(int!null) str1.s:2(collatedstring{en_u_ks_level1}) str2.a:3(int) str2.s:4(collatedstring{en_u_ks_level1})
       ├── scan str1
       │    └── columns: str1.a:1(int!null) str1.s:2(collatedstring{en_u_ks_level1})
@@ -2021,7 +2021,7 @@ project
  ├── columns: s:5(collatedstring{en_u_ks_level1}) s:2(collatedstring{en_u_ks_level1}) s:4(collatedstring{en_u_ks_level1})
  └── project
       ├── columns: s:5(collatedstring{en_u_ks_level1}) str1.a:1(int) str1.s:2(collatedstring{en_u_ks_level1}) str2.a:3(int!null) str2.s:4(collatedstring{en_u_ks_level1})
-      ├── right-join
+      ├── right-join (hash)
       │    ├── columns: str1.a:1(int) str1.s:2(collatedstring{en_u_ks_level1}) str2.a:3(int!null) str2.s:4(collatedstring{en_u_ks_level1})
       │    ├── scan str1
       │    │    └── columns: str1.a:1(int!null) str1.s:2(collatedstring{en_u_ks_level1})
@@ -2043,7 +2043,7 @@ project
  ├── columns: s:5(collatedstring{en_u_ks_level1}) s:2(collatedstring{en_u_ks_level1}) s:4(collatedstring{en_u_ks_level1})
  └── project
       ├── columns: s:5(collatedstring{en_u_ks_level1}) str1.a:1(int) str1.s:2(collatedstring{en_u_ks_level1}) str2.a:3(int) str2.s:4(collatedstring{en_u_ks_level1})
-      ├── full-join
+      ├── full-join (hash)
       │    ├── columns: str1.a:1(int) str1.s:2(collatedstring{en_u_ks_level1}) str2.a:3(int) str2.s:4(collatedstring{en_u_ks_level1})
       │    ├── scan str1
       │    │    └── columns: str1.a:1(int!null) str1.s:2(collatedstring{en_u_ks_level1})
@@ -2067,7 +2067,7 @@ project
  ├── columns: a:3(int!null) s:5(collatedstring{en_u_ks_level1})
  └── project
       ├── columns: s:5(collatedstring{en_u_ks_level1}) str1.a:1(int) str1.s:2(collatedstring{en_u_ks_level1}) str2.a:3(int!null) str2.s:4(collatedstring{en_u_ks_level1})
-      ├── right-join
+      ├── right-join (hash)
       │    ├── columns: str1.a:1(int) str1.s:2(collatedstring{en_u_ks_level1}) str2.a:3(int!null) str2.s:4(collatedstring{en_u_ks_level1})
       │    ├── scan str1
       │    │    └── columns: str1.a:1(int!null) str1.s:2(collatedstring{en_u_ks_level1})
@@ -2101,7 +2101,7 @@ project
  ├── columns: x:1(int!null) y:2(int!null) u:3(int!null) v:6(int!null)
  └── select
       ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) u:3(int!null) xyv.x:4(int!null) xyv.y:5(int!null) v:6(int!null)
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) u:3(int!null) xyv.x:4(int!null) xyv.y:5(int!null) v:6(int!null)
       │    ├── scan xyu
       │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) u:3(int!null)
@@ -2126,7 +2126,7 @@ project
  ├── columns: x:1(int!null) y:2(int!null) u:3(int!null) v:6(int)
  └── select
       ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) u:3(int!null) xyv.x:4(int) xyv.y:5(int) v:6(int)
-      ├── left-join
+      ├── left-join (hash)
       │    ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) u:3(int!null) xyv.x:4(int) xyv.y:5(int) v:6(int)
       │    ├── scan xyu
       │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) u:3(int!null)
@@ -2151,7 +2151,7 @@ project
  ├── columns: x:4(int!null) y:5(int!null) u:3(int) v:6(int!null)
  └── select
       ├── columns: xyu.x:1(int) xyu.y:2(int) u:3(int) xyv.x:4(int!null) xyv.y:5(int!null) v:6(int!null)
-      ├── right-join
+      ├── right-join (hash)
       │    ├── columns: xyu.x:1(int) xyu.y:2(int) u:3(int) xyv.x:4(int!null) xyv.y:5(int!null) v:6(int!null)
       │    ├── scan xyu
       │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) u:3(int!null)
@@ -2178,7 +2178,7 @@ project
       ├── columns: xyu.x:1(int) xyu.y:2(int) u:3(int) xyv.x:4(int) xyv.y:5(int) v:6(int) x:7(int!null) y:8(int)
       ├── project
       │    ├── columns: x:7(int) y:8(int) xyu.x:1(int) xyu.y:2(int) u:3(int) xyv.x:4(int) xyv.y:5(int) v:6(int)
-      │    ├── full-join
+      │    ├── full-join (hash)
       │    │    ├── columns: xyu.x:1(int) xyu.y:2(int) u:3(int) xyv.x:4(int) xyv.y:5(int) v:6(int)
       │    │    ├── scan xyu
       │    │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) u:3(int!null)
@@ -2209,7 +2209,7 @@ SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y WHERE xyu.x 
 ----
 select
  ├── columns: x:1(int!null) y:2(int!null) u:3(int!null) x:4(int!null) y:5(int!null) v:6(int!null)
- ├── inner-join
+ ├── inner-join (hash)
  │    ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) u:3(int!null) xyv.x:4(int!null) xyv.y:5(int!null) v:6(int!null)
  │    ├── scan xyu
  │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) u:3(int!null)
@@ -2235,7 +2235,7 @@ select
 build
 SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-inner-join
+inner-join (hash)
  ├── columns: x:1(int!null) y:2(int!null) u:3(int!null) x:4(int!null) y:5(int!null) v:6(int!null)
  ├── scan xyu
  │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) u:3(int!null)
@@ -2261,7 +2261,7 @@ inner-join
 build
 SELECT * FROM xyu LEFT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-left-join
+left-join (hash)
  ├── columns: x:1(int!null) y:2(int!null) u:3(int!null) x:4(int) y:5(int) v:6(int)
  ├── scan xyu
  │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) u:3(int!null)
@@ -2287,7 +2287,7 @@ left-join
 build
 SELECT * FROM xyu RIGHT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-right-join
+right-join (hash)
  ├── columns: x:1(int) y:2(int) u:3(int) x:4(int!null) y:5(int!null) v:6(int!null)
  ├── scan xyu
  │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) u:3(int!null)
@@ -2320,7 +2320,7 @@ project
  ├── columns: x:1(int!null) y:2(int!null) u:3(int!null) v:6(int)
  └── select
       ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) u:3(int!null) xyv.x:4(int) xyv.y:5(int) v:6(int)
-      ├── left-join
+      ├── left-join (hash)
       │    ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) u:3(int!null) xyv.x:4(int) xyv.y:5(int) v:6(int)
       │    ├── scan xyu
       │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) u:3(int!null)
@@ -2345,7 +2345,7 @@ project
  ├── columns: x:4(int!null) y:5(int!null) u:3(int) v:6(int!null)
  └── select
       ├── columns: xyu.x:1(int) xyu.y:2(int) u:3(int) xyv.x:4(int!null) xyv.y:5(int!null) v:6(int!null)
-      ├── right-join
+      ├── right-join (hash)
       │    ├── columns: xyu.x:1(int) xyu.y:2(int) u:3(int) xyv.x:4(int!null) xyv.y:5(int!null) v:6(int!null)
       │    ├── scan xyu
       │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) u:3(int!null)
@@ -2372,7 +2372,7 @@ project
       ├── columns: xyu.x:1(int) xyu.y:2(int) u:3(int) xyv.x:4(int) xyv.y:5(int) v:6(int) x:7(int!null) y:8(int)
       ├── project
       │    ├── columns: x:7(int) y:8(int) xyu.x:1(int) xyu.y:2(int) u:3(int) xyv.x:4(int) xyv.y:5(int) v:6(int)
-      │    ├── full-join
+      │    ├── full-join (hash)
       │    │    ├── columns: xyu.x:1(int) xyu.y:2(int) u:3(int) xyv.x:4(int) xyv.y:5(int) v:6(int)
       │    │    ├── scan xyu
       │    │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) u:3(int!null)
@@ -2400,7 +2400,7 @@ project
 build
 SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-left-join
+left-join (hash)
  ├── columns: x:1(int!null) y:2(int!null) u:3(int!null) x:4(int) y:5(int) v:6(int)
  ├── scan xyu
  │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) u:3(int!null)
@@ -2426,7 +2426,7 @@ left-join
 build
 SELECT * FROM xyu RIGHT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-right-join
+right-join (hash)
  ├── columns: x:1(int) y:2(int) u:3(int) x:4(int!null) y:5(int!null) v:6(int!null)
  ├── scan xyu
  │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) u:3(int!null)
@@ -2457,7 +2457,7 @@ project
  ├── columns: x:1(int!null) y:2(int!null) u:3(int!null) v:6(int!null)
  └── select
       ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) u:3(int!null) xyv.x:4(int!null) xyv.y:5(int!null) v:6(int!null)
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) u:3(int!null) xyv.x:4(int!null) xyv.y:5(int!null) v:6(int!null)
       │    ├── scan xyu
       │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) u:3(int!null)
@@ -2497,7 +2497,7 @@ SELECT * FROM l LEFT OUTER JOIN r ON l.a = r.a WHERE l.a = 3;
 ----
 select
  ├── columns: a:1(int!null) a:2(int)
- ├── left-join
+ ├── left-join (hash)
  │    ├── columns: l.a:1(int!null) r.a:2(int)
  │    ├── scan l
  │    │    └── columns: l.a:1(int!null)
@@ -2517,7 +2517,7 @@ SELECT * FROM l RIGHT OUTER JOIN r ON l.a = r.a WHERE r.a = 3;
 ----
 select
  ├── columns: a:1(int) a:2(int!null)
- ├── right-join
+ ├── right-join (hash)
  │    ├── columns: l.a:1(int) r.a:2(int!null)
  │    ├── scan l
  │    │    └── columns: l.a:1(int!null)
@@ -2539,7 +2539,7 @@ project
  ├── columns: a:1(int!null)
  └── select
       ├── columns: l.a:1(int!null) r.a:2(int)
-      ├── left-join
+      ├── left-join (hash)
       │    ├── columns: l.a:1(int!null) r.a:2(int)
       │    ├── scan l
       │    │    └── columns: l.a:1(int!null)
@@ -2561,7 +2561,7 @@ project
  ├── columns: a:2(int!null)
  └── select
       ├── columns: l.a:1(int) r.a:2(int!null)
-      ├── right-join
+      ├── right-join (hash)
       │    ├── columns: l.a:1(int) r.a:2(int!null)
       │    ├── scan l
       │    │    └── columns: l.a:1(int!null)
@@ -2605,7 +2605,7 @@ project
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int!null) e:5(int) f:6(int) g:9(int)
  └── select
       ├── columns: abcdef.a:1(int!null) abcdef.b:2(int!null) c:3(int!null) d:4(int!null) e:5(int) f:6(int) abg.a:7(int!null) abg.b:8(int!null) g:9(int)
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── columns: abcdef.a:1(int!null) abcdef.b:2(int!null) c:3(int!null) d:4(int!null) e:5(int) f:6(int) abg.a:7(int!null) abg.b:8(int!null) g:9(int)
       │    ├── scan abcdef
       │    │    └── columns: abcdef.a:1(int!null) abcdef.b:2(int!null) c:3(int!null) d:4(int!null) e:5(int) f:6(int)
@@ -2678,7 +2678,7 @@ SELECT * FROM foo NATURAL JOIN bar
 ----
 project
  ├── columns: a:1(int!null) b:2(int!null) c:3(float!null) d:4(float!null)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: foo.a:1(int!null) foo.b:2(int!null) foo.c:3(float!null) foo.d:4(float!null) foo.rowid:5(int!null) bar.a:6(int!null) bar.b:7(float!null) bar.c:8(float!null) bar.d:9(int!null) bar.rowid:10(int!null)
       ├── scan foo
       │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
@@ -2704,7 +2704,7 @@ SELECT * FROM foo JOIN bar USING (b)
 ----
 project
  ├── columns: b:2(int!null) a:1(int) c:3(float) d:4(float) a:6(int) c:8(float) d:9(int)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: foo.a:1(int) foo.b:2(int!null) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float!null) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
       ├── scan foo
       │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
@@ -2721,7 +2721,7 @@ SELECT * FROM foo JOIN bar USING (a, b)
 ----
 project
  ├── columns: a:1(int!null) b:2(int!null) c:3(float) d:4(float) c:8(float) d:9(int)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: foo.a:1(int!null) foo.b:2(int!null) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int!null) bar.b:7(float!null) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
       ├── scan foo
       │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
@@ -2741,7 +2741,7 @@ SELECT * FROM foo JOIN bar USING (a, b, c)
 ----
 project
  ├── columns: a:1(int!null) b:2(int!null) c:3(float!null) d:4(float) d:9(int)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: foo.a:1(int!null) foo.b:2(int!null) foo.c:3(float!null) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int!null) bar.b:7(float!null) bar.c:8(float!null) bar.d:9(int) bar.rowid:10(int!null)
       ├── scan foo
       │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
@@ -2764,7 +2764,7 @@ SELECT * FROM foo JOIN bar ON foo.b = bar.b
 ----
 project
  ├── columns: a:1(int) b:2(int!null) c:3(float) d:4(float) a:6(int) b:7(float!null) c:8(float) d:9(int)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: foo.a:1(int) foo.b:2(int!null) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float!null) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
       ├── scan foo
       │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
@@ -2781,7 +2781,7 @@ SELECT * FROM foo JOIN bar ON foo.a = bar.a AND foo.b = bar.b
 ----
 project
  ├── columns: a:1(int!null) b:2(int!null) c:3(float) d:4(float) a:6(int!null) b:7(float!null) c:8(float) d:9(int)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: foo.a:1(int!null) foo.b:2(int!null) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int!null) bar.b:7(float!null) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
       ├── scan foo
       │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
@@ -2803,7 +2803,7 @@ project
  ├── columns: a:1(int) b:2(int!null) c:3(float) d:4(float) a:6(int) b:7(float!null) c:8(float) d:9(int)
  └── select
       ├── columns: foo.a:1(int) foo.b:2(int!null) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float!null) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
       │    ├── scan foo
       │    │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
@@ -2823,7 +2823,7 @@ project
  ├── columns: a:1(int!null) b:2(int!null) c:3(float) d:4(float) a:6(int!null) b:7(float!null) c:8(float) d:9(int)
  └── select
       ├── columns: foo.a:1(int!null) foo.b:2(int!null) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int!null) bar.b:7(float!null) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
       │    ├── scan foo
       │    │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
@@ -2847,7 +2847,7 @@ project
  ├── columns: a:1(int!null) b:2(int!null) c:3(float!null) d:4(float!null) c:8(float!null) d:9(int!null)
  └── select
       ├── columns: foo.a:1(int!null) foo.b:2(int!null) foo.c:3(float!null) foo.d:4(float!null) foo.rowid:5(int!null) bar.a:6(int!null) bar.b:7(float!null) bar.c:8(float!null) bar.d:9(int!null) bar.rowid:10(int!null)
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── columns: foo.a:1(int!null) foo.b:2(int!null) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int!null) bar.b:7(float!null) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
       │    ├── scan foo
       │    │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
@@ -2883,7 +2883,7 @@ SELECT k FROM kv, (SELECT 1 AS k)
 ----
 project
  ├── columns: k:5(int!null)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: kv.k:1(int!null) v:2(int) w:3(int) s:4(string) k:5(int!null)
       ├── scan kv
       │    └── columns: kv.k:1(int!null) v:2(int) w:3(int) s:4(string)
@@ -2900,7 +2900,7 @@ select * from (select 1 as k), (select 2 as k) where 1 in (select k from kv)
 ----
 select
  ├── columns: k:1(int!null) k:2(int!null)
- ├── inner-join
+ ├── inner-join (hash)
  │    ├── columns: k:1(int!null) k:2(int!null)
  │    ├── project
  │    │    ├── columns: k:1(int!null)
@@ -2931,7 +2931,7 @@ project
  ├── columns: column1:5(int) column2:6(int)
  └── project
       ├── columns: column1:5(int) column2:6(int) column1:1(unknown) column2:2(unknown) column1:3(int) column2:4(int)
-      ├── full-join
+      ├── full-join (hash)
       │    ├── columns: column1:1(unknown) column2:2(unknown) column1:3(int) column2:4(int)
       │    ├── values
       │    │    ├── columns: column1:1(unknown) column2:2(unknown)
@@ -2974,7 +2974,7 @@ project
  │    ├── columns: column1:5(int) column2:6(int)
  │    └── project
  │         ├── columns: column1:5(int) column2:6(int) column1:1(unknown) column2:2(unknown) column1:3(int) column2:4(int)
- │         ├── full-join
+ │         ├── full-join (hash)
  │         │    ├── columns: column1:1(unknown) column2:2(unknown) column1:3(int) column2:4(int)
  │         │    ├── values
  │         │    │    ├── columns: column1:1(unknown) column2:2(unknown)
@@ -3028,7 +3028,7 @@ SELECT * FROM onecolumn AS a(x) INNER MERGE JOIN onecolumn AS b(y) ON a.x = b.y
 ----
 project
  ├── columns: x:1(int!null) y:3(int!null)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: x:1(int!null) a.rowid:2(int!null) y:3(int!null) b.rowid:4(int!null)
       ├── flags: no-lookup-join;no-hash-join
       ├── scan a
@@ -3050,7 +3050,7 @@ SELECT * FROM onecolumn AS a(x) FULL OUTER HASH JOIN onecolumn AS b(y) ON a.x = 
 ----
 project
  ├── columns: x:1(int) y:3(int)
- └── full-join
+ └── full-join (hash)
       ├── columns: x:1(int) a.rowid:2(int) y:3(int) b.rowid:4(int)
       ├── flags: no-lookup-join;no-merge-join
       ├── scan a

--- a/pkg/sql/opt/optbuilder/testdata/lateral
+++ b/pkg/sql/opt/optbuilder/testdata/lateral
@@ -13,11 +13,11 @@ CREATE TABLE z (c INT PRIMARY KEY)
 build
 SELECT * FROM x, y, z
 ----
-inner-join
+inner-join (hash)
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
  ├── scan x
  │    └── columns: a:1(int!null)
- ├── inner-join
+ ├── inner-join (hash)
  │    ├── columns: b:2(int!null) c:3(int!null)
  │    ├── scan y
  │    │    └── columns: b:2(int!null)
@@ -94,7 +94,7 @@ project
                 ├── columns: y.b:3(int!null)
                 └── project
                      ├── columns: y.b:3(int!null)
-                     └── inner-join
+                     └── inner-join (hash)
                           ├── columns: c:2(int!null) y.b:3(int!null)
                           ├── scan z
                           │    └── columns: c:2(int!null)

--- a/pkg/sql/opt/optbuilder/testdata/srfs
+++ b/pkg/sql/opt/optbuilder/testdata/srfs
@@ -306,7 +306,7 @@ JOIN
   (SELECT unnest(ARRAY[1]) AS filter_id) AS ab
 ON uq.filter_id2 = ab.filter_id
 ----
-inner-join
+inner-join (hash)
  ├── columns: filter_id2:1(int!null) filter_id:2(int!null)
  ├── project-set
  │    ├── columns: unnest:1(int)
@@ -787,9 +787,9 @@ SELECT a.*, b.*, c.* FROM upper('abc') a
 JOIN ROWS FROM (upper('def'), generate_series(1, 3)) b ON true
 JOIN generate_series(1, 4) c ON true
 ----
-inner-join
+inner-join (hash)
  ├── columns: a:1(string) upper:2(string) generate_series:3(int) c:4(int)
- ├── inner-join
+ ├── inner-join (hash)
  │    ├── columns: upper:1(string) upper:2(string) generate_series:3(int)
  │    ├── project-set
  │    │    ├── columns: upper:1(string)
@@ -892,7 +892,7 @@ project
                 │              ├── columns: generate_subscripts:7(int)
                 │              └── project-set
                 │                   ├── columns: a:3(string) t.rowid:4(int!null) b:5(string) u.rowid:6(int!null) generate_subscripts:7(int)
-                │                   ├── inner-join
+                │                   ├── inner-join (hash)
                 │                   │    ├── columns: a:3(string) t.rowid:4(int!null) b:5(string) u.rowid:6(int!null)
                 │                   │    ├── scan t
                 │                   │    │    └── columns: a:3(string) t.rowid:4(int!null)

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -1465,7 +1465,7 @@ SELECT (SELECT t.kv.k) FROM db1.kv, kv
 ----
 project
  ├── columns: k:6(int)
- ├── inner-join
+ ├── inner-join (hash)
  │    ├── columns: db1.public.kv.k:1(int!null) db1.public.kv.v:2(int) t.public.kv.k:3(int!null) t.public.kv.v:4(string)
  │    ├── scan db1.public.kv
  │    │    └── columns: db1.public.kv.k:1(int!null) db1.public.kv.v:2(int)
@@ -1500,7 +1500,7 @@ SELECT (SELECT kv1.k) FROM db1.kv AS kv1, kv
 ----
 project
  ├── columns: k:6(int)
- ├── inner-join
+ ├── inner-join (hash)
  │    ├── columns: db1.public.kv.k:1(int!null) db1.public.kv.v:2(int) t.public.kv.k:3(int!null) t.public.kv.v:4(string)
  │    ├── scan db1.public.kv
  │    │    └── columns: db1.public.kv.k:1(int!null) db1.public.kv.v:2(int)

--- a/pkg/sql/opt/optbuilder/testdata/union
+++ b/pkg/sql/opt/optbuilder/testdata/union
@@ -665,7 +665,7 @@ union-all
 build
 SELECT * FROM (SELECT * FROM (VALUES (1)) a LEFT JOIN (VALUES (1) UNION VALUES (2)) b on a.column1 = b.column1);
 ----
-left-join
+left-join (hash)
  ├── columns: column1:1(int!null) column1:4(int)
  ├── values
  │    ├── columns: column1:1(int!null)
@@ -691,7 +691,7 @@ left-join
 build
 SELECT * FROM (VALUES (1)) a LEFT JOIN (VALUES (1) UNION VALUES (2)) b on a.column1 = b.column1;
 ----
-left-join
+left-join (hash)
  ├── columns: column1:1(int!null) column1:4(int)
  ├── values
  │    ├── columns: column1:1(int!null)

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -94,7 +94,7 @@ upsert abc
       │    ├── columns: column15:15(int) x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int) column14:14(int!null)
       │    ├── project
       │    │    ├── columns: column14:14(int!null) x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
-      │    │    ├── left-join
+      │    │    ├── left-join (hash)
       │    │    │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
       │    │    │    ├── project
       │    │    │    │    ├── columns: column9:9(int) x:5(int!null) y:6(int) column8:8(int)
@@ -191,7 +191,7 @@ project
            │    ├── columns: column16:16(int) x:5(int!null) y:6(int) z:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int!null) column14:14(int!null) column15:15(int!null)
            │    ├── project
            │    │    ├── columns: column13:13(int!null) column14:14(int!null) column15:15(int!null) x:5(int!null) y:6(int) z:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
-           │    │    ├── left-join
+           │    │    ├── left-join (hash)
            │    │    │    ├── columns: x:5(int!null) y:6(int) z:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
            │    │    │    ├── project
            │    │    │    │    ├── columns: column8:8(int) x:5(int!null) y:6(int) z:7(int)
@@ -280,7 +280,7 @@ upsert abc
       │    │    ├── columns: column14:14(int!null) x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
       │    │    ├── select
       │    │    │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
-      │    │    │    ├── left-join
+      │    │    │    ├── left-join (hash)
       │    │    │    │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
       │    │    │    │    ├── project
       │    │    │    │    │    ├── columns: column9:9(int) x:5(int!null) y:6(int) column8:8(int)
@@ -384,7 +384,7 @@ sort
                 │    ├── columns: column14:14(int) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int!null)
                 │    ├── project
                 │    │    ├── columns: column13:13(int!null) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
-                │    │    ├── left-join
+                │    │    ├── left-join (hash)
                 │    │    │    ├── columns: column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
                 │    │    │    ├── project
                 │    │    │    │    ├── columns: column8:8(int) column1:5(int!null) column2:6(int!null) column7:7(int)
@@ -475,7 +475,7 @@ upsert tab
       │    ├── columns: column14:14(int) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int)
       │    ├── project
       │    │    ├── columns: column13:13(int) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
-      │    │    ├── left-join
+      │    │    ├── left-join (hash)
       │    │    │    ├── columns: column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
       │    │    │    ├── project
       │    │    │    │    ├── columns: column8:8(int) column1:5(int!null) column2:6(int!null) column7:7(int)
@@ -587,19 +587,19 @@ insert xyz
       ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
       └── select
            ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null) x:13(int) y:14(int) z:15(int)
-           ├── left-join
+           ├── left-join (hash)
            │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null) x:13(int) y:14(int) z:15(int)
            │    ├── project
            │    │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
            │    │    └── select
            │    │         ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null) x:10(int) y:11(int) z:12(int)
-           │    │         ├── left-join
+           │    │         ├── left-join (hash)
            │    │         │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null) x:10(int) y:11(int) z:12(int)
            │    │         │    ├── project
            │    │         │    │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
            │    │         │    │    └── select
            │    │         │    │         ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null) x:7(int) y:8(int) z:9(int)
-           │    │         │    │         ├── left-join
+           │    │         │    │         ├── left-join (hash)
            │    │         │    │         │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null) x:7(int) y:8(int) z:9(int)
            │    │         │    │         │    ├── values
            │    │         │    │         │    │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
@@ -664,7 +664,7 @@ insert xyz
       ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
       └── select
            ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null) x:7(int) y:8(int) z:9(int)
-           ├── left-join
+           ├── left-join (hash)
            │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null) x:7(int) y:8(int) z:9(int)
            │    ├── values
            │    │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
@@ -726,7 +726,7 @@ project
  │         │    ├── columns: column10:10(int) column11:11(int) column12:12(int) column1:4(int!null) column2:5(int!null) column3:6(int!null) x:7(int) y:8(int) z:9(int)
  │         │    ├── select
  │         │    │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null) x:7(int) y:8(int) z:9(int)
- │         │    │    ├── left-join
+ │         │    │    ├── left-join (hash)
  │         │    │    │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null) x:7(int) y:8(int) z:9(int)
  │         │    │    │    ├── values
  │         │    │    │    │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
@@ -847,7 +847,7 @@ upsert abc
       │    ├── columns: column17:17(int) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) x:13(int) "?column?":16(int)
       │    ├── left-join-apply
       │    │    ├── columns: column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) x:13(int) "?column?":16(int)
-      │    │    ├── left-join
+      │    │    ├── left-join (hash)
       │    │    │    ├── columns: column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
       │    │    │    ├── project
       │    │    │    │    ├── columns: column8:8(int) column1:5(int!null) column2:6(int!null) column7:7(int)
@@ -951,7 +951,7 @@ upsert abc
       │    ├── columns: column15:15(int) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int) column14:14(int!null)
       │    ├── project
       │    │    ├── columns: column13:13(int) column14:14(int!null) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
-      │    │    ├── left-join
+      │    │    ├── left-join (hash)
       │    │    │    ├── columns: column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
       │    │    │    ├── project
       │    │    │    │    ├── columns: column8:8(int) column1:5(int!null) column2:6(int!null) column7:7(int)
@@ -1047,7 +1047,7 @@ upsert mutation
       │    │    ├── columns: column16:16(int) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int)
       │    │    ├── project
       │    │    │    ├── columns: column15:15(int) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
-      │    │    │    ├── left-join
+      │    │    │    ├── left-join (hash)
       │    │    │    │    ├── columns: column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
       │    │    │    │    ├── project
       │    │    │    │    │    ├── columns: column9:9(int) column1:6(int!null) column2:7(int!null) column8:8(int!null)
@@ -1137,7 +1137,7 @@ upsert xyz
  │    └──  column5:5 => z:3
  └── project
       ├── columns: upsert_x:9(int) column1:4(int!null) column5:5(int) x:6(int) y:7(int) z:8(int)
-      ├── left-join
+      ├── left-join (hash)
       │    ├── columns: column1:4(int!null) column5:5(int) x:6(int) y:7(int) z:8(int)
       │    ├── project
       │    │    ├── columns: column5:5(int) column1:4(int!null)
@@ -1205,7 +1205,7 @@ project
       │    └──  upsert_rowid:13 => rowid:4
       └── project
            ├── columns: upsert_rowid:13(int) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
-           ├── left-join
+           ├── left-join (hash)
            │    ├── columns: column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
            │    ├── project
            │    │    ├── columns: column8:8(int) column1:5(int!null) column2:6(int!null) column7:7(int)
@@ -1256,7 +1256,7 @@ upsert xyz
  │    └──  column1:4 => z:3
  └── project
       ├── columns: upsert_x:10(int) column1:4(int!null) column2:5(int!null) column3:6(int!null) x:7(int) y:8(int) z:9(int)
-      ├── left-join
+      ├── left-join (hash)
       │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null) x:7(int) y:8(int) z:9(int)
       │    ├── values
       │    │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
@@ -1322,7 +1322,7 @@ upsert checks
       ├── columns: check1:14(bool) check2:15(bool) column1:5(int!null) column2:6(int!null) column3:7(int!null) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int) upsert_a:13(int)
       ├── project
       │    ├── columns: upsert_a:13(int) column1:5(int!null) column2:6(int!null) column3:7(int!null) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
-      │    ├── left-join
+      │    ├── left-join (hash)
       │    │    ├── columns: column1:5(int!null) column2:6(int!null) column3:7(int!null) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
       │    │    ├── project
       │    │    │    ├── columns: column8:8(int) column1:5(int!null) column2:6(int!null) column3:7(int!null)
@@ -1383,7 +1383,7 @@ upsert mutation
       │    ├── columns: upsert_m:16(int) upsert_o:17(int) upsert_p:18(int) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int)
       │    ├── project
       │    │    ├── columns: column15:15(int) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
-      │    │    ├── left-join
+      │    │    ├── left-join (hash)
       │    │    │    ├── columns: column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
       │    │    │    ├── project
       │    │    │    │    ├── columns: column9:9(int) column1:6(int!null) column2:7(int!null) column8:8(int!null)
@@ -1464,7 +1464,7 @@ upsert mutation
       │    ├── columns: upsert_m:16(int) upsert_o:17(int) upsert_p:18(int) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int)
       │    ├── project
       │    │    ├── columns: column15:15(int) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
-      │    │    ├── left-join
+      │    │    ├── left-join (hash)
       │    │    │    ├── columns: column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
       │    │    │    ├── project
       │    │    │    │    ├── columns: column9:9(int) column1:6(int!null) column2:7(int!null) column8:8(int!null)
@@ -1557,7 +1557,7 @@ upsert checks
       │    │    ├── columns: column15:15(int) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int) column13:13(int!null) column14:14(int!null)
       │    │    ├── project
       │    │    │    ├── columns: column13:13(int!null) column14:14(int!null) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
-      │    │    │    ├── left-join
+      │    │    │    ├── left-join (hash)
       │    │    │    │    ├── columns: column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
       │    │    │    │    ├── project
       │    │    │    │    │    ├── columns: column8:8(int) column1:5(int!null) column2:6(int!null) column7:7(int)
@@ -1647,7 +1647,7 @@ insert checks
       │    ├── columns: column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int)
       │    └── select
       │         ├── columns: column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
-      │         ├── left-join
+      │         ├── left-join (hash)
       │         │    ├── columns: column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
       │         │    ├── project
       │         │    │    ├── columns: column8:8(int) column1:5(int!null) column2:6(int!null) column7:7(int)
@@ -1706,7 +1706,7 @@ upsert checks
       │    ├── columns: upsert_a:14(int) upsert_c:15(int) upsert_d:16(int) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int) column13:13(int)
       │    ├── project
       │    │    ├── columns: column13:13(int) column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
-      │    │    ├── left-join
+      │    │    ├── left-join (hash)
       │    │    │    ├── columns: column1:5(int!null) column2:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
       │    │    │    ├── project
       │    │    │    │    ├── columns: column8:8(int) column1:5(int!null) column2:6(int!null) column7:7(int)
@@ -1795,7 +1795,7 @@ upsert checks
       │    │    ├── columns: column19:19(int) abc.a:5(int!null) abc.b:6(int) column9:9(int) column10:10(int) checks.a:11(int) checks.b:12(int) checks.c:13(int) d:14(int) column18:18(int)
       │    │    ├── project
       │    │    │    ├── columns: column18:18(int) abc.a:5(int!null) abc.b:6(int) column9:9(int) column10:10(int) checks.a:11(int) checks.b:12(int) checks.c:13(int) d:14(int)
-      │    │    │    ├── left-join
+      │    │    │    ├── left-join (hash)
       │    │    │    │    ├── columns: abc.a:5(int!null) abc.b:6(int) column9:9(int) column10:10(int) checks.a:11(int) checks.b:12(int) checks.c:13(int) d:14(int)
       │    │    │    │    ├── project
       │    │    │    │    │    ├── columns: column10:10(int) abc.a:5(int!null) abc.b:6(int) column9:9(int)

--- a/pkg/sql/opt/optbuilder/testdata/view
+++ b/pkg/sql/opt/optbuilder/testdata/view
@@ -32,7 +32,7 @@ project
  ├── columns: k:1(int!null) s:9(string)
  └── select
       ├── columns: k:1(int!null) i:2(int) s:4(string) k:6(int!null) i:7(int) s:9(string)
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── columns: k:1(int!null) i:2(int) s:4(string) k:6(int!null) i:7(int) s:9(string)
       │    ├── project
       │    │    ├── columns: k:1(int!null) i:2(int) s:4(string)

--- a/pkg/sql/opt/optbuilder/testdata/with
+++ b/pkg/sql/opt/optbuilder/testdata/with
@@ -12,7 +12,7 @@ WITH t AS (SELECT a FROM y WHERE a < 3)
 ----
 project
  ├── columns: a:3(int!null)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: y.a:1(int!null) x.a:3(int!null) x.rowid:4(int!null)
       ├── scan x
       │    └── columns: x.a:3(int) x.rowid:4(int!null)
@@ -110,7 +110,7 @@ SELECT * FROM t3 NATURAL JOIN t4
 ----
 project
  ├── columns: a:1(int!null)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: a:1(int!null) a:3(int!null)
       ├── select
       │    ├── columns: a:1(int!null)
@@ -185,11 +185,11 @@ SELECT * FROM t2 NATURAL JOIN x
 ----
 project
  ├── columns: a:3(int!null)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: a:3(int!null) a:5(int!null) rowid:6(int!null)
       ├── project
       │    ├── columns: a:3(int!null)
-      │    └── inner-join
+      │    └── inner-join (hash)
       │         ├── columns: a:1(int!null) a:3(int!null) rowid:4(int!null)
       │         ├── scan x
       │         │    └── columns: a:3(int) rowid:4(int!null)

--- a/pkg/sql/opt/optgen/exprgen/testdata/join
+++ b/pkg/sql/opt/optgen/exprgen/testdata/join
@@ -14,7 +14,7 @@ expr
   [ ]
 )
 ----
-inner-join
+inner-join (hash)
  ├── columns: t.public.abc.a:1(int!null) t.public.abc.b:2(int) t.public.abc.c:3(int) t.public.def.d:5(int!null) t.public.def.e:6(int) t.public.def.f:7(int)
  ├── stats: [rows=10000, distinct(1)=100, null(1)=0, distinct(5)=100, null(5)=0]
  ├── cost: 2270.05

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -14,7 +14,7 @@ project
  ├── stats: [rows=100]
  ├── cost: 2124.745
  ├── fd: (1)==(5), (5)==(1)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: k:1(int!null) d:4(decimal!null) x:5(int!null)
       ├── stats: [rows=100, distinct(1)=10, null(1)=0, distinct(4)=1, null(4)=0, distinct(5)=10, null(5)=0]
       ├── cost: 2123.735
@@ -93,7 +93,7 @@ inner-join (lookup a)
 opt
 SELECT k, x FROM a INNER LOOKUP JOIN b ON k=x
 ----
-inner-join
+inner-join (hash)
  ├── columns: k:1(int!null) x:5(int!null)
  ├── flags: no-merge-join;no-hash-join
  ├── stats: [rows=1000, distinct(1)=100, null(1)=0, distinct(5)=100, null(5)=0]

--- a/pkg/sql/opt/xform/testdata/coster/perturb-cost
+++ b/pkg/sql/opt/xform/testdata/coster/perturb-cost
@@ -26,7 +26,7 @@ sort
  ├── key: (3)
  ├── fd: (1)-->(2), (1)==(3), (3)==(1)
  ├── ordering: +2
- └── inner-join
+ └── inner-join (hash)
       ├── columns: a.x:1(int!null) y:2(int) b.x:3(int!null)
       ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(3)=1000, null(3)=0]
       ├── cost: 2100.05

--- a/pkg/sql/opt/xform/testdata/external/activerecord
+++ b/pkg/sql/opt/xform/testdata/external/activerecord
@@ -113,11 +113,11 @@ sort
  └── project
       ├── columns: format_type:65(string) pg_get_expr:66(string) collname:67(string) comment:68(string) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null)
       ├── fd: (3,9)-->(65)
-      ├── right-join
+      ├── right-join (hash)
       │    ├── columns: attrelid:1(oid!null) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null) attisdropped:15(bool!null) attcollation:18(oid!null) adrelid:23(oid) adnum:24(int) adbin:25(string) c.oid:27(oid) c.collname:28(string) t.oid:34(oid) typcollation:61(oid)
       │    ├── key: (1,6,23,24,27,34)
       │    ├── fd: ()-->(15), (1,6)-->(2,3,9,13,18), (1,2)-->(3,6,9,13,18), (23,24)-->(25), (27)-->(28), (34)-->(61)
-      │    ├── inner-join
+      │    ├── inner-join (hash)
       │    │    ├── columns: c.oid:27(oid!null) c.collname:28(string!null) t.oid:34(oid!null) typcollation:61(oid!null)
       │    │    ├── key: (27,34)
       │    │    ├── fd: (27)-->(28), (34)-->(61)

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -176,11 +176,11 @@ where
             phone0_.id=calls3_.phone_id
     )
 ----
-inner-join
+inner-join (hash)
  ├── columns: id1_6_0_:1(int!null) id1_4_1_:6(int!null) phone_nu2_6_0_:2(varchar) person_i4_6_0_:4(int!null) phone_ty3_6_0_:3(varchar) person_i1_5_0__:12(int!null) addresse2_5_0__:13(varchar) addresse3_0__:14(varchar!null) address2_4_1_:7(varchar) createdo3_4_1_:8(timestamp) name4_4_1_:9(varchar) nickname5_4_1_:10(varchar) version6_4_1_:11(int4!null) person_i1_5_0__:12(int!null) addresse2_5_0__:13(varchar) addresse3_0__:14(varchar!null)
  ├── key: (1,14)
  ├── fd: (1)-->(2-4), (6)-->(7-11), (4)==(6,12), (6)==(4,12), (12,14)-->(13), (12)==(4,6)
- ├── semi-join
+ ├── semi-join (hash)
  │    ├── columns: phone0_.id:1(int!null) phone_number:2(varchar) phone_type:3(varchar) phone0_.person_id:4(int)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
@@ -241,10 +241,10 @@ where
 project
  ├── columns: id1_6_:1(int!null) phone_nu2_6_:2(varchar) person_i4_6_:4(int!null) phone_ty3_6_:3(varchar)
  ├── fd: (1)-->(2-4)
- └── inner-join
+ └── inner-join (hash)
       ├── columns: phone0_.id:1(int!null) phone_number:2(varchar) phone_type:3(varchar) phone0_.person_id:4(int!null) person1_.id:6(int!null) addresses2_.person_id:12(int!null)
       ├── fd: (1)-->(2-4), (4)==(6,12), (6)==(4,12), (12)==(4,6)
-      ├── semi-join
+      ├── semi-join (hash)
       │    ├── columns: phone0_.id:1(int!null) phone_number:2(varchar) phone_type:3(varchar) phone0_.person_id:4(int)
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-4)
@@ -306,12 +306,12 @@ where
     )
     and partner1_.version=0
 ----
-inner-join
+inner-join (hash)
  ├── columns: id1_4_0_:1(int!null) id1_2_1_:7(int!null) address2_4_0_:2(varchar!null) createdo3_4_0_:3(timestamp) name4_4_0_:4(varchar) nickname5_4_0_:5(varchar) version6_4_0_:6(int4!null) name2_2_1_:8(varchar!null) version3_2_1_:9(int4!null)
  ├── has-placeholder
  ├── key: (1,7)
  ├── fd: ()-->(9), (1)-->(2-6), (7)-->(8)
- ├── semi-join
+ ├── semi-join (hash)
  │    ├── columns: person0_.id:1(int!null) address:2(varchar!null) createdon:3(timestamp) person0_.name:4(varchar) nickname:5(varchar) person0_.version:6(int4!null)
  │    ├── has-placeholder
  │    ├── key: (1)
@@ -669,13 +669,13 @@ distinct-on
  ├── grouping columns: person2_.id:10(int!null)
  ├── key: (10)
  ├── fd: (10)-->(11-15)
- ├── inner-join
+ ├── inner-join (hash)
  │    ├── columns: phone0_.id:1(int!null) person_id:4(int!null) calls1_.phone_id:9(int!null) person2_.id:10(int!null) address:11(varchar) createdon:12(timestamp) name:13(varchar) nickname:14(varchar) version:15(int4!null)
  │    ├── fd: (1)-->(4), (1)==(9), (9)==(1), (10)-->(11-15), (4)==(10), (10)==(4)
- │    ├── inner-join
+ │    ├── inner-join (hash)
  │    │    ├── columns: phone0_.id:1(int!null) person_id:4(int) calls1_.phone_id:9(int!null)
  │    │    ├── fd: (1)-->(4), (1)==(9), (9)==(1)
- │    │    ├── anti-join
+ │    │    ├── anti-join (hash)
  │    │    │    ├── columns: phone0_.id:1(int!null) person_id:4(int)
  │    │    │    ├── key: (1)
  │    │    │    ├── fd: (1)-->(4)
@@ -746,7 +746,7 @@ project
       │    ├── grouping columns: phone0_.id:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-4,10)
-      │    ├── inner-join
+      │    ├── inner-join (hash)
       │    │    ├── columns: phone0_.id:1(int!null) phone_number:2(varchar) phone_type:3(varchar) person_id:4(int) calls1_.id:6(int!null) phone_id:9(int!null)
       │    │    ├── key: (6)
       │    │    ├── fd: (1)-->(2-4), (6)-->(9), (1)==(9), (9)==(1)
@@ -805,7 +805,7 @@ project
       │    ├── grouping columns: person0_.id:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-6,12)
-      │    ├── left-join
+      │    ├── left-join (hash)
       │    │    ├── columns: person0_.id:1(int!null) address:2(varchar) createdon:3(timestamp) name:4(varchar) nickname:5(varchar) version:6(int4!null) person_id:10(int)
       │    │    ├── fd: (1)-->(2-6)
       │    │    ├── scan person0_
@@ -865,7 +865,7 @@ project
       │    ├── grouping columns: phone0_.id:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-4,10)
-      │    ├── inner-join
+      │    ├── inner-join (hash)
       │    │    ├── columns: phone0_.id:1(int!null) phone_number:2(varchar) phone_type:3(varchar) person_id:4(int) calls1_.id:6(int!null) phone_id:9(int!null)
       │    │    ├── key: (6)
       │    │    ├── fd: (1)-->(2-4), (6)-->(9), (1)==(9), (9)==(1)
@@ -924,7 +924,7 @@ project
       │    ├── grouping columns: person0_.id:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-6,12)
-      │    ├── inner-join
+      │    ├── inner-join (hash)
       │    │    ├── columns: person0_.id:1(int!null) address:2(varchar) createdon:3(timestamp) name:4(varchar) nickname:5(varchar) version:6(int4!null) person_id:10(int!null) order_id:11(int4!null)
       │    │    ├── fd: (1)-->(2-6), (1)==(10), (10)==(1)
       │    │    ├── scan person0_
@@ -975,7 +975,7 @@ where
             person0_.id=phones1_.person_id
     )
 ----
-semi-join
+semi-join (hash)
  ├── columns: id1_2_:1(int!null) address2_2_:2(varchar) createdo3_2_:3(timestamp) name4_2_:4(varchar) nickname5_2_:5(varchar) version6_2_:6(int4!null)
  ├── has-placeholder
  ├── key: (1)
@@ -1018,7 +1018,7 @@ where
             person0_.id=phones1_.person_id
     )
 ----
-semi-join
+semi-join (hash)
  ├── columns: id1_2_:1(int!null) address2_2_:2(varchar) createdo3_2_:3(timestamp) name4_2_:4(varchar) nickname5_2_:5(varchar) version6_2_:6(int4!null)
  ├── has-placeholder
  ├── key: (1)
@@ -1061,7 +1061,7 @@ where
             person0_.id=phones1_.person_id
     )
 ----
-semi-join
+semi-join (hash)
  ├── columns: id1_2_:1(int!null) address2_2_:2(varchar) createdo3_2_:3(timestamp) name4_2_:4(varchar) nickname5_2_:5(varchar) version6_2_:6(int4!null)
  ├── key: (1)
  ├── fd: (1)-->(2-6)
@@ -1094,7 +1094,7 @@ where
             phone0_.id=repairtime1_.Phone_id
     )
 ----
-anti-join
+anti-join (hash)
  ├── columns: id1_4_:1(int!null) phone_nu2_4_:2(varchar) person_i4_4_:4(int) phone_ty3_4_:3(varchar)
  ├── has-placeholder
  ├── key: (1)
@@ -1193,7 +1193,7 @@ project
       │    ├── grouping columns: phones2_.id:7(int!null)
       │    ├── key: (7)
       │    ├── fd: (1)-->(2-6), (7)-->(1-6,11,17)
-      │    ├── inner-join
+      │    ├── inner-join (hash)
       │    │    ├── columns: person0_.id:1(int!null) address:2(varchar) createdon:3(timestamp) name:4(varchar) nickname:5(varchar) version:6(int4!null) phones2_.id:7(int!null) phones2_.phone_type:9(varchar!null) phones2_.person_id:10(int!null) phones2_.order_id:11(int4) phones1_.person_id:15(int!null) phones1_.order_id:16(int4!null)
       │    │    ├── fd: ()-->(9), (1)-->(2-6), (7)-->(10,11), (1)==(10,15), (10)==(1,15), (15)==(1,10)
       │    │    ├── select
@@ -1258,7 +1258,7 @@ where
     where
         person0_.id=phones1_.person_id))
 ----
-anti-join
+anti-join (hash)
  ├── columns: id1_2_:1(int!null) address2_2_:2(varchar) createdo3_2_:3(timestamp) name4_2_:4(varchar) nickname5_2_:5(varchar) version6_2_:6(int4!null)
  ├── key: (1)
  ├── fd: (1)-->(2-6)
@@ -1293,7 +1293,7 @@ where
             person0_.id=phones1_.person_id
     )
 ----
-semi-join
+semi-join (hash)
  ├── columns: id1_2_:1(int!null) address2_2_:2(varchar) createdo3_2_:3(timestamp) name4_2_:4(varchar) nickname5_2_:5(varchar) version6_2_:6(int4!null)
  ├── key: (1)
  ├── fd: (1)-->(2-6)
@@ -1324,7 +1324,7 @@ where
     where
         phone0_.id=calls1_.phone_id))
 ----
-anti-join
+anti-join (hash)
  ├── columns: id1_4_:1(int!null) phone_nu2_4_:2(varchar) person_i4_4_:4(int) phone_ty3_4_:3(varchar)
  ├── key: (1)
  ├── fd: (1)-->(2-4)
@@ -1475,7 +1475,7 @@ project
       │    ├── grouping columns: id:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(2,3,7)
-      │    ├── left-join
+      │    ├── left-join (hash)
       │    │    ├── columns: id:1(int!null) email:2(varchar) currentproject_id:3(int) employee_id:4(int)
       │    │    ├── fd: (1)-->(2,3)
       │    │    ├── scan componenti0_
@@ -1574,11 +1574,11 @@ where
         company0_.id=employees1_.Company_id
         and employees1_.employees_id=employee2_.id))
 ----
-left-join
+left-join (hash)
  ├── columns: id1_0_0_:1(int!null) id1_8_1_:3(int) location2_0_0_:2(int) address2_8_1_:4(varchar) zip3_8_1_:5(int4)
  ├── key: (1,3)
  ├── fd: (1)-->(2), (3)-->(4,5)
- ├── anti-join
+ ├── anti-join (hash)
  │    ├── columns: company0_.id:1(int!null) location_id:2(int)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
@@ -1586,7 +1586,7 @@ left-join
  │    │    ├── columns: company0_.id:1(int!null) location_id:2(int)
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(2)
- │    ├── inner-join
+ │    ├── inner-join (hash)
  │    │    ├── columns: company_id:6(int!null) employees_id:7(int!null) id:12(int!null) clazz_:13(int!null)
  │    │    ├── fd: (7)==(12), (12)==(7)
  │    │    ├── union-all
@@ -1852,7 +1852,7 @@ project
  │    ├── has-placeholder
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4,11)
- │    ├── right-join
+ │    ├── right-join (hash)
  │    │    ├── columns: bids0_.id:1(int!null) amount:2(decimal) createddatetime:3(timestamp) auctionid:4(int!null) successfulbid:8(int) true:10(bool)
  │    │    ├── has-placeholder
  │    │    ├── fd: (1)-->(2-4), ()~~>(10)
@@ -1975,12 +1975,12 @@ project
  │    ├── grouping columns: lineitems1_.productid:6(varchar)
  │    ├── key: (6)
  │    ├── fd: ()-->(1-3), (6)-->(1-5,7,17), ()~~>(4,5)
- │    ├── right-join
+ │    ├── right-join (hash)
  │    │    ├── columns: order0_.customerid:1(varchar!null) order0_.ordernumber:2(int4!null) orderdate:3(date!null) lineitems1_.customerid:4(varchar) lineitems1_.ordernumber:5(int4) lineitems1_.productid:6(varchar) lineitems1_.quantity:7(int4) li.customerid:8(varchar) li.ordernumber:9(int4) column16:16(decimal)
  │    │    ├── fd: ()-->(1-3), (6)-->(4,5,7), ()~~>(4,5)
  │    │    ├── project
  │    │    │    ├── columns: column16:16(decimal) li.customerid:8(varchar!null) li.ordernumber:9(int4!null)
- │    │    │    ├── inner-join
+ │    │    │    ├── inner-join (hash)
  │    │    │    │    ├── columns: li.customerid:8(varchar!null) li.ordernumber:9(int4!null) li.productid:10(varchar!null) li.quantity:11(int4) p.productid:12(varchar!null) cost:14(decimal)
  │    │    │    │    ├── key: (8,9,12)
  │    │    │    │    ├── fd: (8-10)-->(11), (12)-->(14), (10)==(12), (12)==(10)
@@ -2096,7 +2096,7 @@ project
  │    ├── grouping columns: customer0_.customerid:1(varchar!null) orders1_.customerid:4(varchar) orders1_.ordernumber:5(int4) lineitems2_.customerid:7(varchar) lineitems2_.ordernumber:8(int4) lineitems2_.productid:9(varchar) product3_.productid:11(varchar)
  │    ├── key: (1,4,5,7-9,11)
  │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9,11)-->(2,3,6,10,12-14,24,29)
- │    ├── left-join
+ │    ├── left-join (hash)
  │    │    ├── columns: customer0_.customerid:1(varchar!null) name:2(varchar) address:3(varchar) orders1_.customerid:4(varchar) orders1_.ordernumber:5(int4) orderdate:6(date) lineitems2_.customerid:7(varchar) lineitems2_.ordernumber:8(int4) lineitems2_.productid:9(varchar) lineitems2_.quantity:10(int4) product3_.productid:11(varchar) product3_.description:12(varchar) product3_.cost:13(decimal) product3_.numberavailable:14(int4) sum:24(decimal) li.productid:27(varchar) li.quantity:28(int4)
  │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9,11)-->(2,3,6,10,12-14,24)
  │    │    ├── group-by
@@ -2104,14 +2104,14 @@ project
  │    │    │    ├── grouping columns: customer0_.customerid:1(varchar!null) orders1_.customerid:4(varchar) orders1_.ordernumber:5(int4) lineitems2_.customerid:7(varchar) lineitems2_.ordernumber:8(int4) lineitems2_.productid:9(varchar) product3_.productid:11(varchar)
  │    │    │    ├── key: (1,4,5,7-9,11)
  │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9,11)-->(2,3,6,10,12-14,24)
- │    │    │    ├── left-join
+ │    │    │    ├── left-join (hash)
  │    │    │    │    ├── columns: customer0_.customerid:1(varchar!null) name:2(varchar!null) address:3(varchar!null) orders1_.customerid:4(varchar) orders1_.ordernumber:5(int4) orderdate:6(date) lineitems2_.customerid:7(varchar) lineitems2_.ordernumber:8(int4) lineitems2_.productid:9(varchar) lineitems2_.quantity:10(int4) product3_.productid:11(varchar) product3_.description:12(varchar) product3_.cost:13(decimal) product3_.numberavailable:14(int4) li.customerid:15(varchar) li.ordernumber:16(int4) column23:23(decimal)
  │    │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14)
- │    │    │    │    ├── left-join
+ │    │    │    │    ├── left-join (hash)
  │    │    │    │    │    ├── columns: customer0_.customerid:1(varchar!null) name:2(varchar!null) address:3(varchar!null) orders1_.customerid:4(varchar) orders1_.ordernumber:5(int4) orderdate:6(date) lineitems2_.customerid:7(varchar) lineitems2_.ordernumber:8(int4) lineitems2_.productid:9(varchar) lineitems2_.quantity:10(int4) product3_.productid:11(varchar) product3_.description:12(varchar) product3_.cost:13(decimal) product3_.numberavailable:14(int4)
  │    │    │    │    │    ├── key: (1,4,5,7-9,11)
  │    │    │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14)
- │    │    │    │    │    ├── left-join
+ │    │    │    │    │    ├── left-join (hash)
  │    │    │    │    │    │    ├── columns: customer0_.customerid:1(varchar!null) name:2(varchar!null) address:3(varchar!null) orders1_.customerid:4(varchar) orders1_.ordernumber:5(int4) orderdate:6(date) lineitems2_.customerid:7(varchar) lineitems2_.ordernumber:8(int4) lineitems2_.productid:9(varchar) lineitems2_.quantity:10(int4)
  │    │    │    │    │    │    ├── key: (1,4,5,7-9)
  │    │    │    │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10)
@@ -2147,7 +2147,7 @@ project
  │    │    │    │    │         └── lineitems2_.productid = product3_.productid [type=bool, outer=(9,11), constraints=(/9: (/NULL - ]; /11: (/NULL - ]), fd=(9)==(11), (11)==(9)]
  │    │    │    │    ├── project
  │    │    │    │    │    ├── columns: column23:23(decimal) li.customerid:15(varchar!null) li.ordernumber:16(int4!null)
- │    │    │    │    │    ├── inner-join
+ │    │    │    │    │    ├── inner-join (hash)
  │    │    │    │    │    │    ├── columns: li.customerid:15(varchar!null) li.ordernumber:16(int4!null) li.productid:17(varchar!null) li.quantity:18(int4) p.productid:19(varchar!null) p.cost:21(decimal)
  │    │    │    │    │    │    ├── key: (15,16,19)
  │    │    │    │    │    │    ├── fd: (15-17)-->(18), (19)-->(21), (17)==(19), (19)==(17)
@@ -2251,12 +2251,12 @@ project
  │    ├── grouping columns: lineitems1_.productid:6(varchar)
  │    ├── key: (6)
  │    ├── fd: ()-->(1-3), (6)-->(1-5,7,17), ()~~>(4,5)
- │    ├── right-join
+ │    ├── right-join (hash)
  │    │    ├── columns: order0_.customerid:1(varchar!null) order0_.ordernumber:2(int4!null) orderdate:3(date!null) lineitems1_.customerid:4(varchar) lineitems1_.ordernumber:5(int4) lineitems1_.productid:6(varchar) lineitems1_.quantity:7(int4) li.customerid:8(varchar) li.ordernumber:9(int4) column16:16(decimal)
  │    │    ├── fd: ()-->(1-3), (6)-->(4,5,7), ()~~>(4,5)
  │    │    ├── project
  │    │    │    ├── columns: column16:16(decimal) li.customerid:8(varchar!null) li.ordernumber:9(int4!null)
- │    │    │    ├── inner-join
+ │    │    │    ├── inner-join (hash)
  │    │    │    │    ├── columns: li.customerid:8(varchar!null) li.ordernumber:9(int4!null) li.productid:10(varchar!null) li.quantity:11(int4) p.productid:12(varchar!null) cost:14(decimal)
  │    │    │    │    ├── key: (8,9,12)
  │    │    │    │    ├── fd: (8-10)-->(11), (12)-->(14), (10)==(12), (12)==(10)
@@ -2339,7 +2339,7 @@ project
  │    ├── grouping columns: order0_.customerid:1(varchar!null) order0_.ordernumber:2(int4!null)
  │    ├── key: (1,2)
  │    ├── fd: (1,2)-->(3,13)
- │    ├── left-join
+ │    ├── left-join (hash)
  │    │    ├── columns: order0_.customerid:1(varchar!null) order0_.ordernumber:2(int4!null) orderdate:3(date!null) li.customerid:4(varchar) li.ordernumber:5(int4) column12:12(decimal)
  │    │    ├── fd: (1,2)-->(3)
  │    │    ├── scan order0_
@@ -2348,7 +2348,7 @@ project
  │    │    │    └── fd: (1,2)-->(3)
  │    │    ├── project
  │    │    │    ├── columns: column12:12(decimal) li.customerid:4(varchar!null) li.ordernumber:5(int4!null)
- │    │    │    ├── inner-join
+ │    │    │    ├── inner-join (hash)
  │    │    │    │    ├── columns: li.customerid:4(varchar!null) li.ordernumber:5(int4!null) li.productid:6(varchar!null) quantity:7(int4) p.productid:8(varchar!null) cost:10(decimal)
  │    │    │    │    ├── key: (4,5,8)
  │    │    │    │    ├── fd: (4-6)-->(7), (8)-->(10), (6)==(8), (8)==(6)
@@ -2445,10 +2445,10 @@ group-by
  │    │    ├── grouping columns: this_.studentid:1(int!null) enrolment_.studentid:6(int!null) enrolment_.coursecode:7(varchar!null)
  │    │    ├── key: (1,6,7)
  │    │    ├── fd: (1)-->(2-5), (6,7)-->(9), (1,6,7)-->(2-5,9,14)
- │    │    ├── inner-join
+ │    │    ├── inner-join (hash)
  │    │    │    ├── columns: this_.studentid:1(int!null) name:2(varchar!null) address_city:3(varchar) address_state:4(varchar) preferredcoursecode:5(varchar!null) enrolment_.studentid:6(int!null) enrolment_.coursecode:7(varchar!null) enrolment_.year:9(int2!null) maxstudentenrolment_.coursecode:11(varchar!null) maxstudentenrolment_.year:13(int2!null)
  │    │    │    ├── fd: (1)-->(2-5), (6,7)-->(9), (5)==(11), (11)==(5)
- │    │    │    ├── inner-join
+ │    │    │    ├── inner-join (hash)
  │    │    │    │    ├── columns: this_.studentid:1(int!null) name:2(varchar!null) address_city:3(varchar) address_state:4(varchar) preferredcoursecode:5(varchar!null) maxstudentenrolment_.coursecode:11(varchar!null) maxstudentenrolment_.year:13(int2!null)
  │    │    │    │    ├── fd: (1)-->(2-5), (5)==(11), (11)==(5)
  │    │    │    │    ├── scan maxstudentenrolment_

--- a/pkg/sql/opt/xform/testdata/external/liquibase
+++ b/pkg/sql/opt/xform/testdata/external/liquibase
@@ -168,7 +168,7 @@ project
  │    ├── grouping columns: rownum:136(int!null)
  │    ├── key: (136)
  │    ├── fd: ()-->(29), (1)-->(2,5,10,13,15,17,20,22,23,26,27), (2)-->(1,5,10,13,15,17,20,22,23,26,27), (136)-->(1,2,5,10,13,15,17,20,22,23,26,27,29,33,42,69,92,120,122,132)
- │    ├── right-join
+ │    ├── right-join (hash)
  │    │    ├── columns: c.oid:1(oid!null) c.relname:2(string!null) c.relnamespace:3(oid!null) c.relowner:5(oid!null) c.reltablespace:8(oid!null) c.reltuples:10(float!null) c.relhasindex:13(bool!null) c.relpersistence:15(string!null) c.relkind:17(string!null) c.relhasoids:20(bool!null) c.relhasrules:22(bool!null) c.relhastriggers:23(bool!null) c.relacl:26(string[]) c.reloptions:27(string[]) n.oid:28(oid!null) n.nspname:29(string!null) t.oid:32(oid) spcname:33(string) i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) ci.oid:91(oid) ci.relname:92(string) ftrelid:118(oid) ftserver:119(oid) ftoptions:120(string[]) fs.oid:121(oid) srvname:122(string) pg_inherits.inhparent:130(oid) rownum:136(int!null)
  │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), ()~~>(79), (91)-->(92), (118)-->(119,120), (121)-->(122), (122)-->(121), (136)-->(1,2,5,8,10,13,15,17,20,22,23,26,27,32,33,38,39,41-43,68,69,72,73,79,91,92,118-122)
  │    │    ├── scan pg_inherits
@@ -185,14 +185,14 @@ project
  │    │    │         │    ├── columns: c.oid:1(oid!null) c.relname:2(string!null) c.relnamespace:3(oid!null) c.relowner:5(oid!null) c.reltablespace:8(oid!null) c.reltuples:10(float!null) c.relhasindex:13(bool!null) c.relpersistence:15(string!null) c.relkind:17(string!null) c.relhasoids:20(bool!null) c.relhasrules:22(bool!null) c.relhastriggers:23(bool!null) c.relacl:26(string[]) c.reloptions:27(string[]) n.oid:28(oid!null) n.nspname:29(string!null) t.oid:32(oid) spcname:33(string) i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) ci.oid:91(oid) ci.relname:92(string) ftrelid:118(oid) ftserver:119(oid) ftoptions:120(string[])
  │    │    │         │    ├── key columns: [1] = [118]
  │    │    │         │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), ()~~>(79), (91)-->(92), (118)-->(119,120)
- │    │    │         │    ├── right-join
+ │    │    │         │    ├── right-join (hash)
  │    │    │         │    │    ├── columns: c.oid:1(oid!null) c.relname:2(string!null) c.relnamespace:3(oid!null) c.relowner:5(oid!null) c.reltablespace:8(oid!null) c.reltuples:10(float!null) c.relhasindex:13(bool!null) c.relpersistence:15(string!null) c.relkind:17(string!null) c.relhasoids:20(bool!null) c.relhasrules:22(bool!null) c.relhastriggers:23(bool!null) c.relacl:26(string[]) c.reloptions:27(string[]) n.oid:28(oid!null) n.nspname:29(string!null) t.oid:32(oid) spcname:33(string) i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) ci.oid:91(oid) ci.relname:92(string)
  │    │    │         │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), ()~~>(79), (91)-->(92)
  │    │    │         │    │    ├── scan ci@pg_class_relname_nsp_index
  │    │    │         │    │    │    ├── columns: i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) ci.oid:91(oid!null) ci.relname:92(string!null)
  │    │    │         │    │    │    ├── key: (91)
  │    │    │         │    │    │    └── fd: (91)-->(92)
- │    │    │         │    │    ├── right-join
+ │    │    │         │    │    ├── right-join (hash)
  │    │    │         │    │    │    ├── columns: c.oid:1(oid!null) c.relname:2(string!null) c.relnamespace:3(oid!null) c.relowner:5(oid!null) c.reltablespace:8(oid!null) c.reltuples:10(float!null) c.relhasindex:13(bool!null) c.relpersistence:15(string!null) c.relkind:17(string!null) c.relhasoids:20(bool!null) c.relhasrules:22(bool!null) c.relhastriggers:23(bool!null) c.relacl:26(string[]) c.reloptions:27(string[]) n.oid:28(oid!null) n.nspname:29(string!null) t.oid:32(oid) spcname:33(string) i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool)
  │    │    │         │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), ()~~>(79)
  │    │    │         │    │    │    ├── select
@@ -205,13 +205,13 @@ project
  │    │    │         │    │    │    │    │    └── fd: (72)-->(73,79)
  │    │    │         │    │    │    │    └── filters
  │    │    │         │    │    │    │         └── indisclustered = true [type=bool, outer=(79), constraints=(/79: [/true - /true]; tight), fd=()-->(79)]
- │    │    │         │    │    │    ├── right-join
+ │    │    │         │    │    │    ├── right-join (hash)
  │    │    │         │    │    │    │    ├── columns: c.oid:1(oid!null) c.relname:2(string!null) c.relnamespace:3(oid!null) c.relowner:5(oid!null) c.reltablespace:8(oid!null) c.reltuples:10(float!null) c.relhasindex:13(bool!null) c.relpersistence:15(string!null) c.relkind:17(string!null) c.relhasoids:20(bool!null) c.relhasrules:22(bool!null) c.relhastriggers:23(bool!null) c.relacl:26(string[]) c.reloptions:27(string[]) n.oid:28(oid!null) n.nspname:29(string!null) t.oid:32(oid) spcname:33(string) i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string)
  │    │    │         │    │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68)
- │    │    │         │    │    │    │    ├── left-join
+ │    │    │         │    │    │    │    ├── left-join (hash)
  │    │    │         │    │    │    │    │    ├── columns: i.inhrelid:38(oid!null) i.inhparent:39(oid!null) c2.oid:41(oid!null) c2.relname:42(string!null) c2.relnamespace:43(oid!null) n2.oid:68(oid) n2.nspname:69(string)
  │    │    │         │    │    │    │    │    ├── fd: (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)-->(69), (69)-->(68)
- │    │    │         │    │    │    │    │    ├── inner-join
+ │    │    │         │    │    │    │    │    ├── inner-join (hash)
  │    │    │         │    │    │    │    │    │    ├── columns: i.inhrelid:38(oid!null) i.inhparent:39(oid!null) c2.oid:41(oid!null) c2.relname:42(string!null) c2.relnamespace:43(oid!null)
  │    │    │         │    │    │    │    │    │    ├── fd: (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39)
  │    │    │         │    │    │    │    │    │    ├── scan i
@@ -233,7 +233,7 @@ project
  │    │    │         │    │    │    │    │    ├── key columns: [8] = [32]
  │    │    │         │    │    │    │    │    ├── key: (1,32)
  │    │    │         │    │    │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32)
- │    │    │         │    │    │    │    │    ├── inner-join
+ │    │    │         │    │    │    │    │    ├── inner-join (hash)
  │    │    │         │    │    │    │    │    │    ├── columns: c.oid:1(oid!null) c.relname:2(string!null) c.relnamespace:3(oid!null) c.relowner:5(oid!null) c.reltablespace:8(oid!null) c.reltuples:10(float!null) c.relhasindex:13(bool!null) c.relpersistence:15(string!null) c.relkind:17(string!null) c.relhasoids:20(bool!null) c.relhasrules:22(bool!null) c.relhastriggers:23(bool!null) c.relacl:26(string[]) c.reloptions:27(string[]) n.oid:28(oid!null) n.nspname:29(string!null)
  │    │    │         │    │    │    │    │    │    ├── key: (1)
  │    │    │         │    │    │    │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3)

--- a/pkg/sql/opt/xform/testdata/external/navicat
+++ b/pkg/sql/opt/xform/testdata/external/navicat
@@ -171,7 +171,7 @@ sort
       │    ├── grouping columns: rownum:136(int!null)
       │    ├── key: (136)
       │    ├── fd: ()-->(29), (1)-->(2,5,10,13,15,17,20,22,23,26,27), (2)-->(1,5,10,13,15,17,20,22,23,26,27), (136)-->(1,2,5,10,13,15,17,20,22,23,26,27,29,33,42,69,92,120,122,132)
-      │    ├── right-join
+      │    ├── right-join (hash)
       │    │    ├── columns: c.oid:1(oid!null) c.relname:2(string!null) c.relnamespace:3(oid!null) c.relowner:5(oid!null) c.reltablespace:8(oid!null) c.reltuples:10(float!null) c.relhasindex:13(bool!null) c.relpersistence:15(string!null) c.relkind:17(string!null) c.relhasoids:20(bool!null) c.relhasrules:22(bool!null) c.relhastriggers:23(bool!null) c.relacl:26(string[]) c.reloptions:27(string[]) n.oid:28(oid!null) n.nspname:29(string!null) t.oid:32(oid) spcname:33(string) i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) ci.oid:91(oid) ci.relname:92(string) ftrelid:118(oid) ftserver:119(oid) ftoptions:120(string[]) fs.oid:121(oid) srvname:122(string) pg_inherits.inhparent:130(oid) rownum:136(int!null)
       │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), ()~~>(79), (91)-->(92), (118)-->(119,120), (121)-->(122), (122)-->(121), (136)-->(1,2,5,8,10,13,15,17,20,22,23,26,27,32,33,38,39,41-43,68,69,72,73,79,91,92,118-122)
       │    │    ├── scan pg_inherits
@@ -188,14 +188,14 @@ sort
       │    │    │         │    ├── columns: c.oid:1(oid!null) c.relname:2(string!null) c.relnamespace:3(oid!null) c.relowner:5(oid!null) c.reltablespace:8(oid!null) c.reltuples:10(float!null) c.relhasindex:13(bool!null) c.relpersistence:15(string!null) c.relkind:17(string!null) c.relhasoids:20(bool!null) c.relhasrules:22(bool!null) c.relhastriggers:23(bool!null) c.relacl:26(string[]) c.reloptions:27(string[]) n.oid:28(oid!null) n.nspname:29(string!null) t.oid:32(oid) spcname:33(string) i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) ci.oid:91(oid) ci.relname:92(string) ftrelid:118(oid) ftserver:119(oid) ftoptions:120(string[])
       │    │    │         │    ├── key columns: [1] = [118]
       │    │    │         │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), ()~~>(79), (91)-->(92), (118)-->(119,120)
-      │    │    │         │    ├── right-join
+      │    │    │         │    ├── right-join (hash)
       │    │    │         │    │    ├── columns: c.oid:1(oid!null) c.relname:2(string!null) c.relnamespace:3(oid!null) c.relowner:5(oid!null) c.reltablespace:8(oid!null) c.reltuples:10(float!null) c.relhasindex:13(bool!null) c.relpersistence:15(string!null) c.relkind:17(string!null) c.relhasoids:20(bool!null) c.relhasrules:22(bool!null) c.relhastriggers:23(bool!null) c.relacl:26(string[]) c.reloptions:27(string[]) n.oid:28(oid!null) n.nspname:29(string!null) t.oid:32(oid) spcname:33(string) i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) ci.oid:91(oid) ci.relname:92(string)
       │    │    │         │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), ()~~>(79), (91)-->(92)
       │    │    │         │    │    ├── scan ci@pg_class_relname_nsp_index
       │    │    │         │    │    │    ├── columns: i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) ci.oid:91(oid!null) ci.relname:92(string!null)
       │    │    │         │    │    │    ├── key: (91)
       │    │    │         │    │    │    └── fd: (91)-->(92)
-      │    │    │         │    │    ├── right-join
+      │    │    │         │    │    ├── right-join (hash)
       │    │    │         │    │    │    ├── columns: c.oid:1(oid!null) c.relname:2(string!null) c.relnamespace:3(oid!null) c.relowner:5(oid!null) c.reltablespace:8(oid!null) c.reltuples:10(float!null) c.relhasindex:13(bool!null) c.relpersistence:15(string!null) c.relkind:17(string!null) c.relhasoids:20(bool!null) c.relhasrules:22(bool!null) c.relhastriggers:23(bool!null) c.relacl:26(string[]) c.reloptions:27(string[]) n.oid:28(oid!null) n.nspname:29(string!null) t.oid:32(oid) spcname:33(string) i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool)
       │    │    │         │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), ()~~>(79)
       │    │    │         │    │    │    ├── select
@@ -208,13 +208,13 @@ sort
       │    │    │         │    │    │    │    │    └── fd: (72)-->(73,79)
       │    │    │         │    │    │    │    └── filters
       │    │    │         │    │    │    │         └── indisclustered = true [type=bool, outer=(79), constraints=(/79: [/true - /true]; tight), fd=()-->(79)]
-      │    │    │         │    │    │    ├── right-join
+      │    │    │         │    │    │    ├── right-join (hash)
       │    │    │         │    │    │    │    ├── columns: c.oid:1(oid!null) c.relname:2(string!null) c.relnamespace:3(oid!null) c.relowner:5(oid!null) c.reltablespace:8(oid!null) c.reltuples:10(float!null) c.relhasindex:13(bool!null) c.relpersistence:15(string!null) c.relkind:17(string!null) c.relhasoids:20(bool!null) c.relhasrules:22(bool!null) c.relhastriggers:23(bool!null) c.relacl:26(string[]) c.reloptions:27(string[]) n.oid:28(oid!null) n.nspname:29(string!null) t.oid:32(oid) spcname:33(string) i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string)
       │    │    │         │    │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68)
-      │    │    │         │    │    │    │    ├── left-join
+      │    │    │         │    │    │    │    ├── left-join (hash)
       │    │    │         │    │    │    │    │    ├── columns: i.inhrelid:38(oid!null) i.inhparent:39(oid!null) c2.oid:41(oid!null) c2.relname:42(string!null) c2.relnamespace:43(oid!null) n2.oid:68(oid) n2.nspname:69(string)
       │    │    │         │    │    │    │    │    ├── fd: (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)-->(69), (69)-->(68)
-      │    │    │         │    │    │    │    │    ├── inner-join
+      │    │    │         │    │    │    │    │    ├── inner-join (hash)
       │    │    │         │    │    │    │    │    │    ├── columns: i.inhrelid:38(oid!null) i.inhparent:39(oid!null) c2.oid:41(oid!null) c2.relname:42(string!null) c2.relnamespace:43(oid!null)
       │    │    │         │    │    │    │    │    │    ├── fd: (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39)
       │    │    │         │    │    │    │    │    │    ├── scan i
@@ -236,7 +236,7 @@ sort
       │    │    │         │    │    │    │    │    ├── key columns: [8] = [32]
       │    │    │         │    │    │    │    │    ├── key: (1,32)
       │    │    │         │    │    │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32)
-      │    │    │         │    │    │    │    │    ├── inner-join
+      │    │    │         │    │    │    │    │    ├── inner-join (hash)
       │    │    │         │    │    │    │    │    │    ├── columns: c.oid:1(oid!null) c.relname:2(string!null) c.relnamespace:3(oid!null) c.relowner:5(oid!null) c.reltablespace:8(oid!null) c.reltuples:10(float!null) c.relhasindex:13(bool!null) c.relpersistence:15(string!null) c.relkind:17(string!null) c.relhasoids:20(bool!null) c.relhasrules:22(bool!null) c.relhastriggers:23(bool!null) c.relacl:26(string[]) c.reloptions:27(string[]) n.oid:28(oid!null) n.nspname:29(string!null)
       │    │    │         │    │    │    │    │    │    ├── key: (1)
       │    │    │         │    │    │    │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3)

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -347,7 +347,7 @@ sort
       ├── side-effects, has-placeholder
       ├── key: (1,34)
       ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (34)-->(35-39), (35,37)-->(34,36,38,39)
-      └── right-join
+      └── right-join (hash)
            ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool) flavor_extra_specs_1.id:34(int) key:35(string) value:36(string) flavor_extra_specs_1.flavor_id:37(int) flavor_extra_specs_1.created_at:38(timestamp) flavor_extra_specs_1.updated_at:39(timestamp)
            ├── side-effects, has-placeholder
            ├── key: (1,34)
@@ -602,7 +602,7 @@ sort
       ├── side-effects, has-placeholder
       ├── key: (1,28)
       ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
-      └── right-join
+      └── right-join (hash)
            ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool) instance_type_extra_specs_1.id:28(int) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
            ├── side-effects, has-placeholder
            ├── key: (1,28)
@@ -779,7 +779,7 @@ sort
       ├── has-placeholder
       ├── key: (1,17)
       ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (17)-->(18-24), (18,20,21)~~>(17,19,22-24)
-      └── right-join
+      └── right-join (hash)
            ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs_1.id:17(int) key:18(string) value:19(string) instance_type_extra_specs_1.instance_type_id:20(int) instance_type_extra_specs_1.deleted:21(bool) instance_type_extra_specs_1.deleted_at:22(timestamp) instance_type_extra_specs_1.created_at:23(timestamp) instance_type_extra_specs_1.updated_at:24(timestamp) true_agg:34(bool)
            ├── has-placeholder
            ├── key: (1,17)
@@ -1295,7 +1295,7 @@ project
  ├── side-effects, has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
- └── right-join
+ └── right-join (hash)
       ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool) flavor_extra_specs_1.id:25(int) key:26(string) value:27(string) flavor_extra_specs_1.flavor_id:28(int) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
       ├── side-effects, has-placeholder
       ├── key: (1,25)
@@ -1454,7 +1454,7 @@ project
  ├── side-effects, has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
- └── right-join
+ └── right-join (hash)
       ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool) flavor_extra_specs_1.id:25(int) key:26(string) value:27(string) flavor_extra_specs_1.flavor_id:28(int) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
       ├── side-effects, has-placeholder
       ├── key: (1,25)
@@ -1623,7 +1623,7 @@ sort
       ├── side-effects, has-placeholder
       ├── key: (1,25)
       ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
-      └── right-join
+      └── right-join (hash)
            ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool) flavor_extra_specs_1.id:25(int) key:26(string) value:27(string) flavor_extra_specs_1.flavor_id:28(int) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
            ├── side-effects, has-placeholder
            ├── key: (1,25)
@@ -1808,7 +1808,7 @@ sort
       ├── side-effects, has-placeholder
       ├── key: (1,28)
       ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
-      └── right-join
+      └── right-join (hash)
            ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool) instance_type_extra_specs_1.id:28(int) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
            ├── side-effects, has-placeholder
            ├── key: (1,28)
@@ -2155,7 +2155,7 @@ sort
       ├── has-placeholder
       ├── key: (1,16)
       ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (16)-->(17-21), (17,19)-->(16,18,20,21)
-      └── right-join
+      └── right-join (hash)
            ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs_1.id:16(int) key:17(string) value:18(string) flavor_extra_specs_1.flavor_id:19(int) flavor_extra_specs_1.created_at:20(timestamp) flavor_extra_specs_1.updated_at:21(timestamp) true_agg:29(bool)
            ├── has-placeholder
            ├── key: (1,16)
@@ -2497,7 +2497,7 @@ sort
       ├── side-effects, has-placeholder
       ├── key: (1,25)
       ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
-      └── right-join
+      └── right-join (hash)
            ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool) flavor_extra_specs_1.id:25(int) key:26(string) value:27(string) flavor_extra_specs_1.flavor_id:28(int) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
            ├── side-effects, has-placeholder
            ├── key: (1,25)
@@ -3128,7 +3128,7 @@ project
  ├── side-effects, has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
- └── right-join
+ └── right-join (hash)
       ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool) flavor_extra_specs_1.id:25(int) key:26(string) value:27(string) flavor_extra_specs_1.flavor_id:28(int) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
       ├── side-effects, has-placeholder
       ├── key: (1,25)
@@ -3296,7 +3296,7 @@ sort
       ├── side-effects, has-placeholder
       ├── key: (1,25)
       ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15), (25)-->(26-30), (26,28)-->(25,27,29,30)
-      └── right-join
+      └── right-join (hash)
            ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool) flavor_extra_specs_1.id:25(int) key:26(string) value:27(string) flavor_extra_specs_1.flavor_id:28(int) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
            ├── side-effects, has-placeholder
            ├── key: (1,25)

--- a/pkg/sql/opt/xform/testdata/external/pgjdbc
+++ b/pkg/sql/opt/xform/testdata/external/pgjdbc
@@ -86,7 +86,7 @@ project
  ├── left-join-apply
  │    ├── columns: t.oid:1(oid) t.typname:2(name!null) t.typnamespace:3(oid!null) t.typtype:7(string) t.typbasetype:25(oid) n.oid:33(oid!null) nspname:34(name!null) case:70(string)
  │    ├── fd: (3)==(33), (33)==(3)
- │    ├── inner-join
+ │    ├── inner-join (hash)
  │    │    ├── columns: t.oid:1(oid) t.typname:2(name!null) t.typnamespace:3(oid!null) t.typtype:7(string) t.typbasetype:25(oid) n.oid:33(oid!null) nspname:34(name!null)
  │    │    ├── fd: (3)==(33), (33)==(3)
  │    │    ├── scan t

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -453,11 +453,11 @@ project
       │         │    ├── grouping columns: ps_partkey:17(int!null) ps_suppkey:18(int!null)
       │         │    ├── key: (17,18)
       │         │    ├── fd: (1)-->(3), (17,18)-->(1,3,11,12,14-16,20,23,48), (1)==(17), (17)==(1), (18)-->(11,12,14-16,23)
-      │         │    ├── inner-join
+      │         │    ├── inner-join (hash)
       │         │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(char!null) p_type:5(varchar!null) p_size:6(int!null) s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null) ps_partkey:29(int!null) ps_suppkey:30(int!null) ps_supplycost:32(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │         │    │    ├── key: (18,29,34)
       │         │    │    ├── fd: ()-->(6,27,46), (1)-->(3,5), (10)-->(11-16), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24), (10)==(18), (18)==(10), (13)==(22), (22)==(13), (1)==(17,29), (17)==(1,29), (29,30)-->(32), (34)-->(37), (41)-->(43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (30)==(34), (34)==(30), (29)==(1,17)
-      │         │    │    ├── inner-join
+      │         │    │    ├── inner-join (hash)
       │         │    │    │    ├── columns: ps_partkey:29(int!null) ps_suppkey:30(int!null) ps_supplycost:32(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │         │    │    │    ├── key: (29,34)
       │         │    │    │    ├── fd: ()-->(46), (29,30)-->(32), (34)-->(37), (41)-->(43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (30)==(34), (34)==(30)
@@ -508,11 +508,11 @@ project
       │         │    │    │    │    └── filters (true)
       │         │    │    │    └── filters
       │         │    │    │         └── s_suppkey = ps_suppkey [type=bool, outer=(30,34), constraints=(/30: (/NULL - ]; /34: (/NULL - ]), fd=(30)==(34), (34)==(30)]
-      │         │    │    ├── inner-join
+      │         │    │    ├── inner-join (hash)
       │         │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(char!null) p_type:5(varchar!null) p_size:6(int!null) s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null)
       │         │    │    │    ├── key: (17,18)
       │         │    │    │    ├── fd: ()-->(6,27), (1)-->(3,5), (10)-->(11-16), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24), (10)==(18), (18)==(10), (13)==(22), (22)==(13), (1)==(17), (17)==(1)
-      │         │    │    │    ├── inner-join
+      │         │    │    │    ├── inner-join (hash)
       │         │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null)
       │         │    │    │    │    ├── key: (17,18)
       │         │    │    │    │    ├── fd: ()-->(27), (10)-->(11-16), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24), (10)==(18), (18)==(10), (13)==(22), (22)==(13)
@@ -520,7 +520,7 @@ project
       │         │    │    │    │    │    ├── columns: ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null)
       │         │    │    │    │    │    ├── key: (17,18)
       │         │    │    │    │    │    └── fd: (17,18)-->(20)
-      │         │    │    │    │    ├── inner-join
+      │         │    │    │    │    ├── inner-join (hash)
       │         │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null) n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null)
       │         │    │    │    │    │    ├── key: (10)
       │         │    │    │    │    │    ├── fd: ()-->(27), (22)-->(23,24), (24)==(26), (26)==(24), (10)-->(11-16), (13)==(22), (22)==(13)
@@ -528,7 +528,7 @@ project
       │         │    │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null)
       │         │    │    │    │    │    │    ├── key: (10)
       │         │    │    │    │    │    │    └── fd: (10)-->(11-16)
-      │         │    │    │    │    │    ├── inner-join
+      │         │    │    │    │    │    ├── inner-join (hash)
       │         │    │    │    │    │    │    ├── columns: n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null)
       │         │    │    │    │    │    │    ├── key: (22)
       │         │    │    │    │    │    │    ├── fd: ()-->(27), (22)-->(23,24), (24)==(26), (26)==(24)
@@ -732,7 +732,7 @@ sort
       ├── grouping columns: o_orderpriority:6(char!null)
       ├── key: (6)
       ├── fd: (6)-->(26)
-      ├── semi-join
+      ├── semi-join (hash)
       │    ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null) o_orderpriority:6(char!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(5,6)
@@ -811,13 +811,13 @@ sort
       ├── fd: (42)-->(49)
       ├── project
       │    ├── columns: column48:48(float) n_name:42(char!null)
-      │    ├── inner-join
+      │    ├── inner-join (hash)
       │    │    ├── columns: c_custkey:1(int!null) c_nationkey:4(int!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │    │    ├── fd: ()-->(46), (1)-->(4), (9)-->(10,13), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(4,41), (41)==(4,37), (20)==(34), (34)==(20), (9)==(18), (18)==(9), (1)==(10), (10)==(1), (4)==(37,41)
-      │    │    ├── inner-join
+      │    │    ├── inner-join (hash)
       │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │    │    │    ├── fd: ()-->(46), (9)-->(10,13), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (20)==(34), (34)==(20), (9)==(18), (18)==(9)
-      │    │    │    ├── inner-join
+      │    │    │    ├── inner-join (hash)
       │    │    │    │    ├── columns: l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │    │    │    │    ├── fd: ()-->(46), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (20)==(34), (34)==(20)
       │    │    │    │    ├── scan lineitem
@@ -838,7 +838,7 @@ sort
       │    │    │    │    │    │    ├── key: (41)
       │    │    │    │    │    │    ├── fd: ()-->(46), (41)-->(42,43), (43)==(45), (45)==(43)
       │    │    │    │    │    │    ├── ordering: +41 opt(46) [actual: +41]
-      │    │    │    │    │    │    └── inner-join
+      │    │    │    │    │    │    └── inner-join (hash)
       │    │    │    │    │    │         ├── columns: n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │    │    │    │    │    │         ├── key: (41)
       │    │    │    │    │    │         ├── fd: ()-->(46), (41)-->(42,43), (43)==(45), (45)==(43)
@@ -1003,13 +1003,13 @@ sort
       ├── fd: (42,46,49)-->(51)
       ├── project
       │    ├── columns: l_year:49(int) volume:50(float) n1.n_name:42(char!null) n2.n_name:46(char!null)
-      │    ├── inner-join
+      │    ├── inner-join (hash)
       │    │    ├── columns: s_suppkey:1(int!null) s_nationkey:4(int!null) l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null) o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
       │    │    ├── fd: (1)-->(4), (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25), (8)==(24), (24)==(8), (1)==(10), (10)==(1), (4)==(41), (41)==(4)
-      │    │    ├── inner-join
+      │    │    ├── inner-join (hash)
       │    │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null) o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
       │    │    │    ├── fd: (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25), (8)==(24), (24)==(8)
-      │    │    │    ├── inner-join
+      │    │    │    ├── inner-join (hash)
       │    │    │    │    ├── columns: o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
       │    │    │    │    ├── key: (24,41)
       │    │    │    │    ├── fd: (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25)
@@ -1033,7 +1033,7 @@ sort
       │    │    │    │    │    │    ├── key: (41,45)
       │    │    │    │    │    │    ├── fd: (41)-->(42), (45)-->(46)
       │    │    │    │    │    │    ├── ordering: +45
-      │    │    │    │    │    │    └── inner-join
+      │    │    │    │    │    │    └── inner-join (hash)
       │    │    │    │    │    │         ├── columns: n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
       │    │    │    │    │    │         ├── key: (41,45)
       │    │    │    │    │    │         ├── fd: (41)-->(42), (45)-->(46)
@@ -1147,16 +1147,16 @@ sort
       │    │    ├── columns: column63:63(float) o_year:61(int) volume:62(float)
       │    │    ├── project
       │    │    │    ├── columns: o_year:61(int) volume:62(float) n2.n_name:55(char!null)
-      │    │    │    ├── inner-join
+      │    │    │    ├── inner-join (hash)
       │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(varchar!null) s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
       │    │    │    │    ├── fd: ()-->(5,59), (10)-->(13), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (10)==(19), (19)==(10), (13)==(54), (54)==(13), (1)==(18), (18)==(1)
-      │    │    │    │    ├── inner-join
+      │    │    │    │    ├── inner-join (hash)
       │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
       │    │    │    │    │    ├── fd: ()-->(59), (10)-->(13), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (10)==(19), (19)==(10), (13)==(54), (54)==(13)
-      │    │    │    │    │    ├── inner-join
+      │    │    │    │    │    ├── inner-join (hash)
       │    │    │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
       │    │    │    │    │    │    ├── fd: ()-->(59), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17)
-      │    │    │    │    │    │    ├── inner-join
+      │    │    │    │    │    │    ├── inner-join (hash)
       │    │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
       │    │    │    │    │    │    │    ├── key: (33,54)
       │    │    │    │    │    │    │    ├── fd: ()-->(59), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34)
@@ -1176,7 +1176,7 @@ sort
       │    │    │    │    │    │    │    │    │    ├── key: (50,54)
       │    │    │    │    │    │    │    │    │    ├── fd: ()-->(59), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52)
       │    │    │    │    │    │    │    │    │    ├── ordering: +50 opt(59) [actual: +50]
-      │    │    │    │    │    │    │    │    │    └── inner-join
+      │    │    │    │    │    │    │    │    │    └── inner-join (hash)
       │    │    │    │    │    │    │    │    │         ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
       │    │    │    │    │    │    │    │    │         ├── key: (50,54)
       │    │    │    │    │    │    │    │    │         ├── fd: ()-->(59), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52)
@@ -1327,10 +1327,10 @@ sort
       │    │    ├── columns: p_partkey:1(int!null) p_name:2(varchar!null) s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(char!null)
       │    │    ├── key columns: [18] = [1]
       │    │    ├── fd: (1)-->(2), (10)-->(13), (33,34)-->(36), (38)-->(42), (47)-->(48), (19)==(10,34), (34)==(10,19), (18)==(1,33), (33)==(1,18), (17)==(38), (38)==(17), (10)==(19,34), (13)==(47), (47)==(13), (1)==(18,33)
-      │    │    ├── inner-join
+      │    │    ├── inner-join (hash)
       │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(char!null)
       │    │    │    ├── fd: (10)-->(13), (33,34)-->(36), (38)-->(42), (47)-->(48), (19)==(10,34), (34)==(10,19), (18)==(33), (33)==(18), (17)==(38), (38)==(17), (10)==(19,34), (13)==(47), (47)==(13)
-      │    │    │    ├── inner-join
+      │    │    │    ├── inner-join (hash)
       │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(char!null)
       │    │    │    │    ├── fd: (33,34)-->(36), (38)-->(42), (47)-->(48), (19)==(34), (34)==(19), (18)==(33), (33)==(18), (17)==(38), (38)==(17)
       │    │    │    │    ├── inner-join (lookup orders)
@@ -1442,7 +1442,7 @@ limit
  │         ├── project
  │         │    ├── columns: column38:38(float) c_custkey:1(int!null) c_name:2(varchar!null) c_address:3(varchar!null) c_phone:5(char!null) c_acctbal:6(float!null) c_comment:8(varchar!null) n_name:35(char!null)
  │         │    ├── fd: (1)-->(2,3,5,6,8,35)
- │         │    ├── inner-join
+ │         │    ├── inner-join (hash)
  │         │    │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) c_address:3(varchar!null) c_nationkey:4(int!null) c_phone:5(char!null) c_acctbal:6(float!null) c_comment:8(varchar!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(char!null) n_nationkey:34(int!null) n_name:35(char!null)
  │         │    │    ├── fd: ()-->(26), (1)-->(2-6,8), (9)-->(10,13), (34)-->(35), (9)==(18), (18)==(9), (1)==(10), (10)==(1), (4)==(34), (34)==(4)
  │         │    │    ├── scan nation
@@ -1545,7 +1545,7 @@ sort
       │    ├── fd: (1)-->(18)
       │    ├── project
       │    │    ├── columns: column17:17(float) ps_partkey:1(int!null)
-      │    │    ├── inner-join
+      │    │    ├── inner-join (hash)
       │    │    │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null) ps_availqty:3(int!null) ps_supplycost:4(float!null) s_suppkey:6(int!null) s_nationkey:9(int!null) n_nationkey:13(int!null) n_name:14(char!null)
       │    │    │    ├── key: (1,6)
       │    │    │    ├── fd: ()-->(14), (1,2)-->(3,4), (6)-->(9), (9)==(13), (13)==(9), (2)==(6), (6)==(2)
@@ -1592,7 +1592,7 @@ sort
                           │    ├── fd: ()-->(36)
                           │    ├── project
                           │    │    ├── columns: column35:35(float)
-                          │    │    ├── inner-join
+                          │    │    ├── inner-join (hash)
                           │    │    │    ├── columns: ps_suppkey:20(int!null) ps_availqty:21(int!null) ps_supplycost:22(float!null) s_suppkey:24(int!null) s_nationkey:27(int!null) n_nationkey:31(int!null) n_name:32(char!null)
                           │    │    │    ├── fd: ()-->(32), (24)-->(27), (27)==(31), (31)==(27), (20)==(24), (24)==(20)
                           │    │    │    ├── scan partsupp
@@ -1754,7 +1754,7 @@ sort
       │    ├── grouping columns: c_custkey:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(18)
-      │    ├── right-join
+      │    ├── right-join (hash)
       │    │    ├── columns: c_custkey:1(int!null) o_orderkey:9(int) o_custkey:10(int) o_comment:17(varchar)
       │    │    ├── key: (1,9)
       │    │    ├── fd: (9)-->(10,17)
@@ -1818,7 +1818,7 @@ project
  │    ├── fd: ()-->(27,29)
  │    ├── project
  │    │    ├── columns: column26:26(float) column28:28(float)
- │    │    ├── inner-join
+ │    │    ├── inner-join (hash)
  │    │    │    ├── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null) p_partkey:17(int!null) p_type:21(varchar!null)
  │    │    │    ├── fd: (17)-->(21), (2)==(17), (17)==(2)
  │    │    │    ├── scan part
@@ -2025,7 +2025,7 @@ sort
       ├── grouping columns: p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null)
       ├── key: (9-11)
       ├── fd: (9-11)-->(22)
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null) p_partkey:6(int!null) p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null)
       │    ├── key: (2,6)
       │    ├── fd: (6)-->(9-11), (1)==(6), (6)==(1)
@@ -2238,12 +2238,12 @@ limit
  │         ├── grouping columns: o_orderkey:9(int!null)
  │         ├── key: (9)
  │         ├── fd: (1)-->(2), (9)-->(1,2,12,13,51)
- │         ├── inner-join
+ │         ├── inner-join (hash)
  │         │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_quantity:22(float!null)
  │         │    ├── fd: (1)-->(2), (9)-->(10,12,13), (9)==(18), (18)==(9), (1)==(10), (10)==(1)
  │         │    ├── scan lineitem
  │         │    │    └── columns: l_orderkey:18(int!null) l_quantity:22(float!null)
- │         │    ├── inner-join
+ │         │    ├── inner-join (hash)
  │         │    │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null)
  │         │    │    ├── key: (9)
  │         │    │    ├── fd: (9)-->(10,12,13), (1)-->(2), (1)==(10), (10)==(1)
@@ -2434,11 +2434,11 @@ sort
  ├── ordering: +2
  └── project
       ├── columns: s_name:2(char!null) s_address:3(varchar!null)
-      └── inner-join
+      └── inner-join (hash)
            ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_nationkey:4(int!null) n_nationkey:8(int!null) n_name:9(char!null)
            ├── key: (1)
            ├── fd: ()-->(9), (1)-->(2-4), (4)==(8), (8)==(4)
-           ├── semi-join
+           ├── semi-join (hash)
            │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_nationkey:4(int!null)
            │    ├── key: (1)
            │    ├── fd: (1)-->(2-4)
@@ -2446,7 +2446,7 @@ sort
            │    │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_nationkey:4(int!null)
            │    │    ├── key: (1)
            │    │    └── fd: (1)-->(2-4)
-           │    ├── semi-join
+           │    ├── semi-join (hash)
            │    │    ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null)
            │    │    ├── key: (12,13)
            │    │    ├── project
@@ -2461,7 +2461,7 @@ sort
            │    │    │         │    ├── grouping columns: ps_partkey:12(int!null) ps_suppkey:13(int!null)
            │    │    │         │    ├── key: (12,13)
            │    │    │         │    ├── fd: (12,13)-->(14,42)
-           │    │    │         │    ├── right-join
+           │    │    │         │    ├── right-join (hash)
            │    │    │         │    │    ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null) ps_availqty:14(int!null) l_partkey:27(int) l_suppkey:28(int) l_quantity:30(float) l_shipdate:36(date)
            │    │    │         │    │    ├── fd: (12,13)-->(14)
            │    │    │         │    │    ├── index-join lineitem
@@ -2581,7 +2581,7 @@ limit
  │         ├── grouping columns: s_name:2(char!null)
  │         ├── key: (2)
  │         ├── fd: (2)-->(69)
- │         ├── inner-join
+ │         ├── inner-join (hash)
  │         │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_nationkey:4(int!null) l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null) o_orderkey:24(int!null) o_orderstatus:26(char!null) n_nationkey:33(int!null) n_name:34(char!null)
  │         │    ├── fd: ()-->(26,34), (1)-->(2,4), (8)==(24), (24)==(8), (1)==(10), (10)==(1), (4)==(33), (33)==(4)
  │         │    ├── inner-join (lookup supplier)

--- a/pkg/sql/opt/xform/testdata/external/tpch-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpch-no-stats
@@ -298,11 +298,11 @@ project
       │         │    ├── grouping columns: ps_partkey:17(int!null) ps_suppkey:18(int!null)
       │         │    ├── key: (17,18)
       │         │    ├── fd: (1)-->(3), (17,18)-->(1,3,11,12,14-16,20,23,48), (1)==(17), (17)==(1), (18)-->(11,12,14-16,23)
-      │         │    ├── inner-join
+      │         │    ├── inner-join (hash)
       │         │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(char!null) p_type:5(varchar!null) p_size:6(int!null) s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null) ps_partkey:29(int!null) ps_suppkey:30(int!null) ps_supplycost:32(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │         │    │    ├── key: (18,29,34)
       │         │    │    ├── fd: ()-->(6,27,46), (1)-->(3,5), (10)-->(11-16), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24), (10)==(18), (18)==(10), (13)==(22), (22)==(13), (1)==(17,29), (17)==(1,29), (29,30)-->(32), (34)-->(37), (41)-->(43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (30)==(34), (34)==(30), (29)==(1,17)
-      │         │    │    ├── inner-join
+      │         │    │    ├── inner-join (hash)
       │         │    │    │    ├── columns: ps_partkey:29(int!null) ps_suppkey:30(int!null) ps_supplycost:32(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │         │    │    │    ├── key: (29,34)
       │         │    │    │    ├── fd: ()-->(46), (29,30)-->(32), (34)-->(37), (41)-->(43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (30)==(34), (34)==(30)
@@ -310,7 +310,7 @@ project
       │         │    │    │    │    ├── columns: ps_partkey:29(int!null) ps_suppkey:30(int!null) ps_supplycost:32(float!null)
       │         │    │    │    │    ├── key: (29,30)
       │         │    │    │    │    └── fd: (29,30)-->(32)
-      │         │    │    │    ├── inner-join
+      │         │    │    │    ├── inner-join (hash)
       │         │    │    │    │    ├── columns: s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │         │    │    │    │    ├── key: (34)
       │         │    │    │    │    ├── fd: ()-->(46), (34)-->(37), (41)-->(43), (43)==(45), (45)==(43), (37)==(41), (41)==(37)
@@ -338,11 +338,11 @@ project
       │         │    │    │    │         └── s_nationkey = n_nationkey [type=bool, outer=(37,41), constraints=(/37: (/NULL - ]; /41: (/NULL - ]), fd=(37)==(41), (41)==(37)]
       │         │    │    │    └── filters
       │         │    │    │         └── s_suppkey = ps_suppkey [type=bool, outer=(30,34), constraints=(/30: (/NULL - ]; /34: (/NULL - ]), fd=(30)==(34), (34)==(30)]
-      │         │    │    ├── inner-join
+      │         │    │    ├── inner-join (hash)
       │         │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(char!null) p_type:5(varchar!null) p_size:6(int!null) s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null)
       │         │    │    │    ├── key: (17,18)
       │         │    │    │    ├── fd: ()-->(6,27), (1)-->(3,5), (10)-->(11-16), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24), (10)==(18), (18)==(10), (13)==(22), (22)==(13), (1)==(17), (17)==(1)
-      │         │    │    │    ├── inner-join
+      │         │    │    │    ├── inner-join (hash)
       │         │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null)
       │         │    │    │    │    ├── key: (17,18)
       │         │    │    │    │    ├── fd: ()-->(27), (10)-->(11-16), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24), (10)==(18), (18)==(10), (13)==(22), (22)==(13)
@@ -350,7 +350,7 @@ project
       │         │    │    │    │    │    ├── columns: ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null)
       │         │    │    │    │    │    ├── key: (17,18)
       │         │    │    │    │    │    └── fd: (17,18)-->(20)
-      │         │    │    │    │    ├── inner-join
+      │         │    │    │    │    ├── inner-join (hash)
       │         │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null) n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null)
       │         │    │    │    │    │    ├── key: (10)
       │         │    │    │    │    │    ├── fd: ()-->(27), (22)-->(23,24), (24)==(26), (26)==(24), (10)-->(11-16), (13)==(22), (22)==(13)
@@ -649,18 +649,18 @@ sort
       ├── fd: (42)-->(49)
       ├── project
       │    ├── columns: column48:48(float) n_name:42(char!null)
-      │    ├── inner-join
+      │    ├── inner-join (hash)
       │    │    ├── columns: c_custkey:1(int!null) c_nationkey:4(int!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │    │    ├── fd: ()-->(46), (1)-->(4), (9)-->(10,13), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(4,41), (41)==(4,37), (20)==(34), (34)==(20), (9)==(18), (18)==(9), (1)==(10), (10)==(1), (4)==(37,41)
-      │    │    ├── inner-join
+      │    │    ├── inner-join (hash)
       │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │    │    │    ├── fd: ()-->(46), (9)-->(10,13), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (20)==(34), (34)==(20), (9)==(18), (18)==(9)
-      │    │    │    ├── inner-join
+      │    │    │    ├── inner-join (hash)
       │    │    │    │    ├── columns: l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │    │    │    │    ├── fd: ()-->(46), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (20)==(34), (34)==(20)
       │    │    │    │    ├── scan lineitem
       │    │    │    │    │    └── columns: l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null)
-      │    │    │    │    ├── inner-join
+      │    │    │    │    ├── inner-join (hash)
       │    │    │    │    │    ├── columns: s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │    │    │    │    │    ├── key: (34)
       │    │    │    │    │    ├── fd: ()-->(46), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(41), (41)==(37)
@@ -832,17 +832,17 @@ group-by
  │    ├── ordering: +42,+46,+49
  │    └── project
  │         ├── columns: l_year:49(int) volume:50(float) n1.n_name:42(char!null) n2.n_name:46(char!null)
- │         ├── inner-join
+ │         ├── inner-join (hash)
  │         │    ├── columns: s_suppkey:1(int!null) s_nationkey:4(int!null) l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null) o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
  │         │    ├── fd: (1)-->(4), (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25), (8)==(24), (24)==(8), (1)==(10), (10)==(1), (4)==(41), (41)==(4)
- │         │    ├── inner-join
+ │         │    ├── inner-join (hash)
  │         │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null) o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
  │         │    │    ├── fd: (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25), (8)==(24), (24)==(8)
- │         │    │    ├── inner-join
+ │         │    │    ├── inner-join (hash)
  │         │    │    │    ├── columns: o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
  │         │    │    │    ├── key: (24,41)
  │         │    │    │    ├── fd: (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25)
- │         │    │    │    ├── inner-join
+ │         │    │    │    ├── inner-join (hash)
  │         │    │    │    │    ├── columns: o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
  │         │    │    │    │    ├── key: (24)
  │         │    │    │    │    ├── fd: (45)-->(46), (33)-->(36), (36)==(45), (45)==(36), (24)-->(25), (25)==(33), (33)==(25)
@@ -976,17 +976,17 @@ sort
       │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(varchar!null) s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
       │    │    │    │    ├── key columns: [18] = [1]
       │    │    │    │    ├── fd: ()-->(5,59), (10)-->(13), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (10)==(19), (19)==(10), (13)==(54), (54)==(13), (1)==(18), (18)==(1)
-      │    │    │    │    ├── inner-join
+      │    │    │    │    ├── inner-join (hash)
       │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
       │    │    │    │    │    ├── fd: ()-->(59), (10)-->(13), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (10)==(19), (19)==(10), (13)==(54), (54)==(13)
-      │    │    │    │    │    ├── inner-join
+      │    │    │    │    │    ├── inner-join (hash)
       │    │    │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
       │    │    │    │    │    │    ├── fd: ()-->(59), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17)
-      │    │    │    │    │    │    ├── inner-join
+      │    │    │    │    │    │    ├── inner-join (hash)
       │    │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
       │    │    │    │    │    │    │    ├── key: (33,54)
       │    │    │    │    │    │    │    ├── fd: ()-->(59), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34)
-      │    │    │    │    │    │    │    ├── inner-join
+      │    │    │    │    │    │    │    ├── inner-join (hash)
       │    │    │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
       │    │    │    │    │    │    │    │    ├── key: (42,54)
       │    │    │    │    │    │    │    │    ├── fd: ()-->(59), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45)
@@ -994,7 +994,7 @@ sort
       │    │    │    │    │    │    │    │    │    ├── columns: n2.n_nationkey:54(int!null) n2.n_name:55(char!null)
       │    │    │    │    │    │    │    │    │    ├── key: (54)
       │    │    │    │    │    │    │    │    │    └── fd: (54)-->(55)
-      │    │    │    │    │    │    │    │    ├── inner-join
+      │    │    │    │    │    │    │    │    ├── inner-join (hash)
       │    │    │    │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) r_regionkey:58(int!null) r_name:59(char!null)
       │    │    │    │    │    │    │    │    │    ├── key: (42)
       │    │    │    │    │    │    │    │    │    ├── fd: ()-->(59), (50)-->(52), (52)==(58), (58)==(52), (42)-->(45), (45)==(50), (50)==(45)
@@ -1128,10 +1128,10 @@ sort
       │    │    ├── columns: p_partkey:1(int!null) p_name:2(varchar!null) s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(char!null)
       │    │    ├── key columns: [18] = [1]
       │    │    ├── fd: (1)-->(2), (10)-->(13), (33,34)-->(36), (38)-->(42), (47)-->(48), (19)==(10,34), (34)==(10,19), (18)==(1,33), (33)==(1,18), (17)==(38), (38)==(17), (10)==(19,34), (13)==(47), (47)==(13), (1)==(18,33)
-      │    │    ├── inner-join
+      │    │    ├── inner-join (hash)
       │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(char!null)
       │    │    │    ├── fd: (10)-->(13), (33,34)-->(36), (38)-->(42), (47)-->(48), (19)==(10,34), (34)==(10,19), (18)==(33), (33)==(18), (17)==(38), (38)==(17), (10)==(19,34), (13)==(47), (47)==(13)
-      │    │    │    ├── inner-join
+      │    │    │    ├── inner-join (hash)
       │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(char!null)
       │    │    │    │    ├── fd: (33,34)-->(36), (38)-->(42), (47)-->(48), (19)==(34), (34)==(19), (18)==(33), (33)==(18), (17)==(38), (38)==(17)
       │    │    │    │    ├── scan nation
@@ -1142,7 +1142,7 @@ sort
       │    │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null)
       │    │    │    │    │    ├── key columns: [17] = [38]
       │    │    │    │    │    ├── fd: (38)-->(42), (33,34)-->(36), (19)==(34), (34)==(19), (18)==(33), (33)==(18), (17)==(38), (38)==(17)
-      │    │    │    │    │    ├── inner-join
+      │    │    │    │    │    ├── inner-join (hash)
       │    │    │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null)
       │    │    │    │    │    │    ├── fd: (33,34)-->(36), (19)==(34), (34)==(19), (18)==(33), (33)==(18)
       │    │    │    │    │    │    ├── scan partsupp
@@ -1337,7 +1337,7 @@ sort
       │    ├── fd: (1)-->(18)
       │    ├── project
       │    │    ├── columns: column17:17(float) ps_partkey:1(int!null)
-      │    │    ├── inner-join
+      │    │    ├── inner-join (hash)
       │    │    │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null) ps_availqty:3(int!null) ps_supplycost:4(float!null) s_suppkey:6(int!null) s_nationkey:9(int!null) n_nationkey:13(int!null) n_name:14(char!null)
       │    │    │    ├── key: (1,6)
       │    │    │    ├── fd: ()-->(14), (1,2)-->(3,4), (6)-->(9), (9)==(13), (13)==(9), (2)==(6), (6)==(2)
@@ -1384,7 +1384,7 @@ sort
                           │    ├── fd: ()-->(36)
                           │    ├── project
                           │    │    ├── columns: column35:35(float)
-                          │    │    ├── inner-join
+                          │    │    ├── inner-join (hash)
                           │    │    │    ├── columns: ps_suppkey:20(int!null) ps_availqty:21(int!null) ps_supplycost:22(float!null) s_suppkey:24(int!null) s_nationkey:27(int!null) n_nationkey:31(int!null) n_name:32(char!null)
                           │    │    │    ├── fd: ()-->(32), (24)-->(27), (27)==(31), (31)==(27), (20)==(24), (24)==(20)
                           │    │    │    ├── scan partsupp
@@ -1541,7 +1541,7 @@ sort
       │    ├── grouping columns: c_custkey:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(18)
-      │    ├── left-join
+      │    ├── left-join (hash)
       │    │    ├── columns: c_custkey:1(int!null) o_orderkey:9(int) o_custkey:10(int) o_comment:17(varchar)
       │    │    ├── key: (1,9)
       │    │    ├── fd: (9)-->(10,17)
@@ -1605,7 +1605,7 @@ project
  │    ├── fd: ()-->(27,29)
  │    ├── project
  │    │    ├── columns: column26:26(float) column28:28(float)
- │    │    ├── inner-join
+ │    │    ├── inner-join (hash)
  │    │    │    ├── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null) p_partkey:17(int!null) p_type:21(varchar!null)
  │    │    │    ├── fd: (17)-->(21), (2)==(17), (17)==(2)
  │    │    │    ├── scan part
@@ -1801,7 +1801,7 @@ sort
       ├── grouping columns: p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null)
       ├── key: (9-11)
       ├── fd: (9-11)-->(22)
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null) p_partkey:6(int!null) p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null)
       │    ├── key: (2,6)
       │    ├── fd: (6)-->(9-11), (1)==(6), (6)==(1)
@@ -2014,7 +2014,7 @@ limit
  │         ├── grouping columns: o_orderkey:9(int!null)
  │         ├── key: (9)
  │         ├── fd: (1)-->(2), (9)-->(1,2,12,13,51)
- │         ├── inner-join
+ │         ├── inner-join (hash)
  │         │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_quantity:22(float!null)
  │         │    ├── fd: (1)-->(2), (9)-->(10,12,13), (9)==(18), (18)==(9), (1)==(10), (10)==(1)
  │         │    ├── scan customer
@@ -2212,11 +2212,11 @@ sort
  ├── ordering: +2
  └── project
       ├── columns: s_name:2(char!null) s_address:3(varchar!null)
-      └── inner-join
+      └── inner-join (hash)
            ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_nationkey:4(int!null) n_nationkey:8(int!null) n_name:9(char!null)
            ├── key: (1)
            ├── fd: ()-->(9), (1)-->(2-4), (4)==(8), (8)==(4)
-           ├── semi-join
+           ├── semi-join (hash)
            │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_nationkey:4(int!null)
            │    ├── key: (1)
            │    ├── fd: (1)-->(2-4)
@@ -2224,7 +2224,7 @@ sort
            │    │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_nationkey:4(int!null)
            │    │    ├── key: (1)
            │    │    └── fd: (1)-->(2-4)
-           │    ├── semi-join
+           │    ├── semi-join (hash)
            │    │    ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null)
            │    │    ├── key: (12,13)
            │    │    ├── project
@@ -2239,7 +2239,7 @@ sort
            │    │    │         │    ├── grouping columns: ps_partkey:12(int!null) ps_suppkey:13(int!null)
            │    │    │         │    ├── key: (12,13)
            │    │    │         │    ├── fd: (12,13)-->(14,42)
-           │    │    │         │    ├── left-join
+           │    │    │         │    ├── left-join (hash)
            │    │    │         │    │    ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null) ps_availqty:14(int!null) l_partkey:27(int) l_suppkey:28(int) l_quantity:30(float) l_shipdate:36(date)
            │    │    │         │    │    ├── fd: (12,13)-->(14)
            │    │    │         │    │    ├── scan partsupp

--- a/pkg/sql/opt/xform/testdata/physprops/presentation
+++ b/pkg/sql/opt/xform/testdata/physprops/presentation
@@ -39,7 +39,7 @@ project
 opt
 SELECT b.x, rowid, a.y, a.x, a.y y2, b.y FROM a, b
 ----
-inner-join
+inner-join (hash)
  ├── columns: x:3(int) rowid:5(int!null) y:2(int) x:1(int!null) y2:2(int) y:4(float)
  ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)

--- a/pkg/sql/opt/xform/testdata/ruleprops/orderings
+++ b/pkg/sql/opt/xform/testdata/ruleprops/orderings
@@ -262,7 +262,7 @@ CREATE TABLE xyz (x INT, y INT, z INT, INDEX(z), UNIQUE INDEX(x,y))
 opt
 SELECT * FROM abc JOIN xyz ON a=x 
 ----
-inner-join
+inner-join (hash)
  ├── columns: a:1(int!null) b:2(int) c:3(int) x:5(int!null) y:6(int) z:7(int)
  ├── lax-key: (2,3,5-7)
  ├── fd: (3)~~>(1,2), (5,6)~~>(7), (1)==(5), (5)==(1)

--- a/pkg/sql/opt/xform/testdata/rules/combo
+++ b/pkg/sql/opt/xform/testdata/rules/combo
@@ -29,7 +29,7 @@ SELECT * FROM abc, xyz WHERE a=x AND b=y
 GenerateIndexScans
 ================================================================================
 Source expression:
-  inner-join
+  inner-join (hash)
    ├── columns: a:1(int!null) b:2(int!null) c:3(int) x:5(int!null) y:6(int!null) z:7(int)
    ├── fd: (1)==(5), (5)==(1), (2)==(6), (6)==(2)
    ├── scan abc
@@ -41,7 +41,7 @@ Source expression:
         └── b = y [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
 
 New expression 1 of 1:
-  inner-join
+  inner-join (hash)
    ├── columns: a:1(int!null) b:2(int!null) c:3(int) x:5(int!null) y:6(int!null) z:7(int)
    ├── fd: (1)==(5), (5)==(1), (2)==(6), (6)==(2)
    ├── scan abc@ab
@@ -56,7 +56,7 @@ New expression 1 of 1:
 GenerateIndexScans
 ================================================================================
 Source expression:
-  inner-join
+  inner-join (hash)
    ├── columns: a:1(int!null) b:2(int!null) c:3(int) x:5(int!null) y:6(int!null) z:7(int)
    ├── fd: (1)==(5), (5)==(1), (2)==(6), (6)==(2)
    ├── scan abc
@@ -68,7 +68,7 @@ Source expression:
         └── b = y [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
 
 New expression 1 of 1:
-  inner-join
+  inner-join (hash)
    ├── columns: a:1(int!null) b:2(int!null) c:3(int) x:5(int!null) y:6(int!null) z:7(int)
    ├── fd: (1)==(5), (5)==(1), (2)==(6), (6)==(2)
    ├── scan abc
@@ -83,7 +83,7 @@ New expression 1 of 1:
 CommuteJoin
 ================================================================================
 Source expression:
-  inner-join
+  inner-join (hash)
    ├── columns: a:1(int!null) b:2(int!null) c:3(int) x:5(int!null) y:6(int!null) z:7(int)
    ├── fd: (1)==(5), (5)==(1), (2)==(6), (6)==(2)
    ├── scan abc
@@ -95,7 +95,7 @@ Source expression:
         └── b = y [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
 
 New expression 1 of 1:
-  inner-join
+  inner-join (hash)
    ├── columns: a:1(int!null) b:2(int!null) c:3(int) x:5(int!null) y:6(int!null) z:7(int)
    ├── fd: (1)==(5), (5)==(1), (2)==(6), (6)==(2)
    ├── scan xyz
@@ -110,7 +110,7 @@ New expression 1 of 1:
 GenerateMergeJoins
 ================================================================================
 Source expression:
-  inner-join
+  inner-join (hash)
    ├── columns: a:1(int!null) b:2(int!null) c:3(int) x:5(int!null) y:6(int!null) z:7(int)
    ├── fd: (1)==(5), (5)==(1), (2)==(6), (6)==(2)
    ├── scan abc
@@ -139,7 +139,7 @@ New expression 1 of 1:
 GenerateLookupJoins
 ================================================================================
 Source expression:
-  inner-join
+  inner-join (hash)
    ├── columns: a:1(int!null) b:2(int!null) c:3(int) x:5(int!null) y:6(int!null) z:7(int)
    ├── fd: (1)==(5), (5)==(1), (2)==(6), (6)==(2)
    ├── scan abc
@@ -163,7 +163,7 @@ New expression 1 of 1:
 CommuteJoin
 ================================================================================
 Source expression:
-  inner-join
+  inner-join (hash)
    ├── columns: a:1(int!null) b:2(int!null) c:3(int) x:5(int!null) y:6(int!null) z:7(int)
    ├── fd: (1)==(5), (5)==(1), (2)==(6), (6)==(2)
    ├── scan xyz
@@ -180,7 +180,7 @@ No new expressions.
 GenerateMergeJoins
 ================================================================================
 Source expression:
-  inner-join
+  inner-join (hash)
    ├── columns: a:1(int!null) b:2(int!null) c:3(int) x:5(int!null) y:6(int!null) z:7(int)
    ├── fd: (1)==(5), (5)==(1), (2)==(6), (6)==(2)
    ├── scan xyz
@@ -209,7 +209,7 @@ New expression 1 of 1:
 GenerateLookupJoins
 ================================================================================
 Source expression:
-  inner-join
+  inner-join (hash)
    ├── columns: a:1(int!null) b:2(int!null) c:3(int) x:5(int!null) y:6(int!null) z:7(int)
    ├── fd: (1)==(5), (5)==(1), (2)==(6), (6)==(2)
    ├── scan xyz

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -123,7 +123,7 @@ memo (optimized, ~8KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
 opt
 SELECT * FROM abc INNER JOIN xyz ON a=c WHERE b=1
 ----
-inner-join
+inner-join (hash)
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:5(int) y:6(int) z:7(int)
  ├── fd: ()-->(2), (1)==(3), (3)==(1)
  ├── scan xyz
@@ -142,7 +142,7 @@ inner-join
 opt
 SELECT * FROM (SELECT * FROM abc WHERE b=1) FULL OUTER JOIN xyz ON a=z
 ----
-full-join
+full-join (hash)
  ├── columns: a:1(int) b:2(int) c:3(int) x:5(int) y:6(int) z:7(int)
  ├── fd: ()~~>(2)
  ├── scan xyz
@@ -211,7 +211,7 @@ memo (optimized, ~8KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
 opt
 SELECT * FROM abc LEFT OUTER JOIN xyz ON a=z WHERE b=1
 ----
-right-join
+right-join (hash)
  ├── columns: a:1(int) b:2(int!null) c:3(int) x:5(int) y:6(int) z:7(int)
  ├── fd: ()-->(2)
  ├── scan xyz
@@ -287,7 +287,7 @@ memo (optimized, ~9KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
 opt
 SELECT * FROM (SELECT * FROM abc WHERE b=1) RIGHT OUTER JOIN xyz ON a=z
 ----
-left-join
+left-join (hash)
  ├── columns: a:1(int) b:2(int) c:3(int) x:5(int) y:6(int) z:7(int)
  ├── fd: ()~~>(2)
  ├── scan xyz
@@ -429,7 +429,7 @@ inner-join (merge)
 opt
 SELECT * FROM abc JOIN xyz ON a=x AND b=y WHERE b=1 AND y=1
 ----
-inner-join
+inner-join (hash)
  ├── columns: a:1(int!null) b:2(int!null) c:3(int) x:5(int!null) y:6(int!null) z:7(int)
  ├── fd: ()-->(2,6), (1)==(5), (5)==(1), (2)==(6), (6)==(2)
  ├── scan abc@bc
@@ -493,7 +493,7 @@ SELECT * FROM stu AS l JOIN stu AS r ON (l.s, l.t, l.u) = (r.s, r.t, r.u)
 GenerateMergeJoins
 ================================================================================
 Source expression:
-  inner-join
+  inner-join (hash)
    ├── columns: s:1(int!null) t:2(int!null) u:3(int!null) s:4(int!null) t:5(int!null) u:6(int!null)
    ├── key: (4-6)
    ├── fd: (1)==(4), (4)==(1), (2)==(5), (5)==(2), (3)==(6), (6)==(3)
@@ -546,7 +546,7 @@ New expression 2 of 2:
 GenerateMergeJoins
 ================================================================================
 Source expression:
-  inner-join
+  inner-join (hash)
    ├── columns: s:1(int!null) t:2(int!null) u:3(int!null) s:4(int!null) t:5(int!null) u:6(int!null)
    ├── key: (4-6)
    ├── fd: (1)==(4), (4)==(1), (2)==(5), (5)==(2), (3)==(6), (6)==(3)
@@ -924,7 +924,7 @@ inner-join (lookup abcd)
 opt
 SELECT * FROM small LEFT JOIN abcd ON a=m AND c>n
 ----
-right-join
+right-join (hash)
  ├── columns: m:1(int) n:2(int) a:4(int) b:5(int) c:6(int)
  ├── scan abcd
  │    └── columns: a:4(int) b:5(int) c:6(int)
@@ -944,7 +944,7 @@ SELECT * FROM abc JOIN xyz ON a=x AND a=y
 GenerateLookupJoins
 ================================================================================
 Source expression:
-  inner-join
+  inner-join (hash)
    ├── columns: a:1(int!null) b:2(int) c:3(int) x:5(int!null) y:6(int!null) z:7(int)
    ├── fd: (1)==(5,6), (5)==(1,6), (6)==(1,5)
    ├── scan abc
@@ -969,7 +969,7 @@ New expression 1 of 1:
 GenerateLookupJoins
 ================================================================================
 Source expression:
-  inner-join
+  inner-join (hash)
    ├── columns: a:1(int!null) b:2(int) c:3(int) x:5(int!null) y:6(int!null) z:7(int)
    ├── fd: (1)==(5,6), (5)==(1,6), (6)==(1,5)
    ├── scan xyz
@@ -1001,7 +1001,7 @@ SELECT * FROM abc JOIN xyz ON a=z
 GenerateLookupJoins
 ================================================================================
 Source expression:
-  inner-join
+  inner-join (hash)
    ├── columns: a:1(int!null) b:2(int) c:3(int) x:5(int) y:6(int) z:7(int!null)
    ├── fd: (1)==(7), (7)==(1)
    ├── scan abc
@@ -1017,7 +1017,7 @@ No new expressions.
 GenerateLookupJoins
 ================================================================================
 Source expression:
-  inner-join
+  inner-join (hash)
    ├── columns: a:1(int!null) b:2(int) c:3(int) x:5(int) y:6(int) z:7(int!null)
    ├── fd: (1)==(7), (7)==(1)
    ├── scan xyz
@@ -1046,7 +1046,7 @@ SELECT * FROM abc RIGHT JOIN xyz ON a=z
 GenerateLookupJoins
 ================================================================================
 Source expression:
-  left-join
+  left-join (hash)
    ├── columns: a:1(int) b:2(int) c:3(int) x:5(int) y:6(int) z:7(int)
    ├── scan xyz
    │    └── columns: x:5(int) y:6(int) z:7(int)
@@ -1074,7 +1074,7 @@ SELECT * FROM abc JOIN xyz ON c=x
 GenerateLookupJoins
 ================================================================================
 Source expression:
-  inner-join
+  inner-join (hash)
    ├── columns: a:1(int) b:2(int) c:3(int!null) x:5(int!null) y:6(int) z:7(int)
    ├── fd: (3)==(5), (5)==(3)
    ├── scan abc
@@ -1097,7 +1097,7 @@ New expression 1 of 1:
 GenerateLookupJoins
 ================================================================================
 Source expression:
-  inner-join
+  inner-join (hash)
    ├── columns: a:1(int) b:2(int) c:3(int!null) x:5(int!null) y:6(int) z:7(int)
    ├── fd: (3)==(5), (5)==(3)
    ├── scan xyz
@@ -1119,7 +1119,7 @@ SELECT * FROM abc LEFT JOIN xyz ON c=x
 GenerateLookupJoins
 ================================================================================
 Source expression:
-  left-join
+  left-join (hash)
    ├── columns: a:1(int) b:2(int) c:3(int) x:5(int) y:6(int) z:7(int)
    ├── scan abc
    │    └── columns: a:1(int) b:2(int) c:3(int)
@@ -1147,7 +1147,7 @@ SELECT * FROM abc RIGHT JOIN xyz ON c=x
 GenerateLookupJoins
 ================================================================================
 Source expression:
-  left-join
+  left-join (hash)
    ├── columns: a:1(int) b:2(int) c:3(int) x:5(int) y:6(int) z:7(int)
    ├── scan xyz
    │    └── columns: x:5(int) y:6(int) z:7(int)
@@ -1312,7 +1312,7 @@ inner-join (lookup abcd)
 opt
 SELECT * FROM small LEFT JOIN abcd ON a=m AND c>n AND b>1
 ----
-right-join
+right-join (hash)
  ├── columns: m:1(int) n:2(int) a:4(int) b:5(int) c:6(int)
  ├── select
  │    ├── columns: a:4(int) b:5(int!null) c:6(int)
@@ -2021,7 +2021,7 @@ union-all
  │    ├── columns: "?column?":3(int!null)
  │    ├── cardinality: [6 - 6]
  │    ├── fd: ()-->(3)
- │    ├── inner-join
+ │    ├── inner-join (hash)
  │    │    ├── cardinality: [6 - 6]
  │    │    ├── values
  │    │    │    ├── cardinality: [3 - 3]
@@ -2039,7 +2039,7 @@ union-all
       ├── columns: "?column?":6(int!null)
       ├── cardinality: [6 - 6]
       ├── fd: ()-->(6)
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── cardinality: [6 - 6]
       │    ├── values
       │    │    ├── cardinality: [3 - 3]
@@ -2115,7 +2115,7 @@ project
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  ├── fd: ()-->(21)
- ├── inner-join
+ ├── inner-join (hash)
  │    ├── columns: abc.a:5(int!null) abc.b:6(int) abc.c:7(int) abc.rowid:8(int!null)
  │    ├── cardinality: [0 - 0]
  │    ├── side-effects, mutations
@@ -2166,9 +2166,9 @@ union-all
  │    ├── columns: "?column?":4(int!null)
  │    ├── cardinality: [24 - 24]
  │    ├── fd: ()-->(4)
- │    ├── inner-join
+ │    ├── inner-join (hash)
  │    │    ├── cardinality: [24 - 24]
- │    │    ├── inner-join
+ │    │    ├── inner-join (hash)
  │    │    │    ├── cardinality: [6 - 6]
  │    │    │    ├── values
  │    │    │    │    ├── cardinality: [3 - 3]
@@ -2193,9 +2193,9 @@ union-all
       ├── columns: "?column?":8(int!null)
       ├── cardinality: [24 - 24]
       ├── fd: ()-->(8)
-      ├── inner-join
+      ├── inner-join (hash)
       │    ├── cardinality: [24 - 24]
-      │    ├── inner-join
+      │    ├── inner-join (hash)
       │    │    ├── cardinality: [6 - 6]
       │    │    ├── values
       │    │    │    ├── cardinality: [3 - 3]
@@ -2233,7 +2233,7 @@ union-all
  │    ├── cardinality: [2 - 6]
  │    ├── side-effects
  │    ├── fd: ()-->(3)
- │    ├── left-join
+ │    ├── left-join (hash)
  │    │    ├── cardinality: [2 - 6]
  │    │    ├── side-effects
  │    │    ├── values
@@ -2258,7 +2258,7 @@ union-all
       ├── cardinality: [2 - 6]
       ├── side-effects
       ├── fd: ()-->(6)
-      ├── left-join
+      ├── left-join (hash)
       │    ├── cardinality: [2 - 6]
       │    ├── side-effects
       │    ├── values

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -197,11 +197,11 @@ memo (optimized, ~24KB, required=[presentation: b:1,x:2,c:3,y:4,a:5,b:6,c:7,d:8]
 opt join-limit=4
 SELECT * FROM bx, cy, dz, abc WHERE a = 1
 ----
-inner-join
+inner-join (hash)
  ├── columns: b:1(int!null) x:2(int) c:3(int!null) y:4(int) d:5(int!null) z:6(int) a:7(int!null) b:8(int) c:9(int) d:10(int)
  ├── key: (1,3,5)
  ├── fd: ()-->(7-10), (1)-->(2), (3)-->(4), (5)-->(6)
- ├── inner-join
+ ├── inner-join (hash)
  │    ├── columns: cy.c:3(int!null) y:4(int) dz.d:5(int!null) z:6(int) a:7(int!null) abc.b:8(int) abc.c:9(int) abc.d:10(int)
  │    ├── key: (3,5)
  │    ├── fd: ()-->(7-10), (3)-->(4), (5)-->(6)
@@ -209,7 +209,7 @@ inner-join
  │    │    ├── columns: cy.c:3(int!null) y:4(int)
  │    │    ├── key: (3)
  │    │    └── fd: (3)-->(4)
- │    ├── inner-join
+ │    ├── inner-join (hash)
  │    │    ├── columns: dz.d:5(int!null) z:6(int) a:7(int!null) abc.b:8(int) abc.c:9(int) abc.d:10(int)
  │    │    ├── key: (5)
  │    │    ├── fd: ()-->(7-10), (5)-->(6)
@@ -234,7 +234,7 @@ inner-join
 opt join-limit=3 format=show-all
 SELECT * FROM abc, bx, cy, dz WHERE a = 1
 ----
-inner-join
+inner-join (hash)
  ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int) b:5(int!null) x:6(int) c:7(int!null) y:8(int) d:9(int!null) z:10(int)
  ├── stats: [rows=1e+09]
  ├── cost: 32525668.7
@@ -242,7 +242,7 @@ inner-join
  ├── fd: ()-->(1-4), (5)-->(6), (7)-->(8), (9)-->(10)
  ├── prune: (2-10)
  ├── interesting orderings: (+7) (+9) (+5) (+1)
- ├── inner-join
+ ├── inner-join (hash)
  │    ├── columns: t.public.bx.b:5(int!null) t.public.bx.x:6(int) t.public.cy.c:7(int!null) t.public.cy.y:8(int) t.public.dz.d:9(int!null) t.public.dz.z:10(int)
  │    ├── stats: [rows=1e+09]
  │    ├── cost: 10025667.6
@@ -251,7 +251,7 @@ inner-join
  │    ├── prune: (5-10)
  │    ├── interesting orderings: (+7) (+9) (+5)
  │    ├── join-size: 3
- │    ├── inner-join
+ │    ├── inner-join (hash)
  │    │    ├── columns: t.public.cy.c:7(int!null) t.public.cy.y:8(int) t.public.dz.d:9(int!null) t.public.dz.z:10(int)
  │    │    ├── stats: [rows=1000000]
  │    │    ├── cost: 12110.05
@@ -436,14 +436,14 @@ WHERE
 project
  ├── columns: "?column?":7(int!null)
  ├── fd: ()-->(7)
- ├── inner-join
+ ├── inner-join (hash)
  │    ├── columns: a1.id:1(int!null) a2.id:2(int!null) a3.id:3(int!null) a4.id:4(int!null) bool:6(bool!null)
  │    ├── key: (3)
  │    ├── fd: ()-->(2,4,6), (1)==(3), (3)==(1)
  │    ├── scan a3
  │    │    ├── columns: a3.id:3(int!null)
  │    │    └── key: (3)
- │    ├── inner-join
+ │    ├── inner-join (hash)
  │    │    ├── columns: a1.id:1(int!null) a2.id:2(int!null) a4.id:4(int!null) bool:6(bool!null)
  │    │    ├── key: (1)
  │    │    ├── fd: ()-->(2,4,6)
@@ -473,7 +473,7 @@ project
  │    │    │    │              └── true [type=bool]
  │    │    │    └── filters
  │    │    │         └── variable: bool [type=bool, outer=(6), constraints=(/6: [/true - /true]; tight), fd=()-->(6)]
- │    │    ├── inner-join
+ │    │    ├── inner-join (hash)
  │    │    │    ├── columns: a2.id:2(int!null) a4.id:4(int!null)
  │    │    │    ├── cardinality: [0 - 1]
  │    │    │    ├── key: ()

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -729,7 +729,7 @@ insert check_test.public.alias_test
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    ├── fd: ()-->(2,3)
-      │    ├── left-join
+      │    ├── left-join (hash)
       │    │    ├── columns: column1:2(int!null) a:3(int)
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── key: ()


### PR DESCRIPTION
In EXPLAIN (OPT), joins that have no mention (like `merge` or
`lookup`) are executed as hash joins. Make this explicit, for the
benefit of usage outside of the opt team.

Release note: None