### PR TITLE
demo: Add option to automatically apply the Geo-Partitioned Replicas topology to Movr

### DIFF
--- a/pkg/ccl/cliccl/demo.go
+++ b/pkg/ccl/cliccl/demo.go
@@ -46,7 +46,6 @@ func getLicense(clusterID uuid.UUID) (string, error) {
 		return "", err
 	}
 	defer resp.Body.Close()
-
 	if resp.StatusCode != http.StatusOK {
 		return "", errors.New("unable to connect to licensing endpoint")
 	}

--- a/pkg/ccl/cliccl/demo.go
+++ b/pkg/ccl/cliccl/demo.go
@@ -46,6 +46,7 @@ func getLicense(clusterID uuid.UUID) (string, error) {
 		return "", err
 	}
 	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
 		return "", errors.New("unable to connect to licensing endpoint")
 	}

--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -251,7 +251,7 @@ func TestDeterministicInitialData(t *testing.T) {
 		`intro`:      0x81c6a8cfd9c3452a,
 		`json`:       0xcbf29ce484222325,
 		`ledger`:     0xebe27d872d980271,
-		`movr`:       0x4f19a54c7e779f9c,
+		`movr`:       0x6a094e9d15a07970,
 		`queue`:      0xcbf29ce484222325,
 		`rand`:       0xcbf29ce484222325,
 		`roachmart`:  0xda5e73423dbdb2d9,

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -918,6 +918,18 @@ to us-east1 and availability zone to 3.
 `,
 	}
 
+	DemoGeoPartitionedReplicas = FlagInfo{
+		Name: "geo-partitioned-replicas",
+		Description: `
+When used with the Movr dataset, create a 9 node cluster and automatically apply
+the geo-partitioned replicas topology across 3 virtual regions named us-east1, us-west1, and
+europe-west1. This command will fail with an error if an enterprise license could not
+be acquired, or if the Movr dataset is not used. More information about the geo-partitioned 
+replicas topology can be found at this URL: 
+https://www.cockroachlabs.com/docs/v19.1/topology-geo-partitioned-replicas.html
+		`,
+	}
+
 	UseEmptyDatabase = FlagInfo{
 		Name: "empty",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -147,6 +147,7 @@ func initCLIDefaults() {
 	demoCtx.useEmptyDatabase = false
 	demoCtx.runWorkload = false
 	demoCtx.localities = nil
+	demoCtx.geoPartitionedReplicas = false
 
 	initPreFlagsDefaults()
 
@@ -336,8 +337,9 @@ var sqlfmtCtx struct {
 // demoCtx captures the command-line parameters of the `demo` command.
 // Defaults set by InitCLIDefaults() above.
 var demoCtx struct {
-	nodes            int
-	useEmptyDatabase bool
-	runWorkload      bool
-	localities       demoLocalityList
+	nodes                  int
+	useEmptyDatabase       bool
+	runWorkload            bool
+	localities             demoLocalityList
+	geoPartitionedReplicas bool
 }

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -49,9 +49,9 @@ subcommands: e.g. "cockroach demo startrek". See --help for a full list.
 By default, the 'movr' dataset is pre-loaded. You can also use --empty
 to avoid pre-loading a dataset.
 
-cockroach demo attempts to connect to a Cockroach Labs server to obtain a
-temporary enterprise license for demoing enterprise features and enable
-telemetry back to Cockroach Labs. In order to disable this behavior, set the
+cockroach demo attempts to connect to a Cockroach Labs server to obtain a 
+temporary enterprise license for demoing enterprise features and enable 
+telemetry back to Cockroach Labs. In order to disable this behavior, set the 
 environment variable "COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING".
 `,
 	Example: `  cockroach demo`,

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -586,6 +586,7 @@ func init() {
 	IntFlag(demoFlags, &demoCtx.nodes, cliflags.DemoNodes, 1)
 	BoolFlag(demoFlags, &demoCtx.runWorkload, cliflags.RunDemoWorkload, false)
 	VarFlag(demoFlags, &demoCtx.localities, cliflags.DemoNodeLocality)
+	BoolFlag(demoFlags, &demoCtx.geoPartitionedReplicas, cliflags.DemoGeoPartitionedReplicas, false)
 	// The --empty flag is only valid for the top level demo command,
 	// so we use the regular flag set.
 	BoolFlag(demoCmd.Flags(), &demoCtx.useEmptyDatabase, cliflags.UseEmptyDatabase, false)

--- a/pkg/cli/interactive_tests/test_demo_partitioning.tcl
+++ b/pkg/cli/interactive_tests/test_demo_partitioning.tcl
@@ -1,0 +1,87 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_test "Expect partitioning succeeds"
+# test that partitioning works if a license could be acquired
+spawn $argv demo --geo-partitioned-replicas
+
+# wait for the shell to start up
+eexpect "movr>"
+
+# send multiple "SHOW PARTITIONS" requests to the DB as partitioning is happen asynchronously.
+for {set i 0} {$i < 10} {incr i} {
+  send "SELECT count(*) FROM \[SHOW PARTITIONS FROM DATABASE movr\];\r"
+  sleep 1
+}
+
+# The number of partitions across the MovR database we expect is 24.
+eexpect "24"
+eexpect "(1 row)"
+eexpect "movr>"
+
+send "SHOW PARTITIONS FROM TABLE vehicles;\r"
+
+# Verify the partitions are as we expect
+send "SELECT count(*) FROM \[SHOW PARTITIONS FROM DATABASE movr\] WHERE partition_name='us_west';\r"
+eexpect "8"
+eexpect "(1 row)"
+eexpect "movr>"
+
+send "SELECT count(*) FROM \[SHOW PARTITIONS FROM DATABASE movr\] WHERE partition_name='us_west' AND partition_value='(''seattle''), (''san francisco''), (''los angeles'')';\r"
+eexpect "8"
+eexpect "(1 row)"
+eexpect "movr>"
+
+send "SELECT count(*) FROM \[SHOW PARTITIONS FROM DATABASE movr\] WHERE partition_name='us_west' AND zone_config='constraints = ''\[+region=us-west1\]''';\r"
+eexpect "8"
+eexpect "(1 row)"
+eexpect "movr>"
+
+send "SELECT count(*) FROM \[SHOW PARTITIONS FROM DATABASE movr\] WHERE partition_name='us_east';\r"
+eexpect "8"
+eexpect "(1 row)"
+eexpect "movr>"
+
+send "SELECT count(*) FROM \[SHOW PARTITIONS FROM DATABASE movr\] WHERE partition_name='us_east' AND partition_value='(''new york''), (''boston''), (''washington dc'')';\r"
+eexpect "8"
+eexpect "(1 row)"
+eexpect "movr>"
+
+send "SELECT count(*) FROM \[SHOW PARTITIONS FROM DATABASE movr\] WHERE partition_name='us_east' AND zone_config='constraints = ''\[+region=us-east1\]''';\r"
+eexpect "8"
+eexpect "(1 row)"
+eexpect "movr>"
+
+send "SELECT count(*) FROM \[SHOW PARTITIONS FROM DATABASE movr\] WHERE partition_name='europe_west';\r"
+eexpect "8"
+eexpect "(1 row)"
+eexpect "movr>"
+
+send "SELECT count(*) FROM \[SHOW PARTITIONS FROM DATABASE movr\] WHERE partition_name='europe_west' AND partition_value='(''amsterdam''), (''paris''), (''rome'')';\r"
+eexpect "8"
+eexpect "(1 row)"
+eexpect "movr>"
+
+send "SELECT count(*) FROM \[SHOW PARTITIONS FROM DATABASE movr\] WHERE partition_name='europe_west' AND zone_config='constraints = ''\[+region=europe-west1\]''';\r"
+eexpect "8"
+eexpect "(1 row)"
+eexpect "movr>"
+
+interrupt
+eexpect eof
+end_test
+
+
+start_test "Expect an error if geo-partitioning is requested and a license cannot be acquired"
+
+# set the proper environment variable
+set env(COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING) "true"
+spawn $argv demo --geo-partitioned-replicas
+# expect a failure
+eexpect "Error: license acquisition was unsuccessful. Enterprise features are needed to partition data"
+# clean up after the test
+interrupt
+eexpect eof
+end_test
+

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -107,6 +107,9 @@ type Hooks struct {
 	// These are expected to pass after the initial data load as well as after
 	// running queryload.
 	CheckConsistency func(context.Context, *gosql.DB) error
+	// Partition is used to run a partitioning step on the data created by the workload.
+	// TODO (rohany): migrate existing partitioning steps (such as tpcc's) into here.
+	Partition func(*gosql.DB) error
 }
 
 // Meta is used to register a Generator at init time and holds meta information


### PR DESCRIPTION
Work for #39945.

This PR adds a Partition function to the workload.Hooks struct so that
workloads that have a partitioning step can just implement that function
within the workload package.

Release note (cli change): Add an option for cockroach demo to
automatically apply the geo-partitioned replicas topology to the movr
dataset using the --geo-partitioned-replicas flag.
