### PR TITLE
storage: remain compatible with transactions missing their minimum timestamp

### DIFF
--- a/pkg/storage/batcheval/transaction.go
+++ b/pkg/storage/batcheval/transaction.go
@@ -114,9 +114,19 @@ func CanPushWithPriority(pusher, pushee *roachpb.Transaction) bool {
 func CanCreateTxnRecord(rec EvalContext, txn *roachpb.Transaction) error {
 	// Provide the transaction's minimum timestamp. The transaction could not
 	// have written a transaction record previously with a timestamp below this.
-	txnMinTS := txn.MinTimestamp
-	if txnMinTS.IsEmpty() {
-		return errors.Errorf("no minimum transaction timestamp provided: %v", txn)
+	//
+	// We use InclusiveTimeBounds to remain backward compatible. However, if we
+	// don't need to worry about compatibility, we require the transaction to
+	// have a minimum timestamp field.
+	// TODO(nvanbenschoten): Replace this with txn.MinTimestamp in v20.1.
+	txnMinTS, _ := txn.InclusiveTimeBounds()
+	if util.RaceEnabled {
+		newTxnMinTS := txn.MinTimestamp
+		if newTxnMinTS.IsEmpty() {
+			return errors.Errorf("no minimum transaction timestamp provided: %v", txn)
+		} else if newTxnMinTS != txnMinTS {
+			return errors.Errorf("minimum transaction timestamp differs from lower time bound: %v", txn)
+		}
 	}
 	ok, minCommitTS, reason := rec.CanCreateTxnRecord(txn.ID, txn.Key, txnMinTS)
 	if !ok {


### PR DESCRIPTION
Fixes #39008.

This was missed in #38782. I must have been thinking about the behavior
we'll want to switch to in v20.1. Luckily, the issue was easily caught
by `tpcc/mixed-headroom/n5cpu16`.

Release note: None