### PR TITLE
sql: display postqueries in EXPLAIN

### DIFF
--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -42,6 +42,9 @@ type explainPlanNode struct {
 	// subqueryPlans contains the subquery plans for the explained query.
 	subqueryPlans []subquery
 
+	// postqueryPlans contains the postquery plans for the explained query.
+	postqueryPlans []postquery
+
 	// expanded indicates whether to invoke expandPlan() on the sub-node.
 	expanded bool
 
@@ -59,18 +62,21 @@ type explainPlanNode struct {
 func (p *planner) makeExplainPlanNode(
 	ctx context.Context, opts *tree.ExplainOptions, origStmt tree.Statement,
 ) (planNode, error) {
-	// Build the plan for the query being explained.  We want to capture
-	// all the analyzed sub-queries in the explain node, so we are going
-	// to override the planner's subquery plan slice.
+	// Build the plan for the query being explained.  We want to capture all the
+	// analyzed sub- and postqueries in the explain node, so we are going to
+	// override the planner's sub- and postquery plan slices.
 	defer func(s []subquery) { p.curPlan.subqueryPlans = s }(p.curPlan.subqueryPlans)
 	p.curPlan.subqueryPlans = nil
+	defer func(q []postquery) { p.curPlan.postqueryPlans = q }(p.curPlan.postqueryPlans)
+	p.curPlan.postqueryPlans = nil
 
 	plan, err := p.newPlan(ctx, origStmt, nil)
 	if err != nil {
 		return nil, err
 	}
 	return p.makeExplainPlanNodeWithPlan(
-		ctx, opts, true /* optimizeSubqueries */, plan, p.curPlan.subqueryPlans,
+		ctx, opts, true, /* optimizeSubqueries */
+		plan, p.curPlan.subqueryPlans, p.curPlan.postqueryPlans,
 	)
 }
 
@@ -82,6 +88,7 @@ func (p *planner) makeExplainPlanNodeWithPlan(
 	optimizeSubqueries bool,
 	plan planNode,
 	subqueryPlans []subquery,
+	postqueryPlans []postquery,
 ) (planNode, error) {
 	flags := explainFlags{
 		symbolicVars: opts.Flags.Contains(tree.ExplainFlagSymVars),
@@ -132,6 +139,7 @@ func (p *planner) makeExplainPlanNodeWithPlan(
 		optimizeSubqueries: optimizeSubqueries,
 		plan:               plan,
 		subqueryPlans:      subqueryPlans,
+		postqueryPlans:     postqueryPlans,
 		run: explainPlanRun{
 			results: p.newContainerValuesNode(columns, 0),
 		},
@@ -162,7 +170,7 @@ func (e *explainPlanNode) startExec(params runParams) error {
 		}
 	}
 
-	return params.p.populateExplain(params.ctx, &e.explainer, e.run.results, e.plan, e.subqueryPlans)
+	return params.p.populateExplain(params.ctx, &e.explainer, e.run.results, e.plan, e.subqueryPlans, e.postqueryPlans)
 }
 
 func (e *explainPlanNode) Next(params runParams) (bool, error) { return e.run.results.Next(params) }
@@ -172,6 +180,9 @@ func (e *explainPlanNode) Close(ctx context.Context) {
 	e.plan.Close(ctx)
 	for i := range e.subqueryPlans {
 		e.subqueryPlans[i].plan.Close(ctx)
+	}
+	for i := range e.postqueryPlans {
+		e.postqueryPlans[i].plan.Close(ctx)
 	}
 	e.run.results.Close(ctx)
 }
@@ -230,9 +241,14 @@ var emptyString = tree.NewDString("")
 // The subquery plans, if any are known to the planner, are printed
 // at the bottom.
 func (p *planner) populateExplain(
-	ctx context.Context, e *explainer, v *valuesNode, plan planNode, subqueryPlans []subquery,
+	ctx context.Context,
+	e *explainer,
+	v *valuesNode,
+	plan planNode,
+	subqueryPlans []subquery,
+	postqueryPlans []postquery,
 ) error {
-	e.populateEntries(ctx, plan, subqueryPlans, explainSubqueryFmtFlags)
+	e.populateEntries(ctx, plan, subqueryPlans, postqueryPlans, explainSubqueryFmtFlags)
 
 	tp := treeprinter.New()
 	// n keeps track of the current node on each level.
@@ -283,26 +299,31 @@ func (p *planner) populateExplain(
 }
 
 func (e *explainer) populateEntries(
-	ctx context.Context, plan planNode, subqueryPlans []subquery, subqueryFmtFlags tree.FmtFlags,
+	ctx context.Context,
+	plan planNode,
+	subqueryPlans []subquery,
+	postqueryPlans []postquery,
+	subqueryFmtFlags tree.FmtFlags,
 ) {
 	e.entries = nil
 	observer := e.observer()
-	_ = populateEntriesForObserver(ctx, plan, subqueryPlans, observer, false /* returnError */, subqueryFmtFlags)
+	_ = populateEntriesForObserver(ctx, plan, subqueryPlans, postqueryPlans, observer, false /* returnError */, subqueryFmtFlags)
 }
 
 func populateEntriesForObserver(
 	ctx context.Context,
 	plan planNode,
 	subqueryPlans []subquery,
+	postqueryPlans []postquery,
 	observer planObserver,
 	returnError bool,
 	subqueryFmtFlags tree.FmtFlags,
 ) error {
-	// If there are any subqueries in the plan, we enclose both the main
-	// plan and the sub-queries as children of a virtual "root"
-	// node. This is not introduced in the common case where there are
-	// no subqueries.
-	if len(subqueryPlans) > 0 {
+	// If there are any sub- or postqueries in the plan, we enclose both the main
+	// plan and the sub- and postqueries as children of a virtual "root" node.
+	// This is not introduced in the common case where there are no sub- and
+	// postqueries.
+	if len(subqueryPlans) > 0 || len(postqueryPlans) > 0 {
 		if _, err := observer.enterNode(ctx, "root", plan); err != nil && returnError {
 			return err
 		}
@@ -339,7 +360,22 @@ func populateEntriesForObserver(
 		}
 	}
 
-	if len(subqueryPlans) > 0 {
+	// Explain the postqueries.
+	for i := range postqueryPlans {
+		if _, err := observer.enterNode(ctx, "postquery", plan); err != nil && returnError {
+			return err
+		}
+		if postqueryPlans[i].plan != nil {
+			if err := walkPlan(ctx, postqueryPlans[i].plan, observer); err != nil && returnError {
+				return err
+			}
+		}
+		if err := observer.leaveNode("postquery", postqueryPlans[i].plan); err != nil && returnError {
+			return err
+		}
+	}
+
+	if len(subqueryPlans) > 0 || len(postqueryPlans) > 0 {
 		if err := observer.leaveNode("root", plan); err != nil && returnError {
 			return err
 		}
@@ -349,7 +385,9 @@ func populateEntriesForObserver(
 }
 
 // planToString uses explain() to build a string representation of the planNode.
-func planToString(ctx context.Context, plan planNode, subqueryPlans []subquery) string {
+func planToString(
+	ctx context.Context, plan planNode, subqueryPlans []subquery, postqueryPlans []postquery,
+) string {
 	e := explainer{
 		explainFlags: explainFlags{
 			showMetadata: true,
@@ -357,7 +395,7 @@ func planToString(ctx context.Context, plan planNode, subqueryPlans []subquery) 
 		},
 		fmtFlags: tree.FmtExpr(tree.FmtSymbolicSubqueries, true, true, true),
 	}
-	e.populateEntries(ctx, plan, subqueryPlans, explainSubqueryFmtFlags)
+	e.populateEntries(ctx, plan, subqueryPlans, postqueryPlans, explainSubqueryFmtFlags)
 	var buf bytes.Buffer
 	for _, e := range e.entries {
 		field := e.field

--- a/pkg/sql/explain_tree.go
+++ b/pkg/sql/explain_tree.go
@@ -110,7 +110,7 @@ func planToTree(ctx context.Context, top *planTop) *roachpb.ExplainTreePlanNode 
 	}
 
 	if err := populateEntriesForObserver(
-		ctx, top.plan, top.subqueryPlans, observer, true /* returnError */, sampledLogicalPlanFmtFlags,
+		ctx, top.plan, top.subqueryPlans, top.postqueryPlans, observer, true /* returnError */, sampledLogicalPlanFmtFlags,
 	); err != nil {
 		panic(fmt.Sprintf("error while walking plan to save it to statement stats: %s", err.Error()))
 	}

--- a/pkg/sql/explain_tree_test.go
+++ b/pkg/sql/explain_tree_test.go
@@ -565,7 +565,7 @@ func assertExpectedPlansForTests(t *testing.T, sqlSetup string, plansToTest []*T
 		actualPlanTree := planToTree(ctx, &p.curPlan)
 		assert.Equal(t, test.ExpectedPlanTree, actualPlanTree,
 			"planToTree for %s:\nexpected:%s\nactual:%s", test.SQL, test.ExpectedPlanTree, actualPlanTree)
-		actualPlanString := planToString(ctx, p.curPlan.plan, p.curPlan.subqueryPlans)
+		actualPlanString := planToString(ctx, p.curPlan.plan, p.curPlan.subqueryPlans, p.curPlan.postqueryPlans)
 		assert.Equal(t, test.ExpectedPlanString, actualPlanString,
 			"planToString for %s:\nexpected:%s\nactual:%s", test.SQL, test.ExpectedPlanString, actualPlanString)
 	}

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -98,9 +98,10 @@ func (b *Builder) buildExplain(explain *memo.ExplainExpr) (execPlan, error) {
 	for i, c := range explain.ColList {
 		ep.outputCols.Set(int(c), i)
 	}
-	// The subqueries are now owned by the explain node; remove them so they don't
-	// also show up in the final plan.
+	// The sub- and postqueries are now owned by the explain node; remove them so
+	// they don't also show up in the final plan.
 	b.subqueries = b.subqueries[:0]
+	b.postqueries = b.postqueries[:0]
 	return ep, nil
 }
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk_opt
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk_opt
@@ -1,0 +1,30 @@
+# LogicTest: local-opt
+
+statement ok
+SET experimental_optimizer_foreign_keys = true
+
+statement ok
+CREATE TABLE parent (p INT PRIMARY KEY, other INT)
+
+statement ok
+CREATE TABLE child (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(p))
+
+query TTT
+EXPLAIN INSERT INTO child VALUES (1,1), (2,2)
+----
+root                        ·                      ·
+ ├── count                  ·                      ·
+ │    └── insert            ·                      ·
+ │         │                into                   child(c, p)
+ │         │                strategy               inserter
+ │         └── values       ·                      ·
+ │                          size                   2 columns, 2 rows
+ └── postquery              ·                      ·
+      └── errorIfRows       ·                      ·
+           └── lookup-join  ·                      ·
+                │           table                  parent@primary
+                │           type                   anti
+                │           equality               (column2) = (p)
+                │           equality cols are key  ·
+                └── values  ·                      ·
+·                           size                   1 column, 2 rows

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1124,6 +1124,7 @@ func (ef *execFactory) ConstructExplain(
 			false, /* optimizeSubqueries */
 			p.plan,
 			p.subqueryPlans,
+			p.postqueryPlans,
 		)
 
 	default:

--- a/pkg/sql/opt_filters.go
+++ b/pkg/sql/opt_filters.go
@@ -427,7 +427,7 @@ func (p *planner) triggerFilterPropagation(ctx context.Context, plan planNode) (
 
 	if !isFilterTrue(remainingFilter) {
 		panic(fmt.Sprintf("propagateFilters on \n%s\n spilled a non-trivial remaining filter: %s",
-			planToString(ctx, plan, nil), remainingFilter))
+			planToString(ctx, plan, nil, nil), remainingFilter))
 	}
 
 	return newPlan, nil

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -392,7 +392,7 @@ func (p *planner) makePlan(ctx context.Context) error {
 
 	if log.V(3) {
 		log.Infof(ctx, "statement %s compiled to:\n%s", stmt,
-			planToString(ctx, p.curPlan.plan, p.curPlan.subqueryPlans))
+			planToString(ctx, p.curPlan.plan, p.curPlan.subqueryPlans, p.curPlan.postqueryPlans))
 	}
 
 	return nil


### PR DESCRIPTION
Postqueries are now displayed in the output of EXPLAIN statement.

Fixes: #38340.

Release note: None