### PR TITLE
sql: remove Txn arg from FK representation downgrade method

### DIFF
--- a/pkg/sql/sqlbase/structured_test.go
+++ b/pkg/sql/sqlbase/structured_test.go
@@ -1733,7 +1733,7 @@ func TestUpgradeDowngradeFKRepr(t *testing.T) {
 					pair.expectedUpgraded.InboundFKs[i].LegacyReferencedIndex = 0
 				}
 
-				wasDowngraded, downgraded, err := upgraded.maybeDowngradeForeignKeyRepresentation(ctx, txn, mixedVersionSettings)
+				wasDowngraded, downgraded, err := upgraded.maybeDowngradeForeignKeyRepresentation(ctx, mixedVersionSettings)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -1746,7 +1746,7 @@ func TestUpgradeDowngradeFKRepr(t *testing.T) {
 						proto.MarshalTextString(&pair.oldFormat))
 				}
 
-				wasDowngraded, _, err = upgraded.maybeDowngradeForeignKeyRepresentation(ctx, txn, newVersionSettings)
+				wasDowngraded, _, err = upgraded.maybeDowngradeForeignKeyRepresentation(ctx, newVersionSettings)
 				if err != nil {
 					t.Fatal(err)
 				}


### PR DESCRIPTION
This PR removes the unnecessary `Txn` (actually, `protoGetter`) argument from
`maybeDowngradeForeignKeyRepresentation`. This also anticipates that the table
descriptor downgrade will be a pure function of the upgraded descriptor while
the cluster is in a mixed-version state, because fields on the new
`ForeignKeyConstraint` struct will store all necessary information to have
identical semantics to 19.1 for FKs being associated with indexes.

Release note: None