### PR TITLE
exec: handle nulls in AVG aggregator

### DIFF
--- a/pkg/sql/exec/execgen/cmd/execgen/avg_agg_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/avg_agg_gen.go
@@ -73,9 +73,12 @@ func genAvgAgg(wr io.Writer) error {
 	assignDivRe := regexp.MustCompile(`_ASSIGN_DIV_INT64\((.*),(.*),(.*)\)`)
 	s = assignDivRe.ReplaceAllString(s, "{{.AssignDivInt64 $1 $2 $3}}")
 	assignAddRe := regexp.MustCompile(`_ASSIGN_ADD\((.*),(.*),(.*)\)`)
-	s = assignAddRe.ReplaceAllString(s, "{{.AssignAdd $1 $2 $3}}")
+	s = assignAddRe.ReplaceAllString(s, "{{.Global.AssignAdd $1 $2 $3}}")
 
-	tmpl, err := template.New("avg_agg").Parse(s)
+	accumulateAvg := makeFunctionRegex("_ACCUMULATE_AVG", 4)
+	s = accumulateAvg.ReplaceAllString(s, `{{template "accumulateAvg" buildDict "Global" . "HasNulls" $4}}`)
+
+	tmpl, err := template.New("avg_agg").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/exec/execgen/cmd/execgen/min_max_agg_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/min_max_agg_gen.go
@@ -56,8 +56,8 @@ func genMinMaxAgg(wr io.Writer) error {
 	assignCmpRe := regexp.MustCompile(`_ASSIGN_CMP\((.*),(.*),(.*)\)`)
 	s = assignCmpRe.ReplaceAllString(s, "{{.Global.Assign $1 $2 $3}}")
 
-	accumulateSum := makeFunctionRegex("_ACCUMULATE_MINMAX", 4)
-	s = accumulateSum.ReplaceAllString(s, `{{template "accumulateMinMax" buildDict "Global" . "HasNulls" $4}}`)
+	accumulateMinMax := makeFunctionRegex("_ACCUMULATE_MINMAX", 4)
+	s = accumulateMinMax.ReplaceAllString(s, `{{template "accumulateMinMax" buildDict "Global" . "HasNulls" $4}}`)
 
 	tmpl, err := template.New("min_max_agg").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)
 	if err != nil {


### PR DESCRIPTION
closes #37738 

The random aggregation test uses float64 now so that AVG can be included in this test, until #38823 can be addressed.

```
BenchmarkAggregator/AVG/hash/Decimal/groupSize=1/hasNulls=false/numInputBatches=64-12       	      20	  72817604 ns/op	   7.20 MB/s
BenchmarkAggregator/AVG/hash/Decimal/groupSize=1/hasNulls=true/numInputBatches=64-12        	      20	  67807960 ns/op	   7.73 MB/s
BenchmarkAggregator/AVG/hash/Decimal/groupSize=2/hasNulls=false/numInputBatches=64-12       	      30	  45907478 ns/op	  11.42 MB/s
BenchmarkAggregator/AVG/hash/Decimal/groupSize=2/hasNulls=true/numInputBatches=64-12        	      30	  44468409 ns/op	  11.79 MB/s
BenchmarkAggregator/AVG/hash/Decimal/groupSize=512/hasNulls=false/numInputBatches=64-12     	     200	   8712009 ns/op	  60.18 MB/s
BenchmarkAggregator/AVG/hash/Decimal/groupSize=512/hasNulls=true/numInputBatches=64-12      	     200	   8852871 ns/op	  59.22 MB/s
BenchmarkAggregator/AVG/hash/Decimal/groupSize=1024/hasNulls=false/numInputBatches=64-12    	     200	   9058353 ns/op	  57.88 MB/s
BenchmarkAggregator/AVG/hash/Decimal/groupSize=1024/hasNulls=true/numInputBatches=64-12     	     200	   9289322 ns/op	  56.44 MB/s
BenchmarkAggregator/AVG/ordered/Decimal/groupSize=1/hasNulls=false/numInputBatches=64-12    	      20	  67161015 ns/op	   7.81 MB/s
BenchmarkAggregator/AVG/ordered/Decimal/groupSize=1/hasNulls=true/numInputBatches=64-12     	      20	  60712202 ns/op	   8.64 MB/s
BenchmarkAggregator/AVG/ordered/Decimal/groupSize=2/hasNulls=false/numInputBatches=64-12    	      30	  40953924 ns/op	  12.80 MB/s
BenchmarkAggregator/AVG/ordered/Decimal/groupSize=2/hasNulls=true/numInputBatches=64-12     	      30	  39335420 ns/op	  13.33 MB/s
BenchmarkAggregator/AVG/ordered/Decimal/groupSize=512/hasNulls=false/numInputBatches=64-12  	     300	   4201872 ns/op	 124.77 MB/s
BenchmarkAggregator/AVG/ordered/Decimal/groupSize=512/hasNulls=true/numInputBatches=64-12   	     300	   4202353 ns/op	 124.76 MB/s
BenchmarkAggregator/AVG/ordered/Decimal/groupSize=1024/hasNulls=false/numInputBatches=64-12 	     500	   3982187 ns/op	 131.66 MB/s
BenchmarkAggregator/AVG/ordered/Decimal/groupSize=1024/hasNulls=true/numInputBatches=64-12  	     500	   3766494 ns/op	 139.20 MB/s
```

Release note: None