### PR TITLE
exec: dump stack trace for unexpected internal errors

### DIFF
--- a/pkg/sql/exec/error.go
+++ b/pkg/sql/exec/error.go
@@ -53,7 +53,7 @@ func CatchVectorizedRuntimeError(operation func()) (retErr error) {
 						// needs to be annotated to indicate that it was
 						// unexpected.
 						if code := pgerror.GetPGCode(e); code == pgcode.Uncategorized {
-							e = errors.Wrap(e, "unexpected error from the vectorized runtime")
+							e = errors.AssertionFailedf("unexpected error from the vectorized runtime: %+v", e)
 						}
 						retErr = e
 					} else {


### PR DESCRIPTION
Before: `pq: internal error: unexpected error from the vectorized runtime: interface conversion: coldata.column is []bool, not []float64`

After:

```
pq: internal error: unexpected error from the vectorized runtime: interface conversion: coldata.column is []bool, not []float64
DETAIL: stack trace:
github.com/cockroachdb/cockroach/pkg/sql/exec/error.go:56: func1()
runtime/panic.go:522: gopanic()
runtime/iface.go:248: panicdottypeE()
github.com/cockroachdb/cockroach/pkg/sql/exec/coldata/vec.go:218: Float64()
github.com/cockroachdb/cockroach/pkg/sql/exec/projection_ops.eg.go:10797: Next()
github.com/cockroachdb/cockroach/pkg/sql/exec/projection_ops.eg.go:10980: Next()
github.com/cockroachdb/cockroach/pkg/sql/exec/case.go:68: Next()
github.com/cockroachdb/cockroach/pkg/sql/exec/projection_ops.eg.go:10786: Next()
github.com/cockroachdb/cockroach/pkg/sql/exec/projection_ops.eg.go:10980: Next()
github.com/cockroachdb/cockroach/pkg/sql/exec/simple_project.go:77: Next()
github.com/cockroachdb/cockroach/pkg/sql/exec/fn_op.go:32: Next()
github.com/cockroachdb/cockroach/pkg/sql/exec/one_shot.go:37: Next()
github.com/cockroachdb/cockroach/pkg/sql/exec/aggregator.go:275: Next()
github.com/cockroachdb/cockroach/pkg/sql/exec/projection_ops.eg.go:10884: Next()
github.com/cockroachdb/cockroach/pkg/sql/exec/projection_ops.eg.go:11126: Next()
github.com/cockroachdb/cockroach/pkg/sql/exec/simple_project.go:77: Next()
github.com/cockroachdb/cockroach/pkg/sql/distsqlrun/materializer.go:106: nextBatch()
github.com/cockroachdb/cockroach/pkg/sql/exec/error.go:76: CatchVectorizedRuntimeError()
github.com/cockroachdb/cockroach/pkg/sql/distsqlrun/materializer.go:113: Next()
github.com/cockroachdb/cockroach/pkg/sql/distsqlrun/base.go:171: Run()
github.com/cockroachdb/cockroach/pkg/sql/distsqlrun/processors.go:793: Run()
github.com/cockroachdb/cockroach/pkg/sql/distsqlrun/flow.go:658: Run()
github.com/cockroachdb/cockroach/pkg/sql/distsql_running.go:299: Run()
github.com/cockroachdb/cockroach/pkg/sql/distsql_running.go:882: PlanAndRun()
github.com/cockroachdb/cockroach/pkg/sql/conn_executor_exec.go:902: execWithDistSQLEngine()
github.com/cockroachdb/cockroach/pkg/sql/conn_executor_exec.go:734: dispatchToExecutionEngine()
github.com/cockroachdb/cockroach/pkg/sql/conn_executor_exec.go:417: execStmtInOpenState()
github.com/cockroachdb/cockroach/pkg/sql/conn_executor_exec.go:99: execStmt()
github.com/cockroachdb/cockroach/pkg/sql/conn_executor.go:1204: execCmd()
github.com/cockroachdb/cockroach/pkg/sql/conn_executor.go:1140: run()
github.com/cockroachdb/cockroach/pkg/sql/conn_executor.go:442: ServeConn()
github.com/cockroachdb/cockroach/pkg/sql/pgwire/conn.go:580: func1()

HINT: You have encountered an unexpected error.

Please check the public issue tracker to check whether this problem is
already tracked. If you cannot find it there, please report the error
with details by creating a new issue.

If you would rather not post publicly, please contact us directly
using the support form.

We appreciate your feedback.

```

Release note: None