### PR TITLE
storage: initialize the proposalQuotaBaseIndex from Applied

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -2105,7 +2105,9 @@ func TestQuotaPool(t *testing.T) {
 	testutils.SucceedsSoon(t, assertEqualLastIndex)
 
 	leaderRepl := mtc.getRaftLeader(rangeID)
-	leaderRepl.InitQuotaPool(quota)
+	if err := leaderRepl.InitQuotaPool(quota); err != nil {
+		t.Fatalf("failed to initialize quota pool: %v", err)
+	}
 	followerRepl := func() *storage.Replica {
 		for _, store := range mtc.stores {
 			repl, err := store.GetReplica(rangeID)
@@ -2168,8 +2170,8 @@ func TestQuotaPool(t *testing.T) {
 		}
 
 		testutils.SucceedsSoon(t, func() error {
-			if qLen := leaderRepl.QuotaReleaseQueueLen(); qLen != 1 {
-				return errors.Errorf("expected 1 queued quota release, found: %d", qLen)
+			if qLen := leaderRepl.QuotaReleaseQueueLen(); qLen < 1 {
+				return errors.Errorf("expected at least 1 queued quota release, found: %d", qLen)
 			}
 			return nil
 		})

--- a/pkg/storage/replica_application.go
+++ b/pkg/storage/replica_application.go
@@ -172,16 +172,14 @@ func (r *Replica) retrieveLocalProposals(ctx context.Context, b *cmdAppBatch) {
 			cmd.ctx = ctx
 		}
 	}
-	if !anyLocal {
+	if !anyLocal && r.mu.proposalQuota == nil {
 		// Fast-path.
 		return
 	}
 	for ok := it.init(&b.cmdBuf); ok; ok = it.next() {
 		cmd := it.cur()
-		if !cmd.proposedLocally() {
-			continue
-		}
-		if cmd.raftCmd.MaxLeaseIndex != cmd.proposal.command.MaxLeaseIndex {
+		toRelease := int64(0)
+		shouldRemove := cmd.proposedLocally() &&
 			// If this entry does not have the most up-to-date view of the
 			// corresponding proposal's maximum lease index then the proposal
 			// must have been reproposed with a higher lease index. (see
@@ -189,28 +187,27 @@ func (r *Replica) retrieveLocalProposals(ctx context.Context, b *cmdAppBatch) {
 			// version of the proposal in the pipeline, so don't remove the
 			// proposal from the map. We expect this entry to be rejected by
 			// checkForcedErr.
-			continue
+			cmd.raftCmd.MaxLeaseIndex == cmd.proposal.command.MaxLeaseIndex
+		if shouldRemove {
+			// Delete the proposal from the proposals map. There may be reproposals
+			// of the proposal in the pipeline, but those will all have the same max
+			// lease index, meaning that they will all be rejected after this entry
+			// applies (successfully or otherwise). If tryReproposeWithNewLeaseIndex
+			// picks up the proposal on failure, it will re-add the proposal to the
+			// proposal map, but this won't affect anything in this cmdAppBatch.
+			//
+			// While here, add the proposal's quota size to the quota release queue.
+			// We check the proposal map again first to avoid double free-ing quota
+			// when reproposals from the same proposal end up in the same entry
+			// application batch.
+			delete(r.mu.proposals, cmd.idKey)
+			toRelease = cmd.proposal.quotaSize
 		}
-		// Delete the proposal from the proposals map. There may be reproposals
-		// of the proposal in the pipeline, but those will all have the same max
-		// lease index, meaning that they will all be rejected after this entry
-		// applies (successfully or otherwise). If tryReproposeWithNewLeaseIndex
-		// picks up the proposal on failure, it will re-add the proposal to the
-		// proposal map, but this won't affect anything in this cmdAppBatch.
-		//
-		// While here, add the proposal's quota size to the quota release queue.
-		// We check the proposal map again first to avoid double free-ing quota
-		// when reproposals from the same proposal end up in the same entry
-		// application batch.
-		if _, ok := r.mu.proposals[cmd.idKey]; !ok {
-			continue
-		}
-		delete(r.mu.proposals, cmd.idKey)
 		// At this point we're not guaranteed to have proposalQuota initialized,
 		// the same is true for quotaReleaseQueues. Only queue the proposal's
-		// quota for release if the proposalQuota is initialized.
+		// quota for release if the proposalQuota is initialized
 		if r.mu.proposalQuota != nil {
-			r.mu.quotaReleaseQueue = append(r.mu.quotaReleaseQueue, cmd.proposal.quotaSize)
+			r.mu.quotaReleaseQueue = append(r.mu.quotaReleaseQueue, toRelease)
 		}
 	}
 }


### PR DESCRIPTION
This commit changes the initialization of `proposalQuotaBaseIndex` from
`lastIndex` which may include entries which are not yet committed to
`status.Commit`, the highest committed index. Given the
`proposalQuotaBaseIndex` should account for all committed proposals whose quota
has been released and proposals add their quota to the release queue after they
have been committed, it's important that the that base index not be too high
lest we leave quota in the queue.

This commit also adds an assertion that the `proposalQuotaBaseIndex` plus the
length of the queue does not exceed the current committed index.

See https://github.com/cockroachdb/cockroach/issues/39022#issuecomment-515638973
for more details.

This change did not hit this assertion in 10 runs of an import of TPC-C whereas
without it, the assertion was hit roughly 30% of the time.

Fixes #39022.

Release note (bug fix): Properly initialize proposal quota tracking to prevent
quota leak which can hang imports or other AddSSTable operations.