### PR TITLE
sql: avoid pointless string concatenation in connExecutor.execCmd

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1170,7 +1170,7 @@ func (ex *connExecutor) execCmd(ctx context.Context) error {
 		ctx, ex.server.cfg.AmbientCtx.Tracer,
 		// We print the type of command, not the String() which includes long
 		// statements.
-		"exec cmd: "+cmd.command())
+		cmd.command())
 	defer sp.Finish()
 
 	if log.ExpensiveLogEnabled(ctx, 2) || ex.eventLog != nil {

--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -114,7 +114,7 @@ type StmtBuf struct {
 type Command interface {
 	fmt.Stringer
 	// command returns a string representation of the command type (e.g.
-	// "prepare", "exec stmt").
+	// "prepare stmt", "exec stmt").
 	command() string
 }
 
@@ -190,7 +190,7 @@ type PrepareStmt struct {
 }
 
 // command implements the Command interface.
-func (PrepareStmt) command() string { return "prepare" }
+func (PrepareStmt) command() string { return "prepare stmt" }
 
 func (p PrepareStmt) String() string {
 	// We have the original SQL, but we still use String() because it obfuscates
@@ -213,7 +213,7 @@ type DescribeStmt struct {
 }
 
 // command implements the Command interface.
-func (DescribeStmt) command() string { return "describe" }
+func (DescribeStmt) command() string { return "describe stmt" }
 
 func (d DescribeStmt) String() string {
 	return fmt.Sprintf("Describe: %q", d.Name)
@@ -253,7 +253,7 @@ type BindStmt struct {
 }
 
 // command implements the Command interface.
-func (BindStmt) command() string { return "bind" }
+func (BindStmt) command() string { return "bind stmt" }
 
 func (b BindStmt) String() string {
 	return fmt.Sprintf("BindStmt: %q->%q", b.PreparedStatementName, b.PortalName)
@@ -268,7 +268,7 @@ type DeletePreparedStmt struct {
 }
 
 // command implements the Command interface.
-func (DeletePreparedStmt) command() string { return "delete" }
+func (DeletePreparedStmt) command() string { return "delete stmt" }
 
 func (d DeletePreparedStmt) String() string {
 	return fmt.Sprintf("DeletePreparedStmt: %q", d.Name)

--- a/pkg/sql/logictest/testdata/planner_test/interleaved
+++ b/pkg/sql/logictest/testdata/planner_test/interleaved
@@ -241,7 +241,7 @@ SET TRACING = on,kv,results; DELETE FROM a where a_id <= 7 and a_id >= 5; SET tr
 # Only look at traces from SQL land.
 query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION]
-WHERE operation='flow' OR operation LIKE 'exec cmd:%'
+WHERE operation='flow' OR operation='exec stmt'
 ----
 DelRange /Table/61/1/5 - /Table/61/1/7/NULL
 fast path completed
@@ -282,7 +282,7 @@ SET TRACING = on,kv,results; DELETE FROM a; SET tracing = off
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION]
-WHERE operation='flow' OR operation LIKE 'exec cmd:%'
+WHERE operation='flow' OR operation='exec stmt'
 ----
 DelRange /Table/61/1 - /Table/61/3
 fast path completed
@@ -324,7 +324,7 @@ SET TRACING=off;
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION]
-WHERE operation IN ('flow', 'consuming rows') OR operation LIKE 'exec cmd:%'
+WHERE operation IN ('flow', 'consuming rows') OR operation='exec stmt'
 ----
 Del /Table/61/1/1/0
 cascading delete into table: 62 using index: 1

--- a/pkg/sql/logictest/testdata/planner_test/select
+++ b/pkg/sql/logictest/testdata/planner_test/select
@@ -18,28 +18,28 @@ FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%SPAN START%' OR message LIKE '%pos%executing%';
 ----
 0                         === SPAN START: session recording ===                session recording
-1                         === SPAN START: exec cmd: exec stmt ===              exec cmd: exec stmt
-1                         [NoTxn pos:?] executing ExecStmt: BEGIN TRANSACTION  exec cmd: exec stmt
+1                         === SPAN START: exec stmt ===                        exec stmt
+1                         [NoTxn pos:?] executing ExecStmt: BEGIN TRANSACTION  exec stmt
 2                         === SPAN START: sql txn ===                          sql txn
-3                         === SPAN START: exec cmd: exec stmt ===              exec cmd: exec stmt
-3                         [Open pos:?] executing ExecStmt: SELECT 1            exec cmd: exec stmt
+3                         === SPAN START: exec stmt ===                        exec stmt
+3                         [Open pos:?] executing ExecStmt: SELECT 1            exec stmt
 4                         === SPAN START: consuming rows ===                   consuming rows
 5                         === SPAN START: flow ===                             flow
 13                        === SPAN START: values ===
 cockroach.processorid: 0  values
-6                         === SPAN START: exec cmd: exec stmt ===              exec cmd: exec stmt
-6                         [Open pos:?] executing ExecStmt: COMMIT TRANSACTION  exec cmd: exec stmt
-7                         === SPAN START: exec cmd: exec stmt ===              exec cmd: exec stmt
-7                         [NoTxn pos:?] executing ExecStmt: SELECT 2           exec cmd: exec stmt
+6                         === SPAN START: exec stmt ===                        exec stmt
+6                         [Open pos:?] executing ExecStmt: COMMIT TRANSACTION  exec stmt
+7                         === SPAN START: exec stmt ===                        exec stmt
+7                         [NoTxn pos:?] executing ExecStmt: SELECT 2           exec stmt
 8                         === SPAN START: sql txn ===                          sql txn
-9                         === SPAN START: exec cmd: exec stmt ===              exec cmd: exec stmt
-9                         [Open pos:?] executing ExecStmt: SELECT 2            exec cmd: exec stmt
+9                         === SPAN START: exec stmt ===                        exec stmt
+9                         [Open pos:?] executing ExecStmt: SELECT 2            exec stmt
 10                        === SPAN START: consuming rows ===                   consuming rows
 11                        === SPAN START: flow ===                             flow
 14                        === SPAN START: values ===
 cockroach.processorid: 0  values
-12                        === SPAN START: exec cmd: exec stmt ===              exec cmd: exec stmt
-12                        [NoTxn pos:?] executing ExecStmt: SET TRACING = off  exec cmd: exec stmt
+12                        === SPAN START: exec stmt ===                        exec stmt
+12                        [NoTxn pos:?] executing ExecStmt: SET TRACING = off  exec stmt
 
 # ------------------------------------------------------------------------------
 # Test with storing columns.

--- a/pkg/sql/logictest/testdata/planner_test/show_trace
+++ b/pkg/sql/logictest/testdata/planner_test/show_trace
@@ -21,9 +21,9 @@ WHERE message NOT LIKE '%Z/%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow                 CPut /Table/2/1/0/"t"/3/1 -> 53
-flow                 CPut /Table/3/1/53/2/1 -> database:<name:"t" id:53 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > >
-exec cmd: exec stmt  rows affected: 0
+flow       CPut /Table/2/1/0/"t"/3/1 -> 53
+flow       CPut /Table/3/1/53/2/1 -> database:<name:"t" id:53 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > >
+exec stmt  rows affected: 0
 
 
 # More KV operations.
@@ -41,9 +41,9 @@ WHERE message NOT LIKE '%Z/%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow                 CPut /Table/2/1/53/"kv"/3/1 -> 54
-flow                 CPut /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:false hidden:false > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<wall_time:... > >
-exec cmd: exec stmt  rows affected: 0
+flow       CPut /Table/2/1/53/"kv"/3/1 -> 54
+flow       CPut /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:false hidden:false > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<wall_time:... > >
+exec stmt  rows affected: 0
 
 # We avoid using the full trace output, because that would make the
 # ensuing trace especially chatty, as it traces the index backfill at
@@ -68,8 +68,8 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow                 Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:2 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:false hidden:false > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_ONLY direction:ADD mutation_id:1 rollback:false > next_mutation_id:2 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<wall_time:... > >
-exec cmd: exec stmt  rows affected: 0
+flow       Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:2 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:false hidden:false > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_ONLY direction:ADD mutation_id:1 rollback:false > next_mutation_id:2 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<wall_time:... > >
+exec stmt  rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = off
@@ -82,7 +82,7 @@ flow                                  CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
 flow                                  InitPut /Table/54/2/2/0 -> /BYTES/0x89
 kv.DistSender: sending partial batch  r20: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
 flow                                  fast path completed
-exec cmd: exec stmt                   rows affected: 1
+exec stmt                             rows affected: 1
 
 
 statement error duplicate key value
@@ -96,7 +96,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 flow                                  CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
 flow                                  InitPut /Table/54/2/2/0 -> /BYTES/0x89
 kv.DistSender: sending partial batch  r20: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
-exec cmd: exec stmt                   execution failed after 0 rows: duplicate key value (k)=(1) violates unique constraint "primary"
+exec stmt                             execution failed after 0 rows: duplicate key value (k)=(1) violates unique constraint "primary"
 
 statement error duplicate key value
 SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (2,2); SET tracing = off
@@ -109,7 +109,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 flow                                  CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/2
 flow                                  InitPut /Table/54/2/2/0 -> /BYTES/0x8a
 kv.DistSender: sending partial batch  r20: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
-exec cmd: exec stmt                   execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
+exec stmt                             execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
 
 statement ok
 SET tracing = on,kv,results; CREATE TABLE t.kv2 AS TABLE t.kv; SET tracing = off
@@ -125,10 +125,10 @@ WHERE message NOT LIKE '%Z/%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-table reader         Scan /Table/54/{1-2}
-flow                 CPut /Table/2/1/53/"kv2"/3/1 -> 55
-flow                 CPut /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:ADD view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"TABLE t.public.kv" create_as_of_time:<wall_time:... > >
-exec cmd: exec stmt  rows affected: 0
+table reader  Scan /Table/54/{1-2}
+flow          CPut /Table/2/1/53/"kv2"/3/1 -> 55
+flow          CPut /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:ADD view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"TABLE t.public.kv" create_as_of_time:<wall_time:... > >
+exec stmt     rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; UPDATE t.kv2 SET v = v + 2; SET tracing = off
@@ -148,7 +148,7 @@ table reader                                             Scan /Table/55/{1-2}
 table reader                                             fetched: /kv2/primary/1/k/v -> /1/2
 flow                                                     Put /Table/55/1/1/0 -> /TUPLE/1:1:Int/1/1:2:Int/4
 flow                                                     fast path completed
-exec cmd: exec stmt                                      rows affected: 1
+exec stmt                                                rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DELETE FROM t.kv2; SET tracing = off
@@ -157,9 +157,9 @@ query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-flow                 DelRange /Table/55/1 - /Table/55/2
-flow                 fast path completed
-exec cmd: exec stmt  rows affected: 1
+flow       DelRange /Table/55/1 - /Table/55/2
+flow       fast path completed
+exec stmt  rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DROP TABLE t.kv2; SET tracing = off
@@ -176,8 +176,8 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow                 Put /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:3 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv2" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... create_query:"TABLE t.public.kv" create_as_of_time:<wall_time:... > >
-exec cmd: exec stmt  rows affected: 0
+flow       Put /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:3 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv2" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... create_query:"TABLE t.public.kv" create_as_of_time:<wall_time:... > >
+exec stmt  rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; DELETE FROM t.kv; SET tracing = off
@@ -192,7 +192,7 @@ flow                                  Del /Table/54/2/2/0
 flow                                  Del /Table/54/1/1/0
 kv.DistSender: sending partial batch  r20: sending batch 1 Del to (n1,s1):1
 flow                                  fast path completed
-exec cmd: exec stmt                   rows affected: 1
+exec stmt                             rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DROP INDEX t.kv@woo CASCADE; SET tracing = off
@@ -211,8 +211,8 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow                 Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:5 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:false hidden:false > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_AND_WRITE_ONLY direction:DROP mutation_id:2 rollback:false > next_mutation_id:3 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<wall_time:... > >
-exec cmd: exec stmt  rows affected: 0
+flow       Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:5 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:false hidden:false > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_AND_WRITE_ONLY direction:DROP mutation_id:2 rollback:false > next_mutation_id:3 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<wall_time:... > >
+exec stmt  rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; DROP TABLE t.kv; SET tracing = off
@@ -228,8 +228,8 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow                 Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:8 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:false hidden:false > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:3 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... gc_mutations:<index_id:2 drop_time:... job_id:... > create_query:"" create_as_of_time:<wall_time:... > >
-exec cmd: exec stmt  rows affected: 0
+flow       Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:8 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:false hidden:false > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:3 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... gc_mutations:<index_id:2 drop_time:... job_id:... > create_query:"" create_as_of_time:<wall_time:... > >
+exec stmt  rows affected: 0
 
 # Check that session tracing does not inhibit the fast path for inserts &
 # friends (the path resulting in 1PC transactions).

--- a/pkg/sql/logictest/testdata/planner_test/upsert
+++ b/pkg/sql/logictest/testdata/planner_test/upsert
@@ -64,7 +64,7 @@ flow                                  CPut /Table/56/1/2/0 -> /TUPLE/2:2:Int/3
 flow                                  InitPut /Table/56/2/3/0 -> /BYTES/0x8a
 kv.DistSender: sending partial batch  r20: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
 flow                                  fast path completed
-exec cmd: exec stmt                   rows affected: 1
+exec stmt                             rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = off
@@ -78,7 +78,7 @@ flow                                  CPut /Table/56/1/1/0 -> /TUPLE/2:2:Int/2
 flow                                  InitPut /Table/56/2/2/0 -> /BYTES/0x89
 kv.DistSender: sending partial batch  r20: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
 flow                                  fast path completed
-exec cmd: exec stmt                   rows affected: 1
+exec stmt                             rows affected: 1
 
 statement error duplicate key value
 SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (2,2); SET tracing = off
@@ -94,7 +94,7 @@ flow                                  Put /Table/56/1/2/0 -> /TUPLE/2:2:Int/2
 flow                                  Del /Table/56/2/3/0
 flow                                  CPut /Table/56/2/2/0 -> /BYTES/0x8a (expecting does not exist)
 kv.DistSender: sending partial batch  r20: sending batch 1 Put, 1 EndTxn to (n1,s1):1
-exec cmd: exec stmt                   execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
+exec stmt                             execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
 
 subtest regression_32834
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/interleaved
+++ b/pkg/sql/opt/exec/execbuilder/testdata/interleaved
@@ -241,7 +241,7 @@ SET TRACING = on,kv,results; DELETE FROM a where a_id <= 7 and a_id >= 5; SET tr
 # Only look at traces from SQL land.
 query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION]
-WHERE operation='flow' OR operation LIKE 'exec cmd:%'
+WHERE operation='flow' OR operation='exec stmt'
 ----
 DelRange /Table/61/1/5 - /Table/61/1/7/NULL
 fast path completed
@@ -282,7 +282,7 @@ SET TRACING = on,kv,results; DELETE FROM a; SET tracing = off
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION]
-WHERE operation='flow' OR operation LIKE 'exec cmd:%'
+WHERE operation='flow' OR operation='exec stmt'
 ----
 DelRange /Table/61/1 - /Table/61/3
 fast path completed
@@ -324,7 +324,7 @@ SET TRACING=off;
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION]
-WHERE operation IN ('flow', 'consuming rows') OR operation LIKE 'exec cmd:%'
+WHERE operation IN ('flow', 'consuming rows') OR operation='exec stmt'
 ----
 Del /Table/61/1/1/0
 cascading delete into table: 62 using index: 1

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -18,24 +18,24 @@ FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%SPAN START%' OR message LIKE '%pos%executing%';
 ----
 0   === SPAN START: session recording ===                session recording
