### PR TITLE
opt: use URL for EXPLAIN (OPT,ENV)

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/builder_test.go
+++ b/pkg/sql/opt/exec/execbuilder/builder_test.go
@@ -13,6 +13,7 @@ package execbuilder_test
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/logictest"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
@@ -25,5 +26,6 @@ import (
 // it's sufficient to run on a single configuration.
 func TestExecBuild(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
 	logictest.RunLogicTest(t, "testdata/[^.]*")
 }

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_env
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_env
@@ -32,175 +32,36 @@ CREATE TABLE y (
   INDEX (v)
 )
 
-# NOTE: the logic test rewriter formats these terribly, because it thinks it's
-# formatting relational output. If you need to rewrite these try to keep the
-# current formatting.
-
-# Since version might change for reasons unrelated to this test, just ensure
-# there's a line that includes the version (the NOT LIKE %EXPLAIN% is so that
-# we don't just recognize the printing of this query, which also contains the
-# string "Version").
-query B
-SELECT EXISTS(
-    SELECT text FROM
-        [EXPLAIN (opt, env) SELECT * FROM x WHERE b = 3]
-    WHERE text LIKE '%Version%' AND text NOT LIKE '%EXPLAIN%'
-)
+query T
+EXPLAIN (OPT, ENV) SELECT * FROM x WHERE b = 3
 ----
-true
+https://cockroachdb.github.io/text/decode.html#eJy0ksFum0AQhs_Zp_jFJbiFeDGXCKtSCdmotBhbsE1jWRZa1khBJWDB0hJVlfIQfkI_SQVxXY69hMNIM_98o_8Xe5_VTV6VDrxKfq8rIR9vb5B1mUzbvNhlNVTWKPx43SLEi5jLGbh7EzB00MmFgB_ya4RLjvBrEBjkIj1NXjtvGcY8cv2QQ9vX-ZOonzWsIn_hRmt8YWvoAm7sTQxy4Ye37AFdkib5roOe_p3fuQs_WI9wXRhIJ2QyJ8QNOItOfnqrV_s2LXJ51cEPPzOPI-Yu92PuezEuNwQAfg21_zRZFe1T2WgONufhIAjt3G-N0X6dCZXtEqE0B9qMWtcmtUxqgVoOpQ6l74eqjZBd3qi8lCqRVVv2mEXpSH7MG1UlsioS9bzP-qtjuGyL4gyOsbr6-e_gzLZm9qD9Nv47YfqGCQdDbxeSbC_nhLCHVeD6IfTlihtg4f0EMQv6X_4Od9FygQ7fPrGIIcUH2HNimqZJGilKdB9Pb4zgeDgcDy_HwwtkVTaqFnmpHExnU8vBZmrDxNTekj8BAAD__6-iy5g=
 
 statement error ENV only supported with \(OPT\) option
-EXPLAIN (env) SELECT * FROM x WHERE b = 3
+EXPLAIN (ENV) SELECT * FROM x WHERE b = 3
 
 query T
-SELECT text FROM [
-EXPLAIN (opt, env) SELECT * FROM x WHERE b = 3
-] WHERE text NOT LIKE '%Version%' OR text LIKE '%EXPLAIN%'
+EXPLAIN (OPT, ENV) SELECT * FROM x WHERE b = 3
 ----
-·
-CREATE TABLE x (
-    a INT8 NOT NULL,
-    b INT8 NULL,
-    CONSTRAINT "primary" PRIMARY KEY (a ASC),
-    INDEX x_b_idx (b ASC),
-    FAMILY "primary" (a, b)
-);
-·
-ALTER TABLE test.public.x INJECT STATISTICS '[
-    {
-        "columns": [
-            "a"
-        ],
-        "created_at": "2018-01-01 01:00:00+00:00",
-        "distinct_count": 100,
-        "histo_col_type": "",
-        "null_count": 0,
-        "row_count": 123123
-    },
-    {
-        "columns": [
-            "b"
-        ],
-        "created_at": "2018-01-01 01:00:00+00:00",
-        "distinct_count": 123123,
-        "histo_col_type": "",
-        "null_count": 0,
-        "row_count": 123123
-    }
-]';
-·
-SELECT text FROM [EXPLAIN (OPT, ENV) SELECT * FROM x WHERE b = 3] WHERE (text NOT LIKE '%Version%') OR (text LIKE '%EXPLAIN%');
-----
-scan x@x_b_idx
- └── constraint: /2/1: [/3 - /3]
+https://cockroachdb.github.io/text/decode.html#eJy0ksFum0AQhs_Zp_jFJbiFeDGXCKtSCdmotBhbsE1jWRZa1khBJWDB0hJVlfIQfkI_SQVxXY69hMNIM_98o_8Xe5_VTV6VDrxKfq8rIR9vb5B1mUzbvNhlNVTWKPx43SLEi5jLGbh7EzB00MmFgB_ya4RLjvBrEBjkIj1NXjtvGcY8cv2QQ9vX-ZOonzWsIn_hRmt8YWvoAm7sTQxy4Ye37AFdkib5roOe_p3fuQs_WI9wXRhIJ2QyJ8QNOItOfnqrV_s2LXJ51cEPPzOPI-Yu92PuezEuNwQAfg21_zRZFe1T2WgONufhIAjt3G-N0X6dCZXtEqE0B9qMWtcmtUxqgVoOpQ6l74eqjZBd3qi8lCqRVVv2mEXpSH7MG1UlsioS9bzP-qtjuGyL4gyOsbr6-e_gzLZm9qD9Nv47YfqGCQdDbxeSbC_nhLCHVeD6IfTlihtg4f0EMQv6X_4Od9FygQ7fPrGIIcUH2HNimqZJGilKdB9Pb4zgeDgcDy_HwwtkVTaqFnmpHExnU8vBZmrDxNTekj8BAAD__6-iy5g=
 
 #
 # Multiple Tables.
 #
 
 query T
