### PR TITLE
exec: fix handling of empty table by aggregates

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -231,11 +231,11 @@ func newColOperator(
 		}
 		if needHash {
 			op, err = exec.NewHashAggregator(
-				inputs[0], typs, aggFns, aggSpec.GroupCols, aggCols,
+				inputs[0], typs, aggFns, aggSpec.GroupCols, aggCols, isScalarAggregate(aggSpec),
 			)
 		} else {
 			op, err = exec.NewOrderedAggregator(
-				inputs[0], typs, aggFns, aggSpec.GroupCols, aggCols,
+				inputs[0], typs, aggFns, aggSpec.GroupCols, aggCols, isScalarAggregate(aggSpec),
 			)
 		}
 

--- a/pkg/sql/exec/aggregator_test.go
+++ b/pkg/sql/exec/aggregator_test.go
@@ -59,6 +59,7 @@ type aggType struct {
 		aggFns []distsqlpb.AggregatorSpec_Func,
 		groupCols []uint32,
 		aggCols [][]uint32,
+		isScalar bool,
 	) (Operator, error)
 	name string
 }
@@ -269,6 +270,7 @@ func TestAggregatorOneFunc(t *testing.T) {
 				tc.aggFns,
 				tc.groupCols,
 				tc.aggCols,
+				false, /* isScalar */
 			)
 			if err != nil {
 				t.Fatal(err)
@@ -294,6 +296,7 @@ func TestAggregatorOneFunc(t *testing.T) {
 									tc.aggFns,
 									tc.groupCols,
 									tc.aggCols,
+									false, /* isScalar */
 								)
 							})
 					})
@@ -369,7 +372,7 @@ func TestAggregatorMultiFunc(t *testing.T) {
 				}
 				runTests(t, []tuples{tc.input}, tc.expected, unorderedVerifier, []int{0, 1},
 					func(input []Operator) (Operator, error) {
-						return agg.new(input[0], tc.colTypes, tc.aggFns, tc.groupCols, tc.aggCols)
+						return agg.new(input[0], tc.colTypes, tc.aggFns, tc.groupCols, tc.aggCols, false /* isScalar */)
 					})
 			})
 		}
@@ -452,7 +455,7 @@ func TestAggregatorAllFunctions(t *testing.T) {
 					orderedVerifier,
 					[]int{0, 1, 2, 3, 4, 5, 6, 7, 8}[:len(tc.expected[0])],
 					func(input []Operator) (Operator, error) {
-						return agg.new(input[0], tc.colTypes, tc.aggFns, tc.groupCols, tc.aggCols)
+						return agg.new(input[0], tc.colTypes, tc.aggFns, tc.groupCols, tc.aggCols, false /* isScalar */)
 					})
 			})
 		}
@@ -521,6 +524,7 @@ func TestAggregatorRandom(t *testing.T) {
 									distsqlpb.AggregatorSpec_AVG},
 								[]uint32{0},
 								[][]uint32{{}, {1}, {1}, {1}, {1}, {1}},
+								false, /* isScalar */
 							)
 							if err != nil {
 								t.Fatal(err)
@@ -671,6 +675,7 @@ func BenchmarkAggregator(b *testing.B) {
 											[]distsqlpb.AggregatorSpec_Func{aggFn},
 											[]uint32{0},
 											[][]uint32{[]uint32{1}[:nCols]},
+											false, /* isScalar */
 										)
 										if err != nil {
 											b.Skip()
@@ -821,7 +826,7 @@ func TestHashAggregator(t *testing.T) {
 			cols[i] = i
 		}
 		runTests(t, []tuples{tc.input}, tc.expected, unorderedVerifier, cols, func(sources []Operator) (Operator, error) {
-			return NewHashAggregator(sources[0], tc.colTypes, tc.aggFns, tc.groupCols, tc.aggCols)
+			return NewHashAggregator(sources[0], tc.colTypes, tc.aggFns, tc.groupCols, tc.aggCols, false /* isScalar */)
 		})
 	}
 }

