### PR TITLE
sql: dump puts INTERLEAVE statements outside of CREATE TABLE statements

### DIFF
--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -149,7 +149,7 @@ func backupShowerDefault(ctx context.Context, showSchemas bool) backupShower {
 						tree.NewDInt(tree.DInt(descSizes[table.ID].Rows)),
 					}
 					if showSchemas {
-						schema, err := sql.ShowCreate(ctx, dbName, desc.Descriptors, table, sql.IgnoreMissingFKs)
+						schema, err := sql.ShowCreate(ctx, dbName, desc.Descriptors, table, sql.OmitMissingFKClausesFromCreate)
 						if err != nil {
 							continue
 						}

--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -441,3 +441,52 @@ INSERT INTO t (i, j) VALUES
 		t.Fatalf("unexpected output: %s", out)
 	}
 }
+
+func TestDumpInterleavedTables(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	c := newCLITest(cliTestParams{t: t})
+	defer c.cleanup()
+
+	const create = `
+CREATE DATABASE d;
+CREATE TABLE d.customers (id INT PRIMARY KEY, name STRING(50));
+CREATE TABLE d.orders (
+	customer INT,
+	id INT,
+	total DECIMAL(20, 5),
+	PRIMARY KEY (customer, id),
+	CONSTRAINT fk_customer FOREIGN KEY (customer) REFERENCES d.customers
+) INTERLEAVE IN PARENT d.customers (customer);
+`
+
+	_, err := c.RunWithCaptureArgs([]string{"sql", "-e", create})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dump1, err := c.RunWithCaptureArgs([]string{"dump", "d", "orders"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const want1 = `dump d orders
+CREATE TABLE orders (
+	customer INT8 NOT NULL,
+	id INT8 NOT NULL,
+	total DECIMAL(20,5) NULL,
+	CONSTRAINT "primary" PRIMARY KEY (customer ASC, id ASC),
+	FAMILY "primary" (customer, id, total)
+) INTERLEAVE IN PARENT customers (customer);
+
+ALTER TABLE orders ADD CONSTRAINT fk_customer FOREIGN KEY (customer) REFERENCES customers(id);
+CREATE UNIQUE INDEX "primary" ON orders (customer ASC, id ASC) INTERLEAVE IN PARENT customers (customer);
+
+-- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.
+ALTER TABLE orders VALIDATE CONSTRAINT fk_customer;
+`
+
+	if dump1 != want1 {
+		t.Fatalf("expected: %s\ngot: %s", want1, dump1)
+	}
+}

--- a/pkg/cli/testdata/dump/interleave_index
+++ b/pkg/cli/testdata/dump/interleave_index
@@ -1,0 +1,117 @@
+# Test the interleaving of indexes within tables
+
+sql
+CREATE DATABASE d;
+CREATE TABLE d.t1 (a INT, b INT, PRIMARY KEY (a));
+CREATE INDEX b_idx ON d.t1(a, b) INTERLEAVE IN PARENT d.t1 (a);
+----
+CREATE INDEX
+
+dump d t1
+----
+----
+CREATE TABLE t1 (
+	a INT8 NOT NULL,
+	b INT8 NULL,
+	CONSTRAINT "primary" PRIMARY KEY (a ASC),
+	FAMILY "primary" (a, b)
+);
+
+CREATE INDEX b_idx ON t1 (a ASC, b ASC) INTERLEAVE IN PARENT t1 (a);
+
+-- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.
+----
+----
+
+sql
+CREATE DATABASE e;
+CREATE TABLE e.t2 (a INT, b INT, PRIMARY KEY (a));
+CREATE TABLE e.t3 (a INT, b INT, PRIMARY KEY (a));
+CREATE INDEX b_idx ON e.t2(a, b) INTERLEAVE IN PARENT e.t3 (a);
+INSERT INTO e.t2 VALUES (1, 2);
+INSERT INTO e.t3 VALUES (3, 4);
+----
+INSERT 1
+
+dump e
+----
+----
+CREATE TABLE t3 (
+	a INT8 NOT NULL,
+	b INT8 NULL,
+	CONSTRAINT "primary" PRIMARY KEY (a ASC),
+	FAMILY "primary" (a, b)
+);
+
+CREATE TABLE t2 (
+	a INT8 NOT NULL,
+	b INT8 NULL,
+	CONSTRAINT "primary" PRIMARY KEY (a ASC),
+	FAMILY "primary" (a, b)
+);
+
+INSERT INTO t3 (a, b) VALUES
+	(3, 4);
+
+INSERT INTO t2 (a, b) VALUES
+	(1, 2);
+
+CREATE INDEX b_idx ON t2 (a ASC, b ASC) INTERLEAVE IN PARENT t3 (a);
+
+-- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.
+----
+----
+
+sql
+CREATE DATABASE dd;
+CREATE TABLE dd.unique (a INT, b INT, PRIMARY KEY (a));
+CREATE INDEX "b_idx" ON dd.unique(a, b) INTERLEAVE IN PARENT dd.unique (a);
+----
+CREATE INDEX
+
+dump dd unique
+----
+----
+CREATE TABLE "unique" (
+	a INT8 NOT NULL,
+	b INT8 NULL,
+	CONSTRAINT "primary" PRIMARY KEY (a ASC),
+	FAMILY "primary" (a, b)
+);
+
+CREATE INDEX b_idx ON "unique" (a ASC, b ASC) INTERLEAVE IN PARENT "unique" (a);
+
+-- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.
+----
+----
+
+sql
+CREATE DATABASE ee;
+CREATE TABLE ee.a (i INT, j INT, PRIMARY KEY (i, j DESC));
+CREATE TABLE ee.d (x INT, y INT, z INT, PRIMARY KEY (x, y DESC, z DESC)) INTERLEAVE IN PARENT ee.a (x, y);
+----
+CREATE TABLE
+
+dump ee a d
+----
+----
+CREATE TABLE a (
+	i INT8 NOT NULL,
+	j INT8 NOT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (i ASC, j DESC),
+	FAMILY "primary" (i, j)
+);
+
+CREATE TABLE d (
+	x INT8 NOT NULL,
+	y INT8 NOT NULL,
+	z INT8 NOT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (x ASC, y DESC, z DESC),
+	FAMILY "primary" (x, y, z)
+) INTERLEAVE IN PARENT a (x, y);
+
+CREATE UNIQUE INDEX "primary" ON d (x ASC, y DESC, z DESC) INTERLEAVE IN PARENT a (x, y);
+
+-- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.
+----
+----

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -817,7 +817,7 @@ CREATE TABLE pg_catalog.pg_constraint (
 						return err
 					}
 					var buf bytes.Buffer
-					if err := printForeignKeyConstraint(ctx, &buf, db.Name, table, con.FK, tableLookup); err != nil {
+					if err := showForeignKeyConstraint(&buf, db.Name, table, con.FK, tableLookup); err != nil {
 						return err
 					}
 					condef = tree.NewDString(buf.String())

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -651,6 +651,40 @@ func (l *internalLookupCtx) getParentName(table *TableDescriptor) string {
 	return parentName
 }
 
+// getParentAsTableName returns a TreeTable object of the parent table for a
+// given table ID. Used to get the parent table of a table with interleaved
+// indexes.
+func (l *internalLookupCtx) getParentAsTableName(
+	parentTableID sqlbase.ID, dbPrefix string,
+) (tree.TableName, error) {
+	var parentName tree.TableName
+	parentTable, err := l.getTableByID(parentTableID)
+	if err != nil {
+		return tree.TableName{}, err
+	}
+	parentDbDesc, err := l.getDatabaseByID(parentTable.ParentID)
+	if err != nil {
+		return tree.TableName{}, err
+	}
+	parentName = tree.MakeTableName(tree.Name(parentDbDesc.Name), tree.Name(parentTable.Name))
+	parentName.ExplicitSchema = parentDbDesc.Name != dbPrefix
+	return parentName, nil
+}
+
+// getTableAsTableName returns a TableName object fot a given TableDescriptor.
+func (l *internalLookupCtx) getTableAsTableName(
+	table *sqlbase.TableDescriptor, dbPrefix string,
+) (tree.TableName, error) {
+	var tableName tree.TableName
+	tableDbDesc, err := l.getDatabaseByID(table.ParentID)
+	if err != nil {
+		return tree.TableName{}, err
+	}
+	tableName = tree.MakeTableName(tree.Name(tableDbDesc.Name), tree.Name(table.Name))
+	tableName.ExplicitSchema = tableDbDesc.Name != dbPrefix
+	return tableName, nil
+}
+
 // The versions below are part of the work for #34240.
 // TODO(radu): clean these up when everything is switched over.
 

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -13,132 +13,28 @@ package sql
 import (
 	"bytes"
 	"context"
-	"fmt"
-	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/pkg/errors"
 )
 
-// ShowCreateView returns a valid SQL representation of the CREATE VIEW
-// statement used to create the given view. It is used in the implementation of
-// the crdb_internal.create_statements virtual table.
-func ShowCreateView(
-	ctx context.Context, tn *tree.Name, desc *sqlbase.TableDescriptor,
-) (string, error) {
-	f := tree.NewFmtCtx(tree.FmtSimple)
-	f.WriteString("CREATE VIEW ")
-	f.FormatNode(tn)
-	f.WriteString(" (")
-	for i := range desc.Columns {
-		if i > 0 {
-			f.WriteString(", ")
-		}
-		f.FormatNameP(&desc.Columns[i].Name)
-	}
-	f.WriteString(") AS ")
-	f.WriteString(desc.ViewQuery)
-	return f.CloseAndGetString(), nil
-}
-
-func printForeignKeyConstraint(
-	ctx context.Context,
-	buf *bytes.Buffer,
-	dbPrefix string,
-	originTable *sqlbase.TableDescriptor,
-	fk *sqlbase.ForeignKeyConstraint,
-	lCtx *internalLookupCtx,
-) error {
-	var refNames []string
-	var originNames []string
-	var fkTableName tree.TableName
-	if lCtx != nil {
-		fkTable, err := lCtx.getTableByID(fk.ReferencedTableID)
-		if err != nil {
-			return err
-		}
-		fkDb, err := lCtx.getDatabaseByID(fkTable.ParentID)
-		if err != nil {
-			return err
-		}
-		refNames, err = fkTable.NamesForColumnIDs(fk.ReferencedColumnIDs)
-		if err != nil {
-			return err
-		}
-		fkTableName = tree.MakeTableName(tree.Name(fkDb.Name), tree.Name(fkTable.Name))
-		fkTableName.ExplicitSchema = fkDb.Name != dbPrefix
-		originNames, err = originTable.NamesForColumnIDs(fk.OriginColumnIDs)
-		if err != nil {
-			return err
-		}
-	} else {
-		refNames = []string{"???"}
-		originNames = []string{"???"}
-		fkTableName = tree.MakeTableName(tree.Name(""), tree.Name(fmt.Sprintf("[%d as ref]", fk.ReferencedTableID)))
-		fkTableName.ExplicitSchema = false
-	}
-	buf.WriteString("FOREIGN KEY (")
-	formatQuoteNames(buf, originNames...)
-	buf.WriteString(") REFERENCES ")
-	fmtCtx := tree.NewFmtCtx(tree.FmtSimple)
-	fmtCtx.FormatNode(&fkTableName)
-	buf.WriteString(fmtCtx.CloseAndGetString())
-	buf.WriteString("(")
-	formatQuoteNames(buf, refNames...)
-	buf.WriteByte(')')
-	// We omit MATCH SIMPLE because it is the default.
-	if fk.Match != sqlbase.ForeignKeyReference_SIMPLE {
-		buf.WriteByte(' ')
-		buf.WriteString(fk.Match.String())
-	}
-	if fk.OnDelete != sqlbase.ForeignKeyReference_NO_ACTION {
-		buf.WriteString(" ON DELETE ")
-		buf.WriteString(fk.OnDelete.String())
-	}
-	if fk.OnUpdate != sqlbase.ForeignKeyReference_NO_ACTION {
-		buf.WriteString(" ON UPDATE ")
-		buf.WriteString(fk.OnUpdate.String())
-	}
-	return nil
-}
-
-// ShowCreateSequence returns a valid SQL representation of the
-// CREATE SEQUENCE statement used to create the given sequence.
-func ShowCreateSequence(
-	ctx context.Context, tn *tree.Name, desc *sqlbase.TableDescriptor,
-) (string, error) {
-	f := tree.NewFmtCtx(tree.FmtSimple)
-	f.WriteString("CREATE SEQUENCE ")
-	f.FormatNode(tn)
-	opts := desc.SequenceOpts
-	f.Printf(" MINVALUE %d", opts.MinValue)
-	f.Printf(" MAXVALUE %d", opts.MaxValue)
-	f.Printf(" INCREMENT %d", opts.Increment)
-	f.Printf(" START %d", opts.Start)
-	if opts.Virtual {
-		f.Printf(" VIRTUAL")
-	}
-	return f.CloseAndGetString(), nil
-}
-
-type shouldIgnoreFKs int
+type shouldOmitFKClausesFromCreate int
 
 const (
-	_ shouldIgnoreFKs = iota
-	// IgnoreFKs will not include any foreign key information in the
+	_ shouldOmitFKClausesFromCreate = iota
+	// OmitFKClausesFromCreate will not include any foreign key information in the
 	// create statement.
-	IgnoreFKs
-	// IncludeFKs will include foreign key information in the create
+	OmitFKClausesFromCreate
+	// IncludeFkClausesInCreate will include foreign key information in the create
 	// statement, and error if a FK cannot be resolved.
-	IncludeFKs
-	// IgnoreMissingFKs will include foreign key information only if they
+	IncludeFkClausesInCreate
+	// OmitMissingFKClausesFromCreate will include foreign key information only if they
 	// can be resolved. If not, it will ignore those constraints.
 	// This is used in the case when showing the create statement for
 	// tables stored in backups. Not all relevant tables may have been
 	// included in the back up, so some foreign key information may be
 	// impossible to retrieve.
-	IgnoreMissingFKs
+	OmitMissingFKClausesFromCreate
 )
 
 // ShowCreateTable returns a valid SQL representation of the CREATE
@@ -155,7 +51,7 @@ func ShowCreateTable(
 	dbPrefix string,
 	desc *sqlbase.TableDescriptor,
 	lCtx *internalLookupCtx,
-	ignoreFKs shouldIgnoreFKs,
+	fkDisplayMode shouldOmitFKClausesFromCreate,
 ) (string, error) {
 	a := &sqlbase.DatumAlloc{}
 
@@ -186,17 +82,17 @@ func ShowCreateTable(
 	}
 	// TODO (lucy): Possibly include FKs in the mutations list here, or else
 	// exclude check mutations below, for consistency.
-	if ignoreFKs != IgnoreFKs {
+	if fkDisplayMode != OmitFKClausesFromCreate {
 		for i := range desc.OutboundFKs {
 			fkCtx := tree.NewFmtCtx(tree.FmtSimple)
 			fk := &desc.OutboundFKs[i]
 			fkCtx.WriteString(",\n\tCONSTRAINT ")
 			fkCtx.FormatNameP(&fk.Name)
 			fkCtx.WriteString(" ")
-			if err := printForeignKeyConstraint(ctx, &fkCtx.Buffer, dbPrefix, desc, fk, lCtx); err != nil {
-				if ignoreFKs == IgnoreMissingFKs {
+			if err := showForeignKeyConstraint(&fkCtx.Buffer, dbPrefix, desc, fk, lCtx); err != nil {
+				if fkDisplayMode == OmitMissingFKClausesFromCreate {
 					continue
-				} else { // When ignoreFKs == IncludeFKs.
+				} else { // When fkDisplayMode == IncludeFkClausesInCreate.
 					return "", err
 				}
 			}
@@ -206,14 +102,32 @@ func ShowCreateTable(
 	allIdx := append(desc.Indexes, desc.PrimaryIndex)
 	for i := range allIdx {
 		idx := &allIdx[i]
-		if idx.ID != desc.PrimaryIndex.ID {
+		// Only add indexes to the create_statement column, and not to the
+		// create_nofks column if they are not associated with an INTERLEAVE
+		// statement.
+		// Initialize to false if Interleave has no ancestors, indicating that the
+		// index is not interleaved at all.
+		includeInterleaveClause := len(idx.Interleave.Ancestors) == 0
+		if fkDisplayMode != OmitFKClausesFromCreate {
+			// The caller is instructing us to not omit FK clauses from inside the CREATE.
+			// (i.e. the caller does not want them as separate DDL.)
+			// Since we're including FK clauses, we need to also include the PARTITION and INTERLEAVE
+			// clauses as well.
+			includeInterleaveClause = true
+		}
+		if idx.ID != desc.PrimaryIndex.ID && includeInterleaveClause {
 			// Showing the primary index is handled above.
 			f.WriteString(",\n\t")
 			f.WriteString(idx.SQLString(&sqlbase.AnonymousTable))
 			// Showing the INTERLEAVE and PARTITION BY for the primary index are
 			// handled last.
-			if err := showCreateInterleave(ctx, idx, &f.Buffer, dbPrefix, lCtx); err != nil {
-				return "", err
+
+			// Add interleave or Foreign Key indexes only to the create_table columns,
+			// and not the create_nofks column.
+			if includeInterleaveClause {
+				if err := showCreateInterleave(idx, &f.Buffer, dbPrefix, lCtx); err != nil {
+					return "", err
+				}
 			}
 			if err := ShowCreatePartitioning(
 				a, desc, idx, &idx.Partitioning, &f.Buffer, 1 /* indent */, 0, /* colOffset */
@@ -223,35 +137,11 @@ func ShowCreateTable(
 		}
 	}
 
-	for _, fam := range desc.Families {
-		activeColumnNames := make([]string, 0, len(fam.ColumnNames))
-		for i, colID := range fam.ColumnIDs {
-			if _, err := desc.FindActiveColumnByID(colID); err == nil {
-				activeColumnNames = append(activeColumnNames, fam.ColumnNames[i])
-			}
-		}
-		f.WriteString(",\n\tFAMILY ")
-		formatQuoteNames(&f.Buffer, fam.Name)
-		f.WriteString(" (")
-		formatQuoteNames(&f.Buffer, activeColumnNames...)
-		f.WriteString(")")
-	}
+	// Create the FAMILY and CONSTRAINTs of the CREATE statement
+	showFamilyClause(desc, f)
+	showConstraintClause(desc, f)
 
-	for _, e := range desc.AllActiveAndInactiveChecks() {
-		f.WriteString(",\n\t")
-		if len(e.Name) > 0 {
-			f.WriteString("CONSTRAINT ")
-			formatQuoteNames(&f.Buffer, e.Name)
-			f.WriteString(" ")
-		}
-		f.WriteString("CHECK (")
-		f.WriteString(e.Expr)
-		f.WriteString(")")
-	}
-
-	f.WriteString("\n)")
-
-	if err := showCreateInterleave(ctx, &desc.PrimaryIndex, &f.Buffer, dbPrefix, lCtx); err != nil {
+	if err := showCreateInterleave(&desc.PrimaryIndex, &f.Buffer, dbPrefix, lCtx); err != nil {
 		return "", err
 	}
 	if err := ShowCreatePartitioning(
@@ -275,155 +165,6 @@ func formatQuoteNames(buf *bytes.Buffer, names ...string) {
 	buf.WriteString(f.CloseAndGetString())
 }
 
-// showCreateInterleave returns an INTERLEAVE IN PARENT clause for the specified
-// index, if applicable.
-//
-// The name of the parent table is prefixed by its database name unless
-// it is equal to the given dbPrefix. This allows us to elide the prefix
-// when the given index is interleaved in a table of the current database.
-func showCreateInterleave(
-	ctx context.Context,
-	idx *sqlbase.IndexDescriptor,
-	buf *bytes.Buffer,
-	dbPrefix string,
-	lCtx *internalLookupCtx,
-) error {
-	if len(idx.Interleave.Ancestors) == 0 {
-		return nil
-	}
-	intl := idx.Interleave
-	parentTableID := intl.Ancestors[len(intl.Ancestors)-1].TableID
-
-	var parentName tree.TableName
-	if lCtx != nil {
-		parentTable, err := lCtx.getTableByID(parentTableID)
-		if err != nil {
-			return err
-		}
-		parentDbDesc, err := lCtx.getDatabaseByID(parentTable.ParentID)
-		if err != nil {
-			return err
-		}
-		parentName = tree.MakeTableName(tree.Name(parentDbDesc.Name), tree.Name(parentTable.Name))
-		parentName.ExplicitSchema = parentDbDesc.Name != dbPrefix
-	} else {
-		parentName = tree.MakeTableName(tree.Name(""), tree.Name(fmt.Sprintf("[%d as parent]", parentTableID)))
-		parentName.ExplicitCatalog = false
-		parentName.ExplicitSchema = false
-	}
-	var sharedPrefixLen int
-	for _, ancestor := range intl.Ancestors {
-		sharedPrefixLen += int(ancestor.SharedPrefixLen)
-	}
-	buf.WriteString(" INTERLEAVE IN PARENT ")
-	fmtCtx := tree.NewFmtCtx(tree.FmtSimple)
-	fmtCtx.FormatNode(&parentName)
-	buf.WriteString(fmtCtx.CloseAndGetString())
-	buf.WriteString(" (")
-	formatQuoteNames(buf, idx.ColumnNames[:sharedPrefixLen]...)
-	buf.WriteString(")")
-	return nil
-}
-
-// ShowCreatePartitioning returns a PARTITION BY clause for the specified
-// index, if applicable.
-func ShowCreatePartitioning(
-	a *sqlbase.DatumAlloc,
-	tableDesc *sqlbase.TableDescriptor,
-	idxDesc *sqlbase.IndexDescriptor,
-	partDesc *sqlbase.PartitioningDescriptor,
-	buf *bytes.Buffer,
-	indent int,
-	colOffset int,
-) error {
-	if partDesc.NumColumns == 0 {
-		return nil
-	}
-
-	// We don't need real prefixes in the DecodePartitionTuple calls because we
-	// only use the tree.Datums part of the output.
-	fakePrefixDatums := make([]tree.Datum, colOffset)
-	for i := range fakePrefixDatums {
-		fakePrefixDatums[i] = tree.DNull
-	}
-
-	indentStr := strings.Repeat("\t", indent)
-	buf.WriteString(` PARTITION BY `)
-	if len(partDesc.List) > 0 {
-		buf.WriteString(`LIST`)
-	} else if len(partDesc.Range) > 0 {
-		buf.WriteString(`RANGE`)
-	} else {
-		return errors.Errorf(`invalid partition descriptor: %v`, partDesc)
-	}
-	buf.WriteString(` (`)
-	for i := 0; i < int(partDesc.NumColumns); i++ {
-		if i != 0 {
-			buf.WriteString(", ")
-		}
-		buf.WriteString(idxDesc.ColumnNames[colOffset+i])
-	}
-	buf.WriteString(`) (`)
-	fmtCtx := tree.NewFmtCtx(tree.FmtSimple)
-	for i := range partDesc.List {
-		part := &partDesc.List[i]
-		if i != 0 {
-			buf.WriteString(`, `)
-		}
-		buf.WriteString("\n")
-		buf.WriteString(indentStr)
-		buf.WriteString("\tPARTITION ")
-		fmtCtx.FormatNameP(&part.Name)
-		_, _ = fmtCtx.Buffer.WriteTo(buf)
-		buf.WriteString(` VALUES IN (`)
-		for j, values := range part.Values {
-			if j != 0 {
-				buf.WriteString(`, `)
-			}
-			tuple, _, err := sqlbase.DecodePartitionTuple(
-				a, tableDesc, idxDesc, partDesc, values, fakePrefixDatums)
-			if err != nil {
-				return err
-			}
-			buf.WriteString(tuple.String())
-		}
-		buf.WriteString(`)`)
-		if err := ShowCreatePartitioning(
-			a, tableDesc, idxDesc, &part.Subpartitioning, buf, indent+1,
-			colOffset+int(partDesc.NumColumns),
-		); err != nil {
-			return err
-		}
-	}
-	for i, part := range partDesc.Range {
-		if i != 0 {
-			buf.WriteString(`, `)
-		}
-		buf.WriteString("\n")
-		buf.WriteString(indentStr)
-		buf.WriteString("\tPARTITION ")
-		buf.WriteString(part.Name)
-		buf.WriteString(" VALUES FROM ")
-		fromTuple, _, err := sqlbase.DecodePartitionTuple(
-			a, tableDesc, idxDesc, partDesc, part.FromInclusive, fakePrefixDatums)
-		if err != nil {
-			return err
-		}
-		buf.WriteString(fromTuple.String())
-		buf.WriteString(" TO ")
-		toTuple, _, err := sqlbase.DecodePartitionTuple(
-			a, tableDesc, idxDesc, partDesc, part.ToExclusive, fakePrefixDatums)
-		if err != nil {
-			return err
-		}
-		buf.WriteString(toTuple.String())
-	}
-	buf.WriteString("\n")
-	buf.WriteString(indentStr)
-	buf.WriteString(")")
-	return nil
-}
-
 // ShowCreate returns a valid SQL representation of the CREATE
 // statement used to create the descriptor passed in. The
 //
@@ -437,7 +178,7 @@ func ShowCreate(
 	dbPrefix string,
 	allDescs []sqlbase.Descriptor,
 	desc *sqlbase.TableDescriptor,
-	ignoreFKs shouldIgnoreFKs,
+	ignoreFKs shouldOmitFKClausesFromCreate,
 ) (string, error) {
 	var stmt string
 	var err error

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -1,0 +1,298 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/pkg/errors"
+)
+
+// ShowCreateView returns a valid SQL representation of the CREATE VIEW
+// statement used to create the given view. It is used in the implementation of
+// the crdb_internal.create_statements virtual table.
+func ShowCreateView(
+	ctx context.Context, tn *tree.Name, desc *sqlbase.TableDescriptor,
+) (string, error) {
+	f := tree.NewFmtCtx(tree.FmtSimple)
+	f.WriteString("CREATE VIEW ")
+	f.FormatNode(tn)
+	f.WriteString(" (")
+	for i := range desc.Columns {
+		if i > 0 {
+			f.WriteString(", ")
+		}
+		f.FormatNameP(&desc.Columns[i].Name)
+	}
+	f.WriteString(") AS ")
+	f.WriteString(desc.ViewQuery)
+	return f.CloseAndGetString(), nil
+}
+
+// showForeignKeyConstraint returns a valid SQL representation of a FOREIGN KEY
+// clause for a given index.
+func showForeignKeyConstraint(
+	buf *bytes.Buffer,
+	dbPrefix string,
+	originTable *sqlbase.TableDescriptor,
+	fk *sqlbase.ForeignKeyConstraint,
+	lCtx *internalLookupCtx,
+) error {
+	var refNames []string
+	var originNames []string
+	var fkTableName tree.TableName
+	if lCtx != nil {
+		fkTable, err := lCtx.getTableByID(fk.ReferencedTableID)
+		if err != nil {
+			return err
+		}
+		fkDb, err := lCtx.getDatabaseByID(fkTable.ParentID)
+		if err != nil {
+			return err
+		}
+		refNames, err = fkTable.NamesForColumnIDs(fk.ReferencedColumnIDs)
+		if err != nil {
+			return err
+		}
+		fkTableName = tree.MakeTableName(tree.Name(fkDb.Name), tree.Name(fkTable.Name))
+		fkTableName.ExplicitSchema = fkDb.Name != dbPrefix
+		originNames, err = originTable.NamesForColumnIDs(fk.OriginColumnIDs)
+		if err != nil {
+			return err
+		}
+	} else {
+		refNames = []string{"???"}
+		originNames = []string{"???"}
+		fkTableName = tree.MakeTableName(tree.Name(""), tree.Name(fmt.Sprintf("[%d as ref]", fk.ReferencedTableID)))
+		fkTableName.ExplicitSchema = false
+	}
+	buf.WriteString("FOREIGN KEY (")
+	formatQuoteNames(buf, originNames...)
+	buf.WriteString(") REFERENCES ")
+	fmtCtx := tree.NewFmtCtx(tree.FmtSimple)
+	fmtCtx.FormatNode(&fkTableName)
+	buf.WriteString(fmtCtx.CloseAndGetString())
+	buf.WriteString("(")
+	formatQuoteNames(buf, refNames...)
+	buf.WriteByte(')')
+	// We omit MATCH SIMPLE because it is the default.
+	if fk.Match != sqlbase.ForeignKeyReference_SIMPLE {
+		buf.WriteByte(' ')
+		buf.WriteString(fk.Match.String())
+	}
+	if fk.OnDelete != sqlbase.ForeignKeyReference_NO_ACTION {
+		buf.WriteString(" ON DELETE ")
+		buf.WriteString(fk.OnDelete.String())
+	}
+	if fk.OnUpdate != sqlbase.ForeignKeyReference_NO_ACTION {
+		buf.WriteString(" ON UPDATE ")
+		buf.WriteString(fk.OnUpdate.String())
+	}
+	return nil
+}
+
+// ShowCreateSequence returns a valid SQL representation of the
+// CREATE SEQUENCE statement used to create the given sequence.
+func ShowCreateSequence(
+	ctx context.Context, tn *tree.Name, desc *sqlbase.TableDescriptor,
+) (string, error) {
+	f := tree.NewFmtCtx(tree.FmtSimple)
+	f.WriteString("CREATE SEQUENCE ")
+	f.FormatNode(tn)
+	opts := desc.SequenceOpts
+	f.Printf(" MINVALUE %d", opts.MinValue)
+	f.Printf(" MAXVALUE %d", opts.MaxValue)
+	f.Printf(" INCREMENT %d", opts.Increment)
+	f.Printf(" START %d", opts.Start)
+	if opts.Virtual {
+		f.Printf(" VIRTUAL")
+	}
+	return f.CloseAndGetString(), nil
+}
+
+// showFamilyClause creates the FAMILY clauses for a CREATE statement, writing them
+// to tree.FmtCtx f
+func showFamilyClause(desc *sqlbase.TableDescriptor, f *tree.FmtCtx) {
+	for _, fam := range desc.Families {
+		activeColumnNames := make([]string, 0, len(fam.ColumnNames))
+		for i, colID := range fam.ColumnIDs {
+			if _, err := desc.FindActiveColumnByID(colID); err == nil {
+				activeColumnNames = append(activeColumnNames, fam.ColumnNames[i])
+			}
+		}
+		f.WriteString(",\n\tFAMILY ")
+		formatQuoteNames(&f.Buffer, fam.Name)
+		f.WriteString(" (")
+		formatQuoteNames(&f.Buffer, activeColumnNames...)
+		f.WriteString(")")
+	}
+}
+
+// showCreateInterleave returns an INTERLEAVE IN PARENT clause for the specified
+// index, if applicable.
+//
+// The name of the parent table is prefixed by its database name unless
+// it is equal to the given dbPrefix. This allows us to elide the prefix
+// when the given index is interleaved in a table of the current database.
+func showCreateInterleave(
+	idx *sqlbase.IndexDescriptor, buf *bytes.Buffer, dbPrefix string, lCtx *internalLookupCtx,
+) error {
+	if len(idx.Interleave.Ancestors) == 0 {
+		return nil
+	}
+	intl := idx.Interleave
+	parentTableID := intl.Ancestors[len(intl.Ancestors)-1].TableID
+	var err error
+	var parentName tree.TableName
+	if lCtx != nil {
+		parentName, err = lCtx.getParentAsTableName(parentTableID, dbPrefix)
+		if err != nil {
+			return err
+		}
+	} else {
+		parentName = tree.MakeTableName(tree.Name(""), tree.Name(fmt.Sprintf("[%d as parent]", parentTableID)))
+		parentName.ExplicitCatalog = false
+		parentName.ExplicitSchema = false
+	}
+	var sharedPrefixLen int
+	for _, ancestor := range intl.Ancestors {
+		sharedPrefixLen += int(ancestor.SharedPrefixLen)
+	}
+	buf.WriteString(" INTERLEAVE IN PARENT ")
+	fmtCtx := tree.NewFmtCtx(tree.FmtSimple)
+	fmtCtx.FormatNode(&parentName)
+	buf.WriteString(fmtCtx.CloseAndGetString())
+	buf.WriteString(" (")
+	formatQuoteNames(buf, idx.ColumnNames[:sharedPrefixLen]...)
+	buf.WriteString(")")
+	return nil
+}
+
+// ShowCreatePartitioning returns a PARTITION BY clause for the specified
+// index, if applicable.
+func ShowCreatePartitioning(
+	a *sqlbase.DatumAlloc,
+	tableDesc *sqlbase.TableDescriptor,
+	idxDesc *sqlbase.IndexDescriptor,
+	partDesc *sqlbase.PartitioningDescriptor,
+	buf *bytes.Buffer,
+	indent int,
+	colOffset int,
+) error {
+	if partDesc.NumColumns == 0 {
+		return nil
+	}
+
+	// We don't need real prefixes in the DecodePartitionTuple calls because we
+	// only use the tree.Datums part of the output.
+	fakePrefixDatums := make([]tree.Datum, colOffset)
+	for i := range fakePrefixDatums {
+		fakePrefixDatums[i] = tree.DNull
+	}
+
+	indentStr := strings.Repeat("\t", indent)
+	buf.WriteString(` PARTITION BY `)
+	if len(partDesc.List) > 0 {
+		buf.WriteString(`LIST`)
+	} else if len(partDesc.Range) > 0 {
+		buf.WriteString(`RANGE`)
+	} else {
+		return errors.Errorf(`invalid partition descriptor: %v`, partDesc)
+	}
+	buf.WriteString(` (`)
+	for i := 0; i < int(partDesc.NumColumns); i++ {
+		if i != 0 {
+			buf.WriteString(", ")
+		}
+		buf.WriteString(idxDesc.ColumnNames[colOffset+i])
+	}
+	buf.WriteString(`) (`)
+	fmtCtx := tree.NewFmtCtx(tree.FmtSimple)
+	for i := range partDesc.List {
+		part := &partDesc.List[i]
+		if i != 0 {
+			buf.WriteString(`, `)
+		}
+		buf.WriteString("\n")
+		buf.WriteString(indentStr)
+		buf.WriteString("\tPARTITION ")
+		fmtCtx.FormatNameP(&part.Name)
+		_, _ = fmtCtx.Buffer.WriteTo(buf)
+		buf.WriteString(` VALUES IN (`)
+		for j, values := range part.Values {
+			if j != 0 {
+				buf.WriteString(`, `)
+			}
+			tuple, _, err := sqlbase.DecodePartitionTuple(
+				a, tableDesc, idxDesc, partDesc, values, fakePrefixDatums)
+			if err != nil {
+				return err
+			}
+			buf.WriteString(tuple.String())
+		}
+		buf.WriteString(`)`)
+		if err := ShowCreatePartitioning(
+			a, tableDesc, idxDesc, &part.Subpartitioning, buf, indent+1,
+			colOffset+int(partDesc.NumColumns),
+		); err != nil {
+			return err
+		}
+	}
+	for i, part := range partDesc.Range {
+		if i != 0 {
+			buf.WriteString(`, `)
+		}
+		buf.WriteString("\n")
+		buf.WriteString(indentStr)
+		buf.WriteString("\tPARTITION ")
+		buf.WriteString(part.Name)
+		buf.WriteString(" VALUES FROM ")
+		fromTuple, _, err := sqlbase.DecodePartitionTuple(
+			a, tableDesc, idxDesc, partDesc, part.FromInclusive, fakePrefixDatums)
+		if err != nil {
+			return err
+		}
+		buf.WriteString(fromTuple.String())
+		buf.WriteString(" TO ")
+		toTuple, _, err := sqlbase.DecodePartitionTuple(
+			a, tableDesc, idxDesc, partDesc, part.ToExclusive, fakePrefixDatums)
+		if err != nil {
+			return err
+		}
+		buf.WriteString(toTuple.String())
+	}
+	buf.WriteString("\n")
+	buf.WriteString(indentStr)
+	buf.WriteString(")")
+	return nil
+}
+
+// showConstraintClause creates the CONSTRAINT clauses for a CREATE statement,
+// writing them to tree.FmtCtx f
+func showConstraintClause(desc *sqlbase.TableDescriptor, f *tree.FmtCtx) {
+	for _, e := range desc.AllActiveAndInactiveChecks() {
+		f.WriteString(",\n\t")
+		if len(e.Name) > 0 {
+			f.WriteString("CONSTRAINT ")
+			formatQuoteNames(&f.Buffer, e.Name)
+			f.WriteString(" ")
+		}
+		f.WriteString("CHECK (")
+		f.WriteString(e.Expr)
+		f.WriteString(")")
+	}
+	f.WriteString("\n)")
+}

--- a/pkg/sql/show_create_test.go
+++ b/pkg/sql/show_create_test.go
@@ -47,7 +47,7 @@ func TestStandAloneShowCreateTable(t *testing.T) {
 	}}
 
 	name := tree.Name(desc.Name)
-	got, err := ShowCreateTable(context.TODO(), &name, "", &desc, nil, IncludeFKs)
+	got, err := ShowCreateTable(context.TODO(), &name, "", &desc, nil, IncludeFkClausesInCreate)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -504,6 +504,10 @@ func (desc *IndexDescriptor) ColNamesFormat(ctx *tree.FmtCtx) {
 	}
 }
 
+// TODO (tyler): Issue #39771 This method needs more thorough testing, probably
+// in structured_test.go. Or possibly replace it with a format method taking
+// a format context as argument.
+
 // ColNamesString returns a string describing the column names and directions
 // in this index.
 func (desc *IndexDescriptor) ColNamesString() string {
@@ -511,6 +515,8 @@ func (desc *IndexDescriptor) ColNamesString() string {
 	desc.ColNamesFormat(f)
 	return f.CloseAndGetString()
 }
+
+// TODO (tyler): Issue #39771 Same comment as ColNamesString above.
 
 // SQLString returns the SQL string describing this index. If non-empty,
 // "ON tableName" is included in the output in the correct place.
@@ -523,11 +529,11 @@ func (desc *IndexDescriptor) SQLString(tableName *tree.TableName) string {
 		f.WriteString("INVERTED ")
 	}
 	f.WriteString("INDEX ")
+	f.FormatNameP(&desc.Name)
 	if *tableName != AnonymousTable {
-		f.WriteString("ON ")
+		f.WriteString(" ON ")
 		f.FormatNode(tableName)
 	}
-	f.FormatNameP(&desc.Name)
 	f.WriteString(" (")
 	desc.ColNamesFormat(f)
 	f.WriteByte(')')

--- a/pkg/sql/sqlbase/structured_test.go
+++ b/pkg/sql/sqlbase/structured_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -1999,4 +2000,26 @@ func TestDefaultExprNil(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestSQLString(t *testing.T) {
+	colNames := []string{"derp", "foo"}
+	indexName := "idx"
+	tableName := tree.MakeTableName("DB", "t1")
+	tableName.ExplicitCatalog = false
+	tableName.ExplicitSchema = false
+	index := IndexDescriptor{Name: indexName,
+		ID:               0x0,
+		Unique:           false,
+		ColumnNames:      colNames,
+		ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC, IndexDescriptor_ASC},
+	}
+	expected := fmt.Sprintf("INDEX %s ON t1 (%s ASC, %s ASC)", indexName, colNames[0], colNames[1])
+	if got := index.SQLString(&tableName); got != expected {
+		t.Errorf("Expected '%s', but got '%s'", expected, got)
+	}
+	expected = fmt.Sprintf("INDEX %s (%s ASC, %s ASC)", indexName, colNames[0], colNames[1])
+	if got := index.SQLString(&AnonymousTable); got != expected {
+		t.Errorf("Expected '%s', but got '%s'", expected, got)
+	}
 }


### PR DESCRIPTION
Fix bug where dump would include INTERLEAVE IN PARENT statements inside
of CREATE TABLE statements. CRDB currently does not support this, thus
forcing the user to manually edit the dump files to remove the
INTERLEAVE statements themselves.

Previousily, crdb_internal.go would use show_create.go to create the
SHOW CREATE TABLE statements which would include INTERLEAVE.
crdb_internal.go would also add ALTER STATEMENTs separately to the
alter_statements of the create statements of the table. This change
removes the addition of the INTERLEAVE within show_create.go, and
included the additon of adding the INTERLEAVE statements to the
alter_statements within crdb_internal.go.

A bug was also fixed in structured.go in the SQLString method that
created the SQL string out of order when a non-empty table name is
passed in. The bug caused the "ON tablename" to be printed before
the index and without space in between the two.

Resolves: #35462

Release Note (bug fix): dump now works properly when handling
INTERLEAVED tables, printing them outside of CREATE TABLE statements.