### PR TITLE
roachtest: remove perf artifacts dir when reusing a cluster

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -823,6 +823,9 @@ func (r *testRunner) getWork(
 		if err := c.WipeE(ctx, l); err != nil {
 			return testToRunRes{}, nil, err
 		}
+		if err := c.RunL(ctx, l, c.All(), "rm -rf "+perfArtifactsDir); err != nil {
+			return testToRunRes{}, nil, errors.Wrapf(err, "failed to remove perf artifacts dir")
+		}
 		// Overwrite the spec of the cluster with the one coming from the test. In
 		// particular, this overwrites the reuse policy to reflect what the test
 		// intends to do with it.


### PR DESCRIPTION
Before this PR we'd leave the old perf artifacts dir in place. This had the
unfortunate consequence of polluting some roachperf data with results from
different tests.

Relates to #39634 but doesn't close it because we still need to go back and
clean things up.

Release note: None