### PR TITLE
[DNM, prototype] opt: allow alternate plans to be used upon request

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1812,6 +1812,10 @@ func (m *sessionDataMutator) SetVectorizeRowCountThreshold(val uint64) {
 	m.data.VectorizeRowCountThreshold = val
 }
 
+func (m *sessionDataMutator) SetOptimizerAlternate(val sessiondata.OptimizerAlternate) {
+	m.data.OptimizerAlternate = val
+}
+
 func (m *sessionDataMutator) SetOptimizerFKs(val bool) {
 	m.data.OptimizerFKs = val
 }

--- a/pkg/sql/logictest/testdata/logic_test/alternate
+++ b/pkg/sql/logictest/testdata/logic_test/alternate
@@ -1,0 +1,134 @@
+# LogicTest: local
+
+statement ok
+CREATE TABLE alternate (
+    a INT,
+    b INT,
+    c INT,
+    d INT,
+    e INT,
+    f INT,
+    PRIMARY KEY (d, a, b),
+    INDEX second (d, e, f),
+    INDEX third (a, d, e, f)
+)
+
+statement ok
+CREATE TABLE simple (
+    a INT PRIMARY KEY, 
+    b INT,
+    c INT,
+    d INT,
+    INDEX second (b),
+    INDEX third (b, c)
+)
+
+statement ok
+INSERT INTO alternate values (1, 1, 1, 1, 1, 1), (2, 2, 2, 2, 1, 2), (3, 2, 2, 2, 1, 5)
+
+query IIIIII
+SELECT a, b, c, d, e, f FROM alternate where d > 1 and d < 3 and e = 1
+----
+2  2  2  2  1  2
+3  2  2  2  1  5
+
+query T
+EXPLAIN (OPT) SELECT * FROM simple where b > 1
+----
+select
+ ├── scan simple
+ └── filters
+      └── b > 1
+
+query T
+EXPLAIN (OPT, VERBOSE) SELECT a, b, c, d, e, f FROM alternate where d > 1 and d < 3 and e = 1
+----
+index-join alternate
+ ├── columns: a:1 b:2 c:3 d:4 e:5 f:6
+ ├── stats: [rows=0.099, distinct(1)=0.099, null(1)=0, distinct(2)=0.099, null(2)=0, distinct(4)=0.099, null(4)=0, distinct(5)=0.099, null(5)=0]
+ ├── cost: 0.55955
+ ├── key: (1,2)
+ ├── fd: ()-->(4,5), (1,2)-->(3,6)
+ ├── prune: (1-3,6)
+ └── scan alternate@second
+      ├── columns: a:1 b:2 d:4 e:5 f:6
+      ├── constraint: /4/5/6/1/2: [/2/1 - /2/1]
+      ├── stats: [rows=0.099, distinct(1)=0.099, null(1)=0, distinct(2)=0.099, null(2)=0, distinct(4)=0.099, null(4)=0, distinct(5)=0.099, null(5)=0]
+      ├── cost: 0.1288
+      ├── key: (1,2)
+      └── fd: ()-->(4,5), (1,2)-->(6)
+
+statement ok
+SET OPTIMIZER_ALTERNATE = 1
+
+query IIIIII
+SELECT a, b, c, d, e, f FROM alternate where d > 1 and d < 3 and e = 1
+----
+2  2  2  2  1  2
+3  2  2  2  1  5
+
+query T
+EXPLAIN (OPT) SELECT * FROM simple where b > 1
+----
+index-join simple
+ └── scan simple@second
+      └── constraint: /2/1: [/2 - ]
+
+query T
+EXPLAIN (OPT, VERBOSE) SELECT a, b, c, d, e, f FROM alternate where d > 1 and d < 3 and e = 1
+----
+select
+ ├── columns: a:1 b:2 c:3 d:4 e:5 f:6
+ ├── stats: [rows=0.099, distinct(1)=0.099, null(1)=0, distinct(2)=0.099, null(2)=0, distinct(4)=0.099, null(4)=0, distinct(5)=0.099, null(5)=0]
+ ├── cost: 12.52
+ ├── key: (1,2)
+ ├── fd: ()-->(4,5), (1,2)-->(3,6)
+ ├── prune: (1-3,6)
+ ├── scan alternate
+ │    ├── columns: a:1 b:2 c:3 d:4 e:5 f:6
+ │    ├── constraint: /4/1/2: [/2 - /2]
+ │    ├── stats: [rows=10, distinct(1)=9.5617925, null(1)=0, distinct(2)=9.5617925, null(2)=0, distinct(4)=1, null(4)=0]
+ │    ├── cost: 12.41
+ │    ├── key: (1,2)
+ │    └── fd: ()-->(4), (1,2)-->(3,5,6)
+ └── filters
+      └── e = 1 [outer=(5), constraints=(/5: [/1 - /1]; tight), fd=()-->(5)]
+
+
+statement ok
+SET OPTIMIZER_ALTERNATE = 2
+
+query T
+EXPLAIN (OPT, VERBOSE) SELECT a, b, c, d, e, f FROM alternate where d > 1 and d < 3 and e = 1
+----
+select
+ ├── columns: a:1 b:2 c:3 d:4 e:5 f:6
+ ├── stats: [rows=0.099, distinct(1)=0.099, null(1)=0, distinct(2)=0.099, null(2)=0, distinct(4)=0.099, null(4)=0, distinct(5)=0.099, null(5)=0]
+ ├── cost: 1250.03
+ ├── key: (1,2)
+ ├── fd: ()-->(4,5), (1,2)-->(3,6)
+ ├── prune: (1-3,6)
+ ├── scan alternate
+ │    ├── columns: a:1 b:2 c:3 d:4 e:5 f:6
+ │    ├── stats: [rows=1000, distinct(1)=100, null(1)=0, distinct(2)=100, null(2)=0, distinct(4)=100, null(4)=0, distinct(5)=100, null(5)=10]
+ │    ├── cost: 1240.02
+ │    ├── key: (1,2,4)
+ │    ├── fd: (1,2,4)-->(3,5,6)
+ │    └── prune: (1-6)
+ └── filters
+      ├── (d > 1) AND (d < 3) [outer=(4), constraints=(/4: [/2 - /2]; tight), fd=()-->(4)]
+      └── e = 1 [outer=(5), constraints=(/5: [/1 - /1]; tight), fd=()-->(5)]
+
+
+query IIIIII
+SELECT a, b, c, d, e, f FROM alternate where d > 1 and d < 3 and e = 1
+----
+2  2  2  2  1  2
+3  2  2  2  1  5
+
+query T
+EXPLAIN (OPT) SELECT * FROM simple where b > 1
+----
+index-join simple
+ └── scan simple@third
+      └── constraint: /2/3/1: [/2 - ]

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1536,6 +1536,7 @@ locality                             region=test,dc=dc1  NULL      NULL        N
 lock_timeout                         0                   NULL      NULL        NULL        string
 max_index_keys                       32                  NULL      NULL        NULL        string
 node_id                              1                   NULL      NULL        NULL        string
