### PR TITLE
exec: simplify sort algorithm to avoid physical swaps

### DIFF
--- a/pkg/sql/exec/sort.go
+++ b/pkg/sql/exec/sort.go
@@ -33,7 +33,6 @@ func newSorter(
 ) (resettableOperator, error) {
 	sorters := make([]colSorter, len(orderingCols))
 	partitioners := make([]partitioner, len(orderingCols)-1)
-	isOrderingCol := make([]bool, len(inputTypes))
 
 	var err error
 	for i, ord := range orderingCols {
@@ -47,20 +46,15 @@ func newSorter(
 				return nil, err
 			}
 		}
-		// All ordering columns will have been sorted properly by the time the spool
-		// phase is over - only the columns that weren't sort columns will need to
-		// be reordered.
-		isOrderingCol[ord.ColIdx] = true
 	}
 
 	return &sortOp{
-		input:         input,
-		inputTypes:    inputTypes,
-		sorters:       sorters,
-		partitioners:  partitioners,
-		orderingCols:  orderingCols,
-		isOrderingCol: isOrderingCol,
-		state:         sortSpooling,
+		input:        input,
+		inputTypes:   inputTypes,
+		sorters:      sorters,
+		partitioners: partitioners,
+		orderingCols: orderingCols,
+		state:        sortSpooling,
 	}, nil
 }
 
