### PR TITLE
internal/sqlsmith: add vectorize option

### DIFF
--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -17,7 +17,6 @@ import (
 	"regexp"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
@@ -74,6 +73,7 @@ type Smither struct {
 	disableLimits    bool
 	simpleDatums     bool
 	avoidConsts      bool
+	vectorizable     bool
 	ignoreFNs        []*regexp.Regexp
 }
 
@@ -129,7 +129,7 @@ func (s *Smither) Generate() string {
 // tables or columns.
 func (s *Smither) GenerateExpr() tree.TypedExpr {
 	scope := s.makeScope()
-	return makeScalar(scope, sqlbase.RandScalarType(s.rnd), nil)
+	return makeScalar(scope, s.randScalarType(), nil)
 }
 
 func (s *Smither) name(prefix string) tree.Name {
@@ -232,6 +232,26 @@ func (d avoidConsts) Apply(s *Smither) {
 	s.avoidConsts = true
 }
 
+// Vectorizable causes the Smither to limit query generation to queries
+// supported by vectorized execution.
+func Vectorizable() SmitherOption {
+	return multiOption{
+		DisableMutations(),
+		DisableWith(),
+		// This must be last so it can make the final changes to table
+		// exprs and statements.
+		vectorizable{},
+	}
+}
+
+type vectorizable struct{}
+
+func (d vectorizable) Apply(s *Smither) {
+	s.vectorizable = true
+	s.statements = nonMutatingStatements
+	s.tableExprs = vectorizableTableExprs
+}
+
 type multiOption []SmitherOption
 
 func (d multiOption) Apply(s *Smither) {
@@ -263,9 +283,10 @@ func PostgresMode() SmitherOption {
 	}
 }
 
-// SeedTable is a SQL statement that creates a table with most data types and
-// some sample rows.
-const SeedTable = `
+const (
+	// SeedTable is a SQL statement that creates a table with most data types and
+	// some sample rows.
+	SeedTable = `
 CREATE TABLE IF NOT EXISTS tab_orig AS
 	SELECT
 		g::INT2 AS _int2,
@@ -287,3 +308,20 @@ CREATE TABLE IF NOT EXISTS tab_orig AS
 	FROM
 		generate_series(1, 5) AS g;
 `
+
+	// VecSeedTable is like SeedTable except only types supported by vectorized
+	// execution are used.
+	VecSeedTable = `
+CREATE TABLE IF NOT EXISTS tab_orig AS
+	SELECT
+		g::INT8 AS _int8,
+		g::FLOAT8 AS _float8,
+		'2001-01-01'::DATE + g AS _date,
+		g % 2 = 1 AS _bool,
+		g::DECIMAL AS _decimal,
+		g::STRING AS _string,
+		g::STRING::BYTES AS _bytes
+	FROM
+		generate_series(1, 5) AS g;
+`
+)


### PR DESCRIPTION
This option attempts to limits query generation such that vectorized
execution will occur. Still a lot of work to do but this is a good start.

Release note: None