### PR TITLE
 sql: make FK schema changes backward-compatible with 19.1

### DIFF
--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -502,6 +502,13 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// all old-style table descriptors into the new format upon read. Once the
 		// upgrade is finalized, the database will write the upgraded format, but
 		// continue to upgrade old-style descriptors on-demand.
+		//
+		// This version is also used for the new foreign key schema changes which
+		// are run in the schema changer, requiring new types of mutations on the
+		// table descriptor. The same version is used for both of these changes
+		// because the changes are intertwined, and it slightly simplifies some of
+		// the logic to assume that either neither or both sets of changes can be
+		// active.
 		Key:     VersionTopLevelForeignKeys,
 		Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 7},
 	},

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -284,9 +284,16 @@ func (n *alterTableNode) startExec(params runParams) error {
 						return err
 					}
 				}
-				if err := n.tableDesc.Validate(params.ctx, params.p.txn); err != nil {
-					return err
-				}
+				// TODO(lucy): Validate() can't be called here because it reads the
+				// referenced table descs, which may have to be upgraded to the new FK
+				// representation. That requires reading the original table descriptor
+				// (which the backreference points to) from KV, but we haven't written
+				// the updated table desc yet. We can restore the call to Validate()
+				// after running a migration of all table descriptors, making it
+				// unnecessary to read the original table desc from KV.
+				// if err := n.tableDesc.Validate(params.ctx, params.p.txn); err != nil {
+				// 	return err
+				// }
 
 			default:
 				return errors.AssertionFailedf(

--- a/pkg/sql/logictest/testdata/logic_test/fk-mixed-19.1-19.2
+++ b/pkg/sql/logictest/testdata/logic_test/fk-mixed-19.1-19.2
@@ -1,4 +1,10 @@
 # LogicTest: local-mixed-19.1-19.2
+# This test file is essentially the same as the fk test file in 19.1. These
+# tests are only run in the test configuration that simulates a 19.2 node
+# running in a 19.1 cluster. In that state, schema changes related to foreign
+# keys behave as they do in 19.1, because the new table descriptor mutations are
+# not backward compatible. The most significant difference is that FKs are not
+# validated when added in 19.1, hence the need for different logic tests.
 
 # Disable automatic stats to avoid flakiness.
 statement ok
@@ -308,19 +314,33 @@ ALTER TABLE delivery DROP CONSTRAINT fk_item_ref_products
 statement ok
 UPDATE products SET upc = 'blah' WHERE sku = '780'
 
-statement error pgcode 23503 foreign key violation: "delivery" row item='885155001450', rowid=[0-9]* has no match in "products"
+statement ok
 ALTER TABLE delivery ADD FOREIGN KEY (item) REFERENCES products (upc)
 
 query TTTTB
 SHOW CONSTRAINTS FROM delivery
 ----
-delivery  fk_order_ref_orders  FOREIGN KEY  FOREIGN KEY ("order", shipment) REFERENCES orders(id, shipment)  true
+delivery  fk_item_ref_products  FOREIGN KEY  FOREIGN KEY (item) REFERENCES products(upc)                      false
+delivery  fk_order_ref_orders   FOREIGN KEY  FOREIGN KEY ("order", shipment) REFERENCES orders(id, shipment)  true
+
+statement error pgcode 23503 foreign key violation: "delivery" row item='885155001450', rowid=[0-9]* has no match in "products"
+ALTER TABLE delivery VALIDATE CONSTRAINT fk_item_ref_products
+
+query TTTTB
+SHOW CONSTRAINTS FROM delivery
+----
+delivery  fk_item_ref_products  FOREIGN KEY  FOREIGN KEY (item) REFERENCES products(upc)                      false
+delivery  fk_order_ref_orders   FOREIGN KEY  FOREIGN KEY ("order", shipment) REFERENCES orders(id, shipment)  true
 
 statement ok
 UPDATE products SET upc = '885155001450' WHERE sku = '780'
 
+# Changing referenced non-pk index fails once again with constraint re-added.
+statement error pgcode 23503 foreign key violation: values \['885155001450'\] in columns \[upc\] referenced in table "delivery"
+UPDATE products SET upc = 'blah' WHERE sku = '780'
+
 statement ok
-ALTER TABLE delivery ADD FOREIGN KEY (item) REFERENCES products (upc)
+ALTER TABLE delivery VALIDATE CONSTRAINT fk_item_ref_products
 
 query TTTTB
 SHOW CONSTRAINTS FROM delivery
@@ -757,19 +777,11 @@ CREATE TABLE a (id SERIAL NOT NULL, self_id INT, b_id INT NOT NULL, PRIMARY KEY 
 statement ok
 CREATE TABLE b (id SERIAL NOT NULL, PRIMARY KEY (id))
 
-# NOTE: this test diverges from the main fk test here because of the issue #39037, which
-# breaks the auto-creation of origin indexes in the mixed-version 19.1/19.2 state.
-# TODO(lucy): reset this test to normal once that limitations is fixed.
-
-statement ok
-CREATE INDEX ON a(self_id)
-
+# The index needed for the fk constraint is automatically added because the table is empty
 statement ok
 ALTER TABLE a ADD CONSTRAINT fk_self_id FOREIGN KEY (self_id) REFERENCES a;
 
-statement ok
-CREATE INDEX ON a(b_id)
-
+# The index needed for the fk constraint is automatically added because the table is empty
 statement ok
 ALTER TABLE a ADD CONSTRAINT fk_b FOREIGN KEY (b_id) REFERENCES b;
 
@@ -1245,13 +1257,6 @@ CREATE TABLE no_default_table (
  ,update_no_default INT
 );
 
-# TODO(lucy): remove after #39037 is resolved.
-statement ok
-CREATE INDEX ON no_default_table(delete_no_default)
-
-statement ok
-CREATE INDEX ON no_default_table(update_no_default)
-
 statement ok
 ALTER TABLE no_default_table ADD CONSTRAINT no_default_delete_set_default
   FOREIGN KEY (delete_no_default) REFERENCES a (id)
@@ -1457,52 +1462,6 @@ ALTER TABLE t ADD FOREIGN KEY (a, b) REFERENCES t (a, b)
 statement ok
 DROP TABLE t
 
-subtest unvalidated_fk_plan
-
-# To get an unvalidated foreign key for testing, use the loophole that we
-# currently don't support adding a validated FK in the same transaction as
-# CREATE TABLE
-
-statement ok
-CREATE TABLE a (
-  x STRING NULL,
-  y STRING NULL,
-  z STRING NULL,
-  CONSTRAINT "primary" PRIMARY KEY (z, y, x)
-)
-
-statement ok
-CREATE TABLE b (
-  a_y STRING NULL,
-  a_x STRING NULL,
-  a_z STRING NULL,
-  INDEX idx (a_z, a_y, a_x)
-)
-
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', 'y1', 'z1')
-
-statement ok
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) NOT VALID
-
-statement error pq: foreign key violation: "b" row a_z='z1', a_y='y1', a_x='x2', rowid=[0-9]* has no match in "a"
-ALTER TABLE b VALIDATE CONSTRAINT fk_ref
-
-# Verify that the optimizer doesn't use an unvalidated constraint to simplify plans.
-query TTT
-SELECT
-  s.a_z, s.a_y, s.a_x
-FROM
-  (SELECT * FROM b WHERE a_z IS NOT NULL AND a_y IS NOT NULL AND a_x IS NOT NULL) AS s
-  LEFT JOIN a AS t ON s.a_z = t.z AND s.a_y = t.y AND s.a_x = t.x
-WHERE
-  t.z IS NULL
-----
-z1 y1 x2
-
-statement ok
-DROP TABLE a, b
-
 subtest Composite_Simple
 # Originally from 26748.
 
@@ -1645,120 +1604,6 @@ INSERT INTO b (a_x, a_y, a_z) VALUES (NULL, 'y2', 'z2')
 statement ok
 DROP TABLE b, a
 
-subtest Composite_Simple_Add_Constraint_Valid
-# Test ADD CONSTRAINT validation by inserting valid rows before the constraint is added.
-
-statement ok
-CREATE TABLE a (
-  x STRING NULL
- ,y STRING NULL
- ,z STRING NULL
- ,CONSTRAINT "primary" PRIMARY KEY (z, y, x)
-);
-
-statement ok
-CREATE TABLE b (
-  a_y STRING NULL
- ,a_x STRING NULL
- ,a_z STRING NULL
- ,INDEX idx (a_z, a_y, a_x)
-);
-
-statement ok
-INSERT INTO a (x, y, z) VALUES ('x1', 'y1', 'z1')
-
-# All of these are allowed because we do composite matching using MATCH SIMPLE.
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES ('x1', NULL, NULL)
-
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES (NULL, 'y1', NULL)
-
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES (NULL, NULL, 'z1')
-
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES ('x1', 'y1', NULL)
-
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES ('x1', NULL, 'z1')
-
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES (NULL, 'y1', 'z1')
-
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES (NULL, NULL, NULL)
-
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', NULL, NULL)
-
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES (NULL, 'y2', NULL)
-
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES (NULL, NULL, 'z2')
-
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', 'y2', NULL)
-
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', NULL, 'z2')
-
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES (NULL, 'y2', 'z2')
-
-statement ok
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x)
-
-statement ok
-DROP TABLE b, a
-
-subtest Composite_Simple_Add_Constraint_Invalid
-# Test ADD CONSTRAINT validation by inserting invalid rows before the constraint is added, one at a time.
-
-statement ok
-CREATE TABLE a (
-  x STRING NULL
- ,y STRING NULL
- ,z STRING NULL
- ,CONSTRAINT "primary" PRIMARY KEY (z, y, x)
-);
-
-statement ok
-CREATE TABLE b (
-  a_y STRING NULL
- ,a_x STRING NULL
- ,a_z STRING NULL
- ,INDEX idx (a_z, a_y, a_x)
-);
-
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', 'y1', 'z1')
-
-statement error foreign key violation: "b" row a_z='z1', a_y='y1', a_x='x2', rowid=[0-9]* has no match in "a"
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x)
-
-statement ok
-TRUNCATE b
-
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', 'y2', 'z1')
-
-statement error foreign key violation: "b" row a_z='z1', a_y='y2', a_x='x2', rowid=[0-9]* has no match in "a"
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x)
-
-statement ok
-TRUNCATE b
-
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', 'y2', 'z2')
-
-statement error foreign key violation: "b" row a_z='z2', a_y='y2', a_x='x2', rowid=[0-9]* has no match in "a"
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x)
-
-statement ok
-DROP TABLE b, a
-
 subtest Composite_Simple_Unvalidated
 # Test inserting into table with an unvalidated constraint, and running VALIDATE CONSTRAINT later
 
