### PR TITLE
sql/tree: store From as value in SelectClause AST node

### DIFF
--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -370,9 +370,7 @@ func makeSelectClause(
 func (s *scope) makeSelectClause(
 	desiredTypes []*types.T, refs colRefs, withTables tableRefs,
 ) (clause *tree.SelectClause, selectRefs, orderByRefs colRefs, tables tableRefs, ok bool) {
-	clause = &tree.SelectClause{
-		From: &tree.From{},
-	}
+	clause = &tree.SelectClause{}
 
 	var fromRefs colRefs
 	// Sometimes generate a SELECT with no FROM clause.
@@ -771,7 +769,7 @@ func makeValuesSelect(
 	// for how to achieve exactly that syntax as tree nodes, but it works.
 	return &tree.SelectClause{
 		Exprs: tree.SelectExprs{tree.StarSelectExpr()},
-		From: &tree.From{
+		From: tree.From{
 			Tables: tree.TableExprs{values},
 		},
 	}, valuesRefs, withTables, true

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -40,7 +40,7 @@ func validateCheckExpr(
 	tblref := tree.TableRef{TableID: int64(tableDesc.ID), As: tree.AliasClause{Alias: "t"}}
 	sel := &tree.SelectClause{
 		Exprs: sqlbase.ColumnsSelectors(tableDesc.Columns, false /* forUpdateOrDelete */),
-		From:  &tree.From{Tables: []tree.TableExpr{&tblref}},
+		From:  tree.From{Tables: []tree.TableExpr{&tblref}},
 		Where: &tree.Where{Type: tree.AstWhere, Expr: &tree.NotExpr{Expr: expr}},
 	}
 	lim := &tree.Limit{Count: tree.NewDInt(1)}

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -145,7 +145,7 @@ func (p *planner) Delete(
 	// being deleted. Also RETURNING will expose this.
 	rows, err := p.SelectClause(ctx, &tree.SelectClause{
 		Exprs: sqlbase.ColumnsSelectors(rd.FetchCols, true /* forUpdateOrDelete */),
-		From:  &tree.From{Tables: []tree.TableExpr{n.Table}},
+		From:  tree.From{Tables: []tree.TableExpr{n.Table}},
 		Where: n.Where,
 	}, n.OrderBy, n.Limit, nil /*with*/, nil /*desiredTypes*/, publicAndNonPublicColumns)
 	if err != nil {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -847,7 +847,7 @@ func (p *planner) isAsOf(stmt tree.Statement) (*hlc.Timestamp, error) {
 		if !ok {
 			return nil, nil
 		}
-		if sc.From == nil || sc.From.AsOf.Expr == nil {
+		if sc.From.AsOf.Expr == nil {
 			return nil, nil
 		}
 

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -777,7 +777,7 @@ func (b *Builder) buildSelectClause(
 //
 // See Builder.buildStmt for a description of the remaining input and return
 // values.
-func (b *Builder) buildFrom(from *tree.From, inScope *scope) (outScope *scope) {
+func (b *Builder) buildFrom(from tree.From, inScope *scope) (outScope *scope) {
 	// The root AS OF clause is recognized and handled by the executor. The only
 	// thing that must be done at this point is to ensure that if any timestamps
 	// are specified, the root SELECT was an AS OF SYSTEM TIME and that the time

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -275,8 +275,8 @@ func (u *sqlSymUnion) tblExpr() tree.TableExpr {
 func (u *sqlSymUnion) tblExprs() tree.TableExprs {
     return u.val.(tree.TableExprs)
 }
-func (u *sqlSymUnion) from() *tree.From {
-    return u.val.(*tree.From)
+func (u *sqlSymUnion) from() tree.From {
+    return u.val.(tree.From)
 }
 func (u *sqlSymUnion) int32s() []int32 {
     return u.val.([]int32)
@@ -819,7 +819,7 @@ func newNameFromStr(s string) *tree.Name {
 %type <tree.IndexElemList> index_params create_as_params
 %type <tree.NameList> name_list privilege_list
 %type <[]int32> opt_array_bounds
-%type <*tree.From> from_clause update_from_clause
+%type <tree.From> from_clause update_from_clause
 %type <tree.TableExprs> from_list rowsfrom_list
 %type <tree.TablePatterns> table_pattern_list single_table_pattern_list
 %type <tree.TableNames> table_name_list
@@ -5783,7 +5783,7 @@ table_clause:
   {
     $$.val = &tree.SelectClause{
       Exprs:       tree.SelectExprs{tree.StarSelectExpr()},
-      From:        &tree.From{Tables: tree.TableExprs{$2.tblExpr()}},
+      From:        tree.From{Tables: tree.TableExprs{$2.tblExpr()}},
       TableSelect: true,
     }
   }
@@ -6077,12 +6077,12 @@ values_clause:
 from_clause:
   FROM from_list opt_as_of_clause
   {
-    $$.val = &tree.From{Tables: $2.tblExprs(), AsOf: $3.asOfClause()}
+    $$.val = tree.From{Tables: $2.tblExprs(), AsOf: $3.asOfClause()}
   }
 | FROM error // SHOW HELP: <SOURCE>
 | /* EMPTY */
   {
-    $$.val = &tree.From{}
+    $$.val = tree.From{}
   }
 
 from_list:

--- a/pkg/sql/scrub_constraint.go
+++ b/pkg/sql/scrub_constraint.go
@@ -75,7 +75,7 @@ func (o *sqlCheckConstraintCheckOperation) Start(params runParams) error {
 	}
 	sel := &tree.SelectClause{
 		Exprs: sqlbase.ColumnsSelectors(o.tableDesc.Columns, false /* forUpdateOrDelete */),
-		From: &tree.From{
+		From: tree.From{
 			Tables: tree.TableExprs{o.tableName},
 		},
 		Where: &tree.Where{Expr: &tree.NotExpr{Expr: expr}},

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -78,7 +78,7 @@ type SelectClause struct {
 	Distinct    bool
 	DistinctOn  DistinctOn
 	Exprs       SelectExprs
-	From        *From
+	From        From
 	Where       *Where
 	GroupBy     GroupBy
 	Having      *Where
@@ -104,7 +104,7 @@ func (node *SelectClause) Format(ctx *FmtCtx) {
 		ctx.FormatNode(&node.Exprs)
 		if len(node.From.Tables) > 0 {
 			ctx.WriteByte(' ')
-			ctx.FormatNode(node.From)
+			ctx.FormatNode(&node.From)
 		}
 		if node.Where != nil {
 			ctx.WriteByte(' ')

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -1073,7 +1073,7 @@ func (stmt *Select) walkStmt(v Visitor) Statement {
 func (stmt *SelectClause) copyNode() *SelectClause {
 	stmtCopy := *stmt
 	stmtCopy.Exprs = append(SelectExprs(nil), stmt.Exprs...)
-	stmtCopy.From = &From{
+	stmtCopy.From = From{
 		Tables: append(TableExprs(nil), stmt.From.Tables...),
 		AsOf:   stmt.From.AsOf,
 	}
@@ -1104,7 +1104,7 @@ func (stmt *SelectClause) walkStmt(v Visitor) Statement {
 		}
 	}
 
-	if stmt.From != nil && stmt.From.AsOf.Expr != nil {
+	if stmt.From.AsOf.Expr != nil {
 		e, changed := WalkExpr(v, stmt.From.AsOf.Expr)
 		if changed {
 			if ret == stmt {

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -233,7 +233,7 @@ func (p *planner) Update(
 	// renderNode to ideally reuse some of the queries.
 	rows, err := p.SelectClause(ctx, &tree.SelectClause{
 		Exprs: sqlbase.ColumnsSelectors(ru.FetchCols, true /* forUpdateOrDelete */),
-		From:  &tree.From{Tables: []tree.TableExpr{n.Table}},
+		From:  tree.From{Tables: []tree.TableExpr{n.Table}},
 		Where: n.Where,
 	}, n.OrderBy, n.Limit, nil /* with */, nil /*desiredTypes*/, publicAndNonPublicColumns)
 	if err != nil {


### PR DESCRIPTION
Drive by cleanup. The value is assumed to be non-nil in a number of
places, so we should avoid the unnecessary indirection.

Release note: None