### PR TITLE
kv: fix a buglet in SetSystemConfigTrigger and cleanup

### DIFF
--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -274,8 +274,11 @@ func (txn *Txn) CommitTimestampFixed() bool {
 func (txn *Txn) SetSystemConfigTrigger() error {
 	txn.mu.Lock()
 	defer txn.mu.Unlock()
+	if err := txn.mu.sender.AnchorOnSystemConfigRange(); err != nil {
+		return err
+	}
 	txn.systemConfigTrigger = true
-	return txn.mu.sender.SetSystemConfigTrigger()
+	return nil
 }
 
 // DisablePipelining instructs the transaction not to pipeline requests. It


### PR DESCRIPTION
We were asking for the system config trigger to be executed on
EndTransaction even when we had failed to anchor the transaction on the
system config range.
I think this was benign we weren't actually committing the transactions
for which SetSystemConfigTrigger() returned errors.

I've also cleaned up the code a bit. Before this patch, there was a
systemConfigTrigger field on both the Txn and the TxnCoordSender.
However, the TxnCoordSender didn't actually know anything about any
trigger; it is just concerned with the anchoring of the transaction on
the system config range. I've clarified this point.

Release note: None