### PR TITLE
exec: generate a separate file for each join type for merge joiner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -792,7 +792,13 @@ EXECGEN_TARGETS = \
   pkg/sql/exec/distinct.eg.go \
   pkg/sql/exec/hashjoiner.eg.go \
   pkg/sql/exec/like_ops.eg.go \
-  pkg/sql/exec/mergejoiner.eg.go \
+  pkg/sql/exec/mergejoinbase.eg.go \
+  pkg/sql/exec/mergejoiner_fullouter.eg.go \
+  pkg/sql/exec/mergejoiner_inner.eg.go \
+  pkg/sql/exec/mergejoiner_leftanti.eg.go \
+  pkg/sql/exec/mergejoiner_leftouter.eg.go \
+  pkg/sql/exec/mergejoiner_leftsemi.eg.go \
+  pkg/sql/exec/mergejoiner_rightouter.eg.go \
   pkg/sql/exec/min_max_agg.eg.go \
   pkg/sql/exec/projection_ops.eg.go \
   pkg/sql/exec/quicksort.eg.go \
@@ -1463,7 +1469,13 @@ pkg/sql/exec/avg_agg.eg.go: pkg/sql/exec/avg_agg_tmpl.go
 pkg/sql/exec/const.eg.go: pkg/sql/exec/const_tmpl.go
 pkg/sql/exec/distinct.eg.go: pkg/sql/exec/distinct_tmpl.go
 pkg/sql/exec/hashjoiner.eg.go: pkg/sql/exec/hashjoiner_tmpl.go
-pkg/sql/exec/mergejoiner.eg.go: pkg/sql/exec/mergejoiner_tmpl.go
+pkg/sql/exec/mergejoinbase.eg.go: pkg/sql/exec/mergejoinbase_tmpl.go
+pkg/sql/exec/mergejoiner_fullouter.eg.go: pkg/sql/exec/mergejoiner_tmpl.go
+pkg/sql/exec/mergejoiner_inner.eg.go: pkg/sql/exec/mergejoiner_tmpl.go
+pkg/sql/exec/mergejoiner_leftanti.eg.go: pkg/sql/exec/mergejoiner_tmpl.go
+pkg/sql/exec/mergejoiner_leftouter.eg.go: pkg/sql/exec/mergejoiner_tmpl.go
+pkg/sql/exec/mergejoiner_leftsemi.eg.go: pkg/sql/exec/mergejoiner_tmpl.go
+pkg/sql/exec/mergejoiner_rightouter.eg.go: pkg/sql/exec/mergejoiner_tmpl.go
 pkg/sql/exec/min_max_agg.eg.go: pkg/sql/exec/min_max_agg_tmpl.go
 pkg/sql/exec/quicksort.eg.go: pkg/sql/exec/quicksort_tmpl.go
 pkg/sql/exec/rowstovec.eg.go: pkg/sql/exec/rowstovec_tmpl.go

--- a/pkg/sql/exec/.gitignore
+++ b/pkg/sql/exec/.gitignore
@@ -4,7 +4,13 @@ const.eg.go
 distinct.eg.go
 hashjoiner.eg.go
 like_ops.eg.go
-mergejoiner.eg.go
+mergejoinbase.eg.go
+mergejoiner_fullouter.eg.go
+mergejoiner_inner.eg.go
+mergejoiner_leftanti.eg.go
+mergejoiner_leftouter.eg.go
+mergejoiner_leftsemi.eg.go
+mergejoiner_rightouter.eg.go
 min_max_agg.eg.go
 projection_ops.eg.go
 quicksort.eg.go

--- a/pkg/sql/exec/execgen/cmd/execgen/mergejoinbase_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/mergejoinbase_gen.go
@@ -1,0 +1,68 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"io"
+	"io/ioutil"
+	"strings"
+	"text/template"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+func genMergeJoinBase(wr io.Writer) error {
+	d, err := ioutil.ReadFile("pkg/sql/exec/mergejoinbase_tmpl.go")
+	if err != nil {
+		return err
+	}
+
+	s := string(d)
+
+	// Replace the template variables.
+	s = strings.Replace(s, "_GOTYPE", "{{.LTyp.GoTypeName}}", -1)
+	s = strings.Replace(s, "_TYPES_T", "coltypes.{{.LTyp}}", -1)
+	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
+
+	assignEqRe := makeFunctionRegex("_ASSIGN_EQ", 3)
+	s = assignEqRe.ReplaceAllString(s, `{{.Eq.Assign $1 $2 $3}}`)
+
+	s = replaceManipulationFuncs(".LTyp", s)
+
+	tmpl, err := template.New("mergejoinbase").Parse(s)
+	if err != nil {
+		return err
+	}
+
+	allOverloads := intersectOverloads(sameTypeComparisonOpToOverloads[tree.EQ], sameTypeComparisonOpToOverloads[tree.LT], sameTypeComparisonOpToOverloads[tree.GT])
+
+	// Create an mjOverload for each overload combining three overloads so that
+	// the template code can access all of EQ, LT, and GT in the same range loop.
+	mjOverloads := make([]mjOverload, len(allOverloads[0]))
+	for i := range allOverloads[0] {
+		mjOverloads[i] = mjOverload{
+			overload: *allOverloads[0][i],
+			Eq:       allOverloads[0][i],
+			Lt:       allOverloads[1][i],
+			Gt:       allOverloads[2][i],
+		}
+	}
+
+	return tmpl.Execute(wr, struct {
+		MJOverloads interface{}
+	}{
+		MJOverloads: mjOverloads,
+	})
+}
+
+func init() {
+	registerGenerator(genMergeJoinBase, "mergejoinbase.eg.go")
+}

