### PR TITLE
opt: add "Available" annotation to props.Statistics

### DIFF
--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -213,6 +213,93 @@ func TestMemoIsStale(t *testing.T) {
 	notStale()
 }
 
+// TestStatsAvailable tests that the statisticsBuilder correctly identifies
+// for each expression whether statistics were available on the base table.
+// This test is here (instead of statistics_builder_test.go) to avoid import
+// cycles.
+func TestStatsAvailable(t *testing.T) {
+	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+
+	catalog := testcat.New()
+	if _, err := catalog.ExecuteDDL(
+		"CREATE TABLE t (a INT, b INT)",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	var o xform.Optimizer
+
+	testNotAvailable := func(expr memo.RelExpr) {
+		traverseExpr(expr, func(e memo.RelExpr) {
+			if e.Relational().Stats.Available {
+				t.Fatal("stats should not be available")
+			}
+		})
+	}
+
+	// Stats should not be available for any expression.
+	opttestutils.BuildQuery(t, &o, catalog, &evalCtx, "SELECT * FROM t WHERE a=1")
+	testNotAvailable(o.Memo().RootExpr().(memo.RelExpr))
+
+	opttestutils.BuildQuery(t, &o, catalog, &evalCtx, "SELECT sum(a), b FROM t GROUP BY b")
+	testNotAvailable(o.Memo().RootExpr().(memo.RelExpr))
+
+	opttestutils.BuildQuery(t, &o, catalog, &evalCtx,
+		"SELECT * FROM t AS t1, t AS t2 WHERE t1.a = t2.a AND t1.b = 5",
+	)
+	testNotAvailable(o.Memo().RootExpr().(memo.RelExpr))
+
+	if _, err := catalog.ExecuteDDL(
+		`ALTER TABLE t INJECT STATISTICS '[
+		{
+			"columns": ["a"],
+			"created_at": "2018-01-01 1:00:00.00000+00:00",
+			"row_count": 1000,
+			"distinct_count": 500
+		},
+		{
+			"columns": ["b"],
+			"created_at": "2018-01-01 1:30:00.00000+00:00",
+			"row_count": 1000,
+			"distinct_count": 500
+		}
+	]'`); err != nil {
+		t.Fatal(err)
+	}
+
+	testAvailable := func(expr memo.RelExpr) {
+		traverseExpr(expr, func(e memo.RelExpr) {
+			if !e.Relational().Stats.Available {
+				t.Fatal("stats should be available")
+			}
+		})
+	}
+
+	// Stats should be available for all expressions.
+	opttestutils.BuildQuery(t, &o, catalog, &evalCtx, "SELECT * FROM t WHERE a=1")
+	testAvailable(o.Memo().RootExpr().(memo.RelExpr))
+
+	opttestutils.BuildQuery(t, &o, catalog, &evalCtx, "SELECT sum(a), b FROM t GROUP BY b")
+	testAvailable(o.Memo().RootExpr().(memo.RelExpr))
+
+	opttestutils.BuildQuery(t, &o, catalog, &evalCtx,
+		"SELECT * FROM t AS t1, t AS t2 WHERE t1.a = t2.a AND t1.b = 5",
+	)
+	testAvailable(o.Memo().RootExpr().(memo.RelExpr))
+}
+
+// traverseExpr is a helper function to recursively traverse a relational
+// expression and apply a function to the root as well as each relational
+// child.
+func traverseExpr(expr memo.RelExpr, f func(memo.RelExpr)) {
+	f(expr)
+	for i, n := 0, expr.ChildCount(); i < n; i++ {
+		if child, ok := expr.Child(i).(memo.RelExpr); ok {
+			traverseExpr(child, f)
+		}
+	}
+}
+
 // runDataDrivenTest runs data-driven testcases of the form
 //   <command>
 //   <SQL statement>

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -120,7 +120,7 @@ WHERE a.y>1 AND a.x::string=b.x
 ORDER BY y
 LIMIT 10
 ----
-memo (optimized, ~16KB, required=[presentation: y:2,x:3,c:6] [ordering: +2])
+memo (optimized, ~17KB, required=[presentation: y:2,x:3,c:6] [ordering: +2])
  ├── G1: (project G2 G3 y x)
  │    ├── [presentation: y:2,x:3,c:6] [ordering: +2]
  │    │    ├── best: (project G2="[ordering: +2]" G3 y x)

--- a/pkg/sql/opt/props/statistics.go
+++ b/pkg/sql/opt/props/statistics.go
@@ -42,6 +42,12 @@ import (
 // See memo/statistics_builder.go for more information about how statistics are
 // calculated.
 type Statistics struct {
+	// Available indicates whether the underlying table statistics for this
+	// expression were available. If true, RowCount contains a real estimate.
+	// If false, RowCount does not represent reality, and should only be used
+	// for relative cost comparison.
+	Available bool
+
 	// RowCount is the estimated number of rows returned by the expression.
 	// Note that - especially when there are no stats available - the scaling of
 	// the row counts can be unpredictable; thus, a row count of 0.001 should be
@@ -65,6 +71,7 @@ func (s *Statistics) Init(relProps *Relational) (zeroCardinality bool) {
 	if relProps.Cardinality.IsZero() {
 		s.RowCount = 0
 		s.Selectivity = 0
+		s.Available = true
 		return true
 	}
 	s.Selectivity = 1

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -463,7 +463,7 @@ project
 memo
 SELECT min(a) FROM abc
 ----
-memo (optimized, ~4KB, required=[presentation: min:5])
+memo (optimized, ~5KB, required=[presentation: min:5])
  ├── G1: (scalar-group-by G2 G3 cols=()) (scalar-group-by G4 G5 cols=())
  │    └── [presentation: min:5]
  │         ├── best: (scalar-group-by G4 G5 cols=())
@@ -525,7 +525,7 @@ memo (optimized, ~5KB, required=[presentation: min:5])
 memo
 SELECT max(a) FROM abc
 ----
-memo (optimized, ~4KB, required=[presentation: max:5])
+memo (optimized, ~5KB, required=[presentation: max:5])
  ├── G1: (scalar-group-by G2 G3 cols=()) (scalar-group-by G4 G5 cols=())
  │    └── [presentation: max:5]
  │         ├── best: (scalar-group-by G4 G5 cols=())

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1579,7 +1579,7 @@ inner-join (lookup pqr)
 memo
 SELECT q,r,s FROM pqr WHERE q = 1 AND r = 2
 ----
-memo (optimized, ~14KB, required=[presentation: q:2,r:3,s:4])
+memo (optimized, ~15KB, required=[presentation: q:2,r:3,s:4])
  ├── G1: (select G2 G3) (lookup-join G4 G5 pqr,keyCols=[1],outCols=(2-4)) (select G6 G7) (select G8 G9) (select G10 G9)
  │    └── [presentation: q:2,r:3,s:4]
  │         ├── best: (lookup-join G4 G5 pqr,keyCols=[1],outCols=(2-4))
@@ -1644,7 +1644,7 @@ inner-join (zigzag pqr@q pqr@s)
 memo
 SELECT q,s FROM pqr WHERE q = 1 AND s = 'foo'
 ----
-memo (optimized, ~10KB, required=[presentation: q:2,s:4])
+memo (optimized, ~11KB, required=[presentation: q:2,s:4])
  ├── G1: (select G2 G3) (zigzag-join G3 pqr@q pqr@s) (select G4 G5) (select G6 G7)
  │    └── [presentation: q:2,s:4]
  │         ├── best: (zigzag-join G3 pqr@q pqr@s)
@@ -1789,7 +1789,7 @@ select
 memo
 SELECT p,q,r,s FROM pqr WHERE q = 1 AND r = 1 AND s = 'foo'
 ----
-memo (optimized, ~33KB, required=[presentation: p:1,q:2,r:3,s:4])
+memo (optimized, ~34KB, required=[presentation: p:1,q:2,r:3,s:4])
  ├── G1: (select G2 G3) (lookup-join G4 G5 pqr,keyCols=[1],outCols=(1-4)) (zigzag-join G3 pqr@q pqr@s) (zigzag-join G3 pqr@q pqr@rs) (lookup-join G6 G7 pqr,keyCols=[1],outCols=(1-4)) (lookup-join G8 G7 pqr,keyCols=[1],outCols=(1-4)) (lookup-join G9 G7 pqr,keyCols=[1],outCols=(1-4)) (select G10 G11) (select G12 G13) (select G14 G7) (select G15 G7)
  │    └── [presentation: p:1,q:2,r:3,s:4]
  │         ├── best: (zigzag-join G3 pqr@q pqr@s)

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -127,7 +127,7 @@ inner-join (lookup bx)
 memo join-limit=3
 SELECT * FROM bx, cy, abc WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
-memo (optimized, ~24KB, required=[presentation: b:1,x:2,c:3,y:4,a:5,b:6,c:7,d:8])
+memo (optimized, ~25KB, required=[presentation: b:1,x:2,c:3,y:4,a:5,b:6,c:7,d:8])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+6) (lookup-join G3 G5 bx,keyCols=[6],outCols=(1-8)) (inner-join G6 G7 G8) (inner-join G9 G10 G11) (inner-join G7 G6 G8) (merge-join G6 G7 G5 inner-join,+3,+7) (inner-join G10 G9 G11) (lookup-join G7 G5 cy,keyCols=[7],outCols=(1-8)) (lookup-join G12 G11 abc,keyCols=[11],outCols=(1-8))
  │    └── [presentation: b:1,x:2,c:3,y:4,a:5,b:6,c:7,d:8]
  │         ├── best: (lookup-join G3 G5 bx,keyCols=[6],outCols=(1-8))

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -465,7 +465,7 @@ memo (optimized, ~2KB, required=[presentation: i:2,k:1] [ordering: -4,+2,+1])
 memo
 SELECT i, k FROM a WHERE s >= 'foo'
 ----
-memo (optimized, ~5KB, required=[presentation: i:2,k:1])
+memo (optimized, ~6KB, required=[presentation: i:2,k:1])
  ├── G1: (project G2 G3 k i)
  │    └── [presentation: i:2,k:1]
  │         ├── best: (project G2 G3 k i)

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -457,7 +457,7 @@ select
 memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1
 ----
-memo (optimized, ~4KB, required=[presentation: k:1,u:2,v:3,j:4])
+memo (optimized, ~5KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G1: (select G2 G3) (select G4 G5)
  │    └── [presentation: k:1,u:2,v:3,j:4]
  │         ├── best: (select G4 G5)


### PR DESCRIPTION
This commit adds a boolean field `Available` to `props.Statistics`, which
indicates whether the underlying table statistics for the relational
expression were available. If true, the `RowCount` field contains a real
estimate. If false, the `RowCount` field does not represent reality, and
should only be used for relative cost comparison.

Release note: None