### PR TITLE
storage: add empty DeprecatedTxnSpanGCThreshold to snapshot when key missing

### DIFF
--- a/pkg/storage/stateloader/stateloader.go
+++ b/pkg/storage/stateloader/stateloader.go
@@ -472,11 +472,8 @@ func (rsl StateLoader) LoadLegacyTxnSpanGCThreshold(
 	ctx context.Context, reader engine.Reader,
 ) (*hlc.Timestamp, error) {
 	var t hlc.Timestamp
-	found, err := engine.MVCCGetProto(ctx, reader, rsl.RangeTxnSpanGCThresholdKey(),
+	_, err := engine.MVCCGetProto(ctx, reader, rsl.RangeTxnSpanGCThresholdKey(),
 		hlc.Timestamp{}, &t, engine.MVCCGetOptions{})
-	if !found {
-		return nil, err
-	}
 	return &t, err
 }
 


### PR DESCRIPTION
Fixes #39138.

This was missed in #39003. v19.1 nodes populate their ReplicaState with an empty TxnSpanGCThreshold when the key is missing, not a nil TxnSpanGCThreshold. See https://github.com/cockroachdb/cockroach/blob/b8554ec29fd1620c0e6af9544d678db57d251f4c/pkg/storage/stateloader/stateloader.go#L474-L482

We need to do the same to avoid an assertion failure after a snapshot.

Release note: None