### PR TITLE
storage: assert zero HardState.Commit on replica creation

### DIFF
--- a/pkg/storage/stateloader/stateloader.go
+++ b/pkg/storage/stateloader/stateloader.go
@@ -574,7 +574,7 @@ func (rsl StateLoader) LoadHardState(
 
 // SetHardState overwrites the HardState.
 func (rsl StateLoader) SetHardState(
-	ctx context.Context, batch engine.Writer, st raftpb.HardState,
+	ctx context.Context, batch engine.Writer, hs raftpb.HardState,
 ) error {
 	// "Blind" because ms == nil and timestamp == hlc.Timestamp{}.
 	return engine.MVCCBlindPutProto(
@@ -583,7 +583,7 @@ func (rsl StateLoader) SetHardState(
 		nil, /* ms */
 		rsl.RaftHardStateKey(),
 		hlc.Timestamp{}, /* timestamp */
-		&st,
+		&hs,
 		nil, /* txn */
 	)
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -4006,6 +4006,17 @@ func (s *Store) tryGetOrCreateReplica(
 	s.mu.uninitReplicas[repl.RangeID] = repl
 	s.mu.Unlock()
 
+	// An uninitiazlied replica should have an empty HardState.Commit at
+	// all times. Failure to maintain this invariant indicates corruption.
+	// And yet, we have observed this in the wild. See #40213.
+	if hs, err := repl.mu.stateLoader.LoadHardState(ctx, s.Engine()); err != nil {
+		repl.mu.Unlock()
+		repl.raftMu.Unlock()
+		return nil, false, err
+	} else if hs.Commit != 0 {
+		log.Fatalf(ctx, "found non-zero HardState.Commit on uninitialized replica %s. HS=%+v", repl, hs)
+	}
+
 	desc := &roachpb.RangeDescriptor{
 		RangeID: rangeID,
 		// TODO(bdarnell): other fields are unknown; need to populate them from

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -2863,7 +2863,8 @@ func TestStoreRemovePlaceholderOnRaftIgnored(t *testing.T) {
 	s := tc.store
 	ctx := context.Background()
 
-	// Clobber the existing range so we can test nonoverlapping placeholders.
+	// Clobber the existing range and recreated it with an uninitialized
+	// descriptor so we can test nonoverlapping placeholders.
 	repl1, err := s.GetReplica(1)
 	if err != nil {
 		t.Fatal(err)
@@ -2874,11 +2875,19 @@ func TestStoreRemovePlaceholderOnRaftIgnored(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	uninitDesc := roachpb.RangeDescriptor{RangeID: repl1.Desc().RangeID}
 	cv := s.ClusterSettings().Version.Version().Version
 	if _, err := stateloader.WriteInitialState(
-		ctx, s.Engine(), enginepb.MVCCStats{}, *repl1.Desc(), roachpb.Lease{},
+		ctx, s.Engine(), enginepb.MVCCStats{}, uninitDesc, roachpb.Lease{},
 		hlc.Timestamp{}, cv, stateloader.TruncatedStateUnreplicated,
 	); err != nil {
+		t.Fatal(err)
+	}
+	uninitRepl1, err := NewReplica(&uninitDesc, s, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.addReplicaToRangeMapLocked(uninitRepl1); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
An uninitialized replica should never have a commit index in its
HardState. And yet, we observed in #40213 that (likely) due to a
missing Range deletion tombstone, this invariant can be violated
in practice.

This assertion will allow us to catch this kind of violation without
the need for a MsgVote to race with a MsgSnap, hopefully making the
bug implied by #40213 easier to track down.

Release note: None