### PR TITLE
cli: enable standard telemetry in demo

### DIFF
--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logflags"
 	"github.com/cockroachdb/cockroach/pkg/workload"
@@ -163,6 +164,13 @@ func setupTransientServers(
 		// Remember the first server created.
 		if i == 0 {
 			s = serv
+		}
+
+		// Start up the update check loop.
+		// We don't do this in (*server.Server).Start() because we don't want it
+		// in tests.
+		if !envutil.EnvOrDefaultBool("COCKROACH_SKIP_UPDATE_CHECK", false) {
+			serv.PeriodicallyCheckForUpdates(ctx)
 		}
 	}
 


### PR DESCRIPTION
Due to an implemention detail of how start and demo setup servers, servers created by demo did not previously enable telemetry reporting the same was as regular servers.

This patch fixes that, so they now behave the same as regular servers started via 'start' w.r.t telemetry, including respecting the same opt-in/out controls.

Release note (general change): servers started via 'cockroach demo' now have the same telemetry collection and reporting behavior as servers run via 'start'. See https://www.cockroachlabs.com/docs/stable/diagnostics-reporting.html for more details.