### PR TITLE
logictestccl: fix zone failures under stress

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -30,7 +30,7 @@ scan  ·      ·
 ·     table  t@secondary
 ·     spans  /10-/11
 
-query T
+query T retry
 EXPLAIN (OPT, CATALOG) SELECT * FROM t
 ----
 TABLE t
@@ -70,7 +70,7 @@ scan  ·      ·
 ·     table  t@tertiary
 ·     spans  /10-/11
 
-query T
+query T retry
 EXPLAIN (OPT, CATALOG) SELECT * FROM t
 ----
 TABLE t
@@ -128,7 +128,7 @@ scan  ·      ·
 ·     table  t@primary
 ·     spans  /10-/10/#
 
-query T
+query T retry
 EXPLAIN (OPT, CATALOG) SELECT * FROM t
 ----
 TABLE t
@@ -221,7 +221,7 @@ scan  ·      ·
 ·     table  t@tertiary
 ·     spans  /10-/11
 
-query T
+query T retry
 EXPLAIN (OPT, CATALOG) SELECT * FROM t
 ----
 TABLE t
@@ -271,7 +271,7 @@ scan  ·      ·
 ·     table  t@secondary
 ·     spans  /10-/11
 
-query T
+query T retry
 EXPLAIN (OPT, CATALOG) SELECT * FROM t
 ----
 TABLE t
@@ -362,7 +362,7 @@ scan  ·      ·
 ·     table  t36642@tertiary
 ·     spans  /10-/11
 
-query T
+query T retry
 EXPLAIN (OPT, CATALOG) SELECT * FROM t
 ----
 TABLE t


### PR DESCRIPTION
The 'zone' logic test was failing under stress due to a race between
gossiping zone config changes and running explain plans. As suggested by
an existing comment, I added the "retry" option to more tests to account
for this potential race.

Fixes #38864

Release note: None