### PR TITLE
roachtest: Add tpcc1k test to identify long running schema change txns.

### DIFF
--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -62,6 +62,7 @@ func registerTests(r *testRegistry) {
 	registerSchemaChangeKV(r)
 	registerSchemaChangeIndexTPCC100(r)
 	registerSchemaChangeIndexTPCC1000(r)
+	registerMixedSchemaChangesTPCC1000(r)
 	registerSchemaChangeInvertedIndex(r)
 	registerScrubAllChecksTPCC(r)
 	registerScrubIndexOnlyTPCC(r)

--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -397,6 +397,47 @@ func makeSchemaChangeBulkIngestTest(numNodes, numRows int, length time.Duration)
 	}
 }
 
+func registerMixedSchemaChangesTPCC1000(r *testRegistry) {
+	r.Add(makeMixedSchemaChanges(makeClusterSpec(5, cpu(16)), 1000, time.Hour*3))
+}
+
+func makeMixedSchemaChanges(spec clusterSpec, warehouses int, length time.Duration) testSpec {
+	return testSpec{
+		Name:    "schemachange/mixed/tpcc",
+		Cluster: spec,
+		Timeout: length * 3,
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			runTPCC(ctx, t, c, tpccOptions{
+				Warehouses: warehouses,
+				Extra:      "--wait=false --tolerate-errors",
+				During: func(ctx context.Context) error {
+					return runAndLogStmts(ctx, t, c, "mixed-schema-changes", []string{
+						`CREATE INDEX ON tpcc.order (o_carrier_id);`,
+
+						`CREATE TABLE tpcc.customerpks (c_w_id INT, c_d_id INT, c_id INT, FOREIGN KEY (c_w_id, c_d_id, c_id) REFERENCES tpcc.customer (c_w_id, c_d_id, c_id));`,
+						`CREATE TABLE tpcc.orderpks (o_w_id, o_d_id, o_id, PRIMARY KEY(o_w_id, o_d_id, o_id)) AS select o_w_id, o_d_id, o_id from tpcc.order;`,
+
+						`ALTER TABLE tpcc.order ADD COLUMN orderdiscount INT DEFAULT 0;`,
+						`ALTER TABLE tpcc.order ADD CONSTRAINT nodiscount CHECK (orderdiscount = 0);`,
+
+						`ALTER TABLE tpcc.orderpks ADD CONSTRAINT warehouse_id FOREIGN KEY (o_w_id) REFERENCES tpcc.warehouse (w_id);`,
+
+						// The FK constraint on tpcc.district referencing tpcc.warehouse is
+						// unvalidated, thus this operation will not be a noop.
+						`ALTER TABLE tpcc.district VALIDATE CONSTRAINT fk_d_w_id_ref_warehouse;`,
+
+						`ALTER TABLE tpcc.orderpks RENAME TO tpcc.readytodrop;`,
+						`TRUNCATE TABLE tpcc.readytodrop CASCADE;`,
+						`DROP TABLE tpcc.readytodrop CASCADE;`,
+					})
+				},
+				Duration: length,
+			})
+		},
+		MinVersion: "v19.1.0",
+	}
+}
+
 func runAndLogStmts(ctx context.Context, t *test, c *cluster, prefix string, stmts []string) error {
 	db := c.Conn(ctx, 1)
 	defer db.Close()


### PR DESCRIPTION
This change adds a roachtest which spins up a 5 node, 16 cpu cluster
with a tpcc-1k workload, and runs the schema changes outlined in #37083.
The need for this test arises to have a single source of truth for long
running schema change txns, and the impact of lowering the closed ts
interval.