### PR TITLE
opt: don't use histogram if cardinality < 100

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/project
+++ b/pkg/sql/opt/memo/testdata/logprops/project
@@ -347,6 +347,7 @@ SELECT a, b FROM ab WHERE (a, b) IN ((1, 1), (2, 2))
 ----
 select
  ├── columns: a:1(int!null) b:2(int!null)
+ ├── cardinality: [0 - 2]
  ├── key: (1,2)
  ├── interesting orderings: (+1,+2)
  ├── scan ab

--- a/pkg/sql/opt/memo/testdata/logprops/scan
+++ b/pkg/sql/opt/memo/testdata/logprops/scan
@@ -112,3 +112,66 @@ values
  ├── key: ()
  ├── fd: ()-->(5)
  └── prune: (5)
+
+opt
+SELECT * FROM t WHERE b IN ('a', 'b') AND c IN (1, 2) AND a IN (2, 3)
+----
+index-join t
+ ├── columns: a:1(int!null) b:2(char!null) c:3(int!null) d:4(char)
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3,4)
+ ├── prune: (4)
+ ├── interesting orderings: (+1,+2) (+2,+3,+1) (-1,+2)
+ └── scan t@bc
+      ├── columns: a:1(int!null) b:2(char!null) c:3(int!null)
+      ├── constraint: /2/3/1: [/'a'/1/2 - /'a'/1/3] [/'a'/2/2 - /'a'/2/3] [/'b'/1/2 - /'b'/1/3] [/'b'/2/2 - /'b'/2/3]
+      ├── cardinality: [0 - 8]
+      ├── key: (1,2)
+      ├── fd: (1,2)-->(3)
+      ├── prune: (1-3)
+      └── interesting orderings: (+1,+2) (+2,+3,+1) (-1,+2)
+
+opt
+SELECT * FROM a WHERE x IN (1, 2, 4, 6, 7, 9)
+----
+scan a
+ ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
+ ├── constraint: /1: [/1 - /2] [/4 - /4] [/6 - /7] [/9 - /9]
+ ├── cardinality: [0 - 6]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
+ ├── prune: (2-4)
+ └── interesting orderings: (+1) (-3,+4,+1)
+
+exec-ddl
+CREATE TABLE date_pk (d DATE PRIMARY KEY, i INT)
+----
+
+opt
+SELECT * FROM date_pk WHERE d IN ('2019-08-08', '2019-08-07') OR (d >= '2017-01-01' AND d < '2017-01-05')
+----
+select
+ ├── columns: d:1(date!null) i:2(int)
+ ├── cardinality: [0 - 6]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── prune: (2)
+ ├── interesting orderings: (+1)
+ ├── scan date_pk
+ │    ├── columns: d:1(date!null) i:2(int)
+ │    ├── constraint: /1: [/'2017-01-01' - /'2017-01-04'] [/'2019-08-07' - /'2019-08-08']
+ │    ├── cardinality: [0 - 6]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    ├── prune: (1,2)
+ │    └── interesting orderings: (+1)
+ └── filters
+      └── or [type=bool, outer=(1), constraints=(/1: (/NULL - /'2017-01-04'] [/'2019-08-07' - /'2019-08-07'] [/'2019-08-08' - /'2019-08-08'])]
+           ├── in [type=bool]
+           │    ├── variable: d [type=date]
+           │    └── tuple [type=tuple{date, date}]
+           │         ├── const: '2019-08-07' [type=date]
+           │         └── const: '2019-08-08' [type=date]
+           └── lt [type=bool]
+                ├── variable: d [type=date]
+                └── const: '2017-01-05' [type=date]

--- a/pkg/sql/opt/memo/testdata/logprops/select
+++ b/pkg/sql/opt/memo/testdata/logprops/select
@@ -351,3 +351,82 @@ sequence-select x
  ├── cardinality: [1 - 1]
  ├── key: ()
  └── fd: ()-->(1-3)