+optimizer_alternate                  0                   NULL      NULL        NULL        string
 reorder_joins_limit                  4                   NULL      NULL        NULL        string
 results_buffer_size                  16384               NULL      NULL        NULL        string
 row_security                         off                 NULL      NULL        NULL        string
@@ -1590,6 +1591,7 @@ locality                             region=test,dc=dc1  NULL  user     NULL    
 lock_timeout                         0                   NULL  user     NULL      0                   0
 max_index_keys                       32                  NULL  user     NULL      32                  32
 node_id                              1                   NULL  user     NULL      1                   1
+optimizer_alternate                  0                   NULL  user     NULL      0                   0
 reorder_joins_limit                  4                   NULL  user     NULL      4                   4
 results_buffer_size                  16384               NULL  user     NULL      16384               16384
 row_security                         off                 NULL  user     NULL      off                 off
@@ -1641,6 +1643,7 @@ lock_timeout                         NULL    NULL     NULL     NULL        NULL
 max_index_keys                       NULL    NULL     NULL     NULL        NULL
 node_id                              NULL    NULL     NULL     NULL        NULL
 optimizer                            NULL    NULL     NULL     NULL        NULL
+optimizer_alternate                  NULL    NULL     NULL     NULL        NULL
 reorder_joins_limit                  NULL    NULL     NULL     NULL        NULL
 results_buffer_size                  NULL    NULL     NULL     NULL        NULL
 row_security                         NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -50,6 +50,7 @@ locality                             region=test,dc=dc1
 lock_timeout                         0
 max_index_keys                       32
 node_id                              1
+optimizer_alternate                  0
 reorder_joins_limit                  4
 results_buffer_size                  16384
 row_security                         off

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -325,6 +325,19 @@ func (m *Memo) SetBestProps(
 	bp.cost = cost
 }
 
