### PR TITLE
distsqlrun: fix panic due to multiple calls to tracing.FinishSpan

### DIFF
--- a/pkg/sql/distsqlrun/sample_aggregator.go
+++ b/pkg/sql/distsqlrun/sample_aggregator.go
@@ -135,7 +135,6 @@ func (s *sampleAggregator) pushTrailingMeta(ctx context.Context) {
 func (s *sampleAggregator) Run(ctx context.Context) {
 	s.input.Start(ctx)
 	s.StartInternal(ctx, sampleAggregatorProcName)
-	defer tracing.FinishSpan(s.span)
 
 	earlyExit, err := s.mainLoop(s.Ctx)
 	if err != nil {

--- a/pkg/sql/distsqlrun/sampler.go
+++ b/pkg/sql/distsqlrun/sampler.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 )
 
@@ -172,7 +171,6 @@ func (s *samplerProcessor) pushTrailingMeta(ctx context.Context) {
 func (s *samplerProcessor) Run(ctx context.Context) {
 	s.input.Start(ctx)
 	s.StartInternal(ctx, samplerProcName)
-	defer tracing.FinishSpan(s.span)
 
 	earlyExit, err := s.mainLoop(s.Ctx)
 	if err != nil {


### PR DESCRIPTION
This commit removes calls to `tracing.FinishSpan` from the `samplerProcessor`
and `sampleAggregatorProcessor`. These calls are no longer necessary after
memory accounting was added in #39144, which includes a call to `tracing.FinishSpan`
in `InternalClose()`.

Fixes #39262

Release note: None