### PR TITLE
sql/logictest: make a useful default logic test config

### DIFF
--- a/build/teamcity-sqllogictest.sh
+++ b/build/teamcity-sqllogictest.sh
@@ -13,20 +13,16 @@ export BUILDER_HIDE_GOPATH_SRC=0
 # heuristic planner does not support that feature. Afterwards, run additional
 # tests that do require correlated subquery support, but only with the cost-
 # based optimizer.
-for config in local local-opt fakedist fakedist-opt fakedist-disk; do
-    build/builder.sh \
-        stdbuf -oL -eL \
-        make test TESTFLAGS="-v -bigtest -config ${config}" TESTTIMEOUT='24h' PKG='./pkg/sql/logictest' TESTS='^TestSqlLiteLogic$$' 2>&1 \
-        | tee "artifacts/${config}.log" \
-        | go-test-teamcity
-done
+build/builder.sh \
+  stdbuf -oL -eL \
+  make test TESTFLAGS="-v -bigtest" TESTTIMEOUT='24h' PKG='./pkg/sql/logictest' TESTS='^TestSqlLiteLogic$$' 2>&1 \
+  | tee "artifacts/${config}.log" \
+  | go-test-teamcity
 
 # Need to specify the flex-types flag in order to skip past variations that have
 # numeric typing differences.
