### PR TITLE
backupccl: fix backup/restore after FK table descriptor changes

### DIFF
--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -540,17 +540,26 @@ func (r BackupFileDescriptors) Less(i, j int) bool {
 
 func writeBackupDescriptor(
 	ctx context.Context,
+	settings *cluster.Settings,
 	exportStore storageccl.ExportStorage,
 	filename string,
 	desc *BackupDescriptor,
 ) error {
 	sort.Sort(BackupFileDescriptors(desc.Files))
 
-	descBuf, err := protoutil.Marshal(desc)
+	// When writing a backup descriptor, make sure to downgrade any new-style FKs
+	// when we're in the 19.1/2 mixed state so that 19.1 clusters can still
+	// restore backups taken on a 19.1/2 mixed cluster.
+	// TODO(lucy, jordan): Remove in 20.1.
+	downgradedDesc, err := maybeDowngradeTableDescsInBackupDescriptor(ctx, settings, desc)
 	if err != nil {
 		return err
 	}
 
+	descBuf, err := protoutil.Marshal(downgradedDesc)
+	if err != nil {
+		return err
+	}
 	return exportStore.WriteFile(ctx, filename, bytes.NewReader(descBuf))
 }
 
@@ -786,7 +795,7 @@ func backup(
 					checkpointMu.Lock()
 					backupDesc.Files = checkpointFiles
 					err := writeBackupDescriptor(
-						ctx, defaultStore, BackupDescriptorCheckpointName, backupDesc,
+						ctx, settings, defaultStore, BackupDescriptorCheckpointName, backupDesc,
 					)
 					checkpointMu.Unlock()
 					if err != nil {
@@ -847,7 +856,7 @@ func backup(
 		}
 	}
 
-	if err := writeBackupDescriptor(ctx, defaultStore, BackupDescriptorName, backupDesc); err != nil {
+	if err := writeBackupDescriptor(ctx, settings, defaultStore, BackupDescriptorName, backupDesc); err != nil {
 		return mu.exported, err
 	}
 
@@ -877,7 +886,10 @@ func sanitizeLocalityKV(kv string) string {
 // clean up the written checkpoint file (BackupDescriptorCheckpointName) only
 // after writing to the backup file location (BackupDescriptorName).
 func VerifyUsableExportTarget(
-	ctx context.Context, exportStore storageccl.ExportStorage, readable string,
+	ctx context.Context,
+	settings *cluster.Settings,
+	exportStore storageccl.ExportStorage,
+	readable string,
 ) error {
 	if r, err := exportStore.ReadFile(ctx, BackupDescriptorName); err == nil {
 		// TODO(dt): If we audit exactly what not-exists error each ExportStorage
@@ -894,7 +906,7 @@ func VerifyUsableExportTarget(
 			readable, BackupDescriptorCheckpointName)
 	}
 	if err := writeBackupDescriptor(
-		ctx, exportStore, BackupDescriptorCheckpointName, &BackupDescriptor{},
+		ctx, settings, exportStore, BackupDescriptorCheckpointName, &BackupDescriptor{},
 	); err != nil {
 		return errors.Wrapf(err, "cannot write to %s", readable)
 	}
@@ -1028,6 +1040,12 @@ func backupPlanHook(
 			clusterID := p.ExecCfg().ClusterID()
 			prevBackups = make([]BackupDescriptor, len(incrementalFrom))
 			for i, uri := range incrementalFrom {
+				// TODO(lucy): We may want to upgrade the table descs to the newer
+				// foreign key representation here, in case there are backups from an
+				// older cluster. Keeping the descriptors as they are works for now
+				// since all we need to do is get the past backups' table/index spans,
+				// but it will be safer for future code to avoid having older-style
+				// descriptors around.
 				desc, err := ReadBackupDescriptorFromURI(ctx, uri, p.ExecCfg().Settings)
 				if err != nil {
 					return errors.Wrapf(err, "failed to read backup from %q", uri)
@@ -1170,7 +1188,15 @@ func backupPlanHook(
 			return errors.Errorf("expected backup (along with any previous backups) to cover to %v, not %v", endTime, coveredEnd)
 		}
 
-		descBytes, err := protoutil.Marshal(&backupDesc)
+		// When writing a backup descriptor, make sure to downgrade any new-style FKs
+		// when we're in the 19.1/2 mixed state so that 19.1 clusters can still
+		// restore backups taken on a 19.1/2 mixed cluster.
+		// TODO(lucy, jordan): Remove in 20.1.
+		downgradedBackupDesc, err := maybeDowngradeTableDescsInBackupDescriptor(ctx, p.ExecCfg().Settings, &backupDesc)
+		if err != nil {
+			return err
+		}
+		descBytes, err := protoutil.Marshal(downgradedBackupDesc)
 		if err != nil {
 			return err
 		}
@@ -1182,7 +1208,7 @@ func backupPlanHook(
 
 		// TODO (lucy): For partitioned backups, also add verification for other
 		// stores we are writing to in addition to the default.
-		if err := VerifyUsableExportTarget(ctx, defaultStore, defaultURI); err != nil {
+		if err := VerifyUsableExportTarget(ctx, p.ExecCfg().Settings, defaultStore, defaultURI); err != nil {
 			return err
 		}
 
@@ -1253,6 +1279,10 @@ func (b *backupResumer) Resume(
 		storageByLocalityKV[kv] = &conf
 	}
 	var checkpointDesc *BackupDescriptor
+	// We don't read the table descriptors from the backup descriptor, but
+	// they could be using either the new or the old foreign key
+	// representations. We should just preserve whatever representation the
+	// table descriptors were using and leave them alone.
 	if desc, err := readBackupDescriptor(ctx, defaultStore, BackupDescriptorCheckpointName); err == nil {
 		// If the checkpoint is from a different cluster, it's meaningless to us.
 		// More likely though are dummy/lock-out checkpoints with no ClusterID.
@@ -1458,4 +1488,70 @@ func getURIsByLocalityKV(to []string) (string, map[string]string, error) {
 		return "", nil, errors.Errorf("no default URL provided for partitioned backup")
 	}
 	return defaultURI, urisByLocalityKV, nil
+}
+
+// maybeDowngradeTableDescsInBackupDescriptor returns the backup descriptor
+// with its table descriptors downgraded to the older 19.1-style foreign key
+// representation, if they are not already downgraded, and if the cluster is not
+// fully upgraded to 19.2. It returns a *shallow* copy to avoid mutating the
+// original backup descriptor. This function facilitates writing 19.1-compatible
+// backups when the cluster hasn't been fully upgraded.
+// TODO(lucy, jordan): Remove in 20.1.
+func maybeDowngradeTableDescsInBackupDescriptor(
+	ctx context.Context, settings *cluster.Settings, backupDesc *BackupDescriptor,
+) (*BackupDescriptor, error) {
+	backupDescCopy := &(*backupDesc)
+	// Copy Descriptors so we can return a shallow copy without mutating the slice.
+	copy(backupDescCopy.Descriptors, backupDesc.Descriptors)
+	for i := range backupDesc.Descriptors {
+		if tableDesc := backupDesc.Descriptors[i].GetTable(); tableDesc != nil {
+			downgraded, newDesc, err := tableDesc.MaybeDowngradeForeignKeyRepresentation(ctx, settings)
+			if err != nil {
+				return nil, err
+			}
+			if downgraded {
+				backupDescCopy.Descriptors[i] = *sqlbase.WrapDescriptor(newDesc)
+			}
+		}
+	}
+	return backupDescCopy, nil
+}
+
+// maybeUpgradeTableDescsInBackupDescriptors updates the backup descriptors'
+// table descriptors to use the newer 19.2-style foreign key representation,
+// if they are not already upgraded. This requires resolving cross-table FK
+// references, which is done by looking up all table descriptors across all
+// backup descriptors provided. if skipFKsWithNoMatchingTable is set, FKs whose
+// "other" table is missing from the set provided are omitted during the
+// upgrade, instead of causing an error to be returned.
+func maybeUpgradeTableDescsInBackupDescriptors(
+	ctx context.Context, backupDescs []BackupDescriptor, skipFKsWithNoMatchingTable bool,
+) error {
+	protoGetter := sqlbase.MapProtoGetter{
+		Protos: make(map[interface{}]protoutil.Message),
+	}
+	// Populate the protoGetter with all table descriptors in all backup
+	// descriptors so that they can be looked up.
+	for _, backupDesc := range backupDescs {
+		for _, desc := range backupDesc.Descriptors {
+			if table := desc.GetTable(); table != nil {
+				protoGetter.Protos[string(sqlbase.MakeDescMetadataKey(table.ID))] =
+					sqlbase.WrapDescriptor(protoutil.Clone(table).(*sqlbase.TableDescriptor))
+			}
+		}
+	}
+
+	for i := range backupDescs {
+		backupDesc := &backupDescs[i]
+		for j := range backupDesc.Descriptors {
+			if table := backupDesc.Descriptors[j].GetTable(); table != nil {
+				if _, err := table.MaybeUpgradeForeignKeyRepresentation(ctx, protoGetter, skipFKsWithNoMatchingTable); err != nil {
+					return err
+				}
+				// TODO(lucy): Is this necessary?
+				backupDesc.Descriptors[j] = *sqlbase.WrapDescriptor(table)
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -70,6 +70,13 @@ func showBackupPlanHook(
 		if err != nil {
 			return err
 		}
+		// If we are restoring a backup with old-style foreign keys, skip over the
+		// FKs for which we can't resolve the cross-table references. We can't
+		// display them anyway, because we don't have the referenced table names,
+		// etc.
+		if err := maybeUpgradeTableDescsInBackupDescriptors(ctx, []BackupDescriptor{desc}, true /*skipFKsWithNoMatchingTable*/); err != nil {
+			return err
+		}
 
 		for _, row := range shower.fn(desc) {
 			select {

--- a/pkg/ccl/cliccl/load.go
+++ b/pkg/ccl/cliccl/load.go
@@ -58,6 +58,10 @@ func runLoadShow(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
+	// This reads the raw backup descriptor (with table descriptors possibly not
+	// upgraded from the old FK representation, or even older formats). If more
+	// fields are added to the output, the table descriptors may need to be
+	// upgraded.
 	desc, err := backupccl.ReadBackupDescriptorFromURI(ctx, basepath, cluster.NoSettings)
 	if err != nil {
 		return err
@@ -88,6 +92,8 @@ func runLoadShow(cmd *cobra.Command, args []string) error {
 		fmt.Printf("		IndexEntries: %d\n", f.EntryCounts.IndexEntries)
 		fmt.Printf("		SystemRecords: %d\n", f.EntryCounts.SystemRecords)
 	}
+	// Note that these descriptors could be from any past version of the cluster,
+	// in case more fields need to be added to the output.
 	fmt.Printf("Descriptors:\n")
 	for _, d := range desc.Descriptors {
 		if desc := d.GetTable(); desc != nil {

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -130,6 +130,9 @@ func ImportBufferConfigSizes(st *cluster.Settings, isPKAdder bool) (int64, int64
 func evalImport(ctx context.Context, cArgs batcheval.CommandArgs) (*roachpb.ImportResponse, error) {
 	args := cArgs.Args.(*roachpb.ImportRequest)
 	db := cArgs.EvalCtx.DB()
+	// args.Rekeys could be using table descriptors from either the old or new
+	// foreign key representation on the table descriptor, but this is fine
+	// because foreign keys don't matter for the key rewriter.
 	kr, err := MakeKeyRewriterFromRekeys(args.Rekeys)
 	if err != nil {
 		return nil, errors.Wrap(err, "make key rewriter")


### PR DESCRIPTION
This PR fixes the backup/restore cluster version incompatibility issues
introduced by the FK table descriptor representation upgrade. It forces all
mixed-version clusters to write backup descriptors with table descriptors that
are compatible with 19.1, and enables 19.2 nodes to read 19.1 backups
correctly. This is done by downgrading table descriptors (conditionally, based
on the cluster version) every time they are written to disk or written to a
backup manifest, and upgrading them when FKs need to be read or written.

Backup descriptors are upgraded using a `protoGetter` that reads table
descriptors from the backup descriptors themselves, taking the place of `Txn`,
when resolving cross-table references. To handle backup descriptors containg
tables that reference tables not in the backup, a new argument is added to
`maybeUpgradeForeignKeyRepresentation` that allows for skipping foreign keys
during this lookup process that can't be restored because a table is missing.

I mostly tested this by running one of the failing tpch benchmarks
(`tpchbench/tpchVec/nodes=3/cpu=4/sf=1`) to verify that it actually works, and
restoring the tpch fixture in a real mixed-version cluster (with both 19.1 and
19.2 nodes as the gateway node) and a cluster that had been upgraded from 19.1
to 19.2. I also ran the `backupccl` tests while forcing the cluster to be on
cluster version 19.1 to simulate the mixed-version state:
```
diff --git a/pkg/sql/create_table.go b/pkg/sql/create_table.go
index 077f394442..a7549b0e2a 100644
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -631,7 +631,7 @@ func ResolveFK(
                LegacyReferencedIndex: legacyReferencedIndexID,
        }

-       if !settings.Version.IsActive(cluster.VersionTopLevelForeignKeys) {
+       if !settings.Version.IsActive(cluster.VersionTopLevelForeignKeys) || true {
                legacyUpgradedFromOriginReference := sqlbase.ForeignKeyReference{
                        Table:           target.ID,
                        Index:           legacyReferencedIndexID,
diff --git a/pkg/sql/sqlbase/structured.go b/pkg/sql/sqlbase/structured.go
index 5b7b507633..afc7d75be5 100644
--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -988,7 +988,7 @@ func maybeUpgradeForeignKeyRepOnIndex(
 func (desc *TableDescriptor) MaybeDowngradeForeignKeyRepresentation(
        ctx context.Context, clusterSettings *cluster.Settings,
 ) (bool, *TableDescriptor, error) {
-       downgradeUnnecessary := clusterSettings.Version.IsActive(cluster.VersionTopLevelForeignKeys)
+       downgradeUnnecessary := clusterSettings.Version.IsActive(cluster.VersionTopLevelForeignKeys) && false
        if downgradeUnnecessary {
                return false, desc, nil
        }
```

This PR is based on #39474.
Fixes #39753.

Release note: None