### PR TITLE
sql: add explain(vec)

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2472,7 +2472,7 @@ func (dsp *DistSQLPlanner) wrapPlan(planCtx *PlanningCtx, n planNode) (PhysicalP
 	if err := walkPlan(planCtx.ctx, n, planObserver{
 		enterNode: func(ctx context.Context, nodeName string, plan planNode) (bool, error) {
 			switch plan.(type) {
-			case *explainDistSQLNode, *explainPlanNode:
+			case *explainDistSQLNode, *explainPlanNode, *explainVecNode:
 				// Don't continue recursing into explain nodes - they need to be left
 				// alone since they handle their own planning later.
 				return false, nil

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -147,7 +147,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 			// TODO(yuzefovich): this is a safe but quite inefficient way of setting
 			// up vectorized flows since the flows will effectively be planned twice.
 			for _, spec := range flows {
-				if err := distsqlrun.SupportsVectorized(
+				if _, err := distsqlrun.SupportsVectorized(
 					ctx, &distsqlrun.FlowCtx{
 						EvalCtx: &evalCtx.EvalContext,
 						Cfg:     &distsqlrun.ServerConfig{},

--- a/pkg/sql/distsqlrun/colbatch_scan.go
+++ b/pkg/sql/distsqlrun/colbatch_scan.go
@@ -34,6 +34,7 @@ import (
 // colBatchScan is the exec.Operator implementation of TableReader. It reads a table
 // from kv, presenting it as coldata.Batches via the exec.Operator interface.
 type colBatchScan struct {
+	exec.ZeroInputNode
 	spans     roachpb.Spans
 	flowCtx   *FlowCtx
 	rf        *row.CFetcher

--- a/pkg/sql/distsqlrun/column_exec_setup_test.go
+++ b/pkg/sql/distsqlrun/column_exec_setup_test.go
@@ -199,7 +199,8 @@ func TestDrainOnlyInputDAG(t *testing.T) {
 
 	acc := evalCtx.Mon.MakeBoundAccount()
 	defer acc.Close(ctx)
-	require.NoError(t, vfc.setupFlow(context.Background(), &f.FlowCtx, procs, &acc))
+	_, err := vfc.setupFlow(context.Background(), &f.FlowCtx, procs, &acc)
+	require.NoError(t, err)
 
 	// Verify that an outbox was actually created.
 	require.True(t, outboxCreated)

--- a/pkg/sql/distsqlrun/columnarizer.go
+++ b/pkg/sql/distsqlrun/columnarizer.go
@@ -26,6 +26,7 @@ import (
 // chunk into a coldata.Batch column by column.
 type columnarizer struct {
 	ProcessorBase
+	exec.ZeroInputNode
 
 	input RowSource
 	da    sqlbase.DatumAlloc

--- a/pkg/sql/distsqlrun/materializer.go
+++ b/pkg/sql/distsqlrun/materializer.go
@@ -12,6 +12,7 @@ package distsqlrun
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec"
@@ -121,6 +122,19 @@ func newMaterializer(
 	m.finishTrace = outputStatsToTrace
 	m.cancelFlow = cancelFlow
 	return m, nil
+}
+
+var _ exec.OpNode = &materializer{}
+
+func (m *materializer) ChildCount() int {
+	return 1
+}
+
+func (m *materializer) Child(nth int) exec.OpNode {
+	if nth == 0 {
+		return m.input
+	}
+	panic(fmt.Sprintf("invalid index %d", nth))
 }
 
 func (m *materializer) Start(ctx context.Context) context.Context {

--- a/pkg/sql/distsqlrun/vectorized_error_propagation_test.go
+++ b/pkg/sql/distsqlrun/vectorized_error_propagation_test.go
@@ -147,7 +147,7 @@ func TestNonVectorizedErrorPropagation(t *testing.T) {
 // on every even-numbered (i.e. it becomes a noop for those iterations). Used
 // for tests only.
 type testNonVectorizedErrorEmitter struct {
-	input     exec.Operator
+	exec.OneInputNode
 	emitBatch bool
 }
 
@@ -155,12 +155,12 @@ var _ exec.Operator = &testNonVectorizedErrorEmitter{}
 
 // newTestVectorizedErrorEmitter creates a new TestVectorizedErrorEmitter.
 func newTestVectorizedErrorEmitter(input exec.Operator) exec.Operator {
-	return &testNonVectorizedErrorEmitter{input: input}
+	return &testNonVectorizedErrorEmitter{OneInputNode: exec.NewOneInputNode(input)}
 }
 
 // Init is part of exec.Operator interface.
 func (e *testNonVectorizedErrorEmitter) Init() {
-	e.input.Init()
+	e.Input().Init()
 }
 
 // Next is part of exec.Operator interface.
@@ -171,5 +171,5 @@ func (e *testNonVectorizedErrorEmitter) Next(ctx context.Context) coldata.Batch 
 	}
 
 	e.emitBatch = false
-	return e.input.Next(ctx)
+	return e.Input().Next(ctx)
 }

--- a/pkg/sql/exec/aggregator.go
+++ b/pkg/sql/exec/aggregator.go
@@ -84,7 +84,7 @@ type aggregateFunc interface {
 // output batch if a worst case input batch is encountered (one where every
 // value is part of a new group).
 type orderedAggregator struct {
-	input Operator
+	OneInputNode
 
 	done bool
 
@@ -154,7 +154,7 @@ func NewOrderedAggregator(
 		// mark the first row as distinct, so we have to do it ourselves. Set up a
 		// oneShotOp to set the first row to distinct.
 		op = &oneShotOp{
-			input: op,
+			OneInputNode: NewOneInputNode(op),
 			fn: func(batch coldata.Batch) {
 				if batch.Length() == 0 {
 					return
@@ -170,7 +170,7 @@ func NewOrderedAggregator(
 	}
 
 	*a = orderedAggregator{
-		input: op,
+		OneInputNode: NewOneInputNode(op),
 
 		aggCols:  aggCols,
 		aggTypes: aggTypes,

--- a/pkg/sql/exec/bool_vec_to_sel.go
+++ b/pkg/sql/exec/bool_vec_to_sel.go
@@ -19,7 +19,7 @@ import (
 // boolVecToSelOp transforms a boolean column into a selection vector by adding
 // an index to the selection for each true value in the boolean column.
 type boolVecToSelOp struct {
-	input Operator
+	OneInputNode
 
 	// outputCol is the boolean output column. It should be shared by other
 	// operators that write to it.
@@ -101,8 +101,8 @@ func boolVecToSel64(vec []bool, sel []uint64) []uint64 {
 // based on a boolean column that *isn't* in a batch, just create a
 // boolVecToSelOp directly with the desired boolean slice.
 func NewBoolVecToSelOp(input Operator, colIdx int) Operator {
-	d := selBoolOp{input: input, colIdx: colIdx}
-	ret := &boolVecToSelOp{input: &d}
+	d := selBoolOp{OneInputNode: NewOneInputNode(input), colIdx: colIdx}
+	ret := &boolVecToSelOp{OneInputNode: NewOneInputNode(&d)}
 	d.boolVecToSelOp = ret
 	return ret
 }
@@ -110,7 +110,7 @@ func NewBoolVecToSelOp(input Operator, colIdx int) Operator {
 // selBoolOp is a small helper operator that transforms a boolVecToSelOp into
 // an operator that can see the inside of its input batch for NewBoolVecToSelOp.
 type selBoolOp struct {
-	input          Operator
+	OneInputNode
 	boolVecToSelOp *boolVecToSelOp
 	colIdx         int
 }

--- a/pkg/sql/exec/builtin_funcs.go
+++ b/pkg/sql/exec/builtin_funcs.go
@@ -22,7 +22,7 @@ import (
 )
 
 type defaultBuiltinFuncOperator struct {
-	input          Operator
+	OneInputNode
 	evalCtx        *tree.EvalContext
 	funcExpr       *tree.FuncExpr
 	columnTypes    []semtypes.T
@@ -113,7 +113,7 @@ func NewBuiltinFunctionOperator(
 	// For now, return the default builtin operator. Future work can specialize
 	// out the operators to efficient implementations of specific builtins.
 	return &defaultBuiltinFuncOperator{
-		input:          input,
+		OneInputNode:   NewOneInputNode(input),
 		evalCtx:        evalCtx,
 		funcExpr:       funcExpr,
 		outputIdx:      outputIdx,

--- a/pkg/sql/exec/cancel_checker.go
+++ b/pkg/sql/exec/cancel_checker.go
@@ -20,24 +20,29 @@ import (
 // CancelChecker is an Operator that checks whether query cancellation has
 // occurred. The check happens on every batch.
 type CancelChecker struct {
-	Operator
+	OneInputNode
 
 	// Number of times check() has been called since last context cancellation
 	// check.
 	callsSinceLastCheck uint32
 }
 
+// Init is part of the Operator interface.
+func (c *CancelChecker) Init() {
+	c.input.Init()
+}
+
 var _ Operator = &CancelChecker{}
 
 // NewCancelChecker creates a new CancelChecker.
 func NewCancelChecker(op Operator) *CancelChecker {
-	return &CancelChecker{Operator: op}
+	return &CancelChecker{OneInputNode: NewOneInputNode(op)}
 }
 
 // Next is part of Operator interface.
 func (c *CancelChecker) Next(ctx context.Context) coldata.Batch {
 	c.checkEveryCall(ctx)
-	return c.Operator.Next(ctx)
+	return c.input.Next(ctx)
 }
 
 // Interval of check() calls to wait between checks for context cancellation.

--- a/pkg/sql/exec/coalescer.go
+++ b/pkg/sql/exec/coalescer.go
@@ -20,7 +20,8 @@ import (
 // coalescerOp consumes the input operator and coalesces the resulting batches
 // to return full batches of col.BatchSize.
 type coalescerOp struct {
-	input      Operator
+	OneInputNode
+
 	inputTypes []types.T
 
 	group  coldata.Batch
@@ -34,8 +35,8 @@ var _ StaticMemoryOperator = &coalescerOp{}
 // with the given column types.
 func NewCoalescerOp(input Operator, colTypes []types.T) Operator {
 	return &coalescerOp{
-		input:      input,
-		inputTypes: colTypes,
+		OneInputNode: NewOneInputNode(input),
+		inputTypes:   colTypes,
 	}
 }
 

--- a/pkg/sql/exec/coalescer_test.go
+++ b/pkg/sql/exec/coalescer_test.go
@@ -89,8 +89,8 @@ func BenchmarkCoalescer(b *testing.B) {
 				source := newRandomLengthBatchSource(batch)
 
 				co := &coalescerOp{
-					input:      source,
-					inputTypes: sourceTypes,
+					OneInputNode: NewOneInputNode(source),
+					inputTypes:   sourceTypes,
 				}
 
 				co.Init()

--- a/pkg/sql/exec/colrpc/inbox.go
+++ b/pkg/sql/exec/colrpc/inbox.go
@@ -43,6 +43,7 @@ type flowStreamServer interface {
 // RunWithStream (or more specifically, the RPC handler) will unblock Next by
 // closing the stream.
 type Inbox struct {
+	exec.ZeroInputNode
 	typs []types.T
 
 	zeroBatch coldata.Batch

--- a/pkg/sql/exec/const_tmpl.go
+++ b/pkg/sql/exec/const_tmpl.go
@@ -53,10 +53,10 @@ func NewConstOp(input Operator, t types.T, constVal interface{}, outputIdx int) 
 	// {{range .}}
 	case _TYPES_T:
 		return &const_TYPEOp{
-			input:     input,
-			outputIdx: outputIdx,
-			typ:       t,
-			constVal:  constVal.(_GOTYPE),
+			OneInputNode: NewOneInputNode(input),
+			outputIdx:    outputIdx,
+			typ:          t,
+			constVal:     constVal.(_GOTYPE),
 		}, nil
 	// {{end}}
 	default:
@@ -67,7 +67,7 @@ func NewConstOp(input Operator, t types.T, constVal interface{}, outputIdx int) 
 // {{range .}}
 
 type const_TYPEOp struct {
-	input Operator
+	OneInputNode
 
 	typ       types.T
 	outputIdx int
@@ -107,13 +107,13 @@ func (c const_TYPEOp) Next(ctx context.Context) coldata.Batch {
 // value at index outputIdx.
 func NewConstNullOp(input Operator, outputIdx int) Operator {
 	return &constNullOp{
-		input:     input,
-		outputIdx: outputIdx,
+		OneInputNode: NewOneInputNode(input),
+		outputIdx:    outputIdx,
 	}
 }
 
 type constNullOp struct {
-	input     Operator
+	OneInputNode
 	outputIdx int
 }
 

--- a/pkg/sql/exec/count.go
+++ b/pkg/sql/exec/count.go
@@ -22,7 +22,7 @@ import (
 // column containing a single integer, the count of rows received from the
 // upstream.
 type countOp struct {
-	input Operator
+	OneInputNode
 
 	internalBatch coldata.Batch
 	done          bool
@@ -35,7 +35,7 @@ var _ StaticMemoryOperator = &countOp{}
 // NewCountOp returns a new count operator that counts the rows in its input.
 func NewCountOp(input Operator) Operator {
 	c := &countOp{
-		input: input,
+		OneInputNode: NewOneInputNode(input),
 	}
 	c.internalBatch = coldata.NewMemBatchWithSize([]types.T{types.Int64}, 1)
 	return c

--- a/pkg/sql/exec/deselector.go
+++ b/pkg/sql/exec/deselector.go
@@ -22,7 +22,7 @@ import (
 // or omitted according to the selection vector). If the batches come with no
 // selection vector, it is a noop.
 type deselectorOp struct {
-	input      Operator
+	OneInputNode
 	inputTypes []types.T
 
 	output coldata.Batch
@@ -34,8 +34,8 @@ var _ Operator = &deselectorOp{}
 // operator with the given column types.
 func NewDeselectorOp(input Operator, colTypes []types.T) Operator {
 	return &deselectorOp{
-		input:      input,
-		inputTypes: colTypes,
+		OneInputNode: NewOneInputNode(input),
+		inputTypes:   colTypes,
 	}
 }
 

--- a/pkg/sql/exec/error.go
+++ b/pkg/sql/exec/error.go
@@ -104,7 +104,7 @@ func isPanicFromVectorizedEngine(panicEmittedFrom string) bool {
 // even-numbered (i.e. it becomes a noop for those iterations). Used for tests
 // only.
 type TestVectorizedErrorEmitter struct {
-	input     Operator
+	OneInputNode
 	emitBatch bool
 }
 
@@ -112,7 +112,7 @@ var _ Operator = &TestVectorizedErrorEmitter{}
 
 // NewTestVectorizedErrorEmitter creates a new TestVectorizedErrorEmitter.
 func NewTestVectorizedErrorEmitter(input Operator) Operator {
-	return &TestVectorizedErrorEmitter{input: input}
+	return &TestVectorizedErrorEmitter{OneInputNode: NewOneInputNode(input)}
 }
 
 // Init is part of Operator interface.

--- a/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
@@ -44,7 +44,7 @@ import (
 {{range .}}
 
 type {{template "opRConstName" .}} struct {
-	input Operator
+	OneInputNode
 
 	colIdx   int
 	constArg {{.RGoType}}
@@ -92,7 +92,7 @@ func (p {{template "opRConstName" .}}) Init() {
 }
 
 type {{template "opLConstName" .}} struct {
-	input Operator
+	OneInputNode
 
 	colIdx   int
 	constArg {{.LGoType}}
@@ -140,7 +140,7 @@ func (p {{template "opLConstName" .}}) Init() {
 }
 
 type {{template "opName" .}} struct {
-	input Operator
+	OneInputNode
 
 	col1Idx int
 	col2Idx int
@@ -219,7 +219,7 @@ func GetProjection{{if $left}}L{{else}}R{{end}}ConstOperator(
 			{{if .IsBinOp}}
 			case tree.{{.Name}}:
 				return &{{if $left}}{{template "opLConstName" .}}{{else}}{{template "opRConstName" .}}{{end}}{
-					input:    input,
+					OneInputNode: NewOneInputNode(input),
 					colIdx:   colIdx,
 					constArg: c.({{if $left}}{{.LGoType}}{{else}}{{.RGoType}}{{end}}),
 					outputIdx: outputIdx,
@@ -235,7 +235,7 @@ func GetProjection{{if $left}}L{{else}}R{{end}}ConstOperator(
 			{{if .IsCmpOp}}
 			case tree.{{.Name}}:
 				return &{{if $left}}{{template "opLConstName" .}}{{else}}{{template "opRConstName" .}}{{end}}{
-					input:    input,
+					OneInputNode: NewOneInputNode(input),
 					colIdx:   colIdx,
 					constArg: c.({{if $left}}{{.LGoType}}{{else}}{{.RGoType}}{{end}}),
 					outputIdx: outputIdx,
@@ -275,7 +275,7 @@ func GetProjectionOperator(
 			{{if .IsBinOp}}
 			case tree.{{.Name}}:
 				return &{{template "opName" .}}{
-					input:    input,
+					OneInputNode: NewOneInputNode(input),
 					col1Idx:   col1Idx,
 					col2Idx:   col2Idx,
 					outputIdx: outputIdx,
@@ -291,7 +291,7 @@ func GetProjectionOperator(
 			{{if .IsCmpOp}}
 			case tree.{{.Name}}:
 				return &{{template "opName" .}}{
-					input:    input,
+					OneInputNode: NewOneInputNode(input),
 					col1Idx:   col1Idx,
 					col2Idx:   col2Idx,
 					outputIdx: outputIdx,

--- a/pkg/sql/exec/execgen/cmd/execgen/selection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/selection_ops_gen.go
@@ -91,7 +91,7 @@ if sel := batch.Selection(); sel != nil {
 
 {{define "selConstOp"}}
 type {{template "opConstName" .}} struct {
-	input Operator
+	OneInputNode
 
 	colIdx   int
 	constArg {{.RGoType}}
@@ -128,7 +128,7 @@ func (p {{template "opConstName" .}}) Init() {
 
 {{define "selOp"}}
 type {{template "opName" .}} struct {
-	input Operator
+	OneInputNode
 
 	col1Idx int
 	col2Idx int
@@ -195,7 +195,7 @@ func GetSelectionConstOperator(
 		{{range $overloads}}
 		case tree.{{.Name}}:
 			return &{{template "opConstName" .}}{
-				input:    input,
+				OneInputNode: NewOneInputNode(input),
 				colIdx:   colIdx,
 				constArg: c.({{.RGoType}}),
 			}, nil
@@ -225,7 +225,7 @@ func GetSelectionOperator(
 		{{range $overloads}}
 		case tree.{{.Name}}:
 			return &{{template "opName" .}}{
-				input:   input,
+				OneInputNode: NewOneInputNode(input),
 				col1Idx: col1Idx,
 				col2Idx: col2Idx,
 			}, nil

--- a/pkg/sql/exec/fn_op.go
+++ b/pkg/sql/exec/fn_op.go
@@ -19,7 +19,7 @@ import (
 // fnOp is an operator that executes an arbitrary function for its side-effects,
 // once per input batch, passing the input batch unmodified along.
 type fnOp struct {
-	input Operator
+	OneInputNode
 
 	fn func()
 }

--- a/pkg/sql/exec/hashjoiner.go
+++ b/pkg/sql/exec/hashjoiner.go
@@ -12,6 +12,7 @@ package exec
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
@@ -188,6 +189,20 @@ type hashJoinEqOp struct {
 	emittingUnmatchedState struct {
 		rowIdx uint64
 	}
+}
+
+func (hj *hashJoinEqOp) ChildCount() int {
+	return 2
+}
+
+func (hj *hashJoinEqOp) Child(nth int) OpNode {
+	switch nth {
+	case 0:
+		return hj.spec.left.source
+	case 1:
+		return hj.spec.right.source
+	}
+	panic(fmt.Sprintf("invalid idx %d", nth))
 }
 
 var _ Operator = &hashJoinEqOp{}

--- a/pkg/sql/exec/like_ops.go
+++ b/pkg/sql/exec/like_ops.go
@@ -25,15 +25,15 @@ func GetLikeOperator(
 	if pattern == "" {
 		if negate {
 			return &selNEBytesBytesConstOp{
-				input:    input,
-				colIdx:   colIdx,
-				constArg: []byte{},
+				OneInputNode: NewOneInputNode(input),
+				colIdx:       colIdx,
+				constArg:     []byte{},
 			}, nil
 		}
 		return &selEQBytesBytesConstOp{
-			input:    input,
-			colIdx:   colIdx,
-			constArg: []byte{},
+			OneInputNode: NewOneInputNode(input),
+			colIdx:       colIdx,
+			constArg:     []byte{},
 		}, nil
 	}
 	if pattern == "%" {
@@ -54,45 +54,45 @@ func GetLikeOperator(
 			// No wildcards, so this is just an exact string match.
 			if negate {
 				return &selNEBytesBytesConstOp{
-					input:    input,
-					colIdx:   colIdx,
-					constArg: []byte(pattern),
+					OneInputNode: NewOneInputNode(input),
+					colIdx:       colIdx,
+					constArg:     []byte(pattern),
 				}, nil
 			}
 			return &selEQBytesBytesConstOp{
-				input:    input,
-				colIdx:   colIdx,
-				constArg: []byte(pattern),
+				OneInputNode: NewOneInputNode(input),
+				colIdx:       colIdx,
+				constArg:     []byte(pattern),
 			}, nil
 		}
 		if firstChar == '%' && !isWildcard(lastChar) {
 			suffix := []byte(pattern[1:])
 			if negate {
 				return &selNotSuffixBytesBytesConstOp{
-					input:    input,
-					colIdx:   colIdx,
-					constArg: suffix,
+					OneInputNode: NewOneInputNode(input),
+					colIdx:       colIdx,
+					constArg:     suffix,
 				}, nil
 			}
 			return &selSuffixBytesBytesConstOp{
-				input:    input,
-				colIdx:   colIdx,
-				constArg: suffix,
+				OneInputNode: NewOneInputNode(input),
+				colIdx:       colIdx,
+				constArg:     suffix,
 			}, nil
 		}
 		if lastChar == '%' && !isWildcard(firstChar) {
 			prefix := []byte(pattern[:len(pattern)-1])
 			if negate {
 				return &selNotPrefixBytesBytesConstOp{
-					input:    input,
-					colIdx:   colIdx,
-					constArg: prefix,
+					OneInputNode: NewOneInputNode(input),
+					colIdx:       colIdx,
+					constArg:     prefix,
 				}, nil
 			}
 			return &selPrefixBytesBytesConstOp{
-				input:    input,
-				colIdx:   colIdx,
-				constArg: prefix,
+				OneInputNode: NewOneInputNode(input),
+				colIdx:       colIdx,
+				constArg:     prefix,
 			}, nil
 		}
 	}
@@ -103,15 +103,15 @@ func GetLikeOperator(
 	}
 	if negate {
 		return &selNotRegexpBytesBytesConstOp{
-			input:    input,
-			colIdx:   colIdx,
-			constArg: re,
+			OneInputNode: NewOneInputNode(input),
+			colIdx:       colIdx,
+			constArg:     re,
 		}, nil
 	}
 	return &selRegexpBytesBytesConstOp{
-		input:    input,
-		colIdx:   colIdx,
-		constArg: re,
+		OneInputNode: NewOneInputNode(input),
+		colIdx:       colIdx,
+		constArg:     re,
 	}, nil
 }
 

--- a/pkg/sql/exec/like_ops_test.go
+++ b/pkg/sql/exec/like_ops_test.go
@@ -120,20 +120,20 @@ func BenchmarkLikeOps(b *testing.B) {
 	source.Init()
 
 	prefixOp := &selPrefixBytesBytesConstOp{
-		input:    source,
-		colIdx:   0,
-		constArg: []byte(prefix),
+		OneInputNode: NewOneInputNode(source),
+		colIdx:       0,
+		constArg:     []byte(prefix),
 	}
 	suffixOp := &selSuffixBytesBytesConstOp{
-		input:    source,
-		colIdx:   0,
-		constArg: []byte(suffix),
+		OneInputNode: NewOneInputNode(source),
+		colIdx:       0,
+		constArg:     []byte(suffix),
 	}
 	pattern := fmt.Sprintf("^%s.*%s$", prefix, suffix)
 	regexpOp := &selRegexpBytesBytesConstOp{
-		input:    source,
-		colIdx:   0,
-		constArg: regexp.MustCompile(pattern),
+		OneInputNode: NewOneInputNode(source),
+		colIdx:       0,
+		constArg:     regexp.MustCompile(pattern),
 	}
 
 	testCases := []struct {

--- a/pkg/sql/exec/limit.go
+++ b/pkg/sql/exec/limit.go
@@ -19,7 +19,7 @@ import (
 // limitOp is an operator that implements limit, returning only the first n
 // tuples from its input.
 type limitOp struct {
-	input Operator
+	OneInputNode
 
 	internalBatch coldata.Batch
 	limit         uint64
@@ -35,8 +35,8 @@ var _ Operator = &limitOp{}
 // NewLimitOp returns a new limit operator with the given limit.
 func NewLimitOp(input Operator, limit uint64) Operator {
 	c := &limitOp{
-		input: input,
-		limit: limit,
+		OneInputNode: NewOneInputNode(input),
+		limit:        limit,
 	}
 	return c
 }

--- a/pkg/sql/exec/mergejoiner.go
+++ b/pkg/sql/exec/mergejoiner.go
@@ -153,6 +153,7 @@ type mergeJoinInput struct {
 // feedOperator is used to feed the distincter with input by manually setting
 // the next batch.
 type feedOperator struct {
+	ZeroInputNode
 	batch coldata.Batch
 }
 
@@ -268,6 +269,7 @@ func newMergeJoinBase(
 	}
 
 	base := mergeJoinBase{
+		twoInputNode: newTwoInputNode(left, right),
 		left: mergeJoinInput{
 			source:      left,
 			outCols:     leftOutCols,
@@ -298,6 +300,7 @@ func newMergeJoinBase(
 
 // mergeJoinBase extract the common logic between all merge join operators.
 type mergeJoinBase struct {
+	twoInputNode
 	left  mergeJoinInput
 	right mergeJoinInput
 

--- a/pkg/sql/exec/offset.go
+++ b/pkg/sql/exec/offset.go
@@ -19,7 +19,7 @@ import (
 // offsetOp is an operator that implements offset, returning everything
 // after the first n tuples in its input.
 type offsetOp struct {
-	input Operator
+	OneInputNode
 
 	offset uint64
 
@@ -32,8 +32,8 @@ var _ Operator = &offsetOp{}
 // NewOffsetOp returns a new offset operator with the given offset.
 func NewOffsetOp(input Operator, offset uint64) Operator {
 	c := &offsetOp{
-		input:  input,
-		offset: offset,
+		OneInputNode: NewOneInputNode(input),
+		offset:       offset,
 	}
 	return c
 }

--- a/pkg/sql/exec/one_shot.go
+++ b/pkg/sql/exec/one_shot.go
@@ -20,7 +20,7 @@ import (
 // that it gets, then deletes itself from the operator tree. This is useful for
 // first-Next initialization that has to happen in an operator.
 type oneShotOp struct {
-	input Operator
+	OneInputNode
 
 	outputSourceRef *Operator
 

--- a/pkg/sql/exec/orderedsynchronizer.go
+++ b/pkg/sql/exec/orderedsynchronizer.go
@@ -21,6 +21,7 @@ import (
 )
 
 var _ StaticMemoryOperator = &OrderedSynchronizer{}
+var _ Operator = &OrderedSynchronizer{}
 
 // OrderedSynchronizer receives rows from multiple inputs and produces a single
 // stream of rows, ordered according to a set of columns. The rows in each input
@@ -37,6 +38,16 @@ type OrderedSynchronizer struct {
 	// comparators stores one comparator per ordering column.
 	comparators []vecComparator
 	output      coldata.Batch
+}
+
+// ChildCount implements the OpNode interface.
+func (o *OrderedSynchronizer) ChildCount() int {
+	return len(o.inputs)
+}
+
+// Child implements the OpNode interface.
+func (o *OrderedSynchronizer) Child(nth int) OpNode {
+	return o.inputs[nth]
 }
 
 // NewOrderedSynchronizer creates a new OrderedSynchronizer.

--- a/pkg/sql/exec/ordinality.go
+++ b/pkg/sql/exec/ordinality.go
@@ -20,7 +20,7 @@ import (
 // ordinalityOp is an operator that implements WITH ORDINALITY, which adds
 // an additional column to the result with an ordinal number.
 type ordinalityOp struct {
-	input Operator
+	OneInputNode
 
 	// ordinalityCol is the index of the column in which ordinalityOp will write
 	// the ordinal number. It is colNotAppended if the column has not been
@@ -37,7 +37,7 @@ const colNotAppended = -1
 // NewOrdinalityOp returns a new WITH ORDINALITY operator.
 func NewOrdinalityOp(input Operator) Operator {
 	c := &ordinalityOp{
-		input:         input,
+		OneInputNode:  NewOneInputNode(input),
 		ordinalityCol: colNotAppended,
 		counter:       1,
 	}

--- a/pkg/sql/exec/partitioner.go
+++ b/pkg/sql/exec/partitioner.go
@@ -46,11 +46,15 @@ func NewWindowSortingPartitioner(
 		return nil, err
 	}
 
-	return &windowSortingPartitioner{input: input, distinctCol: distinctCol, partitionColIdx: partitionColIdx}, nil
+	return &windowSortingPartitioner{
+		OneInputNode:    NewOneInputNode(input),
+		distinctCol:     distinctCol,
+		partitionColIdx: partitionColIdx,
+	}, nil
 }
 
 type windowSortingPartitioner struct {
-	input Operator
+	OneInputNode
 
 	// distinctCol is the output column of the chain of ordered distinct
 	// operators in which true will indicate that a new partition begins with the

--- a/pkg/sql/exec/projection_ops_test.go
+++ b/pkg/sql/exec/projection_ops_test.go
@@ -27,10 +27,10 @@ func TestProjPlusInt64Int64ConstOp(t *testing.T) {
 	runTests(t, []tuples{{{1}, {2}, {nil}}}, tuples{{1, 2}, {2, 3}, {nil, nil}}, orderedVerifier,
 		[]int{0, 1}, func(input []Operator) (Operator, error) {
 			return &projPlusInt64Int64ConstOp{
-				input:     input[0],
-				colIdx:    0,
-				constArg:  1,
-				outputIdx: 1,
+				OneInputNode: NewOneInputNode(input[0]),
+				colIdx:       0,
+				constArg:     1,
+				outputIdx:    1,
 			}, nil
 		})
 }
@@ -40,10 +40,10 @@ func TestProjPlusInt64Int64Op(t *testing.T) {
 		orderedVerifier, []int{0, 1, 2},
 		func(input []Operator) (Operator, error) {
 			return &projPlusInt64Int64Op{
-				input:     input[0],
-				col1Idx:   0,
-				col2Idx:   1,
-				outputIdx: 2,
+				OneInputNode: NewOneInputNode(input[0]),
+				col1Idx:      0,
+				col2Idx:      1,
+				outputIdx:    2,
 			}, nil
 		})
 }
@@ -75,10 +75,10 @@ func benchmarkProjPlusInt64Int64ConstOp(b *testing.B, useSelectionVector bool, h
 	source.Init()
 
 	plusOp := &projPlusInt64Int64ConstOp{
-		input:     source,
-		colIdx:    0,
-		constArg:  1,
-		outputIdx: 1,
+		OneInputNode: NewOneInputNode(source),
+		colIdx:       0,
+		constArg:     1,
+		outputIdx:    1,
 	}
 	plusOp.Init()
 
@@ -110,10 +110,10 @@ func TestGetProjectionConstOperator(t *testing.T) {
 		t.Error(err)
 	}
 	expected := &projMultFloat64Float64ConstOp{
-		input:     input,
-		colIdx:    colIdx,
-		constArg:  constVal,
-		outputIdx: outputIdx,
+		OneInputNode: NewOneInputNode(input),
+		colIdx:       colIdx,
+		constArg:     constVal,
+		outputIdx:    outputIdx,
 	}
 	if !reflect.DeepEqual(op, expected) {
 		t.Errorf("got %+v, expected %+v", op, expected)
@@ -132,10 +132,10 @@ func TestGetProjectionOperator(t *testing.T) {
 		t.Error(err)
 	}
 	expected := &projMultInt16Int16Op{
-		input:     input,
-		col1Idx:   col1Idx,
-		col2Idx:   col2Idx,
-		outputIdx: outputIdx,
+		OneInputNode: NewOneInputNode(input),
+		col1Idx:      col1Idx,
+		col2Idx:      col2Idx,
+		outputIdx:    outputIdx,
 	}
 	if !reflect.DeepEqual(op, expected) {
 		t.Errorf("got %+v, expected %+v", op, expected)
@@ -191,34 +191,34 @@ func BenchmarkProjOp(b *testing.B) {
 	projOpMap := map[string]func(*RepeatableBatchSource) Operator{
 		"projPlusInt64Int64Op": func(source *RepeatableBatchSource) Operator {
 			return &projPlusInt64Int64Op{
-				input:     source,
-				col1Idx:   0,
-				col2Idx:   1,
-				outputIdx: 2,
+				OneInputNode: NewOneInputNode(source),
+				col1Idx:      0,
+				col2Idx:      1,
+				outputIdx:    2,
 			}
 		},
 		"projMinusInt64Int64Op": func(source *RepeatableBatchSource) Operator {
 			return &projMinusInt64Int64Op{
-				input:     source,
-				col1Idx:   0,
-				col2Idx:   1,
-				outputIdx: 2,
+				OneInputNode: NewOneInputNode(source),
+				col1Idx:      0,
+				col2Idx:      1,
+				outputIdx:    2,
 			}
 		},
 		"projMultInt64Int64Op": func(source *RepeatableBatchSource) Operator {
 			return &projMultInt64Int64Op{
-				input:     source,
-				col1Idx:   0,
-				col2Idx:   1,
-				outputIdx: 2,
+				OneInputNode: NewOneInputNode(source),
+				col1Idx:      0,
+				col2Idx:      1,
+				outputIdx:    2,
 			}
 		},
 		"projDivInt64Int64Op": func(source *RepeatableBatchSource) Operator {
 			return &projDivInt64Int64Op{
-				input:     source,
-				col1Idx:   0,
-				col2Idx:   1,
-				outputIdx: 2,
+				OneInputNode: NewOneInputNode(source),
+				col1Idx:      0,
+				col2Idx:      1,
+				outputIdx:    2,
 			}
 		},
 	}

--- a/pkg/sql/exec/random_testutils.go
+++ b/pkg/sql/exec/random_testutils.go
@@ -208,6 +208,7 @@ type RandomDataOpArgs struct {
 // RandomDataOp is an operator that generates random data according to
 // RandomDataOpArgs. Call GetBuffer to get all data that was returned.
 type RandomDataOp struct {
+	ZeroInputNode
 	batchAccumulator func(b coldata.Batch)
 	typs             []types.T
 	rng              *rand.Rand

--- a/pkg/sql/exec/routers_test.go
+++ b/pkg/sql/exec/routers_test.go
@@ -417,6 +417,7 @@ func TestRouterOutputRandom(t *testing.T) {
 }
 
 type callbackRouterOutput struct {
+	ZeroInputNode
 	addBatchCb func(coldata.Batch, []uint16) bool
 	cancelCb   func()
 }

--- a/pkg/sql/exec/select_in_test.go
+++ b/pkg/sql/exec/select_in_test.go
@@ -68,11 +68,11 @@ func TestSelectInInt64(t *testing.T) {
 			runTests(t, []tuples{c.inputTuples}, c.outputTuples, orderedVerifier, []int{0},
 				func(input []Operator) (Operator, error) {
 					op := selectInOpInt64{
-						input:     input[0],
-						colIdx:    0,
-						filterRow: c.filterRow,
-						negate:    c.negate,
-						hasNulls:  c.hasNulls,
+						OneInputNode: NewOneInputNode(input[0]),
+						colIdx:       0,
+						filterRow:    c.filterRow,
+						negate:       c.negate,
+						hasNulls:     c.hasNulls,
 					}
 					return &op, nil
 				})
@@ -114,9 +114,9 @@ func benchmarkSelectInInt64(b *testing.B, useSelectionVector bool, hasNulls bool
 	source := NewRepeatableBatchSource(batch)
 	source.Init()
 	inOp := &selectInOpInt64{
-		input:     source,
-		colIdx:    0,
-		filterRow: []int64{1, 2, 3},
+		OneInputNode: NewOneInputNode(source),
+		colIdx:       0,
+		filterRow:    []int64{1, 2, 3},
 	}
 	inOp.Init()
 
@@ -201,12 +201,12 @@ func TestProjectInInt64(t *testing.T) {
 			runTests(t, []tuples{c.inputTuples}, c.outputTuples, orderedVerifier, []int{1},
 				func(input []Operator) (Operator, error) {
 					op := projectInOpInt64{
-						input:     input[0],
-						colIdx:    0,
-						outputIdx: 1,
-						filterRow: c.filterRow,
-						negate:    c.negate,
-						hasNulls:  c.hasNulls,
+						OneInputNode: NewOneInputNode(input[0]),
+						colIdx:       0,
+						outputIdx:    1,
+						filterRow:    c.filterRow,
+						negate:       c.negate,
+						hasNulls:     c.hasNulls,
 					}
 					return &op, nil
 				})

--- a/pkg/sql/exec/select_in_tmpl.go
+++ b/pkg/sql/exec/select_in_tmpl.go
@@ -69,10 +69,10 @@ func GetInProjectionOperator(
 	// {{range .}}
 	case types._TYPE:
 		obj := &projectInOp_TYPE{
-			input:     input,
-			colIdx:    colIdx,
-			outputIdx: resultIdx,
-			negate:    negate,
+			OneInputNode: NewOneInputNode(input),
+			colIdx:       colIdx,
+			outputIdx:    resultIdx,
+			negate:       negate,
 		}
 		obj.filterRow, obj.hasNulls, err = fillDatumRow_TYPE(ct, datumTuple)
 		if err != nil {
@@ -93,9 +93,9 @@ func GetInOperator(
 	// {{range .}}
 	case types._TYPE:
 		obj := &selectInOp_TYPE{
-			input:  input,
-			colIdx: colIdx,
-			negate: negate,
+			OneInputNode: NewOneInputNode(input),
+			colIdx:       colIdx,
+			negate:       negate,
 		}
 		obj.filterRow, obj.hasNulls, err = fillDatumRow_TYPE(ct, datumTuple)
 		if err != nil {
@@ -111,7 +111,7 @@ func GetInOperator(
 // {{range .}}
 
 type selectInOp_TYPE struct {
-	input     Operator
+	OneInputNode
 	colIdx    int
 	filterRow []_GOTYPE
 	hasNulls  bool
@@ -119,7 +119,7 @@ type selectInOp_TYPE struct {
 }
 
 type projectInOp_TYPE struct {
-	input     Operator
+	OneInputNode
 	colIdx    int
 	outputIdx int
 	filterRow []_GOTYPE

--- a/pkg/sql/exec/selection_ops_test.go
+++ b/pkg/sql/exec/selection_ops_test.go
@@ -33,9 +33,9 @@ func TestSelLTInt64Int64ConstOp(t *testing.T) {
 	tups := tuples{{0}, {1}, {2}, {nil}}
 	runTests(t, []tuples{tups}, tuples{{0}, {1}}, orderedVerifier, []int{0}, func(input []Operator) (Operator, error) {
 		return &selLTInt64Int64ConstOp{
-			input:    input[0],
-			colIdx:   0,
-			constArg: 2,
+			OneInputNode: NewOneInputNode(input[0]),
+			colIdx:       0,
+			constArg:     2,
 		}, nil
 	})
 }
@@ -52,9 +52,9 @@ func TestSelLTInt64Int64(t *testing.T) {
 	}
 	runTests(t, []tuples{tups}, tuples{{0, 1}}, orderedVerifier, []int{0, 1}, func(input []Operator) (Operator, error) {
 		return &selLTInt64Int64Op{
-			input:   input[0],
-			col1Idx: 0,
-			col2Idx: 1,
+			OneInputNode: NewOneInputNode(input[0]),
+			col1Idx:      0,
+			col2Idx:      1,
 		}, nil
 	})
 }
@@ -69,7 +69,11 @@ func TestGetSelectionConstOperator(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	expected := &selLTInt64Int64ConstOp{input: input, colIdx: colIdx, constArg: constVal}
+	expected := &selLTInt64Int64ConstOp{
+		OneInputNode: NewOneInputNode(input),
+		colIdx:       colIdx,
+		constArg:     constVal,
+	}
 	if !reflect.DeepEqual(op, expected) {
 		t.Errorf("got %+v, expected %+v", op, expected)
 	}
@@ -85,7 +89,11 @@ func TestGetSelectionOperator(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	expected := &selGEInt16Int16Op{input: input, col1Idx: col1Idx, col2Idx: col2Idx}
+	expected := &selGEInt16Int16Op{
+		OneInputNode: NewOneInputNode(input),
+		col1Idx:      col1Idx,
+		col2Idx:      col2Idx,
+	}
 	if !reflect.DeepEqual(op, expected) {
 		t.Errorf("got %+v, expected %+v", op, expected)
 	}
@@ -122,9 +130,9 @@ func benchmarkSelLTInt64Int64ConstOp(b *testing.B, useSelectionVector bool, hasN
 	source.Init()
 
 	plusOp := &selLTInt64Int64ConstOp{
-		input:    source,
-		colIdx:   0,
-		constArg: 0,
+		OneInputNode: NewOneInputNode(source),
+		colIdx:       0,
+		constArg:     0,
 	}
 	plusOp.Init()
 
@@ -180,9 +188,9 @@ func benchmarkSelLTInt64Int64Op(b *testing.B, useSelectionVector bool, hasNulls 
 	source.Init()
 
 	plusOp := &selLTInt64Int64Op{
-		input:   source,
-		col1Idx: 0,
-		col2Idx: 1,
+		OneInputNode: NewOneInputNode(source),
+		col1Idx:      0,
+		col2Idx:      1,
 	}
 	plusOp.Init()
 

--- a/pkg/sql/exec/simple_project.go
+++ b/pkg/sql/exec/simple_project.go
@@ -20,7 +20,7 @@ import (
 // simpleProjectOp is an operator that implements "simple projection" - removal of
 // columns that aren't needed by later operators.
 type simpleProjectOp struct {
-	input Operator
+	OneInputNode
 
 	batch *projectingBatch
 }
@@ -77,8 +77,8 @@ func NewSimpleProjectOp(input Operator, numInputCols int, projection []uint32) O
 		}
 	}
 	return &simpleProjectOp{
-		input: input,
-		batch: newProjectionBatch(projection),
+		OneInputNode: NewOneInputNode(input),
+		batch:        newProjectionBatch(projection),
 	}
 }
 

--- a/pkg/sql/exec/sort.go
+++ b/pkg/sql/exec/sort.go
@@ -66,6 +66,8 @@ func newSorter(
 
 // spooler is a column vector operator that spools the data from its input.
 type spooler interface {
+	OpNode
+
 	// init initializes this spooler and will be called once at the setup time.
 	init()
 	// spool performs the actual spooling.
@@ -84,7 +86,7 @@ type spooler interface {
 // allSpooler is the spooler that spools all tuples from the input. It is used
 // by the general sorter over the whole input.
 type allSpooler struct {
-	input Operator
+	OneInputNode
 
 	// inputTypes contains the types of all of the columns from the input.
 	inputTypes []types.T
@@ -101,8 +103,8 @@ var _ spooler = &allSpooler{}
 
 func newAllSpooler(input Operator, inputTypes []types.T) spooler {
 	return &allSpooler{
-		input:      input,
-		inputTypes: inputTypes,
+		OneInputNode: NewOneInputNode(input),
+		inputTypes:   inputTypes,
 	}
 }
 
@@ -393,4 +395,15 @@ func (p *sortOp) reset() {
 	}
 	p.emitted = 0
 	p.state = sortSpooling
+}
+
+func (p *sortOp) ChildCount() int {
+	return 1
+}
+
+func (p *sortOp) Child(nth int) OpNode {
+	if nth == 0 {
+		return p.input
+	}
+	panic(fmt.Sprintf("invalid index %d", nth))
 }

--- a/pkg/sql/exec/sort_chunks.go
+++ b/pkg/sql/exec/sort_chunks.go
@@ -52,6 +52,17 @@ type sortChunksOp struct {
 	sorter resettableOperator
 }
 
+func (c *sortChunksOp) ChildCount() int {
+	return 0
+}
+
+func (c *sortChunksOp) Child(nth int) OpNode {
+	if nth == 0 {
+		return c.input
+	}
+	panic(fmt.Sprintf("invalid index %d", nth))
+}
+
 var _ Operator = &sortChunksOp{}
 
 func (c *sortChunksOp) Init() {
@@ -136,7 +147,7 @@ const (
 // in the middle of processing the input). Instead, sortChunksOp will empty the
 // buffer when appropriate.
 type chunker struct {
-	input Operator
+	OneInputNode
 	// inputTypes contains the types of all of the columns from input.
 	inputTypes []types.T
 	// inputDone indicates whether input has been fully consumed.
@@ -190,8 +201,9 @@ func newChunker(
 			return nil, err
 		}
 	}
+	deselector := NewDeselectorOp(input, inputTypes)
 	return &chunker{
-		input:             NewDeselectorOp(input, inputTypes),
+		OneInputNode:      NewOneInputNode(deselector),
 		inputTypes:        inputTypes,
 		alreadySortedCols: alreadySortedCols,
 		partitioners:      partitioners,

--- a/pkg/sql/exec/sorttopk.go
+++ b/pkg/sql/exec/sorttopk.go
@@ -32,7 +32,7 @@ func NewTopKSorter(
 	input Operator, inputTypes []types.T, orderingCols []distsqlpb.Ordering_Column, k uint16,
 ) Operator {
 	return &topKSorter{
-		input:        input,
+		OneInputNode: NewOneInputNode(input),
 		inputTypes:   inputTypes,
 		orderingCols: orderingCols,
 		k:            k,
@@ -58,7 +58,7 @@ const (
 )
 
 type topKSorter struct {
-	input        Operator
+	OneInputNode
 	orderingCols []distsqlpb.Ordering_Column
 	inputTypes   []types.T
 	k            uint16 // TODO(solon): support larger k values

--- a/pkg/sql/exec/stats_test.go
+++ b/pkg/sql/exec/stats_test.go
@@ -65,15 +65,15 @@ func TestVectorizedStatsCollector(t *testing.T) {
 		mjInputWatch := timeutil.NewTestStopWatch(timeSource.Now)
 
 		leftSource := &timeAdvancingOperator{
-			input:      makeFiniteChunksSourceWithBatchSize(nBatches, coldata.BatchSize),
-			timeSource: timeSource,
+			OneInputNode: NewOneInputNode(makeFiniteChunksSourceWithBatchSize(nBatches, coldata.BatchSize)),
+			timeSource:   timeSource,
 		}
 		leftInput := NewVectorizedStatsCollector(leftSource, 0 /* id */, true /* isStall */, timeutil.NewTestStopWatch(timeSource.Now))
 		leftInput.SetOutputWatch(mjInputWatch)
 
 		rightSource := &timeAdvancingOperator{
-			input:      makeFiniteChunksSourceWithBatchSize(nBatches, coldata.BatchSize),
-			timeSource: timeSource,
+			OneInputNode: NewOneInputNode(makeFiniteChunksSourceWithBatchSize(nBatches, coldata.BatchSize)),
+			timeSource:   timeSource,
 		}
 		rightInput := NewVectorizedStatsCollector(rightSource, 1 /* id */, true /* isStall */, timeutil.NewTestStopWatch(timeSource.Now))
 		rightInput.SetOutputWatch(mjInputWatch)
@@ -93,8 +93,8 @@ func TestVectorizedStatsCollector(t *testing.T) {
 			t.Fatal(err)
 		}
 		timeAdvancingMergeJoiner := &timeAdvancingOperator{
-			input:      mergeJoiner,
-			timeSource: timeSource,
+			OneInputNode: NewOneInputNode(mergeJoiner),
+			timeSource:   timeSource,
 		}
 		mjStatsCollector := NewVectorizedStatsCollector(timeAdvancingMergeJoiner, 2 /* id */, false /* isStall */, mjInputWatch)
 
@@ -136,7 +136,7 @@ func makeFiniteChunksSourceWithBatchSize(nBatches int, batchSize int) Operator {
 // timeAdvancingOperator is an Operator that advances the time source upon
 // receiving a non-empty batch from its input. It is used for testing only.
 type timeAdvancingOperator struct {
-	input Operator
+	OneInputNode
 
 	timeSource *timeutil.TestTimeSource
 }

--- a/pkg/sql/exec/testutils.go
+++ b/pkg/sql/exec/testutils.go
@@ -19,6 +19,7 @@ import (
 // BatchBuffer exposes a buffer of coldata.Batches through an Operator
 // interface. If there are no batches to return, Next will panic.
 type BatchBuffer struct {
+	ZeroInputNode
 	buffer []coldata.Batch
 }
 
@@ -48,6 +49,7 @@ func (b *BatchBuffer) Next(context.Context) coldata.Batch {
 
 // RepeatableBatchSource is an Operator that returns the same batch forever.
 type RepeatableBatchSource struct {
+	ZeroInputNode
 	internalBatch coldata.Batch
 	batchLen      uint16
 	// sel specifies the desired selection vector for the batch.
@@ -104,6 +106,7 @@ func (s *RepeatableBatchSource) ResetBatchesToReturn(b int) {
 // CallbackOperator is a testing utility struct that delegates Next calls to a
 // callback provided by the user.
 type CallbackOperator struct {
+	ZeroInputNode
 	NextCb func(ctx context.Context) coldata.Batch
 }
 

--- a/pkg/sql/exec/unorderedsynchronizer.go
+++ b/pkg/sql/exec/unorderedsynchronizer.go
@@ -28,6 +28,8 @@ type unorderedSynchronizerMsg struct {
 	b        coldata.Batch
 }
 
+var _ Operator = &UnorderedSynchronizer{}
+
 // UnorderedSynchronizer is an Operator that combines multiple Operator streams
 // into one.
 type UnorderedSynchronizer struct {
@@ -66,6 +68,16 @@ type UnorderedSynchronizer struct {
 	cancelFn          context.CancelFunc
 	batchCh           chan *unorderedSynchronizerMsg
 	errCh             chan error
+}
+
+// ChildCount implements the OpNode interface.
+func (s *UnorderedSynchronizer) ChildCount() int {
+	return len(s.inputs)
+}
+
+// Child implements the OpNode interface.
+func (s *UnorderedSynchronizer) Child(nth int) OpNode {
+	return s.inputs[nth]
 }
 
 // NewUnorderedSynchronizer creates a new UnorderedSynchronizer. On the first

--- a/pkg/sql/exec/utils_test.go
+++ b/pkg/sql/exec/utils_test.go
@@ -166,6 +166,8 @@ func runTestsWithFixedSel(
 //     t.Fatal(err)
 // }
 type opTestInput struct {
+	ZeroInputNode
+
 	typs []types.T
 
 	batchSize uint16
@@ -314,6 +316,8 @@ func (s *opTestInput) Next(context.Context) coldata.Batch {
 }
 
 type opFixedSelTestInput struct {
+	ZeroInputNode
+
 	typs []types.T
 
 	batchSize uint16
@@ -441,7 +445,7 @@ func (s *opFixedSelTestInput) Next(context.Context) coldata.Batch {
 // opTestOutput is a test verification struct that ensures its input batches
 // match some expected output tuples.
 type opTestOutput struct {
-	input    Operator
+	OneInputNode
 	cols     []int
 	expected tuples
 
@@ -456,9 +460,9 @@ func newOpTestOutput(input Operator, cols []int, expected tuples) *opTestOutput 
 	input.Init()
 
 	return &opTestOutput{
-		input:    input,
-		cols:     cols,
-		expected: expected,
+		OneInputNode: NewOneInputNode(input),
+		cols:         cols,
+		expected:     expected,
 	}
 }
 
@@ -595,6 +599,8 @@ func assertTuplesOrderedEqual(expected tuples, actual tuples) error {
 // finiteBatchSource is an Operator that returns the same batch a specified
 // number of times.
 type finiteBatchSource struct {
+	ZeroInputNode
+
 	repeatableBatch *RepeatableBatchSource
 
 	usableCount int
@@ -628,6 +634,7 @@ func (f *finiteBatchSource) Next(ctx context.Context) coldata.Batch {
 // randomLengthBatchSource is an Operator that forever returns the same batch at
 // a different length each time.
 type randomLengthBatchSource struct {
+	ZeroInputNode
 	internalBatch coldata.Batch
 	rng           *rand.Rand
 }
@@ -656,6 +663,7 @@ func (r *randomLengthBatchSource) Next(context.Context) coldata.Batch {
 // (except for the first) the batch is returned to emulate source that is
 // already ordered on matchLen columns.
 type finiteChunksSource struct {
+	ZeroInputNode
 	repeatableBatch *RepeatableBatchSource
 
 	usableCount int
@@ -792,6 +800,7 @@ func TestRepeatableBatchSourceWithFixedSel(t *testing.T) {
 // chunkingBatchSource is a batch source that takes unlimited-size columns and
 // chunks them into BatchSize-sized chunks when Nexted.
 type chunkingBatchSource struct {
+	ZeroInputNode
 	typs []types.T
 	cols []coldata.Vec
 	len  uint64

--- a/pkg/sql/exec/vecbuiltins/rank.go
+++ b/pkg/sql/exec/vecbuiltins/rank.go
@@ -38,7 +38,7 @@ func NewRankOperator(
 		return nil, err
 	}
 	initFields := rankInitFields{
-		input:           op,
+		OneInputNode:    exec.NewOneInputNode(op),
 		distinctCol:     outputCol,
 		outputColIdx:    outputColIdx,
 		partitionColIdx: partitionColIdx,

--- a/pkg/sql/exec/vecbuiltins/rank_tmpl.go
+++ b/pkg/sql/exec/vecbuiltins/rank_tmpl.go
@@ -44,7 +44,7 @@ func _UPDATE_RANK_INCREMENT() {
 // */}}
 
 type rankInitFields struct {
-	input exec.Operator
+	exec.OneInputNode
 	// distinctCol is the output column of the chain of ordered distinct
 	// operators in which true will indicate that a new rank needs to be assigned
 	// to the corresponding tuple.
@@ -69,7 +69,7 @@ type _RANK_STRINGOp struct {
 var _ exec.Operator = &_RANK_STRINGOp{}
 
 func (r *_RANK_STRINGOp) Init() {
-	r.input.Init()
+	r.Input().Init()
 	// RANK and DENSE_RANK start counting from 1. Before we assign the rank to a
 	// tuple in the batch, we first increment r.rank, so setting this
 	// rankIncrement to 1 will update r.rank to 1 on the very first tuple (as
@@ -78,7 +78,7 @@ func (r *_RANK_STRINGOp) Init() {
 }
 
 func (r *_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
-	batch := r.input.Next(ctx)
+	batch := r.Input().Next(ctx)
 	if batch.Length() == 0 {
 		return batch
 	}

--- a/pkg/sql/exec/vecbuiltins/row_number.go
+++ b/pkg/sql/exec/vecbuiltins/row_number.go
@@ -22,7 +22,7 @@ func NewRowNumberOperator(
 	input exec.Operator, outputColIdx int, partitionColIdx int,
 ) exec.Operator {
 	base := rowNumberBase{
-		input:           input,
+		OneInputNode:    exec.NewOneInputNode(input),
 		outputColIdx:    outputColIdx,
 		partitionColIdx: partitionColIdx,
 	}
@@ -36,7 +36,7 @@ func NewRowNumberOperator(
 // variations of row number operators. Note that it is not an operator itself
 // and should not be used directly.
 type rowNumberBase struct {
-	input           exec.Operator
+	exec.OneInputNode
 	outputColIdx    int
 	partitionColIdx int
 
@@ -44,5 +44,5 @@ type rowNumberBase struct {
 }
 
 func (r *rowNumberBase) Init() {
-	r.input.Init()
+	r.Input().Init()
 }

--- a/pkg/sql/exec/vecbuiltins/row_number_tmpl.go
+++ b/pkg/sql/exec/vecbuiltins/row_number_tmpl.go
@@ -36,7 +36,7 @@ type _ROW_NUMBER_STRINGOp struct {
 var _ exec.Operator = &_ROW_NUMBER_STRINGOp{}
 
 func (r *_ROW_NUMBER_STRINGOp) Next(ctx context.Context) coldata.Batch {
-	batch := r.input.Next(ctx)
+	batch := r.Input().Next(ctx)
 	if batch.Length() == 0 {
 		return batch
 	}

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -153,6 +153,13 @@ func doExpandPlan(
 		explainParams.atTop = true
 		n.plan, err = doExpandPlan(ctx, p, explainParams, n.plan)
 
+	case *explainVecNode:
+		// EXPLAIN only shows the structure of the plan, and wants to do
+		// so "as if" plan was at the top level w.r.t spool semantics.
+		explainParams := noParamsBase
+		explainParams.atTop = true
+		n.plan, err = doExpandPlan(ctx, p, explainParams, n.plan)
+
 	case *showTraceReplicaNode:
 		n.plan, err = doExpandPlan(ctx, p, noParams, n.plan)
 
@@ -697,6 +704,9 @@ func (p *planner) simplifyOrderings(plan planNode, usefulOrdering sqlbase.Column
 		n.source = p.simplifyOrderings(n.source, nil).(batchedPlanNode)
 
 	case *explainDistSQLNode:
+		n.plan = p.simplifyOrderings(n.plan, nil)
+
+	case *explainVecNode:
 		n.plan = p.simplifyOrderings(n.plan, nil)
 
 	case *showTraceReplicaNode:

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -67,6 +67,9 @@ func (p *planner) Explain(ctx context.Context, n *tree.Explain) (planNode, error
 	case tree.ExplainOpt:
 		return nil, errors.New("EXPLAIN (OPT) only supported with the cost-based optimizer")
 
+	case tree.ExplainVec:
+		return nil, errors.New("EXPLAIN (VEC) only supported with the cost-based optimizer")
+
 	default:
 		return nil, fmt.Errorf("unsupported EXPLAIN mode: %d", opts.Mode)
 	}

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -14,13 +14,10 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 )
 
 // explainDistSQLNode is a planNode that wraps a plan and returns
@@ -69,13 +66,6 @@ type distSQLExplainable interface {
 }
 
 func (n *explainDistSQLNode) startExec(params runParams) error {
-	if n.analyze && params.SessionData().DistSQLMode == sessiondata.DistSQLOff {
-		return pgerror.Newf(
-			pgcode.ObjectNotInPrerequisiteState,
-			"cannot run EXPLAIN ANALYZE while distsql is disabled",
-		)
-	}
-
 	// Trigger limit propagation.
 	params.p.prepareForDistSQLSupportCheck()
 

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -1,0 +1,138 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+	"reflect"
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
+)
+
+// explainVecNode is a planNode that wraps a plan and returns
+// information related to running that plan with the vectorized engine.
+type explainVecNode struct {
+	optColumnsSlot
+
+	plan planNode
+
+	stmtType tree.StatementType
+
+	run struct {
+		lines []string
+		// The current row returned by the node.
+		values tree.Datums
+	}
+}
+
+type flowWithNode struct {
+	nodeID roachpb.NodeID
+	flow   *distsqlpb.FlowSpec
+}
+
+func (n *explainVecNode) startExec(params runParams) error {
+	// Trigger limit propagation.
+	params.p.prepareForDistSQLSupportCheck()
+	n.run.values = make(tree.Datums, 1)
+	distSQLPlanner := params.extendedEvalCtx.DistSQLPlanner
+
+	var recommendation distRecommendation
+	if _, ok := n.plan.(distSQLExplainable); ok {
+		recommendation = shouldDistribute
+	} else {
+		recommendation, _ = distSQLPlanner.checkSupportForNode(n.plan)
+	}
+
+	planCtx := distSQLPlanner.NewPlanningCtx(params.ctx, params.extendedEvalCtx, params.p.txn)
+	planCtx.isLocal = !shouldDistributeGivenRecAndMode(recommendation, params.SessionData().DistSQLMode)
+	planCtx.ignoreClose = true
+	planCtx.planner = params.p
+	planCtx.stmtType = n.stmtType
+	planCtx.noEvalSubqueries = true
+
+	var plan PhysicalPlan
+	var err error
+	if planNode, ok := n.plan.(distSQLExplainable); ok {
+		plan, err = planNode.makePlanForExplainDistSQL(planCtx, distSQLPlanner)
+	} else {
+		plan, err = distSQLPlanner.createPlanForNode(planCtx, n.plan)
+	}
+	if err != nil {
+		return err
+	}
+
+	distSQLPlanner.FinalizePlan(planCtx, &plan)
+
+	flows := plan.GenerateFlowSpecs(params.extendedEvalCtx.NodeID)
+
+	var localState distsqlrun.LocalState
+	localState.EvalContext = planCtx.EvalContext()
+	if planCtx.isLocal {
+		localState.IsLocal = true
+		localState.LocalProcs = plan.LocalProcessors
+	}
+	flowCtx := &distsqlrun.FlowCtx{
+		NodeID:  planCtx.EvalContext().NodeID,
+		EvalCtx: planCtx.EvalContext(),
+		Cfg:     &distsqlrun.ServerConfig{},
+	}
+
+	sortedFlows := make([]flowWithNode, 0, len(flows))
+	for nodeID, flow := range flows {
+		sortedFlows = append(sortedFlows, flowWithNode{nodeID: nodeID, flow: flow})
+	}
+	// Sort backward, since the first thing you add to a treeprinter will come last.
+	sort.Slice(sortedFlows, func(i, j int) bool { return sortedFlows[i].nodeID < sortedFlows[j].nodeID })
+	tp := treeprinter.New()
+	root := tp.Child("")
+	for _, flow := range sortedFlows {
+		node := root.Childf("Node %d", flow.nodeID)
+		opChains, err := distsqlrun.SupportsVectorized(params.ctx, flowCtx, flow.flow.Processors)
+		if err != nil {
+			return err
+		}
+		for _, op := range opChains {
+			formatOpChain(op, node)
+		}
+	}
+	n.run.lines = tp.FormattedRows()
+	return nil
+}
+
+func formatOpChain(operator exec.OpNode, node treeprinter.Node) {
+	doFormatOpChain(operator, node.Child(reflect.TypeOf(operator).String()))
+}
+func doFormatOpChain(operator exec.OpNode, node treeprinter.Node) {
+	for i := 0; i < operator.ChildCount(); i++ {
+		child := operator.Child(i)
+		doFormatOpChain(child, node.Child(reflect.TypeOf(child).String()))
+	}
+}
+
+func (n *explainVecNode) Next(runParams) (bool, error) {
+	if len(n.run.lines) == 0 {
+		return false, nil
+	}
+	n.run.values[0] = tree.NewDString(n.run.lines[0])
+	n.run.lines = n.run.lines[1:]
+	return true, nil
+}
+
+func (n *explainVecNode) Values() tree.Datums { return n.run.values }
+func (n *explainVecNode) Close(ctx context.Context) {
+	n.plan.Close(ctx)
+}

--- a/pkg/sql/logictest/testdata/logic_test/dist_vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/dist_vectorize
@@ -85,3 +85,182 @@ true
 
 statement ok
 RESET optimizer
+
+query T
+EXPLAIN (VEC) SELECT count(*) FROM kv
+----
+ │
+ ├── Node 1
+ │    └── *distsqlrun.materializer
+ │         └── *exec.orderedAggregator
+ │              └── *exec.oneShotOp
+ │                   └── exec.fnOp
+ │                        └── *exec.UnorderedSynchronizer
+ │                             ├── *exec.countOp
+ │                             │    └── *exec.simpleProjectOp
+ │                             │         └── *exec.CancelChecker
+ │                             │              └── *distsqlrun.colBatchScan
+ │                             ├── *colrpc.Inbox
+ │                             ├── *colrpc.Inbox
+ │                             ├── *colrpc.Inbox
+ │                             └── *colrpc.Inbox
+ ├── Node 2
+ │    └── *colrpc.Outbox
+ │         └── *exec.deselectorOp
+ │              └── *exec.countOp
+ │                   └── *exec.simpleProjectOp
+ │                        └── *exec.CancelChecker
+ │                             └── *distsqlrun.colBatchScan
+ ├── Node 3
+ │    └── *colrpc.Outbox
+ │         └── *exec.deselectorOp
+ │              └── *exec.countOp
+ │                   └── *exec.simpleProjectOp
+ │                        └── *exec.CancelChecker
+ │                             └── *distsqlrun.colBatchScan
+ ├── Node 4
+ │    └── *colrpc.Outbox
+ │         └── *exec.deselectorOp
+ │              └── *exec.countOp
+ │                   └── *exec.simpleProjectOp
+ │                        └── *exec.CancelChecker
+ │                             └── *distsqlrun.colBatchScan
+ └── Node 5
+      └── *colrpc.Outbox
+           └── *exec.deselectorOp
+                └── *exec.countOp
+                     └── *exec.simpleProjectOp
+                          └── *exec.CancelChecker
+                               └── *distsqlrun.colBatchScan
+
+query T
+EXPLAIN (VEC) SELECT count(*) FROM kv NATURAL INNER HASH JOIN kv kv2
+----
+ │
+ ├── Node 1
+ │    └── *distsqlrun.materializer
+ │         └── *exec.orderedAggregator
+ │              └── *exec.oneShotOp
+ │                   └── exec.fnOp
+ │                        └── *exec.UnorderedSynchronizer
+ │                             ├── *exec.countOp
+ │                             │    └── *exec.simpleProjectOp
+ │                             │         └── *exec.hashJoinEqOp
+ │                             │              ├── *exec.UnorderedSynchronizer
+ │                             │              │    ├── *exec.routerOutputOp
+ │                             │              │    │    └── *exec.HashRouter
+ │                             │              │    │         └── *exec.CancelChecker
+ │                             │              │    │              └── *distsqlrun.colBatchScan
+ │                             │              │    ├── *colrpc.Inbox
+ │                             │              │    ├── *colrpc.Inbox
+ │                             │              │    ├── *colrpc.Inbox
+ │                             │              │    └── *colrpc.Inbox
+ │                             │              └── *exec.UnorderedSynchronizer
+ │                             │                   ├── *exec.routerOutputOp
+ │                             │                   │    └── *exec.HashRouter
+ │                             │                   │         └── *exec.CancelChecker
+ │                             │                   │              └── *distsqlrun.colBatchScan
+ │                             │                   ├── *colrpc.Inbox
+ │                             │                   ├── *colrpc.Inbox
+ │                             │                   ├── *colrpc.Inbox
+ │                             │                   └── *colrpc.Inbox
+ │                             ├── *colrpc.Inbox
+ │                             ├── *colrpc.Inbox
+ │                             ├── *colrpc.Inbox
+ │                             └── *colrpc.Inbox
+ ├── Node 2
+ │    └── *colrpc.Outbox
+ │         └── *exec.deselectorOp
+ │              └── *exec.countOp
+ │                   └── *exec.simpleProjectOp
+ │                        └── *exec.hashJoinEqOp
+ │                             ├── *exec.UnorderedSynchronizer
+ │                             │    ├── *colrpc.Inbox
+ │                             │    ├── *exec.routerOutputOp
+ │                             │    │    └── *exec.HashRouter
+ │                             │    │         └── *exec.CancelChecker
+ │                             │    │              └── *distsqlrun.colBatchScan
+ │                             │    ├── *colrpc.Inbox
+ │                             │    ├── *colrpc.Inbox
+ │                             │    └── *colrpc.Inbox
+ │                             └── *exec.UnorderedSynchronizer
+ │                                  ├── *colrpc.Inbox
+ │                                  ├── *exec.routerOutputOp
+ │                                  │    └── *exec.HashRouter
+ │                                  │         └── *exec.CancelChecker
+ │                                  │              └── *distsqlrun.colBatchScan
+ │                                  ├── *colrpc.Inbox
+ │                                  ├── *colrpc.Inbox
+ │                                  └── *colrpc.Inbox
+ ├── Node 3
+ │    └── *colrpc.Outbox
+ │         └── *exec.deselectorOp
+ │              └── *exec.countOp
+ │                   └── *exec.simpleProjectOp
+ │                        └── *exec.hashJoinEqOp
+ │                             ├── *exec.UnorderedSynchronizer
+ │                             │    ├── *colrpc.Inbox
+ │                             │    ├── *colrpc.Inbox
+ │                             │    ├── *exec.routerOutputOp
+ │                             │    │    └── *exec.HashRouter
+ │                             │    │         └── *exec.CancelChecker
+ │                             │    │              └── *distsqlrun.colBatchScan
+ │                             │    ├── *colrpc.Inbox
+ │                             │    └── *colrpc.Inbox
+ │                             └── *exec.UnorderedSynchronizer
+ │                                  ├── *colrpc.Inbox
+ │                                  ├── *colrpc.Inbox
+ │                                  ├── *exec.routerOutputOp
+ │                                  │    └── *exec.HashRouter
+ │                                  │         └── *exec.CancelChecker
+ │                                  │              └── *distsqlrun.colBatchScan
+ │                                  ├── *colrpc.Inbox
+ │                                  └── *colrpc.Inbox
+ ├── Node 4
+ │    └── *colrpc.Outbox
+ │         └── *exec.deselectorOp
+ │              └── *exec.countOp
+ │                   └── *exec.simpleProjectOp
+ │                        └── *exec.hashJoinEqOp
+ │                             ├── *exec.UnorderedSynchronizer
+ │                             │    ├── *colrpc.Inbox
+ │                             │    ├── *colrpc.Inbox
+ │                             │    ├── *colrpc.Inbox
+ │                             │    ├── *exec.routerOutputOp
+ │                             │    │    └── *exec.HashRouter
+ │                             │    │         └── *exec.CancelChecker
+ │                             │    │              └── *distsqlrun.colBatchScan
+ │                             │    └── *colrpc.Inbox
+ │                             └── *exec.UnorderedSynchronizer
+ │                                  ├── *colrpc.Inbox
+ │                                  ├── *colrpc.Inbox
+ │                                  ├── *colrpc.Inbox
+ │                                  ├── *exec.routerOutputOp
+ │                                  │    └── *exec.HashRouter
+ │                                  │         └── *exec.CancelChecker
+ │                                  │              └── *distsqlrun.colBatchScan
+ │                                  └── *colrpc.Inbox
+ └── Node 5
+      └── *colrpc.Outbox
+           └── *exec.deselectorOp
+                └── *exec.countOp
+                     └── *exec.simpleProjectOp
+                          └── *exec.hashJoinEqOp
+                               ├── *exec.UnorderedSynchronizer
+                               │    ├── *colrpc.Inbox
+                               │    ├── *colrpc.Inbox
+                               │    ├── *colrpc.Inbox
+                               │    ├── *colrpc.Inbox
+                               │    └── *exec.routerOutputOp
+                               │         └── *exec.HashRouter
+                               │              └── *exec.CancelChecker
+                               │                   └── *distsqlrun.colBatchScan
+                               └── *exec.UnorderedSynchronizer
+                                    ├── *colrpc.Inbox
+                                    ├── *colrpc.Inbox
+                                    ├── *colrpc.Inbox
+                                    ├── *colrpc.Inbox
+                                    └── *exec.routerOutputOp
+                                         └── *exec.HashRouter
+                                              └── *exec.CancelChecker
+                                                   └── *distsqlrun.colBatchScan

--- a/pkg/sql/opt/optbuilder/explain.go
+++ b/pkg/sql/opt/optbuilder/explain.go
@@ -62,6 +62,10 @@ func (b *Builder) buildExplain(explain *tree.Explain, inScope *scope) (outScope 
 		}
 		cols = sqlbase.ExplainOptColumns
 
+	case tree.ExplainVec:
+		telemetry.Inc(sqltelemetry.ExplainVecUseCounter)
+		cols = sqlbase.ExplainVecColumns
+
 	default:
 		panic(pgerror.Newf(pgcode.FeatureNotSupported,
 			"EXPLAIN ANALYZE does not support RETURNING NOTHING statements"))

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1169,6 +1169,12 @@ func (ef *execFactory) ConstructExplain(
 			stmtType:      stmtType,
 		}, nil
 
+	case tree.ExplainVec:
+		return &explainVecNode{
+			plan:     p.plan,
+			stmtType: stmtType,
+		}, nil
+
 	case tree.ExplainPlan:
 		if analyzeSet {
 			return nil, errors.New("EXPLAIN ANALYZE only supported with (DISTSQL) option")

--- a/pkg/sql/opt_limits.go
+++ b/pkg/sql/opt_limits.go
@@ -233,6 +233,7 @@ func (p *planner) applyLimit(plan planNode, numRows int64, soft bool) {
 	case *dropViewNode:
 	case *dropSequenceNode:
 	case *DropUserNode:
+	case *explainVecNode:
 	case *zeroNode:
 	case *unaryNode:
 	case *hookFnNode:

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -192,6 +192,7 @@ var _ planNode = &dropViewNode{}
 var _ planNode = &errorIfRowsNode{}
 var _ planNode = &explainDistSQLNode{}
 var _ planNode = &explainPlanNode{}
+var _ planNode = &explainVecNode{}
 var _ planNode = &filterNode{}
 var _ planNode = &groupNode{}
 var _ planNode = &hookFnNode{}
@@ -491,7 +492,7 @@ func startExec(params runParams, plan planNode) error {
 	o := planObserver{
 		enterNode: func(ctx context.Context, _ string, p planNode) (bool, error) {
 			switch p.(type) {
-			case *explainPlanNode, *explainDistSQLNode:
+			case *explainPlanNode, *explainDistSQLNode, *explainVecNode:
 				// Do not recurse: we're not starting the plan if we just show its structure with EXPLAIN.
 				return false, nil
 			case *showTraceNode:

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -99,6 +99,8 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		return n.getColumns(mut, sqlbase.ScrubColumns)
 	case *explainDistSQLNode:
 		return n.getColumns(mut, sqlbase.ExplainDistSQLColumns)
+	case *explainVecNode:
+		return n.getColumns(mut, sqlbase.ExplainVecColumns)
 	case *relocateNode:
 		return n.getColumns(mut, sqlbase.AlterTableRelocateColumns)
 	case *scatterNode:

--- a/pkg/sql/plan_physical_props.go
+++ b/pkg/sql/plan_physical_props.go
@@ -122,6 +122,7 @@ func planPhysicalProps(plan planNode) physicalProps {
 	case *errorIfRowsNode:
 	case *exportNode:
 	case *explainDistSQLNode:
+	case *explainVecNode:
 	case *hookFnNode:
 	case *relocateNode:
 	case *renameColumnNode:

--- a/pkg/sql/row/cfetcher.go
+++ b/pkg/sql/row/cfetcher.go
@@ -1116,6 +1116,10 @@ func (rf *CFetcher) fillNulls() error {
 // GetRangesInfo returns information about the ranges where the rows came from.
 // The RangeInfo's are deduped and not ordered.
 func (rf *CFetcher) GetRangesInfo() []roachpb.RangeInfo {
+	if rf == nil {
+		// Not yet initialized.
+		return nil
+	}
 	return rf.fetcher.getRangesInfo()
 }
 

--- a/pkg/sql/sem/tree/explain.go
+++ b/pkg/sql/sem/tree/explain.go
@@ -84,12 +84,17 @@ const (
 	// ExplainOpt shows the optimized relational expression (from the cost-based
 	// optimizer).
 	ExplainOpt
+
+	// ExplainVec shows the physical vectorized plan for a query and whether a
+	// query would be run in "auto" vectorized mode.
+	ExplainVec
 )
 
 var explainModeStrings = map[string]ExplainMode{
 	"plan":    ExplainPlan,
 	"distsql": ExplainDistSQL,
 	"opt":     ExplainOpt,
+	"vec":     ExplainVec,
 }
 
 // ExplainModeName returns the human-readable name of a given ExplainMode.

--- a/pkg/sql/sqlbase/result_columns.go
+++ b/pkg/sql/sqlbase/result_columns.go
@@ -116,6 +116,12 @@ var ExplainOptColumns = ResultColumns{
 	{Name: "text", Typ: types.String},
 }
 
+// ExplainVecColumns are the result columns of an
+// EXPLAIN (VEC) statement.
+var ExplainVecColumns = ResultColumns{
+	{Name: "text", Typ: types.String},
+}
+
 // ShowTraceColumns are the result columns of a SHOW [KV] TRACE statement.
 var ShowTraceColumns = ResultColumns{
 	{Name: "timestamp", Typ: types.TimestampTZ},

--- a/pkg/sql/sqltelemetry/planning.go
+++ b/pkg/sql/sqltelemetry/planning.go
@@ -57,6 +57,9 @@ var ExplainAnalyzeUseCounter = telemetry.GetCounterOnce("sql.plan.explain-analyz
 // ExplainOptUseCounter is to be incremented whenever EXPLAIN (OPT) is run.
 var ExplainOptUseCounter = telemetry.GetCounterOnce("sql.plan.explain-opt")
 
+// ExplainVecUseCounter is to be incremented whenever EXPLAIN (VEC) is run.
+var ExplainVecUseCounter = telemetry.GetCounterOnce("sql.plan.explain-vec")
+
 // ExplainOptVerboseUseCounter is to be incremented whenever
 // EXPLAIN (OPT, VERBOSE) is run.
 var ExplainOptVerboseUseCounter = telemetry.GetCounterOnce("sql.plan.explain-opt-verbose")

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -595,6 +595,9 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 	case *explainDistSQLNode:
 		n.plan = v.visit(n.plan)
 
+	case *explainVecNode:
+		n.plan = v.visit(n.plan)
+
 	case *ordinalityNode:
 		n.source = v.visit(n.source)
 
@@ -784,6 +787,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&errorIfRowsNode{}):          "error if rows",
 	reflect.TypeOf(&explainDistSQLNode{}):       "explain distsql",
 	reflect.TypeOf(&explainPlanNode{}):          "explain plan",
+	reflect.TypeOf(&explainVecNode{}):           "explain vectorized",
 	reflect.TypeOf(&exportNode{}):               "export",
 	reflect.TypeOf(&filterNode{}):               "filter",
 	reflect.TypeOf(&groupNode{}):                "group",


### PR DESCRIPTION
It prints out all of the flows in a tree format. It's quite verbose...

Currently it's pretty confusing because inboxes and outboxes don't print
any disambiguating information so you can't link them between flows.
Also, routers only show the outputs that are on their local node -
currently their other outboxes aren't displayed.

I'd like to fix these things after this first PR gets in.

The way this works is that all operators were modified to also implement
an exec.OpNode interface that allows traversal to children (inputs) of
each operator. Most operators simply embed a helper one, two or zero
input opNode struct. Some special operators (or non-operators, like the
various distributed infrastructure) implement exec.OpNode themselves,
since they don't have an actual exec.Operator input.

Release note (sql change): add EXPLAIN(VEC) command to show detailed
plan information for vectorized plans.