### PR TITLE
opt: add insert into new_order query to tpcc tests

### DIFF
--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -221,6 +221,58 @@ insert "order"
                           └── variable: c_id [type=int]
 
 opt format=hide-qual
+INSERT INTO new_order (no_o_id, no_d_id, no_w_id) VALUES (2000, 100, 10)
+----
+insert new_order
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├──  column1:4 => no_o_id:1
+ │    ├──  column2:5 => no_d_id:2
+ │    └──  column3:6 => no_w_id:3
+ ├── input binding: &1
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ ├── stats: [rows=0]
+ ├── cost: 6.14
+ ├── values
+ │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1]
+ │    ├── cost: 0.02
+ │    ├── key: ()
+ │    ├── fd: ()-->(4-6)
+ │    ├── prune: (4-6)
+ │    └── tuple [type=tuple{int, int, int}]
+ │         ├── const: 2000 [type=int]
+ │         ├── const: 100 [type=int]
+ │         └── const: 10 [type=int]
+ └── f-k-checks
+      └── f-k-checks-item: new_order(no_w_id,no_d_id,no_o_id) -> order(o_w_id,o_d_id,o_id)
+           └── anti-join (lookup order@order_idx)
+                ├── columns: column3:15(int!null) column2:16(int!null) column1:17(int!null)
+                ├── key columns: [15 16] = [9 8]
+                ├── cardinality: [0 - 1]
+                ├── stats: [rows=1]
+                ├── cost: 6.11
+                ├── key: ()
+                ├── fd: ()-->(4-6), (6)-->(15), (5)-->(16), (4)-->(17)
+                ├── with-scan &1
+                │    ├── columns: column3:15(int!null) column2:16(int!null) column1:17(int!null)
+                │    ├── mapping:
+                │    │    ├──  column3:6(int) => column3:15(int)
+                │    │    ├──  column2:5(int) => column2:16(int)
+                │    │    └──  column1:4(int) => column1:17(int)
+                │    ├── cardinality: [1 - 1]
+                │    ├── stats: [rows=1]
+                │    ├── cost: 0.01
+                │    ├── key: ()
+                │    └── fd: ()-->(4-6), (6)-->(15), (5)-->(16), (4)-->(17)
+                └── filters
+                     └── eq [type=bool, outer=(7,17), constraints=(/7: (/NULL - ]; /17: (/NULL - ]), fd=(7)==(17), (17)==(7)]
+                          ├── variable: column1 [type=int]
+                          └── variable: o_id [type=int]
+
+opt format=hide-qual
 UPDATE
   stock
 SET

--- a/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
@@ -224,6 +224,58 @@ insert "order"
                           └── variable: c_id [type=int]
 
 opt format=hide-qual
+INSERT INTO new_order (no_o_id, no_d_id, no_w_id) VALUES (2000, 100, 10)
+----
+insert new_order
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├──  column1:4 => no_o_id:1
+ │    ├──  column2:5 => no_d_id:2
+ │    └──  column3:6 => no_w_id:3
+ ├── input binding: &1
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ ├── stats: [rows=0]
+ ├── cost: 6.14
+ ├── values
+ │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1]
+ │    ├── cost: 0.02
+ │    ├── key: ()
+ │    ├── fd: ()-->(4-6)
+ │    ├── prune: (4-6)
+ │    └── tuple [type=tuple{int, int, int}]
+ │         ├── const: 2000 [type=int]
+ │         ├── const: 100 [type=int]
+ │         └── const: 10 [type=int]
+ └── f-k-checks
+      └── f-k-checks-item: new_order(no_w_id,no_d_id,no_o_id) -> order(o_w_id,o_d_id,o_id)
+           └── anti-join (lookup order@order_idx)
+                ├── columns: column3:15(int!null) column2:16(int!null) column1:17(int!null)
+                ├── key columns: [15 16] = [9 8]
+                ├── cardinality: [0 - 1]
+                ├── stats: [rows=1]
+                ├── cost: 6.11
+                ├── key: ()
+                ├── fd: ()-->(4-6), (6)-->(15), (5)-->(16), (4)-->(17)
+                ├── with-scan &1
+                │    ├── columns: column3:15(int!null) column2:16(int!null) column1:17(int!null)
+                │    ├── mapping:
+                │    │    ├──  column3:6(int) => column3:15(int)
+                │    │    ├──  column2:5(int) => column2:16(int)
+                │    │    └──  column1:4(int) => column1:17(int)
+                │    ├── cardinality: [1 - 1]
+                │    ├── stats: [rows=1]
+                │    ├── cost: 0.01
+                │    ├── key: ()
+                │    └── fd: ()-->(4-6), (6)-->(15), (5)-->(16), (4)-->(17)
+                └── filters
+                     └── eq [type=bool, outer=(7,17), constraints=(/7: (/NULL - ]; /17: (/NULL - ]), fd=(7)==(17), (17)==(7)]
+                          ├── variable: column1 [type=int]
+                          └── variable: o_id [type=int]
+
+opt format=hide-qual
 UPDATE
   stock
 SET

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -218,6 +218,58 @@ insert "order"
                           └── variable: c_id [type=int]
 
 opt format=hide-qual
+INSERT INTO new_order (no_o_id, no_d_id, no_w_id) VALUES (2000, 100, 10)
+----
+insert new_order
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├──  column1:4 => no_o_id:1
+ │    ├──  column2:5 => no_d_id:2
+ │    └──  column3:6 => no_w_id:3
+ ├── input binding: &1
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ ├── stats: [rows=0]
+ ├── cost: 6.14
+ ├── values
+ │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1]
+ │    ├── cost: 0.02
+ │    ├── key: ()
+ │    ├── fd: ()-->(4-6)
+ │    ├── prune: (4-6)
+ │    └── tuple [type=tuple{int, int, int}]
+ │         ├── const: 2000 [type=int]
+ │         ├── const: 100 [type=int]
+ │         └── const: 10 [type=int]
+ └── f-k-checks
+      └── f-k-checks-item: new_order(no_w_id,no_d_id,no_o_id) -> order(o_w_id,o_d_id,o_id)
+           └── anti-join (lookup order@order_idx)
+                ├── columns: column3:15(int!null) column2:16(int!null) column1:17(int!null)
+                ├── key columns: [15 16] = [9 8]
+                ├── cardinality: [0 - 1]
+                ├── stats: [rows=1]
+                ├── cost: 6.11
+                ├── key: ()
+                ├── fd: ()-->(4-6), (6)-->(15), (5)-->(16), (4)-->(17)
+                ├── with-scan &1
+                │    ├── columns: column3:15(int!null) column2:16(int!null) column1:17(int!null)
+                │    ├── mapping:
+                │    │    ├──  column3:6(int) => column3:15(int)
+                │    │    ├──  column2:5(int) => column2:16(int)
+                │    │    └──  column1:4(int) => column1:17(int)
+                │    ├── cardinality: [1 - 1]
+                │    ├── stats: [rows=1]
+                │    ├── cost: 0.01
+                │    ├── key: ()
+                │    └── fd: ()-->(4-6), (6)-->(15), (5)-->(16), (4)-->(17)
+                └── filters
+                     └── eq [type=bool, outer=(7,17), constraints=(/7: (/NULL - ]; /17: (/NULL - ]), fd=(7)==(17), (17)==(7)]
+                          ├── variable: column1 [type=int]
+                          └── variable: o_id [type=int]
+
+opt format=hide-qual
 UPDATE
   stock
 SET


### PR DESCRIPTION
Somehow missed this one in my previous change.

Release note: None