### PR TITLE
coltypes: don't shallow copy decimals

### DIFF
--- a/pkg/col/coltypes/types.go
+++ b/pkg/col/coltypes/types.go
@@ -12,6 +12,8 @@ package coltypes
 
 import (
 	"fmt"
+	"strings"
+	"text/template"
 
 	"github.com/cockroachdb/apd"
 )
@@ -143,6 +145,7 @@ var (
 	_ = Bool.Swap
 	_ = Bool.Slice
 	_ = Bool.CopySlice
+	_ = Bool.CopyVal
 	_ = Bool.AppendSlice
 	_ = Bool.AppendVal
 	_ = Bool.Len
@@ -159,34 +162,63 @@ func (t T) GoTypeSliceName() string {
 }
 
 // Get is a function that should only be used in templates.
-func (t T) Get(safe string, target, i string) string {
-	if safe != "safe" && safe != "unsafe" {
-		panic(fmt.Sprintf("unknown safe argument %s, use either safe or unsafe", safe))
-	}
-	if t == Bytes {
-		getString := fmt.Sprintf("%s.Get(%s)", target, i)
-		if safe == "safe" {
-			getString = "append([]byte(nil), " + getString + "...)"
-		}
-		return getString
+func (t T) Get(target, i string) string {
+	switch t {
+	case Bytes:
+		return fmt.Sprintf("%s.Get(%s)", target, i)
 	}
 	return fmt.Sprintf("%s[%s]", target, i)
 }
 
+// CopyVal is a function that should only be used in templates.
+func (t T) CopyVal(dest, src string) string {
+	switch t {
+	case Bytes:
+		return fmt.Sprintf("%[1]s = append(%[1]s[:0], %[2]s...)", dest, src)
+	case Decimal:
+		return fmt.Sprintf("%s.Set(&%s)", dest, src)
+	}
+	return fmt.Sprintf("%s = %s", dest, src)
+}
+
 // Set is a function that should only be used in templates.
 func (t T) Set(target, i, new string) string {
-	if t == Bytes {
+	switch t {
+	case Bytes:
 		return fmt.Sprintf("%s.Set(%s, %s)", target, i, new)
+	case Decimal:
+		return fmt.Sprintf("%s[%s].Set(&%s)", target, i, new)
 	}
 	return fmt.Sprintf("%s[%s] = %s", target, i, new)
 }
 
 // Swap is a function that should only be used in templates.
 func (t T) Swap(target, i, j string) string {
-	if t == Bytes {
-		return fmt.Sprintf("%s.Swap(%s, %s)", target, i, j)
+	var tmpl string
+	switch t {
+	case Bytes:
+		tmpl = `{{.Tgt}}.Swap({{.I}}, {{.J}})`
+	case Decimal:
+		tmpl = `
+{
+  var __tmp apd.Decimal
+  __tmp.Set(&{{.Tgt}}[{{.I}}])
+  {{.Tgt}}[{{.I}}].Set(&{{.Tgt}}[{{.J}}])
+  {{.Tgt}}[{{.J}}].Set(&{{.Tgt}}[{{.I}}])
+}`
+	default:
+		tmpl = `{{.Tgt}}[{{.I}}], {{.Tgt}}[{{.J}}] = {{.Tgt}}[{{.J}}], {{.Tgt}}[{{.I}}]`
 	}
-	return fmt.Sprintf("%[1]s[%[2]s], %[1]s[%[3]s] = %[1]s[%[3]s], %[1]s[%[2]s]", target, i, j)
+	args := map[string]string{
+		"Tgt": target,
+		"I":   j,
+		"J":   j,
+	}
+	var buf strings.Builder
+	if err := template.Must(template.New("").Parse(tmpl)).Execute(&buf, args); err != nil {
+		panic(err)
+	}
+	return buf.String()
 }
 
 // Slice is a function that should only be used in templates.
@@ -199,26 +231,84 @@ func (t T) Slice(target, start, end string) string {
 
 // CopySlice is a function that should only be used in templates.
 func (t T) CopySlice(target, src, destIdx, srcStartIdx, srcEndIdx string) string {
-	if t == Bytes {
-		return fmt.Sprintf("%s.CopySlice(%s, %s, %s, %s)", target, src, destIdx, srcStartIdx, srcEndIdx)
+	var tmpl string
+	switch t {
+	case Bytes:
+		tmpl = `{{.Tgt}}.CopySlice({{.Src}}, {{.TgtIdx}}, {{.SrcStart}}, {{.SrcEnd}})`
+	case Decimal:
+		tmpl = `{
+  __tgt_slice := {{.Tgt}}[{{.TgtIdx}}:]
+  __src_slice := {{.Src}}[{{.SrcStart}}:{{.SrcEnd}}]
+  for __i := range __src_slice {
+    __tgt_slice[__i].Set(&__src_slice[__i])
+  }
+}`
+	default:
+		tmpl = `copy({{.Tgt}}[{{.TgtIdx}}:], {{.Src}}[{{.SrcStart}}:{{.SrcEnd}}])`
 	}
-	return fmt.Sprintf("copy(%s[%s:], %s[%s:%s])", target, destIdx, src, srcStartIdx, srcEndIdx)
+	args := map[string]string{
+		"Tgt":      target,
+		"Src":      src,
+		"TgtIdx":   destIdx,
+		"SrcStart": srcStartIdx,
+		"SrcEnd":   srcEndIdx,
+	}
+	var buf strings.Builder
+	if err := template.Must(template.New("").Parse(tmpl)).Execute(&buf, args); err != nil {
+		panic(err)
+	}
+	return buf.String()
 }
 
 // AppendSlice is a function that should only be used in templates.
 func (t T) AppendSlice(target, src, destIdx, srcStartIdx, srcEndIdx string) string {
-	if t == Bytes {
-		return fmt.Sprintf("%s.AppendSlice(%s, %s, %s, %s)", target, src, destIdx, srcStartIdx, srcEndIdx)
+	var tmpl string
+	switch t {
+	case Bytes:
+		tmpl = `{{.Tgt}}.AppendSlice({{.Src}}, {{.TgtIdx}}, {{.SrcStart}}, {{.SrcEnd}})`
+	case Decimal:
+		tmpl = `{
+  __desiredCap := {{.TgtIdx}} + {{.SrcEnd}} - {{.SrcStart}}
+  if cap({{.Tgt}}) >= __desiredCap {
+  	{{.Tgt}} = {{.Tgt}}[:__desiredCap]
+  } else {
+    __new_slice := make([]apd.Decimal, __desiredCap)
+    copy(__new_slice, {{.Tgt}})
+    {{.Tgt}} = __new_slice
+  }
+  __src_slice := {{.Src}}[{{.SrcStart}}:{{.SrcEnd}}]
+  __dst_slice := {{.Tgt}}[{{.TgtIdx}}:]
+  for __i := range __src_slice {
+    __dst_slice[__i].Set(&__src_slice[__i])
+  }
+}`
+	default:
+		tmpl = `{{.Tgt}} = append({{.Tgt}}[:{{.TgtIdx}}], {{.Src}}[{{.SrcStart}}:{{.SrcEnd}}]...)`
 	}
-	return fmt.Sprintf("%[1]s = append(%[1]s[:%s], %s[%s:%s]...)", target, destIdx, src, srcStartIdx, srcEndIdx)
+	args := map[string]string{
+		"Tgt":      target,
+		"Src":      src,
+		"TgtIdx":   destIdx,
+		"SrcStart": srcStartIdx,
+		"SrcEnd":   srcEndIdx,
+	}
+	var buf strings.Builder
+	if err := template.Must(template.New("").Parse(tmpl)).Execute(&buf, args); err != nil {
+		panic(err)
+	}
+	return buf.String()
 }
 
 // AppendVal is a function that should only be used in templates.
 func (t T) AppendVal(target, v string) string {
-	if t == Bytes {
+	switch t {
+	case Bytes:
 		return fmt.Sprintf("%s.AppendVal(%s)", target, v)
+	case Decimal:
+		return fmt.Sprintf(`%[1]s = append(%[1]s, apd.Decimal{})
+%[1]s[len(%[1]s)-1].Set(&%[2]s)`, target, v)
 	}
-	return fmt.Sprintf("%[1]s = append(%[1]s, %s)", target, v)
+	return fmt.Sprintf("%[1]s = append(%[1]s, %[2]s)", target, v)
 }
 
 // Len is a function that should only be used in templates.
@@ -239,8 +329,13 @@ func (t T) Range(loopVariableIdent string, target string) string {
 
 // Zero is a function that should only be used in templates.
 func (t T) Zero(target string) string {
-	if t == Bytes {
+	switch t {
+	case Bytes:
 		return fmt.Sprintf("%s.Zero()", target)
+	case Decimal:
+		return fmt.Sprintf(`for n := 0; n < len(%[1]s); n++ {
+    %[1]s[n].SetInt64(0)
+}`, target)
 	}
 	return fmt.Sprintf("for n := 0; n < len(%[1]s); n += copy(%[1]s[n:], zero%sColumn) {}", target, t.String())
 }

--- a/pkg/sql/exec/any_not_null_agg_tmpl.go
+++ b/pkg/sql/exec/any_not_null_agg_tmpl.go
@@ -183,7 +183,7 @@ func _FIND_ANY_NOT_NULL(a *anyNotNull_TYPEAgg, nulls *coldata.Nulls, i int, _HAS
 		// Explicit template language is used here because the type receiver differs
 		// from the rest of the template file.
 		// TODO(asubiotto): Figure out a way to alias this.
-		// v := {{ .Global.Get "unsafe" "col" "int(i)" }}
+		// v := {{ .Global.Get "col" "int(i)" }}
 		// {{ .Global.Set "a.vec" "a.curIdx" "v" }}
 		a.foundNonNullForCurrentGroup = true
 	}

--- a/pkg/sql/exec/cast_tmpl.go
+++ b/pkg/sql/exec/cast_tmpl.go
@@ -50,8 +50,8 @@ func _ASSIGN_CAST(to, from interface{}) {
 	execerror.VectorizedInternalPanic("")
 }
 
-// This will be replaced with execgen.GET.
-func _FROM_TYPE_GET(to, from interface{}) interface{} {
+// This will be replaced with execgen.UNSAFEGET
+func _FROM_TYPE_UNSAFEGET(to, from interface{}) interface{} {
 	execerror.VectorizedInternalPanic("")
 }
 
@@ -68,7 +68,7 @@ func _FROM_TYPE_SLICE(col, i, j interface{}) interface{} {
 // */}}
 
 // Use execgen package to remove unused import warning.
-var _ interface{} = execgen.GET
+var _ interface{} = execgen.UNSAFEGET
 
 func GetCastOperator(
 	input Operator, colIdx int, resultIdx int, fromType *semtypes.T, toType *semtypes.T,
@@ -142,7 +142,7 @@ func (c *castOp_FROMTYPE_TOTYPE) Next(ctx context.Context) coldata.Batch {
 				if vecNulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
-					v := _FROM_TYPE_GET(col, int(i))
+					v := _FROM_TYPE_UNSAFEGET(col, int(i))
 					var r _GOTYPE
 					_ASSIGN_CAST(r, v)
 					_TO_TYPE_SET(projCol, int(i), r)
@@ -154,7 +154,7 @@ func (c *castOp_FROMTYPE_TOTYPE) Next(ctx context.Context) coldata.Batch {
 				if vecNulls.NullAt(uint16(i)) {
 					projNulls.SetNull(uint16(i))
 				} else {
-					v := _FROM_TYPE_GET(col, int(i))
+					v := _FROM_TYPE_UNSAFEGET(col, int(i))
 					var r _GOTYPE
 					_ASSIGN_CAST(r, v)
 					_TO_TYPE_SET(projCol, int(i), r)
@@ -165,7 +165,7 @@ func (c *castOp_FROMTYPE_TOTYPE) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				v := _FROM_TYPE_GET(col, int(i))
+				v := _FROM_TYPE_UNSAFEGET(col, int(i))
 				var r _GOTYPE
 				_ASSIGN_CAST(r, v)
 				_TO_TYPE_SET(projCol, int(i), r)
@@ -173,7 +173,7 @@ func (c *castOp_FROMTYPE_TOTYPE) Next(ctx context.Context) coldata.Batch {
 		} else {
 			col = _FROM_TYPE_SLICE(col, 0, int(n))
 			for execgen.RANGE(i, col) {
-				v := _FROM_TYPE_GET(col, int(i))
+				v := _FROM_TYPE_UNSAFEGET(col, int(i))
 				var r _GOTYPE
 				_ASSIGN_CAST(r, v)
 				_TO_TYPE_SET(projCol, int(i), r)

--- a/pkg/sql/exec/cast_tmpl.go
+++ b/pkg/sql/exec/cast_tmpl.go
@@ -50,6 +50,21 @@ func _ASSIGN_CAST(to, from interface{}) {
 	execerror.VectorizedInternalPanic("")
 }
 
+// This will be replaced with execgen.GET.
+func _FROM_TYPE_GET(to, from interface{}) interface{} {
+	execerror.VectorizedInternalPanic("")
+}
+
+// This will be replaced with execgen.SET.
+func _TO_TYPE_SET(to, from interface{}) {
+	execerror.VectorizedInternalPanic("")
+}
+
+// This will be replaced with execgen.SLICE.
+func _FROM_TYPE_SLICE(col, i, j interface{}) interface{} {
+	execerror.VectorizedInternalPanic("")
+}
+
 // */}}
 
 // Use execgen package to remove unused import warning.
@@ -127,21 +142,22 @@ func (c *castOp_FROMTYPE_TOTYPE) Next(ctx context.Context) coldata.Batch {
 				if vecNulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
-					v := execgen.GET(col, int(i))
+					v := _FROM_TYPE_GET(col, int(i))
 					var r _GOTYPE
 					_ASSIGN_CAST(r, v)
-					execgen.SET(projCol, int(i), r)
+					_TO_TYPE_SET(projCol, int(i), r)
 				}
 			}
 		} else {
+			col = _FROM_TYPE_SLICE(col, 0, int(n))
 			for execgen.RANGE(i, col) {
 				if vecNulls.NullAt(uint16(i)) {
 					projNulls.SetNull(uint16(i))
 				} else {
-					v := execgen.GET(col, i)
+					v := _FROM_TYPE_GET(col, int(i))
 					var r _GOTYPE
 					_ASSIGN_CAST(r, v)
-					execgen.SET(projCol, int(i), r)
+					_TO_TYPE_SET(projCol, int(i), r)
 				}
 			}
 		}
@@ -149,17 +165,18 @@ func (c *castOp_FROMTYPE_TOTYPE) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				v := execgen.GET(col, int(i))
+				v := _FROM_TYPE_GET(col, int(i))
 				var r _GOTYPE
 				_ASSIGN_CAST(r, v)
-				execgen.SET(projCol, int(i), r)
+				_TO_TYPE_SET(projCol, int(i), r)
 			}
 		} else {
+			col = _FROM_TYPE_SLICE(col, 0, int(n))
 			for execgen.RANGE(i, col) {
-				v := execgen.GET(col, i)
+				v := _FROM_TYPE_GET(col, int(i))
 				var r _GOTYPE
 				_ASSIGN_CAST(r, v)
-				execgen.SET(projCol, int(i), r)
+				_TO_TYPE_SET(projCol, int(i), r)
 			}
 		}
 	}

--- a/pkg/sql/exec/distinct_tmpl.go
+++ b/pkg/sql/exec/distinct_tmpl.go
@@ -362,11 +362,11 @@ func _CHECK_DISTINCT(
 ) { // */}}
 
 	// {{define "checkDistinct"}}
-	v := execgen.GET(col, int(checkIdx))
+	v := execgen.UNSAFEGET(col, int(checkIdx))
 	var unique bool
 	_ASSIGN_NE(unique, v, lastVal)
 	outputCol[outputIdx] = outputCol[outputIdx] || unique
-	lastVal = v
+	execgen.COPYVAL(lastVal, v)
 	// {{end}}
 
 	// {{/*
@@ -388,7 +388,7 @@ func _CHECK_DISTINCT_WITH_NULLS(
 
 	// {{define "checkDistinctWithNulls"}}
 	null := nulls.NullAt(uint16(checkIdx))
-	v := execgen.GET(col, int(checkIdx))
+	v := execgen.UNSAFEGET(col, int(checkIdx))
 	if null != lastValNull {
 		// Either the current value is null and the previous was not or vice-versa.
 		outputCol[outputIdx] = true
@@ -398,7 +398,7 @@ func _CHECK_DISTINCT_WITH_NULLS(
 		_ASSIGN_NE(unique, v, lastVal)
 		outputCol[outputIdx] = outputCol[outputIdx] || unique
 	}
-	lastVal = v
+	execgen.COPYVAL(lastVal, v)
 	lastValNull = null
 	// {{end}}
 

--- a/pkg/sql/exec/execgen/cmd/execgen/cast_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/cast_gen.go
@@ -33,7 +33,17 @@ func genCastOperators(wr io.Writer) error {
 	s = strings.Replace(s, "_TOTYPE", "{{.ToTyp}}", -1)
 	s = strings.Replace(s, "_GOTYPE", "{{.ToGoTyp}}", -1)
 
+	// replace _FROM_TYPE_SLICE's with execgen.SLICE's of the correct type.
+	s = strings.Replace(s, "_FROM_TYPE_SLICE", "execgen.SLICE", -1)
 	s = replaceManipulationFuncs(".FromTyp", s)
+
+	// replace the _FROM_TYPE_GET's with execgen.GET's of the correct type.
+	s = strings.Replace(s, "_FROM_TYPE_GET", "execgen.GET", -1)
+	s = replaceManipulationFuncs(".FromTyp", s)
+
+	// replace the _TO_TYPE_GET's with execgen.SET's of the correct type
+	s = strings.Replace(s, "_TO_TYPE_SET", "execgen.SET", -1)
+	s = replaceManipulationFuncs(".ToTyp", s)
 
 	isCastFuncSet := func(ov castOverload) bool {
 		return ov.AssignFunc != nil

--- a/pkg/sql/exec/execgen/cmd/execgen/cast_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/cast_gen.go
@@ -37,11 +37,11 @@ func genCastOperators(wr io.Writer) error {
 	s = strings.Replace(s, "_FROM_TYPE_SLICE", "execgen.SLICE", -1)
 	s = replaceManipulationFuncs(".FromTyp", s)
 
-	// replace the _FROM_TYPE_GET's with execgen.GET's of the correct type.
-	s = strings.Replace(s, "_FROM_TYPE_GET", "execgen.GET", -1)
+	// replace the _FROM_TYPE_UNSAFEGET's with execgen.UNSAFEGET's of the correct type.
+	s = strings.Replace(s, "_FROM_TYPE_UNSAFEGET", "execgen.UNSAFEGET", -1)
 	s = replaceManipulationFuncs(".FromTyp", s)
 
-	// replace the _TO_TYPE_GET's with execgen.SET's of the correct type
+	// replace the _TO_TYPE_SET's with execgen.SET's of the correct type
 	s = strings.Replace(s, "_TO_TYPE_SET", "execgen.SET", -1)
 	s = replaceManipulationFuncs(".ToTyp", s)
 

--- a/pkg/sql/exec/execgen/cmd/execgen/data_manipulation_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/data_manipulation_gen.go
@@ -27,12 +27,12 @@ var dataManipulationReplacementInfos = []dataManipulationReplacementInfo{
 	{
 		templatePlaceholder: "execgen.UNSAFEGET",
 		numArgs:             2,
-		replaceWith:         "Get \"unsafe\"",
+		replaceWith:         "Get",
 	},
 	{
-		templatePlaceholder: "execgen.GET",
+		templatePlaceholder: "execgen.COPYVAL",
 		numArgs:             2,
-		replaceWith:         "Get \"safe\"",
+		replaceWith:         "CopyVal",
 	},
 	{
 		templatePlaceholder: "execgen.SET",

--- a/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
@@ -69,7 +69,7 @@ func (p {{template "opRConstName" .}}) Next(ctx context.Context) coldata.Batch {
 	if sel := batch.Selection(); sel != nil {
 		sel = sel[:n]
 		for _, i := range sel {
-			arg := {{.LTyp.Get "unsafe" "col" "int(i)"}}
+			arg := {{.LTyp.Get "col" "int(i)"}}
 			{{(.Assign "projCol[i]" "arg" "p.constArg")}}
 		}
 	} else {
@@ -77,7 +77,7 @@ func (p {{template "opRConstName" .}}) Next(ctx context.Context) coldata.Batch {
 		colLen := {{.LTyp.Len "col"}}
 		_ = projCol[colLen-1]
 		for {{.LTyp.Range "i" "col"}} {
-			arg := {{.LTyp.Get "unsafe" "col" "i"}}
+			arg := {{.LTyp.Get "col" "i"}}
 			{{(.Assign "projCol[i]" "arg" "p.constArg")}}
 		}
 	}
@@ -123,7 +123,7 @@ func (p {{template "opLConstName" .}}) Next(ctx context.Context) coldata.Batch {
 	if sel := batch.Selection(); sel != nil {
 		sel = sel[:n]
 		for _, i := range sel {
-			arg := {{.RTyp.Get "unsafe" "col" "int(i)"}}
+			arg := {{.RTyp.Get "col" "int(i)"}}
 			{{(.Assign "projCol[i]" "p.constArg" "arg")}}
 		}
 	} else {
@@ -131,7 +131,7 @@ func (p {{template "opLConstName" .}}) Next(ctx context.Context) coldata.Batch {
 		colLen := {{.RTyp.Len "col"}}
 		_ = projCol[colLen-1]
 		for {{.RTyp.Range "i" "col"}} {
-			arg := {{.RTyp.Get "unsafe" "col" "i"}}
+			arg := {{.RTyp.Get "col" "i"}}
 			{{(.Assign "projCol[i]" "p.constArg" "arg")}}
 		}
 	}
@@ -179,8 +179,8 @@ func (p {{template "opName" .}}) Next(ctx context.Context) coldata.Batch {
 	if sel := batch.Selection(); sel != nil {
 		sel = sel[:n]
 		for _, i := range sel {
-			arg1 := {{.LTyp.Get "unsafe" "col1" "int(i)"}}
-			arg2 := {{.RTyp.Get "unsafe" "col2" "int(i)"}}
+			arg1 := {{.LTyp.Get "col1" "int(i)"}}
+			arg2 := {{.RTyp.Get "col2" "int(i)"}}
 			{{(.Assign "projCol[i]" "arg1" "arg2")}}
 		}
 	} else {
@@ -189,8 +189,8 @@ func (p {{template "opName" .}}) Next(ctx context.Context) coldata.Batch {
 		_ = projCol[colLen-1]
 		_ = {{.LTyp.Slice "col2" "0" "colLen-1"}}
 		for {{.LTyp.Range "i" "col1"}} {
-			arg1 := {{.LTyp.Get "unsafe" "col1" "i"}}
-			arg2 := {{.LTyp.Get "unsafe" "col2" "i"}}
+			arg1 := {{.LTyp.Get "col1" "i"}}
+			arg2 := {{.LTyp.Get "col2" "i"}}
 			{{(.Assign "projCol[i]" "arg1" "arg2")}}
 		}
 	}

--- a/pkg/sql/exec/execgen/cmd/execgen/selection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/selection_ops_gen.go
@@ -43,7 +43,7 @@ if sel := batch.Selection(); sel != nil {
 	sel = sel[:n]
 	for _, i := range sel {
 		var cmp bool
-		arg := {{.Global.LTyp.Get "unsafe" "col" "int(i)"}}
+		arg := {{.Global.LTyp.Get "col" "int(i)"}}
 		{{(.Global.Assign "cmp" "arg" "p.constArg")}}
 		if cmp {{if .HasNulls}}&& !nulls.NullAt(i) {{end}}{
 			sel[idx] = i
@@ -56,7 +56,7 @@ if sel := batch.Selection(); sel != nil {
 	col = {{.Global.LTyp.Slice "col" "0" "int(n)"}}
 	for {{.Global.LTyp.Range "i" "col"}} {
 		var cmp bool
-		arg := {{.Global.LTyp.Get "unsafe" "col" "i"}}
+		arg := {{.Global.LTyp.Get "col" "i"}}
 		{{(.Global.Assign "cmp" "arg" "p.constArg")}}
 		if cmp {{if .HasNulls}}&& !nulls.NullAt(uint16(i)) {{end}}{
 			sel[idx] = uint16(i)
@@ -71,8 +71,8 @@ if sel := batch.Selection(); sel != nil {
 	sel = sel[:n]
 	for _, i := range sel {
 		var cmp bool
-		arg1 := {{.Global.LTyp.Get "unsafe" "col1" "int(i)"}}
-		arg2 := {{.Global.RTyp.Get "unsafe" "col2" "int(i)"}}
+		arg1 := {{.Global.LTyp.Get "col1" "int(i)"}}
+		arg2 := {{.Global.RTyp.Get "col2" "int(i)"}}
 		{{(.Global.Assign "cmp" "arg1" "arg2")}}
 		if cmp {{if .HasNulls}}&& !nulls.NullAt(i) {{end}}{
 			sel[idx] = i
@@ -87,8 +87,8 @@ if sel := batch.Selection(); sel != nil {
 	col2 = {{.Global.RTyp.Slice "col2" "0" "col1Len"}}
 	for {{.Global.LTyp.Range "i" "col1"}} {
 		var cmp bool
-		arg1 := {{.Global.LTyp.Get "unsafe" "col1" "i"}}
-		arg2 := {{.Global.RTyp.Get "unsafe" "col2" "i"}}
+		arg1 := {{.Global.LTyp.Get "col1" "i"}}
+		arg2 := {{.Global.RTyp.Get "col2" "i"}}
 		{{(.Global.Assign "cmp" "arg1" "arg2")}}
 		if cmp {{if .HasNulls}}&& !nulls.NullAt(uint16(i)) {{end}}{
 			sel[idx] = uint16(i)

--- a/pkg/sql/exec/execgen/placeholders.go
+++ b/pkg/sql/exec/execgen/placeholders.go
@@ -17,7 +17,7 @@ const nonTemplatePanic = "do not call from non-template code"
 // Remove unused warnings.
 var (
 	_ = UNSAFEGET
-	_ = GET
+	_ = COPYVAL
 	_ = SET
 	_ = SWAP
 	_ = SLICE
@@ -36,12 +36,12 @@ func UNSAFEGET(target, i interface{}) interface{} {
 	return nil
 }
 
-// GET is a template function. The Bytes implementation of this function
-// performs a copy. Use this if you need to keep values around past the
-// lifecycle of a Batch.
-func GET(target, i interface{}) interface{} {
+// COPYVAL is a template function that can be used to set a scalar to the value
+// of another scalar in such a way that the destination won't be modified if the
+// source is. You must use this on the result of UNSAFEGET if you wish to store
+// that result past the lifetime of the batch you UNSAFEGET'd from.
+func COPYVAL(dest, src interface{}) {
 	execerror.VectorizedInternalPanic(nonTemplatePanic)
-	return nil
 }
 
 // SET is a template function.

--- a/pkg/sql/exec/hashjoiner_tmpl.go
+++ b/pkg/sql/exec/hashjoiner_tmpl.go
@@ -183,7 +183,7 @@ func _REHASH_BODY(
 	// {{ if .HasSel }}
 	_ = sel[nKeys-1]
 	// {{ else }}
-	_ = execgen.GET(keys, int(nKeys-1))
+	_ = execgen.UNSAFEGET(keys, int(nKeys-1))
 	// {{ end }}
 	for i := uint64(0); i < nKeys; i++ {
 		ht.cancelChecker.check(ctx)

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -770,3 +770,24 @@ query R
 select (x/1) from t39417
 ----
 10
+
+# Regression tests for #39540, an issue caused by shallow copying decimals.
+statement ok
+CREATE TABLE IF NOT EXISTS t_39540 AS
+	SELECT
+		g % 2 = 0 AS _bool, g::DECIMAL AS _decimal
+	FROM
+		generate_series(0, 5) AS g
+
+query R rowsort
+SELECT
+	tab_426212._decimal - tab_426216._decimal
+FROM
+	t_39540 AS tab_426212,
+	t_39540 AS tab_426214,
+	t_39540
+	RIGHT JOIN t_39540 AS tab_426216 ON true
+ORDER BY
+	tab_426214._bool ASC
+----
+1296 values hashing to cad02075a867c3c0564bf80fe665eed6


### PR DESCRIPTION
This commit fixes a correctness bug caused by illegal shallow copy of
decimals. To copy a decimal, you must use the .Set method on it, and its
memory must already be distinct from the source decimal.

To facilitate this and generally simplify things, the "safe" GET method
is removed and replaced by COPYVAL, which copies a scalar value to
another scalar value safely. There were fewer than 5 users of GET, so
this wasn't particularly disruptive.

Closes #39777.
Closes #39540.

Release note: None