-1   === SPAN START: exec cmd: exec stmt ===              exec cmd: exec stmt
-1   [NoTxn pos:?] executing ExecStmt: BEGIN TRANSACTION  exec cmd: exec stmt
+1   === SPAN START: exec stmt ===                        exec stmt
+1   [NoTxn pos:?] executing ExecStmt: BEGIN TRANSACTION  exec stmt
 2   === SPAN START: sql txn ===                          sql txn
-3   === SPAN START: exec cmd: exec stmt ===              exec cmd: exec stmt
-3   [Open pos:?] executing ExecStmt: SELECT 1            exec cmd: exec stmt
+3   === SPAN START: exec stmt ===                        exec stmt
+3   [Open pos:?] executing ExecStmt: SELECT 1            exec stmt
 4   === SPAN START: consuming rows ===                   consuming rows
 5   === SPAN START: flow ===                             flow
-6   === SPAN START: exec cmd: exec stmt ===              exec cmd: exec stmt
-6   [Open pos:?] executing ExecStmt: COMMIT TRANSACTION  exec cmd: exec stmt
-7   === SPAN START: exec cmd: exec stmt ===              exec cmd: exec stmt
-7   [NoTxn pos:?] executing ExecStmt: SELECT 2           exec cmd: exec stmt
+6   === SPAN START: exec stmt ===                        exec stmt
+6   [Open pos:?] executing ExecStmt: COMMIT TRANSACTION  exec stmt
+7   === SPAN START: exec stmt ===                        exec stmt
+7   [NoTxn pos:?] executing ExecStmt: SELECT 2           exec stmt
 8   === SPAN START: sql txn ===                          sql txn
