### PR TITLE
sql: reduce unnecessary latency in `SplitTable` for test

### DIFF
--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -47,10 +47,9 @@ import (
 )
 
 // SplitTable splits a range in the table, creates a replica for the right
-// side of the split on targetNodeIdx, and moves the lease for the right
-// side of the split to targetNodeIdx. This forces the querying against
-// the table to be distributed. vals is a list of values forming a primary
-// key for the table.
+// side of the split on TargetNodeIdx, and moves the lease for the right
+// side of the split to TargetNodeIdx for each SplitPoint. This forces the
+// querying against the table to be distributed.
 //
 // TODO(radu): SplitTable or its equivalent should be added to TestCluster.
 //
@@ -60,32 +59,68 @@ func SplitTable(
 	t *testing.T,
 	tc serverutils.TestClusterInterface,
 	desc *sqlbase.TableDescriptor,
-	targetNodeIdx int,
-	vals ...interface{},
+	sps []SplitPoint,
 ) {
 	if tc.ReplicationMode() != base.ReplicationManual {
 		t.Fatal("SplitTable called on a test cluster that was not in manual replication mode")
 	}
 
-	pik, err := sqlbase.TestingMakePrimaryIndexKey(desc, vals...)
-	if err != nil {
-		t.Fatal(err)
+	rkts := make(map[roachpb.RangeID]rangeAndKT)
+	for _, sp := range sps {
+		pik, err := sqlbase.TestingMakePrimaryIndexKey(desc, sp.Vals...)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, rightRange, err := tc.Server(0).SplitRange(pik)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rightRangeStartKey := rightRange.StartKey.AsRawKey()
+		target := tc.Target(sp.TargetNodeIdx)
+
+		rkts[rightRange.RangeID] = rangeAndKT{
+			rightRange,
+			serverutils.KeyAndTargets{StartKey: rightRangeStartKey, Targets: []roachpb.ReplicationTarget{target}}}
 	}
 
-	_, rightRange, err := tc.Server(0).SplitRange(pik)
-	if err != nil {
-		t.Fatal(err)
+	var kts []serverutils.KeyAndTargets
+	for _, rkt := range rkts {
+		kts = append(kts, rkt.KT)
+	}
+	descs, errs := tc.AddReplicasMulti(kts...)
+	for _, err := range errs {
+		if err != nil && !testutils.IsError(err, "is already present") {
+			t.Fatal(err)
+		}
 	}
 
-	rightRangeStartKey := rightRange.StartKey.AsRawKey()
-	rightRange, err = tc.AddReplicas(rightRangeStartKey, tc.Target(targetNodeIdx))
-	if err != nil && !testutils.IsError(err, "is already present") {
-		t.Fatal(err)
-	}
+	for _, desc := range descs {
+		rkt, ok := rkts[desc.RangeID]
+		if !ok {
+			continue
+		}
 
-	if err := tc.TransferRangeLease(rightRange, tc.Target(targetNodeIdx)); err != nil {
-		t.Fatal(err)
+		for _, target := range rkt.KT.Targets {
+			if err := tc.TransferRangeLease(desc, target); err != nil {
+				t.Fatal(err)
+			}
+		}
 	}
+}
+
+// SplitPoint describes a split point that is passed to SplitTable.
+type SplitPoint struct {
+	// TargetNodeIdx is the node that will have the lease for the new range.
+	TargetNodeIdx int
+	// Vals is list of values forming a primary key for the table.
+	Vals []interface{}
+}
+
+type rangeAndKT struct {
+	Range roachpb.RangeDescriptor
+	KT    serverutils.KeyAndTargets
 }
 
 // TestPlanningDuringSplits verifies that table reader planning (resolving

--- a/pkg/sql/distsql_plan_backfill_test.go
+++ b/pkg/sql/distsql_plan_backfill_test.go
@@ -75,11 +75,12 @@ func TestDistBackfill(t *testing.T) {
 	)
 	// Split the table into multiple ranges.
 	descNumToStr := sqlbase.GetTableDescriptor(cdb, "test", "numtostr")
-	// SplitTable moves the right range, so we split things back to front
-	// in order to move less data.
+	var sps []SplitPoint
+	//for i := 1; i <= numNodes-1; i++ {
 	for i := numNodes - 1; i > 0; i-- {
-		SplitTable(t, tc, descNumToStr, i, n*n/numNodes*i)
+		sps = append(sps, SplitPoint{i, []interface{}{n * n / numNodes * i}})
 	}
+	SplitTable(t, tc, descNumToStr, sps)
 
 	db := tc.ServerConn(0)
 	db.SetMaxOpenConns(1)

--- a/pkg/sql/distsqlplan/span_resolver_test.go
+++ b/pkg/sql/distsqlplan/span_resolver_test.go
@@ -52,12 +52,8 @@ func TestSpanResolverUsesCaches(t *testing.T) {
 	// Replicate the row ranges on all of the first 3 nodes. Save the 4th node in
 	// a pristine state, with empty caches.
 	for i := 0; i < 3; i++ {
-		var err error
-		rowRanges[i], err = tc.AddReplicas(
-			rowRanges[i].StartKey.AsRawKey(), tc.Target(1), tc.Target(2))
-		if err != nil {
-			t.Fatal(err)
-		}
+		rowRanges[i] = tc.AddReplicasOrFatal(
+			t, rowRanges[i].StartKey.AsRawKey(), tc.Target(1), tc.Target(2))
 	}
 
 	// Scatter the leases around; node i gets range i.

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -627,11 +627,11 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 
 	// Split the table into multiple ranges.
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
-	// SplitTable moves the right range, so we split things back to front
-	// in order to move less data.
-	for i := numNodes - 1; i > 0; i-- {
-		sql.SplitTable(t, tc, tableDesc, i, maxValue/numNodes*i)
+	var sps []sql.SplitPoint
+	for i := 1; i <= numNodes-1; i++ {
+		sps = append(sps, sql.SplitPoint{TargetNodeIdx: i, Vals: []interface{}{maxValue / numNodes * i}})
 	}
+	sql.SplitTable(t, tc, tableDesc, sps)
 
 	ctx := context.TODO()
 
@@ -803,11 +803,11 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 
 	// Split the table into multiple ranges.
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
-	// SplitTable moves the right range, so we split things back to front
-	// in order to move less data.
-	for i := numNodes - 1; i > 0; i-- {
-		sql.SplitTable(t, tc, tableDesc, i, maxValue/numNodes*i)
+	var sps []sql.SplitPoint
+	for i := 1; i <= numNodes-1; i++ {
+		sps = append(sps, sql.SplitPoint{TargetNodeIdx: i, Vals: []interface{}{maxValue / numNodes * i}})
 	}
+	sql.SplitTable(t, tc, tableDesc, sps)
 
 	ctx := context.TODO()
 
@@ -915,11 +915,11 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 	}
 
 	// Split the table into multiple ranges.
-	// SplitTable moves the right range, so we split things back to front
-	// in order to move less data.
-	for i := numNodes - 1; i > 0; i-- {
-		sql.SplitTable(t, tc, tableDesc, i, maxValue/numNodes*i)
+	var sps []sql.SplitPoint
+	for i := 1; i <= numNodes-1; i++ {
+		sps = append(sps, sql.SplitPoint{TargetNodeIdx: i, Vals: []interface{}{maxValue / numNodes * i}})
 	}
+	sql.SplitTable(t, tc, tableDesc, sps)
 
 	ctx := context.TODO()
 
@@ -2525,11 +2525,11 @@ func TestBackfillCompletesOnChunkBoundary(t *testing.T) {
 
 	// Split the table into multiple ranges.
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
-	// SplitTable moves the right range, so we split things back to front
-	// in order to move less data.
-	for i := numNodes - 1; i > 0; i-- {
-		sql.SplitTable(t, tc, tableDesc, i, maxValue/numNodes*i)
+	var sps []sql.SplitPoint
+	for i := 1; i <= numNodes-1; i++ {
+		sps = append(sps, sql.SplitPoint{TargetNodeIdx: i, Vals: []interface{}{maxValue / numNodes * i}})
 	}
+	sql.SplitTable(t, tc, tableDesc, sps)
 
 	// Run some schema changes.
 	testCases := []struct {
@@ -2830,11 +2830,11 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 
 	// Split the table into multiple ranges.
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
-	// SplitTable moves the right range, so we split things back to front
-	// in order to move less data.
-	for i := numNodes - 1; i > 0; i-- {
-		sql.SplitTable(t, tc, tableDesc, i, maxValue/numNodes*i)
+	var sps []sql.SplitPoint
+	for i := 1; i <= numNodes-1; i++ {
+		sps = append(sps, sql.SplitPoint{TargetNodeIdx: i, Vals: []interface{}{maxValue / numNodes * i}})
 	}
+	sql.SplitTable(t, tc, tableDesc, sps)
 
 	testCases := []struct {
 		sql    string
@@ -3655,12 +3655,12 @@ func TestCancelSchemaChange(t *testing.T) {
 
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
 	// Split the table into multiple ranges.
-	// SplitTable moves the right range, so we split things back to front
-	// in order to move less data.
+	var sps []sql.SplitPoint
 	const numSplits = numNodes * 2
-	for i := numSplits - 1; i > 0; i-- {
-		sql.SplitTable(t, tc, tableDesc, i%numNodes, maxValue/numSplits*i)
+	for i := 1; i <= numSplits-1; i++ {
+		sps = append(sps, sql.SplitPoint{TargetNodeIdx: i % numNodes, Vals: []interface{}{maxValue / numSplits * i}})
 	}
+	sql.SplitTable(t, tc, tableDesc, sps)
 
 	ctx := context.TODO()
 	if err := checkTableKeyCount(ctx, kvDB, 1, maxValue); err != nil {
@@ -4774,9 +4774,11 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 		t.Fatal(err)
 	}
 
-	for i := numNodes - 1; i > 0; i-- {
-		sql.SplitTable(t, tc, tableDesc, i, maxValue/2)
+	var sps []sql.SplitPoint
+	for i := 1; i < numNodes-1; i++ {
+		sps = append(sps, sql.SplitPoint{TargetNodeIdx: i, Vals: []interface{}{maxValue / 2}})
 	}
+	sql.SplitTable(t, tc, tableDesc, sps)
 
 	bg := ctxgroup.WithContext(ctx)
 	bg.Go(func() error {

--- a/pkg/testutils/serverutils/test_cluster_shim.go
+++ b/pkg/testutils/serverutils/test_cluster_shim.go
@@ -52,6 +52,11 @@ type TestClusterInterface interface {
 		startKey roachpb.Key, targets ...roachpb.ReplicationTarget,
 	) (roachpb.RangeDescriptor, error)
 
+	// AddReplicasMulti is the same as AddReplicas but will execute multiple jobs.
+	AddReplicasMulti(
+		kts ...KeyAndTargets,
+	) ([]roachpb.RangeDescriptor, []error)
+
 	// AddReplicasOrFatal is the same as AddReplicas but will Fatal the test on
 	// error.
 	AddReplicasOrFatal(
@@ -128,4 +133,10 @@ func StartTestCluster(t testing.TB, numNodes int, args base.TestClusterArgs) Tes
 			"from the package's TestMain()")
 	}
 	return clusterFactoryImpl.StartTestCluster(t, numNodes, args)
+}
+
+// KeyAndTargets contains replica startKey and targets.
+type KeyAndTargets struct {
+	StartKey roachpb.Key
+	Targets  []roachpb.ReplicationTarget
 }

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -402,43 +402,87 @@ func (tc *TestCluster) AddReplicas(
 	startKey roachpb.Key, targets ...roachpb.ReplicationTarget,
 ) (roachpb.RangeDescriptor, error) {
 	rKey := keys.MustAddr(startKey)
-	errRetry := errors.Errorf("target not found")
-	for {
+
+	rangeDesc, err := tc.changeReplicas(
+		roachpb.ADD_REPLICA, rKey, targets...,
+	)
+	if err != nil {
+		return roachpb.RangeDescriptor{}, err
+	}
+
+	if err := tc.waitForNewReplicas(startKey, targets...); err != nil {
+		return roachpb.RangeDescriptor{}, err
+	}
+
+	return rangeDesc, nil
+}
+
+// AddReplicasMulti is part of TestClusterInterface.
+func (tc *TestCluster) AddReplicasMulti(
+	kts ...serverutils.KeyAndTargets,
+) ([]roachpb.RangeDescriptor, []error) {
+	var descs []roachpb.RangeDescriptor
+	var errs []error
+	for _, kt := range kts {
+		rKey := keys.MustAddr(kt.StartKey)
+
 		rangeDesc, err := tc.changeReplicas(
-			roachpb.ADD_REPLICA, rKey, targets...,
+			roachpb.ADD_REPLICA, rKey, kt.Targets...,
 		)
 		if err != nil {
-			return roachpb.RangeDescriptor{}, err
+			errs = append(errs, err)
+			continue
 		}
 
-		// Wait for the replication to complete on all destination nodes.
-		if err := retry.ForDuration(time.Second*25, func() error {
-			for _, target := range targets {
-				// Use LookupReplica(keys) instead of GetRange(rangeID) to ensure that the
-				// snapshot has been transferred and the descriptor initialized.
-				store, err := tc.findMemberStore(target.StoreID)
-				if err != nil {
-					log.Errorf(context.TODO(), "unexpected error: %s", err)
-					return err
-				}
-				repl := store.LookupReplica(rKey)
-				if repl == nil {
-					return errors.Wrapf(errRetry, "for target %s", target)
-				}
-				desc := repl.Desc()
-				if _, ok := desc.GetReplicaDescriptor(target.StoreID); !ok {
-					return errors.Errorf("target store %d not yet in range descriptor %v", target.StoreID, desc)
-				}
-			}
-			return nil
-		}); errors.Cause(err) == errRetry {
-			log.Warningf(context.Background(), "target was likely downreplicated again; retrying after %s", err)
-			continue
-		} else if err != nil {
-			return roachpb.RangeDescriptor{}, err
-		}
-		return rangeDesc, nil
+		descs = append(descs, rangeDesc)
 	}
+
+	for _, kt := range kts {
+		if err := tc.waitForNewReplicas(kt.StartKey, kt.Targets...); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+	}
+
+	return descs, errs
+}
+
+// waitForNewReplicas waits for each of the targets to have a fully initialized
+// replica of the range indicated by startKey.
+//
+// startKey is start key of range.
+// targets are replication target for change replica.
+func (tc *TestCluster) waitForNewReplicas(
+	startKey roachpb.Key, targets ...roachpb.ReplicationTarget,
+) error {
+	rKey := keys.MustAddr(startKey)
+	errRetry := errors.Errorf("target not found")
+
+	// Wait for the replication to complete on all destination nodes.
+	if err := retry.ForDuration(time.Second*25, func() error {
+		for _, target := range targets {
+			// Use LookupReplica(keys) instead of GetRange(rangeID) to ensure that the
+			// snapshot has been transferred and the descriptor initialized.
+			store, err := tc.findMemberStore(target.StoreID)
+			if err != nil {
+				log.Errorf(context.TODO(), "unexpected error: %s", err)
+				return err
+			}
+			repl := store.LookupReplica(rKey)
+			if repl == nil {
+				return errors.Wrapf(errRetry, "for target %s", target)
+			}
+			desc := repl.Desc()
+			if _, ok := desc.GetReplicaDescriptor(target.StoreID); !ok {
+				return errors.Errorf("target store %d not yet in range descriptor %v", target.StoreID, desc)
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // AddReplicasOrFatal is part of TestClusterInterface.


### PR DESCRIPTION
Before this patch, test waits for the replication to complete on all destination nodes when each `SplitTable` called. The idea let the all `SplitTable` call once and wait only once after that. This makes the tests faster and detail result(in my local machine) is below.

| func | before | after |
| ---- | ------ | ----- |
| TestDistBackfill | 5 s 230 ms | ~~910 ms~~ 1 s 980 ms |
| TestRaceWithBackfill | 4 s 770 ms | ~~1 s 620 ms~~ 2 s 540 ms |
| TestDropWhileBackfill | 3 s 960 ms | ~~790 ms~~ 1 s 800 ms |
| TestBackfillErrors | 4 s 940 ms | ~~750 ms~~ 1 s 690 m |
| TestBackfillCompletesOnChunkBoundary | 5 s 780 ms | ~~1 s 590 ms~~ 2 s 640 ms |
| TestSchemaChangeEvalContext | 2 s 870 ms | ~~740 ms~~ 1 s 970 ms |
| TestCancelSchemaChange | 5 s 650 ms | ~~1 s 500 ms~~ 2 s 420 ms |
| TestIntentRaceWithIndexBackfill | 330 ms | 310 ms |

Related to #37028.

Release note: None