### PR TITLE
storage: skip TestStoreRangeMoveDecommissioning

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -2918,8 +2918,10 @@ func TestReplicaGCRace(t *testing.T) {
 func TestStoreRangeMoveDecommissioning(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	if testutils.NightlyStress() && util.RaceEnabled {
-		t.Skip("can't handle nightly stress: #37811")
+	if util.RaceEnabled {
+		// Six nodes is too much to reliably run under testrace with our aggressive
+		// liveness timings.
+		t.Skip("skipping under testrace: #39807 and #37811")
 	}
 
 	sc := storage.TestStoreConfig(nil)


### PR DESCRIPTION
This was already skipped under nightly stressrace. We saw a few failed
runs that had plenty of liveness timeouts; might be time to skip it
under stressrace in general.

Closes #39807.

Release note: None