### PR TITLE
sql: use row count estimate only when stats are available

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vectorize_threshold
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_threshold
@@ -10,6 +10,26 @@ SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
 statement ok
 CREATE TABLE small (a INT PRIMARY KEY)
 
+# There are no stats available, so this should run through the row execution
+# engine.
+query T
+SELECT url FROM [EXPLAIN ANALYZE SELECT count(*) FROM small]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJyUkc1q6zAQhff3KcRZ3YJK7Cy16s8qm7gkKV0UUxRrMAbJMjMyTQh-92Ib2qbQNl3OmfmOPtAJbXS0toEE5hk5So2OY0UikcdoPli5A0ym0bRdn8a41KgiE8wJqUmeYLCze08bso54kUHDUbKNn2o7boLl440E6z00tp1txahraBR9MmodW4IGx1dRTNYZNRZIst6r1AQyKhNo7I-J3g_UHcpBI_bpQ0mSrQkmH_Tl2rd1zVTbFHmRn1vfF4_r3cumeNr-v7rALtiDChQiH1Uv9Ivi8i-KG5IutkJnet81Z0OpQa6m-fck9lzRA8dqemYei4mbAkeS5m0-D6t2Xo2Cn-H8R3j5BS6Hf28BAAD__xzlxHs=
+
+statement ok
+SET vectorize_row_count_threshold = 0
+
+# This should run through the vectorized execution engine because we disabled
+# the threshold.
+query T
+SELECT url FROM [EXPLAIN ANALYZE SELECT count(*) FROM small]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJyUkT1PwzAQhnd-RXQTSIbGHT2BmLo0qC1iQBFynVOw5NiW74JaVfnvKDEDLZSP8Z7L--Y5-QA-NLjUHRKoZ5BQC4gpGCQKaUT5g0WzA1UKsD72POJagAkJQR2ALTsEBRu9dbhC3WCalSCgQdbWTbUx2U6n_S112jkQsI7akyquQUDVsyqWwSMI2Go2r0hF6DmOeGzhProTROjQsH2zvFdFeVNOjLVzBdsOVVES1IOAHPmQJdYtgpKD-PtBd22bsNUc0kwe33NfPS43L6vqaX159Y23_Ootz3jjDk3PNvjf3ef_cV8hxeAJj7zPNZdDLQCbFvODU-iTwYcUzPSbPFZTbgINEuetzMPC59Uo-DksfwzPT8L1cPEeAAD__yeM11g=
+
+statement ok
+RESET vectorize_row_count_threshold
+
 statement ok
 ALTER TABLE small INJECT STATISTICS '[
   {

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -121,7 +121,8 @@ type scanNode struct {
 	isDeleteSource bool
 
 	// estimatedRowCount is the estimated number of rows that this scanNode will
-	// output.
+	// output. When there are no statistics to make the estimation, it will be
+	// set to zero.
 	estimatedRowCount uint64
 }
 


### PR DESCRIPTION
Previously, we would always use the estimated row count to determine
whether the vectorized row count threshold has been met. However,
when there are no stats, the estimate is meaningless, and, instead,
we should be on the "safe" side and fall back to the row execution
engine by default. This behavior can be overwritten by setting
the row count threshold to zero.

Release note: None