+
+# Test that cardinality is set for constrained keys, but not for other columns.
+norm
+SELECT * FROM xy WHERE x IN (1, 2, 4, 6, 7, 9)
+----
+select
+ ├── columns: x:1(int!null) y:2(int)
+ ├── cardinality: [0 - 6]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── prune: (2)
+ ├── interesting orderings: (+1)
+ ├── scan xy
+ │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    ├── prune: (1,2)
+ │    └── interesting orderings: (+1)
+ └── filters
+      └── in [type=bool, outer=(1), constraints=(/1: [/1 - /1] [/2 - /2] [/4 - /4] [/6 - /6] [/7 - /7] [/9 - /9]; tight)]
+           ├── variable: x [type=int]
+           └── tuple [type=tuple{int, int, int, int, int, int}]
+                ├── const: 1 [type=int]
+                ├── const: 2 [type=int]
+                ├── const: 4 [type=int]
+                ├── const: 6 [type=int]
+                ├── const: 7 [type=int]
+                └── const: 9 [type=int]
+
+norm
+SELECT * FROM xy WHERE x > 0 AND x <= 10
+----
+select
+ ├── columns: x:1(int!null) y:2(int)
+ ├── cardinality: [0 - 10]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── prune: (2)
+ ├── interesting orderings: (+1)
+ ├── scan xy
+ │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    ├── prune: (1,2)
+ │    └── interesting orderings: (+1)
+ └── filters
+      └── range [type=bool, outer=(1), constraints=(/1: [/1 - /10]; tight)]
+           └── and [type=bool]
+                ├── gt [type=bool]
+                │    ├── variable: x [type=int]
+                │    └── const: 0 [type=int]
+                └── le [type=bool]
+                     ├── variable: x [type=int]
+                     └── const: 10 [type=int]
+
+norm
+SELECT * FROM xy WHERE y > 0 AND y <= 10
+----
+select
+ ├── columns: x:1(int!null) y:2(int!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── prune: (1)
+ ├── interesting orderings: (+1)
+ ├── scan xy
+ │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    ├── prune: (1,2)
+ │    └── interesting orderings: (+1)
+ └── filters
+      └── range [type=bool, outer=(2), constraints=(/2: [/1 - /10]; tight)]
+           └── and [type=bool]
+                ├── gt [type=bool]
+                │    ├── variable: y [type=int]
+                │    └── const: 0 [type=int]
+                └── le [type=bool]
+                     ├── variable: y [type=int]
+                     └── const: 10 [type=int]

--- a/pkg/sql/opt/memo/testdata/stats/ordinality
+++ b/pkg/sql/opt/memo/testdata/stats/ordinality
@@ -24,6 +24,7 @@ SELECT * FROM (SELECT * FROM a WITH ORDINALITY) WHERE ordinality > 0 AND ordinal
 ----
 select
  ├── columns: x:1(int!null) y:2(int) ordinality:3(int!null)
+ ├── cardinality: [0 - 10]
  ├── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(3)=10, null(3)=0]
  ├── key: (1)
  ├── fd: (1)-->(2,3), (3)-->(1,2)
@@ -82,10 +83,12 @@ SELECT x FROM (SELECT * FROM a WITH ORDINALITY) WHERE ordinality > 0 AND ordinal
 ----
 project
  ├── columns: x:1(int!null)
+ ├── cardinality: [0 - 10]
  ├── stats: [rows=10]
  ├── key: (1)
  └── select
       ├── columns: x:1(int!null) ordinality:3(int!null)
+      ├── cardinality: [0 - 10]
       ├── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(3)=10, null(3)=0]
       ├── key: (1)
       ├── fd: (1)-->(3), (3)-->(1)

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -91,7 +91,8 @@ SELECT s, x FROM a WHERE x > 0 AND x <= 100
 scan a
  ├── columns: s:3(string) x:1(int!null)
  ├── constraint: /1: [/1 - /100]
- ├── stats: [rows=150, distinct(1)=100, null(1)=0]
+ ├── cardinality: [0 - 100]
+ ├── stats: [rows=100, distinct(1)=100, null(1)=0]
  ├── key: (1)
  └── fd: (1)-->(3)
 
@@ -114,13 +115,15 @@ group-by
  ├── columns: count:6(int) y:2(int) x:1(int!null)
  ├── grouping columns: x:1(int!null)
  ├── internal-ordering: +1
+ ├── cardinality: [0 - 100]
  ├── stats: [rows=100, distinct(1)=100, null(1)=0]
  ├── key: (1)
  ├── fd: (1)-->(2,6)
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(int)
  │    ├── constraint: /1: [/1 - /100]
- │    ├── stats: [rows=150, distinct(1)=100, null(1)=0]
+ │    ├── cardinality: [0 - 100]
+ │    ├── stats: [rows=100, distinct(1)=100, null(1)=0]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    └── ordering: +1

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -71,10 +71,12 @@ SELECT * FROM b WHERE x = 1 AND z = 2 AND rowid >= 5 AND rowid <= 8
 ----
 project
  ├── columns: x:1(int!null) z:2(int!null)
+ ├── cardinality: [0 - 4]
  ├── stats: [rows=8e-06]
  ├── fd: ()-->(1,2)
  └── select
       ├── columns: x:1(int!null) z:2(int!null) rowid:3(int!null)
+      ├── cardinality: [0 - 4]
       ├── stats: [rows=8e-06, distinct(1)=8e-06, null(1)=0, distinct(2)=8e-06, null(2)=0, distinct(3)=8e-06, null(3)=0]
       ├── key: (3)
       ├── fd: ()-->(1,2)
@@ -336,6 +338,7 @@ SELECT * FROM district WHERE d_id > 1 AND d_id < 10 AND d_w_id=10 AND d_name='bo
 ----
 select
  ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string!null)
+ ├── cardinality: [0 - 8]
  ├── stats: [rows=0.08, distinct(1)=0.08, null(1)=0, distinct(2)=0.08, null(2)=0, distinct(3)=0.08, null(3)=0]
  ├── key: (1)
  ├── fd: ()-->(2,3)
@@ -555,6 +558,7 @@ SELECT * FROM c WHERE x >= 0 AND x < 100
 ----
 select
  ├── columns: x:1(int!null) z:2(int!null)
