### PR TITLE
bulk: Compute MVCCStats of the SST being ingested on-the-fly

### DIFF
--- a/pkg/ccl/importccl/sst_writer_proc.go
+++ b/pkg/ccl/importccl/sst_writer_proc.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/bulk"
 	"github.com/cockroachdb/cockroach/pkg/storage/diskmap"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -220,7 +221,7 @@ func (sp *sstWriter) Run(ctx context.Context) {
 					// can never be any shadow keys, and this check could be turned off.
 					// Plumb a user option to toggle this if the overhead without
 					// colliding keys becomes more significant.
-					if err := bulk.AddSSTable(ctx, sp.db, sst.span.Key, sst.span.EndKey, sst.data, true /* disallowShadowing */); err != nil {
+					if err := bulk.AddSSTable(ctx, sp.db, sst.span.Key, sst.span.EndKey, sst.data, true /* disallowShadowing */, enginepb.MVCCStats{} /* ms */); err != nil {
 						return err
 					}
 

--- a/pkg/storage/batcheval/cmd_add_sstable.go
+++ b/pkg/storage/batcheval/cmd_add_sstable.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/kr/pretty"
 	"github.com/pkg/errors"
 )
 
@@ -72,15 +73,32 @@ func EvalAddSSTable(
 		}
 	}
 
+	// Get the MVCCStats for the SST being ingested.
 	var stats enginepb.MVCCStats
 	if args.MVCCStats != nil {
 		stats = *args.MVCCStats
-	} else {
+	}
+
+	// Stats are computed on-the-fly when shadowing of keys is disallowed. If we
+	// took the fast path and race is enabled, assert the stats were correctly
+	// computed.
+	verifyFastPath := args.DisallowShadowing && util.RaceEnabled
+	if args.MVCCStats == nil || verifyFastPath {
 		log.VEventf(ctx, 2, "computing MVCCStats for SSTable [%s,%s)", mvccStartKey.Key, mvccEndKey.Key)
 
 		computed, err := engine.ComputeStatsGo(dataIter, mvccStartKey, mvccEndKey, h.Timestamp.WallTime)
 		if err != nil {
 			return result.Result{}, errors.Wrap(err, "computing SSTable MVCC stats")
+		}
+
+		if verifyFastPath {
+			// Update the timestamp to that of the recently computed stats to get the
+			// diff passing.
+			stats.LastUpdateNanos = computed.LastUpdateNanos
+			if !stats.Equal(computed) {
+				log.Fatalf(ctx, "fast-path MVCCStats computation gave wrong result: diff(fast, computed) = %s",
+					pretty.Diff(stats, computed))
+			}
 		}
 		stats = computed
 	}
