### PR TITLE
server: fix the advisory certificate check

### DIFF
--- a/pkg/cli/interactive_tests/test_cert_advisory_validation.tcl
+++ b/pkg/cli/interactive_tests/test_cert_advisory_validation.tcl
@@ -1,0 +1,60 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+set ::env(COCKROACH_INSECURE) "false"
+
+spawn /bin/bash
+send "PS1=':''/# '\r"
+
+set prompt ":/# "
+eexpect $prompt
+
+# create some cert without an IP address in there.
+set certs_dir "./my-safe-directory"
+send "mkdir -p $certs_dir\r"
+eexpect $prompt
+
+send "$argv cert create-ca --certs-dir=$certs_dir --ca-key=$certs_dir/ca.key\r"
+eexpect $prompt
+send "$argv cert create-node localhost --certs-dir=$certs_dir --ca-key=$certs_dir/ca.key\r"
+eexpect $prompt
+
+start_test "Check that the server reports a warning if attempting to advertise an IP address."
+send "$argv start --certs-dir=$certs_dir --advertise-addr=127.0.0.1\r"
+eexpect "advertise address"
+eexpect "127.0.0.1"
+eexpect "not in node certificate"
+eexpect "node starting"
+interrupt
+eexpect "interrupted"
+eexpect $prompt
+end_test
+
+start_test "Check that the server reports a warning if the advertise addr does not resolve."
+send "$argv start --certs-dir=$certs_dir --advertise-addr=nonexistentwoo\r"
+eexpect "advertise address"
+eexpect "does not resolve"
+
+# also expect the previous message
+eexpect "advertise address"
+eexpect "not in node certificate"
+eexpect "node starting"
+interrupt
+eexpect "interrupted"
+eexpect $prompt
+end_test
+
+start_test "Check that the server reports no warning if the avertise addr is in th cert."
+send "$argv start --certs-dir=$certs_dir --advertise-addr=localhost\r"
+expect {
+  "not in node certificate" {
+     report "unexpected warning"
+     exit 1
+  }
+  "node starting" {}
+}
+interrupt
+eexpect "interrupted"
+expect $prompt
+end_test

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -243,6 +243,13 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 
 	ctx := s.AnnotateCtx(context.Background())
 
+	// Check the compatibility between the configured addresses and that
+	// provided in certificates. This also logs the certificate
+	// addresses in all cases to aid troubleshooting.
+	// This must be called after the certificate manager was initialized
+	// and after ValidateAddrs().
+	s.cfg.CheckCertificateAddrs(ctx)
+
 	s.rpcContext = rpc.NewContext(s.cfg.AmbientCtx, s.cfg.Config, s.clock, s.stopper,
 		&cfg.Settings.Version)
 	s.rpcContext.HeartbeatCB = func() {
@@ -1159,12 +1166,6 @@ func (s *Server) Start(ctx context.Context) error {
 	if err := base.UpdateAddrs(ctx, &s.cfg.HTTPAddr, &s.cfg.HTTPAdvertiseAddr, httpLn.Addr()); err != nil {
 		return errors.Wrapf(err, "internal error: cannot parse http listen address")
 	}
-
-	// Check the compatibility between the configured addresses and that
-	// provided in certificates. This also logs the certificate
-	// addresses in all cases to aid troubleshooting.
-	// This must be called after both calls to UpdateAddrs() above.
-	s.cfg.CheckCertificateAddrs(ctx)
 
 	workersCtx := s.AnnotateCtx(context.Background())
 


### PR DESCRIPTION
Fixes #32539.

(context: `cockroach start` performs some advisory checks on the
certificates prior to starting up, to inform the user upfront if the
cert configuration is suspicious. These checks are complementary to
the actual security validation performed in the go std lib.)

Prior to this patch, the advisory cert validation was performing
checks on both the addres given to `--listen` and that given to
`--advertise` (either explicitly, or implicitly when derived from
`--listen`).

This was problematic because the listen address is really irrelevant
to security validation. What matters for node cert validation is that
the advertised address is present. So this patch removes the check on
the listen addr (recommended by @mberhault).

Additionally this patch also enhances the check on the advertise addr:
if a host name is given to `--advertise-addr` (either explicitly, or
implicitly as derived from `--listen-addr`), and the name is not
present in the cert, the validation is considered to pass if the
resolved address for the given name is present int he cert.

Release note (cli change): The advisory/informative check performed by
`cockroach start` on the validity of addresses contained in the node
certificate is relaxed to focus on the advertised node address, and to
tolerate cases when the cert contains an IP address but a hostname is
specified as advertised address.