### PR TITLE
cli/start: write the URL file as soon as the server is ready

### DIFF
--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -8,6 +8,7 @@ system "mkdir -p logs"
 # developer's own history file when running out of Docker.
 set histfile "cockroach_sql_history"
 
+set ::env(COCKROACH_CONNECT_TIMEOUT) 15
 set ::env(COCKROACH_SQL_CLI_HISTORY) $histfile
 # Set client commands as insecure. The server uses --insecure.
 set ::env(COCKROACH_INSECURE) "true"
@@ -88,9 +89,8 @@ proc send_eof {} {
 # in `server_pid`.
 proc start_server {argv} {
     report "BEGIN START SERVER"
-    system "mkfifo url_fifo || true;
-            $argv start-single-node --insecure --pid-file=server_pid --listening-url-file=url_fifo --background -s=path=logs/db >>logs/expect-cmd.log 2>&1 &
-            cat url_fifo > server_url"
+    system "$argv start-single-node --insecure --pid-file=server_pid --background -s=path=logs/db >>logs/expect-cmd.log 2>&1;
+            $argv sql --insecure -e 'select 1'"
     report "START SERVER DONE"
 }
 proc stop_server {argv} {

--- a/pkg/cli/interactive_tests/test_audit_log.tcl
+++ b/pkg/cli/interactive_tests/test_audit_log.tcl
@@ -62,7 +62,8 @@ stop_server $argv
 
 start_test "Check that audit logging works even with a custom directory"
 # Start a server with a custom log
-system "$argv start-single-node --insecure --pid-file=server_pid --listening-url-file=url_fifo --background -s=path=logs/db --sql-audit-dir=logs/db/audit-new >>logs/expect-cmd.log 2>&1 & cat url_fifo > server_url"
+system "$argv start-single-node --insecure --pid-file=server_pid --background -s=path=logs/db --sql-audit-dir=logs/db/audit-new >>logs/expect-cmd.log 2>&1;
+        $argv sql --insecure -e 'select 1'"
 
 set logfile logs/db/audit-new/cockroach-sql-audit.log
 

--- a/pkg/cli/interactive_tests/test_log_config_msg.tcl
+++ b/pkg/cli/interactive_tests/test_log_config_msg.tcl
@@ -14,7 +14,9 @@ end_test
 
 
 # Make a server with a tiny log buffer so as to force frequent log rotation.
-system "mkfifo url_fifo || true; $argv start-single-node --insecure --pid-file=server_pid --listening-url-file=url_fifo --background -s=path=logs/db --log-file-max-size=2k >>logs/expect-cmd.log 2>&1 & cat url_fifo > server_url"
+system "$argv start-single-node --insecure --pid-file=server_pid --background -s=path=logs/db --log-file-max-size=2k >>logs/expect-cmd.log 2>&1;
+        $argv sql --insecure -e 'select 1'"
+# Stop the server, which also flushes and closes the log files.
 stop_server $argv
 
 start_test "Check that the cluster ID is reported at the start of new log files."

--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -73,7 +73,7 @@ start_test "Check that panic reports are printed to the log even when --logtostd
 send "$argv start-single-node -s=path=logs/db --insecure --logtostderr\r"
 eexpect "CockroachDB node starting"
 
-system "$argv sql --insecure -e \"select crdb_internal.force_panic('helloworld')\" || true"
+system "($argv sql --insecure -e \"select crdb_internal.force_panic('helloworld')\" || true)&"
 # Check the panic is reported on the server's stderr
 eexpect "panic: helloworld"
 eexpect "panic while executing"

--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -23,7 +23,8 @@ end_test
 
 proc start_secure_server {argv certs_dir} {
     report "BEGIN START SECURE SERVER"
-    system "mkfifo url_fifo || true; $argv start-single-node --certs-dir=$certs_dir --pid-file=server_pid --listening-url-file=url_fifo -s=path=logs/db >>expect-cmd.log 2>&1 & cat url_fifo > server_url"
+    system "$argv start-single-node --certs-dir=$certs_dir --pid-file=server_pid -s=path=logs/db --background >>expect-cmd.log 2>&1;
+            $argv sql --certs-dir=$certs_dir -e 'select 1'"
     report "END START SECURE SERVER"
 }
 


### PR DESCRIPTION
Fixes #38758.

Prior to this patch, `cockroach start` would wait until the cluster
was initialized to write the SQL URL to the file indicated by
`--listening-url-file`. This contrasts with the PID file which is
written as soon as the server starts listening.

This prior behavior was motivated by the original design of the
startup routine, where the SQL server was not ready/started until the
cluster was ready.

Since then, #21682 was merged which accepts, but blocks, SQL clients
until the cluster is initialized. Since the SQL clients can now
connect as soon as the server starts listening, there is no reason
any more to wait longer.

This patch thus simplifies the code to emit the URL to the file at the
same time as the PID. This also makes it possible to use a SQL
client/command reliably as soon as the process detaches from the
terminal with `--background`.

Note: if you want to test the new behavior manually in an interactive
terminal, beware that the `cockroach` CLI client commands separately
have a connection timeout, which defaults to 5 seconds. This can be
overridden with the env var COCKROACH_CONNECT_TIMEOUT.

Release note (cli change): `cockroach start` now writes the client URL
to the file specified via `--listen-url-file` as soon as the server
is ready to accept connections. This also happens before the server
detaches from the terminal when `--background` is specified.