### PR TITLE
release-19.1: sql: fix upsert in the presence of column mutations

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1907,8 +1907,9 @@ func (dsp *DistSQLPlanner) createPlanForLookupJoin(
 	}
 
 	joinReaderSpec := distsqlpb.JoinReaderSpec{
-		Table: *n.table.desc.TableDesc(),
-		Type:  n.joinType,
+		Table:      *n.table.desc.TableDesc(),
+		Type:       n.joinType,
+		Visibility: n.table.colCfg.visibility.toDistSQLScanVisibility(),
 	}
 	joinReaderSpec.IndexIdx, err = getIndexIdx(n.table)
 	if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -959,3 +959,30 @@ DO UPDATE SET c = table35970.a+1
 RETURNING b
 ----
 NULL
+
+# ------------------------------------------------------------------------------
+# Regression for #38627: make sure that UPSERTs in the presence of column
+# mutations don't cause problems.
+# ------------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE table38627 (a INT PRIMARY KEY, b INT); INSERT INTO table38627 VALUES(1,1)
+
+statement ok
+BEGIN; ALTER TABLE table38627 ADD COLUMN c INT NOT NULL DEFAULT 5
+
+statement ok
+UPSERT INTO table38627 SELECT * FROM table38627 WHERE a=1
+
+query II
+SELECT * from table38627
+----
+1  1
+
+statement ok
+COMMIT
+
+query III
+SELECT * from table38627
+----
+1  1  5

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -373,3 +373,40 @@ INSERT INTO t35364 (x) VALUES (1.5) ON CONFLICT (x) DO UPDATE SET x=2.5 RETURNIN
 
 statement error pq: failed to satisfy CHECK constraint \(z >= 7\)
 UPSERT INTO t35364 (x) VALUES (0)
+
+# ------------------------------------------------------------------------------
+# Regression for #38627. Combined with the equivalent logic test, make sure that
+# UPSERT in the presence of column mutations uses a lookup join without a
+# problem.
+# ------------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE table38627 (a INT PRIMARY KEY, b INT); INSERT INTO table38627 VALUES(1,1)
+
+statement ok
+BEGIN; ALTER TABLE table38627 ADD COLUMN c INT NOT NULL DEFAULT 5
+
+query TTTTT
+EXPLAIN (VERBOSE) UPSERT INTO table38627 SELECT * FROM table38627 WHERE a=1
+----
+count                       ·                      ·                   ()                     ·
+ └── upsert                 ·                      ·                   ()                     ·
+      │                     into                   table38627(a, b)    ·                      ·
+      │                     strategy               opt upserter        ·                      ·
+      └── render            ·                      ·                   (a, b, a, b, c, b, a)  ·
+           │                render 0               a                   ·                      ·
+           │                render 1               b                   ·                      ·
+           │                render 2               a                   ·                      ·
+           │                render 3               b                   ·                      ·
+           │                render 4               c                   ·                      ·
+           │                render 5               b                   ·                      ·
+           │                render 6               a                   ·                      ·
+           └── lookup-join  ·                      ·                   (a, b, a, b, c)        ·
+                │           table                  table38627@primary  ·                      ·
+                │           type                   inner               ·                      ·
+                └── scan    ·                      ·                   (a, b)                 ·
+·                           table                  table38627@primary  ·                      ·
+·                           spans                  /1-/1/#             ·                      ·
+
+statement ok
+COMMIT


### PR DESCRIPTION
Backport 1/1 commits from #38637.

/cc @cockroachdb/release

---

Fixes #38627.

Previously, UPSERT behaved incorrectly and could cause crashes when
planned with lookup join during a column mutation event.

Now, lookup joins are planned with an explicit visibility flag, which
prevents this issue.

Release note (bug fix): Fix issue where CBO-planned upserts that used
lookup join that were run during column mutations on the table being
upserted into could cause crashes or other issues.
