### PR TITLE
opt: turn optimizer on in schema changer

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -2269,7 +2269,8 @@ func createSchemaChangeEvalCtx(
 		DataConversion: sessiondata.DataConversionConfig{
 			Location: dummyLocation,
 		},
-		User: security.NodeUser,
+		User:          security.NodeUser,
+		OptimizerMode: sessiondata.OptimizerOn,
 	}
 
 	evalCtx := extendedEvalContext{


### PR DESCRIPTION
The schema changer sets up a custom `SessionData`; it wasn't
initializing the `OptimizerMode` field. This change sets it to On
(which is normally the default).

Release note: None