### PR TITLE
exec: introduce two panic functions to use within the exec package

### DIFF
--- a/pkg/sql/distsqlrun/materializer.go
+++ b/pkg/sql/distsqlrun/materializer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -175,7 +176,7 @@ func (m *materializer) next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata)
 }
 
 func (m *materializer) Next() (sqlbase.EncDatumRow, *distsqlpb.ProducerMetadata) {
-	if err := exec.CatchVectorizedRuntimeError(m.nextAdapter); err != nil {
+	if err := execerror.CatchVectorizedRuntimeError(m.nextAdapter); err != nil {
 		m.MoveToDraining(err)
 		return nil, m.DrainHelper()
 	}

--- a/pkg/sql/distsqlrun/vectorized_panic_propagation_test.go
+++ b/pkg/sql/distsqlrun/vectorized_panic_propagation_test.go
@@ -18,17 +18,18 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 )
 
-// TestVectorizedErrorPropagation verifies that materializers successfully
+// TestVectorizedInternalPanic verifies that materializers successfully
 // handle panics coming from exec package. It sets up the following chain:
-// RowSource -> columnarizer -> exec error emitter -> materializer,
+// RowSource -> columnarizer -> test panic emitter -> materializer,
 // and makes sure that a panic doesn't occur yet the error is propagated.
-func TestVectorizedErrorPropagation(t *testing.T) {
+func TestVectorizedInternalPanic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
@@ -49,7 +50,7 @@ func TestVectorizedErrorPropagation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vee := exec.NewTestVectorizedErrorEmitter(col)
+	vee := newTestVectorizedPanicEmitter(col, execerror.VectorizedInternalPanic)
 	mat, err := newMaterializer(
 		&flowCtx,
 		1, /* processorID */
@@ -64,31 +65,18 @@ func TestVectorizedErrorPropagation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	mat.Start(ctx)
 
 	var meta *distsqlpb.ProducerMetadata
-	panicEmitted := false
-	func() {
-		defer func() {
-			if err := recover(); err != nil {
-				panicEmitted = true
-			}
-		}()
-		mat.Start(ctx)
-		_, meta = mat.Next()
-	}()
-	if panicEmitted {
-		t.Fatalf("VectorizedRuntimeError was not caught by the operators.")
-	}
-	if meta == nil || meta.Err == nil {
-		t.Fatalf("VectorizedRuntimeError was not propagated as metadata.")
-	}
+	require.NotPanics(t, func() { _, meta = mat.Next() }, "VectorizedInternalPanic was not caught")
+	require.NotNil(t, meta.Err, "VectorizedInternalPanic was not propagated as metadata")
 }
 
-// TestNonVectorizedErrorPropagation verifies that materializers do not handle
+// TestNonVectorizedPanicPropagation verifies that materializers do not handle
 // panics coming not from exec package. It sets up the following chain:
-// RowSource -> columnarizer -> distsqlrun error emitter -> materializer,
+// RowSource -> columnarizer -> test panic emitter -> materializer,
 // and makes sure that a panic is emitted all the way through the chain.
-func TestNonVectorizedErrorPropagation(t *testing.T) {
+func TestNonVectorizedPanicPropagation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
@@ -109,7 +97,7 @@ func TestNonVectorizedErrorPropagation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	nvee := newTestVectorizedErrorEmitter(col)
+	nvee := newTestVectorizedPanicEmitter(col, nil /* panicFn */)
 	mat, err := newMaterializer(
 		&flowCtx,
 		1, /* processorID */
@@ -124,48 +112,45 @@ func TestNonVectorizedErrorPropagation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	mat.Start(ctx)
 
-	panicEmitted := false
-	func() {
-		defer func() {
-			if err := recover(); err != nil {
-				panicEmitted = true
-			}
-		}()
-		mat.Start(ctx)
-		_, _ = mat.Next()
-	}()
-	if !panicEmitted {
-		t.Fatalf("Not VectorizedRuntimeError was caught by the operators.")
+	require.Panics(t, func() { mat.Next() }, "NonVectorizedPanic was caught by the operators")
+}
+
+// testVectorizedPanicEmitter is an exec.Operator that panics on every
+// odd-numbered invocation of Next() and returns the next batch from the input
+// on every even-numbered (i.e. it becomes a noop for those iterations). Used
+// for tests only. If panicFn is non-nil, it is used; otherwise, the builtin
+// panic function is called.
+type testVectorizedPanicEmitter struct {
+	exec.OneInputNode
+	emitBatch bool
+
+	panicFn func(interface{})
+}
+
+var _ exec.Operator = &testVectorizedPanicEmitter{}
+
+func newTestVectorizedPanicEmitter(input exec.Operator, panicFn func(interface{})) exec.Operator {
+	return &testVectorizedPanicEmitter{
+		OneInputNode: exec.NewOneInputNode(input),
+		panicFn:      panicFn,
 	}
 }
 
-// testNonVectorizedErrorEmitter is an exec.Operator that panics on every
-// odd-numbered invocation of Next() and returns the next batch from the input
-// on every even-numbered (i.e. it becomes a noop for those iterations). Used
-// for tests only.
-type testNonVectorizedErrorEmitter struct {
-	exec.OneInputNode
-	emitBatch bool
-}
-
-var _ exec.Operator = &testNonVectorizedErrorEmitter{}
-
-// newTestVectorizedErrorEmitter creates a new TestVectorizedErrorEmitter.
-func newTestVectorizedErrorEmitter(input exec.Operator) exec.Operator {
-	return &testNonVectorizedErrorEmitter{OneInputNode: exec.NewOneInputNode(input)}
-}
-
 // Init is part of exec.Operator interface.
-func (e *testNonVectorizedErrorEmitter) Init() {
+func (e *testVectorizedPanicEmitter) Init() {
 	e.Input().Init()
 }
 
 // Next is part of exec.Operator interface.
-func (e *testNonVectorizedErrorEmitter) Next(ctx context.Context) coldata.Batch {
+func (e *testVectorizedPanicEmitter) Next(ctx context.Context) coldata.Batch {
 	if !e.emitBatch {
 		e.emitBatch = true
-		panic(errors.New("An error from distsqlrun package"))
+		if e.panicFn != nil {
+			e.panicFn("")
+		}
+		panic("")
 	}
 
 	e.emitBatch = false

--- a/pkg/sql/exec/avg_agg_tmpl.go
+++ b/pkg/sql/exec/avg_agg_tmpl.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/pkg/errors"
 )
@@ -40,13 +41,13 @@ var _ tree.Datum
 // input to the result of the second input / the third input, where the third
 // input is an int64.
 func _ASSIGN_DIV_INT64(_, _, _ string) {
-	panic("")
+	execerror.VectorizedInternalPanic("")
 }
 
 // _ASSIGN_ADD is the template addition function for assigning the first input
 // to the result of the second input + the third input.
 func _ASSIGN_ADD(_, _, _ string) {
-	panic("")
+	execerror.VectorizedInternalPanic("")
 }
 
 // */}}

--- a/pkg/sql/exec/builtin_funcs.go
+++ b/pkg/sql/exec/builtin_funcs.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -80,7 +81,7 @@ func (b *defaultBuiltinFuncOperator) Next(ctx context.Context) coldata.Batch {
 		} else {
 			res, err = b.funcExpr.ResolvedOverload().Fn(b.evalCtx, b.row)
 			if err != nil {
-				panic(err)
+				execerror.NonVectorizedPanic(err)
 			}
 		}
 
@@ -90,7 +91,7 @@ func (b *defaultBuiltinFuncOperator) Next(ctx context.Context) coldata.Batch {
 		} else {
 			converted, err := b.converter(res)
 			if err != nil {
-				panic(err)
+				execerror.VectorizedInternalPanic(err)
 			}
 			coldata.SetValueAt(batch.ColVec(b.outputIdx), converted, rowIdx, b.outputPhysType)
 		}

--- a/pkg/sql/exec/cancel_checker.go
+++ b/pkg/sql/exec/cancel_checker.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
@@ -69,7 +70,7 @@ func (c *CancelChecker) check(ctx context.Context) {
 func (c *CancelChecker) checkEveryCall(ctx context.Context) {
 	select {
 	case <-ctx.Done():
-		panic(sqlbase.QueryCanceledError)
+		execerror.NonVectorizedPanic(sqlbase.QueryCanceledError)
 	default:
 	}
 }

--- a/pkg/sql/exec/cancel_checker_test.go
+++ b/pkg/sql/exec/cancel_checker_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/stretchr/testify/require"
 )
@@ -27,7 +28,8 @@ func TestCancelChecker(t *testing.T) {
 	batch := coldata.NewMemBatch([]coltypes.T{coltypes.Int64})
 	op := NewCancelChecker(NewNoop(NewRepeatableBatchSource(batch)))
 	cancel()
-	require.PanicsWithValue(t, sqlbase.QueryCanceledError, func() {
+	err := execerror.CatchVectorizedRuntimeError(func() {
 		op.Next(ctx)
 	})
+	require.Equal(t, sqlbase.QueryCanceledError, err)
 }

--- a/pkg/sql/exec/colrpc/colrpc_test.go
+++ b/pkg/sql/exec/colrpc/colrpc_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -256,7 +257,7 @@ func TestOutboxInbox(t *testing.T) {
 		var readerErr error
 		for {
 			var outputBatch coldata.Batch
-			if err := exec.CatchVectorizedRuntimeError(func() {
+			if err := execerror.CatchVectorizedRuntimeError(func() {
 				outputBatch = inbox.Next(readerCtx)
 			}); err != nil {
 				readerErr = err

--- a/pkg/sql/exec/colrpc/inbox_test.go
+++ b/pkg/sql/exec/colrpc/inbox_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/stretchr/testify/require"
@@ -56,7 +56,7 @@ func TestInboxCancellation(t *testing.T) {
 		// Cancel the context.
 		cancelFn()
 		// Next should not block if the context is canceled.
-		err = exec.CatchVectorizedRuntimeError(func() { inbox.Next(ctx) })
+		err = execerror.CatchVectorizedRuntimeError(func() { inbox.Next(ctx) })
 		require.True(t, testutils.IsError(err, "context canceled"), err)
 		// Now, the remote stream arrives.
 		err = inbox.RunWithStream(context.Background(), mockFlowStreamServer{})
@@ -148,7 +148,7 @@ func TestInboxTimeout(t *testing.T) {
 		rpcLayer    = makeMockFlowStreamRPCLayer()
 	)
 	go func() {
-		readerErrCh <- exec.CatchVectorizedRuntimeError(func() { inbox.Next(ctx) })
+		readerErrCh <- execerror.CatchVectorizedRuntimeError(func() { inbox.Next(ctx) })
 	}()
 
 	// Timeout the inbox.

--- a/pkg/sql/exec/colrpc/outbox.go
+++ b/pkg/sql/exec/colrpc/outbox.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/logtags"
 	"google.golang.org/grpc"
@@ -207,7 +208,7 @@ func (o *Outbox) sendBatches(
 			return true, nil
 		}
 
-		if err := exec.CatchVectorizedRuntimeError(nextBatch); err != nil {
+		if err := execerror.CatchVectorizedRuntimeError(nextBatch); err != nil {
 			log.Errorf(ctx, "Outbox Next error: %+v", err)
 			return false, err
 		}

--- a/pkg/sql/exec/distinct_tmpl.go
+++ b/pkg/sql/exec/distinct_tmpl.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/pkg/errors"
@@ -55,7 +56,7 @@ func OrderedDistinctColsToOperators(
 		}
 	}
 	if r, ok = input.(resettableOperator); !ok {
-		panic("unexpectedly an ordered distinct is not a resetter")
+		execerror.VectorizedInternalPanic("unexpectedly an ordered distinct is not a resetter")
 	}
 	distinctChain := distinctChainOps{
 		resettableOperator:         r,
@@ -122,7 +123,7 @@ const _TYPES_T = coltypes.Unhandled
 // _ASSIGN_NE is the template equality function for assigning the first input
 // to the result of the second input != the third input.
 func _ASSIGN_NE(_ bool, _, _ _GOTYPE) bool {
-	panic("")
+	execerror.VectorizedInternalPanic("")
 }
 
 // */}}

--- a/pkg/sql/exec/execerror/error.go
+++ b/pkg/sql/exec/execerror/error.go
@@ -8,16 +8,14 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package exec
+package execerror
 
 import (
 	"bufio"
-	"context"
 	"fmt"
 	"runtime/debug"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/errors"
@@ -53,11 +51,24 @@ func CatchVectorizedRuntimeError(operation func()) (retErr error) {
 							// A StorageError was caused by something below SQL, and represents
 							// an error that we'd simply like to propagate along.
 							// Do nothing.
-						} else if code := pgerror.GetPGCode(e); code == pgcode.Uncategorized {
-							// Any error without a code already is "surprising" and
-							// needs to be annotated to indicate that it was
-							// unexpected.
-							e = errors.AssertionFailedf("unexpected error from the vectorized runtime: %+v", e)
+						} else {
+							doNotAnnotate := false
+							if nvie, ok := e.(*notVectorizedInternalError); ok {
+								// A notVectorizedInternalError was not caused by the
+								// vectorized engine and represents an error that we don't
+								// want to annotate in case it doesn't have a valid PG code.
+								doNotAnnotate = true
+								// We want to unwrap notVectorizedInternalError so that in case
+								// the original error does have a valid PG code, the code is
+								// correctly propagated.
+								e = nvie.error
+							}
+							if code := pgerror.GetPGCode(e); !doNotAnnotate && code == pgcode.Uncategorized {
+								// Any error without a code already is "surprising" and
+								// needs to be annotated to indicate that it was
+								// unexpected.
+								e = errors.AssertionFailedf("unexpected error from the vectorized runtime: %+v", e)
+							}
 						}
 						retErr = e
 					} else {
@@ -99,38 +110,6 @@ func isPanicFromVectorizedEngine(panicEmittedFrom string) bool {
 		strings.HasPrefix(panicEmittedFrom, columnarizerPrefix)
 }
 
-// TestVectorizedErrorEmitter is an Operator that panics on every odd-numbered
-// invocation of Next() and returns the next batch from the input on every
-// even-numbered (i.e. it becomes a noop for those iterations). Used for tests
-// only.
-type TestVectorizedErrorEmitter struct {
-	OneInputNode
-	emitBatch bool
-}
-
-var _ Operator = &TestVectorizedErrorEmitter{}
-
-// NewTestVectorizedErrorEmitter creates a new TestVectorizedErrorEmitter.
-func NewTestVectorizedErrorEmitter(input Operator) Operator {
-	return &TestVectorizedErrorEmitter{OneInputNode: NewOneInputNode(input)}
-}
-
-// Init is part of Operator interface.
-func (e *TestVectorizedErrorEmitter) Init() {
-	e.input.Init()
-}
-
-// Next is part of Operator interface.
-func (e *TestVectorizedErrorEmitter) Next(ctx context.Context) coldata.Batch {
-	if !e.emitBatch {
-		e.emitBatch = true
-		panic(errors.New("a panic from exec package"))
-	}
-
-	e.emitBatch = false
-	return e.input.Next(ctx)
-}
-
 // StorageError is an error that was created by a component below the sql
 // stack, such as the network or storage layers. A StorageError will be bubbled
 // up all the way past the SQL layer unchanged.
@@ -147,4 +126,33 @@ func (s *StorageError) Cause() error {
 // an error through the exec subsystem unchanged.
 func NewStorageError(err error) *StorageError {
 	return &StorageError{error: err}
+}
+
+// notVectorizedInternalError is an error that originated outside of the
+// vectorized engine (for example, it was caused by a non-columnar builtin).
+// notVectorizedInternalError will be returned to the client not as an
+// "internal error" and without the stack trace.
+type notVectorizedInternalError struct {
+	error
+}
+
+func newNotVectorizedInternalError(err error) *notVectorizedInternalError {
+	return &notVectorizedInternalError{error: err}
+}
+
+// VectorizedInternalPanic simply panics with the provided object. It will
+// always be returned as internal error to the client with the corresponding
+// stack trace. This method should be called to propagate all unexpected errors
+// that originated within the vectorized engine.
+func VectorizedInternalPanic(err interface{}) {
+	panic(err)
+}
+
+// NonVectorizedPanic panics with the error that is wrapped by
+// notVectorizedInternalError which will not be treated as internal error and
+// will not have a printed out stack trace. This method should be called to
+// propagate all errors that originated outside of the vectorized engine and
+// all expected errors from the vectorized engine.
+func NonVectorizedPanic(err error) {
+	panic(newNotVectorizedInternalError(err))
 }

--- a/pkg/sql/exec/execgen/cmd/execgen/avg_agg_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/avg_agg_gen.go
@@ -19,6 +19,7 @@ import (
 	"text/template"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -37,7 +38,7 @@ func (a avgAggTmplInfo) AssignDivInt64(target, l, r string) string {
 		return fmt.Sprintf(
 			`%s.SetInt64(%s)
 if _, err := tree.DecimalCtx.Quo(&%s, &%s, &%s); err != nil {
-			panic(err)
+			execerror.VectorizedInternalPanic(err)
 		}`,
 			target, r, target, l, target,
 		)
@@ -47,7 +48,9 @@ if _, err := tree.DecimalCtx.Quo(&%s, &%s, &%s); err != nil {
 	case coltypes.Float64:
 		return fmt.Sprintf("%s = %s / float64(%s)", target, l, r)
 	default:
-		panic("unsupported avg agg type")
+		execerror.VectorizedInternalPanic("unsupported avg agg type")
+		// This code is unreachable, but the compiler cannot infer that.
+		return ""
 	}
 }
 

--- a/pkg/sql/exec/execgen/cmd/execgen/main.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/main.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/pkg/errors"
 )
 
@@ -52,7 +53,7 @@ var generators = make(map[string]generator)
 
 func registerGenerator(g generator, filename string) {
 	if _, ok := generators[filename]; ok {
-		panic(fmt.Sprintf("%s generator already registered", filename))
+		execerror.VectorizedInternalPanic(fmt.Sprintf("%s generator already registered", filename))
 	}
 	generators[filename] = g
 }

--- a/pkg/sql/exec/execgen/cmd/execgen/overloads_test_utils_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/overloads_test_utils_gen.go
@@ -24,6 +24,7 @@ import (
   "math"
 
 	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 

--- a/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/typeconv"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/pkg/errors"

--- a/pkg/sql/exec/execgen/placeholders.go
+++ b/pkg/sql/exec/execgen/placeholders.go
@@ -10,6 +10,8 @@
 
 package execgen
 
+import "github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
+
 const nonTemplatePanic = "do not call from non-template code"
 
 // Remove unused warnings.
@@ -28,50 +30,54 @@ var (
 
 // GET is a template function.
 func GET(target, i interface{}) interface{} {
-	panic(nonTemplatePanic)
+	execerror.VectorizedInternalPanic(nonTemplatePanic)
+	return nil
 }
 
 // SET is a template function.
 func SET(target, i, new interface{}) {
-	panic(nonTemplatePanic)
+	execerror.VectorizedInternalPanic(nonTemplatePanic)
 }
 
 // SWAP is a template function.
 func SWAP(target, i, j interface{}) {
-	panic(nonTemplatePanic)
+	execerror.VectorizedInternalPanic(nonTemplatePanic)
 }
 
 // SLICE is a template function.
 func SLICE(target, start, end interface{}) interface{} {
-	panic(nonTemplatePanic)
+	execerror.VectorizedInternalPanic(nonTemplatePanic)
+	return nil
 }
 
 // COPYSLICE is a template function.
 func COPYSLICE(target, src, destIdx, srcStartIdx, srcEndIdx interface{}) {
-	panic(nonTemplatePanic)
+	execerror.VectorizedInternalPanic(nonTemplatePanic)
 }
 
 // APPENDSLICE is a template function.
 func APPENDSLICE(target, src, destIdx, srcStartIdx, srcEndIdx interface{}) {
-	panic(nonTemplatePanic)
+	execerror.VectorizedInternalPanic(nonTemplatePanic)
 }
 
 // APPENDVAL is a template function.
 func APPENDVAL(target, v interface{}) {
-	panic(nonTemplatePanic)
+	execerror.VectorizedInternalPanic(nonTemplatePanic)
 }
 
 // LEN is a template function.
 func LEN(target interface{}) interface{} {
-	panic(nonTemplatePanic)
+	execerror.VectorizedInternalPanic(nonTemplatePanic)
+	return nil
 }
 
 // ZERO is a template function.
 func ZERO(target interface{}) {
-	panic(nonTemplatePanic)
+	execerror.VectorizedInternalPanic(nonTemplatePanic)
 }
 
 // RANGE is a template function.
 func RANGE(loopVariableIdent interface{}, target interface{}) bool {
-	panic(nonTemplatePanic)
+	execerror.VectorizedInternalPanic(nonTemplatePanic)
+	return false
 }

--- a/pkg/sql/exec/hash_aggregator.go
+++ b/pkg/sql/exec/hash_aggregator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
@@ -178,7 +179,9 @@ func (op *hashGrouper) Child(nth int) OpNode {
 	if nth == 0 {
 		return op.builder.spec.source
 	}
-	panic(fmt.Sprintf("invalid index %d", nth))
+	execerror.VectorizedInternalPanic(fmt.Sprintf("invalid index %d", nth))
+	// This code is unreachable, but the compiler cannot infer that.
+	return nil
 }
 
 func (op *hashGrouper) Init() {

--- a/pkg/sql/exec/hashjoiner.go
+++ b/pkg/sql/exec/hashjoiner.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/pkg/errors"
 )
@@ -202,7 +203,9 @@ func (hj *hashJoinEqOp) Child(nth int) OpNode {
 	case 1:
 		return hj.spec.right.source
 	}
-	panic(fmt.Sprintf("invalid idx %d", nth))
+	execerror.VectorizedInternalPanic(fmt.Sprintf("invalid idx %d", nth))
+	// This code is unreachable, but the compiler cannot infer that.
+	return nil
 }
 
 var _ Operator = &hashJoinEqOp{}
@@ -264,7 +267,9 @@ func (hj *hashJoinEqOp) Next(ctx context.Context) coldata.Batch {
 		hj.prober.batch.SetSelection(false)
 		return hj.prober.batch
 	default:
-		panic("hash joiner in unhandled state")
+		execerror.VectorizedInternalPanic("hash joiner in unhandled state")
+		// This code is unreachable, but the compiler cannot infer that.
+		return nil
 	}
 }
 

--- a/pkg/sql/exec/hashjoiner_test.go
+++ b/pkg/sql/exec/hashjoiner_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
@@ -31,7 +32,7 @@ func TestHashJoinerInt64(t *testing.T) {
 	for i, f := range floats {
 		_, err := decs[i].SetFloat64(f)
 		if err != nil {
-			panic(fmt.Sprintf("%v", err))
+			execerror.VectorizedInternalPanic(fmt.Sprintf("%v", err))
 		}
 	}
 

--- a/pkg/sql/exec/hashjoiner_tmpl.go
+++ b/pkg/sql/exec/hashjoiner_tmpl.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
@@ -52,13 +53,13 @@ type _GOTYPESLICE interface{}
 // _ASSIGN_HASH is the template equality function for assigning the first input
 // to the result of the hash value of the second input.
 func _ASSIGN_HASH(_, _ interface{}) uint64 {
-	panic("")
+	execerror.VectorizedInternalPanic("")
 }
 
 // _ASSIGN_NE is the template equality function for assigning the first input
 // to the result of the the second input != the third input.
 func _ASSIGN_NE(_, _, _ interface{}) uint64 {
-	panic("")
+	execerror.VectorizedInternalPanic("")
 }
 
 // _TYPES_T is the template type variable for coltypes.T. It will be replaced by
@@ -324,7 +325,7 @@ func (ht *hashTable) rehash(
 
 	// {{end}}
 	default:
-		panic(fmt.Sprintf("unhandled type %d", t))
+		execerror.VectorizedInternalPanic(fmt.Sprintf("unhandled type %d", t))
 	}
 }
 
@@ -360,7 +361,7 @@ func (ht *hashTable) checkCol(t coltypes.T, keyColIdx int, nToCheck uint16, sel 
 		}
 	// {{end}}
 	default:
-		panic(fmt.Sprintf("unhandled type %d", t))
+		execerror.VectorizedInternalPanic(fmt.Sprintf("unhandled type %d", t))
 	}
 }
 

--- a/pkg/sql/exec/mem_estimation.go
+++ b/pkg/sql/exec/mem_estimation.go
@@ -15,6 +15,7 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 )
 
 const (
@@ -61,7 +62,7 @@ func EstimateBatchSizeBytes(vecTypes []coltypes.T, batchLength int) int {
 			// to hold the arbitrary precision decimal objects.
 			acc += 50
 		default:
-			panic(fmt.Sprintf("unhandled type %s", t))
+			execerror.VectorizedInternalPanic(fmt.Sprintf("unhandled type %s", t))
 		}
 	}
 	return acc * batchLength

--- a/pkg/sql/exec/mergejoiner.go
+++ b/pkg/sql/exec/mergejoiner.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
@@ -210,7 +211,9 @@ func NewMergeJoinOp(
 	case sqlbase.JoinType_LEFT_ANTI:
 		return &mergeJoinLeftAntiOp{base}, err
 	default:
-		panic("unsupported join type")
+		execerror.VectorizedInternalPanic("unsupported join type")
+		// This code is unreachable, but the compiler cannot infer that.
+		return nil, nil
 	}
 }
 

--- a/pkg/sql/exec/mergejoiner_tmpl.go
+++ b/pkg/sql/exec/mergejoiner_tmpl.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
@@ -56,13 +57,13 @@ type _GOTYPE interface{}
 // _ASSIGN_EQ is the template equality function for assigning the first input
 // to the result of the the second input == the third input.
 func _ASSIGN_EQ(_, _, _ interface{}) uint64 {
-	panic("")
+	execerror.VectorizedInternalPanic("")
 }
 
 // _ASSIGN_LT is the template equality function for assigning the first input
 // to the result of the the second input < the third input.
 func _ASSIGN_LT(_, _, _ interface{}) uint64 {
-	panic("")
+	execerror.VectorizedInternalPanic("")
 }
 
 // _L_SEL_IND is the template type variable for the loop variable that
@@ -261,7 +262,7 @@ func _PROBE_SWITCH(
 		}
 	// {{end}}
 	default:
-		panic(fmt.Sprintf("unhandled type %d", colType))
+		execerror.VectorizedInternalPanic(fmt.Sprintf("unhandled type %d", colType))
 	}
 	// {{end}}
 	// {{/*
@@ -282,7 +283,7 @@ func _LEFT_UNMATCHED_GROUP_SWITCH(_JOIN_TYPE joinTypeInfo) { // */}}
 	// {{ if or $.JoinType.IsLeftOuter $.JoinType.IsLeftAnti }}
 	if lGroup.unmatched {
 		if curLIdx+1 != curLLength {
-			panic(fmt.Sprintf("unexpectedly length %d of the left unmatched group is not 1", curLLength-curLIdx))
+			execerror.VectorizedInternalPanic(fmt.Sprintf("unexpectedly length %d of the left unmatched group is not 1", curLLength-curLIdx))
 		}
 		// The row already does not have a match, so we don't need to do any
 		// additional processing.
@@ -322,7 +323,7 @@ func _RIGHT_UNMATCHED_GROUP_SWITCH(_JOIN_TYPE joinTypeInfo) { // */}}
 	// {{ if $.JoinType.IsRightOuter }}
 	if rGroup.unmatched {
 		if curRIdx+1 != curRLength {
-			panic(fmt.Sprintf("unexpectedly length %d of the right unmatched group is not 1", curRLength-curRIdx))
+			execerror.VectorizedInternalPanic(fmt.Sprintf("unexpectedly length %d of the right unmatched group is not 1", curRLength-curRIdx))
 		}
 		// The row already does not have a match, so we don't need to do any
 		// additional processing.
@@ -680,7 +681,7 @@ func _LEFT_SWITCH(_JOIN_TYPE joinTypeInfo, _HAS_SELECTION bool, _HAS_NULLS bool)
 		o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 	// {{end}}
 	default:
-		panic(fmt.Sprintf("unhandled type %d", colType))
+		execerror.VectorizedInternalPanic(fmt.Sprintf("unhandled type %d", colType))
 	}
 	// {{end}}
 	// {{/*
@@ -838,7 +839,7 @@ func _RIGHT_SWITCH(_JOIN_TYPE joinTypeInfo, _HAS_SELECTION bool, _HAS_NULLS bool
 		o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 	// {{end}}
 	default:
-		panic(fmt.Sprintf("unhandled type %d", colType))
+		execerror.VectorizedInternalPanic(fmt.Sprintf("unhandled type %d", colType))
 	}
 	// {{end}}
 	// {{/*
@@ -958,7 +959,7 @@ func (o *mergeJoinBase) isBufferedGroupFinished(
 			}
 		// {{end}}
 		default:
-			panic(fmt.Sprintf("unhandled type %d", colTyp))
+			execerror.VectorizedInternalPanic(fmt.Sprintf("unhandled type %d", colTyp))
 		}
 	}
 	return false
@@ -1266,7 +1267,7 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next(ctx context.Context) coldata.Batch {
 				return o.output
 			}
 		default:
-			panic(fmt.Sprintf("unexpected merge joiner state in Next: %v", o.state))
+			execerror.VectorizedInternalPanic(fmt.Sprintf("unexpected merge joiner state in Next: %v", o.state))
 		}
 	}
 }

--- a/pkg/sql/exec/mergejoiner_util.go
+++ b/pkg/sql/exec/mergejoiner_util.go
@@ -13,6 +13,7 @@ package exec
 import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 )
 
 // circularGroupsBuffer is a struct designed to store the groups' slices for a
@@ -227,12 +228,14 @@ type mjBufferedGroup struct {
 var _ coldata.Batch = &mjBufferedGroup{}
 
 func (bg *mjBufferedGroup) Length() uint16 {
-	panic("Length() should not be called on mjBufferedGroup; instead, " +
+	execerror.VectorizedInternalPanic("Length() should not be called on mjBufferedGroup; instead, " +
 		"length field should be accessed directly")
+	// This code is unreachable, but the compiler cannot infer that.
+	return 0
 }
 
 func (bg *mjBufferedGroup) SetLength(uint16) {
-	panic("SetLength(uint16) should not be called on mjBufferedGroup;" +
+	execerror.VectorizedInternalPanic("SetLength(uint16) should not be called on mjBufferedGroup;" +
 		"instead, length field should be accessed directly")
 }
 
@@ -257,19 +260,19 @@ func (bg *mjBufferedGroup) Selection() []uint16 {
 // SetSelection is not implemented because the tuples should only be appended
 // to mjBufferedGroup, and Append does the deselection step.
 func (bg *mjBufferedGroup) SetSelection(bool) {
-	panic("SetSelection(bool) should not be called on mjBufferedGroup")
+	execerror.VectorizedInternalPanic("SetSelection(bool) should not be called on mjBufferedGroup")
 }
 
 // AppendCol is not implemented because mjBufferedGroup is only initialized
 // when the column schema is known.
 func (bg *mjBufferedGroup) AppendCol(coltypes.T) {
-	panic("AppendCol(coltypes.T) should not be called on mjBufferedGroup")
+	execerror.VectorizedInternalPanic("AppendCol(coltypes.T) should not be called on mjBufferedGroup")
 }
 
 // Reset is not implemented because mjBufferedGroup is not reused with
 // different column schemas at the moment.
 func (bg *mjBufferedGroup) Reset(types []coltypes.T, length int) {
-	panic("Reset([]coltypes.T, int) should not be called on mjBufferedGroup")
+	execerror.VectorizedInternalPanic("Reset([]coltypes.T, int) should not be called on mjBufferedGroup")
 }
 
 // reset resets the state of the buffered group so that we can reuse the

--- a/pkg/sql/exec/min_max_agg_tmpl.go
+++ b/pkg/sql/exec/min_max_agg_tmpl.go
@@ -25,6 +25,9 @@ import (
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	// {{/*
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
+	// */}}
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/pkg/errors"
@@ -51,7 +54,7 @@ type _GOTYPESLICE interface{}
 // if the second input compares successfully to the third input. The comparison
 // operator is tree.LT for MIN and is tree.GT for MAX.
 func _ASSIGN_CMP(_, _, _ string) bool {
-	panic("")
+	execerror.VectorizedInternalPanic("")
 }
 
 // */}}

--- a/pkg/sql/exec/operator.go
+++ b/pkg/sql/exec/operator.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 )
 
 // Operator is a column vector operator that produces a Batch as output.
@@ -66,7 +67,9 @@ func (n OneInputNode) Child(nth int) OpNode {
 	if nth == 0 {
 		return n.input
 	}
-	panic(fmt.Sprintf("invalid index %d", nth))
+	execerror.VectorizedInternalPanic(fmt.Sprintf("invalid index %d", nth))
+	// This code is unreachable, but the compiler cannot infer that.
+	return nil
 }
 
 // Input returns the single input of this OneInputNode as an Operator.
@@ -84,7 +87,9 @@ func (ZeroInputNode) ChildCount() int {
 
 // Child implements the OpNode interface.
 func (ZeroInputNode) Child(nth int) OpNode {
-	panic(fmt.Sprintf("invalid index %d", nth))
+	execerror.VectorizedInternalPanic(fmt.Sprintf("invalid index %d", nth))
+	// This code is unreachable, but the compiler cannot infer that.
+	return nil
 }
 
 // newTwoInputNode returns an OpNode with two Operator inputs.
@@ -108,7 +113,9 @@ func (n *twoInputNode) Child(nth int) OpNode {
 	case 1:
 		return n.inputTwo
 	}
-	panic(fmt.Sprintf("invalid idx %d", nth))
+	execerror.VectorizedInternalPanic(fmt.Sprintf("invalid idx %d", nth))
+	// This code is unreachable, but the compiler cannot infer that.
+	return nil
 }
 
 // StaticMemoryOperator is an interface that streaming operators can implement

--- a/pkg/sql/exec/orderedsynchronizer.go
+++ b/pkg/sql/exec/orderedsynchronizer.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 )
@@ -162,7 +163,7 @@ func (o *OrderedSynchronizer) compareRow(batchIdx1 int, batchIdx2 int) int {
 			case encoding.Descending:
 				return -res
 			default:
-				panic(fmt.Sprintf("unexpected direction value %d", d))
+				execerror.VectorizedInternalPanic(fmt.Sprintf("unexpected direction value %d", d))
 			}
 		}
 	}

--- a/pkg/sql/exec/overloads_test.go
+++ b/pkg/sql/exec/overloads_test.go
@@ -14,17 +14,19 @@ import (
 	"math"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIntegerAddition(t *testing.T) {
 	// The addition overload is the same for all integer widths, so we only test
 	// one of them.
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performPlusInt16(1, math.MaxInt16) })
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performPlusInt16(-1, math.MinInt16) })
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performPlusInt16(math.MaxInt16, 1) })
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performPlusInt16(math.MinInt16, -1) })
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performPlusInt16(1, math.MaxInt16) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performPlusInt16(-1, math.MinInt16) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performPlusInt16(math.MaxInt16, 1) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performPlusInt16(math.MinInt16, -1) }))
 
 	assert.Equal(t, int16(math.MaxInt16), performPlusInt16(1, math.MaxInt16-1))
 	assert.Equal(t, int16(math.MinInt16), performPlusInt16(-1, math.MinInt16+1))
@@ -40,10 +42,10 @@ func TestIntegerAddition(t *testing.T) {
 func TestIntegerSubtraction(t *testing.T) {
 	// The subtraction overload is the same for all integer widths, so we only
 	// test one of them.
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performMinusInt16(1, -math.MaxInt16) })
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performMinusInt16(-2, math.MaxInt16) })
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performMinusInt16(math.MaxInt16, -1) })
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performMinusInt16(math.MinInt16, 1) })
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMinusInt16(1, -math.MaxInt16) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMinusInt16(-2, math.MaxInt16) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMinusInt16(math.MaxInt16, -1) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMinusInt16(math.MinInt16, 1) }))
 
 	assert.Equal(t, int16(math.MaxInt16), performMinusInt16(1, -math.MaxInt16+1))
 	assert.Equal(t, int16(math.MinInt16), performMinusInt16(-1, math.MaxInt16))
