### PR TITLE
exec: Add framework to create specialized builtin operators.

### DIFF
--- a/pkg/sql/exec/builtin_funcs.go
+++ b/pkg/sql/exec/builtin_funcs.go
@@ -12,6 +12,7 @@ package exec
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
@@ -27,7 +28,7 @@ type defaultBuiltinFuncOperator struct {
 	evalCtx        *tree.EvalContext
 	funcExpr       *tree.FuncExpr
 	columnTypes    []types.T
-	inputCols      []int
+	argumentCols   []int
 	outputIdx      int
 	outputType     *types.T
 	outputPhysType coltypes.T
@@ -60,13 +61,13 @@ func (b *defaultBuiltinFuncOperator) Next(ctx context.Context) coldata.Batch {
 
 		hasNulls := false
 
-		for j := range b.inputCols {
-			col := batch.ColVec(b.inputCols[j])
+		for j := range b.argumentCols {
+			col := batch.ColVec(b.argumentCols[j])
 			if col.MaybeHasNulls() && col.Nulls().NullAt(rowIdx) {
 				hasNulls = true
 				b.row[j] = tree.DNull
 			} else {
-				b.row[j] = PhysicalTypeColElemToDatum(col, rowIdx, b.da, b.columnTypes[b.inputCols[j]])
+				b.row[j] = PhysicalTypeColElemToDatum(col, rowIdx, b.da, b.columnTypes[b.argumentCols[j]])
 			}
 		}
 
@@ -98,30 +99,113 @@ func (b *defaultBuiltinFuncOperator) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
+type substringFunctionOperator struct {
+	OneInputNode
+	argumentCols []int
+	outputIdx    int
+}
+
+var _ Operator = &substringFunctionOperator{}
+
+func (s *substringFunctionOperator) Init() {
+	s.input.Init()
+}
+
+func (s *substringFunctionOperator) Next(ctx context.Context) coldata.Batch {
+	batch := s.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return batch
+	}
+
+	if s.outputIdx == batch.Width() {
+		batch.AppendCol(coltypes.Bytes)
+	}
+
+	sel := batch.Selection()
+	runeVec := batch.ColVec(s.argumentCols[0]).Bytes()
+	startVec := batch.ColVec(s.argumentCols[1]).Int64()
+	lengthVec := batch.ColVec(s.argumentCols[2]).Int64()
+	outputVec := batch.ColVec(s.outputIdx).Bytes()
+	for i := uint16(0); i < n; i++ {
+		rowIdx := i
+		if sel != nil {
+			rowIdx = sel[i]
+		}
+
+		// The substring operator does not support nulls. If any of the arguments
+		// are NULL, we output NULL.
+		isNull := false
+		for _, col := range s.argumentCols {
+			if batch.ColVec(col).Nulls().NullAt(rowIdx) {
+				isNull = true
+				break
+			}
+		}
+		if isNull {
+			batch.ColVec(s.outputIdx).Nulls().SetNull(rowIdx)
+			continue
+		}
+
+		runes := runeVec.Get(int(rowIdx))
+		// Substring start is 1 indexed.
+		start := int(startVec[rowIdx]) - 1
+		length := int(lengthVec[rowIdx])
+		if length < 0 {
+			execerror.VectorizedInternalPanic(fmt.Sprintf("negative substring length %d not allowed", length))
+		}
+
+		end := start + length
+		// Check for integer overflow.
+		if end < start {
+			end = len(runes)
+		} else if end < 0 {
+			end = 0
+		} else if end > len(runes) {
+			end = len(runes)
+		}
+
+		if start < 0 {
+			start = 0
+		} else if start > len(runes) {
+			start = len(runes)
+		}
+		outputVec.Set(int(rowIdx), runes[start:end])
+	}
+
+	return batch
+}
+
 // NewBuiltinFunctionOperator returns an operator that applies builtin functions.
 func NewBuiltinFunctionOperator(
 	evalCtx *tree.EvalContext,
 	funcExpr *tree.FuncExpr,
 	columnTypes []types.T,
-	inputCols []int,
+	argumentCols []int,
 	outputIdx int,
 	input Operator,
 ) Operator {
 
-	outputType := funcExpr.ResolvedType()
-
-	// For now, return the default builtin operator. Future work can specialize
-	// out the operators to efficient implementations of specific builtins.
-	return &defaultBuiltinFuncOperator{
-		OneInputNode:   NewOneInputNode(input),
-		evalCtx:        evalCtx,
-		funcExpr:       funcExpr,
-		outputIdx:      outputIdx,
-		columnTypes:    columnTypes,
-		outputType:     outputType,
-		outputPhysType: typeconv.FromColumnType(outputType),
-		converter:      typeconv.GetDatumToPhysicalFn(outputType),
-		row:            make(tree.Datums, len(inputCols)),
-		inputCols:      inputCols,
+	switch funcExpr.ResolvedOverload().SpecializedVecBuiltin {
+	case tree.SubstringStringIntInt:
+		return &substringFunctionOperator{
+			OneInputNode: NewOneInputNode(input),
+			argumentCols: argumentCols,
+			outputIdx:    outputIdx,
+		}
+	default:
+		outputType := funcExpr.ResolvedType()
+		return &defaultBuiltinFuncOperator{
+			OneInputNode:   NewOneInputNode(input),
+			evalCtx:        evalCtx,
+			funcExpr:       funcExpr,
+			outputIdx:      outputIdx,
+			columnTypes:    columnTypes,
+			outputType:     outputType,
+			outputPhysType: typeconv.FromColumnType(outputType),
+			converter:      typeconv.GetDatumToPhysicalFn(outputType),
+			row:            make(tree.Datums, len(argumentCols)),
+			argumentCols:   argumentCols,
+		}
 	}
 }

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3216,7 +3216,8 @@ var substringImpls = makeBuiltin(tree.FunctionProperties{Category: categoryStrin
 			{"start_pos", types.Int},
 			{"length", types.Int},
 		},
-		ReturnType: tree.FixedReturnType(types.String),
+		SpecializedVecBuiltin: tree.SubstringStringIntInt,
+		ReturnType:            tree.FixedReturnType(types.String),
 		Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 			runes := []rune(string(tree.MustBeDString(args[0])))
 			// SQL strings are 1-indexed.

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -23,6 +23,22 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// SpecializedVectorizedBuiltin is used to map overloads
+// to the vectorized operator that is specific to
+// that implementation of the builtin function.
+type SpecializedVectorizedBuiltin int
+
+// TODO (rohany): What is the best place to put this list?
+// I want to put it in builtins or exec, but those create an import
+// cycle with exec. tree is imported by both of them, so
+// this package seems like a good place to do it.
+
+// Keep this list alphabetized so that it is easy to manage.
+const (
+	_ SpecializedVectorizedBuiltin = iota
+	SubstringStringIntInt
+)
+
 // Overload is one of the overloads of a built-in function.
 // Each FunctionDefinition may contain one or more overloads.
 type Overload struct {
@@ -54,6 +70,10 @@ type Overload struct {
 	// counter, if non-nil, should be incremented upon successful
 	// type check of expressions using this overload.
 	counter telemetry.Counter
+
+	// SpecializedVecBuiltin is used to let the vectorized engine
+	// know when an Overload has a specialized vectorized operator.
+	SpecializedVecBuiltin SpecializedVectorizedBuiltin
 }
 
 // params implements the overloadImpl interface.


### PR DESCRIPTION
This PR also implements a specialized substring operator.

Some ideas we had were to automatically generate some identifier
for each builtin based on its type, but this doesn't seem to
work, as a function can have multiple overloads with the
same name and same type! Instead, manually creating an
enum for each builtin operator we implement might be an easier
way of starting off. This strategy is compatible across
a multi version cluster as long as the identifier given to each
overload is not serialized along with each funcExpr.

Future work could also look at extending templating out the
specialized builtin operators to accept functions that implement
the specialized behavior, without having to write all the boilerplate
for a new operator. It is unclear what the performance
impact of that is however.

Release note: None