### PR TITLE
ccl: switch ccl logictest to use the optimizer

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/as_of
+++ b/pkg/ccl/logictestccl/testdata/logic_test/as_of
@@ -1,4 +1,4 @@
-# LogicTest: local
+# LogicTest: local-opt
 
 statement ok
 CREATE TABLE t (i INT)

--- a/pkg/ccl/logictestccl/testdata/logic_test/case_sensitive_names
+++ b/pkg/ccl/logictestccl/testdata/logic_test/case_sensitive_names
@@ -1,4 +1,4 @@
-# LogicTest: local
+# LogicTest: local-opt
 
 statement ok
 CREATE TABLE p (a INT PRIMARY KEY) PARTITION BY LIST (a) (

--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
@@ -1,4 +1,4 @@
-# LogicTest: local
+# LogicTest: local-opt
 
 query IITTITTT colnames
 SELECT * FROM crdb_internal.partitions

--- a/pkg/ccl/logictestccl/testdata/logic_test/distsql_partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/distsql_partitioning
@@ -1,4 +1,4 @@
-# LogicTest: 5node-dist
+# LogicTest: 5node-dist-opt
 
 # Tests for the show partitions command.
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/drop_index
+++ b/pkg/ccl/logictestccl/testdata/logic_test/drop_index
@@ -1,4 +1,4 @@
-# LogicTest: 5node-dist
+# LogicTest: 5node-dist-opt
 
 statement ok
 CREATE TABLE t (

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_index
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_index
@@ -1,4 +1,4 @@
-# LogicTest: local
+# LogicTest: local-opt
 
 statement ok
 CREATE TABLE ok1 (

--- a/pkg/ccl/logictestccl/testdata/logic_test/restore
+++ b/pkg/ccl/logictestccl/testdata/logic_test/restore
@@ -1,4 +1,4 @@
-# LogicTest: local
+# LogicTest: local-opt
 
 # Check that we get through parsing and license check.
 statement error pq: failed to read backup descriptor: unsupported storage scheme: ""

--- a/pkg/ccl/logictestccl/testdata/logic_test/role
+++ b/pkg/ccl/logictestccl/testdata/logic_test/role
@@ -1,4 +1,4 @@
-# LogicTest: local
+# LogicTest: local-opt
 
 query T colnames
 SHOW ROLES

--- a/pkg/ccl/roleccl/role.go
+++ b/pkg/ccl/roleccl/role.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
 func createRolePlanHook(
@@ -60,231 +61,259 @@ func dropRolePlanHook(
 
 func grantRolePlanHook(
 	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
-) (sql.PlanNode, error) {
+) (
+	fn sql.PlanHookRowFn,
+	header sqlbase.ResultColumns,
+	subplans []sql.PlanNode,
+	avoidBuffering bool,
+	err error,
+) {
 	grant, ok := stmt.(*tree.GrantRole)
 	if !ok {
-		return nil, nil
+		return nil, nil, nil, false, nil
 	}
 
-	if err := utilccl.CheckEnterpriseEnabled(
-		p.ExecCfg().Settings, p.ExecCfg().ClusterID(), p.ExecCfg().Organization(), "GRANT <role>",
-	); err != nil {
-		return nil, err
-	}
+	fn = func(ctx context.Context, _ []sql.PlanNode, _ chan<- tree.Datums) error {
+		// TODO(dan): Move this span into sql.
+		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
+		defer tracing.FinishSpan(span)
 
-	if hasAdminRole, err := p.HasAdminRole(ctx); err != nil {
-		return nil, err
-	} else if !hasAdminRole {
-		// Not a superuser: check permissions on each role.
-		allRoles, err := p.MemberOfWithAdminOption(ctx, p.User())
-		if err != nil {
-			return nil, err
+		if err := utilccl.CheckEnterpriseEnabled(
+			p.ExecCfg().Settings, p.ExecCfg().ClusterID(), p.ExecCfg().Organization(), "GRANT <role>",
+		); err != nil {
+			return err
 		}
-		for _, r := range grant.Roles {
-			if isAdmin, ok := allRoles[string(r)]; !ok || !isAdmin {
-				return nil, pgerror.Newf(pgcode.InsufficientPrivilege,
-					"%s is not a superuser or role admin for role %s", p.User(), r)
+
+		if hasAdminRole, err := p.HasAdminRole(ctx); err != nil {
+			return err
+		} else if !hasAdminRole {
+			// Not a superuser: check permissions on each role.
+			allRoles, err := p.MemberOfWithAdminOption(ctx, p.User())
+			if err != nil {
+				return err
 			}
-		}
-	}
-
-	// Check that users and roles exist.
-	// TODO(mberhault): just like GRANT/REVOKE privileges, we fetch the list of all users.
-	// This is wasteful when we have a LOT of users compared to the number of users being operated on.
-	users, err := p.GetAllUsersAndRoles(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	// NOTE: membership manipulation involving the "public" pseudo-role fails with
-	// "role public does not exist". This matches postgres behavior.
-
-	// Check roles: these have to be roles.
-	for _, r := range grant.Roles {
-		if isRole, ok := users[string(r)]; !ok || !isRole {
-			return nil, pgerror.Newf(pgcode.UndefinedObject, "role %s does not exist", r)
-		}
-	}
-
-	// Check grantees: these can be users or roles.
-	for _, m := range grant.Members {
-		if _, ok := users[string(m)]; !ok {
-			return nil, pgerror.Newf(pgcode.UndefinedObject, "user or role %s does not exist", m)
-		}
-	}
-
-	// Given an acyclic directed membership graph, adding a new edge (grant.Member ∈ grant.Role)
-	// means checking whether we have an expanded relationship (grant.Role ∈ ... ∈ grant.Member)
-	// For each grant.Role, we lookup all the roles it is a member of.
-	// After adding a given edge (grant.Member ∈ grant.Role), we add the edge to the list as well.
-	allRoleMemberships := make(map[string]map[string]bool)
-	for _, rawR := range grant.Roles {
-		r := string(rawR)
-		allRoles, err := p.MemberOfWithAdminOption(ctx, r)
-		if err != nil {
-			return nil, err
-		}
-		allRoleMemberships[r] = allRoles
-	}
-
-	// Since we perform no queries here, check all role/member pairs for cycles.
-	// Only if there are no errors do we proceed to write them.
-	for _, rawR := range grant.Roles {
-		r := string(rawR)
-		for _, rawM := range grant.Members {
-			m := string(rawM)
-			if r == m {
-				// self-cycle.
-				return nil, pgerror.Newf(pgcode.InvalidGrantOperation, "%s cannot be a member of itself", m)
-			}
-			// Check if grant.Role ∈ ... ∈ grant.Member
-			if memberOf, ok := allRoleMemberships[r]; ok {
-				if _, ok = memberOf[m]; ok {
-					return nil, pgerror.Newf(pgcode.InvalidGrantOperation,
-						"making %s a member of %s would create a cycle", m, r)
+			for _, r := range grant.Roles {
+				if isAdmin, ok := allRoles[string(r)]; !ok || !isAdmin {
+					return pgerror.Newf(pgcode.InsufficientPrivilege,
+						"%s is not a superuser or role admin for role %s", p.User(), r)
 				}
 			}
-			// Add the new membership. We don't care about the actual bool value.
-			if _, ok := allRoleMemberships[m]; !ok {
-				allRoleMemberships[m] = make(map[string]bool)
-			}
-			allRoleMemberships[m][r] = false
 		}
-	}
 
-	// Add memberships. Existing memberships are allowed.
-	// If admin option is false, we do not remove it from existing memberships.
-	memberStmt := `INSERT INTO system.role_members ("role", "member", "isAdmin") VALUES ($1, $2, $3) ON CONFLICT ("role", "member")`
-	if grant.AdminOption {
-		// admin option: true, set "isAdmin" even if the membership exists.
-		memberStmt += ` DO UPDATE SET "isAdmin" = true`
-	} else {
-		// admin option: false, do not clear it from existing memberships.
-		memberStmt += ` DO NOTHING`
-	}
+		// Check that users and roles exist.
+		// TODO(mberhault): just like GRANT/REVOKE privileges, we fetch the list of all users.
+		// This is wasteful when we have a LOT of users compared to the number of users being operated on.
+		users, err := p.GetAllUsersAndRoles(ctx)
+		if err != nil {
+			return err
+		}
 
-	var rowsAffected int
-	for _, r := range grant.Roles {
+		// NOTE: membership manipulation involving the "public" pseudo-role fails with
+		// "role public does not exist". This matches postgres behavior.
+
+		// Check roles: these have to be roles.
+		for _, r := range grant.Roles {
+			if isRole, ok := users[string(r)]; !ok || !isRole {
+				return pgerror.Newf(pgcode.UndefinedObject, "role %s does not exist", r)
+			}
+		}
+
+		// Check grantees: these can be users or roles.
 		for _, m := range grant.Members {
-			affected, err := p.ExecCfg().InternalExecutor.Exec(
-				ctx, "grant-role", p.Txn(),
-				memberStmt,
-				r, m, grant.AdminOption,
-			)
-			if err != nil {
-				return nil, err
+			if _, ok := users[string(m)]; !ok {
+				return pgerror.Newf(pgcode.UndefinedObject, "user or role %s does not exist", m)
 			}
-
-			rowsAffected += affected
 		}
+
+		// Given an acyclic directed membership graph, adding a new edge (grant.Member ∈ grant.Role)
+		// means checking whether we have an expanded relationship (grant.Role ∈ ... ∈ grant.Member)
+		// For each grant.Role, we lookup all the roles it is a member of.
+		// After adding a given edge (grant.Member ∈ grant.Role), we add the edge to the list as well.
+		allRoleMemberships := make(map[string]map[string]bool)
+		for _, rawR := range grant.Roles {
+			r := string(rawR)
+			allRoles, err := p.MemberOfWithAdminOption(ctx, r)
+			if err != nil {
+				return err
+			}
+			allRoleMemberships[r] = allRoles
+		}
+
+		// Since we perform no queries here, check all role/member pairs for cycles.
+		// Only if there are no errors do we proceed to write them.
+		for _, rawR := range grant.Roles {
+			r := string(rawR)
+			for _, rawM := range grant.Members {
+				m := string(rawM)
+				if r == m {
+					// self-cycle.
+					return pgerror.Newf(pgcode.InvalidGrantOperation, "%s cannot be a member of itself", m)
+				}
+				// Check if grant.Role ∈ ... ∈ grant.Member
+				if memberOf, ok := allRoleMemberships[r]; ok {
+					if _, ok = memberOf[m]; ok {
+						return pgerror.Newf(pgcode.InvalidGrantOperation,
+							"making %s a member of %s would create a cycle", m, r)
+					}
+				}
+				// Add the new membership. We don't care about the actual bool value.
+				if _, ok := allRoleMemberships[m]; !ok {
+					allRoleMemberships[m] = make(map[string]bool)
+				}
+				allRoleMemberships[m][r] = false
+			}
+		}
+
+		// Add memberships. Existing memberships are allowed.
+		// If admin option is false, we do not remove it from existing memberships.
+		memberStmt := `INSERT INTO system.role_members ("role", "member", "isAdmin") VALUES ($1, $2, $3) ON CONFLICT ("role", "member")`
+		if grant.AdminOption {
+			// admin option: true, set "isAdmin" even if the membership exists.
+			memberStmt += ` DO UPDATE SET "isAdmin" = true`
+		} else {
+			// admin option: false, do not clear it from existing memberships.
+			memberStmt += ` DO NOTHING`
+		}
+
+		var rowsAffected int
+		for _, r := range grant.Roles {
+			for _, m := range grant.Members {
+				affected, err := p.ExecCfg().InternalExecutor.Exec(
+					ctx, "grant-role", p.Txn(),
+					memberStmt,
+					r, m, grant.AdminOption,
+				)
+				if err != nil {
+					return err
+				}
+
+				rowsAffected += affected
+			}
+		}
+
+		// We need to bump the table version to trigger a refresh if anything changed.
+		if rowsAffected > 0 {
+			if err := p.BumpRoleMembershipTableVersion(ctx); err != nil {
+				return err
+			}
+		}
+
+		return nil
 	}
 
-	// We need to bump the table version to trigger a refresh if anything changed.
-	if rowsAffected > 0 {
-		if err := p.BumpRoleMembershipTableVersion(ctx); err != nil {
-			return nil, err
-		}
-	}
-
-	return sql.NewZeroNode(nil /* columns */), nil
+	return fn, sqlbase.ResultColumns{}, nil, false, nil
 }
 
 func revokeRolePlanHook(
 	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
-) (sql.PlanNode, error) {
+) (
+	fn sql.PlanHookRowFn,
+	header sqlbase.ResultColumns,
+	subplans []sql.PlanNode,
+	avoidBuffering bool,
+	err error,
+) {
 	revoke, ok := stmt.(*tree.RevokeRole)
 	if !ok {
-		return nil, nil
+		return nil, nil, nil, false, nil
 	}
 
-	if err := utilccl.CheckEnterpriseEnabled(
-		p.ExecCfg().Settings, p.ExecCfg().ClusterID(), p.ExecCfg().Organization(), "REVOKE <role>",
-	); err != nil {
-		return nil, err
-	}
+	fn = func(ctx context.Context, _ []sql.PlanNode, _ chan<- tree.Datums) error {
+		// TODO(dan): Move this span into sql.
+		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
+		defer tracing.FinishSpan(span)
 
-	if hasAdminRole, err := p.HasAdminRole(ctx); err != nil {
-		return nil, err
-	} else if !hasAdminRole {
-		// Not a superuser: check permissions on each role.
-		allRoles, err := p.MemberOfWithAdminOption(ctx, p.User())
-		if err != nil {
-			return nil, err
+		if err := utilccl.CheckEnterpriseEnabled(
+			p.ExecCfg().Settings, p.ExecCfg().ClusterID(), p.ExecCfg().Organization(), "REVOKE <role>",
+		); err != nil {
+			return err
 		}
-		for _, r := range revoke.Roles {
-			if isAdmin, ok := allRoles[string(r)]; !ok || !isAdmin {
-				return nil, pgerror.Newf(pgcode.InsufficientPrivilege,
-					"%s is not a superuser or role admin for role %s", p.User(), r)
-			}
-		}
-	}
 
-	// Check that users and roles exist.
-	// TODO(mberhault): just like GRANT/REVOKE privileges, we fetch the list of all users.
-	// This is wasteful when we have a LOT of users compared to the number of users being operated on.
-	users, err := p.GetAllUsersAndRoles(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	// Check roles: these have to be roles.
-	for _, r := range revoke.Roles {
-		if isRole, ok := users[string(r)]; !ok || !isRole {
-			return nil, pgerror.Newf(pgcode.UndefinedObject, "role %s does not exist", r)
-		}
-	}
-
-	// Check members: these can be users or roles.
-	for _, m := range revoke.Members {
-		if _, ok := users[string(m)]; !ok {
-			return nil, pgerror.Newf(pgcode.UndefinedObject, "user or role %s does not exist", m)
-		}
-	}
-
-	var memberStmt string
-	if revoke.AdminOption {
-		// ADMIN OPTION FOR is specified, we don't remove memberships just remove the admin option.
-		memberStmt = `UPDATE system.role_members SET "isAdmin" = false WHERE "role" = $1 AND "member" = $2`
-	} else {
-		// Admin option not specified: remove membership if it exists.
-		memberStmt = `DELETE FROM system.role_members WHERE "role" = $1 AND "member" = $2`
-	}
-
-	var rowsAffected int
-	for _, r := range revoke.Roles {
-		for _, m := range revoke.Members {
-			if string(r) == sqlbase.AdminRole && string(m) == security.RootUser {
-				// We use CodeObjectInUseError which is what happens if you tried to delete the current user in pg.
-				return nil, pgerror.Newf(pgcode.ObjectInUse,
-					"user %s cannot be removed from role %s or lose the ADMIN OPTION",
-					security.RootUser, sqlbase.AdminRole)
-			}
-			affected, err := p.ExecCfg().InternalExecutor.Exec(
-				ctx, "revoke-role", p.Txn(),
-				memberStmt,
-				r, m,
-			)
+		if hasAdminRole, err := p.HasAdminRole(ctx); err != nil {
+			return err
+		} else if !hasAdminRole {
+			// Not a superuser: check permissions on each role.
+			allRoles, err := p.MemberOfWithAdminOption(ctx, p.User())
 			if err != nil {
-				return nil, err
+				return err
 			}
-
-			rowsAffected += affected
+			for _, r := range revoke.Roles {
+				if isAdmin, ok := allRoles[string(r)]; !ok || !isAdmin {
+					return pgerror.Newf(pgcode.InsufficientPrivilege,
+						"%s is not a superuser or role admin for role %s", p.User(), r)
+				}
+			}
 		}
+
+		// Check that users and roles exist.
+		// TODO(mberhault): just like GRANT/REVOKE privileges, we fetch the list of all users.
+		// This is wasteful when we have a LOT of users compared to the number of users being operated on.
+		users, err := p.GetAllUsersAndRoles(ctx)
+		if err != nil {
+			return err
+		}
+
+		// Check roles: these have to be roles.
+		for _, r := range revoke.Roles {
+			if isRole, ok := users[string(r)]; !ok || !isRole {
+				return pgerror.Newf(pgcode.UndefinedObject, "role %s does not exist", r)
+			}
+		}
+
+		// Check members: these can be users or roles.
+		for _, m := range revoke.Members {
+			if _, ok := users[string(m)]; !ok {
+				return pgerror.Newf(pgcode.UndefinedObject, "user or role %s does not exist", m)
+			}
+		}
+
+		var memberStmt string
+		if revoke.AdminOption {
+			// ADMIN OPTION FOR is specified, we don't remove memberships just remove the admin option.
+			memberStmt = `UPDATE system.role_members SET "isAdmin" = false WHERE "role" = $1 AND "member" = $2`
+		} else {
+			// Admin option not specified: remove membership if it exists.
+			memberStmt = `DELETE FROM system.role_members WHERE "role" = $1 AND "member" = $2`
+		}
+
+		var rowsAffected int
+		for _, r := range revoke.Roles {
+			for _, m := range revoke.Members {
+				if string(r) == sqlbase.AdminRole && string(m) == security.RootUser {
+					// We use CodeObjectInUseError which is what happens if you tried to delete the current user in pg.
+					return pgerror.Newf(pgcode.ObjectInUse,
+						"user %s cannot be removed from role %s or lose the ADMIN OPTION",
+						security.RootUser, sqlbase.AdminRole)
+				}
+				affected, err := p.ExecCfg().InternalExecutor.Exec(
+					ctx, "revoke-role", p.Txn(),
+					memberStmt,
+					r, m,
+				)
+				if err != nil {
+					return err
+				}
+
+				rowsAffected += affected
+			}
+		}
+
+		// We need to bump the table version to trigger a refresh if anything changed.
+		if rowsAffected > 0 {
+			if err := p.BumpRoleMembershipTableVersion(ctx); err != nil {
+				return err
+			}
+		}
+
+		return nil
 	}
 
-	// We need to bump the table version to trigger a refresh if anything changed.
-	if rowsAffected > 0 {
-		if err := p.BumpRoleMembershipTableVersion(ctx); err != nil {
-			return nil, err
-		}
-	}
-
-	return sql.NewZeroNode(nil /* columns */), nil
+	return fn, sqlbase.ResultColumns{}, nil, false, nil
 }
 
 func init() {
 	sql.AddWrappedPlanHook(createRolePlanHook)
 	sql.AddWrappedPlanHook(dropRolePlanHook)
-	sql.AddWrappedPlanHook(grantRolePlanHook)
-	sql.AddWrappedPlanHook(revokeRolePlanHook)
+	sql.AddPlanHook(grantRolePlanHook)
+	sql.AddPlanHook(revokeRolePlanHook)
 }

--- a/pkg/sql/zero.go
+++ b/pkg/sql/zero.go
@@ -28,11 +28,6 @@ func newZeroNode(columns sqlbase.ResultColumns) *zeroNode {
 	return &zeroNode{columns: columns}
 }
 
-// NewZeroNode is the exported version of newZeroNode. Used by CCL.
-func NewZeroNode(columns sqlbase.ResultColumns) PlanNode {
-	return newZeroNode(columns)
-}
-
 func (*zeroNode) startExec(runParams) error    { return nil }
 func (*zeroNode) Next(runParams) (bool, error) { return false, nil }
 func (*zeroNode) Values() tree.Datums          { return nil }


### PR DESCRIPTION
This required fixing the grant/revoke role implementation: we were
doing all the work during planning instead of execution. This is
similar to the recent fix for the non-CCL grant (on which this code is
likely based on).

Release note: None