### PR TITLE
exec: handle NULL group by keys in hash aggregator

### DIFF
--- a/pkg/sql/exec/aggregator_test.go
+++ b/pkg/sql/exec/aggregator_test.go
@@ -424,12 +424,14 @@ func TestAggregatorAllFunctions(t *testing.T) {
 			aggCols:  [][]uint32{{0}, {1}, {}, {1}, {1}, {2}, {2}, {2}, {1}},
 			colTypes: []types.T{types.Int64, types.Decimal, types.Int64},
 			input: tuples{
+				{nil, 1.1, 4},
 				{0, nil, nil},
 				{0, 3.1, 5},
 				{1, nil, nil},
 				{1, nil, nil},
 			},
 			expected: tuples{
+				{nil, 1.1, 1, 1, 1.1, 4, 4, 4, 1.1},
 				{0, 3.1, 2, 1, 3.1, 5, 5, 5, 3.1},
 				{1, nil, 2, 0, nil, nil, nil, nil, nil},
 			},
@@ -489,13 +491,14 @@ func TestAggregatorRandom(t *testing.T) {
 									expNulls = append(expNulls, true)
 									curGroup++
 								}
+								// Keep the inputs small so they are a realistic size. Using a
+								// large range is not realistic and makes decimal operations
+								// slower.
+								aggCol[i] = 2048 * (rng.Float64() - 0.5)
+
 								if hasNulls && rng.Float64() < nullProbability {
 									aggColNulls.SetNull(uint16(i))
 								} else {
-									// Keep the inputs small so they are a realistic size. Using a
-									// large range is not realistic and makes decimal operations
-									// slower.
-									aggCol[i] = 2048 * (rng.Float64() - 0.5)
 									expNulls[curGroup] = false
 									expCounts[curGroup]++
 									expSums[curGroup] += aggCol[i]

--- a/pkg/sql/exec/execgen/cmd/execgen/hashjoiner_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/hashjoiner_gen.go
@@ -38,8 +38,8 @@ func genHashJoiner(wr io.Writer) error {
 	assignHash := makeFunctionRegex("_ASSIGN_HASH", 2)
 	s = assignHash.ReplaceAllString(s, `{{.Global.UnaryAssign "$1" "$2"}}`)
 
-	rehash := makeFunctionRegex("_REHASH_BODY", 6)
-	s = rehash.ReplaceAllString(s, `{{template "rehashBody" buildDict "Global" . "SelInd" $6}}`)
+	rehash := makeFunctionRegex("_REHASH_BODY", 8)
+	s = rehash.ReplaceAllString(s, `{{template "rehashBody" buildDict "Global" . "SelInd" $7 "HasNulls" $8}}`)
 
 	checkCol := makeFunctionRegex("_CHECK_COL_WITH_NULLS", 7)
 	s = checkCol.ReplaceAllString(s, `{{template "checkColWithNulls" buildDict "Global" . "SelInd" $7}}`)
@@ -56,11 +56,13 @@ func genHashJoiner(wr io.Writer) error {
 	collectNoOuter := makeFunctionRegex("_COLLECT_NO_OUTER", 5)
 	s = collectNoOuter.ReplaceAllString(s, `{{template "collectNoOuter" buildDict "Global" . "SelInd" $5}}`)
 
-	checkColMain := makeFunctionRegex("_CHECK_COL_MAIN", 1)
+	checkColMain := makeFunctionRegex("_CHECK_COL_MAIN", 5)
 	s = checkColMain.ReplaceAllString(s, `{{template "checkColMain" .}}`)
 
-	checkColBody := makeFunctionRegex("_CHECK_COL_BODY", 8)
-	s = checkColBody.ReplaceAllString(s, `{{template "checkColBody" buildDict "Global" .Global "SelInd" .SelInd "ProbeHasNulls" $7 "BuildHasNulls" $8}}`)
+	checkColBody := makeFunctionRegex("_CHECK_COL_BODY", 9)
+	s = checkColBody.ReplaceAllString(
+		s,
+		`{{template "checkColBody" buildDict "Global" .Global "SelInd" .SelInd "ProbeHasNulls" $7 "BuildHasNulls" $8 "AllowNullEquality" $9}}`)
 
 	tmpl, err := template.New("hashjoiner_op").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)
 

--- a/pkg/sql/exec/hash_aggregator.go
+++ b/pkg/sql/exec/hash_aggregator.go
@@ -110,6 +110,7 @@ func NewHashAggregator(
 		colTypes,
 		groupCols,
 		outCols,
+		true, /* allowNullEquality */
 	)
 
 	builder := makeHashJoinBuilder(

--- a/pkg/sql/exec/hashjoiner.go
+++ b/pkg/sql/exec/hashjoiner.go
@@ -212,6 +212,7 @@ func (hj *hashJoinEqOp) Init() {
 		build.sourceTypes,
 		build.eqCols,
 		build.outCols,
+		false, /* allowNullEquality */
 	)
 
 	hj.builder = makeHashJoinBuilder(
@@ -392,11 +393,19 @@ type hashTable struct {
 	// key.
 	differs []bool
 
+	// allowNullEquality determines if NULL keys should be treated as equal to
+	// each other.
+	allowNullEquality bool
+
 	cancelChecker CancelChecker
 }
 
 func makeHashTable(
-	bucketSize uint64, sourceTypes []types.T, eqCols []uint32, outCols []uint32,
+	bucketSize uint64,
+	sourceTypes []types.T,
+	eqCols []uint32,
+	outCols []uint32,
+	allowNullEquality bool,
 ) *hashTable {
 	// Compute the union of eqCols and outCols and compress vals to only keep the
 	// important columns.
@@ -467,6 +476,8 @@ func makeHashTable(
 
 		keys:    make([]coldata.Vec, len(eqCols)),
 		buckets: make([]uint64, coldata.BatchSize),
+
+		allowNullEquality: allowNullEquality,
 	}
 }
 
@@ -577,7 +588,8 @@ func makeHashJoinBuilder(ht *hashTable, spec hashJoinerSourceSpec) *hashJoinBuil
 }
 
 // exec executes distinctExec, and then eagerly populates the hashTable's same
-// array by probing the hashTable with every single input key.
+// array by probing the hashTable with every single input key. This is intended
+// for use by the hash aggregator.
 func (builder *hashJoinBuilder) exec(ctx context.Context) {
 	builder.distinctExec(ctx)
 


### PR DESCRIPTION
Previously, if an aggregation was requested with NULL group keys, an
index out of bounds error would occur in the hash aggregator. The reason
was that the hashTable data structure is shared between the hash joiner
and the hash aggregator. It was originally implemented for the hash joiner,
and in that case, NULLs are always supposed to be treated as non-equal.
However, in the hash aggregator, we want NULLs to compare as equal to each
other.

This change allows the tests in logic_test/aggregate to pass with the
local-vec configuration.

In order to exercise more of the null handling logic, the tests now set
garbage data in the corresponing position of the vector whenever an
element is null.

fixes #38750 

Release note: None