### PR TITLE
[do-not-merge] engine: silence warning about rocks levels 

### DIFF
--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -113,7 +113,10 @@ func rocksDBLog(sevLvl C.int, s *C.char, n C.int) {
 	ctx := logtags.AddTag(context.Background(), "rocksdb", nil)
 	switch log.Severity(sevLvl) {
 	case log.Severity_WARNING:
-		log.Warning(ctx, C.GoStringN(s, n))
+		const levelsWarning = `[db/version_set.cc:3086] More existing levels in DB than needed`
+		if str := C.GoStringN(s, n); !strings.HasPrefix(str, levelsWarning) {
+			log.Warning(ctx, str)
+		}
 	case log.Severity_ERROR:
 		log.Error(ctx, C.GoStringN(s, n))
 	case log.Severity_FATAL:


### PR DESCRIPTION
Opening a PR just to get a CI run, to see if silencing this line makes the build faster. If it does, then we can decide if it is something we actually want to do.

This one line is _very_ noisy in testing: on the most recent run of `test` CI on master, the log contained 23658 instances of this line, making up about 4.5mb of the total 38mb log. Based on past experiences, we've seen excessive logging make tests, particularly on our CI agents, _much_ slower.

Release note: none.