### PR TITLE
sql/pgwire: embed commandResult in conn to avoid ClientComm allocations

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -93,10 +93,10 @@ func (ex *connExecutor) execStmt(
 				"stmt.anonymized", stmt.AnonymizedStr,
 			)
 			pprof.Do(ctx, labels, func(ctx context.Context) {
-				ev, payload, err = ex.execStmtInOpenState(ctx, stmt, pinfo, res)
+				ev, payload, err = ex.execStmtInOpenState(ctx, stmt, res, pinfo)
 			})
 		} else {
-			ev, payload, err = ex.execStmtInOpenState(ctx, stmt, pinfo, res)
+			ev, payload, err = ex.execStmtInOpenState(ctx, stmt, res, pinfo)
 		}
 		switch ev.(type) {
 		case eventNonRetriableErr:
@@ -131,7 +131,7 @@ func (ex *connExecutor) recordFailure() {
 //
 // The returned event can be nil if no state transition is required.
 func (ex *connExecutor) execStmtInOpenState(
-	ctx context.Context, stmt Statement, pinfo *tree.PlaceholderInfo, res RestrictedCommandResult,
+	ctx context.Context, stmt Statement, res RestrictedCommandResult, pinfo *tree.PlaceholderInfo,
 ) (retEv fsm.Event, retPayload fsm.EventPayload, retErr error) {
 	ex.incrementStartedStmtCounter(stmt)
 	defer func() {


### PR DESCRIPTION
This commit hangs a `commandResult` struct off of a `pgwire.conn`. This struct is the concrete type that implements `CommandResult` and all of its siblings (`SyncResult`, `BindResult`, etc.). We then track the lifetime of the struct so that we can re-use it in `ClientComm` methods. It turns out that users of `ClientComm` (i.e. the `connExecutor`) only ever use a single `ResultBase` instantiation at a time, so this "one use at a time" optimization allows us to avoid all allocations associated with boxing `commandResult` structs into these interfaces.

The `CommandResult` interface was nicely factored into a `CommandResultClose` sub-interface which gives us clean access to track the lifetime of these objects, so it's a little surprising that this wasn't already done.

```
name                     old time/op    new time/op    delta
KV/Insert/SQL/rows=1-16     260µs ± 6%     245µs ± 2%  -5.81%  (p=0.000 n=9+10)
KV/Update/SQL/rows=1-16     328µs ± 2%     311µs ± 1%  -5.00%  (p=0.000 n=9+10)
KV/Delete/SQL/rows=1-16     360µs ± 2%     352µs ± 6%  -2.32%  (p=0.043 n=10+10)
KV/Scan/SQL/rows=1-16       178µs ± 6%     177µs ± 2%    ~     (p=0.796 n=9+9)

name                     old alloc/op   new alloc/op   delta
KV/Insert/SQL/rows=1-16    34.6kB ± 0%    34.1kB ± 0%  -1.52%  (p=0.000 n=9+9)
KV/Update/SQL/rows=1-16    49.3kB ± 0%    48.8kB ± 0%  -1.05%  (p=0.000 n=10+10)
KV/Delete/SQL/rows=1-16    42.5kB ± 0%    42.0kB ± 0%  -1.31%  (p=0.000 n=9+9)
KV/Scan/SQL/rows=1-16      29.2kB ± 0%    28.7kB ± 0%  -1.78%  (p=0.000 n=9+9)

name                     old allocs/op  new allocs/op  delta
KV/Insert/SQL/rows=1-16       316 ± 0%       313 ± 0%  -0.95%  (p=0.000 n=9+9)
KV/Update/SQL/rows=1-16       467 ± 0%       464 ± 0%  -0.64%  (p=0.000 n=10+10)
KV/Delete/SQL/rows=1-16       400 ± 0%       397 ± 0%  -0.75%  (p=0.001 n=8+9)
KV/Scan/SQL/rows=1-16         292 ± 0%       289 ± 0%  -1.03%  (p=0.000 n=10+10)
```

Release note: None