### PR TITLE
release-19.1: stop assigning GitHub test failures to me

### DIFF
--- a/pkg/cmd/internal/issues/issues.go
+++ b/pkg/cmd/internal/issues/issues.go
@@ -103,7 +103,9 @@ func trimIssueRequestBody(message string, usedCharacters int) string {
 // If the assignee would be the key in this map, assign to the value instead.
 // Helpful to avoid pinging former employees.
 var oldFriendsMap = map[string]string{
-	"tamird": "tschottdorf",
+	"a-robinson": "andreimatei",
+	"benesch":    "nvanbenschoten",
+	"tamird":     "tschottdorf",
 }
 
 func getAssignee(

--- a/pkg/cmd/internal/issues/issues.go
+++ b/pkg/cmd/internal/issues/issues.go
@@ -102,10 +102,13 @@ func trimIssueRequestBody(message string, usedCharacters int) string {
 
 // If the assignee would be the key in this map, assign to the value instead.
 // Helpful to avoid pinging former employees.
+// An "" value means that issues that would have gone to the key are left
+// unassigned.
 var oldFriendsMap = map[string]string{
-	"a-robinson": "andreimatei",
-	"benesch":    "nvanbenschoten",
-	"tamird":     "tschottdorf",
+	"a-robinson":   "andreimatei",
+	"benesch":      "nvanbenschoten",
+	"tamird":       "tbg",
+	"vivekmenezes": "",
 }
 
 func getAssignee(
@@ -136,6 +139,9 @@ func getAssignee(
 	assignee := *commits[0].Author.Login
 
 	if newAssignee, ok := oldFriendsMap[assignee]; ok {
+		if newAssignee == "" {
+			return "", fmt.Errorf("old friend %s is friendless", assignee)
+		}
 		assignee = newAssignee
 	}
 	return assignee, nil
@@ -304,9 +310,6 @@ Failed test: %[3]s`
 
 	assignee, err := getAssignee(ctx, authorEmail, p.listCommits)
 	if err != nil {
-		// if we *can't* assign anyone, sigh, feel free to hard-code me.
-		// -- tbg, 11/3/2017
-		assignee = "tbg"
 		message += fmt.Sprintf("\n\nFailed to find issue assignee: \n%s", err)
 	}
 


### PR DESCRIPTION
https://github.com/cockroachdb/cockroach/issues/39258 made me realize that the oldFriendsMap was missing a few entries on the 19.1 branch.

Backport:
  * 1/1 commits from "issues: add a few old friends" (#36143)
  * 1/1 commits from "issues: introduce friendless old friends" (#38737)

Please see individual PRs for details.

/cc @cockroachdb/release