### PR TITLE
cli: add an option to set node localities in cockroach demo

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -889,6 +889,21 @@ The line length where sqlfmt will try to wrap.`,
 		Description: `How many in-memory nodes to create for the demo.`,
 	}
 
+	DemoNodeLocality = FlagInfo{
+		Name: "demo-locality",
+		Description: `
+Locality information for each demo node. The input is a comma separated
+list of key-value pairs, where the i'th pair is the locality setting
+for the i'th demo cockroach node. For example:
+<PRE>
+
+	--demo-locality=region=us-east1,region=us-east2,region=us-east3
+
+Assigns node 1's region to us-east1, node 2's region to us-east2,
+and node 3's region to us-east3.
+`,
+	}
+
 	UseEmptyDatabase = FlagInfo{
 		Name: "empty",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -145,6 +146,7 @@ func initCLIDefaults() {
 
 	demoCtx.nodes = 1
 	demoCtx.useEmptyDatabase = false
+	demoCtx.localities = roachpb.Locality{}
 
 	initPreFlagsDefaults()
 
@@ -334,4 +336,5 @@ var sqlfmtCtx struct {
 var demoCtx struct {
 	nodes            int
 	useEmptyDatabase bool
+	localities       roachpb.Locality
 }

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -592,6 +592,7 @@ func init() {
 	// The --empty flag is only valid for the top level demo command,
 	// so we use the regular flag set.
 	BoolFlag(demoCmd.Flags(), &demoCtx.useEmptyDatabase, cliflags.UseEmptyDatabase, false)
+	VarFlag(demoFlags, &demoCtx.localities, cliflags.DemoNodeLocality)
 
 	// sqlfmt command.
 	fmtFlags := sqlfmtCmd.Flags()


### PR DESCRIPTION
The demo command now accepts a --demo-locality= flag,
which sets the locality of the i'th node in the demo to the
i'th locality setting input by the user.

Fixes #39450.

Release note (cli change): Add an option to set node
localities in cockroach demo.