### PR TITLE
cli/demo: pre-load 'movr' by default

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -473,6 +473,7 @@ func Example_demo() {
 
 	testData := [][]string{
 		{`demo`, `-e`, `show database`},
+		{`demo`, `-e`, `show database`, `--empty`},
 		{`demo`, `-e`, `show application_name`},
 		{`demo`, `--format=table`, `-e`, `show database`},
 		{`demo`, `-e`, `select 1 as "1"`, `-e`, `select 3 as "3"`},
@@ -488,14 +489,17 @@ func Example_demo() {
 	// Output:
 	// demo -e show database
 	// database
+	// movr
+	// demo -e show database --empty
+	// database
 	// defaultdb
 	// demo -e show application_name
 	// application_name
 	// $ cockroach demo
 	// demo --format=table -e show database
 	//   database
-	// +-----------+
-	//   defaultdb
+	// +----------+
+	//   movr
 	// (1 row)
 	// demo -e select 1 as "1" -e select 3 as "3"
 	// 1

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -795,6 +795,13 @@ The line length where sqlfmt will try to wrap.`,
 		Description: `How many in-memory nodes to create for the demo.`,
 	}
 
+	UseEmptyDatabase = FlagInfo{
+		Name: "empty",
+		Description: `
+Start with an empty database: avoid pre-loading a default dataset in
+the demo shell.`,
+	}
+
 	LogDir = FlagInfo{
 		Name: "log-dir",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -146,6 +146,9 @@ func initCLIDefaults() {
 	networkBenchCtx.port = 8081
 	networkBenchCtx.addresses = []string{"localhost:8081"}
 
+	demoCtx.nodes = 1
+	demoCtx.useEmptyDatabase = false
+
 	initPreFlagsDefaults()
 
 	// Clear the "Changed" state of all the registered command-line flags.
@@ -339,5 +342,6 @@ var sqlfmtCtx struct {
 // demoCtx captures the command-line parameters of the `demo` command.
 // Defaults set by InitCLIDefaults() above.
 var demoCtx struct {
-	nodes int
+	nodes            int
+	useEmptyDatabase bool
 }

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -198,12 +198,20 @@ func runDemo(cmd *cobra.Command, gen workload.Generator) error {
 		fmt.Printf(`#
 # Welcome to the CockroachDB demo database!
 #
-# You are connected to a temporary, in-memory CockroachDB
-# cluster of %d node%s. Your changes will not be saved!
+# You are connected to a temporary, in-memory CockroachDB cluster of %d node%s.
+`, demoCtx.nodes, util.Pluralize(int64(demoCtx.nodes)))
+
+		if gen != nil {
+			fmt.Printf("# The cluster has been preloaded with the %q dataset\n# (%s).\n",
+				gen.Meta().Name, gen.Meta().Description)
+		}
+
+		fmt.Printf(`#
+# Your changes will not be saved!
 #
 # Web UI: %s
 #
-`, demoCtx.nodes, util.Pluralize(int64(demoCtx.nodes)), adminURL)
+`, adminURL)
 	}
 
 	checkTzDatabaseAvailability(context.Background())

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -541,6 +541,9 @@ func init() {
 	// We add this command as a persistent flag so you can do stuff like
 	// ./cockroach demo movr --nodes=3.
 	IntFlag(demoFlags, &demoCtx.nodes, cliflags.DemoNodes, 1)
+	// The --empty flag is only valid for the top level demo command,
+	// so we use the regular flag set.
+	BoolFlag(demoCmd.Flags(), &demoCtx.useEmptyDatabase, cliflags.UseEmptyDatabase, false)
 
 	// sqlfmt command.
 	fmtFlags := sqlfmtCmd.Flags()

--- a/pkg/cli/interactive_tests/test_demo.tcl
+++ b/pkg/cli/interactive_tests/test_demo.tcl
@@ -16,6 +16,6 @@ eexpect "Cluster ID"
 eexpect "brief introduction"
 # Ensure user is root.
 eexpect root@
-# Ensure db is defaultdb.
-eexpect "defaultdb>"
+# Ensure db is movr.
+eexpect "movr>"
 end_test


### PR DESCRIPTION
Requested/suggested by @kenliu.
cc @piyush-singh 

Release note (cli change): `cockroach demo` without argument becomes
equivalent to `cockroach demo movr`. The previous behavior
(no pre-defined dataset) is still available via `cockroach demo
--empty`.