### PR TITLE
storage,nodedialer,kv,rpc: introduce connection class to separate system traffic

### DIFF
--- a/pkg/kv/dist_sender_rangefeed.go
+++ b/pkg/kv/dist_sender_rangefeed.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -227,8 +228,10 @@ func (ds *DistSender) singleRangeFeed(
 	// would still work if we had `All` here.
 	replicas := NewReplicaSlice(ds.gossip, desc.Replicas().Voters())
 	replicas.OptimizeReplicaOrder(ds.getNodeDescriptor(), latencyFn)
-
-	transport, err := ds.transportFactory(SendOptions{}, ds.nodeDialer, replicas)
+	// The RangeFeed is not used for system critical traffic so use a DefaultClass
+	// connection regardless of the range.
+	opts := SendOptions{class: rpc.DefaultClass}
+	transport, err := ds.transportFactory(opts, ds.nodeDialer, replicas)
 	if err != nil {
 		return args.Timestamp, roachpb.NewError(err)
 	}

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -45,6 +45,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -3392,6 +3394,100 @@ func TestEvictMetaRange(t *testing.T) {
 				splitKey, testMetaEndKey, cachedRange.StartKey, cachedRange.EndKey)
 		}
 	})
+}
+
+// TestConnectionClass verifies that the dist sender constructs a transport with
+// the appropriate class for a given resolved range.
+func TestConnectionClass(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.TODO())
+	// Create a mock range descriptor DB that can resolve made up meta1, node
+	// liveness and user ranges.
+	rDB := MockRangeDescriptorDB(func(key roachpb.RKey, _ bool) (
+		[]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error,
+	) {
+		if key.Equal(roachpb.KeyMin) {
+			return []roachpb.RangeDescriptor{{
+				RangeID:  1,
+				StartKey: roachpb.RKeyMin,
+				EndKey:   roachpb.RKey(keys.NodeLivenessPrefix),
+				InternalReplicas: []roachpb.ReplicaDescriptor{
+					{NodeID: 1, StoreID: 1},
+				},
+			}}, nil, nil
+		} else if bytes.HasPrefix(key, keys.NodeLivenessPrefix) {
+			return []roachpb.RangeDescriptor{{
+				RangeID:  2,
+				StartKey: roachpb.RKey(keys.NodeLivenessPrefix),
+				EndKey:   roachpb.RKey(keys.NodeLivenessKeyMax),
+				InternalReplicas: []roachpb.ReplicaDescriptor{
+					{NodeID: 1, StoreID: 1},
+				},
+			}}, nil, nil
+		}
+		return []roachpb.RangeDescriptor{{
+			RangeID:  3,
+			StartKey: roachpb.RKey(keys.NodeLivenessKeyMax),
+			EndKey:   roachpb.RKeyMax,
+			InternalReplicas: []roachpb.ReplicaDescriptor{
+				{NodeID: 1, StoreID: 1},
+			},
+		}}, nil, nil
+	})
+	// Verify that the request carries the class we expect it to for its span.
+	verifyClass := func(class rpc.ConnectionClass, args roachpb.BatchRequest) {
+		span, err := keys.Range(args.Requests)
+		if assert.Nil(t, err) {
+			assert.Equalf(t, rpc.ConnectionClassForKey(span.Key), class,
+				"unexpected class for span key %v", span.Key)
+		}
+	}
+	var testFn simpleSendFn = func(
+		_ context.Context,
+		opts SendOptions,
+		replicas ReplicaSlice,
+		args roachpb.BatchRequest,
+	) (*roachpb.BatchResponse, error) {
+		verifyClass(opts.class, args)
+		return args.CreateReply(), nil
+	}
+	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+	rpcContext := rpc.NewInsecureTestingContext(clock, stopper)
+	g := makeGossip(t, stopper, rpcContext)
+	cfg := DistSenderConfig{
+		AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
+		Clock:      clock,
+		RPCContext: rpcContext,
+		TestingKnobs: ClientTestingKnobs{
+			TransportFactory: adaptSimpleTransport(testFn),
+		},
+		NodeDialer: nodedialer.New(rpcContext, gossip.AddressResolver(g)),
+		RPCRetryOptions: &retry.Options{
+			MaxRetries: 1,
+		},
+		RangeDescriptorDB: rDB,
+	}
+	ds := NewDistSender(cfg, g)
+
+	// Check the three important cases to ensure they are sent with the correct
+	// ConnectionClass.
+	for _, key := range []roachpb.Key{
+		keys.Meta1Prefix,
+		keys.NodeLivenessKey(1),
+		roachpb.Key(keys.MakeTablePrefix(1234)), // A non-system table
+	} {
+		t.Run(key.String(), func(t *testing.T) {
+			var ba roachpb.BatchRequest
+			ba.Add(&roachpb.GetRequest{
+				RequestHeader: roachpb.RequestHeader{
+					Key: key,
+				},
+			})
+			_, err := ds.Send(context.TODO(), ba)
+			require.Nil(t, err)
+		})
+	}
 }
 
 // TestEvictionTokenCoalesce tests when two separate batch requests are a part

