### PR TITLE
exec: add OR expression support

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -704,11 +704,22 @@ func planSelectionOperators(
 	case *tree.IndexedVar:
 		return exec.NewBoolVecToSelOp(input, t.Idx), -1, columnTypes, memUsed, nil
 	case *tree.AndExpr:
-		leftOp, _, ct, memUsage, err := planSelectionOperators(ctx, t.TypedLeft(), columnTypes, input)
+		var leftOp, rightOp exec.Operator
+		var memUsedLeft, memUsedRight int
+		leftOp, _, ct, memUsedLeft, err = planSelectionOperators(ctx, t.TypedLeft(), columnTypes, input)
 		if err != nil {
-			return nil, resultIdx, ct, memUsage, err
+			return nil, resultIdx, ct, memUsed, err
 		}
-		return planSelectionOperators(ctx, t.TypedRight(), ct, leftOp)
+		rightOp, resultIdx, ct, memUsedRight, err = planSelectionOperators(
+			ctx, t.TypedRight(), ct, leftOp)
+		return rightOp, resultIdx, ct, memUsedLeft + memUsedRight, err
+	case *tree.OrExpr:
+		// OR expressions are handled by converting them to an equivalent CASE
+		// statement. Since CASE statements don't have a selection form, plan a
+		// projection and then convert the resulting boolean to a selection vector.
+		op, resultIdx, ct, memUsed, err = planProjectionOperators(ctx, expr, columnTypes, input)
+		op = exec.NewBoolVecToSelOp(op, resultIdx)
+		return op, resultIdx, ct, memUsed, err
 	case *tree.ComparisonExpr:
 		cmpOp := t.Operator
 		leftOp, leftIdx, ct, memUsageLeft, err := planProjectionOperators(ctx, t.TypedLeft(), columnTypes, input)
@@ -864,6 +875,23 @@ func planProjectionOperators(
 		op := exec.NewCaseOp(buffer, caseOps, elseOp, thenIdxs, caseOutputIdx, caseOutputType)
 
 		return op, caseOutputIdx, ct, memUsed, nil
+	case *tree.OrExpr:
+		// Rewrite the OR expression as an equivalent CASE expression.
+		// "a OR b" becomes "CASE WHEN a THEN true WHEN b THEN true ELSE false END".
+		// This way we can take advantage of the short-circuiting logic built into
+		// the CASE operator. (b should not be evaluated if a is true.)
+		caseExpr, err := tree.NewTypedCaseExpr(
+			nil,
+			[]*tree.When{
+				{Cond: t.Left, Val: tree.DBoolTrue},
+				{Cond: t.Right, Val: tree.DBoolTrue},
+			},
+			tree.DBoolFalse,
+			types.Bool)
+		if err != nil {
+			return nil, resultIdx, ct, memUsed, err
+		}
+		return planProjectionOperators(ctx, caseExpr, columnTypes, input)
 	default:
 		return nil, resultIdx, nil, memUsed, errors.Errorf("unhandled projection expression type: %s", reflect.TypeOf(t))
 	}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -20,6 +20,29 @@ SELECT a, CASE WHEN a = 0 THEN 0 WHEN a = 1 THEN 3 ELSE 5 END FROM a LIMIT 6
 2  5
 2  5
 
+# OR expression as projection.
+query IB
+SELECT b, b = 0 OR b = 2 FROM a WHERE b < 4
+----
+0  true
+1  false
+2  true
+3  false
+
+# OR expression as selection.
+query I
+SELECT b FROM a WHERE b = 0 OR b = 2
+----
+0
+2
+
+# Check that the right side of an OR isn't evaluated if the left side is true.
+query I
+SELECT b FROM a WHERE b = 0 OR 1/b = 1
+----
+0
+1
+
 statement ok
 CREATE TABLE bools (b BOOL, i INT, PRIMARY KEY (b, i)); INSERT INTO bools VALUES (true, 0), (false, 1), (true, 2), (false, 3);
 


### PR DESCRIPTION
OR expressions are now handled by the vectorized engine, both as
projections and selections. Since these need the same short-circuiting
logic as CASE expressions, I handled them by converting the OrExpr to an
equivalent CaseExpr and then planning that as usual.

Fixes #39776

Release note: None