### PR TITLE
distsql: fix a couple of issues when falling back to distsql from vectorized

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -169,6 +169,10 @@ func (dsp *DistSQLPlanner) setupFlows(
 	if len(flows) > 1 {
 		resultChan = make(chan runnerResult, len(flows)-1)
 	}
+	// recursed indicates whether we called setupFlows again from this method. It
+	// helps to transfer ownership of the request to the callee to avoid
+	// double-releasing processor specs.
+	recursed := false
 	for nodeID, flowSpec := range flows {
 		if nodeID == thisNodeID {
 			// Skip this node.
@@ -183,7 +187,11 @@ func (dsp *DistSQLPlanner) setupFlows(
 			nodeID:     nodeID,
 			resultChan: resultChan,
 		}
-		defer distsqlplan.ReleaseSetupFlowRequest(&req)
+		defer func() {
+			if !recursed {
+				distsqlplan.ReleaseSetupFlowRequest(&req)
+			}
+		}()
 
 		// Send out a request to the workers; if no worker is available, run
 		// directly.
@@ -219,6 +227,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 			// Recurse once with sessiondata.VectorizeOff, note that this branch will
 			// not be hit again due to prepareVectorizedFlowsForReplanning turning off
 			// vectorized.
+			recursed = true
 			return dsp.setupFlows(ctx, evalCtx, txnCoordMeta, flows, recv, localState)
 		}
 		return nil, nil, firstErr
@@ -227,7 +236,11 @@ func (dsp *DistSQLPlanner) setupFlows(
 	// Set up the flow on this node.
 	localReq := setupReq
 	localReq.Flow = *flows[thisNodeID]
-	defer distsqlplan.ReleaseSetupFlowRequest(&localReq)
+	defer func() {
+		if !recursed {
+			distsqlplan.ReleaseSetupFlowRequest(&localReq)
+		}
+	}()
 	parentMonitor := evalCtx.Mon
 	setupCtx, flow, err := dsp.distSQLSrv.SetupLocalSyncFlow(ctx, evalCtx.Mon, &localReq, recv, localState)
 	if err != nil {
@@ -242,6 +255,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 			// Reset the parent monitor, this field is overwritten when running a flow
 			// locally.
 			evalCtx.Mon = parentMonitor
+			recursed = true
 			return dsp.setupFlows(ctx, evalCtx, txnCoordMeta, flows, recv, localState)
 		}
 		return nil, nil, err

--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -1096,6 +1096,15 @@ func init() {
 	errors.RegisterWrapperDecoder(errors.GetTypeKey((*VectorizedSetupError)(nil)), decodeVectorizedSetupError)
 }
 
+// IsVectorizedSetupError returns whether the error is a VectorizedSetupError.
+func IsVectorizedSetupError(err error) bool {
+	_, ok := errors.If(err, func(err error) (v interface{}, ok bool) {
+		v, ok = err.(*VectorizedSetupError)
+		return v, ok
+	})
+	return ok
+}
+
 func (f *Flow) setupVectorized(ctx context.Context, acc *mon.BoundAccount) error {
 	streamIDToInputOp := make(map[distsqlpb.StreamID]exec.Operator)
 	streamIDToSpecIdx := make(map[distsqlpb.StreamID]int)

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -506,6 +506,9 @@ func (f *Flow) setup(ctx context.Context, spec *distsqlpb.FlowSpec) error {
 			log.VEventf(ctx, 1, "vectorized flow.")
 			return nil
 		}
+		// We won't run this flow through vectorized, so clear the memory account.
+		acc.Close(ctx)
+		f.vectorizedBoundAccount = nil
 		// Vectorization attempt failed with an error.
 		if f.spec.Gateway != f.nodeID {
 			// If we are not the gateway node, do not attempt to plan this with the

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -464,6 +464,7 @@ func (ds *ServerImpl) setupFlow(
 		log.Errorf(ctx, "error setting up flow: %s", err)
 		tracing.FinishSpan(sp)
 		ctx = opentracing.ContextWithSpan(ctx, nil)
+		monitor.Stop(ctx)
 		return ctx, nil, err
 	}
 	if !f.isLocal() {

--- a/pkg/sql/logictest/testdata/logic_test/dist_vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/dist_vectorize
@@ -66,6 +66,11 @@ SELECT url FROM [EXPLAIN ANALYZE SELECT * FROM kv JOIN kw ON kv.k = kw.k]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJzUl89vm0oQx-_vr0Bzek9ZP9gFnBipkq-p1KRKe6t8IDC1UQmLliVNFPl_rzCqUmOzA17Vwjfz47M73_FnpeENCpniXfyEFUTfgAMDAQx8YBAAgxBWDEolE6wqqZpXWuA2fYHIY5AVZa2b2ysGiVQI0RvoTOcIEXyNH3N8wDhF5XrAIEUdZ_lum1JlT7F6Xf54BgZfyrioImfmNhs_xjrZYOXIWpe1jpymIF2XeedWhTkmOnvO9GvkeP97zfqVjvPc0dkTRo5XwWrLoEXasn-X9fjqbOJqs1_QksNqu9qtsUaI-JadlnPek_Pne06XTymp6E36vo5UKSpMu-tcNRsPeutI0z6hWuNHmRWoXN6xI8fv-t8lv_rvg8rWm_YnMLhvWrLkbCnY0mfLwK6H-IJJrTNZ9PXxvUf-gB7VxbH8R6PfyZksXR7uh-5GCQ-jhPZRgr0ofLjYnD7Arpi5_mTE5qcmvR5whCeVVPQmPeMR5pd0hMVwG8QA7_2Za5nkr3k_IunNAO8nlVT0Jj2j9-KSvPeH2-AP8D6YueFkbOCnJl0M8H5SSUVv0jN671-S98FwG4IB3oezybjAT80Z0tbPXO7ERepwR-oNqslkFr2Zz-h_cEn-Ex-wD1iVsqiw8-lyfGWvaQ2ma2wbXslaJfhZyWS3TXt5v-N2s2iKlW6fivbitmgfNQUOh-c28MIG5lZ189BM8xEtE-PguQ28sIG5Vd2dlh3Qokt7f9K-ud--Eeb7PfO6dGAjuBkmBDfDhOBmmBKcoAnBQxvBzTAhuBkmBDfDlOAETQg-txH82kZRM0woaoYJRc0wpShBE4re2ChqhglFzTChqBmmFCVoQtGFjaLcak4gaEJSgiYsJWhKUwqnZgW7YcFuWrAbFyznBbuBgVtNDPxgZBhlq5mmbDXTlK1mmrSVwClbxwxLh__ZmGlpLE3ZOmpeGo1Tth4MD0ZbV9t_fgUAAP__VILF4Q==
 
+# This statement currently tests our fallback logic. Once we support avg()
+# window functions in vectorized, this can go away.
+statement ok
+SELECT avg(k) OVER () FROM kv
+
 # Verify execution.
 statement ok
 SET experimental_vectorize = always;

--- a/pkg/sql/logictest/testdata/logic_test/dist_vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/dist_vectorize
@@ -1,10 +1,4 @@
-# LogicTest: 5node-dist
-
-# Temporary until #38458 is fixed. This test fails under stress with the
-# 5node-dist-vec config, but not with the 5node-dist config and then setting
-# experimental_vectorize=on, which should be equivalent.
-statement ok
-SET experimental_vectorize=on;
+# LogicTest: 5node-dist-vec
 
 statement ok
 CREATE TABLE kv (k INT PRIMARY KEY, v INT)


### PR DESCRIPTION
To summarize (commits have details):
- Release memory when returning an error from `setupVectorized`.
- Include gateway in fallback, we previously only took into account remote vectorized setup failures.
- Fix a double free of `TableReaderSpec`s which could lead to very weird plans.

Fixes #38458 