### PR TITLE
pgwire: handle giant requests better, and bump limit

### DIFF
--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -313,7 +313,10 @@ Loop:
 		typ, n, err = c.readBuf.ReadTypedMsg(&c.rd)
 		c.metrics.BytesInCount.Inc(int64(n))
 		if err != nil {
-			break Loop
+			if err = c.stmtBuf.Push(ctx, sql.SendError{Err: err}); err != nil {
+				break Loop
+			}
+			continue
 		}
 		timeReceived := timeutil.Now()
 		log.VEventf(ctx, 2, "pgwire: processing %s", typ)

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/jackc/pgx/pgproto3"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 )
 
 func wrongArgCountString(want, got int) string {
@@ -2338,4 +2339,38 @@ func TestFailPrepareFailsTxn(t *testing.T) {
 	if err := tx.Rollback(); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestOverlyLargeRequest(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.TODO())
+
+	pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingSQLAddr(), t.Name(), url.User(security.RootUser))
+	defer cleanupFn()
+
+	db, err := gosql.Open("postgres", pgURL.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	stmt, err := db.Prepare("select length($1::text)")
+	assert.NoError(t, err)
+
+	// This string will cause the message to exceed pgwire.maxMessageSize.
+	largeString := make([]byte, 128*1024*1024)
+	_, err = stmt.Exec(string(largeString))
+	assert.EqualError(t, err,
+		"pq: message of size 134217743 bytes exceeds maximum of 134217728 bytes. Try sending smaller batches.")
+
+	// Try again, subtracting off 16 bytes from the string. The request has 16
+	// ther bytes to send besides our string - this is supposed to represent the
+	// largest query that will still run properly.
+	//
+	// In addition, this demonstrates that the connection is still usable even
+	// after we ended a query with a message too large error.
+	_, err = stmt.Exec(string(largeString[:len(largeString)-16]))
+	assert.NoError(t, err)
 }

--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -15,6 +15,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
+	"io/ioutil"
 	"math"
 	"strconv"
 	"time"
@@ -38,7 +39,11 @@ import (
 	"github.com/lib/pq/oid"
 )
 
-const maxMessageSize = 1 << 24
+// maxMessageSize is the maximum size of any varlen string we will accept in the
+// wire protocol. Postgres has a limit of maxint32 on this quantity, but they
+// also have the freedom to not completely die on failures to allocate, so we're
+// a little more conservative.
+const maxMessageSize = 128 * 1024 * 1024
 
 // FormatCode represents a pgwire data format.
 //
@@ -102,9 +107,17 @@ func (b *ReadBuffer) ReadUntypedMsg(rd io.Reader) (int, error) {
 	size := int(binary.BigEndian.Uint32(b.tmp[:]))
 	// size includes itself.
 	size -= 4
-	if size > maxMessageSize || size < 0 {
-		return nread, NewProtocolViolationErrorf("message size %d out of bounds (0..%d)",
-			size, maxMessageSize)
+	if size < 0 {
+		err = NewProtocolViolationErrorf("invalid message size %d", size)
+	} else if size > maxMessageSize {
+		err = pgerror.Newf(pgcode.ProgramLimitExceeded,
+			"message of size %d bytes exceeds maximum of %d bytes. "+
+				"Try sending smaller batches.", size, maxMessageSize)
+	}
+	if err != nil {
+		// Consume the desired number of bytes to regain stream synchronization.
+		io.CopyN(ioutil.Discard, rd, int64(size))
+		return 0, err
 	}
 
 	b.reset(size)


### PR DESCRIPTION
Previously, pgwire had the arbitrary limit of a maximum of 16MB per
payload. This was very different from Postgres, which has no limit (and
propagates allocation errors from the system as normal errors back to
the user). This limitation was preventing some legitimate queries from
working as expected. What's more, this limit manifested as the server
closing the connection unexpectedly, rather than a nice error as you'd
expect.

This commit improves the error handling so that a too-big request will
cause an error to be returned to the user explaining what's going on.

Also, it bumps the limit from 16 MB to 128 MB.

Closes #35699.

Release note: None