+ ├── cardinality: [0 - 100]
  ├── stats: [rows=99.8990918, distinct(1)=99.8990918, null(1)=0, distinct(2)=65.4824076, null(2)=0]
  ├── key: (1)
  ├── fd: (1)-->(2)
@@ -966,10 +970,12 @@ SELECT * FROM b WHERE x = 1 AND z = 2 AND rowid >= 5 AND rowid <= 8
 ----
 project
  ├── columns: x:1(int!null) z:2(int!null)
+ ├── cardinality: [0 - 4]
  ├── stats: [rows=6.4e-06]
  ├── fd: ()-->(1,2)
  └── select
       ├── columns: x:1(int!null) z:2(int!null) rowid:3(int!null)
+      ├── cardinality: [0 - 4]
       ├── stats: [rows=6.4e-06, distinct(1)=6.4e-06, null(1)=0, distinct(2)=6.4e-06, null(2)=0, distinct(3)=6.4e-06, null(3)=0]
       ├── key: (3)
       ├── fd: ()-->(1,2)
@@ -1025,6 +1031,7 @@ SELECT * FROM c WHERE x >= 0 AND x < 100
 ----
 select
  ├── columns: x:1(int!null) z:2(int!null)
+ ├── cardinality: [0 - 100]
  ├── stats: [rows=100, distinct(1)=100, null(1)=0, distinct(2)=100, null(2)=0]
  ├── key: (1)
  ├── fd: (1)-->(2)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpcc
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpcc
@@ -103,6 +103,7 @@ scan item
  ├── save-table-name: new_order_03_scan_1
  ├── columns: i_price:4(decimal) i_name:3(varchar) i_data:5(varchar)  [hidden: i_id:1(int!null)]
  ├── constraint: /1: [/25 - /25] [/50 - /50] [/75 - /75] [/100 - /100] [/125 - /125] [/150 - /150] [/175 - /175] [/200 - /200] [/225 - /225] [/250 - /250] [/275 - /275] [/300 - /300]
+ ├── cardinality: [0 - 12]
  ├── stats: [rows=11.2643678, distinct(1)=11.2643678, null(1)=0, distinct(3)=11.172477, null(3)=0, distinct(4)=11.2585677, null(4)=0, distinct(5)=11.2595726, null(5)=0]
  │   histogram(1)=  0 0.9387 0 0.9387 0 0.9387 0 0.9387 0 0.9387 0 0.9387 0 0.9387 0 0.9387 0 0.9387 0 0.9387 0 0.9387 0 0.9387
  │                <---- 25 ----- 50 ----- 75 ---- 100 ---- 125 ---- 150 ---- 175 ---- 200 ---- 225 ---- 250 ---- 275 ---- 300 -
@@ -136,6 +137,7 @@ ORDER BY s_i_id
 project
  ├── save-table-name: new_order_04_project_1
  ├── columns: s_quantity:3(int) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(varchar) s_dist_05:8(char)  [hidden: s_i_id:1(int!null)]
+ ├── cardinality: [0 - 5]
  ├── stats: [rows=4.98705573, distinct(1)=4.98705573, null(1)=0, distinct(3)=4.85287765, null(3)=0, distinct(8)=4.79176814, null(8)=0, distinct(14)=0.993174353, null(14)=0, distinct(15)=0.993174353, null(15)=0, distinct(16)=0.993174353, null(16)=0, distinct(17)=4.9867867, null(17)=0]
  ├── cost: 6.30369022
  ├── key: (1)
@@ -147,6 +149,7 @@ project
       ├── save-table-name: new_order_04_scan_2
       ├── columns: s_i_id:1(int!null) s_w_id:2(int!null) s_quantity:3(int) s_dist_05:8(char) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(varchar)
       ├── constraint: /2/1: [/4/900 - /4/900] [/4/1000 - /4/1000] [/4/1100 - /4/1100] [/4/1400 - /4/1400] [/4/1500 - /4/1500]
+      ├── cardinality: [0 - 5]
       ├── stats: [rows=4.98705573, distinct(1)=4.98705573, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=4.85287765, null(3)=0, distinct(8)=4.79176814, null(8)=0, distinct(14)=0.993174353, null(14)=0, distinct(15)=0.993174353, null(15)=0, distinct(16)=0.993174353, null(16)=0, distinct(17)=4.9867867, null(17)=0]
       │   histogram(2)=  0 4.9871
       │                <---- 4 --

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpcc
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpcc
@@ -104,10 +104,8 @@ scan item
  ├── columns: i_price:4(decimal) i_name:3(varchar) i_data:5(varchar)  [hidden: i_id:1(int!null)]
  ├── constraint: /1: [/25 - /25] [/50 - /50] [/75 - /75] [/100 - /100] [/125 - /125] [/150 - /150] [/175 - /175] [/200 - /200] [/225 - /225] [/250 - /250] [/275 - /275] [/300 - /300]
  ├── cardinality: [0 - 12]
