### PR TITLE
changefeedccl: allow base64-encoded client certificate

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -65,6 +65,8 @@ const (
 	optFormatAvro formatType = `experimental_avro`
 
 	sinkParamCACert           = `ca_cert`
+	sinkParamClientCert       = `client_cert`
+	sinkParamClientKey        = `client_key`
 	sinkParamFileSize         = `file_size`
 	sinkParamSchemaTopic      = `schema_topic`
 	sinkParamTLSEnabled       = `tls_enabled`

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1405,6 +1405,30 @@ func TestChangefeedErrors(t *testing.T) {
 		t, `ca_cert requires tls_enabled=true`,
 		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?&ca_cert=Zm9v`,
 	)
+	sqlDB.ExpectErr(
+		t, `param client_cert must be base 64 encoded`,
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?client_cert=!`,
+	)
+	sqlDB.ExpectErr(
+		t, `param client_key must be base 64 encoded`,
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?client_key=!`,
+	)
+	sqlDB.ExpectErr(
+		t, `client_cert requires tls_enabled=true`,
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?client_cert=Zm9v`,
+	)
+	sqlDB.ExpectErr(
+		t, `client_cert requires client_key to be set`,
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?tls_enabled=true&client_cert=Zm9v`,
+	)
+	sqlDB.ExpectErr(
+		t, `client_key requires client_cert to be set`,
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?tls_enabled=true&client_key=Zm9v`,
+	)
+	sqlDB.ExpectErr(
+		t, `invalid client certificate`,
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?tls_enabled=true&client_cert=Zm9v&client_key=Zm9v`,
+	)
 
 	// Sanity check kafka sasl parameters.
 	sqlDB.ExpectErr(


### PR DESCRIPTION
Adds `client_cert` and `client_key` options to the `kafka://`
changefeed URI scheme. Works like the existing `ca_cert` option:
the user base64-encodes the contents of a PEM certificate and
private key, and passes those base64 values as parameters in the
Kafka URI.

Fixes #39817.

Release note (enterprise change): Client certificates are now
supported for Kafka changefeed authentication.