### PR TITLE
workloadccl: inject table statistics during fixtures load

### DIFF
--- a/pkg/ccl/workloadccl/cliccl/fixtures.go
+++ b/pkg/ccl/workloadccl/cliccl/fixtures.go
@@ -282,7 +282,7 @@ func (l restoreDataLoader) InitialDataLoad(
 ) (int64, error) {
 	log.Infof(ctx, "starting restore of %d tables", len(gen.Tables()))
 	start := timeutil.Now()
-	bytes, err := workloadccl.RestoreFixture(ctx, db, l.fixture, l.database)
+	bytes, err := workloadccl.RestoreFixture(ctx, db, l.fixture, l.database, true /* injectStats */)
 	if err != nil {
 		return 0, errors.Wrap(err, `restoring fixture`)
 	}

--- a/pkg/ccl/workloadccl/fixture_test.go
+++ b/pkg/ccl/workloadccl/fixture_test.go
@@ -152,7 +152,7 @@ func TestFixture(t *testing.T) {
 	}
 
 	sqlDB.Exec(t, `CREATE DATABASE test`)
-	if _, err := RestoreFixture(ctx, db, fixture, `test`); err != nil {
+	if _, err := RestoreFixture(ctx, db, fixture, `test`, false); err != nil {
 		t.Fatalf(`%+v`, err)
 	}
 	sqlDB.CheckQueryResults(t,


### PR DESCRIPTION
See #39103.

Release note: None