+// ForceSetBestProps sets the pops similar to SetBestProps above but updates the
+// best cost even if we are making it worse.
+// It is called by the optimizer once it determines the expression in the group
+// that is part of the appropriate alternate tree (for the overall query).
+func (m *Memo) ForceSetBestProps(
+	e RelExpr, required *physical.Required, provided *physical.Provided, cost Cost,
+) {
+	bp := e.bestProps()
+	bp.required = required
+	bp.provided = *provided
+	bp.cost = cost
+}
+
 // ResetCost updates the cost of a relational expression's memo group. It
 // should *only* be called by Optimizer.RecomputeCost() for testing purposes.
 func (m *Memo) ResetCost(e RelExpr, cost Cost) {

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -375,3 +375,110 @@ memo (optimized, ~3KB, required=[presentation: tag:4])
  │         ├── best: (show-trace-for-session &{TRACE false [1 2 3 4 5 6 7]})
  │         └── cost: 0.01
  └── G3: (aggregations)
+
+exec-ddl
+CREATE TABLE alternate (
+    a INT,
+    b INT,
+    c INT,
+    d INT,
+    e INT,
+    f INT,
+    PRIMARY KEY (d, a, b),
+    INDEX second (d, e, f),
+    INDEX third (a, d, e, f)
+)
+----
+
+opt
+SELECT a.a, a.b FROM alternate as a JOIN alternate as b ON a.a = b.a JOIN alternate as c ON a.a = c.a
+----
+project
+ ├── columns: a:1(int!null) b:2(int!null)
+ └── inner-join (merge)
+      ├── columns: a.a:1(int!null) a.b:2(int!null) b.a:7(int!null) c.a:13(int!null)
+      ├── left ordering: +1
+      ├── right ordering: +13
+      ├── fd: (1)==(7,13), (7)==(1,13), (13)==(1,7)
+      ├── inner-join (merge)
+      │    ├── columns: a.a:1(int!null) a.b:2(int!null) b.a:7(int!null)
+      │    ├── left ordering: +1
+      │    ├── right ordering: +7
+      │    ├── fd: (1)==(7), (7)==(1)
+      │    ├── ordering: +(1|7) [actual: +1]
+      │    ├── scan a@third
+      │    │    ├── columns: a.a:1(int!null) a.b:2(int!null)
+      │    │    └── ordering: +1
+      │    ├── scan b@third
+      │    │    ├── columns: b.a:7(int!null)
+      │    │    └── ordering: +7
+      │    └── filters (true)
+      ├── scan c@third
+      │    ├── columns: c.a:13(int!null)
+      │    └── ordering: +13
+      └── filters (true)
+
+memo
+SELECT a.a, a.b FROM alternate as a JOIN alternate as b ON a.a = b.a JOIN alternate as c ON a.a = c.a
+----
+memo (optimized, ~30KB, required=[presentation: a:1,b:2])
+ ├── G1: (project G2 G3 a b)
+ │    └── [presentation: a:1,b:2]
+ │         ├── best: (project G2 G3 a b)
+ │         └── cost: 5420.09
+ ├── G2: (inner-join G4 G5 G6) (inner-join G5 G4 G6) (merge-join G4 G5 G7 inner-join,+1,+13) (lookup-join G4 G7 alternate@third,keyCols=[1],outCols=(1,2,7,13)) (inner-join G8 G9 G10) (inner-join G11 G12 G13) (merge-join G5 G4 G7 inner-join,+13,+1) (inner-join G9 G8 G10) (merge-join G8 G9 G6 inner-join,+1,+7) (inner-join G12 G11 G13) (merge-join G11 G12 G7 inner-join,+7,+1) (merge-join G9 G8 G6 inner-join,+7,+1) (lookup-join G9 G6 alternate@third,keyCols=[7],outCols=(1,2,7,13)) (merge-join G12 G11 G7 inner-join,+1,+7) (lookup-join G12 G7 alternate@third,keyCols=[1],outCols=(1,2,7,13))
+ │    └── []
+ │         ├── best: (merge-join G4="[ordering: +(1|7)]" G5="[ordering: +13]" G7 inner-join,+1,+13)
+ │         └── cost: 4420.08
+ ├── G3: (projections)
+ ├── G4: (inner-join G8 G11 G13) (inner-join G11 G8 G13) (merge-join G8 G11 G7 inner-join,+1,+7) (lookup-join G8 G7 alternate@third,keyCols=[1],outCols=(1,2,7)) (merge-join G11 G8 G7 inner-join,+7,+1) (lookup-join G11 G7 alternate@third,keyCols=[7],outCols=(1,2,7))
+ │    ├── [ordering: +(1|7)]
+ │    │    ├── best: (merge-join G8="[ordering: +1]" G11="[ordering: +7]" G7 inner-join,+1,+7)
+ │    │    └── cost: 2250.05
+ │    └── []
+ │         ├── best: (merge-join G8="[ordering: +1]" G11="[ordering: +7]" G7 inner-join,+1,+7)
+ │         └── cost: 2250.05
+ ├── G5: (scan c,cols=(13)) (scan c@second,cols=(13)) (scan c@third,cols=(13))
+ │    ├── [ordering: +13]
+ │    │    ├── best: (scan c@third,cols=(13))
+ │    │    └── cost: 1060.02
+ │    └── []
+ │         ├── best: (scan c@second,cols=(13))
+ │         └── cost: 1060.02
+ ├── G6: (filters G14)
+ ├── G7: (filters)
+ ├── G8: (scan a,cols=(1,2)) (scan a@second,cols=(1,2)) (scan a@third,cols=(1,2))
+ │    ├── [ordering: +1]
+ │    │    ├── best: (scan a@third,cols=(1,2))
+ │    │    └── cost: 1070.02
+ │    └── []
+ │         ├── best: (scan a@second,cols=(1,2))
+ │         └── cost: 1070.02
+ ├── G9: (inner-join G11 G5 G7) (inner-join G5 G11 G7)
+ │    ├── [ordering: +7]
+ │    │    ├── best: (sort G9)
+ │    │    └── cost: 430781.43
+ │    └── []
+ │         ├── best: (inner-join G11 G5 G7)
+ │         └── cost: 12150.05
+ ├── G10: (filters G15 G14)
+ ├── G11: (scan b,cols=(7)) (scan b@second,cols=(7)) (scan b@third,cols=(7))
+ │    ├── [ordering: +7]
+ │    │    ├── best: (scan b@third,cols=(7))
+ │    │    └── cost: 1060.02
+ │    └── []
+ │         ├── best: (scan b@second,cols=(7))
+ │         └── cost: 1060.02
+ ├── G12: (inner-join G8 G5 G6) (inner-join G5 G8 G6) (merge-join G8 G5 G7 inner-join,+1,+13) (lookup-join G8 G7 alternate@third,keyCols=[1],outCols=(1,2,13)) (merge-join G5 G8 G7 inner-join,+13,+1) (lookup-join G5 G7 alternate@third,keyCols=[13],outCols=(1,2,13))
+ │    ├── [ordering: +(1|13)]
+ │    │    ├── best: (merge-join G8="[ordering: +1]" G5="[ordering: +13]" G7 inner-join,+1,+13)
+ │    │    └── cost: 2250.05
+ │    └── []
+ │         ├── best: (merge-join G8="[ordering: +1]" G5="[ordering: +13]" G7 inner-join,+1,+13)
+ │         └── cost: 2250.05
+ ├── G13: (filters G15)
+ ├── G14: (eq G16 G17)
+ ├── G15: (eq G16 G18)
+ ├── G16: (variable a.a)
+ ├── G17: (variable c.a)
+ └── G18: (variable b.a)

--- a/pkg/sql/opt/xform/explorer.go
+++ b/pkg/sql/opt/xform/explorer.go
@@ -197,13 +197,13 @@ func (e *explorer) exploreGroup(grp memo.RelExpr) *exploreState {
 // lookupExploreState returns the optState struct associated with the memo
 // group.
 func (e *explorer) lookupExploreState(grp memo.RelExpr) *exploreState {
-	return &e.o.lookupOptState(grp, physical.MinRequired).explore
+	return &e.o.optState.lookupOptState(grp, physical.MinRequired).explore
 }
 
 // ensureExploreState allocates the exploration state in the optState struct
 // associated with the memo group, with respect to the min physical props.
 func (e *explorer) ensureExploreState(grp memo.RelExpr) *exploreState {
-	return &e.o.ensureOptState(grp, physical.MinRequired).explore
+	return &e.o.optState.ensureOptState(grp, physical.MinRequired).explore
 }
 
 // ----------------------------------------------------------------------

--- a/pkg/sql/opt/xform/memo_format.go
+++ b/pkg/sql/opt/xform/memo_format.go
@@ -88,9 +88,9 @@ func (mf *memoFormatter) format() string {
 		for _, s := range e.states {
 			mf.buf.Reset()
 			c := tpChild.Childf("%s", s.required)
-			mf.formatBest(s.best, s.required)
+			mf.formatBest(s.bestExpr(), s.required)
 			c.Childf("best: %s", mf.buf.String())
-			c.Childf("cost: %.2f", s.cost)
+			c.Childf("cost: %.2f", s.bestCost())
 		}
 	}
 
@@ -173,7 +173,7 @@ func (mf *memoFormatter) numberExpr(expr opt.Expr) {
 }
 
 func (mf *memoFormatter) populateStates() {
-	for groupStateKey, groupState := range mf.o.stateMap {
+	for groupStateKey, groupState := range mf.o.optState.stateMap {
 		if !groupState.fullyOptimized {
 			continue
 		}

--- a/pkg/sql/opt/xform/state.go
+++ b/pkg/sql/opt/xform/state.go
@@ -1,0 +1,415 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package xform
+
+import (
+	"container/heap"
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/errors"
+)
+
+// optState contains all the relevant information about the states
+// of the different groups in the memo.
+type optState struct {
+	// stateMap allocates temporary storage that's used to speed up optimization.
+	// This state could be discarded once optimization is complete.
+	stateMap   map[groupStateKey]*groupState
+	stateAlloc groupStateAlloc
+
+	// alternate stores information about what plan we want the optimizer
+	// to pick. By default this is set to 0, indicating the best plan found
+	// is picked. If alternate plan is set to n, then teh optimizer picks
+	// the n-th best plan.
+	alternate int
+
+	// alternateExprHeap is a min heap containing all the enumerated plans
+	// for the query
+	alternateExprHeap alternateExprHeap
+
+	// candidateState stores values that can be used to restore the state
+	// of all the group states for the candidate.
+	candidateState map[candidate]candidateCurrentState
+}
+
+func (o *optState) init(alternate int) {
+	o.stateMap = make(map[groupStateKey]*groupState)
+	o.alternate = alternate
+
+	if alternate > 0 {
+		heap.Init(&o.alternateExprHeap)
+		o.candidateState = make(map[candidate]candidateCurrentState)
+	}
+}
+
+func (o *optState) clean() {
+	for _, groupState := range o.stateMap {
+		groupState.setCurrentCandidate(0)
+	}
+
+	o.stateMap = nil
+	o.alternateExprHeap = nil
+	o.candidateState = nil
+}
+
+// lookupOptState looks up the state associated with the given group and
+// properties. If no state exists yet, then lookupOptState returns nil.
+func (o *optState) lookupOptState(grp memo.RelExpr, required *physical.Required) *groupState {
+	return o.stateMap[groupStateKey{group: grp, required: required}]
+}
+
+// ensureOptState looks up the state associated with the given group and
+// properties. If none is associated yet, then ensureOptState allocates new
+// state and returns it.
+func (o *optState) ensureOptState(grp memo.RelExpr, required *physical.Required) *groupState {
+	key := groupStateKey{group: grp, required: required}
+	state, ok := o.stateMap[key]
+	if !ok {
+		state = o.stateAlloc.allocate()
+		state.required = required
+		o.stateMap[key] = state
+	}
+	return state
+}
+
+// ratchetCost computes the cost of the candidate expression, and then checks
+// whether it's lower than the cost of the existing best expression in the
+// group. If so, then the candidate becomes the new lowest cost expression.
+func (o *optState) ratchetCost(state *groupState, candidateExpr memo.RelExpr, cost memo.Cost) {
+	if state.best == nil || cost.Less(state.cost) {
+		state.best = candidateExpr
+		state.cost = cost
+	}
+
+	// We must store more information as they might be needed when generating
+	// alternate plans.
+	if o.alternate > 0 {
+		if state.candidates == nil {
+			state.candidates = make([]candidate, 0, o.alternate)
+		}
+		state.candidates = append(state.candidates, candidate{candidateExpr, cost})
+	}
+}
+
+// sortCandidates sorts all the candidates in all the group states.
+// A sorted order of candidates is required before we can begin finding
+// alternate plans.
+func (o *optState) sortCandidates() {
+	for _, state := range o.stateMap {
+		sort.Slice(state.candidates, func(i, j int) bool {
+			return state.candidates[i].cost < state.candidates[j].cost
+		})
+	}
+}
+
+// restoreFromCandidateState restores all the candidate positions based
+// on the candidateState provided.
+func (o *optState) restoreFromCandidateState(cs candidateCurrentState) {
+	for groupKey, groupState := range o.stateMap {
+		groupState.setCurrentCandidate(cs.currentStates[groupKey])
+	}
+}
+
+// getCurrentState creates a candidateCurrentState based on the current
+// current position layout.
+func (o *optState) getCurrentState() candidateCurrentState {
+	var cs candidateCurrentState
+	cs.currentStates = make(map[groupStateKey]int)
+	for groupKey, groupState := range o.stateMap {
+		cs.currentStates[groupKey] = groupState.getCurrentCandidate()
+	}
+
+	return cs
+}
+
+// candidate stores an expression with its corresponding cost. It is used
+// to store alternate expressions for a given group state.
+type candidate struct {
+	candidateExpr opt.Expr
+	cost          memo.Cost
+}
+
+type alternateExprHeap []candidate
+
+func (h alternateExprHeap) Len() int           { return len(h) }
+func (h alternateExprHeap) Less(i, j int) bool { return h[i].cost < h[j].cost }
+func (h alternateExprHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+
+func (h *alternateExprHeap) Push(x interface{}) {
+	// Push and Pop use pointer receivers because they modify the slice's length,
+	// not just its contents.
+	*h = append(*h, x.(candidate))
+}
+
+func (h *alternateExprHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}
+
+// candidateCurrentStates stores the current candidate position for
+// each group state at the time the candidate was inserted into the heap.
+type candidateCurrentState struct {
+	currentStates map[groupStateKey]int
+}
+
+// groupStateKey associates groupState with a group that is being optimized with
+// respect to a set of physical properties.
+type groupStateKey struct {
+	group    memo.RelExpr
+	required *physical.Required
+}
+
+// groupState is temporary storage that's associated with each group that's
+// optimized (or same group with different sets of physical properties). The
+// optimizer stores various flags and other state here that allows it to do
+// quicker lookups and short-circuit already traversed parts of the expression
+// tree.
+type groupState struct {
+	// best identifies the lowest cost expression in the memo group for a given
+	// set of physical properties.
+	best memo.RelExpr
+
+	// required is the set of physical properties that must be provided by this
+	// lowest cost expression. An expression that cannot provide these properties
+	// cannot be the best expression, no matter how low its cost.
+	required *physical.Required
+
+	// cost is the estimated execution cost for this expression. The best
+	// expression for a given group and set of physical properties is the
+	// expression with the lowest cost.
+	cost memo.Cost
+
+	// fullyOptimized is set to true once the lowest cost expression has been
+	// found for a memo group, with respect to the required properties. A lower
+	// cost expression will never be found, no matter how many additional
+	// optimization passes are made.
+	fullyOptimized bool
+
+	// fullyOptimizedExprs contains the set of ordinal positions of each member
+	// expression in the group that has been fully optimized for the required
+	// properties. These never need to be recosted, no matter how many additional
+	// optimization passes are made.
+	fullyOptimizedExprs util.FastIntSet
+
+	// explore is used by the explorer to store intermediate state so that
+	// redundant work is minimized.
+	explore exploreState
+
+	// candidates stores all the expressions in the groupState after being costed.
+	// candidates are only needed if an alternate expression is being looked for.
+	// TODO(ridwanmsharif): We should bound this by |alternate|. Using a heap here
+	//  could be useful.
+	candidates []candidate
+
+	// currentCandididate denotes an index in candidates that is being considered
+	// for this group state.
+	currentCandidate int
+}
+
+// currCandidate returns the index of the current candidate expression in
+// the group state candidates.
+func (os *groupState) getCurrentCandidate() int {
+	return os.currentCandidate
+}
+
+// setCurrentCandidate sets the current candidate index.
+func (os *groupState) setCurrentCandidate(candidate int) {
+	os.currentCandidate = candidate
+}
+
+// bestExpr returns the best expression for this group state based on what has been
+// fixed. If we're looking for the optimal plan, this returns the lowest cost
+// expression. Otherwise this returns the lowest cost candidate expression given that
+// the groupState is being fixed.
+func (os *groupState) bestExpr() memo.RelExpr {
+	if len(os.candidates) == 0 {
+		return os.best
+	}
+
+	// There are alternate ones.
+	return os.candidates[os.getCurrentCandidate()].candidateExpr.(memo.RelExpr)
+}
+
+// bestCost returns the cost opf the best expression for this group state based
+// on what has been fixed. If we're looking for the optimal plan, this returns the
+// cost of the best expression. Otherwise this returns the cost of the lowest cost
+// candidate expression given that the groupState is being fixed.
+func (os *groupState) bestCost() memo.Cost {
+	if len(os.candidates) == 0 {
+		return os.cost
+	}
+
+	// There are alternate ones.
+	return os.candidates[os.getCurrentCandidate()].cost
+}
+
+// isMemberFullyOptimized returns true if the group member at the given ordinal
+// position has been fully optimized for the required properties. The expression
+// never needs to be recosted, no matter how many additional optimization passes
+// are made.
+func (os *groupState) isMemberFullyOptimized(ord int) bool {
+	return os.fullyOptimizedExprs.Contains(ord)
+}
+
+// markMemberAsFullyOptimized marks the group member at the given ordinal
+// position as fully optimized for the required properties. The expression never
+// needs to be recosted, no matter how many additional optimization passes are
+// made.
+func (os *groupState) markMemberAsFullyOptimized(ord int) {
+	if os.fullyOptimized {
+		panic(errors.AssertionFailedf("best expression is already fully optimized"))
+	}
+	if os.isMemberFullyOptimized(ord) {
+		panic(errors.AssertionFailedf("memo expression is already fully optimized for required physical properties"))
+	}
+	os.fullyOptimizedExprs.Add(ord)
+}
+
+// groupStateAlloc allocates pages of groupState structs. This is preferable to
+// a slice of groupState structs because pointers are not invalidated when a
+// resize occurs, and because there's no need to retain a stable index.
+type groupStateAlloc struct {
+	page []groupState
+}
+
+// allocate returns a pointer to a new, empty groupState struct. The pointer is
+// stable, meaning that its location won't change as other groupState structs
+// are allocated.
+func (a *groupStateAlloc) allocate() *groupState {
+	if len(a.page) == 0 {
+		a.page = make([]groupState, 8)
+	}
+	state := &a.page[0]
+	a.page = a.page[1:]
+	return state
+}
+
+// setAlternateExprTree traverses the memo and recursively updates child pointers
+// so that they point to the nth lowest cost expression tree rather than to the
+// normalized expression tree.
+// See comment above setLowestCostTree for more detail.
+func (o *Optimizer) setAlternateExprTree(
+	parent opt.Expr, parentProps *physical.Required, nth int,
+) opt.Expr {
+	// Before we proceed, we must sort all the candidates based on cost.
+	o.optState.sortCandidates()
+
+	var relParent memo.RelExpr
+	var relCost memo.Cost
+	switch t := parent.(type) {
+	case memo.RelExpr:
+		state := o.optState.lookupOptState(t.FirstExpr(), parentProps)
+		relParent, relCost = state.bestExpr(), state.bestCost()
+		parent = relParent
+
+	case memo.ScalarPropsExpr:
+		// Short-circuit traversal of scalar expressions with no nested subquery,
+		// since there's only one possible tree.
+		if !t.ScalarProps(o.mem).HasSubquery {
+			return parent
+		}
+	}
+
+	currCandidate := candidate{o.setLowestCostTree(parent, parentProps, true), relCost}
+	var seenExprs []opt.Expr
+
+	// Save the current state.
+	oldState := o.optState.getCurrentState()
+
+	for i := 0; i < o.optState.alternate; i++ {
+		// Restore the candidate state.
+		candidateState, ok := o.optState.candidateState[currCandidate]
+		if !ok {
+			candidateState = oldState
+		}
+
+		// Use the candidate state.
+		o.optState.restoreFromCandidateState(candidateState)
+
+		// For each group state, generate a new expression to add to the heap.
+		for _, groupState := range o.optState.stateMap {
+			if groupState.getCurrentCandidate()+1 >= len(groupState.candidates) {
+				continue
+			}
+
+			// Update the current position.
+			groupState.setCurrentCandidate(groupState.getCurrentCandidate() + 1)
+
+			// The best plan generated now will respect the current position.
+			newPlan := o.setLowestCostTree(currCandidate.candidateExpr, parentProps, false)
+			isNewPlan := true
+			for _, seenCandidate := range o.optState.alternateExprHeap {
+				if newPlan == seenCandidate.candidateExpr {
+					isNewPlan = false
+					break
+				}
+			}
+
+			// Has this plan been seen before?
+			for _, seenExpr := range seenExprs {
+				if newPlan == seenExpr {
+					isNewPlan = false
+					break
+				}
+			}
+
+			if isNewPlan {
+				newPlanCost := o.recomputeCostImpl(newPlan, parentProps, o.coster)
+				newCandidate := candidate{newPlan, newPlanCost}
+
+				o.optState.candidateState[newCandidate] = o.optState.getCurrentState()
+				heap.Push(&o.optState.alternateExprHeap, newCandidate)
+			}
+
+			// Restore the old current position.
+			groupState.setCurrentCandidate(groupState.getCurrentCandidate() - 1)
+		}
+
+		// Restore the old state.
+		o.optState.restoreFromCandidateState(oldState)
+
+		// Set up the next iteration.
+		if len(o.optState.alternateExprHeap) > 0 {
+			currCandidate = heap.Pop(&o.optState.alternateExprHeap).(candidate)
+		}
+
+		seenExprs = append(seenExprs, currCandidate.candidateExpr)
+	}
+
+	// If the candidate has been seen before, get a new one.
+	for {
+		isNewPlan := true
+		for _, seenExpr := range seenExprs {
+			if currCandidate.candidateExpr == seenExpr {
+				isNewPlan = false
+				break
+			}
+		}
+
+		if len(o.optState.alternateExprHeap) == 0 || isNewPlan {
+			break
+		}
+
+		if !isNewPlan {
+			currCandidate = heap.Pop(&o.optState.alternateExprHeap).(candidate)
+		}
+	}
+
+	o.optState.clean()
+	return currCandidate.candidateExpr
+}

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -360,7 +360,8 @@ func (opc *optPlanningCtx) reuseMemo(cachedMemo *memo.Memo) (*memo.Memo, error) 
 func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ error) {
 	prepared := opc.p.stmt.Prepared
 	p := opc.p
-	if opc.allowMemoReuse && prepared != nil && prepared.Memo != nil {
+	alternatePlanUsed := int(p.EvalContext().SessionData.OptimizerAlternate) > 0
+	if opc.allowMemoReuse && prepared != nil && prepared.Memo != nil && !alternatePlanUsed {
 		// We are executing a previously prepared statement and a reusable memo is
 		// available.
 
@@ -380,7 +381,7 @@ func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ e
 		return memo, err
 	}
 
-	if opc.useCache {
+	if opc.useCache && !alternatePlanUsed {
 		// Consult the query cache.
 		cachedData, ok := p.execCfg.QueryCache.Find(&p.queryCacheSession, opc.p.stmt.SQL)
 		if ok {

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -13,6 +13,7 @@ package sessiondata
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -38,6 +39,11 @@ type SessionData struct {
 	// ForceSplitAt indicates whether checks to prevent incorrect usage of ALTER
 	// TABLE ... SPLIT AT should be skipped.
 	ForceSplitAt bool
+	// OptimizerAlternate is a session variable that is used to indicate which alternate
+	// plan should be executed by the optimizer. By default the value is 0, indicating
+	// the optimizer picks the best plan. A value of 1 would indicate that the
+	// next best plan for each query would be picked instead.
+	OptimizerAlternate OptimizerAlternate
 	// OptimizerFKs indicates whether we should use the new paths to plan foreign
 	// key checks in the optimizer.
 	OptimizerFKs bool
@@ -299,6 +305,34 @@ func VectorizeExecModeFromString(val string) (VectorizeExecMode, bool) {
 		return 0, false
 	}
 	return m, true
+}
+
+// OptimizerAlternate controls which alternate plan is picked by the optimizer.
+type OptimizerAlternate int
+
+// OptimizerAlternateUpperBound is an upper bound to how many alternate plans
+// are allowed. This must be kept the same as the value in xform/state.go.
+const OptimizerAlternateUpperBound = 5
+
+func (n OptimizerAlternate) String() string {
+	if n >= 0 && n <= OptimizerAlternateUpperBound {
+		return strconv.FormatInt(int64(n), 10)
+	}
+	return fmt.Sprintf("alternate value (%d) too high, must be lower than (%d)", n, OptimizerAlternateUpperBound)
+}
+
+// OptimizerAlternateFromString converts a string into a OptimizerMode
+func OptimizerAlternateFromString(val string) (_ OptimizerAlternate, ok bool) {
+	alternateVal, err := strconv.Atoi(val)
+	if err != nil {
+		return 0, false
+	}
+
+	if alternateVal <= OptimizerAlternateUpperBound && alternateVal >= 0 {
+		return OptimizerAlternate(alternateVal), true
+	}
+
+	return 0, false
 }
 
 // SerialNormalizationMode controls if and when the Executor uses DistSQL.

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -442,6 +442,23 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`optimizer_alternate`: {
+		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
+			alternate, ok := sessiondata.OptimizerAlternateFromString(s)
+			if !ok {
+				return newVarValueError(`optimizer_alternate`, s, "0 to 5")
+			}
+			m.SetOptimizerAlternate(alternate)
+			return nil
+		},
+		GetStringVal: makeIntGetStringValFn("optimizer_alternate"),
+		Get: func(evalCtx *extendedEvalContext) string {
+			return evalCtx.SessionData.OptimizerAlternate.String()
+		},
+		GlobalDefault: func(sv *settings.Values) string { return "0" },
+	},
+
+	// CockroachDB extension.
 	`experimental_optimizer_foreign_keys`: {
 		GetStringVal: makeBoolGetStringValFn(`experimental_optimizer_foreign_keys`),
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {


### PR DESCRIPTION
This is a rough prototype that needs some more tlc. I'm putting this up
here so I don't lose track of it.

This change allows users to run plans that is not the best one
chosen by the optimizer. This is useful because it allows users
to compare the performance of the best plan against the alternatives,
allows users to try out other plans and see if they perform better
(if they do, they may understand better about what hints to give), it
also allows users to understand why the optimizer picks the plans it
does. For example, if a user runs a query and see's that an index they
expected to be used wasn't being used, they can see the alternate plans
to see why the optimizer thinks that's not a good idea (maybe an index
join would be required as the index doesn't store enough columns of the
query). This is also a useful feature for testing as we continue
building the optimizer.

Steps to complete:
- [x] Separate out the group state code from the optimizer code.
- [x] Communicate to the optimizer when additional information needs to
      be collected. We don't want to do this all the time, we should
      be conservative with this. (Used a session variable for this)
- [x] Collect the extra information needed for each group state.
- [x] Maintain a min-heap of best plans.
- [x] Generate |states| of plans for each alternate run and add to the
      heap with its recomputed cost.
- [x] We need some way of storing, with each alternate plan found, the
      state of the candidates.
- [x] Set the alternate plan appropriately with the appropriate props.
- [ ] Document the design clearly.
- [ ] Test it a ton. And hopefully it works? (At the time of the latest
      revision, it is still very broken. There are a few problems around
      setting and using the right props)

Release note: None