### PR TITLE
release-19.1: sql: account for memory of results of window functions computations

### DIFF
--- a/pkg/sql/distsqlrun/windower_test.go
+++ b/pkg/sql/distsqlrun/windower_test.go
@@ -17,14 +17,101 @@ package distsqlrun
 import (
 	"context"
 	"fmt"
+	"math"
+	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 )
+
+const noFilterIdx = -1
+
+func TestWindowerAccountingForResults(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	monitor := mon.MakeMonitorWithLimit(
+		"test-monitor",
+		mon.MemoryResource,
+		100000,        /* limit */
+		nil,           /* curCount */
+		nil,           /* maxHist */
+		5000,          /* increment */
+		math.MaxInt64, /* noteworthy */
+		st,
+	)
+	evalCtx := tree.MakeTestingEvalContextWithMon(st, &monitor)
+	defer evalCtx.Stop(ctx)
+	diskMonitor := makeTestDiskMonitor(ctx, st)
+	defer diskMonitor.Stop(ctx)
+	tempEngine, err := engine.NewTempEngine(base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tempEngine.Close()
+
+	flowCtx := &FlowCtx{
+		Settings:    st,
+		EvalCtx:     &evalCtx,
+		diskMonitor: diskMonitor,
+		TempStorage: tempEngine,
+	}
+
+	post := &distsqlpb.PostProcessSpec{}
+	input := NewRepeatableRowSource(sqlbase.OneIntCol, sqlbase.MakeIntRows(1000, 1))
+	aggSpec := distsqlpb.AggregatorSpec_ARRAY_AGG
+	spec := distsqlpb.WindowerSpec{
+		PartitionBy: []uint32{},
+		WindowFns: []distsqlpb.WindowerSpec_WindowFn{{
+			Func:         distsqlpb.WindowerSpec_Func{AggregateFunc: &aggSpec},
+			ArgIdxStart:  0,
+			ArgCount:     1,
+			Ordering:     distsqlpb.Ordering{Columns: []distsqlpb.Ordering_Column{{ColIdx: 0}}},
+			FilterColIdx: noFilterIdx,
+			Frame: &distsqlpb.WindowerSpec_Frame{
+				Mode: distsqlpb.WindowerSpec_Frame_ROWS,
+				Bounds: distsqlpb.WindowerSpec_Frame_Bounds{
+					Start: distsqlpb.WindowerSpec_Frame_Bound{
+						BoundType: distsqlpb.WindowerSpec_Frame_OFFSET_PRECEDING,
+						IntOffset: 100,
+					},
+				},
+			},
+		}},
+	}
+	output := NewRowBuffer(
+		sqlbase.OneIntCol, nil, RowBufferArgs{},
+	)
+
+	d, err := newWindower(flowCtx, 0 /* processorID */, &spec, input, post, output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d.Run(ctx)
+	for {
+		row, meta := output.Next()
+		if row != nil {
+			t.Fatalf("unexpectedly received row %+v", row)
+		}
+		if meta == nil {
+			t.Fatalf("unexpectedly didn't receive an OOM error")
+		}
+		if meta.Err != nil {
+			if !strings.Contains(meta.Err.Error(), "memory budget exceeded") {
+				t.Fatalf("unexpectedly received an error other than OOM")
+			}
+			break
+		}
+	}
+}
 
 type windowTestSpec struct {
 	// The column indices of PARTITION BY clause.
@@ -65,6 +152,7 @@ func windows(windowTestSpecs []windowTestSpec) ([]distsqlpb.WindowerSpec, error)
 			}
 			windowFnSpec.Ordering = distsqlpb.Ordering{Columns: ordCols}
 		}
+		windowFnSpec.FilterColIdx = noFilterIdx
 		windows[i].WindowFns[0] = windowFnSpec
 	}
 	return windows, nil


### PR DESCRIPTION
Backport 1/1 commits from #38839.

/cc @cockroachdb/release

---

Previously, Datums that were the result of computing of window
functions were accounted for in memory monitoring only as nils which
could lead to OOM when the actual Datum's size was a lot bigger than
default one (array_agg and concat_agg were most prone to this).
Now, the underlying memory is tracked correctly.

Fixes: #38818.

Release note: None
