### PR TITLE
exec: add streamID to the Inbox

### DIFF
--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -32,6 +33,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/logtags"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
@@ -214,7 +217,7 @@ func TestOutboxInbox(t *testing.T) {
 		outbox, err := NewOutbox(input, typs, nil)
 		require.NoError(t, err)
 
-		inbox, err := NewInbox(typs)
+		inbox, err := NewInbox(typs, execinfrapb.StreamID(0))
 		require.NoError(t, err)
 
 		streamHandlerErrCh := handleStream(serverStream.Context(), inbox, serverStream, func() { close(serverStreamNotification.Donec) })
@@ -444,7 +447,7 @@ func TestOutboxInboxMetadataPropagation(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			inbox, err := NewInbox(typs)
+			inbox, err := NewInbox(typs, execinfrapb.StreamID(0))
 			require.NoError(t, err)
 
 			var (
@@ -505,7 +508,7 @@ func BenchmarkOutboxInbox(b *testing.B) {
 	outbox, err := NewOutbox(input, typs, nil /* metadataSources */)
 	require.NoError(b, err)
 
-	inbox, err := NewInbox(typs)
+	inbox, err := NewInbox(typs, execinfrapb.StreamID(0))
 	require.NoError(b, err)
 
 	var wg sync.WaitGroup
@@ -530,4 +533,130 @@ func BenchmarkOutboxInbox(b *testing.B) {
 
 	require.NoError(b, <-streamHandlerErrCh)
 	wg.Wait()
+}
+
+func TestOutboxStreamIDPropagation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	outboxStreamID := execinfrapb.StreamID(1234)
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	_, mockServer, addr, err := execinfrapb.StartMockDistSQLServer(
+		hlc.NewClock(hlc.UnixNano, time.Nanosecond), stopper, execinfra.StaticNodeID,
+	)
+	require.NoError(t, err)
+	dialer := &execinfrapb.MockDialer{Addr: addr}
+	defer dialer.Close()
+
+	typs := []coltypes.T{coltypes.Int64}
+
+	var inTags *logtags.Buffer
+
+	nextDone := make(chan struct{})
+	input := &colexec.CallbackOperator{NextCb: func(ctx context.Context) coldata.Batch {
+		b := coldata.NewMemBatchWithSize(typs, 0)
+		b.SetLength(0)
+		inTags = logtags.FromContext(ctx)
+		nextDone <- struct{}{}
+		return b
+	}}
+
+	outbox, err := NewOutbox(input, typs, nil)
+	require.NoError(t, err)
+
+	outboxDone := make(chan struct{})
+	go func() {
+		outbox.Run(
+			ctx,
+			dialer,
+			roachpb.NodeID(0),
+			execinfrapb.FlowID{UUID: uuid.MakeV4()},
+			outboxStreamID,
+			nil,
+		)
+		outboxDone <- struct{}{}
+	}()
+
+	<-nextDone
+	serverStreamNotification := <-mockServer.InboundStreams
+	close(serverStreamNotification.Donec)
+	<-outboxDone
+
+	// Assert that the ctx passed to Next() has no caller tags (e.g. streamID).
+	require.Equal(t, (*logtags.Buffer)(nil), inTags)
+}
+
+func TestInboxCtxStreamIDTagging(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	streamID := execinfrapb.StreamID(1234)
+	ctx := context.Background()
+	inboxInternalCtx := context.Background()
+	taggedCtx := logtags.AddTag(context.Background(), "streamID", streamID)
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	testCases := []struct {
+		name string
+		// test is the body of the test to be run.
+		test func(context.Context, *Inbox)
+	}{
+		{
+			// CtxTaggedInNext verifies that Next adds StreamID to the Context in maybeInit.
+			name: "CtxTaggedInNext",
+			test: func(ctx context.Context, inbox *Inbox) {
+				inbox.Next(ctx)
+			},
+		},
+		{
+			// CtxTaggedInDrainMeta verifies that DrainMeta adds StreamID to the Context in maybeInit.
+			name: "CtxTaggedInDrainMeta",
+			test: func(ctx context.Context, inbox *Inbox) {
+				inbox.DrainMeta(ctx)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			rpcLayer := makeMockFlowStreamRPCLayer()
+
+			typs := []coltypes.T{coltypes.Int64}
+
+			inbox, err := NewInbox(typs, streamID)
+			require.NoError(t, err)
+
+			ctxExtract := make(chan struct{})
+			inbox.ctxInterceptorFn = func(ctx context.Context) {
+				inboxInternalCtx = ctx
+				ctxExtract <- struct{}{}
+			}
+
+			streamHandlerErr := handleStream(ctx, inbox, callbackFlowStreamServer{
+				server: rpcLayer.server,
+				recvCb: nil,
+			}, nil)
+
+			inboxTested := make(chan struct{})
+			go func() {
+				tc.test(ctx, inbox)
+				inboxTested <- struct{}{}
+			}()
+
+			<-ctxExtract
+			require.NoError(t, rpcLayer.client.CloseSend())
+			require.NoError(t, <-streamHandlerErr)
+			<-inboxTested
+
+			// Assert that ctx passed to Next and DrainMeta was not modified.
+			require.Equal(t, (*logtags.Buffer)(nil), logtags.FromContext(ctx))
+			// Assert that inboxInternalCtx has streamID tag, after init is called.
+			require.Equal(t, logtags.FromContext(taggedCtx), logtags.FromContext(inboxInternalCtx))
+
+		})
+	}
 }

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/logtags"
 )
 
 // flowStreamServer is a utility interface used to mock out the RPC layer.
@@ -52,6 +53,10 @@ type Inbox struct {
 	converter  *colserde.ArrowBatchConverter
 	serializer *colserde.RecordBatchSerializer
 
+	// streamID is used to overwrite a caller's streamID
+	// in the ctx argument of Next and DrainMeta.
+	streamID execinfrapb.StreamID
+
 	// streamCh is the channel over which the stream is passed from the stream
 	// handler to the reader goroutine.
 	streamCh chan flowStreamServer
@@ -69,6 +74,10 @@ type Inbox struct {
 	// channel in the event of a cancellation or a non-io.EOF error originating
 	// from a stream.Recv.
 	errCh chan error
+
+	// ctxInterceptorFn is a callback to expose the inbox's context
+	// right after init. To be used for unit testing.
+	ctxInterceptorFn func(context.Context)
 
 	// We need two mutexes because a single mutex is insufficient to handle
 	// concurrent calls to Next() and DrainMeta(). See comment in DrainMeta.
@@ -109,7 +118,7 @@ type Inbox struct {
 var _ colexec.StaticMemoryOperator = &Inbox{}
 
 // NewInbox creates a new Inbox.
-func NewInbox(typs []coltypes.T) (*Inbox, error) {
+func NewInbox(typs []coltypes.T, streamID execinfrapb.StreamID) (*Inbox, error) {
 	c, err := colserde.NewArrowBatchConverter(typs)
 	if err != nil {
 		return nil, err
@@ -123,6 +132,7 @@ func NewInbox(typs []coltypes.T) (*Inbox, error) {
 		zeroBatch:  coldata.NewMemBatchWithSize(typs, 0),
 		converter:  c,
 		serializer: s,
+		streamID:   streamID,
 		streamCh:   make(chan flowStreamServer, 1),
 		contextCh:  make(chan context.Context, 1),
 		timeoutCh:  make(chan error, 1),
@@ -175,6 +185,10 @@ func (i *Inbox) initLocked(ctx context.Context) error {
 		i.errCh <- fmt.Errorf("%s: Inbox while waiting for stream", ctx.Err())
 		return ctx.Err()
 	}
+
+	if i.ctxInterceptorFn != nil {
+		i.ctxInterceptorFn(ctx)
+	}
 	i.contextCh <- ctx
 	return nil
 }
@@ -193,6 +207,7 @@ func (i *Inbox) closeLocked() {
 // canceled, a caller of Next cancels the first context passed into Next, or
 // an EOF is encountered on the stream by the Next goroutine.
 func (i *Inbox) RunWithStream(streamCtx context.Context, stream flowStreamServer) error {
+	streamCtx = logtags.AddTag(streamCtx, "streamID", i.streamID)
 	log.VEvent(streamCtx, 2, "Inbox handling stream")
 	defer log.VEvent(streamCtx, 2, "Inbox exited stream handler")
 	// Pass the stream to the reader goroutine (non-blocking) and get the context
@@ -250,6 +265,8 @@ func (i *Inbox) Next(ctx context.Context) coldata.Batch {
 		// the length here (and below) to 0?
 		return i.zeroBatch
 	}
+
+	ctx = logtags.AddTag(ctx, "streamID", i.streamID)
 
 	defer func() {
 		// Catch any panics that occur and close the errCh in order to not leak the
@@ -347,6 +364,8 @@ func (i *Inbox) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
 	if i.stateMu.done {
 		return allMeta
 	}
+
+	ctx = logtags.AddTag(ctx, "streamID", i.streamID)
 
 	// We want draining the Inbox to work regardless of whether or not we have a
 	// goroutine in Next. We essentially need to do two things: 1) Is the stream

--- a/pkg/sql/colflow/colrpc/inbox_test.go
+++ b/pkg/sql/colflow/colrpc/inbox_test.go
@@ -60,7 +60,7 @@ func TestInboxCancellation(t *testing.T) {
 
 	typs := []coltypes.T{coltypes.Int64}
 	t.Run("ReaderWaitingForStreamHandler", func(t *testing.T) {
-		inbox, err := NewInbox(typs)
+		inbox, err := NewInbox(typs, execinfrapb.StreamID(0))
 		require.NoError(t, err)
 		ctx, cancelFn := context.WithCancel(context.Background())
 		// Cancel the context.
@@ -75,7 +75,7 @@ func TestInboxCancellation(t *testing.T) {
 
 	t.Run("DuringRecv", func(t *testing.T) {
 		rpcLayer := makeMockFlowStreamRPCLayer()
-		inbox, err := NewInbox(typs)
+		inbox, err := NewInbox(typs, execinfrapb.StreamID(0))
 		require.NoError(t, err)
 		ctx, cancelFn := context.WithCancel(context.Background())
 
@@ -106,7 +106,7 @@ func TestInboxCancellation(t *testing.T) {
 
 	t.Run("StreamHandlerWaitingForReader", func(t *testing.T) {
 		rpcLayer := makeMockFlowStreamRPCLayer()
-		inbox, err := NewInbox(typs)
+		inbox, err := NewInbox(typs, execinfrapb.StreamID(0))
 		require.NoError(t, err)
 
 		ctx, cancelFn := context.WithCancel(context.Background())
@@ -124,7 +124,7 @@ func TestInboxCancellation(t *testing.T) {
 func TestInboxNextPanicDoesntLeakGoroutines(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	inbox, err := NewInbox([]coltypes.T{coltypes.Int64})
+	inbox, err := NewInbox([]coltypes.T{coltypes.Int64}, execinfrapb.StreamID(0))
 	require.NoError(t, err)
 
 	rpcLayer := makeMockFlowStreamRPCLayer()
@@ -149,7 +149,7 @@ func TestInboxNextPanicDoesntLeakGoroutines(t *testing.T) {
 func TestInboxTimeout(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	inbox, err := NewInbox([]coltypes.T{coltypes.Int64})
+	inbox, err := NewInbox([]coltypes.T{coltypes.Int64}, execinfrapb.StreamID(0))
 	require.NoError(t, err)
 
 	var (
@@ -218,7 +218,7 @@ func TestInboxShutdown(t *testing.T) {
 					"drain=%t/next=%t/stream=%t/inf=%t",
 					runDrainMetaGoroutine, runNextGoroutine, runRunWithStreamGoroutine, infiniteBatches,
 				), func(t *testing.T) {
-					inbox, err := NewInbox(typs)
+					inbox, err := NewInbox(typs, execinfrapb.StreamID(0))
 					require.NoError(t, err)
 					c, err := colserde.NewArrowBatchConverter(typs)
 					require.NoError(t, err)

--- a/pkg/sql/colflow/colrpc/outbox_test.go
+++ b/pkg/sql/colflow/colrpc/outbox_test.go
@@ -50,7 +50,7 @@ func TestOutboxCatchesPanics(t *testing.T) {
 		wg.Done()
 	}()
 
-	inbox, err := NewInbox(typs)
+	inbox, err := NewInbox(typs, execinfrapb.StreamID(0))
 	require.NoError(t, err)
 
 	streamHandlerErrCh := handleStream(ctx, inbox, rpcLayer.server, func() { close(rpcLayer.server.csChan) })

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -31,7 +31,7 @@ import (
 
 type callbackRemoteComponentCreator struct {
 	newOutboxFn func(colexec.Operator, []coltypes.T, []execinfrapb.MetadataSource) (*colrpc.Outbox, error)
-	newInboxFn  func(typs []coltypes.T) (*colrpc.Inbox, error)
+	newInboxFn  func(typs []coltypes.T, streamID execinfrapb.StreamID) (*colrpc.Inbox, error)
 }
 
 func (c callbackRemoteComponentCreator) newOutbox(
@@ -40,8 +40,10 @@ func (c callbackRemoteComponentCreator) newOutbox(
 	return c.newOutboxFn(input, typs, metadataSources)
 }
 
-func (c callbackRemoteComponentCreator) newInbox(typs []coltypes.T) (*colrpc.Inbox, error) {
-	return c.newInboxFn(typs)
+func (c callbackRemoteComponentCreator) newInbox(
+	typs []coltypes.T, streamID execinfrapb.StreamID,
+) (*colrpc.Inbox, error) {
+	return c.newInboxFn(typs, streamID)
 }
 
 func intCols(numCols int) []types.T {
@@ -185,8 +187,8 @@ func TestDrainOnlyInputDAG(t *testing.T) {
 			require.Len(t, inboxToNumInputTypes[sources[0].(*colrpc.Inbox)], numInputTypesToOutbox)
 			return colrpc.NewOutbox(op, typs, sources)
 		},
-		newInboxFn: func(typs []coltypes.T) (*colrpc.Inbox, error) {
-			inbox, err := colrpc.NewInbox(typs)
+		newInboxFn: func(typs []coltypes.T, streamID execinfrapb.StreamID) (*colrpc.Inbox, error) {
+			inbox, err := colrpc.NewInbox(typs, streamID)
 			inboxToNumInputTypes[inbox] = typs
 			return inbox, err
 		},


### PR DESCRIPTION
Resolves #39399
This commit adds SreamID to the Inbox.
To distinguish between StreamID of the inbox's creator
and the StreamID of the inbox's methods caller.
This commit also add tests, that verify following:
1. `Outbox.sendBatches()` doesn't propogate its ctx to `Next()`
2. `Inbox.Next()` adds Inboxes StreamID to the incoming ctx
3. `Inbox.DrainMeta()` adds Inboxes StreamID to the incoming ctx

Release justification: low-risk patch to log tags to improve debuggability.