### PR TITLE
storage: issue swaps on AllocatorConsiderRebalance

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -86,7 +86,9 @@ var disableSyncRaftLog = settings.RegisterBoolSetting(
 	false,
 )
 
-var useAtomicReplicationChanges = settings.RegisterBoolSetting(
+// UseAtomicReplicationChanges determines whether to issue atomic replication changes.
+// This has no effect until the cluster version is 19.2 or higher.
+var UseAtomicReplicationChanges = settings.RegisterBoolSetting(
 	"kv.atomic_replication_changes.enabled",
 	"use atomic replication changes",
 	false,

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -893,7 +893,7 @@ func (r *Replica) ChangeReplicas(
 	// replication changes or if that was explicitly disabled.
 	st := r.ClusterSettings()
 	unroll := !st.Version.IsActive(cluster.VersionAtomicChangeReplicas) ||
-		!useAtomicReplicationChanges.Get(&st.SV)
+		!UseAtomicReplicationChanges.Get(&st.SV)
 
 	if unroll {
 		// Legacy behavior.

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -440,12 +440,13 @@ func (rq *replicateQueue) add(
 func (rq *replicateQueue) findRemoveTarget(
 	ctx context.Context,
 	repl interface {
+		DescAndZone() (*roachpb.RangeDescriptor, *config.ZoneConfig)
 		LastReplicaAdded() (roachpb.ReplicaID, time.Time)
 		RaftStatus() *raft.Status
 	},
-	zone *config.ZoneConfig,
 	existingReplicas []roachpb.ReplicaDescriptor,
 ) (roachpb.ReplicaDescriptor, string, error) {
+	_, zone := repl.DescAndZone()
 	// This retry loop involves quick operations on local state, so a
 	// small MaxBackoff is good (but those local variables change on
 	// network time scales as raft receives responses).
@@ -507,54 +508,63 @@ func (rq *replicateQueue) findRemoveTarget(
 	return rq.allocator.RemoveTarget(ctx, zone, candidates, existingReplicas)
 }
 
+func (rq *replicateQueue) maybeTransferLeaseAway(
+	ctx context.Context, repl *Replica, removeReplica roachpb.ReplicaDescriptor, dryRun bool,
+) (transferred bool, _ error) {
+	if removeReplica.StoreID != repl.store.StoreID() {
+		return false, nil
+	}
+	desc, zone := repl.DescAndZone()
+	// The local replica was selected as the removal target, but that replica
+	// is the leaseholder, so transfer the lease instead. We don't check that
+	// the current store has too many leases in this case under the
+	// assumption that replica balance is a greater concern. Also note that
+	// AllocatorRemove action takes preference over AllocatorConsiderRebalance
+	// (rebalancing) which is where lease transfer would otherwise occur. We
+	// need to be able to transfer leases in AllocatorRemove in order to get
+	// out of situations where this store is overfull and yet holds all the
+	// leases. The fullness checks need to be ignored for cases where
+	// a replica needs to be removed for constraint violations.
+	return rq.findTargetAndTransferLease(
+		ctx,
+		repl,
+		desc,
+		zone,
+		transferLeaseOptions{
+			dryRun: dryRun,
+		},
+	)
+}
+
 func (rq *replicateQueue) remove(
 	ctx context.Context, repl *Replica, existingReplicas []roachpb.ReplicaDescriptor, dryRun bool,
 ) (requeue bool, _ error) {
-	desc, zone := repl.DescAndZone()
-	removeReplica, details, err := rq.findRemoveTarget(ctx, repl, zone, existingReplicas)
+	removeReplica, details, err := rq.findRemoveTarget(ctx, repl, existingReplicas)
 	if err != nil {
 		return false, err
 	}
-	if removeReplica.StoreID == repl.store.StoreID() {
-		// The local replica was selected as the removal target, but that replica
-		// is the leaseholder, so transfer the lease instead. We don't check that
-		// the current store has too many leases in this case under the
-		// assumption that replica balance is a greater concern. Also note that
-		// AllocatorRemove action takes preference over AllocatorConsiderRebalance
-		// (rebalancing) which is where lease transfer would otherwise occur. We
-		// need to be able to transfer leases in AllocatorRemove in order to get
-		// out of situations where this store is overfull and yet holds all the
-		// leases. The fullness checks need to be ignored for cases where
-		// a replica needs to be removed for constraint violations.
-		transferred, err := rq.findTargetAndTransferLease(
-			ctx,
-			repl,
-			desc,
-			zone,
-			transferLeaseOptions{
-				dryRun: dryRun,
-			},
-		)
-		if err != nil {
-			return false, err
-		}
-		// Do not requeue as we transferred our lease away.
-		if transferred {
-			return false, nil
-		}
-	} else {
-		rq.metrics.RemoveReplicaCount.Inc(1)
-		log.VEventf(ctx, 1, "removing replica %+v due to over-replication: %s",
-			removeReplica, rangeRaftProgress(repl.RaftStatus(), existingReplicas))
-		target := roachpb.ReplicationTarget{
-			NodeID:  removeReplica.NodeID,
-			StoreID: removeReplica.StoreID,
-		}
-		if err := rq.removeReplica(
-			ctx, repl, target, desc, storagepb.ReasonRangeOverReplicated, details, dryRun,
-		); err != nil {
-			return false, err
-		}
+	done, err := rq.maybeTransferLeaseAway(ctx, repl, removeReplica, dryRun)
+	if err != nil {
+		return false, err
+	}
+	if done {
+		// Lease is now elsewhere, so we're not in charge any more.
+		return false, nil
+	}
+
+	// Remove a replica.
+	rq.metrics.RemoveReplicaCount.Inc(1)
+	log.VEventf(ctx, 1, "removing replica %+v due to over-replication: %s",
+		removeReplica, rangeRaftProgress(repl.RaftStatus(), existingReplicas))
+	target := roachpb.ReplicationTarget{
+		NodeID:  removeReplica.NodeID,
+		StoreID: removeReplica.StoreID,
+	}
+	desc, _ := repl.DescAndZone()
+	if err := rq.removeReplica(
+		ctx, repl, target, desc, storagepb.ReasonRangeOverReplicated, details, dryRun,
+	); err != nil {
+		return false, err
 	}
 	return true, nil
 }
@@ -562,7 +572,7 @@ func (rq *replicateQueue) remove(
 func (rq *replicateQueue) removeDecommissioning(
 	ctx context.Context, repl *Replica, dryRun bool,
 ) (requeue bool, _ error) {
-	desc, zone := repl.DescAndZone()
+	desc, _ := repl.DescAndZone()
 	decommissioningReplicas := rq.allocator.storePool.decommissioningReplicas(
 		desc.RangeID, desc.Replicas().All())
 	if len(decommissioningReplicas) == 0 {
@@ -571,41 +581,27 @@ func (rq *replicateQueue) removeDecommissioning(
 		return true, nil
 	}
 	decommissioningReplica := decommissioningReplicas[0]
-	if decommissioningReplica.StoreID == repl.store.StoreID() {
-		// As in the AllocatorRemove case, if we're trying to remove ourselves, we
-		// we must first transfer our lease away.
-		if dryRun {
-			return false, nil
-		}
-		transferred, err := rq.findTargetAndTransferLease(
-			ctx,
-			repl,
-			desc,
-			zone,
-			transferLeaseOptions{
-				dryRun: dryRun,
-			},
-		)
-		if err != nil {
-			return false, err
-		}
-		// Do not requeue as we transferred our lease away.
-		if transferred {
-			return false, nil
-		}
-	} else {
-		rq.metrics.RemoveReplicaCount.Inc(1)
-		log.VEventf(ctx, 1, "removing decommissioning replica %+v from store", decommissioningReplica)
-		target := roachpb.ReplicationTarget{
-			NodeID:  decommissioningReplica.NodeID,
-			StoreID: decommissioningReplica.StoreID,
-		}
-		if err := rq.removeReplica(
-			ctx, repl, target, desc, storagepb.ReasonStoreDecommissioning, "", dryRun,
-		); err != nil {
-			return false, err
-		}
+	done, err := rq.maybeTransferLeaseAway(ctx, repl, decommissioningReplica, dryRun)
+	if err != nil {
+		return false, err
 	}
+	if done {
+		// Not leaseholder any more.
+		return false, nil
+	}
+	// Remove the decommissioning replica.
+	rq.metrics.RemoveReplicaCount.Inc(1)
+	log.VEventf(ctx, 1, "removing decommissioning replica %+v from store", decommissioningReplica)
+	target := roachpb.ReplicationTarget{
+		NodeID:  decommissioningReplica.NodeID,
+		StoreID: decommissioningReplica.StoreID,
+	}
+	if err := rq.removeReplica(
+		ctx, repl, target, desc, storagepb.ReasonStoreDecommissioning, "", dryRun,
+	); err != nil {
+		return false, err
+	}
+	// We removed a replica, so check if there's more to do.
 	return true, nil
 }
 
@@ -624,6 +620,9 @@ func (rq *replicateQueue) removeDead(
 		NodeID:  deadReplica.NodeID,
 		StoreID: deadReplica.StoreID,
 	}
+	// NB: we don't check whether to transfer the lease away because if the removal target
+	// is dead, it's not us (and if for some reason that happens, the removal is simply
+	// going to fail).
 	if err := rq.removeReplica(
 		ctx, repl, target, desc, storagepb.ReasonStoreDead, "", dryRun,
 	); err != nil {
@@ -649,6 +648,9 @@ func (rq *replicateQueue) removeLearner(
 		NodeID:  learnerReplica.NodeID,
 		StoreID: learnerReplica.StoreID,
 	}
+	// NB: we don't check whether to transfer the lease away because we're very unlikely
+	// to be the learner (and if so, we don't have the lease any more, so after the removal
+	// fails the situation will have rectified itself).
 	if err := rq.removeReplica(
 		ctx, repl, target, desc, storagepb.ReasonAbandonedLearner, "", dryRun,
 	); err != nil {

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -338,6 +338,14 @@ func (rq *replicateQueue) processOneChange(
 		return rq.add(ctx, repl, existingReplicas, dryRun)
 	case AllocatorRemove:
 		return rq.remove(ctx, repl, voterReplicas, dryRun)
+	case AllocatorReplaceDead, AllocatorReplaceDecommissioning:
+		existingReplicas := liveVoterReplicas
+		// WIP(tbg): pass a slice of replicas that can be replaced in.
+		// In ReplaceDead, it's the dead replicas, in ReplaceDecommissioning
+		// it's the decommissioning ones.
+		// Rename rq.add to rq.addOrReplace, and let it actually replace a replica
+		// atomically when there's suitable candidate in the slice.
+		return rq.add(ctx, repl, existingReplicas, dryRun)
 	case AllocatorRemoveDecommissioning:
 		return rq.removeDecommissioning(ctx, repl, dryRun)
 	case AllocatorRemoveDead:

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -419,10 +419,10 @@ func (rq *replicateQueue) add(
 	rq.metrics.AddReplicaCount.Inc(1)
 	log.VEventf(ctx, 1, "adding replica %+v due to under-replication: %s",
 		newReplica, rangeRaftProgress(repl.RaftStatus(), existingReplicas))
-	if err := rq.addReplica(
+	if err := rq.changeReplicas(
 		ctx,
 		repl,
-		newReplica,
+		roachpb.MakeReplicationChanges(roachpb.ADD_REPLICA, newReplica),
 		desc,
 		SnapshotRequest_RECOVERY,
 		storagepb.ReasonRangeUnderReplicated,
@@ -561,8 +561,15 @@ func (rq *replicateQueue) remove(
 		StoreID: removeReplica.StoreID,
 	}
 	desc, _ := repl.DescAndZone()
-	if err := rq.removeReplica(
-		ctx, repl, target, desc, storagepb.ReasonRangeOverReplicated, details, dryRun,
+	if err := rq.changeReplicas(
+		ctx,
+		repl,
+		roachpb.MakeReplicationChanges(roachpb.REMOVE_REPLICA, target),
+		desc,
+		SnapshotRequest_UNKNOWN, // unused
+		storagepb.ReasonRangeOverReplicated,
+		details,
+		dryRun,
 	); err != nil {
 		return false, err
 	}
@@ -596,8 +603,13 @@ func (rq *replicateQueue) removeDecommissioning(
 		NodeID:  decommissioningReplica.NodeID,
 		StoreID: decommissioningReplica.StoreID,
 	}
-	if err := rq.removeReplica(
-		ctx, repl, target, desc, storagepb.ReasonStoreDecommissioning, "", dryRun,
+	if err := rq.changeReplicas(
+		ctx,
+		repl,
+		roachpb.MakeReplicationChanges(roachpb.REMOVE_REPLICA, target),
+		desc,
+		SnapshotRequest_UNKNOWN, // unused
+		storagepb.ReasonStoreDecommissioning, "", dryRun,
 	); err != nil {
 		return false, err
 	}
@@ -623,8 +635,15 @@ func (rq *replicateQueue) removeDead(
 	// NB: we don't check whether to transfer the lease away because if the removal target
 	// is dead, it's not us (and if for some reason that happens, the removal is simply
 	// going to fail).
-	if err := rq.removeReplica(
-		ctx, repl, target, desc, storagepb.ReasonStoreDead, "", dryRun,
+	if err := rq.changeReplicas(
+		ctx,
+		repl,
+		roachpb.MakeReplicationChanges(roachpb.REMOVE_REPLICA, target),
+		desc,
+		SnapshotRequest_UNKNOWN, // unused
+		storagepb.ReasonStoreDead,
+		"",
+		dryRun,
 	); err != nil {
 		return false, err
 	}
@@ -651,8 +670,15 @@ func (rq *replicateQueue) removeLearner(
 	// NB: we don't check whether to transfer the lease away because we're very unlikely
 	// to be the learner (and if so, we don't have the lease any more, so after the removal
 	// fails the situation will have rectified itself).
-	if err := rq.removeReplica(
-		ctx, repl, target, desc, storagepb.ReasonAbandonedLearner, "", dryRun,
+	if err := rq.changeReplicas(
+		ctx,
+		repl,
+		roachpb.MakeReplicationChanges(roachpb.REMOVE_REPLICA, target),
+		desc,
+		SnapshotRequest_UNKNOWN,
+		storagepb.ReasonAbandonedLearner,
+		"",
+		dryRun,
 	); err != nil {
 		return false, err
 	}
@@ -684,10 +710,10 @@ func (rq *replicateQueue) considerRebalance(
 			rq.metrics.RebalanceReplicaCount.Inc(1)
 			log.VEventf(ctx, 1, "rebalancing to %+v: %s",
 				rebalanceReplica, rangeRaftProgress(repl.RaftStatus(), existingReplicas))
-			if err := rq.addReplica(
+			if err := rq.changeReplicas(
 				ctx,
 				repl,
-				rebalanceReplica,
+				[]roachpb.ReplicationChange{{Target: rebalanceReplica, ChangeType: roachpb.ADD_REPLICA}},
 				desc,
 				SnapshotRequest_REBALANCE,
 				storagepb.ReasonRebalance,
@@ -786,10 +812,10 @@ func (rq *replicateQueue) transferLease(
 	return nil
 }
 
-func (rq *replicateQueue) addReplica(
+func (rq *replicateQueue) changeReplicas(
 	ctx context.Context,
 	repl *Replica,
-	target roachpb.ReplicationTarget,
+	chgs roachpb.ReplicationChanges,
 	desc *roachpb.RangeDescriptor,
 	priority SnapshotRequest_Priority,
 	reason storagepb.RangeLogEventReason,
@@ -799,35 +825,14 @@ func (rq *replicateQueue) addReplica(
 	if dryRun {
 		return nil
 	}
-	chgs := roachpb.MakeReplicationChanges(roachpb.ADD_REPLICA, target)
 	if _, err := repl.ChangeReplicas(ctx, desc, priority, reason, details, chgs); err != nil {
 		return err
 	}
 	rangeUsageInfo := rangeUsageInfoForRepl(repl)
-	rq.allocator.storePool.updateLocalStoreAfterRebalance(
-		target.StoreID, rangeUsageInfo, roachpb.ADD_REPLICA)
-	return nil
-}
-
-func (rq *replicateQueue) removeReplica(
-	ctx context.Context,
-	repl *Replica,
-	target roachpb.ReplicationTarget,
-	desc *roachpb.RangeDescriptor,
-	reason storagepb.RangeLogEventReason,
-	details string,
-	dryRun bool,
-) error {
-	if dryRun {
-		return nil
+	for _, chg := range chgs {
+		rq.allocator.storePool.updateLocalStoreAfterRebalance(
+			chg.Target.StoreID, rangeUsageInfo, chg.ChangeType)
 	}
-	chgs := roachpb.MakeReplicationChanges(roachpb.REMOVE_REPLICA, target)
-	if _, err := repl.ChangeReplicas(ctx, desc, SnapshotRequest_REBALANCE, reason, details, chgs); err != nil {
-		return err
-	}
-	rangeUsageInfo := rangeUsageInfoForRepl(repl)
-	rq.allocator.storePool.updateLocalStoreAfterRebalance(
-		target.StoreID, rangeUsageInfo, roachpb.REMOVE_REPLICA)
 	return nil
 }
 

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -696,28 +696,63 @@ func (rq *replicateQueue) considerRebalance(
 	// The Noop case will result if this replica was queued in order to
 	// rebalance. Attempt to find a rebalancing target.
 	if !rq.store.TestingKnobs().DisableReplicaRebalancing {
+		// See if we can swap out a replica. First, we find one that we're allowed
+		// to remove.
+		removeReplica, detailsRemove, err := rq.findRemoveTarget(ctx, repl, existingReplicas)
+		if err != nil {
+			return false, err
+		}
+
+		// TODO(tbg): the details are JSON, and the ChangeReplicas API only allows us
+		// to pass one along. Attach the details to each change instead. Tracked in:
+		// https://github.com/cockroachdb/cockroach/issues/12768#issuecomment-522591757
+		_ = detailsRemove
+		done, err := rq.maybeTransferLeaseAway(ctx, repl, removeReplica, dryRun)
+		if err != nil {
+			return false, err
+		}
+		if done {
+			// Not leaseholder any more.
+			return false, nil
+		}
+
+		// Then, not taking into account the replica we're going to remove, see
+		// if we could add a new one.
 		rangeUsageInfo := rangeUsageInfoForRepl(repl)
-		rebalanceStore, details := rq.allocator.RebalanceTarget(
+		rebalanceStore, detailsAdd := rq.allocator.RebalanceTarget(
 			ctx, zone, repl.RaftStatus(), desc.RangeID, existingReplicas, rangeUsageInfo,
 			storeFilterThrottled)
 		if rebalanceStore == nil {
 			log.VEventf(ctx, 1, "no suitable rebalance target")
 		} else {
-			rebalanceReplica := roachpb.ReplicationTarget{
+			// We have a replica to remove and one we can add, so let's swap them
+			// out.
+			addTarget := roachpb.ReplicationTarget{
 				NodeID:  rebalanceStore.Node.NodeID,
 				StoreID: rebalanceStore.StoreID,
 			}
+			removeTarget := roachpb.ReplicationTarget{
+				NodeID:  removeReplica.NodeID,
+				StoreID: removeReplica.StoreID,
+			}
 			rq.metrics.RebalanceReplicaCount.Inc(1)
-			log.VEventf(ctx, 1, "rebalancing to %+v: %s",
-				rebalanceReplica, rangeRaftProgress(repl.RaftStatus(), existingReplicas))
+			log.VEventf(ctx, 1, "rebalancing %+v to %+v: %s",
+				removeTarget, addTarget, rangeRaftProgress(repl.RaftStatus(), existingReplicas))
 			if err := rq.changeReplicas(
 				ctx,
 				repl,
-				[]roachpb.ReplicationChange{{Target: rebalanceReplica, ChangeType: roachpb.ADD_REPLICA}},
+				[]roachpb.ReplicationChange{
+					// NB: we place the addition first because in the case of
+					// atomic replication changes being turned off, the changes
+					// will be executed individually in the order in which they
+					// appear.
+					{Target: addTarget, ChangeType: roachpb.ADD_REPLICA},
+					{Target: removeTarget, ChangeType: roachpb.REMOVE_REPLICA},
+				},
 				desc,
 				SnapshotRequest_REBALANCE,
 				storagepb.ReasonRebalance,
-				details,
+				detailsAdd,
 				dryRun,
 			); err != nil {
 				return false, err

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -434,10 +434,18 @@ func (rq *replicateQueue) add(
 	return true, nil
 }
 
-func (rq *replicateQueue) remove(
-	ctx context.Context, repl *Replica, existingReplicas []roachpb.ReplicaDescriptor, dryRun bool,
-) (requeue bool, _ error) {
-	desc, zone := repl.DescAndZone()
+// findRemoveTarget takes a list of replicas and picks one to remove, making
+// sure to not remove a newly added replica or to violate the zone configs in
+// the progress.
+func (rq *replicateQueue) findRemoveTarget(
+	ctx context.Context,
+	repl interface {
+		LastReplicaAdded() (roachpb.ReplicaID, time.Time)
+		RaftStatus() *raft.Status
+	},
+	zone *config.ZoneConfig,
+	existingReplicas []roachpb.ReplicaDescriptor,
+) (roachpb.ReplicaDescriptor, string, error) {
 	// This retry loop involves quick operations on local state, so a
 	// small MaxBackoff is good (but those local variables change on
 	// network time scales as raft receives responses).
@@ -461,7 +469,7 @@ func (rq *replicateQueue) remove(
 		raftStatus := repl.RaftStatus()
 		if raftStatus == nil || raftStatus.RaftState != raft.StateLeader {
 			// If we've lost raft leadership, we're unlikely to regain it so give up immediately.
-			return false, &benignError{errors.Errorf("not raft leader while range needs removal")}
+			return roachpb.ReplicaDescriptor{}, "", &benignError{errors.Errorf("not raft leader while range needs removal")}
 		}
 		candidates = filterUnremovableReplicas(raftStatus, existingReplicas, lastReplAdded)
 		log.VEventf(ctx, 3, "filtered unremovable replicas from %v to get %v as candidates for removal: %s",
@@ -492,11 +500,18 @@ func (rq *replicateQueue) remove(
 	}
 	if len(candidates) == 0 {
 		// If we timed out and still don't have any valid candidates, give up.
-		return false, errors.Errorf("no removable replicas from range that needs a removal: %s",
+		return roachpb.ReplicaDescriptor{}, "", errors.Errorf("no removable replicas from range that needs a removal: %s",
 			rangeRaftProgress(repl.RaftStatus(), existingReplicas))
 	}
 
-	removeReplica, details, err := rq.allocator.RemoveTarget(ctx, zone, candidates, existingReplicas)
+	return rq.allocator.RemoveTarget(ctx, zone, candidates, existingReplicas)
+}
+
+func (rq *replicateQueue) remove(
+	ctx context.Context, repl *Replica, existingReplicas []roachpb.ReplicaDescriptor, dryRun bool,
+) (requeue bool, _ error) {
+	desc, zone := repl.DescAndZone()
+	removeReplica, details, err := rq.findRemoveTarget(ctx, repl, zone, existingReplicas)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/storage/replicate_queue_test.go
+++ b/pkg/storage/replicate_queue_test.go
@@ -331,6 +331,8 @@ func TestLargeUnsplittableRangeReplicate(t *testing.T) {
 		base.TestClusterArgs{
 			ReplicationMode: base.ReplicationAuto,
 			ServerArgs: base.TestServerArgs{
+				ScanMinIdleTime: time.Millisecond,
+				ScanMaxIdleTime: time.Millisecond,
 				Knobs: base.TestingKnobs{
 					Server: &server.TestingKnobs{
 						DefaultZoneConfigOverride: &zcfg,


### PR DESCRIPTION
Change the rebalancing code so that it not only looks up a new replica to
add, but also picks one to remove. Both actions are then given to a
ChangeReplicas invocation which will carry it out atomically as long as
that feature is enabled.

Release note (bug fix): Replicas can now be moved between stores without
entering an intermediate configuration that violates the zone constraints.
Violations may still occur during zone config changes, decommissioning, and
in the presence of dead nodes (NB: the remainder be addressed in a future
change, so merge the corresponding release note)