### PR TITLE
sql: skip flaky test in schema_change_in_txn logic tests

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1670,22 +1670,26 @@ ROLLBACK
 statement ok
 ALTER TABLE t DROP CONSTRAINT fk
 
-statement ok
-ALTER TABLE t ADD CONSTRAINT fk_not_valid FOREIGN KEY (a) REFERENCES t2 NOT VALID
+# TODO(lucy): This part of the test is flaky and sometimes fails with a
+# TransactionRetryWithProtoRefreshError (see #40200), so it's being skipped
+# and investigated.
 
-statement ok
-BEGIN
-
-statement ok
-ALTER TABLE t DROP CONSTRAINT fk_not_valid
-
-# The constraint was unvalidated, so it doesn't need to go through the schema
-# changer and is dropped immediately.
-statement ok
-INSERT INTO t VALUES (1)
-
-statement ok
-COMMIT
+# statement ok
+# ALTER TABLE t ADD CONSTRAINT fk_not_valid FOREIGN KEY (a) REFERENCES t2 NOT VALID
+#
+# statement ok
+# BEGIN
+#
+# statement ok
+# ALTER TABLE t DROP CONSTRAINT fk_not_valid
+#
+# # The constraint was unvalidated, so it doesn't need to go through the schema
+# # changer and is dropped immediately.
+# statement ok
+# INSERT INTO t VALUES (1)
+#
+# statement ok
+# COMMIT
 
 statement ok
 DROP TABLE t, t2


### PR DESCRIPTION
The test in `schema_change_in_txn` that drops a foreign key constraint in a
transaction has been sometimes failing with this error:
```
(40001) restart transaction: TransactionRetryWithProtoRefreshError: cannot publish new versions for tables: [{t2 116 5} {t 115 11}], old versions still in use
```
I'm commenting it out for now with a TODO while investigating.

Release note: None