### PR TITLE
roachtest: various overload/tpcc_olap fixes

### DIFF
--- a/pkg/cmd/roachtest/overload_tpcc_olap.go
+++ b/pkg/cmd/roachtest/overload_tpcc_olap.go
@@ -59,7 +59,7 @@ func (s tpccOLAPSpec) run(ctx context.Context, t *test, c *cluster) {
 				" --query-file %s"+
 				" --histograms="+perfArtifactsDir+"/stats.json "+
 				" --ramp=%s --duration=%s {pgurl:1-%d}",
-			s.Warehouses, queryFileName, rampDuration, duration, c.spec.NodeCount-1)
+			s.Concurrency, queryFileName, rampDuration, duration, c.spec.NodeCount-1)
 		c.Run(ctx, workloadNode, cmd)
 		return nil
 	})

--- a/pkg/cmd/roachtest/overload_tpcc_olap.go
+++ b/pkg/cmd/roachtest/overload_tpcc_olap.go
@@ -48,8 +48,8 @@ func (s tpccOLAPSpec) run(ctx context.Context, t *test, c *cluster) {
 	c.Run(ctx, workloadNode, "echo", queryLine, "> "+queryFileName)
 	t.Status("waiting")
 	m := newMonitor(ctx, c, crdbNodes)
-	rampDuration := time.Minute
-	duration := 2 * time.Minute
+	rampDuration := 2 * time.Minute
+	duration := 3 * time.Minute
 	m.Go(func(ctx context.Context) error {
 		t.WorkerStatus("running querybench")
 		cmd := fmt.Sprintf(
@@ -109,10 +109,10 @@ func registerTPCCOverloadSpec(r *testRegistry, s tpccOLAPSpec) {
 func registerOverload(r *testRegistry) {
 	specs := []tpccOLAPSpec{
 		{
-			CPUs:        16,
-			Concurrency: 256,
+			CPUs:        8,
+			Concurrency: 96,
 			Nodes:       3,
-			Warehouses:  100,
+			Warehouses:  50,
 		},
 	}
 	for _, s := range specs {

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -147,7 +147,7 @@ func setupTPCC(
 
 				t.Status("loading dataset")
 				c.Start(ctx, t, crdbNodes, startArgsDontEncrypt)
-
+				waitForFullReplication(t, c.Conn(ctx, crdbNodes[0]))
 				c.Run(ctx, workloadNode, tpccFixturesCmd(t, cloud, warehouses, ""))
 				c.Stop(ctx, crdbNodes)
 
@@ -158,6 +158,7 @@ func setupTPCC(
 			c.Start(ctx, t, crdbNodes, startArgsDontEncrypt)
 		} else {
 			c.Start(ctx, t, crdbNodes, startArgsDontEncrypt)
+			waitForFullReplication(t, c.Conn(ctx, crdbNodes[0]))
 			c.Run(ctx, workloadNode, tpccFixturesCmd(t, cloud, warehouses, ""))
 		}
 	}()
@@ -640,6 +641,7 @@ func loadTPCCBench(
 
 	// Load the corresponding fixture.
 	t.l.Printf("restoring tpcc fixture\n")
+	waitForFullReplication(t, db)
 	cmd := tpccFixturesCmd(t, cloud, b.LoadWarehouses, loadArgs)
 	if err := c.RunE(ctx, loadNode, cmd); err != nil {
 		return err


### PR DESCRIPTION
This PR comes in 3 commits:

1) Actually use the concurrency option
2) Use 8-core nodes with a more favorable RAM/core ratio on smaller warehouse count at lower concurrency for a bit longer
3) Add a retry loop when fetching liveness metrics
4) Wait for full replication after starting the cluster. Immediately diving in to the restore can lead to restoring in to under replicated tables because the initial user range hasn't been up-replicated yet. 

I ran this now 20 times on each of GCP and AWS and it passed on all of them. I also ran it on 19.1.4 10 times each before and after the last commit. It failed 4 and 10 times respectively. 

Refers to #39684