### PR TITLE
build: add ui-clean target to clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1534,7 +1534,7 @@ clean-execgen-files:
 
 .PHONY: clean
 clean: ## Remove build artifacts.
-clean: clean-c-deps clean-execgen-files
+clean: clean-c-deps clean-execgen-files ui-clean
 	rm -rf bin/.go_protobuf_sources bin/.gw_protobuf_sources bin/.cpp_protobuf_sources build/defs.mk*
 	$(GO) clean $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -i -cache github.com/cockroachdb/cockroach...
 	$(FIND_RELEVANT) -type f \( -name 'zcgo_flags*.go' -o -name '*.test' \) -exec rm {} +

--- a/build/verify-archive.sh
+++ b/build/verify-archive.sh
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 apt-get update
-apt-get install -y autoconf bison cmake libncurses-dev
+apt-get install -y autoconf bison cmake libncurses-dev nodejs
 
 workdir=$(mktemp -d)
 tar xzf cockroach.src.tgz -C "$workdir"


### PR DESCRIPTION
I recently ran into a problem when I couldn't build cockroach
after doing `make clean` due to having leftover javascript stuff
that is cleaned with `ui-clean`.

Release note: None