### PR TITLE
sqlbase: clarify constants for col id and col fam id for Zones table

### DIFF
--- a/pkg/config/keys.go
+++ b/pkg/config/keys.go
@@ -27,7 +27,7 @@ func MakeZoneKeyPrefix(id uint32) roachpb.Key {
 // MakeZoneKey returns the key for id's entry in the system.zones table.
 func MakeZoneKey(id uint32) roachpb.Key {
 	k := MakeZoneKeyPrefix(id)
-	return keys.MakeFamilyKey(k, uint32(keys.ZonesTableConfigColumnID))
+	return keys.MakeFamilyKey(k, uint32(keys.ZonesTableConfigColFamID))
 }
 
 // DecodeObjectID decodes the object ID from the front of key. It returns the

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -306,6 +306,7 @@ const (
 	// avoid introducing a dependency on sql/sqlbase throughout the codebase.
 	ZonesTablePrimaryIndexID = 1
 	ZonesTableConfigColumnID = 2
+	ZonesTableConfigColFamID = 2
 
 	// Reserved IDs for other system tables. Note that some of these IDs refer
 	// to "Ranges" instead of a Table - these IDs are needed to store custom

--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -385,7 +385,8 @@ var (
 		NextColumnID: 3,
 		Families: []ColumnFamilyDescriptor{
 			{Name: "primary", ID: 0, ColumnNames: []string{"id"}, ColumnIDs: singleID1},
-			{Name: "fam_2_config", ID: 2, ColumnNames: []string{"config"}, ColumnIDs: []ColumnID{2}, DefaultColumnID: 2},
+			{Name: "fam_2_config", ID: keys.ZonesTableConfigColFamID, ColumnNames: []string{"config"},
+				ColumnIDs: []ColumnID{keys.ZonesTableConfigColumnID}, DefaultColumnID: keys.ZonesTableConfigColumnID},
 		},
 		PrimaryIndex: IndexDescriptor{
 			Name:             "primary",


### PR DESCRIPTION
Before this patch, the code was conflating a col id and a col fam id in
the construction of zone config keys.

Release note: None