### PR TITLE
sql: stop using the HP for CREATE TABLE AS

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/create_as_opt
+++ b/pkg/sql/logictest/testdata/logic_test/create_as_opt
@@ -1,0 +1,39 @@
+# LogicTest: local-opt
+
+# Test CREATE TABLE AS with a correlated subquery.
+statement ok
+CREATE TABLE ab (a INT PRIMARY KEY, b INT)
+
+statement ok
+CREATE TABLE cd (c INT PRIMARY KEY, b INT)
+
+statement ok
+INSERT INTO ab VALUES (1, 1), (2, 2), (3, 3)
+
+statement ok
+INSERT INTO cd VALUES (2, 2), (3, 3), (4, 4)
+
+statement ok
+CREATE TABLE t AS SELECT a, b, EXISTS(SELECT c FROM cd WHERE cd.c=ab.a) FROM ab;
+
+query IIB rowsort
+SELECT * FROM t
+----
+1  1  false
+2  2  true
+3  3  true
+
+# Test CREATE TABLE AS with a mutation.
+statement ok
+CREATE TABLE t2 AS SELECT * FROM [DELETE FROM t WHERE b>2 RETURNING a,b]
+
+# TODO(radu): this should contain (3,3); bug tracked by #39197.
+query II
+SELECT * FROM t2
+----
+
+query IIB rowsort
+SELECT * FROM t
+----
+1  1  false
+2  2  true

--- a/pkg/sql/opt/ops/statement.opt
+++ b/pkg/sql/opt/ops/statement.opt
@@ -24,7 +24,8 @@ define CreateTablePrivate {
     # defined when the AS clause was used in the CREATE TABLE statement.
     InputCols Presentation
 
-    # Syntax is the CREATE TABLE AST node.
+    # Syntax is the CREATE TABLE AST node. All data sources inside AsSource are
+    # fully qualified.
     Syntax CreateTable
 }
 

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -123,6 +123,13 @@ type Builder struct {
 	// trackViewDeps would be false inside that inner view).
 	trackViewDeps bool
 	viewDeps      opt.ViewDeps
+
+	// If set, the data source names in the AST are rewritten to the fully
+	// qualified version (after resolution). Used to construct the strings for
+	// CREATE VIEW and CREATE TABLE AS queries.
+	// TODO(radu): modifying the AST in-place is hacky; we will need to switch to
+	// using AST annotations.
+	qualifyDataSourceNamesInAST bool
 }
 
 // New creates a new Builder structure initialized with the given

--- a/pkg/sql/opt/optbuilder/create_table.go
+++ b/pkg/sql/opt/optbuilder/create_table.go
@@ -39,6 +39,15 @@ func (b *Builder) buildCreateTable(ct *tree.CreateTable, inScope *scope) (outSco
 	var input memo.RelExpr
 	var inputCols physical.Presentation
 	if ct.As() {
+		// The execution code might need to stringify the query to run it
+		// asynchronously. For that we need the data sources to be fully qualified.
+		// TODO(radu): this interaction is pretty hacky, investigate moving the
+		// generation of the string to the optimizer.
+		b.qualifyDataSourceNamesInAST = true
+		defer func() {
+			b.qualifyDataSourceNamesInAST = false
+		}()
+
 		// Build the input query.
 		outScope := b.buildSelect(ct.AsSource, nil /* desiredTypes */, inScope)
 

--- a/pkg/sql/opt/optbuilder/create_view.go
+++ b/pkg/sql/opt/optbuilder/create_view.go
@@ -31,10 +31,12 @@ func (b *Builder) buildCreateView(cv *tree.CreateView, inScope *scope) (outScope
 	// The result is not otherwise used.
 	b.insideViewDef = true
 	b.trackViewDeps = true
+	b.qualifyDataSourceNamesInAST = true
 	defer func() {
 		b.insideViewDef = false
 		b.trackViewDeps = false
 		b.viewDeps = nil
+		b.qualifyDataSourceNamesInAST = false
 	}()
 
 	defScope := b.buildSelect(cv.AsSource, nil /* desiredTypes */, inScope)

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -98,14 +98,6 @@ func (b *Builder) buildDataSource(
 		}
 
 		ds, resName := b.resolveDataSource(tn, privilege.SELECT)
-		if b.insideViewDef {
-			// Overwrite the table name in the AST to the fully resolved version.
-			// TODO(radu): modifying the AST in-place is hacky; we will need to switch
-			// to using AST annotations.
-			*tn = resName
-			tn.ExplicitCatalog = true
-			tn.ExplicitSchema = true
-		}
 		switch t := ds.(type) {
 		case cat.Table:
 			tabMeta := b.addTable(t, &resName)

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -462,6 +462,9 @@ func (b *Builder) resolveTable(
 // resolveDataSource returns the data source in the catalog with the given name.
 // If the name does not resolve to a table, or if the current user does not have
 // the given privilege, then resolveDataSource raises an error.
+//
+// If the b.qualifyDataSourceNamesInAST flag is set, tn is updated to contain
+// the fully qualified name.
 func (b *Builder) resolveDataSource(
 	tn *tree.TableName, priv privilege.Kind,
 ) (cat.DataSource, cat.DataSourceName) {
@@ -475,6 +478,12 @@ func (b *Builder) resolveDataSource(
 		panic(err)
 	}
 	b.checkPrivilege(opt.DepByName(tn), ds, priv)
+
+	if b.qualifyDataSourceNamesInAST {
+		*tn = resName
+		tn.ExplicitCatalog = true
+		tn.ExplicitSchema = true
+	}
 	return ds, resName
 }
 


### PR DESCRIPTION
The `createTableNode` uses the heuristic planner just to populate
fully qualified datasource names in the AST. This prevents it from
working with any queries that are not supported by the HP (like
correlated subqueries).

This change makes the optbuilder do this data source replacement. This
is still a pretty hacky way to do things; it will be reconsidered when
we are further down the road of no HP and immutable ASTs.

Release note: None