@@ -57,15 +59,15 @@ func TestIntegerSubtraction(t *testing.T) {
 }
 
 func TestIntegerDivision(t *testing.T) {
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performDivInt8(math.MinInt8, -1) })
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performDivInt16(math.MinInt16, -1) })
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performDivInt32(math.MinInt32, -1) })
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performDivInt64(math.MinInt64, -1) })
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performDivInt8(math.MinInt8, -1) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performDivInt16(math.MinInt16, -1) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performDivInt32(math.MinInt32, -1) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performDivInt64(math.MinInt64, -1) }))
 
-	assert.PanicsWithValue(t, tree.ErrDivByZero, func() { performDivInt8(10, 0) })
-	assert.PanicsWithValue(t, tree.ErrDivByZero, func() { performDivInt16(10, 0) })
-	assert.PanicsWithValue(t, tree.ErrDivByZero, func() { performDivInt32(10, 0) })
-	assert.PanicsWithValue(t, tree.ErrDivByZero, func() { performDivInt64(10, 0) })
+	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivInt8(10, 0) }))
+	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivInt16(10, 0) }))
+	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivInt32(10, 0) }))
+	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivInt64(10, 0) }))
 
 	assert.Equal(t, int8(-math.MaxInt8), performDivInt8(math.MaxInt8, -1))
 	assert.Equal(t, int16(-math.MaxInt16), performDivInt16(math.MaxInt16, -1))