- ├── stats: [rows=11.2643678, distinct(1)=11.2643678, null(1)=0, distinct(3)=11.172477, null(3)=0, distinct(4)=11.2585677, null(4)=0, distinct(5)=11.2595726, null(5)=0]
- │   histogram(1)=  0 0.9387 0 0.9387 0 0.9387 0 0.9387 0 0.9387 0 0.9387 0 0.9387 0 0.9387 0 0.9387 0 0.9387 0 0.9387 0 0.9387
- │                <---- 25 ----- 50 ----- 75 ---- 100 ---- 125 ---- 150 ---- 175 ---- 200 ---- 225 ---- 250 ---- 275 ---- 300 -
- ├── cost: 12.2881609
+ ├── stats: [rows=12, distinct(1)=12, null(1)=0, distinct(3)=11.8957521, null(3)=0, distinct(4)=11.9934177, null(4)=0, distinct(5)=11.9945581, null(5)=0]
+ ├── cost: 13.09
  ├── key: (1)
  ├── fd: (1)-->(3-5)
  ├── ordering: +1
@@ -123,10 +121,10 @@ column_names  row_count  distinct_count  null_count
 {i_price}     12         12              0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{i_data}      11.00          1.09           11.00               1.09                0.00            1.00
-{i_id}        11.00          1.09           11.00               1.09                0.00            1.00
-{i_name}      11.00          1.09           11.00               1.09                0.00            1.00
-{i_price}     11.00          1.09           11.00               1.09                0.00            1.00
+{i_data}      12.00          1.00           12.00               1.00                0.00            1.00
+{i_id}        12.00          1.00           12.00               1.00                0.00            1.00
+{i_name}      12.00          1.00           12.00               1.00                0.00            1.00
+{i_price}     12.00          1.00           12.00               1.00                0.00            1.00
 
 save-tables format=hide-qual database=tpcc save-tables-prefix=new_order_04
 SELECT s_quantity, s_ytd, s_order_cnt, s_remote_cnt, s_data, s_dist_05
@@ -138,8 +136,8 @@ project
  ├── save-table-name: new_order_04_project_1
  ├── columns: s_quantity:3(int) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(varchar) s_dist_05:8(char)  [hidden: s_i_id:1(int!null)]
  ├── cardinality: [0 - 5]
- ├── stats: [rows=4.98705573, distinct(1)=4.98705573, null(1)=0, distinct(3)=4.85287765, null(3)=0, distinct(8)=4.79176814, null(8)=0, distinct(14)=0.993174353, null(14)=0, distinct(15)=0.993174353, null(15)=0, distinct(16)=0.993174353, null(16)=0, distinct(17)=4.9867867, null(17)=0]
- ├── cost: 6.30369022
+ ├── stats: [rows=5, distinct(1)=5, null(1)=0, distinct(3)=4.86513081, null(3)=0, distinct(8)=4.8037108, null(8)=0, distinct(14)=0.993262137, null(14)=0, distinct(15)=0.993262137, null(15)=0, distinct(16)=0.993262137, null(16)=0, distinct(17)=4.99972957, null(17)=0]
+ ├── cost: 6.32
  ├── key: (1)
  ├── fd: (1)-->(3,8,14-17)
  ├── ordering: +1
@@ -150,10 +148,8 @@ project
       ├── columns: s_i_id:1(int!null) s_w_id:2(int!null) s_quantity:3(int) s_dist_05:8(char) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(varchar)
       ├── constraint: /2/1: [/4/900 - /4/900] [/4/1000 - /4/1000] [/4/1100 - /4/1100] [/4/1400 - /4/1400] [/4/1500 - /4/1500]
       ├── cardinality: [0 - 5]
-      ├── stats: [rows=4.98705573, distinct(1)=4.98705573, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=4.85287765, null(3)=0, distinct(8)=4.79176814, null(8)=0, distinct(14)=0.993174353, null(14)=0, distinct(15)=0.993174353, null(15)=0, distinct(16)=0.993174353, null(16)=0, distinct(17)=4.9867867, null(17)=0]
-      │   histogram(2)=  0 4.9871
-      │                <---- 4 --
-      ├── cost: 6.24381966
+      ├── stats: [rows=5, distinct(1)=5, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=4.86513081, null(3)=0, distinct(8)=4.8037108, null(8)=0, distinct(14)=0.993262137, null(14)=0, distinct(15)=0.993262137, null(15)=0, distinct(16)=0.993262137, null(16)=0, distinct(17)=4.99972957, null(17)=0]
+      ├── cost: 6.26
       ├── key: (1)
       ├── fd: ()-->(2), (1)-->(3,8,14-17)
       ├── ordering: +1 opt(2) [actual: +1]

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -5095,11 +5095,13 @@ SELECT * FROM a WHERE k > 1 AND k < 5 AND i > ALL(SELECT y FROM xy)
 ----
 anti-join (hash)
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── cardinality: [0 - 3]
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── constraint: /1: [/2 - /4]
+ │    ├── cardinality: [0 - 3]
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  ├── scan xy

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -455,17 +455,20 @@ semi-join (merge)
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  ├── left ordering: +1
  ├── right ordering: +6
