### PR TITLE
sql: Changing k/v tracing test formats.

### DIFF
--- a/pkg/sql/logictest/testdata/planner_test/aggregate
+++ b/pkg/sql/logictest/testdata/planner_test/aggregate
@@ -351,8 +351,9 @@ statement ok
 SET tracing = on,kv,results; SELECT min(x) FROM xyz WHERE (y, z) = (2, 3.0); SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /xyz/zyx/3.0/2/1 -> NULL
 output row: [1]
@@ -378,8 +379,9 @@ statement ok
 SET tracing = on,kv,results; SELECT variance(x), variance(y::decimal), round(variance(z), 14) FROM xyz; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /xyz/primary/1 -> NULL
 fetched: /xyz/primary/1/y -> 2
@@ -404,17 +406,6 @@ group           ·            ·
       └── scan  ·            ·
 ·               table        xyz@xy
 ·               spans        /1-/2
-
-# Verify we only look at one row for MIN when we have an index on that column.
-statement ok
-SET tracing = on,kv,results; SELECT min(z) FROM xyz; SET tracing = off
-
-query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
- WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
-----
-fetched: /xyz/zyx/3.0/2/1 -> NULL
-output row: [3.0]
 
 # Tests for the single-row optimization.
 statement OK
@@ -448,18 +439,6 @@ INSERT INTO ab VALUES
   (4, 40),
   (5, 50)
 
-# Verify we only buffer one row.
-statement ok
-SET tracing = on,kv,results; SELECT min(a) FROM ab; SET tracing = off
-
-query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
- WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
-----
-fetched: /ab/primary/1 -> NULL
-fetched: /ab/primary/1/b -> 10
-output row: [1]
-
 query TTT
 SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT max(a) FROM abc
@@ -474,18 +453,6 @@ group              ·            ·
 ·                  table        abc@primary
 ·                  spans        ALL
 ·                  limit        1
