### PR TITLE
opt: remove RightJoinApply and OuterJoinApply

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -819,10 +819,10 @@ func joinOpToJoinType(op opt.Operator) sqlbase.JoinType {
 	case opt.LeftJoinOp, opt.LeftJoinApplyOp:
 		return sqlbase.LeftOuterJoin
 
-	case opt.RightJoinOp, opt.RightJoinApplyOp:
+	case opt.RightJoinOp:
 		return sqlbase.RightOuterJoin
 
-	case opt.FullJoinOp, opt.FullJoinApplyOp:
+	case opt.FullJoinOp:
 		return sqlbase.FullOuterJoin
 
 	case opt.SemiJoinOp, opt.SemiJoinApplyOp:

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -318,73 +318,6 @@ right-join (hash)
            ├── variable: x [type=int]
            └── variable: u [type=int]
 
-# Right-join-apply.
-opt
-SELECT * FROM xysd RIGHT JOIN uv ON (SELECT u FROM uv WHERE u=x OFFSET 1) IS NULL
-----
-right-join (hash)
- ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) v:6(int!null)
- ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
- ├── prune: (1-6)
- ├── reject-nulls: (1-4)
- ├── interesting orderings: (+1) (-3,+4,+1)
- ├── project
- │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── key: (1)
- │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
- │    ├── prune: (1-4)
- │    ├── interesting orderings: (+1) (-3,+4,+1)
- │    └── select
- │         ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:8(int)
- │         ├── key: (1)
- │         ├── fd: ()-->(8), (1)-->(2-4), (3,4)~~>(1,2)
- │         ├── prune: (2-4)
- │         ├── interesting orderings: (+1) (-3,+4,+1)
- │         ├── left-join-apply
- │         │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:8(int)
- │         │    ├── key: (1)
- │         │    ├── fd: (1)-->(2-4,8), (3,4)~~>(1,2)
- │         │    ├── prune: (2-4)
- │         │    ├── reject-nulls: (8)
- │         │    ├── interesting orderings: (+1) (-3,+4,+1)
- │         │    ├── scan xysd
- │         │    │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │         │    │    ├── key: (1)
- │         │    │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
- │         │    │    ├── prune: (1-4)
- │         │    │    └── interesting orderings: (+1) (-3,+4,+1)
- │         │    ├── max1-row
- │         │    │    ├── columns: u:8(int!null)
- │         │    │    ├── outer: (1)
- │         │    │    ├── cardinality: [0 - 1]
- │         │    │    ├── key: ()
- │         │    │    ├── fd: ()-->(8)
- │         │    │    └── offset
- │         │    │         ├── columns: u:8(int!null)
- │         │    │         ├── outer: (1)
- │         │    │         ├── fd: ()-->(8)
- │         │    │         ├── select
- │         │    │         │    ├── columns: u:8(int!null)
- │         │    │         │    ├── outer: (1)
- │         │    │         │    ├── fd: ()-->(8)
- │         │    │         │    ├── scan uv
- │         │    │         │    │    ├── columns: u:8(int)
- │         │    │         │    │    └── prune: (8)
- │         │    │         │    └── filters
- │         │    │         │         └── eq [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
- │         │    │         │              ├── variable: u [type=int]
- │         │    │         │              └── variable: x [type=int]
- │         │    │         └── const: 1 [type=int]
- │         │    └── filters (true)
- │         └── filters
- │              └── is [type=bool, outer=(8), constraints=(/8: [/NULL - /NULL]; tight), fd=()-->(8)]
- │                   ├── variable: u [type=int]
- │                   └── null [type=unknown]
- ├── scan uv
- │    ├── columns: u:5(int) v:6(int!null)
- │    └── prune: (5,6)
- └── filters (true)
-
 # Full-join.
 build
 SELECT *, rowid FROM xysd FULL JOIN uv ON x=u
@@ -412,64 +345,6 @@ full-join (hash)
       └── eq [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
            ├── variable: x [type=int]
            └── variable: u [type=int]
-
-# Full-join-apply.
-opt
-SELECT * FROM xysd FULL JOIN uv ON (SELECT u FROM uv WHERE u=x OFFSET 1) IS NULL
-----
-project
- ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) v:6(int)
- ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
- ├── prune: (1-6)
- ├── interesting orderings: (+1) (-3,+4,+1)
- └── full-join-apply
-      ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) v:6(int) u:8(int)
-      ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
-      ├── prune: (2-6)
-      ├── reject-nulls: (1-6,8)
-      ├── interesting orderings: (+1) (-3,+4,+1)
-      ├── scan xysd
-      │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
-      │    ├── prune: (1-4)
-      │    └── interesting orderings: (+1) (-3,+4,+1)
-      ├── left-join (hash)
-      │    ├── columns: u:5(int) v:6(int!null) u:8(int)
-      │    ├── outer: (1)
-      │    ├── fd: ()~~>(8)
-      │    ├── prune: (5,6)
-      │    ├── reject-nulls: (8)
-      │    ├── scan uv
-      │    │    ├── columns: u:5(int) v:6(int!null)
-      │    │    └── prune: (5,6)
-      │    ├── max1-row
-      │    │    ├── columns: u:8(int!null)
-      │    │    ├── outer: (1)
-      │    │    ├── cardinality: [0 - 1]
-      │    │    ├── key: ()
-      │    │    ├── fd: ()-->(8)
-      │    │    └── offset
-      │    │         ├── columns: u:8(int!null)
-      │    │         ├── outer: (1)
-      │    │         ├── fd: ()-->(8)
-      │    │         ├── select
-      │    │         │    ├── columns: u:8(int!null)
-      │    │         │    ├── outer: (1)
-      │    │         │    ├── fd: ()-->(8)
-      │    │         │    ├── scan uv
-      │    │         │    │    ├── columns: u:8(int)
-      │    │         │    │    └── prune: (8)
-      │    │         │    └── filters
-      │    │         │         └── eq [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
-      │    │         │              ├── variable: u [type=int]
-      │    │         │              └── variable: x [type=int]
-      │    │         └── const: 1 [type=int]
-      │    └── filters (true)
-      └── filters
-           └── is [type=bool, outer=(8), constraints=(/8: [/NULL - /NULL]; tight), fd=()-->(8)]
-                ├── variable: u [type=int]
-                └── null [type=unknown]
 
 # Semi-join.
 opt

--- a/pkg/sql/opt/norm/decorrelate.go
+++ b/pkg/sql/opt/norm/decorrelate.go
@@ -328,10 +328,6 @@ func (c *CustomFuncs) ConstructNonApplyJoin(
 		return c.f.ConstructInnerJoin(left, right, on, private)
 	case opt.LeftJoinOp, opt.LeftJoinApplyOp:
 		return c.f.ConstructLeftJoin(left, right, on, private)
-	case opt.RightJoinOp, opt.RightJoinApplyOp:
-		return c.f.ConstructRightJoin(left, right, on, private)
-	case opt.FullJoinOp, opt.FullJoinApplyOp:
-		return c.f.ConstructFullJoin(left, right, on, private)
 	case opt.SemiJoinOp, opt.SemiJoinApplyOp:
 		return c.f.ConstructSemiJoin(left, right, on, private)
 	case opt.AntiJoinOp, opt.AntiJoinApplyOp:
@@ -350,10 +346,6 @@ func (c *CustomFuncs) ConstructApplyJoin(
 		return c.f.ConstructInnerJoinApply(left, right, on, private)
 	case opt.LeftJoinOp, opt.LeftJoinApplyOp:
 		return c.f.ConstructLeftJoinApply(left, right, on, private)
-	case opt.RightJoinOp, opt.RightJoinApplyOp:
-		return c.f.ConstructRightJoinApply(left, right, on, private)
-	case opt.FullJoinOp, opt.FullJoinApplyOp:
-		return c.f.ConstructFullJoinApply(left, right, on, private)
 	case opt.SemiJoinOp, opt.SemiJoinApplyOp:
 		return c.f.ConstructSemiJoinApply(left, right, on, private)
 	case opt.AntiJoinOp, opt.AntiJoinApplyOp:

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -296,12 +296,8 @@ func (f *Factory) ConstructJoin(
 		return f.ConstructLeftJoinApply(left, right, on, private)
 	case opt.RightJoinOp:
 		return f.ConstructRightJoin(left, right, on, private)
-	case opt.RightJoinApplyOp:
-		return f.ConstructRightJoinApply(left, right, on, private)
 	case opt.FullJoinOp:
 		return f.ConstructFullJoin(left, right, on, private)
-	case opt.FullJoinApplyOp:
-		return f.ConstructFullJoinApply(left, right, on, private)
 	case opt.SemiJoinOp:
 		return f.ConstructSemiJoin(left, right, on, private)
 	case opt.SemiJoinApplyOp:

--- a/pkg/sql/opt/norm/join.go
+++ b/pkg/sql/opt/norm/join.go
@@ -45,8 +45,6 @@ func (c *CustomFuncs) ConstructNonLeftJoin(
 		return c.f.ConstructInnerJoinApply(left, right, on, private)
 	case opt.FullJoinOp:
 		return c.f.ConstructRightJoin(left, right, on, private)
-	case opt.FullJoinApplyOp:
-		return c.f.ConstructRightJoinApply(left, right, on, private)
 	}
 	panic(errors.AssertionFailedf("unexpected join operator: %v", log.Safe(joinOp)))
 }
@@ -60,12 +58,8 @@ func (c *CustomFuncs) ConstructNonRightJoin(
 	switch joinOp {
 	case opt.RightJoinOp:
 		return c.f.ConstructInnerJoin(left, right, on, private)
-	case opt.RightJoinApplyOp:
-		return c.f.ConstructInnerJoinApply(left, right, on, private)
 	case opt.FullJoinOp:
 		return c.f.ConstructLeftJoin(left, right, on, private)
-	case opt.FullJoinApplyOp:
-		return c.f.ConstructLeftJoinApply(left, right, on, private)
 	}
 	panic(errors.AssertionFailedf("unexpected join operator: %v", log.Safe(joinOp)))
 }

--- a/pkg/sql/opt/norm/prune_cols.go
+++ b/pkg/sql/opt/norm/prune_cols.go
@@ -437,7 +437,7 @@ func DerivePruneCols(e memo.RelExpr) opt.ColSet {
 
 	case opt.InnerJoinOp, opt.LeftJoinOp, opt.RightJoinOp, opt.FullJoinOp,
 		opt.SemiJoinOp, opt.AntiJoinOp, opt.InnerJoinApplyOp, opt.LeftJoinApplyOp,
-		opt.RightJoinApplyOp, opt.FullJoinApplyOp, opt.SemiJoinApplyOp, opt.AntiJoinApplyOp:
+		opt.SemiJoinApplyOp, opt.AntiJoinApplyOp:
 		// Any pruneable columns from projected inputs can potentially be pruned, as
 		// long as they're not used by the right input (i.e. in Apply case) or by
 		// the join filter.

--- a/pkg/sql/opt/norm/reject_nulls.go
+++ b/pkg/sql/opt/norm/reject_nulls.go
@@ -90,7 +90,7 @@ func DeriveRejectNullCols(in memo.RelExpr) opt.ColSet {
 		}
 		relProps.Rule.RejectNullCols.UnionWith(in.Child(1).(memo.RelExpr).Relational().OutputCols)
 
-	case opt.RightJoinOp, opt.RightJoinApplyOp:
+	case opt.RightJoinOp:
 		// Pass through null-rejection columns from right input, and request null-
 		// rejection on left columns.
 		relProps.Rule.RejectNullCols = in.Child(0).(memo.RelExpr).Relational().OutputCols
@@ -98,7 +98,7 @@ func DeriveRejectNullCols(in memo.RelExpr) opt.ColSet {
 			relProps.Rule.RejectNullCols.UnionWith(DeriveRejectNullCols(in.Child(1).(memo.RelExpr)))
 		}
 
-	case opt.FullJoinOp, opt.FullJoinApplyOp:
+	case opt.FullJoinOp:
 		// Request null-rejection on all output columns.
 		relProps.Rule.RejectNullCols = relProps.OutputCols
 

--- a/pkg/sql/opt/norm/rules/decorrelate.opt
+++ b/pkg/sql/opt/norm/rules/decorrelate.opt
@@ -778,11 +778,12 @@
 
 # HoistJoinSubquery extracts subqueries from a join filter and joins them with
 # the join's right input. This and other subquery hoisting patterns create a
-# single, top-level relational query with no nesting.
+# single, top-level relational query with no nesting. This rule only applies to
+# join types which have a legal apply variant.
 #
 # This rule is marked as low priority for the same reason as HoistSelectExists.
 [HoistJoinSubquery, Normalize, LowPriority]
-(Join
+(InnerJoin | LeftJoin | SemiJoin | AntiJoin
     $left:*
     $right:*
     $on:[ ... $item:* & (HasHoistableSubquery $item) ... ]

--- a/pkg/sql/opt/norm/rules/join.opt
+++ b/pkg/sql/opt/norm/rules/join.opt
@@ -101,7 +101,7 @@
 #       be ordered before PushFilterIntoJoinLeft (otherwise,
 #       PushFilterIntoJoinLeft might need to be applied multiple times).
 [MapFilterIntoJoinLeft, Normalize]
-(InnerJoin | InnerJoinApply | RightJoin | RightJoinApply | SemiJoin | SemiJoinApply
+(InnerJoin | InnerJoinApply | RightJoin | SemiJoin | SemiJoinApply
     $left:* & ^(HasOuterCols $left)
     $right:*
     $on:[
@@ -171,7 +171,7 @@
 #
 # Citations: [1]
 [PushFilterIntoJoinLeft, Normalize]
-(InnerJoin | InnerJoinApply | RightJoin | RightJoinApply | SemiJoin | SemiJoinApply
+(InnerJoin | InnerJoinApply | RightJoin | SemiJoin | SemiJoinApply
     $left:* & ^(HasOuterCols $left)
     $right:*
     $on:[
@@ -224,7 +224,7 @@
 # join only populates the right side with NULL values when it would otherwise
 # not be present.
 [SimplifyLeftJoinWithoutFilters, Normalize]
-(LeftJoin | LeftJoinApply | FullJoin | FullJoinApply
+(LeftJoin | LeftJoinApply | FullJoin
     $left:*
     $right:* & ^(CanHaveZeroRows $right)
     $on:[]
@@ -245,7 +245,7 @@
 # join only populates the left side with NULL values when it would otherwise not
 # be present.
 [SimplifyRightJoinWithoutFilters, Normalize]
-(RightJoin | RightJoinApply | FullJoin | FullJoinApply
+(RightJoin | FullJoin
     $left:* & ^(CanHaveZeroRows $left)
     $right:*
     $on:[]
@@ -278,7 +278,7 @@
 #   =>
 #   SELECT * FROM orders o INNER JOIN customers c ON o.customer_id = c.id
 [SimplifyLeftJoinWithFilters, Normalize]
-(LeftJoin | LeftJoinApply | FullJoin | FullJoinApply
+(LeftJoin | LeftJoinApply | FullJoin
     $left:*
     $right:*
     $on:^[] & (JoinFiltersMatchAllLeftRows $left $right $on)
@@ -299,7 +299,7 @@
 # is symmetric with SimplifyLeftJoinWithFilters; see that rule for more details
 # and examples.
 [SimplifyRightJoinWithFilters, Normalize]
-(RightJoin | RightJoinApply | FullJoin | FullJoinApply
+(RightJoin | FullJoin
     $left:*
     $right:*
     $on:^[] & (JoinFiltersMatchAllLeftRows $right $left $on)

--- a/pkg/sql/opt/norm/rules/reject_nulls.opt
+++ b/pkg/sql/opt/norm/rules/reject_nulls.opt
@@ -58,7 +58,7 @@
 # Citations: [1]
 [RejectNullsLeftJoin, Normalize, HighPriority]
 (Select
-    $input:(LeftJoin | LeftJoinApply | FullJoin | FullJoinApply
+    $input:(LeftJoin | LeftJoinApply | FullJoin
         $left:*
         $right:*
         $on:*
@@ -86,7 +86,7 @@
 # RejectNullsLeftJoin.
 [RejectNullsRightJoin, Normalize, HighPriority]
 (Select
-    $input:(RightJoin | RightJoinApply | FullJoin | FullJoinApply
+    $input:(RightJoin | FullJoin
         $left:*
         $right:*
         $on:*

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -200,7 +200,7 @@
 # details.
 [PushSelectCondRightIntoJoinLeftAndRight, Normalize]
 (Select
-    $input:(InnerJoin | InnerJoinApply | RightJoin | RightJoinApply
+    $input:(InnerJoin | InnerJoinApply | RightJoin
         $left:*
         $right:*
         $on:*
@@ -279,7 +279,7 @@
 # into the left side. See that rule's comments for more details.
 [PushSelectIntoJoinRight, Normalize]
 (Select
-    $input:(InnerJoin | InnerJoinApply | RightJoin | RightJoinApply
+    $input:(InnerJoin | InnerJoinApply | RightJoin
         $left:*
         $right:*
         $on:*

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -4106,60 +4106,50 @@ project
       └── filters
            └── x = ?column? [type=bool, outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6)]
 
-# Right join + multiple subqueries.
-opt expect=HoistJoinSubquery
+# Can't hoist in a right join.
+opt expect-not=HoistJoinSubquery
 SELECT y FROM a RIGHT JOIN xy ON (SELECT k+1) = (SELECT x+1)
 ----
 project
  ├── columns: y:7(int)
- └── right-join-apply
-      ├── columns: k:1(int) x:6(int!null) y:7(int) "?column?":8(int) "?column?":9(int)
+ └── right-join (hash)
+      ├── columns: k:1(int) x:6(int!null) y:7(int)
       ├── key: (1,6)
-      ├── fd: (1,6)-->(7-9)
+      ├── fd: (6)-->(7)
       ├── scan a
       │    ├── columns: k:1(int!null)
       │    └── key: (1)
-      ├── inner-join-apply
-      │    ├── columns: x:6(int!null) y:7(int) "?column?":8(int) "?column?":9(int)
-      │    ├── outer: (1)
+      ├── scan xy
+      │    ├── columns: x:6(int!null) y:7(int)
       │    ├── key: (6)
-      │    ├── fd: ()-->(8), (6)-->(7,9)
-      │    ├── inner-join (hash)
-      │    │    ├── columns: x:6(int!null) y:7(int) "?column?":8(int)
-      │    │    ├── outer: (1)
-      │    │    ├── key: (6)
-      │    │    ├── fd: ()-->(8), (6)-->(7)
-      │    │    ├── scan xy
-      │    │    │    ├── columns: x:6(int!null) y:7(int)
-      │    │    │    ├── key: (6)
-      │    │    │    └── fd: (6)-->(7)
-      │    │    ├── values
-      │    │    │    ├── columns: "?column?":8(int)
-      │    │    │    ├── outer: (1)
-      │    │    │    ├── cardinality: [1 - 1]
-      │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(8)
-      │    │    │    └── (k + 1,) [type=tuple{int}]
-      │    │    └── filters (true)
-      │    ├── values
-      │    │    ├── columns: "?column?":9(int)
-      │    │    ├── outer: (6)
-      │    │    ├── cardinality: [1 - 1]
-      │    │    ├── key: ()
-      │    │    ├── fd: ()-->(9)
-      │    │    └── (x + 1,) [type=tuple{int}]
-      │    └── filters (true)
+      │    └── fd: (6)-->(7)
       └── filters
-           └── ?column? = ?column? [type=bool, outer=(8,9), constraints=(/8: (/NULL - ]; /9: (/NULL - ]), fd=(8)==(9), (9)==(8)]
+           └── eq [type=bool, outer=(1,6), correlated-subquery]
+                ├── subquery [type=int]
+                │    └── values
+                │         ├── columns: "?column?":8(int)
+                │         ├── outer: (1)
+                │         ├── cardinality: [1 - 1]
+                │         ├── key: ()
+                │         ├── fd: ()-->(8)
+                │         └── (k + 1,) [type=tuple{int}]
+                └── subquery [type=int]
+                     └── values
+                          ├── columns: "?column?":9(int)
+                          ├── outer: (6)
+                          ├── cardinality: [1 - 1]
+                          ├── key: ()
+                          ├── fd: ()-->(9)
+                          └── (x + 1,) [type=tuple{int}]
 
 # Hoist Exists in join filter disjunction.
 opt expect=HoistJoinSubquery
-SELECT s, x FROM a FULL JOIN xy ON EXISTS(SELECT * FROM uv WHERE u=y) OR k=x
+SELECT s, x FROM a INNER JOIN xy ON EXISTS(SELECT * FROM uv WHERE u=y) OR k=x
 ----
 project
- ├── columns: s:4(string) x:6(int)
- └── full-join (hash)
-      ├── columns: k:1(int) s:4(string) x:6(int) exists:12(bool)
+ ├── columns: s:4(string) x:6(int!null)
+ └── inner-join (hash)
+      ├── columns: k:1(int!null) s:4(string) x:6(int!null) exists:12(bool)
       ├── key: (1,6)
       ├── fd: (1)-->(4), (6)-->(12)
       ├── scan a

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -2440,16 +2440,16 @@ full-join (hash)
       └── (u + v) = 1 [type=bool, outer=(3,4)]
 
 opt expect-not=ExtractJoinEqualities
-SELECT * FROM xy FULL OUTER JOIN uv ON (SELECT k FROM a WHERE i=x)=u
+SELECT * FROM xy INNER JOIN uv ON (SELECT k FROM a WHERE i=x)=u
 ----
 project
- ├── columns: x:1(int) y:2(int) u:3(int) v:4(int)
+ ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int)
  ├── key: (1,3)
  ├── fd: (1)-->(2), (1,3)-->(4)
- └── full-join-apply
-      ├── columns: x:1(int) y:2(int) u:3(int) v:4(int) k:5(int)
+ └── inner-join-apply
+      ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int) k:5(int)
       ├── key: (1,3)
-      ├── fd: (1)-->(2), (1,3)-->(4,5)
+      ├── fd: (1)-->(2), (1,3)-->(4,5), (3)==(5), (5)==(3)
       ├── scan xy
       │    ├── columns: x:1(int!null) y:2(int)
       │    ├── key: (1)
@@ -2489,16 +2489,16 @@ project
            └── u = k [type=bool, outer=(3,5), constraints=(/3: (/NULL - ]; /5: (/NULL - ]), fd=(3)==(5), (5)==(3)]
 
 opt expect-not=ExtractJoinEqualities
-SELECT * FROM xy FULL OUTER JOIN uv ON x=(SELECT k FROM a WHERE i=u)
+SELECT * FROM xy INNER JOIN uv ON x=(SELECT k FROM a WHERE i=u)
 ----
 project
- ├── columns: x:1(int) y:2(int) u:3(int) v:4(int)
- ├── key: (1,3)
- ├── fd: (1)-->(2), (3)-->(4)
- └── full-join (hash)
-      ├── columns: x:1(int) y:2(int) u:3(int) v:4(int) k:5(int)
-      ├── key: (1,3)
-      ├── fd: (1)-->(2), (3)-->(4,5)
+ ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int)
+ ├── key: (3)
+ ├── fd: (1)-->(2), (3)-->(1,2,4)
+ └── inner-join (hash)
+      ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int) k:5(int!null)
+      ├── key: (3)
+      ├── fd: (1)-->(2), (3)-->(4,5), (1)==(5), (5)==(1)
       ├── scan xy
       │    ├── columns: x:1(int!null) y:2(int)
       │    ├── key: (1)

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -426,24 +426,6 @@ define LeftJoinApply {
 }
 
 [Relational, Join, JoinApply, Telemetry]
-define RightJoinApply {
-    Left  RelExpr
-    Right RelExpr
-    On    FiltersExpr
-
-    _ JoinPrivate
-}
-
-[Relational, Join, JoinApply, Telemetry]
-define FullJoinApply {
-    Left  RelExpr
-    Right RelExpr
-    On    FiltersExpr
-
-    _ JoinPrivate
-}
-
-[Relational, Join, JoinApply, Telemetry]
 define SemiJoinApply {
     Left  RelExpr
     Right RelExpr

--- a/pkg/sql/opt/optgen/lang/support/textmate/OptGen.tmbundle/Syntaxes/optgen.tmLanguage
+++ b/pkg/sql/opt/optgen/lang/support/textmate/OptGen.tmbundle/Syntaxes/optgen.tmLanguage
@@ -227,8 +227,6 @@
                         MergeJoinPrivate |
                         InnerJoinApply |
                         LeftJoinApply |
-                        RightJoinApply |
-                        FullJoinApply |
                         SemiJoinApply |
                         AntiJoinApply |
                         GroupBy |

--- a/pkg/sql/opt/optgen/lang/support/vim/cropt.vim
+++ b/pkg/sql/opt/optgen/lang/support/vim/cropt.vim
@@ -50,7 +50,7 @@ syn keyword operator Scan ScanPrivate VirtualScan VirtualScanPrivate Values Sele
 syn keyword operator InnerJoin LeftJoin RightJoin FullJoin SemiJoin AntiJoin
 syn keyword operator IndexJoin IndexJoinPrivate LookupJoin LookupJoinPrivate
 syn keyword operator MergeJoin MergeJoinPrivate
-syn keyword operator InnerJoinApply LeftJoinApply RightJoinApply FullJoinApply
+syn keyword operator InnerJoinApply LeftJoinApply
 syn keyword operator SemiJoinApply AntiJoinApply
 syn keyword operator GroupBy GroupingPrivate ScalarGroupBy DistinctOn
 syn keyword operator Union SetPrivate Intersect Except UnionAll IntersectAll ExceptAll

--- a/pkg/sql/opt/optgen/lang/support/vscode/cockroachdb.optgen-1.0.0/syntaxes/optgen.tmLanguage
+++ b/pkg/sql/opt/optgen/lang/support/vscode/cockroachdb.optgen-1.0.0/syntaxes/optgen.tmLanguage
@@ -227,8 +227,6 @@
                         MergeJoinPrivate |
                         InnerJoinApply |
                         LeftJoinApply |
-                        RightJoinApply |
-                        FullJoinApply |
                         SemiJoinApply |
                         AntiJoinApply |
                         GroupBy |

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -163,7 +163,7 @@ func (c *coster) ComputeCost(candidate memo.RelExpr, required *physical.Required
 
 	case opt.InnerJoinOp, opt.LeftJoinOp, opt.RightJoinOp, opt.FullJoinOp,
 		opt.SemiJoinOp, opt.AntiJoinOp, opt.InnerJoinApplyOp, opt.LeftJoinApplyOp,
-		opt.RightJoinApplyOp, opt.FullJoinApplyOp, opt.SemiJoinApplyOp, opt.AntiJoinApplyOp:
+		opt.SemiJoinApplyOp, opt.AntiJoinApplyOp:
 		// All join ops use hash join by default.
 		cost = c.computeHashJoinCost(candidate)
 


### PR DESCRIPTION
These two don't actually have a reasonable definition, and are also not
a part of the original "orthogonal optimization" paper[1] so we
shouldn't be constructing them.

[1]: http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.563.8492&rep=rep1&type=pdf

Release note: None