### PR TITLE
cli: Add command line parameter to use pebble as temp storage engine

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -137,6 +137,17 @@ type lazyCertificateManager struct {
 	err  error
 }
 
+// EngineType specifies type of storage engine (eg. rocksdb, pebble).
+type EngineType int
+
+// Engine types.
+const (
+	// Denotes RocksDB as the underlying storage engine type.
+	EngineTypeRocksDB EngineType = iota
+	// Denotes Pebble as the underlying storage engine type.
+	EngineTypePebble
+)
+
 // Config is embedded by server.Config. A base config is not meant to be used
 // directly, but embedding configs should call cfg.InitDefaults().
 type Config struct {
@@ -660,6 +671,8 @@ const (
 // pertaining to temp storage flags, specifically --temp-dir and
 // --max-disk-temp-storage.
 type TempStorageConfig struct {
+	// Engine specifies whether to use rocksdb or pebble for temp storage.
+	Engine EngineType
 	// InMemory specifies whether the temporary storage will remain
 	// in-memory or occupy a temporary subdirectory on-disk.
 	InMemory bool
@@ -683,6 +696,7 @@ func TempStorageConfigFromEnv(
 	st *cluster.Settings,
 	firstStore StoreSpec,
 	parentDir string,
+	engine EngineType,
 	maxSizeBytes int64,
 	specIdx int,
 ) TempStorageConfig {
@@ -713,6 +727,7 @@ func TempStorageConfigFromEnv(
 	}
 
 	return TempStorageConfig{
+		Engine:   engine,
 		InMemory: inMem,
 		Mon:      &monitor,
 		SpecIdx:  specIdx,

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -729,6 +729,14 @@ If this flag is unspecified, the temporary subdirectory will be located under
 the root of the first store.`,
 	}
 
+	TempEngine = FlagInfo{
+		Name: "temp-engine",
+		Description: `
+Storage engine to use for temporary storage. Options are rocksdb (default), or
+experiemental-pebble.
+`,
+	}
+
 	ExternalIODir = FlagInfo{
 		Name: "external-io-dir",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -265,6 +265,8 @@ var startCtx struct {
 
 	// temporary directory to use to spill computation results to disk.
 	tempDir string
+	// storage engine to use for temporary storage (eg. rocksdb, pebble)
+	tempEngine storageEngine
 	// directory to use for remotely-initiated operations that can
 	// specify node-local I/O paths, like BACKUP/RESTORE/IMPORT.
 	externalIODir string

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -395,6 +395,9 @@ func init() {
 		// refers to becomes known.
 		VarFlag(f, diskTempStorageSizeValue, cliflags.SQLTempStorage)
 		StringFlag(f, &startCtx.tempDir, cliflags.TempDir, startCtx.tempDir)
+		VarFlag(f, &startCtx.tempEngine, cliflags.TempEngine)
+		// Hide the tempEngine flag while it's experimental.
+		_ = f.MarkHidden(cliflags.TempEngine.Name)
 		StringFlag(f, &startCtx.externalIODir, cliflags.ExternalIODir, startCtx.externalIODir)
 
 		VarFlag(f, serverCfg.SQLAuditLogDirName, cliflags.SQLAuditLogDirName)

--- a/pkg/cli/flags_util.go
+++ b/pkg/cli/flags_util.go
@@ -348,6 +348,41 @@ func (f *tableDisplayFormat) Set(s string) error {
 	return nil
 }
 
+type storageEngine int
+
+const (
+	engineRocksDB storageEngine = iota
+	enginePebble
+)
+
+// Type implements the pflag.Value interface.
+func (f *storageEngine) Type() string { return "string" }
+
+// String implements the pflag.Value interface.
+func (f *storageEngine) String() string {
+	switch *f {
+	case engineRocksDB:
+		return "rocksdb"
+	case enginePebble:
+		return "experimental-pebble"
+	}
+	return ""
+}
+
+// Set implements the pflag.Value interface.
+func (f *storageEngine) Set(s string) error {
+	switch s {
+	case "rocksdb":
+		*f = engineRocksDB
+	case "experimental-pebble":
+		*f = enginePebble
+	default:
+		return fmt.Errorf("invalid storage engine: %s "+
+			"(possible values: rocksdb, experimental-pebble)", s)
+	}
+	return nil
+}
+
 // bytesOrPercentageValue is a flag that accepts an integer value, an integer
 // plus a unit (e.g. 32GB or 32GiB) or a percentage (e.g. 32%). In all these
 // cases, it transforms the string flag input into an int64 value.

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -368,6 +368,10 @@ func initTempStorageConfig(
 			tempStorageMaxSizeBytes = base.DefaultTempStorageMaxSizeBytes
 		}
 	}
+	storageEngine := base.EngineTypeRocksDB
+	if startCtx.tempEngine == enginePebble {
+		storageEngine = base.EngineTypePebble
+	}
 
 	// Initialize a base.TempStorageConfig based on first store's spec and
 	// cli flags.
@@ -376,6 +380,7 @@ func initTempStorageConfig(
 		st,
 		firstStore,
 		startCtx.tempDir,
+		storageEngine,
 		tempStorageMaxSizeBytes,
 		specIdx,
 	)

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -354,7 +354,7 @@ func MakeConfig(ctx context.Context, st *cluster.Settings) Config {
 			Specs: []base.StoreSpec{storeSpec},
 		},
 		TempStorageConfig: base.TempStorageConfigFromEnv(
-			ctx, st, storeSpec, "" /* parentDir */, base.DefaultTempStorageMaxSizeBytes, 0),
+			ctx, st, storeSpec, "" /* parentDir */, base.EngineTypeRocksDB, base.DefaultTempStorageMaxSizeBytes, 0),
 	}
 	cfg.AmbientCtx.Tracer = st.Tracer
 


### PR DESCRIPTION
Adds a new command line argument to specify pebble as the temp storage
engine of choice. This setting is propagated through startCtx and then
through tempStorageConfig (similar to the temp storage directory), and
then honoured in the initializer for the diskmap.

Release note: None