### PR TITLE
sql: allow cascading action when default is set implicitly to null

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -1201,25 +1201,26 @@ CREATE TABLE a (
 );
 
 # Create a table with no DEFAULT expressions column and a SET DEFAULT action.
-statement error pq: cannot add a SET DEFAULT cascading action on column "test.public.no_default_table.delete_no_default" which has no DEFAULT expression
-CREATE TABLE no_default_table (
+statement ok
+CREATE TABLE delete_no_default_table (
   id INT PRIMARY KEY
  ,delete_no_default INT REFERENCES a ON DELETE SET DEFAULT
 );
 
-statement error pq: cannot add a SET DEFAULT cascading action on column "test.public.no_default_table.update_no_default" which has no DEFAULT expression
-CREATE TABLE no_default_table (
+statement error pq: cannot add a SET DEFAULT cascading action on column "test.public.update_no_default_table.update_no_default" which has a NOT NULL constraint and a NULL default expression
+CREATE TABLE update_no_default_table (
   id INT PRIMARY KEY
  ,update_no_default INT NOT NULL REFERENCES a ON UPDATE SET DEFAULT
 );
 
 # Create a table where the primary key has a SET DEFAULT action.
-statement error pq: cannot add a SET DEFAULT cascading action on column "test.public.primary_key_table.id" which has no DEFAULT expression
-CREATE TABLE primary_key_table (
+# Primary keys are not allowed to be NULL
+statement error pq: cannot add a SET DEFAULT cascading action on column "test.public.primary_key_table_set_default.id" which has a NOT NULL constraint and a NULL default expression
+CREATE TABLE primary_key_table_set_default (
   id INT PRIMARY KEY REFERENCES a ON DELETE SET DEFAULT
 );
 
-statement error pq: cannot add a SET DEFAULT cascading action on column "test.public.primary_key_table.id" which has no DEFAULT expression
+statement error pq: cannot add a SET DEFAULT cascading action on column "test.public.primary_key_table.id" which has a NOT NULL constraint and a NULL default expression
 CREATE TABLE primary_key_table (
   id INT PRIMARY KEY REFERENCES a ON UPDATE SET DEFAULT
 );
@@ -1232,12 +1233,12 @@ CREATE TABLE no_default_table (
  ,update_no_default INT
 );
 
-statement error pq: cannot add a SET DEFAULT cascading action on column "test.public.no_default_table.delete_no_default" which has no DEFAULT expression
+statement ok
 ALTER TABLE no_default_table ADD CONSTRAINT no_default_delete_set_default
   FOREIGN KEY (delete_no_default) REFERENCES a (id)
   ON DELETE SET DEFAULT;
 
-statement error pq: cannot add a SET DEFAULT cascading action on column "test.public.no_default_table.update_no_default" which has no DEFAULT expression
+statement ok
 ALTER TABLE no_default_table ADD CONSTRAINT no_default_update_set_default
   FOREIGN KEY (update_no_default) REFERENCES a (id)
   ON UPDATE SET DEFAULT;
@@ -1253,19 +1254,20 @@ CREATE TABLE primary_key_table (
   id INT PRIMARY KEY
 );
 
-statement error pq: cannot add a SET DEFAULT cascading action on column "test.public.primary_key_table.id" which has no DEFAULT expression
+# id is a primary key and thus cannot be NULL
+statement error pq: cannot add a SET DEFAULT cascading action on column "test.public.primary_key_table.id" which has a NOT NULL constraint and a NULL default expression
 ALTER TABLE primary_key_table ADD CONSTRAINT no_default_delete_set_default
   FOREIGN KEY (id) REFERENCES a (id)
   ON DELETE SET DEFAULT;
 
-statement error pq: cannot add a SET DEFAULT cascading action on column "test.public.primary_key_table.id" which has no DEFAULT expression
+statement error pq: cannot add a SET DEFAULT cascading action on column "test.public.primary_key_table.id" which has a NOT NULL constraint and a NULL default expression
 ALTER TABLE primary_key_table ADD CONSTRAINT no_default_update_set_default
   FOREIGN KEY (id) REFERENCES a (id)
   ON UPDATE SET DEFAULT;
 
 # Clean up the tables used so far.
 statement ok
-DROP TABLE primary_key_table, a;
+DROP TABLE primary_key_table, delete_no_default_table, a;
 
 # Now test composite foreign keys
 statement ok
@@ -1276,7 +1278,7 @@ CREATE TABLE a (
 );
 
 # Create a table with a column without a DEFAULT expression and a SET DEFAULT action.
-statement error pq: cannot add a SET DEFAULT cascading action on column "test.public.no_default_table.ref1" which has no DEFAULT expression
+statement ok
 CREATE TABLE no_default_table (
   id INT PRIMARY KEY
  ,ref1 INT
@@ -1285,8 +1287,32 @@ CREATE TABLE no_default_table (
  ,FOREIGN KEY (ref1, ref2) REFERENCES a (id2, id1) ON DELETE SET DEFAULT
 );
 
-statement error pq: cannot add a SET DEFAULT cascading action on column "test.public.no_default_table.ref1" which has no DEFAULT expression
-CREATE TABLE no_default_table (
+statement ok
+INSERT INTO a VALUES (1, 2)
+
+statement ok
+INSERT INTO a VALUES (3, 4)
+
+statement ok
+INSERT INTO no_default_table VALUES (6, 2, 1)
+
+query III colnames
+SELECT * FROM no_default_table
+----
+id  ref1  ref2
+6   2     1
+
+statement ok
+DELETE FROM a WHERE id1=1
+
+query III colnames
+SELECT * FROM no_default_table
+----
+id  ref1  ref2
+6   NULL  NULL
+
+statement ok
+CREATE TABLE no_default_table_on_update (
   id INT PRIMARY KEY
  ,ref1 INT
  ,ref2 INT
@@ -1294,8 +1320,26 @@ CREATE TABLE no_default_table (
  ,FOREIGN KEY (ref1, ref2) REFERENCES a (id2, id1) ON UPDATE SET DEFAULT
 );
 
-statement error pq: cannot add a SET DEFAULT cascading action on column "test.public.no_default_table.ref1" which has no DEFAULT expression
-CREATE TABLE no_default_table (
+statement ok
+INSERT INTO no_default_table_on_update VALUES (0, 4, 3)
+
+query III colnames
+SELECT * FROM no_default_table_on_update
+----
+id  ref1  ref2
+0   4     3
+
+statement ok
+UPDATE a SET id1=33, id2=44 WHERE id1=3;
+
+query III colnames
+SELECT * FROM no_default_table_on_update
+----
+id  ref1  ref2
+0   NULL  NULL
+
+statement ok
+CREATE TABLE no_default_table_ref2_default_on_delete (
   id INT PRIMARY KEY
  ,ref1 INT
  ,ref2 INT DEFAULT 1
@@ -1303,9 +1347,8 @@ CREATE TABLE no_default_table (
  ,FOREIGN KEY (ref1, ref2) REFERENCES a (id2, id1) ON DELETE SET DEFAULT
 );
 
-
-statement error pq: cannot add a SET DEFAULT cascading action on column "test.public.no_default_table.ref1" which has no DEFAULT expression
-CREATE TABLE no_default_table (
+statement ok
+CREATE TABLE no_default_table_ref2_default_on_update (
   id INT PRIMARY KEY
  ,ref1 INT
  ,ref2 INT DEFAULT 1
@@ -1313,8 +1356,8 @@ CREATE TABLE no_default_table (
  ,FOREIGN KEY (ref1, ref2) REFERENCES a (id2, id1) ON UPDATE SET DEFAULT
 );
 
-statement error pq: cannot add a SET DEFAULT cascading action on column "test.public.no_default_table.ref2" which has no DEFAULT expression
-CREATE TABLE no_default_table (
+statement ok
+CREATE TABLE no_default_table_ref1_default_on_delete (
   id INT PRIMARY KEY
  ,ref1 INT DEFAULT 1
  ,ref2 INT
@@ -1322,18 +1365,30 @@ CREATE TABLE no_default_table (
  ,FOREIGN KEY (ref1, ref2) REFERENCES a (id2, id1) ON DELETE SET DEFAULT
 );
 
-statement error pq: cannot add a SET DEFAULT cascading action on column "test.public.no_default_table.ref2" which has no DEFAULT expression
-CREATE TABLE no_default_table (
+statement ok
+CREATE TABLE no_default_table_ref1_default_on_update (
   id INT PRIMARY KEY
  ,ref1 INT DEFAULT 1
  ,ref2 INT
  ,INDEX (ref1, ref2)
  ,FOREIGN KEY (ref1, ref2) REFERENCES a (id2, id1) ON UPDATE SET DEFAULT
+);
+
+# Create a table with a NOT NULL column and a SET NULL action.
+statement error pq: cannot add a SET DEFAULT cascading action on column "test.public.not_null_table.ref1" which has a NOT NULL constraint and a NULL default expression
+CREATE TABLE not_null_table (
+  id INT PRIMARY KEY
+ ,ref1 INT NOT NULL
+ ,ref2 INT NOT NULL
+ ,INDEX (ref1, ref2)
+ ,FOREIGN KEY (ref1, ref2) REFERENCES a (id2, id1) ON DELETE SET DEFAULT
 );
 
 # Clean up after the test.
 statement ok
-DROP TABLE a;
+DROP TABLE a, no_default_table, no_default_table_on_update, no_default_table_ref2_default_on_delete,
+no_default_table_ref2_default_on_update, no_default_table_ref1_default_on_delete,
+no_default_table_ref1_default_on_update
 
 # Test that no column can have more than 1 FK constraint
 subtest column_uniqueness

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -461,7 +461,7 @@ query TT
 SHOW CREATE TABLE test.null_default
 ----
 test.public.null_default  CREATE TABLE null_default (
-                          ts TIMESTAMP NULL DEFAULT NULL,
+                          ts TIMESTAMP NULL,
                           FAMILY "primary" (ts, rowid)
 )
 

--- a/pkg/sql/row/cascader.go
+++ b/pkg/sql/row/cascader.go
@@ -730,6 +730,11 @@ func (c *cascader) updateRows(
 			if err != nil {
 				return nil, nil, nil, 0, err
 			}
+			// If the default expression is nil, treat it as a SET NULL case.
+			if !column.HasDefault() {
+				referencingIndexValuesByColIDs[columnID] = tree.DNull
+				continue
+			}
 			parsedExpr, err := parser.ParseExpr(*column.DefaultExpr)
 			if err != nil {
 				return nil, nil, nil, 0, err

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -168,12 +168,15 @@ func MakeColumnDefDescs(
 		); err != nil {
 			return nil, nil, nil, err
 		}
-		// We keep the type checked expression so that the type annotation
-		// gets properly stored.
-		d.DefaultExpr.Expr = typedExpr
 
-		s := tree.Serialize(d.DefaultExpr.Expr)
-		col.DefaultExpr = &s
+		// Keep the type checked expression so that the type annotation gets
+		// properly stored, only if the default expression is not NULL.
+		// Otherwise we want to keep the default expression nil.
+		if typedExpr != tree.DNull {
+			d.DefaultExpr.Expr = typedExpr
+			s := tree.Serialize(d.DefaultExpr.Expr)
+			col.DefaultExpr = &s
+		}
 	}
 
 	if d.IsComputed() {


### PR DESCRIPTION
Add support for implicitly setting the default value of a column
to null, for cascading tables for both ON DELETE and ON UPDATE.

The problem was in updateRows within cascader.go when the column ids
were being updated for a table. If a user did not explicitly specify
NULL as the default value, the default expression was dereferenced,
which was null. Instead of deferencing said value, and setting it to the
column id, we now just set the column id to nil if the default
expression is also nil. This is the same behavior for the explicit case.

Resolves: #38975

Release note (sql change): Now supports the implicit setting of NULL
values for foreign keys.