### PR TITLE
sql: more test fixes for opt-driven foreign keys

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1357,25 +1357,25 @@ func TestBackupRestoreCrossTableReferences(t *testing.T) {
 
 		// FK validation on customers from receipts is preserved.
 		db.ExpectErr(
-			t, "foreign key violation.* referenced in table \"receipts\"",
+			t, "foreign key violation.* referenced in table \"receipts\"|update.*violates foreign key constraint on table \"receipts\"",
 			`UPDATE store.customers SET email = concat(id::string, 'nope')`,
 		)
 
 		// FK validation on customers from orders is preserved.
 		db.ExpectErr(
-			t, "foreign key violation.* referenced in table \"orders\"",
+			t, "foreign key violation.* referenced in table \"orders\"|update.*violates foreign key constraint on table \"orders\"",
 			`UPDATE store.customers SET id = id * 1000`,
 		)
 
 		// FK validation of customer id is preserved.
 		db.ExpectErr(
-			t, "foreign key violation.* in customers@primary",
+			t, "foreign key violation.* in customers@primary|insert.*violates foreign key constraint \"fk_customerid_ref_customers\"",
 			`INSERT INTO store.orders VALUES (999, NULL, 999)`,
 		)
 
 		// FK validation of self-FK is preserved.
 		db.ExpectErr(
-			t, "foreign key violation: value .999. not found in receipts@primary",
+			t, "foreign key violation: value .999. not found in receipts@primary|insert.*violates foreign key constraint \"fk_reissue_ref_receipts\"",
 			`INSERT INTO store.receipts VALUES (1, 999, NULL, NULL)`,
 		)
 	})
@@ -1390,7 +1390,7 @@ func TestBackupRestoreCrossTableReferences(t *testing.T) {
 
 		// FK validation on customers from orders is preserved.
 		db.ExpectErr(
-			t, "foreign key violation.* referenced in table \"orders\"",
+			t, "foreign key violation.* referenced in table \"orders\"|update.*violates foreign key constraint on table \"orders\"",
 			`UPDATE store.customers SET id = id*100`,
 		)
 
@@ -1431,8 +1431,8 @@ func TestBackupRestoreCrossTableReferences(t *testing.T) {
 
 		// FK validation of self-FK is preserved.
 		db.ExpectErr(
-			t, "foreign key violation: value .999. not found in receipts@primary",
-			`INSERT INTO store.receipts VALUES (1, 999, NULL, NULL)`,
+			t, "foreign key violation: value .999. not found in receipts@primary|insert.*violates foreign key constraint \"fk_reissue_ref_receipts\"",
+			`INSERT INTO store.receipts VALUES (-1, 999, NULL, NULL)`,
 		)
 	})
 
@@ -1449,20 +1449,20 @@ func TestBackupRestoreCrossTableReferences(t *testing.T) {
 
 		// FK validation of customer email is preserved.
 		db.ExpectErr(
-			t, "foreign key violation.* in customers@customers_email_key",
-			`INSERT INTO store.receipts VALUES (1, NULL, '999', 999)`,
+			t, "foreign key violation.* in customers@customers_email_key|insert.*violates foreign key constraint \"fk_dest_ref_customers\"",
+			`INSERT INTO store.receipts VALUES (-1, NULL, '999', 999)`,
 		)
 
 		// FK validation on customers from receipts is preserved.
 		db.ExpectErr(
-			t, "foreign key violation.* referenced in table \"receipts\"",
+			t, "foreign key violation.* referenced in table \"receipts\"|delete.*violates foreign key constraint on table \"receipts\"",
 			`DELETE FROM store.customers`,
 		)
 
 		// FK validation of self-FK is preserved.
 		db.ExpectErr(
-			t, "foreign key violation: value .999. not found in receipts@primary",
-			`INSERT INTO store.receipts VALUES (1, 999, NULL, NULL)`,
+			t, "foreign key violation: value .999. not found in receipts@primary|insert.*violates foreign key constraint \"fk_reissue_ref_receipts\"",
+			`INSERT INTO store.receipts VALUES (-1, 999, NULL, NULL)`,
 		)
 	})
 

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -708,7 +708,12 @@ func (mb *mutationBuilder) makeMutationPrivate(needResults bool) *memo.MutationP
 		UpdateCols: makeColList(mb.updateOrds),
 		CanaryCol:  mb.canaryColID,
 		CheckCols:  makeColList(mb.checkOrds),
-		WithID:     mb.withID,
+	}
+
+	// If we didn't actually plan any checks (e.g. because of cascades), don't
+	// buffer the input.
+	if len(mb.checks) > 0 {
+		private.WithID = mb.withID
 	}
 
 	if needResults {
@@ -1076,11 +1081,6 @@ func (mb *mutationBuilder) buildFKChecksForUpdate() {
 			mb.checks = nil
 			break
 		}
-	}
-
-	// If we didn't end up having to do any checks, then don't buffer the input.
-	if mb.checks == nil {
-		mb.withID = 0
 	}
 }
 

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-delete
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-delete
@@ -166,7 +166,6 @@ DELETE FROM parent WHERE p = 1
 delete parent
  ├── columns: <none>
  ├── fetch columns: x:4(int) parent.p:5(int) parent.other:6(int)
- ├── input binding: &1
  └── select
       ├── columns: x:4(int) parent.p:5(int!null) parent.other:6(int)
       ├── scan parent


### PR DESCRIPTION
Fixing up some expected errors in tests and making sure we don't
buffer the mutation input if we fall back to the legacy path (the
bufferNode is unnecessary and interferes with an interleaved delete
fast path).

Release note: None