### PR TITLE
reduce: add SQL reducer

### DIFF
--- a/pkg/cmd/reduce/main.go
+++ b/pkg/cmd/reduce/main.go
@@ -1,0 +1,94 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// reduce reduces SQL passed over stdin using cockroach demo. The input is
+// simplified such that the contains argument is present as an error during SQL
+// execution.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/reduce"
+	"github.com/cockroachdb/cockroach/pkg/testutils/reduce/reducesql"
+)
+
+var (
+	flags    = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	path     = flags.String("path", "./cockroach", "path to cockroach binary")
+	verbose  = flags.Bool("v", false, "log progress")
+	contains = flags.String("contains", "", "error regex to search for")
+)
+
+func usage() {
+	fmt.Fprintf(flags.Output(), "Usage of %s:\n", os.Args[0])
+	flags.PrintDefaults()
+	os.Exit(1)
+}
+
+func main() {
+	if err := flags.Parse(os.Args[1:]); err != nil {
+		usage()
+	}
+	if *contains == "" {
+		fmt.Print("missing contains\n\n")
+		usage()
+	}
+	out, err := reduceSQL(*path, *contains, *verbose)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(out)
+}
+
+func reduceSQL(path, contains string, verbose bool) (string, error) {
+	containsRE, err := regexp.Compile(contains)
+	if err != nil {
+		return "", err
+	}
+	input, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		return "", err
+	}
+
+	interesting := func(f reduce.File) bool {
+		cmd := exec.Command(path, "demo")
+		sql := string(f)
+		if !strings.HasSuffix(sql, ";") {
+			sql += ";"
+		}
+		cmd.Stdin = strings.NewReader(sql)
+		out, err := cmd.CombinedOutput()
+		switch err := err.(type) {
+		case *exec.Error:
+			if err.Err == exec.ErrNotFound {
+				log.Fatal(err)
+			}
+		case *os.PathError:
+			log.Fatal(err)
+		}
+		return containsRE.Match(out)
+	}
+
+	var logger io.Writer
+	if verbose {
+		logger = os.Stderr
+	}
+	out, err := reduce.Reduce(logger, reduce.File(input), interesting, reducesql.SQLPasses...)
+	return string(out), err
+}

--- a/pkg/testutils/reduce/datadriven.go
+++ b/pkg/testutils/reduce/datadriven.go
@@ -1,0 +1,63 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package reduce
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/datadriven"
+)
+
+// Walk walks path for datadriven files and calls RunTest on them.
+func Walk(
+	t *testing.T, path string, interesting func(contains string) InterestingFn, passes []Pass,
+) {
+	datadriven.Walk(t, path, func(t *testing.T, path string) {
+		RunTest(t, path, interesting, passes)
+	})
+}
+
+// RunTest executes reducer commands. In verbose mode, output is written to
+// stderr. Supported commands:
+//
+// "contains": Sets the substring that must be contained by an error message
+// for a test case to be marked as interesting. This variable is passed to the
+// `interesting` func.
+//
+// "reduce": Creates an InterestingFn based on the current value of contains
+// and executes the reducer. Outputs the reduced case.
+func RunTest(
+	t *testing.T, path string, interesting func(contains string) InterestingFn, passes []Pass,
+) {
+	var contains string
+	var log io.Writer
+	if testing.Verbose() {
+		log = os.Stderr
+	}
+	datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
+		switch d.Cmd {
+		case "contains":
+			contains = d.Input
+			return ""
+		case "reduce":
+			output, err := Reduce(log, File(d.Input), interesting(contains), passes...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return string(output) + "\n"
+		default:
+			t.Fatalf("unknown command: %s", d.Cmd)
+			return ""
+		}
+	})
+}

