### PR TITLE
debug: fix and improve pretty-printing of ConfChange Raft entries

### DIFF
--- a/pkg/storage/debug_print.go
+++ b/pkg/storage/debug_print.go
@@ -98,7 +98,7 @@ func tryIntent(kv engine.MVCCKeyValue) (string, error) {
 
 func decodeWriteBatch(writeBatch *storagepb.WriteBatch) (string, error) {
 	if writeBatch == nil {
-		return "<nil>", nil
+		return "<nil>\n", nil
 	}
 
 	r, err := engine.NewRocksDBBatchReader(writeBatch.Data)

--- a/pkg/storage/debug_print.go
+++ b/pkg/storage/debug_print.go
@@ -165,30 +165,18 @@ func tryRaftLogEntry(kv engine.MVCCKeyValue) (string, error) {
 	if err := maybeUnmarshalInline(kv.Value, &ent); err != nil {
 		return "", err
 	}
-	if ent.Type == raftpb.EntryNormal {
-		if len(ent.Data) > 0 {
-			_, cmdData := DecodeRaftCommand(ent.Data)
-			var cmd storagepb.RaftCommand
-			if err := protoutil.Unmarshal(cmdData, &cmd); err != nil {
-				return "", err
-			}
-			ent.Data = nil
-			var leaseStr string
-			if l := cmd.DeprecatedProposerLease; l != nil {
-				// Use the full lease, if available.
-				leaseStr = l.String()
-			} else {
-				leaseStr = fmt.Sprintf("lease #%d", cmd.ProposerLeaseSequence)
-			}
-			writeBatch, err := decodeWriteBatch(cmd.WriteBatch)
-			if err != nil {
-				writeBatch = "failed to decode: " + err.Error() + "\nafter:\n" + writeBatch
-			}
-			return fmt.Sprintf("%s by %s\n%s\nwrite batch:\n%s",
-				&ent, leaseStr, &cmd, writeBatch), nil
+
+	var cmd storagepb.RaftCommand
+	switch ent.Type {
+	case raftpb.EntryNormal:
+		if len(ent.Data) == 0 {
+			return fmt.Sprintf("%s: EMPTY\n", &ent), nil
 		}
-		return fmt.Sprintf("%s: EMPTY\n", &ent), nil
-	} else if ent.Type == raftpb.EntryConfChange || ent.Type == raftpb.EntryConfChangeV2 {
+		_, cmdData := DecodeRaftCommand(ent.Data)
+		if err := protoutil.Unmarshal(cmdData, &cmd); err != nil {
+			return "", err
+		}
+	case raftpb.EntryConfChange, raftpb.EntryConfChangeV2:
 		var c raftpb.ConfChangeI
 		if ent.Type == raftpb.EntryConfChange {
 			var cc raftpb.ConfChange
@@ -208,14 +196,28 @@ func tryRaftLogEntry(kv engine.MVCCKeyValue) (string, error) {
 		if err := protoutil.Unmarshal(c.AsV2().Context, &ctx); err != nil {
 			return "", err
 		}
-		var cmd storagepb.RaftCommand
 		if err := protoutil.Unmarshal(ctx.Payload, &cmd); err != nil {
 			return "", err
 		}
-		ent.Data = nil
-		return fmt.Sprintf("%s\n%s\n", &ent, &cmd), nil
+	default:
+		return "", fmt.Errorf("unknown log entry type: %s", &ent)
 	}
-	return "", fmt.Errorf("unknown log entry type: %s", &ent)
+	ent.Data = nil
+
+	var leaseStr string
+	if l := cmd.DeprecatedProposerLease; l != nil {
+		leaseStr = l.String() // use full lease, if available
+	} else {
+		leaseStr = fmt.Sprintf("lease #%d", cmd.ProposerLeaseSequence)
+	}
+
+	wbStr, err := decodeWriteBatch(cmd.WriteBatch)
+	if err != nil {
+		wbStr = "failed to decode: " + err.Error() + "\nafter:\n" + wbStr
+	}
+	cmd.WriteBatch = nil
+
+	return fmt.Sprintf("%s by %s\n%s\nwrite batch:\n%s", &ent, leaseStr, &cmd, wbStr), nil
 }
 
 func tryTxn(kv engine.MVCCKeyValue) (string, error) {

--- a/pkg/storage/debug_print.go
+++ b/pkg/storage/debug_print.go
@@ -208,7 +208,7 @@ func tryRaftLogEntry(kv engine.MVCCKeyValue) (string, error) {
 		if err := protoutil.Unmarshal(c.AsV2().Context, &ctx); err != nil {
 			return "", err
 		}
-		var cmd storagepb.ReplicatedEvalResult
+		var cmd storagepb.RaftCommand
 		if err := protoutil.Unmarshal(ctx.Payload, &cmd); err != nil {
 			return "", err
 		}


### PR DESCRIPTION
The tryRaftLogEntry function was trying to decode into the wrong struct type, resulting in the error `proto: wrong wireType = 0 for field Desc`.

The second commit unifies the pretty-printing of ConfChange Raft entries with that of non-ConfChange Raft entries. This allows us to print the WriteBatch of ConfChanges.