### PR TITLE
build: print node version error to stderr

### DIFF
--- a/build/node-run.sh
+++ b/build/node-run.sh
@@ -42,7 +42,7 @@ set -euo pipefail
 
 raw_version=$(node --version)
 if [ $(grep -oE 'v[0-9]+\.' <<< ${raw_version}) != "v10." ]; then
-    echo "node v10.x is required, found ${raw_version}"
+    echo "node v10.x is required, found ${raw_version}" >&2
     exit 1
 fi
 


### PR DESCRIPTION
Without this, the error was being appended to `pkg/ui/src/js/protos.d.ts`,
which was promptly being deleted, making the failure completely silent.

Release note: None