### PR TITLE
roachtest: don't panic when writing to a closed logger, various logger fixes

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2081,10 +2081,12 @@ func (m *monitor) Go(fn func(context.Context) error) {
 	})
 }
 
+var errTestAlreadyFailed = errors.New("already failed")
+
 func (m *monitor) WaitE() error {
 	if m.t.Failed() {
 		// If the test has failed, don't try to limp along.
-		return errors.New("already failed")
+		return errTestAlreadyFailed
 	}
 
 	return m.wait(roachprod, "monitor", m.nodes)
@@ -2095,7 +2097,7 @@ func (m *monitor) Wait() {
 		// If the test has failed, don't try to limp along.
 		return
 	}
-	if err := m.WaitE(); err != nil {
+	if err := m.WaitE(); err != nil && err != errTestAlreadyFailed && !m.t.Failed() {
 		m.t.Fatal(err)
 	}
 }

--- a/pkg/cmd/roachtest/log.go
+++ b/pkg/cmd/roachtest/log.go
@@ -12,6 +12,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -250,8 +251,8 @@ func (l *logger) PrintfCtxDepth(ctx context.Context, depth int, f string, args .
 	msg := crdblog.MakeMessage(ctx, f, args)
 	if err := l.stdoutL.Output(depth+1, msg); err != nil {
 		// Changing our interface to return an Error from a logging method seems too
-		// onerous. Let's just crash.
-		panic(err)
+		// onerous. Let's yell to the default logger and if that fails, oh well.
+		_ = log.Output(depth+1, fmt.Sprintf("failed to log message: %v: %s", err, msg))
 	}
 }
 
@@ -264,8 +265,8 @@ func (l *logger) ErrorfCtxDepth(ctx context.Context, depth int, f string, args .
 	msg := crdblog.MakeMessage(ctx, f, args)
 	if err := l.stderrL.Output(depth+1, msg); err != nil {
 		// Changing our interface to return an Error from a logging method seems too
-		// onerous. Let's just crash.
-		panic(err)
+		// onerous. Let's yell to the default logger and if that fails, oh well.
+		_ = log.Output(depth+1, fmt.Sprintf("failed to log error: %v: %s", err, msg))
 	}
 }
 

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -265,21 +265,14 @@ func FatalIfErr(t *test, err error) {
 }
 
 func (t *test) printAndFail(skip int, args ...interface{}) {
-	msg := t.decorate(skip+1, fmt.Sprint(args...))
-	t.l.Printf("test failure: " + msg)
-
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	t.mu.output = append(t.mu.output, msg...)
-	t.mu.failed = true
-	if t.mu.cancel != nil {
-		t.mu.cancel()
-	}
+	t.failWithMsg(t.decorate(skip+1, fmt.Sprint(args...)))
 }
 
 func (t *test) printfAndFail(skip int, format string, args ...interface{}) {
-	msg := t.decorate(skip+1, fmt.Sprintf(format, args...))
+	t.failWithMsg(t.decorate(skip+1, fmt.Sprintf(format, args...)))
+}
 
+func (t *test) failWithMsg(msg string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -360,6 +360,7 @@ func (r *testRunner) runWorker(
 	}()
 
 	var c *cluster // The cluster currently being used.
+	var err error
 	// When this method returns we'll destroy the cluster we had at the time.
 	// Note that, if debug was set, c has been set to nil.
 	defer func() {
@@ -401,9 +402,7 @@ func (r *testRunner) runWorker(
 				c = nil
 			}
 		}
-
 		var testToRun testToRunRes
-		var err error
 		wStatus.SetTest(nil /* test */, testToRunRes{})
 		wStatus.SetStatus("getting work")
 		testToRun, c, err = r.getWork(
@@ -452,7 +451,6 @@ func (r *testRunner) runWorker(
 		l.PrintfCtx(ctx, "starting test: %s:%d", testToRun.spec.Name, testToRun.runNum)
 		var success bool
 		success, err = r.runTest(ctx, t, testToRun.runNum, c, testRunnerLogPath, stdout, testL)
-		testL.close()
 		if err != nil {
 			shout(ctx, l, stdout, "test returned error: %s: %s", t.Name(), err)
 			// Mark the test as failed if it isn't already.
@@ -466,6 +464,7 @@ func (r *testRunner) runWorker(
 			}
 			l.PrintfCtx(ctx, msg)
 		}
+		testL.close()
 		if err != nil || t.Failed() {
 			failureMsg := fmt.Sprintf("%s (%d) - ", testToRun.spec.Name, testToRun.runNum)
 			if err != nil {


### PR DESCRIPTION
This PR was motivated by #39706. It comes in 4 commits.

1) refactor similar logic in `printAndFail()` and `printfAndFail()` to share code (drive-by cleanup)
2) don't panic if writing to the logger fails, this is too brittle for relatively untested critical infrastructure like roachtest
3) don't close the test logger until after we're done writing to it. There was a case where we'd close it and proceed to use it.
4) don't call `Fatal()` from a monitor if the test has already failed. 

Fixes #39706.

Release note: None