### PR TITLE
storage: clean up BatchRequest movement through storage stack

### DIFF
--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -804,12 +804,11 @@ func EnsureSafeSplitKey(key roachpb.Key) (roachpb.Key, error) {
 	return key[:idx], nil
 }
 
-// Range returns a key range encompassing the key ranges of all requests in the
-// Batch.
-func Range(ba roachpb.BatchRequest) (roachpb.RSpan, error) {
+// Range returns a key range encompassing the key ranges of all requests.
+func Range(reqs []roachpb.RequestUnion) (roachpb.RSpan, error) {
 	from := roachpb.RKeyMax
 	to := roachpb.RKeyMin
-	for _, arg := range ba.Requests {
+	for _, arg := range reqs {
 		req := arg.GetInner()
 		h := req.Header()
 		if !roachpb.IsRange(req) && len(h.EndKey) != 0 {

--- a/pkg/keys/keys_test.go
+++ b/pkg/keys/keys_test.go
@@ -474,7 +474,7 @@ func TestBatchRange(t *testing.T) {
 				Key: roachpb.Key(pair[0]), EndKey: roachpb.Key(pair[1]),
 			}})
 		}
-		if rs, err := Range(ba); err != nil {
+		if rs, err := Range(ba.Requests); err != nil {
 			t.Errorf("%d: %v", i, err)
 		} else if actPair := [2]string{string(rs.Key), string(rs.EndKey)}; !reflect.DeepEqual(actPair, c.exp) {
 			t.Errorf("%d: expected [%q,%q), got [%q,%q)", i, c.exp[0], c.exp[1], actPair[0], actPair[1])
@@ -503,7 +503,7 @@ func TestBatchError(t *testing.T) {
 		ba.Add(&roachpb.ScanRequest{RequestHeader: roachpb.RequestHeader{
 			Key: roachpb.Key(c.req[0]), EndKey: roachpb.Key(c.req[1]),
 		}})
-		if _, err := Range(ba); !testutils.IsError(err, c.errMsg) {
+		if _, err := Range(ba.Requests); !testutils.IsError(err, c.errMsg) {
 			t.Errorf("%d: unexpected error %v", i, err)
 		}
 	}
@@ -513,7 +513,7 @@ func TestBatchError(t *testing.T) {
 	ba.Add(&roachpb.GetRequest{RequestHeader: roachpb.RequestHeader{
 		Key: roachpb.Key("a"), EndKey: roachpb.Key("b"),
 	}})
-	if _, err := Range(ba); !testutils.IsError(err, "end key specified for non-range operation") {
+	if _, err := Range(ba.Requests); !testutils.IsError(err, "end key specified for non-range operation") {
 		t.Errorf("unexpected error %v", err)
 	}
 }

--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -703,7 +703,7 @@ func (ds *DistSender) Send(
 		// Local addressing has already been resolved.
 		// TODO(tschottdorf): consider rudimentary validation of the batch here
 		// (for example, non-range requests with EndKey, or empty key ranges).
-		rs, err := keys.Range(ba)
+		rs, err := keys.Range(ba.Requests)
 		if err != nil {
 			return nil, roachpb.NewError(err)
 		}
@@ -840,7 +840,7 @@ func (ds *DistSender) divideAndSendParallelCommit(
 	// over multiple ranges, so call into divideAndSendBatchToRanges.
 	qiBa := ba
 	qiBa.Requests = swappedReqs[swapIdx+1:]
-	qiRS, err := keys.Range(qiBa)
+	qiRS, err := keys.Range(qiBa.Requests)
 	if err != nil {
 		return br, roachpb.NewError(err)
 	}
@@ -882,7 +882,7 @@ func (ds *DistSender) divideAndSendParallelCommit(
 	// QueryIntent requests. Make sure to determine the request's
 	// new key span.
 	ba.Requests = swappedReqs[:swapIdx+1]
-	rs, err = keys.Range(ba)
+	rs, err = keys.Range(ba.Requests)
 	if err != nil {
 		return nil, roachpb.NewError(err)
 	}

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -1114,7 +1114,7 @@ func TestRetryOnWrongReplicaError(t *testing.T) {
 		_ ReplicaSlice,
 		ba roachpb.BatchRequest,
 	) (*roachpb.BatchResponse, error) {
-		rs, err := keys.Range(ba)
+		rs, err := keys.Range(ba.Requests)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1211,7 +1211,7 @@ func TestRetryOnWrongReplicaErrorWithSuggestion(t *testing.T) {
 		_ ReplicaSlice,
 		ba roachpb.BatchRequest,
 	) (*roachpb.BatchResponse, error) {
-		rs, err := keys.Range(ba)
+		rs, err := keys.Range(ba.Requests)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1652,7 +1652,7 @@ func TestMultiRangeMergeStaleDescriptor(t *testing.T) {
 		_ ReplicaSlice,
 		ba roachpb.BatchRequest,
 	) (*roachpb.BatchResponse, error) {
-		rs, err := keys.Range(ba)
+		rs, err := keys.Range(ba.Requests)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1867,7 +1867,7 @@ func TestTruncateWithSpanAndDescriptor(t *testing.T) {
 		_ ReplicaSlice,
 		ba roachpb.BatchRequest,
 	) (*roachpb.BatchResponse, error) {
-		rs, err := keys.Range(ba)
+		rs, err := keys.Range(ba.Requests)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3264,7 +3264,7 @@ func TestEvictMetaRange(t *testing.T) {
 			_ ReplicaSlice,
 			ba roachpb.BatchRequest,
 		) (*roachpb.BatchResponse, error) {
-			rs, err := keys.Range(ba)
+			rs, err := keys.Range(ba.Requests)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -3431,7 +3431,7 @@ func TestEvictionTokenCoalesce(t *testing.T) {
 		_ ReplicaSlice,
 		ba roachpb.BatchRequest,
 	) (*roachpb.BatchResponse, error) {
-		rs, err := keys.Range(ba)
+		rs, err := keys.Range(ba.Requests)
 		br := ba.CreateReply()
 		if err != nil {
 			br.Error = roachpb.NewError(err)

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1220,7 +1220,7 @@ func (r *Replica) executeAdminBatch(
 		return nil, roachpb.NewErrorf("only single-element admin batches allowed")
 	}
 
-	rSpan, err := keys.Range(ba)
+	rSpan, err := keys.Range(ba.Requests)
 	if err != nil {
 		return nil, roachpb.NewError(err)
 	}

--- a/pkg/storage/replica_backpressure.go
+++ b/pkg/storage/replica_backpressure.go
@@ -51,7 +51,7 @@ var backpressurableSpans = []roachpb.Span{
 
 // canBackpressureBatch returns whether the provided BatchRequest is eligible
 // for backpressure.
-func canBackpressureBatch(ba roachpb.BatchRequest) bool {
+func canBackpressureBatch(ba *roachpb.BatchRequest) bool {
 	// Don't backpressure splits themselves.
 	if ba.Txn != nil && ba.Txn.Name == splitTxnName {
 		return false
@@ -92,7 +92,7 @@ func (r *Replica) shouldBackpressureWrites() bool {
 
 // maybeBackpressureWriteBatch blocks to apply backpressure if the replica
 // deems that backpressure is necessary.
-func (r *Replica) maybeBackpressureWriteBatch(ctx context.Context, ba roachpb.BatchRequest) error {
+func (r *Replica) maybeBackpressureWriteBatch(ctx context.Context, ba *roachpb.BatchRequest) error {
 	if !canBackpressureBatch(ba) {
 		return nil
 	}

--- a/pkg/storage/replica_follower_read.go
+++ b/pkg/storage/replica_follower_read.go
@@ -35,7 +35,7 @@ var FollowerReadsEnabled = settings.RegisterBoolSetting(
 // acquired, whether the read only batch can be served as a follower
 // read despite the error.
 func (r *Replica) canServeFollowerRead(
-	ctx context.Context, ba roachpb.BatchRequest, pErr *roachpb.Error,
+	ctx context.Context, ba *roachpb.BatchRequest, pErr *roachpb.Error,
 ) *roachpb.Error {
 	canServeFollowerRead := false
 	if lErr, ok := pErr.GetDetail().(*roachpb.NotLeaseHolderError); ok &&

--- a/pkg/storage/replica_gossip.go
+++ b/pkg/storage/replica_gossip.go
@@ -135,7 +135,7 @@ func (r *Replica) MaybeGossipNodeLiveness(ctx context.Context, span roachpb.Span
 	// Call evaluateBatch instead of Send to avoid reacquiring latches.
 	rec := NewReplicaEvalContext(r, todoSpanSet)
 	br, result, pErr :=
-		evaluateBatch(ctx, storagebase.CmdIDKey(""), r.store.Engine(), rec, nil, ba, true /* readOnly */)
+		evaluateBatch(ctx, storagebase.CmdIDKey(""), r.store.Engine(), rec, nil, &ba, true /* readOnly */)
 	if pErr != nil {
 		return errors.Wrapf(pErr.GoError(), "couldn't scan node liveness records in span %s", span)
 	}
@@ -175,7 +175,7 @@ func (r *Replica) loadSystemConfig(ctx context.Context) (*config.SystemConfigEnt
 	// Call evaluateBatch instead of Send to avoid reacquiring latches.
 	rec := NewReplicaEvalContext(r, todoSpanSet)
 	br, result, pErr := evaluateBatch(
-		ctx, storagebase.CmdIDKey(""), r.store.Engine(), rec, nil, ba, true, /* readOnly */
+		ctx, storagebase.CmdIDKey(""), r.store.Engine(), rec, nil, &ba, true, /* readOnly */
 	)
 	if pErr != nil {
 		return nil, pErr.GoError()

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -83,9 +83,9 @@ type ProposalData struct {
 	// tmpFooter is used to avoid an allocation.
 	tmpFooter storagepb.RaftCommandFooter
 
-	// endCmds.finish is called after command execution to update the
-	// timestamp cache & release latches.
-	endCmds *endCmds
+	// ec.done is called after command application to update the timestamp
+	// cache and release latches.
+	ec endCmds
 
 	// doneCh is used to signal the waiting RPC handler (the contents of
 	// proposalResult come from LocalEvalResult).
@@ -122,10 +122,7 @@ type ProposalData struct {
 // is canceled, it won't be listening to this done channel, and so it can't be
 // counted on to invoke endCmds itself.)
 func (proposal *ProposalData) finishApplication(pr proposalResult) {
-	if proposal.endCmds != nil {
-		proposal.endCmds.done(proposal.Request, pr.Reply, pr.Err)
-		proposal.endCmds = nil
-	}
+	proposal.ec.done(proposal.Request, pr.Reply, pr.Err)
 	if proposal.sp != nil {
 		tracing.FinishSpan(proposal.sp)
 	}
@@ -740,11 +737,7 @@ func (r *Replica) evaluateProposal(
 // on a non-nil *roachpb.Error and should be proposed through Raft
 // if ProposalData.command is non-nil.
 func (r *Replica) requestToProposal(
-	ctx context.Context,
-	idKey storagebase.CmdIDKey,
-	ba *roachpb.BatchRequest,
-	endCmds *endCmds,
-	spans *spanset.SpanSet,
+	ctx context.Context, idKey storagebase.CmdIDKey, ba *roachpb.BatchRequest, spans *spanset.SpanSet,
 ) (*ProposalData, *roachpb.Error) {
 	res, needConsensus, pErr := r.evaluateProposal(ctx, idKey, ba, spans)
 
@@ -752,7 +745,6 @@ func (r *Replica) requestToProposal(
 	proposal := &ProposalData{
 		ctx:     ctx,
 		idKey:   idKey,
-		endCmds: endCmds,
 		doneCh:  make(chan proposalResult, 1),
 		Local:   &res.Local,
 		Request: ba,

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -123,7 +123,7 @@ type ProposalData struct {
 // counted on to invoke endCmds itself.)
 func (proposal *ProposalData) finishApplication(pr proposalResult) {
 	if proposal.endCmds != nil {
-		proposal.endCmds.done(pr.Reply, pr.Err)
+		proposal.endCmds.done(proposal.Request, pr.Reply, pr.Err)
 		proposal.endCmds = nil
 	}
 	if proposal.sp != nil {
@@ -636,7 +636,7 @@ type proposalResult struct {
 //
 // Replica.mu must not be held.
 func (r *Replica) evaluateProposal(
-	ctx context.Context, idKey storagebase.CmdIDKey, ba roachpb.BatchRequest, spans *spanset.SpanSet,
+	ctx context.Context, idKey storagebase.CmdIDKey, ba *roachpb.BatchRequest, spans *spanset.SpanSet,
 ) (*result.Result, bool, *roachpb.Error) {
 	if ba.Timestamp == (hlc.Timestamp{}) {
 		return nil, false, roachpb.NewErrorf("can't propose Raft command with zero timestamp")
@@ -742,7 +742,7 @@ func (r *Replica) evaluateProposal(
 func (r *Replica) requestToProposal(
 	ctx context.Context,
 	idKey storagebase.CmdIDKey,
-	ba roachpb.BatchRequest,
+	ba *roachpb.BatchRequest,
 	endCmds *endCmds,
 	spans *spanset.SpanSet,
 ) (*ProposalData, *roachpb.Error) {
@@ -755,7 +755,7 @@ func (r *Replica) requestToProposal(
 		endCmds: endCmds,
 		doneCh:  make(chan proposalResult, 1),
 		Local:   &res.Local,
-		Request: &ba,
+		Request: ba,
 	}
 
 	if needConsensus {

--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -65,7 +65,7 @@ func makeIDKey() storagebase.CmdIDKey {
 func (r *Replica) evalAndPropose(
 	ctx context.Context,
 	lease roachpb.Lease,
-	ba roachpb.BatchRequest,
+	ba *roachpb.BatchRequest,
 	endCmds *endCmds,
 	spans *spanset.SpanSet,
 ) (_ chan proposalResult, _ func(), _ int64, pErr *roachpb.Error) {
@@ -200,7 +200,7 @@ func (r *Replica) evalAndPropose(
 			Ctx:   ctx,
 			Cmd:   *proposal.command,
 			CmdID: idKey,
-			Req:   ba,
+			Req:   *ba,
 		}
 		if pErr := filter(filterArgs); pErr != nil {
 			return nil, nil, 0, pErr

--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -84,7 +84,7 @@ func (r *Replica) evalAndPropose(
 	}
 	r.mu.RUnlock()
 
-	rSpan, err := keys.Range(ba)
+	rSpan, err := keys.Range(ba.Requests)
 	if err != nil {
 		return nil, nil, 0, roachpb.NewError(err)
 	}

--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -45,10 +45,10 @@ func makeIDKey() storagebase.CmdIDKey {
 	return storagebase.CmdIDKey(idKeyBuf)
 }
 
-// evalAndPropose prepares the necessary pending command struct and initializes a
-// client command ID if one hasn't been. A verified lease is supplied
-// as a parameter if the command requires a lease; nil otherwise. It
-// then evaluates the command and proposes it to Raft on success.
+// evalAndPropose prepares the necessary pending command struct and initializes
+// a client command ID if one hasn't been. A verified lease is supplied as a
+// parameter if the command requires a lease; nil otherwise. It then evaluates
+// the command and proposes it to Raft on success.
 //
 // Return values:
 // - a channel which receives a response or error upon application
@@ -66,9 +66,17 @@ func (r *Replica) evalAndPropose(
 	ctx context.Context,
 	lease roachpb.Lease,
 	ba *roachpb.BatchRequest,
-	endCmds *endCmds,
 	spans *spanset.SpanSet,
+	ec endCmds,
 ) (_ chan proposalResult, _ func(), _ int64, pErr *roachpb.Error) {
+	// Guarantee we release the latches that we acquired if we never make
+	// it to passing responsibility to a proposal. This is wrapped to
+	// delay pErr evaluation to its value when returning.
+	defer func() {
+		// No-op if we move ec into proposal.ec.
+		ec.done(ba, nil /* br */, pErr)
+	}()
+
 	// TODO(nvanbenschoten): Can this be moved into Replica.requestCanProceed?
 	r.mu.RLock()
 	if !r.mu.destroyStatus.IsAlive() {
@@ -105,8 +113,18 @@ func (r *Replica) evalAndPropose(
 	}
 
 	idKey := makeIDKey()
-	proposal, pErr := r.requestToProposal(ctx, idKey, ba, endCmds, spans)
+	proposal, pErr := r.requestToProposal(ctx, idKey, ba, spans)
 	log.Event(proposal.ctx, "evaluated request")
+
+	// Attach the endCmds to the proposal. This moves responsibility of
+	// releasing latches to "below Raft" machinery. However, we make sure
+	// we clean up this resource if the proposal doesn't make it to Raft.
+	proposal.ec = ec.move()
+	defer func() {
+		if pErr != nil {
+			proposal.ec.done(ba, nil /* br */, pErr)
+		}
+	}()
 
 	// Pull out proposal channel to return. proposal.doneCh may be set to
 	// nil if it is signaled in this function.

--- a/pkg/storage/replica_read.go
+++ b/pkg/storage/replica_read.go
@@ -50,7 +50,7 @@ func (r *Replica) executeReadOnlyBatch(
 	// Acquire latches to prevent overlapping commands from executing
 	// until this command completes.
 	log.Event(ctx, "acquire latches")
-	endCmds, err := r.beginCmds(ctx, ba, spans)
+	ec, err := r.beginCmds(ctx, ba, spans)
 	if err != nil {
 		return nil, roachpb.NewError(err)
 	}
@@ -64,7 +64,7 @@ func (r *Replica) executeReadOnlyBatch(
 	// timestamp cache update is synchronized. This is wrapped to delay
 	// pErr evaluation to its value when returning.
 	defer func() {
-		endCmds.done(ba, br, pErr)
+		ec.done(ba, br, pErr)
 	}()
 
 	// TODO(nvanbenschoten): Can this be moved into Replica.requestCanProceed?

--- a/pkg/storage/replica_read.go
+++ b/pkg/storage/replica_read.go
@@ -72,7 +72,7 @@ func (r *Replica) executeReadOnlyBatch(
 		return nil, roachpb.NewError(err)
 	}
 
-	rSpan, err := keys.Range(ba)
+	rSpan, err := keys.Range(ba.Requests)
 	if err != nil {
 		return nil, roachpb.NewError(err)
 	}

--- a/pkg/storage/replica_read.go
+++ b/pkg/storage/replica_read.go
@@ -27,7 +27,7 @@ import (
 // overlapping writes currently processing through Raft ahead of us to
 // clear via the latches.
 func (r *Replica) executeReadOnlyBatch(
-	ctx context.Context, ba roachpb.BatchRequest,
+	ctx context.Context, ba *roachpb.BatchRequest,
 ) (br *roachpb.BatchResponse, pErr *roachpb.Error) {
 	// If the read is not inconsistent, the read requires the range lease or
 	// permission to serve via follower reads.
@@ -40,9 +40,9 @@ func (r *Replica) executeReadOnlyBatch(
 			r.store.metrics.FollowerReadsCount.Inc(1)
 		}
 	}
-	r.limitTxnMaxTimestamp(ctx, &ba, status)
+	r.limitTxnMaxTimestamp(ctx, ba, status)
 
-	spans, err := r.collectSpans(&ba)
+	spans, err := r.collectSpans(ba)
 	if err != nil {
 		return nil, roachpb.NewError(err)
 	}
@@ -50,7 +50,7 @@ func (r *Replica) executeReadOnlyBatch(
 	// Acquire latches to prevent overlapping commands from executing
 	// until this command completes.
 	log.Event(ctx, "acquire latches")
-	endCmds, err := r.beginCmds(ctx, &ba, spans)
+	endCmds, err := r.beginCmds(ctx, ba, spans)
 	if err != nil {
 		return nil, roachpb.NewError(err)
 	}
@@ -64,7 +64,7 @@ func (r *Replica) executeReadOnlyBatch(
 	// timestamp cache update is synchronized. This is wrapped to delay
 	// pErr evaluation to its value when returning.
 	defer func() {
-		endCmds.done(br, pErr)
+		endCmds.done(ba, br, pErr)
 	}()
 
 	// TODO(nvanbenschoten): Can this be moved into Replica.requestCanProceed?

--- a/pkg/storage/replica_write.go
+++ b/pkg/storage/replica_write.go
@@ -79,7 +79,7 @@ func (r *Replica) executeWriteBatch(
 		return nil, roachpb.NewError(err)
 	}
 
-	var endCmds *endCmds
+	var ec endCmds
 	if !ba.IsLeaseRequest() {
 		// Acquire latches to prevent overlapping commands from executing until
 		// this command completes. Note that this must be done before getting
@@ -87,18 +87,18 @@ func (r *Replica) executeWriteBatch(
 		// after preceding commands have been run to successful completion.
 		log.Event(ctx, "acquire latches")
 		var err error
-		endCmds, err = r.beginCmds(ctx, ba, spans)
+		ec, err = r.beginCmds(ctx, ba, spans)
 		if err != nil {
 			return nil, roachpb.NewError(err)
 		}
 	}
 
-	// Guarantee we release the latches that we just acquired. This is
-	// wrapped to delay pErr evaluation to its value when returning.
+	// Guarantee we release the latches that we just acquired if we never make
+	// it to passing responsibility to evalAndPropose. This is wrapped to delay
+	// pErr evaluation to its value when returning.
 	defer func() {
-		if endCmds != nil {
-			endCmds.done(ba, br, pErr)
-		}
+		// No-op if we move ec into evalAndPropose.
+		ec.done(ba, br, pErr)
 	}()
 
 	var lease roachpb.Lease
@@ -146,7 +146,9 @@ func (r *Replica) executeWriteBatch(
 
 	log.Event(ctx, "applied timestamp cache")
 
-	ch, abandon, maxLeaseIndex, pErr := r.evalAndPropose(ctx, lease, ba, endCmds, spans)
+	// After the command is proposed to Raft, invoking endCmds.done is the
+	// responsibility of Raft, so move the endCmds into evalAndPropose.
+	ch, abandon, maxLeaseIndex, pErr := r.evalAndPropose(ctx, lease, ba, spans, ec.move())
 	if pErr != nil {
 		if maxLeaseIndex != 0 {
 			log.Fatalf(
@@ -163,10 +165,6 @@ func (r *Replica) executeWriteBatch(
 	if maxLeaseIndex != 0 {
 		untrack(ctx, ctpb.Epoch(lease.Epoch), r.RangeID, ctpb.LAI(maxLeaseIndex))
 	}
-
-	// After the command is proposed to Raft, invoking endCmds.done is now the
-	// responsibility of processRaftCommand.
-	endCmds = nil
 
 	// If the command was accepted by raft, wait for the range to apply it.
 	ctxDone := ctx.Done()
@@ -258,10 +256,7 @@ and the following Raft status: %+v`,
 // re-executed in full. This allows it to lay down intents and return
 // an appropriate retryable error.
 func (r *Replica) evaluateWriteBatch(
-	ctx context.Context, 
-	idKey storagebase.CmdIDKey, 
-	ba *roachpb.BatchRequest, 
-	spans *spanset.SpanSet,
+	ctx context.Context, idKey storagebase.CmdIDKey, ba *roachpb.BatchRequest, spans *spanset.SpanSet,
 ) (engine.Batch, enginepb.MVCCStats, *roachpb.BatchResponse, result.Result, *roachpb.Error) {
 	ms := enginepb.MVCCStats{}
 	// If not transactional or there are indications that the batch's txn will

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -727,7 +727,7 @@ func TestStoreRemoveReplicaDestroy(t *testing.T) {
 	}
 
 	if _, _, _, pErr := repl1.evalAndPropose(
-		context.Background(), lease, &roachpb.BatchRequest{}, nil, &allSpans,
+		context.Background(), lease, &roachpb.BatchRequest{}, &allSpans, endCmds{},
 	); !pErr.Equal(expErr) {
 		t.Fatalf("expected error %s, but got %v", expErr, pErr)
 	}

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -72,7 +72,7 @@ func (s *Store) TestSender() client.Sender {
 		// If the client hasn't set ba.Range, we do it a favor and figure out the
 		// range to which the request needs to go.
 		//
-		// NOTE: We don't use keys.Range(ba) here because that does some
+		// NOTE: We don't use keys.Range(ba.Requests) here because that does some
 		// validation on the batch, and some tests using this sender don't like
 		// that.
 		key, err := keys.Addr(ba.Requests[0].GetInner().Header().Key)
@@ -150,7 +150,7 @@ func (db *testSender) Send(
 		return nil, roachpb.NewErrorf("%s method not supported", et.Method())
 	}
 	// Lookup range and direct request.
-	rs, err := keys.Range(ba)
+	rs, err := keys.Range(ba.Requests)
 	if err != nil {
 		return nil, roachpb.NewError(err)
 	}

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -727,7 +727,7 @@ func TestStoreRemoveReplicaDestroy(t *testing.T) {
 	}
 
 	if _, _, _, pErr := repl1.evalAndPropose(
-		context.Background(), lease, roachpb.BatchRequest{}, nil, &allSpans,
+		context.Background(), lease, &roachpb.BatchRequest{}, nil, &allSpans,
 	); !pErr.Equal(expErr) {
 		t.Fatalf("expected error %s, but got %v", expErr, pErr)
 	}


### PR DESCRIPTION
This PR contains a series of three refactorings that improve the way that BatchRequests are passed throughout the storage stack.

They aren't exactly prereqs for https://github.com/cockroachdb/cockroach/issues/17500#issuecomment-467238817, but I was prompted to make the changes as part of that larger change.