### PR TITLE
util/log: avoid clobbering the global logger in TestRace

### DIFF
--- a/pkg/util/log/trace_test.go
+++ b/pkg/util/log/trace_test.go
@@ -62,10 +62,6 @@ func noLogV() int32 {
 func TestTrace(t *testing.T) {
 	ctx := context.Background()
 
-	// The test below merely cares about observing events in traces.
-	// Do not pollute the test's stderr with them.
-	logging.stderrThreshold = Severity_FATAL
-
 	// Events to context without a trace should be no-ops.
 	Event(ctx, "should-not-show-up")
 


### PR DESCRIPTION
Fixes #16551.

Noticed/requested by @andreimatei: the test was presumably trying to
avoid spamming the test log by clobbering the global logging
threshold, however a casual revert reveals that there is no spam log
without this override. So it's not necessary after all.

Release note: None