### PR TITLE
importccl: Fixes target col bug for IMPORT INTO

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -411,7 +411,7 @@ func importPlanHook(
 
 			// Validate target columns.
 			var intoCols []string
-			var isTargetCol = make(map[string]bool, len(importStmt.IntoCols))
+			var isTargetCol = make(map[string]bool)
 			for _, name := range importStmt.IntoCols {
 				var err error
 				if _, err = found.FindActiveColumnByName(name.String()); err != nil {
@@ -430,7 +430,7 @@ func importPlanHook(
 					return errors.Errorf("cannot IMPORT INTO a table with a DEFAULT expression for any of its columns")
 				}
 
-				if !isTargetCol[col.Name] && !col.IsNullable() {
+				if len(isTargetCol) != 0 && !isTargetCol[col.Name] && !col.IsNullable() {
 					return errors.Errorf("all non-target columns in IMPORT INTO must be nullable")
 				}
 			}

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1687,13 +1687,13 @@ func TestImportIntoCSV(t *testing.T) {
 	// import of all columns in the exisiting table.
 	t.Run("no-target-cols-specified", func(t *testing.T) {
 		sqlDB.Exec(t, "CREATE DATABASE targetcols; USE targetcols")
-		sqlDB.Exec(t, `CREATE TABLE t (a INT, b STRING)`)
+		sqlDB.Exec(t, `CREATE TABLE t (a INT PRIMARY KEY, b STRING)`)
 
 		// Insert the test data
 		insert := []string{"''", "'text'", "'a'", "'e'", "'l'", "'t'", "'z'"}
 
 		for i, v := range insert {
-			sqlDB.Exec(t, "INSERT INTO t (a, b) VALUES ($1, $2)", i, v)
+			sqlDB.Exec(t, "INSERT INTO t (a, b) VALUES ($1, $2)", i+rowsPerFile, v)
 		}
 
 		sqlDB.Exec(t, fmt.Sprintf("IMPORT INTO t CSV DATA (%s)", testFiles.files[0]))


### PR DESCRIPTION
There was an edge case where if you did not specify any target
columns and your target table had a PK specified, then we would
fail the IMPORT because your non-target col (PK column) was non-nullable.

Added check that we did indeed specify at least one target before
enforcing the non-nullable condition.

Release note: None