### PR TITLE
sql: relax error matching in a test

### DIFF
--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -1117,7 +1117,7 @@ CREATE DATABASE t;
 CREATE TABLE t.test (k TEXT PRIMARY KEY, v TEXT);
 INSERT INTO t.test (k, v) VALUES ('test_key', 'test_val');
 SELECT * from t.test WHERE k = 'test_key';
-`); !testutils.IsError(err, "pq: testError") {
+`); !testutils.IsError(err, ".*testError.*") {
 		t.Errorf("unexpected error %v", err)
 	}
 	if !hitError {


### PR DESCRIPTION
Previously, TestNonRetryableError was doing an exact match with the
error message. This will not happen when vectorized engine is enabled
due to annotations of the error, so now we relax the matching to simply
containing the expected text.

Fixes: #38944.

Release note: None