### PR TITLE
Use bulk.SSTWriter to write SSTs on the receiver side

### DIFF
--- a/pkg/ccl/changefeedccl/table_history.go
+++ b/pkg/ccl/changefeedccl/table_history.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/sst"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -249,7 +250,7 @@ func fetchTableDescriptorVersions(
 	var tableDescs []*sqlbase.TableDescriptor
 	for _, file := range res.(*roachpb.ExportResponse).Files {
 		if err := func() error {
-			it, err := engine.NewMemSSTIterator(file.SST, false /* verify */)
+			it, err := sst.NewMemIterator(file.SST, false /* verify */)
 			if err != nil {
 				return err
 			}

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/storage/bulk"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/sst"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -183,7 +184,7 @@ func evalImport(ctx context.Context, cArgs batcheval.CommandArgs) (*roachpb.Impo
 			}
 		}
 
-		iter, err := engine.NewMemSSTIterator(fileContents, false)
+		iter, err := sst.NewMemIterator(fileContents, false)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/storage/batcheval/cmd_add_sstable.go
+++ b/pkg/storage/batcheval/cmd_add_sstable.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/sst"
 	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -57,7 +58,7 @@ func EvalAddSSTable(
 	// Verify that the keys in the sstable are within the range specified by the
 	// request header, and if the request did not include pre-computed stats,
 	// compute the expected MVCC stats delta of ingesting the SST.
-	dataIter, err := engine.NewMemSSTIterator(args.Data, true)
+	dataIter, err := sst.NewMemIterator(args.Data, true)
 	if err != nil {
 		return result.Result{}, err
 	}

--- a/pkg/storage/batcheval/cmd_add_sstable_test.go
+++ b/pkg/storage/batcheval/cmd_add_sstable_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/sst"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -447,7 +448,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 	}
 
 	getStats := func(startKey, endKey engine.MVCCKey, data []byte) enginepb.MVCCStats {
-		dataIter, err := engine.NewMemSSTIterator(data, true)
+		dataIter, err := sst.NewMemIterator(data, true)
 		if err != nil {
 			return enginepb.MVCCStats{}
 		}

--- a/pkg/storage/bulk/sst_batcher_test.go
+++ b/pkg/storage/bulk/sst_batcher_test.go
@@ -25,12 +25,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/bulk"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/sst"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddBatched(t *testing.T) {
@@ -239,12 +241,13 @@ func TestAddBigSpanningSSTWithSplits(t *testing.T) {
 	const numKeys, valueSize, splitEvery = 500, 5000, 1
 
 	// Make some KVs and grab [start,end). Generate one extra for exclusive `end`.
-	kvs := makeIntTableKVs(t, numKeys+1, valueSize, 1)
+	kvs := sst.MakeTestingIntTableKVs(numKeys+1, valueSize, 1)
 	start, end := kvs[0].Key.Key, kvs[numKeys].Key.Key
 	kvs = kvs[:numKeys]
 
 	// Create a large SST.
-	sst := makeRocksSST(t, kvs)
+	sst, err := sst.MakeTestingRocksSST(kvs)
+	require.NoError(t, err)
 
 	var splits []roachpb.Key
 	for i := range kvs {

--- a/pkg/storage/bulk/sst_writer.go
+++ b/pkg/storage/bulk/sst_writer.go
@@ -22,13 +22,53 @@ import (
 	"github.com/pkg/errors"
 )
 
+type writeCloseSyncer interface {
+	io.WriteCloser
+	Sync() error
+}
+
 // SSTWriter writes SSTables.
 type SSTWriter struct {
 	fw *sstable.Writer
-	f  *memFile
+	f  writeCloseSyncer
 	// DataSize tracks the total key and value bytes added so far.
 	DataSize uint64
 	scratch  []byte
+}
+
+var _ engine.Writer = &SSTWriter{}
+
+var mvccComparer = &pebble.Comparer{
+	Compare: engine.MVCCKeyCompare,
+	AbbreviatedKey: func(k []byte) uint64 {
+		key, _, ok := enginepb.SplitMVCCKey(k)
+		if !ok {
+			return 0
+		}
+		return pebble.DefaultComparer.AbbreviatedKey(key)
+	},
+
+	Separator: func(dst, a, b []byte) []byte {
+		return append(dst, a...)
+	},
+
+	Successor: func(dst, a []byte) []byte {
+		return append(dst, a...)
+	},
+	Split: func(k []byte) int {
+		if len(k) == 0 {
+			return len(k)
+		}
+		// This is similar to what enginepb.SplitMVCCKey does.
+		tsLen := int(k[len(k)-1])
+		keyPartEnd := len(k) - 1 - tsLen
+		if keyPartEnd < 0 {
+			return len(k)
+		}
+		return keyPartEnd
+	},
+
+	Name: "cockroach_comparator",
 }
 
 // timeboundPropCollector implements a property collector for MVCC Timestamps.
@@ -67,17 +107,19 @@ func (t *timeboundPropCollector) Name() string {
 
 // dummyDeleteRangeCollector is a stub collector that just identifies itself.
 // This stub can be installed so that SSTs claim to have the same props as those
-// written by the Rocks writer, using the collector in table_props.cc. However
-// since bulk-ingestion SSTs never contain deletions (range or otherwise), there
-// is no actual implementation needed here.
+// written by the Rocks writer, using the collector in table_props.cc.
+//
+// TODO(jeffreyxiao): The implementation of this collector is different from
+// the one in table_props.cc because Pebble does not expose a NeedCompact
+// function. The actual behavior should not differ from the RocksDB
+// implementation because although NeedsCompact() is true and the
+// marked_for_compaction tag is set for the RocksDB implementation, the tag is
+// never checked in IngestExternalFiles.
 type dummyDeleteRangeCollector struct{}
 
 var _ pebble.TablePropertyCollector = &dummyDeleteRangeCollector{}
 
 func (dummyDeleteRangeCollector) Add(key pebble.InternalKey, value []byte) error {
-	if key.Kind() != pebble.InternalKeyKindSet {
-		return errors.Errorf("unsupported key kind %v", key.Kind())
-	}
 	return nil
 }
 
@@ -107,37 +149,115 @@ var pebbleOpts = func() *pebble.Options {
 }()
 
 // MakeSSTWriter creates a new SSTWriter.
-func MakeSSTWriter() SSTWriter {
-	f := &memFile{}
+func MakeSSTWriter(f writeCloseSyncer) SSTWriter {
 	// Setting the IndexBlockSize to MaxInt disables twoLevelIndexes in Pebble.
 	// TODO(pbardea): Remove the IndexBlockSize option when https://github.com/cockroachdb/pebble/issues/285 is resolved.
 	sst := sstable.NewWriter(f, pebbleOpts, pebble.LevelOptions{BlockSize: 64 * 1024, IndexBlockSize: math.MaxInt32})
 	return SSTWriter{fw: sst, f: f}
 }
 
-// Add puts a kv entry into the sstable being built. An error is returned if it
-// is not greater than any previously added entry (according to the comparator
-// configured during writer creation). `Close` cannot have been called.
-func (fw *SSTWriter) Add(kv engine.MVCCKeyValue) error {
+// ApplyBatchRepr implements the Writer interface.
+func (fw *SSTWriter) ApplyBatchRepr(repr []byte, sync bool) error {
+	panic("unimplemented")
+}
+
+// Clear implements the Writer interface. Note that it inserts a tombstone
+// rather than actually remove the entry from the storage engine. An error is
+// returned if it is not greater than any previous key used in Put or Clear
+// (according to the comparator configured during writer creation). Close
+// cannot have been called.
+func (fw *SSTWriter) Clear(key engine.MVCCKey) error {
+	if fw.fw == nil {
+		return errors.New("cannot call Clear on a closed writer")
+	}
+	fw.DataSize += uint64(len(key.Key))
+	fw.scratch = engine.EncodeKeyToBuf(fw.scratch[:0], key)
+	return fw.fw.Delete(fw.scratch)
+}
+
+// SingleClear implements the Writer interface.
+func (fw *SSTWriter) SingleClear(key engine.MVCCKey) error {
+	panic("unimplemented")
+}
+
+// ClearRange implements the Writer interface. Note that it inserts a range deletion
+// tombstone rather than actually remove the entries from the storage engine.
+// It can be called at any time with respect to Put and Clear.
+func (fw *SSTWriter) ClearRange(start, end engine.MVCCKey) error {
+	if fw.fw == nil {
+		return errors.New("cannot call ClearRange on a closed writer")
+	}
+	fw.DataSize += uint64(len(start.Key)) + uint64(len(end.Key))
+	fw.scratch = engine.EncodeKeyToBuf(fw.scratch[:0], start)
+	startScratchLen := len(fw.scratch)
+	fw.scratch = engine.EncodeKeyToBuf(fw.scratch, end)
+	return fw.fw.DeleteRange(fw.scratch[:startScratchLen], fw.scratch[startScratchLen:])
+}
+
+// ClearIterRange implements the Writer interface. It inserts range deletion
+// tombstones for all keys from start (inclusive) to end (exclusive) in
+// the provided iterator.
+func (fw *SSTWriter) ClearIterRange(iter engine.Iterator, start, end engine.MVCCKey) error {
+	if fw.fw == nil {
+		return errors.New("cannot call ClearIterRange on a closed writer")
+	}
+	iter.Seek(start)
+	for {
+		valid, err := iter.Valid()
+		if err != nil {
+			return err
+		}
+		if !valid || !iter.Key().Less(end) {
+			break
+		}
+		if err := fw.Clear(iter.Key()); err != nil {
+			return err
+		}
+		iter.Next()
+	}
+	return nil
+}
+
+// Merge implements the Writer interface.
+func (fw *SSTWriter) Merge(key engine.MVCCKey, value []byte) error {
+	panic("unimplemented")
+}
+
+// Put implements the Writer interface. It puts a kv entry into the sstable
+// being built. An error is returned if it is not greater than any previous key
+// used in Put or Clear (according to the comparator configured during writer
+// creation). Close cannot have been called.
+func (fw *SSTWriter) Put(key engine.MVCCKey, value []byte) error {
 	if fw.fw == nil {
 		return errors.New("cannot call Open on a closed writer")
 	}
-	fw.DataSize += uint64(len(kv.Key.Key)) + uint64(len(kv.Value))
-	fw.scratch = engine.EncodeKeyToBuf(fw.scratch[:0], kv.Key)
-	return fw.fw.Set(fw.scratch, kv.Value)
+	fw.DataSize += uint64(len(key.Key)) + uint64(len(value))
+	fw.scratch = engine.EncodeKeyToBuf(fw.scratch[:0], key)
+	return fw.fw.Set(fw.scratch, value)
 }
 
-// Finish finalizes the writer and returns the constructed file's contents. At
-// least one kv entry must have been added.
-func (fw *SSTWriter) Finish() ([]byte, error) {
+// LogData implements the Writer interface.
+func (fw *SSTWriter) LogData(data []byte) error {
+	panic("unimplemented")
+}
+
+// LogLogicalOp implements the Writer interface.
+func (fw *SSTWriter) LogLogicalOp(
+	op engine.MVCCLogicalOpType, details engine.MVCCLogicalOpDetails,
+) {
+	// No-op. Logical logging disabled.
+}
+
+// Finish finalizes the writer. At least one kv entry must have been added.
+func (fw *SSTWriter) Finish() error {
 	if fw.fw == nil {
-		return nil, errors.New("cannot call Finish on a closed writer")
+		return errors.New("cannot call Finish on a closed writer")
 	}
 	if err := fw.fw.Close(); err != nil {
-		return nil, err
+		return err
 	}
 	fw.fw = nil
-	return fw.f.data, nil
+	return nil
 }
 
 // Close finishes and frees memory and other resources. Close is idempotent.
@@ -154,20 +274,27 @@ func (fw *SSTWriter) Close() {
 	fw.fw = nil
 }
 
-type memFile struct {
+// SSTMemFile is an in-memory SST file.
+type SSTMemFile struct {
 	data []byte
 	pos  int
 }
 
-func (*memFile) Close() error {
+var _ writeCloseSyncer = &SSTMemFile{}
+
+// Close closes the SSTMemFile. This is a no-op.
+func (*SSTMemFile) Close() error {
 	return nil
 }
 
-func (*memFile) Sync() error {
+// Sync syncs the SSTMemFile. This is a no-op.
+func (*SSTMemFile) Sync() error {
 	return nil
 }
 
-func (f *memFile) Read(p []byte) (int, error) {
+// Read copies the data from the current position in the SSTMemFile to the
+// provided buffer.
+func (f *SSTMemFile) Read(p []byte) (int, error) {
 	if f.pos >= len(f.data) {
 		return 0, io.EOF
 	}
@@ -176,14 +303,22 @@ func (f *memFile) Read(p []byte) (int, error) {
 	return n, nil
 }
 
-func (f *memFile) ReadAt(p []byte, off int64) (int, error) {
+// ReadAt copies the data from the specified offset in the SSTMemFile to the
+// provided buffer.
+func (f *SSTMemFile) ReadAt(p []byte, off int64) (int, error) {
 	if off >= int64(len(f.data)) {
 		return 0, io.EOF
 	}
 	return copy(p, f.data[off:]), nil
 }
 
-func (f *memFile) Write(p []byte) (int, error) {
+// Data returns the underlying buffer that backs the SSTMemFile.
+func (f *SSTMemFile) Data() []byte {
+	return f.data
+}
+
+// Write writes data to the SSTMemFile.
+func (f *SSTMemFile) Write(p []byte) (int, error) {
 	f.data = append(f.data, p...)
 	return len(p), nil
 }

--- a/pkg/storage/bulk/sst_writer_test.go
+++ b/pkg/storage/bulk/sst_writer_test.go
@@ -66,17 +66,18 @@ func makeRocksSST(t testing.TB, kvs []engine.MVCCKeyValue) []byte {
 }
 
 func makePebbleSST(t testing.TB, kvs []engine.MVCCKeyValue) []byte {
-	w := bulk.MakeSSTWriter()
+	sst := bulk.SSTMemFile{}
+	w := bulk.MakeSSTWriter(&sst)
 	defer w.Close()
 
 	for i := range kvs {
-		if err := w.Add(kvs[i]); err != nil {
+		if err := w.Put(kvs[i].Key, kvs[i].Value); err != nil {
 			t.Fatal(err)
 		}
 	}
-	sst, err := w.Finish()
+	err := w.Finish()
 	require.NoError(t, err)
-	return sst
+	return sst.Data()
 }
 
 // TestPebbleWritesSameSSTs tests that using pebble to write some SST produces

--- a/pkg/storage/engine/sst/writer_test.go
+++ b/pkg/storage/engine/sst/writer_test.go
@@ -8,77 +8,16 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package bulk_test
+package sst
 
 import (
-	"math/rand"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/storage/bulk"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
-	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/stretchr/testify/require"
 )
-
-func makeIntTableKVs(t testing.TB, numKeys, valueSize, maxRevisions int) []engine.MVCCKeyValue {
-	prefix := encoding.EncodeUvarintAscending(keys.MakeTablePrefix(uint32(100)), uint64(1))
-	kvs := make([]engine.MVCCKeyValue, numKeys)
-	r, _ := randutil.NewPseudoRand()
-
-	var k int
-	for i := 0; i < numKeys; {
-		k += 1 + rand.Intn(100)
-		key := encoding.EncodeVarintAscending(append([]byte{}, prefix...), int64(k))
-		buf := make([]byte, valueSize)
-		randutil.ReadTestdataBytes(r, buf)
-		revisions := 1 + r.Intn(maxRevisions)
-
-		ts := int64(maxRevisions * 100)
-		for j := 0; j < revisions && i < numKeys; j++ {
-			ts -= 1 + r.Int63n(99)
-			kvs[i].Key.Key = key
-			kvs[i].Key.Timestamp.WallTime = ts
-			kvs[i].Key.Timestamp.Logical = r.Int31()
-			kvs[i].Value = roachpb.MakeValueFromString(string(buf)).RawBytes
-			i++
-		}
-	}
-	return kvs
-}
-
-func makeRocksSST(t testing.TB, kvs []engine.MVCCKeyValue) []byte {
-	w, err := engine.MakeRocksDBSstFileWriter()
-	require.NoError(t, err)
-	defer w.Close()
-
-	for i := range kvs {
-		if err := w.Put(kvs[i].Key, kvs[i].Value); err != nil {
-			t.Fatal(err)
-		}
-	}
-	sst, err := w.Finish()
-	require.NoError(t, err)
-	return sst
-}
-
-func makePebbleSST(t testing.TB, kvs []engine.MVCCKeyValue) []byte {
-	sst := bulk.SSTMemFile{}
-	w := bulk.MakeSSTWriter(&sst)
-	defer w.Close()
-
-	for i := range kvs {
-		if err := w.Put(kvs[i].Key, kvs[i].Value); err != nil {
-			t.Fatal(err)
-		}
-	}
-	err := w.Finish()
-	require.NoError(t, err)
-	return sst.Data()
-}
 
 // TestPebbleWritesSameSSTs tests that using pebble to write some SST produces
 // the same file -- byte-for-byte -- as using our Rocks-based writer. This is is
@@ -103,13 +42,15 @@ func TestPebbleWritesSameSSTs(t *testing.T) {
 	r, _ := randutil.NewPseudoRand()
 	const numKeys, valueSize, revisions = 5000, 100, 100
 
-	kvs := makeIntTableKVs(t, numKeys, valueSize, revisions)
-	sstRocks := makeRocksSST(t, kvs)
-	sstPebble := makePebbleSST(t, kvs)
-
-	itRocks, err := engine.NewMemSSTIterator(sstRocks, false)
+	kvs := MakeTestingIntTableKVs(numKeys, valueSize, revisions)
+	sstRocks, err := MakeTestingRocksSST(kvs)
 	require.NoError(t, err)
-	itPebble, err := engine.NewMemSSTIterator(sstPebble, false)
+	sstPebble, err := MakeTestingPebbleSST(kvs)
+	require.NoError(t, err)
+
+	itRocks, err := NewMemIterator(sstRocks, false)
+	require.NoError(t, err)
+	itPebble, err := NewMemIterator(sstPebble, false)
 	require.NoError(t, err)
 
 	itPebble.Seek(engine.NilKey)
@@ -146,12 +87,13 @@ func BenchmarkWriteSSTable(b *testing.B) {
 	b.StopTimer()
 	// Writing the SST 10 times keeps size needed for ~10s benchtime under 1gb.
 	const valueSize, revisions, ssts = 100, 100, 10
-	kvs := makeIntTableKVs(b, b.N, valueSize, revisions)
+	kvs := MakeTestingIntTableKVs(b.N, valueSize, revisions)
 	approxUserDataSizePerKV := kvs[b.N/2].Key.EncodedSize() + valueSize
 	b.SetBytes(int64(approxUserDataSizePerKV * ssts))
 	b.ResetTimer()
 	b.StartTimer()
 	for i := 0; i < ssts; i++ {
-		_ = makePebbleSST(b, kvs)
+		_, err := MakeTestingPebbleSST(kvs)
+		require.NoError(b, err)
 	}
 }

--- a/pkg/storage/engine/sst/writer_testing.go
+++ b/pkg/storage/engine/sst/writer_testing.go
@@ -1,0 +1,85 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sst
+
+import (
+	"math/rand"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+// MakeTestingIntTableKVs returns MVCC key values for a number of keys with
+// given value size and number of max revisions.
+func MakeTestingIntTableKVs(numKeys, valueSize, maxRevisions int) []engine.MVCCKeyValue {
+	prefix := encoding.EncodeUvarintAscending(keys.MakeTablePrefix(uint32(100)), uint64(1))
+	kvs := make([]engine.MVCCKeyValue, numKeys)
+	r, _ := randutil.NewPseudoRand()
+
+	var k int
+	for i := 0; i < numKeys; {
+		k += 1 + rand.Intn(100)
+		key := encoding.EncodeVarintAscending(append([]byte{}, prefix...), int64(k))
+		buf := make([]byte, valueSize)
+		randutil.ReadTestdataBytes(r, buf)
+		revisions := 1 + r.Intn(maxRevisions)
+
+		ts := int64(maxRevisions * 100)
+		for j := 0; j < revisions && i < numKeys; j++ {
+			ts -= 1 + r.Int63n(99)
+			kvs[i].Key.Key = key
+			kvs[i].Key.Timestamp.WallTime = ts
+			kvs[i].Key.Timestamp.Logical = r.Int31()
+			kvs[i].Value = roachpb.MakeValueFromString(string(buf)).RawBytes
+			i++
+		}
+	}
+	return kvs
+}
+
+// MakeTestingRocksSST creates an SST with the specified MVCC key values using
+// RocksDB.
+func MakeTestingRocksSST(kvs []engine.MVCCKeyValue) ([]byte, error) {
+	w, err := engine.MakeRocksDBSstFileWriter()
+	if err != nil {
+		return nil, err
+	}
+	defer w.Close()
+
+	for i := range kvs {
+		if err := w.Put(kvs[i].Key, kvs[i].Value); err != nil {
+			return nil, err
+		}
+	}
+	return w.Finish()
+}
+
+// MakeTestingPebbleSST creates an SST with the specified MVCC key values using
+// Pebble.
+func MakeTestingPebbleSST(kvs []engine.MVCCKeyValue) ([]byte, error) {
+	sst := MemFile{}
+	w := MakeWriter(&sst)
+	defer w.Close()
+
+	for i := range kvs {
+		if err := w.Put(kvs[i].Key, kvs[i].Value); err != nil {
+			return nil, err
+		}
+	}
+	err := w.Finish()
+	if err != nil {
+		return nil, err
+	}
+	return sst.Data(), nil
+}

--- a/pkg/storage/replica_sst_snapshot_storage_test.go
+++ b/pkg/storage/replica_sst_snapshot_storage_test.go
@@ -44,7 +44,7 @@ func TestSSTSnapshotStorage(t *testing.T) {
 		t.Fatalf("expected %s to not exist", ssss.snapDir)
 	}
 
-	sssf, err := ssss.NewFile()
+	sssf, err := ssss.NewFile(0)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, sssf.Close())
@@ -62,6 +62,7 @@ func TestSSTSnapshotStorage(t *testing.T) {
 	}
 
 	require.NoError(t, sssf.Write(ctx, []byte("foo")))
+	require.NoError(t, sssf.Sync())
 
 	// After writing to files, check that they have been flushed to disk.
 	for _, fileName := range ssss.SSTs() {
@@ -78,11 +79,15 @@ func TestSSTSnapshotStorage(t *testing.T) {
 	// Check that writing to a closed file is an error.
 	require.EqualError(t, sssf.Write(ctx, []byte("foo")), "file has already been closed")
 
+	// Check that syncing to a closed file is an error.
+	require.EqualError(t, sssf.Sync(), "file has already been closed")
+
 	// Check that closing an empty file is an error.
-	sssf, err = ssss.NewFile()
+	sssf, err = ssss.NewFile(0)
 	require.NoError(t, err)
 	require.EqualError(t, sssf.Close(), "file is empty")
 	require.NoError(t, sssf.Write(ctx, []byte("foo")))
+	require.NoError(t, sssf.Sync())
 
 	// Check that Clear removes the directory.
 	require.NoError(t, ssss.Clear())

--- a/pkg/storage/store_snapshot.go
+++ b/pkg/storage/store_snapshot.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/sst"
 	"github.com/cockroachdb/cockroach/pkg/storage/rditer"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -118,39 +119,75 @@ type kvBatchSnapshotStrategy struct {
 // disk.
 type multiSSTWriter struct {
 	ssss        *SSTSnapshotStorageScratch
-	currSST     engine.RocksDBSstFileWriter
-	currSSTFile *SSTSnapshotStorageFile
+	currSSTFile *sstFile
+	currSST     sst.Writer
 	keyRanges   []rditer.KeyRange
 	currRange   int
-	// The size of the SST the last time the SST file writer was truncated. This
-	// size is used to determine the size of the SST chunk buffered in-memory.
-	truncatedSize int64
-	// The approximate size of the SST chunk to buffer in memory on the receiver
-	// before flushing to disk.
+	// The approximate size of the SST chunk to buffer on the receiver before
+	// syncing to disk.
 	sstChunkSize int64
 }
 
+// sstFile is an adapter of SSTSnapshotStorageFile to implement
+// writeCloseSyncer for use with sst.Writer.
+type sstFile struct {
+	ctx  context.Context
+	sssf *SSTSnapshotStorageFile
+}
+
+func newSSTFile(
+	ctx context.Context, ssss *SSTSnapshotStorageScratch, bytesPerSync int64,
+) (*sstFile, error) {
+	sssf, err := ssss.NewFile(bytesPerSync)
+	if err != nil {
+		return nil, err
+	}
+	ssf := &sstFile{
+		ctx:  ctx,
+		sssf: sssf,
+	}
+	return ssf, nil
+}
+
+func (ssf *sstFile) Write(data []byte) (int, error) {
+	if err := ssf.sssf.Write(ssf.ctx, data); err != nil {
+		return 0, err
+	}
+	return len(data), nil
+}
+
+func (ssf *sstFile) Sync() error {
+	return ssf.sssf.Sync()
+}
+
+func (ssf *sstFile) Close() error {
+	return ssf.sssf.Close()
+}
+
 func newMultiSSTWriter(
-	ssss *SSTSnapshotStorageScratch, keyRanges []rditer.KeyRange, sstChunkSize int64,
+	ctx context.Context,
+	ssss *SSTSnapshotStorageScratch,
+	keyRanges []rditer.KeyRange,
+	sstChunkSize int64,
 ) (multiSSTWriter, error) {
 	msstw := multiSSTWriter{
 		ssss:         ssss,
 		keyRanges:    keyRanges,
 		sstChunkSize: sstChunkSize,
 	}
-	if err := msstw.initSST(); err != nil {
+	if err := msstw.initSST(ctx); err != nil {
 		return msstw, err
 	}
 	return msstw, nil
 }
 
-func (msstw *multiSSTWriter) initSST() error {
-	newSSTFile, err := msstw.ssss.NewFile()
+func (msstw *multiSSTWriter) initSST(ctx context.Context) error {
+	newSSTFile, err := newSSTFile(ctx, msstw.ssss, msstw.sstChunkSize)
 	if err != nil {
-		return errors.Wrap(err, "failed to create new sst file")
+		return errors.Wrap(err, "failed to create sst file")
 	}
 	msstw.currSSTFile = newSSTFile
-	newSST, err := engine.MakeRocksDBSstFileWriter()
+	newSST := sst.MakeWriter(newSSTFile)
 	if err != nil {
 		return errors.Wrap(err, "failed to create sst file writer")
 	}
@@ -159,20 +196,13 @@ func (msstw *multiSSTWriter) initSST() error {
 		msstw.currSST.Close()
 		return errors.Wrap(err, "failed to clear range on sst file writer")
 	}
-	msstw.truncatedSize = 0
 	return nil
 }
 
 func (msstw *multiSSTWriter) finalizeSST(ctx context.Context) error {
-	chunk, err := msstw.currSST.Finish()
+	err := msstw.currSST.Finish()
 	if err != nil {
 		return errors.Wrap(err, "failed to finish sst")
-	}
-	if err := msstw.currSSTFile.Write(ctx, chunk); err != nil {
-		return errors.Wrap(err, "failed to write to sst file")
-	}
-	if err := msstw.currSSTFile.Close(); err != nil {
-		return errors.Wrap(err, "failed to close sst file")
 	}
 	msstw.currRange++
 	msstw.currSST.Close()
@@ -186,7 +216,7 @@ func (msstw *multiSSTWriter) Put(ctx context.Context, key engine.MVCCKey, value 
 		if err := msstw.finalizeSST(ctx); err != nil {
 			return err
 		}
-		if err := msstw.initSST(); err != nil {
+		if err := msstw.initSST(ctx); err != nil {
 			return err
 		}
 	}
@@ -195,18 +225,6 @@ func (msstw *multiSSTWriter) Put(ctx context.Context, key engine.MVCCKey, value 
 	}
 	if err := msstw.currSST.Put(key, value); err != nil {
 		return errors.Wrap(err, "failed to put in sst")
-	}
-	if msstw.currSST.DataSize-msstw.truncatedSize > msstw.sstChunkSize {
-		msstw.truncatedSize = msstw.currSST.DataSize
-		chunk, err := msstw.currSST.Truncate()
-		if err != nil {
-			return errors.Wrap(err, "failed to truncate sst")
-		}
-		// NOTE: Chunk may be empty due to the semantics of Truncate(), but Write()
-		// handles an empty chunk as a noop.
-		if err := msstw.currSSTFile.Write(ctx, chunk); err != nil {
-			return errors.Wrap(err, "failed to write to sst file")
-		}
 	}
 	return nil
 }
@@ -220,7 +238,7 @@ func (msstw *multiSSTWriter) Finish(ctx context.Context) error {
 			if msstw.currRange >= len(msstw.keyRanges) {
 				break
 			}
-			if err := msstw.initSST(); err != nil {
+			if err := msstw.initSST(ctx); err != nil {
 				return err
 			}
 		}
@@ -228,9 +246,8 @@ func (msstw *multiSSTWriter) Finish(ctx context.Context) error {
 	return nil
 }
 
-func (msstw *multiSSTWriter) Close() error {
+func (msstw *multiSSTWriter) Close() {
 	msstw.currSST.Close()
-	return msstw.currSSTFile.Close()
 }
 
 // Receive implements the snapshotStrategy interface.
@@ -249,17 +266,13 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 	// At the moment we'll write at most three SSTs.
 	// TODO(jeffreyxiao): Re-evaluate as the default range size grows.
 	keyRanges := rditer.MakeReplicatedKeyRanges(header.State.Desc)
-	msstw, err := newMultiSSTWriter(kvSS.ssss, keyRanges, kvSS.sstChunkSize)
+	msstw, err := newMultiSSTWriter(ctx, kvSS.ssss, keyRanges, kvSS.sstChunkSize)
 	if err != nil {
 		return noSnap, err
 	}
-	defer func() {
-		// Nothing actionable if closing multiSSTWriter. Closing the same SST and
-		// SST file multiple times is idempotent.
-		if err := msstw.Close(); err != nil {
-			log.Warningf(ctx, "failed to close multiSSTWriter: %v", err)
-		}
-	}()
+	// Closing the same SST multiple times is idempotent.
+	defer msstw.Close()
+
 	var logEntries [][]byte
 
 	for {
@@ -300,10 +313,6 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 			// we must still construct SSTs with range deletion tombstones to remove
 			// the data.
 			if err := msstw.Finish(ctx); err != nil {
-				return noSnap, err
-			}
-
-			if err := msstw.Close(); err != nil {
 				return noSnap, err
 			}
 


### PR DESCRIPTION
The first commit implements the `engine.Writer` interface for `bulk.SSTWriter` and also adapts it to accept an `writeCloseSyncer`. This change allows users to specify if they want to write directly to the disk or to an in-memory buffer.

The second commit creates a new package in `engine` called `sst` that stores `sst.Iterator` and `sst.Writer`.

The third commit uses `bulk.SSTWriter` to write SSTs when receiving snapshots.

Using the same recovery evaluation metric in #38932, I found that there was a nice win in terms of recovery time for an average range size of 128 MiB.

```
name         old s/op   new s/op   delta
AvgBytes121  38.8 ±19%  32.6 ± 7%  -16.03%  (p=0.011 n=8+5)
```

This change should be beneficial across the board since we are avoiding the cost of a Cgo call per `Put`. We are also reducing the memory cost since we are eliminating the in-memory buffer when creating the SST chunks incrementally.

Depends on petermattis/pebble#240.

Fixes #39748.