### PR TITLE
opt: support CREATE VIEW

### DIFF
--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -24,9 +24,13 @@ import (
 
 // createViewNode represents a CREATE VIEW statement.
 type createViewNode struct {
-	n             *tree.CreateView
-	dbDesc        *sqlbase.DatabaseDescriptor
-	sourceColumns sqlbase.ResultColumns
+	viewName tree.Name
+	// viewQuery contains the view definition, with all table names fully
+	// qualified.
+	viewQuery string
+	dbDesc    *sqlbase.DatabaseDescriptor
+	columns   sqlbase.ResultColumns
+
 	// planDeps tracks which tables and views the view being created
 	// depends on. This is collected during the construction of
 	// the view query's logical plan.
@@ -85,27 +89,29 @@ func (p *planner) CreateView(ctx context.Context, n *tree.CreateView) (planNode,
 		f.Close() // We don't need the string.
 	}
 
-	numColNames := len(n.ColumnNames)
-	numColumns := len(sourceColumns)
-	if numColNames != 0 && numColNames != numColumns {
-		return nil, sqlbase.NewSyntaxError(fmt.Sprintf(
-			"CREATE VIEW specifies %d column name%s, but data source has %d column%s",
-			numColNames, util.Pluralize(int64(numColNames)),
-			numColumns, util.Pluralize(int64(numColumns))))
+	if numColNames := len(n.ColumnNames); numColNames != 0 {
+		if numColumns := len(sourceColumns); numColNames != numColumns {
+			return nil, sqlbase.NewSyntaxError(fmt.Sprintf(
+				"CREATE VIEW specifies %d column name%s, but data source has %d column%s",
+				numColNames, util.Pluralize(int64(numColNames)),
+				numColumns, util.Pluralize(int64(numColumns))))
+		}
+		sourceColumns = overrideColumnNames(sourceColumns, n.ColumnNames)
 	}
 
-	log.VEventf(ctx, 2, "collected view dependencies:\n%s", planDeps.String())
-
 	return &createViewNode{
-		n:             n,
-		dbDesc:        dbDesc,
-		sourceColumns: sourceColumns,
-		planDeps:      planDeps,
+		viewName:  n.Name.TableName,
+		viewQuery: tree.AsStringWithFlags(n.AsSource, tree.FmtParsable),
+		dbDesc:    dbDesc,
+		columns:   sourceColumns,
+		planDeps:  planDeps,
 	}, nil
 }
 
 func (n *createViewNode) startExec(params runParams) error {
-	viewName := n.n.Name.Table()
+	viewName := string(n.viewName)
+	log.VEventf(params.ctx, 2, "dependencies for view %s:\n%s", viewName, n.planDeps.String())
+
 	tKey := sqlbase.NewTableKey(n.dbDesc.ID, viewName)
 	key := tKey.Key()
 	if exists, err := descExists(params.ctx, params.p.txn, key); err == nil && exists {
@@ -125,11 +131,10 @@ func (n *createViewNode) startExec(params runParams) error {
 
 	desc, err := makeViewTableDesc(
 		viewName,
-		tree.AsStringWithFlags(n.n.AsSource, tree.FmtParsable),
-		n.n.ColumnNames,
+		n.viewQuery,
 		n.dbDesc.ID,
 		id,
-		n.sourceColumns,
+		n.columns,
 		params.p.txn.CommitTimestamp(),
 		privs,
 		&params.p.semaCtx,
@@ -175,6 +180,7 @@ func (n *createViewNode) startExec(params runParams) error {
 
 	// Log Create View event. This is an auditable log event and is
 	// recorded in the same transaction as the table descriptor update.
+	tn := tree.MakeTableName(tree.Name(n.dbDesc.Name), n.viewName)
 	return MakeEventLogger(params.extendedEvalCtx.ExecCfg).InsertEventRecord(
 		params.ctx,
 		params.p.txn,
@@ -183,9 +189,13 @@ func (n *createViewNode) startExec(params runParams) error {
 		int32(params.extendedEvalCtx.NodeID),
 		struct {
 			ViewName  string
-			Statement string
+			ViewQuery string
 			User      string
-		}{n.n.Name.FQString(), n.n.String(), params.SessionData().User},
+		}{
+			ViewName:  tn.FQString(),
+			ViewQuery: n.viewQuery,
+			User:      params.SessionData().User,
+		},
 	)
 }
 
@@ -203,7 +213,6 @@ func (n *createViewNode) Close(ctx context.Context)  {}
 func makeViewTableDesc(
 	viewName string,
 	viewQuery string,
-	columnNames tree.NameList,
 	parentID sqlbase.ID,
 	id sqlbase.ID,
 	resultColumns []sqlbase.ResultColumn,
@@ -213,11 +222,8 @@ func makeViewTableDesc(
 ) (sqlbase.MutableTableDescriptor, error) {
 	desc := InitTableDescriptor(id, parentID, viewName, creationTime, privileges)
 	desc.ViewQuery = viewQuery
-	for i, colRes := range resultColumns {
+	for _, colRes := range resultColumns {
 		columnTableDef := tree.ColumnTableDef{Name: tree.Name(colRes.Name), Type: colRes.Typ}
-		if len(columnNames) > i {
-			columnTableDef.Name = columnNames[i]
-		}
 		// The new types in the CREATE VIEW column specs never use
 		// SERIAL so we need not process SERIAL types here.
 		col, _, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef, semaCtx)
@@ -230,4 +236,12 @@ func makeViewTableDesc(
 		return sqlbase.MutableTableDescriptor{}, err
 	}
 	return desc, nil
+}
+
+func overrideColumnNames(cols sqlbase.ResultColumns, newNames tree.NameList) sqlbase.ResultColumns {
+	res := append(sqlbase.ResultColumns(nil), cols...)
+	for i := range res {
+		res[i].Name = string(newNames[i])
+	}
+	return res
 }

--- a/pkg/sql/logictest/testdata/logic_test/dependencies
+++ b/pkg/sql/logictest/testdata/logic_test/dependencies
@@ -137,18 +137,3 @@ SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name LIKE 'blo
 ----
 descriptor_id  descriptor_name    index_id  dependedonby_id  dependedonby_type  dependedonby_index_id  dependedonby_name  dependedonby_details
 63             blog_posts_id_seq  NULL      64               sequence           0                      NULL               Columns: [0]
-
-# Verify that we report a dependency on a column that is being mutated.
-  #CREATE VIEW v AS WITH a AS (UPDATE kv SET v = 444 RETURNING k) SELECT k FROM a;
-statement ok
-CREATE TABLE kv (k INT PRIMARY KEY, v INT);
-BEGIN;
-  ALTER TABLE kv ADD COLUMN z INT DEFAULT 123;
-  CREATE VIEW v AS SELECT k FROM [UPDATE kv SET v = 444 WHERE k > 0 RETURNING k];
-COMMIT
-
-query ITIITITT colnames
-SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name = 'kv'
-----
-descriptor_id  descriptor_name  index_id  dependedonby_id  dependedonby_type  dependedonby_index_id  dependedonby_name  dependedonby_details
-65             kv               NULL      66               view               0                      NULL               Columns: [1 2 3]

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -537,21 +537,3 @@ query T
 SELECT create_statement FROM [SHOW CREATE w3]
 ----
 CREATE VIEW w3 (x) AS (WITH t AS (SELECT x FROM test.public.w) SELECT x FROM t)
-
-# Test CRUD privilege in view.
-
-statement ok
-CREATE TABLE t (a INT PRIMARY KEY, b INT)
-
-statement ok
-CREATE VIEW crud_view AS SELECT a, b FROM [INSERT INTO t (a, b) VALUES (100, 100) RETURNING a, b]
-
-statement ok
-GRANT SELECT ON crud_view TO testuser
-
-user testuser
-
-query error user testuser does not have INSERT privilege on relation t
-SELECT * FROM crud_view
-
-user root

--- a/pkg/sql/logictest/testdata/logic_test/views_opt
+++ b/pkg/sql/logictest/testdata/logic_test/views_opt
@@ -1,0 +1,27 @@
+# LogicTest: local-opt
+
+statement ok
+CREATE TABLE ab (a INT PRIMARY KEY, b INT)
+
+statement error INSERT cannot be used inside a view definition
+CREATE VIEW crud_view AS SELECT a, b FROM [INSERT INTO ab VALUES (100, 100) RETURNING a, b]
+
+statement ok
+CREATE TABLE cd (c INT PRIMARY KEY, b INT)
+
+statement ok
+INSERT INTO ab VALUES (1, 1), (2, 2), (3, 3)
+
+statement ok
+INSERT INTO cd VALUES (2, 2), (3, 3), (4, 4)
+
+# View containing a correlated subquery.
+statement ok
+CREATE VIEW v1 AS SELECT a, b, EXISTS(SELECT c FROM cd WHERE cd.c=ab.a) FROM ab;
+
+query IIB rowsort
+SELECT * FROM v1
+----
+1  1  false
+2  2  true
+3  3  true

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -338,3 +338,13 @@ func (f *stubFactory) ConstructCancelQueries(input exec.Node, ifExists bool) (ex
 func (f *stubFactory) ConstructCancelSessions(input exec.Node, ifExists bool) (exec.Node, error) {
 	return struct{}{}, nil
 }
+
+func (f *stubFactory) ConstructCreateView(
+	schema cat.Schema,
+	viewName string,
+	viewQuery string,
+	columns sqlbase.ResultColumns,
+	deps opt.ViewDeps,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -107,7 +107,7 @@ type Catalog interface {
 	//
 	// NOTE: The returned data source must be immutable after construction, and
 	// so can be safely copied or used across goroutines.
-	ResolveDataSourceByID(ctx context.Context, id StableID) (DataSource, error)
+	ResolveDataSourceByID(ctx context.Context, flags Flags, id StableID) (DataSource, error)
 
 	// CheckPrivilege verifies that the current user has the given privilege on
 	// the given catalog object. If not, then CheckPrivilege returns an error.

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -244,11 +244,11 @@ func formatCols(tab Table, numCols int, colOrdinal func(tab Table, i int) int) s
 func formatCatalogFKRef(
 	catalog Catalog, inbound bool, fkRef ForeignKeyConstraint, tp treeprinter.Node,
 ) {
-	originDS, err := catalog.ResolveDataSourceByID(context.TODO(), fkRef.OriginTableID())
+	originDS, err := catalog.ResolveDataSourceByID(context.TODO(), Flags{}, fkRef.OriginTableID())
 	if err != nil {
 		panic(err)
 	}
-	refDS, err := catalog.ResolveDataSourceByID(context.TODO(), fkRef.ReferencedTableID())
+	refDS, err := catalog.ResolveDataSourceByID(context.TODO(), Flags{}, fkRef.ReferencedTableID())
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/sql/opt/cat/view.go
+++ b/pkg/sql/opt/cat/view.go
@@ -34,6 +34,10 @@ type View interface {
 	// ColumnNames returns the name of the column at the ith ordinal position
 	// within the view, where i < ColumnNameCount.
 	ColumnName(i int) tree.Name
+
+	// IsSystemView returns true if this view is a system view (like
+	// crdb_internal.ranges).
+	IsSystemView() bool
 }
 
 // FormatView nicely formats a catalog view using a treeprinter for debugging

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -246,6 +246,9 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 	case *memo.CreateTableExpr:
 		ep, err = b.buildCreateTable(t)
 
+	case *memo.CreateViewExpr:
+		ep, err = b.buildCreateView(t)
+
 	case *memo.WithExpr:
 		ep, err = b.buildWith(t)
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/ddl
+++ b/pkg/sql/opt/exec/execbuilder/testdata/ddl
@@ -228,30 +228,3 @@ CREATE TABLE test_kv(k INT PRIMARY KEY, v INT, w DECIMAL);
   CREATE UNIQUE INDEX test_kvi2_idx ON test_kvi2(v) INTERLEAVE IN PARENT test_kv(v);
   CREATE VIEW test_v1 AS SELECT v FROM test_kv;
   CREATE VIEW test_v2 AS SELECT v FROM test_v1;
-
-# Verify that we report a dependency on a column that is being mutated.
-statement ok
-CREATE TABLE kv (k INT PRIMARY KEY, v INT);
-BEGIN;
-  ALTER TABLE kv ADD COLUMN z INT DEFAULT 123;
-  CREATE VIEW v AS SELECT k FROM [UPDATE kv SET v = 444 WHERE k > 0 RETURNING k];
-COMMIT
-
-# The view should contain column z.
-query TTTTT colnames
-EXPLAIN (VERBOSE) SELECT * FROM v
-----
-tree                 field     description  columns             ordering
-run                  ·         ·            (k)                 ·
- └── update          ·         ·            (k)                 ·
-      │              table     kv           ·                   ·
-      │              set       v            ·                   ·
-      │              strategy  updater      ·                   ·
-      └── render     ·         ·            (k, v, z, column7)  ·
-           │         render 0  k            ·                   ·
-           │         render 1  v            ·                   ·
-           │         render 2  z            ·                   ·
-           │         render 3  444          ·                   ·
-           └── scan  ·         ·            (k, v, z)           ·
-·                    table     kv@primary   ·                   ·
-·                    spans     /1-          ·                   ·

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -395,6 +395,16 @@ type Factory interface {
 	// statement.
 	ConstructCreateTable(input Node, schema cat.Schema, ct *tree.CreateTable) (Node, error)
 
+	// ConstructCreateView returns a node that implements a CREATE VIEW
+	// statement.
+	ConstructCreateView(
+		schema cat.Schema,
+		viewName string,
+		viewQuery string,
+		columns sqlbase.ResultColumns,
+		deps opt.ViewDeps,
+	) (Node, error)
+
 	// ConstructSequenceSelect creates a node that implements a scan of a sequence
 	// as a data source.
 	ConstructSequenceSelect(sequence cat.Sequence) (Node, error)

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -502,6 +502,14 @@ func (h *hasher) HashIndexOrdinal(val cat.IndexOrdinal) {
 	h.HashInt(val)
 }
 
+func (h *hasher) HashViewDeps(val opt.ViewDeps) {
+	// Hash the length and address of the first element.
+	h.HashInt(len(val))
+	if len(val) > 0 {
+		h.HashPointer(unsafe.Pointer(&val[0]))
+	}
+}
+
 func (h *hasher) HashWindowFrame(val WindowFrame) {
 	h.HashInt(int(val.StartBoundType))
 	h.HashInt(int(val.EndBoundType))
@@ -799,6 +807,13 @@ func (h *hasher) IsJobCommandEqual(l, r tree.JobCommand) bool {
 
 func (h *hasher) IsIndexOrdinalEqual(l, r cat.IndexOrdinal) bool {
 	return l == r
+}
+
+func (h *hasher) IsViewDepsEqual(l, r opt.ViewDeps) bool {
+	if len(l) != len(r) {
+		return false
+	}
+	return len(l) == 0 || &l[0] == &r[0]
 }
 
 func (h *hasher) IsWindowFrameEqual(l, r WindowFrame) bool {

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1248,6 +1248,10 @@ func (b *logicalPropsBuilder) buildCreateTableProps(ct *CreateTableExpr, rel *pr
 	BuildSharedProps(b.mem, ct, &rel.Shared)
 }
 
+func (b *logicalPropsBuilder) buildCreateViewProps(cv *CreateViewExpr, rel *props.Relational) {
+	BuildSharedProps(b.mem, cv, &rel.Shared)
+}
+
 func (b *logicalPropsBuilder) buildFiltersItemProps(item *FiltersItem, scalar *props.Scalar) {
 	BuildSharedProps(b.mem, item.Condition, &scalar.Shared)
 

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -214,7 +214,7 @@ func (md *Metadata) CheckDependencies(
 		var toCheck cat.DataSource
 		var err error
 		if name.byID != 0 {
-			toCheck, err = catalog.ResolveDataSourceByID(ctx, name.byID)
+			toCheck, err = catalog.ResolveDataSourceByID(ctx, cat.Flags{}, name.byID)
 		} else {
 			// Resolve data source object.
 			toCheck, _, err = catalog.ResolveDataSource(ctx, cat.Flags{}, &name.byName)

--- a/pkg/sql/opt/ops/statement.opt
+++ b/pkg/sql/opt/ops/statement.opt
@@ -28,6 +28,30 @@ define CreateTablePrivate {
     Syntax CreateTable
 }
 
+[Relational, DDL, Mutation]
+define CreateView {
+    _ CreateViewPrivate
+}
+
+[Private]
+define CreateViewPrivate {
+    # Schema is the ID of the catalog schema into which the new table goes.
+    Schema SchemaID
+
+    ViewName string
+
+    # ViewQuery contains the query for the view; data sources are always fully
+    # qualified.
+    ViewQuery string
+
+    # Columns that correspond to the output of the view query, with the names
+    # they will have as part of the view.
+    Columns Presentation
+
+    # Deps contains the data source dependencies of the view.
+    Deps ViewDeps
+}
+
 # Explain returns information about the execution plan of the "input"
 # expression.
 [Relational]

--- a/pkg/sql/opt/optbuilder/create_view.go
+++ b/pkg/sql/opt/optbuilder/create_view.go
@@ -1,0 +1,67 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package optbuilder
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
+
+func (b *Builder) buildCreateView(cv *tree.CreateView, inScope *scope) (outScope *scope) {
+	b.DisableMemoReuse = true
+	sch, _ := b.resolveSchemaForCreate(&cv.Name)
+	schID := b.factory.Metadata().AddSchema(sch)
+
+	// We build the select statement to:
+	//  - check the statement semantically,
+	//  - get the fully resolved names into the AST, and
+	//  - collect the view dependencies in b.viewDeps.
+	// The result is not otherwise used.
+	b.insideViewDef = true
+	b.trackViewDeps = true
+	defer func() {
+		b.insideViewDef = false
+		b.trackViewDeps = false
+		b.viewDeps = nil
+	}()
+
+	defScope := b.buildSelect(cv.AsSource, nil /* desiredTypes */, inScope)
+
+	p := defScope.makePhysicalProps().Presentation
+	if len(cv.ColumnNames) != 0 {
+		if len(p) != len(cv.ColumnNames) {
+			panic(sqlbase.NewSyntaxError(fmt.Sprintf(
+				"CREATE VIEW specifies %d column name%s, but data source has %d column%s",
+				len(cv.ColumnNames), util.Pluralize(int64(len(cv.ColumnNames))),
+				len(p), util.Pluralize(int64(len(p)))),
+			))
+		}
+		// Override the columns.
+		for i := range p {
+			p[i].Alias = string(cv.ColumnNames[i])
+		}
+	}
+
+	expr := b.factory.ConstructCreateView(
+		&memo.CreateViewPrivate{
+			Schema:    schID,
+			ViewName:  cv.Name.Table(),
+			ViewQuery: tree.AsStringWithFlags(cv.AsSource, tree.FmtParsable),
+			Columns:   p,
+			Deps:      b.viewDeps,
+		},
+	)
+	return &scope{builder: b, expr: expr}
+}

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -786,7 +786,7 @@ func (mb *mutationBuilder) buildFKChecksForInsert() {
 		// referenced columns on the right.
 
 		refID := fk.ReferencedTableID()
-		ref, err := mb.b.catalog.ResolveDataSourceByID(mb.b.ctx, refID)
+		ref, err := mb.b.catalog.ResolveDataSourceByID(mb.b.ctx, cat.Flags{}, refID)
 		if err != nil {
 			panic(err)
 		}
@@ -937,7 +937,7 @@ func (mb *mutationBuilder) buildFKChecksForDelete() {
 		// origin columns on the right.
 
 		origID := fk.OriginTableID()
-		orig, err := mb.b.catalog.ResolveDataSourceByID(mb.b.ctx, origID)
+		orig, err := mb.b.catalog.ResolveDataSourceByID(mb.b.ctx, cat.Flags{}, origID)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -98,14 +98,24 @@ func (b *Builder) buildDataSource(
 		}
 
 		ds, resName := b.resolveDataSource(tn, privilege.SELECT)
+		if b.insideViewDef {
+			// Overwrite the table name in the AST to the fully resolved version.
+			// TODO(radu): modifying the AST in-place is hacky; we will need to switch
+			// to using AST annotations.
+			*tn = resName
+			tn.ExplicitCatalog = true
+			tn.ExplicitSchema = true
+		}
 		switch t := ds.(type) {
 		case cat.Table:
 			tabMeta := b.addTable(t, &resName)
 			return b.buildScan(tabMeta, nil /* ordinals */, indexFlags, excludeMutations, inScope)
-		case cat.View:
-			return b.buildView(t, &resName, inScope)
+
 		case cat.Sequence:
 			return b.buildSequenceSelect(t, &resName, inScope)
+
+		case cat.View:
+			return b.buildView(t, &resName, inScope)
 		default:
 			panic(errors.AssertionFailedf("unknown DataSource type %T", ds))
 		}
@@ -202,6 +212,13 @@ func (b *Builder) buildView(
 		b.skipSelectPrivilegeChecks = true
 		defer func() { b.skipSelectPrivilegeChecks = false }()
 	}
+	trackDeps := b.trackViewDeps
+	if trackDeps {
+		// We are only interested in the direct dependency on this view descriptor.
+		// Any further dependency by the view's query should not be tracked.
+		b.trackViewDeps = false
+		defer func() { b.trackViewDeps = true }()
+	}
 
 	outScope = b.buildSelect(sel, nil /* desiredTypes */, &scope{builder: b})
 
@@ -213,6 +230,14 @@ func (b *Builder) buildView(
 		if hasCols {
 			outScope.cols[i].name = view.ColumnName(i)
 		}
+	}
+
+	if trackDeps && !view.IsSystemView() {
+		dep := opt.ViewDep{DataSource: view}
+		for i := range outScope.cols {
+			dep.ColumnOrdinals.Add(i)
+		}
+		b.viewDeps = append(b.viewDeps, dep)
 	}
 
 	return outScope
@@ -360,15 +385,18 @@ func (b *Builder) buildScan(
 		}
 	}
 
+	getOrdinal := func(i int) int {
+		if ordinals == nil {
+			return i
+		}
+		return ordinals[i]
+	}
+
 	var tabColIDs opt.ColSet
 	outScope = inScope.push()
 	outScope.cols = make([]scopeColumn, 0, colCount)
 	for i := 0; i < colCount; i++ {
-		ord := i
-		if ordinals != nil {
-			ord = ordinals[i]
-		}
-
+		ord := getOrdinal(i)
 		col := tab.Column(ord)
 		colID := tabID.ColumnID(ord)
 		tabColIDs.Add(colID)
@@ -391,6 +419,8 @@ func (b *Builder) buildScan(
 		}
 		private := memo.VirtualScanPrivate{Table: tabID, Cols: tabColIDs}
 		outScope.expr = b.factory.ConstructVirtualScan(&private)
+
+		// Virtual tables should not be collected as view dependencies.
 	} else {
 		private := memo.ScanPrivate{Table: tabID, Cols: tabColIDs}
 
@@ -421,6 +451,18 @@ func (b *Builder) buildScan(
 		}
 		outScope.expr = b.factory.ConstructScan(&private)
 		b.addCheckConstraintsToScan(outScope, tabMeta)
+
+		if b.trackViewDeps {
+			dep := opt.ViewDep{DataSource: tab}
+			for i := 0; i < colCount; i++ {
+				dep.ColumnOrdinals.Add(getOrdinal(i))
+			}
+			if private.Flags.ForceIndex {
+				dep.SpecificIndex = true
+				dep.Index = private.Flags.Index
+			}
+			b.viewDeps = append(b.viewDeps, dep)
+		}
 	}
 	return outScope
 }
@@ -478,6 +520,10 @@ func (b *Builder) buildSequenceSelect(
 		Cols:     cols,
 	}
 	outScope.expr = b.factory.ConstructSequenceSelect(&private)
+
+	if b.trackViewDeps {
+		b.viewDeps = append(b.viewDeps, opt.ViewDep{DataSource: seq})
+	}
 	return outScope
 }
 

--- a/pkg/sql/opt/optbuilder/testdata/create_view
+++ b/pkg/sql/opt/optbuilder/testdata/create_view
@@ -1,0 +1,167 @@
+# This table has ID 53.
+exec-ddl
+CREATE TABLE ab (a INT PRIMARY KEY, b INT, INDEX idx(b))
+----
+
+exec-ddl
+CREATE TABLE cd (c INT PRIMARY KEY, d INT)
+----
+
+exec-ddl
+CREATE SEQUENCE s
+----
+
+build
+CREATE VIEW v1 AS VALUES (1)
+----
+create-view t.public.v1
+ ├── VALUES (1)
+ ├── columns: column1:1(int)
+ └── dependencies
+
+build
+CREATE VIEW v1 AS SELECT a FROM ab 
+----
+create-view t.public.v1
+ ├── SELECT a FROM t.public.ab
+ ├── columns: a:1(int)
+ └── dependencies
+      └── ab [columns: (0,1)]
+
+# Test dependency on specific index.
+build
+CREATE VIEW v1 AS SELECT a FROM ab@idx
+----
+create-view t.public.v1
+ ├── SELECT a FROM t.public.ab@idx
+ ├── columns: a:1(int)
+ └── dependencies
+      └── ab@idx [columns: (0,1)]
+
+build
+CREATE VIEW v1 AS SELECT a FROM ab@primary
+----
+create-view t.public.v1
+ ├── SELECT a FROM t.public.ab@primary
+ ├── columns: a:1(int)
+ └── dependencies
+      └── ab@primary [columns: (0,1)]
+
+# Test dependency on view.
+exec-ddl
+CREATE VIEW av AS SELECT a FROM ab
+----
+
+build
+CREATE VIEW v1 AS SELECT a FROM av 
+----
+create-view t.public.v1
+ ├── SELECT a FROM t.public.av
+ ├── columns: a:1(int)
+ └── dependencies
+      └── av [columns: (0)]
+
+build
+CREATE VIEW v1 AS SELECT av.a, ab.a FROM av, ab
+----
+create-view t.public.v1
+ ├── SELECT av.a, ab.a FROM t.public.av, t.public.ab
+ ├── columns: a:1(int) a:3(int)
+ └── dependencies
+      ├── av [columns: (0)]
+      └── ab [columns: (0,1)]
+
+# Test that we don't report virtual table dependencies.
+build
+CREATE VIEW v1 AS SELECT a, table_schema FROM ab, information_schema.columns
+----
+create-view t.public.v1
+ ├── SELECT a, table_schema FROM t.public.ab, "".information_schema.columns
+ ├── columns: a:1(int) table_schema:4(string)
+ └── dependencies
+      └── ab [columns: (0,1)]
+
+# Test cases with specified column names.
+build
+CREATE VIEW v2 (x) AS SELECT ab.a FROM ab, ab AS ab2, cd
+----
+create-view t.public.v2
+ ├── SELECT ab.a FROM t.public.ab, t.public.ab AS ab2, t.public.cd
+ ├── columns: x:1(int)
+ └── dependencies
+      ├── ab [columns: (0,1)]
+      ├── ab [columns: (0,1)]
+      └── cd [columns: (0,1)]
+
+build
+CREATE VIEW v3 (x, y) AS SELECT a FROM ab
+----
+error (42601): CREATE VIEW specifies 2 column names, but data source has 1 column
+
+build
+CREATE VIEW v3 (x) AS SELECT a, b FROM ab
+----
+error (42601): CREATE VIEW specifies 1 column name, but data source has 2 columns
+
+# Verify that we disallow * in view definitions (#10028).
+build
+CREATE VIEW v4 AS SELECT * FROM ab
+----
+error (0A000): unimplemented: views do not currently support * expressions
+
+build
+CREATE VIEW v5 AS SELECT a FROM [53 AS t]
+----
+create-view t.public.v5
+ ├── SELECT a FROM [53 AS t]
+ ├── columns: a:1(int)
+ └── dependencies
+      └── ab [columns: (0,1)]
+
+# Verify that we only depend on the specified column.
+build
+CREATE VIEW v6 AS SELECT a FROM [53(1) AS t]
+----
+create-view t.public.v6
+ ├── SELECT a FROM [53(1) AS t]
+ ├── columns: a:1(int)
+ └── dependencies
+      └── ab [columns: (0)]
+
+# Verify dependency on sequence.
+build
+CREATE VIEW v7 AS SELECT last_value FROM s
+----
+create-view t.public.v7
+ ├── SELECT last_value FROM t.public.s
+ ├── columns: last_value:1(int)
+ └── dependencies
+      └── s
+
+# Verify CTEs (and that we don't depend on tables with the same name).
+build
+CREATE VIEW v8 AS
+WITH cd AS (SELECT a, b FROM ab)
+  SELECT a+b FROM cd
+----
+create-view t.public.v8
+ ├── WITH cd AS (SELECT a, b FROM t.public.ab) SELECT a + b FROM cd
+ ├── columns: "?column?":5(int)
+ └── dependencies
+      └── ab [columns: (0,1)]
+
+# Verify that we disallow mutation statements.
+build
+CREATE VIEW v8 AS SELECT a,b FROM [INSERT INTO ab VALUES (1,1) RETURNING a, b]
+----
+error (42601): INSERT cannot be used inside a view definition
+
+build
+CREATE VIEW v9 AS SELECT a,b FROM [UPDATE ab SET a=a+1 RETURNING a, b]
+----
+error (42601): UPDATE cannot be used inside a view definition
+
+build
+CREATE VIEW v9 AS SELECT a,b FROM [DELETE FROM ab WHERE a>b RETURNING a, b]
+----
+error (42601): DELETE cannot be used inside a view definition

--- a/pkg/sql/opt/optgen/cmd/optgen/metadata.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/metadata.go
@@ -180,6 +180,7 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"OpaqueMetadata": {fullName: "opt.OpaqueMetadata", isPointer: true},
 		"JobCommand":     {fullName: "tree.JobCommand", passByVal: true},
 		"IndexOrdinal":   {fullName: "cat.IndexOrdinal", passByVal: true},
+		"ViewDeps":       {fullName: "opt.ViewDeps", passByVal: true},
 	}
 
 	// Add types of generated op and private structs.

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -156,7 +156,7 @@ func (tc *Catalog) ResolveDataSource(
 
 // ResolveDataSourceByID is part of the cat.Catalog interface.
 func (tc *Catalog) ResolveDataSourceByID(
-	ctx context.Context, id cat.StableID,
+	ctx context.Context, flags cat.Flags, id cat.StableID,
 ) (cat.DataSource, error) {
 	for _, ds := range tc.testSchema.dataSources {
 		if ds.ID() == id {
@@ -490,6 +490,11 @@ func (tv *View) Name() tree.Name {
 // fqName is part of the dataSource interface.
 func (tv *View) fqName() cat.DataSourceName {
 	return tv.ViewName
+}
+
+// IsSystemView is part of the cat.View interface.
+func (tv *View) IsSystemView() bool {
+	return false
 }
 
 // Query is part of the cat.View interface.

--- a/pkg/sql/opt/view_dependencies.go
+++ b/pkg/sql/opt/view_dependencies.go
@@ -1,0 +1,35 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package opt
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
+
+// ViewDeps contains information about the dependencies of a view.
+type ViewDeps []ViewDep
+
+// ViewDep contains information about a view dependency.
+type ViewDep struct {
+	DataSource cat.DataSource
+
+	// ColumnOrdinals is the set of column ordinals that are referenced by the
+	// view for this table. In most cases, this consists of all "public" columns
+	// of the table; the only exception is when a table is referenced by table ID
+	// with a specific list of column IDs.
+	ColumnOrdinals util.FastIntSet
+
+	// If an index is referenced specifically (via an index hint), SpecificIndex
+	// is true and Index is the ordinal of that index.
+	SpecificIndex bool
+	Index         cat.IndexOrdinal
+}

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -180,8 +180,15 @@ func (oc *optCatalog) ResolveDataSource(
 
 // ResolveDataSourceByID is part of the cat.Catalog interface.
 func (oc *optCatalog) ResolveDataSourceByID(
-	ctx context.Context, dataSourceID cat.StableID,
+	ctx context.Context, flags cat.Flags, dataSourceID cat.StableID,
 ) (cat.DataSource, error) {
+	if flags.AvoidDescriptorCaches {
+		defer func(prev bool) {
+			oc.planner.avoidCachedDescriptors = prev
+		}(oc.planner.avoidCachedDescriptors)
+		oc.planner.avoidCachedDescriptors = true
+	}
+
 	tableLookup, err := oc.planner.LookupTableByID(ctx, sqlbase.ID(dataSourceID))
 
 	if err != nil || tableLookup.IsAdding {
@@ -195,7 +202,7 @@ func (oc *optCatalog) ResolveDataSourceByID(
 	return oc.dataSourceForDesc(ctx, cat.Flags{}, tableLookup.Desc, &tree.TableName{})
 }
 
-func (oc *optCatalog) getDescForObject(o cat.Object) (sqlbase.DescriptorProto, error) {
+func getDescForCatalogObject(o cat.Object) (sqlbase.DescriptorProto, error) {
 	switch t := o.(type) {
 	case *optSchema:
 		return t.desc, nil
@@ -212,9 +219,24 @@ func (oc *optCatalog) getDescForObject(o cat.Object) (sqlbase.DescriptorProto, e
 	}
 }
 
+func getDescForDataSource(o cat.DataSource) (*sqlbase.ImmutableTableDescriptor, error) {
+	switch t := o.(type) {
+	case *optTable:
+		return t.desc, nil
+	case *optVirtualTable:
+		return t.desc, nil
+	case *optView:
+		return t.desc, nil
+	case *optSequence:
+		return t.desc, nil
+	default:
+		return nil, errors.AssertionFailedf("invalid object type: %T", o)
+	}
+}
+
 // CheckPrivilege is part of the cat.Catalog interface.
 func (oc *optCatalog) CheckPrivilege(ctx context.Context, o cat.Object, priv privilege.Kind) error {
-	desc, err := oc.getDescForObject(o)
+	desc, err := getDescForCatalogObject(o)
 	if err != nil {
 		return err
 	}
@@ -223,7 +245,7 @@ func (oc *optCatalog) CheckPrivilege(ctx context.Context, o cat.Object, priv pri
 
 // CheckAnyPrivilege is part of the cat.Catalog interface.
 func (oc *optCatalog) CheckAnyPrivilege(ctx context.Context, o cat.Object) error {
-	desc, err := oc.getDescForObject(o)
+	desc, err := getDescForCatalogObject(o)
 	if err != nil {
 		return err
 	}
@@ -250,17 +272,17 @@ func (oc *optCatalog) FullyQualifiedName(
 		return vt.name, nil
 	}
 
-	desc, err := oc.getDescForObject(ds)
+	desc, err := getDescForDataSource(ds)
 	if err != nil {
 		return cat.DataSourceName{}, err
 	}
 
-	dbID := desc.(*sqlbase.ImmutableTableDescriptor).ParentID
+	dbID := desc.ParentID
 	dbDesc, err := sqlbase.GetDatabaseDescFromID(ctx, oc.planner.Txn(), dbID)
 	if err != nil {
 		return cat.DataSourceName{}, err
 	}
-	return tree.MakeTableName(tree.Name(dbDesc.Name), tree.Name(desc.GetName())), nil
+	return tree.MakeTableName(tree.Name(dbDesc.Name), tree.Name(desc.Name)), nil
 }
 
 // dataSourceForDesc returns a data source wrapper for the given descriptor.
@@ -399,6 +421,11 @@ func (ov *optView) Equals(other cat.Object) bool {
 // Name is part of the cat.View interface.
 func (ov *optView) Name() tree.Name {
 	return tree.Name(ov.desc.Name)
+}
+
+// IsSystemView is part of the cat.View interface.
+func (ov *optView) IsSystemView() bool {
+	return ov.desc.IsVirtualTable()
 }
 
 // Query is part of the cat.View interface.

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -149,13 +149,16 @@ func (v virtualSchemaView) initVirtualTableDesc(
 
 	create := stmt.AST.(*tree.CreateView)
 
+	columns := v.resultColumns
+	if len(create.ColumnNames) != 0 {
+		columns = overrideColumnNames(columns, create.ColumnNames)
+	}
 	mutDesc, err := makeViewTableDesc(
 		create.Name.Table(),
 		tree.AsStringWithFlags(create.AsSource, tree.FmtParsable),
-		create.ColumnNames,
 		0, /* parentID */
 		id,
-		v.resultColumns,
+		columns,
 		hlc.Timestamp{}, /* creationTime */
 		publicSelectPrivileges,
 		nil, /* semaCtx */

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -149,15 +149,16 @@ func (v virtualSchemaView) initVirtualTableDesc(
 
 	create := stmt.AST.(*tree.CreateView)
 
-	mutDesc, err := MakeViewTableDesc(
-		create,
-		v.resultColumns,
-		0,
+	mutDesc, err := makeViewTableDesc(
+		create.Name.Table(),
+		tree.AsStringWithFlags(create.AsSource, tree.FmtParsable),
+		create.ColumnNames,
+		0, /* parentID */
 		id,
-		hlc.Timestamp{},
+		v.resultColumns,
+		hlc.Timestamp{}, /* creationTime */
 		publicSelectPrivileges,
-		nil, // semaCtx
-		nil, // evalCtx
+		nil, /* semaCtx */
 	)
 	return mutDesc.TableDescriptor, err
 }

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -569,7 +569,7 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 
 	case *createViewNode:
 		if v.observer.attr != nil {
-			v.observer.attr(name, "query", tree.AsStringWithFlags(n.n.AsSource, tree.FmtParsable))
+			v.observer.attr(name, "query", n.viewQuery)
 		}
 
 	case *setVarNode:


### PR DESCRIPTION
#### sql: minor cleanup in create_view

Release note: None

#### opt: support CREATE VIEW

This change adds support for CREATE VIEW in the optimizer. Some of the
trickier aspects:
 - to create a view, we need to collect info on data source
   dependencies. This is slightly different than the memo dependencies
   we already collect (e.g. it includes column sets), so we collect
   these separately in the opt builder.
 - the view descriptor needs to contain the query with fully qualified
   names; to achieve this, we rewrite the table names in the AST like
   the heuristic planner does (this will be switched over to use the
   new AST annotations in the future).

The optimizer implementation does not allow mutations inside view
definitions. I believe this is the right thing to do (and it's
consistent with postgres). Some tests around that had to be adjusted.

Fixes #38940.

Release note (sql change): CREATE VIEW now supports all queries
supported by the optimizer (including those containing correlated
subqueries).

Release note (sql change): Mutations are no longer allowed inside
views.
