### PR TITLE
distsql: move creation of cancellable flow context back to startInternal 

### DIFF
--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -456,9 +456,6 @@ func (f *Flow) setupProcessors(ctx context.Context, inputSyncs [][]RowSource) er
 
 func (f *Flow) setup(ctx context.Context, spec *distsqlpb.FlowSpec) error {
 	f.spec = spec
-	ctx, f.ctxCancel = contextutil.WithCancel(ctx)
-	f.ctxDone = ctx.Done()
-
 	if f.isVectorized {
 		log.VEventf(ctx, 1, "setting up vectorize flow %d", f.id)
 		acc := f.EvalCtx.Mon.MakeBoundAccount()
@@ -490,6 +487,9 @@ func (f *Flow) startInternal(ctx context.Context, doneFn func()) error {
 	log.VEventf(
 		ctx, 1, "starting (%d processors, %d startables)", len(f.processors), len(f.startables),
 	)
+
+	ctx, f.ctxCancel = contextutil.WithCancel(ctx)
+	f.ctxDone = ctx.Done()
 
 	// Only register the flow if there will be inbound stream connections that
 	// need to look up this flow in the flow registry.

--- a/pkg/sql/distsqlrun/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/distsqlrun/vectorized_flow_shutdown_test.go
@@ -280,7 +280,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					nil, /* output */
 					materializerMetadataSources,
 					nil, /* outputStatsToTrace */
-					cancelLocal,
+					func() context.CancelFunc { return cancelLocal },
 				)
 				require.NoError(t, err)
 				materializer.Start(ctxLocal)


### PR DESCRIPTION
It was previously moved to `setup` so that a flow cancel function could
be passed to a materializer in order to cancel a flow. However, there
could be cases where the cancellation would have no effect on the
context used to actually run the flow (e.g. remote nodes where the
parent context would be used). To solve this, we go back to deriving a
cancel function when running a flow and have the materializer access
this cancel function lazily when it is actually necessary and populated
(in InternalClose).

Release note: None

Fixes #39299