+ ├── cardinality: [0 - 2]
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    ├── constraint: /1: [/7 - /7] [/10 - /10]
+ │    ├── cardinality: [0 - 2]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
  │    └── ordering: +1
  ├── scan b
  │    ├── columns: x:6(int!null) y:7(int)
  │    ├── constraint: /6: [/7 - /7] [/10 - /10]
+ │    ├── cardinality: [0 - 2]
  │    ├── key: (6)
  │    ├── fd: (6)-->(7)
  │    └── ordering: +6
@@ -518,6 +521,7 @@ left-join (merge)
  ├── scan b
  │    ├── columns: x:6(int!null) y:7(int)
  │    ├── constraint: /6: [/7 - /7] [/10 - /10]
+ │    ├── cardinality: [0 - 2]
  │    ├── key: (6)
  │    ├── fd: (6)-->(7)
  │    └── ordering: +6
@@ -565,6 +569,7 @@ right-join (merge)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    ├── constraint: /1: [/7 - /7] [/10 - /10]
+ │    ├── cardinality: [0 - 2]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
  │    └── ordering: +1
@@ -673,6 +678,7 @@ anti-join (merge)
  ├── scan b
  │    ├── columns: x:6(int!null) y:7(int)
  │    ├── constraint: /6: [/7 - /7] [/10 - /10]
+ │    ├── cardinality: [0 - 2]
  │    ├── key: (6)
  │    ├── fd: (6)-->(7)
  │    └── ordering: +6

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -903,6 +903,7 @@ SELECT k FROM a WHERE k = ANY (1, 2, 3)
 scan a
  ├── columns: k:1(int!null)
  ├── constraint: /1: [/1 - /3]
+ ├── cardinality: [0 - 3]
  └── key: (1)
 
 opt expect=SimplifyEqualsAnyTuple
@@ -969,6 +970,7 @@ SELECT k FROM a WHERE k = ANY ARRAY[1, 2, 3]
 scan a
  ├── columns: k:1(int!null)
  ├── constraint: /1: [/1 - /3]
+ ├── cardinality: [0 - 3]
  └── key: (1)
 
 opt expect=(SimplifyAnyScalarArray,SimplifyEqualsAnyTuple)
@@ -987,6 +989,7 @@ SELECT k FROM a WHERE k = ANY '{1,2,3}'::INT[]
 scan a
  ├── columns: k:1(int!null)
  ├── constraint: /1: [/1 - /3]
