### PR TITLE
roachtest: update predecessor versions

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1020,9 +1020,9 @@ func PredecessorVersion(buildVersion version.Version) (string, error) {
 	buildVersionMajorMinor := fmt.Sprintf("%d.%d", buildVersion.Major(), buildVersion.Minor())
 
 	verMap := map[string]string{
-		"19.2": "19.1.0-rc.4",
-		"19.1": "2.1.6",
-		"2.2":  "2.1.6",
+		"19.2": "19.1.3",
+		"19.1": "2.1.8",
+		"2.2":  "2.1.8",
 		"2.1":  "2.0.7",
 	}
 	v, ok := verMap[buildVersionMajorMinor]


### PR DESCRIPTION
Update `PredecessorVersion` to use the latest patch releases, 2.1.8
and 19.1.3.

Release note: None