### PR TITLE
roachtest: fix acceptance/version-upgrade

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -64,6 +64,7 @@ func registerAcceptance(r *testRegistry) {
 		tc := tc // copy for closure
 		spec := specTemplate
 		spec.Name = specTemplate.Name + "/" + tc.name
+		spec.MinVersion = tc.minVersion
 		spec.Run = func(ctx context.Context, t *test, c *cluster) {
 			tc.fn(ctx, t, c)
 		}


### PR DESCRIPTION
In the last step, it was using the master-built roachtest's view of
settings.BinaryServerVersion, which may not be the actual
BinaryServerVersion corresponding to the binary being tested. Instead,
auto-discover the executable version via SQL. This also allowed removing a
noisy flag.

Closes #38640.

Release note: None