### PR TITLE
distsql: a couple of fixes

### DIFF
--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -507,6 +507,9 @@ func (f *Flow) setup(ctx context.Context, spec *distsqlpb.FlowSpec) error {
 			log.VEventf(ctx, 1, "vectorized flow.")
 			return nil
 		}
+		// We won't run this flow through vectorized, so clear the memory account.
+		acc.Close(ctx)
+		f.vectorizedBoundAccount = nil
 		// Vectorization attempt failed with an error.
 		if f.spec.Gateway != f.NodeID {
 			// If we are not the gateway node, do not attempt to plan this with the


### PR DESCRIPTION
I extracted two commits that we want to merge from #38952.

First commit clears vectorized memory account on setup error.
Otherwise there could be cases where memory reservations could live on
in the monitor since Cleanup would never be called on a flow.

Second commit avoids double freeing processor specs.
Distributed vectorized fallback logic introduced recursive calls to
setupFlows in which Releases of processor specs would be deferred. This
could result in double Releases of processor specs, in between which a
goroutine could have grabbed a spec from the pool, written to it, and
then found that the spec had been zeroed out.

Fixes: #38651.