### PR TITLE
row: fix behavior of uninitialized cfetchers

### DIFF
--- a/pkg/sql/row/cfetcher.go
+++ b/pkg/sql/row/cfetcher.go
@@ -1116,11 +1116,12 @@ func (rf *CFetcher) fillNulls() error {
 // GetRangesInfo returns information about the ranges where the rows came from.
 // The RangeInfo's are deduped and not ordered.
 func (rf *CFetcher) GetRangesInfo() []roachpb.RangeInfo {
-	if rf == nil {
+	f := rf.fetcher.kvBatchFetcher
+	if f == nil {
 		// Not yet initialized.
 		return nil
 	}
-	return rf.fetcher.getRangesInfo()
+	return f.getRangesInfo()
 }
 
 // getCurrentColumnFamilyID returns the column family id of the key in

--- a/pkg/sql/row/cfetcher_test.go
+++ b/pkg/sql/row/cfetcher_test.go
@@ -1,0 +1,25 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package row
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCFetcherUninitialized(t *testing.T) {
+	// Regression test for #36570: make sure it's okay to call GetRangesInfo even
+	// before the fetcher was fully initialized.
+	var fetcher CFetcher
+
+	assert.Nil(t, fetcher.GetRangesInfo())
+}


### PR DESCRIPTION
Previously, calling DrainMeta on a cfetcher that hadn't been fully
initialized was problematic. Add a guard for that.

Closes #36570.

Release note: None