### PR TITLE
coldata: clean up the vectorized templates and nulls

### DIFF
--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -37,11 +37,6 @@ func (b *Bytes) Set(i int, v []byte) {
 	b.data[i] = v
 }
 
-// Swap swaps the ith []byte with the jth []byte and vice-versa.
-func (b *Bytes) Swap(i int, j int) {
-	b.data[i], b.data[j] = b.data[j], b.data[i]
-}
-
 // Slice returns a new Bytes struct with its internal data sliced according to
 // start and end.
 func (b *Bytes) Slice(start, end int) *Bytes {
@@ -90,6 +85,9 @@ func (b *Bytes) Reset() {}
 
 // TODO(yuzefovich): fix flatBytes implementation and use that instead of
 // Bytes.
+
+// Remove the unused warnings.
+var _ *flatBytes = newFlatBytes(0)
 
 // flatBytes is a wrapper type for a two-dimensional byte slice ([][]byte).
 type flatBytes struct {
@@ -151,12 +149,6 @@ func (b *flatBytes) Set(i int, v []byte) {
 	b.lengths[i] = int32(len(v))
 	b.data = append(b.data, v...)
 	b.maxSetIndex = i
-}
-
-// Swap swaps the ith []byte with the jth []byte and vice-versa. This is
-// disallowed.
-func (b *flatBytes) Swap(i int, j int) {
-	panic("cannot swap flat Bytes elements")
 }
 
 // Slice modifies and returns the receiver flatBytes struct sliced according to

--- a/pkg/col/coldata/bytes_test.go
+++ b/pkg/col/coldata/bytes_test.go
@@ -271,14 +271,6 @@ func TestFlatBytes(t *testing.T) {
 		// Same with Reset.
 		b1.Reset()
 		b1.Set(1, []byte("reset new usage"))
-
-		// Swap exists temporarily due to execgen.SWAP.
-		// TODO(asubiotto): Remove execgen.SWAP and Swap.
-		require.Panics(
-			t,
-			func() { b1.Swap(0, 1) },
-			"should be unable to swap values",
-		)
 	})
 
 	t.Run("Append", func(t *testing.T) {

--- a/pkg/col/coldata/nulls.go
+++ b/pkg/col/coldata/nulls.go
@@ -205,15 +205,20 @@ func (n *Nulls) UnsetNull64(i uint64) {
 	n.nulls[i/8] |= bitMask[i%8]
 }
 
-// SwapNulls swaps the null values at the argument indices.
-// We implement the logic directly on the byte array
-// rather than case on the result of NullAt to avoid
+// Remove the unused warning.
+var (
+	n = Nulls{}
+	_ = n.swap
+)
+
+// swap swaps the null values at the argument indices. We implement the logic
+// directly on the byte array rather than case on the result of NullAt to avoid
 // having to take some branches.
-func (n *Nulls) SwapNulls(i, j uint64) {
+func (n *Nulls) swap(i, j uint64) {
 	// Get original null values.
 	ni := (n.nulls[i/8] >> (i % 8)) & 0x1
 	nj := (n.nulls[j/8] >> (j % 8)) & 0x1
-	// Write into the correct positions
+	// Write into the correct positions.
 	iMask := bitMask[i%8]
 	jMask := bitMask[j%8]
 	n.nulls[i/8] = (n.nulls[i/8] & ^iMask) | (nj << (i % 8))

--- a/pkg/col/coldata/nulls.go
+++ b/pkg/col/coldata/nulls.go
@@ -225,39 +225,24 @@ func (n *Nulls) swap(i, j uint64) {
 	n.nulls[j/8] = (n.nulls[j/8] & ^jMask) | (ni << (j % 8))
 }
 
-// Extend extends the nulls vector with the next toAppend values from src,
-// starting at srcStartIdx.
-func (n *Nulls) Extend(src *Nulls, destStartIdx uint64, srcStartIdx uint16, toAppend uint16) {
-	if toAppend == 0 {
-		return
-	}
-	outputLen := destStartIdx + uint64(toAppend)
-	// We will need ceil(outputLen/8) bytes to encode the combined nulls.
-	needed := (outputLen-1)/8 + 1
-	current := uint64(len(n.nulls))
-	if current < needed {
-		n.nulls = append(n.nulls, filledNulls[:needed-current]...)
-	}
-	if src.MaybeHasNulls() {
-		for i := uint16(0); i < toAppend; i++ {
-			// TODO(yuzefovich): this can be done more efficiently with a bitwise OR:
-			// like n.nulls[i] |= vec.nulls[i].
-			if src.NullAt(srcStartIdx + i) {
-				n.SetNull64(destStartIdx + uint64(i))
-			}
-		}
-	}
+func (n *Nulls) append(args AppendArgs) {
+	n.duplicate(args.Src.Nulls(), args.Sel, args.DestIdx, uint64(args.SrcStartIdx), uint64(args.SrcEndIdx))
 }
 
-// ExtendWithSel extends the nulls vector with the next toAppend values from
-// src, starting at srcStartIdx and using the provided selection vector.
-func (n *Nulls) ExtendWithSel(
-	src *Nulls, destStartIdx uint64, srcStartIdx uint16, toAppend uint16, sel []uint16,
-) {
-	if toAppend == 0 {
+func (n *Nulls) copy(args CopyArgs) {
+	n.duplicate(args.Src.Nulls(), args.Sel, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
+}
+
+// duplicate copies over a slice [srcStartIdx: srcEndIdx] of src and puts it
+// starting at destIdx. If the length of this nulls is smaller than destIdx,
+// then this nulls is extended; otherwise, any overlapping old values are
+// overwritten, and this nulls is also extended if necessary.
+func (n *Nulls) duplicate(src *Nulls, sel []uint16, destIdx, srcStartIdx, srcEndIdx uint64) {
+	if srcStartIdx == srcEndIdx {
 		return
 	}
-	outputLen := destStartIdx + uint64(toAppend)
+	toDuplicate := srcEndIdx - srcStartIdx
+	outputLen := destIdx + toDuplicate
 	// We will need ceil(outputLen/8) bytes to encode the combined nulls.
 	needed := (outputLen-1)/8 + 1
 	current := uint64(len(n.nulls))
@@ -265,13 +250,23 @@ func (n *Nulls) ExtendWithSel(
 		n.nulls = append(n.nulls, filledNulls[:needed-current]...)
 	}
 	if src.MaybeHasNulls() {
-		for i := uint16(0); i < toAppend; i++ {
-			// TODO(yuzefovich): this can be done more efficiently with a bitwise OR:
-			// like n.nulls[i] |= vec.nulls[i].
-			if src.NullAt(sel[srcStartIdx+i]) {
-				n.SetNull64(destStartIdx + uint64(i))
+		if sel != nil {
+			for i := uint64(0); i < toDuplicate; i++ {
+				if src.NullAt(sel[srcStartIdx+i]) {
+					n.SetNull64(destIdx + i)
+				}
+			}
+		} else {
+			for i := uint64(0); i < toDuplicate; i++ {
+				// TODO(yuzefovich): this can be done more efficiently with a bitwise OR:
+				// like n.nulls[i] |= vec.nulls[i].
+				if src.NullAt64(srcStartIdx + i) {
+					n.SetNull64(destIdx + i)
+				}
 			}
 		}
+	} else {
+		n.UnsetNullRange(destIdx, destIdx+toDuplicate)
 	}
 }
 

--- a/pkg/col/coldata/nulls.go
+++ b/pkg/col/coldata/nulls.go
@@ -225,48 +225,42 @@ func (n *Nulls) swap(i, j uint64) {
 	n.nulls[j/8] = (n.nulls[j/8] & ^jMask) | (ni << (j % 8))
 }
 
-func (n *Nulls) append(args AppendArgs) {
-	n.duplicate(args.Src.Nulls(), args.Sel, args.DestIdx, uint64(args.SrcStartIdx), uint64(args.SrcEndIdx))
-}
-
-func (n *Nulls) copy(args CopyArgs) {
-	n.duplicate(args.Src.Nulls(), args.Sel, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
-}
-
-// duplicate copies over a slice [srcStartIdx: srcEndIdx] of src and puts it
-// starting at destIdx. If the length of this nulls is smaller than destIdx,
-// then this nulls is extended; otherwise, any overlapping old values are
-// overwritten, and this nulls is also extended if necessary.
-func (n *Nulls) duplicate(src *Nulls, sel []uint16, destIdx, srcStartIdx, srcEndIdx uint64) {
-	if srcStartIdx == srcEndIdx {
+// set copies over a slice [args.SrcStartIdx: args.SrcEndIdx] of
+// args.Src.Nulls() and puts it into this nulls starting at args.DestIdx. If
+// the length of this nulls is smaller than args.DestIdx, then this nulls is
+// extended; otherwise, any overlapping old values are overwritten, and this
+// nulls is also extended if necessary.
+func (n *Nulls) set(args SliceArgs) {
+	if args.SrcStartIdx == args.SrcEndIdx {
 		return
 	}
-	toDuplicate := srcEndIdx - srcStartIdx
-	outputLen := destIdx + toDuplicate
+	toDuplicate := args.SrcEndIdx - args.SrcStartIdx
+	outputLen := args.DestIdx + toDuplicate
 	// We will need ceil(outputLen/8) bytes to encode the combined nulls.
 	needed := (outputLen-1)/8 + 1
 	current := uint64(len(n.nulls))
 	if current < needed {
 		n.nulls = append(n.nulls, filledNulls[:needed-current]...)
 	}
-	if src.MaybeHasNulls() {
-		if sel != nil {
+	if args.Src.MaybeHasNulls() {
+		src := args.Src.Nulls()
+		if args.Sel != nil {
 			for i := uint64(0); i < toDuplicate; i++ {
-				if src.NullAt(sel[srcStartIdx+i]) {
-					n.SetNull64(destIdx + i)
+				if src.NullAt(args.Sel[args.SrcStartIdx+i]) {
+					n.SetNull64(args.DestIdx + i)
 				}
 			}
 		} else {
 			for i := uint64(0); i < toDuplicate; i++ {
 				// TODO(yuzefovich): this can be done more efficiently with a bitwise OR:
 				// like n.nulls[i] |= vec.nulls[i].
-				if src.NullAt64(srcStartIdx + i) {
-					n.SetNull64(destIdx + i)
+				if src.NullAt64(args.SrcStartIdx + i) {
+					n.SetNull64(args.DestIdx + i)
 				}
 			}
 		}
 	} else {
-		n.UnsetNullRange(destIdx, destIdx+toDuplicate)
+		n.UnsetNullRange(args.DestIdx, args.DestIdx+toDuplicate)
 	}
 }
 

--- a/pkg/col/coldata/nulls_test.go
+++ b/pkg/col/coldata/nulls_test.go
@@ -106,7 +106,7 @@ func TestSwapNulls(t *testing.T) {
 		}
 		for _, i := range swapPos {
 			for _, j := range swapPos {
-				n.SwapNulls(i, j)
+				n.swap(i, j)
 				for k := uint64(0); k < BatchSize; k++ {
 					require.Equal(t, idxInSwapPos(k), n.NullAt64(k),
 						"after swapping NULLS (%d, %d), NullAt(%d) saw %t, expected %t", i, j, k, n.NullAt64(k), idxInSwapPos(k))
@@ -137,7 +137,7 @@ func TestSwapNulls(t *testing.T) {
 			n.SetNull64(j)
 		}
 		for i, j := range swaps {
-			n.SwapNulls(i, j)
+			n.swap(i, j)
 			require.Truef(t, n.NullAt64(i), "after swapping not null and null (%d, %d), found null=%t at %d", i, j, n.NullAt64(i), i)
 			require.Truef(t, !n.NullAt64(j), "after swapping not null and null (%d, %d), found null=%t at %d", i, j, !n.NullAt64(j), j)
 			for k := uint64(0); k < BatchSize; k++ {
@@ -158,7 +158,7 @@ func TestSwapNulls(t *testing.T) {
 		}
 		for _, i := range swapPos {
 			for _, j := range swapPos {
-				n.SwapNulls(i, j)
+				n.swap(i, j)
 				for k := uint64(0); k < BatchSize; k++ {
 					require.Equal(t, idxInSwapPos(k), !n.NullAt64(k),
 						"after swapping NULLS (%d, %d), NullAt(%d) saw %t, expected %t", i, j, k, !n.NullAt64(k), idxInSwapPos(k))

--- a/pkg/col/coldata/nulls_test.go
+++ b/pkg/col/coldata/nulls_test.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/stretchr/testify/require"
 )
 
@@ -220,7 +221,11 @@ func TestSetAndUnsetNulls(t *testing.T) {
 	}
 }
 
-func TestNullsDuplicate(t *testing.T) {
+func TestNullsSet(t *testing.T) {
+	args := SliceArgs{
+		// Neither type nor the length here matter.
+		Src: NewMemColumn(coltypes.Bool, 0),
+	}
 	for _, destStartIdx := range pos {
 		for _, srcStartIdx := range pos {
 			for _, srcEndIdx := range pos {
@@ -230,7 +235,11 @@ func TestNullsDuplicate(t *testing.T) {
 						srcStartIdx, toAppend)
 					t.Run(name, func(t *testing.T) {
 						n := nulls3.Copy()
-						n.duplicate(&nulls5, nil /* sel */, destStartIdx, srcStartIdx, srcEndIdx)
+						args.Src.SetNulls(&nulls5)
+						args.DestIdx = destStartIdx
+						args.SrcStartIdx = srcStartIdx
+						args.SrcEndIdx = srcEndIdx
+						n.set(args)
 						for i := uint64(0); i < destStartIdx; i++ {
 							require.Equal(t, nulls3.NullAt64(i), n.NullAt64(i))
 						}
@@ -251,12 +260,16 @@ func TestNullsDuplicate(t *testing.T) {
 	}
 }
 
-func TestNullsDuplicateWithSel(t *testing.T) {
+func TestNullsSetWithSel(t *testing.T) {
+	args := SliceArgs{
+		// Neither type nor the length here matter.
+		Src: NewMemColumn(coltypes.Bool, 0),
+		Sel: make([]uint16, BatchSize),
+	}
 	// Make a selection vector with every even index. (This turns nulls10 into
 	// nulls5.)
-	sel := make([]uint16, BatchSize)
-	for i := range sel {
-		sel[i] = uint16(i) * 2
+	for i := range args.Sel {
+		args.Sel[i] = uint16(i) * 2
 	}
 
 	for _, destStartIdx := range pos {
@@ -268,7 +281,11 @@ func TestNullsDuplicateWithSel(t *testing.T) {
 						srcStartIdx, toAppend)
 					t.Run(name, func(t *testing.T) {
 						n := nulls3.Copy()
-						n.duplicate(&nulls10, sel, destStartIdx, srcStartIdx, srcEndIdx)
+						args.Src.SetNulls(&nulls10)
+						args.DestIdx = destStartIdx
+						args.SrcStartIdx = srcStartIdx
+						args.SrcEndIdx = srcEndIdx
+						n.set(args)
 						for i := uint64(0); i < destStartIdx; i++ {
 							require.Equal(t, nulls3.NullAt64(i), n.NullAt64(i))
 						}

--- a/pkg/col/coldata/nulls_test.go
+++ b/pkg/col/coldata/nulls_test.go
@@ -220,7 +220,7 @@ func TestSetAndUnsetNulls(t *testing.T) {
 	}
 }
 
-func TestExtend(t *testing.T) {
+func TestNullsDuplicate(t *testing.T) {
 	for _, destStartIdx := range pos {
 		for _, srcStartIdx := range pos {
 			for _, srcEndIdx := range pos {
@@ -230,7 +230,7 @@ func TestExtend(t *testing.T) {
 						srcStartIdx, toAppend)
 					t.Run(name, func(t *testing.T) {
 						n := nulls3.Copy()
-						n.Extend(&nulls5, destStartIdx, uint16(srcStartIdx), uint16(toAppend))
+						n.duplicate(&nulls5, nil /* sel */, destStartIdx, srcStartIdx, srcEndIdx)
 						for i := uint64(0); i < destStartIdx; i++ {
 							require.Equal(t, nulls3.NullAt64(i), n.NullAt64(i))
 						}
@@ -251,7 +251,7 @@ func TestExtend(t *testing.T) {
 	}
 }
 
-func TestExtendSel(t *testing.T) {
+func TestNullsDuplicateWithSel(t *testing.T) {
 	// Make a selection vector with every even index. (This turns nulls10 into
 	// nulls5.)
 	sel := make([]uint16, BatchSize)
@@ -268,7 +268,7 @@ func TestExtendSel(t *testing.T) {
 						srcStartIdx, toAppend)
 					t.Run(name, func(t *testing.T) {
 						n := nulls3.Copy()
-						n.ExtendWithSel(&nulls10, destStartIdx, uint16(srcStartIdx), uint16(toAppend), sel)
+						n.duplicate(&nulls10, sel, destStartIdx, srcStartIdx, srcEndIdx)
 						for i := uint64(0); i < destStartIdx; i++ {
 							require.Equal(t, nulls3.NullAt64(i), n.NullAt64(i))
 						}

--- a/pkg/col/coldata/vec.go
+++ b/pkg/col/coldata/vec.go
@@ -20,8 +20,8 @@ import (
 // column is an interface that represents a raw array of a Go native type.
 type column interface{}
 
-// AppendArgs represents the arguments passed in to Vec.Append.
-type AppendArgs struct {
+// SliceArgs represents the arguments passed in to Vec.Append and Nulls.set.
+type SliceArgs struct {
 	// ColType is the type of both the destination and source slices.
 	ColType coltypes.T
 	// Src is the data being appended.
@@ -33,22 +33,17 @@ type AppendArgs struct {
 	DestIdx uint64
 	// SrcStartIdx is the index of the first element in Src that Append will
 	// append.
-	SrcStartIdx uint16
+	SrcStartIdx uint64
 	// SrcEndIdx is the exclusive end index of Src. i.e. the element in the index
 	// before SrcEndIdx is the last element appended to the destination slice,
 	// similar to Src[SrcStartIdx:SrcEndIdx].
-	SrcEndIdx uint16
+	SrcEndIdx uint64
 }
 
-// CopyArgs represents the arguments passed in to Vec.Copy.
-type CopyArgs struct {
-	// ColType is the type of both the destination and source slices.
-	ColType coltypes.T
-	// Src is the data being copied.
-	Src Vec
-	// Sel is an optional slice specifying indices to copy to the destination
-	// slice. Note that Src{Start,End}Idx apply to Sel.
-	Sel []uint16
+// CopySliceArgs represents the extension of SliceArgs that is passed in to
+// Vec.Copy.
+type CopySliceArgs struct {
+	SliceArgs
 	// Sel64 overrides Sel. Used when the amount of data being copied exceeds the
 	// representation capabilities of a []uint16.
 	Sel64 []uint64
@@ -57,14 +52,6 @@ type CopyArgs struct {
 	// selection vector is applied to the source vector, but the results are
 	// copied densely into the destination vector.
 	SelOnDest bool
-	// DestIdx is the first index that Copy will copy to.
-	DestIdx uint64
-	// SrcStartIdx is the index of the first element in Src that Copy will copy.
-	SrcStartIdx uint64
-	// SrcEndIdx is the exclusive end index of Src. i.e. the element in the index
-	// before SrcEndIdx is the last element copied into the destination slice,
-	// similar to Src[SrcStartIdx:SrcEndIdx].
-	SrcEndIdx uint64
 }
 
 // Vec is an interface that represents a column vector that's accessible by
@@ -104,21 +91,21 @@ type Vec interface {
 	// Do not call this from normal code - it'll always panic.
 	_TemplateType() []interface{}
 
-	// Append uses AppendArgs to append elements of a source Vec into this Vec.
+	// Append uses SliceArgs to append elements of a source Vec into this Vec.
 	// It is logically equivalent to:
 	// destVec = append(destVec[:args.DestIdx], args.Src[args.SrcStartIdx:args.SrcEndIdx])
 	// An optional Sel slice can also be provided to apply a filter on the source
 	// Vec.
-	// Refer to the AppendArgs comment for specifics and TestAppend for examples.
-	Append(AppendArgs)
+	// Refer to the SliceArgs comment for specifics and TestAppend for examples.
+	Append(SliceArgs)
 
-	// Copy uses CopyArgs to copy elements of a source Vec into this Vec. It is
+	// Copy uses CopySliceArgs to copy elements of a source Vec into this Vec. It is
 	// logically equivalent to:
 	// copy(destVec[args.DestIdx:], args.Src[args.SrcStartIdx:args.SrcEndIdx])
 	// An optional Sel slice can also be provided to apply a filter on the source
 	// Vec.
-	// Refer to the CopyArgs comment for specifics and TestCopy for examples.
-	Copy(CopyArgs)
+	// Refer to the CopySliceArgs comment for specifics and TestCopy for examples.
+	Copy(CopySliceArgs)
 
 	// Slice returns a new Vec representing a slice of the current Vec from
 	// [start, end).

--- a/pkg/col/coldata/vec_test.go
+++ b/pkg/col/coldata/vec_test.go
@@ -143,12 +143,12 @@ func TestAppend(t *testing.T) {
 
 	testCases := []struct {
 		name           string
-		args           AppendArgs
+		args           SliceArgs
 		expectedLength int
 	}{
 		{
 			name: "AppendSimple",
-			args: AppendArgs{
+			args: SliceArgs{
 				// DestIdx must be specified to append to the end of dest.
 				DestIdx: BatchSize,
 			},
@@ -156,7 +156,7 @@ func TestAppend(t *testing.T) {
 		},
 		{
 			name: "AppendOverwriteSimple",
-			args: AppendArgs{
+			args: SliceArgs{
 				// DestIdx 0, the default value, will start appending at index 0.
 				DestIdx: 0,
 			},
@@ -164,7 +164,7 @@ func TestAppend(t *testing.T) {
 		},
 		{
 			name: "AppendOverwriteSlice",
-			args: AppendArgs{
+			args: SliceArgs{
 				// Start appending at index 10.
 				DestIdx: 10,
 			},
@@ -172,7 +172,7 @@ func TestAppend(t *testing.T) {
 		},
 		{
 			name: "AppendSlice",
-			args: AppendArgs{
+			args: SliceArgs{
 				DestIdx:     20,
 				SrcStartIdx: 10,
 				SrcEndIdx:   20,
@@ -181,7 +181,7 @@ func TestAppend(t *testing.T) {
 		},
 		{
 			name: "AppendWithSel",
-			args: AppendArgs{
+			args: SliceArgs{
 				DestIdx:     5,
 				SrcStartIdx: 10,
 				SrcEndIdx:   20,
@@ -191,10 +191,10 @@ func TestAppend(t *testing.T) {
 		},
 		{
 			name: "AppendWithHalfSel",
-			args: AppendArgs{
+			args: SliceArgs{
 				DestIdx:   5,
 				Sel:       sel[:len(sel)/2],
-				SrcEndIdx: uint16(len(sel) / 2),
+				SrcEndIdx: uint64(len(sel) / 2),
 			},
 			expectedLength: 5 + (BatchSize / 2),
 		},
@@ -243,35 +243,39 @@ func TestCopy(t *testing.T) {
 
 	testCases := []struct {
 		name        string
-		args        CopyArgs
+		args        CopySliceArgs
 		expectedSum int
 	}{
 		{
 			name:        "CopyNothing",
-			args:        CopyArgs{},
+			args:        CopySliceArgs{},
 			expectedSum: 0,
 		},
 		{
 			name: "CopyBatchSizeMinus1WithOffset1",
-			args: CopyArgs{
-				// Use DestIdx 1 to make sure that it is respected.
-				DestIdx:   1,
-				SrcEndIdx: BatchSize - 1,
+			args: CopySliceArgs{
+				SliceArgs: SliceArgs{
+					// Use DestIdx 1 to make sure that it is respected.
+					DestIdx:   1,
+					SrcEndIdx: BatchSize - 1,
+				},
 			},
 			// expectedSum uses sum of positive integers formula.
 			expectedSum: ((BatchSize - 1) * (BatchSize)) / 2,
 		},
 		{
 			name: "CopyWithSel",
-			args: CopyArgs{
-				// Set sel, but this should be ignored in favor of Sel64.
-				Sel: sel,
+			args: CopySliceArgs{
+				SliceArgs: SliceArgs{
+					// Set sel, but this should be ignored in favor of Sel64.
+					Sel:         sel,
+					DestIdx:     25,
+					SrcStartIdx: 1,
+					SrcEndIdx:   2,
+				},
 				// Since sel64 and sel refer to the same indices, slice sel64 to be able
 				// to tell which sel was used.
-				Sel64:       sel64[1:],
-				DestIdx:     25,
-				SrcStartIdx: 1,
-				SrcEndIdx:   2,
+				Sel64: sel64[1:],
 			},
 			// We'll have just the third element in the resulting slice.
 			expectedSum: 3,
@@ -324,12 +328,14 @@ func TestCopyNulls(t *testing.T) {
 		src.Nulls().SetNull(uint16(i))
 	}
 
-	copyArgs := CopyArgs{
-		ColType:     typ,
-		Src:         src,
-		DestIdx:     3,
-		SrcStartIdx: 3,
-		SrcEndIdx:   10,
+	copyArgs := CopySliceArgs{
+		SliceArgs: SliceArgs{
+			ColType:     typ,
+			Src:         src,
+			DestIdx:     3,
+			SrcStartIdx: 3,
+			SrcEndIdx:   10,
+		},
 	}
 
 	dst.Copy(copyArgs)
@@ -361,15 +367,15 @@ func BenchmarkAppend(b *testing.B) {
 
 	benchCases := []struct {
 		name string
-		args AppendArgs
+		args SliceArgs
 	}{
 		{
 			name: "AppendSimple",
-			args: AppendArgs{},
+			args: SliceArgs{},
 		},
 		{
 			name: "AppendWithSel",
-			args: AppendArgs{
+			args: SliceArgs{
 				Sel: sel,
 			},
 		},
@@ -399,16 +405,18 @@ func BenchmarkCopy(b *testing.B) {
 
 	benchCases := []struct {
 		name string
-		args CopyArgs
+		args CopySliceArgs
 	}{
 		{
 			name: "CopySimple",
-			args: CopyArgs{},
+			args: CopySliceArgs{},
 		},
 		{
 			name: "CopyWithSel",
-			args: CopyArgs{
-				Sel: sel,
+			args: CopySliceArgs{
+				SliceArgs: SliceArgs{
+					Sel: sel,
+				},
 			},
 		},
 	}

--- a/pkg/col/coldata/vec_tmpl.go
+++ b/pkg/col/coldata/vec_tmpl.go
@@ -85,32 +85,28 @@ func _COPY_WITH_SEL(
 	// {{define "copyWithSel"}}
 	if args.Src.MaybeHasNulls() {
 		nulls := args.Src.Nulls()
-		n := execgen.LEN(toCol)
-		toColSliced := execgen.SLICE(toCol, int(args.DestIdx), n)
 		for i, selIdx := range sel[args.SrcStartIdx:args.SrcEndIdx] {
 			if nulls.NullAt64(uint64(selIdx)) {
 				m.nulls.SetNull64(uint64(i) + args.DestIdx)
 			} else {
 				v := execgen.UNSAFEGET(fromCol, int(selIdx))
 				// {{if .SelOnDest}}
-				execgen.SET(toColSliced, int(selIdx), v)
+				execgen.SET(toCol, int(selIdx), v)
 				// {{else}}
-				execgen.SET(toColSliced, i, v)
+				execgen.SET(toCol, i, v)
 				// {{end}}
 			}
 		}
 		return
 	}
 	// No Nulls.
-	n := execgen.LEN(toCol)
-	toColSliced := execgen.SLICE(toCol, int(args.DestIdx), n)
 	for i := range sel[args.SrcStartIdx:args.SrcEndIdx] {
 		selIdx := sel[int(args.SrcStartIdx)+i]
 		v := execgen.UNSAFEGET(fromCol, int(selIdx))
 		// {{if .SelOnDest}}
-		execgen.SET(toColSliced, int(selIdx), v)
+		execgen.SET(toCol, int(selIdx), v)
 		// {{else}}
-		execgen.SET(toColSliced, i, v)
+		execgen.SET(toCol, i, v)
 		// {{end}}
 	}
 	// {{end}}
@@ -168,6 +164,7 @@ func (m *memColumn) Slice(colType coltypes.T, start uint64, end uint64) Vec {
 	case _TYPES_T:
 		col := m._TemplateType()
 		return &memColumn{
+			t:     colType,
 			col:   execgen.SLICE(col, int(start), int(end)),
 			nulls: m.nulls.Slice(start, end),
 		}

--- a/pkg/col/coldata/vec_tmpl.go
+++ b/pkg/col/coldata/vec_tmpl.go
@@ -47,7 +47,7 @@ var _ apd.Decimal
 
 // */}}
 
-func (m *memColumn) Append(args AppendArgs) {
+func (m *memColumn) Append(args SliceArgs) {
 	switch args.ColType {
 	// {{range .}}
 	case _TYPES_T:
@@ -66,7 +66,7 @@ func (m *memColumn) Append(args AppendArgs) {
 				execgen.APPENDVAL(toCol, val)
 			}
 		}
-		m.nulls.append(args)
+		m.nulls.set(args)
 		m.col = toCol
 	// {{end}}
 	default:
@@ -76,7 +76,7 @@ func (m *memColumn) Append(args AppendArgs) {
 
 // {{/*
 func _COPY_WITH_SEL(
-	m *memColumn, args CopyArgs, fromCol, toCol _GOTYPESLICE, sel interface{}, _SEL_ON_DEST bool,
+	m *memColumn, args CopySliceArgs, fromCol, toCol _GOTYPESLICE, sel interface{}, _SEL_ON_DEST bool,
 ) { // */}}
 	// {{define "copyWithSel"}}
 	if args.Src.MaybeHasNulls() {
@@ -111,7 +111,7 @@ func _COPY_WITH_SEL(
 
 // */}}
 
-func (m *memColumn) Copy(args CopyArgs) {
+func (m *memColumn) Copy(args CopySliceArgs) {
 	m.Nulls().UnsetNullRange(args.DestIdx, args.DestIdx+(args.SrcEndIdx-args.SrcStartIdx))
 
 	switch args.ColType {
@@ -138,7 +138,7 @@ func (m *memColumn) Copy(args CopyArgs) {
 		}
 		// No Sel or Sel64.
 		execgen.COPYSLICE(toCol, fromCol, int(args.DestIdx), int(args.SrcStartIdx), int(args.SrcEndIdx))
-		m.nulls.copy(args)
+		m.nulls.set(args.SliceArgs)
 	// {{end}}
 	default:
 		panic(fmt.Sprintf("unhandled type %s", args.ColType))

--- a/pkg/col/colserde/arrowbatchconverter_test.go
+++ b/pkg/col/colserde/arrowbatchconverter_test.go
@@ -61,10 +61,12 @@ func copyBatch(original coldata.Batch) coldata.Batch {
 	b := coldata.NewMemBatchWithSize(typs, int(original.Length()))
 	b.SetLength(original.Length())
 	for colIdx, col := range original.ColVecs() {
-		b.ColVec(colIdx).Copy(coldata.CopyArgs{
-			ColType:   typs[colIdx],
-			Src:       col,
-			SrcEndIdx: uint64(original.Length()),
+		b.ColVec(colIdx).Copy(coldata.CopySliceArgs{
+			SliceArgs: coldata.SliceArgs{
+				ColType:   typs[colIdx],
+				Src:       col,
+				SrcEndIdx: uint64(original.Length()),
+			},
 		})
 	}
 	return b

--- a/pkg/col/coltypes/types.go
+++ b/pkg/col/coltypes/types.go
@@ -142,7 +142,6 @@ var (
 	_ = Bool.GoTypeSliceName
 	_ = Bool.Get
 	_ = Bool.Set
-	_ = Bool.Swap
 	_ = Bool.Slice
 	_ = Bool.CopySlice
 	_ = Bool.CopyVal
@@ -190,35 +189,6 @@ func (t T) Set(target, i, new string) string {
 		return fmt.Sprintf("%s[%s].Set(&%s)", target, i, new)
 	}
 	return fmt.Sprintf("%s[%s] = %s", target, i, new)
-}
-
-// Swap is a function that should only be used in templates.
-func (t T) Swap(target, i, j string) string {
-	var tmpl string
-	switch t {
-	case Bytes:
-		tmpl = `{{.Tgt}}.Swap({{.I}}, {{.J}})`
-	case Decimal:
-		tmpl = `
-{
-  var __tmp apd.Decimal
-  __tmp.Set(&{{.Tgt}}[{{.I}}])
-  {{.Tgt}}[{{.I}}].Set(&{{.Tgt}}[{{.J}}])
-  {{.Tgt}}[{{.J}}].Set(&{{.Tgt}}[{{.I}}])
-}`
-	default:
-		tmpl = `{{.Tgt}}[{{.I}}], {{.Tgt}}[{{.J}}] = {{.Tgt}}[{{.J}}], {{.Tgt}}[{{.I}}]`
-	}
-	args := map[string]string{
-		"Tgt": target,
-		"I":   j,
-		"J":   j,
-	}
-	var buf strings.Builder
-	if err := template.Must(template.New("").Parse(tmpl)).Execute(&buf, args); err != nil {
-		panic(err)
-	}
-	return buf.String()
 }
 
 // Slice is a function that should only be used in templates.

--- a/pkg/sql/exec/aggregator.go
+++ b/pkg/sql/exec/aggregator.go
@@ -267,11 +267,13 @@ func (a *orderedAggregator) Next(ctx context.Context) coldata.Batch {
 			// According to the aggregate function interface contract, the value at
 			// the current index must also be copied.
 			a.scratch.ColVec(i).Copy(
-				coldata.CopyArgs{
-					Src:         a.scratch.ColVec(i),
-					ColType:     a.outputTypes[i],
-					SrcStartIdx: uint64(a.scratch.outputSize),
-					SrcEndIdx:   uint64(a.scratch.resumeIdx + 1),
+				coldata.CopySliceArgs{
+					SliceArgs: coldata.SliceArgs{
+						Src:         a.scratch.ColVec(i),
+						ColType:     a.outputTypes[i],
+						SrcStartIdx: uint64(a.scratch.outputSize),
+						SrcEndIdx:   uint64(a.scratch.resumeIdx + 1),
+					},
 				},
 			)
 			a.aggregateFuncs[i].SetOutputIndex(newResumeIdx)

--- a/pkg/sql/exec/case.go
+++ b/pkg/sql/exec/case.go
@@ -139,13 +139,15 @@ func (c *caseOp) Next(ctx context.Context) coldata.Batch {
 		// Copy the results into the output vector, using the toSubtract selection
 		// vector to copy only the elements that we actually wrote according to the
 		// current case arm.
-		outputCol.Copy(coldata.CopyArgs{
-			ColType:     c.typ,
-			Src:         inputCol,
-			Sel:         toSubtract,
-			SrcStartIdx: 0,
-			SrcEndIdx:   uint64(len(toSubtract)),
-			SelOnDest:   true,
+		outputCol.Copy(coldata.CopySliceArgs{
+			SliceArgs: coldata.SliceArgs{
+				ColType:     c.typ,
+				Src:         inputCol,
+				Sel:         toSubtract,
+				SrcStartIdx: 0,
+				SrcEndIdx:   uint64(len(toSubtract)),
+			},
+			SelOnDest: true,
 		})
 		if oldSel := c.buffer.batch.Batch.Selection(); oldSel != nil {
 			// We have an old selection vector, which represents the tuples that
@@ -188,13 +190,15 @@ func (c *caseOp) Next(ctx context.Context) coldata.Batch {
 	// that's done, restore the original selection vector and return the batch.
 	batch := c.elseOp.Next(ctx)
 	inputCol := c.buffer.batch.Batch.ColVec(c.thenIdxs[len(c.thenIdxs)-1])
-	outputCol.Copy(coldata.CopyArgs{
-		ColType:     c.typ,
-		Src:         inputCol,
-		Sel:         batch.Selection(),
-		SrcStartIdx: 0,
-		SrcEndIdx:   uint64(batch.Length()),
-		SelOnDest:   true,
+	outputCol.Copy(coldata.CopySliceArgs{
+		SliceArgs: coldata.SliceArgs{
+			ColType:     c.typ,
+			Src:         inputCol,
+			Sel:         batch.Selection(),
+			SrcStartIdx: 0,
+			SrcEndIdx:   uint64(batch.Length()),
+		},
+		SelOnDest: true,
 	})
 	batch.SetLength(origLen)
 	batch.SetSelection(origHasSel)

--- a/pkg/sql/exec/coalescer.go
+++ b/pkg/sql/exec/coalescer.go
@@ -75,32 +75,34 @@ func (p *coalescerOp) Next(ctx context.Context) coldata.Batch {
 
 			if batchSize <= leftover {
 				toCol.Append(
-					coldata.AppendArgs{
+					coldata.SliceArgs{
 						ColType:   t,
 						Src:       fromCol,
 						Sel:       sel,
 						DestIdx:   uint64(p.group.Length()),
-						SrcEndIdx: batchSize,
+						SrcEndIdx: uint64(batchSize),
 					},
 				)
 			} else {
 				bufferCol := p.buffer.ColVec(i)
 				toCol.Append(
-					coldata.AppendArgs{
+					coldata.SliceArgs{
 						ColType:   t,
 						Src:       fromCol,
 						Sel:       sel,
 						DestIdx:   uint64(p.group.Length()),
-						SrcEndIdx: leftover,
+						SrcEndIdx: uint64(leftover),
 					},
 				)
 				bufferCol.Copy(
-					coldata.CopyArgs{
-						ColType:     t,
-						Src:         fromCol,
-						Sel:         sel,
-						SrcStartIdx: uint64(leftover),
-						SrcEndIdx:   uint64(batchSize),
+					coldata.CopySliceArgs{
+						SliceArgs: coldata.SliceArgs{
+							ColType:     t,
+							Src:         fromCol,
+							Sel:         sel,
+							SrcStartIdx: uint64(leftover),
+							SrcEndIdx:   uint64(batchSize),
+						},
 					},
 				)
 			}

--- a/pkg/sql/exec/colrpc/colrpc_test.go
+++ b/pkg/sql/exec/colrpc/colrpc_test.go
@@ -269,10 +269,10 @@ func TestOutboxInbox(t *testing.T) {
 				batchCopy := coldata.NewMemBatchWithSize(typs, int(outputBatch.Length()))
 				for i := range typs {
 					batchCopy.ColVec(i).Append(
-						coldata.AppendArgs{
+						coldata.SliceArgs{
 							ColType:   typs[i],
 							Src:       outputBatch.ColVec(i),
-							SrcEndIdx: outputBatch.Length(),
+							SrcEndIdx: uint64(outputBatch.Length()),
 						},
 					)
 				}

--- a/pkg/sql/exec/deselector.go
+++ b/pkg/sql/exec/deselector.go
@@ -57,11 +57,13 @@ func (p *deselectorOp) Next(ctx context.Context) coldata.Batch {
 		toCol := p.output.ColVec(i)
 		fromCol := batch.ColVec(i)
 		toCol.Copy(
-			coldata.CopyArgs{
-				ColType:   t,
-				Src:       fromCol,
-				Sel:       sel,
-				SrcEndIdx: uint64(batch.Length()),
+			coldata.CopySliceArgs{
+				SliceArgs: coldata.SliceArgs{
+					ColType:   t,
+					Src:       fromCol,
+					Sel:       sel,
+					SrcEndIdx: uint64(batch.Length()),
+				},
 			},
 		)
 	}

--- a/pkg/sql/exec/execgen/cmd/execgen/data_manipulation_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/data_manipulation_gen.go
@@ -40,11 +40,6 @@ var dataManipulationReplacementInfos = []dataManipulationReplacementInfo{
 		replaceWith:         "Set",
 	},
 	{
-		templatePlaceholder: "execgen.SWAP",
-		numArgs:             3,
-		replaceWith:         "Swap",
-	},
-	{
 		templatePlaceholder: "execgen.SLICE",
 		numArgs:             3,
 		replaceWith:         "Slice",

--- a/pkg/sql/exec/execgen/cmd/execgen/vec_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/vec_gen.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
-func genColvec(wr io.Writer) error {
+func genVec(wr io.Writer) error {
 	d, err := ioutil.ReadFile("pkg/col/coldata/vec_tmpl.go")
 	if err != nil {
 		return err
@@ -45,5 +45,5 @@ func genColvec(wr io.Writer) error {
 	return tmpl.Execute(wr, sameTypeComparisonOpToOverloads[tree.NE])
 }
 func init() {
-	registerGenerator(genColvec, "vec.eg.go")
+	registerGenerator(genVec, "vec.eg.go")
 }

--- a/pkg/sql/exec/execgen/placeholders.go
+++ b/pkg/sql/exec/execgen/placeholders.go
@@ -19,7 +19,6 @@ var (
 	_ = UNSAFEGET
 	_ = COPYVAL
 	_ = SET
-	_ = SWAP
 	_ = SLICE
 	_ = COPYSLICE
 	_ = APPENDSLICE
@@ -46,11 +45,6 @@ func COPYVAL(dest, src interface{}) {
 
 // SET is a template function.
 func SET(target, i, new interface{}) {
-	execerror.VectorizedInternalPanic(nonTemplatePanic)
-}
-
-// SWAP is a template function.
-func SWAP(target, i, j interface{}) {
 	execerror.VectorizedInternalPanic(nonTemplatePanic)
 }
 

--- a/pkg/sql/exec/hash_aggregator.go
+++ b/pkg/sql/exec/hash_aggregator.go
@@ -243,12 +243,14 @@ func (op *hashGrouper) Next(ctx context.Context) coldata.Batch {
 		toCol := op.batch.ColVec(i)
 		fromCol := op.ht.vals[colIdx]
 		toCol.Copy(
-			coldata.CopyArgs{
-				ColType:     op.ht.valTypes[op.ht.outCols[i]],
-				Src:         fromCol,
-				Sel64:       op.sel,
-				SrcStartIdx: op.batchStart,
-				SrcEndIdx:   batchEnd,
+			coldata.CopySliceArgs{
+				SliceArgs: coldata.SliceArgs{
+					ColType:     op.ht.valTypes[op.ht.outCols[i]],
+					Src:         fromCol,
+					SrcStartIdx: op.batchStart,
+					SrcEndIdx:   batchEnd,
+				},
+				Sel64: op.sel,
 			},
 		)
 	}

--- a/pkg/sql/exec/hashjoiner.go
+++ b/pkg/sql/exec/hashjoiner.go
@@ -313,11 +313,13 @@ func (hj *hashJoinEqOp) emitUnmatched() {
 		colType := hj.ht.valTypes[hj.ht.outCols[i]]
 
 		outCol.Copy(
-			coldata.CopyArgs{
-				ColType:   colType,
-				Src:       valCol,
-				Sel64:     hj.prober.buildIdx,
-				SrcEndIdx: uint64(nResults),
+			coldata.CopySliceArgs{
+				SliceArgs: coldata.SliceArgs{
+					ColType:   colType,
+					Src:       valCol,
+					SrcEndIdx: uint64(nResults),
+				},
+				Sel64: hj.prober.buildIdx,
 			},
 		)
 	}
@@ -505,12 +507,12 @@ func (ht *hashTable) loadBatch(batch coldata.Batch) {
 	batchSize := batch.Length()
 	for i, colIdx := range ht.valCols {
 		ht.vals[i].Append(
-			coldata.AppendArgs{
+			coldata.SliceArgs{
 				ColType:   ht.valTypes[i],
 				Src:       batch.ColVec(int(colIdx)),
 				Sel:       batch.Selection(),
 				DestIdx:   ht.size,
-				SrcEndIdx: batchSize,
+				SrcEndIdx: uint64(batchSize),
 			},
 		)
 	}
@@ -960,11 +962,13 @@ func (prober *hashJoinProber) congregate(nResults uint16, batch coldata.Batch, b
 		colType := prober.ht.valTypes[prober.ht.outCols[i]]
 
 		outCol.Copy(
-			coldata.CopyArgs{
-				ColType:   colType,
-				Src:       valCol,
-				Sel64:     prober.buildIdx,
-				SrcEndIdx: uint64(nResults),
+			coldata.CopySliceArgs{
+				SliceArgs: coldata.SliceArgs{
+					ColType:   colType,
+					Src:       valCol,
+					SrcEndIdx: uint64(nResults),
+				},
+				Sel64: prober.buildIdx,
 			},
 		)
 		if prober.spec.outer {
@@ -984,11 +988,13 @@ func (prober *hashJoinProber) congregate(nResults uint16, batch coldata.Batch, b
 		colType := prober.spec.sourceTypes[colIdx]
 
 		outCol.Copy(
-			coldata.CopyArgs{
-				ColType:   colType,
-				Src:       valCol,
-				Sel:       prober.probeIdx,
-				SrcEndIdx: uint64(nResults),
+			coldata.CopySliceArgs{
+				SliceArgs: coldata.SliceArgs{
+					ColType:   colType,
+					Src:       valCol,
+					Sel:       prober.probeIdx,
+					SrcEndIdx: uint64(nResults),
+				},
 			},
 		)
 	}

--- a/pkg/sql/exec/mergejoiner.go
+++ b/pkg/sql/exec/mergejoiner.go
@@ -406,22 +406,6 @@ func (o *mergeJoinBase) appendToBufferedGroup(
 				SrcEndIdx:   uint16(groupEndIdx),
 			},
 		)
-		if sel != nil {
-			bufferedGroup.ColVec(cIdx).Nulls().ExtendWithSel(
-				batch.ColVec(cIdx).Nulls(),
-				destStartIdx,
-				uint16(groupStartIdx),
-				uint16(groupLength),
-				sel,
-			)
-		} else {
-			bufferedGroup.ColVec(cIdx).Nulls().Extend(
-				batch.ColVec(cIdx).Nulls(),
-				destStartIdx,
-				uint16(groupStartIdx),
-				uint16(groupLength),
-			)
-		}
 	}
 
 	// We've added groupLength number of tuples to bufferedGroup, so we need to

--- a/pkg/sql/exec/mergejoiner.go
+++ b/pkg/sql/exec/mergejoiner.go
@@ -397,13 +397,13 @@ func (o *mergeJoinBase) appendToBufferedGroup(
 	groupEndIdx := groupStartIdx + groupLength
 	for cIdx, cType := range input.sourceTypes {
 		bufferedGroup.ColVec(cIdx).Append(
-			coldata.AppendArgs{
+			coldata.SliceArgs{
 				ColType:     cType,
 				Src:         batch.ColVec(cIdx),
 				Sel:         sel,
 				DestIdx:     destStartIdx,
-				SrcStartIdx: uint16(groupStartIdx),
-				SrcEndIdx:   uint16(groupEndIdx),
+				SrcStartIdx: uint64(groupStartIdx),
+				SrcEndIdx:   uint64(groupEndIdx),
 			},
 		)
 	}

--- a/pkg/sql/exec/mergejoiner_tmpl.go
+++ b/pkg/sql/exec/mergejoiner_tmpl.go
@@ -805,13 +805,15 @@ func _RIGHT_SWITCH(_JOIN_TYPE joinTypeInfo, _HAS_SELECTION bool, _HAS_NULLS bool
 						// {{ end }}
 					} else {
 						out.Copy(
-							coldata.CopyArgs{
-								ColType:     colType,
-								Src:         src,
-								Sel:         sel,
-								DestIdx:     uint64(outStartIdx),
-								SrcStartIdx: uint64(o.builderState.right.curSrcStartIdx),
-								SrcEndIdx:   uint64(o.builderState.right.curSrcStartIdx + toAppend),
+							coldata.CopySliceArgs{
+								SliceArgs: coldata.SliceArgs{
+									ColType:     colType,
+									Src:         src,
+									Sel:         sel,
+									DestIdx:     uint64(outStartIdx),
+									SrcStartIdx: uint64(o.builderState.right.curSrcStartIdx),
+									SrcEndIdx:   uint64(o.builderState.right.curSrcStartIdx + toAppend),
+								},
 							},
 						)
 					}

--- a/pkg/sql/exec/orderedsynchronizer.go
+++ b/pkg/sql/exec/orderedsynchronizer.go
@@ -103,12 +103,12 @@ func (o *OrderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 				srcStartIdx = sel[srcStartIdx]
 			}
 			o.output.ColVec(i).Append(
-				coldata.AppendArgs{
+				coldata.SliceArgs{
 					ColType:     o.columnTypes[i],
 					Src:         vec,
 					DestIdx:     uint64(outputIdx),
-					SrcStartIdx: srcStartIdx,
-					SrcEndIdx:   srcStartIdx + 1,
+					SrcStartIdx: uint64(srcStartIdx),
+					SrcEndIdx:   uint64(srcStartIdx + 1),
 				},
 			)
 		}

--- a/pkg/sql/exec/routers.go
+++ b/pkg/sql/exec/routers.go
@@ -217,12 +217,12 @@ func (o *routerOutputOp) addBatch(batch coldata.Batch, selection []uint16) bool 
 
 		for i, t := range o.types {
 			dst.ColVec(i).Append(
-				coldata.AppendArgs{
+				coldata.SliceArgs{
 					ColType:   t,
 					Src:       batch.ColVec(i),
 					Sel:       selection,
 					DestIdx:   uint64(dst.Length()),
-					SrcEndIdx: uint16(len(selection)),
+					SrcEndIdx: uint64(len(selection)),
 				},
 			)
 		}

--- a/pkg/sql/exec/sort.go
+++ b/pkg/sql/exec/sort.go
@@ -120,12 +120,12 @@ func (p *allSpooler) spool(ctx context.Context) {
 	for ; batch.Length() != 0; batch = p.input.Next(ctx) {
 		for i := 0; i < len(p.values); i++ {
 			p.values[i].Append(
-				coldata.AppendArgs{
+				coldata.SliceArgs{
 					ColType:   p.inputTypes[i],
 					Src:       batch.ColVec(i),
 					Sel:       batch.Selection(),
 					DestIdx:   nTuples,
-					SrcEndIdx: batch.Length(),
+					SrcEndIdx: uint64(batch.Length()),
 				},
 			)
 		}
@@ -250,12 +250,14 @@ func (p *sortOp) Next(ctx context.Context) coldata.Batch {
 
 		for j := 0; j < len(p.inputTypes); j++ {
 			p.output.ColVec(j).Copy(
-				coldata.CopyArgs{
-					ColType:     p.inputTypes[j],
-					Src:         p.input.getValues(j),
-					Sel64:       p.order,
-					SrcStartIdx: p.emitted,
-					SrcEndIdx:   p.emitted + uint64(p.output.Length()),
+				coldata.CopySliceArgs{
+					SliceArgs: coldata.SliceArgs{
+						ColType:     p.inputTypes[j],
+						Src:         p.input.getValues(j),
+						SrcStartIdx: p.emitted,
+						SrcEndIdx:   p.emitted + uint64(p.output.Length()),
+					},
+					Sel64: p.order,
 				},
 			)
 		}

--- a/pkg/sql/exec/sort_chunks.go
+++ b/pkg/sql/exec/sort_chunks.go
@@ -360,12 +360,12 @@ func (s *chunker) prepareNextChunks(ctx context.Context) chunkerReadingState {
 func (s *chunker) buffer(start uint16, end uint16) {
 	for i := 0; i < len(s.bufferedColumns); i++ {
 		s.bufferedColumns[i].Append(
-			coldata.AppendArgs{
+			coldata.SliceArgs{
 				ColType:     s.inputTypes[i],
 				Src:         s.batch.ColVec(i),
 				DestIdx:     s.buffered,
-				SrcStartIdx: start,
-				SrcEndIdx:   end,
+				SrcStartIdx: uint64(start),
+				SrcEndIdx:   uint64(end),
 			},
 		)
 	}

--- a/pkg/sql/exec/sorttopk.go
+++ b/pkg/sql/exec/sorttopk.go
@@ -131,12 +131,12 @@ func (t *topKSorter) spool(ctx context.Context) {
 			vec := inputBatch.ColVec(i)
 			colType := t.inputTypes[i]
 			destVec.Append(
-				coldata.AppendArgs{
+				coldata.SliceArgs{
 					ColType:   colType,
 					Src:       vec,
 					Sel:       inputBatch.Selection(),
 					DestIdx:   toLength,
-					SrcEndIdx: fromLength,
+					SrcEndIdx: uint64(fromLength),
 				},
 			)
 		}
@@ -202,11 +202,13 @@ func (t *topKSorter) emit() coldata.Batch {
 	for i := range t.inputTypes {
 		vec := t.output.ColVec(i)
 		vec.Copy(
-			coldata.CopyArgs{
-				ColType:   t.inputTypes[i],
-				Src:       t.topK.ColVec(i),
-				Sel:       t.sel,
-				SrcEndIdx: uint64(toEmit),
+			coldata.CopySliceArgs{
+				SliceArgs: coldata.SliceArgs{
+					ColType:   t.inputTypes[i],
+					Src:       t.topK.ColVec(i),
+					Sel:       t.sel,
+					SrcEndIdx: uint64(toEmit),
+				},
 			},
 		)
 	}


### PR DESCRIPTION
**coldata: clean up the templates**

This commit makes several tweaks to the templates:
- in vec_tmpl:
    - remove slicing in _COPY_WITH_SEL. I think it was neither accomplishing
      its goal of bounds check elimination nor was actually correct.
    - add a type information to a slice of Vec.
- rename the generator file.
- remove SWAP placeholder since it's not used anymore.
- rename SwapNulls to swap so that is unexported, but it is not removed just
  case we need it later since it contains non-trivial logic.

**coldata: combine two Nulls.Extend variations into one method**

This commit combines Extend and ExtendWithSel into one method
'duplicate' which is now unexported and is called as part of
Vec.Copy and Vec.Append methods.

**coldata: extract out "core" slice args from AppendArgs and CopyArgs**

Both AppendArgs and CopyArgs had the same "core" which is now extracted
as SliceArgs. CopySliceArgs is now an extension of SliceArgs. This allows
for unifying the interfaces a little bit. Also, Nulls.duplicate is
renamed to Nulls.set.

Release note: None