### PR TITLE
sql: quieter TestFuncNulls

### DIFF
--- a/pkg/sql/builtin_test.go
+++ b/pkg/sql/builtin_test.go
@@ -33,12 +33,10 @@ func TestFuncNull(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 
 	run := func(t *testing.T, q string) {
-		t.Run(q, func(t *testing.T) {
-			rows, err := db.QueryContext(ctx, q)
-			if err == nil {
-				rows.Close()
-			}
-		})
+		rows, err := db.QueryContext(ctx, q)
+		if err == nil {
+			rows.Close()
+		}
 	}
 
 	for _, name := range builtins.AllBuiltinNames {


### PR DESCRIPTION
Before this was running every combination of builtin func and type as a separate, named subtest.
It is unlikely we need such granular ability to run just one combination (the test runs <1s),
while generating so many named substests resulted in 5655 lines / 400kb of test output.

Removing the subtest cuts this to about 140 lines / 14kb (there are some stacktraces logged).

Release note: none.