### PR TITLE
sql: change privilege check error message (superuser to admin role)

### DIFF
--- a/docs/RFCS/20171220_sql_role_based_access_control.md
+++ b/docs/RFCS/20171220_sql_role_based_access_control.md
@@ -440,8 +440,8 @@ Permission checks currently consist of calls to one of:
 ```
 func (p *planner) CheckPrivilege(descriptor sqlbase.DescriptorProto, privilege privilege.Kind) error
 func (p *planner) CheckAnyPrivilege(descriptor sqlbase.DescriptorProto) error
-func (p *planner) RequireSuperUser(action string) error
-func (p *planner) IsSuperUser(action string) (bool, error)
+func (p *planner) RequireAdminRole(action string) error
+func (p *planner) HasAdminRole() (bool, error)
 func (p *planner) MemberOfWithAdminOption(member string) (map[string]bool, error)
 ```
 

--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -839,7 +839,7 @@ func backupPlanHook(
 			return err
 		}
 
-		if err := p.RequireSuperUser(ctx, "BACKUP"); err != nil {
+		if err := p.RequireAdminRole(ctx, "BACKUP"); err != nil {
 			return err
 		}
 

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -2298,12 +2298,12 @@ func TestBackupRestorePermissions(t *testing.T) {
 
 	t.Run("root-only", func(t *testing.T) {
 		if _, err := testuser.Exec(backupStmt); !testutils.IsError(
-			err, "only superusers are allowed to BACKUP",
+			err, "only users with the admin role are allowed to BACKUP",
 		) {
 			t.Fatal(err)
 		}
 		if _, err := testuser.Exec(`RESTORE blah FROM 'blah'`); !testutils.IsError(
-			err, "only superusers are allowed to RESTORE",
+			err, "only users with the admin role are allowed to RESTORE",
 		) {
 			t.Fatal(err)
 		}

--- a/pkg/ccl/backupccl/restore.go
+++ b/pkg/ccl/backupccl/restore.go
@@ -1332,7 +1332,7 @@ func restorePlanHook(
 			return err
 		}
 
-		if err := p.RequireSuperUser(ctx, "RESTORE"); err != nil {
+		if err := p.RequireAdminRole(ctx, "RESTORE"); err != nil {
 			return err
 		}
 

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -38,7 +38,7 @@ func showBackupPlanHook(
 		return nil, nil, nil, false, err
 	}
 
-	if err := p.RequireSuperUser(ctx, "SHOW BACKUP"); err != nil {
+	if err := p.RequireAdminRole(ctx, "SHOW BACKUP"); err != nil {
 		return nil, nil, nil, false, err
 	}
 

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -136,7 +136,7 @@ func changefeedPlanHook(
 		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer tracing.FinishSpan(span)
 
-		if err := p.RequireSuperUser(ctx, "CREATE CHANGEFEED"); err != nil {
+		if err := p.RequireAdminRole(ctx, "CREATE CHANGEFEED"); err != nil {
 			return err
 		}
 

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1489,8 +1489,8 @@ func TestChangefeedPermissions(t *testing.T) {
 		if strings.Contains(t.Name(), `enterprise`) {
 			stmt = `CREATE CHANGEFEED FOR foo`
 		}
-		if _, err := testuser.Exec(stmt); !testutils.IsError(err, `only superusers`) {
-			t.Errorf(`expected 'only superusers' error got: %+v`, err)
+		if _, err := testuser.Exec(stmt); !testutils.IsError(err, `only users with the admin role`) {
+			t.Errorf(`expected 'only users with the admin role' error got: %+v`, err)
 		}
 	}
 

--- a/pkg/ccl/importccl/exportcsv.go
+++ b/pkg/ccl/importccl/exportcsv.go
@@ -96,7 +96,7 @@ func exportPlanHook(
 			return err
 		}
 
-		if err := p.RequireSuperUser(ctx, "EXPORT"); err != nil {
+		if err := p.RequireAdminRole(ctx, "EXPORT"); err != nil {
 			return err
 		}
 

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -158,7 +158,7 @@ func importPlanHook(
 
 		walltime := p.ExecCfg().Clock.Now().WallTime
 
-		if err := p.RequireSuperUser(ctx, "IMPORT"); err != nil {
+		if err := p.RequireAdminRole(ctx, "IMPORT"); err != nil {
 			return err
 		}
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/role
+++ b/pkg/ccl/logictestccl/testdata/logic_test/role
@@ -590,7 +590,7 @@ CREATE DATABASE db1
 
 user testuser
 
-statement error only superusers are allowed to CREATE DATABASE
+statement error only users with the admin role are allowed to CREATE DATABASE
 CREATE DATABASE db2
 
 statement error user testuser does not have DROP privilege on database db1

--- a/pkg/ccl/roleccl/role.go
+++ b/pkg/ccl/roleccl/role.go
@@ -72,9 +72,9 @@ func grantRolePlanHook(
 		return nil, err
 	}
 
-	if isSuperUser, err := p.IsSuperUser(ctx, "grant role"); err != nil {
+	if hasAdminRole, err := p.HasAdminRole(ctx); err != nil {
 		return nil, err
-	} else if !isSuperUser {
+	} else if !hasAdminRole {
 		// Not a superuser: check permissions on each role.
 		allRoles, err := p.MemberOfWithAdminOption(ctx, p.User())
 		if err != nil {
@@ -203,9 +203,9 @@ func revokeRolePlanHook(
 		return nil, err
 	}
 
-	if isSuperUser, err := p.IsSuperUser(ctx, "revoke role"); err != nil {
+	if hasAdminRole, err := p.HasAdminRole(ctx); err != nil {
 		return nil, err
-	} else if !isSuperUser {
+	} else if !hasAdminRole {
 		// Not a superuser: check permissions on each role.
 		allRoles, err := p.MemberOfWithAdminOption(ctx, p.User())
 		if err != nil {

--- a/pkg/server/settingsworker_test.go
+++ b/pkg/server/settingsworker_test.go
@@ -266,22 +266,22 @@ func TestSettingsSetAndShow(t *testing.T) {
 	defer testuser.Close()
 
 	if _, err := testuser.Exec(`SET CLUSTER SETTING foo = 'bar'`); !testutils.IsError(err,
-		`only superusers are allowed to SET CLUSTER SETTING`,
+		`only users with the admin role are allowed to SET CLUSTER SETTING`,
 	) {
 		t.Fatal(err)
 	}
 	if _, err := testuser.Exec(`SHOW CLUSTER SETTING foo`); !testutils.IsError(err,
-		`only superusers are allowed to SHOW CLUSTER SETTING`,
+		`only users with the admin role are allowed to SHOW CLUSTER SETTING`,
 	) {
 		t.Fatal(err)
 	}
 	if _, err := testuser.Exec(`SHOW ALL CLUSTER SETTINGS`); !testutils.IsError(err,
-		`only superusers are allowed to SHOW ALL CLUSTER SETTINGS`,
+		`only users with the admin role are allowed to SHOW ALL CLUSTER SETTINGS`,
 	) {
 		t.Fatal(err)
 	}
 	if _, err := testuser.Exec(`SELECT * FROM crdb_internal.cluster_settings`); !testutils.IsError(err,
-		`only superusers are allowed to read crdb_internal.cluster_settings`,
+		`only users with the admin role are allowed to read crdb_internal.cluster_settings`,
 	) {
 		t.Fatal(err)
 	}

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -714,7 +714,7 @@ func (p *planner) setAuditMode(
 		auditEvent{desc: desc, writing: true})
 
 	// We require root for now. Later maybe use a different permission?
-	if err := p.RequireSuperUser(ctx, "change auditing settings on a table"); err != nil {
+	if err := p.RequireAdminRole(ctx, "change auditing settings on a table"); err != nil {
 		return false, err
 	}
 

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -144,7 +144,7 @@ CREATE TABLE crdb_internal.node_runtime_info (
   value     STRING NOT NULL
 )`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		if err := p.RequireSuperUser(ctx, "access the node runtime information"); err != nil {
+		if err := p.RequireAdminRole(ctx, "access the node runtime information"); err != nil {
 			return err
 		}
 
@@ -595,7 +595,7 @@ CREATE TABLE crdb_internal.node_statement_statistics (
   implicit_txn        BOOL NOT NULL
 )`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		if err := p.RequireSuperUser(ctx, "access application statistics"); err != nil {
+		if err := p.RequireAdminRole(ctx, "access application statistics"); err != nil {
 			return err
 		}
 
@@ -731,7 +731,7 @@ CREATE TABLE crdb_internal.cluster_settings (
   description   STRING NOT NULL
 )`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		if err := p.RequireSuperUser(ctx, "read crdb_internal.cluster_settings"); err != nil {
+		if err := p.RequireAdminRole(ctx, "read crdb_internal.cluster_settings"); err != nil {
 			return err
 		}
 		for _, k := range settings.Keys() {
@@ -789,7 +789,7 @@ CREATE TABLE crdb_internal.%s (
 
 func (p *planner) makeSessionsRequest(ctx context.Context) serverpb.ListSessionsRequest {
 	req := serverpb.ListSessionsRequest{Username: p.SessionData().User}
-	if err := p.RequireSuperUser(ctx, "list sessions"); err == nil {
+	if err := p.RequireAdminRole(ctx, "list sessions"); err == nil {
 		// The root user can see all sessions.
 		req.Username = ""
 	}
@@ -1033,7 +1033,7 @@ var crdbInternalLocalMetricsTable = virtualSchemaTable{
   value							 FLOAT NOT NULL    -- value of the metric
 )`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		if err := p.RequireSuperUser(ctx, "read crdb_internal.node_metrics"); err != nil {
+		if err := p.RequireAdminRole(ctx, "read crdb_internal.node_metrics"); err != nil {
 			return err
 		}
 
@@ -1722,7 +1722,7 @@ CREATE TABLE crdb_internal.ranges_no_leases (
 )
 `,
 	generator: func(ctx context.Context, p *planner, _ *DatabaseDescriptor) (virtualTableGenerator, error) {
-		if err := p.RequireSuperUser(ctx, "read crdb_internal.ranges_no_leases"); err != nil {
+		if err := p.RequireAdminRole(ctx, "read crdb_internal.ranges_no_leases"); err != nil {
 			return nil, err
 		}
 		descs, err := p.Tables().getAllDescriptors(ctx, p.txn)
@@ -1982,7 +1982,7 @@ CREATE TABLE crdb_internal.gossip_nodes (
 )
 	`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		if err := p.RequireSuperUser(ctx, "read crdb_internal.gossip_nodes"); err != nil {
+		if err := p.RequireAdminRole(ctx, "read crdb_internal.gossip_nodes"); err != nil {
 			return err
 		}
 
@@ -2102,7 +2102,7 @@ CREATE TABLE crdb_internal.gossip_liveness (
 		// which is highly available. DO NOT CALL functions which require the
 		// cluster to be healthy, such as StatusServer.Nodes().
 
-		if err := p.RequireSuperUser(ctx, "read crdb_internal.gossip_liveness"); err != nil {
+		if err := p.RequireAdminRole(ctx, "read crdb_internal.gossip_liveness"); err != nil {
 			return err
 		}
 
@@ -2170,7 +2170,7 @@ CREATE TABLE crdb_internal.gossip_alerts (
 )
 	`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		if err := p.RequireSuperUser(ctx, "read crdb_internal.gossip_alerts"); err != nil {
+		if err := p.RequireAdminRole(ctx, "read crdb_internal.gossip_alerts"); err != nil {
 			return err
 		}
 
@@ -2236,7 +2236,7 @@ CREATE TABLE crdb_internal.gossip_network (
 )
 	`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		if err := p.RequireSuperUser(ctx, "read crdb_internal.gossip_network"); err != nil {
+		if err := p.RequireAdminRole(ctx, "read crdb_internal.gossip_network"); err != nil {
 			return err
 		}
 
@@ -2411,7 +2411,7 @@ CREATE TABLE crdb_internal.kv_node_status (
 )
 	`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		if err := p.RequireSuperUser(ctx, "read crdb_internal.kv_node_status"); err != nil {
+		if err := p.RequireAdminRole(ctx, "read crdb_internal.kv_node_status"); err != nil {
 			return err
 		}
 
@@ -2514,7 +2514,7 @@ CREATE TABLE crdb_internal.kv_store_status (
 )
 	`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		if err := p.RequireSuperUser(ctx, "read crdb_internal.kv_store_status"); err != nil {
+		if err := p.RequireAdminRole(ctx, "read crdb_internal.kv_store_status"); err != nil {
 			return err
 		}
 

--- a/pkg/sql/create_database.go
+++ b/pkg/sql/create_database.go
@@ -65,7 +65,7 @@ func (p *planner) CreateDatabase(ctx context.Context, n *tree.CreateDatabase) (p
 		}
 	}
 
-	if err := p.RequireSuperUser(ctx, "CREATE DATABASE"); err != nil {
+	if err := p.RequireAdminRole(ctx, "CREATE DATABASE"); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/delegate/show_all_cluster_settings.go
+++ b/pkg/sql/delegate/show_all_cluster_settings.go
@@ -15,7 +15,7 @@ import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 func (d *delegator) delegateShowAllClusterSettings(
 	stmt *tree.ShowAllClusterSettings,
 ) (tree.Statement, error) {
-	if err := d.catalog.RequireSuperUser(d.ctx, "SHOW ALL CLUSTER SETTINGS"); err != nil {
+	if err := d.catalog.RequireAdminRole(d.ctx, "SHOW ALL CLUSTER SETTINGS"); err != nil {
 		return nil, err
 	}
 	return parse(

--- a/pkg/sql/logictest/testdata/logic_test/cluster_version
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_version
@@ -12,7 +12,7 @@ SELECT crdb_internal.node_executable_version()
 
 user testuser
 
-statement error only superusers are allowed to SET CLUSTER SETTING
+statement error only users with the admin role are allowed to SET CLUSTER SETTING
 SET CLUSTER SETTING version = '2.0'
 
 user root

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -405,28 +405,28 @@ select crdb_internal.force_log_fatal('foo')
 query error insufficient privilege
 select crdb_internal.set_vmodule('')
 
-query error pq: only superusers are allowed to access the node runtime information
+query error pq: only users with the admin role are allowed to access the node runtime information
 select * from crdb_internal.node_runtime_info
 
-query error pq: only superusers are allowed to read crdb_internal.ranges
+query error pq: only users with the admin role are allowed to read crdb_internal.ranges
 select * from crdb_internal.ranges
 
-query error pq: only superusers are allowed to read crdb_internal.gossip_nodes
+query error pq: only users with the admin role are allowed to read crdb_internal.gossip_nodes
 select * from crdb_internal.gossip_nodes
 
-query error pq: only superusers are allowed to read crdb_internal.gossip_liveness
+query error pq: only users with the admin role are allowed to read crdb_internal.gossip_liveness
 select * from crdb_internal.gossip_liveness
 
-query error pq: only superusers are allowed to read crdb_internal.node_metrics
+query error pq: only users with the admin role are allowed to read crdb_internal.node_metrics
 select * from crdb_internal.node_metrics
 
-query error pq: only superusers are allowed to read crdb_internal.kv_node_status
+query error pq: only users with the admin role are allowed to read crdb_internal.kv_node_status
 select * from crdb_internal.kv_node_status
 
-query error pq: only superusers are allowed to read crdb_internal.kv_store_status
+query error pq: only users with the admin role are allowed to read crdb_internal.kv_store_status
 select * from crdb_internal.kv_store_status
 
-query error pq: only superusers are allowed to read crdb_internal.gossip_alerts
+query error pq: only users with the admin role are allowed to read crdb_internal.gossip_alerts
 select * from crdb_internal.gossip_alerts
 
 # Anyone can see the executable version.

--- a/pkg/sql/logictest/testdata/logic_test/database
+++ b/pkg/sql/logictest/testdata/logic_test/database
@@ -169,7 +169,7 @@ SELECT * FROM b.a
 
 user testuser
 
-statement error only superusers are allowed to CREATE DATABASE
+statement error only users with the admin role are allowed to CREATE DATABASE
 CREATE DATABASE privs
 
 user root

--- a/pkg/sql/logictest/testdata/logic_test/privileges_database
+++ b/pkg/sql/logictest/testdata/logic_test/privileges_database
@@ -36,7 +36,7 @@ REVOKE ALL ON DATABASE a FROM bar
 # Switch to a user without any privileges.
 user testuser
 
-statement error only superusers are allowed to CREATE DATABASE
+statement error only users with the admin role are allowed to CREATE DATABASE
 CREATE DATABASE b
 
 statement error user testuser does not have DROP privilege on database a
@@ -71,7 +71,7 @@ GRANT SELECT ON DATABASE a TO testuser
 
 user testuser
 
-statement error only superusers are allowed to CREATE DATABASE
+statement error only users with the admin role are allowed to CREATE DATABASE
 CREATE DATABASE b
 
 statement error user testuser does not have DROP privilege on database a
@@ -106,7 +106,7 @@ GRANT ALL ON DATABASE a TO testuser
 
 user testuser
 
-statement error only superusers are allowed to CREATE DATABASE
+statement error only users with the admin role are allowed to CREATE DATABASE
 CREATE DATABASE b
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/rename_database
+++ b/pkg/sql/logictest/testdata/logic_test/rename_database
@@ -103,7 +103,7 @@ GRANT ALL ON DATABASE t TO testuser
 
 user testuser
 
-statement error only superusers are allowed to ALTER DATABASE ... RENAME
+statement error only users with the admin role are allowed to ALTER DATABASE ... RENAME
 ALTER DATABASE t RENAME TO v
 
 query T

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -117,13 +117,13 @@ type Catalog interface {
 	// the given catalog object. If not, then CheckAnyPrivilege returns an error.
 	CheckAnyPrivilege(ctx context.Context, o Object) error
 
-	// IsSuperUser checks that the current user has admin privileges. If yes,
+	// HasAdminRole checks that the current user has admin privileges. If yes,
 	// returns true. Returns an error if query on the `system.users` table failed
-	IsSuperUser(ctx context.Context, action string) (bool, error)
+	HasAdminRole(ctx context.Context) (bool, error)
 
-	// RequireSuperUser checks that the current user has admin privileges. If not,
+	// RequireAdminRole checks that the current user has admin privileges. If not,
 	// returns an error.
-	RequireSuperUser(ctx context.Context, action string) error
+	RequireAdminRole(ctx context.Context, action string) error
 
 	// FullyQualifiedName retrieves the fully qualified name of a data source.
 	// Note that:

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -197,13 +197,13 @@ func (tc *Catalog) CheckAnyPrivilege(ctx context.Context, o cat.Object) error {
 	return nil
 }
 
-// IsSuperUser is part of the cat.Catalog interface.
-func (tc *Catalog) IsSuperUser(ctx context.Context, action string) (bool, error) {
+// HasAdminRole is part of the cat.Catalog interface.
+func (tc *Catalog) HasAdminRole(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-// RequireSuperUser is part of the cat.Catalog interface.
-func (tc *Catalog) RequireSuperUser(ctx context.Context, action string) error {
+// RequireAdminRole is part of the cat.Catalog interface.
+func (tc *Catalog) RequireAdminRole(ctx context.Context, action string) error {
 	return nil
 }
 

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -230,14 +230,14 @@ func (oc *optCatalog) CheckAnyPrivilege(ctx context.Context, o cat.Object) error
 	return oc.planner.CheckAnyPrivilege(ctx, desc)
 }
 
-// IsSuperUser is part of the cat.Catalog interface.
-func (oc *optCatalog) IsSuperUser(ctx context.Context, action string) (bool, error) {
-	return oc.planner.IsSuperUser(ctx, action)
+// HasAdminRole is part of the cat.Catalog interface.
+func (oc *optCatalog) HasAdminRole(ctx context.Context) (bool, error) {
+	return oc.planner.HasAdminRole(ctx)
 }
 
-// RequireSuperUser is part of the cat.Catalog interface.
-func (oc *optCatalog) RequireSuperUser(ctx context.Context, action string) error {
-	return oc.planner.RequireSuperUser(ctx, action)
+// RequireAdminRole is part of the cat.Catalog interface.
+func (oc *optCatalog) RequireAdminRole(ctx context.Context, action string) error {
+	return oc.planner.RequireAdminRole(ctx, action)
 }
 
 // FullyQualifiedName is part of the cat.Catalog interface.

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -39,7 +39,7 @@ func (p *planner) RenameDatabase(ctx context.Context, n *tree.RenameDatabase) (p
 		return nil, pgerror.DangerousStatementf("RENAME DATABASE on current database")
 	}
 
-	if err := p.RequireSuperUser(ctx, "ALTER DATABASE ... RENAME"); err != nil {
+	if err := p.RequireAdminRole(ctx, "ALTER DATABASE ... RENAME"); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -72,7 +72,7 @@ type checkOperation interface {
 // Scrub checks the database.
 // Privileges: superuser.
 func (p *planner) Scrub(ctx context.Context, n *tree.Scrub) (planNode, error) {
-	if err := p.RequireSuperUser(ctx, "SCRUB"); err != nil {
+	if err := p.RequireAdminRole(ctx, "SCRUB"); err != nil {
 		return nil, err
 	}
 	return &scrubNode{n: n}, nil

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -44,7 +44,7 @@ type setClusterSettingNode struct {
 func (p *planner) SetClusterSetting(
 	ctx context.Context, n *tree.SetClusterSetting,
 ) (planNode, error) {
-	if err := p.RequireSuperUser(ctx, "SET CLUSTER SETTING"); err != nil {
+	if err := p.RequireAdminRole(ctx, "SET CLUSTER SETTING"); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/show_cluster_setting.go
+++ b/pkg/sql/show_cluster_setting.go
@@ -104,7 +104,7 @@ func (p *planner) ShowClusterSetting(
 	ctx context.Context, n *tree.ShowClusterSetting,
 ) (planNode, error) {
 
-	if err := p.RequireSuperUser(ctx, "SHOW CLUSTER SETTING"); err != nil {
+	if err := p.RequireAdminRole(ctx, "SHOW CLUSTER SETTING"); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This PR resolves #39099
change privilege check error message from "only superusers are allowed to" to "only users with the admin role are allowed to"

Open question: should `IsSuperUser` and `RequireSuperUser` method names stay the same?
 