### PR TITLE
opt: support view and sequence numeric refs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/numeric_references
+++ b/pkg/sql/logictest/testdata/logic_test/numeric_references
@@ -1,91 +1,52 @@
-# LogicTest: local-opt
-# ------------------------------------------------------------------------------
-# Numeric References Tests.
-# These are put at the beginning of the file to ensure the numeric table
-# reference is 53 (the numeric reference of the first table).
-# If the numbering scheme in cockroach changes, this test will break.
-# TODO(madhavsuresh): get the numeric reference ID in a less brittle fashion
-# ------------------------------------------------------------------------------
+# LogicTest: local-opt local
 
 statement ok
-CREATE TABLE num_ref (a INT PRIMARY KEY, xx INT, b INT, c INT, INDEX bc (b,c))
+CREATE TABLE x (a INT PRIMARY KEY, xx INT, b INT, c INT, INDEX bc (b,c))
 
 statement ok
-CREATE TABLE num_ref_hidden (a INT, b INT)
-
-
-statement ok
-ALTER TABLE num_ref RENAME COLUMN b TO d
+INSERT INTO x VALUES (1), (2), (3)
 
 statement ok
-ALTER TABLE num_ref RENAME COLUMN a TO p
+CREATE VIEW view_ref AS SELECT a, 1 FROM x
 
-statement ok
-ALTER TABLE num_ref DROP COLUMN xx
+let $v_id
+SELECT id FROM system.namespace WHERE name='view_ref'
 
-statement ok
-INSERT INTO num_ref VALUES (1, 10, 101), (2, 20, 200), (3, 30, 300)
+statement error cannot specify an explicit column list when accessing a view by reference
+SELECT * FROM [$v_id(1) AS _]
 
-statement ok
-INSERT INTO num_ref_hidden VALUES (1, 10), (2, 20), (3, 30)
-
-query III
-SELECT * FROM num_ref
+query II
+SELECT * FROM [$v_id AS _]
 ----
-1  10  101
-2  20  200
-3  30  300
-
-query III
-SELECT * FROM [53 as num_ref_alias]
-----
-1  10  101
-2  20  200
-3  30  300
-
-query III
-SELECT * FROM [53(4,3,1) AS num_ref_alias]
-----
-101  10  1
-200  20  2
-300  30  3
+1  1
+2  1
+3  1
 
 query I
-SELECT * FROM [53(4) AS num_ref_alias]@[2]
-----
-101
-200
-300
-
-query I
-SELECT * FROM [53(1) AS num_ref_alias]@[1]
+SELECT foo.a FROM [$v_id AS foo]
 ----
 1
 2
 3
 
-query III colnames
-SELECT * FROM [53(1,3,4) AS num_ref_alias(col1,col2,col3)]
+statement ok
+CREATE SEQUENCE seq
+
+let $seq_id
+SELECT id FROM system.namespace WHERE name='seq'
+
+query IIB
+SELECT * FROM [$seq_id AS _]
 ----
-col1  col2  col3
-1     10    101
-2     20    200
-3     30    300
+0 0 true
 
-query I
-SELECT * FROM [54(1,3) AS num_ref_hidden]
+# Col refs in sequences are ignored.
+query IIB
+SELECT * FROM [$seq_id(1) AS _]
 ----
-1
-2
-3
+0 0 true
 
-query I
-SELECT count(rowid) FROM [54(3) AS num_ref_hidden]
+query IIB
+SELECT * FROM [$seq_id(1, 2) AS _]
 ----
-3
-
-# Ensure that privileges are checked when using numeric references.
-user testuser
-
-statement error pq: user testuser does not have SELECT privilege on relation num_ref
-SELECT * FROM [53 AS t]
+0 0 true

--- a/pkg/sql/logictest/testdata/logic_test/numeric_references_opt
+++ b/pkg/sql/logictest/testdata/logic_test/numeric_references_opt
@@ -1,0 +1,96 @@
+# LogicTest: local-opt
+# ------------------------------------------------------------------------------
+# Numeric References Tests.
+# These are put at the beginning of the file to ensure the numeric table
+# reference is 53 (the numeric reference of the first table).
+# If the numbering scheme in cockroach changes, this test will break.
+# TODO(madhavsuresh): get the numeric reference ID in a less brittle fashion
+# ------------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE num_ref (a INT PRIMARY KEY, xx INT, b INT, c INT, INDEX bc (b,c))
+
+statement ok
+CREATE TABLE num_ref_hidden (a INT, b INT)
+
+statement ok
+ALTER TABLE num_ref RENAME COLUMN b TO d
+
+statement ok
+ALTER TABLE num_ref RENAME COLUMN a TO p
+
+statement ok
+ALTER TABLE num_ref DROP COLUMN xx
+
+statement ok
+INSERT INTO num_ref VALUES (1, 10, 101), (2, 20, 200), (3, 30, 300)
+
+statement ok
+INSERT INTO num_ref_hidden VALUES (1, 10), (2, 20), (3, 30)
+
+query III
+SELECT * FROM num_ref
+----
+1  10  101
+2  20  200
+3  30  300
+
+let $num_ref_id
+SELECT id FROM system.namespace WHERE name='num_ref'
+
+query III
+SELECT * FROM [$num_ref_id as num_ref_alias]
+----
+1  10  101
+2  20  200
+3  30  300
+
+query III
+SELECT * FROM [$num_ref_id(4,3,1) AS num_ref_alias]
+----
+101  10  1
+200  20  2
+300  30  3
+
+query I
+SELECT * FROM [$num_ref_id(4) AS num_ref_alias]@[2]
+----
+101
+200
+300
+
+query I
+SELECT * FROM [$num_ref_id(1) AS num_ref_alias]@[1]
+----
+1
+2
+3
+
+query III colnames
+SELECT * FROM [$num_ref_id(1,3,4) AS num_ref_alias(col1,col2,col3)]
+----
+col1  col2  col3
+1     10    101
+2     20    200
+3     30    300
+
+let $num_ref_hidden_id
+SELECT id FROM system.namespace WHERE name='num_ref_hidden'
+
+query I
+SELECT * FROM [$num_ref_hidden_id(1,3) AS num_ref_hidden]
+----
+1
+2
+3
+
+query I
+SELECT count(rowid) FROM [$num_ref_hidden_id(3) AS num_ref_hidden]
+----
+3
+
+# Ensure that privileges are checked when using numeric references.
+user testuser
+
+statement error pq: user testuser does not have SELECT privilege on relation num_ref
+SELECT * FROM [$num_ref_id AS t]

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -159,7 +159,7 @@ func (tc *Catalog) ResolveDataSourceByID(
 	ctx context.Context, id cat.StableID,
 ) (cat.DataSource, error) {
 	for _, ds := range tc.testSchema.dataSources {
-		if tab, ok := ds.(*Table); ok && tab.TabID == id {
+		if ds.ID() == id {
 			return ds, nil
 		}
 	}


### PR DESCRIPTION
I ended up complicating this much more than necessary - it turns out the
heuristic planner doesn't even support specifying columns for view
numeric references, so this feature is actually really straightforward.

I added a separate test file that is run under the heuristic planner as
well (the existing numeric reference test file panics when run under the
HP, concerningly...).

Release note: None