### PR TITLE
util/quotapool: make sync.Pools global

### DIFF
--- a/pkg/util/quotapool/intpool.go
+++ b/pkg/util/quotapool/intpool.go
@@ -33,10 +33,6 @@ type IntPool struct {
 	// The capacity is originally set when the IntPool is constructed, and then it
 	// can be decreased by IntAlloc.Freeze().
 	capacity uint64
-
-	intAllocSyncPool       sync.Pool
-	intRequestSyncPool     sync.Pool
-	intFuncRequestSyncPool sync.Pool
 }
 
 // IntAlloc is an allocated quantity which should be released.
@@ -98,15 +94,6 @@ func (ia *intAlloc) Merge(other Resource) {
 func NewIntPool(name string, capacity uint64, options ...Option) *IntPool {
 	p := IntPool{
 		capacity: capacity,
-		intAllocSyncPool: sync.Pool{
-			New: func() interface{} { return new(IntAlloc) },
-		},
-		intRequestSyncPool: sync.Pool{
-			New: func() interface{} { return new(intRequest) },
-		},
-		intFuncRequestSyncPool: sync.Pool{
-			New: func() interface{} { return new(intFuncRequest) },
-		},
 	}
 	p.qp = New(name, (*intAlloc)(p.newIntAlloc(capacity)), options...)
 	return &p
@@ -212,41 +199,53 @@ func (p *IntPool) Close(reason string) {
 	p.qp.Close(reason)
 }
 
+var intAllocSyncPool = sync.Pool{
+	New: func() interface{} { return new(IntAlloc) },
+}
+
 func (p *IntPool) newIntAlloc(v uint64) *IntAlloc {
-	ia := p.intAllocSyncPool.Get().(*IntAlloc)
+	ia := intAllocSyncPool.Get().(*IntAlloc)
 	*ia = IntAlloc{p: p, alloc: v}
 	return ia
 }
 
 func (p *IntPool) putIntAlloc(ia *IntAlloc) {
-	p.intAllocSyncPool.Put(ia)
+	*ia = IntAlloc{}
+	intAllocSyncPool.Put(ia)
+}
+
+var intRequestSyncPool = sync.Pool{
+	New: func() interface{} { return new(intRequest) },
 }
 
 // newIntRequest allocates an intRequest from the sync.Pool.
 // It should be returned with putIntRequest.
 func (p *IntPool) newIntRequest(v uint64) *intRequest {
-	r := p.intRequestSyncPool.Get().(*intRequest)
-	r.want = v
+	r := intRequestSyncPool.Get().(*intRequest)
+	*r = intRequest{want: v}
 	return r
 }
 
 func (p *IntPool) putIntRequest(r *intRequest) {
-	p.intRequestSyncPool.Put(r)
+	*r = intRequest{}
+	intRequestSyncPool.Put(r)
+}
+
+var intFuncRequestSyncPool = sync.Pool{
+	New: func() interface{} { return new(intFuncRequest) },
 }
 
 // newIntRequest allocates an intFuncRequest from the sync.Pool.
 // It should be returned with putIntFuncRequest.
 func (p *IntPool) newIntFuncRequest(f IntRequestFunc) *intFuncRequest {
-	r := p.intFuncRequestSyncPool.Get().(*intFuncRequest)
-	r.f = f
-	r.p = p
+	r := intFuncRequestSyncPool.Get().(*intFuncRequest)
+	*r = intFuncRequest{f: f, p: p}
 	return r
 }
 
 func (p *IntPool) putIntFuncRequest(r *intFuncRequest) {
-	r.f = nil
-	r.took = 0
-	p.intFuncRequestSyncPool.Put(r)
+	*r = intFuncRequest{}
+	intFuncRequestSyncPool.Put(r)
 }
 
 // Capacity returns the amount of quota managed by this pool.


### PR DESCRIPTION
This commit moves the sync.Pool objects in this package from struct membership
to package globals. Each sync.Pool has runtime overhead and there's no
correctness problem to sharing sync.Pool objects so long as the objects they
store are properly zero'd before being put back into the pool.

Thanks @petermattis for the catch. See https://github.com/cockroachdb/cockroach/pull/38759#pullrequestreview-267345161. 

Release note: None