### PR TITLE
config: validate that subzones have fields in tandem

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -340,7 +340,7 @@ CREATE TABLE t36642 (
 );
 
 statement ok
-ALTER INDEX t36642@secondary CONFIGURE ZONE USING lease_preferences='[[+region=test,+dc=dc1]]'
+ALTER INDEX t36642@secondary CONFIGURE ZONE USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc1]]'
 
 query TTT retry
 EXPLAIN SELECT * FROM t36642 WHERE k=10
@@ -350,10 +350,10 @@ scan  ·      ·
 ·     spans  /10-/11
 
 statement ok
-ALTER INDEX t36642@tertiary CONFIGURE ZONE USING lease_preferences='[[+region=test,+dc=dc1]]'
+ALTER INDEX t36642@tertiary CONFIGURE ZONE USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc1]]'
 
 statement ok
-ALTER INDEX t36642@secondary CONFIGURE ZONE USING lease_preferences='[[+region=test,+dc=dc2]]'
+ALTER INDEX t36642@secondary CONFIGURE ZONE USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc2]]'
 
 query TTT retry
 EXPLAIN SELECT * FROM t36642 WHERE k=10
@@ -566,3 +566,25 @@ ALTER PARTITION p1 OF INDEX "my database".public.show_test@primary CONFIGURE ZON
   constraints = '[+dc=dc1]';
 ALTER PARTITION p2 OF INDEX "my database".public.show_test@primary CONFIGURE ZONE USING
   constraints = '[+dc=dc2]'
+
+# Regression test for #39994: verify that certain fields have to be set in tandem in indexes and partitions.
+statement ok
+CREATE TABLE validateTandemFields (a INT, b INT, c INT, PRIMARY KEY (a, b))
+  PARTITION BY LIST (a, b) (PARTITION simple VALUES IN ((1, 1), (2, 2), (3, 3)))
+
+statement error pq: could not validate zone config: range_min_bytes and range_max_bytes must be set together
+ALTER PARTITION simple OF TABLE validateTandemFields CONFIGURE ZONE USING range_min_bytes = 66666;
+
+statement ok
+CREATE INDEX secondary
+    ON validateTandemFields (b)
+    PARTITION BY LIST (b)
+        (
+            PARTITION indexPartition VALUES IN (2, 3, 4)
+        )
+
+statement error pq: could not validate zone config: range_min_bytes and range_max_bytes must be set together
+ALTER INDEX validateTandemFields@secondary CONFIGURE ZONE USING range_min_bytes = 66666;
+
+statement error pq: could not validate zone config: range_min_bytes and range_max_bytes must be set together
+ALTER PARTITION indexPartition OF INDEX validateTandemFields@secondary CONFIGURE ZONE USING range_min_bytes = 66666;


### PR DESCRIPTION
Fixes #39994.

Previously we only validated the zone we were writing
but when we're writing index or partition zones, we write
a subzone inside another zone. Instead of validating this
subzone, we we're incorrectly validating the parent zone.
This change rectifies that.

Release note: None

cc @andreimatei I'll be losing bors access and might not be 
able to continue working on this soon. Going to punt this over
to you to triage if that happens 😀 