### PR TITLE
config: propagate zone config info for non-gossiped system tables

### DIFF
--- a/pkg/cmd/roachtest/gossip.go
+++ b/pkg/cmd/roachtest/gossip.go
@@ -350,6 +350,7 @@ func runGossipRestartNodeOne(ctx context.Context, t *test, c *cluster) {
 	run(`ALTER DATABASE system %[1]s CONFIGURE ZONE %[2]s 'constraints: {"-rack=0"}'`)
 	run(`ALTER RANGE meta %[1]s CONFIGURE ZONE %[2]s 'constraints: {"-rack=0"}'`)
 	run(`ALTER RANGE liveness %[1]s CONFIGURE ZONE %[2]s 'constraints: {"-rack=0"}'`)
+	run(`ALTER TABLE system.jobs %[1]s CONFIGURE ZONE %[2]s 'constraints: {"-rack=0"}'`)
 
 	var lastReplCount int
 	if err := retry.ForDuration(2*time.Minute, func() error {

--- a/pkg/config/system_test.go
+++ b/pkg/config/system_test.go
@@ -402,11 +402,23 @@ func TestGetZoneConfigForKey(t *testing.T) {
 		{roachpb.RKey(keys.TimeseriesPrefix.PrefixEnd()), keys.SystemRangesID},
 		{roachpb.RKey(keys.TableDataMin), keys.SystemDatabaseID},
 		{roachpb.RKey(keys.SystemConfigSplitKey), keys.SystemDatabaseID},
+
+		// Gossiped system tables should refer to the SystemDatabaseID.
 		{tkey(keys.NamespaceTableID), keys.SystemDatabaseID},
 		{tkey(keys.ZonesTableID), keys.SystemDatabaseID},
-		{tkey(keys.LeaseTableID), keys.SystemDatabaseID},
-		{tkey(keys.JobsTableID), keys.SystemDatabaseID},
-		{tkey(keys.LocationsTableID), keys.SystemDatabaseID},
+
+		// Non-gossiped system tables should refer to themselves.
+		{tkey(keys.LeaseTableID), keys.LeaseTableID},
+		{tkey(keys.JobsTableID), keys.JobsTableID},
+		{tkey(keys.LocationsTableID), keys.LocationsTableID},
+
+		// Pseudo-tables should refer to the SystemDatabaseID.
+		{tkey(keys.MetaRangesID), keys.SystemDatabaseID},
+		{tkey(keys.SystemRangesID), keys.SystemDatabaseID},
+		{tkey(keys.TimeseriesRangesID), keys.SystemDatabaseID},
+		{tkey(keys.LivenessRangesID), keys.SystemDatabaseID},
+
+		// User tables should refer to themselves.
 		{tkey(keys.MinUserDescID), keys.MinUserDescID},
 		{tkey(keys.MinUserDescID + 22), keys.MinUserDescID + 22},
 		{roachpb.RKeyMax, keys.RootNamespaceID},

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -1783,6 +1783,13 @@ func TestSystemZoneConfigs(t *testing.T) {
 	testutils.SucceedsSoon(t, waitForReplicas)
 	log.Info(ctx, "TestSystemZoneConfig: down-replication of timeseries ranges succeeded")
 
+	// Up-replicate the system.jobs table to demonstrate that it is configured
+	// independently from the system database.
+	sqlutils.SetZoneConfig(t, sqlDB, "TABLE system.jobs", "num_replicas: 7")
+	expectedReplicas += 2
+	testutils.SucceedsSoon(t, waitForReplicas)
+	log.Info(ctx, "TestSystemZoneConfig: up-replication of jobs table succeeded")
+
 	// Finally, verify the system ranges. Note that in a new cluster there are
 	// two system ranges, which we have to take into account here.
 	sqlutils.SetZoneConfig(t, sqlDB, "RANGE system", "num_replicas: 7")


### PR DESCRIPTION
Before this PR we would allow setting zone configurations on system tables but
they would not propagate because the GetZoneConfig function would return the
zone config for the entire system database. This leaves us in a still weird
situation where some system tables will ignore their zone configs but not
others.

Fixes #39605.

Release note (bug fix): Propagate zone configuration to non-gossiped system
tables.