### PR TITLE
roachprod: don't mix ssh stderr and stdout in GetInternalIP

### DIFF
--- a/pkg/cmd/roachprod/install/cluster_synced.go
+++ b/pkg/cmd/roachprod/install/cluster_synced.go
@@ -116,14 +116,16 @@ func (c *SyncedCluster) GetInternalIP(index int) (string, error) {
 	}
 	defer session.Close()
 
+	var stdout, stderr strings.Builder
+	session.SetStdout(&stdout)
+	session.SetStderr(&stderr)
 	cmd := `hostname --all-ip-addresses`
-	out, err := session.CombinedOutput(cmd)
-	if err != nil {
+	if err := session.Run(cmd); err != nil {
 		return "", errors.Wrapf(err,
-			"GetInternalIP: failed to execute hostname on %s:%d: (output) %s",
-			c.Name, index, out)
+			"GetInternalIP: failed to execute hostname on %s:%d:\n(stdout) %s\n(stderr) %s",
+			c.Name, index, stdout.String(), stderr.String())
 	}
-	return strings.TrimSpace(string(out)), nil
+	return strings.TrimSpace(stdout.String()), nil
 }
 
 // Start TODO(peter): document

--- a/pkg/cmd/roachprod/install/session.go
+++ b/pkg/cmd/roachprod/install/session.go
@@ -58,10 +58,10 @@ func newRemoteSession(user, host string, logdir string) (*remoteSession, error) 
 
 		// TODO(tbg): see above.
 		//"-vvv", "-E", logfile,
-
 		// NB: -q suppresses -E, at least on OSX. Difficult decisions will have
 		// to be made if omitting -q leads to annoyance on stdout/stderr.
-		// "-q",
+
+		"-q",
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "StrictHostKeyChecking=no",
 		// Send keep alives every minute to prevent connections without activity


### PR DESCRIPTION
Fixes what we see in https://teamcity.cockroachdb.com/viewLog.html?buildId=1395419

```
teamcity-1563484197-01-n4cpu4: [gce] 12h48m14s remaining
  teamcity-1563484197-01-n4cpu4-0001	teamcity-1563484197-01-n4cpu4-0001.us-central1-b.cockroach-ephemeral	10.128.0.114	104.197.98.118
  teamcity-1563484197-01-n4cpu4-0002	teamcity-1563484197-01-n4cpu4-0002.us-central1-b.cockroach-ephemeral	10.128.0.99	35.225.204.228
  teamcity-1563484197-01-n4cpu4-0003	teamcity-1563484197-01-n4cpu4-0003.us-central1-b.cockroach-ephemeral	10.128.0.96	35.222.36.160
  teamcity-1563484197-01-n4cpu4-0004	teamcity-1563484197-01-n4cpu4-0004.us-central1-b.cockroach-ephemeral	10.128.0.87	35.184.231.75
I190718 21:11:46.314694 1 main.go:421  could not clear ssh key for hostname 104.197.98.118:
do_known_hosts: hostkeys_foreach failed: No such file or directory
I190718 21:11:46.317238 1 main.go:421  could not clear ssh key for hostname 35.225.204.228:
do_known_hosts: hostkeys_foreach failed: No such file or directory
I190718 21:11:46.319632 1 main.go:421  could not clear ssh key for hostname 35.222.36.160:
do_known_hosts: hostkeys_foreach failed: No such file or directory
I190718 21:11:46.321860 1 main.go:421  could not clear ssh key for hostname 35.184.231.75:
do_known_hosts: hostkeys_foreach failed: No such file or directory
teamcity-1563484197-01-n4cpu4: waiting for nodes to start
generating ssh key.
distributing ssh key
retrieving hosts.
scanning hosts
0: exit status 2

set -e
tmp="$(tempfile -d ~/.ssh -p 'roachprod' )"
on_exit() {
    rm -f "${tmp}"
}
trap on_exit EXIT
for i in {1..20}; do
  ssh-keyscan -T 60 -t rsa Warning: Permanently added '104.197.98.118' (ECDSA) to the list of known hosts.
10.128.0.114 Warning: Permanently added '35.225.204.228' (ECDSA) to the list of known hosts.
10.128.0.99 Warning: Permanently added '35.222.36.160' (ECDSA) to the list of known hosts.
10.128.0.96 Warning: Permanently added '35.184.231.75' (ECDSA) to the list of known hosts.
10.128.0.87 104.197.98.118 35.225.204.228 35.222.36.160 35.184.231.75 > "${tmp}"
  if [[ "$(wc < ${tmp} -l)" -eq "8" ]]; then
    [[ -f .ssh/known_hosts ]] && cat .ssh/known_hosts >> "${tmp}"
    sort -u < "${tmp}"
    exit 0
  fi
  sleep 1
done
exit 1
: stderr:
Warning: Permanently added '104.197.98.118' (ECDSA) to the list of known hosts.
bash: -c: line 8: syntax error near unexpected token `('

github.com/cockroachdb/cockroach/pkg/cmd/roachprod/install.(*SyncedCluster).SetupSSH.func4
	/home/agent/work/.go/src/github.com/cockroachdb/cockroach/pkg/cmd/roachprod/install/cluster_synced.go:670
github.com/cockroachdb/cockroach/pkg/cmd/roachprod/install.(*SyncedCluster).Parallel.func1.1
	/home/agent/work/.go/src/github.com/cockroachdb/cockroach/pkg/cmd/roachprod/install/cluster_synced.go:1524
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1337:
```

Release note: None