-for config in local-opt fakedist-opt; do
-    build/builder.sh \
-        stdbuf -oL -eL \
-        make test TESTFLAGS="-v -bigtest -config ${config} -flex-types" TESTTIMEOUT='24h' PKG='./pkg/sql/logictest' TESTS='^TestSqlLiteCorrelatedLogic$$' 2>&1 \
-        | tee "artifacts/${config}.log" \
-        | go-test-teamcity
-done
+build/builder.sh \
+  stdbuf -oL -eL \
+  make test TESTFLAGS="-v -bigtest -config local-opt,fakedist-opt -flex-types" TESTTIMEOUT='24h' PKG='./pkg/sql/logictest' TESTS='^TestSqlLiteCorrelatedLogic$$' 2>&1 \
+  | tee "artifacts/${config}.log" \
+  | go-test-teamcity

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 subtest other
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/alias_types
+++ b/pkg/sql/logictest/testdata/logic_test/alias_types
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-metadata fakedist-opt
-
 statement ok
 CREATE TABLE aliases (
     a OID,

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # A basic sanity check to demonstrate column type changes.
 subtest SanityCheck
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_sequence
+++ b/pkg/sql/logictest/testdata/logic_test/alter_sequence
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # see also file `sequences`
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE TABLE other (b INT PRIMARY KEY)
 

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-metadata fakedist-opt
-
 # pg arrays must preserve control characters when converted to string,
 # but their direct representation as string does not escape the
 # control characters. In order for the test file to remain valid

--- a/pkg/sql/logictest/testdata/logic_test/backup
+++ b/pkg/sql/logictest/testdata/logic_test/backup
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 query error pgcode XXC01 a CCL binary is required to use this statement type
 BACKUP DATABASE foo TO '/bar' INCREMENTAL FROM '/baz'
 

--- a/pkg/sql/logictest/testdata/logic_test/bit
+++ b/pkg/sql/logictest/testdata/logic_test/bit
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 query TTT
 SELECT B'1000101'::BIT(4)::STRING,
        B'1000101'::BIT(4),

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-metadata fakedist-opt
-
 statement ok
 CREATE TABLE foo (a int)
 

--- a/pkg/sql/logictest/testdata/logic_test/bytes
+++ b/pkg/sql/logictest/testdata/logic_test/bytes
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 query T
 SHOW bytea_output
 ----

--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 subtest AllCascadingActions
 ### A test of all cascading actions in their most basic form.
 # A

--- a/pkg/sql/logictest/testdata/logic_test/case_sensitive_names
+++ b/pkg/sql/logictest/testdata/logic_test/case_sensitive_names
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # Case sensitivity of database names
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/check_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/check_constraints
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 #### column CHECK constraints
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement error pq: invalid locale bad_locale: language: subtag "locale" is well-formed but unknown
 SELECT 'a' COLLATE bad_locale
 

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_constraint
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_constraint
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata fakedist-disk
-
 # English collation chart: http://www.unicode.org/cldr/charts/30/collation/en_US_POSIX.html
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_index1
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_index1
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata fakedist-disk
-
 ##
 # Test a primary key with a collated string in first position (can get a key range).
 #

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_index2
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_index2
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata fakedist-disk
-
 ##
 # Test a primary key with a collated string in second position (cannot get a key range).
 #

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_normalization
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_normalization
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE TABLE t (
   a STRING COLLATE fr PRIMARY KEY

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_nullinindex
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_nullinindex
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata fakedist-disk
-
 statement ok
 CREATE TABLE t (
   a INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex1
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex1
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata fakedist-disk
-
 ##
 # Test a primary key with a collated string in first position (can get a key range).
 #

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex2
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex2
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata fakedist-disk
-
 ##
 # Test a primary key with a collated string in second position (cannot get a key range).
 #

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE TABLE with_no_column_refs (
   a INT,

--- a/pkg/sql/logictest/testdata/logic_test/conditional
+++ b/pkg/sql/logictest/testdata/logic_test/conditional
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-metadata fakedist-opt
-
 query II
 SELECT IF(1 = 2, NULL, 1), IF(2 = 2, NULL, 2)
 ----

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 query error database "crdb_internal" does not exist
 ALTER DATABASE crdb_internal RENAME TO not_crdb_internal
 

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE TABLE t (
   a INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE TABLE t (a INT REFERENCES t)
 

--- a/pkg/sql/logictest/testdata/logic_test/custom_escape_character
+++ b/pkg/sql/logictest/testdata/logic_test/custom_escape_character
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-metadata fakedist-opt
-
 query B
 SELECT '%' LIKE 't%' ESCAPE CASE WHEN (SELECT '-A' SIMILAR TO '--A' ESCAPE '-') THEN 't' ELSE 'f' END
 ----

--- a/pkg/sql/logictest/testdata/logic_test/dangerous_statements
+++ b/pkg/sql/logictest/testdata/logic_test/dangerous_statements
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE TABLE foo(x INT)
 

--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata fakedist-disk
-
 statement ok
 CREATE TABLE t (
   a TIMESTAMP PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/decimal
+++ b/pkg/sql/logictest/testdata/logic_test/decimal
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata fakedist-disk
-
 # The following tests have results equivalent to Postgres (differences
 # in string representation and number of decimals returned, but otherwise
 # the same). These do not pass using the inf package. The inf package

--- a/pkg/sql/logictest/testdata/logic_test/deep_interleaving
+++ b/pkg/sql/logictest/testdata/logic_test/deep_interleaving
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # Test querying deeply interleaved tables.
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/default
+++ b/pkg/sql/logictest/testdata/logic_test/default
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement error expected DEFAULT expression to have type int, but 'false' has type bool
 CREATE TABLE t (a INT PRIMARY KEY DEFAULT false)
 

--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt
-
 statement ok
 CREATE TABLE kv (
   k INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/dependencies
+++ b/pkg/sql/logictest/testdata/logic_test/dependencies
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE TABLE test_kv(k INT PRIMARY KEY, v INT, w DECIMAL);
   CREATE UNIQUE INDEX test_v_idx ON test_kv(v);

--- a/pkg/sql/logictest/testdata/logic_test/discard
+++ b/pkg/sql/logictest/testdata/logic_test/discard
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 SET SEARCH_PATH = foo
 

--- a/pkg/sql/logictest/testdata/logic_test/distinct
+++ b/pkg/sql/logictest/testdata/logic_test/distinct
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata fakedist-disk
-
 statement ok
 CREATE TABLE xyz (
   x INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/distinct_on
+++ b/pkg/sql/logictest/testdata/logic_test/distinct_on
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata fakedist-disk
-
 statement ok
 CREATE TABLE xyz (
   x INT,

--- a/pkg/sql/logictest/testdata/logic_test/distsql_expr
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_expr
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE TABLE t (c int PRIMARY KEY)
 

--- a/pkg/sql/logictest/testdata/logic_test/drop_sequence
+++ b/pkg/sql/logictest/testdata/logic_test/drop_sequence
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # see also file `sequences`
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/edge
+++ b/pkg/sql/logictest/testdata/logic_test/edge
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata fakedist-disk
-
 # Test on-disk SQL semantics of edge cases and overflows. On-disk is
 # important because it avoids any constant folding that could happen
 # in the parse or normalization phases, forcing it to be handled by the

--- a/pkg/sql/logictest/testdata/logic_test/errors
+++ b/pkg/sql/logictest/testdata/logic_test/errors
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement error pgcode 42P01 relation "fake1" does not exist
 ALTER TABLE fake1 DROP COLUMN a
 

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 ##################
 # TABLE DDL
 ##################

--- a/pkg/sql/logictest/testdata/logic_test/family
+++ b/pkg/sql/logictest/testdata/logic_test/family
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # a is the primary key so b gets optimized into a one column value. The c, d
 # family has two columns, so it's encoded as a tuple
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # Disable automatic stats to avoid flakiness.
 statement ok
 SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false

--- a/pkg/sql/logictest/testdata/logic_test/float
+++ b/pkg/sql/logictest/testdata/logic_test/float
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # -0 and 0 should not be possible in a unique index.
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/function_lookup
+++ b/pkg/sql/logictest/testdata/logic_test/function_lookup
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE TABLE foo(x INT DEFAULT length(pg_typeof(1234))-1)
 

--- a/pkg/sql/logictest/testdata/logic_test/inet
+++ b/pkg/sql/logictest/testdata/logic_test/inet
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # Basic IPv4 tests
 
 query T

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt
-
 statement error pgcode 42P01 relation "kv" does not exist
 INSERT INTO kv VALUES ('a', 'b')
 

--- a/pkg/sql/logictest/testdata/logic_test/int_size
+++ b/pkg/sql/logictest/testdata/logic_test/int_size
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 subtest defaults
 
 query T

--- a/pkg/sql/logictest/testdata/logic_test/interleaved_join
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved_join
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt
-
 # The following tables form the interleaved hierarchy:
 #   name:             primary key:                # rows:   'a' = id mod X :
 #   parent1           (pid1)                      40        8

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE TABLE t (
   a INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata fakedist-disk
-
 # The join condition logic is tricky to get right with NULL
 # values. Simple implementations can deal well with NULLs on the first
 # or last row but fail to handle them in the middle. So the test table

--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 ## Basic creation
 
 query TT

--- a/pkg/sql/logictest/testdata/logic_test/json_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/json_builtins
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 ## json_typeof and jsonb_typeof
 
 query T

--- a/pkg/sql/logictest/testdata/logic_test/limit
+++ b/pkg/sql/logictest/testdata/logic_test/limit
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 query I
 SELECT generate_series FROM generate_series(1, 100) ORDER BY generate_series LIMIT 5;
 ----

--- a/pkg/sql/logictest/testdata/logic_test/manual_retry
+++ b/pkg/sql/logictest/testdata/logic_test/manual_retry
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 subtest automatic_retry
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/multi_statement
+++ b/pkg/sql/logictest/testdata/logic_test/multi_statement
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE TABLE kv (
   k CHAR PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/name_escapes
+++ b/pkg/sql/logictest/testdata/logic_test/name_escapes
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # Check that the various things in a table definition are properly escaped when
 # printed out.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/namespace
+++ b/pkg/sql/logictest/testdata/logic_test/namespace
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE TABLE a(a INT)
 

--- a/pkg/sql/logictest/testdata/logic_test/no_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/no_primary_key
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 query error duplicate column name: "rowid"
 CREATE TABLE t (
   rowid INT

--- a/pkg/sql/logictest/testdata/logic_test/optimizer
+++ b/pkg/sql/logictest/testdata/logic_test/optimizer
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt
-
 statement ok
 CREATE TABLE t (k INT PRIMARY KEY, v INT)
 

--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata fakedist-disk
-
 statement ok
 CREATE TABLE t (
   a INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/ordinal_references
+++ b/pkg/sql/logictest/testdata/logic_test/ordinal_references
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE TABLE foo(a INT, b CHAR)
 

--- a/pkg/sql/logictest/testdata/logic_test/ordinality
+++ b/pkg/sql/logictest/testdata/logic_test/ordinality
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 query TI colnames
 SELECT * FROM (VALUES ('a'), ('b')) WITH ORDINALITY AS x(name, i)
 ----

--- a/pkg/sql/logictest/testdata/logic_test/orms
+++ b/pkg/sql/logictest/testdata/logic_test/orms
@@ -1,3 +1,5 @@
+# TODO(mjibson): The fakedist-disk config produces an error. When fixed,
+# remove this config line. See #38985.
 # LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
 
 ## This test file contains various complex queries that ORMs issue during

--- a/pkg/sql/logictest/testdata/logic_test/parallel_stmts_compat
+++ b/pkg/sql/logictest/testdata/logic_test/parallel_stmts_compat
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # Parallel statement execution was removed in 19.2. See #34789.
 # The RETURNING NOTHING syntax was retained to ensure backward compatibility,
 # even though the runtime semantics of parallel statements were removed. This

--- a/pkg/sql/logictest/testdata/logic_test/partial_txn_commit
+++ b/pkg/sql/logictest/testdata/logic_test/partial_txn_commit
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-metadata fakedist-opt
-
 # This test exercises the presence of an explanatory hint when a transaction
 # ends up partially committed and partially aborted.
 

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 query OO
 SELECT 3::OID, '3'::OID
 ----

--- a/pkg/sql/logictest/testdata/logic_test/poison_after_push
+++ b/pkg/sql/logictest/testdata/logic_test/poison_after_push
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # This example session documents that a SERIALIZABLE transaction is
 # not immediately poisoned when it revisits a Range on which one of
 # its intents has had its timestamp pushed. This allows it to continue

--- a/pkg/sql/logictest/testdata/logic_test/postgres_jsonb
+++ b/pkg/sql/logictest/testdata/logic_test/postgres_jsonb
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # This file is an incomplete porting of
 # https://github.com/postgres/postgres/blob/11e264517dff7a911d9e6494de86049cab42cde3/src/test/regress/sql/jsonb.sql
 # to CockroachDB logic tests.

--- a/pkg/sql/logictest/testdata/logic_test/postgresjoin
+++ b/pkg/sql/logictest/testdata/logic_test/postgresjoin
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata fakedist-disk
-
 # These are postgres regress sql join test suite
 # https://github.com/postgres/postgres/blob/master/src/test/regress/sql/join.sql
 # Adapted to sqllogictest format

--- a/pkg/sql/logictest/testdata/logic_test/privilege_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/privilege_builtins
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE USER bar
 

--- a/pkg/sql/logictest/testdata/logic_test/privileges_database
+++ b/pkg/sql/logictest/testdata/logic_test/privileges_database
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # Test default database-level permissions.
 # Default user is root.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/privileges_table
+++ b/pkg/sql/logictest/testdata/logic_test/privileges_table
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # Disable automatic stats to avoid flakiness.
 statement ok
 SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false

--- a/pkg/sql/logictest/testdata/logic_test/rename_column
+++ b/pkg/sql/logictest/testdata/logic_test/rename_column
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE TABLE users (
   uid    INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/rename_constraint
+++ b/pkg/sql/logictest/testdata/logic_test/rename_constraint
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE TABLE t (
   x INT, y INT,

--- a/pkg/sql/logictest/testdata/logic_test/rename_database
+++ b/pkg/sql/logictest/testdata/logic_test/rename_database
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 query T
 SHOW DATABASES
 ----

--- a/pkg/sql/logictest/testdata/logic_test/rename_index
+++ b/pkg/sql/logictest/testdata/logic_test/rename_index
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE TABLE users (
   id    INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/rename_sequence
+++ b/pkg/sql/logictest/testdata/logic_test/rename_sequence
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # see also file `sequences`
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/rename_table
+++ b/pkg/sql/logictest/testdata/logic_test/rename_table
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement error pgcode 42P01 relation "foo" does not exist
 ALTER TABLE foo RENAME TO bar
 

--- a/pkg/sql/logictest/testdata/logic_test/rename_view
+++ b/pkg/sql/logictest/testdata/logic_test/rename_view
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement error pgcode 42P01 relation "foo" does not exist
 ALTER VIEW foo RENAME TO bar
 

--- a/pkg/sql/logictest/testdata/logic_test/returning
+++ b/pkg/sql/logictest/testdata/logic_test/returning
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt
-
 statement ok
 CREATE TABLE a (a int, b int)
 

--- a/pkg/sql/logictest/testdata/logic_test/rows_from
+++ b/pkg/sql/logictest/testdata/logic_test/rows_from
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 query II colnames
 SELECT * FROM ROWS FROM (generate_series(1,2), generate_series(4,8))
 ----

--- a/pkg/sql/logictest/testdata/logic_test/run_control
+++ b/pkg/sql/logictest/testdata/logic_test/run_control
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 query error job with ID 1 does not exist
 PAUSE JOB 1
 

--- a/pkg/sql/logictest/testdata/logic_test/scale
+++ b/pkg/sql/logictest/testdata/logic_test/scale
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE TABLE test (
   t CHAR(4),

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # Disable automatic stats to avoid flakiness (sometimes causes retry errors).
 statement ok
 SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_retry
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_retry
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # This test reproduces https://github.com/cockroachdb/cockroach/issues/23979
 
 # Schema changes that experienced retriable errors in RELEASE

--- a/pkg/sql/logictest/testdata/logic_test/scrub
+++ b/pkg/sql/logictest/testdata/logic_test/scrub
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement error pgcode 42P01 relation "t" does not exist
 EXPERIMENTAL SCRUB TABLE t
 -----

--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE TABLE t (
   a INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/select_index_flags
+++ b/pkg/sql/logictest/testdata/logic_test/select_index_flags
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE TABLE abcd (
   a INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/select_index_span_ranges
+++ b/pkg/sql/logictest/testdata/logic_test/select_index_span_ranges
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # This test verifies that we correctly perform an index join when the KV
 # batches span ranges. This is testing that SQL disables batch limits for index
 # join; otherwise it can get out of order results from KV that it can't handle.

--- a/pkg/sql/logictest/testdata/logic_test/select_search_path
+++ b/pkg/sql/logictest/testdata/logic_test/select_search_path
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # Test that pg_catalog tables are accessible without qualifying table/view
 # names.
 

--- a/pkg/sql/logictest/testdata/logic_test/select_table_alias
+++ b/pkg/sql/logictest/testdata/logic_test/select_table_alias
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # Tests for SELECT with table aliasing.
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # see also files `drop_sequence`, `alter_sequence`, `rename_sequence`
 
 # USING THE `lastval` FUNCTION

--- a/pkg/sql/logictest/testdata/logic_test/serial
+++ b/pkg/sql/logictest/testdata/logic_test/serial
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 subtest serial_rowid
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/serializable_eager_restart
+++ b/pkg/sql/logictest/testdata/logic_test/serializable_eager_restart
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # Demonstrates late restarting of a serializable transaction when its
 # commit timestamp has moved forward.
 # TODO(tschottdorf): implement eager restart for CLI.

--- a/pkg/sql/logictest/testdata/logic_test/shift
+++ b/pkg/sql/logictest/testdata/logic_test/shift
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # Check non-constant eval
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/show_fingerprints
+++ b/pkg/sql/logictest/testdata/logic_test/show_fingerprints
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE TABLE t (a INT PRIMARY KEY, b INT, c INT, d INT, INDEX (b) STORING (d))
 

--- a/pkg/sql/logictest/testdata/logic_test/sqlsmith
+++ b/pkg/sql/logictest/testdata/logic_test/sqlsmith
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # This file contains regression tests discovered by sqlsmith.
 
 

--- a/pkg/sql/logictest/testdata/logic_test/srfs
+++ b/pkg/sql/logictest/testdata/logic_test/srfs
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-metadata fakedist-opt
-
 subtest generate_series
 
 query I

--- a/pkg/sql/logictest/testdata/logic_test/statement_source
+++ b/pkg/sql/logictest/testdata/logic_test/statement_source
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt
-
 statement ok
 CREATE TABLE a (a INT PRIMARY KEY, b INT)
 

--- a/pkg/sql/logictest/testdata/logic_test/storing
+++ b/pkg/sql/logictest/testdata/logic_test/storing
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE TABLE t (
   a INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/suboperators
+++ b/pkg/sql/logictest/testdata/logic_test/suboperators
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE TABLE abc (a INT, b INT, C INT)
 

--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # Tests for subqueries (SELECT statements which are part of a bigger statement).
 
 query I

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 query T
 SHOW DATABASES
 ----

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 SET DATABASE = ""
 

--- a/pkg/sql/logictest/testdata/logic_test/time
+++ b/pkg/sql/logictest/testdata/logic_test/time
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # Note that the odd '0000-01-01 hh:mi:ss +0000 UTC' result format is an
 # artifact of how pq displays TIMEs.
 

--- a/pkg/sql/logictest/testdata/logic_test/timestamp
+++ b/pkg/sql/logictest/testdata/logic_test/timestamp
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 query T
 SELECT '2000-05-05 10:00:00+03':::TIMESTAMP
 ----

--- a/pkg/sql/logictest/testdata/logic_test/truncate
+++ b/pkg/sql/logictest/testdata/logic_test/truncate
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE TABLE kv (
   k INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata fakedist-disk
-
 statement ok
 CREATE TABLE tb(unused INT); INSERT INTO tb VALUES (1)
 

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # Transaction involving schema changes.
 statement ok
 BEGIN TRANSACTION

--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -1,3 +1,5 @@
+# TODO(mjibson): The fakedist-disk config produces a panic. When fixed,
+# remove this config line. See #38987.
 # LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
 
 query I rowsort

--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt
-
 statement ok
 CREATE TABLE kv (
   k INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 subtest strict
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/uuid
+++ b/pkg/sql/logictest/testdata/logic_test/uuid
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE TABLE u (token uuid PRIMARY KEY,
                 token2 uuid,

--- a/pkg/sql/logictest/testdata/logic_test/values
+++ b/pkg/sql/logictest/testdata/logic_test/values
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # Tests for the implicit one row, zero column values operator.
 query I
 SELECT 1

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # NOTE: Keep this table at the beginning of the file to ensure that its numeric
 #       reference is 53 (the numeric reference of the first table). If the
 #       numbering scheme in cockroach changes, this test will break.

--- a/pkg/sql/logictest/testdata/logic_test/where
+++ b/pkg/sql/logictest/testdata/logic_test/where
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE TABLE kv (
   k INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/with
+++ b/pkg/sql/logictest/testdata/logic_test/with
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 statement ok
 CREATE TABLE x(a) AS SELECT generate_series(1, 3)
 

--- a/pkg/sql/logictest/testdata/logic_test/zero
+++ b/pkg/sql/logictest/testdata/logic_test/zero
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata fakedist-disk
-
 # This tests zeros and numbers with trailing zeros.
 
 # ints

--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -1,5 +1,3 @@
-# LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
-
 # Check that we can alter the default zone config.
 
 statement ok

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1071,50 +1071,6 @@ func TestLint(t *testing.T) {
 		}
 	})
 
-	// TestLogicTestsLint verifies that all the logic test files start with
-	// a LogicTest directive.
-	t.Run("TestLogicTestsLint", func(t *testing.T) {
-		t.Parallel()
-		cmd, stderr, filter, err := dirCmd(
-			pkgDir, "git", "ls-files",
-			"sql/logictest/testdata/logic_test/",
-			"sql/logictest/testdata/planner_test/",
-			"sql/opt/exec/execbuilder/testdata/",
-		)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if err := cmd.Start(); err != nil {
-			t.Fatal(err)
-		}
-
-		if err := stream.ForEach(filter, func(filename string) {
-			file, err := os.Open(filepath.Join(pkgDir, filename))
-			if err != nil {
-				t.Error(err)
-				return
-			}
-			defer file.Close()
-			firstLine, err := bufio.NewReader(file).ReadString('\n')
-			if err != nil {
-				t.Errorf("reading first line of %s: %s", filename, err)
-				return
-			}
-			if !strings.HasPrefix(firstLine, "# LogicTest:") {
-				t.Errorf("%s must start with a directive, e.g. `# LogicTest: default`", filename)
-			}
-		}); err != nil {
-			t.Error(err)
-		}
-
-		if err := cmd.Wait(); err != nil {
-			if out := stderr.String(); len(out) > 0 {
-				t.Fatalf("err=%s, stderr=%s", err, out)
-			}
-		}
-	})
-
 	// Things that are packaged scoped are below here.
 	pkgScope := pkgVar
 	if !pkgSpecified {


### PR DESCRIPTION
Previously when creating a new logic testdata file we had to figure out
what the correct LogicTest config line was. To many of us this was not
obvious and we just wanted to do whatever we were supposed to, so we
cargo culted by copying some randomly chosen existing file. Did it have
the right config? A guess.

Also, when adding a new test config, we would presumably have to decide
which existing files should be told about it. Another guess.

The goal here is to make the default case of nothing useful. That is,
most files have no LogicTest config line, and that's correct most of the
time. Files that do need special treatment can still configure exactly
how they are run.

Release note: None