### PR TITLE
roachtest: enable sysbench test suite

### DIFF
--- a/pkg/cmd/roachprod/install/cluster_synced.go
+++ b/pkg/cmd/roachprod/install/cluster_synced.go
@@ -1412,16 +1412,25 @@ func (c *SyncedCluster) Get(src, dest string) {
 }
 
 func (c *SyncedCluster) pgurls(nodes []int) map[int]string {
+	hosts := c.pghosts(nodes)
+	m := make(map[int]string, len(hosts))
+	for node, host := range hosts {
+		m[node] = c.Impl.NodeURL(c, host, c.Impl.NodePort(c, node))
+	}
+	return m
+}
+
+func (c *SyncedCluster) pghosts(nodes []int) map[int]string {
 	ips := make([]string, len(nodes))
 	c.Parallel("", len(nodes), 0, func(i int) ([]byte, error) {
 		var err error
 		ips[i], err = c.GetInternalIP(nodes[i])
-		return nil, errors.Wrapf(err, "pgurls")
+		return nil, errors.Wrapf(err, "pghosts")
 	})
 
 	m := make(map[int]string, len(ips))
 	for i, ip := range ips {
-		m[nodes[i]] = c.Impl.NodeURL(c, ip, c.Impl.NodePort(c, nodes[i]))
+		m[nodes[i]] = ip
 	}
 	return m
 }


### PR DESCRIPTION
Informs #32738.

Now that we know more about #32738, we know that we can safely avoid the segfault if we talk directly to a cockroach node (i.e bypass haproxy) during the preparation phase of sysbench. This commit re-enables the sysbench test suite after doing so.

The commit also passes the `--auto_inc=false` flag to sysbench. This is critical, because without this the test will use a `SERIAL` column for the primary key of each table. It then expects that the `SERIAL` column will create rows with values [1, table_size], which is not true in CRDB by default. Before this fix, I was noticing incredibly high UPDATE throughput, which was a result of never finding any real rows to update. We can use the `experimental_serial_normalization` variable to use a real SQL sequence to back the `SERIAL` column, but this slows down the import step by two orders of magnitude because updates to the sequence are not batched for multi-value INSERT statements.

One question I'd like to resolve during the review is whether we should tag this as a weekly test. We don't have the ability to parse its output to hook it up to roachperf (yet), so there's not a particularly strong reason to run it nightly.