### PR TITLE
opt: remove op from mutationBuilder

### DIFF
--- a/pkg/sql/opt/optbuilder/delete.go
+++ b/pkg/sql/opt/optbuilder/delete.go
@@ -59,7 +59,7 @@ func (b *Builder) buildDelete(del *tree.Delete, inScope *scope) (outScope *scope
 	b.checkPrivilege(opt.DepByName(tn), tab, privilege.SELECT)
 
 	var mb mutationBuilder
-	mb.init(b, opt.DeleteOp, tab, *alias)
+	mb.init(b, "delete", tab, *alias)
 
 	// Build the input expression that selects the rows that will be deleted:
 	//
@@ -85,7 +85,7 @@ func (b *Builder) buildDelete(del *tree.Delete, inScope *scope) (outScope *scope
 // buildDelete constructs a Delete operator, possibly wrapped by a Project
 // operator that corresponds to the given RETURNING clause.
 func (mb *mutationBuilder) buildDelete(returning tree.ReturningExprs) {
-	mb.buildFKChecks()
+	mb.buildFKChecksForDelete()
 
 	private := mb.makeMutationPrivate(returning != nil)
 	mb.outScope.expr = mb.b.factory.ConstructDelete(mb.outScope.expr, mb.checks, private)

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -184,9 +184,9 @@ func (b *Builder) buildInsert(ins *tree.Insert, inScope *scope) (outScope *scope
 
 	var mb mutationBuilder
 	if ins.OnConflict != nil && ins.OnConflict.IsUpsertAlias() {
-		mb.init(b, opt.UpsertOp, tab, *alias)
+		mb.init(b, "upsert", tab, *alias)
 	} else {
-		mb.init(b, opt.InsertOp, tab, *alias)
+		mb.init(b, "insert", tab, *alias)
 	}
 
 	// Compute target columns in two cases:
@@ -615,7 +615,7 @@ func (mb *mutationBuilder) buildInsert(returning tree.ReturningExprs) {
 	// Add any check constraint boolean columns to the input.
 	mb.addCheckConstraintCols()
 
-	mb.buildFKChecks()
+	mb.buildFKChecksForInsert()
 
 	private := mb.makeMutationPrivate(returning != nil)
 	mb.outScope.expr = mb.b.factory.ConstructInsert(mb.outScope.expr, mb.checks, private)

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -94,7 +94,7 @@ func (b *Builder) buildUpdate(upd *tree.Update, inScope *scope) (outScope *scope
 	b.checkPrivilege(opt.DepByName(tn), tab, privilege.SELECT)
 
 	var mb mutationBuilder
-	mb.init(b, opt.UpdateOp, tab, *alias)
+	mb.init(b, "update", tab, *alias)
 
 	// Build the input expression that selects the rows that will be updated:
 	//
@@ -324,7 +324,7 @@ func (mb *mutationBuilder) addComputedColsForUpdate() {
 func (mb *mutationBuilder) buildUpdate(returning tree.ReturningExprs) {
 	mb.addCheckConstraintCols()
 
-	mb.buildFKChecks()
+	mb.buildFKChecksForUpdate()
 
 	private := mb.makeMutationPrivate(returning != nil)
 	for _, col := range mb.extraAccessibleCols {


### PR DESCRIPTION
This is some minor cleanup in mutationBuilder. The structure currently
stores an `Operator`, mainly used when creating error messages. This
operator is confusing, as it's not necessarily the operator that ends
up getting built (there is a case where it's set as `InsertOp` but we
end up building an Upsert).

This change removes the operator and replaces it with the statement
string. We now directly call into the correct `buildFKChecks` variant
without having to consult the operator.

Release note: None