### PR TITLE
release-19.1: opt: improve per-ON condition cost adjustment for lookup join

### DIFF
--- a/pkg/sql/opt/optgen/exprgen/testdata/join
+++ b/pkg/sql/opt/optgen/exprgen/testdata/join
@@ -66,7 +66,7 @@ left-join (lookup abc@ab)
  ├── columns: t.public.abc.a:5(int) t.public.abc.b:6(int)
  ├── key columns: [5] = [5]
  ├── stats: [rows=333333.333]
- ├── cost: 691726.697
+ ├── cost: 691726.707
  ├── scan t.public.def
  │    ├── columns: t.public.def.d:1(int) t.public.def.e:2(int)
  │    ├── stats: [rows=1000]

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -407,6 +407,9 @@ func (c *coster) computeLookupJoinCost(join *memo.LookupJoinExpr) memo.Cost {
 	// joins where we don't have the equality and leftover filters readily
 	// available.
 	perRowCost += cpuCostFactor * memo.Cost(len(join.On))
+	// We also add a constant "setup" cost per ON condition. Without this, the
+	// adjustment above can be inconsequential when the RowCount is too small.
+	cost += cpuCostFactor * memo.Cost(len(join.On))
 
 	cost += memo.Cost(join.Relational().Stats.RowCount) * perRowCost
 	return cost

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -177,8 +177,7 @@ CREATE TABLE abcde (
   c UUID NOT NULL,
   d VARCHAR(255) NOT NULL,
   e TEXT NOT NULL,
-  CONSTRAINT "primary" PRIMARY KEY (a, b, c),
-  UNIQUE INDEX idx_abd (a, b, d),
+  UNIQUE INDEX idx_abd (a, b, d) STORING (c),
   UNIQUE INDEX idx_abcd (a, b, c, d)
 )
 ----
@@ -188,20 +187,21 @@ TABLE abcde
  ├── c uuid not null
  ├── d string not null
  ├── e string not null
+ ├── rowid int not null (hidden)
  ├── INDEX primary
- │    ├── a string not null
- │    ├── b uuid not null
- │    └── c uuid not null
+ │    └── rowid int not null (hidden)
  ├── INDEX idx_abd
  │    ├── a string not null
  │    ├── b uuid not null
  │    ├── d string not null
+ │    ├── rowid int not null (hidden) (storing)
  │    └── c uuid not null (storing)
  └── INDEX idx_abcd
       ├── a string not null
       ├── b uuid not null
       ├── c uuid not null
-      └── d string not null
+      ├── d string not null
+      └── rowid int not null (hidden) (storing)
 
 exec-ddl
 ALTER TABLE abcde INJECT STATISTICS '[
@@ -231,9 +231,7 @@ CREATE TABLE wxyz (
   w TEXT NOT NULL,
   x UUID NOT NULL,
   y UUID NOT NULL,
-  z TEXT NOT NULL,
-  CONSTRAINT "primary" PRIMARY KEY (w, x, y),
-  CONSTRAINT "foreign" FOREIGN KEY (w, x, y) REFERENCES abcde (a, b, c)
+  z TEXT NOT NULL
 )
 ----
 TABLE wxyz
@@ -241,14 +239,100 @@ TABLE wxyz
  ├── x uuid not null
  ├── y uuid not null
  ├── z string not null
- ├── INDEX primary
- │    ├── w string not null
- │    ├── x uuid not null
- │    └── y uuid not null
- └── FOREIGN KEY (w, x, y) REFERENCES t.public.abcde (a, b, c)
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
 
 exec-ddl
 ALTER TABLE wxyz INJECT STATISTICS '[
+  {
+    "columns": ["w"],
+    "created_at": "2019-02-08 04:10:40.001179+00:00",
+    "row_count": 100,
+    "distinct_count": 1
+  },
+  {
+    "columns": ["x"],
+    "created_at": "2019-02-08 04:10:40.119954+00:00",
+    "row_count": 100,
+    "distinct_count": 1
+  },
+  {
+    "columns": ["y"],
+    "created_at": "2019-02-08 04:10:40.119954+00:00",
+    "row_count": 100,
+    "distinct_count": 25
+  }
+]'
+----
+
+opt
+SELECT w, x, y, z
+FROM wxyz
+INNER JOIN abcde
+ON w = a AND x = b AND y = c
+WHERE w = 'foo' AND x = '2AB23800-06B1-4E19-A3BB-DF3768B808D2'
+----
+project
+ ├── columns: w:1(string!null) x:2(uuid!null) y:3(uuid!null) z:4(string!null)
+ ├── stats: [rows=500.488759]
+ ├── cost: 1566.10128
+ ├── fd: ()-->(1,2)
+ └── inner-join (lookup abcde@idx_abcd)
+      ├── columns: w:1(string!null) x:2(uuid!null) y:3(uuid!null) z:4(string!null) a:6(string!null) b:7(uuid!null) c:8(uuid!null)
+      ├── key columns: [1 2 3] = [6 7 8]
+      ├── stats: [rows=500.488759, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=25, null(3)=0, distinct(4)=10, null(4)=0, distinct(6)=1, null(6)=0, distinct(7)=1, null(7)=0, distinct(8)=25, null(8)=0]
+      ├── cost: 1561.08639
+      ├── fd: ()-->(1,2,6,7), (1)==(6), (6)==(1), (2)==(7), (7)==(2), (3)==(8), (8)==(3)
+      ├── select
+      │    ├── columns: w:1(string!null) x:2(uuid!null) y:3(uuid!null) z:4(string!null)
+      │    ├── stats: [rows=100, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=25, null(3)=0, distinct(4)=10, null(4)=0]
+      │    ├── cost: 110.03
+      │    ├── fd: ()-->(1,2)
+      │    ├── scan wxyz
+      │    │    ├── columns: w:1(string!null) x:2(uuid!null) y:3(uuid!null) z:4(string!null)
+      │    │    ├── stats: [rows=100, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=25, null(3)=0, distinct(4)=10, null(4)=0]
+      │    │    └── cost: 109.02
+      │    └── filters
+      │         ├── w = 'foo' [type=bool, outer=(1), constraints=(/1: [/'foo' - /'foo']; tight), fd=()-->(1)]
+      │         └── x = '2ab23800-06b1-4e19-a3bb-df3768b808d2' [type=bool, outer=(2), constraints=(/2: [/'2ab23800-06b1-4e19-a3bb-df3768b808d2' - /'2ab23800-06b1-4e19-a3bb-df3768b808d2']; tight), fd=()-->(2)]
+      └── filters
+           ├── a = 'foo' [type=bool, outer=(6), constraints=(/6: [/'foo' - /'foo']; tight), fd=()-->(6)]
+           └── b = '2ab23800-06b1-4e19-a3bb-df3768b808d2' [type=bool, outer=(7), constraints=(/7: [/'2ab23800-06b1-4e19-a3bb-df3768b808d2' - /'2ab23800-06b1-4e19-a3bb-df3768b808d2']; tight), fd=()-->(7)]
+
+# Also for 34810: make sure the cost adjustment works when the estimated row
+# count is tiny.
+exec-ddl
+CREATE TABLE wxyzijklmn (
+  w TEXT NOT NULL,
+  x UUID NOT NULL,
+  y UUID NOT NULL,
+  z TEXT NOT NULL,
+  i INT,
+  j INT,
+  k INT,
+  l INT,
+  m INT,
+  n INT
+)
+----
+TABLE wxyzijklmn
+ ├── w string not null
+ ├── x uuid not null
+ ├── y uuid not null
+ ├── z string not null
+ ├── i int
+ ├── j int
+ ├── k int
+ ├── l int
+ ├── m int
+ ├── n int
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+exec-ddl
+ALTER TABLE wxyzijklmn INJECT STATISTICS '[
   {
     "columns": ["w"],
     "created_at": "2019-02-08 04:10:40.001179+00:00",
@@ -265,67 +349,83 @@ ALTER TABLE wxyz INJECT STATISTICS '[
     "columns": ["y"],
     "created_at": "2019-02-08 04:10:40.119954+00:00",
     "row_count": 10000,
-    "distinct_count": 2500
+    "distinct_count": 25
+  },
+  {
+    "columns": ["i"],
+    "created_at": "2019-02-08 04:10:40.119954+00:00",
+    "row_count": 10000,
+    "distinct_count": 10000
+  },
+  {
+    "columns": ["j"],
+    "created_at": "2019-02-08 04:10:40.119954+00:00",
+    "row_count": 10000,
+    "distinct_count": 10000
+  },
+  {
+    "columns": ["k"],
+    "created_at": "2019-02-08 04:10:40.119954+00:00",
+    "row_count": 10000,
+    "distinct_count": 10000
+  },
+  {
+    "columns": ["l"],
+    "created_at": "2019-02-08 04:10:40.119954+00:00",
+    "row_count": 10000,
+    "distinct_count": 10000
+  },
+  {
+    "columns": ["m"],
+    "created_at": "2019-02-08 04:10:40.119954+00:00",
+    "row_count": 10000,
+    "distinct_count": 10000
+  },
+  {
+    "columns": ["n"],
+    "created_at": "2019-02-08 04:10:40.119954+00:00",
+    "row_count": 10000,
+    "distinct_count": 10000
   }
 ]'
 ----
 
 opt
 SELECT w, x, y, z
