### PR TITLE
sql/sem: fix interaction between framing and peers in window functions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -3572,3 +3572,50 @@ SELECT array_agg(a) OVER () FROM l LIMIT 1
 
 statement ok
 RESET CLUSTER SETTING sql.distsql.temp_storage.workmem
+
+# Regression test for #38901 verifying that window frame takes precedence over
+# the concept of peers.
+query I
+SELECT count(a) OVER (ROWS 1 PRECEDING) FROM t
+----
+1
+2
+2
+
+statement ok
+CREATE TABLE t38901 (a INT PRIMARY KEY); INSERT INTO t38901 VALUES (1), (2), (3)
+
+query T
+SELECT array_agg(a) OVER (ORDER BY a ROWS BETWEEN 2 PRECEDING AND 1 PRECEDING) FROM t38901 ORDER BY a
+----
+NULL
+{1}
+{1,2}
+
+# Regression test for #42935.
+query IIIII
+SELECT
+	a,
+	b,
+	count(*) OVER (ORDER BY b),
+	count(*) OVER (
+		ORDER BY
+			b
+		RANGE
+			BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+	),
+	count(*) OVER (
+		ORDER BY
+			b
+		ROWS
+			BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+	)
+FROM
+	(VALUES (1, 1), (2, 1), (3, 2), (4, 2)) AS t (a, b)
+ORDER BY
+	a, b
+----
+1  1  2  2  1
+2  1  2  2  2
+3  2  4  4  3
+4  2  4  4  4

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -483,7 +483,11 @@ func (w *windower) processPartition(
 	partition *rowcontainer.DiskBackedIndexedRowContainer,
 	partitionIdx int,
 ) error {
-	var peerGrouper tree.PeerGroupChecker
+	peerGrouper := &partitionPeerGrouper{
+		ctx:     ctx,
+		evalCtx: evalCtx,
+		rowCopy: make(sqlbase.EncDatumRow, len(w.inputTypes)),
+	}
 	usage := sizeOfSliceOfRows + rowSliceOverhead + sizeOfRow*int64(len(w.windowFns))
 	if err := w.growMemAccount(&w.acc, usage); err != nil {
 		return err
@@ -600,17 +604,9 @@ func (w *windower) processPartition(
 				}
 				partition.Sort(ctx)
 			}
-			peerGrouper = &partitionPeerGrouper{
-				ctx:       ctx,
-				evalCtx:   evalCtx,
-				partition: partition,
-				ordering:  windowFn.ordering,
-				rowCopy:   make(sqlbase.EncDatumRow, len(w.inputTypes)),
-			}
-		} else {
-			// If ORDER BY clause is not provided, all rows are peers.
-			peerGrouper = allPeers{}
 		}
+		peerGrouper.ordering = windowFn.ordering
+		peerGrouper.partition = partition
 
 		frameRun.Rows = partition
 		frameRun.RowIdx = 0
@@ -830,6 +826,10 @@ type partitionPeerGrouper struct {
 }
 
 func (n *partitionPeerGrouper) InSameGroup(i, j int) (bool, error) {
+	if len(n.ordering.Columns) == 0 {
+		// ORDER BY clause is omitted, so all rows are peers.
+		return true, nil
+	}
 	if n.err != nil {
 		return false, n.err
 	}
@@ -863,11 +863,6 @@ func (n *partitionPeerGrouper) InSameGroup(i, j int) (bool, error) {
 	}
 	return true, nil
 }
-
-type allPeers struct{}
-
-// allPeers implements the PeerGroupChecker interface.
-func (allPeers) InSameGroup(i, j int) (bool, error) { return true, nil }
 
 const sizeOfInt = int64(unsafe.Sizeof(int(0)))
 const sliceOfIntsOverhead = int64(unsafe.Sizeof([]int{}))

--- a/pkg/sql/sem/tree/window_funcs.go
+++ b/pkg/sql/sem/tree/window_funcs.go
@@ -255,6 +255,7 @@ func (wfr *WindowFrameRun) IsDefaultFrame() bool {
 	}
 	if wfr.Frame.Bounds.StartBound.BoundType == UnboundedPreceding {
 		return wfr.DefaultFrameExclusion() &&
+			wfr.Frame.Mode == RANGE &&
 			(wfr.Frame.Bounds.EndBound == nil || wfr.Frame.Bounds.EndBound.BoundType == CurrentRow)
 	}
 	return false


### PR DESCRIPTION
**rowexec: minor refactor of partitionPeerGrouper**

This commit removes allPeers peerGroupChecker and refactors
partitionPeerGrouper to support the case of omitted ORDER BY clause.

Release note: None

**sql/sem: fix interaction between framing and peers in window functions**

Previously, whenever we had a result of a window function already
computed for a peer of the row, we would return that result. However,
the concept of window framing takes precedence over the concept of peers
(i.e. if the window frame over which we computed the result for a peer
is different from the window frame of the current row, we need to
recompute the result). Now this is fixed by tracking the boundaries of
the window frame over which peerRes is computed and recomputing the
latter when needed.

There was also a bug in IsDefaultFrame where we forgot to check whether
the mode of framing is RANGE. This caused incorrect results in some
cases when ROWS or GROUPS modes of framing were used.

Fixes: #38901.
Fixes: #42935.

Release note (bug fix): CockroachDB previously was returning incorrect
results for some aggregate functions when used as window functions with
non-default window frame. Now this is fixed. Note that MIN, MAX, SUM,
AVG as well as "pure" window functions (i.e. non-aggregates) were not
affected.