+ ├── cardinality: [0 - 3]
  └── key: (1)
 
 # --------------------------------------------------

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -229,6 +229,7 @@ inner-join (hash)
  │         └── ((a.k = 5) AND (a.k > 1)) AND (a.k < 10) [type=bool, outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
  ├── select
  │    ├── columns: e.k:6(int!null) e.i:7(int) t:8(timestamp) tz:9(timestamptz) d:10(date)
+ │    ├── cardinality: [0 - 8]
  │    ├── key: (6)
  │    ├── fd: (6)-->(7-10)
  │    ├── scan e

--- a/pkg/sql/opt/norm/testdata/rules/set
+++ b/pkg/sql/opt/norm/testdata/rules/set
@@ -93,6 +93,7 @@ union
  ├── scan b
  │    ├── columns: b.k:1(int!null)
  │    ├── constraint: /1: [/2 - /9]
+ │    ├── cardinality: [0 - 8]
  │    └── key: (1)
  └── select
       ├── columns: w:7(int!null)
@@ -160,10 +161,12 @@ except
  ├── columns: k:1(int!null)
  ├── left columns: k:1(int!null)
  ├── right columns: w:7(int)
+ ├── cardinality: [0 - 8]
  ├── key: (1)
  ├── scan b
  │    ├── columns: k:1(int!null)
  │    ├── constraint: /1: [/2 - /9]
+ │    ├── cardinality: [0 - 8]
  │    └── key: (1)
  └── select
       ├── columns: w:7(int!null)
@@ -183,9 +186,11 @@ except-all
  ├── columns: k:1(int!null)
  ├── left columns: k:1(int!null)
  ├── right columns: w:7(int)
+ ├── cardinality: [0 - 8]
  ├── scan b
  │    ├── columns: k:1(int!null)
  │    ├── constraint: /1: [/2 - /9]
+ │    ├── cardinality: [0 - 8]
  │    └── key: (1)
  └── select
       ├── columns: w:7(int!null)
@@ -205,10 +210,12 @@ intersect
  ├── columns: k:1(int!null)
  ├── left columns: k:1(int!null)
  ├── right columns: w:7(int)
+ ├── cardinality: [0 - 8]
  ├── key: (1)
  ├── scan b
  │    ├── columns: k:1(int!null)
  │    ├── constraint: /1: [/2 - /9]
+ │    ├── cardinality: [0 - 8]
  │    └── key: (1)
  └── select
       ├── columns: w:7(int!null)
@@ -228,9 +235,11 @@ intersect-all
  ├── columns: k:1(int!null)
  ├── left columns: k:1(int!null)
  ├── right columns: w:7(int)
+ ├── cardinality: [0 - 8]
  ├── scan b
  │    ├── columns: k:1(int!null)
  │    ├── constraint: /1: [/2 - /9]
+ │    ├── cardinality: [0 - 8]
  │    └── key: (1)
  └── select
       ├── columns: w:7(int!null)
@@ -254,11 +263,13 @@ union
  ├── key: (11)
  ├── select
  │    ├── columns: b.k:1(int!null)
+ │    ├── cardinality: [0 - 8]
  │    ├── side-effects
  │    ├── key: (1)
  │    ├── scan b
  │    │    ├── columns: b.k:1(int!null)
  │    │    ├── constraint: /1: [/2 - /9]
+ │    │    ├── cardinality: [0 - 8]
  │    │    └── key: (1)
  │    └── filters
  │         └── random() < 0.5 [type=bool, side-effects]

--- a/pkg/sql/opt/xform/testdata/coster/scan
+++ b/pkg/sql/opt/xform/testdata/coster/scan
@@ -22,6 +22,7 @@ SELECT id FROM speed_test@primary WHERE id BETWEEN 1 AND 1000 AND ((id % 16) = 0
 ----
 select
  ├── columns: id:1(int!null)
+ ├── cardinality: [0 - 1000]
  ├── stats: [rows=333.333333, distinct(1)=333.333333, null(1)=0]
  ├── cost: 1030.02
  ├── key: (1)
@@ -29,6 +30,7 @@ select
  │    ├── columns: id:1(int!null)
  │    ├── constraint: /1: [/1 - /1000]
  │    ├── flags: force-index=primary
+ │    ├── cardinality: [0 - 1000]
  │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0]
  │    ├── cost: 1020.01
  │    └── key: (1)
@@ -40,6 +42,7 @@ SELECT id FROM speed_test@primary WHERE id BETWEEN 1 AND 2000 AND ((id % 16) = 0
 ----
 select
  ├── columns: id:1(int!null)
+ ├── cardinality: [0 - 2000]
  ├── stats: [rows=333.333333, distinct(1)=333.333333, null(1)=0]
  ├── cost: 1030.02
  ├── key: (1)
@@ -47,6 +50,7 @@ select
  │    ├── columns: id:1(int!null)
  │    ├── constraint: /1: [/1 - /2000]
  │    ├── flags: force-index=primary
+ │    ├── cardinality: [0 - 2000]
  │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0]
  │    ├── cost: 1020.01
  │    └── key: (1)

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -70,6 +70,7 @@ ORDER BY i_id
 scan item
  ├── columns: i_price:4(decimal) i_name:3(varchar) i_data:5(varchar)  [hidden: i_id:1(int!null)]
  ├── constraint: /1: [/25 - /25] [/50 - /50] [/75 - /75] [/100 - /100] [/125 - /125] [/150 - /150] [/175 - /175] [/200 - /200] [/225 - /225] [/250 - /250] [/275 - /275] [/300 - /300]
+ ├── cardinality: [0 - 12]
  ├── stats: [rows=12, distinct(1)=12, null(1)=0]
  ├── cost: 13.09
  ├── key: (1)
@@ -86,6 +87,7 @@ ORDER BY s_i_id
 ----
 project
  ├── columns: s_quantity:3(int) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(varchar) s_dist_05:8(char)  [hidden: s_i_id:1(int!null)]
+ ├── cardinality: [0 - 5]
  ├── stats: [rows=4.93715008]
  ├── cost: 6.2408091
  ├── key: (1)
@@ -96,6 +98,7 @@ project
  └── scan stock
       ├── columns: s_i_id:1(int!null) s_w_id:2(int!null) s_quantity:3(int) s_dist_05:8(char) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(varchar)
       ├── constraint: /2/1: [/4/900 - /4/900] [/4/1000 - /4/1000] [/4/1100 - /4/1100] [/4/1400 - /4/1400] [/4/1500 - /4/1500]
+      ├── cardinality: [0 - 5]
       ├── stats: [rows=4.93715008, distinct(1)=4.93715008, null(1)=0, distinct(2)=1, null(2)=0]
       ├── cost: 6.1814376
       ├── key: (1)
@@ -1703,6 +1706,7 @@ ORDER BY i_id
 scan item
  ├── columns: i_price:4(decimal) i_name:3(varchar) i_data:5(varchar)  [hidden: i_id:1(int!null)]
  ├── constraint: /1: [/25 - /25] [/50 - /50] [/75 - /75] [/100 - /100] [/125 - /125] [/150 - /150] [/175 - /175] [/200 - /200] [/225 - /225] [/250 - /250] [/275 - /275] [/300 - /300]
+ ├── cardinality: [0 - 12]
  ├── stats: [rows=12, distinct(1)=12, null(1)=0]
  ├── cost: 13.09
  ├── key: (1)
@@ -1719,6 +1723,7 @@ ORDER BY s_i_id
 ----
 project
  ├── columns: s_quantity:3(int) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(varchar) s_dist_05:8(char)  [hidden: s_i_id:1(int!null)]
+ ├── cardinality: [0 - 5]
  ├── stats: [rows=4.93715008]
  ├── cost: 6.2408091
  ├── key: (1)
@@ -1729,6 +1734,7 @@ project
  └── scan stock
       ├── columns: s_i_id:1(int!null) s_w_id:2(int!null) s_quantity:3(int) s_dist_05:8(char) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(varchar)
       ├── constraint: /2/1: [/4/900 - /4/900] [/4/1000 - /4/1000] [/4/1100 - /4/1100] [/4/1400 - /4/1400] [/4/1500 - /4/1500]
+      ├── cardinality: [0 - 5]
       ├── stats: [rows=4.93715008, distinct(1)=4.93715008, null(1)=0, distinct(2)=1, null(2)=0]
       ├── cost: 6.1814376
       ├── key: (1)

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -67,6 +67,7 @@ ORDER BY i_id
 scan item
  ├── columns: i_price:4(decimal) i_name:3(varchar) i_data:5(varchar)  [hidden: i_id:1(int!null)]
  ├── constraint: /1: [/25 - /25] [/50 - /50] [/75 - /75] [/100 - /100] [/125 - /125] [/150 - /150] [/175 - /175] [/200 - /200] [/225 - /225] [/250 - /250] [/275 - /275] [/300 - /300]
+ ├── cardinality: [0 - 12]
  ├── stats: [rows=12, distinct(1)=12, null(1)=0]
  ├── cost: 13.09
  ├── key: (1)
@@ -83,6 +84,7 @@ ORDER BY s_i_id
 ----
 project
  ├── columns: s_quantity:3(int) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(varchar) s_dist_05:8(char)  [hidden: s_i_id:1(int!null)]
+ ├── cardinality: [0 - 5]
  ├── stats: [rows=0.5]
  ├── cost: 0.65
  ├── key: (1)
@@ -93,6 +95,7 @@ project
  └── scan stock
       ├── columns: s_i_id:1(int!null) s_w_id:2(int!null) s_quantity:3(int) s_dist_05:8(char) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(varchar)
       ├── constraint: /2/1: [/4/900 - /4/900] [/4/1000 - /4/1000] [/4/1100 - /4/1100] [/4/1400 - /4/1400] [/4/1500 - /4/1500]
+      ├── cardinality: [0 - 5]
       ├── stats: [rows=0.5, distinct(1)=0.5, null(1)=0, distinct(2)=0.5, null(2)=0]
       ├── cost: 0.635
       ├── key: (1)

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -200,11 +200,13 @@ explain
       ├── ordering: -2
       ├── sort
       │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+      │    ├── cardinality: [0 - 11]
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
       │    ├── ordering: -2
       │    └── select
       │         ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+      │         ├── cardinality: [0 - 11]
       │         ├── key: (1)
       │         ├── fd: (1)-->(2-4), (2-4)~~>(1)
       │         ├── index-join abcd
@@ -243,11 +245,13 @@ Initial expression
              ├── fd: (1)-->(2-4), (2-4)~~>(1)
              ├── sort
              │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+             │    ├── cardinality: [0 - 11]
              │    ├── key: (1)
              │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
              │    ├── ordering: -2
              │    └── select
              │         ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+             │         ├── cardinality: [0 - 11]
              │         ├── key: (1)
              │         ├── fd: (1)-->(2-4), (2-4)~~>(1)
              │         ├── scan abcd
@@ -278,11 +282,13 @@ SimplifySelectFilters
               ├── fd: (1)-->(2-4), (2-4)~~>(1)
               ├── sort
               │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+  -           │    ├── cardinality: [0 - 11]
               │    ├── key: (1)
               │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
               │    ├── ordering: -2
               │    └── select
               │         ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+  -           │         ├── cardinality: [0 - 11]
               │         ├── key: (1)
               │         ├── fd: (1)-->(2-4), (2-4)~~>(1)
               │         ├── scan abcd
@@ -315,11 +321,13 @@ ConsolidateSelectFilters
               ├── fd: (1)-->(2-4), (2-4)~~>(1)
               ├── sort
               │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+  +           │    ├── cardinality: [0 - 11]
               │    ├── key: (1)
               │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
               │    ├── ordering: -2
               │    └── select
               │         ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+  +           │         ├── cardinality: [0 - 11]
               │         ├── key: (1)
               │         ├── fd: (1)-->(2-4), (2-4)~~>(1)
               │         ├── scan abcd
@@ -354,11 +362,13 @@ GenerateIndexScans
   -           ├── fd: (1)-->(2-4), (2-4)~~>(1)
   -           ├── sort
   -           │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+  -           │    ├── cardinality: [0 - 11]
   -           │    ├── key: (1)
   -           │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
   -           │    ├── ordering: -2
   -           │    └── select
   -           │         ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+  -           │         ├── cardinality: [0 - 11]
   -           │         ├── key: (1)
   -           │         ├── fd: (1)-->(2-4), (2-4)~~>(1)
   -           │         ├── scan abcd
@@ -371,11 +381,13 @@ GenerateIndexScans
   -           └── const: 5 [type=int]
   +      ├── sort
   +      │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+  +      │    ├── cardinality: [0 - 11]
   +      │    ├── key: (1)
   +      │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
   +      │    ├── ordering: -2
   +      │    └── select
   +      │         ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+  +      │         ├── cardinality: [0 - 11]
   +      │         ├── key: (1)
   +      │         ├── fd: (1)-->(2-4), (2-4)~~>(1)
   +      │         ├── index-join abcd
@@ -411,11 +423,13 @@ Final best expression
         ├── ordering: -2
         ├── sort
         │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+        │    ├── cardinality: [0 - 11]
         │    ├── key: (1)
         │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
         │    ├── ordering: -2
         │    └── select
         │         ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+        │         ├── cardinality: [0 - 11]
         │         ├── key: (1)
         │         ├── fd: (1)-->(2-4), (2-4)~~>(1)
         │         ├── index-join abcd

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -285,11 +285,13 @@ SELECT * FROM b WHERE v >= 1 AND v <= 10
 ----
 index-join b
  ├── columns: k:1(int!null) u:2(int) v:3(int!null) j:4(jsonb)
+ ├── cardinality: [0 - 10]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)-->(1,2,4)
  └── scan b@v
       ├── columns: k:1(int!null) v:3(int!null)
       ├── constraint: /3: [/1 - /10]