--- a/pkg/rpc/connection_class.go
+++ b/pkg/rpc/connection_class.go
@@ -1,0 +1,62 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rpc
+
+import (
+	"bytes"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+)
+
+// ConnectionClass is the identifier of a group of RPC client sessions that are
+// allowed to share an underlying TCP connections; RPC sessions with different
+// connection classes are guaranteed to use separate gRPC client connections.
+//
+// RPC sessions that share a connection class are arbitrated using the gRPC flow
+// control logic, see google.golang.org/grpc/internal/transport. The lack of
+// support of prioritization in the current gRPC implementation is the reason
+// why we are separating different priority flows across separate TCP
+// connections. Future gRPC improvements may enable further simplification
+// here. See https://github.com/grpc/grpc-go/issues/1448 for progress on gRPC's
+// adoption of HTTP2 priorities.
+type ConnectionClass int8
+
+const (
+	// DefaultClass is the default ConnectionClass and should be used for most
+	// client traffic.
+	DefaultClass ConnectionClass = iota
+	// SystemClass is the ConnectionClass used for system traffic.
+	SystemClass
+
+	// NumConnectionClasses is the number of valid ConnectionClass values.
+	NumConnectionClasses int = iota
+)
+
+var systemClassKeyPrefixes = []roachpb.RKey{
+	roachpb.RKey(keys.Meta1Prefix),
+	roachpb.RKey(keys.NodeLivenessPrefix),
+}
+
+// ConnectionClassForKey determines the ConnectionClass which should be used
+// for traffic addressed to the RKey.
+func ConnectionClassForKey(key roachpb.RKey) ConnectionClass {
+	// An empty RKey addresses range 1 and warrants SystemClass.
+	if len(key) == 0 {
+		return SystemClass
+	}
+	for _, prefix := range systemClassKeyPrefixes {
+		if bytes.HasPrefix(key, prefix) {
+			return SystemClass
+		}
+	}
+	return DefaultClass
+}

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -405,6 +405,7 @@ type Context struct {
 	// For unittesting.
 	BreakerFactory  func() *circuit.Breaker
 	testingDialOpts []grpc.DialOption
+	testingKnobs    ContextTestingKnobs
 
 	// For testing. See the comment on the same field in HeartbeatService.
 	TestingAllowNamedRPCToAnonymousServer bool
@@ -435,6 +436,19 @@ func NewContext(
 	stopper *stop.Stopper,
 	version *cluster.ExposedClusterVersion,
 ) *Context {
+	return NewContextWithTestingKnobs(ambient, baseCtx, hlcClock, stopper, version,
+		ContextTestingKnobs{})
+}
+
+// NewContextWithTestingKnobs creates an rpc Context with the supplied values.
+func NewContextWithTestingKnobs(
+	ambient log.AmbientContext,
+	baseCtx *base.Config,
+	hlcClock *hlc.Clock,
+	stopper *stop.Stopper,
+	version *cluster.ExposedClusterVersion,
+	knobs ContextTestingKnobs,
+) *Context {
 	if hlcClock == nil {
 		panic("nil clock is forbidden")
 	}
@@ -449,6 +463,7 @@ func NewContext(
 		version:                        version,
 		clusterName:                    baseCtx.ClusterName,
 		disableClusterNameVerification: baseCtx.DisableClusterNameVerification,
+		testingKnobs:                   knobs,
 	}
 	var cancel context.CancelFunc
 	ctx.masterCtx, cancel = context.WithCancel(ambient.AnnotateCtx(context.Background()))
@@ -477,7 +492,9 @@ func NewContext(
 			return true
 		})
 	})
-
+	if knobs.ClusterID != nil {
+		ctx.ClusterID.Set(ctx.masterCtx, *knobs.ClusterID)
+	}
 	return ctx
 }
 
