### PR TITLE
cli/zip: use "cockroach zip" as application name

### DIFF
--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -215,7 +215,7 @@ func runDebugZip(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	sqlConn, err := getPasswordAndMakeSQLClient("cockroach sql")
+	sqlConn, err := getPasswordAndMakeSQLClient("cockroach zip")
 	if err != nil {
 		log.Warningf(baseCtx, "unable to open a SQL session. Debug information will be incomplete: %s", err)
 	}


### PR DESCRIPTION
Fixes #39376.

.. this enables separate telemetry for the command.

Release note: None