### PR TITLE
sql: support views that depend on virtual views

### DIFF
--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -370,14 +370,16 @@ func (p *planner) getViewPlan(
 
 	// Register the dependency to the planner, if requested.
 	if p.curPlan.deps != nil {
-		usedColumns := make([]sqlbase.ColumnID, len(desc.Columns))
-		for i := range desc.Columns {
-			usedColumns[i] = desc.Columns[i].ID
+		if !desc.IsVirtualTable() {
+			usedColumns := make([]sqlbase.ColumnID, len(desc.Columns))
+			for i := range desc.Columns {
+				usedColumns[i] = desc.Columns[i].ID
+			}
+			deps := p.curPlan.deps[desc.ID]
+			deps.desc = desc
+			deps.deps = append(deps.deps, sqlbase.TableDescriptor_Reference{ColumnIDs: usedColumns})
+			p.curPlan.deps[desc.ID] = deps
 		}
-		deps := p.curPlan.deps[desc.ID]
-		deps.desc = desc
-		deps.deps = append(deps.deps, sqlbase.TableDescriptor_Reference{ColumnIDs: usedColumns})
-		p.curPlan.deps[desc.ID] = deps
 
 		// We are only interested in the dependency to this view descriptor. Any
 		// further dependency by the view's query should not be tracked in this planner.

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -326,6 +326,20 @@ DROP VIEW v1
 statement error pgcode 42P01 relation "v1" does not exist
 DROP VIEW v1
 
+# Verify that we can depend on virtual tables.
+statement ok
+CREATE VIEW virt1 AS SELECT table_schema FROM information_schema.columns
+
+statement ok
+DROP VIEW virt1
+
+# Verify that we can depend on virtual views.
+statement ok
+CREATE VIEW virt2 AS SELECT range_id, lease_holder FROM crdb_internal.ranges
+
+statement ok
+DROP VIEW virt2
+
 # Verify correct rejection of star expressions
 # TODO(a-robinson): Support star expressions as soon as we can (#10028)
 


### PR DESCRIPTION
When creating a view, we report a plan dependency on virtual
views which causes a failure. This commit fixes the logic to avoid
reporting a dependency in this case (just like we don't report
dependencies on virtual tables).

Fixes #38440.

Release note (bug fix): crdb_internal.ranges can now be used inside
views. Note that such views can become invalid in future releases if
`crdb_internal.ranges` changes.
