### PR TITLE
WIP: security: enforce cluster name in client certificates

### DIFF
--- a/pkg/acceptance/cluster/certs.go
+++ b/pkg/acceptance/cluster/certs.go
@@ -39,17 +39,17 @@ func GenerateCerts(ctx context.Context) func() {
 	// Root user.
 	maybePanic(security.CreateClientPair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
-		512, 48*time.Hour, false, security.RootUser, true /* generate pk8 key */))
+		512, 48*time.Hour, false, security.RootUser, nil /* no cluster names */, true /* generate pk8 key */))
 
 	// Test user.
 	maybePanic(security.CreateClientPair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
-		512, 48*time.Hour, false, "testuser", true /* generate pk8 key */))
+		512, 48*time.Hour, false, "testuser", nil /* no cluster names */, true /* generate pk8 key */))
 
 	// Certs for starting a cockroach server. Key size is from cli/cert.go:defaultKeySize.
 	maybePanic(security.CreateNodePair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
-		2048, 48*time.Hour, false, []string{"localhost", "cockroach"}))
+		2048, 48*time.Hour, false, []string{"localhost", "cockroach"}, nil /* no cluster names */))
 
 	// Store a copy of the client certificate and private key in a PKCS#12
 	// bundle, which is the only format understood by Npgsql (.NET).

--- a/pkg/acceptance/cluster/dockercluster.go
+++ b/pkg/acceptance/cluster/dockercluster.go
@@ -451,7 +451,7 @@ func (l *DockerCluster) createNodeCerts() {
 	maybePanic(security.CreateNodePair(
 		certsDir,
 		filepath.Join(certsDir, security.EmbeddedCAKey),
-		keyLen, 48*time.Hour, true /* overwrite */, nodes))
+		keyLen, 48*time.Hour, true /* overwrite */, nodes, nil /* no cluster names */))
 }
 
 // startNode starts a Docker container to run testNode. It may be called in

