### PR TITLE
release-19.1: workloadccl: inject table statistics during fixtures load

### DIFF
--- a/pkg/ccl/workloadccl/cliccl/fixtures.go
+++ b/pkg/ccl/workloadccl/cliccl/fixtures.go
@@ -293,7 +293,7 @@ func fixturesLoad(gen workload.Generator, urls []string, dbName string) error {
 	}
 
 	log.Infof(ctx, "starting load of %d tables", len(gen.Tables()))
-	bytes, err := workloadccl.RestoreFixture(ctx, sqlDB, fixture, dbName)
+	bytes, err := workloadccl.RestoreFixture(ctx, sqlDB, fixture, dbName, true /* injectStats */)
 	if err != nil {
 		return errors.Wrap(err, `restoring fixture`)
 	}

--- a/pkg/ccl/workloadccl/fixture_test.go
+++ b/pkg/ccl/workloadccl/fixture_test.go
@@ -152,7 +152,7 @@ func TestFixture(t *testing.T) {
 	}
 
 	sqlDB.Exec(t, `CREATE DATABASE test`)
-	if _, err := RestoreFixture(ctx, db, fixture, `test`); err != nil {
+	if _, err := RestoreFixture(ctx, db, fixture, `test`, false); err != nil {
 		t.Fatalf(`%+v`, err)
 	}
 	sqlDB.CheckQueryResults(t,


### PR DESCRIPTION
Backport 1/1 commits from #39106.

/cc @cockroachdb/release

---

See #39103.

Release note: None
