### PR TITLE
exec: cancel the flow context when materializer is done

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -16,6 +16,7 @@ import (
 	"math"
 	"reflect"
 	"sync"
+	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
@@ -79,6 +80,7 @@ func wrapRowSource(
 			nil, /* output */
 			nil, /* metadataSourcesQueue */
 			nil, /* outputStatsToTrace */
+			nil, /* cancelFlow */
 		)
 		if err != nil {
 			return nil, err
@@ -964,6 +966,8 @@ type flowCreatorHelper interface {
 	accumulateAsyncComponent(runFn)
 	// addMaterializer adds a materializer to the flow.
 	addMaterializer(*materializer)
+	// getCancelFlowFn returns a flow cancellation function.
+	getCancelFlowFn() context.CancelFunc
 }
 
 // vectorizedFlowCreator performs all the setup of vectorized flows. Depending
@@ -981,6 +985,11 @@ type vectorizedFlowCreator struct {
 	syncFlowConsumer               RowReceiver
 	nodeDialer                     *nodedialer.Dialer
 	flowID                         distsqlpb.FlowID
+
+	// numOutboxes counts how many exec.Outboxes have been set up on this node.
+	// It must be accessed atomically.
+	numOutboxes       int32
+	materializerAdded bool
 }
 
 func newVectorizedFlowCreator(
@@ -1014,8 +1023,21 @@ func (s *vectorizedFlowCreator) setupRemoteOutputStream(
 	if err != nil {
 		return err
 	}
+	atomic.AddInt32(&s.numOutboxes, 1)
 	run := func(ctx context.Context, cancelFn context.CancelFunc) {
 		outbox.Run(ctx, s.nodeDialer, stream.TargetNodeID, s.flowID, stream.StreamID, cancelFn)
+		atomic.AddInt32(&s.numOutboxes, -1)
+		// When the last Outbox on this node exits, we want to make sure that
+		// everything is shutdown; namely, we need to call cancelFn if:
+		// - it is the last Outbox
+		// - there is no root materializer on this node (if it were, it would take
+		// care of the cancellation itself)
+		// - cancelFn is non-nil (it can be nil in tests).
+		// Calling cancelFn will cancel the context that all infrastructure on this
+		// node is listening on, so it will shut everything down.
+		if atomic.LoadInt32(&s.numOutboxes) == 0 && !s.materializerAdded && cancelFn != nil {
+			cancelFn()
+		}
 	}
 	s.accumulateAsyncComponent(run)
 	return nil
@@ -1267,6 +1289,7 @@ func (s *vectorizedFlowCreator) setupOutput(
 				// further appends without overwriting.
 				append([]distsqlpb.MetadataSource(nil), metadataSourcesQueue...),
 				outputStatsToTrace,
+				s.getCancelFlowFn(),
 			)
 			if err != nil {
 				return nil, err
@@ -1274,6 +1297,7 @@ func (s *vectorizedFlowCreator) setupOutput(
 			metadataSourcesQueue = metadataSourcesQueue[:0]
 			s.vectorizedStatsCollectorsQueue = s.vectorizedStatsCollectorsQueue[:0]
 			s.addMaterializer(proc)
+			s.materializerAdded = true
 		default:
 			return nil, errors.Errorf("unsupported output stream type %s", outputStream.Type)
 		}
@@ -1446,6 +1470,10 @@ func (r *vectorizedFlowCreatorHelper) addMaterializer(m *materializer) {
 	r.f.processors[0] = m
 }
 
+func (r *vectorizedFlowCreatorHelper) getCancelFlowFn() context.CancelFunc {
+	return r.f.ctxCancel
+}
+
 func (f *Flow) setupVectorizedFlow(ctx context.Context, acc *mon.BoundAccount) error {
 	recordingStats := false
 	if sp := opentracing.SpanFromContext(ctx); sp != nil && tracing.IsRecording(sp) {
@@ -1487,7 +1515,10 @@ func (r *noopFlowCreatorHelper) checkInboundStreamID(sid distsqlpb.StreamID) err
 
 func (r *noopFlowCreatorHelper) accumulateAsyncComponent(runFn) {}
 
-func (r *noopFlowCreatorHelper) addMaterializer(m *materializer) {
+func (r *noopFlowCreatorHelper) addMaterializer(*materializer) {}
+
+func (r *noopFlowCreatorHelper) getCancelFlowFn() context.CancelFunc {
+	return nil
 }
 
 // SupportsVectorized checks whether flow is supported by the vectorized engine

--- a/pkg/sql/distsqlrun/columnar_utils_test.go
+++ b/pkg/sql/distsqlrun/columnar_utils_test.go
@@ -50,7 +50,7 @@ func verifyColOperator(
 	defer diskMonitor.Stop(ctx)
 	flowCtx := &FlowCtx{
 		EvalCtx:     &evalCtx,
-		Settings:    cluster.MakeTestingClusterSettings(),
+		Settings:    st,
 		TempStorage: tempEngine,
 		diskMonitor: diskMonitor,
 	}
@@ -99,6 +99,7 @@ func verifyColOperator(
 		nil, /* output */
 		nil, /* metadataSourcesQueue */
 		nil, /* outputStatsToTrace */
+		nil, /* cancelFlow */
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -32,7 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/errors"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 )
 
 // FlowCtx encompasses the contexts needed for various flow components.
@@ -497,6 +497,8 @@ func (f *Flow) setupProcessors(ctx context.Context, inputSyncs [][]RowSource) er
 
 func (f *Flow) setup(ctx context.Context, spec *distsqlpb.FlowSpec) error {
 	f.spec = spec
+	ctx, f.ctxCancel = contextutil.WithCancel(ctx)
+	f.ctxDone = ctx.Done()
 
 	if f.EvalCtx.SessionData.Vectorize != sessiondata.VectorizeOff {
 		log.VEventf(ctx, 1, "setting up vectorize flow %d with setting %s", f.id, f.EvalCtx.SessionData.Vectorize)
@@ -529,9 +531,6 @@ func (f *Flow) startInternal(ctx context.Context, doneFn func()) error {
 	log.VEventf(
 		ctx, 1, "starting (%d processors, %d startables)", len(f.processors), len(f.startables),
 	)
-
-	ctx, f.ctxCancel = contextutil.WithCancel(ctx)
-	f.ctxDone = ctx.Done()
 
 	// Only register the flow if there will be inbound stream connections that
 	// need to look up this flow in the flow registry.

--- a/pkg/sql/distsqlrun/materializer.go
+++ b/pkg/sql/distsqlrun/materializer.go
@@ -51,18 +51,41 @@ type materializer struct {
 	// adapter.
 	outputRow      sqlbase.EncDatumRow
 	outputMetadata *distsqlpb.ProducerMetadata
+
+	// ctxCancel will cancel the context that is passed to the input (which will
+	// pass it down further). This allows for the cancellation of the tree rooted
+	// at this materializer when it is closed.
+	ctxCancel context.CancelFunc
+	// cancelFlow will cancel the context of the flow (i.e. if non-nil, it is
+	// Flow.ctxCancel).
+	cancelFlow context.CancelFunc
 }
 
+const materializerProcName = "materializer"
+
+// newMaterializer creates a new materializer processor which processes the
+// columnar data coming from input to return it as rows.
+// Arguments:
+// - typs is the output types scheme.
+// - metadataSourcesQueue are all of the metadata sources that are planned on
+// the same node as the materializer and that need to be drained.
+// - outputStatsToTrace (when tracing is enabled) finishes the stats.
+// - cancelFlow is the context cancellation function that cancels the context
+// of the flow (i.e. it is Flow.ctxCancel). It should only be non-nil in case
+// of a root materializer (i.e. not when we're wrapping a row source).
 func newMaterializer(
 	flowCtx *FlowCtx,
 	processorID int32,
 	input exec.Operator,
 	typs []types.T,
+	// TODO(yuzefovich): I feel like we should remove outputToInputColIdx
+	// argument since it's always {0, 1, ..., len(typs)-1}.
 	outputToInputColIdx []int,
 	post *distsqlpb.PostProcessSpec,
 	output RowReceiver,
 	metadataSourcesQueue []distsqlpb.MetadataSource,
 	outputStatsToTrace func(),
+	cancelFlow context.CancelFunc,
 ) (*materializer, error) {
 	m := &materializer{
 		input:               input,
@@ -84,6 +107,7 @@ func newMaterializer(
 				for _, src := range metadataSourcesQueue {
 					trailingMeta = append(trailingMeta, src.DrainMeta(ctx)...)
 				}
+				m.InternalClose()
 				return trailingMeta
 			},
 		},
@@ -91,13 +115,23 @@ func newMaterializer(
 		return nil, err
 	}
 	m.finishTrace = outputStatsToTrace
+	m.cancelFlow = cancelFlow
 	return m, nil
 }
 
 func (m *materializer) Start(ctx context.Context) context.Context {
 	m.input.Init()
-	m.Ctx = ctx
-	return ctx
+	ctx = m.ProcessorBase.StartInternal(ctx, materializerProcName)
+	// In general case, ctx that is passed is related to the "flow context" that
+	// will be canceled by m.cancelFlow. However, in some cases (like when there
+	// is a subquery), it appears as if the subquery flow context is not related
+	// to the flow context of the main query, so calling m.cancelFlow will not
+	// shutdown the subquery tree. To work around this, we always use another
+	// context and get another cancellation function, and we will trigger both
+	// upon exit from the materializer.
+	// TODO(yuzefovich): figure out what is the problem here.
+	m.Ctx, m.ctxCancel = context.WithCancel(ctx)
+	return m.Ctx
 }
 
 // nextAdapter calls next() and saves the returned results in m. For internal
@@ -157,9 +191,24 @@ func (m *materializer) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata)
 	return m.outputRow, m.outputMetadata
 }
 
+func (m *materializer) InternalClose() bool {
+	if m.ProcessorBase.InternalClose() {
+		m.ctxCancel()
+		if m.cancelFlow != nil {
+			m.cancelFlow()
+		}
+		return true
+	}
+	return false
+}
+
+func (m *materializer) ConsumerDone() {
+	// Materializer will move into 'draining' state, and after all the metadata
+	// has been drained - as part of TrailingMetaCallback - InternalClose() will
+	// be called which will cancel the flow.
+	m.MoveToDraining(nil /* err */)
+}
+
 func (m *materializer) ConsumerClosed() {
-	// TODO(yuzefovich): this seems like a hack to me, but in order to close an
-	// Inbox, we need to drain it.
-	m.trailingMetaCallback(m.Ctx)
 	m.InternalClose()
 }

--- a/pkg/sql/distsqlrun/materializer_test.go
+++ b/pkg/sql/distsqlrun/materializer_test.go
@@ -58,6 +58,7 @@ func TestColumnarizeMaterialize(t *testing.T) {
 		nil, /* output */
 		nil, /* metadataSourcesQueue */
 		nil, /* outputStatsToTrace */
+		nil, /* cancelFlow */
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -143,6 +144,7 @@ func TestMaterializeTypes(t *testing.T) {
 		nil, /* output */
 		nil, /* metadataSourcesQueue */
 		nil, /* outputStatsToTrace */
+		nil, /* cancelFlow */
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -197,6 +199,7 @@ func BenchmarkColumnarizeMaterialize(b *testing.B) {
 			nil, /* output */
 			nil, /* metadataSourcesQueue */
 			nil, /* outputStatsToTrace */
+			nil, /* cancelFlow */
 		)
 		if err != nil {
 			b.Fatal(err)

--- a/pkg/sql/distsqlrun/vectorized_error_propagation_test.go
+++ b/pkg/sql/distsqlrun/vectorized_error_propagation_test.go
@@ -60,6 +60,7 @@ func TestVectorizedErrorPropagation(t *testing.T) {
 		nil, /* output */
 		nil, /* metadataSourceQueue */
 		nil, /* outputStatsToTrace */
+		nil, /* cancelFlow */
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -120,6 +121,7 @@ func TestNonVectorizedErrorPropagation(t *testing.T) {
 		nil, /* output */
 		nil, /* metadataSourceQueue */
 		nil, /* outputStatsToTrace */
+		nil, /* cancelFlow */
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sql/distsqlrun/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/distsqlrun/vectorized_flow_shutdown_test.go
@@ -1,0 +1,335 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package distsqlrun
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"net"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/colrpc"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	semtypes "github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+type mockDialer struct {
+	addr net.Addr
+	mu   struct {
+		syncutil.Mutex
+		conn *grpc.ClientConn
+	}
+}
+
+func (d *mockDialer) Dial(context.Context, roachpb.NodeID) (*grpc.ClientConn, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.mu.conn != nil {
+		return d.mu.conn, nil
+	}
+	var err error
+	d.mu.conn, err = grpc.Dial(d.addr.String(), grpc.WithInsecure(), grpc.WithBlock())
+	return d.mu.conn, err
+}
+
+// close must be called after the test.
+func (d *mockDialer) close() {
+	if err := d.mu.conn.Close(); err != nil {
+		panic(err)
+	}
+}
+
+type shutdownScenario struct {
+	string
+}
+
+var (
+	consumerDone      = shutdownScenario{"ConsumerDone"}
+	consumerClosed    = shutdownScenario{"ConsumerClosed"}
+	shutdownScenarios = []shutdownScenario{consumerDone, consumerClosed}
+)
+
+// TestVectorizedFlowShutdown tests that closing the materializer correctly
+// closes all the infrastructure corresponding to the flow ending in that
+// materializer. Namely:
+// - on a remote node, it creates an exec.HashRouter with 3 outputs (with a
+// corresponding to each Outbox) as well as 3 standalone Outboxes;
+// - on a local node, it creates 6 exec.Inboxes that feed into an unordered
+// synchronizer which then outputs all the data into a materializer.
+// The resulting scheme looks as follows:
+//
+//            Remote Node             |                  Local Node
+//                                    |
+//             -> output -> Outbox -> | -> Inbox -> |
+//            |                       |
+// Hash Router -> output -> Outbox -> | -> Inbox -> |
+//            |                       |
+//             -> output -> Outbox -> | -> Inbox -> |
+//                                    |              -> Synchronizer -> materializer
+//                          Outbox -> | -> Inbox -> |
+//                                    |
+//                          Outbox -> | -> Inbox -> |
+//                                    |
+//                          Outbox -> | -> Inbox -> |
+//
+// Also, with 50% probability, another remote node with the chain of an Outbox
+// and Inbox is placed between the synchronizer and materializer. The resulting
+// scheme then looks as follows:
+//
+//            Remote Node             |            Another Remote Node             |         Local Node
+//                                    |                                            |
+//             -> output -> Outbox -> | -> Inbox ->                                |
+//            |                       |             |                              |
+// Hash Router -> output -> Outbox -> | -> Inbox ->                                |
+//            |                       |             |                              |
+//             -> output -> Outbox -> | -> Inbox ->                                |
+//                                    |             | -> Synchronizer -> Outbox -> | -> Inbox -> materializer
+//                          Outbox -> | -> Inbox ->                                |
+//                                    |             |                              |
+//                          Outbox -> | -> Inbox ->                                |
+//                                    |             |                              |
+//                          Outbox -> | -> Inbox ->                                |
+//
+// Remote nodes are simulated by having separate contexts and separate outbox
+// registries.
+//
+// Additionally, all Outboxes have a single metadata source. In ConsumerDone
+// shutdown scenario, we check that the metadata has been successfully
+// propagated from all of the metadata sources.
+func TestVectorizedFlowShutdown(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+	_, mockServer, addr, err := distsqlpb.StartMockDistSQLServer(
+		hlc.NewClock(hlc.UnixNano, time.Nanosecond), stopper, staticNodeID,
+	)
+	require.NoError(t, err)
+	dialer := &mockDialer{addr: addr}
+	defer dialer.close()
+
+	for run := 0; run < 10; run++ {
+		for _, shutdownOperation := range shutdownScenarios {
+			t.Run(fmt.Sprintf("shutdownScenario=%s", shutdownOperation.string), func(t *testing.T) {
+				ctxLocal := context.Background()
+				st := cluster.MakeTestingClusterSettings()
+				evalCtx := tree.MakeTestingEvalContext(st)
+				defer evalCtx.Stop(ctxLocal)
+				flowCtx := &FlowCtx{
+					EvalCtx:  &evalCtx,
+					Settings: st,
+				}
+
+				rng, _ := randutil.NewPseudoRand()
+				var (
+					err             error
+					wg              sync.WaitGroup
+					typs            = []types.T{types.Int64}
+					semtyps         = []semtypes.T{*semtypes.Int}
+					hashRouterInput = exec.NewRandomDataOp(
+						rng,
+						exec.RandomDataOpArgs{
+							DeterministicTyps: typs,
+							// Set a high number of batches to ensure that the HashRouter is
+							// very far from being finished when the flow is shut down.
+							NumBatches: math.MaxInt64,
+							Selection:  true,
+						},
+					)
+					numHashRouterOutputs        = 3
+					numInboxes                  = numHashRouterOutputs + 3
+					inboxes                     = make([]*colrpc.Inbox, 0, numInboxes+1)
+					handleStreamErrCh           = make([]chan error, numInboxes+1)
+					synchronizerInputs          = make([]exec.Operator, 0, numInboxes)
+					materializerMetadataSources = make([]distsqlpb.MetadataSource, 0, numInboxes+1)
+					streamID                    = 0
+					addAnotherRemote            = rng.Float64() < 0.5
+				)
+
+				hashRouter, hashRouterOutputs := exec.NewHashRouter(hashRouterInput, typs, []int{0}, numHashRouterOutputs)
+				for i := 0; i < numInboxes; i++ {
+					inbox, err := colrpc.NewInbox(typs)
+					require.NoError(t, err)
+					inboxes = append(inboxes, inbox)
+					materializerMetadataSources = append(materializerMetadataSources, inbox)
+					synchronizerInputs = append(synchronizerInputs, exec.Operator(inbox))
+				}
+				synchronizer := exec.NewUnorderedSynchronizer(synchronizerInputs, typs, &wg)
+				flowID := distsqlpb.FlowID{UUID: uuid.MakeV4()}
+
+				runOutboxInbox := func(
+					ctx context.Context,
+					cancelFn context.CancelFunc,
+					outboxInput exec.Operator,
+					inbox *colrpc.Inbox,
+					id int,
+					outboxMetadataSources []distsqlpb.MetadataSource,
+				) {
+					outbox, err := colrpc.NewOutbox(
+						outboxInput,
+						typs,
+						append(outboxMetadataSources,
+							distsqlpb.CallbackMetadataSource{
+								DrainMetaCb: func(ctx context.Context) []distsqlpb.ProducerMetadata {
+									return []distsqlpb.ProducerMetadata{{Err: errors.Errorf("%d", id)}}
+								},
+							},
+						),
+					)
+					require.NoError(t, err)
+					wg.Add(1)
+					go func(id int) {
+						outbox.Run(ctx, dialer, staticNodeID, flowID, distsqlpb.StreamID(id), cancelFn)
+						wg.Done()
+					}(id)
+
+					require.NoError(t, err)
+					serverStreamNotification := <-mockServer.InboundStreams
+					serverStream := serverStreamNotification.Stream
+					handleStreamErrCh[id] = make(chan error, 1)
+					doneFn := func() { close(serverStreamNotification.Donec) }
+					wg.Add(1)
+					go func(id int, stream distsqlpb.DistSQL_FlowStreamServer, doneFn func()) {
+						handleStreamErrCh[id] <- inbox.RunWithStream(stream.Context(), stream)
+						doneFn()
+						wg.Done()
+					}(id, serverStream, doneFn)
+				}
+
+				ctxRemote, cancelRemote := context.WithCancel(context.Background())
+				// Linter says there is a possibility of "context leak" because
+				// cancelRemote variable may not be used, so we defer the call to it.
+				// This does not change anything about the test since we're blocking on
+				// the wait group.
+				defer cancelRemote()
+
+				wg.Add(1)
+				go func() {
+					hashRouter.Run(ctxRemote)
+					wg.Done()
+				}()
+				for i := 0; i < numInboxes; i++ {
+					var outboxMetadataSources []distsqlpb.MetadataSource
+					if i < numHashRouterOutputs {
+						if i == 0 {
+							// Only one outbox should drain the hash router.
+							outboxMetadataSources = append(outboxMetadataSources, hashRouter)
+						}
+						runOutboxInbox(ctxRemote, cancelRemote, hashRouterOutputs[i], inboxes[i], streamID, outboxMetadataSources)
+					} else {
+						batch := coldata.NewMemBatch(typs)
+						batch.SetLength(coldata.BatchSize)
+						runOutboxInbox(ctxRemote, cancelRemote, exec.NewRepeatableBatchSource(batch), inboxes[i], streamID, outboxMetadataSources)
+					}
+					streamID++
+				}
+
+				var materializerInput exec.Operator
+				ctxAnotherRemote, cancelAnotherRemote := context.WithCancel(context.Background())
+				if addAnotherRemote {
+					// Add another "remote" node to the flow.
+					inbox, err := colrpc.NewInbox(typs)
+					require.NoError(t, err)
+					inboxes = append(inboxes, inbox)
+					runOutboxInbox(ctxAnotherRemote, cancelAnotherRemote, synchronizer, inbox, streamID, materializerMetadataSources)
+					streamID++
+					// There is now only a single Inbox on the "local" node which is the
+					// only metadata source.
+					materializerMetadataSources = []distsqlpb.MetadataSource{inbox}
+					materializerInput = inbox
+				} else {
+					materializerInput = synchronizer
+				}
+
+				ctxLocal, cancelLocal := context.WithCancel(ctxLocal)
+				materializer, err := newMaterializer(
+					flowCtx,
+					1, /* processorID */
+					materializerInput,
+					semtyps,
+					[]int{0},
+					&distsqlpb.PostProcessSpec{},
+					nil, /* output */
+					materializerMetadataSources,
+					nil, /* outputStatsToTrace */
+					cancelLocal,
+				)
+				require.NoError(t, err)
+				materializer.Start(ctxLocal)
+
+				for i := 0; i < 10; i++ {
+					row, meta := materializer.Next()
+					require.NotNil(t, row)
+					require.Nil(t, meta)
+				}
+				switch shutdownOperation {
+				case consumerDone:
+					materializer.ConsumerDone()
+					receivedMetaFromID := make([]bool, streamID)
+					metaCount := 0
+					for {
+						row, meta := materializer.Next()
+						require.Nil(t, row)
+						if meta == nil {
+							break
+						}
+						metaCount++
+						require.NotNil(t, meta.Err)
+						id, err := strconv.Atoi(meta.Err.Error())
+						require.NoError(t, err)
+						require.False(t, receivedMetaFromID[id])
+						receivedMetaFromID[id] = true
+					}
+					require.Equal(t, streamID, metaCount, fmt.Sprintf("received metadata from Outbox %+v", receivedMetaFromID))
+				case consumerClosed:
+					materializer.ConsumerClosed()
+				}
+
+				// When Outboxes are setup through vectorizedFlowCreator, the latter
+				// keeps track of how many outboxes are on the node. When the last one
+				// exits (and if there is no materializer on that node),
+				// vectorizedFlowCreator will cancel the flow context of the node. To
+				// simulate this, we manually cancel contexts of both remote nodes.
+				cancelRemote()
+				cancelAnotherRemote()
+
+				for i := range inboxes {
+					err = <-handleStreamErrCh[i]
+					// We either should get no error or a context cancellation error.
+					if err != nil {
+						require.True(t, testutils.IsError(err, "context canceled"), err)
+					}
+				}
+				wg.Wait()
+			})
+		}
+	}
+}

--- a/pkg/sql/distsqlrun/vectorized_meta_propagation_test.go
+++ b/pkg/sql/distsqlrun/vectorized_meta_propagation_test.go
@@ -76,6 +76,7 @@ func TestVectorizedMetaPropagation(t *testing.T) {
 		nil, /* output */
 		[]distsqlpb.MetadataSource{col},
 		nil, /* outputStatsToTrace */
+		nil, /* cancelFlow */
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sql/exec/colrpc/inbox.go
+++ b/pkg/sql/exec/colrpc/inbox.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sync"
 
 	"github.com/apache/arrow/go/arrow/array"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
@@ -22,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/colserde"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
 // flowStreamServer is a utility interface used to mock out the RPC layer.
@@ -48,18 +50,11 @@ type Inbox struct {
 	converter  *colserde.ArrowBatchConverter
 	serializer *colserde.RecordBatchSerializer
 
-	// initialized and done prevent double initialization/closing. Should not be
-	// used by the RunWithStream goroutine.
-	initialized bool
-	done        bool
-	// stream is the RPC stream. It is set when RunWithStream is called but only
-	// the Next goroutine may access it.
-	stream flowStreamServer
 	// streamCh is the channel over which the stream is passed from the stream
 	// handler to the reader goroutine.
 	streamCh chan flowStreamServer
 	// contextCh is the channel over which the reader goroutine passes the first
-	// context to the stream handler, so that it can listen for context
+	// context to the stream handler so that it can listen for context
 	// cancellation.
 	contextCh chan context.Context
 
@@ -73,9 +68,35 @@ type Inbox struct {
 	// from a stream.Recv.
 	errCh chan error
 
-	// bufferedMeta buffers any metadata found in Next when reading from the
-	// stream and is returned by DrainMeta.
-	bufferedMeta []distsqlpb.ProducerMetadata
+	// We need two mutexes because a single mutex is insufficient to handle
+	// concurrent calls to Next() and DrainMeta(). See comment in DrainMeta.
+	stateMu struct {
+		syncutil.Mutex
+		// initialized prevents double initialization. Should not be used by the
+		// RunWithStream goroutine.
+		initialized bool
+		// done prevents double closing. It should not be used by the RunWithStream
+		// goroutine.
+		done bool
+		// nextRunning indicates whether Next goroutine is running at the moment.
+		nextRunning bool
+		// nextExited is a condition variable on which DrainMeta might block in
+		// order to wait for Next goroutine to exit.
+		nextExited *sync.Cond
+		// nextShouldExit indicates to Next goroutine that it should exit. It must
+		// only be updated by DrainMeta goroutine.
+		nextShouldExit bool
+		// bufferedMeta buffers any metadata found in Next when reading from the
+		// stream and is returned by DrainMeta.
+		bufferedMeta []distsqlpb.ProducerMetadata
+	}
+
+	streamMu struct {
+		syncutil.Mutex
+		// stream is the RPC stream. It is set when RunWithStream is called but
+		// only the Next and DrainMeta goroutines may access it.
+		stream flowStreamServer
+	}
 
 	scratch struct {
 		data []*array.Data
@@ -97,19 +118,20 @@ func NewInbox(typs []types.T) (*Inbox, error) {
 		return nil, err
 	}
 	i := &Inbox{
-		typs:         typs,
-		zeroBatch:    coldata.NewMemBatchWithSize(typs, 0),
-		converter:    c,
-		serializer:   s,
-		streamCh:     make(chan flowStreamServer, 1),
-		contextCh:    make(chan context.Context, 1),
-		timeoutCh:    make(chan error, 1),
-		errCh:        make(chan error, 1),
-		bufferedMeta: make([]distsqlpb.ProducerMetadata, 0),
+		typs:       typs,
+		zeroBatch:  coldata.NewMemBatchWithSize(typs, 0),
+		converter:  c,
+		serializer: s,
+		streamCh:   make(chan flowStreamServer, 1),
+		contextCh:  make(chan context.Context, 1),
+		timeoutCh:  make(chan error, 1),
+		errCh:      make(chan error, 1),
 	}
 	i.zeroBatch.SetLength(0)
 	i.scratch.data = make([]*array.Data, len(typs))
 	i.scratch.b = coldata.NewMemBatch(typs)
+	i.stateMu.bufferedMeta = make([]distsqlpb.ProducerMetadata, 0)
+	i.stateMu.nextExited = sync.NewCond(&i.stateMu)
 	return i, nil
 }
 
@@ -118,29 +140,33 @@ func (i *Inbox) EstimateStaticMemoryUsage() int {
 	return exec.EstimateBatchSizeBytes(i.typs, coldata.BatchSize)
 }
 
-// maybeInit calls Inbox.init if the inbox is not initialized and returns an
-// error if the initialization was not successful. Usually this is because the
-// given context is canceled before the remote stream arrives.
-func (i *Inbox) maybeInit(ctx context.Context) error {
-	if !i.initialized {
-		if err := i.init(ctx); err != nil {
+// maybeInitLocked calls Inbox.initLocked if the inbox is not initialized and
+// returns an error if the initialization was not successful. Usually this is
+// because the given context is canceled before the remote stream arrives.
+// NOTE: i.stateMu *must* be held when calling this function.
+func (i *Inbox) maybeInitLocked(ctx context.Context) error {
+	if !i.stateMu.initialized {
+		if err := i.initLocked(ctx); err != nil {
 			return err
 		}
-		i.initialized = true
+		i.stateMu.initialized = true
 	}
 	return nil
 }
 
-// init initializes the Inbox for operation by blocking until RunWithStream
-// sets the stream to read from. ctx ownership is retained until the stream
-// arrives (to allow for unblocking the wait for a stream), at which point
-// ownership is transferred to RunWithStream. This should only be called from
-// the reader goroutine when it needs a stream.
-func (i *Inbox) init(ctx context.Context) error {
+// initLocked initializes the Inbox for operation by blocking until
+// RunWithStream sets the stream to read from. ctx ownership is retained until
+// the stream arrives (to allow for unblocking the wait for a stream), at which
+// point ownership is transferred to RunWithStream. This should only be called
+// from the reader goroutine when it needs a stream.
+// NOTE: i.stateMu *must* be held when calling this function because it is
+// sufficient to protect access to i.streamMu.stream since the stream will only
+// be accessed after the initialization.
+func (i *Inbox) initLocked(ctx context.Context) error {
 	// Wait for the stream to be initialized. We're essentially waiting for the
 	// remote connection.
 	select {
-	case i.stream = <-i.streamCh:
+	case i.streamMu.stream = <-i.streamCh:
 	case err := <-i.timeoutCh:
 		i.errCh <- fmt.Errorf("%s: remote stream arrived too late", err)
 		return err
@@ -152,11 +178,12 @@ func (i *Inbox) init(ctx context.Context) error {
 	return nil
 }
 
-// close closes the inbox, ensuring that any call to RunWithStream will return
-// immediately. close is idempotent.
-func (i *Inbox) close() {
-	if !i.done {
-		i.done = true
+// closeLocked closes the inbox, ensuring that any call to RunWithStream will
+// return immediately. closeLocked is idempotent.
+// NOTE: i.stateMu *must* be held when calling this function.
+func (i *Inbox) closeLocked() {
+	if !i.stateMu.done {
+		i.stateMu.done = true
 		close(i.errCh)
 	}
 }
@@ -182,7 +209,7 @@ func (i *Inbox) RunWithStream(streamCtx context.Context, stream flowStreamServer
 
 	// Now wait for one of the events described in the method comment. If a
 	// cancellation is encountered, nothing special must be done to cancel the
-	// reader goroutine, as returning from the handler will close the stream.
+	// reader goroutine as returning from the handler will close the stream.
 	select {
 	case err := <-i.errCh:
 		// nil will be read from errCh when the channel is closed.
@@ -206,10 +233,18 @@ func (i *Inbox) Timeout(err error) {
 func (i *Inbox) Init() {}
 
 // Next returns the next batch. It will block until there is data available.
-// For simplicity, the Inbox will only listen for cancellation of the context
-// passed in to the first Next call.
+// The Inbox will exit when either the context passed in on the first call to
+// Next is canceled or when DrainMeta goroutine tells it to do so.
 func (i *Inbox) Next(ctx context.Context) coldata.Batch {
-	if i.done {
+	i.stateMu.Lock()
+	stateMuLocked := true
+	i.stateMu.nextRunning = true
+	defer func() {
+		i.stateMu.nextRunning = false
+		i.stateMu.nextExited.Signal()
+		i.stateMu.Unlock()
+	}()
+	if i.stateMu.done {
 		return i.zeroBatch
 	}
 
@@ -218,24 +253,43 @@ func (i *Inbox) Next(ctx context.Context) coldata.Batch {
 		// goroutine listening for context cancellation. errCh must still be closed
 		// during normal termination.
 		if err := recover(); err != nil {
-			i.close()
+			if !stateMuLocked {
+				// The panic occurred while we were Recv'ing when we were holding
+				// i.streamMu and were not holding i.stateMu.
+				i.stateMu.Lock()
+				i.streamMu.Unlock()
+			}
+			i.closeLocked()
 			panic(err)
 		}
 	}()
 
 	// NOTE: It is very important to close i.errCh only when execution terminates
-	// ungracefully. DrainMeta will use the stream to read any remaining metadata
+	// ungracefully or when DrainMeta has been called (which indicates a graceful
+	// termination). DrainMeta will use the stream to read any remaining metadata
 	// after Next returns a zero-length batch during normal execution.
-	if err := i.maybeInit(ctx); err != nil {
+	if err := i.maybeInitLocked(ctx); err != nil {
 		panic(err)
 	}
 
 	for {
-		m, err := i.stream.Recv()
+		// DrainMeta goroutine indicated to us that we should exit. We do so
+		// without closing errCh since DrainMeta still needs the stream.
+		if i.stateMu.nextShouldExit {
+			return i.zeroBatch
+		}
+
+		i.stateMu.Unlock()
+		stateMuLocked = false
+		i.streamMu.Lock()
+		m, err := i.streamMu.stream.Recv()
+		i.streamMu.Unlock()
+		i.stateMu.Lock()
+		stateMuLocked = true
 		if err != nil {
 			if err == io.EOF {
 				// Done.
-				i.close()
+				i.closeLocked()
 				return i.zeroBatch
 			}
 			i.errCh <- err
@@ -247,14 +301,13 @@ func (i *Inbox) Next(ctx context.Context) coldata.Batch {
 				if !ok {
 					continue
 				}
-				i.bufferedMeta = append(i.bufferedMeta, meta)
+				i.stateMu.bufferedMeta = append(i.stateMu.bufferedMeta, meta)
 			}
 			// Continue until we get the next batch or EOF.
 			continue
 		}
 		if len(m.Data.RawBytes) == 0 {
 			// Protect against Deserialization panics by skipping empty messages.
-			// TODO(asubiotto): I don't think we're using NumEmptyRows, right?
 			continue
 		}
 		i.scratch.data = i.scratch.data[:0]
@@ -268,28 +321,74 @@ func (i *Inbox) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-// DrainMeta is part of the MetadataGenerator interface. DrainMeta may not be
-// called concurrently with Next.
-func (i *Inbox) DrainMeta(ctx context.Context) []distsqlpb.ProducerMetadata {
-	allMeta := i.bufferedMeta
-	i.bufferedMeta = i.bufferedMeta[:0]
+func (i *Inbox) sendDrainSignal(ctx context.Context) error {
+	log.VEvent(ctx, 2, "Inbox sending drain signal to Outbox")
+	// It is safe to Send without holding the mutex because it is legal to call
+	// Send and Recv from different goroutines.
+	if err := i.streamMu.stream.Send(&distsqlpb.ConsumerSignal{DrainRequest: &distsqlpb.DrainRequest{}}); err != nil {
+		log.Warningf(ctx, "Inbox unable to send drain signal to Outbox: %+v", err)
+		return err
+	}
+	return nil
+}
 
-	if i.done {
+// DrainMeta is part of the MetadataGenerator interface. DrainMeta may be
+// called concurrently with Next.
+// Note: DrainMeta will cause Next goroutine to finish.
+func (i *Inbox) DrainMeta(ctx context.Context) []distsqlpb.ProducerMetadata {
+	i.stateMu.Lock()
+	defer i.stateMu.Unlock()
+	allMeta := i.stateMu.bufferedMeta
+	i.stateMu.bufferedMeta = i.stateMu.bufferedMeta[:0]
+
+	if i.stateMu.done {
 		return allMeta
 	}
 
-	defer i.close()
-	if err := i.maybeInit(ctx); err != nil {
+	// We want draining the Inbox to work regardless of whether or not we have a
+	// goroutine in Next. We essentially need to do two things: 1) Is the stream
+	// safe to use? If yes, then 2) Make sure nobody else is receiving.
+	// Unfortunately, there is no way to cancel a Recv on a stream, so we need to
+	// do this by sending the message. However, we can't unconditionally send a
+	// message since we don't know the state of the stream (is it initialized?).
+	// This leaves us with having two separate mutexes, one for the state and
+	// another one for the stream (to make sure we wait until the Next goroutine
+	// has finished Recv'ing).
+	drainSignalSent := false
+	if i.stateMu.initialized {
+		if err := i.sendDrainSignal(ctx); err != nil {
+			return allMeta
+		}
+		drainSignalSent = true
+		i.stateMu.nextShouldExit = true
+		for i.stateMu.nextRunning {
+			i.stateMu.nextExited.Wait()
+		}
+		// It is possible that Next goroutine has buffered more metadata, so we
+		// need to grab it.
+		allMeta = append(allMeta, i.stateMu.bufferedMeta...)
+		i.stateMu.bufferedMeta = i.stateMu.bufferedMeta[:0]
+	}
+
+	// Note that unlocking defer from above will execute after this defer because
+	// the unlocking one will be pushed below on the stack, so we still will have
+	// the lock when this one is executed.
+	defer i.closeLocked()
+
+	if err := i.maybeInitLocked(ctx); err != nil {
 		log.Warningf(ctx, "Inbox unable to initialize stream while draining metadata: %+v", err)
 		return allMeta
 	}
-	log.VEvent(ctx, 2, "Inbox sending drain signal to Outbox")
-	if err := i.stream.Send(&distsqlpb.ConsumerSignal{DrainRequest: &distsqlpb.DrainRequest{}}); err != nil {
-		log.Warningf(ctx, "Inbox unable to send drain signal to Outbox: %+v", err)
-		return allMeta
+	if !drainSignalSent {
+		if err := i.sendDrainSignal(ctx); err != nil {
+			return allMeta
+		}
 	}
+
+	i.streamMu.Lock()
+	defer i.streamMu.Unlock()
 	for {
-		msg, err := i.stream.Recv()
+		msg, err := i.streamMu.stream.Recv()
 		if err != nil {
 			if err == io.EOF {
 				break

--- a/pkg/sql/exec/colrpc/outbox.go
+++ b/pkg/sql/exec/colrpc/outbox.go
@@ -17,7 +17,6 @@ import (
 	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
@@ -25,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/logtags"
+	"google.golang.org/grpc"
 )
 
 // flowStreamClient is a utility interface used to mock out the RPC layer.
@@ -34,12 +34,21 @@ type flowStreamClient interface {
 	CloseSend() error
 }
 
+// Dialer is used for dialing based on node IDs. It extracts out the single
+// method that Outbox.Run needs from nodedialer.Dialer so that we can mock it
+// in tests outside of this package.
+type Dialer interface {
+	Dial(context.Context, roachpb.NodeID) (*grpc.ClientConn, error)
+}
+
 // Outbox is used to push data from local flows to a remote endpoint. Run may
 // be called with the necessary information to establish a connection to a
 // given remote endpoint.
 type Outbox struct {
 	input exec.Operator
 	typs  []types.T
+	// batch is the last batch received from the input.
+	batch coldata.Batch
 
 	converter  *colserde.ArrowBatchConverter
 	serializer *colserde.RecordBatchSerializer
@@ -100,7 +109,7 @@ func NewOutbox(
 //    Outbox goes through the same steps as 1).
 func (o *Outbox) Run(
 	ctx context.Context,
-	dialer *nodedialer.Dialer,
+	dialer Dialer,
 	nodeID roachpb.NodeID,
 	flowID distsqlpb.FlowID,
 	streamID distsqlpb.StreamID,
@@ -187,22 +196,25 @@ func (o *Outbox) moveToDraining(ctx context.Context) {
 //    will be called in this case.
 func (o *Outbox) sendBatches(
 	ctx context.Context, stream flowStreamClient, cancelFn context.CancelFunc,
-) (bool, error) {
+) (terminatedGracefully bool, _ error) {
+	nextBatch := func() {
+		o.batch = o.input.Next(ctx)
+	}
 	for {
 		if atomic.LoadUint32(&o.draining) == 1 {
 			return true, nil
 		}
-		var b coldata.Batch
-		if err := exec.CatchVectorizedRuntimeError(func() { b = o.input.Next(ctx) }); err != nil {
+
+		if err := exec.CatchVectorizedRuntimeError(nextBatch); err != nil {
 			log.Errorf(ctx, "Outbox Next error: %+v", err)
 			return false, err
 		}
-		if b.Length() == 0 {
+		if o.batch.Length() == 0 {
 			return true, nil
 		}
 
 		o.scratch.buf.Reset()
-		d, err := o.converter.BatchToArrow(b)
+		d, err := o.converter.BatchToArrow(o.batch)
 		if err != nil {
 			log.Errorf(ctx, "Outbox BatchToArrow data serialization error: %+v", err)
 			return false, err
@@ -231,13 +243,11 @@ func (o *Outbox) sendMetadata(ctx context.Context, stream flowStreamClient, errT
 	if errToSend != nil {
 		msg.Data.Metadata = append(
 			msg.Data.Metadata, distsqlpb.LocalMetaToRemoteProducerMeta(ctx, distsqlpb.ProducerMetadata{Err: errToSend}),
-			// TODO(yuzefovich): obtain and release producer metadata from the pool.
 		)
 	}
 	for _, src := range o.metadataSources {
 		for _, meta := range src.DrainMeta(ctx) {
 			msg.Data.Metadata = append(msg.Data.Metadata, distsqlpb.LocalMetaToRemoteProducerMeta(ctx, meta))
-			// TODO(yuzefovich): release meta object to the pool.
 		}
 	}
 	if len(msg.Data.Metadata) == 0 {
@@ -246,7 +256,7 @@ func (o *Outbox) sendMetadata(ctx context.Context, stream flowStreamClient, errT
 	return stream.Send(msg)
 }
 
-// runwWithStream should be called after sending the ProducerHeader on the
+// runWithStream should be called after sending the ProducerHeader on the
 // stream. It implements the behavior described in Run.
 func (o *Outbox) runWithStream(
 	ctx context.Context, stream flowStreamClient, cancelFn context.CancelFunc,

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -425,6 +425,7 @@ var logicTestConfigs = []testClusterConfig{
 	{name: "local-vec", numNodes: 1, overrideOptimizerMode: "on", overrideExpVectorize: "on"},
 	{name: "fakedist", numNodes: 3, useFakeSpanResolver: true, overrideDistSQLMode: "on", overrideOptimizerMode: "off"},
 	{name: "fakedist-opt", numNodes: 3, useFakeSpanResolver: true, overrideDistSQLMode: "on", overrideOptimizerMode: "on", overrideAutoStats: "false"},
+	{name: "fakedist-vec", numNodes: 3, useFakeSpanResolver: true, overrideDistSQLMode: "on", overrideOptimizerMode: "on", overrideAutoStats: "false", overrideExpVectorize: "on"},
 	{name: "fakedist-metadata", numNodes: 3, useFakeSpanResolver: true, overrideDistSQLMode: "on", overrideOptimizerMode: "off",
 		distSQLMetadataTestEnabled: true, skipShort: true},
 	{name: "fakedist-disk", numNodes: 3, useFakeSpanResolver: true, overrideDistSQLMode: "on", overrideOptimizerMode: "off",

--- a/pkg/sql/logictest/testdata/logic_test/overflow
+++ b/pkg/sql/logictest/testdata/logic_test/overflow
@@ -1,4 +1,4 @@
-# LogicTest: local-vec local-opt fakedist fakedist-opt fakedist-metadata
+# LogicTest: local-vec local-opt fakedist fakedist-opt fakedist-metadata fakedist-vec
 
 # Test for overflow handling in sum aggregate.
 

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -249,6 +249,7 @@ func TestTrace(t *testing.T) {
 				"sql txn",
 				"exec stmt",
 				"flow",
+				"materializer",
 				"operator for processor 0",
 				"consuming rows",
 				"txn coordinator send",


### PR DESCRIPTION
Previously, flow shutting down has been a little fragile since
some goroutines would remain blocked when the materializer finishes
its execution. Now we will cancel the shared flow context, and if
all infrastructure listens to it, the infra will be shut down
appropriately.

Fixes: #39029.
Fixes: #39092.
Fixes: #38919.

Release note: None