### PR TITLE
exec: modify tests to catch bad selection vector access

### DIFF
--- a/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
@@ -67,6 +67,7 @@ func (p {{template "opRConstName" .}}) Next(ctx context.Context) coldata.Batch {
 	projVec := batch.ColVec(p.outputIdx)
 	projCol := projVec.{{.RetTyp}}()
 	if sel := batch.Selection(); sel != nil {
+		sel = sel[:n]
 		for _, i := range sel {
 			arg := {{.LTyp.Get "unsafe" "col" "int(i)"}}
 			{{(.Assign "projCol[i]" "arg" "p.constArg")}}
@@ -120,6 +121,7 @@ func (p {{template "opLConstName" .}}) Next(ctx context.Context) coldata.Batch {
 	projVec := batch.ColVec(p.outputIdx)
 	projCol := projVec.{{.RetTyp}}()
 	if sel := batch.Selection(); sel != nil {
+		sel = sel[:n]
 		for _, i := range sel {
 			arg := {{.RTyp.Get "unsafe" "col" "int(i)"}}
 			{{(.Assign "projCol[i]" "p.constArg" "arg")}}
@@ -175,6 +177,7 @@ func (p {{template "opName" .}}) Next(ctx context.Context) coldata.Batch {
 	col1 := vec1.{{.LTyp}}()
 	col2 := vec2.{{.RTyp}}()
 	if sel := batch.Selection(); sel != nil {
+		sel = sel[:n]
 		for _, i := range sel {
 			arg1 := {{.LTyp.Get "unsafe" "col1" "int(i)"}}
 			arg2 := {{.RTyp.Get "unsafe" "col2" "int(i)"}}


### PR DESCRIPTION
The runTests helper will now cause a panic if a vectorized operator
tries to access a part of the selection vector that is out of bounds.
This identified bugs in the projection operator.

Release note: None