-9   === SPAN START: exec cmd: exec stmt ===              exec cmd: exec stmt
-9   [Open pos:?] executing ExecStmt: SELECT 2            exec cmd: exec stmt
+9   === SPAN START: exec stmt ===                        exec stmt
+9   [Open pos:?] executing ExecStmt: SELECT 2            exec stmt
 10  === SPAN START: consuming rows ===                   consuming rows
 11  === SPAN START: flow ===                             flow
-12  === SPAN START: exec cmd: exec stmt ===              exec cmd: exec stmt
-12  [NoTxn pos:?] executing ExecStmt: SET TRACING = off  exec cmd: exec stmt
+12  === SPAN START: exec stmt ===                        exec stmt
+12  [NoTxn pos:?] executing ExecStmt: SET TRACING = off  exec stmt
 
 # ------------------------------------------------------------------------------
 # Numeric References Tests.

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace
@@ -17,9 +17,9 @@ WHERE message NOT LIKE '%Z/%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow                 CPut /Table/2/1/0/"t"/3/1 -> 53
-flow                 CPut /Table/3/1/53/2/1 -> database:<name:"t" id:53 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > >
-exec cmd: exec stmt  rows affected: 0
+flow       CPut /Table/2/1/0/"t"/3/1 -> 53
+flow       CPut /Table/3/1/53/2/1 -> database:<name:"t" id:53 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > >
+exec stmt  rows affected: 0
 
 
 # More KV operations.
