### PR TITLE
demo: don't log errors to stdout

### DIFF
--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -103,13 +103,12 @@ func setupTransientServers(
 	df := cmd.Flags().Lookup(cliflags.LogDir.Name)
 	sf := cmd.Flags().Lookup(logflags.LogToStderrName)
 	if !df.Changed && !sf.Changed {
-		// User did not request logging flags; shut down logging under
-		// errors and make logs appear on stderr.
+		// User did not request logging flags; shut down all logging.
 		// Otherwise, the demo command would cause a cockroach-data
 		// directory to appear in the current directory just for logs.
 		_ = df.Value.Set("")
 		df.Changed = true
-		_ = sf.Value.Set(log.Severity_ERROR.String())
+		_ = sf.Value.Set(log.Severity_NONE.String())
 		sf.Changed = true
 	}
 	stopper, err := setupAndInitializeLoggingAndProfiling(ctx, cmd)


### PR DESCRIPTION
It's not important for demo users to see errors in the logs, and they
can always enable logging via flags if necessary.

Fixes #39939.

Release note (cli change): don't log errors in cockroach demo to the
CLI.