### PR TITLE
build: only print c-deps CI compilation output on failure

### DIFF
--- a/build/teamcity-acceptance.sh
+++ b/build/teamcity-acceptance.sh
@@ -16,7 +16,9 @@ type=$(go env GOOS)
 tc_end_block "Prepare environment for acceptance tests"
 
 tc_start_block "Compile CockroachDB"
-run pkg/acceptance/prepare.sh
+# Buffer noisy output and only print it on failure.
+run pkg/acceptance/prepare.sh &> artifacts/acceptance-compile.log || (cat artifacts/acceptance-compile.log && false)
+rm artifacts/acceptance-compile.log
 run ln -s cockroach-linux-2.6.32-gnu-amd64 cockroach  # For the tests that run without Docker.
 tc_end_block "Compile CockroachDB"
 

--- a/build/teamcity-bench.sh
+++ b/build/teamcity-bench.sh
@@ -10,7 +10,9 @@ export TMPDIR=$PWD/artifacts/bench
 mkdir -p "$TMPDIR"
 
 tc_start_block "Compile C dependencies"
-run build/builder.sh make -Otarget c-deps
+# Buffer noisy output and only print it on failure.
+run build/builder.sh make -Otarget c-deps &> artifacts/bench-c-build.log || (cat artifacts/bench-c-build.log && false)
+rm artifacts/bench-c-build.log
 tc_end_block "Compile C dependencies"
 
 tc_start_block "Run Benchmarks"

--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -12,7 +12,9 @@ run build/builder.sh env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" TARGET=checkdeps g
 tc_end_block "Ensure dependencies are up-to-date"
 
 tc_start_block "Ensure generated code is up-to-date"
-run build/builder.sh make generate buildshort
+# Buffer noisy output and only print it on failure.
+run build/builder.sh make generate buildshort &> artifacts/generate.log || (cat artifacts/generate.log && false)
+rm artifacts/generate.log
 # The workspace is clean iff `git status --porcelain` produces no output. Any
 # output is either an error message or a listing of an untracked/dirty file.
 if [[ "$(git status --porcelain 2>&1)" != "" ]]; then

--- a/build/teamcity-local-roachtest.sh
+++ b/build/teamcity-local-roachtest.sh
@@ -12,7 +12,9 @@ maybe_ccache
 tc_end_block "Prepare environment"
 
 tc_start_block "Compile CockroachDB"
-run build/builder.sh make build
+# Buffer noisy output and only print it on failure.
+run build/builder.sh make build &> artifacts/roachtests-compile.log || (cat artifacts/roachtests-compile.log && false)
+rm artifacts/roachtests-compile.log
 tc_end_block "Compile CockroachDB"
 
 tc_start_block "Compile roachprod/workload/roachtest"

--- a/build/teamcity-test.sh
+++ b/build/teamcity-test.sh
@@ -15,8 +15,11 @@ run build/builder.sh env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" TARGET=stress gith
 tc_end_block "Maybe stress pull request"
 
 tc_start_block "Compile C dependencies"
-run build/builder.sh make -Otarget c-deps
+# Buffer noisy output and only print it on failure.
+run build/builder.sh make -Otarget c-deps &> artifacts/c-build.log || (cat artifacts/c-build.log && false)
+rm artifacts/c-build.log
 tc_end_block "Compile C dependencies"
+
 
 tc_start_block "Run Go tests"
 run build/builder.sh \
@@ -33,5 +36,6 @@ echo "Slow individual tests:"
 grep "^--- PASS" artifacts/test.log | sed 's/(//; s/)//' | sort -n -k4 | tail -n25
 
 tc_start_block "Run C++ tests"
-run build/builder.sh make check-libroach
+# Buffer noisy output and only print it on failure.
+run build/builder.sh make check-libroach &> artifacts/c-tests.log || (cat artifacts/c-tests.log && false)
 tc_end_block "Run C++ tests"

--- a/build/teamcity-testrace.sh
+++ b/build/teamcity-testrace.sh
@@ -36,7 +36,9 @@ fi
 tc_end_block "Determine changed packages"
 
 tc_start_block "Compile C dependencies"
-run build/builder.sh make -Otarget c-deps GOFLAGS=-race
+# Buffer noisy output and only print it on failure.
+run build/builder.sh make -Otarget c-deps GOFLAGS=-race &> artifacts/race-c-build.log || (cat artifacts/race-c-build.log && false)
+rm artifacts/race-c-build.log
 tc_end_block "Compile C dependencies"
 
 tc_start_block "Run Go tests under race detector"


### PR DESCRIPTION
(this PR is just to trigger CI and see if/how much of a difference this makes, at which point can evaluate if it is actually something we want to do).

cmake output is pretty verbose and unless it fails it is entirely uninteresting noise.

The noise makes digging though CI logs (to find actual failures) more difficult, while also likely slowing down the overall build itself given our past experiences with TeamCity's output handling performance.

Release note: none