### PR TITLE
exec: minor fix to appease trace tests

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"math"
 	"reflect"
-	"strings"
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
@@ -105,7 +104,7 @@ type newColOperatorResult struct {
 func newColOperator(
 	ctx context.Context, flowCtx *FlowCtx, spec *distsqlpb.ProcessorSpec, inputs []exec.Operator,
 ) (result newColOperatorResult, err error) {
-	log.VEventf(ctx, 2, "planning col operator for spec %+v", spec)
+	log.VEventf(ctx, 2, "planning col operator for spec %q", spec)
 
 	core := &spec.Core
 	post := &spec.Post
@@ -550,7 +549,7 @@ func newColOperator(
 		columnTypes = append(spec.Input[0].ColumnTypes, *semtypes.Int)
 
 	default:
-		return result, errors.Newf("unsupported processor core %s", strings.TrimSpace(core.String()))
+		return result, errors.Newf("unsupported processor core %q", core)
 	}
 
 	// After constructing the base operator, calculate the memory usage

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -13,7 +13,6 @@ package distsqlrun
 import (
 	"context"
 	"math"
-	"strings"
 	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -1197,7 +1196,7 @@ func newProcessor(
 		}
 		return NewChangeFrontierProcessor(flowCtx, processorID, *core.ChangeFrontier, inputs[0], outputs[0])
 	}
-	return nil, errors.Errorf("unsupported processor core %s", strings.TrimSpace(core.String()))
+	return nil, errors.Errorf("unsupported processor core %q", core)
 }
 
 // LocalProcessor is a RowSourcedProcessor that needs to be initialized with


### PR DESCRIPTION
TestTraceFieldDecomposition was failing with vectorized enabled due to
trailing space in a log message.

Release note: None