### PR TITLE
sql: adding column with default null should not call backfill

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -458,6 +458,21 @@ func TestChangefeedSchemaChangeNoBackfill(t *testing.T) {
 				`alter_default: [2]->{"after": {"a": 2, "b": "after"}}`,
 			})
 		})
+
+		// Test adding a column with explicitly setting the default value to be NULL
+		t.Run(`add column with DEFAULT NULL`, func(t *testing.T) {
+			sqlDB.Exec(t, `CREATE TABLE t (id INT PRIMARY KEY)`)
+			sqlDB.Exec(t, `INSERT INTO t VALUES (1)`)
+			defaultNull := feed(t, f, `CREATE CHANGEFEED FOR t`)
+			defer closeFeed(t, defaultNull)
+			sqlDB.Exec(t, `ALTER TABLE t ADD COLUMN c INT DEFAULT NULL`)
+			sqlDB.Exec(t, `INSERT INTO t VALUES (2, 2)`)
+			assertPayloads(t, defaultNull, []string{
+				// Verify that no column backfill occurs
+				`t: [1]->{"after": {"id": 1}}`,
+				`t: [2]->{"after": {"c": 2, "id": 2}}`,
+			})
+		})
 	}
 
 	t.Run(`sinkless`, sinklessTest(testFn))

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2643,6 +2643,16 @@ func (desc *ImmutableTableDescriptor) MakeFirstMutationPublic(
 // ColumnNeedsBackfill returns true if adding the given column requires a
 // backfill (dropping a column always requires a backfill).
 func ColumnNeedsBackfill(desc *ColumnDescriptor) bool {
+	// Consider the case where the user explicitly states the default value of a
+	// new column to be NULL. desc.DefaultExpr is not nil, but the string "NULL"
+	if desc.DefaultExpr != nil {
+		if defaultExpr, err := parser.ParseExpr(*desc.DefaultExpr); err != nil {
+			panic(errors.NewAssertionErrorWithWrappedErrf(err,
+				"failed to parse default expression %s", *desc.DefaultExpr))
+		} else if defaultExpr == tree.DNull {
+			return false
+		}
+	}
 	return desc.DefaultExpr != nil || !desc.Nullable || desc.IsComputed()
 }
 

--- a/pkg/sql/sqlbase/structured_test.go
+++ b/pkg/sql/sqlbase/structured_test.go
@@ -1307,3 +1307,30 @@ func TestKeysPerRow(t *testing.T) {
 		})
 	}
 }
+
+func TestColumnNeedsBackfill(t *testing.T) {
+	// Define variable strings here such that we can pass their address below
+	null := "NULL"
+	four := "4:::INT8"
+	// Create Column Descriptors that reflect the definition of a column with a
+	// default value of NULL that was set implicitly, one that was set explicitly,
+	// and one that has an INT default value, respectively.
+	implicitNull := &ColumnDescriptor{Name: "im", ID: 2, DefaultExpr: nil, Nullable: true, ComputeExpr: nil}
+	explicitNull := &ColumnDescriptor{Name: "ex", ID: 3, DefaultExpr: &null, Nullable: true, ComputeExpr: nil}
+	defaultNotNull := &ColumnDescriptor{Name: "four", ID: 4, DefaultExpr: &four, Nullable: true, ComputeExpr: nil}
+	// Verify that a backfill doesn't occur according to the ColumnNeedsBackfill
+	// function for the default NULL values, and that it does occur for an INT
+	// default value.
+	if ColumnNeedsBackfill(implicitNull) != false {
+		t.Fatal("Expected implicit SET DEFAULT NULL to not require a backfill," +
+			" ColumnNeedsBackfill states that it does.")
+	}
+	if ColumnNeedsBackfill(explicitNull) != false {
+		t.Fatal("Expected explicit SET DEFAULT NULL to not require a backfill," +
+			" ColumnNeedsBackfill states that it does.")
+	}
+	if ColumnNeedsBackfill(defaultNotNull) != true {
+		t.Fatal("Expected explicit SET DEFAULT NULL to require a backfill," +
+			" ColumnNeedsBackfill states that it does not.")
+	}
+}


### PR DESCRIPTION
A backfill operation should not occur when a user creates a new column
on a table, and specifies the default value to be null. A backfill does
not occur if the user performs a command such as "ALTER TABLE t ADD
COLUMN c INT NULL", but prior to this PR, a backfill did occur with
a command such as "ALTER TABLE t ADD COLUMN c INT DEFAULT NULL".

The issue was that the default expression in the code is nil for the
first case, but in the second case it is the string "NULL", which
wasn't being checked. This brought up another potential issue, that
being, should we in fact normalize the default expression to be nil in
both cases? Possibly a topic for further discussion later.

Resolves: #37948

Release note (sql change): No longer performs a backfill when a user
explicitly sets the default value of a new column to be NULL