### PR TITLE
exec: make sure that builder state of merge joiner is always set up

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/exec_merge_join_dist
+++ b/pkg/sql/logictest/testdata/logic_test/exec_merge_join_dist
@@ -1,0 +1,52 @@
+# LogicTest: 5node-dist-vec
+
+# Regression test for #39317.
+
+statement ok
+CREATE TABLE l (a INT PRIMARY KEY)
+
+statement ok
+CREATE TABLE r (a INT PRIMARY KEY)
+
+statement ok
+INSERT INTO l VALUES (1), (2)
+
+statement ok
+INSERT INTO r VALUES (2), (3)
+
+statement ok
+ALTER TABLE l SPLIT AT VALUES (2)
+
+statement ok
+ALTER TABLE r SPLIT AT VALUES (2)
+
+statement ok
+ALTER TABLE l EXPERIMENTAL_RELOCATE VALUES (ARRAY[1], 1), (ARRAY[2], 2)
+
+statement ok
+ALTER TABLE r EXPERIMENTAL_RELOCATE VALUES (ARRAY[1], 2), (ARRAY[2], 1)
+
+query TTTI colnames
+SELECT start_key, end_key, replicas, lease_holder from [SHOW EXPERIMENTAL_RANGES FROM TABLE l]
+----
+start_key  end_key  replicas  lease_holder
+NULL       /2       {1}       1
+/2         NULL     {2}       2
+
+query TTTI colnames
+SELECT start_key, end_key, replicas, lease_holder from [SHOW EXPERIMENTAL_RANGES FROM TABLE r]
+----
+start_key  end_key  replicas  lease_holder
+/2         NULL     {1}       1
+NULL       /2       {2}       2
+
+query T
+SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM l LEFT OUTER JOIN r USING(a) WHERE a = 2]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJzEk09rgzAYxu_7FPLusrEUjXWXwKCXDlq2Ojp3Gh5S884K1kgSYaX43Yc6aHXWtWxsN_Pn97zPkwd3kEmBC75BDewVKBBwISSQKxmh1lJV282lmXgH5hBIsrww1XZIIJIKge3AJCZFYBDwVYpL5AKVXWkJNDxJa-lcJRuuthMFBJ5znmlm2e7Idu1LCEsCsjCfsnu11dZac71u60wohGVIQBseIzC3JEfs7XWKTCqBCkVLKazI7670ZHxEFeNcJhkqe9z2FmxzZNbD9D6w_JdgurTm_mwBBFJ8M1cTenN9p5J43XwCAb8wzKrzHObfZxv_IFuP8YUcydz2uo_QO9prjaant-70t57-buv0qL2_aN39p9Z7bC1R5zLTeFKpThUMRYzNQ2lZqAiflIzqMc3Sr7n6TQVq05x6zWKW1Uf1L3c6TIdh2oWdQ9htwbQLu4PwbQt2uvD4jMxfJg_DdBj2zsoclhcfAQAA___49Nlj
+
+query I
+SELECT * FROM l LEFT OUTER JOIN r USING(a) WHERE a = 2
+----
+2
+


### PR DESCRIPTION
Previously, in some situations the builder state of the merge joiner
would not be properly set up which could trigger a null pointer error.
Now we always initialize it and then update it, if needed.

Fixes: #39317.

Release note: None