### PR TITLE
cmd/fuzz: add new fuzz command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ artifacts
 /certs
 # make stress, acceptance produce stress.test, acceptance.test
 *.test*
+# fuzz tests
+work-Fuzz*
+*-fuzz.zip
 
 # Custom or private env vars (e.g. internal keys, access tokens, etc).
 customenv.mk

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2076,6 +2076,7 @@
     "golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow",
     "golang.org/x/tools/go/ast/inspector",
     "golang.org/x/tools/go/buildutil",
+    "golang.org/x/tools/go/packages",
     "google.golang.org/api/iterator",
     "google.golang.org/api/option",
     "google.golang.org/grpc",

--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,9 @@ help: ## Print help for targets with comments.
 		"make testlogic FILES='prepare fk'" "Run the logic tests in the files named prepare and fk." \
 		"make testlogic FILES=fk SUBTESTS='20042|20045'" "Run the logic tests within subtests 20042 and 20045 in the file named fk." \
 		"make testlogic TESTCONFIG=local" "Run the logic tests for the cluster configuration 'local'." \
+		"make fuzz" "Run all fuzz tests for 12m each (or whatever the default TESTTIMEOUT is)." \
+		"make fuzz PKG=./pkg/sql/... TESTTIMEOUT=1m" "Run all fuzz tests under the sql directory for 1m each." \
+		"make fuzz PKG=./pkg/sql/sem/tree TESTS=Decimal TESTTIMEOUT=1m" "Run the Decimal fuzz tests in the tree directory for 1m." \
 		"make check-libroach TESTS=ccl" "Run the libroach tests matching .*ccl.*"
 
 BUILDTYPE := development
@@ -1561,6 +1564,7 @@ bins = \
   bin/cockroach-short \
   bin/docgen \
   bin/execgen \
+  bin/fuzz \
   bin/generate-binary \
   bin/terraformgen \
   bin/github-post \
