### PR TITLE
roachtest: don't retry getDiskUsageInBytes if context is canceled

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1980,6 +1980,9 @@ func getDiskUsageInBytes(
 		var err error
 		out, err = c.RunWithBuffer(ctx, logger, c.Node(nodeIdx), fmt.Sprint("du -sk {store-dir} | grep -oE '^[0-9]+'"))
 		if err != nil {
+			if ctx.Err() != nil {
+				return 0, ctx.Err()
+			}
 			// `du` can fail if files get removed out from under it. RocksDB likes to do that
 			// during compactions and such. It's rare enough to just retry.
 			logger.Printf("retrying disk usage computation after spurious error: %s", err)


### PR DESCRIPTION
We see 9741070 identical lines like:
```
14:47:24]W:	 [Step 2/2] I190820 14:47:24.014582 176324 cluster.go:1985  failed to log message: write /home/agent/work/.go/src/github.com/cockroachdb/cockroach/artifacts/20190820-1445527/import/tpch/nodes=8/run_1/diskusage-exec.log: no space left on device: retrying disk usage computation after spurious error: cluster.RunWithBuffer: context canceled
```

in the teamcity roachprod logs, which looks to be the cause of the error:
```
Artifact file 'diskusage-exec.log' has size 28719493120 bytes which exceeds maximum allowed size of 3221225472 bytes. Maximum artifact size is configured at the Administration -> Global Settings page.
```

This might also be related to some test timeouts.

Release note: None