### PR TITLE
sql: drop check/FK/non-null constraints in the schema changer

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -233,7 +234,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 				} else {
 					ck.Validity = sqlbase.ConstraintValidity_Unvalidated
 				}
-				n.tableDesc.AddCheckMutation(ck)
+				n.tableDesc.AddCheckMutation(ck, sqlbase.DescriptorMutation_ADD)
 
 			case *tree.ForeignKeyConstraintTableDef:
 				for _, colName := range d.FromCols {
@@ -495,7 +496,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 				name, details,
 				func(desc *sqlbase.MutableTableDescriptor, ref *sqlbase.ForeignKeyConstraint) error {
 					return params.p.removeFKBackReference(params.ctx, desc, ref)
-				}); err != nil {
+				}, params.ExecCfg().Settings); err != nil {
 				return err
 			}
 			descriptorChanged = true
@@ -838,7 +839,12 @@ func applyColumnMutation(
 		for i := range tableDesc.Mutations {
 			if constraint := tableDesc.Mutations[i].GetConstraint(); constraint != nil &&
 				constraint.ConstraintType == sqlbase.ConstraintToUpdate_NOT_NULL {
-				return nil
+				if tableDesc.Mutations[i].Direction == sqlbase.DescriptorMutation_ADD {
+					return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+						"constraint in the middle of being added")
+				}
+				return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+					"constraint in the middle of being dropped, try again later")
 			}
 		}
 
@@ -850,22 +856,41 @@ func applyColumnMutation(
 		for k := range info {
 			inuseNames[k] = struct{}{}
 		}
-		tableDesc.AddNotNullValidationMutation(string(t.Column), col.ID, inuseNames)
+		check := sqlbase.MakeNotNullCheckConstraint(col.Name, col.ID, inuseNames, sqlbase.ConstraintValidity_Validating)
+		tableDesc.AddNotNullMutation(check, sqlbase.DescriptorMutation_ADD)
 
 	case *tree.AlterTableDropNotNull:
 		if col.Nullable {
 			return nil
 		}
-		// See if there's already a mutation to add a not null constraint
+		// See if there's already a mutation to add/drop a not null constraint.
 		for i := range tableDesc.Mutations {
 			if constraint := tableDesc.Mutations[i].GetConstraint(); constraint != nil &&
 				constraint.ConstraintType == sqlbase.ConstraintToUpdate_NOT_NULL {
+				if tableDesc.Mutations[i].Direction == sqlbase.DescriptorMutation_ADD {
+					return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+						"constraint in the middle of being added, try again later")
+				}
 				return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
-					"constraint in the middle of being added, try again later")
+					"constraint in the middle of being dropped")
 			}
 		}
-		// TODO (lucy): As with FKs and check constraints, move this to the schema changer
+		info, err := tableDesc.GetConstraintInfo(params.ctx, nil)
+		if err != nil {
+			return err
+		}
+		inuseNames := make(map[string]struct{}, len(info))
+		for k := range info {
+			inuseNames[k] = struct{}{}
+		}
 		col.Nullable = true