@@ -1620,6 +1624,11 @@ $(testbins): bin/%: bin/%.d | bin/prereqs $(SUBMODULES_TARGET)
 bin/prereqs: ./pkg/cmd/prereqs/*.go
 	@echo go install -v ./pkg/cmd/prereqs
 	@$(GO_INSTALL) -v ./pkg/cmd/prereqs
+
+.PHONY: fuzz
+fuzz: ## Run fuzz tests.
+fuzz: bin/fuzz
+	bin/fuzz $(TESTFLAGS) -tests $(TESTS) -timeout $(TESTTIMEOUT) $(PKG)
 
 .PRECIOUS: bin/%.d
 bin/%.d: ;

--- a/pkg/cmd/fuzz/main.go
+++ b/pkg/cmd/fuzz/main.go
@@ -1,0 +1,210 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// fuzz builds and executes fuzz tests.
+//
+// Fuzz tests can be added to CockroachDB by adding a function of the form:
+//   func FuzzXXX(data []byte) int
+// To help the fuzzer increase coverage, this function should return 1 on
+// interesting input (for example, a parse succeeded) and 0 otherwise. Panics
+// will be detected and reported.
+//
+// To exclude this file except during fuzzing, tag it with:
+//   // +build gofuzz
+package main
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"time"
+
+	"golang.org/x/tools/go/packages"
+)
+
+var (
+	flags   = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	tests   = flags.String("tests", "", "regex filter for tests to run")
+	timeout = flags.Duration("timeout", 1*time.Minute, "time to run each Fuzz func")
+	verbose = flags.Bool("v", false, "verbose output")
+)
+
+func usage() {
+	fmt.Fprintf(flags.Output(), "Usage of %s:\n", os.Args[0])
+	flags.PrintDefaults()
+	os.Exit(1)
+}
+
+func main() {
+	// go-fuzz-build doesn't seem to support the vendor directory. It
+	// appears to require the go-fuzz-dep be in the canonical
+	// location. Hence we can't vendor go-fuzz and go-fuzz-build, we
+	// require the user install them to their global GOPATH.
+	for _, file := range []string{"go-fuzz", "go-fuzz-build"} {
+		if _, err := exec.LookPath(file); err != nil {
+			fmt.Println(file, "must be in your PATH")
+			fmt.Println("Run `go get -u github.com/dvyukov/go-fuzz/...` to install.")
+			os.Exit(1)
+		}
+	}
+	if err := flags.Parse(os.Args[1:]); err != nil {
+		usage()
+	}
+	patterns := flags.Args()
+	if len(patterns) == 0 {
+		fmt.Print("missing packages\n\n")
+		usage()
+	}
+	crashers, err := fuzz(patterns, *tests, *timeout)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	if crashers > 0 {
+		fmt.Println(crashers, "crashers")
+		os.Exit(2)
+	}
+}
+
+func fatal(arg interface{}) {
+	panic(arg)
+}
+
+func log(format string, args ...interface{}) {
+	if !*verbose {
+		return
+	}
+	fmt.Fprintf(os.Stderr, format, args...)
+}
+
+func fuzz(patterns []string, tests string, timeout time.Duration) (int, error) {
+	ctx := context.Background()
+	pkgs, err := packages.Load(&packages.Config{
+		Mode:       packages.NeedFiles,
+		BuildFlags: []string{"-tags", "gofuzz"},
+	}, patterns...)
+	if err != nil {
+		return 0, err
+	}
+	var testsRE *regexp.Regexp
+	if tests != "" {
+		testsRE, err = regexp.Compile(tests)
+		if err != nil {
+			return 0, err
+		}
+	}
+	crashers := 0
+	for _, pkg := range pkgs {
+		if len(pkg.Errors) > 0 {
+			return 0, pkg.Errors[0]
+		}
+		log("%s: searching for Fuzz funcs\n", pkg)
+		fns, err := findFuncs(pkg)
+		if err != nil {
+			return 0, err
+		}
+		if len(fns) == 0 {
+			continue
+		}
+		dir := filepath.Dir(pkg.GoFiles[0])
+		{
+			log("%s: executing go-fuzz-build...", pkg)
+			cmd := exec.Command("go-fuzz-build")
+			cmd.Dir = dir
+			out, err := cmd.CombinedOutput()
+			log(" done\n")
+			if err != nil {
+				log("%s\n", out)
+				return 0, err
+			}
+		}
+		for _, fn := range fns {
+			if testsRE != nil && !testsRE.MatchString(fn) {
+				continue
+			}
+			crashers += execGoFuzz(ctx, pkg, dir, fn, timeout)
+		}
+	}
+	return crashers, nil
+}
+
+var goFuzzRE = regexp.MustCompile(`crashers: (\d+)`)
+
+// execGoFuzz executes go-fuzz and returns the number of crashers found.
+func execGoFuzz(
+	ctx context.Context, pkg *packages.Package, dir, fn string, timeout time.Duration,
+) int {
+	log("\n%s: fuzzing %s for %v\n", pkg, fn, timeout)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	workdir := fmt.Sprintf("work-%s", fn)
+	cmd := exec.CommandContext(ctx, "go-fuzz", "-func", fn, "-workdir", workdir)
+	cmd.Dir = dir
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		fatal(err)
+	}
+	crashers := 0
+	scanner := bufio.NewScanner(stderr)
+	for scanner.Scan() {
+		line := scanner.Text()
+		log("%s\n", line)
+		matches := goFuzzRE.FindStringSubmatch(line)
+		if len(matches) == 0 {
+			continue
+		}
+		i, err := strconv.Atoi(matches[1])
+		if err != nil {
+			fatal(err)
+		}
+		if i > crashers {
+			if crashers == 0 {
+				fmt.Printf("workdir: %s\n", filepath.Join(dir, workdir))
+			}
+			crashers = i
+			fmt.Printf("crashers: %d\n", crashers)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		fatal(err)
+	}
+	if err := cmd.Wait(); err != nil {
+		fatal(err)
+	}
+	return crashers
+}
+
+var fuzzFuncRE = regexp.MustCompile(`(?m)^func (Fuzz\w*)\(\w+ \[\]byte\) int {$`)
+
+// findFuncs returns a list of fuzzable function names in the given package.
+func findFuncs(pkg *packages.Package) ([]string, error) {
+	var ret []string
+	for _, file := range pkg.GoFiles {
+		content, err := ioutil.ReadFile(file)
+		if err != nil {
+			return nil, err
+		}
+		matches := fuzzFuncRE.FindAllSubmatch(content, -1)
+		for _, match := range matches {
+			ret = append(ret, string(match[1]))
+		}
+	}
+	return ret, nil
+}

--- a/pkg/sql/parser/fuzz/empty.go
+++ b/pkg/sql/parser/fuzz/empty.go
@@ -1,0 +1,11 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package fuzz

--- a/pkg/sql/parser/fuzz/fuzz.go
+++ b/pkg/sql/parser/fuzz/fuzz.go
@@ -1,0 +1,32 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// +build gofuzz
+
+// The parser fuzzer needs to live in its own package because it must import
+// the builtins package so functions that are hard coded in sql.y (like
+// "current_user") can be resolved. However importing that in parser creates a
+// cyclic dependency.
+
+package fuzz
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	// See above comment about why this is imported.
+	_ "github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
+)
+
+func FuzzParse(data []byte) int {
+	_, err := parser.Parse(string(data))
+	if err != nil {
+		return 0
+	}
+	return 1
+}

--- a/pkg/sql/pgwire/pgwirebase/fuzz.go
+++ b/pkg/sql/pgwire/pgwirebase/fuzz.go
@@ -1,0 +1,49 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// +build gofuzz
+
+package pgwirebase
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/lib/pq/oid"
+)
+
+var (
+	timeCtx = tree.NewParseTimeContext(duration.AdditionModeCompatible, timeutil.Now())
+	// Compile a slice of all oids.
+	oids = func() []oid.Oid {
+		var ret []oid.Oid
+		for oid := range types.OidToType {
+			ret = append(ret, oid)
+		}
+		return ret
+	}()
+)
+
+func FuzzDecodeOidDatum(data []byte) int {
+	if len(data) < 2 {
+		return 0
+	}
+
+	id := oids[int(data[1])%len(oids)]
+	code := FormatCode(data[0]) % (FormatBinary + 1)
+	b := data[2:]
+
+	_, err := DecodeOidDatum(timeCtx, id, code, b)
+	if err != nil {
+		return 0
+	}
+	return 1
+}

--- a/pkg/sql/sem/tree/fuzz.go
+++ b/pkg/sql/sem/tree/fuzz.go
@@ -1,0 +1,38 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// +build gofuzz
+
+package tree
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+var (
+	timeCtx = NewParseTimeContext(duration.AdditionModeCompatible, timeutil.Now())
+)
+
+func FuzzParseDDecimal(data []byte) int {
+	_, err := ParseDDecimal(string(data))
+	if err != nil {
+		return 0
+	}
+	return 1
+}
+
+func FuzzParseDDate(data []byte) int {
+	_, err := ParseDDate(timeCtx, string(data))
+	if err != nil {
+		return 0
+	}
+	return 1
+}

--- a/pkg/util/json/fuzz.go
+++ b/pkg/util/json/fuzz.go
@@ -1,0 +1,21 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// +build gofuzz
+
+package json
+
+func FuzzParseJSON(data []byte) int {
+	_, err := ParseJSON(string(data))
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
fuzz is a CLI program that takes a packages spec (like ./pkg/...),
searches for fuzz functions in it, builds and runs them, and reports
the results.

Various fuzzers have been added.

A `make fuzz` rule has been added to facilite fuzz testing. It supports
the optional PKG, TESTS, and TESTTIMEOUT variables. TESTTIMEOUT specifies
how long to run each fuzz func for. For example:

`make fuzz PKG=./pkg/sql/... TESTS=Decimal TESTTIMEOUT=1m`

Release note: None