### PR TITLE
opt: move EXPORT planning to the optimizer

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -9,7 +9,6 @@ stmt ::=
 	| execute_stmt
 	| deallocate_stmt
 	| discard_stmt
-	| export_stmt
 	| grant_stmt
 	| prepare_stmt
 	| revoke_stmt
@@ -33,6 +32,7 @@ preparable_stmt ::=
 	| reset_stmt
 	| restore_stmt
 	| resume_stmt
+	| export_stmt
 	| scrub_stmt
 	| select_stmt
 	| preparable_set_stmt
@@ -60,9 +60,6 @@ deallocate_stmt ::=
 
 discard_stmt ::=
 	'DISCARD' 'ALL'
-
-export_stmt ::=
-	'EXPORT' 'INTO' import_format string_or_placeholder opt_with_options 'FROM' select_stmt
 
 grant_stmt ::=
 	'GRANT' privileges 'ON' targets 'TO' name_list
@@ -152,6 +149,9 @@ resume_stmt ::=
 	'RESUME' 'JOB' a_expr
 	| 'RESUME' 'JOBS' select_stmt
 
+export_stmt ::=
+	'EXPORT' 'INTO' import_format string_or_placeholder opt_with_options 'FROM' select_stmt
+
 scrub_stmt ::=
 	scrub_table_stmt
 	| scrub_database_stmt
@@ -228,18 +228,6 @@ name ::=
 	| unreserved_keyword
 	| col_name_keyword
 
-import_format ::=
-	name
-
-string_or_placeholder ::=
-	non_reserved_word_or_sconst
-	| 'PLACEHOLDER'
-
-opt_with_options ::=
-	'WITH' kv_option_list
-	| 'WITH' 'OPTIONS' '(' kv_option_list ')'
-	| 
-
 privileges ::=
 	'ALL'
 	| privilege_list
@@ -296,12 +284,21 @@ alter_ddl_stmt ::=
 alter_user_stmt ::=
 	alter_user_password_stmt
 
+string_or_placeholder ::=
+	non_reserved_word_or_sconst
+	| 'PLACEHOLDER'
+
 opt_as_of_clause ::=
 	as_of_clause
 	| 
 
 opt_incremental ::=
 	'INCREMENTAL' 'FROM' string_or_placeholder_list
+	| 
+
+opt_with_options ::=
+	'WITH' kv_option_list
+	| 'WITH' 'OPTIONS' '(' kv_option_list ')'
 	| 
 
 cancel_jobs_stmt ::=
@@ -383,6 +380,9 @@ drop_user_stmt ::=
 
 explain_option_list ::=
 	( explain_option_name ) ( ( ',' explain_option_name ) )*
+
+import_format ::=
+	name
 
 string_or_placeholder_list ::=
 	( string_or_placeholder ) ( ( ',' string_or_placeholder ) )*
@@ -865,13 +865,6 @@ col_name_keyword ::=
 	| 'VIRTUAL'
 	| 'WORK'
 
-non_reserved_word_or_sconst ::=
-	non_reserved_word
-	| 'SCONST'
-
-kv_option_list ::=
-	( kv_option ) ( ( ',' kv_option ) )*
-
 complex_table_pattern ::=
 	complex_db_object_name
 	| db_object_name_component '.' unrestricted_name '.' '*'
@@ -949,6 +942,13 @@ alter_range_stmt ::=
 alter_user_password_stmt ::=
 	'ALTER' 'USER' string_or_placeholder 'WITH' 'PASSWORD' string_or_placeholder
 	| 'ALTER' 'USER' 'IF' 'EXISTS' string_or_placeholder 'WITH' 'PASSWORD' string_or_placeholder
+
+non_reserved_word_or_sconst ::=
+	non_reserved_word
+	| 'SCONST'
+
+kv_option_list ::=
+	( kv_option ) ( ( ',' kv_option ) )*
 
 opt_password ::=
 	opt_with 'PASSWORD' string_or_placeholder
@@ -1204,18 +1204,6 @@ unrestricted_name ::=
 	| type_func_name_keyword
 	| reserved_keyword
 
