### PR TITLE
batcheval: MVCCStats for AddSSTable with no shadowing should not contain estimates

### DIFF
--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -272,16 +272,6 @@ DBStatus DBMergeOne(DBSlice existing, DBSlice update, DBString* new_value);
 // merged with existing. This method is provided for invocation from Go code.
 DBStatus DBPartialMergeOne(DBSlice existing, DBSlice update, DBString* new_value);
 
-// DBCheckForKeyCollisions runs both iterators in lockstep and errors out at the
-// first key collision, where a collision refers to any two MVCC keys with the
-// same user key, and with a different timestamp or value.
-//
-// An exception is made when the latest version of the colliding key is a
-// tombstone from an MVCC delete in the existing data. If the timestamp of the
-// SST key is greater than or equal to the timestamp of the tombstone, then it
-// is not considered a collision and we continue iteration from the next key in
-// the existing data.
-DBIterState DBCheckForKeyCollisions(DBIterator* existingIter, DBIterator* sstIter, DBString* write_intent);
 
 // NB: The function (cStatsToGoStats) that converts these to the go
 // representation is unfortunately duplicated in engine and engineccl. If this
@@ -304,6 +294,17 @@ typedef struct {
 } MVCCStatsResult;
 
 MVCCStatsResult MVCCComputeStats(DBIterator* iter, DBKey start, DBKey end, int64_t now_nanos);
+
+// DBCheckForKeyCollisions runs both iterators in lockstep and errors out at the
+// first key collision, where a collision refers to any two MVCC keys with the
+// same user key, and with a different timestamp or value.
+//
+// An exception is made when the latest version of the colliding key is a
+// tombstone from an MVCC delete in the existing data. If the timestamp of the
+// SST key is greater than or equal to the timestamp of the tombstone, then it
+// is not considered a collision and we continue iteration from the next key in
+// the existing data.
+DBIterState DBCheckForKeyCollisions(DBIterator* existingIter, DBIterator* sstIter, MVCCStatsResult* skippedKVStats, DBString* write_intent);
 
 bool MVCCIsValidSplitKey(DBSlice key);
 DBStatus MVCCFindSplitKey(DBIterator* iter, DBKey start, DBKey end, DBKey min_split,

--- a/pkg/storage/batcheval/cmd_add_sstable_test.go
+++ b/pkg/storage/batcheval/cmd_add_sstable_test.go
@@ -479,7 +479,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 				DisallowShadowing: true,
 				MVCCStats:         &stats,
 			},
-			Stats: &stats,
+			Stats: &enginepb.MVCCStats{},
 		}
 
 		_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
@@ -562,7 +562,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 				DisallowShadowing: true,
 				MVCCStats:         &stats,
 			},
-			Stats: &stats,
+			Stats: &enginepb.MVCCStats{},
 		}
 
 		_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
@@ -765,7 +765,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 				DisallowShadowing: true,
 				MVCCStats:         &stats,
 			},
-			Stats: &stats,
+			Stats: &enginepb.MVCCStats{},
 		}
 
 		_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
