### PR TITLE
storage: Add `disk_map` implementation for pebble

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1311,7 +1311,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a00ca3a2402bb841b2b0cc9606e7b08df8af1bc50f6bca6fece1bd9f083247ae"
+  digest = "1:87181865d8ba4479e412d0ee0091bc34da5ce84a5beb9487f18e7b1a90fb031c"
   name = "github.com/petermattis/pebble"
   packages = [
     ".",
@@ -1330,7 +1330,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "fcb9ed13025a2407eb66dd0bc6b370868b52cc17"
+  revision = "532c1b32141230575d62419f43330eaa26853104"
 
 [[projects]]
   digest = "1:e39a5ee8fcbec487f8fc68863ef95f2b025e0739b0e4aa55558a2b4cf8f0ecf0"
@@ -2019,6 +2019,7 @@
     "github.com/openzipkin-contrib/zipkin-go-opentracing",
     "github.com/petermattis/goid",
     "github.com/petermattis/pebble",
+    "github.com/petermattis/pebble/cache",
     "github.com/petermattis/pebble/sstable",
     "github.com/pkg/errors",
     "github.com/pmezard/go-difflib/difflib",

--- a/pkg/storage/engine/disk_map.go
+++ b/pkg/storage/engine/disk_map.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/diskmap"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/petermattis/pebble"
 	"github.com/pkg/errors"
 )
 
