### PR TITLE
randutil: allow COCKROACH_RANDOM_SEED to seed NewPseudoRand

### DIFF
--- a/pkg/internal/sqlsmith/sqlsmith_test.go
+++ b/pkg/internal/sqlsmith/sqlsmith_test.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"math/rand"
 	"reflect"
 	"strings"
 	"testing"
@@ -49,10 +48,7 @@ func TestGenerateParse(t *testing.T) {
 	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
-	// Set COCKROACH_RANDOM_SEED to make this test deterministic between
-	// runs.
-	randutil.SeedForTests()
-	rnd := rand.New(rand.NewSource(rand.Int63()))
+	rnd, _ := randutil.NewPseudoRand()
 
 	db := sqlutils.MakeSQLRunner(sqlDB)
 	var opts []SmitherOption

--- a/pkg/util/randutil/rand.go
+++ b/pkg/util/randutil/rand.go
@@ -30,11 +30,13 @@ func NewPseudoSeed() int64 {
 	return seed
 }
 
-// NewPseudoRand returns an instance of math/rand.Rand seeded from crypto/rand
-// and its seed so we can easily and cheaply generate unique streams of
-// numbers. The created object is not safe for concurrent access.
+// NewPseudoRand returns an instance of math/rand.Rand seeded from the
+// environment variable COCKROACH_RANDOM_SEED.  If that variable is not set,
+// crypto/rand is used to generate a seed. The seed is also returned so we can
+// easily and cheaply generate unique streams of numbers. The created object is
+// not safe for concurrent access.
 func NewPseudoRand() (*rand.Rand, int64) {
-	seed := NewPseudoSeed()
+	seed := envutil.EnvOrDefaultInt64("COCKROACH_RANDOM_SEED", NewPseudoSeed())
 	return rand.New(rand.NewSource(seed)), seed
 }
 


### PR DESCRIPTION
Multiple people have been confused about the lack of interaction
between NewPseudoRand (which used to always generate a random seed)
and COCKROACH_RANDOM_SEED (which only influenced using the global rand
methods).

Release note: None