### PR TITLE
exec: remove fallback logic and enhance SupportsVectorized check

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -139,7 +139,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 	if evalCtx.SessionData.Vectorize != sessiondata.VectorizeOff {
 		for _, spec := range flows {
 			if err := distsqlrun.SupportsVectorized(
-				ctx, &distsqlrun.FlowCtx{EvalCtx: &evalCtx.EvalContext, NodeID: -1}, spec,
+				ctx, &distsqlrun.FlowCtx{EvalCtx: &evalCtx.EvalContext, NodeID: -1}, spec.Processors,
 			); err != nil {
 				// Vectorization attempt failed with an error.
 				returnVectorizationSetupError := false

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -34,9 +34,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 )
 
 // To allow queries to send out flow RPCs in parallel, we use a pool of workers
@@ -215,28 +214,6 @@ func (dsp *DistSQLPlanner) setupFlows(
 		// into the local flow.
 	}
 	if firstErr != nil {
-		if _, ok := errors.If(firstErr, func(err error) (v interface{}, ok bool) {
-			v, ok = err.(*distsqlrun.VectorizedSetupError)
-			return v, ok
-		}); ok && evalCtx.SessionData.Vectorize == sessiondata.VectorizeOn {
-			// Error vectorizing remote flows, try again with off.
-			// Generate a new flow ID so that any remote nodes that successfully set
-			// up a vectorized flow will not be connected to by a non-vectorized flow.
-			newFlowID := uuid.MakeV4()
-			log.Infof(
-				ctx, "error vectorizing remote flow %s, restarting with vectorize=off and ID %s: %s", flows[thisNodeID].FlowID, newFlowID, firstErr,
-			)
-			for i := range flows {
-				flows[i].FlowID.UUID = newFlowID
-			}
-			evalCtx.SessionData.Vectorize = sessiondata.VectorizeOff
-			// Reset vectorize setting after returning.
-			defer func() { evalCtx.SessionData.Vectorize = sessiondata.VectorizeOn }()
-			// Recurse once with sessiondata.VectorizeOff, note that this branch will
-			// not be hit again due to the condition above that
-			// evalCtx.SessionData.Vectorize == sessiondata.VectorizeOn.
-			return dsp.setupFlows(ctx, evalCtx, txnCoordMeta, flows, recv, localState)
-		}
 		return nil, nil, firstErr
 	}
 

--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -1128,43 +1127,6 @@ func (f *Flow) setupVectorizedInputSynchronizer(
 		}
 	}
 	return op, metaSources, memUsed, nil
-}
-
-// VectorizedSetupError is a wrapper for any error that happens during
-// setupVectorized.
-type VectorizedSetupError struct {
-	cause error
-}
-
-var _ error = (*VectorizedSetupError)(nil)
-var _ fmt.Formatter = (*VectorizedSetupError)(nil)
-var _ errors.Formatter = (*VectorizedSetupError)(nil)
-
-// Error implemented the error interface.
-func (e *VectorizedSetupError) Error() string { return e.cause.Error() }
-
-// Cause implements the causer interface.
-func (e *VectorizedSetupError) Cause() error { return e.cause }
-
-// Format implements the fmt.Formatter interface.
-func (e *VectorizedSetupError) Format(s fmt.State, verb rune) { errors.FormatError(e, s, verb) }
-
-// FormatError implements the errors.Formatter interface.
-func (e *VectorizedSetupError) FormatError(p errors.Printer) error {
-	if p.Detail() {
-		p.Print("error while setting up columnar execution")
-	}
-	return e.cause
-}
-
-func decodeVectorizedSetupError(
-	_ context.Context, cause error, _ string, _ []string, _ protoutil.SimpleMessage,
-) error {
-	return &VectorizedSetupError{cause: cause}
-}
-
-func init() {
-	errors.RegisterWrapperDecoder(errors.GetTypeKey((*VectorizedSetupError)(nil)), decodeVectorizedSetupError)
 }
 
 func (f *Flow) setupVectorized(ctx context.Context, acc *mon.BoundAccount) error {

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -502,7 +502,7 @@ func (f *Flow) setup(ctx context.Context, spec *distsqlpb.FlowSpec) error {
 		log.VEventf(ctx, 1, "setting up vectorize flow %d with setting %s", f.id, f.EvalCtx.SessionData.Vectorize)
 		acc := f.EvalCtx.Mon.MakeBoundAccount()
 		f.vectorizedBoundAccount = &acc
-		err := f.setupVectorized(ctx, f.vectorizedBoundAccount)
+		err := f.setupVectorizedFlow(ctx, f.vectorizedBoundAccount)
 		if err == nil {
 			log.VEventf(ctx, 1, "vectorized flow setup succeeded")
 			return nil

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -499,52 +499,16 @@ func (f *Flow) setup(ctx context.Context, spec *distsqlpb.FlowSpec) error {
 	f.spec = spec
 
 	if f.EvalCtx.SessionData.Vectorize != sessiondata.VectorizeOff {
-		log.VEventf(ctx, 1, "attempting to vectorize flow %d with setting %s", f.id, f.EvalCtx.SessionData.Vectorize)
+		log.VEventf(ctx, 1, "setting up vectorize flow %d with setting %s", f.id, f.EvalCtx.SessionData.Vectorize)
 		acc := f.EvalCtx.Mon.MakeBoundAccount()
 		f.vectorizedBoundAccount = &acc
 		err := f.setupVectorized(ctx, f.vectorizedBoundAccount)
 		if err == nil {
-			log.VEventf(ctx, 1, "vectorized flow.")
+			log.VEventf(ctx, 1, "vectorized flow setup succeeded")
 			return nil
 		}
-		// Vectorization attempt failed with an error.
-		if f.spec.Gateway != f.NodeID {
-			// If we are not the gateway node, do not attempt to plan this with the
-			// row execution branch since there is no way to tell whether vectorized
-			// planning will succeed on any other node. Notify the gateway by
-			// returning an error.
-			log.VEventf(
-				ctx,
-				1,
-				"flow vectorization failed on remote node, returning error to gateway for possible replanning: %s", err,
-			)
-			return &VectorizedSetupError{cause: err}
-		}
-		// Reset state to be used by the row execution branch.
-		f.processors = nil
-		f.inboundStreams = nil
-		f.startables = nil
-
-		if f.EvalCtx.SessionData.Vectorize == sessiondata.VectorizeAlways {
-			// Only return the error if we are running a local planNode that is an
-			// exception to the rule that failures to set up a vectorized flow when
-			// experimental_vectorize=always should return an error.
-			var isException bool
-			if len(spec.Processors) == 1 &&
-				spec.Processors[0].Core.LocalPlanNode != nil {
-				rsidx := spec.Processors[0].Core.LocalPlanNode.RowSourceIdx
-				if rsidx != nil {
-					lp := f.localProcessors[*rsidx]
-					if z, ok := lp.(VectorizeAlwaysException); ok {
-						isException = z.IsException()
-					}
-				}
-			}
-			if !isException {
-				return err
-			}
-		}
 		log.VEventf(ctx, 1, "failed to vectorize: %s", err)
+		return err
 	}
 
 	// First step: setup the input synchronizers for all processors.

--- a/pkg/sql/distsqlrun/vectorized_meta_propagation_test.go
+++ b/pkg/sql/distsqlrun/vectorized_meta_propagation_test.go
@@ -28,7 +28,7 @@ import (
 // RowSource -> metadataTestSender -> columnarizer -> noopOperator ->
 // -> materializer -> metadataTestReceiver. Metadata propagation is hooked up
 // manually from the columnarizer into the materializer similar to how it is
-// done in setupVectorized.
+// done in setupVectorizedFlow.
 func TestVectorizedMetaPropagation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()

--- a/pkg/sql/logictest/testdata/logic_test/dist_vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/dist_vectorize
@@ -1,10 +1,4 @@
-# LogicTest: 5node-dist
-
-# Temporary until #38458 is fixed. This test fails under stress with the
-# 5node-dist-vec config, but not with the 5node-dist config and then setting
-# experimental_vectorize=on, which should be equivalent.
-statement ok
-SET experimental_vectorize=on;
+# LogicTest: 5node-dist-vec
 
 statement ok
 CREATE TABLE kv (k INT PRIMARY KEY, v INT)
@@ -79,10 +73,10 @@ SELECT kv.k FROM kv JOIN kw ON kv.k = kw.k
 4
 5
 
-# Regression test for #38919.
 statement ok
-SET experimental_vectorize = on
+RESET experimental_vectorize
 
+# Regression test for #38919.
 statement ok
 SET optimizer = on
 
@@ -93,6 +87,3 @@ true
 
 statement ok
 RESET optimizer
-
-statement ok
-RESET experimental_vectorize

--- a/pkg/sql/logictest/testdata/logic_test/dist_vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/dist_vectorize
@@ -26,10 +26,9 @@ statement ok
 ALTER TABLE kw EXPERIMENTAL_RELOCATE SELECT ARRAY[i], i FROM generate_series(1, 5) as g(i)
 
 # Verify data placement.
-query TTTI colnames
+query TTTI rowsort
 SELECT start_key, end_key, replicas, lease_holder from [SHOW EXPERIMENTAL_RANGES FROM TABLE kv]
 ----
-start_key  end_key  replicas  lease_holder
 NULL       /1       {1}       1
 /1         /2       {1}       1
 /2         /3       {2}       2
@@ -38,10 +37,9 @@ NULL       /1       {1}       1
 /5         NULL     {5}       5
 
 # Verify data placement.
-query TTTI colnames
+query TTTI rowsort
 SELECT start_key, end_key, replicas, lease_holder from [SHOW EXPERIMENTAL_RANGES FROM TABLE kw]
 ----
-start_key  end_key  replicas  lease_holder
 NULL       /1       {5}       5
 /1         /2       {1}       1
 /2         /3       {2}       2


### PR DESCRIPTION
First commit removes fallback logic from vectorized to DistSQL.

The fallback logic has been very fragile and causes some hard to
debug and understand issues. This commit removes it entirely so
that if the vectorized flow encounters a runtime execution error,
the error is returned to the client.

Second commit refactors vectorized flow setup

Setup of the vectorized flow has been refactored to decouple
planning and running steps. This allows us to have a noop
runner to check whether the flow is supported through the
vectorized engine which enhances SupportsVectorized check.

Addresses: #38919.
Fixes: #38458.
Fixes: #38651.