### PR TITLE
importccl: Resolves some flakes introduced by IMPORT INTO tests.

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1860,12 +1860,12 @@ func TestImportIntoCSV(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE t (a INT PRIMARY KEY, b STRING)`)
 
 		sqlDB.Exec(t,
-			fmt.Sprintf(`IMPORT INTO t (a, b) CSV DATA (%s)`, testFiles.files[0]),
+			fmt.Sprintf(`IMPORT INTO t (a, b) CSV DATA (%s) WITH experimental_direct_ingestion`, testFiles.files[0]),
 		)
 
 		sqlDB.ExpectErr(
-			t, `ingested key collides with an existing one: /Table/115/1/0/0`,
-			fmt.Sprintf(`IMPORT INTO t (a, b) CSV DATA (%s)`, testFiles.files[0]),
+			t, `ingested key collides with an existing one: /Table/\d+/1/0/0`,
+			fmt.Sprintf(`IMPORT INTO t (a, b) CSV DATA (%s) WITH experimental_direct_ingestion`, testFiles.files[0]),
 		)
 	})
 
@@ -1905,7 +1905,7 @@ func TestImportIntoCSV(t *testing.T) {
 		)
 
 		sqlDB.ExpectErr(
-			t, `ingested key collides with an existing one: /Table/119/1/0/0`,
+			t, `ingested key collides with an existing one: /Table/\d+/1/0/0`,
 			fmt.Sprintf(`IMPORT INTO t (a, b) CSV DATA (%s)`, testFiles.fileWithShadowKeys[0]),
 		)
 	})
@@ -1921,7 +1921,7 @@ func TestImportIntoCSV(t *testing.T) {
 		)
 
 		sqlDB.ExpectErr(
-			t, `ingested key collides with an existing one: /Table/121/1/0/0`,
+			t, `ingested key collides with an existing one: /Table/\d+/1/0/0`,
 			fmt.Sprintf(`IMPORT INTO t (a, b) CSV DATA (%s) WITH experimental_direct_ingestion`, testFiles.fileWithShadowKeys[0]),
 		)
 	})


### PR DESCRIPTION
Changes the regex pattern on some of the IsError clauses to
accomodate for variable table IDs.

Closes #39456.

Release note: None