--- a/pkg/sql/exec/any_not_null_agg_tmpl.go
+++ b/pkg/sql/exec/any_not_null_agg_tmpl.go
@@ -102,9 +102,8 @@ func (a *anyNotNull_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 	inputLen := b.Length()
 	if inputLen == 0 {
 		// If we haven't found any non-nulls for this group so far, the output for
-		// this group should be null. If a.curIdx is negative, it means the input
-		// has zero rows, and there should be no output at all.
-		if !a.foundNonNullForCurrentGroup && a.curIdx >= 0 {
+		// this group should be null.
+		if !a.foundNonNullForCurrentGroup {
 			a.nulls.SetNull(uint16(a.curIdx))
 		}
 		a.curIdx++
@@ -139,6 +138,10 @@ func (a *anyNotNull_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 			}
 		}
 	}
+}
+
+func (a *anyNotNull_TYPEAgg) HandleEmptyInputScalar() {
+	a.nulls.SetNull(0)
 }
 
 // {{end}}

--- a/pkg/sql/exec/avg_agg_tmpl.go
+++ b/pkg/sql/exec/avg_agg_tmpl.go
@@ -124,17 +124,13 @@ func (a *avg_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 	}
 	inputLen := b.Length()
 	if inputLen == 0 {
-
 		// The aggregation is finished. Flush the last value. If we haven't found
-		// any non-nulls for this group so far, the output for this group should
-		// be null. If a.scratch.curIdx is negative, it means the input has zero rows, and
-		// there should be no output at all.
-		if a.scratch.curIdx >= 0 {
-			if !a.scratch.foundNonNullForCurrentGroup {
-				a.scratch.nulls.SetNull(uint16(a.scratch.curIdx))
-			} else {
-				_ASSIGN_DIV_INT64("a.scratch.vec[a.scratch.curIdx]", "a.scratch.curSum", "a.scratch.curCount")
-			}
+		// any non-nulls for this group so far, the output for this group should be
+		// NULL.
+		if !a.scratch.foundNonNullForCurrentGroup {
+			a.scratch.nulls.SetNull(uint16(a.scratch.curIdx))
+		} else {
+			_ASSIGN_DIV_INT64("a.scratch.vec[a.scratch.curIdx]", "a.scratch.curSum", "a.scratch.curCount")
 		}
 		a.scratch.curIdx++
 		a.done = true
@@ -167,6 +163,10 @@ func (a *avg_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 			}
 		}
 	}
+}
+
+func (a *avg_TYPEAgg) HandleEmptyInputScalar() {
+	a.scratch.nulls.SetNull(0)
 }
 
 // {{end}}

--- a/pkg/sql/exec/count_agg.go
+++ b/pkg/sql/exec/count_agg.go
@@ -126,3 +126,7 @@ func (a *countAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 		}
 	}
 }
+
+func (a *countAgg) HandleEmptyInputScalar() {
+	a.vec[0] = 0
+}

