### PR TITLE
release-19.1: sql: run deleteRange queries in batches

### DIFF
--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -19,11 +19,11 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/pkg/errors"
 )
 
 // deleteRangeNode implements DELETE on a primary index satisfying certain
@@ -37,8 +37,6 @@ type deleteRangeNode struct {
 	spans roachpb.Spans
 	// desc is the table descriptor the delete is operating on.
 	desc *sqlbase.ImmutableTableDescriptor
-	// tableWriter orchestrates the deletion operation itself.
-	tableWriter tableWriterBase
 	// fetcher is around to decode the returned keys from the DeleteRange, so that
 	// we can count the number of rows deleted.
 	fetcher row.Fetcher
@@ -156,45 +154,54 @@ func (d *deleteRangeNode) startExec(params runParams) error {
 		}); err != nil {
 		return err
 	}
-	d.tableWriter.init(params.p.txn)
 	if d.interleavedFastPath {
 		for i := range d.spans {
 			d.spans[i].EndKey = d.spans[i].EndKey.PrefixEnd()
 		}
 	}
 	ctx := params.ctx
+	log.VEvent(ctx, 2, "fast delete: skipping scan")
 	traceKV := params.p.ExtendedEvalContext().Tracing.KVTracingEnabled()
-	for _, span := range d.spans {
-		log.VEvent(ctx, 2, "fast delete: skipping scan")
-		if traceKV {
-			log.VEventf(ctx, 2, "DelRange %s - %s", span.Key, span.EndKey)
+	spans := make([]roachpb.Span, len(d.spans))
+	copy(spans, d.spans)
+	for len(spans) != 0 {
+		b := params.p.txn.NewBatch()
+		for _, span := range spans {
+			if traceKV {
+				log.VEventf(ctx, 2, "DelRange %s - %s", span.Key, span.EndKey)
+			}
+			b.DelRange(span.Key, span.EndKey, true /* returnKeys */)
 		}
-		d.tableWriter.b.DelRange(span.Key, span.EndKey, true /* returnKeys */)
-	}
+		b.Header.MaxSpanRequestKeys = TableTruncateChunkSize
 
-	if err := d.tableWriter.finalize(ctx, d.desc); err != nil {
-		return err
-	}
+		if err := params.p.txn.Run(ctx, b); err != nil {
+			return err
+		}
 
-	for _, r := range d.tableWriter.b.Results {
-		var prev []byte
-		for _, i := range r.Keys {
-			// If prefix is same, don't bother decoding key.
-			if len(prev) > 0 && bytes.HasPrefix(i, prev) {
-				continue
-			}
+		spans = spans[:0]
+		for _, r := range b.Results {
+			var prev []byte
+			for _, keyBytes := range r.Keys {
+				// If prefix is same, don't bother decoding key.
+				if len(prev) > 0 && bytes.HasPrefix(keyBytes, prev) {
+					continue
+				}
 
-			after, ok, err := d.fetcher.ReadIndexKey(i)
-			if err != nil {
-				return err
+				after, ok, err := d.fetcher.ReadIndexKey(keyBytes)
+				if err != nil {
+					return err
+				}
+				if !ok {
+					return pgerror.NewAssertionErrorf("key did not match descriptor")
+				}
+				k := keyBytes[:len(keyBytes)-len(after)]
+				if !bytes.Equal(k, prev) {
+					prev = k
+					d.rowCount++
+				}
 			}
-			if !ok {
-				return errors.Errorf("key did not match descriptor")
-			}
-			k := i[:len(i)-len(after)]
-			if !bytes.Equal(k, prev) {
-				prev = k
-				d.rowCount++
+			if r.ResumeSpan.Valid() {
+				spans = append(spans, r.ResumeSpan)
 			}
 		}
 	}
@@ -220,5 +227,7 @@ func (*deleteRangeNode) Close(ctx context.Context) {}
 
 // enableAutoCommit implements the autoCommitNode interface.
 func (d *deleteRangeNode) enableAutoCommit() {
-	d.tableWriter.enableAutoCommit()
+	// DeleteRange can't autocommit, because it has to delete in batches, and it
+	// won't know whether or not there is more work to do until after a batch is
+	// returned. This property precludes using auto commit.
 }

--- a/pkg/sql/logictest/testdata/planner_test/delete_range
+++ b/pkg/sql/logictest/testdata/planner_test/delete_range
@@ -1,0 +1,19 @@
+# LogicTest: local
+
+statement ok
+CREATE TABLE a (a INT PRIMARY KEY)
+
+# Delete range operates in chunks of 600 (defined by sql.TableTruncateChunkSize).
+statement ok
+INSERT INTO a SELECT * FROM generate_series(1,1000)
+
+statement ok
+SET tracing = on,kv; DELETE FROM a; SET tracing = off
+
+# Ensure that DelRange requests are chunked for DELETE FROM...
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%DelRange%'
+----
+flow                 DelRange /Table/53/1 - /Table/53/2
+flow                 DelRange /Table/53/1/601/0 - /Table/53/2

--- a/pkg/sql/logictest/testdata/planner_test/interleaved
+++ b/pkg/sql/logictest/testdata/planner_test/interleaved
@@ -243,9 +243,11 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION]
 ----
 DelRange /Table/61/1/5 - /Table/61/1/7/NULL
 querying next range at /Table/61/1/5
-r20: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
+r20: sending batch 1 DelRng to (n1,s1):1
 fast path completed
 rows affected: 3
+querying next range at /Table/61/1/5
+r20: sending batch 1 EndTxn to (n1,s1):1
 
 query II colnames
 select * from b order by a_id, b_id
@@ -285,9 +287,11 @@ select message FROM [SHOW KV TRACE FOR SESSION]
 ----
 DelRange /Table/61/1 - /Table/61/3
 querying next range at /Table/61/1
-r20: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
+r20: sending batch 1 DelRng to (n1,s1):1
 fast path completed
 rows affected: 5
+querying next range at /Table/61/1
+r20: sending batch 1 EndTxn to (n1,s1):1
 
 query II colnames
 select * from b order by a_id, b_id

--- a/pkg/sql/opt/exec/execbuilder/testdata/interleaved
+++ b/pkg/sql/opt/exec/execbuilder/testdata/interleaved
@@ -243,9 +243,11 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION]
 ----
 DelRange /Table/61/1/5 - /Table/61/1/7/NULL
 querying next range at /Table/61/1/5
-r20: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
+r20: sending batch 1 DelRng to (n1,s1):1
 fast path completed
 rows affected: 3
+querying next range at /Table/61/1/5
+r20: sending batch 1 EndTxn to (n1,s1):1
 
 query II colnames
 select * from b order by a_id, b_id
@@ -285,9 +287,11 @@ select message FROM [SHOW KV TRACE FOR SESSION]
 ----
 DelRange /Table/61/1 - /Table/61/3
 querying next range at /Table/61/1
-r20: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
+r20: sending batch 1 DelRng to (n1,s1):1
 fast path completed
 rows affected: 5
+querying next range at /Table/61/1
+r20: sending batch 1 EndTxn to (n1,s1):1
 
 query II colnames
 select * from b order by a_id, b_id

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -87,7 +87,10 @@ type tableWriter interface {
 
 type autoCommitOpt int
 
-const autoCommitEnabled autoCommitOpt = 1
+const (
+	_                 autoCommitOpt = 0
+	autoCommitEnabled autoCommitOpt = 1
+)
 
 // extendedTableWriter is a temporary interface introduced
 // until all the tableWriters implement it. When that is achieved, it will be merged into

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -205,30 +205,6 @@ func TestTrace(t *testing.T) {
 				"noop",
 			},
 		},
-		{
-			name: "ShowTraceForSplitBatch",
-			getRows: func(_ *testing.T, sqlDB *gosql.DB) (*gosql.Rows, error) {
-				if _, err := sqlDB.Exec("SET distsql = off"); err != nil {
-					t.Fatal(err)
-				}
-
-				// Deleting from a multi-range table will result in a 2PC transaction
-				// and will split the underlying BatchRequest/BatchResponse. Tracing
-				// in the presence of multi-part batches is what we want to test here.
-				if _, err := sqlDB.Exec("SET tracing = on; DELETE FROM test.bar; SET tracing = off"); err != nil {
-					t.Fatal(err)
-				}
-
-				return sqlDB.Query(
-					"SELECT DISTINCT operation AS op FROM [SHOW TRACE FOR SESSION] " +
-						"WHERE message LIKE '%1 DelRng%' ORDER BY op")
-			},
-			expSpans: []string{
-				"dist sender send",
-				"kv.DistSender: sending partial batch",
-				"/cockroach.roachpb.Internal/Batch",
-			},
-		},
 	}
 
 	// Create a cluster. We'll run sub-tests using each node of this cluster.


### PR DESCRIPTION
Backport 1/1 commits from #36728.

Fixes #39671.

/cc @cockroachdb/release

---

Fixes #36588.

Previously, a query like `DELETE FROM t` that uses a deleteRangeNode
under the hood would attempt to send a single `DelRange` request for
each span it was responsible for deleting. This led to unlimited memory
usage, since the `DelRange` request must return the keys it deleted in
this context so SQL can know how many rows were affected.

To solve this problem, we send `DelRange` requests with a returned-key
limit in a loop until the range is fully deleted.

Release note (bug fix): prevent unlimited memory usage during SQL range
deletions
