### PR TITLE
roachtest: relax max range lookups for kv50/rangelookups/split

### DIFF
--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -576,7 +576,6 @@ func registerKVRangeLookups(r *testRegistry) {
 								kv.kv
 							SPLIT AT
 								VALUES (CAST(floor(random() * 9223372036854775808) AS INT))
-							WITH EXPIRATION '1s'
 						`)
 						if err != nil && !pgerror.IsSQLRetryableError(err) {
 							return err
@@ -605,7 +604,7 @@ func registerKVRangeLookups(r *testRegistry) {
 		workloadType              rangeLookupWorkloadType
 		maximumRangeLookupsPerSec float64
 	}{
-		{2, splitWorkload, 10.0},
+		{2, splitWorkload, 15.0},
 		// Relocates are expected to fail periodically when relocating random
 		// ranges, so use more workers.
 		{4, relocateWorkload, 50.0},
@@ -622,8 +621,9 @@ func registerKVRangeLookups(r *testRegistry) {
 			panic("unexpected")
 		}
 		r.Add(testSpec{
-			Name:    fmt.Sprintf("kv50/rangelookups/%s/nodes=%d", workloadName, nodes),
-			Cluster: makeClusterSpec(nodes+1, cpu(cpus)),
+			Name:       fmt.Sprintf("kv50/rangelookups/%s/nodes=%d", workloadName, nodes),
+			MinVersion: "v19.2.0",
+			Cluster:    makeClusterSpec(nodes+1, cpu(cpus)),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runRangeLookups(ctx, t, c, item.workers, item.workloadType, item.maximumRangeLookupsPerSec)
 			},


### PR DESCRIPTION
This roachtest was occasionally failing because it was exceeding the maximum of 10 lookup/sec. This commit relaxes it to 15 lookup/sec. This roachtest will still detect regressions in range descriptor cache performance since the old rate was approximately 30 lookup/sec.

Also, set a minimum version on the test since they are expected to fail on 19.1 and "distsender.rangelookups" isn't available on 19.1.

Finally, remove WITH EXPIRATION with performing splits as temporary splits aren't necessary for the test.

Fixes #39174.

Release note: None