### PR TITLE
bulk: Add metrics to bulk mem monitor for better visualisation

### DIFF
--- a/pkg/storage/bulk/bulk_metrics.go
+++ b/pkg/storage/bulk/bulk_metrics.go
@@ -1,0 +1,56 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package bulk
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+)
+
+// Metrics contains pointers to the metrics for
+// monitoring bulk operations.
+type Metrics struct {
+	MaxBytesHist  *metric.Histogram
+	CurBytesCount *metric.Gauge
+}
+
+// MetricStruct implements the metrics.Struct interface.
+func (Metrics) MetricStruct() {}
+
+var _ metric.Struct = Metrics{}
+
+var (
+	metaMemMaxBytes = metric.Metadata{
+		Name:        "sql.mem.bulk.max",
+		Help:        "Memory usage per sql statement for bulk operations",
+		Measurement: "Memory",
+		Unit:        metric.Unit_BYTES,
+	}
+	metaMemCurBytes = metric.Metadata{
+		Name:        "sql.mem.bulk.current",
+		Help:        "Current sql statement memory usage for bulk operations",
+		Measurement: "Memory",
+		Unit:        metric.Unit_BYTES,
+	}
+)
+
+// See pkg/sql/mem_metrics.go
+// log10int64times1000 = log10(math.MaxInt64) * 1000, rounded up somewhat
+const log10int64times1000 = 19 * 1000
+
+// MakeBulkMetrics instantiates the metrics holder for bulk operation monitoring.
+func MakeBulkMetrics(histogramWindow time.Duration) Metrics {
+	return Metrics{
+		MaxBytesHist:  metric.NewHistogram(metaMemMaxBytes, histogramWindow, log10int64times1000, 3),
+		CurBytesCount: metric.NewGauge(metaMemCurBytes),
+	}
+}

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1375,6 +1375,19 @@ var charts = []sectionDescription{
 		},
 	},
 	{
+		Organization: [][]string{{SQLLayer, "Bulk"}},
+		Charts: []chartDescription{
+			{
+				Title:   "Current Memory Usage",
+				Metrics: []string{"sql.mem.bulk.current"},
+			},
+			{
+				Title:   "Memory Usage per Statement",
+				Metrics: []string{"sql.mem.bulk.max"},
+			},
+		},
+	},
+	{
 		Organization: [][]string{{SQLLayer, "Optimizer"}},
 		Charts: []chartDescription{
 			{

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -215,8 +215,13 @@ type BytesMonitor struct {
 	// become reported in the logs.
 	noteworthyUsageBytes int64
 
+	// curBytesCount is the metric object used to track number of bytes reserved
+	// by the monitor during its lifetime.
 	curBytesCount *metric.Gauge
-	maxBytesHist  *metric.Histogram
+
+	// maxBytesHist is the metric object used to track the high watermark of bytes
+	// allocated by the monitor during its lifetime.
+	maxBytesHist *metric.Histogram
 
 	settings *cluster.Settings
 }
@@ -426,6 +431,12 @@ func (mm *BytesMonitor) AllocBytes() int64 {
 	mm.mu.Lock()
 	defer mm.mu.Unlock()
 	return mm.mu.curAllocated
+}
+
+// SetMetrics sets the metric objects for the monitor.
+func (mm *BytesMonitor) SetMetrics(curCount *metric.Gauge, maxHist *metric.Histogram) {
+	mm.curBytesCount = curCount
+	mm.maxBytesHist = maxHist
 }
 
 // BoundAccount tracks the cumulated allocations for one client of a pool or


### PR DESCRIPTION
This change reworks how we want to use memory monitors for bulk
operations.

We have a single `bulkMonitor` which is a child of the
root sql memory monitor. Each bulk operation will further create a
child of the `bulkMonitor` which will be used to control memory
growth of the bulk adder.
A new class of metrics has been hooked up to the `bulkMonitor`
which allows for visualization of total memory usage in the
admin UI.

Release note: None