@@ -79,30 +81,30 @@ func TestIntegerDivision(t *testing.T) {
 }
 
 func TestIntegerMultiplication(t *testing.T) {
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performMultInt8(math.MaxInt8-1, 100) })
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performMultInt8(math.MaxInt8-1, 3) })
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performMultInt8(math.MinInt8+1, 3) })
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performMultInt8(math.MinInt8+1, 100) })
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt8(math.MaxInt8-1, 100) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt8(math.MaxInt8-1, 3) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt8(math.MinInt8+1, 3) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt8(math.MinInt8+1, 100) }))
 
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performMultInt16(math.MaxInt16-1, 100) })
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performMultInt16(math.MaxInt16-1, 3) })
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performMultInt16(math.MinInt16+1, 3) })
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performMultInt16(math.MinInt16+1, 100) })
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16(math.MaxInt16-1, 100) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16(math.MaxInt16-1, 3) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16(math.MinInt16+1, 3) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16(math.MinInt16+1, 100) }))
 
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performMultInt32(math.MaxInt32-1, 100) })
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performMultInt32(math.MaxInt32-1, 3) })
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performMultInt32(math.MinInt32+1, 3) })
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performMultInt32(math.MinInt32+1, 100) })
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt32(math.MaxInt32-1, 100) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt32(math.MaxInt32-1, 3) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt32(math.MinInt32+1, 3) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt32(math.MinInt32+1, 100) }))
 
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performMultInt64(math.MaxInt64-1, 100) })
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performMultInt64(math.MaxInt64-1, 3) })
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performMultInt64(math.MinInt64+1, 3) })
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performMultInt64(math.MinInt64+1, 100) })
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt64(math.MaxInt64-1, 100) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt64(math.MaxInt64-1, 3) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt64(math.MinInt64+1, 3) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt64(math.MinInt64+1, 100) }))
 
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performMultInt8(math.MinInt8, -1) })
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performMultInt16(math.MinInt16, -1) })
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performMultInt32(math.MinInt32, -1) })
-	assert.PanicsWithValue(t, tree.ErrIntOutOfRange, func() { performMultInt64(math.MinInt64, -1) })
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt8(math.MinInt8, -1) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16(math.MinInt16, -1) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt32(math.MinInt32, -1) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt64(math.MinInt64, -1) }))
 
 	assert.Equal(t, int8(-math.MaxInt8), performMultInt8(math.MaxInt8, -1))
 	assert.Equal(t, int16(-math.MaxInt16), performMultInt16(math.MaxInt16, -1))