-non_reserved_word ::=
-	'identifier'
-	| unreserved_keyword
-	| col_name_keyword
-	| type_func_name_keyword
-
-kv_option ::=
-	name '=' string_or_placeholder
-	| name
-	| 'SCONST' '=' string_or_placeholder
-	| 'SCONST'
-
 transaction_mode ::=
 	transaction_user_priority
 	| transaction_read_mode
@@ -1293,6 +1281,18 @@ alter_zone_database_stmt ::=
 
 alter_zone_range_stmt ::=
 	'ALTER' 'RANGE' zone_name set_zone_config
+
+non_reserved_word ::=
+	'identifier'
+	| unreserved_keyword
+	| col_name_keyword
+	| type_func_name_keyword
+
+kv_option ::=
+	name '=' string_or_placeholder
+	| name
+	| 'SCONST' '=' string_or_placeholder
+	| 'SCONST'
 
 opt_with ::=
 	'WITH'

--- a/pkg/ccl/importccl/exportcsv.go
+++ b/pkg/ccl/importccl/exportcsv.go
@@ -12,152 +12,23 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
-	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding/csv"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/pkg/errors"
 )
 
-// exportHeader is the header for EXPORT stmt results.
-var exportHeader = sqlbase.ResultColumns{
-	{Name: "filename", Typ: types.String},
-	{Name: "rows", Typ: types.Int},
-	{Name: "bytes", Typ: types.Int},
-}
-
-const (
-	exportOptionDelimiter = "delimiter"
-	exportOptionNullAs    = "nullas"
-	exportOptionChunkSize = "chunk_rows"
-	exportOptionFileName  = "filename"
-)
-
-var exportOptionExpectValues = map[string]sql.KVStringOptValidate{
-	exportOptionChunkSize: sql.KVStringOptRequireValue,
-	exportOptionDelimiter: sql.KVStringOptRequireValue,
-	exportOptionFileName:  sql.KVStringOptRequireValue,
-	exportOptionNullAs:    sql.KVStringOptRequireValue,
-}
-
-const exportChunkSizeDefault = 100000
 const exportFilePatternPart = "%part%"
 const exportFilePatternDefault = exportFilePatternPart + ".csv"
