### PR TITLE
[wip] storage: allow atomic removal/addition of multiple LEARNERs

### DIFF
--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1078,6 +1078,8 @@ func addLearnerReplicas(
 	// This isn't crazy, we just need to transition out of the joint config
 	// before returning from this method, and it's unclear that it's worth
 	// doing.
+	//
+	// WIP(tbg): address the above TODO now.
 	for _, target := range targets {
 		iChgs := []internalReplicationChange{{target: target, typ: internalChangeTypeAddLearner}}
 		var err error


### PR DESCRIPTION
@nvanbenschoten this doesn't even compile because it needs to sit on top of
\#40234. The meat is in the commentary anyway, I don't think it's clear enough
yet, lmk how I can improve it.

----

When we add/remove more than one voter "atomically", we end up with a
range descriptor that has the affected voters as
VOTER_{INCOMING,OUTGOING}.

Adding/removing multiple learners does not need joint consensus, but
etcd/raft does require it on a technicality (not being able to prove
that the learner changes don't correspond to voter demotions, basically).

We don't have LEARNER_{INCOMING,OUTGOING} nor do we want to clutter the
range descriptor further. As a result, we're unable to accurately
reflect a joint configuration in which only learners changed via the
range descriptor, and thus aren't able to mutate only learners in an
atomic replication change.

We could argue that this isn't needed, but it's actually a very awkward
papercut because for removing nodes, we don't distinguish between
learners and voters and so anyone running atomic replication changes
needs to make sure they're not accidentally trying to remove multiple
learners at once.

To lift this restriction, just work around the raft restriction. We make
the convention that a transition into a joint raft config that takes
place under a descriptor that doesn't reflect a joint config is left
right when it is entered (i.e. in the same raft command). This
essentially amounts to letting etcd/raft trust us that we are not
running demotions, which we are not.

Release note: None