### PR TITLE
storage: prepare for kv.atomic_replication_changes=true

### DIFF
--- a/pkg/roachpb/api.pb.go
+++ b/pkg/roachpb/api.pb.go
@@ -71,7 +71,7 @@ func (x ReadConsistencyType) String() string {
 	return proto.EnumName(ReadConsistencyType_name, int32(x))
 }
 func (ReadConsistencyType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{0}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{0}
 }
 
 // ScanFormat is an enumeration of the available response formats for MVCCScan
@@ -99,7 +99,7 @@ func (x ScanFormat) String() string {
 	return proto.EnumName(ScanFormat_name, int32(x))
 }
 func (ScanFormat) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{1}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{1}
 }
 
 type ChecksumMode int32
@@ -146,7 +146,7 @@ func (x ChecksumMode) String() string {
 	return proto.EnumName(ChecksumMode_name, int32(x))
 }
 func (ChecksumMode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{2}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{2}
 }
 
 // PushTxnType determines what action to take when pushing a transaction.
@@ -177,7 +177,7 @@ func (x PushTxnType) String() string {
 	return proto.EnumName(PushTxnType_name, int32(x))
 }
 func (PushTxnType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{3}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{3}
 }
 
 type ExportStorageProvider int32
@@ -215,7 +215,7 @@ func (x ExportStorageProvider) String() string {
 	return proto.EnumName(ExportStorageProvider_name, int32(x))
 }
 func (ExportStorageProvider) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{4}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{4}
 }
 
 type MVCCFilter int32
@@ -238,7 +238,7 @@ func (x MVCCFilter) String() string {
 	return proto.EnumName(MVCCFilter_name, int32(x))
 }
 func (MVCCFilter) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{5}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{5}
 }
 
 type ResponseHeader_ResumeReason int32
@@ -270,7 +270,7 @@ func (x ResponseHeader_ResumeReason) String() string {
 	return proto.EnumName(ResponseHeader_ResumeReason_name, int32(x))
 }
 func (ResponseHeader_ResumeReason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{2, 0}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{2, 0}
 }
 
 type CheckConsistencyResponse_Status int32
@@ -312,7 +312,7 @@ func (x CheckConsistencyResponse_Status) String() string {
 	return proto.EnumName(CheckConsistencyResponse_Status_name, int32(x))
 }
 func (CheckConsistencyResponse_Status) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{27, 0}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{27, 0}
 }
 
 // RangeInfo describes a range which executed a request. It contains
