### PR TITLE
sql: Fix bug where dropping table didn't drop corresponding zone config.

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1901,10 +1901,11 @@ CREATE TABLE crdb_internal.zones (
 			var zoneSpecifier *tree.ZoneSpecifier
 			zs, err := config.ZoneSpecifierFromID(id, resolveID)
 			if err != nil {
-				// The database or table has been deleted so there is no way
-				// to refer to it anymore. We are still going to show
-				// something but the CLI specifier part will become NULL.
-				zoneSpecifier = nil
+				// We can have valid zoneSpecifiers whose table/database has been
+				// deleted because zoneSpecifiers are collected asynchronously.
+				// In this case, just don't show the zoneSpecifier in the
+				// output of the table.
+				continue
 			} else {
 				zoneSpecifier = &zs
 			}


### PR DESCRIPTION
This PR also addresses a bug where when an index was dropped
the subzone corresponding to that index was left as a
hanging subzone within the system.zones table.

Fixes #38392.