### PR TITLE
storage/engine: fix unnecessary C.ulonglong conversion

### DIFF
--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -2213,8 +2213,8 @@ func (r *rocksDBIterator) destroy() {
 func (r *rocksDBIterator) Stats() IteratorStats {
 	stats := C.DBIterStats(r.iter)
 	return IteratorStats{
-		TimeBoundNumSSTs:           int(C.ulonglong(stats.timebound_num_ssts)),
-		InternalDeleteSkippedCount: int(C.ulonglong(stats.internal_delete_skipped_count)),
+		TimeBoundNumSSTs:           int(stats.timebound_num_ssts),
+		InternalDeleteSkippedCount: int(stats.internal_delete_skipped_count),
 	}
 }
 


### PR DESCRIPTION
Something recently shook up the build, causing the following lint warnings to start firing:

```
--- FAIL: TestLint/TestRoachLint (56.77s)
    lint_test.go:77:
        /Users/nathan/Go/src/github.com/cockroachdb/cockroach/pkg/storage/engine/rocksdb.go:2216:35: unnecessary conversion
    lint_test.go:77:
        /Users/nathan/Go/src/github.com/cockroachdb/cockroach/pkg/storage/engine/rocksdb.go:2217:35: unnecessary conversion
```

Release note: None