-SELECT text FROM [
-EXPLAIN (opt, env) SELECT * FROM x, y WHERE b = 3
-] WHERE text NOT LIKE '%Version%' OR text LIKE '%EXPLAIN%'
+EXPLAIN (OPT, ENV) SELECT * FROM x, y WHERE b = 3
 ----
-·
-CREATE TABLE x (
-    a INT8 NOT NULL,
-    b INT8 NULL,
-    CONSTRAINT "primary" PRIMARY KEY (a ASC),
-    INDEX x_b_idx (b ASC),
-    FAMILY "primary" (a, b)
-);
-·
-ALTER TABLE test.public.x INJECT STATISTICS '[
-    {
-        "columns": [
-            "a"
-        ],
-        "created_at": "2018-01-01 01:00:00+00:00",
-        "distinct_count": 100,
-        "histo_col_type": "",
-        "null_count": 0,
-        "row_count": 123123
-    },
-    {
-        "columns": [
-            "b"
-        ],
-        "created_at": "2018-01-01 01:00:00+00:00",
-        "distinct_count": 123123,
-        "histo_col_type": "",
-        "null_count": 0,
-        "row_count": 123123
-    }
-]';
-·
-CREATE TABLE y (
-    u INT8 NOT NULL,
-    v INT8 NULL,
-    CONSTRAINT "primary" PRIMARY KEY (u ASC),
-    CONSTRAINT fk_v_ref_x FOREIGN KEY (v) REFERENCES x(a),
-    INDEX y_v_idx (v ASC),
-    FAMILY "primary" (u, v)
-);
-·
-ALTER TABLE test.public.y INJECT STATISTICS '[]';
-·
-SELECT text FROM [EXPLAIN (OPT, ENV) SELECT * FROM x, y WHERE b = 3] WHERE (text NOT LIKE '%Version%') OR (text LIKE '%EXPLAIN%');
-----
-inner-join (hash)
- ├── scan y
- ├── scan x@x_b_idx
- │    └── constraint: /2/1: [/3 - /3]
- └── filters (true)
+https://cockroachdb.github.io/text/decode.html#eJy0k8Fum0wUhdeZpzhiE_h_iMHeRESVSsi4pSU4ApomiiIEmMjTEIiGgYKqSlGfwcs-nZ-kwnYc1LRVuwiLkebec67uEd-cZ7xiZWHCLtNbXsbp4uQYWZulSc3yecYhskqg2agIsX1qhRShdexStJDJXgzHCw_hzUJ4H1xXJXvJtrK52TMvCH3L8UJI95zdxbyTcOY7p5Z_iff0EnIMK7AVlew53gm9QBslEZu3kJPH-tQ6ddzLgV2OVSQKUY4IsdyQ-tt9-lUP7uskZ-lBC8d7R-0QQWiFThA6doD9KwIAX9Zn_0lpmdd3RSWZuNoV141Y2t2v1YGeZ7HI5lEsJBPSWDcONd3QdAO6Yeq6qev_r09pYJmzSrAiFVFa1kVvM3R90F6wSpRRWuaR6O6zfurQXNR5vjMObbz8_DRwPDHGk3Xvq_rXCZMXTLhe6OVCkuv9o59Q7HoU62coNv-IYv2I3EB6cxs1Ec9uohbTmU-dN95G2yjw6ZT61LNpgFaOnxDuomaDcPN7hGsVzZ8R7n6J8Do7vThzLceDPDsLVVDvXEFA3V77H6b-7BStig4f31KfIsErTI6IpmkaYUWRce1TyQrIi7haKASr5ffV8mG1fECVxgW6Z5X29fZF9p1v_Q9YLZdbQVoWleAxK4SJ0XhkmLgaTaBhNLkmA9kNy0XGK8iC15lCfgQAAP__Ye8zdQ==
 
 #
 # Same table twice should only show up once.
 #
 
 query T
