### PR TITLE
sql: account for memory of results of window functions computations

### DIFF
--- a/pkg/sql/distsqlrun/windower.go
+++ b/pkg/sql/distsqlrun/windower.go
@@ -598,6 +598,7 @@ func (w *windower) processPartition(
 		}
 		frameRun.CurRowPeerGroupNum = 0
 
+		var prevRes tree.Datum
 		for frameRun.RowIdx < partition.Len() {
 			// Perform calculations on each row in the current peer group.
 			peerGroupEndIdx := frameRun.PeerHelper.GetFirstPeerIdx(frameRun.CurRowPeerGroupNum) + frameRun.PeerHelper.GetRowCount(frameRun.CurRowPeerGroupNum)
@@ -613,7 +614,19 @@ func (w *windower) processPartition(
 				if err != nil {
 					return err
 				}
+				if prevRes == nil || prevRes != res {
+					// We don't want to double count the same memory, and since the same
+					// memory can only be reused contiguously as res, comparing against
+					// result of the previous row is sufficient.
+					// We have already accounted for the size of a nil datum prior to
+					// allocating the slice for window values, so we need to keep that in
+					// mind.
+					if err := w.growMemAccount(&w.acc, int64(res.Size())-sizeOfDatum); err != nil {
+						return err
+					}
+				}
 				w.windowValues[partitionIdx][windowFnIdx][row.GetIdx()] = res
+				prevRes = res
 			}
 			if err := frameRun.PeerHelper.Update(frameRun); err != nil {
 				return err

--- a/pkg/sql/distsqlrun/windower_test.go
+++ b/pkg/sql/distsqlrun/windower_test.go
@@ -13,14 +13,101 @@ package distsqlrun
 import (
 	"context"
 	"fmt"
+	"math"
+	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 )
+
+const noFilterIdx = -1
+
+func TestWindowerAccountingForResults(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	monitor := mon.MakeMonitorWithLimit(
+		"test-monitor",
+		mon.MemoryResource,
+		100000,        /* limit */
+		nil,           /* curCount */
+		nil,           /* maxHist */
+		5000,          /* increment */
+		math.MaxInt64, /* noteworthy */
+		st,
+	)
+	evalCtx := tree.MakeTestingEvalContextWithMon(st, &monitor)
+	defer evalCtx.Stop(ctx)
+	diskMonitor := makeTestDiskMonitor(ctx, st)
+	defer diskMonitor.Stop(ctx)
+	tempEngine, err := engine.NewTempEngine(base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tempEngine.Close()
+
+	flowCtx := &FlowCtx{
+		Settings:    st,
+		EvalCtx:     &evalCtx,
+		diskMonitor: diskMonitor,
+		TempStorage: tempEngine,
+	}
+
+	post := &distsqlpb.PostProcessSpec{}
+	input := NewRepeatableRowSource(sqlbase.OneIntCol, sqlbase.MakeIntRows(1000, 1))
+	aggSpec := distsqlpb.AggregatorSpec_Func(distsqlpb.AggregatorSpec_ARRAY_AGG)
+	spec := distsqlpb.WindowerSpec{
+		PartitionBy: []uint32{},
+		WindowFns: []distsqlpb.WindowerSpec_WindowFn{{
+			Func:         distsqlpb.WindowerSpec_Func{AggregateFunc: &aggSpec},
+			ArgsIdxs:     []uint32{0},
+			Ordering:     distsqlpb.Ordering{Columns: []distsqlpb.Ordering_Column{{ColIdx: 0}}},
+			OutputColIdx: 0,
+			FilterColIdx: noFilterIdx,
+			Frame: &distsqlpb.WindowerSpec_Frame{
+				Mode: distsqlpb.WindowerSpec_Frame_ROWS,
+				Bounds: distsqlpb.WindowerSpec_Frame_Bounds{
+					Start: distsqlpb.WindowerSpec_Frame_Bound{
+						BoundType: distsqlpb.WindowerSpec_Frame_OFFSET_PRECEDING,
+						IntOffset: 100,
+					},
+				},
+			},
+		}},
+	}
+	output := NewRowBuffer(
+		sqlbase.OneIntCol, nil, RowBufferArgs{},
+	)
+
+	d, err := newWindower(flowCtx, 0 /* processorID */, &spec, input, post, output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d.Run(ctx)
+	for {
+		row, meta := output.Next()
+		if row != nil {
+			t.Fatalf("unexpectedly received row %+v", row)
+		}
+		if meta == nil {
+			t.Fatalf("unexpectedly didn't receive an OOM error")
+		}
+		if meta.Err != nil {
+			if !strings.Contains(meta.Err.Error(), "memory budget exceeded") {
+				t.Fatalf("unexpectedly received an error other than OOM")
+			}
+			break
+		}
+	}
+}
 
 type windowTestSpec struct {
 	// The column indices of PARTITION BY clause.
@@ -59,6 +146,7 @@ func windows(windowTestSpecs []windowTestSpec) ([]distsqlpb.WindowerSpec, error)
 			}
 			windowFnSpec.Ordering = distsqlpb.Ordering{Columns: ordCols}
 		}
+		windowFnSpec.FilterColIdx = noFilterIdx
 		windows[i].WindowFns[0] = windowFnSpec
 	}
 	return windows, nil


### PR DESCRIPTION
Previously, Datums that were the result of computing of window
functions were accounted for in memory monitoring only as nils which
could lead to OOM when the actual Datum's size was a lot bigger than
default one (array_agg and concat_agg were most prone to this).
Now, the underlying memory is tracked correctly.

Fixes: #38818.

Release note: None