### PR TITLE
sql: correct StatementTag for UPSERT

### DIFF
--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -1037,11 +1037,14 @@ func (fi *flushInfo) registerCmd(pos sql.CmdPos) {
 }
 
 func cookTag(tagStr string, buf []byte, stmtType tree.StatementType, rowsAffected int) []byte {
-	if tagStr == "INSERT" {
-		// From the postgres docs (49.5. Message Formats):
-		// `INSERT oid rows`... oid is the object ID of the inserted row if
-		//	rows is 1 and the target table has OIDs; otherwise oid is 0.
+	// From the postgres docs (49.5. Message Formats):
+	// `INSERT oid rows`... oid is the object ID of the inserted row if
+	//	rows is 1 and the target table has OIDs; otherwise oid is 0.
+	switch tagStr {
+	case "INSERT":
 		tagStr = "INSERT 0"
+	case "UPSERT":
+		tagStr = "UPSERT 0"
 	}
 	tag := append(buf, tagStr...)
 

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -448,7 +448,12 @@ func (*GrantRole) cclOnlyStatement() {}
 func (n *Insert) StatementType() StatementType { return n.Returning.statementType() }
 
 // StatementTag returns a short string identifying the type of statement.
-func (*Insert) StatementTag() string { return "INSERT" }
+func (n *Insert) StatementTag() string {
+	if n.OnConflict != nil && n.OnConflict.IsUpsertAlias() {
+		return "UPSERT"
+	}
+	return "INSERT"
+}
 
 // StatementType implements the Statement interface.
 func (n *Import) StatementType() StatementType { return Rows }


### PR DESCRIPTION
The `UPSERT` statement is represented as an `Insert` AST node. This change
makes this node report the correct tag ("INSERT" or "UPSERT")
depending on the variant used.

Note that Postgres does not implement an `UPSERT` statement so there are
no compatibility concerns.

Release note: None