### PR TITLE
internal/sqlsmith: add a common example table to use in places

### DIFF
--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -254,3 +254,28 @@ func PostgresMode() SmitherOption {
 		IgnoreFNs("^version"),
 	}
 }
+
+// SeedTable is a SQL statement that creates a table with most data types and
+// some sample rows.
+const SeedTable = `
+CREATE TABLE IF NOT EXISTS tab_orig AS
+	SELECT
+		g::INT2 AS _int2,
+		g::INT4 AS _int4,
+		g::INT8 AS _int8,
+		g::FLOAT4 AS _float4,
+		g::FLOAT8 AS _float8,
+		'2001-01-01'::DATE + g AS _date,
+		'2001-01-01'::TIMESTAMP + g * '1 day'::INTERVAL AS _timestamp,
+		'2001-01-01'::TIMESTAMPTZ + g * '1 day'::INTERVAL AS _timestamptz,
+		g * '1 day'::INTERVAL AS _interval,
+		g % 2 = 1 AS _bool,
+		g::DECIMAL AS _decimal,
+		g::STRING AS _string,
+		g::STRING::BYTES AS _bytes,
+		substring('00000000-0000-0000-0000-' || g::STRING || '00000000000', 1, 36)::UUID AS _uuid,
+		'0.0.0.0'::INET + g AS _inet,
+		g::STRING::JSONB AS _jsonb
+	FROM
+		generate_series(1, 5) AS g;
+`

--- a/pkg/internal/sqlsmith/sqlsmith_test.go
+++ b/pkg/internal/sqlsmith/sqlsmith_test.go
@@ -49,27 +49,7 @@ func TestGenerateParse(t *testing.T) {
 	rnd, _ := randutil.NewPseudoRand()
 
 	db := sqlutils.MakeSQLRunner(sqlDB)
-	db.Exec(t, `
-		CREATE TABLE t (
-			_bool bool,
-			_bytes bytes,
-			_date date,
-			_decimal decimal,
-			_float4 float4,
-			_float8 float8,
-			_inet inet,
-			_int4 int4,
-			_int8 int8,
-			_interval interval,
-			_jsonb jsonb,
-			_string string,
-			_time time,
-			_timestamp timestamp,
-			_timestamptz timestamptz,
-			_uuid uuid
-		);
-		INSERT INTO t DEFAULT VALUES;
-	`)
+	db.Exec(t, SeedTable)
 
 	var opts []SmitherOption
 	if *flagNoMutations {
@@ -79,7 +59,7 @@ func TestGenerateParse(t *testing.T) {
 		opts = append(opts, DisableWith())
 	}
 
-	smither, err := NewSmither(nil, rnd, opts...)
+	smither, err := NewSmither(sqlDB, rnd, opts...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -511,6 +511,10 @@ func TestRandomSyntaxSQLSmith(t *testing.T) {
 			fmt.Printf("%s;\n", stmt)
 			tableStmts[i] = stmt
 		}
+		if err := db.exec(ctx, sqlsmith.SeedTable); err != nil {
+			return err
+		}
+		fmt.Printf("%s;\n", sqlsmith.SeedTable)
 		var err error
 		smither, err = sqlsmith.NewSmither(db.db, r.Rnd, sqlsmith.DisableMutations())
 		return err


### PR DESCRIPTION
Also actually hook up this table to the sqlsmith internal tests.

Release note: None