### PR TITLE
*: make CI logs quieter

### DIFF
--- a/build/teamcity-acceptance.sh
+++ b/build/teamcity-acceptance.sh
@@ -16,7 +16,9 @@ type=$(go env GOOS)
 tc_end_block "Prepare environment for acceptance tests"
 
 tc_start_block "Compile CockroachDB"
-run pkg/acceptance/prepare.sh
+# Buffer noisy output and only print it on failure.
+run pkg/acceptance/prepare.sh &> artifacts/acceptance-compile.log || (cat artifacts/acceptance-compile.log && false)
+rm artifacts/acceptance-compile.log
 run ln -s cockroach-linux-2.6.32-gnu-amd64 cockroach  # For the tests that run without Docker.
 tc_end_block "Compile CockroachDB"
 

--- a/build/teamcity-bench.sh
+++ b/build/teamcity-bench.sh
@@ -10,7 +10,9 @@ export TMPDIR=$PWD/artifacts/bench
 mkdir -p "$TMPDIR"
 
 tc_start_block "Compile C dependencies"
-run build/builder.sh make -Otarget c-deps
+# Buffer noisy output and only print it on failure.
+run build/builder.sh make -Otarget c-deps &> artifacts/bench-c-build.log || (cat artifacts/bench-c-build.log && false)
+rm artifacts/bench-c-build.log
 tc_end_block "Compile C dependencies"
 
 tc_start_block "Run Benchmarks"

--- a/build/teamcity-build-test-binary.sh
+++ b/build/teamcity-build-test-binary.sh
@@ -10,6 +10,8 @@ source "$(dirname "${0}")/teamcity-support.sh"
 tc_prepare
 
 tc_start_block "Build test binary"
-run build/builder.sh mkrelease linux-gnu -Otarget
+# Buffer noisy output and only print it on failure.
+run build/builder.sh mkrelease linux-gnu -Otarget &> artifacts/build-binary.log || (cat artifacts/build-binary.log && false)
+rm artifacts/build-binary.log
 run mv cockroach-linux-2.6.32-gnu-amd64 artifacts/cockroach
 tc_end_block "Build test binary"

--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -12,7 +12,9 @@ run build/builder.sh env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" TARGET=checkdeps g
 tc_end_block "Ensure dependencies are up-to-date"
 
 tc_start_block "Ensure generated code is up-to-date"
-run build/builder.sh make generate buildshort
+# Buffer noisy output and only print it on failure.
+run build/builder.sh make generate buildshort &> artifacts/generate.log || (cat artifacts/generate.log && false)
+rm artifacts/generate.log
 # The workspace is clean iff `git status --porcelain` produces no output. Any
 # output is either an error message or a listing of an untracked/dirty file.
 if [[ "$(git status --porcelain 2>&1)" != "" ]]; then

--- a/build/teamcity-local-roachtest.sh
+++ b/build/teamcity-local-roachtest.sh
@@ -12,7 +12,9 @@ maybe_ccache
 tc_end_block "Prepare environment"
 
 tc_start_block "Compile CockroachDB"
-run build/builder.sh make build
+# Buffer noisy output and only print it on failure.
+run build/builder.sh make build &> artifacts/roachtests-compile.log || (cat artifacts/roachtests-compile.log && false)
+rm artifacts/roachtests-compile.log
 tc_end_block "Compile CockroachDB"
 
 tc_start_block "Compile roachprod/workload/roachtest"

--- a/build/teamcity-testrace.sh
+++ b/build/teamcity-testrace.sh
@@ -9,11 +9,6 @@ tc_prepare
 export TMPDIR=$PWD/artifacts/testrace
 mkdir -p "$TMPDIR"
 
-tc_start_block "Maybe stressrace pull request"
-build/builder.sh go install ./pkg/cmd/github-pull-request-make
-build/builder.sh env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" TARGET=stressrace github-pull-request-make
-tc_end_block "Maybe stressrace pull request"
-
 tc_start_block "Determine changed packages"
 if tc_release_branch; then
 	pkgspec=./pkg/...
@@ -36,8 +31,15 @@ fi
 tc_end_block "Determine changed packages"
 
 tc_start_block "Compile C dependencies"
-run build/builder.sh make -Otarget c-deps GOFLAGS=-race
+# Buffer noisy output and only print it on failure.
+run build/builder.sh make -Otarget c-deps GOFLAGS=-race &> artifacts/race-c-build.log || (cat artifacts/race-c-build.log && false)
+rm artifacts/race-c-build.log
 tc_end_block "Compile C dependencies"
+
+tc_start_block "Maybe stressrace pull request"
+build/builder.sh go install ./pkg/cmd/github-pull-request-make
+build/builder.sh env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" TARGET=stressrace github-pull-request-make
+tc_end_block "Maybe stressrace pull request"
 
 tc_start_block "Run Go tests under race detector"
 true >artifacts/testrace.log

--- a/build/teamcity-verify-archive.sh
+++ b/build/teamcity-verify-archive.sh
@@ -16,7 +16,9 @@ fi
 tc_end_block "Check build tag"
 
 tc_start_block "Build archive"
-run build/builder.sh make archive -Otarget ARCHIVE=build/cockroach.src.tgz
+# Buffer noisy output and only print it on failure.
+run build/builder.sh make archive -Otarget ARCHIVE=build/cockroach.src.tgz &> artifacts/build-archive.log || (cat artifacts/build-archive.log && false)
+rm artifacts/build-archive.log
 tc_end_block "Build archive"
 
 tc_start_block "Test archive"


### PR DESCRIPTION
CI logs are hovering around 35mb or more on recent test runs. These can be painful to dig though, and we've seen in the past that TeamCity is very slow at handling logging output (in that it actually slows the build time down if a build logs more).

The single biggest change here is that c-deps compilation output is redirected into a file, which is only printed to the collected log when compilation fails. In the common case where rarely changed c-deps are just being recompiled repeatedly, this likely means we don't log any of the noisy cmake output to the collected logs at all, but if anything does go wrong, we should still have all the same output as before.

This same pattern is used in the other builds that build some binary or dependencies before then running their tests.