-SELECT text FROM [
-EXPLAIN (opt, env) SELECT * FROM x one, x two
-] WHERE text NOT LIKE '%Version%' OR text LIKE '%EXPLAIN%'
+EXPLAIN (OPT, ENV) SELECT * FROM x one, x two
 ----
-·
-CREATE TABLE x (
-    a INT8 NOT NULL,
-    b INT8 NULL,
-    CONSTRAINT "primary" PRIMARY KEY (a ASC),
-    INDEX x_b_idx (b ASC),
-    FAMILY "primary" (a, b)
-);
-·
-ALTER TABLE test.public.x INJECT STATISTICS '[
-    {
-        "columns": [
-            "a"
-        ],
-        "created_at": "2018-01-01 01:00:00+00:00",
-        "distinct_count": 100,
-        "histo_col_type": "",
-        "null_count": 0,
-        "row_count": 123123
-    },
-    {
-        "columns": [
-            "b"
-        ],
-        "created_at": "2018-01-01 01:00:00+00:00",
-        "distinct_count": 123123,
-        "histo_col_type": "",
-        "null_count": 0,
-        "row_count": 123123
-    }
-]';
-·
-SELECT text FROM [EXPLAIN (OPT, ENV) SELECT * FROM x AS one, x AS two] WHERE (text NOT LIKE '%Version%') OR (text LIKE '%EXPLAIN%');
-----
-inner-join (hash)
- ├── scan one
- ├── scan two
- └── filters (true)
+https://cockroachdb.github.io/text/decode.html#eJy0kcFum0AQQM_erxhxCbQQLc4lsk8bspFoMbZgG8WKIrTgrbwt2bWWpSaqKuUjfOzX-UsqbNdF6iWXcBgxb-aNZrT3wjRSqwlEuvpuNK_WtzcgOlGVraxXwoAVjYUfxy6EoowSRoGRm4RCBy4acYhTdg3pnEH6JUl8NCpP5JhF8zRnGYlTBs7GyGduXhxYZPGMZEv4TJfgciB55PloFKe39AG6oizkqgO3_MvvyCxOlgPd5T6UHvKmCJGE0ey0T7_q5aYta1lddhCnn2jEIGeExTmLoxwuHhEAwM9D7D-n0nX7rBpnAo9neChw55w_-YN-I7gVq4JbZwLOGIfXAQ4DHAIOJxhPMP54iM5AWcnGSlXZotKt6rUQ40F5LRuri0rXhX3ZiH7qUFZtXZ_FoWb09t_A8VU4vjrUfvlvvrB8xwsPC73fkejpYooQfVgkJE7BnS-YDzS99yCnSf_kH-Aum8-gA5KDVsI__tmtnqIgCAIklRIm-KalAnfNm7WHYL_7vd-97nev0FRc9dZ_zG51z3Yn9lXWVpgGXGta4aE_AQAA__9eYt7E
 
 #
 # Set a relevant session variable to a non-default value and ensure it shows up
