### PR TITLE
store: pull updateMVCCGauges out of StoreMetrics lock, use atomics

### DIFF
--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
-	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -83,7 +82,6 @@ var recordHistogramQuantiles = []quantile{
 type storeMetrics interface {
 	StoreID() roachpb.StoreID
 	Descriptor(bool) (*roachpb.StoreDescriptor, error)
-	MVCCStats() enginepb.MVCCStats
 	Registry() *metric.Registry
 }
 

--- a/pkg/server/status/recorder_test.go
+++ b/pkg/server/status/recorder_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -81,7 +80,6 @@ var _ sort.Interface = byStoreDescID{}
 // interact with stores.
 type fakeStore struct {
 	storeID  roachpb.StoreID
-	stats    enginepb.MVCCStats
 	desc     roachpb.StoreDescriptor
 	registry *metric.Registry
 }
@@ -92,10 +90,6 @@ func (fs fakeStore) StoreID() roachpb.StoreID {
 
 func (fs fakeStore) Descriptor(_ bool) (*roachpb.StoreDescriptor, error) {
 	return &fs.desc, nil
-}
-
-func (fs fakeStore) MVCCStats() enginepb.MVCCStats {
-	return fs.stats
 }
 
 func (fs fakeStore) Registry() *metric.Registry {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2799,15 +2799,6 @@ func (s *Store) Metrics() *StoreMetrics {
 	return s.metrics
 }
 
-// MVCCStats returns the current MVCCStats accumulated for this store.
-// TODO(mrtracy): This should be removed as part of #4465, this is only needed
-// to support the current NodeStatus structures which will be changing.
-func (s *Store) MVCCStats() enginepb.MVCCStats {
-	s.metrics.mu.Lock()
-	defer s.metrics.mu.Unlock()
-	return s.metrics.mu.stats
-}
-
 // Descriptor returns a StoreDescriptor including current store
 // capacity information.
 func (s *Store) Descriptor(useCached bool) (*roachpb.StoreDescriptor, error) {


### PR DESCRIPTION
The operations it performs are already atomic, so we can use atomic add instructions to avoid any critical section.

This was responsible for 8.15% of mutex contention on a YCSB run.

The change also removes MVCCStats from the `storeMetrics` interface, which addresses a long-standing TODO.