### PR TITLE
exec: pass through errors caused by kvfetcher and below

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -1210,7 +1210,7 @@ func (f *Flow) setupVectorized(ctx context.Context, acc *mon.BoundAccount) error
 
 		op, outputTypes, memUsage, err := newColOperator(ctx, &f.FlowCtx, pspec, inputs)
 		if err != nil {
-			return errors.Wrapf(err, "unable to vectorize execution plan.")
+			return errors.Wrapf(err, "unable to vectorize execution plan")
 		}
 		if err = acc.Grow(ctx, int64(memUsage)); err != nil {
 			return errors.Wrapf(err, "not enough memory to setup vectorized plan.")

--- a/pkg/sql/exec/error.go
+++ b/pkg/sql/exec/error.go
@@ -49,10 +49,14 @@ func CatchVectorizedRuntimeError(operation func()) (retErr error) {
 					// We only want to catch runtime errors coming from the vectorized
 					// engine.
 					if e, ok := err.(error); ok {
-						// Any error without a code already is "surprising" and
-						// needs to be annotated to indicate that it was
-						// unexpected.
-						if code := pgerror.GetPGCode(e); code == pgcode.Uncategorized {
+						if _, ok := err.(*StorageError); ok {
+							// A StorageError was caused by something below SQL, and represents
+							// an error that we'd simply like to propagate along.
+							// Do nothing.
+						} else if code := pgerror.GetPGCode(e); code == pgcode.Uncategorized {
+							// Any error without a code already is "surprising" and
+							// needs to be annotated to indicate that it was
+							// unexpected.
 							e = errors.AssertionFailedf("unexpected error from the vectorized runtime: %+v", e)
 						}
 						retErr = e
@@ -125,4 +129,22 @@ func (e *TestVectorizedErrorEmitter) Next(ctx context.Context) coldata.Batch {
 
 	e.emitBatch = false
 	return e.input.Next(ctx)
+}
+
+// StorageError is an error that was created by a component below the sql
+// stack, such as the network or storage layers. A StorageError will be bubbled
+// up all the way past the SQL layer unchanged.
+type StorageError struct {
+	error
+}
+
+// Cause implements the Causer interface.
+func (s *StorageError) Cause() error {
+	return s.error
+}
+
+// NewStorageError returns a new storage error. This can be used to propagate
+// an error through the exec subsystem unchanged.
+func NewStorageError(err error) *StorageError {
+	return &StorageError{error: err}
 }

--- a/pkg/sql/row/cfetcher.go
+++ b/pkg/sql/row/cfetcher.go
@@ -553,7 +553,7 @@ func (rf *CFetcher) NextBatch(ctx context.Context) (coldata.Batch, error) {
 		case stateInitFetch:
 			moreKeys, kv, newSpan, err := rf.fetcher.nextKV(ctx)
 			if err != nil {
-				return nil, err
+				return nil, exec.NewStorageError(err)
 			}
 			if !moreKeys {
 				rf.machine.state[0] = stateEmitLastBatch
@@ -655,7 +655,7 @@ func (rf *CFetcher) NextBatch(ctx context.Context) (coldata.Batch, error) {
 			for {
 				moreRows, kv, _, err := rf.fetcher.nextKV(ctx)
 				if err != nil {
-					return nil, err
+					return nil, exec.NewStorageError(err)
 				}
 				if debugState {
 					log.Infof(ctx, "found kv %s, seeking to prefix %s", kv.Key, rf.machine.seekPrefix)
@@ -678,7 +678,7 @@ func (rf *CFetcher) NextBatch(ctx context.Context) (coldata.Batch, error) {
 		case stateFetchNextKVWithUnfinishedRow:
 			moreKVs, kv, _, err := rf.fetcher.nextKV(ctx)
 			if err != nil {
-				return nil, err
+				return nil, exec.NewStorageError(err)
 			}
 			if !moreKVs {
 				// No more data. Finalize the row and exit.


### PR DESCRIPTION
Previously, errors caused by kvfetcher would be accidentally considered
unexpected errors and wrapped with assertion failures. This caused
higher level components to fail to operate as expected. Now, storage
errors are handled separately.

Fixes #38943.

Release note: None