### PR TITLE
[wip] storage: implement atomic replication changes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1511,8 +1511,8 @@
   revision = "b5bfa59ec0adc420475f97f89b58045c721d761c"
 
 [[projects]]
-  branch = "master"
-  digest = "1:7b2765d91bece066a1cb4928d8b39cce152a6a08602e13b1169648c2f200cfff"
+  branch = "joint-auto-leave"
+  digest = "1:859f31861c4c8f0c709ee9747f016f82c7a3ae0f7016a536f6c6156538f14294"
   name = "go.etcd.io/etcd"
   packages = [
     "raft",
@@ -1522,7 +1522,8 @@
     "raft/tracker",
   ]
   pruneopts = "UT"
-  revision = "4a4629fd9f01d4e2669c4f537a56a0019d95617e"
+  revision = "76c1a2a5a867b75e161cbeb3eb05b661f3588ac6"
+  source = "https://github.com/tbg/etcd"
 
 [[projects]]
   digest = "1:3b5a3bc35810830ded5e26ef9516e933083a2380d8e57371fdfde3c70d7c6952"
@@ -2021,6 +2022,7 @@
     "github.com/petermattis/pebble",
     "github.com/petermattis/pebble/cache",
     "github.com/petermattis/pebble/sstable",
+    "github.com/petermattis/pebble/vfs",
     "github.com/pkg/errors",
     "github.com/pmezard/go-difflib/difflib",
     "github.com/prometheus/client_golang/prometheus",
@@ -2043,6 +2045,7 @@
     "github.com/stretchr/testify/require",
     "github.com/wadey/gocovmerge",
     "go.etcd.io/etcd/raft",
+    "go.etcd.io/etcd/raft/quorum",
     "go.etcd.io/etcd/raft/raftpb",
     "go.etcd.io/etcd/raft/tracker",
     "golang.org/x/crypto/bcrypt",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -38,7 +38,9 @@ ignored = [
 
 [[constraint]]
   name = "go.etcd.io/etcd"
-  branch = "master"
+  # branch = "master"
+  branch = "joint-auto-leave"
+  source = "https://github.com/tbg/etcd"
 
 # Used for the API client; we want the latest.
 [[constraint]]

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -43,6 +43,7 @@ const (
 	VersionLearnerReplicas
 	VersionTopLevelForeignKeys
 	VersionAtomicChangeReplicasTrigger
+	VersionAtomicChangeReplicas
 
 	// Add new versions here (step one of two).
 
@@ -512,6 +513,15 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// support atomic replication changes.
 		Key:     VersionAtomicChangeReplicasTrigger,
 		Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 8},
+	},
+	{
+		// VersionAtomicChangeReplicas is https://github.com/cockroachdb/cockroach/pull/39713.
+		//
+		// It provides an implementation of (*Replica).ChangeReplicas that uses atomic replication
+		// changes. The corresponding cluster setting 'kv.atomic_replication_changes' provides a
+		// killswitch (i.e. no atomic replication changes will be scheduled when it is set to 'false').
+		Key:     VersionAtomicChangeReplicas,
+		Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 9},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/storage/client_atomic_membership_change_test.go
+++ b/pkg/storage/client_atomic_membership_change_test.go
@@ -12,50 +12,109 @@ package storage_test
 
 import (
 	"context"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/raft/quorum"
+	"go.etcd.io/etcd/raft/tracker"
 )
 
+// TestAtomicMembershipChange is a simple smoke test for atomic membership
+// changes.
 func TestAtomicMembershipChange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-
-	// This is a simple smoke test to spot obvious issues with atomic replica changes.
-	// These aren't implemented at the time of writing. The compound change below is
-	// internally unwound and executed step by step (see executeAdminBatch()).
 	ctx := context.Background()
 
 	args := base.TestClusterArgs{
 		ReplicationMode: base.ReplicationManual,
 	}
