### PR TITLE
sql: fix SCRUB for indexes with AS OF SYSTEM TIME

### DIFF
--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -137,7 +137,6 @@ func matchFullUnacceptableKeyQuery(
 // WHERE
 //   t.a IS NULL
 // LIMIT 1  -- if limitResults is set
-// AS OF SYSTEM TIME .. -- if asOf is not hlc.MaxTimestamp
 //
 // TODO(radu): change this to a query which executes as an anti-join when we
 // remove the heuristic planner.


### PR DESCRIPTION
`SCRUB` with `AS OF SYSTEM TIME` was failing for index checks because the
index subquery included its own `AS OF SYSTEM TIME`, which should not happen,
and I think some interaction with the newly enabled optimizer started causing
nightlies to fail. This was fixed for FKs a while ago but not for indexes. This
PR removes AOST from the index subquery to match the FK subquery.

The PR for FKs was #37604.
Closes #39328.
Closes #39327.

Release note: None