### PR TITLE
opt: add catalog test with FKs

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/catalog
+++ b/pkg/sql/opt/exec/execbuilder/testdata/catalog
@@ -80,3 +80,48 @@ TABLE uvwxy
       ├── u int not null
       └── v int not null
 scan uvwxy
+
+# Test foreign keys.
+statement ok
+CREATE TABLE parent (p INT, q INT, r INT, other INT, PRIMARY KEY (p, q, r))
+
+statement ok
+CREATE TABLE child  (
+  c INT PRIMARY KEY,
+  p INT, q INT, r INT,
+  CONSTRAINT fk FOREIGN KEY (p,q,r) REFERENCES parent(p,q,r) MATCH FULL
+)
+
+query T
+EXPLAIN (OPT, CATALOG) SELECT * from child
+----
+TABLE child
+ ├── c int not null
+ ├── p int
+ ├── q int
+ ├── r int
+ ├── INDEX primary
+ │    └── c int not null
+ ├── INDEX child_auto_index_fk
+ │    ├── p int
+ │    ├── q int
+ │    ├── r int
+ │    └── c int not null
+ └── CONSTRAINT fk FOREIGN KEY test.public.child (p, q, r) REFERENCES test.public.parent (p, q, r) MATCH FULL
+scan child
+
+# TODO(lucy/jordan/radu): the inbound foreign key reference is borked.
+query T
+EXPLAIN (OPT, CATALOG) SELECT * from parent
+----
+TABLE parent
+ ├── p int not null
+ ├── q int not null
+ ├── r int not null
+ ├── other int
+ ├── INDEX primary
+ │    ├── p int not null
+ │    ├── q int not null
+ │    └── r int not null
+ └── REFERENCED BY CONSTRAINT  FOREIGN KEY test.public.child () REFERENCES test.public.parent ()
+scan parent


### PR DESCRIPTION
Add `EXPLAIN (OPT, CATALOG)` tests with foreign keys, which show the
current problem with inbound references.

Release note: None