### PR TITLE
exec: check for unsupported by ArrowBatchConverter type

### DIFF
--- a/pkg/sql/exec/colrpc/inbox.go
+++ b/pkg/sql/exec/colrpc/inbox.go
@@ -87,6 +87,10 @@ var _ exec.Operator = &Inbox{}
 
 // NewInbox creates a new Inbox.
 func NewInbox(typs []types.T) (*Inbox, error) {
+	c, err := colserde.NewArrowBatchConverter(typs)
+	if err != nil {
+		return nil, err
+	}
 	s, err := colserde.NewRecordBatchSerializer(typs)
 	if err != nil {
 		return nil, err
@@ -94,7 +98,7 @@ func NewInbox(typs []types.T) (*Inbox, error) {
 	i := &Inbox{
 		typs:         typs,
 		zeroBatch:    coldata.NewMemBatchWithSize(typs, 0),
-		converter:    colserde.NewArrowBatchConverter(typs),
+		converter:    c,
 		serializer:   s,
 		streamCh:     make(chan flowStreamServer, 1),
 		contextCh:    make(chan context.Context, 1),

--- a/pkg/sql/exec/colrpc/outbox.go
+++ b/pkg/sql/exec/colrpc/outbox.go
@@ -58,6 +58,10 @@ type Outbox struct {
 func NewOutbox(
 	input exec.Operator, typs []types.T, metadataSources []distsqlpb.MetadataSource,
 ) (*Outbox, error) {
+	c, err := colserde.NewArrowBatchConverter(typs)
+	if err != nil {
+		return nil, err
+	}
 	s, err := colserde.NewRecordBatchSerializer(typs)
 	if err != nil {
 		return nil, err
@@ -67,7 +71,7 @@ func NewOutbox(
 		// be).
 		input:           exec.NewDeselectorOp(input, typs),
 		typs:            typs,
-		converter:       colserde.NewArrowBatchConverter(typs),
+		converter:       c,
 		serializer:      s,
 		metadataSources: metadataSources,
 	}

--- a/pkg/sql/exec/colserde/arrowbatchconverter_test.go
+++ b/pkg/sql/exec/colserde/arrowbatchconverter_test.go
@@ -86,11 +86,20 @@ func assertEqualBatches(t *testing.T, expected, actual coldata.Batch) {
 	}
 }
 
+func TestArrowBatchConverterRejectsUnsupportedTypes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	typs := []types.T{types.Decimal}
+	_, err := NewArrowBatchConverter(typs)
+	require.Error(t, err)
+}
+
 func TestArrowBatchConverterRandom(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	typs, b := randomBatch()
-	c := NewArrowBatchConverter(typs)
+	c, err := NewArrowBatchConverter(typs)
+	require.NoError(t, err)
 
 	// Make a copy of the original batch because the converter modifies and casts
 	// data without copying for performance reasons.
@@ -108,7 +117,8 @@ func TestRecordBatchRoundtripThroughBytes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	typs, b := randomBatch()
-	c := NewArrowBatchConverter(typs)
+	c, err := NewArrowBatchConverter(typs)
+	require.NoError(t, err)
 	r, err := NewRecordBatchSerializer(typs)
 	require.NoError(t, err)
 
@@ -161,7 +171,8 @@ func BenchmarkArrowBatchConverter(b *testing.B) {
 				}
 			}
 		}
-		c := NewArrowBatchConverter([]types.T{typ})
+		c, err := NewArrowBatchConverter([]types.T{typ})
+		require.NoError(b, err)
 		nullFractions := []float64{0, 0.25, 0.5}
 		setNullFraction := func(batch coldata.Batch, nullFraction float64) {
 			vec := batch.ColVec(0)


### PR DESCRIPTION
Previously, we would create an arrow batch converter without
paying attention to whether we supported the types which could
lead to a panic during actual conversion. Now we do this check
upfront so that we can fall back to DistSQL.

Release note: None