### PR TITLE
kv: unwrap MixedSuccessError even when retry attempts exhausted

### DIFF
--- a/pkg/kv/txn_interceptor_span_refresher.go
+++ b/pkg/kv/txn_interceptor_span_refresher.go
@@ -39,11 +39,69 @@ var MaxTxnRefreshSpansBytes = settings.RegisterIntSetting(
 	256*1000,
 )
 
-// txnSpanRefresher is a txnInterceptor that collects the read spans
-// of a serializable transaction in the event we get a serializable
-// retry error. We can use the set of read spans to avoid retrying
-// the transaction if all the spans can be updated to the current
-// transaction timestamp.
+// txnSpanRefresher is a txnInterceptor that collects the read spans of a
+// serializable transaction in the event it gets a serializable retry error. It
+// can then use the set of read spans to avoid retrying the transaction if all
+// the spans can be updated to the current transaction timestamp.
+//
+// Serializable isolation mandates that transactions appear to have occurred in
+// some total order, where none of their component sub-operations appear to have
+// interleaved with sub-operations from other transactions. CockroachDB enforces
+// this isolation level by ensuring that all of a transaction's reads and writes
+// are performed at the same HLC timestamp. This timestamp is referred to as the
+// transaction's commit timestamp.
+//
+// As a transaction in CockroachDB executes at a certain provisional commit
+// timestamp, it lays down intents at this timestamp for any write operations
+// and ratchets various timestamp cache entries to this timestamp for any read
+// operations. If a transaction performs all of its reads and writes and is able
+// to commit at its original provisional commit timestamp then it may go ahead
+// and do so. However, for a number of reasons including conflicting reads and
+// writes, a transaction may discover that its provisional commit timestamp is
+// too low and that it needs to move this timestamp forward to commit.
+//
+// This poses a problem for operations that the transaction has already
+// completed at lower timestamps. Are the effects of these operations still
+// valid? The transaction is always free to perform a full restart at a higher
+// epoch, but this often requires iterating in a client-side retry loop and
+// performing all of the transaction's operations again. Intents are maintained
+// across retries to improve the chance that later epochs succeed, but it is
+// vastly preferable to avoid re-issuing these operations. Instead, it would be
+// ideal if the transaction could "move" each of its operations to its new
+// provisional commit timestamp without redoing them entirely.
+//
+// Only a single write intent can exist on a key and no reads are allowed above
+// the intent's timestamp until the intent is resolved, so a transaction is free
+// to move any of its intent to a higher timestamp. In fact, a synchronous
+// rewrite of these intents isn't even necessary because intent resolution will
+// already rewrite the intents at higher timestamp if necessary. So, moving
+// write intents to a higher timestamp can be performed implicitly by committing
+// their transaction at a higher timestamp. However, unlike intents created by
+// writes, timestamp cache entries created by reads only prevent writes on
+// overlapping keys from being written at or below their timestamp; they do
+// nothing to prevent writes on overlapping keys from being written above their
+// timestamp. This means that a transaction is not free to blindly move its
+// reads to a higher timestamp because writes from other transaction may have
+// already invalidated them. In effect, this means that transactions acquire
+// pessimistic write locks and optimistic read locks.
+//
+// The txnSpanRefresher is in charge of detecting when a transaction may want to
+// move its provisional commit timestamp forward and determining whether doing
+// so is safe given the reads that it has performed (i.e. its "optimistic read
+// locks"). When the interceptor decides to attempt to move a transaction's
+// timestamp forward, it first "refreshes" each of its reads. This refreshing
+// step revisits all of the key spans that the transaction has read and checks
+// whether any writes have occurred between the original time that these span
+// were read and the timestamp that the transaction now wants to commit at that
+// change the result of these reads. If any read would produce a different
+// result at the newer commit timestamp, the refresh fails and the transaction
+// is forced to fall back to a full transaction restart. However, if all of the
+// reads would produce exactly the same result at the newer commit timestamp,
+// the timestamp cache entries for these reads are updated and the transaction
+// is free to update its provisional commit timestamp without needing to
+// restart.
+//
+// TODO(nvanbenschoten): Unit test this file.
 type txnSpanRefresher struct {
 	st      *cluster.Settings
 	knobs   *ClientTestingKnobs


### PR DESCRIPTION
Fixes #40328.
Closes #40332.

This commit fixes a bug where MixedSuccessErrors would not be unwrapped by the txnSpanRefresher when a request had exhausted its refresh attempt limit.

The theory is that the race test plus the background stats computation in `TestParallel/create_stats` was causing a lot of transaction retries, which exhausted `maxTxnRefreshAttempts`.

The PR also improves the documentation on the `txnSpanRefresher`. It adds a comment describing the interceptors role in the transaction model, which is similar to the comments we have on the other interceptors.