### PR TITLE
exec: support projections of LIKE operators

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -850,7 +850,11 @@ func planProjectionExpr(
 		// The projection result will be outputted to a new column which is appended
 		// to the input batch.
 		resultIdx = len(ct)
-		if binOp == tree.In || binOp == tree.NotIn {
+		if binOp == tree.Like || binOp == tree.NotLike {
+			negate := binOp == tree.NotLike
+			op, err = exec.GetLikeProjectionOperator(
+				ctx, leftOp, leftIdx, resultIdx, string(tree.MustBeDString(rConstArg)), negate)
+		} else if binOp == tree.In || binOp == tree.NotIn {
 			negate := binOp == tree.NotIn
 			datumTuple, ok := tree.AsDTuple(rConstArg)
 			if !ok {

--- a/pkg/sql/exec/execgen/cmd/execgen/like_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/like_ops_gen.go
@@ -31,17 +31,23 @@ import (
 	"regexp"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 )
 
 {{range .}}
 {{template "selConstOp" .}}
+{{template "projRConstOp" .}}
 {{end}}
 `
 
 func genLikeOps(wr io.Writer) error {
-	tmpl := template.New("like_ops").Funcs(template.FuncMap{"buildDict": buildDict})
+	tmpl := template.New("like_sel_ops").Funcs(template.FuncMap{"buildDict": buildDict})
 	var err error
 	tmpl, err = tmpl.Parse(selTemplate)
+	if err != nil {
+		return err
+	}
+	tmpl, err = tmpl.Parse(projTemplate)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
@@ -38,11 +38,7 @@ import (
 {{define "opLConstName"}}proj{{.Name}}{{.LTyp}}Const{{.RTyp}}Op{{end}}
 {{define "opName"}}proj{{.Name}}{{.LTyp}}{{.RTyp}}Op{{end}}
 
-{{/* The outer range is a types.T, and the inner is the overloads associated
-     with that type. */}}
-{{range .TypToOverloads}}
-{{range .}}
-
+{{define "projRConstOp"}}
 type {{template "opRConstName" .}} struct {
 	OneInputNode
 
@@ -90,7 +86,9 @@ func (p {{template "opRConstName" .}}) Next(ctx context.Context) coldata.Batch {
 func (p {{template "opRConstName" .}}) Init() {
 	p.input.Init()
 }
+{{end}}
 
+{{define "projLConstOp"}}
 type {{template "opLConstName" .}} struct {
 	OneInputNode
 
@@ -138,7 +136,9 @@ func (p {{template "opLConstName" .}}) Next(ctx context.Context) coldata.Batch {
 func (p {{template "opLConstName" .}}) Init() {
 	p.input.Init()
 }
+{{end}}
 
+{{define "projOp"}}
 type {{template "opName" .}} struct {
 	OneInputNode
 
@@ -188,7 +188,15 @@ func (p {{template "opName" .}}) Next(ctx context.Context) coldata.Batch {
 func (p {{template "opName" .}}) Init() {
 	p.input.Init()
 }
+{{end}}
 
+{{/* The outer range is a types.T, and the inner is the overloads associated
+     with that type. */}}
+{{range .TypToOverloads}}
+{{range .}}
+{{template "projRConstOp" .}}
+{{template "projLConstOp" .}}
+{{template "projOp" .}}
 {{end}}
 {{end}}
 

--- a/pkg/sql/exec/like_ops.go
+++ b/pkg/sql/exec/like_ops.go
@@ -13,36 +13,40 @@ package exec
 import (
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
 )
 
-// GetLikeOperator returns a selection operator which applies the specified LIKE
-// pattern, or NOT LIKE if the negate argument is true. The implementation
-// varies depending on the complexity of the pattern.
-func GetLikeOperator(
-	ctx *tree.EvalContext, input Operator, colIdx int, pattern string, negate bool,
-) (Operator, error) {
+// likeOpType is an enum that describes all of the different variants of LIKE
+// that we support.
+type likeOpType int
+
+const (
+	likeConstant likeOpType = iota + 1
+	likeConstantNegate
+	likeNeverMatch
+	likeAlwaysMatch
+	likeSuffix
+	likeSuffixNegate
+	likePrefix
+	likePrefixNegate
+	likeRegexp
+	likeRegexpNegate
+)
+
+func getLikeOperatorType(pattern string, negate bool) (likeOpType, string, error) {
 	if pattern == "" {
 		if negate {
-			return &selNEBytesBytesConstOp{
-				OneInputNode: NewOneInputNode(input),
-				colIdx:       colIdx,
-				constArg:     []byte{},
-			}, nil
+			return likeConstantNegate, "", nil
 		}
-		return &selEQBytesBytesConstOp{
-			OneInputNode: NewOneInputNode(input),
-			colIdx:       colIdx,
-			constArg:     []byte{},
-		}, nil
+		return likeConstant, "", nil
 	}
 	if pattern == "%" {
 		if negate {
-			return NewZeroOp(input), nil
+			return likeNeverMatch, "", nil
 		}
-		// Matches everything.
-		// TODO(solon): Replace this with a NOT NULL operator.
-		return NewNoop(input), nil
+		return likeAlwaysMatch, "", nil
 	}
 	if len(pattern) > 1 && !strings.ContainsAny(pattern[1:len(pattern)-1], "_%") {
 		// There are no wildcards in the middle of the string, so we only need to
@@ -53,68 +57,198 @@ func GetLikeOperator(
 		if !isWildcard(firstChar) && !isWildcard(lastChar) {
 			// No wildcards, so this is just an exact string match.
 			if negate {
-				return &selNEBytesBytesConstOp{
-					OneInputNode: NewOneInputNode(input),
-					colIdx:       colIdx,
-					constArg:     []byte(pattern),
-				}, nil
+				return likeConstantNegate, pattern, nil
 			}
-			return &selEQBytesBytesConstOp{
-				OneInputNode: NewOneInputNode(input),
-				colIdx:       colIdx,
-				constArg:     []byte(pattern),
-			}, nil
+			return likeConstant, pattern, nil
 		}
 		if firstChar == '%' && !isWildcard(lastChar) {
-			suffix := []byte(pattern[1:])
+			suffix := pattern[1:]
 			if negate {
-				return &selNotSuffixBytesBytesConstOp{
-					OneInputNode: NewOneInputNode(input),
-					colIdx:       colIdx,
-					constArg:     suffix,
-				}, nil
+				return likeSuffixNegate, suffix, nil
 			}
-			return &selSuffixBytesBytesConstOp{
-				OneInputNode: NewOneInputNode(input),
-				colIdx:       colIdx,
-				constArg:     suffix,
-			}, nil
+			return likeSuffix, suffix, nil
 		}
 		if lastChar == '%' && !isWildcard(firstChar) {
-			prefix := []byte(pattern[:len(pattern)-1])
+			prefix := pattern[:len(pattern)-1]
 			if negate {
-				return &selNotPrefixBytesBytesConstOp{
-					OneInputNode: NewOneInputNode(input),
-					colIdx:       colIdx,
-					constArg:     prefix,
-				}, nil
+				return likePrefixNegate, prefix, nil
 			}
-			return &selPrefixBytesBytesConstOp{
-				OneInputNode: NewOneInputNode(input),
-				colIdx:       colIdx,
-				constArg:     prefix,
-			}, nil
+			return likePrefix, prefix, nil
 		}
 	}
 	// Default (slow) case: execute as a regular expression match.
-	re, err := tree.ConvertLikeToRegexp(ctx, pattern, false, '\\')
+	if negate {
+		return likeRegexpNegate, pattern, nil
+	}
+	return likeRegexp, pattern, nil
+}
+
+// GetLikeOperator returns a selection operator which applies the specified LIKE
+// pattern, or NOT LIKE if the negate argument is true. The implementation
+// varies depending on the complexity of the pattern.
+func GetLikeOperator(
+	ctx *tree.EvalContext, input Operator, colIdx int, pattern string, negate bool,
+) (Operator, error) {
+	likeOpType, pattern, err := getLikeOperatorType(pattern, negate)
 	if err != nil {
 		return nil, err
 	}
-	if negate {
+	pat := []byte(pattern)
+	switch likeOpType {
+	case likeConstant:
+		return &selEQBytesBytesConstOp{
+			OneInputNode: NewOneInputNode(input),
+			colIdx:       colIdx,
+			constArg:     pat,
+		}, nil
+	case likeConstantNegate:
+		return &selNEBytesBytesConstOp{
+			OneInputNode: NewOneInputNode(input),
+			colIdx:       colIdx,
+			constArg:     pat,
+		}, nil
+	case likeNeverMatch:
+		return NewZeroOp(input), nil
+	case likeAlwaysMatch:
+		// Matches everything.
+		// TODO(solon): Replace this with a NOT NULL operator.
+		return NewNoop(input), nil
+	case likeSuffix:
+		return &selSuffixBytesBytesConstOp{
+			OneInputNode: NewOneInputNode(input),
+			colIdx:       colIdx,
+			constArg:     pat,
+		}, nil
+	case likeSuffixNegate:
+		return &selNotSuffixBytesBytesConstOp{
+			OneInputNode: NewOneInputNode(input),
+			colIdx:       colIdx,
+			constArg:     pat,
+		}, nil
+	case likePrefix:
+		return &selPrefixBytesBytesConstOp{
+			OneInputNode: NewOneInputNode(input),
+			colIdx:       colIdx,
+			constArg:     pat,
+		}, nil
+	case likePrefixNegate:
+		return &selNotPrefixBytesBytesConstOp{
+			OneInputNode: NewOneInputNode(input),
+			colIdx:       colIdx,
+			constArg:     pat,
+		}, nil
+	case likeRegexp:
+		re, err := tree.ConvertLikeToRegexp(ctx, pattern, false, '\\')
+		if err != nil {
+			return nil, err
+		}
+		return &selRegexpBytesBytesConstOp{
+			OneInputNode: NewOneInputNode(input),
+			colIdx:       colIdx,
+			constArg:     re,
+		}, nil
+	case likeRegexpNegate:
+		re, err := tree.ConvertLikeToRegexp(ctx, pattern, false, '\\')
+		if err != nil {
+			return nil, err
+		}
 		return &selNotRegexpBytesBytesConstOp{
 			OneInputNode: NewOneInputNode(input),
 			colIdx:       colIdx,
 			constArg:     re,
 		}, nil
+	default:
+		return nil, errors.AssertionFailedf("unsupported like op type %d", likeOpType)
 	}
-	return &selRegexpBytesBytesConstOp{
-		OneInputNode: NewOneInputNode(input),
-		colIdx:       colIdx,
-		constArg:     re,
-	}, nil
 }
 
 func isWildcard(c byte) bool {
 	return c == '%' || c == '_'
+}
+
+// GetLikeProjectionOperator returns a projection operator which projects the
+// result of the specified LIKE pattern, or NOT LIKE if the negate argument is
+// true. The implementation varies depending on the complexity of the pattern.
+func GetLikeProjectionOperator(
+	ctx *tree.EvalContext, input Operator, colIdx int, resultIdx int, pattern string, negate bool,
+) (Operator, error) {
+	likeOpType, pattern, err := getLikeOperatorType(pattern, negate)
+	if err != nil {
+		return nil, err
+	}
+	pat := []byte(pattern)
+	switch likeOpType {
+	case likeConstant:
+		return &projEQBytesBytesConstOp{
+			OneInputNode: NewOneInputNode(input),
+			colIdx:       colIdx,
+			constArg:     pat,
+			outputIdx:    resultIdx,
+		}, nil
+	case likeConstantNegate:
+		return &projNEBytesBytesConstOp{
+			OneInputNode: NewOneInputNode(input),
+			colIdx:       colIdx,
+			constArg:     pat,
+			outputIdx:    resultIdx,
+		}, nil
+	case likeNeverMatch:
+		return NewConstOp(input, types.Bool, false, resultIdx)
+	case likeAlwaysMatch:
+		// Matches everything.
+		// TODO(solon): Replace this with a NOT NULL operator.
+		return NewConstOp(input, types.Bool, true, resultIdx)
+	case likeSuffix:
+		return &projSuffixBytesBytesConstOp{
+			OneInputNode: NewOneInputNode(input),
+			colIdx:       colIdx,
+			constArg:     pat,
+			outputIdx:    resultIdx,
+		}, nil
+	case likeSuffixNegate:
+		return &projNotSuffixBytesBytesConstOp{
+			OneInputNode: NewOneInputNode(input),
+			colIdx:       colIdx,
+			constArg:     pat,
+			outputIdx:    resultIdx,
+		}, nil
+	case likePrefix:
+		return &projPrefixBytesBytesConstOp{
+			OneInputNode: NewOneInputNode(input),
+			colIdx:       colIdx,
+			constArg:     pat,
+			outputIdx:    resultIdx,
+		}, nil
+	case likePrefixNegate:
+		return &projNotPrefixBytesBytesConstOp{
+			OneInputNode: NewOneInputNode(input),
+			colIdx:       colIdx,
+			constArg:     pat,
+			outputIdx:    resultIdx,
+		}, nil
+	case likeRegexp:
+		re, err := tree.ConvertLikeToRegexp(ctx, pattern, false, '\\')
+		if err != nil {
+			return nil, err
+		}
+		return &projRegexpBytesBytesConstOp{
+			OneInputNode: NewOneInputNode(input),
+			colIdx:       colIdx,
+			constArg:     re,
+			outputIdx:    resultIdx,
+		}, nil
+	case likeRegexpNegate:
+		re, err := tree.ConvertLikeToRegexp(ctx, pattern, false, '\\')
+		if err != nil {
+			return nil, err
+		}
+		return &projNotRegexpBytesBytesConstOp{
+			OneInputNode: NewOneInputNode(input),
+			colIdx:       colIdx,
+			constArg:     re,
+			outputIdx:    resultIdx,
+		}, nil
+	default:
+		return nil, errors.AssertionFailedf("unsupported like op type %d", likeOpType)
+	}
 }

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -334,6 +334,12 @@ SELECT * FROM e WHERE x NOT LIKE 'a%c'
 ----
 xyz
 
+query TBBBBBBBB
+SELECT x, x LIKE '%', x NOT LIKE '%', x LIKE 'ab%', x NOT LIKE 'ab%', x LIKE '%bc', x NOT LIKE '%bc', x LIKE 'a%c', x NOT LIKE 'a%c' FROM e ORDER BY x
+----
+abc  true  false  true   false  true   false  true   false
+xyz  true  false  false  true   false  true   false  true
+
 # Test that vectorized stats are collected correctly.
 statement ok
 SET vectorize = experimental_on


### PR DESCRIPTION
This commit adds support for projections of the various LIKE operators.
The existing constructor for LIKE selection operators was refactored so
that some logic could be shared between the selection and projection
operator choosing.


Closes #38657.