### PR TITLE
distsql: add disk spilling to lookup joiner

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -150,8 +150,11 @@ func (dsp *DistSQLPlanner) setupFlows(
 				if _, err := distsqlrun.SupportsVectorized(
 					ctx, &distsqlrun.FlowCtx{
 						EvalCtx: &evalCtx.EvalContext,
-						Cfg:     &distsqlrun.ServerConfig{},
-						NodeID:  -1,
+						Cfg: &distsqlrun.ServerConfig{
+							DiskMonitor: &mon.BytesMonitor{},
+							Settings:    dsp.st,
+						},
+						NodeID: -1,
 					}, spec.Processors,
 				); err != nil {
 					// Vectorization attempt failed with an error.


### PR DESCRIPTION
In lookup joins on partial index keys, there is no limit on how many
rows might be returned by any particular lookup, so the joinreader may
be buffering an unbounded number of rows into memory. I changed
joinreader to use a disk-backed row container rather than just storing
the rows in memory with no accounting.

Fixes #39044

Release note (bug fix): Lookup joins now spill to disk if the index
lookups return more rows than can be stored in memory.