### PR TITLE
exec: handle empty table for aggregate operators

### DIFF
--- a/pkg/sql/exec/any_not_null_agg_tmpl.go
+++ b/pkg/sql/exec/any_not_null_agg_tmpl.go
@@ -103,11 +103,16 @@ func (a *anyNotNull_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 	if inputLen == 0 {
 		// If we haven't found any non-nulls for this group so far, the output for
 		// this group should be null. If a.curIdx is negative, it means the input
-		// has zero rows, and there should be no output at all.
-		if !a.foundNonNullForCurrentGroup && a.curIdx >= 0 {
-			a.nulls.SetNull(uint16(a.curIdx))
+		// has zero rows, and the output should be NULL.
+		if a.curIdx >= 0 {
+			if !a.foundNonNullForCurrentGroup {
+				a.nulls.SetNull(uint16(a.curIdx))
+			}
+			a.curIdx++
+		} else {
+			a.nulls.SetNull(0)
+			a.curIdx = 1
 		}
-		a.curIdx++
 		a.done = true
 		return
 	}

--- a/pkg/sql/exec/avg_agg_tmpl.go
+++ b/pkg/sql/exec/avg_agg_tmpl.go
@@ -124,19 +124,21 @@ func (a *avg_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 	}
 	inputLen := b.Length()
 	if inputLen == 0 {
-
 		// The aggregation is finished. Flush the last value. If we haven't found
-		// any non-nulls for this group so far, the output for this group should
-		// be null. If a.scratch.curIdx is negative, it means the input has zero rows, and
-		// there should be no output at all.
+		// any non-nulls for this group so far, the output for this group should be
+		// null. If a.scratch.curIdx is negative, it means the input has zero rows,
+		// and the output should be NULL.
 		if a.scratch.curIdx >= 0 {
 			if !a.scratch.foundNonNullForCurrentGroup {
 				a.scratch.nulls.SetNull(uint16(a.scratch.curIdx))
 			} else {
 				_ASSIGN_DIV_INT64("a.scratch.vec[a.scratch.curIdx]", "a.scratch.curSum", "a.scratch.curCount")
 			}
+			a.scratch.curIdx++
+		} else {
+			a.scratch.nulls.SetNull(0)
+			a.scratch.curIdx = 1
 		}
-		a.scratch.curIdx++
 		a.done = true
 		return
 	}

--- a/pkg/sql/exec/count_agg.go
+++ b/pkg/sql/exec/count_agg.go
@@ -63,7 +63,14 @@ func (a *countAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 	}
 	inputLen := b.Length()
 	if inputLen == 0 {
-		a.curIdx++
+		// If a.curIdx is negative, it means the input has zero rows, and the output
+		// should be a single row with the value 0.
+		if a.curIdx >= 0 {
+			a.curIdx++
+		} else {
+			a.vec[0] = 0
+			a.curIdx = 1
+		}
 		a.done = true
 		return
 	}

--- a/pkg/sql/exec/min_max_agg_tmpl.go
+++ b/pkg/sql/exec/min_max_agg_tmpl.go
@@ -123,14 +123,17 @@ func (a *_AGG_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 		// The aggregation is finished. Flush the last value. If we haven't found
 		// any non-nulls for this group so far, the output for this group should
 		// be null. If a.curIdx is negative, it means the input has zero rows, and
-		// there should be no output at all.
+		// the output should be NULL.
 		if a.curIdx >= 0 {
 			if !a.foundNonNullForCurrentGroup {
 				a.nulls.SetNull(uint16(a.curIdx))
 			}
 			a.vec[a.curIdx] = a.curAgg
+			a.curIdx++
+		} else {
+			a.nulls.SetNull(0)
+			a.curIdx = 1
 		}
-		a.curIdx++
 		a.done = true
 		return
 	}

--- a/pkg/sql/exec/sum_agg_tmpl.go
+++ b/pkg/sql/exec/sum_agg_tmpl.go
@@ -115,14 +115,17 @@ func (a *sum_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 		// The aggregation is finished. Flush the last value. If we haven't found
 		// any non-nulls for this group so far, the output for this group should be
 		// null. If a.scratch.curIdx is negative, it means the input has zero rows,
-		// and there should be no output at all.
+		// and the output should be NULL.
 		if a.scratch.curIdx >= 0 {
 			if !a.scratch.foundNonNullForCurrentGroup {
 				a.scratch.nulls.SetNull(uint16(a.scratch.curIdx))
 			}
 			a.scratch.vec[a.scratch.curIdx] = a.scratch.curAgg
+			a.scratch.curIdx++
+		} else {
+			a.scratch.nulls.SetNull(0)
+			a.scratch.curIdx = 1
 		}
-		a.scratch.curIdx++
 		a.done = true
 		return
 	}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -17,6 +17,9 @@ statement ok
 CREATE TABLE nulls (a INT, b INT)
 
 statement ok
+CREATE TABLE empty (a INT PRIMARY KEY, b FLOAT);
+
+statement ok
 INSERT INTO nulls VALUES (NULL, NULL), (NULL, 1), (1, NULL), (1, 1)
 
 query I
@@ -270,6 +273,12 @@ SELECT c.a FROM c INNER LOOKUP JOIN c@sec AS s ON c.b=s.b
 1
 2
 2
+
+# Test for #38858 -- handle aggregates correctly on an empty table.
+query IIIIIRR
+SELECT count(*), count(a), sum_int(a), min(a), max(a), sum(b), avg(b) FROM empty
+----
+0  0  NULL  NULL  NULL  NULL  NULL
 
 # Test that LIKE expressions are properly handled by vectorized execution.
 statement ok


### PR DESCRIPTION
If the table is empty, the COUNT aggregates should return 0, and all the
other aggregates should return NULL.

fixes #38858 

Release note: None