@@ -211,57 +72,17 @@ statement ok
 SET reorder_joins_limit = 100
 
 query T
-SELECT text FROM [
-EXPLAIN (opt, env) SELECT * FROM y WHERE u = 3
-] WHERE text NOT LIKE '%Version%' OR text LIKE '%EXPLAIN%'
+EXPLAIN (OPT, ENV) SELECT * FROM y WHERE u = 3
 ----
-·
-CREATE TABLE y (
-    u INT8 NOT NULL,
-    v INT8 NULL,
-    CONSTRAINT "primary" PRIMARY KEY (u ASC),
-    CONSTRAINT fk_v_ref_x FOREIGN KEY (v) REFERENCES x(a),
-    INDEX y_v_idx (v ASC),
-    FAMILY "primary" (u, v)
-);
-·
-ALTER TABLE test.public.y INJECT STATISTICS '[]';
-·
-SET reorder_joins_limit = 100;
-·
-SELECT text FROM [EXPLAIN (OPT, ENV) SELECT * FROM y WHERE u = 3] WHERE (text NOT LIKE '%Version%') OR (text LIKE '%EXPLAIN%');
-----
-scan y
- └── constraint: /1: [/3 - /3]
+https://cockroachdb.github.io/text/decode.html#eJxUj89O20AQh8_sU_zEBbuKCSiXKhGHxUzabZ11tLulRAhZxlnULcFG6z-ybzyEnzBPUkVJpfY4o2--0Xdvfe2qco64Kl59lRe_7m5he1s8t263tR6NrRt0R4qxWBE3BMNvE8KAgJ21ENJ8hkwN5I8kmbCz7rQ5TnEqtVFcSIPzd-_ecj-cY63EiqsNvtMGQQuu4_B_9OU16zJvX7Iey1SR-CKPbBdC0ZIUyZg0-iA_3Al5Rw8Ysi5z2x5B99e35CuRbP55G7QTdCELF4zxxJA6dRwSL9_b550rLgcI-Y1iA224EdqIWOPi8eliwZgmA28rv7U--125ss527s01uMH11dWCMXpYJ1xIBOnaTEDyPoSm5OD6hKVKVxjw8yspQosbzBYsiqKI1UVeYmDYj-N-_NiPHyiqsm587spmjun1HI_TGSJMZ0_sTwAAAP__tV18Lw==
 
 statement ok
 SET experimental_enable_zigzag_join = false
 
 query T
-SELECT text FROM [
-EXPLAIN (opt, env) SELECT * FROM y WHERE u = 3
-] WHERE text NOT LIKE '%Version%' OR text LIKE '%EXPLAIN%'
+EXPLAIN (OPT, ENV) SELECT * FROM y WHERE u = 3
 ----