--- a/pkg/sql/exec/partitioner.go
+++ b/pkg/sql/exec/partitioner.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 )
 
 // NewWindowSortingPartitioner creates a new exec.Operator that orders input
@@ -75,7 +76,7 @@ func (p *windowSortingPartitioner) Next(ctx context.Context) coldata.Batch {
 	if p.partitionColIdx == b.Width() {
 		b.AppendCol(coltypes.Bool)
 	} else if p.partitionColIdx > b.Width() {
-		panic("unexpected: column partitionColIdx is neither present nor the next to be appended")
+		execerror.VectorizedInternalPanic("unexpected: column partitionColIdx is neither present nor the next to be appended")
 	}
 	partitionVec := b.ColVec(p.partitionColIdx).Bool()
 	sel := b.Selection()

--- a/pkg/sql/exec/random_testutils.go
+++ b/pkg/sql/exec/random_testutils.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 )
 
 // maxVarLen specifies a length limit for variable length types (e.g. byte slices).
@@ -94,7 +95,7 @@ func randomVec(rng *rand.Rand, typ coltypes.T, vec coldata.Vec, n int, nullProba
 			floats[i] = rng.Float64()
 		}
 	default:
-		panic(fmt.Sprintf("unhandled type %s", typ))
+		execerror.VectorizedInternalPanic(fmt.Sprintf("unhandled type %s", typ))
 	}
 	vec.Nulls().UnsetNulls()
 	if nullProbability == 0 {
@@ -128,7 +129,7 @@ func RandomBatch(rng *rand.Rand, typs []coltypes.T, n int, nullProbability float
 // less than batchSize.
 func randomSel(rng *rand.Rand, batchSize uint16, probOfOmitting float64) []uint16 {
 	if probOfOmitting < 0 || probOfOmitting > 1 {
-		panic(fmt.Sprintf("probability of omitting a row is %f - outside of [0, 1] range", probOfOmitting))
+		execerror.VectorizedInternalPanic(fmt.Sprintf("probability of omitting a row is %f - outside of [0, 1] range", probOfOmitting))
 	}
 	sel := make([]uint16, batchSize)
 	used := make([]bool, batchSize)

--- a/pkg/sql/exec/routers.go
+++ b/pkg/sql/exec/routers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
@@ -75,7 +76,9 @@ func (o *routerOutputOp) Child(nth int) OpNode {
 	if nth == 0 {
 		return o.input
 	}
-	panic(fmt.Sprintf("invalid index %d", nth))
+	execerror.VectorizedInternalPanic(fmt.Sprintf("invalid index %d", nth))
+	// This code is unreachable, but the compiler cannot infer that.
+	return nil
 }
 
 var _ Operator = &routerOutputOp{}
@@ -396,7 +399,7 @@ func (r *HashRouter) Run(ctx context.Context) {
 			}
 		}
 
-		if err := CatchVectorizedRuntimeError(processNextBatch); err != nil {
+		if err := execerror.CatchVectorizedRuntimeError(processNextBatch); err != nil {
 			cancelOutputs(err)
 			return
 		}

--- a/pkg/sql/exec/rowstovec_tmpl.go
+++ b/pkg/sql/exec/rowstovec_tmpl.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -99,14 +100,14 @@ func EncDatumRowsToColVec(
 			_ROWS_TO_COL_VEC(rows, vec, columnIdx, columnType, alloc)
 		// {{end}}
 		default:
-			panic(fmt.Sprintf("unsupported width %d for column type %s", columnType.Width(), columnType.String()))
+			execerror.VectorizedInternalPanic(fmt.Sprintf("unsupported width %d for column type %s", columnType.Width(), columnType.String()))
 		}
 		// {{ else }}
 		_ROWS_TO_COL_VEC(rows, vec, columnIdx, columnType, alloc)
 		// {{end}}
 	// {{end}}
 	default:
-		panic(fmt.Sprintf("unsupported column type %s", columnType.String()))
+		execerror.VectorizedInternalPanic(fmt.Sprintf("unsupported column type %s", columnType.String()))
 	}
 	return nil
 }

--- a/pkg/sql/exec/select_in_tmpl.go
+++ b/pkg/sql/exec/select_in_tmpl.go
@@ -11,7 +11,7 @@
 // {{/*
 // +build execgen_template
 //
-// This file is the execgen template for distinct.eg.go. It's formatted in a
+// This file is the execgen template for select_in.eg.go. It's formatted in a
 // special way, so it's both valid Go and a valid text/template input. This
 // permits editing this file with editor support.
 //
@@ -26,6 +26,9 @@ import (
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	// {{/*
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
+	// */}}
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -48,7 +51,7 @@ var _ coltypes.T
 var _ bytes.Buffer
 
 func _ASSIGN_EQ(_, _, _ interface{}) uint64 {
-	panic("")
+	execerror.VectorizedInternalPanic("")
 }
 
 // */}}

--- a/pkg/sql/exec/simple_project.go
+++ b/pkg/sql/exec/simple_project.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 )
 
 // simpleProjectOp is an operator that implements "simple projection" - removal of
@@ -47,7 +48,9 @@ func (b *projectingBatch) ColVec(i int) coldata.Vec {
 }
 
 func (b *projectingBatch) ColVecs() []coldata.Vec {
-	panic("projectingBatch doesn't support ColVecs()")
+	execerror.VectorizedInternalPanic("projectingBatch doesn't support ColVecs()")
+	// This code is unreachable, but the compiler cannot infer that.
+	return nil
 }
 
 func (b *projectingBatch) Width() int {

--- a/pkg/sql/exec/sort.go
+++ b/pkg/sql/exec/sort.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/pkg/errors"
 )
 
@@ -111,7 +112,7 @@ func (p *allSpooler) init() {
 
 func (p *allSpooler) spool(ctx context.Context) {
 	if p.spooled {
-		panic("spool() is called for the second time")
+		execerror.VectorizedInternalPanic("spool() is called for the second time")
 	}
 	p.spooled = true
 	batch := p.input.Next(ctx)
@@ -135,21 +136,21 @@ func (p *allSpooler) spool(ctx context.Context) {
 
 func (p *allSpooler) getValues(i int) coldata.Vec {
 	if !p.spooled {
-		panic("getValues() is called before spool()")
+		execerror.VectorizedInternalPanic("getValues() is called before spool()")
 	}
 	return p.values[i]
 }
 
 func (p *allSpooler) getNumTuples() uint64 {
 	if !p.spooled {
-		panic("getNumTuples() is called before spool()")
+		execerror.VectorizedInternalPanic("getNumTuples() is called before spool()")
 	}
 	return p.spooledTuples
 }
 
 func (p *allSpooler) getPartitionsCol() []bool {
 	if !p.spooled {
-		panic("getPartitionsCol() is called before spool()")
+		execerror.VectorizedInternalPanic("getPartitionsCol() is called before spool()")
 	}
 	return nil
 }
@@ -261,7 +262,9 @@ func (p *sortOp) Next(ctx context.Context) coldata.Batch {
 		p.emitted = newEmitted
 		return p.output
 	}
-	panic(fmt.Sprintf("invalid sort state %v", p.state))
+	execerror.VectorizedInternalPanic(fmt.Sprintf("invalid sort state %v", p.state))
+	// This code is unreachable, but the compiler cannot infer that.
+	return nil
 }
 
 // sort sorts the spooled tuples, so it must be called after spool() has been
@@ -377,5 +380,7 @@ func (p *sortOp) Child(nth int) OpNode {
 	if nth == 0 {
 		return p.input
 	}
-	panic(fmt.Sprintf("invalid index %d", nth))
+	execerror.VectorizedInternalPanic(fmt.Sprintf("invalid index %d", nth))
+	// This code is unreachable, but the compiler cannot infer that.
+	return nil
 }

--- a/pkg/sql/exec/sort_chunks.go
+++ b/pkg/sql/exec/sort_chunks.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 )
 
 // NewSortChunks returns a new sort chunks operator, which sorts its input on
@@ -32,7 +33,7 @@ func NewSortChunks(
 		return input, nil
 	}
 	if matchLen < 1 {
-		panic(fmt.Sprintf("Sort Chunks should only be used when the input is "+
+		execerror.VectorizedInternalPanic(fmt.Sprintf("Sort Chunks should only be used when the input is "+
 			"already ordered on at least one column. matchLen = %d was given.",
 			matchLen))
 	}
@@ -60,7 +61,9 @@ func (c *sortChunksOp) Child(nth int) OpNode {
 	if nth == 0 {
 		return c.input
 	}
-	panic(fmt.Sprintf("invalid index %d", nth))
+	execerror.VectorizedInternalPanic(fmt.Sprintf("invalid index %d", nth))
+	// This code is unreachable, but the compiler cannot infer that.
+	return nil
 }
 
 var _ Operator = &sortChunksOp{}
@@ -248,7 +251,7 @@ func (s *chunker) prepareNextChunks(ctx context.Context) chunkerReadingState {
 			if s.batch.Selection() != nil {
 				// We assume that the input has been deselected, so the batch should
 				// never have a selection vector set.
-				panic(fmt.Sprintf("unexpected: batch with non-nil selection vector"))
+				execerror.VectorizedInternalPanic(fmt.Sprintf("unexpected: batch with non-nil selection vector"))
 			}
 
 			// First, run the partitioners on our pre-sorted columns to determine the
@@ -288,7 +291,7 @@ func (s *chunker) prepareNextChunks(ctx context.Context) chunkerReadingState {
 						0, /* bTupleIdx */
 						&differ,
 					); err != nil {
-						panic(err)
+						execerror.VectorizedInternalPanic(err)
 					}
 				}
 				if differ {
@@ -343,11 +346,11 @@ func (s *chunker) prepareNextChunks(ctx context.Context) chunkerReadingState {
 				if s.inputDone {
 					return inputDone
 				}
-				panic(fmt.Sprintf("unexpected: chunkerEmittingFromBatch state" +
+				execerror.VectorizedInternalPanic(fmt.Sprintf("unexpected: chunkerEmittingFromBatch state" +
 					"when s.chunks is fully processed and input is not done"))
 			}
 		default:
-			panic(fmt.Sprintf("invalid chunker spooler state %v", s.state))
+			execerror.VectorizedInternalPanic(fmt.Sprintf("invalid chunker spooler state %v", s.state))
 		}
 	}
 }
@@ -380,7 +383,9 @@ func (s *chunker) getValues(i int) coldata.Vec {
 	case chunkerReadFromBatch:
 		return s.batch.ColVec(i).Slice(s.inputTypes[i], s.chunks[s.chunksStartIdx], s.chunks[len(s.chunks)-1])
 	default:
-		panic(fmt.Sprintf("unexpected chunkerReadingState in getValues: %v", s.state))
+		execerror.VectorizedInternalPanic(fmt.Sprintf("unexpected chunkerReadingState in getValues: %v", s.state))
+		// This code is unreachable, but the compiler cannot infer that.
+		return nil
 	}
 }
 
@@ -393,7 +398,9 @@ func (s *chunker) getNumTuples() uint64 {
 	case inputDone:
 		return 0
 	default:
-		panic(fmt.Sprintf("unexpected chunkerReadingState in getNumTuples: %v", s.state))
+		execerror.VectorizedInternalPanic(fmt.Sprintf("unexpected chunkerReadingState in getNumTuples: %v", s.state))
+		// This code is unreachable, but the compiler cannot infer that.
+		return 0
 	}
 }
 
@@ -417,7 +424,9 @@ func (s *chunker) getPartitionsCol() []bool {
 		}
 		return s.partitionCol
 	default:
-		panic(fmt.Sprintf("unexpected chunkerReadingState in getPartitionsCol: %v", s.state))
+		execerror.VectorizedInternalPanic(fmt.Sprintf("unexpected chunkerReadingState in getPartitionsCol: %v", s.state))
+		// This code is unreachable, but the compiler cannot infer that.
+		return nil
 	}
 }
 

