### PR TITLE
exec: a small amount of DRY for proj/sel ops

### DIFF
--- a/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
@@ -41,12 +41,8 @@ import (
 
 {{define "projRConstOp"}}
 type {{template "opRConstName" .}} struct {
-	OneInputNode
-
-	colIdx   int
+  projConstOpBase
 	constArg {{.RGoType}}
-
-	outputIdx int
 }
 
 func (p {{template "opRConstName" .}}) EstimateStaticMemoryUsage() int {
@@ -91,16 +87,12 @@ func (p {{template "opRConstName" .}}) Next(ctx context.Context) coldata.Batch {
 func (p {{template "opRConstName" .}}) Init() {
 	p.input.Init()
 }
-{{end}}
+{{end -}}
 
 {{define "projLConstOp"}}
 type {{template "opLConstName" .}} struct {
-	OneInputNode
-
-	colIdx   int
+  projConstOpBase
 	constArg {{.LGoType}}
-
-	outputIdx int
 }
 
 func (p {{template "opLConstName" .}}) EstimateStaticMemoryUsage() int {
@@ -149,12 +141,7 @@ func (p {{template "opLConstName" .}}) Init() {
 
 {{define "projOp"}}
 type {{template "opName" .}} struct {
-	OneInputNode
-
-	col1Idx int
-	col2Idx int
-
-	outputIdx int
+  projOpBase
 }
 
 func (p {{template "opName" .}}) EstimateStaticMemoryUsage() int {
@@ -187,7 +174,7 @@ func (p {{template "opName" .}}) Next(ctx context.Context) coldata.Batch {
 		col1 = {{.LTyp.Slice "col1" "0" "int(n)"}}
 		colLen := {{.LTyp.Len "col1"}}
 		_ = projCol[colLen-1]
-		_ = {{.LTyp.Slice "col2" "0" "colLen-1"}}
+		_ = {{.LTyp.Get "col2" "colLen-1"}}
 		for {{.LTyp.Range "i" "col1"}} {
 			arg1 := {{.LTyp.Get "col1" "i"}}
 			arg2 := {{.LTyp.Get "col2" "i"}}
@@ -232,6 +219,11 @@ func GetProjection{{if $left}}L{{else}}R{{end}}ConstOperator(
 	constArg tree.Datum,
   outputIdx int,
 ) (Operator, error) {
+  projConstOpBase := projConstOpBase {
+    OneInputNode: NewOneInputNode(input),
+    colIdx: colIdx,
+    outputIdx: outputIdx,
+  }
 	c, err := typeconv.GetDatumToPhysicalFn({{if $left}}leftColType{{else}}rightColType{{end}})(constArg)
 	if err != nil {
 		return nil, err
@@ -245,49 +237,57 @@ func GetProjection{{if $left}}L{{else}}R{{end}}ConstOperator(
 			switch op.(type) {
 			case tree.BinaryOperator:
 				switch op {
-				{{range $overloads}}
-				{{if .IsBinOp}}
+				{{range $overloads -}}
+				{{if .IsBinOp -}}
 				case tree.{{.Name}}:
-					return &{{if $left}}{{template "opLConstName" .}}{{else}}{{template "opRConstName" .}}{{end}}{
-						OneInputNode: NewOneInputNode(input),
-						colIdx:   colIdx,
-						constArg: c.({{if $left}}{{.LGoType}}{{else}}{{.RGoType}}{{end}}),
-						outputIdx: outputIdx,
-					}, nil
-				{{end}}
-				{{end}}
+					return &{{if $left -}}
+                  {{template "opLConstName" . -}}
+                  {{else -}}
+                  {{template "opRConstName" . -}}
+                  {{end -}}
+                  {projConstOpBase: projConstOpBase, constArg: c.({{if $left -}}
+                                                                  {{.LGoType -}}
+                                                                  {{else -}}
+                                                                  {{.RGoType -}}
+                                                                  {{end}})}, nil
+				{{end -}}
+				{{end -}}
 				default:
 					return nil, errors.Errorf("unhandled binary operator: %s", op)
 				}
 			case tree.ComparisonOperator:
 				switch op {
-				{{range $overloads}}
-				{{if .IsCmpOp}}
+				{{range $overloads -}}
+				{{if .IsCmpOp -}}
 				case tree.{{.Name}}:
-					return &{{if $left}}{{template "opLConstName" .}}{{else}}{{template "opRConstName" .}}{{end}}{
-						OneInputNode: NewOneInputNode(input),
-						colIdx:   colIdx,
-						constArg: c.({{if $left}}{{.LGoType}}{{else}}{{.RGoType}}{{end}}),
-						outputIdx: outputIdx,
-					}, nil
-				{{end}}
-				{{end}}
+					return &{{if $left -}}
+                  {{template "opLConstName" . -}}
+                  {{else -}}
+                  {{template "opRConstName" . -}}
+                  {{end -}}
+                  {projConstOpBase: projConstOpBase, constArg: c.({{if $left -}}
+                                                                  {{.LGoType -}}
+                                                                  {{else -}}
+                                                                  {{.RGoType -}}
+                                                                  {{end}})}, nil
+				{{end -}}
+				{{end -}}
 				default:
 					return nil, errors.Errorf("unhandled comparison operator: %s", op)
 				}
 			default:
 				return nil, errors.New("unhandled operator type")
 			}
-		{{end}}
+		{{end -}}
 		default:
 			return nil, errors.Errorf("unhandled right type: %s", rightType)
 		}
-	{{end}}
+	{{end -}}
 	default:
 		return nil, errors.Errorf("unhandled left type: %s", leftType)
 	}
 }
-{{end}}
+{{end -}}
 
 // GetProjectionOperator returns the appropriate projection operator for the
 // given left and right column types and comparison.
@@ -300,6 +300,7 @@ func GetProjectionOperator(
 	col2Idx int,
   outputIdx int,
 ) (Operator, error) {
+  projOpBase := projOpBase{OneInputNode: NewOneInputNode(input), col1Idx: col1Idx, col2Idx: col2Idx, outputIdx: outputIdx}
 	switch leftType := typeconv.FromColumnType(leftColType); leftType {
 	{{range $lTyp, $rTypToOverloads := .LTypToRTypToOverloads}}
 	case coltypes.{{$lTyp}}:
@@ -309,44 +310,32 @@ func GetProjectionOperator(
 			switch op.(type) {
 			case tree.BinaryOperator:
 				switch op {
-				{{range $overloads}}
-				{{if .IsBinOp}}
-				case tree.{{.Name}}:
-					return &{{template "opName" .}}{
-						OneInputNode: NewOneInputNode(input),
-						col1Idx:   col1Idx,
-						col2Idx:   col2Idx,
-						outputIdx: outputIdx,
-					}, nil
-				{{end}}
-				{{end}}
+				{{range $overloads -}}
+				{{if .IsBinOp -}}
+				case tree.{{.Name}}: return &{{template "opName" .}}{projOpBase: projOpBase}, nil
+				{{end -}}
+				{{end -}}
 				default:
 					return nil, errors.Errorf("unhandled binary operator: %s", op)
 				}
 			case tree.ComparisonOperator:
 				switch op {
-				{{range $overloads}}
-				{{if .IsCmpOp}}
-				case tree.{{.Name}}:
-					return &{{template "opName" .}}{
-						OneInputNode: NewOneInputNode(input),
-						col1Idx:   col1Idx,
-						col2Idx:   col2Idx,
-						outputIdx: outputIdx,
-					}, nil
-				{{end}}
-				{{end}}
+				{{range $overloads -}}
+				{{if .IsCmpOp -}}
+				case tree.{{.Name}}: return &{{template "opName" .}}{projOpBase: projOpBase}, nil
+				{{end -}}
+				{{end -}}
 				default:
 					return nil, errors.Errorf("unhandled comparison operator: %s", op)
 				}
 			default:
 				return nil, errors.New("unhandled operator type")
 			}
-		{{end}}
+		{{end -}}
 		default:
 			return nil, errors.Errorf("unhandled right type: %s", rightType)
 		}
-	{{end}}
+	{{end -}}
 	default:
 		return nil, errors.Errorf("unhandled left type: %s", leftType)
 	}

--- a/pkg/sql/exec/like_ops.go
+++ b/pkg/sql/exec/like_ops.go
@@ -94,18 +94,20 @@ func GetLikeOperator(
 		return nil, err
 	}
 	pat := []byte(pattern)
+	base := selConstOpBase{
+		OneInputNode: NewOneInputNode(input),
+		colIdx:       colIdx,
+	}
 	switch likeOpType {
 	case likeConstant:
 		return &selEQBytesBytesConstOp{
-			OneInputNode: NewOneInputNode(input),
-			colIdx:       colIdx,
-			constArg:     pat,
+			selConstOpBase: base,
+			constArg:       pat,
 		}, nil
 	case likeConstantNegate:
 		return &selNEBytesBytesConstOp{
-			OneInputNode: NewOneInputNode(input),
-			colIdx:       colIdx,
-			constArg:     pat,
+			selConstOpBase: base,
+			constArg:       pat,
 		}, nil
 	case likeNeverMatch:
 		return NewZeroOp(input), nil
@@ -115,27 +117,23 @@ func GetLikeOperator(
 		return NewNoop(input), nil
 	case likeSuffix:
 		return &selSuffixBytesBytesConstOp{
-			OneInputNode: NewOneInputNode(input),
-			colIdx:       colIdx,
-			constArg:     pat,
+			selConstOpBase: base,
+			constArg:       pat,
 		}, nil
 	case likeSuffixNegate:
 		return &selNotSuffixBytesBytesConstOp{
-			OneInputNode: NewOneInputNode(input),
-			colIdx:       colIdx,
-			constArg:     pat,
+			selConstOpBase: base,
+			constArg:       pat,
 		}, nil
 	case likePrefix:
 		return &selPrefixBytesBytesConstOp{
-			OneInputNode: NewOneInputNode(input),
-			colIdx:       colIdx,
-			constArg:     pat,
+			selConstOpBase: base,
+			constArg:       pat,
 		}, nil
 	case likePrefixNegate:
 		return &selNotPrefixBytesBytesConstOp{
-			OneInputNode: NewOneInputNode(input),
-			colIdx:       colIdx,
-			constArg:     pat,
+			selConstOpBase: base,
+			constArg:       pat,
 		}, nil
 	case likeRegexp:
 		re, err := tree.ConvertLikeToRegexp(ctx, pattern, false, '\\')
@@ -143,9 +141,8 @@ func GetLikeOperator(
 			return nil, err
 		}
 		return &selRegexpBytesBytesConstOp{
-			OneInputNode: NewOneInputNode(input),
-			colIdx:       colIdx,
-			constArg:     re,
+			selConstOpBase: base,
+			constArg:       re,
 		}, nil
 	case likeRegexpNegate:
 		re, err := tree.ConvertLikeToRegexp(ctx, pattern, false, '\\')
@@ -153,9 +150,8 @@ func GetLikeOperator(
 			return nil, err
 		}
 		return &selNotRegexpBytesBytesConstOp{
-			OneInputNode: NewOneInputNode(input),
-			colIdx:       colIdx,
-			constArg:     re,
+			selConstOpBase: base,
+			constArg:       re,
 		}, nil
 	default:
 		return nil, errors.AssertionFailedf("unsupported like op type %d", likeOpType)
@@ -177,20 +173,21 @@ func GetLikeProjectionOperator(
 		return nil, err
 	}
 	pat := []byte(pattern)
+	base := projConstOpBase{
+		OneInputNode: NewOneInputNode(input),
+		colIdx:       colIdx,
+		outputIdx:    resultIdx,
+	}
 	switch likeOpType {
 	case likeConstant:
 		return &projEQBytesBytesConstOp{
-			OneInputNode: NewOneInputNode(input),
-			colIdx:       colIdx,
-			constArg:     pat,
-			outputIdx:    resultIdx,
+			projConstOpBase: base,
+			constArg:        pat,
 		}, nil
 	case likeConstantNegate:
 		return &projNEBytesBytesConstOp{
-			OneInputNode: NewOneInputNode(input),
-			colIdx:       colIdx,
-			constArg:     pat,
-			outputIdx:    resultIdx,
+			projConstOpBase: base,
+			constArg:        pat,
 		}, nil
 	case likeNeverMatch:
 		return NewConstOp(input, coltypes.Bool, false, resultIdx)
@@ -200,31 +197,23 @@ func GetLikeProjectionOperator(
 		return NewConstOp(input, coltypes.Bool, true, resultIdx)
 	case likeSuffix:
 		return &projSuffixBytesBytesConstOp{
-			OneInputNode: NewOneInputNode(input),
-			colIdx:       colIdx,
-			constArg:     pat,
-			outputIdx:    resultIdx,
+			projConstOpBase: base,
+			constArg:        pat,
 		}, nil
 	case likeSuffixNegate:
 		return &projNotSuffixBytesBytesConstOp{
-			OneInputNode: NewOneInputNode(input),
-			colIdx:       colIdx,
-			constArg:     pat,
-			outputIdx:    resultIdx,
+			projConstOpBase: base,
+			constArg:        pat,
 		}, nil
 	case likePrefix:
 		return &projPrefixBytesBytesConstOp{
-			OneInputNode: NewOneInputNode(input),
-			colIdx:       colIdx,
-			constArg:     pat,
-			outputIdx:    resultIdx,
+			projConstOpBase: base,
+			constArg:        pat,
 		}, nil
 	case likePrefixNegate:
 		return &projNotPrefixBytesBytesConstOp{
-			OneInputNode: NewOneInputNode(input),
-			colIdx:       colIdx,
-			constArg:     pat,
-			outputIdx:    resultIdx,
+			projConstOpBase: base,
+			constArg:        pat,
 		}, nil
 	case likeRegexp:
 		re, err := tree.ConvertLikeToRegexp(ctx, pattern, false, '\\')
@@ -232,10 +221,8 @@ func GetLikeProjectionOperator(
 			return nil, err
 		}
 		return &projRegexpBytesBytesConstOp{
-			OneInputNode: NewOneInputNode(input),
-			colIdx:       colIdx,
-			constArg:     re,
-			outputIdx:    resultIdx,
+			projConstOpBase: base,
+			constArg:        re,
 		}, nil
 	case likeRegexpNegate:
 		re, err := tree.ConvertLikeToRegexp(ctx, pattern, false, '\\')
@@ -243,10 +230,8 @@ func GetLikeProjectionOperator(
 			return nil, err
 		}
 		return &projNotRegexpBytesBytesConstOp{
-			OneInputNode: NewOneInputNode(input),
-			colIdx:       colIdx,
-			constArg:     re,
-			outputIdx:    resultIdx,
+			projConstOpBase: base,
+			constArg:        re,
 		}, nil
 	default:
 		return nil, errors.AssertionFailedf("unsupported like op type %d", likeOpType)

--- a/pkg/sql/exec/like_ops_test.go
+++ b/pkg/sql/exec/like_ops_test.go
@@ -119,21 +119,22 @@ func BenchmarkLikeOps(b *testing.B) {
 	source := NewRepeatableBatchSource(batch)
 	source.Init()
 
-	prefixOp := &selPrefixBytesBytesConstOp{
+	base := selConstOpBase{
 		OneInputNode: NewOneInputNode(source),
 		colIdx:       0,
-		constArg:     []byte(prefix),
+	}
+	prefixOp := &selPrefixBytesBytesConstOp{
+		selConstOpBase: base,
+		constArg:       []byte(prefix),
 	}
 	suffixOp := &selSuffixBytesBytesConstOp{
-		OneInputNode: NewOneInputNode(source),
-		colIdx:       0,
-		constArg:     []byte(suffix),
+		selConstOpBase: base,
+		constArg:       []byte(suffix),
 	}
 	pattern := fmt.Sprintf("^%s.*%s$", prefix, suffix)
 	regexpOp := &selRegexpBytesBytesConstOp{
-		OneInputNode: NewOneInputNode(source),
-		colIdx:       0,
-		constArg:     regexp.MustCompile(pattern),
+		selConstOpBase: base,
+		constArg:       regexp.MustCompile(pattern),
 	}
 
 	testCases := []struct {

--- a/pkg/sql/exec/projection_ops.go
+++ b/pkg/sql/exec/projection_ops.go
@@ -1,0 +1,27 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package exec
+
+// projConstOpBase contains all of the fields for binary projections with a
+// constant, except for the constant itself.
+type projConstOpBase struct {
+	OneInputNode
+	colIdx    int
+	outputIdx int
+}
+
+// projOpBase contains all of the fields for non-constant binary projections.
+type projOpBase struct {
+	OneInputNode
+	col1Idx   int
+	col2Idx   int
+	outputIdx int
+}

--- a/pkg/sql/exec/selection_ops.go
+++ b/pkg/sql/exec/selection_ops.go
@@ -1,0 +1,25 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package exec
+
+// selConstOpBase contains all of the fields for binary selections with a
+// constant, except for the constant itself.
+type selConstOpBase struct {
+	OneInputNode
+	colIdx int
+}
+
+// selOpBase contains all of the fields for non-constant binary selections.
+type selOpBase struct {
+	OneInputNode
+	col1Idx int
+	col2Idx int
+}

--- a/pkg/sql/exec/selection_ops_test.go
+++ b/pkg/sql/exec/selection_ops_test.go
@@ -33,9 +33,11 @@ func TestSelLTInt64Int64ConstOp(t *testing.T) {
 	tups := tuples{{0}, {1}, {2}, {nil}}
 	runTests(t, []tuples{tups}, tuples{{0}, {1}}, orderedVerifier, []int{0}, func(input []Operator) (Operator, error) {
 		return &selLTInt64Int64ConstOp{
-			OneInputNode: NewOneInputNode(input[0]),
-			colIdx:       0,
-			constArg:     2,
+			selConstOpBase: selConstOpBase{
+				OneInputNode: NewOneInputNode(input[0]),
+				colIdx:       0,
+			},
+			constArg: 2,
 		}, nil
 	})
 }
@@ -52,9 +54,11 @@ func TestSelLTInt64Int64(t *testing.T) {
 	}
 	runTests(t, []tuples{tups}, tuples{{0, 1}}, orderedVerifier, []int{0, 1}, func(input []Operator) (Operator, error) {
 		return &selLTInt64Int64Op{
-			OneInputNode: NewOneInputNode(input[0]),
-			col1Idx:      0,
-			col2Idx:      1,
+			selOpBase: selOpBase{
+				OneInputNode: NewOneInputNode(input[0]),
+				col1Idx:      0,
+				col2Idx:      1,
+			},
 		}, nil
 	})
 }
@@ -70,9 +74,11 @@ func TestGetSelectionConstOperator(t *testing.T) {
 		t.Error(err)
 	}
 	expected := &selLTInt64Int64ConstOp{
-		OneInputNode: NewOneInputNode(input),
-		colIdx:       colIdx,
-		constArg:     constVal,
+		selConstOpBase: selConstOpBase{
+			OneInputNode: NewOneInputNode(input),
+			colIdx:       colIdx,
+		},
+		constArg: constVal,
 	}
 	if !reflect.DeepEqual(op, expected) {
 		t.Errorf("got %+v, expected %+v", op, expected)
@@ -90,9 +96,11 @@ func TestGetSelectionConstMixedTypeOperator(t *testing.T) {
 		t.Error(err)
 	}
 	expected := &selLTInt64Int16ConstOp{
-		OneInputNode: NewOneInputNode(input),
-		colIdx:       colIdx,
-		constArg:     constVal,
+		selConstOpBase: selConstOpBase{
+			OneInputNode: NewOneInputNode(input),
+			colIdx:       colIdx,
+		},
+		constArg: constVal,
 	}
 	if !reflect.DeepEqual(op, expected) {
 		t.Errorf("got %+v, expected %+v", op, expected)
@@ -110,9 +118,11 @@ func TestGetSelectionOperator(t *testing.T) {
 		t.Error(err)
 	}
 	expected := &selGEInt16Int16Op{
-		OneInputNode: NewOneInputNode(input),
-		col1Idx:      col1Idx,
-		col2Idx:      col2Idx,
+		selOpBase: selOpBase{
+			OneInputNode: NewOneInputNode(input),
+			col1Idx:      col1Idx,
+			col2Idx:      col2Idx,
+		},
 	}
 	if !reflect.DeepEqual(op, expected) {
 		t.Errorf("got %+v, expected %+v", op, expected)
@@ -150,9 +160,11 @@ func benchmarkSelLTInt64Int64ConstOp(b *testing.B, useSelectionVector bool, hasN
 	source.Init()
 
 	plusOp := &selLTInt64Int64ConstOp{
-		OneInputNode: NewOneInputNode(source),
-		colIdx:       0,
-		constArg:     0,
+		selConstOpBase: selConstOpBase{
+			OneInputNode: NewOneInputNode(source),
+			colIdx:       0,
+		},
+		constArg: 0,
 	}
 	plusOp.Init()
 
@@ -208,9 +220,11 @@ func benchmarkSelLTInt64Int64Op(b *testing.B, useSelectionVector bool, hasNulls 
 	source.Init()
 
 	plusOp := &selLTInt64Int64Op{
-		OneInputNode: NewOneInputNode(source),
-		col1Idx:      0,
-		col2Idx:      1,
+		selOpBase: selOpBase{
+			OneInputNode: NewOneInputNode(source),
+			col1Idx:      0,
+			col2Idx:      1,
+		},
 	}
 	plusOp.Init()
 


### PR DESCRIPTION
The struct definitions had a lot of overlap - this adds some base
structs to clean things up a little bit.

Release note: None