### PR TITLE
workload/bank: reset payload column before reuse

### DIFF
--- a/pkg/workload/bank/bank.go
+++ b/pkg/workload/bank/bank.go
@@ -148,6 +148,8 @@ func (b *bank) Tables() []workload.Table {
 				idCol := cb.ColVec(0).Int64()
 				balanceCol := cb.ColVec(1).Int64()
 				payloadCol := cb.ColVec(2).Bytes()
+				// coldata.Bytes only allows appends so we have to reset it
+				payloadCol.Reset()
 				for rowIdx := rowBegin; rowIdx < rowEnd; rowIdx++ {
 					var payload []byte
 					*a, payload = a.Alloc(b.payloadBytes, 0 /* extraCap */)


### PR DESCRIPTION
Without this change, running the bank workload on a non-trivial number
of rows causes cockroach to fail with this error message:

`panic: cannot overwrite value on flat Bytes: maxSetIndex=999, setIndex=0, consider using Reset`

Release note: None