### PR TITLE
vendor: bump go.etcd.io/etcd

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1489,7 +1489,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:51f3f946cfff94e96c8d0a8705a2bcd88d17a70408676ff740acd5255f40a537"
+  digest = "1:a5dd907052a1b42bbdf6a9608300143ee14f477bd6232597494203a21aa0fd45"
   name = "go.etcd.io/etcd"
   packages = [
     "raft",
@@ -1499,7 +1499,7 @@
     "raft/tracker",
   ]
   pruneopts = "UT"
-  revision = "62f4fb3c5eaed2a7614258083b4504f18bf44269"
+  revision = "d137fa9d4ad7aa242f6fed04186a700ce082fdda"
 
 [[projects]]
   digest = "1:3b5a3bc35810830ded5e26ef9516e933083a2380d8e57371fdfde3c70d7c6952"

--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -1265,7 +1265,7 @@ func (r *Replica) withRaftGroupLocked(
 			r.mu.state.RaftAppliedIndex,
 			r.store.cfg,
 			&raftLogger{ctx: ctx},
-		), nil)
+		))
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -67,7 +67,7 @@ func (r *replicaRaftStorage) InitialState() (raftpb.HardState, raftpb.ConfState,
 	}
 	var cs raftpb.ConfState
 	for _, rep := range r.mu.state.Desc.Replicas().Voters() {
-		cs.Nodes = append(cs.Nodes, uint64(rep.ReplicaID))
+		cs.Voters = append(cs.Voters, uint64(rep.ReplicaID))
 	}
 	for _, rep := range r.mu.state.Desc.Replicas().Learners() {
 		cs.Learners = append(cs.Learners, uint64(rep.ReplicaID))
@@ -540,7 +540,7 @@ func snapshot(
 	// Synthesize our raftpb.ConfState from desc.
 	var cs raftpb.ConfState
 	for _, rep := range desc.Replicas().Voters() {
-		cs.Nodes = append(cs.Nodes, uint64(rep.ReplicaID))
+		cs.Voters = append(cs.Voters, uint64(rep.ReplicaID))
 	}
 	for _, rep := range desc.Replicas().Learners() {
 		cs.Learners = append(cs.Learners, uint64(rep.ReplicaID))

--- a/pkg/storage/store_snapshot_preemptive.go
+++ b/pkg/storage/store_snapshot_preemptive.go
@@ -303,7 +303,7 @@ func (s *Store) processPreemptiveSnapshotRequest(
 				appliedIndex,
 				r.store.cfg,
 				&raftLogger{ctx: ctx},
-			), nil)
+			))
 		if err != nil {
 			return roachpb.NewError(err)
 		}


### PR DESCRIPTION
This picks up Joint Consensus, see:

https://github.com/etcd-io/etcd/pull/10914

Release note: None