### PR TITLE
opt: remove fallback to heuristic planner

### DIFF
--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -528,7 +528,7 @@ func TestReportUsage(t *testing.T) {
 			t.Fatal(err)
 		}
 		// Try a correlated subquery to check that feature reporting.
-		if _, err := db.Exec(`SELECT x	FROM (VALUES (1)) AS b(x) WHERE EXISTS(SELECT * FROM (VALUES (1)) AS a(x) WHERE a.x = b.x)`); err != nil {
+		if _, err := db.Exec(`SELECT x FROM (VALUES (1)) AS b(x) WHERE EXISTS(SELECT * FROM (VALUES (1)) AS a(x) WHERE a.x = b.x)`); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -690,19 +690,20 @@ func TestReportUsage(t *testing.T) {
 
 		// Although the query is executed 10 times, due to plan caching
 		// keyed by the SQL text, the planning only occurs once.
+		// TODO(radu): fix this (#39361).
 		"sql.plan.ops.cast.string::inet":                                            1,
 		"sql.plan.ops.bin.jsonb - string":                                           1,
 		"sql.plan.builtins.crdb_internal.force_assertion_error(msg: string) -> int": 1,
 		"sql.plan.ops.array.ind":                                                    1,
 		"sql.plan.ops.array.cons":                                                   1,
 		"sql.plan.ops.array.flatten":                                                1,
+		// The CTE counter is exercised by `WITH a AS (SELECT 1) ...`.
+		"sql.plan.cte": 1,
 
 		// The subquery counter is exercised by `(1, 20, 30, 40) = (SELECT ...)`.
 		"sql.plan.subquery": 1,
 		// The correlated sq counter is exercised by `WHERE EXISTS ( ... )` above.
 		"sql.plan.subquery.correlated": 1,
-		// The CTE counter is exercised by `WITH a AS (SELECT 1) ...`.
-		"sql.plan.cte": 10,
 
 		"unimplemented.#33285.json_object_agg":          10,
 		"unimplemented.pg_catalog.pg_stat_wal_receiver": 10,

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -776,14 +776,10 @@ func (ex *connExecutor) makeExecPlan(ctx context.Context, planner *planner) erro
 			planner.curPlan.flags.Set(planFlagOptIsCorrelated)
 		}
 		log.VEventf(ctx, 1, "optimizer plan failed (isCorrelated=%t): %v", isCorrelated, err)
-		if !canFallbackFromOpt(err, optMode, stmt) {
-			return err
-		}
-		planner.curPlan.flags.Set(planFlagOptFallback)
-		log.VEvent(ctx, 1, "optimizer falls back on heuristic planner")
-	} else {
-		log.VEvent(ctx, 2, "optimizer disabled")
+		return err
 	}
+
+	log.VEvent(ctx, 2, "optimizer disabled")
 	// Use the heuristic planner.
 	optFlags := planner.curPlan.flags
 	err := planner.makePlan(ctx)
@@ -810,46 +806,6 @@ func (ex *connExecutor) saveLogicalPlanDescription(
 	defer stats.Unlock()
 	timeLastSampled := stats.data.SensitiveInfo.MostRecentPlanTimestamp
 	return now.Sub(timeLastSampled) >= period
-}
-
-// canFallbackFromOpt returns whether we can fallback on the heuristic planner
-// when the optimizer hits an error.
-func canFallbackFromOpt(err error, optMode sessiondata.OptimizerMode, stmt *Statement) bool {
-	if !errors.HasUnimplementedError(err) {
-		// We only fallback on "feature not supported" errors.
-		return false
-	}
-	if err.Error() == "unimplemented: schema change statement cannot follow a statement that has written in the same transaction" {
-		// This is a special error generated when SetSystemConfigTrigger fails. If
-		// we fall back to the heuristic planner, the second call to that method
-		// succeeds.
-		// TODO(radu): this will go away very soon when we remove fallback
-		// altogether.
-		return false
-	}
-
-	if optMode == sessiondata.OptimizerAlways {
-		// In Always mode we never fallback, with one exception: SET commands (or
-		// else we can't switch to another mode).
-		_, isSetVar := stmt.AST.(*tree.SetVar)
-		return isSetVar
-	}
-
-	// If the statement is EXPLAIN (OPT), then don't fallback (we want to return
-	// the error, not show a plan from the heuristic planner).
-	// TODO(radu): this is hacky and doesn't handle an EXPLAIN (OPT) inside
-	// a larger query.
-	if e, ok := stmt.AST.(*tree.Explain); ok {
-		if opts, err := e.ParseOptions(); err == nil && opts.Mode == tree.ExplainOpt {
-			return false
-		}
-	}
-
-	// Never fall back on PREPARE AS OPT PLAN.
-	if _, ok := stmt.AST.(*tree.CannedOptPlan); ok {
-		return false
-	}
-	return true
 }
 
 // execWithDistSQLEngine converts a plan to a distributed SQL physical plan and

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -215,18 +215,12 @@ func (ex *connExecutor) populatePrepared(
 			return flags, nil
 		}
 		log.VEventf(ctx, 1, "optimizer prepare failed: %v", err)
