### PR TITLE
importccl,row: offset rowId by ts in converter

### DIFF
--- a/pkg/ccl/importccl/bench_test.go
+++ b/pkg/ccl/importccl/bench_test.go
@@ -172,7 +172,7 @@ func benchmarkConvertToKVs(b *testing.B, g workload.Generator) {
 		g.GoCtx(func(ctx context.Context) error {
 			defer close(kvCh)
 			wc := importccl.NewWorkloadKVConverter(
-				tableDesc, t.InitialRows, 0, t.InitialRows.NumBatches, kvCh)
+				tableDesc, t.InitialRows, 0, t.InitialRows.NumBatches, kvCh, ts.UnixNano())
 			evalCtx := &tree.EvalContext{SessionData: &sessiondata.SessionData{}}
 			finishedBatchFn := func() {}
 			return wc.Worker(ctx, evalCtx, finishedBatchFn)

--- a/pkg/ccl/importccl/read_import_mysql.go
+++ b/pkg/ccl/importccl/read_import_mysql.go
@@ -55,6 +55,7 @@ func newMysqldumpReader(
 	kvCh chan []roachpb.KeyValue,
 	tables map[string]*distsqlpb.ReadImportDataSpec_ImportTable,
 	evalCtx *tree.EvalContext,
+	walltime int64,
 ) (*mysqldumpReader, error) {
 	res := &mysqldumpReader{evalCtx: evalCtx, kvCh: kvCh}
 
@@ -64,7 +65,7 @@ func newMysqldumpReader(
 			converters[name] = nil
 			continue
 		}
-		conv, err := row.NewDatumRowConverter(table.Desc, nil /* targetColNames */, evalCtx, kvCh)
+		conv, err := row.NewDatumRowConverter(table.Desc, noTargetCols, walltime, evalCtx, kvCh)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/importccl/read_import_mysql_test.go
+++ b/pkg/ccl/importccl/read_import_mysql_test.go
@@ -91,7 +91,7 @@ func TestMysqldumpDataReader(t *testing.T) {
 	table := descForTable(t, `CREATE TABLE simple (i INT PRIMARY KEY, s text, b bytea)`, 10, 20, NoFKs)
 	tables := map[string]*distsqlpb.ReadImportDataSpec_ImportTable{"simple": {Desc: table}}
 
-	converter, err := newMysqldumpReader(make(chan []roachpb.KeyValue, 10), tables, testEvalCtx)
+	converter, err := newMysqldumpReader(make(chan []roachpb.KeyValue, 10), tables, testEvalCtx, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/ccl/importccl/read_import_mysqlout.go
+++ b/pkg/ccl/importccl/read_import_mysqlout.go
@@ -35,8 +35,9 @@ func newMysqloutfileReader(
 	opts roachpb.MySQLOutfileOptions,
 	tableDesc *sqlbase.TableDescriptor,
 	evalCtx *tree.EvalContext,
+	walltime int64,
 ) (*mysqloutfileReader, error) {
-	conv, err := row.NewDatumRowConverter(tableDesc, nil /* targetColNames */, evalCtx, kvCh)
+	conv, err := row.NewDatumRowConverter(tableDesc, noTargetCols, walltime, evalCtx, kvCh)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/importccl/read_import_pgcopy.go
+++ b/pkg/ccl/importccl/read_import_pgcopy.go
@@ -43,8 +43,9 @@ func newPgCopyReader(
 	opts roachpb.PgCopyOptions,
 	tableDesc *sqlbase.TableDescriptor,
 	evalCtx *tree.EvalContext,
+	walltime int64,
 ) (*pgCopyReader, error) {
-	conv, err := row.NewDatumRowConverter(tableDesc, nil /* targetColNames */, evalCtx, kvCh)
+	conv, err := row.NewDatumRowConverter(tableDesc, noTargetCols, walltime, evalCtx, kvCh)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -407,11 +407,12 @@ func newPgDumpReader(
 	opts roachpb.PgDumpOptions,
 	descs map[string]*distsqlpb.ReadImportDataSpec_ImportTable,
 	evalCtx *tree.EvalContext,
+	walltime int64,
 ) (*pgDumpReader, error) {
 	converters := make(map[string]*row.DatumRowConverter, len(descs))
 	for name, table := range descs {
 		if table.Desc.IsTable() {
-			conv, err := row.NewDatumRowConverter(table.Desc, nil /* targetColNames */, evalCtx, kvCh)
+			conv, err := row.NewDatumRowConverter(table.Desc, noTargetCols, walltime, evalCtx, kvCh)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/ccl/importccl/read_import_proc.go
+++ b/pkg/ccl/importccl/read_import_proc.go
@@ -299,13 +299,13 @@ func (cp *readImportDataProcessor) doRun(ctx context.Context) error {
 			conv = newCSVInputReader(kvCh, cp.spec.Format.Csv, cp.spec.WalltimeNanos, singleTable, singleTableTargetCols, evalCtx)
 		}
 	case roachpb.IOFileFormat_MysqlOutfile:
-		conv, err = newMysqloutfileReader(kvCh, cp.spec.Format.MysqlOut, singleTable, evalCtx)
+		conv, err = newMysqloutfileReader(kvCh, cp.spec.Format.MysqlOut, singleTable, evalCtx, cp.spec.WalltimeNanos)
 	case roachpb.IOFileFormat_Mysqldump:
-		conv, err = newMysqldumpReader(kvCh, cp.spec.Tables, evalCtx)
+		conv, err = newMysqldumpReader(kvCh, cp.spec.Tables, evalCtx, cp.spec.WalltimeNanos)
 	case roachpb.IOFileFormat_PgCopy:
-		conv, err = newPgCopyReader(kvCh, cp.spec.Format.PgCopy, singleTable, evalCtx)
+		conv, err = newPgCopyReader(kvCh, cp.spec.Format.PgCopy, singleTable, evalCtx, cp.spec.WalltimeNanos)
 	case roachpb.IOFileFormat_PgDump:
-		conv, err = newPgDumpReader(kvCh, cp.spec.Format.PgDump, cp.spec.Tables, evalCtx)
+		conv, err = newPgDumpReader(kvCh, cp.spec.Format.PgDump, cp.spec.Tables, evalCtx, cp.spec.WalltimeNanos)
 	default:
 		err = errors.Errorf("Requested IMPORT format (%d) not supported by this node", cp.spec.Format.Format)
 	}

--- a/pkg/ccl/workloadccl/format/sstable.go
+++ b/pkg/ccl/workloadccl/format/sstable.go
@@ -66,7 +66,7 @@ func ToSSTable(t workload.Table, tableID sqlbase.ID, ts time.Time) ([]byte, erro
 
 	kvCh := make(chan []roachpb.KeyValue)
 	wc := importccl.NewWorkloadKVConverter(
-		tableDesc, t.InitialRows, 0, t.InitialRows.NumBatches, kvCh)
+		tableDesc, t.InitialRows, 0, t.InitialRows.NumBatches, kvCh, ts.UnixNano())
 
 	var ssts addSSTableSender
 	g := ctxgroup.WithContext(ctx)

--- a/pkg/sql/distsqlrun/bulk_row_writer.go
+++ b/pkg/sql/distsqlrun/bulk_row_writer.go
@@ -188,7 +188,8 @@ func (sp *bulkRowWriter) Run(ctx context.Context) {
 
 	sp.input.Start(ctx)
 
-	conv, err := row.NewDatumRowConverter(&sp.spec.Table, nil /* targetColNames */, evalCtx, kvCh)
+	ts := sp.spec.Table.CreateAsOfTime.WallTime
+	conv, err := row.NewDatumRowConverter(&sp.spec.Table, nil /* targetColNames */, ts, evalCtx, kvCh)
 	if err != nil {
 		DrainAndClose(
 			ctx, sp.output, err, func(context.Context) {} /* pushTrailingMeta */, sp.input)


### PR DESCRIPTION
Previously we discovered that having UniqueRowId be fully determined by
the file and row number led to collisions when importing into a table
more than once: line 1 of file 1 of the first and second IMPORT got the
same ID.

To fix this we changed the row number to start at the current timestamp,
so that rows for IMPORTs run at different times got different IDs. This
change however was made locally in the CSV reader, before passing the
row number to the row converter.

This change moves that logic into the converter itself, and changes all
the formats to pass a base timestamp when creating the converter.
Given that IMPORT INTO initially only supports CSV this likely isn't
strictly required at the moment, but it is easier to do it now than have
to debug it later when we enable incremental import of e.g. PGCOPY data.

Release note: none.