### PR TITLE
sql: make sure that typ field of DTuple is initialized when used as JSON

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/json_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/json_builtins
@@ -327,6 +327,10 @@ SELECT to_json(x.*) FROM (VALUES (1,2)) AS x(a);
 query error found duplicate tuple label: \"column2\"
 SELECT to_json(x.*) FROM (VALUES (1,2)) AS x(column2);
 
+# Regression test for #39502.
+statement ok
+SELECT json_agg((3808362714,))
+
 ## json_array_elements and jsonb_array_elements
 
 query T


### PR DESCRIPTION
We're accessing typ field of a DTuple to get the tuple labels when
converting the tuple to JSON; however, typ field can be nil in some
cases. Now, we're making sure that the field is initialized.

Fixes: #39502.

Release note: None