@@ -259,4 +260,232 @@ func (b *rocksDBMapBatchWriter) Close(ctx context.Context) error {
 	err := b.Flush()
 	b.batch.Close()
 	return err
+}
+
+// pebbleMapBatchWriter batches writes to a pebbleMap.
+type pebbleMapBatchWriter struct {
+	// capacity is the number of bytes to write before a Flush() is triggered.
+	capacity int
+
+	// makeKey is a function that transforms a key into a byte slice with a prefix
+	// to be written to the underlying store.
+	makeKey func(k []byte) []byte
+	batch   *pebble.Batch
+	store   *pebble.DB
+}
+
+// pebbleMapIterator iterates over the keys of a pebbleMap in sorted order.
+type pebbleMapIterator struct {
+	allowDuplicates bool
+	iter            *pebble.Iterator
+	// makeKey is a function that transforms a key into a byte slice with a prefix
+	// used to Seek() the underlying iterator.
+	makeKey func(k []byte) []byte
+	// prefix is the prefix of keys that this iterator iterates over.
+	prefix []byte
+}
+
+// pebbleMap is a SortedDiskMap, similar to rocksDBMap, that uses pebble as its
+// underlying storage engine.
+type pebbleMap struct {
+	prefix          []byte
+	store           *pebble.DB
+	allowDuplicates bool
+	keyID           int64
+}
+
+var _ diskmap.SortedDiskMapBatchWriter = &pebbleMapBatchWriter{}
+var _ diskmap.SortedDiskMapIterator = &pebbleMapIterator{}
+var _ diskmap.SortedDiskMap = &pebbleMap{}
+
+// newPebbleMap creates a new pebbleMap with the passed in Engine as the
+// underlying store. The pebbleMap instance will have a keyspace prefixed by a
+// unique prefix. The allowDuplicates parameter controls whether Puts with
+// identical keys will write multiple entries or overwrite previous entries.
+func newPebbleMap(e *pebble.DB, allowDuplicates bool) *pebbleMap {
+	prefix := generateTempStorageID()
+	return &pebbleMap{
+		prefix:          encoding.EncodeUvarintAscending([]byte(nil), prefix),
+		store:           e,
+		allowDuplicates: allowDuplicates,
+	}
+}
+
+// makeKey appends k to the pebbleMap's prefix to keep the key local to this
+// instance and returns a byte slice containing the user-provided key and the
+// prefix. Pebble's operations can take this byte slice as a key. This key is
+// only valid until the next call to makeKey.
+func (r *pebbleMap) makeKey(k []byte) []byte {
+	prefixLen := len(r.prefix)
+	r.prefix = append(r.prefix, k...)
+	key := r.prefix
+	r.prefix = r.prefix[:prefixLen]
+	return key
+}
+
+// makeKeyWithSequence makes a key appropriate for a Put operation. It is like
+// makeKey except it respects allowDuplicates, by appending a sequence number to
+// the user-provided key.
+func (r *pebbleMap) makeKeyWithSequence(k []byte) []byte {
+	byteKey := r.makeKey(k)
+	if r.allowDuplicates {
+		r.keyID++
+		byteKey = encoding.EncodeUint64Ascending(byteKey, uint64(r.keyID))
+	}
+	return byteKey
+}
+
+// Put implements the SortedDiskMap interface.
+func (r *pebbleMap) Put(k []byte, v []byte) error {
+	return r.store.Set(r.makeKeyWithSequence(k), v, pebble.NoSync)
+}
+
+// Get implements the SortedDiskMap interface.
+func (r *pebbleMap) Get(k []byte) ([]byte, error) {
+	if r.allowDuplicates {
+		return nil, errors.New("Get not supported if allowDuplicates is true")
+	}
+	return r.store.Get(r.makeKey(k))
+}
+
+// NewIterator implements the SortedDiskMap interface.
+func (r *pebbleMap) NewIterator() diskmap.SortedDiskMapIterator {
+	return &pebbleMapIterator{
+		allowDuplicates: r.allowDuplicates,
+		iter: r.store.NewIter(&pebble.IterOptions{
+			UpperBound: roachpb.Key(r.prefix).PrefixEnd(),
+		}),
+		makeKey: r.makeKey,
+		prefix:  r.prefix,
+	}
+}
+
+// NewBatchWriter implements the SortedDiskMap interface.
+func (r *pebbleMap) NewBatchWriter() diskmap.SortedDiskMapBatchWriter {
+	return r.NewBatchWriterCapacity(defaultBatchCapacityBytes)
+}
+
+// NewBatchWriterCapacity implements the SortedDiskMap interface.
+func (r *pebbleMap) NewBatchWriterCapacity(capacityBytes int) diskmap.SortedDiskMapBatchWriter {
+	makeKey := r.makeKey
+	if r.allowDuplicates {
+		makeKey = r.makeKeyWithSequence
+	}
+	return &pebbleMapBatchWriter{
+		capacity: capacityBytes,
+		makeKey:  makeKey,
+		batch:    r.store.NewBatch(),
+		store:    r.store,
+	}
+}
+
+// Clear implements the SortedDiskMap interface.
+func (r *pebbleMap) Clear() error {
+	if err := r.store.DeleteRange(
+		r.prefix,
+		roachpb.Key(r.prefix).PrefixEnd(),
+		pebble.NoSync,
+	); err != nil {
+		return errors.Wrapf(err, "unable to clear range with prefix %v", r.prefix)
+	}
+	// NB: we manually flush after performing the clear range to ensure that the
+	// range tombstone is pushed to disk which will kick off compactions that
+	// will eventually free up the deleted space.
+	return r.store.AsyncFlush()
+}
+
+// Close implements the SortedDiskMap interface.
+func (r *pebbleMap) Close(ctx context.Context) {
+	if err := r.Clear(); err != nil {
+		log.Error(ctx, err)
+	}
+}
+
+// Seek implements the SortedDiskMapIterator interface.
+func (i *pebbleMapIterator) Seek(k []byte) {
+	i.iter.SeekGE(i.makeKey(k))
+}
+
+// Rewind implements the SortedDiskMapIterator interface.
+func (i *pebbleMapIterator) Rewind() {
+	i.iter.SeekGE(i.makeKey(nil))
+}
+
+// Valid implements the SortedDiskMapIterator interface.
+func (i *pebbleMapIterator) Valid() (bool, error) {
+	return i.iter.Valid(), nil
+}
+
+// Next implements the SortedDiskMapIterator interface.
+func (i *pebbleMapIterator) Next() {
+	i.iter.Next()
+}
+
+// Key implements the SortedDiskMapIterator interface.
+func (i *pebbleMapIterator) Key() []byte {
+	unsafeKey := i.UnsafeKey()
+	safeKey := make([]byte, len(unsafeKey))
+	copy(safeKey, unsafeKey)
+
+	return safeKey
+}
+
+// Value implements the SortedDiskMapIterator interface.
+func (i *pebbleMapIterator) Value() []byte {
+	unsafeValue := i.iter.Value()
+	safeValue := make([]byte, len(unsafeValue))
+	copy(safeValue, unsafeValue)
+
+	return safeValue
+}
+
+// UnsafeKey implements the SortedDiskMapIterator interface.
+func (i *pebbleMapIterator) UnsafeKey() []byte {
+	unsafeKey := i.iter.Key()
+	end := len(unsafeKey)
+	if i.allowDuplicates {
+		// There are 8 bytes of sequence number at the end of the key, remove them.
+		end -= 8
+	}
+	return unsafeKey[len(i.prefix):end]
+}
+
+// UnsafeValue implements the SortedDiskMapIterator interface.
+func (i *pebbleMapIterator) UnsafeValue() []byte {
+	return i.iter.Value()
+}
+
+// Close implements the SortedDiskMapIterator interface.
+func (i *pebbleMapIterator) Close() {
+	_ = i.iter.Close()
+}
+
+// Put implements the SortedDiskMapBatchWriter interface.
+func (b *pebbleMapBatchWriter) Put(k []byte, v []byte) error {
+	key := b.makeKey(k)
+	if err := b.batch.Set(key, v, nil); err != nil {
+		return err
+	}
+	if len(b.batch.Repr()) >= b.capacity {
+		return b.Flush()
+	}
+	return nil
+}
+
+// Flush implements the SortedDiskMapBatchWriter interface.
+func (b *pebbleMapBatchWriter) Flush() error {
+	if err := b.batch.Commit(pebble.NoSync); err != nil {
+		return err
+	}
+	b.batch = b.store.NewBatch()
+	return nil
+}
+
+// Close implements the SortedDiskMapBatchWriter interface.
+func (b *pebbleMapBatchWriter) Close(ctx context.Context) error {
+	err := b.Flush()
+	if err != nil {
+		return err
+	}
+	return b.batch.Close()
 }

