### PR TITLE
roachtest: add backwards-compat for SHOW RANGES

### DIFF
--- a/pkg/cmd/roachtest/copy.go
+++ b/pkg/cmd/roachtest/copy.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
+	"strings"
 
 	"github.com/cockroachdb/cockroach-go/crdb"
 	_ "github.com/lib/pq"
@@ -59,7 +60,14 @@ func registerCopy(r *testRegistry) {
 				var count int
 				const q = "SELECT count(*) FROM [SHOW RANGES FROM TABLE bank.bank]"
 				if err := db.QueryRow(q).Scan(&count); err != nil {
-					t.Fatalf("failed to get range count: %v", err)
+					// TODO(rafi): Remove experimental_ranges query once we stop testing
+					// 19.1 or earlier.
+					if strings.Contains(err.Error(), "syntax error at or near \"ranges\"") {
+						err = db.QueryRow("SELECT count(*) FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE bank.bank]").Scan(&count)
+					}
+					if err != nil {
+						t.Fatalf("failed to get range count: %v", err)
+					}
 				}
 				return count
 			}

--- a/pkg/cmd/roachtest/rebalance_load.go
+++ b/pkg/cmd/roachtest/rebalance_load.go
@@ -162,6 +162,16 @@ func isLoadEvenlyDistributed(l *logger, db *gosql.DB, numNodes int) (bool, error
 			`from [show ranges from table kv.kv] ` +
 			`group by lease_holder;`)
 	if err != nil {
+		// TODO(rafi): Remove experimental_ranges query once we stop testing 19.1 or
+		// earlier.
+		if strings.Contains(err.Error(), "syntax error at or near \"ranges\"") {
+			rows, err = db.Query(
+				`select lease_holder, count(*) ` +
+					`from [show experimental_ranges from table kv.kv] ` +
+					`group by lease_holder;`)
+		}
+	}
+	if err != nil {
 		return false, err
 	}
 	defer rows.Close()

--- a/pkg/cmd/roachtest/split.go
+++ b/pkg/cmd/roachtest/split.go
@@ -162,7 +162,14 @@ func runLoadSplits(ctx context.Context, t *test, c *cluster, params splitParams)
 			var ranges int
 			const q = "SELECT count(*) FROM [SHOW RANGES FROM TABLE kv.kv]"
 			if err := db.QueryRow(q).Scan(&ranges); err != nil {
-				t.Fatalf("failed to get range count: %v", err)
+				// TODO(rafi): Remove experimental_ranges query once we stop testing
+				// 19.1 or earlier.
+				if strings.Contains(err.Error(), "syntax error at or near \"ranges\"") {
+					err = db.QueryRow("SELECT count(*) FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE kv.kv]").Scan(&ranges)
+				}
+				if err != nil {
+					t.Fatalf("failed to get range count: %v", err)
+				}
 			}
 			return ranges
 		}

--- a/pkg/sql/delegate/show_ranges.go
+++ b/pkg/sql/delegate/show_ranges.go
@@ -20,7 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
-// delegateShowRanges implements the SHOW EXPERIMENTAL_RANGES statement:
+// delegateShowRanges implements the SHOW RANGES statement:
 //   SHOW RANGES FROM TABLE t
 //   SHOW RANGES FROM INDEX t@idx
 //   SHOW RANGES FROM DATABASE db


### PR DESCRIPTION
The EXPERIMENTAL_RANGES syntax was removed in master in #39181 but older
versions still use this syntax. roachtest will now detect a syntax error
when using the new syntax and fallback to the old syntax, so that the
tests can still work on older versions.

Release note: None