--- a/pkg/testutils/reduce/reduce.go
+++ b/pkg/testutils/reduce/reduce.go
@@ -1,0 +1,147 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package reduce implements a reducer core for reducing the size of test
+// failure cases.
+//
+// See: https://blog.regehr.org/archives/1678.
+package reduce
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// Pass defines a reduce pass.
+type Pass interface {
+	// New creates a new opaque state object for the input File.
+	New(File) State
+	// Transform applies this transformation pass to the input File using
+	// State to determine which occurrence to transform. It returns the
+	// transformed File, a Result indicating whether to proceed or not, and
+	// an error if the transformation could not be performed.
+	Transform(File, State) (File, Result, error)
+	// Advance moves State to the next occurrence of a transformation in
+	// the given input File and returns the new State.
+	Advance(File, State) State
+}
+
+// Result is returned by a Transform func.
+type Result int
+
+const (
+	// OK indicates there are more transforms in the current Pass.
+	OK Result = iota
+	// STOP indicates there are no more transforms.
+	STOP
+)
+
+// State is opaque state for a Pass.
+type State interface{}
+
+// File contains the contents of a file.
+type File string
+
+// Size returns the size of the file in bytes.
+func (f File) Size() int {
+	return len(f)
+}
+
+// InterestingFn returns true if File triggers the target test failure.
+type InterestingFn func(File) bool
+
+// Reduce executes the test case reduction algorithm. logger, if not nil, will
+// log progress output.
+func Reduce(
+	logger io.Writer, originalTestCase File, isInteresting InterestingFn, passList ...Pass,
+) (File, error) {
+	log := func(format string, args ...interface{}) {
+		if logger == nil {
+			return
+		}
+		fmt.Fprintf(logger, format, args...)
+	}
+	if !isInteresting(originalTestCase) {
+		return "", errors.New("original test case not interesting")
+	}
+	current := originalTestCase
+	start := timeutil.Now()
+	for {
+		sizeAtStart := current.Size()
+		log("size: %d\n", current.Size())
+		for pi, p := range passList {
+			log("\tpass %d of %d\n", pi+1, len(passList))
+			state := p.New(current)
+			for {
+				variant, result, err := p.Transform(current, state)
+				if err != nil {
+					return "", err
+				}
+				if result == OK {
+					if isInteresting(variant) {
+						current = variant
+					} else {
+						state = p.Advance(current, state)
+					}
+				} else {
+					break
+				}
+			}
+		}
+		if current.Size() >= sizeAtStart {
+			break
+		}
+	}
+	log("total time: %v\n", timeutil.Since(start))
+	log("original size: %v\n", originalTestCase.Size())
+	log("final size: %v\n", current.Size())
+	log("reduction: %v%%\n", 100-int(100*float64(current.Size())/float64(originalTestCase.Size())))
+	return current, nil
+}
+
+type intPass func(string, int) (string, bool, error)
+
+// MakeIntPass returns a Pass with a state that starts at 0 and increments by
+// 1 each Advance. f is a transformation function that takes the input and an
+// index (zero-based) determining which occurrence to transform. It returns the
+// possibly transformed output and a boolean that is false if a transformation
+// could not be done because i was exhausted.
+//
+// For example, if f is a func that replaces spaces with underscores, invoking
+// that function with an i value of 2 should return the input string with only
+// the 3rd occurrence of a space replaced with an underscore.
+//
+// This is a convenience wrapper since a large number of Pass implementations
+// just need their state to increment a counter and don't have to keep track of
+// other things like byte offsets.
+func MakeIntPass(f func(s string, i int) (out string, ok bool, err error)) Pass {
+	return intPass(f)
+}
+
+func (p intPass) New(File) State {
+	return 0
+}
+
+func (p intPass) Transform(f File, s State) (File, Result, error) {
+	i := s.(int)
+	data, ok, err := p(string(f), i)
+	res := OK
+	if !ok {
+		res = STOP
+	}
+	return File(data), res, err
+}
+
+func (p intPass) Advance(f File, s State) State {
+	return s.(int) + 1
+}

--- a/pkg/testutils/reduce/reduce_test.go
+++ b/pkg/testutils/reduce/reduce_test.go
@@ -1,0 +1,60 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package reduce_test
+
+import (
+	"go/parser"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/reduce"
+)
+
+func TestReduceGo(t *testing.T) {
+	reduce.Walk(t, "testdata", isInterestingGo, goPasses)
+}
+
+var (
+	goPasses = []reduce.Pass{
+		removeLine,
+		simplifyConsts,
+	}
+	removeLine = reduce.MakeIntPass(func(s string, i int) (string, bool, error) {
+		sp := strings.Split(s, "\n")
+		if i >= len(sp) {
+			return "", false, nil
+		}
+		out := strings.Join(append(sp[:i], sp[i+1:]...), "\n")
+		return out, true, nil
+	})
+	simplifyConstsRE = regexp.MustCompile(`[a-z0-9][a-z0-9]+`)
+	simplifyConsts   = reduce.MakeIntPass(func(s string, i int) (string, bool, error) {
+		out := simplifyConstsRE.ReplaceAllStringFunc(s, func(found string) string {
+			i--
+			if i == -1 {
+				return found[:1]
+			}
+			return found
+		})
+		return out, i < 0, nil
+	})
+)
+
+func isInterestingGo(contains string) reduce.InterestingFn {
+	return func(f reduce.File) bool {
+		_, err := parser.ParseExpr(string(f))
+		if err == nil {
+			return false
+		}
+		return strings.Contains(err.Error(), contains)
+	}
+}

