### PR TITLE
exec: Add tests with nulls to sort chunks

### DIFF
--- a/pkg/sql/distsqlrun/columnar_operators_test.go
+++ b/pkg/sql/distsqlrun/columnar_operators_test.go
@@ -73,8 +73,7 @@ func TestSortChunksAgainstProcessor(t *testing.T) {
 	nRows := 100
 	maxCols := 5
 	maxNum := 10
-	// TODO (yuzefovich): change nullProbability to non 0 value.
-	nullProbability := 0.0
+	nullProbability := 0.2
 	typs := make([]types.T, maxCols)
 	for i := range typs {
 		typs[i] = *types.Int

--- a/pkg/sql/exec/sort_chunks_test.go
+++ b/pkg/sql/exec/sort_chunks_test.go
@@ -51,6 +51,22 @@ func TestSortChunks(t *testing.T) {
 			matchLen:    1,
 		},
 		{
+			description: `simple nulls asc`,
+			tuples:      tuples{{1, 2}, {1, nil}, {1, 3}, {1, 1}, {5, 5}, {6, 6}, {6, nil}},
+			expected:    tuples{{1, nil}, {1, 1}, {1, 2}, {1, 3}, {5, 5}, {6, nil}, {6, 6}},
+			typ:         []types.T{types.Int64, types.Int64},
+			ordCols:     []distsqlpb.Ordering_Column{{ColIdx: 0}, {ColIdx: 1}},
+			matchLen:    1,
+		},
+		{
+			description: `simple nulls desc`,
+			tuples:      tuples{{1, 2}, {1, nil}, {1, 3}, {1, 1}, {5, 5}, {6, 6}, {6, nil}},
+			expected:    tuples{{1, 3}, {1, 2}, {1, 1}, {1, nil}, {5, 5}, {6, 6}, {6, nil}},
+			typ:         []types.T{types.Int64, types.Int64},
+			ordCols:     []distsqlpb.Ordering_Column{{ColIdx: 0}, {ColIdx: 1, Direction: distsqlpb.Ordering_Column_DESC}},
+			matchLen:    1,
+		},
+		{
 			description: `one chunk, matchLen 1, three ordering columns`,
 			tuples: tuples{
 				{0, 1, 2},


### PR DESCRIPTION
As null handling was added to the sorter in #39375, sort chunks now handles nulls as well. This PR adds some tests with nulls to the sort_chunks test.

Fixes #36880.

Release note: None