--- a/pkg/sql/exec/mergejoinbase_tmpl.go
+++ b/pkg/sql/exec/mergejoinbase_tmpl.go
@@ -1,0 +1,124 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// {{/*
+// +build execgen_template
+//
+// This file is the execgen template for mergejoinerbase.eg.go. It's formatted
+// in a special way, so it's both valid Go and a valid text/template input.
+// This permits editing this file with editor support.
+//
+// */}}
+
+package exec
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+
+	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/execgen"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// {{/*
+// Declarations to make the template compile properly.
+
+// Dummy import to pull in "bytes" package.
+var _ bytes.Buffer
+
+// Dummy import to pull in "tree" package.
+var _ tree.Datum
+
+// Dummy import to pull in "apd" package.
+var _ apd.Decimal
+
+// Dummy import to pull in "math" package.
+var _ = math.MaxInt64
+
+// _TYPES_T is the template type variable for coltypes.T. It will be replaced by
+// coltypes.Foo for each type Foo in the coltypes.T type.
+const _TYPES_T = coltypes.Unhandled
+
+// _GOTYPE is the template Go type variable for this operator. It will be
+// replaced by the Go type equivalent for each type in coltypes.T, for example
+// int64 for coltypes.Int64.
+type _GOTYPE interface{}
+
+// _ASSIGN_EQ is the template equality function for assigning the first input
+// to the result of the the second input == the third input.
+func _ASSIGN_EQ(_, _, _ interface{}) uint64 {
+	execerror.VectorizedInternalPanic("")
+}
+
+// */}}
+
+// Use execgen package to remove unused import warning.
+var _ interface{} = execgen.UNSAFEGET
+
+// isBufferedGroupFinished checks to see whether or not the buffered group
+// corresponding to input continues in batch.
+func (o *mergeJoinBase) isBufferedGroupFinished(
+	input *mergeJoinInput, batch coldata.Batch, rowIdx int,
+) bool {
+	if batch.Length() == 0 {
+		return true
+	}
+	bufferedGroup := o.proberState.lBufferedGroup
+	if input == &o.right {
+		bufferedGroup = o.proberState.rBufferedGroup
+	}
+	lastBufferedTupleIdx := bufferedGroup.length - 1
+	tupleToLookAtIdx := uint64(rowIdx)
+	sel := batch.Selection()
+	if sel != nil {
+		tupleToLookAtIdx = uint64(sel[rowIdx])
+	}
+
+	// Check all equality columns in the first row of batch to make sure we're in
+	// the same group.
+	for _, colIdx := range input.eqCols[:len(input.eqCols)] {
+		colTyp := input.sourceTypes[colIdx]
+
+		switch colTyp {
+		// {{ range $.MJOverloads }}
+		case _TYPES_T:
+			// We perform this null check on every equality column of the last
+			// buffered tuple regardless of the join type since it is done only once
+			// per batch. In some cases (like INNER JOIN, or LEFT OUTER JOIN with the
+			// right side being an input) this check will always return false since
+			// nulls couldn't be buffered up though.
+			if bufferedGroup.ColVec(int(colIdx)).Nulls().NullAt64(uint64(lastBufferedTupleIdx)) {
+				return true
+			}
+			bufferedCol := bufferedGroup.ColVec(int(colIdx))._TemplateType()
+			prevVal := execgen.UNSAFEGET(bufferedCol, int(lastBufferedTupleIdx))
+			var curVal _GOTYPE
+			if batch.ColVec(int(colIdx)).MaybeHasNulls() && batch.ColVec(int(colIdx)).Nulls().NullAt64(tupleToLookAtIdx) {
+				return true
+			}
+			col := batch.ColVec(int(colIdx))._TemplateType()
+			curVal = execgen.UNSAFEGET(col, int(tupleToLookAtIdx))
+			var match bool
+			_ASSIGN_EQ("match", "prevVal", "curVal")
+			if !match {
+				return true
+			}
+		// {{end}}
+		default:
+			execerror.VectorizedInternalPanic(fmt.Sprintf("unhandled type %d", colTyp))
+		}
+	}
+	return false
+}


### PR DESCRIPTION
The generated merge joiner file got to the point where GoLand became
not really useful (like the usage of methods in the search would not
show up). Additionally, bigger code files seem to have a minor
performance impact. Now we generate a separate file for each of the
join types as well as a new file for the shared base logic.

Release note: None