### PR TITLE
tree: make int::regtype::text O(1)

### DIFF
--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3017,7 +3017,7 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 }
 
 // PerformCast performs a cast from the provided Datum to the specified
-// CastTargetType.
+// types.T.
 func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 	switch t.Family() {
 	case types.BitFamily:
@@ -3476,6 +3476,15 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 			switch t.Oid() {
 			case oid.T_oid:
 				return &DOid{semanticType: t, DInt: v.DInt}, nil
+			case oid.T_regtype:
+				// Mapping an oid to a regtype is easy: we have a hardcoded map.
+				typ, ok := types.OidToType[oid.Oid(v.DInt)]
+				ret := &DOid{semanticType: t, DInt: v.DInt}
+				if !ok {
+					return ret, nil
+				}
+				ret.name = typ.PGName()
+				return ret, nil
 			default:
 				oid, err := queryOid(ctx, t, v)
 				if err != nil {


### PR DESCRIPTION
Previously, casting an integer to a regtype and then text (which turns a
type OID into the string of its corresponding type) would run a select
over pg_type to figure out the answer, which under the hood
materializes all of the types into a table and filters, an O(n)
operation. This is silly because we already have a static lookup table
for this info. Use it.

This commonly shows up in visualization tools as O(n^2), since people
tend to run one of these casts once per type. So this improves metadata
query performance significantly.

Release note: None