-	tc := testcluster.StartTestCluster(t, 4, args)
+	tc := testcluster.StartTestCluster(t, 6, args)
 	defer tc.Stopper().Stop(ctx)
 
+	// Create a range and put it on n1, n2, n3. Intentionally do this one at a
+	// time so we're not using atomic replication changes yet.
 	k := tc.ScratchRange(t)
-	expDesc, err := tc.AddReplicas(k, tc.Target(1), tc.Target(2))
+	expDesc, err := tc.AddReplicas(k, tc.Target(1))
+	require.NoError(t, err)
+	expDesc, err = tc.AddReplicas(k, tc.Target(2))
 	require.NoError(t, err)
 
-	// Range is now on s1,s2,s3. "Atomically" add it to s4 while removing from s3.
-	// This isn't really atomic yet.
+	// Range is now on s1,s2,s3. Atomically add s4 and remove s3.
 
 	chgs := []roachpb.ReplicationChange{
 		{ChangeType: roachpb.ADD_REPLICA, Target: tc.Target(3)},
+		{ChangeType: roachpb.ADD_REPLICA, Target: tc.Target(5)},
 		{ChangeType: roachpb.REMOVE_REPLICA, Target: tc.Target(2)},
+		{ChangeType: roachpb.ADD_REPLICA, Target: tc.Target(4)},
 	}
-	// TODO(tbg): when 19.2 is out, remove this "feature gate" here and in
-	// AdminChangeReplicas.
-	ctx = context.WithValue(ctx, "testing", "testing")
-	desc, err := tc.Servers[0].DB().AdminChangeReplicas(ctx, k, expDesc, chgs)
+
+	repl, err := tc.Servers[0].Stores().GetReplicaForRangeID(expDesc.RangeID)
 	require.NoError(t, err)
+	desc, err := repl.ChangeReplicas(ctx, &expDesc, storage.SnapshotRequest_REBALANCE, storagepb.ReasonRebalance, "testing", chgs)
+	require.NoError(t, err)
+
+	// TODO(tbg): switch to this branch once AdminChangeReplicas generically uses
+	// atomic replication changes. At the time of writing, it executes each change
+	// individually.
+	if false {
+		desc, err = tc.Servers[0].DB().AdminChangeReplicas(
+			// TODO(tbg): when 19.2 is out, remove this "feature gate" here and in
+			// AdminChangeReplicas.
+			context.WithValue(ctx, "testing", "testing"),
+			k, expDesc, chgs,
+		)
+		var _ = desc // pacify linters
+		require.NoError(t, err)
+	}
+
 	var stores []roachpb.StoreID
 	for _, rDesc := range desc.Replicas().All() {
+		if rDesc.GetType() == roachpb.ReplicaType_LEARNER {
+			t.Fatalf("found a learner: %+v", desc)
+		}
 		stores = append(stores, rDesc.StoreID)
 	}
-	exp := []roachpb.StoreID{1, 2, 4}
-	// TODO(tbg): test more details and scenarios (learners etc).
+	sort.Slice(stores, func(i, j int) bool { return stores[i] < stores[j] })
+	exp := []roachpb.StoreID{1, 2, 4, 5, 6}
 	require.Equal(t, exp, stores)
+
+	descJointKey := keys.RangeDescriptorJointKey(desc.StartKey)
+	for _, idx := range []int{0, 1, 3, 4, 5} {
+		// Verify that all replicas left the joint config automatically (raft does
+		// this and ChangeReplicas blocks until it has).
+		repl, err := tc.Servers[idx].Stores().GetReplicaForRangeID(expDesc.RangeID)
+		require.NoError(t, err)
+		act := repl.RaftStatus().Config
+		exp := tracker.Config{
+			Voters: quorum.JointConfig{
+				{1: {}, 2: {}, 4: {}, 5: {}, 6: {}},
+				{},
+			},
+		}
+		if sl := pretty.Diff(exp, act); len(sl) > 0 {
+			t.Fatalf("exp != act:\n%s", strings.Join(sl, "\n"))
+		}
+		// Also check that the replicated marker from which the conf state would
+		// be recreated on restart is gone.
+		var desc roachpb.RangeDescriptor
+		ok, err := engine.MVCCGetProto(ctx, repl.Engine(), descJointKey, hlc.Timestamp{}, &desc, engine.MVCCGetOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ok {
+			t.Fatalf("still have joint descriptor %+v", desc)
+		}
+	}
 }