@@ -135,6 +153,18 @@ func EvalAddSSTable(
 	// Callers can trigger such a re-computation to fixup any discrepancies (and
 	// remove the ContainsEstimates flag) after they are done ingesting files by
 	// sending an explicit recompute.
+	//
+	// TODO(adityamaru): There is a significant performance win to be achieved by
+	// ensuring that the stats computed are not estimates as it prevents
+	// recompuation on splits. Running AddSSTable with disallowShadowing=true gets
+	// us close to this as we do not allow colliding keys to be ingested. However,
+	// in the situation that two SSTs have KV(s) which "perfectly" shadow an
+	// existing key (equal ts and value), we do not consider this a collision.
+	// While the KV would just overwrite the existing data, the stats would be
+	// added below, causing a double count for those KVs. One solution is to
+	// compute the stats for these "skipped" KVs on-the-fly while checking for the
+	// collision condition and returning their stats. The final stats would then
+	// be ms + stats - skipped_stats, and this would be accurate.
 	stats.ContainsEstimates = true
 	ms.Add(stats)
 

--- a/pkg/storage/bulk/sst_batcher_test.go
+++ b/pkg/storage/bulk/sst_batcher_test.go
@@ -278,7 +278,7 @@ func TestAddBigSpanningSSTWithSplits(t *testing.T) {
 
 	t.Logf("Adding %dkb sst spanning %d splits from %v to %v", len(sst)/kb, len(splits), start, end)
 	if err := bulk.AddSSTable(
-		context.TODO(), mock, start, end, sst, false, /* disallowShadowing */
+		context.TODO(), mock, start, end, sst, false /* disallowShadowing */, enginepb.MVCCStats{},
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/engine/mvcc_stats_test.go
+++ b/pkg/storage/engine/mvcc_stats_test.go
@@ -82,7 +82,7 @@ func TestMVCCStatsDeleteCommitMovesTimestamp(t *testing.T) {
 	}
 
 	mKeySize := int64(mvccKey(key).EncodedSize()) // 2
-	vKeySize := mvccVersionTimestampSize          // 12
+	vKeySize := MVCCVersionTimestampSize          // 12
 	vValSize := int64(len(value.RawBytes))        // 10
 
 	expMS := enginepb.MVCCStats{
@@ -165,7 +165,7 @@ func TestMVCCStatsPutCommitMovesTimestamp(t *testing.T) {
 		Deleted:   false,
 		Txn:       &txn.TxnMeta,
 	}).Size())
-	vKeySize := mvccVersionTimestampSize   // 12
+	vKeySize := MVCCVersionTimestampSize   // 12
 	vValSize := int64(len(value.RawBytes)) // 10
 
 	expMS := enginepb.MVCCStats{
@@ -240,7 +240,7 @@ func TestMVCCStatsPutPushMovesTimestamp(t *testing.T) {
 		Deleted:   false,
 		Txn:       &txn.TxnMeta,
 	}).Size())
-	vKeySize := mvccVersionTimestampSize   // 12
+	vKeySize := MVCCVersionTimestampSize   // 12
 	vValSize := int64(len(value.RawBytes)) // 10
 
 	expMS := enginepb.MVCCStats{
@@ -331,7 +331,7 @@ func TestMVCCStatsDeleteMovesTimestamp(t *testing.T) {
 	}).Size())
 	require.EqualValues(t, m1ValSize, 46)
 
-	vKeySize := mvccVersionTimestampSize
+	vKeySize := MVCCVersionTimestampSize
 	require.EqualValues(t, vKeySize, 12)
 
 	vValSize := int64(len(value.RawBytes))
@@ -440,7 +440,7 @@ func TestMVCCStatsPutMovesDeletionTimestamp(t *testing.T) {
 	}).Size())
 	require.EqualValues(t, m1ValSize, 46)
 
-	vKeySize := mvccVersionTimestampSize
+	vKeySize := MVCCVersionTimestampSize
 	require.EqualValues(t, vKeySize, 12)
 
 	vValSize := int64(len(value.RawBytes))