@@ -638,6 +655,14 @@ func (ctx *Context) removeConn(conn *Connection, keys ...connKey) {
 // necessarily included to support compression-enabled servers, and compression
 // is included for symmetry. These choices are admittedly subjective.
 func (ctx *Context) GRPCDialOptions() ([]grpc.DialOption, error) {
+	return ctx.grpcDialOptions("", DefaultClass)
+}
+
+// grpcDialOptions extends GRPCDialOptions to support a connection class for use
+// with TestingKnobs.
+func (ctx *Context) grpcDialOptions(
+	target string, class ConnectionClass,
+) ([]grpc.DialOption, error) {
 	var dialOpts []grpc.DialOption
 	if ctx.Insecure {
 		dialOpts = append(dialOpts, grpc.WithInsecure())
@@ -665,17 +690,29 @@ func (ctx *Context) GRPCDialOptions() ([]grpc.DialOption, error) {
 		dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(grpc.UseCompressor((snappyCompressor{}).Name())))
 	}
 
+	var unaryInterceptors []grpc.UnaryClientInterceptor
+
 	if tracer := ctx.AmbientCtx.Tracer; tracer != nil {
 		// We use a SpanInclusionFunc to circumvent the interceptor's work when
 		// tracing is disabled. Otherwise, the interceptor causes an increase in
 		// the number of packets (even with an empty context!). See #17177.
-		interceptor := otgrpc.OpenTracingClientInterceptor(
-			tracer,
-			otgrpc.IncludingSpans(otgrpc.SpanInclusionFunc(spanInclusionFuncForClient)),
-		)
-		dialOpts = append(dialOpts, grpc.WithUnaryInterceptor(interceptor))
+		unaryInterceptors = append(unaryInterceptors,
+			otgrpc.OpenTracingClientInterceptor(tracer,
+				otgrpc.IncludingSpans(otgrpc.SpanInclusionFunc(spanInclusionFuncForClient))))
 	}
-
+	if ctx.testingKnobs.UnaryClientInterceptor != nil {
+		testingUnaryInterceptor := ctx.testingKnobs.UnaryClientInterceptor(target, class)
+		if testingUnaryInterceptor != nil {
+			unaryInterceptors = append(unaryInterceptors, testingUnaryInterceptor)
+		}
+	}
+	dialOpts = append(dialOpts, grpc.WithChainUnaryInterceptor(unaryInterceptors...))
+	if ctx.testingKnobs.StreamClientInterceptor != nil {
+		testingStreamInterceptor := ctx.testingKnobs.StreamClientInterceptor(target, class)
+		if testingStreamInterceptor != nil {
+			dialOpts = append(dialOpts, grpc.WithStreamInterceptor(testingStreamInterceptor))
+		}
+	}
 	return dialOpts, nil
 }
 
@@ -742,7 +779,7 @@ func (ctx *Context) GRPCDialRaw(target string) (*grpc.ClientConn, <-chan struct{
 func (ctx *Context) grpcDialRaw(
 	target string, class ConnectionClass,
 ) (*grpc.ClientConn, <-chan struct{}, error) {
-	dialOpts, err := ctx.GRPCDialOptions()
+	dialOpts, err := ctx.grpcDialOptions(target, class)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -410,12 +410,21 @@ type Context struct {
 	TestingAllowNamedRPCToAnonymousServer bool
 }
 
-// connKey is used as key in the Context.conns map.  Different remote
-// node IDs get different *Connection objects, to ensure that we don't
-// mis-route RPC requests.
+// connKey is used as key in the Context.conns map.
+// Connections which carry a different class but share a target and nodeID
+// will always specify distinct connections. Different remote node IDs get
+// distinct *Connection objects to ensure that we don't mis-route RPC
+// requests in the face of address reuse. Gossip connections and other
+// non-Internal users of the Context are free to dial nodes without
+// specifying a node ID (see GRPCUnvalidatedDial()) however later calls to
+// Dial with the same target and class with a node ID will create a new
+// underlying connection. The inverse however is not true, a connection
+// dialed without a node ID will use an existing connection to a matching
+// (targetAddr, class) pair.
 type connKey struct {
 	targetAddr string
 	nodeID     roachpb.NodeID
+	class      ConnectionClass
 }
 
 // NewContext creates an rpc Context with the supplied values.
@@ -721,10 +730,18 @@ func (ood *onlyOnceDialer) dial(ctx context.Context, addr string) (net.Conn, err
 }
 
 // GRPCDialRaw calls grpc.Dial with options appropriate for the context.
-// Unlike GRPCDial, it does not start an RPC heartbeat to validate the
+// Unlike GRPCDialNode, it does not start an RPC heartbeat to validate the
 // connection. This connection will not be reconnected automatically;
 // the returned channel is closed when a reconnection is attempted.
+// This method implies a DefaultClass ConnectionClass for the returned
+// ClientConn.
 func (ctx *Context) GRPCDialRaw(target string) (*grpc.ClientConn, <-chan struct{}, error) {
+	return ctx.grpcDialRaw(target, DefaultClass)
+}
+
+func (ctx *Context) grpcDialRaw(
+	target string, class ConnectionClass,
+) (*grpc.ClientConn, <-chan struct{}, error) {
 	dialOpts, err := ctx.GRPCDialOptions()
 	if err != nil {
 		return nil, nil, err
@@ -759,26 +776,36 @@ func (ctx *Context) GRPCDialRaw(target string) (*grpc.ClientConn, <-chan struct{
 // GRPCUnvalidatedDial uses GRPCDialNode and disables validation of the
 // node ID between client and server. This function should only be
 // used with the gossip client and CLI commands which can talk to any
-// node.
+// node. This method implies a SystemClass.
 func (ctx *Context) GRPCUnvalidatedDial(target string) *Connection {
-	return ctx.grpcDialNodeInternal(target, 0)
+	return ctx.grpcDialNodeInternal(target, 0, SystemClass)
 }
 
-// GRPCDialNode calls grpc.Dial with options appropriate for the context.
+// GRPCDialNodeClass calls grpc.Dial with options appropriate for the
+// context and class (see the comment on ConnectionClass).
 //
 // The remoteNodeID becomes a constraint on the expected node ID of
 // the remote node; this is checked during heartbeats. The caller is
 // responsible for ensuring the remote node ID is known prior to using
 // this function.
-func (ctx *Context) GRPCDialNode(target string, remoteNodeID roachpb.NodeID) *Connection {
+func (ctx *Context) GRPCDialNodeClass(
+	target string, remoteNodeID roachpb.NodeID, class ConnectionClass,
+) *Connection {
 	if remoteNodeID == 0 && !ctx.TestingAllowNamedRPCToAnonymousServer {
 		log.Fatalf(context.TODO(), "invalid node ID 0 in GRPCDialNode()")
 	}
-	return ctx.grpcDialNodeInternal(target, remoteNodeID)
+	return ctx.grpcDialNodeInternal(target, remoteNodeID, class)
 }
 
-func (ctx *Context) grpcDialNodeInternal(target string, remoteNodeID roachpb.NodeID) *Connection {
-	thisConnKeys := []connKey{{target, remoteNodeID}}
+// GRPCDialNode is a shorthand for calling GRPCDialNodeClass with DefaultClass.
+func (ctx *Context) GRPCDialNode(target string, remoteNodeID roachpb.NodeID) *Connection {
+	return ctx.GRPCDialNodeClass(target, remoteNodeID, DefaultClass)
+}
+
+func (ctx *Context) grpcDialNodeInternal(
+	target string, remoteNodeID roachpb.NodeID, class ConnectionClass,
+) *Connection {
+	thisConnKeys := []connKey{{target, remoteNodeID, class}}
 	value, ok := ctx.conns.Load(thisConnKeys[0])
 	if !ok {
 		value, _ = ctx.conns.LoadOrStore(thisConnKeys[0], newConnectionToNodeID(ctx.Stopper, remoteNodeID))
@@ -799,7 +826,7 @@ func (ctx *Context) grpcDialNodeInternal(target string, remoteNodeID roachpb.Nod
 			//
 			// See:
 			// https://github.com/cockroachdb/cockroach/issues/37200
-			otherKey := connKey{target, 0}
+			otherKey := connKey{target, 0, class}
 			if _, loaded := ctx.conns.LoadOrStore(otherKey, value); !loaded {
 				thisConnKeys = append(thisConnKeys, otherKey)
 			}
@@ -811,7 +838,7 @@ func (ctx *Context) grpcDialNodeInternal(target string, remoteNodeID roachpb.Nod
 		// Either we kick off the heartbeat loop (and clean up when it's done),
 		// or we clean up the connKey entries immediately.
 		var redialChan <-chan struct{}
-		conn.grpcConn, redialChan, conn.dialErr = ctx.GRPCDialRaw(target)
+		conn.grpcConn, redialChan, conn.dialErr = ctx.grpcDialRaw(target, class)
 		if conn.dialErr == nil {
 			if err := ctx.Stopper.RunTask(
 				ctx.masterCtx, "rpc.Context: grpc heartbeat", func(masterCtx context.Context) {

--- a/pkg/rpc/context_testutils.go
+++ b/pkg/rpc/context_testutils.go
@@ -11,8 +11,6 @@
 package rpc
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -20,7 +18,30 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"google.golang.org/grpc"
 )
+
+// ContextTestingKnobs provides hooks to aid in testing the system. The testing
+// knob functions are called at various points in the Context life cycle if they
+// are non-nil.
+type ContextTestingKnobs struct {
+
+	// UnaryClientInterceptor if non-nil will be called at dial time to provide
+	// the base unary interceptor for client connections.
+	// This function may return a nil interceptor to avoid injecting behavior
+	// for a given target and class.
+	UnaryClientInterceptor func(target string, class ConnectionClass) grpc.UnaryClientInterceptor
+
+	// StreamClient if non-nil will be called at dial time to provide
+	// the base stream interceptor for client connections.
+	// This function may return a nil interceptor to avoid injecting behavior
+	// for a given target and class.
+	StreamClientInterceptor func(target string, class ConnectionClass) grpc.StreamClientInterceptor
+
+	// ClusterID initializes the Context's ClusterID container to this value if
+	// non-nil at construction time.
+	ClusterID *uuid.UUID
+}
 
 // NewInsecureTestingContext creates an insecure rpc Context suitable for tests.
 func NewInsecureTestingContext(clock *hlc.Clock, stopper *stop.Stopper) *Context {
@@ -33,16 +54,22 @@ func NewInsecureTestingContext(clock *hlc.Clock, stopper *stop.Stopper) *Context
 func NewInsecureTestingContextWithClusterID(
 	clock *hlc.Clock, stopper *stop.Stopper, clusterID uuid.UUID,
 ) *Context {
-	ctx := NewContext(
+	return NewInsecureTestingContextWithKnobs(clock, stopper, ContextTestingKnobs{
+		ClusterID: &clusterID,
+	})
+}
+
+// NewInsecureTestingContextWithKnobs creates an insecure rpc Context
+// suitable for tests configured with the provided knobs.
+func NewInsecureTestingContextWithKnobs(
+	clock *hlc.Clock, stopper *stop.Stopper, knobs ContextTestingKnobs,
+) *Context {
+	return NewContextWithTestingKnobs(
 		log.AmbientContext{Tracer: tracing.NewTracer()},
 		&base.Config{Insecure: true},
 		clock,
 		stopper,
 		&cluster.MakeTestingClusterSettings().Version,
+		knobs,
 	)
-	// Ensure that tests using this test context and restart/shut down
-	// their servers do not inadvertently start talking to servers from
-	// unrelated concurrent tests.
-	ctx.ClusterID.Set(context.TODO(), clusterID)
-	return ctx
 }

--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -95,12 +95,12 @@ func (n *Dialer) Dial(ctx context.Context, nodeID roachpb.NodeID) (_ *grpc.Clien
 	return n.DialClass(ctx, nodeID, rpc.DefaultClass)
 }
 
-// DialInternalClientClass is a specialization of DialClass for callers that
+// DialInternalClient is a specialization of DialClass for callers that
 // want a roachpb.InternalClient. This supports an optimization to bypass the
 // network for the local node. Returns a context.Context which should be used
 // when making RPC calls on the returned server. (This context is annotated to
 // mark this request as in-process and bypass ctx.Peer checks).
-func (n *Dialer) DialInternalClientClass(
+func (n *Dialer) DialInternalClient(
 	ctx context.Context, nodeID roachpb.NodeID, class rpc.ConnectionClass,
 ) (context.Context, roachpb.InternalClient, error) {
 	if n == nil || n.resolver == nil {
@@ -125,14 +125,6 @@ func (n *Dialer) DialInternalClientClass(
 		return nil, nil, err
 	}
 	return ctx, roachpb.NewInternalClient(conn), err
-}
-
-// DialInternalClient is shorthand for
-// n.DialInternalClientClass(ctx, nodeID, rpc.DefaultClass)
-func (n *Dialer) DialInternalClient(
-	ctx context.Context, nodeID roachpb.NodeID,
-) (context.Context, roachpb.InternalClient, error) {
-	return n.DialInternalClientClass(ctx, nodeID, rpc.DefaultClass)
 }
 
 // dial performs the dialing of the remote connection.

--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -48,7 +48,7 @@ type Dialer struct {
 	rpcContext *rpc.Context
 	resolver   AddressResolver
 
-	breakers syncutil.IntMap // map[roachpb.NodeID]*wrappedBreaker
+	breakers [rpc.NumConnectionClasses]syncutil.IntMap // map[roachpb.NodeID]*wrappedBreaker
 }
 
 // New initializes a Dialer.
@@ -68,9 +68,11 @@ func (n *Dialer) Stopper() *stop.Stopper {
 // Silence lint warning because this method is only used in race builds.
 var _ = (*Dialer).Stopper
 
-// Dial returns a grpc connection to the given node. It logs whenever the
+// DialClass returns a grpc connection to the given node. It logs whenever the
 // node first becomes unreachable or reachable.
-func (n *Dialer) Dial(ctx context.Context, nodeID roachpb.NodeID) (_ *grpc.ClientConn, err error) {
+func (n *Dialer) DialClass(
+	ctx context.Context, nodeID roachpb.NodeID, class rpc.ConnectionClass,
+) (_ *grpc.ClientConn, err error) {
 	if n == nil || n.resolver == nil {
 		return nil, errors.New("no node dialer configured")
 	}
@@ -78,24 +80,28 @@ func (n *Dialer) Dial(ctx context.Context, nodeID roachpb.NodeID) (_ *grpc.Clien
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return nil, ctxErr
 	}
-	breaker := n.getBreaker(nodeID)
+	breaker := n.getBreaker(nodeID, class)
 	addr, err := n.resolver(nodeID)
 	if err != nil {
 		err = errors.Wrapf(err, "failed to resolve n%d", nodeID)
 		breaker.Fail(err)
 		return nil, err
 	}
-	return n.dial(ctx, nodeID, addr, breaker)
+	return n.dial(ctx, nodeID, addr, breaker, class)
 }
 
-// DialInternalClient is a specialization of Dial for callers that
-// want a roachpb.InternalClient. This supports an optimization to
-// bypass the network for the local node. Returns a context.Context
-// which should be used when making RPC calls on the returned server
-// (This context is annotated to mark this request as in-process and
-// bypass ctx.Peer checks).
-func (n *Dialer) DialInternalClient(
-	ctx context.Context, nodeID roachpb.NodeID,
+// Dial is shorthand for n.DialClass(ctx, nodeID, rpc.DefaultClass).
+func (n *Dialer) Dial(ctx context.Context, nodeID roachpb.NodeID) (_ *grpc.ClientConn, err error) {
+	return n.DialClass(ctx, nodeID, rpc.DefaultClass)
+}
+
+// DialInternalClientClass is a specialization of DialClass for callers that
+// want a roachpb.InternalClient. This supports an optimization to bypass the
+// network for the local node. Returns a context.Context which should be used
+// when making RPC calls on the returned server. (This context is annotated to
+// mark this request as in-process and bypass ctx.Peer checks).
+func (n *Dialer) DialInternalClientClass(
+	ctx context.Context, nodeID roachpb.NodeID, class rpc.ConnectionClass,
 ) (context.Context, roachpb.InternalClient, error) {
 	if n == nil || n.resolver == nil {
 		return nil, nil, errors.New("no node dialer configured")
@@ -114,16 +120,28 @@ func (n *Dialer) DialInternalClient(
 		return localCtx, localClient, nil
 	}
 	log.VEventf(ctx, 2, "sending request to %s", addr)
-	conn, err := n.dial(ctx, nodeID, addr, n.getBreaker(nodeID))
+	conn, err := n.dial(ctx, nodeID, addr, n.getBreaker(nodeID, class), class)
 	if err != nil {
 		return nil, nil, err
 	}
 	return ctx, roachpb.NewInternalClient(conn), err
 }
 
+// DialInternalClient is shorthand for
+// n.DialInternalClientClass(ctx, nodeID, rpc.DefaultClass)
+func (n *Dialer) DialInternalClient(
+	ctx context.Context, nodeID roachpb.NodeID,
+) (context.Context, roachpb.InternalClient, error) {
+	return n.DialInternalClientClass(ctx, nodeID, rpc.DefaultClass)
+}
+
 // dial performs the dialing of the remote connection.
 func (n *Dialer) dial(
-	ctx context.Context, nodeID roachpb.NodeID, addr net.Addr, breaker *wrappedBreaker,
+	ctx context.Context,
+	nodeID roachpb.NodeID,
+	addr net.Addr,
+	breaker *wrappedBreaker,
+	class rpc.ConnectionClass,
 ) (_ *grpc.ClientConn, err error) {
 	// Don't trip the breaker if we're already canceled.
 	if ctxErr := ctx.Err(); ctxErr != nil {
@@ -139,7 +157,7 @@ func (n *Dialer) dial(
 			log.Infof(ctx, "unable to connect to n%d: %s", nodeID, err)
 		}
 	}()
-	conn, err := n.rpcContext.GRPCDialNode(addr.String(), nodeID).Connect(ctx)
+	conn, err := n.rpcContext.GRPCDialNodeClass(addr.String(), nodeID, class).Connect(ctx)
 	if err != nil {
 		// If we were canceled during the dial, don't trip the breaker.
 		if ctxErr := ctx.Err(); ctxErr != nil {
@@ -168,14 +186,14 @@ func (n *Dialer) dial(
 	return conn, nil
 }
 
-// ConnHealth returns nil if we have an open connection to the given node
-// that succeeded on its most recent heartbeat. See the method of the same
-// name on rpc.Context for more details.
-func (n *Dialer) ConnHealth(nodeID roachpb.NodeID) error {
+// ConnHealthClass returns nil if we have an open connection of the request
+// class to the given node that succeeded on its most recent heartbeat. See the
+// method of the same name on rpc.Context for more details.
+func (n *Dialer) ConnHealthClass(nodeID roachpb.NodeID, class rpc.ConnectionClass) error {
 	if n == nil || n.resolver == nil {
 		return errors.New("no node dialer configured")
 	}
-	if !n.getBreaker(nodeID).Ready() {
+	if !n.getBreaker(nodeID, class).Ready() {
 		return circuit.ErrBreakerOpen
 	}
 	addr, err := n.resolver(nodeID)
@@ -192,19 +210,33 @@ func (n *Dialer) ConnHealth(nodeID roachpb.NodeID) error {
 	return conn.Health()
 }
 
-// GetCircuitBreaker retrieves the circuit breaker for connections to the given
-// node. The breaker should not be mutated as this affects all connections
-// dialing to that node through this NodeDialer.
-func (n *Dialer) GetCircuitBreaker(nodeID roachpb.NodeID) *circuit.Breaker {
-	return n.getBreaker(nodeID).Breaker
+// ConnHealth is shorthand for n.ConnHealthClass(nodeID, rpc.DefaultClass).
+func (n *Dialer) ConnHealth(nodeID roachpb.NodeID) error {
+	return n.ConnHealthClass(nodeID, rpc.DefaultClass)
 }
 
-func (n *Dialer) getBreaker(nodeID roachpb.NodeID) *wrappedBreaker {
-	value, ok := n.breakers.Load(int64(nodeID))
+// GetCircuitBreaker is shorthand for
+// n.GetCircuitBreakerClass(nodeID, rpc.DefaultClass).
+func (n *Dialer) GetCircuitBreaker(nodeID roachpb.NodeID) *circuit.Breaker {
+	return n.GetCircuitBreakerClass(nodeID, rpc.DefaultClass)
+}
+
+// GetCircuitBreakerClass retrieves the circuit breaker for connections to the
+// given node. The breaker should not be mutated as this affects all connections
+// dialing to that node through this NodeDialer.
+func (n *Dialer) GetCircuitBreakerClass(
+	nodeID roachpb.NodeID, class rpc.ConnectionClass,
+) *circuit.Breaker {
+	return n.getBreaker(nodeID, class).Breaker
+}
+
+func (n *Dialer) getBreaker(nodeID roachpb.NodeID, class rpc.ConnectionClass) *wrappedBreaker {
+	breakers := &n.breakers[class]
+	value, ok := breakers.Load(int64(nodeID))
 	if !ok {
 		name := fmt.Sprintf("rpc %v [n%d]", n.rpcContext.Config.Addr, nodeID)
 		breaker := &wrappedBreaker{Breaker: n.rpcContext.NewBreaker(name), EveryN: log.Every(logPerNodeFailInterval)}
-		value, _ = n.breakers.LoadOrStore(int64(nodeID), unsafe.Pointer(breaker))
+		value, _ = breakers.LoadOrStore(int64(nodeID), unsafe.Pointer(breaker))
 	}
 	return (*wrappedBreaker)(value)
 }

--- a/pkg/sql/ambiguous_commit_test.go
+++ b/pkg/sql/ambiguous_commit_test.go
@@ -82,7 +82,9 @@ func TestAmbiguousCommit(t *testing.T) {
 		}
 
 		params.Knobs.KVClient = &kv.ClientTestingKnobs{
-			TransportFactory: func(opts kv.SendOptions, nodeDialer *nodedialer.Dialer, replicas kv.ReplicaSlice) (kv.Transport, error) {
+			TransportFactory: func(
+				opts kv.SendOptions, nodeDialer *nodedialer.Dialer, replicas kv.ReplicaSlice,
+			) (kv.Transport, error) {
 				transport, err := kv.GRPCTransportFactory(opts, nodeDialer, replicas)
 				return &interceptingTransport{
 					Transport: transport,

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -1702,7 +1703,7 @@ func TestStoreReplicaGCAfterMerge(t *testing.T) {
 						Commit:        42,
 					},
 				},
-			}); !sent {
+			}, rpc.DefaultClass); !sent {
 				t.Fatal("failed to send heartbeat")
 			}
 			select {

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -2669,7 +2670,7 @@ func TestRaftAfterRemoveRange(t *testing.T) {
 				ToReplicaID:   replica1.ReplicaID,
 			},
 		},
-	})
+	}, rpc.DefaultClass)
 	// Execute another replica change to ensure that raft has processed
 	// the heartbeat just sent.
 	mtc.replicateRange(roachpb.RangeID(1), 1)
@@ -2945,7 +2946,7 @@ func TestReplicaGCRace(t *testing.T) {
 	// Send the heartbeat. Boom. See #11591.
 	// We have to send this multiple times to protect against
 	// dropped messages (see #18355).
-	if sent := fromTransport.SendAsync(&hbReq); !sent {
+	if sent := fromTransport.SendAsync(&hbReq, rpc.DefaultClass); !sent {
 		t.Fatal("failed to send heartbeat")
 	}
 	heartbeatsSent := 1
@@ -2965,7 +2966,7 @@ func TestReplicaGCRace(t *testing.T) {
 			t.Fatal("did not get expected error")
 		}
 		heartbeatsSent++
-		if sent := fromTransport.SendAsync(&hbReq); !sent {
+		if sent := fromTransport.SendAsync(&hbReq, rpc.DefaultClass); !sent {
 			t.Fatal("failed to send heartbeat")
 		}
 	}
@@ -3315,7 +3316,7 @@ func TestReplicateRemovedNodeDisruptiveElection(t *testing.T) {
 			Type: raftpb.MsgVote,
 			Term: term + 1,
 		},
-	}) {
+	}, rpc.DefaultClass) {
 	}
 
 	// The receiver of this message (i.e. replica1) should return an error telling
@@ -4370,7 +4371,7 @@ func TestStoreWaitForReplicaInit(t *testing.T) {
 					StoreID: store.Ident.StoreID,
 				},
 				Heartbeats: []storage.RaftHeartbeat{{RangeID: 42, ToReplicaID: 1}},
-			})
+			}, rpc.DefaultClass)
 			repl42, err = store.GetReplica(42)
 			return err
 		})

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -2089,7 +2090,7 @@ func TestStoreRangeSplitRaceUninitializedRHS(t *testing.T) {
 						From: uint64(replicas[1].ReplicaID),
 						Term: term,
 					},
-				}); !sent {
+				}, rpc.DefaultClass); !sent {
 					t.Error("transport failed to send vote request")
 				}
 				select {

--- a/pkg/storage/raft_transport_test.go
+++ b/pkg/storage/raft_transport_test.go
@@ -205,7 +205,7 @@ func (rttc *raftTransportTestContext) Send(
 		ToReplica:   to,
 		FromReplica: from,
 	}
-	return rttc.transports[from.NodeID].SendAsync(req)
+	return rttc.transports[from.NodeID].SendAsync(req, rpc.DefaultClass)
 }
 
 func TestSendAndReceive(t *testing.T) {
@@ -287,7 +287,7 @@ func TestSendAndReceive(t *testing.T) {
 				req := baseReq
 				req.Message.Type = messageType
 
-				if !transports[fromNodeID].SendAsync(&req) {
+				if !transports[fromNodeID].SendAsync(&req, rpc.DefaultClass) {
 					t.Errorf("unable to send %s from %d to %d", req.Message.Type, fromNodeID, toNodeID)
 				}
 				messageTypeCounts[toStoreID][req.Message.Type]++
@@ -355,7 +355,7 @@ func TestSendAndReceive(t *testing.T) {
 			ReplicaID: replicaIDs[toStoreID],
 		},
 	}
-	if !transports[storeNodes[fromStoreID]].SendAsync(expReq) {
+	if !transports[storeNodes[fromStoreID]].SendAsync(expReq, rpc.DefaultClass) {
 		t.Errorf("unable to send message from %d to %d", fromStoreID, toStoreID)
 	}
 	// NB: proto.Equal will panic here since it doesn't know about `gogoproto.casttype`.

--- a/pkg/storage/raft_transport_unit_test.go
+++ b/pkg/storage/raft_transport_unit_test.go
@@ -81,7 +81,7 @@ func TestRaftTransportStartNewQueue(t *testing.T) {
 		}
 	}()
 
-	_, existingQueue := tp.getQueue(1)
+	_, existingQueue := tp.getQueue(1, rpc.SystemClass)
 	if existingQueue {
 		t.Fatal("queue already exists")
 	}
@@ -99,7 +99,7 @@ func TestRaftTransportStartNewQueue(t *testing.T) {
 		wg.Done()
 	}()
 	var stats raftTransportStats
-	tp.startProcessNewQueue(ctxBoom, 1, &stats)
+	tp.startProcessNewQueue(ctxBoom, 1, rpc.SystemClass, &stats)
 
 	wg.Wait()
 }

--- a/pkg/storage/replica_init.go
+++ b/pkg/storage/replica_init.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/storage/abortspan"
 	"github.com/cockroachdb/cockroach/pkg/storage/spanlatch"
 	"github.com/cockroachdb/cockroach/pkg/storage/split"
@@ -321,5 +322,6 @@ func (r *Replica) setDesc(ctx context.Context, desc *roachpb.RangeDescriptor) {
 	}
 
 	r.rangeStr.store(r.mu.replicaID, desc)
+	r.connectionClass.set(rpc.ConnectionClassForKey(desc.StartKey))
 	r.mu.state.Desc = desc
 }

--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -1141,8 +1141,7 @@ func (r *Replica) sendRaftMessageRequest(ctx context.Context, req *RaftMessageRe
 	if log.V(4) {
 		log.Infof(ctx, "sending raft request %+v", req)
 	}
-
-	ok := r.store.cfg.Transport.SendAsync(req)
+	ok := r.store.cfg.Transport.SendAsync(req, r.connectionClass.get())
 	// TODO(peter): Looping over all of the outgoing Raft message queues to
 	// update this stat on every send is a bit expensive.
 	r.store.metrics.RaftEnqueuedPending.Update(r.store.cfg.Transport.queuedMessageCount())

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3802,7 +3802,7 @@ func (s *Store) sendQueuedHeartbeatsToNode(
 		log.Infof(ctx, "sending raft request (coalesced) %+v", chReq)
 	}
 
-	if !s.cfg.Transport.SendAsync(chReq) {
+	if !s.cfg.Transport.SendAsync(chReq, rpc.SystemClass) {
 		for _, beat := range beats {
 			if value, ok := s.mu.replicas.Load(int64(beat.RangeID)); ok {
 				(*Replica)(value).addUnreachableRemoteReplica(beat.ToReplicaID)


### PR DESCRIPTION
**Motivation**

This PR was primarily motivated by https://github.com/cockroachdb/cockroach/issues/35535. In that specific case and in other reproducible workloads we observe that large volumes of traffic primarily due to large OLAP-style table scans with filtering and sorting can lead to massive increases in latency node-liveness latency. The roachtest added in https://github.com/cockroachdb/cockroach/pull/39167 demonstrates this scenario. That roachtest fails every time on master and has succeeded for 10 consecutive runs with this change.

**Impact**

Below we have charts showing the node liveness failure rate, latency, and CPU utilization on a 3-node 16-CPU (n1-standard-16) single region cluster with 100 TPCC warehouses loaded using the query from the above roachtest both before and after this change. We can see that the former suffers from node liveness failures and high node liveness latency while the latter does not.

![image](https://user-images.githubusercontent.com/1839234/62215027-2764b380-b374-11e9-9640-9bf5d17b21b9.png)

The dip in CPU in the middle of the chart is where the binary is switched from master to a build with this PR. It is clear that before this change node liveness failed at a high rate leading to much poorer CPU utilization. It is worth noting that there was a single liveness failure that occurred during the run with this change. 

**PR Layout**

The PR itself comes in 5 commits

1) Introduce `ConnectionClass` to the `rpc` pacakge and `nodedialer`
2) Add testing knobs to inject interceptors in the `rpc` package
3) Adopt `ConnectionClass` in the the `kv` package
4) Adopt `ConnectionClass` in the `storage` package
5) Add testing for the storage package change

The change probably would benefit from a unit test in the `kv` package which I'll type today but wanted to start the review process.

Another point of conversation is that this change will double the number of TCP connections between nodes for any reasonably sized cluster. Today we never close opened connections and on large clusters we'll potentially dial `SystemClass` connections to nodes which at one point were the leaseholder for or held a replica of a system range that no longer do. In order to mitigate these superfluous connections a follow up PR will add logic to detect and close idle connections. 