### PR TITLE
ui: add a "Last 2 days" option to the duration picker

### DIFF
--- a/pkg/ui/src/redux/timewindow.ts
+++ b/pkg/ui/src/redux/timewindow.ts
@@ -85,6 +85,11 @@ export let availableTimeScales: TimeScaleCollection = _.mapValues(
       windowValid: moment.duration(10, "minutes"),
       sampleSize: moment.duration(5, "minutes"),
     },
+    "2 days": {
+      windowSize: moment.duration(2, "day"),
+      windowValid: moment.duration(10, "minutes"),
+      sampleSize: moment.duration(5, "minutes"),
+    },
     "1 week": {
       windowSize: moment.duration(7, "days"),
       windowValid: moment.duration(10, "minutes"),


### PR DESCRIPTION
I've heard we want to revamp this at some point to work totally
differently, but that's not going to happy anytime soon. In the
meantime, I've had a number of occasions when a 2 or 3 day picker would
have been quite useful. In particular, this happens when trying to
eyeball whether the last 24 hours is anomalous.

Release note (admin ui change): Dashboard graphs now offer a "Last 2
days" option in the time selector.