### PR TITLE
exec: switch Bytes representation from [][]byte to []byte + offsets

### DIFF
--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -164,4 +164,9 @@ func (m *MemBatch) Reset(types []coltypes.T, length int) {
 // ResetInternalBatch implements the Batch interface.
 func (m *MemBatch) ResetInternalBatch() {
 	m.SetSelection(false)
+	for _, v := range m.b {
+		if v.Type() == coltypes.Bytes {
+			v.Bytes().Reset()
+		}
+	}
 }

--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -45,6 +45,11 @@ type Batch interface {
 	// columns and allocations, invalidating existing references to the Batch or
 	// its Vecs. However, Reset does _not_ zero out the column data.
 	Reset(types []coltypes.T, length int)
+	// ResetInternalBatch resets a batch and its underlying Vecs for reuse. It's
+	// important for callers to call ResetInternalBatch if they own internal
+	// batches that they reuse as not doing this could result in correctness
+	// or memory blowup issues.
+	ResetInternalBatch()
 }
 
 var _ Batch = &MemBatch{}
@@ -154,4 +159,9 @@ func (m *MemBatch) Reset(types []coltypes.T, length int) {
 	for _, col := range m.ColVecs() {
 		col.Nulls().UnsetNulls()
 	}
+}
+
+// ResetInternalBatch implements the Batch interface.
+func (m *MemBatch) ResetInternalBatch() {
+	m.SetSelection(false)
 }

--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -295,16 +295,6 @@ func (b Bytes) String() string {
 	return builder.String()
 }
 
-// PrimitiveRepr is a temprorary migration tool.
-// TODO(asubiotto): Remove this.
-func (b Bytes) PrimitiveRepr() [][]byte {
-	bytes := make([][]byte, b.Len())
-	for i := 0; i < b.Len(); i++ {
-		bytes[i] = b.Get(i)
-	}
-	return bytes
-}
-
 // BytesFromArrowSerializationFormat takes an Arrow byte slice and accompanying
 // offsets and populates b.
 func BytesFromArrowSerializationFormat(b *Bytes, data []byte, offsets []int32) {

--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -10,71 +10,329 @@
 
 package coldata
 
-// Bytes is a wrapper type for a two-dimensional byte slice.
+import (
+	"fmt"
+	"strings"
+)
+
+// Bytes is a wrapper type for a two-dimensional byte slice ([][]byte).
 type Bytes struct {
-	data [][]byte
+	// data is the slice of all bytes.
+	data []byte
+	// offsets contains the offsets for each []byte slice in data.
+	offsets []int32
+	// lengths[i] contains the length of the []byte value beginning at offsets[i].
+	// TODO(asubiotto): lengths are unnecessary since we can use
+	//  offsets[i+1]-offsets[i] to determine the length of the element at
+	//  offsets[i].
+	lengths []int32
+
+	// maxSetIndex specifies the last index set by the user of this struct. This
+	// enables us to disallow unordered sets (which would require data movement).
+	maxSetIndex int
 }
 
-// NewBytes returns a Bytes struct with enough capacity for n elements.
+// NewBytes returns a Bytes struct with enough capacity for n zero-length
+// []byte values. It is legal to call Set on the returned Bytes at this point,
+// but Get is undefined until at least one element is Set.
 func NewBytes(n int) *Bytes {
 	return &Bytes{
-		data: make([][]byte, n),
+		// Given that the []byte slices are of variable length, we multiply the
+		// number of elements by some constant factor.
+		// TODO(asubiotto): Make this tunable.
+		data:    make([]byte, 0, n*64),
+		offsets: make([]int32, n),
+		lengths: make([]int32, n),
 	}
 }
 
-// Get returns the ith []byte in Bytes.
+// Get returns the ith []byte in Bytes. Note that the returned byte slice is
+// unsafe for reuse if any write operation happens.
 func (b Bytes) Get(i int) []byte {
-	return b.data[i]
+	return b.data[b.offsets[i] : b.offsets[i]+b.lengths[i]]
 }
 
-// Set sets the ith []byte in Bytes.
-func (b Bytes) Set(i int, v []byte) {
-	b.data[i] = v
+// Set sets the ith []byte in Bytes. Overwriting a value that is not at the end
+// of the Bytes is not allowed since it complicates memory movement to make/take
+// away necessary space in the flat buffer. Note that a nil value will be
+// "converted" into an empty byte slice.
+func (b *Bytes) Set(i int, v []byte) {
+	if i < b.maxSetIndex {
+		panic(
+			fmt.Sprintf(
+				"cannot overwrite value on flat Bytes: maxSetIndex=%d, setIndex=%d, consider using Reset",
+				b.maxSetIndex,
+				i,
+			),
+		)
+	}
+	if i == b.maxSetIndex && b.offsets[i]+b.lengths[i] > 0 {
+		// We are overwriting a non-zero element at the end of b.data, truncate so
+		// we can append in every path.
+		b.data = b.data[:b.offsets[i]]
+	}
+	b.offsets[i] = int32(len(b.data))
+	b.lengths[i] = int32(len(v))
+	b.data = append(b.data, v...)
+	b.maxSetIndex = i
 }
 
-// Swap swaps the ith []byte with the jth []byte and vice-versa.
-func (b Bytes) Swap(i int, j int) {
-	b.data[i], b.data[j] = b.data[j], b.data[i]
+// Swap swaps the ith []byte with the jth []byte and vice-versa. This is
+// disallowed.
+func (b *Bytes) Swap(i int, j int) {
+	panic("cannot swap flat Bytes elements")
 }
 
-// Slice returns a new Bytes struct with its internal data sliced according to
-// start and end.
-func (b Bytes) Slice(start, end int) *Bytes {
-	return &Bytes{data: b.data[start:end]}
+// Slice modifies and returns the receiver Bytes struct sliced according to
+// start and end. Returning the result is not necessary but is done for
+// compatibility with the usage of other data representations in vectorized
+// execution. Note that Slicing can be expensive since it incurs a step to
+// translate offsets.
+func (b *Bytes) Slice(start, end int) *Bytes {
+	if start == 0 && end == len(b.offsets) {
+		return b
+	}
+	if start == end {
+		b.offsets = b.offsets[:0]
+		b.lengths = b.lengths[:0]
+		b.data = b.data[:0]
+		b.maxSetIndex = 0
+		return b
+	}
+	translateBy := b.offsets[start]
+	b.data = b.data[b.offsets[start] : b.offsets[end-1]+b.lengths[end-1]]
+	b.offsets = b.offsets[start:end]
+	for i := range b.offsets {
+		b.offsets[i] -= translateBy
+	}
+	b.lengths = b.lengths[start:end]
+	b.maxSetIndex = end - start - 1
+	return b
 }
 
-// CopySlice copies srcStartIdx inclusive and srcEndIdx inclusive []byte values
-// from src into the receiver starting at destIdx.
-func (b Bytes) CopySlice(src *Bytes, destIdx, srcStartIdx, srcEndIdx int) {
-	copy(b.data[destIdx:], src.data[srcStartIdx:srcEndIdx])
+// CopySlice copies srcStartIdx inclusive and srcEndIdx exclusive []byte values
+// from src into the receiver starting at destIdx. Similar to the copy builtin,
+// min(dest.Len(), src.Len()) values will be copied. Note that if the length of
+// the receiver is greater than the length of the source, bytes will have to be
+// physically moved. Consider the following example:
+// dest Bytes: "helloworld", offsets: []int32{0, 5}, lengths: []int32{5, 5}
+// src Bytes: "a", offsets: []int32{0}, lengths: []int32{1}
+// If we copy src into the beginning of dest, we will have to move "world" so
+// that the result is:
+// result Bytes: "aworld", offsets: []int32{0, 1}, lengths: []int32{1, 5}
+func (b *Bytes) CopySlice(src *Bytes, destIdx, srcStartIdx, srcEndIdx int) {
+	if destIdx < 0 || destIdx > b.Len() {
+		panic(fmt.Sprintf("dest index %d out of range (len=%d)", destIdx, b.Len()))
+	} else if srcStartIdx < 0 || srcStartIdx >= src.Len() || srcEndIdx > src.Len() || srcStartIdx > srcEndIdx {
+		panic(
+			fmt.Sprintf("source index start %d or end %d invalid (len=%d)", srcStartIdx, srcEndIdx, src.Len()),
+		)
+	}
+	toCopy := srcEndIdx - srcStartIdx
+	if toCopy == 0 || len(b.offsets) == 0 || destIdx == len(b.offsets) {
+		return
+	}
+
+	srcDataToCopy := src.data[src.offsets[srcStartIdx] : src.offsets[srcEndIdx-1]+src.lengths[srcEndIdx-1]]
+	if destIdx+toCopy > len(b.offsets) {
+		// Reduce the number of elements to copy to what can fit into the
+		// destination.
+		toCopy = len(b.offsets) - destIdx
+		srcDataToCopy = src.data[src.offsets[srcStartIdx]:src.offsets[srcStartIdx+toCopy]]
+	}
+
+	newMaxIdx := destIdx + (toCopy - 1)
+	if newMaxIdx > b.maxSetIndex {
+		b.maxSetIndex = newMaxIdx
+	}
+
+	var leftoverDestBytes []byte
+	if destIdx+toCopy < len(b.offsets) {
+		// There will still be elements left over after the last element to copy. We
+		// copy those elements into leftoverDestBytes to append after all elements
+		// have been copied.
+		leftoverDestBytesToCopy := b.data[b.offsets[destIdx+toCopy]:]
+		leftoverDestBytes = make([]byte, len(leftoverDestBytesToCopy))
+		copy(leftoverDestBytes, leftoverDestBytesToCopy)
+	}
+
+	destDataIdx := int32(0)
+	if destIdx != 0 {
+		destDataIdx = b.offsets[destIdx-1] + b.lengths[destIdx-1]
+	}
+	translateBy := destDataIdx - src.offsets[srcStartIdx]
+
+	// Append the actual bytes, we use an append instead of a copy to ensure that
+	// b.data has enough capacity. Note that the "capacity" was checked
+	// beforehand, but the number of elements to copy does not correlate with the
+	// number of bytes.
+	b.data = append(b.data[:b.offsets[destIdx]], srcDataToCopy...)
+	copy(b.lengths[destIdx:], src.lengths[srcStartIdx:srcEndIdx])
+	copy(b.offsets[destIdx:], src.offsets[srcStartIdx:srcEndIdx])
+
+	if translateBy != 0 {
+		destOffsets := b.offsets[destIdx : destIdx+toCopy]
+		for i := range destOffsets {
+			destOffsets[i] += translateBy
+		}
+	}
+
+	if leftoverDestBytes != nil {
+		dataToAppendTo := b.data[:b.offsets[destIdx+toCopy-1]+b.lengths[destIdx+toCopy-1]]
+		// Append (to make sure we have the capacity for) the leftoverDestBytes to
+		// the end of the data we just copied.
+		b.data = append(dataToAppendTo, leftoverDestBytes...)
+		// The lengths for these elements are correct (they weren't overwritten),
+		// but the offsets need updating.
+		destOffsets := b.offsets[destIdx+toCopy:]
+		translateBy := int32(len(dataToAppendTo)) - destOffsets[0]
+		for i := range destOffsets {
+			destOffsets[i] += translateBy
+		}
+	}
+
+	// "Trim" unnecessary bytes. It's important we do this because we don't want
+	// to have unreferenced bytes. This could lead to issues since we assume that
+	// all bytes are "live" in order to use the builtin copy/append functions.
+	dataLen := len(b.offsets)
+	b.data = b.data[:b.offsets[dataLen-1]+b.lengths[dataLen-1]]
 }
 
-// AppendSlice appends srcStartIdx inclusive and srcEndIdx inclusive []byte
+// AppendSlice appends srcStartIdx inclusive and srcEndIdx exclusive []byte
 // values from src into the receiver starting at destIdx.
 func (b *Bytes) AppendSlice(src *Bytes, destIdx, srcStartIdx, srcEndIdx int) {
-	b.data = append(b.data[:destIdx], src.data[srcStartIdx:srcEndIdx]...)
+	if destIdx < 0 || destIdx > b.Len() {
+		panic(fmt.Sprintf("dest index %d out of range (len=%d)", destIdx, b.Len()))
+	} else if srcStartIdx < 0 || srcStartIdx >= src.Len() || srcEndIdx > src.Len() || srcStartIdx > srcEndIdx {
+		panic(
+			fmt.Sprintf("source index start %d or end %d invalid (len=%d)", srcStartIdx, srcEndIdx, src.Len()),
+		)
+	}
+	toAppend := srcEndIdx - srcStartIdx
+	b.maxSetIndex = destIdx + (toAppend - 1)
+	if toAppend == 0 {
+		if destIdx == len(b.offsets) {
+			return
+		}
+		b.data = b.data[:b.offsets[destIdx]]
+		b.offsets = b.offsets[:destIdx]
+		b.lengths = b.lengths[:destIdx]
+		return
+	}
+
+	srcDataToAppend := src.data[src.offsets[srcStartIdx] : src.offsets[srcEndIdx-1]+src.lengths[srcEndIdx-1]]
+
+	destDataIdx := int32(0)
+	if destIdx != 0 {
+		destDataIdx = b.offsets[destIdx-1] + b.lengths[destIdx-1]
+	}
+
+	// Calculate the amount to translate offsets by before modifying any
+	// destination offsets since we might be appending from the same Bytes (and
+	// might be overwriting information).
+	translateBy := destDataIdx - src.offsets[srcStartIdx]
+	b.data = append(b.data[:destDataIdx], srcDataToAppend...)
+	b.offsets = append(b.offsets[:destIdx], src.offsets[srcStartIdx:srcEndIdx]...)
+	b.lengths = append(b.lengths[:destIdx], src.lengths[srcStartIdx:srcEndIdx]...)
+	if translateBy == 0 {
+		// No offset translation needed.
+		return
+	}
+	// destOffsets is used to avoid having to recompute the target index on every
+	// iteration.
+	destOffsets := b.offsets[destIdx:]
+	for i := range destOffsets {
+		destOffsets[i] += translateBy
+	}
 }
 
-// AppendVal appends the given []byte value to the end of the receiver.
+// AppendVal appends the given []byte value to the end of the receiver. A nil
+// value will be "converted" into an empty byte slice.
 func (b *Bytes) AppendVal(v []byte) {
-	b.data = append(b.data, v)
+	b.maxSetIndex = len(b.offsets)
+	b.offsets = append(b.offsets, int32(len(b.data)))
+	b.lengths = append(b.lengths, int32(len(v)))
+	b.data = append(b.data, v...)
 }
 
 // Len returns how many []byte values the receiver contains.
 func (b Bytes) Len() int {
-	return len(b.data)
+	return len(b.offsets)
 }
 
-var zeroBytesColumn = make([][]byte, BatchSize)
+var zeroInt32Slice = make([]int32, BatchSize)
 
-// Zero zeroes out the underlying bytes.
+// Zero zeroes out the underlying bytes. Note that this doesn't change the
+// length. Use this instead of Reset if you need to be able to Get zeroed byte
+// slices.
 func (b Bytes) Zero() {
-	for n := 0; n < len(b.data); n += copy(b.data[n:], zeroBytesColumn) {
+	b.data = b.data[:0]
+	for n := 0; n < len(b.offsets); n += copy(b.offsets[n:], zeroInt32Slice) {
 	}
+	for n := 0; n < len(b.lengths); n += copy(b.lengths[n:], zeroInt32Slice) {
+	}
+	b.maxSetIndex = 0
+}
+
+// Reset resets the underlying Bytes for reuse.
+// This is useful when the caller is going to overwrite the underlying bytes and
+// needs a quick way to Reset. Note that this doesn't change the length either.
+// TODO(asubiotto): Move towards removing Set in favor of AppendVal. At that
+//  point we can reset the length to 0.
+func (b *Bytes) Reset() {
+	b.data = b.data[:0]
+	b.maxSetIndex = 0
+}
+
+// String is used for debugging purposes.
+func (b Bytes) String() string {
+	var builder strings.Builder
+	for i := range b.offsets {
+		builder.WriteString(
+			fmt.Sprintf("%d: %v\n", i, b.data[b.offsets[i]:b.offsets[i]+b.lengths[i]]),
+		)
+	}
+	return builder.String()
 }
 
 // PrimitiveRepr is a temprorary migration tool.
 // TODO(asubiotto): Remove this.
 func (b Bytes) PrimitiveRepr() [][]byte {
-	return b.data
+	bytes := make([][]byte, b.Len())
+	for i := 0; i < b.Len(); i++ {
+		bytes[i] = b.Get(i)
+	}
+	return bytes
+}
+
+// BytesFromArrowSerializationFormat takes an Arrow byte slice and accompanying
+// offsets and populates b.
+func BytesFromArrowSerializationFormat(b *Bytes, data []byte, offsets []int32) {
+	if cap(b.lengths) < len(offsets)-1 {
+		b.lengths = b.lengths[:cap(b.lengths)]
+		b.lengths = append(b.lengths, make([]int32, len(offsets)-1-len(b.lengths))...)
+	}
+	b.lengths = b.lengths[:len(offsets)-1]
+	for i, offset := range offsets[1:] {
+		// Starting from the second index, the length for each element is the
+		// current offset minus the previous offset.
+		b.lengths[i] = offset - offsets[i]
+	}
+	// Trim the last offset, which is just the length of the data slice.
+	offsets = offsets[:len(offsets)-1]
+	b.data = data
+	b.offsets = offsets
+	b.maxSetIndex = len(offsets) - 1
+}
+
+// ToArrowSerializationFormat returns a bytes slice and offsets that are
+// Arrow-compatible. n is the number of elements to serialize.
+func (b Bytes) ToArrowSerializationFormat(n int) ([]byte, []int32) {
+	if n == 0 {
+		return []byte{}, []int32{0}
+	}
+	serializeLength := b.offsets[n-1] + b.lengths[n-1]
+	data := b.data[:serializeLength]
+	offsets := append(b.offsets[:n], serializeLength)
+	return data, offsets
 }

--- a/pkg/col/coldata/bytes_test.go
+++ b/pkg/col/coldata/bytes_test.go
@@ -1,0 +1,358 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package coldata
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+type bytesMethod int
+
+const (
+	set bytesMethod = iota
+	slice
+	copySlice
+	appendSlice
+	appendVal
+)
+
+func (m bytesMethod) String() string {
+	switch m {
+	case set:
+		return "Set"
+	case slice:
+		return "Slice"
+	case copySlice:
+		return "CopySlice"
+	case appendSlice:
+		return "AppendSlice"
+	case appendVal:
+		return "AppendVal"
+	default:
+		panic(fmt.Sprintf("unknown bytes method %d", m))
+	}
+}
+
+var bytesMethods = []bytesMethod{set, slice, copySlice, appendSlice, appendVal}
+
+// applyMethodsAndVerify applies the given methods on b1 and a reference
+// [][]byte implementation and checks if the results are equal. If
+// selfReferencingSources is true, this is an indication by the caller that we
+// are testing an edge case where the source for copies/appends refers to the
+// destination. In cases where *Bytes updates itself under the hood, we also
+// update the corresponding b2Source to mirror the behavior.
+func applyMethodsAndVerify(
+	rng *rand.Rand,
+	b1, b1Source *Bytes,
+	b2, b2Source [][]byte,
+	methods []bytesMethod,
+	selfReferencingSources bool,
+) error {
+	if err := verifyEqual(b1, b2); err != nil {
+		return errors.Wrap(err, "arguments should start as equal")
+	}
+	if err := verifyEqual(b1Source, b2Source); err != nil {
+		return errors.Wrap(err, "argument sources should start as equal")
+	}
+	var debugString string
+	for _, m := range methods {
+		n := b1.Len()
+		if n != len(b2) {
+			return errors.Errorf("length mismatch between flat and reference: %d != %d", n, len(b2))
+		}
+		sourceN := b1Source.Len()
+		if sourceN != len(b2Source) {
+			return errors.Errorf("length mismatch between flat and reference sources: %d != %d", sourceN, len(b2Source))
+		}
+		debugString += m.String()
+		switch m {
+		case set:
+			// Can only Set the last index.
+			i := b1.Len() - 1
+			new := make([]byte, rng.Intn(16))
+			rng.Read(new)
+			debugString += fmt.Sprintf("(%d, %v)", i, new)
+			b1.Set(i, new)
+			b2[i] = new
+		case slice:
+			start := rng.Intn(n)
+			end := rng.Intn(n + 1)
+			if start > end {
+				end = start + 1
+			} else if start == end {
+				// If start == end, do a noop Slice, otherwise the rest of the methods
+				// won't do much (and rng.Intn will panic with an n of 0).
+				start = 0
+				end = n
+			}
+			debugString += fmt.Sprintf("(%d, %d)", start, end)
+			b1 = b1.Slice(start, end)
+			b2 = b2[start:end]
+			if selfReferencingSources {
+				b2Source = b2
+			}
+		case copySlice, appendSlice:
+			// Generate a length-inclusive destIdx.
+			destIdx := rng.Intn(n + 1)
+			srcStartIdx := rng.Intn(sourceN)
+			srcEndIdx := rng.Intn(sourceN)
+			if srcStartIdx > srcEndIdx {
+				srcEndIdx = srcStartIdx + 1
+			} else if srcStartIdx == srcEndIdx {
+				// Avoid whittling down our destination slice.
+				srcStartIdx = 0
+				srcEndIdx = sourceN
+			}
+			debugString += fmt.Sprintf("(%d, %d, %d)", destIdx, srcStartIdx, srcEndIdx)
+			var numNewVals int
+			if m == copySlice {
+				b1.CopySlice(b1Source, destIdx, srcStartIdx, srcEndIdx)
+				numNewVals = copy(b2[destIdx:], b2Source[srcStartIdx:srcEndIdx])
+			} else {
+				b1.AppendSlice(b1Source, destIdx, srcStartIdx, srcEndIdx)
+				b2 = append(b2[:destIdx], b2Source[srcStartIdx:srcEndIdx]...)
+				if selfReferencingSources {
+					b2Source = b2
+				}
+				numNewVals = srcEndIdx - srcStartIdx
+			}
+			// Deep copy the copied/appended byte slices.
+			b2Slice := b2[destIdx : destIdx+numNewVals]
+			for i := range b2Slice {
+				b2Slice[i] = append([]byte(nil), b2Slice[i]...)
+			}
+		case appendVal:
+			v := make([]byte, 16)
+			rng.Read(v)
+			debugString += fmt.Sprintf("(%v)", v)
+			b1.AppendVal(v)
+			b2 = append(b2, v)
+			if selfReferencingSources {
+				b2Source = b2
+			}
+		default:
+			return errors.Errorf("unknown method name: %s", m)
+		}
+		debugString += "\n"
+		if err := verifyEqual(b1, b2); err != nil {
+			return errors.Wrap(err, fmt.Sprintf("\ndebugString:\n%sflat (maxSetIdx=%d):\n%sreference:\n%s", debugString, b1.maxSetIndex, b1.String(), prettyByteSlice(b2)))
+		}
+	}
+	return nil
+}
+
+func verifyEqual(flat *Bytes, b [][]byte) error {
+	if flat.Len() != len(b) {
+		return errors.Errorf("mismatched lengths %d != %d", flat.Len(), len(b))
+	}
+	for i := range b {
+		if !bytes.Equal(b[i], flat.Get(i)) {
+			return errors.Errorf("mismatch at index %d", i)
+		}
+	}
+	return nil
+}
+
+func prettyByteSlice(b [][]byte) string {
+	var builder strings.Builder
+	for i := range b {
+		builder.WriteString(
+			fmt.Sprintf("%d: %v\n", i, b[i]),
+		)
+	}
+	return builder.String()
+}
+
+func TestBytesRefImpl(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	rng, _ := randutil.NewPseudoRand()
+
+	const (
+		maxNumberOfCalls = 64
+		maxLength        = 16
+	)
+
+	n := 1 + rng.Intn(maxLength)
+
+	flat := NewBytes(n)
+	reference := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		v := make([]byte, rng.Intn(16))
+		rng.Read(v)
+		flat.Set(i, append([]byte(nil), v...))
+		reference[i] = append([]byte(nil), v...)
+	}
+
+	// Make a pair of sources to copy/append from. Use the destination variables
+	// with a certain probability.
+	sourceN := n
+	flatSource := flat
+	referenceSource := reference
+	selfReferencingSources := true
+	if rng.Float64() < 0.5 {
+		selfReferencingSources = false
+		sourceN = 1 + rng.Intn(maxLength)
+		flatSource = NewBytes(sourceN)
+		referenceSource = make([][]byte, sourceN)
+		for i := 0; i < sourceN; i++ {
+			v := make([]byte, rng.Intn(16))
+			rng.Read(v)
+			flatSource.Set(i, append([]byte(nil), v...))
+			referenceSource[i] = append([]byte(nil), v...)
+		}
+	}
+
+	if err := verifyEqual(flat, reference); err != nil {
+		t.Fatalf("not equal: %v\nflat:\n%sreference:\n%s", err, flat, prettyByteSlice(reference))
+	}
+
+	if err := verifyEqual(flatSource, referenceSource); err != nil {
+		t.Fatalf("sources not equal: %v\nflat:\n%sreference:\n%s", err, flat, prettyByteSlice(reference))
+	}
+
+	numCalls := 1 + rng.Intn(maxNumberOfCalls)
+	methods := make([]bytesMethod, 0, numCalls)
+	for i := 0; i < numCalls; i++ {
+		methods = append(methods, bytesMethods[rng.Intn(len(bytesMethods))])
+	}
+	if err := applyMethodsAndVerify(rng, flat, flatSource, reference, referenceSource, methods, selfReferencingSources); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBytes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	t.Run("Simple", func(t *testing.T) {
+		b1 := NewBytes(0)
+		b1.AppendVal([]byte("hello"))
+		require.Equal(t, "hello", string(b1.Get(0)))
+		b1.AppendVal(nil)
+		require.Equal(t, []byte{}, b1.Get(1))
+		require.Equal(t, 2, b1.Len())
+		// Verify that we cannot overwrite a value.
+		require.Panics(
+			t,
+			func() { b1.Set(0, []byte("not allowed")) },
+			"should be unable to overwrite value",
+		)
+
+		// However, it is legal to overwrite the last value.
+		b1.Set(1, []byte("ok"))
+
+		// If we Zero the Bytes, we can Set any index.
+		b1.Zero()
+		b1.Set(1, []byte("new usage"))
+		// But not an index before that.
+		require.Panics(
+			t,
+			func() { b1.Set(0, []byte("still not allowed")) },
+			"should be unable to overwrite value",
+		)
+
+		// Same with Reset.
+		b1.Reset()
+		b1.Set(1, []byte("reset new usage"))
+
+		// Swap exists temporarily due to execgen.SWAP.
+		// TODO(asubiotto): Remove execgen.SWAP and Swap.
+		require.Panics(
+			t,
+			func() { b1.Swap(0, 1) },
+			"should be unable to swap values",
+		)
+	})
+
+	t.Run("Append", func(t *testing.T) {
+		b1 := NewBytes(0)
+		b2 := NewBytes(0)
+		b2.AppendVal([]byte("source bytes value"))
+		b1.AppendVal([]byte("one"))
+		b1.AppendVal([]byte("two"))
+		// Truncate b1.
+		require.Equal(t, 2, b1.Len())
+		b1.AppendSlice(b2, 0, 0, 0)
+		require.Equal(t, 0, b1.Len())
+
+		b1.AppendVal([]byte("hello again"))
+
+		// Try appending b2 3 times. The first time will overwrite the current
+		// present value in b1.
+		for i := 0; i < 3; i++ {
+			b1.AppendSlice(b2, i, 0, b2.Len())
+			require.Equal(t, i+1, b1.Len())
+			for j := 0; j <= i; j++ {
+				require.Equal(t, "source bytes value", string(b1.Get(j)))
+			}
+		}
+
+		b2 = NewBytes(0)
+		b2.AppendVal([]byte("hello again"))
+		b2.AppendVal([]byte("hello again"))
+		b2.AppendVal([]byte("hello again"))
+		// Try to append only a subset of the source keeping the first element of
+		// b1 intact.
+		b1.AppendSlice(b2, 1, 1, 2)
+		require.Equal(t, 2, b1.Len())
+		require.Equal(t, "source bytes value", string(b1.Get(0)))
+		require.Equal(t, "hello again", string(b1.Get(1)))
+	})
+
+	t.Run("Copy", func(t *testing.T) {
+		b1 := NewBytes(0)
+		b2 := NewBytes(0)
+		b1.AppendVal([]byte("one"))
+		b1.AppendVal([]byte("two"))
+		b1.AppendVal([]byte("three"))
+
+		b2.AppendVal([]byte("source one"))
+		b2.AppendVal([]byte("source two"))
+
+		// Copy "source two" into "two"'s position. This also tests that elements
+		// following the copied element are correctly shifted.
+		b1.CopySlice(b2, 1, 1, 2)
+		require.Equal(t, 3, b1.Len())
+		require.Equal(t, "one", string(b1.Get(0)))
+		require.Equal(t, "source two", string(b1.Get(1)))
+		require.Equal(t, "three", string(b1.Get(2)))
+
+		// Copy will only copy as many elements as there is capacity for. In this
+		// call, the copy starts at index 2, so there is only capacity for one
+		// element.
+		b1.CopySlice(b2, 2, 0, b2.Len())
+		require.Equal(t, "one", string(b1.Get(0)))
+		require.Equal(t, "source two", string(b1.Get(1)))
+		require.Equal(t, "source one", string(b1.Get(2)))
+
+		// Slice b1 to test slicing logic and follow it with testing a full
+		// overwrite of only one element.
+		b1 = b1.Slice(0, 1)
+		require.Equal(t, 1, b1.Len())
+		b1.CopySlice(b2, 0, 0, b2.Len())
+		require.Equal(t, 1, b1.Len())
+		require.Equal(t, "source one", string(b1.Get(0)))
+
+		// Verify a full overwrite with a non-zero source start index.
+		b1.CopySlice(b2, 0, 1, b2.Len())
+		require.Equal(t, 1, b1.Len())
+		require.Equal(t, "source two", string(b1.Get(0)))
+	})
+}

--- a/pkg/col/coldata/vec_tmpl.go
+++ b/pkg/col/coldata/vec_tmpl.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+
 	// {{/*
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/execgen"
 	// */}}
@@ -61,7 +62,7 @@ func (m *memColumn) Append(args AppendArgs) {
 			// Improve this.
 			toCol = execgen.SLICE(toCol, 0, int(args.DestIdx))
 			for _, selIdx := range sel {
-				val := execgen.GET(fromCol, int(selIdx))
+				val := execgen.UNSAFEGET(fromCol, int(selIdx))
 				execgen.APPENDVAL(toCol, val)
 			}
 			// TODO(asubiotto): Change Extend* signatures to allow callers to pass in
@@ -99,7 +100,7 @@ func (m *memColumn) Copy(args CopyArgs) {
 						if args.Nils[i] || nulls.NullAt64(selIdx) {
 							m.nulls.SetNull64(uint64(i) + args.DestIdx)
 						} else {
-							v := execgen.GET(fromCol, int(selIdx))
+							v := execgen.UNSAFEGET(fromCol, int(selIdx))
 							execgen.SET(toColSliced, i, v)
 						}
 					}
@@ -112,7 +113,7 @@ func (m *memColumn) Copy(args CopyArgs) {
 					if args.Nils[i] {
 						m.nulls.SetNull64(uint64(i) + args.DestIdx)
 					} else {
-						v := execgen.GET(fromCol, int(selIdx))
+						v := execgen.UNSAFEGET(fromCol, int(selIdx))
 						execgen.SET(toColSliced, i, v)
 					}
 				}
@@ -127,7 +128,7 @@ func (m *memColumn) Copy(args CopyArgs) {
 					if nulls.NullAt64(selIdx) {
 						m.nulls.SetNull64(uint64(i) + args.DestIdx)
 					} else {
-						v := execgen.GET(fromCol, int(selIdx))
+						v := execgen.UNSAFEGET(fromCol, int(selIdx))
 						execgen.SET(toColSliced, i, v)
 					}
 				}
@@ -137,7 +138,7 @@ func (m *memColumn) Copy(args CopyArgs) {
 			n := execgen.LEN(toCol)
 			toColSliced := execgen.SLICE(toCol, int(args.DestIdx), n)
 			for i, selIdx := range sel[args.SrcStartIdx:args.SrcEndIdx] {
-				v := execgen.GET(fromCol, int(selIdx))
+				v := execgen.UNSAFEGET(fromCol, int(selIdx))
 				execgen.SET(toColSliced, i, v)
 			}
 			return
@@ -151,7 +152,7 @@ func (m *memColumn) Copy(args CopyArgs) {
 					if nulls.NullAt64(uint64(selIdx)) {
 						m.nulls.SetNull64(uint64(i) + args.DestIdx)
 					} else {
-						v := execgen.GET(fromCol, int(selIdx))
+						v := execgen.UNSAFEGET(fromCol, int(selIdx))
 						execgen.SET(toColSliced, i, v)
 					}
 				}
@@ -161,7 +162,7 @@ func (m *memColumn) Copy(args CopyArgs) {
 			n := execgen.LEN(toCol)
 			toColSliced := execgen.SLICE(toCol, int(args.DestIdx), n)
 			for i, selIdx := range sel[args.SrcStartIdx:args.SrcEndIdx] {
-				v := execgen.GET(fromCol, int(selIdx))
+				v := execgen.UNSAFEGET(fromCol, int(selIdx))
 				execgen.SET(toColSliced, i, v)
 			}
 			return
@@ -207,7 +208,7 @@ func (m *memColumn) PrettyValueAt(colIdx uint16, colType coltypes.T) string {
 	// {{range .}}
 	case _TYPES_T:
 		col := m._TemplateType()
-		v := execgen.GET(col, int(colIdx))
+		v := execgen.UNSAFEGET(col, int(colIdx))
 		return fmt.Sprintf("%v", v)
 	// {{end}}
 	default:

--- a/pkg/col/coldata/vec_tmpl.go
+++ b/pkg/col/coldata/vec_tmpl.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
-
 	// {{/*
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/execgen"
 	// */}}

--- a/pkg/col/colserde/arrowbatchconverter.go
+++ b/pkg/col/colserde/arrowbatchconverter.go
@@ -223,8 +223,8 @@ func (c *ArrowBatchConverter) ArrowToBatch(data []*array.Data, b coldata.Batch) 
 	// is allocated.
 	b.Reset(c.typs, n)
 	b.SetLength(uint16(n))
-	// No selection, all values are valid.
-	b.SetSelection(false)
+	// Reset the batch, this resets the selection vector as well.
+	b.ResetInternalBatch()
 
 	for i, typ := range c.typs {
 		vec := b.ColVec(i)

--- a/pkg/col/colserde/arrowbatchconverter.go
+++ b/pkg/col/colserde/arrowbatchconverter.go
@@ -15,7 +15,6 @@ import (
 	"reflect"
 	"unsafe"
 
-	"github.com/apache/arrow/go/arrow"
 	"github.com/apache/arrow/go/arrow/array"
 	"github.com/apache/arrow/go/arrow/memory"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -34,9 +33,6 @@ type ArrowBatchConverter struct {
 	builders struct {
 		// boolBuilder builds arrow bool columns as a bitmap from a bool slice.
 		boolBuilder *array.BooleanBuilder
-		// binaryBuilder builds arrow []byte columns as one []byte slice with
-		// accompanying offsets from a [][]byte slice.
-		binaryBuilder *array.BinaryBuilder
 	}
 
 	scratch struct {
@@ -60,13 +56,12 @@ func NewArrowBatchConverter(typs []coltypes.T) (*ArrowBatchConverter, error) {
 	}
 	c := &ArrowBatchConverter{typs: typs}
 	c.builders.boolBuilder = array.NewBooleanBuilder(memory.DefaultAllocator)
-	c.builders.binaryBuilder = array.NewBinaryBuilder(memory.DefaultAllocator, arrow.BinaryTypes.Binary)
 	c.scratch.arrowData = make([]*array.Data, len(typs))
 	c.scratch.buffers = make([][]*memory.Buffer, len(typs))
 	for i := range c.scratch.buffers {
-		// Only primitive types are directly constructed, therefore we only need
-		// two buffers: one for the nulls, the other for the values.
-		c.scratch.buffers[i] = make([]*memory.Buffer, 2)
+		// Most types need only two buffers: one for the nulls, and one for the
+		// values, but some type (i.e. Bytes) need an extra buffer for the offsets.
+		c.scratch.buffers[i] = make([]*memory.Buffer, 0, 3)
 	}
 	return c, nil
 }
@@ -117,20 +112,11 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]*array.Data, 
 			arrowBitmap = n.NullBitmap()
 		}
 
-		if typ == coltypes.Bool || typ == coltypes.Bytes {
-			// Bools and Bytes are handled differently from other coltypes. Refer to the
-			// comment on ArrowBatchConverter.builders for more information.
-			var data *array.Data
-			switch typ {
-			case coltypes.Bool:
-				c.builders.boolBuilder.AppendValues(vec.Bool()[:n], nil /* valid */)
-				data = c.builders.boolBuilder.NewBooleanArray().Data()
-			case coltypes.Bytes:
-				c.builders.binaryBuilder.AppendValues(vec.Bytes().PrimitiveRepr()[:n], nil /* valid */)
-				data = c.builders.binaryBuilder.NewBinaryArray().Data()
-			default:
-				panic(fmt.Sprintf("unexpected type %s", typ))
-			}
+		if typ == coltypes.Bool {
+			// Bools are handled differently from other types. Refer to the comment on
+			// ArrowBatchConverter.builders for more information.
+			c.builders.boolBuilder.AppendValues(vec.Bool()[:n], nil /* valid */)
+			data := c.builders.boolBuilder.NewBooleanArray().Data()
 			if arrowBitmap != nil {
 				// Overwrite empty null bitmap with the true bitmap.
 				data.Buffers()[0] = memory.NewBufferBytes(arrowBitmap)
@@ -140,7 +126,8 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]*array.Data, 
 		}
 
 		var (
-			values []byte
+			values  []byte
+			offsets []byte
 			// dataHeader is the reflect.SliceHeader of the coldata.Vec's underlying
 			// data slice that we are casting to bytes.
 			dataHeader *reflect.SliceHeader
@@ -149,6 +136,15 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]*array.Data, 
 		)
 
 		switch typ {
+		case coltypes.Bytes:
+			var int32Offsets []int32
+			values, int32Offsets = vec.Bytes().ToArrowSerializationFormat(n)
+			// Cast int32Offsets to []byte.
+			int32Header := (*reflect.SliceHeader)(unsafe.Pointer(&int32Offsets))
+			offsetsHeader := (*reflect.SliceHeader)(unsafe.Pointer(&offsets))
+			offsetsHeader.Data = int32Header.Data
+			offsetsHeader.Len = int32Header.Len * sizeOfInt32
+			offsetsHeader.Cap = int32Header.Cap * sizeOfInt32
 		case coltypes.Int8:
 			ints := vec.Int8()[:n]
 			dataHeader = (*reflect.SliceHeader)(unsafe.Pointer(&ints))
@@ -177,16 +173,22 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]*array.Data, 
 			panic(fmt.Sprintf("unsupported type for conversion to arrow data %s", typ))
 		}
 
-		// Cast values.
-		valuesHeader := (*reflect.SliceHeader)(unsafe.Pointer(&values))
-		valuesHeader.Data = dataHeader.Data
-		valuesHeader.Len = dataHeader.Len * datumSize
-		valuesHeader.Cap = dataHeader.Cap * datumSize
+		// Cast values if not set (mostly for non-byte types).
+		if values == nil {
+			valuesHeader := (*reflect.SliceHeader)(unsafe.Pointer(&values))
+			valuesHeader.Data = dataHeader.Data
+			valuesHeader.Len = dataHeader.Len * datumSize
+			valuesHeader.Cap = dataHeader.Cap * datumSize
+		}
 
 		// Construct the underlying arrow buffers.
 		// WARNING: The ordering of construction is critical.
-		c.scratch.buffers[i][0] = memory.NewBufferBytes(arrowBitmap)
-		c.scratch.buffers[i][1] = memory.NewBufferBytes(values)
+		c.scratch.buffers[i] = c.scratch.buffers[i][:0]
+		c.scratch.buffers[i] = append(c.scratch.buffers[i], memory.NewBufferBytes(arrowBitmap))
+		if offsets != nil {
+			c.scratch.buffers[i] = append(c.scratch.buffers[i], memory.NewBufferBytes(offsets))
+		}
+		c.scratch.buffers[i] = append(c.scratch.buffers[i], memory.NewBufferBytes(values))
 
 		// Create the data from the buffers. It might be surprising that we don't
 		// set a type or a null count, but these fields are not used in the way that
@@ -249,11 +251,7 @@ func (c *ArrowBatchConverter) ArrowToBatch(data []*array.Data, b coldata.Batch) 
 					// corresponds.
 					bytes = make([]byte, 0)
 				}
-				offsets := bytesArr.ValueOffsets()
-				vecArr := vec.Bytes()
-				for i := 0; i < len(offsets)-1; i++ {
-					vecArr.Set(i, bytes[offsets[i]:offsets[i+1]])
-				}
+				coldata.BytesFromArrowSerializationFormat(vec.Bytes(), bytes, bytesArr.ValueOffsets())
 				arr = bytesArr
 			default:
 				panic(fmt.Sprintf("unexpected type %s", typ))

--- a/pkg/col/colserde/arrowbatchconverter_test.go
+++ b/pkg/col/colserde/arrowbatchconverter_test.go
@@ -41,10 +41,18 @@ func randomBatch() ([]coltypes.T, coldata.Batch) {
 		typs[i] = availableTyps[rng.Intn(len(availableTyps))]
 	}
 
-	b := exec.RandomBatch(rng, typs, rng.Intn(coldata.BatchSize)+1, rng.Float64())
+	capacity := rng.Intn(coldata.BatchSize) + 1
+	length := rng.Intn(capacity)
+	b := exec.RandomBatch(rng, typs, capacity, length, rng.Float64())
 	return typs, b
 }
 
+// copyBatch copies the original batch. However, to increase test coverage, only
+// use the returned batch to assert equality, not as an input to a testing
+// function, since Copy simplifies the internals (e.g. if there are zero
+// elements to copy, copyBatch returns a zero-capacity batch, which is less
+// interesting than testing a batch with a different capacity of BatchSize but
+// zero elements).
 func copyBatch(original coldata.Batch) coldata.Batch {
 	typs := make([]coltypes.T, original.Width())
 	for i, vec := range original.ColVecs() {
@@ -78,11 +86,31 @@ func assertEqualBatches(t *testing.T, expected, actual coldata.Batch) {
 		// fail.
 		expectedVec := expected.ColVec(colIdx)
 		actualVec := actual.ColVec(colIdx)
+		typ := expectedVec.Type()
+		require.Equal(t, typ, actualVec.Type())
 		require.Equal(
 			t,
-			expectedVec.Slice(expectedVec.Type(), 0, uint64(expected.Length())),
-			actualVec.Slice(actualVec.Type(), 0, uint64(actual.Length())),
+			expectedVec.Nulls().Slice(0, uint64(expected.Length())),
+			actualVec.Nulls().Slice(0, uint64(actual.Length())),
 		)
+		if typ == coltypes.Bytes {
+			// Cannot use require.Equal for this type.
+			// TODO(asubiotto): Again, why not?
+			expectedBytes := expectedVec.Bytes().Slice(0, int(expected.Length()))
+			resultBytes := actualVec.Bytes().Slice(0, int(actual.Length()))
+			require.Equal(t, expectedBytes.Len(), resultBytes.Len())
+			for i := 0; i < expectedBytes.Len(); i++ {
+				if !bytes.Equal(expectedBytes.Get(i), resultBytes.Get(i)) {
+					t.Fatalf("bytes mismatch at index %d:\nexpected:\n%sactual:\n%s", i, expectedBytes, resultBytes)
+				}
+			}
+		} else {
+			require.Equal(
+				t,
+				expectedVec.Slice(expectedVec.Type(), 0, uint64(expected.Length())),
+				actualVec.Slice(actualVec.Type(), 0, uint64(actual.Length())),
+			)
+		}
 	}
 }
 
@@ -113,6 +141,34 @@ func TestArrowBatchConverterRandom(t *testing.T) {
 	assertEqualBatches(t, expected, actual)
 }
 
+// roundTripAndAssertEquality is a helper function that round trips a batch
+// through the ArrowBatchConverter and RecordBatchSerializer and asserts that
+// the output batch is equal to the input batch. Make sure to copy the input
+// batch before passing it to this function to assert equality.
+func roundTripBatch(
+	b coldata.Batch, c *ArrowBatchConverter, r *RecordBatchSerializer,
+) (coldata.Batch, error) {
+	var buf bytes.Buffer
+	arrowDataIn, err := c.BatchToArrow(b)
+	if err != nil {
+		return nil, err
+	}
+	_, _, err = r.Serialize(&buf, arrowDataIn)
+	if err != nil {
+		return nil, err
+	}
+
+	var arrowDataOut []*array.Data
+	if err := r.Deserialize(&arrowDataOut, buf.Bytes()); err != nil {
+		return nil, err
+	}
+	actual := coldata.NewMemBatchWithSize(nil, 0)
+	if err := c.ArrowToBatch(arrowDataOut, actual); err != nil {
+		return nil, err
+	}
+	return actual, nil
+}
+
 func TestRecordBatchRoundtripThroughBytes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -125,17 +181,8 @@ func TestRecordBatchRoundtripThroughBytes(t *testing.T) {
 	// Make a copy of the original batch because the converter modifies and casts
 	// data without copying for performance reasons.
 	expected := copyBatch(b)
-
-	var buf bytes.Buffer
-	arrowDataIn, err := c.BatchToArrow(b)
+	actual, err := roundTripBatch(b, c, r)
 	require.NoError(t, err)
-	_, _, err = r.Serialize(&buf, arrowDataIn)
-	require.NoError(t, err)
-
-	var arrowDataOut []*array.Data
-	require.NoError(t, r.Deserialize(&arrowDataOut, buf.Bytes()))
-	actual := coldata.NewMemBatchWithSize(nil, 0)
-	require.NoError(t, c.ArrowToBatch(arrowDataOut, actual))
 
 	assertEqualBatches(t, expected, actual)
 }
@@ -154,7 +201,7 @@ func BenchmarkArrowBatchConverter(b *testing.B) {
 	numBytes := []int64{coldata.BatchSize, fixedLen * coldata.BatchSize, 8 * coldata.BatchSize}
 	// Run a benchmark on every type we care about.
 	for typIdx, typ := range typs {
-		batch := exec.RandomBatch(rng, []coltypes.T{typ}, coldata.BatchSize, 0 /* nullProbability */)
+		batch := exec.RandomBatch(rng, []coltypes.T{typ}, coldata.BatchSize, 0 /* length */, 0 /* nullProbability */)
 		if batch.Width() != 1 {
 			b.Fatalf("unexpected batch width: %d", batch.Width())
 		}

--- a/pkg/col/coltypes/types.go
+++ b/pkg/col/coltypes/types.go
@@ -153,9 +153,16 @@ func (t T) GoTypeSliceName() string {
 }
 
 // Get is a function that should only be used in templates.
-func (t T) Get(target, i string) string {
+func (t T) Get(safe string, target, i string) string {
+	if safe != "safe" && safe != "unsafe" {
+		panic(fmt.Sprintf("unknown safe argument %s, use either safe or unsafe", safe))
+	}
 	if t == Bytes {
-		return fmt.Sprintf("%s.Get(%s)", target, i)
+		getString := fmt.Sprintf("%s.Get(%s)", target, i)
+		if safe == "safe" {
+			getString = "append([]byte(nil), " + getString + "...)"
+		}
+		return getString
 	}
 	return fmt.Sprintf("%s[%s]", target, i)
 }

--- a/pkg/sql/exec/any_not_null_agg_tmpl.go
+++ b/pkg/sql/exec/any_not_null_agg_tmpl.go
@@ -57,7 +57,7 @@ const _TYPES_T = coltypes.Unhandled
 // */}}
 
 // Use execgen package to remove unused import warning.
-var _ interface{} = execgen.GET
+var _ interface{} = execgen.UNSAFEGET
 
 // {{range .}}
 
@@ -183,7 +183,7 @@ func _FIND_ANY_NOT_NULL(a *anyNotNull_TYPEAgg, nulls *coldata.Nulls, i int, _HAS
 		// Explicit template language is used here because the type receiver differs
 		// from the rest of the template file.
 		// TODO(asubiotto): Figure out a way to alias this.
-		// v := {{ .Global.Get "col" "int(i)" }}
+		// v := {{ .Global.Get "unsafe" "col" "int(i)" }}
 		// {{ .Global.Set "a.vec" "a.curIdx" "v" }}
 		a.foundNonNullForCurrentGroup = true
 	}

--- a/pkg/sql/exec/const_tmpl.go
+++ b/pkg/sql/exec/const_tmpl.go
@@ -48,7 +48,7 @@ type _GOTYPE interface{}
 // */}}
 
 // Use execgen package to remove unused import warning.
-var _ interface{} = execgen.GET
+var _ interface{} = execgen.UNSAFEGET
 
 // NewConstOp creates a new operator that produces a constant value constVal of
 // type t at index outputIdx.

--- a/pkg/sql/exec/count.go
+++ b/pkg/sql/exec/count.go
@@ -53,7 +53,7 @@ func (c *countOp) Init() {
 }
 
 func (c *countOp) Next(ctx context.Context) coldata.Batch {
-	c.internalBatch.SetSelection(false)
+	c.internalBatch.ResetInternalBatch()
 	if c.done {
 		c.internalBatch.SetLength(0)
 		return c.internalBatch

--- a/pkg/sql/exec/deselector.go
+++ b/pkg/sql/exec/deselector.go
@@ -51,7 +51,7 @@ func (p *deselectorOp) Next(ctx context.Context) coldata.Batch {
 	}
 
 	p.output.SetLength(batch.Length())
-	p.output.SetSelection(false)
+	p.output.ResetInternalBatch()
 	sel := batch.Selection()
 	for i, t := range p.inputTypes {
 		toCol := p.output.ColVec(i)

--- a/pkg/sql/exec/distinct_tmpl.go
+++ b/pkg/sql/exec/distinct_tmpl.go
@@ -133,7 +133,7 @@ func _ASSIGN_NE(_ bool, _, _ _GOTYPE) bool {
 // */}}
 
 // Use execgen package to remove unused import warning.
-var _ interface{} = execgen.GET
+var _ interface{} = execgen.UNSAFEGET
 
 func newSingleOrderedDistinct(
 	input Operator, distinctColIdx int, outputCol []bool, t coltypes.T,
@@ -362,7 +362,7 @@ func _CHECK_DISTINCT(
 ) { // */}}
 
 	// {{define "checkDistinct"}}
-	v := execgen.GET(col, int(checkIdx))
+	v := execgen.UNSAFEGET(col, int(checkIdx))
 	var unique bool
 	_ASSIGN_NE(unique, v, lastVal)
 	outputCol[outputIdx] = outputCol[outputIdx] || unique
@@ -388,7 +388,7 @@ func _CHECK_DISTINCT_WITH_NULLS(
 
 	// {{define "checkDistinctWithNulls"}}
 	null := nulls.NullAt(uint16(checkIdx))
-	v := execgen.GET(col, int(checkIdx))
+	v := execgen.UNSAFEGET(col, int(checkIdx))
 	if null != lastValNull {
 		// Either the current value is null and the previous was not or vice-versa.
 		outputCol[outputIdx] = true

--- a/pkg/sql/exec/distinct_tmpl.go
+++ b/pkg/sql/exec/distinct_tmpl.go
@@ -362,7 +362,7 @@ func _CHECK_DISTINCT(
 ) { // */}}
 
 	// {{define "checkDistinct"}}
-	v := execgen.UNSAFEGET(col, int(checkIdx))
+	v := execgen.GET(col, int(checkIdx))
 	var unique bool
 	_ASSIGN_NE(unique, v, lastVal)
 	outputCol[outputIdx] = outputCol[outputIdx] || unique
@@ -388,7 +388,7 @@ func _CHECK_DISTINCT_WITH_NULLS(
 
 	// {{define "checkDistinctWithNulls"}}
 	null := nulls.NullAt(uint16(checkIdx))
-	v := execgen.UNSAFEGET(col, int(checkIdx))
+	v := execgen.GET(col, int(checkIdx))
 	if null != lastValNull {
 		// Either the current value is null and the previous was not or vice-versa.
 		outputCol[outputIdx] = true

--- a/pkg/sql/exec/execgen/cmd/execgen/data_manipulation_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/data_manipulation_gen.go
@@ -25,9 +25,14 @@ type dataManipulationReplacementInfo struct {
 
 var dataManipulationReplacementInfos = []dataManipulationReplacementInfo{
 	{
+		templatePlaceholder: "execgen.UNSAFEGET",
+		numArgs:             2,
+		replaceWith:         "Get \"unsafe\"",
+	},
+	{
 		templatePlaceholder: "execgen.GET",
 		numArgs:             2,
-		replaceWith:         "Get",
+		replaceWith:         "Get \"safe\"",
 	},
 	{
 		templatePlaceholder: "execgen.SET",

--- a/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
@@ -68,7 +68,7 @@ func (p {{template "opRConstName" .}}) Next(ctx context.Context) coldata.Batch {
 	projCol := projVec.{{.RetTyp}}()
 	if sel := batch.Selection(); sel != nil {
 		for _, i := range sel {
-			arg := {{.LTyp.Get "col" "int(i)"}}
+			arg := {{.LTyp.Get "unsafe" "col" "int(i)"}}
 			{{(.Assign "projCol[i]" "arg" "p.constArg")}}
 		}
 	} else {
@@ -76,7 +76,7 @@ func (p {{template "opRConstName" .}}) Next(ctx context.Context) coldata.Batch {
 		colLen := {{.LTyp.Len "col"}}
 		_ = projCol[colLen-1]
 		for {{.LTyp.Range "i" "col"}} {
-			arg := {{.LTyp.Get "col" "i"}}
+			arg := {{.LTyp.Get "unsafe" "col" "i"}}
 			{{(.Assign "projCol[i]" "arg" "p.constArg")}}
 		}
 	}
@@ -121,7 +121,7 @@ func (p {{template "opLConstName" .}}) Next(ctx context.Context) coldata.Batch {
 	projCol := projVec.{{.RetTyp}}()
 	if sel := batch.Selection(); sel != nil {
 		for _, i := range sel {
-			arg := {{.RTyp.Get "col" "int(i)"}}
+			arg := {{.RTyp.Get "unsafe" "col" "int(i)"}}
 			{{(.Assign "projCol[i]" "p.constArg" "arg")}}
 		}
 	} else {
@@ -129,7 +129,7 @@ func (p {{template "opLConstName" .}}) Next(ctx context.Context) coldata.Batch {
 		colLen := {{.RTyp.Len "col"}}
 		_ = projCol[colLen-1]
 		for {{.RTyp.Range "i" "col"}} {
-			arg := {{.RTyp.Get "col" "i"}}
+			arg := {{.RTyp.Get "unsafe" "col" "i"}}
 			{{(.Assign "projCol[i]" "p.constArg" "arg")}}
 		}
 	}
@@ -176,8 +176,8 @@ func (p {{template "opName" .}}) Next(ctx context.Context) coldata.Batch {
 	col2 := vec2.{{.RTyp}}()
 	if sel := batch.Selection(); sel != nil {
 		for _, i := range sel {
-			arg1 := {{.LTyp.Get "col1" "int(i)"}}
-			arg2 := {{.RTyp.Get "col2" "int(i)"}}
+			arg1 := {{.LTyp.Get "unsafe" "col1" "int(i)"}}
+			arg2 := {{.RTyp.Get "unsafe" "col2" "int(i)"}}
 			{{(.Assign "projCol[i]" "arg1" "arg2")}}
 		}
 	} else {
@@ -186,8 +186,8 @@ func (p {{template "opName" .}}) Next(ctx context.Context) coldata.Batch {
 		_ = projCol[colLen-1]
 		_ = {{.LTyp.Slice "col2" "0" "colLen-1"}}
 		for {{.LTyp.Range "i" "col1"}} {
-			arg1 := {{.LTyp.Get "col1" "i"}}
-			arg2 := {{.LTyp.Get "col2" "i"}}
+			arg1 := {{.LTyp.Get "unsafe" "col1" "i"}}
+			arg2 := {{.LTyp.Get "unsafe" "col2" "i"}}
 			{{(.Assign "projCol[i]" "arg1" "arg2")}}
 		}
 	}

--- a/pkg/sql/exec/execgen/cmd/execgen/selection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/selection_ops_gen.go
@@ -42,7 +42,7 @@ if sel := batch.Selection(); sel != nil {
 	sel = sel[:n]
 	for _, i := range sel {
 		var cmp bool
-		arg := {{.Global.LTyp.Get "col" "int(i)"}}
+		arg := {{.Global.LTyp.Get "unsafe" "col" "int(i)"}}
 		{{(.Global.Assign "cmp" "arg" "p.constArg")}}
 		if cmp {{if .HasNulls}}&& !nulls.NullAt(i) {{end}}{
 			sel[idx] = i
@@ -55,7 +55,7 @@ if sel := batch.Selection(); sel != nil {
 	col = {{.Global.LTyp.Slice "col" "0" "int(n)"}}
 	for {{.Global.LTyp.Range "i" "col"}} {
 		var cmp bool
-		arg := {{.Global.LTyp.Get "col" "i"}}
+		arg := {{.Global.LTyp.Get "unsafe" "col" "i"}}
 		{{(.Global.Assign "cmp" "arg" "p.constArg")}}
 		if cmp {{if .HasNulls}}&& !nulls.NullAt(uint16(i)) {{end}}{
 			sel[idx] = uint16(i)
@@ -70,8 +70,8 @@ if sel := batch.Selection(); sel != nil {
 	sel = sel[:n]
 	for _, i := range sel {
 		var cmp bool
-		arg1 := {{.Global.LTyp.Get "col1" "int(i)"}}
-		arg2 := {{.Global.RTyp.Get "col2" "int(i)"}}
+		arg1 := {{.Global.LTyp.Get "unsafe" "col1" "int(i)"}}
+		arg2 := {{.Global.RTyp.Get "unsafe" "col2" "int(i)"}}
 		{{(.Global.Assign "cmp" "arg1" "arg2")}}
 		if cmp {{if .HasNulls}}&& !nulls.NullAt(i) {{end}}{
 			sel[idx] = i
@@ -86,8 +86,8 @@ if sel := batch.Selection(); sel != nil {
 	col2 = {{.Global.RTyp.Slice "col2" "0" "col1Len"}}
 	for {{.Global.LTyp.Range "i" "col1"}} {
 		var cmp bool
-		arg1 := {{.Global.LTyp.Get "col1" "i"}}
-		arg2 := {{.Global.RTyp.Get "col2" "i"}}
+		arg1 := {{.Global.LTyp.Get "unsafe" "col1" "i"}}
+		arg2 := {{.Global.RTyp.Get "unsafe" "col2" "i"}}
 		{{(.Global.Assign "cmp" "arg1" "arg2")}}
 		if cmp {{if .HasNulls}}&& !nulls.NullAt(uint16(i)) {{end}}{
 			sel[idx] = uint16(i)

--- a/pkg/sql/exec/execgen/placeholders.go
+++ b/pkg/sql/exec/execgen/placeholders.go
@@ -16,6 +16,7 @@ const nonTemplatePanic = "do not call from non-template code"
 
 // Remove unused warnings.
 var (
+	_ = UNSAFEGET
 	_ = GET
 	_ = SET
 	_ = SWAP
@@ -28,7 +29,16 @@ var (
 	_ = RANGE
 )
 
-// GET is a template function.
+// UNSAFEGET is a template function. Use this if you are not keeping data around
+// (including passing it to SET).
+func UNSAFEGET(target, i interface{}) interface{} {
+	execerror.VectorizedInternalPanic(nonTemplatePanic)
+	return nil
+}
+
+// GET is a template function. The Bytes implementation of this function
+// performs a copy. Use this if you need to keep values around past the
+// lifecycle of a Batch.
 func GET(target, i interface{}) interface{} {
 	execerror.VectorizedInternalPanic(nonTemplatePanic)
 	return nil

--- a/pkg/sql/exec/hashjoiner.go
+++ b/pkg/sql/exec/hashjoiner.go
@@ -248,6 +248,7 @@ func (hj *hashJoinEqOp) Init() {
 }
 
 func (hj *hashJoinEqOp) Next(ctx context.Context) coldata.Batch {
+	hj.prober.batch.ResetInternalBatch()
 	switch hj.runningState {
 	case hjBuilding:
 		hj.build(ctx)
@@ -259,12 +260,9 @@ func (hj *hashJoinEqOp) Next(ctx context.Context) coldata.Batch {
 			hj.initEmitting()
 			return hj.Next(ctx)
 		}
-
-		hj.prober.batch.SetSelection(false)
 		return hj.prober.batch
 	case hjEmittingUnmatched:
 		hj.emitUnmatched()
-		hj.prober.batch.SetSelection(false)
 		return hj.prober.batch
 	default:
 		execerror.VectorizedInternalPanic("hash joiner in unhandled state")

--- a/pkg/sql/exec/hashjoiner_tmpl.go
+++ b/pkg/sql/exec/hashjoiner_tmpl.go
@@ -76,9 +76,9 @@ const _SEL_IND = 0
 
 func _CHECK_COL_MAIN(ht *hashTable, buildKeys, probeKeys []interface{}, keyID uint64, i uint16) { // */}}
 	// {{define "checkColMain"}}
-	buildVal := execgen.GET(buildKeys, int(keyID-1))
+	buildVal := execgen.UNSAFEGET(buildKeys, int(keyID-1))
 	selIdx := _SEL_IND
-	probeVal := execgen.GET(probeKeys, int(selIdx))
+	probeVal := execgen.UNSAFEGET(probeKeys, int(selIdx))
 	var unique bool
 	_ASSIGN_NE(unique, buildVal, probeVal)
 
@@ -186,7 +186,7 @@ func _REHASH_BODY(
 		}
 		// {{ end }}
 		selIdx := _SEL_IND
-		v := execgen.GET(keys, int(selIdx))
+		v := execgen.UNSAFEGET(keys, int(selIdx))
 		p := uintptr(buckets[i])
 		_ASSIGN_HASH(p, v)
 		buckets[i] = uint64(p)
@@ -295,7 +295,7 @@ func _DISTINCT_COLLECT_NO_OUTER(
 // */}}
 
 // Use execgen package to remove unused import warning.
-var _ interface{} = execgen.GET
+var _ interface{} = execgen.UNSAFEGET
 
 // rehash takes an element of a key (tuple representing a row of equality
 // column values) at a given column and computes a new hash by applying a

--- a/pkg/sql/exec/mergejoiner_tmpl.go
+++ b/pkg/sql/exec/mergejoiner_tmpl.go
@@ -96,7 +96,7 @@ const _MJ_OVERLOAD = 0
 // */}}
 
 // Use execgen package to remove unused import warning.
-var _ interface{} = execgen.GET
+var _ interface{} = execgen.UNSAFEGET
 
 // {{ range $joinType := .JoinTypes }}
 type mergeJoin_JOIN_TYPE_STRINGOp struct {
@@ -152,9 +152,9 @@ func _PROBE_SWITCH(
 				// {{ end }}
 
 				lSelIdx := _L_SEL_IND
-				lVal := execgen.GET(lKeys, int(lSelIdx))
+				lVal := execgen.UNSAFEGET(lKeys, int(lSelIdx))
 				rSelIdx := _R_SEL_IND
-				rVal := execgen.GET(rKeys, int(rSelIdx))
+				rVal := execgen.UNSAFEGET(rKeys, int(rSelIdx))
 
 				var match bool
 				_ASSIGN_EQ("match", "lVal", "rVal")
@@ -177,7 +177,7 @@ func _PROBE_SWITCH(
 							}
 							// {{ end }}
 							lSelIdx := _L_SEL_IND
-							newLVal := execgen.GET(lKeys, int(lSelIdx))
+							newLVal := execgen.UNSAFEGET(lKeys, int(lSelIdx))
 							_ASSIGN_EQ("match", "newLVal", "lVal")
 							if !match {
 								lComplete = true
@@ -201,7 +201,7 @@ func _PROBE_SWITCH(
 							}
 							// {{ end }}
 							rSelIdx := _R_SEL_IND
-							newRVal := execgen.GET(rKeys, int(rSelIdx))
+							newRVal := execgen.UNSAFEGET(rKeys, int(rSelIdx))
 							_ASSIGN_EQ("match", "newRVal", "rVal")
 							if !match {
 								rComplete = true
@@ -426,7 +426,7 @@ func _INCREMENT_LEFT_SWITCH(
 		}
 		// {{ end }}
 		lSelIdx = _L_SEL_IND
-		newLVal := execgen.GET(lKeys, int(lSelIdx))
+		newLVal := execgen.UNSAFEGET(lKeys, int(lSelIdx))
 		// {{with _MJ_OVERLOAD}}
 		_ASSIGN_EQ("match", "newLVal", "lVal")
 		// {{end}}
@@ -484,7 +484,7 @@ func _INCREMENT_RIGHT_SWITCH(
 		}
 		// {{ end }}
 		rSelIdx = _R_SEL_IND
-		newRVal := execgen.GET(rKeys, int(rSelIdx))
+		newRVal := execgen.UNSAFEGET(rKeys, int(rSelIdx))
 		// {{with _MJ_OVERLOAD}}
 		_ASSIGN_EQ("match", "newRVal", "rVal")
 		// {{end}}
@@ -660,7 +660,7 @@ func _LEFT_SWITCH(_JOIN_TYPE joinTypeInfo, _HAS_SELECTION bool, _HAS_NULLS bool)
 					// {{ end }}
 
 					if !isNull {
-						val = execgen.GET(srcCol, srcStartIdx)
+						val = execgen.UNSAFEGET(srcCol, srcStartIdx)
 						for i := 0; i < toAppend; i++ {
 							execgen.SET(outCol, outStartIdx, val)
 							outStartIdx++
@@ -805,16 +805,16 @@ func _RIGHT_SWITCH(_JOIN_TYPE joinTypeInfo, _HAS_SELECTION bool, _HAS_NULLS bool
 					// instead of copy.
 					if toAppend == 1 {
 						// {{ if _HAS_SELECTION }}
-						v := execgen.GET(srcCol, int(sel[o.builderState.right.curSrcStartIdx]))
+						v := execgen.UNSAFEGET(srcCol, int(sel[o.builderState.right.curSrcStartIdx]))
 						execgen.SET(outCol, outStartIdx, v)
 						// {{ else }}
-						v := execgen.GET(srcCol, o.builderState.right.curSrcStartIdx)
+						v := execgen.UNSAFEGET(srcCol, o.builderState.right.curSrcStartIdx)
 						execgen.SET(outCol, outStartIdx, v)
 						// {{ end }}
 					} else {
 						// {{ if _HAS_SELECTION }}
 						for i := 0; i < toAppend; i++ {
-							v := execgen.GET(srcCol, int(sel[i+o.builderState.right.curSrcStartIdx]))
+							v := execgen.UNSAFEGET(srcCol, int(sel[i+o.builderState.right.curSrcStartIdx]))
 							execgen.SET(outCol, i+outStartIdx, v)
 						}
 						// {{ else }}
@@ -951,13 +951,13 @@ func (o *mergeJoinBase) isBufferedGroupFinished(
 				return true
 			}
 			bufferedCol := bufferedGroup.ColVec(int(colIdx))._TemplateType()
-			prevVal := execgen.GET(bufferedCol, int(lastBufferedTupleIdx))
+			prevVal := execgen.UNSAFEGET(bufferedCol, int(lastBufferedTupleIdx))
 			var curVal _GOTYPE
 			if batch.ColVec(int(colIdx)).MaybeHasNulls() && batch.ColVec(int(colIdx)).Nulls().NullAt64(tupleToLookAtIdx) {
 				return true
 			}
 			col := batch.ColVec(int(colIdx))._TemplateType()
-			curVal = execgen.GET(col, int(tupleToLookAtIdx))
+			curVal = execgen.UNSAFEGET(col, int(tupleToLookAtIdx))
 			var match bool
 			_ASSIGN_EQ("match", "prevVal", "curVal")
 			if !match {

--- a/pkg/sql/exec/mergejoiner_tmpl.go
+++ b/pkg/sql/exec/mergejoiner_tmpl.go
@@ -1225,6 +1225,7 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next(ctx context.Context) coldata.Batch {
 		case mjEntry:
 			if o.needToResetOutput {
 				o.needToResetOutput = false
+				o.output.ResetInternalBatch()
 				for _, vec := range o.output.ColVecs() {
 					// We only need to explicitly reset nulls since the values will be
 					// copied over and the correct length will be set.
@@ -1264,7 +1265,6 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next(ctx context.Context) coldata.Batch {
 			}
 
 			if o.outputReady || o.builderState.outCount == o.outputBatchSize {
-				o.output.SetSelection(false)
 				o.output.SetLength(o.builderState.outCount)
 				// Reset builder out count.
 				o.builderState.outCount = uint16(0)

--- a/pkg/sql/exec/mergejoiner_util.go
+++ b/pkg/sql/exec/mergejoiner_util.go
@@ -276,7 +276,13 @@ func (bg *mjBufferedGroup) Reset(types []coltypes.T, length int) {
 }
 
 // ResetInternalBatch implements the Batch interface.
-func (bg *mjBufferedGroup) ResetInternalBatch() {}
+func (bg *mjBufferedGroup) ResetInternalBatch() {
+	for _, v := range bg.colVecs {
+		if v.Type() == coltypes.Bytes {
+			v.Bytes().Reset()
+		}
+	}
+}
 
 // reset resets the state of the buffered group so that we can reuse the
 // underlying memory.

--- a/pkg/sql/exec/mergejoiner_util.go
+++ b/pkg/sql/exec/mergejoiner_util.go
@@ -275,6 +275,9 @@ func (bg *mjBufferedGroup) Reset(types []coltypes.T, length int) {
 	execerror.VectorizedInternalPanic("Reset([]coltypes.T, int) should not be called on mjBufferedGroup")
 }
 
+// ResetInternalBatch implements the Batch interface.
+func (bg *mjBufferedGroup) ResetInternalBatch() {}
+
 // reset resets the state of the buffered group so that we can reuse the
 // underlying memory.
 func (bg *mjBufferedGroup) reset() {
@@ -285,4 +288,5 @@ func (bg *mjBufferedGroup) reset() {
 		// written over, but we do need to reset the nulls.
 		colVec.Nulls().UnsetNulls()
 	}
+	bg.ResetInternalBatch()
 }

--- a/pkg/sql/exec/min_max_agg_tmpl.go
+++ b/pkg/sql/exec/min_max_agg_tmpl.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+
 	// {{/*
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	// */}}
@@ -64,7 +65,7 @@ func _ASSIGN_CMP(_, _, _ string) bool {
 // */}}
 
 // Use execgen package to remove unused import warning.
-var _ interface{} = execgen.GET
+var _ interface{} = execgen.UNSAFEGET
 
 // {{range .}} {{/* for each aggregation (min and max) */}}
 
@@ -209,7 +210,7 @@ func _ACCUMULATE_MINMAX(a *_AGG_TYPEAgg, nulls *coldata.Nulls, i int, _HAS_NULLS
 		// The next element of vec is guaranteed  to be initialized to the zero
 		// value. We can't use zero_TYPEColumn here because this is outside of
 		// the earlier template block.
-		a.curAgg = execgen.GET(a.vec, a.curIdx)
+		a.curAgg = execgen.UNSAFEGET(a.vec, a.curIdx)
 	}
 	var isNull bool
 	// {{ if .HasNulls }}
@@ -219,11 +220,11 @@ func _ACCUMULATE_MINMAX(a *_AGG_TYPEAgg, nulls *coldata.Nulls, i int, _HAS_NULLS
 	// {{ end }}
 	if !isNull {
 		if !a.foundNonNullForCurrentGroup {
-			a.curAgg = execgen.GET(col, int(i))
+			a.curAgg = execgen.UNSAFEGET(col, int(i))
 			a.foundNonNullForCurrentGroup = true
 		} else {
 			var cmp bool
-			candidate := execgen.GET(col, int(i))
+			candidate := execgen.UNSAFEGET(col, int(i))
 			_ASSIGN_CMP("cmp", "candidate", "a.curAgg")
 			if cmp {
 				a.curAgg = candidate

--- a/pkg/sql/exec/min_max_agg_tmpl.go
+++ b/pkg/sql/exec/min_max_agg_tmpl.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
-
 	// {{/*
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	// */}}

--- a/pkg/sql/exec/orderedsynchronizer.go
+++ b/pkg/sql/exec/orderedsynchronizer.go
@@ -75,6 +75,7 @@ func (o *OrderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 			o.updateComparators(i)
 		}
 	}
+	o.output.ResetInternalBatch()
 	outputIdx := uint16(0)
 	for outputIdx < coldata.BatchSize {
 		// Determine the batch with the smallest row.
@@ -123,7 +124,6 @@ func (o *OrderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 
 		outputIdx++
 	}
-	o.output.SetSelection(false)
 	o.output.SetLength(outputIdx)
 	return o.output
 }

--- a/pkg/sql/exec/random_testutils.go
+++ b/pkg/sql/exec/random_testutils.go
@@ -132,21 +132,11 @@ func randomSel(rng *rand.Rand, batchSize uint16, probOfOmitting float64) []uint1
 		execerror.VectorizedInternalPanic(fmt.Sprintf("probability of omitting a row is %f - outside of [0, 1] range", probOfOmitting))
 	}
 	sel := make([]uint16, batchSize)
-	used := make([]bool, batchSize)
 	for i := uint16(0); i < batchSize; i++ {
 		if rng.Float64() < probOfOmitting {
-			batchSize--
-			i--
 			continue
 		}
-		for {
-			j := uint16(rng.Intn(int(batchSize)))
-			if !used[j] {
-				used[j] = true
-				sel[i] = j
-				break
-			}
-		}
+		sel[i] = i
 	}
 	return sel[:batchSize]
 }

--- a/pkg/sql/exec/rowstovec_test.go
+++ b/pkg/sql/exec/rowstovec_test.go
@@ -85,6 +85,7 @@ func TestEncDatumRowsToColVecString(t *testing.T) {
 	vec := coldata.NewMemColumn(coltypes.Bytes, 2)
 	for _, width := range []int32{0, 25} {
 		ct := types.MakeString(width)
+		vec.Bytes().Reset()
 		if err := EncDatumRowsToColVec(rows, vec, 0 /* columnIdx */, ct, &alloc); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/exec/rowstovec_tmpl.go
+++ b/pkg/sql/exec/rowstovec_tmpl.go
@@ -78,7 +78,7 @@ func _ROWS_TO_COL_VEC(
 // */}}
 
 // Use execgen package to remove unused import warning.
-var _ interface{} = execgen.GET
+var _ interface{} = execgen.UNSAFEGET
 
 // EncDatumRowsToColVec converts one column from EncDatumRows to a column
 // vector. columnIdx is the 0-based index of the column in the EncDatumRows.

--- a/pkg/sql/exec/select_in_tmpl.go
+++ b/pkg/sql/exec/select_in_tmpl.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+
 	// {{/*
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	// */}}
@@ -61,7 +62,7 @@ func _ASSIGN_EQ(_, _, _ interface{}) uint64 {
 // */}}
 
 // Use execgen package to remove unused import warning.
-var _ interface{} = execgen.GET
+var _ interface{} = execgen.UNSAFEGET
 
 // Enum used to represent comparison results
 type comparisonResult int
@@ -208,7 +209,7 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					v := execgen.GET(col, int(i))
+					v := execgen.UNSAFEGET(col, int(i))
 					if !nulls.NullAt(uint16(i)) && cmpIn_TYPE(v, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = uint16(i)
 						idx++
@@ -219,7 +220,7 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 				sel := batch.Selection()
 				col = execgen.SLICE(col, 0, int(n))
 				for execgen.RANGE(i, col) {
-					v := execgen.GET(col, i)
+					v := execgen.UNSAFEGET(col, i)
 					if !nulls.NullAt(uint16(i)) && cmpIn_TYPE(v, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = uint16(i)
 						idx++
@@ -230,7 +231,7 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					v := execgen.GET(col, int(i))
+					v := execgen.UNSAFEGET(col, int(i))
 					if cmpIn_TYPE(v, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = uint16(i)
 						idx++
@@ -241,7 +242,7 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 				sel := batch.Selection()
 				col = execgen.SLICE(col, 0, int(n))
 				for execgen.RANGE(i, col) {
-					v := execgen.GET(col, i)
+					v := execgen.UNSAFEGET(col, i)
 					if cmpIn_TYPE(v, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = uint16(i)
 						idx++
@@ -289,7 +290,7 @@ func (pi *projectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(uint16(i)) {
 					projNulls.SetNull(uint16(i))
 				} else {
-					v := execgen.GET(col, int(i))
+					v := execgen.UNSAFEGET(col, int(i))
 					cmpRes := cmpIn_TYPE(v, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
 						projNulls.SetNull(uint16(i))
@@ -304,7 +305,7 @@ func (pi *projectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 				if nulls.NullAt(uint16(i)) {
 					projNulls.SetNull(uint16(i))
 				} else {
-					v := execgen.GET(col, i)
+					v := execgen.UNSAFEGET(col, i)
 					cmpRes := cmpIn_TYPE(v, pi.filterRow, pi.hasNulls)
 					if cmpRes == siNull {
 						projNulls.SetNull(uint16(i))
@@ -318,7 +319,7 @@ func (pi *projectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				v := execgen.GET(col, int(i))
+				v := execgen.UNSAFEGET(col, int(i))
 				cmpRes := cmpIn_TYPE(v, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
 					projNulls.SetNull(uint16(i))
@@ -329,7 +330,7 @@ func (pi *projectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col = execgen.SLICE(col, 0, int(n))
 			for execgen.RANGE(i, col) {
-				v := execgen.GET(col, i)
+				v := execgen.UNSAFEGET(col, i)
 				cmpRes := cmpIn_TYPE(v, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {
 					projNulls.SetNull(uint16(i))

--- a/pkg/sql/exec/select_in_tmpl.go
+++ b/pkg/sql/exec/select_in_tmpl.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
-
 	// {{/*
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	// */}}

--- a/pkg/sql/exec/sort.go
+++ b/pkg/sql/exec/sort.go
@@ -242,7 +242,7 @@ func (p *sortOp) Next(ctx context.Context) coldata.Batch {
 		if newEmitted > p.input.getNumTuples() {
 			newEmitted = p.input.getNumTuples()
 		}
-		p.output.SetSelection(false)
+		p.output.ResetInternalBatch()
 		p.output.SetLength(uint16(newEmitted - p.emitted))
 		if p.output.Length() == 0 {
 			return p.output

--- a/pkg/sql/exec/sort_tmpl.go
+++ b/pkg/sql/exec/sort_tmpl.go
@@ -72,7 +72,7 @@ func _ASSIGN_LT(_, _, _ string) bool {
 // */}}
 
 // Use execgen package to remove unused import warning.
-var _ interface{} = execgen.GET
+var _ interface{} = execgen.UNSAFEGET
 
 func isSorterSupported(t coltypes.T, dir distsqlpb.Ordering_Column_Direction) bool {
 	switch t {
@@ -187,8 +187,8 @@ func (s *sort_TYPE_DIR_HANDLES_NULLSOp) Less(i, j int) bool {
 	// {{end}}
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := execgen.GET(s.sortCol, int(s.order[i]))
-	arg2 := execgen.GET(s.sortCol, int(s.order[j]))
+	arg1 := execgen.UNSAFEGET(s.sortCol, int(s.order[i]))
+	arg2 := execgen.UNSAFEGET(s.sortCol, int(s.order[j]))
 	_ASSIGN_LT("lt", "arg1", "arg2")
 	return lt
 }

--- a/pkg/sql/exec/sorttopk.go
+++ b/pkg/sql/exec/sorttopk.go
@@ -189,7 +189,7 @@ func (t *topKSorter) spool(ctx context.Context) {
 }
 
 func (t *topKSorter) emit() coldata.Batch {
-	t.output.SetSelection(false)
+	t.output.ResetInternalBatch()
 	toEmit := t.topK.Length() - t.emitted
 	if toEmit == 0 {
 		// We're done.

--- a/pkg/sql/exec/tuples_differ_tmpl.go
+++ b/pkg/sql/exec/tuples_differ_tmpl.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
-
 	// {{/*
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	// */}}

--- a/pkg/sql/exec/tuples_differ_tmpl.go
+++ b/pkg/sql/exec/tuples_differ_tmpl.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+
 	// {{/*
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	// */}}
@@ -64,7 +65,7 @@ func _ASSIGN_NE(_, _, _ string) bool {
 // */}}
 
 // Use execgen package to remove unused import warning.
-var _ interface{} = execgen.GET
+var _ interface{} = execgen.UNSAFEGET
 
 // tuplesDiffer takes in two ColVecs as well as tuple indices to check whether
 // the tuples differ.
@@ -82,8 +83,8 @@ func tuplesDiffer(
 		aCol := aColVec._TemplateType()
 		bCol := bColVec._TemplateType()
 		var unique bool
-		arg1 := execgen.GET(aCol, aTupleIdx)
-		arg2 := execgen.GET(bCol, bTupleIdx)
+		arg1 := execgen.UNSAFEGET(aCol, aTupleIdx)
+		arg2 := execgen.UNSAFEGET(bCol, bTupleIdx)
 		_ASSIGN_NE("unique", "arg1", "arg2")
 		*differ = *differ || unique
 		return nil

--- a/pkg/sql/exec/unorderedsynchronizer_test.go
+++ b/pkg/sql/exec/unorderedsynchronizer_test.go
@@ -43,7 +43,7 @@ func TestUnorderedSynchronizer(t *testing.T) {
 
 	inputs := make([]Operator, numInputs)
 	for i := range inputs {
-		source := NewRepeatableBatchSource(RandomBatch(rng, typs, coldata.BatchSize, rng.Float64()))
+		source := NewRepeatableBatchSource(RandomBatch(rng, typs, coldata.BatchSize, 0 /* length */, rng.Float64()))
 		source.ResetBatchesToReturn(numBatches)
 		inputs[i] = source
 	}

--- a/pkg/sql/exec/utils_test.go
+++ b/pkg/sql/exec/utils_test.go
@@ -245,7 +245,7 @@ func (s *opTestInput) Init() {
 }
 
 func (s *opTestInput) Next(context.Context) coldata.Batch {
-	s.batch.SetSelection(false)
+	s.batch.ResetInternalBatch()
 	if len(s.tuples) == 0 {
 		s.batch.SetLength(0)
 		return s.batch

--- a/pkg/sql/exec/utils_test.go
+++ b/pkg/sql/exec/utils_test.go
@@ -504,7 +504,7 @@ func (r *opTestOutput) next(ctx context.Context) tuple {
 		} else {
 			var val reflect.Value
 			if colBytes, ok := vec.Col().(*coldata.Bytes); ok {
-				val = reflect.ValueOf(colBytes.Get(int(curIdx)))
+				val = reflect.ValueOf(append([]byte(nil), colBytes.Get(int(curIdx))...))
 			} else {
 				val = reflect.ValueOf(vec.Col()).Index(int(curIdx))
 			}

--- a/pkg/sql/exec/vec_comparators_tmpl.go
+++ b/pkg/sql/exec/vec_comparators_tmpl.go
@@ -57,7 +57,7 @@ func _COMPARE(_, _, _ string) bool {
 // */}}
 
 // Use execgen package to remove unused import warning.
-var _ interface{} = execgen.GET
+var _ interface{} = execgen.UNSAFEGET
 
 // {{range .}}
 type _TYPEVecComparator struct {
@@ -75,8 +75,8 @@ func (c *_TYPEVecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 uint
 	} else if n2 {
 		return 1
 	}
-	left := execgen.GET(c.vecs[vecIdx1], int(valIdx1))
-	right := execgen.GET(c.vecs[vecIdx2], int(valIdx2))
+	left := execgen.UNSAFEGET(c.vecs[vecIdx1], int(valIdx1))
+	right := execgen.UNSAFEGET(c.vecs[vecIdx2], int(valIdx2))
 	var cmp int
 	_COMPARE("cmp", "left", "right")
 	return cmp
@@ -92,7 +92,7 @@ func (c *_TYPEVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx uint16
 		c.nulls[dstVecIdx].SetNull(dstIdx)
 	} else {
 		c.nulls[dstVecIdx].UnsetNull(dstIdx)
-		v := execgen.GET(c.vecs[srcVecIdx], int(srcIdx))
+		v := execgen.UNSAFEGET(c.vecs[srcVecIdx], int(srcIdx))
 		execgen.SET(c.vecs[dstVecIdx], int(dstIdx), v)
 	}
 }

--- a/pkg/sql/row/cfetcher.go
+++ b/pkg/sql/row/cfetcher.go
@@ -595,7 +595,7 @@ func (rf *CFetcher) NextBatch(ctx context.Context) (coldata.Batch, error) {
 			for i := range rf.machine.colvecs {
 				rf.machine.colvecs[i].Nulls().UnsetNulls()
 			}
-			rf.machine.batch.SetSelection(false)
+			rf.machine.batch.ResetInternalBatch()
 			rf.shiftState()
 		case stateDecodeFirstKVOfRow:
 			if rf.mustDecodeIndexKey || rf.traceKV {

--- a/pkg/workload/bulkingest/bulkingest.go
+++ b/pkg/workload/bulkingest/bulkingest.go
@@ -159,6 +159,7 @@ func (w *bulkingest) Tables() []workload.Table {
 				var payload []byte
 				payload, *alloc = alloc.Alloc(w.cCount*w.payloadBytes, 0 /* extraCap */)
 				randutil.ReadTestdataBytes(rng, payload)
+				payloadCol.Reset()
 				for rowIdx := 0; rowIdx < w.cCount; rowIdx++ {
 					c := rowIdx
 					off := c * w.payloadBytes

--- a/pkg/workload/tpcc/generate.go
+++ b/pkg/workload/tpcc/generate.go
@@ -629,6 +629,8 @@ func (w *tpcc) tpccOrderLineInitialRowBatch(
 	olAmountCol := cb.ColVec(8).Float64()
 	olDistInfoCol := cb.ColVec(9).Bytes()
 
+	olDeliveryDCol.Reset()
+	olDistInfoCol.Reset()
 	for rowIdx := 0; rowIdx < numOrderLines; rowIdx++ {
 		olNumber := rowIdx + 1
 


### PR DESCRIPTION
This gives us much faster serialization and the ability to account for memory used in O(1). Look at the individual commits for details.

Closes #37704