### PR TITLE
distsqlrun: drain meta on ConsumerClosed of materializer

### DIFF
--- a/pkg/sql/distsqlrun/materializer.go
+++ b/pkg/sql/distsqlrun/materializer.go
@@ -158,5 +158,8 @@ func (m *materializer) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata)
 }
 
 func (m *materializer) ConsumerClosed() {
+	// TODO(yuzefovich): this seems like a hack to me, but in order to close an
+	// Inbox, we need to drain it.
+	m.trailingMetaCallback(m.Ctx)
 	m.InternalClose()
 }

--- a/pkg/sql/logictest/testdata/logic_test/dist_vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/dist_vectorize
@@ -68,7 +68,7 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJzUl89vm0oQx-_vr0Bzek9ZP9
 
 # Verify execution.
 statement ok
-SET experimental_vectorize = always;
+SET experimental_vectorize = always
 
 query I rowsort
 SELECT kv.k FROM kv JOIN kw ON kv.k = kw.k
@@ -79,5 +79,20 @@ SELECT kv.k FROM kv JOIN kw ON kv.k = kw.k
 4
 5
 
+# Regression test for #38919.
 statement ok
-RESET experimental_vectorize;
+SET experimental_vectorize = on
+
+statement ok
+SET optimizer = on
+
+query B
+SELECT EXISTS(SELECT * FROM kv WHERE k > 2)
+----
+true
+
+statement ok
+RESET optimizer
+
+statement ok
+RESET experimental_vectorize


### PR DESCRIPTION
Previously, when ConsumerClosed was called on materializer, any
Inboxes that were in the chain of columnar operators under that
materializer would hang because they never received a closing
signal. Now, we will drain metadata sources in materializer
which will trigger the closure of Inboxes. This seems like a
hack to me, but it seems to work.

Addresses: #38919.

Release note: None