### PR TITLE
cli: adds \d, \dt, \du, \l metacommands to sql shell

### DIFF
--- a/pkg/cli/interactive_tests/test_sql_version_reporting.tcl
+++ b/pkg/cli/interactive_tests/test_sql_version_reporting.tcl
@@ -7,7 +7,7 @@ start_server $argv
 spawn $argv sql
 
 start_test "Check that the client starts with the welcome message."
-eexpect "# Welcome to the cockroach SQL interface."
+eexpect "# Welcome to the CockroachDB SQL shell."
 end_test
 
 start_test "Check that the client reports the server version, and correctly detects the version is the same as the client."


### PR DESCRIPTION
Also tweaked shell welcome message to mention “\q” instead of “CTRL + D” (doesn’t work on Windows, and isn’t primary command)

Release note: added \d, \dt, \du, \l metacommands to cli shell