--- a/pkg/sql/exec/sort_test.go
+++ b/pkg/sql/exec/sort_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
@@ -401,7 +402,7 @@ func generateColumnOrdering(
 	rng *rand.Rand, nCols int, nOrderingCols int,
 ) []distsqlpb.Ordering_Column {
 	if nOrderingCols > nCols {
-		panic("nOrderingCols > nCols in generateColumnOrdering")
+		execerror.VectorizedInternalPanic("nOrderingCols > nCols in generateColumnOrdering")
 	}
 	orderingCols := make([]distsqlpb.Ordering_Column, nOrderingCols)
 	for i, col := range rng.Perm(nCols)[:nOrderingCols] {

--- a/pkg/sql/exec/sort_tmpl.go
+++ b/pkg/sql/exec/sort_tmpl.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
@@ -61,7 +62,7 @@ const _ISNULL = false
 // _ASSIGN_LT is the template equality function for assigning the first input
 // to the result of the second input < the third input.
 func _ASSIGN_LT(_, _, _ string) bool {
-	panic("")
+	execerror.VectorizedInternalPanic("")
 }
 
 // */}}
@@ -102,16 +103,18 @@ func newSingleSorter(
 				return &sort_TYPE_DIR_HANDLES_NULLSOp{}
 			// {{end}}
 			default:
-				panic("nulls switch failed")
+				execerror.VectorizedInternalPanic("nulls switch failed")
 			}
 			// {{end}}
 		default:
-			panic("nulls switch failed")
+			execerror.VectorizedInternalPanic("nulls switch failed")
 		}
 	// {{end}}
 	default:
-		panic("nulls switch failed")
+		execerror.VectorizedInternalPanic("nulls switch failed")
 	}
