### PR TITLE
querybench: bugfix to vectorized setting string

### DIFF
--- a/pkg/workload/querybench/query_bench.go
+++ b/pkg/workload/querybench/query_bench.go
@@ -122,7 +122,7 @@ func (g *queryBench) Ops(urls []string, reg *histogram.Registry) (workload.Query
 		}
 	}
 	if g.vectorize != "" {
-		_, err := db.Exec("SET vectorize=%s", g.vectorize)
+		_, err := db.Exec("SET vectorize=" + g.vectorize)
 		if err != nil {
 			return workload.QueryLoad{}, err
 		}


### PR DESCRIPTION
Typo in previous similar commit.

Closes #39391.

Release note: None