### PR TITLE
opt: allow arbitrary expression in aggregate ORDER BY

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/aggregate-opt
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate-opt
@@ -23,6 +23,12 @@ array_agg
 {-3,-2,-1,0,1,2}
 
 query T colnames
+SELECT array_agg(col1 ORDER BY col2*100+col1) FROM tab
+----
+array_agg
+{-1,1,-2,2,-3,0}
+
+query T colnames
 SELECT json_agg(col1 ORDER BY col1) FROM tab
 ----
 json_agg

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -512,6 +512,13 @@ func (b *Builder) buildAggregateFunction(
 		info.filter = b.buildAggArg(f.Filter.(tree.TypedExpr), &info, tempScope, inScope)
 	}
 
+	// If we have ORDER BY, add the ordering columns to the tempScope.
+	if f.OrderBy != nil {
+		for _, o := range f.OrderBy {
+			b.buildAggArg(o.Expr.(tree.TypedExpr), &info, tempScope, inScope)
+		}
+	}
+
 	// Find the appropriate aggregation scopes for this aggregate now that we
 	// know which columns it references. If necessary, we'll move the columns
 	// for the arguments from tempScope to aggInScope below.

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -3123,7 +3123,7 @@ SELECT count(col1 ORDER BY col2) FROM tab
 scalar-group-by
  ├── columns: count:5(int)
  ├── project
- │    ├── columns: col1:1(int!null)
+ │    ├── columns: col1:1(int!null) col2:2(int!null)
  │    └── scan tab
  │         └── columns: col1:1(int!null) col2:2(int!null) col3:3(string) rowid:4(int!null)
  └── aggregations
@@ -3402,6 +3402,74 @@ project
       └── aggregations
            └── array-agg [type=string[]]
                 └── variable: column5 [type=string]
+
+build
+SELECT array_agg(v+w ORDER BY w) FROM kv
+----
+scalar-group-by
+ ├── columns: array_agg:6(int[])
+ ├── window partition=() ordering=+3
+ │    ├── columns: k:1(int!null) v:2(int) w:3(int) s:4(string) column5:5(int) array_agg:6(int[])
+ │    ├── project
+ │    │    ├── columns: column5:5(int) k:1(int!null) v:2(int) w:3(int) s:4(string)
+ │    │    ├── scan kv
+ │    │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ │    │    └── projections
+ │    │         └── plus [type=int]
+ │    │              ├── variable: v [type=int]
+ │    │              └── variable: w [type=int]
+ │    └── windows
+ │         └── windows-item: range from unbounded to unbounded [type=int[]]
+ │              └── array-agg [type=int[]]
+ │                   └── variable: column5 [type=int]
+ └── aggregations
+      └── const-agg [type=int[]]
+           └── variable: array_agg [type=int[]]
+
+build
+SELECT array_agg(v ORDER BY v+w) FROM kv
+----
+scalar-group-by
+ ├── columns: array_agg:6(int[])
+ ├── window partition=() ordering=+5
+ │    ├── columns: k:1(int!null) v:2(int) w:3(int) s:4(string) column5:5(int) array_agg:6(int[])
+ │    ├── project
+ │    │    ├── columns: column5:5(int) k:1(int!null) v:2(int) w:3(int) s:4(string)
+ │    │    ├── scan kv
+ │    │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ │    │    └── projections
+ │    │         └── plus [type=int]
+ │    │              ├── variable: v [type=int]
+ │    │              └── variable: w [type=int]
+ │    └── windows
+ │         └── windows-item: range from unbounded to unbounded [type=int[]]
+ │              └── array-agg [type=int[]]
+ │                   └── variable: v [type=int]
+ └── aggregations
+      └── const-agg [type=int[]]
+           └── variable: array_agg [type=int[]]
+
+build
+SELECT array_agg(a ORDER BY b) FROM (SELECT 1 AS a, 2 AS b)
+----
+scalar-group-by
+ ├── columns: array_agg:3(int[])
+ ├── window partition=() ordering=+2
+ │    ├── columns: a:1(int!null) b:2(int!null) array_agg:3(int[])
+ │    ├── project
+ │    │    ├── columns: a:1(int!null) b:2(int!null)
+ │    │    ├── values
+ │    │    │    └── tuple [type=tuple]
+ │    │    └── projections
+ │    │         ├── const: 1 [type=int]
+ │    │         └── const: 2 [type=int]
+ │    └── windows
+ │         └── windows-item: range from unbounded to unbounded [type=int[]]
+ │              └── array-agg [type=int[]]
+ │                   └── variable: a [type=int]
+ └── aggregations
+      └── const-agg [type=int[]]
+           └── variable: array_agg [type=int[]]
 
 # Regression test for #38551.
 build

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -916,6 +916,16 @@ func (expr *FuncExpr) TypeCheck(ctx *SemaContext, desired *types.T) (TypedExpr, 
 		expr.Filter = typedFilter
 	}
 
+	if expr.OrderBy != nil {
+		for i := range expr.OrderBy {
+			typedExpr, err := expr.OrderBy[i].Expr.TypeCheck(ctx, types.Any)
+			if err != nil {
+				return nil, err
+			}
+			expr.OrderBy[i].Expr = typedExpr
+		}
+	}
+
 	for i, subExpr := range typedSubExprs {
 		expr.Exprs[i] = subExpr
 	}

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -312,6 +312,16 @@ func (expr *FuncExpr) Walk(v Visitor) Expr {
 			ret.Filter = e
 		}
 	}
+
+	if expr.OrderBy != nil {
+		order, changed := walkOrderBy(v, expr.OrderBy)
+		if changed {
+			if ret == expr {
+				ret = expr.copyNode()
+			}
+			ret.OrderBy = order
+		}
+	}
 	return ret
 }
 


### PR DESCRIPTION
The ORDER BY inside aggregations works only when the ordering columns
are simple column references (and even that doesn't work in all
cases). This change adds the missing pieces to allow arbitrary
expressions:
 - build the expressions into the pre-aggregation scope
 - walk and type-check the OrderBy arguments.

Fixes #38621.

Release note (bug fix): ORDER BY inside aggregation functions are now
fully supported.