### PR TITLE
opt: ignore FKs to tables in adding state, test updates

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_constraint
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_constraint
@@ -62,7 +62,7 @@ INSERT INTO c2 VALUES ('A' COLLATE en_u_ks_level1, 'apple' COLLATE en_u_ks_level
 statement ok
 INSERT INTO c2 VALUES ('b' COLLATE en_u_ks_level1, 'banana' COLLATE en_u_ks_level1)
 
-statement error foreign key violation: value \['p' COLLATE en_u_ks_level1\] not found in p@primary \[a\]
+statement error foreign key violation: value \['p' COLLATE en_u_ks_level1\] not found in p@primary \[a\]|insert on table "c2" violates foreign key constraint "fk_p"
 INSERT INTO c2 VALUES ('p' COLLATE en_u_ks_level1, 'pear' COLLATE en_u_ks_level1)
 
 query T

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -508,7 +508,7 @@ create table y (
 statement ok
 INSERT INTO y VALUES (5)
 
-statement error foreign key violation
+statement error foreign key
 INSERT INTO y VALUES (100)
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/fk-mixed-19.1-19.2
+++ b/pkg/sql/logictest/testdata/logic_test/fk-mixed-19.1-19.2
@@ -6,6 +6,9 @@
 # not backward compatible. The most significant difference is that FKs are not
 # validated when added in 19.1, hence the need for different logic tests.
 
+statement ok
+SET experimental_optimizer_foreign_keys = false
+
 # Disable automatic stats to avoid flakiness.
 statement ok
 SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -573,7 +573,7 @@ CREATE TABLE src(x VARCHAR PRIMARY KEY);
                        y VARCHAR CHECK(length(y) < 4) REFERENCES src(x))
 
 # Sanity check that the FK constraints gets actually validated
-statement error foreign key violation
+statement error foreign key
 INSERT INTO derived(x) VALUES('xxx')
 
 statement error value too long for type CHAR\(3\)

--- a/pkg/sql/logictest/testdata/logic_test/parallel_stmts_compat
+++ b/pkg/sql/logictest/testdata/logic_test/parallel_stmts_compat
@@ -42,7 +42,7 @@ DELETE FROM kv WHERE k = 1 RETURNING NOTHING
 statement ok
 INSERT INTO fk VALUES (2)
 
-statement error foreign key violation: values \[2\] in columns \[k\] referenced in table \"fk\"
+statement error foreign key violation: values \[2\] in columns \[k\] referenced in table \"fk\"|delete on table "kv" violates foreign key constraint on table "fk"
 DELETE FROM kv WHERE k = 2 RETURNING NOTHING
 
 statement ok
@@ -240,7 +240,7 @@ BEGIN
 statement ok
 DELETE FROM kv WHERE k = 1 RETURNING NOTHING
 
-statement error foreign key violation: values \[2\] in columns \[k\] referenced in table \"fk\"
+statement error foreign key violation: values \[2\] in columns \[k\] referenced in table \"fk\"|delete on table "kv" violates foreign key constraint on table "fk"
 DELETE FROM kv WHERE k = 2 RETURNING NOTHING
 
 statement error current transaction is aborted, commands ignored until end of transaction block

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1661,7 +1661,7 @@ ALTER TABLE t DROP CONSTRAINT fk
 
 # Since the foreign key constraint is dropped in the schema changer after the
 # transaction commits, it's still enforced during the rest of the transaction.
-statement error pgcode 23503 value \[1\] not found in t2@primary \[b\]
+statement error pgcode 23503 foreign key
 INSERT INTO t VALUES (1)
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -416,7 +416,7 @@ CREATE TABLE src(x VARCHAR PRIMARY KEY);
   INSERT INTO derived(x, y) VALUES ('abc', 'abc')
 
 # Sanity check that the FK constraints gets actually validated
-statement error foreign key violation
+statement error foreign key
 UPDATE derived SET x = 'xxx'
 
 statement error value too long for type CHAR\(3\)

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -105,9 +105,14 @@ type Catalog interface {
 	// locates a data source by its StableID. See the comment for StableID for
 	// more details.
 	//
+	// If the table is in the process of being added, returns an
+	// "undefined relation" error but also returns isAdding=true.
+	//
 	// NOTE: The returned data source must be immutable after construction, and
 	// so can be safely copied or used across goroutines.
-	ResolveDataSourceByID(ctx context.Context, flags Flags, id StableID) (DataSource, error)
+	ResolveDataSourceByID(
+		ctx context.Context, flags Flags, id StableID,
+	) (_ DataSource, isAdding bool, _ error)
 
 	// CheckPrivilege verifies that the current user has the given privilege on
 	// the given catalog object. If not, then CheckPrivilege returns an error.

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -244,11 +244,11 @@ func formatCols(tab Table, numCols int, colOrdinal func(tab Table, i int) int) s
 func formatCatalogFKRef(
 	catalog Catalog, inbound bool, fkRef ForeignKeyConstraint, tp treeprinter.Node,
 ) {
-	originDS, err := catalog.ResolveDataSourceByID(context.TODO(), Flags{}, fkRef.OriginTableID())
+	originDS, _, err := catalog.ResolveDataSourceByID(context.TODO(), Flags{}, fkRef.OriginTableID())
 	if err != nil {
 		panic(err)
 	}
-	refDS, err := catalog.ResolveDataSourceByID(context.TODO(), Flags{}, fkRef.ReferencedTableID())
+	refDS, _, err := catalog.ResolveDataSourceByID(context.TODO(), Flags{}, fkRef.ReferencedTableID())
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -214,7 +214,7 @@ func (md *Metadata) CheckDependencies(
 		var toCheck cat.DataSource
 		var err error
 		if name.byID != 0 {
-			toCheck, err = catalog.ResolveDataSourceByID(ctx, cat.Flags{}, name.byID)
+			toCheck, _, err = catalog.ResolveDataSourceByID(ctx, cat.Flags{}, name.byID)
 		} else {
 			// Resolve data source object.
 			toCheck, _, err = catalog.ResolveDataSource(ctx, cat.Flags{}, &name.byName)

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -497,7 +497,7 @@ func (b *Builder) resolveDataSourceRef(ref *tree.TableRef, priv privilege.Kind) 
 		// Avoid taking table leases when we're creating a view.
 		flags.AvoidDescriptorCaches = true
 	}
-	ds, err := b.catalog.ResolveDataSourceByID(b.ctx, flags, cat.StableID(ref.TableID))
+	ds, _, err := b.catalog.ResolveDataSourceByID(b.ctx, flags, cat.StableID(ref.TableID))
 	if err != nil {
 		panic(pgerror.Wrapf(err, pgcode.UndefinedObject, "%s", tree.ErrString(ref)))
 	}

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -157,13 +157,13 @@ func (tc *Catalog) ResolveDataSource(
 // ResolveDataSourceByID is part of the cat.Catalog interface.
 func (tc *Catalog) ResolveDataSourceByID(
 	ctx context.Context, flags cat.Flags, id cat.StableID,
-) (cat.DataSource, error) {
+) (_ cat.DataSource, isAdding bool, _ error) {
 	for _, ds := range tc.testSchema.dataSources {
 		if ds.ID() == id {
-			return ds, nil
+			return ds, false, nil
 		}
 	}
-	return nil, pgerror.Newf(pgcode.UndefinedTable,
+	return nil, false, pgerror.Newf(pgcode.UndefinedTable,
 		"relation [%d] does not exist", id)
 }
 

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -3152,7 +3152,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT, pi DECIMAL REFERENCES t.pi (d) DE
 	// Ensure that the FK property still holds.
 	if _, err := sqlDB.Exec(
 		`INSERT INTO t.test VALUES ($1 , $2, $3)`, maxValue+2, maxValue+2, 3.15,
-	); !testutils.IsError(err, "foreign key violation") {
+	); !testutils.IsError(err, "foreign key violation|violates foreign key") {
 		t.Fatalf("err = %v", err)
 	}
 


### PR DESCRIPTION
#### opt: ignore FKs to tables in adding state

Normally tables that are in "adding" state (i.e. in the process of
being added) are treated as non-existent. There is an exception with
FKs: it is possible for a visible table to have a FK relationship with
a table in adding state, in which case the FK must be ignored.

This case is exercised by `sql.TestAddingFKs`, which now passes with
`experimental_optimizer_foreign_keys` enabled.

Release note: None

#### sql: test updates for opt-driven FKs

Release note: None
