### PR TITLE
demo: Add location information to default demo localities.

### DIFF
--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -52,7 +52,8 @@ to avoid pre-loading a dataset.`,
 const defaultGeneratorName = "movr"
 
 var defaultGenerator workload.Generator
-var defaultLocalities = []roachpb.Locality{
+
+var defaultLocalities = demoLocalityList{
 	// Default localities for a 3 node cluster
 	{Tiers: []roachpb.Tier{{Key: "region", Value: "us-east1"}, {Key: "az", Value: "b"}}},
 	{Tiers: []roachpb.Tier{{Key: "region", Value: "us-east1"}, {Key: "az", Value: "c"}}},

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -514,3 +514,37 @@ func (l *Locality) Set(value string) error {
 	l.Tiers = tiers
 	return nil
 }
+
+// DefaultLocationInformation is used to populate the system.locations
+// table. The region values here are specific to GCP.
+var DefaultLocationInformation = []struct {
+	Locality  Locality
+	Latitude  string
+	Longitude string
+}{
+	{
+		Locality:  Locality{Tiers: []Tier{{Key: "region", Value: "us-east1"}}},
+		Latitude:  "33.836082",
+		Longitude: "-81.163727",
+	},
+	{
+		Locality:  Locality{Tiers: []Tier{{Key: "region", Value: "us-east4"}}},
+		Latitude:  "37.478397",
+		Longitude: "-76.453077",
+	},
+	{
+		Locality:  Locality{Tiers: []Tier{{Key: "region", Value: "us-central1"}}},
+		Latitude:  "42.032974",
+		Longitude: "-93.581543",
+	},
+	{
+		Locality:  Locality{Tiers: []Tier{{Key: "region", Value: "us-west1"}}},
+		Latitude:  "43.804133",
+		Longitude: "-120.554201",
+	},
+	{
+		Locality:  Locality{Tiers: []Tier{{Key: "region", Value: "europe-west1"}}},
+		Latitude:  "50.44816",
+		Longitude: "3.81886",
+	},
+}


### PR DESCRIPTION
Fixes #39937.

Adds default latitude and longitude information for the default
localities in cockroach demo so that the web UI is pre-populated.

Release note (cli change): Add location information to default
localities to populate web UI for cockroach demo.