### PR TITLE
sql, backupccl: backup and restore fk-upgrade-downgrade awareness

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1573,6 +1573,9 @@ func TestBackupRestoreCrossTableReferences(t *testing.T) {
 		db.Exec(t, `RESTORE DATABASE store from $1 WITH OPTIONS ('skip_missing_views')`, localFoo)
 		db.CheckQueryResults(t, `SELECT * FROM store.early_customers`, origEarlyCustomers)
 		db.CheckQueryResults(t, `SELECT * FROM store.referencing_early_customers`, origEarlyCustomers)
+		// TODO(lucy, jordan): DROP DATABASE CASCADE doesn't work in the mixed 19.1/
+		// 19.2 state, which is unrelated to backup/restore. See #39504 for a
+		// description of that problem, which is yet to be investigated.
 		db.Exec(t, `DROP DATABASE store CASCADE`)
 
 		// Test when some tables (views) are skipped and others are restored

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -188,6 +188,10 @@ func TestShowBackup(t *testing.T) {
 
 	// Foreign keys that were not included in the backup are not mentioned in
 	// the create statement.
+	// TODO(lucy, jordan): This doesn't work in the mixed 19.1/19.2 state,
+	// probably because when we upgrade the backup descriptor tables using the
+	// other tables, we don't account for missing tables. It's not clear why
+	// this *does* work in the 19.2 state; this needs investigation.
 	{
 		missingFK := localFoo + "/missingFK"
 		sqlDB.Exec(t, `BACKUP data2.FKRefTable TO $1;`, missingFK)

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -130,6 +130,9 @@ func ImportBufferConfigSizes(st *cluster.Settings, isPKAdder bool) (int64, int64
 func evalImport(ctx context.Context, cArgs batcheval.CommandArgs) (*roachpb.ImportResponse, error) {
 	args := cArgs.Args.(*roachpb.ImportRequest)
 	db := cArgs.EvalCtx.DB()
+	// args.Rekeys could be using table descriptors from either the old or new
+	// foreign key representation on the table descriptor, but this is fine
+	// because foreign keys don't matter for the key rewriter.
 	kr, err := MakeKeyRewriterFromRekeys(args.Rekeys)
 	if err != nil {
 		return nil, errors.Wrap(err, "make key rewriter")

--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -494,6 +494,7 @@ func (s *Server) collectSchemaInfo(ctx context.Context) ([]sqlbase.TableDescript
 	redactor := stringRedactor{}
 	for _, kv := range kvs {
 		var desc sqlbase.Descriptor
+		// TODO(jordan,lucy): does this need an upgrade?
 		if err := kv.ValueProto(&desc); err != nil {
 			return nil, errors.Wrapf(err, "%s: unable to unmarshal SQL descriptor", kv.Key)
 		}

--- a/pkg/sql/sqlbase/structured_test.go
+++ b/pkg/sql/sqlbase/structured_test.go
@@ -1325,26 +1325,6 @@ func TestColumnNeedsBackfill(t *testing.T) {
 	}
 }
 
-type fakeProtoGetter struct {
-	protos map[interface{}]protoutil.Message
-}
-
-func (m fakeProtoGetter) GetProto(
-	ctx context.Context, key interface{}, msg protoutil.Message,
-) error {
-	msg.Reset()
-	if other, ok := m.protos[string(key.(roachpb.Key))]; ok {
-		bytes := make([]byte, other.Size())
-		if _, err := other.MarshalTo(bytes); err != nil {
-			return err
-		}
-		if err := protoutil.Unmarshal(bytes, msg); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // oldFormatUpgradedPair is a helper struct for the upgrade/downgrade test
 // below. It holds an "old format" (pre-19.2) table descriptor, and an expected
 // upgraded equivalent. The test will verify that the old format descriptor
@@ -1834,7 +1814,7 @@ func TestUpgradeDowngradeFKRepr(t *testing.T) {
 		tc.origin.oldFormat.Privileges = NewDefaultPrivilegeDescriptor()
 		tc.referenced.expectedUpgraded.Privileges = NewDefaultPrivilegeDescriptor()
 		tc.referenced.oldFormat.Privileges = NewDefaultPrivilegeDescriptor()
-		txn := fakeProtoGetter{protos: map[interface{}]protoutil.Message{
+		txn := MapProtoGetter{Protos: map[interface{}]protoutil.Message{
 			string(MakeDescMetadataKey(tc.origin.oldFormat.ID)):     WrapDescriptor(&tc.origin.oldFormat),
 			string(MakeDescMetadataKey(tc.referenced.oldFormat.ID)): WrapDescriptor(&tc.referenced.oldFormat),
 		}}
@@ -1859,7 +1839,7 @@ func TestUpgradeDowngradeFKRepr(t *testing.T) {
 			}
 			t.Run(fmt.Sprintf("%s/%s", tc.name, name), func(t *testing.T) {
 				upgraded := protoutil.Clone(&pair.oldFormat).(*TableDescriptor)
-				wasUpgraded, err := upgraded.maybeUpgradeForeignKeyRepresentation(ctx, txn)
+				wasUpgraded, err := upgraded.MaybeUpgradeForeignKeyRepresentation(ctx, txn)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -1876,7 +1856,7 @@ func TestUpgradeDowngradeFKRepr(t *testing.T) {
 					}
 				}
 
-				wasUpgradedAgain, err := upgraded.maybeUpgradeForeignKeyRepresentation(ctx, txn)
+				wasUpgradedAgain, err := upgraded.MaybeUpgradeForeignKeyRepresentation(ctx, txn)
 				if err != nil {
 					t.Fatal(err)
 				}


### PR DESCRIPTION
This commit has a solution for all 4 cases that you need to worry about
with regards to writing and reading table descriptors in a mixed
19.1/19.2 state.

We now:

1. upgrade the descriptors from disk while creating a backup
2. downgrade the descriptors from memory into the backup descriptor if
   we're in a 19.1/2 mixed state
1. upgrade the descriptors from a backup while preparing to restore
4. downgrade the descriptors from memory onto the disk while restoring
   a backup if we're in a 19.1/2 mixed state

Release note: None