### PR TITLE
exec: add memory estimation to a few streaming operators

### DIFF
--- a/pkg/sql/distsqlrun/colbatch_scan.go
+++ b/pkg/sql/distsqlrun/colbatch_scan.go
@@ -47,7 +47,11 @@ type colBatchScan struct {
 	init bool
 }
 
-var _ exec.Operator = &colBatchScan{}
+var _ exec.StaticMemoryOperator = &colBatchScan{}
+
+func (s *colBatchScan) EstimateStaticMemoryUsage() int {
+	return s.rf.EstimateStaticMemoryUsage()
+}
 
 func (s *colBatchScan) Init() {
 	s.ctx = context.Background()

--- a/pkg/sql/distsqlrun/columnarizer.go
+++ b/pkg/sql/distsqlrun/columnarizer.go
@@ -38,7 +38,6 @@ type columnarizer struct {
 	typs            []types.T
 }
 
-var _ exec.Operator = &columnarizer{}
 var _ exec.StaticMemoryOperator = &columnarizer{}
 
 // newColumnarizer returns a new columnarizer.

--- a/pkg/sql/exec/aggregator.go
+++ b/pkg/sql/exec/aggregator.go
@@ -117,7 +117,6 @@ type orderedAggregator struct {
 	seenNonEmptyBatch bool
 }
 
-var _ Operator = &orderedAggregator{}
 var _ StaticMemoryOperator = &orderedAggregator{}
 
 // NewOrderedAggregator creates an ordered aggregator on the given grouping

--- a/pkg/sql/exec/coalescer.go
+++ b/pkg/sql/exec/coalescer.go
@@ -28,7 +28,6 @@ type coalescerOp struct {
 	buffer coldata.Batch
 }
 
-var _ Operator = &coalescerOp{}
 var _ StaticMemoryOperator = &coalescerOp{}
 
 // NewCoalescerOp creates a new coalescer operator on the given input operator

--- a/pkg/sql/exec/colrpc/inbox.go
+++ b/pkg/sql/exec/colrpc/inbox.go
@@ -105,7 +105,6 @@ type Inbox struct {
 	}
 }
 
-var _ exec.Operator = &Inbox{}
 var _ exec.StaticMemoryOperator = &Inbox{}
 
 // NewInbox creates a new Inbox.

--- a/pkg/sql/exec/count.go
+++ b/pkg/sql/exec/count.go
@@ -29,7 +29,6 @@ type countOp struct {
 	count         int64
 }
 
-var _ Operator = &countOp{}
 var _ StaticMemoryOperator = &countOp{}
 
 // NewCountOp returns a new count operator that counts the rows in its input.

--- a/pkg/sql/exec/fn_op.go
+++ b/pkg/sql/exec/fn_op.go
@@ -24,6 +24,8 @@ type fnOp struct {
 	fn func()
 }
 
+var _ resettableOperator = fnOp{}
+
 func (f fnOp) Init() {
 	f.input.Init()
 }
@@ -33,3 +35,5 @@ func (f fnOp) Next(ctx context.Context) coldata.Batch {
 	f.fn()
 	return batch
 }
+
+func (f fnOp) reset() {}

--- a/pkg/sql/exec/operator.go
+++ b/pkg/sql/exec/operator.go
@@ -114,6 +114,7 @@ func (n *twoInputNode) Child(nth int) OpNode {
 // StaticMemoryOperator is an interface that streaming operators can implement
 // if they are able to declare their memory usage upfront.
 type StaticMemoryOperator interface {
+	Operator
 	// EstimateStaticMemoryUsage estimates the memory usage (in bytes)
 	// of an operator.
 	EstimateStaticMemoryUsage() int

--- a/pkg/sql/exec/orderedsynchronizer.go
+++ b/pkg/sql/exec/orderedsynchronizer.go
@@ -20,9 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 )
 
-var _ StaticMemoryOperator = &OrderedSynchronizer{}
-var _ Operator = &OrderedSynchronizer{}
-
 // OrderedSynchronizer receives rows from multiple inputs and produces a single
 // stream of rows, ordered according to a set of columns. The rows in each input
 // stream are assumed to be ordered according to the same set of columns.
@@ -39,6 +36,8 @@ type OrderedSynchronizer struct {
 	comparators []vecComparator
 	output      coldata.Batch
 }
+
+var _ StaticMemoryOperator = &OrderedSynchronizer{}
 
 // ChildCount implements the OpNode interface.
 func (o *OrderedSynchronizer) ChildCount() int {

--- a/pkg/sql/exec/ordinality.go
+++ b/pkg/sql/exec/ordinality.go
@@ -30,7 +30,11 @@ type ordinalityOp struct {
 	counter int64
 }
 
-var _ Operator = &ordinalityOp{}
+var _ StaticMemoryOperator = &ordinalityOp{}
+
+func (c *ordinalityOp) EstimateStaticMemoryUsage() int {
+	return EstimateBatchSizeBytes([]types.T{types.Int64}, coldata.BatchSize)
+}
 
 const colNotAppended = -1
 

--- a/pkg/sql/logictest/testdata/logic_test/dist_vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/dist_vectorize
@@ -94,7 +94,7 @@ EXPLAIN (VEC) SELECT count(*) FROM kv
  │    └── *distsqlrun.materializer
  │         └── *exec.orderedAggregator
  │              └── *exec.oneShotOp
- │                   └── exec.fnOp
+ │                   └── exec.distinctChainOps
  │                        └── *exec.UnorderedSynchronizer
  │                             ├── *exec.countOp
  │                             │    └── *exec.simpleProjectOp
@@ -141,7 +141,7 @@ EXPLAIN (VEC) SELECT count(*) FROM kv NATURAL INNER HASH JOIN kv kv2
  │    └── *distsqlrun.materializer
  │         └── *exec.orderedAggregator
  │              └── *exec.oneShotOp
- │                   └── exec.fnOp
+ │                   └── exec.distinctChainOps
  │                        └── *exec.UnorderedSynchronizer
  │                             ├── *exec.countOp
  │                             │    └── *exec.simpleProjectOp

--- a/pkg/sql/row/cfetcher.go
+++ b/pkg/sql/row/cfetcher.go
@@ -226,6 +226,10 @@ type CFetcher struct {
 		// having to call batch.Vec too often in the tight loop.
 		colvecs []coldata.Vec
 	}
+
+	// estimatedStaticMemoryUsage is the best guess about how much memory the
+	// CFetcher will use.
+	estimatedStaticMemoryUsage int
 }
 
 // Init sets up a Fetcher for a given table and index. If we are using a
@@ -283,6 +287,7 @@ func (rf *CFetcher) Init(
 	}
 	rf.machine.batch = coldata.NewMemBatch(typs)
 	rf.machine.colvecs = rf.machine.batch.ColVecs()
+	rf.estimatedStaticMemoryUsage = exec.EstimateBatchSizeBytes(typs, coldata.BatchSize)
 
 	var err error
 
@@ -1141,4 +1146,10 @@ func (rf *CFetcher) getCurrentColumnFamilyID() (sqlbase.FamilyID, error) {
 		return 0, scrub.WrapError(scrub.IndexKeyDecodingError, err)
 	}
 	return sqlbase.FamilyID(id), nil
+}
+
+// EstimateStaticMemoryUsage estimates how much memory is pre-allocated by the
+// CFetcher.
+func (rf *CFetcher) EstimateStaticMemoryUsage() int {
+	return rf.estimatedStaticMemoryUsage
 }


### PR DESCRIPTION
Previously, we would not account for the static memory usage by
colBatchScan, distinct chain, and ordinality operators. Now this is
fixed.

Release note: None