--- a/pkg/testutils/reduce/reducesql/reducesql.go
+++ b/pkg/testutils/reduce/reducesql/reducesql.go
@@ -1,0 +1,854 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package reducesql
+
+import (
+	"fmt"
+	"go/constant"
+	"regexp"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	// Import builtins.
+	_ "github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/testutils/reduce"
+)
+
+// SQLPasses is a collection of reduce.Pass interfaces that reduce SQL
+// statements.
+var SQLPasses = []reduce.Pass{
+	removeStatement,
+	replaceStmt,
+	removeWithCTEs,
+	removeWith,
+	removeCTENames,
+	removeWithSelectExprs,
+	removeValuesCols,
+	removeSelectAsExprs,
+	removeValuesRows,
+	removeLimit,
+	removeOrderBy,
+	removeOrderByExprs,
+	removeGroupBy,
+	removeGroupByExprs,
+	nullExprs,
+	nullifyFuncArgs,
+	removeSelectExprs,
+	removeCreateDefs,
+	removeCreateNullDefs,
+	removeIndexCols,
+	removeWindowPartitions,
+	removeCasts,
+	removeAliases,
+	removeDBSchema,
+	removeFroms,
+	removeWhere,
+	removeHaving,
+	removeDistinct,
+	simplifyOnCond,
+	simplifyVal,
+	unparenthesize,
+}
+
+type sqlWalker struct {
+	match   func(int, interface{}) int
+	replace func(int, interface{}) (int, tree.NodeFormatter)
+}
+
+// walkSQL walks SQL statements and allows for in-place transformations to be
+// made directly to the nodes. match is a function that does both matching
+// and transformation. It takes an int specifying the 0-based occurrence to
+// transform. If the number of possible transformations is lower than that,
+// nothing is mutated. It returns the number of transformations it could have
+// performed. It is safe to mutate AST nodes directly because the string is
+// reparsed into a new AST each time.
+func walkSQL(match func(transform int, node interface{}) (matched int)) reduce.Pass {
+	w := sqlWalker{
+		match: match,
+	}
+	return reduce.MakeIntPass(w.Transform)
+}
+
+// replaceStatement is like walkSQL, except if it returns a non-nil
+// replacement, the top-level SQL statement is completely replaced with the
+// return value.
+func replaceStatement(
+	replace func(transform int, node interface{}) (matched int, replacement tree.NodeFormatter),
+) reduce.Pass {
+	w := sqlWalker{
+		replace: replace,
+	}
+	return reduce.MakeIntPass(w.Transform)
+}
+
+var (
+	// LogUnknown determines whether unknown types encountered during
+	// statement walking.
+	LogUnknown   bool
+	unknownTypes = map[string]bool{}
+)
+
+func (w sqlWalker) Transform(s string, i int) (out string, ok bool, err error) {
+	stmts, err := parser.Parse(s)
+	if err != nil {
+		return "", false, err
+	}
+
+	asts := make([]tree.NodeFormatter, len(stmts))
+	for si, stmt := range stmts {
+		asts[si] = stmt.AST
+	}
+
+	var replacement tree.NodeFormatter
+	var walk func(...interface{})
+	walk = func(nodes ...interface{}) {
+		for _, node := range nodes {
+			if i < 0 {
+				return
+			}
+			var matches int
+			if w.match != nil {
+				matches = w.match(i, node)
+			} else {
+				matches, replacement = w.replace(i, node)
+			}
+			i -= matches
+
+			switch node := node.(type) {
+			case *tree.AliasedTableExpr:
+				walk(node.Expr)
+			case *tree.AnnotateTypeExpr:
+				walk(node.Expr)
+			case *tree.Array:
+				walk(node.Exprs)
+			case *tree.BinaryExpr:
+				walk(node.Left, node.Right)
+			case *tree.CastExpr:
+				walk(node.Expr)
+			case *tree.ColumnTableDef:
+			case *tree.CreateTable:
+				for _, def := range node.Defs {
+					walk(def)
+				}
+			case *tree.CTE:
+				walk(node.Stmt)
+			case *tree.DBool:
+			case tree.Exprs:
+				for _, expr := range node {
+					walk(expr)
+				}
+			case *tree.FamilyTableDef:
+			case *tree.FuncExpr:
+				if node.WindowDef != nil {
+					walk(node.WindowDef)
+				}
+				walk(node.Exprs, node.Filter)
+			case *tree.IndexTableDef:
+			case *tree.JoinTableExpr:
+				walk(node.Left, node.Right, node.Cond)
+			case *tree.NumVal:
+			case *tree.OnJoinCond:
+				walk(node.Expr)
+			case *tree.ParenExpr:
+				walk(node.Expr)
+			case *tree.ParenSelect:
+				walk(node.Select)
+			case *tree.Select:
+				if node.With != nil {
+					walk(node.With)
+				}
+				walk(node.Select)
+			case *tree.SelectClause:
+				walk(node.Exprs)
+				if node.Where != nil {
+					walk(node.Where)
+				}
+				if node.Having != nil {
+					walk(node.Having)
+				}
+				for _, table := range node.From.Tables {
+					walk(table)
+				}
+			case tree.SelectExpr:
+				walk(node.Expr)
+			case tree.SelectExprs:
+				for _, expr := range node {
+					walk(expr)
+				}
+			case *tree.StrVal:
+			case *tree.Subquery:
+				walk(node.Select)
+			case *tree.TableName:
+			case *tree.UnaryExpr:
+				walk(node.Expr)
+			case *tree.UniqueConstraintTableDef:
+			case *tree.UnionClause:
+				walk(node.Left, node.Right)
+			case *tree.UnresolvedName:
+			case *tree.ValuesClause:
+				for _, row := range node.Rows {
+					walk(row)
+				}
+			case *tree.Where:
+				walk(node.Expr)
+			case *tree.WindowDef:
+				walk(node.Partitions, node.Frame)
+			case *tree.WindowFrame:
+				if node.Bounds.StartBound != nil {
+					walk(node.Bounds.StartBound)
+				}
+				if node.Bounds.EndBound != nil {
+					walk(node.Bounds.EndBound)
+				}
+			case *tree.WindowFrameBound:
+				walk(node.OffsetExpr)
+			case *tree.Window:
+			case *tree.With:
+				for _, expr := range node.CTEList {
+					walk(expr)
+				}
+			default:
+				if LogUnknown {
+					n := fmt.Sprintf("%T", node)
+					if !unknownTypes[n] {
+						unknownTypes[n] = true
+						fmt.Println("UNKNOWN", n)
+					}
+				}
+			}
+		}
+	}
+
+	for i, ast := range asts {
+		replacement = nil
+		walk(ast)
+		if replacement != nil {
+			asts[i] = replacement
+		}
+	}
+	if i >= 0 {
+		// Didn't find enough matches, so we're done.
+		return s, false, nil
+	}
+	var sb strings.Builder
+	for i, ast := range asts {
+		if i > 0 {
+			sb.WriteString("\n\n")
+		}
+		sb.WriteString(tree.Pretty(ast))
+		sb.WriteString(";")
+	}
+	return sb.String(), true, nil
+}
+
+var (
+	// Mutations.
+
+	removeLimit = walkSQL(func(xfi int, node interface{}) int {
+		xf := xfi == 0
+		switch node := node.(type) {
+		case *tree.Delete:
+			if node.Limit != nil {
+				if xf {
+					node.Limit = nil
+				}
+				return 1
+			}
+		case *tree.Select:
+			if node.Limit != nil {
+				if xf {
+					node.Limit = nil
+				}
+				return 1
+			}
+		case *tree.Update:
+			if node.Limit != nil {
+				if xf {
+					node.Limit = nil
+				}
+				return 1
+			}
+		}
+		return 0
+	})
+	removeOrderBy = walkSQL(func(xfi int, node interface{}) int {
+		xf := xfi == 0
+		switch node := node.(type) {
+		case *tree.Delete:
+			if node.OrderBy != nil {
+				if xf {
+					node.OrderBy = nil
+				}
+				return 1
+			}
+		case *tree.FuncExpr:
+			if node.OrderBy != nil {
+				if xf {
+					node.OrderBy = nil
+				}
+				return 1
+			}
+		case *tree.Select:
+			if node.OrderBy != nil {
+				if xf {
+					node.OrderBy = nil
+				}
+				return 1
+			}
+		case *tree.Update:
+			if node.OrderBy != nil {
+				if xf {
+					node.OrderBy = nil
+				}
+				return 1
+			}
+		case *tree.WindowDef:
+			if node.OrderBy != nil {
+				if xf {
+					node.OrderBy = nil
+				}
+				return 1
+			}
+		}
+		return 0
+	})
+	removeOrderByExprs = walkSQL(func(xfi int, node interface{}) int {
+		switch node := node.(type) {
+		case *tree.Delete:
+			n := len(node.OrderBy)
+			if xfi < len(node.OrderBy) {
+				node.OrderBy = append(node.OrderBy[:xfi], node.OrderBy[xfi+1:]...)
+			}
+			return n
+		case *tree.FuncExpr:
+			n := len(node.OrderBy)
+			if xfi < len(node.OrderBy) {
+				node.OrderBy = append(node.OrderBy[:xfi], node.OrderBy[xfi+1:]...)
+			}
+			return n
+		case *tree.Select:
+			n := len(node.OrderBy)
+			if xfi < len(node.OrderBy) {
+				node.OrderBy = append(node.OrderBy[:xfi], node.OrderBy[xfi+1:]...)
+			}
+			return n
+		case *tree.Update:
+			n := len(node.OrderBy)
+			if xfi < len(node.OrderBy) {
+				node.OrderBy = append(node.OrderBy[:xfi], node.OrderBy[xfi+1:]...)
+			}
+			return n
+		case *tree.WindowDef:
+			n := len(node.OrderBy)
+			if xfi < len(node.OrderBy) {
+				node.OrderBy = append(node.OrderBy[:xfi], node.OrderBy[xfi+1:]...)
+			}
+			return n
+		}
+		return 0
+	})
+	removeGroupBy = walkSQL(func(xfi int, node interface{}) int {
+		xf := xfi == 0
+		switch node := node.(type) {
+		case *tree.SelectClause:
+			if node.GroupBy != nil {
+				if xf {
+					node.GroupBy = nil
+				}
+				return 1
+			}
+		}
+		return 0
+	})
+	removeGroupByExprs = walkSQL(func(xfi int, node interface{}) int {
+		switch node := node.(type) {
+		case *tree.SelectClause:
+			n := len(node.GroupBy)
+			if xfi < len(node.GroupBy) {
+				node.GroupBy = append(node.GroupBy[:xfi], node.GroupBy[xfi+1:]...)
+			}
+			return n
+		}
+		return 0
+	})
+	nullExprs = walkSQL(func(xfi int, node interface{}) int {
+		xf := xfi == 0
+		switch node := node.(type) {
+		case *tree.SelectClause:
+			if len(node.Exprs) != 1 || node.Exprs[0].Expr != tree.DNull {
+				if xf {
+					node.Exprs = tree.SelectExprs{tree.SelectExpr{Expr: tree.DNull}}
+				}
+				return 1
+			}
+		}
+		return 0
+	})
+	removeSelectExprs = walkSQL(func(xfi int, node interface{}) int {
+		switch node := node.(type) {
+		case *tree.SelectClause:
+			n := len(node.Exprs)
+			if xfi < len(node.Exprs) {
+				node.Exprs = append(node.Exprs[:xfi], node.Exprs[xfi+1:]...)
+			}
+			return n
+		}
+		return 0
+	})
+	removeWithSelectExprs = walkSQL(func(xfi int, node interface{}) int {
+		switch node := node.(type) {
+		case *tree.CTE:
+			if len(node.Name.Cols) < 1 {
+				break
+			}
+			slct, ok := node.Stmt.(*tree.Select)
+			if !ok {
+				break
+			}
+			clause, ok := slct.Select.(*tree.SelectClause)
+			if !ok {
+				break
+			}
+			n := len(clause.Exprs)
+			if xfi < len(clause.Exprs) {
+				node.Name.Cols = append(node.Name.Cols[:xfi], node.Name.Cols[xfi+1:]...)
+				clause.Exprs = append(clause.Exprs[:xfi], clause.Exprs[xfi+1:]...)
+			}
+			return n
+		}
+		return 0
+	})
+	removeValuesCols = walkSQL(func(xfi int, node interface{}) int {
+		switch node := node.(type) {
+		case *tree.AliasedTableExpr:
+			subq, ok := node.Expr.(*tree.Subquery)
+			if !ok {
+				break
+			}
+			values, ok := skipParenSelect(subq.Select).(*tree.ValuesClause)
+			if !ok {
+				break
+			}
+			if len(values.Rows) < 1 {
+				break
+			}
+			n := len(values.Rows[0])
+			if xfi < n {
+				removeValuesCol(values, xfi)
+				// Remove the VALUES alias.
+				if len(node.As.Cols) > xfi {
+					node.As.Cols = append(node.As.Cols[:xfi], node.As.Cols[xfi+1:]...)
+				}
+			}
+			return n
+		case *tree.CTE:
+			slct, ok := node.Stmt.(*tree.Select)
+			if !ok {
+				break
+			}
+			clause, ok := slct.Select.(*tree.SelectClause)
+			if !ok {
+				break
+			}
+			if len(clause.From.Tables) != 1 {
+				break
+			}
+			ate, ok := clause.From.Tables[0].(*tree.AliasedTableExpr)
+			if !ok {
+				break
+			}
+			subq, ok := ate.Expr.(*tree.Subquery)
+			if !ok {
+				break
+			}
+			values, ok := skipParenSelect(subq.Select).(*tree.ValuesClause)
+			if !ok {
+				break
+			}
+			if len(values.Rows) < 1 {
+				break
+			}
+			n := len(values.Rows[0])
+			if xfi < n {
+				removeValuesCol(values, xfi)
+				// Remove the WITH alias.
+				if len(node.Name.Cols) > xfi {
+					node.Name.Cols = append(node.Name.Cols[:xfi], node.Name.Cols[xfi+1:]...)
+				}
+				// Remove the VALUES alias.
+				if len(ate.As.Cols) > xfi {
+					ate.As.Cols = append(ate.As.Cols[:xfi], ate.As.Cols[xfi+1:]...)
+				}
+			}
+			return n
+		case *tree.ValuesClause:
+			if len(node.Rows) < 1 {
+				break
+			}
+			n := len(node.Rows[0])
+			if xfi < n {
+				removeValuesCol(node, xfi)
+			}
+			return n
+		}
+		return 0
+	})
+	removeSelectAsExprs = walkSQL(func(xfi int, node interface{}) int {
+		switch node := node.(type) {
+		case *tree.AliasedTableExpr:
+			if len(node.As.Cols) < 1 {
+				break
+			}
+			subq, ok := node.Expr.(*tree.Subquery)
+			if !ok {
+				break
+			}
+			clause, ok := skipParenSelect(subq.Select).(*tree.SelectClause)
+			if !ok {
+				break
+			}
+			n := len(clause.Exprs)
+			if xfi < len(clause.Exprs) {
+				node.As.Cols = append(node.As.Cols[:xfi], node.As.Cols[xfi+1:]...)
+				clause.Exprs = append(clause.Exprs[:xfi], clause.Exprs[xfi+1:]...)
+			}
+			return n
+		}
+		return 0
+	})
+	removeWith = walkSQL(func(xfi int, node interface{}) int {
+		xf := xfi == 0
+		switch node := node.(type) {
+		case *tree.Delete:
+			if node.With != nil {
+				if xf {
+					node.With = nil
+				}
+				return 1
+			}
+		case *tree.Insert:
+			if node.With != nil {
+				if xf {
+					node.With = nil
+				}
+				return 1
+			}
+		case *tree.Select:
+			if node.With != nil {
+				if xf {
+					node.With = nil
+				}
+				return 1
+			}
+		case *tree.Update:
+			if node.With != nil {
+				if xf {
+					node.With = nil
+				}
+				return 1
+			}
+		}
+		return 0
+	})
+	removeCreateDefs = walkSQL(func(xfi int, node interface{}) int {
+		switch node := node.(type) {
+		case *tree.CreateTable:
+			n := len(node.Defs)
+			if xfi < len(node.Defs) {
+				node.Defs = append(node.Defs[:xfi], node.Defs[xfi+1:]...)
+			}
+			return n
+		}
+		return 0
+	})
+	removeCreateNullDefs = walkSQL(func(xfi int, node interface{}) int {
+		xf := xfi == 0
+		switch node := node.(type) {
+		case *tree.ColumnTableDef:
+			if node.Nullable.Nullability != tree.SilentNull {
+				if xf {
+					node.Nullable.Nullability = tree.SilentNull
+				}
+				return 1
+			}
+		}
+		return 0
+	})
+	removeIndexCols = walkSQL(func(xfi int, node interface{}) int {
+		switch node := node.(type) {
+		case *tree.IndexTableDef:
+			n := len(node.Columns)
+			if xfi < len(node.Columns) {
+				node.Columns = append(node.Columns[:xfi], node.Columns[xfi+1:]...)
+			}
+			return n
+		}
+		return 0
+	})
+	removeWindowPartitions = walkSQL(func(xfi int, node interface{}) int {
+		switch node := node.(type) {
+		case *tree.WindowDef:
+			n := len(node.Partitions)
+			if xfi < len(node.Partitions) {
+				node.Partitions = append(node.Partitions[:xfi], node.Partitions[xfi+1:]...)
+			}
+			return n
+		}
+		return 0
+	})
+	removeValuesRows = walkSQL(func(xfi int, node interface{}) int {
+		switch node := node.(type) {
+		case *tree.ValuesClause:
+			n := len(node.Rows)
+			if xfi < len(node.Rows) {
+				node.Rows = append(node.Rows[:xfi], node.Rows[xfi+1:]...)
+			}
+			return n
+		}
+		return 0
+	})
+	removeWithCTEs = walkSQL(func(xfi int, node interface{}) int {
+		switch node := node.(type) {
+		case *tree.With:
+			n := len(node.CTEList)
+			if xfi < len(node.CTEList) {
+				node.CTEList = append(node.CTEList[:xfi], node.CTEList[xfi+1:]...)
+			}
+			return n
+		}
+		return 0
+	})
+	removeCTENames = walkSQL(func(xfi int, node interface{}) int {
+		xf := xfi == 0
+		switch node := node.(type) {
+		case *tree.CTE:
+			if len(node.Name.Cols) > 0 {
+				if xf {
+					node.Name.Cols = nil
+				}
+				return 1
+			}
+		}
+		return 0
+	})
+	removeFroms = walkSQL(func(xfi int, node interface{}) int {
+		switch node := node.(type) {
+		case *tree.SelectClause:
+			n := len(node.From.Tables)
+			if xfi < len(node.From.Tables) {
+				node.From.Tables = append(node.From.Tables[:xfi], node.From.Tables[xfi+1:]...)
+			}
+			return n
+		}
+		return 0
+	})
+	simplifyVal = walkSQL(func(xfi int, node interface{}) int {
+		xf := xfi == 0
+		switch node := node.(type) {
+		case *tree.StrVal:
+			if node.RawString() != "" {
+				if xf {
+					*node = *tree.NewStrVal("")
+				}
+				return 1
+			}
+		case *tree.NumVal:
+			if node.OrigString != "0" {
+				if xf {
+					*node = tree.NumVal{
+						Value:      constant.MakeInt64(0),
+						OrigString: "0",
+					}
+				}
+				return 1
+			}
+		}
+		return 0
+	})
+	removeWhere = walkSQL(func(xfi int, node interface{}) int {
+		xf := xfi == 0
+		switch node := node.(type) {
+		case *tree.SelectClause:
+			if node.Where != nil {
+				if xf {
+					node.Where = nil
+				}
+				return 1
+			}
+		}
+		return 0
+	})
+	removeHaving = walkSQL(func(xfi int, node interface{}) int {
+		xf := xfi == 0
+		switch node := node.(type) {
+		case *tree.SelectClause:
+			if node.Having != nil {
+				if xf {
+					node.Having = nil
+				}
+				return 1
+			}
+		}
+		return 0
+	})
+	removeDistinct = walkSQL(func(xfi int, node interface{}) int {
+		xf := xfi == 0
+		switch node := node.(type) {
+		case *tree.SelectClause:
+			if node.Distinct {
+				if xf {
+					node.Distinct = false
+				}
+				return 1
+			}
+		}
+		return 0
+	})
+	unparenthesize = walkSQL(func(xfi int, node interface{}) int {
+		switch node := node.(type) {
+		case tree.Exprs:
+			n := 0
+			for i, x := range node {
+				if x, ok := x.(*tree.ParenExpr); ok {
+					if n == xfi {
+						node[i] = x.Expr
+					}
+					n++
+				}
+			}
+			return n
+		}
+		return 0
+	})
+	nullifyFuncArgs = walkSQL(func(xfi int, node interface{}) int {
+		switch node := node.(type) {
+		case *tree.FuncExpr:
+			n := 0
+			for i, x := range node.Exprs {
+				if x != tree.DNull {
+					if n == xfi {
+						node.Exprs[i] = tree.DNull
+					}
+					n++
+				}
+			}
+			return n
+		}
+		return 0
+	})
+	simplifyOnCond = walkSQL(func(xfi int, node interface{}) int {
+		xf := xfi == 0
+		switch node := node.(type) {
+		case *tree.OnJoinCond:
+			if node.Expr != tree.DBoolTrue {
+				if xf {
+					node.Expr = tree.DBoolTrue
+				}
+				return 1
+			}
+		}
+		return 0
+	})
+
+	// Replacements.
+
+	removeStatement = replaceStatement(func(xfi int, node interface{}) (int, tree.NodeFormatter) {
+		xf := xfi == 0
+		if _, ok := node.(tree.Statement); ok {
+			if xf {
+				return 1, emptyStatement{}
+			}
+			return 1, nil
+		}
+		return 0, nil
+	})
+	replaceStmt = replaceStatement(func(xfi int, node interface{}) (int, tree.NodeFormatter) {
+		xf := xfi == 0
+		switch node := node.(type) {
+		case *tree.ParenSelect:
+			if xf {
+				return 1, node.Select
+			}
+			return 1, nil
+		case *tree.Subquery:
+			if xf {
+				return 1, node.Select
+			}
+			return 1, nil
+		case *tree.With:
+			n := len(node.CTEList)
+			if xfi < len(node.CTEList) {
+				return n, node.CTEList[xfi].Stmt
+			}
+			return n, nil
+		}
+		return 0, nil
+	})
+
+	// Regexes.
+
+	removeCastsRE = regexp.MustCompile(`:::?[a-zA-Z0-9]+`)
+	removeCasts   = reduce.MakeIntPass(func(s string, i int) (string, bool, error) {
+		out := removeCastsRE.ReplaceAllStringFunc(s, func(found string) string {
+			i--
+			if i == -1 {
+				return ""
+			}
+			return found
+		})
+		return out, i < 0, nil
+	})
+	removeAliasesRE = regexp.MustCompile(`\sAS\s+\w+`)
+	removeAliases   = reduce.MakeIntPass(func(s string, i int) (string, bool, error) {
+		out := removeAliasesRE.ReplaceAllStringFunc(s, func(found string) string {
+			i--
+			if i == -1 {
+				return ""
+			}
+			return found
+		})
+		return out, i < 0, nil
+	})
+	removeDBSchemaRE = regexp.MustCompile(`\w+\.\w+\.`)
+	removeDBSchema   = reduce.MakeIntPass(func(s string, i int) (string, bool, error) {
+		// Remove the database and schema from "default.public.xxx".
+		out := removeDBSchemaRE.ReplaceAllStringFunc(s, func(found string) string {
+			i--
+			if i == -1 {
+				return ""
+			}
+			return found
+		})
+		return out, i < 0, nil
+	})
+)
+
+func skipParenSelect(stmt tree.SelectStatement) tree.SelectStatement {
+	for {
+		ps, ok := stmt.(*tree.ParenSelect)
+		if !ok {
+			return stmt
+		}
+		stmt = ps.Select.Select
+	}
+
+}
+
+func removeValuesCol(values *tree.ValuesClause, col int) {
+	for i, row := range values.Rows {
+		values.Rows[i] = append(row[:col], row[col+1:]...)
+	}
+}
+
+type emptyStatement struct{}
+
+func (e emptyStatement) Format(*tree.FmtCtx) {}

