### PR TITLE
storage: remove span declaration for merges

### DIFF
--- a/pkg/storage/batcheval/cmd_end_transaction.go
+++ b/pkg/storage/batcheval/cmd_end_transaction.go
@@ -124,21 +124,11 @@ func declareKeysEndTransaction(
 					EndKey: abortspan.MaxKey(header.RangeID)})
 			}
 			if mt := et.InternalCommitTrigger.MergeTrigger; mt != nil {
-				// Merges write to the left side's abort span and the right side's data
-				// and range-local spans. They also read from the right side's range ID
-				// span.
-				leftRangeIDPrefix := keys.MakeRangeIDReplicatedPrefix(header.RangeID)
+				// Merges copy over the RHS abort span to the LHS, and compute
+				// replicated range ID stats over the RHS in the merge trigger.
 				spans.Add(spanset.SpanReadWrite, roachpb.Span{
-					Key:    leftRangeIDPrefix,
-					EndKey: leftRangeIDPrefix.PrefixEnd(),
-				})
-				spans.Add(spanset.SpanReadWrite, roachpb.Span{
-					Key:    mt.RightDesc.StartKey.AsRawKey(),
-					EndKey: mt.RightDesc.EndKey.AsRawKey(),
-				})
-				spans.Add(spanset.SpanReadWrite, roachpb.Span{
-					Key:    keys.MakeRangeKeyPrefix(mt.RightDesc.StartKey),
-					EndKey: keys.MakeRangeKeyPrefix(mt.RightDesc.EndKey),
+					Key:    abortspan.MinKey(mt.LeftDesc.RangeID),
+					EndKey: abortspan.MaxKey(mt.LeftDesc.RangeID).PrefixEnd(),
 				})
 				spans.Add(spanset.SpanReadOnly, roachpb.Span{
 					Key:    keys.MakeRangeIDReplicatedPrefix(mt.RightDesc.RangeID),
@@ -1034,8 +1024,8 @@ func splitTriggerHelper(
 }
 
 // mergeTrigger is called on a successful commit of an AdminMerge transaction.
-// It writes data from the right-hand range into the left-hand range and
-// recomputes stats for the left-hand range.
+// It calculates stats for the LHS by merging in RHS stats, and copies over the
+// abort span entries from the RHS.
 func mergeTrigger(
 	ctx context.Context,
 	rec EvalContext,

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -515,7 +515,7 @@ func (r *Replica) executeAdminCommandWithDescriptor(
 // hand side range (the subsumed range). It also updates the range
 // addressing metadata. The handover of responsibility for the
 // reassigned key range is carried out seamlessly through a merge
-// trigger carried out as part of the commit of that transaction.  A
+// trigger carried out as part of the commit of that transaction. A
 // merge requires that the two ranges are collocated on the same set
 // of replicas.
 //


### PR DESCRIPTION
Prior to #28661, we used to include a snapshot of the RHS in the merge
trigger. Due to this, we declared a read only span over the RHS data
range. Now that we require ranges to be collocated during merges, we
didn't need to include the snapshot nor declare the span. 
Also informs #32583.

Orthogonal to this are Subsume requests that block out concurrent
commands to the RHS, with the appropriate span declarations contained
therein.

Release note: None