### PR TITLE
storage/apply: rename Batch.Commit to Batch.ApplyToStateMachine

### DIFF
--- a/pkg/storage/apply/cmd.go
+++ b/pkg/storage/apply/cmd.go
@@ -47,7 +47,8 @@ type AppliedCommand interface {
 	// completed. It also acknowledges the outcome of the command to its
 	// client if it was proposed locally. An error will immediately stall
 	// entry application, so one must only be returned if the state machine
-	// is no longer able to make progress.
+	// is no longer able to make progress. The method will be called exactly
+	// once per Command.
 	FinishAndAckOutcome() error
 }
 

--- a/pkg/storage/apply/doc_test.go
+++ b/pkg/storage/apply/doc_test.go
@@ -54,7 +54,7 @@ func ExampleTask() {
 	//  decoding command 7; local=true
 	//
 	// ApplyCommittedEntries:
-	//  committing batch with commands=[1 2 3 4]
+	//  applying batch with commands=[1 2 3 4]
 	//  applying side-effects of command 1
 	//  applying side-effects of command 2
 	//  applying side-effects of command 3
@@ -63,10 +63,10 @@ func ExampleTask() {
 	//  finishing and acknowledging command 2; rejected=false
 	//  finishing and acknowledging command 3; rejected=true
 	//  finishing and acknowledging command 4; rejected=false
-	//  committing batch with commands=[5]
+	//  applying batch with commands=[5]
 	//  applying side-effects of command 5
 	//  finishing and acknowledging command 5; rejected=false
-	//  committing batch with commands=[6 7]
+	//  applying batch with commands=[6 7]
 	//  applying side-effects of command 6
 	//  applying side-effects of command 7
 	//  finishing and acknowledging command 6; rejected=true

--- a/pkg/storage/apply/task_test.go
+++ b/pkg/storage/apply/task_test.go
@@ -136,11 +136,11 @@ func (b *testBatch) Stage(cmdI apply.Command) (apply.CheckedCommand, error) {
 	ccmd := checkedCmd{cmd: cmd, rejected: cmd.shouldReject}
 	return &ccmd, nil
 }
-func (b *testBatch) Commit(_ context.Context) error {
+func (b *testBatch) ApplyToStateMachine(_ context.Context) error {
 	b.sm.batches = append(b.sm.batches, b.staged)
 	b.sm.applied = append(b.sm.applied, b.staged...)
 	if logging {
-		fmt.Printf(" committing batch with commands=%v\n", b.staged)
+		fmt.Printf(" applying batch with commands=%v\n", b.staged)
 	}
 	return nil
 }

--- a/pkg/storage/replica_application_state_machine.go
+++ b/pkg/storage/replica_application_state_machine.go
@@ -634,10 +634,12 @@ func (b *replicaAppBatch) stageTrivialReplicatedEvalResult(
 	}
 }
 
-// Commit implements the apply.Batch interface. The method handles the
-// second phase of applying a command to the replica state machine. It writes
-// the application batch's accumulated RocksDB batch to the storage engine.
-func (b *replicaAppBatch) Commit(ctx context.Context) error {
+// ApplyToStateMachine implements the apply.Batch interface. The method handles
+// the second phase of applying a command to the replica state machine. It
+// writes the application batch's accumulated RocksDB batch to the storage
+// engine. This encompasses the persistent state transition portion of entry
+// application.
+func (b *replicaAppBatch) ApplyToStateMachine(ctx context.Context) error {
 	if log.V(4) {
 		log.Infof(ctx, "flushing batch %v of %d entries", b.state, b.entries)
 	}


### PR DESCRIPTION
This came out of a discussion with Dan. The method can't be moved
to StateMachine because then we'll need a type switch to handle the
different kinds of Batch implementations, but it can be renamed to
provide more symmetry with StateMachine.ApplySideEffects.

The commit also tries to clean up some of the phrasing around the
persistent state transition updates and the side-effects of these
state transition updates.

Release note: None