### PR TITLE
sql: initialize node ID in an internal test

### DIFF
--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -265,7 +265,7 @@ func startConnExecutor(
 			ClusterID: func() uuid.UUID { return uuid.UUID{} },
 		},
 		DistSQLPlanner: NewDistSQLPlanner(
-			ctx, distsqlrun.Version, st, roachpb.NodeDescriptor{},
+			ctx, distsqlrun.Version, st, roachpb.NodeDescriptor{NodeID: 1},
 			nil, /* rpcCtx */
 			distsqlrun.NewServer(ctx, distsqlrun.ServerConfig{
 				AmbientContext: testutils.MakeAmbientCtx(),


### PR DESCRIPTION
We are failing this test when enabling vectorized engine due to
an uninitialized nodeID. I don't think it is such on purpose, so let's initialize it.

Release note: None