### PR TITLE
distsqlrun: set vectorize=off in flaky test

### DIFF
--- a/pkg/sql/distsqlrun/processors_test.go
+++ b/pkg/sql/distsqlrun/processors_test.go
@@ -596,6 +596,11 @@ func TestDrainingProcessorSwallowsUncertaintyError(t *testing.T) {
 		if _, err := conn.Exec("set distsql='always'"); err != nil {
 			t.Fatal(err)
 		}
+		// Temporarily disable vectorized execution due to flaky failures.
+		// https://github.com/cockroachdb/cockroach/issues/39277
+		if _, err := conn.Exec("set vectorize='off'"); err != nil {
+			t.Fatal(err)
+		}
 		limit := 5
 		if dummy {
 			limit = 6


### PR DESCRIPTION
The TestDrainingProcessorSwallowsUncertaintyError unit test is failing
inconsistently since we enabled the vectorize=auto setting by default. I
disabled vectorized execution in that test until we get the failures
figured out.

Refers #39277

Release note: None