### PR TITLE
exec: fix output types for projections

### DIFF
--- a/pkg/sql/exec/colserde/arrowbatchconverter.go
+++ b/pkg/sql/exec/colserde/arrowbatchconverter.go
@@ -20,7 +20,7 @@ import (
 	"github.com/apache/arrow/go/arrow/memory"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
-	"github.com/pkg/errors"
+	"github.com/cockroachdb/errors"
 )
 
 // ArrowBatchConverter converts batches to arrow column data
@@ -103,7 +103,7 @@ var supportedTypes = func() map[types.T]struct{} {
 // next call to BatchToArrow.
 func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]*array.Data, error) {
 	if batch.Width() != len(c.typs) {
-		return nil, errors.Errorf("mismatched batch width and schema length: %d != %d", batch.Width(), len(c.typs))
+		return nil, errors.AssertionFailedf("mismatched batch width and schema length: %d != %d", batch.Width(), len(c.typs))
 	}
 	n := int(batch.Length())
 	for i, typ := range c.typs {


### PR DESCRIPTION
Previously, the output type of a projection was always set to the data
type of its input. This doesn't work for boolean projections like
eqIntIntOp, obviously. This wasn't failing tests because the final
materializer ignores the output column types, and we never fed boolean
projections into things that weren't the final materializers. This will
be tested going forward via distributed plans as well.

Closes #38970.

Release note: None