### PR TITLE
sql/tests: add datum roundtrip to RSG tests

### DIFF
--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -17,6 +17,7 @@ import (
 	"regexp"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
@@ -122,6 +123,13 @@ func (s *Smither) Generate() string {
 		i = 0
 		return prettyCfg.Pretty(stmt)
 	}
+}
+
+// GenerateExpr returns a random SQL expression that does not depend on any
+// tables or columns.
+func (s *Smither) GenerateExpr() tree.TypedExpr {
+	scope := s.makeScope()
+	return makeScalar(scope, sqlbase.RandScalarType(s.rnd), nil)
 }
 
 func (s *Smither) name(prefix string) tree.Name {

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -545,6 +545,88 @@ func TestRandomSyntaxSQLSmith(t *testing.T) {
 	fmt.Printf("\n")
 }
 
+func TestRandomDatumRoundtrip(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	sema := tree.MakeSemaContext()
+	eval := tree.MakeTestingEvalContext(nil)
+
+	var smither *sqlsmith.Smither
+	testRandomSyntax(t, true, "", func(ctx context.Context, db *verifyFormatDB, r *rsg.RSG) error {
+		var err error
+		smither, err = sqlsmith.NewSmither(nil, r.Rnd)
+		return err
+	}, func(ctx context.Context, db *verifyFormatDB, r *rsg.RSG) error {
+		defer func() {
+			if err := recover(); err != nil {
+				s := fmt.Sprint(err)
+				// JSONB NaN and Infinity can't round
+				// trip because JSON doesn't support
+				// those as Numbers, only strings. (Try
+				// `JSON.stringify(Infinity)` in a JS console.)
+				if strings.Contains(s, "JSONB") && (strings.Contains(s, "Infinity") || strings.Contains(s, "NaN")) {
+					return
+				}
+				for _, cmp := range []string{
+					"ReturnType called on TypedExpr with empty typeAnnotation",
+					"runtime error: invalid memory address or nil pointer dereference",
+				} {
+					if strings.Contains(s, cmp) {
+						return
+					}
+				}
+				panic(err)
+			}
+		}()
+		generated := smither.GenerateExpr()
+		typ := generated.ResolvedType()
+		switch typ {
+		case types.Date, types.Decimal:
+			return nil
+		}
+		serializedGen := tree.Serialize(generated)
+
+		// We don't care about errors below because they are often
+		// caused by sqlsmith generating bogus queries. We're just
+		// looking for datums that don't match.
+		parsed1, err := parser.ParseExpr(serializedGen)
+		if err != nil {
+			return nil
+		}
+		typed1, err := parsed1.TypeCheck(&sema, typ)
+		if err != nil {
+			return nil
+		}
+		datum1, err := typed1.Eval(&eval)
+		if err != nil {
+			return nil
+		}
+		serialized1 := tree.Serialize(datum1)
+
+		parsed2, err := parser.ParseExpr(serialized1)
+		if err != nil {
+			return nil
+		}
+		typed2, err := parsed2.TypeCheck(&sema, typ)
+		if err != nil {
+			return nil
+		}
+		datum2, err := typed2.Eval(&eval)
+		if err != nil {
+			return nil
+		}
+		serialized2 := tree.Serialize(datum2)
+
+		if serialized1 != serialized2 {
+			panic(errors.Errorf("serialized didn't match:\nexpr: %s\nfirst: %s\nsecond: %s", generated, serialized1, serialized2))
+		}
+		if datum1.Compare(&eval, datum2) != 0 {
+			panic(errors.Errorf("%s [%[1]T] != %s [%[2]T] (original expr: %s)", serialized1, serialized2, serializedGen))
+		}
+		return nil
+	})
+}
+
 // testRandomSyntax performs all of the RSG setup and teardown for common
 // random syntax testing operations. It takes a closure where the random
 // expression should be generated and executed. It returns an error indicating


### PR DESCRIPTION
This test verifies that arbitrary expressions roundtrip as their result
datum. This previously found some bugs (#36557, #36606) and has thus
earned its place in the RSG tests.

Release note: None