+	// This code is unreachable, but the compiler cannot infer that.
+	return nil
 }
 
 // {{range $typ, $ := . }} {{/* for each type */}}
@@ -138,7 +141,7 @@ func (s *sort_TYPE_DIR_HANDLES_NULLSOp) sort(ctx context.Context) {
 
 func (s *sort_TYPE_DIR_HANDLES_NULLSOp) sortPartitions(ctx context.Context, partitions []uint64) {
 	if len(partitions) < 1 {
-		panic(fmt.Sprintf("invalid partitions list %v", partitions))
+		execerror.VectorizedInternalPanic(fmt.Sprintf("invalid partitions list %v", partitions))
 	}
 	order := s.order
 	for i, partitionStart := range partitions {

--- a/pkg/sql/exec/sorttopk.go
+++ b/pkg/sql/exec/sorttopk.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 )
 
 const (
@@ -98,7 +99,9 @@ func (t *topKSorter) Next(ctx context.Context) coldata.Batch {
 	case topKSortEmitting:
 		return t.emit()
 	}
-	panic(fmt.Sprintf("invalid sort state %v", t.state))
+	execerror.VectorizedInternalPanic(fmt.Sprintf("invalid sort state %v", t.state))
+	// This code is unreachable, but the compiler cannot infer that.
+	return nil
 }
 
 // spool reads in the entire input, always storing the top K rows it has seen so
@@ -223,7 +226,7 @@ func (t *topKSorter) compareRow(vecIdx1, vecIdx2 int, rowIdx1, rowIdx2 uint16) i
 			case distsqlpb.Ordering_Column_DESC:
 				return -res
 			default:
-				panic(fmt.Sprintf("unexpected direction value %d", d))
+				execerror.VectorizedInternalPanic(fmt.Sprintf("unexpected direction value %d", d))
 			}
 		}
 	}

