### PR TITLE
importccl: Add a memory monitor to reserve/grow memory in BulkAdder

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -27,6 +27,12 @@
 <tr><td><code>kv.allocator.load_based_rebalancing</code></td><td>enumeration</td><td><code>leases and replicas</code></td><td>whether to rebalance based on the distribution of QPS across stores [off = 0, leases = 1, leases and replicas = 2]</td></tr>
 <tr><td><code>kv.allocator.qps_rebalance_threshold</code></td><td>float</td><td><code>0.25</code></td><td>minimum fraction away from the mean a store's QPS (such as queries per second) can be before it is considered overfull or underfull</td></tr>
 <tr><td><code>kv.allocator.range_rebalance_threshold</code></td><td>float</td><td><code>0.05</code></td><td>minimum fraction away from the mean a store's range count can be before it is considered overfull or underfull</td></tr>
+<tr><td><code>kv.bulk_ingest.batch_size</code></td><td>byte size</td><td><code>16 MiB</code></td><td>the maximum size of the payload in an AddSSTable request</td></tr>
+<tr><td><code>kv.bulk_ingest.buffer_increment</code></td><td>byte size</td><td><code>32 MiB</code></td><td>the size by which the BulkAdder attempts to grow its buffer before flushing</td></tr>
+<tr><td><code>kv.bulk_ingest.index_buffer_size</code></td><td>byte size</td><td><code>32 MiB</code></td><td>the initial size of the BulkAdder buffer handling secondary index imports</td></tr>
+<tr><td><code>kv.bulk_ingest.max_index_buffer_size</code></td><td>byte size</td><td><code>512 MiB</code></td><td>the maximum size of the BulkAdder buffer handling secondary index imports</td></tr>
+<tr><td><code>kv.bulk_ingest.max_pk_buffer_size</code></td><td>byte size</td><td><code>128 MiB</code></td><td>the maximum size of the BulkAdder buffer handling primary index imports</td></tr>
+<tr><td><code>kv.bulk_ingest.pk_buffer_size</code></td><td>byte size</td><td><code>32 MiB</code></td><td>the initial size of the BulkAdder buffer handling primary index imports</td></tr>
 <tr><td><code>kv.bulk_io_write.addsstable_max_rate</code></td><td>float</td><td><code>1.7976931348623157E+308</code></td><td>maximum number of AddSSTable requests per second for a single store</td></tr>
 <tr><td><code>kv.bulk_io_write.concurrent_addsstable_requests</code></td><td>integer</td><td><code>1</code></td><td>number of AddSSTable requests a store will handle concurrently before queuing</td></tr>
 <tr><td><code>kv.bulk_io_write.concurrent_export_requests</code></td><td>integer</td><td><code>3</code></td><td>number of export requests a store will handle concurrently before queuing</td></tr>
@@ -37,7 +43,6 @@
 <tr><td><code>kv.closed_timestamp.follower_reads_enabled</code></td><td>boolean</td><td><code>true</code></td><td>allow (all) replicas to serve consistent historical reads based on closed timestamp information</td></tr>
 <tr><td><code>kv.closed_timestamp.target_duration</code></td><td>duration</td><td><code>30s</code></td><td>if nonzero, attempt to provide closed timestamp notifications for timestamps trailing cluster time by approximately this duration</td></tr>
 <tr><td><code>kv.follower_read.target_multiple</code></td><td>float</td><td><code>3</code></td><td>if above 1, encourages the distsender to perform a read against the closest replica if a request is older than kv.closed_timestamp.target_duration * (1 + kv.closed_timestamp.close_fraction * this) less a clock uncertainty interval. This value also is used to create follower_timestamp(). (WARNING: may compromise cluster stability or correctness; do not edit without supervision)</td></tr>
-<tr><td><code>kv.import.batch_size</code></td><td>byte size</td><td><code>32 MiB</code></td><td>the maximum size of the payload in an AddSSTable request (WARNING: may compromise cluster stability or correctness; do not edit without supervision)</td></tr>
 <tr><td><code>kv.learner_replicas.enabled</code></td><td>boolean</td><td><code>true</code></td><td>use learner replicas for replica addition</td></tr>
 <tr><td><code>kv.raft.command.max_size</code></td><td>byte size</td><td><code>64 MiB</code></td><td>maximum size of a raft command</td></tr>
 <tr><td><code>kv.raft_log.disable_synchronization_unsafe</code></td><td>boolean</td><td><code>false</code></td><td>set to true to disable synchronization on Raft log writes to persistent storage. Setting to true risks data loss or data corruption on server crashes. The setting is meant for internal testing only and SHOULD NOT be used in production.</td></tr>