@@ -1772,18 +1617,13 @@ CREATE TABLE a (
 
 statement ok
 CREATE TABLE b (
-  a_y STRING NULL
+ a_y STRING NULL
  ,a_x STRING NULL
 );
 
-
-# TODO(lucy): remove after #39037 is resolved.
-statement ok
-CREATE INDEX ON b(a_y, a_x)
-
 # Add the constraint separately so that it's unvalidated, so we can test VALIDATE CONSTRAINT.
 statement ok
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_y, a_x) REFERENCES a (y, x) NOT VALID
+ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_y, a_x) REFERENCES a (y, x)
 
 statement ok
 INSERT INTO a (x, y) VALUES ('x1', 'y1')
@@ -1835,13 +1675,9 @@ CREATE TABLE b (
  ,a_z STRING NULL
 );
 
-# TODO(lucy): remove after #39037 is resolved.
-statement ok
-CREATE INDEX ON b(a_z, a_y, a_x)
-
 # Add the constraint separately so that it's unvalidated, so we can test VALIDATE CONSTRAINT.
 statement ok
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) NOT VALID
+ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x)
 
 statement ok
 INSERT INTO a (x, y, z) VALUES ('x1', 'y1', 'z1')
@@ -1928,7 +1764,78 @@ ALTER TABLE b VALIDATE CONSTRAINT fk_ref
 statement ok
 DROP TABLE b, a
 
