### PR TITLE
build: require node version 10

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ new engineers.
      - GNU Make (3.81+ is known to work)
      - CMake 3.1+
      - Autoconf 2.68+
-     - NodeJS 6.x and Yarn 1.7+
+     - NodeJS 10.x and Yarn 1.7+
      - Yacc or Bison
 
    Note that at least 4GB of RAM is required to build from source and run tests.

--- a/build/node-run.sh
+++ b/build/node-run.sh
@@ -40,6 +40,12 @@ set -euo pipefail
 
 [[ "${1-}" ]] || { echo "usage: $0 [-C CWD] COMMAND [ARGS...]" >&2; exit 1; }
 
+raw_version=$(node --version)
+if [ $(grep -oE 'v[0-9]+\.' <<< ${raw_version}) != "v10." ]; then
+    echo "node v10.x is required, found ${raw_version}"
+    exit 1
+fi
+
 while getopts "C:" opt; do
   case $opt in
      C) cd "$OPTARG" ;;


### PR DESCRIPTION
Newer versions do not compile. Older version are...old.

Fixes #37309

Release note (build change): Require node version 10 for builds. This
was previously implicitly required. Now the requirement is explicit.