### PR TITLE
exec: Fixing panics in cfetcher logging.

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -524,3 +524,39 @@ query I
 SELECT sum_int(_int2) FROM t38937
 ----
 1
+
+# Regression tests for #38959
+
+statement ok
+CREATE TABLE t38959 (a INT PRIMARY KEY, b INT, c INT, d INT, INDEX b_idx (b) STORING (c, d), UNIQUE INDEX c_idx (c) STORING (b, d))
+
+statement ok
+INSERT INTO t38959 VALUES (1, 2, 3, 4)
+
+statement ok
+SET tracing=on,kv,results
+
+query IIII
+SELECT * FROM t38959@c_idx
+----
+1 2 3 4
+
+statement ok
+SET tracing=off
+
+statement ok
+CREATE TABLE t38959_2 (x INT PRIMARY KEY, y INT, z FLOAT, INDEX xy (x, y), INDEX zyx (z, y, x), FAMILY (x), FAMILY (y), FAMILY (z))
+
+statement ok
+INSERT INTO t38959_2 VALUES (1, 2, 3.0), (4, 5, 6.0), (7, NULL, 8.0)
+
+statement ok
+SET tracing=on,kv,results
+
+query I
+SELECT min(x) FROM t38959_2 WHERE (y, z) = (2, 3.0)
+----
+1
+
+statement ok
+SET tracing=off

--- a/pkg/sql/row/cfetcher.go
+++ b/pkg/sql/row/cfetcher.go
@@ -785,7 +785,7 @@ func (rf *CFetcher) processValue(
 		for _, idx := range rf.table.indexColOrdinals {
 			buf.WriteByte('/')
 			if idx != -1 {
-				dVal := exec.PhysicalTypeColElemToDatum(rf.machine.colvecs[idx], rf.machine.rowIdx, rf.table.da, rf.table.keyValTypes[idx])
+				dVal := exec.PhysicalTypeColElemToDatum(rf.machine.colvecs[idx], rf.machine.rowIdx, rf.table.da, rf.table.cols[idx].Type)
 				buf.WriteString(fmt.Sprintf("%v", dVal.String()))
 			} else {
 				buf.WriteByte('?')
@@ -1057,7 +1057,7 @@ func (rf *CFetcher) fillNulls() error {
 			var indexColValues []string
 			for _, idx := range table.indexColOrdinals {
 				if idx != -1 {
-					indexColValues = append(indexColValues, exec.PhysicalTypeColElemToDatum(rf.machine.colvecs[idx], rf.machine.rowIdx, rf.table.da, rf.table.keyValTypes[idx]).String())
+					indexColValues = append(indexColValues, exec.PhysicalTypeColElemToDatum(rf.machine.colvecs[idx], rf.machine.rowIdx, rf.table.da, rf.table.cols[idx].Type).String())
 				} else {
 					indexColValues = append(indexColValues, "?")
 				}


### PR DESCRIPTION
Addresses #38951 and #38950.

Caused by a misunderstanding on my part of fields in the cfetcher.

Release note: None