--- a/pkg/sql/exec/stats.go
+++ b/pkg/sql/exec/stats.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execpb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
@@ -48,7 +49,7 @@ func NewVectorizedStatsCollector(
 	op Operator, id int32, isStall bool, inputWatch *timeutil.StopWatch,
 ) *VectorizedStatsCollector {
 	if inputWatch == nil {
-		panic("input watch for VectorizedStatsCollector is nil")
+		execerror.VectorizedInternalPanic("input watch for VectorizedStatsCollector is nil")
 	}
 	return &VectorizedStatsCollector{
 		Operator:        op,

--- a/pkg/sql/exec/sum_agg_tmpl.go
+++ b/pkg/sql/exec/sum_agg_tmpl.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/pkg/errors"
 )
@@ -39,7 +40,7 @@ var _ tree.Datum
 // _ASSIGN_ADD is the template addition function for assigning the first input
 // to the result of the second input + the third input.
 func _ASSIGN_ADD(_, _, _ string) {
-	panic("")
+	execerror.VectorizedInternalPanic("")
 }
 
 // */}}

--- a/pkg/sql/exec/tuples_differ_tmpl.go
+++ b/pkg/sql/exec/tuples_differ_tmpl.go
@@ -24,6 +24,9 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	// {{/*
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
+	// */}}
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/pkg/errors"
@@ -51,7 +54,7 @@ const _TYPES_T = coltypes.Unhandled
 // _ASSIGN_NE is the template equality function for assigning the first input
 // to the result of the second input != the third input.
 func _ASSIGN_NE(_, _, _ string) bool {
-	panic("")
+	execerror.VectorizedInternalPanic("")
 }
 
 // */}}

--- a/pkg/sql/exec/typeconv/typeconv.go
+++ b/pkg/sql/exec/typeconv/typeconv.go
@@ -15,6 +15,7 @@ import (
 	"reflect"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -43,7 +44,7 @@ func FromColumnType(ct *types.T) coltypes.T {
 		case 0, 64:
 			return coltypes.Int64
 		}
-		panic(fmt.Sprintf("integer with unknown width %d", ct.Width()))
+		execerror.VectorizedInternalPanic(fmt.Sprintf("integer with unknown width %d", ct.Width()))
 	case types.FloatFamily:
 		return coltypes.Float64
 	}
@@ -118,7 +119,7 @@ func GetDatumToPhysicalFn(ct *types.T) func(tree.Datum) (interface{}, error) {
 				return int64(*d), nil
 			}
 		}
-		panic(fmt.Sprintf("unhandled INT width %d", ct.Width()))
+		execerror.VectorizedInternalPanic(fmt.Sprintf("unhandled INT width %d", ct.Width()))
 	case types.DateFamily:
 		return func(datum tree.Datum) (interface{}, error) {
 			d, ok := datum.(*tree.DDate)

--- a/pkg/sql/exec/unorderedsynchronizer.go
+++ b/pkg/sql/exec/unorderedsynchronizer.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 )
 