-·
-CREATE TABLE y (
-    u INT8 NOT NULL,
-    v INT8 NULL,
-    CONSTRAINT "primary" PRIMARY KEY (u ASC),
-    CONSTRAINT fk_v_ref_x FOREIGN KEY (v) REFERENCES x(a),
-    INDEX y_v_idx (v ASC),
-    FAMILY "primary" (u, v)
-);
-·
-ALTER TABLE test.public.y INJECT STATISTICS '[]';
-·
-SET reorder_joins_limit = 100;
-·
-SET experimental_enable_zigzag_join = off;
-·
-SELECT text FROM [EXPLAIN (OPT, ENV) SELECT * FROM y WHERE u = 3] WHERE (text NOT LIKE '%Version%') OR (text LIKE '%EXPLAIN%');
-----
-scan y
- └── constraint: /1: [/3 - /3]
+https://cockroachdb.github.io/text/decode.html#eJxUj81u2kAUhdeZpzjKJnaFQyI2FYiF41zaac0YjadpUBRZxgzpNMZG4x_ZWeUheEKepKJQqVnee79zj74HbStTFmMEZfZqyzT7dX8H3els1Zh8rS1qXdVoTxRjgSRfEZR_FxJ6OOyiARfqM0SkIH6E4YBdtOfNaQoiESvpc6FwubNmm9r-EgvJ575c4jst4TTw48D9iG5ekzaxepN0mEWS-BdxYlsXkmYkSQQUo3PSY46Le3pEn7SJWXdw2n__Zv6ch8v_ap1mgNZl7oQxP1Qkzx5Hxetds8pNdt2Di28UKMTKVzxWPIhx9fR8NWEsJgWrS7vWNvldmqJKcrM1Naa4vbk533W309ZsdVGneaKLdJXr5M28vKUvfyOYotxsJozR4yL0uYATLdQAJB5cxBQeez9hJqM5evz8SpLQYIrRhHme57EqSwv0DIf9_rB_P-zfkZVFVdvUFPUYw9sxnoYjeBiOntmfAAAA__-o1YwQ
 
 statement ok
 RESET reorder_joins_limit
@@ -277,16 +98,9 @@ statement ok
 CREATE SEQUENCE seq
 
 query T
-SELECT text FROM [
-EXPLAIN (opt, env) SELECT * FROM seq
-] WHERE text NOT LIKE '%Version%' OR text LIKE '%EXPLAIN%'
+EXPLAIN (OPT, ENV) SELECT * FROM seq
 ----
-·
-CREATE SEQUENCE seq MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
-·
-SELECT text FROM [EXPLAIN (OPT, ENV) SELECT * FROM seq] WHERE (text NOT LIKE '%Version%') OR (text LIKE '%EXPLAIN%');
-----
-sequence-select test.public.seq
+https://cockroachdb.github.io/text/decode.html#eJwkjkFPgzAcR-_9FL-jGrsMcHa6U61_ExLazdKRXV39JxLJEArGj2-U2zu85L2Gx9T2l0eYPn6O_Vv8eH4C_3A8z233ziMmThO-F0sI40kHQk2vR3KGkHiALV2jqyMhg9WnBR_yvChUvi7ut5s7pTbbtULpjCdLLiBDHbQPyHZC0OlQ6dLhan8ItyDXXKOmikzADV783v4ldkJKKUXiYeZLZJm44zj9r62-5nPXxlXiQfwGAAD__6j-PBk=
 
 #
 # Test views.
@@ -296,59 +110,6 @@ statement ok
 CREATE VIEW v AS SELECT a, b, u, v FROM x, y WHERE b = 3
 
 query T
-SELECT text FROM [
-EXPLAIN (opt, env) SELECT * FROM v
-] WHERE text NOT LIKE '%Version%' OR text LIKE '%EXPLAIN%'
+EXPLAIN (OPT, ENV) SELECT * FROM v
 ----