-		if !canFallbackFromOpt(err, optMode, stmt) {
-			return 0, err
-		}
-		flags.Set(planFlagOptFallback)
-		log.VEvent(ctx, 1, "prepare falls back on heuristic planner")
-	} else {
-		log.VEvent(ctx, 2, "optimizer disabled (prepare)")
+		return 0, err
 	}
+	log.VEvent(ctx, 2, "optimizer disabled (prepare)")
 
-	// Fallback on the heuristic planner if the optimizer was not enabled or used:
-	// create a plan for the statement to figure out the typing, then close the
-	// plan.
+	// Fallback on the heuristic planner if the optimizer was not enabled: create
+	// a plan for the statement to figure out the typing, then close the plan.
 	prepared.AnonymizedStr = anonymizeStmt(stmt.AST)
 	if err := p.prepare(ctx, stmt.AST); err != nil {
 		err = enhanceErrWithCorrelation(err, isCorrelated)

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -204,11 +204,10 @@ func (ex *connExecutor) populatePrepared(
 	// fallback for all others, so this should be safe for the foreseeable
 	// future.
 	var flags planFlags
-	var isCorrelated bool
 	if optMode := ex.sessionData.OptimizerMode; optMode != sessiondata.OptimizerOff {
 		log.VEvent(ctx, 2, "preparing using optimizer")
 		var err error
-		flags, isCorrelated, err = p.prepareUsingOptimizer(ctx)
+		flags, err = p.prepareUsingOptimizer(ctx)
 		if err == nil {
 			log.VEvent(ctx, 2, "optimizer prepare succeeded")
 			// stmt.Prepared fields have been populated.
@@ -223,7 +222,6 @@ func (ex *connExecutor) populatePrepared(
 	// a plan for the statement to figure out the typing, then close the plan.
 	prepared.AnonymizedStr = anonymizeStmt(stmt.AST)
 	if err := p.prepare(ctx, stmt.AST); err != nil {
-		err = enhanceErrWithCorrelation(err, isCorrelated)
 		return 0, err
 	}
 

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -195,8 +195,6 @@ func (ex *connExecutor) updateOptCounters(planFlags planFlags) {
 	m := &ex.metrics.EngineMetrics
 	if planFlags.IsSet(planFlagOptUsed) {
 		m.SQLOptCount.Inc(1)
-	} else if planFlags.IsSet(planFlagOptFallback) {
-		m.SQLOptFallbackCount.Inc(1)
 	}
 
 	if planFlags.IsSet(planFlagOptCacheHit) {

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -183,14 +183,16 @@ func init() {
 		&tree.ShowFingerprints{},
 		&tree.Truncate{},
 
-		// CCL statements.
+		// CCL statements (without Export which has an optimizer operator).
 		&tree.Backup{},
+		&tree.ShowBackup{},
 		&tree.Restore{},
 		&tree.CreateChangefeed{},
 		&tree.CreateRole{},
 		&tree.DropRole{},
 		&tree.GrantRole{},
 		&tree.RevokeRole{},
+		&tree.Import{},
 	} {
 		typ := optbuilder.OpaqueReadOnly
 		if tree.CanModifySchema(stmt) {

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -74,10 +74,6 @@ type Builder struct {
 	// These fields are set during the building process and can be used after
 	// Build is called.
 
-	// IsCorrelated is set to true during semantic analysis if a scalar variable was
-	// pulled from an outer scope, that is, if the query was found to be correlated.
-	IsCorrelated bool
-
 	// HadPlaceholders is set to true if we replaced any placeholders with their
 	// values.
 	HadPlaceholders bool
@@ -130,6 +126,10 @@ type Builder struct {
 	// TODO(radu): modifying the AST in-place is hacky; we will need to switch to
 	// using AST annotations.
 	qualifyDataSourceNamesInAST bool
+
+	// isCorrelated is set to true if we already reported to telemetry that the
+	// query contains a correlated subquery.
+	isCorrelated bool
 }
 
 // New creates a new Builder structure initialized with the given

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -511,15 +511,11 @@ func (b *Builder) checkSubqueryOuterCols(
 		return
 	}
 
-	if !b.IsCorrelated {
-		// Remember whether the query was correlated for the heuristic planner,
-		// to enhance error messages.
-		// TODO(knz): this can go away when the HP disappears.
-		b.IsCorrelated = true
-
-		// Register the use of correlation to telemetry.
-		// Note: we don't blindly increment the counter every time this
-		// method is called, to avoid double counting the same query.
+	// Register the use of correlation to telemetry.
+	// Note: we don't blindly increment the counter every time this
+	// method is called, to avoid double counting the same query.
+	if !b.isCorrelated {
+		b.isCorrelated = true
 		telemetry.Inc(sqltelemetry.CorrelatedSubqueryUseCounter)
 	}
 

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -825,10 +825,6 @@ const (
 	// This is used to enhance the error fallback and for telemetry.
 	planFlagOptIsCorrelated
 
-	// planFlagOptFallback is set if the optimizer was enabled but did not support the
-	// statement.
-	planFlagOptFallback
-
 	// planFlagOptCacheHit is set if a plan from the query plan cache was used (and
 	// re-optimized).
 	planFlagOptCacheHit

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -821,10 +821,6 @@ const (
 	// planFlagOptUsed is set if the optimizer was used to create the plan.
 	planFlagOptUsed planFlags = (1 << iota)
 
-	// planFlagIsCorrelated is set if the plan contained a correlated subquery.
-	// This is used to enhance the error fallback and for telemetry.
-	planFlagOptIsCorrelated
-
 	// planFlagOptCacheHit is set if a plan from the query plan cache was used (and
 	// re-optimized).
 	planFlagOptCacheHit

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -36,10 +36,6 @@ type PreparedStatement struct {
 	// if it is used by the optimizer as a starting point.
 	Memo *memo.Memo
 
-	// IsCorrelated memoizes whether the query contained correlated
-	// subqueries during planning (prior to de-correlation).
-	IsCorrelated bool
-
 	// refCount keeps track of the number of references to this PreparedStatement.
 	// New references are registered through incRef().
 	// Once refCount hits 0 (through calls to decRef()), the following memAcc is

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -593,14 +593,12 @@ func (sc *SchemaChanger) maybeBackfillCreateTableAs(
 			}
 
 			// Construct an optimized logical plan of the AS source stmt.
-			// TODO(adityamaru): Design a way to fallback on the heuristic planner if
-			// the optimizer fails.
 			localPlanner.stmt = &Statement{Statement: stmt}
 			localPlanner.optPlanningCtx.init(localPlanner)
 
 			var result *planTop
 			localPlanner.runWithOptions(resolveFlags{skipCache: true}, func() {
-				result, _, err = localPlanner.makeOptimizerPlan(ctx)
+				result, err = localPlanner.makeOptimizerPlan(ctx)
 				if err == nil {
 					localPlanner.curPlan = *result
 				}

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -163,12 +163,15 @@ type CCLOnlyStatement interface {
 }
 
 var _ CCLOnlyStatement = &Backup{}
+var _ CCLOnlyStatement = &ShowBackup{}
 var _ CCLOnlyStatement = &Restore{}
 var _ CCLOnlyStatement = &CreateRole{}
 var _ CCLOnlyStatement = &DropRole{}
 var _ CCLOnlyStatement = &GrantRole{}
 var _ CCLOnlyStatement = &RevokeRole{}
 var _ CCLOnlyStatement = &CreateChangefeed{}
+var _ CCLOnlyStatement = &Import{}
+var _ CCLOnlyStatement = &Export{}
 
 // StatementType implements the Statement interface.
 func (*AlterIndex) StatementType() StatementType { return DDL }
@@ -430,6 +433,8 @@ func (*Explain) StatementTag() string { return "EXPLAIN" }
 // StatementType implements the Statement interface.
 func (*Export) StatementType() StatementType { return Rows }
 
+func (*Export) cclOnlyStatement() {}
+
 // StatementTag returns a short string identifying the type of statement.
 func (*Export) StatementTag() string { return "EXPORT" }
 
@@ -458,6 +463,8 @@ func (n *Import) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*Import) StatementTag() string { return "IMPORT" }
+
+func (*Import) cclOnlyStatement() {}
 
 // StatementType implements the Statement interface.
 func (*ParenSelect) StatementType() StatementType { return Rows }
@@ -659,6 +666,8 @@ func (*ShowBackup) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowBackup) StatementTag() string { return "SHOW BACKUP" }
+
+func (*ShowBackup) cclOnlyStatement() {}
 
 // StatementType implements the Statement interface.
 func (*ShowDatabases) StatementType() StatementType { return Rows }

--- a/pkg/sql/with.go
+++ b/pkg/sql/with.go
@@ -105,6 +105,7 @@ func containsMutations(plan planNode) (bool, error) {
 // is finished resolving names, which pops the environment frame.
 func (p *planner) initWith(ctx context.Context, with *tree.With) (func(p *planner) error, error) {
 	if with != nil {
+		telemetry.Inc(sqltelemetry.CteUseCounter)
 		frame := make(cteNameEnvironmentFrame)
 		p.curPlan.cteNameEnvironment = p.curPlan.cteNameEnvironment.push(frame)
 		for _, cte := range with.CTEList {
@@ -122,8 +123,6 @@ func (p *planner) initWith(ctx context.Context, with *tree.With) (func(p *planne
 		}
 		return popCteNameEnvironment, nil
 	}
-
-	telemetry.Inc(sqltelemetry.CteUseCounter)
 
 	return nil, nil
 }


### PR DESCRIPTION
The optimizer is able to handle all statements now; we can remove the
logic to fall back to the heuristic planner.

A couple of things needed fixing:
 - we didn't include `Import` and `ShowBackup` as opaque statements (they
   weren't implementing `CCLOnlyStatement`, which is also fixed).
 - the HP was incorrectly hitting the CTE telemetry counter even when
   there was no `WITH`. In the existing test, the HP was running as
   fallback because of some unimplemented functions.

Release note: None