### PR TITLE
exec: Fix type ambiguity error out for IN and NOT IN.

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -730,6 +730,14 @@ func assertHomogeneousTypes(expr tree.TypedExpr) error {
 	case *tree.ComparisonExpr:
 		left := t.TypedLeft().ResolvedType()
 		right := t.TypedRight().ResolvedType()
+
+		// Special rules for IN and NOT IN expressions. The type checker
+		// handles invalid types for the IN and NOT IN operations at this point,
+		// and we allow a comparison between t and t tuple.
+		if t.Operator == tree.In || t.Operator == tree.NotIn {
+			return nil
+		}
+
 		if !left.Identical(right) {
 			return errors.Errorf("ComparisonExpr on %s and %s is unhandled", left, right)
 		}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -455,3 +455,21 @@ query I
 SELECT * FROM (SELECT count(*) AS x FROM b) WHERE x > 0;
 ----
 4
+
+# Regression test for #38908
+statement ok
+CREATE TABLE t38908 (x INT)
+
+statement ok
+INSERT INTO t38908 VALUES (1)
+
+statement ok
+SET experimental_vectorize=always
+
+query I
+SELECT * FROM t38908 WHERE x IN (1, 2)
+----
+1
+
+statement ok
+RESET experimental_vectorize


### PR DESCRIPTION
A previous PR introduced this error, this PR fixes it and adds a regression test.

Release note: None