### PR TITLE
opt: clean up tags and add opaque operator flavors for mutations and DDL

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/show_fingerprints
+++ b/pkg/sql/logictest/testdata/logic_test/show_fingerprints
@@ -110,3 +110,15 @@ query TT
 SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE blocks
 ----
 primary  590700560494856555
+
+# Verify that we can show fingerprints from a read-only transaction (#39204).
+statement ok
+BEGIN TRANSACTION AS OF SYSTEM TIME '-1us'
+
+query TT
+SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE t
+----
+primary  1205834892498753533
+
+statement ok
+COMMIT

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -13,7 +13,6 @@ package sql
 import (
 	"context"
 	"reflect"
-	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
@@ -65,14 +64,14 @@ func buildOpaque(
 		return nil, nil, err
 	}
 	res := &opaqueMetadata{
-		info: strings.TrimPrefix(reflect.TypeOf(stmt).String(), "*tree."),
+		info: stmt.StatementTag(),
 		plan: plan,
 	}
 	return res, planColumns(plan), nil
 }
 
 func init() {
-	opaqueStmts := []reflect.Type{
+	opaqueReadOnlyStmts := []reflect.Type{
 		reflect.TypeOf(&tree.ShowClusterSetting{}),
 		reflect.TypeOf(&tree.ShowHistogram{}),
 		reflect.TypeOf(&tree.ShowTableStats{}),
@@ -80,7 +79,7 @@ func init() {
 		reflect.TypeOf(&tree.ShowZoneConfig{}),
 		reflect.TypeOf(&tree.ShowFingerprints{}),
 	}
-	for _, t := range opaqueStmts {
-		optbuilder.RegisterOpaque(t, buildOpaque)
+	for _, t := range opaqueReadOnlyStmts {
+		optbuilder.RegisterOpaque(t, optbuilder.OpaqueReadOnly, buildOpaque)
 	}
 }

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -193,9 +193,10 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 
 	case *ScanExpr, *VirtualScanExpr, *IndexJoinExpr, *ShowTraceForSessionExpr,
 		*InsertExpr, *UpdateExpr, *UpsertExpr, *DeleteExpr, *SequenceSelectExpr,
-		*WindowExpr, *OpaqueRelExpr, *AlterTableSplitExpr, *AlterTableUnsplitExpr,
-		*AlterTableUnsplitAllExpr, *AlterTableRelocateExpr, *ControlJobsExpr,
-		*CancelQueriesExpr, *CancelSessionsExpr:
+		*WindowExpr, *OpaqueRelExpr, *OpaqueMutationExpr, *OpaqueDDLExpr,
+		*AlterTableSplitExpr, *AlterTableUnsplitExpr, *AlterTableUnsplitAllExpr,
+		*AlterTableRelocateExpr, *ControlJobsExpr, *CancelQueriesExpr,
+		*CancelSessionsExpr:
 		fmt.Fprintf(f.Buffer, "%v", e.Op())
 		FormatPrivate(f, e.Private(), required)
 

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -809,59 +809,46 @@ func (b *logicalPropsBuilder) buildShowTraceForSessionProps(
 
 func (b *logicalPropsBuilder) buildOpaqueRelProps(op *OpaqueRelExpr, rel *props.Relational) {
 	b.buildBasicProps(op, op.Columns, rel)
-	rel.CanHaveSideEffects = true
-	rel.CanMutate = true
 }
 
 func (b *logicalPropsBuilder) buildAlterTableSplitProps(
 	split *AlterTableSplitExpr, rel *props.Relational,
 ) {
 	b.buildBasicProps(split, split.Columns, rel)
-	rel.CanHaveSideEffects = true
-	rel.CanMutate = true
 }
 
 func (b *logicalPropsBuilder) buildAlterTableUnsplitProps(
 	unsplit *AlterTableUnsplitExpr, rel *props.Relational,
 ) {
 	b.buildBasicProps(unsplit, unsplit.Columns, rel)
-	rel.CanHaveSideEffects = true
-	rel.CanMutate = true
 }
 
 func (b *logicalPropsBuilder) buildAlterTableUnsplitAllProps(
 	unsplitAll *AlterTableUnsplitAllExpr, rel *props.Relational,
 ) {
 	b.buildBasicProps(unsplitAll, unsplitAll.Columns, rel)
-	rel.CanHaveSideEffects = true
-	rel.CanMutate = true
 }
 
 func (b *logicalPropsBuilder) buildAlterTableRelocateProps(
 	relocate *AlterTableRelocateExpr, rel *props.Relational,
 ) {
 	b.buildBasicProps(relocate, relocate.Columns, rel)
-	rel.CanHaveSideEffects = true
-	rel.CanMutate = true
 }
 
 func (b *logicalPropsBuilder) buildControlJobsProps(ctl *ControlJobsExpr, rel *props.Relational) {
 	b.buildBasicProps(ctl, opt.ColList{}, rel)
-	rel.CanHaveSideEffects = true
 }
 
 func (b *logicalPropsBuilder) buildCancelQueriesProps(
 	cancel *CancelQueriesExpr, rel *props.Relational,
 ) {
 	b.buildBasicProps(cancel, opt.ColList{}, rel)
-	rel.CanHaveSideEffects = true
 }
 
 func (b *logicalPropsBuilder) buildCancelSessionsProps(
 	cancel *CancelSessionsExpr, rel *props.Relational,
 ) {
 	b.buildBasicProps(cancel, opt.ColList{}, rel)
-	rel.CanHaveSideEffects = true
 }
 
 func (b *logicalPropsBuilder) buildLimitProps(limit *LimitExpr, rel *props.Relational) {

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -811,6 +811,16 @@ func (b *logicalPropsBuilder) buildOpaqueRelProps(op *OpaqueRelExpr, rel *props.
 	b.buildBasicProps(op, op.Columns, rel)
 }
 
+func (b *logicalPropsBuilder) buildOpaqueMutationProps(
+	op *OpaqueMutationExpr, rel *props.Relational,
+) {
+	b.buildBasicProps(op, op.Columns, rel)
+}
+
+func (b *logicalPropsBuilder) buildOpaqueDDLProps(op *OpaqueDDLExpr, rel *props.Relational) {
+	b.buildBasicProps(op, op.Columns, rel)
+}
+
 func (b *logicalPropsBuilder) buildAlterTableSplitProps(
 	split *AlterTableSplitExpr, rel *props.Relational,
 ) {

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -342,7 +342,8 @@ func (sb *statisticsBuilder) colStat(colSet opt.ColSet, e RelExpr) *props.Column
 	case opt.SequenceSelectOp:
 		return sb.colStatSequenceSelect(colSet, e.(*SequenceSelectExpr))
 
-	case opt.ExplainOp, opt.ShowTraceForSessionOp, opt.OpaqueRelOp:
+	case opt.ExplainOp, opt.ShowTraceForSessionOp,
+		opt.OpaqueRelOp, opt.OpaqueMutationOp, opt.OpaqueDDLOp:
 		return sb.colStatUnknown(colSet, e.Relational())
 
 	case opt.WithOp:

--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -281,8 +281,8 @@ func AggregateIsNullOnEmpty(op Operator) bool {
 type OpaqueMetadata interface {
 	ImplementsOpaqueMetadata()
 
-	// String is used when printing optimizer trees and should contain a short
-	// description of the statement.
+	// String is a short description used when printing optimizer trees and when
+	// forming error messages; it should be the SQL statement tag.
 	String() string
 }
 

--- a/pkg/sql/opt/ops/README.md
+++ b/pkg/sql/opt/ops/README.md
@@ -1,0 +1,54 @@
+Optimizer operator definitions
+==============================
+
+This directory contains definitions for the optimizer operators.
+
+The syntax should be fairly self-evident from the existing definitions. Try to
+keep the formatting consistent. In particular:
+ - use 4 spaces (no tabs) for indentation;
+ - include a comment describing the operator;
+ - include comments for non-trivial fields;
+ - put Private definitions after the corresponding operator.
+
+If a new type is necessary for a Private definition, an entry must be added in
+optgen (`opt/optgen/cmd/optgen/metadata.go`), and `HashXX / IsXXEqual` functions
+must be added to the interner (`opt/memo/interner.go`).
+
+## Tags
+
+Operators can have various tags. This section lists all the used tags and their
+intended semantics.
+
+General operator type tags (each operator has exactly one of these tags):
+ - `Relational`: used for relational operators.
+ - `Scalar`: used for scalar operators.
+ - `Enforcer`: used for enforcers.
+
+Tags for scalar operators:
+ - `List`: used for scalar lists operators.
+ - `ListItem`: used for scalar list items.
+ - `Binary`: used for binary operators.
+ - `Bool`: used for operators that always return a boolean.
+ - `Int`: used for operators that always return an integer.
+ - `Float`: used for operators that always return a float.
+ - `Comparison`: used for binary operators that return a boolean.
+ - `ConstValue`: used for operators that represent a constant value.
+ - `Aggregate`: used for operators that represent an aggregation function.
+ - `Window`: used for operators that represent a window function.
+
+Tags for relational operators:
+ - `Join`: used for logical variations of join, including apply joins (but not
+   physical variations like lookup join).
+ - `JoinApply`: used for logical variations of apply join.
+ - `JoinNonApply`: used for logical variations of join, not including apply
+   joins.
+ - `Grouping`: used for aggregation operators.
+ - `Set`: used for set operation operators (like Union, Intersect).
+ - `Telemetry`: if used, triggers operator usage tracking via telemetry.
+ - `Mutation`: used for operators that can mutate data as part of the
+   transaction. This includes DML operations like INSERT, as well as DDL
+   operations. In general, anything that can't execute in a read-only
+   transaction must have this tag.
+ - `DDL`: used for schema change operations; these operators cannot be executed
+   following a mutation in the same transaction. Should always be used in
+   conjunction with the `Mutation` tag.

--- a/pkg/sql/opt/ops/statement.opt
+++ b/pkg/sql/opt/ops/statement.opt
@@ -116,7 +116,7 @@ define OpaqueRelPrivate {
 }
 
 # AlterTableSplit represents an `ALTER TABLE/INDEX .. SPLIT AT ..` statement.
-[Relational, DDL]
+[Relational, Mutation]
 define AlterTableSplit {
     # The input expression provides values for the index columns (or a prefix of
     # them).
@@ -150,7 +150,7 @@ define AlterTableSplitPrivate {
 
 # AlterTableUnsplit represents an `ALTER TABLE/INDEX .. UNSPLIT AT ..`
 # statement.
-[Relational, DDL]
+[Relational, Mutation]
 define AlterTableUnsplit {
     Input RelExpr
 
@@ -158,13 +158,13 @@ define AlterTableUnsplit {
 }
 
 # AlterTableUnsplit represents an `ALTER TABLE/INDEX .. UNSPLIT ALL` statement.
-[Relational, DDL]
+[Relational, Mutation]
 define AlterTableUnsplitAll {
     _ AlterTableSplitPrivate
 }
 
 # AlterTableRelocate represents an `ALTER TABLE/INDEX .. SPLIT AT ..` statement.
-[Relational, DDL]
+[Relational, Mutation]
 define AlterTableRelocate {
     # The input expression provides values for the index columns (or a prefix of
     # them).

--- a/pkg/sql/opt/ops/statement.opt
+++ b/pkg/sql/opt/ops/statement.opt
@@ -104,8 +104,22 @@ define ShowTracePrivate {
 #
 # OpaqueRel can produce data and can be used as a data source as part of a
 # larger enclosing query.
-[Relational, DDL, Mutation]
+[Relational]
 define OpaqueRel {
+    _ OpaqueRelPrivate
+}
+
+# OpaqueMutation is a variant of OpaqueRel for operators that can mutate data as
+# part of the transaction.
+[Relational, Mutation]
+define OpaqueMutation {
+    _ OpaqueRelPrivate
+}
+
+# OpaqueMutation is a variant of OpaqueRel for operators that cause a schema
+# change and cannot be executed following a mutation in the same transaction.
+[Relational, Mutation, DDL]
+define OpaqueDDL {
     _ OpaqueRelPrivate
 }
 

--- a/pkg/sql/opt/optbuilder/opaque.go
+++ b/pkg/sql/opt/optbuilder/opaque.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/errors"
 )
 
 // BuildOpaqueFn is a handler for building the metadata for an opaque statement.
@@ -25,27 +26,66 @@ type BuildOpaqueFn func(
 	context.Context, *tree.SemaContext, *tree.EvalContext, tree.Statement,
 ) (opt.OpaqueMetadata, sqlbase.ResultColumns, error)
 
+// OpaqueType indicates whether an opaque statement can mutate data or change
+// schema.
+type OpaqueType int
+
+const (
+	// OpaqueReadOnly is used for statements that do not mutate state as part of
+	// the transaction, and can be run in read-only transactions.
+	OpaqueReadOnly OpaqueType = iota
+
+	// OpaqueMutation is used for statements that mutate data and cannot be run as
+	// part of read-only transactions.
+	OpaqueMutation
+
+	// OpaqueDDL is used for statements that change a schema and cannot be
+	// executed following a mutation in the same transaction.
+	OpaqueDDL
+)
+
 // RegisterOpaque registers an opaque handler for a specific statement type.
-func RegisterOpaque(stmtType reflect.Type, fn BuildOpaqueFn) {
-	opaqueStatements[stmtType] = fn
+func RegisterOpaque(stmtType reflect.Type, opaqueType OpaqueType, fn BuildOpaqueFn) {
+	if _, ok := opaqueStatements[stmtType]; ok {
+		panic(errors.AssertionFailedf("opaque statement %s already registered", stmtType))
+	}
+	opaqueStatements[stmtType] = opaqueStmtInfo{
+		typ:     opaqueType,
+		buildFn: fn,
+	}
 }
 
-var opaqueStatements = make(map[reflect.Type]BuildOpaqueFn)
+type opaqueStmtInfo struct {
+	typ     OpaqueType
+	buildFn BuildOpaqueFn
+}
+
+var opaqueStatements = make(map[reflect.Type]opaqueStmtInfo)
 
 func (b *Builder) tryBuildOpaque(stmt tree.Statement, inScope *scope) (outScope *scope) {
-	fn, ok := opaqueStatements[reflect.TypeOf(stmt)]
+	info, ok := opaqueStatements[reflect.TypeOf(stmt)]
 	if !ok {
 		return nil
 	}
-	obj, cols, err := fn(b.ctx, b.semaCtx, b.evalCtx, stmt)
+	obj, cols, err := info.buildFn(b.ctx, b.semaCtx, b.evalCtx, stmt)
 	if err != nil {
 		panic(err)
 	}
 	outScope = inScope.push()
 	b.synthesizeResultColumns(outScope, cols)
-	outScope.expr = b.factory.ConstructOpaqueRel(&memo.OpaqueRelPrivate{
+	private := &memo.OpaqueRelPrivate{
 		Columns:  colsToColList(outScope.cols),
 		Metadata: obj,
-	})
+	}
+	switch info.typ {
+	case OpaqueReadOnly:
+		outScope.expr = b.factory.ConstructOpaqueRel(private)
+	case OpaqueMutation:
+		outScope.expr = b.factory.ConstructOpaqueMutation(private)
+	case OpaqueDDL:
+		outScope.expr = b.factory.ConstructOpaqueDDL(private)
+	default:
+		panic(errors.AssertionFailedf("invalid opaque statement type %d", info.typ))
+	}
 	return outScope
 }


### PR DESCRIPTION
#### opt: clean up tags

This change adds a README file that describes the operator tags. In
particular, the semantics of the `Mutation` and `DDL` tags were pretty
obscure.

We also correct the tags for various statements that incorrectly used
`DDL` and `Mutation`. The tag should correspond to
`tree.CanModifySchema()` and `tree.CanWriteData()` (which are used by
the heuristic planner).

Release note: None

#### opt: add opaque operator flavors for mutations and DDL

The opaque operator assumes the worst and is tagged with Mutation and
DDL. This prevents all opaque statements from running in read-only
transactions.

This change splits `OpaqueRel` into three flavors: `OpaqueRel`,
`OpaqueMutation`, and `OpaqueDDL`. The difference is in the operator
tags, which causes different behavior in the execbuilder.

In addition, the opaque metadata `String()` now returns the
`StatementTag` and is used in error messages. This was tested manually
as all opaque operators are read-only so far.

Fixes #39204.

Release note: None
