### PR TITLE
sql: Add pg_collation_for info function

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -2009,7 +2009,8 @@ over_clause ::=
 	| 
 
 func_expr_common_subexpr ::=
-	'CURRENT_DATE'
+	'COLLATION' 'FOR' '(' a_expr ')'
+	| 'CURRENT_DATE'
 	| 'CURRENT_SCHEMA'
 	| 'CURRENT_CATALOG'
 	| 'CURRENT_TIMESTAMP'

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -785,6 +785,8 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><code>overlay(input: <a href="string.html">string</a>, overlay_val: <a href="string.html">string</a>, start_pos: <a href="int.html">int</a>, end_pos: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Deletes the characters in <code>input</code> between <code>start_pos</code> and <code>end_pos</code> (count starts at 1), and then insert <code>overlay_val</code> at <code>start_pos</code>.</p>
 </span></td></tr>
+<tr><td><code>pg_collation_for(str: anyelement) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the collation of the argument</p>
+</span></td></tr>
 <tr><td><code>quote_ident(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Return <code>val</code> suitably quoted to serve as identifier in a SQL statement.</p>
 </span></td></tr>
 <tr><td><code>quote_literal(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Return <code>val</code> suitably quoted to serve as string literal in a SQL statement.</p>

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1510,6 +1510,35 @@ SELECT current_schema()
 ----
 public
 
+# COLLATION FOR returns a locale name for a collated string
+# but for a not collated string 'default' locale name is a Postgres compatible behavior:
+# https://www.postgresql.org/docs/10/functions-info.html#FUNCTIONS-INFO-CATALOG-TABLE
+query T
+SELECT COLLATION FOR ('foo')
+----
+default
+
+query T
+SELECT COLLATION FOR ('foo' COLLATE "de_DE");
+----
+de_DE
+
+statement error pq: pg_collation_for\(\): collations are not supported by type: int
+SELECT COLLATION FOR (1);
+
+query T
+SELECT pg_collation_for ('foo')
+----
+default
+
+query T
+SELECT pg_collation_for ('foo' COLLATE "de_DE");
+----
+de_DE
+
+statement error pq: pg_collation_for\(\): collations are not supported by type: int
+SELECT pg_collation_for(1);
+
 query I
 SELECT array_length(ARRAY['a', 'b'], 1)
 ----

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -3026,7 +3026,6 @@ func TestUnimplementedSyntax(t *testing.T) {
 		{`SELECT GROUPING (a,b,c)`, 0, `d_expr grouping`},
 		{`SELECT a(VARIADIC b)`, 0, `variadic`},
 		{`SELECT a(b, c, VARIADIC b)`, 0, `variadic`},
-		{`SELECT COLLATION FOR (a)`, 32563, ``},
 		{`SELECT CURRENT_TIME`, 26097, `current_time`},
 		{`SELECT CURRENT_TIME()`, 26097, `current_time`},
 		{`SELECT TREAT (a AS INT8)`, 0, `treat`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -7825,7 +7825,10 @@ func_expr_windowless:
 
 // Special expressions that are considered to be functions.
 func_expr_common_subexpr:
-  COLLATION FOR '(' a_expr ')' { return unimplementedWithIssue(sqllex, 32563) }
+  COLLATION FOR '(' a_expr ')'
+  {
+    $$.val = &tree.FuncExpr{Func: tree.WrapFunction("pg_collation_for"), Exprs: tree.Exprs{$4.expr()}}
+  }
 | CURRENT_DATE
   {
     $$.val = &tree.FuncExpr{Func: tree.WrapFunction($1)}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2783,6 +2783,27 @@ may increase either contention or retry errors, or both.`,
 		},
 	),
 
+	// https://www.postgresql.org/docs/10/functions-info.html#FUNCTIONS-INFO-CATALOG-TABLE
+	"pg_collation_for": makeBuiltin(
+		tree.FunctionProperties{Category: categoryString},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"str", types.Any}},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				switch t := args[0].(type) {
+				case *tree.DString:
+					return tree.NewDString("default"), nil
+				case *tree.DCollatedString:
+					return tree.NewDString(t.Locale), nil
+				default:
+					return tree.DNull, pgerror.Newf(pgcode.DatatypeMismatch,
+						"collations are not supported by type: %s", t.ResolvedType())
+				}
+			},
+			Info: "Returns the collation of the argument",
+		},
+	),
+
 	"crdb_internal.locality_value": makeBuiltin(
 		tree.FunctionProperties{Category: categorySystemInfo},
 		tree.Overload{


### PR DESCRIPTION
PR resolves #32563
Adds Postgres' `pg_collation_for` built-in function, which returns a locale string for a collated string
Also add `COLLATION FOR (<expr>)` sql syntactic sugar.