### PR TITLE
storage: clean up below-Raft Split and Merge locking

### DIFF
--- a/pkg/storage/cmd_app_ctx.go
+++ b/pkg/storage/cmd_app_ctx.go
@@ -51,7 +51,7 @@ type cmdAppCtx struct {
 	proposalRetry proposalReevaluationReason
 	mutationCount int // number of mutations in the WriteBatch, for writeStats
 	// splitMergeUnlock is acquired for splits and merges.
-	splitMergeUnlock func(*storagepb.ReplicatedEvalResult)
+	splitMergeUnlock func()
 
 	// The below fields are set after the data has been written to the storage
 	// engine in prepareLocalResult.

--- a/pkg/storage/replica_application.go
+++ b/pkg/storage/replica_application.go
@@ -296,21 +296,7 @@ func (r *Replica) stageRaftCommand(
 		log.Event(ctx, "applying command")
 
 		if splitMergeUnlock, err := r.maybeAcquireSplitMergeLock(ctx, cmd.raftCmd); err != nil {
-			log.Eventf(ctx, "unable to acquire split lock: %s", err)
-			// Send a crash report because a former bug in the error handling might have
-			// been the root cause of #19172.
-			_ = r.store.stopper.RunAsyncTask(ctx, "crash report", func(ctx context.Context) {
-				log.SendCrashReport(
-					ctx,
-					&r.store.cfg.Settings.SV,
-					0, // depth
-					"while acquiring split lock: %s",
-					[]interface{}{err},
-					log.ReportTypeError,
-				)
-			})
-
-			cmd.forcedErr = roachpb.NewError(err)
+			log.Fatalf(ctx, "unable to acquire split lock: %s", err)
 		} else if splitMergeUnlock != nil {
 			// Set the splitMergeUnlock on the cmdAppCtx to be called after the batch
 			// has been applied (see applyBatch).

--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -1453,13 +1453,12 @@ func (r *Replica) maybeAcquireSnapshotMergeLock(
 }
 
 // maybeAcquireSplitMergeLock examines the given raftCmd (which need
-// not be evaluated yet) and acquires the split or merge lock if
+// not be applied yet) and acquires the split or merge lock if
 // necessary (in addition to other preparation). It returns a function
-// which will release any lock acquired (or nil) and use the result of
-// applying the command to perform any necessary cleanup.
+// which will release any lock acquired (or nil).
 func (r *Replica) maybeAcquireSplitMergeLock(
 	ctx context.Context, raftCmd storagepb.RaftCommand,
-) (func(*storagepb.ReplicatedEvalResult), error) {
+) (func(), error) {
 	if split := raftCmd.ReplicatedEvalResult.Split; split != nil {
 		return r.acquireSplitLock(ctx, &split.SplitTrigger)
 	} else if merge := raftCmd.ReplicatedEvalResult.Merge; merge != nil {
@@ -1470,8 +1469,8 @@ func (r *Replica) maybeAcquireSplitMergeLock(
 
 func (r *Replica) acquireSplitLock(
 	ctx context.Context, split *roachpb.SplitTrigger,
-) (func(*storagepb.ReplicatedEvalResult), error) {
-	rightRng, created, err := r.store.getOrCreateReplica(ctx, split.RightDesc.RangeID, 0, nil)
+) (func(), error) {
+	rightRng, _, err := r.store.getOrCreateReplica(ctx, split.RightDesc.RangeID, 0, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1487,33 +1486,12 @@ func (r *Replica) acquireSplitLock(
 	// commands that have reproposals interacting with retries (i.e. we don't
 	// treat splits differently).
 
-	return func(rResult *storagepb.ReplicatedEvalResult) {
-		if rResult.Split == nil && created && !rightRng.IsInitialized() {
-			// An error occurred during processing of the split and the RHS is still
-			// uninitialized. Mark the RHS destroyed and remove it from the replica's
-			// map as it is likely detritus. One reason this can occur is when
-			// concurrent splits on the same key are executed. Only one of the splits
-			// will succeed while the other will allocate a range ID, but fail to
-			// commit.
-			//
-			// We condition this removal on whether the RHS was newly created in
-			// order to be conservative. If a Raft message had created the Replica
-			// then presumably it was alive for some reason other than a concurrent
-			// split and shouldn't be destroyed.
-			rightRng.mu.Lock()
-			rightRng.mu.destroyStatus.Set(errors.Errorf("%s: failed to initialize", rightRng), destroyReasonRemoved)
-			rightRng.mu.Unlock()
-			r.store.mu.Lock()
-			r.store.unlinkReplicaByRangeIDLocked(rightRng.RangeID)
-			r.store.mu.Unlock()
-		}
-		rightRng.raftMu.Unlock()
-	}, nil
+	return rightRng.raftMu.Unlock, nil
 }
 
 func (r *Replica) acquireMergeLock(
 	ctx context.Context, merge *roachpb.MergeTrigger,
-) (func(*storagepb.ReplicatedEvalResult), error) {
+) (func(), error) {
 	// The merge lock is the right-hand replica's raftMu. The right-hand replica
 	// is required to exist on this store. Otherwise, an incoming snapshot could
 	// create the right-hand replica before the merge trigger has a chance to
@@ -1531,9 +1509,7 @@ func (r *Replica) acquireMergeLock(
 		return nil, errors.Errorf("RHS of merge %s <- %s not present on store; found %s in place of the RHS",
 			&merge.LeftDesc, &merge.RightDesc, rightDesc)
 	}
-	return func(*storagepb.ReplicatedEvalResult) {
-		rightRepl.raftMu.Unlock()
-	}, nil
+	return rightRepl.raftMu.Unlock, nil
 }
 
 // handleTruncatedStateBelowRaft is called when a Raft command updates the truncated

--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -1528,7 +1528,7 @@ func (r *Replica) acquireMergeLock(
 	}
 	rightDesc := rightRepl.Desc()
 	if !rightDesc.StartKey.Equal(merge.RightDesc.StartKey) || !rightDesc.EndKey.Equal(merge.RightDesc.EndKey) {
-		log.Fatalf(ctx, "RHS of merge %s <- %s not present on store; found %s in place of the RHS",
+		return nil, errors.Errorf("RHS of merge %s <- %s not present on store; found %s in place of the RHS",
 			&merge.LeftDesc, &merge.RightDesc, rightDesc)
 	}
 	return func(*storagepb.ReplicatedEvalResult) {

--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -1474,18 +1474,10 @@ func (r *Replica) acquireSplitLock(
 	if err != nil {
 		return nil, err
 	}
-
-	// It would be nice to assert that rightRng is not initialized
-	// here. Unfortunately, due to reproposals and retries we might be executing
-	// a reproposal for a split trigger that was already executed via a
-	// retry. The reproposed command will not succeed (the transaction has
-	// already committed).
-	//
-	// TODO(peter): It might be okay to return an error here, but it is more
-	// conservative to hit the exact same error paths that we would hit for other
-	// commands that have reproposals interacting with retries (i.e. we don't
-	// treat splits differently).
-
+	if rightRng.IsInitialized() {
+		return nil, errors.Errorf("RHS of split %s / %s already initialized before split application",
+			&split.LeftDesc, &split.RightDesc)
+	}
 	return rightRng.raftMu.Unlock, nil
 }
 


### PR DESCRIPTION
This PR contains three related cleanups that I stumbled into while cleaning up raft entry application in preparation for #38954.

The first cleanup is that we avoid improperly handling errors that may be returned when acquiring the split/merge locks. If this operation fails then we can't simply return an error and not apply the command. We need to be deterministic at this point. The only option we have is to fatal. See https://github.com/cockroachdb/cockroach/pull/19448#issuecomment-516242901.

The second cleanup is that we then remove stale code that was attempting to recover from failed split and merge application. This error handling only made sense in a pre-proposer evaluated KV world.

The third commit addresses a TODO to assert that the RHS range during a split is not initialized. The TODO looks like it went in before proposer evaluated KV, which protects us against both replays and reproposals.