### PR TITLE
debug: don't error in check-store on Range without TruncatedState

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -707,7 +707,7 @@ func runDebugCheckStoreRaft(ctx context.Context, db *engine.RocksDB) error {
 	}
 
 	for rangeID, info := range replicaInfo {
-		if info.truncatedIndex != info.firstIndex-1 {
+		if info.truncatedIndex != 0 && info.truncatedIndex != info.firstIndex-1 {
 			hasError = true
 			fmt.Printf("range %s: truncated index %v should equal first index %v - 1\n",
 				rangeID, info.truncatedIndex, info.firstIndex)


### PR DESCRIPTION
Otherwise we get lots of errors like:
```
range 411: truncated index 0 should equal first index 0 - 1
range 306: truncated index 0 should equal first index 0 - 1
range 399: truncated index 0 should equal first index 0 - 1
range 290: truncated index 0 should equal first index 0 - 1
range 340: truncated index 0 should equal first index 0 - 1
range 547: truncated index 0 should equal first index 0 - 1
range 266: truncated index 0 should equal first index 0 - 1
```

Release note: None