-
-// exportPlanHook implements sql.PlanHook.
-func exportPlanHook(
-	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
-) (sql.PlanHookRowFn, sqlbase.ResultColumns, []sql.PlanNode, bool, error) {
-	exportStmt, ok := stmt.(*tree.Export)
-	if !ok {
-		return nil, nil, nil, false, nil
-	}
-
-	fileFn, err := p.TypeAsString(exportStmt.File, "EXPORT")
-	if err != nil {
-		return nil, nil, nil, false, err
-	}
-
-	if exportStmt.FileFormat != "CSV" {
-		return nil, nil, nil, false, errors.Errorf("unsupported export format: %q", exportStmt.FileFormat)
-	}
-
-	optsFn, err := p.TypeAsStringOpts(exportStmt.Options, exportOptionExpectValues)
-	if err != nil {
-		return nil, nil, nil, false, err
-	}
-
-	sel, err := p.Select(ctx, exportStmt.Query, nil)
-	if err != nil {
-		return nil, nil, nil, false, err
-	}
-
-	fn := func(ctx context.Context, plans []sql.PlanNode, resultsCh chan<- tree.Datums) error {
-		ctx, span := tracing.ChildSpan(ctx, exportStmt.StatementTag())
-		defer tracing.FinishSpan(span)
-
-		if err := p.RequireAdminRole(ctx, "EXPORT"); err != nil {
-			return err
-		}
-
-		if !p.ExtendedEvalContext().TxnImplicit {
-			return errors.Errorf("EXPORT cannot be used inside a transaction")
-		}
-
-		file, err := fileFn()
-		if err != nil {
-			return err
-		}
-
-		opts, err := optsFn()
-		if err != nil {
-			return err
-		}
-
-		csvOpts := roachpb.CSVOptions{}
-
-		if override, ok := opts[exportOptionDelimiter]; ok {
-			csvOpts.Comma, err = util.GetSingleRune(override)
-			if err != nil {
-				return pgerror.New(pgcode.InvalidParameterValue, "invalid delimiter")
-			}
-		}
-
-		if override, ok := opts[exportOptionNullAs]; ok {
-			csvOpts.NullEncoding = &override
-		}
-
-		chunk := exportChunkSizeDefault
-		if override, ok := opts[exportOptionChunkSize]; ok {
-			chunk, err = strconv.Atoi(override)
-			if err != nil {
-				return pgerror.New(pgcode.InvalidParameterValue, err.Error())
-			}
-			if chunk < 1 {
-				return pgerror.New(pgcode.InvalidParameterValue, "invalid csv chunk size")
-			}
-		}
-
-		out := distsqlpb.ProcessorCoreUnion{CSVWriter: &distsqlpb.CSVWriterSpec{
-			Destination: file,
-			NamePattern: exportFilePatternDefault,
-			Options:     csvOpts,
-			ChunkRows:   int64(chunk),
-		}}
-
-		rows := rowcontainer.NewRowContainer(
-			p.ExtendedEvalContext().Mon.MakeBoundAccount(), sqlbase.ColTypeInfoFromColTypes(sql.ExportPlanResultTypes), 0,
-		)
-		rw := sql.NewRowResultWriter(rows)
-
-		if err := sql.PlanAndRunExport(
-			ctx, p.DistSQLPlanner(), p.ExecCfg(), p.Txn(), p.ExtendedEvalContext(), plans[0], out, rw,
-		); err != nil {
-			return err
-		}
-		for i := 0; i < rows.Len(); i++ {
-			resultsCh <- rows.At(i)
-		}
-		rows.Close(ctx)
-		return rw.Err()
-	}
-
-	return fn, exportHeader, []sql.PlanNode{sel}, false, nil
-}
 
 func newCSVWriterProcessor(
 	flowCtx *distsqlrun.FlowCtx,
@@ -183,7 +54,7 @@ func newCSVWriterProcessor(
 		input:       input,
 		output:      output,
 	}
-	if err := c.out.Init(&distsqlpb.PostProcessSpec{}, sql.ExportPlanResultTypes, flowCtx.NewEvalCtx(), output); err != nil {
+	if err := c.out.Init(&distsqlpb.PostProcessSpec{}, c.OutputTypes(), flowCtx.NewEvalCtx(), output); err != nil {
 		return nil, err
 	}
 	return c, nil
@@ -201,7 +72,11 @@ type csvWriter struct {
 var _ distsqlrun.Processor = &csvWriter{}
 
 func (sp *csvWriter) OutputTypes() []types.T {
-	return sql.ExportPlanResultTypes
+	res := make([]types.T, len(sqlbase.ExportColumns))
+	for i := range res {
+		res[i] = *sqlbase.ExportColumns[i].Typ
+	}
+	return res
 }
 
 func (sp *csvWriter) Run(ctx context.Context) {
@@ -330,6 +205,5 @@ func (sp *csvWriter) Run(ctx context.Context) {
 }
 
 func init() {
-	sql.AddPlanHook(exportPlanHook)
 	distsqlrun.NewCSVWriterProcessor = newCSVWriterProcessor
 }

--- a/pkg/ccl/importccl/exportcsv_test.go
+++ b/pkg/ccl/importccl/exportcsv_test.go
@@ -211,7 +211,7 @@ func TestExportShow(t *testing.T) {
 	defer srv.Stopper().Stop(context.Background())
 	sqlDB := sqlutils.MakeSQLRunner(db)
 
-	sqlDB.Exec(t, `EXPORT INTO CSV 'nodelocal:///show' FROM SELECT * FROM [SHOW DATABASES]`)
+	sqlDB.Exec(t, `EXPORT INTO CSV 'nodelocal:///show' FROM SELECT * FROM [SHOW DATABASES] ORDER BY database_name`)
 	content, err := ioutil.ReadFile(filepath.Join(dir, "show", "n1.0.csv"))
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sql/export.go
+++ b/pkg/sql/export.go
@@ -1,0 +1,126 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/pkg/errors"
+)
+
+type exportNode struct {
+	optColumnsSlot
+
+	source planNode
+
+	fileName  string
+	csvOpts   roachpb.CSVOptions
+	chunkSize int
+}
+
+func (e *exportNode) startExec(params runParams) error {
+	panic("exportNode cannot be run in local mode")
+}
+
+func (e *exportNode) Next(params runParams) (bool, error) {
+	panic("exportNode cannot be run in local mode")
+}
+
+func (e *exportNode) Values() tree.Datums {
+	panic("exportNode cannot be run in local mode")
+}
+
+func (e *exportNode) Close(ctx context.Context) {
+	e.source.Close(ctx)
+}
+
+const (
+	exportOptionDelimiter = "delimiter"
+	exportOptionNullAs    = "nullas"
+	exportOptionChunkSize = "chunk_rows"
+	exportOptionFileName  = "filename"
+)
+
+var exportOptionExpectValues = map[string]KVStringOptValidate{
+	exportOptionChunkSize: KVStringOptRequireValue,
+	exportOptionDelimiter: KVStringOptRequireValue,
+	exportOptionFileName:  KVStringOptRequireValue,
+	exportOptionNullAs:    KVStringOptRequireValue,
+}
+
+const exportChunkSizeDefault = 100000
+const exportFilePatternPart = "%part%"
+const exportFilePatternDefault = exportFilePatternPart + ".csv"
+
+// ConstructExport is part of the exec.Factory interface.
+func (ef *execFactory) ConstructExport(
+	input exec.Node, fileName tree.TypedExpr, fileFormat string, options []exec.KVOption,
+) (exec.Node, error) {
+	if !ef.planner.ExtendedEvalContext().TxnImplicit {
+		return nil, errors.Errorf("EXPORT cannot be used inside a transaction")
+	}
+
+	if fileFormat != "CSV" {
+		return nil, errors.Errorf("unsupported export format: %q", fileFormat)
+	}
+
+	fileNameDatum, err := fileName.Eval(ef.planner.EvalContext())
+	if err != nil {
+		return nil, err
+	}
+	fileNameStr, ok := fileNameDatum.(*tree.DString)
+	if !ok {
+		return nil, errors.Errorf("expected string value for the file location")
+	}
+
+	optVals, err := evalStringOptions(ef.planner.EvalContext(), options, exportOptionExpectValues)
+	if err != nil {
+		return nil, err
+	}
+
+	csvOpts := roachpb.CSVOptions{}
+
+	if override, ok := optVals[exportOptionDelimiter]; ok {
+		csvOpts.Comma, err = util.GetSingleRune(override)
+		if err != nil {
+			return nil, pgerror.New(pgcode.InvalidParameterValue, "invalid delimiter")
+		}
+	}
+
+	if override, ok := optVals[exportOptionNullAs]; ok {
+		csvOpts.NullEncoding = &override
+	}
+
+	chunkSize := exportChunkSizeDefault
+	if override, ok := optVals[exportOptionChunkSize]; ok {
+		chunkSize, err = strconv.Atoi(override)
+		if err != nil {
+			return nil, pgerror.New(pgcode.InvalidParameterValue, err.Error())
+		}
+		if chunkSize < 1 {
+			return nil, pgerror.New(pgcode.InvalidParameterValue, "invalid csv chunk size")
+		}
+	}
+
+	return &exportNode{
+		source:    input.(planNode),
+		fileName:  string(*fileNameStr),
+		csvOpts:   csvOpts,
+		chunkSize: chunkSize,
+	}, nil
+}

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -348,3 +348,9 @@ func (f *stubFactory) ConstructCreateView(
 ) (exec.Node, error) {
 	return struct{}{}, nil
 }
+
+func (f *stubFactory) ConstructExport(
+	input exec.Node, fileName tree.TypedExpr, fileFormat string, options []exec.KVOption,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -283,6 +283,9 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 	case *memo.CancelSessionsExpr:
 		ep, err = b.buildCancelSessions(t)
 
+	case *memo.ExportExpr:
+		ep, err = b.buildExport(t)
+
 	default:
 		if opt.IsSetOp(e) {
 			ep, err = b.buildSetOp(e)

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -454,6 +454,14 @@ type Factory interface {
 
 	// ConstructCancelSessions creates a node that implements CANCEL SESSIONS.
 	ConstructCancelSessions(input Node, ifExists bool) (Node, error)
+
+	// ConstructExport creates a node that implements EXPORT.
+	ConstructExport(
+		input Node,
+		fileName tree.TypedExpr,
+		fileFormat string,
+		options []KVOption,
+	) (Node, error)
 }
 
 // OutputOrdering indicates the required output ordering on a Node that is being
@@ -562,4 +570,12 @@ type ExplainEnvData struct {
 	Tables    []tree.TableName
 	Sequences []tree.TableName
 	Views     []tree.TableName
+}
+
+// KVOption represents information about a statement option
+// (see tree.KVOptions).
+type KVOption struct {
+	Key string
+	// If there is no value, Value is DNull.
+	Value tree.TypedExpr
 }

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -588,6 +588,13 @@ func (h *hasher) HashFKChecksExpr(val FKChecksExpr) {
 	}
 }
 
+func (h *hasher) HashKVOptionsExpr(val KVOptionsExpr) {
+	for i := range val {
+		h.HashString(val[i].Key)
+		h.HashScalarExpr(val[i].Value)
+	}
+}
+
 func (h *hasher) HashPresentation(val physical.Presentation) {
 	for i := range val {
 		col := &val[i]
@@ -922,6 +929,18 @@ func (h *hasher) IsFKChecksExprEqual(l, r FKChecksExpr) bool {
 	}
 	for i := range l {
 		if l[i].Check != r[i].Check {
+			return false
+		}
+	}
+	return true
+}
+
+func (h *hasher) IsKVOptionsExprEqual(l, r KVOptionsExpr) bool {
+	if len(l) != len(r) {
+		return false
+	}
+	for i := range l {
+		if l[i].Key != r[i].Key || l[i].Value != r[i].Value {
 			return false
 		}
 	}

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -861,6 +861,10 @@ func (b *logicalPropsBuilder) buildCancelSessionsProps(
 	b.buildBasicProps(cancel, opt.ColList{}, rel)
 }
 
+func (b *logicalPropsBuilder) buildExportProps(export *ExportExpr, rel *props.Relational) {
+	b.buildBasicProps(export, export.Columns, rel)
+}
+
 func (b *logicalPropsBuilder) buildLimitProps(limit *LimitExpr, rel *props.Relational) {
 	BuildSharedProps(b.mem, limit, &rel.Shared)
 

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -1030,6 +1030,22 @@ define NthValue {
     Nth   ScalarExpr
 }
 
+# KVOptions is a set of KVOptionItems that specify arbitrary keys and values
+# that are used as modifiers for various statements (see tree.KVOptions). The
+# key is a constant string but the value can be a scalar expression.
+[Scalar, List]
+define KVOptions {
+}
+
+# KVOptionsItem is the key and value of an option (see tree.KVOption). For keys
+# that don't have values, the value is Null.
+[Scalar, ListItem]
+define KVOptionsItem {
+    Value ScalarExpr
+
+    Key string
+}
+
 # ScalarList is a list expression that has scalar expression items of type
 # opt.ScalarExpr. opt.ScalarExpr is an external type that is defined outside of
 # Optgen. It is hard-coded in the code generator to be the item type for

--- a/pkg/sql/opt/ops/statement.opt
+++ b/pkg/sql/opt/ops/statement.opt
@@ -127,7 +127,7 @@ define OpaqueDDL {
 [Private]
 define OpaqueRelPrivate {
     Columns ColList
-    Metadata OpaqueMetadata 
+    Metadata OpaqueMetadata
 }
 
 # AlterTableSplit represents an `ALTER TABLE/INDEX .. SPLIT AT ..` statement.
@@ -238,4 +238,30 @@ define CancelSessions {
     Input RelExpr
 
     _ CancelPrivate
+}
+
+# Export represents an `EXPORT` statement.
+[Relational]
+define Export {
+    # Input is the relational expression for the data we are exporting.
+    Input    RelExpr
+
+    # FileName is the string URI for the output file.
+    FileName ScalarExpr
+
+    Options  KVOptionsExpr
+
+    _ ExportPrivate
+}
+
+[Private]
+define ExportPrivate {
+    # FileFormat describes the requested format, e.g. "CSV".
+    FileFormat string
+
+    # Props stores the required physical properties for the input expression.
+    Props PhysProps
+
+    # Columns stores the column IDs for the statement result columns.
+    Columns ColList
 }

--- a/pkg/sql/opt/optbuilder/alter_table.go
+++ b/pkg/sql/opt/optbuilder/alter_table.go
@@ -47,7 +47,7 @@ func (b *Builder) buildAlterTableSplit(split *tree.Split, inScope *scope) (outSc
 	// We don't allow the input statement to reference outer columns, so we
 	// pass a "blank" scope rather than inScope.
 	emptyScope := &scope{builder: b}
-	inputScope := b.buildStmt(split.Rows, colTypes, emptyScope)
+	inputScope := b.buildSelect(split.Rows, colTypes, emptyScope)
 	checkInputColumns("SPLIT AT", inputScope, colNames, colTypes, 1)
 
 	// Build the expiration scalar.

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -273,6 +273,9 @@ func (b *Builder) buildStmt(
 	case *tree.CancelSessions:
 		return b.buildCancelSessions(stmt, inScope)
 
+	case *tree.Export:
+		return b.buildExport(stmt, inScope)
+
 	default:
 		// See if this statement can be rewritten to another statement using the
 		// delegate functionality.

--- a/pkg/sql/opt/optbuilder/export.go
+++ b/pkg/sql/opt/optbuilder/export.go
@@ -1,0 +1,65 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package optbuilder
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+)
+
+// buildExport builds an EXPORT statement.
+func (b *Builder) buildExport(export *tree.Export, inScope *scope) (outScope *scope) {
+	if err := b.catalog.RequireAdminRole(b.ctx, "EXPORT"); err != nil {
+		panic(err)
+	}
+	// We don't allow the input statement to reference outer columns, so we
+	// pass a "blank" scope rather than inScope.
+	emptyScope := &scope{builder: b}
+	inputScope := b.buildSelect(export.Query, nil /* desiredTypes */, emptyScope)
+
+	texpr := emptyScope.resolveType(export.File, types.String)
+	fileName := b.buildScalar(
+		texpr, emptyScope, nil /* outScope */, nil /* outCol */, nil, /* colRefs */
+	)
+	options := b.buildKVOptions(export.Options, emptyScope)
+
+	outScope = inScope.push()
+	b.synthesizeResultColumns(outScope, sqlbase.ExportColumns)
+	outScope.expr = b.factory.ConstructExport(
+		inputScope.expr.(memo.RelExpr),
+		fileName,
+		options,
+		&memo.ExportPrivate{
+			FileFormat: export.FileFormat,
+			Columns:    colsToColList(outScope.cols),
+			Props:      inputScope.makePhysicalProps(),
+		},
+	)
+	return outScope
+}
+
+func (b *Builder) buildKVOptions(opts tree.KVOptions, inScope *scope) memo.KVOptionsExpr {
+	res := make(memo.KVOptionsExpr, len(opts))
+	for i := range opts {
+		res[i].Key = string(opts[i].Key)
+		if opts[i].Value != nil {
+			texpr := inScope.resolveType(opts[i].Value, types.String)
+			res[i].Value = b.buildScalar(
+				texpr, inScope, nil /* outScope */, nil /* outCol */, nil, /* colRefs */
+			)
+		} else {
+			res[i].Value = b.factory.ConstructNull(types.String)
+		}
+	}
+	return res
+}

--- a/pkg/sql/opt/optbuilder/testdata/misc_statements
+++ b/pkg/sql/opt/optbuilder/testdata/misc_statements
@@ -140,3 +140,47 @@ build
 CANCEL QUERIES VALUES (1, 2)
 ----
 error (42601): too many columns in CANCEL QUERIES data
+
+build
+EXPORT INTO CSV 'nodelocal://foo' FROM SELECT * FROM ab
+----
+export
+ ├── columns: filename:4(string) rows:5(int) bytes:6(int)
+ ├── format: CSV
+ ├── project
+ │    ├── columns: a:1(int) b:2(string)
+ │    └── scan ab
+ │         └── columns: a:1(int) b:2(string) rowid:3(int!null)
+ └── const: 'nodelocal://foo' [type=string]
+
+build
+EXPORT INTO CSV 'nodelocal://foo' WITH 'foo', 'bar'='baz' FROM SELECT * FROM ab
+----
+export
+ ├── columns: filename:4(string) rows:5(int) bytes:6(int)
+ ├── format: CSV
+ ├── project
+ │    ├── columns: a:1(int) b:2(string)
+ │    └── scan ab
+ │         └── columns: a:1(int) b:2(string) rowid:3(int!null)
+ ├── const: 'nodelocal://foo' [type=string]
+ └── k-v-options
+      ├── k-v-options-item foo
+      │    └── null [type=string]
+      └── k-v-options-item bar
+           └── const: 'baz' [type=string]
+
+build
+EXPORT INTO CSV 'nodelocal://foo' WITH 'foo' = $1 FROM SELECT * FROM ab
+----
+export
+ ├── columns: filename:4(string) rows:5(int) bytes:6(int)
+ ├── format: CSV
+ ├── project
+ │    ├── columns: a:1(int) b:2(string)
+ │    └── scan ab
+ │         └── columns: a:1(int) b:2(string) rowid:3(int!null)
+ ├── const: 'nodelocal://foo' [type=string]
+ └── k-v-options
+      └── k-v-options-item foo
+           └── placeholder: $1 [type=string]

--- a/pkg/sql/opt/ordering/ordering.go
+++ b/pkg/sql/opt/ordering/ordering.go
@@ -217,6 +217,11 @@ func init() {
 		buildChildReqOrdering: cancelSessionsBuildChildReqOrdering,
 		buildProvidedOrdering: noProvidedOrdering,
 	}
+	funcMap[opt.ExportOp] = funcs{
+		canProvideOrdering:    canNeverProvideOrdering,
+		buildChildReqOrdering: exportBuildChildReqOrdering,
+		buildProvidedOrdering: noProvidedOrdering,
+	}
 }
 
 func canNeverProvideOrdering(expr memo.RelExpr, required *physical.OrderingChoice) bool {

--- a/pkg/sql/opt/ordering/statement.go
+++ b/pkg/sql/opt/ordering/statement.go
@@ -74,3 +74,12 @@ func cancelSessionsBuildChildReqOrdering(
 	}
 	return parent.(*memo.CancelSessionsExpr).Props.Ordering
 }
+
+func exportBuildChildReqOrdering(
+	parent memo.RelExpr, required *physical.OrderingChoice, childIdx int,
+) physical.OrderingChoice {
+	if childIdx != 0 {
+		return physical.OrderingChoice{}
+	}
+	return parent.(*memo.ExportExpr).Props.Ordering
+}

--- a/pkg/sql/opt/xform/physical_props.go
+++ b/pkg/sql/opt/xform/physical_props.go
@@ -63,6 +63,8 @@ func BuildChildPhysicalProps(
 		childProps.Presentation = parent.(*memo.CancelQueriesExpr).Props.Presentation
 	case opt.CancelSessionsOp:
 		childProps.Presentation = parent.(*memo.CancelSessionsExpr).Props.Presentation
+	case opt.ExportOp:
+		childProps.Presentation = parent.(*memo.ExportExpr).Props.Presentation
 	}
 
 	childProps.Ordering = ordering.BuildChildRequired(parent, &parentProps.Ordering, nth)

--- a/pkg/sql/opt_limits.go
+++ b/pkg/sql/opt_limits.go
@@ -201,6 +201,9 @@ func (p *planner) applyLimit(plan planNode, numRows int64, soft bool) {
 	case *bufferNode:
 		p.setUnlimited(n.plan)
 
+	case *exportNode:
+		p.setUnlimited(n.source)
+
 	case *valuesNode:
 	case *virtualTableNode:
 	case *alterIndexNode:

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1063,7 +1063,6 @@ stmt:
 | execute_stmt      // EXTEND WITH HELP: EXECUTE
 | deallocate_stmt   // EXTEND WITH HELP: DEALLOCATE
 | discard_stmt      // EXTEND WITH HELP: DISCARD
-| export_stmt       // EXTEND WITH HELP: EXPORT
 | grant_stmt        // EXTEND WITH HELP: GRANT
 | prepare_stmt      // EXTEND WITH HELP: PREPARE
 | revoke_stmt       // EXTEND WITH HELP: REVOKE
@@ -2565,6 +2564,7 @@ preparable_stmt:
 | reset_stmt        // help texts in sub-rule
 | restore_stmt      // EXTEND WITH HELP: RESTORE
 | resume_stmt       // EXTEND WITH HELP: RESUME JOBS
+| export_stmt       // EXTEND WITH HELP: EXPORT
 | scrub_stmt        // help texts in sub-rule
 | select_stmt       // help texts in sub-rule
   {

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -115,6 +115,8 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		return n.getColumns(mut, sqlbase.ShowReplicaTraceColumns)
 	case *sequenceSelectNode:
 		return n.getColumns(mut, sqlbase.SequenceSelectColumns)
+	case *exportNode:
+		return n.getColumns(mut, sqlbase.ExportColumns)
 
 	// Nodes that have the same schema as their source or their
 	// valueNode helper.

--- a/pkg/sql/plan_physical_props.go
+++ b/pkg/sql/plan_physical_props.go
@@ -119,6 +119,7 @@ func planPhysicalProps(plan planNode) physicalProps {
 	case *dropTableNode:
 	case *dropViewNode:
 	case *errorIfRowsNode:
+	case *exportNode:
 	case *explainDistSQLNode:
 	case *hookFnNode:
 	case *relocateNode:

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
@@ -86,7 +85,6 @@ type PlanHookState interface {
 	) (*DropUserNode, error)
 	GetAllUsersAndRoles(ctx context.Context) (map[string]bool, error)
 	BumpRoleMembershipTableVersion(ctx context.Context) error
-	Select(ctx context.Context, n *tree.Select, desiredTypes []*types.T) (planNode, error)
 	EvalAsOfTimestamp(asOf tree.AsOfClause) (hlc.Timestamp, error)
 	ResolveUncachedDatabaseByName(
 		ctx context.Context, dbName string, required bool) (*UncachedDatabaseDescriptor, error)

--- a/pkg/sql/sqlbase/result_columns.go
+++ b/pkg/sql/sqlbase/result_columns.go
@@ -214,3 +214,10 @@ var SequenceSelectColumns = ResultColumns{
 	{Name: `log_cnt`, Typ: types.Int},
 	{Name: `is_called`, Typ: types.Bool},
 }
+
+// ExportColumns are the result columns of an EXPORT statement.
+var ExportColumns = ResultColumns{
+	{Name: "filename", Typ: types.String},
+	{Name: "rows", Typ: types.Int},
+	{Name: "bytes", Typ: types.Int},
+}

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -659,6 +659,12 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 			v.observer.attr(name, "label", n.label)
 		}
 		n.plan = v.visit(n.plan)
+
+	case *exportNode:
+		if v.observer.attr != nil {
+			v.observer.attr(name, "destination", n.fileName)
+		}
+		n.source = v.visit(n.source)
 	}
 }
 
@@ -777,6 +783,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&errorIfRowsNode{}):          "error if rows",
 	reflect.TypeOf(&explainDistSQLNode{}):       "explain distsql",
 	reflect.TypeOf(&explainPlanNode{}):          "explain plan",
+	reflect.TypeOf(&exportNode{}):               "export",
 	reflect.TypeOf(&filterNode{}):               "filter",
 	reflect.TypeOf(&groupNode{}):                "group",
 	reflect.TypeOf(&hookFnNode{}):               "plugin",


### PR DESCRIPTION
#### importccl: move export enterprise check to processor instantiation

This change moves the EXPORT license check from the planning code to
the execution part, when we instantiate the CSV Writer processor. The
planning code will move into the optimizer and making the check from
there is more awkward.

Release note: None

#### opt: move EXPORT planning to the optimizer

This change moves the planning of EXPORT to the optimizer. The
planning logic is fairly straightforward and doesn't need to be CCL.

EXPORT can now be used with EXPLAIN and PREPARE.

EXPORT can now only be used with the optimizer (the heuristic planner
will hopefully be removed soon altogether anyway).

One somewhat tricky aspect of the change is around the `KVOptions`
which have string expressions as values (in order to support
placeholders).

Fixes #33469.

Release note: None
