### PR TITLE
storage/bulk,storagebase: add BulkAdderOptions struct

### DIFF
--- a/pkg/ccl/workloadccl/format/sstable.go
+++ b/pkg/ccl/workloadccl/format/sstable.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage/bulk"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/workload"
@@ -78,8 +79,10 @@ func ToSSTable(t workload.Table, tableID sqlbase.ID, ts time.Time) ([]byte, erro
 	})
 	g.GoCtx(func(ctx context.Context) error {
 		sstTS := hlc.Timestamp{WallTime: ts.UnixNano()}
-		const sstSize = math.MaxInt64
-		ba, err := bulk.MakeBulkAdder(&ssts, nil /* rangeCache */, sstSize, sstSize, sstTS)
+		const sstSize = math.MaxUint64
+		ba, err := bulk.MakeBulkAdder(
+			&ssts, nil /* rangeCache */, sstTS, storagebase.BulkAdderOptions{SSTSize: sstSize, BufferSize: sstSize},
+		)
 		if err != nil {
 			return err
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -537,8 +537,10 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		ClusterName:    s.cfg.ClusterName,
 
 		TempStorage: tempEngine,
-		BulkAdder: func(ctx context.Context, db *client.DB, bufferSize, flushSize int64, ts hlc.Timestamp) (storagebase.BulkAdder, error) {
-			return bulk.MakeBulkAdder(db, s.distSender.RangeDescriptorCache(), bufferSize, flushSize, ts)
+		BulkAdder: func(
+			ctx context.Context, db *client.DB, ts hlc.Timestamp, opts storagebase.BulkAdderOptions,
+		) (storagebase.BulkAdder, error) {
+			return bulk.MakeBulkAdder(db, s.distSender.RangeDescriptorCache(), ts, opts)
 		},
 		DiskMonitor: s.cfg.TempStorageConfig.Mon,
 

--- a/pkg/sql/distsqlrun/bulk_row_writer.go
+++ b/pkg/sql/distsqlrun/bulk_row_writer.go
@@ -73,8 +73,10 @@ func (sp *bulkRowWriter) OutputTypes() []types.T {
 
 func (sp *bulkRowWriter) ingestLoop(ctx context.Context, kvCh chan []roachpb.KeyValue) error {
 	writeTS := sp.spec.Table.CreateAsOfTime
-	const bufferSize, flushSize = 64 << 20, 16 << 20
-	adder, err := sp.flowCtx.Cfg.BulkAdder(ctx, sp.flowCtx.Cfg.DB, bufferSize, flushSize, writeTS)
+	const bufferSize = 64 << 20
+	adder, err := sp.flowCtx.Cfg.BulkAdder(
+		ctx, sp.flowCtx.Cfg.DB, writeTS, storagebase.BulkAdderOptions{BufferSize: bufferSize},
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/distsqlrun/indexbackfiller.go
+++ b/pkg/sql/distsqlrun/indexbackfiller.go
@@ -79,12 +79,16 @@ func newIndexBackfiller(
 func (ib *indexBackfiller) prepare(ctx context.Context) error {
 	bufferSize := backfillerBufferSize.Get(&ib.flowCtx.Cfg.Settings.SV)
 	sstSize := backillerSSTSize.Get(&ib.flowCtx.Cfg.Settings.SV)
-	adder, err := ib.flowCtx.Cfg.BulkAdder(ctx, ib.flowCtx.Cfg.DB, bufferSize, sstSize, ib.spec.ReadAsOf)
+	opts := storagebase.BulkAdderOptions{
+		SSTSize:        uint64(sstSize),
+		BufferSize:     uint64(bufferSize),
+		SkipDuplicates: ib.ContainsInvertedIndex(),
+	}
+	adder, err := ib.flowCtx.Cfg.BulkAdder(ctx, ib.flowCtx.Cfg.DB, ib.spec.ReadAsOf, opts)
 	if err != nil {
 		return err
 	}
 	ib.adder = adder
-	ib.adder.SkipLocalDuplicates(ib.ContainsInvertedIndex())
 	return nil
 }
 

--- a/pkg/storage/bulk/sst_batcher_test.go
+++ b/pkg/storage/bulk/sst_batcher_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/bulk"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -42,7 +43,7 @@ func TestAddBatched(t *testing.T) {
 	})
 }
 
-func runTestImport(t *testing.T, batchSize int64) {
+func runTestImport(t *testing.T, batchSize uint64) {
 
 	ctx := context.Background()
 	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
@@ -127,7 +128,9 @@ func runTestImport(t *testing.T, batchSize int64) {
 			}
 
 			ts := hlc.Timestamp{WallTime: 100}
-			b, err := bulk.MakeBulkAdder(kvDB, mockCache, batchSize, batchSize, ts)
+			b, err := bulk.MakeBulkAdder(
+				kvDB, mockCache, ts, storagebase.BulkAdderOptions{BufferSize: batchSize, SSTSize: batchSize},
+			)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/storage/storagebase/bulk_adder.go
+++ b/pkg/storage/storagebase/bulk_adder.go
@@ -19,9 +19,36 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
+// BulkAdderOptions is used to configure the behavior of a BulkAdder.
+type BulkAdderOptions struct {
+	// Name is used in logging messages to identify this adder or the process on
+	// behalf of which it is adding data.
+	Name string
+
+	// SSTSize is the size at which an SST will be flushed and a new one started.
+	// SSTs are also split during a buffer flush to avoid spanning range bounds so
+	// they may be smaller than this limit.
+	SSTSize uint64
+
+	// BufferSize is the maximum amount of data to buffer before flushing SSTs.
+	BufferSize uint64
+
+	// SkipLocalDuplicates configures handling of duplicate keys within a local
+	// sorted batch. When true if the same key/value pair is added more than once
+	// subsequent additions will be ignored instead of producing an error. If an
+	// attempt to add the same key has a differnet value, it is always an error.
+	// Once a batch is flushed – explicitly or automatically – local duplicate
+	// detection does not apply.
+	SkipDuplicates bool
+
+	// DisallowShadowing controls whether shadowing of existing keys is permitted
+	// when the SSTables produced by this adder are ingested.
+	DisallowShadowing bool
+}
+
 // BulkAdderFactory describes a factory function for BulkAdders.
 type BulkAdderFactory func(
-	ctx context.Context, db *client.DB, bufferBytes, flushBytes int64, timestamp hlc.Timestamp,
+	ctx context.Context, db *client.DB, timestamp hlc.Timestamp, opts BulkAdderOptions,
 ) (BulkAdder, error)
 
 // BulkAdder describes a bulk-adding helper that can be used to add lots of KVs.
@@ -36,18 +63,6 @@ type BulkAdder interface {
 	GetSummary() roachpb.BulkOpSummary
 	// Close closes the underlying buffers/writers.
 	Close(ctx context.Context)
-	// SkipLocalDuplicates configures handling of duplicate keys within a local
-	// sorted batch. Once a batch is flushed – explicitly or automatically – local
-	// duplicate detection does not apply.
-	SkipLocalDuplicates(bool)
-	// SkipLocalDuplicatesWithSameValues configures handling of duplicate keys
-	// with the same value within a local sorted batch.
-	SkipLocalDuplicatesWithSameValues(bool)
-	// SetDisallowShadowing sets the flag which controls whether shadowing of
-	// existing keys is permitted in the AddSSTable method.
-	SetDisallowShadowing(bool)
-	// SetName sets the name of the adder for the purpose of logging adder stats.
-	SetName(string)
 }
 
 // DuplicateKeyError represents a failed attempt to ingest the same key twice


### PR DESCRIPTION
The signature on this is hard to modify as it is plumbed though in several places,
and as a result, many flags that control one behavior or another, like if SSTs
should be added disallowing duplicates, were being mutated via 'Set' functions
that were starting to get messy.

By making a options struct that is in the signature used and plumbed through all
the sql/distsql/etc layers, any new flags can be added here with minimal extra
work involved.

Release note: none.