### PR TITLE
libroach: Allow KVs with the same ts and value to shadow in AddSSTable

### DIFF
--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -274,7 +274,7 @@ DBStatus DBPartialMergeOne(DBSlice existing, DBSlice update, DBString* new_value
 
 // DBCheckForKeyCollisions runs both iterators in lockstep and errors out at the
 // first key collision, where a collision refers to any two MVCC keys with the
-// same user key, regardless of timestamps.
+// same user key, and with a different timestamp or value.
 //
 // An exception is made when the latest version of the colliding key is a
 // tombstone from an MVCC delete in the existing data. If the timestamp of the


### PR DESCRIPTION
This is a slight modification to the `disallowShadowing` option in
AddSSTable. It allows an ingested KV with the same ts
(walltime and logical), and same value as an existing KV to
overwrite that existing KV.

The motivation behind this is to support the behavior of an
IMPORT job on resume. A resumed IMPORT job must re-import KVs
not in the checkpointed set. Some of these KVs could have
already been ingested into the table (but not checkpointed), and
thus prior to this change the `disallowShadowing` logic would
see a collision and error out. Since the entirety of an IMPORT
(including reattempts) occurs at the same ts, we can let such
"collisions" silently slip by ensuring the ts and the value of the
KV is identical to what has already been ingested.

In order to keep the behavior uniform, duplicate KVs in the same
SST will also be skipped, instead of throwing a uniqueness error.
This logic will be added in the sorting phase of the IMPORT in
PR #39152, once this is merged.

Release note: None