### PR TITLE
sqlbase: Move ProcessColumns() from sql to sqlbase

### DIFF
--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -114,7 +114,7 @@ func newCopyMachine(
 	if err := c.p.CheckPrivilege(ctx, tableDesc, privilege.INSERT); err != nil {
 		return nil, err
 	}
-	cols, err := c.p.processColumns(tableDesc, n.Columns,
+	cols, err := sqlbase.ProcessTargetColumns(tableDesc, n.Columns,
 		true /* ensureColumns */, false /* allowMutations */)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -148,7 +148,7 @@ func (p *planner) Insert(
 		insertCols = desc.WritableColumns()
 	} else {
 		var err error
-		if insertCols, err = p.processColumns(desc, n.Columns,
+		if insertCols, err = sqlbase.ProcessTargetColumns(desc, n.Columns,
 			true /* ensureColumns */, false /* allowMutations */); err != nil {
 			return nil, err
 		}
@@ -617,53 +617,6 @@ func (n *insertNode) Close(ctx context.Context) {
 // enableAutoCommit is part of the autoCommitNode interface.
 func (n *insertNode) enableAutoCommit() {
 	n.run.ti.enableAutoCommit()
-}
-
-// processColumns returns the column descriptors identified by the
-// given name list. It also checks that a given column name is only
-// listed once. If no column names are given (special case for INSERT)
-// and ensureColumns is set, the descriptors for all visible columns
-// are returned. If allowMutations is set, even columns undergoing
-// mutations are added.
-func (p *planner) processColumns(
-	tableDesc *sqlbase.ImmutableTableDescriptor,
-	nameList tree.NameList,
-	ensureColumns, allowMutations bool,
-) ([]sqlbase.ColumnDescriptor, error) {
-	if len(nameList) == 0 {
-		if ensureColumns {
-			// VisibleColumns is used here to prevent INSERT INTO <table> VALUES (...)
-			// (as opposed to INSERT INTO <table> (...) VALUES (...)) from writing
-			// hidden columns. At present, the only hidden column is the implicit rowid
-			// primary key column.
-			return tableDesc.VisibleColumns(), nil
-		}
-		return nil, nil
-	}
-
-	cols := make([]sqlbase.ColumnDescriptor, len(nameList))
-	colIDSet := make(map[sqlbase.ColumnID]struct{}, len(nameList))
-	for i, colName := range nameList {
-		var col *sqlbase.ColumnDescriptor
-		var err error
-		if allowMutations {
-			col, _, err = tableDesc.FindColumnByName(colName)
-		} else {
-			col, err = tableDesc.FindActiveColumnByName(string(colName))
-		}
-		if err != nil {
-			return nil, err
-		}
-
-		if _, ok := colIDSet[col.ID]; ok {
-			return nil, pgerror.Newf(pgcode.Syntax,
-				"multiple assignments to the same column %q", &nameList[i])
-		}
-		colIDSet[col.ID] = struct{}{}
-		cols[i] = *col
-	}
-
-	return cols, nil
 }
 
 // extractInsertSource removes the parentheses around the data source of an INSERT statement.

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -128,7 +128,7 @@ func (p *planner) Update(
 	// Extract the column descriptors for the column names listed
 	// in the LHS operands of SET expressions. This also checks
 	// that each column is assigned at most once.
-	updateCols, err := p.processColumns(desc, names,
+	updateCols, err := sqlbase.ProcessTargetColumns(desc, names,
 		true /* ensureColumns */, false /* allowMutations */)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -142,7 +142,7 @@ func (p *planner) newUpsertNode(
 		// to include mutation columns being added. If the SET
 		// expressions were explicit (specified by the client),
 		// then we want to reject assignments to mutation columns.
-		updateCols, err := p.processColumns(desc, names,
+		updateCols, err := sqlbase.ProcessTargetColumns(desc, names,
 			false /* ensureColumns */, autoGenUpdates /* allowMutations */)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
ProcessColumns returns a list of ColumnDescriptors when provided
a list of columns names and their table desc.
Previously, this method was defined as a planner method in sql
as it was only used for INSERT statements. With IMPORT INTO
also working towards allowing users to specify target columns
to import data into, there is value in reusing this method.
This change does not modify the method in any way.

Release note: None