### PR TITLE
storage/engine: Use pebble.Batch to build/iterate over RocksDB batches

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1319,7 +1319,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:734e71eca8396da1dfe9c6d6331c9b85dc1a8119ddbc7ebb29c224824f52033a"
+  digest = "1:b70a442c8948d6a72c8bbc39c61a07b0c6513f7ce854abcda975de319bab2692"
   name = "github.com/petermattis/pebble"
   packages = [
     ".",
@@ -1338,7 +1338,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "eb27354f6b1a03c0e197d9475c8527a801e79103"
+  revision = "213fac439da9e95051ccc2c17279574e80a59c8c"
 
 [[projects]]
   digest = "1:e39a5ee8fcbec487f8fc68863ef95f2b025e0739b0e4aa55558a2b4cf8f0ecf0"

--- a/pkg/storage/engine/batch.go
+++ b/pkg/storage/engine/batch.go
@@ -12,10 +12,10 @@ package engine
 
 import (
 	"encoding/binary"
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/petermattis/pebble"
 	"github.com/pkg/errors"
 )
 
@@ -48,11 +48,9 @@ const (
 const (
 	// The batch header is composed of an 8-byte sequence number (all zeroes) and
 	// 4-byte count of the number of entries in the batch.
-	headerSize           int = 12
-	countPos                 = 8
-	initialBatchSize         = 1 << 10 // 1 KB
-	maxRetainedBatchSize     = 1 << 20 // 1 MB
-	maxVarintLen32           = 5
+	headerSize       int = 12
+	countPos             = 8
+	initialBatchSize     = 1 << 10 // 1 KB
 )
 
 // RocksDBBatchBuilder is used to construct the RocksDB batch representation.
@@ -87,31 +85,12 @@ const (
 // Note that the encoding of these keys needs to match up with the encoding in
 // rocksdb/db.cc:EncodeKey().
 type RocksDBBatchBuilder struct {
-	repr    []byte
-	count   int
+	batch   pebble.Batch
 	logData bool
 }
 
-func (b *RocksDBBatchBuilder) maybeInit() {
-	if b.repr == nil {
-		b.repr = make([]byte, headerSize, initialBatchSize)
-	}
-}
-
 func (b *RocksDBBatchBuilder) reset() {
-	if b.repr != nil {
-		if cap(b.repr) > maxRetainedBatchSize {
-			// If the capacity of the buffer is larger than our maximum
-			// retention size, don't re-use it. Let it be GC-ed instead.
-			// This prevents the memory from an unusually large batch from
-			// being held on to indefinitely.
-			b.repr = nil
-		} else {
-			// Otherwise, reset the buffer for re-use.
-			b.repr = b.repr[:headerSize]
-		}
-	}
-	b.count = 0
+	b.batch.Reset()
 	b.logData = false
 }
 
@@ -119,55 +98,22 @@ func (b *RocksDBBatchBuilder) reset() {
 // the builder may be used to construct another batch, but the returned []byte
 // is only valid until the next builder method is called.
 func (b *RocksDBBatchBuilder) Finish() []byte {
-	repr := b.getRepr()
-	b.repr = b.repr[:headerSize]
-	b.count = 0
-	b.logData = false
+	repr := b.batch.Repr()
+	b.reset()
+
 	return repr
 }
 
 // Len returns the number of bytes currently in the under construction repr.
 func (b *RocksDBBatchBuilder) Len() int {
-	return len(b.repr)
+	return len(b.batch.Repr())
 }
 
 var _ = (*RocksDBBatchBuilder).Len
 
 // getRepr constructs the batch representation and returns it.
 func (b *RocksDBBatchBuilder) getRepr() []byte {
-	b.maybeInit()
-	buf := b.repr[countPos:headerSize]
-	v := uint32(b.count)
-	buf[0] = byte(v)
-	buf[1] = byte(v >> 8)
-	buf[2] = byte(v >> 16)
-	buf[3] = byte(v >> 24)
-	return b.repr
-}
-
-func (b *RocksDBBatchBuilder) grow(n int) {
-	newSize := len(b.repr) + n
-	if newSize > cap(b.repr) {
-		newCap := 2 * cap(b.repr)
-		for newCap < newSize {
-			newCap *= 2
-		}
-		newRepr := make([]byte, len(b.repr), newCap)
-		copy(newRepr, b.repr)
-		b.repr = newRepr
-	}
-	b.repr = b.repr[:newSize]
-}
-
-func putUvarint32(buf []byte, x uint32) int {
-	i := 0
-	for x >= 0x80 {
-		buf[i] = byte(x) | 0x80
-		x >>= 7
-		i++
-	}
-	buf[i] = byte(x)
-	return i + 1
+	return b.batch.Repr()
 }
 
 func putUint32(b []byte, v uint32) {
@@ -188,61 +134,14 @@ func putUint64(b []byte, v uint64) {
 	b[7] = byte(v)
 }
 
-// encodeKey encodes an MVCC key into the batch, reserving extra bytes in
-// b.repr for use in encoding a value as well. This encoding must match with
-// the encoding in engine/db.cc:EncodeKey().
-func (b *RocksDBBatchBuilder) encodeKey(key MVCCKey, extra int) {
-	length := 1 + len(key.Key)
-	timestampLength := 0
-	if key.Timestamp != (hlc.Timestamp{}) {
-		timestampLength = 1 + 8
-		if key.Timestamp.Logical != 0 {
-			timestampLength += 4
-		}
-	}
-	length += timestampLength
-
-	pos := 1 + len(b.repr)
-	b.grow(1 + maxVarintLen32 + length + extra)
-	n := putUvarint32(b.repr[pos:], uint32(length))
-	b.repr = b.repr[:len(b.repr)-(maxVarintLen32-n)]
-	pos += n
-	copy(b.repr[pos:], key.Key)
-	if timestampLength > 0 {
-		pos += len(key.Key)
-		b.repr[pos] = 0
-		pos++
-		putUint64(b.repr[pos:], uint64(key.Timestamp.WallTime))
-		if key.Timestamp.Logical != 0 {
-			pos += 8
-			putUint32(b.repr[pos:], uint32(key.Timestamp.Logical))
-		}
-	}
-	b.repr[len(b.repr)-1-extra] = byte(timestampLength)
-}
-
-func (b *RocksDBBatchBuilder) encodeKeyValue(key MVCCKey, value []byte, tag BatchType) {
-	b.maybeInit()
-	b.count++
-
-	l := uint32(len(value))
-	extra := int(l) + maxVarintLen32
-
-	pos := len(b.repr)
-	b.encodeKey(key, extra)
-	b.repr[pos] = byte(tag)
-
-	pos = len(b.repr) - extra
-	n := putUvarint32(b.repr[pos:], l)
-	b.repr = b.repr[:len(b.repr)-(maxVarintLen32-n)]
-	copy(b.repr[pos+n:], value)
-}
-
 // Put sets the given key to the value provided.
 //
 // It is safe to modify the contents of the arguments after Put returns.
 func (b *RocksDBBatchBuilder) Put(key MVCCKey, value []byte) {
-	b.encodeKeyValue(key, value, BatchTypeValue)
+	deferredOp, _ := b.batch.SetDeferred(key.Len(), len(value), nil)
+	EncodeKeyToBuf(deferredOp.Key, key)
+	copy(deferredOp.Value, value)
+	deferredOp.Finish()
 }
 
 // Merge is a high-performance write operation used for values which are
@@ -252,29 +151,28 @@ func (b *RocksDBBatchBuilder) Put(key MVCCKey, value []byte) {
 //
 // It is safe to modify the contents of the arguments after Merge returns.
 func (b *RocksDBBatchBuilder) Merge(key MVCCKey, value []byte) {
-	b.encodeKeyValue(key, value, BatchTypeMerge)
+	deferredOp, _ := b.batch.MergeDeferred(key.Len(), len(value), nil)
+	EncodeKeyToBuf(deferredOp.Key, key)
+	copy(deferredOp.Value, value)
+	deferredOp.Finish()
 }
 
 // Clear removes the item from the db with the given key.
 //
 // It is safe to modify the contents of the arguments after Clear returns.
 func (b *RocksDBBatchBuilder) Clear(key MVCCKey) {
-	b.maybeInit()
-	b.count++
-	pos := len(b.repr)
-	b.encodeKey(key, 0)
-	b.repr[pos] = byte(BatchTypeDeletion)
+	deferredOp, _ := b.batch.DeleteDeferred(key.Len(), nil)
+	EncodeKeyToBuf(deferredOp.Key, key)
+	deferredOp.Finish()
 }
 
 // SingleClear removes the most recent item from the db with the given key.
 //
 // It is safe to modify the contents of the arguments after SingleClear returns.
 func (b *RocksDBBatchBuilder) SingleClear(key MVCCKey) {
-	b.maybeInit()
-	b.count++
-	pos := len(b.repr)
-	b.encodeKey(key, 0)
-	b.repr[pos] = byte(BatchTypeSingleDeletion)
+	// TODO(itsbilal): When pebble.Batch supports SingleDelete, use that instead.
+	// Until then, alias this operation to regular Delete.
+	b.Clear(key)
 }
 
 // LogData adds a blob of log data to the batch. It will be written to the WAL,
@@ -282,16 +180,8 @@ func (b *RocksDBBatchBuilder) SingleClear(key MVCCKey) {
 //
 // It is safe to modify the contents of the arguments after LogData returns.
 func (b *RocksDBBatchBuilder) LogData(data []byte) {
-	b.maybeInit()
+	_ = b.batch.LogData(data, nil)
 	b.logData = true
-	pos := len(b.repr)
-	b.grow(1 + maxVarintLen32 + len(data))
-	b.repr[pos] = byte(BatchTypeLogData)
-	pos++
-	n := putUvarint32(b.repr[pos:], uint32(len(data)))
-	b.repr = b.repr[:len(b.repr)-(maxVarintLen32-n)]
-	pos += n
-	copy(b.repr[pos:], data)
 }
 
 // ApplyRepr applies the mutations in repr to the current batch.
@@ -299,16 +189,17 @@ func (b *RocksDBBatchBuilder) LogData(data []byte) {
 // It is safe to modify the contents of the arguments after ApplyRepr
 // returns.
 func (b *RocksDBBatchBuilder) ApplyRepr(repr []byte) error {
-	if len(repr) < headerSize {
-		return errors.Errorf("batch repr too small: %d < %d", len(repr), headerSize)
+	b2 := &pebble.Batch{}
+	if err := b2.SetRepr(repr); err != nil {
+		return err
 	}
-	b.maybeInit()
-	pos := len(b.repr)
-	data := repr[headerSize:]
-	b.grow(len(data))
-	copy(b.repr[pos:], data)
-	b.count += int(binary.LittleEndian.Uint32(repr[countPos:headerSize]))
-	return nil
+
+	return b.batch.Apply(b2, nil)
+}
+
+// Count returns the count of memtable-modifying operations in this batch.
+func (b *RocksDBBatchBuilder) Count() uint32 {
+	return b.batch.Count()
 }
 
 // EncodeKey encodes an engine.MVCC key into the RocksDB representation. This
@@ -371,7 +262,7 @@ func DecodeMVCCKey(encodedKey []byte) (MVCCKey, error) {
 
 // Decode the header of RocksDB batch repr, returning both the count of the
 // entries in the batch and the suffix of data remaining in the batch.
-func rocksDBBatchDecodeHeader(repr []byte) (count int, orepr []byte, err error) {
+func rocksDBBatchDecodeHeader(repr []byte) (count int, orepr pebble.BatchReader, err error) {
 	if len(repr) < headerSize {
 		return 0, nil, errors.Errorf("batch repr too small: %d < %d", len(repr), headerSize)
 	}
@@ -380,25 +271,7 @@ func rocksDBBatchDecodeHeader(repr []byte) (count int, orepr []byte, err error) 
 		return 0, nil, errors.Errorf("bad sequence: expected 0, but found %d", seq)
 	}
 	count = int(binary.LittleEndian.Uint32(repr[countPos:headerSize]))
-	return count, repr[headerSize:], nil
-}
-
-// Decode a RocksDB batch repr variable length string, returning both the
-// string and the suffix of data remaining in the batch.
-func rocksDBBatchVarString(repr []byte) (s []byte, orepr []byte, err error) {
-	v, n := binary.Uvarint(repr)
-	if n <= 0 {
-		return nil, nil, fmt.Errorf("unable to decode uvarint")
-	}
-	repr = repr[n:]
-	if v == 0 {
-		return nil, repr, nil
-	}
-	if v > uint64(len(repr)) {
-		return nil, nil, fmt.Errorf("malformed varstring, expected %d bytes, but only %d remaining",
-			v, len(repr))
-	}
-	return repr[:v], repr[v:], nil
+	return count, pebble.MakeBatchReader(repr), nil
 }
 
 // RocksDBBatchReader is used to iterate the entries in a RocksDB batch
@@ -427,7 +300,7 @@ func rocksDBBatchVarString(repr []byte) (s []byte, orepr []byte, err error) {
 //   return err
 // }
 type RocksDBBatchReader struct {
-	repr []byte
+	batchReader pebble.BatchReader
 
 	// The error encountered during iterator, if any
 	err error
@@ -438,21 +311,19 @@ type RocksDBBatchReader struct {
 	// The following all represent the current entry and are updated by Next.
 	// `value` is not applicable for BatchTypeDeletion or BatchTypeSingleDeletion.
 	// `value` indicates the end key for BatchTypeRangeDeletion.
-	offset int
-	typ    BatchType
-	key    []byte
-	value  []byte
+	typ   BatchType
+	key   []byte
+	value []byte
 }
 
 // NewRocksDBBatchReader creates a RocksDBBatchReader from the given repr and
 // verifies the header.
 func NewRocksDBBatchReader(repr []byte) (*RocksDBBatchReader, error) {
-	count, repr, err := rocksDBBatchDecodeHeader(repr)
+	count, batchReader, err := rocksDBBatchDecodeHeader(repr)
 	if err != nil {
 		return nil, err
 	}
-	// Set offset to -1 so the first call to Next will increment it to 0.
-	return &RocksDBBatchReader{repr: repr, count: count, offset: -1}, nil
+	return &RocksDBBatchReader{batchReader: batchReader, count: count}, nil
 }
 
 // Count returns the declared number of entries in the batch.
@@ -505,44 +376,13 @@ func (r *RocksDBBatchReader) MVCCEndKey() (MVCCKey, error) {
 // Next advances to the next entry in the batch, returning false when the batch
 // is empty.
 func (r *RocksDBBatchReader) Next() bool {
-	if r.err != nil {
-		return false
-	}
+	kind, ukey, value, ok := r.batchReader.Next()
 
-	r.offset++
-	if len(r.repr) == 0 {
-		if r.offset < r.count {
-			r.err = errors.Errorf("invalid batch: expected %d entries but found %d", r.count, r.offset)
-		}
-		return false
-	}
+	r.typ = BatchType(kind)
+	r.key = ukey
+	r.value = value
 
-	r.typ = BatchType(r.repr[0])
-	r.repr = r.repr[1:]
-	switch r.typ {
-	case BatchTypeDeletion, BatchTypeSingleDeletion:
-		if r.key, r.err = r.varstring(); r.err != nil {
-			return false
-		}
-	case BatchTypeValue, BatchTypeMerge, BatchTypeRangeDeletion:
-		if r.key, r.err = r.varstring(); r.err != nil {
-			return false
-		}
-		if r.value, r.err = r.varstring(); r.err != nil {
-			return false
-		}
-	default:
-		r.err = errors.Errorf("unexpected type %d", r.typ)
-		return false
-	}
-	return true
-}
-
-func (r *RocksDBBatchReader) varstring() ([]byte, error) {
-	var s []byte
-	var err error
-	s, r.repr, err = rocksDBBatchVarString(r.repr)
-	return s, err
+	return ok
 }
 
 // RocksDBBatchCount provides an efficient way to get the count of mutations

--- a/pkg/storage/engine/batch_test.go
+++ b/pkg/storage/engine/batch_test.go
@@ -302,12 +302,14 @@ func TestBatchRepr(t *testing.T) {
 
 		// The keys in the batch have the internal MVCC encoding applied which for
 		// this test implies an appended 0 byte.
+		// TODO(itsbilal): Treat SingleDeletions as Deletions until pebble.Batch
+		// works with SingleDelete.
 		expOps := []string{
 			"put(a\x00,value)",
 			"delete(b\x00)",
 			"merge(c\x00)",
 			"put(e\x00,)",
-			"single_delete(d\x00)",
+			"delete(d\x00)",
 		}
 		if !reflect.DeepEqual(expOps, ops) {
 			t.Fatalf("expected %v, but found %v", expOps, ops)
@@ -786,16 +788,18 @@ func TestBatchBuilder(t *testing.T) {
 		if err := dbClear(batch.batch, key); err != nil {
 			t.Fatal(err)
 		}
-		if err := dbSingleClear(batch.batch, key); err != nil {
-			t.Fatal(err)
-		}
+		// TODO(itsbilal): Uncomment this when pebble.Batch supports SingleDeletion.
+		//if err := dbSingleClear(batch.batch, key); err != nil {
+		//	t.Fatal(err)
+		//}
 		if err := dbMerge(batch.batch, key, appender("bar")); err != nil {
 			t.Fatal(err)
 		}
 
 		builder.Put(key, []byte("value"))
 		builder.Clear(key)
-		builder.SingleClear(key)
+		// TODO(itsbilal): Uncomment this when pebble.Batch supports SingleDeletion.
+		//builder.SingleClear(key)
 		builder.Merge(key, appender("bar"))
 	}
 
@@ -857,10 +861,12 @@ func TestBatchBuilderStress(t *testing.T) {
 					}
 					builder.Clear(key)
 				case 2:
-					if err := dbSingleClear(batch.batch, key); err != nil {
-						t.Fatal(err)
-					}
-					builder.SingleClear(key)
+					// TODO(itsbilal): Don't test SingleClears matching up until
+					// pebble.Batch supports them.
+					//if err := dbSingleClear(batch.batch, key); err != nil {
+					//	t.Fatal(err)
+					//}
+					//builder.SingleClear(key)
 				case 3:
 					if err := dbMerge(batch.batch, key, appender("bar")); err != nil {
 						t.Fatal(err)

--- a/pkg/storage/engine/disk_map.go
+++ b/pkg/storage/engine/disk_map.go
@@ -365,7 +365,8 @@ func (r *pebbleMap) Clear() error {
 	// NB: we manually flush after performing the clear range to ensure that the
 	// range tombstone is pushed to disk which will kick off compactions that
 	// will eventually free up the deleted space.
-	return r.store.AsyncFlush()
+	_, err := r.store.AsyncFlush()
+	return err
 }
 
 // Close implements the SortedDiskMap interface.


### PR DESCRIPTION
We currently manipulate with the RocksDB batch format directly in
Cockroach through RocksDBBatch{Reader, Builder}. pebble.Batch follows
the same binary format, so leverage that code instead of duplicating
it in CockroachDB.

Fixes #39672

Depends on changes in https://github.com/petermattis/pebble/pull/231 .

Release note: None