### PR TITLE
sql: run all logic tests with both vectorize auto and off by default

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/edge
+++ b/pkg/sql/logictest/testdata/logic_test/edge
@@ -1,3 +1,6 @@
+# LogicTest: local-vec-off fakedist-vec-off
+# TODO(yuzefovich): run with all default configs once #40354 is resolved.
+
 # Test on-disk SQL semantics of edge cases and overflows. On-disk is
 # important because it avoids any constant folding that could happen
 # in the parse or normalization phases, forcing it to be handled by the

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -362,6 +362,7 @@ FROM system.eventlog
 WHERE "eventType" = 'set_cluster_setting'
 AND info NOT LIKE '%version%' AND info NOT LIKE '%sql.defaults.distsql%' AND info NOT LIKE '%cluster.secret%'
 AND info NOT LIKE '%sql.stats.automatic_collection.enabled%'
+AND info NOT LIKE '%sql.defaults.vectorize%'
 ORDER BY "timestamp"
 ----
 0  1  {"SettingName":"diagnostics.reporting.enabled","Value":"true","User":"root"}

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze_plans
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze_plans
@@ -1,7 +1,7 @@
 # LogicTest: 5node-dist
 
 # These tests are different from explain_analyze because they require manual
-# data placement and are run without the optimizer.
+# data placement.
 
 statement ok
 CREATE TABLE kv (k INT PRIMARY KEY, v INT)
@@ -98,4 +98,4 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJy8lFGL1DAQx9_9FGGeFFKapq
 query T
 SELECT url FROM [EXPLAIN ANALYZE (DISTSQL) SELECT k FROM kv WHERE k = 0];
 ----
-https://cockroachdb.github.io/distsqlplan/decode.html#eJyMkD9LxEAQxXs_xfJsR7JptzrsrvHktJMUe9nhCCbZMDNRjyPfXZIFxUK48v3Ztz_mijEnfooDK8IbajSESXLLqllWqxT26QvBE7pxmm21G0KbhRGusM56RsBrPPV85JhYKg9CYotdv81O0g1RLrv3DxBepjhqcJV_qHx1D8JhtuB2NQiSP9UJxxTcuqAW-95ZN3BwXkE4XYx_Cu4RzULIs_0yqcUzI9QL3c59ZJ3yqPwH-b9lvzQETmcut9E8S8vPktvtmyIP27vNSKxW0rqI_ViipVnuvgMAAP__mHp6ww==
+https://cockroachdb.github.io/distsqlplan/decode.html#eJyMkDFPwzAUhHd-hXWshjirp65dKCpsKINrPxULJ7b8XiqqKv8dJWYBCYnxvvOdfb5hyoGe3EgM-4Yeg0ap2RNzritqB_bhE9ZoxKnMsuJBw-dKsDdIlESweHWnREdygWpnoBFIXExbbalxdPW6-7hA46W4ia3qzENnuntoHGaxatdD4-TEvxOrPEtZ4Vojc0m_EFMiL_ES5WqVeTQbE5eSkjiSVYYxLBot8v1aFncm2H7R_190JC55Yvox5q9mswwaFM7Ufo3zXD091-y3a5o8bLkNBGJpbt_EfmrWMix3XwEAAP__bYGETQ==

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1556,7 +1556,7 @@ transaction_priority                 normal              NULL      NULL        N
 transaction_read_only                off                 NULL      NULL        NULL        string
 transaction_status                   NoTxn               NULL      NULL        NULL        string
 vectorize                            auto                NULL      NULL        NULL        string
-vectorize_row_count_threshold        1000                NULL      NULL        NULL        string
+vectorize_row_count_threshold        0                   NULL      NULL        NULL        string
 
 query TTTTTTT colnames
 SELECT
@@ -1610,7 +1610,7 @@ transaction_priority                 normal              NULL  user     NULL    
 transaction_read_only                off                 NULL  user     NULL      off                 off
 transaction_status                   NoTxn               NULL  user     NULL      NoTxn               NoTxn
 vectorize                            auto                NULL  user     NULL      auto                auto
-vectorize_row_count_threshold        1000                NULL  user     NULL      1000                1000
+vectorize_row_count_threshold        0                   NULL  user     NULL      0                   0
 
 query TTTTTT colnames
 SELECT name, source, min_val, max_val, sourcefile, sourceline FROM pg_catalog.pg_settings

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -49,7 +49,7 @@ locality                             region=test,dc=dc1
 lock_timeout                         0
 max_index_keys                       32
 node_id                              1
-optimizer_foreign_keys  off
+optimizer_foreign_keys               off
 reorder_joins_limit                  4
 results_buffer_size                  16384
 row_security                         off
@@ -69,7 +69,7 @@ transaction_priority                 normal
 transaction_read_only                off
 transaction_status                   NoTxn
 vectorize                            auto
-vectorize_row_count_threshold        1000
+vectorize_row_count_threshold        0
 
 query T colnames
 SELECT * FROM [SHOW CLUSTER SETTING sql.defaults.distsql]

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -441,6 +441,7 @@ SELECT name
 FROM system.settings
 WHERE name != 'sql.defaults.distsql'
 AND name != 'sql.stats.automatic_collection.enabled'
