### PR TITLE
roachprod: support staging local non-linux binaries

### DIFF
--- a/pkg/cmd/roachprod/install/staging.go
+++ b/pkg/cmd/roachprod/install/staging.go
@@ -22,12 +22,16 @@ const (
 	releaseBinaryServer = "https://s3.amazonaws.com/binaries.cockroachdb.com/"
 )
 
-func getEdgeBinaryURL(binaryName string, SHA string) (*url.URL, error) {
+func getEdgeBinaryURL(binaryName, SHA, arch string) (*url.URL, error) {
 	edgeBinaryLocation, err := url.Parse(edgeBinaryServer)
 	if err != nil {
 		return nil, err
 	}
 	edgeBinaryLocation.Path = binaryName
+	// If a target architecture is provided, attach that.
+	if len(arch) > 0 {
+		edgeBinaryLocation.Path += "." + arch
+	}
 	// If a specific SHA is provided, just attach that.
 	if len(SHA) > 0 {
 		edgeBinaryLocation.Path += "." + SHA
@@ -48,8 +52,8 @@ func getEdgeBinaryURL(binaryName string, SHA string) (*url.URL, error) {
 // StageRemoteBinary downloads a cockroach edge binary with the provided
 // application path to each specified by the cluster. If no SHA is specified,
 // the latest build of the binary is used instead.
-func StageRemoteBinary(c *SyncedCluster, applicationName, binaryPath, SHA string) error {
-	binURL, err := getEdgeBinaryURL(binaryPath, SHA)
+func StageRemoteBinary(c *SyncedCluster, applicationName, binaryPath, SHA, arch string) error {
+	binURL, err := getEdgeBinaryURL(binaryPath, SHA, arch)
 	if err != nil {
 		return err
 	}
@@ -64,7 +68,7 @@ func StageRemoteBinary(c *SyncedCluster, applicationName, binaryPath, SHA string
 
 // StageCockroachRelease downloads an official CockroachDB release binary with
 // the specified version.
-func StageCockroachRelease(c *SyncedCluster, version string) error {
+func StageCockroachRelease(c *SyncedCluster, version, arch string) error {
 	if len(version) == 0 {
 		return fmt.Errorf(
 			"release application cannot be staged without specifying a specific version",
@@ -74,7 +78,7 @@ func StageCockroachRelease(c *SyncedCluster, version string) error {
 	if err != nil {
 		return err
 	}
-	binURL.Path += fmt.Sprintf("cockroach-%s.linux-amd64.tgz", version)
+	binURL.Path += fmt.Sprintf("cockroach-%s.%s.tgz", version, arch)
 	fmt.Printf("Resolved release url for cockroach version %s: %s\n", version, binURL)
 
 	// This command incantation:

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -90,6 +90,7 @@ var (
 	quiet             = false
 	sig               = 9
 	waitFlag          = false
+	stageOS           string
 	logsDir           string
 	logsFilter        string
 	logsFrom          time.Time
@@ -1262,7 +1263,9 @@ Some examples of usage:
 		}
 
 		os := "linux"
-		if c.IsLocal() {
+		if stageOS != "" {
+			os = stageOS
+		} else if c.IsLocal() {
 			os = runtime.GOOS
 		}
 		var debugArch, releaseArch string
@@ -1659,6 +1662,8 @@ func main() {
 	}
 
 	putCmd.Flags().BoolVar(&useTreeDist, "treedist", useTreeDist, "use treedist copy algorithm")
+
+	stageCmd.Flags().StringVar(&stageOS, "os", "", "operating system override for staged binaries")
 
 	logsCmd.Flags().StringVar(
 		&logsFilter, "filter", "", "re to filter log messages")

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -21,6 +21,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -1260,6 +1261,22 @@ Some examples of usage:
 			return err
 		}
 
+		os := "linux"
+		if c.IsLocal() {
+			os = runtime.GOOS
+		}
+		var debugArch, releaseArch string
+		switch os {
+		case "linux":
+			debugArch, releaseArch = "linux-gnu-amd64", "linux-amd64"
+		case "darwin":
+			debugArch, releaseArch = "darwin-amd64", "darwin-10.9-amd64"
+		case "windows":
+			debugArch, releaseArch = "windows-amd64", "windows-6.2-amd64"
+		default:
+			return errors.Errorf("cannot stage binary on %s", os)
+		}
+
 		applicationName := args[1]
 		versionArg := ""
 		if len(args) == 3 {
@@ -1268,14 +1285,14 @@ Some examples of usage:
 		switch applicationName {
 		case "cockroach":
 			return install.StageRemoteBinary(
-				c, applicationName, "cockroach/cockroach.linux-gnu-amd64", versionArg,
+				c, applicationName, "cockroach/cockroach", versionArg, debugArch,
 			)
 		case "workload":
 			return install.StageRemoteBinary(
-				c, applicationName, "cockroach/workload", versionArg,
+				c, applicationName, "cockroach/workload", versionArg, "", /* arch */
 			)
 		case "release":
-			return install.StageCockroachRelease(c, versionArg)
+			return install.StageCockroachRelease(c, versionArg, releaseArch)
 		default:
 			return fmt.Errorf("unknown application %s", applicationName)
 		}


### PR DESCRIPTION
This commit adds support to `roachprod stage` to install binaries to a
local non-linux cluster. For instance, Mac users can now use roachprod
stage to stage Darwin binaries on their local cluster instead of needing
to either compile the binary themselves or download it separately.

Release note: None