@@ -176,12 +170,6 @@ type sortOp struct {
 	// orderingCols is the ordered list of column orderings that the sorter should
 	// sort on.
 	orderingCols []distsqlpb.Ordering_Column
-	// isOrderingCol is set to true for every column that will have been pre-sorted
-	// by the time the spool phase is finished. This will be true for all of the
-	// sort columns except for the final one. The rest of the columns will not be
-	// sorted yet, and will need to be sorted before outputting by rearrangement
-	// to the order specified by the order field.
-	isOrderingCol []bool
 	// sorters contains one colSorter per sort column.
 	sorters []colSorter
 	// partitioners contains one partitioner per sort column except for the last,
@@ -198,8 +186,7 @@ type sortOp struct {
 	// state is the current state of the sort.
 	state sortState
 
-	workingSpace []uint64
-	output       coldata.Batch
+	output coldata.Batch
 }
 
 var _ Operator = &sortOp{}
@@ -208,16 +195,13 @@ var _ Operator = &sortOp{}
 type colSorter interface {
 	// init prepares this sorter, given a particular Vec and an order vector,
 	// which must be the same size as the input Vec and will be permuted with
-	// the same swaps as the column. workingSpace is a vector of the same size as
-	// the column that is needed for temporary space.
-	init(col coldata.Vec, order []uint64, workingSpace []uint64)
+	// the same swaps as the column.
+	init(col coldata.Vec, order []uint64)
 	// sort globally sorts this sorter's column.
 	sort(ctx context.Context)
 	// sortPartitions sorts this sorter's column once for every partition in the
 	// partition slice.
 	sortPartitions(ctx context.Context, partitions []uint64)
-	// reorder reorders this sorter's column according to its order vector.
-	reorder()
 }
 
 func (p *sortOp) Init() {
@@ -262,27 +246,15 @@ func (p *sortOp) Next(ctx context.Context) coldata.Batch {
 		}
 
 		for j := 0; j < len(p.inputTypes); j++ {
-			if p.isOrderingCol[j] {
-				// The vec is already sorted, so just fill it directly.
-				p.output.ColVec(j).Copy(
-					coldata.CopyArgs{
-						ColType:     p.inputTypes[j],
-						Src:         p.input.getValues(j),
-						SrcStartIdx: p.emitted,
-						SrcEndIdx:   newEmitted,
-					},
-				)
-			} else {
-				p.output.ColVec(j).Copy(
-					coldata.CopyArgs{
-						ColType:     p.inputTypes[j],
-						Src:         p.input.getValues(j),
-						Sel64:       p.order,
-						SrcStartIdx: p.emitted,
-						SrcEndIdx:   p.emitted + uint64(p.output.Length()),
-					},
-				)
-			}
+			p.output.ColVec(j).Copy(
+				coldata.CopyArgs{
+					ColType:     p.inputTypes[j],
+					Src:         p.input.getValues(j),
+					Sel64:       p.order,
+					SrcStartIdx: p.emitted,
+					SrcEndIdx:   p.emitted + uint64(p.output.Length()),
+				},
+			)
 		}
 		p.emitted = newEmitted
 		return p.output
@@ -302,10 +274,8 @@ func (p *sortOp) sort(ctx context.Context) {
 	// underlying memory is insufficient.
 	if p.order == nil || uint64(cap(p.order)) < spooledTuples {
 		p.order = make([]uint64, spooledTuples)
-		p.workingSpace = make([]uint64, spooledTuples)
 	}
 	p.order = p.order[:spooledTuples]
-	p.workingSpace = p.workingSpace[:spooledTuples]
 
 	// Initialize the order vector to the ordinal positions within the input set.
 	for i := uint64(0); i < uint64(len(p.order)); i++ {
@@ -313,7 +283,7 @@ func (p *sortOp) sort(ctx context.Context) {
 	}
 
 	for i := range p.orderingCols {
-		p.sorters[i].init(p.input.getValues(int(p.orderingCols[i].ColIdx)), p.order, p.workingSpace)
+		p.sorters[i].init(p.input.getValues(int(p.orderingCols[i].ColIdx)), p.order)
 	}
 
 	// Now, sort each column in turn.
@@ -359,7 +329,7 @@ func (p *sortOp) sort(ctx context.Context) {
 	// 2  b
 	// 2  a
 	//
-	// Then, for each group in the sorted, first column, we sort the second coldata:
+	// Then, for each group in the sorted, first column, we sort the second column:
 	//
 	// 1 a
 	// 1 b
@@ -373,16 +343,14 @@ func (p *sortOp) sort(ctx context.Context) {
 			// on it, ORing the results together with each subsequent column. This
 			// produces a distinct vector (a boolean vector that has true in each
 			// position that is different from the last position).
-			p.partitioners[i-offset].partition(p.input.getValues(int(p.orderingCols[i-offset].ColIdx)), partitionsCol, spooledTuples)
+			p.partitioners[i-offset].partitionWithOrder(p.input.getValues(int(p.orderingCols[i-offset].ColIdx)), p.order,
+				partitionsCol, spooledTuples)
 		} else {
 			omitNextPartitioning = false
 		}
 		// Convert the distinct vector into a selection vector - a vector of indices
 		// that were true in the distinct vector.
 		partitions = boolVecToSel64(partitionsCol, partitions[:0])
-		// Reorder the column we're about to sort, based on the swaps we've seen in
-		// the sort so far.
-		sorter.reorder()
 		// For each partition (set of tuples that are identical in all of the sort
 		// columns we've seen so far), sort based on the new column.
 		sorter.sortPartitions(ctx, partitions)

--- a/pkg/sql/exec/sort_chunks.go
+++ b/pkg/sql/exec/sort_chunks.go
@@ -255,7 +255,8 @@ func (s *chunker) prepareNextChunks(ctx context.Context) chunkerReadingState {
 			// boundaries of the chunks (stored in s.chunks) to sort further.
 			copy(s.partitionCol, zeroBoolColumn)
 			for i, orderedCol := range s.alreadySortedCols {
-				s.partitioners[i].partition(s.batch.ColVec(int(orderedCol.ColIdx)), s.partitionCol, uint64(s.batch.Length()))
+				s.partitioners[i].partition(s.batch.ColVec(int(orderedCol.ColIdx)), s.partitionCol,
+					uint64(s.batch.Length()))
 			}
 			s.chunks = boolVecToSel64(s.partitionCol, s.chunks[:0])
 

--- a/pkg/sql/exec/sort_tmpl.go
+++ b/pkg/sql/exec/sort_tmpl.go
@@ -90,14 +90,12 @@ func newSingleSorter(t types.T, dir distsqlpb.Ordering_Column_Direction) (colSor
 type sort_TYPE_DIROp struct {
 	sortCol       _GOTYPESLICE
 	order         []uint64
-	workingSpace  []uint64
 	cancelChecker CancelChecker
 }
 
-func (s *sort_TYPE_DIROp) init(col coldata.Vec, order []uint64, workingSpace []uint64) {
+func (s *sort_TYPE_DIROp) init(col coldata.Vec, order []uint64) {
 	s.sortCol = col._TemplateType()
 	s.order = order
-	s.workingSpace = workingSpace
 }
 
 func (s *sort_TYPE_DIROp) sort(ctx context.Context) {
@@ -105,35 +103,11 @@ func (s *sort_TYPE_DIROp) sort(ctx context.Context) {
 	s.quickSort(ctx, 0, n, maxDepth(n))
 }
 
-func (s *sort_TYPE_DIROp) reorder() {
-	// Initialize our index vector to the inverse of the order vector. This
-	// creates what is known as a permutation. Position i in the permutation has
-	// the output index for the value at position i in the original ordering of
-	// the data we sorted. For example, if we were sorting the column [d,c,a,b],
-	// the order vector would be [2,3,1,0], and the permutation would be
-	// [3,2,0,1].
-	index := s.workingSpace
-	for idx, ord := range s.order {
-		index[int(ord)] = uint64(idx)
-	}
-	// Once we have our permutation, we apply it to our value column by following
-	// each cycle within the permutation until we reach the identity. This
-	// algorithm takes just O(n) swaps to reorder the sortCol. It also returns
-	// the index array to an ordinal list in the process.
-	for i := range index {
-		for index[i] != uint64(i) {
-			execgen.SWAP(s.sortCol, int(index[i]), i)
-			index[i], index[index[i]] = index[index[i]], index[i]
-		}
-	}
-}
-
 func (s *sort_TYPE_DIROp) sortPartitions(ctx context.Context, partitions []uint64) {
 	if len(partitions) < 1 {
 		panic(fmt.Sprintf("invalid partitions list %v", partitions))
 	}
 	order := s.order
-	sortCol := s.sortCol
 	for i, partitionStart := range partitions {
 		var partitionEnd uint64
 		if i == len(partitions)-1 {
@@ -142,7 +116,6 @@ func (s *sort_TYPE_DIROp) sortPartitions(ctx context.Context, partitions []uint6
 			partitionEnd = partitions[i+1]
 		}
 		s.order = order[partitionStart:partitionEnd]
-		s.sortCol = execgen.SLICE(sortCol, int(partitionStart), int(partitionEnd))
 		n := int(partitionEnd - partitionStart)
 		s.quickSort(ctx, 0, n, maxDepth(n))
 	}
@@ -150,17 +123,15 @@ func (s *sort_TYPE_DIROp) sortPartitions(ctx context.Context, partitions []uint6
 
 func (s *sort_TYPE_DIROp) Less(i, j int) bool {
 	var lt bool
-	arg1 := execgen.GET(s.sortCol, i)
-	arg2 := execgen.GET(s.sortCol, j)
+	// We always indirect via the order vector.
+	arg1 := execgen.GET(s.sortCol, int(s.order[i]))
+	arg2 := execgen.GET(s.sortCol, int(s.order[j]))
 	_ASSIGN_LT("lt", "arg1", "arg2")
 	return lt
 }
 
 func (s *sort_TYPE_DIROp) Swap(i, j int) {
-	// Swap needs to swap the values in the column being sorted, as otherwise
-	// subsequent calls to Less would be incorrect.
-	// We also store the swap order in s.order to swap all the other columns.
-	execgen.SWAP(s.sortCol, i, j)
+	// We don't physically swap the column - we merely edit the order vector.
 	s.order[i], s.order[j] = s.order[j], s.order[i]
 }
 


### PR DESCRIPTION
Previously, the sort algorithm used a mixture of physical swaps (editing
the columns to be sorted by swapping values) and logical swaps (editing
an ordinal vector by swapping ordinals) to compute a sort. This was a
bit confusing, and required a somewhat tricky algorithm to reconstruct
the order vector each time. More importantly, reordering the column
physically is a bit of a no-no, as it breaks the soft assumption that
our columns stay immutable.

This commit edits the sorting algorithm to occur completely logically.
The only mutation that occurs happens on the order vector, and all input
vectors are left alone.

Release note: None