### PR TITLE
sql: improve consistency for putting descriptor protos

### DIFF
--- a/pkg/ccl/backupccl/restore.go
+++ b/pkg/ccl/backupccl/restore.go
@@ -949,7 +949,7 @@ func WriteTableDescs(
 			// TODO(dt): support restoring privs.
 			desc.Privileges = sqlbase.NewDefaultPrivilegeDescriptor()
 			wroteDBs[desc.ID] = desc
-			b.CPut(sqlbase.MakeDescMetadataKey(desc.ID), sqlbase.WrapDescriptor(desc), nil)
+			sql.WriteNewDescToBatch(ctx, false /* kvTrace */, settings, b, desc.ID, desc)
 			b.CPut(sqlbase.MakeNameMetadataKey(keys.RootNamespaceID, desc.Name), desc.ID, nil)
 		}
 		for i := range tables {
@@ -969,8 +969,8 @@ func WriteTableDescs(
 				// TODO(dt): Make this more configurable.
 				tables[i].Privileges = parentDB.GetPrivileges()
 			}
-			b.CPut(tables[i].GetDescMetadataKey(), sqlbase.WrapDescriptor(tables[i]), nil)
-			b.CPut(tables[i].GetNameMetadataKey(), tables[i].ID, nil)
+			sql.WriteNewDescToBatch(ctx, false /* kvTrace */, settings, b, tables[i].ID, tables[i])
+			b.CPut(sqlbase.MakeNameMetadataKey(tables[i].ParentID, tables[i].Name), tables[i].ID, nil)
 		}
 		for _, kv := range extra {
 			b.InitPut(kv.Key, &kv.Value, false)
@@ -1543,7 +1543,7 @@ func (r *restoreResumer) OnFailOrCancel(ctx context.Context, txn *client.Txn) er
 	b := txn.NewBatch()
 	for _, tableDesc := range details.TableDescs {
 		tableDesc.State = sqlbase.TableDescriptor_DROP
-		b.CPut(sqlbase.MakeDescMetadataKey(tableDesc.ID), sqlbase.WrapDescriptor(tableDesc), nil)
+		sql.WriteNewDescToBatch(ctx, false /* kvTrace */, r.settings, b, tableDesc.ID, tableDesc)
 	}
 	return txn.Run(ctx, b)
 }

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -420,6 +420,10 @@ func importPlanHook(
 					return err
 				}
 				return errors.Wrap(
+					// Note that this CPut is safe with respect to mixed-version descriptor
+					// upgrade and downgrade, because IMPORT does not operate in mixed-version
+					// states.
+					// TODO(jordan,lucy): remove this comment once 19.2 is released.
 					txn.CPut(ctx, sqlbase.MakeDescMetadataKey(found.TableDescriptor.ID),
 						sqlbase.WrapDescriptor(&importing), sqlbase.WrapDescriptor(&found.TableDescriptor),
 					), "another operation is currently operating on the table")
@@ -827,6 +831,10 @@ func (r *importResumer) OnFailOrCancel(ctx context.Context, txn *client.Txn) err
 			tableDesc.Version++
 			tableDesc.State = sqlbase.TableDescriptor_PUBLIC
 		}
+		// Note that this CPut is safe with respect to mixed-version descriptor
+		// upgrade and downgrade, because IMPORT does not operate in mixed-version
+		// states.
+		// TODO(jordan,lucy): remove this comment once 19.2 is released.
 		b.CPut(sqlbase.MakeDescMetadataKey(tableDesc.ID), sqlbase.WrapDescriptor(&tableDesc), sqlbase.WrapDescriptor(tbl.Desc))
 	}
 	return errors.Wrap(txn.Run(ctx, b), "rolling back tables")
