### PR TITLE
tree: skip nulls when type checking a list of tuples

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2327,3 +2327,26 @@ query TT
 SELECT pg_get_function_result('pg_sleep'::regproc), pg_get_function_result('unnest'::regproc)
 ----
 bool  anyelement
+
+# Regression test for #40297.
+statement ok
+CREATE TABLE t40297 AS SELECT g FROM generate_series(NULL, NULL) AS g
+
+query I
+SELECT COALESCE((SELECT ()), NULL) FROM t40297
+----
+
+query T
+SELECT CASE WHEN true THEN (1, 2) ELSE NULL END
+----
+(1,2)
+
+query B
+SELECT (1, 2) IN ((2, 3), NULL, (1, 2))
+----
+true
+
+query B
+SELECT (1, 2) IN ((2, 3), NULL)
+----
+NULL

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2316,11 +2316,17 @@ func makeEvalTupleIn(typ *types.T) *CmpOp {
 			} else {
 				// The left-hand side is a tuple, e.g. `(1, 2) IN ((1, 2), (3, 4))`.
 				for _, val := range vtuple.D {
-					// Use the EQ function which properly handles NULLs.
-					if res := cmpOpTupleFn(ctx, *argTuple, *val.(*DTuple), EQ); res == DNull {
+					if val == DNull {
+						// We allow for a null value to be in the list of tuples, so we
+						// need to check that upfront.
 						sawNull = true
-					} else if res == DBoolTrue {
-						return DBoolTrue, nil
+					} else {
+						// Use the EQ function which properly handles NULLs.
+						if res := cmpOpTupleFn(ctx, *argTuple, *val.(*DTuple), EQ); res == DNull {
+							sawNull = true
+						} else if res == DBoolTrue {
+							return DBoolTrue, nil
+						}
 					}
 				}
 			}

--- a/pkg/sql/sem/tree/type_check_internal_test.go
+++ b/pkg/sql/sem/tree/type_check_internal_test.go
@@ -292,6 +292,7 @@ func TestTypeCheckSameTypedTupleExprs(t *testing.T) {
 		// Verify dealing with Null.
 		{nil, nil, exprs(tuple(intConst("1"), dnull), tuple(dnull, decConst("1"))), ttuple(types.Int, types.Decimal), nil},
 		{nil, nil, exprs(tuple(dint(1), dnull), tuple(dnull, ddecimal(1))), ttuple(types.Int, types.Decimal), nil},
+		{nil, nil, exprs(tuple(dint(1), dnull), dnull, tuple(dint(1), dnull), dnull), ttuple(types.Int, types.Unknown), nil},
 		// Verify desired type when possible.
 		{nil, ttuple(types.Int, types.Decimal), exprs(tuple(intConst("1"), intConst("1")), tuple(intConst("1"), intConst("1"))), ttuple(types.Int, types.Decimal), nil},
 		// Verify desired type when possible with unresolved constants.


### PR DESCRIPTION
Previously, the type checking code for a list of tuples expected that
all expressions in the list are actually tuples. Now we will also allow
for nulls to be present in the list.

Fixes: #40297.

Release note (sql change): NULLs are now allowed to be among tuples when
being compared against a tuple.