### PR TITLE
importccl: fix mysqqoutfile import bug

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -214,11 +214,18 @@ d
 
 		// MySQL OUTFILE
 		{
-			name:   "unexpected number of columns",
+			name:   "too many imported columns",
 			create: `i int8`,
 			typ:    "MYSQLOUTFILE",
 			data:   "1\t2",
 			err:    "row 1: too many columns, expected 1",
+		},
+		{
+			name:   "unexpected number of columns",
+			create: `a string, b string`,
+			typ:    "MYSQLOUTFILE",
+			data:   "1,2",
+			err:    "row 1: unexpected number of columns, expected 2 got 1",
 		},
 		{
 			name:   "unmatched field enclosure",

--- a/pkg/ccl/importccl/read_import_mysqlout.go
+++ b/pkg/ccl/importccl/read_import_mysqlout.go
@@ -115,6 +115,10 @@ func (d *mysqloutfileReader) readFile(
 		return nil
 	}
 	addRow := func() error {
+		if len(row) != len(d.conv.VisibleCols) {
+			return makeRowErr(inputName, count, pgcode.Syntax,
+				"unexpected number of columns, expected %d got %d: %#v", len(d.conv.VisibleCols), len(row), row)
+		}
 		copy(d.conv.Datums, row)
 		if err := d.conv.Row(ctx, inputIdx, count); err != nil {
 			return wrapRowErr(err, inputName, count, pgcode.Uncategorized, "")
@@ -148,9 +152,6 @@ func (d *mysqloutfileReader) readFile(
 					return err
 				}
 			}
-		}
-
-		if finished {
 			break
 		}
 


### PR DESCRIPTION
When importing from csv if the number of fields is less than the columns
in the schema the server will panic. Added a check for this case.

Tested: Note that the test currently skipped. I added a test case and ran tests successfully locally.

Touches 39820.

Release note: None