--- a/pkg/testutils/reduce/reducesql/reducesql_test.go
+++ b/pkg/testutils/reduce/reducesql/reducesql_test.go
@@ -1,0 +1,73 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package reducesql_test
+
+import (
+	"context"
+	"flag"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/reduce"
+	"github.com/cockroachdb/cockroach/pkg/testutils/reduce/reducesql"
+	"github.com/jackc/pgx"
+)
+
+var printUnknown = flag.Bool("unknown", false, "print unknown types during walk")
+
+func TestReduceSQL(t *testing.T) {
+	// These take a bit too long to need to run every time.
+	t.Skip("unnecessary")
+	reducesql.LogUnknown = *printUnknown
+
+	reduce.Walk(t, "testdata", isInterestingSQL, reducesql.SQLPasses)
+}
+
+func isInterestingSQL(contains string) reduce.InterestingFn {
+	return func(f reduce.File) bool {
+		args := base.TestServerArgs{
+			Insecure: true,
+		}
+		server := server.TestServerFactory.New(args).(*server.TestServer)
+		if err := server.Start(args); err != nil {
+			panic(err)
+		}
+		ctx := context.Background()
+		defer server.Stopper().Stop(ctx)
+
+		options := url.Values{}
+		options.Add("sslmode", "disable")
+		url := url.URL{
+			Scheme:   "postgres",
+			User:     url.User(security.RootUser),
+			Host:     server.ServingAddr(),
+			RawQuery: options.Encode(),
+		}
+
+		conf, err := pgx.ParseURI(url.String())
+		if err != nil {
+			panic(err)
+		}
+		db, err := pgx.Connect(conf)
+		if err != nil {
+			panic(err)
+		}
+		_, err = db.Exec(string(f))
+		if err == nil {
+			return false
+		}
+		return strings.Contains(err.Error(), contains)
+	}
+}