-#subtest Composite_Simple_Validate_Constraint_Invalid
+subtest Composite_Simple_Validate_Constraint_Invalid
+# Test VALIDATE CONSTRAINT by inserting invalid rows before the constraint is added, one at a time.
+
+statement ok
+CREATE TABLE a (
+  x STRING NULL
+ ,y STRING NULL
+ ,z STRING NULL
+ ,CONSTRAINT "primary" PRIMARY KEY (z, y, x)
+);
+
+statement ok
+CREATE TABLE b (
+  a_y STRING NULL
+ ,a_x STRING NULL
+ ,a_z STRING NULL
+ ,INDEX idx (a_z, a_y, a_x)
+);
+
+statement ok
+INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', 'y1', 'z1')
+
+statement ok
+ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x)
+
+# Verify that the optimizer doesn't use an unvalidated constraint to simplify plans.
+query TTT
+SELECT
+  s.a_z, s.a_y, s.a_x
+FROM
+  (SELECT * FROM b WHERE a_z IS NOT NULL AND a_y IS NOT NULL AND a_x IS NOT NULL) AS s
+  LEFT JOIN a AS t ON s.a_z = t.z AND s.a_y = t.y AND s.a_x = t.x
+WHERE
+  t.z IS NULL
+----
+z1 y1 x2
+
+statement error foreign key violation: "b" row a_z='z1', a_y='y1', a_x='x2', rowid=[0-9]* has no match in "a"
+ALTER TABLE b VALIDATE CONSTRAINT fk_ref
+
+statement ok
+TRUNCATE b
+
+statement ok
+ALTER TABLE b DROP CONSTRAINT fk_ref
+
+statement ok
+INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', 'y2', 'z1')
+
+statement ok
+ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x)
+
+statement error foreign key violation: "b" row a_z='z1', a_y='y2', a_x='x2', rowid=[0-9]* has no match in "a"
+ALTER TABLE b VALIDATE CONSTRAINT fk_ref
+
+statement ok
+TRUNCATE b
+
+statement ok
+ALTER TABLE b DROP CONSTRAINT fk_ref
+
+statement ok
+INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', 'y2', 'z2')
+
+statement ok
+ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x)
+
+statement error foreign key violation: "b" row a_z='z2', a_y='y2', a_x='x2', rowid=[0-9]* has no match in "a"
+ALTER TABLE b VALIDATE CONSTRAINT fk_ref
+
+statement ok
+DROP TABLE b, a
 
 subtest Composite_Full
 # Originally from 26748.
@@ -1936,20 +1843,17 @@ subtest Composite_Full
 # Test composite key with two columns.
 statement ok
 CREATE TABLE a (
-  x STRING NULL,
-  y STRING NULL,
-  CONSTRAINT "primary" PRIMARY KEY (y, x)
+  x STRING NULL
+ ,y STRING NULL
+ ,CONSTRAINT "primary" PRIMARY KEY (y, x)
 );
 
 statement ok
 CREATE TABLE b (
-  a_y STRING NULL,
-  a_x STRING NULL
+ a_y STRING NULL
+ ,a_x STRING NULL
+ ,CONSTRAINT fk_ref FOREIGN KEY (a_y, a_x) REFERENCES a (y, x) MATCH FULL
 );
