### PR TITLE
opt: fix incorrect span boundary from ConsolidateSpans

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -613,3 +613,24 @@ SELECT * FROM abc WHERE (c IS NULL OR c=2) AND a>0
 1  1  NULL
 1  2  NULL
 2  2  2
+
+# Regression test for #38878 (incorrect span generation with OR and exclusive
+# string boundaries).
+statement ok
+CREATE TABLE t38878 (k1 STRING, k2 STRING, v INT, PRIMARY KEY (k1, k2))
+
+statement ok
+INSERT INTO t38878 VALUES ('a', 'u', 1), ('b', 'v', 2), ('c', 'w', 3), ('d', 'x', 4), ('d', 'x2', 5)
+
+query TTI rowsort
+SELECT * FROM t38878 WHERE k1 = 'b' OR (k1 > 'b' AND k1 < 'd')
+----
+b  v  2
+c  w  3
+
+query TTI rowsort
+SELECT * FROM t38878 WHERE (k1 = 'd' AND k2 = 'x') OR k1 = 'b' OR (k1 > 'b' AND k1 < 'd')
+----
+b  v  2
+c  w  3
+d  x  4

--- a/pkg/sql/opt/constraint/constraint.go
+++ b/pkg/sql/opt/constraint/constraint.go
@@ -399,7 +399,9 @@ func (c *Constraint) ConsolidateSpans(evalCtx *tree.EvalContext) {
 					result.Append(c.Spans.Get(j))
 				}
 			}
-			result.Get(result.Count() - 1).end = sp.end
+			r := result.Get(result.Count() - 1)
+			r.end = sp.end
+			r.endBoundary = sp.endBoundary
 		} else {
 			if result.Count() != 0 {
 				result.Append(sp)

--- a/pkg/sql/opt/constraint/constraint_test.go
+++ b/pkg/sql/opt/constraint/constraint_test.go
@@ -298,6 +298,12 @@ func TestConsolidateSpans(t *testing.T) {
 			s: "[/1 - /2] [/3 - /4] [/5 - /6] [/8 - /9] [/10 - /11] [/12 - /13] [/15 - /16]",
 			e: "[/1 - /6] [/8 - /13] [/15 - /16]",
 		},
+		{
+			// Test that consolidating two spans preserves the correct type of ending
+			// boundary (#38878).
+			s: "[/1 - /2] [/3 - /5)",
+			e: "[/1 - /5)",
+		},
 	}
 
 	kc := testKeyContext(1, 2, -3)

--- a/pkg/sql/opt/idxconstraint/testdata/strings
+++ b/pkg/sql/opt/idxconstraint/testdata/strings
@@ -76,3 +76,16 @@ index-constraints vars=(string) index=(@1)
 ----
 [/'' - ]
 Remaining filter: @1 SIMILAR TO '.*'
+
+index-constraints vars=(string) index=(@1)
+@1 = 'eu' OR (@1 > 'eu' AND @1 < 'us')
+----
+[/'eu' - /'us')
+Remaining filter: (@1 = 'eu') OR (@1 > 'eu')
+
+index-constraints vars=(string, string) index=(@1, @2)
+(@1 = 'us' AND @2 = 'cali') OR (@1 = 'eu') OR (@1 > 'eu' AND @1 < 'us')
+----
+[/'eu' - /'us')
+[/'us'/'cali' - /'us'/'cali']
+Remaining filter: (((@1 = 'us') AND (@2 = 'cali')) OR (@1 = 'eu')) OR ((@1 > 'eu') AND (@1 < 'us'))


### PR DESCRIPTION
ConsolidateSpans has an omission: when consolidating two spans, it
doesn't copy the ending boundary of the right span. Fixing and adding
tests at multiple layers.

Fixes #38878.

Release note (bug fix): Fixed incorrect results, or "unordered span"
errors in some cases involving exclusive inequalities with non-numeric
types.