-FROM wxyz
+FROM wxyzijklmn
 INNER JOIN abcde
 ON w = a AND x = b AND y = c
-WHERE w = 'foo' AND x = '2AB23800-06B1-4E19-A3BB-DF3768B808D2'
-ORDER BY d
-LIMIT 10
+WHERE w = 'foo' AND x = '2AB23800-06B1-4E19-A3BB-DF3768B808D2' AND (i,j,k,l,m,n)=(1,2,3,4,5,6)
 ----
 project
- ├── columns: w:1(string!null) x:2(uuid!null) y:3(uuid!null) z:4(string!null)  [hidden: d:8(string!null)]
- ├── cardinality: [0 - 10]
- ├── stats: [rows=10]
- ├── cost: 164278.036
- ├── key: (8)
- ├── fd: ()-->(1,2), (3)-->(4,8), (8)-->(3,4)
- ├── ordering: +8 opt(1,2) [actual: +8]
- └── limit
-      ├── columns: w:1(string!null) x:2(uuid!null) y:3(uuid!null) z:4(string!null) a:5(string!null) b:6(uuid!null) c:7(uuid!null) d:8(string!null)
-      ├── internal-ordering: +8 opt(1,2,5,6)
-      ├── cardinality: [0 - 10]
-      ├── stats: [rows=10]
-      ├── cost: 164277.926
-      ├── key: (7)
-      ├── fd: ()-->(1,2,5,6), (3)-->(4), (7)-->(8), (8)-->(7), (1)==(5), (5)==(1), (2)==(6), (6)==(2), (3)==(7), (7)==(3)
-      ├── ordering: +8 opt(1,2,5,6) [actual: +8]
-      ├── sort
-      │    ├── columns: w:1(string!null) x:2(uuid!null) y:3(uuid!null) z:4(string!null) a:5(string!null) b:6(uuid!null) c:7(uuid!null) d:8(string!null)
-      │    ├── stats: [rows=50048.8759, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=2500, null(3)=0, distinct(4)=1000, null(4)=0, distinct(5)=1, null(5)=0, distinct(6)=1, null(6)=0, distinct(7)=2500, null(7)=0, distinct(8)=38781.1698, null(8)=0]
-      │    ├── cost: 164277.816
-      │    ├── key: (7)
-      │    ├── fd: ()-->(1,2,5,6), (3)-->(4), (7)-->(8), (8)-->(7), (1)==(5), (5)==(1), (2)==(6), (6)==(2), (3)==(7), (7)==(3)
-      │    ├── ordering: +8 opt(1,2,5,6) [actual: +8]
-      │    └── inner-join (merge)
-      │         ├── columns: w:1(string!null) x:2(uuid!null) y:3(uuid!null) z:4(string!null) a:5(string!null) b:6(uuid!null) c:7(uuid!null) d:8(string!null)
-      │         ├── left ordering: +1,+2,+3
-      │         ├── right ordering: +5,+6,+7
-      │         ├── stats: [rows=50048.8759, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=2500, null(3)=0, distinct(4)=1000, null(4)=0, distinct(5)=1, null(5)=0, distinct(6)=1, null(6)=0, distinct(7)=2500, null(7)=0, distinct(8)=38781.1698, null(8)=0]
-      │         ├── cost: 147650.519
-      │         ├── key: (7)
-      │         ├── fd: ()-->(1,2,5,6), (3)-->(4), (7)-->(8), (8)-->(7), (1)==(5), (5)==(1), (2)==(6), (6)==(2), (3)==(7), (7)==(3)
-      │         ├── scan wxyz
-      │         │    ├── columns: w:1(string!null) x:2(uuid!null) y:3(uuid!null) z:4(string!null)
-      │         │    ├── constraint: /1/2/3: [/'foo'/'2ab23800-06b1-4e19-a3bb-df3768b808d2' - /'foo'/'2ab23800-06b1-4e19-a3bb-df3768b808d2']
-      │         │    ├── stats: [rows=10000, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=2500, null(3)=0, distinct(4)=1000, null(4)=0]
-      │         │    ├── cost: 10800.01
-      │         │    ├── key: (3)
-      │         │    ├── fd: ()-->(1,2), (3)-->(4)
-      │         │    └── ordering: +3 opt(1,2) [actual: +3]
-      │         ├── scan abcde@idx_abcd
-      │         │    ├── columns: a:5(string!null) b:6(uuid!null) c:7(uuid!null) d:8(string!null)
-      │         │    ├── constraint: /5/6/7/8: [/'foo'/'2ab23800-06b1-4e19-a3bb-df3768b808d2' - /'foo'/'2ab23800-06b1-4e19-a3bb-df3768b808d2']
-      │         │    ├── stats: [rows=125000, distinct(5)=1, null(5)=0, distinct(6)=1, null(6)=0, distinct(7)=24975.5859, null(7)=0, distinct(8)=93750, null(8)=0]
-      │         │    ├── cost: 135000.01
-      │         │    ├── key: (7)
-      │         │    ├── fd: ()-->(5,6), (7)-->(8), (8)-->(7)
-      │         │    └── ordering: +7 opt(5,6) [actual: +7]
-      │         └── filters (true)
-      └── const: 10 [type=int]
+ ├── columns: w:1(string!null) x:2(uuid!null) y:3(uuid!null) z:4(string!null)
+ ├── stats: [rows=1.25e-15]
+ ├── cost: 12200.07
+ ├── fd: ()-->(1,2)
+ └── inner-join (lookup abcde@idx_abcd)
+      ├── columns: w:1(string!null) x:2(uuid!null) y:3(uuid!null) z:4(string!null) i:5(int!null) j:6(int!null) k:7(int!null) l:8(int!null) m:9(int!null) n:10(int!null) a:12(string!null) b:13(uuid!null) c:14(uuid!null)
+      ├── key columns: [1 2 3] = [12 13 14]
+      ├── stats: [rows=1.25e-15, distinct(1)=1e-20, null(1)=0, distinct(2)=1e-20, null(2)=0, distinct(3)=0, null(3)=0, distinct(4)=0, null(4)=0, distinct(5)=1e-20, null(5)=0, distinct(6)=1e-20, null(6)=0, distinct(7)=1e-20, null(7)=0, distinct(8)=1e-20, null(8)=0, distinct(9)=1e-20, null(9)=0, distinct(10)=1e-20, null(10)=0, distinct(12)=1e-20, null(12)=0, distinct(13)=1e-20, null(13)=0, distinct(14)=0, null(14)=0]
+      ├── cost: 12200.06
+      ├── fd: ()-->(1,2,5-10,12,13), (1)==(12), (12)==(1), (2)==(13), (13)==(2), (3)==(14), (14)==(3)
+      ├── select
+      │    ├── columns: w:1(string!null) x:2(uuid!null) y:3(uuid!null) z:4(string!null) i:5(int!null) j:6(int!null) k:7(int!null) l:8(int!null) m:9(int!null) n:10(int!null)
+      │    ├── stats: [rows=1e-20, distinct(1)=1e-20, null(1)=0, distinct(2)=1e-20, null(2)=0, distinct(3)=0, null(3)=0, distinct(4)=0, null(4)=0, distinct(5)=1e-20, null(5)=0, distinct(6)=1e-20, null(6)=0, distinct(7)=1e-20, null(7)=0, distinct(8)=1e-20, null(8)=0, distinct(9)=1e-20, null(9)=0, distinct(10)=1e-20, null(10)=0]
+      │    ├── cost: 12200.03
+      │    ├── fd: ()-->(1,2,5-10)
+      │    ├── scan wxyzijklmn
+      │    │    ├── columns: w:1(string!null) x:2(uuid!null) y:3(uuid!null) z:4(string!null) i:5(int) j:6(int) k:7(int) l:8(int) m:9(int) n:10(int)
+      │    │    ├── stats: [rows=10000, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=25, null(3)=0, distinct(4)=1000, null(4)=0, distinct(5)=10000, null(5)=0, distinct(6)=10000, null(6)=0, distinct(7)=10000, null(7)=0, distinct(8)=10000, null(8)=0, distinct(9)=10000, null(9)=0, distinct(10)=10000, null(10)=0]
+      │    │    └── cost: 12100.02
+      │    └── filters
+      │         ├── w = 'foo' [type=bool, outer=(1), constraints=(/1: [/'foo' - /'foo']; tight), fd=()-->(1)]
+      │         ├── x = '2ab23800-06b1-4e19-a3bb-df3768b808d2' [type=bool, outer=(2), constraints=(/2: [/'2ab23800-06b1-4e19-a3bb-df3768b808d2' - /'2ab23800-06b1-4e19-a3bb-df3768b808d2']; tight), fd=()-->(2)]
+      │         ├── i = 1 [type=bool, outer=(5), constraints=(/5: [/1 - /1]; tight), fd=()-->(5)]
+      │         ├── j = 2 [type=bool, outer=(6), constraints=(/6: [/2 - /2]; tight), fd=()-->(6)]
+      │         ├── k = 3 [type=bool, outer=(7), constraints=(/7: [/3 - /3]; tight), fd=()-->(7)]
+      │         ├── l = 4 [type=bool, outer=(8), constraints=(/8: [/4 - /4]; tight), fd=()-->(8)]
+      │         ├── m = 5 [type=bool, outer=(9), constraints=(/9: [/5 - /5]; tight), fd=()-->(9)]
+      │         └── n = 6 [type=bool, outer=(10), constraints=(/10: [/6 - /6]; tight), fd=()-->(10)]
+      └── filters
+           ├── a = 'foo' [type=bool, outer=(12), constraints=(/12: [/'foo' - /'foo']; tight), fd=()-->(12)]
+           └── b = '2ab23800-06b1-4e19-a3bb-df3768b808d2' [type=bool, outer=(13), constraints=(/13: [/'2ab23800-06b1-4e19-a3bb-df3768b808d2' - /'2ab23800-06b1-4e19-a3bb-df3768b808d2']; tight), fd=()-->(13)]

