### PR TITLE
tree: to_json returns proper field names

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/json_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/json_builtins
@@ -314,6 +314,19 @@ SELECT to_jsonb((1, 2, 'hello', NULL, NULL))
 ----
 {"f1": 1, "f2": 2, "f3": "hello", "f4": null, "f5": null}
 
+query T
+SELECT to_json(x.*) FROM (VALUES (1,2)) AS x(a,b);
+----
+{"a": 1, "b": 2}
+
+query T
+SELECT to_json(x.*) FROM (VALUES (1,2)) AS x(a);
+----
+{"a": 1, "column2": 2}
+
+query error found duplicate tuple label: \"column2\"
+SELECT to_json(x.*) FROM (VALUES (1,2)) AS x(column2);
+
 ## json_array_elements and jsonb_array_elements
 
 query T

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -2495,12 +2495,19 @@ func AsJSON(d Datum) (json.JSON, error) {
 		return builder.Build(), nil
 	case *DTuple:
 		builder := json.NewObjectBuilder(len(t.D))
+		labels := t.typ.TupleLabels()
 		for i, e := range t.D {
 			j, err := AsJSON(e)
 			if err != nil {
 				return nil, err
 			}
-			builder.Add(fmt.Sprintf("f%d", i+1), j)
+			var key string
+			if i >= len(labels) {
+				key = fmt.Sprintf("f%d", i+1)
+			} else {
+				key = labels[i]
+			}
+			builder.Add(key, j)
 		}
 		return builder.Build(), nil
 	case *DTimestampTZ:


### PR DESCRIPTION
If to_json gets a labeled tuple, it now correctly outputs a JSON object
that's keyed with the labels of the tuple and not a generic numbered
key.

Closes #37478.

Release note: None