### PR TITLE
sql: Update show create to show table and partition zone configs

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -537,3 +537,32 @@ TABLE "my database".public."my table"                                         NU
 INDEX "my database".public."my table"@"my index"                              NULL      my database  my table  my index   NULL
 PARTITION "my partition" OF INDEX "my database".public."my table"@primary     NULL      my database  my table  primary    my partition
 PARTITION "my partition" OF INDEX "my database".public."my table"@"my index"  NULL      my database  my table  my index   my partition
+
+# Test the zone information being displayed in SHOW CREATE
+statement ok
+CREATE TABLE show_test (x INT PRIMARY KEY) PARTITION BY LIST (x) (
+  PARTITION p1 VALUES IN (1),
+  PARTITION p2 VALUES IN (2)
+)
+
+statement ok
+ALTER PARTITION p1 OF TABLE show_test CONFIGURE ZONE USING CONSTRAINTS='[+dc=dc1]'
+
+statement ok
+ALTER PARTITION p2 OF TABLE show_test CONFIGURE ZONE USING CONSTRAINTS='[+dc=dc2]'
+
+query TT
+SHOW CREATE TABLE show_test
+----
+show_test  CREATE TABLE show_test (
+          x INT8 NOT NULL,
+          CONSTRAINT "primary" PRIMARY KEY (x ASC),
+          FAMILY "primary" (x)
+) PARTITION BY LIST (x) (
+   PARTITION p1 VALUES IN ((1)),
+   PARTITION p2 VALUES IN ((2))
+);
+ALTER PARTITION p1 OF INDEX "my database".public.show_test@primary CONFIGURE ZONE USING
+  constraints = '[+dc=dc1]';
+ALTER PARTITION p2 OF INDEX "my database".public.show_test@primary CONFIGURE ZONE USING
+  constraints = '[+dc=dc2]'

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"gopkg.in/yaml.v2"
 )
 
 const crdbInternalName = "crdb_internal"
