### PR TITLE
sql: add RevertTable wrapper for RevertRangeRequest

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -576,6 +576,8 @@ func (ds *DistSender) initAndVerifyBatch(
 			case *roachpb.BeginTransactionRequest, *roachpb.EndTransactionRequest, *roachpb.ReverseScanRequest:
 				continue
 
+			case *roachpb.RevertRangeRequest:
+				continue
 			default:
 				return roachpb.NewErrorf("batch with limit contains %T request", inner)
 			}

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -286,6 +286,21 @@ func (dr *DeleteRangeResponse) combine(c combinable) error {
 	return nil
 }
 
+var _ combinable = &DeleteRangeResponse{}
+
+// combine implements the combinable interface.
+func (dr *RevertRangeResponse) combine(c combinable) error {
+	otherDR := c.(*RevertRangeResponse)
+	if dr != nil {
+		if err := dr.ResponseHeader.combine(otherDR.Header()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+var _ combinable = &RevertRangeResponse{}
+
 // combine implements the combinable interface.
 func (rr *ResolveIntentRangeResponse) combine(c combinable) error {
 	otherRR := c.(*ResolveIntentRangeResponse)
@@ -1039,7 +1054,7 @@ func (*ClearRangeRequest) flags() int { return isWrite | isRange | isAlone }
 
 // Note that RevertRange commands cannot be part of a transaction as
 // they clear all MVCC versions above their target time.
-func (*RevertRangeRequest) flags() int { return isWrite | isRange | isAlone }
+func (*RevertRangeRequest) flags() int { return isWrite | isRange }
 
 func (*ScanRequest) flags() int { return isRead | isRange | isTxn | updatesReadTSCache | needsRefresh }
 func (*ReverseScanRequest) flags() int {

--- a/pkg/sql/revert.go
+++ b/pkg/sql/revert.go
@@ -1,0 +1,102 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/errors"
+)
+
+// RevertTableDefaultBatchSize is the default batch size for reverting tables.
+// This only needs to be small enough to keep raft/rocks happy -- there is no
+// reply size to worry about.
+// TODO(dt): tune this via experimentation.
+const RevertTableDefaultBatchSize = 500000
+
+// RevertTables reverts the passed table to the target time.
+func RevertTables(
+	ctx context.Context,
+	db *client.DB,
+	tables []*sqlbase.TableDescriptor,
+	targetTime hlc.Timestamp,
+	batchSize int64,
+) error {
+	reverting := make(map[sqlbase.ID]bool, len(tables))
+	for i := range tables {
+		reverting[tables[i].ID] = true
+	}
+
+	spans := make([]roachpb.Span, 0, len(tables))
+
+	// Check that all the tables are revertable -- i.e. offline and that their
+	// full interleave hierarchy is being reverted.
+	for i := range tables {
+		if tables[i].State != sqlbase.TableDescriptor_IMPORTING {
+			return errors.New("only offline tables can be reverted")
+		}
+
+		if !tables[i].IsPhysicalTable() {
+			return errors.Errorf("cannot revert virtual table %s", tables[i].Name)
+		}
+		for _, idx := range tables[i].AllNonDropIndexes() {
+			for _, parent := range idx.Interleave.Ancestors {
+				if !reverting[parent.TableID] {
+					return errors.New("cannot revert table without reverting all interleaved tables and indexes")
+				}
+			}
+			for _, child := range idx.InterleavedBy {
+				if !reverting[child.Table] {
+					return errors.New("cannot revert table without reverting all interleaved tables and indexes")
+				}
+			}
+		}
+		spans = append(spans, tables[i].TableSpan())
+	}
+
+	// TODO(dt): pre-split requests up using a rangedesc cache and run batches in
+	// parallel (since we're passing a key limit, distsender won't do its usual
+	// splitting/parallel sending to separate ranges).
+	for len(spans) != 0 {
+		var b client.Batch
+		for _, span := range spans {
+			b.AddRawRequest(&roachpb.RevertRangeRequest{
+				RequestHeader: roachpb.RequestHeader{
+					Key:    span.Key,
+					EndKey: span.EndKey,
+				},
+				TargetTime: targetTime,
+			})
+		}
+		b.Header.MaxSpanRequestKeys = batchSize
+
+		if err := db.Run(ctx, &b); err != nil {
+			return err
+		}
+
+		spans = spans[:0]
+		for _, raw := range b.RawResponse().Responses {
+			r := raw.GetRevertRange()
+			if r.ResumeSpan != nil {
+				if !r.ResumeSpan.Valid() {
+					return errors.Errorf("invalid resume span: %s", r.ResumeSpan)
+				}
+				spans = append(spans, *r.ResumeSpan)
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/sql/revert_test.go
+++ b/pkg/sql/revert_test.go
@@ -1,0 +1,116 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRevertTable(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.TODO()
+
+	s, sqlDB, kv := serverutils.StartServer(
+		t, base.TestServerArgs{UseDatabase: "test"})
+	defer s.Stopper().Stop(context.TODO())
+
+	db := sqlutils.MakeSQLRunner(sqlDB)
+	db.Exec(t, `CREATE DATABASE IF NOT EXISTS test`)
+	db.Exec(t, `CREATE TABLE test (k INT PRIMARY KEY, rev INT DEFAULT 0, INDEX (rev))`)
+
+	// Fill a table with some rows plus some revisions to those rows.
+	const numRows = 1000
+	db.Exec(t, `INSERT INTO test (k) SELECT generate_series(1, $1)`, numRows)
+	db.Exec(t, `UPDATE test SET rev = 1 WHERE k % 3 = 0`)
+	db.Exec(t, `DELETE FROM test WHERE k % 10 = 0`)
+	db.Exec(t, `ALTER TABLE test SPLIT AT VALUES (30), (300), (501), (700)`)
+
+	var ts string
+	var before int
+	db.QueryRow(t, `SELECT cluster_logical_timestamp(), xor_agg(k # rev) FROM test`).Scan(&ts, &before)
+	targetTime, err := ParseHLC(ts)
+	require.NoError(t, err)
+
+	t.Run("simple", func(t *testing.T) {
+		// Make some more edits: delete some rows and edit others, insert into some of
+		// the gaps made between previous rows, edit a large swath of rows and add a
+		// large swath of new rows as well.
+		db.Exec(t, `UPDATE test SET rev = 2 WHERE k % 4 = 0`)
+		db.Exec(t, `DELETE FROM test WHERE k % 5 = 2`)
+		db.Exec(t, `INSERT INTO test (k, rev) SELECT generate_series(10, $1, 10), 10`, numRows)
+		db.Exec(t, `UPDATE test SET rev = 4 WHERE k > 150 and k < 350`)
+		db.Exec(t, `INSERT INTO test (k, rev) SELECT generate_series($1+1, $1+500, 1), 500`, numRows)
+
+		var edited, aost int
+		db.QueryRow(t, `SELECT xor_agg(k # rev) FROM test`).Scan(&edited)
+		require.NotEqual(t, before, edited)
+		db.QueryRow(t, fmt.Sprintf(`SELECT xor_agg(k # rev) FROM test AS OF SYSTEM TIME %s`, ts)).Scan(&aost)
+		require.Equal(t, before, aost)
+
+		// Revert the table to ts.
+		desc := sqlbase.GetTableDescriptor(kv, "test", "test")
+		desc.State = sqlbase.TableDescriptor_IMPORTING // bypass the offline check.
+		require.NoError(t, RevertTables(context.TODO(), kv, []*sqlbase.TableDescriptor{desc}, targetTime, 10))
+
+		var reverted int
+		db.QueryRow(t, `SELECT xor_agg(k # rev) FROM test`).Scan(&reverted)
+		require.Equal(t, before, reverted, "expected reverted table after edits to match before")
+	})
+
+	t.Run("interleaved", func(t *testing.T) {
+		db.Exec(t, `CREATE TABLE child (a INT, b INT, rev INT DEFAULT 0, INDEX (rev), PRIMARY KEY (a, b)) INTERLEAVE IN PARENT test (a)`)
+		db.Exec(t, `INSERT INTO child (a, b) SELECT generate_series(1, $1, 2), generate_series(2, $1, 2)`, numRows)
+		db.Exec(t, `UPDATE child SET rev = 1 WHERE a % 3 = 0`)
+
+		db.QueryRow(t, `SELECT cluster_logical_timestamp() FROM test`).Scan(&ts)
+		targetTime, err = ParseHLC(ts)
+		require.NoError(t, err)
+
+		var beforeChild int
+		db.QueryRow(t, `SELECT xor_agg(a # b # rev) FROM child`).Scan(&beforeChild)
+
+		db.Exec(t, `UPDATE child SET rev = 2 WHERE a % 5 = 0`)
+		db.Exec(t, `UPDATE child SET rev = 3 WHERE a > 450 and a < 700`)
+		db.Exec(t, `DELETE FROM child WHERE a % 7 = 0`)
+
+		// Revert the table to ts.
+		desc := sqlbase.GetTableDescriptor(kv, "test", "test")
+		desc.State = sqlbase.TableDescriptor_IMPORTING
+		child := sqlbase.GetTableDescriptor(kv, "test", "child")
+		child.State = sqlbase.TableDescriptor_IMPORTING
+		t.Run("reject only parent", func(t *testing.T) {
+			require.Error(t, RevertTables(ctx, kv, []*sqlbase.TableDescriptor{desc}, targetTime, 10))
+		})
+		t.Run("reject only child", func(t *testing.T) {
+			require.Error(t, RevertTables(ctx, kv, []*sqlbase.TableDescriptor{child}, targetTime, 10))
+		})
+
+		t.Run("rollback parent and child", func(t *testing.T) {
+			require.NoError(t, RevertTables(ctx, kv, []*sqlbase.TableDescriptor{desc, child}, targetTime, RevertTableDefaultBatchSize))
+
+			var reverted, revertedChild int
+			db.QueryRow(t, `SELECT xor_agg(k # rev) FROM test`).Scan(&reverted)
+			require.Equal(t, before, reverted, "expected reverted table after edits to match before")
+			db.QueryRow(t, `SELECT xor_agg(a # b # rev) FROM child`).Scan(&revertedChild)
+			require.Equal(t, beforeChild, revertedChild, "expected reverted table after edits to match before")
+		})
+	})
+}

--- a/pkg/storage/batcheval/cmd_revert_range.go
+++ b/pkg/storage/batcheval/cmd_revert_range.go
@@ -34,6 +34,7 @@ func declareKeysRevertRange(
 	// We look up the range descriptor key to check whether the span
 	// is equal to the entire range for fast stats updating.
 	spans.Add(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeDescriptorKey(desc.StartKey)})
+	spans.Add(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeLastGCKey(desc.RangeID)})
 }
 
 // isEmptyKeyTimeRange checks if the span has no writes in (since,until].

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -2013,7 +2013,7 @@ func MVCCClearTimeRange(
 
 		if startTime.Less(k.Timestamp) && !endTime.Less(k.Timestamp) {
 			if batchSize >= maxBatchSize {
-				resume = &roachpb.Span{Key: append([]byte{}, k.Key...)}
+				resume = &roachpb.Span{Key: append([]byte{}, k.Key...), EndKey: endKey}
 				break
 			}
 			clearMatchingKey(k)


### PR DESCRIPTION
(first commit is #39251)

kv,batcheval: fix RevertRange to work with DistSender and ResumeSpans

    This patch includes several changes required to make RevertRange requests
    get along with DistSender:

    1) add RevertRange to the explicit check for maxkey-supported requests.
    2) makes RevertRangeResponse combinable, however combining assumes
    that at-most-one reply returned a ResumeSpan, so it also
    3) sets NumKeys to MaxKeys in RevertRange when returning a ResumeSpan,
    to stop distsender from sending any further requests that might also hit
    a resume and then trip up combining.

    Together these make it possible to send batches of RevertRange requests
    via DistSender and get back resume spans.

    Release note: none.

sql: add RevertTables helper for reverting a Table via RevertRange

    This adds a helper that can revert a collection of tables to a target
    timestamp using the RevertRange RPC.

    It checks that the tables do not  overlap the key space of another table
    not being reverted (i.e. that all the reverting tables are interleaved,
    if at all, only with each other) and that the tables are offline.

    It then reverts the table spans using RevertRange, including handling
    the ResumeSpan pagination.

    Release note: none.