### PR TITLE
sql: Remove unnecessary constraints check in show create

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -593,3 +593,26 @@ PARTITION p1 OF INDEX "my database".public.t2@x1       ALTER PARTITION p1 OF IND
                                                        num_replicas = 1
 PARTITION p1 OF INDEX "my database".public.t2@x2       ALTER PARTITION p1 OF INDEX "my database".public.t2@x2 CONFIGURE ZONE USING
                                                        num_replicas = 1
+
+# regression for #40417
+statement ok
+CREATE TABLE t40417 (x INT PRIMARY KEY)
+
+statement ok
+ALTER TABLE t40417 PARTITION BY LIST (x) ( PARTITION p1 VALUES IN (1));
+
+statement ok
+ALTER PARTITION p1 OF TABLE t40417 CONFIGURE ZONE USING num_replicas = 1
+
+query TT
+SHOW CREATE TABLE t40417
+----
+t40417  CREATE TABLE t40417 (
+        x INT8 NOT NULL,
+        CONSTRAINT "primary" PRIMARY KEY (x ASC),
+        FAMILY "primary" (x)
+) PARTITION BY LIST (x) (
+  PARTITION p1 VALUES IN ((1))
+);
+ALTER PARTITION p1 OF INDEX "my database".public.t40417@primary CONFIGURE ZONE USING
+  num_replicas = 1

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1215,7 +1215,8 @@ CREATE TABLE crdb_internal.create_statements (
 				if err != nil {
 					return err
 				}
-				if len(zoneConfig.Constraints) > 0 {
+				// If all constraints are default, then don't show anything.
+				if !zoneConfig.Equal(config.ZoneConfig{}) {
 					sqlString := string(tree.MustBeDString(row[2]))
 					zoneConfigStmts[tableName] = append(zoneConfigStmts[tableName], sqlString)
 				}


### PR DESCRIPTION
The show create table function would not display a zone configuration
if the constraints list was empty. However, this isn't a valid check
because the constraints list could be empty but other fields set.

Release note: None