-
-# Verify we only buffer one row.
-statement ok
-SET tracing = on,kv,results; SELECT max(a) FROM ab; SET tracing = off
-
-query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
- WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
-----
-fetched: /ab/primary/5/b -> 50
-fetched: /ab/primary/5 -> NULL
-output row: [5]
 
 query TTT
 SELECT tree, field, description FROM [

--- a/pkg/sql/logictest/testdata/planner_test/aggregate_vectorize_off
+++ b/pkg/sql/logictest/testdata/planner_test/aggregate_vectorize_off
@@ -1,0 +1,115 @@
+# LogicTest: local
+
+# This file contains test cases that cannot be run with the vectorized
+# execution engine.
+
+statement ok
+SET experimental_vectorize=off
+
+statement ok
+CREATE TABLE xyz (
+  x INT PRIMARY KEY,
+  y INT,
+  z FLOAT,
+  INDEX xy (x, y),
+  INDEX zyx (z, y, x),
+  FAMILY (x),
+  FAMILY (y),
+  FAMILY (z)
+)
+
+statement okSE
+INSERT INTO xyz VALUES (1, 2, 3.0), (4, 5, 6.0), (7, NULL, 8.0)
+
+# Verify we only look at one row for MIN when we have an index on that column.
+statement ok
+SET tracing = on,kv,results; SELECT min(z) FROM xyz; SET tracing = off
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
+ WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
+----
+fetched: /xyz/zyx/3.0/2/1 -> NULL
+output row: [3.0]
+
+# Tests for the single-row optimization.
+statement OK
+CREATE TABLE ab (
+  a INT PRIMARY KEY,
+  b INT,
+  FAMILY (a),
+  FAMILY (b)
+)
+
+statement ok
+CREATE TABLE abc (
+  a CHAR PRIMARY KEY,
+  b FLOAT,
+  c BOOLEAN,
+  d DECIMAL
+)
+
+query TTT
+SELECT tree, field, description FROM [
+EXPLAIN (VERBOSE) SELECT min(a) FROM abc
+]
+----
+group           ·            ·
+ │              aggregate 0  min(a)
+ │              scalar       ·
+ └── render     ·            ·
+      │         render 0     test.public.abc.a
+      └── scan  ·            ·
+·               table        abc@primary
+·               spans        ALL
+·               limit        1
+
+statement OK
+INSERT INTO ab VALUES
+  (1, 10),
+  (2, 20),
+  (3, 30),
+  (4, 40),
+  (5, 50)
+
+# Verify we only buffer one row.
+statement ok
+SET tracing = on,kv,results; SELECT min(a) FROM ab; SET tracing = off
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
+ WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
+----
+fetched: /ab/primary/1 -> NULL
+fetched: /ab/primary/1/b -> 10
+output row: [1]
+
+query TTT
+SELECT tree, field, description FROM [
+EXPLAIN (VERBOSE) SELECT max(a) FROM abc
+]
+----
+group              ·            ·
+ │                 aggregate 0  max(a)
+ │                 scalar       ·
+ └── render        ·            ·
+      │            render 0     test.public.abc.a
+      └── revscan  ·            ·
+·                  table        abc@primary
+·                  spans        ALL
+·                  limit        1
+
+# Verify we only buffer one row.
+statement ok
+SET tracing = on,kv,results; SELECT max(a) FROM ab; SET tracing = off
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
+ WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
+----
+fetched: /ab/primary/5/b -> 50
+fetched: /ab/primary/5 -> NULL
+output row: [5]

--- a/pkg/sql/logictest/testdata/planner_test/ddl
+++ b/pkg/sql/logictest/testdata/planner_test/ddl
@@ -19,8 +19,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/primary/1/f -> /9
 output row: [1 9]
@@ -35,8 +36,9 @@ statement ok
 SET tracing = on,kv,results; SELECT b FROM t@foo; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/foo/NULL -> /1
 output row: [NULL]
@@ -57,14 +59,15 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/primary/1/f -> /9
-output row: [1 9 NULL NULL]
 fetched: /t/primary/2/f/b/c -> /9/1/1
-output row: [2 9 1 1]
 fetched: /t/primary/3/f/b/c -> /9/2/1
+output row: [1 9 NULL NULL]
+output row: [2 9 1 1]
 output row: [3 9 2 1]
 
 statement ok
@@ -74,14 +77,15 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/primary/1/f -> /9
-output row: [1 9]
 fetched: /t/primary/2/f -> /9
-output row: [2 9]
 fetched: /t/primary/3/f -> /9
+output row: [1 9]
+output row: [2 9]
 output row: [3 9]
 
 # Verify limits and orderings are propagated correctly to the select.
@@ -124,8 +128,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/primary/1 -> NULL
 fetched: /t/primary/1/b -> 1
@@ -149,8 +154,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t@foo; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/foo/1/1 -> NULL
 output row: [1 1]
@@ -162,12 +168,13 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t@foo; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/foo/1/1 -> NULL
-output row: [1 1]
 fetched: /t/foo/1/2 -> NULL
+output row: [1 1]
 output row: [2 1]
 
 # test for DESC index
@@ -196,14 +203,15 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t@b_desc; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/b_desc/2/2 -> NULL
 fetched: /t/b_desc/1/1 -> NULL
 fetched: /t/primary/2/b/c -> /2/2
-output row: [2 2 2]
 fetched: /t/primary/1/b/c -> /1/1
+output row: [2 2 2]
 output row: [1 1 1]
 
 statement ok

--- a/pkg/sql/logictest/testdata/planner_test/delete
+++ b/pkg/sql/logictest/testdata/planner_test/delete
@@ -33,24 +33,27 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM kv; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM kv@foo; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM kv@bar; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 
 # Check that EXPLAIN does not destroy data (#6613)

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -46,8 +46,9 @@ statement ok
 SET tracing = on,kv,results; SELECT 1; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 output row: [1]
 

--- a/pkg/sql/logictest/testdata/planner_test/insert
+++ b/pkg/sql/logictest/testdata/planner_test/insert
@@ -27,56 +27,58 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM kv; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv/primary/'A' -> NULL
-output row: ['A' NULL]
 fetched: /kv/primary/'a' -> NULL
 fetched: /kv/primary/'a'/v -> 'b'
-output row: ['a' 'b']
 fetched: /kv/primary/'c' -> NULL
 fetched: /kv/primary/'c'/v -> 'd'
-output row: ['c' 'd']
 fetched: /kv/primary/'e' -> NULL
 fetched: /kv/primary/'e'/v -> 'f'
-output row: ['e' 'f']
 fetched: /kv/primary/'g' -> NULL
 fetched: /kv/primary/'g'/v -> ''
-output row: ['g' '']
 fetched: /kv/primary/'nil1' -> NULL
-output row: ['nil1' NULL]
 fetched: /kv/primary/'nil2' -> NULL
-output row: ['nil2' NULL]
 fetched: /kv/primary/'nil3' -> NULL
-output row: ['nil3' NULL]
 fetched: /kv/primary/'nil4' -> NULL
+output row: ['A' NULL]
+output row: ['a' 'b']
+output row: ['c' 'd']
+output row: ['e' 'f']
+output row: ['g' '']
+output row: ['nil1' NULL]
+output row: ['nil2' NULL]
+output row: ['nil3' NULL]
 output row: ['nil4' NULL]
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM kv@a; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv/a/NULL -> /'A'
-output row: ['A' NULL]
 fetched: /kv/a/NULL -> /'nil1'
-output row: ['nil1' NULL]
 fetched: /kv/a/NULL -> /'nil2'
-output row: ['nil2' NULL]
 fetched: /kv/a/NULL -> /'nil3'
-output row: ['nil3' NULL]
 fetched: /kv/a/NULL -> /'nil4'
-output row: ['nil4' NULL]
 fetched: /kv/a/'' -> /'g'
-output row: ['g' '']
 fetched: /kv/a/'b' -> /'a'
-output row: ['a' 'b']
 fetched: /kv/a/'d' -> /'c'
-output row: ['c' 'd']
 fetched: /kv/a/'f' -> /'e'
+output row: ['A' NULL]
+output row: ['nil1' NULL]
+output row: ['nil2' NULL]
+output row: ['nil3' NULL]
+output row: ['nil4' NULL]
+output row: ['g' '']
+output row: ['a' 'b']
+output row: ['c' 'd']
 output row: ['e' 'f']
 
 statement error pgcode 23505 duplicate key value \(v\)=\('f'\) violates unique constraint "a"
@@ -86,56 +88,58 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM kv; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv/primary/'A' -> NULL
-output row: ['A' NULL]
 fetched: /kv/primary/'a' -> NULL
 fetched: /kv/primary/'a'/v -> 'b'
-output row: ['a' 'b']
 fetched: /kv/primary/'c' -> NULL
 fetched: /kv/primary/'c'/v -> 'd'
-output row: ['c' 'd']
 fetched: /kv/primary/'e' -> NULL
 fetched: /kv/primary/'e'/v -> 'f'
-output row: ['e' 'f']
 fetched: /kv/primary/'g' -> NULL
 fetched: /kv/primary/'g'/v -> ''
-output row: ['g' '']
 fetched: /kv/primary/'nil1' -> NULL
-output row: ['nil1' NULL]
 fetched: /kv/primary/'nil2' -> NULL
-output row: ['nil2' NULL]
 fetched: /kv/primary/'nil3' -> NULL
-output row: ['nil3' NULL]
 fetched: /kv/primary/'nil4' -> NULL
+output row: ['A' NULL]
+output row: ['a' 'b']
+output row: ['c' 'd']
+output row: ['e' 'f']
+output row: ['g' '']
+output row: ['nil1' NULL]
+output row: ['nil2' NULL]
+output row: ['nil3' NULL]
 output row: ['nil4' NULL]
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM kv@a; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv/a/NULL -> /'A'
-output row: ['A' NULL]
 fetched: /kv/a/NULL -> /'nil1'
-output row: ['nil1' NULL]
 fetched: /kv/a/NULL -> /'nil2'
-output row: ['nil2' NULL]
 fetched: /kv/a/NULL -> /'nil3'
-output row: ['nil3' NULL]
 fetched: /kv/a/NULL -> /'nil4'
-output row: ['nil4' NULL]
 fetched: /kv/a/'' -> /'g'
-output row: ['g' '']
 fetched: /kv/a/'b' -> /'a'
-output row: ['a' 'b']
 fetched: /kv/a/'d' -> /'c'
-output row: ['c' 'd']
 fetched: /kv/a/'f' -> /'e'
+output row: ['A' NULL]
+output row: ['nil1' NULL]
+output row: ['nil2' NULL]
+output row: ['nil3' NULL]
+output row: ['nil4' NULL]
+output row: ['g' '']
+output row: ['a' 'b']
+output row: ['c' 'd']
 output row: ['e' 'f']
 
 statement ok
@@ -145,61 +149,63 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM kv; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv/primary/'A' -> NULL
-output row: ['A' NULL]
 fetched: /kv/primary/'a' -> NULL
 fetched: /kv/primary/'a'/v -> 'b'
-output row: ['a' 'b']
 fetched: /kv/primary/'c' -> NULL
 fetched: /kv/primary/'c'/v -> 'd'
-output row: ['c' 'd']
 fetched: /kv/primary/'e' -> NULL
 fetched: /kv/primary/'e'/v -> 'f'
-output row: ['e' 'f']
 fetched: /kv/primary/'f' -> NULL
 fetched: /kv/primary/'f'/v -> 'g'
-output row: ['f' 'g']
 fetched: /kv/primary/'g' -> NULL
 fetched: /kv/primary/'g'/v -> ''
-output row: ['g' '']
 fetched: /kv/primary/'nil1' -> NULL
-output row: ['nil1' NULL]
 fetched: /kv/primary/'nil2' -> NULL
-output row: ['nil2' NULL]
 fetched: /kv/primary/'nil3' -> NULL
-output row: ['nil3' NULL]
 fetched: /kv/primary/'nil4' -> NULL
+output row: ['A' NULL]
+output row: ['a' 'b']
+output row: ['c' 'd']
+output row: ['e' 'f']
+output row: ['f' 'g']
+output row: ['g' '']
+output row: ['nil1' NULL]
+output row: ['nil2' NULL]
+output row: ['nil3' NULL]
 output row: ['nil4' NULL]
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM kv@a; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv/a/NULL -> /'A'
-output row: ['A' NULL]
 fetched: /kv/a/NULL -> /'nil1'
-output row: ['nil1' NULL]
 fetched: /kv/a/NULL -> /'nil2'
-output row: ['nil2' NULL]
 fetched: /kv/a/NULL -> /'nil3'
-output row: ['nil3' NULL]
 fetched: /kv/a/NULL -> /'nil4'
-output row: ['nil4' NULL]
 fetched: /kv/a/'' -> /'g'
-output row: ['g' '']
 fetched: /kv/a/'b' -> /'a'
-output row: ['a' 'b']
 fetched: /kv/a/'d' -> /'c'
-output row: ['c' 'd']
 fetched: /kv/a/'f' -> /'e'
-output row: ['e' 'f']
 fetched: /kv/a/'g' -> /'f'
+output row: ['A' NULL]
+output row: ['nil1' NULL]
+output row: ['nil2' NULL]
+output row: ['nil3' NULL]
+output row: ['nil4' NULL]
+output row: ['g' '']
+output row: ['a' 'b']
+output row: ['c' 'd']
+output row: ['e' 'f']
 output row: ['f' 'g']
 
 statement error duplicate key value \(v\)=\('g'\) violates unique constraint "a"
@@ -209,61 +215,63 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM kv; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv/primary/'A' -> NULL
-output row: ['A' NULL]
 fetched: /kv/primary/'a' -> NULL
 fetched: /kv/primary/'a'/v -> 'b'
-output row: ['a' 'b']
 fetched: /kv/primary/'c' -> NULL
 fetched: /kv/primary/'c'/v -> 'd'
-output row: ['c' 'd']
 fetched: /kv/primary/'e' -> NULL
 fetched: /kv/primary/'e'/v -> 'f'
-output row: ['e' 'f']
 fetched: /kv/primary/'f' -> NULL
 fetched: /kv/primary/'f'/v -> 'g'
-output row: ['f' 'g']
 fetched: /kv/primary/'g' -> NULL
 fetched: /kv/primary/'g'/v -> ''
-output row: ['g' '']
 fetched: /kv/primary/'nil1' -> NULL
-output row: ['nil1' NULL]
 fetched: /kv/primary/'nil2' -> NULL
-output row: ['nil2' NULL]
 fetched: /kv/primary/'nil3' -> NULL
-output row: ['nil3' NULL]
 fetched: /kv/primary/'nil4' -> NULL
+output row: ['A' NULL]
+output row: ['a' 'b']
+output row: ['c' 'd']
+output row: ['e' 'f']
+output row: ['f' 'g']
+output row: ['g' '']
+output row: ['nil1' NULL]
+output row: ['nil2' NULL]
+output row: ['nil3' NULL]
 output row: ['nil4' NULL]
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM kv@a; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv/a/NULL -> /'A'
-output row: ['A' NULL]
 fetched: /kv/a/NULL -> /'nil1'
-output row: ['nil1' NULL]
 fetched: /kv/a/NULL -> /'nil2'
-output row: ['nil2' NULL]
 fetched: /kv/a/NULL -> /'nil3'
-output row: ['nil3' NULL]
 fetched: /kv/a/NULL -> /'nil4'
-output row: ['nil4' NULL]
 fetched: /kv/a/'' -> /'g'
-output row: ['g' '']
 fetched: /kv/a/'b' -> /'a'
-output row: ['a' 'b']
 fetched: /kv/a/'d' -> /'c'
-output row: ['c' 'd']
 fetched: /kv/a/'f' -> /'e'
-output row: ['e' 'f']
 fetched: /kv/a/'g' -> /'f'
+output row: ['A' NULL]
+output row: ['nil1' NULL]
+output row: ['nil2' NULL]
+output row: ['nil3' NULL]
+output row: ['nil4' NULL]
+output row: ['g' '']
+output row: ['a' 'b']
+output row: ['c' 'd']
+output row: ['e' 'f']
 output row: ['f' 'g']
 
 statement ok
@@ -280,8 +288,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM kv5@a; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv5/a/NULL/'a' -> NULL
 output row: ['a' NULL]

--- a/pkg/sql/logictest/testdata/planner_test/interleaved
+++ b/pkg/sql/logictest/testdata/planner_test/interleaved
@@ -128,16 +128,17 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM p1_0; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /p1_0/primary/2/'2'/s2 -> /'2.01'
 fetched: /p1_0/primary/2/'2'/d -> 2
-output row: [2 '2' '2.01' 2]
 fetched: /p1_0/primary/3/'3'/s2 -> /'3.01'
 fetched: /p1_0/primary/3/'3'/d -> 3
-output row: [3 '3' '3.01' 3]
 fetched: /p1_0/primary/5/'5' -> NULL
+output row: [2 '2' '2.01' 2]
+output row: [3 '3' '3.01' 3]
 output row: [5 '5' NULL NULL]
 
 # ------------------------------------------------------------------------------

--- a/pkg/sql/logictest/testdata/planner_test/order_by
+++ b/pkg/sql/logictest/testdata/planner_test/order_by
@@ -207,26 +207,28 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM abc ORDER BY a; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /abc/primary/1/2/3 -> NULL
 fetched: /abc/primary/1/2/3/d -> 'one'
-output row: [1 2 3 'one']
 fetched: /abc/primary/4/5/6 -> NULL
 fetched: /abc/primary/4/5/6/d -> 'Two'
+output row: [1 2 3 'one']
 output row: [4 5 6 'Two']
 
 statement ok
 SET tracing = on,kv,results; SELECT a, b FROM abc ORDER BY b, a; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /abc/ba/2/1/3 -> NULL
-output row: [1 2]
 fetched: /abc/ba/5/4/6 -> NULL
+output row: [1 2]
 output row: [4 5]
 
 # The non-unique index ba includes column c (required to make the keys unique)
@@ -309,38 +311,41 @@ statement ok
 SET tracing = on,kv,results; SELECT b, c FROM abc ORDER BY b, c; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /abc/bc/2/3 -> /1
-output row: [2 3]
 fetched: /abc/bc/5/6 -> /4
+output row: [2 3]
 output row: [5 6]
 
 statement ok
 SET tracing = on,kv,results; SELECT a, b, c FROM abc ORDER BY b; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /abc/bc/2/3 -> /1
-output row: [1 2 3]
 fetched: /abc/bc/5/6 -> /4
+output row: [1 2 3]
 output row: [4 5 6]
 
 statement ok
 SET tracing = on,kv,results; SELECT a FROM abc ORDER BY a DESC; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /abc/primary/4/5/6/d -> 'Two'
 fetched: /abc/primary/4/5/6 -> NULL
-output row: [4]
 fetched: /abc/primary/1/2/3/d -> 'one'
 fetched: /abc/primary/1/2/3 -> NULL
+output row: [4]
 output row: [1]
 
 query TTT

--- a/pkg/sql/logictest/testdata/planner_test/select
+++ b/pkg/sql/logictest/testdata/planner_test/select
@@ -75,8 +75,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t@b_idx; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/b_idx/2/1/c/d -> /3/4
 output row: [1 2 3 4]
@@ -85,8 +86,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t@c_idx; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/c_idx/3/b/d -> /2/4
 output row: [1 2 3 4]
@@ -100,8 +102,9 @@ statement ok
 SET tracing = on,kv,results; SELECT a, b, d FROM t@d_idx; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/d_idx/4/1/b -> /2
 output row: [1 2 4]
@@ -113,8 +116,9 @@ statement ok
 SET tracing = on,kv,results; SELECT a, b FROM t@a_idx; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/a_idx/1/b -> /2
 output row: [1 2]
@@ -130,14 +134,15 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t@b_idx; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/b_idx/NULL/2 -> NULL
-output row: [2 NULL NULL NULL]
 fetched: /t/b_idx/NULL/3 -> NULL
-output row: [3 NULL NULL NULL]
 fetched: /t/b_idx/2/1/c/d -> /3/4
+output row: [2 NULL NULL NULL]
+output row: [3 NULL NULL NULL]
 output row: [1 2 3 4]
 
 # Regression test for #14601.
@@ -269,8 +274,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM dt WHERE a = '2015-08-25 04:45:45.53453+02:00'::timestamp; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /dt/primary/'2015-08-25 04:45:45.53453+00:00' -> NULL
 fetched: /dt/primary/'2015-08-25 04:45:45.53453+00:00'/b -> '2015-08-25'
@@ -281,8 +287,9 @@ statement ok
 SET tracing = on,kv,results; SELECT b FROM dt WHERE b < '2015-08-29'::date; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /dt/dt_b_key/'2015-08-25' -> /'2015-08-25 04:45:45.53453+00:00'
 output row: ['2015-08-25']
@@ -291,12 +298,13 @@ statement ok
 SET tracing = on,kv,results; SELECT c FROM dt WHERE c < '234h45m2s234ms'::interval; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /dt/dt_c_key/'02:45:02.234' -> /'2015-08-25 04:45:45.53453+00:00'
-output row: ['02:45:02.234']
 fetched: /dt/dt_c_key/'34:00:02' -> /'2015-08-30 03:34:45.34567+00:00'
+output row: ['02:45:02.234']
 output row: ['34:00:02']
 
 # ------------------------------------------------------------------------------
@@ -349,14 +357,15 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM c@b_idx; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /c/b_idx/NULL/2 -> NULL
-output row: [2 NULL]
 fetched: /c/b_idx/NULL/3 -> NULL
-output row: [3 NULL]
 fetched: /c/b_idx/0.4/1/b -> /0.40
+output row: [2 NULL]
+output row: [3 NULL]
 output row: [1 0.40]
 
 # ------------------------------------------------------------------------------

--- a/pkg/sql/logictest/testdata/planner_test/select_index
+++ b/pkg/sql/logictest/testdata/planner_test/select_index
@@ -25,8 +25,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE a = 2; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/primary/2/'two' -> NULL
 fetched: /t/primary/2/'two'/c -> 22
@@ -37,48 +38,52 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE a IN (1, 3); SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/primary/1/'one' -> NULL
 fetched: /t/primary/1/'one'/c -> 11
 fetched: /t/primary/1/'one'/d -> 'foo'
-output row: [1 'one' 11 'foo']
 fetched: /t/primary/3/'three' -> NULL
 fetched: /t/primary/3/'three'/c -> 33
 fetched: /t/primary/3/'three'/d -> 'blah'
+output row: [1 'one' 11 'foo']
 output row: [3 'three' 33 'blah']
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE d = 'foo' OR d = 'bar'; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/dc/'bar'/22/2/'two' -> NULL
-output row: [2 'two' 22 'bar']
 fetched: /t/dc/'foo'/11/1/'one' -> NULL
+output row: [2 'two' 22 'bar']
 output row: [1 'one' 11 'foo']
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE (d, c) IN (('foo', 11), ('bar', 22)); SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/dc/'bar'/22/2/'two' -> NULL
-output row: [2 'two' 22 'bar']
 fetched: /t/dc/'foo'/11/1/'one' -> NULL
+output row: [2 'two' 22 'bar']
 output row: [1 'one' 11 'foo']
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE (d, c) = ('foo', 11); SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/dc/'foo'/11/1/'one' -> NULL
 output row: [1 'one' 11 'foo']
@@ -87,8 +92,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE a < 2; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/primary/1/'one' -> NULL
 fetched: /t/primary/1/'one'/c -> 11
@@ -99,36 +105,39 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE a <= (1 + 1); SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/primary/1/'one' -> NULL
 fetched: /t/primary/1/'one'/c -> 11
 fetched: /t/primary/1/'one'/d -> 'foo'
-output row: [1 'one' 11 'foo']
 fetched: /t/primary/2/'two' -> NULL
 fetched: /t/primary/2/'two'/c -> 22
 fetched: /t/primary/2/'two'/d -> 'bar'
+output row: [1 'one' 11 'foo']
 output row: [2 'two' 22 'bar']
 
 statement ok
 SET tracing = on,kv,results; SELECT a, b FROM t WHERE b > 't'; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/bc/'three'/33/3 -> NULL
-output row: [3 'three']
 fetched: /t/bc/'two'/22/2 -> NULL
+output row: [3 'three']
 output row: [2 'two']
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE d < ('b' || 'l'); SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/dc/'bar'/22/2/'two' -> NULL
 output row: [2 'two' 22 'bar']
@@ -141,27 +150,29 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE c = 22; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/dc/'bar'/22/2/'two' -> NULL
-output row: [2 'two' 22 'bar']
 fetched: /t/dc/'blah'/33/3/'three' -> NULL
 fetched: /t/dc/'foo'/11/1/'one' -> NULL
+output row: [2 'two' 22 'bar']
 
 # Use the descending index
 statement ok
 SET tracing = on,kv,results; SELECT a FROM t ORDER BY a DESC; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/a_desc/3/'three' -> NULL
-output row: [3]
 fetched: /t/a_desc/2/'two' -> NULL
-output row: [2]
 fetched: /t/a_desc/1/'one' -> NULL
+output row: [3]
+output row: [2]
 output row: [1]
 
 # Use the descending index with multiple spans.
@@ -169,12 +180,13 @@ statement ok
 SET tracing = on,kv,results; SELECT a FROM t WHERE a in (2, 3) ORDER BY a DESC; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/a_desc/3/'three' -> NULL
-output row: [3]
 fetched: /t/a_desc/2/'two' -> NULL
+output row: [3]
 output row: [2]
 
 # Index selection occurs in direct join operands too.
@@ -211,8 +223,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE a = 1 AND b > 'b'; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/primary/1/'c' -> NULL
 output row: [1 'c' NULL NULL]
@@ -221,8 +234,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE a > 0 AND b > 'b'; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/primary/1/'c' -> NULL
 output row: [1 'c' NULL NULL]
@@ -231,8 +245,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE a > 1 AND b > 'b'; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 
 query TTT
@@ -244,8 +259,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE a = 1 AND 'a' < b AND 'c' > b; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/primary/1/'b' -> NULL
 output row: [1 'b' NULL NULL]
@@ -267,8 +283,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t@ab WHERE a >= 3 AND a < 5; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/ab/3/4 -> NULL
 output row: [3 4]
@@ -277,8 +294,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t@ab WHERE a BETWEEN 3 AND 4; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/ab/3/4 -> NULL
 output row: [3 4]
@@ -287,104 +305,113 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t@ab WHERE a BETWEEN 3 AND 5; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/ab/3/4 -> NULL
-output row: [3 4]
 fetched: /t/ab/5/6 -> NULL
+output row: [3 4]
 output row: [5 6]
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t@ab WHERE a < 2 OR a < 4; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/ab/1/2 -> NULL
-output row: [1 2]
 fetched: /t/ab/3/4 -> NULL
+output row: [1 2]
 output row: [3 4]
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t@ab WHERE a < 3 OR a <= 3; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/ab/1/2 -> NULL
-output row: [1 2]
 fetched: /t/ab/3/4 -> NULL
+output row: [1 2]
 output row: [3 4]
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t@ab WHERE a <= 3 OR a < 3; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/ab/1/2 -> NULL
-output row: [1 2]
 fetched: /t/ab/3/4 -> NULL
+output row: [1 2]
 output row: [3 4]
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t@ab WHERE a > 3 OR a >= 3; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/ab/3/4 -> NULL
-output row: [3 4]
 fetched: /t/ab/5/6 -> NULL
+output row: [3 4]
 output row: [5 6]
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t@ab WHERE a >= 3 OR a > 3; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/ab/3/4 -> NULL
-output row: [3 4]
 fetched: /t/ab/5/6 -> NULL
+output row: [3 4]
 output row: [5 6]
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t@ab WHERE a = 3 OR a = 5; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/ab/3/4 -> NULL
-output row: [3 4]
 fetched: /t/ab/5/6 -> NULL
+output row: [3 4]
 output row: [5 6]
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t@ab WHERE a < 3 OR a > 3; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/ab/1/2 -> NULL
-output row: [1 2]
 fetched: /t/ab/5/6 -> NULL
+output row: [1 2]
 output row: [5 6]
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t@ab WHERE a + 1 = 4; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/ab/3/4 -> NULL
 output row: [3 4]
@@ -642,60 +669,8 @@ limit              ·      ·
 ·                  spans  /!NULL-/"100"/PrefixEnd
 ·                  limit  20
 
-# Result check: The following query must not issue more than the
-# requested LIMIT K/V reads, even though an index join batches 100
-# rows at a time -- the limit should be enforced by the scan.  We are
-# reading from the end (ORDER BY k DESC) so we should see 20 values
-# from 030 to 011 (thus not 001-010).
-
-statement ok
-SET tracing = on,kv,results; SELECT * FROM test2 WHERE k <= '100' ORDER BY k DESC LIMIT 20; SET tracing = off
-
-query T
-SELECT regexp_replace(message, '\d\d\d\d\d+', '...PK...')
-  FROM [SHOW KV TRACE FOR SESSION]
- WHERE message LIKE 'fetched:%'
-----
-fetched: /test2/test2_k_key/'030' -> /...PK...
-fetched: /test2/test2_k_key/'029' -> /...PK...
-fetched: /test2/test2_k_key/'028' -> /...PK...
-fetched: /test2/test2_k_key/'027' -> /...PK...
-fetched: /test2/test2_k_key/'026' -> /...PK...
-fetched: /test2/test2_k_key/'025' -> /...PK...
-fetched: /test2/test2_k_key/'024' -> /...PK...
-fetched: /test2/test2_k_key/'023' -> /...PK...
-fetched: /test2/test2_k_key/'022' -> /...PK...
-fetched: /test2/test2_k_key/'021' -> /...PK...
-fetched: /test2/test2_k_key/'020' -> /...PK...
-fetched: /test2/test2_k_key/'019' -> /...PK...
-fetched: /test2/test2_k_key/'018' -> /...PK...
-fetched: /test2/test2_k_key/'017' -> /...PK...
-fetched: /test2/test2_k_key/'016' -> /...PK...
-fetched: /test2/test2_k_key/'015' -> /...PK...
-fetched: /test2/test2_k_key/'014' -> /...PK...
-fetched: /test2/test2_k_key/'013' -> /...PK...
-fetched: /test2/test2_k_key/'012' -> /...PK...
-fetched: /test2/test2_k_key/'011' -> /...PK...
-fetched: /test2/primary/...PK.../k/v -> /'030'/42
-fetched: /test2/primary/...PK.../k/v -> /'029'/42
-fetched: /test2/primary/...PK.../k/v -> /'028'/42
-fetched: /test2/primary/...PK.../k/v -> /'027'/42
-fetched: /test2/primary/...PK.../k/v -> /'026'/42
-fetched: /test2/primary/...PK.../k/v -> /'025'/42
-fetched: /test2/primary/...PK.../k/v -> /'024'/42
-fetched: /test2/primary/...PK.../k/v -> /'023'/42
-fetched: /test2/primary/...PK.../k/v -> /'022'/42
-fetched: /test2/primary/...PK.../k/v -> /'021'/42
-fetched: /test2/primary/...PK.../k/v -> /'020'/42
-fetched: /test2/primary/...PK.../k/v -> /'019'/42
-fetched: /test2/primary/...PK.../k/v -> /'018'/42
-fetched: /test2/primary/...PK.../k/v -> /'017'/42
-fetched: /test2/primary/...PK.../k/v -> /'016'/42
-fetched: /test2/primary/...PK.../k/v -> /'015'/42
-fetched: /test2/primary/...PK.../k/v -> /'014'/42
-fetched: /test2/primary/...PK.../k/v -> /'013'/42
-fetched: /test2/primary/...PK.../k/v -> /'012'/42
-fetched: /test2/primary/...PK.../k/v -> /'011'/42
+# The result output of this test requires that vectorized execution
+# is not used, so it has been moved to select_index_vectorize_off.
 
 # Regression test for #20035.
 statement ok
@@ -968,8 +943,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM noncover WHERE b = 2; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /noncover/b/2/1 -> NULL
 fetched: /noncover/primary/1 -> NULL
@@ -991,8 +967,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM noncover WHERE c = 7; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /noncover/c/7 -> /5
 fetched: /noncover/primary/5 -> NULL
@@ -1141,8 +1118,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t2 WHERE b = 2 AND c % 2 = 0; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t2/bc/2/1/4 -> NULL
 fetched: /t2/bc/2/2/5 -> NULL
@@ -1170,8 +1148,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t2 WHERE b = 2 AND c != b; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t2/bc/2/1/4 -> NULL
 fetched: /t2/bc/2/2/5 -> NULL
@@ -1180,11 +1159,11 @@ fetched: /t2/primary/4 -> NULL
 fetched: /t2/primary/4/b -> 2
 fetched: /t2/primary/4/c -> 1
 fetched: /t2/primary/4/s -> '21'
-output row: [4 2 1 '21']
 fetched: /t2/primary/6 -> NULL
 fetched: /t2/primary/6/b -> 2
 fetched: /t2/primary/6/c -> 3
 fetched: /t2/primary/6/s -> '23'
+output row: [4 2 1 '21']
 output row: [6 2 3 '23']
 
 # We do NOT look up the table row for '22'.
@@ -1192,8 +1171,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t2 WHERE b = 2 AND c != b AND s <> '21'; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t2/bc/2/1/4 -> NULL
 fetched: /t2/bc/2/2/5 -> NULL
@@ -1213,8 +1193,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t2 WHERE b > 1 AND ((c = b+1 AND s != '23') OR (a > b+4 AND s != '32')); SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t2/bc/2/1/4 -> NULL
 fetched: /t2/bc/2/2/5 -> NULL

--- a/pkg/sql/logictest/testdata/planner_test/select_index_vectorize_off
+++ b/pkg/sql/logictest/testdata/planner_test/select_index_vectorize_off
@@ -1,0 +1,69 @@
+# LogicTest: local
+
+# This file contains test cases that cannot be run with the vectorized
+# execution engine.
+
+statement ok
+SET experimental_vectorize=off
+
+statement ok
+CREATE TABLE test2 (id BIGSERIAL PRIMARY KEY, k TEXT UNIQUE, v INT DEFAULT 42);
+INSERT INTO test2(k)
+     VALUES ('001'),('002'),('003'),('004'),('005'),('006'),('007'),('008'),('009'),('010'),
+            ('011'),('012'),('013'),('014'),('015'),('016'),('017'),('018'),('019'),('020'),
+            ('021'),('022'),('023'),('024'),('025'),('026'),('027'),('028'),('029'),('030')
+
+# Result check: The following query must not issue more than the
+# requested LIMIT K/V reads, even though an index join batches 100
+# rows at a time -- the limit should be enforced by the scan.  We are
+# reading from the end (ORDER BY k DESC) so we should see 20 values
+# from 030 to 011 (thus not 001-010).
+
+statement ok
+SET tracing = on,kv,results; SELECT * FROM test2 WHERE k <= '100' ORDER BY k DESC LIMIT 20; SET tracing = off
+
+query T
+SELECT regexp_replace(message, '\d\d\d\d\d+', '...PK...')
+  FROM [SHOW KV TRACE FOR SESSION]
+ WHERE message LIKE 'fetched:%'
+----
+fetched: /test2/test2_k_key/'030' -> /...PK...
+fetched: /test2/test2_k_key/'029' -> /...PK...
+fetched: /test2/test2_k_key/'028' -> /...PK...
+fetched: /test2/test2_k_key/'027' -> /...PK...
+fetched: /test2/test2_k_key/'026' -> /...PK...
+fetched: /test2/test2_k_key/'025' -> /...PK...
+fetched: /test2/test2_k_key/'024' -> /...PK...
+fetched: /test2/test2_k_key/'023' -> /...PK...
+fetched: /test2/test2_k_key/'022' -> /...PK...
+fetched: /test2/test2_k_key/'021' -> /...PK...
+fetched: /test2/test2_k_key/'020' -> /...PK...
+fetched: /test2/test2_k_key/'019' -> /...PK...
+fetched: /test2/test2_k_key/'018' -> /...PK...
+fetched: /test2/test2_k_key/'017' -> /...PK...
+fetched: /test2/test2_k_key/'016' -> /...PK...
+fetched: /test2/test2_k_key/'015' -> /...PK...
+fetched: /test2/test2_k_key/'014' -> /...PK...
+fetched: /test2/test2_k_key/'013' -> /...PK...
+fetched: /test2/test2_k_key/'012' -> /...PK...
+fetched: /test2/test2_k_key/'011' -> /...PK...
+fetched: /test2/primary/...PK.../k/v -> /'030'/42
+fetched: /test2/primary/...PK.../k/v -> /'029'/42
+fetched: /test2/primary/...PK.../k/v -> /'028'/42
+fetched: /test2/primary/...PK.../k/v -> /'027'/42
+fetched: /test2/primary/...PK.../k/v -> /'026'/42
+fetched: /test2/primary/...PK.../k/v -> /'025'/42
+fetched: /test2/primary/...PK.../k/v -> /'024'/42
+fetched: /test2/primary/...PK.../k/v -> /'023'/42
+fetched: /test2/primary/...PK.../k/v -> /'022'/42
+fetched: /test2/primary/...PK.../k/v -> /'021'/42
+fetched: /test2/primary/...PK.../k/v -> /'020'/42
+fetched: /test2/primary/...PK.../k/v -> /'019'/42
+fetched: /test2/primary/...PK.../k/v -> /'018'/42
+fetched: /test2/primary/...PK.../k/v -> /'017'/42
+fetched: /test2/primary/...PK.../k/v -> /'016'/42
+fetched: /test2/primary/...PK.../k/v -> /'015'/42
+fetched: /test2/primary/...PK.../k/v -> /'014'/42
+fetched: /test2/primary/...PK.../k/v -> /'013'/42
+fetched: /test2/primary/...PK.../k/v -> /'012'/42
+fetched: /test2/primary/...PK.../k/v -> /'011'/42

--- a/pkg/sql/logictest/testdata/planner_test/update
+++ b/pkg/sql/logictest/testdata/planner_test/update
@@ -16,36 +16,38 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM kv2; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv2/primary/'a' -> NULL
 fetched: /kv2/primary/'a'/v -> 'b'
-output row: ['a' 'b']
 fetched: /kv2/primary/'c' -> NULL
 fetched: /kv2/primary/'c'/v -> 'd'
-output row: ['c' 'd']
 fetched: /kv2/primary/'e' -> NULL
 fetched: /kv2/primary/'e'/v -> 'f'
-output row: ['e' 'f']
 fetched: /kv2/primary/'f' -> NULL
 fetched: /kv2/primary/'f'/v -> 'g'
+output row: ['a' 'b']
+output row: ['c' 'd']
+output row: ['e' 'f']
 output row: ['f' 'g']
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM kv2@a; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv2/a/'b' -> /'a'
-output row: ['a' 'b']
 fetched: /kv2/a/'d' -> /'c'
-output row: ['c' 'd']
 fetched: /kv2/a/'f' -> /'e'
-output row: ['e' 'f']
 fetched: /kv2/a/'g' -> /'f'
+output row: ['a' 'b']
+output row: ['c' 'd']
+output row: ['e' 'f']
 output row: ['f' 'g']
 
 statement error duplicate key value \(v\)=\('g'\) violates unique constraint "a"
@@ -55,36 +57,38 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM kv2; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv2/primary/'a' -> NULL
 fetched: /kv2/primary/'a'/v -> 'b'
-output row: ['a' 'b']
 fetched: /kv2/primary/'c' -> NULL
 fetched: /kv2/primary/'c'/v -> 'd'
-output row: ['c' 'd']
 fetched: /kv2/primary/'e' -> NULL
 fetched: /kv2/primary/'e'/v -> 'f'
-output row: ['e' 'f']
 fetched: /kv2/primary/'f' -> NULL
 fetched: /kv2/primary/'f'/v -> 'g'
+output row: ['a' 'b']
+output row: ['c' 'd']
+output row: ['e' 'f']
 output row: ['f' 'g']
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM kv2@a; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv2/a/'b' -> /'a'
-output row: ['a' 'b']
 fetched: /kv2/a/'d' -> /'c'
-output row: ['c' 'd']
 fetched: /kv2/a/'f' -> /'e'
-output row: ['e' 'f']
 fetched: /kv2/a/'g' -> /'f'
+output row: ['a' 'b']
+output row: ['c' 'd']
+output row: ['e' 'f']
 output row: ['f' 'g']
 
 statement ok
@@ -179,8 +183,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM pks WHERE k1 = 2; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /pks/primary/2/2 -> NULL
 fetched: /pks/primary/2/2/v -> 3

--- a/pkg/sql/logictest/testdata/planner_test/window
+++ b/pkg/sql/logictest/testdata/planner_test/window
@@ -29,8 +29,9 @@ statement ok
 SET tracing = on,kv,results; SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k; SET tracing = off
 
 query T rowsort
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv/primary/1/v -> /2
 fetched: /kv/primary/1/d -> 1

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -420,8 +420,9 @@ statement ok
 SET tracing = on,kv,results; SELECT min(x) FROM xyz WHERE (y, z) = (2, 3.0); SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /xyz/zyx/3.0/2/1 -> NULL
 output row: [1]
@@ -444,8 +445,9 @@ statement ok
 SET tracing = on,kv,results; SELECT variance(x), variance(y::decimal), round(variance(z), 14) FROM xyz; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /xyz/primary/1 -> NULL
 fetched: /xyz/primary/1/y -> 2

--- a/pkg/sql/opt/exec/execbuilder/testdata/ddl
+++ b/pkg/sql/opt/exec/execbuilder/testdata/ddl
@@ -19,8 +19,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/primary/1/f -> /9
 output row: [1 9]
@@ -35,8 +36,9 @@ statement ok
 SET tracing = on,kv,results; SELECT b FROM t@foo; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/foo/NULL -> /1
 output row: [NULL]
@@ -57,14 +59,15 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/primary/1/f -> /9
-output row: [1 9 NULL NULL]
 fetched: /t/primary/2/f/b/c -> /9/1/1
-output row: [2 9 1 1]
 fetched: /t/primary/3/f/b/c -> /9/2/1
+output row: [1 9 NULL NULL]
+output row: [2 9 1 1]
 output row: [3 9 2 1]
 
 statement ok
@@ -74,14 +77,15 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/primary/1/f -> /9
-output row: [1 9]
 fetched: /t/primary/2/f -> /9
-output row: [2 9]
 fetched: /t/primary/3/f -> /9
+output row: [1 9]
+output row: [2 9]
 output row: [3 9]
 
 # Verify limits and orderings are propagated correctly to the select.
@@ -119,8 +123,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/primary/1 -> NULL
 fetched: /t/primary/1/b -> 1
@@ -144,8 +149,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t@foo; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/foo/1/1 -> NULL
 output row: [1 1]
@@ -157,12 +163,13 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t@foo; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/foo/1/1 -> NULL
-output row: [1 1]
 fetched: /t/foo/1/2 -> NULL
+output row: [1 1]
 output row: [2 1]
 
 # test for DESC index
@@ -191,14 +198,15 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t@b_desc; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/b_desc/2/2 -> NULL
 fetched: /t/b_desc/1/1 -> NULL
 fetched: /t/primary/2/b/c -> /2/2
-output row: [2 2 2]
 fetched: /t/primary/1/b/c -> /1/1
+output row: [2 2 2]
 output row: [1 1 1]
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -33,24 +33,27 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM kv; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM kv@foo; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM kv@bar; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 
 # Check that EXPLAIN does not destroy data (#6613)

--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -27,56 +27,58 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM kv; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv/primary/'A' -> NULL
-output row: ['A' NULL]
 fetched: /kv/primary/'a' -> NULL
 fetched: /kv/primary/'a'/v -> 'b'
-output row: ['a' 'b']
 fetched: /kv/primary/'c' -> NULL
 fetched: /kv/primary/'c'/v -> 'd'
-output row: ['c' 'd']
 fetched: /kv/primary/'e' -> NULL
 fetched: /kv/primary/'e'/v -> 'f'
-output row: ['e' 'f']
 fetched: /kv/primary/'g' -> NULL
 fetched: /kv/primary/'g'/v -> ''
-output row: ['g' '']
 fetched: /kv/primary/'nil1' -> NULL
-output row: ['nil1' NULL]
 fetched: /kv/primary/'nil2' -> NULL
-output row: ['nil2' NULL]
 fetched: /kv/primary/'nil3' -> NULL
-output row: ['nil3' NULL]
 fetched: /kv/primary/'nil4' -> NULL
+output row: ['A' NULL]
+output row: ['a' 'b']
+output row: ['c' 'd']
+output row: ['e' 'f']
+output row: ['g' '']
+output row: ['nil1' NULL]
+output row: ['nil2' NULL]
+output row: ['nil3' NULL]
 output row: ['nil4' NULL]
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM kv@a; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv/a/NULL -> /'A'
-output row: ['A' NULL]
 fetched: /kv/a/NULL -> /'nil1'
-output row: ['nil1' NULL]
 fetched: /kv/a/NULL -> /'nil2'
-output row: ['nil2' NULL]
 fetched: /kv/a/NULL -> /'nil3'
-output row: ['nil3' NULL]
 fetched: /kv/a/NULL -> /'nil4'
-output row: ['nil4' NULL]
 fetched: /kv/a/'' -> /'g'
-output row: ['g' '']
 fetched: /kv/a/'b' -> /'a'
-output row: ['a' 'b']
 fetched: /kv/a/'d' -> /'c'
-output row: ['c' 'd']
 fetched: /kv/a/'f' -> /'e'
+output row: ['A' NULL]
+output row: ['nil1' NULL]
+output row: ['nil2' NULL]
+output row: ['nil3' NULL]
+output row: ['nil4' NULL]
+output row: ['g' '']
+output row: ['a' 'b']
+output row: ['c' 'd']
 output row: ['e' 'f']
 
 statement error pgcode 23505 duplicate key value \(v\)=\('f'\) violates unique constraint "a"
@@ -86,56 +88,58 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM kv; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv/primary/'A' -> NULL
-output row: ['A' NULL]
 fetched: /kv/primary/'a' -> NULL
 fetched: /kv/primary/'a'/v -> 'b'
-output row: ['a' 'b']
 fetched: /kv/primary/'c' -> NULL
 fetched: /kv/primary/'c'/v -> 'd'
-output row: ['c' 'd']
 fetched: /kv/primary/'e' -> NULL
 fetched: /kv/primary/'e'/v -> 'f'
-output row: ['e' 'f']
 fetched: /kv/primary/'g' -> NULL
 fetched: /kv/primary/'g'/v -> ''
-output row: ['g' '']
 fetched: /kv/primary/'nil1' -> NULL
-output row: ['nil1' NULL]
 fetched: /kv/primary/'nil2' -> NULL
-output row: ['nil2' NULL]
 fetched: /kv/primary/'nil3' -> NULL
-output row: ['nil3' NULL]
 fetched: /kv/primary/'nil4' -> NULL
+output row: ['A' NULL]
+output row: ['a' 'b']
+output row: ['c' 'd']
+output row: ['e' 'f']
+output row: ['g' '']
+output row: ['nil1' NULL]
+output row: ['nil2' NULL]
+output row: ['nil3' NULL]
 output row: ['nil4' NULL]
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM kv@a; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv/a/NULL -> /'A'
-output row: ['A' NULL]
 fetched: /kv/a/NULL -> /'nil1'
-output row: ['nil1' NULL]
 fetched: /kv/a/NULL -> /'nil2'
-output row: ['nil2' NULL]
 fetched: /kv/a/NULL -> /'nil3'
-output row: ['nil3' NULL]
 fetched: /kv/a/NULL -> /'nil4'
-output row: ['nil4' NULL]
 fetched: /kv/a/'' -> /'g'
-output row: ['g' '']
 fetched: /kv/a/'b' -> /'a'
-output row: ['a' 'b']
 fetched: /kv/a/'d' -> /'c'
-output row: ['c' 'd']
 fetched: /kv/a/'f' -> /'e'
+output row: ['A' NULL]
+output row: ['nil1' NULL]
+output row: ['nil2' NULL]
+output row: ['nil3' NULL]
+output row: ['nil4' NULL]
+output row: ['g' '']
+output row: ['a' 'b']
+output row: ['c' 'd']
 output row: ['e' 'f']
 
 statement ok
@@ -145,61 +149,63 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM kv; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv/primary/'A' -> NULL
-output row: ['A' NULL]
 fetched: /kv/primary/'a' -> NULL
 fetched: /kv/primary/'a'/v -> 'b'
-output row: ['a' 'b']
 fetched: /kv/primary/'c' -> NULL
 fetched: /kv/primary/'c'/v -> 'd'
-output row: ['c' 'd']
 fetched: /kv/primary/'e' -> NULL
 fetched: /kv/primary/'e'/v -> 'f'
-output row: ['e' 'f']
 fetched: /kv/primary/'f' -> NULL
 fetched: /kv/primary/'f'/v -> 'g'
-output row: ['f' 'g']
 fetched: /kv/primary/'g' -> NULL
 fetched: /kv/primary/'g'/v -> ''
-output row: ['g' '']
 fetched: /kv/primary/'nil1' -> NULL
-output row: ['nil1' NULL]
 fetched: /kv/primary/'nil2' -> NULL
-output row: ['nil2' NULL]
 fetched: /kv/primary/'nil3' -> NULL
-output row: ['nil3' NULL]
 fetched: /kv/primary/'nil4' -> NULL
+output row: ['A' NULL]
+output row: ['a' 'b']
+output row: ['c' 'd']
+output row: ['e' 'f']
+output row: ['f' 'g']
+output row: ['g' '']
+output row: ['nil1' NULL]
+output row: ['nil2' NULL]
+output row: ['nil3' NULL]
 output row: ['nil4' NULL]
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM kv@a; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv/a/NULL -> /'A'
-output row: ['A' NULL]
 fetched: /kv/a/NULL -> /'nil1'
-output row: ['nil1' NULL]
 fetched: /kv/a/NULL -> /'nil2'
-output row: ['nil2' NULL]
 fetched: /kv/a/NULL -> /'nil3'
-output row: ['nil3' NULL]
 fetched: /kv/a/NULL -> /'nil4'
-output row: ['nil4' NULL]
 fetched: /kv/a/'' -> /'g'
-output row: ['g' '']
 fetched: /kv/a/'b' -> /'a'
-output row: ['a' 'b']
 fetched: /kv/a/'d' -> /'c'
-output row: ['c' 'd']
 fetched: /kv/a/'f' -> /'e'
-output row: ['e' 'f']
 fetched: /kv/a/'g' -> /'f'
+output row: ['A' NULL]
+output row: ['nil1' NULL]
+output row: ['nil2' NULL]
+output row: ['nil3' NULL]
+output row: ['nil4' NULL]
+output row: ['g' '']
+output row: ['a' 'b']
+output row: ['c' 'd']
+output row: ['e' 'f']
 output row: ['f' 'g']
 
 statement error duplicate key value \(v\)=\('g'\) violates unique constraint "a"
@@ -209,61 +215,63 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM kv; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv/primary/'A' -> NULL
-output row: ['A' NULL]
 fetched: /kv/primary/'a' -> NULL
 fetched: /kv/primary/'a'/v -> 'b'
-output row: ['a' 'b']
 fetched: /kv/primary/'c' -> NULL
 fetched: /kv/primary/'c'/v -> 'd'
-output row: ['c' 'd']
 fetched: /kv/primary/'e' -> NULL
 fetched: /kv/primary/'e'/v -> 'f'
-output row: ['e' 'f']
 fetched: /kv/primary/'f' -> NULL
 fetched: /kv/primary/'f'/v -> 'g'
-output row: ['f' 'g']
 fetched: /kv/primary/'g' -> NULL
 fetched: /kv/primary/'g'/v -> ''
-output row: ['g' '']
 fetched: /kv/primary/'nil1' -> NULL
-output row: ['nil1' NULL]
 fetched: /kv/primary/'nil2' -> NULL
-output row: ['nil2' NULL]
 fetched: /kv/primary/'nil3' -> NULL
-output row: ['nil3' NULL]
 fetched: /kv/primary/'nil4' -> NULL
+output row: ['A' NULL]
+output row: ['a' 'b']
+output row: ['c' 'd']
+output row: ['e' 'f']
+output row: ['f' 'g']
+output row: ['g' '']
+output row: ['nil1' NULL]
+output row: ['nil2' NULL]
+output row: ['nil3' NULL]
 output row: ['nil4' NULL]
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM kv@a; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv/a/NULL -> /'A'
-output row: ['A' NULL]
 fetched: /kv/a/NULL -> /'nil1'
-output row: ['nil1' NULL]
 fetched: /kv/a/NULL -> /'nil2'
-output row: ['nil2' NULL]
 fetched: /kv/a/NULL -> /'nil3'
-output row: ['nil3' NULL]
 fetched: /kv/a/NULL -> /'nil4'
-output row: ['nil4' NULL]
 fetched: /kv/a/'' -> /'g'
-output row: ['g' '']
 fetched: /kv/a/'b' -> /'a'
-output row: ['a' 'b']
 fetched: /kv/a/'d' -> /'c'
-output row: ['c' 'd']
 fetched: /kv/a/'f' -> /'e'
-output row: ['e' 'f']
 fetched: /kv/a/'g' -> /'f'
+output row: ['A' NULL]
+output row: ['nil1' NULL]
+output row: ['nil2' NULL]
+output row: ['nil3' NULL]
+output row: ['nil4' NULL]
+output row: ['g' '']
+output row: ['a' 'b']
+output row: ['c' 'd']
+output row: ['e' 'f']
 output row: ['f' 'g']
 
 statement ok
@@ -280,8 +288,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM kv5@a; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv5/a/NULL/'a' -> NULL
 output row: ['a' NULL]

--- a/pkg/sql/opt/exec/execbuilder/testdata/interleaved
+++ b/pkg/sql/opt/exec/execbuilder/testdata/interleaved
@@ -128,16 +128,17 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM p1_0; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /p1_0/primary/2/'2'/s2 -> /'2.01'
 fetched: /p1_0/primary/2/'2'/d -> 2
-output row: [2 '2' '2.01' 2]
 fetched: /p1_0/primary/3/'3'/s2 -> /'3.01'
 fetched: /p1_0/primary/3/'3'/d -> 3
-output row: [3 '3' '3.01' 3]
 fetched: /p1_0/primary/5/'5' -> NULL
+output row: [2 '2' '2.01' 2]
+output row: [3 '3' '3.01' 3]
 output row: [5 '5' NULL NULL]
 
 # ------------------------------------------------------------------------------

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -190,26 +190,28 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM abc ORDER BY a; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /abc/primary/1/2/3 -> NULL
 fetched: /abc/primary/1/2/3/d -> 'one'
-output row: [1 2 3 'one']
 fetched: /abc/primary/4/5/6 -> NULL
 fetched: /abc/primary/4/5/6/d -> 'Two'
+output row: [1 2 3 'one']
 output row: [4 5 6 'Two']
 
 statement ok
 SET tracing = on,kv,results; SELECT a, b FROM abc ORDER BY b, a; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /abc/ba/2/1/3 -> NULL
-output row: [1 2]
 fetched: /abc/ba/5/4/6 -> NULL
+output row: [1 2]
 output row: [4 5]
 
 # The non-unique index ba includes column c (required to make the keys unique)
@@ -306,38 +308,41 @@ statement ok
 SET tracing = on,kv,results; SELECT b, c FROM abc ORDER BY b, c; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /abc/bc/2/3 -> /1
-output row: [2 3]
 fetched: /abc/bc/5/6 -> /4
+output row: [2 3]
 output row: [5 6]
 
 statement ok
 SET tracing = on,kv,results; SELECT a, b, c FROM abc ORDER BY b; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /abc/bc/2/3 -> /1
-output row: [1 2 3]
 fetched: /abc/bc/5/6 -> /4
+output row: [1 2 3]
 output row: [4 5 6]
 
 statement ok
 SET tracing = on,kv,results; SELECT a FROM abc ORDER BY a DESC; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /abc/primary/4/5/6/d -> 'Two'
 fetched: /abc/primary/4/5/6 -> NULL
-output row: [4]
 fetched: /abc/primary/1/2/3/d -> 'one'
 fetched: /abc/primary/1/2/3 -> NULL
+output row: [4]
 output row: [1]
 
 query TTT

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -381,8 +381,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t@b_idx; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/b_idx/2/1/c/d -> /3/4
 output row: [1 2 3 4]
@@ -391,8 +392,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t@c_idx; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/c_idx/3/b/d -> /2/4
 output row: [1 2 3 4]
@@ -406,8 +408,9 @@ statement ok
 SET tracing = on,kv,results; SELECT a, b, d FROM t@d_idx; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/d_idx/4/1/b -> /2
 output row: [1 2 4]
@@ -419,8 +422,9 @@ statement ok
 SET tracing = on,kv,results; SELECT a, b FROM t@a_idx; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/a_idx/1/b -> /2
 output row: [1 2]
@@ -436,14 +440,15 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t@b_idx; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/b_idx/NULL/2 -> NULL
-output row: [2 NULL NULL NULL]
 fetched: /t/b_idx/NULL/3 -> NULL
-output row: [3 NULL NULL NULL]
 fetched: /t/b_idx/2/1/c/d -> /3/4
+output row: [2 NULL NULL NULL]
+output row: [3 NULL NULL NULL]
 output row: [1 2 3 4]
 
 # Regression test for #14601.
@@ -612,8 +617,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM dt WHERE a = '2015-08-25 04:45:45.53453+02:00'::timestamp; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /dt/primary/'2015-08-25 04:45:45.53453+00:00' -> NULL
 fetched: /dt/primary/'2015-08-25 04:45:45.53453+00:00'/b -> '2015-08-25'
@@ -624,8 +630,9 @@ statement ok
 SET tracing = on,kv,results; SELECT b FROM dt WHERE b < '2015-08-29'::date; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /dt/dt_b_key/'2015-08-25' -> /'2015-08-25 04:45:45.53453+00:00'
 output row: ['2015-08-25']
@@ -634,12 +641,13 @@ statement ok
 SET tracing = on,kv,results; SELECT c FROM dt WHERE c < '234h45m2s234ms'::interval; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /dt/dt_c_key/'02:45:02.234' -> /'2015-08-25 04:45:45.53453+00:00'
-output row: ['02:45:02.234']
 fetched: /dt/dt_c_key/'34:00:02' -> /'2015-08-30 03:34:45.34567+00:00'
+output row: ['02:45:02.234']
 output row: ['34:00:02']
 
 statement ok
@@ -698,14 +706,15 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM c@b_idx; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /c/b_idx/NULL/2 -> NULL
-output row: [2 NULL]
 fetched: /c/b_idx/NULL/3 -> NULL
-output row: [3 NULL]
 fetched: /c/b_idx/0.4/1/b -> /0.40
+output row: [2 NULL]
+output row: [3 NULL]
 output row: [1 0.40]
 
 # ------------------------------------------------------------------------------

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -25,8 +25,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE a = 2; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/primary/2/'two' -> NULL
 fetched: /t/primary/2/'two'/c -> 22
@@ -37,48 +38,52 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE a IN (1, 3); SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/primary/1/'one' -> NULL
 fetched: /t/primary/1/'one'/c -> 11
 fetched: /t/primary/1/'one'/d -> 'foo'
-output row: [1 'one' 11 'foo']
 fetched: /t/primary/3/'three' -> NULL
 fetched: /t/primary/3/'three'/c -> 33
 fetched: /t/primary/3/'three'/d -> 'blah'
+output row: [1 'one' 11 'foo']
 output row: [3 'three' 33 'blah']
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE d = 'foo' OR d = 'bar'; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/dc/'bar'/22/2/'two' -> NULL
-output row: [2 'two' 22 'bar']
 fetched: /t/dc/'foo'/11/1/'one' -> NULL
+output row: [2 'two' 22 'bar']
 output row: [1 'one' 11 'foo']
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE (d, c) IN (('foo', 11), ('bar', 22)); SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/dc/'bar'/22/2/'two' -> NULL
-output row: [2 'two' 22 'bar']
 fetched: /t/dc/'foo'/11/1/'one' -> NULL
+output row: [2 'two' 22 'bar']
 output row: [1 'one' 11 'foo']
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE (d, c) = ('foo', 11); SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/dc/'foo'/11/1/'one' -> NULL
 output row: [1 'one' 11 'foo']
@@ -87,8 +92,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE a < 2; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/primary/1/'one' -> NULL
 fetched: /t/primary/1/'one'/c -> 11
@@ -99,36 +105,39 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE a <= (1 + 1); SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/primary/1/'one' -> NULL
 fetched: /t/primary/1/'one'/c -> 11
 fetched: /t/primary/1/'one'/d -> 'foo'
-output row: [1 'one' 11 'foo']
 fetched: /t/primary/2/'two' -> NULL
 fetched: /t/primary/2/'two'/c -> 22
 fetched: /t/primary/2/'two'/d -> 'bar'
+output row: [1 'one' 11 'foo']
 output row: [2 'two' 22 'bar']
 
 statement ok
 SET tracing = on,kv,results; SELECT a, b FROM t WHERE b > 't'; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/bc/'three'/33/3 -> NULL
-output row: [3 'three']
 fetched: /t/bc/'two'/22/2 -> NULL
+output row: [3 'three']
 output row: [2 'two']
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE d < ('b' || 'l'); SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/dc/'bar'/22/2/'two' -> NULL
 output row: [2 'two' 22 'bar']
@@ -137,8 +146,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE c = 22; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/primary/1/'one' -> NULL
 fetched: /t/primary/1/'one'/c -> 11
@@ -146,24 +156,25 @@ fetched: /t/primary/1/'one'/d -> 'foo'
 fetched: /t/primary/2/'two' -> NULL
 fetched: /t/primary/2/'two'/c -> 22
 fetched: /t/primary/2/'two'/d -> 'bar'
-output row: [2 'two' 22 'bar']
 fetched: /t/primary/3/'three' -> NULL
 fetched: /t/primary/3/'three'/c -> 33
 fetched: /t/primary/3/'three'/d -> 'blah'
+output row: [2 'two' 22 'bar']
 
 # Use the descending index
 statement ok
 SET tracing = on,kv,results; SELECT a FROM t ORDER BY a DESC; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/a_desc/3/'three' -> NULL
-output row: [3]
 fetched: /t/a_desc/2/'two' -> NULL
-output row: [2]
 fetched: /t/a_desc/1/'one' -> NULL
+output row: [3]
+output row: [2]
 output row: [1]
 
 # Use the descending index with multiple spans.
@@ -171,12 +182,13 @@ statement ok
 SET tracing = on,kv,results; SELECT a FROM t WHERE a in (2, 3) ORDER BY a DESC; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/a_desc/3/'three' -> NULL
-output row: [3]
 fetched: /t/a_desc/2/'two' -> NULL
+output row: [3]
 output row: [2]
 
 # Index selection occurs in direct join operands too.
@@ -219,8 +231,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE a = 1 AND b > 'b'; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/primary/1/'c' -> NULL
 output row: [1 'c' NULL NULL]
@@ -229,8 +242,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE a > 0 AND b > 'b'; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/primary/1/'c' -> NULL
 output row: [1 'c' NULL NULL]
@@ -239,8 +253,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE a > 1 AND b > 'b'; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 
 query TTT
@@ -252,8 +267,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE a = 1 AND 'a' < b AND 'c' > b; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/primary/1/'b' -> NULL
 output row: [1 'b' NULL NULL]
@@ -275,8 +291,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t@ab WHERE a >= 3 AND a < 5; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/ab/3/4 -> NULL
 output row: [3 4]
@@ -285,8 +302,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t@ab WHERE a BETWEEN 3 AND 4; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/ab/3/4 -> NULL
 output row: [3 4]
@@ -295,104 +313,113 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t@ab WHERE a BETWEEN 3 AND 5; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/ab/3/4 -> NULL
-output row: [3 4]
 fetched: /t/ab/5/6 -> NULL
+output row: [3 4]
 output row: [5 6]
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t@ab WHERE a < 2 OR a < 4; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/ab/1/2 -> NULL
-output row: [1 2]
 fetched: /t/ab/3/4 -> NULL
+output row: [1 2]
 output row: [3 4]
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t@ab WHERE a < 3 OR a <= 3; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/ab/1/2 -> NULL
-output row: [1 2]
 fetched: /t/ab/3/4 -> NULL
+output row: [1 2]
 output row: [3 4]
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t@ab WHERE a <= 3 OR a < 3; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/ab/1/2 -> NULL
-output row: [1 2]
 fetched: /t/ab/3/4 -> NULL
+output row: [1 2]
 output row: [3 4]
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t@ab WHERE a > 3 OR a >= 3; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/ab/3/4 -> NULL
-output row: [3 4]
 fetched: /t/ab/5/6 -> NULL
+output row: [3 4]
 output row: [5 6]
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t@ab WHERE a >= 3 OR a > 3; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/ab/3/4 -> NULL
-output row: [3 4]
 fetched: /t/ab/5/6 -> NULL
+output row: [3 4]
 output row: [5 6]
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t@ab WHERE a = 3 OR a = 5; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/ab/3/4 -> NULL
-output row: [3 4]
 fetched: /t/ab/5/6 -> NULL
+output row: [3 4]
 output row: [5 6]
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t@ab WHERE a < 3 OR a > 3; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/ab/1/2 -> NULL
-output row: [1 2]
 fetched: /t/ab/5/6 -> NULL
+output row: [1 2]
 output row: [5 6]
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t@ab WHERE a + 1 = 4; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t/ab/3/4 -> NULL
 output row: [3 4]
@@ -658,60 +685,9 @@ index-join    ·      ·                        (id, k, v)  -k
 ·             spans  /!NULL-/"100"/PrefixEnd  ·           ·
 ·             limit  20                       ·           ·
 
-# Result check: The following query must not issue more than the
-# requested LIMIT K/V reads, even though an index join batches 100
-# rows at a time -- the limit should be enforced by the scan.  We are
-# reading from the end (ORDER BY k DESC) so we should see 20 values
-# from 030 to 011 (thus not 001-010).
+# The result output of this test requires that vectorized execution
+# is not used, so it has been moved to select_index_vectorize_off.
 
-statement ok
-SET tracing = on,kv,results; SELECT * FROM test2 WHERE k <= '100' ORDER BY k DESC LIMIT 20; SET tracing = off
-
-query T
-SELECT regexp_replace(message, '\d\d\d\d\d+', '...PK...')
-  FROM [SHOW KV TRACE FOR SESSION]
- WHERE message LIKE 'fetched:%'
-----
-fetched: /test2/test2_k_key/'030' -> /...PK...
-fetched: /test2/test2_k_key/'029' -> /...PK...
-fetched: /test2/test2_k_key/'028' -> /...PK...
-fetched: /test2/test2_k_key/'027' -> /...PK...
-fetched: /test2/test2_k_key/'026' -> /...PK...
-fetched: /test2/test2_k_key/'025' -> /...PK...
-fetched: /test2/test2_k_key/'024' -> /...PK...
-fetched: /test2/test2_k_key/'023' -> /...PK...
-fetched: /test2/test2_k_key/'022' -> /...PK...
-fetched: /test2/test2_k_key/'021' -> /...PK...
-fetched: /test2/test2_k_key/'020' -> /...PK...
-fetched: /test2/test2_k_key/'019' -> /...PK...
-fetched: /test2/test2_k_key/'018' -> /...PK...
-fetched: /test2/test2_k_key/'017' -> /...PK...
-fetched: /test2/test2_k_key/'016' -> /...PK...
-fetched: /test2/test2_k_key/'015' -> /...PK...
-fetched: /test2/test2_k_key/'014' -> /...PK...
-fetched: /test2/test2_k_key/'013' -> /...PK...
-fetched: /test2/test2_k_key/'012' -> /...PK...
-fetched: /test2/test2_k_key/'011' -> /...PK...
-fetched: /test2/primary/...PK.../k/v -> /'030'/42
-fetched: /test2/primary/...PK.../k/v -> /'029'/42
-fetched: /test2/primary/...PK.../k/v -> /'028'/42
-fetched: /test2/primary/...PK.../k/v -> /'027'/42
-fetched: /test2/primary/...PK.../k/v -> /'026'/42
-fetched: /test2/primary/...PK.../k/v -> /'025'/42
-fetched: /test2/primary/...PK.../k/v -> /'024'/42
-fetched: /test2/primary/...PK.../k/v -> /'023'/42
-fetched: /test2/primary/...PK.../k/v -> /'022'/42
-fetched: /test2/primary/...PK.../k/v -> /'021'/42
-fetched: /test2/primary/...PK.../k/v -> /'020'/42
-fetched: /test2/primary/...PK.../k/v -> /'019'/42
-fetched: /test2/primary/...PK.../k/v -> /'018'/42
-fetched: /test2/primary/...PK.../k/v -> /'017'/42
-fetched: /test2/primary/...PK.../k/v -> /'016'/42
-fetched: /test2/primary/...PK.../k/v -> /'015'/42
-fetched: /test2/primary/...PK.../k/v -> /'014'/42
-fetched: /test2/primary/...PK.../k/v -> /'013'/42
-fetched: /test2/primary/...PK.../k/v -> /'012'/42
-fetched: /test2/primary/...PK.../k/v -> /'011'/42
 
 # Regression test for #20035.
 statement ok
@@ -999,8 +975,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM noncover WHERE b = 2; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /noncover/b/2/1 -> NULL
 fetched: /noncover/primary/1 -> NULL
@@ -1022,8 +999,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM noncover WHERE c = 7; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /noncover/c/7 -> /5
 fetched: /noncover/primary/5 -> NULL
@@ -1181,8 +1159,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t2 WHERE b = 2 AND c % 2 = 0; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t2/bc/2/1/4 -> NULL
 fetched: /t2/bc/2/2/5 -> NULL
@@ -1210,8 +1189,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t2 WHERE b = 2 AND c != b; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t2/bc/2/1/4 -> NULL
 fetched: /t2/bc/2/2/5 -> NULL
@@ -1220,11 +1200,11 @@ fetched: /t2/primary/4 -> NULL
 fetched: /t2/primary/4/b -> 2
 fetched: /t2/primary/4/c -> 1
 fetched: /t2/primary/4/s -> '21'
-output row: [4 2 1 '21']
 fetched: /t2/primary/6 -> NULL
 fetched: /t2/primary/6/b -> 2
 fetched: /t2/primary/6/c -> 3
 fetched: /t2/primary/6/s -> '23'
+output row: [4 2 1 '21']
 output row: [6 2 3 '23']
 
 # We do NOT look up the table row for '22'.
@@ -1232,8 +1212,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t2 WHERE b = 2 AND c != b AND s <> '21'; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t2/bc/2/1/4 -> NULL
 fetched: /t2/bc/2/2/5 -> NULL
@@ -1254,8 +1235,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM t2 WHERE b > 1 AND ((c = b+1 AND s != '23') OR (a > b+4 AND s != '32')); SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t2/primary/1 -> NULL
 fetched: /t2/primary/1/b -> 1
@@ -1360,8 +1342,9 @@ statement ok
 SET tracing = on,kv,results; SELECT c FROM t4 WHERE a = 10 and b = 20; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t4/primary/10/20 -> NULL
 fetched: /t4/primary/10/20/c -> 30
@@ -1381,8 +1364,9 @@ statement ok
 SET tracing = on,kv,results; SELECT d FROM t4 WHERE a = 10 and b = 20; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /t4/primary/10/20 -> NULL
 fetched: /t4/primary/10/20/d -> 40

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index_vectorize_off
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index_vectorize_off
@@ -1,0 +1,74 @@
+# LogicTest: local-opt
+
+# This file contains test cases that cannot be run with the vectorized
+# execution engine.
+
+statement ok
+SET experimental_vectorize=off
+
+# Check that no extraneous rows are fetched due to excessive batching (#15910)
+# The test is composed of three parts: populate a table, check
+# that the problematic plan is properly derived from the test query,
+# then test the results.
+
+statement ok
+CREATE TABLE test2 (id BIGSERIAL PRIMARY KEY, k TEXT UNIQUE, v INT DEFAULT 42);
+INSERT INTO test2(k)
+     VALUES ('001'),('002'),('003'),('004'),('005'),('006'),('007'),('008'),('009'),('010'),
+            ('011'),('012'),('013'),('014'),('015'),('016'),('017'),('018'),('019'),('020'),
+            ('021'),('022'),('023'),('024'),('025'),('026'),('027'),('028'),('029'),('030')
+
+statement ok
+SET tracing = on,kv,results; SELECT * FROM test2 WHERE k <= '100' ORDER BY k DESC LIMIT 20; SET tracing = off
+
+# Result check: The following query must not issue more than the
+# requested LIMIT K/V reads, even though an index join batches 100
+# rows at a time -- the limit should be enforced by the scan.  We are
+# reading from the end (ORDER BY k DESC) so we should see 20 values
+# from 030 to 011 (thus not 001-010).
+
+query T
+SELECT regexp_replace(message, '\d\d\d\d\d+', '...PK...')
+  FROM [SHOW KV TRACE FOR SESSION]
+ WHERE message LIKE 'fetched:%'
+----
+fetched: /test2/test2_k_key/'030' -> /...PK...
+fetched: /test2/test2_k_key/'029' -> /...PK...
+fetched: /test2/test2_k_key/'028' -> /...PK...
+fetched: /test2/test2_k_key/'027' -> /...PK...
+fetched: /test2/test2_k_key/'026' -> /...PK...
+fetched: /test2/test2_k_key/'025' -> /...PK...
+fetched: /test2/test2_k_key/'024' -> /...PK...
+fetched: /test2/test2_k_key/'023' -> /...PK...
+fetched: /test2/test2_k_key/'022' -> /...PK...
+fetched: /test2/test2_k_key/'021' -> /...PK...
+fetched: /test2/test2_k_key/'020' -> /...PK...
+fetched: /test2/test2_k_key/'019' -> /...PK...
+fetched: /test2/test2_k_key/'018' -> /...PK...
+fetched: /test2/test2_k_key/'017' -> /...PK...
+fetched: /test2/test2_k_key/'016' -> /...PK...
+fetched: /test2/test2_k_key/'015' -> /...PK...
+fetched: /test2/test2_k_key/'014' -> /...PK...
+fetched: /test2/test2_k_key/'013' -> /...PK...
+fetched: /test2/test2_k_key/'012' -> /...PK...
+fetched: /test2/test2_k_key/'011' -> /...PK...
+fetched: /test2/primary/...PK.../k/v -> /'030'/42
+fetched: /test2/primary/...PK.../k/v -> /'029'/42
+fetched: /test2/primary/...PK.../k/v -> /'028'/42
+fetched: /test2/primary/...PK.../k/v -> /'027'/42
+fetched: /test2/primary/...PK.../k/v -> /'026'/42
+fetched: /test2/primary/...PK.../k/v -> /'025'/42
+fetched: /test2/primary/...PK.../k/v -> /'024'/42
+fetched: /test2/primary/...PK.../k/v -> /'023'/42
+fetched: /test2/primary/...PK.../k/v -> /'022'/42
+fetched: /test2/primary/...PK.../k/v -> /'021'/42
+fetched: /test2/primary/...PK.../k/v -> /'020'/42
+fetched: /test2/primary/...PK.../k/v -> /'019'/42
+fetched: /test2/primary/...PK.../k/v -> /'018'/42
+fetched: /test2/primary/...PK.../k/v -> /'017'/42
+fetched: /test2/primary/...PK.../k/v -> /'016'/42
+fetched: /test2/primary/...PK.../k/v -> /'015'/42
+fetched: /test2/primary/...PK.../k/v -> /'014'/42
+fetched: /test2/primary/...PK.../k/v -> /'013'/42
+fetched: /test2/primary/...PK.../k/v -> /'012'/42
+fetched: /test2/primary/...PK.../k/v -> /'011'/42

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -16,36 +16,38 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM kv2; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv2/primary/'a' -> NULL
 fetched: /kv2/primary/'a'/v -> 'b'
-output row: ['a' 'b']
 fetched: /kv2/primary/'c' -> NULL
 fetched: /kv2/primary/'c'/v -> 'd'
-output row: ['c' 'd']
 fetched: /kv2/primary/'e' -> NULL
 fetched: /kv2/primary/'e'/v -> 'f'
-output row: ['e' 'f']
 fetched: /kv2/primary/'f' -> NULL
 fetched: /kv2/primary/'f'/v -> 'g'
+output row: ['a' 'b']
+output row: ['c' 'd']
+output row: ['e' 'f']
 output row: ['f' 'g']
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM kv2@a; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv2/a/'b' -> /'a'
-output row: ['a' 'b']
 fetched: /kv2/a/'d' -> /'c'
-output row: ['c' 'd']
 fetched: /kv2/a/'f' -> /'e'
-output row: ['e' 'f']
 fetched: /kv2/a/'g' -> /'f'
+output row: ['a' 'b']
+output row: ['c' 'd']
+output row: ['e' 'f']
 output row: ['f' 'g']
 
 statement error duplicate key value \(v\)=\('g'\) violates unique constraint "a"
@@ -55,36 +57,38 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM kv2; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv2/primary/'a' -> NULL
 fetched: /kv2/primary/'a'/v -> 'b'
-output row: ['a' 'b']
 fetched: /kv2/primary/'c' -> NULL
 fetched: /kv2/primary/'c'/v -> 'd'
-output row: ['c' 'd']
 fetched: /kv2/primary/'e' -> NULL
 fetched: /kv2/primary/'e'/v -> 'f'
-output row: ['e' 'f']
 fetched: /kv2/primary/'f' -> NULL
 fetched: /kv2/primary/'f'/v -> 'g'
+output row: ['a' 'b']
+output row: ['c' 'd']
+output row: ['e' 'f']
 output row: ['f' 'g']
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM kv2@a; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv2/a/'b' -> /'a'
-output row: ['a' 'b']
 fetched: /kv2/a/'d' -> /'c'
-output row: ['c' 'd']
 fetched: /kv2/a/'f' -> /'e'
-output row: ['e' 'f']
 fetched: /kv2/a/'g' -> /'f'
+output row: ['a' 'b']
+output row: ['c' 'd']
+output row: ['e' 'f']
 output row: ['f' 'g']
 
 statement ok
@@ -192,8 +196,9 @@ statement ok
 SET tracing = on,kv,results; SELECT * FROM pks WHERE k1 = 2; SET tracing = off
 
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /pks/primary/2/2 -> NULL
 fetched: /pks/primary/2/2/v -> 3

--- a/pkg/sql/opt/exec/execbuilder/testdata/window
+++ b/pkg/sql/opt/exec/execbuilder/testdata/window
@@ -27,8 +27,9 @@ statement ok
 SET tracing = on,kv,results; SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k; SET tracing = off
 
 query T rowsort
-SELECT message FROM [SHOW KV TRACE FOR SESSION]
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+ ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /kv/primary/1/v -> /2
 fetched: /kv/primary/1/d -> 1


### PR DESCRIPTION
There were a large number of tests that mixed k/v logs with output row logs. This behavior worked but is specific to distsql query execution. To be specific, the tests look at the output of the k/v fetcher where it logs "fetched: k -> v", and where distsqlrunning logs "output row: ". The vectorized engine has similar output, but because it loads multiple rows into a batch before outputting any rows. This PR eliminates the testing pattern that depends on the interleaved orderin of "fetched" and "output row" statements by grouping the two types of statements using an ORDER BY and WITH ORDINALITY statement.

Release note: None