--- a/pkg/sql/opt/xform/testdata/coster/zone
+++ b/pkg/sql/opt/xform/testdata/coster/zone
@@ -426,7 +426,7 @@ inner-join (lookup xy@y2)
  ├── flags: no-merge-join;no-hash-join
  ├── key columns: [2] = [5]
  ├── stats: [rows=98.01, distinct(1)=9.9, null(1)=0, distinct(2)=1, null(2)=0, distinct(4)=9.9, null(4)=0, distinct(5)=1, null(5)=0]
- ├── cost: 251.0345
+ ├── cost: 251.0445
  ├── key: (1,4)
  ├── fd: ()-->(2,5), (1)-->(3), (2,3)~~>(1), (2)==(5), (5)==(2)
  ├── prune: (1,3,4)
@@ -468,7 +468,7 @@ inner-join (lookup xy@y1)
  ├── flags: no-merge-join;no-hash-join
  ├── key columns: [2] = [5]
  ├── stats: [rows=98.01, distinct(1)=9.9, null(1)=0, distinct(2)=1, null(2)=0, distinct(4)=9.9, null(4)=0, distinct(5)=1, null(5)=0]
- ├── cost: 251.0345
+ ├── cost: 251.0445
  ├── key: (1,4)
  ├── fd: ()-->(2,5), (1)-->(3), (2,3)~~>(1), (2)==(5), (5)==(2)
  ├── prune: (1,3,4)

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -1405,7 +1405,7 @@ scalar-group-by
  ├── columns: count:28(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 1551.03048
+ ├── cost: 1551.05048
  ├── key: ()
  ├── fd: ()-->(28)
  ├── prune: (28)
@@ -1413,7 +1413,7 @@ scalar-group-by
  │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_i_id:5(int!null) s_i_id:11(int!null) s_w_id:12(int!null) s_quantity:13(int!null)
  │    ├── key columns: [3 5] = [12 11]
  │    ├── stats: [rows=234.432912, distinct(1)=19.9998377, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(5)=199.843131, null(5)=0, distinct(11)=199.843131, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=84.0785286, null(13)=0]
- │    ├── cost: 1548.66615
+ │    ├── cost: 1548.68615
  │    ├── fd: ()-->(2,3,12), (11)-->(13), (5)==(11), (11)==(5), (3)==(12), (12)==(3)
  │    ├── interesting orderings: (+3,+2,-1)
  │    ├── scan order_line
@@ -3040,7 +3040,7 @@ scalar-group-by
  ├── columns: count:28(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 1534.07466
+ ├── cost: 1534.09466
  ├── key: ()
  ├── fd: ()-->(28)
  ├── prune: (28)
@@ -3048,7 +3048,7 @@ scalar-group-by
  │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_i_id:5(int!null) s_i_id:11(int!null) s_w_id:12(int!null) s_quantity:13(int!null)
  │    ├── key columns: [3 5] = [12 11]
  │    ├── stats: [rows=229.899982, distinct(1)=19.9997964, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(5)=198.51294, null(5)=0, distinct(11)=198.51294, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=83.7250115, null(13)=0]
- │    ├── cost: 1531.75566
+ │    ├── cost: 1531.77566
  │    ├── fd: ()-->(2,3,12), (11)-->(13), (5)==(11), (11)==(5), (3)==(12), (12)==(3)
  │    ├── interesting orderings: (+3,+2,-1)
  │    ├── scan order_line

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -709,7 +709,7 @@ scalar-group-by
  ├── columns: count:28(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 0.28998
+ ├── cost: 0.30998
  ├── key: ()
  ├── fd: ()-->(28)
  ├── prune: (28)
@@ -717,7 +717,7 @@ scalar-group-by
  │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_i_id:5(int!null) s_i_id:11(int!null) s_w_id:12(int!null) s_quantity:13(int!null)
  │    ├── key columns: [3 5] = [12 11]
  │    ├── stats: [rows=0.066, distinct(1)=0.02, null(1)=0, distinct(2)=0.02, null(2)=0, distinct(3)=0.02, null(3)=0, distinct(5)=0.0199982001, null(5)=0, distinct(11)=0.0199982001, null(11)=0, distinct(12)=0.02, null(12)=0, distinct(13)=0.066, null(13)=0]
- │    ├── cost: 0.26932
+ │    ├── cost: 0.28932
  │    ├── fd: ()-->(2,3,12), (11)-->(13), (5)==(11), (11)==(5), (3)==(12), (12)==(3)
  │    ├── interesting orderings: (+3,+2,-1)
  │    ├── scan order_line
@@ -762,7 +762,7 @@ scalar-group-by
  ├── columns: count:22(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 1621.35
+ ├── cost: 1621.36
  ├── key: ()
  ├── fd: ()-->(22)
  ├── prune: (22)
@@ -770,7 +770,7 @@ scalar-group-by
  │    ├── columns: w_id:1(int!null) w_ytd:9(decimal!null) d_w_id:11(int!null) sum:21(decimal!null)
  │    ├── key columns: [11] = [1]
  │    ├── stats: [rows=33, distinct(1)=33, null(1)=0, distinct(9)=28.3508504, null(9)=0, distinct(11)=33, null(11)=0, distinct(21)=28.3508504, null(21)=0]
- │    ├── cost: 1621
+ │    ├── cost: 1621.01
  │    ├── key: (11)
  │    ├── fd: (1)-->(9), (11)-->(21), (1)==(11), (11)==(1)
  │    ├── interesting orderings: (+11)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1892,11 +1892,11 @@ memo (optimized, ~11KB, required=[presentation: a:1])
  ├── G1: (project G2 G3 a)
  │    └── [presentation: a:1]
  │         ├── best: (project G2 G3 a)
- │         └── cost: 100.40
+ │         └── cost: 100.41
  ├── G2: (select G4 G5) (lookup-join G6 G5 t5,keyCols=[1],outCols=(1,2)) (select G7 G5)
  │    └── []
  │         ├── best: (lookup-join G6 G5 t5,keyCols=[1],outCols=(1,2))
- │         └── cost: 100.27
+ │         └── cost: 100.28
  ├── G3: (projections)
  ├── G4: (scan t5,cols=(1,2))
  │    └── []


### PR DESCRIPTION
Backport 1/1 commits from #39016.

/cc @cockroachdb/release

---

Issue #34810 tracks taking into account the internal row count of
lookup joins. We currently have a hack in place to always prefer
looking indexes that constrain more columns (see #35587). We encountered a case
where this adjustment doesn't work: when the estimated row count is
very very small (which happens when there are a lot of conditions),
the per-row cost adjustment ends up not making a difference (this is
because of limited floating point precision, and the "tolerance" built
into `Cost.Less()`). To address this, we also add a constant per-ON
condition cost which isn't scaled by the row count.

Release note (bug fix): Fixed bug in the optimizer causing a bad index
for lookup join in some cases.
