### PR TITLE
sql: do not re-create columnFormatCodes if there is a single column.

### DIFF
--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -365,7 +365,7 @@ func (ex *connExecutor) execBind(
 	}
 
 	columnFormatCodes := bindCmd.OutFormats
-	if len(bindCmd.OutFormats) == 1 {
+	if len(bindCmd.OutFormats) == 1 && numCols > 1 {
 		// Apply the format code to every column.
 		columnFormatCodes = make([]pgwirebase.FormatCode, numCols)
 		for i := 0; i < numCols; i++ {


### PR DESCRIPTION
If there is only one column and there is only one format code, then
there is no need to rebuild the list. We would only need to rebuild the
list if there is more than 1 column and only a single format code was
provided by the client.

This was just something I had noticed a while after I had already
submitted #38870.