### PR TITLE
importccl: gossip the change to IMPORTING in IMPORT INTO

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -416,6 +416,9 @@ func importPlanHook(
 			// TODO(dt): de-validate all the FKs.
 
 			if err := p.ExecCfg().DB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+				if err := txn.SetSystemConfigTrigger(); err != nil {
+					return err
+				}
 				return errors.Wrap(
 					txn.CPut(ctx, sqlbase.MakeDescMetadataKey(found.TableDescriptor.ID),
 						sqlbase.WrapDescriptor(&importing), sqlbase.WrapDescriptor(&found.TableDescriptor),

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1213,12 +1213,6 @@ func TestImportCSVStmt(t *testing.T) {
 func TestImportIntoCSV(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	// TODO(adityamaru): This needs to be removed once we can figure out why
-	// leases are not being released after insertion, and before importing into a
-	// table. Without this, the test waits for the lease to expire ~5m before
-	// running.
-	defer sql.TestDisableTableLeases()()
-
 	if testing.Short() {
 		t.Skip("short")
 	}

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -1080,7 +1080,7 @@ func releaseLease(lease *storedTableLease, m *LeaseManager) {
 
 // purgeOldVersions removes old unused table descriptor versions older than
 // minVersion and releases any associated leases.
-// If dropped is set, minVersion is ignored; no lease is acquired and all
+// If takenOffline is set, minVersion is ignored; no lease is acquired and all
 // existing unused versions are removed. The table is further marked dropped,
 // which will cause existing in-use leases to be eagerly released once
 // they're not in use any more.
@@ -1089,7 +1089,7 @@ func purgeOldVersions(
 	ctx context.Context,
 	db *client.DB,
 	id sqlbase.ID,
-	dropped bool,
+	takenOffline bool,
 	minVersion sqlbase.DescriptorVersion,
 	m *LeaseManager,
 ) error {
@@ -1116,8 +1116,8 @@ func purgeOldVersions(
 		}
 	}
 
-	if dropped {
-		removeInactives(dropped)
+	if takenOffline {
+		removeInactives(takenOffline)
 		return nil
 	}
 
@@ -1742,7 +1742,7 @@ func (m *LeaseManager) RefreshLeases(s *stop.Stopper, db *client.DB, g *gossip.G
 						}
 						// Try to refresh the table lease to one >= this version.
 						if err := purgeOldVersions(
-							ctx, db, table.ID, table.Dropped(), table.Version, m); err != nil {
+							ctx, db, table.ID, table.GoingOffline(), table.Version, m); err != nil {
 							log.Warningf(ctx, "error purging leases for table %d(%s): %s",
 								table.ID, table.Name, err)
 						}

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2665,6 +2665,11 @@ func (desc *TableDescriptor) HasColumnBackfillMutation() bool {
 	return false
 }
 
+// GoingOffline returns true if the table is being dropped or is importing.
+func (desc *TableDescriptor) GoingOffline() bool {
+	return desc.Dropped() || desc.State == TableDescriptor_IMPORTING
+}
+
 // Dropped returns true if the table is being dropped.
 func (desc *TableDescriptor) Dropped() bool {
 	return desc.State == TableDescriptor_DROP


### PR DESCRIPTION
Previously the IMPORT INTO update of the table to the offline IMPORTING
state was not setting the trigger on that transaction that caused the
update to be gossiped. This meant that the lease manager was not
immediately seeing the update and clearing leases, so IMPORT could then
hang waiting for leases on the table that had no intention on releasing
right away.

However after fixing that, leases were still not being released because
since the table was not *dropped*, the lease manager tried to instead
lease the new version, but then failed on the IMPORTING state, instead
doing nothing.

This change therefore also adds a check if the table is dropped *or
importing* and treats it, from the point of view of lease management, as
if it is dropped i.e. leases should be releases and traffic to it should
stop.

With these changes, IMPORT INTO no longer hangs waiting for the table to
become offline.

Release note: none.