### PR TITLE
exec: use CopySlice for Bytes in top k instead of Set

### DIFF
--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -120,6 +120,8 @@ func (b *Bytes) Slice(start, end int) *Bytes {
 // If we copy src into the beginning of dest, we will have to move "world" so
 // that the result is:
 // result Bytes: "aworld", offsets: []int32{0, 1}, lengths: []int32{1, 5}
+// Similarly, if "a", is instead "alongerstring", "world" would have to be
+// shifted right.
 func (b *Bytes) CopySlice(src *Bytes, destIdx, srcStartIdx, srcEndIdx int) {
 	if destIdx < 0 || destIdx > b.Len() {
 		panic(fmt.Sprintf("dest index %d out of range (len=%d)", destIdx, b.Len()))

--- a/pkg/sql/exec/vec_comparators_tmpl.go
+++ b/pkg/sql/exec/vec_comparators_tmpl.go
@@ -92,8 +92,18 @@ func (c *_TYPEVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx uint16
 		c.nulls[dstVecIdx].SetNull(dstIdx)
 	} else {
 		c.nulls[dstVecIdx].UnsetNull(dstIdx)
+		// {{ if eq .LTyp.String "Bytes" }}
+		// Since flat Bytes cannot be set at arbitrary indices (data needs to be
+		// moved around), we use CopySlice to accept the performance hit.
+		// Specifically, this is a performance hit because we are overwriting the
+		// variable number of bytes in `dstVecIdx`, so we will have to either shift
+		// the bytes after that element left or right, depending on how long the
+		// source bytes slice is. Refer to the CopySlice comment for an example.
+		execgen.COPYSLICE(c.vecs[dstVecIdx], c.vecs[srcVecIdx], int(dstIdx), int(srcIdx), int(srcIdx+1))
+		// {{ else }}
 		v := execgen.UNSAFEGET(c.vecs[srcVecIdx], int(srcIdx))
 		execgen.SET(c.vecs[dstVecIdx], int(dstIdx), v)
+		// {{ end }}
 	}
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -636,3 +636,16 @@ SELECT a, ordinality*2 FROM t_38995 WITH ORDINALITY
 1 2
 2 4
 3 6
+
+# Test for #39827, top k sort with bytes.
+statement ok
+CREATE TABLE t_39827 (a STRING)
+
+statement ok
+INSERT INTO t_39827 VALUES ('hello'), ('world'), ('a'), ('foo')
+
+query T
+SELECT a FROM t_39827 ORDER BY a LIMIT 2
+----
+a
+foo


### PR DESCRIPTION
Since the top k sorter needs to maintain a heap, it requires the ability
to do out of order sets on a flat bytes slice. This is achieved by using
CopySlice.

Release note: None

Fixes #39827

cc @jordanlewis 