### PR TITLE
importccl: stop double incrementing table version

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -981,7 +981,6 @@ func (r *importResumer) OnFailOrCancel(ctx context.Context, txn *client.Txn) err
 			b.CPut(sqlbase.MakeNameMetadataKey(tableDesc.ParentID, tableDesc.Name), nil, tableDesc.ID)
 		} else {
 			// IMPORT did not create this table, so we should not drop it.
-			tableDesc.Version++
 			tableDesc.State = sqlbase.TableDescriptor_PUBLIC
 		}
 		// Note that this CPut is safe with respect to mixed-version descriptor


### PR DESCRIPTION
The table desc version was incremented twice when cleaning up import
jobs (on fail) that did not create a table.

Release note: None