### PR TITLE
roachtest: use --insert-count instead of --record-count in YCSB

### DIFF
--- a/pkg/cmd/roachtest/ycsb.go
+++ b/pkg/cmd/roachtest/ycsb.go
@@ -29,7 +29,7 @@ func registerYCSB(r *testRegistry) {
 			ramp := " --ramp=" + ifLocal("0s", "1m")
 			duration := " --duration=" + ifLocal("10s", "10m")
 			cmd := fmt.Sprintf(
-				"./workload run ycsb --init --record-count=1000000 --splits=100"+
+				"./workload run ycsb --init --insert-count=1000000 --splits=100"+
 					" --workload=%s --concurrency=64 --histograms="+perfArtifactsDir+"/stats.json"+
 					ramp+duration+" {pgurl:1-%d}",
 				wl, nodes)


### PR DESCRIPTION
#38043 used the wrong flag and this caused the roachtest to insert
10000 keys and generate them starting at index 1000000 instead of
inserting 1000000 keys and generating them starting from index 1000000.

Release note: None

Also probably addresses #38125 because this flag was the only functional thing that changed about the roachtest from #38043.