### PR TITLE
build: compile RocksDB with -Wno-error-shadow

### DIFF
--- a/c-deps/rocksdb-rebuild
+++ b/c-deps/rocksdb-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing rocksdb CMake flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-12
+13


### PR DESCRIPTION
Clang 11.x (llvm 8.x) has new shadow warnings about enums which are
being tickled by RocksDB. As a temporary workaround, don't error out on
these warnings.

Release note: None