### PR TITLE
roachtest: don't panic on unknown cluster unregistration

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -217,9 +217,10 @@ func (r *clusterRegistry) registerCluster(c *cluster) error {
 func (r *clusterRegistry) unregisterCluster(c *cluster) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	_, exists := r.mu.clusters[c.name]
-	if !exists {
-		panic(fmt.Sprintf("trying to unregister cluster not in registry: %s", c))
+	if _, ok := r.mu.clusters[c.name]; !ok {
+		// If the cluster is not registered, no-op. This allows the
+		// method to be called defensively.
+		return false
 	}
 	delete(r.mu.clusters, c.name)
 	if c.tag != "" {
@@ -228,7 +229,7 @@ func (r *clusterRegistry) unregisterCluster(c *cluster) bool {
 		}
 		r.mu.tagCount[c.tag]--
 	}
-	return exists
+	return true
 }
 
 func (r *clusterRegistry) countForTag(tag string) int {


### PR DESCRIPTION
This is easily possible if we call `cluster.Destroy` to "make sure" a cluster wasn't partially created.

Release note: None