### PR TITLE
docs: explain that the builder image needs more RAM

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,12 @@ download and install various dependencies. After running `make build`,
 the `cockroach` executable will be in your current directory and can
 be run as shown in the [README](README.md).
 
+Note that if you use the builder image, you should ensure that your
+Docker installation grants 4GB or more of RAM to containers. On some
+systems, the default configuration limits containers to 2GB memory
+usage and this can be insufficient to build/link a CockroachDB
+executable.
+
 ### Other Considerations
 
 - The default binary contains core open-source functionally covered by

--- a/build/README.md
+++ b/build/README.md
@@ -21,6 +21,12 @@ It is well suited to hacking around and running the tests (including the
 acceptance tests). To fetch this image, run `./builder.sh pull`. The image can
 be run conveniently via `./builder.sh`.
 
+Note that if you use the builder image, you should ensure that your
+Docker installation grants 4GB or more of RAM to containers. On some
+systems, the default configuration limits containers to 2GB memory
+usage and this can be insufficient to build/link a CockroachDB
+executable.
+
 ### Deployment
 
 The deploy image is a downsized image containing a minimal environment for


### PR DESCRIPTION
Found/requested by Tim Veil: on some systems the default Docker config
limits containers to 2GB and this is not sufficient to link
CockroachDB. The doc should point this out.

Release note: None