### PR TITLE
roachpb: move ReplicaTypeLearner/ReplicaTypeVoter to metadata_replicas.go

### DIFF
--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -831,8 +831,8 @@ func TestLeaseEquivalence(t *testing.T) {
 	stasis2 := Lease{Replica: r1, Start: ts1, Epoch: 1, DeprecatedStartStasis: ts2.Clone()}
 
 	r1Voter, r1Learner := r1, r1
-	r1Voter.Type = newReplicaType(ReplicaType_VOTER)
-	r1Learner.Type = newReplicaType(ReplicaType_LEARNER)
+	r1Voter.Type = ReplicaTypeVoter()
+	r1Learner.Type = ReplicaTypeLearner()
 	epoch1Voter := Lease{Replica: r1Voter, Start: ts1, Epoch: 1}
 	epoch1Learner := Lease{Replica: r1Learner, Start: ts1, Epoch: 1}
 

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -270,20 +270,6 @@ func (r ReplicationTarget) String() string {
 	return fmt.Sprintf("n%d,s%d", r.NodeID, r.StoreID)
 }
 
-// ReplicaTypeLearner returns a ReplicaType_LEARNER pointer suitable for use in
-// a nullable proto field.
-func ReplicaTypeLearner() *ReplicaType {
-	t := ReplicaType_LEARNER
-	return &t
-}
-
-// ReplicaTypeVoter returns a ReplicaType_VOTER pointer suitable for use in a
-// nullable proto field.
-func ReplicaTypeVoter() *ReplicaType {
-	t := ReplicaType_VOTER
-	return &t
-}
-
 func (r ReplicaDescriptor) String() string {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "(n%d,s%d):", r.NodeID, r.StoreID)

--- a/pkg/roachpb/metadata_replicas.go
+++ b/pkg/roachpb/metadata_replicas.go
@@ -16,6 +16,20 @@ import (
 	"strings"
 )
 
+// ReplicaTypeVoter returns a ReplicaType_VOTER pointer suitable for use in a
+// nullable proto field.
+func ReplicaTypeVoter() *ReplicaType {
+	t := ReplicaType_VOTER
+	return &t
+}
+
+// ReplicaTypeLearner returns a ReplicaType_LEARNER pointer suitable for use in
+// a nullable proto field.
+func ReplicaTypeLearner() *ReplicaType {
+	t := ReplicaType_LEARNER
+	return &t
+}
+
 // ReplicaDescriptors is a set of replicas, usually the nodes/stores on which
 // replicas of a range are stored.
 type ReplicaDescriptors struct {

--- a/pkg/roachpb/metadata_replicas_test.go
+++ b/pkg/roachpb/metadata_replicas_test.go
@@ -16,13 +16,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func newReplicaType(t ReplicaType) *ReplicaType {
-	return &t
-}
-
 func TestVotersLearnersAll(t *testing.T) {
-	voter := newReplicaType(ReplicaType_VOTER)
-	learner := newReplicaType(ReplicaType_LEARNER)
+	voter := ReplicaTypeVoter()
+	learner := ReplicaTypeLearner()
 	tests := [][]ReplicaDescriptor{
 		{},
 		{{Type: voter}},
@@ -71,7 +67,7 @@ func TestReplicaDescriptorsRemove(t *testing.T) {
 				{NodeID: 1, StoreID: 1},
 				{NodeID: 2, StoreID: 2},
 				{NodeID: 3, StoreID: 3},
-				{NodeID: 4, StoreID: 4, Type: newReplicaType(ReplicaType_LEARNER)},
+				{NodeID: 4, StoreID: 4, Type: ReplicaTypeLearner()},
 			},
 			remove:   ReplicationTarget{NodeID: 2, StoreID: 2},
 			expected: true,


### PR DESCRIPTION
This is NOT performance-critical based on the functions' uses. I just
noticed this while catching up on 844eac4 and it seemed like the right
thing to do.

The change also cleans up a few tests that wanted this kind of thing.

Release note: None