### PR TITLE
roachprod: report missing google cloud sdk

### DIFF
--- a/pkg/cmd/roachprod/vm/gce/gcloud.go
+++ b/pkg/cmd/roachprod/vm/gce/gcloud.go
@@ -45,7 +45,7 @@ var projectsWithGC = []string{defaultProject, "andrei-jepsen"}
 
 // init will inject the GCE provider into vm.Providers, but only if the gcloud tool is available on the local path.
 func init() {
-	var p vm.Provider
+	var p vm.Provider = &Provider{}
 	if _, err := exec.LookPath("gcloud"); err != nil {
 		p = flagstub.New(p, "please install the gcloud CLI utilities "+
 			"(https://cloud.google.com/sdk/downloads)")


### PR DESCRIPTION
Previously users saw the below unhelpful segfault if Google cloud SDK
was not installed (both for AWS and GCE):

```
$ ./bin/roachprod create andrewk-test -n 1 --clouds aws --aws-machine-type t3.micro --local-ssd=false
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0xb13719]

goroutine 1 [running]:
github.com/cockroachdb/cockroach/pkg/cmd/roachprod/vm/flagstub.(*provider).Flags(0xc0003befc0,
0xc0000cc800, 0xc0003b2900)
        /home/andrew/go/src/github.com/cockroachdb/cockroach/pkg/cmd/roachprod/vm/flagstub/flagstub.go:66
+0x29
main.main()
        /home/andrew/go/src/github.com/cockroachdb/cockroach/pkg/cmd/roachprod/main.go:1577
+0xb26
```

After this PR it still fails to launch instances, but at least it tells
users what the problem is.

New AWS output:
```
$ ./bin/roachprod create andrewk-test2 -n 1 --clouds aws --aws-machine-type t3.micro --local-ssd=false
...
Cleaning up partially-created cluster (prev err: failed to retrieve authorized keys from gcloud: exec: "gcloud": executable file not found in $PATH)
Cleaning up OK
Error:  failed to retrieve authorized keys from gcloud: exec: "gcloud": executable file not found in $PATH
```

New GCE output:
```
$ ./bin/roachprod create andrewk-test2 -n 1
Creating cluster andrewk-test2 with 1 nodes
Cleaning up partially-created cluster (prev err: in provider: gce: please install the gcloud CLI utilities (https://cloud.google.com/sdk/downloads))
Cleaning up OK
Error:  in provider: gce: please install the gcloud CLI utilities (https://cloud.google.com/sdk/downloads)
```

Release note: None