-
-# Add the constraint separately so that it's unvalidated, so we can test VALIDATE CONSTRAINT.
-statement ok
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_y, a_x) REFERENCES a (y, x) MATCH FULL NOT VALID
 
 statement ok
 INSERT INTO a (x, y) VALUES ('x1', 'y1')
@@ -1980,21 +1884,19 @@ DROP TABLE b, a
 # Test composite key with three columns.
 statement ok
 CREATE TABLE a (
-  x STRING NULL,
-  y STRING NULL,
-  z STRING NULL,
-  CONSTRAINT "primary" PRIMARY KEY (z, y, x)
+  x STRING NULL
+ ,y STRING NULL
+ ,z STRING NULL
+ ,CONSTRAINT "primary" PRIMARY KEY (z, y, x)
 );
 
 statement ok
 CREATE TABLE b (
-  a_y STRING NULL,
-  a_x STRING NULL,
-  a_z STRING NULL
+  a_y STRING NULL
+ ,a_x STRING NULL
+ ,a_z STRING NULL
+ ,CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
 );
-
-statement ok
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL NOT VALID
 
 statement ok
 INSERT INTO a (x, y, z) VALUES ('x1', 'y1', 'z1')
@@ -2057,138 +1959,6 @@ INSERT INTO b (a_x, a_y, a_z) VALUES (NULL, 'y1', 'z1')
 # This statement should still be allowed.
 statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES (NULL, NULL, NULL)
-
-statement ok
-DROP TABLE b, a
-
-subtest Composite_Full_Add_Constraint_Valid
-# Test ADD CONSTRAINT validation by inserting valid rows before the constraint is added.
-
-statement ok
-CREATE TABLE a (
-  x STRING NULL
- ,y STRING NULL
- ,z STRING NULL
- ,CONSTRAINT "primary" PRIMARY KEY (z, y, x)
-);
-
-statement ok
-CREATE TABLE b (
-  a_y STRING NULL
- ,a_x STRING NULL
- ,a_z STRING NULL
- ,INDEX idx (a_z, a_y, a_x)
-);
-
-statement ok
-INSERT INTO a (x, y, z) VALUES ('x1', 'y1', 'z1')
-
-# This statement should still be allowed.
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES (NULL, NULL, NULL)
-
-statement ok
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x)
-
-statement ok
-DROP TABLE b, a
-
-subtest Composite_Full_Validate_Constraint_Invalid
-# Test VALIDATE CONSTRAINT by inserting invalid rows before the constraint is added, one at a time.
-
-statement ok
-CREATE TABLE a (
-  x STRING NULL
- ,y STRING NULL
- ,z STRING NULL
- ,CONSTRAINT "primary" PRIMARY KEY (z, y, x)
-);
-
-statement ok
-CREATE TABLE b (
-  a_y STRING NULL
- ,a_x STRING NULL
- ,a_z STRING NULL
- ,INDEX idx (a_z, a_y, a_x)
-);
-
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES ('x1', NULL, NULL)
-
-statement error foreign key violation: MATCH FULL does not allow mixing of null and nonnull values
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
-
-statement ok
-TRUNCATE b
-
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES (NULL, 'y1', NULL)
-
-statement error foreign key violation: MATCH FULL does not allow mixing of null and nonnull values
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
-
-statement ok
-TRUNCATE b
-
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES (NULL, NULL, 'z1')
-
-statement error foreign key violation: MATCH FULL does not allow mixing of null and nonnull values
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
-
-statement ok
-TRUNCATE b
-
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES ('x1', 'y1', NULL)
-
-statement error foreign key violation: MATCH FULL does not allow mixing of null and nonnull values
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
-
-statement ok
-TRUNCATE b
-
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES ('x1', NULL, 'z1')
-
-statement error foreign key violation: MATCH FULL does not allow mixing of null and nonnull values
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
-
-statement ok
-TRUNCATE b
-
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES (NULL, 'y1', 'z1')
-
-statement error foreign key violation: MATCH FULL does not allow mixing of null and nonnull values
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
-
-statement ok
-TRUNCATE b
-
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', 'y1', 'z1')
-
-statement error foreign key violation: "b" row a_z='z1', a_y='y1', a_x='x2', rowid=[0-9]* has no match in "a"
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
-
-statement ok
-TRUNCATE b
-
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', 'y2', 'z1')
-
-statement error foreign key violation: "b" row a_z='z1', a_y='y2', a_x='x2', rowid=[0-9]* has no match in "a"
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
-
-statement ok
-TRUNCATE b
-
-statement ok
-INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', 'y2', 'z2')
-
-statement error foreign key violation: "b" row a_z='z2', a_y='y2', a_x='x2', rowid=[0-9]* has no match in "a"
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
 
 statement ok
 DROP TABLE b, a
