### PR TITLE
opt: add support for DELETE FK checks

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/fk_opt
+++ b/pkg/sql/logictest/testdata/logic_test/fk_opt
@@ -3,19 +3,22 @@
 statement ok
 SET experimental_optimizer_foreign_keys = true
 
+# Insert
+# ------
+
 statement ok
 CREATE TABLE parent (p INT PRIMARY KEY, other INT)
 
 statement ok
 CREATE TABLE child (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(p))
 
-statement error insert or update on table "child" violates foreign key constraint "fk_p_ref_parent"\nDETAIL: Key \(p\)=\(1\) is not present in table "parent"\.
+statement error insert on table "child" violates foreign key constraint "fk_p_ref_parent"\nDETAIL: Key \(p\)=\(1\) is not present in table "parent"\.
 INSERT INTO child VALUES (1,1)
 
 statement ok
 INSERT INTO parent VALUES (1), (2)
 
-statement error insert or update on table "child" violates foreign key constraint "fk_p_ref_parent"\nDETAIL: Key \(p\)=\(3\) is not present in table "parent"\.
+statement error insert on table "child" violates foreign key constraint "fk_p_ref_parent"\nDETAIL: Key \(p\)=\(3\) is not present in table "parent"\.
 INSERT INTO child VALUES (1,1), (2,2), (3,3)
 
 statement ok
@@ -28,7 +31,7 @@ CREATE TABLE xy (x INT, y INT)
 statement ok
 INSERT INTO xy VALUES (4, 4), (5, 5), (6, 6)
 
-statement error insert or update on table "child" violates foreign key constraint "fk_p_ref_parent"\nDETAIL: Key \(p\)=\(4\) is not present in table "parent"\.
+statement error insert on table "child" violates foreign key constraint "fk_p_ref_parent"\nDETAIL: Key \(p\)=\(4\) is not present in table "parent"\.
 INSERT INTO child SELECT x,y FROM xy
 
 statement ok
@@ -36,3 +39,71 @@ INSERT INTO parent SELECT x FROM xy
 
 statement ok
 INSERT INTO child SELECT x,y FROM xy