@@ -37,9 +37,9 @@ WHERE message NOT LIKE '%Z/%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow                 CPut /Table/2/1/53/"kv"/3/1 -> 54
-flow                 CPut /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:false hidden:false > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<wall_time:... > >
-exec cmd: exec stmt  rows affected: 0
+flow       CPut /Table/2/1/53/"kv"/3/1 -> 54
+flow       CPut /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:false hidden:false > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<wall_time:... > >
+exec stmt  rows affected: 0
 
 # We avoid using the full trace output, because that would make the
 # ensuing trace especially chatty, as it traces the index backfill at
@@ -64,8 +64,8 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow                 Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:2 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:false hidden:false > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_ONLY direction:ADD mutation_id:1 rollback:false > next_mutation_id:2 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<wall_time:... > >
-exec cmd: exec stmt  rows affected: 0
+flow       Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:2 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:false hidden:false > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_ONLY direction:ADD mutation_id:1 rollback:false > next_mutation_id:2 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<wall_time:... > >
+exec stmt  rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = off
@@ -78,7 +78,7 @@ flow                                  CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
 flow                                  InitPut /Table/54/2/2/0 -> /BYTES/0x89
 kv.DistSender: sending partial batch  r20: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
 flow                                  fast path completed
-exec cmd: exec stmt                   rows affected: 1
+exec stmt                             rows affected: 1
 
 
 statement error duplicate key value
