### PR TITLE
exec: add support for ON expression for LEFT SEMI and LEFT ANTI merge join

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -792,6 +792,7 @@ EXECGEN_TARGETS = \
   pkg/sql/exec/const.eg.go \
   pkg/sql/exec/distinct.eg.go \
   pkg/sql/exec/hashjoiner.eg.go \
+  pkg/sql/exec/joiner_util.eg.go \
   pkg/sql/exec/like_ops.eg.go \
   pkg/sql/exec/mergejoinbase.eg.go \
   pkg/sql/exec/mergejoiner_fullouter.eg.go \
@@ -1471,6 +1472,7 @@ pkg/sql/exec/cast.eg.go: pkg/sql/exec/cast_tmpl.go
 pkg/sql/exec/const.eg.go: pkg/sql/exec/const_tmpl.go
 pkg/sql/exec/distinct.eg.go: pkg/sql/exec/distinct_tmpl.go
 pkg/sql/exec/hashjoiner.eg.go: pkg/sql/exec/hashjoiner_tmpl.go
+pkg/sql/exec/joiner_util.eg.go: pkg/sql/exec/joiner_util_tmpl.go
 pkg/sql/exec/mergejoinbase.eg.go: pkg/sql/exec/mergejoinbase_tmpl.go
 pkg/sql/exec/mergejoiner_fullouter.eg.go: pkg/sql/exec/mergejoiner_tmpl.go
 pkg/sql/exec/mergejoiner_inner.eg.go: pkg/sql/exec/mergejoiner_tmpl.go

