### PR TITLE
sql: Add locality information to SHOW EXPERIMENTAL_RANGES

### DIFF
--- a/pkg/sql/delegate/show_ranges.go
+++ b/pkg/sql/delegate/show_ranges.go
@@ -45,10 +45,14 @@ SELECT
   CASE WHEN r.end_key >= x'%s' THEN NULL ELSE crdb_internal.pretty_key(r.end_key, 2) END AS end_key,
   range_id,
   replicas,
-  lease_holder
+  lease_holder,
+  locality
 FROM crdb_internal.ranges AS r
+LEFT JOIN crdb_internal.gossip_nodes n ON
+r.lease_holder = n.node_id
 WHERE (r.start_key < x'%s')
-  AND (r.end_key   > x'%s')`,
+  AND (r.end_key   > x'%s') ORDER BY r.start_key
+`,
 		startKey, endKey, endKey, startKey,
 	))
 }

--- a/pkg/sql/logictest/testdata/logic_test/distsql_agg
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_agg
@@ -21,7 +21,7 @@ INSERT INTO data SELECT a, b, c::FLOAT, d::DECIMAL FROM
    generate_series(1, 10) AS d(d)
 
 # Verify data placement.
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE data]
 ----
 start_key  end_key  replicas  lease_holder
@@ -312,7 +312,7 @@ ALTER TABLE two EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 0)
 statement ok
 INSERT INTO two VALUES (1,1), (2,2), (3,3), (4,4), (5,5), (6,6), (7,7), (8,8), (9,9), (10,10)
 
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE one]
 ----
 start_key  end_key  replicas  lease_holder
@@ -320,7 +320,7 @@ NULL       /0       {5}       5
 /0         /99      {1}       1
 /99        NULL     {5}       5
 
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE two]
 ----
 start_key  end_key  replicas  lease_holder

--- a/pkg/sql/logictest/testdata/logic_test/distsql_distinct_on
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_distinct_on
@@ -61,7 +61,7 @@ ALTER TABLE abc EXPERIMENTAL_RELOCATE VALUES
   (ARRAY[4], '2', '3', '4'),
   (ARRAY[5], '3', '4', '5')
 
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder from [SHOW EXPERIMENTAL_RANGES FROM TABLE xyz]
 ----
 start_key  end_key  replicas  lease_holder
@@ -71,7 +71,7 @@ NULL       /2       {1}       1
 /6         /7       {4}       4
 /7         NULL     {5}       5
 
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder from [SHOW EXPERIMENTAL_RANGES FROM TABLE abc]
 ----
 start_key        end_key          replicas  lease_holder

--- a/pkg/sql/logictest/testdata/logic_test/distsql_interleaved_join
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_interleaved_join
@@ -191,7 +191,7 @@ ALTER TABLE grandchild2 EXPERIMENTAL_RELOCATE
   SELECT ARRAY[((i-1)/2)::INT%5+1], i, i+20, i, i FROM generate_series(1, 39, 2) AS g(i)
 
 # Verify data placement.
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder from [SHOW EXPERIMENTAL_RANGES FROM TABLE parent1]
 ----
 start_key                   end_key                     replicas  lease_holder
@@ -216,7 +216,7 @@ NULL                        /2/#/56/1/42/2/#/58/1/2     {1}       1
 /36/#/55/1/76               /38/#/56/1/78/38/#/58/1/38  {4}       4
 /38/#/56/1/78/38/#/58/1/38  NULL                        {5}       5
 
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder from [SHOW EXPERIMENTAL_RANGES FROM TABLE child1]
 ----
 start_key                   end_key                     replicas  lease_holder
@@ -241,7 +241,7 @@ NULL                        /2/#/56/1/42/2/#/58/1/2     {1}       1
 /36/#/55/1/76               /38/#/56/1/78/38/#/58/1/38  {4}       4
 /38/#/56/1/78/38/#/58/1/38  NULL                        {5}       5
 
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder from [SHOW EXPERIMENTAL_RANGES FROM TABLE grandchild1]
 ----
 start_key                   end_key                     replicas  lease_holder
@@ -512,7 +512,7 @@ statement ok
 ALTER TABLE outer_p1 EXPERIMENTAL_RELOCATE
   SELECT ARRAY[(((i-3)/5)%4)::INT + 1], i FROM generate_series(3, 40, 5) AS g(i)
 
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder from [SHOW EXPERIMENTAL_RANGES FROM TABLE outer_p1]
 ----
 start_key  end_key  replicas  lease_holder

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -28,7 +28,7 @@ INSERT INTO data SELECT a, b, c::FLOAT, d::DECIMAL FROM
    generate_series(1, 10) AS d(d)
 
 # Verify data placement.
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE data]
 ----
 start_key  end_key  replicas  lease_holder

--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -3,7 +3,7 @@
 statement ok
 CREATE TABLE t (k1 INT, k2 INT, v INT, w INT, PRIMARY KEY (k1, k2))
 
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE t]
 ----
 start_key  end_key  replicas  lease_holder
