### PR TITLE
storage: prevent recording events into closed tracing spans

### DIFF
--- a/pkg/storage/cmd_app_batch.go
+++ b/pkg/storage/cmd_app_batch.go
@@ -93,7 +93,7 @@ func (b *cmdAppBatch) add(e *raftpb.Entry, d decodedRaftEntry) {
 // numEmptyEntries indicates the number of entries in the consumed portion of
 // toProcess contained a zero-byte payload.
 func (b *cmdAppBatch) decode(
-	ctx context.Context, toProcess []raftpb.Entry, decodeBuf *decodedRaftEntry,
+	ctx context.Context, toProcess []raftpb.Entry, decodeBuf *decodedRaftEntry, maxEntries int,
 ) (
 	foundNonTrivialEntry bool,
 	numEmptyEntries int,
@@ -101,7 +101,7 @@ func (b *cmdAppBatch) decode(
 	errExpl string,
 	err error,
 ) {
-	for len(toProcess) > 0 {
+	for len(toProcess) > 0 && (maxEntries <= 0 || int(b.cmdBuf.len) < maxEntries) {
 		e := &toProcess[0]
 		if len(e.Data) == 0 {
 			numEmptyEntries++

--- a/pkg/storage/replica_application.go
+++ b/pkg/storage/replica_application.go
@@ -164,6 +164,16 @@ func (r *Replica) retrieveLocalProposals(ctx context.Context, b *cmdAppBatch) {
 	for ok := it.init(&b.cmdBuf); ok; ok = it.next() {
 		cmd := it.cur()
 		cmd.proposal = r.mu.proposals[cmd.idKey]
+		if cmd.proposedLocally() && cmd.raftCmd.MaxLeaseIndex != cmd.proposal.command.MaxLeaseIndex {
+			// If this entry does not have the most up-to-date view of the
+			// corresponding proposal's maximum lease index then the proposal
+			// must have been reproposed with a higher lease index. (see
+			// tryReproposeWithNewLeaseIndex). In that case, there's a newer
+			// version of the proposal in the pipeline, so don't consider this
+			// entry to have been proposed locally. The entry must necessarily be
+			// rejected by checkForcedErr.
+			cmd.proposal = nil
+		}
 		if cmd.proposedLocally() {
 			// We initiated this command, so use the caller-supplied context.
 			cmd.ctx = cmd.proposal.ctx
@@ -179,16 +189,7 @@ func (r *Replica) retrieveLocalProposals(ctx context.Context, b *cmdAppBatch) {
 	for ok := it.init(&b.cmdBuf); ok; ok = it.next() {
 		cmd := it.cur()
 		toRelease := int64(0)
-		shouldRemove := cmd.proposedLocally() &&
-			// If this entry does not have the most up-to-date view of the
-			// corresponding proposal's maximum lease index then the proposal
-			// must have been reproposed with a higher lease index. (see
-			// tryReproposeWithNewLeaseIndex). In that case, there's a newer
-			// version of the proposal in the pipeline, so don't remove the
-			// proposal from the map. We expect this entry to be rejected by
-			// checkForcedErr.
-			cmd.raftCmd.MaxLeaseIndex == cmd.proposal.command.MaxLeaseIndex
-		if shouldRemove {
+		if cmd.proposedLocally() {
 			// Delete the proposal from the proposals map. There may be reproposals
 			// of the proposal in the pipeline, but those will all have the same max
 			// lease index, meaning that they will all be rejected after this entry

--- a/pkg/storage/replica_application.go
+++ b/pkg/storage/replica_application.go
@@ -111,7 +111,7 @@ func (r *Replica) handleCommittedEntriesRaftMuLocked(
 			// Decode zero or more trivial entries into b.
 			var numEmptyEntries int
 			haveNonTrivialEntry, numEmptyEntries, toProcess, errExpl, err =
-				b.decode(ctx, toProcess, &b.decodeBuf)
+				b.decode(ctx, toProcess, &b.decodeBuf, r.store.TestingKnobs().MaxApplicationBatchSize)
 			if err != nil {
 				return stats, errExpl, err
 			}

--- a/pkg/storage/replica_application_result.go
+++ b/pkg/storage/replica_application_result.go
@@ -457,6 +457,9 @@ func (r *Replica) finishRaftCommand(ctx context.Context, cmd *cmdAppCtx) {
 	}
 
 	if cmd.proposedLocally() {
+		if cmd.raftCmd.MaxLeaseIndex != cmd.proposal.command.MaxLeaseIndex {
+			log.Fatalf(ctx, "finishing proposal with outstanding reproposal at a higher max lease index")
+		}
 		cmd.proposal.finishApplication(cmd.response)
 	} else if cmd.response.Err != nil {
 		log.VEventf(ctx, 1, "applying raft command resulted in error: %s", cmd.response.Err)

--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -435,27 +435,6 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	leaderID := r.mu.leaderID
 	lastLeaderID := leaderID
 
-	// We defer the check to Replica.updateProposalQuotaRaftMuLocked because we need
-	// to check it in both cases, if hasReady is false and otherwise.
-	// If hasReady == false:
-	//     Consider the case when our quota is of size 1 and two out of three
-	//     replicas have committed one log entry while the third is lagging
-	//     behind. When the third replica finally does catch up and sends
-	//     along a MsgAppResp, since the entry is already committed on the
-	//     leader replica, no Ready is emitted. But given that the third
-	//     replica has caught up, we can release
-	//     some quota back to the pool.
-	// Otherwise:
-	//     Consider the case where there are two replicas and we have a quota
-	//     of size 1. We acquire the quota when the write gets proposed on the
-	//     leader and expect it to be released when the follower commits it
-	//     locally. In order to do so we need to have the entry 'come out of
-	//     raft' and in the case of a two node raft group, this only happens if
-	//     hasReady == true.
-	//     If we don't release quota back at the end of
-	//     handleRaftReadyRaftMuLocked, the next write will get blocked.
-	defer r.updateProposalQuotaRaftMuLocked(ctx, lastLeaderID)
-
 	err := r.withRaftGroupLocked(true, func(raftGroup *raft.RawNode) (bool, error) {
 		if err := r.mu.proposalBuf.FlushLockedWithRaftGroup(raftGroup); err != nil {
 			return false, err
@@ -472,6 +451,15 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	}
 
 	if !hasReady {
+		// We must update the proposal quota even if we don't have a ready.
+		// Consider the case when our quota is of size 1 and two out of three
+		// replicas have committed one log entry while the third is lagging
+		// behind. When the third replica finally does catch up and sends
+		// along a MsgAppResp, since the entry is already committed on the
+		// leader replica, no Ready is emitted. But given that the third
+		// replica has caught up, we can release
+		// some quota back to the pool.
+		r.updateProposalQuotaRaftMuLocked(ctx, lastLeaderID)
 		return stats, "", nil
 	}
 
@@ -767,6 +755,18 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	}); err != nil {
 		return stats, expl, errors.Wrap(err, expl)
 	}
+
+	// NB: All early returns other than the one due to not having a ready
+	// which also makes the below call are due to fatal errors.
+	// We must also update the proposal quota when have a ready; consider the
+	// case where there are two replicas and we have a quota of size 1. We
+	// acquire the quota when the write gets proposed on the leader and expect it
+	// to be released when the follower commits it locally. In order to do so we
+	// need to have the entry 'come out of raft' and in the case of a two node
+	// raft group, this only happens if hasReady == true. If we don't release
+	// quota back at the end of handleRaftReadyRaftMuLocked, the next write will
+	// get blocked.
+	r.updateProposalQuotaRaftMuLocked(ctx, lastLeaderID)
 	return stats, "", nil
 }
 

--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -258,8 +258,20 @@ func (r *Replica) evalAndPropose(
 //
 // The method hands ownership of the command over to the Raft machinery. After
 // the method returns, all access to the command must be performed while holding
-// Replica.mu and Replica.raftMu.
-func (r *Replica) propose(ctx context.Context, p *ProposalData) (int64, *roachpb.Error) {
+// Replica.mu and Replica.raftMu. If a non-nil error is returned the
+// MaxLeaseIndex is not updated.
+func (r *Replica) propose(ctx context.Context, p *ProposalData) (index int64, pErr *roachpb.Error) {
+
+	// If an error occurs reset the command's MaxLeaseIndex to its initial value.
+	// Failure to propose will propagate to the client. An invariant of this
+	// package is that proposals which are finished carry a raft command with a
+	// MaxLeaseIndex equal to the proposal command's max lease index.
+	defer func(prev uint64) {
+		if pErr != nil {
+			p.command.MaxLeaseIndex = prev
+		}
+	}(p.command.MaxLeaseIndex)
+
 	// Make sure the maximum lease index is unset. This field will be set in
 	// propBuf.Insert and its encoded bytes will be appended to the encoding
 	// buffer as a RaftCommandFooter.

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -58,6 +58,7 @@ import (
 	"github.com/cockroachdb/logtags"
 	"github.com/gogo/protobuf/proto"
 	"github.com/kr/pretty"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -11706,6 +11707,108 @@ func TestHighestMaxLeaseIndexReproposalFinishesCommand(t *testing.T) {
 	log.Flush()
 
 	stopper.Quiesce(ctx)
+	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1,
+		regexp.MustCompile("net/trace"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) > 0 {
+		t.Fatalf("reused span after free: %v", entries)
+	}
+}
+
+// TestLaterReproposalsDoNotReuseContext ensures that when commands are
+// reproposed more than once at the same MaxLeaseIndex and the first command
+// applies that the later reproposals do not log into the proposal's context
+// as its underlying trace span may already be finished.
+func TestLaterReproposalsDoNotReuseContext(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Set the trace infrastructure to log if a span is used after being finished.
+	defer enableTraceDebugUseAfterFree()()
+
+	tc := testContext{}
+	ctx := context.Background()
+
+	// Set logging up to a test specific directory.
+	scope := log.Scope(t)
+	defer scope.Close(t)
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	cfg := TestStoreConfig(hlc.NewClock(hlc.UnixNano, time.Nanosecond))
+	// Set up tracing.
+	tracer := tracing.NewTracer()
+	tracer.Configure(&cfg.Settings.SV)
+	tracer.AlwaysTrace()
+	cfg.AmbientCtx.Tracer = tracer
+	tc.StartWithStoreConfig(t, stopper, cfg)
+	key := roachpb.Key("a")
+	lease, _ := tc.repl.GetLease()
+	txn := newTransaction("test", key, roachpb.NormalUserPriority, tc.Clock())
+	ba := roachpb.BatchRequest{
+		Header: roachpb.Header{
+			RangeID: tc.repl.RangeID,
+			Txn:     txn,
+		},
+	}
+	ba.Timestamp = txn.OrigTimestamp
+	ba.Add(&roachpb.PutRequest{
+		RequestHeader: roachpb.RequestHeader{
+			Key: key,
+		},
+		Value: roachpb.MakeValueFromBytes([]byte("val")),
+	})
+
+	// Hold the RaftLock to encourage the reproposals to occur in the same batch.
+	tc.repl.RaftLock()
+	sp := tracer.StartRootSpan("replica send", logtags.FromContext(ctx), tracing.RecordableSpan)
+	tracedCtx := opentracing.ContextWithSpan(ctx, sp)
+	// Go out of our way to enable recording so that expensive logging is enabled
+	// for this context.
+	tracing.StartRecording(sp, tracing.SingleNodeRecording)
+	ch, _, _, pErr := tc.repl.evalAndPropose(tracedCtx, lease, &ba, &allSpans, endCmds{})
+	if pErr != nil {
+		t.Fatal(pErr)
+	}
+	// Launch a goroutine to finish the span as soon as a result has been sent.
+	errCh := make(chan *roachpb.Error)
+	go func() {
+		res := <-ch
+		sp.Finish()
+		errCh <- res.Err
+	}()
+
+	// Flush the proposal and then repropose it twice.
+	// This test verifies that these later reproposals don't record into the
+	// tracedCtx after its span has been finished.
+	func() {
+		tc.repl.mu.Lock()
+		defer tc.repl.mu.Unlock()
+		if err := tc.repl.mu.proposalBuf.flushLocked(); err != nil {
+			t.Fatal(err)
+		}
+		tc.repl.refreshProposalsLocked(0, reasonNewLeaderOrConfigChange)
+		if err := tc.repl.mu.proposalBuf.flushLocked(); err != nil {
+			t.Fatal(err)
+		}
+		tc.repl.refreshProposalsLocked(0, reasonNewLeaderOrConfigChange)
+	}()
+	tc.repl.RaftUnlock()
+
+	if pErr = <-errCh; pErr != nil {
+		t.Fatal(pErr)
+	}
+	// Round trip another proposal through the replica to ensure that previously
+	// committed entries have been applied.
+	_, pErr = tc.repl.sendWithRangeID(ctx, tc.repl.RangeID, ba)
+	if pErr != nil {
+		t.Fatal(pErr)
+	}
+
+	stopper.Quiesce(ctx)
+	// Check and see if the trace package logged an error.
+	log.Flush()
 	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1,
 		regexp.MustCompile("net/trace"))
 	if err != nil {

--- a/pkg/storage/testing_knobs.go
+++ b/pkg/storage/testing_knobs.go
@@ -195,6 +195,11 @@ type StoreTestingKnobs struct {
 	// This ensures the `*Replica` will be materialized on the Store when it
 	// returns.
 	ReplicaAddStopAfterLearnerSnapshot func() bool
+
+	// MaxApplicationBatchSize enforces a maximum size on application batches.
+	// This can be useful for testing conditions which require commands to be
+	// applied in separate batches.
+	MaxApplicationBatchSize int
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
In #39188 we saw a surprising assertion failure due to a panic not being captured in a deferred function, the second commit deals with this obfuscation. The first commit adds a useful testing knobs utilized by the third commit. The third commit ensures that the if a command is reproposed more than one time at different MaxLeaseIndex values in such a way that the reproposals fail that the latter, not the earlier failure will report to the client. This prevents the panics seen in #39188. The fourth commit deals with cases where the same command is reproposed more than once at the same MaxLeaseIndex. 

The motivation for all of this is the logging of events into a closed recording trace span. In order to test such reuse the tests enable the [`trace.DebugUseAfterFinish`](https://github.com/golang/net/blob/ca1201d0de80cfde86cb01aea620983605dfe99b/trace/trace.go#L85-L87) and then read the logs to determine if the debugging code detected a use after finish. The code also adds an assertion that commands are finished at the highest MaxLeaseIndex at which they have been proposed. 

Fixes #39188.
Fixes #39190.