+      ├── cardinality: [0 - 10]
       ├── key: (1)
       └── fd: (1)-->(3), (3)-->(1)
 
@@ -338,15 +340,18 @@ SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k > 5
 ----
 index-join b
  ├── columns: k:1(int!null) u:2(int) v:3(int!null) j:4(jsonb)
+ ├── cardinality: [0 - 10]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)-->(1,2,4)
  └── select
       ├── columns: k:1(int!null) v:3(int!null)
+      ├── cardinality: [0 - 10]
       ├── key: (1)
       ├── fd: (1)-->(3), (3)-->(1)
       ├── scan b@v
       │    ├── columns: k:1(int!null) v:3(int!null)
       │    ├── constraint: /3: [/1 - /10]
+      │    ├── cardinality: [0 - 10]
       │    ├── key: (1)
       │    └── fd: (1)-->(3), (3)-->(1)
       └── filters
@@ -432,15 +437,18 @@ SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1
 ----
 select
  ├── columns: k:1(int!null) u:2(int) v:3(int!null) j:4(jsonb)
+ ├── cardinality: [0 - 10]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)-->(1,2,4)
  ├── index-join b
  │    ├── columns: k:1(int!null) u:2(int) v:3(int) j:4(jsonb)
+ │    ├── cardinality: [0 - 10]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3)-->(1), (3)~~>(1,2,4)
  │    └── scan b@v
  │         ├── columns: k:1(int!null) v:3(int!null)
  │         ├── constraint: /3: [/1 - /10]
