### PR TITLE
roachtest: Bump min version for direct ingest import roachtest

### DIFF
--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -97,7 +97,7 @@ func registerImportTPCC(r *testRegistry) {
 	})
 	r.Add(testSpec{
 		Name:       `import/experimental-direct-ingestion`,
-		MinVersion: `v19.1.0`,
+		MinVersion: `v19.2.0`,
 		Cluster:    makeClusterSpec(3, cpu(16)),
 		Timeout:    2 * time.Hour,
 		Run: func(ctx context.Context, t *test, c *cluster) {


### PR DESCRIPTION
Bumping the roachtest version to 19.2.0 to ensure it runs on
master branch.

Closes: #39395

Release note: None