### PR TITLE
cli: add default ballast size of 1GB

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -598,6 +598,7 @@ Also, if you use equal signs in the file path to a store, you must use the
 		Description: `
 The Size to fill Store upto(using a ballast file):
 Negative value means denotes amount of space that should be left after filling the disk.
+If the Size is left unspecified, it defaults to 1GB.
 <PRE>
 
   --size=20GiB

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -98,7 +98,7 @@ func initCLIDefaults() {
 	debugCtx.inputFile = ""
 	debugCtx.printSystemConfig = false
 	debugCtx.maxResults = 1000
-	debugCtx.ballastSize = base.SizeSpec{}
+	debugCtx.ballastSize = base.SizeSpec{InBytes: 1000000000}
 
 	zoneCtx.zoneConfig = ""
 	zoneCtx.zoneDisableReplication = false


### PR DESCRIPTION
Resolves #38661
Defaults the size of the ballast debug command to 1GB