### PR TITLE
build/node-run: don't print error messages to stdout

### DIFF
--- a/build/node-run.sh
+++ b/build/node-run.sh
@@ -42,7 +42,7 @@ set -euo pipefail
 
 raw_version=$(node --version)
 if [ $(grep -oE 'v[0-9]+\.' <<< ${raw_version}) != "v10." ]; then
-    echo "node v10.x is required, found ${raw_version}"
+    echo "$0: node v10.x is required, found ${raw_version}" >&2
     exit 1
 fi
 


### PR DESCRIPTION
node-run was previously warning about incorrect Node versions on stdout.
This would often cause Make to swallow the error message, as node-run.sh
is often invoked redirected to a file. For example, this is build output
I observed:

    $ make build
    Running make with -j8
    GOPATH set to /Users/benesch/go
    Cleaning old generated files.
    # Add comment recognized by reviewable.
    echo '// GENERATED FILE DO NOT EDIT' > pkg/ui/src/js/protos.d.ts
    # Add comment recognized by reviewable.
    echo '// GENERATED FILE DO NOT EDIT' > pkg/ui/ccl/src/js/protos.js
    build/node-run.sh pkg/ui/node_modules/.bin/pbts pkg/ui/src/js/protos.js >> pkg/ui/src/js/protos.d.ts
    build/node-run.sh pkg/ui/node_modules/.bin/pbjs -t static-module -w es6 --strict-long --keep-case --path pkg --path ./vendor/github.com --path ./vendor/github.com/gogo/protobuf --path ./vendor/github.com/cockroachdb/errors --path ./vendor/go.etcd.io --path ./vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis ./pkg/server/serverpb/admin.proto ./pkg/server/serverpb/status.proto ./pkg/server/serverpb/authentication.proto ./pkg/ts/tspb/timeseries.proto ./pkg/ccl/storageccl/engineccl/enginepbccl/stats.proto >> pkg/ui/ccl/src/js/protos.js
    make: *** [pkg/ui/ccl/src/js/protos.js] Error 1
    make: *** Deleting file `pkg/ui/ccl/src/js/protos.js'
    make: *** Waiting for unfinished jobs....
    make: *** [pkg/ui/src/js/protos.d.ts] Error 1
    make: *** Deleting file `pkg/ui/src/js/protos.d.ts'

Note how the error message is not displayed.

This commit changes the error message to be printed to stderr, along
with a prefix identifying the error message as coming from node-run.sh.
This makes the the error visible in the above scenario.

Release note: None