### PR TITLE
workload: adjust query 30 of tpcds benchmark

### DIFF
--- a/pkg/workload/tpcds/queries.go
+++ b/pkg/workload/tpcds/queries.go
@@ -2958,6 +2958,8 @@ LIMIT
 	100;
 `
 
+	// TODO(yuzefovich): update the query once 'customer' table contains
+	// correctly named column 'c_last_review_date_sk'.
 	query30 = `
 WITH
 	customer_total_return
@@ -2987,7 +2989,7 @@ SELECT
 	c_birth_country,
 	c_login,
 	c_email_address,
-	c_last_review_date_sk,
+	c_last_review_date,
 	ctr_total_return
 FROM
 	customer_total_return AS ctr1,
@@ -3018,7 +3020,7 @@ ORDER BY
 	c_birth_country,
 	c_login,
 	c_email_address,
-	c_last_review_date_sk,
+	c_last_review_date,
 	ctr_total_return
 LIMIT
 	100;


### PR DESCRIPTION
For some reason, a suffix "_sk" is missing from one of the columns on 'customer'
table. The correct schema can be found on page 27 of
http://www.tpc.org/tpc_documents_current_versions/pdf/tpc-ds_v2.1.0.pdf.
For now, let's tweak the query a little bit.

Release note: None