### PR TITLE
rpc,nodedialer: excise methods which do not use ConnectionClass

### DIFF
--- a/pkg/cli/debug_test.go
+++ b/pkg/cli/debug_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
@@ -250,6 +251,7 @@ func TestRemoveDeadReplicas(t *testing.T) {
 	grpcConn, err := tc.Server(0).RPCContext().GRPCDialNode(
 		tc.Server(0).ServingRPCAddr(),
 		tc.Server(0).NodeID(),
+		rpc.DefaultClass,
 	).Connect(ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/kv/transport.go
+++ b/pkg/kv/transport.go
@@ -98,7 +98,7 @@ func grpcTransportFactoryImpl(
 ) (Transport, error) {
 	clients := make([]batchClient, 0, len(replicas))
 	for _, replica := range replicas {
-		healthy := nodeDialer.ConnHealth(replica.NodeID) == nil
+		healthy := nodeDialer.ConnHealth(replica.NodeID, opts.class) == nil
 		clients = append(clients, batchClient{
 			replica: replica.ReplicaDescriptor,
 			healthy: healthy,

--- a/pkg/rpc/stats_handler_test.go
+++ b/pkg/rpc/stats_handler_test.go
@@ -126,7 +126,8 @@ func TestStatsHandlerWithHeartbeats(t *testing.T) {
 	// Make the interval shorter to speed up the test.
 	clientCtx.heartbeatInterval = 1 * time.Millisecond
 	go func() { heartbeat.ready <- nil }()
-	if _, err := clientCtx.GRPCDialNode(remoteAddr, serverNodeID).Connect(context.Background()); err != nil {
+	if _, err := clientCtx.GRPCDialNode(remoteAddr, serverNodeID, DefaultClass).
+		Connect(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/debug"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
@@ -2126,7 +2127,8 @@ func (s *adminServer) dialNode(
 	if err != nil {
 		return nil, err
 	}
-	conn, err := s.server.rpcContext.GRPCDialNode(addr.String(), nodeID).Connect(ctx)
+	conn, err := s.server.rpcContext.GRPCDialNode(
+		addr.String(), nodeID, rpc.DefaultClass).Connect(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -208,7 +208,8 @@ func (s *statusServer) dialNode(
 	if err != nil {
 		return nil, err
 	}
-	conn, err := s.rpcCtx.GRPCDialNode(addr.String(), nodeID).Connect(ctx)
+	conn, err := s.rpcCtx.GRPCDialNode(addr.String(), nodeID,
+		rpc.DefaultClass).Connect(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -284,7 +284,7 @@ func TestStatusGetFiles(t *testing.T) {
 
 	url := ts.ServingRPCAddr()
 	nodeID := ts.NodeID()
-	conn, err := rpcContext.GRPCDialNode(url, nodeID).Connect(context.Background())
+	conn, err := rpcContext.GRPCDialNode(url, nodeID, rpc.DefaultClass).Connect(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -952,7 +952,7 @@ func TestSpanStatsGRPCResponse(t *testing.T) {
 
 	url := ts.ServingRPCAddr()
 	nodeID := ts.NodeID()
-	conn, err := rpcContext.GRPCDialNode(url, nodeID).Connect(ctx)
+	conn, err := rpcContext.GRPCDialNode(url, nodeID, rpc.DefaultClass).Connect(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -982,7 +982,7 @@ func TestNodesGRPCResponse(t *testing.T) {
 
 	url := ts.ServingRPCAddr()
 	nodeID := ts.NodeID()
-	conn, err := rpcContext.GRPCDialNode(url, nodeID).Connect(context.Background())
+	conn, err := rpcContext.GRPCDialNode(url, nodeID, rpc.DefaultClass).Connect(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1183,7 +1183,7 @@ func TestRemoteDebugModeSetting(t *testing.T) {
 	rpcContext := newRPCTestContext(ts, rootConfig)
 	url := ts.ServingRPCAddr()
 	nodeID := ts.NodeID()
-	conn, err := rpcContext.GRPCDialNode(url, nodeID).Connect(context.Background())
+	conn, err := rpcContext.GRPCDialNode(url, nodeID, rpc.DefaultClass).Connect(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1383,7 +1383,7 @@ func TestListSessionsSecurity(t *testing.T) {
 	rpcContext := newRPCTestContext(ts, rootConfig)
 	url := ts.ServingRPCAddr()
 	nodeID := ts.NodeID()
-	conn, err := rpcContext.GRPCDialNode(url, nodeID).Connect(context.Background())
+	conn, err := rpcContext.GRPCDialNode(url, nodeID, rpc.DefaultClass).Connect(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -640,8 +640,8 @@ type SpanPartition struct {
 
 type distSQLNodeHealth struct {
 	gossip     *gossip.Gossip
-	connHealth func(roachpb.NodeID) error
 	isLive     func(roachpb.NodeID) (bool, error)
+	connHealth func(roachpb.NodeID, rpc.ConnectionClass) error
 }
 
 func (h *distSQLNodeHealth) check(ctx context.Context, nodeID roachpb.NodeID) error {
@@ -653,7 +653,7 @@ func (h *distSQLNodeHealth) check(ctx context.Context, nodeID roachpb.NodeID) er
 		// artifact of rpcContext's reconnection mechanism at the time of
 		// writing). This is better than having it used in 100% of cases
 		// (until the liveness check below kicks in).
-		err := h.connHealth(nodeID)
+		err := h.connHealth(nodeID, rpc.DefaultClass)
 		if err != nil && err != rpc.ErrNotHeartbeated {
 			// This host is known to be unhealthy. Don't use it (use the gateway
 			// instead). Note: this can never happen for our nodeID (which

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
@@ -789,7 +790,7 @@ func TestPartitionSpans(t *testing.T) {
 				gossip:       mockGossip,
 				nodeHealth: distSQLNodeHealth{
 					gossip: mockGossip,
-					connHealth: func(node roachpb.NodeID) error {
+					connHealth: func(node roachpb.NodeID, _ rpc.ConnectionClass) error {
 						for _, n := range tc.deadNodes {
 							if int(node) == n {
 								return fmt.Errorf("test node is unhealthy")
@@ -973,7 +974,7 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 				gossip:       mockGossip,
 				nodeHealth: distSQLNodeHealth{
 					gossip: mockGossip,
-					connHealth: func(roachpb.NodeID) error {
+					connHealth: func(roachpb.NodeID, rpc.ConnectionClass) error {
 						// All the nodes are healthy.
 						return nil
 					},
@@ -1068,7 +1069,7 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 		gossip:       mockGossip,
 		nodeHealth: distSQLNodeHealth{
 			gossip: mockGossip,
-			connHealth: func(node roachpb.NodeID) error {
+			connHealth: func(node roachpb.NodeID, _ rpc.ConnectionClass) error {
 				_, err := mockGossip.GetNodeIDAddress(node)
 				return err
 			},
@@ -1144,10 +1145,10 @@ func TestCheckNodeHealth(t *testing.T) {
 		return true, nil
 	}
 
-	connHealthy := func(roachpb.NodeID) error {
+	connHealthy := func(roachpb.NodeID, rpc.ConnectionClass) error {
 		return nil
 	}
-	connUnhealthy := func(roachpb.NodeID) error {
+	connUnhealthy := func(roachpb.NodeID, rpc.ConnectionClass) error {
 		return errors.New("injected conn health error")
 	}
 	_ = connUnhealthy
@@ -1175,7 +1176,7 @@ func TestCheckNodeHealth(t *testing.T) {
 	}
 
 	connHealthTests := []struct {
-		connHealth func(roachpb.NodeID) error
+		connHealth func(roachpb.NodeID, rpc.ConnectionClass) error
 		exp        string
 	}{
 		{connHealthy, ""},

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlplan"
@@ -36,7 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 // To allow queries to send out flow RPCs in parallel, we use a pool of workers
@@ -65,7 +66,7 @@ type runnerResult struct {
 func (req runnerRequest) run() {
 	res := runnerResult{nodeID: req.nodeID}
 
-	conn, err := req.nodeDialer.Dial(req.ctx, req.nodeID)
+	conn, err := req.nodeDialer.Dial(req.ctx, req.nodeID, rpc.DefaultClass)
 	if err != nil {
 		res.err = err
 	} else {

--- a/pkg/sql/distsqlrun/cluster_test.go
+++ b/pkg/sql/distsqlrun/cluster_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -33,7 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 func TestClusterFlow(t *testing.T) {
@@ -204,7 +205,8 @@ func TestClusterFlow(t *testing.T) {
 	var clients []distsqlpb.DistSQLClient
 	for i := 0; i < 3; i++ {
 		s := tc.Server(i)
-		conn, err := s.RPCContext().GRPCDialNode(s.ServingRPCAddr(), s.NodeID()).Connect(ctx)
+		conn, err := s.RPCContext().GRPCDialNode(s.ServingRPCAddr(), s.NodeID(),
+			rpc.DefaultClass).Connect(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -486,7 +488,8 @@ func TestLimitedBufferingDeadlock(t *testing.T) {
 		},
 	}
 	s := tc.Server(0)
-	conn, err := s.RPCContext().GRPCDialNode(s.ServingRPCAddr(), s.NodeID()).Connect(context.Background())
+	conn, err := s.RPCContext().GRPCDialNode(s.ServingRPCAddr(), s.NodeID(),
+		rpc.DefaultClass).Connect(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -715,7 +718,8 @@ func BenchmarkInfrastructure(b *testing.B) {
 					var clients []distsqlpb.DistSQLClient
 					for i := 0; i < numNodes; i++ {
 						s := tc.Server(i)
-						conn, err := s.RPCContext().GRPCDialNode(s.ServingRPCAddr(), s.NodeID()).Connect(context.Background())
+						conn, err := s.RPCContext().GRPCDialNode(s.ServingRPCAddr(), s.NodeID(),
+							rpc.DefaultClass).Connect(context.Background())
 						if err != nil {
 							b.Fatal(err)
 						}

--- a/pkg/sql/distsqlrun/outbox.go
+++ b/pkg/sql/distsqlrun/outbox.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -217,7 +218,7 @@ func (m *outbox) mainLoop(ctx context.Context) error {
 	if m.stream == nil {
 		var conn *grpc.ClientConn
 		var err error
-		conn, err = m.flowCtx.Cfg.NodeDialer.Dial(ctx, m.nodeID)
+		conn, err = m.flowCtx.Cfg.NodeDialer.Dial(ctx, m.nodeID, rpc.DefaultClass)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/distsqlrun/outbox_test.go
+++ b/pkg/sql/distsqlrun/outbox_test.go
@@ -335,7 +335,7 @@ func TestOutboxClosesWhenConsumerCloses(t *testing.T) {
 			} else {
 				// We're going to perform a RunSyncFlow call and then have the client
 				// cancel the call's context.
-				conn, err := flowCtx.Cfg.NodeDialer.Dial(ctx, staticNodeID)
+				conn, err := flowCtx.Cfg.NodeDialer.Dial(ctx, staticNodeID, rpc.DefaultClass)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/sql/distsqlrun/server_test.go
+++ b/pkg/sql/distsqlrun/server_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -33,7 +34,8 @@ func TestServer(t *testing.T) {
 	ctx := context.Background()
 	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
-	conn, err := s.RPCContext().GRPCDialNode(s.ServingRPCAddr(), s.NodeID()).Connect(ctx)
+	conn, err := s.RPCContext().GRPCDialNode(s.ServingRPCAddr(), s.NodeID(),
+		rpc.DefaultClass).Connect(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/distsqlrun/utils_test.go
+++ b/pkg/sql/distsqlrun/utils_test.go
@@ -148,7 +148,8 @@ func createDummyStream() (
 	}
 
 	rpcContext := rpc.NewInsecureTestingContextWithClusterID(clock, stopper, clusterID)
-	conn, err := rpcContext.GRPCDialNode(addr.String(), staticNodeID).Connect(context.Background())
+	conn, err := rpcContext.GRPCDialNode(addr.String(), staticNodeID,
+		rpc.DefaultClass).Connect(context.Background())
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/sql/distsqlrun/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/distsqlrun/vectorized_flow_shutdown_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec"
@@ -49,7 +50,9 @@ type mockDialer struct {
 	}
 }
 
-func (d *mockDialer) Dial(context.Context, roachpb.NodeID) (*grpc.ClientConn, error) {
+func (d *mockDialer) Dial(
+	context.Context, roachpb.NodeID, rpc.ConnectionClass,
+) (*grpc.ClientConn, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if d.mu.conn != nil {

--- a/pkg/sql/exec/colrpc/outbox.go
+++ b/pkg/sql/exec/colrpc/outbox.go
@@ -17,6 +17,7 @@ import (
 	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
@@ -38,7 +39,7 @@ type flowStreamClient interface {
 // method that Outbox.Run needs from nodedialer.Dialer so that we can mock it
 // in tests outside of this package.
 type Dialer interface {
-	Dial(context.Context, roachpb.NodeID) (*grpc.ClientConn, error)
+	Dial(context.Context, roachpb.NodeID, rpc.ConnectionClass) (*grpc.ClientConn, error)
 }
 
 // Outbox is used to push data from local flows to a remote endpoint. Run may
@@ -119,7 +120,7 @@ func (o *Outbox) Run(
 	ctx = logtags.AddTag(ctx, "streamID", streamID)
 
 	log.VEventf(ctx, 2, "Outbox Dialing %s", nodeID)
-	conn, err := dialer.Dial(ctx, nodeID)
+	conn, err := dialer.Dial(ctx, nodeID, rpc.DefaultClass)
 	if err != nil {
 		log.Warningf(
 			ctx,

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -2382,7 +2382,8 @@ func TestReportUnreachableHeartbeats(t *testing.T) {
 	// Shut down a raft transport via the circuit breaker, and wait for two
 	// election timeouts to trigger an election if reportUnreachable broke
 	// heartbeat transmission to the other store.
-	cb := mtc.transport.GetCircuitBreaker(mtc.stores[followerIdx].Ident.NodeID)
+	cb := mtc.transport.GetCircuitBreaker(mtc.stores[followerIdx].Ident.NodeID,
+		rpc.DefaultClass)
 	cb.Break()
 
 	// Send a command to ensure Raft is aware of lost follower so that it won't
@@ -2443,7 +2444,7 @@ outer:
 						mtc.transferLease(context.TODO(), rangeID, leaderIdx, replicaIdx)
 					}
 					mtc.unreplicateRange(rangeID, leaderIdx)
-					cb := mtc.transport.GetCircuitBreaker(toStore.Ident.NodeID)
+					cb := mtc.transport.GetCircuitBreaker(toStore.Ident.NodeID, rpc.DefaultClass)
 					cb.Break()
 					time.Sleep(mtc.storeConfig.CoalescedHeartbeatsInterval)
 					cb.Reset()
@@ -4197,7 +4198,7 @@ func TestStoreRangeWaitForApplication(t *testing.T) {
 
 	var targets []target
 	for _, s := range mtc.stores {
-		conn, err := mtc.nodeDialer.Dial(ctx, s.Ident.NodeID)
+		conn, err := mtc.nodeDialer.Dial(ctx, s.Ident.NodeID, rpc.DefaultClass)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -4328,7 +4329,7 @@ func TestStoreWaitForReplicaInit(t *testing.T) {
 	defer mtc.Stop()
 	store := mtc.Store(0)
 
-	conn, err := mtc.nodeDialer.Dial(ctx, store.Ident.NodeID)
+	conn, err := mtc.nodeDialer.Dial(ctx, store.Ident.NodeID, rpc.DefaultClass)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -917,7 +917,8 @@ func (m *multiTestContext) addStore(idx int) {
 	// having to worry about such conditions we pre-warm the connection
 	// cache. See #8440 for an example of the headaches the long dial times
 	// cause.
-	if _, err := m.rpcContext.GRPCDialNode(ln.Addr().String(), nodeID).Connect(ctx); err != nil {
+	if _, err := m.rpcContext.GRPCDialNode(ln.Addr().String(), nodeID,
+		rpc.DefaultClass).Connect(ctx); err != nil {
 		m.t.Fatal(err)
 	}
 
@@ -992,7 +993,7 @@ func (m *multiTestContext) stopStore(i int) {
 	// store stopping and that store restarting will never remain in-flight in
 	// the transport and end up reaching the store. This has been the cause of
 	// flakiness in the past.
-	m.transport.GetCircuitBreaker(m.idents[i].NodeID).Break()
+	m.transport.GetCircuitBreaker(m.idents[i].NodeID, rpc.DefaultClass).Break()
 	m.senders[i].RemoveStore(m.stores[i])
 	m.stores[i] = nil
 	m.mu.Unlock()
@@ -1026,7 +1027,7 @@ func (m *multiTestContext) restartStoreWithoutHeartbeat(i int) {
 		m.t.Fatal(err)
 	}
 	m.senders[i].AddStore(store)
-	m.transport.GetCircuitBreaker(m.idents[i].NodeID).Reset()
+	m.transport.GetCircuitBreaker(m.idents[i].NodeID, rpc.DefaultClass).Reset()
 	m.mu.Unlock()
 	cfg.NodeLiveness.StartHeartbeat(ctx, stopper, func(ctx context.Context) {
 		now := m.clocks[i].Now()

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
@@ -484,8 +485,10 @@ func (nl *NodeLiveness) SetDecommissioningInternal(
 
 // GetCircuitBreaker returns the circuit breaker controlling
 // connection attempts to the specified node.
-func (t *RaftTransport) GetCircuitBreaker(nodeID roachpb.NodeID) *circuit.Breaker {
-	return t.dialer.GetCircuitBreaker(nodeID)
+func (t *RaftTransport) GetCircuitBreaker(
+	nodeID roachpb.NodeID, class rpc.ConnectionClass,
+) *circuit.Breaker {
+	return t.dialer.GetCircuitBreaker(nodeID, class)
 }
 
 func WriteRandomDataToRange(

--- a/pkg/storage/raft_transport.go
+++ b/pkg/storage/raft_transport.go
@@ -551,7 +551,7 @@ func (t *RaftTransport) SendAsync(req *RaftMessageRequest, class rpc.ConnectionC
 		panic("snapshots must be sent using SendSnapshot")
 	}
 
-	if !t.dialer.GetCircuitBreakerClass(toNodeID, class).Ready() {
+	if !t.dialer.GetCircuitBreaker(toNodeID, class).Ready() {
 		return false
 	}
 
@@ -591,7 +591,7 @@ func (t *RaftTransport) startProcessNewQueue(
 	class rpc.ConnectionClass,
 	stats *raftTransportStats,
 ) bool {
-	conn, err := t.dialer.DialClass(ctx, toNodeID, class)
+	conn, err := t.dialer.Dial(ctx, toNodeID, class)
 	if err != nil {
 		// DialNode already logs sufficiently, so just return after deleting the
 		// queue.
@@ -662,7 +662,7 @@ func (t *RaftTransport) SendSnapshot(
 	var stream MultiRaft_RaftSnapshotClient
 	nodeID := header.RaftMessageRequest.ToReplica.NodeID
 
-	conn, err := t.dialer.Dial(ctx, nodeID)
+	conn, err := t.dialer.Dial(ctx, nodeID, rpc.DefaultClass)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/raft_transport_test.go
+++ b/pkg/storage/raft_transport_test.go
@@ -446,7 +446,7 @@ func TestRaftTransportCircuitBreaker(t *testing.T) {
 	// snuck in.
 	testutils.SucceedsSoon(t, func() error {
 		if !rttc.Send(clientReplica, serverReplica, 1, raftpb.Message{Commit: 2}) {
-			clientTransport.GetCircuitBreaker(serverReplica.NodeID).Reset()
+			clientTransport.GetCircuitBreaker(serverReplica.NodeID, rpc.DefaultClass).Reset()
 		}
 		select {
 		case req := <-serverChannel.ch:

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -733,7 +734,7 @@ func waitForApplication(
 		for _, repl := range replicas {
 			repl := repl // copy for goroutine
 			g.GoCtx(func(ctx context.Context) error {
-				conn, err := dialer.Dial(ctx, repl.NodeID)
+				conn, err := dialer.Dial(ctx, repl.NodeID, rpc.DefaultClass)
 				if err != nil {
 					return errors.Wrapf(err, "could not dial n%d", repl.NodeID)
 				}
@@ -764,7 +765,7 @@ func waitForReplicasInit(
 		for _, repl := range replicas {
 			repl := repl // copy for goroutine
 			g.GoCtx(func(ctx context.Context) error {
-				conn, err := dialer.Dial(ctx, repl.NodeID)
+				conn, err := dialer.Dial(ctx, repl.NodeID, rpc.DefaultClass)
 				if err != nil {
 					return errors.Wrapf(err, "could not dial n%d", repl.NodeID)
 				}

--- a/pkg/storage/replica_consistency.go
+++ b/pkg/storage/replica_consistency.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
@@ -253,7 +254,7 @@ type ConsistencyCheckResult struct {
 func (r *Replica) collectChecksumFromReplica(
 	ctx context.Context, replica roachpb.ReplicaDescriptor, id uuid.UUID, checksum []byte,
 ) (CollectChecksumResponse, error) {
-	conn, err := r.store.cfg.NodeDialer.Dial(ctx, replica.NodeID)
+	conn, err := r.store.cfg.NodeDialer.Dial(ctx, replica.NodeID, rpc.DefaultClass)
 	if err != nil {
 		return CollectChecksumResponse{},
 			errors.Wrapf(err, "could not dial node ID %d", replica.NodeID)

--- a/pkg/storage/replica_proposal_quota.go
+++ b/pkg/storage/replica_proposal_quota.go
@@ -169,7 +169,7 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 		}
 
 		// Only consider followers that that have "healthy" RPC connections.
-		if err := r.store.cfg.NodeDialer.ConnHealth(rep.NodeID); err != nil {
+		if err := r.store.cfg.NodeDialer.ConnHealth(rep.NodeID, r.connectionClass.get()); err != nil {
 			return
 		}
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3720,7 +3720,7 @@ func (s *Store) raftTickLoop(ctx context.Context) {
 					// Raft transport, so ConnHealth should usually indicate a real problem if
 					// it gives us an error back. The check can also have false positives if the
 					// node goes down after populating the map, but that matters even less.
-					entry.IsLive = (s.cfg.NodeDialer.ConnHealth(nodeID) == nil)
+					entry.IsLive = (s.cfg.NodeDialer.ConnHealth(nodeID, rpc.SystemClass) == nil)
 					nextMap[nodeID] = entry
 				}
 				s.livenessMap.Store(nextMap)

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -667,7 +668,8 @@ func (tc *TestCluster) WaitForNodeStatuses(t testing.TB) {
 	testutils.SucceedsSoon(t, func() error {
 		url := tc.Server(0).ServingRPCAddr()
 		nodeID := tc.Server(0).NodeID()
-		conn, err := tc.Server(0).RPCContext().GRPCDialNode(url, nodeID).Connect(context.Background())
+		conn, err := tc.Server(0).RPCContext().GRPCDialNode(url, nodeID,
+			rpc.DefaultClass).Connect(context.Background())
 		if err != nil {
 			return err
 		}

--- a/pkg/testutils/testcluster/testcluster_test.go
+++ b/pkg/testutils/testcluster/testcluster_test.go
@@ -207,7 +207,8 @@ func TestStopServer(t *testing.T) {
 		tc.Server(1).RPCContext().Config, tc.Server(1).Clock(), tc.Stopper(),
 		&tc.Server(1).ClusterSettings().Version,
 	)
-	conn, err := rpcContext.GRPCDialNode(server1.ServingRPCAddr(), server1.NodeID()).Connect(context.Background())
+	conn, err := rpcContext.GRPCDialNode(server1.ServingRPCAddr(), server1.NodeID(),
+		rpc.DefaultClass).Connect(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/ts/server_test.go
+++ b/pkg/ts/server_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -173,7 +174,8 @@ func TestServerQuery(t *testing.T) {
 		},
 	}
 
-	conn, err := tsrv.RPCContext().GRPCDialNode(tsrv.Cfg.Addr, tsrv.NodeID()).Connect(context.Background())
+	conn, err := tsrv.RPCContext().GRPCDialNode(tsrv.Cfg.Addr, tsrv.NodeID(),
+		rpc.DefaultClass).Connect(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -268,7 +270,8 @@ func TestServerQueryStarvation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	conn, err := tsrv.RPCContext().GRPCDialNode(tsrv.Cfg.Addr, tsrv.NodeID()).Connect(context.Background())
+	conn, err := tsrv.RPCContext().GRPCDialNode(tsrv.Cfg.Addr, tsrv.NodeID(),
+		rpc.DefaultClass).Connect(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -323,7 +326,8 @@ func TestServerQueryMemoryManagement(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	conn, err := tsrv.RPCContext().GRPCDialNode(tsrv.Cfg.Addr, tsrv.NodeID()).Connect(context.Background())
+	conn, err := tsrv.RPCContext().GRPCDialNode(tsrv.Cfg.Addr, tsrv.NodeID(),
+		rpc.DefaultClass).Connect(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -370,7 +374,8 @@ func TestServerDump(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	conn, err := tsrv.RPCContext().GRPCDialNode(tsrv.Cfg.Addr, tsrv.NodeID()).Connect(context.Background())
+	conn, err := tsrv.RPCContext().GRPCDialNode(tsrv.Cfg.Addr, tsrv.NodeID(),
+		rpc.DefaultClass).Connect(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -448,7 +453,8 @@ func BenchmarkServerQuery(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	conn, err := tsrv.RPCContext().GRPCDialNode(tsrv.Cfg.Addr, tsrv.NodeID()).Connect(context.Background())
+	conn, err := tsrv.RPCContext().GRPCDialNode(tsrv.Cfg.Addr, tsrv.NodeID(),
+		rpc.DefaultClass).Connect(context.Background())
 	if err != nil {
 		b.Fatal(err)
 	}


### PR DESCRIPTION
#39172 added the concept of connection class to create multiple connections
to a given target. In order to reduce the adoption burden that PR introduced new
methods for dialing connections, checking connection health, and retrieving circuit
breakers which took a ConnectionClass and carried a `Class` suffix. It left the previous
method signatures untouched, opting instead to convert them to a shorthand which passed DefaultClass to the new method.

This PR moves all clients of these methods to use ConnectionClass explicitly.

Release note: None