### PR TITLE
exec: reset the columnarizer's internal batch

### DIFF
--- a/pkg/sql/distsqlrun/columnarizer.go
+++ b/pkg/sql/distsqlrun/columnarizer.go
@@ -81,6 +81,7 @@ func (c *columnarizer) Init() {
 }
 
 func (c *columnarizer) Next(context.Context) coldata.Batch {
+	c.batch.ResetInternalBatch()
 	// Buffer up n rows.
 	nRows := uint16(0)
 	columnTypes := c.OutputTypes()

--- a/pkg/sql/distsqlrun/columnarizer_test.go
+++ b/pkg/sql/distsqlrun/columnarizer_test.go
@@ -15,11 +15,53 @@ import (
 	"testing"
 	"unsafe"
 
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
 )
+
+func TestColumnarizerResetsInternalBatch(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	typs := []types.T{*types.Int}
+	// There will be at least two batches of rows so that we can see whether the
+	// internal batch is reset.
+	nRows := coldata.BatchSize * 2
+	nCols := len(typs)
+	rows := sqlbase.MakeIntRows(nRows, nCols)
+	input := NewRepeatableRowSource(typs, rows)
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+	flowCtx := &FlowCtx{
+		Cfg:     &ServerConfig{Settings: st},
+		EvalCtx: &evalCtx,
+	}
+
+	c, err := newColumnarizer(ctx, flowCtx, 0, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Init()
+	foundRows := 0
+	for {
+		batch := c.Next(ctx)
+		require.Nil(t, batch.Selection(), "columnarizer didn't reset the internal batch")
+		if batch.Length() == 0 {
+			break
+		}
+		foundRows += int(batch.Length())
+		// The "meat" of the test - we're updating the batch that the columnarizer
+		// owns.
+		batch.SetSelection(true)
+	}
+	require.Equal(t, nRows, foundRows)
+}
 
 func BenchmarkColumnarize(b *testing.B) {
 	types := []types.T{*types.Int, *types.Int}

--- a/pkg/sql/exec/aggregator.go
+++ b/pkg/sql/exec/aggregator.go
@@ -254,7 +254,7 @@ func (a *orderedAggregator) Init() {
 }
 
 func (a *orderedAggregator) Next(ctx context.Context) coldata.Batch {
-	a.scratch.SetSelection(false)
+	a.scratch.ResetInternalBatch()
 	if a.done {
 		a.scratch.SetLength(0)
 		return a.scratch

--- a/pkg/sql/exec/coalescer.go
+++ b/pkg/sql/exec/coalescer.go
@@ -18,7 +18,7 @@ import (
 )
 
 // coalescerOp consumes the input operator and coalesces the resulting batches
-// to return full batches of col.BatchSize.
+// to return full batches of coldata.BatchSize.
 type coalescerOp struct {
 	OneInputNode
 
@@ -50,6 +50,8 @@ func (p *coalescerOp) Init() {
 }
 
 func (p *coalescerOp) Next(ctx context.Context) coldata.Batch {
+	p.group.ResetInternalBatch()
+	p.buffer.ResetInternalBatch()
 	tempBatch := p.group
 	p.group = p.buffer
 

--- a/pkg/sql/exec/coalescer_test.go
+++ b/pkg/sql/exec/coalescer_test.go
@@ -64,7 +64,7 @@ func TestCoalescer(t *testing.T) {
 func BenchmarkCoalescer(b *testing.B) {
 	ctx := context.Background()
 	// The input operator to the coalescer returns a batch of random size from [1,
-	// col.BatchSize) each time.
+	// coldata.BatchSize) each time.
 	nCols := 4
 	sourceTypes := make([]coltypes.T, nCols)
 

--- a/pkg/sql/exec/colrpc/inbox.go
+++ b/pkg/sql/exec/colrpc/inbox.go
@@ -246,6 +246,8 @@ func (i *Inbox) Next(ctx context.Context) coldata.Batch {
 		i.stateMu.Unlock()
 	}()
 	if i.stateMu.done {
+		// TODO(yuzefovich): do we want to be on the safe side and explicitly set
+		// the length here (and below) to 0?
 		return i.zeroBatch
 	}
 

--- a/pkg/sql/exec/hash_aggregator.go
+++ b/pkg/sql/exec/hash_aggregator.go
@@ -189,6 +189,7 @@ func (op *hashGrouper) Init() {
 }
 
 func (op *hashGrouper) Next(ctx context.Context) coldata.Batch {
+	op.batch.ResetInternalBatch()
 	// First, build the hash table.
 	if !op.buildFinished {
 		op.buildFinished = true

--- a/pkg/sql/exec/operator.go
+++ b/pkg/sql/exec/operator.go
@@ -207,7 +207,7 @@ func (s *singleTupleNoInputOperator) Init() {
 }
 
 func (s *singleTupleNoInputOperator) Next(ctx context.Context) coldata.Batch {
-	s.batch.SetSelection(false)
+	s.batch.ResetInternalBatch()
 	if s.nexted {
 		s.batch.SetLength(0)
 		return s.batch

--- a/pkg/sql/exec/unorderedsynchronizer.go
+++ b/pkg/sql/exec/unorderedsynchronizer.go
@@ -200,6 +200,8 @@ func (s *UnorderedSynchronizer) init(ctx context.Context) {
 // Next is part of the Operator interface.
 func (s *UnorderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 	if s.done {
+		// TODO(yuzefovich): do we want to be on the safe side and explicitly set
+		// the length here (and below) to 0?
 		return s.zeroBatch
 	}
 	if !s.initialized {


### PR DESCRIPTION
The columnarizer "owns" a batch, but it is never reset (namely,
selection vector can remain unset).

Release note: None