### PR TITLE
storage: fix TestQuotaPool flake

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -2067,10 +2067,21 @@ func TestQuotaPool(t *testing.T) {
 	}
 	testutils.SucceedsSoon(t, assertEqualLastIndex)
 
+	// NB: See TestRaftBlockedReplica/#9914 for why we use a separate	goroutine.
+	raftLockReplica := func(repl *storage.Replica) {
+		ch := make(chan struct{})
+		go func() { repl.RaftLock(); close(ch) }()
+		<-ch
+	}
+
 	leaderRepl := mtc.getRaftLeader(rangeID)
+	// Grab the raftMu to re-initialize the QuotaPool to ensure that we don't
+	// race with ongoing applications.
+	raftLockReplica(leaderRepl)
 	if err := leaderRepl.InitQuotaPool(quota); err != nil {
 		t.Fatalf("failed to initialize quota pool: %v", err)
 	}
+	leaderRepl.RaftUnlock()
 	followerRepl := func() *storage.Replica {
 		for _, store := range mtc.stores {
 			repl, err := store.GetReplica(rangeID)
@@ -2090,17 +2101,7 @@ func TestQuotaPool(t *testing.T) {
 
 	// We block the third replica effectively causing acquisition of quota
 	// without subsequent release.
-	//
-	// NB: See TestRaftBlockedReplica/#9914 for why we use a separate
-	// goroutine.
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		followerRepl.RaftLock()
-		wg.Done()
-	}()
-	wg.Wait()
-
+	raftLockReplica(followerRepl)
 	ch := make(chan *roachpb.Error, 1)
 
 	func() {

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -263,7 +263,7 @@ func (r *Replica) LastAssignedLeaseIndex() uint64 {
 // SetQuotaPool allows the caller to set a replica's quota pool initialized to
 // a given quota. Additionally it initializes the replica's quota release queue
 // and its command sizes map. Only safe to call on the replica that is both
-// lease holder and raft leader.
+// lease holder and raft leader while holding the raftMu.
 func (r *Replica) InitQuotaPool(quota uint64) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()


### PR DESCRIPTION
The test was flakey due to a race. This is almost definitely fallout from
removed a sanity check that prevented numReleases from exceeding the length of
the quotaReleaseQueue. The underlying race is due to a previous change which
switched initialization of the quota base index from last index to the applied
index. It's now possible for the last index values to all match but for the
leader replica to still have commands to apply. If we hold on to the raftMu
while initializing the quota pool there's no risk of a race.

I wonder if this also was affected by the recent move to learners which will
potentially have their last index set before they are full members of the range.

Anyway, the bug was not in the production code but rather in the use of the
test helper InitQuotaPool which is only used in this test. The test previously
failed rapidly under roachprod stress and now seems not to.

Fixes #39683.

Release note: None