### PR TITLE
sql: Remove EXPERIMENTAL_ and TESTING_ prefix from RANGES command.

### DIFF
--- a/docs/generated/sql/bnf/show_ranges_stmt.bnf
+++ b/docs/generated/sql/bnf/show_ranges_stmt.bnf
@@ -1,3 +1,3 @@
 show_ranges_stmt ::=
-	'SHOW' 'EXPERIMENTAL_RANGES' 'FROM' 'TABLE' table_name
-	| 'SHOW' 'EXPERIMENTAL_RANGES' 'FROM' 'INDEX' table_index_name
+	'SHOW' 'RANGES' 'FROM' 'TABLE' table_name
+	| 'SHOW' 'RANGES' 'FROM' 'INDEX' table_index_name

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -487,8 +487,8 @@ show_queries_stmt ::=
 	| 'SHOW' 'ALL' opt_cluster 'QUERIES'
 
 show_ranges_stmt ::=
-	'SHOW' ranges_kw 'FROM' 'TABLE' table_name
-	| 'SHOW' ranges_kw 'FROM' 'INDEX' table_index_name
+	'SHOW' 'RANGES' 'FROM' 'TABLE' table_name
+	| 'SHOW' 'RANGES' 'FROM' 'INDEX' table_index_name
 
 show_roles_stmt ::=
 	'SHOW' 'ROLES'
@@ -618,7 +618,6 @@ unreserved_keyword ::=
 	| 'EXPERIMENTAL'
 	| 'EXPERIMENTAL_AUDIT'
 	| 'EXPERIMENTAL_FINGERPRINTS'
-	| 'EXPERIMENTAL_RANGES'
 	| 'EXPERIMENTAL_RELOCATE'
 	| 'EXPERIMENTAL_REPLICA'
 	| 'EXPIRATION'
@@ -781,7 +780,6 @@ unreserved_keyword ::=
 	| 'TEMP'
 	| 'TEMPLATE'
 	| 'TEMPORARY'
-	| 'TESTING_RANGES'
 	| 'TESTING_RELOCATE'
 	| 'TEXT'
 	| 'TRACE'
@@ -1151,10 +1149,6 @@ opt_automatic ::=
 opt_cluster ::=
 	'CLUSTER'
 	| 'LOCAL'
-
-ranges_kw ::=
-	'TESTING_RANGES'
-	| 'EXPERIMENTAL_RANGES'
 
 table_index_name ::=
 	table_name '@' index_name

--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -1146,9 +1146,8 @@ var specs = []stmtSpec{
 		name: "show_roles_stmt",
 	},
 	{
-		name:    "show_ranges_stmt",
-		inline:  []string{"ranges_kw"},
-		exclude: []*regexp.Regexp{regexp.MustCompile("'TESTING_RANGES'")},
+		name: "show_ranges_stmt",
+		stmt: "show_ranges_stmt",
 	},
 	{
 		name: "show_schemas",

--- a/pkg/sql/lex/experimental_keywords.go
+++ b/pkg/sql/lex/experimental_keywords.go
@@ -1,0 +1,21 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package lex
+
+// AllowedExperimental contains keywords for which the EXPERIMENTAL_
+// or TESTING_ prefixes are allowed to be parsed along with the
+// keyword to the same token. This ambiguity exists during the
+// deprecation period of an EXPERIMENTAL_ keyword as it is being
+// transitioned to the normal version. Once the transition is done,
+// the keyword should be removed from here as well.
+var AllowedExperimental = map[string]struct{}{
+	"ranges": {},
+}

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -550,7 +550,7 @@ func newNameFromStr(s string) *tree.Name {
 %token <str> START STATISTICS STATUS STDIN STRICT STRING STORE STORED STORING SUBSTRING
 %token <str> SYMMETRIC SYNTAX SYSTEM SUBSCRIPTION
 
-%token <str> TABLE TABLES TEMP TEMPLATE TEMPORARY TESTING_RANGES EXPERIMENTAL_RANGES TESTING_RELOCATE EXPERIMENTAL_RELOCATE TEXT THEN
+%token <str> TABLE TABLES TEMP TEMPLATE TEMPORARY TESTING_RELOCATE EXPERIMENTAL_RELOCATE TEXT THEN
 %token <str> TIME TIMETZ TIMESTAMP TIMESTAMPTZ TO THROTTLING TRAILING TRACE TRANSACTION TREAT TRIGGER TRIM TRUE
 %token <str> TRUNCATE TRUSTED TYPE
 %token <str> TRACING
@@ -976,7 +976,7 @@ func newNameFromStr(s string) *tree.Name {
 %type <privilege.List> privileges
 %type <tree.AuditMode> audit_mode
 
-%type <str> relocate_kw ranges_kw
+%type <str> relocate_kw 
 
 %type <*tree.SetZoneConfig> set_zone_config
 
@@ -3702,23 +3702,19 @@ show_zone_stmt:
 // %Help: SHOW RANGES - list ranges
 // %Category: Misc
 // %Text:
-// SHOW EXPERIMENTAL_RANGES FROM TABLE <tablename>
-// SHOW EXPERIMENTAL_RANGES FROM INDEX [ <tablename> @ ] <indexname>
+// SHOW RANGES FROM TABLE <tablename>
+// SHOW RANGES FROM INDEX [ <tablename> @ ] <indexname>
 show_ranges_stmt:
-  SHOW ranges_kw FROM TABLE table_name
+  SHOW RANGES FROM TABLE table_name
   {
     name := $5.unresolvedObjectName().ToTableName()
     $$.val = &tree.ShowRanges{TableOrIndex: tree.TableIndexName{Table: name}}
   }
-| SHOW ranges_kw FROM INDEX table_index_name
+| SHOW RANGES FROM INDEX table_index_name
   {
     $$.val = &tree.ShowRanges{TableOrIndex: $5.tableIndexName()}
   }
-| SHOW ranges_kw error // SHOW HELP: SHOW RANGES
-
-ranges_kw:
-  TESTING_RANGES
-| EXPERIMENTAL_RANGES
+| SHOW RANGES error // SHOW HELP: SHOW RANGES
 
 show_fingerprints_stmt:
   SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE table_name
@@ -9049,7 +9045,6 @@ unreserved_keyword:
 | EXPERIMENTAL
 | EXPERIMENTAL_AUDIT
 | EXPERIMENTAL_FINGERPRINTS
-| EXPERIMENTAL_RANGES
 | EXPERIMENTAL_RELOCATE
 | EXPERIMENTAL_REPLICA
 | EXPIRATION
@@ -9212,7 +9207,6 @@ unreserved_keyword:
 | TEMP
 | TEMPLATE
 | TEMPORARY
-| TESTING_RANGES
 | TESTING_RELOCATE
 | TEXT
 | TRACE


### PR DESCRIPTION
This change is done by creating a small framework in the lexer
to emit the normal token for a specified set of keywords
where the EXPERIMENTAL_ and TESTING_ prefixes are allowed.

Addresses #39127.
 
Release note (sql change): Remove EXPERIMENTAL_ and TESTING_
prefixes from the SHOW EXPERIMENTAL_RANGES command.
