### PR TITLE
row: fix decoding bug with cfetcher and wide rows

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -624,3 +624,19 @@ CREATE TABLE nocols(x INT); ALTER TABLE nocols DROP COLUMN x
 query I
 SELECT 1, * FROM nocols
 ----
+
+# ------------------------------------------------------------------------------
+# Wide tables can tickle edge cases.
+# ------------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE wide (id INT4 NOT NULL, a INT4, b VARCHAR(255), c INT4, d VARCHAR(255), e VARCHAR(255), f INT4, g VARCHAR(255), h VARCHAR(255), i VARCHAR(255), j VARCHAR(255), k INT4,
+                   l FLOAT4, m FLOAT8, n INT2, PRIMARY KEY (id))
+
+statement ok
+INSERT INTO wide(id, n) VALUES(0, 10)
+
+query IITITTITTTTIFFI
+SELECT * FROM wide
+----
+0  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL  10

--- a/pkg/sql/row/cfetcher.go
+++ b/pkg/sql/row/cfetcher.go
@@ -1007,15 +1007,15 @@ func (rf *CFetcher) processValueBytes(
 	}
 
 	var (
-		colIDDiff              uint32
-		lastColID              sqlbase.ColumnID
-		typeOffset, dataOffset int
-		typ                    encoding.Type
-		lastColIDIndex         int
-		lastNeededColIndex     int
+		colIDDiff          uint32
+		lastColID          sqlbase.ColumnID
+		dataOffset         int
+		typ                encoding.Type
+		lastColIDIndex     int
+		lastNeededColIndex int
 	)
 	for len(valueBytes) > 0 && rf.machine.remainingValueColsByIdx.Len() > 0 {
-		typeOffset, dataOffset, colIDDiff, typ, err = encoding.DecodeValueTag(valueBytes)
+		_, dataOffset, colIDDiff, typ, err = encoding.DecodeValueTag(valueBytes)
 		if err != nil {
 			return "", "", err
 		}
@@ -1062,7 +1062,7 @@ func (rf *CFetcher) processValueBytes(
 
 		valTyp := &table.cols[idx].Type
 		valueBytes, err = colencoding.DecodeTableValueToCol(vec, rf.machine.rowIdx, typ, dataOffset, valTyp,
-			valueBytes[typeOffset:])
+			valueBytes)
 		if err != nil {
 			return "", "", err
 		}


### PR DESCRIPTION
CFetcher was failing to properly decode value columns of tables that had
more than 8 columns due to an indexing bug that only manifested when the
value tag (the column id and tag, encoded as a varint) was more than a
single byte, which only occurs when the column id or type id is large
enough.

I'm not quite sure how this didn't come up before, since TPCH has tables
with more than 8 columns.

Updates #38288.

Release note: None