@@ -847,6 +855,10 @@ func (r *importResumer) OnSuccess(ctx context.Context, txn *client.Txn) error {
 		tableDesc.Version++
 		tableDesc.State = sqlbase.TableDescriptor_PUBLIC
 		// TODO(dt): re-validate any FKs?
+		// Note that this CPut is safe with respect to mixed-version descriptor
+		// upgrade and downgrade, because IMPORT does not operate in mixed-version
+		// states.
+		// TODO(jordan,lucy): remove this comment once 19.2 is released.
 		b.CPut(sqlbase.MakeDescMetadataKey(tableDesc.ID), sqlbase.WrapDescriptor(&tableDesc), sqlbase.WrapDescriptor(tbl.Desc))
 	}
 	if err := txn.Run(ctx, b); err != nil {

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -104,8 +104,8 @@ func (p *planner) changePrivileges(
 			if err := d.Validate(); err != nil {
 				return nil, err
 			}
-			descKey := sqlbase.MakeDescMetadataKey(descriptor.GetID())
-			b.Put(descKey, sqlbase.WrapDescriptor(descriptor))
+			writeDescToBatch(ctx, p.extendedEvalCtx.Tracing.KVTracingEnabled(), p.execCfg.Settings,
+				b, descriptor.GetID(), descriptor)
 
 		case *sqlbase.MutableTableDescriptor:
 			if !d.Dropped() {

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -418,7 +418,7 @@ func (s LeaseStore) PublishMultiple(
 			}
 			b := txn.NewBatch()
 			for tableID, tableDesc := range tableDescs {
-				b.Put(sqlbase.MakeDescMetadataKey(tableID), sqlbase.WrapDescriptor(tableDesc))
+				writeDescToBatch(ctx, false /* kvTrace */, s.settings, b, tableID, tableDesc.TableDesc())
 			}
 			if logEvent != nil {
 				// If an event log is required for this update, ensure that the

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -106,7 +106,6 @@ func (n *renameTableNode) startExec(params runParams) error {
 	tableDesc.SetName(newTn.Table())
 	tableDesc.ParentID = targetDbDesc.ID
 
-	descKey := sqlbase.MakeDescMetadataKey(tableDesc.GetID())
 	newTbKey := sqlbase.NewTableKey(targetDbDesc.ID, newTn.Table()).Key()
 
 	if err := tableDesc.Validate(ctx, p.txn, p.EvalContext().Settings); err != nil {
@@ -114,7 +113,6 @@ func (n *renameTableNode) startExec(params runParams) error {
 	}
 
 	descID := tableDesc.GetID()
-	descDesc := sqlbase.WrapDescriptor(tableDesc)
 
 	renameDetails := sqlbase.TableDescriptor_NameInfo{
 		ParentID: prevDbDesc.ID,
@@ -129,10 +127,10 @@ func (n *renameTableNode) startExec(params runParams) error {
 	// has made sure it's not in use any more.
 	b := &client.Batch{}
 	if p.extendedEvalCtx.Tracing.KVTracingEnabled() {
-		log.VEventf(ctx, 2, "Put %s -> %s", descKey, descDesc)
 		log.VEventf(ctx, 2, "CPut %s -> %d", newTbKey, descID)
 	}
-	b.Put(descKey, descDesc)
+	writeDescToBatch(ctx, p.extendedEvalCtx.Tracing.KVTracingEnabled(), p.EvalContext().Settings,
+		b, descID, tableDesc)
 	b.CPut(newTbKey, descID, nil)
 
 	if err := p.txn.Run(ctx, b); err != nil {

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2851,16 +2851,6 @@ func (desc *TableDescriptor) TableSpan() roachpb.Span {
 	return roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()}
 }
 
-// GetDescMetadataKey returns the descriptor key for the table.
-func (desc TableDescriptor) GetDescMetadataKey() roachpb.Key {
-	return MakeDescMetadataKey(desc.ID)
-}
-
-// GetNameMetadataKey returns the namespace key for the table.
-func (desc TableDescriptor) GetNameMetadataKey() roachpb.Key {
-	return MakeNameMetadataKey(desc.ParentID, desc.Name)
-}
-
 // SQLString returns the SQL statement describing the column.
 func (desc *ColumnDescriptor) SQLString() string {
 	f := tree.NewFmtCtx(tree.FmtSimple)

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -849,12 +849,7 @@ func (p *planner) writeTableDescToBatch(
 		return err
 	}
 
-	descKey := sqlbase.MakeDescMetadataKey(tableDesc.GetID())
-	descVal := sqlbase.WrapDescriptor(tableDesc)
-	if p.extendedEvalCtx.Tracing.KVTracingEnabled() {
-		log.VEventf(ctx, 2, "Put %s -> %s", descKey, descVal)
-	}
-
-	b.Put(descKey, descVal)
+	writeDescToBatch(ctx, p.extendedEvalCtx.Tracing.KVTracingEnabled(), p.execCfg.Settings,
+		b, tableDesc.GetID(), tableDesc)
 	return nil
 }


### PR DESCRIPTION
This paves the way for having a downgrade step for the foreign key
descriptor migration coming up soon.

Release note: None