--- a/pkg/sql/exec/hash_aggregator.go
+++ b/pkg/sql/exec/hash_aggregator.go
@@ -69,6 +69,7 @@ func NewHashAggregator(
 	aggFns []distsqlpb.AggregatorSpec_Func,
 	groupCols []uint32,
 	aggCols [][]uint32,
+	isScalar bool,
 ) (Operator, error) {
 	aggTyps := extractAggTypes(aggCols, colTypes)
 
@@ -141,6 +142,7 @@ func NewHashAggregator(
 		groupCol:       distinctCol,
 		aggregateFuncs: funcs,
 		outputTypes:    outTyps,
+		isScalar:       isScalar,
 	}
 
 	return &hashAggregator{

--- a/pkg/sql/exec/min_max_agg_tmpl.go
+++ b/pkg/sql/exec/min_max_agg_tmpl.go
@@ -122,14 +122,11 @@ func (a *_AGG_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 	if inputLen == 0 {
 		// The aggregation is finished. Flush the last value. If we haven't found
 		// any non-nulls for this group so far, the output for this group should
-		// be null. If a.curIdx is negative, it means the input has zero rows, and
-		// there should be no output at all.
-		if a.curIdx >= 0 {
-			if !a.foundNonNullForCurrentGroup {
-				a.nulls.SetNull(uint16(a.curIdx))
-			}
-			a.vec[a.curIdx] = a.curAgg
+		// be null.
+		if !a.foundNonNullForCurrentGroup {
+			a.nulls.SetNull(uint16(a.curIdx))
 		}
+		a.vec[a.curIdx] = a.curAgg
 		a.curIdx++
 		a.done = true
 		return
@@ -161,6 +158,10 @@ func (a *_AGG_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 			}
 		}
 	}
+}
+
+func (a *_AGG_TYPEAgg) HandleEmptyInputScalar() {
+	a.nulls.SetNull(0)
 }
 
 // {{end}}

--- a/pkg/sql/exec/sum_agg_tmpl.go
+++ b/pkg/sql/exec/sum_agg_tmpl.go
@@ -114,14 +114,11 @@ func (a *sum_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 	if inputLen == 0 {
 		// The aggregation is finished. Flush the last value. If we haven't found
 		// any non-nulls for this group so far, the output for this group should be
-		// null. If a.scratch.curIdx is negative, it means the input has zero rows,
-		// and there should be no output at all.
-		if a.scratch.curIdx >= 0 {
-			if !a.scratch.foundNonNullForCurrentGroup {
-				a.scratch.nulls.SetNull(uint16(a.scratch.curIdx))
-			}
-			a.scratch.vec[a.scratch.curIdx] = a.scratch.curAgg
+		// null.
+		if !a.scratch.foundNonNullForCurrentGroup {
+			a.scratch.nulls.SetNull(uint16(a.scratch.curIdx))
 		}
+		a.scratch.vec[a.scratch.curIdx] = a.scratch.curAgg
 		a.scratch.curIdx++
 		a.done = true
 		return
@@ -153,6 +150,10 @@ func (a *sum_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 			}
 		}
 	}
+}
+
+func (a *sum_TYPEAgg) HandleEmptyInputScalar() {
+	a.scratch.nulls.SetNull(0)
 }
 
 // {{end}}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -578,6 +578,8 @@ statement ok
 SET tracing = on; SELECT * FROM tpar WHERE a = 0 OR a = 10; SET tracing = off
 
 # The span "sending partial batch" means that the scan was parallelized.
+# Note that table ID here is hardcoded, so if a new table is created before
+# tpar, this query will need an adjustment.
 query T
 SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message IN 
     ('querying next range at /Table/71/1/0',
@@ -588,3 +590,18 @@ SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message IN
 querying next range at /Table/71/1/0
 === SPAN START: kv.DistSender: sending partial batch ===
 querying next range at /Table/71/1/10
+
+# Test for #38858 -- handle aggregates correctly on an empty table.
+statement ok
+CREATE TABLE empty (a INT PRIMARY KEY, b FLOAT)
+
+# GROUP BY is omitted, so aggregates are in scalar context.
+query IIIIIRR
+SELECT count(*), count(a), sum_int(a), min(a), max(a), sum(b), avg(b) FROM empty
+----
+0  0  NULL  NULL  NULL  NULL  NULL
+
+ # GROUP BY is present, so aggregates are in non-scalar context.
+query IIIIIRR
+SELECT count(*), count(a), sum_int(a), min(a), max(a), sum(b), avg(b) FROM empty GROUP BY a
+----


### PR DESCRIPTION
This commit adds special behavior for a case when the input to an
aggregate is empty. There is also a subtle difference between a
scalar and non-scalar case: if GROUP BY clause is omitted, the
aggregate is scalar, so it should emit null or zero, but if GROUP
BY is present, the aggregate is non-scalar and should emit no
output. These two cases are templated out.

Based on #38872.

Fixes: #38858.

Release note: None