### PR TITLE
exec: support comparisons between all numeric types

### DIFF
--- a/pkg/col/coltypes/types.go
+++ b/pkg/col/coltypes/types.go
@@ -54,24 +54,30 @@ var AllTypes []T
 // type in a binary expression.
 var CompatibleTypes map[T][]T
 
+// NumberTypes is a slice containing all numeric types.
+var NumberTypes = []T{Int8, Int16, Int32, Int64, Float32, Float64, Decimal}
+
+// IntTypes is a slice containing all int types.
+var IntTypes = []T{Int8, Int16, Int32, Int64}
+
+// FloatTypes is a slice containing all float types.
+var FloatTypes = []T{Float32, Float64}
+
 func init() {
 	for i := Bool; i < Unhandled; i++ {
 		AllTypes = append(AllTypes, i)
 	}
 
-	intTypes := []T{Int8, Int16, Int32, Int64}
-	floatTypes := []T{Float32, Float64}
-
 	CompatibleTypes = make(map[T][]T)
 	CompatibleTypes[Bool] = append(CompatibleTypes[Bool], Bool)
 	CompatibleTypes[Bytes] = append(CompatibleTypes[Bytes], Bytes)
-	CompatibleTypes[Decimal] = append(CompatibleTypes[Decimal], Decimal)
-	CompatibleTypes[Int8] = append(CompatibleTypes[Int8], intTypes...)
-	CompatibleTypes[Int16] = append(CompatibleTypes[Int16], intTypes...)
-	CompatibleTypes[Int32] = append(CompatibleTypes[Int32], intTypes...)
-	CompatibleTypes[Int64] = append(CompatibleTypes[Int64], intTypes...)
-	CompatibleTypes[Float32] = append(CompatibleTypes[Float32], floatTypes...)
-	CompatibleTypes[Float64] = append(CompatibleTypes[Float64], floatTypes...)
+	CompatibleTypes[Decimal] = append(CompatibleTypes[Decimal], NumberTypes...)
+	CompatibleTypes[Int8] = append(CompatibleTypes[Int8], NumberTypes...)
+	CompatibleTypes[Int16] = append(CompatibleTypes[Int16], NumberTypes...)
+	CompatibleTypes[Int32] = append(CompatibleTypes[Int32], NumberTypes...)
+	CompatibleTypes[Int64] = append(CompatibleTypes[Int64], NumberTypes...)
+	CompatibleTypes[Float32] = append(CompatibleTypes[Float32], NumberTypes...)
+	CompatibleTypes[Float64] = append(CompatibleTypes[Float64], NumberTypes...)
 }
 
 // FromGoType returns the type for a Go value, if applicable. Shouldn't be used at