@@ -153,7 +154,7 @@ func (s *UnorderedSynchronizer) init(ctx context.Context) {
 				inputIdx: inputIdx,
 			}
 			for {
-				if err := CatchVectorizedRuntimeError(s.nextBatch[inputIdx]); err != nil {
+				if err := execerror.CatchVectorizedRuntimeError(s.nextBatch[inputIdx]); err != nil {
 					select {
 					// Non-blocking write to errCh, if an error is present the main
 					// goroutine will use that and cancel all inputs.
@@ -216,7 +217,7 @@ func (s *UnorderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 			// propagate this error through a panic.
 			s.cancelFn()
 			s.internalWaitGroup.Wait()
-			panic(err)
+			execerror.VectorizedInternalPanic(err)
 		}
 	case msg := <-s.batchCh:
 		if msg == nil {
@@ -226,7 +227,7 @@ func (s *UnorderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 			select {
 			case err := <-s.errCh:
 				if err != nil {
-					panic(err)
+					execerror.VectorizedInternalPanic(err)
 				}
 			default:
 			}

--- a/pkg/sql/exec/utils_test.go
+++ b/pkg/sql/exec/utils_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -218,7 +219,7 @@ func newOpTestSelInput(rng *rand.Rand, batchSize uint16, tuples tuples) *opTestI
 
 func (s *opTestInput) Init() {
 	if len(s.tuples) == 0 {
-		panic("empty tuple source")
+		execerror.VectorizedInternalPanic("empty tuple source")
 	}
 
 	typs := make([]coltypes.T, len(s.tuples[0]))
@@ -259,7 +260,7 @@ func (s *opTestInput) Next(context.Context) coldata.Batch {
 	tupleLen := len(tups[0])
 	for i := range tups {
 		if len(tups[i]) != tupleLen {
-			panic(fmt.Sprintf("mismatched tuple lens: found %+v expected %d vals",
+			execerror.VectorizedInternalPanic(fmt.Sprintf("mismatched tuple lens: found %+v expected %d vals",
 				tups[i], tupleLen))
 		}
 	}
@@ -312,7 +313,7 @@ func (s *opTestInput) Next(context.Context) coldata.Batch {
 					d := apd.Decimal{}
 					_, err := d.SetFloat64(rng.Float64())
 					if err != nil {
-						panic(fmt.Sprintf("%v", err))
+						execerror.VectorizedInternalPanic(fmt.Sprintf("%v", err))
 					}
 					col.Index(int(outputIdx)).Set(reflect.ValueOf(d))
 				} else if typ == coltypes.Bytes {
@@ -322,7 +323,7 @@ func (s *opTestInput) Next(context.Context) coldata.Batch {
 				} else if val, ok := quick.Value(reflect.TypeOf(vec.Col()).Elem(), rng); ok {
 					setColVal(vec, int(outputIdx), val.Interface())
 				} else {
-					panic(fmt.Sprintf("could not generate a random value of type %T\n.", vec.Type()))
+					execerror.VectorizedInternalPanic(fmt.Sprintf("could not generate a random value of type %T\n.", vec.Type()))
 				}
 			} else {
 				setColVal(vec, int(outputIdx), tups[j][i])
@@ -365,7 +366,7 @@ func newOpFixedSelTestInput(sel []uint16, batchSize uint16, tuples tuples) *opFi
 
 func (s *opFixedSelTestInput) Init() {
 	if len(s.tuples) == 0 {
-		panic("empty tuple source")
+		execerror.VectorizedInternalPanic("empty tuple source")
 	}
 
 	typs := make([]coltypes.T, len(s.tuples[0]))
@@ -386,7 +387,7 @@ func (s *opFixedSelTestInput) Init() {
 	tupleLen := len(s.tuples[0])
 	for _, i := range s.sel {
 		if len(s.tuples[i]) != tupleLen {
-			panic(fmt.Sprintf("mismatched tuple lens: found %+v expected %d vals",
+			execerror.VectorizedInternalPanic(fmt.Sprintf("mismatched tuple lens: found %+v expected %d vals",
 				s.tuples[i], tupleLen))
 		}
 	}

--- a/pkg/sql/exec/vec_comparators_tmpl.go
+++ b/pkg/sql/exec/vec_comparators_tmpl.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
@@ -46,7 +47,7 @@ var _ tree.Datum
 // _COMPARE is the template equality function for assigning the first input
 // to the result of comparing second and third inputs.
 func _COMPARE(_, _, _ string) bool {
-	panic("")
+	execerror.VectorizedInternalPanic("")
 }
 
 // */}}
@@ -104,5 +105,7 @@ func GetVecComparator(t coltypes.T, numVecs int) vecComparator {
 		}
 		// {{end}}
 	}
-	panic(fmt.Sprintf("unhandled type %v", t))
+	execerror.VectorizedInternalPanic(fmt.Sprintf("unhandled type %v", t))
+	// This code is unreachable, but the compiler cannot infer that.
+	return nil
 }

--- a/pkg/sql/exec/vec_elem_to_datum.go
+++ b/pkg/sql/exec/vec_elem_to_datum.go
@@ -15,6 +15,7 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -60,6 +61,8 @@ func PhysicalTypeColElemToDatum(
 	case types.OidFamily:
 		return da.NewDOid(tree.MakeDOid(tree.DInt(col.Int64()[rowIdx])))
 	default:
-		panic(fmt.Sprintf("Unsupported column type %s", ct.String()))
+		execerror.VectorizedInternalPanic(fmt.Sprintf("Unsupported column type %s", ct.String()))
+		// This code is unreachable, but the compiler cannot infer that.
+		return nil
 	}
 }

--- a/pkg/sql/exec/vecbuiltins/rank_tmpl.go
+++ b/pkg/sql/exec/vecbuiltins/rank_tmpl.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 )
 
 // {{/*
@@ -32,13 +33,13 @@ import (
 // _UPDATE_RANK_ is the template function for updating the state of rank
 // operators.
 func _UPDATE_RANK_() {
-	panic("")
+	execerror.VectorizedInternalPanic("")
 }
 
 // _UPDATE_RANK_INCREMENT is the template function for updating the state of
 // rank operators.
 func _UPDATE_RANK_INCREMENT() {
-	panic("")
+	execerror.VectorizedInternalPanic("")
 }
 
 // */}}
@@ -87,7 +88,7 @@ func (r *_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 	if r.partitionColIdx == batch.Width() {
 		batch.AppendCol(coltypes.Bool)
 	} else if r.partitionColIdx > batch.Width() {
-		panic("unexpected: column partitionColIdx is neither present nor the next to be appended")
+		execerror.VectorizedInternalPanic("unexpected: column partitionColIdx is neither present nor the next to be appended")
 	}
 	partitionCol := batch.ColVec(r.partitionColIdx).Bool()
 	// {{ end }}
@@ -95,7 +96,7 @@ func (r *_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 	if r.outputColIdx == batch.Width() {
 		batch.AppendCol(coltypes.Int64)
 	} else if r.outputColIdx > batch.Width() {
-		panic("unexpected: column outputColIdx is neither present nor the next to be appended")
+		execerror.VectorizedInternalPanic("unexpected: column outputColIdx is neither present nor the next to be appended")
 	}
 	rankCol := batch.ColVec(r.outputColIdx).Int64()
 	sel := batch.Selection()

--- a/pkg/sql/exec/vecbuiltins/row_number_tmpl.go
+++ b/pkg/sql/exec/vecbuiltins/row_number_tmpl.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 )
 
 // {{ range . }}
@@ -44,7 +45,7 @@ func (r *_ROW_NUMBER_STRINGOp) Next(ctx context.Context) coldata.Batch {
 	if r.partitionColIdx == batch.Width() {
 		batch.AppendCol(coltypes.Bool)
 	} else if r.partitionColIdx > batch.Width() {
-		panic("unexpected: column partitionColIdx is neither present nor the next to be appended")
+		execerror.VectorizedInternalPanic("unexpected: column partitionColIdx is neither present nor the next to be appended")
 	}
 	partitionCol := batch.ColVec(r.partitionColIdx).Bool()
 	// {{ end }}
@@ -52,7 +53,7 @@ func (r *_ROW_NUMBER_STRINGOp) Next(ctx context.Context) coldata.Batch {
 	if r.outputColIdx == batch.Width() {
 		batch.AppendCol(coltypes.Int64)
 	} else if r.outputColIdx > batch.Width() {
-		panic("unexpected: column outputColIdx is neither present nor the next to be appended")
+		execerror.VectorizedInternalPanic("unexpected: column outputColIdx is neither present nor the next to be appended")
 	}
 	rowNumberCol := batch.ColVec(r.outputColIdx).Int64()
 	sel := batch.Selection()

--- a/pkg/sql/row/cfetcher.go
+++ b/pkg/sql/row/cfetcher.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/colencoding"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/scrub"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -558,7 +559,7 @@ func (rf *CFetcher) NextBatch(ctx context.Context) (coldata.Batch, error) {
 		case stateInitFetch:
 			moreKeys, kv, newSpan, err := rf.fetcher.nextKV(ctx)
 			if err != nil {
-				return nil, exec.NewStorageError(err)
+				return nil, execerror.NewStorageError(err)
 			}
 			if !moreKeys {
 				rf.machine.state[0] = stateEmitLastBatch
@@ -660,7 +661,7 @@ func (rf *CFetcher) NextBatch(ctx context.Context) (coldata.Batch, error) {
 			for {
 				moreRows, kv, _, err := rf.fetcher.nextKV(ctx)
 				if err != nil {
-					return nil, exec.NewStorageError(err)
+					return nil, execerror.NewStorageError(err)
 				}
 				if debugState {
 					log.Infof(ctx, "found kv %s, seeking to prefix %s", kv.Key, rf.machine.seekPrefix)
@@ -683,7 +684,7 @@ func (rf *CFetcher) NextBatch(ctx context.Context) (coldata.Batch, error) {
 		case stateFetchNextKVWithUnfinishedRow:
 			moreKVs, kv, _, err := rf.fetcher.nextKV(ctx)
 			if err != nil {
-				return nil, exec.NewStorageError(err)
+				return nil, execerror.NewStorageError(err)
 			}
 			if !moreKVs {
 				// No more data. Finalize the row and exit.

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1450,4 +1450,37 @@ func TestLint(t *testing.T) {
 			stream.GrepNot(`pkg/.*_test\.go:`),
 		})
 	})
+
+	t.Run("TestVectorizedPanics", func(t *testing.T) {
+		t.Parallel()
+		cmd, stderr, filter, err := dirCmd(
+			pkgDir,
+			"git",
+			"grep",
+			"-nE",
+			fmt.Sprintf(`panic\(.*\)`),
+			"--",
+			"sql/exec",
+			":!sql/exec/execerror/error.go",
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := stream.ForEach(filter, func(s string) {
+			t.Errorf("\n%s <- forbidden; use either execerror.VectorizedInternalPanic() or execerror.NonVectorizedPanic() instead", s)
+		}); err != nil {
+			t.Error(err)
+		}
+
+		if err := cmd.Wait(); err != nil {
+			if out := stderr.String(); len(out) > 0 {
+				t.Fatalf("err=%s, stderr=%s", err, out)
+			}
+		}
+	})
 }


### PR DESCRIPTION
Previously, all errors (except for the ones originated below SQL
layer) without PG codes would be treated as "internal errors"
and would be returned to the client with the stack trace. However,
in a few places, those errors are not caused by the vectorized
engine, and we would like to simply propagate the errors.

In order to distinguish whether an error is caused by the vectorized
engine, two new "panic" functions are introduced. All code within
pkg/sql/exec is now required to use one of the two, and the usage
of Golang's panic function is prohibited with a linter.

Fixes: #39422.

Release note: None