### PR TITLE
testutils/lint/passes: disable under nightly stress

### DIFF
--- a/pkg/testutils/lint/passes/hash/hash_test.go
+++ b/pkg/testutils/lint/passes/hash/hash_test.go
@@ -13,11 +13,15 @@ package hash_test
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/hash"
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 
 func Test(t *testing.T) {
+	if testutils.NightlyStress() {
+		t.Skip("Go cache files don't work under stress")
+	}
 	testdata := analysistest.TestData()
 	analysistest.Run(t, testdata, hash.Analyzer, "a")
 }

--- a/pkg/testutils/lint/passes/timer/timer_test.go
+++ b/pkg/testutils/lint/passes/timer/timer_test.go
@@ -13,11 +13,15 @@ package timer_test
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/timer"
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 
 func Test(t *testing.T) {
+	if testutils.NightlyStress() {
+		t.Skip("Go cache files don't work under stress")
+	}
 	testdata := analysistest.TestData()
 	analysistest.Run(t, testdata, timer.Analyzer, "a")
 }

--- a/pkg/testutils/lint/passes/unconvert/unconvert_test.go
+++ b/pkg/testutils/lint/passes/unconvert/unconvert_test.go
@@ -13,11 +13,15 @@ package unconvert_test
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/unconvert"
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 
 func Test(t *testing.T) {
+	if testutils.NightlyStress() {
+		t.Skip("Go cache files don't work under stress")
+	}
 	testdata := analysistest.TestData()
 	analysistest.Run(t, testdata, unconvert.Analyzer, "a")
 }


### PR DESCRIPTION
Under stress these error with "go build a: failed to cache compiled Go files".

Fixes #39616
Fixes #39541
Fixes #39479

Release note: None