### PR TITLE
sql: makes MakeCollatedString allow oid.T_name.

### DIFF
--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -593,7 +593,7 @@ func MakeQChar(width int32) *T {
 //
 func MakeCollatedString(strType *T, locale string) *T {
 	switch strType.Oid() {
-	case oid.T_text, oid.T_varchar, oid.T_bpchar, oid.T_char:
+	case oid.T_text, oid.T_varchar, oid.T_bpchar, oid.T_char, oid.T_name:
 		return &T{InternalType: InternalType{
 			Family: CollatedStringFamily, Oid: strType.Oid(), Width: strType.Width(), Locale: &locale}}
 	}
@@ -1480,7 +1480,11 @@ func (t *T) upgradeType() error {
 		t.InternalType.ArrayContents = Oid
 
 	case name:
-		t.InternalType.Family = StringFamily
+		if t.InternalType.Locale != nil {
+			t.InternalType.Family = CollatedStringFamily
+		} else {
+			t.InternalType.Family = StringFamily
+		}
 		t.InternalType.Oid = oid.T_name
 		if t.Width() != 0 {
 			return errors.AssertionFailedf("name type cannot have non-zero width: %d", t.Width())

--- a/pkg/sql/types/types_test.go
+++ b/pkg/sql/types/types_test.go
@@ -117,6 +117,9 @@ func TestTypes(t *testing.T) {
 		{MakeCollatedString(MakeQChar(20), enCollate),
 			MakeScalar(CollatedStringFamily, oid.T_char, 0, 20, enCollate)},
 
+		{MakeCollatedString(Name, enCollate), &T{InternalType: InternalType{
+			Family: CollatedStringFamily, Oid: oid.T_name, Locale: &enCollate}}},
+
 		// DATE
 		{Date, &T{InternalType: InternalType{
 			Family: DateFamily, Oid: oid.T_date, Locale: &emptyLocale}}},


### PR DESCRIPTION
Fixes #39654.

Release note: None