### PR TITLE
util/log: do not rely on a late-initialized global var in Shout()

### DIFF
--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -918,7 +918,7 @@ func (l *loggingT) outputLogEntry(s Severity, file string, line int, msg string)
 		}
 	}
 
-	if s >= l.stderrThreshold.get() || (s == Severity_FATAL && stderrRedirected) {
+	if s >= l.stderrThreshold.get() || (s == Severity_FATAL && stderrRedirected()) {
 		// We force-copy FATAL messages to stderr, because the process is bound
 		// to terminate and the user will want to know why.
 		l.outputToStderr(entry, stacks)
@@ -1116,7 +1116,7 @@ func (sb *syncBuffer) rotateFile(now time.Time) error {
 	// stack traces that are written by the Go runtime to stderr. Note that if
 	// --logtostderr is true we'll never enter this code path and panic stack
 	// traces will go to the original stderr as you would expect.
-	if logging.stderrThreshold > Severity_INFO && !logging.noStderrRedirect {
+	if stderrRedirected() {
 		// NB: any concurrent output to stderr may straddle the old and new
 		// files. This doesn't apply to log messages as we won't reach this code
 		// unless we're not logging to stderr.

--- a/pkg/util/log/crash_reporting.go
+++ b/pkg/util/log/crash_reporting.go
@@ -206,7 +206,7 @@ func (st SafeType) WithCause(cause interface{}) SafeType {
 func ReportPanic(ctx context.Context, sv *settings.Values, r interface{}, depth int) {
 	Shout(ctx, Severity_ERROR, "a panic has occurred!")
 
-	if stderrRedirected {
+	if stderrRedirected() {
 		// We do not use Shout() to print the panic details here, because
 		// if stderr is not redirected (e.g. when logging to file is
 		// disabled) Shout() would copy its argument to stderr

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -80,7 +80,7 @@ func Shout(ctx context.Context, sev Severity, args ...interface{}) {
 		})
 		defer t.Stop()
 	}
-	if stderrRedirected {
+	if stderrRedirected() {
 		fmt.Fprintf(OrigStderr, "*\n* %s: %s\n*\n", sev.String(),
 			strings.Replace(MakeMessage(ctx, "", args), "\n", "\n* ", -1))
 	}

--- a/pkg/util/log/stderr_redirect.go
+++ b/pkg/util/log/stderr_redirect.go
@@ -22,21 +22,22 @@ var OrigStderr = func() *os.File {
 	return os.NewFile(fd, os.Stderr.Name())
 }()
 
-// stderrRedirected attempts to track whether stderr was redirected.
-// This is used to de-duplicate the panic log.
-var stderrRedirected bool
+// stderrRedirected returns true if and only if logging captures
+// stderr output to the log file. This is used e.g. by Shout() to
+// determine whether to report to standard error in addition to logs.
+func stderrRedirected() bool {
+	return logging.stderrThreshold > Severity_INFO && !logging.noStderrRedirect
+}
 
 // hijackStderr replaces stderr with the given file descriptor.
 //
 // A client that wishes to use the original stderr must use
 // OrigStderr defined above.
 func hijackStderr(f *os.File) error {
-	stderrRedirected = true
 	return redirectStderr(f)
 }
 
 // restoreStderr cancels the effect of hijackStderr().
 func restoreStderr() error {
-	stderrRedirected = false
 	return redirectStderr(OrigStderr)
 }

--- a/pkg/util/log/testshout/shout_test.go
+++ b/pkg/util/log/testshout/shout_test.go
@@ -1,0 +1,47 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package testshout
+
+import (
+	"context"
+	"flag"
+	"os"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logflags"
+)
+
+// Example_shout_before_log verifies that Shout output emitted after
+// the log flags were set, but before the first log message was
+// output, properly appears on stderr.
+//
+// This test needs to occur in its own test package where there is no
+// other activity on the log flags, and no other log activity,
+// otherwise the test's behavior will break on `make stress`.
+func Example_shout_before_log() {
+	origStderr := log.OrigStderr
+	log.OrigStderr = os.Stdout
+	defer func() { log.OrigStderr = origStderr }()
+
+	if err := flag.Set(logflags.LogToStderrName, "WARNING"); err != nil {
+		panic(err)
+	}
+	if err := flag.Set(logflags.NoRedirectStderrName, "false"); err != nil {
+		panic(err)
+	}
+
+	log.Shout(context.Background(), log.Severity_INFO, "hello world")
+
+	// output:
+	// *
+	// * INFO: hello world
+	// *
+}


### PR DESCRIPTION
Fixes #33458.

Prior to this patch, `log.Shout()` would not behave properly if called
before the first regular logging operation, because it relied on a
global boolean (`stderrRedirect`) initialized lazily.

This patch fixes the behavior by making `log.Shout()` use the same
predicate used to initialize said boolean. Given the predicate can be
evaluated early, this gives the correct behavior.

Release note: None