### PR TITLE
backupccl: add support for SHOW BACKUP WITH SCHEMAS

### DIFF
--- a/docs/generated/sql/bnf/show_backup.bnf
+++ b/docs/generated/sql/bnf/show_backup.bnf
@@ -1,2 +1,3 @@
 show_backup_stmt ::=
 	'SHOW' 'BACKUP' location
+	| 'SHOW' 'BACKUP' 'SCHEMAS' location

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -450,6 +450,7 @@ use_stmt ::=
 
 show_backup_stmt ::=
 	'SHOW' 'BACKUP' string_or_placeholder
+	| 'SHOW' 'BACKUP' 'SCHEMAS' string_or_placeholder
 
 show_columns_stmt ::=
 	'SHOW' 'COLUMNS' 'FROM' table_name with_comment

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -12,6 +12,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -110,4 +111,102 @@ func TestShowBackup(t *testing.T) {
 	if len(pathRows) != 2 {
 		t.Fatalf("expected 2 files, but got %d", len(pathRows))
 	}
+
+	// SCHEMAS: Test the creation statement.
+	var showBackupRows [][]string
+	var expected []string
+
+	// Test that tables, views and sequences are all supported.
+	{
+		viewTableSeq := localFoo + "/tableviewseq"
+		sqlDB.Exec(t, `CREATE TABLE data.tableA (a int primary key, b int)`)
+		sqlDB.Exec(t, `CREATE VIEW data.viewA AS SELECT a from data.tableA`)
+		sqlDB.Exec(t, `CREATE SEQUENCE data.seqA START 1 INCREMENT 2 MAXVALUE 20`)
+		sqlDB.Exec(t, `BACKUP data.tableA, data.viewA, data.seqA TO $1;`, viewTableSeq)
+
+		expectedCreateTable := `CREATE TABLE tablea (
+				a INT8 NOT NULL,
+				b INT8 NULL,
+				CONSTRAINT "primary" PRIMARY KEY (a ASC),
+				FAMILY "primary" (a, b)
+			)`
+		expectedCreateView := `CREATE VIEW viewa (a) AS SELECT a FROM data.public.tablea`
+		expectedCreateSeq := `CREATE SEQUENCE seqa MINVALUE 1 MAXVALUE 20 INCREMENT 2 START 1`
+
+		showBackupRows = sqlDB.QueryStr(t, fmt.Sprintf(`SHOW BACKUP SCHEMAS '%s'`, viewTableSeq))
+		expected = []string{
+			expectedCreateTable,
+			expectedCreateView,
+			expectedCreateSeq,
+		}
+		for i, row := range showBackupRows {
+			createStmt := row[6]
+			if !eqWhitespace(createStmt, expected[i]) {
+				t.Fatalf("mismatched create statement: %s, want %s", createStmt, expected[i])
+			}
+		}
+	}
+
+	// Test that foreign keys that reference tables that are in the backup
+	// are included.
+	{
+		includedFK := localFoo + "/includedFK"
+		sqlDB.Exec(t, `CREATE TABLE data.FKSrc (a INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `CREATE TABLE data.FKRefTable (a INT PRIMARY KEY, B INT REFERENCES data.FKSrc(a))`)
+		sqlDB.Exec(t, `CREATE DATABASE data2`)
+		sqlDB.Exec(t, `CREATE TABLE data2.FKRefTable (a INT PRIMARY KEY, B INT REFERENCES data.FKSrc(a))`)
+		sqlDB.Exec(t, `BACKUP data.FKSrc, data.FKRefTable, data2.FKRefTable TO $1;`, includedFK)
+
+		wantSameDB := `CREATE TABLE fkreftable (
+				a INT8 NOT NULL,
+				b INT8 NULL,
+				CONSTRAINT "primary" PRIMARY KEY (a ASC),
+				CONSTRAINT fk_b_ref_fksrc FOREIGN KEY (b) REFERENCES fksrc(a),
+				INDEX fkreftable_auto_index_fk_b_ref_fksrc (b ASC),
+				FAMILY "primary" (a, b)
+			)`
+		wantDiffDB := `CREATE TABLE fkreftable (
+				a INT8 NOT NULL,
+				b INT8 NULL,
+				CONSTRAINT "primary" PRIMARY KEY (a ASC),
+				CONSTRAINT fk_b_ref_fksrc FOREIGN KEY (b) REFERENCES data.public.fksrc(a),
+				INDEX fkreftable_auto_index_fk_b_ref_fksrc (b ASC),
+				FAMILY "primary" (a, b)
+			)`
+
+		showBackupRows = sqlDB.QueryStr(t, fmt.Sprintf(`SHOW BACKUP SCHEMAS '%s'`, includedFK))
+		createStmtSameDB := showBackupRows[1][6]
+		if !eqWhitespace(createStmtSameDB, wantSameDB) {
+			t.Fatalf("mismatched create statement: %s, want %s", createStmtSameDB, wantSameDB)
+		}
+
+		createStmtDiffDB := showBackupRows[2][6]
+		if !eqWhitespace(createStmtDiffDB, wantDiffDB) {
+			t.Fatalf("mismatched create statement: %s, want %s", createStmtDiffDB, wantDiffDB)
+		}
+	}
+
+	// Foreign keys that were not included in the backup are not mentioned in
+	// the create statement.
+	{
+		missingFK := localFoo + "/missingFK"
+		sqlDB.Exec(t, `BACKUP data2.FKRefTable TO $1;`, missingFK)
+
+		want := `CREATE TABLE fkreftable (
+				a INT8 NOT NULL,
+				b INT8 NULL,
+				CONSTRAINT "primary" PRIMARY KEY (a ASC),
+				FAMILY "primary" (a, b)
+			)`
+
+		showBackupRows = sqlDB.QueryStr(t, fmt.Sprintf(`SHOW BACKUP SCHEMAS '%s'`, missingFK))
+		createStmt := showBackupRows[0][6]
+		if !eqWhitespace(createStmt, want) {
+			t.Fatalf("mismatched create statement: %s, want %s", createStmt, want)
+		}
+	}
+}
+
+func eqWhitespace(a, b string) bool {
+	return strings.Replace(a, "\t", "", -1) == strings.Replace(b, "\t", "", -1)
 }

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1146,7 +1146,7 @@ CREATE TABLE crdb_internal.create_statements (
 				} else {
 					descType = typeTable
 					tn := (*tree.Name)(&table.Name)
-					createNofk, err = ShowCreateTable(ctx, tn, contextName, table, lCtx, true /* ignoreFKs */)
+					createNofk, err = ShowCreateTable(ctx, tn, contextName, table, lCtx, IgnoreFKs)
 					if err != nil {
 						return err
 					}
@@ -1178,7 +1178,7 @@ CREATE TABLE crdb_internal.create_statements (
 							}
 						}
 					}
-					stmt, err = ShowCreateTable(ctx, tn, contextName, table, lCtx, false /* ignoreFKs */)
+					stmt, err = ShowCreateTable(ctx, tn, contextName, table, lCtx, IncludeFKs)
 				}
 				if err != nil {
 					return err

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3290,7 +3290,7 @@ show_histogram_stmt:
 
 // %Help: SHOW BACKUP - list backup contents
 // %Category: CCL
-// %Text: SHOW BACKUP [FILES|RANGES] <location>
+// %Text: SHOW BACKUP [SCHEMAS|FILES|RANGES] <location>
 // %SeeAlso: WEBDOCS/show-backup.html
 show_backup_stmt:
   SHOW BACKUP string_or_placeholder
@@ -3298,6 +3298,14 @@ show_backup_stmt:
     $$.val = &tree.ShowBackup{
       Details: tree.BackupDefaultDetails,
       Path:    $3.expr(),
+    }
+  }
+| SHOW BACKUP SCHEMAS string_or_placeholder
+  {
+    $$.val = &tree.ShowBackup{
+      Details: tree.BackupDefaultDetails,
+      ShouldIncludeSchemas: true,
+      Path:    $4.expr(),
     }
   }
 | SHOW BACKUP RANGES string_or_placeholder

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -75,8 +75,9 @@ const (
 
 // ShowBackup represents a SHOW BACKUP statement.
 type ShowBackup struct {
-	Path    Expr
-	Details BackupDetails
+	Path                 Expr
+	Details              BackupDetails
+	ShouldIncludeSchemas bool
 }
 
 // Format implements the NodeFormatter interface.
@@ -86,6 +87,9 @@ func (node *ShowBackup) Format(ctx *FmtCtx) {
 		ctx.WriteString("RANGES ")
 	} else if node.Details == BackupFileDetails {
 		ctx.WriteString("FILES ")
+	}
+	if node.ShouldIncludeSchemas {
+		ctx.WriteString("SCHEMAS ")
 	}
 	ctx.FormatNode(node.Path)
 }

--- a/pkg/sql/show_create_test.go
+++ b/pkg/sql/show_create_test.go
@@ -44,7 +44,7 @@ func TestStandAloneShowCreateTable(t *testing.T) {
 	desc.Indexes[0].Interleave.Ancestors = []sqlbase.InterleaveDescriptor_Ancestor{{TableID: 51, IndexID: 10, SharedPrefixLen: 1}}
 
 	name := tree.Name(desc.Name)
-	got, err := ShowCreateTable(context.TODO(), &name, "", &desc, nil, false)
+	got, err := ShowCreateTable(context.TODO(), &name, "", &desc, nil, IncludeFKs)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Add the ability to show the create statement for the tables, views
or sequences that are stored within a backup. Tables with references to
foreign keys will only display foreign key constraints if the table to
which the constraint relates to is also in the backup.

Closes #38517.

The SQL syntax chose was `SHOW BACKUP WITH SCHEMAS`. The
changes for this were minimal since they were all already keywords. 
Note that `WITH SCHEMAS` cannot be used along with the `RANGES`
and `FILES` descriptor.

Release note (enterprise change): Add support for displaying creation
statements of relations stored in a backup.