+
+statement ok
+DROP TABLE child
+
+statement ok
+DROP TABLE parent
+
+# Delete
+# ------
+
+statement ok
+CREATE TABLE parent (x INT, p INT PRIMARY KEY, u INT UNIQUE)
+
+statement ok
+CREATE TABLE child (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(p))
+
+statement ok
+INSERT INTO parent (p, u) VALUES (1, 10), (2, 20)
+
+statement ok
+INSERT INTO child VALUES (1, 1)
+
+statement ok
+DELETE FROM parent WHERE p = 2
+
+statement error delete on table "parent" violates foreign key constraint on table "child"
+DELETE FROM parent WHERE p = 1
+
+statement ok
+CREATE TABLE child_u (c INT PRIMARY KEY, u INT NOT NULL REFERENCES parent(u))
+
+statement ok
+DROP TABLE child
+
+statement ok
+INSERT INTO child_u VALUES (1, 10)
+
+statement error delete on table "parent" violates foreign key constraint on table "child_u"
+DELETE FROM parent WHERE p = 1
+
+statement ok
+CREATE TABLE parent2 (p1 INT, p2 INT, other INT, PRIMARY KEY (p1, p2))
+
+statement ok
+CREATE TABLE child2 (c INT PRIMARY KEY, p1 INT, p2 INT, FOREIGN KEY (p1, p2) REFERENCES parent2 (p1, p2))
+
+statement ok
+INSERT INTO parent2 VALUES
+  (10, 100),
+  (10, 150),
+  (20, 200)
+
+statement ok
+INSERT INTO child2 VALUES
+  (1, 10, 100),
+  (2, 10, NULL),
+  (3, 10, 150),
+  (4, 20, 200),
+  (5, NULL, 100)
+
+statement error delete on table "parent2" violates foreign key constraint on table "child2"
+DELETE FROM parent2 WHERE p1 = 10 AND p2 = 100
+
+statement ok
+DELETE FROM child2 WHERE p1 = 10 AND p2 = 100
+
+statement ok
+DELETE FROM parent2 WHERE p1 = 10 AND p2 = 100

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -258,6 +258,7 @@ func (f *stubFactory) ConstructDelete(
 	table cat.Table,
 	fetchCols exec.ColumnOrdinalSet,
 	returnCols exec.ColumnOrdinalSet,
+	skipFKChecks bool,
 ) (exec.Node, error) {
 	return struct{}{}, nil
 }

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -238,4 +238,14 @@ type ForeignKeyConstraint interface {
 
 	// MatchMethod returns the method used for comparing composite foreign keys.
 	MatchMethod() tree.CompositeKeyMatchMethod
+
+	// DeleteReferenceAction returns the action to be performed if the foreign key
+	// constraint would be violated.
+	DeleteReferenceAction() tree.ReferenceAction
+
+	// ID returns a stable identifier that is unique within both the origin and
+	// referenced tables.
+	// TODO(justin): we only need this to be able to match up constraints between
+	// the two tables, so delete this once descriptors are made symmetric.
+	ID() StableID
 }

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -234,8 +234,19 @@ func (b *Builder) buildDelete(del *memo.DeleteExpr) (execPlan, error) {
 	tab := md.Table(del.Table)
 	fetchColOrds := ordinalSetFromColList(del.FetchCols)
 	returnColOrds := ordinalSetFromColList(del.ReturnCols)
-	node, err := b.factory.ConstructDelete(input.root, tab, fetchColOrds, returnColOrds)
+	disableExecFKs := len(del.Checks) > 0
+	node, err := b.factory.ConstructDelete(
+		input.root,
+		tab,
+		fetchColOrds,
+		returnColOrds,
+		disableExecFKs,
+	)
 	if err != nil {
+		return execPlan{}, err
+	}
+
+	if err := b.buildFKChecks(del.Checks); err != nil {
 		return execPlan{}, err
 	}
 
@@ -244,6 +255,7 @@ func (b *Builder) buildDelete(del *memo.DeleteExpr) (execPlan, error) {
 	if del.NeedResults() {
 		ep.outputCols = mutationOutputColMap(del)
 	}
+
 	return ep, nil
 }
 
@@ -368,9 +380,9 @@ func (b *Builder) buildFKChecks(checks memo.FKChecksExpr) error {
 			var msg, details bytes.Buffer
 			if c.FKOutbound {
 				// Generate an error of the form:
-				//   ERROR:  insert or update on table "child" violates foreign key constraint "foo"
+				//   ERROR:  insert on table "child" violates foreign key constraint "foo"
 				//   DETAIL: Key (child_p)=(2) is not present in table "parent".
-				msg.WriteString("insert or update on table ")
+				msg.WriteString("insert on table ")
 				lex.EncodeEscapedSQLIdent(&msg, string(origin.Alias.TableName))
 				msg.WriteString(" violates foreign key constraint ")
 				lex.EncodeEscapedSQLIdent(&msg, fk.Name())
@@ -395,9 +407,17 @@ func (b *Builder) buildFKChecks(checks memo.FKChecksExpr) error {
 				details.WriteByte('.')
 			} else {
 				// Generate an error of the form:
-				//   ERROR:  update or delete on table "parent" violates foreign key constraint "child_child_p_fkey" on table "child"
+				//   ERROR:  delete on table "parent" violates foreign key constraint "child_child_p_fkey" on table "child"
 				//   DETAIL: Key (p)=(1) is still referenced from table "child".
-				panic(errors.AssertionFailedf("unimplemented"))
+				msg.WriteString("delete on table ")
+				lex.EncodeEscapedSQLIdent(&msg, string(referenced.Alias.TableName))
+				msg.WriteString(" violates foreign key constraint")
+				// TODO(justin): get the name of the FK constraint (it's not populated
+				// on this descriptor.
+				msg.WriteString(" on table ")
+				lex.EncodeEscapedSQLIdent(&msg, string(origin.Alias.TableName))
+				// TODO(justin): get the details, the columns are not populated on this
+				// descriptor.
 			}
 
 			return errors.WithDetail(

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -373,7 +373,11 @@ type Factory interface {
 	// as they appear in the table schema. The rowsNeeded parameter is true if a
 	// RETURNING clause needs the deleted row(s) as output.
 	ConstructDelete(
-		input Node, table cat.Table, fetchCols ColumnOrdinalSet, returnCols ColumnOrdinalSet,
+		input Node,
+		table cat.Table,
+		fetchCols ColumnOrdinalSet,
+		returnCols ColumnOrdinalSet,
+		skipFKChecks bool,
 	) (Node, error)
 
 	// ConstructDeleteRange creates a node that efficiently deletes contiguous

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -865,10 +865,6 @@ define WithScanPrivate {
 
     # InCols are the columns output by the expression referenced by this
     # expression. They correspond elementwise to the columns listed in OutCols.
-    # Every WithScanPrivate with the same WithID should have the same set of
-    # InCols, being the OutputCols of the binding for the referenced With.
-    # TODO(justin): this should be relaxed eventually so that we can prune
-    # these.
     InCols ColList
 
     # OutCols contains a list of columns which correspond elementwise to the

--- a/pkg/sql/opt/optbuilder/delete.go
+++ b/pkg/sql/opt/optbuilder/delete.go
@@ -85,6 +85,8 @@ func (b *Builder) buildDelete(del *tree.Delete, inScope *scope) (outScope *scope
 // buildDelete constructs a Delete operator, possibly wrapped by a Project
 // operator that corresponds to the given RETURNING clause.
 func (mb *mutationBuilder) buildDelete(returning tree.ReturningExprs) {
+	mb.buildFKChecks()
+
 	private := mb.makeMutationPrivate(returning != nil)
 	mb.outScope.expr = mb.b.factory.ConstructDelete(mb.outScope.expr, mb.checks, private)
 

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -170,6 +170,12 @@ func (mb *mutationBuilder) insertColID(tabOrd int) opt.ColumnID {
 	return mb.scopeOrdToColID(mb.insertOrds[tabOrd])
 }
 
+// fetchColID is a convenience method that returns the ID of the fetch column
+// for the given table column (specified by ordinal position in the table).
+func (mb *mutationBuilder) fetchColID(tabOrd int) opt.ColumnID {
+	return mb.scopeOrdToColID(mb.fetchOrds[tabOrd])
+}
+
 // buildInputForUpdateOrDelete constructs a Select expression from the fields in
 // the Update or Delete operator, similar to this:
 //
@@ -746,11 +752,18 @@ func (mb *mutationBuilder) buildFKChecks() {
 		return
 	}
 
-	// TODO(radu): only insert supported for now.
-	if mb.op != opt.InsertOp {
-		return
+	// TODO(radu): only insert/delete supported for now.
+	switch mb.op {
+	case opt.InsertOp:
+		mb.buildFKChecksForInsert()
+	case opt.DeleteOp:
+		mb.buildFKChecksForDelete()
+	default:
+		// Not supported yet.
 	}
+}
 
+func (mb *mutationBuilder) buildFKChecksForInsert() {
 	if mb.tab.OutboundForeignKeyCount() == 0 {
 		return
 	}
@@ -763,7 +776,6 @@ func (mb *mutationBuilder) buildFKChecks() {
 
 	for i, n := 0, mb.tab.OutboundForeignKeyCount(); i < n; i++ {
 		fk := mb.tab.OutboundForeignKey(i)
-		numCols := fk.ColumnCount()
 		item := memo.FKChecksItem{FKChecksItemPrivate: memo.FKChecksItemPrivate{
 			OriginTable: mb.tabID,
 			FKOutbound:  true,
@@ -774,20 +786,25 @@ func (mb *mutationBuilder) buildFKChecks() {
 		// referenced columns on the right.
 
 		refID := fk.ReferencedTableID()
-		refTab, err := mb.b.catalog.ResolveDataSourceByID(mb.b.ctx, refID)
+		ref, err := mb.b.catalog.ResolveDataSourceByID(mb.b.ctx, refID)
 		if err != nil {
 			panic(err)
 		}
+		refTab := ref.(cat.Table)
+
+		numCols := fk.ColumnCount()
+
 		// We need SELECT privileges on the referenced table.
 		mb.b.checkPrivilege(opt.DepByID(refID), refTab, privilege.SELECT)
 
 		refOrdinals := make([]int, numCols)
 		for j := range refOrdinals {
-			refOrdinals[j] = fk.ReferencedColumnOrdinal(refTab.(cat.Table), j)
+			refOrdinals[j] = fk.ReferencedColumnOrdinal(refTab, j)
 		}
 
 		refTabMeta := mb.b.addTable(refTab.(cat.Table), tree.NewUnqualifiedTableName(refTab.Name()))
 		item.ReferencedTable = refTabMeta.MetaID
+
 		scanScope := mb.b.buildScan(
 			refTabMeta,
 			refOrdinals,
@@ -797,7 +814,7 @@ func (mb *mutationBuilder) buildFKChecks() {
 		)
 
 		inputProps := mb.outScope.expr.Relational()
-		inputCols := make(opt.ColList, numCols)
+		insertedFKCols := make(opt.ColList, numCols)
 		var notNullInputCols opt.ColSet
 		for j := 0; j < numCols; j++ {
 			ord := fk.OriginColumnOrdinal(mb.tab, j)
@@ -807,7 +824,7 @@ func (mb *mutationBuilder) buildFKChecks() {
 				// columns.
 				panic(errors.AssertionFailedf("no value for FK column %d", ord))
 			}
-			inputCols[j] = inputColID
+			insertedFKCols[j] = inputColID
 
 			// If a table column is not nullable, NULLs cannot be inserted (the
 			// mutation will fail). So for the purposes of FK checks, we can treat
@@ -816,22 +833,8 @@ func (mb *mutationBuilder) buildFKChecks() {
 				notNullInputCols.Add(inputColID)
 			}
 		}
-
-		// Set up a WithRef; for this we have to synthesize new columns.
-		withRefCols := make(opt.ColList, numCols)
-		for i := 0; i < numCols; i++ {
-			c := mb.b.factory.Metadata().ColumnMeta(inputCols[i])
-			withRefCols[i] = mb.md.AddColumn(c.Alias, c.Type)
-		}
-
-		left := mb.b.factory.ConstructWithScan(&memo.WithScanPrivate{
-			ID:           mb.withID,
-			InCols:       inputCols,
-			OutCols:      withRefCols,
-			BindingProps: mb.outScope.expr.Relational(),
-		})
-
-		item.KeyCols = withRefCols
+		left, withScanCols := mb.makeFKInputScan(insertedFKCols)
+		item.KeyCols = withScanCols
 
 		if notNullInputCols.Len() < numCols {
 			// The columns we are inserting might have NULLs. These require special
@@ -856,11 +859,11 @@ func (mb *mutationBuilder) buildFKChecks() {
 				// Filter out any rows which have a NULL; build filters of the form
 				//   (a IS NOT NULL) AND (b IS NOT NULL) ...
 				filters := make(memo.FiltersExpr, 0, numCols-notNullInputCols.Len())
-				for i := range inputCols {
-					if !notNullInputCols.Contains(inputCols[i]) {
+				for i := range insertedFKCols {
+					if !notNullInputCols.Contains(insertedFKCols[i]) {
 						filters = append(filters, memo.FiltersItem{
 							Condition: mb.b.factory.ConstructIsNot(
-								mb.b.factory.ConstructVariable(withRefCols[i]),
+								mb.b.factory.ConstructVariable(withScanCols[i]),
 								memo.NullSingleton,
 							),
 						})
@@ -879,7 +882,7 @@ func (mb *mutationBuilder) buildFKChecks() {
 				// Build a filter of the form
 				//   (a IS NOT NULL) OR (b IS NOT NULL) ...
 				var condition opt.ScalarExpr
-				for _, col := range withRefCols {
+				for _, col := range withScanCols {
 					is := mb.b.factory.ConstructIsNot(
 						mb.b.factory.ConstructVariable(col),
 						memo.NullSingleton,
@@ -902,7 +905,7 @@ func (mb *mutationBuilder) buildFKChecks() {
 		antiJoinFilters := make(memo.FiltersExpr, numCols)
 		for j := 0; j < numCols; j++ {
 			antiJoinFilters[j].Condition = mb.b.factory.ConstructEq(
-				mb.b.factory.ConstructVariable(withRefCols[j]),
+				mb.b.factory.ConstructVariable(withScanCols[j]),
 				mb.b.factory.ConstructVariable(scanScope.cols[j].id),
 			)
 		}
@@ -913,6 +916,129 @@ func (mb *mutationBuilder) buildFKChecks() {
 
 		mb.checks = append(mb.checks, item)
 	}
+}
+
+func (mb *mutationBuilder) buildFKChecksForDelete() {
+	if mb.tab.InboundForeignKeyCount() == 0 {
+		return
+	}
+
+	mb.withID = mb.b.factory.Memo().NextWithID()
+
+	for i, n := 0, mb.tab.InboundForeignKeyCount(); i < n; i++ {
+		fk := mb.tab.InboundForeignKey(i)
+		item := memo.FKChecksItem{FKChecksItemPrivate: memo.FKChecksItemPrivate{
+			ReferencedTable: mb.tabID,
+			FKOutbound:      false,
+			FKOrdinal:       i,
+		}}
+
+		// Build a semi join, with the referenced FK columns on the left and the
+		// origin columns on the right.
+
+		origID := fk.OriginTableID()
+		orig, err := mb.b.catalog.ResolveDataSourceByID(mb.b.ctx, origID)
+		if err != nil {
+			panic(err)
+		}
+		origTab := orig.(cat.Table)
+
+		// Grab the outbound FK ref since the inbound one is incomplete.
+		// TODO(justin): remove this once descriptors are symmetric.
+		oFK := mb.getOutboundFKRef(origTab, fk)
+		// Bail, so that exec FK checks pick up on FK checks and perform them.
+		if oFK.DeleteReferenceAction() != tree.Restrict && oFK.DeleteReferenceAction() != tree.NoAction {
+			mb.checks = nil
+			return
+		}
+		numCols := oFK.ColumnCount()
+
+		// We need SELECT privileges on the origin table.
+		mb.b.checkPrivilege(opt.DepByID(origID), origTab, privilege.SELECT)
+
+		origOrdinals := make([]int, numCols)
+		for j := range origOrdinals {
+			origOrdinals[j] = fk.OriginColumnOrdinal(origTab.(cat.Table), j)
+		}
+
+		origTabMeta := mb.b.addTable(origTab, tree.NewUnqualifiedTableName(origTab.Name()))
+		item.OriginTable = origTabMeta.MetaID
+
+		scanScope := mb.b.buildScan(
+			origTabMeta,
+			origOrdinals,
+			&tree.IndexFlags{IgnoreForeignKeys: true},
+			includeMutations,
+			mb.b.allocScope(),
+		)
+
+		// deletedCols is the list of columns partaking in the FK for the deletion.
+		deletedFKCols := make(opt.ColList, numCols)
+		for j := 0; j < numCols; j++ {
+			ord := fk.ReferencedColumnOrdinal(mb.tab, j)
+			colID := mb.fetchColID(ord)
+			if colID == 0 {
+				panic(errors.AssertionFailedf("no value for FK column %d", ord))
+			}
+			deletedFKCols[j] = colID
+		}
+		left, withScanCols := mb.makeFKInputScan(deletedFKCols)
+		item.KeyCols = withScanCols
+
+		// Note that it's impossible to orphan a row whose FK key columns contain a
+		// NULL, since by definition a NULL never refers to an actual row (in
+		// either MATCH FULL or MATCH SIMPLE).
+		// Build the join filters:
+		//   (origin_a = referenced_a) AND (origin_b = referenced_b) AND ...
+		semiJoinFilters := make(memo.FiltersExpr, numCols)
+		for j := 0; j < numCols; j++ {
+			semiJoinFilters[j].Condition = mb.b.factory.ConstructEq(
+				mb.b.factory.ConstructVariable(withScanCols[j]),
+				mb.b.factory.ConstructVariable(scanScope.cols[j].id),
+			)
+		}
+
+		item.Check = mb.b.factory.ConstructSemiJoin(
+			left, scanScope.expr, semiJoinFilters, &memo.JoinPrivate{},
+		)
+
+		mb.checks = append(mb.checks, item)
+	}
+}
+
+// makeFKInputScan constructs a WithScan that iterates over the input to the
+// mutation operator in order to generate rows that must be checked for FK
+// violations.
+func (mb *mutationBuilder) makeFKInputScan(
+	inputCols opt.ColList,
+) (scan memo.RelExpr, outCols opt.ColList) {
+	// Set up a WithScan; for this we have to synthesize new columns.
+	outCols = make(opt.ColList, len(inputCols))
+	for i := 0; i < len(inputCols); i++ {
+		c := mb.b.factory.Metadata().ColumnMeta(inputCols[i])
+		outCols[i] = mb.md.AddColumn(c.Alias, c.Type)
+	}
+	scan = mb.b.factory.ConstructWithScan(&memo.WithScanPrivate{
+		ID:           mb.withID,
+		InCols:       inputCols,
+		OutCols:      outCols,
+		BindingProps: mb.outScope.expr.Relational(),
+	})
+	return scan, outCols
+}
+
+// getOutboundFKRef returns the corresponding FK reference from the other side.
+// TODO(justin): remove this once descriptors are symmetric.
+func (mb *mutationBuilder) getOutboundFKRef(
+	otherTab cat.Table, fk cat.ForeignKeyConstraint,
+) cat.ForeignKeyConstraint {
+	for i, n := 0, otherTab.OutboundForeignKeyCount(); i < n; i++ {
+		outboundRef := otherTab.OutboundForeignKey(i)
+		if outboundRef.ID() == fk.ID() {
+			return outboundRef
+		}
+	}
+	panic(errors.AssertionFailedf("didn't find matching outbound FK reference"))
 }
 
 // findNotNullIndexCol finds the first not-null column in the given index and

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-delete
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-delete
@@ -1,0 +1,177 @@
+exec-ddl
+CREATE TABLE parent (x INT, p INT PRIMARY KEY, other INT UNIQUE)
+----
+
+exec-ddl
+CREATE TABLE child (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(p))
+----
+
+build
+DELETE FROM child WHERE c = 4
+----
+delete child
+ ├── columns: <none>
+ ├── fetch columns: c:3(int) p:4(int)
+ └── select
+      ├── columns: c:3(int!null) p:4(int!null)
+      ├── scan child
+      │    └── columns: c:3(int!null) p:4(int!null)
+      └── filters
+           └── eq [type=bool]
+                ├── variable: c [type=int]
+                └── const: 4 [type=int]
+
+build
+DELETE FROM parent WHERE p = 3
+----
+delete parent
+ ├── columns: <none>
+ ├── fetch columns: x:4(int) parent.p:5(int) other:6(int)
+ ├── input binding: &1
+ ├── select
+ │    ├── columns: x:4(int) parent.p:5(int!null) other:6(int)
+ │    ├── scan parent
+ │    │    └── columns: x:4(int) parent.p:5(int!null) other:6(int)
+ │    └── filters
+ │         └── eq [type=bool]
+ │              ├── variable: parent.p [type=int]
+ │              └── const: 3 [type=int]
+ └── f-k-checks
+      └── f-k-checks-item: child(p) -> parent(p)
+           └── semi-join (hash)
+                ├── columns: p:9(int!null)
+                ├── with-scan &1
+                │    ├── columns: p:9(int!null)
+                │    └── mapping:
+                │         └──  parent.p:5(int) => p:9(int)
+                ├── scan child
+                │    └── columns: child.p:8(int!null)
+                └── filters
+                     └── eq [type=bool]
+                          ├── variable: p [type=int]
+                          └── variable: child.p [type=int]
+
+exec-ddl
+CREATE TABLE child2 (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(other))
+----
+
+build
+DELETE FROM parent WHERE p = 3
+----
+delete parent
+ ├── columns: <none>
+ ├── fetch columns: x:4(int) parent.p:5(int) parent.other:6(int)
+ ├── input binding: &1
+ ├── select
+ │    ├── columns: x:4(int) parent.p:5(int!null) parent.other:6(int)
+ │    ├── scan parent
+ │    │    └── columns: x:4(int) parent.p:5(int!null) parent.other:6(int)
+ │    └── filters
+ │         └── eq [type=bool]
+ │              ├── variable: parent.p [type=int]
+ │              └── const: 3 [type=int]
+ └── f-k-checks
+      ├── f-k-checks-item: child(p) -> parent(p)
+      │    └── semi-join (hash)
+      │         ├── columns: p:9(int!null)
+      │         ├── with-scan &1
+      │         │    ├── columns: p:9(int!null)
+      │         │    └── mapping:
+      │         │         └──  parent.p:5(int) => p:9(int)
+      │         ├── scan child
+      │         │    └── columns: child.p:8(int!null)
+      │         └── filters
+      │              └── eq [type=bool]
+      │                   ├── variable: p [type=int]
+      │                   └── variable: child.p [type=int]
+      └── f-k-checks-item: child2(p) -> parent(other)
+           └── semi-join (hash)
+                ├── columns: other:12(int)
+                ├── with-scan &1
+                │    ├── columns: other:12(int)
+                │    └── mapping:
+                │         └──  parent.other:6(int) => other:12(int)
+                ├── scan child2
+                │    └── columns: child2.p:11(int!null)
+                └── filters
+                     └── eq [type=bool]
+                          ├── variable: other [type=int]
+                          └── variable: child2.p [type=int]
+
+exec-ddl
+CREATE TABLE doubleparent (p1 INT, p2 INT, other INT, PRIMARY KEY (p1, p2))
+----
+
+exec-ddl
+CREATE TABLE doublechild (c INT PRIMARY KEY, p1 INT, p2 INT, FOREIGN KEY (p1, p2) REFERENCES doubleparent (p1, p2))
+----
+
+build
+DELETE FROM doubleparent WHERE p1 = 10
+----
+delete doubleparent
+ ├── columns: <none>
+ ├── fetch columns: doubleparent.p1:4(int) doubleparent.p2:5(int) other:6(int)
+ ├── input binding: &1
+ ├── select
+ │    ├── columns: doubleparent.p1:4(int!null) doubleparent.p2:5(int!null) other:6(int)
+ │    ├── scan doubleparent
+ │    │    └── columns: doubleparent.p1:4(int!null) doubleparent.p2:5(int!null) other:6(int)
+ │    └── filters
+ │         └── eq [type=bool]
+ │              ├── variable: doubleparent.p1 [type=int]
+ │              └── const: 10 [type=int]
+ └── f-k-checks
+      └── f-k-checks-item: doublechild(p1,p2) -> doubleparent(p1,p2)
+           └── semi-join (hash)
+                ├── columns: p1:10(int!null) p2:11(int!null)
+                ├── with-scan &1
+                │    ├── columns: p1:10(int!null) p2:11(int!null)
+                │    └── mapping:
+                │         ├──  doubleparent.p1:4(int) => p1:10(int)
+                │         └──  doubleparent.p2:5(int) => p2:11(int)
+                ├── scan doublechild
+                │    └── columns: doublechild.p1:8(int) doublechild.p2:9(int)
+                └── filters
+                     ├── eq [type=bool]
+                     │    ├── variable: p1 [type=int]
+                     │    └── variable: doublechild.p1 [type=int]
+                     └── eq [type=bool]
+                          ├── variable: p2 [type=int]
+                          └── variable: doublechild.p2 [type=int]
+
+build
+DELETE FROM doublechild WHERE p1 = 10
+----
+delete doublechild
+ ├── columns: <none>
+ ├── fetch columns: c:4(int) p1:5(int) p2:6(int)
+ └── select
+      ├── columns: c:4(int!null) p1:5(int!null) p2:6(int)
+      ├── scan doublechild
+      │    └── columns: c:4(int!null) p1:5(int) p2:6(int)
+      └── filters
+           └── eq [type=bool]
+                ├── variable: p1 [type=int]
+                └── const: 10 [type=int]
+
+exec-ddl
+CREATE TABLE child_cascade (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(p) ON DELETE CASCADE)
+----
+
+# Bail in the presence of CASCADE, so that exec-style FK checks take over.
+build
+DELETE FROM parent WHERE p = 1
+----
+delete parent
+ ├── columns: <none>
+ ├── fetch columns: x:4(int) parent.p:5(int) parent.other:6(int)
+ ├── input binding: &1
+ └── select
+      ├── columns: x:4(int) parent.p:5(int!null) parent.other:6(int)
+      ├── scan parent
+      │    └── columns: x:4(int) parent.p:5(int!null) parent.other:6(int)
+      └── filters
+           └── eq [type=bool]
+                ├── variable: parent.p [type=int]
+                └── const: 1 [type=int]

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -327,6 +327,14 @@ func (tc *Catalog) resolveFK(tab *Table, d *tree.ForeignKeyConstraintTableDef) {
 		tab.addIndex(&idx, nonUniqueIndex)
 	}
 
+	// We can't use the ordinal in either the origin or referenced table to
+	// identify the constraint, so we use a pairing function to uniquely combine
+	// them.
+	// TODO(justin): remove this once descriptors are symmetric.
+	targetOrd := len(targetTable.inboundFKs)
+	sourceOrd := len(tab.outboundFKs)
+	id := cat.StableID(1 + pair(targetOrd, sourceOrd))
+
 	fk := ForeignKeyConstraint{
 		name:                     constraintName,
 		originTableID:            tab.ID(),
@@ -335,9 +343,17 @@ func (tc *Catalog) resolveFK(tab *Table, d *tree.ForeignKeyConstraintTableDef) {
 		referencedColumnOrdinals: toCols,
 		validated:                true,
 		matchMethod:              d.Match,
+		deleteAction:             d.Actions.Delete,
+		id:                       id,
 	}
 	tab.outboundFKs = append(tab.outboundFKs, fk)
 	targetTable.inboundFKs = append(targetTable.inboundFKs, fk)
+}
+
+// pair is a one-to-one function from pairs of integers to integers. See
+// https://en.wikipedia.org/wiki/Pairing_function.
+func pair(n, m int) int {
+	return (n+m)*(n+m+1)/2 + m
 }
 
 func (tt *Table) addColumn(def *tree.ColumnTableDef) {

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -1019,8 +1019,11 @@ type ForeignKeyConstraint struct {
 	originColumnOrdinals     []int
 	referencedColumnOrdinals []int
 
-	validated   bool
-	matchMethod tree.CompositeKeyMatchMethod
+	validated    bool
+	matchMethod  tree.CompositeKeyMatchMethod
+	deleteAction tree.ReferenceAction
+
+	id cat.StableID
 }
 
 var _ cat.ForeignKeyConstraint = &ForeignKeyConstraint{}
@@ -1076,6 +1079,16 @@ func (fk *ForeignKeyConstraint) Validated() bool {
 // MatchMethod is part of the cat.ForeignKeyConstraint interface.
 func (fk *ForeignKeyConstraint) MatchMethod() tree.CompositeKeyMatchMethod {
 	return fk.matchMethod
+}
+
+// DeleteReferenceAction is part of the cat.ForeignKeyConstraint interface.
+func (fk *ForeignKeyConstraint) DeleteReferenceAction() tree.ReferenceAction {
+	return fk.deleteAction
+}
+
+// ID is part of the cat.ForeignKeyConstraint interface.
+func (fk *ForeignKeyConstraint) ID() cat.StableID {
+	return fk.id
 }
 
 // Sequence implements the cat.Sequence interface for testing purposes.

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1652,6 +1652,7 @@ func (ef *execFactory) ConstructDelete(
 	table cat.Table,
 	fetchColOrdSet exec.ColumnOrdinalSet,
 	returnColOrdSet exec.ColumnOrdinalSet,
+	skipFKChecks bool,
 ) (exec.Node, error) {
 	// Derive table and column descriptors.
 	rowsNeeded := !returnColOrdSet.Empty()
@@ -1670,6 +1671,10 @@ func (ef *execFactory) ConstructDelete(
 		return fastPathNode, nil
 	}
 
+	checkFKs := row.CheckFKs
+	if skipFKChecks {
+		checkFKs = row.SkipFKs
+	}
 	// Create the table deleter, which does the bulk of the work. In the HP,
 	// the deleter derives the columns that need to be fetched. By contrast, the
 	// CBO will have already determined the set of fetch columns, and passes
@@ -1679,7 +1684,7 @@ func (ef *execFactory) ConstructDelete(
 		tabDesc,
 		fkTables,
 		fetchColDescs,
-		row.CheckFKs,
+		checkFKs,
 		ef.planner.EvalContext(),
 		&ef.planner.alloc,
 	)

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2980,8 +2980,18 @@ func (x ForeignKeyReference_Match) String() string {
 	}
 }
 
-// ForeignKeyReferenceActionValue allows the conversion between a
+// ForeignKeyReferenceActionType allows the conversion between a
 // tree.ReferenceAction and a ForeignKeyReference_Action.
+var ForeignKeyReferenceActionType = [...]tree.ReferenceAction{
+	ForeignKeyReference_NO_ACTION:   tree.NoAction,
+	ForeignKeyReference_RESTRICT:    tree.Restrict,
+	ForeignKeyReference_SET_DEFAULT: tree.SetDefault,
+	ForeignKeyReference_SET_NULL:    tree.SetNull,
+	ForeignKeyReference_CASCADE:     tree.Cascade,
+}
+
+// ForeignKeyReferenceActionValue allows the conversion between a
+// ForeignKeyReference_Action and a tree.ReferenceAction.
 var ForeignKeyReferenceActionValue = [...]ForeignKeyReference_Action{
 	tree.NoAction:   ForeignKeyReference_NO_ACTION,
 	tree.Restrict:   ForeignKeyReference_RESTRICT,


### PR DESCRIPTION
This commit adds FK checks for DELETE statements. It's very structurally
similar to INSERT, I tried to abstract things to avoid having the
duplicated structure here but there were enough differences between the
two (referring to the Referenced table vs. the Origin table, etc) that
it felt to me as though it was clearer to just extract some helpers
where possible.

@RaduBerinde The existing structure in the method looked to me like you were planning for it to be more unified than this so if you have thoughts on what that might look like I'm interested to hear them :)

We also introduce an ID field to the foreign key interface so that we
can work around the fact that inbound FK descriptors do not contain the
number of columns participating in the constraint, it's my hope that
this method can be deleted when the descriptors are unified.

Release note: None