@@ -1100,17 +1101,18 @@ var crdbInternalCreateStmtsTable = virtualSchemaTable{
 	comment: `CREATE and ALTER statements for all tables accessible by current user in current database (KV scan)`,
 	schema: `
 CREATE TABLE crdb_internal.create_statements (
-  database_id         INT,
-  database_name       STRING,
-  schema_name         STRING NOT NULL,
-  descriptor_id       INT,
-  descriptor_type     STRING NOT NULL,
-  descriptor_name     STRING NOT NULL,
-  create_statement    STRING NOT NULL,
-  state               STRING NOT NULL,
-  create_nofks        STRING NOT NULL,
-  alter_statements    STRING[] NOT NULL,
-  validate_statements STRING[] NOT NULL
+  database_id                   INT,
+  database_name                 STRING,
+  schema_name                   STRING NOT NULL,
+  descriptor_id                 INT,
+  descriptor_type               STRING NOT NULL,
+  descriptor_name               STRING NOT NULL,
+  create_statement              STRING NOT NULL,
+  state                         STRING NOT NULL,
+  create_nofks                  STRING NOT NULL,
+  alter_statements              STRING[] NOT NULL,
+  validate_statements           STRING[] NOT NULL,
+  zone_configuration_statements STRING[] NOT NULL
 )
 `,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
@@ -1123,6 +1125,47 @@ CREATE TABLE crdb_internal.create_statements (
 		typeView := tree.NewDString("view")
 		typeTable := tree.NewDString("table")
 		typeSequence := tree.NewDString("sequence")
+
+		// Hold the configuration statements for each table
+		zoneConfigStmts := make(map[string][]string)
+		// Prepare a query used to see zones configuations on this table.
+		configStmtsQuery := `
+			SELECT
+				table_name, config_yaml, config_sql
+			FROM
+				crdb_internal.zones
+			WHERE
+				database_name = '%[1]s'
+				AND table_name IS NOT NULL
+				AND config_yaml IS NOT NULL
+				AND config_sql IS NOT NULL
+			ORDER BY
+				database_name, table_name, index_name, partition_name
+		`
+		// The create_statements table is used at times where other internal
+		// tables have not been created, or are unaccessible (perhaps during
+		// certain tests (TestDumpAsOf in pkg/cli/dump_test.go)). So if something
+		// goes wrong querying this table, proceed without any constraint data.
+		zoneConstraintRows, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.Query(
+			ctx, "zone-constraints-for-show-create-table", p.txn,
+			fmt.Sprintf(configStmtsQuery, contextName))
+		if err != nil {
+			log.VEventf(ctx, 1, "%q", err)
+		} else {
+			for _, row := range zoneConstraintRows {
+				tableName := string(tree.MustBeDString(row[0]))
+				var zoneConfig config.ZoneConfig
+				yamlString := string(tree.MustBeDString(row[1]))
+				err := yaml.UnmarshalStrict([]byte(yamlString), &zoneConfig)
+				if err != nil {
+					return err
+				}
+				if len(zoneConfig.Constraints) > 0 {
+					sqlString := string(tree.MustBeDString(row[2]))
+					zoneConfigStmts[tableName] = append(zoneConfigStmts[tableName], sqlString)
+				}
+			}
+		}
 
 		return forEachTableDescWithTableLookupInternal(ctx, p, dbContext, virtualOnce, true, /*allowAdding*/
 			func(db *DatabaseDescriptor, scName string, table *TableDescriptor, lCtx tableLookupFn) error {
@@ -1184,6 +1227,15 @@ CREATE TABLE crdb_internal.create_statements (
 					return err
 				}
 
+				zoneRows := tree.NewDArray(types.String)
+				if val, ok := zoneConfigStmts[table.Name]; ok {
+					for _, s := range val {
+						if err := zoneRows.Append(tree.NewDString(s)); err != nil {
+							return err
+						}
+					}
+				}
+
 				descID := tree.NewDInt(tree.DInt(table.ID))
 				dbDescID := tree.NewDInt(tree.DInt(table.GetParentID()))
 				if createNofk == "" {
@@ -1201,6 +1253,7 @@ CREATE TABLE crdb_internal.create_statements (
 					tree.NewDString(createNofk),
 					alterStmts,
 					validateStmts,
+					zoneRows,
 				)
 			})
 	},

--- a/pkg/sql/delegate/show_table.go
+++ b/pkg/sql/delegate/show_table.go
@@ -20,12 +20,23 @@ import (
 
 func (d *delegator) delegateShowCreate(n *tree.ShowCreate) (tree.Statement, error) {
 	const showCreateQuery = `
-     SELECT %[3]s AS table_name,
-            create_statement
-       FROM %[4]s.crdb_internal.create_statements
-      WHERE (database_name IS NULL OR database_name = %[1]s)
-        AND schema_name = %[5]s
-        AND descriptor_name = %[2]s`
+    SELECT
+			%[3]s AS table_name,
+			array_to_string(
+				array_cat(
+					ARRAY[create_statement],
+					zone_configuration_statements
+				),
+				e';\n'
+			)
+				AS create_statement
+		FROM
+			%[4]s.crdb_internal.create_statements
+		WHERE
+			(database_name IS NULL OR database_name = %[1]s)
+			AND schema_name = %[5]s
+			AND descriptor_name = %[2]s
+	`
 
 	return d.showTableDetails(n.Name, showCreateQuery)
 }

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -170,10 +170,10 @@ SELECT * FROM crdb_internal.builtin_functions WHERE function = ''
 ----
 function  signature  category  details
 
-query ITTITTTTTTT colnames
+query ITTITTTTTTTT colnames
 SELECT * FROM crdb_internal.create_statements WHERE database_name = ''
 ----
-database_id  database_name  schema_name  descriptor_id  descriptor_type  descriptor_name  create_statement  state  create_nofks  alter_statements  validate_statements
+database_id  database_name  schema_name  descriptor_id  descriptor_type  descriptor_name  create_statement  state  create_nofks  alter_statements  validate_statements zone_configuration_statements
 
 query ITITTBTB colnames
 SELECT * FROM crdb_internal.table_columns WHERE descriptor_name = ''

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -116,11 +116,11 @@ CREATE SEQUENCE ignored_options_test CACHE 1 NO CYCLE
 statement ok
 CREATE SEQUENCE show_create_test
 
-query ITTITTTTTTT colnames
+query ITTITTTTTTTT colnames
 SELECT * FROM crdb_internal.create_statements WHERE descriptor_name = 'show_create_test'
 ----
-database_id  database_name  schema_name  descriptor_id  descriptor_type  descriptor_name   create_statement                                                                              state   create_nofks                                                                                  alter_statements  validate_statements
-52           test           public       66             sequence         show_create_test  CREATE SEQUENCE show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1  PUBLIC  CREATE SEQUENCE show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1  {}                {}
+database_id  database_name  schema_name  descriptor_id  descriptor_type  descriptor_name   create_statement                                                                              state   create_nofks                                                                                  alter_statements  validate_statements zone_configuration_statements
+52           test           public       66             sequence         show_create_test  CREATE SEQUENCE show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1  PUBLIC  CREATE SEQUENCE show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1  {}                {}                  {}
 
 query TT colnames
 SHOW CREATE SEQUENCE show_create_test


### PR DESCRIPTION
Create table now shows the ALTER statements used to create partitions and zone configuration on the chosen table.

Fixes #39076.

Release note (sql change): Update SHOW CREATE to display
information about partition and table zone configurations.