+ │         ├── cardinality: [0 - 10]
  │         ├── key: (1)
  │         └── fd: (1)-->(3), (3)-->(1)
  └── filters
@@ -485,19 +493,23 @@ SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1 AND k > 5
 ----
 select
  ├── columns: k:1(int!null) u:2(int) v:3(int!null) j:4(jsonb)
+ ├── cardinality: [0 - 10]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)-->(1,2,4)
  ├── index-join b
  │    ├── columns: k:1(int!null) u:2(int) v:3(int) j:4(jsonb)
+ │    ├── cardinality: [0 - 10]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3)-->(1), (3)~~>(1,2,4)
  │    └── select
  │         ├── columns: k:1(int!null) v:3(int!null)
+ │         ├── cardinality: [0 - 10]
  │         ├── key: (1)
  │         ├── fd: (1)-->(3), (3)-->(1)
  │         ├── scan b@v
  │         │    ├── columns: k:1(int!null) v:3(int!null)
  │         │    ├── constraint: /3: [/1 - /10]
+ │         │    ├── cardinality: [0 - 10]
  │         │    ├── key: (1)
  │         │    └── fd: (1)-->(3), (3)-->(1)
  │         └── filters


### PR DESCRIPTION
**opt: calculate cardinality from filters**

This commit adds logic to determine whether a tight cardinality bound
can be determined from the filters in a `Select` or `Scan` expression, and
updates the cardinality accordingly in the logical properties.
Specifically, it may be possible to determine a tight bound if the key
column(s) are constrained to a finite number of values.

**opt: don't use histogram if cardinality < 100**

This commit changes the logic in the `statisticsBuilder` so it will not
use a histogram if the cardinality of an expression is known to be less
than 100. This could be the case due to a limit clause or due to a
constraint on a key column. Since we can statically prove that the
cardinality is less than 100, a histogram will not be especially
useful and just adds overhead.

I chose the number 100 by doing some tests varying the batch size with
the kv workload with 95% reads. When batch=100, there is not a noticeable
difference in performance when histograms are enabled v. disabled. Below 100,
e.g. when batch=50, there is a noticeable difference.
