### PR TITLE
cli: support \d client-side command with no arguments

### DIFF
--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -51,7 +51,7 @@ const (
 	helpMessageFmt = `You are using 'cockroach sql', CockroachDB's lightweight SQL client.
 Type:
   \? or "help"      print this help.
-  \q, quit, exit    exit the shell (Ctrl+C/Ctrl+D also supported)
+  \q, quit, exit    exit the shell (Ctrl+C/Ctrl+D also supported).
   \! CMD            run an external command and print its results on standard output.
   \| CMD            run an external command and run its output as SQL statements.
   \set [NAME]       set a client-side flag or (without argument) print the current settings.
@@ -59,10 +59,10 @@ Type:
   \show             during a multi-line statement or transaction, show the SQL entered so far.
   \h [NAME]         help on syntax of SQL commands.
   \hf [NAME]        help on SQL built-in functions.
-  \l                list all databases in the CockroachDB cluster
-  \dt               show the tables of the current schema in the current database
-  \du               list the users for all databases
-  \d TABLE          show details about columns in the specified table
+  \l                list all databases in the CockroachDB cluster.
+  \dt               show the tables of the current schema in the current database.
+  \du               list the users for all databases.
+  \d [TABLE]        show details about columns in the specified table, or alias for '\dt' if no table is specified.
 More documentation about our SQL dialect and the CLI shell is available online:
 %s
 %s`
@@ -1037,7 +1037,10 @@ func (c *cliState) doHandleCliCmd(loopState, nextState cliStateEnum) cliStateEnu
 		return cliRunStatement
 
 	case `\d`:
-		if len(cmd) == 2 {
+		if len(cmd) == 1 {
+			c.concatLines = `SHOW TABLES`
+			return cliRunStatement
+		} else if len(cmd) == 2 {
 			c.concatLines = `SHOW COLUMNS FROM ` + cmd[1]
 			return cliRunStatement
 		}

--- a/pkg/cli/sql_test.go
+++ b/pkg/cli/sql_test.go
@@ -190,10 +190,11 @@ func TestIsEndOfStatement(t *testing.T) {
 	}
 }
 
-// Test handleCliCmd cases for metacommands that are aliases for sql statements
-func TestHandleCliCmdSqlAliasMetacommands(t *testing.T) {
+// Test handleCliCmd cases for client-side commands that are aliases for sql
+// statements.
+func TestHandleCliCmdSqlAlias(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	metaCommandTestsTable := []struct {
+	clientSideCommandTestsTable := []struct {
 		commandString string
 		wantSQLStmt   string
 	}{
@@ -201,10 +202,11 @@ func TestHandleCliCmdSqlAliasMetacommands(t *testing.T) {
 		{`\dt`, `SHOW TABLES`},
 		{`\du`, `SHOW USERS`},
 		{`\d mytable`, `SHOW COLUMNS FROM mytable`},
+		{`\d`, `SHOW TABLES`},
 	}
 
 	var c cliState
-	for _, tt := range metaCommandTestsTable {
+	for _, tt := range clientSideCommandTestsTable {
 		c = setupTestCliState()
 		c.lastInputLine = tt.commandString
 		gotState := c.doHandleCliCmd(cliStateEnum(0), cliStateEnum(1))
@@ -217,10 +219,10 @@ func TestHandleCliCmdSqlAliasMetacommands(t *testing.T) {
 func TestHandleCliCmdSlashDInvalidSyntax(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	metaCommandTestsTable := []string{`\d`, `\d goodarg badarg`, `\dz`}
+	clientSideCommandTests := []string{`\d goodarg badarg`, `\dz`}
 
 	var c cliState
-	for _, tt := range metaCommandTestsTable {
+	for _, tt := range clientSideCommandTests {
 		c = setupTestCliState()
 		c.lastInputLine = tt
 		gotState := c.doHandleCliCmd(cliStateEnum(0), cliStateEnum(1))


### PR DESCRIPTION
`\d` can be used with no arguments as a way to show all the
tables in a database. This is an alias for `\dt`.

Release note (cli change): Support `\d` client-side command with no
arguments as an alias for `\dt`, for more ease of adoption by `psql`
users.