### PR TITLE
distsqlrun: store pointer to ServerConfig in FlowCtx

### DIFF
--- a/pkg/ccl/importccl/exportcsv.go
+++ b/pkg/ccl/importccl/exportcsv.go
@@ -274,7 +274,7 @@ func (sp *csvWriter) Run(ctx context.Context) {
 			if err != nil {
 				return err
 			}
-			es, err := storageccl.MakeExportStorage(ctx, conf, sp.flowCtx.Settings)
+			es, err := storageccl.MakeExportStorage(ctx, conf, sp.flowCtx.Cfg.Settings)
 			if err != nil {
 				return err
 			}

--- a/pkg/ccl/importccl/sst_writer_proc.go
+++ b/pkg/ccl/importccl/sst_writer_proc.go
@@ -58,9 +58,9 @@ func newSSTWriterProcessor(
 		spec:        spec,
 		input:       input,
 		output:      output,
-		tempStorage: flowCtx.TempStorage,
-		settings:    flowCtx.Settings,
-		registry:    flowCtx.JobRegistry,
+		tempStorage: flowCtx.Cfg.TempStorage,
+		settings:    flowCtx.Cfg.Settings,
+		registry:    flowCtx.Cfg.JobRegistry,
 		progress:    spec.Progress,
 		db:          flowCtx.EvalCtx.Txn.DB(),
 	}
@@ -153,7 +153,7 @@ func (sp *sstWriter) Run(ctx context.Context) {
 		// to ensure that the splits are not automatically split by the merge
 		// queue. If the cluster does not support sticky bits, we disable the merge
 		// queue via gossip, so we can just set the split to expire immediately.
-		stickyBitEnabled := sp.flowCtx.Settings.Version.IsActive(cluster.VersionStickyBit)
+		stickyBitEnabled := sp.flowCtx.Cfg.Settings.Version.IsActive(cluster.VersionStickyBit)
 		expirationTime := hlc.Timestamp{}
 		if stickyBitEnabled {
 			expirationTime = sp.db.Clock().Now().Add(time.Hour.Nanoseconds(), 0)

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -36,7 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 // To allow queries to send out flow RPCs in parallel, we use a pool of workers
@@ -140,7 +140,11 @@ func (dsp *DistSQLPlanner) setupFlows(
 	if evalCtx.SessionData.VectorizeMode != sessiondata.VectorizeOff {
 		for _, spec := range flows {
 			if err := distsqlrun.SupportsVectorized(
-				ctx, &distsqlrun.FlowCtx{EvalCtx: &evalCtx.EvalContext, NodeID: -1}, spec.Processors,
+				ctx, &distsqlrun.FlowCtx{
+					EvalCtx: &evalCtx.EvalContext,
+					Cfg:     &distsqlrun.ServerConfig{},
+					NodeID:  -1,
+				}, spec.Processors,
 			); err != nil {
 				// Vectorization attempt failed with an error.
 				returnVectorizationSetupError := false

--- a/pkg/sql/distsqlrun/aggregator_test.go
+++ b/pkg/sql/distsqlrun/aggregator_test.go
@@ -416,8 +416,8 @@ func BenchmarkAggregation(b *testing.B) {
 	defer evalCtx.Stop(ctx)
 
 	flowCtx := &FlowCtx{
-		Settings: st,
-		EvalCtx:  &evalCtx,
+		Cfg:     &ServerConfig{Settings: st},
+		EvalCtx: &evalCtx,
 	}
 
 	for _, aggFunc := range aggFuncs {
@@ -469,8 +469,8 @@ func BenchmarkCountRows(b *testing.B) {
 	defer evalCtx.Stop(ctx)
 
 	flowCtx := &FlowCtx{
-		Settings: st,
-		EvalCtx:  &evalCtx,
+		Cfg:     &ServerConfig{Settings: st},
+		EvalCtx: &evalCtx,
 	}
 
 	b.SetBytes(int64(8 * numRows * numCols))
@@ -495,8 +495,8 @@ func BenchmarkGrouping(b *testing.B) {
 	defer evalCtx.Stop(ctx)
 
 	flowCtx := &FlowCtx{
-		Settings: st,
-		EvalCtx:  &evalCtx,
+		Cfg:     &ServerConfig{Settings: st},
+		EvalCtx: &evalCtx,
 	}
 	spec := &distsqlpb.AggregatorSpec{
 		GroupCols: []uint32{0},
@@ -543,8 +543,8 @@ func benchmarkAggregationWithGrouping(b *testing.B, numOrderedCols int) {
 	defer evalCtx.Stop(ctx)
 
 	flowCtx := &FlowCtx{
-		Settings: st,
-		EvalCtx:  &evalCtx,
+		Cfg:     &ServerConfig{Settings: st},
+		EvalCtx: &evalCtx,
 	}
 
 	for _, aggFunc := range aggFuncs {

--- a/pkg/sql/distsqlrun/backfiller.go
+++ b/pkg/sql/distsqlrun/backfiller.go
@@ -194,12 +194,12 @@ func (b *backfiller) mainLoop(ctx context.Context) error {
 		b.name, totalSpans, totalChunks, timeutil.Since(start))
 
 	return WriteResumeSpan(ctx,
-		b.flowCtx.ClientDB,
+		b.flowCtx.Cfg.DB,
 		b.spec.Table.ID,
 		mutationID,
 		b.filter,
 		finishedSpans,
-		b.flowCtx.JobRegistry,
+		b.flowCtx.Cfg.JobRegistry,
 	)
 }
 

--- a/pkg/sql/distsqlrun/bulk_row_writer.go
+++ b/pkg/sql/distsqlrun/bulk_row_writer.go
@@ -74,8 +74,7 @@ func (sp *bulkRowWriter) OutputTypes() []types.T {
 func (sp *bulkRowWriter) ingestLoop(ctx context.Context, kvCh chan []roachpb.KeyValue) error {
 	writeTS := sp.spec.Table.CreateAsOfTime
 	const bufferSize, flushSize = 64 << 20, 16 << 20
-	adder, err := sp.flowCtx.BulkAdder(ctx, sp.flowCtx.ClientDB,
-		bufferSize, flushSize, writeTS)
+	adder, err := sp.flowCtx.Cfg.BulkAdder(ctx, sp.flowCtx.Cfg.DB, bufferSize, flushSize, writeTS)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/distsqlrun/colbatch_scan_test.go
+++ b/pkg/sql/distsqlrun/colbatch_scan_test.go
@@ -59,10 +59,10 @@ func BenchmarkColBatchScan(b *testing.B) {
 			defer evalCtx.Stop(ctx)
 
 			flowCtx := FlowCtx{
-				EvalCtx:  &evalCtx,
-				Settings: s.ClusterSettings(),
-				txn:      client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
-				NodeID:   s.NodeID(),
+				EvalCtx: &evalCtx,
+				Cfg:     &ServerConfig{Settings: s.ClusterSettings()},
+				txn:     client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
+				NodeID:  s.NodeID(),
 			}
 
 			b.SetBytes(int64(numRows * numCols * 8))

--- a/pkg/sql/distsqlrun/columnar_utils_test.go
+++ b/pkg/sql/distsqlrun/columnar_utils_test.go
@@ -49,10 +49,12 @@ func verifyColOperator(
 	diskMonitor := makeTestDiskMonitor(ctx, st)
 	defer diskMonitor.Stop(ctx)
 	flowCtx := &FlowCtx{
-		EvalCtx:     &evalCtx,
-		Settings:    st,
-		TempStorage: tempEngine,
-		diskMonitor: diskMonitor,
+		EvalCtx: &evalCtx,
+		Cfg: &ServerConfig{
+			Settings:    st,
+			TempStorage: tempEngine,
+			DiskMonitor: diskMonitor,
+		},
 	}
 
 	inputsProc := make([]RowSource, len(inputs))

--- a/pkg/sql/distsqlrun/columnarizer_test.go
+++ b/pkg/sql/distsqlrun/columnarizer_test.go
@@ -33,8 +33,8 @@ func BenchmarkColumnarize(b *testing.B) {
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
 	flowCtx := &FlowCtx{
-		Settings: st,
-		EvalCtx:  &evalCtx,
+		Cfg:     &ServerConfig{Settings: st},
+		EvalCtx: &evalCtx,
 	}
 
 	b.SetBytes(int64(nRows * nCols * int(unsafe.Sizeof(int64(0)))))

--- a/pkg/sql/distsqlrun/columnbackfiller.go
+++ b/pkg/sql/distsqlrun/columnbackfiller.go
@@ -86,14 +86,14 @@ func (cb *columnBackfiller) runChunk(
 	readAsOf hlc.Timestamp,
 ) (roachpb.Key, error) {
 	var key roachpb.Key
-	err := cb.flowCtx.ClientDB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-		if cb.flowCtx.testingKnobs.RunBeforeBackfillChunk != nil {
-			if err := cb.flowCtx.testingKnobs.RunBeforeBackfillChunk(sp); err != nil {
+	err := cb.flowCtx.Cfg.DB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+		if cb.flowCtx.Cfg.TestingKnobs.RunBeforeBackfillChunk != nil {
+			if err := cb.flowCtx.Cfg.TestingKnobs.RunBeforeBackfillChunk(sp); err != nil {
 				return err
 			}
 		}
-		if cb.flowCtx.testingKnobs.RunAfterBackfillChunk != nil {
-			defer cb.flowCtx.testingKnobs.RunAfterBackfillChunk()
+		if cb.flowCtx.Cfg.TestingKnobs.RunAfterBackfillChunk != nil {
+			defer cb.flowCtx.Cfg.TestingKnobs.RunAfterBackfillChunk()
 		}
 
 		// TODO(knz): do KV tracing in DistSQL processors.

--- a/pkg/sql/distsqlrun/distinct_test.go
+++ b/pkg/sql/distsqlrun/distinct_test.go
@@ -115,8 +115,8 @@ func TestDistinct(t *testing.T) {
 			evalCtx := tree.MakeTestingEvalContext(st)
 			defer evalCtx.Stop(context.Background())
 			flowCtx := FlowCtx{
-				Settings: st,
-				EvalCtx:  &evalCtx,
+				Cfg:     &ServerConfig{Settings: st},
+				EvalCtx: &evalCtx,
 			}
 
 			d, err := NewDistinct(&flowCtx, 0 /* processorID */, &ds, in, &distsqlpb.PostProcessSpec{}, out)
@@ -153,8 +153,8 @@ func benchmarkDistinct(b *testing.B, orderedColumns []uint32) {
 	defer evalCtx.Stop(ctx)
 
 	flowCtx := &FlowCtx{
-		Settings: st,
-		EvalCtx:  &evalCtx,
+		Cfg:     &ServerConfig{Settings: st},
+		EvalCtx: &evalCtx,
 	}
 	spec := &distsqlpb.DistinctSpec{
 		DistinctColumns: []uint32{0, 1},

--- a/pkg/sql/distsqlrun/flow_vectorize_space_test.go
+++ b/pkg/sql/distsqlrun/flow_vectorize_space_test.go
@@ -33,8 +33,8 @@ func TestVectorizeSpaceError(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 
 	flowCtx := &FlowCtx{
-		Settings: st,
-		EvalCtx:  &evalCtx,
+		Cfg:     &ServerConfig{Settings: st},
+		EvalCtx: &evalCtx,
 	}
 
 	// Without a limit, the default sorter creates a vectorized operator

--- a/pkg/sql/distsqlrun/inbound_test.go
+++ b/pkg/sql/distsqlrun/inbound_test.go
@@ -73,8 +73,11 @@ func TestOutboxInboundStreamIntegration(t *testing.T) {
 	// The outbox uses this stopper to run a goroutine.
 	outboxStopper := stop.NewStopper()
 	flowCtx := FlowCtx{
-		nodeDialer: nodedialer.New(rpcContext, staticAddressResolver(ln.Addr())),
-		stopper:    outboxStopper,
+		Cfg: &ServerConfig{
+			Settings:   st,
+			NodeDialer: nodedialer.New(rpcContext, staticAddressResolver(ln.Addr())),
+			Stopper:    outboxStopper,
+		},
 	}
 
 	streamID := distsqlpb.StreamID(1)

--- a/pkg/sql/distsqlrun/index_skip_table_reader_test.go
+++ b/pkg/sql/distsqlrun/index_skip_table_reader_test.go
@@ -404,10 +404,10 @@ func TestIndexSkipTableReader(t *testing.T) {
 			evalCtx := tree.MakeTestingEvalContext(s.ClusterSettings())
 			defer evalCtx.Stop(ctx)
 			flowCtx := FlowCtx{
-				EvalCtx:  &evalCtx,
-				Settings: s.ClusterSettings(),
-				txn:      client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
-				NodeID:   s.NodeID(),
+				EvalCtx: &evalCtx,
+				Cfg:     &ServerConfig{Settings: s.ClusterSettings()},
+				txn:     client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
+				NodeID:  s.NodeID(),
 			}
 
 			tr, err := newIndexSkipTableReader(&flowCtx, 0 /* processorID */, &ts, &c.post, nil)
@@ -475,10 +475,10 @@ ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[
 	defer evalCtx.Stop(ctx)
 	nodeID := tc.Server(0).NodeID()
 	flowCtx := FlowCtx{
-		EvalCtx:  &evalCtx,
-		Settings: st,
-		txn:      client.NewTxn(ctx, tc.Server(0).DB(), nodeID, client.RootTxn),
-		NodeID:   nodeID,
+		EvalCtx: &evalCtx,
+		Cfg:     &ServerConfig{Settings: st},
+		txn:     client.NewTxn(ctx, tc.Server(0).DB(), nodeID, client.RootTxn),
+		NodeID:  nodeID,
 	}
 	spec := distsqlpb.IndexSkipTableReaderSpec{
 		Spans: []distsqlpb.TableReaderSpan{{Span: td.PrimaryIndexSpan()}},
@@ -599,10 +599,10 @@ func BenchmarkIndexScanTableReader(b *testing.B) {
 			}
 
 			flowCtxTableReader := FlowCtx{
-				EvalCtx:  &evalCtx,
-				Settings: s.ClusterSettings(),
-				txn:      client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
-				NodeID:   s.NodeID(),
+				EvalCtx: &evalCtx,
+				Cfg:     &ServerConfig{Settings: s.ClusterSettings()},
+				txn:     client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
+				NodeID:  s.NodeID(),
 			}
 
 			b.Run(fmt.Sprintf("TableReader+Distinct-rows=%d-ratio=%d", numRows, valueRatio), func(b *testing.B) {
@@ -636,10 +636,10 @@ func BenchmarkIndexScanTableReader(b *testing.B) {
 			})
 
 			flowCtxIndexSkipTableReader := FlowCtx{
-				EvalCtx:  &evalCtx,
-				Settings: s.ClusterSettings(),
-				txn:      client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
-				NodeID:   s.NodeID(),
+				EvalCtx: &evalCtx,
+				Cfg:     &ServerConfig{Settings: s.ClusterSettings()},
+				txn:     client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
+				NodeID:  s.NodeID(),
 			}
 
 			// run the index skip table reader

--- a/pkg/sql/distsqlrun/interleaved_reader_joiner_test.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner_test.go
@@ -396,8 +396,8 @@ func TestInterleavedReaderJoiner(t *testing.T) {
 			evalCtx := tree.MakeTestingEvalContext(s.ClusterSettings())
 			defer evalCtx.Stop(ctx)
 			flowCtx := FlowCtx{
-				EvalCtx:  &evalCtx,
-				Settings: s.ClusterSettings(),
+				EvalCtx: &evalCtx,
+				Cfg:     &ServerConfig{Settings: s.ClusterSettings()},
 				// Run in a RootTxn so that there's no txn metadata produced.
 				txn:    client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
 				NodeID: s.NodeID(),
@@ -526,8 +526,8 @@ func TestInterleavedReaderJoinerErrors(t *testing.T) {
 			evalCtx := tree.MakeTestingEvalContext(s.ClusterSettings())
 			defer evalCtx.Stop(ctx)
 			flowCtx := FlowCtx{
-				EvalCtx:  &evalCtx,
-				Settings: s.ClusterSettings(),
+				EvalCtx: &evalCtx,
+				Cfg:     &ServerConfig{Settings: s.ClusterSettings()},
 				// Run in a RootTxn so that there's no txn metadata produced.
 				txn:    client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
 				NodeID: s.NodeID(),
@@ -584,8 +584,8 @@ func TestInterleavedReaderJoinerTrailingMetadata(t *testing.T) {
 	defer sp.Finish()
 
 	flowCtx := FlowCtx{
-		EvalCtx:  &evalCtx,
-		Settings: s.ClusterSettings(),
+		EvalCtx: &evalCtx,
+		Cfg:     &ServerConfig{Settings: s.ClusterSettings()},
 		// Run in a LeafTxn so that txn metadata is produced.
 		txn:    client.NewTxn(ctx, s.DB(), s.NodeID(), client.LeafTxn),
 		NodeID: s.NodeID(),

--- a/pkg/sql/distsqlrun/joinreader_test.go
+++ b/pkg/sql/distsqlrun/joinreader_test.go
@@ -382,9 +382,9 @@ func TestJoinReader(t *testing.T) {
 				evalCtx := tree.MakeTestingEvalContext(st)
 				defer evalCtx.Stop(ctx)
 				flowCtx := FlowCtx{
-					EvalCtx:  &evalCtx,
-					Settings: st,
-					txn:      client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
+					EvalCtx: &evalCtx,
+					Cfg:     &ServerConfig{Settings: st},
+					txn:     client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
 				}
 				encRows := make(sqlbase.EncDatumRows, len(c.input))
 				for rowIdx, row := range c.input {
@@ -474,9 +474,9 @@ func TestJoinReaderDrain(t *testing.T) {
 	defer sp.Finish()
 
 	flowCtx := FlowCtx{
-		EvalCtx:  &evalCtx,
-		Settings: s.ClusterSettings(),
-		txn:      client.NewTxn(ctx, s.DB(), s.NodeID(), client.LeafTxn),
+		EvalCtx: &evalCtx,
+		Cfg:     &ServerConfig{Settings: s.ClusterSettings()},
+		txn:     client.NewTxn(ctx, s.DB(), s.NodeID(), client.LeafTxn),
 	}
 
 	encRow := make(sqlbase.EncDatumRow, 1)
@@ -565,9 +565,9 @@ func BenchmarkJoinReader(b *testing.B) {
 	defer evalCtx.Stop(ctx)
 
 	flowCtx := FlowCtx{
-		EvalCtx:  &evalCtx,
-		Settings: s.ClusterSettings(),
-		txn:      client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
+		EvalCtx: &evalCtx,
+		Cfg:     &ServerConfig{Settings: s.ClusterSettings()},
+		txn:     client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
 	}
 
 	const numCols = 2

--- a/pkg/sql/distsqlrun/materializer_test.go
+++ b/pkg/sql/distsqlrun/materializer_test.go
@@ -40,8 +40,8 @@ func TestColumnarizeMaterialize(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
 	flowCtx := &FlowCtx{
-		Settings: st,
-		EvalCtx:  &evalCtx,
+		Cfg:     &ServerConfig{Settings: st},
+		EvalCtx: &evalCtx,
 	}
 	c, err := newColumnarizer(ctx, flowCtx, 0, input)
 	if err != nil {
@@ -122,8 +122,8 @@ func TestMaterializeTypes(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
 	flowCtx := &FlowCtx{
-		Settings: st,
-		EvalCtx:  &evalCtx,
+		Cfg:     &ServerConfig{Settings: st},
+		EvalCtx: &evalCtx,
 	}
 	c, err := newColumnarizer(ctx, flowCtx, 0, input)
 	if err != nil {
@@ -179,8 +179,8 @@ func BenchmarkColumnarizeMaterialize(b *testing.B) {
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
 	flowCtx := &FlowCtx{
-		Settings: st,
-		EvalCtx:  &evalCtx,
+		Cfg:     &ServerConfig{Settings: st},
+		EvalCtx: &evalCtx,
 	}
 	c, err := newColumnarizer(ctx, flowCtx, 0, input)
 	if err != nil {

--- a/pkg/sql/distsqlrun/mergejoiner_test.go
+++ b/pkg/sql/distsqlrun/mergejoiner_test.go
@@ -700,8 +700,8 @@ func TestMergeJoiner(t *testing.T) {
 			evalCtx := tree.MakeTestingEvalContext(st)
 			defer evalCtx.Stop(context.Background())
 			flowCtx := FlowCtx{
-				Settings: st,
-				EvalCtx:  &evalCtx,
+				Cfg:     &ServerConfig{Settings: st},
+				EvalCtx: &evalCtx,
 			}
 
 			post := distsqlpb.PostProcessSpec{Projection: true, OutputColumns: c.outCols}
@@ -806,8 +806,8 @@ func TestConsumerClosed(t *testing.T) {
 			evalCtx := tree.MakeTestingEvalContext(st)
 			defer evalCtx.Stop(context.Background())
 			flowCtx := FlowCtx{
-				Settings: st,
-				EvalCtx:  &evalCtx,
+				Cfg:     &ServerConfig{Settings: st},
+				EvalCtx: &evalCtx,
 			}
 			post := distsqlpb.PostProcessSpec{Projection: true, OutputColumns: outCols}
 			m, err := newMergeJoiner(&flowCtx, 0 /* processorID */, &spec, leftInput, rightInput, &post, out)
@@ -830,8 +830,8 @@ func BenchmarkMergeJoiner(b *testing.B) {
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
 	flowCtx := &FlowCtx{
-		Settings: st,
-		EvalCtx:  &evalCtx,
+		Cfg:     &ServerConfig{Settings: st},
+		EvalCtx: &evalCtx,
 	}
 
 	spec := &distsqlpb.MergeJoinerSpec{

--- a/pkg/sql/distsqlrun/noop_test.go
+++ b/pkg/sql/distsqlrun/noop_test.go
@@ -31,8 +31,8 @@ func BenchmarkNoop(b *testing.B) {
 	defer evalCtx.Stop(ctx)
 
 	flowCtx := &FlowCtx{
-		Settings: st,
-		EvalCtx:  &evalCtx,
+		Cfg:     &ServerConfig{Settings: st},
+		EvalCtx: &evalCtx,
 	}
 	post := &distsqlpb.PostProcessSpec{}
 	disposer := &RowDisposer{}

--- a/pkg/sql/distsqlrun/ordinality_test.go
+++ b/pkg/sql/distsqlrun/ordinality_test.go
@@ -109,8 +109,8 @@ func TestOrdinality(t *testing.T) {
 			evalCtx := tree.MakeTestingEvalContext(st)
 			defer evalCtx.Stop(context.Background())
 			flowCtx := FlowCtx{
-				Settings: st,
-				EvalCtx:  &evalCtx,
+				Cfg:     &ServerConfig{Settings: st},
+				EvalCtx: &evalCtx,
 			}
 
 			d, err := newOrdinalityProcessor(&flowCtx, 0 /* processorID */, &os, in, &distsqlpb.PostProcessSpec{}, out)
@@ -156,8 +156,8 @@ func BenchmarkOrdinality(b *testing.B) {
 	defer evalCtx.Stop(ctx)
 
 	flowCtx := &FlowCtx{
-		Settings: st,
-		EvalCtx:  &evalCtx,
+		Cfg:     &ServerConfig{Settings: st},
+		EvalCtx: &evalCtx,
 	}
 	spec := &distsqlpb.OrdinalitySpec{}
 

--- a/pkg/sql/distsqlrun/outbox.go
+++ b/pkg/sql/distsqlrun/outbox.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 	"google.golang.org/grpc"
 )
 
@@ -217,7 +217,7 @@ func (m *outbox) mainLoop(ctx context.Context) error {
 	if m.stream == nil {
 		var conn *grpc.ClientConn
 		var err error
-		conn, err = m.flowCtx.nodeDialer.Dial(ctx, m.nodeID)
+		conn, err = m.flowCtx.Cfg.NodeDialer.Dial(ctx, m.nodeID)
 		if err != nil {
 			return err
 		}
@@ -275,7 +275,7 @@ func (m *outbox) mainLoop(ctx context.Context) error {
 					if err != nil {
 						return nil
 					}
-					if m.flowCtx.testingKnobs.DeterministicStats {
+					if m.flowCtx.Cfg.TestingKnobs.DeterministicStats {
 						m.stats.BytesSent = 0
 					}
 					tracing.SetSpanStats(span, &m.stats)
@@ -365,7 +365,7 @@ func (m *outbox) listenForDrainSignalFromConsumer(ctx context.Context) (<-chan d
 	ch := make(chan drainSignal, 1)
 
 	stream := m.stream
-	if err := m.flowCtx.stopper.RunAsyncTask(ctx, "drain", func(ctx context.Context) {
+	if err := m.flowCtx.Cfg.Stopper.RunAsyncTask(ctx, "drain", func(ctx context.Context) {
 		sendDrainSignal := func(drainRequested bool, err error) bool {
 			select {
 			case ch <- drainSignal{drainRequested: drainRequested, err: err}:

--- a/pkg/sql/distsqlrun/outbox_test.go
+++ b/pkg/sql/distsqlrun/outbox_test.go
@@ -64,10 +64,12 @@ func TestOutbox(t *testing.T) {
 
 	clientRPC := rpc.NewInsecureTestingContextWithClusterID(clock, stopper, clusterID)
 	flowCtx := FlowCtx{
-		Settings:   st,
-		stopper:    stopper,
-		EvalCtx:    &evalCtx,
-		nodeDialer: nodedialer.New(clientRPC, staticAddressResolver(addr)),
+		EvalCtx: &evalCtx,
+		Cfg: &ServerConfig{
+			Settings:   st,
+			Stopper:    stopper,
+			NodeDialer: nodedialer.New(clientRPC, staticAddressResolver(addr)),
+		},
 	}
 	flowID := distsqlpb.FlowID{UUID: uuid.MakeV4()}
 	streamID := distsqlpb.StreamID(42)
@@ -218,10 +220,12 @@ func TestOutboxInitializesStreamBeforeReceivingAnyRows(t *testing.T) {
 
 	clientRPC := rpc.NewInsecureTestingContextWithClusterID(clock, stopper, clusterID)
 	flowCtx := FlowCtx{
-		Settings:   st,
-		stopper:    stopper,
-		EvalCtx:    &evalCtx,
-		nodeDialer: nodedialer.New(clientRPC, staticAddressResolver(addr)),
+		EvalCtx: &evalCtx,
+		Cfg: &ServerConfig{
+			Settings:   st,
+			Stopper:    stopper,
+			NodeDialer: nodedialer.New(clientRPC, staticAddressResolver(addr)),
+		},
 	}
 	flowID := distsqlpb.FlowID{UUID: uuid.MakeV4()}
 	streamID := distsqlpb.StreamID(42)
@@ -290,10 +294,12 @@ func TestOutboxClosesWhenConsumerCloses(t *testing.T) {
 
 			clientRPC := rpc.NewInsecureTestingContextWithClusterID(clock, stopper, clusterID)
 			flowCtx := FlowCtx{
-				Settings:   st,
-				stopper:    stopper,
-				EvalCtx:    &evalCtx,
-				nodeDialer: nodedialer.New(clientRPC, staticAddressResolver(addr)),
+				EvalCtx: &evalCtx,
+				Cfg: &ServerConfig{
+					Settings:   st,
+					Stopper:    stopper,
+					NodeDialer: nodedialer.New(clientRPC, staticAddressResolver(addr)),
+				},
 			}
 			flowID := distsqlpb.FlowID{UUID: uuid.MakeV4()}
 			streamID := distsqlpb.StreamID(42)
@@ -329,7 +335,7 @@ func TestOutboxClosesWhenConsumerCloses(t *testing.T) {
 			} else {
 				// We're going to perform a RunSyncFlow call and then have the client
 				// cancel the call's context.
-				conn, err := flowCtx.nodeDialer.Dial(ctx, staticNodeID)
+				conn, err := flowCtx.Cfg.NodeDialer.Dial(ctx, staticNodeID)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -365,7 +371,12 @@ func TestOutboxClosesWhenConsumerCloses(t *testing.T) {
 				// Wait for the consumer to connect.
 				call := <-mockServer.RunSyncFlowCalls
 				outbox = newOutboxSyncFlowStream(call.Stream)
-				outbox.setFlowCtx(&FlowCtx{Settings: cluster.MakeTestingClusterSettings(), stopper: stopper})
+				outbox.setFlowCtx(&FlowCtx{
+					Cfg: &ServerConfig{
+						Settings: cluster.MakeTestingClusterSettings(),
+						Stopper:  stopper,
+					},
+				})
 				outbox.init(sqlbase.OneIntCol)
 				// In a RunSyncFlow call, the outbox runs under the call's context.
 				outbox.start(call.Stream.Context(), &wg, cancel)
@@ -419,10 +430,12 @@ func TestOutboxCancelsFlowOnError(t *testing.T) {
 
 	clientRPC := rpc.NewInsecureTestingContextWithClusterID(clock, stopper, clusterID)
 	flowCtx := FlowCtx{
-		Settings:   st,
-		stopper:    stopper,
-		EvalCtx:    &evalCtx,
-		nodeDialer: nodedialer.New(clientRPC, staticAddressResolver(addr)),
+		EvalCtx: &evalCtx,
+		Cfg: &ServerConfig{
+			Settings:   st,
+			Stopper:    stopper,
+			NodeDialer: nodedialer.New(clientRPC, staticAddressResolver(addr)),
+		},
 	}
 	flowID := distsqlpb.FlowID{UUID: uuid.MakeV4()}
 	streamID := distsqlpb.StreamID(42)
@@ -469,11 +482,13 @@ func TestOutboxUnblocksProducers(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
 	flowCtx := FlowCtx{
-		Settings: st,
-		stopper:  stopper,
-		EvalCtx:  &evalCtx,
-		// a nil nodeDialer will always fail to connect.
-		nodeDialer: nil,
+		EvalCtx: &evalCtx,
+		Cfg: &ServerConfig{
+			Settings: st,
+			Stopper:  stopper,
+			// a nil nodeDialer will always fail to connect.
+			NodeDialer: nil,
+		},
 	}
 	flowID := distsqlpb.FlowID{UUID: uuid.MakeV4()}
 	streamID := distsqlpb.StreamID(42)
@@ -539,10 +554,12 @@ func BenchmarkOutbox(b *testing.B) {
 
 			clientRPC := rpc.NewInsecureTestingContextWithClusterID(clock, stopper, clusterID)
 			flowCtx := FlowCtx{
-				Settings:   st,
-				stopper:    stopper,
-				EvalCtx:    &evalCtx,
-				nodeDialer: nodedialer.New(clientRPC, staticAddressResolver(addr)),
+				EvalCtx: &evalCtx,
+				Cfg: &ServerConfig{
+					Settings:   st,
+					Stopper:    stopper,
+					NodeDialer: nodedialer.New(clientRPC, staticAddressResolver(addr)),
+				},
 			}
 			outbox := newOutbox(&flowCtx, staticNodeID, flowID, streamID)
 			outbox.init(sqlbase.MakeIntCols(numCols))

--- a/pkg/sql/distsqlrun/processor_utils_test.go
+++ b/pkg/sql/distsqlrun/processor_utils_test.go
@@ -37,8 +37,8 @@ func DefaultProcessorTestConfig() ProcessorTestConfig {
 	evalCtx := tree.MakeTestingEvalContext(st)
 	return ProcessorTestConfig{
 		FlowCtx: &FlowCtx{
-			Settings: st,
-			EvalCtx:  &evalCtx,
+			Cfg:     &ServerConfig{Settings: st},
+			EvalCtx: &evalCtx,
 		},
 	}
 }

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -24,7 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -922,7 +922,7 @@ func getInputStats(flowCtx *FlowCtx, input RowSource) (InputStats, bool) {
 	if !ok {
 		return InputStats{}, false
 	}
-	if flowCtx.testingKnobs.DeterministicStats {
+	if flowCtx.Cfg.TestingKnobs.DeterministicStats {
 		isc.InputStats.StallTime = 0
 	}
 	return isc.InputStats, true
@@ -938,7 +938,7 @@ func getFetcherInputStats(flowCtx *FlowCtx, f rowFetcher) (InputStats, bool) {
 		return InputStats{}, false
 	}
 	// Add row fetcher start scan stall time to Next() stall time.
-	if !flowCtx.testingKnobs.DeterministicStats {
+	if !flowCtx.Cfg.TestingKnobs.DeterministicStats {
 		is.StallTime += rfsc.startScanStallTime
 	}
 	return is, true

--- a/pkg/sql/distsqlrun/processors_test.go
+++ b/pkg/sql/distsqlrun/processors_test.go
@@ -410,8 +410,8 @@ func TestProcessorBaseContext(t *testing.T) {
 	runTest := func(t *testing.T, f func(noop *noopProcessor)) {
 		evalCtx := tree.MakeTestingEvalContext(st)
 		flowCtx := &FlowCtx{
-			Settings: st,
-			EvalCtx:  &evalCtx,
+			Cfg:     &ServerConfig{Settings: st},
+			EvalCtx: &evalCtx,
 		}
 		defer flowCtx.EvalCtx.Stop(ctx)
 

--- a/pkg/sql/distsqlrun/project_set_test.go
+++ b/pkg/sql/distsqlrun/project_set_test.go
@@ -155,9 +155,9 @@ func BenchmarkProjectSet(b *testing.B) {
 		b.Run(c.description, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				flowCtx := FlowCtx{
-					Settings: st,
-					EvalCtx:  &evalCtx,
-					txn:      nil,
+					Cfg:     &ServerConfig{Settings: st},
+					EvalCtx: &evalCtx,
+					txn:     nil,
 				}
 
 				in := NewRowBuffer(c.inputTypes, c.input, RowBufferArgs{})

--- a/pkg/sql/distsqlrun/routers.go
+++ b/pkg/sql/distsqlrun/routers.go
@@ -31,7 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -242,7 +242,7 @@ func (rb *routerBase) init(ctx context.Context, flowCtx *FlowCtx, types []types.
 		// to take the mutex.
 		evalCtx := flowCtx.NewEvalCtx()
 		memoryMonitor := evalCtx.Mon
-		diskMonitor := flowCtx.diskMonitor
+		diskMonitor := flowCtx.Cfg.DiskMonitor
 		if rb.statsCollectionEnabled {
 			// Start private monitors for stats collection.
 			memoryMonitorName := fmt.Sprintf("router-stat-mem-%d", rb.outputs[i].streamID)
@@ -255,7 +255,7 @@ func (rb *routerBase) init(ctx context.Context, flowCtx *FlowCtx, types []types.
 			nil, /* ordering */
 			types,
 			evalCtx,
-			flowCtx.TempStorage,
+			flowCtx.Cfg.TempStorage,
 			memoryMonitor,
 			diskMonitor,
 			0, /* rowCapacity */

--- a/pkg/sql/distsqlrun/sample_aggregator_test.go
+++ b/pkg/sql/distsqlrun/sample_aggregator_test.go
@@ -41,11 +41,13 @@ func TestSampleAggregator(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(context.Background())
 	flowCtx := FlowCtx{
-		Settings: st,
-		EvalCtx:  &evalCtx,
-		Gossip:   server.Gossip(),
-		ClientDB: kvDB,
-		executor: server.InternalExecutor().(sqlutil.InternalExecutor),
+		EvalCtx: &evalCtx,
+		Cfg: &ServerConfig{
+			Settings: st,
+			DB:       kvDB,
+			Executor: server.InternalExecutor().(sqlutil.InternalExecutor),
+			Gossip:   server.Gossip(),
+		},
 	}
 
 	inputRows := [][]int{

--- a/pkg/sql/distsqlrun/sampler.go
+++ b/pkg/sql/distsqlrun/sampler.go
@@ -225,7 +225,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 				//  - if it is lower than cpuUsageMinThrottle, we do not throttle;
 				//  - if it is higher than cpuUsageMaxThrottle, we throttle all the way;
 				//  - in-between, we scale the idle time proportionally.
-				usage := s.flowCtx.RuntimeStats.GetCPUCombinedPercentNorm()
+				usage := s.flowCtx.Cfg.RuntimeStats.GetCPUCombinedPercentNorm()
 
 				if usage > cpuUsageMinThrottle {
 					fractionIdle := s.maxFractionIdle

--- a/pkg/sql/distsqlrun/sampler_test.go
+++ b/pkg/sql/distsqlrun/sampler_test.go
@@ -46,8 +46,8 @@ func runSampler(t *testing.T, numRows, numSamples int) []int {
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(context.Background())
 	flowCtx := FlowCtx{
-		Settings: st,
-		EvalCtx:  &evalCtx,
+		Cfg:     &ServerConfig{Settings: st},
+		EvalCtx: &evalCtx,
 	}
 
 	spec := &distsqlpb.SamplerSpec{SampleSize: uint32(numSamples)}
@@ -170,8 +170,8 @@ func TestSamplerSketch(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(context.Background())
 	flowCtx := FlowCtx{
-		Settings: st,
-		EvalCtx:  &evalCtx,
+		Cfg:     &ServerConfig{Settings: st},
+		EvalCtx: &evalCtx,
 	}
 
 	spec := &distsqlpb.SamplerSpec{

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -438,24 +438,12 @@ func (ds *ServerImpl) setupFlow(
 	}
 	// TODO(radu): we should sanity check some of these fields.
 	flowCtx := FlowCtx{
-		Settings:       ds.Settings,
-		RuntimeStats:   ds.RuntimeStats,
 		AmbientContext: ds.AmbientContext,
-		stopper:        ds.Stopper,
+		Cfg:            &ds.ServerConfig,
 		id:             req.Flow.FlowID,
 		EvalCtx:        evalCtx,
-		nodeDialer:     ds.NodeDialer,
-		Gossip:         ds.Gossip,
 		txn:            txn,
-		ClientDB:       ds.DB,
-		executor:       ds.Executor,
-		LeaseManager:   ds.LeaseManager,
-		testingKnobs:   ds.TestingKnobs,
 		NodeID:         nodeID,
-		TempStorage:    ds.TempStorage,
-		BulkAdder:      ds.BulkAdder,
-		diskMonitor:    ds.DiskMonitor,
-		JobRegistry:    ds.JobRegistry,
 		traceKV:        req.TraceKV,
 		local:          localState.IsLocal,
 	}

--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -57,15 +57,15 @@ func (s *sorterBase) init(
 		s.finishTrace = s.outputStatsToTrace
 	}
 
-	useTempStorage := settingUseTempStorageSorts.Get(&flowCtx.Settings.SV) ||
-		flowCtx.testingKnobs.MemoryLimitBytes > 0
+	useTempStorage := settingUseTempStorageSorts.Get(&flowCtx.Cfg.Settings.SV) ||
+		flowCtx.Cfg.TestingKnobs.MemoryLimitBytes > 0
 	var memMonitor *mon.BytesMonitor
 	if useTempStorage {
 		// Limit the memory use by creating a child monitor with a hard limit.
 		// The processor will overflow to disk if this limit is not enough.
-		limit := flowCtx.testingKnobs.MemoryLimitBytes
+		limit := flowCtx.Cfg.TestingKnobs.MemoryLimitBytes
 		if limit <= 0 {
-			limit = settingWorkMemBytes.Get(&flowCtx.Settings.SV)
+			limit = settingWorkMemBytes.Get(&flowCtx.Cfg.Settings.SV)
 		}
 		limitedMon := mon.MakeMonitorInheritWithLimit(
 			"sortall-limited", limit, flowCtx.EvalCtx.Mon,
@@ -84,13 +84,13 @@ func (s *sorterBase) init(
 	}
 
 	if useTempStorage {
-		s.diskMonitor = NewMonitor(ctx, flowCtx.diskMonitor, "sorter-disk")
+		s.diskMonitor = NewMonitor(ctx, flowCtx.Cfg.DiskMonitor, "sorter-disk")
 		rc := rowcontainer.DiskBackedRowContainer{}
 		rc.Init(
 			ordering,
 			input.OutputTypes(),
 			s.evalCtx,
-			flowCtx.TempStorage,
+			flowCtx.Cfg.TempStorage,
 			memMonitor,
 			s.diskMonitor,
 			0, /* rowCapacity */

--- a/pkg/sql/distsqlrun/sorter_test.go
+++ b/pkg/sql/distsqlrun/sorter_test.go
@@ -302,15 +302,17 @@ func TestSorter(t *testing.T) {
 						diskMonitor := makeTestDiskMonitor(ctx, st)
 						defer diskMonitor.Stop(ctx)
 						flowCtx := FlowCtx{
-							EvalCtx:     &evalCtx,
-							Settings:    cluster.MakeTestingClusterSettings(),
-							TempStorage: tempEngine,
-							diskMonitor: diskMonitor,
+							EvalCtx: &evalCtx,
+							Cfg: &ServerConfig{
+								Settings:    cluster.MakeTestingClusterSettings(),
+								TempStorage: tempEngine,
+								DiskMonitor: diskMonitor,
+							},
 						}
 						// Override the default memory limit. This will result in using
 						// a memory row container which will hit this limit and fall
 						// back to using a disk row container.
-						flowCtx.testingKnobs.MemoryLimitBytes = memLimit.bytes
+						flowCtx.Cfg.TestingKnobs.MemoryLimitBytes = memLimit.bytes
 
 						in := NewRowBuffer(c.types, c.input, RowBufferArgs{})
 						out := &RowBuffer{}
@@ -415,9 +417,11 @@ func BenchmarkSortAll(b *testing.B) {
 	diskMonitor := makeTestDiskMonitor(ctx, st)
 	defer diskMonitor.Stop(ctx)
 	flowCtx := FlowCtx{
-		Settings:    st,
-		EvalCtx:     &evalCtx,
-		diskMonitor: diskMonitor,
+		EvalCtx: &evalCtx,
+		Cfg: &ServerConfig{
+			Settings:    st,
+			DiskMonitor: diskMonitor,
+		},
 	}
 
 	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
@@ -455,9 +459,11 @@ func BenchmarkSortLimit(b *testing.B) {
 	diskMonitor := makeTestDiskMonitor(ctx, st)
 	defer diskMonitor.Stop(ctx)
 	flowCtx := FlowCtx{
-		Settings:    st,
-		EvalCtx:     &evalCtx,
-		diskMonitor: diskMonitor,
+		EvalCtx: &evalCtx,
+		Cfg: &ServerConfig{
+			Settings:    st,
+			DiskMonitor: diskMonitor,
+		},
 	}
 
 	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
@@ -499,9 +505,11 @@ func BenchmarkSortChunks(b *testing.B) {
 	diskMonitor := makeTestDiskMonitor(ctx, st)
 	defer diskMonitor.Stop(ctx)
 	flowCtx := FlowCtx{
-		Settings:    st,
-		EvalCtx:     &evalCtx,
-		diskMonitor: diskMonitor,
+		EvalCtx: &evalCtx,
+		Cfg: &ServerConfig{
+			Settings:    st,
+			DiskMonitor: diskMonitor,
+		},
 	}
 
 	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -24,7 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -42,7 +42,7 @@ func scanShouldLimitBatches(maxResults uint64, limitHint int64, flowCtx *FlowCtx
 	if maxResults != 0 &&
 		maxResults < ParallelScanResultThreshold &&
 		limitHint == 0 &&
-		sqlbase.ParallelScans.Get(&flowCtx.Settings.SV) {
+		sqlbase.ParallelScans.Get(&flowCtx.Cfg.Settings.SV) {
 		return false
 	}
 	return true
@@ -232,7 +232,7 @@ func (tr *tableReader) Start(ctx context.Context) context.Context {
 	} else {
 		initialTS := tr.flowCtx.txn.GetTxnCoordMeta(ctx).Txn.OrigTimestamp
 		err = tr.fetcher.StartInconsistentScan(
-			fetcherCtx, tr.flowCtx.ClientDB, initialTS,
+			fetcherCtx, tr.flowCtx.Cfg.DB, initialTS,
 			tr.maxTimestampAge, tr.spans,
 			limitBatches, tr.limitHint, tr.flowCtx.traceKV,
 		)

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/gogo/protobuf/types"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 func TestTableReader(t *testing.T) {
@@ -126,10 +126,10 @@ func TestTableReader(t *testing.T) {
 				evalCtx := tree.MakeTestingEvalContext(s.ClusterSettings())
 				defer evalCtx.Stop(ctx)
 				flowCtx := FlowCtx{
-					EvalCtx:  &evalCtx,
-					Settings: s.ClusterSettings(),
-					txn:      client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
-					NodeID:   s.NodeID(),
+					EvalCtx: &evalCtx,
+					Cfg:     &ServerConfig{Settings: s.ClusterSettings()},
+					txn:     client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
+					NodeID:  s.NodeID(),
 				}
 
 				var out RowReceiver
@@ -211,10 +211,10 @@ ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[
 	defer evalCtx.Stop(ctx)
 	nodeID := tc.Server(0).NodeID()
 	flowCtx := FlowCtx{
-		EvalCtx:  &evalCtx,
-		Settings: st,
-		txn:      client.NewTxn(ctx, tc.Server(0).DB(), nodeID, client.RootTxn),
-		NodeID:   nodeID,
+		EvalCtx: &evalCtx,
+		Cfg:     &ServerConfig{Settings: st},
+		txn:     client.NewTxn(ctx, tc.Server(0).DB(), nodeID, client.RootTxn),
+		NodeID:  nodeID,
 	}
 	spec := distsqlpb.TableReaderSpec{
 		Spans: []distsqlpb.TableReaderSpan{{Span: td.PrimaryIndexSpan()}},
@@ -316,10 +316,10 @@ func TestLimitScans(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext(s.ClusterSettings())
 	defer evalCtx.Stop(ctx)
 	flowCtx := FlowCtx{
-		EvalCtx:  &evalCtx,
-		Settings: s.ClusterSettings(),
-		txn:      client.NewTxn(ctx, kvDB, s.NodeID(), client.RootTxn),
-		NodeID:   s.NodeID(),
+		EvalCtx: &evalCtx,
+		Cfg:     &ServerConfig{Settings: s.ClusterSettings()},
+		txn:     client.NewTxn(ctx, kvDB, s.NodeID(), client.RootTxn),
+		NodeID:  s.NodeID(),
 	}
 	spec := distsqlpb.TableReaderSpec{
 		Table: *tableDesc,
@@ -420,10 +420,10 @@ func BenchmarkTableReader(b *testing.B) {
 		)
 		tableDesc := sqlbase.GetTableDescriptor(kvDB, "test", tableName)
 		flowCtx := FlowCtx{
-			EvalCtx:  &evalCtx,
-			Settings: s.ClusterSettings(),
-			txn:      client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
-			NodeID:   s.NodeID(),
+			EvalCtx: &evalCtx,
+			Cfg:     &ServerConfig{Settings: s.ClusterSettings()},
+			txn:     client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
+			NodeID:  s.NodeID(),
 		}
 
 		b.Run(fmt.Sprintf("rows=%d", numRows), func(b *testing.B) {

--- a/pkg/sql/distsqlrun/utils_test.go
+++ b/pkg/sql/distsqlrun/utils_test.go
@@ -185,9 +185,9 @@ func runProcessorTest(
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(context.Background())
 	flowCtx := FlowCtx{
-		Settings: st,
-		EvalCtx:  &evalCtx,
-		txn:      txn,
+		Cfg:     &ServerConfig{Settings: st},
+		EvalCtx: &evalCtx,
+		txn:     txn,
 	}
 
 	p, err := newProcessor(

--- a/pkg/sql/distsqlrun/values_test.go
+++ b/pkg/sql/distsqlrun/values_test.go
@@ -72,8 +72,8 @@ func TestValuesProcessor(t *testing.T) {
 					evalCtx := tree.NewTestingEvalContext(st)
 					defer evalCtx.Stop(context.Background())
 					flowCtx := FlowCtx{
-						Settings: st,
-						EvalCtx:  evalCtx,
+						Cfg:     &ServerConfig{Settings: st},
+						EvalCtx: evalCtx,
 					}
 
 					v, err := newValuesProcessor(&flowCtx, 0 /* processorID */, &spec, &distsqlpb.PostProcessSpec{}, out)
@@ -131,8 +131,8 @@ func BenchmarkValuesProcessor(b *testing.B) {
 	defer evalCtx.Stop(ctx)
 
 	flowCtx := FlowCtx{
-		Settings: st,
-		EvalCtx:  &evalCtx,
+		Cfg:     &ServerConfig{Settings: st},
+		EvalCtx: &evalCtx,
 	}
 	post := distsqlpb.PostProcessSpec{}
 	output := RowDisposer{}

--- a/pkg/sql/distsqlrun/vectorized_error_propagation_test.go
+++ b/pkg/sql/distsqlrun/vectorized_error_propagation_test.go
@@ -36,8 +36,8 @@ func TestVectorizedErrorPropagation(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 
 	flowCtx := FlowCtx{
-		EvalCtx:  &evalCtx,
-		Settings: cluster.MakeTestingClusterSettings(),
+		EvalCtx: &evalCtx,
+		Cfg:     &ServerConfig{Settings: cluster.MakeTestingClusterSettings()},
 	}
 
 	nRows, nCols := 1, 1
@@ -97,8 +97,8 @@ func TestNonVectorizedErrorPropagation(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 
 	flowCtx := FlowCtx{
-		EvalCtx:  &evalCtx,
-		Settings: cluster.MakeTestingClusterSettings(),
+		EvalCtx: &evalCtx,
+		Cfg:     &ServerConfig{Settings: cluster.MakeTestingClusterSettings()},
 	}
 
 	nRows, nCols := 1, 1

--- a/pkg/sql/distsqlrun/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/distsqlrun/vectorized_flow_shutdown_test.go
@@ -144,8 +144,8 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 				evalCtx := tree.MakeTestingEvalContext(st)
 				defer evalCtx.Stop(ctxLocal)
 				flowCtx := &FlowCtx{
-					EvalCtx:  &evalCtx,
-					Settings: st,
+					EvalCtx: &evalCtx,
+					Cfg:     &ServerConfig{Settings: st},
 				}
 
 				rng, _ := randutil.NewPseudoRand()

--- a/pkg/sql/distsqlrun/vectorized_meta_propagation_test.go
+++ b/pkg/sql/distsqlrun/vectorized_meta_propagation_test.go
@@ -37,8 +37,8 @@ func TestVectorizedMetaPropagation(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 
 	flowCtx := FlowCtx{
-		EvalCtx:  &evalCtx,
-		Settings: cluster.MakeTestingClusterSettings(),
+		EvalCtx: &evalCtx,
+		Cfg:     &ServerConfig{Settings: cluster.MakeTestingClusterSettings()},
 	}
 
 	nRows := 10

--- a/pkg/sql/distsqlrun/windower.go
+++ b/pkg/sql/distsqlrun/windower.go
@@ -162,7 +162,7 @@ func newWindower(
 	ctx := evalCtx.Ctx()
 	memMonitor := NewMonitor(ctx, evalCtx.Mon, "windower-mem")
 	w.acc = memMonitor.MakeBoundAccount()
-	w.diskMonitor = NewMonitor(ctx, flowCtx.diskMonitor, "windower-disk")
+	w.diskMonitor = NewMonitor(ctx, flowCtx.Cfg.DiskMonitor, "windower-disk")
 	if sp := opentracing.SpanFromContext(ctx); sp != nil && tracing.IsRecording(sp) {
 		w.input = NewInputStatCollector(w.input)
 		w.finishTrace = w.outputStatsToTrace
@@ -175,7 +175,7 @@ func newWindower(
 		evalCtx,
 		memMonitor,
 		w.diskMonitor,
-		flowCtx.TempStorage,
+		flowCtx.Cfg.TempStorage,
 	)
 	w.allRowsPartitioned = &allRowsPartitioned
 	if err := w.allRowsPartitioned.Init(
@@ -667,7 +667,7 @@ func (w *windower) computeWindowFunctions(ctx context.Context, evalCtx *tree.Eva
 		ordering,
 		w.inputTypes,
 		w.evalCtx,
-		w.flowCtx.TempStorage,
+		w.flowCtx.Cfg.TempStorage,
 		w.MemMonitor,
 		w.diskMonitor,
 		0, /* rowCapacity */

--- a/pkg/sql/distsqlrun/windower_test.go
+++ b/pkg/sql/distsqlrun/windower_test.go
@@ -55,10 +55,12 @@ func TestWindowerAccountingForResults(t *testing.T) {
 	defer tempEngine.Close()
 
 	flowCtx := &FlowCtx{
-		Settings:    st,
-		EvalCtx:     &evalCtx,
-		diskMonitor: diskMonitor,
-		TempStorage: tempEngine,
+		EvalCtx: &evalCtx,
+		Cfg: &ServerConfig{
+			Settings:    st,
+			TempStorage: tempEngine,
+			DiskMonitor: diskMonitor,
+		},
 	}
 
 	post := &distsqlpb.PostProcessSpec{}
@@ -199,9 +201,11 @@ func BenchmarkWindower(b *testing.B) {
 	defer diskMonitor.Stop(ctx)
 
 	flowCtx := &FlowCtx{
-		Settings:    st,
-		EvalCtx:     &evalCtx,
-		diskMonitor: diskMonitor,
+		EvalCtx: &evalCtx,
+		Cfg: &ServerConfig{
+			Settings:    st,
+			DiskMonitor: diskMonitor,
+		},
 	}
 
 	rowsGenerators := []func(int, int) sqlbase.EncDatumRows{

--- a/pkg/sql/distsqlrun/zigzagjoiner_test.go
+++ b/pkg/sql/distsqlrun/zigzagjoiner_test.go
@@ -498,9 +498,9 @@ func TestZigzagJoiner(t *testing.T) {
 			evalCtx := tree.MakeTestingEvalContext(st)
 			defer evalCtx.Stop(ctx)
 			flowCtx := FlowCtx{
-				EvalCtx:  &evalCtx,
-				Settings: st,
-				txn:      client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
+				EvalCtx: &evalCtx,
+				Cfg:     &ServerConfig{Settings: st},
+				txn:     client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
 			}
 
 			out := &RowBuffer{}
@@ -561,9 +561,9 @@ func TestZigzagJoinerDrain(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext(s.ClusterSettings())
 	defer evalCtx.Stop(ctx)
 	flowCtx := FlowCtx{
-		EvalCtx:  &evalCtx,
-		Settings: s.ClusterSettings(),
-		txn:      client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
+		EvalCtx: &evalCtx,
+		Cfg:     &ServerConfig{Settings: s.ClusterSettings()},
+		txn:     client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
 	}
 
 	encRow := make(sqlbase.EncDatumRow, 1)


### PR DESCRIPTION
The `FlowCtx` structure duplicates many of the fields in
`ServerConfig`. This change replaces these duplicate fields with a
pointer to the `ServerConfig`.

Release note: None