### PR TITLE
storage: create new tracing span for each replicatedCmd during application

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1075,11 +1075,13 @@ func (ec *endCmds) move() endCmds {
 // the timestamp cache using the final timestamp of each command.
 //
 // No-op if the receiver has been zeroed out by a call to move.
+// Idempotent and is safe to call more than once.
 func (ec *endCmds) done(ba *roachpb.BatchRequest, br *roachpb.BatchResponse, pErr *roachpb.Error) {
 	if ec.repl == nil {
 		// The endCmds were cleared.
 		return
 	}
+	defer ec.move() // clear
 
 	// Update the timestamp cache if the request is not being re-evaluated. Each
 	// request is considered in turn; only those marked as affecting the cache are

--- a/pkg/storage/replica_application_state_machine.go
+++ b/pkg/storage/replica_application_state_machine.go
@@ -839,22 +839,20 @@ func (sm *replicaStateMachine) ApplySideEffects(
 
 	// Mark the command as applied and return it as an apply.AppliedCommand.
 	if cmd.IsLocal() {
-		if !cmd.Rejected() && cmd.raftCmd.MaxLeaseIndex != cmd.proposal.command.MaxLeaseIndex {
-			log.Fatalf(ctx, "finishing proposal with outstanding reproposal at a higher max lease index")
-		}
-		if cmd.proposal.applied {
-			// If the command already applied then we shouldn't be "finishing" its
-			// application again because it should only be able to apply successfully
-			// once. We expect that when any reproposal for the same command attempts
-			// to apply it will be rejected by the below raft lease sequence or lease
-			// index check in checkForcedErr.
-			if !cmd.Rejected() {
+		if !cmd.Rejected() {
+			if cmd.raftCmd.MaxLeaseIndex != cmd.proposal.command.MaxLeaseIndex {
+				log.Fatalf(ctx, "finishing proposal with outstanding reproposal at a higher max lease index")
+			}
+			if cmd.proposal.applied {
+				// If the command already applied then we shouldn't be "finishing" its
+				// application again because it should only be able to apply successfully
+				// once. We expect that when any reproposal for the same command attempts
+				// to apply it will be rejected by the below raft lease sequence or lease
+				// index check in checkForcedErr.
 				log.Fatalf(ctx, "command already applied: %+v; unexpected successful result", cmd)
 			}
-			cmd.proposal = nil
-		} else {
-			cmd.proposal.applied = true
 		}
+		cmd.proposal.applied = true
 	}
 	return cmd, nil
 }

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -126,6 +126,9 @@ type ProposalData struct {
 // order to allow the original client to be canceled. (When the original client
 // is canceled, it won't be listening to this done channel, and so it can't be
 // counted on to invoke endCmds itself.)
+//
+// The method is safe to call more than once, but only the first result will be
+// returned to the client.
 func (proposal *ProposalData) finishApplication(pr proposalResult) {
 	proposal.ec.done(proposal.Request, pr.Reply, pr.Err)
 	proposal.signalProposalResult(pr)
@@ -139,6 +142,9 @@ func (proposal *ProposalData) finishApplication(pr proposalResult) {
 // has not already been signaled. The method can be called even before the
 // proposal has finished replication and command application, and does not
 // release the request's latches.
+//
+// The method is safe to call more than once, but only the first result will be
+// returned to the client.
 func (proposal *ProposalData) signalProposalResult(pr proposalResult) {
 	if proposal.doneCh != nil {
 		proposal.doneCh <- pr


### PR DESCRIPTION
This change adjusts our handling of contexts and replicatedCmds. We no longer
assign a local proposal's context to its replicatedCmds directly. Instead,
we always create a new tracing span that follows from this context. This
eliminates a whole class of bugs that we have fought to fix in changes
like #39203. In fact, we are still seeing issues after the recent refactor
when stressing #39390.

The change also paves the way for tracing the application of command application
on follower replicas.