### PR TITLE
sql: clean up explain_tree tests

### DIFF
--- a/pkg/sql/explain_tree_test.go
+++ b/pkg/sql/explain_tree_test.go
@@ -16,563 +16,69 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/stretchr/testify/assert"
+	"github.com/cockroachdb/datadriven"
+	yaml "gopkg.in/yaml.v2"
 )
 
-// TestPlanToTreeAndPlanToString verifies that output from planToTree()
-// 1) matches expected ExplainTreePlanNode structure, and
-// 2) is similar to the output of the pre-existing planToString().
 func TestPlanToTreeAndPlanToString(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	sqlSetup := "CREATE DATABASE t; CREATE TABLE t.orders (oid INT PRIMARY KEY, cid INT, value DECIMAL, date DATE);"
-	plansToTest := []*TestData{
-		{
-			// Test span anonymization.
-			SQL: `SELECT oid FROM t.orders WHERE oid = 123`,
-			// In the string version, the constants are not anonimized.
-			ExpectedPlanString: `0 render  (oid int) oid=CONST; key()
-0 .render 0 (@1)[int] (oid int) oid=CONST; key()
-1 scan  (oid int) oid=CONST; key()
-1 .table orders@primary (oid int) oid=CONST; key()
-1 .spans /123-/123/# (oid int) oid=CONST; key()
-`,
-			ExpectedPlanTree: &roachpb.ExplainTreePlanNode{
-				Name: "render",
-				Attrs: []*roachpb.ExplainTreePlanNode_Attr{
-					{
-						Key:   "render",
-						Value: "oid",
-					},
-				},
-				Children: []*roachpb.ExplainTreePlanNode{
-					{
-						Name: "scan",
-						Attrs: []*roachpb.ExplainTreePlanNode_Attr{
-							{
-								Key:   "table",
-								Value: "orders@primary",
-							},
-							{
-								// Span is anonimized.
-								Key:   "spans",
-								Value: "1 span",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			// Test select statement 1.
-			SQL: "SELECT CId, Date, Value FROM t.Orders",
-			ExpectedPlanString: `0 render  (cid int, date date, value decimal) 
-0 .render 0 (@2)[int] (cid int, date date, value decimal) 
-0 .render 1 (@4)[date] (cid int, date date, value decimal) 
-0 .render 2 (@3)[decimal] (cid int, date date, value decimal) 
-1 scan  (cid int, date date, value decimal) 
-1 .table orders@primary (cid int, date date, value decimal) 
-1 .spans ALL (cid int, date date, value decimal) 
-`,
-			ExpectedPlanTree: &roachpb.ExplainTreePlanNode{
-				Name: "render",
-				Attrs: []*roachpb.ExplainTreePlanNode_Attr{
-					{
-						Key:   "render",
-						Value: "cid",
-					},
-					{
-						Key:   "render",
-						Value: "date",
-					},
-					{
-						Key:   "render",
-						Value: "value",
-					},
-				},
-				Children: []*roachpb.ExplainTreePlanNode{
-					{
-						Name: "scan",
-						Attrs: []*roachpb.ExplainTreePlanNode_Attr{
-							{
-								Key:   "table",
-								Value: "orders@primary",
-							},
-							{
-								Key:   "spans",
-								Value: "ALL",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			// Test select statement 2.
-			SQL: "SELECT CId, sum(Value) FROM t.Orders WHERE Date > '2015-01-01' GROUP BY CId ORDER BY 1 - sum(Value);",
-			ExpectedPlanString: `0 sort  (cid int, sum decimal) weak-key(cid)
-0 .order +"?column?" (cid int, sum decimal) weak-key(cid)
-1 render  (cid int, sum decimal) weak-key(cid)
-1 .render 0 (@1)[int] (cid int, sum decimal) weak-key(cid)
-1 .render 1 (@2)[decimal] (cid int, sum decimal) weak-key(cid)
-1 .render 2 ((1)[decimal] - (@2)[decimal])[decimal] (cid int, sum decimal) weak-key(cid)
-2 group  (cid int, sum decimal) weak-key(cid)
-2 .aggregate 0 cid (cid int, sum decimal) weak-key(cid)
-2 .aggregate 1 sum(value) (cid int, sum decimal) weak-key(cid)
-2 .group by cid (cid int, sum decimal) weak-key(cid)
-3 render  (cid int, sum decimal) weak-key(cid)
-3 .render 0 (@2)[int] (cid int, sum decimal) weak-key(cid)
-3 .render 1 (@3)[decimal] (cid int, sum decimal) weak-key(cid)
-4 scan  (cid int, sum decimal) weak-key(cid)
-4 .table orders@primary (cid int, sum decimal) weak-key(cid)
-4 .spans ALL (cid int, sum decimal) weak-key(cid)
-4 .filter ((@4)[date] > ('2015-01-01')[date])[bool] (cid int, sum decimal) weak-key(cid)
-`,
-			ExpectedPlanTree: &roachpb.ExplainTreePlanNode{
-				Name: "sort",
-				Attrs: []*roachpb.ExplainTreePlanNode_Attr{
-					{
-						Key:   "order",
-						Value: "+\"?column?\"",
-					},
-				},
-				Children: []*roachpb.ExplainTreePlanNode{
-					{
-						Name: "render",
-						Attrs: []*roachpb.ExplainTreePlanNode_Attr{
-							{
-								Key:   "render",
-								Value: "agg0",
-							},
-							{
-								Key:   "render",
-								Value: "agg1",
-							},
-							{
-								Key:   "render",
-								Value: "_ - agg1",
-							},
-						},
-						Children: []*roachpb.ExplainTreePlanNode{
-							{
-								Name: "group",
-								Attrs: []*roachpb.ExplainTreePlanNode_Attr{
-									{
-										Key:   "aggregate 0",
-										Value: "cid",
-									},
-									{
-										Key:   "aggregate 1",
-										Value: "sum(value)",
-									},
-									{
-										Key:   "group by",
-										Value: "cid",
-									},
-								},
-								Children: []*roachpb.ExplainTreePlanNode{
-									{
-										Name: "render",
-										Attrs: []*roachpb.ExplainTreePlanNode_Attr{
-											{
-												Key:   "render",
-												Value: "cid",
-											},
-											{
-												Key:   "render",
-												Value: "value",
-											},
-										},
-										Children: []*roachpb.ExplainTreePlanNode{
-											{
-												Name: "scan",
-												Attrs: []*roachpb.ExplainTreePlanNode_Attr{
-													{
-														Key:   "table",
-														Value: "orders@primary",
-													},
-													{
-														Key:   "spans",
-														Value: "ALL",
-													},
-													{
-														Key:   "filter",
-														Value: "date > _",
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			SQL: "SELECT Value FROM (SELECT CId, Date, Value FROM t.Orders)",
-			ExpectedPlanString: `0 render  (value decimal) 
-0 .render 0 (@3)[decimal] (value decimal) 
-1 render  (value decimal) 
-1 .render 0 (NULL)[unknown] (value decimal) 
-1 .render 1 (NULL)[unknown] (value decimal) 
-1 .render 2 (@3)[decimal] (value decimal) 
-2 scan  (value decimal) 
-2 .table orders@primary (value decimal) 
-2 .spans ALL (value decimal) 
-`,
-			ExpectedPlanTree: &roachpb.ExplainTreePlanNode{
-				Name: "render",
-				Attrs: []*roachpb.ExplainTreePlanNode_Attr{
-					{
-						Key:   "render",
-						Value: "value",
-					},
-				},
-				Children: []*roachpb.ExplainTreePlanNode{
-					{
-						Name: "render",
-						Attrs: []*roachpb.ExplainTreePlanNode_Attr{
-							{
-								Key:   "render",
-								Value: "_",
-							},
-							{
-								Key:   "render",
-								Value: "_",
-							},
-							{
-								Key:   "render",
-								Value: "value",
-							},
-						},
-						Children: []*roachpb.ExplainTreePlanNode{
-							{
-								Name: "scan",
-								Attrs: []*roachpb.ExplainTreePlanNode_Attr{
-									{
-										Key:   "table",
-										Value: "orders@primary",
-									},
-									{
-										Key:   "spans",
-										Value: "ALL",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			SQL: "SELECT cid, date, value FROM t.Orders WHERE date IN (SELECT date FROM t.Orders)",
-			ExpectedPlanString: `0 root  (cid int, date date, value decimal) date!=NULL
-1 render  (cid int, date date, value decimal) date!=NULL
-1 .render 0 (@2)[int] (cid int, date date, value decimal) date!=NULL
-1 .render 1 (@4)[date] (cid int, date date, value decimal) date!=NULL
-1 .render 2 (@3)[decimal] (cid int, date date, value decimal) date!=NULL
-2 scan  (cid int, date date, value decimal) date!=NULL
-2 .table orders@primary (cid int, date date, value decimal) date!=NULL
-2 .spans ALL (cid int, date date, value decimal) date!=NULL
-2 .filter ((@4)[date] IN (@S1)[tuple{date}])[bool] (cid int, date date, value decimal) date!=NULL
-1 subquery  (cid int, date date, value decimal) date!=NULL
-1 .id @S1 (cid int, date date, value decimal) date!=NULL
-1 .original sql (SELECT date FROM t.public.orders) (cid int, date date, value decimal) date!=NULL
-1 .exec mode all rows normalized (cid int, date date, value decimal) date!=NULL
-2 render  (cid int, date date, value decimal) date!=NULL
-2 .render 0 (@4)[date] (cid int, date date, value decimal) date!=NULL
-3 scan  (cid int, date date, value decimal) date!=NULL
-3 .table orders@primary (cid int, date date, value decimal) date!=NULL
-3 .spans ALL (cid int, date date, value decimal) date!=NULL
-`,
-			ExpectedPlanTree: &roachpb.ExplainTreePlanNode{
-				Name: "root",
-				Children: []*roachpb.ExplainTreePlanNode{
-					{
-						Name: "render",
-						Attrs: []*roachpb.ExplainTreePlanNode_Attr{
-							{
-								Key:   "render",
-								Value: "cid",
-							},
-							{
-								Key:   "render",
-								Value: "date",
-							},
-							{
-								Key:   "render",
-								Value: "value",
-							},
-						},
-						Children: []*roachpb.ExplainTreePlanNode{
-							{
-								Name: "scan",
-								Attrs: []*roachpb.ExplainTreePlanNode_Attr{
-									{
-										Key:   "table",
-										Value: "orders@primary",
-									},
-									{
-										Key:   "spans",
-										Value: "ALL",
-									},
-									{
-										Key:   "filter",
-										Value: "date IN (SELECT date FROM t.public.orders)",
-									},
-								},
-							},
-						},
-					},
-					{
-						Name: "subquery",
-						Attrs: []*roachpb.ExplainTreePlanNode_Attr{
-							{
-								Key:   "id",
-								Value: "@S1",
-							},
-							{
-								Key:   "original sql",
-								Value: "(SELECT date FROM t.public.orders)",
-							},
-							{
-								Key:   "exec mode",
-								Value: "all rows normalized",
-							},
-						},
-						Children: []*roachpb.ExplainTreePlanNode{
-							{
-								Name: "render",
-								Attrs: []*roachpb.ExplainTreePlanNode_Attr{
-									{
-										Key:   "render",
-										Value: "date",
-									},
-								},
-								Children: []*roachpb.ExplainTreePlanNode{
-									{
-										Name: "scan",
-										Attrs: []*roachpb.ExplainTreePlanNode_Attr{
-											{
-												Key:   "table",
-												Value: "orders@primary",
-											},
-											{
-												Key:   "spans",
-												Value: "ALL",
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	assertExpectedPlansForTests(t, sqlSetup, plansToTest)
-}
 
-func TestScrubExplainTreeButNotExplainString(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	sqlSetup := `CREATE DATABASE t; 
-create table t.movies (
-  id serial primary key,
-  title text,
-  released int
-);
-
-create table t.actors (
-  id serial primary key,
-  name text
-);`
-
-	//subquery is `(SELECT name FROM t.actors WHERE name = 'Foo')`.
-	sqlWithSubquery := "SELECT id AS movie_id, title, (SELECT name FROM t.actors WHERE name = 'Foo') FROM t.movies"
-
-	//`EXPLAIN` should not scrub subquery.
-	expectedPlantoStringWithNoScrubbing := `0 root  (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
-1 render  (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
-1 .render 0 (@1)[int] (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
-1 .render 1 (@2)[string] (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
-1 .render 2 (@S1)[string] (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
-2 scan  (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
-2 .table movies@primary (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
-2 .spans ALL (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
-1 subquery  (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
-1 .id @S1 (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
-1 .original sql (SELECT name FROM t.public.actors WHERE name = 'Foo') (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
-1 .exec mode one row (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
-2 max1row  (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
-3 limit  (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
-3 .count (2)[int] (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
-4 render  (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
-4 .render 0 (@2)[string] (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
-5 scan  (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
-5 .table actors@primary (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
-5 .spans ALL (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
-5 .filter ((@2)[string] = ('Foo')[string])[bool] (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
-`
-	//explainToTree should scrub expressions and subquery attributes.
-	expectedPlanToTreeShouldScrub := &roachpb.ExplainTreePlanNode{
-		Name: "root",
-		Children: []*roachpb.ExplainTreePlanNode{
-			{
-				Name: "render",
-				Attrs: []*roachpb.ExplainTreePlanNode_Attr{
-					{
-						Key:   "render",
-						Value: "id",
-					},
-					{
-						Key:   "render",
-						Value: "title",
-					},
-					{
-						Key:   "render",
-						Value: "(SELECT name FROM t.public.actors WHERE name = _)",
-					},
-				},
-				Children: []*roachpb.ExplainTreePlanNode{
-					{
-						Name: "scan",
-						Attrs: []*roachpb.ExplainTreePlanNode_Attr{
-							{
-								Key:   "table",
-								Value: "movies@primary",
-							},
-							{
-								Key:   "spans",
-								Value: "ALL",
-							},
-						},
-					},
-				},
-			},
-			{
-				Name: "subquery",
-				Attrs: []*roachpb.ExplainTreePlanNode_Attr{
-					{
-						Key:   "id",
-						Value: "@S1",
-					},
-					{
-						Key:   "original sql",
-						Value: "(SELECT name FROM t.public.actors WHERE name = _)",
-					},
-					{
-						Key:   "exec mode",
-						Value: "one row",
-					},
-				},
-				Children: []*roachpb.ExplainTreePlanNode{
-					{
-						Name: "max1row",
-						Children: []*roachpb.ExplainTreePlanNode{
-							{
-								Name: "limit",
-								Attrs: []*roachpb.ExplainTreePlanNode_Attr{
-									{
-										Key:   "count",
-										Value: "_",
-									},
-								},
-								Children: []*roachpb.ExplainTreePlanNode{
-									{
-										Name: "render",
-										Attrs: []*roachpb.ExplainTreePlanNode_Attr{
-											{
-												Key:   "render",
-												Value: "name",
-											},
-										},
-										Children: []*roachpb.ExplainTreePlanNode{
-											{
-												Name: "scan",
-												Attrs: []*roachpb.ExplainTreePlanNode_Attr{
-													{
-														Key:   "table",
-														Value: "actors@primary",
-													},
-													{
-														Key:   "spans",
-														Value: "ALL",
-													},
-													{
-														Key:   "filter",
-														Value: "name = _",
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	assertExpectedPlansForTests(t, sqlSetup, []*TestData{
-		{
-			SQL:                sqlWithSubquery,
-			ExpectedPlanString: expectedPlantoStringWithNoScrubbing,
-			ExpectedPlanTree:   expectedPlanToTreeShouldScrub,
-		},
-	})
-}
-
-func assertExpectedPlansForTests(t *testing.T, sqlSetup string, plansToTest []*TestData) {
-	// Setup.
 	ctx := context.Background()
 	s, sqlDB, db := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
-	if _, err := sqlDB.ExecContext(
-		ctx, sqlSetup); err != nil {
-		t.Fatal(err)
-	}
 	execCfg := s.ExecutorConfig().(ExecutorConfig)
-	internalPlanner, cleanup := NewInternalPlanner(
-		"test",
-		client.NewTxn(ctx, db, s.NodeID(), client.RootTxn),
-		security.RootUser,
-		&MemoryMetrics{},
-		&execCfg,
-	)
-	defer cleanup()
-	p := internalPlanner.(*planner)
+	r := sqlutils.MakeSQLRunner(sqlDB)
+	r.Exec(t, `
+		SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;
+		CREATE DATABASE t;
+		USE t;
+	`)
 
-	// Run planToTree() and assert expected value for each plan in plansToTest.
-	for _, test := range plansToTest {
-		stmt, err := parser.ParseOne(test.SQL)
-		if err != nil {
-			t.Fatal(err)
-		}
-		p.stmt = &Statement{Statement: stmt}
-		if err := p.makePlan(ctx); err != nil {
-			t.Fatal(err)
-		}
-		actualPlanTree := planToTree(ctx, &p.curPlan)
-		assert.Equal(t, test.ExpectedPlanTree, actualPlanTree,
-			"planToTree for %s:\nexpected:%s\nactual:%s", test.SQL, test.ExpectedPlanTree, actualPlanTree)
-		actualPlanString := planToString(ctx, p.curPlan.plan, p.curPlan.subqueryPlans, p.curPlan.postqueryPlans)
-		assert.Equal(t, test.ExpectedPlanString, actualPlanString,
-			"planToString for %s:\nexpected:%s\nactual:%s", test.SQL, test.ExpectedPlanString, actualPlanString)
-	}
-}
+	datadriven.RunTest(t, "testdata/explain_tree", func(d *datadriven.TestData) string {
+		switch d.Cmd {
+		case "exec":
+			r.Exec(t, d.Input)
+			return ""
 
-type TestData struct {
-	SQL                string
-	ExpectedPlanString string
-	ExpectedPlanTree   *roachpb.ExplainTreePlanNode
+		case "plan-string", "plan-tree":
+			stmt, err := parser.ParseOne(d.Input)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			internalPlanner, cleanup := NewInternalPlanner(
+				"test",
+				client.NewTxn(ctx, db, s.NodeID(), client.RootTxn),
+				security.RootUser,
+				&MemoryMetrics{},
+				&execCfg,
+			)
+			defer cleanup()
+			p := internalPlanner.(*planner)
+
+			p.stmt = &Statement{Statement: stmt}
+			if err := p.makePlan(ctx); err != nil {
+				t.Fatal(err)
+			}
+			if d.Cmd == "plan-string" {
+				return planToString(ctx, p.curPlan.plan, p.curPlan.subqueryPlans, p.curPlan.postqueryPlans)
+			}
+			tree := planToTree(ctx, &p.curPlan)
+			treeYaml, err := yaml.Marshal(tree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return string(treeYaml)
+
+		default:
+			t.Fatalf("unsupported command %s", d.Cmd)
+			return ""
+		}
+	})
 }

--- a/pkg/sql/testdata/explain_tree
+++ b/pkg/sql/testdata/explain_tree
@@ -1,0 +1,325 @@
+exec
+CREATE TABLE t.orders (oid INT PRIMARY KEY, cid INT, value DECIMAL, date DATE)
+----
+
+# In the string version, the constants are not anonymized.
+plan-string
+SELECT oid FROM t.orders WHERE oid = 123
+----
+0 render  (oid int) oid=CONST; key()
+0 .render 0 (@1)[int] (oid int) oid=CONST; key()
+1 scan  (oid int) oid=CONST; key()
+1 .table orders@primary (oid int) oid=CONST; key()
+1 .spans /123-/123/# (oid int) oid=CONST; key()
+
+plan-tree
+SELECT oid FROM t.orders WHERE oid = 123
+----
+name: render
+attrs:
+- key: render
+  value: oid
+children:
+- name: scan
+  attrs:
+  - key: table
+    value: orders@primary
+  - key: spans
+    value: 1 span
+  children: []
+
+plan-string
+SELECT cid, date, value FROM t.orders
+----
+0 render  (cid int, date date, value decimal) 
+0 .render 0 (@2)[int] (cid int, date date, value decimal) 
+0 .render 1 (@4)[date] (cid int, date date, value decimal) 
+0 .render 2 (@3)[decimal] (cid int, date date, value decimal) 
+1 scan  (cid int, date date, value decimal) 
+1 .table orders@primary (cid int, date date, value decimal) 
+1 .spans ALL (cid int, date date, value decimal) 
+
+plan-tree
+SELECT cid, date, value FROM t.orders
+----
+name: render
+attrs:
+- key: render
+  value: cid
+- key: render
+  value: date
+- key: render
+  value: value
+children:
+- name: scan
+  attrs:
+  - key: table
+    value: orders@primary
+  - key: spans
+    value: ALL
+  children: []
+
+plan-string
+SELECT cid, sum(value) FROM t.orders WHERE date > '2015-01-01' GROUP BY cid ORDER BY 1 - sum(value)
+----
+0 sort  (cid int, sum decimal) weak-key(cid)
+0 .order +"?column?" (cid int, sum decimal) weak-key(cid)
+1 render  (cid int, sum decimal) weak-key(cid)
+1 .render 0 (@1)[int] (cid int, sum decimal) weak-key(cid)
+1 .render 1 (@2)[decimal] (cid int, sum decimal) weak-key(cid)
+1 .render 2 ((1)[decimal] - (@2)[decimal])[decimal] (cid int, sum decimal) weak-key(cid)
+2 group  (cid int, sum decimal) weak-key(cid)
+2 .aggregate 0 cid (cid int, sum decimal) weak-key(cid)
+2 .aggregate 1 sum(value) (cid int, sum decimal) weak-key(cid)
+2 .group by cid (cid int, sum decimal) weak-key(cid)
+3 render  (cid int, sum decimal) weak-key(cid)
+3 .render 0 (@2)[int] (cid int, sum decimal) weak-key(cid)
+3 .render 1 (@3)[decimal] (cid int, sum decimal) weak-key(cid)
+4 scan  (cid int, sum decimal) weak-key(cid)
+4 .table orders@primary (cid int, sum decimal) weak-key(cid)
+4 .spans ALL (cid int, sum decimal) weak-key(cid)
+4 .filter ((@4)[date] > ('2015-01-01')[date])[bool] (cid int, sum decimal) weak-key(cid)
+
+plan-tree
+SELECT cid, sum(value) FROM t.orders WHERE date > '2015-01-01' GROUP BY cid ORDER BY 1 - sum(value)
+----
+name: sort
+attrs:
+- key: order
+  value: +"?column?"
+children:
+- name: render
+  attrs:
+  - key: render
+    value: agg0
+  - key: render
+    value: agg1
+  - key: render
+    value: _ - agg1
+  children:
+  - name: group
+    attrs:
+    - key: aggregate 0
+      value: cid
+    - key: aggregate 1
+      value: sum(value)
+    - key: group by
+      value: cid
+    children:
+    - name: render
+      attrs:
+      - key: render
+        value: cid
+      - key: render
+        value: value
+      children:
+      - name: scan
+        attrs:
+        - key: table
+          value: orders@primary
+        - key: spans
+          value: ALL
+        - key: filter
+          value: date > _
+        children: []
+
+plan-string
+SELECT value FROM (SELECT cid, date, value FROM t.orders)
+----
+0 render  (value decimal) 
+0 .render 0 (@3)[decimal] (value decimal) 
+1 render  (value decimal) 
+1 .render 0 (NULL)[unknown] (value decimal) 
+1 .render 1 (NULL)[unknown] (value decimal) 
+1 .render 2 (@3)[decimal] (value decimal) 
+2 scan  (value decimal) 
+2 .table orders@primary (value decimal) 
+2 .spans ALL (value decimal) 
+
+plan-tree
+SELECT value FROM (SELECT cid, date, value FROM t.orders)
+----
+name: render
+attrs:
+- key: render
+  value: value
+children:
+- name: render
+  attrs:
+  - key: render
+    value: _
+  - key: render
+    value: _
+  - key: render
+    value: value
+  children:
+  - name: scan
+    attrs:
+    - key: table
+      value: orders@primary
+    - key: spans
+      value: ALL
+    children: []
+
+plan-string
+SELECT cid, date, value FROM t.orders WHERE date IN (SELECT date FROM t.orders)
+----
+0 root  (cid int, date date, value decimal) date!=NULL
+1 render  (cid int, date date, value decimal) date!=NULL
+1 .render 0 (@2)[int] (cid int, date date, value decimal) date!=NULL
+1 .render 1 (@4)[date] (cid int, date date, value decimal) date!=NULL
+1 .render 2 (@3)[decimal] (cid int, date date, value decimal) date!=NULL
+2 scan  (cid int, date date, value decimal) date!=NULL
+2 .table orders@primary (cid int, date date, value decimal) date!=NULL
+2 .spans ALL (cid int, date date, value decimal) date!=NULL
+2 .filter ((@4)[date] IN (@S1)[tuple{date}])[bool] (cid int, date date, value decimal) date!=NULL
+1 subquery  (cid int, date date, value decimal) date!=NULL
+1 .id @S1 (cid int, date date, value decimal) date!=NULL
+1 .original sql (SELECT date FROM t.public.orders) (cid int, date date, value decimal) date!=NULL
+1 .exec mode all rows normalized (cid int, date date, value decimal) date!=NULL
+2 render  (cid int, date date, value decimal) date!=NULL
+2 .render 0 (@4)[date] (cid int, date date, value decimal) date!=NULL
+3 scan  (cid int, date date, value decimal) date!=NULL
+3 .table orders@primary (cid int, date date, value decimal) date!=NULL
+3 .spans ALL (cid int, date date, value decimal) date!=NULL
+
+plan-tree
+SELECT cid, date, value FROM t.orders WHERE date IN (SELECT date FROM t.orders)
+----
+name: root
+attrs: []
+children:
+- name: render
+  attrs:
+  - key: render
+    value: cid
+  - key: render
+    value: date
+  - key: render
+    value: value
+  children:
+  - name: scan
+    attrs:
+    - key: table
+      value: orders@primary
+    - key: spans
+      value: ALL
+    - key: filter
+      value: date IN (SELECT date FROM t.public.orders)
+    children: []
+- name: subquery
+  attrs:
+  - key: id
+    value: '@S1'
+  - key: original sql
+    value: (SELECT date FROM t.public.orders)
+  - key: exec mode
+    value: all rows normalized
+  children:
+  - name: render
+    attrs:
+    - key: render
+      value: date
+    children:
+    - name: scan
+      attrs:
+      - key: table
+        value: orders@primary
+      - key: spans
+        value: ALL
+      children: []
+
+exec
+CREATE TABLE t.movies (
+  id SERIAL PRIMARY KEY,
+  title TEXT,
+  released INT
+)
+----
+
+exec
+CREATE TABLE t.actors (
+  id SERIAL PRIMARY KEY,
+  name TEXT
+)
+----
+
+# Subquery.
+plan-string
+SELECT id AS movie_id, title, (SELECT name FROM t.actors WHERE name = 'Foo') FROM t.movies
+----
+0 root  (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
+1 render  (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
+1 .render 0 (@1)[int] (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
+1 .render 1 (@2)[string] (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
+1 .render 2 (@S1)[string] (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
+2 scan  (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
+2 .table movies@primary (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
+2 .spans ALL (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
+1 subquery  (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
+1 .id @S1 (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
+1 .original sql (SELECT name FROM t.public.actors WHERE name = 'Foo') (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
+1 .exec mode one row (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
+2 max1row  (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
+3 limit  (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
+3 .count (2)[int] (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
+4 render  (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
+4 .render 0 (@2)[string] (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
+5 scan  (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
+5 .table actors@primary (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
+5 .spans ALL (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
+5 .filter ((@2)[string] = ('Foo')[string])[bool] (movie_id int, title string, name string) name=CONST; movie_id!=NULL; key(movie_id)
+
+plan-tree
+SELECT id AS movie_id, title, (SELECT name FROM t.actors WHERE name = 'Foo') FROM t.movies
+----
+name: root
+attrs: []
+children:
+- name: render
+  attrs:
+  - key: render
+    value: id
+  - key: render
+    value: title
+  - key: render
+    value: (SELECT name FROM t.public.actors WHERE name = _)
+  children:
+  - name: scan
+    attrs:
+    - key: table
+      value: movies@primary
+    - key: spans
+      value: ALL
+    children: []
+- name: subquery
+  attrs:
+  - key: id
+    value: '@S1'
+  - key: original sql
+    value: (SELECT name FROM t.public.actors WHERE name = _)
+  - key: exec mode
+    value: one row
+  children:
+  - name: max1row
+    attrs: []
+    children:
+    - name: limit
+      attrs:
+      - key: count
+        value: _
+      children:
+      - name: render
+        attrs:
+        - key: render
+          value: name
+        children:
+        - name: scan
+          attrs:
+          - key: table
+            value: actors@primary
+          - key: spans
+            value: ALL
+          - key: filter
+            value: name = _
+          children: []


### PR DESCRIPTION
These tests are extremely difficult to update when the plans change.
Most of them are changing soon when we switch over the test to use the
optimizer.

This change replaces the hardcoded tests with a datadriven test. The
tree is converted to a yaml representation which is easily read.
Updating the tests is now trivial with the `-rewrite` flag.

Release note: None