### PR TITLE
storage: avoid boxing allocation in RangeDescriptor.Replicas

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1184,7 +1184,7 @@ func removeDeadReplicas(
 			}}
 			newDesc.SetReplicas(roachpb.MakeReplicaDescriptors(&replicas))
 			newDesc.NextReplicaID++
-			fmt.Printf("Replica %s -> %s\n", desc, newDesc)
+			fmt.Printf("Replica %s -> %s\n", &desc, &newDesc)
 			newDescs = append(newDescs, newDesc)
 		}
 		return false, nil

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1177,11 +1177,12 @@ func removeDeadReplicas(
 			// Rewrite the replicas list. Bump the replica ID as an extra
 			// defense against one of the old replicas returning from the
 			// dead.
-			newDesc.SetReplicas(roachpb.MakeReplicaDescriptors([]roachpb.ReplicaDescriptor{{
+			replicas := []roachpb.ReplicaDescriptor{{
 				NodeID:    storeIdent.NodeID,
 				StoreID:   storeIdent.StoreID,
 				ReplicaID: desc.NextReplicaID,
-			}}))
+			}}
+			newDesc.SetReplicas(roachpb.MakeReplicaDescriptors(&replicas))
 			newDesc.NextReplicaID++
 			fmt.Printf("Replica %s -> %s\n", desc, newDesc)
 			newDescs = append(newDescs, newDesc)

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -125,8 +125,8 @@ func (r RangeDescriptor) ContainsKeyRange(start, end RKey) bool {
 
 // Replicas returns the set of nodes/stores on which replicas of this range are
 // stored.
-func (r RangeDescriptor) Replicas() ReplicaDescriptors {
-	return MakeReplicaDescriptors(r.InternalReplicas)
+func (r *RangeDescriptor) Replicas() ReplicaDescriptors {
+	return MakeReplicaDescriptors(&r.InternalReplicas)
 }
 
 // SetReplicas overwrites the set of nodes/stores on which replicas of this
@@ -191,7 +191,7 @@ func (r RangeDescriptor) GetGeneration() int64 {
 }
 
 // IncrementGeneration increments the generation of this RangeDescriptor.
-func (r *RangeDescriptor) IncrementGeneration() {
+func (r RangeDescriptor) IncrementGeneration() {
 	// Create a new *int64 for the new generation. We permit shallow copies of
 	// RangeDescriptors, so we need to be careful not to mutate the
 	// potentially-shared generation counter.
@@ -236,7 +236,7 @@ func (r RangeDescriptor) Validate() error {
 	return nil
 }
 
-func (r RangeDescriptor) String() string {
+func (r *RangeDescriptor) String() string {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "r%d:", r.RangeID)
 

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -101,25 +101,25 @@ func (a Attributes) String() string {
 }
 
 // RSpan returns the RangeDescriptor's resolved span.
-func (r RangeDescriptor) RSpan() RSpan {
+func (r *RangeDescriptor) RSpan() RSpan {
 	return RSpan{Key: r.StartKey, EndKey: r.EndKey}
 }
 
 // ContainsKey returns whether this RangeDescriptor contains the specified key.
-func (r RangeDescriptor) ContainsKey(key RKey) bool {
+func (r *RangeDescriptor) ContainsKey(key RKey) bool {
 	return r.RSpan().ContainsKey(key)
 }
 
 // ContainsKeyInverted returns whether this RangeDescriptor contains the
 // specified key using an inverted range. See RSpan.ContainsKeyInverted.
-func (r RangeDescriptor) ContainsKeyInverted(key RKey) bool {
+func (r *RangeDescriptor) ContainsKeyInverted(key RKey) bool {
 	return r.RSpan().ContainsKeyInverted(key)
 }
 
 // ContainsKeyRange returns whether this RangeDescriptor contains the specified
 // key range from start (inclusive) to end (exclusive).
 // If end is empty, returns ContainsKey(start).
-func (r RangeDescriptor) ContainsKeyRange(start, end RKey) bool {
+func (r *RangeDescriptor) ContainsKeyRange(start, end RKey) bool {
 	return r.RSpan().ContainsKeyRange(start, end)
 }
 
@@ -155,7 +155,7 @@ func (r *RangeDescriptor) RemoveReplica(nodeID NodeID, storeID StoreID) (Replica
 
 // GetReplicaDescriptor returns the replica which matches the specified store
 // ID.
-func (r RangeDescriptor) GetReplicaDescriptor(storeID StoreID) (ReplicaDescriptor, bool) {
+func (r *RangeDescriptor) GetReplicaDescriptor(storeID StoreID) (ReplicaDescriptor, bool) {
 	for _, repDesc := range r.Replicas().Unwrap() {
 		if repDesc.StoreID == storeID {
 			return repDesc, true
@@ -166,7 +166,7 @@ func (r RangeDescriptor) GetReplicaDescriptor(storeID StoreID) (ReplicaDescripto
 
 // GetReplicaDescriptorByID returns the replica which matches the specified store
 // ID.
-func (r RangeDescriptor) GetReplicaDescriptorByID(replicaID ReplicaID) (ReplicaDescriptor, bool) {
+func (r *RangeDescriptor) GetReplicaDescriptorByID(replicaID ReplicaID) (ReplicaDescriptor, bool) {
 	for _, repDesc := range r.Replicas().Unwrap() {
 		if repDesc.ReplicaID == replicaID {
 			return repDesc, true
@@ -178,12 +178,12 @@ func (r RangeDescriptor) GetReplicaDescriptorByID(replicaID ReplicaID) (ReplicaD
 // IsInitialized returns false if this descriptor represents an
 // uninitialized range.
 // TODO(bdarnell): unify this with Validate().
-func (r RangeDescriptor) IsInitialized() bool {
+func (r *RangeDescriptor) IsInitialized() bool {
 	return len(r.EndKey) != 0
 }
 
 // GetGeneration returns the generation of this RangeDescriptor.
-func (r RangeDescriptor) GetGeneration() int64 {
+func (r *RangeDescriptor) GetGeneration() int64 {
 	if r.Generation != nil {
 		return *r.Generation
 	}
@@ -191,7 +191,7 @@ func (r RangeDescriptor) GetGeneration() int64 {
 }
 
 // IncrementGeneration increments the generation of this RangeDescriptor.
-func (r RangeDescriptor) IncrementGeneration() {
+func (r *RangeDescriptor) IncrementGeneration() {
 	// Create a new *int64 for the new generation. We permit shallow copies of
 	// RangeDescriptors, so we need to be careful not to mutate the
 	// potentially-shared generation counter.
@@ -199,7 +199,7 @@ func (r RangeDescriptor) IncrementGeneration() {
 }
 
 // GetGenerationComparable returns if the generation of this RangeDescriptor is comparable.
-func (r RangeDescriptor) GetGenerationComparable() bool {
+func (r *RangeDescriptor) GetGenerationComparable() bool {
 	if r.GenerationComparable == nil {
 		return false
 	}
@@ -207,7 +207,7 @@ func (r RangeDescriptor) GetGenerationComparable() bool {
 }
 
 // GetStickyBit returns the sticky bit of this RangeDescriptor.
-func (r RangeDescriptor) GetStickyBit() hlc.Timestamp {
+func (r *RangeDescriptor) GetStickyBit() hlc.Timestamp {
 	if r.StickyBit == nil {
 		return hlc.Timestamp{}
 	}
@@ -215,7 +215,7 @@ func (r RangeDescriptor) GetStickyBit() hlc.Timestamp {
 }
 
 // Validate performs some basic validation of the contents of a range descriptor.
-func (r RangeDescriptor) Validate() error {
+func (r *RangeDescriptor) Validate() error {
 	if r.NextReplicaID == 0 {
 		return errors.Errorf("NextReplicaID must be non-zero")
 	}

--- a/pkg/roachpb/metadata_replicas_test.go
+++ b/pkg/roachpb/metadata_replicas_test.go
@@ -34,7 +34,7 @@ func TestVotersLearnersAll(t *testing.T) {
 		{{Type: learner}, {Type: nil}, {Type: learner}},
 	}
 	for i, test := range tests {
-		r := MakeReplicaDescriptors(test)
+		r := MakeReplicaDescriptors(&test)
 		for _, voter := range r.Voters() {
 			assert.Equal(t, ReplicaType_VOTER, voter.GetType(), "testcase %d", i)
 		}
@@ -78,7 +78,7 @@ func TestReplicaDescriptorsRemove(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		r := MakeReplicaDescriptors(test.replicas)
+		r := MakeReplicaDescriptors(&test.replicas)
 		lenBefore := len(r.All())
 		removedDesc, ok := r.RemoveReplica(test.remove.NodeID, test.remove.StoreID)
 		assert.Equal(t, test.expected, ok, "testcase %d", i)

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -751,7 +751,8 @@ func (dsp *DistSQLPlanner) PartitionSpans(
 			}
 			desc := it.Desc()
 			if log.V(1) {
-				log.Infof(ctx, "lastKey: %s desc: %s", lastKey, desc)
+				descCpy := desc // don't let desc escape
+				log.Infof(ctx, "lastKey: %s desc: %s", lastKey, &descCpy)
 			}
 
 			if !desc.ContainsKey(lastKey) {

--- a/pkg/sql/distsqlplan/span_resolver_test.go
+++ b/pkg/sql/distsqlplan/span_resolver_test.go
@@ -422,7 +422,7 @@ func selectReplica(nodeID roachpb.NodeID, rng roachpb.RangeDescriptor) rngInfo {
 			return rngInfo{ReplicaDescriptor: rep, rngDesc: rng}
 		}
 	}
-	panic(fmt.Sprintf("no replica on node %d in: %s", nodeID, rng))
+	panic(fmt.Sprintf("no replica on node %d in: %s", nodeID, &rng))
 }
 
 func expectResolved(actual [][]rngInfo, expected ...[]rngInfo) error {

--- a/pkg/storage/batcheval/cmd_end_transaction.go
+++ b/pkg/storage/batcheval/cmd_end_transaction.go
@@ -1108,7 +1108,7 @@ func changeReplicasTrigger(
 		desc = *change.Desc
 	} else {
 		desc = *rec.Desc()
-		desc.SetReplicas(roachpb.MakeReplicaDescriptors(change.DeprecatedUpdatedReplicas))
+		desc.SetReplicas(roachpb.MakeReplicaDescriptors(&change.DeprecatedUpdatedReplicas))
 		desc.NextReplicaID = change.DeprecatedNextReplicaID
 	}
 

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -1080,7 +1080,7 @@ func (m *multiTestContext) findMemberStoreLocked(desc roachpb.RangeDescriptor) *
 			}
 		}
 	}
-	m.t.Fatalf("couldn't find a live member of %s", desc)
+	m.t.Fatalf("couldn't find a live member of %s", &desc)
 	return nil // unreached, but the compiler can't tell.
 }
 

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -66,7 +66,7 @@ func maybeDescriptorChangedError(desc *roachpb.RangeDescriptor, err error) (stri
 			return fmt.Sprintf("descriptor changed: expected %s != [actual] nil (range subsumed)", desc), true
 		} else if err := detail.ActualValue.GetProto(&actualDesc); err == nil &&
 			desc.RangeID == actualDesc.RangeID && !desc.Equal(actualDesc) {
-			return fmt.Sprintf("descriptor changed: [expected] %s != [actual] %s", desc, actualDesc), true
+			return fmt.Sprintf("descriptor changed: [expected] %s != [actual] %s", desc, &actualDesc), true
 		}
 	}
 	return "", false
@@ -569,7 +569,7 @@ func (r *Replica) AdminMerge(
 		updatedLeftDesc.IncrementGeneration()
 		r.maybeMarkGenerationComparable(&updatedLeftDesc)
 		updatedLeftDesc.EndKey = rightDesc.EndKey
-		log.Infof(ctx, "initiating a merge of %s into this range (%s)", rightDesc, reason)
+		log.Infof(ctx, "initiating a merge of %s into this range (%s)", &rightDesc, reason)
 
 		// Update the range descriptor for the receiving range. It is important
 		// (for transaction record placement) that the first write inside the

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1422,7 +1422,7 @@ func (s *Store) AdminRelocateRange(
 			desc.NextReplicaID++
 		case roachpb.REMOVE_REPLICA:
 			newReplicas := removeTargetFromSlice(desc.Replicas().Unwrap(), target)
-			desc.SetReplicas(roachpb.MakeReplicaDescriptors(newReplicas))
+			desc.SetReplicas(roachpb.MakeReplicaDescriptors(&newReplicas))
 		default:
 			panic(errors.Errorf("unknown ReplicaChangeType %v", changeType))
 		}

--- a/pkg/storage/replica_gc_queue.go
+++ b/pkg/storage/replica_gc_queue.go
@@ -318,7 +318,7 @@ func (rgcq *replicaGCQueue) process(
 			if len(rs) != 1 {
 				return errors.Errorf("expected 1 range descriptor, got %d", len(rs))
 			}
-			if leftReplyDesc := rs[0]; !leftDesc.Equal(leftReplyDesc) {
+			if leftReplyDesc := &rs[0]; !leftDesc.Equal(*leftReplyDesc) {
 				log.VEventf(ctx, 1, "left neighbor %s not up-to-date with meta descriptor %s; cannot safely GC range yet",
 					leftDesc, leftReplyDesc)
 				// Chances are that the left replica needs to be GC'd. Since we don't

--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -1579,7 +1579,7 @@ func (r *Replica) acquireMergeLock(
 	rightDesc := rightRepl.Desc()
 	if !rightDesc.StartKey.Equal(merge.RightDesc.StartKey) || !rightDesc.EndKey.Equal(merge.RightDesc.EndKey) {
 		log.Fatalf(ctx, "RHS of merge %s <- %s not present on store; found %s in place of the RHS",
-			merge.LeftDesc, merge.RightDesc, rightDesc)
+			&merge.LeftDesc, &merge.RightDesc, rightDesc)
 	}
 	return func(*storagepb.ReplicatedEvalResult) {
 		rightRepl.raftMu.Unlock()

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2086,7 +2086,7 @@ func (s *Store) NewRangeDescriptor(
 		EndKey:        end,
 		NextReplicaID: roachpb.ReplicaID(len(replicas) + 1),
 	}
-	desc.SetReplicas(roachpb.MakeReplicaDescriptors(replicas))
+	desc.SetReplicas(roachpb.MakeReplicaDescriptors(&replicas))
 	return desc, nil
 }
 

--- a/pkg/storage/store_bootstrap.go
+++ b/pkg/storage/store_bootstrap.go
@@ -153,13 +153,14 @@ func WriteInitialClusterData(
 		if !bootstrapVersion.Less(cluster.VersionByKey(cluster.VersionGenerationComparable)) {
 			desc.GenerationComparable = proto.Bool(true)
 		}
-		desc.SetReplicas(roachpb.MakeReplicaDescriptors([]roachpb.ReplicaDescriptor{
+		replicas := []roachpb.ReplicaDescriptor{
 			{
 				NodeID:    1,
 				StoreID:   1,
 				ReplicaID: 1,
 			},
-		}))
+		}
+		desc.SetReplicas(roachpb.MakeReplicaDescriptors(&replicas))
 		if err := desc.Validate(); err != nil {
 			return err
 		}


### PR DESCRIPTION
f96e0f9 introduces a sorting step into MakeReplicaDescriptors, which is
called by `RangeDescriptor.Replicas`. Unfortunately the use of `sort.Interface`
here results in an allocation due to the interface boxing. This is very
noticable on both micro-benchmarks and system-level benchmarks. For
instance, on a large-scale, 192 vCPU kv90 test, this was responsible for
**1.84%** of all allocations in the system. The numbers are similar on
micro-benchmarks, where this PR has the following impact:

```
name                        old time/op    new time/op    delta
KV/Insert/Native/rows=1-16    94.5µs ± 4%    93.9µs ± 1%    ~     (p=0.684 n=10+10)

name                        old alloc/op   new alloc/op   delta
KV/Insert/Native/rows=1-16    11.6kB ± 0%    11.5kB ± 0%  -1.33%  (p=0.000 n=9+10)

name                        old allocs/op  new allocs/op  delta
KV/Insert/Native/rows=1-16       129 ± 0%       124 ± 0%  -3.88%  (p=0.000 n=9+9)
```

Release note: None