### PR TITLE
cli: new command 'dashboard'

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1473,6 +1473,14 @@
   version = "v1.3.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:519621a373ae7d96a16415a6356d7b97722ed3a292f73409b361b7c0322971e3"
+  name = "github.com/skratchdot/open-golang"
+  packages = ["open"]
+  pruneopts = "UT"
+  revision = "79abb63cd66e41cb1473e26d11ebdcd68b04c8e5"
+
+[[projects]]
   digest = "1:e01b05ba901239c783dfe56450bcde607fc858908529868259c9a8765dc176d0"
   name = "github.com/spf13/cobra"
   packages = [
@@ -2036,6 +2044,7 @@
     "github.com/shirou/gopsutil/load",
     "github.com/shirou/gopsutil/mem",
     "github.com/shirou/gopsutil/net",
+    "github.com/skratchdot/open-golang/open",
     "github.com/spf13/cobra",
     "github.com/spf13/cobra/doc",
     "github.com/spf13/pflag",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -154,3 +154,7 @@ ignored = [
   [[prune.project]]
     name = "github.com/knz/go-libedit"
     unused-packages = false
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/skratchdot/open-golang"

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -195,6 +195,7 @@ func init() {
 		userCmd,
 		nodeCmd,
 		dumpCmd,
+		dashboardCmd,
 
 		// Miscellaneous commands.
 		// TODO(pmattis): stats

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1562,6 +1562,7 @@ Available Commands:
   node              list, inspect or remove nodes
   dump              dump sql tables
 
+  dashboard         open a local browser pointing to the remote web UI
   demo              open a demo sql shell
   gen               generate auxiliary files
   version           output version information

--- a/pkg/cli/dashboard.go
+++ b/pkg/cli/dashboard.go
@@ -1,0 +1,54 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/skratchdot/open-golang/open"
+	"github.com/spf13/cobra"
+)
+
+var dashboardCmd = &cobra.Command{
+	Use:   "dashboard",
+	Short: "open a local browser pointing to the remote web UI",
+	Long: `
+Connect to a running cluster via one of its nodes, retrieve the URL of
+the web UI as advertised by the node, and launch a web browser
+on the local machine pointing to this URL automatically.
+`,
+	Args: cobra.NoArgs,
+	RunE: MaybeDecorateGRPCError(func(cmd *cobra.Command, _ []string) error {
+		return runDashboard(cmd)
+	}),
+}
+
+func runDashboard(cmd *cobra.Command) error {
+	conn, err := getPasswordAndMakeSQLClient("cockroach dashboard")
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	vals, err := conn.QueryRow(
+		`SELECT value FROM crdb_internal.node_runtime_info WHERE component='UI' AND field = 'URL'`, nil,
+	)
+	if err != nil {
+		return err
+	}
+	if len(vals) == 0 {
+		return errors.AssertionFailedf("unable to obtain the web UI URL from the server")
+	}
+
+	uiStr := vals[0].(string)
+	return errors.WithHintf(
+		open.Run(uiStr),
+		"You can open the web UI manually in a web browser:\n\n\t%s\n", uiStr)
+}

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -456,6 +456,7 @@ func init() {
 		genHAProxyCmd,
 		quitCmd,
 		sqlShellCmd,
+		dashboardCmd,
 		/* StartCmds are covered above */
 	}
 	clientCmds = append(clientCmds, userCmds...)
@@ -540,7 +541,7 @@ func init() {
 	StringFlag(dumpCmd.Flags(), &dumpCtx.asOf, cliflags.DumpTime, dumpCtx.asOf)
 
 	// Commands that establish a SQL connection.
-	sqlCmds := []*cobra.Command{sqlShellCmd, dumpCmd, demoCmd}
+	sqlCmds := []*cobra.Command{sqlShellCmd, dumpCmd, demoCmd, dashboardCmd}
 	sqlCmds = append(sqlCmds, userCmds...)
 	sqlCmds = append(sqlCmds, demoCmd.Commands()...)
 	for _, cmd := range sqlCmds {


### PR DESCRIPTION
Requested by @jseldess.
Fixes #8780.

Release note (cli change): the new command 'cockroach dashboard'
opens a web browser pointing to the web UI of the node targeted
by --url. The node must be started already.