### PR TITLE
importccl: Modify row_id generation for IMPORT from CSV.

### DIFF
--- a/pkg/ccl/importccl/read_import_proc.go
+++ b/pkg/ccl/importccl/read_import_proc.go
@@ -297,7 +297,7 @@ func (cp *readImportDataProcessor) doRun(ctx context.Context) error {
 		if isWorkload {
 			conv = newWorkloadReader(kvCh, singleTable, evalCtx)
 		} else {
-			conv = newCSVInputReader(kvCh, cp.spec.Format.Csv, singleTable, singleTableTargetCols, evalCtx)
+			conv = newCSVInputReader(kvCh, cp.spec.Format.Csv, cp.spec.WalltimeNanos, singleTable, singleTableTargetCols, evalCtx)
 		}
 	case roachpb.IOFileFormat_MysqlOutfile:
 		conv, err = newMysqloutfileReader(kvCh, cp.spec.Format.MysqlOut, singleTable, evalCtx)


### PR DESCRIPTION
This change was motivated by a bug in which consecutive IMPORT INTO
queries into a table without an explicit PK, and from unique data
sources would overwrite instead of appending data.
This is because row_id generation was based on fileIndex and
rowNum which created colliding PKs across query runs.

To fix this we add the timestamp at which IMPORT INTO is run
at a 10-microsecond granularity to the rowNum.