### PR TITLE
Diagram changes for documentation

### DIFF
--- a/docs/generated/sql/bnf/comment.bnf
+++ b/docs/generated/sql/bnf/comment.bnf
@@ -1,5 +1,5 @@
 comment_stmt ::=
 	'COMMENT' 'ON' 'DATABASE' database_name 'IS' comment_text
 	| 'COMMENT' 'ON' 'TABLE' table_name 'IS' comment_text
-	| 'COMMENT' 'ON' 'COLUMN' column_path 'IS' comment_text
+	| 'COMMENT' 'ON' 'COLUMN' column_name 'IS' comment_text
 	| 'COMMENT' 'ON' 'INDEX' table_index_name 'IS' comment_text

--- a/docs/generated/sql/bnf/create_as_col_qual_list.bnf
+++ b/docs/generated/sql/bnf/create_as_col_qual_list.bnf
@@ -1,0 +1,2 @@
+create_as_col_qual_list ::=
+	 ( ( ( ( 'PRIMARY' 'KEY' ) | 'FAMILY' family_name ) ) )*

--- a/docs/generated/sql/bnf/create_as_constraint_def.bnf
+++ b/docs/generated/sql/bnf/create_as_constraint_def.bnf
@@ -1,0 +1,2 @@
+create_as_constraint_def ::=
+	'PRIMARY' 'KEY' '(' create_as_params ')'

--- a/docs/generated/sql/bnf/create_table_as_stmt.bnf
+++ b/docs/generated/sql/bnf/create_table_as_stmt.bnf
@@ -1,3 +1,5 @@
 create_table_as_stmt ::=
-	'CREATE' opt_temp_create_table 'TABLE' table_name create_as_opt_col_list 'AS' select_stmt
-	| 'CREATE' opt_temp_create_table 'TABLE' 'IF' 'NOT' 'EXISTS' table_name create_as_opt_col_list 'AS' select_stmt
+	'CREATE' opt_temp_create_table 'TABLE' table_name '(' column_name create_as_col_qual_list ( ( ',' column_name create_as_col_qual_list | ',' family_def | ',' create_as_constraint_def ) )* ')' 'AS' select_stmt
+	| 'CREATE' opt_temp_create_table 'TABLE' table_name  'AS' select_stmt
+	| 'CREATE' opt_temp_create_table 'TABLE' 'IF' 'NOT' 'EXISTS' table_name '(' column_name create_as_col_qual_list ( ( ',' column_name create_as_col_qual_list | ',' family_def | ',' create_as_constraint_def ) )* ')' 'AS' select_stmt
+	| 'CREATE' opt_temp_create_table 'TABLE' 'IF' 'NOT' 'EXISTS' table_name  'AS' select_stmt

--- a/docs/generated/sql/bnf/explain_analyze_stmt.bnf
+++ b/docs/generated/sql/bnf/explain_analyze_stmt.bnf
@@ -1,3 +1,5 @@
 explain_stmt ::=
 	'EXPLAIN' 'ANALYZE' preparable_stmt
+	| 'EXPLAIN' 'ANALYSE' preparable_stmt
 	| 'EXPLAIN' 'ANALYZE' '(' 'DISTSQL' ')' preparable_stmt
+	| 'EXPLAIN' 'ANALYSE' '(' 'DISTSQL' ')' preparable_stmt

--- a/docs/generated/sql/bnf/explain_stmt.bnf
+++ b/docs/generated/sql/bnf/explain_stmt.bnf
@@ -1,5 +1,3 @@
 explain_stmt ::=
 	'EXPLAIN' preparable_stmt
-	| 'EXPLAIN' '(' ( 'VERBOSE' | 'TYPES' | 'OPT' | 'DISTSQL' ) ( ( ',' ( 'VERBOSE' | 'TYPES' | 'OPT' | 'DISTSQL' ) ) )* ')' preparable_stmt
-	| 'EXPLAIN' 'ANALYSE' preparable_stmt
-	| 'EXPLAIN' 'ANALYSE' '(' ( 'VERBOSE' | 'TYPES' | 'OPT' | 'DISTSQL' ) ( ( ',' ( 'VERBOSE' | 'TYPES' | 'OPT' | 'DISTSQL' ) ) )* ')' preparable_stmt
+	| 'EXPLAIN' '(' ( 'VERBOSE' | 'TYPES' | 'OPT' | 'DISTSQL' | 'VEC' ) ( ( ',' ( 'VERBOSE' | 'TYPES' | 'OPT' | 'DISTSQL' | 'VEC' ) ) )* ')' preparable_stmt

--- a/docs/generated/sql/bnf/opt_frame_clause.bnf
+++ b/docs/generated/sql/bnf/opt_frame_clause.bnf
@@ -1,0 +1,7 @@
+opt_frame_clause ::=
+	'RANGE' frame_bound opt_frame_exclusion
+	| 'RANGE' 'BETWEEN' frame_bound 'AND' frame_bound opt_frame_exclusion
+	| 'ROWS' frame_bound opt_frame_exclusion
+	| 'ROWS' 'BETWEEN' frame_bound 'AND' frame_bound opt_frame_exclusion
+	| 'GROUPS' frame_bound opt_frame_exclusion
+	| 'GROUPS' 'BETWEEN' frame_bound 'AND' frame_bound opt_frame_exclusion

