### PR TITLE
rpc: don't enable internalClientAdapter until rpcServer is operational

### DIFF
--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -57,7 +57,10 @@ func (s *grpcServer) setMode(mode serveMode) {
 	s.mode.set(mode)
 }
 
-func (s *grpcServer) operational() bool {
+// Operational returns whether the grpcServer is currently operational
+// based on the current server mode. Non-operational grpc servers will
+// only serve a subset of RPC methods.
+func (s *grpcServer) Operational() bool {
 	sMode := s.mode.get()
 	return sMode == modeOperational || sMode == modeDraining
 }
@@ -71,7 +74,7 @@ var rpcsAllowedWhileBootstrapping = map[string]struct{}{
 
 // intercept implements filtering rules for each server state.
 func (s *grpcServer) intercept(fullName string) error {
-	if s.operational() {
+	if s.Operational() {
 		return nil
 	}
 	if _, allowed := rpcsAllowedWhileBootstrapping[fullName]; !allowed {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1111,9 +1111,12 @@ func (s *Server) Start(ctx context.Context) error {
 	s.startTime = timeutil.Now()
 	s.startMonitoringForwardClockJumps(ctx)
 
-	// Connect the node as loopback handler for RPC requests to the
-	// local node.
-	s.rpcContext.SetLocalInternalServer(s.node)
+	// Connect the node as loopback handler for RPC requests to the local node.
+	// Provide the Server's grpcServer as the adapter's OperationalCheck to
+	// ensure that they are both enabled at the same time. We don't want this
+	// adapter enabled until the rpc server is operational as well (i.e. after
+	// the server has finished initialization).
+	s.rpcContext.SetLocalInternalServer(s.node, s.grpc)
 
 	// Load the TLS configuration for the HTTP server.
 	uiTLSConfig, err := s.cfg.GetUIServerTLSConfig()


### PR DESCRIPTION
Fixes #39415.

This commit fixes the issue we saw in #39415, where a node would attempt
to allocate a store ID for a new store on an existing node and would
get stuck. The reason it would get stuck is because the KV request to
allocate the store ID could be routed to the node's own replica for
Range 1 (when doing a range descriptor lookup) over the node's
internalClientAdapter. This KV request could then get stuck attempting
to acquire a lease because we would still be blocking all Raft RPC
traffic (see rpcsAllowedWhileBootstrapping). This would cause the KV
request to stall indefinitely.

The fix is to tie the operationality of the internalClientAdapter to
that of the rpcServer. If we don't want to be serving external KV
traffic during this node initialization period then we shouldn't
be serving internal KV traffic.

DNM: this still needs a higher-level test that verifies that the bug
during the bootstrap problem we saw when adding a store to a node with
existing stores is no longer possible. I have only verified this
manually so far.

Release note: None