### PR TITLE
release-2.1: sql/sem/tree: bugfix in handling unary negatives

### DIFF
--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -21,12 +21,11 @@ import (
 	"math"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/pkg/errors"
 )
 
 // Constant is an constant literal expression which may be resolved to more than one type.
@@ -125,6 +124,8 @@ type NumVal struct {
 	resDecimal DDecimal
 }
 
+var _ Constant = &NumVal{}
+
 // Format implements the NodeFormatter interface.
 func (expr *NumVal) Format(ctx *FmtCtx) {
 	s := expr.OrigString
@@ -198,14 +199,21 @@ func (expr *NumVal) AsInt32() (int32, error) {
 	return int32(i), nil
 }
 
-// asConstantInt returns the value as an constant.Int if possible, along
-// with a flag indicating whether the conversion was possible.
-// The result contains the proper sign as per expr.Negative.
-func (expr *NumVal) asConstantInt() (constant.Value, bool) {
+// asValue returns the value as a constant numerical value, with the proper sign
+// as given by expr.Negative.
+func (expr *NumVal) asValue() constant.Value {
 	v := expr.Value
 	if expr.Negative {
 		v = constant.UnaryOp(token.SUB, v, 0)
 	}
+	return v
+}
+
+// asConstantInt returns the value as an constant.Int if possible, along
+// with a flag indicating whether the conversion was possible.
+// The result contains the proper sign as per expr.Negative.
+func (expr *NumVal) asConstantInt() (constant.Value, bool) {
+	v := expr.asValue()
 	intVal := constant.ToInt(v)
 	if intVal.Kind() == constant.Int {
 		return intVal, true
@@ -299,9 +307,11 @@ func (expr *NumVal) ResolveAsType(ctx *SemaContext, typ types.T) (Datum, error) 
 			}
 		}
 		if !dd.IsZero() {
-			// Negative zero does not exist for DECIMAL, in that case we
-			// ignore the sign.
-			dd.Negative = expr.Negative
+			// Negative zero does not exist for DECIMAL, in that case we ignore the
+			// sign. Otherwise XOR the signs of the expr and the decimal value
+			// contained in the expr, since the negative may have been folded into the
+			// inner decimal.
+			dd.Negative = dd.Negative != expr.Negative
 		}
 		return dd, nil
 	case types.Oid,
@@ -559,16 +569,7 @@ func (constantFolderVisitor) VisitPost(expr Expr) (retExpr Expr) {
 		switch cv := t.Expr.(type) {
 		case *NumVal:
 			if tok, ok := unaryOpToToken[t.Operator]; ok {
-				switch tok {
-				case token.ADD:
-					return cv
-				case token.SUB:
-					// We always coerce -0 to 0 everywhere else, so this can be a passthrough.
-					if cv.Value.Kind() == constant.Float && constant.Compare(cv.Value, token.EQL, constant.MakeFloat64(0)) {
-						return cv
-					}
-				}
-				return &NumVal{Value: constant.UnaryOp(tok, cv.Value, 0)}
+				return &NumVal{Value: constant.UnaryOp(tok, cv.asValue(), 0)}
 			}
 			if token, ok := unaryOpToTokenIntOnly[t.Operator]; ok {
 				if intVal, ok := cv.asConstantInt(); ok {
@@ -581,7 +582,7 @@ func (constantFolderVisitor) VisitPost(expr Expr) (retExpr Expr) {
 		case *NumVal:
 			if r, ok := t.Right.(*NumVal); ok {
 				if token, ok := binaryOpToToken[t.Operator]; ok {
-					return &NumVal{Value: constant.BinaryOp(l.Value, token, r.Value)}
+					return &NumVal{Value: constant.BinaryOp(l.asValue(), token, r.asValue())}
 				}
 				if token, ok := binaryOpToTokenIntOnly[t.Operator]; ok {
 					if lInt, ok := l.asConstantInt(); ok {
@@ -610,7 +611,7 @@ func (constantFolderVisitor) VisitPost(expr Expr) (retExpr Expr) {
 		case *NumVal:
 			if r, ok := t.Right.(*NumVal); ok {
 				if token, ok := comparisonOpToToken[t.Operator]; ok {
-					return MakeDBool(DBool(constant.Compare(l.Value, token, r.Value)))
+					return MakeDBool(DBool(constant.Compare(l.asValue(), token, r.asValue())))
 				}
 			}
 		case *StrVal:


### PR DESCRIPTION
Backport 1/2 commits from #39245.

/cc @cockroachdb/release

---

When performing constant folding, we will now always evaluate unary
negatives right away. To facilitate this, this commit extracts a NumExpr
interface that is implemented by *NumVal. The new interface has methods
to access the constant.Value of the *NumVal, and this accessor always
will perform the necessary unary negation operator.

This works because unary negation has high precedence (only preceded by
the typecast operation).

This change requires us to inspect the Negative flags of both the Expr
and inner Decimal value when resolving a NumExpr that contains a
Decimal, since on some operations like division, the negative value will
now get folded into the Decimal.

Tests have not been backported since there have been significant changes
in testing infrastructure.

Release note (bug fix): unary negatives in constant arithmetic expressions
are no longer ignored.
