### PR TITLE
roachprod: don't fetch the cores

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1385,6 +1385,15 @@ func (c *cluster) FetchCores(ctx context.Context) error {
 		return nil
 	}
 
+	if true {
+		// TeamCity does not handle giant artifacts well. We'd generally profit
+		// from having the cores, but we should push them straight into a temp
+		// bucket on S3 instead. OTOH, the ROI of this may be low; I don't know
+		// of a recent example where we've wanted the Core dumps.
+		c.l.Printf("skipped fetching cores\n")
+		return nil
+	}
+
 	c.l.Printf("fetching cores\n")
 	c.status("fetching cores")
 


### PR DESCRIPTION
We haven't looked at them so far (as far as I know) but it causes nasty
TeamCity complaints of the form

```
Failed to publish artifacts: Artifact file 'core.cockroach.4702.teamcity-1564984076-21-n9cpu4-0007.1565020901' has size 3605676032 bytes which exceeds maximum allowed size of 3221225472 bytes. Maximum artifact size is configured at the Administration -> Global Settings page.
```

Core dumps are giant, so there's little hope of hosting them on our
TeamCity instance. We need to push them straight to the cloud or
set up TeamCity with a cloud-backed artifacts storage.

Release note: None