--- a/pkg/storage/engine/disk_map_test.go
+++ b/pkg/storage/engine/disk_map_test.go
@@ -22,10 +22,12 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/diskmap"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/petermattis/pebble"
 )
 
 func TestRocksDBMap(t *testing.T) {
@@ -453,6 +455,407 @@ func BenchmarkRocksDBMapIteration(b *testing.B) {
 			if err := diskMap.Put([]byte(k), []byte(v)); err != nil {
 				b.Fatal(err)
 			}
+		}
+
+		b.Run(fmt.Sprintf("InputSize%d", inputSize), func(b *testing.B) {
+			for j := 0; j < b.N; j++ {
+				i := diskMap.NewIterator()
+				for i.Rewind(); ; i.Next() {
+					if ok, err := i.Valid(); err != nil {
+						b.Fatal(err)
+					} else if !ok {
+						break
+					}
+					i.Key()
+					i.Value()
+				}
+				i.Close()
+			}
+		})
+	}
+}
+
+func TestPebbleMap(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	dir, err := ioutil.TempDir("", "TestPebbleMap")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e, err := NewPebbleTempEngine(base.TempStorageConfig{Path: dir}, base.StoreSpec{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer e.Close()
+
+	diskMap := e.NewSortedDiskMap()
+	defer diskMap.Close(ctx)
+
+	batchWriter := diskMap.NewBatchWriterCapacity(64)
+	defer func() {
+		err := batchWriter.Close(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+
+	numKeysToWrite := 1 << 12
+	keys := make([]string, numKeysToWrite)
+	for i := 0; i < numKeysToWrite; i++ {
+		k := []byte(fmt.Sprintf("%d", rng.Int()))
+		v := []byte(fmt.Sprintf("%d", rng.Int()))
+
+		keys[i] = string(k)
+		// Use batch on every other write.
+		if i%2 == 0 {
+			if err := diskMap.Put(k, v); err != nil {
+				t.Fatal(err)
+			}
+			// Check key was inserted properly.
+			if b, err := diskMap.Get(k); err != nil {
+				t.Fatal(err)
+			} else if !bytes.Equal(b, v) {
+				t.Fatalf("expected %v for value of key %v but got %v", v, k, b)
+			}
+		} else {
+			if err := batchWriter.Put(k, v); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	sort.StringSlice(keys).Sort()
+
+	if err := batchWriter.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	i := diskMap.NewIterator()
+	defer i.Close()
+
+	checkKeyAndPopFirst := func(k []byte) error {
+		if !bytes.Equal([]byte(keys[0]), k) {
+			return fmt.Errorf("expected %v but got %v", []byte(keys[0]), k)
+		}
+		keys = keys[1:]
+		return nil
+	}
+
+	i.Rewind()
+	if ok, err := i.Valid(); err != nil {
+		t.Fatal(err)
+	} else if !ok {
+		t.Fatal("unexpectedly invalid")
+	}
+	lastKey := i.Key()
+	if err := checkKeyAndPopFirst(lastKey); err != nil {
+		t.Fatal(err)
+	}
+	i.Next()
+
+	numKeysRead := 1
+	for ; ; i.Next() {
+		if ok, err := i.Valid(); err != nil {
+			t.Fatal(err)
+		} else if !ok {
+			break
+		}
+		curKey := i.Key()
+		if err := checkKeyAndPopFirst(curKey); err != nil {
+			t.Fatal(err)
+		}
+		if bytes.Compare(curKey, lastKey) < 0 {
+			t.Fatalf("expected keys in sorted order but %v is larger than %v", curKey, lastKey)
+		}
+		lastKey = curKey
+		numKeysRead++
+	}
+	if numKeysRead != numKeysToWrite {
+		t.Fatalf("expected to read %d keys but only read %d", numKeysToWrite, numKeysRead)
+	}
+}
+
+// TestPebbleMapSandbox verifies that multiple instances of a RocksDBMap
+// initialized with the same RocksDB storage engine cannot read or write
+// another instance's data.
+func TestPebbleMapSandbox(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	dir, err := ioutil.TempDir("", "TestPebbleMapSandbox")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e, err := NewPebbleTempEngine(base.TempStorageConfig{Path: dir}, base.StoreSpec{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer e.Close()
+
+	diskMaps := make([]diskmap.SortedDiskMap, 3)
+	for i := 0; i < len(diskMaps); i++ {
+		diskMaps[i] = e.NewSortedDiskMap()
+	}
+
+	// Put [0,10) as a key into each diskMap with the value specifying which
+	// diskMap inserted this value.
+	numKeys := 10
+	for i := 0; i < numKeys; i++ {
+		for j := 0; j < len(diskMaps); j++ {
+			if err := diskMaps[j].Put([]byte{byte(i)}, []byte{byte(j)}); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	// Verify that an iterator created from a diskMap is constrained to the
+	// diskMap's keyspace and that the keys in the keyspace were all written
+	// by the expected diskMap.
+	t.Run("KeyspaceSandbox", func(t *testing.T) {
+		for j := 0; j < len(diskMaps); j++ {
+			func() {
+				i := diskMaps[j].NewIterator()
+				defer i.Close()
+				numRead := 0
+				for i.Rewind(); ; i.Next() {
+					if ok, err := i.Valid(); err != nil {
+						t.Fatal(err)
+					} else if !ok {
+						break
+					}
+					numRead++
+					if numRead > numKeys {
+						t.Fatal("read too many keys")
+					}
+					if int(i.Value()[0]) != j {
+						t.Fatalf(
+							"key %s in %d's keyspace was clobbered by %d", i.Key(), j, i.Value()[0],
+						)
+					}
+				}
+				if numRead < numKeys {
+					t.Fatalf("only read %d keys in %d's keyspace", numRead, j)
+				}
+			}()
+		}
+	})
+
+	// Verify that a diskMap cleans up its keyspace when closed.
+	t.Run("KeyspaceDelete", func(t *testing.T) {
+		for j := 0; j < len(diskMaps); j++ {
+			diskMaps[j].Close(ctx)
+			numKeysRemaining := 0
+			func() {
+				i := e.(*pebbleTempEngine).db.NewIter(&pebble.IterOptions{UpperBound: roachpb.KeyMax})
+				defer func() {
+					if err := i.Close(); err != nil {
+						t.Fatal(err)
+					}
+				}()
+				for i.SeekGE(EncodeKey(NilKey)); ; i.Next() {
+					if !i.Valid() {
+						break
+					}
+					if int(i.Value()[0]) == j {
+						t.Fatalf("key %s belonging to %d was not deleted", i.Key(), j)
+					}
+					numKeysRemaining++
+				}
+				expectedKeysRemaining := (len(diskMaps) - 1 - j) * numKeys
+				if numKeysRemaining != expectedKeysRemaining {
+					t.Fatalf(
+						"expected %d keys to remain but counted %d",
+						expectedKeysRemaining,
+						numKeysRemaining,
+					)
+				}
+			}()
+		}
+	})
+}
+
+// TestPebbleStore tests that the allowDuplicates setting allows duplicate
+// keys to be put.
+func TestPebbleStore(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	dir, err := ioutil.TempDir("", "TestPebbleStore")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e, err := NewPebbleTempEngine(base.TempStorageConfig{Path: dir}, base.StoreSpec{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer e.Close()
+
+	var (
+		v1 = []byte("v1")
+		v2 = []byte("v2")
+		k1 = []byte("k1")
+	)
+
+	tests := []struct {
+		allowDuplicates bool
+		// expect is a map containing the expected number of found values for key k1.
+		expect map[string]int
+	}{
+		{
+			true,
+			map[string]int{
+				string(v1): 4,
+				string(v2): 2,
+			},
+		},
+		{
+			false,
+			map[string]int{
+				string(v1): 1,
+				// v1 is the final Put, so it should overwrite the previous v2.
+				string(v2): 0,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("AllowDuplicates=%v", tc.allowDuplicates), func(t *testing.T) {
+			var diskStore diskmap.SortedDiskMap
+			if tc.allowDuplicates {
+				diskStore = e.NewSortedDiskMultiMap()
+			} else {
+				diskStore = e.NewSortedDiskMap()
+			}
+			defer diskStore.Close(ctx)
+
+			batchWriter := diskStore.NewBatchWriter()
+			_ = diskStore.Put(k1, v1)
+			_ = diskStore.Put(k1, v1)
+			_ = diskStore.Put(k1, v2)
+			_ = batchWriter.Put(k1, v2)
+			_ = batchWriter.Put(k1, v1)
+			_ = batchWriter.Put(k1, v1)
+			if err := batchWriter.Close(ctx); err != nil {
+				t.Fatal(err)
+			}
+
+			i := diskStore.NewIterator()
+			defer i.Close()
+
+			for i.Rewind(); ; i.Next() {
+				if ok, err := i.Valid(); err != nil {
+					t.Fatal(err)
+				} else if !ok {
+					break
+				}
+				if !bytes.Equal(i.Key(), k1) {
+					t.Fatalf("unexpected key: %s", i.Key())
+				}
+				tc.expect[string(i.Value())]--
+			}
+			for k, v := range tc.expect {
+				if v != 0 {
+					t.Errorf("expected 0, got %d for %s", v, k)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkPebbleMapWrite(b *testing.B) {
+	dir, err := ioutil.TempDir("", "BenchmarkPebbleMapWrite")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			b.Fatal(err)
+		}
+	}()
+	ctx := context.Background()
+	tempEngine, err := NewPebbleTempEngine(base.TempStorageConfig{Path: dir}, base.DefaultTestStoreSpec)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer tempEngine.Close()
+
+	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+
+	for _, inputSize := range []int{1 << 12, 1 << 14, 1 << 16, 1 << 18, 1 << 20} {
+		b.Run(fmt.Sprintf("InputSize%d", inputSize), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				func() {
+					diskMap := tempEngine.NewSortedDiskMap()
+					defer diskMap.Close(ctx)
+					batchWriter := diskMap.NewBatchWriter()
+					// This Close() flushes writes.
+					defer func() {
+						if err := batchWriter.Close(ctx); err != nil {
+							b.Fatal(err)
+						}
+					}()
+					for j := 0; j < inputSize; j++ {
+						k := fmt.Sprintf("%d", rng.Int())
+						v := fmt.Sprintf("%d", rng.Int())
+						if err := batchWriter.Put([]byte(k), []byte(v)); err != nil {
+							b.Fatal(err)
+						}
+					}
+				}()
+			}
+		})
+	}
+}
+
+func BenchmarkPebbleMapIteration(b *testing.B) {
+	if testing.Short() {
+		b.Skip("short flag")
+	}
+	dir, err := ioutil.TempDir("", "BenchmarkPebbleMapIteration")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			b.Fatal(err)
+		}
+	}()
+	tempEngine, err := NewPebbleTempEngine(base.TempStorageConfig{Path: dir}, base.DefaultTestStoreSpec)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer tempEngine.Close()
+
+	diskMap := tempEngine.NewSortedDiskMap()
+	defer diskMap.Close(context.Background())
+
+	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+	ctx := context.Background()
+
+	for _, inputSize := range []int{1 << 12, 1 << 14, 1 << 16, 1 << 18, 1 << 20} {
+		batchWriter := diskMap.NewBatchWriter()
+		defer func() {
+			if err := batchWriter.Close(ctx); err != nil {
+				b.Fatal(err)
+			}
+		}()
+
+		for i := 0; i < inputSize; i++ {
+			k := fmt.Sprintf("%d", rng.Int())
+			v := fmt.Sprintf("%d", rng.Int())
+			if err := batchWriter.Put([]byte(k), []byte(v)); err != nil {
+				b.Fatal(err)
+			}
+		}
+
+		if err := batchWriter.Flush(); err != nil {
+			b.Fatal(err)
 		}
 
 		b.Run(fmt.Sprintf("InputSize%d", inputSize), func(b *testing.B) {


### PR DESCRIPTION
This PR adds a disk-map implementation that uses pebble instead of rocksdb.
The rocksdb implementation is still default in the binary and the pebble
implementation isn't substituted anywhere except in unit tests and benchmarks.
Soon (or as part of this PR if that's seen as valuable), a runtime argument
could be added to the binary to switch between the two.

Relies on new commit in the vendor submodule that vendors pebble.

Release note: None