### PR TITLE
sql: add partial support for pgwire row count limits

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -957,7 +957,7 @@
   version = "v1.0"
 
 [[projects]]
-  digest = "1:6a5edb6e9ad91f22d33e01739bbabea324fed674c40bc4f7d60adb48235e8b48"
+  digest = "1:a7261255f31aa65e511b45cf7a36fda39dafb08914287506c93cb8c07afb9708"
   name = "github.com/jackc/pgx"
   packages = [
     ".",
@@ -968,8 +968,8 @@
     "pgtype",
   ]
   pruneopts = "UT"
-  revision = "c59c9cac59ab95eceb0c12ff338923c62f411ea2"
-  version = "v3.3.0"
+  revision = "a1d6202434aa40c3624688f6c2cacbc27eef5472"
+  version = "v3.5.0"
 
 [[projects]]
   digest = "1:dcb3e2ad17349c0cc89ffc16692d05195e6a67b4924fe81760fba9a307a7271d"
@@ -1526,7 +1526,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:55a70b7b8111fbbe7f412b3839dbff52bfba5c35d04a21fedc0b0f724895b3a5"
+  digest = "1:3454241817ada8069448d68384231cb86f2107046f2560fdcc092da8f6b5cb2b"
   name = "golang.org/x/crypto"
   packages = [
     "bcrypt",
@@ -1536,6 +1536,7 @@
     "ed25519/internal/edwards25519",
     "internal/chacha20",
     "internal/subtle",
+    "pbkdf2",
     "poly1305",
     "ssh",
     "ssh/agent",
@@ -1625,23 +1626,28 @@
   revision = "a457fd036447854c0c02e89ea439481bdcf941a2"
 
 [[projects]]
-  digest = "1:a4427f5b90e0d06b5b19d2891615137a814eb934c5a77397d0d5a753783e5f1e"
+  digest = "1:4de077368be8e07b66ac3f803454b4dc1138c135b5b0917edef59f6580e0bda5"
   name = "golang.org/x/text"
   packages = [
+    "cases",
     "collate",
     "collate/build",
+    "internal",
     "internal/colltab",
     "internal/gen",
     "internal/tag",
     "internal/triegen",
     "internal/ucd",
     "language",
+    "runes",
     "secure/bidirule",
+    "secure/precis",
     "transform",
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
     "unicode/rangetable",
+    "width",
   ]
   pruneopts = "UT"
   revision = "470f45bf29f4147d6fbd7dfd0a02a848e49f5bf4"

--- a/pkg/acceptance/testdata/java/src/main/java/MainTest.java
+++ b/pkg/acceptance/testdata/java/src/main/java/MainTest.java
@@ -1,6 +1,8 @@
 import org.junit.*;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import static junit.framework.TestCase.fail;
+import org.postgresql.util.PSQLException;
 
 import java.math.BigDecimal;
 import java.sql.Array;
@@ -242,6 +244,22 @@ public class MainTest extends CockroachDBTest {
         rs = getNextVal.executeQuery();
         rs.next();
         Assert.assertEquals(rs.getInt(1), 2);
+    }
+
+    @Test
+    public void selectLimitExplicitTxn() throws Exception {
+        conn.setAutoCommit(false);
+        PreparedStatement stmt = conn.prepareStatement("SELECT * from generate_series(1, 10)");
+        stmt.setFetchSize(1);
+        ResultSet rs = stmt.executeQuery();
+        rs.next();
+        Assert.assertEquals(1, rs.getInt(1));
+        rs.next();
+        Assert.assertEquals(2, rs.getInt(1));
+        rs.setFetchSize(0);
+        rs.next();
+        Assert.assertEquals(3, rs.getInt(1));
+        conn.setAutoCommit(true);
     }
 
     // Regression for 30538: SQL query with wrong parameter value crashes

--- a/pkg/sql/conn_io_test.go
+++ b/pkg/sql/conn_io_test.go
@@ -77,7 +77,7 @@ func TestStmtBuf(t *testing.T) {
 	// same statement.
 	expPos := CmdPos(0)
 	for i := 0; i < 2; i++ {
-		cmd, pos, err := buf.curCmd()
+		cmd, pos, err := buf.CurCmd()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -87,9 +87,9 @@ func TestStmtBuf(t *testing.T) {
 		assertStmt(t, cmd, "SELECT 1")
 	}
 
-	buf.advanceOne()
+	buf.AdvanceOne()
 	expPos++
-	cmd, pos, err := buf.curCmd()
+	cmd, pos, err := buf.CurCmd()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,9 +98,9 @@ func TestStmtBuf(t *testing.T) {
 	}
 	assertStmt(t, cmd, "SELECT 2")
 
-	buf.advanceOne()
+	buf.AdvanceOne()
 	expPos++
-	cmd, pos, err = buf.curCmd()
+	cmd, pos, err = buf.CurCmd()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,9 +109,9 @@ func TestStmtBuf(t *testing.T) {
 	}
 	assertStmt(t, cmd, "SELECT 3")
 
-	buf.advanceOne()
+	buf.AdvanceOne()
 	expPos++
-	cmd, pos, err = buf.curCmd()
+	cmd, pos, err = buf.CurCmd()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -123,7 +123,7 @@ func TestStmtBuf(t *testing.T) {
 	// Now rewind.
 	expPos = 1
 	buf.rewind(ctx, expPos)
-	cmd, pos, err = buf.curCmd()
+	cmd, pos, err = buf.CurCmd()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,7 +149,7 @@ func TestStmtBufSignal(t *testing.T) {
 	}()
 
 	expPos := CmdPos(0)
-	cmd, pos, err := buf.curCmd()
+	cmd, pos, err := buf.CurCmd()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,8 +173,8 @@ func TestStmtBufLtrim(t *testing.T) {
 		mustPush(ctx, t, buf, ExecStmt{Statement: stmt})
 	}
 	// Advance the cursor so that we can trim.
-	buf.advanceOne()
-	buf.advanceOne()
+	buf.AdvanceOne()
+	buf.AdvanceOne()
 	trimPos := CmdPos(2)
 	buf.ltrim(ctx, trimPos)
 	if l := len(buf.mu.data); l != 3 {
@@ -185,7 +185,7 @@ func TestStmtBufLtrim(t *testing.T) {
 	}
 }
 
-// Test that, after Close() is called, buf.curCmd() returns io.EOF even if
+// Test that, after Close() is called, buf.CurCmd() returns io.EOF even if
 // there were commands queued up.
 func TestStmtBufClose(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -199,13 +199,13 @@ func TestStmtBufClose(t *testing.T) {
 	mustPush(ctx, t, buf, ExecStmt{Statement: stmt})
 	buf.Close()
 
-	_, _, err = buf.curCmd()
+	_, _, err = buf.CurCmd()
 	if err != io.EOF {
 		t.Fatalf("expected EOF, got: %v", err)
 	}
 }
 
-// Test that a call to Close() unblocks a curCmd() call.
+// Test that a call to Close() unblocks a CurCmd() call.
 func TestStmtBufCloseUnblocksReader(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -215,7 +215,7 @@ func TestStmtBufCloseUnblocksReader(t *testing.T) {
 		buf.Close()
 	}()
 
-	_, _, err := buf.curCmd()
+	_, _, err := buf.CurCmd()
 	if err != io.EOF {
 		t.Fatalf("expected EOF, got: %v", err)
 	}
@@ -237,21 +237,21 @@ func TestStmtBufPreparedStmt(t *testing.T) {
 	mustPush(ctx, t, buf, PrepareStmt{Name: "p1"})
 	mustPush(ctx, t, buf, PrepareStmt{Name: "p2"})
 
-	cmd, _, err := buf.curCmd()
+	cmd, _, err := buf.CurCmd()
 	if err != nil {
 		t.Fatal(err)
 	}
 	assertStmt(t, cmd, "SELECT 1")
 
-	buf.advanceOne()
-	cmd, _, err = buf.curCmd()
+	buf.AdvanceOne()
+	cmd, _, err = buf.CurCmd()
 	if err != nil {
 		t.Fatal(err)
 	}
 	assertPrepareStmt(t, cmd, "p1")
 
-	buf.advanceOne()
-	cmd, _, err = buf.curCmd()
+	buf.AdvanceOne()
+	cmd, _, err = buf.CurCmd()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -259,7 +259,7 @@ func TestStmtBufPreparedStmt(t *testing.T) {
 
 	// Rewind to the first prepared stmt.
 	buf.rewind(ctx, CmdPos(1))
-	cmd, _, err = buf.curCmd()
+	cmd, _, err = buf.CurCmd()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -299,7 +299,7 @@ func TestStmtBufBatching(t *testing.T) {
 	if err := buf.seekToNextBatch(); err != nil {
 		t.Fatal(err)
 	}
-	_, pos, err := buf.curCmd()
+	_, pos, err := buf.CurCmd()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -311,7 +311,7 @@ func TestStmtBufBatching(t *testing.T) {
 	if err := buf.seekToNextBatch(); err != nil {
 		t.Fatal(err)
 	}
-	_, pos, err = buf.curCmd()
+	_, pos, err = buf.CurCmd()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -329,7 +329,7 @@ func TestStmtBufBatching(t *testing.T) {
 	if err := buf.seekToNextBatch(); err != nil {
 		t.Fatal(err)
 	}
-	_, pos, err = buf.curCmd()
+	_, pos, err = buf.CurCmd()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -594,6 +594,9 @@ func (icc *internalClientComm) CreateStatementResult(
 	pos CmdPos,
 	_ []pgwirebase.FormatCode,
 	_ sessiondata.DataConversionConfig,
+	_ int,
+	_ string,
+	_ bool,
 ) CommandResult {
 	return icc.createRes(pos, nil /* onClose */)
 }

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -1142,6 +1142,13 @@ func (c *conn) bufferCommandComplete(tag []byte) {
 	}
 }
 
+func (c *conn) bufferPortalSuspended() {
+	c.msgBuilder.initMsg(pgwirebase.ServerMsgPortalSuspended)
+	if err := c.msgBuilder.finishMsg(&c.writerState.buf); err != nil {
+		panic(fmt.Sprintf("unexpected err from buffer: %s", err))
+	}
+}
+
 func (c *conn) bufferErr(err error) {
 	// TODO(andrei,knz): This would benefit from a context with the
 	// current connection log tags.
@@ -1364,8 +1371,11 @@ func (c *conn) CreateStatementResult(
 	pos sql.CmdPos,
 	formatCodes []pgwirebase.FormatCode,
 	conv sessiondata.DataConversionConfig,
+	limit int,
+	portalName string,
+	implicitTxn bool,
 ) sql.CommandResult {
-	return c.newCommandResult(descOpt, pos, stmt, formatCodes, conv)
+	return c.newCommandResult(descOpt, pos, stmt, formatCodes, conv, limit, portalName, implicitTxn)
 }
 
 // CreateSyncResult is part of the sql.ClientComm interface.

--- a/pkg/sql/pgwire/pgwirebase/msg.go
+++ b/pkg/sql/pgwire/pgwirebase/msg.go
@@ -48,6 +48,7 @@ const (
 	ServerMsgParameterDescription ServerMessageType = 't'
 	ServerMsgParameterStatus      ServerMessageType = 'S'
 	ServerMsgParseComplete        ServerMessageType = '1'
+	ServerMsgPortalSuspended      ServerMessageType = 's'
 	ServerMsgReady                ServerMessageType = 'Z'
 	ServerMsgRowDescription       ServerMessageType = 'T'
 )

--- a/pkg/sql/pgwire/pgwirebase/servermessagetype_string.go
+++ b/pkg/sql/pgwire/pgwirebase/servermessagetype_string.go
@@ -20,6 +20,7 @@ func _() {
 	_ = x[ServerMsgParameterDescription-116]
 	_ = x[ServerMsgParameterStatus-83]
 	_ = x[ServerMsgParseComplete-49]
+	_ = x[ServerMsgPortalSuspended-115]
 	_ = x[ServerMsgReady-90]
 	_ = x[ServerMsgRowDescription-84]
 }
@@ -32,13 +33,14 @@ const (
 	_ServerMessageType_name_4 = "ServerMsgAuthServerMsgParameterStatusServerMsgRowDescription"
 	_ServerMessageType_name_5 = "ServerMsgReady"
 	_ServerMessageType_name_6 = "ServerMsgNoData"
-	_ServerMessageType_name_7 = "ServerMsgParameterDescription"
+	_ServerMessageType_name_7 = "ServerMsgPortalSuspendedServerMsgParameterDescription"
 )
 
 var (
 	_ServerMessageType_index_0 = [...]uint8{0, 22, 43, 65}
 	_ServerMessageType_index_1 = [...]uint8{0, 24, 40, 62}
 	_ServerMessageType_index_4 = [...]uint8{0, 13, 37, 60}
+	_ServerMessageType_index_7 = [...]uint8{0, 24, 53}
 )
 
 func (i ServerMessageType) String() string {
@@ -60,8 +62,9 @@ func (i ServerMessageType) String() string {
 		return _ServerMessageType_name_5
 	case i == 110:
 		return _ServerMessageType_name_6
-	case i == 116:
-		return _ServerMessageType_name_7
+	case 115 <= i && i <= 116:
+		i -= 115
+		return _ServerMessageType_name_7[_ServerMessageType_index_7[i]:_ServerMessageType_index_7[i+1]]
 	default:
 		return "ServerMessageType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}

--- a/pkg/sql/pgwire/testdata/pgtest/portals
+++ b/pkg/sql/pgwire/testdata/pgtest/portals
@@ -114,3 +114,179 @@ ReadyForQuery
 ----
 {"Type":"CommandComplete","CommandTag":"COMMIT"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Execute a portal with limited rows inside a transaction.
+
+send
+Query {"String": "BEGIN"}
+Parse {"Query": "SELECT * FROM generate_series(1, 2)"}
+Bind
+Execute {"MaxRows": 1}
+Sync
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"BEGIN"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"1"}]}
+{"Type":"PortalSuspended"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+# This is the second of 2 rows, but we don't expect a command complete
+# yet.
+
+send
+Execute {"MaxRows": 1}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"DataRow","Values":[{"text":"2"}]}
+{"Type":"PortalSuspended"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+# There were only 2 rows, so this third execute should return a command
+# complete.
+
+send
+Execute {"MaxRows": 1}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"SELECT 0"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+send
+Query {"String": "COMMIT"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"COMMIT"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "SELECT 'here'"}
+----
+
+until ignore=RowDescription
+ReadyForQuery
+----
+{"Type":"DataRow","Values":[{"text":"here"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Execute a portal first with a row limit and then without.
+
+send
+Query {"String": "BEGIN"}
+Parse {"Query": "SELECT * FROM generate_series(1, 4)"}
+Bind
+Execute {"MaxRows": 1}
+Sync
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"BEGIN"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"1"}]}
+{"Type":"PortalSuspended"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+send
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"DataRow","Values":[{"text":"2"}]}
+{"Type":"DataRow","Values":[{"text":"3"}]}
+{"Type":"DataRow","Values":[{"text":"4"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 3"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+send
+Query {"String": "COMMIT"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"COMMIT"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "SELECT 'here'"}
+----
+
+until ignore=RowDescription
+ReadyForQuery
+----
+{"Type":"DataRow","Values":[{"text":"here"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Execute a portal with a result limit. This is outside of a transaction
+# so we expect an error. This differs slightly from the postgres behavior,
+# which will do the first execute, auto close the portal, and then fail
+# on the second.
+
+send
+Parse {"Query": "SELECT * FROM generate_series(1, 2)"}
+Bind
+Execute {"MaxRows": 1}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"1"}]}
+{"Type":"PortalSuspended"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Try the second execute, which we expect to fail because implicit
+# transactions auto close portals after the first suspension.
+
+send
+Execute
+Sync
+----
+
+until
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ErrorResponse","Code":"34000"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "SELECT 'here'"}
+----
+
+until ignore=RowDescription
+ReadyForQuery
+----
+{"Type":"DataRow","Values":[{"text":"here"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/testdata/pgtest/portals_crbugs
+++ b/pkg/sql/pgwire/testdata/pgtest/portals_crbugs
@@ -1,0 +1,138 @@
+# This file tests behavior that differs from Postgres wrt portal
+# handling. That is, the -rewrite flag, when used with Postgres, will
+# produce different results than Cockroach.
+
+# More behavior that differs from postgres. Try executing a new query
+# when a portal is suspended. Cockroach errors.
+
+send
+Query {"String": "BEGIN"}
+Parse {"Query": "SELECT * FROM generate_series(1, 2)"}
+Bind
+Execute {"MaxRows": 1}
+Query {"String": "SELECT 1"}
+Sync
+----
+
+until keepErrMessage
+ReadyForQuery
+ErrorResponse
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"BEGIN"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"1"}]}
+{"Type":"PortalSuspended"}
+{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: execute row count limits only partially supported"}
+{"Type":"ReadyForQuery","TxStatus":"E"}
+{"Type":"ReadyForQuery","TxStatus":"E"}
+
+send
+Query {"String": "ROLLBACK"}
+Query {"String": "SELECT 'here'"}
+----
+
+until ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"ROLLBACK"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"DataRow","Values":[{"text":"here"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Also try binding another portal during suspension.
+
+send
+Query {"String": "BEGIN"}
+Parse {"Query": "SELECT * FROM generate_series(1, 2)"}
+Bind
+Execute {"MaxRows": 1}
+Bind
+Sync
+----
+
+until keepErrMessage
+ReadyForQuery
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"BEGIN"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"1"}]}
+{"Type":"PortalSuspended"}
+{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: execute row count limits only partially supported"}
+{"Type":"ReadyForQuery","TxStatus":"E"}
+
+send
+Query {"String": "ROLLBACK"}
+Query {"String": "SELECT 'here'"}
+----
+
+until ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"ROLLBACK"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"DataRow","Values":[{"text":"here"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Execute a portal partially and close it. In PG this works, but we
+# don't support manually closing a portal early.
+
+send
+Query {"String": "BEGIN"}
+Parse {"Query": "SELECT * FROM generate_series(1, 2)"}
+Bind
+Execute {"MaxRows": 1}
+Sync
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"BEGIN"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"1"}]}
+{"Type":"PortalSuspended"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+# Close the empty portal then try to execute it. 80 = 'P'
+send
+Close {"ObjectType": 80}
+Execute
+Sync
+----
+
+until
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ErrorResponse","Code":"0A000"}
+{"Type":"ReadyForQuery","TxStatus":"E"}
+
+send
+Query {"String": "ROLLBACK"}
+Query {"String": "SELECT 'here'"}
+----
+
+until ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"ROLLBACK"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"DataRow","Values":[{"text":"here"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -73,13 +73,13 @@ func MakeStmtBufReader(buf *StmtBuf) StmtBufReader {
 
 // CurCmd returns the current command in the buffer.
 func (r StmtBufReader) CurCmd() (Command, error) {
-	cmd, _ /* pos */, err := r.buf.curCmd()
+	cmd, _ /* pos */, err := r.buf.CurCmd()
 	return cmd, err
 }
 
 // AdvanceOne moves the cursor one position over.
 func (r *StmtBufReader) AdvanceOne() {
-	r.buf.advanceOne()
+	r.buf.AdvanceOne()
 }
 
 // SeekToNextBatch skips to the beginning of the next batch of commands.


### PR DESCRIPTION
Previously we supported row count limits as long as the limit was higher
than the number of returned rows. Here we add a feature that supports
this part of the spec in a partial way. This should unblock simple JDBC
usage of this feature.

Supported use cases:
- implicit transactions (which auto close the portal after suspension)
- explicit transactions executed to completion

Unsupported use cases (with explicit transactions):
- interleaved execution
- explicitly closing a portal after partial execution

Many options were evaluated during implementation. The one here is based
on work where the pgwire package itself takes over the state machine
processing during AddRow and looks for further ExecPortal messages. This
has a number of problems: there are now two state machines, we can only
support a part of the spec. However it also has a number of benefits
like it is a simple implementation that is easy to understand.

Two other solutions were evaluated.

First, teaching distsql how to pause and resume execution (a
proof-of-concept branch for this was produced). I did not pursue this
route because of my own unfamiliarity with distsql, and I thought that
attempting to reach a high level of confidence that all of the new pause,
resume, and error logic flows were correct would be very difficult
(I may be wrong about this). Also, this approach needed to address how
to handle post-distsql execution cleanup and stats gathering. That is,
after the call into distsql was paused and returned control back to
the sql executor, there's a lot of code that gets run to cleanup stuff
and report stats in various places, including some defers. These would
need to be audited and only execute once per statement, not once per
portal execution.

Second, start distsql execution in a new go routine and send exec portal
requests to it over a channel. This would avoid teaching distsql how
to pause and resume itself, but instead move that complexity into the
channel and go routine handling, another area ripe for race conditions
and deadlocks. This also needed to deal with the post-distsql execution
cleanup and defers handling discussed above.

For now, we decided that this limited implementation is good enough for
what we need today. In order to one day either support the full spec
or pay down some of our technical debt, we can probably do a number of
preliminary refactors that will make invoking much of the distsql path
multpile times easier.

pgx got a version bump to get support for PortalSuspended. The current
pgx version had a few new dependencies too.

See #4035

Release note (sql change): add partial support for row limits during
portal execution in pgwire.