@@ -61,7 +66,9 @@
 <tr><td><code>rocksdb.ingest_backpressure.max_delay</code></td><td>duration</td><td><code>5s</code></td><td>maximum amount of time to backpressure a single SST ingestion</td></tr>
 <tr><td><code>rocksdb.ingest_backpressure.pending_compaction_threshold</code></td><td>byte size</td><td><code>64 GiB</code></td><td>pending compaction estimate above which to backpressure SST ingestions</td></tr>
 <tr><td><code>rocksdb.min_wal_sync_interval</code></td><td>duration</td><td><code>0s</code></td><td>minimum duration between syncs of the RocksDB WAL</td></tr>
-<tr><td><code>schemachanger.backfiller.buffer_size</code></td><td>byte size</td><td><code>196 MiB</code></td><td>amount to buffer in memory during backfills</td></tr>
+<tr><td><code>schemachanger.backfiller.buffer_increment</code></td><td>byte size</td><td><code>32 MiB</code></td><td>the size by which the BulkAdder attempts to grow its buffer before flushing</td></tr>
+<tr><td><code>schemachanger.backfiller.buffer_size</code></td><td>byte size</td><td><code>32 MiB</code></td><td>the initial size of the BulkAdder buffer handling index backfills</td></tr>
+<tr><td><code>schemachanger.backfiller.max_buffer_size</code></td><td>byte size</td><td><code>512 MiB</code></td><td>the maximum size of the BulkAdder buffer handling index backfills</td></tr>
 <tr><td><code>schemachanger.backfiller.max_sst_size</code></td><td>byte size</td><td><code>16 MiB</code></td><td>target size for ingested files during backfills</td></tr>
 <tr><td><code>schemachanger.bulk_index_backfill.batch_size</code></td><td>integer</td><td><code>50000</code></td><td>number of rows to process at a time during bulk index backfill</td></tr>
 <tr><td><code>schemachanger.lease.duration</code></td><td>duration</td><td><code>5m0s</code></td><td>the duration of a schema change lease</td></tr>

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -56,6 +56,8 @@ func TestImportData(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(db)
 
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.bulk_ingest.batch_size = '10KB'`)
+
 	tests := []struct {
 		name   string
 		create string
@@ -784,7 +786,7 @@ func TestImportCSVStmt(t *testing.T) {
 	conn := tc.Conns[0]
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
-	sqlDB.Exec(t, `SET CLUSTER SETTING kv.import.batch_size = '10KB'`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.bulk_ingest.batch_size = '10KB'`)
 
 	testFiles := makeCSVData(t, numFiles, rowsPerFile, nodes, rowsPerRaceFile)
 	if util.RaceEnabled {
@@ -1241,7 +1243,7 @@ func TestImportIntoCSV(t *testing.T) {
 
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
-	sqlDB.Exec(t, `SET CLUSTER SETTING kv.import.batch_size = '10KB'`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.bulk_ingest.batch_size = '10KB'`)
 
 	testFiles := makeCSVData(t, numFiles, rowsPerFile, nodes, rowsPerRaceFile)
 	if util.RaceEnabled {
@@ -2214,7 +2216,7 @@ func TestImportWorkerFailure(t *testing.T) {
 // restart in that issue was caused by node liveness and that the work
 // already performed (the splits and addsstables) somehow caused the second
 // error. However this does not appear to be the case, as running many stress
-// iterations with differing constants (rows, sstsize, kv.import.batch_size)
+// iterations with differing constants (rows, sstsize, kv.bulk_ingest.batch_size)
 // was not able to fail in the way listed by the second bug.
 func TestImportLivenessWithRestart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -2248,7 +2250,7 @@ func TestImportLivenessWithRestart(t *testing.T) {
 	// Prevent hung HTTP connections in leaktest.
 	sqlDB.Exec(t, `SET CLUSTER SETTING cloudstorage.timeout = '3s'`)
 
-	sqlDB.Exec(t, `SET CLUSTER SETTING kv.import.batch_size = '300B'`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.bulk_ingest.batch_size = '300B'`)
 	sqlDB.Exec(t, `CREATE DATABASE liveness`)
 
 	const rows = 5000
@@ -2379,7 +2381,7 @@ func TestImportLivenessWithLeniency(t *testing.T) {
 	sqlDB.Exec(t, `SET CLUSTER SETTING cloudstorage.timeout = '3s'`)
 	// We want to know exactly how much leniency is configured.
 	sqlDB.Exec(t, `SET CLUSTER SETTING jobs.registry.leniency = '1m'`)
-	sqlDB.Exec(t, `SET CLUSTER SETTING kv.import.batch_size = '300B'`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.bulk_ingest.batch_size = '300B'`)
 	sqlDB.Exec(t, `CREATE DATABASE liveness`)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2488,7 +2490,7 @@ func TestImportMysql(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
 
-	sqlDB.Exec(t, `SET CLUSTER SETTING kv.import.batch_size = '10KB'`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.bulk_ingest.batch_size = '10KB'`)
 	sqlDB.Exec(t, `CREATE DATABASE foo; SET DATABASE = foo`)
 
 	files := getMysqldumpTestdata(t)
@@ -2615,7 +2617,7 @@ func TestImportMysqlOutfile(t *testing.T) {
 	conn := tc.Conns[0]
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
-	sqlDB.Exec(t, `SET CLUSTER SETTING kv.import.batch_size = '10KB'`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.bulk_ingest.batch_size = '10KB'`)
 	sqlDB.Exec(t, `CREATE DATABASE foo; SET DATABASE = foo`)
 
 	testRows, configs := getMysqlOutfileTestdata(t)
@@ -2676,7 +2678,7 @@ func TestImportPgCopy(t *testing.T) {
 	conn := tc.Conns[0]
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
-	sqlDB.Exec(t, `SET CLUSTER SETTING kv.import.batch_size = '10KB'`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.bulk_ingest.batch_size = '10KB'`)
 	sqlDB.Exec(t, `CREATE DATABASE foo; SET DATABASE = foo`)
 
 	testRows, configs := getPgCopyTestdata(t)
@@ -2742,7 +2744,7 @@ func TestImportPgDump(t *testing.T) {
 	conn := tc.Conns[0]
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
-	sqlDB.Exec(t, `SET CLUSTER SETTING kv.import.batch_size = '10KB'`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.bulk_ingest.batch_size = '10KB'`)
 	sqlDB.Exec(t, `CREATE DATABASE foo; SET DATABASE = foo`)
 
 	simplePgTestRows, simpleFile := getSimplePostgresDumpTestdata(t)

--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -44,6 +44,8 @@ func bigInitialData(meta workload.Meta) bool {
 func TestAllRegisteredImportFixture(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	sqlMemoryPoolSize := int64(1000 << 20) // 1GiB
+
 	for _, meta := range workload.Registered() {
 		meta := meta
 		gen := meta.New()
@@ -81,7 +83,8 @@ func TestAllRegisteredImportFixture(t *testing.T) {
 
 			ctx := context.Background()
 			s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
-				UseDatabase: "d",
+				UseDatabase:       "d",
+				SQLMemoryPoolSize: sqlMemoryPoolSize,
 			})
 			defer s.Stopper().Stop(ctx)
 			sqlutils.MakeSQLRunner(db).Exec(t, `CREATE DATABASE d`)

--- a/pkg/ccl/workloadccl/format/sstable.go
+++ b/pkg/ccl/workloadccl/format/sstable.go
@@ -81,7 +81,7 @@ func ToSSTable(t workload.Table, tableID sqlbase.ID, ts time.Time) ([]byte, erro
 		sstTS := hlc.Timestamp{WallTime: ts.UnixNano()}
 		const sstSize = math.MaxUint64
 		ba, err := bulk.MakeBulkAdder(
-			&ssts, nil /* rangeCache */, sstTS, storagebase.BulkAdderOptions{SSTSize: sstSize, BufferSize: sstSize},
+			ctx, &ssts, nil /* rangeCache */, sstTS, storagebase.BulkAdderOptions{SSTSize: sstSize, MinBufferSize: sstSize}, nil, /* bulkMon */
 		)
 		if err != nil {
 			return err

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -17,7 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
-const maxSettings = 128
+const maxSettings = 256
 
 // Values is a container that stores values for all registered settings.
 // Each setting is assigned a unique slot (up to maxSettings).

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-const maxSettings = 128
+const maxSettings = 256
 
 type dummy struct {
 	msg1       string

--- a/pkg/sql/distsqlrun/bulk_row_writer.go
+++ b/pkg/sql/distsqlrun/bulk_row_writer.go
@@ -75,7 +75,7 @@ func (sp *bulkRowWriter) ingestLoop(ctx context.Context, kvCh chan []roachpb.Key
 	writeTS := sp.spec.Table.CreateAsOfTime
 	const bufferSize = 64 << 20
 	adder, err := sp.flowCtx.Cfg.BulkAdder(
-		ctx, sp.flowCtx.Cfg.DB, writeTS, storagebase.BulkAdderOptions{BufferSize: bufferSize},
+		ctx, sp.flowCtx.Cfg.DB, writeTS, storagebase.BulkAdderOptions{MinBufferSize: bufferSize},
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/distsqlrun/indexbackfiller.go
+++ b/pkg/sql/distsqlrun/indexbackfiller.go
@@ -42,7 +42,15 @@ var _ Processor = &indexBackfiller{}
 var _ chunkBackfiller = &indexBackfiller{}
 
 var backfillerBufferSize = settings.RegisterByteSizeSetting(
-	"schemachanger.backfiller.buffer_size", "amount to buffer in memory during backfills", 196<<20,
+	"schemachanger.backfiller.buffer_size", "the initial size of the BulkAdder buffer handling index backfills", 32<<20,
+)
+
+var backfillerMaxBufferSize = settings.RegisterByteSizeSetting(
+	"schemachanger.backfiller.max_buffer_size", "the maximum size of the BulkAdder buffer handling index backfills", 512<<20,
+)
+
+var backfillerBufferIncrementSize = settings.RegisterByteSizeSetting(
+	"schemachanger.backfiller.buffer_increment", "the size by which the BulkAdder attempts to grow its buffer before flushing", 32<<20,
 )
 
 var backillerSSTSize = settings.RegisterByteSizeSetting(
@@ -77,11 +85,15 @@ func newIndexBackfiller(
 }
 
 func (ib *indexBackfiller) prepare(ctx context.Context) error {
-	bufferSize := backfillerBufferSize.Get(&ib.flowCtx.Cfg.Settings.SV)
+	minBufferSize := backfillerBufferSize.Get(&ib.flowCtx.Cfg.Settings.SV)
+	maxBufferSize := backfillerMaxBufferSize.Get(&ib.flowCtx.Cfg.Settings.SV)
 	sstSize := backillerSSTSize.Get(&ib.flowCtx.Cfg.Settings.SV)
+	stepSize := backfillerBufferIncrementSize.Get(&ib.flowCtx.Cfg.Settings.SV)
 	opts := storagebase.BulkAdderOptions{
 		SSTSize:        uint64(sstSize),
-		BufferSize:     uint64(bufferSize),
+		MinBufferSize:  uint64(minBufferSize),
+		MaxBufferSize:  uint64(maxBufferSize),
+		StepBufferSize: uint64(stepSize),
 		SkipDuplicates: ib.ContainsInvertedIndex(),
 	}
 	adder, err := ib.flowCtx.Cfg.BulkAdder(ctx, ib.flowCtx.Cfg.DB, ib.spec.ReadAsOf, opts)

--- a/pkg/storage/bulk/buffering_adder.go
+++ b/pkg/storage/bulk/buffering_adder.go
@@ -20,6 +20,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/pkg/errors"
 )
 
 // BufferingAdder is a wrapper for an SSTBatcher that allows out-of-order calls
@@ -31,7 +33,13 @@ type BufferingAdder struct {
 	timestamp hlc.Timestamp
 
 	// threshold at which buffered entries will be flushed to SSTBatcher.
-	flushSize int
+	curBufferSize uint64
+
+	// ceiling till which we can grow curBufferSize if bulkMon permits.
+	maxBufferSize uint64
+
+	// unit by which we increment the curBufferSize.
+	incrementBufferSize uint64
 
 	// currently buffered kvs.
 	curBuf kvBuf
@@ -43,6 +51,9 @@ type BufferingAdder struct {
 
 	// name of the BufferingAdder for the purpose of logging only.
 	name string
+
+	bulkMon *mon.BytesMonitor
+	memAcc  mon.BoundAccount
 }
 
 // MakeBulkAdder makes a storagebase.BulkAdder that buffers and sorts K/Vs
@@ -50,17 +61,26 @@ type BufferingAdder struct {
 // consulted to avoid generating an SST that will span a range boundary and thus
 // encounter an error and need to be split and retired to be applied.
 func MakeBulkAdder(
+	ctx context.Context,
 	db sender,
 	rangeCache *kv.RangeDescriptorCache,
 	timestamp hlc.Timestamp,
 	opts storagebase.BulkAdderOptions,
+	bulkMon *mon.BytesMonitor,
 ) (*BufferingAdder, error) {
-	if opts.BufferSize == 0 {
-		opts.BufferSize = 32 << 20
+	if opts.MinBufferSize == 0 {
+		opts.MinBufferSize = 32 << 20
+	}
+	if opts.MaxBufferSize == 0 {
+		opts.MaxBufferSize = 128 << 20
+	}
+	if opts.StepBufferSize == 0 {
+		opts.StepBufferSize = 32 << 20
 	}
 	if opts.SSTSize == 0 {
-		opts.SSTSize = 32 << 20
+		opts.SSTSize = 16 << 20
 	}
+
 	b := &BufferingAdder{
 		name: opts.Name,
 		sink: SSTBatcher{
@@ -70,22 +90,49 @@ func MakeBulkAdder(
 			skipDuplicates:    opts.SkipDuplicates,
 			disallowShadowing: opts.DisallowShadowing,
 		},
-		timestamp: timestamp,
-		flushSize: int(opts.BufferSize),
+		timestamp:           timestamp,
+		curBufferSize:       opts.MinBufferSize,
+		maxBufferSize:       opts.MaxBufferSize,
+		incrementBufferSize: opts.StepBufferSize,
+		bulkMon:             bulkMon,
 	}
+
+	// If no monitor is attached to the instance of a bulk adder, we do not
+	// control its memory usage.
+	if bulkMon == nil {
+		return b, nil
+	}
+
+	// At minimum a bulk adder needs enough space to store a buffer of
+	// curBufferSize, and a subsequent SST of SSTSize in-memory. If the memory
+	// account is unable to reserve this minimum threshold we cannot continue.
+	//
+	// TODO(adityamaru): IMPORT should also reserve memory for a single SST which
+	// it will store in-memory before sending it to RocksDB.
+	b.memAcc = bulkMon.MakeBoundAccount()
+	if err := b.memAcc.Grow(ctx, int64(b.curBufferSize)); err != nil {
+		return nil, errors.Wrap(err, "Not enough memory available to create a BulkAdder. Try setting a higher --max-sql-memory.")
+	}
+
 	return b, nil
 }
 
 // Close closes the underlying SST builder.
 func (b *BufferingAdder) Close(ctx context.Context) {
 	log.VEventf(ctx, 2,
-		"bulk adder %s ingested %s, flushed %d times, %d due to buffer size. Flushed %d files, %d due to ranges, %d due to sst size",
+		"bulk adder %s ingested %s, flushed %d times, %d due to buffer size. Flushed %d files, %d due to ranges, %d due to sst size. Used %d bytes.",
 		b.name,
 		sz(b.sink.totalRows.DataSize),
 		b.flushCounts.total, b.flushCounts.bufferSize,
 		b.sink.flushCounts.total, b.sink.flushCounts.split, b.sink.flushCounts.sstSize,
+		b.memAcc.Used(),
 	)
 	b.sink.Close()
+
+	if b.bulkMon != nil {
+		b.memAcc.Close(ctx)
+		b.bulkMon.Stop(ctx)
+	}
 }
 
 // Add adds a key to the buffer and checks if it needs to flush.
@@ -94,17 +141,34 @@ func (b *BufferingAdder) Add(ctx context.Context, key roachpb.Key, value []byte)
 		return err
 	}
 
-	if b.curBuf.MemSize > b.flushSize {
-		b.flushCounts.bufferSize++
-		log.VEventf(ctx, 3, "buffer size triggering flush of %s buffer", sz(b.curBuf.MemSize))
-		return b.Flush(ctx)
+	if b.curBuf.MemSize > int(b.curBufferSize) {
+		// This is an optimization to try and increase the current buffer size if
+		// our memory account permits it. This would lead to creation of a fewer
+		// number of SSTs.
+		//
+		// To prevent a single import from growing its buffer indefinitely we check
+		// if it has exceeded its upper bound.
+		if b.bulkMon != nil && b.curBufferSize < b.maxBufferSize {
+			if err := b.memAcc.Grow(ctx, int64(b.incrementBufferSize)); err != nil {
+				// If we are unable to reserve the additional memory then flush the
+				// buffer, and continue as normal.
+				b.flushCounts.bufferSize++
+				log.VEventf(ctx, 3, "buffer size triggering flush of %s buffer", sz(b.curBuf.MemSize))
+				return b.Flush(ctx)
+			}
+			b.curBufferSize += b.incrementBufferSize
+		} else {
+			b.flushCounts.bufferSize++
+			log.VEventf(ctx, 3, "buffer size triggering flush of %s buffer", sz(b.curBuf.MemSize))
+			return b.Flush(ctx)
+		}
 	}
 	return nil
 }
 
 // CurrentBufferFill returns the current buffer fill percentage.
 func (b *BufferingAdder) CurrentBufferFill() float32 {
-	return float32(b.curBuf.MemSize) / float32(b.flushSize)
+	return float32(b.curBuf.MemSize) / float32(b.curBufferSize)
 }
 
 // Flush flushes any buffered kvs to the batcher.

--- a/pkg/storage/bulk/kv_buf.go
+++ b/pkg/storage/bulk/kv_buf.go
@@ -38,6 +38,7 @@ type kvBufEntry struct {
 	valSpan uint64
 }
 
+// entryOverhead is the slice header overhead per KV pair
 const entryOverhead = 16
 
 const (

--- a/pkg/storage/bulk/sst_batcher_test.go
+++ b/pkg/storage/bulk/sst_batcher_test.go
@@ -129,7 +129,7 @@ func runTestImport(t *testing.T, batchSize uint64) {
 
 			ts := hlc.Timestamp{WallTime: 100}
 			b, err := bulk.MakeBulkAdder(
-				kvDB, mockCache, ts, storagebase.BulkAdderOptions{BufferSize: batchSize, SSTSize: batchSize},
+				ctx, kvDB, mockCache, ts, storagebase.BulkAdderOptions{MinBufferSize: batchSize, SSTSize: batchSize}, nil, /* bulkMon */
 			)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/storage/storagebase/bulk_adder.go
+++ b/pkg/storage/storagebase/bulk_adder.go
@@ -30,8 +30,17 @@ type BulkAdderOptions struct {
 	// they may be smaller than this limit.
 	SSTSize uint64
 
-	// BufferSize is the maximum amount of data to buffer before flushing SSTs.
-	BufferSize uint64
+	// MinBufferSize is the initial size of the BulkAdder buffer. It indicates the
+	// amount of memory we require to be able to buffer data before flushing for
+	// SST creation.
+	MinBufferSize uint64
+
+	// BufferSize is the maximum size we can grow the BulkAdder buffer to.
+	MaxBufferSize uint64
+
+	// StepBufferSize is the increment in which we will attempt to grow the
+	// BulkAdder buffer if the memory monitor permits.
+	StepBufferSize uint64
 
 	// SkipLocalDuplicates configures handling of duplicate keys within a local
 	// sorted batch. When true if the same key/value pair is added more than once


### PR DESCRIPTION
This change hooks a child of the root server monitor to each
BulkAdder created during execution. The main purpose of this
is to prevent OOMs during bulk ingestion of data, either for
index backfills or direct ingest import.

This change adds three configurable fields to the BulkAdderOptions
to tune its memory usage. These fields support a scheme whereby the
BulkAdder begins with an initial buffering capacity and grows its
capacity by preset units if the memory monitor permits. This will
allow for fewer flushes and consequently fewer SSTs being produced.