### PR TITLE
distsqlrun: make joinreader use limited batches

### DIFF
--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -12,6 +12,7 @@ package distsqlrun
 
 import (
 	"context"
+	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
@@ -23,7 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 )
 
 // TODO(radu): we currently create one batch at a time and run the KV operations
@@ -401,8 +402,13 @@ func (jr *joinReader) readInput() (joinReaderState, *distsqlpb.ProducerMetadata)
 		jr.finalLookupBatch = true
 		return jrCollectingOutputRows, nil
 	}
+	// Sort the spans so that we can rely upon the fetcher to limit the number of
+	// results per batch. It's safe to reorder the spans here because we already
+	// restore the original order of the output during the output collection
+	// phase.
+	sort.Sort(spans)
 	err := jr.fetcher.StartScan(
-		jr.Ctx, jr.flowCtx.txn, spans, false /* limitBatches */, 0, /* limitHint */
+		jr.Ctx, jr.flowCtx.txn, spans, true /* limitBatches */, 0, /* limitHint */
 		jr.flowCtx.traceKV)
 	if err != nil {
 		jr.MoveToDraining(err)

--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -533,9 +533,10 @@ func (jr *joinReader) hasNullLookupColumn(row sqlbase.EncDatumRow) bool {
 // Start is part of the RowSource interface.
 func (jr *joinReader) Start(ctx context.Context) context.Context {
 	jr.input.Start(ctx)
+	ctx = jr.StartInternal(ctx, joinReaderProcName)
 	jr.fetcher.Start(ctx)
 	jr.runningState = jrReadingInput
-	return jr.StartInternal(ctx, joinReaderProcName)
+	return ctx
 }
 
 // ConsumerClosed is part of the RowSource interface.

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -749,3 +749,57 @@ SELECT url FROM [ EXPLAIN (DISTSQL)
 ]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJzMlVFr2z4Uxd__n0Lcp_6pjC3ZTlM9-aWFlC4Zbd62PGjRpfPmWEaSYaXkuw_HZbXLKmsEQh4t-XDO_R3BfYFaK1zKHVoQX4ABBQ4UUqCQAYUcNhQao7dorTbdL71goX6BSCiUddO67nhDYasNgngBV7oKQcBafqvwAaVCEydAQaGTZXWwaUy5k-a5sDtZVUDhsZG1FSSKGZG1Ioxo9x0NULgtK4dGkIuCkUtS8P_J1zZJ0i3hiRBisVzPgcKqdYIUjBYcNnsKunVvoayTTwiC7Wl48Dtd1q-583Hu9XODgtzf3K7J482nBblbLZZA_4yjpJNA4V7rn21DfuiyJrruonUhl-Si4N0Q-esQSFj-T0PwD4d4y66NQoNqHLtgl7DZ_2XSpY50E7NxOx_ZpyN7Fl4-Cyo_ZlHMT1L_RPRB_bPzrZ-H8-dh_HkUpyfhPxF9wP_qfPmn4fzTMP5pFGcn4T8RfcB_fr78s3D-WRj_LIrzk_CfiD7gf32-_Cd26APaRtcWgzZL0u0mVE_Y7zKrW7PFz0ZvDzb95-qgOxwotK6_Zf3Hou6vuoBDMfOK-UjM3ou533nCOvWqM784OyZ37hXP_M6zY5yvvOK533l-jPO1v6tk4pn4H9l7783-v98BAAD__0_IfTU=
+
+# Regression test for #35950: Make sure that lookup joins use a batch limit.
+
+statement ok
+CREATE TABLE a (a INT, b INT, PRIMARY KEY (a, b))
+
+statement ok
+CREATE TABLE b (a INT PRIMARY KEY)
+
+# We insert over 10k rows, which is the currently configured batch limit.
+
+statement ok
+INSERT INTO a SELECT 1, g FROM generate_series(1,11000) g
+
+statement ok
+INSERT INTO b VALUES(1)
+
+query TTT
+EXPLAIN SELECT count(*) FROM (SELECT * FROM b NATURAL INNER LOOKUP JOIN a)
+----
+group                  ·            ·
+ │                     aggregate 0  count_rows()
+ │                     scalar       ·
+ └── render            ·            ·
+      └── lookup-join  ·            ·
+           │           table        a@primary
+           │           type         inner
+           │           equality     (a) = (a)
+           └── scan    ·            ·
+·                      table        b@primary
+·                      spans        ALL
+
+statement ok
+SET tracing = on
+
+query I
+SELECT count(*) FROM (SELECT * FROM b NATURAL INNER LOOKUP JOIN a)
+----
+11000
+
+statement ok
+SET tracing = off
+
+let $lookupTableID
+SELECT 'a'::regclass::oid
+
+# Now assert that we get more than 1 separate batch request into the lookup
+# table, since the first one wouldn't have returned all of the results.
+
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE 'Scan /Table/$lookupTableID%'
+----
+Scan /Table/63/1/{1-2}
+Scan /Table/63/1/{1/10001/0-2}


### PR DESCRIPTION
Closes #35950.

Previously, lookup join put no limit on the number of returned rows from
each of its lookups. This could be hugely problematic. Imagine a
circumstance in which a lookup join was planned on a pair of tables that
had 1 billion match rows on the right side for every row on the left
side: in this case, the lookup join would ask the KV backend to return a
single giant buffer with all 1 billion rows.

Also, joinReader's tracing span collection was slightly broken - fix that while we're at it, to make sure we can test this change properly.

Release note (bug fix): prevent OOM conditions during lookup joins
between tables with a very large n:1 relationship.