@@ -92,7 +92,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 flow                                  CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
 flow                                  InitPut /Table/54/2/2/0 -> /BYTES/0x89
 kv.DistSender: sending partial batch  r20: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
-exec cmd: exec stmt                   execution failed after 0 rows: duplicate key value (k)=(1) violates unique constraint "primary"
+exec stmt                             execution failed after 0 rows: duplicate key value (k)=(1) violates unique constraint "primary"
 
 statement error duplicate key value
 SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (2,2); SET tracing = off
@@ -105,7 +105,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 flow                                  CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/2
 flow                                  InitPut /Table/54/2/2/0 -> /BYTES/0x8a
 kv.DistSender: sending partial batch  r20: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
-exec cmd: exec stmt                   execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
+exec stmt                             execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
 
 statement ok
 SET tracing = on,kv,results; CREATE TABLE t.kv2 AS TABLE t.kv; SET tracing = off
@@ -121,10 +121,10 @@ WHERE message NOT LIKE '%Z/%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-table reader         Scan /Table/54/{1-2}
-flow                 CPut /Table/2/1/53/"kv2"/3/1 -> 55
-flow                 CPut /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:ADD view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"TABLE t.public.kv" create_as_of_time:<wall_time:... > >
-exec cmd: exec stmt  rows affected: 0
+table reader  Scan /Table/54/{1-2}
+flow          CPut /Table/2/1/53/"kv2"/3/1 -> 55
+flow          CPut /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:ADD view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"TABLE t.public.kv" create_as_of_time:<wall_time:... > >
+exec stmt     rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; UPDATE t.kv2 SET v = v + 2; SET tracing = off
@@ -144,7 +144,7 @@ table reader                                             Scan /Table/55/{1-2}
 table reader                                             fetched: /kv2/primary/1/k/v -> /1/2
 flow                                                     Put /Table/55/1/1/0 -> /TUPLE/1:1:Int/1/1:2:Int/4
 flow                                                     fast path completed
