### PR TITLE
storageccl: un-experimentalize the workload ExportStorage

### DIFF
--- a/pkg/ccl/storageccl/export_storage.go
+++ b/pkg/ccl/storageccl/export_storage.go
@@ -162,7 +162,7 @@ func ExportStorageConfFromURI(path string) (roachpb.ExportStorage, error) {
 		conf.Provider = roachpb.ExportStorageProvider_LocalFile
 		conf.LocalFile.Path = uri.Path
 		conf.LocalFile.NodeID = roachpb.NodeID(nodeID)
-	case "experimental-workload":
+	case "experimental-workload", "workload":
 		conf.Provider = roachpb.ExportStorageProvider_Workload
 		if conf.WorkloadConfig, err = ParseWorkloadConfig(uri); err != nil {
 			return conf, err
@@ -191,7 +191,7 @@ func SanitizeExportStorageURI(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if uri.Scheme == "experimental-workload" {
+	if uri.Scheme == "experimental-workload" || uri.Scheme == "workload" {
 		return path, nil
 	}
 	// All current export storage providers store credentials in the query string,

--- a/pkg/ccl/storageccl/export_storage_test.go
+++ b/pkg/ccl/storageccl/export_storage_test.go
@@ -542,7 +542,7 @@ func TestWorkloadStorage(t *testing.T) {
 			}
 		}
 		return &url.URL{
-			Scheme:   `experimental-workload`,
+			Scheme:   `workload`,
 			Path:     `/` + path.Join(`csv`, gen.Meta().Name, bankTable.Name),
 			RawQuery: params.Encode(),
 		}
@@ -579,16 +579,16 @@ func TestWorkloadStorage(t *testing.T) {
 		`), strings.TrimSpace(string(bytes)))
 	}
 
-	_, err := ExportStorageFromURI(ctx, `experimental-workload:///nope`, settings)
+	_, err := ExportStorageFromURI(ctx, `workload:///nope`, settings)
 	require.EqualError(t, err, `path must be of the form /<format>/<generator>/<table>: /nope`)
-	_, err = ExportStorageFromURI(ctx, `experimental-workload:///fmt/bank/bank?version=`, settings)
+	_, err = ExportStorageFromURI(ctx, `workload:///fmt/bank/bank?version=`, settings)
 	require.EqualError(t, err, `unsupported format: fmt`)
-	_, err = ExportStorageFromURI(ctx, `experimental-workload:///csv/nope/nope?version=`, settings)
+	_, err = ExportStorageFromURI(ctx, `workload:///csv/nope/nope?version=`, settings)
 	require.EqualError(t, err, `unknown generator: nope`)
-	_, err = ExportStorageFromURI(ctx, `experimental-workload:///csv/bank/bank`, settings)
+	_, err = ExportStorageFromURI(ctx, `workload:///csv/bank/bank`, settings)
 	require.EqualError(t, err, `parameter version is required`)
-	_, err = ExportStorageFromURI(ctx, `experimental-workload:///csv/bank/bank?version=`, settings)
+	_, err = ExportStorageFromURI(ctx, `workload:///csv/bank/bank?version=`, settings)
 	require.EqualError(t, err, `expected bank version "" but got "1.0.0"`)
-	_, err = ExportStorageFromURI(ctx, `experimental-workload:///csv/bank/bank?version=nope`, settings)
+	_, err = ExportStorageFromURI(ctx, `workload:///csv/bank/bank?version=nope`, settings)
 	require.EqualError(t, err, `expected bank version "nope" but got "1.0.0"`)
 }

--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -330,7 +330,7 @@ func ImportFixture(
 
 	pathPrefix := csvServer
 	if pathPrefix == `` {
-		pathPrefix = `experimental-workload://`
+		pathPrefix = `workload://`
 	}
 
 	for _, t := range tables {

--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -323,7 +323,7 @@ func makeSchemaChangeBulkIngestTest(numNodes, numRows int, length time.Duration)
 		Name:    "schemachange/bulkingest",
 		Cluster: makeClusterSpec(numNodes),
 		Timeout: length * 2,
-		// `fixtures import` (with the experimental-workload paths) is not supported in 2.1
+		// `fixtures import` (with the workload paths) is not supported in 2.1
 		MinVersion: "v19.1.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			// Configure column a to have sequential ascending values, and columns b and c to be constant.


### PR DESCRIPTION
This has been stable since it was introduced, seems fine to commit to
supporting it.

If any roachtests are using the standalone workload binary with fixtures
import and not using the --csv-server option, this will break them on
the release branches. I don't see any though.

Release note: None