### PR TITLE
batcheval: add GetNodeLocality() to EvalContext

### DIFF
--- a/pkg/storage/batcheval/cmd_resolve_intent_test.go
+++ b/pkg/storage/batcheval/cmd_resolve_intent_test.go
@@ -74,6 +74,9 @@ func (m *mockEvalCtx) GetTxnWaitQueue() *txnwait.Queue {
 func (m *mockEvalCtx) NodeID() roachpb.NodeID {
 	panic("unimplemented")
 }
+func (m *mockEvalCtx) GetNodeLocality() roachpb.Locality {
+	panic("unimplemented")
+}
 func (m *mockEvalCtx) StoreID() roachpb.StoreID {
 	return m.storeID
 }

--- a/pkg/storage/batcheval/eval_context.go
+++ b/pkg/storage/batcheval/eval_context.go
@@ -59,6 +59,7 @@ type EvalContext interface {
 	NodeID() roachpb.NodeID
 	StoreID() roachpb.StoreID
 	GetRangeID() roachpb.RangeID
+	GetNodeLocality() roachpb.Locality
 
 	IsFirstRange() bool
 	GetFirstIndex() (uint64, error)

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -659,6 +659,11 @@ func (r *Replica) NodeID() roachpb.NodeID {
 	return r.store.nodeDesc.NodeID
 }
 
+// GetNodeLocality returns the locality of the node this replica belongs to.
+func (r *Replica) GetNodeLocality() roachpb.Locality {
+	return r.store.nodeDesc.Locality
+}
+
 // ClusterSettings returns the node's ClusterSettings.
 func (r *Replica) ClusterSettings() *cluster.Settings {
 	return r.store.cfg.Settings

--- a/pkg/storage/replica_eval_context_span.go
+++ b/pkg/storage/replica_eval_context_span.go
@@ -83,6 +83,11 @@ func (rec *SpanSetReplicaEvalContext) NodeID() roachpb.NodeID {
 	return rec.i.NodeID()
 }
 
+// GetNodeLocality returns the node locality.
+func (rec *SpanSetReplicaEvalContext) GetNodeLocality() roachpb.Locality {
+	return rec.i.GetNodeLocality()
+}
+
 // Engine returns the engine.
 func (rec *SpanSetReplicaEvalContext) Engine() engine.Engine {
 	return rec.i.Engine()


### PR DESCRIPTION
This PR adds a method `GetNodeLocality()` to `batcheval.EvalContext`, which
returns the locality of the node the replica belongs to. This is needed for
geo-distributed BACKUP: `ExportRequest`s will contain a map of locality values
to export stores, so the locality of the node must be available during
evaluation.

Release note: None