--- a/pkg/storage/replica_proposal_buf.go
+++ b/pkg/storage/replica_proposal_buf.go
@@ -446,34 +446,71 @@ func (b *propBuf) FlushLockedWithRaftGroup(raftGroup *raft.RawNode) error {
 			}
 
 			added, removed := crt.Added(), crt.Removed()
-			if len(added)+len(removed) != 1 {
-				log.Fatalf(context.TODO(), "atomic replication changes not supported yet")
+
+			replToSingle := func(rDesc roachpb.ReplicaDescriptor, typ roachpb.ReplicaChangeType) raftpb.ConfChangeSingle {
+				var changeType raftpb.ConfChangeType
+				if typ == roachpb.ADD_REPLICA {
+					replTyp := rDesc.GetType()
+					switch replTyp {
+					case roachpb.ReplicaType_VOTER:
+						changeType = raftpb.ConfChangeAddNode
+					case roachpb.ReplicaType_LEARNER:
+						changeType = raftpb.ConfChangeAddLearnerNode
+					default:
+						panic(errors.Errorf("unknown replica type %v", typ))
+					}
+				} else {
+					changeType = raftpb.ConfChangeRemoveNode
+				}
+				return raftpb.ConfChangeSingle{
+					NodeID: uint64(rDesc.ReplicaID),
+					Type:   changeType,
+				}
 			}
 
-			var changeType raftpb.ConfChangeType
-			var replicaID roachpb.ReplicaID
-			if len(added) > 0 {
-				replicaID = added[0].ReplicaID
-				typ := added[0].GetType()
-				switch typ {
-				case roachpb.ReplicaType_VOTER:
-					changeType = raftpb.ConfChangeAddNode
-				case roachpb.ReplicaType_LEARNER:
-					changeType = raftpb.ConfChangeAddLearnerNode
-				default:
-					panic(errors.Errorf("unknown replica type %v", typ))
+			var cc raftpb.ConfChangeI
+			if joint := len(added)+len(removed) > 1; joint {
+				// TODO(tbg): use this branch for all changes once we know that
+				// the cluster version is 19.2.
+				var sl []raftpb.ConfChangeSingle
+				for _, rDesc := range added {
+					sl = append(sl, replToSingle(rDesc, roachpb.ADD_REPLICA))
+				}
+				for _, rDesc := range removed {
+					sl = append(sl, replToSingle(rDesc, roachpb.REMOVE_REPLICA))
+				}
+				cc = raftpb.ConfChangeV2{
+					Transition: raftpb.ConfChangeTransitionAuto,
+					Changes:    sl,
+					Context:    encodedCtx,
 				}
 			} else {
-				changeType, replicaID = raftpb.ConfChangeRemoveNode, removed[0].ReplicaID
+				var changeType raftpb.ConfChangeType
+				var replicaID roachpb.ReplicaID
+				if len(added) > 0 {
+					replicaID = added[0].ReplicaID
+					typ := added[0].GetType()
+					switch typ {
+					case roachpb.ReplicaType_VOTER:
+						changeType = raftpb.ConfChangeAddNode
+					case roachpb.ReplicaType_LEARNER:
+						changeType = raftpb.ConfChangeAddLearnerNode
+					default:
+						panic(errors.Errorf("unknown replica type %v", typ))
+					}
+				} else {
+					changeType, replicaID = raftpb.ConfChangeRemoveNode, removed[0].ReplicaID
+				}
+
+				cc = raftpb.ConfChange{
+					Type:    changeType,
+					NodeID:  uint64(replicaID),
+					Context: encodedCtx,
+				}
 			}
 
-			confChange := raftpb.ConfChange{
-				Type:    changeType,
-				NodeID:  uint64(replicaID),
-				Context: encodedCtx,
-			}
 			if err := raftGroup.ProposeConfChange(
-				confChange,
+				cc,
 			); err != nil && err != raft.ErrProposalDropped {
 				// Silently ignore dropped proposals (they were always silently
 				// ignored prior to the introduction of ErrProposalDropped).

--- a/pkg/storage/stateloader/stateloader.go
+++ b/pkg/storage/stateloader/stateloader.go
@@ -642,3 +642,56 @@ func (rsl StateLoader) SynthesizeHardState(
 	err := rsl.SetHardState(ctx, eng, newHS)
 	return errors.Wrapf(err, "writing HardState %+v", &newHS)
 }
+
+// makeConfState transforms the current and, optionally, previous descriptor
+// of the range into a ConfState. The previous descriptor is only supplied when
+// the range is in the middle of an atomic replication change.
+func makeConfState(
+	reps []roachpb.ReplicaDescriptor, jointReps ...roachpb.ReplicaDescriptor,
+) raftpb.ConfState {
+	var cs raftpb.ConfState
+	var outgoingVoters map[roachpb.ReplicaID]struct{}
+	if len(jointReps) != 0 {
+		// We'll return a ConfState in a joint state, and we always want Raft
+		// to leave it for us.
+		cs.AutoLeave = true
+		// Populate outgoingVoters for the code handling learners below.
+		outgoingVoters = map[roachpb.ReplicaID]struct{}{}
+		for _, rep := range jointReps {
+			if rep.GetType() == roachpb.ReplicaType_VOTER {
+				outgoingVoters[rep.ReplicaID] = struct{}{}
+				cs.VotersOutgoing = append(cs.VotersOutgoing, uint64(rep.ReplicaID))
+			}
+		}
+	}
+
+	// The incoming config is taken verbatim from 'desc' when the config is not
+	// joint. If it is, the voters are still taken verbatim, but some of the
+	// learners which are also in the outgoing config must be put into
+	// LearnersNext instead of Learners.
+	for _, rep := range reps {
+		if rep.GetType() == roachpb.ReplicaType_VOTER {
+			cs.Voters = append(cs.Voters, uint64(rep.ReplicaID))
+		} else {
+			if _, ok := outgoingVoters[rep.ReplicaID]; ok {
+				cs.LearnersNext = append(cs.LearnersNext, uint64(rep.ReplicaID))
+			} else {
+				cs.Learners = append(cs.Learners, uint64(rep.ReplicaID))
+			}
+		}
+	}
+	return cs
+}
+
+// LoadConfState creates the raftpb.ConfState for the given descriptor.
+func (rsl StateLoader) LoadConfState(
+	ctx context.Context, eng engine.Reader, desc *roachpb.RangeDescriptor,
+) (raftpb.ConfState, error) {
+	jointDesc := &roachpb.RangeDescriptor{}
+	_, err := engine.MVCCGetProto(
+		ctx, eng, keys.RangeDescriptorJointKey(desc.StartKey), hlc.Timestamp{}, jointDesc, engine.MVCCGetOptions{})
+	if err != nil {
+		return raftpb.ConfState{}, err
+	}
+	return makeConfState(desc.Replicas().All(), jointDesc.Replicas().All()...), nil
+}

--- a/pkg/storage/stateloader/stateloader_test.go
+++ b/pkg/storage/stateloader/stateloader_test.go
@@ -1,0 +1,80 @@
+package stateloader
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/datadriven"
+	"go.etcd.io/etcd/raft"
+)
+
+var testMakeConfState = `
+# Not in a joint config, just two voters.
+cs reps=(1,2)
+----
+Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+
+# A voter and an outgoing voter. We'll see AutoLeave=true because this is a
+# joint state (so are all others that follow).
+cs reps=(1) joint=(2)
+----
+Voters:[1] VotersOutgoing:[2] Learners:[] LearnersNext:[] AutoLeave:true
+
+# Test that a learner in the incoming config gets read into LearnersNext if it
+# overlaps an outgoing voter.
+cs reps=(1,2LEARNER) joint=(2)
+----
+Voters:[1] VotersOutgoing:[2] Learners:[] LearnersNext:[2] AutoLeave:true
+
+# Add another learner that does not overlap to check that it goes into Learners.
+cs reps=(1,2LEARNER,4LEARNER) joint=(2,3)
+----
+Voters:[1] VotersOutgoing:[2 3] Learners:[4] LearnersNext:[2] AutoLeave:true
+
+# Add some learners to joint where they should not make a difference (the
+# incoming descriptor has all the relevant info on learners already).
+cs reps=(1,2LEARNER,4LEARNER) joint=(2,3,4LEARNER,1LEARNER)
+----
+Voters:[1] VotersOutgoing:[2 3] Learners:[4] LearnersNext:[2] AutoLeave:true
+`
+
+func TestMakeConfState(t *testing.T) {
+	all := make([]roachpb.ReplicaDescriptor, 10)
+	for i := 0; i < len(all)/2; i++ {
+		all[i] = roachpb.ReplicaDescriptor{
+			NodeID:    roachpb.NodeID(i + 1),
+			StoreID:   roachpb.StoreID(i + 1),
+			ReplicaID: roachpb.ReplicaID(i + 1),
+		}
+		all[i+5] = roachpb.ReplicaDescriptor{
+			NodeID:    roachpb.NodeID(i + 6),
+			StoreID:   roachpb.StoreID(i + 6),
+			ReplicaID: roachpb.ReplicaID(i + 6),
+			Type:      roachpb.ReplicaTypeLearner(),
+		}
+	}
+
+	datadriven.RunTestFromString(t, testMakeConfState, func(d *datadriven.TestData) string {
+		var reps, joint []roachpb.ReplicaDescriptor
+		for _, arg := range d.CmdArgs {
+			for i := 0; i < len(arg.Vals); i++ {
+				var rep roachpb.ReplicaDescriptor
+				if strings.HasSuffix(arg.Vals[i], "LEARNER") {
+					arg.Vals[i] = arg.Vals[i][:len(arg.Vals[i])-7]
+					rep.Type = roachpb.ReplicaTypeLearner()
+				}
+				var id int
+				arg.Scan(t, i, &id)
+				rep.ReplicaID, rep.StoreID, rep.NodeID = roachpb.ReplicaID(id), roachpb.StoreID(id), roachpb.NodeID(id)
+				switch arg.Key {
+				case "reps":
+					reps = append(reps, rep)
+				case "joint":
+					joint = append(joint, rep)
+				}
+			}
+		}
+		return raft.DescribeConfState(makeConfState(reps, joint...)) + "\n"
+	})
+}


### PR DESCRIPTION
TODO:
- actually use RangeDescriptorJointKey in InitialState() and while
  applying snapshots
- much more testing

----

This commit allows running end-to-end atomic replication changes for
testing purposes.

`(*Replica).ChangeReplicas` accepts a slice of changes which the commit
trigger will turn into a raft V2 configuration change while atomically
persisting the previous descriptor to `RangeDescriptorJointKey` (a
replicated key that is only written below Raft). This key makes sure that
in the event of an untimely crash (while in the joint config) the replica
will, upon restart, initialize the same joint configuration. Since the
source of truth, the RangeDescriptor, already reflects the new
configuration at this point, this needs the extra information to be
sidelined.

We're setting up raft so that it automatically transitions us out of the
joint configuration once this is safe via an empty ConfChangeV2, and again
we atomically tie a write to the application of this command that clears
RangeDescriptorJointKey.

Nothing except tests uses atomic replication changes yet.

Release note: None