@@ -855,6 +855,120 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 		_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
 		if !testutils.IsError(err, "ingested key collides with an existing one: \"z\"") {
 			t.Fatalf("%+v", err)
+		}
+	}
+
+	// This test ensures accuracy of MVCCStats in the situation that successive
+	// SSTs being ingested via AddSSTable have "perfectly shadowing" keys (same ts
+	// and value). Such KVs are not considered as collisions and so while they are
+	// skipped during ingestion, their stats would previously be double counted.
+	// To mitigate this problem we now return the stats of such skipped KVs while
+	// evaluating the AddSSTable command, and accumulate accurate stats in the
+	// CommandArgs Stats field by using:
+	// cArgs.Stats + ingested_stats - skipped_stats.
+	{
+		// Successfully evaluate the first SST as there are no key collisions.
+		sstKVs := mvccKVsFromStrs([]strKv{
+			{"c", 2, "bb"},
+			{"h", 6, "hh"},
+		})
+
+		sstBytes := getSSTBytes(sstKVs)
+		stats := getStats(engine.MVCCKey{Key: roachpb.Key("c")}, engine.MVCCKey{Key: roachpb.Key("i")}, sstBytes)
+
+		// Accumulate stats across SST ingestion.
+		commandStats := enginepb.MVCCStats{}
+
+		cArgs := batcheval.CommandArgs{
+			Header: roachpb.Header{
+				Timestamp: hlc.Timestamp{WallTime: 7},
+			},
+			Args: &roachpb.AddSSTableRequest{
+				RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("c"), EndKey: roachpb.Key("i")},
+				Data:              sstBytes,
+				DisallowShadowing: true,
+				MVCCStats:         &stats,
+			},
+			Stats: &commandStats,
+		}
+		_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+		firstSSTStats := commandStats
+
+		// Insert KV entries so that we can correctly identify keys to skip when
+		// ingesting the perfectly shadowing KVs (same ts and same value) in the
+		// second SST.
+		for _, kv := range sstKVs {
+			if err := e.Put(kv.Key, kv.Value); err != nil {
+				t.Fatalf("%+v", err)
+			}
+		}
+
+		// Evaluate the second SST. Both the KVs are perfectly shadowing and should
+		// not contribute to the stats.
+		secondSSTKVs := mvccKVsFromStrs([]strKv{
+			{"c", 2, "bb"}, // key has the same timestamp and value as the one present in the existing data.
+			{"h", 6, "hh"}, // key has the same timestamp and value as the one present in the existing data.
+		})
+		secondSSTBytes := getSSTBytes(secondSSTKVs)
+		secondStats := getStats(engine.MVCCKey{Key: roachpb.Key("c")}, engine.MVCCKey{Key: roachpb.Key("i")}, secondSSTBytes)
+
+		cArgs.Args = &roachpb.AddSSTableRequest{
+			RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("c"), EndKey: roachpb.Key("i")},
+			Data:              secondSSTBytes,
+			DisallowShadowing: true,
+			MVCCStats:         &secondStats,
+		}
+		_, err = batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+
+		// Check that there has been no double counting of stats.
+		if !firstSSTStats.Equal(*cArgs.Stats) {
+			t.Errorf("mvcc stats should not have changed as all keys in second SST are shadowing: %s",
+				pretty.Diff(firstSSTStats, *cArgs.Stats))
+		}
+
+		// Evaluate the third SST. Two of the three KVs are perfectly shadowing, but
+		// there is one valid KV which should contribute to the stats.
+		thirdSSTKVs := mvccKVsFromStrs([]strKv{
+			{"c", 2, "bb"}, // key has the same timestamp and value as the one present in the existing data.
+			{"e", 2, "ee"},
+			{"h", 6, "hh"}, // key has the same timestamp and value as the one present in the existing data.
+		})
+		thirdSSTBytes := getSSTBytes(thirdSSTKVs)
+		thirdStats := getStats(engine.MVCCKey{Key: roachpb.Key("c")}, engine.MVCCKey{Key: roachpb.Key("i")}, thirdSSTBytes)
+
+		cArgs.Args = &roachpb.AddSSTableRequest{
+			RequestHeader:     roachpb.RequestHeader{Key: roachpb.Key("c"), EndKey: roachpb.Key("i")},
+			Data:              thirdSSTBytes,
+			DisallowShadowing: true,
+			MVCCStats:         &thirdStats,
+		}
+		_, err = batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+
+		// This is the stats contribution of the KV {"e", 2, "ee"}. This should be
+		// the only addition to the cumulative stats, as the other two KVs are
+		// perfect shadows of existing data.
+		var delta enginepb.MVCCStats
+		delta.LiveCount = 1
+		delta.LiveBytes = 21
+		delta.KeyCount = 1
+		delta.KeyBytes = 14
+		delta.ValCount = 1
+		delta.ValBytes = 7
+
+		// Check that there has been no double counting of stats.
+		firstSSTStats.Add(delta)
+		if !firstSSTStats.Equal(*cArgs.Stats) {
+			t.Errorf("mvcc stats are not accurate: %s",
+				pretty.Diff(firstSSTStats, *cArgs.Stats))
 		}
 	}
 }

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -2913,28 +2913,32 @@ func (fr *RocksDBSstFileReader) Close() {
 }
 
 // CheckForKeyCollisions indicates if the two iterators collide on any keys.
-func CheckForKeyCollisions(existingIter Iterator, sstIter Iterator) error {
+func CheckForKeyCollisions(existingIter Iterator, sstIter Iterator) (enginepb.MVCCStats, error) {
 	existingIterGetter := existingIter.(dbIteratorGetter)
 	sstableIterGetter := sstIter.(dbIteratorGetter)
 	var intentErr C.DBString
+	var skippedKVStats C.MVCCStatsResult
+	emptyStats := enginepb.MVCCStats{}
 
-	state := C.DBCheckForKeyCollisions(existingIterGetter.getIter(), sstableIterGetter.getIter(), &intentErr)
+	state := C.DBCheckForKeyCollisions(existingIterGetter.getIter(), sstableIterGetter.getIter(), &skippedKVStats, &intentErr)
 
 	err := statusToError(state.status)
 	if err != nil {
 		if err.Error() == "WriteIntentError" {
 			var e roachpb.WriteIntentError
 			if err := protoutil.Unmarshal(cStringToGoBytes(intentErr), &e); err != nil {
-				return errors.Wrap(err, "failed to decode write intent error")
+				return emptyStats, errors.Wrap(err, "failed to decode write intent error")
 			}
-			return &e
+			return emptyStats, &e
 		} else if err.Error() == "InlineError" {
-			return errors.Errorf("inline values are unsupported when checking for key collisions")
+			return emptyStats, errors.Errorf("inline values are unsupported when checking for key collisions")
 		}
 		err = errors.Wrap(&RocksDBError{msg: cToGoKey(state.key).String()}, "ingested key collides with an existing one")
+		return emptyStats, err
 	}
 
-	return err
+	skippedStats, err := cStatsToGoStats(skippedKVStats, 0)
+	return skippedStats, err
 }
 
 // RocksDBSstFileWriter creates a file suitable for importing with


### PR DESCRIPTION
There is a significant performance win to be achieved by ensuring that the
stats computed when using AddSSTable are not estimates as it prevents
recomputation on splits. Running AddSSTable with disallowShadowing=true
gets us close to this as we do not allow colliding keys to be ingested.
However, in the situation that two SSTs have KV(s) which "perfectly"
shadow an existing key (equal ts and value), we do not consider this
a collision. While the shadowing KV would be skipped during ingestion,
the stats would be added to the cumulative stats for the AddSSTable
command, causing a double count for such KVs.
Therefore, we compute the stats for these "skipped" KVs on-the-fly while
checking for the collision condition in C++ and subtract them from the
stats of the SST being ingested before adding them to the running
cumulative for this command. These stats can then be marked as accurate.

Tagging #34809 

Release note: None