### PR TITLE
importccl: make direct-ingest import default

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -62,6 +62,7 @@ const (
 	importOptionSkipFKs    = "skip_foreign_keys"
 
 	importOptionDirectIngest = "experimental_direct_ingestion"
+	importOptionSortedIngest = "experimental_sorted_ingestion"
 
 	pgCopyDelimiter = "delimiter"
 	pgCopyNull      = "nullif"
@@ -87,6 +88,7 @@ var importOptionExpectValues = map[string]sql.KVStringOptValidate{
 	importOptionSkipFKs: sql.KVStringOptRequireNoValue,
 
 	importOptionDirectIngest: sql.KVStringOptRequireNoValue,
+	importOptionSortedIngest: sql.KVStringOptRequireNoValue,
 
 	pgMaxRowSize: sql.KVStringOptRequireValue,
 }
@@ -372,6 +374,11 @@ func importPlanHook(
 		}
 
 		_, ingestDirectly := opts[importOptionDirectIngest]
+		_, ingestSorted := opts[importOptionSortedIngest]
+		if ingestDirectly && ingestSorted {
+			return pgerror.Newf(pgcode.Syntax, "cannot use %q with %q", importOptionDirectIngest, importOptionSortedIngest)
+		}
+		ingestDirectly = !ingestSorted
 
 		var tableDetails []jobspb.ImportDetails_Table
 		jobDesc, err := importJobDescription(p, importStmt, nil, files, opts)

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -968,7 +968,7 @@ func TestImportCSVStmt(t *testing.T) {
 			schema,
 			testFiles.filesWithDups,
 			``,
-			"primary or unique index has duplicate keys",
+			"duplicate key in primary index",
 		},
 		{
 			"no-database",
@@ -2329,7 +2329,7 @@ func TestImportLivenessWithRestart(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	const query = `IMPORT TABLE liveness.t (i INT8 PRIMARY KEY) CSV DATA ($1) WITH sstsize = '500B'`
+	const query = `IMPORT TABLE liveness.t (i INT8 PRIMARY KEY) CSV DATA ($1) WITH sstsize = '500B', experimental_sorted_ingestion`
 
 	// Start an IMPORT and wait until it's done one addsstable.
 	allowResponse = make(chan struct{})

--- a/pkg/storage/batcheval/cmd_clear_range.go
+++ b/pkg/storage/batcheval/cmd_clear_range.go
@@ -145,6 +145,7 @@ func computeStatsDelta(
 		}
 		// If we took the fast path but race is enabled, assert stats were correctly computed.
 		if fast {
+			delta.ContainsEstimates = computed.ContainsEstimates
 			if !delta.Equal(computed) {
 				log.Fatalf(ctx, "fast-path MVCCStats computation gave wrong result: diff(fast, computed) = %s",
 					pretty.Diff(delta, computed))


### PR DESCRIPTION
This changes the default implementation of IMPORT from sorted to direct.

The direct version has been available in 19.1 via the flag
"experimental_direct_ingestion" though with some known issues such
as progress support or lack of uniqueness enforcement. With these issues
having been solved or soon to be solved, turning this on by default should
help catch any remaining issues.

The old, sorted implementaion can still be used by passing the flag
"experimental_sorted_ingestion".

Sorted IMPORT runs a multi-step process wherein all input is pre-read
and then read again and run though a network-distributed sort, which
also includes nodes buffering the entirety of it in on-disk temp storage
before importing it. This process adds *siginficant* overhead to IMPORT,
but in exchange yields sorted, non-overlapping data that can be then be
made into neat, tidy, non-overlapping SSTables.

Direct IMPORT instead simply reads the input until its buffer is full, then
sorts the buffer and makes SSTables then continues. This has far less
overhead (only reads input once, no network sort or O(n) disk buffer),
but can make overlapping files on each flush as well as potentially more
small files (since splitting a fixed size buffer, of random data, by target
range could result in small amounts in each split if the number of target
ranges is large).

These downsides however can be mitigated with reasonable buffer sizes
and by trying to be smart buffering and flushing, and avoids the more
significant overhead of adding an extra read, convert and distributed
sort of the entire IMPORT.

Release note (performance improvment): IMPORT writes unsorted data directly, reducing IMPORT's overhead (but potentially increasing RocksDB compaction overhead).