--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -415,9 +415,12 @@ func newColOperator(
 		var filterConstructor func(exec.Operator) (exec.Operator, error)
 		filterOnlyOnLeft := true
 		onExprAlreadyHandled := false
-		if !core.MergeJoiner.OnExpr.Empty() {
-			// TODO(yuzefovich): figure out how to correctly populate
-			// filterOnlyOnLeft when core.MergeJoiner.OnExpr.LocalExpr is non-nil.
+		if !core.MergeJoiner.OnExpr.Empty() && core.MergeJoiner.Type != sqlbase.JoinType_INNER {
+			if core.MergeJoiner.OnExpr.LocalExpr != nil {
+				// TODO(yuzefovich): figure out how to correctly populate
+				// filterOnlyOnLeft in this case.
+				return result, errors.Errorf("only INNER merge joins with ON expressions passed in LocalExpr are supported")
+			}
 			onExpr := core.MergeJoiner.OnExpr.Expr
 			if onExpr != "" {
 				rightColumnFound := false

--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -333,6 +333,21 @@ func newColOperator(
 			}
 		}
 
+		var (
+			onExpr         *distsqlpb.Expression
+			filterPlanning *filterPlanningState
+		)
+		if !core.HashJoiner.OnExpr.Empty() {
+			if core.HashJoiner.Type != sqlbase.JoinType_INNER {
+				return result, errors.Newf("can't plan non-inner hash join with on expressions")
+			}
+			onExpr = &core.HashJoiner.OnExpr
+			filterPlanning = newFilterPlanningState(len(leftTypes), len(rightTypes))
+			leftOutCols, rightOutCols = filterPlanning.renderAllNeededCols(
+				*onExpr, leftOutCols, rightOutCols,
+			)
+		}
+
 		result.op, err = exec.NewEqHashJoinerOp(
 			inputs[0],
 			inputs[1],
@@ -359,11 +374,10 @@ func newColOperator(
 			result.columnTypes = result.columnTypes[:nLeftCols]
 		}
 
-		if !core.HashJoiner.OnExpr.Empty() {
-			if core.HashJoiner.Type != sqlbase.JoinType_INNER {
-				return result, errors.Newf("can't plan non-inner hash join with on expressions")
-			}
-			err = result.planFilterExpr(flowCtx.NewEvalCtx(), core.HashJoiner.OnExpr)
+		if onExpr != nil {
+			filterPlanning.remapIVars(onExpr)
+			err = result.planFilterExpr(flowCtx.NewEvalCtx(), *onExpr)
+			filterPlanning.projectOutExtraCols(&result, leftOutCols, rightOutCols)
 		}
 
 	case core.MergeJoiner != nil:
@@ -412,39 +426,35 @@ func newColOperator(
 			}
 		}
 
-		var filterConstructor func(exec.Operator) (exec.Operator, error)
-		filterOnlyOnLeft := true
-		onExprAlreadyHandled := false
-		if !core.MergeJoiner.OnExpr.Empty() && core.MergeJoiner.Type != sqlbase.JoinType_INNER {
-			if core.MergeJoiner.OnExpr.LocalExpr != nil {
-				// TODO(yuzefovich): figure out how to correctly populate
-				// filterOnlyOnLeft in this case.
-				return result, errors.Errorf("only INNER merge joins with ON expressions passed in LocalExpr are supported")
-			}
-			onExpr := core.MergeJoiner.OnExpr.Expr
-			if onExpr != "" {
-				rightColumnFound := false
-				colOffset := len(spec.Input[0].ColumnTypes) + 1
-				for rColIdx := range spec.Input[1].ColumnTypes {
-					rColOrdinal := fmt.Sprintf("@%d", rColIdx+colOffset)
-					if strings.Contains(onExpr, rColOrdinal) {
-						rightColumnFound = true
-						break
-					}
-				}
-				filterOnlyOnLeft = !rightColumnFound
-			}
-			if core.MergeJoiner.Type == sqlbase.JoinType_LEFT_SEMI ||
-				core.MergeJoiner.Type == sqlbase.JoinType_LEFT_ANTI {
-				onExprAlreadyHandled = true
+		var (
+			onExpr            *distsqlpb.Expression
+			filterPlanning    *filterPlanningState
+			filterOnlyOnLeft  bool
+			filterConstructor func(exec.Operator) (exec.Operator, error)
+		)
+		if !core.MergeJoiner.OnExpr.Empty() {
+			onExpr = &core.MergeJoiner.OnExpr
+			filterPlanning = newFilterPlanningState(len(leftTypes), len(rightTypes))
+			switch core.MergeJoiner.Type {
+			case sqlbase.JoinType_INNER:
+				leftOutCols, rightOutCols = filterPlanning.renderAllNeededCols(
+					*onExpr, leftOutCols, rightOutCols,
+				)
+			case sqlbase.JoinType_LEFT_SEMI, sqlbase.JoinType_LEFT_ANTI:
+				filterOnlyOnLeft = filterPlanning.isFilterOnlyOnLeft(*onExpr)
 				filterConstructor = func(op exec.Operator) (exec.Operator, error) {
 					r := newColOperatorResult{
 						op:          op,
 						columnTypes: append(spec.Input[0].ColumnTypes, spec.Input[1].ColumnTypes...),
 					}
-					err := r.planFilterExpr(flowCtx.NewEvalCtx(), core.MergeJoiner.OnExpr)
+					// We don't need to remap the indexed vars in onExpr because the
+					// filter will be run alongside the merge joiner, and it will have
+					// access to all of the columns from both sides.
+					err := r.planFilterExpr(flowCtx.NewEvalCtx(), *onExpr)
 					return r.op, err
 				}
+			default:
+				return result, errors.Errorf("can only plan INNER, LEFT SEMI, and LEFT ANTI merge joins with ON expressions")
 			}
 		}
 
@@ -474,11 +484,10 @@ func newColOperator(
 			result.columnTypes = result.columnTypes[:nLeftCols]
 		}
 
-		if !core.MergeJoiner.OnExpr.Empty() && !onExprAlreadyHandled {
-			if core.MergeJoiner.Type != sqlbase.JoinType_INNER {
-				return result, errors.Errorf("can only plan INNER, LEFT SEMI, and LEFT ANTI merge joins with ON expressions")
-			}
-			err = result.planFilterExpr(flowCtx.NewEvalCtx(), core.MergeJoiner.OnExpr)
+		if onExpr != nil && core.MergeJoiner.Type == sqlbase.JoinType_INNER {
+			filterPlanning.remapIVars(onExpr)
+			err = result.planFilterExpr(flowCtx.NewEvalCtx(), *onExpr)
+			filterPlanning.projectOutExtraCols(&result, leftOutCols, rightOutCols)
 		}
 
 		// Merge joiner is a streaming operator when equality columns form a key
@@ -688,6 +697,156 @@ func newColOperator(
 		result.op = exec.NewLimitOp(result.op, post.Limit)
 	}
 	return result, err
+}
+
+type filterPlanningState struct {
+	numLeftInputCols  int
+	numRightInputCols int
+	// indexVarMap will be populated when rendering all needed columns in case
+	// when at least one column from either side is used by the filter.
+	indexVarMap       []int
+	extraLeftOutCols  int
+	extraRightOutCols int
+}
+
+func newFilterPlanningState(numLeftInputCols, numRightInputCols int) *filterPlanningState {
+	return &filterPlanningState{
+		numLeftInputCols:  numLeftInputCols,
+		numRightInputCols: numRightInputCols,
+	}
+}
+
+// renderAllNeededCols makes sure that all columns used by filter expression
+// will be output. It does so by extracting the indices of all indexed vars
+// used in the expression and appending those that are missing from *OutCols
+// slices to the slices. Additionally, it populates p.indexVarMap to be used
+// later to correctly remap the indexed vars and stores information about how
+// many extra columns are added so that those extra columns could be projected
+// out after the filter has been run.
+// It returns updated leftOutCols and rightOutCols.
+func (p *filterPlanningState) renderAllNeededCols(
+	filter distsqlpb.Expression, leftOutCols []uint32, rightOutCols []uint32,
+) ([]uint32, []uint32) {
+	neededColumnsForFilter := findIVarsInRange(
+		filter,
+		0, /* start */
+		p.numLeftInputCols+p.numRightInputCols,
+	)
+	if len(neededColumnsForFilter) > 0 {
+		// At least one column is referenced by the filter expression.
+		p.indexVarMap = make([]int, p.numLeftInputCols+p.numRightInputCols)
+		for i := range p.indexVarMap {
+			p.indexVarMap[i] = -1
+		}
+		// First, we process only the left side.
+		for i, lCol := range leftOutCols {
+			p.indexVarMap[lCol] = i
+		}
+		for _, neededCol := range neededColumnsForFilter {
+			if int(neededCol) < p.numLeftInputCols {
+				if p.indexVarMap[neededCol] == -1 {
+					p.indexVarMap[neededCol] = len(leftOutCols)
+					leftOutCols = append(leftOutCols, neededCol)
+					p.extraLeftOutCols++
+				}
+			}
+		}
+		// Now that we know how many columns from the left will be output, we can
+		// process the right side.
+		//
+		// Here is the explanation of all the indices' dance below:
+		//   suppose we have two inputs with three columns in each, the filter
+		//   expression as @1 = @4 AND @3 = @5, and leftOutCols = {0} and
+		//   rightOutCols = {0} when this method was called. Note that only
+		//   ordinals in the expression are counting from 1, everything else is
+		//   zero-based.
+		// - After we processed the left side above, we have the following state:
+		//   neededColumnsForFilter = {0, 2, 3, 4}
+		//   leftOutCols = {0, 2}
+		//   p.indexVarMap = {0, -1, 1, -1, -1, -1}
+		// - We calculate rColOffset = 3 to know which columns for filter are from
+		//   the right side as well as to remap those for rightOutCols (the
+		//   remapping step is needed because rightOutCols "thinks" only in the
+		//   context of the right side).
+		// - Next, we add already present rightOutCols to the indexed var map:
+		//   rightOutCols = {0}
+		//   p.indexVarMap = {0, -1, 1, 2, -1, -1}
+		//   Note that we needed to remap the column index, and we could do so only
+		//   after the left side has been processed because we need to know how
+		//   many columns will be output from the left.
+		// - Then, we go through the needed columns for filter slice again, and add
+		//   any that are still missing to rightOutCols:
+		//   rightOutCols = {0, 1}
+		//   p.indexVarMap = {0, -1, 1, 2, 3, -1}
+		// - We also stored the fact that we appended 1 extra column for both
+		//   inputs, and we will project those out.
+		rColOffset := uint32(p.numLeftInputCols)
+		for i, rCol := range rightOutCols {
+			p.indexVarMap[rCol+rColOffset] = len(leftOutCols) + i
+		}
+		for _, neededCol := range neededColumnsForFilter {
+			if neededCol >= rColOffset {
+				if p.indexVarMap[neededCol] == -1 {
+					p.indexVarMap[neededCol] = len(rightOutCols) + len(leftOutCols)
+					rightOutCols = append(rightOutCols, neededCol-rColOffset)
+					p.extraRightOutCols++
+				}
+			}
+		}
+	}
+	return leftOutCols, rightOutCols
+}
+
+// isFilterOnlyOnLeft returns whether the filter expression doesn't use columns
+// from the right side.
+func (p *filterPlanningState) isFilterOnlyOnLeft(filter distsqlpb.Expression) bool {
+	// Find all needed columns for filter only from the right side.
+	neededColumnsForFilter := findIVarsInRange(
+		filter, p.numLeftInputCols, p.numLeftInputCols+p.numRightInputCols,
+	)
+	return len(neededColumnsForFilter) == 0
+}
+
+// remapIVars remaps tree.IndexedVars in expr using p.indexVarMap. Note that
+// expr is modified in-place.
+func (p *filterPlanningState) remapIVars(expr *distsqlpb.Expression) {
+	if p.indexVarMap == nil {
+		// If p.indexVarMap is nil, then there is no remapping to do.
+		return
+	}
+	if expr.LocalExpr != nil {
+		expr.LocalExpr = sqlbase.RemapIVarsInTypedExpr(expr.LocalExpr, p.indexVarMap)
+	} else {
+		// We iterate in the reverse order so that the multiple digit numbers are
+		// handled correctly (consider an expression like @1 AND @11).
+		for idx := len(p.indexVarMap) - 1; idx >= 0; idx-- {
+			if p.indexVarMap[idx] != -1 {
+				// We need +1 below because the ordinals are counting from 1.
+				expr.Expr = strings.ReplaceAll(
+					expr.Expr,
+					fmt.Sprintf("@%d", idx+1),
+					fmt.Sprintf("@%d", p.indexVarMap[idx]+1),
+				)
+			}
+		}
+	}
+}
+
+// projectOutExtraCols, possibly, adds a projection to remove all the extra
+// columns that were needed by the filter expression.
+func (p *filterPlanningState) projectOutExtraCols(
+	result *newColOperatorResult, leftOutCols, rightOutCols []uint32,
+) {
+	if p.extraLeftOutCols+p.extraRightOutCols > 0 {
+		projection := make([]uint32, 0, len(leftOutCols)+len(rightOutCols)-p.extraLeftOutCols-p.extraRightOutCols)
+		for i := 0; i < len(leftOutCols)-p.extraLeftOutCols; i++ {
+			projection = append(projection, uint32(i))
+		}
+		for i := 0; i < len(rightOutCols)-p.extraRightOutCols; i++ {
+			projection = append(projection, uint32(i+len(leftOutCols)))
+		}
+		result.op = exec.NewSimpleProjectOp(result.op, len(leftOutCols)+len(rightOutCols), projection)
+	}
 }
 
 func (r *newColOperatorResult) planFilterExpr(

--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -93,7 +93,7 @@ func wrapRowSource(
 
 type newColOperatorResult struct {
 	op              exec.Operator
-	outputTypes     []coltypes.T
+	columnTypes     []types.T
 	memUsage        int
 	metadataSources []distsqlpb.MetadataSource
 	isStreaming     bool
@@ -108,13 +108,6 @@ func newColOperator(
 	core := &spec.Core
 	post := &spec.Post
 
-	// Planning additional operators for the PostProcessSpec (filters and render
-	// expressions) requires knowing the operator's output column types. Currently
-	// this must be set for any core spec which might require post-processing. In
-	// the future we may want to make these column types part of the Operator
-	// interface.
-	var columnTypes []types.T
-
 	// By default, we safely assume that an operator is not streaming. Note that
 	// projections, renders, filters, limits, offsets as well as all internal
 	// operators (like stats collectors and cancel checkers) are streaming, so in
@@ -127,7 +120,7 @@ func newColOperator(
 			return result, err
 		}
 		result.op, result.isStreaming = exec.NewNoop(inputs[0]), true
-		columnTypes = spec.Input[0].ColumnTypes
+		result.columnTypes = spec.Input[0].ColumnTypes
 	case core.TableReader != nil:
 		if err := checkNumIn(inputs, 0); err != nil {
 			return result, err
@@ -156,7 +149,7 @@ func newColOperator(
 		// performing long operations.
 		result.op = exec.NewCancelChecker(result.op)
 		returnMutations := core.TableReader.Visibility == distsqlpb.ScanVisibility_PUBLIC_AND_NOT_PUBLIC
-		columnTypes = core.TableReader.Table.ColumnTypesWithMutations(returnMutations)
+		result.columnTypes = core.TableReader.Table.ColumnTypesWithMutations(returnMutations)
 	case core.Aggregator != nil:
 		if err := checkNumIn(inputs, 1); err != nil {
 			return result, err
@@ -174,7 +167,7 @@ func newColOperator(
 			// Ideally the optimizer would not plan a scan in this unusual case.
 			result.op, result.isStreaming, err = exec.NewSingleTupleNoInputOp(), true, nil
 			// We make columnTypes non-nil so that sanity check doesn't panic.
-			columnTypes = make([]types.T, 0)
+			result.columnTypes = make([]types.T, 0)
 			break
 		}
 		if len(aggSpec.GroupCols) == 0 &&
@@ -183,7 +176,7 @@ func newColOperator(
 			aggSpec.Aggregations[0].Func == distsqlpb.AggregatorSpec_COUNT_ROWS &&
 			!aggSpec.Aggregations[0].Distinct {
 			result.op, result.isStreaming, err = exec.NewCountOp(inputs[0]), true, nil
-			columnTypes = []types.T{*types.Int}
+			result.columnTypes = []types.T{*types.Int}
 			break
 		}
 
@@ -207,7 +200,7 @@ func newColOperator(
 		aggTyps := make([][]types.T, len(aggSpec.Aggregations))
 		aggCols := make([][]uint32, len(aggSpec.Aggregations))
 		aggFns := make([]distsqlpb.AggregatorSpec_Func, len(aggSpec.Aggregations))
-		columnTypes = make([]types.T, len(aggSpec.Aggregations))
+		result.columnTypes = make([]types.T, len(aggSpec.Aggregations))
 		for i, agg := range aggSpec.Aggregations {
 			if agg.Distinct {
 				return result, errors.Newf("distinct aggregation not supported")
@@ -243,7 +236,7 @@ func newColOperator(
 			if err != nil {
 				return result, err
 			}
-			columnTypes[i] = *retType
+			result.columnTypes[i] = *retType
 		}
 		var typs []coltypes.T
 		typs, err = typeconv.FromColumnTypes(spec.Input[0].ColumnTypes)
@@ -281,9 +274,9 @@ func newColOperator(
 			return result, errors.AssertionFailedf("ordered cols must be a subset of distinct cols")
 		}
 
-		columnTypes = spec.Input[0].ColumnTypes
+		result.columnTypes = spec.Input[0].ColumnTypes
 		var typs []coltypes.T
-		typs, err = typeconv.FromColumnTypes(columnTypes)
+		typs, err = typeconv.FromColumnTypes(result.columnTypes)
 		if err != nil {
 			return result, err
 		}
@@ -294,7 +287,7 @@ func newColOperator(
 		if err := checkNumIn(inputs, 1); err != nil {
 			return result, err
 		}
-		columnTypes = append(spec.Input[0].ColumnTypes, *types.Int)
+		result.columnTypes = append(spec.Input[0].ColumnTypes, *types.Int)
 		result.op, result.isStreaming = exec.NewOrdinalityOp(inputs[0]), true
 
 	case core.HashJoiner != nil:
@@ -356,20 +349,20 @@ func newColOperator(
 			return result, err
 		}
 
-		columnTypes = make([]types.T, nLeftCols+nRightCols)
-		copy(columnTypes, spec.Input[0].ColumnTypes)
+		result.columnTypes = make([]types.T, nLeftCols+nRightCols)
+		copy(result.columnTypes, spec.Input[0].ColumnTypes)
 		if core.HashJoiner.Type != sqlbase.JoinType_LEFT_SEMI {
 			// TODO(yuzefovich): update this conditional once LEFT ANTI is supported.
-			copy(columnTypes[nLeftCols:], spec.Input[1].ColumnTypes)
+			copy(result.columnTypes[nLeftCols:], spec.Input[1].ColumnTypes)
 		} else {
-			columnTypes = columnTypes[:nLeftCols]
+			result.columnTypes = result.columnTypes[:nLeftCols]
 		}
 
 		if !core.HashJoiner.OnExpr.Empty() {
 			if core.HashJoiner.Type != sqlbase.JoinType_INNER {
 				return result, errors.Newf("can't plan non-inner hash join with on expressions")
 			}
-			columnTypes, err = result.planFilterExpr(flowCtx, core.HashJoiner.OnExpr, columnTypes)
+			err = result.planFilterExpr(flowCtx.NewEvalCtx(), core.HashJoiner.OnExpr)
 		}
 
 	case core.MergeJoiner != nil:
@@ -433,20 +426,20 @@ func newColOperator(
 			return result, err
 		}
 
-		columnTypes = make([]types.T, nLeftCols+nRightCols)
-		copy(columnTypes, spec.Input[0].ColumnTypes)
+		result.columnTypes = make([]types.T, nLeftCols+nRightCols)
+		copy(result.columnTypes, spec.Input[0].ColumnTypes)
 		if core.MergeJoiner.Type != sqlbase.JoinType_LEFT_SEMI &&
 			core.MergeJoiner.Type != sqlbase.JoinType_LEFT_ANTI {
-			copy(columnTypes[nLeftCols:], spec.Input[1].ColumnTypes)
+			copy(result.columnTypes[nLeftCols:], spec.Input[1].ColumnTypes)
 		} else {
-			columnTypes = columnTypes[:nLeftCols]
+			result.columnTypes = result.columnTypes[:nLeftCols]
 		}
 
 		if !core.MergeJoiner.OnExpr.Empty() {
 			if core.MergeJoiner.Type != sqlbase.JoinType_INNER {
 				return result, errors.Errorf("can't plan non-inner merge joins with on expressions")
 			}
-			columnTypes, err = result.planFilterExpr(flowCtx, core.MergeJoiner.OnExpr, columnTypes)
+			err = result.planFilterExpr(flowCtx.NewEvalCtx(), core.MergeJoiner.OnExpr)
 		}
 
 		// Merge joiner is a streaming operator when equality columns form a key
@@ -481,7 +474,7 @@ func newColOperator(
 			if err != nil {
 				return nil, err
 			}
-			columnTypes = jr.OutputTypes()
+			result.columnTypes = jr.OutputTypes()
 			return jr, nil
 		})
 		result.op, result.isStreaming = c, true
@@ -513,7 +506,7 @@ func newColOperator(
 			// No optimizations possible. Default to the standard sort operator.
 			result.op, err = exec.NewSorter(input, inputTypes, orderingCols)
 		}
-		columnTypes = spec.Input[0].ColumnTypes
+		result.columnTypes = spec.Input[0].ColumnTypes
 
 	case core.Windower != nil:
 		if err := checkNumIn(inputs, 1); err != nil {
@@ -583,7 +576,7 @@ func newColOperator(
 			result.op = exec.NewSimpleProjectOp(result.op, int(wf.OutputColIdx+1), projection)
 		}
 
-		columnTypes = append(spec.Input[0].ColumnTypes, *types.Int)
+		result.columnTypes = append(spec.Input[0].ColumnTypes, *types.Int)
 
 	default:
 		return result, errors.Newf("unsupported processor core %q", core)
@@ -601,23 +594,23 @@ func newColOperator(
 
 	log.VEventf(ctx, 1, "made op %T\n", result.op)
 
-	if columnTypes == nil {
+	if result.columnTypes == nil {
 		return result, errors.AssertionFailedf("output columnTypes unset after planning %T", result.op)
 	}
 
 	if !post.Filter.Empty() {
-		if columnTypes, err = result.planFilterExpr(flowCtx, post.Filter, columnTypes); err != nil {
+		if err = result.planFilterExpr(flowCtx.NewEvalCtx(), post.Filter); err != nil {
 			return result, err
 		}
 	}
 	if post.Projection {
-		result.op = exec.NewSimpleProjectOp(result.op, len(columnTypes), post.OutputColumns)
+		result.op = exec.NewSimpleProjectOp(result.op, len(result.columnTypes), post.OutputColumns)
 		// Update output columnTypes.
 		newTypes := make([]types.T, 0, len(post.OutputColumns))
 		for _, j := range post.OutputColumns {
-			newTypes = append(newTypes, columnTypes[j])
+			newTypes = append(newTypes, result.columnTypes[j])
 		}
-		columnTypes = newTypes
+		result.columnTypes = newTypes
 	} else if post.RenderExprs != nil {
 		log.VEventf(ctx, 2, "planning render expressions %+v", post.RenderExprs)
 		var renderedCols []uint32
@@ -626,13 +619,13 @@ func newColOperator(
 				helper    exprHelper
 				renderMem int
 			)
-			err := helper.init(expr, columnTypes, flowCtx.EvalCtx)
+			err := helper.init(expr, result.columnTypes, flowCtx.EvalCtx)
 			if err != nil {
 				return result, err
 			}
 			var outputIdx int
-			result.op, outputIdx, columnTypes, renderMem, err = planProjectionOperators(
-				flowCtx.NewEvalCtx(), helper.expr, columnTypes, result.op)
+			result.op, outputIdx, result.columnTypes, renderMem, err = planProjectionOperators(
+				flowCtx.NewEvalCtx(), helper.expr, result.columnTypes, result.op)
 			if err != nil {
 				return result, errors.Wrapf(err, "unable to columnarize render expression %q", expr)
 			}
@@ -642,12 +635,12 @@ func newColOperator(
 			result.memUsage += renderMem
 			renderedCols = append(renderedCols, uint32(outputIdx))
 		}
-		result.op = exec.NewSimpleProjectOp(result.op, len(columnTypes), renderedCols)
+		result.op = exec.NewSimpleProjectOp(result.op, len(result.columnTypes), renderedCols)
 		newTypes := make([]types.T, 0, len(renderedCols))
 		for _, j := range renderedCols {
-			newTypes = append(newTypes, columnTypes[j])
+			newTypes = append(newTypes, result.columnTypes[j])
 		}
-		columnTypes = newTypes
+		result.columnTypes = newTypes
 	}
 	if post.Offset != 0 {
 		result.op = exec.NewOffsetOp(result.op, post.Offset)
@@ -655,46 +648,42 @@ func newColOperator(
 	if post.Limit != 0 {
 		result.op = exec.NewLimitOp(result.op, post.Limit)
 	}
-	if err != nil {
-		return result, err
-	}
-	result.outputTypes, err = typeconv.FromColumnTypes(columnTypes)
 	return result, err
 }
 
 func (r *newColOperatorResult) planFilterExpr(
-	flowCtx *FlowCtx, filter distsqlpb.Expression, columnTypes []types.T,
-) ([]types.T, error) {
+	evalCtx *tree.EvalContext, filter distsqlpb.Expression,
+) error {
 	var (
 		helper       exprHelper
 		selectionMem int
 	)
-	err := helper.init(filter, columnTypes, flowCtx.EvalCtx)
+	err := helper.init(filter, r.columnTypes, evalCtx)
 	if err != nil {
-		return columnTypes, err
+		return err
 	}
 	if helper.expr == tree.DNull {
 		// The filter expression is tree.DNull meaning that it is always false, so
 		// we put a zero operator.
 		r.op = exec.NewZeroOp(r.op)
-		return columnTypes, nil
+		return nil
 	}
 	var filterColumnTypes []types.T
-	r.op, _, filterColumnTypes, selectionMem, err = planSelectionOperators(flowCtx.NewEvalCtx(), helper.expr, columnTypes, r.op)
+	r.op, _, filterColumnTypes, selectionMem, err = planSelectionOperators(evalCtx, helper.expr, r.columnTypes, r.op)
 	if err != nil {
-		return columnTypes, errors.Wrapf(err, "unable to columnarize filter expression %q", filter.Expr)
+		return errors.Wrapf(err, "unable to columnarize filter expression %q", filter.Expr)
 	}
 	r.memUsage += selectionMem
-	if len(filterColumnTypes) > len(columnTypes) {
+	if len(filterColumnTypes) > len(r.columnTypes) {
 		// Additional columns were appended to store projections while evaluating
 		// the filter. Project them away.
 		var outputColumns []uint32
-		for i := range columnTypes {
+		for i := range r.columnTypes {
 			outputColumns = append(outputColumns, uint32(i))
 		}
 		r.op = exec.NewSimpleProjectOp(r.op, len(filterColumnTypes), outputColumns)
 	}
-	return columnTypes, nil
+	return nil
 }
 
 func planSelectionOperators(
@@ -1539,8 +1528,12 @@ func (s *vectorizedFlowCreator) setupFlow(
 			// when vectorize=auto.
 			return nil, errors.Errorf("hash router encountered when vectorize=auto")
 		}
+		opOutputTypes, err := typeconv.FromColumnTypes(result.columnTypes)
+		if err != nil {
+			return nil, err
+		}
 		if err = s.setupOutput(
-			ctx, flowCtx, pspec, op, result.outputTypes, metadataSourcesQueue,
+			ctx, flowCtx, pspec, op, opOutputTypes, metadataSourcesQueue,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/sql/distsqlrun/columnar_operators_test.go
+++ b/pkg/sql/distsqlrun/columnar_operators_test.go
@@ -310,10 +310,12 @@ func TestMergeJoinerAgainstProcessor(t *testing.T) {
 			anyOrder: true,
 		},
 		{
-			joinType: sqlbase.JoinType_LEFT_SEMI,
+			joinType:        sqlbase.JoinType_LEFT_SEMI,
+			onExprSupported: true,
 		},
 		{
-			joinType: sqlbase.JoinType_LEFT_ANTI,
+			joinType:        sqlbase.JoinType_LEFT_ANTI,
+			onExprSupported: true,
 		},
 	}
 

--- a/pkg/sql/exec/.gitignore
+++ b/pkg/sql/exec/.gitignore
@@ -4,6 +4,7 @@ cast.eg.go
 const.eg.go
 distinct.eg.go
 hashjoiner.eg.go
+joiner_util.eg.go
 like_ops.eg.go
 mergejoinbase.eg.go
 mergejoiner_fullouter.eg.go

--- a/pkg/sql/exec/execgen/cmd/execgen/joiner_util_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/joiner_util_gen.go
@@ -1,0 +1,45 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"io"
+	"io/ioutil"
+	"strings"
+	"text/template"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+func genJoinerUtil(wr io.Writer) error {
+	d, err := ioutil.ReadFile("pkg/sql/exec/joiner_util_tmpl.go")
+	if err != nil {
+		return err
+	}
+
+	s := string(d)
+
+	// Replace the template variables.
+	s = strings.Replace(s, "_TYPES_T", "coltypes.{{.LTyp}}", -1)
+	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
+	s = replaceManipulationFuncs(".LTyp", s)
+
+	// Now, generate the op, from the template.
+	tmpl, err := template.New("joiner_util").Parse(s)
+	if err != nil {
+		return err
+	}
+
+	return tmpl.Execute(wr, sameTypeComparisonOpToOverloads[tree.NE])
+}
+func init() {
+	registerGenerator(genJoinerUtil, "joiner_util.eg.go")
+}

--- a/pkg/sql/exec/execgen/cmd/execgen/mergejoiner_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/mergejoiner_gen.go
@@ -51,6 +51,11 @@ type joinTypeInfo struct {
 	String string
 }
 
+type filterInfo struct {
+	HasFilter bool
+	String    string
+}
+
 func genMergeJoinOps(wr io.Writer, jti joinTypeInfo) error {
 	d, err := ioutil.ReadFile("pkg/sql/exec/mergejoiner_tmpl.go")
 	if err != nil {
@@ -70,6 +75,8 @@ func genMergeJoinOps(wr io.Writer, jti joinTypeInfo) error {
 	s = strings.Replace(s, "_SEL_ARG", "$sel", -1)
 	s = strings.Replace(s, "_JOIN_TYPE_STRING", "{{$.JoinType.String}}", -1)
 	s = strings.Replace(s, "_JOIN_TYPE", "$.JoinType", -1)
+	s = strings.Replace(s, "_FILTER_INFO_STRING", "{{$filterInfo.String}}", -1)
+	s = strings.Replace(s, "_FILTER_INFO", "$filterInfo", -1)
 	s = strings.Replace(s, "_MJ_OVERLOAD", "$mjOverload", -1)
 	s = strings.Replace(s, "_L_HAS_NULLS", "$.lHasNulls", -1)
 	s = strings.Replace(s, "_R_HAS_NULLS", "$.rHasNulls", -1)
@@ -99,8 +106,8 @@ func genMergeJoinOps(wr io.Writer, jti joinTypeInfo) error {
 	processNotLastGroupInColumnSwitch := makeFunctionRegex("_PROCESS_NOT_LAST_GROUP_IN_COLUMN_SWITCH", 1)
 	s = processNotLastGroupInColumnSwitch.ReplaceAllString(s, `{{template "processNotLastGroupInColumnSwitch" buildDict "Global" $ "JoinType" $1}}`)
 
-	probeSwitch := makeFunctionRegex("_PROBE_SWITCH", 5)
-	s = probeSwitch.ReplaceAllString(s, `{{template "probeSwitch" buildDict "Global" $ "JoinType" $1 "SelPermutation" $2 "lHasNulls" $3 "rHasNulls" $4 "AscDirection" $5}}`)
+	probeSwitch := makeFunctionRegex("_PROBE_SWITCH", 6)
+	s = probeSwitch.ReplaceAllString(s, `{{template "probeSwitch" buildDict "Global" $ "JoinType" $1 "FilterInfo" $2 "SelPermutation" $3 "lHasNulls" $4 "rHasNulls" $5 "AscDirection" $6}}`)
 
 	sourceFinishedSwitch := makeFunctionRegex("_SOURCE_FINISHED_SWITCH", 1)
 	s = sourceFinishedSwitch.ReplaceAllString(s, `{{template "sourceFinishedSwitch" buildDict "Global" $ "JoinType" $1}}`)
@@ -170,14 +177,27 @@ func genMergeJoinOps(wr io.Writer, jti joinTypeInfo) error {
 		},
 	}
 
+	filterInfos := []filterInfo{
+		{
+			HasFilter: false,
+			String:    "",
+		},
+		{
+			HasFilter: true,
+			String:    "WithOnExpr",
+		},
+	}
+
 	return tmpl.Execute(wr, struct {
 		MJOverloads     interface{}
 		SelPermutations interface{}
 		JoinType        interface{}
+		FilterInfos     interface{}
 	}{
 		MJOverloads:     mjOverloads,
 		SelPermutations: selPermutations,
 		JoinType:        jti,
+		FilterInfos:     filterInfos,
 	})
 }
 

--- a/pkg/sql/exec/joiner_util_tmpl.go
+++ b/pkg/sql/exec/joiner_util_tmpl.go
@@ -1,0 +1,173 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// {{/*
+// +build execgen_template
+//
+// This file is the execgen template for joiner_util.eg.go. It's formatted in a
+// special way, so it's both valid Go and a valid text/template input. This
+// permits editing this file with editor support.
+//
+// */}}
+
+package exec
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
+)
+
+// {{/*
+// Declarations to make the template compile properly.
+
+// _TYPES_T is the template type variable for coltypes.T. It will be replaced by
+// coltypes.Foo for each type Foo in the coltypes.T type.
+const _TYPES_T = coltypes.Unhandled
+
+// */}}
+
+// filterFeedOperator is used to feed the filter by manually setting the batch
+// to be returned on the first Next() call with zero-length batches returned on
+// all subsequent calls.
+type filterFeedOperator struct {
+	ZeroInputNode
+	batch     coldata.Batch
+	zeroBatch coldata.Batch
+	nexted    bool
+}
+
+var _ Operator = &filterFeedOperator{}
+
+func newFilterFeedOperator(inputTypes []coltypes.T) *filterFeedOperator {
+	return &filterFeedOperator{
+		batch:     coldata.NewMemBatchWithSize(inputTypes, 1 /* size */),
+		zeroBatch: coldata.NewMemBatchWithSize([]coltypes.T{}, 0 /* size */),
+	}
+}
+
+func (o *filterFeedOperator) Init() {}
+
+func (o *filterFeedOperator) Next(context.Context) coldata.Batch {
+	if !o.nexted {
+		o.nexted = true
+		return o.batch
+	}
+	o.zeroBatch.SetLength(0)
+	return o.zeroBatch
+}
+
+func (o *filterFeedOperator) reset() {
+	o.nexted = false
+}
+
+func newJoinerFilter(
+	leftSourceTypes []coltypes.T,
+	rightSourceTypes []coltypes.T,
+	filterConstructor func(Operator) (Operator, error),
+	filterOnlyOnLeft bool,
+) (*joinerFilter, error) {
+	input := newFilterFeedOperator(append(leftSourceTypes, rightSourceTypes...))
+	filter, err := filterConstructor(input)
+	return &joinerFilter{
+		Operator:         filter,
+		leftSourceTypes:  leftSourceTypes,
+		rightSourceTypes: rightSourceTypes,
+		input:            input,
+		onlyOnLeft:       filterOnlyOnLeft,
+	}, err
+}
+
+// joinerFilter is a side chain of Operators needed to support ON expressions.
+type joinerFilter struct {
+	Operator
+
+	leftSourceTypes  []coltypes.T
+	rightSourceTypes []coltypes.T
+	input            *filterFeedOperator
+	// onlyOnLeft indicates whether the ON expression is such that only columns
+	// from the left input are used.
+	onlyOnLeft bool
+}
+
+var _ StaticMemoryOperator = &joinerFilter{}
+
+// isLeftTupleFilteredOut returns whether a tuple lIdx from lBatch combined
+// with all tuples in range [rStartIdx, rEndIdx) from rBatch does *not* satisfy
+// the filter.
+func (f *joinerFilter) isLeftTupleFilteredOut(
+	ctx context.Context, lBatch, rBatch coldata.Batch, lIdx, rStartIdx, rEndIdx int,
+) bool {
+	if f.onlyOnLeft {
+		f.input.reset()
+		f.setInputBatch(lBatch, nil /* rBatch */, lIdx, 0 /* rIdx */)
+		b := f.Next(ctx)
+		return b.Length() == 0
+	}
+	for rIdx := rStartIdx; rIdx < rEndIdx; rIdx++ {
+		f.input.reset()
+		f.setInputBatch(lBatch, rBatch, lIdx, rIdx)
+		b := f.Next(ctx)
+		if b.Length() > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// setInputBatch sets the batch of filterFeedOperator, namely, it copies a
+// single tuple from each of the batches at the specified indices and puts the
+// combined "double" tuple into f.filterInput.
+// Either lBatch or rBatch can be nil to indicate that the tuple from the
+// respective side should not be set, i.e. the filter input batch will only be
+// partially initialized.
+func (f *joinerFilter) setInputBatch(lBatch, rBatch coldata.Batch, lIdx, rIdx int) {
+	if lBatch == nil && rBatch == nil {
+		execerror.VectorizedInternalPanic("only one of lBatch and rBatch can be nil")
+	}
+	setOneSide := func(colOffset int, batch coldata.Batch, sourceTypes []coltypes.T, idx int) {
+		for colIdx := 0; colIdx < batch.Width(); colIdx++ {
+			colType := sourceTypes[colIdx]
+			col := batch.ColVec(colIdx)
+			memCol := col.Slice(colType, uint64(idx), uint64(idx+1))
+			switch colType {
+			// {{ range . }}
+			case _TYPES_T:
+				f.input.batch.ColVec(colOffset + colIdx).SetCol(memCol._TemplateType())
+				// {{ end }}
+			default:
+				execerror.VectorizedInternalPanic(fmt.Sprintf("unhandled type %d", colType))
+			}
+			f.input.batch.ColVec(colOffset + colIdx).SetNulls(memCol.Nulls())
+		}
+	}
+	if lBatch != nil {
+		setOneSide(0 /* colOffset */, lBatch, f.leftSourceTypes, lIdx)
+	}
+	if rBatch != nil {
+		setOneSide(len(f.leftSourceTypes), rBatch, f.rightSourceTypes, rIdx)
+	}
+	f.input.batch.SetLength(1)
+	f.input.batch.SetSelection(false)
+}
+
+// EstimateStaticMemoryUsage implements the StaticMemoryOperator interface.
+func (f *joinerFilter) EstimateStaticMemoryUsage() int {
+	filterMemUsage := 0
+	if s, ok := f.Operator.(StaticMemoryOperator); ok {
+		filterMemUsage = s.EstimateStaticMemoryUsage()
+	}
+	return filterMemUsage +
+		EstimateBatchSizeBytes(f.leftSourceTypes, 1 /* batchLength */) +
+		EstimateBatchSizeBytes(f.rightSourceTypes, 1 /* batchLength */)
+}

--- a/pkg/sql/exec/mergejoinbase_tmpl.go
+++ b/pkg/sql/exec/mergejoinbase_tmpl.go
@@ -21,7 +21,6 @@ package exec
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"math"
 
@@ -122,64 +121,4 @@ func (o *mergeJoinBase) isBufferedGroupFinished(
 		}
 	}
 	return false
-}
-
-// isLeftTupleFilteredOut returns whether a tuple lIdx from lBatch combined
-// with any tuple in range [rStartIdx, rEndIdx) from rBatch satisfies the
-// filter.
-// A special case of rBatch == nil is supported which will run the filter only
-// on the partial tuple coming from the left input.
-func (o *mergeJoinBase) isLeftTupleFilteredOut(
-	ctx context.Context, lBatch, rBatch coldata.Batch, lIdx, rStartIdx, rEndIdx int,
-) bool {
-	if o.filterOnlyOnLeft || rBatch == nil {
-		o.filterInput.reset()
-		o.setFilterInputBatch(lBatch, nil /* rBatch */, lIdx, 0 /* rIdx */)
-		b := o.filter.Next(ctx)
-		return b.Length() == 0
-	}
-	for rIdx := rStartIdx; rIdx < rEndIdx; rIdx++ {
-		o.filterInput.reset()
-		o.setFilterInputBatch(lBatch, rBatch, lIdx, rIdx)
-		b := o.filter.Next(ctx)
-		if b.Length() > 0 {
-			return false
-		}
-	}
-	return true
-}
-
-// setFilterInputBatch sets the batch of filterFeedOperator, namely, it copies
-// a single tuple from each of the batches at the specified indices and puts
-// the combined "double" tuple into o.filterInput.
-// Either lBatch or rBatch can be nil to indicate that the tuple from the
-// respective side should not be set, i.e. the filter input batch will only be
-// partially initialized.
-func (o *mergeJoinBase) setFilterInputBatch(lBatch, rBatch coldata.Batch, lIdx, rIdx int) {
-	if lBatch == nil && rBatch == nil {
-		execerror.VectorizedInternalPanic("only one of lBatch and rBatch can be nil")
-	}
-	setOneSide := func(colOffset int, batch coldata.Batch, sourceTypes []coltypes.T, idx int) {
-		for colIdx, col := range batch.ColVecs() {
-			colType := sourceTypes[colIdx]
-			memCol := col.Slice(colType, uint64(idx), uint64(idx+1))
-			switch colType {
-			// {{ range $mjOverload := $.MJOverloads }}
-			case _TYPES_T:
-				o.filterInput.batch.ColVec(colOffset + colIdx).SetCol(memCol._TemplateType())
-				// {{ end }}
-			default:
-				execerror.VectorizedInternalPanic(fmt.Sprintf("unhandled type %d", colType))
-			}
-			o.filterInput.batch.ColVec(colOffset + colIdx).SetNulls(memCol.Nulls())
-		}
-	}
-	if lBatch != nil {
-		setOneSide(0 /* colOffset */, lBatch, o.left.sourceTypes, lIdx)
-	}
-	if rBatch != nil {
-		setOneSide(len(o.left.sourceTypes), rBatch, o.right.sourceTypes, rIdx)
-	}
-	o.filterInput.batch.SetLength(1)
-	o.filterInput.batch.SetSelection(false)
 }

--- a/pkg/sql/exec/mergejoiner.go
+++ b/pkg/sql/exec/mergejoiner.go
@@ -168,40 +168,6 @@ func (o *feedOperator) Next(context.Context) coldata.Batch {
 
 var _ Operator = &feedOperator{}
 
-// filterFeedOperator is used to feed the filter by manually setting the batch
-// to be returned on the first Next() call with zero-length batches returned on
-// all consequent calls.
-type filterFeedOperator struct {
-	ZeroInputNode
-	batch     coldata.Batch
-	zeroBatch coldata.Batch
-	nexted    bool
-}
-
-var _ Operator = &filterFeedOperator{}
-
-func newFilterFeedOperator(inputTypes []coltypes.T) *filterFeedOperator {
-	return &filterFeedOperator{
-		batch:     coldata.NewMemBatchWithSize(inputTypes, 1 /* size */),
-		zeroBatch: coldata.NewMemBatchWithSize([]coltypes.T{}, 0 /* size */),
-	}
-}
-
-func (o *filterFeedOperator) Init() {}
-
-func (o *filterFeedOperator) Next(context.Context) coldata.Batch {
-	if !o.nexted {
-		o.nexted = true
-		return o.batch
-	}
-	o.zeroBatch.SetLength(0)
-	return o.zeroBatch
-}
-
-func (o *filterFeedOperator) reset() {
-	o.nexted = false
-}
-
 // The merge join operator uses a probe and build approach to generate the
 // join. What this means is that instead of going through and expanding the
 // cross product row by row, the operator performs two passes.
@@ -367,14 +333,17 @@ func newMergeJoinBase(
 		return base, err
 	}
 	if filterConstructor != nil {
-		base.filterInput = newFilterFeedOperator(append(leftTypes, rightTypes...))
-		base.filter, err = filterConstructor(base.filterInput)
-		base.filterOnlyOnLeft = filterOnlyOnLeft
+		base.filter, err = newJoinerFilter(
+			leftTypes,
+			rightTypes,
+			filterConstructor,
+			filterOnlyOnLeft,
+		)
 	}
 	return base, err
 }
 
-// mergeJoinBase extract the common logic between all merge join operators.
+// mergeJoinBase extracts the common logic between all merge join operators.
 type mergeJoinBase struct {
 	twoInputNode
 	left  mergeJoinInput
@@ -395,12 +364,7 @@ type mergeJoinBase struct {
 	proberState  mjProberState
 	builderState mjBuilderState
 
-	// A side chain of Operators needed to support ON expressions.
-	filter      Operator
-	filterInput *filterFeedOperator
-	// filterOnlyOnLeft indicates whether the ON expression is such that only
-	// columns from the left input are used.
-	filterOnlyOnLeft bool
+	filter *joinerFilter
 }
 
 func (o *mergeJoinBase) getOutColTypes() []coltypes.T {
@@ -417,11 +381,10 @@ func (o *mergeJoinBase) EstimateStaticMemoryUsage() int {
 	const sizeOfGroup = int(unsafe.Sizeof(group{}))
 	leftDistincter := o.left.distincter.(StaticMemoryOperator)
 	rightDistincter := o.right.distincter.(StaticMemoryOperator)
-	// Note that we're ignoring filter memory usage (if any) since the filter
-	// input uses only two batches of lengths 1 and 0 and the filter itself does
-	// not use any static memory.
-	// TODO(yuzefovich): update this calculation if the above comment is no
-	// longer true.
+	filterMemUsage := 0
+	if o.filter != nil {
+		filterMemUsage = o.filter.EstimateStaticMemoryUsage()
+	}
 	return EstimateBatchSizeBytes(
 		o.getOutColTypes(), coldata.BatchSize,
 	) + // base.output
@@ -433,7 +396,8 @@ func (o *mergeJoinBase) EstimateStaticMemoryUsage() int {
 		) + // base.proberState.rBufferedGroup
 		4*sizeOfGroup*coldata.BatchSize + // base.groups
 		leftDistincter.EstimateStaticMemoryUsage() + // base.left.distincter
-		rightDistincter.EstimateStaticMemoryUsage() // base.right.distincter
+		rightDistincter.EstimateStaticMemoryUsage() + // base.right.distincter
+		filterMemUsage
 }
 
 func (o *mergeJoinBase) Init() {

--- a/pkg/sql/exec/mergejoiner_test.go
+++ b/pkg/sql/exec/mergejoiner_test.go
@@ -1537,7 +1537,8 @@ func TestMergeJoiner(t *testing.T) {
 		runTests(t, []tuples{tc.leftTuples, tc.rightTuples}, tc.expected, mergeJoinVerifier,
 			tc.expectedOutCols, func(input []Operator) (Operator, error) {
 				return NewMergeJoinOp(tc.joinType, input[0], input[1], tc.leftOutCols,
-					tc.rightOutCols, tc.leftTypes, tc.rightTypes, lOrderings, rOrderings)
+					tc.rightOutCols, tc.leftTypes, tc.rightTypes, lOrderings, rOrderings,
+					nil /* filterConstructor */, false /* filterOnlyOnLeft */)
 			})
 	}
 }
@@ -1572,6 +1573,8 @@ func TestMergeJoinerMultiBatch(t *testing.T) {
 						typs,
 						[]distsqlpb.Ordering_Column{{ColIdx: 0, Direction: distsqlpb.Ordering_Column_ASC}},
 						[]distsqlpb.Ordering_Column{{ColIdx: 0, Direction: distsqlpb.Ordering_Column_ASC}},
+						nil,   /* filterConstructor */
+						false, /* filterOnlyOnLeft */
 					)
 					if err != nil {
 						t.Fatal("error in merge join op constructor", err)
@@ -1634,6 +1637,8 @@ func TestMergeJoinerMultiBatchRuns(t *testing.T) {
 						typs,
 						[]distsqlpb.Ordering_Column{{ColIdx: 0, Direction: distsqlpb.Ordering_Column_ASC}, {ColIdx: 1, Direction: distsqlpb.Ordering_Column_ASC}},
 						[]distsqlpb.Ordering_Column{{ColIdx: 0, Direction: distsqlpb.Ordering_Column_ASC}, {ColIdx: 1, Direction: distsqlpb.Ordering_Column_ASC}},
+						nil,   /* filterConstructor */
+						false, /* filterOnlyOnLeft */
 					)
 					if err != nil {
 						t.Fatal("error in merge join op constructor", err)
@@ -1700,6 +1705,8 @@ func TestMergeJoinerLongMultiBatchCount(t *testing.T) {
 							typs,
 							[]distsqlpb.Ordering_Column{{ColIdx: 0, Direction: distsqlpb.Ordering_Column_ASC}},
 							[]distsqlpb.Ordering_Column{{ColIdx: 0, Direction: distsqlpb.Ordering_Column_ASC}},
+							nil,   /* filterConstructor */
+							false, /* filterOnlyOnLeft */
 						)
 						if err != nil {
 							t.Fatal("error in merge join op constructor", err)
@@ -1751,6 +1758,8 @@ func TestMergeJoinerMultiBatchCountRuns(t *testing.T) {
 						typs,
 						[]distsqlpb.Ordering_Column{{ColIdx: 0, Direction: distsqlpb.Ordering_Column_ASC}},
 						[]distsqlpb.Ordering_Column{{ColIdx: 0, Direction: distsqlpb.Ordering_Column_ASC}},
+						nil,   /* filterConstructor */
+						false, /* filterOnlyOnLeft */
 					)
 					if err != nil {
 						t.Fatal("error in merge join op constructor", err)
@@ -1866,6 +1875,8 @@ func TestMergeJoinerRandomized(t *testing.T) {
 								typs,
 								[]distsqlpb.Ordering_Column{{ColIdx: 0, Direction: distsqlpb.Ordering_Column_ASC}},
 								[]distsqlpb.Ordering_Column{{ColIdx: 0, Direction: distsqlpb.Ordering_Column_ASC}},
+								nil,   /* filterConstructor */
+								false, /* filterOnlyOnLeft */
 							)
 
 							if err != nil {

--- a/pkg/sql/exec/mergejoiner_tmpl.go
+++ b/pkg/sql/exec/mergejoiner_tmpl.go
@@ -411,9 +411,8 @@ func _INCREMENT_LEFT_SWITCH(
 	// */}}
 	// {{ end }}
 	// {{ if or $.JoinType.IsLeftOuter $.JoinType.IsLeftAnti }}
-	// All the rows on the left within the current group will not get
-	// a match on the right, so we're adding each of them as a left
-	// outer group.
+	// All the rows on the left within the current group will not get a match on
+	// the right, so we're adding each of them as a left unmatched group.
 	o.groups.addLeftUnmatchedGroup(curLIdx-1, curRIdx)
 	for curLIdx < curLLength {
 		// {{ if _L_HAS_NULLS }}
@@ -509,12 +508,10 @@ func _PROCESS_NOT_LAST_GROUP_IN_COLUMN_SWITCH(_JOIN_TYPE joinTypeInfo) { // */}}
 	// {{ end }}
 	// {{ if or $.JoinType.IsLeftOuter $.JoinType.IsLeftAnti }}
 	if !o.groups.isLastGroupInCol() && !areGroupsProcessed {
-		// The current group is not the last one within the column, so it
-		// cannot be extended into the next batch, and we need to process it
-		// right now.
-		// Any unprocessed row in the left group will not get a match, so
-		// each one of them becomes a new unmatched group with a
-		// corresponding null group.
+		// The current group is not the last one within the column, so it cannot be
+		// extended into the next batch, and we need to process it right now. Any
+		// unprocessed row in the left group will not get a match, so each one of
+		// them becomes a new unmatched group with a corresponding null group.
 		for curLIdx < curLLength {
 			o.groups.addLeftUnmatchedGroup(curLIdx, curRIdx)
 			curLIdx++
@@ -523,12 +520,10 @@ func _PROCESS_NOT_LAST_GROUP_IN_COLUMN_SWITCH(_JOIN_TYPE joinTypeInfo) { // */}}
 	// {{ end }}
 	// {{ if $.JoinType.IsRightOuter }}
 	if !o.groups.isLastGroupInCol() && !areGroupsProcessed {
-		// The current group is not the last one within the column, so it
-		// cannot be extended into the next batch, and we need to process it
-		// right now.
-		// Any unprocessed row in the right group will not get a match, so
-		// each one of them becomes a new unmatched group with a
-		// corresponding null group.
+		// The current group is not the last one within the column, so it cannot be
+		// extended into the next batch, and we need to process it right now. Any
+		// unprocessed row in the right group will not get a match, so each one of
+		// them becomes a new unmatched group with a corresponding null group.
 		for curRIdx < curRLength {
 			o.groups.addRightOuterGroup(curLIdx, curRIdx)
 			curRIdx++
@@ -979,10 +974,10 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) setBuilderSourceToBufferedGroup() {
 // the left source. It should only be called when the right source has been
 // exhausted.
 func (o *mergeJoin_JOIN_TYPE_STRINGOp) exhaustLeftSource() {
-	// {{ if _JOIN_TYPE.IsInner }}
+	// {{ if or _JOIN_TYPE.IsInner _JOIN_TYPE.IsLeftSemi }}
 	// {{/*
 	// Remaining tuples from the left source do not have a match, so they are
-	// ignored in INNER JOIN.
+	// ignored in INNER JOIN and LEFT SEMI JOIN.
 	// */}}
 	// {{ end }}
 	// {{ if or _JOIN_TYPE.IsLeftOuter _JOIN_TYPE.IsLeftAnti }}
@@ -1019,10 +1014,10 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) exhaustLeftSource() {
 // the right source. It should only be called when the left source has been
 // exhausted.
 func (o *mergeJoin_JOIN_TYPE_STRINGOp) exhaustRightSource() {
-	// {{ if _JOIN_TYPE.IsInner }}
+	// {{ if or _JOIN_TYPE.IsInner _JOIN_TYPE.IsLeftSemi }}
 	// {{/*
 	// Remaining tuples from the right source do not have a match, so they are
-	// ignored in INNER JOIN.
+	// ignored in INNER JOIN and LEFT SEMI JOIN.
 	// */}}
 	// {{ end }}
 	// {{ if _JOIN_TYPE.IsLeftOuter }}

--- a/pkg/sql/exec/mergejoiner_tmpl.go
+++ b/pkg/sql/exec/mergejoiner_tmpl.go
@@ -93,21 +93,29 @@ const _JOIN_TYPE = 0
 // valid go code.
 const _MJ_OVERLOAD = 0
 
+// _FILTER_INFO is used in place of the string "$filterInfo", since that isn't
+// valid go code.
+const _FILTER_INFO = 0
+
 // */}}
 
 // Use execgen package to remove unused import warning.
 var _ interface{} = execgen.UNSAFEGET
 
-type mergeJoin_JOIN_TYPE_STRINGOp struct {
+// {{ range $filterInfo := $.FilterInfos }}
+type mergeJoin_JOIN_TYPE_STRING_FILTER_INFO_STRINGOp struct {
 	mergeJoinBase
 }
 
-var _ StaticMemoryOperator = &mergeJoin_JOIN_TYPE_STRINGOp{}
+var _ StaticMemoryOperator = &mergeJoin_JOIN_TYPE_STRING_FILTER_INFO_STRINGOp{}
+
+// {{ end }}
 
 // {{/*
 // This code snippet is the "meat" of the probing phase.
 func _PROBE_SWITCH(
 	_JOIN_TYPE joinTypeInfo,
+	_FILTER_INFO filterInfo,
 	_SEL_PERMUTATION selPermutation,
 	_L_HAS_NULLS bool,
 	_R_HAS_NULLS bool,
@@ -116,6 +124,7 @@ func _PROBE_SWITCH(
 	// {{define "probeSwitch"}}
 	// {{ $sel := $.SelPermutation }}
 	// {{ $mjOverloads := $.Global.MJOverloads }}
+	// {{ $filterInfo := $.FilterInfo }}
 	switch colType {
 	// {{range $mjOverload := $.Global.MJOverloads }}
 	case _TYPES_T:
@@ -220,17 +229,39 @@ func _PROBE_SWITCH(
 						break EqLoop
 					}
 
-					// {{ if _JOIN_TYPE.IsLeftSemi }}
 					if eqColIdx < len(o.left.eqCols)-1 {
 						o.groups.addGroupsToNextCol(beginLIdx, lGroupLength, beginRIdx, rGroupLength)
 					} else {
+						// {{ if _JOIN_TYPE.IsLeftSemi }}
+						// {{ if _FILTER_INFO.HasFilter }}
+						for lIdx := beginLIdx; lIdx < beginLIdx+lGroupLength; lIdx++ {
+							if !o.isLeftTupleFilteredOut(ctx, o.proberState.lBatch, o.proberState.rBatch, lIdx, beginRIdx, beginRIdx+rGroupLength) {
+								o.groups.addLeftSemiGroup(lIdx, 1)
+							}
+						}
+						// {{ else }}
 						o.groups.addLeftSemiGroup(beginLIdx, lGroupLength)
+						// {{ end }}
+						// {{ else if _JOIN_TYPE.IsLeftAnti }}
+						// {{ if _FILTER_INFO.HasFilter }}
+						// With LEFT ANTI join, we are only interested in unmatched tuples
+						// from the left, and so far all tuples in the current group have a
+						// match. We will only add an unmatched group corresponding to a
+						// tuple from the left source if there is a filter and the tuple
+						// doesn't pass the filter.
+						for lIdx := beginLIdx; lIdx < beginLIdx+lGroupLength; lIdx++ {
+							if o.isLeftTupleFilteredOut(ctx, o.proberState.lBatch, o.proberState.rBatch, lIdx, beginRIdx, beginRIdx+rGroupLength) {
+								// The second argument doesn't matter in case of LEFT ANTI join.
+								o.groups.addLeftUnmatchedGroup(lIdx, beginRIdx)
+							}
+						}
+						// {{ end }}
+						// {{ else }}
+						// Neither group ends with the batch, so add the group to the
+						// circular buffer.
+						o.groups.addGroupsToNextCol(beginLIdx, lGroupLength, beginRIdx, rGroupLength)
+						// {{ end }}
 					}
-					// {{ else }}
-					// Neither group ends with the batch, so add the group to the
-					// circular buffer.
-					o.groups.addGroupsToNextCol(beginLIdx, lGroupLength, beginRIdx, rGroupLength)
-					// {{ end }}
 				} else { // mismatch
 					var incrementLeft bool
 					// {{ if _ASC_DIRECTION }}
@@ -537,7 +568,10 @@ func _PROCESS_NOT_LAST_GROUP_IN_COLUMN_SWITCH(_JOIN_TYPE joinTypeInfo) { // */}}
 // */}}
 
 // {{ range $sel := $.SelPermutations }}
-func (o *mergeJoin_JOIN_TYPE_STRINGOp) probeBodyLSel_IS_L_SELRSel_IS_R_SEL() {
+// {{ range $filterInfo := $.FilterInfos }}
+func (o *mergeJoin_JOIN_TYPE_STRING_FILTER_INFO_STRINGOp) probeBodyLSel_IS_L_SELRSel_IS_R_SEL(
+	ctx context.Context,
+) {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -548,29 +582,29 @@ EqLoop:
 		if lVec.MaybeHasNulls() {
 			if rVec.MaybeHasNulls() {
 				if o.left.directions[eqColIdx] == distsqlpb.Ordering_Column_ASC {
-					_PROBE_SWITCH(_JOIN_TYPE, _SEL_ARG, true, true, true)
+					_PROBE_SWITCH(_JOIN_TYPE, _FILTER_INFO, _SEL_ARG, true, true, true)
 				} else {
-					_PROBE_SWITCH(_JOIN_TYPE, _SEL_ARG, true, true, false)
+					_PROBE_SWITCH(_JOIN_TYPE, _FILTER_INFO, _SEL_ARG, true, true, false)
 				}
 			} else {
 				if o.left.directions[eqColIdx] == distsqlpb.Ordering_Column_ASC {
-					_PROBE_SWITCH(_JOIN_TYPE, _SEL_ARG, true, false, true)
+					_PROBE_SWITCH(_JOIN_TYPE, _FILTER_INFO, _SEL_ARG, true, false, true)
 				} else {
-					_PROBE_SWITCH(_JOIN_TYPE, _SEL_ARG, true, false, false)
+					_PROBE_SWITCH(_JOIN_TYPE, _FILTER_INFO, _SEL_ARG, true, false, false)
 				}
 			}
 		} else {
 			if rVec.MaybeHasNulls() {
 				if o.left.directions[eqColIdx] == distsqlpb.Ordering_Column_ASC {
-					_PROBE_SWITCH(_JOIN_TYPE, _SEL_ARG, false, true, true)
+					_PROBE_SWITCH(_JOIN_TYPE, _FILTER_INFO, _SEL_ARG, false, true, true)
 				} else {
-					_PROBE_SWITCH(_JOIN_TYPE, _SEL_ARG, false, true, false)
+					_PROBE_SWITCH(_JOIN_TYPE, _FILTER_INFO, _SEL_ARG, false, true, false)
 				}
 			} else {
 				if o.left.directions[eqColIdx] == distsqlpb.Ordering_Column_ASC {
-					_PROBE_SWITCH(_JOIN_TYPE, _SEL_ARG, false, false, true)
+					_PROBE_SWITCH(_JOIN_TYPE, _FILTER_INFO, _SEL_ARG, false, false, true)
 				} else {
-					_PROBE_SWITCH(_JOIN_TYPE, _SEL_ARG, false, false, false)
+					_PROBE_SWITCH(_JOIN_TYPE, _FILTER_INFO, _SEL_ARG, false, false, false)
 				}
 			}
 		}
@@ -580,6 +614,7 @@ EqLoop:
 	}
 }
 
+// {{ end }}
 // {{ end }}
 
 // {{/*
@@ -683,6 +718,8 @@ func _LEFT_SWITCH(_JOIN_TYPE joinTypeInfo, _HAS_SELECTION bool, _HAS_NULLS bool)
 
 // */}}
 
+// {{ range $filterInfo := $.FilterInfos }}
+
 // buildLeftGroups takes a []group and expands each group into the output by
 // repeating each row in the group numRepeats times. For example, given an
 // input table:
@@ -703,7 +740,7 @@ func _LEFT_SWITCH(_JOIN_TYPE joinTypeInfo, _HAS_SELECTION bool, _HAS_NULLS bool)
 // Note: this is different from buildRightGroups in that each row of group is
 // repeated numRepeats times, instead of a simple copy of the group as a whole.
 // SIDE EFFECTS: writes into o.output.
-func (o *mergeJoin_JOIN_TYPE_STRINGOp) buildLeftGroups(
+func (o *mergeJoin_JOIN_TYPE_STRING_FILTER_INFO_STRINGOp) buildLeftGroups(
 	leftGroups []group,
 	colOffset int,
 	input *mergeJoinInput,
@@ -739,6 +776,8 @@ LeftColLoop:
 	}
 	o.builderState.left.reset()
 }
+
+// {{ end }}
 
 // {{/*
 // This code snippet builds the output corresponding to the right side (i.e. is
@@ -844,6 +883,8 @@ func _RIGHT_SWITCH(_JOIN_TYPE joinTypeInfo, _HAS_SELECTION bool, _HAS_NULLS bool
 
 // */}}
 
+// {{ range $filterInfo := $.FilterInfos }}
+
 // buildRightGroups takes a []group and repeats each group numRepeats times.
 // For example, given an input table:
 //  R1 |  R2
@@ -863,7 +904,7 @@ func _RIGHT_SWITCH(_JOIN_TYPE joinTypeInfo, _HAS_SELECTION bool, _HAS_NULLS bool
 // Note: this is different from buildLeftGroups in that each group is not
 // expanded but directly copied numRepeats times.
 // SIDE EFFECTS: writes into o.output.
-func (o *mergeJoin_JOIN_TYPE_STRINGOp) buildRightGroups(
+func (o *mergeJoin_JOIN_TYPE_STRING_FILTER_INFO_STRINGOp) buildRightGroups(
 	rightGroups []group,
 	colOffset int,
 	input *mergeJoinInput,
@@ -902,6 +943,10 @@ RightColLoop:
 	o.builderState.right.reset()
 }
 
+// {{ end }}
+
+// {{ range $filterInfo := $.FilterInfos }}
+
 // probe is where we generate the groups slices that are used in the build
 // phase. We do this by first assuming that every row in both batches
 // contributes to the cross product. Then, with every equality column, we
@@ -910,34 +955,84 @@ RightColLoop:
 // and set the correct cardinality.
 // Note that in this phase, we do this for every group, except the last group
 // in the batch.
-func (o *mergeJoin_JOIN_TYPE_STRINGOp) probe() {
+func (o *mergeJoin_JOIN_TYPE_STRING_FILTER_INFO_STRINGOp) probe(ctx context.Context) {
 	o.groups.reset(o.proberState.lIdx, o.proberState.lLength, o.proberState.rIdx, o.proberState.rLength)
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 	if lSel != nil {
 		if rSel != nil {
-			o.probeBodyLSeltrueRSeltrue()
+			o.probeBodyLSeltrueRSeltrue(ctx)
 		} else {
-			o.probeBodyLSeltrueRSelfalse()
+			o.probeBodyLSeltrueRSelfalse(ctx)
 		}
 	} else {
 		if rSel != nil {
-			o.probeBodyLSelfalseRSeltrue()
+			o.probeBodyLSelfalseRSeltrue(ctx)
 		} else {
-			o.probeBodyLSelfalseRSelfalse()
+			o.probeBodyLSelfalseRSelfalse(ctx)
 		}
 	}
 }
 
 // setBuilderSourceToBufferedGroup sets up the builder state to use the
 // buffered group.
-func (o *mergeJoin_JOIN_TYPE_STRINGOp) setBuilderSourceToBufferedGroup() {
+func (o *mergeJoin_JOIN_TYPE_STRING_FILTER_INFO_STRINGOp) setBuilderSourceToBufferedGroup(
+	ctx context.Context,
+) {
+	// {{ if _JOIN_TYPE.IsLeftAnti }}
+	// {{ if _FILTER_INFO.HasFilter }}
+	o.builderState.lGroups = o.builderState.lGroups[:0]
+	rBatch := o.proberState.rBufferedGroup
+	rEndIdx := int(o.proberState.rBufferedGroup.length)
+	if o.filterOnlyOnLeft {
+		rBatch = nil
+	}
+	for lIdx := 0; lIdx < int(o.proberState.lBufferedGroup.length); lIdx++ {
+		if o.isLeftTupleFilteredOut(ctx, o.proberState.lBufferedGroup, rBatch, lIdx, 0 /* rStartIdx */, rEndIdx) {
+			o.builderState.lGroups = append(o.builderState.lGroups, group{
+				rowStartIdx: lIdx,
+				rowEndIdx:   lIdx + 1,
+				numRepeats:  1,
+				toBuild:     1,
+				unmatched:   true,
+			})
+		}
+	}
+	// {{ else }}
+	// All tuples in the buffered group have matches, so they are not output in
+	// case of LEFT ANTI join.
+	o.builderState.lGroups = o.builderState.lGroups[:0]
+	// {{ end }}
+	// {{ else }}
 	lGroupEndIdx := int(o.proberState.lBufferedGroup.length)
 	// The capacity of builder state lGroups and rGroups is always at least 1
 	// given the init.
 	o.builderState.lGroups = o.builderState.lGroups[:1]
 	o.builderState.rGroups = o.builderState.rGroups[:1]
-	// {{ if not _JOIN_TYPE.IsLeftSemi }}
+	// {{ if _JOIN_TYPE.IsLeftSemi }}
+	// TODO(yuzefovich): think about using selection vectors on mjBufferedGroups.
+	// {{ if _FILTER_INFO.HasFilter }}
+	rGroupEndIdx := int(o.proberState.rBufferedGroup.length)
+	o.builderState.lGroups = o.builderState.lGroups[:0]
+	for lIdx := 0; lIdx < lGroupEndIdx; lIdx++ {
+		if !o.isLeftTupleFilteredOut(ctx, o.proberState.lBufferedGroup, o.proberState.rBufferedGroup, lIdx, 0 /* rStartIdx */, rGroupEndIdx) {
+			o.builderState.lGroups = append(o.builderState.lGroups, group{
+				rowStartIdx: lIdx,
+				rowEndIdx:   lIdx + 1,
+				numRepeats:  1,
+				toBuild:     1,
+			})
+		}
+	}
+	// {{ else }}
+	o.builderState.lGroups[0] = group{
+		rowStartIdx: 0,
+		rowEndIdx:   lGroupEndIdx,
+		numRepeats:  1,
+		toBuild:     lGroupEndIdx,
+	}
+	// {{ end }}
+	// {{ else }}
 	rGroupEndIdx := int(o.proberState.rBufferedGroup.length)
 	o.builderState.lGroups[0] = group{
 		rowStartIdx: 0,
@@ -951,13 +1046,7 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) setBuilderSourceToBufferedGroup() {
 		numRepeats:  lGroupEndIdx,
 		toBuild:     rGroupEndIdx * lGroupEndIdx,
 	}
-	// {{ else }}
-	o.builderState.lGroups[0] = group{
-		rowStartIdx: 0,
-		rowEndIdx:   lGroupEndIdx,
-		numRepeats:  1,
-		toBuild:     lGroupEndIdx,
-	}
+	// {{ end }}
 	// {{ end }}
 
 	o.builderState.lBatch = o.proberState.lBufferedGroup
@@ -973,7 +1062,7 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) setBuilderSourceToBufferedGroup() {
 // exhaustLeftSource sets up the builder to process any remaining tuples from
 // the left source. It should only be called when the right source has been
 // exhausted.
-func (o *mergeJoin_JOIN_TYPE_STRINGOp) exhaustLeftSource() {
+func (o *mergeJoin_JOIN_TYPE_STRING_FILTER_INFO_STRINGOp) exhaustLeftSource(ctx context.Context) {
 	// {{ if or _JOIN_TYPE.IsInner _JOIN_TYPE.IsLeftSemi }}
 	// {{/*
 	// Remaining tuples from the left source do not have a match, so they are
@@ -991,6 +1080,7 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) exhaustLeftSource() {
 		toBuild:     o.proberState.lLength - o.proberState.lIdx,
 		unmatched:   true,
 	}
+	// {{ if _JOIN_TYPE.IsLeftOuter }}
 	o.builderState.rGroups = o.builderState.rGroups[:1]
 	o.builderState.rGroups[0] = group{
 		rowStartIdx: o.proberState.lIdx,
@@ -999,6 +1089,7 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) exhaustLeftSource() {
 		toBuild:     o.proberState.lLength - o.proberState.lIdx,
 		nullGroup:   true,
 	}
+	// {{ end }}
 
 	o.proberState.lIdx = o.proberState.lLength
 	// {{ end }}
@@ -1013,7 +1104,7 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) exhaustLeftSource() {
 // exhaustRightSource sets up the builder to process any remaining tuples from
 // the right source. It should only be called when the left source has been
 // exhausted.
-func (o *mergeJoin_JOIN_TYPE_STRINGOp) exhaustRightSource() {
+func (o *mergeJoin_JOIN_TYPE_STRING_FILTER_INFO_STRINGOp) exhaustRightSource() {
 	// {{ if or _JOIN_TYPE.IsInner _JOIN_TYPE.IsLeftSemi }}
 	// {{/*
 	// Remaining tuples from the right source do not have a match, so they are
@@ -1051,7 +1142,7 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) exhaustRightSource() {
 }
 
 // build creates the cross product, and writes it to the output member.
-func (o *mergeJoin_JOIN_TYPE_STRINGOp) build() {
+func (o *mergeJoin_JOIN_TYPE_STRING_FILTER_INFO_STRINGOp) build() {
 	if o.output.Width() != 0 {
 		outStartIdx := o.builderState.outCount
 		o.buildLeftGroups(o.builderState.lGroups, 0 /* colOffset */, &o.left, o.builderState.lBatch, outStartIdx)
@@ -1062,6 +1153,8 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) build() {
 	o.builderState.outCount = o.calculateOutputCount(o.builderState.lGroups)
 }
 
+// {{ end }}
+
 // {{/*
 // This code snippet is executed when at least one of the input sources has
 // been exhausted. It processes any remaining tuples and then sets up the
@@ -1070,7 +1163,7 @@ func _SOURCE_FINISHED_SWITCH(_JOIN_TYPE joinTypeInfo) { // */}}
 	// {{define "sourceFinishedSwitch"}}
 	o.outputReady = true
 	// {{ if or $.JoinType.IsInner $.JoinType.IsLeftSemi }}
-	o.setBuilderSourceToBufferedGroup()
+	o.setBuilderSourceToBufferedGroup(ctx)
 	// {{ else }}
 	// First we make sure that batches of the builder state are always set. This
 	// is needed because the batches are accessed outside of _LEFT_SWITCH and
@@ -1091,7 +1184,7 @@ func _SOURCE_FINISHED_SWITCH(_JOIN_TYPE joinTypeInfo) { // */}}
 	// nulls corresponding to the right one. But if the left source is
 	// finished, then there is nothing left to do.
 	if o.proberState.lIdx < o.proberState.lLength {
-		o.exhaustLeftSource()
+		o.exhaustLeftSource(ctx)
 		// We unset o.outputReady here because we want to put as many unmatched
 		// tuples from the left into the output batch. Once outCount reaches the
 		// desired output batch size, the output will be returned.
@@ -1117,11 +1210,15 @@ func _SOURCE_FINISHED_SWITCH(_JOIN_TYPE joinTypeInfo) { // */}}
 
 // */}}
 
+// {{ range $filterInfo := $.FilterInfos }}
+
 // calculateOutputCount uses the toBuild field of each group and the output
 // batch size to determine the output count. Note that as soon as a group is
 // materialized partially or fully to output, its toBuild field is updated
 // accordingly.
-func (o *mergeJoin_JOIN_TYPE_STRINGOp) calculateOutputCount(groups []group) uint16 {
+func (o *mergeJoin_JOIN_TYPE_STRING_FILTER_INFO_STRINGOp) calculateOutputCount(
+	groups []group,
+) uint16 {
 	count := int(o.builderState.outCount)
 
 	for i := 0; i < len(groups); i++ {
@@ -1144,7 +1241,7 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) calculateOutputCount(groups []group) uint
 	return uint16(count)
 }
 
-func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next(ctx context.Context) coldata.Batch {
+func (o *mergeJoin_JOIN_TYPE_STRING_FILTER_INFO_STRINGOp) Next(ctx context.Context) coldata.Batch {
 	for {
 		switch o.state {
 		case mjEntry:
@@ -1175,10 +1272,10 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next(ctx context.Context) coldata.Batch {
 			o.state = mjBuild
 		case mjFinishBufferedGroup:
 			o.finishProbe(ctx)
-			o.setBuilderSourceToBufferedGroup()
+			o.setBuilderSourceToBufferedGroup(ctx)
 			o.state = mjBuild
 		case mjProbe:
-			o.probe()
+			o.probe(ctx)
 			o.setBuilderSourceToBatch()
 			o.state = mjBuild
 		case mjBuild:
@@ -1202,3 +1299,5 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next(ctx context.Context) coldata.Batch {
 		}
 	}
 }
+
+// {{ end }}

--- a/pkg/sql/exec/mergejoiner_tmpl.go
+++ b/pkg/sql/exec/mergejoiner_tmpl.go
@@ -235,7 +235,9 @@ func _PROBE_SWITCH(
 						// {{ if _JOIN_TYPE.IsLeftSemi }}
 						// {{ if _FILTER_INFO.HasFilter }}
 						for lIdx := beginLIdx; lIdx < beginLIdx+lGroupLength; lIdx++ {
-							if !o.isLeftTupleFilteredOut(ctx, o.proberState.lBatch, o.proberState.rBatch, lIdx, beginRIdx, beginRIdx+rGroupLength) {
+							if !o.filter.isLeftTupleFilteredOut(
+								ctx, o.proberState.lBatch, o.proberState.rBatch, lIdx, beginRIdx, beginRIdx+rGroupLength,
+							) {
 								o.groups.addLeftSemiGroup(lIdx, 1)
 							}
 						}
@@ -250,7 +252,9 @@ func _PROBE_SWITCH(
 						// tuple from the left source if there is a filter and the tuple
 						// doesn't pass the filter.
 						for lIdx := beginLIdx; lIdx < beginLIdx+lGroupLength; lIdx++ {
-							if o.isLeftTupleFilteredOut(ctx, o.proberState.lBatch, o.proberState.rBatch, lIdx, beginRIdx, beginRIdx+rGroupLength) {
+							if o.filter.isLeftTupleFilteredOut(
+								ctx, o.proberState.lBatch, o.proberState.rBatch, lIdx, beginRIdx, beginRIdx+rGroupLength,
+							) {
 								// The second argument doesn't matter in case of LEFT ANTI join.
 								o.groups.addLeftUnmatchedGroup(lIdx, beginRIdx)
 							}
@@ -982,13 +986,11 @@ func (o *mergeJoin_JOIN_TYPE_STRING_FILTER_INFO_STRINGOp) setBuilderSourceToBuff
 	// {{ if _JOIN_TYPE.IsLeftAnti }}
 	// {{ if _FILTER_INFO.HasFilter }}
 	o.builderState.lGroups = o.builderState.lGroups[:0]
-	rBatch := o.proberState.rBufferedGroup
 	rEndIdx := int(o.proberState.rBufferedGroup.length)
-	if o.filterOnlyOnLeft {
-		rBatch = nil
-	}
 	for lIdx := 0; lIdx < int(o.proberState.lBufferedGroup.length); lIdx++ {
-		if o.isLeftTupleFilteredOut(ctx, o.proberState.lBufferedGroup, rBatch, lIdx, 0 /* rStartIdx */, rEndIdx) {
+		if o.filter.isLeftTupleFilteredOut(
+			ctx, o.proberState.lBufferedGroup, o.proberState.rBufferedGroup, lIdx, 0 /* rStartIdx */, rEndIdx,
+		) {
 			o.builderState.lGroups = append(o.builderState.lGroups, group{
 				rowStartIdx: lIdx,
 				rowEndIdx:   lIdx + 1,
@@ -1015,7 +1017,9 @@ func (o *mergeJoin_JOIN_TYPE_STRING_FILTER_INFO_STRINGOp) setBuilderSourceToBuff
 	rGroupEndIdx := int(o.proberState.rBufferedGroup.length)
 	o.builderState.lGroups = o.builderState.lGroups[:0]
 	for lIdx := 0; lIdx < lGroupEndIdx; lIdx++ {
-		if !o.isLeftTupleFilteredOut(ctx, o.proberState.lBufferedGroup, o.proberState.rBufferedGroup, lIdx, 0 /* rStartIdx */, rGroupEndIdx) {
+		if !o.filter.isLeftTupleFilteredOut(
+			ctx, o.proberState.lBufferedGroup, o.proberState.rBufferedGroup, lIdx, 0 /* rStartIdx */, rGroupEndIdx,
+		) {
 			o.builderState.lGroups = append(o.builderState.lGroups, group{
 				rowStartIdx: lIdx,
 				rowEndIdx:   lIdx + 1,

--- a/pkg/sql/exec/mergejoiner_util.go
+++ b/pkg/sql/exec/mergejoiner_util.go
@@ -106,9 +106,9 @@ func (b *circularGroupsBuffer) addGroupsToNextCol(
 	}
 }
 
-// addLeftOuterGroup adds a left and right group to the buffer that correspond
-// to an unmatched row from the left side in the case of LEFT OUTER JOIN or
-// LEFT ANTI JOIN.
+// addLeftUnmatchedGroup adds a left and right group to the buffer that
+// correspond to an unmatched row from the left side in the case of LEFT OUTER
+// JOIN or LEFT ANTI JOIN.
 func (b *circularGroupsBuffer) addLeftUnmatchedGroup(curLIdx int, curRIdx int) {
 	b.leftGroups[b.endIdx] = group{
 		rowStartIdx: curLIdx,

--- a/pkg/sql/exec/stats_test.go
+++ b/pkg/sql/exec/stats_test.go
@@ -88,6 +88,8 @@ func TestVectorizedStatsCollector(t *testing.T) {
 			[]coltypes.T{coltypes.Int64},
 			[]distsqlpb.Ordering_Column{{ColIdx: 0}},
 			[]distsqlpb.Ordering_Column{{ColIdx: 0}},
+			nil,   /* filterConstructor */
+			false, /* filterOnlyOnLeft */
 		)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/sql/logictest/testdata/logic_test/tpch_vec
+++ b/pkg/sql/logictest/testdata/logic_test/tpch_vec
@@ -502,7 +502,7 @@ query error unsorted distinct not supported
 EXPLAIN (VEC) SELECT s_name, s_address FROM supplier, nation WHERE s_suppkey IN ( SELECT ps_suppkey FROM partsupp WHERE ps_partkey IN ( SELECT p_partkey FROM part WHERE p_name LIKE 'forest%') AND ps_availqty > ( SELECT 0.5 * sum(l_quantity) FROM lineitem WHERE l_partkey = ps_partkey AND l_suppkey = ps_suppkey AND l_shipdate >= DATE '1994-01-01' AND l_shipdate < DATE '1994-01-01' + INTERVAL '1' YEAR)) AND s_nationkey = n_nationkey AND n_name = 'CANADA' ORDER BY s_name
 
 # Query 21
-query error can't plan non-inner merge joins with on
+query error can't plan non-inner hash join with on expressions
 EXPLAIN (VEC) SELECT s_name, count(*) AS numwait FROM supplier, lineitem l1, orders, nation WHERE s_suppkey = l1.l_suppkey AND o_orderkey = l1.l_orderkey AND o_orderstatus = 'F' AND l1.l_receiptDATE > l1.l_commitdate AND EXISTS ( SELECT * FROM lineitem l2 WHERE l2.l_orderkey = l1.l_orderkey AND l2.l_suppkey <> l1.l_suppkey) AND NOT EXISTS ( SELECT * FROM lineitem l3 WHERE l3.l_orderkey = l1.l_orderkey AND l3.l_suppkey <> l1.l_suppkey AND l3.l_receiptDATE > l3.l_commitdate) AND s_nationkey = n_nationkey AND n_name = 'SAUDI ARABIA' GROUP BY s_name ORDER BY numwait DESC, s_name LIMIT 100
 
 # Query 22

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -791,3 +791,39 @@ ORDER BY
 	tab_426214._bool ASC
 ----
 1296 values hashing to cad02075a867c3c0564bf80fe665eed6
+
+# Regression test for #40372.
+statement ok
+CREATE TABLE t40372_1 (
+  a INT,
+  b INT,
+  c FLOAT,
+  d FLOAT
+)
+
+statement ok
+INSERT INTO t40372_1 VALUES
+  (1, 1, 1, 1),
+  (2, 2, 2, 2),
+  (3, 3, 3, 3)
+
+statement ok
+CREATE TABLE t40372_2 (
+  a INT,
+  b FLOAT,
+  c FLOAT,
+  d INT
+)
+
+statement ok
+INSERT INTO t40372_2 VALUES
+  (1, 1, 1, 1),
+  (2, 2, 2, 2),
+  (3, 3, 3, 3)
+
+query IIRR rowsort
+SELECT * FROM t40372_1 NATURAL JOIN t40372_2
+----
+1  1  1  1
+2  2  2  2
+3  3  3  3


### PR DESCRIPTION
**exec: minor clean up**

**exec: add support for ON expression for LEFT SEMI and LEFT ANTI merge join**

This commit adds support for ON expression for LEFT SEMI and LEFT ANTI
merge joins. This is achieved by setting up a side chain of two operators
filterFeedOperator -> filterOperator which lives alongside the merge join
but not on the same chain. Then, whenever a filter is present, we run
the matched tuples, one at a time, from the left and right inputs through it.
When the filter expression only references the columns from the left side, we
can optimize the filtering to do the check once for every tuple in question
from the left; however, when the filter references the columns from the right,
we need to filter the full cross product of each left tuple with the full
matching group of tuples from the right which gives us quadratic behavior.

**exec: move the filtering logic out of the merge joiner**

This commit moves out the infrastructure that supports ON expressions
for merge joiner into a separate file to be reused later by hash joiner.

**distsqlrun: refactor support for ON expressions for vectorized joiners**

This commit adds a comprehensive planning step for ON expressions
for vectorized hash and merge joiners. With INNER joins, the ON
expression is supported by planning a filter after the joiner;
however, without the extra work, this can be incorrect when the
filter expression refers to the columns that are not output by the
joiner. This is now fixed. Additionally, this commit allows for
correctly populating filterOnlyOnLeft field regardless of how the
filter expression is represented.

Fixes: #39458.
Addresses: #38018.
Fixes: #40372.

Release note: None