### PR TITLE
storage: test atomic replication changes

### DIFF
--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -137,18 +137,19 @@ func (r *RangeDescriptor) SetReplicas(replicas ReplicaDescriptors) {
 
 // SetReplicaType changes the type of the replica with the given ID to the given
 // type. Returns zero values if the replica was not found and the updated
-// descriptor and true otherwise.
+// descriptor, the previous type, and true, otherwise.
 func (r *RangeDescriptor) SetReplicaType(
 	nodeID NodeID, storeID StoreID, typ ReplicaType,
-) (ReplicaDescriptor, bool) {
+) (ReplicaDescriptor, ReplicaType, bool) {
 	for i := range r.InternalReplicas {
 		desc := &r.InternalReplicas[i]
 		if desc.StoreID == storeID && desc.NodeID == nodeID {
+			prevTyp := desc.GetType()
 			desc.Type = &typ
-			return *desc, true
+			return *desc, prevTyp, true
 		}
 	}
-	return ReplicaDescriptor{}, false
+	return ReplicaDescriptor{}, 0, false
 }
 
 // AddReplica adds a replica on the given node and store with the supplied type.

--- a/pkg/roachpb/metadata_replicas.go
+++ b/pkg/roachpb/metadata_replicas.go
@@ -210,9 +210,7 @@ func (d ReplicaDescriptors) Learners() []ReplicaDescriptor {
 
 // Filter returns only the replica descriptors for which the supplied method
 // returns true. The memory returned may be shared with the receiver.
-func (d ReplicaDescriptors) Filter(
-	pred func(descriptor ReplicaDescriptor) bool,
-) []ReplicaDescriptor {
+func (d ReplicaDescriptors) Filter(pred func(rDesc ReplicaDescriptor) bool) []ReplicaDescriptor {
 	// Fast path when all or none match to avoid allocations.
 	fastpath := true
 	out := d.wrapped

--- a/pkg/storage/batcheval/cmd_lease.go
+++ b/pkg/storage/batcheval/cmd_lease.go
@@ -48,6 +48,13 @@ func checkCanReceiveLease(rec EvalContext) error {
 		return errors.AssertionFailedf(
 			`could not find replica for store %s in %s`, rec.StoreID(), rec.Desc())
 	} else if t := repDesc.GetType(); t != roachpb.VOTER_FULL {
+		// NB: there's no harm in transferring the lease to a VOTER_INCOMING,
+		// but we disallow it anyway. On the other hand, transferring to
+		// VOTER_OUTGOING would be a pretty bad idea since those voters are
+		// dropped when transitioning out of the joint config, which then
+		// amounts to removing the leaseholder without any safety precautions.
+		// This would either wedge the range or allow illegal reads to be
+		// served.
 		return errors.Errorf(`cannot transfer lease to replica of type %s`, t)
 	}
 	return nil

--- a/pkg/storage/batcheval/cmd_lease.go
+++ b/pkg/storage/batcheval/cmd_lease.go
@@ -55,6 +55,9 @@ func checkCanReceiveLease(rec EvalContext) error {
 		// amounts to removing the leaseholder without any safety precautions.
 		// This would either wedge the range or allow illegal reads to be
 		// served.
+		//
+		// Since the leaseholder can't remove itself and is a VOTER_FULL, we
+		// also know that in any configuration there's at least one VOTER_FULL.
 		return errors.Errorf(`cannot transfer lease to replica of type %s`, t)
 	}
 	return nil

--- a/pkg/storage/merge_queue.go
+++ b/pkg/storage/merge_queue.go
@@ -275,29 +275,30 @@ func (mq *mergeQueue) process(
 	}
 
 	{
+		store, db := lhsRepl.store, lhsRepl.store.DB()
 		// AdminMerge errors if there is a learner or joint config on either
 		// side and AdminRelocateRange removes any on the range it operates on.
 		// For the sake of obviousness, just fix this all upfront.
 		var err error
-		lhsDesc, err = maybeLeaveAtomicChangeReplicas(ctx, lhsRepl.store, lhsDesc)
+		lhsDesc, err = maybeLeaveAtomicChangeReplicas(ctx, store, lhsDesc)
 		if err != nil {
 			log.VEventf(ctx, 2, `%v`, err)
 			return err
 		}
 
-		lhsDesc, err = removeLearners(ctx, lhsRepl.store.DB(), lhsDesc)
+		lhsDesc, err = removeLearners(ctx, db, lhsDesc)
 		if err != nil {
 			log.VEventf(ctx, 2, `%v`, err)
 			return err
 		}
 
-		rhsDesc, err = maybeLeaveAtomicChangeReplicas(ctx, lhsRepl.store, rhsDesc)
+		rhsDesc, err = maybeLeaveAtomicChangeReplicas(ctx, store, rhsDesc)
 		if err != nil {
 			log.VEventf(ctx, 2, `%v`, err)
 			return err
 		}
 
-		rhsDesc, err = removeLearners(ctx, lhsRepl.store.DB(), rhsDesc)
+		rhsDesc, err = removeLearners(ctx, db, rhsDesc)
 		if err != nil {
 			log.VEventf(ctx, 2, `%v`, err)
 			return err

--- a/pkg/storage/merge_queue.go
+++ b/pkg/storage/merge_queue.go
@@ -188,22 +188,22 @@ var _ purgatoryError = rangeMergePurgatoryError{}
 
 func (mq *mergeQueue) requestRangeStats(
 	ctx context.Context, key roachpb.Key,
-) (roachpb.RangeDescriptor, enginepb.MVCCStats, float64, error) {
+) (*roachpb.RangeDescriptor, enginepb.MVCCStats, float64, error) {
 	res, pErr := client.SendWrappedWith(ctx, mq.db.NonTransactionalSender(), roachpb.Header{
 		ReturnRangeInfo: true,
 	}, &roachpb.RangeStatsRequest{
 		RequestHeader: roachpb.RequestHeader{Key: key},
 	})
 	if pErr != nil {
-		return roachpb.RangeDescriptor{}, enginepb.MVCCStats{}, 0, pErr.GoError()
+		return nil, enginepb.MVCCStats{}, 0, pErr.GoError()
 	}
 	rangeInfos := res.Header().RangeInfos
 	if len(rangeInfos) != 1 {
-		return roachpb.RangeDescriptor{}, enginepb.MVCCStats{}, 0, fmt.Errorf(
+		return nil, enginepb.MVCCStats{}, 0, fmt.Errorf(
 			"mergeQueue.requestRangeStats: response had %d range infos but exactly one was expected",
 			len(rangeInfos))
 	}
-	return rangeInfos[0].Desc, res.(*roachpb.RangeStatsResponse).MVCCStats,
+	return &rangeInfos[0].Desc, res.(*roachpb.RangeStatsResponse).MVCCStats,
 		res.(*roachpb.RangeStatsResponse).QueriesPerSecond, nil
 }
 
@@ -275,21 +275,33 @@ func (mq *mergeQueue) process(
 	}
 
 	{
-		// AdminMerge errors if there are learners on either side and
-		// AdminRelocateRange removes any on the range it operates on. For the sake
-		// of obviousness, just remove them all upfront.
-		newLHSDesc, err := removeLearners(ctx, lhsRepl.store.DB(), lhsDesc)
+		// AdminMerge errors if there is a learner or joint config on either
+		// side and AdminRelocateRange removes any on the range it operates on.
+		// For the sake of obviousness, just fix this all upfront.
+		var err error
+		lhsDesc, err = maybeLeaveAtomicChangeReplicas(ctx, lhsRepl.store, lhsDesc)
 		if err != nil {
 			log.VEventf(ctx, 2, `%v`, err)
 			return err
 		}
-		lhsDesc = newLHSDesc
-		newRHSDesc, err := removeLearners(ctx, lhsRepl.store.DB(), &rhsDesc)
+
+		lhsDesc, err = removeLearners(ctx, lhsRepl.store.DB(), lhsDesc)
 		if err != nil {
 			log.VEventf(ctx, 2, `%v`, err)
 			return err
 		}
-		rhsDesc = *newRHSDesc
+
+		rhsDesc, err = maybeLeaveAtomicChangeReplicas(ctx, lhsRepl.store, rhsDesc)
+		if err != nil {
+			log.VEventf(ctx, 2, `%v`, err)
+			return err
+		}
+
+		rhsDesc, err = removeLearners(ctx, lhsRepl.store.DB(), rhsDesc)
+		if err != nil {
+			log.VEventf(ctx, 2, `%v`, err)
+			return err
+		}
 	}
 	lhsReplicas, rhsReplicas := lhsDesc.Replicas().All(), rhsDesc.Replicas().All()
 

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1362,13 +1362,13 @@ func execChangeReplicasTxn(
 				if !ok {
 					return nil, errors.Errorf("target %s not found", chg.target)
 				}
-				if typ := rDesc.GetType(); !useJoint || typ != roachpb.VOTER_FULL {
-					// NB: typ != VOTER_FULL means it's a LEARNER since we verified above that we
-					// did not start in a joint config.
+				if typ := rDesc.GetType(); !useJoint || typ == roachpb.LEARNER {
 					rDesc, _ = updatedDesc.RemoveReplica(chg.target.NodeID, chg.target.StoreID)
 				} else {
+					// NB: typ is already known to be VOTER_FULL because of !InAtomicReplicationChange() above.
+					// We check it anyway.
 					var prevTyp roachpb.ReplicaType
-					rDesc, prevTyp, _ = updatedDesc.SetReplicaType(chg.target.NodeID, chg.target.StoreID, roachpb.VOTER_OUTGOING)
+					rDesc, _, _ = updatedDesc.SetReplicaType(chg.target.NodeID, chg.target.StoreID, roachpb.VOTER_OUTGOING)
 					if prevTyp != roachpb.VOTER_FULL {
 						return nil, errors.Errorf("cannot transition from %s to VOTER_OUTGOING", prevTyp)
 					}

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -585,10 +585,14 @@ func (r *Replica) AdminMerge(
 		// This behavior can be changed later if the complexity becomes worth
 		// it, but it's not right now.
 		lReplicas, rReplicas := origLeftDesc.Replicas(), rightDesc.Replicas()
-		if len(lReplicas.Voters()) != len(lReplicas.All()) {
+
+		predFullVoter := func(rDesc roachpb.ReplicaDescriptor) bool {
+			return rDesc.GetType() == roachpb.VOTER_FULL
+		}
+		if len(lReplicas.Filter(predFullVoter)) != len(lReplicas.All()) {
 			return errors.Errorf("cannot merge range with non-voter replicas on lhs: %s", lReplicas)
 		}
-		if len(rReplicas.Voters()) != len(rReplicas.All()) {
+		if len(rReplicas.Filter(predFullVoter)) != len(rReplicas.All()) {
 			return errors.Errorf("cannot merge range with non-voter replicas on rhs: %s", rReplicas)
 		}
 		if !replicaSetsEqual(lReplicas.All(), rReplicas.All()) {

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1322,6 +1322,9 @@ func execChangeReplicasTxn(
 		}
 
 		useJoint := len(chgs) > 1
+		if fn := store.TestingKnobs().ReplicationAlwaysUseJointConfig; fn != nil && fn() {
+			useJoint = true
+		}
 		for _, chg := range chgs {
 			switch chg.typ {
 			case internalChangeTypeAddVoterViaPreemptiveSnap:

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1153,10 +1153,8 @@ func (r *Replica) atomicReplicationChange(
 		}
 	}
 
-	if fn := r.store.cfg.TestingKnobs.ReplicaAddStopAfterLearnerSnapshot; fn != nil {
-		if fn() {
-			return desc, nil
-		}
+	if fn := r.store.cfg.TestingKnobs.ReplicaAddStopAfterLearnerSnapshot; fn != nil && fn() {
+		return desc, nil
 	}
 
 	for _, target := range chgs.Removals() {
@@ -1168,6 +1166,11 @@ func (r *Replica) atomicReplicationChange(
 	if err != nil {
 		return nil, err
 	}
+
+	if fn := r.store.cfg.TestingKnobs.ReplicaAddStopAfterJointConfig; fn != nil && fn() {
+		return desc, nil
+	}
+
 	// Leave the joint config if we entered one.
 	return r.maybeLeaveAtomicChangeReplicas(ctx, desc)
 }

--- a/pkg/storage/replica_follower_read.go
+++ b/pkg/storage/replica_follower_read.go
@@ -37,16 +37,17 @@ var FollowerReadsEnabled = settings.RegisterBoolSetting(
 func (r *Replica) canServeFollowerRead(
 	ctx context.Context, ba *roachpb.BatchRequest, pErr *roachpb.Error,
 ) *roachpb.Error {
-	// There's no known reason that a learner replica couldn't serve follower
-	// reads (or RangeFeed), but as of the time of writing, learners are expected
+	// There's no known reason that a non-VOTER_FULL replica couldn't serve follower
+	// reads (or RangeFeed), but as of the time of writing, these are expected
 	// to be short-lived, so it's not worth working out the edge-cases. Revisit if
-	// we add long-lived learners.
+	// we add long-lived learners or feel that incoming/outgoing voters also need
+	// to be able to serve follower reads.
 	repDesc, err := r.GetReplicaDescriptor()
 	if err != nil {
 		return roachpb.NewError(err)
 	}
-	if repDesc.GetType() == roachpb.LEARNER {
-		log.Event(ctx, "learner replicas cannot serve follower reads")
+	if typ := repDesc.GetType(); typ != roachpb.VOTER_FULL {
+		log.Eventf(ctx, "%s replicas cannot serve follower reads", typ)
 		return pErr
 	}
 

--- a/pkg/storage/replica_learner_test.go
+++ b/pkg/storage/replica_learner_test.go
@@ -53,19 +53,16 @@ type replicationTestKnobs struct {
 }
 
 func (rtl *replicationTestKnobs) withStopAfterLearnerAtomic(f func()) {
-	prev := atomic.LoadInt64(&rtl.replicaAddStopAfterLearnerAtomic)
+	prev := atomic.SwapInt64(&rtl.replicaAddStopAfterLearnerAtomic, 1)
 	defer atomic.StoreInt64(&rtl.replicaAddStopAfterLearnerAtomic, prev)
-	atomic.StoreInt64(&rtl.replicaAddStopAfterLearnerAtomic, 1)
 	f()
 }
 
 func (rtl *replicationTestKnobs) withStopAfterJointConfig(f func()) {
-	au := atomic.LoadInt64(&rtl.replicationAlwaysUseJointConfig)
-	sa := atomic.LoadInt64(&rtl.replicaAddStopAfterJointConfig)
+	au := atomic.SwapInt64(&rtl.replicationAlwaysUseJointConfig, 1)
+	sa := atomic.SwapInt64(&rtl.replicaAddStopAfterJointConfig, 1)
 	defer atomic.StoreInt64(&rtl.replicationAlwaysUseJointConfig, au)
 	defer atomic.StoreInt64(&rtl.replicaAddStopAfterJointConfig, sa)
-	atomic.StoreInt64(&rtl.replicationAlwaysUseJointConfig, 1)
-	atomic.StoreInt64(&rtl.replicaAddStopAfterJointConfig, 1)
 	f()
 }
 

--- a/pkg/storage/replica_learner_test.go
+++ b/pkg/storage/replica_learner_test.go
@@ -702,9 +702,9 @@ func TestJointConfigLease(t *testing.T) {
 	exp := `cannot transfer lease to replica of type VOTER_INCOMING`
 	require.True(t, testutils.IsError(err, exp), err)
 
-	// NB: we don't have to transition out of the joint config first because
-	// this is done automatically by ChangeReplicas before it does what it's
-	// asked to do.
+	// NB: we don't have to transition out of the previous joint config first
+	// because this is done automatically by ChangeReplicas before it does what
+	// it's asked to do.
 	desc = tc.RemoveReplicasOrFatal(t, k, tc.Target(1))
 	err = tc.TransferRangeLease(desc, tc.Target(1))
 	exp = `cannot transfer lease to replica of type VOTER_OUTGOING`

--- a/pkg/storage/replica_learner_test.go
+++ b/pkg/storage/replica_learner_test.go
@@ -344,7 +344,7 @@ func TestReplicateQueueSeesLearner(t *testing.T) {
 	require.Len(t, desc.Replicas().Voters(), 3)
 }
 
-func TestGCQueueSeesLearner(t *testing.T) {
+func TestReplicaGCQueueSeesLearner(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 	knobs, ltk := makeLearnerTestKnobs()

--- a/pkg/storage/replica_learner_test.go
+++ b/pkg/storage/replica_learner_test.go
@@ -900,7 +900,7 @@ func TestLearnerAndJointConfigAdminMerge(t *testing.T) {
 	// VOTER_OUTGOING on the lhs or rhs should fail.
 	checkFails()
 
-	// Add a VOTER_INCOMING to desc2 to make sure it actually exludes this type
+	// Add a VOTER_INCOMING to desc2 to make sure it actually excludes this type
 	// of replicas from merges (rather than really just checking whether the
 	// replica sets are equal).
 	// desc{1,2,3} = (VOTER_FULL, VOTER_OUTGOING) (VOTER_FULL, VOTER_INCOMING) (VOTER_FULL, VOTER_OUTGOING)

--- a/pkg/storage/replica_learner_test.go
+++ b/pkg/storage/replica_learner_test.go
@@ -787,7 +787,6 @@ func TestLearnerAndJointConfigFollowerRead(t *testing.T) {
 	check()
 
 	// Removing the voter (and remaining in joint config) does.
-
 	scratchDesc = tc.RemoveReplicasOrFatal(t, scratchStartKey, tc.Target(1))
 	require.True(t, scratchDesc.Replicas().InAtomicReplicationChange(), scratchDesc)
 	require.Len(t, scratchDesc.Replicas().Filter(predOutgoing), 1)

--- a/pkg/storage/replica_learner_test.go
+++ b/pkg/storage/replica_learner_test.go
@@ -873,6 +873,7 @@ func TestLearnerAndJointConfigAdminMerge(t *testing.T) {
 	}
 
 	// LEARNER on the lhs or rhs should fail.
+	// desc{1,2,3} = (VOTER_FULL, LEARNER) (VOTER_FULL) (VOTER_FULL, LEARNER)
 	checkFails()
 
 	// Turn the learners on desc1 and desc3 into VOTER_INCOMINGs.
@@ -886,9 +887,11 @@ func TestLearnerAndJointConfigAdminMerge(t *testing.T) {
 	require.Len(t, desc1.Replicas().Filter(predIncoming), 1)
 
 	// VOTER_INCOMING on the lhs or rhs should fail.
+	// desc{1,2,3} = (VOTER_FULL, VOTER_INCOMING) (VOTER_FULL) (VOTER_FULL, VOTER_INCOMING)
 	checkFails()
 
 	// Turn the incoming voters on desc1 and desc3 into VOTER_OUTGOINGs.
+	// desc{1,2,3} = (VOTER_FULL, VOTER_OUTGOING) (VOTER_FULL) (VOTER_FULL, VOTER_OUTGOING)
 	desc1 = tc.RemoveReplicasOrFatal(t, desc1.StartKey.AsRawKey(), tc.Target(1))
 	require.Len(t, desc1.Replicas().Filter(predOutgoing), 1)
 	desc3 = tc.RemoveReplicasOrFatal(t, desc3.StartKey.AsRawKey(), tc.Target(1))
@@ -900,13 +903,14 @@ func TestLearnerAndJointConfigAdminMerge(t *testing.T) {
 	// Add a VOTER_INCOMING to desc2 to make sure it actually exludes this type
 	// of replicas from merges (rather than really just checking whether the
 	// replica sets are equal).
-
+	// desc{1,2,3} = (VOTER_FULL, VOTER_OUTGOING) (VOTER_FULL, VOTER_INCOMING) (VOTER_FULL, VOTER_OUTGOING)
 	desc2 := tc.AddReplicasOrFatal(t, splitKey1, tc.Target(1))
 	require.Len(t, desc2.Replicas().Filter(predIncoming), 1)
 
 	checkFails()
 
 	// Ditto VOTER_OUTGOING.
+	// desc{1,2,3} = (VOTER_FULL, VOTER_OUTGOING) (VOTER_FULL, VOTER_OUTGOING) (VOTER_FULL, VOTER_OUTGOING)
 	desc2 = tc.RemoveReplicasOrFatal(t, desc2.StartKey.AsRawKey(), tc.Target(1))
 	require.Len(t, desc2.Replicas().Filter(predOutgoing), 1)
 

--- a/pkg/storage/replica_learner_test.go
+++ b/pkg/storage/replica_learner_test.go
@@ -42,6 +42,7 @@ type replicationTestKnobs struct {
 	storeKnobs                       storage.StoreTestingKnobs
 	replicaAddStopAfterLearnerAtomic int64
 	replicaAddStopAfterJointConfig   int64
+	replicationAlwaysUseJointConfig  int64
 }
 
 func makeReplicationTestKnobs() (base.TestingKnobs, *replicationTestKnobs) {
@@ -51,6 +52,9 @@ func makeReplicationTestKnobs() (base.TestingKnobs, *replicationTestKnobs) {
 	}
 	k.storeKnobs.ReplicaAddStopAfterJointConfig = func() bool {
 		return atomic.LoadInt64(&k.replicaAddStopAfterJointConfig) > 0
+	}
+	k.storeKnobs.ReplicationAlwaysUseJointConfig = func() bool {
+		return atomic.LoadInt64(&k.replicationAlwaysUseJointConfig) > 0
 	}
 	return base.TestingKnobs{Store: &k.storeKnobs}, &k
 }

--- a/pkg/storage/replica_learner_test.go
+++ b/pkg/storage/replica_learner_test.go
@@ -973,9 +973,10 @@ func TestMergeQueueSeesLearnerOrJointConfig(t *testing.T) {
 		require.Empty(t, desc.Replicas().Learners())
 	}
 
+	// Create the RHS again and repeat the same game, except this time the LHS
+	// gets a VOTER_INCOMING for s2, and then the merge queue runs into it. It
+	// will transition the LHS out of the joint config and then do the merge.
 	{
-		// Create the RHS again and repeat the same game, except this time the LHS
-		// gets a VOTER_INCOMING for s2.
 		desc := splitAndUnsplit()
 
 		ltk.withJointConfigAndStop(func() {
@@ -1002,6 +1003,7 @@ func TestMergeQueueSeesLearnerOrJointConfig(t *testing.T) {
 		checkTransitioningOut()
 		desc = tc.LookupRangeOrFatal(t, scratchStartKey)
 		require.Len(t, desc.Replicas().Voters(), 2)
+		require.False(t, desc.Replicas().InAtomicReplicationChange(), desc)
 
 		// Repeat the game, except now we start with two replicas and we're
 		// giving the RHS a VOTER_OUTGOING.

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -348,6 +348,8 @@ func (rq *replicateQueue) processOneChange(
 		return rq.considerRebalance(ctx, repl, voterReplicas, canTransferLease, dryRun)
 	case AllocatorFinalizeAtomicReplicationChange:
 		_, err := maybeLeaveAtomicChangeReplicas(ctx, repl.store, repl.Desc())
+		// Requeue because either we failed to transition out of a joint state
+		// (bad) or we did and there might be more to do for that range.
 		return true, err
 	}
 	return true, nil

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -348,7 +348,7 @@ func (rq *replicateQueue) processOneChange(
 		return rq.considerRebalance(ctx, repl, voterReplicas, canTransferLease, dryRun)
 	case AllocatorFinalizeAtomicReplicationChange:
 		_, err := maybeLeaveAtomicChangeReplicas(ctx, repl.store, repl.Desc())
-		return false, err
+		return true, err
 	}
 	return true, nil
 }

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -347,7 +347,7 @@ func (rq *replicateQueue) processOneChange(
 	case AllocatorConsiderRebalance:
 		return rq.considerRebalance(ctx, repl, voterReplicas, canTransferLease, dryRun)
 	case AllocatorFinalizeAtomicReplicationChange:
-		_, err := repl.maybeLeaveAtomicChangeReplicas(ctx, repl.Desc())
+		_, err := maybeLeaveAtomicChangeReplicas(ctx, repl.store, repl.Desc())
 		return false, err
 	}
 	return true, nil

--- a/pkg/storage/testing_knobs.go
+++ b/pkg/storage/testing_knobs.go
@@ -203,7 +203,8 @@ type StoreTestingKnobs struct {
 	// configuration.
 	ReplicaAddStopAfterJointConfig func() bool
 	// ReplicationAlwaysUseJointConfig causes replica addition to always go
-	// through a joint configuration, even when this isn't necessary.
+	// through a joint configuration, even when this isn't necessary (because
+	// the replication change affects only one replica).
 	ReplicationAlwaysUseJointConfig func() bool
 	// BeforeSnapshotSSTIngestion is run just before the SSTs are ingested when
 	// applying a snapshot.

--- a/pkg/storage/testing_knobs.go
+++ b/pkg/storage/testing_knobs.go
@@ -198,6 +198,10 @@ type StoreTestingKnobs struct {
 	// This ensures the `*Replica` will be materialized on the Store when it
 	// returns.
 	ReplicaAddStopAfterLearnerSnapshot func() bool
+	// ReplicaAddStopAfterJointConfig causes replica addition to return early if
+	// the func returns true. This happens before transitioning out of a joint
+	// configuration.
+	ReplicaAddStopAfterJointConfig func() bool
 	// BeforeSnapshotSSTIngestion is run just before the SSTs are ingested when
 	// applying a snapshot.
 	BeforeSnapshotSSTIngestion func(IncomingSnapshot, SnapshotRequest_Type, []string) error

--- a/pkg/storage/testing_knobs.go
+++ b/pkg/storage/testing_knobs.go
@@ -202,6 +202,9 @@ type StoreTestingKnobs struct {
 	// the func returns true. This happens before transitioning out of a joint
 	// configuration.
 	ReplicaAddStopAfterJointConfig func() bool
+	// ReplicationAlwaysUseJointConfig causes replica addition to always go
+	// through a joint configuration, even when this isn't necessary.
+	ReplicationAlwaysUseJointConfig func() bool
 	// BeforeSnapshotSSTIngestion is run just before the SSTs are ingested when
 	// applying a snapshot.
 	BeforeSnapshotSSTIngestion func(IncomingSnapshot, SnapshotRequest_Type, []string) error

--- a/pkg/storage/testing_knobs.go
+++ b/pkg/storage/testing_knobs.go
@@ -200,7 +200,10 @@ type StoreTestingKnobs struct {
 	ReplicaAddStopAfterLearnerSnapshot func() bool
 	// ReplicaAddStopAfterJointConfig causes replica addition to return early if
 	// the func returns true. This happens before transitioning out of a joint
-	// configuration.
+	// configuration, after the joint configuration has been entered by means
+	// of a first ChangeReplicas transaction. If the replication change does
+	// not use joint consensus, this early return is identical to the regular
+	// return path.
 	ReplicaAddStopAfterJointConfig func() bool
 	// ReplicationAlwaysUseJointConfig causes replica addition to always go
 	// through a joint configuration, even when this isn't necessary (because

--- a/pkg/testutils/serverutils/test_cluster_shim.go
+++ b/pkg/testutils/serverutils/test_cluster_shim.go
@@ -68,6 +68,12 @@ type TestClusterInterface interface {
 		startKey roachpb.Key, targets ...roachpb.ReplicationTarget,
 	) (roachpb.RangeDescriptor, error)
 
+	// RemoveReplicasOrFatal is the same as RemoveReplicas but will Fatal the test on
+	// error.
+	RemoveReplicasOrFatal(
+		t testing.TB, startKey roachpb.Key, targets ...roachpb.ReplicationTarget,
+	) roachpb.RangeDescriptor
+
 	// FindRangeLeaseHolder returns the current lease holder for the given range.
 	// In particular, it returns one particular node's (the hint, if specified) view
 	// of the current lease.

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -506,6 +506,7 @@ func (tc *TestCluster) RemoveReplicas(
 	return tc.changeReplicas(roachpb.REMOVE_REPLICA, keys.MustAddr(startKey), targets...)
 }
 
+// RemoveReplicasOrFatal is part of TestClusterInterface.
 func (tc *TestCluster) RemoveReplicasOrFatal(
 	t testing.TB, startKey roachpb.Key, targets ...roachpb.ReplicationTarget,
 ) roachpb.RangeDescriptor {

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -506,6 +506,18 @@ func (tc *TestCluster) RemoveReplicas(
 	return tc.changeReplicas(roachpb.REMOVE_REPLICA, keys.MustAddr(startKey), targets...)
 }
 
+func (tc *TestCluster) RemoveReplicasOrFatal(
+	t testing.TB, startKey roachpb.Key, targets ...roachpb.ReplicationTarget,
+) roachpb.RangeDescriptor {
+	t.Helper()
+	desc, err := tc.RemoveReplicas(startKey, targets...)
+	if err != nil {
+		t.Fatalf(`could not remove %v replicas from range containing %s: %+v`,
+			targets, startKey, err)
+	}
+	return desc
+}
+
 // TransferRangeLease is part of the TestServerInterface.
 func (tc *TestCluster) TransferRangeLease(
 	rangeDesc roachpb.RangeDescriptor, dest roachpb.ReplicationTarget,


### PR DESCRIPTION
This PR adds a number of tests that focus on the interaction between the various
queues and joint configurations.

We don't flip the switch yet since adding/removing only learners does not work
yet via the joint path. This isn't something we need per se, but it's an
annoying restriction to keep in mind and work around if it does happen. Tracked
in
https://github.com/cockroachdb/cockroach/issues/12768#issuecomment-522591757.