### PR TITLE
opt: support CANCEL/RESUME/STOP JOBS and CANCEL QUERIES/SESSIONS

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/run_control
+++ b/pkg/sql/logictest/testdata/logic_test/run_control
@@ -9,10 +9,12 @@ PAUSE JOB 'foo'
 query error could not parse "foo" as type int
 CANCEL JOBS SELECT 'foo'
 
-query error CANCEL JOBS expects a single column source, got 2 columns
+# The heuristic planner and the optimizer give different errors for these
+# queries. Accept both.
+query error (CANCEL JOBS expects a single column source, got 2 columns|too many columns in CANCEL JOBS data)
 CANCEL JOBS VALUES (1,2)
 
-query error CANCEL JOBS requires int values, not type oid
+query error (CANCEL JOBS requires int values, not type oid|pq: CANCEL JOBS data column 1 \(job_id\) must be of type int, not type oid)
 CANCEL JOB 1::OID
 
 statement ok count 0
@@ -24,7 +26,7 @@ PAUSE JOBS SELECT id FROM system.jobs LIMIT 0
 query error could not parse "foo" as type int
 PAUSE JOBS SELECT 'foo'
 
-query error PAUSE JOBS expects a single column source, got 2 columns
+query error (PAUSE JOBS expects a single column source, got 2 columns|too many columns in PAUSE JOBS data)
 PAUSE JOBS VALUES (1,2)
 
 query error job with ID 1 does not exist
@@ -36,7 +38,7 @@ RESUME JOB 'foo'
 query error could not parse "foo" as type int
 RESUME JOBS SELECT 'foo'
 
-query error RESUME JOBS expects a single column source, got 2 columns
+query error (RESUME JOBS expects a single column source, got 2 columns|too many columns in RESUME JOBS data)
 RESUME JOBS VALUES (1,2)
 
 statement ok count 0

--- a/pkg/sql/logictest/testdata/logic_test/run_control
+++ b/pkg/sql/logictest/testdata/logic_test/run_control
@@ -59,10 +59,10 @@ CANCEL JOB (SELECT id FROM system.jobs LIMIT 0)
 statement ok count 0
 CANCEL JOBS SELECT id FROM system.jobs LIMIT 0
 
-query error CANCEL QUERIES requires string values, not type int
+query error (CANCEL QUERIES requires string values, not type int|CANCEL QUERIES data column 1 \(query_id\) must be of type string, not type int)
 CANCEL QUERY 1
 
-query error CANCEL QUERIES expects a single column source, got 2 columns
+query error (CANCEL QUERIES expects a single column source, got 2 columns|too many columns in CANCEL QUERIES data)
 CANCEL QUERIES VALUES (1,2)
 
 query error odd length hex string
@@ -71,10 +71,13 @@ CANCEL QUERY 'f54'
 query error not found
 CANCEL QUERY '14d2355b9cccbca50000000000000001'
 
-query error CANCEL SESSIONS requires string values, not type int
+statement ok
+CANCEL QUERY IF EXISTS '14d2355b9cccbca50000000000000001'
+
+query error (CANCEL SESSIONS requires string values, not type int|CANCEL SESSIONS data column 1 \(session_id\) must be of type string, not type int)
 CANCEL SESSION 1
 
-query error CANCEL SESSIONS expects a single column source, got 2 columns
+query error (CANCEL SESSIONS expects a single column source, got 2 columns|too many columns in CANCEL SESSIONS data)
 CANCEL SESSIONS VALUES (1,2)
 
 query error odd length hex string
@@ -82,6 +85,9 @@ CANCEL SESSION 'f54'
 
 query error not found
 CANCEL SESSION '14d2355b9cccbca50000000000000001'
+
+statement ok
+CANCEL SESSION IF EXISTS '14d2355b9cccbca50000000000000001'
 
 statement ok count 0
 CANCEL SESSION (SELECT 'a' LIMIT 0)

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -329,3 +329,11 @@ func (f *stubFactory) ConstructControlJobs(
 ) (exec.Node, error) {
 	return struct{}{}, nil
 }
