### PR TITLE
kv: don't update transaction proto directly from heartbeat loop

### DIFF
--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -42,8 +42,8 @@ const (
 	opTxnCoordSender = "txn coordinator send"
 )
 
-// txnState represents states relating to whether Begin/EndTxn requests need to
-// be sent.
+// txnState represents states relating to whether an EndTransaction request
+// needs to be sent.
 //go:generate stringer -type=txnState
 type txnState int
 
@@ -484,14 +484,13 @@ func (tcf *TxnCoordSenderFactory) TransactionalSender(
 	if typ == client.RootTxn {
 		tcs.interceptorAlloc.txnHeartbeater.init(
 			tcf.AmbientContext,
-			&tcs.mu.Mutex,
-			&tcs.mu.txn,
+			tcs.stopper,
 			tcs.clock,
+			&tcs.metrics,
 			tcs.heartbeatInterval,
 			&tcs.interceptorAlloc.txnLockGatekeeper,
-			&tcs.metrics,
-			tcs.stopper,
-			tcs.cleanupTxnLocked,
+			&tcs.mu.Mutex,
+			&tcs.mu.txn,
 		)
 		tcs.interceptorAlloc.txnCommitter = txnCommitter{
 			st:      tcf.st,
@@ -609,12 +608,17 @@ func (tc *TxnCoordSender) GetMeta(
 	for _, reqInt := range tc.interceptorStack {
 		reqInt.populateMetaLocked(&meta)
 	}
-	if opt == client.OnlyPending && meta.Txn.Status != roachpb.PENDING {
+	switch opt {
+	case client.AnyTxnStatus:
+		// Nothing to check.
+	case client.OnlyPending:
+		// Check the coordinator's proto status.
 		rejectErr := tc.maybeRejectClientLocked(ctx, nil /* ba */)
-		if rejectErr == nil {
-			log.Fatal(ctx, "expected non-nil rejectErr")
+		if rejectErr != nil {
+			return roachpb.TxnCoordMeta{}, rejectErr.GoError()
 		}
-		return roachpb.TxnCoordMeta{}, rejectErr.GoError()
+	default:
+		panic("unreachable")
 	}
 	return meta, nil
 }
@@ -863,9 +867,7 @@ func (tc *TxnCoordSender) maybeSleepForLinearizable(
 func (tc *TxnCoordSender) maybeRejectClientLocked(
 	ctx context.Context, ba *roachpb.BatchRequest,
 ) *roachpb.Error {
-	if singleRollback := ba != nil &&
-		ba.IsSingleEndTransactionRequest() &&
-		!ba.Requests[0].GetInner().(*roachpb.EndTransactionRequest).Commit; singleRollback {
+	if ba != nil && ba.IsSingleAbortTransactionRequest() {
 		// As a special case, we allow rollbacks to be sent at any time. Any
 		// rollback attempt moves the TxnCoordSender state to txnFinalized, but higher
 		// layers are free to retry rollbacks if they want (and they do, for
@@ -873,17 +875,33 @@ func (tc *TxnCoordSender) maybeRejectClientLocked(
 		return nil
 	}
 
-	if tc.mu.txnState == txnFinalized {
+	// Check the transaction coordinator state.
+	switch tc.mu.txnState {
+	case txnPending:
+		// All good.
+	case txnError:
+		return tc.mu.storedErr
+	case txnFinalized:
 		msg := fmt.Sprintf("client already committed or rolled back the transaction. "+
 			"Trying to execute: %s", ba)
 		stack := string(debug.Stack())
 		log.Errorf(ctx, "%s. stack:\n%s", msg, stack)
 		return roachpb.NewErrorWithTxn(roachpb.NewTransactionStatusError(msg), &tc.mu.txn)
 	}
-	if tc.mu.txnState == txnError {
-		return tc.mu.storedErr
-	}
-	if tc.mu.txn.Status == roachpb.ABORTED {
+
+	// Check the transaction proto state, along with any finalized transaction
+	// status observed by the transaction heartbeat loop.
+	protoStatus := tc.mu.txn.Status
+	hbObservedStatus := tc.interceptorAlloc.txnHeartbeater.mu.finalObservedStatus
+	switch {
+	case protoStatus == roachpb.ABORTED:
+		// The transaction was rolled back synchronously.
+		fallthrough
+	case protoStatus != roachpb.COMMITTED && hbObservedStatus == roachpb.ABORTED:
+		// The transaction heartbeat observed an aborted transaction record and
+		// this was not due to a synchronous transaction commit and transaction
+		// record garbage collection.
+		// See the comment on txnHeartbeater.mu.finalizedStatus for more details.
 		abortedErr := roachpb.NewErrorWithTxn(
 			roachpb.NewTransactionAbortedError(roachpb.ABORT_REASON_CLIENT_REJECT), &tc.mu.txn)
 		if tc.typ == client.LeafTxn {
@@ -891,16 +909,17 @@ func (tc *TxnCoordSender) maybeRejectClientLocked(
 			// root) rather than TransactionRetryWithProtoRefreshError.
 			return abortedErr
 		}
+		// Root txns handle retriable errors.
 		newTxn := roachpb.PrepareTransactionForRetry(
-			ctx, abortedErr,
-			// priority is not used for aborted errors
-			roachpb.NormalUserPriority,
-			tc.clock)
+			ctx, abortedErr, roachpb.NormalUserPriority, tc.clock)
 		return roachpb.NewError(roachpb.NewTransactionRetryWithProtoRefreshError(
 			abortedErr.Message, tc.mu.txn.ID, newTxn))
-	}
-	if tc.mu.txn.Status != roachpb.PENDING {
-		return roachpb.NewErrorf("(see issue #37866) unexpected txn state: %s", tc.mu.txn)
+	case protoStatus != roachpb.PENDING || hbObservedStatus != roachpb.PENDING:
+		// The transaction proto is in an unexpected state.
+		return roachpb.NewErrorf(
+			"unexpected txn state: %s; heartbeat observed status: %s", tc.mu.txn, hbObservedStatus)
+	default:
+		// All good.
 	}
 	return nil
 }
@@ -1004,6 +1023,7 @@ func (tc *TxnCoordSender) handleRetryableErrLocked(
 		// Abort the old txn. The client is not supposed to use use this
 		// TxnCoordSender any more.
 		tc.interceptorAlloc.txnHeartbeater.abortTxnAsyncLocked(ctx)
+		tc.cleanupTxnLocked(ctx)
 		return retErr
 	}
 
@@ -1238,4 +1258,11 @@ func (tc *TxnCoordSender) SerializeTxn() *roachpb.Transaction {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
 	return tc.mu.txn.Clone()
+}
+
+// IsTracking returns true if the heartbeat loop is running.
+func (tc *TxnCoordSender) IsTracking() bool {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	return tc.interceptorAlloc.txnHeartbeater.heartbeatLoopRunningLocked()
 }

--- a/pkg/kv/txn_coord_sender_server_test.go
+++ b/pkg/kv/txn_coord_sender_server_test.go
@@ -112,8 +112,8 @@ func TestHeartbeatFindsOutAboutAbortedTransaction(t *testing.T) {
 
 	// Now wait until the heartbeat loop notices that the transaction is aborted.
 	testutils.SucceedsSoon(t, func() error {
-		if txn.GetTxnCoordMeta(ctx).Txn.Status != roachpb.ABORTED {
-			return fmt.Errorf("txn not aborted yet")
+		if txn.Sender().(*kv.TxnCoordSender).IsTracking() {
+			return fmt.Errorf("txn heartbeat loop running")
 		}
 		return nil
 	})

--- a/pkg/kv/txn_interceptor_heartbeater.go
+++ b/pkg/kv/txn_interceptor_heartbeater.go
@@ -52,12 +52,14 @@ import (
 // coordinator is running on is alive then that transaction is still in-progress
 // unless it specifies otherwise. These are both approaches we could consider in
 // the future.
-//
-// TODO(nvanbenschoten): Unit test this file.
 type txnHeartbeater struct {
 	log.AmbientContext
+	stopper      *stop.Stopper
+	clock        *hlc.Clock
+	metrics      *TxnMetrics
+	loopInterval time.Duration
 
-	// wrapped is the next sender in the stack
+	// wrapped is the next sender in the interceptor stack.
 	wrapped lockedSender
 	// gatekeeper is the sender to which heartbeat requests need to be sent. It is
 	// set to the gatekeeper interceptor, so sending directly to it will bypass
@@ -67,37 +69,41 @@ type txnHeartbeater struct {
 	// sends got through `wrapped`, not directly through `gatekeeper`.
 	gatekeeper lockedSender
 
-	clock             *hlc.Clock
-	heartbeatInterval time.Duration
-	metrics           *TxnMetrics
-
-	// stopper is the TxnCoordSender's stopper. Used to stop the heartbeat loop
-	// when quiescing.
-	stopper *stop.Stopper
-
-	// asyncAbortCallbackLocked is called when the heartbeat loop shuts itself
-	// down because it has detected the transaction to be aborted. The intention
-	// is to notify the TxnCoordSender to shut itself down.
-	asyncAbortCallbackLocked func(context.Context)
-
 	// mu contains state protected by the TxnCoordSender's mutex.
 	mu struct {
 		sync.Locker
+
+		// txn is a reference to the TxnCoordSender's proto.
+		txn *roachpb.Transaction
 
 		// loopStarted indicates whether the heartbeat loop has been launched
 		// for the transaction or not. It remains true once the loop terminates.
 		loopStarted bool
 
-		// txnEnd is closed when the transaction is aborted or committed, terminating
-		// the heartbeat loop. Nil if the heartbeat loop is not running.
-		txnEnd chan struct{}
+		// loopCancel is a function to cancel the context of the heartbeat loop.
+		// Non-nil if the heartbeat loop is currently running.
+		loopCancel func()
 
-		// txn is a reference to the TxnCoordSender's proto.
-		txn *roachpb.Transaction
-
-		// finalErr, if set, will be returned by all subsequent SendLocked() calls,
-		// except rollbacks.
-		finalErr *roachpb.Error
+		// finalObservedStatus is the finalized status that the heartbeat loop
+		// observed while heartbeating the transaction's record. As soon as the
+		// heartbeat loop observes a finalized status, it shuts down.
+		//
+		// If the status here is COMMITTED then the transaction definitely
+		// committed. However, if the status here is ABORTED then the
+		// transaction may or may not have been aborted. Instead, it's possible
+		// that the transaction was committed by an EndTransaction request and
+		// then its record was garbage collected before the heartbeat request
+		// reached the record. The only way to distinguish this situation from
+		// a truly aborted transaction is to consider whether or not the
+		// transaction coordinator sent an EndTransaction request and, if so,
+		// consider whether it succeeded or not.
+		//
+		// Because of this ambiguity, the status is not used to immediately
+		// update txn in case the heartbeat loop raced with an EndTransaction
+		// request. Instead, it is used by the transaction coordinator to reject
+		// any future requests sent though it (which indicates that the
+		// heartbeat loop did not race with an EndTransaction request).
+		finalObservedStatus roachpb.TransactionStatus
 	}
 }
 
@@ -105,39 +111,28 @@ type txnHeartbeater struct {
 // constructor because txnHeartbeaters live in a pool in the TxnCoordSender.
 func (h *txnHeartbeater) init(
 	ac log.AmbientContext,
+	stopper *stop.Stopper,
+	clock *hlc.Clock,
+	metrics *TxnMetrics,
+	loopInterval time.Duration,
+	gatekeeper lockedSender,
 	mu sync.Locker,
 	txn *roachpb.Transaction,
-	clock *hlc.Clock,
-	heartbeatInterval time.Duration,
-	gatekeeper lockedSender,
-	metrics *TxnMetrics,
-	stopper *stop.Stopper,
-	asyncAbortCallbackLocked func(context.Context),
 ) {
 	h.AmbientContext = ac
 	h.stopper = stopper
 	h.clock = clock
-	h.heartbeatInterval = heartbeatInterval
 	h.metrics = metrics
+	h.loopInterval = loopInterval
+	h.gatekeeper = gatekeeper
 	h.mu.Locker = mu
 	h.mu.txn = txn
-	h.gatekeeper = gatekeeper
-	h.asyncAbortCallbackLocked = asyncAbortCallbackLocked
 }
 
-// SendLocked is part of the txnInteceptor interface.
+// SendLocked is part of the txnInterceptor interface.
 func (h *txnHeartbeater) SendLocked(
 	ctx context.Context, ba roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
-	// If finalErr is set, we reject everything but rollbacks.
-	if h.mu.finalErr != nil {
-		singleRollback := ba.IsSingleEndTransactionRequest() &&
-			!ba.Requests[0].GetInner().(*roachpb.EndTransactionRequest).Commit
-		if !singleRollback {
-			return nil, h.mu.finalErr
-		}
-	}
-
 	firstWriteIdx, pErr := firstWriteIndex(&ba)
 	if pErr != nil {
 		return nil, pErr
@@ -163,8 +158,7 @@ func (h *txnHeartbeater) SendLocked(
 		if !h.mu.loopStarted {
 			if _, haveEndTxn := ba.GetArg(roachpb.EndTransaction); !haveEndTxn {
 				if err := h.startHeartbeatLoopLocked(ctx); err != nil {
-					h.mu.finalErr = roachpb.NewError(err)
-					return nil, h.mu.finalErr
+					return nil, roachpb.NewError(err)
 				}
 			}
 		}
@@ -174,39 +168,32 @@ func (h *txnHeartbeater) SendLocked(
 	return h.wrapped.SendLocked(ctx, ba)
 }
 
-// setWrapped is part of the txnInteceptor interface.
+// setWrapped is part of the txnInterceptor interface.
 func (h *txnHeartbeater) setWrapped(wrapped lockedSender) {
 	h.wrapped = wrapped
 }
 
-// populateMetaLocked is part of the txnInteceptor interface.
+// populateMetaLocked is part of the txnInterceptor interface.
 func (h *txnHeartbeater) populateMetaLocked(*roachpb.TxnCoordMeta) {}
 
-// augmentMetaLocked is part of the txnInteceptor interface.
+// augmentMetaLocked is part of the txnInterceptor interface.
 func (h *txnHeartbeater) augmentMetaLocked(roachpb.TxnCoordMeta) {}
 
-// epochBumpedLocked is part of the txnInteceptor interface.
+// epochBumpedLocked is part of the txnInterceptor interface.
 func (h *txnHeartbeater) epochBumpedLocked() {}
 
-// closeLocked is part of the txnInteceptor interface.
+// closeLocked is part of the txnInterceptor interface.
 func (h *txnHeartbeater) closeLocked() {
-	// If the heartbeat loop has already finished, there's nothing more to do.
-	if h.mu.txnEnd == nil {
-		return
-	}
-	close(h.mu.txnEnd)
-	h.mu.txnEnd = nil
+	h.cancelHeartbeatLoopLocked()
 }
 
 // startHeartbeatLoopLocked starts a heartbeat loop in a different goroutine.
 func (h *txnHeartbeater) startHeartbeatLoopLocked(ctx context.Context) error {
-	if h.mu.loopStarted || h.mu.txnEnd != nil {
-		log.Fatal(ctx, "attempting to start a second heartbeat loop ")
+	if h.mu.loopStarted {
+		log.Fatal(ctx, "attempting to start a second heartbeat loop")
 	}
-
 	log.VEventf(ctx, 2, "coordinator spawns heartbeat loop")
 	h.mu.loopStarted = true
-	h.mu.txnEnd = make(chan struct{})
 	// NB: we can't do this in init() because the txn isn't populated yet then
 	// (it's zero).
 	h.AmbientContext.AddLogTag("txn-hb", h.mu.txn.Short())
@@ -218,71 +205,59 @@ func (h *txnHeartbeater) startHeartbeatLoopLocked(ctx context.Context) error {
 	// immediately.
 	hbCtx := h.AnnotateCtx(context.Background())
 	hbCtx = opentracing.ContextWithSpan(hbCtx, opentracing.SpanFromContext(ctx))
+	hbCtx, h.mu.loopCancel = context.WithCancel(hbCtx)
 
-	return h.stopper.RunAsyncTask(
-		hbCtx, "kv.TxnCoordSender: heartbeat loop", func(ctx context.Context) {
-			h.heartbeatLoop(ctx)
-		})
+	return h.stopper.RunAsyncTask(hbCtx, "kv.TxnCoordSender: heartbeat loop", h.heartbeatLoop)
+}
+
+func (h *txnHeartbeater) cancelHeartbeatLoopLocked() {
+	// If the heartbeat loop has already started, cancel it.
+	if h.heartbeatLoopRunningLocked() {
+		h.mu.loopCancel()
+		h.mu.loopCancel = nil
+	}
+}
+
+func (h *txnHeartbeater) heartbeatLoopRunningLocked() bool {
+	return h.mu.loopCancel != nil
 }
 
 // heartbeatLoop periodically sends a HeartbeatTxn request to the transaction
 // record, stopping in the event the transaction is aborted or committed after
 // attempting to resolve the intents.
 func (h *txnHeartbeater) heartbeatLoop(ctx context.Context) {
+	defer func() {
+		h.mu.Lock()
+		h.cancelHeartbeatLoopLocked()
+		h.mu.Unlock()
+	}()
+
 	var tickChan <-chan time.Time
 	{
-		ticker := time.NewTicker(h.heartbeatInterval)
+		ticker := time.NewTicker(h.loopInterval)
 		tickChan = ticker.C
 		defer ticker.Stop()
 	}
 
-	var finalErr *roachpb.Error
-	defer func() {
-		h.mu.Lock()
-		// Prevent future SendLocked() calls.
-		if finalErr != nil {
-			h.mu.finalErr = finalErr
-		}
-		if h.mu.txnEnd != nil {
-			h.mu.txnEnd = nil
-		}
-		h.mu.Unlock()
-	}()
-
-	var closer <-chan struct{}
-	{
-		h.mu.Lock()
-		closer = h.mu.txnEnd
-		h.mu.Unlock()
-		if closer == nil {
-			return
-		}
-	}
 	// Loop with ticker for periodic heartbeats.
 	for {
 		select {
 		case <-tickChan:
 			if !h.heartbeat(ctx) {
-				// This error we're generating here should not be seen by clients. Since
-				// the transaction is aborted, they should be rejected before they reach
-				// this interceptor.
-				finalErr = roachpb.NewErrorf("heartbeat failed fatally")
+				// The heartbeat noticed a finalized transaction,
+				// so shut down the heartbeat loop.
 				return
 			}
-		case <-closer:
+		case <-ctx.Done():
 			// Transaction finished normally.
-			finalErr = roachpb.NewErrorf("txnHeartbeater already closed")
 			return
 		case <-h.stopper.ShouldQuiesce():
-			finalErr = roachpb.NewErrorf("node already quiescing")
 			return
 		}
 	}
 }
 
 // heartbeat sends a HeartbeatTxnRequest to the txn record.
-// Errors that carry update txn information (e.g. TransactionAbortedError) will
-// update the txn. Other errors are swallowed.
 // Returns true if heartbeating should continue, false if the transaction is no
 // longer Pending and so there's no point in heartbeating further.
 func (h *txnHeartbeater) heartbeat(ctx context.Context) bool {
@@ -297,7 +272,7 @@ func (h *txnHeartbeater) heartbeat(ctx context.Context) bool {
 	// This h.heartbeat() call could have raced with a response that updated the
 	// status. That response is supposed to have closed the txnHeartbeater.
 	if h.mu.txn.Status != roachpb.PENDING {
-		if h.mu.txnEnd != nil {
+		if ctx.Err() == nil {
 			log.Fatalf(ctx,
 				"txn committed or aborted but heartbeat loop hasn't been signaled to stop. txn: %s",
 				h.mu.txn)
@@ -324,7 +299,8 @@ func (h *txnHeartbeater) heartbeat(ctx context.Context) bool {
 	log.VEvent(ctx, 2, "heartbeat")
 	br, pErr := h.gatekeeper.SendLocked(ctx, ba)
 
-	// If the txn is no longer pending, ignore the result of the heartbeat.
+	// If the txn is no longer pending, ignore the result of the heartbeat
+	// and tear down the heartbeat loop.
 	if h.mu.txn.Status != roachpb.PENDING {
 		return false
 	}
@@ -339,62 +315,53 @@ func (h *txnHeartbeater) heartbeat(ctx context.Context) bool {
 		// TODO(nvanbenschoten): Make this the only case where we get back an
 		// Aborted txn.
 		if _, ok := pErr.GetDetail().(*roachpb.TransactionAbortedError); ok {
-			h.mu.txn.Status = roachpb.ABORTED
-			log.VEventf(ctx, 1, "Heartbeat detected aborted txn. Cleaning up.")
+			// Note that it's possible that the txn actually committed but its
+			// record got GC'ed. In that case, aborting won't hurt anyone though,
+			// since all intents have already been resolved.
+			// The only thing we must ascertain is that we don't tell the client
+			// about this error - it will get either a definitive result of
+			// its commit or an ambiguous one and we have nothing to offer that
+			// provides more clarity. We do however prevent it from running more
+			// requests in case it isn't aware that the transaction is over.
 			h.abortTxnAsyncLocked(ctx)
+			h.mu.finalObservedStatus = roachpb.ABORTED
 			return false
 		}
 
 		respTxn = pErr.GetTxn()
 	} else {
-		respTxn = br.Responses[0].GetInner().(*roachpb.HeartbeatTxnResponse).Txn
+		respTxn = br.Txn
 	}
 
-	// Update our txn. In particular, we need to make sure that the client will
-	// notice when the txn has been aborted (in which case we'll give them an
-	// error on their next request).
-	//
-	// TODO(nvanbenschoten): It's possible for a HeartbeatTxn request to observe
-	// the result of an EndTransaction request and beat it back to the client.
-	// This is an issue when a COMMITTED txn record is GCed and later re-written
-	// as ABORTED. The coordinator's local status could flip from PENDING to
-	// ABORTED (after heartbeat response) to COMMITTED (after commit response).
-	// This appears to be benign, but it's still somewhat disconcerting. If this
-	// ever causes any issues, we'll need to be smarter about detecting this race
-	// on the client and conditionally ignoring the result of heartbeat responses.
-	if respTxn != nil {
-		if respTxn.Status == roachpb.STAGING {
-			// Consider STAGING transactions to be PENDING for the purpose of
-			// the heartbeat loop. Interceptors above the txnCommitter should
-			// be oblivious to parallel commits.
-			respTxn.Status = roachpb.PENDING
+	// Tear down the heartbeat loop if the response transaction is finalized.
+	if respTxn != nil && respTxn.Status.IsFinalized() {
+		switch respTxn.Status {
+		case roachpb.COMMITTED:
+			// Shut down the heartbeat loop without doing anything else.
+			// We must have raced with an EndTransaction(commit=true).
+		case roachpb.ABORTED:
+			// Roll back the transaction record to clean up intents and
+			// then shut down the heartbeat loop.
+			h.abortTxnAsyncLocked(ctx)
 		}
-		h.mu.txn.Update(respTxn)
-		if h.mu.txn.Status != roachpb.PENDING {
-			if h.mu.txn.Status == roachpb.ABORTED {
-				log.VEventf(ctx, 1, "Heartbeat detected aborted txn. Cleaning up.")
-				h.abortTxnAsyncLocked(ctx)
-			}
-			return false
-		}
+		h.mu.finalObservedStatus = respTxn.Status
+		return false
 	}
 	return true
 }
 
 // abortTxnAsyncLocked send an EndTransaction(commmit=false) asynchronously.
-// The asyncAbortCallbackLocked callback is also called.
+// The purpose of the async cleanup is to resolve transaction intents as soon
+// as possible when a transaction coordinator observes an ABORTED transaction.
 func (h *txnHeartbeater) abortTxnAsyncLocked(ctx context.Context) {
-	if h.mu.txn.Status != roachpb.ABORTED {
-		log.Fatalf(ctx, "abortTxnAsyncLocked called for non-aborted txn: %s", h.mu.txn)
-	}
-	h.asyncAbortCallbackLocked(ctx)
-	txn := h.mu.txn.Clone()
+	log.VEventf(ctx, 1, "Heartbeat detected aborted txn. Cleaning up.")
 
 	// NB: We use context.Background() here because we don't want a canceled
 	// context to interrupt the aborting.
 	ctx = h.AnnotateCtx(context.Background())
 
 	// Construct a batch with an EndTransaction request.
+	txn := h.mu.txn.Clone()
 	ba := roachpb.BatchRequest{}
 	ba.Header = roachpb.Header{Txn: txn}
 	ba.Add(&roachpb.EndTransactionRequest{

--- a/pkg/kv/txn_interceptor_heartbeater_test.go
+++ b/pkg/kv/txn_interceptor_heartbeater_test.go
@@ -1,0 +1,369 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kv
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func makeMockTxnHeartbeater(
+	txn *roachpb.Transaction,
+) (th txnHeartbeater, mockSender, mockGatekeeper *mockLockedSender) {
+	mockSender, mockGatekeeper = &mockLockedSender{}, &mockLockedSender{}
+	manual := hlc.NewManualClock(123)
+	th.init(
+		log.AmbientContext{Tracer: tracing.NewTracer()},
+		stop.NewStopper(),
+		hlc.NewClock(manual.UnixNano, time.Nanosecond),
+		new(TxnMetrics),
+		1*time.Millisecond,
+		mockGatekeeper,
+		new(syncutil.Mutex),
+		txn,
+	)
+	th.setWrapped(mockSender)
+	return th, mockSender, mockGatekeeper
+}
+
+func waitForHeartbeatLoopToStop(t *testing.T, th *txnHeartbeater) {
+	t.Helper()
+	testutils.SucceedsSoon(t, func() error {
+		th.mu.Lock()
+		defer th.mu.Unlock()
+		if th.heartbeatLoopRunningLocked() {
+			return errors.New("txn heartbeat loop running")
+		}
+		return nil
+	})
+}
+
+// TestTxnHeartbeaterSetsTransactionKey tests that the txnHeartbeater sets the
+// transaction key to the key of the first write that is sent through it.
+func TestTxnHeartbeaterSetsTransactionKey(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	txn := makeTxnProto()
+	txn.Key = nil // reset
+	th, mockSender, _ := makeMockTxnHeartbeater(&txn)
+	defer th.stopper.Stop(ctx)
+
+	// No key is set on a read-only batch.
+	keyA, keyB := roachpb.Key("a"), roachpb.Key("b")
+	var ba roachpb.BatchRequest
+	ba.Header = roachpb.Header{Txn: txn.Clone()}
+	ba.Add(&roachpb.GetRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+	ba.Add(&roachpb.GetRequest{RequestHeader: roachpb.RequestHeader{Key: keyB}})
+
+	mockSender.MockSend(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+		require.Len(t, ba.Requests, 2)
+		require.Equal(t, keyA, ba.Requests[0].GetInner().Header().Key)
+		require.Equal(t, keyB, ba.Requests[1].GetInner().Header().Key)
+
+		require.Equal(t, txn.ID, ba.Txn.ID)
+		require.Nil(t, ba.Txn.Key)
+
+		br := ba.CreateReply()
+		br.Txn = ba.Txn
+		return br, nil
+	})
+
+	br, pErr := th.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+	require.Nil(t, txn.Key)
+
+	// The key of the first write is set as the transaction key.
+	ba.Requests = nil
+	ba.Add(&roachpb.PutRequest{RequestHeader: roachpb.RequestHeader{Key: keyB}})
+	ba.Add(&roachpb.PutRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+
+	mockSender.MockSend(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+		require.Len(t, ba.Requests, 2)
+		require.Equal(t, keyB, ba.Requests[0].GetInner().Header().Key)
+		require.Equal(t, keyA, ba.Requests[1].GetInner().Header().Key)
+
+		require.Equal(t, txn.ID, ba.Txn.ID)
+		require.Equal(t, keyB, roachpb.Key(ba.Txn.Key))
+
+		br = ba.CreateReply()
+		br.Txn = ba.Txn
+		return br, nil
+	})
+
+	br, pErr = th.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+	require.Equal(t, keyB, roachpb.Key(txn.Key))
+
+	// The transaction key is not changed on subsequent batches.
+	ba.Requests = nil
+	ba.Add(&roachpb.PutRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+
+	mockSender.MockSend(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+		require.Len(t, ba.Requests, 1)
+		require.Equal(t, keyA, ba.Requests[0].GetInner().Header().Key)
+
+		require.Equal(t, txn.ID, ba.Txn.ID)
+		require.Equal(t, keyB, roachpb.Key(ba.Txn.Key))
+
+		br = ba.CreateReply()
+		br.Txn = ba.Txn
+		return br, nil
+	})
+
+	br, pErr = th.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+	require.Equal(t, keyB, roachpb.Key(txn.Key))
+}
+
+// TestTxnHeartbeaterLoopStartedOnFirstWrite tests that the txnHeartbeater
+// doesn't start its heartbeat loop until it observes the transaction perform
+// a write.
+func TestTxnHeartbeaterLoopStartedOnFirstWrite(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	txn := makeTxnProto()
+	th, _, _ := makeMockTxnHeartbeater(&txn)
+	defer th.stopper.Stop(ctx)
+
+	// Read-only requests don't start the heartbeat loop.
+	keyA := roachpb.Key("a")
+	var ba roachpb.BatchRequest
+	ba.Header = roachpb.Header{Txn: txn.Clone()}
+	ba.Add(&roachpb.GetRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+
+	br, pErr := th.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+
+	th.mu.Lock()
+	require.False(t, th.mu.loopStarted)
+	require.False(t, th.heartbeatLoopRunningLocked())
+	th.mu.Unlock()
+
+	// The heartbeat loop is started on the first writing request.
+	ba.Requests = nil
+	ba.Add(&roachpb.PutRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+
+	br, pErr = th.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+
+	th.mu.Lock()
+	require.True(t, th.mu.loopStarted)
+	require.True(t, th.heartbeatLoopRunningLocked())
+	th.mu.Unlock()
+
+	// Closing the interceptor stops the heartbeat loop.
+	th.mu.Lock()
+	th.closeLocked()
+	th.mu.Unlock()
+	waitForHeartbeatLoopToStop(t, &th)
+	require.True(t, th.mu.loopStarted) // still set
+}
+
+// TestTxnHeartbeaterLoopNotStartedFor1PC tests that the txnHeartbeater does
+// not start a heartbeat loop if it detects a 1PC transaction.
+func TestTxnHeartbeaterLoopNotStartedFor1PC(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	txn := makeTxnProto()
+	th, _, _ := makeMockTxnHeartbeater(&txn)
+	defer th.stopper.Stop(ctx)
+
+	keyA := roachpb.Key("a")
+	var ba roachpb.BatchRequest
+	ba.Header = roachpb.Header{Txn: txn.Clone()}
+	ba.Add(&roachpb.PutRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+	ba.Add(&roachpb.EndTransactionRequest{Commit: true})
+
+	br, pErr := th.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+
+	th.mu.Lock()
+	require.False(t, th.mu.loopStarted)
+	require.False(t, th.heartbeatLoopRunningLocked())
+	th.mu.Unlock()
+}
+
+// TestTxnHeartbeaterLoopRequests tests that the HeartbeatTxnRequests that the
+// txnHeartbeater sends contain the correct information. It then tests that the
+// heartbeat loop shuts itself down if it detects a committed transaction. This
+// can occur through two different paths. A heartbeat request itself can find
+// a committed transaction record or the request can race with a request sent
+// from the transaction coordinator that finalizes the transaction.
+func TestTxnHeartbeaterLoopRequests(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testutils.RunTrueAndFalse(t, "heartbeatObserved", func(t *testing.T, heartbeatObserved bool) {
+		ctx := context.Background()
+		txn := makeTxnProto()
+		th, _, mockGatekeeper := makeMockTxnHeartbeater(&txn)
+		defer th.stopper.Stop(ctx)
+
+		var count int
+		var lastTime hlc.Timestamp
+		mockGatekeeper.MockSend(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			require.Len(t, ba.Requests, 1)
+			require.IsType(t, &roachpb.HeartbeatTxnRequest{}, ba.Requests[0].GetInner())
+
+			hbReq := ba.Requests[0].GetInner().(*roachpb.HeartbeatTxnRequest)
+			require.Equal(t, &txn, ba.Txn)
+			require.Equal(t, roachpb.Key(txn.Key), hbReq.Key)
+			require.True(t, lastTime.Less(hbReq.Now))
+
+			count++
+			lastTime = hbReq.Now
+
+			br := ba.CreateReply()
+			br.Txn = ba.Txn
+			return br, nil
+		})
+
+		// Kick off the heartbeat loop.
+		keyA := roachpb.Key("a")
+		var ba roachpb.BatchRequest
+		ba.Header = roachpb.Header{Txn: txn.Clone()}
+		ba.Add(&roachpb.PutRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+
+		br, pErr := th.SendLocked(ctx, ba)
+		require.Nil(t, pErr)
+		require.NotNil(t, br)
+
+		// Wait for 5 heartbeat requests.
+		testutils.SucceedsSoon(t, func() error {
+			th.mu.Lock()
+			defer th.mu.Unlock()
+			require.True(t, th.mu.loopStarted)
+			require.True(t, th.heartbeatLoopRunningLocked())
+			if count < 5 {
+				return errors.Errorf("waiting for more heartbeat requests, found %d", count)
+			}
+			return nil
+		})
+
+		// Mark the coordinator's transaction record as COMMITTED while a heartbeat
+		// is in-flight. This should cause the heartbeat loop to shut down.
+		th.mu.Lock()
+		mockGatekeeper.MockSend(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			require.Len(t, ba.Requests, 1)
+			require.IsType(t, &roachpb.HeartbeatTxnRequest{}, ba.Requests[0].GetInner())
+
+			br := ba.CreateReply()
+			br.Txn = ba.Txn
+			if heartbeatObserved {
+				// Mimic a Heartbeat request that observed a committed record.
+				br.Txn.Status = roachpb.COMMITTED
+			} else {
+				// Mimic an EndTransaction that raced with the heartbeat loop.
+				txn.Status = roachpb.COMMITTED
+			}
+			return br, nil
+		})
+		th.mu.Unlock()
+		waitForHeartbeatLoopToStop(t, &th)
+
+		// Depending on how the committed transaction was observed, we may or
+		// may not expect the heartbeater's final observed status to be set.
+		if heartbeatObserved {
+			require.Equal(t, roachpb.COMMITTED, th.mu.finalObservedStatus)
+		} else {
+			require.Equal(t, roachpb.PENDING, th.mu.finalObservedStatus)
+		}
+	})
+}
+
+// TestTxnHeartbeaterAsyncAbort tests that the txnHeartbeater rolls back the
+// transaction asynchronously if it detects an aborted transaction, either
+// through a TransactionAbortedError or through an ABORTED transaction proto
+// in the HeartbeatTxn response.
+func TestTxnHeartbeaterAsyncAbort(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testutils.RunTrueAndFalse(t, "abortedErr", func(t *testing.T, abortedErr bool) {
+		ctx := context.Background()
+		txn := makeTxnProto()
+		th, mockSender, mockGatekeeper := makeMockTxnHeartbeater(&txn)
+		defer th.stopper.Stop(ctx)
+
+		putDone, asyncAbortDone := make(chan struct{}), make(chan struct{})
+		mockGatekeeper.MockSend(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			// Wait for the Put to finish to avoid a data race.
+			<-putDone
+
+			require.Len(t, ba.Requests, 1)
+			require.IsType(t, &roachpb.HeartbeatTxnRequest{}, ba.Requests[0].GetInner())
+
+			if abortedErr {
+				return nil, roachpb.NewErrorWithTxn(
+					roachpb.NewTransactionAbortedError(roachpb.ABORT_REASON_UNKNOWN), ba.Txn,
+				)
+			}
+			br := ba.CreateReply()
+			br.Txn = ba.Txn
+			br.Txn.Status = roachpb.ABORTED
+			return br, nil
+		})
+
+		// Kick off the heartbeat loop.
+		keyA := roachpb.Key("a")
+		var ba roachpb.BatchRequest
+		ba.Header = roachpb.Header{Txn: txn.Clone()}
+		ba.Add(&roachpb.PutRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+
+		br, pErr := th.SendLocked(ctx, ba)
+		require.Nil(t, pErr)
+		require.NotNil(t, br)
+
+		// Test that the transaction is rolled back.
+		mockSender.MockSend(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			defer close(asyncAbortDone)
+			require.Len(t, ba.Requests, 1)
+			require.IsType(t, &roachpb.EndTransactionRequest{}, ba.Requests[0].GetInner())
+
+			etReq := ba.Requests[0].GetInner().(*roachpb.EndTransactionRequest)
+			require.Equal(t, &txn, ba.Txn)
+			require.Nil(t, etReq.Key) // set in txnCommitter
+			require.False(t, etReq.Commit)
+			require.True(t, etReq.Poison)
+
+			br = ba.CreateReply()
+			br.Txn = ba.Txn
+			br.Txn.Status = roachpb.ABORTED
+			return br, nil
+		})
+		close(putDone)
+
+		// The heartbeat loop should eventually close.
+		waitForHeartbeatLoopToStop(t, &th)
+
+		// Wait for the async abort to finish.
+		<-asyncAbortDone
+
+		// Regardless of which channel informed the heartbeater of the
+		// transaction's aborted status, we expect the heartbeater's final
+		// observed status to be set.
+		require.Equal(t, roachpb.ABORTED, th.mu.finalObservedStatus)
+	})
+}

--- a/pkg/kv/txn_interceptor_metric_recorder.go
+++ b/pkg/kv/txn_interceptor_metric_recorder.go
@@ -46,7 +46,7 @@ func (m *txnMetricRecorder) SendLocked(
 	}
 
 	br, pErr := m.wrapped.SendLocked(ctx, ba)
-	if pErr == nil && br.Txn != nil {
+	if pErr == nil {
 		m.parallelCommit = br.Txn.Status == roachpb.STAGING
 	}
 	return br, pErr

--- a/pkg/kv/txn_interceptor_pipeliner.go
+++ b/pkg/kv/txn_interceptor_pipeliner.go
@@ -468,7 +468,7 @@ func (tp *txnPipeliner) updateWriteTracking(
 	// If the transaction is no longer pending, clear the in-flight writes set
 	// and immediately return.
 	// TODO(nvanbenschoten): Do we have to handle missing Txn's anymore?
-	if br.Txn != nil && br.Txn.Status != roachpb.PENDING {
+	if br.Txn.Status != roachpb.PENDING {
 		tp.ifWrites.clear(false /* reuse */)
 		return
 	}

--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -194,6 +194,17 @@ func (ba *BatchRequest) IsSingleEndTransactionRequest() bool {
 	return false
 }
 
+// IsSingleAbortTransactionRequest returns true iff the batch contains a single
+// request, and that request is an EndTransactionRequest(commit=false).
+func (ba *BatchRequest) IsSingleAbortTransactionRequest() bool {
+	if ba.IsSingleRequest() {
+		if et, ok := ba.Requests[0].GetInner().(*EndTransactionRequest); ok {
+			return !et.Commit
+		}
+	}
+	return false
+}
+
 // IsSingleSubsumeRequest returns true iff the batch contains a single request,
 // and that request is an SubsumeRequest.
 func (ba *BatchRequest) IsSingleSubsumeRequest() bool {

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -122,8 +122,8 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 
 			// Now wait until the heartbeat loop notices that the transaction is aborted.
 			testutils.SucceedsSoon(t, func() error {
-				if txn.GetTxnCoordMeta(ctx).Txn.Status != roachpb.ABORTED {
-					return fmt.Errorf("txn not aborted yet")
+				if txn.Sender().(*kv.TxnCoordSender).IsTracking() {
+					return fmt.Errorf("txn heartbeat loop running")
 				}
 				return nil
 			})

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -1059,8 +1059,6 @@ func TestFailedSnapshotFillsReservation(t *testing.T) {
 func TestConcurrentRaftSnapshots(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/39652")
-
 	mtc := &multiTestContext{
 		// This test was written before the multiTestContext started creating many
 		// system ranges at startup, and hasn't been update to take that into


### PR DESCRIPTION
Fixes #39652.
Fixes #39661.
Fixes #35144.

This commit fixes the referenced issues by eliminating the practice of updating
the transaction coordinator's proto directly from its heartbeat loop. This was
problematic because of the race described in
https://github.com/cockroachdb/cockroach/blob/dc3686f79b3750500efaff7092c81a3e5ce6d02c/pkg/kv/txn_interceptor_heartbeater.go#L357-L364

The heartbeat loop doesn't know if it's racing with an EndTransaction request
and it could incorrectly interpret a missing transaction record if it is. The
safest thing to do is to limit the path in which it informs the TxnCoordSender
of updates.

This limits the responsibility of the heartbeat loop. Its job is now
only to:
1. update the transaction record to maintain liveness
2. eagerly clean up a transaction if it is found to be aborted
3. inform the transaction coordinator about an aborted transaction
   record IF the transaction coordinator is continuing to send requests
   through the interceptor.

Notably, the heartbeat loop no longer blindly updates the transaction
coordinator's transaction proto. There wasn't a strong reason for it to be able
to do so, especially now that we no longer push transactions or ratchet their
priority frequently. Moreover, even if those were still frequent occurrences,
updating the proto from the heartbeat loop prevented usual restart handling from
being used. For instance, doing so might prevent us from refreshing the
transaction. All in all, allowing this didn't seem worth the complexity.

This commit also includes some cleanup. For instance, it removes a confusing
dependency where the txnHeartbeater called back into the TxnCoordSender. It also
addresses a longstanding TODO to actually unit test the txnHeartbeater.