### PR TITLE
sql: close main query after all postqueries are executed

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -188,7 +188,7 @@ func distChangefeedFlow(
 
 	// Copy the evalCtx, as dsp.Run() might change it.
 	evalCtxCopy := *evalCtx
-	dsp.Run(planCtx, noTxn, &p, recv, &evalCtxCopy, finishedSetupFn)
+	dsp.Run(planCtx, noTxn, &p, recv, &evalCtxCopy, finishedSetupFn)()
 	return resultRows.Err()
 }
 

--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -326,7 +326,8 @@ func (a *applyJoinNode) runRightSidePlan(params runParams, plan *planTop) error 
 	planCtx.stmtType = recv.stmtType
 
 	params.p.extendedEvalCtx.ExecCfg.DistSQLPlanner.PlanAndRun(
-		params.ctx, evalCtx, planCtx, params.p.Txn(), plan.plan, recv)
+		params.ctx, evalCtx, planCtx, params.p.Txn(), plan.plan, recv,
+	)()
 	if recv.commErr != nil {
 		return recv.commErr
 	}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -769,7 +769,7 @@ func (sc *SchemaChanger) distBackfill(
 					nil, /* txn - the processors manage their own transactions */
 					&plan, recv, evalCtx,
 					nil, /* finishedSetupFn */
-				)
+				)()
 				return rw.Err()
 			}); err != nil {
 				return err

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -513,9 +513,8 @@ type PlanningCtx struct {
 	planner *planner
 	// ignoreClose, when set to true, will prevent the closing of the planner's
 	// current plan. Only the top-level query needs to close it, but everything
-	// else (like subqueries or EXPLAIN ANALYZE) should set this to true to avoid
-	// double closes of the planNode tree. Postqueries also need to set it to
-	// true, and they are responsible for closing their own plan.
+	// else (like sub- and postqueries, or EXPLAIN ANALYZE) should set this to
+	// true to avoid double closes of the planNode tree.
 	ignoreClose bool
 	stmtType    tree.StatementType
 	// planDepth is set to the current depth of the planNode tree. It's used to

--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -87,7 +87,7 @@ func PlanAndRunExport(
 
 	// Copy the evalCtx, as dsp.Run() might change it.
 	evalCtxCopy := *evalCtx
-	dsp.Run(planCtx, txn, &p, recv, &evalCtxCopy, nil /* finishedSetupFn */)
+	dsp.Run(planCtx, txn, &p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
 	return resultRows.Err()
 }
 
@@ -429,7 +429,7 @@ func LoadCSV(
 	// Copy the evalCtx, as dsp.Run() might change it.
 	evalCtxCopy := *evalCtx
 	return db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-		dsp.Run(planCtx, txn, &p, recv, &evalCtxCopy, nil /* finishedSetupFn */)
+		dsp.Run(planCtx, txn, &p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
 		return resultRows.Err()
 	})
 }
@@ -641,7 +641,7 @@ func (dsp *DistSQLPlanner) loadCSVSamplingPlan(
 	samples = nil
 	// Copy the evalCtx, as dsp.Run() might change it.
 	evalCtxCopy := *evalCtx
-	dsp.Run(planCtx, nil, &p, recv, &evalCtxCopy, nil /* finishedSetupFn */)
+	dsp.Run(planCtx, nil, &p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
 	if err := rowResultWriter.Err(); err != nil {
 		return nil, err
 	}
@@ -738,7 +738,7 @@ func DistIngest(
 	defer recv.Release()
 	// Copy the evalCtx, as dsp.Run() might change it.
 	evalCtxCopy := *evalCtx
-	dsp.Run(planCtx, nil, &p, recv, &evalCtxCopy, nil /* finishedSetupFn */)
+	dsp.Run(planCtx, nil, &p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
 	if err := rowResultWriter.Err(); err != nil {
 		return roachpb.BulkOpSummary{}, err
 	}

--- a/pkg/sql/distsql_plan_ctas.go
+++ b/pkg/sql/distsql_plan_ctas.go
@@ -53,5 +53,5 @@ func PlanAndRunCTAS(
 	// Make copy of evalCtx as Run might modify it.
 	evalCtxCopy := planner.ExtendedEvalContextCopy()
 	dsp.FinalizePlan(planCtx, &p)
-	dsp.Run(planCtx, txn, &p, recv, evalCtxCopy, nil /* finishedSetupFn */)
+	dsp.Run(planCtx, txn, &p, recv, evalCtxCopy, nil /* finishedSetupFn */)()
 }

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -251,6 +251,6 @@ func (dsp *DistSQLPlanner) planAndRunCreateStats(
 	)
 	defer recv.Release()
 
-	dsp.Run(planCtx, txn, &physPlan, recv, evalCtx, nil /* finishedSetupFn */)
+	dsp.Run(planCtx, txn, &physPlan, recv, evalCtx, nil /* finishedSetupFn */)()
 	return resultRows.Err()
 }

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -221,6 +221,10 @@ func (dsp *DistSQLPlanner) setupFlows(
 // mutated.
 // - finishedSetupFn, if non-nil, is called synchronously after all the
 // processors have successfully started up.
+//
+// It returns a non-nil (although it can be a noop when an error is
+// encountered) cleanup function that must be called in order to release the
+// resources.
 func (dsp *DistSQLPlanner) Run(
 	planCtx *PlanningCtx,
 	txn *client.Txn,
@@ -228,7 +232,7 @@ func (dsp *DistSQLPlanner) Run(
 	recv *DistSQLReceiver,
 	evalCtx *extendedEvalContext,
 	finishedSetupFn func(),
-) {
+) (cleanup func()) {
 	ctx := planCtx.ctx
 
 	var (
@@ -249,7 +253,7 @@ func (dsp *DistSQLPlanner) Run(
 		if err != nil {
 			log.Infof(ctx, "%s: %s", clientRejectedMsg, err)
 			recv.SetError(err)
-			return
+			return func() {}
 		}
 		meta.StripRootToLeaf()
 		txnCoordMeta = &meta
@@ -257,7 +261,7 @@ func (dsp *DistSQLPlanner) Run(
 
 	if err := planCtx.sanityCheckAddresses(); err != nil {
 		recv.SetError(err)
-		return
+		return func() {}
 	}
 
 	flows := plan.GenerateFlowSpecs(dsp.nodeDesc.NodeID /* gateway */)
@@ -284,7 +288,7 @@ func (dsp *DistSQLPlanner) Run(
 	ctx, flow, err := dsp.setupFlows(ctx, evalCtx, txnCoordMeta, flows, recv, localState)
 	if err != nil {
 		recv.SetError(err)
-		return
+		return func() {}
 	}
 
 	if finishedSetupFn != nil {
@@ -296,13 +300,28 @@ func (dsp *DistSQLPlanner) Run(
 		log.Fatalf(ctx, "unexpected error from syncFlow.Start(): %s "+
 			"The error should have gone to the consumer.", err)
 	}
-	// We need to close the planNode tree we translated into a DistSQL plan before
-	// flow.Cleanup, which closes memory accounts that expect to be emptied.
+
+	// TODO(yuzefovich): it feels like this closing should happen after
+	// PlanAndRun. We should refactor this and get rid off ignoreClose field.
 	if planCtx.planner != nil && !planCtx.ignoreClose {
-		planCtx.planner.curPlan.execErr = recv.resultWriter.Err()
-		planCtx.planner.curPlan.close(ctx)
+		// planCtx can change before the cleanup function is executed, so we make
+		// a copy of the planner and bind it to the function.
+		curPlan := &planCtx.planner.curPlan
+		return func() {
+			// We need to close the planNode tree we translated into a DistSQL plan
+			// before flow.Cleanup, which closes memory accounts that expect to be
+			// emptied.
+			curPlan.execErr = recv.resultWriter.Err()
+			curPlan.close(ctx)
+			flow.Cleanup(ctx)
+		}
 	}
-	flow.Cleanup(ctx)
+
+	// ignoreClose is set to true meaning that someone else will handle the
+	// closing of the current plan, so we simply clean up the flow.
+	return func() {
+		flow.Cleanup(ctx)
+	}
 }
 
 // DistSQLReceiver is a RowReceiver that writes results to a rowResultWriter.
@@ -778,7 +797,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	subqueryRowReceiver := NewRowResultWriter(rows)
 	subqueryRecv.resultWriter = subqueryRowReceiver
 	subqueryPlans[planIdx].started = true
-	dsp.Run(subqueryPlanCtx, planner.txn, &subqueryPhysPlan, subqueryRecv, evalCtx, nil /* finishedSetupFn */)
+	dsp.Run(subqueryPlanCtx, planner.txn, &subqueryPhysPlan, subqueryRecv, evalCtx, nil /* finishedSetupFn */)()
 	if subqueryRecv.commErr != nil {
 		return subqueryRecv.commErr
 	}
@@ -840,6 +859,10 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 // while using that resultWriter), the error is also stored in
 // DistSQLReceiver.commErr. That can be tested to see if a client session needs
 // to be closed.
+//
+// It returns a non-nil (although it can be a noop when an error is
+// encountered) cleanup function that must be called in order to release the
+// resources.
 func (dsp *DistSQLPlanner) PlanAndRun(
 	ctx context.Context,
 	evalCtx *extendedEvalContext,
@@ -847,16 +870,16 @@ func (dsp *DistSQLPlanner) PlanAndRun(
 	txn *client.Txn,
 	plan planNode,
 	recv *DistSQLReceiver,
-) {
+) (cleanup func()) {
 	log.VEventf(ctx, 1, "creating DistSQL plan with isLocal=%v", planCtx.isLocal)
 
 	physPlan, err := dsp.createPlanForNode(planCtx, plan)
 	if err != nil {
 		recv.SetError(err)
-		return
+		return func() {}
 	}
 	dsp.FinalizePlan(planCtx, &physPlan)
-	dsp.Run(planCtx, txn, &physPlan, recv, evalCtx, nil /* finishedSetupFn */)
+	return dsp.Run(planCtx, txn, &physPlan, recv, evalCtx, nil /* finishedSetupFn */)
 }
 
 // PlanAndRunPostqueries returns false if an error was encountered and sets
@@ -924,11 +947,7 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 	postqueryPlanCtx.isLocal = !distributePostquery
 	postqueryPlanCtx.planner = planner
 	postqueryPlanCtx.stmtType = tree.Rows
-	// We cannot close the postqueries' plans through the plan top since
-	// postqueries haven't been executed yet, so we manually close each postquery
-	// plan right after the execution.
 	postqueryPlanCtx.ignoreClose = true
-	defer postqueryPlan.plan.Close(ctx)
 
 	postqueryPhysPlan, err := dsp.createPlanForNode(postqueryPlanCtx, postqueryPlan.plan)
 	if err != nil {
@@ -939,7 +958,7 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 	postqueryRecv := recv.clone()
 	var postqueryRowReceiver postqueryRowResultWriter
 	postqueryRecv.resultWriter = &postqueryRowReceiver
-	dsp.Run(postqueryPlanCtx, planner.txn, &postqueryPhysPlan, postqueryRecv, evalCtx, nil /* finishedSetupFn */)
+	dsp.Run(postqueryPlanCtx, planner.txn, &postqueryPhysPlan, postqueryRecv, evalCtx, nil /* finishedSetupFn */)()
 	if postqueryRecv.commErr != nil {
 		return postqueryRecv.commErr
 	}

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -164,7 +164,8 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 		planCtx.stmtType = recv.stmtType
 
 		execCfg.DistSQLPlanner.PlanAndRun(
-			ctx, evalCtx, planCtx, txn, p.curPlan.plan, recv)
+			ctx, evalCtx, planCtx, txn, p.curPlan.plan, recv,
+		)()
 		return rw.Err()
 	})
 	if err != nil {

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -223,7 +223,8 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 		)
 		defer recv.Release()
 		distSQLPlanner.Run(
-			planCtx, newParams.p.txn, &plan, recv, newParams.extendedEvalCtx, nil /* finishedSetupFn */)
+			planCtx, newParams.p.txn, &plan, recv, newParams.extendedEvalCtx, nil, /* finishedSetupFn */
+		)()
 
 		n.run.executedStatement = true
 

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -445,6 +445,13 @@ func (p *planTop) close(ctx context.Context) {
 			p.subqueryPlans[i].plan = nil
 		}
 	}
+
+	for i := range p.postqueryPlans {
+		if p.postqueryPlans[i].plan != nil {
+			p.postqueryPlans[i].plan.Close(ctx)
+			p.postqueryPlans[i].plan = nil
+		}
+	}
 }
 
 // columns retrieves the plan's columns.

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -551,7 +551,8 @@ func scrubRunDistSQL(
 	// Copy the evalCtx, as dsp.Run() might change it.
 	evalCtxCopy := p.extendedEvalCtx
 	p.extendedEvalCtx.DistSQLPlanner.Run(
-		planCtx, p.txn, plan, recv, &evalCtxCopy, nil /* finishedSetupFn */)
+		planCtx, p.txn, plan, recv, &evalCtxCopy, nil, /* finishedSetupFn */
+	)()
 	if rowResultWriter.Err() != nil {
 		return rows, rowResultWriter.Err()
 	} else if rows.Len() == 0 {

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -126,6 +126,6 @@ func (dsp *DistSQLPlanner) Exec(
 	planCtx.planner = p
 	planCtx.stmtType = recv.stmtType
 
-	dsp.PlanAndRun(ctx, evalCtx, planCtx, p.txn, p.curPlan.plan, recv)
+	dsp.PlanAndRun(ctx, evalCtx, planCtx, p.txn, p.curPlan.plan, recv)()
 	return rw.Err()
 }


### PR DESCRIPTION
Previously, we were closing the main query plan nodes right after
it was executed. However, some postqueries require access to the
objects belonging to the main query tree (for example, scan buffer
nodes in postqueries will be reading from the buffer nodes in the
main tree). Now this is fixed.

Release note: None