### PR TITLE
workload/tpcc: perform checks atomically, optionally historically and separately

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all.go
+++ b/pkg/ccl/workloadccl/allccl/all.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/workload/rand"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/sqlsmith"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/tpcc"
+	_ "github.com/cockroachdb/cockroach/pkg/workload/tpccchecks"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/tpcds"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/tpch"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/ycsb"

--- a/pkg/workload/tpcc/checks.go
+++ b/pkg/workload/tpcc/checks.go
@@ -16,19 +16,53 @@ import (
 	"github.com/pkg/errors"
 )
 
-func check3321(db *gosql.DB) error {
+type check struct {
+	name string
+	// If asOfSystemTime is non-empty it will be used to perform the check as
+	// a historical query using the provided value as the argument to the
+	// AS OF SYSTEM TIME clause.
+	f         func(db *gosql.DB, asOfSystemTime string) error
+	expensive bool
+}
+
+func allChecks() []check {
+	return []check{
+		{"3.3.2.1", check3321, false},
+		{"3.3.2.2", check3322, false},
+		{"3.3.2.3", check3323, false},
+		{"3.3.2.4", check3324, false},
+		{"3.3.2.5", check3325, false},
+		{"3.3.2.6", check3326, true},
+		{"3.3.2.7", check3327, false},
+		{"3.3.2.8", check3328, false},
+		{"3.3.2.9", check3329, false},
+	}
+}
+
+func check3321(db *gosql.DB, asOfSystemTime string) error {
 	// 3.3.2.1 Entries in the WAREHOUSE and DISTRICT tables must satisfy the relationship:
 	// W_YTD = sum (D_YTD)
-
-	row := db.QueryRow(`
-SELECT count(*)
-FROM warehouse
-FULL OUTER JOIN
-(SELECT d_w_id, sum(d_ytd) as sum_d_ytd FROM district GROUP BY d_w_id)
-ON (w_id = d_w_id)
-WHERE w_ytd != sum_d_ytd
+	txn, err := beginAsOfSystemTime(db, asOfSystemTime)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = txn.Rollback() }()
+	row := txn.QueryRow(`
+SELECT
+    count(*)
+FROM
+    warehouse
+    FULL JOIN (
+            SELECT
+                d_w_id, sum(d_ytd) AS sum_d_ytd
+            FROM
+                district
+            GROUP BY
+                d_w_id
+        ) ON w_id = d_w_id
+WHERE
+    w_ytd != sum_d_ytd
 `)
-
 	var i int
 	if err := row.Scan(&i); err != nil {
 		return err
@@ -41,23 +75,52 @@ WHERE w_ytd != sum_d_ytd
 	return nil
 }
 
-func check3322(db *gosql.DB) error {
+func check3322(db *gosql.DB, asOfSystemTime string) (err error) {
 	// Entries in the DISTRICT, ORDER, and NEW-ORDER tables must satisfy the relationship:
 	// D_NEXT_O_ID - 1 = max(O_ID) = max(NO_O_ID)
-
-	districtRows, err := db.Query("SELECT d_next_o_id FROM district ORDER BY d_w_id, d_id")
+	txn, err := beginAsOfSystemTime(db, asOfSystemTime)
 	if err != nil {
 		return err
 	}
-	newOrderRows, err := db.Query(`
-SELECT max(no_o_id) FROM new_order GROUP BY no_d_id, no_w_id ORDER BY no_w_id, no_d_id
-`)
+	ts, err := selectTimestamp(txn)
+	_ = txn.Rollback() // close the txn now that we're done with it
 	if err != nil {
 		return err
 	}
-	orderRows, err := db.Query(`
-SELECT max(o_id) FROM "order" GROUP BY o_d_id, o_w_id ORDER BY o_w_id, o_d_id
-`)
+	districtRowsQuery := `
+SELECT
+    d_next_o_id
+FROM
+    district AS OF SYSTEM TIME '` + ts + `'
+ORDER BY
+    d_w_id, d_id`
+	districtRows, err := db.Query(districtRowsQuery)
+	if err != nil {
+		return err
+	}
+	newOrderQuery := `
+SELECT
+    max(no_o_id)
+FROM
+    new_order AS OF SYSTEM TIME '` + ts + `'
+GROUP BY
+    no_d_id, no_w_id
+ORDER BY
+    no_w_id, no_d_id;`
+	newOrderRows, err := db.Query(newOrderQuery)
+	if err != nil {
+		return err
+	}
+	orderRowsQuery := `
+SELECT
+    max(o_id)
+FROM
+    "order" AS OF SYSTEM TIME '` + ts + `'
+GROUP BY
+    o_d_id, o_w_id
+ORDER BY
+    o_w_id, o_d_id`
+	orderRows, err := db.Query(orderRowsQuery)
 	if err != nil {
 		return err
 	}
@@ -100,14 +163,27 @@ SELECT max(o_id) FROM "order" GROUP BY o_d_id, o_w_id ORDER BY o_w_id, o_d_id
 	return nil
 }
 
-func check3323(db *gosql.DB) error {
+func check3323(db *gosql.DB, asOfSystemTime string) error {
 	// max(NO_O_ID) - min(NO_O_ID) + 1 = # of rows in new_order for each warehouse/district
-	row := db.QueryRow(`
-SELECT count(*) FROM
- (SELECT max(no_o_id) - min(no_o_id) - count(*) AS nod FROM new_order
-  GROUP BY no_w_id, no_d_id)
- WHERE nod != -1
-`)
+	txn, err := beginAsOfSystemTime(db, asOfSystemTime)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = txn.Rollback() }()
+	row := txn.QueryRow(`
+SELECT
+    count(*)
+FROM
+    (
+        SELECT
+            max(no_o_id) - min(no_o_id) - count(*) AS nod
+        FROM
+            new_order
+        GROUP BY
+            no_w_id, no_d_id
+    )
+WHERE
+    nod != -1`)
 
 	var i int
 	if err := row.Scan(&i); err != nil {
@@ -121,18 +197,39 @@ SELECT count(*) FROM
 	return nil
 }
 
-func check3324(db *gosql.DB) error {
+func check3324(db *gosql.DB, asOfSystemTime string) (err error) {
 	// sum(O_OL_CNT) = [number of rows in the ORDER-LINE table for this district]
-
+	txn, err := beginAsOfSystemTime(db, asOfSystemTime)
+	if err != nil {
+		return err
+	}
+	// Select a timestamp which will be used for the concurrent queries below.
+	ts, err := selectTimestamp(txn)
+	_ = txn.Rollback() // close txn now that we're done with it.
+	if err != nil {
+		return err
+	}
 	leftRows, err := db.Query(`
-SELECT sum(o_ol_cnt) FROM "order" GROUP BY o_w_id, o_d_id ORDER BY o_w_id, o_d_id
-`)
+SELECT
+    sum(o_ol_cnt)
+FROM
+    "order" AS OF SYSTEM TIME '` + ts + `'
+GROUP BY
+    o_w_id, o_d_id
+ORDER BY
+    o_w_id, o_d_id`)
 	if err != nil {
 		return err
 	}
 	rightRows, err := db.Query(`
-SELECT count(*) FROM order_line GROUP BY ol_w_id, ol_d_id ORDER BY ol_w_id, ol_d_id
-`)
+SELECT
+    count(*)
+FROM
+    order_line AS OF SYSTEM TIME '` + ts + `'
+GROUP BY
+    ol_w_id, ol_d_id
+ORDER BY
+    ol_w_id, ol_d_id`)
 	if err != nil {
 		return err
 	}
@@ -162,47 +259,53 @@ SELECT count(*) FROM order_line GROUP BY ol_w_id, ol_d_id ORDER BY ol_w_id, ol_d
 	return rightRows.Close()
 }
 
-func check3325(db *gosql.DB) error {
+func check3325(db *gosql.DB, asOfSystemTime string) error {
 	// We want the symmetric difference between the sets:
 	// (SELECT no_w_id, no_d_id, no_o_id FROM new_order)
 	// (SELECT o_w_id, o_d_id, o_id FROM order@primary WHERE o_carrier_id IS NULL)
 	// We achieve this by two EXCEPT ALL queries.
-
-	firstQuery, err := db.Query(`
+	txn, err := beginAsOfSystemTime(db, asOfSystemTime)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = txn.Rollback() }()
+	firstQuery, err := txn.Query(`
 (SELECT no_w_id, no_d_id, no_o_id FROM new_order)
 EXCEPT ALL
 (SELECT o_w_id, o_d_id, o_id FROM "order"@primary WHERE o_carrier_id IS NULL)`)
 	if err != nil {
 		return err
 	}
-	secondQuery, err := db.Query(`
+	if firstQuery.Next() {
+		return errors.Errorf("left EXCEPT right returned nonzero results.")
+	}
+	if err := firstQuery.Close(); err != nil {
+		return err
+	}
+	secondQuery, err := txn.Query(`
 (SELECT o_w_id, o_d_id, o_id FROM "order"@primary WHERE o_carrier_id IS NULL)
 EXCEPT ALL
 (SELECT no_w_id, no_d_id, no_o_id FROM new_order)`)
 	if err != nil {
 		return err
 	}
-
-	if firstQuery.Next() {
-		return errors.Errorf("left EXCEPT right returned nonzero results.")
-	}
-
 	if secondQuery.Next() {
 		return errors.Errorf("right EXCEPT left returned nonzero results.")
-	}
-
-	if err := firstQuery.Close(); err != nil {
-		return err
 	}
 	return secondQuery.Close()
 }
 
-func check3326(db *gosql.DB) error {
+func check3326(db *gosql.DB, asOfSystemTime string) (err error) {
 	// For any row in the ORDER table, O_OL_CNT must equal the number of rows
 	// in the ORDER-LINE table for the corresponding order defined by
 	// (O_W_ID, O_D_ID, O_ID) = (OL_W_ID, OL_D_ID, OL_O_ID).
+	txn, err := beginAsOfSystemTime(db, asOfSystemTime)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = txn.Rollback() }()
 
-	firstQuery, err := db.Query(`
+	firstQuery, err := txn.Query(`
 (SELECT o_w_id, o_d_id, o_id, o_ol_cnt FROM "order"
   ORDER BY o_w_id, o_d_id, o_id DESC)
 EXCEPT ALL
@@ -212,7 +315,13 @@ EXCEPT ALL
 	if err != nil {
 		return err
 	}
-	secondQuery, err := db.Query(`
+	if firstQuery.Next() {
+		return errors.Errorf("left EXCEPT right returned nonzero results")
+	}
+	if err := firstQuery.Close(); err != nil {
+		return err
+	}
+	secondQuery, err := txn.Query(`
 (SELECT ol_w_id, ol_d_id, ol_o_id, count(*) FROM order_line
   GROUP BY (ol_w_id, ol_d_id, ol_o_id) ORDER BY ol_w_id, ol_d_id, ol_o_id DESC)
 EXCEPT ALL
@@ -222,27 +331,23 @@ EXCEPT ALL
 		return err
 	}
 
-	if firstQuery.Next() {
-		return errors.Errorf("left EXCEPT right returned nonzero results")
-	}
-
 	if secondQuery.Next() {
 		return errors.Errorf("right EXCEPT left returned nonzero results")
-	}
-
-	if err := firstQuery.Close(); err != nil {
-		return err
 	}
 	return secondQuery.Close()
 }
 
-func check3327(db *gosql.DB) error {
+func check3327(db *gosql.DB, asOfSystemTime string) error {
 	// For any row in the ORDER-LINE table, OL_DELIVERY_D is set to a null
 	// date/time if and only if the corresponding row in the ORDER table defined
 	// by (O_W_ID, O_D_ID, O_ID) = (OL_W_ID, OL_D_ID, OL_O_ID) has
 	// O_CARRIER_ID set to a null value.
-
-	row := db.QueryRow(`
+	txn, err := beginAsOfSystemTime(db, asOfSystemTime)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = txn.Rollback() }()
+	row := txn.QueryRow(`
 SELECT count(*) FROM
   (SELECT o_w_id, o_d_id, o_id FROM "order" WHERE o_carrier_id IS NULL)
 FULL OUTER JOIN
@@ -263,11 +368,15 @@ WHERE ol_o_id IS NULL OR o_id IS NULL
 	return nil
 }
 
-func check3328(db *gosql.DB) error {
+func check3328(db *gosql.DB, asOfSystemTime string) error {
 	// Entries in the WAREHOUSE and HISTORY tables must satisfy the relationship:
 	// W_YTD = SUM(H_AMOUNT) for each warehouse defined by (W_ID = H _W_ID).
-
-	row := db.QueryRow(`
+	txn, err := beginAsOfSystemTime(db, asOfSystemTime)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = txn.Rollback() }()
+	row := txn.QueryRow(`
 SELECT count(*) FROM
   (SELECT w_id, w_ytd, sum FROM warehouse
   JOIN
@@ -289,11 +398,15 @@ SELECT count(*) FROM
 	return nil
 }
 
-func check3329(db *gosql.DB) error {
+func check3329(db *gosql.DB, asOfSystemTime string) error {
 	// Entries in the DISTRICT and HISTORY tables must satisfy the relationship:
 	// D_YTD=SUM(H_AMOUNT) for each district defined by (D_W_ID,D_ID)=(H_W_ID,H_D_ID)
-
-	row := db.QueryRow(`
+	txn, err := beginAsOfSystemTime(db, asOfSystemTime)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = txn.Rollback() }()
+	row := txn.QueryRow(`
 SELECT count(*) FROM
   (SELECT d_id, d_ytd, sum FROM district
   JOIN
@@ -315,22 +428,28 @@ SELECT count(*) FROM
 	return nil
 }
 
-type check struct {
-	name      string
-	f         func(db *gosql.DB) error
-	expensive bool
+// beginAsOfSystemTime starts a transaction and optionally sets it to occur at
+// the provided asOfSystemTime. If asOfSystemTime is empty, the transaction will
+// not be historical. The asOfSystemTime value will be used as literal SQL in a
+// SET TRANSACTION AS OF SYSTEM TIME clause.
+func beginAsOfSystemTime(db *gosql.DB, asOfSystemTime string) (txn *gosql.Tx, err error) {
+	txn, err = db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	if asOfSystemTime != "" {
+		_, err = txn.Exec("SET TRANSACTION AS OF SYSTEM TIME " + asOfSystemTime)
+		if err != nil {
+			_ = txn.Rollback()
+			return nil, err
+		}
+	}
+	return txn, nil
 }
 
-func allChecks() []check {
-	return []check{
-		{"3.3.2.1", check3321, false},
-		{"3.3.2.2", check3322, false},
-		{"3.3.2.3", check3323, false},
-		{"3.3.2.4", check3324, false},
-		{"3.3.2.5", check3325, false},
-		{"3.3.2.6", check3326, true},
-		{"3.3.2.7", check3327, false},
-		{"3.3.2.8", check3328, false},
-		{"3.3.2.9", check3329, false},
-	}
+// selectTimestamp retreives an unqouted string literal of a decimal value
+// representing the hlc timestamp of the provided txn.
+func selectTimestamp(txn *gosql.Tx) (ts string, err error) {
+	err = txn.QueryRow("SELECT cluster_logical_timestamp()::string").Scan(&ts)
+	return ts, err
 }

--- a/pkg/workload/tpcc/checks.go
+++ b/pkg/workload/tpcc/checks.go
@@ -16,17 +16,19 @@ import (
 	"github.com/pkg/errors"
 )
 
-type check struct {
-	name string
+// Check is a tpcc consistency check.
+type Check struct {
+	Name string
 	// If asOfSystemTime is non-empty it will be used to perform the check as
 	// a historical query using the provided value as the argument to the
 	// AS OF SYSTEM TIME clause.
-	f         func(db *gosql.DB, asOfSystemTime string) error
-	expensive bool
+	Fn        func(db *gosql.DB, asOfSystemTime string) error
+	Expensive bool
 }
 
-func allChecks() []check {
-	return []check{
+// AllChecks returns a slice of all of the checks.
+func AllChecks() []Check {
+	return []Check{
 		{"3.3.2.1", check3321, false},
 		{"3.3.2.2", check3322, false},
 		{"3.3.2.3", check3323, false},

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -289,15 +289,15 @@ func (w *tpcc) Hooks() workload.Hooks {
 			return nil
 		},
 		CheckConsistency: func(ctx context.Context, db *gosql.DB) error {
-			for _, check := range allChecks() {
-				if !w.expensiveChecks && check.expensive {
+			for _, check := range AllChecks() {
+				if !w.expensiveChecks && check.Expensive {
 					continue
 				}
 				start := timeutil.Now()
-				err := check.f(db, "" /* asOfSystemTime */)
-				log.Infof(ctx, `check %s took %s`, check.name, timeutil.Since(start))
+				err := check.Fn(db, "" /* asOfSystemTime */)
+				log.Infof(ctx, `check %s took %s`, check.Name, timeutil.Since(start))
 				if err != nil {
-					return errors.Wrapf(err, `check failed: %s`, check.name)
+					return errors.Wrapf(err, `check failed: %s`, check.Name)
 				}
 			}
 			return nil

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -289,14 +289,12 @@ func (w *tpcc) Hooks() workload.Hooks {
 			return nil
 		},
 		CheckConsistency: func(ctx context.Context, db *gosql.DB) error {
-			// TODO(arjun): We should run each test in a single transaction as
-			// currently we have to shut down load before running the checks.
 			for _, check := range allChecks() {
 				if !w.expensiveChecks && check.expensive {
 					continue
 				}
 				start := timeutil.Now()
-				err := check.f(db)
+				err := check.f(db, "" /* asOfSystemTime */)
 				log.Infof(ctx, `check %s took %s`, check.name, timeutil.Since(start))
 				if err != nil {
 					return errors.Wrapf(err, `check failed: %s`, check.name)

--- a/pkg/workload/tpccchecks/checks_generator.go
+++ b/pkg/workload/tpccchecks/checks_generator.go
@@ -1,0 +1,183 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tpcc
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"math/rand"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
+	"github.com/cockroachdb/cockroach/pkg/workload/tpcc"
+	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
+)
+
+var tpccChecksMeta = workload.Meta{
+	Name:        `tpcc-checks`,
+	Description: `tpcc-checks runs the TPC-C consistency checks as a workload.`,
+	Details: `It is primarily intended as a tool to create an overload scenario.
+An --as-of flag is exposed to prevent the work from interfering with a
+foreground TPC-C workload`,
+	Version: `1.0.0`,
+	New: func() workload.Generator {
+		g := &tpccChecks{}
+		g.flags.FlagSet = pflag.NewFlagSet(`tpcc`, pflag.ContinueOnError)
+		g.flags.Meta = map[string]workload.FlagMeta{
+			`db`:          {RuntimeOnly: true},
+			`concurrency`: {RuntimeOnly: true},
+			`as-of`:       {RuntimeOnly: true},
+		}
+		g.flags.IntVar(&g.concurrency, `concurrency`, 1,
+			`Number of concurrent workers. Defaults to 1.`,
+		)
+		g.flags.StringVar(&g.asOfSystemTime, "as-of", "",
+			"Timestamp at which the query should be run."+
+				" If non-empty the provided value will be used as the expression in an"+
+				" AS OF SYSTEM TIME CLAUSE for all checks.")
+		checkNames := func() (checkNames []string) {
+			for _, c := range tpcc.AllChecks() {
+				checkNames = append(checkNames, c.Name)
+			}
+			return checkNames
+		}()
+		g.flags.StringSliceVar(&g.checks, "checks", checkNames,
+			"Name of checks to be run.")
+		g.connFlags = workload.NewConnFlags(&g.flags)
+		{ // Set the dbOveride to default to "tpcc".
+			dbOverrideFlag := g.flags.Lookup(`db`)
+			dbOverrideFlag.DefValue = `tpcc`
+			if err := dbOverrideFlag.Value.Set(`tpcc`); err != nil {
+				panic(err)
+			}
+		}
+		return g
+	},
+}
+
+func (w *tpccChecks) Flags() workload.Flags {
+	return w.flags
+}
+
+func init() {
+	workload.Register(tpccChecksMeta)
+}
+
+type tpccChecks struct {
+	flags     workload.Flags
+	connFlags *workload.ConnFlags
+
+	asOfSystemTime string
+	checks         []string
+	concurrency    int
+}
+
+// The tables should already exist, if they do not an error will occur later.
+func (*tpccChecks) Tables() []workload.Table {
+	return nil
+}
+
+func (*tpccChecks) Meta() workload.Meta {
+	return tpccChecksMeta
+}
+
+// Ops implements the Opser interface.
+func (w *tpccChecks) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
+	sqlDatabase, err := workload.SanitizeUrls(w, w.flags.Lookup("db").Value.String(), urls)
+	if err != nil {
+		return workload.QueryLoad{}, fmt.Errorf("%v", err)
+	}
+	dbs := make([]*gosql.DB, len(urls))
+	for i, url := range urls {
+		dbs[i], err = gosql.Open(`cockroach`, url)
+		if err != nil {
+			return workload.QueryLoad{}, errors.Wrapf(err, "failed to dial %s", url)
+		}
+		// Set the maximum number of open connections to 3x the concurrency because
+		// that's the maximum number of connections used by any check at once.
+		dbs[i].SetMaxOpenConns(3 * w.concurrency)
+		dbs[i].SetMaxIdleConns(3 * w.concurrency)
+	}
+	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
+	ql.WorkerFns = make([]func(context.Context) error, w.concurrency)
+	checks, err := filterChecks(tpcc.AllChecks(), w.checks)
+	if err != nil {
+		return workload.QueryLoad{}, err
+	}
+	for i := range ql.WorkerFns {
+		worker := newCheckWorker(dbs, checks, reg.GetHandle(), w.asOfSystemTime)
+		ql.WorkerFns[i] = worker.run
+	}
+	// Preregister all of the histograms so they always print.
+	for _, c := range checks {
+		reg.GetHandle().Get(c.Name)
+	}
+	return ql, nil
+}
+
+type checkWorker struct {
+	dbs            []*gosql.DB
+	checks         []tpcc.Check
+	histograms     *histogram.Histograms
+	asOfSystemTime string
+	dbPerm         []int
+	checkPerm      []int
+	i              int
+}
+
+func newCheckWorker(
+	dbs []*gosql.DB, checks []tpcc.Check, histograms *histogram.Histograms, asOfSystemTime string,
+) *checkWorker {
+	return &checkWorker{
+		dbs:            dbs,
+		checks:         checks,
+		histograms:     histograms,
+		asOfSystemTime: asOfSystemTime,
+		dbPerm:         rand.Perm(len(dbs)),
+		checkPerm:      rand.Perm(len(checks)),
+	}
+}
+
+func (w *checkWorker) run(ctx context.Context) error {
+	defer func() { w.i++ }()
+	c := w.checks[w.checkPerm[w.i%len(w.checks)]]
+	db := w.dbs[w.dbPerm[w.i%len(w.dbs)]]
+	start := timeutil.Now()
+	if err := c.Fn(db, w.asOfSystemTime); err != nil {
+		return errors.Wrapf(err, "failed check %s", c.Name)
+	}
+	w.histograms.Get(c.Name).Record(timeutil.Since(start))
+	return nil
+}
+
+// filterChecks removes all elements from checks which do not have their name
+// in toRun. An error is returned if any elements of toRun do not exist in
+// checks. The checks slice is modified in place and returned.
+func filterChecks(checks []tpcc.Check, toRun []string) ([]tpcc.Check, error) {
+	toRunSet := make(map[string]struct{}, len(toRun))
+	for _, s := range toRun {
+		toRunSet[s] = struct{}{}
+	}
+	filtered := checks[:0]
+	for _, c := range checks {
+		if _, exists := toRunSet[c.Name]; exists {
+			filtered = append(filtered, c)
+			delete(toRunSet, c.Name)
+		}
+	}
+	if len(toRunSet) > 0 {
+		return nil, fmt.Errorf("cannot run checks %v which do not exist", toRun)
+	}
+	return filtered, nil
+}


### PR DESCRIPTION
This PR comes in two commits. The first makes the TPC-C checks each occur atomically either by using a single transaction or by selecting a timestamp and running all statements at that timestamp using AOST. In addition that commit allows the checks to be run historically.

The second commit adds a workload Generator to run the checks as a stand-alone workload.