### PR TITLE
opt: remove fully qualified names from catalog

### DIFF
--- a/pkg/sql/delegate/show_ranges.go
+++ b/pkg/sql/delegate/show_ranges.go
@@ -26,7 +26,7 @@ import (
 // These statements show the ranges corresponding to the given table or index,
 // along with the list of replicas and the lease holder.
 func (d *delegator) delegateShowRanges(n *tree.ShowRanges) (tree.Statement, error) {
-	idx, err := cat.ResolveTableIndex(
+	idx, _, err := cat.ResolveTableIndex(
 		d.ctx, d.catalog, cat.Flags{AvoidDescriptorCaches: true}, &n.TableOrIndex,
 	)
 	if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/prepare_opt_plan
+++ b/pkg/sql/logictest/testdata/logic_test/prepare_opt_plan
@@ -90,7 +90,7 @@ select
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── prune: (2)
- ├── scan test.public.t
+ ├── scan t
  │    ├── columns: k:1 str:2
  │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0]
  │    ├── cost: 1040.02

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -124,4 +124,12 @@ type Catalog interface {
 	// RequireSuperUser checks that the current user has admin privileges. If not,
 	// returns an error.
 	RequireSuperUser(ctx context.Context, action string) error
+
+	// FullyQualifiedName retrieves the fully qualified name of a data source.
+	// Note that:
+	//  - this call may involve a database operation so it shouldn't be used in
+	//    performance sensitive paths;
+	//  - the fully qualified name of a data source object can change without the
+	//    object itself changing (e.g. when a database is renamed).
+	FullyQualifiedName(ctx context.Context, ds DataSource) (DataSourceName, error)
 }

--- a/pkg/sql/opt/cat/data_source.go
+++ b/pkg/sql/opt/cat/data_source.go
@@ -21,9 +21,6 @@ type DataSourceName = tree.TableName
 type DataSource interface {
 	Object
 
-	// Name returns the fully normalized, fully qualified, and fully resolved
-	// name of the data source (<db-name>.<schema-name>.<data-source-name>). The
-	// ExplicitCatalog and ExplicitSchema fields will always be true, since all
-	// parts of the name are always specified.
-	Name() *DataSourceName
+	// Name returns the unqualified name of the object.
+	Name() tree.Name
 }

--- a/pkg/sql/opt/cat/sequence.go
+++ b/pkg/sql/opt/cat/sequence.go
@@ -10,20 +10,15 @@
 
 package cat
 
-import (
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
-)
+import "github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 
 // Sequence is an interface to a database sequence.
 type Sequence interface {
 	DataSource
 
-	// SequenceName returns the name of the sequence. This method should always
-	// return the same value as DataSource.Name(), but is included here as a
-	// safety measure so that every DataSource does not trivially implement
-	// Sequence.
-	SequenceName() *tree.TableName
+	// SequenceMarker is a dummy method, included as a safety measure so that
+	// every DataSource does not trivially implement Sequence.
+	SequenceMarker()
 }
 
 // FormatSequence nicely formats a catalog sequence using a treeprinter for

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -134,7 +134,7 @@ func FindTableColumnByName(tab Table, name tree.Name) int {
 // FormatTable nicely formats a catalog table using a treeprinter for debugging
 // and testing.
 func FormatTable(cat Catalog, tab Table, tp treeprinter.Node) {
-	child := tp.Childf("TABLE %s", tab.Name().TableName)
+	child := tp.Childf("TABLE %s", tab.Name())
 	if tab.IsVirtualTable() {
 		child.Child("virtual table")
 	}

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -52,28 +52,28 @@ func ExpandDataSourceGlob(
 // ResolveTableIndex resolves a TableIndexName.
 func ResolveTableIndex(
 	ctx context.Context, catalog Catalog, flags Flags, name *tree.TableIndexName,
-) (Index, error) {
+) (Index, DataSourceName, error) {
 	if name.Table.TableName != "" {
-		ds, _, err := catalog.ResolveDataSource(ctx, flags, &name.Table)
+		ds, tn, err := catalog.ResolveDataSource(ctx, flags, &name.Table)
 		if err != nil {
-			return nil, err
+			return nil, DataSourceName{}, err
 		}
 		table, ok := ds.(Table)
 		if !ok {
-			return nil, pgerror.Newf(
+			return nil, DataSourceName{}, pgerror.Newf(
 				pgcode.WrongObjectType, "%q is not a table", name.Table.TableName,
 			)
 		}
 		if name.Index == "" {
 			// Return primary index.
-			return table.Index(0), nil
+			return table.Index(0), tn, nil
 		}
 		for i := 0; i < table.IndexCount(); i++ {
 			if idx := table.Index(i); idx.Name() == tree.Name(name.Index) {
-				return idx, nil
+				return idx, tn, nil
 			}
 		}
-		return nil, pgerror.Newf(
+		return nil, DataSourceName{}, pgerror.Newf(
 			pgcode.UndefinedObject, "index %q does not exist", name.Index,
 		)
 	}
@@ -81,17 +81,18 @@ func ResolveTableIndex(
 	// We have to search for a table that has an index with the given name.
 	schema, _, err := catalog.ResolveSchema(ctx, flags, &name.Table.TableNamePrefix)
 	if err != nil {
-		return nil, err
+		return nil, DataSourceName{}, err
 	}
 	dsNames, err := schema.GetDataSourceNames(ctx)
 	if err != nil {
-		return nil, err
+		return nil, DataSourceName{}, err
 	}
 	var found Index
+	var foundTabName DataSourceName
 	for i := range dsNames {
-		ds, _, err := catalog.ResolveDataSource(ctx, flags, &dsNames[i])
+		ds, tn, err := catalog.ResolveDataSource(ctx, flags, &dsNames[i])
 		if err != nil {
-			return nil, err
+			return nil, DataSourceName{}, err
 		}
 		table, ok := ds.(Table)
 		if !ok {
@@ -101,21 +102,22 @@ func ResolveTableIndex(
 		for i := 0; i < table.IndexCount(); i++ {
 			if idx := table.Index(i); idx.Name() == tree.Name(name.Index) {
 				if found != nil {
-					return nil, pgerror.Newf(pgcode.AmbiguousParameter,
+					return nil, DataSourceName{}, pgerror.Newf(pgcode.AmbiguousParameter,
 						"index name %q is ambiguous (found in %s and %s)",
-						name.Index, table.Name().String(), found.Table().Name().String())
+						name.Index, tn.String(), foundTabName.String())
 				}
 				found = idx
+				foundTabName = tn
 				break
 			}
 		}
 	}
 	if found == nil {
-		return nil, pgerror.Newf(
+		return nil, DataSourceName{}, pgerror.Newf(
 			pgcode.UndefinedObject, "index %q does not exist", name.Index,
 		)
 	}
-	return found, nil
+	return found, foundTabName, nil
 }
 
 // FindTableColumnByName returns the ordinal of the non-mutation column having
@@ -240,13 +242,13 @@ func formatCols(tab Table, numCols int, colOrdinal func(tab Table, i int) int) s
 // formatCatalogFKRef nicely formats a catalog foreign key reference using a
 // treeprinter for debugging and testing.
 func formatCatalogFKRef(
-	cat Catalog, inbound bool, fkRef ForeignKeyConstraint, tp treeprinter.Node,
+	catalog Catalog, inbound bool, fkRef ForeignKeyConstraint, tp treeprinter.Node,
 ) {
-	originDS, err := cat.ResolveDataSourceByID(context.TODO(), fkRef.OriginTableID())
+	originDS, err := catalog.ResolveDataSourceByID(context.TODO(), fkRef.OriginTableID())
 	if err != nil {
 		panic(err)
 	}
-	refDS, err := cat.ResolveDataSourceByID(context.TODO(), fkRef.ReferencedTableID())
+	refDS, err := catalog.ResolveDataSourceByID(context.TODO(), fkRef.ReferencedTableID())
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/sql/opt/cat/utils_test.go
+++ b/pkg/sql/opt/cat/utils_test.go
@@ -177,11 +177,11 @@ func TestResolveTableIndex(t *testing.T) {
 
 	for _, tc := range testCases {
 		var res string
-		idx, err := cat.ResolveTableIndex(ctx, testcat, cat.Flags{}, &tc.name)
+		idx, tn, err := cat.ResolveTableIndex(ctx, testcat, cat.Flags{}, &tc.name)
 		if err != nil {
 			res = fmt.Sprintf("error: %v", err)
 		} else {
-			res = fmt.Sprintf("%s@%s", idx.Table().Name().FQString(), idx.Name())
+			res = fmt.Sprintf("%s@%s", tn.FQString(), idx.Name())
 		}
 		if res != tc.expected {
 			t.Errorf("pattern: %v  expected: %s  got: %s", tc.name.String(), tc.expected, res)

--- a/pkg/sql/opt/cat/view.go
+++ b/pkg/sql/opt/cat/view.go
@@ -51,7 +51,7 @@ func FormatView(view View, tp treeprinter.Node) {
 		buf.WriteString(")")
 	}
 
-	child := tp.Childf("VIEW %s%s", view.Name().TableName, buf.String())
+	child := tp.Childf("VIEW %s%s", view.Name(), buf.String())
 
 	child.Child(view.Query())
 }

--- a/pkg/sql/opt/exec/execbuilder/format.go
+++ b/pkg/sql/opt/exec/execbuilder/format.go
@@ -60,7 +60,7 @@ func fmtInterceptor(f *memo.ExprFmtCtx, tp treeprinter.Node, nd opt.Expr) bool {
 	fmtCtx := tree.NewFmtCtx(tree.FmtSimple)
 	fmtCtx.SetIndexedVarFormat(func(ctx *tree.FmtCtx, idx int) {
 		fullyQualify := !f.HasFlags(memo.ExprFmtHideQualifications)
-		alias := md.QualifiedAlias(opt.ColumnID(idx+1), fullyQualify)
+		alias := md.QualifiedAlias(opt.ColumnID(idx+1), fullyQualify, f.Catalog)
 		ctx.WriteString(alias)
 	})
 	expr.Format(fmtCtx)

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -76,7 +76,7 @@ func (b *Builder) buildExplain(explain *memo.ExplainExpr) (execPlan, error) {
 			// TODO(radu): add views, sequences
 		}
 
-		f := memo.MakeExprFmtCtx(fmtFlags, b.mem)
+		f := memo.MakeExprFmtCtx(fmtFlags, b.mem, b.catalog)
 		f.FormatExpr(explain.Input)
 		planText.WriteString(f.Buffer.String())
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/catalog
+++ b/pkg/sql/opt/exec/execbuilder/testdata/catalog
@@ -107,7 +107,7 @@ TABLE child
  │    ├── q int
  │    ├── r int
  │    └── c int not null
- └── CONSTRAINT fk FOREIGN KEY test.public.child (p, q, r) REFERENCES test.public.parent (p, q, r) MATCH FULL
+ └── CONSTRAINT fk FOREIGN KEY child (p, q, r) REFERENCES parent (p, q, r) MATCH FULL
 scan child
 
 # TODO(lucy/jordan/radu): the inbound foreign key reference is borked.
@@ -123,5 +123,5 @@ TABLE parent
  │    ├── p int not null
  │    ├── q int not null
  │    └── r int not null
- └── REFERENCED BY CONSTRAINT  FOREIGN KEY test.public.child () REFERENCES test.public.parent ()
+ └── REFERENCED BY CONSTRAINT  FOREIGN KEY child () REFERENCES parent ()
 scan parent

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_env
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_env
@@ -100,7 +100,7 @@ CREATE SEQUENCE seq
 query T
 EXPLAIN (OPT, ENV) SELECT * FROM seq
 ----
-https://cockroachdb.github.io/text/decode.html#eJwkjkFPgzAcR-_9FL-jGrsMcHa6U61_ExLazdKRXV39JxLJEArGj2-U2zu85L2Gx9T2l0eYPn6O_Vv8eH4C_3A8z233ziMmThO-F0sI40kHQk2vR3KGkHiALV2jqyMhg9WnBR_yvChUvi7ut5s7pTbbtULpjCdLLiBDHbQPyHZC0OlQ6dLhan8ItyDXXKOmikzADV783v4ldkJKKUXiYeZLZJm44zj9r62-5nPXxlXiQfwGAAD__6j-PBk=
+https://cockroachdb.github.io/text/decode.html#eJwkjcFKxDAYBu95iu-oYmDbumZ1TzH-QqHJrmm27FXjDxZLS5tWfHwpvQ3MwDQ8pXbon2GG-DMNH_H79QX8x_FzabsvnjBzmvG7VUIYTzoQanq_kDOExCNs6RpdXQgZrL5u-JTnRaHyXfF42D8otT_sFEpnPFlyARnqoH1AdhSCrudKlw43p3O4B7nmFjVVZALu8OZPdl0chZRSisTjwn1kmbjjOK9G_AcAAP__7QE3fg==
 
 #
 # Test views.

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -12,6 +12,7 @@ package memo
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"unicode"
 
@@ -88,12 +89,12 @@ func (f ExprFmtFlags) HasFlags(subset ExprFmtFlags) bool {
 
 // FormatExpr returns a string representation of the given expression, formatted
 // according to the specified flags.
-func FormatExpr(e opt.Expr, flags ExprFmtFlags) string {
+func FormatExpr(e opt.Expr, flags ExprFmtFlags, catalog cat.Catalog) string {
 	var mem *Memo
 	if nd, ok := e.(RelExpr); ok {
 		mem = nd.Memo()
 	}
-	f := MakeExprFmtCtx(flags, mem)
+	f := MakeExprFmtCtx(flags, mem, catalog)
 	f.FormatExpr(e)
 	return f.Buffer.String()
 }
@@ -110,6 +111,9 @@ type ExprFmtCtx struct {
 	// Memo must contain any expression that is formatted.
 	Memo *Memo
 
+	// Catalog must be set unless the ExprFmtHideQualifications flag is set.
+	Catalog cat.Catalog
+
 	// nameGen is used to generate a unique name for each relational
 	// subexpression when Memo.saveTablesPrefix is non-empty. These names
 	// correspond to the tables that would be saved if the query were run
@@ -118,18 +122,20 @@ type ExprFmtCtx struct {
 }
 
 // MakeExprFmtCtx creates an expression formatting context from a new buffer.
-func MakeExprFmtCtx(flags ExprFmtFlags, mem *Memo) ExprFmtCtx {
-	return MakeExprFmtCtxBuffer(&bytes.Buffer{}, flags, mem)
+func MakeExprFmtCtx(flags ExprFmtFlags, mem *Memo, catalog cat.Catalog) ExprFmtCtx {
+	return MakeExprFmtCtxBuffer(&bytes.Buffer{}, flags, mem, catalog)
 }
 
 // MakeExprFmtCtxBuffer creates an expression formatting context from an
 // existing buffer.
-func MakeExprFmtCtxBuffer(buf *bytes.Buffer, flags ExprFmtFlags, mem *Memo) ExprFmtCtx {
+func MakeExprFmtCtxBuffer(
+	buf *bytes.Buffer, flags ExprFmtFlags, mem *Memo, catalog cat.Catalog,
+) ExprFmtCtx {
 	var nameGen *ExprNameGenerator
 	if mem != nil && mem.saveTablesPrefix != "" {
 		nameGen = NewExprNameGenerator(mem.saveTablesPrefix)
 	}
-	return ExprFmtCtx{Buffer: buf, Flags: flags, Memo: mem, nameGen: nameGen}
+	return ExprFmtCtx{Buffer: buf, Flags: flags, Memo: mem, Catalog: catalog, nameGen: nameGen}
 }
 
 // HasFlags tests whether the given flags are all set.
@@ -866,7 +872,7 @@ func formatCol(
 	colMeta := md.ColumnMeta(id)
 	if label == "" {
 		fullyQualify := !f.HasFlags(ExprFmtHideQualifications)
-		label = md.QualifiedAlias(id, fullyQualify)
+		label = md.QualifiedAlias(id, fullyQualify, f.Catalog)
 	}
 
 	if !isSimpleColumnName(label) {
@@ -915,7 +921,7 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 	switch t := private.(type) {
 	case *opt.ColumnID:
 		fullyQualify := !f.HasFlags(ExprFmtHideQualifications)
-		label := f.Memo.metadata.QualifiedAlias(*t, fullyQualify)
+		label := f.Memo.metadata.QualifiedAlias(*t, fullyQualify, f.Catalog)
 		fmt.Fprintf(f.Buffer, " %s", label)
 
 	case *TupleOrdinal:
@@ -934,9 +940,7 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 		}
 
 	case *VirtualScanPrivate:
-		// Always fully qualify virtual table names.
-		tabMeta := f.Memo.metadata.TableMeta(t.Table)
-		fmt.Fprintf(f.Buffer, " %s", tabMeta.Table.Name())
+		fmt.Fprintf(f.Buffer, " %s", tableAlias(f, t.Table))
 
 	case *SequenceSelectPrivate:
 		seq := f.Memo.metadata.Sequence(t.Sequence)
@@ -958,14 +962,14 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 
 	case *IndexJoinPrivate:
 		tab := f.Memo.metadata.Table(t.Table)
-		fmt.Fprintf(f.Buffer, " %s", tab.Name().TableName)
+		fmt.Fprintf(f.Buffer, " %s", tab.Name())
 
 	case *LookupJoinPrivate:
 		tab := f.Memo.metadata.Table(t.Table)
 		if t.Index == cat.PrimaryIndex {
-			fmt.Fprintf(f.Buffer, " %s", tab.Name().TableName)
+			fmt.Fprintf(f.Buffer, " %s", tab.Name())
 		} else {
-			fmt.Fprintf(f.Buffer, " %s@%s", tab.Name().TableName, tab.Index(t.Index).Name())
+			fmt.Fprintf(f.Buffer, " %s@%s", tab.Name(), tab.Index(t.Index).Name())
 		}
 
 	case *ValuesPrivate:
@@ -974,11 +978,11 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 	case *ZigzagJoinPrivate:
 		leftTab := f.Memo.metadata.Table(t.LeftTable)
 		rightTab := f.Memo.metadata.Table(t.RightTable)
-		fmt.Fprintf(f.Buffer, " %s", leftTab.Name().TableName)
+		fmt.Fprintf(f.Buffer, " %s", leftTab.Name())
 		if t.LeftIndex != cat.PrimaryIndex {
 			fmt.Fprintf(f.Buffer, "@%s", leftTab.Index(t.LeftIndex).Name())
 		}
-		fmt.Fprintf(f.Buffer, " %s", rightTab.Name().TableName)
+		fmt.Fprintf(f.Buffer, " %s", rightTab.Name())
 		if t.RightIndex != cat.PrimaryIndex {
 			fmt.Fprintf(f.Buffer, "@%s", rightTab.Index(t.RightIndex).Name())
 		}
@@ -1057,7 +1061,11 @@ func tableAlias(f *ExprFmtCtx, tabID opt.TableID) string {
 	if f.HasFlags(ExprFmtHideQualifications) {
 		return tabMeta.Alias.String()
 	}
-	return tabMeta.Table.Name().FQString()
+	tn, err := f.Catalog.FullyQualifiedName(context.TODO(), tabMeta.Table)
+	if err != nil {
+		panic(err)
+	}
+	return tn.FQString()
 }
 
 // isSimpleColumnName returns true if the given label consists of only ASCII

--- a/pkg/sql/opt/memo/statistics_builder_test.go
+++ b/pkg/sql/opt/memo/statistics_builder_test.go
@@ -88,8 +88,9 @@ func TestGetStatsFromConstraint(t *testing.T) {
 
 	var mem Memo
 	mem.Init(&evalCtx)
-	tab := catalog.Table(tree.NewUnqualifiedTableName("sel"))
-	tabID := mem.Metadata().AddTable(tab)
+	tn := tree.NewUnqualifiedTableName("sel")
+	tab := catalog.Table(tn)
+	tabID := mem.Metadata().AddTable(tab, tn)
 
 	// Test that applyConstraintSet correctly updates the statistics from
 	// constraint set cs, and selectivity is calculated correctly.

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -1383,7 +1383,7 @@ inner-join (merge)
  ├── right ordering: +5
  ├── key: (7)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6), (1)==(5), (5)==(1)
- ├── scan t.public.xysd
+ ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
@@ -1395,7 +1395,7 @@ inner-join (merge)
  │    ├── key: (7)
  │    ├── fd: (7)-->(5,6)
  │    ├── ordering: +5
- │    └── scan t.public.uv
+ │    └── scan uv
  │         ├── columns: u:5(int) v:6(int!null) rowid:7(int!null)
  │         ├── key: (7)
  │         └── fd: (7)-->(5,6)
@@ -1422,7 +1422,7 @@ left-join (merge)
  ├── right ordering: +5
  ├── key: (1,7)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)
- ├── scan t.public.xysd
+ ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
@@ -1434,7 +1434,7 @@ left-join (merge)
  │    ├── key: (7)
  │    ├── fd: (7)-->(5,6)
  │    ├── ordering: +5
- │    └── scan t.public.uv
+ │    └── scan uv
  │         ├── columns: u:5(int) v:6(int!null) rowid:7(int!null)
  │         ├── key: (7)
  │         └── fd: (7)-->(5,6)
@@ -1461,7 +1461,7 @@ right-join (merge)
  ├── right ordering: +5
  ├── key: (1,7)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)
- ├── scan t.public.xysd
+ ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
@@ -1473,7 +1473,7 @@ right-join (merge)
  │    ├── key: (7)
  │    ├── fd: (7)-->(5,6)
  │    ├── ordering: +5
- │    └── scan t.public.uv
+ │    └── scan uv
  │         ├── columns: u:5(int) v:6(int!null) rowid:7(int!null)
  │         ├── key: (7)
  │         └── fd: (7)-->(5,6)

--- a/pkg/sql/opt/memo/testdata/logprops/select
+++ b/pkg/sql/opt/memo/testdata/logprops/select
@@ -346,7 +346,7 @@ CREATE SEQUENCE x
 build
 SELECT * FROM x
 ----
-sequence-select t.public.x
+sequence-select x
  ├── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
  ├── cardinality: [1 - 1]
  ├── key: ()

--- a/pkg/sql/opt/memo/testdata/logprops/virtual-scan
+++ b/pkg/sql/opt/memo/testdata/logprops/virtual-scan
@@ -14,13 +14,13 @@ project
       ├── select
       │    ├── columns: catalog_name:1(string) schema_name:2(string!null) default_character_set_name:3(string) sql_path:4(string)
       │    ├── fd: ()-->(2)
-      │    ├── virtual-scan t.information_schema.schemata
+      │    ├── virtual-scan information_schema.schemata
       │    │    └── columns: catalog_name:1(string) schema_name:2(string) default_character_set_name:3(string) sql_path:4(string)
       │    └── filters
       │         └── eq [type=bool, outer=(2), constraints=(/2: [/'public' - /'public']; tight), fd=()-->(2)]
       │              ├── variable: schema_name [type=string]
       │              └── const: 'public' [type=string]
-      ├── virtual-scan t.information_schema.tables
+      ├── virtual-scan information_schema.tables
       │    └── columns: table_catalog:5(string) table_schema:6(string) table_name:7(string) table_type:8(string) is_insertable_into:9(string) version:10(int)
       └── filters
            └── and [type=bool, outer=(1,2,5,6), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /5: (/NULL - ]; /6: (/NULL - ])]

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -853,7 +853,7 @@ inner-join (merge)
  ├── stats: [rows=10000, distinct(1)=500, null(1)=0, distinct(2)=400, null(2)=5000, distinct(3)=500, null(3)=100, distinct(4)=499.999999, null(4)=0, distinct(5)=500, null(5)=0, distinct(6)=100, null(6)=0, distinct(7)=6321.5735, null(7)=0, distinct(2,3)=5000, null(2,3)=5050, distinct(3,5)=10000, null(3,5)=5050, distinct(1,2,7)=10000, null(1,2,7)=5000]
  ├── key: (7)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6), (1)==(5), (5)==(1)
- ├── scan t.public.xysd
+ ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
  │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(4)=500, null(4)=0, distinct(1,2)=2501, null(1,2)=2500, distinct(2,3)=5000, null(2,3)=2525]
  │    ├── key: (1)
@@ -865,7 +865,7 @@ inner-join (merge)
  │    ├── key: (7)
  │    ├── fd: (7)-->(5,6)
  │    ├── ordering: +5
- │    └── scan t.public.uv
+ │    └── scan uv
  │         ├── columns: u:5(int) v:6(int!null) rowid:7(int!null)
  │         ├── stats: [rows=10000, distinct(5)=500, null(5)=5000, distinct(6)=100, null(6)=0, distinct(7)=10000, null(7)=0]
  │         ├── key: (7)
@@ -894,7 +894,7 @@ left-join (merge)
  ├── stats: [rows=5000, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(5)=500, null(5)=1666.66667, distinct(6)=100, null(6)=1666.66667, distinct(2,3)=5000, null(2,3)=2525, distinct(3,5)=5000, null(3,5)=2525, distinct(1,2,7)=5000, null(1,2,7)=2500]
  ├── key: (1,7)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)
- ├── scan t.public.xysd
+ ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
  │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(4)=500, null(4)=0, distinct(1,2)=2501, null(1,2)=2500, distinct(2,3)=5000, null(2,3)=2525]
  │    ├── key: (1)
@@ -906,7 +906,7 @@ left-join (merge)
  │    ├── key: (7)
  │    ├── fd: (7)-->(5,6)
  │    ├── ordering: +5
- │    └── scan t.public.uv
+ │    └── scan uv
  │         ├── columns: u:5(int) v:6(int!null) rowid:7(int!null)
  │         ├── stats: [rows=10000, distinct(5)=500, null(5)=5000, distinct(6)=100, null(6)=0, distinct(7)=10000, null(7)=0]
  │         ├── key: (7)

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -445,7 +445,7 @@ CREATE SEQUENCE seq
 opt
 SELECT * FROM seq
 ----
-sequence-select t.public.seq
+sequence-select seq
  ├── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -352,7 +352,7 @@ func (md *Metadata) ColumnMeta(colID ColumnID) *ColumnMeta {
 //      a different table name, then prefix the column alias with the table
 //      name: "tabName.columnAlias".
 //
-func (md *Metadata) QualifiedAlias(colID ColumnID, fullyQualify bool) string {
+func (md *Metadata) QualifiedAlias(colID ColumnID, fullyQualify bool, catalog cat.Catalog) string {
 	cm := md.ColumnMeta(colID)
 	if cm.Table == 0 {
 		// Column doesn't belong to a table, so no need to qualify it further.
@@ -393,8 +393,11 @@ func (md *Metadata) QualifiedAlias(colID ColumnID, fullyQualify bool) string {
 
 	var sb strings.Builder
 	if fullyQualify {
-		s := md.TableMeta(cm.Table).Table.Name().FQString()
-		sb.WriteString(s)
+		tn, err := catalog.FullyQualifiedName(context.TODO(), md.TableMeta(cm.Table).Table)
+		if err != nil {
+			panic(err)
+		}
+		sb.WriteString(tn.FQString())
 	} else {
 		sb.WriteString(tabAlias.String())
 	}

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -260,19 +260,15 @@ func (md *Metadata) Schema(schID SchemaID) cat.Schema {
 	return md.schemas[schID-1]
 }
 
-// AddTable is a helper that calls AddTableWithAlias with tab.Name() as the
-// table's alias.
-func (md *Metadata) AddTable(tab cat.Table) TableID {
-	return md.AddTableWithAlias(tab, tab.Name())
-}
-
-// AddTableWithAlias indexes a new reference to a table within the query.
-// Separate references to the same table are assigned different table ids (e.g.
-// in a self-join query). All columns are added to the metadata. If mutation
-// columns are present, they are added after active columns. The table's alias
-// is passed separately so that its original formatting is preserved for error
-// messages, pretty-printing, etc.
-func (md *Metadata) AddTableWithAlias(tab cat.Table, alias *tree.TableName) TableID {
+// AddTable indexes a new reference to a table within the query. Separate
+// references to the same table are assigned different table ids (e.g.  in a
+// self-join query). All columns are added to the metadata. If mutation columns
+// are present, they are added after active columns.
+//
+// The ExplicitCatalog/ExplicitSchema fields of the table's alias are honored so
+// that its original formatting is preserved for error messages,
+// pretty-printing, etc.
+func (md *Metadata) AddTable(tab cat.Table, alias *tree.TableName) TableID {
 	tabID := makeTableID(len(md.tables), ColumnID(len(md.cols)+1))
 	if md.tables == nil {
 		md.tables = make([]TableMeta, 0, 4)

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -26,7 +26,7 @@ func TestMetadata(t *testing.T) {
 	var md opt.Metadata
 	schID := md.AddSchema(&testcat.Schema{})
 	colID := md.AddColumn("col", types.Int)
-	tabID := md.AddTable(&testcat.Table{})
+	tabID := md.AddTable(&testcat.Table{}, &tree.TableName{})
 
 	// Call Init and add objects from catalog, verifying that IDs have been reset.
 	testCat := testcat.New()
@@ -40,7 +40,7 @@ func TestMetadata(t *testing.T) {
 	if md.AddColumn("col2", types.Int) != colID {
 		t.Fatalf("unexpected column id")
 	}
-	if md.AddTable(tab) != tabID {
+	if md.AddTable(tab, &tree.TableName{}) != tabID {
 		t.Fatalf("unexpected table id")
 	}
 
@@ -140,7 +140,7 @@ func TestMetadataTables(t *testing.T) {
 	y := &testcat.Column{Name: "y"}
 	a.Columns = append(a.Columns, x, y)
 
-	tabID := md.AddTable(a)
+	tabID := md.AddTable(a, &tree.TableName{})
 	if tabID == 0 {
 		t.Fatalf("unexpected table id: %d", tabID)
 	}
@@ -165,7 +165,7 @@ func TestMetadataTables(t *testing.T) {
 	b.TabName = tree.MakeUnqualifiedTableName(tree.Name("b"))
 	b.Columns = append(b.Columns, &testcat.Column{Name: "x"})
 
-	otherTabID := md.AddTable(b)
+	otherTabID := md.AddTable(b, &tree.TableName{})
 	if otherTabID == tabID {
 		t.Fatalf("unexpected table id: %d", tabID)
 	}
@@ -192,7 +192,8 @@ func TestIndexColumns(t *testing.T) {
 	}
 
 	var md opt.Metadata
-	a := md.AddTable(cat.Table(tree.NewUnqualifiedTableName("a")))
+	tn := tree.NewUnqualifiedTableName("a")
+	a := md.AddTable(cat.Table(tn), tn)
 
 	k := a.ColumnID(0)
 	i := a.ColumnID(1)

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -44,7 +44,7 @@ func TestMetadata(t *testing.T) {
 		t.Fatalf("unexpected table id")
 	}
 
-	md.AddDependency(opt.DepByName(tab.Name()), tab, privilege.CREATE)
+	md.AddDependency(opt.DepByName(&tab.TabName), tab, privilege.CREATE)
 	depsUpToDate, err := md.CheckDependencies(context.TODO(), testCat)
 	if err == nil || depsUpToDate {
 		t.Fatalf("expected table privilege to be revoked")

--- a/pkg/sql/opt/norm/factory_test.go
+++ b/pkg/sql/opt/norm/factory_test.go
@@ -36,7 +36,8 @@ func TestSimplifyFilters(t *testing.T) {
 	if _, err := cat.ExecuteDDL("CREATE TABLE a (x INT PRIMARY KEY, y INT)"); err != nil {
 		t.Fatal(err)
 	}
-	a := f.Metadata().AddTable(cat.Table(tree.NewTableName("t", "a")))
+	tn := tree.NewTableName("t", "a")
+	a := f.Metadata().AddTable(cat.Table(tn), tn)
 	ax := a.ColumnID(0)
 
 	variable := f.ConstructVariable(ax)

--- a/pkg/sql/opt/norm/testdata/rules/reject_nulls
+++ b/pkg/sql/opt/norm/testdata/rules/reject_nulls
@@ -438,7 +438,7 @@ select
  │    │    ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int!null)
  │    │    ├── key: (1,3)
  │    │    ├── fd: (1)-->(2), (3)-->(4)
- │    │    ├── scan t.public.xy
+ │    │    ├── scan xy
  │    │    │    ├── columns: x:1(int!null) y:2(int)
  │    │    │    ├── key: (1)
  │    │    │    └── fd: (1)-->(2)
@@ -446,7 +446,7 @@ select
  │    │    │    ├── columns: u:3(int!null) v:4(int!null)
  │    │    │    ├── key: (3)
  │    │    │    ├── fd: (3)-->(4)
- │    │    │    ├── scan t.public.uv
+ │    │    │    ├── scan uv
  │    │    │    │    ├── columns: u:3(int!null) v:4(int)
  │    │    │    │    ├── key: (3)
  │    │    │    │    └── fd: (3)-->(4)
@@ -639,7 +639,7 @@ select
  │    │    ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int) z:5(int)
  │    │    ├── key: (1,3)
  │    │    ├── fd: (1)-->(2), (1,3)-->(4,5)
- │    │    ├── scan t.public.xy
+ │    │    ├── scan xy
  │    │    │    ├── columns: x:1(int!null) y:2(int)
  │    │    │    ├── key: (1)
  │    │    │    └── fd: (1)-->(2)
@@ -648,7 +648,7 @@ select
  │    │    │    ├── outer: (1)
  │    │    │    ├── key: (3)
  │    │    │    ├── fd: (3)-->(4,5)
- │    │    │    ├── scan t.public.uv
+ │    │    │    ├── scan uv
  │    │    │    │    ├── columns: u:3(int!null) v:4(int)
  │    │    │    │    ├── key: (3)
  │    │    │    │    └── fd: (3)-->(4)

--- a/pkg/sql/opt/optbuilder/alter_table.go
+++ b/pkg/sql/opt/optbuilder/alter_table.go
@@ -29,7 +29,7 @@ func (b *Builder) buildAlterTableSplit(split *tree.Split, inScope *scope) (outSc
 		AvoidDescriptorCaches: true,
 		NoTableStats:          true,
 	}
-	index, err := cat.ResolveTableIndex(b.ctx, b.catalog, flags, &split.TableOrIndex)
+	index, tn, err := cat.ResolveTableIndex(b.ctx, b.catalog, flags, &split.TableOrIndex)
 	if err != nil {
 		panic(err)
 	}
@@ -72,7 +72,7 @@ func (b *Builder) buildAlterTableSplit(split *tree.Split, inScope *scope) (outSc
 		inputScope.expr.(memo.RelExpr),
 		expiration,
 		&memo.AlterTableSplitPrivate{
-			Table:   b.factory.Metadata().AddTable(table),
+			Table:   b.factory.Metadata().AddTable(table, &tn),
 			Index:   index.Ordinal(),
 			Columns: colsToColList(outScope.cols),
 			Props:   inputScope.makePhysicalProps(),
@@ -87,7 +87,7 @@ func (b *Builder) buildAlterTableUnsplit(unsplit *tree.Unsplit, inScope *scope) 
 		AvoidDescriptorCaches: true,
 		NoTableStats:          true,
 	}
-	index, err := cat.ResolveTableIndex(b.ctx, b.catalog, flags, &unsplit.TableOrIndex)
+	index, tn, err := cat.ResolveTableIndex(b.ctx, b.catalog, flags, &unsplit.TableOrIndex)
 	if err != nil {
 		panic(err)
 	}
@@ -101,7 +101,7 @@ func (b *Builder) buildAlterTableUnsplit(unsplit *tree.Unsplit, inScope *scope) 
 	outScope = inScope.push()
 	b.synthesizeResultColumns(outScope, sqlbase.AlterTableUnsplitColumns)
 	private := &memo.AlterTableSplitPrivate{
-		Table:   b.factory.Metadata().AddTable(table),
+		Table:   b.factory.Metadata().AddTable(table, &tn),
 		Index:   index.Ordinal(),
 		Columns: colsToColList(outScope.cols),
 	}
@@ -137,7 +137,7 @@ func (b *Builder) buildAlterTableRelocate(
 		AvoidDescriptorCaches: true,
 		NoTableStats:          true,
 	}
-	index, err := cat.ResolveTableIndex(b.ctx, b.catalog, flags, &relocate.TableOrIndex)
+	index, tn, err := cat.ResolveTableIndex(b.ctx, b.catalog, flags, &relocate.TableOrIndex)
 	if err != nil {
 		panic(err)
 	}
@@ -177,7 +177,7 @@ func (b *Builder) buildAlterTableRelocate(
 		&memo.AlterTableRelocatePrivate{
 			RelocateLease: relocate.RelocateLease,
 			AlterTableSplitPrivate: memo.AlterTableSplitPrivate{
-				Table:   b.factory.Metadata().AddTable(table),
+				Table:   b.factory.Metadata().AddTable(table, &tn),
 				Index:   index.Ordinal(),
 				Columns: colsToColList(outScope.cols),
 				Props:   inputScope.makePhysicalProps(),

--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -115,7 +115,7 @@ func TestBuilder(t *testing.T) {
 				if err != nil {
 					return fmt.Sprintf("error: %s\n", strings.TrimSpace(err.Error()))
 				}
-				f := memo.MakeExprFmtCtx(tester.Flags.ExprFormat, o.Memo())
+				f := memo.MakeExprFmtCtx(tester.Flags.ExprFormat, o.Memo(), catalog)
 				f.FormatExpr(o.Memo().RootExpr())
 				return f.Buffer.String()
 

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -573,9 +573,7 @@ func (mb *mutationBuilder) buildInputForInsert(inScope *scope, inputRows *tree.S
 		// Type check the input column against the corresponding table column.
 		checkDatumTypeFitsColumnType(mb.tab.Column(ord), inCol.typ)
 
-		// Assign name of input column. Computed columns can refer to this column
-		// by its name.
-		inCol.table = *mb.tab.Name()
+		// Assign name of input column.
 		inCol.name = tree.Name(mb.md.ColumnMeta(mb.targetColList[i]).Alias)
 
 		// Record the ordinal position of the scope column that contains the
@@ -938,9 +936,7 @@ func (mb *mutationBuilder) projectUpsertColumns() {
 		scopeCol := mb.b.synthesizeColumn(projectionsScope, alias, typ, nil /* expr */, caseExpr)
 		scopeColOrd := scopeOrdinal(len(projectionsScope.cols) - 1)
 
-		// Assign name to synthesized column. Check constraint columns may refer
-		// to columns in the table by name.
-		scopeCol.table = *mb.tab.Name()
+		// Assign name to synthesized column.
 		scopeCol.name = mb.tab.Column(i).ColName()
 
 		// Update the scope ordinals for the update columns that are involved in

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -151,7 +151,7 @@ func (mb *mutationBuilder) init(b *Builder, op opt.Operator, tab cat.Table, alia
 	mb.checkOrds = scopeOrds[n*4:]
 
 	// Add the table and its columns (including mutation columns) to metadata.
-	mb.tabID = mb.md.AddTableWithAlias(tab, &mb.alias)
+	mb.tabID = mb.md.AddTable(tab, &mb.alias)
 }
 
 // scopeOrdToColID returns the ID of the given scope column. If no scope column

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -786,7 +786,7 @@ func (mb *mutationBuilder) buildFKChecks() {
 			refOrdinals[j] = fk.ReferencedColumnOrdinal(refTab.(cat.Table), j)
 		}
 
-		refTabMeta := mb.b.addTable(refTab.(cat.Table), refTab.Name())
+		refTabMeta := mb.b.addTable(refTab.(cat.Table), tree.NewUnqualifiedTableName(refTab.Name()))
 		item.ReferencedTable = refTabMeta.MetaID
 		scanScope := mb.b.buildScan(
 			refTabMeta,

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -308,7 +308,7 @@ func (b *Builder) buildScanFromTableRef(
 // catalog and schema names were explicitly specified.
 func (b *Builder) addTable(tab cat.Table, alias *tree.TableName) *opt.TableMeta {
 	md := b.factory.Metadata()
-	tabID := md.AddTableWithAlias(tab, alias)
+	tabID := md.AddTable(tab, alias)
 	return md.TableMeta(tabID)
 }
 

--- a/pkg/sql/opt/optbuilder/testdata/alter_table
+++ b/pkg/sql/opt/optbuilder/testdata/alter_table
@@ -6,7 +6,7 @@ CREATE TABLE abc (a INT PRIMARY KEY, b INT, c STRING, INDEX b (b), UNIQUE INDEX 
 build
 ALTER TABLE abc SPLIT AT VALUES (1), (2)
 ----
-alter-table-split t.public.abc
+alter-table-split abc
  ├── columns: key:2(bytes) pretty:3(string) split_enforced_until:4(timestamp)
  ├── values
  │    ├── columns: column1:1(int!null)
@@ -19,7 +19,7 @@ alter-table-split t.public.abc
 build
 ALTER TABLE abc SPLIT AT VALUES (1), (2) WITH EXPIRATION '2200-01-01 00:00:00.0'
 ----
-alter-table-split t.public.abc
+alter-table-split abc
  ├── columns: key:2(bytes) pretty:3(string) split_enforced_until:4(timestamp)
  ├── values
  │    ├── columns: column1:1(int!null)
@@ -37,7 +37,7 @@ error (42601): too many columns in SPLIT AT data
 build
 ALTER INDEX abc@bc SPLIT AT VALUES (1), (2) WITH EXPIRATION '2200-01-01 00:00:00.0'
 ----
-alter-table-split t.public.abc@bc
+alter-table-split abc@bc
  ├── columns: key:2(bytes) pretty:3(string) split_enforced_until:4(timestamp)
  ├── values
  │    ├── columns: column1:1(int!null)
@@ -50,7 +50,7 @@ alter-table-split t.public.abc@bc
 build
 ALTER INDEX abc@bc SPLIT AT VALUES (1, 'foo'), (2, 'bar')
 ----
-alter-table-split t.public.abc@bc
+alter-table-split abc@bc
  ├── columns: key:3(bytes) pretty:4(string) split_enforced_until:5(timestamp)
  ├── values
  │    ├── columns: column1:1(int!null) column2:2(string!null)
@@ -70,13 +70,13 @@ error (42601): SPLIT AT data column 2 (c) must be of type string, not type int
 build
 ALTER INDEX abc@bc SPLIT AT SELECT b FROM abc ORDER BY a
 ----
-alter-table-split t.public.abc@bc
+alter-table-split abc@bc
  ├── columns: key:4(bytes) pretty:5(string) split_enforced_until:6(timestamp)
  ├── project
- │    ├── columns: b:2(int)  [hidden: abc.a:1(int!null)]
+ │    ├── columns: b:2(int)  [hidden: a:1(int!null)]
  │    ├── ordering: +1
  │    └── scan abc
- │         ├── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(string)
+ │         ├── columns: a:1(int!null) b:2(int) c:3(string)
  │         └── ordering: +1
  └── null [type=string]
 
@@ -84,7 +84,7 @@ alter-table-split t.public.abc@bc
 build
 ALTER TABLE abc UNSPLIT AT VALUES (1), (2)
 ----
-alter-table-unsplit t.public.abc
+alter-table-unsplit abc
  ├── columns: key:1(bytes) pretty:2(string)
  └── values
       ├── columns: column1:6(int!null)
@@ -96,7 +96,7 @@ alter-table-unsplit t.public.abc
 build
 ALTER TABLE abc UNSPLIT ALL
 ----
-alter-table-unsplit-all t.public.abc
+alter-table-unsplit-all abc
  └── columns: key:1(bytes) pretty:2(string)
 
 build
@@ -107,13 +107,13 @@ error (42601): too many columns in UNSPLIT AT data
 build
 ALTER INDEX abc@bc UNSPLIT ALL
 ----
-alter-table-unsplit-all t.public.abc@bc
+alter-table-unsplit-all abc@bc
  └── columns: key:1(bytes) pretty:2(string)
 
 build
 ALTER INDEX abc@bc UNSPLIT AT VALUES (1, 'foo'), (2, 'bar')
 ----
-alter-table-unsplit t.public.abc@bc
+alter-table-unsplit abc@bc
  ├── columns: key:1(bytes) pretty:2(string)
  └── values
       ├── columns: column1:6(int!null) column2:7(string!null)
@@ -132,20 +132,20 @@ error (42601): UNSPLIT AT data column 2 (c) must be of type string, not type int
 build
 ALTER INDEX abc@bc UNSPLIT AT SELECT b FROM abc ORDER BY a
 ----
-alter-table-unsplit t.public.abc@bc
+alter-table-unsplit abc@bc
  ├── columns: key:1(bytes) pretty:2(string)
  └── project
-      ├── columns: b:7(int)  [hidden: abc.a:6(int!null)]
+      ├── columns: b:7(int)  [hidden: a:6(int!null)]
       ├── ordering: +6
       └── scan abc
-           ├── columns: abc.a:6(int!null) abc.b:7(int) abc.c:8(string)
+           ├── columns: a:6(int!null) b:7(int) c:8(string)
            └── ordering: +6
 
 # Tests for ALTER TABLE EXPERIMENTAL_RELOCATE.
 build
 ALTER TABLE abc EXPERIMENTAL_RELOCATE VALUES (ARRAY[1,2,3], 1), (ARRAY[4], 2)
 ----
-alter-table-relocate t.public.abc
+alter-table-relocate abc
  ├── columns: key:1(bytes) pretty:2(string)
  └── values
       ├── columns: column1:3(int[]) column2:4(int!null)
@@ -173,7 +173,7 @@ error (42601): too many columns in EXPERIMENTAL_RELOCATE LEASE data
 build
 ALTER INDEX abc@bc EXPERIMENTAL_RELOCATE VALUES (ARRAY[5], 1, 'foo'), (ARRAY[6,7,8], 2, 'bar')
 ----
-alter-table-relocate t.public.abc@bc
+alter-table-relocate abc@bc
  ├── columns: key:1(bytes) pretty:2(string)
  └── values
       ├── columns: column1:3(int[]) column2:4(int!null) column3:5(string!null)
@@ -213,7 +213,7 @@ error (42601): EXPERIMENTAL_RELOCATE data column 3 (c) must be of type string, n
 build
 ALTER INDEX abc@bc EXPERIMENTAL_RELOCATE LEASE VALUES (10, 1, 'foo'), (11, 3, 'bar')
 ----
-alter-table-relocate t.public.abc@bc [lease]
+alter-table-relocate abc@bc [lease]
  ├── columns: key:1(bytes) pretty:2(string)
  └── values
       ├── columns: column1:3(int!null) column2:4(int!null) column3:5(string!null)

--- a/pkg/sql/opt/optbuilder/testdata/delegate
+++ b/pkg/sql/opt/optbuilder/testdata/delegate
@@ -9,7 +9,7 @@ sort
       ├── grouping columns: catalog_name:1(string)
       └── project
            ├── columns: catalog_name:1(string)
-           └── virtual-scan t.information_schema.schemata
+           └── virtual-scan "".information_schema.schemata
                 └── columns: catalog_name:1(string) schema_name:2(string) default_character_set_name:3(string) sql_path:4(string)
 
 # Note: t is the default database for the test catalog.

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
@@ -31,12 +31,12 @@ insert child
                 │    ├── columns: column2:7(int!null)
                 │    └── mapping:
                 │         └──  column2:4(int) => column2:7(int)
-                ├── scan t.public.parent
-                │    └── columns: t.public.parent.p:5(int!null)
+                ├── scan parent
+                │    └── columns: parent.p:5(int!null)
                 └── filters
                      └── eq [type=bool]
                           ├── variable: column2 [type=int]
-                          └── variable: t.public.parent.p [type=int]
+                          └── variable: parent.p [type=int]
 
 # Use a non-constant input.
 exec-ddl
@@ -64,12 +64,12 @@ insert child
                 │    ├── columns: y:8(int)
                 │    └── mapping:
                 │         └──  xy.y:4(int) => y:8(int)
-                ├── scan t.public.parent
-                │    └── columns: t.public.parent.p:6(int!null)
+                ├── scan parent
+                │    └── columns: parent.p:6(int!null)
                 └── filters
                      └── eq [type=bool]
                           ├── variable: y [type=int]
-                          └── variable: t.public.parent.p [type=int]
+                          └── variable: parent.p [type=int]
 
 exec-ddl
 CREATE TABLE child_nullable (c INT PRIMARY KEY, p INT REFERENCES parent(p));
@@ -109,12 +109,12 @@ insert child_nullable
                 │         └── is-not [type=bool]
                 │              ├── variable: column2 [type=int]
                 │              └── null [type=unknown]
-                ├── scan t.public.parent
-                │    └── columns: t.public.parent.p:5(int!null)
+                ├── scan parent
+                │    └── columns: parent.p:5(int!null)
                 └── filters
                      └── eq [type=bool]
                           ├── variable: column2 [type=int]
-                          └── variable: t.public.parent.p [type=int]
+                          └── variable: parent.p [type=int]
 
 # The column is nullable but we know that the input is not null, so we don't
 # need to plan the filter.
@@ -143,12 +143,12 @@ insert child_nullable
                 │    ├── columns: column2:7(int!null)
                 │    └── mapping:
                 │         └──  column2:4(int) => column2:7(int)
-                ├── scan t.public.parent
-                │    └── columns: t.public.parent.p:5(int!null)
+                ├── scan parent
+                │    └── columns: parent.p:5(int!null)
                 └── filters
                      └── eq [type=bool]
                           ├── variable: column2 [type=int]
-                          └── variable: t.public.parent.p [type=int]
+                          └── variable: parent.p [type=int]
 
 # Check planning of filter with FULL match (which should be the same on a
 # single column).
@@ -188,12 +188,12 @@ insert child_nullable_full
                 │         └── is-not [type=bool]
                 │              ├── variable: column2 [type=int]
                 │              └── null [type=unknown]
-                ├── scan t.public.parent
-                │    └── columns: t.public.parent.p:5(int!null)
+                ├── scan parent
+                │    └── columns: parent.p:5(int!null)
                 └── filters
                      └── eq [type=bool]
                           ├── variable: column2 [type=int]
-                          └── variable: t.public.parent.p [type=int]
+                          └── variable: parent.p [type=int]
 
 # Tests with multicolumn FKs.
 exec-ddl
@@ -252,18 +252,18 @@ insert multi_col_child
                 │         └── is-not [type=bool]
                 │              ├── variable: column4 [type=int]
                 │              └── null [type=unknown]
-                ├── scan t.public.multi_col_parent
-                │    └── columns: t.public.multi_col_parent.p:9(int!null) t.public.multi_col_parent.q:10(int!null) t.public.multi_col_parent.r:11(int!null)
+                ├── scan multi_col_parent
+                │    └── columns: multi_col_parent.p:9(int!null) multi_col_parent.q:10(int!null) multi_col_parent.r:11(int!null)
                 └── filters
                      ├── eq [type=bool]
                      │    ├── variable: column2 [type=int]
-                     │    └── variable: t.public.multi_col_parent.p [type=int]
+                     │    └── variable: multi_col_parent.p [type=int]
                      ├── eq [type=bool]
                      │    ├── variable: column3 [type=int]
-                     │    └── variable: t.public.multi_col_parent.q [type=int]
+                     │    └── variable: multi_col_parent.q [type=int]
                      └── eq [type=bool]
                           ├── variable: column4 [type=int]
-                          └── variable: t.public.multi_col_parent.r [type=int]
+                          └── variable: multi_col_parent.r [type=int]
 
 # Only p and q are nullable.
 build
@@ -310,18 +310,18 @@ insert multi_col_child
                 │         └── is-not [type=bool]
                 │              ├── variable: column3 [type=int]
                 │              └── null [type=unknown]
-                ├── scan t.public.multi_col_parent
-                │    └── columns: t.public.multi_col_parent.p:9(int!null) t.public.multi_col_parent.q:10(int!null) t.public.multi_col_parent.r:11(int!null)
+                ├── scan multi_col_parent
+                │    └── columns: multi_col_parent.p:9(int!null) multi_col_parent.q:10(int!null) multi_col_parent.r:11(int!null)
                 └── filters
                      ├── eq [type=bool]
                      │    ├── variable: column2 [type=int]
-                     │    └── variable: t.public.multi_col_parent.p [type=int]
+                     │    └── variable: multi_col_parent.p [type=int]
                      ├── eq [type=bool]
                      │    ├── variable: column3 [type=int]
-                     │    └── variable: t.public.multi_col_parent.q [type=int]
+                     │    └── variable: multi_col_parent.q [type=int]
                      └── eq [type=bool]
                           ├── variable: column4 [type=int]
-                          └── variable: t.public.multi_col_parent.r [type=int]
+                          └── variable: multi_col_parent.r [type=int]
 
 # All the FK columns are not-null; no filter necessary.
 build
@@ -352,18 +352,18 @@ insert multi_col_child
                 │         ├──  column2:6(int) => column2:13(int)
                 │         ├──  column3:7(int) => column3:14(int)
                 │         └──  column4:8(int) => column4:15(int)
-                ├── scan t.public.multi_col_parent
-                │    └── columns: t.public.multi_col_parent.p:9(int!null) t.public.multi_col_parent.q:10(int!null) t.public.multi_col_parent.r:11(int!null)
+                ├── scan multi_col_parent
+                │    └── columns: multi_col_parent.p:9(int!null) multi_col_parent.q:10(int!null) multi_col_parent.r:11(int!null)
                 └── filters
                      ├── eq [type=bool]
                      │    ├── variable: column2 [type=int]
-                     │    └── variable: t.public.multi_col_parent.p [type=int]
+                     │    └── variable: multi_col_parent.p [type=int]
                      ├── eq [type=bool]
                      │    ├── variable: column3 [type=int]
-                     │    └── variable: t.public.multi_col_parent.q [type=int]
+                     │    └── variable: multi_col_parent.q [type=int]
                      └── eq [type=bool]
                           ├── variable: column4 [type=int]
-                          └── variable: t.public.multi_col_parent.r [type=int]
+                          └── variable: multi_col_parent.r [type=int]
 
 exec-ddl
 CREATE TABLE multi_col_child_full  (
@@ -419,18 +419,18 @@ insert multi_col_child_full
                 │              └── is-not [type=bool]
                 │                   ├── variable: column4 [type=int]
                 │                   └── null [type=unknown]
-                ├── scan t.public.multi_col_parent
-                │    └── columns: t.public.multi_col_parent.p:9(int!null) t.public.multi_col_parent.q:10(int!null) t.public.multi_col_parent.r:11(int!null)
+                ├── scan multi_col_parent
+                │    └── columns: multi_col_parent.p:9(int!null) multi_col_parent.q:10(int!null) multi_col_parent.r:11(int!null)
                 └── filters
                      ├── eq [type=bool]
                      │    ├── variable: column2 [type=int]
-                     │    └── variable: t.public.multi_col_parent.p [type=int]
+                     │    └── variable: multi_col_parent.p [type=int]
                      ├── eq [type=bool]
                      │    ├── variable: column3 [type=int]
-                     │    └── variable: t.public.multi_col_parent.q [type=int]
+                     │    └── variable: multi_col_parent.q [type=int]
                      └── eq [type=bool]
                           ├── variable: column4 [type=int]
-                          └── variable: t.public.multi_col_parent.r [type=int]
+                          └── variable: multi_col_parent.r [type=int]
 
 # Only p and q are nullable; no filter necessary.
 build
@@ -468,18 +468,18 @@ insert multi_col_child_full
                 │         ├──  column2:6(int) => column2:13(int)
                 │         ├──  column3:7(int) => column3:14(int)
                 │         └──  column4:8(int) => column4:15(int)
-                ├── scan t.public.multi_col_parent
-                │    └── columns: t.public.multi_col_parent.p:9(int!null) t.public.multi_col_parent.q:10(int!null) t.public.multi_col_parent.r:11(int!null)
+                ├── scan multi_col_parent
+                │    └── columns: multi_col_parent.p:9(int!null) multi_col_parent.q:10(int!null) multi_col_parent.r:11(int!null)
                 └── filters
                      ├── eq [type=bool]
                      │    ├── variable: column2 [type=int]
-                     │    └── variable: t.public.multi_col_parent.p [type=int]
+                     │    └── variable: multi_col_parent.p [type=int]
                      ├── eq [type=bool]
                      │    ├── variable: column3 [type=int]
-                     │    └── variable: t.public.multi_col_parent.q [type=int]
+                     │    └── variable: multi_col_parent.q [type=int]
                      └── eq [type=bool]
                           ├── variable: column4 [type=int]
-                          └── variable: t.public.multi_col_parent.r [type=int]
+                          └── variable: multi_col_parent.r [type=int]
 
 # All the FK columns are not-null; no filter necessary.
 build
@@ -510,18 +510,18 @@ insert multi_col_child_full
                 │         ├──  column2:6(int) => column2:13(int)
                 │         ├──  column3:7(int) => column3:14(int)
                 │         └──  column4:8(int) => column4:15(int)
-                ├── scan t.public.multi_col_parent
-                │    └── columns: t.public.multi_col_parent.p:9(int!null) t.public.multi_col_parent.q:10(int!null) t.public.multi_col_parent.r:11(int!null)
+                ├── scan multi_col_parent
+                │    └── columns: multi_col_parent.p:9(int!null) multi_col_parent.q:10(int!null) multi_col_parent.r:11(int!null)
                 └── filters
                      ├── eq [type=bool]
                      │    ├── variable: column2 [type=int]
-                     │    └── variable: t.public.multi_col_parent.p [type=int]
+                     │    └── variable: multi_col_parent.p [type=int]
                      ├── eq [type=bool]
                      │    ├── variable: column3 [type=int]
-                     │    └── variable: t.public.multi_col_parent.q [type=int]
+                     │    └── variable: multi_col_parent.q [type=int]
                      └── eq [type=bool]
                           ├── variable: column4 [type=int]
-                          └── variable: t.public.multi_col_parent.r [type=int]
+                          └── variable: multi_col_parent.r [type=int]
 
 exec-ddl
 CREATE TABLE multi_ref_parent_a (a INT PRIMARY KEY, other INT)
@@ -577,12 +577,12 @@ insert multi_ref_child
       │         │         └── is-not [type=bool]
       │         │              ├── variable: column2 [type=int]
       │         │              └── null [type=unknown]
-      │         ├── scan t.public.multi_ref_parent_a
-      │         │    └── columns: t.public.multi_ref_parent_a.a:9(int!null)
+      │         ├── scan multi_ref_parent_a
+      │         │    └── columns: multi_ref_parent_a.a:9(int!null)
       │         └── filters
       │              └── eq [type=bool]
       │                   ├── variable: column2 [type=int]
-      │                   └── variable: t.public.multi_ref_parent_a.a [type=int]
+      │                   └── variable: multi_ref_parent_a.a [type=int]
       └── f-k-checks-item: multi_ref_child(b,c) -> multi_ref_parent_bc(b,c)
            └── anti-join (hash)
                 ├── columns: column3:15(int!null) column4:16(int!null)
@@ -600,12 +600,12 @@ insert multi_ref_child
                 │         └── is-not [type=bool]
                 │              ├── variable: column4 [type=int]
                 │              └── null [type=unknown]
-                ├── scan t.public.multi_ref_parent_bc
-                │    └── columns: t.public.multi_ref_parent_bc.b:12(int!null) t.public.multi_ref_parent_bc.c:13(int!null)
+                ├── scan multi_ref_parent_bc
+                │    └── columns: multi_ref_parent_bc.b:12(int!null) multi_ref_parent_bc.c:13(int!null)
                 └── filters
                      ├── eq [type=bool]
                      │    ├── variable: column3 [type=int]
-                     │    └── variable: t.public.multi_ref_parent_bc.b [type=int]
+                     │    └── variable: multi_ref_parent_bc.b [type=int]
                      └── eq [type=bool]
                           ├── variable: column4 [type=int]
-                          └── variable: t.public.multi_ref_parent_bc.c [type=int]
+                          └── variable: multi_ref_parent_bc.c [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/sequence
+++ b/pkg/sql/opt/optbuilder/testdata/sequence
@@ -9,7 +9,7 @@ CREATE SEQUENCE y
 build
 SELECT * FROM x
 ----
-sequence-select t.public.x
+sequence-select x
  └── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
 
 build
@@ -17,7 +17,7 @@ SELECT z.last_value FROM x AS z
 ----
 project
  ├── columns: last_value:1(int!null)
- └── sequence-select t.public.x
+ └── sequence-select x
       └── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
 
 build
@@ -25,7 +25,7 @@ SELECT last_value FROM x
 ----
 project
  ├── columns: last_value:1(int!null)
- └── sequence-select t.public.x
+ └── sequence-select x
       └── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
 
 build
@@ -33,7 +33,7 @@ SELECT log_cnt FROM x
 ----
 project
  ├── columns: log_cnt:2(int!null)
- └── sequence-select t.public.x
+ └── sequence-select x
       └── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
 
 # Multiple sequences in a query.
@@ -44,9 +44,9 @@ union
  ├── columns: last_value:7(int!null) log_cnt:8(int!null) is_called:9(bool!null)
  ├── left columns: last_value:1(int) log_cnt:2(int) is_called:3(bool)
  ├── right columns: last_value:4(int) log_cnt:5(int) is_called:6(bool)
- ├── sequence-select t.public.x
+ ├── sequence-select x
  │    └── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
- └── sequence-select t.public.y
+ └── sequence-select y
       └── columns: last_value:4(int!null) log_cnt:5(int!null) is_called:6(bool!null)
 
 # Sequences occurring multiple times in a query.
@@ -73,28 +73,28 @@ except
  │    │    │    ├── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
  │    │    │    ├── left columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
  │    │    │    ├── right columns: last_value:4(int) log_cnt:5(int) is_called:6(bool)
- │    │    │    ├── sequence-select t.public.x
+ │    │    │    ├── sequence-select x
  │    │    │    │    └── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
- │    │    │    └── sequence-select t.public.x
+ │    │    │    └── sequence-select x
  │    │    │         └── columns: last_value:4(int!null) log_cnt:5(int!null) is_called:6(bool!null)
- │    │    └── sequence-select t.public.y
+ │    │    └── sequence-select y
  │    │         └── columns: last_value:7(int!null) log_cnt:8(int!null) is_called:9(bool!null)
- │    └── sequence-select t.public.x
+ │    └── sequence-select x
  │         └── columns: last_value:10(int!null) log_cnt:11(int!null) is_called:12(bool!null)
- └── sequence-select t.public.y
+ └── sequence-select y
       └── columns: last_value:13(int!null) log_cnt:14(int!null) is_called:15(bool!null)
 
 # Ensure index flags are ignored.
 build
 SELECT * FROM x@primary
 ----
-sequence-select t.public.x
+sequence-select x
  └── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
 
 build
 SELECT * FROM x@foobar
 ----
-sequence-select t.public.x
+sequence-select x
  └── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
 
 # Ordinal refs with a sequence.
@@ -103,7 +103,7 @@ SELECT @1 FROM x
 ----
 project
  ├── columns: "?column?":4(int)
- ├── sequence-select t.public.x
+ ├── sequence-select x
  │    └── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
  └── projections
       └── variable: last_value [type=int]
@@ -114,7 +114,7 @@ SELECT * FROM x WHERE last_value = 0
 ----
 select
  ├── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
- ├── sequence-select t.public.x
+ ├── sequence-select x
  │    └── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
  └── filters
       └── eq [type=bool]

--- a/pkg/sql/opt/optbuilder/testdata/virtual-scan
+++ b/pkg/sql/opt/optbuilder/testdata/virtual-scan
@@ -6,7 +6,7 @@ error (42P01): no data source matches prefix: "information_schema.public.does_no
 build
 SELECT * FROM information_schema.columns
 ----
-virtual-scan t.information_schema.columns
+virtual-scan information_schema.columns
  └── columns: table_catalog:1(string) table_schema:2(string) table_name:3(string) column_name:4(string) ordinal_position:5(int) column_default:6(string) is_nullable:7(string) data_type:8(string) character_maximum_length:9(int) character_octet_length:10(int) numeric_precision:11(int) numeric_precision_radix:12(int) numeric_scale:13(int) datetime_precision:14(int) interval_type:15(string) interval_precision:16(int) character_set_catalog:17(string) character_set_schema:18(string) character_set_name:19(string) collation_catalog:20(string) collation_schema:21(string) collation_name:22(string) domain_catalog:23(string) domain_schema:24(string) domain_name:25(string) udt_catalog:26(string) udt_schema:27(string) udt_name:28(string) scope_catalog:29(string) scope_schema:30(string) scope_name:31(string) maximum_cardinality:32(int) dtd_identifier:33(string) is_self_referencing:34(string) is_identity:35(string) identity_generation:36(string) identity_start:37(string) identity_increment:38(string) identity_maximum:39(string) identity_minimum:40(string) identity_cycle:41(string) is_generated:42(string) generation_expression:43(string) is_updatable:44(string) is_hidden:45(string) crdb_sql_type:46(string)
 
 # Since we lazily create these, the name resolution codepath is slightly
@@ -14,12 +14,12 @@ virtual-scan t.information_schema.columns
 build
 SELECT * FROM information_schema.columns
 ----
-virtual-scan t.information_schema.columns
+virtual-scan information_schema.columns
  └── columns: table_catalog:1(string) table_schema:2(string) table_name:3(string) column_name:4(string) ordinal_position:5(int) column_default:6(string) is_nullable:7(string) data_type:8(string) character_maximum_length:9(int) character_octet_length:10(int) numeric_precision:11(int) numeric_precision_radix:12(int) numeric_scale:13(int) datetime_precision:14(int) interval_type:15(string) interval_precision:16(int) character_set_catalog:17(string) character_set_schema:18(string) character_set_name:19(string) collation_catalog:20(string) collation_schema:21(string) collation_name:22(string) domain_catalog:23(string) domain_schema:24(string) domain_name:25(string) udt_catalog:26(string) udt_schema:27(string) udt_name:28(string) scope_catalog:29(string) scope_schema:30(string) scope_name:31(string) maximum_cardinality:32(int) dtd_identifier:33(string) is_self_referencing:34(string) is_identity:35(string) identity_generation:36(string) identity_start:37(string) identity_increment:38(string) identity_maximum:39(string) identity_minimum:40(string) identity_cycle:41(string) is_generated:42(string) generation_expression:43(string) is_updatable:44(string) is_hidden:45(string) crdb_sql_type:46(string)
 
 # Alias the virtual table name.
 build
 SELECT * FROM information_schema.columns c
 ----
-virtual-scan t.information_schema.columns
+virtual-scan information_schema.columns
  └── columns: table_catalog:1(string) table_schema:2(string) table_name:3(string) column_name:4(string) ordinal_position:5(int) column_default:6(string) is_nullable:7(string) data_type:8(string) character_maximum_length:9(int) character_octet_length:10(int) numeric_precision:11(int) numeric_precision_radix:12(int) numeric_scale:13(int) datetime_precision:14(int) interval_type:15(string) interval_precision:16(int) character_set_catalog:17(string) character_set_schema:18(string) character_set_name:19(string) collation_catalog:20(string) collation_schema:21(string) collation_name:22(string) domain_catalog:23(string) domain_schema:24(string) domain_name:25(string) udt_catalog:26(string) udt_schema:27(string) udt_name:28(string) scope_catalog:29(string) scope_schema:30(string) scope_name:31(string) maximum_cardinality:32(int) dtd_identifier:33(string) is_self_referencing:34(string) is_identity:35(string) identity_generation:36(string) identity_start:37(string) identity_increment:38(string) identity_maximum:39(string) identity_minimum:40(string) identity_cycle:41(string) is_generated:42(string) generation_expression:43(string) is_updatable:44(string) is_hidden:45(string) crdb_sql_type:46(string)

--- a/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
@@ -279,9 +279,9 @@ func (g *exprsGen) genExprFuncs(define *lang.DefineExpr) {
 	// Generate the String method.
 	fmt.Fprintf(g.w, "func (e *%s) String() string {\n", opTyp.name)
 	if define.Tags.Contains("Scalar") {
-		fmt.Fprintf(g.w, "  f := MakeExprFmtCtx(ExprFmtHideQualifications, nil)\n")
+		fmt.Fprintf(g.w, "  f := MakeExprFmtCtx(ExprFmtHideQualifications, nil, nil)\n")
 	} else {
-		fmt.Fprintf(g.w, "  f := MakeExprFmtCtx(ExprFmtHideQualifications, e.Memo())\n")
+		fmt.Fprintf(g.w, "  f := MakeExprFmtCtx(ExprFmtHideQualifications, e.Memo(), nil)\n")
 	}
 	fmt.Fprintf(g.w, "  f.FormatExpr(e)\n")
 	fmt.Fprintf(g.w, "  return f.Buffer.String()\n")
@@ -424,7 +424,7 @@ func (g *exprsGen) genEnforcerFuncs(define *lang.DefineExpr) {
 
 	// Generate the String method.
 	fmt.Fprintf(g.w, "func (e *%s) String() string {\n", opTyp.name)
-	fmt.Fprintf(g.w, "  f := MakeExprFmtCtx(ExprFmtHideQualifications, e.Memo())\n")
+	fmt.Fprintf(g.w, "  f := MakeExprFmtCtx(ExprFmtHideQualifications, e.Memo(), nil)\n")
 	fmt.Fprintf(g.w, "  f.FormatExpr(e)\n")
 	fmt.Fprintf(g.w, "  return f.Buffer.String()\n")
 	fmt.Fprintf(g.w, "}\n\n")
@@ -535,7 +535,7 @@ func (g *exprsGen) genListExprFuncs(define *lang.DefineExpr) {
 
 	// Generate the String method.
 	fmt.Fprintf(g.w, "func (e *%s) String() string {\n", opTyp.name)
-	fmt.Fprintf(g.w, "  f := MakeExprFmtCtx(ExprFmtHideQualifications, nil)\n")
+	fmt.Fprintf(g.w, "  f := MakeExprFmtCtx(ExprFmtHideQualifications, nil, nil)\n")
 	fmt.Fprintf(g.w, "  f.FormatExpr(e)\n")
 	fmt.Fprintf(g.w, "  return f.Buffer.String()\n")
 	fmt.Fprintf(g.w, "}\n\n")

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
@@ -94,7 +94,7 @@ func (e *ProjectExpr) Private() interface{} {
 }
 
 func (e *ProjectExpr) String() string {
-	f := MakeExprFmtCtx(ExprFmtHideQualifications, e.Memo())
+	f := MakeExprFmtCtx(ExprFmtHideQualifications, e.Memo(), nil)
 	f.FormatExpr(e)
 	return f.Buffer.String()
 }
@@ -214,7 +214,7 @@ func (e *ProjectionsExpr) Private() interface{} {
 }
 
 func (e *ProjectionsExpr) String() string {
-	f := MakeExprFmtCtx(ExprFmtHideQualifications, nil)
+	f := MakeExprFmtCtx(ExprFmtHideQualifications, nil, nil)
 	f.FormatExpr(e)
 	return f.Buffer.String()
 }
@@ -262,7 +262,7 @@ func (e *ProjectionsItem) Private() interface{} {
 }
 
 func (e *ProjectionsItem) String() string {
-	f := MakeExprFmtCtx(ExprFmtHideQualifications, nil)
+	f := MakeExprFmtCtx(ExprFmtHideQualifications, nil, nil)
 	f.FormatExpr(e)
 	return f.Buffer.String()
 }
@@ -320,7 +320,7 @@ func (e *SortExpr) Private() interface{} {
 }
 
 func (e *SortExpr) String() string {
-	f := MakeExprFmtCtx(ExprFmtHideQualifications, e.Memo())
+	f := MakeExprFmtCtx(ExprFmtHideQualifications, e.Memo(), nil)
 	f.FormatExpr(e)
 	return f.Buffer.String()
 }

--- a/pkg/sql/opt/optgen/exprgen/custom_funcs.go
+++ b/pkg/sql/opt/optgen/exprgen/custom_funcs.go
@@ -117,7 +117,7 @@ func (c *customFuncs) FindTable(name string) opt.TableID {
 
 	var res opt.TableID
 	for i := range tables {
-		if string(tables[i].Table.Name().TableName) == name {
+		if string(tables[i].Table.Name()) == name {
 			if res != 0 {
 				panic(errorf("ambiguous table %q", name))
 			}

--- a/pkg/sql/opt/optgen/exprgen/private.go
+++ b/pkg/sql/opt/optgen/exprgen/private.go
@@ -116,7 +116,7 @@ func (eg *exprGen) addTable(name string) opt.TableID {
 	if !ok {
 		panic(errorf("non-table datasource %s not supported", name))
 	}
-	return eg.mem.Metadata().AddTable(tab)
+	return eg.mem.Metadata().AddTable(tab, &tn)
 }
 
 // findIndex looks for an index specified as "table@idx_name" among the tables

--- a/pkg/sql/opt/ordering/lookup_join_test.go
+++ b/pkg/sql/opt/ordering/lookup_join_test.go
@@ -36,7 +36,8 @@ func TestLookupJoinProvided(t *testing.T) {
 	var f norm.Factory
 	f.Init(evalCtx)
 	md := f.Metadata()
-	tab := md.AddTable(tc.Table(tree.NewUnqualifiedTableName("t")))
+	tn := tree.NewUnqualifiedTableName("t")
+	tab := md.AddTable(tc.Table(tn), tn)
 
 	if c1 := tab.ColumnID(0); c1 != 1 {
 		t.Fatalf("unexpected ID for column c1: %d\n", c1)

--- a/pkg/sql/opt/ordering/scan_test.go
+++ b/pkg/sql/opt/ordering/scan_test.go
@@ -35,7 +35,8 @@ func TestScan(t *testing.T) {
 	var f norm.Factory
 	f.Init(evalCtx)
 	md := f.Metadata()
-	tab := md.AddTable(tc.Table(tree.NewUnqualifiedTableName("t")))
+	tn := tree.NewUnqualifiedTableName("t")
+	tab := md.AddTable(tc.Table(tn), tn)
 
 	if c1 := tab.ColumnID(0); c1 != 1 {
 		t.Fatalf("unexpected ID for column c1: %d\n", c1)

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -359,7 +359,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 			return fmt.Sprintf("error: %s\n", text)
 		}
 		ot.postProcess(tb, d, e)
-		return memo.FormatExpr(e, ot.Flags.ExprFormat)
+		return memo.FormatExpr(e, ot.Flags.ExprFormat, ot.catalog)
 
 	case "norm":
 		e, err := ot.OptNorm()
@@ -376,7 +376,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 			return fmt.Sprintf("error: %s\n", text)
 		}
 		ot.postProcess(tb, d, e)
-		return memo.FormatExpr(e, ot.Flags.ExprFormat)
+		return memo.FormatExpr(e, ot.Flags.ExprFormat, ot.catalog)
 
 	case "opt":
 		e, err := ot.Optimize()
@@ -384,7 +384,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 			d.Fatalf(tb, "%+v", err)
 		}
 		ot.postProcess(tb, d, e)
-		return memo.FormatExpr(e, ot.Flags.ExprFormat)
+		return memo.FormatExpr(e, ot.Flags.ExprFormat, ot.catalog)
 
 	case "optsteps":
 		result, err := ot.OptSteps()
@@ -420,7 +420,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 			d.Fatalf(tb, "%+v", err)
 		}
 		ot.postProcess(tb, d, e)
-		return memo.FormatExpr(e, ot.Flags.ExprFormat)
+		return memo.FormatExpr(e, ot.Flags.ExprFormat, ot.catalog)
 
 	case "exprnorm":
 		e, err := ot.ExprNorm()
@@ -428,7 +428,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 			d.Fatalf(tb, "%+v", err)
 		}
 		ot.postProcess(tb, d, e)
-		return memo.FormatExpr(e, ot.Flags.ExprFormat)
+		return memo.FormatExpr(e, ot.Flags.ExprFormat, ot.catalog)
 
 	case "save-tables":
 		e, err := ot.SaveTables()
@@ -436,7 +436,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 			d.Fatalf(tb, "%+v", err)
 		}
 		ot.postProcess(tb, d, e)
-		return memo.FormatExpr(e, ot.Flags.ExprFormat)
+		return memo.FormatExpr(e, ot.Flags.ExprFormat, ot.catalog)
 
 	case "stats":
 		result, err := ot.Stats(d)
@@ -880,7 +880,7 @@ func (ot *OptTester) OptSteps() (string, error) {
 			return "", err
 		}
 
-		next = memo.FormatExpr(os.Root(), ot.Flags.ExprFormat)
+		next = memo.FormatExpr(os.Root(), ot.Flags.ExprFormat, ot.catalog)
 
 		// This call comes after setting "next", because we want to output the
 		// final expression, even though there were no diffs from the previous
@@ -1013,14 +1013,14 @@ func (ot *OptTester) ExploreTrace() (string, error) {
 		ot.output("%s\n", et.LastRuleName())
 		ot.separator("=")
 		ot.output("Source expression:\n")
-		ot.indent(memo.FormatExpr(et.SrcExpr(), ot.Flags.ExprFormat))
+		ot.indent(memo.FormatExpr(et.SrcExpr(), ot.Flags.ExprFormat, ot.catalog))
 		newNodes := et.NewExprs()
 		if len(newNodes) == 0 {
 			ot.output("\nNo new expressions.\n")
 		}
 		for i := range newNodes {
 			ot.output("\nNew expression %d of %d:\n", i+1, len(newNodes))
-			ot.indent(memo.FormatExpr(newNodes[i], ot.Flags.ExprFormat))
+			ot.indent(memo.FormatExpr(newNodes[i], ot.Flags.ExprFormat, ot.catalog))
 		}
 	}
 	return ot.builder.String(), nil

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -42,6 +42,11 @@ type Catalog struct {
 	counter    int
 }
 
+type dataSource interface {
+	cat.DataSource
+	fqName() cat.DataSourceName
+}
+
 var _ cat.Catalog = &Catalog{}
 
 // New creates a new empty instance of the test catalog.
@@ -55,7 +60,7 @@ func New() *Catalog {
 				ExplicitSchema:  true,
 				ExplicitCatalog: true,
 			},
-			dataSources: make(map[string]cat.DataSource),
+			dataSources: make(map[string]dataSource),
 		},
 	}
 }
@@ -200,6 +205,13 @@ func (tc *Catalog) IsSuperUser(ctx context.Context, action string) (bool, error)
 // RequireSuperUser is part of the cat.Catalog interface.
 func (tc *Catalog) RequireSuperUser(ctx context.Context, action string) error {
 	return nil
+}
+
+// FullyQualifiedName is part of the cat.Catalog interface.
+func (tc *Catalog) FullyQualifiedName(
+	ctx context.Context, ds cat.DataSource,
+) (cat.DataSourceName, error) {
+	return ds.(dataSource).fqName(), nil
 }
 
 func (tc *Catalog) resolveSchema(toResolve *cat.SchemaName) (cat.Schema, cat.SchemaName, error) {
@@ -401,7 +413,7 @@ type Schema struct {
 	// If Revoked is true, then the user has had privileges on the schema revoked.
 	Revoked bool
 
-	dataSources map[string]cat.DataSource
+	dataSources map[string]dataSource
 }
 
 var _ cat.Schema = &Schema{}
@@ -431,7 +443,7 @@ func (s *Schema) GetDataSourceNames(ctx context.Context) ([]cat.DataSourceName, 
 	sort.Strings(keys)
 	var res []cat.DataSourceName
 	for _, k := range keys {
-		res = append(res, *s.dataSources[k].Name())
+		res = append(res, s.dataSources[k].fqName())
 	}
 	return res, nil
 }
@@ -471,8 +483,13 @@ func (tv *View) Equals(other cat.Object) bool {
 }
 
 // Name is part of the cat.DataSource interface.
-func (tv *View) Name() *cat.DataSourceName {
-	return &tv.ViewName
+func (tv *View) Name() tree.Name {
+	return tv.ViewName.TableName
+}
+
+// fqName is part of the dataSource interface.
+func (tv *View) fqName() cat.DataSourceName {
+	return tv.ViewName
 }
 
 // Query is part of the cat.View interface.
@@ -542,8 +559,13 @@ func (tt *Table) Equals(other cat.Object) bool {
 }
 
 // Name is part of the cat.DataSource interface.
-func (tt *Table) Name() *cat.DataSourceName {
-	return &tt.TabName
+func (tt *Table) Name() tree.Name {
+	return tt.TabName.TableName
+}
+
+// fqName is part of the dataSource interface.
+func (tt *Table) fqName() cat.DataSourceName {
+	return tt.TabName
 }
 
 // IsVirtualTable is part of the cat.Table interface.
@@ -1084,14 +1106,17 @@ func (ts *Sequence) Equals(other cat.Object) bool {
 }
 
 // Name is part of the cat.DataSource interface.
-func (ts *Sequence) Name() *tree.TableName {
-	return &ts.SeqName
+func (ts *Sequence) Name() tree.Name {
+	return ts.SeqName.TableName
 }
 
-// SequenceName is part of the cat.Sequence interface.
-func (ts *Sequence) SequenceName() *tree.TableName {
-	return ts.Name()
+// fqName is part of the dataSource interface.
+func (ts *Sequence) fqName() cat.DataSourceName {
+	return ts.SeqName
 }
+
+// SequenceMarker is part of the cat.Sequence interface.
+func (ts *Sequence) SequenceMarker() {}
 
 func (ts *Sequence) String() string {
 	tp := treeprinter.New()

--- a/pkg/sql/opt/testutils/testcat/testdata/foreign_keys
+++ b/pkg/sql/opt/testutils/testcat/testdata/foreign_keys
@@ -14,7 +14,7 @@ TABLE parent
  ├── p int not null
  ├── INDEX primary
  │    └── p int not null
- └── REFERENCED BY CONSTRAINT fk_p_ref_parent FOREIGN KEY t.public.child (p) REFERENCES t.public.parent (p)
+ └── REFERENCED BY CONSTRAINT fk_p_ref_parent FOREIGN KEY child (p) REFERENCES parent (p)
 
 exec-ddl
 SHOW CREATE child
@@ -27,7 +27,7 @@ TABLE child
  ├── INDEX child_auto_index_fk_p_ref_parent
  │    ├── p int
  │    └── c int not null
- └── CONSTRAINT fk_p_ref_parent FOREIGN KEY t.public.child (p) REFERENCES t.public.parent (p)
+ └── CONSTRAINT fk_p_ref_parent FOREIGN KEY child (p) REFERENCES parent (p)
 
 exec-ddl
 CREATE TABLE parent2 (p INT UNIQUE)
@@ -48,7 +48,7 @@ TABLE parent2
  ├── INDEX parent2_p_key
  │    ├── p int
  │    └── rowid int not null default (unique_rowid()) [hidden] (storing)
- └── REFERENCED BY CONSTRAINT fk_p_ref_parent2 FOREIGN KEY t.public.child2 (p) REFERENCES t.public.parent2 (p)
+ └── REFERENCED BY CONSTRAINT fk_p_ref_parent2 FOREIGN KEY child2 (p) REFERENCES parent2 (p)
 
 exec-ddl
 SHOW CREATE child2
@@ -61,7 +61,7 @@ TABLE child2
  ├── INDEX child2_auto_index_fk_p_ref_parent2
  │    ├── p int
  │    └── c int not null
- └── CONSTRAINT fk_p_ref_parent2 FOREIGN KEY t.public.child2 (p) REFERENCES t.public.parent2 (p)
+ └── CONSTRAINT fk_p_ref_parent2 FOREIGN KEY child2 (p) REFERENCES parent2 (p)
 
 exec-ddl
 CREATE TABLE parent_multicol (p INT, q INT, r INT, PRIMARY KEY (p,q,r))
@@ -98,8 +98,8 @@ TABLE parent_multicol
  │    ├── p int not null
  │    ├── q int not null
  │    └── r int not null
- ├── REFERENCED BY CONSTRAINT fk FOREIGN KEY t.public.child_multicol (p, q, r) REFERENCES t.public.parent_multicol (p, q, r)
- └── REFERENCED BY CONSTRAINT fk FOREIGN KEY t.public.child_multicol_full (p, q, r) REFERENCES t.public.parent_multicol (p, q, r) MATCH FULL
+ ├── REFERENCED BY CONSTRAINT fk FOREIGN KEY child_multicol (p, q, r) REFERENCES parent_multicol (p, q, r)
+ └── REFERENCED BY CONSTRAINT fk FOREIGN KEY child_multicol_full (p, q, r) REFERENCES parent_multicol (p, q, r) MATCH FULL
 
 exec-ddl
 SHOW CREATE child_multicol
@@ -112,7 +112,7 @@ TABLE child_multicol
  │    ├── p int not null
  │    ├── q int not null
  │    └── r int not null
- └── CONSTRAINT fk FOREIGN KEY t.public.child_multicol (p, q, r) REFERENCES t.public.parent_multicol (p, q, r)
+ └── CONSTRAINT fk FOREIGN KEY child_multicol (p, q, r) REFERENCES parent_multicol (p, q, r)
 
 exec-ddl
 SHOW CREATE child_multicol_full
@@ -125,4 +125,4 @@ TABLE child_multicol_full
  │    ├── p int not null
  │    ├── q int not null
  │    └── r int not null
- └── CONSTRAINT fk FOREIGN KEY t.public.child_multicol_full (p, q, r) REFERENCES t.public.parent_multicol (p, q, r) MATCH FULL
+ └── CONSTRAINT fk FOREIGN KEY child_multicol_full (p, q, r) REFERENCES parent_multicol (p, q, r) MATCH FULL

--- a/pkg/sql/opt/xform/memo_format.go
+++ b/pkg/sql/opt/xform/memo_format.go
@@ -268,7 +268,7 @@ func (mf *memoFormatter) formatPrivate(e opt.Expr, physProps *physical.Required)
 
 	// Start by using private expression formatting.
 	m := mf.o.mem
-	nf := memo.MakeExprFmtCtxBuffer(mf.buf, memo.ExprFmtHideAll, m)
+	nf := memo.MakeExprFmtCtxBuffer(mf.buf, memo.ExprFmtHideAll, m, nil /* catalog */)
 	memo.FormatPrivate(&nf, private, physProps)
 
 	// Now append additional information that's useful in the memo case.

--- a/pkg/sql/opt/xform/testdata/coster/virtual-scan
+++ b/pkg/sql/opt/xform/testdata/coster/virtual-scan
@@ -6,7 +6,7 @@ select
  ├── stats: [rows=10, distinct(2)=1, null(2)=0]
  ├── cost: 20.02
  ├── fd: ()-->(2)
- ├── virtual-scan t.information_schema.schemata
+ ├── virtual-scan information_schema.schemata
  │    ├── columns: catalog_name:1(string) schema_name:2(string) default_character_set_name:3(string) sql_path:4(string)
  │    ├── stats: [rows=1000, distinct(2)=100, null(2)=0]
  │    └── cost: 10.01

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -190,15 +190,9 @@ func (oc *optCatalog) ResolveDataSourceByID(
 		}
 		return nil, err
 	}
-	desc := tableLookup.Desc
 
-	dbDesc, err := sqlbase.GetDatabaseDescFromID(ctx, oc.planner.Txn(), desc.ParentID)
-	if err != nil {
-		return nil, err
-	}
-
-	name := tree.MakeTableName(tree.Name(dbDesc.Name), tree.Name(desc.Name))
-	return oc.dataSourceForDesc(ctx, cat.Flags{}, desc, &name)
+	// The name is only used for virtual tables, which can't be looked up by ID.
+	return oc.dataSourceForDesc(ctx, cat.Flags{}, tableLookup.Desc, &tree.TableName{})
 }
 
 func (oc *optCatalog) getDescForObject(o cat.Object) (sqlbase.DescriptorProto, error) {
@@ -246,6 +240,29 @@ func (oc *optCatalog) RequireSuperUser(ctx context.Context, action string) error
 	return oc.planner.RequireSuperUser(ctx, action)
 }
 
+// FullyQualifiedName is part of the cat.Catalog interface.
+func (oc *optCatalog) FullyQualifiedName(
+	ctx context.Context, ds cat.DataSource,
+) (cat.DataSourceName, error) {
+	if vt, ok := ds.(*optVirtualTable); ok {
+		// Virtual tables require special handling, because they can have multiple
+		// effective instances that utilize the same descriptor.
+		return vt.name, nil
+	}
+
+	desc, err := oc.getDescForObject(ds)
+	if err != nil {
+		return cat.DataSourceName{}, err
+	}
+
+	dbID := desc.(*sqlbase.ImmutableTableDescriptor).ParentID
+	dbDesc, err := sqlbase.GetDatabaseDescFromID(ctx, oc.planner.Txn(), dbID)
+	if err != nil {
+		return cat.DataSourceName{}, err
+	}
+	return tree.MakeTableName(tree.Name(dbDesc.Name), tree.Name(desc.GetName())), nil
+}
+
 // dataSourceForDesc returns a data source wrapper for the given descriptor.
 // The wrapper might come from the cache, or it may be created now.
 func (oc *optCatalog) dataSourceForDesc(
@@ -266,10 +283,10 @@ func (oc *optCatalog) dataSourceForDesc(
 
 	switch {
 	case desc.IsView():
-		ds = newOptView(desc, name)
+		ds = newOptView(desc)
 
 	case desc.IsSequence():
-		ds = newOptSequence(desc, name)
+		ds = newOptSequence(desc)
 
 	default:
 		return nil, errors.AssertionFailedf("unexpected table descriptor: %+v", desc)
@@ -319,7 +336,7 @@ func (oc *optCatalog) dataSourceForTable(
 		return ds, nil
 	}
 
-	ds, err := newOptTable(desc, name, tableStats, zoneConfig)
+	ds, err := newOptTable(desc, tableStats, zoneConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -357,22 +374,12 @@ func (oc *optCatalog) getZoneConfig(
 // the cat.Object, cat.DataSource, and cat.View interfaces.
 type optView struct {
 	desc *sqlbase.ImmutableTableDescriptor
-
-	// name is the fully qualified, fully resolved, fully normalized name of
-	// the view.
-	name cat.DataSourceName
 }
 
 var _ cat.View = &optView{}
 
-func newOptView(desc *sqlbase.ImmutableTableDescriptor, name *cat.DataSourceName) *optView {
-	ov := &optView{desc: desc, name: *name}
-
-	// The cat.View interface requires that view names be fully qualified.
-	ov.name.ExplicitSchema = true
-	ov.name.ExplicitCatalog = true
-
-	return ov
+func newOptView(desc *sqlbase.ImmutableTableDescriptor) *optView {
+	return &optView{desc: desc}
 }
 
 // ID is part of the cat.Object interface.
@@ -390,8 +397,8 @@ func (ov *optView) Equals(other cat.Object) bool {
 }
 
 // Name is part of the cat.View interface.
-func (ov *optView) Name() *cat.DataSourceName {
-	return &ov.name
+func (ov *optView) Name() tree.Name {
+	return tree.Name(ov.desc.Name)
 }
 
 // Query is part of the cat.View interface.
@@ -413,23 +420,13 @@ func (ov *optView) ColumnName(i int) tree.Name {
 // implements the cat.Object and cat.DataSource interfaces.
 type optSequence struct {
 	desc *sqlbase.ImmutableTableDescriptor
-
-	// name is the fully qualified, fully resolved, fully normalized name of the
-	// sequence.
-	name cat.DataSourceName
 }
 
 var _ cat.DataSource = &optSequence{}
 var _ cat.Sequence = &optSequence{}
 
-func newOptSequence(desc *sqlbase.ImmutableTableDescriptor, name *cat.DataSourceName) *optSequence {
-	os := &optSequence{desc: desc, name: *name}
-
-	// The cat.Sequence interface requires that table names be fully qualified.
-	os.name.ExplicitSchema = true
-	os.name.ExplicitCatalog = true
-
-	return os
+func newOptSequence(desc *sqlbase.ImmutableTableDescriptor) *optSequence {
+	return &optSequence{desc: desc}
 }
 
 // ID is part of the cat.Object interface.
@@ -446,24 +443,18 @@ func (os *optSequence) Equals(other cat.Object) bool {
 	return os.desc.ID == otherSeq.desc.ID && os.desc.Version == otherSeq.desc.Version
 }
 
-// Name is part of the cat.DataSource interface.
-func (os *optSequence) Name() *cat.DataSourceName {
-	return &os.name
+// Name is part of the cat.Sequence interface.
+func (os *optSequence) Name() tree.Name {
+	return tree.Name(os.desc.Name)
 }
 
-// SequenceName is part of the cat.Sequence interface.
-func (os *optSequence) SequenceName() *tree.TableName {
-	return os.Name()
-}
+// SequenceMarker is part of the cat.Sequence interface.
+func (os *optSequence) SequenceMarker() {}
 
 // optTable is a wrapper around sqlbase.ImmutableTableDescriptor that caches
 // index wrappers and maintains a ColumnID => Column mapping for fast lookup.
 type optTable struct {
 	desc *sqlbase.ImmutableTableDescriptor
-
-	// name is the fully qualified, fully resolved, fully normalized name of the
-	// table.
-	name cat.DataSourceName
 
 	// indexes are the inlined wrappers for the table's primary and secondary
 	// indexes.
@@ -500,21 +491,13 @@ type optTable struct {
 var _ cat.Table = &optTable{}
 
 func newOptTable(
-	desc *sqlbase.ImmutableTableDescriptor,
-	name *cat.DataSourceName,
-	stats []*stats.TableStatistic,
-	tblZone *config.ZoneConfig,
+	desc *sqlbase.ImmutableTableDescriptor, stats []*stats.TableStatistic, tblZone *config.ZoneConfig,
 ) (*optTable, error) {
 	ot := &optTable{
 		desc:     desc,
-		name:     *name,
 		rawStats: stats,
 		zone:     tblZone,
 	}
-
-	// The cat.Table interface requires that table names be fully qualified.
-	ot.name.ExplicitSchema = true
-	ot.name.ExplicitCatalog = true
 
 	// Create the table's column mapping from sqlbase.ColumnID to column ordinal.
 	ot.colMap = make(map[sqlbase.ColumnID]int, ot.DeletableColumnCount())
@@ -666,9 +649,9 @@ func (ot *optTable) Equals(other cat.Object) bool {
 	return true
 }
 
-// Name is part of the cat.DataSource interface.
-func (ot *optTable) Name() *cat.DataSourceName {
-	return &ot.name
+// Name is part of the cat.Table interface.
+func (ot *optTable) Name() tree.Name {
+	return tree.Name(ot.desc.Name)
 }
 
 // IsVirtualTable is part of the cat.Table interface.
@@ -1276,7 +1259,6 @@ func newOptVirtualTable(
 		name: *name,
 	}
 
-	// The cat.Table interface requires that table names be fully qualified.
 	ot.name.ExplicitSchema = true
 	ot.name.ExplicitCatalog = true
 
@@ -1307,9 +1289,9 @@ func (ot *optVirtualTable) Equals(other cat.Object) bool {
 	return true
 }
 
-// Name is part of the cat.DataSource interface.
-func (ot *optVirtualTable) Name() *cat.DataSourceName {
-	return &ot.name
+// Name is part of the cat.Table interface.
+func (ot *optVirtualTable) Name() tree.Name {
+	return ot.name.TableName
 }
 
 // IsVirtualTable is part of the cat.Table interface.

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -126,7 +126,7 @@ func (ef *execFactory) ConstructScan(
 
 // ConstructVirtualScan is part of the exec.Factory interface.
 func (ef *execFactory) ConstructVirtualScan(table cat.Table) (exec.Node, error) {
-	tn := table.Name()
+	tn := &table.(*optVirtualTable).name
 	virtual, err := ef.planner.getVirtualTabler().getVirtualTableEntry(tn)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -506,7 +506,7 @@ func (p *planner) getTableAndIndex(
 	catalog.init(p)
 	catalog.reset()
 
-	idx, err := cat.ResolveTableIndex(
+	idx, _, err := cat.ResolveTableIndex(
 		ctx, &catalog, cat.Flags{AvoidDescriptorCaches: true}, tableWithIndex,
 	)
 	if err != nil {


### PR DESCRIPTION
#### opt: require passing table aliases to the metadata

The current code allows adding a table to the metadata without an
alias (in which case the fully qualified name from the catalog object
is used). We want to reduce the reliance on fully qualified names from
objects, as they are expensive to obtain in certain cases (like
lookup-by-id); in addition, it is preferable to pass the table name
that has the correct `ExplicitCatalog/ExplicitSchema` flags.

This change modifies the API to always require a table alias. The
opttest output for some statements is now improved.

Release note: None

#### opt: remove fully qualified names from catalog

Currently catalog objects store fully qualified names and can return
them via the `Name()` method. This is a conceptual problem: the fully
qualified path can change without the object changing (by renaming a
database). There is also a practical problem: when looking up a table
by ID (which happens for FK checks), we have to look up the database
descriptor just to get the fully qualified name.

This commit makes the following changes to address these issues:
 - `cat.DataSource.Name()` now only returns the unqualified name
 - catalog objects no longer store a name (except virtual tables)
 - the catalog now implements a `FullyQualifiedName` method which
   retrieves the fully qualified name. This is only used for
   formatting purposes (when the flag to fully qualify everything is
   used).

In various places in the code we were using the fully qualified name
just for convenience, causing fully qualified names to be shown in some
cases (which explains many of the diffs in the testfiles).

Release note: None