--- a/docs/generated/sql/bnf/show_columns_stmt.bnf
+++ b/docs/generated/sql/bnf/show_columns_stmt.bnf
@@ -1,0 +1,3 @@
+show_columns_stmt ::=
+	'SHOW' 'COLUMNS' 'FROM' table_name 'WITH' 'COMMENT'
+	| 'SHOW' 'COLUMNS' 'FROM' table_name 

--- a/docs/generated/sql/bnf/show_databases_stmt.bnf
+++ b/docs/generated/sql/bnf/show_databases_stmt.bnf
@@ -1,0 +1,3 @@
+show_databases_stmt ::=
+	'SHOW' 'DATABASES' 'WITH' 'COMMENT'
+	| 'SHOW' 'DATABASES' 

--- a/docs/generated/sql/bnf/show_indexes.bnf
+++ b/docs/generated/sql/bnf/show_indexes.bnf
@@ -1,0 +1,7 @@
+show_indexes_stmt ::=
+	'SHOW' 'INDEX' 'FROM' table_name with_comment
+	| 'SHOW' 'INDEX' 'FROM' 'DATABASE' database_name with_comment
+	| 'SHOW' 'INDEXES' 'FROM' table_name with_comment
+	| 'SHOW' 'INDEXES' 'FROM' 'DATABASE' database_name with_comment
+	| 'SHOW' 'KEYS' 'FROM' table_name with_comment
+	| 'SHOW' 'KEYS' 'FROM' 'DATABASE' database_name with_comment

--- a/docs/generated/sql/bnf/show_locality.bnf
+++ b/docs/generated/sql/bnf/show_locality.bnf
@@ -1,0 +1,2 @@
+show_roles_stmt ::=
+	'SHOW' 'LOCALITY'

--- a/docs/generated/sql/bnf/show_partitions_stmt.bnf
+++ b/docs/generated/sql/bnf/show_partitions_stmt.bnf
@@ -1,0 +1,5 @@
+show_partitions_stmt ::=
+	'SHOW' 'PARTITIONS' 'FROM' 'TABLE' table_name
+	| 'SHOW' 'PARTITIONS' 'FROM' 'DATABASE' database_name
+	| 'SHOW' 'PARTITIONS' 'FROM' 'INDEX' table_index_name
+	| 'SHOW' 'PARTITIONS' 'FROM' 'INDEX' table_name '@' '*'

--- a/docs/generated/sql/bnf/show_range_for_row_stmt.bnf
+++ b/docs/generated/sql/bnf/show_range_for_row_stmt.bnf
@@ -1,0 +1,3 @@
+show_range_for_row_stmt ::=
+	'SHOW' 'RANGE' 'FROM' 'TABLE' table_name 'FOR' 'ROW' '(' row_vals ( ( ',' row_vals ) )* ')'
+	| 'SHOW' 'RANGE' 'FROM' 'INDEX' table_index_name 'FOR' 'ROW' '(' row_vals ( ( ',' row_vals ) )* ')'

--- a/docs/generated/sql/bnf/unsplit_index_at.bnf
+++ b/docs/generated/sql/bnf/unsplit_index_at.bnf
@@ -1,0 +1,5 @@
+alter_unsplit_index_stmt ::=
+	'ALTER' 'INDEX' table_name '@' index_name 'UNSPLIT' 'AT' select_stmt
+	| 'ALTER' 'INDEX' standalone_index_name 'UNSPLIT' 'AT' select_stmt
+	| 'ALTER' 'INDEX' table_name '@' index_name 'UNSPLIT' 'ALL'
+	| 'ALTER' 'INDEX' standalone_index_name 'UNSPLIT' 'ALL'

--- a/docs/generated/sql/bnf/unsplit_table_at.bnf
+++ b/docs/generated/sql/bnf/unsplit_table_at.bnf
@@ -1,0 +1,3 @@
+alter_unsplit_stmt ::=
+	'ALTER' 'TABLE' table_name 'UNSPLIT' 'AT' select_stmt
+	| 'ALTER' 'TABLE' table_name 'UNSPLIT' 'ALL'

--- a/docs/generated/sql/bnf/window_definition.bnf
+++ b/docs/generated/sql/bnf/window_definition.bnf
@@ -1,0 +1,2 @@
+window_definition ::=
+	window_name 'AS' '(' opt_existing_window_name opt_partition_clause opt_sort_clause opt_frame_clause ')'


### PR DESCRIPTION
Added changes to `diagrams.go` for the following statements:
- `SHOW PARTITIONS`
- `SHOW LOCALITY` (this change is a little hacky due to the fact that `SHOW LOCALITY` is, in fact, not defined in the SQL grammar... see #39058)
- `SHOW CREATE TABLE AS`
- `SHOW COLUMNS` (`WITH COMMENT`)
- `SHOW DATABASES` (`WITH COMMENT`)

@mjibson Adding you as reviewer because you created this generator.

Release note (docs): none