### PR TITLE
exec: wait for internal goroutine completion in UnorderedSynchronizer

### DIFF
--- a/pkg/sql/exec/testutils.go
+++ b/pkg/sql/exec/testutils.go
@@ -100,3 +100,17 @@ func (s *RepeatableBatchSource) ResetBatchesToReturn(b int) {
 	s.batchesToReturn = b
 	s.batchesReturned = 0
 }
+
+// CallbackOperator is a testing utility struct that delegates Next calls to a
+// callback provided by the user.
+type CallbackOperator struct {
+	NextCb func(ctx context.Context) coldata.Batch
+}
+
+// Init is part of the Operator interface.
+func (o *CallbackOperator) Init() {}
+
+// Next is part of the Operator interface.
+func (o *CallbackOperator) Next(ctx context.Context) coldata.Batch {
+	return o.NextCb(ctx)
+}


### PR DESCRIPTION
Previously, when an error was encountered from one of its input
goroutines, the UnorderedSynchronizer would cancel the other inputs but
not wait for completion. This could lead to race conditions due to
assumption by calling code that these internal goroutines had completed
on an error or zero-length batch received from Next.

Release note: None

Fixes #38757