@@ -2206,13 +1976,13 @@ CREATE TABLE a (
 
 statement ok
 CREATE TABLE b (
-  a_y STRING NULL
+ a_y STRING NULL
  ,a_x STRING NULL
 );
 
 # Add the constraint separately so that it's unvalidated, so we can test VALIDATE CONSTRAINT.
 statement ok
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_y, a_x) REFERENCES a (y, x) MATCH FULL NOT VALID
+ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_y, a_x) REFERENCES a (y, x) MATCH FULL
 
 statement ok
 INSERT INTO a (x, y) VALUES ('x1', 'y1')
@@ -2261,7 +2031,7 @@ CREATE TABLE b (
 
 # Add the constraint separately so that it's unvalidated, so we can test VALIDATE CONSTRAINT.
 statement ok
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL NOT VALID
+ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
 
 statement ok
 INSERT INTO a (x, y, z) VALUES ('x1', 'y1', 'z1')
@@ -2354,7 +2124,7 @@ statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES ('x1', NULL, NULL)
 
 statement ok
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL NOT VALID
+ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
 
 statement error foreign key violation: MATCH FULL does not allow mixing of null and nonnull values
 ALTER TABLE b VALIDATE CONSTRAINT fk_ref
@@ -2369,7 +2139,7 @@ statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES (NULL, 'y1', NULL)
 
 statement ok
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL NOT VALID
+ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
 
 statement error foreign key violation: MATCH FULL does not allow mixing of null and nonnull values
 ALTER TABLE b VALIDATE CONSTRAINT fk_ref
@@ -2384,7 +2154,7 @@ statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES (NULL, NULL, 'z1')
 
 statement ok
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL NOT VALID
+ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
 
 statement error foreign key violation: MATCH FULL does not allow mixing of null and nonnull values
 ALTER TABLE b VALIDATE CONSTRAINT fk_ref
@@ -2399,7 +2169,7 @@ statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES ('x1', 'y1', NULL)
 
 statement ok
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL NOT VALID
+ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
 
 statement error foreign key violation: MATCH FULL does not allow mixing of null and nonnull values
 ALTER TABLE b VALIDATE CONSTRAINT fk_ref
@@ -2414,7 +2184,7 @@ statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES ('x1', NULL, 'z1')
 
 statement ok
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL NOT VALID
+ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
 
 statement error foreign key violation: MATCH FULL does not allow mixing of null and nonnull values
 ALTER TABLE b VALIDATE CONSTRAINT fk_ref
@@ -2429,7 +2199,7 @@ statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES (NULL, 'y1', 'z1')
 
 statement ok
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL NOT VALID
+ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
 
 statement error foreign key violation: MATCH FULL does not allow mixing of null and nonnull values
 ALTER TABLE b VALIDATE CONSTRAINT fk_ref
@@ -2444,7 +2214,7 @@ statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', 'y1', 'z1')
 
 statement ok
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL NOT VALID
+ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
 
 statement error pq: foreign key violation: "b" row a_z='z1', a_y='y1', a_x='x2', rowid=[0-9]* has no match in "a"
 ALTER TABLE b VALIDATE CONSTRAINT fk_ref
@@ -2459,7 +2229,7 @@ statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', 'y2', 'z1')
 
 statement ok
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL NOT VALID
+ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
 
 statement error pq: foreign key violation: "b" row a_z='z1', a_y='y2', a_x='x2', rowid=[0-9]* has no match in "a"
 ALTER TABLE b VALIDATE CONSTRAINT fk_ref
@@ -2474,7 +2244,7 @@ statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', 'y2', 'z2')
 
 statement ok
-ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL NOT VALID
+ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
 
 statement error pq: foreign key violation: "b" row a_z='z2', a_y='y2', a_x='x2', rowid=[0-9]* has no match in "a"
 ALTER TABLE b VALIDATE CONSTRAINT fk_ref
@@ -2489,10 +2259,6 @@ CREATE TABLE parent_composite_index (a_id INT NOT NULL, b_id INT NOT NULL, PRIMA
 
 statement ok
 CREATE TABLE child_composite_index (id SERIAL NOT NULL, parent_a_id INT, parent_b_id INT, PRIMARY KEY (id))
-
-# TODO(lucy): remove after #39037 is resolved.
-statement ok
-CREATE INDEX ON child_composite_index (parent_a_id, parent_b_id)
 
 # The (composite) index needed for the fk constraint is automatically added because the table is empty
 statement ok
@@ -2638,44 +2404,3 @@ DELETE FROM t1 WHERE x IS NULL
 
 statement ok
 DROP TABLE t1, t2 CASCADE
-
-subtest test_not_valid_fk
-
-statement ok
-CREATE TABLE person (id INT PRIMARY KEY, age INT, name STRING)
-
-statement ok
-CREATE TABLE pet (id INT PRIMARY KEY, name STRING)
-
-statement ok
-INSERT INTO pet VALUES (0, 'crookshanks')
-
-statement error pq: foreign key violation: "pet" row id=0 has no match in "person"
-ALTER TABLE pet ADD CONSTRAINT fk_constraint FOREIGN KEY (id) REFERENCES person (id)
-
-statement ok
-ALTER TABLE pet ADD CONSTRAINT fk_constraint FOREIGN KEY (id) REFERENCES person (id) NOT VALID
-
-query TTTTB
-SHOW CONSTRAINTS FROM pet
-----
-pet  fk_constraint  FOREIGN KEY  FOREIGN KEY (id) REFERENCES person(id)  false
-pet  primary        PRIMARY KEY  PRIMARY KEY (id ASC)                    true
-
-statement error pq: foreign key violation: "pet" row id=0 has no match in "person"
-ALTER TABLE pet VALIDATE CONSTRAINT fk_constraint
-
-statement ok
-INSERT INTO person VALUES (0, 18, 'Hermione Granger')
-
-statement ok
-ALTER TABLE pet VALIDATE CONSTRAINT fk_constraint
-
-query TTTTB
-SHOW CONSTRAINTS FROM pet
-----
-pet  fk_constraint  FOREIGN KEY  FOREIGN KEY (id) REFERENCES person(id)  true
-pet  primary        PRIMARY KEY  PRIMARY KEY (id ASC)                    true
-
-statement ok
-DROP TABLE person, pet

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn-mixed-19.1-19.2
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn-mixed-19.1-19.2
@@ -1,3 +1,12 @@
+# LogicTest: local-mixed-19.1-19.2
+# This test file is essentially the same as the schema_change_in_txn test file
+# in 19.1. These tests are only run in the test configuration that simulates a
+# 19.2 node running in a 19.1 cluster. In that state, schema changes related to
+# foreign keys behave as they do in 19.1, because the new table descriptor
+# mutations are not backward compatible. The most significant difference is that
+# FKs are not validated when added in 19.1, hence the need for different logic
+# tests.
+
 # Disable automatic stats to avoid flakiness (sometimes causes retry errors).
 statement ok
 SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
@@ -32,24 +41,6 @@ SELECT * FROM test.child@child_auto_index_fk_child_parent_id
 statement ok
 COMMIT
 
-# Verify that the constraint is unvalidated, which is a limitation of adding the
-# constraint in the same transaction as CREATE TABLE.
-# TODO (lucy): Add a job to validate the table in this situation.
-query TTTTB
-SHOW CONSTRAINTS FROM test.child
-----
-child  fk_child_parent_id  FOREIGN KEY  FOREIGN KEY (parent_id) REFERENCES parent(id)  false
-child  primary             PRIMARY KEY  PRIMARY KEY (id ASC)                           true
-
-statement ok
-ALTER TABLE test.child VALIDATE CONSTRAINT fk_child_parent_id
-
-query TTTTB
-SHOW CONSTRAINTS FROM test.child
-----
-child  fk_child_parent_id  FOREIGN KEY  FOREIGN KEY (parent_id) REFERENCES parent(id)  true
-child  primary             PRIMARY KEY  PRIMARY KEY (id ASC)                           true
-
 statement ok
 DROP TABLE test.child, test.parent
 
@@ -63,13 +54,6 @@ INSERT INTO test.parent values (1)
 
 statement ok
 CREATE TABLE test.child (id int primary key, parent_id int)
-
-# NOTE: this test diverges from the main fk test here because of the issue #39037, which
-# breaks the auto-creation of origin indexes in the mixed-version 19.1/19.2 state.
-# TODO(lucy): reset this test to normal once that limitations is fixed.
-
-statement ok
-CREATE INDEX child_auto_index_fk_child_parent_id ON test.child(parent_id)
 
 statement ok
 BEGIN
@@ -89,13 +73,6 @@ query II rowsort
 SELECT * FROM test.child@child_auto_index_fk_child_parent_id
 ----
 1 1
-
-# Verify that the constraint is validated.
-query TTTTB
-SHOW CONSTRAINTS FROM test.child
-----
-child  fk_child_parent_id  FOREIGN KEY  FOREIGN KEY (parent_id) REFERENCES parent(id)  true
-child  primary             PRIMARY KEY  PRIMARY KEY (id ASC)                           true
 
 statement ok
 DROP TABLE test.child, test.parent
@@ -204,9 +181,6 @@ subtest create_with_other_commands_in_txn
 statement ok
 CREATE TABLE kv (item, quantity) AS VALUES ('cups', 10), ('plates', 30), ('forks', 15)
 
-statement count 3
-SELECT * FROM kv
-
 statement ok
 BEGIN
 
@@ -245,7 +219,7 @@ SELECT * FROM test.child@idx_child_parent_id
 1 1
 2 1
 
-# create index on a table that was created outside of the transaction
+# create index on a table that was created outside of the trasanction
 statement ok
 CREATE INDEX foo ON test.kv (quantity)
 
@@ -819,110 +793,35 @@ succeeded  ALTER TABLE test.public.customers ADD COLUMN i INT8 DEFAULT 5;ALTER T
 
 # VALIDATE CONSTRAINT will not hang when executed in the same txn as
 # a schema change in the same txn #32118
-subtest validate_in_schema_change_txn
-
-# To get an unvalidated foreign key for testing, use the loophole that we
-# currently don't support adding a validated FK in the same transaction as
-# CREATE TABLE
-statement ok
-BEGIN
-
-statement ok
-CREATE TABLE products (sku STRING PRIMARY KEY, upc STRING UNIQUE, vendor STRING)
-
-statement ok
-CREATE TABLE orders2 (
-  id INT8 PRIMARY KEY,
-  product STRING DEFAULT 'sprockets',
-  INDEX (product)
-)
-
-statement ok
-ALTER TABLE orders2 ADD FOREIGN KEY (product) REFERENCES products
-
-statement ok
-COMMIT
-
-# TODO(lucy): this fails (hangs) but we don't know why, in the mixed version state.
+# TODO(lucy): The FK upgrade work caused a regression here, and VALIDATE
+# CONSTRAINT will hang when run in the same transaction as another schema
+# change, in the 19.1/19.2 mixed version state. Once we stop trying to use the
+# internal executor from the planner, this class of problems related to VALIDATE
+# CONSTRAINT will go away, but ideally we would fix this for the 19.1-to-19.2
+# upgrade path.
+# subtest validate_in_schema_change_txn
+#
+# statement ok
+# CREATE TABLE products (sku STRING PRIMARY KEY, upc STRING UNIQUE, vendor STRING)
+#
+# statement ok
+# CREATE TABLE orders2 (
+#   id INT8 PRIMARY KEY,
+#   product STRING DEFAULT 'sprockets',
+#   INDEX (product)
+# )
+#
 # statement ok
 # BEGIN
-# 
-# # Perform an unrelated schema change
+#
 # statement ok
-# ALTER TABLE orders2 ADD CHECK (id > 0)
-# 
+# ALTER TABLE orders2 ADD FOREIGN KEY (product) REFERENCES products
+#
 # statement ok
 # ALTER TABLE orders2 VALIDATE CONSTRAINT fk_product_ref_products
-# 
+#
 # statement ok
 # COMMIT
-
-statement ok
-DROP TABLE products, orders2
-
-subtest fk_constraint_being_added
-
-statement ok
-CREATE TABLE products (sku STRING PRIMARY KEY, upc STRING UNIQUE, vendor STRING)
-
-statement ok
-CREATE TABLE orders2 (
-  id INT8 PRIMARY KEY,
-  product STRING DEFAULT 'sprockets',
-  INDEX (product)
-)
-
-# The constraint can't be validated with VALIDATE CONSTRAINT in the same transaction
-statement ok
-BEGIN
-
-statement ok
-ALTER TABLE orders2 ADD FOREIGN KEY (product) REFERENCES products
-
-statement error constraint "fk_product_ref_products" in the middle of being added, try again later
-ALTER TABLE orders2 VALIDATE CONSTRAINT fk_product_ref_products
-
-statement ok
-COMMIT
-
-# Dependent columns can't be dropped
-statement ok
-BEGIN
-
-statement ok
-ALTER TABLE orders2 ADD FOREIGN KEY (product) REFERENCES products
-
-statement error constraint "fk_product_ref_products" in the middle of being added, try again later
-ALTER TABLE orders2 DROP COLUMN product
-
-statement ok
-COMMIT
-
-# Dependent indexes can't be dropped
-statement ok
-BEGIN
-
-statement ok
-ALTER TABLE orders2 ADD FOREIGN KEY (product) REFERENCES products
-
-statement error constraint "fk_product_ref_products" in the middle of being added, try again later
-DROP INDEX orders2@orders2_product_idx
-
-statement ok
-COMMIT
-
-# The constraint can't be renamed
-statement ok
-BEGIN
-
-statement ok
-ALTER TABLE orders2 ADD CONSTRAINT c FOREIGN KEY (product) REFERENCES products
-
-statement error constraint "c" in the middle of being added, try again later
-ALTER TABLE orders2 RENAME CONSTRAINT c to d
-
-statement ok
-COMMIT
 
 # Verify that check constraints can be added on columns being added in the same transaction
 subtest check_on_add_col
@@ -940,7 +839,7 @@ statement ok
 ALTER TABLE check_table ADD c INT
 
 statement ok
-ALTER TABLE check_table ADD CONSTRAINT c_0 CHECK (c > 0) NOT VALID
+ALTER TABLE check_table ADD CONSTRAINT c_0 CHECK (c > 0)
 
 statement ok
 ALTER TABLE check_table ADD d INT DEFAULT 1
@@ -954,7 +853,7 @@ COMMIT
 query TTTTB
 SHOW CONSTRAINTS FROM check_table
 ----
-check_table  c_0      CHECK        CHECK ((c > 0))      false
+check_table  c_0      CHECK        CHECK ((c > 0))      true
 check_table  d_0      CHECK        CHECK ((d > 0))      true
 check_table  primary  PRIMARY KEY  PRIMARY KEY (k ASC)  true
 
@@ -987,7 +886,7 @@ COMMIT
 query TTTTB
 SHOW CONSTRAINTS FROM check_table
 ----
-check_table  c_0      CHECK        CHECK ((c > 0))      false
+check_table  c_0      CHECK        CHECK ((c > 0))      true
 check_table  d_0      CHECK        CHECK ((d > 0))      true
 check_table  primary  PRIMARY KEY  PRIMARY KEY (k ASC)  true
 
@@ -1441,137 +1340,3 @@ COMMIT
 
 statement ok
 DROP TABLE t
-
-# Test adding NOT NULL constraints on a new column.
-subtest not_null_new_column
-
-statement ok
-CREATE TABLE t (a INT)
-
-statement ok
-INSERT INTO t VALUES (1)
-
-statement ok
-BEGIN
-
-statement ok
-ALTER TABLE t ADD COLUMN b INT AS (a) STORED
-
-statement ok
-ALTER TABLE t ALTER COLUMN b SET NOT NULL
-
-statement ok
-COMMIT
-
-statement ok
-BEGIN
-
-statement ok
-ALTER TABLE t ADD COLUMN c INT
-
-statement ok
-ALTER TABLE t ALTER COLUMN c SET NOT NULL
-
-statement error pgcode XXA00 validation of NOT NULL constraint failed: validation of CHECK "c IS NOT NULL" failed
-COMMIT
-
-statement ok
-DROP TABLE t
-
-# Test adding CHECK and NOT NULL constraints in the same transaction.
-subtest check_and_not_null
-
-statement ok
-CREATE TABLE t (a INT)
-
-statement ok
-INSERT INTO t VALUES (1)
-
-statement ok
-BEGIN
-
-statement ok
-ALTER TABLE t ADD CHECK (a > 0)
-
-# Check for name collisions with the auto-generated NOT NULL check constraint name
-statement ok
-ALTER TABLE t ADD CONSTRAINT a_auto_not_null CHECK (a IS NOT NULL)
-
-statement ok
-ALTER TABLE t ALTER COLUMN a SET NOT NULL
-
-statement ok
-COMMIT
-
-statement ok
-DROP TABLE t
-
-# Test that DROP INDEX on an index with dependent foreign keys is correctly
-# rolled back when there is an error
-subtest 38733
-
-statement ok
-CREATE TABLE x (a INT PRIMARY KEY, b INT, UNIQUE INDEX (b), c INT)
-
-statement ok
-CREATE TABLE y (a INT PRIMARY KEY, b INT, INDEX (b))
-
-statement ok
-INSERT INTO x VALUES (1, 1, 1), (2, 2, 1);
-
-statement ok
-INSERT INTO y VALUES (1, 1), (2, 1);
-
-# First, test dropping the index on the referencing side
-statement ok
-ALTER TABLE y ADD FOREIGN KEY (b) REFERENCES x (b)
-
-statement ok
-BEGIN
-
-# Drop the index that the FK reference depends on
-statement ok
-DROP INDEX y_b_idx CASCADE;
-
-# This will fail, causing the previous DROP INDEX to also be rolled back
-statement ok
-CREATE UNIQUE INDEX ON y (b);
-
-statement error pgcode XXA00 violates unique constraint
-COMMIT
-
-# Verify that table y is in a consistent state (otherwise, SHOW CONSTRAINTS
-# would fail with an error)
-query TTTTB
-SHOW CONSTRAINTS FROM y
-----
-y  primary  PRIMARY KEY  PRIMARY KEY (a ASC)  true
-
-# Also test dropping the index on the referenced side
-statement ok
-ALTER TABLE y ADD FOREIGN KEY (b) REFERENCES x (b)
-
-statement ok
-BEGIN
-
-# Drop the index that the FK reference depends on
-statement ok
-DROP INDEX x_b_key CASCADE;
-
-# This will fail, causing the previous DROP INDEX to also be rolled back
-statement ok
-CREATE UNIQUE INDEX ON x (c);
-
-statement error pgcode XXA00 violates unique constraint
-COMMIT
-
-# Verify that table x is in a consistent state (otherwise, SHOW CONSTRAINTS
-# would fail with an error).
-query TTTTB
-SHOW CONSTRAINTS FROM x
-----
-x  primary  PRIMARY KEY  PRIMARY KEY (a ASC)  true
-x  x_b_key  UNIQUE       UNIQUE (b ASC)       true
-
-statement ok
-DROP TABLE x, y


### PR DESCRIPTION
This PR makes adding a foreign key using `ADD CONSTRAINT` backward-compatible
with 19.1, by doing it in the user transaction and adding the constraint in the
`Unvalidated` state if the cluster is not upgraded to 19.2, instead of queuing
a mutation that can't be handled by 19.1 nodes.

The cluster version used for this is `cluster.VersionTopLevelForeignKeys`,
which is also used for the new foreign key representation. It made sense to
reuse this cluster version since both sets of changes affect the same code, and
it's assumed that either both or neither sets of changes will be active.

This PR also updates the special mixed 19.1/19.2 logic tests for foreign keys,
introduced in the FK representation refactoring, to revert the files to their
19.1 state, aside from some small changes to conform to unrelated 19.2
behavior, since 19.1 supports fewer FK schema change-related features.

Closes #39037.

Release note: None