### PR TITLE
cli: deprecate 'cockroach user'

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -601,6 +601,7 @@ func Example_sql() {
 	// sql -e copy t.f from stdin
 	// woops! COPY has confused this client! Suggestion: use 'psql' for COPY
 	// user ls --echo-sql
+	// warning: This command is deprecated. Use SHOW USERS or SHOW ROLES in a SQL session.
 	// > SHOW USERS
 	// user_name
 	// root
@@ -1411,57 +1412,80 @@ func Example_user() {
 
 	// Output:
 	// user ls
+	// warning: This command is deprecated. Use SHOW USERS or SHOW ROLES in a SQL session.
 	// user_name
 	// root
 	// user ls --format=table
+	// warning: This command is deprecated. Use SHOW USERS or SHOW ROLES in a SQL session.
 	//   user_name
 	// +-----------+
 	//   root
 	// (1 row)
 	// user ls --format=tsv
+	// warning: This command is deprecated. Use SHOW USERS or SHOW ROLES in a SQL session.
 	// user_name
 	// root
 	// user set FOO
+	// warning: This command is deprecated. Use CREATE USER or ALTER USER ... WITH PASSWORD ... in a SQL session.
 	// CREATE USER 1
 	// sql -e create user if not exists 'FOO'
 	// CREATE USER 0
 	// user set Foo
+	// warning: This command is deprecated. Use CREATE USER or ALTER USER ... WITH PASSWORD ... in a SQL session.
 	// CREATE USER 0
 	// user set fOo
+	// warning: This command is deprecated. Use CREATE USER or ALTER USER ... WITH PASSWORD ... in a SQL session.
 	// CREATE USER 0
 	// user set foO
+	// warning: This command is deprecated. Use CREATE USER or ALTER USER ... WITH PASSWORD ... in a SQL session.
 	// CREATE USER 0
 	// user set foo
+	// warning: This command is deprecated. Use CREATE USER or ALTER USER ... WITH PASSWORD ... in a SQL session.
 	// CREATE USER 0
 	// user set _foo
+	// warning: This command is deprecated. Use CREATE USER or ALTER USER ... WITH PASSWORD ... in a SQL session.
 	// CREATE USER 1
 	// user set f_oo
+	// warning: This command is deprecated. Use CREATE USER or ALTER USER ... WITH PASSWORD ... in a SQL session.
 	// CREATE USER 1
 	// user set foo_
+	// warning: This command is deprecated. Use CREATE USER or ALTER USER ... WITH PASSWORD ... in a SQL session.
 	// CREATE USER 1
 	// user set ,foo
+	// warning: This command is deprecated. Use CREATE USER or ALTER USER ... WITH PASSWORD ... in a SQL session.
 	// pq: username ",foo" invalid; usernames are case insensitive, must start with a letter or underscore, may contain letters, digits, dashes, or underscores, and must not exceed 63 characters
 	// user set f,oo
+	// warning: This command is deprecated. Use CREATE USER or ALTER USER ... WITH PASSWORD ... in a SQL session.
 	// pq: username "f,oo" invalid; usernames are case insensitive, must start with a letter or underscore, may contain letters, digits, dashes, or underscores, and must not exceed 63 characters
 	// user set foo,
+	// warning: This command is deprecated. Use CREATE USER or ALTER USER ... WITH PASSWORD ... in a SQL session.
 	// pq: username "foo," invalid; usernames are case insensitive, must start with a letter or underscore, may contain letters, digits, dashes, or underscores, and must not exceed 63 characters
 	// user set 0foo
+	// warning: This command is deprecated. Use CREATE USER or ALTER USER ... WITH PASSWORD ... in a SQL session.
 	// pq: username "0foo" invalid; usernames are case insensitive, must start with a letter or underscore, may contain letters, digits, dashes, or underscores, and must not exceed 63 characters
 	// user set foo0
+	// warning: This command is deprecated. Use CREATE USER or ALTER USER ... WITH PASSWORD ... in a SQL session.
 	// CREATE USER 1
 	// user set f0oo
+	// warning: This command is deprecated. Use CREATE USER or ALTER USER ... WITH PASSWORD ... in a SQL session.
 	// CREATE USER 1
 	// user set foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoof
+	// warning: This command is deprecated. Use CREATE USER or ALTER USER ... WITH PASSWORD ... in a SQL session.
 	// pq: username "foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoof" invalid; usernames are case insensitive, must start with a letter or underscore, may contain letters, digits, dashes, or underscores, and must not exceed 63 characters
 	// user set foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo
+	// warning: This command is deprecated. Use CREATE USER or ALTER USER ... WITH PASSWORD ... in a SQL session.
 	// CREATE USER 1
 	// user set Ομηρος
+	// warning: This command is deprecated. Use CREATE USER or ALTER USER ... WITH PASSWORD ... in a SQL session.
 	// CREATE USER 1
 	// user set and
+	// warning: This command is deprecated. Use CREATE USER or ALTER USER ... WITH PASSWORD ... in a SQL session.
 	// CREATE USER 1
 	// user set table
+	// warning: This command is deprecated. Use CREATE USER or ALTER USER ... WITH PASSWORD ... in a SQL session.
 	// CREATE USER 1
 	// user ls --format=table
+	// warning: This command is deprecated. Use SHOW USERS or SHOW ROLES in a SQL session.
 	//                              user_name
 	// +-----------------------------------------------------------------+
 	//   _foo
@@ -1477,8 +1501,10 @@ func Example_user() {
 	//   ομηρος
 	// (11 rows)
 	// user rm foo
+	// warning: This command is deprecated. Use DROP USER or DROP ROLE in a SQL session.
 	// DROP USER 1
 	// user ls --format=table
+	// warning: This command is deprecated. Use SHOW USERS or SHOW ROLES in a SQL session.
 	//                              user_name
 	// +-----------------------------------------------------------------+
 	//   _foo
@@ -1525,7 +1551,7 @@ Available Commands:
   quit              drain and shutdown node
 
   sql               open a sql shell
-  user              get, set, list and remove users
+  user              get, set, list and remove users (deprecated)
   node              list, inspect or remove nodes
   dump              dump sql tables
 

--- a/pkg/cli/user.go
+++ b/pkg/cli/user.go
@@ -11,7 +11,9 @@
 package cli
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -20,15 +22,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// TODO(knz): Remove this file after 19.2 is released.
+// Then also remove the flag definitions in flags.go.
+
 var password bool
 
 // A getUserCmd command displays the config for the specified username.
 var getUserCmd = &cobra.Command{
 	Use:   "get [options] <username>",
-	Short: "fetches and displays a user",
+	Short: "fetches and displays a user (deprecated)",
 	Long: `
-Fetches and displays the user for <username>.
-`,
+This command is deprecated.
+Use SHOW USERS or SHOW ROLES in a SQL session.`,
 	Args: cobra.ExactArgs(1),
 	RunE: MaybeDecorateGRPCError(runGetUser),
 }
@@ -38,6 +43,7 @@ var verRmUser = version.MustParse("v1.1.0-alpha.20170622")
 var verSetUser = version.MustParse("v1.2.0-alpha.20171113")
 
 func runGetUser(cmd *cobra.Command, args []string) error {
+	fmt.Fprintf(stderr, "warning: %s\n", strings.ReplaceAll(strings.TrimSpace(cmd.Long), "\n", " "))
 	conn, err := getPasswordAndMakeSQLClient("cockroach user")
 	if err != nil {
 		return err
@@ -60,15 +66,16 @@ SELECT username AS user_name,
 // A lsUsersCmd command displays a list of users.
 var lsUsersCmd = &cobra.Command{
 	Use:   "ls [options]",
-	Short: "list all users",
+	Short: "list all users (deprecated)",
 	Long: `
-List all users.
-`,
+This command is deprecated.
+Use SHOW USERS or SHOW ROLES in a SQL session.`,
 	Args: cobra.NoArgs,
 	RunE: MaybeDecorateGRPCError(runLsUsers),
 }
 
 func runLsUsers(cmd *cobra.Command, args []string) error {
+	fmt.Fprintf(stderr, "warning: %s\n", strings.ReplaceAll(strings.TrimSpace(cmd.Long), "\n", " "))
 	conn, err := getPasswordAndMakeSQLClient("cockroach user")
 	if err != nil {
 		return err
@@ -81,15 +88,16 @@ func runLsUsers(cmd *cobra.Command, args []string) error {
 // A rmUserCmd command removes the user for the specified username.
 var rmUserCmd = &cobra.Command{
 	Use:   "rm [options] <username>",
-	Short: "remove a user",
+	Short: "remove a user (deprecated)",
 	Long: `
-Remove an existing user by username.
-`,
+This command is deprecated.
+Use DROP USER or DROP ROLE in a SQL session.`,
 	Args: cobra.ExactArgs(1),
 	RunE: MaybeDecorateGRPCError(runRmUser),
 }
 
 func runRmUser(cmd *cobra.Command, args []string) error {
+	fmt.Fprintf(stderr, "warning: %s\n", strings.ReplaceAll(strings.TrimSpace(cmd.Long), "\n", " "))
 	conn, err := getPasswordAndMakeSQLClient("cockroach user")
 	if err != nil {
 		return err
@@ -108,14 +116,10 @@ func runRmUser(cmd *cobra.Command, args []string) error {
 // A setUserCmd command creates a new or updates an existing user.
 var setUserCmd = &cobra.Command{
 	Use:   "set [options] <username>",
-	Short: "create or update a user",
+	Short: "create or update a user (deprecated)",
 	Long: `
-Create or update a user for the specified username, prompting
-for the password.
-
-Valid usernames contain 1 to 63 alphanumeric characters. They must
-begin with either a letter or an underscore. Subsequent characters
-may be letters, numbers, or underscores.
+This command is deprecated.
+Use CREATE USER or ALTER USER ... WITH PASSWORD ... in a SQL session.
 `,
 	Args: cobra.ExactArgs(1),
 	RunE: MaybeDecorateGRPCError(runSetUser),
@@ -126,6 +130,7 @@ may be letters, numbers, or underscores.
 // TODO(marc): once we have more fields in the user, we will need
 // to allow changing just some of them (eg: change email, but leave password).
 func runSetUser(cmd *cobra.Command, args []string) error {
+	fmt.Fprintf(stderr, "warning: %s\n", strings.ReplaceAll(strings.TrimSpace(cmd.Long), "\n", " "))
 	pwdString := ""
 	if password {
 		var err error
@@ -172,7 +177,7 @@ var userCmds = []*cobra.Command{
 
 var userCmd = &cobra.Command{
 	Use:   "user",
-	Short: "get, set, list and remove users",
+	Short: "get, set, list and remove users (deprecated)",
 	RunE:  usageAndErr,
 }
 


### PR DESCRIPTION
Informs #33594.
As requested by @jseldess, as the functionality in SQL is simpler /
clearer to use (properly differentiates users from roles).

Release note (cli change): The `cockroach user` sub-commands are now
deprecated. Users and roles can be managed using SQL statements
instead. This functionality will be removed in the next release.