### PR TITLE
sql: warn when creating non-partitioned index

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -833,3 +833,17 @@ scan ok12
 # implicit NOT NULL contrainst of a primary key.
 statement error null value in column "a" violates not-null constraint
 INSERT INTO ok12 (a, b, c) VALUES (NULL, 2, 3)
+
+statement ok
+SET sql_safe_updates = true
+
+statement error non-partitioned index on partitioned table
+CREATE INDEX ON ok1 (c)
+
+statement error non-partitioned index on partitioned table
+CREATE TABLE t (a INT PRIMARY KEY, b INT, INDEX (b)) PARTITION BY LIST (a) (
+    PARTITION p1 VALUES IN (1)
+)
+
+statement ok
+RESET sql_safe_updates

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -135,6 +135,18 @@ func (n *createTableNode) startExec(params runParams) error {
 		return err
 	}
 
+	// Guard against creating non-partitioned indexes on a partitioned table,
+	// which is undesirable in most cases.
+	if params.SessionData().SafeUpdates && n.n.PartitionBy != nil {
+		for _, def := range n.n.Defs {
+			if d, ok := def.(*tree.IndexTableDef); ok {
+				if d.PartitionBy == nil {
+					return pgerror.DangerousStatementf("non-partitioned index on partitioned table")
+				}
+			}
+		}
+	}
+
 	id, err := GenerateUniqueDescID(params.ctx, params.extendedEvalCtx.ExecCfg.DB)
 	if err != nil {
 		return err


### PR DESCRIPTION
In most cases, secondary indexes created on a partitioned table should
also be partitioned. To protect users from this gotcha, we now return an
error in this case if sql_safe_updates is on.

This isn't an ideal solution to the problem. It only really protects
users who are using the interactive CLI, and if a user really does want
an unpartitioned index it will force them to turn off sql_safe_updates,
at least temporarily. However, I didn't have much luck finding another
way to deliver a warning which users were likely to see.

Fixes #38475

Release note: None