### PR TITLE
sql: Error out on conflicting zone constraints.

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -479,3 +479,20 @@ test.t38391.x1_idx  ALTER PARTITION x1_idx OF INDEX t38391@foo CONFIGURE ZONE US
                     num_replicas = 3,
                     constraints = '[]',
                     lease_preferences = '[]'
+
+statement ok
+CREATE TABLE dup_constraint (x INT PRIMARY KEY);
+
+statement ok
+ALTER TABLE dup_constraint PARTITION BY LIST (x) (
+    PARTITION p1 VALUES IN (1),
+    PARTITION p2 VALUES IN (2)
+)
+
+statement error pq: incompatible zone constraints: "\+region=us-east1" and "\+region=us-west1"
+ALTER PARTITION p1 OF TABLE dup_constraint CONFIGURE ZONE USING
+CONSTRAINTS='[+region=us-east1, +region=us-west1]'
+
+statement error pq: incompatible zone constraints: "\+region=us-east1" and "\-region=us-east1"
+ALTER PARTITION p1 OF TABLE dup_constraint CONFIGURE ZONE USING
+CONSTRAINTS='[+region=us-east1, -region=us-east1]'


### PR DESCRIPTION
We error out when zone configurations contain the
following pattern.

* constraints: ["+k:v", "+k:v2"]
* constraints: ["+k:v", "-k:v"]

In prose, we disallow positive redefinitions of a single
key along with both the positive and negative definitions
of the same key/value pair.

Addresses #35336.

Release note (sql change): Error out when zone constraints cause conflicts with each other.