### PR TITLE
[dnm] tracing parity in cfetcher

### DIFF
--- a/pkg/sql/exec/coldata/vec.go
+++ b/pkg/sql/exec/coldata/vec.go
@@ -129,9 +129,9 @@ type Vec interface {
 	// [start, end).
 	Slice(colType types.T, start uint64, end uint64) Vec
 
-	// PrettyValueAt returns a "pretty"value for the idx'th value in this Vec.
-	// It uses the reflect package and is not suitable for calling in hot paths.
-	PrettyValueAt(idx uint16, colType types.T) string
+	// ValueAt returns the value for the idx'th value in this Vec. It isn't
+	// suitable for calling in hot paths.
+	ValueAt(idx uint16) interface{}
 
 	// MaybeHasNulls returns true if the column possibly has any null values, and
 	// returns false if the column definitely has no null values.

--- a/pkg/sql/exec/coldata/vec_tmpl.go
+++ b/pkg/sql/exec/coldata/vec_tmpl.go
@@ -177,16 +177,16 @@ func (m *memColumn) Slice(colType types.T, start uint64, end uint64) Vec {
 	}
 }
 
-func (m *memColumn) PrettyValueAt(colIdx uint16, colType types.T) string {
+func (m *memColumn) ValueAt(colIdx uint16) interface{} {
 	if m.nulls.NullAt(colIdx) {
-		return "NULL"
+		return nil
 	}
-	switch colType {
+	switch m.t {
 	// {{range .}}
 	case _TYPES_T:
-		return fmt.Sprintf("%v", m._TemplateType()[colIdx])
+		return m._TemplateType()[colIdx]
 	// {{end}}
 	default:
-		panic(fmt.Sprintf("unhandled type %d", colType))
+		panic(fmt.Sprintf("unhandled type %d", m.t))
 	}
 }

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -1,4 +1,4 @@
-# LogicTest: local-opt
+# LogicTest: local-vec
 
 statement ok
 CREATE TABLE kv (

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -3570,6 +3570,15 @@ func DatumTypeSize(t *types.T) (uintptr, bool) {
 	panic(errors.AssertionFailedf("unknown type: %T", t))
 }
 
+func MakeDatum(t *types.T, d interface{}) (Datum, error) {
+	if d == nil {
+		return DNull, nil
+	}
+	switch t.Family() {
+
+	}
+}
+
 const (
 	fixedSize    = false
 	variableSize = true


### PR DESCRIPTION
I started hacking on this and didn't get very far. We need to add the same tracing that the fetcher has. It's mildly annoying because you have to Datumify the data that's already in vector form, but I don't think there's anything too painful about it.

@rohany take a look at this, there's a couple of other spots in the cfetcher to add similar tracing to, based on how the original fetcher does it.

Release note: None