@@ -532,7 +532,7 @@ func TestMVCCStatsDelDelCommitMovesTimestamp(t *testing.T) {
 
 	mKeySize := int64(mvccKey(key).EncodedSize())
 	require.EqualValues(t, mKeySize, 2)
-	vKeySize := mvccVersionTimestampSize
+	vKeySize := MVCCVersionTimestampSize
 	require.EqualValues(t, vKeySize, 12)
 
 	expMS := enginepb.MVCCStats{
@@ -669,7 +669,7 @@ func TestMVCCStatsPutDelPutMovesTimestamp(t *testing.T) {
 	mKeySize := int64(mvccKey(key).EncodedSize())
 	require.EqualValues(t, mKeySize, 2)
 
-	vKeySize := mvccVersionTimestampSize
+	vKeySize := MVCCVersionTimestampSize
 	require.EqualValues(t, vKeySize, 12)
 
 	vValSize := int64(len(value.RawBytes))
@@ -832,7 +832,7 @@ func TestMVCCStatsDelDelGC(t *testing.T) {
 	}
 
 	mKeySize := int64(mvccKey(key).EncodedSize()) // 2
-	vKeySize := mvccVersionTimestampSize          // 12
+	vKeySize := MVCCVersionTimestampSize          // 12
 
 	expMS := enginepb.MVCCStats{
 		LastUpdateNanos: 2E9,
@@ -909,7 +909,7 @@ func TestMVCCStatsPutIntentTimestampNotPutTimestamp(t *testing.T) {
 		Timestamp: hlc.LegacyTimestamp(ts201),
 		Txn:       &txn.TxnMeta,
 	}).Size())
-	vKeySize := mvccVersionTimestampSize   // 12
+	vKeySize := MVCCVersionTimestampSize   // 12
 	vValSize := int64(len(value.RawBytes)) // 10
 
 	expMS := enginepb.MVCCStats{
@@ -992,7 +992,7 @@ func TestMVCCStatsPutWaitDeleteGC(t *testing.T) {
 	mKeySize := int64(mvccKey(key).EncodedSize())
 	require.EqualValues(t, mKeySize, 2)
 
-	vKeySize := mvccVersionTimestampSize
+	vKeySize := MVCCVersionTimestampSize
 	require.EqualValues(t, vKeySize, 12)
 
 	vValSize := int64(len(val1.RawBytes))
@@ -1087,7 +1087,7 @@ func TestMVCCStatsTxnSysPutPut(t *testing.T) {
 	}).Size())
 	require.EqualValues(t, mValSize, 46)
 
-	vKeySize := mvccVersionTimestampSize
+	vKeySize := MVCCVersionTimestampSize
 	require.EqualValues(t, vKeySize, 12)
 
 	vVal1Size := int64(len(val1.RawBytes))
@@ -1171,7 +1171,7 @@ func TestMVCCStatsTxnSysPutAbort(t *testing.T) {
 	}).Size())
 	require.EqualValues(t, mValSize, 46)
 
-	vKeySize := mvccVersionTimestampSize
+	vKeySize := MVCCVersionTimestampSize
 	require.EqualValues(t, vKeySize, 12)
 
 	vVal1Size := int64(len(val1.RawBytes))
