### PR TITLE
sql: Add per replica locality information to show ranges.

### DIFF
--- a/pkg/sql/delegate/show_ranges.go
+++ b/pkg/sql/delegate/show_ranges.go
@@ -44,10 +44,8 @@ func (d *delegator) delegateShowRanges(n *tree.ShowRanges) (tree.Statement, erro
 			range_size / 1000000 as range_size_mb,
 			replicas,
 			lease_holder,
-			locality
+			replica_localities,
 		FROM %[1]s.crdb_internal.ranges AS r
-		LEFT JOIN %[1]s.crdb_internal.gossip_nodes n ON
-		r.lease_holder = n.node_id
 		WHERE database_name=%[2]s
 		ORDER BY table_name, r.start_key
 		`
@@ -75,10 +73,8 @@ SELECT
   range_size / 1000000 as range_size_mb,
   replicas,
   lease_holder,
-  locality
+  replica_localities
 FROM crdb_internal.ranges AS r
-LEFT JOIN crdb_internal.gossip_nodes n ON
-r.lease_holder = n.node_id
 WHERE (r.start_key < x'%s')
   AND (r.end_key   > x'%s') ORDER BY r.start_key
 `,

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -213,15 +213,15 @@ SELECT * FROM crdb_internal.zones WHERE false
 ----
 zone_id  target  range_name  database_name  table_name  index_name  partition_name  config_yaml  config_sql  config_protobuf
 
-query ITTTTTTTTTTTI colnames
+query ITTTTTTTTTTTTI colnames
 SELECT * FROM crdb_internal.ranges WHERE range_id < 0
 ----
-range_id  start_key  start_pretty  end_key  end_pretty  database_name  table_name  index_name  replicas  learner_replicas  split_enforced_until  lease_holder range_size
+range_id  start_key  start_pretty  end_key  end_pretty  database_name  table_name  index_name  replicas  replica_localities learner_replicas  split_enforced_until  lease_holder range_size
 
-query ITTTTTTTTTT colnames
+query ITTTTTTTTTTT colnames
 SELECT * FROM crdb_internal.ranges_no_leases WHERE range_id < 0
 ----
-range_id  start_key  start_pretty  end_key  end_pretty  database_name  table_name  index_name  replicas  learner_replicas  split_enforced_until
+range_id  start_key  start_pretty  end_key  end_pretty  database_name  table_name  index_name  replicas  replica_localities learner_replicas  split_enforced_until
 
 statement ok
 INSERT INTO system.zones (id, config) VALUES

--- a/pkg/sql/show_ranges_test.go
+++ b/pkg/sql/show_ranges_test.go
@@ -13,6 +13,7 @@ package sql_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -24,7 +25,7 @@ import (
 func TestShowRangesWithLocality(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	const numNodes = 4
+	const numNodes = 3
 	ctx := context.Background()
 	tcArgs := base.TestClusterArgs{}
 
@@ -35,16 +36,32 @@ func TestShowRangesWithLocality(t *testing.T) {
 	sqlDB.Exec(t, `CREATE TABLE t (x INT PRIMARY KEY)`)
 	sqlDB.Exec(t, `ALTER TABLE t SPLIT AT SELECT i FROM generate_series(0, 20) AS g(i)`)
 
-	const nodeColIdx = 5
-	const localityColIdx = 6
+	const replicasColIdx = 4
+	const localitiesColIdx = 6
+	replicas := make([]int, 3)
 
 	result := sqlDB.QueryStr(t, `SHOW RANGES FROM TABLE t`)
 	for _, row := range result {
+		_, err := fmt.Sscanf(row[replicasColIdx], "{%d,%d,%d}", &replicas[0], &replicas[1], &replicas[2])
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		// Because StartTestCluster changes the locality no matter what the
 		// arguments are, we expect whatever the test server sets up.
-		locality := fmt.Sprintf("region=test,dc=dc%s", row[nodeColIdx])
-		if row[localityColIdx] != locality {
-			t.Fatalf("expected %s found %s", locality, row[localityColIdx])
+		var builder strings.Builder
+		builder.WriteString("{")
+		for i, replica := range replicas {
+			builder.WriteString(fmt.Sprintf(`"region=test,dc=dc%d"`, replica))
+			if i != len(replicas)-1 {
+				builder.WriteString(",")
+			}
+		}
+		builder.WriteString("}")
+		expected := builder.String()
+
+		if row[localitiesColIdx] != expected {
+			t.Fatalf("expected %s found %s", expected, row[localitiesColIdx])
 		}
 	}
 }


### PR DESCRIPTION
Fixes #39793.

Release note (sql change): Show ranges now displays per replica
locality information.