### PR TITLE
rsg: bump memory limit during tests

### DIFF
--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -651,8 +651,6 @@ func testRandomSyntax(
 
 	params, _ := tests.CreateTestServerParams()
 	params.UseDatabase = databaseName
-	// Use a low memory limit to quickly halt runaway functions.
-	params.SQLMemoryPoolSize = 3 * 1024 * 1024 // 3MB
 	// Catch panics and return them as errors.
 	params.Knobs.PGWireTestingKnobs = &sql.PGWireTestingKnobs{
 		CatchPanics: true,


### PR DESCRIPTION
`CREATE TABLE AS` when used outside a transaction will use the bulk adder
which allocates 64MB from the memory pool. The 3MB limit was thus causing
an error during setup for the sqlsmith tests. Switch to the default limit.

Release note: None