+AND name NOT LIKE '%sql.defaults.vectorize%'
 ORDER BY name
 ----
 cluster.secret
@@ -457,7 +458,8 @@ query TT
 SELECT name, value
 FROM system.settings
 WHERE name NOT IN ('version', 'sql.defaults.distsql', 'cluster.secret',
-  'sql.stats.automatic_collection.enabled')
+  'sql.stats.automatic_collection.enabled', 'sql.defaults.vectorize',
+  'sql.defaults.vectorize_row_count_threshold')
 ORDER BY name
 ----
 diagnostics.reporting.enabled                  true

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_threshold
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_threshold
@@ -10,6 +10,9 @@ SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
 statement ok
 CREATE TABLE small (a INT PRIMARY KEY)
 
+statement ok
+SET vectorize_row_count_threshold = 1000
+
 # There are no stats available, so this should run through the row execution
 # engine.
 query T
@@ -28,7 +31,7 @@ SELECT url FROM [EXPLAIN ANALYZE SELECT count(*) FROM small]
 https://cockroachdb.github.io/distsqlplan/decode.html#eJyUkT1PwzAQhnd-RXQTSIbGHT2BmLo0qC1iQBFynVOw5NiW74JaVfnvKDEDLZSP8Z7L--Y5-QA-NLjUHRKoZ5BQC4gpGCQKaUT5g0WzA1UKsD72POJagAkJQR2ALTsEBRu9dbhC3WCalSCgQdbWTbUx2U6n_S112jkQsI7akyquQUDVsyqWwSMI2Go2r0hF6DmOeGzhProTROjQsH2zvFdFeVNOjLVzBdsOVVES1IOAHPmQJdYtgpKD-PtBd22bsNUc0kwe33NfPS43L6vqaX159Y23_Ootz3jjDk3PNvjf3ef_cV8hxeAJj7zPNZdDLQCbFvODU-iTwYcUzPSbPFZTbgINEuetzMPC59Uo-DksfwzPT8L1cPEeAAD__yeM11g=
 
 statement ok
-RESET vectorize_row_count_threshold
+SET vectorize_row_count_threshold = 1000
 
 statement ok
 ALTER TABLE small INJECT STATISTICS '[
@@ -57,7 +60,7 @@ SELECT url FROM [EXPLAIN ANALYZE SELECT count(*) FROM small]
 https://cockroachdb.github.io/distsqlplan/decode.html#eJyUkT1PwzAQhnd-RXQTSIbGHT2BmLo0qC1iQBFynVOw5NiW74JaVfnvKDEDLZSP8Z7L--Y5-QA-NLjUHRKoZ5BQC4gpGCQKaUT5g0WzA1UKsD72POJagAkJQR2ALTsEBRu9dbhC3WCalSCgQdbWTbUx2U6n_S112jkQsI7akyquQUDVsyqWwSMI2Go2r0hF6DmOeGzhProTROjQsH2zvFdFeVNOjLVzBdsOVVES1IOAHPmQJdYtgpKD-PtBd22bsNUc0kwe33NfPS43L6vqaX159Y23_Ootz3jjDk3PNvjf3ef_cV8hxeAJj7zPNZdDLQCbFvODU-iTwYcUzPSbPFZTbgINEuetzMPC59Uo-DksfwzPT8L1cPEeAAD__yeM11g=
 
 statement ok
-RESET vectorize_row_count_threshold
+SET vectorize_row_count_threshold = 1000
 
 statement ok
 CREATE TABLE large (a INT PRIMARY KEY)
@@ -87,6 +90,3 @@ query T
 SELECT url FROM [EXPLAIN ANALYZE SELECT count(*) FROM large]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJyUkU9L80AQxu_vp1ie0yusNOlxT_459dJIW_EgQbbZIQSSbJiZYEvJd5ckoFZQ63Gemd-zP9gT2hho7RsSuGekyC06jgWJRB6j-WAVDnCJRdV2vY5xblFEJrgTtNKa4LDz-5o25APxIoFFIPVVPdV2XDWejze155Jgse18K85cwyLr1Zl1bMeY46sYJh-cGQtEfV0brRpyJhFY7I9K7wfmDvlgEXv9UBL1JcGlg71c-7YsmUqvkRfpufV99rjevWyyp-3_qwvsGn8wDTWRj6YX-kVx-RfFDUkXW6Ezve-akyG3oFDS_HsSey7ogWMxPTOP2cRNQSDReZvOw6qdV6PgZzj9EV5-gfPh31sAAAD__wIExG0=
-
-statement ok
-RESET vectorize_row_count_threshold


### PR DESCRIPTION
When vectorize is set to 'auto', we pay attention to whether the
stats are present on the input tables and whether the row count
threshold is met. This means that many logic tests might not be run
through the vectorized engine even if it supports the queries. Now
we will override the row count threshold so that the vectorized
engine is tested.

In order to not reduce the test coverage of the row execution engine,
we introduce new configs that explicitly turn off the vectorized engine.
Two of such configs are added to the list of default configs.

Release note: None