### PR TITLE
opt: check dependencies by ID

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -1018,3 +1018,41 @@ SET database = ''
 
 query error  cannot access virtual schema in anonymous database
 EXECUTE display_appname
+
+statement ok
+SET database = 'test'
+
+# Lookup by ID: Rename column in table and ensure that the prepared statement
+# is updated to incorporate it.
+statement ok
+CREATE TABLE ab (a INT PRIMARY KEY, b INT); INSERT INTO ab(a, b) VALUES (1, 10)
+
+let $id
+SELECT id FROM system.namespace WHERE name='ab'
+
+statement ok
+PREPARE change_rename_2 AS SELECT * FROM [$id AS ab]
+
+query II colnames
+EXECUTE change_rename_2
+----
+a  b
+1  10
+
+statement ok
+ALTER TABLE ab RENAME COLUMN b TO c
+
+query II colnames
+EXECUTE change_rename_2
+----
+a  c
+1  10
+
+statement ok
+ALTER TABLE ab RENAME COLUMN c TO b
+
+query II colnames
+EXECUTE change_rename_2
+----
+a  b
+1  10

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -99,12 +99,26 @@ type Metadata struct {
 type mdDep struct {
 	ds cat.DataSource
 
-	// name is the unresolved name from the query that was used to resolve the
-	// object.
-	name cat.DataSourceName
+	name MDDepName
 
 	// privileges is the union of all required privileges.
 	privileges privilegeBitmap
+}
+
+// MDDepName stores either the unresolved DataSourceName or the StableID from
+// the query that was used to resolve a data source.
+type MDDepName struct {
+	// byID is non-zero if and only if the data source was looked up using the
+	// StableID.
+	byID cat.StableID
+
+	// byName is non-zero if and only if the data source was looked up using a
+	// name.
+	byName cat.DataSourceName
+}
+
+func (n *MDDepName) equals(other *MDDepName) bool {
+	return n.byID == other.byID && n.byName.Equals(&other.byName)
 }
 
 // Init prepares the metadata for use (or reuse).
@@ -152,24 +166,33 @@ func (md *Metadata) CopyFrom(from *Metadata) {
 	md.deps = append(md.deps, from.deps...)
 }
 
+// DepByName is used with AddDependency when the data source was looked up using a
+// data source name.
+func DepByName(name *cat.DataSourceName) MDDepName {
+	return MDDepName{byName: *name}
+}
+
+// DepByID is used with AddDependency when the data source was looked up by ID.
+func DepByID(id cat.StableID) MDDepName {
+	return MDDepName{byID: id}
+}
+
 // AddDependency tracks one of the catalog data sources on which the query
 // depends, as well as the privilege required to access that data source. If
 // the Memo using this metadata is cached, then a call to CheckDependencies can
 // detect if the name resolves to a different data source now, or if changes to
 // schema or permissions on the data source has invalidated the cached metadata.
-func (md *Metadata) AddDependency(
-	name *cat.DataSourceName, ds cat.DataSource, priv privilege.Kind,
-) {
+func (md *Metadata) AddDependency(name MDDepName, ds cat.DataSource, priv privilege.Kind) {
 	// Search for the same name / object pair.
 	for i := range md.deps {
-		if md.deps[i].ds == ds && md.deps[i].name.Equals(name) {
+		if md.deps[i].ds == ds && md.deps[i].name.equals(&name) {
 			md.deps[i].privileges |= (1 << priv)
 			return
 		}
 	}
 	md.deps = append(md.deps, mdDep{
 		ds:         ds,
-		name:       *name,
+		name:       name,
 		privileges: (1 << priv),
 	})
 }
@@ -187,9 +210,15 @@ func (md *Metadata) CheckDependencies(
 	ctx context.Context, catalog cat.Catalog,
 ) (upToDate bool, err error) {
 	for i := range md.deps {
-		name := md.deps[i].name
-		// Resolve data source object.
-		toCheck, _, err := catalog.ResolveDataSource(ctx, cat.Flags{}, &name)
+		name := &md.deps[i].name
+		var toCheck cat.DataSource
+		var err error
+		if name.byID != 0 {
+			toCheck, err = catalog.ResolveDataSourceByID(ctx, name.byID)
+		} else {
+			// Resolve data source object.
+			toCheck, _, err = catalog.ResolveDataSource(ctx, cat.Flags{}, &name.byName)
+		}
 		if err != nil {
 			return false, err
 		}

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -44,7 +44,7 @@ func TestMetadata(t *testing.T) {
 		t.Fatalf("unexpected table id")
 	}
 
-	md.AddDependency(tab.Name(), tab, privilege.CREATE)
+	md.AddDependency(opt.DepByName(tab.Name()), tab, privilege.CREATE)
 	depsUpToDate, err := md.CheckDependencies(context.TODO(), testCat)
 	if err == nil || depsUpToDate {
 		t.Fatalf("expected table privilege to be revoked")

--- a/pkg/sql/opt/optbuilder/delete.go
+++ b/pkg/sql/opt/optbuilder/delete.go
@@ -56,7 +56,7 @@ func (b *Builder) buildDelete(del *tree.Delete, inScope *scope) (outScope *scope
 	}
 
 	// Check Select permission as well, since existing values must be read.
-	b.checkPrivilege(tn, tab, privilege.SELECT)
+	b.checkPrivilege(opt.DepByName(tn), tab, privilege.SELECT)
 
 	var mb mutationBuilder
 	mb.init(b, opt.DeleteOp, tab, *alias)

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -173,12 +173,12 @@ func (b *Builder) buildInsert(ins *tree.Insert, inScope *scope) (outScope *scope
 	if ins.OnConflict != nil {
 		// UPSERT and INDEX ON CONFLICT will read from the table to check for
 		// duplicates.
-		b.checkPrivilege(tn, tab, privilege.SELECT)
+		b.checkPrivilege(opt.DepByName(tn), tab, privilege.SELECT)
 
 		if !ins.OnConflict.DoNothing {
 			// UPSERT and INDEX ON CONFLICT DO UPDATE may modify rows if the
 			// DO NOTHING clause is not present.
-			b.checkPrivilege(tn, tab, privilege.UPDATE)
+			b.checkPrivilege(opt.DepByName(tn), tab, privilege.UPDATE)
 		}
 	}
 

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -91,7 +91,7 @@ func (b *Builder) buildUpdate(upd *tree.Update, inScope *scope) (outScope *scope
 	}
 
 	// Check Select permission as well, since existing values must be read.
-	b.checkPrivilege(tn, tab, privilege.SELECT)
+	b.checkPrivilege(opt.DepByName(tn), tab, privilege.SELECT)
 
 	var mb mutationBuilder
 	mb.init(b, opt.UpdateOp, tab, *alias)


### PR DESCRIPTION
#### opt: check dependencies by ID

Currently, table dependencies are checked by resolving based on the
name. In the case of resolving by ID, we have to get the fully
qualified name. This change improves this by allowing the dependencies
to store either a `DataSourceName` or a `StableID` and re-resolve
using the original method. This will allow us to remove the db
descriptor lookup in the by-id case (which is used only to get the FQ
name). Note that the by-id case is important for FK checks.

Release note: None

#### opt: check privilege of referenced table for FK checks

Release note: None
