### PR TITLE
backupccl: Remove flaky backup stats test

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -42,7 +42,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
@@ -3026,38 +3025,6 @@ func TestBackupRestoreShowJob(t *testing.T) {
 		{"BACKUP DATABASE data TO 'nodelocal:///foo' WITH revision_history"},
 		{"RESTORE TABLE data.bank FROM 'nodelocal:///foo' WITH into_db = 'data 2', skip_missing_foreign_keys"},
 	})
-}
-
-func TestCreateStatsAfterRestore(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	defer func(oldRefreshInterval, oldAsOf time.Duration) {
-		stats.DefaultRefreshInterval = oldRefreshInterval
-		stats.DefaultAsOfTime = oldAsOf
-	}(stats.DefaultRefreshInterval, stats.DefaultAsOfTime)
-	stats.DefaultRefreshInterval = time.Millisecond
-	stats.DefaultAsOfTime = time.Microsecond
-
-	const numAccounts = 1
-	_, _, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, initNone)
-	defer cleanupFn()
-
-	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled=true`)
-
-	sqlDB.Exec(t, `BACKUP DATABASE data TO $1 WITH revision_history`, localFoo)
-	sqlDB.Exec(t, `CREATE DATABASE "data 2"`)
-	sqlDB.Exec(t, `RESTORE data.bank FROM $1 WITH skip_missing_foreign_keys, into_db = $2`,
-		localFoo, "data 2")
-
-	// Verify that statistics have been created.
-	sqlDB.CheckQueryResultsRetry(t,
-		`SELECT statistics_name, column_names, row_count, distinct_count, null_count
-	  FROM [SHOW STATISTICS FOR TABLE "data 2".bank]`,
-		[][]string{
-			{"__auto__", "{id}", "1", "1", "0"},
-			{"__auto__", "{balance}", "1", "1", "0"},
-			{"__auto__", "{payload}", "1", "1", "0"},
-		})
 }
 
 func TestBackupCreatedStats(t *testing.T) {


### PR DESCRIPTION
This test was meant to test that the automatic stats collection was
backed-up, however sometimes stats could have been collected before any
data was inserted. This would result in a falky test.

TestBackupCreatedStats would already test this functionality, only
not for automatically generated stats. This should be sufficient
and not flaky.

Closes #39805.

Release note: None