-exec cmd: exec stmt                                      rows affected: 1
+exec stmt                                                rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DELETE FROM t.kv2; SET tracing = off
@@ -153,9 +153,9 @@ query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-flow                 DelRange /Table/55/1 - /Table/55/2
-flow                 fast path completed
-exec cmd: exec stmt  rows affected: 1
+flow       DelRange /Table/55/1 - /Table/55/2
+flow       fast path completed
+exec stmt  rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DROP TABLE t.kv2; SET tracing = off
@@ -172,8 +172,8 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow                 Put /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:3 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv2" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... create_query:"TABLE t.public.kv" create_as_of_time:<wall_time:... > >
-exec cmd: exec stmt  rows affected: 0
+flow       Put /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:3 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv2" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... create_query:"TABLE t.public.kv" create_as_of_time:<wall_time:... > >
+exec stmt  rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; DELETE FROM t.kv; SET tracing = off
@@ -188,7 +188,7 @@ flow                                  Del /Table/54/2/2/0
 flow                                  Del /Table/54/1/1/0
 kv.DistSender: sending partial batch  r20: sending batch 1 Del to (n1,s1):1
 flow                                  fast path completed
-exec cmd: exec stmt                   rows affected: 1
+exec stmt                             rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DROP INDEX t.kv@woo CASCADE; SET tracing = off
@@ -207,8 +207,8 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow                 Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:5 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:false hidden:false > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_AND_WRITE_ONLY direction:DROP mutation_id:2 rollback:false > next_mutation_id:3 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<wall_time:... > >
-exec cmd: exec stmt  rows affected: 0
+flow       Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:5 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:false hidden:false > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_AND_WRITE_ONLY direction:DROP mutation_id:2 rollback:false > next_mutation_id:3 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<wall_time:... > >
+exec stmt  rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; DROP TABLE t.kv; SET tracing = off
@@ -224,8 +224,8 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow                 Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:8 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:false hidden:false > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:3 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... gc_mutations:<index_id:2 drop_time:... job_id:... > create_query:"" create_as_of_time:<wall_time:... > >
-exec cmd: exec stmt  rows affected: 0
+flow       Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:8 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:false hidden:false > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 > > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:3 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... gc_mutations:<index_id:2 drop_time:... job_id:... > create_query:"" create_as_of_time:<wall_time:... > >
+exec stmt  rows affected: 0
 
 # Check that session tracing does not inhibit the fast path for inserts &
 # friends (the path resulting in 1PC transactions).

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -233,7 +233,7 @@ flow                                  CPut /Table/57/1/2/0 -> /TUPLE/2:2:Int/3
 flow                                  InitPut /Table/57/2/3/0 -> /BYTES/0x8a
 kv.DistSender: sending partial batch  r20: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
 flow                                  fast path completed
