### PR TITLE
roachtest: drop indexes and ledger duration to 10m

### DIFF
--- a/pkg/cmd/roachtest/indexes.go
+++ b/pkg/cmd/roachtest/indexes.go
@@ -55,7 +55,7 @@ func registerNIndexes(r *testRegistry, secondaryIndexes int) {
 
 				payload := " --payload=256"
 				concurrency := ifLocal("", " --concurrency="+strconv.Itoa(nodes*32))
-				duration := " --duration=" + ifLocal("10s", "30m")
+				duration := " --duration=" + ifLocal("10s", "10m")
 				runCmd := fmt.Sprintf("./workload run indexes --histograms="+perfArtifactsDir+"/stats.json"+
 					payload+concurrency+duration+" {pgurl%s}", gatewayNodes)
 				c.Run(ctx, loadNode, runCmd)

--- a/pkg/cmd/roachtest/ledger.go
+++ b/pkg/cmd/roachtest/ledger.go
@@ -34,7 +34,7 @@ func registerLedger(r *testRegistry) {
 			m := newMonitor(ctx, c, roachNodes)
 			m.Go(func(ctx context.Context) error {
 				concurrency := ifLocal("", " --concurrency="+fmt.Sprint(nodes*32))
-				duration := " --duration=" + ifLocal("10s", "30m")
+				duration := " --duration=" + ifLocal("10s", "10m")
 
 				cmd := fmt.Sprintf("./workload run ledger --init --histograms="+perfArtifactsDir+"/stats.json"+
 					concurrency+duration+" {pgurl%s}", gatewayNodes)


### PR DESCRIPTION
These tests were running for 30m each. That seems unnecessary, given
that we run these nightly along with a large suite of other tests.

Release note: None