### PR TITLE
sql: Fixing show partitions and show ranges to work on not current database

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -859,3 +859,67 @@ CREATE TABLE t (a INT PRIMARY KEY, b INT, INDEX (b)) PARTITION BY LIST (a) (
 
 statement ok
 RESET sql_safe_updates
+
+# regression tests for #40450
+statement ok
+CREATE DATABASE d_show_partitions
+
+statement ok
+CREATE TABLE d_show_partitions.t (x INT PRIMARY KEY) PARTITION BY LIST (x) ( PARTITION p1 VALUES IN (1))
+
+query TTTTTTTT
+SHOW PARTITIONS FROM DATABASE d_show_partitions
+----
+d_show_partitions t p1 NULL x t@primary (1) NULL
+
+query TTTTTTTT
+SHOW PARTITIONS FROM TABLE d_show_partitions.t
+----
+d_show_partitions t p1 NULL x t@primary (1) NULL
+
+query TTTTTTTT
+SHOW PARTITIONS FROM INDEX d_show_partitions.t@primary
+----
+d_show_partitions t p1 NULL x t@primary (1) NULL
+
+statement ok
+CREATE DATABASE "show partitions"
+
+statement ok
+CREATE TABLE "show partitions".t (x INT PRIMARY KEY) PARTITION BY LIST (x) ( PARTITION p1 VALUES IN (1))
+
+query TTTTTTTT
+SHOW PARTITIONS FROM DATABASE "show partitions"
+----
+show partitions t p1 NULL x t@primary (1) NULL
+
+query TTTTTTTT
+SHOW PARTITIONS FROM TABLE "show partitions".t
+----
+show partitions t p1 NULL x t@primary (1) NULL
+
+query TTTTTTTT
+SHOW PARTITIONS FROM INDEX "show partitions".t@primary
+----
+show partitions t p1 NULL x t@primary (1) NULL
+
+statement ok
+CREATE DATABASE """"
+
+statement ok
+CREATE TABLE """".t (x INT PRIMARY KEY) PARTITION BY LIST (x) ( PARTITION p1 VALUES IN (1))
+
+query TTTTTTTT
+SHOW PARTITIONS FROM DATABASE """"
+----
+" t p1 NULL x t@primary (1) NULL
+
+query TTTTTTTT
+SHOW PARTITIONS FROM TABLE """".t
+----
+" t p1 NULL x t@primary (1) NULL
+
+query TTTTTTTT
+SHOW PARTITIONS FROM INDEX """".t@primary
+----
+" t p1 NULL x t@primary (1) NULL

--- a/pkg/sql/delegate/show_partitions.go
+++ b/pkg/sql/delegate/show_partitions.go
@@ -45,12 +45,12 @@ func (d *delegator) delegateShowPartitions(n *tree.ShowPartitions) (tree.Stateme
 			coalesce(partitions.list_value, partitions.range_value) as partition_value,
 		  replace(regexp_extract(config_sql, 'CONFIGURE ZONE USING\n((?s:.)*)'), e'\t', '') as zone_config
 		FROM
-			crdb_internal.partitions
-			JOIN crdb_internal.tables ON partitions.table_id = tables.table_id
-			JOIN crdb_internal.table_indexes ON
+			%[3]s.crdb_internal.partitions
+			JOIN %[3]s.crdb_internal.tables ON partitions.table_id = tables.table_id
+			JOIN %[3]s.crdb_internal.table_indexes ON
 					table_indexes.descriptor_id = tables.table_id
 					AND table_indexes.index_id = partitions.index_id
-			LEFT JOIN crdb_internal.zones ON
+			LEFT JOIN %[3]s.crdb_internal.zones ON
 					zones.database_name = tables.database_name
 					AND zones.table_name = tables.name
 					AND zones.index_name = table_indexes.index_name
@@ -58,7 +58,10 @@ func (d *delegator) delegateShowPartitions(n *tree.ShowPartitions) (tree.Stateme
 		WHERE
 			tables.name = %[1]s AND tables.database_name = %[2]s;
 		`
-		return parse(fmt.Sprintf(showTablePartitionsQuery, lex.EscapeSQLString(resName.Table()), lex.EscapeSQLString(resName.Catalog())))
+		return parse(fmt.Sprintf(showTablePartitionsQuery,
+			lex.EscapeSQLString(resName.Table()),
+			lex.EscapeSQLString(resName.Catalog()),
+			resName.CatalogName.String()))
 	} else if n.IsDB {
 		const showDatabasePartitionsQuery = `
 		SELECT
@@ -86,7 +89,8 @@ func (d *delegator) delegateShowPartitions(n *tree.ShowPartitions) (tree.Stateme
 		ORDER BY
 			tables.name, partitions.name;
 		`
-		return parse(fmt.Sprintf(showDatabasePartitionsQuery, n.Object, lex.EscapeSQLString(n.Object)))
+		// Note: n.Database.String() != string(n.Database)
+		return parse(fmt.Sprintf(showDatabasePartitionsQuery, n.Database.String(), lex.EscapeSQLString(string(n.Database))))
 	}
 
 	flags := cat.Flags{AvoidDescriptorCaches: true, NoTableStats: true}
@@ -112,7 +116,7 @@ func (d *delegator) delegateShowPartitions(n *tree.ShowPartitions) (tree.Stateme
 	// is a dirty hack that needs to be fixed.
 	const showIndexPartitionsQuery = `
 	WITH
-		dummy AS (SELECT * FROM %[3]s@%[4]s LIMIT 0)
+		dummy AS (SELECT * FROM %[5]s.%[3]s@%[4]s LIMIT 0)
 	SELECT
 		tables.database_name,
 		tables.name AS table_name,
@@ -123,12 +127,12 @@ func (d *delegator) delegateShowPartitions(n *tree.ShowPartitions) (tree.Stateme
 		coalesce(partitions.list_value, partitions.range_value) as partition_value,
 	  replace(regexp_extract(config_sql, 'CONFIGURE ZONE USING\n((?s:.)*)'), e'\t', '') as zone_config
 	FROM
-		crdb_internal.partitions
-		JOIN crdb_internal.table_indexes ON
+		%[5]s.crdb_internal.partitions
+		JOIN %[5]s.crdb_internal.table_indexes ON
 				partitions.index_id = table_indexes.index_id
 				AND partitions.table_id = table_indexes.descriptor_id
-		JOIN crdb_internal.tables ON table_indexes.descriptor_id = tables.table_id
-		LEFT JOIN crdb_internal.zones ON
+		JOIN %[5]s.crdb_internal.tables ON table_indexes.descriptor_id = tables.table_id
+		LEFT JOIN %[5]s.crdb_internal.zones ON
 				zones.database_name = tables.database_name
 				AND zones.table_name = tables.name
 				AND zones.index_name = table_indexes.index_name
@@ -140,5 +144,7 @@ func (d *delegator) delegateShowPartitions(n *tree.ShowPartitions) (tree.Stateme
 		lex.EscapeSQLString(n.Index.Index.String()),
 		lex.EscapeSQLString(resName.Table()),
 		resName.Table(),
-		n.Index.Index.String()))
+		n.Index.Index.String(),
+		// note: CatalogName.String() != Catalog()
+		resName.CatalogName.String()))
 }

--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -186,7 +186,7 @@ CREATE INDEX idx on t1(v1,v2,v3) INTERLEAVE IN PARENT t(v1,v2)
 
 # We expect the splits for the index to be the same as the splits for t.
 query TTTI colnames,rowsort
-SELECT start_key, end_key, replicas, lease_holder FROM [SHOW RANGES FROM INDEX t1@idx] 
+SELECT start_key, end_key, replicas, lease_holder FROM [SHOW RANGES FROM INDEX t1@idx]
 ----
 start_key      end_key        replicas  lease_holder
 NULL           /1             {1}       1
@@ -364,3 +364,47 @@ start_key                          start_pretty                   end_key       
 [196 137 246 123]                  /Table/60/1/123                Ċ                                  /Table/60/2                    d              c                                ·           {1}       1
 Ċ                                  /Table/60/2                    [196 138 136]                      /Table/60/2/0                  d              c                                c_i_idx     {1}       1
 [196 138 136]                      /Table/60/2/0                  [255 255]                          /Max                           d              c                                c_i_idx     {1}       1
+
+
+# Due to asynchronous splitting of ranges, we cannot guarantee the output
+# of the show ranges from database command. The test below just ensures that
+# the command gets parsed and evaluated correctly.
+
+# regression tests for #40450
+statement ok
+CREATE DATABASE "show ranges"
+
+statement ok
+CREATE TABLE "show ranges".t (x INT PRIMARY KEY)
+
+statement ok
+SHOW RANGES FROM DATABASE "show ranges"
+
+query TT
+SELECT start_key, end_key FROM [SHOW RANGES FROM TABLE "show ranges".t]
+----
+NULL NULL
+
+query TT
+SELECT start_key, end_key FROM [SHOW RANGES FROM INDEX "show ranges".t@primary]
+----
+NULL NULL
+
+statement ok
+CREATE DATABASE """"
+
+statement ok
+CREATE TABLE """".t (x INT PRIMARY KEY)
+
+statement ok
+SHOW RANGES FROM DATABASE """"
+
+query TT
+SELECT start_key, end_key FROM [SHOW RANGES FROM TABLE """".t]
+----
+NULL NULL
+
+query TT
+SELECT start_key, end_key FROM [SHOW RANGES FROM INDEX """".t@primary]
+----
+NULL NULL

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3445,15 +3445,15 @@ show_columns_stmt:
 show_partitions_stmt:
   SHOW PARTITIONS FROM TABLE table_name
   {
-    $$.val = &tree.ShowPartitions{Object: $5.unresolvedObjectName().String(), IsTable: true, Table: $5.unresolvedObjectName()}
+    $$.val = &tree.ShowPartitions{IsTable: true, Table: $5.unresolvedObjectName()}
   }
 | SHOW PARTITIONS FROM DATABASE database_name
   {
-    $$.val = &tree.ShowPartitions{Object: $5, IsDB: true}
+    $$.val = &tree.ShowPartitions{IsDB: true, Database: tree.Name($5)}
   }
 | SHOW PARTITIONS FROM INDEX table_index_name
   {
-    $$.val = &tree.ShowPartitions{Object: $5.newTableIndexName().String(), IsIndex: true, Index: $5.tableIndexName()}
+    $$.val = &tree.ShowPartitions{IsIndex: true, Index: $5.tableIndexName()}
   }
 | SHOW PARTITIONS error // SHOW HELP: SHOW PARTITIONS
 
@@ -3854,7 +3854,7 @@ show_ranges_stmt:
   }
 | SHOW RANGES FROM DATABASE database_name 
   {
-    $$.val = &tree.ShowRanges{DatabaseName: $5}
+    $$.val = &tree.ShowRanges{DatabaseName: tree.Name($5)}
   }
 | SHOW RANGES error // SHOW HELP: SHOW RANGES
 

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -393,7 +393,7 @@ func (node *ShowRoles) Format(ctx *FmtCtx) {
 // ShowRanges represents a SHOW RANGES statement.
 type ShowRanges struct {
 	TableOrIndex TableIndexName
-	DatabaseName string
+	DatabaseName Name
 }
 
 // Format implements the NodeFormatter interface.
@@ -401,7 +401,7 @@ func (node *ShowRanges) Format(ctx *FmtCtx) {
 	ctx.WriteString("SHOW RANGES FROM ")
 	if node.DatabaseName != "" {
 		ctx.WriteString("DATABASE ")
-		ctx.WriteString(node.DatabaseName)
+		ctx.FormatNode(&node.DatabaseName)
 	} else if node.TableOrIndex.Index != "" {
 		ctx.WriteString("INDEX ")
 		ctx.FormatNode(&node.TableOrIndex)
@@ -450,9 +450,8 @@ func (node *ShowHistogram) Format(ctx *FmtCtx) {
 
 // ShowPartitions represents a SHOW PARTITIONS statement.
 type ShowPartitions struct {
-	Object string
-
-	IsDB bool
+	IsDB     bool
+	Database Name
 
 	IsIndex bool
 	Index   TableIndexName
@@ -464,10 +463,13 @@ type ShowPartitions struct {
 // Format implements the NodeFormatter interface.
 func (node *ShowPartitions) Format(ctx *FmtCtx) {
 	if node.IsDB {
-		ctx.Printf("SHOW PARTITIONS FROM DATABASE %s", node.Object)
+		ctx.Printf("SHOW PARTITIONS FROM DATABASE ")
+		ctx.FormatNode(&node.Database)
 	} else if node.IsIndex {
-		ctx.Printf("SHOW PARTITIONS FROM INDEX %s", node.Object)
+		ctx.Printf("SHOW PARTITIONS FROM INDEX ")
+		ctx.FormatNode(&node.Index)
 	} else {
-		ctx.Printf("SHOW PARTITIONS FROM TABLE %s", node.Object)
+		ctx.Printf("SHOW PARTITIONS FROM TABLE ")
+		ctx.FormatNode(node.Table)
 	}
 }


### PR DESCRIPTION
show partitions and show ranges did not work correctly when the database
the object was within was not the current database. This PR updates show
partitions and show ranges to fix this and adds regression tests.

Fixes #40448.

Release note: None