### PR TITLE
sql: fix a bug with ordinality planning

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2739,11 +2739,11 @@ func (dsp *DistSQLPlanner) createPlanForOrdinality(
 	}
 
 	plan.PlanToStreamColMap = append(plan.PlanToStreamColMap, len(plan.ResultTypes))
-	plan.ResultTypes = append(plan.ResultTypes, *types.Int)
+	outputTypes := append(plan.ResultTypes, *types.Int)
 
 	// WITH ORDINALITY never gets distributed so that the gateway node can
 	// always number each row in order.
-	plan.AddSingleGroupStage(dsp.nodeDesc.NodeID, ordinalitySpec, distsqlpb.PostProcessSpec{}, plan.ResultTypes)
+	plan.AddSingleGroupStage(dsp.nodeDesc.NodeID, ordinalitySpec, distsqlpb.PostProcessSpec{}, outputTypes)
 
 	return plan, nil
 }

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -605,3 +605,17 @@ SELECT count(*), count(a), sum_int(a), min(a), max(a), sum(b), avg(b) FROM empty
 query IIIIIRR
 SELECT count(*), count(a), sum_int(a), min(a), max(a), sum(b), avg(b) FROM empty GROUP BY a
 ----
+
+
+statement ok
+CREATE TABLE t_38995 (a INT PRIMARY KEY)
+
+statement ok
+INSERT INTO t_38995 VALUES (1), (2), (3)
+
+query II
+SELECT a, ordinality*2 FROM t_38995 WITH ORDINALITY
+----
+1 2
+2 4
+3 6


### PR DESCRIPTION
Ordinality node appends an Int column so that it can write to it.
Previously, plan.ResultTypes were appended to before adding a
single group stage which internally used updated ResultTypes to
set up inputs to the ordinality processor. Now this behavior is
fixed and adding a single group stage takes care of updating
ResultTypes accordingly.

Fixes: #38995.

Release note: None