-exec cmd: exec stmt                   rows affected: 1
+exec stmt                             rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = off
@@ -247,7 +247,7 @@ flow                                  CPut /Table/57/1/1/0 -> /TUPLE/2:2:Int/2
 flow                                  InitPut /Table/57/2/2/0 -> /BYTES/0x89
 kv.DistSender: sending partial batch  r20: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
 flow                                  fast path completed
-exec cmd: exec stmt                   rows affected: 1
+exec stmt                             rows affected: 1
 
 statement error duplicate key value
 SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (2,2); SET tracing = off
@@ -263,7 +263,7 @@ flow                                  Put /Table/57/1/2/0 -> /TUPLE/2:2:Int/2
 flow                                  Del /Table/57/2/3/0
 flow                                  CPut /Table/57/2/2/0 -> /BYTES/0x8a (expecting does not exist)
 kv.DistSender: sending partial batch  r20: sending batch 1 Put, 1 EndTxn to (n1,s1):1
-exec cmd: exec stmt                   execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
+exec stmt                             execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
 
 
 subtest regression_32473

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -67,7 +67,7 @@ func TestTrace(t *testing.T) {
 						"WHERE operation IS NOT NULL ORDER BY op")
 			},
 			expSpans: []string{
-				"exec cmd: exec stmt",
+				"exec stmt",
 				"flow",
 				"session recording",
 				"sql txn",
@@ -122,7 +122,7 @@ func TestTrace(t *testing.T) {
 			expSpans: []string{
 				"session recording",
 				"sql txn",
-				"exec cmd: exec stmt",
+				"exec stmt",
 				"flow",
 				"table reader",
 				"consuming rows",
@@ -157,7 +157,7 @@ func TestTrace(t *testing.T) {
 						"WHERE operation IS NOT NULL ORDER BY op")
 			},
 			expSpans: []string{
-				"exec cmd: exec stmt",
+				"exec stmt",
 				"flow",
 				"session recording",
 				"sql txn",
@@ -190,7 +190,7 @@ func TestTrace(t *testing.T) {
 			expSpans: []string{
 				"session recording",
 				"sql txn",
-				"exec cmd: exec stmt",
+				"exec stmt",
 				"flow",
 				"table reader",
 				"consuming rows",


### PR DESCRIPTION
This saves an allocation per StmtBuf command. The standard (non-prepared) SQL
query appears to require three StmtBuf commands.

```
name                     old alloc/op   new alloc/op   delta
KV/Insert/SQL/rows=1-16    34.8kB ± 0%    34.6kB ± 0%  -0.42%  (p=0.000 n=10+9)
KV/Update/SQL/rows=1-16    49.7kB ± 0%    49.6kB ± 0%  -0.16%  (p=0.000 n=10+9)
KV/Delete/SQL/rows=1-16    42.8kB ± 0%    42.7kB ± 0%  -0.18%  (p=0.001 n=9+10)
KV/Scan/SQL/rows=1-16      29.4kB ± 0%    29.3kB ± 0%  -0.26%  (p=0.000 n=10+10)

name                     old allocs/op  new allocs/op  delta
KV/Insert/SQL/rows=1-16       324 ± 0%       321 ± 0%  -0.93%  (p=0.000 n=9+9)
KV/Update/SQL/rows=1-16       479 ± 0%       476 ± 0%  -0.59%  (p=0.000 n=10+10)
KV/Delete/SQL/rows=1-16       412 ± 0%       409 ± 0%  -0.73%  (p=0.000 n=9+10)
KV/Scan/SQL/rows=1-16         298 ± 0%       295 ± 0%  -1.01%  (p=0.000 n=10+10)
```

Release note: None