### PR TITLE
storage: fix stress flake

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -4430,8 +4430,17 @@ func TestDefaultConnectionDisruptionDoesNotInterfereWithSystemTraffic(t *testing
 		disabled.Store(true)
 		repl1, err := mtc.stores[0].GetReplica(1)
 		require.Nil(t, err)
-		// Transfer the lease on range 1
-		lease, _ := repl1.GetLease()
+		// Transfer the lease on range 1. Make sure there's no pending transfer.
+		var lease roachpb.Lease
+		testutils.SucceedsSoon(t, func() error {
+			var next roachpb.Lease
+			lease, next = repl1.GetLease()
+			if next != (roachpb.Lease{}) {
+				return fmt.Errorf("lease transfer in process, next = %v", next)
+			}
+			return nil
+		})
+
 		var target int
 		for i := roachpb.StoreID(1); i <= numReplicas; i++ {
 			if lease.Replica.StoreID != i {
@@ -4439,7 +4448,11 @@ func TestDefaultConnectionDisruptionDoesNotInterfereWithSystemTraffic(t *testing
 				break
 			}
 		}
-		mtc.transferLease(ctx, 1, int(lease.Replica.StoreID-1), target)
+		// Use SucceedsSoon to deal with rare stress cases where the lease
+		// transfer may fail.
+		testutils.SucceedsSoon(t, func() error {
+			return mtc.transferLeaseNonFatal(ctx, 1, target, int(lease.Replica.StoreID-1))
+		})
 		// Set a relatively short timeout so that this test doesn't take too long.
 		// We should always hit it.
 		withTimeout, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
@@ -4448,15 +4461,22 @@ func TestDefaultConnectionDisruptionDoesNotInterfereWithSystemTraffic(t *testing
 		_, pErr = client.SendWrapped(withTimeout, mtc.stores[0].TestSender(), putReq)
 		require.NotNil(t, pErr, "expected an error when sending to a disconnected store")
 		// Transfer the lease back to demonstrate that the system range is still live.
-		mtc.transferLease(ctx, 1, target, int(lease.Replica.StoreID-1))
+		testutils.SucceedsSoon(t, func() error {
+			return mtc.transferLeaseNonFatal(ctx, 1, target, int(lease.Replica.StoreID-1))
+		})
+
 		// Heal the partition, the previous proposal may now succeed but it may have
 		// have been canceled.
 		disabled.Store(false)
 		// Overwrite with a new value and ensure that it propagates.
 		putReq.Value.SetInt(3)
-		_, pErr = client.SendWrapped(ctx, mtc.stores[0].TestSender(), putReq)
-		require.Nil(t, pErr, "expected to succeed after healing the partition")
-		mtc.waitForValues(keyA, []int64{3, 3, 3})
+		// Retry because failures in stress due to liveness epoch failures can
+		// happen.
+		testutils.SucceedsSoon(t, func() error {
+			_, pErr = client.SendWrapped(ctx, mtc.stores[0].TestSender(), putReq)
+			return pErr.GoError()
+		})
+		mtc.waitForValuesT(t, keyA, []int64{3, 3, 3})
 	}
 	t.Run("initial_run", runTest)
 	mtc.restart()

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -1265,18 +1265,25 @@ func (m *multiTestContext) readIntFromEngines(key roachpb.Key) []int64 {
 	return results
 }
 
-// waitForValues waits up to the given duration for the integer values
-// at the given key to match the expected slice (across all engines).
-// Fails the test if they do not match.
-func (m *multiTestContext) waitForValues(key roachpb.Key, expected []int64) {
-	m.t.Helper()
-	testutils.SucceedsSoon(m.t, func() error {
+// waitForValuesT is like waitForValues but allows the caller to provide a
+// testing.T which may differ from m.t.
+func (m *multiTestContext) waitForValuesT(t testing.TB, key roachpb.Key, expected []int64) {
+	t.Helper()
+	testutils.SucceedsSoon(t, func() error {
 		actual := m.readIntFromEngines(key)
 		if !reflect.DeepEqual(expected, actual) {
 			return errors.Errorf("expected %v, got %v", expected, actual)
 		}
 		return nil
 	})
+}
+
+// waitForValues waits up to the given duration for the integer values
+// at the given key to match the expected slice (across all engines).
+// Fails the test if they do not match.
+func (m *multiTestContext) waitForValues(key roachpb.Key, expected []int64) {
+	m.t.Helper()
+	m.waitForValuesT(m.t, key, expected)
 }
 
 // transferLease transfers the lease for the given range from the source


### PR DESCRIPTION
While stressing storage for #39643 I encountered
TestDefaultConnectionDisruptionDoesNotInterfereWithSystemTraffic
failing under stress. It also complained about the parent testing.T
having been failed when then using a child so fixed that too though
in a perhaps messy way.

```
--- FAIL: TestDefaultConnectionDisruptionDoesNotInterfereWithSystemTraffic (2.29s)
    --- PASS: TestDefaultConnectionDisruptionDoesNotInterfereWithSystemTraffic/initial_run (0.14s)
    client_test.go:1280: [NotLeaseHolderError] r1: replica (n1,s1):1 not lease holder; current lease is repl=(n3,s3):3 seq=4 start=1566532897.322355813,1 exp=1566532898.378802707,0 pro=1566532897.478824123,0
    --- FAIL: TestDefaultConnectionDisruptionDoesNotInterfereWithSystemTraffic/after_restart (1.02s)
        testing.go:820: test executed panic(nil) or runtime.Goexit: subtest may have called FailNow on a parent test
```

Release note: None