@@ -12,7 +12,7 @@ NULL       NULL     {1}       1
 statement ok
 ALTER TABLE t SPLIT AT VALUES (1), (10)
 
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE t]
 ----
 start_key  end_key  replicas  lease_holder
@@ -26,7 +26,7 @@ ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[4], 1, 12)
 statement ok
 ALTER TABLE t EXPERIMENTAL_RELOCATE LEASE VALUES (4, 1, 12)
 
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE t]
 ----
 start_key  end_key  replicas  lease_holder
@@ -37,7 +37,7 @@ NULL       /1       {1}       1
 statement ok
 ALTER TABLE t SPLIT AT VALUES (5,1), (5,2), (5,3)
 
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE t]
 ----
 start_key  end_key  replicas  lease_holder
@@ -57,7 +57,7 @@ ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[3,4], 4)
 statement ok
 ALTER TABLE t EXPERIMENTAL_RELOCATE LEASE VALUES (1, 5, 1), (5, 5, 2)
 
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE t]
 ----
 start_key  end_key  replicas  lease_holder
@@ -71,7 +71,7 @@ NULL       /1       {1}       1
 statement ok
 CREATE INDEX idx ON t(v, w)
 
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder FROM [SHOW EXPERIMENTAL_RANGES FROM INDEX t@idx]
 ----
 start_key  end_key  replicas  lease_holder
@@ -80,7 +80,7 @@ NULL       NULL     {1}       1
 statement ok
 ALTER INDEX t@idx SPLIT AT VALUES (100,1), (100,50)
 
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder FROM [SHOW EXPERIMENTAL_RANGES FROM INDEX t@idx]
 ----
 start_key  end_key  replicas  lease_holder
@@ -91,7 +91,7 @@ NULL       /100/1   {1}       1
 statement ok
 ALTER INDEX t@idx SPLIT AT VALUES (8), (9)
 
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder FROM [SHOW EXPERIMENTAL_RANGES FROM INDEX t@idx]
 ----
 start_key  end_key  replicas  lease_holder
@@ -104,7 +104,7 @@ NULL       /8       {1}       1
 statement ok
 ALTER INDEX t@idx EXPERIMENTAL_RELOCATE VALUES (ARRAY[5], 100, 10), (ARRAY[3], 100, 11)
 
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder FROM [SHOW EXPERIMENTAL_RANGES FROM INDEX t@idx]
 ----
 start_key  end_key  replicas  lease_holder
@@ -122,7 +122,7 @@ CREATE TABLE t0 (
 ) INTERLEAVE IN PARENT t(k1, k2)
 
 # We expect the splits for t0 to be the same as the splits for t.
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE t0]
 ----
 start_key  end_key  replicas  lease_holder
@@ -136,7 +136,7 @@ NULL       /1       {1}       1
 statement ok
 ALTER TABLE t0 SPLIT AT VALUES (7, 8, 9)
 
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE t0]
 ----
 start_key      end_key        replicas  lease_holder
@@ -151,7 +151,7 @@ NULL           /1             {1}       1
 statement ok
 ALTER TABLE t0 SPLIT AT VALUES (11)
 
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE t0]
 ----
 start_key      end_key        replicas  lease_holder
@@ -164,7 +164,7 @@ NULL           /1             {1}       1
 /10            /11            {1}       1
 /11            NULL           {1}       1
 
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE t]
 ----
 start_key      end_key        replicas  lease_holder
@@ -185,8 +185,8 @@ statement ok
 CREATE INDEX idx on t1(v1,v2,v3) INTERLEAVE IN PARENT t(v1,v2)
 
 # We expect the splits for the index to be the same as the splits for t.
-query TTTI colnames
-SELECT start_key, end_key, replicas, lease_holder FROM [SHOW EXPERIMENTAL_RANGES FROM INDEX t1@idx]
+query TTTI colnames,rowsort
+SELECT start_key, end_key, replicas, lease_holder FROM [SHOW EXPERIMENTAL_RANGES FROM INDEX t1@idx] 
 ----
 start_key      end_key        replicas  lease_holder
 NULL           /1             {1}       1
@@ -201,7 +201,7 @@ NULL           /1             {1}       1
 statement ok
 ALTER INDEX t1@idx SPLIT AT VALUES (15,16)
 
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder FROM [SHOW EXPERIMENTAL_RANGES FROM INDEX t1@idx]
 ----
 start_key      end_key        replicas  lease_holder

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
@@ -13,7 +13,7 @@ ALTER TABLE data EXPERIMENTAL_RELOCATE
   SELECT ARRAY[i%5+1], i FROM generate_series(0, 9) AS g(i)
 
 # Verify data placement.
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE data]
 ----
 start_key  end_key  replicas  lease_holder
@@ -241,7 +241,7 @@ ALTER TABLE sorted_data EXPERIMENTAL_RELOCATE
   SELECT ARRAY[i%5+1], i FROM generate_series(0, 9) AS g(i)
 
 # Verify data placement.
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE sorted_data]
 ----
 start_key  end_key  replicas  lease_holder