--- a/pkg/testutils/reduce/reducesql/testdata/simple
+++ b/pkg/testutils/reduce/reducesql/testdata/simple
@@ -1,0 +1,69 @@
+contains
+division by zero
+----
+
+reduce
+WITH
+	with_t1 (c1, c2)
+		AS (
+			SELECT 1, 1/0
+		)
+SELECT * FROM with_t1
+----
+SELECT 1 / 0;
+
+reduce
+WITH
+	w
+		AS (
+			VALUES
+				(1),
+				(2),
+				((1 / 0)::INT8)
+		)
+SELECT
+	*
+FROM
+	w;
+----
+VALUES (1 / 0);
+
+reduce
+SELECT
+	1 / 0
+FROM
+	(SELECT 1), (SELECT 2);
+----
+SELECT 1 / 0;
+
+reduce
+CREATE TABLE a (i) AS VALUES (1);
+
+CREATE TABLE b (j) AS VALUES (0);
+
+SELECT
+	c.i / j
+FROM
+	a, a AS c JOIN b ON true;
+----
+----
+CREATE TABLE a (i) AS VALUES (1);
+
+CREATE TABLE b (j) AS VALUES (0);
+
+SELECT c.i / j FROM a AS c JOIN b ON true;
+----
+----
+
+contains
+no data source matches prefix
+----
+
+reduce
+SELECT
+	set_masklen(
+		'4ac:ded4:393a:a371:7690:9d0f:4817:3371/43',
+		tab_1226.col5
+	);
+----
+SELECT set_masklen(NULL, tab_1226.col5);

