### PR TITLE
workload/tpcc: fix --partition-affinity flag

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -379,6 +379,15 @@ func registerTPCC(r *testRegistry) {
 		EstimatedMax:   2500,
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
+		Nodes:        9,
+		CPUs:         4,
+		Distribution: multiRegion,
+		LoadConfig:   multiLoadgen,
+
+		LoadWarehouses: 2000,
+		EstimatedMax:   1000,
+	})
+	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes:      9,
 		CPUs:       4,
 		Chaos:      true,

--- a/pkg/workload/tpcc/partition.go
+++ b/pkg/workload/tpcc/partition.go
@@ -393,8 +393,8 @@ func replicateItem(db *gosql.DB, cfg zoneConfig) error {
 
 		configure := fmt.Sprintf(`
 			ALTER INDEX item@%s
-			CONFIGURE ZONE USING lease_preferences = '[[+zone=%s]]'`,
-			idxName, zone)
+			CONFIGURE ZONE USING constraints = '{"+zone=%s":1}', lease_preferences = '[[+zone=%s]]'`,
+			idxName, zone, zone)
 		if _, err := db.Exec(configure); err != nil {
 			return errors.Wrapf(err, "Couldn't exec %q", configure)
 		}

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -551,12 +551,12 @@ func (w *tpcc) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, 
 
 	fmt.Printf("Initializing %d workers and preparing statements...\n", w.workers)
 	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
-	ql.WorkerFns = make([]func(context.Context) error, w.workers)
+	ql.WorkerFns = make([]func(context.Context) error, 0, w.workers)
 	var group errgroup.Group
 	// Limit the amount of workers we initialize in parallel, to avoid running out
 	// of memory (#36897).
 	sem := make(chan struct{}, 100)
-	for workerIdx := range ql.WorkerFns {
+	for workerIdx := 0; workerIdx < w.workers; workerIdx++ {
 		workerIdx := workerIdx
 		warehouse := w.wPart.totalElems[workerIdx%len(w.wPart.totalElems)]
 
@@ -568,11 +568,14 @@ func (w *tpcc) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, 
 		dbs := partitionDBs[p]
 		db := dbs[warehouse%len(dbs)]
 
+		// NB: ql.WorkerFns is sized so this never re-allocs.
+		ql.WorkerFns = append(ql.WorkerFns, nil)
+		idx := len(ql.WorkerFns) - 1
 		sem <- struct{}{}
 		group.Go(func() error {
 			worker, err := newWorker(context.TODO(), w, db, reg.GetHandle(), warehouse)
 			if err == nil {
-				ql.WorkerFns[workerIdx] = worker.run
+				ql.WorkerFns[idx] = worker.run
 			}
 			<-sem
 			return err


### PR DESCRIPTION
This was broken by b4e7796.

The second commit adds a new roachtest that uses the flag and would have caught this regression.

cc. @sploiselle 