### PR TITLE
backupccl: add 19.2 version gate for partitioned backup

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -132,6 +132,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>19.1-10</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>19.1-11</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -1005,6 +1005,11 @@ func backupPlanHook(
 		if err != nil {
 			return err
 		}
+		if len(to) > 1 &&
+			!p.ExecCfg().Settings.Version.IsActive(cluster.VersionPartitionedBackup) {
+			return errors.Errorf("partitioned backups can only be made on a cluster that has been fully upgraded to version 19.2")
+		}
+
 		incrementalFrom, err := incrementalFromFn()
 		if err != nil {
 			return err
@@ -1018,7 +1023,6 @@ func backupPlanHook(
 			}
 		}
 
-		// TODO (lucy): put partitioned BACKUP behind a 19.2 version gate
 		defaultURI, urisByLocalityKV, err := getURIsByLocalityKV(to)
 		if err != nil {
 			return nil

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -45,6 +45,7 @@ const (
 	VersionAtomicChangeReplicasTrigger
 	VersionAtomicChangeReplicas
 	VersionTableDescModificationTimeFromMVCC
+	VersionPartitionedBackup
 
 	// Add new versions here (step one of two).
 
@@ -544,6 +545,11 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// row which contained the serialized table descriptor.
 		Key:     VersionTableDescModificationTimeFromMVCC,
 		Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 10},
+	},
+	{
+		// VersionPartitionedBackup is https://github.com/cockroachdb/cockroach/pull/39250.
+		Key:     VersionPartitionedBackup,
+		Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 11},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/settings/cluster/versionkey_string.go
+++ b/pkg/settings/cluster/versionkey_string.go
@@ -22,11 +22,12 @@ func _() {
 	_ = x[VersionAtomicChangeReplicasTrigger-11]
 	_ = x[VersionAtomicChangeReplicas-12]
 	_ = x[VersionTableDescModificationTimeFromMVCC-13]
+	_ = x[VersionPartitionedBackup-14]
 }
 
-const _VersionKey_name = "Version2_1VersionUnreplicatedRaftTruncatedStateVersionSideloadedStorageNoReplicaIDVersion19_1VersionStart19_2VersionQueryTxnTimestampVersionStickyBitVersionParallelCommitsVersionGenerationComparableVersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCC"
+const _VersionKey_name = "Version2_1VersionUnreplicatedRaftTruncatedStateVersionSideloadedStorageNoReplicaIDVersion19_1VersionStart19_2VersionQueryTxnTimestampVersionStickyBitVersionParallelCommitsVersionGenerationComparableVersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackup"
 
-var _VersionKey_index = [...]uint16{0, 10, 47, 82, 93, 109, 133, 149, 171, 198, 220, 246, 280, 307, 347}
+var _VersionKey_index = [...]uint16{0, 10, 47, 82, 93, 109, 133, 149, 171, 198, 220, 246, 280, 307, 347, 371}
 
 func (i VersionKey) String() string {
 	if i < 0 || i >= VersionKey(len(_VersionKey_index)-1) {


### PR DESCRIPTION
This PR adds a new cluster version for partitioned backup, and adds a check
that a mixed-version cluster whose upgrade to 19.2 has not been finalized
cannot create partitioned backups.

Release justification: This is a small fix for a new feature.

Release note: None