### PR TITLE
opt: fix some issues with WITH

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/with-opt
+++ b/pkg/sql/logictest/testdata/logic_test/with-opt
@@ -141,3 +141,17 @@ EXECUTE z5(3, 5)
 ----
 3
 5
+
+statement ok
+PREPARE z6(int) AS
+    SELECT * FROM
+    (VALUES (1), (2)) v(x),
+    LATERAL (SELECT * FROM
+      (WITH foo AS (SELECT $1 + x) SELECT * FROM foo)
+    )
+
+query II
+EXECUTE z6(3)
+----
+1 4
+2 5

--- a/pkg/sql/logictest/testdata/logic_test/with-opt
+++ b/pkg/sql/logictest/testdata/logic_test/with-opt
@@ -68,3 +68,76 @@ query I
 SELECT count(*) FROM z
 ----
 0
+
+# WITH and prepared statements.
+
+statement ok
+CREATE TABLE engineer (
+    fellow BOOL NOT NULL, id INT4 NOT NULL, companyname VARCHAR(255) NOT NULL,
+    PRIMARY KEY (id, companyname)
+)
+
+statement ok
+PREPARE x (INT4, VARCHAR, INT4, VARCHAR) AS
+  WITH ht_engineer (id, companyname) AS (
+    SELECT id, companyname FROM (VALUES ($1, $2), ($3, $4)) AS ht (id, companyname)
+  )
+DELETE FROM engineer WHERE (id, companyname) IN (SELECT id, companyname FROM ht_engineer)
+
+statement ok
+EXECUTE x (1, 'fo', 2, 'bar')
+
+statement ok
+PREPARE z(int) AS WITH foo AS (SELECT * FROM x WHERE a = $1) SELECT * FROM foo
+
+query I
+EXECUTE z(1)
+----
+1
+
+query I
+EXECUTE z(2)
+----
+2
+
+query I
+EXECUTE z(3)
+----
+3
+
+# WITH containing a placeholder that isn't referenced.
+
+statement ok
+PREPARE z2(int) AS WITH foo AS (SELECT * FROM x WHERE a = $1) SELECT * FROM x ORDER BY a
+
+query I
+EXECUTE z2(1)
+----
+1
+2
+3
+
+statement ok
+PREPARE z3(int) AS WITH foo AS (SELECT $1) SELECT * FROM foo
+
+query I
+EXECUTE z3(3)
+----
+3
+
+statement ok
+PREPARE z4(int) AS WITH foo AS (SELECT $1), bar AS (SELECT * FROM foo) SELECT * FROM bar
+
+query I
+EXECUTE z4(3)
+----
+3
+
+statement ok
+PREPARE z5(int, int) AS WITH foo AS (SELECT $1), bar AS (SELECT $2) (SELECT * FROM foo) UNION ALL (SELECT * FROM bar)
+
+query I rowsort
+EXECUTE z5(3, 5)
+----
+3
+5

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -716,10 +716,10 @@ func (b *logicalPropsBuilder) buildBasicProps(e opt.Expr, cols opt.ColList, rel 
 }
 
 func (b *logicalPropsBuilder) buildWithProps(with *WithExpr, rel *props.Relational) {
-	BuildSharedProps(b.mem, with, &rel.Shared)
-
 	// Copy over the props from the input.
 	*rel = *with.Input.Relational()
+
+	BuildSharedProps(b.mem, with, &rel.Shared)
 
 	// Side Effects
 	// ------------
@@ -759,6 +759,9 @@ func (b *logicalPropsBuilder) buildWithScanProps(ref *WithScanExpr, rel *props.R
 	// WithScan inherits most of the logical properties of the expression it
 	// references.
 	*rel = *e.Relational()
+
+	rel.HasPlaceholder = false
+	rel.CanHaveSideEffects = false
 
 	// Side Effects
 	// ------------

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -754,19 +754,19 @@ func (b *logicalPropsBuilder) buildWithProps(with *WithExpr, rel *props.Relation
 }
 
 func (b *logicalPropsBuilder) buildWithScanProps(ref *WithScanExpr, rel *props.Relational) {
-	e := b.mem.WithExpr(ref.ID)
-
 	// WithScan inherits most of the logical properties of the expression it
 	// references.
-	*rel = *e.Relational()
+	*rel = *ref.BindingProps
 
+	// Has Placeholder
+	// ---------------
+	// Overwrite this from the copied props.
 	rel.HasPlaceholder = false
-	rel.CanHaveSideEffects = false
 
 	// Side Effects
 	// ------------
-	// TODO(justin): these shouldn't have side-effects, but mutating that here
-	// has complications with the way that shared props are built.
+	// Overwrite this from the copied props.
+	rel.CanHaveSideEffects = false
 
 	// Output Columns
 	// --------------
@@ -778,12 +778,12 @@ func (b *logicalPropsBuilder) buildWithScanProps(ref *WithScanExpr, rel *props.R
 
 	// Outer Columns
 	// -------------
-	// Copied from the referenced expression.
+	rel.OuterCols = opt.ColSet{}
 
 	// Functional Dependencies
 	// -----------------------
 	rel.FuncDeps = props.FuncDepSet{}
-	rel.FuncDeps.CopyFrom(&e.Relational().FuncDeps)
+	rel.FuncDeps.CopyFrom(&ref.BindingProps.FuncDeps)
 	for i := range ref.InCols {
 		rel.FuncDeps.AddSynthesizedCol(opt.MakeColSet(ref.InCols[i]), ref.OutCols[i])
 	}

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -373,7 +373,8 @@ func (m *Memo) WithExpr(id opt.WithID) RelExpr {
 }
 
 // CopyWiths copies over the set of WITH expressions used by the other memo.
-// TODO(justin): These are just used for their logical props, so we should just store those..
+// TODO(justin): These are just used to compute stats, we should have a way to
+// avoid hanging on to expressions like this.
 func (m *Memo) CopyWiths(o *Memo, replace func(opt.Expr) opt.Expr) {
 	m.withExprs = make([]RelExpr, len(o.withExprs))
 	copy(m.withExprs, o.withExprs)

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -371,3 +371,10 @@ func (m *Memo) AddWithBinding(e RelExpr) opt.WithID {
 func (m *Memo) WithExpr(id opt.WithID) RelExpr {
 	return m.withExprs[id-1]
 }
+
+// CopyWiths copies over the set of WITH expressions used by the other memo.
+// TODO(justin): These are just used for their logical props, so we should just store those..
+func (m *Memo) CopyWiths(o *Memo, replace func(opt.Expr) opt.Expr) {
+	m.withExprs = make([]RelExpr, len(o.withExprs))
+	copy(m.withExprs, o.withExprs)
+}

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -2078,6 +2078,13 @@ func (sb *statisticsBuilder) colStatWithScan(
 	// expression, rather than the reference.
 	cols := translateColSet(colSet, ws.OutCols, ws.InCols)
 
+	// Note that if the WITH contained placeholders, we still hold onto the
+	// original, unreplaced expression, and so we won't be able to generate stats
+	// corresponding to the replaced expression.
+	// TODO(justin): find a way to lift this limitation. One way could be to
+	// rebuild WithScans when the WITH they reference has placeholders that get
+	// replaced.
+
 	colstat, _ := s.ColStats.Add(colSet)
 	*colstat = *sb.colStat(cols, withExpr)
 	colstat.Cols = colSet

--- a/pkg/sql/opt/memo/testdata/logprops/with
+++ b/pkg/sql/opt/memo/testdata/logprops/with
@@ -23,8 +23,8 @@ with &1 (foo)
       ├── key: (1)
       └── fd: (1)-->(2,3), (2)-->(4)
 
-# Side effects should not be propagated up to the top-level from the Value
-# side of a WITH.
+# Side effects should be propagated up to the top-level from the Binding side
+# of a WITH.
 build
 WITH foo AS (SELECT 1/0) SELECT * FROM foo
 ----
@@ -54,7 +54,6 @@ with &1 (foo)
       ├── mapping:
       │    └──  "?column?":1(decimal) => "?column?":2(decimal)
       ├── cardinality: [1 - 1]
-      ├── side-effects
       ├── key: ()
       └── fd: ()-->(1), (1)-->(2)
 
@@ -99,3 +98,42 @@ with &1 (foo)
            └── div [type=decimal, side-effects]
                 ├── const: 1 [type=int]
                 └── const: 0 [type=int]
+
+build
+WITH foo AS (SELECT $1::INT) SELECT 1 FROM foo
+----
+with &1 (foo)
+ ├── columns: "?column?":3(int!null)
+ ├── cardinality: [1 - 1]
+ ├── has-placeholder
+ ├── key: ()
+ ├── fd: ()-->(3)
+ ├── project
+ │    ├── columns: int8:1(int)
+ │    ├── cardinality: [1 - 1]
+ │    ├── has-placeholder
+ │    ├── key: ()
+ │    ├── fd: ()-->(1)
+ │    ├── prune: (1)
+ │    ├── values
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    └── tuple [type=tuple]
+ │    └── projections
+ │         └── cast: INT8 [type=int]
+ │              └── placeholder: $1 [type=string]
+ └── project
+      ├── columns: "?column?":3(int!null)
+      ├── cardinality: [1 - 1]
+      ├── key: ()
+      ├── fd: ()-->(3)
+      ├── prune: (3)
+      ├── with-scan &1 (foo)
+      │    ├── columns: int8:2(int)
+      │    ├── mapping:
+      │    │    └──  int8:1(int) => int8:2(int)
+      │    ├── cardinality: [1 - 1]
+      │    ├── key: ()
+      │    └── fd: ()-->(1), (1)-->(2)
+      └── projections
+           └── const: 1 [type=int]

--- a/pkg/sql/opt/memo/testdata/logprops/with
+++ b/pkg/sql/opt/memo/testdata/logprops/with
@@ -137,3 +137,52 @@ with &1 (foo)
       │    └── fd: ()-->(1), (1)-->(2)
       └── projections
            └── const: 1 [type=int]
+
+# WithScan should not have outer columns.
+build
+SELECT
+    *
+FROM
+    (VALUES (1), (2)) AS v (x),
+    LATERAL (SELECT * FROM (WITH foo AS (SELECT 1 + x) SELECT * FROM foo))
+----
+inner-join-apply
+ ├── columns: x:1(int!null) "?column?":3(int)
+ ├── cardinality: [2 - 2]
+ ├── values
+ │    ├── columns: column1:1(int!null)
+ │    ├── cardinality: [2 - 2]
+ │    ├── prune: (1)
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 1 [type=int]
+ │    └── tuple [type=tuple{int}]
+ │         └── const: 2 [type=int]
+ ├── with &1 (foo)
+ │    ├── columns: "?column?":3(int)
+ │    ├── outer: (1)
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(2), (2)-->(3)
+ │    ├── project
+ │    │    ├── columns: "?column?":2(int)
+ │    │    ├── outer: (1)
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(2)
+ │    │    ├── prune: (2)
+ │    │    ├── values
+ │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    └── tuple [type=tuple]
+ │    │    └── projections
+ │    │         └── plus [type=int, outer=(1)]
+ │    │              ├── const: 1 [type=int]
+ │    │              └── variable: column1 [type=int]
+ │    └── with-scan &1 (foo)
+ │         ├── columns: "?column?":3(int)
+ │         ├── mapping:
+ │         │    └──  "?column?":2(int) => "?column?":3(int)
+ │         ├── cardinality: [1 - 1]
+ │         ├── key: ()
+ │         └── fd: ()-->(2), (2)-->(3)
+ └── filters (true)

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -189,6 +189,7 @@ func (f *Factory) CopyAndReplace(
 	// Copy all metadata to the target memo so that referenced tables and columns
 	// can keep the same ids they had in the "from" memo.
 	f.mem.Metadata().CopyFrom(from.Memo().Metadata())
+	f.mem.CopyWiths(from.Memo(), replace)
 
 	// Perform copy and replacement, and store result as the root of this
 	// factory's memo.

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -857,6 +857,9 @@ define WithScan {
 define WithScanPrivate {
     ID WithID
 
+    # BindingProps stores the relational properties of the referenced expression.
+    BindingProps RelPropsPtr
+
     # Name is used to identify the with being referenced for debugging purposes.
     Name string
 

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -825,9 +825,10 @@ func (mb *mutationBuilder) buildFKChecks() {
 		}
 
 		left := mb.b.factory.ConstructWithScan(&memo.WithScanPrivate{
-			ID:      mb.withID,
-			InCols:  inputCols,
-			OutCols: withRefCols,
+			ID:           mb.withID,
+			InCols:       inputCols,
+			OutCols:      withRefCols,
+			BindingProps: mb.outScope.expr.Relational(),
 		})
 
 		item.KeyCols = withRefCols

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -88,10 +88,11 @@ func (b *Builder) buildDataSource(
 			}
 
 			outScope.expr = b.factory.ConstructWithScan(&memo.WithScanPrivate{
-				ID:      cte.id,
-				Name:    string(cte.name.Alias),
-				InCols:  inCols,
-				OutCols: outCols,
+				ID:           cte.id,
+				Name:         string(cte.name.Alias),
+				InCols:       inCols,
+				OutCols:      outCols,
+				BindingProps: cte.expr.Relational(),
 			})
 			return outScope
 		}


### PR DESCRIPTION
This pair of commits fixes several issues involved with WITH planning, most notably around their use in prepared statements (or any situation where memos could get re-used).