### PR TITLE
 importccl: Rollback partial IMPORT INTO

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -633,6 +633,10 @@ type importResumer struct {
 	settings       *cluster.Settings
 	res            roachpb.BulkOpSummary
 	statsRefresher *stats.Refresher
+
+	testingKnobs struct {
+		forceFailure bool
+	}
 }
 
 // Prepares descriptors for newly created tables being imported into.
@@ -899,6 +903,10 @@ func (r *importResumer) Resume(
 	if err != nil {
 		return err
 	}
+	if r.testingKnobs.forceFailure {
+		return errors.New("testing injected failure")
+	}
+
 	r.res = res
 	r.statsRefresher = p.ExecCfg().StatsRefresher
 	return nil

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1227,8 +1227,6 @@ func TestImportIntoCSV(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, nodes, base.TestClusterArgs{ServerArgs: base.TestServerArgs{ExternalIODir: baseDir}})
 	defer tc.Stopper().Stop(ctx)
 	conn := tc.Conns[0]
-	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop(ctx)
 
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
@@ -1412,16 +1410,8 @@ func TestImportIntoCSV(t *testing.T) {
 			insert := []string{"''", "'text'", "'a'", "'e'", "'l'", "'t'", "'z'"}
 			numExistingRows := len(insert)
 
-			if tx, err := db.Begin(); err != nil {
-				t.Fatal(err)
-			} else {
-				for i, v := range insert {
-					sqlDB.Exec(t, fmt.Sprintf("INSERT INTO t (a, b) VALUES (%d, %s)", i, v))
-				}
-
-				if err := tx.Commit(); err != nil {
-					t.Fatal(err)
-				}
+			for i, v := range insert {
+				sqlDB.Exec(t, "INSERT INTO t (a, b) VALUES ($1, $2)", i, v)
 			}
 
 			var result int
@@ -1493,16 +1483,8 @@ func TestImportIntoCSV(t *testing.T) {
 		insert := []string{"''", "'text'", "'a'", "'e'", "'l'", "'t'", "'z'"}
 		numExistingRows := len(insert)
 
-		if tx, err := db.Begin(); err != nil {
-			t.Fatal(err)
-		} else {
-			for i, v := range insert {
-				sqlDB.Exec(t, fmt.Sprintf("INSERT INTO pk.t (a, b) VALUES (%d, %s)", i, v))
-			}
-
-			if err := tx.Commit(); err != nil {
-				t.Fatal(err)
-			}
+		for i, v := range insert {
+			sqlDB.Exec(t, "INSERT INTO pk.t (a, b) VALUES ($1, $2)", i, v)
 		}
 
 		sqlDB.Exec(t, fmt.Sprintf(`IMPORT INTO pk.t (a, b) CSV DATA (%s)`, strings.Join(testFiles.files, ", ")))
@@ -1527,16 +1509,8 @@ func TestImportIntoCSV(t *testing.T) {
 		// Insert the test data
 		insert := []string{"''", "'text'", "'a'", "'e'", "'l'", "'t'", "'z'"}
 
-		if tx, err := db.Begin(); err != nil {
-			t.Fatal(err)
-		} else {
-			for i, v := range insert {
-				sqlDB.Exec(t, fmt.Sprintf("INSERT INTO t (a, b) VALUES (%d, %s)", i, v))
-			}
-
-			if err := tx.Commit(); err != nil {
-				t.Fatal(err)
-			}
+		for i, v := range insert {
+			sqlDB.Exec(t, "INSERT INTO t (a, b) VALUES ($1, $2)", i, v)
 		}
 
 		// Specify wrong table name.
@@ -1616,16 +1590,8 @@ func TestImportIntoCSV(t *testing.T) {
 		// Insert the test data
 		insert := []string{"''", "'text'", "'a'", "'e'", "'l'", "'t'", "'z'"}
 
-		if tx, err := db.Begin(); err != nil {
-			t.Fatal(err)
-		} else {
-			for i, v := range insert {
-				sqlDB.Exec(t, fmt.Sprintf("INSERT INTO t (a, b) VALUES (%d, %s)", i+1000, v))
-			}
-
-			if err := tx.Commit(); err != nil {
-				t.Fatal(err)
-			}
+		for i, v := range insert {
+			sqlDB.Exec(t, "INSERT INTO t (a, b) VALUES ($1, $2)", i+1000, v)
 		}
 
 		sqlDB.Exec(t, fmt.Sprintf("IMPORT INTO t (a) CSV DATA (%s)", testFiles.files[0]))
@@ -1674,16 +1640,8 @@ func TestImportIntoCSV(t *testing.T) {
 		// Insert the test data
 		insert := []string{"''", "'text'", "'a'", "'e'", "'l'", "'t'", "'z'"}
 
-		if tx, err := db.Begin(); err != nil {
-			t.Fatal(err)
-		} else {
-			for i, v := range insert {
-				sqlDB.Exec(t, fmt.Sprintf("INSERT INTO t (a, b, c) VALUES (%d, %s, %d)", i, v, i))
-			}
-
-			if err := tx.Commit(); err != nil {
-				t.Fatal(err)
-			}
+		for i, v := range insert {
+			sqlDB.Exec(t, "INSERT INTO t (a, b) VALUES ($1, $2)", i, v)
 		}
 
 		stripFilenameQuotes := testFiles.files[0][1 : len(testFiles.files[0])-1]
@@ -1700,21 +1658,6 @@ func TestImportIntoCSV(t *testing.T) {
 	t.Run("fewer-table-cols-than-csv", func(t *testing.T) {
 		sqlDB.Exec(t, "CREATE DATABASE targetcols; USE targetcols")
 		sqlDB.Exec(t, `CREATE TABLE t (a INT)`)
-
-		// Insert the test data
-		insert := []string{"''", "'text'", "'a'", "'e'", "'l'", "'t'", "'z'"}
-
-		if tx, err := db.Begin(); err != nil {
-			t.Fatal(err)
-		} else {
-			for i := range insert {
-				sqlDB.Exec(t, fmt.Sprintf("INSERT INTO t (a) VALUES (%d)", i))
-			}
-
-			if err := tx.Commit(); err != nil {
-				t.Fatal(err)
-			}
-		}
 
 		stripFilenameQuotes := testFiles.files[0][1 : len(testFiles.files[0])-1]
 		sqlDB.ExpectErr(
@@ -1734,16 +1677,8 @@ func TestImportIntoCSV(t *testing.T) {
 		// Insert the test data
 		insert := []string{"''", "'text'", "'a'", "'e'", "'l'", "'t'", "'z'"}
 
-		if tx, err := db.Begin(); err != nil {
-			t.Fatal(err)
-		} else {
-			for i, v := range insert {
-				sqlDB.Exec(t, fmt.Sprintf("INSERT INTO t (a, b) VALUES (%d, %s)", i, v))
-			}
-
-			if err := tx.Commit(); err != nil {
-				t.Fatal(err)
-			}
+		for i, v := range insert {
+			sqlDB.Exec(t, "INSERT INTO t (a, b) VALUES ($1, $2)", i, v)
 		}
 
 		sqlDB.Exec(t, fmt.Sprintf("IMPORT INTO t CSV DATA (%s)", testFiles.files[0]))
@@ -1773,16 +1708,8 @@ func TestImportIntoCSV(t *testing.T) {
 		// Insert the test data
 		insert := []string{"''", "'text'", "'a'", "'e'", "'l'", "'t'", "'z'"}
 
-		if tx, err := db.Begin(); err != nil {
-			t.Fatal(err)
-		} else {
-			for i, v := range insert {
-				sqlDB.Exec(t, fmt.Sprintf("INSERT INTO t (a, b) VALUES (%d, %s)", i, v))
-			}
-
-			if err := tx.Commit(); err != nil {
-				t.Fatal(err)
-			}
+		for i, v := range insert {
+			sqlDB.Exec(t, "INSERT INTO t (a, b) VALUES ($1, $2)", i, v)
 		}
 
 		sqlDB.ExpectErr(
@@ -1805,16 +1732,8 @@ func TestImportIntoCSV(t *testing.T) {
 		numExistingRows := len(insert)
 		insertedRows := rowsPerFile * 3
 
-		if tx, err := db.Begin(); err != nil {
-			t.Fatal(err)
-		} else {
-			for i, v := range insert {
-				sqlDB.Exec(t, fmt.Sprintf("INSERT INTO t (a, b) VALUES (%d, %s)", i, v))
-			}
-
-			if err := tx.Commit(); err != nil {
-				t.Fatal(err)
-			}
+		for i, v := range insert {
+			sqlDB.Exec(t, "INSERT INTO t (a, b) VALUES ($1, $2)", i, v)
 		}
 
 		// Expect it to succeed with correct columns.

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1515,7 +1515,7 @@ func TestImportIntoCSV(t *testing.T) {
 	// Verify a failed IMPORT INTO won't prevent a subsequent IMPORT INTO.
 	t.Run("import-into-checkpoint-leftover", func(t *testing.T) {
 		sqlDB.Exec(t, "CREATE DATABASE checkpoint; USE checkpoint")
-		sqlDB.Exec(t, `CREATE TABLE t (a INT, b STRING)`)
+		sqlDB.Exec(t, `CREATE TABLE t (a INT PRIMARY KEY, b STRING)`)
 
 		// Insert the test data
 		insert := []string{"''", "'text'", "'a'", "'e'", "'l'", "'t'", "'z'"}
@@ -1528,12 +1528,12 @@ func TestImportIntoCSV(t *testing.T) {
 		forceFailure = true
 		sqlDB.ExpectErr(
 			t, `testing injected failure`,
-			fmt.Sprintf(`IMPORT INTO t (a, b) CSV DATA (%s)`, testFiles.files[0]),
+			fmt.Sprintf(`IMPORT INTO t (a, b) CSV DATA (%s)`, testFiles.files[1]),
 		)
 		forceFailure = false
 
 		// Expect it to succeed on re-attempt.
-		sqlDB.Exec(t, fmt.Sprintf(`IMPORT INTO t (a, b) CSV DATA (%s)`, testFiles.files[0]))
+		sqlDB.Exec(t, fmt.Sprintf(`IMPORT INTO t (a, b) CSV DATA (%s)`, testFiles.files[1]))
 	})
 
 	// Tests for user specified target columns in IMPORT INTO statements.

--- a/pkg/sql/revert.go
+++ b/pkg/sql/revert.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
 
@@ -64,6 +65,12 @@ func RevertTables(
 			}
 		}
 		spans = append(spans, tables[i].TableSpan())
+	}
+
+	for i := range tables {
+		// This is a) rare and b) probably relevant if we are looking at logs so it
+		// probably makes sense to log it without a verbosity filter.
+		log.Infof(ctx, "reverting table %s (%d) to time %v", tables[i].Name, tables[i].ID, targetTime)
 	}
 
 	// TODO(dt): pre-split requests up using a rangedesc cache and run batches in


### PR DESCRIPTION
importccl: Rollback partial IMPORT INTO

This uses RevertRange to rollback IMPORT’ed data when IMPORT fails.
Without this, partially imported data would remain in the table — which
could lead to unexpected results, prevent retrying (due to uniqueness)
and generally make things messy.

Release note (sql change): IMPORT INTO cleans up any imported rows if it fails.

jobs,importccl: add testing knobs to job resumers

Jobs are run by resumers, which are created by the registry.
Any testing knobs in a job's execution therefore need to be plumbed via
the resumer, which in turn needs to be plumbed from the registry.

This adds a generic hook that can be installed to run during resumer creation
and an example of it for IMPORT for failure injection after a job is otherwise
complete (e.g. so it has the most to clean up).

Release note: none.

importccl: fix no-op txn against unused server

Somehow ended up with a testserver as well as the testcluster.
This code meant to insert X rows in one txn, but the txn was against the
single server while the inserts were being sent (standalone) to the cluster.

This simply removes the extra server and the unused txns.

Release note: none.

sql: log when reverting tables

Reverting a table is a big deal, and could easily trip up other systems
so if someone is looking at logs around the time a revert happened, it
would probably be useful for it to be mentioned there.

Release note: none.