### PR TITLE
release-19.1: sql: reject CTAS queries with window functions

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -63,6 +64,13 @@ func (p *planner) CreateTable(ctx context.Context, n *tree.CreateTable) (planNod
 	var sourcePlan planNode
 	var synthRowID bool
 	if n.As() {
+		if containsWindowFunc(p.txCtx, n.AsSource) {
+			return nil, pgerror.NewError(
+				pgerror.CodeFeatureNotSupportedError,
+				"window functions are not supported in CREATE TABLE AS",
+			).SetHintf("This feature was added in CockroachDB 19.2. Consider upgrading.")
+		}
+
 		// The sourcePlan is needed to determine the set of columns to use
 		// to populate the new table descriptor in Start() below.
 		sourcePlan, err = p.Select(ctx, n.AsSource, []types.T{})
@@ -88,6 +96,24 @@ func (p *planner) CreateTable(ctx context.Context, n *tree.CreateTable) (planNod
 	ct := &createTableNode{n: n, dbDesc: dbDesc, sourcePlan: sourcePlan}
 	ct.run.synthRowID = synthRowID
 	return ct, nil
+}
+
+// containsWindowFunc returns whether 's' contains a window function.
+func containsWindowFunc(txCtx transform.ExprTransformContext, s *tree.Select) bool {
+	switch c := s.Select.(type) {
+	case *tree.ParenSelect:
+		return containsWindowFunc(txCtx, c.Select)
+	case *tree.SelectClause:
+		for _, expr := range c.Exprs {
+			if txCtx.WindowFuncInExpr(expr.Expr) {
+				return true
+			}
+		}
+		return false
+	case *tree.UnionClause:
+		return containsWindowFunc(txCtx, c.Left) || containsWindowFunc(txCtx, c.Right)
+	}
+	return false
 }
 
 // createTableRun contains the run-time state of createTableNode

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -3074,3 +3074,7 @@ SELECT a, b, avg(b) OVER (ROWS 0 PRECEDING) FROM t ORDER BY a
 1  1     1
 2  NULL  NULL
 3  3     3
+
+# Regression test for #40409.
+statement error window functions are not supported in CREATE TABLE AS.*\nHINT.*This feature was added in CockroachDB 19.2. Consider upgrading.
+CREATE TABLE ctas AS (SELECT row_number() OVER (), * FROM t)


### PR DESCRIPTION
Window functions do not have a local execution mode anymore, but
CREATE TABLE AS uses only local execution which leads to a panic
when window functions are present in the source statement. Now
we will be rejecting such queries and hinting at upgrading to 19.2
since such feature is supported there.

cc @cockroachdb/release

Fixes: #40409.

Release note (bug fix): a crash caused by presence of window functions
in the source of CREATE TABLE AS statement is fixed.