### PR TITLE
exec: eagerly fail if any flows aren't vectorizable

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -131,6 +131,45 @@ func (dsp *DistSQLPlanner) setupFlows(
 	if len(flows) > 1 {
 		resultChan = make(chan runnerResult, len(flows)-1)
 	}
+	// First check to see whether or not to even try vectorizing the flow. The
+	// goal here is to determine up front whether all of the flows can be
+	// vectorized. If any of them can't, turn off the setting.
+	if evalCtx.SessionData.Vectorize != sessiondata.VectorizeOff {
+		for _, spec := range flows {
+			for i := range spec.Processors {
+				proc := &spec.Processors[i]
+				if err := distsqlrun.SupportsVectorized(ctx, &distsqlrun.FlowCtx{EvalCtx: &evalCtx.EvalContext, NodeID: -1},
+					proc); err != nil {
+					// Vectorization attempt failed with an error.
+					returnSetupError := false
+					if evalCtx.SessionData.Vectorize == sessiondata.VectorizeAlways {
+						returnSetupError = true
+						// If running with VectorizeAlways, this check makes sure that we can
+						// still run SET statements (mostly to set experimental_vectorize=off) and
+						// the like.
+						if len(spec.Processors) == 1 &&
+							spec.Processors[0].Core.LocalPlanNode != nil {
+							rsidx := spec.Processors[0].Core.LocalPlanNode.RowSourceIdx
+							if rsidx != nil {
+								lp := localState.LocalProcs[*rsidx]
+								if z, ok := lp.(distsqlrun.VectorizeAlwaysException); ok {
+									if z.IsException() {
+										returnSetupError = false
+									}
+								}
+							}
+						}
+					}
+					log.VEventf(ctx, 1, "failed to vectorize: %s", err)
+					if returnSetupError {
+						return nil, nil, err
+					} else {
+						setupReq.EvalContext.Vectorize = int32(sessiondata.VectorizeOff)
+					}
+				}
+			}
+		}
+	}
 	for nodeID, flowSpec := range flows {
 		if nodeID == thisNodeID {
 			// Skip this node.

--- a/pkg/sql/distsqlrun/colbatch_scan.go
+++ b/pkg/sql/distsqlrun/colbatch_scan.go
@@ -58,7 +58,7 @@ func (s *colBatchScan) Next(ctx context.Context) coldata.Batch {
 func (s *colBatchScan) DrainMeta(ctx context.Context) []distsqlpb.ProducerMetadata {
 	var trailingMeta []distsqlpb.ProducerMetadata
 	if !s.flowCtx.local {
-		ranges := misplannedRanges(ctx, s.rf.GetRangesInfo(), s.flowCtx.nodeID)
+		ranges := misplannedRanges(ctx, s.rf.GetRangesInfo(), s.flowCtx.NodeID)
 		if ranges != nil {
 			trailingMeta = append(trailingMeta, distsqlpb.ProducerMetadata{Ranges: ranges})
 		}
@@ -73,7 +73,7 @@ func (s *colBatchScan) DrainMeta(ctx context.Context) []distsqlpb.ProducerMetada
 func newColBatchScan(
 	flowCtx *FlowCtx, spec *distsqlpb.TableReaderSpec, post *distsqlpb.PostProcessSpec,
 ) (*colBatchScan, error) {
-	if flowCtx.nodeID == 0 {
+	if flowCtx.NodeID == 0 {
 		return nil, errors.Errorf("attempting to create a colBatchScan with uninitialized NodeID")
 	}
 

--- a/pkg/sql/distsqlrun/colbatch_scan_test.go
+++ b/pkg/sql/distsqlrun/colbatch_scan_test.go
@@ -62,7 +62,7 @@ func BenchmarkColBatchScan(b *testing.B) {
 				EvalCtx:  &evalCtx,
 				Settings: s.ClusterSettings(),
 				txn:      client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
-				nodeID:   s.NodeID(),
+				NodeID:   s.NodeID(),
 			}
 
 			b.SetBytes(int64(numRows * numCols * 8))

--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -216,13 +216,17 @@ func newColOperator(
 			}
 			columnTypes[i] = *retType
 		}
+		typs, err := conv.FromColumnTypes(spec.Input[0].ColumnTypes)
+		if err != nil {
+			return nil, nil, memUsage, err
+		}
 		if needHash {
 			op, err = exec.NewHashAggregator(
-				inputs[0], conv.FromColumnTypes(spec.Input[0].ColumnTypes), aggFns, aggSpec.GroupCols, aggCols,
+				inputs[0], typs, aggFns, aggSpec.GroupCols, aggCols,
 			)
 		} else {
 			op, err = exec.NewOrderedAggregator(
-				inputs[0], conv.FromColumnTypes(spec.Input[0].ColumnTypes), aggFns, aggSpec.GroupCols, aggCols,
+				inputs[0], typs, aggFns, aggSpec.GroupCols, aggCols,
 			)
 		}
 
@@ -247,7 +251,10 @@ func newColOperator(
 		}
 
 		columnTypes = spec.Input[0].ColumnTypes
-		typs := conv.FromColumnTypes(columnTypes)
+		typs, err := conv.FromColumnTypes(columnTypes)
+		if err != nil {
+			return nil, nil, 0, err
+		}
 		op, err = exec.NewOrderedDistinct(inputs[0], core.Distinct.OrderedColumns, typs)
 
 	case core.Ordinality != nil:
@@ -266,8 +273,14 @@ func newColOperator(
 			return nil, nil, memUsage, errors.Newf("can't plan hash join with on expressions")
 		}
 
-		leftTypes := conv.FromColumnTypes(spec.Input[0].ColumnTypes)
-		rightTypes := conv.FromColumnTypes(spec.Input[1].ColumnTypes)
+		leftTypes, err := conv.FromColumnTypes(spec.Input[0].ColumnTypes)
+		if err != nil {
+			return nil, nil, 0, err
+		}
+		rightTypes, err := conv.FromColumnTypes(spec.Input[1].ColumnTypes)
+		if err != nil {
+			return nil, nil, 0, err
+		}
 
 		columnTypes = make([]semtypes.T, len(leftTypes)+len(rightTypes))
 		copy(columnTypes, spec.Input[0].ColumnTypes)
@@ -324,8 +337,14 @@ func newColOperator(
 			return nil, nil, memUsage, errors.AssertionFailedf("unexpectedly %s merge join was planned", core.MergeJoiner.Type.String())
 		}
 
-		leftTypes := conv.FromColumnTypes(spec.Input[0].ColumnTypes)
-		rightTypes := conv.FromColumnTypes(spec.Input[1].ColumnTypes)
+		leftTypes, err := conv.FromColumnTypes(spec.Input[0].ColumnTypes)
+		if err != nil {
+			return nil, nil, 0, err
+		}
+		rightTypes, err := conv.FromColumnTypes(spec.Input[1].ColumnTypes)
+		if err != nil {
+			return nil, nil, 0, err
+		}
 
 		nLeftCols := uint32(len(leftTypes))
 		nRightCols := uint32(len(rightTypes))
@@ -412,7 +431,10 @@ func newColOperator(
 			return nil, nil, memUsage, err
 		}
 		input := inputs[0]
-		inputTypes := conv.FromColumnTypes(spec.Input[0].ColumnTypes)
+		inputTypes, err := conv.FromColumnTypes(spec.Input[0].ColumnTypes)
+		if err != nil {
+			return nil, nil, 0, err
+		}
 		orderingCols := core.Sorter.OutputOrdering.Columns
 		matchLen := core.Sorter.OrderingMatchLen
 		if matchLen > 0 {
@@ -450,7 +472,10 @@ func newColOperator(
 		}
 
 		input := inputs[0]
-		typs := conv.FromColumnTypes(spec.Input[0].ColumnTypes)
+		typs, err := conv.FromColumnTypes(spec.Input[0].ColumnTypes)
+		if err != nil {
+			return nil, nil, memUsage, err
+		}
 		tempPartitionColOffset, partitionColIdx := 0, -1
 		if len(core.Windower.PartitionBy) > 0 {
 			// TODO(yuzefovich): add support for hashing partitioner (probably by
@@ -578,7 +603,11 @@ func newColOperator(
 	if post.Limit != 0 {
 		op = exec.NewLimitOp(op, post.Limit)
 	}
-	return op, conv.FromColumnTypes(columnTypes), memUsage, nil
+	if err != nil {
+		return nil, nil, memUsage, err
+	}
+	typs, err := conv.FromColumnTypes(columnTypes)
+	return op, typs, memUsage, err
 }
 
 func planSelectionOperators(
@@ -1000,7 +1029,11 @@ func (f *Flow) setupVectorizedInputSynchronizer(
 			if err := f.checkInboundStreamID(inputStream.StreamID); err != nil {
 				return nil, nil, memUsed, err
 			}
-			inbox, err := colrpc.NewInbox(conv.FromColumnTypes(input.ColumnTypes))
+			typs, err := conv.FromColumnTypes(input.ColumnTypes)
+			if err != nil {
+				return nil, nil, memUsed, err
+			}
+			inbox, err := colrpc.NewInbox(typs)
 			if err != nil {
 				return nil, nil, memUsed, err
 			}
@@ -1034,13 +1067,17 @@ func (f *Flow) setupVectorizedInputSynchronizer(
 	op := inputStreamOps[0]
 	if len(inputStreamOps) > 1 {
 		statsInputs := inputStreamOps
+		typs, err := conv.FromColumnTypes(input.ColumnTypes)
+		if err != nil {
+			return nil, nil, memUsed, err
+		}
 		if input.Type == distsqlpb.InputSyncSpec_ORDERED {
 			op = exec.NewOrderedSynchronizer(
-				inputStreamOps, conv.FromColumnTypes(input.ColumnTypes), distsqlpb.ConvertToColumnOrdering(input.Ordering),
+				inputStreamOps, typs, distsqlpb.ConvertToColumnOrdering(input.Ordering),
 			)
 			memUsed += op.(exec.StaticMemoryOperator).EstimateStaticMemoryUsage()
 		} else {
-			op = exec.NewUnorderedSynchronizer(inputStreamOps, conv.FromColumnTypes(input.ColumnTypes), &f.waitGroup)
+			op = exec.NewUnorderedSynchronizer(inputStreamOps, typs, &f.waitGroup)
 			// Don't use the unordered synchronizer's inputs for stats collection
 			// given that they run concurrently. The stall time will be collected
 			// instead.
@@ -1311,4 +1348,14 @@ func (f *Flow) setupVectorized(ctx context.Context, acc *mon.BoundAccount) error
 		panic("not all vectorized stats collectors have been processed")
 	}
 	return nil
+}
+
+// SupportsVectorized returns nil if the input ProcessorSpec can be vectorized,
+// and an error if it cannot.
+func SupportsVectorized(
+	ctx context.Context, flowCtx *FlowCtx, spec *distsqlpb.ProcessorSpec,
+) error {
+	ops := make([]exec.Operator, len(spec.Input))
+	_, _, _, err := newColOperator(ctx, flowCtx, spec, ops)
+	return err
 }

--- a/pkg/sql/distsqlrun/columnarizer.go
+++ b/pkg/sql/distsqlrun/columnarizer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types/conv"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
@@ -32,6 +33,7 @@ type columnarizer struct {
 	buffered        sqlbase.EncDatumRows
 	batch           coldata.Batch
 	accumulatedMeta []distsqlpb.ProducerMetadata
+	typs            []types.T
 }
 
 var _ exec.Operator = &columnarizer{}
@@ -54,21 +56,21 @@ func newColumnarizer(flowCtx *FlowCtx, processorID int32, input RowSource) (*col
 	); err != nil {
 		return nil, err
 	}
-	c.Init()
+	var err error
+	c.typs, err = conv.FromColumnTypes(c.OutputTypes())
 
-	return c, nil
+	return c, err
 }
 
 func (c *columnarizer) EstimateStaticMemoryUsage() int {
-	return exec.EstimateBatchSizeBytes(conv.FromColumnTypes(c.OutputTypes()), coldata.BatchSize)
+	return exec.EstimateBatchSizeBytes(c.typs, coldata.BatchSize)
 }
 
 func (c *columnarizer) Init() {
-	typs := conv.FromColumnTypes(c.OutputTypes())
-	c.batch = coldata.NewMemBatch(typs)
+	c.batch = coldata.NewMemBatch(c.typs)
 	c.buffered = make(sqlbase.EncDatumRows, coldata.BatchSize)
 	for i := range c.buffered {
-		c.buffered[i] = make(sqlbase.EncDatumRow, len(typs))
+		c.buffered[i] = make(sqlbase.EncDatumRow, len(c.typs))
 	}
 	c.accumulatedMeta = make([]distsqlpb.ProducerMetadata, 0, 1)
 	c.input.Start(context.TODO())

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -85,7 +85,7 @@ type FlowCtx struct {
 
 	// nodeID is the ID of the node on which the processors using this FlowCtx
 	// run.
-	nodeID       roachpb.NodeID
+	NodeID       roachpb.NodeID
 	testingKnobs TestingKnobs
 
 	// TempStorage is used by some DistSQL processors to store Rows when the
@@ -507,7 +507,7 @@ func (f *Flow) setup(ctx context.Context, spec *distsqlpb.FlowSpec) error {
 			return nil
 		}
 		// Vectorization attempt failed with an error.
-		if f.spec.Gateway != f.nodeID {
+		if f.spec.Gateway != f.NodeID {
 			// If we are not the gateway node, do not attempt to plan this with the
 			// row execution branch since there is no way to tell whether vectorized
 			// planning will succeed on any other node. Notify the gateway by
@@ -534,7 +534,7 @@ func (f *Flow) setup(ctx context.Context, spec *distsqlpb.FlowSpec) error {
 				rsidx := spec.Processors[0].Core.LocalPlanNode.RowSourceIdx
 				if rsidx != nil {
 					lp := f.localProcessors[*rsidx]
-					if z, ok := lp.(vectorizeAlwaysException); ok {
+					if z, ok := lp.(VectorizeAlwaysException); ok {
 						isException = z.IsException()
 					}
 				}

--- a/pkg/sql/distsqlrun/index_skip_table_reader.go
+++ b/pkg/sql/distsqlrun/index_skip_table_reader.go
@@ -70,7 +70,7 @@ func newIndexSkipTableReader(
 	post *distsqlpb.PostProcessSpec,
 	output RowReceiver,
 ) (*indexSkipTableReader, error) {
-	if flowCtx.nodeID == 0 {
+	if flowCtx.NodeID == 0 {
 		return nil, errors.Errorf("attempting to create a tableReader with uninitialized NodeID")
 	}
 
@@ -175,7 +175,7 @@ func (t *indexSkipTableReader) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerM
 		// Range info resets once a scan begins, so we need to maintain
 		// the range info we get after each scan.
 		if !t.ignoreMisplannedRanges {
-			ranges := misplannedRanges(t.Ctx, t.fetcher.GetRangesInfo(), t.flowCtx.nodeID)
+			ranges := misplannedRanges(t.Ctx, t.fetcher.GetRangesInfo(), t.flowCtx.NodeID)
 			for _, r := range ranges {
 				t.misplannedRanges = roachpb.InsertRangeInfo(t.misplannedRanges, r)
 			}

--- a/pkg/sql/distsqlrun/index_skip_table_reader_test.go
+++ b/pkg/sql/distsqlrun/index_skip_table_reader_test.go
@@ -407,7 +407,7 @@ func TestIndexSkipTableReader(t *testing.T) {
 				EvalCtx:  &evalCtx,
 				Settings: s.ClusterSettings(),
 				txn:      client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
-				nodeID:   s.NodeID(),
+				NodeID:   s.NodeID(),
 			}
 
 			tr, err := newIndexSkipTableReader(&flowCtx, 0 /* processorID */, &ts, &c.post, nil)
@@ -478,7 +478,7 @@ ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[
 		EvalCtx:  &evalCtx,
 		Settings: st,
 		txn:      client.NewTxn(ctx, tc.Server(0).DB(), nodeID, client.RootTxn),
-		nodeID:   nodeID,
+		NodeID:   nodeID,
 	}
 	spec := distsqlpb.IndexSkipTableReaderSpec{
 		Spans: []distsqlpb.TableReaderSpan{{Span: td.PrimaryIndexSpan()}},
@@ -602,7 +602,7 @@ func BenchmarkIndexScanTableReader(b *testing.B) {
 				EvalCtx:  &evalCtx,
 				Settings: s.ClusterSettings(),
 				txn:      client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
-				nodeID:   s.NodeID(),
+				NodeID:   s.NodeID(),
 			}
 
 			b.Run(fmt.Sprintf("TableReader+Distinct-rows=%d-ratio=%d", numRows, valueRatio), func(b *testing.B) {
@@ -639,7 +639,7 @@ func BenchmarkIndexScanTableReader(b *testing.B) {
 				EvalCtx:  &evalCtx,
 				Settings: s.ClusterSettings(),
 				txn:      client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
-				nodeID:   s.NodeID(),
+				NodeID:   s.NodeID(),
 			}
 
 			// run the index skip table reader

--- a/pkg/sql/distsqlrun/interleaved_reader_joiner.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner.go
@@ -276,7 +276,7 @@ func newInterleavedReaderJoiner(
 	post *distsqlpb.PostProcessSpec,
 	output RowReceiver,
 ) (*interleavedReaderJoiner, error) {
-	if flowCtx.nodeID == 0 {
+	if flowCtx.NodeID == 0 {
 		return nil, errors.AssertionFailedf("attempting to create an interleavedReaderJoiner with uninitialized NodeID")
 	}
 
@@ -430,7 +430,7 @@ func (irj *interleavedReaderJoiner) generateTrailingMeta(
 
 func (irj *interleavedReaderJoiner) generateMeta(ctx context.Context) []distsqlpb.ProducerMetadata {
 	var trailingMeta []distsqlpb.ProducerMetadata
-	ranges := misplannedRanges(ctx, irj.fetcher.GetRangesInfo(), irj.flowCtx.nodeID)
+	ranges := misplannedRanges(ctx, irj.fetcher.GetRangesInfo(), irj.flowCtx.NodeID)
 	if ranges != nil {
 		trailingMeta = append(trailingMeta, distsqlpb.ProducerMetadata{Ranges: ranges})
 	}

--- a/pkg/sql/distsqlrun/interleaved_reader_joiner_test.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner_test.go
@@ -400,7 +400,7 @@ func TestInterleavedReaderJoiner(t *testing.T) {
 				Settings: s.ClusterSettings(),
 				// Run in a RootTxn so that there's no txn metadata produced.
 				txn:    client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
-				nodeID: s.NodeID(),
+				NodeID: s.NodeID(),
 			}
 
 			out := &RowBuffer{}
@@ -530,7 +530,7 @@ func TestInterleavedReaderJoinerErrors(t *testing.T) {
 				Settings: s.ClusterSettings(),
 				// Run in a RootTxn so that there's no txn metadata produced.
 				txn:    client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
-				nodeID: s.NodeID(),
+				NodeID: s.NodeID(),
 			}
 
 			out := &RowBuffer{}
@@ -588,7 +588,7 @@ func TestInterleavedReaderJoinerTrailingMetadata(t *testing.T) {
 		Settings: s.ClusterSettings(),
 		// Run in a LeafTxn so that txn metadata is produced.
 		txn:    client.NewTxn(ctx, s.DB(), s.NodeID(), client.LeafTxn),
-		nodeID: s.NodeID(),
+		NodeID: s.NodeID(),
 	}
 
 	innerJoinSpec := distsqlpb.InterleavedReaderJoinerSpec{

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -1212,12 +1212,12 @@ type LocalProcessor interface {
 	SetInput(ctx context.Context, input RowSource) error
 }
 
-// vectorizeAlwaysException is an object that returns whether or not execution
+// VectorizeAlwaysException is an object that returns whether or not execution
 // should continue if experimental_vectorize=always and an error occurred when
 // setting up the vectorized flow. Consider the case in which
 // experimental_vectorize=always. The user must be able to unset this session
 // variable without getting an error.
-type vectorizeAlwaysException interface {
+type VectorizeAlwaysException interface {
 	// IsException returns whether this object should be an exception to the rule
 	// that an inability to run this node in a vectorized flow should produce an
 	// error.

--- a/pkg/sql/distsqlrun/scrub_tablereader.go
+++ b/pkg/sql/distsqlrun/scrub_tablereader.go
@@ -67,7 +67,7 @@ func newScrubTableReader(
 	post *distsqlpb.PostProcessSpec,
 	output RowReceiver,
 ) (*scrubTableReader, error) {
-	if flowCtx.nodeID == 0 {
+	if flowCtx.NodeID == 0 {
 		return nil, errors.Errorf("attempting to create a tableReader with uninitialized NodeID")
 	}
 	if flowCtx.txn == nil {

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -451,7 +451,7 @@ func (ds *ServerImpl) setupFlow(
 		executor:       ds.Executor,
 		LeaseManager:   ds.LeaseManager,
 		testingKnobs:   ds.TestingKnobs,
-		nodeID:         nodeID,
+		NodeID:         nodeID,
 		TempStorage:    ds.TempStorage,
 		BulkAdder:      ds.BulkAdder,
 		diskMonitor:    ds.DiskMonitor,

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -82,7 +82,7 @@ func newTableReader(
 	post *distsqlpb.PostProcessSpec,
 	output RowReceiver,
 ) (*tableReader, error) {
-	if flowCtx.nodeID == 0 {
+	if flowCtx.NodeID == 0 {
 		return nil, errors.Errorf("attempting to create a tableReader with uninitialized NodeID")
 	}
 
@@ -325,7 +325,7 @@ func (tr *tableReader) outputStatsToTrace() {
 func (tr *tableReader) generateMeta(ctx context.Context) []distsqlpb.ProducerMetadata {
 	var trailingMeta []distsqlpb.ProducerMetadata
 	if !tr.ignoreMisplannedRanges {
-		ranges := misplannedRanges(ctx, tr.fetcher.GetRangesInfo(), tr.flowCtx.nodeID)
+		ranges := misplannedRanges(ctx, tr.fetcher.GetRangesInfo(), tr.flowCtx.NodeID)
 		if ranges != nil {
 			trailingMeta = append(trailingMeta, distsqlpb.ProducerMetadata{Ranges: ranges})
 		}

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -129,7 +129,7 @@ func TestTableReader(t *testing.T) {
 					EvalCtx:  &evalCtx,
 					Settings: s.ClusterSettings(),
 					txn:      client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
-					nodeID:   s.NodeID(),
+					NodeID:   s.NodeID(),
 				}
 
 				var out RowReceiver
@@ -214,7 +214,7 @@ ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[
 		EvalCtx:  &evalCtx,
 		Settings: st,
 		txn:      client.NewTxn(ctx, tc.Server(0).DB(), nodeID, client.RootTxn),
-		nodeID:   nodeID,
+		NodeID:   nodeID,
 	}
 	spec := distsqlpb.TableReaderSpec{
 		Spans: []distsqlpb.TableReaderSpan{{Span: td.PrimaryIndexSpan()}},
@@ -319,7 +319,7 @@ func TestLimitScans(t *testing.T) {
 		EvalCtx:  &evalCtx,
 		Settings: s.ClusterSettings(),
 		txn:      client.NewTxn(ctx, kvDB, s.NodeID(), client.RootTxn),
-		nodeID:   s.NodeID(),
+		NodeID:   s.NodeID(),
 	}
 	spec := distsqlpb.TableReaderSpec{
 		Table: *tableDesc,
@@ -423,7 +423,7 @@ func BenchmarkTableReader(b *testing.B) {
 			EvalCtx:  &evalCtx,
 			Settings: s.ClusterSettings(),
 			txn:      client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
-			nodeID:   s.NodeID(),
+			NodeID:   s.NodeID(),
 		}
 
 		b.Run(fmt.Sprintf("rows=%d", numRows), func(b *testing.B) {

--- a/pkg/sql/exec/types/conv/conv.go
+++ b/pkg/sql/exec/types/conv/conv.go
@@ -52,12 +52,15 @@ func FromColumnType(ct *semtypes.T) types.T {
 
 // FromColumnTypes calls FromColumnType on each element of cts, returning the
 // resulting slice.
-func FromColumnTypes(cts []semtypes.T) []types.T {
+func FromColumnTypes(cts []semtypes.T) ([]types.T, error) {
 	typs := make([]types.T, len(cts))
 	for i := range typs {
 		typs[i] = FromColumnType(&cts[i])
+		if typs[i] == types.Unhandled {
+			return nil, errors.Errorf("unsupported type %s", cts[i])
+		}
 	}
-	return typs
+	return typs, nil
 }
 
 // GetDatumToPhysicalFn returns a function for converting a datum of the given


### PR DESCRIPTION
Before setting up flows on remote nodes, we now iterate over all flows
locally and check to see whether they're vectorizable or not. If any of
them are not vectorizable, we either fall back or error out depending on
the settings. If they are all vectorizable, we continue on.

Release note: None