@@ -309,7 +309,7 @@ ALTER TABLE data2 EXPERIMENTAL_RELOCATE
   SELECT ARRAY[i%5+1], i FROM generate_series(0, 9) AS g(i);
 
 # Verify data placement.
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE data2]
 ----
 start_key  end_key  replicas  lease_holder

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
@@ -53,7 +53,7 @@ NULL       /2       {1}       1
 /6         /7       {4}       4
 /7         NULL     {5}       5
 
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder from [SHOW EXPERIMENTAL_RANGES FROM TABLE abc]
 ----
 start_key        end_key          replicas  lease_holder

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
@@ -103,7 +103,7 @@ ALTER TABLE grandchild2 EXPERIMENTAL_RELOCATE
   SELECT ARRAY[((i-1)/2)::INT%5+1], i, i+20, i, i FROM generate_series(1, 39, 2) AS g(i)
 
 # Verify data placement.
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder from [SHOW EXPERIMENTAL_RANGES FROM TABLE parent1]
 ----
 start_key                   end_key                     replicas  lease_holder
@@ -128,7 +128,7 @@ NULL                        /2/#/56/1/42/2/#/58/1/2     {1}       1
 /36/#/55/1/76               /38/#/56/1/78/38/#/58/1/38  {4}       4
 /38/#/56/1/78/38/#/58/1/38  NULL                        {5}       5
 
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder from [SHOW EXPERIMENTAL_RANGES FROM TABLE child1]
 ----
 start_key                   end_key                     replicas  lease_holder
@@ -153,7 +153,7 @@ NULL                        /2/#/56/1/42/2/#/58/1/2     {1}       1
 /36/#/55/1/76               /38/#/56/1/78/38/#/58/1/38  {4}       4
 /38/#/56/1/78/38/#/58/1/38  NULL                        {5}       5
 
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder from [SHOW EXPERIMENTAL_RANGES FROM TABLE grandchild1]
 ----
 start_key                   end_key                     replicas  lease_holder
@@ -363,7 +363,7 @@ statement ok
 ALTER TABLE outer_p1 EXPERIMENTAL_RELOCATE
   SELECT ARRAY[(((i-3)/5)%4)::INT + 1], i FROM generate_series(3, 40, 5) AS g(i)
 
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder from [SHOW EXPERIMENTAL_RANGES FROM TABLE outer_p1]
 ----
 start_key  end_key  replicas  lease_holder

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
@@ -13,7 +13,7 @@ ALTER TABLE data EXPERIMENTAL_RELOCATE
   SELECT ARRAY[i%5+1], i FROM generate_series(0, 9) AS g(i)
 
 # Verify data placement.
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder from [SHOW EXPERIMENTAL_RANGES FROM TABLE data]
 ----
 start_key  end_key  replicas  lease_holder

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_misc
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_misc
@@ -70,7 +70,7 @@ ALTER TABLE data EXPERIMENTAL_RELOCATE
   SELECT ARRAY[i%5+1], i FROM generate_series(0, 9) AS g(i)
 
 # Verify data placement.
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE data]
 ----
 start_key  end_key  replicas  lease_holder

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -119,7 +119,7 @@ ALTER TABLE data EXPERIMENTAL_RELOCATE
   SELECT ARRAY[i%5+1], i FROM generate_series(0, 9) AS g(i)
 
 # Verify data placement.
-query TTTI colnames
+query TTTI colnames,rowsort
 SELECT start_key, end_key, replicas, lease_holder from [SHOW EXPERIMENTAL_RANGES FROM TABLE data]
 ----
 start_key  end_key  replicas  lease_holder

--- a/pkg/sql/show_ranges_test.go
+++ b/pkg/sql/show_ranges_test.go
@@ -1,0 +1,50 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestShowRangesWithLocality(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const numNodes = 4
+	ctx := context.Background()
+	tcArgs := base.TestClusterArgs{}
+
+	tc := testcluster.StartTestCluster(t, numNodes, tcArgs)
+	defer tc.Stopper().Stop(ctx)
+
+	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+	sqlDB.Exec(t, `CREATE TABLE t (x INT PRIMARY KEY)`)
+	sqlDB.Exec(t, `ALTER TABLE t SPLIT AT SELECT i FROM generate_series(0, 20) AS g(i)`)
+
+	const nodeColIdx = 4
+	const localityColIdx = 5
+
+	result := sqlDB.QueryStr(t, `SHOW EXPERIMENTAL_RANGES FROM TABLE t`)
+	for _, row := range result {
+		// Because StartTestCluster changes the locality no matter what the
+		// arguments are, we expect whatever the test server sets up.
+		locality := fmt.Sprintf("region=test,dc=dc%s", row[nodeColIdx])
+		if row[localityColIdx] != locality {
+			t.Fatalf("expected %s found %s", locality, row[localityColIdx])
+		}
+	}
+}


### PR DESCRIPTION
This commit includes some test changes in logic and opt tests. These tests relied on the output ordering of the SHOW EXPERIMENTAL_RANGES command without explicitly enforcing it, which caused these tests to fail after these changes.

Fixes #38608 