+		// In 19.2 and above, add a check constraint equivalent to the non-null
+		// constraint and drop it in the schema changer.
+		if params.ExecCfg().Settings.Version.IsActive(cluster.VersionTopLevelForeignKeys) {
+			check := sqlbase.MakeNotNullCheckConstraint(col.Name, col.ID, inuseNames, sqlbase.ConstraintValidity_Dropping)
+			tableDesc.Checks = append(tableDesc.Checks, check)
+			tableDesc.AddNotNullMutation(check, sqlbase.DescriptorMutation_DROP)
+		}
 
 	case *tree.AlterTableDropStored:
 		if !col.IsComputed() {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -658,17 +658,9 @@ func ResolveFK(
 
 	if ts == NewTable || !settings.Version.IsActive(cluster.VersionTopLevelForeignKeys) {
 		tbl.OutboundFKs = append(tbl.OutboundFKs, ref)
-	} else {
-		tbl.AddForeignKeyValidationMutation(&ref)
-	}
-
-	// If the table is being created or was created earlier in the same
-	// transaction, add the backreference now so it happens in the same
-	// transaction too. (The forward reference will be installed in
-	// runSchemaChangesInTxn()).
-	// TODO (lucy): Ideally the backreference would also be installed there.
-	if ts == NewTable || tbl.IsNewTable() || !settings.Version.IsActive(cluster.VersionTopLevelForeignKeys) {
 		target.InboundFKs = append(target.InboundFKs, ref)
+	} else {
+		tbl.AddForeignKeyMutation(&ref, sqlbase.DescriptorMutation_ADD)
 	}
 
 	// Multiple FKs from the same column would potentially result in ambiguous or

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1573,3 +1573,120 @@ x  x_b_key  UNIQUE       UNIQUE (b ASC)       true
 
 statement ok
 DROP TABLE x, y
+
+subtest drop_constraint_in_txn
+
+statement ok
+CREATE TABLE t (a INT)
+
+statement ok
+ALTER TABLE t ADD CONSTRAINT c CHECK (a > 0)
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE t DROP CONSTRAINT c
+
+# Since the check constraint is dropped in the schema changer after the
+# transaction commits, it's still enforced during the rest of the transaction.
+statement error pq: failed to satisfy CHECK constraint \(a > 0\)
+INSERT INTO t VALUES (0)
+
+statement ok
+ROLLBACK
+
+statement ok
+ALTER TABLE t DROP CONSTRAINT c
+
+statement ok
+ALTER TABLE t ADD CONSTRAINT c_not_valid CHECK (a > 0) NOT VALID
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE t DROP CONSTRAINT c_not_valid
+
+# The constraint was unvalidated, so it doesn't need to go through the schema
+# changer and is dropped immediately.
+statement ok
+INSERT INTO t VALUES (0)
+
+statement ok
+COMMIT
+
+statement ok
+DROP TABLE t
+
+statement ok
+CREATE TABLE t (a INT)
+
+statement ok
+ALTER TABLE t ALTER COLUMN a SET NOT NULL
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE t ALTER COLUMN a DROP NOT NULL
+
+# Since the non-null constraint is dropped in the schema changer after the
+# transaction commits, it's still enforced during the rest of the transaction.
+# The error is about a check constraint because we generate a check constraint
+# when dropping not-null constraints in the schema changer.
+statement error failed to satisfy CHECK constraint \(a IS NOT NULL\)
+INSERT INTO t VALUES (NULL)
+
+statement ok
+ROLLBACK
+
+statement ok
+DROP TABLE t
+
+statement ok
+CREATE TABLE t (a INT)
+
+statement ok
+CREATE TABLE t2 (b INT PRIMARY KEY)
+
+statement ok
+ALTER TABLE t ADD CONSTRAINT fk FOREIGN KEY (a) REFERENCES t2
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE t DROP CONSTRAINT fk
+
+# Since the foreign key constraint is dropped in the schema changer after the
+# transaction commits, it's still enforced during the rest of the transaction.
+statement error pgcode 23503 value \[1\] not found in t2@primary \[b\]
+INSERT INTO t VALUES (1)
+
+statement ok
+ROLLBACK
+
+statement ok
+ALTER TABLE t DROP CONSTRAINT fk
+
+statement ok
+ALTER TABLE t ADD CONSTRAINT fk_not_valid FOREIGN KEY (a) REFERENCES t2 NOT VALID
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE t DROP CONSTRAINT fk_not_valid
+
+# The constraint was unvalidated, so it doesn't need to go through the schema
+# changer and is dropped immediately.
+statement ok
+INSERT INTO t VALUES (1)
+
+statement ok
+COMMIT
+
+statement ok
+DROP TABLE t, t2
+

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -676,11 +676,11 @@ func (desc *TableDescriptor) AllActiveAndInactiveChecks() []*TableDescriptor_Che
 	// previous versions.)
 	checks := make([]*TableDescriptor_CheckConstraint, 0, len(desc.Checks))
 	for _, c := range desc.Checks {
-		// While a check constraint is being validated for existing rows, the
-		// check constraint is present both on the table descriptor and in the
-		// mutations list in the Validating state, so those constraints are excluded
-		// here to avoid double-counting.
-		if c.Validity != ConstraintValidity_Validating {
+		// While a constraint is being validated for existing rows or being dropped,
+		// the constraint is present both on the table descriptor and in the
+		// mutations list in the Validating or Dropping state, so those constraints
+		// are excluded here to avoid double-counting.
+		if c.Validity != ConstraintValidity_Validating && c.Validity != ConstraintValidity_Dropping {
 			checks = append(checks, c)
 		}
 	}
@@ -701,11 +701,11 @@ func (desc *TableDescriptor) AllActiveAndInactiveForeignKeys() []*ForeignKeyCons
 	fks := make([]*ForeignKeyConstraint, 0, len(desc.OutboundFKs))
 	for i := range desc.OutboundFKs {
 		fk := &desc.OutboundFKs[i]
-		// While a foreign key constraint is being validated for existing rows, the
-		// foreign key reference is present both on the table descriptor and in the
-		// mutations list in the Validating state, so those FKs are excluded here to
-		// avoid double-counting.
-		if fk.Validity != ConstraintValidity_Validating {
+		// While a constraint is being validated for existing rows or being dropped,
+		// the constraint is present both on the table descriptor and in the
+		// mutations list in the Validating or Dropping state, so those constraints
+		// are excluded here to avoid double-counting.
+		if fk.Validity != ConstraintValidity_Validating && fk.Validity != ConstraintValidity_Dropping {
 			fks = append(fks, fk)
 		}
 	}
@@ -2568,11 +2568,13 @@ func (desc *MutableTableDescriptor) RenameIndexDescriptor(
 	return fmt.Errorf("index with id = %d does not exist", id)
 }
 
-// DropConstraint drops a constraint.
+// DropConstraint drops a constraint, either by removing it from the table
+// descriptor or by queuing a mutation for a schema change.
 func (desc *MutableTableDescriptor) DropConstraint(
 	name string,
 	detail ConstraintDetail,
 	removeFK func(*MutableTableDescriptor, *ForeignKeyConstraint) error,
+	settings *cluster.Settings,
 ) error {
 	switch detail.Kind {
 	case ConstraintTypePK:
@@ -2585,36 +2587,66 @@ func (desc *MutableTableDescriptor) DropConstraint(
 
 	case ConstraintTypeCheck:
 		if detail.CheckConstraint.Validity == ConstraintValidity_Validating {
-			return unimplemented.Newf("rename-constraint-check-mutation",
-				"constraint %q in the middle of being added, try again later",
-				tree.ErrNameStringP(&detail.CheckConstraint.Name))
+			return unimplemented.Newf("drop-constraint-check-mutation",
+				"constraint %q in the middle of being added, try again later", name)
+		}
+		if detail.CheckConstraint.Validity == ConstraintValidity_Dropping {
+			return unimplemented.Newf("drop-constraint-check-mutation",
+				"constraint %q in the middle of being dropped", name)
 		}
 		for i, c := range desc.Checks {
 			if c.Name == name {
-				desc.Checks = append(desc.Checks[:i], desc.Checks[i+1:]...)
-				break
+				// If the constraint is unvalidated, there's no assumption that it must
+				// hold for all rows, so it can be dropped immediately.
+				// We also drop the constraint immediately instead of queuing a mutation
+				// unless the cluster is fully upgraded to 19.2, for backward
+				// compatibility.
+				if detail.CheckConstraint.Validity == ConstraintValidity_Unvalidated ||
+					!settings.Version.IsActive(cluster.VersionTopLevelForeignKeys) {
+					desc.Checks = append(desc.Checks[:i], desc.Checks[i+1:]...)
+					return nil
+				}
+				c.Validity = ConstraintValidity_Dropping
+				desc.AddCheckMutation(c, DescriptorMutation_DROP)
+				return nil
 			}
 		}
-		return nil
+		return errors.Errorf("constraint %q not found on table %q", name, desc.Name)
 
 	case ConstraintTypeFK:
-		if err := removeFK(desc, detail.FK); err != nil {
-			return err
+		if detail.FK.Validity == ConstraintValidity_Validating {
+			return unimplemented.Newf("drop-constraint-fk-mutation",
+				"constraint %q in the middle of being added, try again later", name)
+		}
+		if detail.FK.Validity == ConstraintValidity_Dropping {
+			return unimplemented.Newf("drop-constraint-fk-mutation",
+				"constraint %q in the middle of being dropped", name)
 		}
 		// Search through the descriptor's foreign key constraints and delete the
 		// one that we're supposed to be deleting.
-		foundIdx := -1
-		for i, ref := range desc.OutboundFKs {
+		for i := range desc.OutboundFKs {
+			ref := &desc.OutboundFKs[i]
 			if ref.Name == name {
-				foundIdx = i
-				break
+				// If the constraint is unvalidated, there's no assumption that it must
+				// hold for all rows, so it can be dropped immediately.
+				// We also drop the constraint immediately instead of queuing a mutation
+				// unless the cluster is fully upgraded to 19.2, for backward
+				// compatibility.
+				if detail.FK.Validity == ConstraintValidity_Unvalidated ||
+					!settings.Version.IsActive(cluster.VersionTopLevelForeignKeys) {
+					// Remove the backreference.
+					if err := removeFK(desc, detail.FK); err != nil {
+						return err
+					}
+					desc.OutboundFKs = append(desc.OutboundFKs[:i], desc.OutboundFKs[i+1:]...)
+					return nil
+				}
+				ref.Validity = ConstraintValidity_Dropping
+				desc.AddForeignKeyMutation(ref, DescriptorMutation_DROP)
+				return nil
 			}
 		}
-		if foundIdx == -1 {
-			return errors.AssertionFailedf("constraint %q not found on table %q", name, desc.Name)
-		}
-		desc.OutboundFKs = append(desc.OutboundFKs[:foundIdx], desc.OutboundFKs[foundIdx+1:]...)
-		return nil
+		return errors.AssertionFailedf("constraint %q not found on table %q", name, desc.Name)
 
 	default:
 		return unimplemented.Newf(fmt.Sprintf("drop-constraint-%s", detail.Kind),
@@ -2870,25 +2902,30 @@ func (desc *MutableTableDescriptor) MakeMutationComplete(m DescriptorMutation) e
 		}
 		// Nothing else to be done. The column/index was already removed from the
 		// set of column/index descriptors at mutation creation time.
+		// Constraints to be dropped are dropped before column/index backfills.
 	}
 	return nil
 }
 
 // AddCheckMutation adds a check constraint mutation to desc.Mutations.
-func (desc *MutableTableDescriptor) AddCheckMutation(ck *TableDescriptor_CheckConstraint) {
+func (desc *MutableTableDescriptor) AddCheckMutation(
+	ck *TableDescriptor_CheckConstraint, direction DescriptorMutation_Direction,
+) {
 	m := DescriptorMutation{
 		Descriptor_: &DescriptorMutation_Constraint{
 			Constraint: &ConstraintToUpdate{
 				ConstraintType: ConstraintToUpdate_CHECK, Name: ck.Name, Check: *ck,
 			},
 		},
-		Direction: DescriptorMutation_ADD,
+		Direction: direction,
 	}
 	desc.addMutation(m)
 }
 
-// AddForeignKeyValidationMutation adds a foreign key constraint validation mutation to desc.Mutations.
-func (desc *MutableTableDescriptor) AddForeignKeyValidationMutation(fk *ForeignKeyConstraint) {
+// AddForeignKeyMutation adds a foreign key constraint mutation to desc.Mutations.
+func (desc *MutableTableDescriptor) AddForeignKeyMutation(
+	fk *ForeignKeyConstraint, direction DescriptorMutation_Direction,
+) {
 	m := DescriptorMutation{
 		Descriptor_: &DescriptorMutation_Constraint{
 			Constraint: &ConstraintToUpdate{
@@ -2897,17 +2934,17 @@ func (desc *MutableTableDescriptor) AddForeignKeyValidationMutation(fk *ForeignK
 				ForeignKey:     *fk,
 			},
 		},
-		Direction: DescriptorMutation_ADD,
+		Direction: direction,
 	}
 	desc.addMutation(m)
 }
 
-// makeNotNullCheckConstraint creates a dummy check constraint equivalent to a
+// MakeNotNullCheckConstraint creates a dummy check constraint equivalent to a
 // NOT NULL constraint on a column, so that NOT NULL constraints can be added
 // and dropped correctly in the schema changer. This function mutates inuseNames
 // to add the new constraint name.
-func makeNotNullCheckConstraint(
-	colName string, colID ColumnID, inuseNames map[string]struct{},
+func MakeNotNullCheckConstraint(
+	colName string, colID ColumnID, inuseNames map[string]struct{}, validity ConstraintValidity,
 ) *TableDescriptor_CheckConstraint {
 	name := fmt.Sprintf("%s_auto_not_null", colName)
 	// If generated name isn't unique, attempt to add a number to the end to
@@ -2936,33 +2973,33 @@ func makeNotNullCheckConstraint(
 	return &TableDescriptor_CheckConstraint{
 		Name:                name,
 		Expr:                tree.Serialize(expr),
-		Validity:            ConstraintValidity_Validating,
+		Validity:            validity,
 		ColumnIDs:           []ColumnID{colID},
 		IsNonNullConstraint: true,
 	}
 }
 
-// AddNotNullValidationMutation adds a not null constraint validation mutation
-// to desc.Mutations. Similarly to other schema elements, adding a non-null
+// AddNotNullMutation adds a not null constraint mutation to desc.Mutations.
+// Similarly to other schema elements, adding or dropping a non-null
 // constraint requires a multi-state schema change, including a bulk validation
 // step, before the Nullable flag can be set to false on the descriptor. This is
 // done by adding a dummy check constraint of the form "x IS NOT NULL" that is
 // treated like other check constraints being added, until the completion of the
 // schema change, at which the check constraint is deleted. This function
 // mutates inuseNames to add the new constraint name.
-func (desc *MutableTableDescriptor) AddNotNullValidationMutation(
-	colName string, colID ColumnID, inuseNames map[string]struct{},
+func (desc *MutableTableDescriptor) AddNotNullMutation(
+	ck *TableDescriptor_CheckConstraint, direction DescriptorMutation_Direction,
 ) {
-	ck := makeNotNullCheckConstraint(colName, colID, inuseNames)
 	m := DescriptorMutation{
 		Descriptor_: &DescriptorMutation_Constraint{
 			Constraint: &ConstraintToUpdate{
 				ConstraintType: ConstraintToUpdate_NOT_NULL,
-				NotNullColumn:  colID,
+				Name:           ck.Name,
+				NotNullColumn:  ck.ColumnIDs[0],
 				Check:          *ck,
 			},
 		},
-		Direction: DescriptorMutation_ADD,
+		Direction: direction,
 	}
 	desc.addMutation(m)
 }

--- a/pkg/sql/sqlbase/structured.pb.go
+++ b/pkg/sql/sqlbase/structured.pb.go
@@ -37,17 +37,21 @@ const (
 	// The constraint was just added, but the validation for existing rows is not
 	// yet complete. If validation fails, the constraint will be dropped.
 	ConstraintValidity_Validating ConstraintValidity = 2
+	// The constraint is being dropped in the schema changer.
+	ConstraintValidity_Dropping ConstraintValidity = 3
 )
 
 var ConstraintValidity_name = map[int32]string{
 	0: "Validated",
 	1: "Unvalidated",
 	2: "Validating",
+	3: "Dropping",
 }
 var ConstraintValidity_value = map[string]int32{
 	"Validated":   0,
 	"Unvalidated": 1,
 	"Validating":  2,
+	"Dropping":    3,
 }
 
 func (x ConstraintValidity) Enum() *ConstraintValidity {
@@ -67,7 +71,7 @@ func (x *ConstraintValidity) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ConstraintValidity) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{0}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{0}
 }
 
 type ForeignKeyReference_Action int32
@@ -112,7 +116,7 @@ func (x *ForeignKeyReference_Action) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ForeignKeyReference_Action) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{0, 0}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{0, 0}
 }
 
 // Match is the algorithm used to compare composite keys.
@@ -152,7 +156,7 @@ func (x *ForeignKeyReference_Match) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ForeignKeyReference_Match) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{0, 1}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{0, 1}
 }
 
 // The direction of a column in the index.
@@ -189,7 +193,7 @@ func (x *IndexDescriptor_Direction) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (IndexDescriptor_Direction) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{6, 0}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{6, 0}
 }
 
 // The type of the index.
@@ -226,7 +230,7 @@ func (x *IndexDescriptor_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (IndexDescriptor_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{6, 1}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{6, 1}
 }
 
 type ConstraintToUpdate_ConstraintType int32
@@ -269,7 +273,7 @@ func (x *ConstraintToUpdate_ConstraintType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ConstraintToUpdate_ConstraintType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{7, 0}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{7, 0}
 }
 
 // A descriptor within a mutation is unavailable for reads, writes
@@ -334,7 +338,7 @@ func (x *DescriptorMutation_State) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DescriptorMutation_State) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{8, 0}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{8, 0}
 }
 
 // Direction of mutation.
@@ -377,7 +381,7 @@ func (x *DescriptorMutation_Direction) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DescriptorMutation_Direction) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{8, 1}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{8, 1}
 }
 
 // State is set if this TableDescriptor is in the process of being added or deleted.
@@ -428,7 +432,7 @@ func (x *TableDescriptor_State) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TableDescriptor_State) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{9, 0}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{9, 0}
 }
 
 // AuditMode indicates which auditing actions to take when this table is used.
@@ -465,7 +469,7 @@ func (x *TableDescriptor_AuditMode) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TableDescriptor_AuditMode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{9, 1}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{9, 1}
 }
 
 type ForeignKeyReference struct {
@@ -487,7 +491,7 @@ func (m *ForeignKeyReference) Reset()         { *m = ForeignKeyReference{} }
 func (m *ForeignKeyReference) String() string { return proto.CompactTextString(m) }
 func (*ForeignKeyReference) ProtoMessage()    {}
 func (*ForeignKeyReference) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{0}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{0}
 }
 func (m *ForeignKeyReference) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -555,7 +559,7 @@ func (m *ForeignKeyConstraint) Reset()         { *m = ForeignKeyConstraint{} }
 func (m *ForeignKeyConstraint) String() string { return proto.CompactTextString(m) }
 func (*ForeignKeyConstraint) ProtoMessage()    {}
 func (*ForeignKeyConstraint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{1}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{1}
 }
 func (m *ForeignKeyConstraint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -600,7 +604,7 @@ func (m *ColumnDescriptor) Reset()         { *m = ColumnDescriptor{} }
 func (m *ColumnDescriptor) String() string { return proto.CompactTextString(m) }
 func (*ColumnDescriptor) ProtoMessage()    {}
 func (*ColumnDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{2}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{2}
 }
 func (m *ColumnDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -651,7 +655,7 @@ func (m *ColumnFamilyDescriptor) Reset()         { *m = ColumnFamilyDescriptor{}
 func (m *ColumnFamilyDescriptor) String() string { return proto.CompactTextString(m) }
 func (*ColumnFamilyDescriptor) ProtoMessage()    {}
 func (*ColumnFamilyDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{3}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{3}
 }
 func (m *ColumnFamilyDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -697,7 +701,7 @@ func (m *InterleaveDescriptor) Reset()         { *m = InterleaveDescriptor{} }
 func (m *InterleaveDescriptor) String() string { return proto.CompactTextString(m) }
 func (*InterleaveDescriptor) ProtoMessage()    {}
 func (*InterleaveDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{4}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{4}
 }
 func (m *InterleaveDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -741,7 +745,7 @@ func (m *InterleaveDescriptor_Ancestor) Reset()         { *m = InterleaveDescrip
 func (m *InterleaveDescriptor_Ancestor) String() string { return proto.CompactTextString(m) }
 func (*InterleaveDescriptor_Ancestor) ProtoMessage()    {}
 func (*InterleaveDescriptor_Ancestor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{4, 0}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{4, 0}
 }
 func (m *InterleaveDescriptor_Ancestor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -786,7 +790,7 @@ func (m *PartitioningDescriptor) Reset()         { *m = PartitioningDescriptor{}
 func (m *PartitioningDescriptor) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor) ProtoMessage()    {}
 func (*PartitioningDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{5}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{5}
 }
 func (m *PartitioningDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -829,7 +833,7 @@ func (m *PartitioningDescriptor_List) Reset()         { *m = PartitioningDescrip
 func (m *PartitioningDescriptor_List) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor_List) ProtoMessage()    {}
 func (*PartitioningDescriptor_List) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{5, 0}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{5, 0}
 }
 func (m *PartitioningDescriptor_List) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -874,7 +878,7 @@ func (m *PartitioningDescriptor_Range) Reset()         { *m = PartitioningDescri
 func (m *PartitioningDescriptor_Range) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor_Range) ProtoMessage()    {}
 func (*PartitioningDescriptor_Range) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{5, 1}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{5, 1}
 }
 func (m *PartitioningDescriptor_Range) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1007,7 +1011,7 @@ func (m *IndexDescriptor) Reset()         { *m = IndexDescriptor{} }
 func (m *IndexDescriptor) String() string { return proto.CompactTextString(m) }
 func (*IndexDescriptor) ProtoMessage()    {}
 func (*IndexDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{6}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{6}
 }
 func (m *IndexDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1058,7 +1062,7 @@ func (m *ConstraintToUpdate) Reset()         { *m = ConstraintToUpdate{} }
 func (m *ConstraintToUpdate) String() string { return proto.CompactTextString(m) }
 func (*ConstraintToUpdate) ProtoMessage()    {}
 func (*ConstraintToUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{7}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{7}
 }
 func (m *ConstraintToUpdate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1112,7 +1116,7 @@ func (m *DescriptorMutation) Reset()         { *m = DescriptorMutation{} }
 func (m *DescriptorMutation) String() string { return proto.CompactTextString(m) }
 func (*DescriptorMutation) ProtoMessage()    {}
 func (*DescriptorMutation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{8}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{8}
 }
 func (m *DescriptorMutation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1403,7 +1407,7 @@ func (m *TableDescriptor) Reset()         { *m = TableDescriptor{} }
 func (m *TableDescriptor) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor) ProtoMessage()    {}
 func (*TableDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{9}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{9}
 }
 func (m *TableDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1688,7 +1692,7 @@ func (m *TableDescriptor_SchemaChangeLease) Reset()         { *m = TableDescript
 func (m *TableDescriptor_SchemaChangeLease) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_SchemaChangeLease) ProtoMessage()    {}
 func (*TableDescriptor_SchemaChangeLease) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{9, 0}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{9, 0}
 }
 func (m *TableDescriptor_SchemaChangeLease) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1726,7 +1730,7 @@ func (m *TableDescriptor_CheckConstraint) Reset()         { *m = TableDescriptor
 func (m *TableDescriptor_CheckConstraint) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_CheckConstraint) ProtoMessage()    {}
 func (*TableDescriptor_CheckConstraint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{9, 1}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{9, 1}
 }
 func (m *TableDescriptor_CheckConstraint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1829,7 +1833,7 @@ func (m *TableDescriptor_NameInfo) Reset()         { *m = TableDescriptor_NameIn
 func (m *TableDescriptor_NameInfo) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_NameInfo) ProtoMessage()    {}
 func (*TableDescriptor_NameInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{9, 2}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{9, 2}
 }
 func (m *TableDescriptor_NameInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1869,7 +1873,7 @@ func (m *TableDescriptor_Reference) Reset()         { *m = TableDescriptor_Refer
 func (m *TableDescriptor_Reference) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_Reference) ProtoMessage()    {}
 func (*TableDescriptor_Reference) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{9, 3}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{9, 3}
 }
 func (m *TableDescriptor_Reference) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1906,7 +1910,7 @@ func (m *TableDescriptor_MutationJob) Reset()         { *m = TableDescriptor_Mut
 func (m *TableDescriptor_MutationJob) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_MutationJob) ProtoMessage()    {}
 func (*TableDescriptor_MutationJob) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{9, 4}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{9, 4}
 }
 func (m *TableDescriptor_MutationJob) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1948,7 +1952,7 @@ func (m *TableDescriptor_SequenceOpts) Reset()         { *m = TableDescriptor_Se
 func (m *TableDescriptor_SequenceOpts) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_SequenceOpts) ProtoMessage()    {}
 func (*TableDescriptor_SequenceOpts) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{9, 5}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{9, 5}
 }
 func (m *TableDescriptor_SequenceOpts) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1982,7 +1986,7 @@ func (m *TableDescriptor_Replacement) Reset()         { *m = TableDescriptor_Rep
 func (m *TableDescriptor_Replacement) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_Replacement) ProtoMessage()    {}
 func (*TableDescriptor_Replacement) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{9, 6}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{9, 6}
 }
 func (m *TableDescriptor_Replacement) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2019,7 +2023,7 @@ func (m *TableDescriptor_GCDescriptorMutation) Reset()         { *m = TableDescr
 func (m *TableDescriptor_GCDescriptorMutation) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_GCDescriptorMutation) ProtoMessage()    {}
 func (*TableDescriptor_GCDescriptorMutation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{9, 7}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{9, 7}
 }
 func (m *TableDescriptor_GCDescriptorMutation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2058,7 +2062,7 @@ func (m *DatabaseDescriptor) Reset()         { *m = DatabaseDescriptor{} }
 func (m *DatabaseDescriptor) String() string { return proto.CompactTextString(m) }
 func (*DatabaseDescriptor) ProtoMessage()    {}
 func (*DatabaseDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{10}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{10}
 }
 func (m *DatabaseDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2116,7 +2120,7 @@ func (m *Descriptor) Reset()         { *m = Descriptor{} }
 func (m *Descriptor) String() string { return proto.CompactTextString(m) }
 func (*Descriptor) ProtoMessage()    {}
 func (*Descriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_99848ee4fd67bc2e, []int{11}
+	return fileDescriptor_structured_c4626d7b9f93c613, []int{11}
 }
 func (m *Descriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -9520,11 +9524,11 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/sqlbase/structured.proto", fileDescriptor_structured_99848ee4fd67bc2e)
+	proto.RegisterFile("sql/sqlbase/structured.proto", fileDescriptor_structured_c4626d7b9f93c613)
 }
 
-var fileDescriptor_structured_99848ee4fd67bc2e = []byte{
-	// 3302 bytes of a gzipped FileDescriptorProto
+var fileDescriptor_structured_c4626d7b9f93c613 = []byte{
+	// 3310 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x5a, 0x4d, 0x6c, 0x23, 0xc7,
 	0xb1, 0xd6, 0xf0, 0x9f, 0xc5, 0xbf, 0x51, 0x6b, 0x77, 0xcd, 0xa5, 0xd7, 0x12, 0x97, 0xeb, 0xb5,
 	0xe5, 0x3f, 0x69, 0xad, 0x7d, 0x3f, 0xfb, 0xfc, 0x1e, 0xfc, 0x1e, 0xff, 0xb4, 0xa2, 0xa4, 0x25,
@@ -9726,10 +9730,10 @@ var fileDescriptor_structured_99848ee4fd67bc2e = []byte{
 	0x47, 0x6c, 0xc3, 0x95, 0xcf, 0x24, 0x80, 0xd0, 0xe6, 0xde, 0x0f, 0xff, 0xf3, 0xd3, 0xe5, 0x7d,
 	0xe0, 0xb9, 0x14, 0xbf, 0x36, 0x23, 0xfe, 0x35, 0xea, 0x31, 0xa4, 0x74, 0x7e, 0x64, 0xee, 0x3a,
 	0x97, 0x36, 0x5c, 0x17, 0x2c, 0xb3, 0x46, 0xee, 0x94, 0x4b, 0x6b, 0x49, 0x88, 0x8f, 0x2c, 0xc3,
-	0xb6, 0xde, 0x6c, 0x84, 0x9f, 0x2e, 0x05, 0x0b, 0x13, 0xe3, 0xd3, 0xdf, 0xaa, 0x87, 0x75, 0xf6,
-	0x34, 0xb2, 0x6b, 0x1d, 0xf9, 0x02, 0x09, 0xe5, 0x01, 0xf8, 0xb8, 0x61, 0xf5, 0xe5, 0x48, 0xed,
-	0x8d, 0x2f, 0xfe, 0x32, 0x3f, 0xf3, 0xc5, 0xd9, 0xbc, 0xf4, 0xe5, 0xd9, 0xbc, 0xf4, 0xd5, 0xd9,
-	0xbc, 0xf4, 0xe7, 0xb3, 0x79, 0xe9, 0x67, 0x5f, 0xcf, 0xcf, 0x7c, 0xf9, 0xf5, 0xfc, 0xcc, 0x57,
-	0x5f, 0xcf, 0xcf, 0xfc, 0x7f, 0x92, 0x6f, 0xec, 0x9f, 0x01, 0x00, 0x00, 0xff, 0xff, 0xc8, 0x8e,
-	0x42, 0xac, 0x9a, 0x26, 0x00, 0x00,
+	0xb6, 0xde, 0x54, 0xc2, 0x4f, 0x97, 0x82, 0x85, 0x89, 0xf1, 0xe9, 0x6f, 0xd5, 0xc3, 0x3a, 0x7b,
+	0x1a, 0xd9, 0xb5, 0x8e, 0x7c, 0x81, 0x84, 0xf2, 0x00, 0x7c, 0xdc, 0xb0, 0xfa, 0x72, 0x84, 0x5e,
+	0x9d, 0x63, 0x0f, 0x87, 0xe4, 0x2b, 0x5a, 0x7b, 0xe3, 0x8b, 0xbf, 0xcc, 0xcf, 0x7c, 0x71, 0x36,
+	0x2f, 0x7d, 0x79, 0x36, 0x2f, 0x7d, 0x75, 0x36, 0x2f, 0xfd, 0xf9, 0x6c, 0x5e, 0xfa, 0xd9, 0xd7,
+	0xf3, 0x33, 0x5f, 0x7e, 0x3d, 0x3f, 0xf3, 0xd5, 0xd7, 0xf3, 0x33, 0xff, 0x9f, 0xe4, 0xdb, 0xfc,
+	0x67, 0x00, 0x00, 0x00, 0xff, 0xff, 0xd0, 0xa6, 0x26, 0x5d, 0xa8, 0x26, 0x00, 0x00,
 }

--- a/pkg/sql/sqlbase/structured.proto
+++ b/pkg/sql/sqlbase/structured.proto
@@ -26,6 +26,8 @@ enum ConstraintValidity {
   // The constraint was just added, but the validation for existing rows is not
   // yet complete. If validation fails, the constraint will be dropped.
   Validating = 2;
+  // The constraint is being dropped in the schema changer.
+  Dropping = 3;
 }
 
 message ForeignKeyReference {

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -826,13 +826,8 @@ func (p *planner) writeTableDescToBatch(
 	}
 
 	if tableDesc.IsNewTable() {
-		if err := runSchemaChangesInTxn(ctx,
-			p.txn,
-			p.Tables(),
-			p.execCfg,
-			p.EvalContext(),
-			tableDesc,
-			p.ExtendedEvalContext().Tracing.KVTracingEnabled(),
+		if err := runSchemaChangesInTxn(
+			ctx, p, tableDesc, p.ExtendedEvalContext().Tracing.KVTracingEnabled(),
 		); err != nil {
 			return err
 		}


### PR DESCRIPTION
Previously, `DROP CONSTRAINT` for check, foreign key, and non-null constraints
would cause those constraints to be immediately removed from the table
descriptor in a single transaction, which causes inconsistencies if the
constraint was validated and the optimizer was relying on those constraints to
hold. In this PR, constraints are now dropped in the schema changer if they
were previously validated. The existing code path is preserved for clusters not
fully upgraded to 19.2.

This PR slightly changes the behavior of `DROP CONSTRAINT` statements within
transactions: Since constraints are not removed immediately, they are still
enforced for writes within the same transaction, in the same way that
constraints are _not_ enforced within the same transaction in which they are
added. (The difference is that when adding constraints in a transaction that
also contains writes, a validation query is run before any results are returned
to the client, and the schema change is rolled back if necessary.)

Release note (sql change): When `DROP CONSTRAINT` is executed in a transaction
on a validated constraint, subsequent writes in that constraint will now fail
if they violate that constraint. This is to enforce consistency when dropping
constraints asynchronously in the schema changer.