--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -185,6 +185,12 @@ type Config struct {
 	// existing cluster into using a new cluster name.
 	DisableClusterNameVerification bool
 
+	// EnforceClusterNameInCertificate, when set, requires the
+	// cluster name to match one of the cluster names specified
+	// in client certificates.
+	// If either is specified, both must be set.
+	EnforceClusterNameInCertificate bool
+
 	// SplitListenSQL indicates whether to listen for SQL
 	// clients on a separate address from RPC requests.
 	SplitListenSQL bool
@@ -249,6 +255,7 @@ func (cfg *Config) InitDefaults() {
 	cfg.RPCHeartbeatInterval = defaultRPCHeartbeatInterval
 	cfg.ClusterName = ""
 	cfg.DisableClusterNameVerification = false
+	cfg.EnforceClusterNameInCertificate = false
 }
 
 // HTTPRequestScheme returns "http" or "https" based on the value of Insecure.

--- a/pkg/ccl/gssapiccl/gssapi.go
+++ b/pkg/ccl/gssapiccl/gssapi.go
@@ -42,9 +42,9 @@ const (
 // https:github.com/postgres/postgres/blob/0f9cdd7dca694d487ab663d463b308919f591c02/src/backend/libpq/auth.c#L1090
 func authGSS(
 	c pgwire.AuthConn,
-	tlsState tls.ConnectionState,
-	insecure bool,
-	hashedPassword []byte,
+	_ tls.ConnectionState,
+	_ security.AuthContext,
+	_ []byte,
 	execCfg *sql.ExecutorConfig,
 	entry *hba.Entry,
 ) (security.UserAuthHook, error) {

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -315,14 +315,14 @@ restarted again with this flag removed.`,
 Specify the cluster name in the certificate. When connecting to a node
 the cluster name in the certificate and the node's --cluster-name must match.
 
-This is stored in the Subject OU as: "clustername=<identifier>".`,
+This is stored in the Subject OU as: "cluster-name=<identifier>".`,
 	}
 
 	EnforceClusterNameInCertificate = FlagInfo{
 		Name: "enforce-cluster-name-in-certificate",
 		Description: `
 The --cluster-name must match one of the clusters in client certificate
-Subject.OrganizationUnit (can be repeated, format: "clustername=<identifier>").
+Subject.OrganizationUnit (can be repeated, format: "cluster-name=<identifier>").
 
 If --cluster-name is set, an exact match must be found in client certificates.
 If --cluster-name is not set, no cluster name must be set in client certificates.

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -307,6 +307,17 @@ been updated to know the new cluster name, the cluster can be
 restarted again with this flag removed.`,
 	}
 
+	// This is the cluster-name passed to the cert sub-commands.
+	// We could reuse ClusterName but a more specific description is helpful.
+	CertificateClusterName = FlagInfo{
+		Name: "cluster-name",
+		Description: `
+Specify the cluster name in the certificate. When connecting to a node
+the cluster name in the certificate and the node's --cluster-name must match.
+
+This is stored in the Subject OU as: "clustername=<identifier>".`,
+	}
+
 	Join = FlagInfo{
 		Name:      "join",
 		Shorthand: "j",

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -318,6 +318,19 @@ the cluster name in the certificate and the node's --cluster-name must match.
 This is stored in the Subject OU as: "clustername=<identifier>".`,
 	}
 
+	EnforceClusterNameInCertificate = FlagInfo{
+		Name: "enforce-cluster-name-in-certificate",
+		Description: `
+The --cluster-name must match one of the clusters in client certificate
+Subject.OrganizationUnit (can be repeated, format: "clustername=<identifier>").
+
+If --cluster-name is set, an exact match must be found in client certificates.
+If --cluster-name is not set, no cluster name must be set in client certificates.
+
+This applies to client certificates for SQL clients AND client certificates
+used by nodes.`,
+	}
+
 	Join = FlagInfo{
 		Name:      "join",
 		Shorthand: "j",

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -372,10 +372,13 @@ func init() {
 		VarFlag(f, &serverCfg.JoinList, cliflags.Join)
 		VarFlag(f, clusterNameSetter{&baseCfg.ClusterName}, cliflags.ClusterName)
 		BoolFlag(f, &baseCfg.DisableClusterNameVerification, cliflags.DisableClusterNameVerification, false)
+
+		// Enforcement of cluster name (--cluster-name) in client (SQL and internal) certificates.
+		BoolFlag(f, &baseCfg.EnforceClusterNameInCertificate, cliflags.EnforceClusterNameInCertificate, false)
+
 		// We also hide it from help for 'start-single-node'.
 		if cmd == startSingleNodeCmd {
 			_ = f.MarkHidden(cliflags.Join.Name)
-			_ = f.MarkHidden(cliflags.ClusterName.Name)
 			_ = f.MarkHidden(cliflags.DisableClusterNameVerification.Name)
 		}
 

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -429,6 +429,8 @@ func init() {
 	for _, cmd := range []*cobra.Command{createNodeCertCmd, createClientCertCmd} {
 		f := cmd.Flags()
 		DurationFlag(f, &certificateLifetime, cliflags.CertificateLifetime, defaultCertLifetime)
+		// Only the node and client certificates have a cluster name.
+		VarFlag(f, clusterNameSetter{&certificateClusterName}, cliflags.CertificateClusterName)
 	}
 
 	// The remaining flags are shared between all cert-generating functions.

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -111,7 +111,7 @@ func spanInclusionFuncForClient(
 }
 
 // checkTLSSuperUser is called for secure mode only. It checks the request context
-// for a valid super user ("node" or "root"), as well as
+// for a valid super user ("node" or "root") as well as cluster name if specified at startup.
 func checkTLSSuperUser(ctx context.Context, authCtx security.AuthContext) error {
 	if grpcutil.IsLocalRequestContext(ctx) {
 		// This is an in-process request. Bypass authentication check.

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -128,11 +128,7 @@ func checkTLSSuperUser(ctx context.Context, authCtx security.AuthContext) error 
 		return errors.New("internal authentication error: TLSInfo is not available in request context")
 	}
 
-	if err := security.AuthenticateRPC(authCtx, &tlsInfo.State); err != nil {
-		return err
-	}
-
-	return nil
+	return security.AuthenticateRPC(authCtx, &tlsInfo.State)
 }
 
 // NewServer is a thin wrapper around grpc.NewServer that registers a heartbeat

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -110,30 +110,28 @@ func spanInclusionFuncForClient(
 	return parentSpanCtx != nil && !tracing.IsNoopContext(parentSpanCtx)
 }
 
-func requireSuperUser(ctx context.Context) error {
-	// TODO(marc): grpc's authentication model (which gives credential access in
-	// the request handler) doesn't really fit with the current design of the
-	// security package (which assumes that TLS state is only given at connection
-	// time) - that should be fixed.
+// checkTLSSuperUser is called for secure mode only. It checks the request context
+// for a valid super user ("node" or "root"), as well as
+func checkTLSSuperUser(ctx context.Context, authCtx security.AuthContext) error {
 	if grpcutil.IsLocalRequestContext(ctx) {
 		// This is an in-process request. Bypass authentication check.
-	} else if peer, ok := peer.FromContext(ctx); ok {
-		if tlsInfo, ok := peer.AuthInfo.(credentials.TLSInfo); ok {
-			certUser, err := security.GetCertificateUser(&tlsInfo.State)
-			if err != nil {
-				return err
-			}
-			// TODO(benesch): the vast majority of RPCs should be limited to just
-			// NodeUser. This is not a security concern, as RootUser has access to
-			// read and write all data, merely good hygiene. For example, there is
-			// no reason to permit the root user to send raw Raft RPCs.
-			if certUser != security.NodeUser && certUser != security.RootUser {
-				return errors.Errorf("user %s is not allowed to perform this RPC", certUser)
-			}
-		}
-	} else {
+		return nil
+	}
+
+	peer, ok := peer.FromContext(ctx)
+	if !ok {
+		return errors.New("internal authentication error: peer info is not available in request context")
+	}
+
+	tlsInfo, ok := peer.AuthInfo.(credentials.TLSInfo)
+	if !ok {
 		return errors.New("internal authentication error: TLSInfo is not available in request context")
 	}
+
+	if err := security.AuthenticateRPC(authCtx, &tlsInfo.State); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -240,11 +238,18 @@ func NewServerWithInterceptor(
 	}
 
 	if !ctx.Insecure {
+		// Authentication context for the node. Does not change during its lifetime.
+		authContext := security.AuthContext{
+			Insecure:                        false,
+			ClusterName:                     ctx.ClusterName(),
+			EnforceClusterNameInCertificate: ctx.enforceClusterNameInCertificate,
+		}
+
 		prevUnaryInterceptor := unaryInterceptor
 		unaryInterceptor = func(
 			ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
 		) (interface{}, error) {
-			if err := requireSuperUser(ctx); err != nil {
+			if err := checkTLSSuperUser(ctx, authContext); err != nil {
 				return nil, err
 			}
 			if prevUnaryInterceptor != nil {
@@ -256,7 +261,7 @@ func NewServerWithInterceptor(
 		streamInterceptor = func(
 			srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler,
 		) error {
-			if err := requireSuperUser(stream.Context()); err != nil {
+			if err := checkTLSSuperUser(stream.Context(), authContext); err != nil {
 				return err
 			}
 			if prevStreamInterceptor != nil {
@@ -397,8 +402,9 @@ type Context struct {
 	NodeID    base.NodeIDContainer
 	version   *cluster.ExposedClusterVersion
 
-	clusterName                    string
-	disableClusterNameVerification bool
+	clusterName                     string
+	disableClusterNameVerification  bool
+	enforceClusterNameInCertificate bool
 
 	metrics Metrics
 
@@ -459,11 +465,12 @@ func NewContextWithTestingKnobs(
 		breakerClock: breakerClock{
 			clock: hlcClock,
 		},
-		rpcCompression:                 enableRPCCompression,
-		version:                        version,
-		clusterName:                    baseCtx.ClusterName,
-		disableClusterNameVerification: baseCtx.DisableClusterNameVerification,
-		testingKnobs:                   knobs,
+		rpcCompression:                  enableRPCCompression,
+		version:                         version,
+		clusterName:                     baseCtx.ClusterName,
+		disableClusterNameVerification:  baseCtx.DisableClusterNameVerification,
+		enforceClusterNameInCertificate: baseCtx.EnforceClusterNameInCertificate,
+		testingKnobs:                    knobs,
 	}
 	var cancel context.CancelFunc
 	ctx.masterCtx, cancel = context.WithCancel(ambient.AnnotateCtx(context.Background()))

--- a/pkg/security/auth.go
+++ b/pkg/security/auth.go
@@ -51,7 +51,7 @@ func GetCertificateUser(tlsState *tls.ConnectionState) (string, error) {
 	return tlsState.PeerCertificates[0].Subject.CommonName, nil
 }
 
-// CheckCertificateClusterName checks whether the clustername is set in the peer certificate.
+// CheckCertificateClusterName checks whether the cluster-name is set in the peer certificate.
 func CheckCertificateClusterName(authCtx AuthContext, tlsState *tls.ConnectionState) error {
 	if tlsState == nil {
 		return errors.Errorf("request is not using TLS")

--- a/pkg/security/auth.go
+++ b/pkg/security/auth.go
@@ -116,11 +116,7 @@ func AuthenticateRPC(authCtx AuthContext, tlsState *tls.ConnectionState) error {
 		return errors.Errorf("user %s is not allowed to perform this RPC", certUser)
 	}
 
-	if err := CheckCertificateClusterName(authCtx, tlsState); err != nil {
-		return err
-	}
-
-	return nil
+	return CheckCertificateClusterName(authCtx, tlsState)
 }
 
 // UserAuthCertHook builds an authentication hook based on the security
@@ -168,7 +164,9 @@ func UserAuthCertHook(authCtx AuthContext, tlsState *tls.ConnectionState) (UserA
 
 // UserAuthPasswordHook builds an authentication hook based on the security
 // mode, password, and its potentially matching hash.
-func UserAuthPasswordHook(authCtx AuthContext, password string, hashedPassword []byte) UserAuthHook {
+func UserAuthPasswordHook(
+	authCtx AuthContext, password string, hashedPassword []byte,
+) UserAuthHook {
 	return func(requestedUser string, clientConnection bool) error {
 		if len(requestedUser) == 0 {
 			return errors.New("user is missing")

--- a/pkg/security/auth_test.go
+++ b/pkg/security/auth_test.go
@@ -102,7 +102,7 @@ func TestAuthenticationHook(t *testing.T) {
 	}
 
 	for tcNum, tc := range testCases {
-		hook, err := security.UserAuthCertHook(tc.insecure, tc.tls)
+		hook, err := security.UserAuthCertHook(security.AuthContext{Insecure: tc.insecure}, tc.tls)
 		if (err == nil) != tc.buildHookSuccess {
 			t.Fatalf("#%d: expected success=%t, got err=%v", tcNum, tc.buildHookSuccess, err)
 		}

--- a/pkg/security/certs.go
+++ b/pkg/security/certs.go
@@ -234,7 +234,8 @@ func createCACertAndKey(
 // The CA cert and key must load properly. If multiple certificates
 // exist in the CA cert, the first one is used.
 func CreateNodePair(
-	certsDir, caKeyPath string, keySize int, lifetime time.Duration, overwrite bool, hosts []string,
+	certsDir, caKeyPath string, keySize int, lifetime time.Duration, overwrite bool,
+	hosts []string, clusterNames []string,
 ) error {
 	if len(caKeyPath) == 0 {
 		return errors.New("the path to the CA key is required")
@@ -265,7 +266,7 @@ func CreateNodePair(
 		return errors.Errorf("could not generate new node key: %v", err)
 	}
 
-	nodeCert, err := GenerateServerCert(caCert, caPrivateKey, nodeKey.Public(), lifetime, hosts)
+	nodeCert, err := GenerateServerCert(caCert, caPrivateKey, nodeKey.Public(), lifetime, hosts, clusterNames)
 	if err != nil {
 		return errors.Errorf("error creating node server certificate and key: %s", err)
 	}
@@ -351,6 +352,7 @@ func CreateClientPair(
 	lifetime time.Duration,
 	overwrite bool,
 	user string,
+	clusterNames []string,
 	wantPKCS8Key bool,
 ) error {
 	if len(caKeyPath) == 0 {
@@ -391,7 +393,7 @@ func CreateClientPair(
 		return errors.Errorf("could not generate new client key: %v", err)
 	}
 
-	clientCert, err := GenerateClientCert(caCert, caPrivateKey, clientKey.Public(), lifetime, user)
+	clientCert, err := GenerateClientCert(caCert, caPrivateKey, clientKey.Public(), lifetime, user, clusterNames)
 	if err != nil {
 		return errors.Errorf("error creating client certificate and key: %s", err)
 	}

--- a/pkg/security/certs.go
+++ b/pkg/security/certs.go
@@ -234,8 +234,13 @@ func createCACertAndKey(
 // The CA cert and key must load properly. If multiple certificates
 // exist in the CA cert, the first one is used.
 func CreateNodePair(
-	certsDir, caKeyPath string, keySize int, lifetime time.Duration, overwrite bool,
-	hosts []string, clusterNames []string,
+	certsDir string,
+	caKeyPath string,
+	keySize int,
+	lifetime time.Duration,
+	overwrite bool,
+	hosts []string,
+	clusterNames []string,
 ) error {
 	if len(caKeyPath) == 0 {
 		return errors.New("the path to the CA key is required")

--- a/pkg/security/certs_test.go
+++ b/pkg/security/certs_test.go
@@ -125,7 +125,7 @@ func TestGenerateNodeCerts(t *testing.T) {
 	// Try generating node certs without CA certs present.
 	if err := security.CreateNodePair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
-		512, time.Hour*48, false, []string{"localhost"},
+		512, time.Hour*48, false, []string{"localhost"}, nil,
 	); err == nil {
 		t.Fatalf("Expected error, but got none")
 	}
@@ -139,7 +139,7 @@ func TestGenerateNodeCerts(t *testing.T) {
 
 	if err := security.CreateNodePair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
-		512, time.Hour*48, false, []string{"localhost"},
+		512, time.Hour*48, false, []string{"localhost"}, nil,
 	); err != nil {
 		t.Fatalf("Expected success, got %v", err)
 	}
@@ -159,14 +159,14 @@ func generateBaseCerts(certsDir string) error {
 
 	if err := security.CreateNodePair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
-		512, time.Hour*48, true, []string{"127.0.0.1"},
+		512, time.Hour*48, true, []string{"127.0.0.1"}, nil,
 	); err != nil {
 		return errors.Errorf("could not generate Node pair: %v", err)
 	}
 
 	if err := security.CreateClientPair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
-		512, time.Hour*48, true, security.RootUser, false,
+		512, time.Hour*48, true, security.RootUser, nil, false,
 	); err != nil {
 		return errors.Errorf("could not generate Client pair: %v", err)
 	}
@@ -190,7 +190,7 @@ func generateSplitCACerts(certsDir string) error {
 
 	if err := security.CreateNodePair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
-		512, time.Hour*48, true, []string{"127.0.0.1"},
+		512, time.Hour*48, true, []string{"127.0.0.1"}, nil,
 	); err != nil {
 		return errors.Errorf("could not generate Node pair: %v", err)
 	}
@@ -204,14 +204,14 @@ func generateSplitCACerts(certsDir string) error {
 
 	if err := security.CreateClientPair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedClientCAKey),
-		512, time.Hour*48, true, security.NodeUser, false,
+		512, time.Hour*48, true, security.NodeUser, nil, false,
 	); err != nil {
 		return errors.Errorf("could not generate Client pair: %v", err)
 	}
 
 	if err := security.CreateClientPair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedClientCAKey),
-		512, time.Hour*48, true, security.RootUser, false,
+		512, time.Hour*48, true, security.RootUser, nil, false,
 	); err != nil {
 		return errors.Errorf("could not generate Client pair: %v", err)
 	}

--- a/pkg/security/utils.go
+++ b/pkg/security/utils.go
@@ -85,7 +85,7 @@ func ExtKeyUsageToString(eku x509.ExtKeyUsage) string {
 }
 
 // ClusterNamesFromList takes in a list of strings.
-// When a string of the form `clustername=<identifier>` is encountered, `<identifier>` is
+// When a string of the form `cluster-name=<identifier>` is encountered, `<identifier>` is
 // added to the returned list.
 func ClusterNamesFromList(strList []string) []string {
 	ret := []string{}

--- a/pkg/security/utils.go
+++ b/pkg/security/utils.go
@@ -10,7 +10,10 @@
 
 package security
 
-import "crypto/x509"
+import (
+	"crypto/x509"
+	"strings"
+)
 
 // KeyUsageToString returns the list of key usages described by the bitmask.
 // This list may not up-to-date with https://golang.org/pkg/crypto/x509/#KeyUsage
@@ -79,4 +82,24 @@ func ExtKeyUsageToString(eku x509.ExtKeyUsage) string {
 	default:
 		return "unknown"
 	}
+}
+
+// ClusterNamesFromList takes in a list of strings.
+// When a string of the form `clustername=<identifier>` is encountered, `<identifier>` is
+// added to the returned list.
+func ClusterNamesFromList(strList []string) []string {
+	ret := []string{}
+	prefixLength := len(clusternamePrefix)
+	for _, s := range strList {
+		if len(s) <= prefixLength {
+			// Skip strings that are too short of have an empty cluster name.
+			continue
+		}
+		if !strings.HasPrefix(s, clusternamePrefix) {
+			continue
+		}
+
+		ret = append(ret, s[prefixLength:])
+	}
+	return ret
 }

--- a/pkg/security/x509.go
+++ b/pkg/security/x509.go
@@ -38,7 +38,9 @@ const (
 
 // newTemplate returns a partially-filled template.
 // It should be further populated based on the type of certificate (CA/server/client).
-func newTemplate(commonName string, clusterNames []string, lifetime time.Duration) (*x509.Certificate, error) {
+func newTemplate(
+	commonName string, clusterNames []string, lifetime time.Duration,
+) (*x509.Certificate, error) {
 	// Generate a random serial number.
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
@@ -50,7 +52,7 @@ func newTemplate(commonName string, clusterNames []string, lifetime time.Duratio
 	notBefore := now.Add(validFrom)
 	notAfter := now.Add(lifetime)
 
-	populatedClusterNames := make([]string, len(clusterNames), len(clusterNames))
+	populatedClusterNames := make([]string, len(clusterNames))
 	for i, n := range clusterNames {
 		populatedClusterNames[i] = clusternamePrefix + n
 	}

--- a/pkg/security/x509.go
+++ b/pkg/security/x509.go
@@ -33,7 +33,7 @@ const (
 	validFrom         = -time.Hour * 24
 	maxPathLength     = 1
 	caCommonName      = "Cockroach CA"
-	clusternamePrefix = "clustername="
+	clusternamePrefix = "cluster-name="
 )
 
 // newTemplate returns a partially-filled template.
@@ -118,7 +118,7 @@ func checkLifetimeAgainstCA(cert, ca *x509.Certificate) error {
 // GenerateServerCert generates a server certificate and returns the cert bytes.
 // Takes in the CA cert and private key, the node public key, the certificate lifetime,
 // and the list of hosts/ip addresses this certificate applies to.
-// If non-empty, the list of `clusterNames` is added as repeated `clustername=<name>` to the subject's OU.
+// If non-empty, the list of `clusterNames` is added as repeated `cluster-name=<name>` to the subject's OU.
 func GenerateServerCert(
 	caCert *x509.Certificate,
 	caPrivateKey crypto.PrivateKey,
@@ -198,7 +198,7 @@ func GenerateUIServerCert(
 // GenerateClientCert generates a client certificate and returns the cert bytes.
 // Takes in the CA cert and private key, the client public key, the certificate lifetime,
 // and the username.
-// If non-empty, the list of `clusterNames` is added as repeated `clustername=<name>` to the subject's OU.
+// If non-empty, the list of `clusterNames` is added as repeated `cluster-name=<name>` to the subject's OU.
 func GenerateClientCert(
 	caCert *x509.Certificate,
 	caPrivateKey crypto.PrivateKey,

--- a/pkg/security/x509.go
+++ b/pkg/security/x509.go
@@ -30,14 +30,15 @@ import (
 const (
 	// Make certs valid a day before to handle clock issues, specifically
 	// boot2docker: https://github.com/boot2docker/boot2docker/issues/69
-	validFrom     = -time.Hour * 24
-	maxPathLength = 1
-	caCommonName  = "Cockroach CA"
+	validFrom         = -time.Hour * 24
+	maxPathLength     = 1
+	caCommonName      = "Cockroach CA"
+	clusternamePrefix = "clustername="
 )
 
 // newTemplate returns a partially-filled template.
-// It should be further populated based on whether the cert is for a CA or node.
-func newTemplate(commonName string, lifetime time.Duration) (*x509.Certificate, error) {
+// It should be further populated based on the type of certificate (CA/server/client).
+func newTemplate(commonName string, clusterNames []string, lifetime time.Duration) (*x509.Certificate, error) {
 	// Generate a random serial number.
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
@@ -49,11 +50,17 @@ func newTemplate(commonName string, lifetime time.Duration) (*x509.Certificate, 
 	notBefore := now.Add(validFrom)
 	notAfter := now.Add(lifetime)
 
+	populatedClusterNames := make([]string, len(clusterNames), len(clusterNames))
+	for i, n := range clusterNames {
+		populatedClusterNames[i] = clusternamePrefix + n
+	}
+
 	cert := &x509.Certificate{
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
-			Organization: []string{"Cockroach"},
-			CommonName:   commonName,
+			Organization:       []string{"Cockroach"},
+			CommonName:         commonName,
+			OrganizationalUnit: populatedClusterNames,
 		},
 		NotBefore: notBefore,
 		NotAfter:  notAfter,
@@ -67,7 +74,7 @@ func newTemplate(commonName string, lifetime time.Duration) (*x509.Certificate, 
 // GenerateCA generates a CA certificate and signs it using the signer (a private key).
 // It returns the DER-encoded certificate.
 func GenerateCA(signer crypto.Signer, lifetime time.Duration) ([]byte, error) {
-	template, err := newTemplate(caCommonName, lifetime)
+	template, err := newTemplate(caCommonName, nil, lifetime)
 	if err != nil {
 		return nil, err
 	}
@@ -109,15 +116,17 @@ func checkLifetimeAgainstCA(cert, ca *x509.Certificate) error {
 // GenerateServerCert generates a server certificate and returns the cert bytes.
 // Takes in the CA cert and private key, the node public key, the certificate lifetime,
 // and the list of hosts/ip addresses this certificate applies to.
+// If non-empty, the list of `clusterNames` is added as repeated `clustername=<name>` to the subject's OU.
 func GenerateServerCert(
 	caCert *x509.Certificate,
 	caPrivateKey crypto.PrivateKey,
 	nodePublicKey crypto.PublicKey,
 	lifetime time.Duration,
 	hosts []string,
+	clusterNames []string,
 ) ([]byte, error) {
 	// Create template for user "NodeUser".
-	template, err := newTemplate(NodeUser, lifetime)
+	template, err := newTemplate(NodeUser, clusterNames, lifetime)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +136,7 @@ func GenerateServerCert(
 		return nil, err
 	}
 
-	// Only server authentication is allowed.
+	// Dual-purpose certificate: allow server and client authentication.
 	template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}
 	for _, h := range hosts {
 		if ip := net.ParseIP(h); ip != nil {
@@ -156,7 +165,7 @@ func GenerateUIServerCert(
 	hosts []string,
 ) ([]byte, error) {
 	// Use the first host as the CN. We still place all in the alternative subject name.
-	template, err := newTemplate(hosts[0], lifetime)
+	template, err := newTemplate(hosts[0], nil, lifetime)
 	if err != nil {
 		return nil, err
 	}
@@ -187,21 +196,22 @@ func GenerateUIServerCert(
 // GenerateClientCert generates a client certificate and returns the cert bytes.
 // Takes in the CA cert and private key, the client public key, the certificate lifetime,
 // and the username.
+// If non-empty, the list of `clusterNames` is added as repeated `clustername=<name>` to the subject's OU.
 func GenerateClientCert(
 	caCert *x509.Certificate,
 	caPrivateKey crypto.PrivateKey,
 	clientPublicKey crypto.PublicKey,
 	lifetime time.Duration,
 	user string,
+	clusterNames []string,
 ) ([]byte, error) {
 
-	// TODO(marc): should we add extra checks?
 	if len(user) == 0 {
 		return nil, errors.Errorf("user cannot be empty")
 	}
 
 	// Create template for "user".
-	template, err := newTemplate(user, lifetime)
+	template, err := newTemplate(user, clusterNames, lifetime)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/x509_test.go
+++ b/pkg/security/x509_test.go
@@ -61,14 +61,14 @@ func TestGenerateCertLifetime(t *testing.T) {
 
 	// Create a Node certificate expiring in 4 days. Fails on shorter CA lifetime.
 	nodeDuration := time.Hour * 96
-	_, err = security.GenerateServerCert(caCert, testKey, testKey.Public(), nodeDuration, []string{"localhost"})
+	_, err = security.GenerateServerCert(caCert, testKey, testKey.Public(), nodeDuration, []string{"localhost"}, nil)
 	if !testutils.IsError(err, "CA lifetime is .*, shorter than the requested .*") {
 		t.Fatal(err)
 	}
 
 	// Try again, but expiring before the CA cert.
 	nodeDuration = time.Hour * 24
-	nodeBytes, err := security.GenerateServerCert(caCert, testKey, testKey.Public(), nodeDuration, []string{"localhost"})
+	nodeBytes, err := security.GenerateServerCert(caCert, testKey, testKey.Public(), nodeDuration, []string{"localhost"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,14 +84,14 @@ func TestGenerateCertLifetime(t *testing.T) {
 
 	// Create a Client certificate expiring in 4 days. Should get reduced to the CA lifetime.
 	clientDuration := time.Hour * 96
-	_, err = security.GenerateClientCert(caCert, testKey, testKey.Public(), clientDuration, "testuser")
+	_, err = security.GenerateClientCert(caCert, testKey, testKey.Public(), clientDuration, "testuser", []string{})
 	if !testutils.IsError(err, "CA lifetime is .*, shorter than the requested .*") {
 		t.Fatal(err)
 	}
 
 	// Try again, but expiring before the CA cert.
 	clientDuration = time.Hour * 24
-	clientBytes, err := security.GenerateClientCert(caCert, testKey, testKey.Public(), clientDuration, "testuser")
+	clientBytes, err := security.GenerateClientCert(caCert, testKey, testKey.Public(), clientDuration, "testuser", []string{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -552,7 +552,8 @@ func (s *statusServer) Certificates(
 }
 
 func formatCertNames(p pkix.Name) string {
-	return fmt.Sprintf("CommonName=%s, Organization=%s", p.CommonName, strings.Join(p.Organization, ","))
+	return fmt.Sprintf("CN=%s, O=%s, OU=%s",
+		p.CommonName, strings.Join(p.Organization, ","), strings.Join(p.OrganizationalUnit, ","))
 }
 
 func extractCertFields(contents []byte, details *serverpb.CertificateDetails) error {

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -1466,10 +1466,7 @@ func (r *pgwireReader) ReadByte() (byte, error) {
 // authentication and update c.sessionArgs with the authenticated user's name,
 // if different from the one given initially.
 func (c *conn) handleAuthentication(
-	ctx context.Context,
-	ac AuthConn,
-	authOpt authOptions,
-	execCfg *sql.ExecutorConfig,
+	ctx context.Context, ac AuthConn, authOpt authOptions, execCfg *sql.ExecutorConfig,
 ) error {
 	sendError := func(err error) error {
 		_ /* err */ = writeErr(ctx, &execCfg.Settings.SV, err, &c.msgBuilder, c.conn)

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -538,7 +539,11 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 		&s.metrics, reserved, s.SQLServer,
 		s.IsDraining,
 		authOptions{
-			insecure: s.cfg.Insecure,
+			authCtx: security.AuthContext{
+				Insecure:                        s.cfg.Insecure,
+				ClusterName:                     s.cfg.ClusterName,
+				EnforceClusterNameInCertificate: s.cfg.EnforceClusterNameInCertificate,
+			},
 			ie:       s.execCfg.InternalExecutor,
 			auth:     auth,
 			authHook: authHook,


### PR DESCRIPTION
This is a work in progress: DO NOT MERGE.

Part of #28408.

Add a new flag to the `start` command: `--enforce-cluster-name-in-certificate`

If true, the `--cluster-name` must be found in all client certificate `Subject.OrganizationalUnit` field.
If absent in one, it must be absent in both. The OU field can contain multiple cluster names.

When the flag is not set, we check nothing at all. This is to allow the use of `--cluster-name` for join safety but not used to certificate restrictions.

The check is performed by nodes against all client certificates (SQL clients as well as internal clients).

When the flag is set, the following use cases are either accepted (:heavy_check_mark:) or rejected (:x:):

|  | OU: | OU: `clustername=cyan` | OU: `clustername=omega` | OU: `clustername=cyan`, `clustername=omega` |
|-|-|-|-|-|
| `--cluster-name=` | :heavy_check_mark: | :x: | :x: | :x: |
| `--clustername=cyan` | :x: | :heavy_check_mark: | :x: | :heavy_check_mark: |
| `--clustername=adriatic` | :x: | :x: | :x: | :x: |

The `cert` subcommand currently allows a single cluster name to be set in the cert, but the underlying code allows more than one (for testing). Is it necessary to allow more than one on the CLI?

Some of the remaining TODOs:
- testing (duh)
- verify that a node's client certificate has the right cluster name at startup (otherwise we can't talk to ourselves)

CC: @rolandcrosby 