### PR TITLE
bulk: split-and-scatter when SSTBatcher 'fills' range

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1083,14 +1083,6 @@ func TestImportCSVStmt(t *testing.T) {
 				}
 			}
 
-			// Verify spans don't have trailing '/0'.
-			ranges := sqlDB.QueryStr(t, `SHOW ranges FROM TABLE t`)
-			for _, r := range ranges {
-				const end = `/0`
-				if strings.HasSuffix(r[0], end) || strings.HasSuffix(r[1], end) {
-					t.Errorf("bad span: %s - %s", r[0], r[1])
-				}
-			}
 		})
 	}
 
@@ -1483,15 +1475,6 @@ func TestImportIntoCSV(t *testing.T) {
 			}
 			if result != expectedNulls {
 				t.Fatalf("expected %d rows, got %d", expectedNulls, result)
-			}
-
-			// Verify spans don't have trailing '/0'.
-			ranges := sqlDB.QueryStr(t, `SHOW ranges FROM TABLE t`)
-			for _, r := range ranges {
-				const end = `/0`
-				if strings.HasSuffix(r[0], end) || strings.HasSuffix(r[1], end) {
-					t.Errorf("bad span: %s - %s", r[0], r[1])
-				}
 			}
 		})
 	}

--- a/pkg/ccl/importccl/sst_writer_proc.go
+++ b/pkg/ccl/importccl/sst_writer_proc.go
@@ -221,7 +221,7 @@ func (sp *sstWriter) Run(ctx context.Context) {
 					// can never be any shadow keys, and this check could be turned off.
 					// Plumb a user option to toggle this if the overhead without
 					// colliding keys becomes more significant.
-					if err := bulk.AddSSTable(ctx, sp.db, sst.span.Key, sst.span.EndKey, sst.data, true /* disallowShadowing */, enginepb.MVCCStats{} /* ms */); err != nil {
+					if _, err := bulk.AddSSTable(ctx, sp.db, sst.span.Key, sst.span.EndKey, sst.data, true /* disallowShadowing */, enginepb.MVCCStats{} /* ms */); err != nil {
 						return err
 					}
 

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -192,7 +192,7 @@ func evalImport(ctx context.Context, cArgs batcheval.CommandArgs) (*roachpb.Impo
 		iters = append(iters, iter)
 	}
 
-	batcher, err := bulk.MakeSSTBatcher(ctx, db, MaxImportBatchSize(cArgs.EvalCtx.ClusterSettings()))
+	batcher, err := bulk.MakeSSTBatcher(ctx, db, uint64(MaxImportBatchSize(cArgs.EvalCtx.ClusterSettings())))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/workloadccl/format/sstable.go
+++ b/pkg/ccl/workloadccl/format/sstable.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/importccl"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -111,5 +112,11 @@ func (s *addSSTableSender) AddSSTable(
 	_ context.Context, _, _ interface{}, data []byte, _ bool, _ *enginepb.MVCCStats,
 ) error {
 	*s = append(*s, data)
+	return nil
+}
+
+func (s *addSSTableSender) SplitAndScatter(
+	_ context.Context, _ roachpb.Key, _ hlc.Timestamp,
+) error {
 	return nil
 }

--- a/pkg/storage/bulk/buffering_adder.go
+++ b/pkg/storage/bulk/buffering_adder.go
@@ -129,12 +129,13 @@ func (b *BufferingAdder) SetOnFlush(fn func()) {
 // Close closes the underlying SST builder.
 func (b *BufferingAdder) Close(ctx context.Context) {
 	log.VEventf(ctx, 2,
-		"bulk adder %s ingested %s, flushed %d times, %d due to buffer size. Flushed %d files, %d due to ranges, %d due to sst size. Used %d bytes.",
+		"bulk adder %s ingested %s, flushed %d due to buffer (%s) size. Flushed chunked as %d files (%d after split-retries), %d due to ranges, %d due to sst size.",
 		b.name,
 		sz(b.sink.totalRows.DataSize),
-		b.flushCounts.total, b.flushCounts.bufferSize,
-		b.sink.flushCounts.total, b.sink.flushCounts.split, b.sink.flushCounts.sstSize,
-		b.memAcc.Used(),
+		b.flushCounts.bufferSize,
+		sz(b.memAcc.Used()),
+		b.sink.flushCounts.total, b.sink.flushCounts.files,
+		b.sink.flushCounts.split, b.sink.flushCounts.sstSize,
 	)
 	b.sink.Close()
 

--- a/pkg/storage/bulk/buffering_adder.go
+++ b/pkg/storage/bulk/buffering_adder.go
@@ -84,15 +84,21 @@ func MakeBulkAdder(
 	if opts.SSTSize == 0 {
 		opts.SSTSize = 16 << 20
 	}
+	if opts.SplitAndScatterAfter == 0 {
+		// splitting _before_ hitting max reduces chance of auto-splitting after the
+		// range is full and is more expensive to split/move.
+		opts.SplitAndScatterAfter = 48 << 20
+	}
 
 	b := &BufferingAdder{
 		name: opts.Name,
 		sink: SSTBatcher{
 			db:                db,
-			maxSize:           int64(opts.SSTSize),
+			maxSize:           opts.SSTSize,
 			rc:                rangeCache,
 			skipDuplicates:    opts.SkipDuplicates,
 			disallowShadowing: opts.DisallowShadowing,
+			splitAfter:        opts.SplitAndScatterAfter,
 		},
 		timestamp:           timestamp,
 		curBufferSize:       opts.MinBufferSize,

--- a/pkg/storage/bulk/sst_batcher.go
+++ b/pkg/storage/bulk/sst_batcher.go
@@ -13,6 +13,7 @@ package bulk
 import (
 	"bytes"
 	"context"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -20,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -39,9 +41,10 @@ func (b sz) String() string {
 // it to attempt to flush SSTs before they cross range boundaries to minimize
 // expensive on-split retries.
 type SSTBatcher struct {
-	db      sender
-	rc      *kv.RangeDescriptorCache
-	maxSize int64
+	db         sender
+	rc         *kv.RangeDescriptorCache
+	maxSize    uint64
+	splitAfter uint64
 
 	// allows ingestion of keys where the MVCC.Key would shadow an existing row.
 	disallowShadowing bool
@@ -67,8 +70,11 @@ type SSTBatcher struct {
 		sstSize int
 		files   int // a single flush might create multiple files.
 	}
+	// Tracking for if we have "filled" a range in case we want to split/scatter.
+	flushedToCurrentRange uint64
+	lastFlushKey          []byte
 
-	// Thee rest of the fields are per-batch and are reset via Reset() before each
+	// The rest of the fields are per-batch and are reset via Reset() before each
 	// batch is started.
 	sstWriter       SSTWriter
 	batchStartKey   []byte
@@ -83,7 +89,7 @@ type SSTBatcher struct {
 }
 
 // MakeSSTBatcher makes a ready-to-use SSTBatcher.
-func MakeSSTBatcher(ctx context.Context, db sender, flushBytes int64) (*SSTBatcher, error) {
+func MakeSSTBatcher(ctx context.Context, db sender, flushBytes uint64) (*SSTBatcher, error) {
 	b := &SSTBatcher{db: db, maxSize: flushBytes}
 	err := b.Reset()
 	return b, err
@@ -194,14 +200,14 @@ func (b *SSTBatcher) flushIfNeeded(ctx context.Context, nextKey roachpb.Key) err
 	}
 
 	if b.flushKey != nil && b.flushKey.Compare(nextKey) <= 0 {
-		if err := b.doFlush(ctx, rangeFlush); err != nil {
+		if err := b.doFlush(ctx, rangeFlush, nil); err != nil {
 			return err
 		}
 		return b.Reset()
 	}
 
 	if b.sstWriter.DataSize >= b.maxSize {
-		if err := b.doFlush(ctx, sizeFlush); err != nil {
+		if err := b.doFlush(ctx, sizeFlush, nextKey); err != nil {
 			return err
 		}
 		return b.Reset()
@@ -211,25 +217,41 @@ func (b *SSTBatcher) flushIfNeeded(ctx context.Context, nextKey roachpb.Key) err
 
 // Flush sends the current batch, if any.
 func (b *SSTBatcher) Flush(ctx context.Context) error {
-	return b.doFlush(ctx, manualFlush)
+	return b.doFlush(ctx, manualFlush, nil)
 }
 
-func (b *SSTBatcher) doFlush(ctx context.Context, reason int) error {
+func (b *SSTBatcher) doFlush(ctx context.Context, reason int, nextKey roachpb.Key) error {
 	if b.sstWriter.DataSize == 0 {
 		return nil
 	}
 	b.flushCounts.total++
+
+	hour := hlc.Timestamp{WallTime: timeutil.Now().Add(time.Hour).UnixNano()}
 
 	start := roachpb.Key(append([]byte(nil), b.batchStartKey...))
 	// The end key of the WriteBatch request is exclusive, but batchEndKey is
 	// currently the largest key in the batch. Increment it.
 	end := roachpb.Key(append([]byte(nil), b.batchEndKey...)).Next()
 
-
 	size := b.sstWriter.DataSize
 	if reason == sizeFlush {
 		log.VEventf(ctx, 3, "flushing %s SST due to size > %s", sz(size), sz(b.maxSize))
 		b.flushCounts.sstSize++
+
+		// On first flush, if it is due to size, we introduce one split at the start
+		// of our span, since size means we didn't already hit one. When adders have
+		// non-overlapping keyspace this split partitions off "our" target space for
+		// future splitting/scattering, while if they don't, doing this only once
+		// minimizes impact on other adders (e.g. causing extra SST splitting).
+		if b.flushCounts.total == 1 {
+			if splitAt, err := keys.EnsureSafeSplitKey(start); err != nil {
+				log.Warning(ctx, err)
+			} else {
+				if err := b.db.SplitAndScatter(ctx, splitAt, hour); err != nil {
+					log.Warning(ctx, err)
+				}
+			}
+		}
 	} else if reason == rangeFlush {
 		log.VEventf(ctx, 3, "flushing %s SST due to range boundary %s", sz(size), b.flushKey)
 		b.flushCounts.split++
@@ -245,13 +267,38 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int) error {
 	if (b.ms != enginepb.MVCCStats{}) {
 		b.ms.LastUpdateNanos = timeutil.Now().UnixNano()
 	}
-	if files, err := AddSSTable(ctx, b.db, start, end, sstBytes, b.disallowShadowing, b.ms); err != nil {
+	files, err := AddSSTable(ctx, b.db, start, end, sstBytes, b.disallowShadowing, b.ms)
+	if err != nil {
 		return err
-	} else {
-		b.flushCounts.files += files
 	}
+
+	b.flushCounts.files += files
+	if b.flushKey != nil {
+		// If the flush-before key hasn't changed we know we don't think we passed
+		// a range boundary, and if the files-added count is 1 we didn't hit an
+		// unexpected split either, so assume we added to the same range.
+		if reason == sizeFlush && bytes.Equal(b.flushKey, b.lastFlushKey) && files == 1 {
+			b.flushedToCurrentRange += size
+		} else {
+			// Assume we started adding to new different range with this SST.
+			b.lastFlushKey = append(b.lastFlushKey[:0], b.flushKey...)
+			b.flushedToCurrentRange = size
+		}
+		if b.splitAfter > 0 && b.flushedToCurrentRange > b.splitAfter && nextKey != nil {
+			if splitAt, err := keys.EnsureSafeSplitKey(nextKey); err != nil {
+				log.Warning(ctx, err)
+			} else {
+				log.VEventf(ctx, 2, "%s added since last split, splitting/scattering for next range at %v", sz(b.flushedToCurrentRange), end)
+				if err := b.db.SplitAndScatter(ctx, splitAt, hour); err != nil {
+					log.Warningf(ctx, "failed to split and scatter during ingest: %+v", err)
+				}
+			}
+			b.flushedToCurrentRange = 0
+		}
+	}
+
 	b.totalRows.Add(b.rowCounter.BulkOpSummary)
-	b.totalRows.DataSize += b.sstWriter.DataSize
+	b.totalRows.DataSize += int64(b.sstWriter.DataSize)
 	return nil
 }
 
@@ -269,6 +316,7 @@ type sender interface {
 	AddSSTable(
 		ctx context.Context, begin, end interface{}, data []byte, disallowShadowing bool, stats *enginepb.MVCCStats,
 	) error
+	SplitAndScatter(ctx context.Context, key roachpb.Key, expirationTime hlc.Timestamp) error
 }
 
 type sstSpan struct {

--- a/pkg/storage/bulk/sst_batcher_test.go
+++ b/pkg/storage/bulk/sst_batcher_test.go
@@ -278,7 +278,7 @@ func TestAddBigSpanningSSTWithSplits(t *testing.T) {
 	const kb = 1 << 10
 
 	t.Logf("Adding %dkb sst spanning %d splits from %v to %v", len(sst)/kb, len(splits), start, end)
-	if err := bulk.AddSSTable(
+	if _, err := bulk.AddSSTable(
 		context.TODO(), mock, start, end, sst, false /* disallowShadowing */, enginepb.MVCCStats{},
 	); err != nil {
 		t.Fatal(err)

--- a/pkg/storage/bulk/sst_batcher_test.go
+++ b/pkg/storage/bulk/sst_batcher_test.go
@@ -223,6 +223,10 @@ func (m mockSender) AddSSTable(
 	return m(roachpb.Span{Key: begin.(roachpb.Key), EndKey: end.(roachpb.Key)})
 }
 
+func (m mockSender) SplitAndScatter(ctx context.Context, _ roachpb.Key, _ hlc.Timestamp) error {
+	return nil
+}
+
 // TestAddBigSpanningSSTWithSplits tests a situation where a large
 // spanning SST is being ingested over a span with a lot of splits.
 func TestAddBigSpanningSSTWithSplits(t *testing.T) {

--- a/pkg/storage/bulk/sst_writer.go
+++ b/pkg/storage/bulk/sst_writer.go
@@ -26,7 +26,7 @@ type SSTWriter struct {
 	fw *sstable.Writer
 	f  *memFile
 	// DataSize tracks the total key and value bytes added so far.
-	DataSize int64
+	DataSize uint64
 	scratch  []byte
 }
 
@@ -152,7 +152,7 @@ func (fw *SSTWriter) Add(kv engine.MVCCKeyValue) error {
 	if fw.fw == nil {
 		return errors.New("cannot call Open on a closed writer")
 	}
-	fw.DataSize += int64(len(kv.Key.Key)) + int64(len(kv.Value))
+	fw.DataSize += uint64(len(kv.Key.Key)) + uint64(len(kv.Value))
 	fw.scratch = engine.EncodeKeyToBuf(fw.scratch[:0], kv.Key)
 	return fw.fw.Set(fw.scratch, kv.Value)
 }

--- a/pkg/storage/storagebase/bulk_adder.go
+++ b/pkg/storage/storagebase/bulk_adder.go
@@ -30,6 +30,10 @@ type BulkAdderOptions struct {
 	// they may be smaller than this limit.
 	SSTSize uint64
 
+	// SplitAndScatterAfter is the number of bytes which if added without hitting
+	// an existing split will cause the adder to split and scatter the next span.
+	SplitAndScatterAfter uint64
+
 	// MinBufferSize is the initial size of the BulkAdder buffer. It indicates the
 	// amount of memory we require to be able to buffer data before flushing for
 	// SST creation.


### PR DESCRIPTION
By keeping track of how many bytes have added to range we just added to, we can decide to split and scatter a new range when we decide we have 'filled' the one to which we've been adding.
When we do so, we split at the end of what we just added and scatter the next range, i.e. not what we just imported (sicne scattering a full range is expensive) but rather what we can assume we're about to ingest into -- since given that we just ingested multiple SSTs without hitting a split, it seems likely we will keep doing so.

With this change backup2tb's 620GB IMPORT of the bank table shows even growth in ranges across nodes and even leaseholders-per-stores, and runs in 59m8s or 179.48 MiB/s. That appears to be a large improvement over the most recent run on master where it took 1h49m24s / 97.02 MiB/s (some master runs have also been crashing when a node ran out of space).

Release note: none.