### PR TITLE
sql: fix has_column_privilege builtin

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/privilege_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/privilege_builtins
@@ -951,3 +951,36 @@ query B
 SELECT has_type_privilege('bar', 'text'::REGTYPE::OID, 'USAGE')
 ----
 true
+
+# Regression test for #39703.
+
+statement ok
+DROP TABLE IF EXISTS hcp_test; CREATE TABLE hcp_test (a INT8, b INT8, c INT8)
+
+statement ok
+ALTER TABLE hcp_test DROP COLUMN b
+
+query TI
+SELECT attname, attnum FROM pg_attribute WHERE attrelid = 'hcp_test'::REGCLASS
+----
+a     1
+c     3
+rowid 4
+
+query B
+SELECT has_column_privilege('hcp_test'::REGCLASS, 1, 'SELECT')
+----
+true
+
+statement error column 2 of relation hcp_test does not exist
+SELECT has_column_privilege('hcp_test'::REGCLASS, 2, 'SELECT')
+
+query B
+SELECT has_column_privilege('hcp_test'::REGCLASS, 3, 'SELECT')
+----
+true
+
+query B
+SELECT has_column_privilege('hcp_test'::REGCLASS, 4, 'SELECT')
+----
+true


### PR DESCRIPTION
Previously, has_column_privilege would treat its second argument
(when it is an integer) that specifies the column to check the
privileges on as an ordinal index of the column, but when a column
is dropped from the table, ordinal indices are adjusted, so
ordinal_position of information_schema.columns would contain a
different from attnum of pg_catalog.pg_attribute number. Now
this is fixed.

Fixes: #39703.

Release note: None