### PR TITLE
cli: add --nodes flag to cockroach demo

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -790,6 +790,11 @@ The line length where sqlfmt will try to wrap.`,
 		Description: `Align the output.`,
 	}
 
+	DemoNodes = FlagInfo{
+		Name:        "nodes",
+		Description: `How many in-memory nodes to create for the demo.`,
+	}
+
 	LogDir = FlagInfo{
 		Name: "log-dir",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -229,7 +229,7 @@ var sqlCtx = struct {
 	debugMode bool
 }{cliContext: &cliCtx}
 
-// dumpCtx captures the command-line parameters of the `sql` command.
+// dumpCtx captures the command-line parameters of the `dump` command.
 // Defaults set by InitCLIDefaults() above.
 var dumpCtx struct {
 	// dumpMode determines which part of the database should be dumped.
@@ -332,4 +332,10 @@ var sqlfmtCtx struct {
 	noSimplify bool
 	align      bool
 	execStmts  statementsValue
+}
+
+// demoCtx captures the command-line parameters of the `demo` command.
+// Defaults set by InitCLIDefaults() above.
+var demoCtx struct {
+	nodes int
 }

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logflags"
 	"github.com/cockroachdb/cockroach/pkg/workload"
@@ -61,12 +62,12 @@ func init() {
 				return runDemo(cmd, gen)
 			}),
 		}
-		genDemoCmd.Flags().AddFlagSet(genFlags)
 		demoCmd.AddCommand(genDemoCmd)
+		genDemoCmd.Flags().AddFlagSet(genFlags)
 	}
 }
 
-func setupTransientServer(
+func setupTransientServers(
 	cmd *cobra.Command, gen workload.Generator,
 ) (connURL string, adminURL string, cleanup func(), err error) {
 	cleanup = func() {}
@@ -95,27 +96,37 @@ func setupTransientServer(
 	// Set up the default zone configuration. We are using an in-memory store
 	// so we really want to disable replication.
 	cfg := config.DefaultZoneConfig()
-	cfg.NumReplicas = proto.Int32(1)
-
 	sysCfg := config.DefaultSystemZoneConfig()
-	sysCfg.NumReplicas = proto.Int32(1)
 
-	// Create the transient server.
+	if demoCtx.nodes < 3 {
+		cfg.NumReplicas = proto.Int32(1)
+		sysCfg.NumReplicas = proto.Int32(1)
+	}
+
+	// Create the first transient server. The others will join this one.
 	args := base.TestServerArgs{
-		Insecure: true,
+		PartOfCluster: true,
+		Insecure:      true,
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				DefaultZoneConfigOverride:       &cfg,
 				DefaultSystemZoneConfigOverride: &sysCfg,
 			},
 		},
+		Stopper: stopper,
 	}
-	server := server.TestServerFactory.New(args).(*server.TestServer)
-	if err := server.Start(args); err != nil {
+	serverFactory := server.TestServerFactory
+	s := serverFactory.New(args).(*server.TestServer)
+	if err := s.Start(args); err != nil {
 		return connURL, adminURL, cleanup, err
 	}
-	prevCleanup := cleanup
-	cleanup = func() { prevCleanup(); server.Stopper().Stop(ctx) }
+	args.JoinAddr = s.ServingAddr()
+	for i := 0; i < demoCtx.nodes-1; i++ {
+		s := serverFactory.New(args).(*server.TestServer)
+		if err := s.Start(args); err != nil {
+			return connURL, adminURL, cleanup, err
+		}
+	}
 
 	// Prepare the URL for use by the SQL shell.
 	options := url.Values{}
@@ -124,7 +135,7 @@ func setupTransientServer(
 	url := url.URL{
 		Scheme:   "postgres",
 		User:     url.User(security.RootUser),
-		Host:     server.ServingAddr(),
+		Host:     s.ServingAddr(),
 		RawQuery: options.Encode(),
 	}
 	if gen != nil {
@@ -152,11 +163,11 @@ func setupTransientServer(
 		}
 	}
 
-	return urlStr, server.AdminURL(), cleanup, nil
+	return urlStr, s.AdminURL(), cleanup, nil
 }
 
 func runDemo(cmd *cobra.Command, gen workload.Generator) error {
-	connURL, adminURL, cleanup, err := setupTransientServer(cmd, gen)
+	connURL, adminURL, cleanup, err := setupTransientServers(cmd, gen)
 	defer cleanup()
 	if err != nil {
 		return checkAndMaybeShout(err)
@@ -169,11 +180,11 @@ func runDemo(cmd *cobra.Command, gen workload.Generator) error {
 # Welcome to the CockroachDB demo database!
 #
 # You are connected to a temporary, in-memory CockroachDB
-# instance. Your changes will not be saved!
+# cluster of %d node%s. Your changes will not be saved!
 #
 # Web UI: %s
 #
-`, adminURL)
+`, demoCtx.nodes, util.Pluralize(int64(demoCtx.nodes)), adminURL)
 	}
 
 	checkTzDatabaseAvailability(context.Background())

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -515,6 +515,12 @@ func init() {
 		VarFlag(f, &cliCtx.tableDisplayFormat, cliflags.TableDisplayFormat)
 	}
 
+	// demo command.
+	demoFlags := demoCmd.PersistentFlags()
+	// We add this command as a persistent flag so you can do stuff like
+	// ./cockroach demo movr --nodes=3.
+	IntFlag(demoFlags, &demoCtx.nodes, cliflags.DemoNodes, 1)
+
 	// sqlfmt command.
 	fmtFlags := sqlfmtCmd.Flags()
 	VarFlag(fmtFlags, &sqlfmtCtx.execStmts, cliflags.Execute)


### PR DESCRIPTION
This flag permits the user to customize the number of in-memory nodes
spun up by the cockroach demo command. This makes the demo command much
more compelling for testing features that require distribution, such as
distsql, zone configurations, or partitioning.

Release note (cli change): the cockroach demo flag now accepts a --nodes
flag, which permits customization of the size of the demo cluster. The
default remains at 1.