### PR TITLE
exec: eagerly fail if any flows aren't vectorizable

### DIFF
--- a/pkg/sql/distsqlrun/colbatch_scan.go
+++ b/pkg/sql/distsqlrun/colbatch_scan.go
@@ -64,7 +64,7 @@ func (s *colBatchScan) Next(ctx context.Context) coldata.Batch {
 func (s *colBatchScan) DrainMeta(ctx context.Context) []distsqlpb.ProducerMetadata {
 	var trailingMeta []distsqlpb.ProducerMetadata
 	if !s.flowCtx.local {
-		ranges := misplannedRanges(ctx, s.rf.GetRangesInfo(), s.flowCtx.nodeID)
+		ranges := misplannedRanges(ctx, s.rf.GetRangesInfo(), s.flowCtx.NodeID)
 		if ranges != nil {
 			trailingMeta = append(trailingMeta, distsqlpb.ProducerMetadata{Ranges: ranges})
 		}
@@ -79,7 +79,7 @@ func (s *colBatchScan) DrainMeta(ctx context.Context) []distsqlpb.ProducerMetada
 func newColBatchScan(
 	flowCtx *FlowCtx, spec *distsqlpb.TableReaderSpec, post *distsqlpb.PostProcessSpec,
 ) (*colBatchScan, error) {
-	if flowCtx.nodeID == 0 {
+	if flowCtx.NodeID == 0 {
 		return nil, errors.Errorf("attempting to create a colBatchScan with uninitialized NodeID")
 	}
 

--- a/pkg/sql/distsqlrun/colbatch_scan_test.go
+++ b/pkg/sql/distsqlrun/colbatch_scan_test.go
@@ -62,7 +62,7 @@ func BenchmarkColBatchScan(b *testing.B) {
 				EvalCtx:  &evalCtx,
 				Settings: s.ClusterSettings(),
 				txn:      client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
-				nodeID:   s.NodeID(),
+				NodeID:   s.NodeID(),
 			}
 
 			b.SetBytes(int64(numRows * numCols * 8))

--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -507,7 +507,7 @@ func newColOperator(
 		memUsage += sMemOp.EstimateStaticMemoryUsage()
 	}
 
-	log.VEventf(ctx, 1, "Made op %T\n", op)
+	log.VEventf(ctx, 1, "made op %T\n", op)
 
 	if err != nil {
 		return nil, nil, memUsage, err

--- a/pkg/sql/distsqlrun/columnarizer.go
+++ b/pkg/sql/distsqlrun/columnarizer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types/conv"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
@@ -33,6 +34,7 @@ type columnarizer struct {
 	batch           coldata.Batch
 	accumulatedMeta []distsqlpb.ProducerMetadata
 	ctx             context.Context
+	typs            []types.T
 }
 
 var _ exec.Operator = &columnarizer{}
@@ -42,11 +44,12 @@ var _ exec.StaticMemoryOperator = &columnarizer{}
 func newColumnarizer(
 	ctx context.Context, flowCtx *FlowCtx, processorID int32, input RowSource,
 ) (*columnarizer, error) {
+	var err error
 	c := &columnarizer{
 		input: input,
 		ctx:   ctx,
 	}
-	if err := c.ProcessorBase.Init(
+	if err = c.ProcessorBase.Init(
 		nil,
 		&distsqlpb.PostProcessSpec{},
 		input.OutputTypes(),
@@ -58,21 +61,20 @@ func newColumnarizer(
 	); err != nil {
 		return nil, err
 	}
-	c.Init()
+	c.typs, err = conv.FromColumnTypes(c.OutputTypes())
 
-	return c, nil
+	return c, err
 }
 
 func (c *columnarizer) EstimateStaticMemoryUsage() int {
-	return exec.EstimateBatchSizeBytes(conv.FromColumnTypes(c.OutputTypes()), coldata.BatchSize)
+	return exec.EstimateBatchSizeBytes(c.typs, coldata.BatchSize)
 }
 
 func (c *columnarizer) Init() {
-	typs := conv.FromColumnTypes(c.OutputTypes())
-	c.batch = coldata.NewMemBatch(typs)
+	c.batch = coldata.NewMemBatch(c.typs)
 	c.buffered = make(sqlbase.EncDatumRows, coldata.BatchSize)
 	for i := range c.buffered {
-		c.buffered[i] = make(sqlbase.EncDatumRow, len(typs))
+		c.buffered[i] = make(sqlbase.EncDatumRow, len(c.typs))
 	}
 	c.accumulatedMeta = make([]distsqlpb.ProducerMetadata, 0, 1)
 	c.input.Start(c.ctx)

--- a/pkg/sql/distsqlrun/columnarizer_test.go
+++ b/pkg/sql/distsqlrun/columnarizer_test.go
@@ -43,6 +43,7 @@ func BenchmarkColumnarize(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
+	c.Init()
 	for i := 0; i < b.N; i++ {
 		foundRows := 0
 		for {

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -499,6 +499,7 @@ func (f *Flow) setup(ctx context.Context, spec *distsqlpb.FlowSpec) error {
 	f.spec = spec
 
 	if f.EvalCtx.SessionData.Vectorize != sessiondata.VectorizeOff {
+		log.VEventf(ctx, 1, "attempting to vectorize flow %d with setting %s", f.id, f.EvalCtx.SessionData.Vectorize)
 		acc := f.EvalCtx.Mon.MakeBoundAccount()
 		f.vectorizedBoundAccount = &acc
 		err := f.setupVectorized(ctx, f.vectorizedBoundAccount)

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -85,7 +85,7 @@ type FlowCtx struct {
 
 	// nodeID is the ID of the node on which the processors using this FlowCtx
 	// run.
-	nodeID       roachpb.NodeID
+	NodeID       roachpb.NodeID
 	testingKnobs TestingKnobs
 
 	// TempStorage is used by some DistSQL processors to store Rows when the
@@ -507,7 +507,7 @@ func (f *Flow) setup(ctx context.Context, spec *distsqlpb.FlowSpec) error {
 			return nil
 		}
 		// Vectorization attempt failed with an error.
-		if f.spec.Gateway != f.nodeID {
+		if f.spec.Gateway != f.NodeID {
 			// If we are not the gateway node, do not attempt to plan this with the
 			// row execution branch since there is no way to tell whether vectorized
 			// planning will succeed on any other node. Notify the gateway by
@@ -534,7 +534,7 @@ func (f *Flow) setup(ctx context.Context, spec *distsqlpb.FlowSpec) error {
 				rsidx := spec.Processors[0].Core.LocalPlanNode.RowSourceIdx
 				if rsidx != nil {
 					lp := f.localProcessors[*rsidx]
-					if z, ok := lp.(vectorizeAlwaysException); ok {
+					if z, ok := lp.(VectorizeAlwaysException); ok {
 						isException = z.IsException()
 					}
 				}

--- a/pkg/sql/distsqlrun/index_skip_table_reader.go
+++ b/pkg/sql/distsqlrun/index_skip_table_reader.go
@@ -70,7 +70,7 @@ func newIndexSkipTableReader(
 	post *distsqlpb.PostProcessSpec,
 	output RowReceiver,
 ) (*indexSkipTableReader, error) {
-	if flowCtx.nodeID == 0 {
+	if flowCtx.NodeID == 0 {
 		return nil, errors.Errorf("attempting to create a tableReader with uninitialized NodeID")
 	}
 
@@ -175,7 +175,7 @@ func (t *indexSkipTableReader) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerM
 		// Range info resets once a scan begins, so we need to maintain
 		// the range info we get after each scan.
 		if !t.ignoreMisplannedRanges {
-			ranges := misplannedRanges(t.Ctx, t.fetcher.GetRangesInfo(), t.flowCtx.nodeID)
+			ranges := misplannedRanges(t.Ctx, t.fetcher.GetRangesInfo(), t.flowCtx.NodeID)
 			for _, r := range ranges {
 				t.misplannedRanges = roachpb.InsertRangeInfo(t.misplannedRanges, r)
 			}

--- a/pkg/sql/distsqlrun/index_skip_table_reader_test.go
+++ b/pkg/sql/distsqlrun/index_skip_table_reader_test.go
@@ -407,7 +407,7 @@ func TestIndexSkipTableReader(t *testing.T) {
 				EvalCtx:  &evalCtx,
 				Settings: s.ClusterSettings(),
 				txn:      client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
-				nodeID:   s.NodeID(),
+				NodeID:   s.NodeID(),
 			}
 
 			tr, err := newIndexSkipTableReader(&flowCtx, 0 /* processorID */, &ts, &c.post, nil)
@@ -478,7 +478,7 @@ ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[
 		EvalCtx:  &evalCtx,
 		Settings: st,
 		txn:      client.NewTxn(ctx, tc.Server(0).DB(), nodeID, client.RootTxn),
-		nodeID:   nodeID,
+		NodeID:   nodeID,
 	}
 	spec := distsqlpb.IndexSkipTableReaderSpec{
 		Spans: []distsqlpb.TableReaderSpan{{Span: td.PrimaryIndexSpan()}},
@@ -602,7 +602,7 @@ func BenchmarkIndexScanTableReader(b *testing.B) {
 				EvalCtx:  &evalCtx,
 				Settings: s.ClusterSettings(),
 				txn:      client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
-				nodeID:   s.NodeID(),
+				NodeID:   s.NodeID(),
 			}
 
 			b.Run(fmt.Sprintf("TableReader+Distinct-rows=%d-ratio=%d", numRows, valueRatio), func(b *testing.B) {
@@ -639,7 +639,7 @@ func BenchmarkIndexScanTableReader(b *testing.B) {
 				EvalCtx:  &evalCtx,
 				Settings: s.ClusterSettings(),
 				txn:      client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
-				nodeID:   s.NodeID(),
+				NodeID:   s.NodeID(),
 			}
 
 			// run the index skip table reader

--- a/pkg/sql/distsqlrun/interleaved_reader_joiner.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner.go
@@ -276,7 +276,7 @@ func newInterleavedReaderJoiner(
 	post *distsqlpb.PostProcessSpec,
 	output RowReceiver,
 ) (*interleavedReaderJoiner, error) {
-	if flowCtx.nodeID == 0 {
+	if flowCtx.NodeID == 0 {
 		return nil, errors.AssertionFailedf("attempting to create an interleavedReaderJoiner with uninitialized NodeID")
 	}
 
@@ -430,7 +430,7 @@ func (irj *interleavedReaderJoiner) generateTrailingMeta(
 
 func (irj *interleavedReaderJoiner) generateMeta(ctx context.Context) []distsqlpb.ProducerMetadata {
 	var trailingMeta []distsqlpb.ProducerMetadata
-	ranges := misplannedRanges(ctx, irj.fetcher.GetRangesInfo(), irj.flowCtx.nodeID)
+	ranges := misplannedRanges(ctx, irj.fetcher.GetRangesInfo(), irj.flowCtx.NodeID)
 	if ranges != nil {
 		trailingMeta = append(trailingMeta, distsqlpb.ProducerMetadata{Ranges: ranges})
 	}

--- a/pkg/sql/distsqlrun/interleaved_reader_joiner_test.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner_test.go
@@ -400,7 +400,7 @@ func TestInterleavedReaderJoiner(t *testing.T) {
 				Settings: s.ClusterSettings(),
 				// Run in a RootTxn so that there's no txn metadata produced.
 				txn:    client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
-				nodeID: s.NodeID(),
+				NodeID: s.NodeID(),
 			}
 
 			out := &RowBuffer{}
@@ -530,7 +530,7 @@ func TestInterleavedReaderJoinerErrors(t *testing.T) {
 				Settings: s.ClusterSettings(),
 				// Run in a RootTxn so that there's no txn metadata produced.
 				txn:    client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
-				nodeID: s.NodeID(),
+				NodeID: s.NodeID(),
 			}
 
 			out := &RowBuffer{}
@@ -588,7 +588,7 @@ func TestInterleavedReaderJoinerTrailingMetadata(t *testing.T) {
 		Settings: s.ClusterSettings(),
 		// Run in a LeafTxn so that txn metadata is produced.
 		txn:    client.NewTxn(ctx, s.DB(), s.NodeID(), client.LeafTxn),
-		nodeID: s.NodeID(),
+		NodeID: s.NodeID(),
 	}
 
 	innerJoinSpec := distsqlpb.InterleavedReaderJoinerSpec{

--- a/pkg/sql/distsqlrun/materializer_test.go
+++ b/pkg/sql/distsqlrun/materializer_test.go
@@ -62,6 +62,7 @@ func TestColumnarizeMaterialize(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	m.Start(ctx)
 
 	for i := 0; i < nRows; i++ {
 		row, meta := m.Next()
@@ -146,6 +147,7 @@ func TestMaterializeTypes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	m.Start(ctx)
 
 	row, meta := m.Next()
 	if meta != nil {
@@ -199,6 +201,7 @@ func BenchmarkColumnarizeMaterialize(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
+		m.Start(ctx)
 
 		foundRows := 0
 		for {

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -1213,12 +1213,12 @@ type LocalProcessor interface {
 	SetInput(ctx context.Context, input RowSource) error
 }
 
-// vectorizeAlwaysException is an object that returns whether or not execution
+// VectorizeAlwaysException is an object that returns whether or not execution
 // should continue if experimental_vectorize=always and an error occurred when
 // setting up the vectorized flow. Consider the case in which
 // experimental_vectorize=always. The user must be able to unset this session
 // variable without getting an error.
-type vectorizeAlwaysException interface {
+type VectorizeAlwaysException interface {
 	// IsException returns whether this object should be an exception to the rule
 	// that an inability to run this node in a vectorized flow should produce an
 	// error.

--- a/pkg/sql/distsqlrun/scrub_tablereader.go
+++ b/pkg/sql/distsqlrun/scrub_tablereader.go
@@ -67,7 +67,7 @@ func newScrubTableReader(
 	post *distsqlpb.PostProcessSpec,
 	output RowReceiver,
 ) (*scrubTableReader, error) {
-	if flowCtx.nodeID == 0 {
+	if flowCtx.NodeID == 0 {
 		return nil, errors.Errorf("attempting to create a tableReader with uninitialized NodeID")
 	}
 	if flowCtx.txn == nil {

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -451,7 +451,7 @@ func (ds *ServerImpl) setupFlow(
 		executor:       ds.Executor,
 		LeaseManager:   ds.LeaseManager,
 		testingKnobs:   ds.TestingKnobs,
-		nodeID:         nodeID,
+		NodeID:         nodeID,
 		TempStorage:    ds.TempStorage,
 		BulkAdder:      ds.BulkAdder,
 		diskMonitor:    ds.DiskMonitor,

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -96,7 +96,7 @@ func newTableReader(
 	post *distsqlpb.PostProcessSpec,
 	output RowReceiver,
 ) (*tableReader, error) {
-	if flowCtx.nodeID == 0 {
+	if flowCtx.NodeID == 0 {
 		return nil, errors.Errorf("attempting to create a tableReader with uninitialized NodeID")
 	}
 
@@ -328,7 +328,7 @@ func (tr *tableReader) outputStatsToTrace() {
 func (tr *tableReader) generateMeta(ctx context.Context) []distsqlpb.ProducerMetadata {
 	var trailingMeta []distsqlpb.ProducerMetadata
 	if !tr.ignoreMisplannedRanges {
-		ranges := misplannedRanges(ctx, tr.fetcher.GetRangesInfo(), tr.flowCtx.nodeID)
+		ranges := misplannedRanges(ctx, tr.fetcher.GetRangesInfo(), tr.flowCtx.NodeID)
 		if ranges != nil {
 			trailingMeta = append(trailingMeta, distsqlpb.ProducerMetadata{Ranges: ranges})
 		}

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -129,7 +129,7 @@ func TestTableReader(t *testing.T) {
 					EvalCtx:  &evalCtx,
 					Settings: s.ClusterSettings(),
 					txn:      client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
-					nodeID:   s.NodeID(),
+					NodeID:   s.NodeID(),
 				}
 
 				var out RowReceiver
@@ -214,7 +214,7 @@ ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[
 		EvalCtx:  &evalCtx,
 		Settings: st,
 		txn:      client.NewTxn(ctx, tc.Server(0).DB(), nodeID, client.RootTxn),
-		nodeID:   nodeID,
+		NodeID:   nodeID,
 	}
 	spec := distsqlpb.TableReaderSpec{
 		Spans: []distsqlpb.TableReaderSpan{{Span: td.PrimaryIndexSpan()}},
@@ -319,7 +319,7 @@ func TestLimitScans(t *testing.T) {
 		EvalCtx:  &evalCtx,
 		Settings: s.ClusterSettings(),
 		txn:      client.NewTxn(ctx, kvDB, s.NodeID(), client.RootTxn),
-		nodeID:   s.NodeID(),
+		NodeID:   s.NodeID(),
 	}
 	spec := distsqlpb.TableReaderSpec{
 		Table: *tableDesc,
@@ -423,7 +423,7 @@ func BenchmarkTableReader(b *testing.B) {
 			EvalCtx:  &evalCtx,
 			Settings: s.ClusterSettings(),
 			txn:      client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
-			nodeID:   s.NodeID(),
+			NodeID:   s.NodeID(),
 		}
 
 		b.Run(fmt.Sprintf("rows=%d", numRows), func(b *testing.B) {

--- a/pkg/sql/distsqlrun/vectorized_meta_propagation_test.go
+++ b/pkg/sql/distsqlrun/vectorized_meta_propagation_test.go
@@ -94,6 +94,7 @@ func TestVectorizedMetaPropagation(t *testing.T) {
 	if !ok {
 		t.Fatal("MetadataTestReceiver is not a RowSource")
 	}
+	mtrAsRowSource.Start(ctx)
 
 	rowCount, metaCount := 0, 0
 	for {

--- a/pkg/sql/exec/types/conv/conv.go
+++ b/pkg/sql/exec/types/conv/conv.go
@@ -52,12 +52,15 @@ func FromColumnType(ct *semtypes.T) types.T {
 
 // FromColumnTypes calls FromColumnType on each element of cts, returning the
 // resulting slice.
-func FromColumnTypes(cts []semtypes.T) []types.T {
+func FromColumnTypes(cts []semtypes.T) ([]types.T, error) {
 	typs := make([]types.T, len(cts))
 	for i := range typs {
 		typs[i] = FromColumnType(&cts[i])
+		if typs[i] == types.Unhandled {
+			return nil, errors.Errorf("unsupported type %s", cts[i].String())
+		}
 	}
-	return typs
+	return typs, nil
 }
 
 // GetDatumToPhysicalFn returns a function for converting a datum of the given


### PR DESCRIPTION
- First commit makes NodeID and VectorizeAlwaysException public.
    
We will need to have access to these from sql package.

- Second commit checks for an unhandled type during type conversion.
    
Previously, we would convert semantic types to exec types without
paying attention whether we encountered an unhandled type. Now, we
return an error in such cases.

Also, a bug in the columnarizer that it was calling Init on itself
upon its creation is now fixed.

- Third commit eagerly fails if any flows aren't vectorizable.

Before setting up flows on remote nodes, we now iterate over all flows
locally and check to see whether they're vectorizable or not. If any of
them are not vectorizable, we either fall back or error out depending on
the setting. If they are all vectorizable, we continue on.

This PR is based on #38977 with some fixes from #38981.