### PR TITLE
exec: fix a panic with sum_int aggregate with input types other than Int64

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -204,6 +204,11 @@ func newColOperator(
 					// issues, at first, we could plan SUM for all types besides Int64.
 					return nil, nil, memUsage, errors.Newf("sum on int cols not supported (use sum_int)")
 				}
+			case distsqlpb.AggregatorSpec_SUM_INT:
+				// TODO(yuzefovich): support this case through vectorize.
+				if aggTyps[i][0].Width() != 64 {
+					return nil, nil, memUsage, errors.Newf("sum_int is only supported on Int64 through vectorized")
+				}
 			}
 			_, retType, err := GetAggregateInfo(agg.Func, aggTyps[i]...)
 			if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -515,3 +515,12 @@ query I
 SELECT EXTRACT(YEAR FROM x) FROM extract_test
 ----
 2017
+
+# Regression test for #38937
+statement ok
+CREATE TABLE t38937 (_int2) AS SELECT 1::INT2
+
+query I
+SELECT sum_int(_int2) FROM t38937
+----
+1


### PR DESCRIPTION
First commit wraps Next of materializer with a vectorized panic catcher.

We used to catch panics only when calling Next() on the the input to
materializer. However, it is also possible that types get messed up
during planning a vectorized flow which can lead to a type conversion
panic. We do not want to crash in such case either, so we wrap full
Next() method with a catcher.

Second commit falls back to DistSQL on sum_int if not on Int64.

Currently, our aggregates expect that input and output types are
the same. However, sum_int is planned such that flow consumer
expects Int64 regardless of the input types. Supporting this would
require adding specialized sum aggregates that would take in any
int type and would output Int64. It is easier for now to just
fallback to DistSQL on non-int64 input types.

Fixes: #38937.