@@ -1228,7 +1228,7 @@ func TestMVCCStatsSysPutPut(t *testing.T) {
 	mKeySize := int64(mvccKey(key).EncodedSize())
 	require.EqualValues(t, mKeySize, 11)
 
-	vKeySize := mvccVersionTimestampSize
+	vKeySize := MVCCVersionTimestampSize
 	require.EqualValues(t, vKeySize, 12)
 
 	vVal1Size := int64(len(val1.RawBytes))

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -523,7 +523,7 @@ func TestMVCCPutNewEpochLowerSequence(t *testing.T) {
 	aggMeta := &enginepb.MVCCMetadata{
 		Txn:           &txn.TxnMeta,
 		Timestamp:     hlc.LegacyTimestamp{WallTime: 1},
-		KeyBytes:      mvccVersionTimestampSize,
+		KeyBytes:      MVCCVersionTimestampSize,
 		ValBytes:      int64(len(value2.RawBytes)),
 		IntentHistory: nil,
 	}
@@ -5273,7 +5273,7 @@ func TestMVCCIdempotentTransactions(t *testing.T) {
 	aggMeta := &enginepb.MVCCMetadata{
 		Txn:       &txn.TxnMeta,
 		Timestamp: hlc.LegacyTimestamp(ts1),
-		KeyBytes:  mvccVersionTimestampSize,
+		KeyBytes:  MVCCVersionTimestampSize,
 		ValBytes:  int64(len(newValue.RawBytes)),
 		IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
 			{Sequence: 0, Value: value.RawBytes},
@@ -5402,7 +5402,7 @@ func TestMVCCIntentHistory(t *testing.T) {
 	aggMeta := &enginepb.MVCCMetadata{
 		Txn:       &txn.TxnMeta,
 		Timestamp: hlc.LegacyTimestamp(ts1),
-		KeyBytes:  mvccVersionTimestampSize,
+		KeyBytes:  MVCCVersionTimestampSize,
 		ValBytes:  int64(len(value.RawBytes)),
 	}
 	metaKey := mvccKey(key)
@@ -5429,7 +5429,7 @@ func TestMVCCIntentHistory(t *testing.T) {
 	aggMeta = &enginepb.MVCCMetadata{
 		Txn:       &txn.TxnMeta,
 		Timestamp: hlc.LegacyTimestamp(ts2),
-		KeyBytes:  mvccVersionTimestampSize,
+		KeyBytes:  MVCCVersionTimestampSize,
 		ValBytes:  int64(len(newValue.RawBytes)),
 		IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
 			{Sequence: 1, Value: value.RawBytes},
@@ -5456,7 +5456,7 @@ func TestMVCCIntentHistory(t *testing.T) {
 	aggMeta = &enginepb.MVCCMetadata{
 		Txn:       &txn.TxnMeta,
 		Timestamp: hlc.LegacyTimestamp(ts2),
-		KeyBytes:  mvccVersionTimestampSize,
+		KeyBytes:  MVCCVersionTimestampSize,
 		ValBytes:  0,
 		Deleted:   true,
 		IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
@@ -5485,7 +5485,7 @@ func TestMVCCIntentHistory(t *testing.T) {
 	aggMeta = &enginepb.MVCCMetadata{
 		Txn:       &txn.TxnMeta,
 		Timestamp: hlc.LegacyTimestamp(ts2),
-		KeyBytes:  mvccVersionTimestampSize,
+		KeyBytes:  MVCCVersionTimestampSize,
 		ValBytes:  int64(len(value.RawBytes)),
 		IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
 			{Sequence: 1, Value: value.RawBytes},

--- a/pkg/storage/gc_queue_test.go
+++ b/pkg/storage/gc_queue_test.go
@@ -478,7 +478,7 @@ func TestGCQueueProcess(t *testing.T) {
 	}
 
 	// The total size of the GC'able versions of the keys and values in GCInfo.
-	// Key size: len("a") + mvccVersionTimestampSize (13 bytes) = 14 bytes.
+	// Key size: len("a") + MVCCVersionTimestampSize (13 bytes) = 14 bytes.
 	// Value size: len("value") + headerSize (5 bytes) = 10 bytes.
 	// key1 at ts1  (14 bytes) => "value" (10 bytes)
 	// key2 at ts1  (14 bytes) => "value" (10 bytes)
@@ -987,7 +987,7 @@ func TestGCQueueChunkRequests(t *testing.T) {
 	if gcKeyVersionChunkBytes%keyCount != 0 {
 		t.Fatalf("expected gcKeyVersionChunkBytes to be a multiple of %d", keyCount)
 	}
-	// Reduce the key size by mvccVersionTimestampSize (13 bytes) to prevent batch overflow.
+	// Reduce the key size by MVCCVersionTimestampSize (13 bytes) to prevent batch overflow.
 	// This is due to MVCCKey.EncodedSize(), which returns the full size of the encoded key.
 	const keySize = (gcKeyVersionChunkBytes / keyCount) - 13
 	// Create a format string for creating version keys of exactly


### PR DESCRIPTION
This change is an optimization to the MVCCStats collection
in the bulk ingestion pipeline. Currently when ingesting an
SST via the SSTBatcher, we have one iteration to construct an
SST, and an additional one to compute the MVCCStats for the
span being ingested.
In scenarios such as IMPORT, where we have an enforced guarantee
(via the disallowShadowing flag) that the KVs being ingested
do not shadow existing data, MVCCStats collection becomes very
simple. This change adds logic to collect these stats on-the-fly
while the SST is being constructed, thereby saving us an additional
iteration which has been profiled as a bottleneck in IMPORT.

TODO:
There is a significant performance win to be achieved by
ensuring that the stats computed are not estimates as it prevents
recompuation on splits. Running AddSSTable with disallowShadowing=true gets
us close to this as we do not allow colliding keys to be ingested. However,
in the situation that two SSTs have KV(s) which "perfectly" shadow an
existing key (equal ts and value), we do not consider this a collision.
While the KV would just overwrite the existing data, the stats would be
re-added, causing a double count for such KVs. One solution is to
compute the stats for these "skipped" KVs on-the-fly while checking for the
collision condition and returning their stats. The final stats would then
be base_stats + sst_stats - skipped_stats, and this would be accurate.

Benchmark update: Over three runs of TPCC 1k on a 4 node, default roachprod cluster, the time dropped from ~32m to ~22m.

Release note: None