### PR TITLE
exec: minor cleanup of planning of hash and merge joiners

### DIFF
--- a/pkg/sql/distsqlrun/columnar_operators_test.go
+++ b/pkg/sql/distsqlrun/columnar_operators_test.go
@@ -382,6 +382,8 @@ func generateColumnOrdering(
 // comparison which can be either comparing a column from the left against a
 // column from the right or comparing a column from either side against a
 // constant.
+// TODO(yuzefovich): update this once LEFT SEMI or LEFT ANTI is supported with
+// ON expression.
 func generateOnExpr(rng *rand.Rand, nCols int, nEqCols int, maxNum int) distsqlpb.Expression {
 	var comparison string
 	r := rng.Float64()

--- a/pkg/sql/logictest/testdata/logic_test/exec_hash_join
+++ b/pkg/sql/logictest/testdata/logic_test/exec_hash_join
@@ -1,7 +1,7 @@
 # LogicTest: local-vec
 
 # Test that the exec HashJoiner follows SQL NULL semantics for ON predicate
-# equivalence. The use of sorts here force the planning of merge join.
+# equivalence.
 
 statement ok
 CREATE TABLE  t1 (k INT PRIMARY KEY, v INT)
@@ -34,41 +34,41 @@ statement ok
 INSERT INTO c VALUES (1, 'a'), (1, 'b'), (2, 'c')
 
 query IIII
-SELECT * FROM t1 JOIN t2 ON t1.k = t2.x
+SELECT * FROM t1 INNER HASH JOIN t2 ON t1.k = t2.x ORDER BY 1
 ----
 0  4  0  5
 3  4  3  2
 
-query IIII rowsort
-SELECT * FROM a AS a1 JOIN a AS a2 ON a1.k = a2.v
+query IIII
+SELECT * FROM a AS a1 JOIN a AS a2 ON a1.k = a2.v ORDER BY 1
 ----
 0  1  2  0
 1  2  0  1
 2  0  1  2
 
-query IIII rowsort
-SELECT * FROM a AS a2 JOIN a AS a1 ON a1.k = a2.v
+query IIII
+SELECT * FROM a AS a2 JOIN a AS a1 ON a1.k = a2.v ORDER BY 1
 ----
 0  1  1  2
 1  2  2  0
 2  0  0  1
 
 query II
-SELECT t2.y, t1.v FROM t1 JOIN t2 ON t1.k = t2.x
+SELECT t2.y, t1.v FROM t1 INNER HASH JOIN t2 ON t1.k = t2.x ORDER BY 1 DESC
 ----
 5  4
 2  4
 
-query IIII rowsort
-SELECT * FROM t1 JOIN t2 ON t1.v = t2.x
+query IIII
+SELECT * FROM t1 JOIN t2 ON t1.v = t2.x ORDER BY 1
 ----
 0  4  4  6
 2  1  1  3
 3  4  4  6
 5  4  4  6
 
-query IIII rowsort
-SELECT * FROM t1 LEFT JOIN t2 ON t1.v = t2.x
+query IIII
+SELECT * FROM t1 LEFT JOIN t2 ON t1.v = t2.x ORDER BY 1
 ----
 -1  -1  NULL  NULL
 0   4   4     6
@@ -97,14 +97,14 @@ SELECT * FROM t1 FULL JOIN t2 ON t1.v = t2.x
 NULL  NULL  3     2
 NULL  NULL  0     5
 
-query IIT rowsort
-SELECT b.a, b.b, b.c FROM b JOIN a ON b.a = a.k AND a.v = b.b
+query IIT
+SELECT b.a, b.b, b.c FROM b JOIN a ON b.a = a.k AND a.v = b.b ORDER BY 3
 ----
 0  1  a
 0  1  d
 
 query ITI
-SELECT b.a, b.c, c.a FROM b JOIN c ON b.b = c.a AND b.c = c.b
+SELECT b.a, b.c, c.a FROM b JOIN c ON b.b = c.a AND b.c = c.b ORDER BY 2
 ----
 0  a  1
 2  b  1


### PR DESCRIPTION
A minor bug with setting up output column types with hash joiner is
fixed. Also, in some cases, we need to use a join hint to force
planning of hash joiner in the test.

Release note: None