### PR TITLE
rowcontainer: fix iterator leak on creation error

### DIFF
--- a/pkg/sql/rowcontainer/hash_row_container.go
+++ b/pkg/sql/rowcontainer/hash_row_container.go
@@ -567,6 +567,7 @@ func (h *HashDiskRowContainer) NewBucketIterator(
 		diskRowIterator:      h.NewIterator(ctx).(*diskRowIterator),
 	}
 	if err := ret.Reset(ctx, row); err != nil {
+		ret.Close()
 		return nil, err
 	}
 	return ret, nil


### PR DESCRIPTION
Previously, an error that occurred during creation of a bucket iterator
over a HashDiskRowContainer would cause a leaked iterator panic.

This commit resolves that situation.

Downgrades severity of #38987.

Release note: None