+
+func (f *stubFactory) ConstructCancelQueries(input exec.Node, ifExists bool) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructCancelSessions(input exec.Node, ifExists bool) (exec.Node, error) {
+	return struct{}{}, nil
+}

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -323,3 +323,9 @@ func (f *stubFactory) ConstructBuffer(value exec.Node, label string) (exec.Node,
 func (f *stubFactory) ConstructScanBuffer(ref exec.Node, label string) (exec.Node, error) {
 	return struct{}{}, nil
 }
+
+func (f *stubFactory) ConstructControlJobs(
+	command tree.JobCommand, input exec.Node,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -268,6 +268,12 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 	case *memo.ControlJobsExpr:
 		ep, err = b.buildControlJobs(t)
 
+	case *memo.CancelQueriesExpr:
+		ep, err = b.buildCancelQueries(t)
+
+	case *memo.CancelSessionsExpr:
+		ep, err = b.buildCancelSessions(t)
+
 	default:
 		if opt.IsSetOp(e) {
 			ep, err = b.buildSetOp(e)

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -265,6 +265,9 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 	case *memo.AlterTableRelocateExpr:
 		ep, err = b.buildAlterTableRelocate(t)
 
+	case *memo.ControlJobsExpr:
+		ep, err = b.buildControlJobs(t)
+
 	default:
 		if opt.IsSetOp(e) {
 			ep, err = b.buildSetOp(e)

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -230,3 +230,29 @@ func (b *Builder) buildControlJobs(ctl *memo.ControlJobsExpr) (execPlan, error) 
 	// ControlJobs returns no columns.
 	return execPlan{root: node}, nil
 }
+
+func (b *Builder) buildCancelQueries(cancel *memo.CancelQueriesExpr) (execPlan, error) {
+	input, err := b.buildRelational(cancel.Input)
+	if err != nil {
+		return execPlan{}, err
+	}
+	node, err := b.factory.ConstructCancelQueries(input.root, cancel.IfExists)
+	if err != nil {
+		return execPlan{}, err
+	}
+	// CancelQueries returns no columns.
+	return execPlan{root: node}, nil
+}
+
+func (b *Builder) buildCancelSessions(cancel *memo.CancelSessionsExpr) (execPlan, error) {
+	input, err := b.buildRelational(cancel.Input)
+	if err != nil {
+		return execPlan{}, err
+	}
+	node, err := b.factory.ConstructCancelSessions(input.root, cancel.IfExists)
+	if err != nil {
+		return execPlan{}, err
+	}
+	// CancelSessions returns no columns.
+	return execPlan{root: node}, nil
+}

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -214,3 +214,19 @@ func (b *Builder) buildAlterTableRelocate(relocate *memo.AlterTableRelocateExpr)
 	}
 	return ep, nil
 }
+
+func (b *Builder) buildControlJobs(ctl *memo.ControlJobsExpr) (execPlan, error) {
+	input, err := b.buildRelational(ctl.Input)
+	if err != nil {
+		return execPlan{}, err
+	}
+	node, err := b.factory.ConstructControlJobs(
+		ctl.Command,
+		input.root,
+	)
+	if err != nil {
+		return execPlan{}, err
+	}
+	// ControlJobs returns no columns.
+	return execPlan{root: node}, nil
+}

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -430,6 +430,10 @@ type Factory interface {
 	// ConstructScanBuffer constructs a node which refers to a node constructed by
 	// ConstructBuffer.
 	ConstructScanBuffer(ref Node, label string) (Node, error)
+
+	// ConstructControlJobs creates a node that implements PAUSE/CANCEL/RESUME
+	// JOBS.
+	ConstructControlJobs(command tree.JobCommand, input Node) (Node, error)
 }
 
 // OutputOrdering indicates the required output ordering on a Node that is being

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -434,6 +434,12 @@ type Factory interface {
 	// ConstructControlJobs creates a node that implements PAUSE/CANCEL/RESUME
 	// JOBS.
 	ConstructControlJobs(command tree.JobCommand, input Node) (Node, error)
+
+	// ConstructCancelQueries creates a node that implements CANCEL QUERIES.
+	ConstructCancelQueries(input Node, ifExists bool) (Node, error)
+
+	// ConstructCancelSessions creates a node that implements CANCEL SESSIONS.
+	ConstructCancelSessions(input Node, ifExists bool) (Node, error)
 }
 
 // OutputOrdering indicates the required output ordering on a Node that is being

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -188,7 +188,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 	case *ScanExpr, *VirtualScanExpr, *IndexJoinExpr, *ShowTraceForSessionExpr,
 		*InsertExpr, *UpdateExpr, *UpsertExpr, *DeleteExpr, *SequenceSelectExpr,
 		*WindowExpr, *OpaqueRelExpr, *AlterTableSplitExpr, *AlterTableUnsplitExpr,
-		*AlterTableUnsplitAllExpr, *AlterTableRelocateExpr:
+		*AlterTableUnsplitAllExpr, *AlterTableRelocateExpr, *ControlJobsExpr:
 		fmt.Fprintf(f.Buffer, "%v", e.Op())
 		FormatPrivate(f, e.Private(), required)
 
@@ -1018,6 +1018,9 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 		if t.RelocateLease {
 			f.Buffer.WriteString(" [lease]")
 		}
+
+	case *ControlJobsPrivate:
+		fmt.Fprintf(f.Buffer, " (%s)", tree.JobCommandToStatement[t.Command])
 
 	case *JoinPrivate:
 		// Nothing to show; flags are shown separately.

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -188,7 +188,8 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 	case *ScanExpr, *VirtualScanExpr, *IndexJoinExpr, *ShowTraceForSessionExpr,
 		*InsertExpr, *UpdateExpr, *UpsertExpr, *DeleteExpr, *SequenceSelectExpr,
 		*WindowExpr, *OpaqueRelExpr, *AlterTableSplitExpr, *AlterTableUnsplitExpr,
-		*AlterTableUnsplitAllExpr, *AlterTableRelocateExpr, *ControlJobsExpr:
+		*AlterTableUnsplitAllExpr, *AlterTableRelocateExpr, *ControlJobsExpr,
+		*CancelQueriesExpr, *CancelSessionsExpr:
 		fmt.Fprintf(f.Buffer, "%v", e.Op())
 		FormatPrivate(f, e.Private(), required)
 
@@ -1021,6 +1022,11 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 
 	case *ControlJobsPrivate:
 		fmt.Fprintf(f.Buffer, " (%s)", tree.JobCommandToStatement[t.Command])
+
+	case *CancelPrivate:
+		if t.IfExists {
+			f.Buffer.WriteString(" [if-exists]")
+		}
 
 	case *JoinPrivate:
 		// Nothing to show; flags are shown separately.

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -493,6 +493,10 @@ func (h *hasher) HashShowTraceType(val tree.ShowTraceType) {
 	h.HashString(string(val))
 }
 
+func (h *hasher) HashJobCommand(val tree.JobCommand) {
+	h.HashInt(int(val))
+}
+
 func (h *hasher) HashWindowFrame(val WindowFrame) {
 	h.HashInt(int(val.StartBoundType))
 	h.HashInt(int(val.EndBoundType))
@@ -781,6 +785,10 @@ func (h *hasher) IsStatementTypeEqual(l, r tree.StatementType) bool {
 }
 
 func (h *hasher) IsShowTraceTypeEqual(l, r tree.ShowTraceType) bool {
+	return l == r
+}
+
+func (h *hasher) IsJobCommandEqual(l, r tree.JobCommand) bool {
 	return l == r
 }
 

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -842,6 +842,11 @@ func (b *logicalPropsBuilder) buildAlterTableRelocateProps(
 	rel.CanMutate = true
 }
 
+func (b *logicalPropsBuilder) buildControlJobsProps(ctl *ControlJobsExpr, rel *props.Relational) {
+	b.buildBasicProps(ctl, opt.ColList{}, rel)
+	rel.CanHaveSideEffects = true
+}
+
 func (b *logicalPropsBuilder) buildLimitProps(limit *LimitExpr, rel *props.Relational) {
 	BuildSharedProps(b.mem, limit, &rel.Shared)
 

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -847,6 +847,20 @@ func (b *logicalPropsBuilder) buildControlJobsProps(ctl *ControlJobsExpr, rel *p
 	rel.CanHaveSideEffects = true
 }
 
+func (b *logicalPropsBuilder) buildCancelQueriesProps(
+	cancel *CancelQueriesExpr, rel *props.Relational,
+) {
+	b.buildBasicProps(cancel, opt.ColList{}, rel)
+	rel.CanHaveSideEffects = true
+}
+
+func (b *logicalPropsBuilder) buildCancelSessionsProps(
+	cancel *CancelSessionsExpr, rel *props.Relational,
+) {
+	b.buildBasicProps(cancel, opt.ColList{}, rel)
+	rel.CanHaveSideEffects = true
+}
+
 func (b *logicalPropsBuilder) buildLimitProps(limit *LimitExpr, rel *props.Relational) {
 	BuildSharedProps(b.mem, limit, &rel.Shared)
 

--- a/pkg/sql/opt/ops/statement.opt
+++ b/pkg/sql/opt/ops/statement.opt
@@ -155,3 +155,20 @@ define AlterTableRelocatePrivate {
 
     _ AlterTableSplitPrivate
 }
+
+# ControlJobs represents a `PAUSE/CANCEL/RESUME JOBS` statement.
+[Relational]
+define ControlJobs {
+    # The input expression returns job IDs (as integers).
+    Input RelExpr
+
+    _ ControlJobsPrivate
+}
+
+[Private]
+define ControlJobsPrivate {
+    # Props stores the required physical properties for the enclosed
+    # expression.
+    Props    PhysProps
+    Command  JobCommand
+}

--- a/pkg/sql/opt/ops/statement.opt
+++ b/pkg/sql/opt/ops/statement.opt
@@ -117,7 +117,7 @@ define AlterTableSplitPrivate {
     # cat.Index metadata.
     Index int
 
-    # Props stores the required physical properties for the enclosed expression.
+    # Props stores the required physical properties for the input expression.
     Props PhysProps
 
     # Columns stores the column IDs for the statement result columns.
@@ -167,8 +167,36 @@ define ControlJobs {
 
 [Private]
 define ControlJobsPrivate {
-    # Props stores the required physical properties for the enclosed
+    # Props stores the required physical properties for the input
     # expression.
     Props    PhysProps
     Command  JobCommand
+}
+
+# CancelQueries represents a `CANCEL QUERIES` statement.
+[Relational]
+define CancelQueries {
+    # The input expression returns query IDs (as strings).
+    Input RelExpr
+
+    _ CancelPrivate
+}
+
+[Private]
+define CancelPrivate {
+    # Props stores the required physical properties for the input
+    # expression.
+    Props PhysProps
+
+    # IfExists is set if we should tolerate IDs that don't exist.
+    IfExists bool
+}
+
+# CancelSessions represents a `CANCEL SESSIONS` statement.
+[Relational]
+define CancelSessions {
+    # The input expression returns session IDs (as strings).
+    Input RelExpr
+
+    _ CancelPrivate
 }

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -226,6 +226,9 @@ func (b *Builder) buildStmt(
 	case *tree.Relocate:
 		return b.buildAlterTableRelocate(stmt, inScope)
 
+	case *tree.ControlJobs:
+		return b.buildControlJobs(stmt, inScope)
+
 	default:
 		// See if this statement can be rewritten to another statement using the
 		// delegate functionality.

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -229,6 +229,12 @@ func (b *Builder) buildStmt(
 	case *tree.ControlJobs:
 		return b.buildControlJobs(stmt, inScope)
 
+	case *tree.CancelQueries:
+		return b.buildCancelQueries(stmt, inScope)
+
+	case *tree.CancelSessions:
+		return b.buildCancelSessions(stmt, inScope)
+
 	default:
 		// See if this statement can be rewritten to another statement using the
 		// delegate functionality.

--- a/pkg/sql/opt/optbuilder/misc_statements.go
+++ b/pkg/sql/opt/optbuilder/misc_statements.go
@@ -1,0 +1,44 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package optbuilder
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+)
+
+func (b *Builder) buildControlJobs(n *tree.ControlJobs, inScope *scope) (outScope *scope) {
+	// We don't allow the input statement to reference outer columns, so we
+	// pass a "blank" scope rather than inScope.
+	emptyScope := &scope{builder: b}
+	colTypes := []*types.T{types.Int}
+	inputScope := b.buildStmt(n.Jobs, colTypes, emptyScope)
+
+	checkInputColumns(
+		fmt.Sprintf("%s JOBS", tree.JobCommandToStatement[n.Command]),
+		inputScope,
+		[]string{"job_id"},
+		colTypes,
+		1, /* minPrefix */
+	)
+	outScope = inScope.push()
+	outScope.expr = b.factory.ConstructControlJobs(
+		inputScope.expr.(memo.RelExpr),
+		&memo.ControlJobsPrivate{
+			Props:   inputScope.makePhysicalProps(),
+			Command: n.Command,
+		},
+	)
+	return outScope
+}

--- a/pkg/sql/opt/optbuilder/testdata/misc_statements
+++ b/pkg/sql/opt/optbuilder/testdata/misc_statements
@@ -1,0 +1,58 @@
+exec-ddl
+CREATE TABLE ab (a INT, b INT)
+----
+
+build
+CANCEL JOBS SELECT 1
+----
+control-jobs (CANCEL)
+ └── project
+      ├── columns: "?column?":1(int!null)
+      ├── values
+      │    └── tuple [type=tuple]
+      └── projections
+           └── const: 1 [type=int]
+
+build
+RESUME JOBS VALUES (1), (2), (3)
+----
+control-jobs (RESUME)
+ └── values
+      ├── columns: column1:1(int!null)
+      ├── tuple [type=tuple{int}]
+      │    └── const: 1 [type=int]
+      ├── tuple [type=tuple{int}]
+      │    └── const: 2 [type=int]
+      └── tuple [type=tuple{int}]
+           └── const: 3 [type=int]
+
+build
+PAUSE JOBS SELECT b FROM ab ORDER BY a
+----
+control-jobs (PAUSE)
+ └── sort
+      ├── columns: b:2(int)  [hidden: a:1(int)]
+      ├── ordering: +1
+      └── project
+           ├── columns: a:1(int) b:2(int)
+           └── scan ab
+                └── columns: a:1(int) b:2(int) rowid:3(int!null)
+
+build
+PAUSE JOB 1
+----
+control-jobs (PAUSE)
+ └── values
+      ├── columns: column1:1(int!null)
+      └── tuple [type=tuple{int}]
+           └── const: 1 [type=int]
+
+build
+PAUSE JOBS SELECT 1.1
+----
+error (42601): PAUSE JOBS data column 1 (job_id) must be of type int, not type decimal
+
+build
+CANCEL JOBS SELECT 1, 1
+----
+error (42601): too many columns in CANCEL JOBS data

--- a/pkg/sql/opt/optbuilder/testdata/misc_statements
+++ b/pkg/sql/opt/optbuilder/testdata/misc_statements
@@ -1,5 +1,5 @@
 exec-ddl
-CREATE TABLE ab (a INT, b INT)
+CREATE TABLE ab (a INT, b STRING)
 ----
 
 build
@@ -27,16 +27,16 @@ control-jobs (RESUME)
            └── const: 3 [type=int]
 
 build
-PAUSE JOBS SELECT b FROM ab ORDER BY a
+PAUSE JOBS SELECT a FROM ab ORDER BY b
 ----
 control-jobs (PAUSE)
  └── sort
-      ├── columns: b:2(int)  [hidden: a:1(int)]
-      ├── ordering: +1
+      ├── columns: a:1(int)  [hidden: b:2(string)]
+      ├── ordering: +2
       └── project
-           ├── columns: a:1(int) b:2(int)
+           ├── columns: a:1(int) b:2(string)
            └── scan ab
-                └── columns: a:1(int) b:2(int) rowid:3(int!null)
+                └── columns: a:1(int) b:2(string) rowid:3(int!null)
 
 build
 PAUSE JOB 1
@@ -56,3 +56,87 @@ build
 CANCEL JOBS SELECT 1, 1
 ----
 error (42601): too many columns in CANCEL JOBS data
+
+build
+CANCEL SESSION 'foo'
+----
+cancel-sessions
+ └── values
+      ├── columns: column1:1(string!null)
+      └── tuple [type=tuple{string}]
+           └── const: 'foo' [type=string]
+
+build
+CANCEL SESSIONS VALUES ('foo'), ('bar')
+----
+cancel-sessions
+ └── values
+      ├── columns: column1:1(string!null)
+      ├── tuple [type=tuple{string}]
+      │    └── const: 'foo' [type=string]
+      └── tuple [type=tuple{string}]
+           └── const: 'bar' [type=string]
+
+build
+CANCEL SESSIONS SELECT b FROM ab ORDER BY a
+----
+cancel-sessions
+ └── sort
+      ├── columns: b:2(string)  [hidden: a:1(int)]
+      ├── ordering: +1
+      └── project
+           ├── columns: a:1(int) b:2(string)
+           └── scan ab
+                └── columns: a:1(int) b:2(string) rowid:3(int!null)
+
+build
+CANCEL SESSION 1
+----
+error (42601): CANCEL SESSIONS data column 1 (session_id) must be of type string, not type int
+
+build
+CANCEL SESSIONS VALUES (1, 2)
+----
+error (42601): too many columns in CANCEL SESSIONS data
+
+build
+CANCEL QUERY 'foo'
+----
+cancel-queries
+ └── values
+      ├── columns: column1:1(string!null)
+      └── tuple [type=tuple{string}]
+           └── const: 'foo' [type=string]
+
+build
+CANCEL QUERIES VALUES ('foo'), ('bar')
+----
+cancel-queries
+ └── values
+      ├── columns: column1:1(string!null)
+      ├── tuple [type=tuple{string}]
+      │    └── const: 'foo' [type=string]
+      └── tuple [type=tuple{string}]
+           └── const: 'bar' [type=string]
+
+build
+CANCEL QUERIES SELECT b FROM ab ORDER BY a
+----
+cancel-queries
+ └── sort
+      ├── columns: b:2(string)  [hidden: a:1(int)]
+      ├── ordering: +1
+      └── project
+           ├── columns: a:1(int) b:2(string)
+           └── scan ab
+                └── columns: a:1(int) b:2(string) rowid:3(int!null)
+
+build
+CANCEL QUERY 1
+----
+error (42601): CANCEL QUERIES data column 1 (query_id) must be of type string, not type int
+
+build
+CANCEL QUERIES VALUES (1, 2)
+----
+error (42601): too many columns in CANCEL QUERIES data

--- a/pkg/sql/opt/optgen/cmd/optgen/metadata.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/metadata.go
@@ -178,6 +178,7 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"RelPropsPtr":    {fullName: "*props.Relational", isPointer: true, usePointerIntern: true},
 		"ScalarProps":    {fullName: "props.Scalar"},
 		"OpaqueMetadata": {fullName: "opt.OpaqueMetadata", isPointer: true},
+		"JobCommand":     {fullName: "tree.JobCommand", passByVal: true},
 	}
 
 	// Add types of generated op and private structs.

--- a/pkg/sql/opt/ordering/ordering.go
+++ b/pkg/sql/opt/ordering/ordering.go
@@ -202,6 +202,11 @@ func init() {
 		buildChildReqOrdering: alterTableRelocateBuildChildReqOrdering,
 		buildProvidedOrdering: noProvidedOrdering,
 	}
+	funcMap[opt.ControlJobsOp] = funcs{
+		canProvideOrdering:    canNeverProvideOrdering,
+		buildChildReqOrdering: controlJobsBuildChildReqOrdering,
+		buildProvidedOrdering: noProvidedOrdering,
+	}
 }
 
 func canNeverProvideOrdering(expr memo.RelExpr, required *physical.OrderingChoice) bool {

--- a/pkg/sql/opt/ordering/ordering.go
+++ b/pkg/sql/opt/ordering/ordering.go
@@ -207,6 +207,16 @@ func init() {
 		buildChildReqOrdering: controlJobsBuildChildReqOrdering,
 		buildProvidedOrdering: noProvidedOrdering,
 	}
+	funcMap[opt.CancelQueriesOp] = funcs{
+		canProvideOrdering:    canNeverProvideOrdering,
+		buildChildReqOrdering: cancelQueriesBuildChildReqOrdering,
+		buildProvidedOrdering: noProvidedOrdering,
+	}
+	funcMap[opt.CancelSessionsOp] = funcs{
+		canProvideOrdering:    canNeverProvideOrdering,
+		buildChildReqOrdering: cancelSessionsBuildChildReqOrdering,
+		buildProvidedOrdering: noProvidedOrdering,
+	}
 }
 
 func canNeverProvideOrdering(expr memo.RelExpr, required *physical.OrderingChoice) bool {

--- a/pkg/sql/opt/ordering/statement.go
+++ b/pkg/sql/opt/ordering/statement.go
@@ -56,3 +56,21 @@ func controlJobsBuildChildReqOrdering(
 	}
 	return parent.(*memo.ControlJobsExpr).Props.Ordering
 }
+
+func cancelQueriesBuildChildReqOrdering(
+	parent memo.RelExpr, required *physical.OrderingChoice, childIdx int,
+) physical.OrderingChoice {
+	if childIdx != 0 {
+		return physical.OrderingChoice{}
+	}
+	return parent.(*memo.CancelQueriesExpr).Props.Ordering
+}
+
+func cancelSessionsBuildChildReqOrdering(
+	parent memo.RelExpr, required *physical.OrderingChoice, childIdx int,
+) physical.OrderingChoice {
+	if childIdx != 0 {
+		return physical.OrderingChoice{}
+	}
+	return parent.(*memo.CancelSessionsExpr).Props.Ordering
+}

--- a/pkg/sql/opt/ordering/statement.go
+++ b/pkg/sql/opt/ordering/statement.go
@@ -47,3 +47,12 @@ func alterTableRelocateBuildChildReqOrdering(
 	}
 	return parent.(*memo.AlterTableRelocateExpr).Props.Ordering
 }
+
+func controlJobsBuildChildReqOrdering(
+	parent memo.RelExpr, required *physical.OrderingChoice, childIdx int,
+) physical.OrderingChoice {
+	if childIdx != 0 {
+		return physical.OrderingChoice{}
+	}
+	return parent.(*memo.ControlJobsExpr).Props.Ordering
+}

--- a/pkg/sql/opt/xform/physical_props.go
+++ b/pkg/sql/opt/xform/physical_props.go
@@ -57,6 +57,8 @@ func BuildChildPhysicalProps(
 		childProps.Presentation = parent.(*memo.AlterTableUnsplitExpr).Props.Presentation
 	case opt.AlterTableRelocateOp:
 		childProps.Presentation = parent.(*memo.AlterTableRelocateExpr).Props.Presentation
+	case opt.ControlJobsOp:
+		childProps.Presentation = parent.(*memo.ControlJobsExpr).Props.Presentation
 	}
 
 	childProps.Ordering = ordering.BuildChildRequired(parent, &parentProps.Ordering, nth)

--- a/pkg/sql/opt/xform/physical_props.go
+++ b/pkg/sql/opt/xform/physical_props.go
@@ -59,6 +59,10 @@ func BuildChildPhysicalProps(
 		childProps.Presentation = parent.(*memo.AlterTableRelocateExpr).Props.Presentation
 	case opt.ControlJobsOp:
 		childProps.Presentation = parent.(*memo.ControlJobsExpr).Props.Presentation
+	case opt.CancelQueriesOp:
+		childProps.Presentation = parent.(*memo.CancelQueriesExpr).Props.Presentation
+	case opt.CancelSessionsOp:
+		childProps.Presentation = parent.(*memo.CancelSessionsExpr).Props.Presentation
 	}
 
 	childProps.Ordering = ordering.BuildChildRequired(parent, &parentProps.Ordering, nth)

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1820,6 +1820,16 @@ func (ef *execFactory) ConstructAlterTableRelocate(
 	}, nil
 }
 
+// ConstructControlJobs is part of the exec.Factory interface.
+func (ef *execFactory) ConstructControlJobs(
+	command tree.JobCommand, input exec.Node,
+) (exec.Node, error) {
+	return &controlJobsNode{
+		rows:          input.(planNode),
+		desiredStatus: jobCommandToDesiredStatus[command],
+	}, nil
+}
+
 // renderBuilder encapsulates the code to build a renderNode.
 type renderBuilder struct {
 	r   *renderNode

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1830,6 +1830,22 @@ func (ef *execFactory) ConstructControlJobs(
 	}, nil
 }
 
+// ConstructCancelQueries is part of the exec.Factory interface.
+func (ef *execFactory) ConstructCancelQueries(input exec.Node, ifExists bool) (exec.Node, error) {
+	return &cancelQueriesNode{
+		rows:     input.(planNode),
+		ifExists: ifExists,
+	}, nil
+}
+
+// ConstructCancelSessions is part of the exec.Factory interface.
+func (ef *execFactory) ConstructCancelSessions(input exec.Node, ifExists bool) (exec.Node, error) {
+	return &cancelSessionsNode{
+		rows:     input.(planNode),
+		ifExists: ifExists,
+	}, nil
+}
+
 // renderBuilder encapsulates the code to build a renderNode.
 type renderBuilder struct {
 	r   *renderNode


### PR DESCRIPTION
#### opt: support CANCEL/RESUME/STOP JOBS

Support these flavors of the `ControlJobs` node as a `ControlJobs`
operator.

Release note: None

#### opt: support CANCEL QUERIES and CANCEL SESSIONS

Release note: None
