### PR TITLE
roachprod: disable ssh logging

### DIFF
--- a/pkg/cmd/roachprod/install/session.go
+++ b/pkg/cmd/roachprod/install/session.go
@@ -12,16 +12,13 @@ package install
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sync"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod/config"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/pkg/errors"
 )
 
@@ -47,13 +44,21 @@ type remoteSession struct {
 }
 
 func newRemoteSession(user, host string, logdir string) (*remoteSession, error) {
-	logfile := filepath.Join(
-		logdir,
-		fmt.Sprintf("ssh_%s_%s", host, timeutil.Now().Format(time.RFC3339)),
-	)
+	// TODO(tbg): this is disabled at the time of writing. It was difficult
+	// to assign the logfiles to the roachtest and as a bonus our CI harness
+	// never actually managed to collect the files since they had wrong
+	// permissions; instead they clogged up the roachprod dir.
+	// logfile := filepath.Join(
+	//	logdir,
+	// 	fmt.Sprintf("ssh_%s_%s", host, timeutil.Now().Format(time.RFC3339)),
+	// )
+	const logfile = ""
 	args := []string{
 		user + "@" + host,
-		"-vvv", "-E", logfile,
+
+		// TODO(tbg): see above.
+		//"-vvv", "-E", logfile,
+
 		// NB: -q suppresses -E, at least on OSX. Difficult decisions will have
 		// to be made if omitting -q leads to annoyance on stdout/stderr.
 		// "-q",
@@ -73,7 +78,7 @@ func newRemoteSession(user, host string, logdir string) (*remoteSession, error) 
 }
 
 func (s *remoteSession) errWithDebug(err error) error {
-	if err != nil {
+	if err != nil && s.logfile != "" {
 		err = errors.Wrapf(err, "ssh verbose log retained in %s", s.logfile)
 		s.logfile = "" // prevent removal on close
 	}


### PR DESCRIPTION
This was never fully introduced and there is currently no impetus to
push it over the finish line. It would be useful to diagnose issues
that are readily reproducible, but we haven't seen any of those.

Release note: None