### PR TITLE
roachtest: print to correct logs in gossip/chaos

### DIFF
--- a/pkg/cmd/roachtest/gossip.go
+++ b/pkg/cmd/roachtest/gossip.go
@@ -73,7 +73,7 @@ SELECT string_agg(source_id::TEXT || ':' || target_id::TEXT, ',')
 					}
 					for _, id := range strings.FieldsFunc(s, split) {
 						if id == deadNodeStr {
-							fmt.Printf("%d: gossip not ok (dead node %d present): %s (%.0fs)\n",
+							c.l.Printf("%d: gossip not ok (dead node %d present): %s (%.0fs)\n",
 								i, deadNode, s, timeutil.Since(start).Seconds())
 							return false
 						}
@@ -83,7 +83,7 @@ SELECT string_agg(source_id::TEXT || ':' || target_id::TEXT, ',')
 					continue
 				}
 				if expected != s {
-					fmt.Printf("%d: gossip not ok: %s != %s (%.0fs)\n",
+					c.l.Printf("%d: gossip not ok: %s != %s (%.0fs)\n",
 						i, expected, s, timeutil.Since(start).Seconds())
 					return false
 				}


### PR DESCRIPTION
It was printing to Stdout, where the output is hard to find.

Touches #38829.

Release note: None