### PR TITLE
sql: don't close plan in recordStatementSummary

### DIFF
--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -162,12 +162,6 @@ func (ex *connExecutor) recordStatementSummary(
 		m.SQLServiceLatency.RecordValue(svcLatRaw.Nanoseconds())
 	}
 
-	// Close the plan if this was not done earlier.
-	// This also ensures that curPlan.savedPlanForStats is
-	// collected (see maybeSavePlan).
-	planner.curPlan.execErr = err
-	planner.curPlan.close(ctx)
-
 	planner.statsCollector.RecordStatement(
 		stmt, planner.curPlan.savedPlanForStats,
 		flags.IsSet(planFlagDistributed), flags.IsSet(planFlagOptUsed), flags.IsSet(planFlagImplicitTxn),


### PR DESCRIPTION
Local execution has been removed, so we no longer need to close plans
here. They are already closed by DistSQLPlanner.Run, which is used for
all queries.

See #33561

Release note: None