### PR TITLE
roachprod: remove -v flag from scp

### DIFF
--- a/pkg/cmd/roachprod/install/cluster_synced.go
+++ b/pkg/cmd/roachprod/install/cluster_synced.go
@@ -1486,7 +1486,7 @@ func (c *SyncedCluster) SSH(sshArgs, args []string) error {
 
 func (c *SyncedCluster) scp(src, dest string) error {
 	args := []string{
-		"scp", "-v", "-r", "-C",
+		"scp", "-r", "-C",
 		"-o", "StrictHostKeyChecking=no",
 	}
 	args = append(args, sshAuthArgs()...)


### PR DESCRIPTION
The flag was added in hopes of improving debugging. It only ever added noise.

For example, with this flag we'll see:
```
stderr:

stdout:
1: Requesting no-more-sessions@openssh.com
debug1: Entering interactive session.
debug1: pledge: network
debug1: client_input_global_request: rtype hostkeys-00@openssh.com want_reply 0
debug1: Sending environment.
debug1: Sending env LANG = en_US.UTF-8
debug1: Sending command: scp -v -r -f perf
debug1: client_input_channel_req: channel 0 rtype exit-status reply 0
debug1: client_input_channel_req: channel 0 rtype eow@openssh.com reply 0
debug1: channel 0: free: client-session, nchannels 1
Sink: \001scp: perf: No such file or directory
scp: perf: No such file or directory
debug1: fd 0 clearing O_NONBLOCK
debug1: fd 2 clearing O_NONBLOCK
Transferred: sent 2748, received 2856 bytes, in 0.2 seconds
Bytes per second: sent 11097.8, received 11534.0
debug1: Exit status 1
debug1: compress outgoing: raw data 177, compressed 156, factor 0.88
debug1: compress incoming: raw data 1050, compressed 1029, factor 0.98
: exit status 1
```

Which obfuscates the only really interesting error:

```
scp: perf: No such file or directory
```