### PR TITLE
engine: optimize MVCCClearTimeRange

### DIFF
--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -222,6 +222,9 @@ type Writer interface {
 	// (exclusive). Similar to Clear, this method actually removes entries from
 	// the storage engine.
 	//
+	// Note that when used on batches, subsequent reads may not reflect the result
+	// of the ClearRange.
+	//
 	// It is safe to modify the contents of the arguments after ClearRange
 	// returns.
 	ClearRange(start, end MVCCKey) error

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -1856,6 +1856,57 @@ func MVCCMerge(
 func MVCCClearTimeRange(
 	ctx context.Context, batch ReadWriter, key, endKey roachpb.Key, startTime, endTime hlc.Timestamp,
 ) error {
+
+	// When iterating, instead of immediately clearing a matching key we can
+	// accumulate it in buf until either a) useRangeClearThreshold is reached and
+	// we discard the buffer, instead just keeping track of where the span of keys
+	// matching started or b) a non-matching key is seen and we flush the buffer
+	// keys one by one as Clears. Once we switch to just tracking where the run
+	// started, on seeing a non-matching key we flush the run via one ClearRange.
+	// This can be a big win for reverting bulk-ingestion of clustered data as the
+	// entire span may likely match and thus could be cleared in one ClearRange
+	// instead of hundreds of thousands of individual Clears. This constant hasn't
+	// been tuned here at all, but was just borrowed from `clearRangeData` where
+	// where this strategy originated.
+	const useClearRangeThreshold = 64
+	var buf [useClearRangeThreshold]MVCCKey
+	var bufSize int
+	var clearRangeStart MVCCKey
+
+	clearMatchingKey := func(k MVCCKey) {
+		if len(clearRangeStart.Key) == 0 {
+			// Currently buffering keys to clear one-by-one.
+			if bufSize < useClearRangeThreshold {
+				buf[bufSize].Key = append(buf[bufSize].Key[:0], k.Key...)
+				buf[bufSize].Timestamp = k.Timestamp
+				bufSize++
+			} else {
+				// Buffer is now full -- switch to just tracking the start of the range
+				// from which we will clear when we either see a non-matching key or if
+				// we finish iterating.
+				clearRangeStart = buf[0]
+				bufSize = 0
+			}
+		}
+	}
+
+	flushClearedKeys := func(nonMatch MVCCKey) error {
+		if len(clearRangeStart.Key) != 0 {
+			if err := batch.ClearRange(clearRangeStart, nonMatch); err != nil {
+				return err
+			}
+			clearRangeStart = MVCCKey{}
+		} else if bufSize > 0 {
+			for i := 0; i < bufSize; i++ {
+				if err := batch.Clear(buf[i]); err != nil {
+					return err
+				}
+			}
+			bufSize = 0
+		}
+		return nil
+	}
+
 	// TODO(dt): time-bound iter could potentially be a big win here -- the
 	// expected use-case for this is to run over an entire table's span with a
 	// very recent timestamp, rolling back just the writes of some failed IMPORT
@@ -1867,45 +1918,51 @@ func MVCCClearTimeRange(
 	// for deletion, allowing us to quickly skip over swaths of uninteresting
 	// keys, but then use a normal iteration to actually do the delete including
 	// updating the live key stats correctly.
-	// TODO(dt): use our own iterator since we don't need to allocate safe keys
-	// for every key we're skipping over.
-	if err := batch.Iterate(
-		MVCCKey{Key: key}, MVCCKey{Key: endKey},
-		func(kv MVCCKeyValue) (bool, error) {
-			var meta enginepb.MVCCMetadata
-			if !kv.Key.IsValue() {
-				if err := protoutil.Unmarshal(kv.Value, &meta); err != nil {
-					return false, err
-				}
-				ts := hlc.Timestamp(meta.Timestamp)
-				if meta.Txn != nil && startTime.Less(ts) && !endTime.Less(ts) {
-					err := &roachpb.WriteIntentError{
-						Intents: []roachpb.Intent{{Span: roachpb.Span{Key: append([]byte{}, kv.Key.Key...)},
-							Status: roachpb.PENDING, Txn: *meta.Txn,
-						}}}
-					return false, err
-				}
-			}
+	it := batch.NewIterator(IterOptions{LowerBound: key, UpperBound: endKey})
+	defer it.Close()
 
-			// TODO(dt): buffer keys and flush large runs in a single ClearRange. In
-			// many workloads, it is likely that large blocks of keys are written at
-			// similar times, e.g. bulk ingestions may ingest entire ranges of new
-			// data all at the same time. In this case a single ClearRange could take
-			// the place of hundreds of thousands of individual Clears. We should
-			// buffer up to some number of keys to clear before flushing individual
-			// Clears so that if we exceed the run threshold we instead just scan
-			// until we end the run and flush the ClearRange instead.
-			if startTime.Less(kv.Key.Timestamp) && !endTime.Less(kv.Key.Timestamp) {
-				if err := batch.Clear(kv.Key); err != nil {
-					return false, err
-				}
+	for it.Seek(MVCCKey{Key: key}); ; it.Next() {
+		ok, err := it.Valid()
+		if err != nil {
+			return err
+		} else if !ok {
+			break
+		}
+		k := it.UnsafeKey()
+		if c := k.Key.Compare(endKey); c >= 0 {
+			break
+		}
+
+		// We need to check for and fail on any intents in our time-range as we do
+		// not want to clear any running transactions. We don't _expect_ to hit this
+		// since the RevertRange is only intended for non-live key spans but there
+		// could be an intent leftover.
+		var meta enginepb.MVCCMetadata
+		if !k.IsValue() {
+			if err := it.ValueProto(&meta); err != nil {
+				return err
 			}
-			return false, nil
-		},
-	); err != nil {
-		return err
+			ts := hlc.Timestamp(meta.Timestamp)
+			if meta.Txn != nil && startTime.Less(ts) && !endTime.Less(ts) {
+				err := &roachpb.WriteIntentError{
+					Intents: []roachpb.Intent{{Span: roachpb.Span{Key: append([]byte{}, k.Key...)},
+						Status: roachpb.PENDING, Txn: *meta.Txn,
+					}}}
+				return err
+			}
+		}
+
+		if startTime.Less(k.Timestamp) && !endTime.Less(k.Timestamp) {
+			clearMatchingKey(k)
+		} else {
+			// This key does not match, so we need to flush our run of matching keys.
+			if err := flushClearedKeys(k); err != nil {
+				return err
+			}
+		}
 	}
-	return nil
+
+	return flushClearedKeys(MVCCKey{Key: key})
 }
 
 // MVCCDeleteRange deletes the range of key/value pairs specified by start and


### PR DESCRIPTION
This is change is purely for optimization.

One common expected use-case of MVCCClearTimeRange is to revert
bulk-ingestion that often may create entire ranges of new keys, thus
meaning the entire range would meet the time predicate and be cleared.
Clearing all of those keys individually via Clear would result in a much
more expensive batch than a single ClearRange, so when iterating, this
change switches to buffer keys determined to match the time-bounds until
some threshold is met, and beyond that simply iterate tracking the
beginning of the span until the first non-matching key is observed, then
flush a single ClearRange for the matching span. If a non-matching key
is seen before that threshold is met, the buffered matching keys are
instead flushed as individual Clears.

This also changes the iteration to use an actual Iterator instead of
batch.Iterate, which allows using UnsafeKey to check the time bounds and
avoid allocating when iterating over non-matching keys. This to is
expected in many bulk-ingestions -- just as clustered data might result
in a swath of all matching keys, it also likely results in large swaths
of all non-matching keys, so avoiding extra expense in skipping
non-matching keys is also expected to be a win in those cases.

Finally, to test these cases that only come up when dealing with larger
numbers of keys, this change also adds some random-data based tests to
complement the existing hand-made test cases that remain small enough
and simple enough for a human to trace their expected results.

Release note: none.