### PR TITLE
sql: Allow zone configs on offline tables

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1048,6 +1048,7 @@ func TestBackupRestoreControlJob(t *testing.T) {
 					`SELECT name FROM crdb_internal.tables WHERE database_name = 'pause' AND state = 'OFFLINE'`,
 					[][]string{{"bank"}},
 				)
+				sqlDB.Exec(t, `ALTER TABLE pause.bank CONFIGURE ZONE USING constraints='[+dc=dc1]'`)
 			}
 			sqlDB.Exec(t, fmt.Sprintf(`RESUME JOB %d`, jobID))
 			jobutils.WaitForJob(t, sqlDB, jobID)

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -71,9 +71,9 @@ func (r *descriptorResolver) LookupSchema(
 
 // LookupObject implements the tree.TableNameExistingResolver interface.
 func (r *descriptorResolver) LookupObject(
-	_ context.Context, requireMutable bool, dbName, scName, obName string,
+	_ context.Context, flags tree.ObjectLookupFlags, dbName, scName, obName string,
 ) (bool, tree.NameResolutionResult, error) {
-	if requireMutable {
+	if flags.RequireMutable {
 		panic("did not expect request for mutable descriptor")
 	}
 	if scName != tree.PublicSchema {
@@ -204,7 +204,7 @@ func descriptorsMatchingTargets(
 
 		switch p := pattern.(type) {
 		case *tree.TableName:
-			found, descI, err := p.ResolveExisting(ctx, resolver, false /*requireMutable*/, currentDatabase, searchPath)
+			found, descI, err := p.ResolveExisting(ctx, resolver, tree.ObjectLookupFlags{}, currentDatabase, searchPath)
 			if err != nil {
 				return ret, err
 			}

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -258,18 +258,21 @@ func (r fkResolver) CurrentSearchPath() sessiondata.SearchPath {
 }
 
 // Implements the sql.SchemaResolver interface.
-func (r fkResolver) CommonLookupFlags(required bool) sql.CommonLookupFlags {
-	return sql.CommonLookupFlags{}
+func (r fkResolver) CommonLookupFlags(required bool) tree.CommonLookupFlags {
+	return tree.CommonLookupFlags{}
 }
 
 // Implements the sql.SchemaResolver interface.
-func (r fkResolver) ObjectLookupFlags(required bool, requireMutable bool) sql.ObjectLookupFlags {
-	return sql.ObjectLookupFlags{}
+func (r fkResolver) ObjectLookupFlags(required bool, requireMutable bool) tree.ObjectLookupFlags {
+	return tree.ObjectLookupFlags{
+		CommonLookupFlags: tree.CommonLookupFlags{Required: required},
+		RequireMutable:    requireMutable,
+	}
 }
 
 // Implements the tree.TableNameExistingResolver interface.
 func (r fkResolver) LookupObject(
-	ctx context.Context, requireMutable bool, dbName, scName, obName string,
+	ctx context.Context, lookupFlags tree.ObjectLookupFlags, dbName, scName, obName string,
 ) (found bool, objMeta tree.NameResolutionResult, err error) {
 	if scName != "" {
 		obName = strings.TrimPrefix(obName, scName+".")

--- a/pkg/sql/alter_user.go
+++ b/pkg/sql/alter_user.go
@@ -33,7 +33,7 @@ type alterUserSetPasswordNode struct {
 func (p *planner) AlterUserSetPassword(
 	ctx context.Context, n *tree.AlterUserSetPassword,
 ) (planNode, error) {
-	tDesc, err := ResolveExistingObject(ctx, p, userTableName, true /*required*/, ResolveRequireTableDesc)
+	tDesc, err := ResolveExistingObject(ctx, p, userTableName, tree.ObjectLookupFlagsWithRequired(), ResolveRequireTableDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -556,7 +556,7 @@ func (sc *SchemaChanger) validateConstraints(
 func (sc *SchemaChanger) getTableVersion(
 	ctx context.Context, txn *client.Txn, tc *TableCollection, version sqlbase.DescriptorVersion,
 ) (*sqlbase.ImmutableTableDescriptor, error) {
-	tableDesc, err := tc.getTableVersionByID(ctx, txn, sc.tableID, ObjectLookupFlags{})
+	tableDesc, err := tc.getTableVersionByID(ctx, txn, sc.tableID, tree.ObjectLookupFlags{})
 	if err != nil {
 		return nil, err
 	}
@@ -835,7 +835,7 @@ func (sc *SchemaChanger) distBackfill(
 					}
 
 					for k := range fkTables {
-						table, err := tc.getTableVersionByID(ctx, txn, k, ObjectLookupFlags{})
+						table, err := tc.getTableVersionByID(ctx, txn, k, tree.ObjectLookupFlags{})
 						if err != nil {
 							return err
 						}

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -107,7 +107,7 @@ func newCopyMachine(
 		retErr = cleanup(ctx, retErr)
 	}()
 
-	tableDesc, err := ResolveExistingObject(ctx, &c.p, &n.Table, true /*required*/, ResolveRequireTableDesc)
+	tableDesc, err := ResolveExistingObject(ctx, &c.p, &n.Table, tree.ObjectLookupFlagsWithRequired(), ResolveRequireTableDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -153,8 +153,8 @@ func (n *createStatsNode) makeJobRecord(ctx context.Context) (*jobs.Record, erro
 		fqTableName = n.p.ResolvedName(t).FQString()
 
 	case *tree.TableRef:
-		flags := ObjectLookupFlags{CommonLookupFlags: CommonLookupFlags{
-			avoidCached: n.p.avoidCachedDescriptors,
+		flags := tree.ObjectLookupFlags{CommonLookupFlags: tree.CommonLookupFlags{
+			AvoidCached: n.p.avoidCachedDescriptors,
 		}}
 		tableDesc, err = n.p.Tables().getTableVersionByID(ctx, n.p.txn, sqlbase.ID(t.TableID), flags)
 		if err != nil {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -755,7 +755,7 @@ func addInterleave(
 	}
 
 	parentTable, err := ResolveExistingObject(
-		ctx, vt, &interleave.Parent, true /*required*/, ResolveRequireTableDesc,
+		ctx, vt, &interleave.Parent, tree.ObjectLookupFlagsWithRequired(), ResolveRequireTableDesc,
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/create_user.go
+++ b/pkg/sql/create_user.go
@@ -47,7 +47,7 @@ func (p *planner) CreateUser(ctx context.Context, n *tree.CreateUser) (planNode,
 func (p *planner) CreateUserNode(
 	ctx context.Context, nameE, passwordE tree.Expr, ifNotExists bool, isRole bool, opName string,
 ) (*CreateUserNode, error) {
-	tDesc, err := ResolveExistingObject(ctx, p, userTableName, true /*required*/, ResolveRequireTableDesc)
+	tDesc, err := ResolveExistingObject(ctx, p, userTableName, tree.ObjectLookupFlagsWithRequired(), ResolveRequireTableDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -112,7 +112,7 @@ func (p *planner) getDataSource(
 			return ds, err
 		}
 
-		desc, err := ResolveExistingObject(ctx, p, tn, true /*required*/, ResolveAnyDescType)
+		desc, err := ResolveExistingObject(ctx, p, tn, tree.ObjectLookupFlagsWithRequired(), ResolveAnyDescType)
 		if err != nil {
 			return planDataSource{}, err
 		}
@@ -198,8 +198,8 @@ func (p *planner) getTableScanByRef(
 	indexFlags *tree.IndexFlags,
 	scanVisibility scanVisibility,
 ) (planDataSource, error) {
-	flags := ObjectLookupFlags{CommonLookupFlags: CommonLookupFlags{
-		avoidCached: p.avoidCachedDescriptors,
+	flags := tree.ObjectLookupFlags{CommonLookupFlags: tree.CommonLookupFlags{
+		AvoidCached: p.avoidCachedDescriptors,
 	}}
 	desc, err := p.Tables().getTableVersionByID(ctx, p.txn, sqlbase.ID(tref.TableID), flags)
 	if err != nil {

--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -193,7 +193,7 @@ func (dc *databaseCache) getDatabaseDesc(
 		if err := txnRunner(ctx, func(ctx context.Context, txn *client.Txn) error {
 			a := UncachedPhysicalAccessor{}
 			desc, err = a.GetDatabaseDesc(ctx, txn, name,
-				DatabaseLookupFlags{required: required})
+				tree.DatabaseLookupFlags{Required: required})
 			return err
 		}); err != nil {
 			return nil, err

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -85,7 +85,7 @@ func (p *planner) Delete(
 	}
 
 	// Find which table we're working on, check the permissions.
-	desc, err := ResolveExistingObject(ctx, p, tn, true /*required*/, ResolveRequireTableDesc)
+	desc, err := ResolveExistingObject(ctx, p, tn, tree.ObjectLookupFlagsWithRequired(), ResolveRequireTableDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/drop_user.go
+++ b/pkg/sql/drop_user.go
@@ -43,7 +43,7 @@ func (p *planner) DropUser(ctx context.Context, n *tree.DropUser) (planNode, err
 func (p *planner) DropUserNode(
 	ctx context.Context, namesE tree.Exprs, ifExists bool, isRole bool, opName string,
 ) (*DropUserNode, error) {
-	tDesc, err := ResolveExistingObject(ctx, p, userTableName, true /*required*/, ResolveRequireTableDesc)
+	tDesc, err := ResolveExistingObject(ctx, p, userTableName, tree.ObjectLookupFlagsWithRequired(), ResolveRequireTableDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -89,7 +89,7 @@ func (p *planner) Insert(
 	}
 
 	// Find which table we're working on, check the permissions.
-	desc, err := ResolveExistingObject(ctx, p, tn, true /*required*/, ResolveRequireTableDesc)
+	desc, err := ResolveExistingObject(ctx, p, tn, tree.ObjectLookupFlagsWithRequired(), ResolveRequireTableDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/logical_schema_accessors.go
+++ b/pkg/sql/logical_schema_accessors.go
@@ -48,15 +48,15 @@ func (l *LogicalSchemaAccessor) GetObjectNames(
 	txn *client.Txn,
 	dbDesc *DatabaseDescriptor,
 	scName string,
-	flags DatabaseListFlags,
+	flags tree.DatabaseListFlags,
 ) (TableNames, error) {
 	if entry, ok := l.vt.getVirtualSchemaEntry(scName); ok {
 		names := make(TableNames, len(entry.orderedDefNames))
 		for i, name := range entry.orderedDefNames {
 			names[i] = tree.MakeTableNameWithSchema(
 				tree.Name(dbDesc.Name), tree.Name(entry.desc.Name), tree.Name(name))
-			names[i].ExplicitCatalog = flags.explicitPrefix
-			names[i].ExplicitSchema = flags.explicitPrefix
+			names[i].ExplicitCatalog = flags.ExplicitPrefix
+			names[i].ExplicitSchema = flags.ExplicitPrefix
 		}
 
 		return names, nil
@@ -68,12 +68,12 @@ func (l *LogicalSchemaAccessor) GetObjectNames(
 
 // GetObjectDesc implements the ObjectAccessor interface.
 func (l *LogicalSchemaAccessor) GetObjectDesc(
-	ctx context.Context, txn *client.Txn, name *ObjectName, flags ObjectLookupFlags,
+	ctx context.Context, txn *client.Txn, name *ObjectName, flags tree.ObjectLookupFlags,
 ) (ObjectDescriptor, error) {
 	if scEntry, ok := l.vt.getVirtualSchemaEntry(name.Schema()); ok {
 		tableName := name.Table()
 		if t, ok := scEntry.defs[tableName]; ok {
-			if flags.requireMutable {
+			if flags.RequireMutable {
 				return sqlbase.NewMutableExistingTableDescriptor(*t.desc), nil
 			}
 			return sqlbase.NewImmutableTableDescriptor(*t.desc), nil
@@ -83,7 +83,7 @@ func (l *LogicalSchemaAccessor) GetObjectDesc(
 				"virtual schema table not implemented: %s.%s", name.Schema(), tableName)
 		}
 
-		if flags.required {
+		if flags.Required {
 			return nil, sqlbase.NewUndefinedRelationError(name)
 		}
 		return nil, nil

--- a/pkg/sql/opt/ordering/doc.go
+++ b/pkg/sql/opt/ordering/doc.go
@@ -10,7 +10,7 @@
 
 /*
 Package ordering contains operator-specific logic related to orderings - whether
-ops can provide required orderings, what orderings do they need to require from
+ops can provide Required orderings, what orderings do they need to require from
 their children, etc.
 
 The package provides generic APIs that can be called on any RelExpr, as well as

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -167,7 +167,7 @@ func (oc *optCatalog) ResolveDataSource(
 	}
 
 	oc.tn = *name
-	desc, err := ResolveExistingObject(ctx, oc.planner, &oc.tn, true /* required */, ResolveAnyDescType)
+	desc, err := ResolveExistingObject(ctx, oc.planner, &oc.tn, tree.ObjectLookupFlagsWithRequired(), ResolveAnyDescType)
 	if err != nil {
 		return nil, cat.DataSourceName{}, err
 	}

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -403,7 +403,7 @@ func (p *planner) ParseQualifiedTableName(
 
 // ResolveTableName implements the tree.EvalDatabase interface.
 func (p *planner) ResolveTableName(ctx context.Context, tn *tree.TableName) error {
-	_, err := ResolveExistingObject(ctx, p, tn, true /*required*/, ResolveAnyDescType)
+	_, err := ResolveExistingObject(ctx, p, tn, tree.ObjectLookupFlagsWithRequired(), ResolveAnyDescType)
 	return err
 }
 
@@ -411,7 +411,7 @@ func (p *planner) ResolveTableName(ctx context.Context, tn *tree.TableName) erro
 // CommonLookupFlags, it could use or skip the TableCollection cache. See
 // TableCollection.getTableVersionByID for how it's used.
 func (p *planner) LookupTableByID(ctx context.Context, tableID sqlbase.ID) (row.TableEntry, error) {
-	flags := ObjectLookupFlags{CommonLookupFlags: CommonLookupFlags{avoidCached: p.avoidCachedDescriptors}}
+	flags := tree.ObjectLookupFlags{CommonLookupFlags: tree.CommonLookupFlags{AvoidCached: p.avoidCachedDescriptors}}
 	table, err := p.Tables().getTableVersionByID(ctx, p.txn, tableID, flags)
 	if err != nil {
 		if err == errTableAdding {

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -75,19 +75,19 @@ func (n *renameDatabaseNode) startExec(params runParams) error {
 	phyAccessor := p.PhysicalSchemaAccessor()
 	lookupFlags := p.CommonLookupFlags(true /*required*/)
 	// DDL statements bypass the cache.
-	lookupFlags.avoidCached = true
+	lookupFlags.AvoidCached = true
 	tbNames, err := phyAccessor.GetObjectNames(
-		ctx, p.txn, dbDesc, tree.PublicSchema, DatabaseListFlags{
+		ctx, p.txn, dbDesc, tree.PublicSchema, tree.DatabaseListFlags{
 			CommonLookupFlags: lookupFlags,
-			explicitPrefix:    true,
+			ExplicitPrefix:    true,
 		})
 	if err != nil {
 		return err
 	}
-	lookupFlags.required = false
+	lookupFlags.Required = false
 	for i := range tbNames {
 		objDesc, err := phyAccessor.GetObjectDesc(ctx, p.txn, &tbNames[i],
-			ObjectLookupFlags{CommonLookupFlags: lookupFlags})
+			tree.ObjectLookupFlags{CommonLookupFlags: lookupFlags})
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/schema_accessors.go
+++ b/pkg/sql/schema_accessors.go
@@ -74,7 +74,7 @@ type SchemaAccessor interface {
 	// GetDatabaseDesc looks up a database by name and returns its
 	// descriptor. If the database is not found and required is true,
 	// an error is returned; otherwise a nil reference is returned.
-	GetDatabaseDesc(ctx context.Context, txn *client.Txn, dbName string, flags DatabaseLookupFlags) (*DatabaseDescriptor, error)
+	GetDatabaseDesc(ctx context.Context, txn *client.Txn, dbName string, flags tree.DatabaseLookupFlags) (*DatabaseDescriptor, error)
 
 	// IsValidSchema returns true if the given schema name is valid for the given database.
 	IsValidSchema(db *DatabaseDescriptor, scName string) bool
@@ -83,37 +83,11 @@ type SchemaAccessor interface {
 	// database and schema.
 	// TODO(whomever): when separate schemas are supported, this
 	// API should be extended to use schema descriptors.
-	GetObjectNames(ctx context.Context, txn *client.Txn, db *DatabaseDescriptor, scName string, flags DatabaseListFlags) (TableNames, error)
+	GetObjectNames(ctx context.Context, txn *client.Txn, db *DatabaseDescriptor, scName string, flags tree.DatabaseListFlags) (TableNames, error)
 
-	// GetObjectDesc looks up an objcet by name and returns both its
+	// GetObjectDesc looks up an object by name and returns both its
 	// descriptor and that of its parent database. If the object is not
 	// found and flags.required is true, an error is returned, otherwise
 	// a nil reference is returned.
-	GetObjectDesc(ctx context.Context, txn *client.Txn, name *ObjectName, flags ObjectLookupFlags) (ObjectDescriptor, error)
-}
-
-// CommonLookupFlags is the common set of flags for the various accessor interfaces.
-type CommonLookupFlags struct {
-	// if required is set, lookup will return an error if the item is not found.
-	required bool
-	// if avoidCached is set, lookup will avoid the cache (if any).
-	avoidCached bool
-}
-
-// DatabaseLookupFlags is the flag struct suitable for GetDatabaseDesc().
-type DatabaseLookupFlags = CommonLookupFlags
-
-// DatabaseListFlags is the flag struct suitable for GetObjectNames().
-type DatabaseListFlags struct {
-	CommonLookupFlags
-	// explicitPrefix, when set, will cause the returned table names to
-	// have an explicit schema and catalog part.
-	explicitPrefix bool
-}
-
-// ObjectLookupFlags is the flag struct suitable for GetObjectDesc().
-type ObjectLookupFlags struct {
-	CommonLookupFlags
-	// return a MutableTableDeescriptor
-	requireMutable bool
+	GetObjectDesc(ctx context.Context, txn *client.Txn, name *ObjectName, flags tree.ObjectLookupFlags) (ObjectDescriptor, error)
 }

--- a/pkg/sql/sem/tree/name_resolution_test.go
+++ b/pkg/sql/sem/tree/name_resolution_test.go
@@ -449,7 +449,7 @@ func (fakeResResult) NameResolutionResult() {}
 
 // LookupObject implements the TableNameResolver interface.
 func (f *fakeMetadata) LookupObject(
-	_ context.Context, requireMutable bool, dbName, scName, tbName string,
+	_ context.Context, lookupFlags tree.ObjectLookupFlags, dbName, scName, tbName string,
 ) (found bool, obMeta tree.NameResolutionResult, err error) {
 	defer func() {
 		f.t.Logf("LookupObject(%s, %s, %s) -> found %v meta %v err %v",
@@ -721,7 +721,8 @@ func TestResolveTablePatternOrName(t *testing.T) {
 					ctPrefix = tpv.Catalog()
 				case *tree.TableName:
 					if tc.expected {
-						found, obMeta, err = tpv.ResolveExisting(ctx, fakeResolver, false /*requireMutable*/, tc.curDb, tc.searchPath)
+						flags := tree.ObjectLookupFlags{}
+						found, obMeta, err = tpv.ResolveExisting(ctx, fakeResolver, flags, tc.curDb, tc.searchPath)
 					} else {
 						found, scMeta, err = tpv.ResolveTarget(ctx, fakeResolver, tc.curDb, tc.searchPath)
 					}

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -35,7 +35,7 @@ func (p *planner) IncrementSequence(ctx context.Context, seqName *tree.TableName
 		return 0, readOnlyError("nextval()")
 	}
 
-	descriptor, err := ResolveExistingObject(ctx, p, seqName, true /*required*/, ResolveRequireSequenceDesc)
+	descriptor, err := ResolveExistingObject(ctx, p, seqName, tree.ObjectLookupFlagsWithRequired(), ResolveRequireSequenceDesc)
 	if err != nil {
 		return 0, err
 	}
@@ -93,7 +93,7 @@ func boundsExceededError(descriptor *sqlbase.ImmutableTableDescriptor) error {
 func (p *planner) GetLatestValueInSessionForSequence(
 	ctx context.Context, seqName *tree.TableName,
 ) (int64, error) {
-	descriptor, err := ResolveExistingObject(ctx, p, seqName, true /*required*/, ResolveRequireSequenceDesc)
+	descriptor, err := ResolveExistingObject(ctx, p, seqName, tree.ObjectLookupFlagsWithRequired(), ResolveRequireSequenceDesc)
 	if err != nil {
 		return 0, err
 	}
@@ -116,7 +116,7 @@ func (p *planner) SetSequenceValue(
 		return readOnlyError("setval()")
 	}
 
-	descriptor, err := ResolveExistingObject(ctx, p, seqName, true /*required*/, ResolveRequireSequenceDesc)
+	descriptor, err := ResolveExistingObject(ctx, p, seqName, tree.ObjectLookupFlagsWithRequired(), ResolveRequireSequenceDesc)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -316,7 +316,7 @@ func (p *planner) rewriteIndexOrderings(
 
 		case tree.OrderByIndex:
 			tn := o.Table
-			desc, err := ResolveExistingObject(ctx, p, &tn, true /*required*/, ResolveRequireTableDesc)
+			desc, err := ResolveExistingObject(ctx, p, &tn, tree.ObjectLookupFlagsWithRequired(), ResolveRequireTableDesc)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -90,7 +90,7 @@ func (p *planner) Update(
 	}
 
 	// Find which table we're working on, check the permissions.
-	desc, err := ResolveExistingObject(ctx, p, tn, true /*required*/, ResolveRequireTableDesc)
+	desc, err := ResolveExistingObject(ctx, p, tn, tree.ObjectLookupFlagsWithRequired(), ResolveRequireTableDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -185,7 +185,7 @@ var varGen = map[string]sessionVar{
 			if len(dbName) != 0 {
 				// Verify database descriptor exists.
 				if _, err := evalCtx.schemaAccessors.logical.GetDatabaseDesc(ctx, evalCtx.Txn, dbName,
-					DatabaseLookupFlags{required: true}); err != nil {
+					tree.DatabaseLookupFlags{Required: true}); err != nil {
 					return "", err
 				}
 			}

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -240,7 +240,7 @@ func (e virtualDefEntry) getPlanInfo() (sqlbase.ResultColumns, virtualTableConst
 		if dbName != "" {
 			var err error
 			dbDesc, err = p.LogicalSchemaAccessor().GetDatabaseDesc(ctx, p.txn, dbName,
-				DatabaseLookupFlags{required: true, avoidCached: p.avoidCachedDescriptors})
+				tree.DatabaseLookupFlags{Required: true, AvoidCached: p.avoidCachedDescriptors})
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/zone_config.go
+++ b/pkg/sql/zone_config.go
@@ -258,9 +258,9 @@ func (p *planner) resolveTableForZone(
 	} else if zs.TargetsTable() {
 		var immutRes *ImmutableTableDescriptor
 		p.runWithOptions(resolveFlags{skipCache: true}, func() {
-			immutRes, err = ResolveExistingObject(
-				ctx, p, &zs.TableOrIndex.Table, true /*required*/, ResolveAnyDescType,
-			)
+			flags := tree.ObjectLookupFlagsWithRequired()
+			flags.IncludeOffline = true
+			immutRes, err = ResolveExistingObject(ctx, p, &zs.TableOrIndex.Table, flags, ResolveAnyDescType)
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Zone configs should be allowed to be set for offline tables. The specific use
case that this is targetting is to create a work-around for #39602. This is to
allow for tables to start being restored, having the restored job paused and
then making zone config changes on these offline tables.

Release note: None