### PR TITLE
ccl/importccl: temporarily skip TestImportData

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -52,6 +52,8 @@ import (
 func TestImportData(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	t.Skipf("failing on teamcity with testrace")
+
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	ctx := context.Background()
 	defer s.Stopper().Stop(ctx)


### PR DESCRIPTION
This test is failing repeatedly on teamcity under testrace.

See #40187 for one of many example failures

Release note: None