### PR TITLE
importccl: force csv import to fail on bad usage of quotes in csv fields

### DIFF
--- a/pkg/ccl/importccl/read_import_csv.go
+++ b/pkg/ccl/importccl/read_import_csv.go
@@ -114,7 +114,7 @@ func (c *csvInputReader) readFile(
 		cr.Comma = c.opts.Comma
 	}
 	cr.FieldsPerRecord = -1
-	cr.LazyQuotes = true
+	cr.LazyQuotes = false
 	cr.Comment = c.opts.Comment
 
 	c.batch = csvRecord{


### PR DESCRIPTION
Before this change we will incorrectly import fields like `abc"xy"z`.
The reason was setting `LazyQuotes = true` when parsing csv rows.
Now the client will return an error on an attempt to import a csv file
containing such fields.

Touches: #39820.

Release note: quotes are no longer accepted inside an unquoted csv field.