### PR TITLE
testcluster: don't overwrite localities indiscriminately

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1043,8 +1043,6 @@ func (t *logicTest) setup(cfg testClusterConfig) {
 			},
 			ClusterName: "testclustername",
 			UseDatabase: "test",
-			// Set Locality so we can use it in zone config tests.
-			Locality: roachpb.Locality{Tiers: []roachpb.Tier{{Key: "region", Value: "test"}}},
 		},
 		// For distributed SQL tests, we use the fake span resolver; it doesn't
 		// matter where the data really is.

--- a/pkg/sql/show_ranges_test.go
+++ b/pkg/sql/show_ranges_test.go
@@ -27,9 +27,7 @@ func TestShowRangesWithLocality(t *testing.T) {
 
 	const numNodes = 3
 	ctx := context.Background()
-	tcArgs := base.TestClusterArgs{}
-
-	tc := testcluster.StartTestCluster(t, numNodes, tcArgs)
+	tc := testcluster.StartTestCluster(t, numNodes, base.TestClusterArgs{})
 	defer tc.Stopper().Stop(ctx)
 
 	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
@@ -42,10 +40,9 @@ func TestShowRangesWithLocality(t *testing.T) {
 	const localitiesColIdx = 3
 	replicas := make([]int, 3)
 
+	// TestClusters get some localities by default.
 	q := `SELECT lease_holder, lease_holder_locality, replicas, replica_localities from [SHOW RANGES FROM TABLE t]`
 	result := sqlDB.QueryStr(t, q)
-	// Because StartTestCluster changes the locality no matter what the
-	// arguments are, we expect whatever the test server sets up.
 	for _, row := range result {
 		// Verify the leaseholder localities.
 		leaseHolder := row[leaseHolderIdx]


### PR DESCRIPTION
Before this patch, a TestCluster would set localities for all nodes to a
static values. This was overwriting any values set throught the
TestClusterArgs. This patch makes it so that, if any localities are set
in the args, we don't overwrite them.

Release note: None