-·
-CREATE TABLE x (
-    a INT8 NOT NULL,
-    b INT8 NULL,
-    CONSTRAINT "primary" PRIMARY KEY (a ASC),
-    INDEX x_b_idx (b ASC),
-    FAMILY "primary" (a, b)
-);
-·
-ALTER TABLE test.public.x INJECT STATISTICS '[
-    {
-        "columns": [
-            "a"
-        ],
-        "created_at": "2018-01-01 01:00:00+00:00",
-        "distinct_count": 100,
-        "histo_col_type": "",
-        "null_count": 0,
-        "row_count": 123123
-    },
-    {
-        "columns": [
-            "b"
-        ],
-        "created_at": "2018-01-01 01:00:00+00:00",
-        "distinct_count": 123123,
-        "histo_col_type": "",
-        "null_count": 0,
-        "row_count": 123123
-    }
-]';
-·
-CREATE TABLE y (
-    u INT8 NOT NULL,
-    v INT8 NULL,
-    CONSTRAINT "primary" PRIMARY KEY (u ASC),
-    CONSTRAINT fk_v_ref_x FOREIGN KEY (v) REFERENCES x(a),
-    INDEX y_v_idx (v ASC),
-    FAMILY "primary" (u, v)
-);
-·
-ALTER TABLE test.public.y INJECT STATISTICS '[]';
-·
-CREATE VIEW v (a, b, u, v) AS SELECT a, b, u, v FROM test.public.x, test.public.y WHERE b = 3;
-·
-SELECT text FROM [EXPLAIN (OPT, ENV) SELECT * FROM v] WHERE (text NOT LIKE '%Version%') OR (text LIKE '%EXPLAIN%');
-----
-inner-join (hash)
- ├── scan test.public.y
- ├── scan test.public.x@x_b_idx
- │    └── constraint: /2/1: [/3 - /3]
- └── filters (true)
+https://cockroachdb.github.io/text/decode.html#eJy0U91um0wUvM4-xYib4O-DGExTu7YqlZB1S4txChsnURQhwESmcSDlr1hVpajP4Ms-nZ-kwjgOSduovYgvVt5zZmbPiDmTIEnDOOpDi_2rJHb92eEBgjLwvTycT4MEWZBmKGoUIZpFVUZh04_H1NQo0uAzRro5UY1jChkj9bT--6rTUZRuR1Je9vZfdLv7PakL3dQsOqImgwybqRaDPNgqMvXAoCjBkx0Xusl6MMcM5rFhCGTH21TqmzY2bWapusnA3SThtZssOBxZ-ki1zvCBnoF3odpaSyA7unlIT1E6nhNOS_DeXX2ojnTjrEHnXQFei7QGhKgGo9Zmnsr83k3uzUN_r4Ruvqcaq2Znus10zcbuOQGAr-uz-nF-PM-vo5Tr43xbXDdcbnu_EBr4JHCzYOq4GdcH15HknijJoiRDkvuS1Jek_9cn16BMwzQLIz9z_DiPKposSY32LEyz2PHjuZMtboJKtUmO8vl8S2zSkvjLvWBHkTvKuvdN-GuH3jM6XA_0fCbJxe7jKC6qKOa_RLH4xyjmd5FrQC-vnMJJgkunxHBsUf2tWWOLFiw6pFa1WTZK3r2P8MIp6ggXf45wLqB4OsKL30a46X2i0xMU9ToIWCtCtWFTo6LdVzG0xqOH6yE8eurkHbUoPLyGMiCEnh4Zqm6CHx8xAdSctO5E_6u1igERRVEkYRQFifgpDiPwMzedtQhWyx-r5e1qeYvUd6OHzzzZLd9sVr9Cfa--9Gq53ID9OEqzxA2jrI92py33cd5WIKKtXJAG7DKcZ0GSgs-SPGiRnwEAAP__wUhoXw==

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -11,8 +11,12 @@
 package sql
 
 import (
+	"bytes"
+	"compress/zlib"
 	"context"
+	"encoding/base64"
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -919,21 +923,40 @@ func (ef *execFactory) ConstructPlan(
 	return res, nil
 }
 
-// lineOutputter handles writing strings for EXPLAIN (env). It's a layer of
-// indirection to ensure each line gets its own row and there's exactly one
-// blank line between each output.
-type lineOutputter struct {
-	rows [][]tree.TypedExpr
+// urlOutputter handles writing strings into an encoded URL for EXPLAIN (OPT,
+// ENV). It also ensures that (in the text that is encoded by the URL) each
+// entry gets its own line and there's exactly one blank line between entries.
+type urlOutputter struct {
+	buf bytes.Buffer
 }
 
-func (e *lineOutputter) write(s string) {
-	if len(e.rows) > 0 {
-		e.rows = append(e.rows, []tree.TypedExpr{tree.NewDString("")})
+func (e *urlOutputter) writef(format string, args ...interface{}) {
+	if e.buf.Len() > 0 {
+		e.buf.WriteString("\n")
 	}
-	ss := strings.Split(strings.Trim(s, "\n"), "\n")
-	for _, line := range ss {
-		e.rows = append(e.rows, []tree.TypedExpr{tree.NewDString(line)})
+	fmt.Fprintf(&e.buf, format, args...)
+}
+
+func (e *urlOutputter) finish() (url.URL, error) {
+	// Generate a URL that encodes all the text.
+	var compressed bytes.Buffer
+	encoder := base64.NewEncoder(base64.URLEncoding, &compressed)
+	compressor := zlib.NewWriter(encoder)
+	if _, err := e.buf.WriteTo(compressor); err != nil {
+		return url.URL{}, err
 	}
+	if err := compressor.Close(); err != nil {
+		return url.URL{}, err
+	}
+	if err := encoder.Close(); err != nil {
+		return url.URL{}, err
+	}
+	return url.URL{
+		Scheme:   "https",
+		Host:     "cockroachdb.github.io",
+		Path:     "text/decode.html",
+		Fragment: compressed.String(),
+	}, nil
 }
 
 // environmentQuery is a helper to run a query to build up the output of
@@ -969,17 +992,30 @@ func (ef *execFactory) environmentQuery(query string) (string, error) {
 	return string(*s), nil
 }
 
+var testingOverrideExplainEnvVersion string
+
+// TestingOverrideExplainEnvVersion overrides the version reported by
+// EXPLAIN (OPT, ENV). Used for testing.
+func TestingOverrideExplainEnvVersion(ver string) func() {
+	prev := testingOverrideExplainEnvVersion
+	testingOverrideExplainEnvVersion = ver
+	return func() { testingOverrideExplainEnvVersion = prev }
+}
+
 // showEnv implements EXPLAIN (opt, env). It returns a node which displays
 // the environment a query was run in.
 func (ef *execFactory) showEnv(plan string, envOpts exec.ExplainEnvData) (exec.Node, error) {
-	var out lineOutputter
+	var out urlOutputter
 
 	// Show the version of Cockroach running.
 	version, err := ef.environmentQuery("SELECT version()")
 	if err != nil {
 		return nil, err
 	}
-	out.write(fmt.Sprintf("Version: %s", version))
+	if testingOverrideExplainEnvVersion != "" {
+		version = testingOverrideExplainEnvVersion
+	}
+	out.writef("Version: %s\n", version)
 
 	// Show the definition of each referenced catalog object.
 	for _, tn := range envOpts.Sequences {
@@ -990,7 +1026,7 @@ func (ef *execFactory) showEnv(plan string, envOpts exec.ExplainEnvData) (exec.N
 			return nil, err
 		}
 
-		out.write(fmt.Sprintf("%s;", createStatement))
+		out.writef("%s;\n", createStatement)
 	}
 
 	// TODO(justin): it might also be relevant in some cases to print the create
@@ -1003,7 +1039,7 @@ func (ef *execFactory) showEnv(plan string, envOpts exec.ExplainEnvData) (exec.N
 			return nil, err
 		}
 
-		out.write(fmt.Sprintf("%s;", createStatement))
+		out.writef("%s;\n", createStatement)
 
 		// In addition to the schema, it's important to know what the table
 		// statistics on each table are.
@@ -1031,11 +1067,7 @@ FROM
 			return nil, err
 		}
 
-		out.write(
-			fmt.Sprintf(
-				"ALTER TABLE %s INJECT STATISTICS '%s';", tn.String(), stats,
-			),
-		)
+		out.writef("ALTER TABLE %s INJECT STATISTICS '%s';\n", tn.String(), stats)
 	}
 
 	for _, tn := range envOpts.Views {
@@ -1046,7 +1078,7 @@ FROM
 			return nil, err
 		}
 
-		out.write(fmt.Sprintf("%s;", createStatement))
+		out.writef("%s;\n", createStatement)
 	}
 
 	// Show the values of any non-default session variables that can impact
@@ -1057,7 +1089,7 @@ FROM
 		return nil, err
 	}
 	if value != strconv.FormatInt(opt.DefaultJoinOrderLimit, 10) {
-		out.write(fmt.Sprintf("SET reorder_joins_limit = %s;", value))
+		out.writef("SET reorder_joins_limit = %s;\n", value)
 	}
 
 	for _, param := range []string{
@@ -1069,17 +1101,21 @@ FROM
 		}
 		defaultVal := varGen[param].GlobalDefault(nil)
 		if value != defaultVal {
-			out.write(fmt.Sprintf("SET %s = %s;", param, value))
+			out.writef("SET %s = %s;\n", param, value)
 		}
 	}
 
 	// Show the query running. Note that this is the *entire* query, including
 	// the "EXPLAIN (opt, env)" preamble.
-	out.write(fmt.Sprintf("%s;\n----\n%s", ef.planner.stmt.AST.String(), plan))
+	out.writef("%s;\n----\n%s", ef.planner.stmt.AST.String(), plan)
 
+	url, err := out.finish()
+	if err != nil {
+		return nil, err
+	}
 	return &valuesNode{
 		columns:          sqlbase.ExplainOptColumns,
-		tuples:           out.rows,
+		tuples:           [][]tree.TypedExpr{{tree.NewDString(url.String())}},
 		specifiedInQuery: true,
 	}, nil
 }