--- a/pkg/testutils/reduce/reducesql/testdata/ungrouped-column
+++ b/pkg/testutils/reduce/reducesql/testdata/ungrouped-column
@@ -1,0 +1,90 @@
+contains
+subquery uses ungrouped column "col1" from outer query
+----
+
+reduce
+CREATE TABLE table0 (col0 STRING NOT NULL, col1 FLOAT4 NULL, col2 REGTYPE NULL, col3 INT8 NOT NULL, col4 BIT(44), col5 TIME NOT NULL, FAMILY fam0 (col2), FAMILY fam1 (col4), FAMILY fam2 (col5), FAMILY fam3 (col0), FAMILY fam4 (col3), FAMILY fam5 (col1), PRIMARY KEY (col2));
+
+CREATE TABLE table1 (col0 DECIMAL NOT NULL, col1 BYTES NULL, col2 REGPROCEDURE NOT NULL, col3 UUID NOT NULL, col4 REGPROC NULL, col5 INT4 NULL, col6 CHAR, col7 REGTYPE, FAMILY fam0 (col1), FAMILY fam1 (col2, col0), FAMILY fam2 (col6, col5), FAMILY fam3 (col4), FAMILY fam4 (col7, col3), PRIMARY KEY (col1 DESC), UNIQUE (col0 ASC, col3 ASC, col6, col2 DESC, col4 ASC, col7), UNIQUE (col7 ASC, col3 DESC, col1, col5, col0 ASC, col4 DESC, col2, col6 DESC), UNIQUE (col3, col7, col4 ASC, col0, col5 ASC, col1), INDEX (col2, col5 ASC, col0 DESC), UNIQUE (col7 ASC, col6), INDEX (col0 ASC, col5 ASC, col1 ASC, col2 ASC, col6 DESC, col7 DESC), UNIQUE (col1, col5, col3 DESC), UNIQUE (col4 DESC, col0 DESC, col5 DESC, col2));
+
+WITH
+	with_273 (col_3485, col_3486, col_3487, col_3488, col_3489, col_3490, col_3491, col_3492, col_3493)
+		AS (
+			SELECT
+				(-6623365040095722935):::INT8 AS col_3485,
+				false AS col_3486,
+				tab_1229.col1 AS col_3487,
+				tab_1229.col6 AS col_3488,
+				'1993-06-15':::DATE AS col_3489,
+				'`rV':::STRING AS col_3490,
+				tab_1229.col4 AS col_3491,
+				B'0110011001100' AS col_3492,
+				tab_1229.col0 AS col_3493
+			FROM
+				(
+					SELECT
+						tab_1222.col5 AS col_3477,
+						tab_1222.col4 AS col_3478,
+						max(tab_1222.col3::UUID)::UUID AS col_3479,
+						stddev(tab_1222.col5::INT8)::DECIMAL AS col_3480
+					FROM
+						defaultdb.public.table1 AS tab_1222
+					WHERE
+						false
+					GROUP BY
+						tab_1222.col0, tab_1222.col4, tab_1222.col5, tab_1222.col3
+					HAVING
+						inet_same_family(((SELECT set_masklen('4ac:ded4:393a:a371:7690:9d0f:4817:3371/43':::INET::INET, tab_1226.col5::INT8)::INET AS col_3476 FROM defaultdb.public.table1 AS tab_1223 RIGHT JOIN (SELECT tab_1222.col1 AS col_3470, tab_1222.col0 AS col_3471, tab_1222.col3 AS col_3472 LIMIT 5:::INT8) AS tab_1224 (col_3473, col_3474, col_3475) JOIN defaultdb.public.table0 AS tab_1225 RIGHT JOIN defaultdb.public.table1 AS tab_1226 ON NULL FULL JOIN defaultdb.public.table1 AS tab_1227 ON false ON similar_to_escape(tab_1222.col6::STRING, NULL::STRING, tab_1222.col6::STRING)::BOOL ON inet_contains_or_equals(set_masklen('198f:60f5:287a:8163:c091:2a95:afdc:ae8b/108':::INET::INET, (-4475677368810664623):::INT8::INT8)::INET::INET, '6d38:61ce:1af7:9283:cf0d:beb2:23e0:d7f/109':::INET::INET)::BOOL ORDER BY tab_1226.col7 DESC LIMIT 1:::INT8)::INET - tab_1222.col5::INT8)::INET::INET, NULL::INET)::BOOL
+				)
+					AS tab_1228 (col_3481, col_3482, col_3483, col_3484),
+				defaultdb.public.table1 AS tab_1229,
+				defaultdb.public.table1 AS tab_1230
+		)
+SELECT
+	'c':::STRING AS col_3494,
+	e'\x00':::STRING AS col_3495,
+	tab_1232.col2 AS col_3496,
+	tab_1232.col3 AS col_3497,
+	3.4028234663852886e+38:::FLOAT8 AS col_3498,
+	NULL AS col_3499
+FROM
+	defaultdb.public.table1 AS tab_1231,
+	defaultdb.public.table0 AS tab_1232,
+	with_273,
+	defaultdb.public.table0 AS tab_1233
+WHERE
+	with_273.col_3486
+ORDER BY
+	tab_1233.col0 DESC, tab_1232.col4 ASC, with_273.col_3490 ASC
+LIMIT
+	23:::INT8;
+----
+----
+CREATE TABLE table0 ();
+
+CREATE TABLE table1 (col1 BYTES, col5 INT4);
+
+SELECT
+	NULL
+FROM
+	table1 AS tab_1222
+HAVING
+	inet_same_family(
+		(
+			SELECT
+				NULL
+			FROM
+				table1
+				RIGHT JOIN (SELECT tab_1222.col1)
+						AS tab_1224 (col_3473)
+					JOIN table0
+						RIGHT JOIN table1 AS tab_1226 ON
+								true
+						FULL JOIN table1 AS tab_1227 ON
+								true ON true ON true
+		)::INET
+		- tab_1222.col5,
+		NULL::INET
+	);
+----
+----

--- a/pkg/testutils/reduce/testdata/go
+++ b/pkg/testutils/reduce/testdata/go
@@ -1,0 +1,9 @@
+contains
+expected 'EOF', found blah
+----
+
+reduce
+123 + abc blah
+* 456
+----
+1 + a blah


### PR DESCRIPTION
reduce is a new command and package that reduces SQL based on a target
error. It is implemented in 3 separate packages for reuse.

The reduce package contains the base reduction algorithm described in
its godoc. It has some helpers, but otherwise doesn't know about any
specific language.

The reducesql package contains the reducers for SQL.

The reduce command wraps both of those packages in a CLI command that
reduces SQL by running cockroach demo.

Release note: None