### PR TITLE
engine: add batch size limits and ResumeSpan to RevertRange

### DIFF
--- a/pkg/storage/batcheval/cmd_revert_range_test.go
+++ b/pkg/storage/batcheval/cmd_revert_range_test.go
@@ -111,7 +111,7 @@ func TestCmdRevertRange(t *testing.T) {
 		StartKey: roachpb.RKey(startKey),
 		EndKey:   roachpb.RKey(endKey),
 	}
-	cArgs := CommandArgs{Header: roachpb.Header{RangeID: desc.RangeID, Timestamp: tsC}}
+	cArgs := CommandArgs{Header: roachpb.Header{RangeID: desc.RangeID, Timestamp: tsC}, MaxKeys: 2}
 	evalCtx := &mockEvalCtx{desc: &desc, clock: hlc.NewClock(hlc.UnixNano, time.Nanosecond), stats: stats}
 	cArgs.EvalCtx = evalCtx
 	afterStats := getStats(t, eng)
@@ -119,21 +119,39 @@ func TestCmdRevertRange(t *testing.T) {
 		name     string
 		ts       hlc.Timestamp
 		expected []byte
+		resumes  int
 	}{
-		{"revert revert to time A", tsA, sumA},
-		{"revert revert to time B", tsB, sumB},
-		{"revert revert to time C (nothing)", tsC, sumC},
+		{"revert revert to time A", tsA, sumA, 4},
+		{"revert revert to time B", tsB, sumB, 4},
+		{"revert revert to time C (nothing)", tsC, sumC, 0},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			batch := &wrappedBatch{Batch: eng.NewBatch()}
 			defer batch.Close()
 
-			cArgs.Stats = &enginepb.MVCCStats{}
-			cArgs.Args = &roachpb.RevertRangeRequest{
+			req := roachpb.RevertRangeRequest{
 				RequestHeader: roachpb.RequestHeader{Key: startKey, EndKey: endKey}, TargetTime: tc.ts,
 			}
-			if _, err := RevertRange(ctx, batch, cArgs, &roachpb.RevertRangeResponse{}); err != nil {
-				t.Fatal(err)
+			cArgs.Stats = &enginepb.MVCCStats{}
+			cArgs.Args = &req
+			var resumes int
+			for {
+				var reply roachpb.RevertRangeResponse
+				if _, err := RevertRange(ctx, batch, cArgs, &reply); err != nil {
+					t.Fatal(err)
+				}
+				if reply.ResumeSpan == nil {
+					break
+				}
+				resumes++
+				req.RequestHeader.Key = reply.ResumeSpan.Key
+			}
+			if resumes != tc.resumes {
+				// NB: since ClearTimeRange buffers keys until it hits one that is not
+				// going to be cleared, and thus may exceed the max batch size by up to
+				// the buffer size (64) when it flushes after breaking out of the loop,
+				// expected resumes isn't *quite* a simple num_cleared_keys/batch_size.
+				t.Fatalf("expected %d resumes, got %d", tc.resumes, resumes)
 			}
 			if reverted := hashRange(t, batch, startKey, endKey); !bytes.Equal(reverted, tc.expected) {
 				t.Error("expected reverted keys to match checksum")
@@ -186,20 +204,36 @@ func TestCmdRevertRange(t *testing.T) {
 		ts          hlc.Timestamp
 		expectErr   bool
 		expectedSum []byte
+		resumes     int
 	}{
-		{"hit intent", tsB, true, nil},
-		{"hit intent exactly", tsC, false, sumCIntent},
-		{"clear above intent", tsC.Add(0, 1), false, sumCIntent},
-		{"clear nothing above intent", tsD, false, sumD},
+		{"hit intent", tsB, true, nil, 2},
+		{"hit intent exactly", tsC, false, sumCIntent, 2},
+		{"clear above intent", tsC.Add(0, 1), false, sumCIntent, 2},
+		{"clear nothing above intent", tsD, false, sumD, 0},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			batch := &wrappedBatch{Batch: eng.NewBatch()}
 			defer batch.Close()
 			cArgs.Stats = &enginepb.MVCCStats{}
-			cArgs.Args = &roachpb.RevertRangeRequest{
+			req := roachpb.RevertRangeRequest{
 				RequestHeader: roachpb.RequestHeader{Key: startKey, EndKey: endKey}, TargetTime: tc.ts,
 			}
-			_, err := RevertRange(ctx, batch, cArgs, &roachpb.RevertRangeResponse{})
+			cArgs.Args = &req
+			var resumes int
+			var err error
+			for {
+				var reply roachpb.RevertRangeResponse
+				_, err = RevertRange(ctx, batch, cArgs, &reply)
+				if err != nil || reply.ResumeSpan == nil {
+					break
+				}
+				req.RequestHeader.Key = reply.ResumeSpan.Key
+				resumes++
+			}
+			if resumes != tc.resumes {
+				t.Fatalf("expected %d resumes, got %d", tc.resumes, resumes)
+			}
+
 			if tc.expectErr {
 				if !testutils.IsError(err, "intents") {
 					t.Fatalf("expected write intent error; got: %T %+v", err, err)

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -1849,13 +1849,26 @@ func MVCCMerge(
 // apparent effect of "reverting" the range to startTime if all of the older
 // revisions of cleared keys are still available (i.e. have not been GC'ed).
 //
+// Long runs of keys that all qualify for clearing will be cleared via a single
+// clear-range operation. Once maxBatchSize Clear and ClearRange operations are
+// hit during iteration, the next matching key is instead returned in the
+// resumeSpan. It is possible to exceed maxBatchSize by up to the size of the
+// buffer of keys selected for deletion but not yet flushed (as done to detect
+// long runs for cleaning in a single ClearRange).
+//
 // This function does not handle the stats computations to determine the correct
 // incremental deltas of clearing these keys (and correctly determining if it
 // does or not not change the live and gc keys) so the caller is responsible for
 // recomputing stats over the resulting span if needed.
 func MVCCClearTimeRange(
-	ctx context.Context, batch ReadWriter, key, endKey roachpb.Key, startTime, endTime hlc.Timestamp,
-) error {
+	ctx context.Context,
+	batch ReadWriter,
+	key, endKey roachpb.Key,
+	startTime, endTime hlc.Timestamp,
+	maxBatchSize int64,
+) (*roachpb.Span, error) {
+	var batchSize int64
+	var resume *roachpb.Span
 
 	// When iterating, instead of immediately clearing a matching key we can
 	// accumulate it in buf until either a) useRangeClearThreshold is reached and
@@ -1895,6 +1908,7 @@ func MVCCClearTimeRange(
 			if err := batch.ClearRange(clearRangeStart, nonMatch); err != nil {
 				return err
 			}
+			batchSize++
 			clearRangeStart = MVCCKey{}
 		} else if bufSize > 0 {
 			for i := 0; i < bufSize; i++ {
@@ -1902,6 +1916,7 @@ func MVCCClearTimeRange(
 					return err
 				}
 			}
+			batchSize += int64(bufSize)
 			bufSize = 0
 		}
 		return nil
@@ -1924,7 +1939,7 @@ func MVCCClearTimeRange(
 	for it.Seek(MVCCKey{Key: key}); ; it.Next() {
 		ok, err := it.Valid()
 		if err != nil {
-			return err
+			return nil, err
 		} else if !ok {
 			break
 		}
@@ -1940,7 +1955,7 @@ func MVCCClearTimeRange(
 		var meta enginepb.MVCCMetadata
 		if !k.IsValue() {
 			if err := it.ValueProto(&meta); err != nil {
-				return err
+				return nil, err
 			}
 			ts := hlc.Timestamp(meta.Timestamp)
 			if meta.Txn != nil && startTime.Less(ts) && !endTime.Less(ts) {
@@ -1948,21 +1963,25 @@ func MVCCClearTimeRange(
 					Intents: []roachpb.Intent{{Span: roachpb.Span{Key: append([]byte{}, k.Key...)},
 						Status: roachpb.PENDING, Txn: *meta.Txn,
 					}}}
-				return err
+				return nil, err
 			}
 		}
 
 		if startTime.Less(k.Timestamp) && !endTime.Less(k.Timestamp) {
+			if batchSize >= maxBatchSize {
+				resume = &roachpb.Span{Key: append([]byte{}, k.Key...)}
+				break
+			}
 			clearMatchingKey(k)
 		} else {
 			// This key does not match, so we need to flush our run of matching keys.
 			if err := flushClearedKeys(k); err != nil {
-				return err
+				return nil, err
 			}
 		}
 	}
 
-	return flushClearedKeys(MVCCKey{Key: key})
+	return resume, flushClearedKeys(MVCCKey{Key: key})
 }
 
 // MVCCDeleteRange deletes the range of key/value pairs specified by start and

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -2434,7 +2434,8 @@ func TestMVCCClearTimeRange(t *testing.T) {
 	t.Run("clear > ts0", func(t *testing.T) {
 		e := setupKVs(t)
 		defer e.Close()
-		require.NoError(t, MVCCClearTimeRange(ctx, e, keyMin, keyMax, ts0, ts5))
+		_, err := MVCCClearTimeRange(ctx, e, keyMin, keyMax, ts0, ts5, 10)
+		require.NoError(t, err)
 		assertKVs(t, e, ts0, ts0Content)
 		assertKVs(t, e, ts1, ts0Content)
 		assertKVs(t, e, ts5, ts0Content)
@@ -2443,7 +2444,8 @@ func TestMVCCClearTimeRange(t *testing.T) {
 	t.Run("clear > ts1 ", func(t *testing.T) {
 		e := setupKVs(t)
 		defer e.Close()
-		require.NoError(t, MVCCClearTimeRange(ctx, e, keyMin, keyMax, ts1, ts5))
+		_, err := MVCCClearTimeRange(ctx, e, keyMin, keyMax, ts1, ts5, 10)
+		require.NoError(t, err)
 		assertKVs(t, e, ts1, ts1Content)
 		assertKVs(t, e, ts2, ts1Content)
 		assertKVs(t, e, ts5, ts1Content)
@@ -2452,7 +2454,8 @@ func TestMVCCClearTimeRange(t *testing.T) {
 	t.Run("clear > ts2", func(t *testing.T) {
 		e := setupKVs(t)
 		defer e.Close()
-		require.NoError(t, MVCCClearTimeRange(ctx, e, keyMin, keyMax, ts2, ts5))
+		_, err := MVCCClearTimeRange(ctx, e, keyMin, keyMax, ts2, ts5, 10)
+		require.NoError(t, err)
 		assertKVs(t, e, ts2, ts2Content)
 		assertKVs(t, e, ts5, ts2Content)
 	})
@@ -2460,7 +2463,8 @@ func TestMVCCClearTimeRange(t *testing.T) {
 	t.Run("clear > ts3", func(t *testing.T) {
 		e := setupKVs(t)
 		defer e.Close()
-		require.NoError(t, MVCCClearTimeRange(ctx, e, keyMin, keyMax, ts3, ts5))
+		_, err := MVCCClearTimeRange(ctx, e, keyMin, keyMax, ts3, ts5, 10)
+		require.NoError(t, err)
 		assertKVs(t, e, ts3, ts3Content)
 		assertKVs(t, e, ts5, ts3Content)
 	})
@@ -2468,7 +2472,8 @@ func TestMVCCClearTimeRange(t *testing.T) {
 	t.Run("clear > ts4 (nothing) ", func(t *testing.T) {
 		e := setupKVs(t)
 		defer e.Close()
-		require.NoError(t, MVCCClearTimeRange(ctx, e, keyMin, keyMax, ts4, ts5))
+		_, err := MVCCClearTimeRange(ctx, e, keyMin, keyMax, ts4, ts5, 10)
+		require.NoError(t, err)
 		assertKVs(t, e, ts4, ts4Content)
 		assertKVs(t, e, ts5, ts4Content)
 	})
@@ -2476,7 +2481,8 @@ func TestMVCCClearTimeRange(t *testing.T) {
 	t.Run("clear > ts5 (nothing)", func(t *testing.T) {
 		e := setupKVs(t)
 		defer e.Close()
-		require.NoError(t, MVCCClearTimeRange(ctx, e, keyMin, keyMax, ts5, ts5))
+		_, err := MVCCClearTimeRange(ctx, e, keyMin, keyMax, ts5, ts5, 10)
+		require.NoError(t, err)
 		assertKVs(t, e, ts4, ts4Content)
 		assertKVs(t, e, ts5, ts4Content)
 	})
@@ -2484,7 +2490,8 @@ func TestMVCCClearTimeRange(t *testing.T) {
 	t.Run("clear up to k5 to ts0", func(t *testing.T) {
 		e := setupKVs(t)
 		defer e.Close()
-		require.NoError(t, MVCCClearTimeRange(ctx, e, testKey1, testKey5, ts0, ts5))
+		_, err := MVCCClearTimeRange(ctx, e, testKey1, testKey5, ts0, ts5, 10)
+		require.NoError(t, err)
 		assertKVs(t, e, ts2, []roachpb.KeyValue{{Key: testKey5, Value: v2}})
 		assertKVs(t, e, ts5, []roachpb.KeyValue{{Key: testKey5, Value: v4}})
 	})
@@ -2492,7 +2499,8 @@ func TestMVCCClearTimeRange(t *testing.T) {
 	t.Run("clear > ts0 in empty span (nothing)", func(t *testing.T) {
 		e := setupKVs(t)
 		defer e.Close()
-		require.NoError(t, MVCCClearTimeRange(ctx, e, testKey3, testKey5, ts0, ts5))
+		_, err := MVCCClearTimeRange(ctx, e, testKey3, testKey5, ts0, ts5, 10)
+		require.NoError(t, err)
 		assertKVs(t, e, ts2, ts2Content)
 		assertKVs(t, e, ts5, ts4Content)
 	})
@@ -2500,7 +2508,8 @@ func TestMVCCClearTimeRange(t *testing.T) {
 	t.Run("clear > ts0 in empty span [k3,k5) (nothing)", func(t *testing.T) {
 		e := setupKVs(t)
 		defer e.Close()
-		require.NoError(t, MVCCClearTimeRange(ctx, e, testKey3, testKey5, ts0, ts5))
+		_, err := MVCCClearTimeRange(ctx, e, testKey3, testKey5, ts0, ts5, 10)
+		require.NoError(t, err)
 		assertKVs(t, e, ts2, ts2Content)
 		assertKVs(t, e, ts5, ts4Content)
 	})
@@ -2508,7 +2517,8 @@ func TestMVCCClearTimeRange(t *testing.T) {
 	t.Run("clear k3 and up in ts0 > x >= ts1 (nothing)", func(t *testing.T) {
 		e := setupKVs(t)
 		defer e.Close()
-		require.NoError(t, MVCCClearTimeRange(ctx, e, testKey3, keyMax, ts0, ts1))
+		_, err := MVCCClearTimeRange(ctx, e, testKey3, keyMax, ts0, ts1, 10)
+		require.NoError(t, err)
 		assertKVs(t, e, ts2, ts2Content)
 		assertKVs(t, e, ts5, ts4Content)
 	})
@@ -2523,19 +2533,22 @@ func TestMVCCClearTimeRange(t *testing.T) {
 	t.Run("clear everything hitting intent fails", func(t *testing.T) {
 		e := setupKVsWithIntent(t)
 		defer e.Close()
-		require.EqualError(t, MVCCClearTimeRange(ctx, e, keyMin, keyMax, ts0, ts5), "conflicting intents on \"/db3\"")
+		_, err := MVCCClearTimeRange(ctx, e, keyMin, keyMax, ts0, ts5, 10)
+		require.EqualError(t, err, "conflicting intents on \"/db3\"")
 	})
 
 	t.Run("clear exactly hitting intent fails", func(t *testing.T) {
 		e := setupKVsWithIntent(t)
 		defer e.Close()
-		require.EqualError(t, MVCCClearTimeRange(ctx, e, testKey3, testKey4, ts2, ts3), "conflicting intents on \"/db3\"")
+		_, err := MVCCClearTimeRange(ctx, e, testKey3, testKey4, ts2, ts3, 10)
+		require.EqualError(t, err, "conflicting intents on \"/db3\"")
 	})
 
 	t.Run("clear everything above intent", func(t *testing.T) {
 		e := setupKVsWithIntent(t)
 		defer e.Close()
-		require.NoError(t, MVCCClearTimeRange(ctx, e, keyMin, keyMax, ts3, ts5))
+		_, err := MVCCClearTimeRange(ctx, e, keyMin, keyMax, ts3, ts5, 10)
+		require.NoError(t, err)
 		assertKVs(t, e, ts2, ts2Content)
 
 		// Scan (< k3 to avoid intent) to confirm that k2 was indeed reverted to
@@ -2559,7 +2572,8 @@ func TestMVCCClearTimeRange(t *testing.T) {
 		e := setupKVsWithIntent(t)
 		defer e.Close()
 		assertKVs(t, e, ts2, ts2Content)
-		require.NoError(t, MVCCClearTimeRange(ctx, e, keyMin, keyMax, ts1, ts2))
+		_, err := MVCCClearTimeRange(ctx, e, keyMin, keyMax, ts1, ts2, 10)
+		require.NoError(t, err)
 		assertKVs(t, e, ts2, ts1Content)
 	})
 }
@@ -2632,7 +2646,15 @@ func TestMVCCClearTimeRangeOnRandomData(t *testing.T) {
 			require.NoError(t, err)
 
 			// Revert to the revert time.
-			require.NoError(t, MVCCClearTimeRange(ctx, e, keyMin, keyMax, revertTo, now))
+			startKey := keyMin
+			for {
+				resume, err := MVCCClearTimeRange(ctx, e, startKey, keyMax, revertTo, now, 100)
+				require.NoError(t, err)
+				if resume == nil {
+					break
+				}
+				startKey = resume.Key
+			}
 
 			// Scanning at "now" post-revert should yield the same result as scanning
 			// at revert-time pre-revert.


### PR DESCRIPTION
RevertRange is expected to be run on entire tables, so it is possible it could need to
clear millions of keys and while it will attempt to use ClearRange when possible, in
some cases it could produce very large numbers of individual Clears in a given batch.
This change adds support for limiting the batch size and returning a ResumeSpan instead
allowing a client to run a paginated Revert over very large spans.

Release note: none.