### PR TITLE
kv: init heartbeat txn log tag later

### DIFF
--- a/pkg/kv/txn_interceptor_heartbeater.go
+++ b/pkg/kv/txn_interceptor_heartbeater.go
@@ -115,7 +115,6 @@ func (h *txnHeartbeater) init(
 	asyncAbortCallbackLocked func(context.Context),
 ) {
 	h.AmbientContext = ac
-	h.AmbientContext.AddLogTag("txn-hb", txn.Short())
 	h.stopper = stopper
 	h.clock = clock
 	h.heartbeatInterval = heartbeatInterval
@@ -208,6 +207,9 @@ func (h *txnHeartbeater) startHeartbeatLoopLocked(ctx context.Context) error {
 	log.VEventf(ctx, 2, "coordinator spawns heartbeat loop")
 	h.mu.loopStarted = true
 	h.mu.txnEnd = make(chan struct{})
+	// NB: we can't do this in init() because the txn isn't populated yet then
+	// (it's zero).
+	h.AmbientContext.AddLogTag("txn-hb", h.mu.txn.Short())
 
 	// Create a new context so that the heartbeat loop doesn't inherit the
 	// caller's cancelation.


### PR DESCRIPTION
At init() time, the txn proto has not been populated yet.
Found while investigating #39652.

This change strikes me as clunky, but I don't have the bandwidth to dig deeper
right now.

Release note: None