--- a/pkg/sql/exec/execgen/cmd/execgen/overloads.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/overloads.go
@@ -160,7 +160,7 @@ func init() {
 	sameTypeComparisonOpToOverloads = make(map[tree.ComparisonOperator][]*overload, len(comparisonOpName))
 	anyTypeComparisonOpToOverloads = make(map[tree.ComparisonOperator][]*overload, len(comparisonOpName))
 	for _, t := range inputTypes {
-		customizer := typeCustomizers[t]
+		customizer := typeCustomizers[coltypePair{t, t}]
 		for _, op := range binOps {
 			// Skip types that don't have associated binary ops.
 			switch t {
@@ -200,8 +200,8 @@ func init() {
 		hashOverloads = append(hashOverloads, ov)
 	}
 	for _, leftType := range inputTypes {
-		customizer := typeCustomizers[leftType]
 		for _, rightType := range coltypes.CompatibleTypes[leftType] {
+			customizer := typeCustomizers[coltypePair{leftType, rightType}]
 			for _, op := range cmpOps {
 				opStr := comparisonOpInfix[op]
 				ov := &overload{
@@ -258,14 +258,18 @@ func init() {
 // (==, <, etc) or binary operator (+, -, etc) semantics.
 type typeCustomizer interface{}
 
-// TODO(rafi): make this map keyed by (leftType, rightType) so we can have
-// customizers for mixed-type operations.
-var typeCustomizers map[coltypes.T]typeCustomizer
+// coltypePair is used to key a map that holds all typeCustomizers.
+type coltypePair struct {
+	leftType  coltypes.T
+	rightType coltypes.T
+}
 
-// registerTypeCustomizer registers a particular type customizer to a type, for
-// usage by templates.
-func registerTypeCustomizer(t coltypes.T, customizer typeCustomizer) {
-	typeCustomizers[t] = customizer
+var typeCustomizers map[coltypePair]typeCustomizer
+
+// registerTypeCustomizer registers a particular type customizer to a
+// pair of types, for usage by templates.
+func registerTypeCustomizer(pair coltypePair, customizer typeCustomizer) {
+	typeCustomizers[pair] = customizer
 }
 
 // binOpTypeCustomizer is a type customizer that changes how the templater
@@ -301,8 +305,32 @@ type decimalCustomizer struct{}
 // floatCustomizers are used for hash functions.
 type floatCustomizer struct{ width int }
 
-// intCustomizers are used for hash functions.
+// intCustomizers are used for hash functions and overflow handling.
 type intCustomizer struct{ width int }
+
+// decimalFloatCustomizer supports mixed type expressions with a decimal
+// left-hand side and a float right-hand side.
+type decimalFloatCustomizer struct{}
+
+// decimalIntCustomizer supports mixed type expressions with a decimal left-hand
+// side and an int right-hand side.
+type decimalIntCustomizer struct{}
+
+// floatDecimalCustomizer supports mixed type expressions with a float left-hand
+// side and a decimal right-hand side.
+type floatDecimalCustomizer struct{}
+
+// intDecimalCustomizer supports mixed type expressions with an int left-hand
+// side and a decimal right-hand side.
+type intDecimalCustomizer struct{}
+
+// floatIntCustomizer supports mixed type expressions with a float left-hand
+// side and an int right-hand side.
+type floatIntCustomizer struct{}
+
+// intFloatCustomizer supports mixed type expressions with an int left-hand
+// side and a float right-hand side.
+type intFloatCustomizer struct{}
 
 func (boolCustomizer) getCmpOpCompareFunc() compareFunc {
 	return func(target, l, r string) string {
@@ -386,13 +414,20 @@ func (c floatCustomizer) getHashAssignFunc() assignFunc {
 	}
 }
 
-func (c floatCustomizer) getCmpOpCompareFunc() compareFunc {
+func getFloatCmpOpCompareFunc(checkLeftNan, checkRightNan bool) compareFunc {
 	return func(target, l, r string) string {
-		args := map[string]string{"Target": target, "Left": l, "Right": r}
+		args := map[string]interface{}{
+			"Target":        target,
+			"Left":          l,
+			"Right":         r,
+			"CheckLeftNan":  checkLeftNan,
+			"CheckRightNan": checkRightNan}
 		buf := strings.Builder{}
 		// In SQL, NaN is treated as less than all other float values. In Go, any
 		// comparison with NaN returns false. To allow floats of different sizes to
-		// be compared, always upcast to float64.
+		// be compared, always upcast to float64. The CheckLeftNan and CheckRightNan
+		// flags skip NaN checks when the input is an int (which is necessary to
+		// pass linting.)
 		t := template.Must(template.New("").Parse(`
 			{
 				a, b := float64({{.Left}}), float64({{.Right}})
@@ -402,8 +437,8 @@ func (c floatCustomizer) getCmpOpCompareFunc() compareFunc {
 					{{.Target}} = 1
 				}	else if a == b {
 					{{.Target}} = 0
-				}	else if math.IsNaN(a) {
-					if math.IsNaN(b) {
+				}	else if {{ if .CheckLeftNan }} math.IsNaN(a) {{ else }} false {{ end }} {
+					if {{ if .CheckRightNan }} math.IsNaN(b) {{ else }} false {{ end }} {
 						{{.Target}} = 0
 					} else {
 						{{.Target}} = -1
@@ -419,6 +454,10 @@ func (c floatCustomizer) getCmpOpCompareFunc() compareFunc {
 		}
 		return buf.String()
 	}
+}
+
+func (c floatCustomizer) getCmpOpCompareFunc() compareFunc {
+	return getFloatCmpOpCompareFunc(true /* checkLeftNan */, true /* checkRightNan */)
 }
 
 func (c intCustomizer) getHashAssignFunc() assignFunc {
@@ -450,7 +489,6 @@ func (c intCustomizer) getCmpOpCompareFunc() compareFunc {
 		}
 		return buf.String()
 	}
-
 }
 
 func (c intCustomizer) getBinOpAssignFunc() assignFunc {
@@ -567,17 +605,147 @@ func (c intCustomizer) getBinOpAssignFunc() assignFunc {
 	}
 }
 
+func (c decimalFloatCustomizer) getCmpOpCompareFunc() compareFunc {
+	return func(target, l, r string) string {
+		args := map[string]string{"Target": target, "Left": l, "Right": r}
+		buf := strings.Builder{}
+		// todo(rafi): is there a way to avoid allocating on each comparison?
+		t := template.Must(template.New("").Parse(`
+			{
+				tmpDec := &apd.Decimal{}
+				if _, err := tmpDec.SetFloat64(float64({{.Right}})); err != nil {
+					execerror.NonVectorizedPanic(err)
+				}
+				{{.Target}} = tree.CompareDecimals(&{{.Left}}, tmpDec)
+			}
+		`))
+
+		if err := t.Execute(&buf, args); err != nil {
+			execerror.VectorizedInternalPanic(err)
+		}
+		return buf.String()
+	}
+}
+
+func (c decimalIntCustomizer) getCmpOpCompareFunc() compareFunc {
+	return func(target, l, r string) string {
+		args := map[string]string{"Target": target, "Left": l, "Right": r}
+		buf := strings.Builder{}
+		// todo(rafi): is there a way to avoid allocating on each comparison?
+		t := template.Must(template.New("").Parse(`
+			{
+				tmpDec := &apd.Decimal{}
+				tmpDec.SetFinite(int64({{.Right}}), 0)
+				{{.Target}} = tree.CompareDecimals(&{{.Left}}, tmpDec)
+			}
+		`))
+
+		if err := t.Execute(&buf, args); err != nil {
+			execerror.VectorizedInternalPanic(err)
+		}
+		return buf.String()
+	}
+}
+
+func (c floatDecimalCustomizer) getCmpOpCompareFunc() compareFunc {
+	return func(target, l, r string) string {
+		args := map[string]string{"Target": target, "Left": l, "Right": r}
+		buf := strings.Builder{}
+		// todo(rafi): is there a way to avoid allocating on each comparison?
+		t := template.Must(template.New("").Parse(`
+			{
+				tmpDec := &apd.Decimal{}
+				if _, err := tmpDec.SetFloat64(float64({{.Left}})); err != nil {
+					execerror.NonVectorizedPanic(err)
+				}
+				{{.Target}} = tree.CompareDecimals(tmpDec, &{{.Right}})
+			}
+		`))
+
+		if err := t.Execute(&buf, args); err != nil {
+			execerror.VectorizedInternalPanic(err)
+		}
+		return buf.String()
+	}
+}
+
+func (c intDecimalCustomizer) getCmpOpCompareFunc() compareFunc {
+	return func(target, l, r string) string {
+		args := map[string]string{"Target": target, "Left": l, "Right": r}
+		buf := strings.Builder{}
+		// todo(rafi): is there a way to avoid allocating on each comparison?
+		t := template.Must(template.New("").Parse(`
+			{
+				tmpDec := &apd.Decimal{}
+				tmpDec.SetFinite(int64({{.Left}}), 0)
+				{{.Target}} = tree.CompareDecimals(tmpDec, &{{.Right}})
+			}
+		`))
+
+		if err := t.Execute(&buf, args); err != nil {
+			execerror.VectorizedInternalPanic(err)
+		}
+		return buf.String()
+	}
+}
+
+func (c floatIntCustomizer) getCmpOpCompareFunc() compareFunc {
+	// floatCustomizer's comparison function can be reused since float-int
+	// comparison works by casting the int.
+	return getFloatCmpOpCompareFunc(true /* checkLeftNan */, false /* checkRightNan */)
+}
+
+func (c intFloatCustomizer) getCmpOpCompareFunc() compareFunc {
+	// floatCustomizer's comparison function can be reused since int-float
+	// comparison works by casting the int.
+	return getFloatCmpOpCompareFunc(false /* checkLeftNan */, true /* checkRightNan */)
+}
+
 func registerTypeCustomizers() {
-	typeCustomizers = make(map[coltypes.T]typeCustomizer)
-	registerTypeCustomizer(coltypes.Bool, boolCustomizer{})
-	registerTypeCustomizer(coltypes.Bytes, bytesCustomizer{})
-	registerTypeCustomizer(coltypes.Decimal, decimalCustomizer{})
-	registerTypeCustomizer(coltypes.Float32, floatCustomizer{width: 32})
-	registerTypeCustomizer(coltypes.Float64, floatCustomizer{width: 64})
-	registerTypeCustomizer(coltypes.Int8, intCustomizer{width: 8})
-	registerTypeCustomizer(coltypes.Int16, intCustomizer{width: 16})
-	registerTypeCustomizer(coltypes.Int32, intCustomizer{width: 32})
-	registerTypeCustomizer(coltypes.Int64, intCustomizer{width: 64})
+	typeCustomizers = make(map[coltypePair]typeCustomizer)
+	registerTypeCustomizer(coltypePair{coltypes.Bool, coltypes.Bool}, boolCustomizer{})
+	registerTypeCustomizer(coltypePair{coltypes.Bytes, coltypes.Bytes}, bytesCustomizer{})
+	registerTypeCustomizer(coltypePair{coltypes.Decimal, coltypes.Decimal}, decimalCustomizer{})
+	for _, leftFloatType := range coltypes.FloatTypes {
+		for _, rightFloatType := range coltypes.FloatTypes {
+			registerTypeCustomizer(coltypePair{leftFloatType, rightFloatType}, floatCustomizer{width: 64})
+		}
+	}
+	for _, leftIntType := range coltypes.IntTypes {
+		for _, rightIntType := range coltypes.IntTypes {
+			registerTypeCustomizer(coltypePair{leftIntType, rightIntType}, intCustomizer{width: 64})
+		}
+	}
+	// Use a customizer of appropriate width when widths are the same.
+	registerTypeCustomizer(coltypePair{coltypes.Float32, coltypes.Float32}, floatCustomizer{width: 32})
+	registerTypeCustomizer(coltypePair{coltypes.Float64, coltypes.Float64}, floatCustomizer{width: 64})
+	registerTypeCustomizer(coltypePair{coltypes.Int8, coltypes.Int8}, intCustomizer{width: 8})
+	registerTypeCustomizer(coltypePair{coltypes.Int16, coltypes.Int16}, intCustomizer{width: 16})
+	registerTypeCustomizer(coltypePair{coltypes.Int32, coltypes.Int32}, intCustomizer{width: 32})
+	registerTypeCustomizer(coltypePair{coltypes.Int64, coltypes.Int64}, intCustomizer{width: 64})
+
+	for _, rightFloatType := range coltypes.FloatTypes {
+		registerTypeCustomizer(coltypePair{coltypes.Decimal, rightFloatType}, decimalFloatCustomizer{})
+	}
+	for _, rightIntType := range coltypes.IntTypes {
+		registerTypeCustomizer(coltypePair{coltypes.Decimal, rightIntType}, decimalIntCustomizer{})
+	}
+	for _, leftFloatType := range coltypes.FloatTypes {
+		registerTypeCustomizer(coltypePair{leftFloatType, coltypes.Decimal}, floatDecimalCustomizer{})
+	}
+	for _, leftIntType := range coltypes.IntTypes {
+		registerTypeCustomizer(coltypePair{leftIntType, coltypes.Decimal}, intDecimalCustomizer{})
+	}
+	for _, leftFloatType := range coltypes.FloatTypes {
+		for _, rightIntType := range coltypes.IntTypes {
+			registerTypeCustomizer(coltypePair{leftFloatType, rightIntType}, floatIntCustomizer{})
+		}
+	}
+	for _, leftIntType := range coltypes.IntTypes {
+		for _, rightFloatType := range coltypes.FloatTypes {
+			registerTypeCustomizer(coltypePair{leftIntType, rightFloatType}, intFloatCustomizer{})
+		}
+	}
 }
 
 // Avoid unused warning for functions which are only used in templates.

--- a/pkg/sql/exec/execgen/cmd/execgen/selection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/selection_ops_gen.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"

--- a/pkg/sql/exec/overloads_test.go
+++ b/pkg/sql/exec/overloads_test.go
@@ -14,110 +14,202 @@ import (
 	"math"
 	"testing"
 
+	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestIntegerAddition(t *testing.T) {
 	// The addition overload is the same for all integer widths, so we only test
 	// one of them.
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performPlusInt16(1, math.MaxInt16) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performPlusInt16(-1, math.MinInt16) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performPlusInt16(math.MaxInt16, 1) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performPlusInt16(math.MinInt16, -1) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performPlusInt16Int16(1, math.MaxInt16) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performPlusInt16Int16(-1, math.MinInt16) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performPlusInt16Int16(math.MaxInt16, 1) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performPlusInt16Int16(math.MinInt16, -1) }))
 
-	assert.Equal(t, int16(math.MaxInt16), performPlusInt16(1, math.MaxInt16-1))
-	assert.Equal(t, int16(math.MinInt16), performPlusInt16(-1, math.MinInt16+1))
-	assert.Equal(t, int16(math.MaxInt16-1), performPlusInt16(-1, math.MaxInt16))
-	assert.Equal(t, int16(math.MinInt16+1), performPlusInt16(1, math.MinInt16))
+	require.Equal(t, int16(math.MaxInt16), performPlusInt16Int16(1, math.MaxInt16-1))
+	require.Equal(t, int16(math.MinInt16), performPlusInt16Int16(-1, math.MinInt16+1))
+	require.Equal(t, int16(math.MaxInt16-1), performPlusInt16Int16(-1, math.MaxInt16))
+	require.Equal(t, int16(math.MinInt16+1), performPlusInt16Int16(1, math.MinInt16))
 
-	assert.Equal(t, int16(22), performPlusInt16(10, 12))
-	assert.Equal(t, int16(-22), performPlusInt16(-10, -12))
-	assert.Equal(t, int16(2), performPlusInt16(-10, 12))
-	assert.Equal(t, int16(-2), performPlusInt16(10, -12))
+	require.Equal(t, int16(22), performPlusInt16Int16(10, 12))
+	require.Equal(t, int16(-22), performPlusInt16Int16(-10, -12))
+	require.Equal(t, int16(2), performPlusInt16Int16(-10, 12))
+	require.Equal(t, int16(-2), performPlusInt16Int16(10, -12))
 }
 
 func TestIntegerSubtraction(t *testing.T) {
 	// The subtraction overload is the same for all integer widths, so we only
 	// test one of them.
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMinusInt16(1, -math.MaxInt16) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMinusInt16(-2, math.MaxInt16) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMinusInt16(math.MaxInt16, -1) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMinusInt16(math.MinInt16, 1) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMinusInt16Int16(1, -math.MaxInt16) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMinusInt16Int16(-2, math.MaxInt16) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMinusInt16Int16(math.MaxInt16, -1) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMinusInt16Int16(math.MinInt16, 1) }))
 
-	assert.Equal(t, int16(math.MaxInt16), performMinusInt16(1, -math.MaxInt16+1))
-	assert.Equal(t, int16(math.MinInt16), performMinusInt16(-1, math.MaxInt16))
-	assert.Equal(t, int16(math.MaxInt16-1), performMinusInt16(-1, -math.MaxInt16))
-	assert.Equal(t, int16(math.MinInt16+1), performMinusInt16(0, math.MaxInt16))
+	require.Equal(t, int16(math.MaxInt16), performMinusInt16Int16(1, -math.MaxInt16+1))
+	require.Equal(t, int16(math.MinInt16), performMinusInt16Int16(-1, math.MaxInt16))
+	require.Equal(t, int16(math.MaxInt16-1), performMinusInt16Int16(-1, -math.MaxInt16))
+	require.Equal(t, int16(math.MinInt16+1), performMinusInt16Int16(0, math.MaxInt16))
 
-	assert.Equal(t, int16(-2), performMinusInt16(10, 12))
-	assert.Equal(t, int16(2), performMinusInt16(-10, -12))
-	assert.Equal(t, int16(-22), performMinusInt16(-10, 12))
-	assert.Equal(t, int16(22), performMinusInt16(10, -12))
+	require.Equal(t, int16(-2), performMinusInt16Int16(10, 12))
+	require.Equal(t, int16(2), performMinusInt16Int16(-10, -12))
+	require.Equal(t, int16(-22), performMinusInt16Int16(-10, 12))
+	require.Equal(t, int16(22), performMinusInt16Int16(10, -12))
 }
 
 func TestIntegerDivision(t *testing.T) {
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performDivInt8(math.MinInt8, -1) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performDivInt16(math.MinInt16, -1) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performDivInt32(math.MinInt32, -1) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performDivInt64(math.MinInt64, -1) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performDivInt8Int8(math.MinInt8, -1) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performDivInt16Int16(math.MinInt16, -1) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performDivInt32Int32(math.MinInt32, -1) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performDivInt64Int64(math.MinInt64, -1) }))
 
-	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivInt8(10, 0) }))
-	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivInt16(10, 0) }))
-	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivInt32(10, 0) }))
-	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivInt64(10, 0) }))
+	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivInt8Int8(10, 0) }))
+	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivInt16Int16(10, 0) }))
+	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivInt32Int32(10, 0) }))
+	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivInt64Int64(10, 0) }))
 
-	assert.Equal(t, int8(-math.MaxInt8), performDivInt8(math.MaxInt8, -1))
-	assert.Equal(t, int16(-math.MaxInt16), performDivInt16(math.MaxInt16, -1))
-	assert.Equal(t, int32(-math.MaxInt32), performDivInt32(math.MaxInt32, -1))
-	assert.Equal(t, int64(-math.MaxInt64), performDivInt64(math.MaxInt64, -1))
+	require.Equal(t, int8(-math.MaxInt8), performDivInt8Int8(math.MaxInt8, -1))
+	require.Equal(t, int16(-math.MaxInt16), performDivInt16Int16(math.MaxInt16, -1))
+	require.Equal(t, int32(-math.MaxInt32), performDivInt32Int32(math.MaxInt32, -1))
+	require.Equal(t, int64(-math.MaxInt64), performDivInt64Int64(math.MaxInt64, -1))
 
-	assert.Equal(t, int16(0), performDivInt16(10, 12))
-	assert.Equal(t, int16(0), performDivInt16(-10, -12))
-	assert.Equal(t, int16(-1), performDivInt16(-12, 10))
-	assert.Equal(t, int16(-1), performDivInt16(12, -10))
+	require.Equal(t, int16(0), performDivInt16Int16(10, 12))
+	require.Equal(t, int16(0), performDivInt16Int16(-10, -12))
+	require.Equal(t, int16(-1), performDivInt16Int16(-12, 10))
+	require.Equal(t, int16(-1), performDivInt16Int16(12, -10))
 }
 
 func TestIntegerMultiplication(t *testing.T) {
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt8(math.MaxInt8-1, 100) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt8(math.MaxInt8-1, 3) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt8(math.MinInt8+1, 3) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt8(math.MinInt8+1, 100) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt8Int8(math.MaxInt8-1, 100) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt8Int8(math.MaxInt8-1, 3) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt8Int8(math.MinInt8+1, 3) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt8Int8(math.MinInt8+1, 100) }))
 
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16(math.MaxInt16-1, 100) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16(math.MaxInt16-1, 3) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16(math.MinInt16+1, 3) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16(math.MinInt16+1, 100) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MaxInt16-1, 100) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MaxInt16-1, 3) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MinInt16+1, 3) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MinInt16+1, 100) }))
 
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt32(math.MaxInt32-1, 100) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt32(math.MaxInt32-1, 3) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt32(math.MinInt32+1, 3) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt32(math.MinInt32+1, 100) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt32Int32(math.MaxInt32-1, 100) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt32Int32(math.MaxInt32-1, 3) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt32Int32(math.MinInt32+1, 3) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt32Int32(math.MinInt32+1, 100) }))
 
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt64(math.MaxInt64-1, 100) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt64(math.MaxInt64-1, 3) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt64(math.MinInt64+1, 3) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt64(math.MinInt64+1, 100) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt64Int64(math.MaxInt64-1, 100) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt64Int64(math.MaxInt64-1, 3) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt64Int64(math.MinInt64+1, 3) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt64Int64(math.MinInt64+1, 100) }))
 
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt8(math.MinInt8, -1) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16(math.MinInt16, -1) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt32(math.MinInt32, -1) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt64(math.MinInt64, -1) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt8Int8(math.MinInt8, -1) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MinInt16, -1) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt32Int32(math.MinInt32, -1) }))
+	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt64Int64(math.MinInt64, -1) }))
 
-	assert.Equal(t, int8(-math.MaxInt8), performMultInt8(math.MaxInt8, -1))
-	assert.Equal(t, int16(-math.MaxInt16), performMultInt16(math.MaxInt16, -1))
-	assert.Equal(t, int32(-math.MaxInt32), performMultInt32(math.MaxInt32, -1))
-	assert.Equal(t, int64(-math.MaxInt64), performMultInt64(math.MaxInt64, -1))
+	require.Equal(t, int8(-math.MaxInt8), performMultInt8Int8(math.MaxInt8, -1))
+	require.Equal(t, int16(-math.MaxInt16), performMultInt16Int16(math.MaxInt16, -1))
+	require.Equal(t, int32(-math.MaxInt32), performMultInt32Int32(math.MaxInt32, -1))
+	require.Equal(t, int64(-math.MaxInt64), performMultInt64Int64(math.MaxInt64, -1))
 
-	assert.Equal(t, int8(0), performMultInt8(math.MinInt8, 0))
-	assert.Equal(t, int16(0), performMultInt16(math.MinInt16, 0))
-	assert.Equal(t, int32(0), performMultInt32(math.MinInt32, 0))
-	assert.Equal(t, int64(0), performMultInt64(math.MinInt64, 0))
+	require.Equal(t, int8(0), performMultInt8Int8(math.MinInt8, 0))
+	require.Equal(t, int16(0), performMultInt16Int16(math.MinInt16, 0))
+	require.Equal(t, int32(0), performMultInt32Int32(math.MinInt32, 0))
+	require.Equal(t, int64(0), performMultInt64Int64(math.MinInt64, 0))
 
-	assert.Equal(t, int8(120), performMultInt8(10, 12))
-	assert.Equal(t, int16(120), performMultInt16(-10, -12))
-	assert.Equal(t, int32(-120), performMultInt32(-12, 10))
-	assert.Equal(t, int64(-120), performMultInt64(12, -10))
+	require.Equal(t, int8(120), performMultInt8Int8(10, 12))
+	require.Equal(t, int16(120), performMultInt16Int16(-10, -12))
+	require.Equal(t, int32(-120), performMultInt32Int32(-12, 10))
+	require.Equal(t, int64(-120), performMultInt64Int64(12, -10))
+}
+
+func TestDecimalComparison(t *testing.T) {
+	d := apd.Decimal{}
+	if _, err := d.SetFloat64(1.234); err != nil {
+		t.Error(err)
+	}
+	require.Equal(t, true, performEQDecimalDecimal(d, d))
+	require.Equal(t, false, performEQDecimalFloat32(d, 0.43))
+	require.Equal(t, true, performEQDecimalFloat64(d, 1.234))
+	require.Equal(t, false, performEQDecimalInt8(d, 0))
+	require.Equal(t, false, performEQDecimalInt16(d, 1))
+	require.Equal(t, false, performEQDecimalInt32(d, 2))
+	require.Equal(t, false, performEQDecimalInt64(d, 3))
+
+	require.Equal(t, false, performLTDecimalDecimal(d, d))
+	require.Equal(t, false, performLTDecimalFloat32(d, 0.43))
+	require.Equal(t, true, performLTDecimalFloat64(d, 4.234))
+	require.Equal(t, false, performLTDecimalInt8(d, 0))
+	require.Equal(t, false, performLTDecimalInt16(d, 1))
+	require.Equal(t, true, performLTDecimalInt32(d, 2))
+	require.Equal(t, true, performLTDecimalInt64(d, 3))
+
+	require.Equal(t, true, performGEDecimalDecimal(d, d))
+	require.Equal(t, true, performGEDecimalFloat32(d, 0.43))
+	require.Equal(t, false, performGEDecimalFloat64(d, 4.234))
+	require.Equal(t, true, performGEDecimalInt8(d, 0))
+	require.Equal(t, true, performGEDecimalInt16(d, 1))
+	require.Equal(t, false, performGEDecimalInt32(d, 2))
+	require.Equal(t, false, performGEDecimalInt64(d, 3))
+}
+
+func TestFloatComparison(t *testing.T) {
+	f := 1.234
+	d := apd.Decimal{}
+	if _, err := d.SetFloat64(f); err != nil {
+		t.Error(err)
+	}
+	require.Equal(t, true, performEQFloat64Decimal(f, d))
+	require.Equal(t, false, performEQFloat64Float32(f, 0.43))
+	require.Equal(t, true, performEQFloat64Float64(f, 1.234))
+	require.Equal(t, false, performEQFloat64Int8(f, 0))
+	require.Equal(t, false, performEQFloat64Int16(f, 1))
+	require.Equal(t, false, performEQFloat64Int32(f, 2))
+	require.Equal(t, false, performEQFloat64Int64(f, 3))
+
+	require.Equal(t, false, performLTFloat64Decimal(f, d))
+	require.Equal(t, false, performLTFloat64Float32(f, 0.43))
+	require.Equal(t, true, performLTFloat64Float64(f, 4.234))
+	require.Equal(t, false, performLTFloat64Int8(f, 0))
+	require.Equal(t, false, performLTFloat64Int16(f, 1))
+	require.Equal(t, true, performLTFloat64Int32(f, 2))
+	require.Equal(t, true, performLTFloat64Int64(f, 3))
+
+	require.Equal(t, true, performGEFloat64Decimal(f, d))
+	require.Equal(t, true, performGEFloat64Float32(f, 0.43))
+	require.Equal(t, false, performGEFloat64Float64(f, 4.234))
+	require.Equal(t, true, performGEFloat64Int8(f, 0))
+	require.Equal(t, true, performGEFloat64Int16(f, 1))
+	require.Equal(t, false, performGEFloat64Int32(f, 2))
+	require.Equal(t, false, performGEFloat64Int64(f, 3))
+}
+
+func TestIntComparison(t *testing.T) {
+	i := int64(2)
+	d := apd.Decimal{}
+	if _, err := d.SetFloat64(1.234); err != nil {
+		t.Error(err)
+	}
+	require.Equal(t, false, performEQInt64Decimal(i, d))
+	require.Equal(t, false, performEQInt64Float32(i, 0.43))
+	require.Equal(t, false, performEQInt64Float64(i, 1.234))
+	require.Equal(t, false, performEQInt64Int8(i, 0))
+	require.Equal(t, false, performEQInt64Int16(i, 1))
+	require.Equal(t, true, performEQInt64Int32(i, 2))
+	require.Equal(t, false, performEQInt64Int64(i, 3))
+
+	require.Equal(t, false, performLTInt64Decimal(i, d))
+	require.Equal(t, false, performLTInt64Float32(i, 0.43))
+	require.Equal(t, true, performLTInt64Float64(i, 4.234))
+	require.Equal(t, false, performLTInt64Int8(i, 0))
+	require.Equal(t, false, performLTInt64Int16(i, 1))
+	require.Equal(t, false, performLTInt64Int32(i, 2))
+	require.Equal(t, true, performLTInt64Int64(i, 3))
+
+	require.Equal(t, true, performGEInt64Decimal(i, d))
+	require.Equal(t, true, performGEInt64Float32(i, 0.43))
+	require.Equal(t, false, performGEInt64Float64(i, 4.234))
+	require.Equal(t, true, performGEInt64Int8(i, 0))
+	require.Equal(t, true, performGEInt64Int16(i, 1))
+	require.Equal(t, true, performGEInt64Int32(i, 2))
+	require.Equal(t, false, performGEInt64Int64(i, 3))
 }

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -176,6 +176,22 @@ SELECT (a + b)::INT FROM intdec
 ----
 3
 
+statement ok
+SET vectorize = experimental_always
+
+query B
+SELECT b > a FROM intdec
+----
+true
+
+query IR
+SELECT a, b FROM intdec WHERE a < b;
+----
+1  2.0
+
+statement ok
+RESET vectorize
+
 # AND expressions.
 query II
 SELECT a, b FROM a WHERE a < 2 AND b > 0 AND a * b != 3


### PR DESCRIPTION
The vectorized engine now supports comparisons between floats, ints, and
decimals.

touches #39189

Release note: None