### PR TITLE
exec: implement the case operator

### DIFF
--- a/pkg/col/coldata/vec.go
+++ b/pkg/col/coldata/vec.go
@@ -52,6 +52,11 @@ type CopyArgs struct {
 	// Sel64 overrides Sel. Used when the amount of data being copied exceeds the
 	// representation capabilities of a []uint16.
 	Sel64 []uint64
+	// SelOnDest, if true, uses the selection vector as a lens into the
+	// destination as well as the source. Normally, when SelOnDest is false, the
+	// selection vector is applied to the source vector, but the results are
+	// copied densely into the destination vector.
+	SelOnDest bool
 	// DestIdx is the first index that Copy will copy to.
 	DestIdx uint64
 	// SrcStartIdx is the index of the first element in Src that Copy will copy.

--- a/pkg/sql/exec/buffer.go
+++ b/pkg/sql/exec/buffer.go
@@ -1,0 +1,109 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package exec
+
+import (
+	"context"
+	"unsafe"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+)
+
+// bufferOp is an operator that buffers a single batch at a time from an input,
+// and makes it available to be read multiple times by downstream consumers.
+type bufferOp struct {
+	OneInputNode
+
+	// read is true if someone has read the current batch already.
+	read     bool
+	batch    *selectionBatch
+	batchLen uint16
+}
+
+var _ StaticMemoryOperator = &bufferOp{}
+
+// NewBufferOp returns a new bufferOp, initialized to buffer batches from the
+// supplied input.
+func NewBufferOp(input Operator) Operator {
+	return &bufferOp{
+		OneInputNode: NewOneInputNode(input),
+		batch: &selectionBatch{
+			sel: make([]uint16, coldata.BatchSize),
+		},
+	}
+}
+
+func (b *bufferOp) EstimateStaticMemoryUsage() int {
+	return cap(b.batch.sel) * int(unsafe.Sizeof(uint16(0)))
+}
+
+func (b *bufferOp) Init() {
+	b.input.Init()
+}
+
+// rewind resets this buffer to be readable again.
+func (b *bufferOp) rewind() {
+	b.read = false
+	b.batch.SetLength(b.batch.Batch.Length())
+	b.batch.useSel = b.batch.Batch.Selection() != nil
+	if b.batch.useSel {
+		copy(b.batch.sel, b.batch.Batch.Selection())
+	}
+}
+
+// advance reads the next batch from the input into the buffer, preparing itself
+// for reads.
+func (b *bufferOp) advance(ctx context.Context) {
+	b.batch.Batch = b.input.Next(ctx)
+	b.batchLen = b.batch.Length()
+	b.read = false
+}
+
+func (b *bufferOp) Next(ctx context.Context) coldata.Batch {
+	if b.read {
+		b.batch.SetLength(0)
+		return b.batch
+	}
+	b.read = true
+	return b.batch
+}
+
+// selectionBatch is a smaller wrapper around coldata.Batch that adds another
+// selection vector on top. This is useful for operators that might want to
+// permute the selection vector for downstream operators without touching the
+// original selection of the batch.
+type selectionBatch struct {
+	coldata.Batch
+	sel    []uint16
+	useSel bool
+	n      uint16
+}
+
+var _ coldata.Batch = &selectionBatch{}
+
+func (s *selectionBatch) SetSelection(b bool) {
+	s.useSel = b
+}
+
+func (s *selectionBatch) Selection() []uint16 {
+	if s.useSel {
+		return s.sel
+	}
+	return nil
+}
+
+func (s *selectionBatch) Length() uint16 {
+	return s.n
+}
+
+func (s *selectionBatch) SetLength(n uint16) {
+	s.n = n
+}

--- a/pkg/sql/exec/builtin_funcs.go
+++ b/pkg/sql/exec/builtin_funcs.go
@@ -44,12 +44,11 @@ func (b *defaultBuiltinFuncOperator) Init() {
 func (b *defaultBuiltinFuncOperator) Next(ctx context.Context) coldata.Batch {
 	batch := b.input.Next(ctx)
 	n := batch.Length()
-	if n == 0 {
-		return batch
-	}
-
 	if b.outputIdx == batch.Width() {
 		batch.AppendCol(b.outputPhysType)
+	}
+	if n == 0 {
+		return batch
 	}
 
 	sel := batch.Selection()

--- a/pkg/sql/exec/case.go
+++ b/pkg/sql/exec/case.go
@@ -1,0 +1,205 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package exec
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
+)
+
+type caseOp struct {
+	buffer *bufferOp
+
+	caseOps []Operator
+	elseOp  Operator
+
+	thenIdxs  []int
+	outputIdx int
+	typ       coltypes.T
+
+	// origSel is a buffer used to keep track of the original selection vector of
+	// the input batch. We need to do this because we're going to destructively
+	// modify the selection vector in order to do the work of the case statement.
+	origSel []uint16
+}
+
+func (c *caseOp) ChildCount() int {
+	return 1
+}
+
+func (c *caseOp) Child(nth int) OpNode {
+	if nth == 0 {
+		return c.buffer
+	}
+	execerror.VectorizedInternalPanic(fmt.Sprintf("invalid idx %d", nth))
+	// This code is unreachable, but the compiler cannot infer that.
+	return nil
+}
+
+func (c *caseOp) EstimateStaticMemoryUsage() int {
+	// We statically use a single selection vector, origSel.
+	return coldata.BatchSize * sizeOfInt16
+}
+
+// NewCaseOp returns an operator that runs a case statement.
+// buffer is a bufferOp that will return the input batch repeatedly.
+// caseOps is a list of operator chains, one per branch in the case statement.
+//   Each caseOp is connected to the input buffer op, and filters the input based
+//   on the case arm's WHEN condition, and then projects the remaining selected
+//   tuples based on the case arm's THEN condition.
+// elseOp is the ELSE condition.
+// whenCol is the index into the input batch to read from.
+// thenCol is the index into the output batch to write to.
+// typ is the type of the CASE expression.
+func NewCaseOp(
+	buffer Operator,
+	caseOps []Operator,
+	elseOp Operator,
+	thenIdxs []int,
+	outputIdx int,
+	typ coltypes.T,
+) Operator {
+	return &caseOp{
+		buffer:    buffer.(*bufferOp),
+		caseOps:   caseOps,
+		elseOp:    elseOp,
+		thenIdxs:  thenIdxs,
+		outputIdx: outputIdx,
+		typ:       typ,
+		origSel:   make([]uint16, coldata.BatchSize),
+	}
+}
+
+func (c *caseOp) Init() {
+	for i := range c.caseOps {
+		c.caseOps[i].Init()
+	}
+	c.elseOp.Init()
+}
+
+func (c *caseOp) Next(ctx context.Context) coldata.Batch {
+	c.buffer.advance(ctx)
+	origLen := c.buffer.batch.Batch.Length()
+	if c.buffer.batch.Width() == c.outputIdx {
+		c.buffer.batch.AppendCol(c.typ)
+	}
+	if origLen == 0 {
+		return c.buffer.batch.Batch
+	}
+	var origHasSel bool
+	if sel := c.buffer.batch.Batch.Selection(); sel != nil {
+		origHasSel = true
+		copy(c.origSel, sel)
+	}
+
+	outputCol := c.buffer.batch.Batch.ColVec(c.outputIdx)
+	for i := range c.caseOps {
+		c.buffer.rewind()
+		// Run the next case operator chain. It will project its THEN expression
+		// for all tuples that matched its WHEN expression and that were not
+		// already matched.
+		batch := c.caseOps[i].Next(ctx)
+		// The batch's projection column now additionally contains results for all
+		// of the tuples that passed the ith WHEN clause. The batch's selection
+		// vector is set to the same selection of tuples.
+		// Now, we must subtract this selection vector from the last buffered
+		// selection vector, so that the next operator gets to operate on the
+		// remaining set of tuples in the input that haven't matched an arm of the
+		// case statement.
+		// As an example, imagine the first WHEN op matched tuple 3. The following
+		// diagram shows the selection vector before running WHEN, after running
+		// WHEN, and then the desired selection vector after subtraction:
+		// - origSel
+		// | - selection vector after running WHEN
+		// | | - desired selection vector after subtraction
+		// | | |
+		// 1   1
+		// 2   2
+		// 3 3
+		// 4   4
+		toSubtract := batch.Selection()
+		toSubtract = toSubtract[:batch.Length()]
+		// toSubtract is now a selection vector containing all matched tuples of the
+		// current case arm.
+		var subtractIdx int
+		var curIdx uint16
+		inputCol := c.buffer.batch.Batch.ColVec(c.thenIdxs[i])
+		// Copy the results into the output vector, using the toSubtract selection
+		// vector to copy only the elements that we actually wrote according to the
+		// current case arm.
+		outputCol.Copy(coldata.CopyArgs{
+			ColType:     c.typ,
+			Src:         inputCol,
+			Sel:         toSubtract,
+			SrcStartIdx: 0,
+			SrcEndIdx:   uint64(len(toSubtract)),
+			SelOnDest:   true,
+		})
+		if oldSel := c.buffer.batch.Batch.Selection(); oldSel != nil {
+			// We have an old selection vector, which represents the tuples that
+			// haven't yet been matched. Remove the ones that just matched from the
+			// old selection vector.
+			for i := range oldSel[:c.buffer.batch.Batch.Length()] {
+				if subtractIdx < len(toSubtract) && toSubtract[subtractIdx] == oldSel[i] {
+					// The ith element of the old selection vector matched the current one
+					// in toSubtract. Skip writing this element, removing it from the old
+					// selection vector.
+					subtractIdx++
+					continue
+				}
+				oldSel[curIdx] = oldSel[i]
+				curIdx++
+			}
+		} else {
+			// No selection vector means there have been no matches yet, and we were
+			// considering the entire batch of tuples for this case arm. Make a new
+			// selection vector with all of the tuples but the ones that just matched.
+			c.buffer.batch.Batch.SetSelection(true)
+			oldSel = c.buffer.batch.Batch.Selection()
+			for i := uint16(0); i < c.buffer.batch.Batch.Length(); i++ {
+				if subtractIdx < len(toSubtract) && toSubtract[subtractIdx] == i {
+					subtractIdx++
+					continue
+				}
+				oldSel[curIdx] = i
+				curIdx++
+			}
+		}
+		c.buffer.batch.Batch.SetLength(curIdx)
+
+		// Now our selection vector is set to exclude all the things that have
+		// matched so far. Reset the buffer and run the next case arm.
+		c.buffer.rewind()
+	}
+	// Finally, run the else operator, which will project into all tuples that
+	// are remaining in the selection vector (didn't match any case arms). Once
+	// that's done, restore the original selection vector and return the batch.
+	batch := c.elseOp.Next(ctx)
+	inputCol := c.buffer.batch.Batch.ColVec(c.thenIdxs[len(c.thenIdxs)-1])
+	outputCol.Copy(coldata.CopyArgs{
+		ColType:     c.typ,
+		Src:         inputCol,
+		Sel:         batch.Selection(),
+		SrcStartIdx: 0,
+		SrcEndIdx:   uint64(batch.Length()),
+		SelOnDest:   true,
+	})
+	batch.SetLength(origLen)
+	batch.SetSelection(origHasSel)
+	if origHasSel {
+		copy(batch.Selection(), c.origSel)
+	}
+	return batch
+}

--- a/pkg/sql/exec/const_tmpl.go
+++ b/pkg/sql/exec/const_tmpl.go
@@ -87,12 +87,11 @@ func (c const_TYPEOp) Init() {
 func (c const_TYPEOp) Next(ctx context.Context) coldata.Batch {
 	batch := c.input.Next(ctx)
 	n := batch.Length()
-	if n == 0 {
-		return batch
-	}
-
 	if batch.Width() == c.outputIdx {
 		batch.AppendCol(c.typ)
+	}
+	if n == 0 {
+		return batch
 	}
 	col := batch.ColVec(c.outputIdx)._TemplateType()
 	if sel := batch.Selection(); sel != nil {

--- a/pkg/sql/exec/execgen/cmd/execgen/colvec_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/colvec_gen.go
@@ -33,8 +33,8 @@ func genColvec(wr io.Writer) error {
 	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
 	s = replaceManipulationFuncs(".LTyp", s)
 
-	copyWithSel := makeFunctionRegex("_COPY_WITH_SEL", 3)
-	s = copyWithSel.ReplaceAllString(s, `{{template "copyWithSel" buildDict "LTyp" .LTyp}}`)
+	copyWithSel := makeFunctionRegex("_COPY_WITH_SEL", 6)
+	s = copyWithSel.ReplaceAllString(s, `{{template "copyWithSel" buildDict "LTyp" .LTyp "SelOnDest" $6}}`)
 
 	// Now, generate the op, from the template.
 	tmpl, err := template.New("vec_op").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)

--- a/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
@@ -56,11 +56,11 @@ func (p {{template "opRConstName" .}}) EstimateStaticMemoryUsage() int {
 func (p {{template "opRConstName" .}}) Next(ctx context.Context) coldata.Batch {
 	batch := p.input.Next(ctx)
 	n := batch.Length()
-	if n == 0 {
-		return batch
-	}
 	if p.outputIdx == batch.Width() {
 		batch.AppendCol(coltypes.{{.RetTyp}})
+	}
+	if n == 0 {
+		return batch
 	}
 	vec := batch.ColVec(p.colIdx)
 	col := vec.{{.LTyp}}()
@@ -109,11 +109,11 @@ func (p {{template "opLConstName" .}}) EstimateStaticMemoryUsage() int {
 func (p {{template "opLConstName" .}}) Next(ctx context.Context) coldata.Batch {
 	batch := p.input.Next(ctx)
 	n := batch.Length()
-	if n == 0 {
-		return batch
-	}
 	if p.outputIdx == batch.Width() {
 		batch.AppendCol(coltypes.{{.RetTyp}})
+	}
+	if n == 0 {
+		return batch
 	}
 	vec := batch.ColVec(p.colIdx)
 	col := vec.{{.RTyp}}()
@@ -162,11 +162,11 @@ func (p {{template "opName" .}}) EstimateStaticMemoryUsage() int {
 func (p {{template "opName" .}}) Next(ctx context.Context) coldata.Batch {
 	batch := p.input.Next(ctx)
 	n := batch.Length()
-	if n == 0 {
-		return batch
-	}
 	if p.outputIdx == batch.Width() {
 		batch.AppendCol(coltypes.{{.RetTyp}})
+	}
+	if n == 0 {
+		return batch
 	}
 	projVec := batch.ColVec(p.outputIdx)
 	projCol := projVec.{{.RetTyp}}()

--- a/pkg/sql/exec/partitioner.go
+++ b/pkg/sql/exec/partitioner.go
@@ -70,13 +70,13 @@ func (p *windowSortingPartitioner) Init() {
 
 func (p *windowSortingPartitioner) Next(ctx context.Context) coldata.Batch {
 	b := p.input.Next(ctx)
-	if b.Length() == 0 {
-		return b
-	}
 	if p.partitionColIdx == b.Width() {
 		b.AppendCol(coltypes.Bool)
 	} else if p.partitionColIdx > b.Width() {
 		execerror.VectorizedInternalPanic("unexpected: column partitionColIdx is neither present nor the next to be appended")
+	}
+	if b.Length() == 0 {
+		return b
 	}
 	partitionVec := b.ColVec(p.partitionColIdx).Bool()
 	sel := b.Selection()

--- a/pkg/sql/exec/select_in_tmpl.go
+++ b/pkg/sql/exec/select_in_tmpl.go
@@ -259,12 +259,11 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 
 func (pi *projectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 	batch := pi.input.Next(ctx)
-	if batch.Length() == 0 {
-		return batch
-	}
-
 	if pi.outputIdx == batch.Width() {
 		batch.AppendCol(coltypes.Bool)
+	}
+	if batch.Length() == 0 {
+		return batch
 	}
 
 	vec := batch.ColVec(pi.colIdx)

--- a/pkg/sql/exec/vecbuiltins/rank_tmpl.go
+++ b/pkg/sql/exec/vecbuiltins/rank_tmpl.go
@@ -80,10 +80,6 @@ func (r *_RANK_STRINGOp) Init() {
 
 func (r *_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 	batch := r.Input().Next(ctx)
-	if batch.Length() == 0 {
-		return batch
-	}
-
 	// {{ if .HasPartition }}
 	if r.partitionColIdx == batch.Width() {
 		batch.AppendCol(coltypes.Bool)
@@ -98,6 +94,11 @@ func (r *_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 	} else if r.outputColIdx > batch.Width() {
 		execerror.VectorizedInternalPanic("unexpected: column outputColIdx is neither present nor the next to be appended")
 	}
+
+	if batch.Length() == 0 {
+		return batch
+	}
+
 	rankCol := batch.ColVec(r.outputColIdx).Int64()
 	sel := batch.Selection()
 	// TODO(yuzefovich): template out sel vs non-sel cases.

--- a/pkg/sql/exec/vecbuiltins/row_number_tmpl.go
+++ b/pkg/sql/exec/vecbuiltins/row_number_tmpl.go
@@ -38,9 +38,6 @@ var _ exec.Operator = &_ROW_NUMBER_STRINGOp{}
 
 func (r *_ROW_NUMBER_STRINGOp) Next(ctx context.Context) coldata.Batch {
 	batch := r.Input().Next(ctx)
-	if batch.Length() == 0 {
-		return batch
-	}
 	// {{ if .HasPartition }}
 	if r.partitionColIdx == batch.Width() {
 		batch.AppendCol(coltypes.Bool)
@@ -54,6 +51,9 @@ func (r *_ROW_NUMBER_STRINGOp) Next(ctx context.Context) coldata.Batch {
 		batch.AppendCol(coltypes.Int64)
 	} else if r.outputColIdx > batch.Width() {
 		execerror.VectorizedInternalPanic("unexpected: column outputColIdx is neither present nor the next to be appended")
+	}
+	if batch.Length() == 0 {
+		return batch
 	}
 	rowNumberCol := batch.ColVec(r.outputColIdx).Int64()
 	sel := batch.Selection()

--- a/pkg/sql/logictest/testdata/logic_test/conditional
+++ b/pkg/sql/logictest/testdata/logic_test/conditional
@@ -1,3 +1,4 @@
+# LogicTest: local local-vec fakedist fakedist-metadata fakedist-vec
 query II
 SELECT IF(1 = 2, NULL, 1), IF(2 = 2, NULL, 2)
 ----

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -10,6 +10,16 @@ CREATE TABLE a (a INT, b INT, c INT4, PRIMARY KEY (a, b))
 statement ok
 INSERT INTO a SELECT g//2, g, g FROM generate_series(0,2000) g(g)
 
+query II
+SELECT a, CASE WHEN a = 0 THEN 0 WHEN a = 1 THEN 3 ELSE 5 END FROM a LIMIT 6
+----
+0  0
+0  0
+1  3
+1  3
+2  5
+2  5
+
 statement ok
 CREATE TABLE bools (b BOOL, i INT, PRIMARY KEY (b, i)); INSERT INTO bools VALUES (true, 0), (false, 1), (true, 2), (false, 3);
 


### PR DESCRIPTION
This PR adds support for projections of CASE expressions in the vectorized engine. It only adds support for the form `CASE WHEN x THEN y ... [ELSE z]`, not the `CASE foo WHEN x THEN y ...` form.

Release note: None