@@ -1094,12 +1130,15 @@ func (ef *execFactory) ConstructExplainOpt(
 		return ef.showEnv(planText, envOpts)
 	}
 
-	var out lineOutputter
-	out.write(planText)
+	var rows [][]tree.TypedExpr
+	ss := strings.Split(strings.Trim(planText, "\n"), "\n")
+	for _, line := range ss {
+		rows = append(rows, []tree.TypedExpr{tree.NewDString(line)})
+	}
 
 	return &valuesNode{
 		columns:          sqlbase.ExplainOptColumns,
-		tuples:           out.rows,
+		tuples:           rows,
 		specifiedInQuery: true,
 	}, nil
 }


### PR DESCRIPTION
The output of `EXPLAIN (OPT,ENV)` is usually unwieldy and can be a
pain to be passed around properly (reformatting/terminal issues).

This change converts it to an encoded URL, similar to distributed
plans. The URL is to a simple page that decodes the compressed data
and displays it.

Fixes #38942.

Example URL: https://cockroachdb.github.io/text/decode.html#eJxUzs2OqjAcBfC1fYp_3AgJRSBaUFeINeGmooFec83NzU0LfjTDgKkwozsfgif0SSYks5nlSc755eyP-qbqag5Rnb_pWuSX1RKiiMGHO7M928GivF6E7TnuzCEOwcHUweepfyLEnx3zCS6Ubh5g3APyn0xwqar2js9Va4FsVdlAvxs7_tgNwHPm02Du-Raca9d2PZuYCEUpDTkFHi4ZBSHBQAMBccIDSH4zZqGB_JHW4SZmBxhetXoX-jEEQ1ggLdD1pypMZC4QChmn6TdYHE-iLZtC2tdWliq3Rc_9ohGHjIc8zngcZTD6-2-0QIj-2bEwTsDY7rgFNNmbkFHWdyWs0-2mv7dNVzSF5QHEAmGMMbrVukHw6rpX93x1T7jlogIh0VcAAAD__1ttYDI=

Release note (sql change): EXPLAIN (OPT,ENV) now returns a URL with
the data encoded in the fragment portion. Opening the URL shows a page
with the decoded data. Note that the data is processed in the local
browser session and is never sent out.