@@ -326,7 +326,7 @@ func (m *RangeInfo) Reset()         { *m = RangeInfo{} }
 func (m *RangeInfo) String() string { return proto.CompactTextString(m) }
 func (*RangeInfo) ProtoMessage()    {}
 func (*RangeInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{0}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{0}
 }
 func (m *RangeInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -369,7 +369,7 @@ func (m *RequestHeader) Reset()         { *m = RequestHeader{} }
 func (m *RequestHeader) String() string { return proto.CompactTextString(m) }
 func (*RequestHeader) ProtoMessage()    {}
 func (*RequestHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{1}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{1}
 }
 func (m *RequestHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -427,7 +427,7 @@ func (m *ResponseHeader) Reset()         { *m = ResponseHeader{} }
 func (m *ResponseHeader) String() string { return proto.CompactTextString(m) }
 func (*ResponseHeader) ProtoMessage()    {}
 func (*ResponseHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{2}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{2}
 }
 func (m *ResponseHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -461,7 +461,7 @@ func (m *GetRequest) Reset()         { *m = GetRequest{} }
 func (m *GetRequest) String() string { return proto.CompactTextString(m) }
 func (*GetRequest) ProtoMessage()    {}
 func (*GetRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{3}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{3}
 }
 func (m *GetRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -499,7 +499,7 @@ func (m *GetResponse) Reset()         { *m = GetResponse{} }
 func (m *GetResponse) String() string { return proto.CompactTextString(m) }
 func (*GetResponse) ProtoMessage()    {}
 func (*GetResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{4}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{4}
 }
 func (m *GetResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -542,7 +542,7 @@ func (m *PutRequest) Reset()         { *m = PutRequest{} }
 func (m *PutRequest) String() string { return proto.CompactTextString(m) }
 func (*PutRequest) ProtoMessage()    {}
 func (*PutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{5}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{5}
 }
 func (m *PutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -576,7 +576,7 @@ func (m *PutResponse) Reset()         { *m = PutResponse{} }
 func (m *PutResponse) String() string { return proto.CompactTextString(m) }
 func (*PutResponse) ProtoMessage()    {}
 func (*PutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{6}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{6}
 }
 func (m *PutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -630,7 +630,7 @@ func (m *ConditionalPutRequest) Reset()         { *m = ConditionalPutRequest{} }
 func (m *ConditionalPutRequest) String() string { return proto.CompactTextString(m) }
 func (*ConditionalPutRequest) ProtoMessage()    {}
 func (*ConditionalPutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{7}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{7}
 }
 func (m *ConditionalPutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -665,7 +665,7 @@ func (m *ConditionalPutResponse) Reset()         { *m = ConditionalPutResponse{}
 func (m *ConditionalPutResponse) String() string { return proto.CompactTextString(m) }
 func (*ConditionalPutResponse) ProtoMessage()    {}
 func (*ConditionalPutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{8}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{8}
 }
 func (m *ConditionalPutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -711,7 +711,7 @@ func (m *InitPutRequest) Reset()         { *m = InitPutRequest{} }
 func (m *InitPutRequest) String() string { return proto.CompactTextString(m) }
 func (*InitPutRequest) ProtoMessage()    {}
 func (*InitPutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{9}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{9}
 }
 func (m *InitPutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -745,7 +745,7 @@ func (m *InitPutResponse) Reset()         { *m = InitPutResponse{} }
 func (m *InitPutResponse) String() string { return proto.CompactTextString(m) }
 func (*InitPutResponse) ProtoMessage()    {}
 func (*InitPutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{10}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{10}
 }
 func (m *InitPutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -785,7 +785,7 @@ func (m *IncrementRequest) Reset()         { *m = IncrementRequest{} }
 func (m *IncrementRequest) String() string { return proto.CompactTextString(m) }
 func (*IncrementRequest) ProtoMessage()    {}
 func (*IncrementRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{11}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{11}
 }
 func (m *IncrementRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -822,7 +822,7 @@ func (m *IncrementResponse) Reset()         { *m = IncrementResponse{} }
 func (m *IncrementResponse) String() string { return proto.CompactTextString(m) }
 func (*IncrementResponse) ProtoMessage()    {}
 func (*IncrementResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{12}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{12}
 }
 func (m *IncrementResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -856,7 +856,7 @@ func (m *DeleteRequest) Reset()         { *m = DeleteRequest{} }
 func (m *DeleteRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteRequest) ProtoMessage()    {}
 func (*DeleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{13}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{13}
 }
 func (m *DeleteRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -890,7 +890,7 @@ func (m *DeleteResponse) Reset()         { *m = DeleteResponse{} }
 func (m *DeleteResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteResponse) ProtoMessage()    {}
 func (*DeleteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{14}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{14}
 }
 func (m *DeleteResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -939,7 +939,7 @@ func (m *DeleteRangeRequest) Reset()         { *m = DeleteRangeRequest{} }
 func (m *DeleteRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteRangeRequest) ProtoMessage()    {}
 func (*DeleteRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{15}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{15}
 }
 func (m *DeleteRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -976,7 +976,7 @@ func (m *DeleteRangeResponse) Reset()         { *m = DeleteRangeResponse{} }
 func (m *DeleteRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteRangeResponse) ProtoMessage()    {}
 func (*DeleteRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{16}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{16}
 }
 func (m *DeleteRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1023,7 +1023,7 @@ func (m *ClearRangeRequest) Reset()         { *m = ClearRangeRequest{} }
 func (m *ClearRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*ClearRangeRequest) ProtoMessage()    {}
 func (*ClearRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{17}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{17}
 }
 func (m *ClearRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1057,7 +1057,7 @@ func (m *ClearRangeResponse) Reset()         { *m = ClearRangeResponse{} }
 func (m *ClearRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*ClearRangeResponse) ProtoMessage()    {}
 func (*ClearRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{18}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{18}
 }
 func (m *ClearRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1098,7 +1098,7 @@ func (m *RevertRangeRequest) Reset()         { *m = RevertRangeRequest{} }
 func (m *RevertRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*RevertRangeRequest) ProtoMessage()    {}
 func (*RevertRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{19}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{19}
 }
 func (m *RevertRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1132,7 +1132,7 @@ func (m *RevertRangeResponse) Reset()         { *m = RevertRangeResponse{} }
 func (m *RevertRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*RevertRangeResponse) ProtoMessage()    {}
 func (*RevertRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{20}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{20}
 }
 func (m *RevertRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1201,7 +1201,7 @@ func (m *ScanOptions) Reset()         { *m = ScanOptions{} }
 func (m *ScanOptions) String() string { return proto.CompactTextString(m) }
 func (*ScanOptions) ProtoMessage()    {}
 func (*ScanOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{21}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{21}
 }
 func (m *ScanOptions) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1241,7 +1241,7 @@ func (m *ScanRequest) Reset()         { *m = ScanRequest{} }
 func (m *ScanRequest) String() string { return proto.CompactTextString(m) }
 func (*ScanRequest) ProtoMessage()    {}
 func (*ScanRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{22}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{22}
 }
 func (m *ScanRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1288,7 +1288,7 @@ func (m *ScanResponse) Reset()         { *m = ScanResponse{} }
 func (m *ScanResponse) String() string { return proto.CompactTextString(m) }
 func (*ScanResponse) ProtoMessage()    {}
 func (*ScanResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{23}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{23}
 }
 func (m *ScanResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1328,7 +1328,7 @@ func (m *ReverseScanRequest) Reset()         { *m = ReverseScanRequest{} }
 func (m *ReverseScanRequest) String() string { return proto.CompactTextString(m) }
 func (*ReverseScanRequest) ProtoMessage()    {}
 func (*ReverseScanRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{24}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{24}
 }
 func (m *ReverseScanRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1375,7 +1375,7 @@ func (m *ReverseScanResponse) Reset()         { *m = ReverseScanResponse{} }
 func (m *ReverseScanResponse) String() string { return proto.CompactTextString(m) }
 func (*ReverseScanResponse) ProtoMessage()    {}
 func (*ReverseScanResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{25}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{25}
 }
 func (m *ReverseScanResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1421,7 +1421,7 @@ func (m *CheckConsistencyRequest) Reset()         { *m = CheckConsistencyRequest
 func (m *CheckConsistencyRequest) String() string { return proto.CompactTextString(m) }
 func (*CheckConsistencyRequest) ProtoMessage()    {}
 func (*CheckConsistencyRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{26}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{26}
 }
 func (m *CheckConsistencyRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1458,7 +1458,7 @@ func (m *CheckConsistencyResponse) Reset()         { *m = CheckConsistencyRespon
 func (m *CheckConsistencyResponse) String() string { return proto.CompactTextString(m) }
 func (*CheckConsistencyResponse) ProtoMessage()    {}
 func (*CheckConsistencyResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{27}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{27}
 }
 func (m *CheckConsistencyResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1502,7 +1502,7 @@ func (m *CheckConsistencyResponse_Result) Reset()         { *m = CheckConsistenc
 func (m *CheckConsistencyResponse_Result) String() string { return proto.CompactTextString(m) }
 func (*CheckConsistencyResponse_Result) ProtoMessage()    {}
 func (*CheckConsistencyResponse_Result) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{27, 0}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{27, 0}
 }
 func (m *CheckConsistencyResponse_Result) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1550,7 +1550,7 @@ func (m *RecomputeStatsRequest) Reset()         { *m = RecomputeStatsRequest{} }
 func (m *RecomputeStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*RecomputeStatsRequest) ProtoMessage()    {}
 func (*RecomputeStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{28}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{28}
 }
 func (m *RecomputeStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1586,7 +1586,7 @@ func (m *RecomputeStatsResponse) Reset()         { *m = RecomputeStatsResponse{}
 func (m *RecomputeStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*RecomputeStatsResponse) ProtoMessage()    {}
 func (*RecomputeStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{29}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{29}
 }
 func (m *RecomputeStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1620,7 +1620,7 @@ func (m *BeginTransactionRequest) Reset()         { *m = BeginTransactionRequest
 func (m *BeginTransactionRequest) String() string { return proto.CompactTextString(m) }
 func (*BeginTransactionRequest) ProtoMessage()    {}
 func (*BeginTransactionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{30}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{30}
 }
 func (m *BeginTransactionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1654,7 +1654,7 @@ func (m *BeginTransactionResponse) Reset()         { *m = BeginTransactionRespon
 func (m *BeginTransactionResponse) String() string { return proto.CompactTextString(m) }
 func (*BeginTransactionResponse) ProtoMessage()    {}
 func (*BeginTransactionResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{31}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{31}
 }
 func (m *BeginTransactionResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1742,7 +1742,7 @@ func (m *EndTransactionRequest) Reset()         { *m = EndTransactionRequest{} }
 func (m *EndTransactionRequest) String() string { return proto.CompactTextString(m) }
 func (*EndTransactionRequest) ProtoMessage()    {}
 func (*EndTransactionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{32}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{32}
 }
 func (m *EndTransactionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1789,7 +1789,7 @@ func (m *EndTransactionResponse) Reset()         { *m = EndTransactionResponse{}
 func (m *EndTransactionResponse) String() string { return proto.CompactTextString(m) }
 func (*EndTransactionResponse) ProtoMessage()    {}
 func (*EndTransactionResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{33}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{33}
 }
 func (m *EndTransactionResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1850,7 +1850,7 @@ func (m *AdminSplitRequest) Reset()         { *m = AdminSplitRequest{} }
 func (m *AdminSplitRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminSplitRequest) ProtoMessage()    {}
 func (*AdminSplitRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{34}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{34}
 }
 func (m *AdminSplitRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1885,7 +1885,7 @@ func (m *AdminSplitResponse) Reset()         { *m = AdminSplitResponse{} }
 func (m *AdminSplitResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminSplitResponse) ProtoMessage()    {}
 func (*AdminSplitResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{35}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{35}
 }
 func (m *AdminSplitResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1924,7 +1924,7 @@ func (m *AdminUnsplitRequest) Reset()         { *m = AdminUnsplitRequest{} }
 func (m *AdminUnsplitRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminUnsplitRequest) ProtoMessage()    {}
 func (*AdminUnsplitRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{36}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{36}
 }
 func (m *AdminUnsplitRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1959,7 +1959,7 @@ func (m *AdminUnsplitResponse) Reset()         { *m = AdminUnsplitResponse{} }
 func (m *AdminUnsplitResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminUnsplitResponse) ProtoMessage()    {}
 func (*AdminUnsplitResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{37}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{37}
 }
 func (m *AdminUnsplitResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1993,6 +1993,7 @@ var xxx_messageInfo_AdminUnsplitResponse proto.InternalMessageInfo
 // now encompass all keys from its original start key to the end key
 // of the subsumed range. If AdminMerge is called on the final range
 // in the key space, it is a noop.
+// The request must be addressed to the start key of the left hand side.
 type AdminMergeRequest struct {
 	RequestHeader `protobuf:"bytes,1,opt,name=header,proto3,embedded=header" json:"header"`
 }
@@ -2001,7 +2002,7 @@ func (m *AdminMergeRequest) Reset()         { *m = AdminMergeRequest{} }
 func (m *AdminMergeRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminMergeRequest) ProtoMessage()    {}
 func (*AdminMergeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{38}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{38}
 }
 func (m *AdminMergeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2036,7 +2037,7 @@ func (m *AdminMergeResponse) Reset()         { *m = AdminMergeResponse{} }
 func (m *AdminMergeResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminMergeResponse) ProtoMessage()    {}
 func (*AdminMergeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{39}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{39}
 }
 func (m *AdminMergeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2074,7 +2075,7 @@ func (m *AdminTransferLeaseRequest) Reset()         { *m = AdminTransferLeaseReq
 func (m *AdminTransferLeaseRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminTransferLeaseRequest) ProtoMessage()    {}
 func (*AdminTransferLeaseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{40}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{40}
 }
 func (m *AdminTransferLeaseRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2107,7 +2108,7 @@ func (m *AdminTransferLeaseResponse) Reset()         { *m = AdminTransferLeaseRe
 func (m *AdminTransferLeaseResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminTransferLeaseResponse) ProtoMessage()    {}
 func (*AdminTransferLeaseResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{41}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{41}
 }
 func (m *AdminTransferLeaseResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2142,7 +2143,7 @@ func (m *ReplicationChange) Reset()         { *m = ReplicationChange{} }
 func (m *ReplicationChange) String() string { return proto.CompactTextString(m) }
 func (*ReplicationChange) ProtoMessage()    {}
 func (*ReplicationChange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{42}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{42}
 }
 func (m *ReplicationChange) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2200,7 +2201,7 @@ func (m *AdminChangeReplicasRequest) Reset()         { *m = AdminChangeReplicasR
 func (m *AdminChangeReplicasRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminChangeReplicasRequest) ProtoMessage()    {}
 func (*AdminChangeReplicasRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{43}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{43}
 }
 func (m *AdminChangeReplicasRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2235,7 +2236,7 @@ func (m *AdminChangeReplicasResponse) Reset()         { *m = AdminChangeReplicas
 func (m *AdminChangeReplicasResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminChangeReplicasResponse) ProtoMessage()    {}
 func (*AdminChangeReplicasResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{44}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{44}
 }
 func (m *AdminChangeReplicasResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2272,7 +2273,7 @@ func (m *AdminRelocateRangeRequest) Reset()         { *m = AdminRelocateRangeReq
 func (m *AdminRelocateRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminRelocateRangeRequest) ProtoMessage()    {}
 func (*AdminRelocateRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{45}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{45}
 }
 func (m *AdminRelocateRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2305,7 +2306,7 @@ func (m *AdminRelocateRangeResponse) Reset()         { *m = AdminRelocateRangeRe
 func (m *AdminRelocateRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminRelocateRangeResponse) ProtoMessage()    {}
 func (*AdminRelocateRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{46}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{46}
 }
 func (m *AdminRelocateRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2344,7 +2345,7 @@ func (m *HeartbeatTxnRequest) Reset()         { *m = HeartbeatTxnRequest{} }
 func (m *HeartbeatTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*HeartbeatTxnRequest) ProtoMessage()    {}
 func (*HeartbeatTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{47}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{47}
 }
 func (m *HeartbeatTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2381,7 +2382,7 @@ func (m *HeartbeatTxnResponse) Reset()         { *m = HeartbeatTxnResponse{} }
 func (m *HeartbeatTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*HeartbeatTxnResponse) ProtoMessage()    {}
 func (*HeartbeatTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{48}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{48}
 }
 func (m *HeartbeatTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2419,7 +2420,7 @@ func (m *GCRequest) Reset()         { *m = GCRequest{} }
 func (m *GCRequest) String() string { return proto.CompactTextString(m) }
 func (*GCRequest) ProtoMessage()    {}
 func (*GCRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{49}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{49}
 }
 func (m *GCRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2453,7 +2454,7 @@ func (m *GCRequest_GCKey) Reset()         { *m = GCRequest_GCKey{} }
 func (m *GCRequest_GCKey) String() string { return proto.CompactTextString(m) }
 func (*GCRequest_GCKey) ProtoMessage()    {}
 func (*GCRequest_GCKey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{49, 0}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{49, 0}
 }
 func (m *GCRequest_GCKey) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2487,7 +2488,7 @@ func (m *GCResponse) Reset()         { *m = GCResponse{} }
 func (m *GCResponse) String() string { return proto.CompactTextString(m) }
 func (*GCResponse) ProtoMessage()    {}
 func (*GCResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{50}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{50}
 }
 func (m *GCResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2562,7 +2563,7 @@ func (m *PushTxnRequest) Reset()         { *m = PushTxnRequest{} }
 func (m *PushTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*PushTxnRequest) ProtoMessage()    {}
 func (*PushTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{51}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{51}
 }
 func (m *PushTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2605,7 +2606,7 @@ func (m *PushTxnResponse) Reset()         { *m = PushTxnResponse{} }
 func (m *PushTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*PushTxnResponse) ProtoMessage()    {}
 func (*PushTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{52}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{52}
 }
 func (m *PushTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2652,7 +2653,7 @@ func (m *RecoverTxnRequest) Reset()         { *m = RecoverTxnRequest{} }
 func (m *RecoverTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*RecoverTxnRequest) ProtoMessage()    {}
 func (*RecoverTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{53}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{53}
 }
 func (m *RecoverTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2688,7 +2689,7 @@ func (m *RecoverTxnResponse) Reset()         { *m = RecoverTxnResponse{} }
 func (m *RecoverTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*RecoverTxnResponse) ProtoMessage()    {}
 func (*RecoverTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{54}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{54}
 }
 func (m *RecoverTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2732,7 +2733,7 @@ func (m *QueryTxnRequest) Reset()         { *m = QueryTxnRequest{} }
 func (m *QueryTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryTxnRequest) ProtoMessage()    {}
 func (*QueryTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{55}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{55}
 }
 func (m *QueryTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2771,7 +2772,7 @@ func (m *QueryTxnResponse) Reset()         { *m = QueryTxnResponse{} }
 func (m *QueryTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryTxnResponse) ProtoMessage()    {}
 func (*QueryTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{56}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{56}
 }
 func (m *QueryTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2831,7 +2832,7 @@ func (m *QueryIntentRequest) Reset()         { *m = QueryIntentRequest{} }
 func (m *QueryIntentRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryIntentRequest) ProtoMessage()    {}
 func (*QueryIntentRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{57}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{57}
 }
 func (m *QueryIntentRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2867,7 +2868,7 @@ func (m *QueryIntentResponse) Reset()         { *m = QueryIntentResponse{} }
 func (m *QueryIntentResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryIntentResponse) ProtoMessage()    {}
 func (*QueryIntentResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{58}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{58}
 }
 func (m *QueryIntentResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2911,7 +2912,7 @@ func (m *ResolveIntentRequest) Reset()         { *m = ResolveIntentRequest{} }
 func (m *ResolveIntentRequest) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentRequest) ProtoMessage()    {}
 func (*ResolveIntentRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{59}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{59}
 }
 func (m *ResolveIntentRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2946,7 +2947,7 @@ func (m *ResolveIntentResponse) Reset()         { *m = ResolveIntentResponse{} }
 func (m *ResolveIntentResponse) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentResponse) ProtoMessage()    {}
 func (*ResolveIntentResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{60}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{60}
 }
 func (m *ResolveIntentResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2994,7 +2995,7 @@ func (m *ResolveIntentRangeRequest) Reset()         { *m = ResolveIntentRangeReq
 func (m *ResolveIntentRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentRangeRequest) ProtoMessage()    {}
 func (*ResolveIntentRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{61}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{61}
 }
 func (m *ResolveIntentRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3029,7 +3030,7 @@ func (m *ResolveIntentRangeResponse) Reset()         { *m = ResolveIntentRangeRe
 func (m *ResolveIntentRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentRangeResponse) ProtoMessage()    {}
 func (*ResolveIntentRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{62}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{62}
 }
 func (m *ResolveIntentRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3066,7 +3067,7 @@ func (m *MergeRequest) Reset()         { *m = MergeRequest{} }
 func (m *MergeRequest) String() string { return proto.CompactTextString(m) }
 func (*MergeRequest) ProtoMessage()    {}
 func (*MergeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{63}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{63}
 }
 func (m *MergeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3100,7 +3101,7 @@ func (m *MergeResponse) Reset()         { *m = MergeResponse{} }
 func (m *MergeResponse) String() string { return proto.CompactTextString(m) }
 func (*MergeResponse) ProtoMessage()    {}
 func (*MergeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{64}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{64}
 }
 func (m *MergeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3145,7 +3146,7 @@ func (m *TruncateLogRequest) Reset()         { *m = TruncateLogRequest{} }
 func (m *TruncateLogRequest) String() string { return proto.CompactTextString(m) }
 func (*TruncateLogRequest) ProtoMessage()    {}
 func (*TruncateLogRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{65}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{65}
 }
 func (m *TruncateLogRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3179,7 +3180,7 @@ func (m *TruncateLogResponse) Reset()         { *m = TruncateLogResponse{} }
 func (m *TruncateLogResponse) String() string { return proto.CompactTextString(m) }
 func (*TruncateLogResponse) ProtoMessage()    {}
 func (*TruncateLogResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{66}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{66}
 }
 func (m *TruncateLogResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3223,7 +3224,7 @@ func (m *RequestLeaseRequest) Reset()         { *m = RequestLeaseRequest{} }
 func (m *RequestLeaseRequest) String() string { return proto.CompactTextString(m) }
 func (*RequestLeaseRequest) ProtoMessage()    {}
 func (*RequestLeaseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{67}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{67}
 }
 func (m *RequestLeaseRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3272,7 +3273,7 @@ func (m *TransferLeaseRequest) Reset()         { *m = TransferLeaseRequest{} }
 func (m *TransferLeaseRequest) String() string { return proto.CompactTextString(m) }
 func (*TransferLeaseRequest) ProtoMessage()    {}
 func (*TransferLeaseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{68}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{68}
 }
 func (m *TransferLeaseRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3309,7 +3310,7 @@ func (m *LeaseInfoRequest) Reset()         { *m = LeaseInfoRequest{} }
 func (m *LeaseInfoRequest) String() string { return proto.CompactTextString(m) }
 func (*LeaseInfoRequest) ProtoMessage()    {}
 func (*LeaseInfoRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{69}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{69}
 }
 func (m *LeaseInfoRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3346,7 +3347,7 @@ func (m *LeaseInfoResponse) Reset()         { *m = LeaseInfoResponse{} }
 func (m *LeaseInfoResponse) String() string { return proto.CompactTextString(m) }
 func (*LeaseInfoResponse) ProtoMessage()    {}
 func (*LeaseInfoResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{70}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{70}
 }
 func (m *LeaseInfoResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3381,7 +3382,7 @@ func (m *RequestLeaseResponse) Reset()         { *m = RequestLeaseResponse{} }
 func (m *RequestLeaseResponse) String() string { return proto.CompactTextString(m) }
 func (*RequestLeaseResponse) ProtoMessage()    {}
 func (*RequestLeaseResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{71}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{71}
 }
 func (m *RequestLeaseResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3431,7 +3432,7 @@ func (m *ComputeChecksumRequest) Reset()         { *m = ComputeChecksumRequest{}
 func (m *ComputeChecksumRequest) String() string { return proto.CompactTextString(m) }
 func (*ComputeChecksumRequest) ProtoMessage()    {}
 func (*ComputeChecksumRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{72}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{72}
 }
 func (m *ComputeChecksumRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3468,7 +3469,7 @@ func (m *ComputeChecksumResponse) Reset()         { *m = ComputeChecksumResponse
 func (m *ComputeChecksumResponse) String() string { return proto.CompactTextString(m) }
 func (*ComputeChecksumResponse) ProtoMessage()    {}
 func (*ComputeChecksumResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{73}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{73}
 }
 func (m *ComputeChecksumResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3507,7 +3508,7 @@ func (m *ExportStorage) Reset()         { *m = ExportStorage{} }
 func (m *ExportStorage) String() string { return proto.CompactTextString(m) }
 func (*ExportStorage) ProtoMessage()    {}
 func (*ExportStorage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{74}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{74}
 }
 func (m *ExportStorage) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3541,7 +3542,7 @@ func (m *ExportStorage_LocalFilePath) Reset()         { *m = ExportStorage_Local
 func (m *ExportStorage_LocalFilePath) String() string { return proto.CompactTextString(m) }
 func (*ExportStorage_LocalFilePath) ProtoMessage()    {}
 func (*ExportStorage_LocalFilePath) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{74, 0}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{74, 0}
 }
 func (m *ExportStorage_LocalFilePath) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3574,7 +3575,7 @@ func (m *ExportStorage_Http) Reset()         { *m = ExportStorage_Http{} }
 func (m *ExportStorage_Http) String() string { return proto.CompactTextString(m) }
 func (*ExportStorage_Http) ProtoMessage()    {}
 func (*ExportStorage_Http) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{74, 1}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{74, 1}
 }
 func (m *ExportStorage_Http) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3613,7 +3614,7 @@ func (m *ExportStorage_S3) Reset()         { *m = ExportStorage_S3{} }
 func (m *ExportStorage_S3) String() string { return proto.CompactTextString(m) }
 func (*ExportStorage_S3) ProtoMessage()    {}
 func (*ExportStorage_S3) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{74, 2}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{74, 2}
 }
 func (m *ExportStorage_S3) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3652,7 +3653,7 @@ func (m *ExportStorage_GCS) Reset()         { *m = ExportStorage_GCS{} }
 func (m *ExportStorage_GCS) String() string { return proto.CompactTextString(m) }
 func (*ExportStorage_GCS) ProtoMessage()    {}
 func (*ExportStorage_GCS) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{74, 3}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{74, 3}
 }
 func (m *ExportStorage_GCS) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3688,7 +3689,7 @@ func (m *ExportStorage_Azure) Reset()         { *m = ExportStorage_Azure{} }
 func (m *ExportStorage_Azure) String() string { return proto.CompactTextString(m) }
 func (*ExportStorage_Azure) ProtoMessage()    {}
 func (*ExportStorage_Azure) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{74, 4}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{74, 4}
 }
 func (m *ExportStorage_Azure) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3727,7 +3728,7 @@ func (m *ExportStorage_Workload) Reset()         { *m = ExportStorage_Workload{}
 func (m *ExportStorage_Workload) String() string { return proto.CompactTextString(m) }
 func (*ExportStorage_Workload) ProtoMessage()    {}
 func (*ExportStorage_Workload) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{74, 5}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{74, 5}
 }
 func (m *ExportStorage_Workload) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3767,7 +3768,7 @@ func (m *WriteBatchRequest) Reset()         { *m = WriteBatchRequest{} }
 func (m *WriteBatchRequest) String() string { return proto.CompactTextString(m) }
 func (*WriteBatchRequest) ProtoMessage()    {}
 func (*WriteBatchRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{75}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{75}
 }
 func (m *WriteBatchRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3801,7 +3802,7 @@ func (m *WriteBatchResponse) Reset()         { *m = WriteBatchResponse{} }
 func (m *WriteBatchResponse) String() string { return proto.CompactTextString(m) }
 func (*WriteBatchResponse) ProtoMessage()    {}
 func (*WriteBatchResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{76}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{76}
 }
 func (m *WriteBatchResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3863,7 +3864,7 @@ func (m *ExportRequest) Reset()         { *m = ExportRequest{} }
 func (m *ExportRequest) String() string { return proto.CompactTextString(m) }
 func (*ExportRequest) ProtoMessage()    {}
 func (*ExportRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{77}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{77}
 }
 func (m *ExportRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3899,7 +3900,7 @@ func (m *BulkOpSummary) Reset()         { *m = BulkOpSummary{} }
 func (m *BulkOpSummary) String() string { return proto.CompactTextString(m) }
 func (*BulkOpSummary) ProtoMessage()    {}
 func (*BulkOpSummary) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{78}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{78}
 }
 func (m *BulkOpSummary) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3935,7 +3936,7 @@ func (m *ExportResponse) Reset()         { *m = ExportResponse{} }
 func (m *ExportResponse) String() string { return proto.CompactTextString(m) }
 func (*ExportResponse) ProtoMessage()    {}
 func (*ExportResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{79}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{79}
 }
 func (m *ExportResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3975,7 +3976,7 @@ func (m *ExportResponse_File) Reset()         { *m = ExportResponse_File{} }
 func (m *ExportResponse_File) String() string { return proto.CompactTextString(m) }
 func (*ExportResponse_File) ProtoMessage()    {}
 func (*ExportResponse_File) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{79, 0}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{79, 0}
 }
 func (m *ExportResponse_File) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4025,7 +4026,7 @@ func (m *ImportRequest) Reset()         { *m = ImportRequest{} }
 func (m *ImportRequest) String() string { return proto.CompactTextString(m) }
 func (*ImportRequest) ProtoMessage()    {}
 func (*ImportRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{80}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{80}
 }
 func (m *ImportRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4060,7 +4061,7 @@ func (m *ImportRequest_File) Reset()         { *m = ImportRequest_File{} }
 func (m *ImportRequest_File) String() string { return proto.CompactTextString(m) }
 func (*ImportRequest_File) ProtoMessage()    {}
 func (*ImportRequest_File) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{80, 0}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{80, 0}
 }
 func (m *ImportRequest_File) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4096,7 +4097,7 @@ func (m *ImportRequest_TableRekey) Reset()         { *m = ImportRequest_TableRek
 func (m *ImportRequest_TableRekey) String() string { return proto.CompactTextString(m) }
 func (*ImportRequest_TableRekey) ProtoMessage()    {}
 func (*ImportRequest_TableRekey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{80, 1}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{80, 1}
 }
 func (m *ImportRequest_TableRekey) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4131,7 +4132,7 @@ func (m *ImportResponse) Reset()         { *m = ImportResponse{} }
 func (m *ImportResponse) String() string { return proto.CompactTextString(m) }
 func (*ImportResponse) ProtoMessage()    {}
 func (*ImportResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{81}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{81}
 }
 func (m *ImportResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4169,7 +4170,7 @@ func (m *AdminScatterRequest) Reset()         { *m = AdminScatterRequest{} }
 func (m *AdminScatterRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminScatterRequest) ProtoMessage()    {}
 func (*AdminScatterRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{82}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{82}
 }
 func (m *AdminScatterRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4204,7 +4205,7 @@ func (m *AdminScatterResponse) Reset()         { *m = AdminScatterResponse{} }
 func (m *AdminScatterResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminScatterResponse) ProtoMessage()    {}
 func (*AdminScatterResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{83}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{83}
 }
 func (m *AdminScatterResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4237,7 +4238,7 @@ func (m *AdminScatterResponse_Range) Reset()         { *m = AdminScatterResponse
 func (m *AdminScatterResponse_Range) String() string { return proto.CompactTextString(m) }
 func (*AdminScatterResponse_Range) ProtoMessage()    {}
 func (*AdminScatterResponse_Range) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{83, 0}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{83, 0}
 }
 func (m *AdminScatterResponse_Range) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4282,7 +4283,7 @@ func (m *AddSSTableRequest) Reset()         { *m = AddSSTableRequest{} }
 func (m *AddSSTableRequest) String() string { return proto.CompactTextString(m) }
 func (*AddSSTableRequest) ProtoMessage()    {}
 func (*AddSSTableRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{84}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{84}
 }
 func (m *AddSSTableRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4316,7 +4317,7 @@ func (m *AddSSTableResponse) Reset()         { *m = AddSSTableResponse{} }
 func (m *AddSSTableResponse) String() string { return proto.CompactTextString(m) }
 func (*AddSSTableResponse) ProtoMessage()    {}
 func (*AddSSTableResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{85}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{85}
 }
 func (m *AddSSTableResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4360,7 +4361,7 @@ func (m *RefreshRequest) Reset()         { *m = RefreshRequest{} }
 func (m *RefreshRequest) String() string { return proto.CompactTextString(m) }
 func (*RefreshRequest) ProtoMessage()    {}
 func (*RefreshRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{86}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{86}
 }
 func (m *RefreshRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4394,7 +4395,7 @@ func (m *RefreshResponse) Reset()         { *m = RefreshResponse{} }
 func (m *RefreshResponse) String() string { return proto.CompactTextString(m) }
 func (*RefreshResponse) ProtoMessage()    {}
 func (*RefreshResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{87}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{87}
 }
 func (m *RefreshResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4434,7 +4435,7 @@ func (m *RefreshRangeRequest) Reset()         { *m = RefreshRangeRequest{} }
 func (m *RefreshRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*RefreshRangeRequest) ProtoMessage()    {}
 func (*RefreshRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{88}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{88}
 }
 func (m *RefreshRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4468,7 +4469,7 @@ func (m *RefreshRangeResponse) Reset()         { *m = RefreshRangeResponse{} }
 func (m *RefreshRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*RefreshRangeResponse) ProtoMessage()    {}
 func (*RefreshRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{89}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{89}
 }
 func (m *RefreshRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4520,7 +4521,7 @@ func (m *SubsumeRequest) Reset()         { *m = SubsumeRequest{} }
 func (m *SubsumeRequest) String() string { return proto.CompactTextString(m) }
 func (*SubsumeRequest) ProtoMessage()    {}
 func (*SubsumeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{90}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{90}
 }
 func (m *SubsumeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4565,7 +4566,7 @@ func (m *SubsumeResponse) Reset()         { *m = SubsumeResponse{} }
 func (m *SubsumeResponse) String() string { return proto.CompactTextString(m) }
 func (*SubsumeResponse) ProtoMessage()    {}
 func (*SubsumeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{91}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{91}
 }
 func (m *SubsumeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4600,7 +4601,7 @@ func (m *RangeStatsRequest) Reset()         { *m = RangeStatsRequest{} }
 func (m *RangeStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*RangeStatsRequest) ProtoMessage()    {}
 func (*RangeStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{92}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{92}
 }
 func (m *RangeStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4639,7 +4640,7 @@ func (m *RangeStatsResponse) Reset()         { *m = RangeStatsResponse{} }
 func (m *RangeStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*RangeStatsResponse) ProtoMessage()    {}
 func (*RangeStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{93}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{93}
 }
 func (m *RangeStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4722,7 +4723,7 @@ func (m *RequestUnion) Reset()         { *m = RequestUnion{} }
 func (m *RequestUnion) String() string { return proto.CompactTextString(m) }
 func (*RequestUnion) ProtoMessage()    {}
 func (*RequestUnion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{94}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{94}
 }
 func (m *RequestUnion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -6172,7 +6173,7 @@ func (m *ResponseUnion) Reset()         { *m = ResponseUnion{} }
 func (m *ResponseUnion) String() string { return proto.CompactTextString(m) }
 func (*ResponseUnion) ProtoMessage()    {}
 func (*ResponseUnion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{95}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{95}
 }
 func (m *ResponseUnion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7616,7 +7617,7 @@ func (m *Header) Reset()         { *m = Header{} }
 func (m *Header) String() string { return proto.CompactTextString(m) }
 func (*Header) ProtoMessage()    {}
 func (*Header) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{96}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{96}
 }
 func (m *Header) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7652,7 +7653,7 @@ type BatchRequest struct {
 func (m *BatchRequest) Reset()      { *m = BatchRequest{} }
 func (*BatchRequest) ProtoMessage() {}
 func (*BatchRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{97}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{97}
 }
 func (m *BatchRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7689,7 +7690,7 @@ type BatchResponse struct {
 func (m *BatchResponse) Reset()      { *m = BatchResponse{} }
 func (*BatchResponse) ProtoMessage() {}
 func (*BatchResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{98}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{98}
 }
 func (m *BatchResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7748,7 +7749,7 @@ func (m *BatchResponse_Header) Reset()         { *m = BatchResponse_Header{} }
 func (m *BatchResponse_Header) String() string { return proto.CompactTextString(m) }
 func (*BatchResponse_Header) ProtoMessage()    {}
 func (*BatchResponse_Header) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{98, 0}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{98, 0}
 }
 func (m *BatchResponse_Header) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7784,7 +7785,7 @@ func (m *RangeFeedRequest) Reset()         { *m = RangeFeedRequest{} }
 func (m *RangeFeedRequest) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedRequest) ProtoMessage()    {}
 func (*RangeFeedRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{99}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{99}
 }
 func (m *RangeFeedRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7820,7 +7821,7 @@ func (m *RangeFeedValue) Reset()         { *m = RangeFeedValue{} }
 func (m *RangeFeedValue) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedValue) ProtoMessage()    {}
 func (*RangeFeedValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{100}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{100}
 }
 func (m *RangeFeedValue) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7861,7 +7862,7 @@ func (m *RangeFeedCheckpoint) Reset()         { *m = RangeFeedCheckpoint{} }
 func (m *RangeFeedCheckpoint) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedCheckpoint) ProtoMessage()    {}
 func (*RangeFeedCheckpoint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{101}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{101}
 }
 func (m *RangeFeedCheckpoint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7898,7 +7899,7 @@ func (m *RangeFeedError) Reset()         { *m = RangeFeedError{} }
 func (m *RangeFeedError) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedError) ProtoMessage()    {}
 func (*RangeFeedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{102}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{102}
 }
 func (m *RangeFeedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7935,7 +7936,7 @@ func (m *RangeFeedEvent) Reset()         { *m = RangeFeedEvent{} }
 func (m *RangeFeedEvent) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedEvent) ProtoMessage()    {}
 func (*RangeFeedEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_b45d714c466fb74e, []int{103}
+	return fileDescriptor_api_bf28ee004ba75ae5, []int{103}
 }
 func (m *RangeFeedEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -36509,9 +36510,9 @@ var (
 	ErrIntOverflowApi   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("roachpb/api.proto", fileDescriptor_api_b45d714c466fb74e) }
+func init() { proto.RegisterFile("roachpb/api.proto", fileDescriptor_api_bf28ee004ba75ae5) }
 
-var fileDescriptor_api_b45d714c466fb74e = []byte{
+var fileDescriptor_api_bf28ee004ba75ae5 = []byte{
 	// 6978 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe4, 0x7d, 0x5b, 0x6c, 0x23, 0xc9,
 	0x75, 0x36, 0x9b, 0xa4, 0x28, 0xf2, 0xf0, 0xa2, 0x56, 0x69, 0x2e, 0x1c, 0xed, 0xae, 0xa4, 0xe1,

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -720,6 +720,7 @@ message AdminUnsplitResponse {
 // now encompass all keys from its original start key to the end key
 // of the subsumed range. If AdminMerge is called on the final range
 // in the key space, it is a noop.
+// The request must be addressed to the start key of the left hand side.
 message AdminMergeRequest {
   option (gogoproto.equal) = true;
 

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -100,6 +100,24 @@ func (a Attributes) String() string {
 	return strings.Join(a.Attrs, ",")
 }
 
+// NewRangeDescriptor returns a RangeDescriptor populated from the input.
+func NewRangeDescriptor(
+	rangeID RangeID, start, end RKey, replicas ReplicaDescriptors,
+) *RangeDescriptor {
+	repls := append([]ReplicaDescriptor(nil), replicas.All()...)
+	for i := range repls {
+		repls[i].ReplicaID = ReplicaID(i + 1)
+	}
+	desc := &RangeDescriptor{
+		RangeID:       rangeID,
+		StartKey:      start,
+		EndKey:        end,
+		NextReplicaID: ReplicaID(len(repls) + 1),
+	}
+	desc.SetReplicas(MakeReplicaDescriptors(repls))
+	return desc
+}
+
 // RSpan returns the RangeDescriptor's resolved span.
 func (r *RangeDescriptor) RSpan() RSpan {
 	return RSpan{Key: r.StartKey, EndKey: r.EndKey}

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -2259,7 +2259,7 @@ func TestStoreRangeMergeDeadFollowerDuringTxn(t *testing.T) {
 
 	args := adminMergeArgs(lhsDesc.StartKey.AsRawKey())
 	_, pErr := client.SendWrapped(ctx, store0.TestSender(), args)
-	expErr := "merge of range into .* failed: waiting for all right-hand replicas to catch up"
+	expErr := "merge failed: waiting for all right-hand replicas to catch up"
 	if !testutils.IsPError(pErr, expErr) {
 		t.Fatalf("expected %q error, but got %v", expErr, pErr)
 	}

--- a/pkg/storage/merge_queue.go
+++ b/pkg/storage/merge_queue.go
@@ -353,7 +353,9 @@ func (mq *mergeQueue) process(
 		humanizeutil.IBytes(mergedStats.Total()),
 		mergedQPS,
 	)
-	_, pErr := lhsRepl.AdminMerge(ctx, roachpb.AdminMergeRequest{}, reason)
+	_, pErr := lhsRepl.AdminMerge(ctx, roachpb.AdminMergeRequest{
+		RequestHeader: roachpb.RequestHeader{Key: lhsRepl.Desc().StartKey.AsRawKey()},
+	}, reason)
 	switch err := pErr.GoError(); err.(type) {
 	case nil:
 	case *roachpb.ConditionFailedError:

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -246,10 +246,11 @@ func (r *Replica) adminSplitWithDescriptor(
 	log.Event(ctx, "found split key")
 
 	// Create right hand side range descriptor.
-	rightDesc, err := r.store.NewRangeDescriptor(ctx, splitKey, desc.EndKey, desc.Replicas())
+	rightRangeID, err := r.store.AllocateRangeID(ctx)
 	if err != nil {
-		return reply, errors.Errorf("unable to allocate right hand side range descriptor: %s", err)
+		return reply, errors.Wrap(err, "unable to allocate range id for right hand side")
 	}
+	rightDesc := roachpb.NewRangeDescriptor(rightRangeID, splitKey, desc.EndKey, desc.Replicas())
 
 	// TODO(jeffreyxiao): Remove this check in 20.1.
 	// Note that the client API for splitting has expiration time as

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -347,10 +347,6 @@ func (r *Replica) adminSplitWithDescriptor(
 		}
 
 		// Log the split into the range event log.
-		// TODO(spencer): event logging API should accept a batch
-		// instead of a transaction; there's no reason this logging
-		// shouldn't be done in parallel via the batch with the updated
-		// range addressing.
 		if err := r.store.logSplit(ctx, txn, *leftDesc, *rightDesc); err != nil {
 			return err
 		}

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1302,14 +1302,9 @@ type internalReplicationChange struct {
 	typ    internalChangeType
 }
 
-func execChangeReplicasTxn(
-	ctx context.Context,
-	store *Store,
-	desc *roachpb.RangeDescriptor,
-	reason storagepb.RangeLogEventReason,
-	details string,
-	chgs []internalReplicationChange,
-) (*roachpb.RangeDescriptor, error) {
+func prepareChangeReplicasTrigger(
+	store *Store, desc *roachpb.RangeDescriptor, chgs []internalReplicationChange,
+) (*roachpb.ChangeReplicasTrigger, error) {
 	updatedDesc := *desc
 	updatedDesc.SetReplicas(desc.Replicas().DeepCopy())
 
@@ -1426,6 +1421,18 @@ func execChangeReplicasTxn(
 	if _, err := crt.ConfChange(nil); err != nil {
 		return nil, errors.Wrapf(err, "programming error: malformed trigger created from desc %s to %s", desc, &updatedDesc)
 	}
+	return crt, nil
+}
+
+func execChangeReplicasTxn(
+	ctx context.Context,
+	store *Store,
+	desc *roachpb.RangeDescriptor,
+	reason storagepb.RangeLogEventReason,
+	details string,
+	chgs []internalReplicationChange,
+) (*roachpb.RangeDescriptor, error) {
+	var returnDesc *roachpb.RangeDescriptor
 
 	descKey := keys.RangeDescriptorKey(desc.StartKey)
 	if err := store.DB().Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
@@ -1435,14 +1442,18 @@ func execChangeReplicasTxn(
 		if err != nil {
 			return err
 		}
-		log.Infof(ctx, "change replicas (add %v remove %v): existing descriptor %s", added, removed, desc)
+		crt, err := prepareChangeReplicasTrigger(store, desc, chgs)
+		if err != nil {
+			return err
+		}
+		log.Infof(ctx, "change replicas (add %v remove %v): existing descriptor %s", crt.Added(), crt.Removed(), desc)
 
 		{
 			b := txn.NewBatch()
 
 			// Important: the range descriptor must be the first thing touched in the transaction
 			// so the transaction record is co-located with the range being modified.
-			if err := updateRangeDescriptor(b, descKey, dbDescValue, &updatedDesc); err != nil {
+			if err := updateRangeDescriptor(b, descKey, dbDescValue, crt.Desc); err != nil {
 				return err
 			}
 
@@ -1457,12 +1468,12 @@ func execChangeReplicasTxn(
 			typ      roachpb.ReplicaChangeType
 			repDescs []roachpb.ReplicaDescriptor
 		}{
-			{roachpb.ADD_REPLICA, added},
-			{roachpb.REMOVE_REPLICA, removed},
+			{roachpb.ADD_REPLICA, crt.Added()},
+			{roachpb.REMOVE_REPLICA, crt.Removed()},
 		} {
 			for _, repDesc := range tup.repDescs {
 				if err := store.logChange(
-					ctx, txn, tup.typ, repDesc, updatedDesc, reason, details,
+					ctx, txn, tup.typ, repDesc, *crt.Desc, reason, details,
 				); err != nil {
 					return err
 				}
@@ -1474,7 +1485,7 @@ func execChangeReplicasTxn(
 		b := txn.NewBatch()
 
 		// Update range descriptor addressing record(s).
-		if err := updateRangeAddressing(b, &updatedDesc); err != nil {
+		if err := updateRangeAddressing(b, crt.Desc); err != nil {
 			return err
 		}
 
@@ -1489,6 +1500,7 @@ func execChangeReplicasTxn(
 			return err
 		}
 
+		returnDesc = crt.Desc
 		return nil
 	}); err != nil {
 		log.Event(ctx, err.Error())
@@ -1498,7 +1510,7 @@ func execChangeReplicasTxn(
 		return nil, errors.Wrapf(err, "change replicas of r%d failed", desc.RangeID)
 	}
 	log.Event(ctx, "txn complete")
-	return &updatedDesc, nil
+	return returnDesc, nil
 }
 
 // sendSnapshot sends a snapshot of the replica state to the specified replica.

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1407,6 +1407,9 @@ func execChangeReplicasTxn(
 			deprecatedRepDesc = removed[0]
 		}
 		crt = &roachpb.ChangeReplicasTrigger{
+			// NB: populate Desc as well because locally we rely on it being
+			// set.
+			Desc:                      &updatedDesc,
 			DeprecatedChangeType:      deprecatedChangeType,
 			DeprecatedReplica:         deprecatedRepDesc,
 			DeprecatedUpdatedReplicas: updatedDesc.Replicas().All(),

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -302,8 +302,6 @@ func (r *Replica) adminSplitWithDescriptor(
 	extra += splitSnapshotWarningStr(r.RangeID, r.RaftStatus())
 
 	if err := r.store.DB().Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-		log.Event(ctx, "split closure begins")
-		defer log.Event(ctx, "split closure ends")
 		txn.SetDebugName(splitTxnName)
 
 		dbDescValue, err := conditionalGetDescValueFromDB(ctx, txn, desc)

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1193,8 +1193,10 @@ func (r *Replica) atomicReplicationChange(
 		}
 	}
 
-	if fn := r.store.cfg.TestingKnobs.ReplicaAddStopAfterLearnerSnapshot; fn != nil && fn() {
-		return desc, nil
+	if len(chgs.Additions()) > 0 {
+		if fn := r.store.cfg.TestingKnobs.ReplicaAddStopAfterLearnerSnapshot; fn != nil && fn() {
+			return desc, nil
+		}
 	}
 
 	for _, target := range chgs.Removals() {

--- a/pkg/storage/replica_learner_test.go
+++ b/pkg/storage/replica_learner_test.go
@@ -783,6 +783,9 @@ func TestLearnerAdminRelocateRange(t *testing.T) {
 	})
 	defer tc.Stopper().Stop(ctx)
 
+	_, err := tc.Conns[0].Exec(`SET CLUSTER SETTING kv.atomic_replication_changes.enabled = true`)
+	require.NoError(t, err)
+
 	scratchStartKey := tc.ScratchRange(t)
 	ltk.withStopAfterLearnerAtomic(func() {
 		_ = tc.AddReplicasOrFatal(t, scratchStartKey, tc.Target(1))

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -52,6 +52,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/kr/pretty"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/raft"
 	"go.etcd.io/etcd/raft/raftpb"
 	"golang.org/x/time/rate"
@@ -1334,33 +1335,27 @@ func TestStoreSendBadRange(t *testing.T) {
 // See #702
 // TODO(bdarnell): convert tests that use this function to use AdminSplit instead.
 func splitTestRange(store *Store, key, splitKey roachpb.RKey, t *testing.T) *Replica {
+	ctx := context.Background()
 	repl := store.LookupReplica(key)
-	if repl == nil {
-		t.Fatalf("couldn't lookup range for key %q", key)
-	}
-	desc, err := store.NewRangeDescriptor(
-		context.Background(), splitKey, repl.Desc().EndKey, repl.Desc().Replicas())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NotNil(t, repl)
+	rangeID, err := store.AllocateRangeID(ctx)
+	require.NoError(t, err)
+	desc := roachpb.NewRangeDescriptor(
+		rangeID, splitKey, repl.Desc().EndKey, repl.Desc().Replicas())
 	// Minimal amount of work to keep this deprecated machinery working: Write
 	// some required Raft keys.
 	cv := store.ClusterSettings().Version.Version().Version
-	if _, err := stateloader.WriteInitialState(
+	_, err = stateloader.WriteInitialState(
 		context.Background(), store.engine, enginepb.MVCCStats{}, *desc, roachpb.Lease{},
 		hlc.Timestamp{}, cv, stateloader.TruncatedStateUnreplicated,
-	); err != nil {
-		t.Fatal(err)
-	}
+	)
+	require.NoError(t, err)
 	newRng, err := NewReplica(desc, store, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	newLeftDesc := *repl.Desc()
 	newLeftDesc.EndKey = splitKey
-	if err = store.SplitRange(repl.AnnotateCtx(context.TODO()), repl, newRng, newLeftDesc); err != nil {
-		t.Fatal(err)
-	}
+	err = store.SplitRange(repl.AnnotateCtx(context.TODO()), repl, newRng, newLeftDesc)
+	require.NoError(t, err)
 	return newRng
 }
 
@@ -1397,8 +1392,10 @@ func TestStoreSendOutOfRange(t *testing.T) {
 // allocated in successive blocks.
 func TestStoreRangeIDAllocation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
 	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
+	defer stopper.Stop(ctx)
 	store, _ := createTestStore(t,
 		testStoreOpts{
 			// This test was written before test stores could start with more than one
@@ -1410,16 +1407,9 @@ func TestStoreRangeIDAllocation(t *testing.T) {
 	// Range IDs should be allocated from ID 2 (first allocated range)
 	// to rangeIDAllocCount * 3 + 1.
 	for i := 0; i < rangeIDAllocCount*3; i++ {
-		replicas := []roachpb.ReplicaDescriptor{{StoreID: store.StoreID()}}
-		desc, err := store.NewRangeDescriptor(context.Background(),
-			roachpb.RKey(fmt.Sprintf("%03d", i)), roachpb.RKey(fmt.Sprintf("%03d", i+1)),
-			roachpb.MakeReplicaDescriptors(replicas))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if desc.RangeID != roachpb.RangeID(2+i) {
-			t.Errorf("expected range id %d; got %d", 2+i, desc.RangeID)
-		}
+		rangeID, err := store.AllocateRangeID(ctx)
+		require.NoError(t, err)
+		require.EqualValues(t, 2+i, rangeID)
 	}
 }
 


### PR DESCRIPTION
First three commits are #40363.

----

This PR enables atomic replication changes by default. But most of it is
just dealing with the fallout of doing so:

1. we don't handle removal of multiple learners well at the moment. This will
   be fixed more holistically in #40268, but it's not worth waiting for that
   because it's easy for us to just avoid the problem.
2. tests that carry out splits become quite flaky because at the beginning of
   a split, we transition out of a joint config if we see one, and due to
   the initial upreplication we often do. If we lose the race against the
   replicate queue, the split catches an error for no good reason.
   I took this as an opportunity to refactor the descriptor comparisons
   and to make this specific case a noop, but making it easier to avoid
   this general class of conflict where it's avoidable in the future.

There are probably some more problems that will only become apparent over time,
but it's quite simple to turn the cluster setting off again and to patch things
up if we do.

Release note (general change): atomic replication changes are now enabled
by default.