### PR TITLE
opt: fix error due to incorrect number of columns after EliminateDistinct

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch
@@ -5965,10 +5965,10 @@ sort
            │    │    ├── key: (12,13)
            │    │    └── project
            │    │         ├── save-table-name: q20_project_7
-           │    │         ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null) p_partkey:17(int!null) p_name:18(varchar!null)
-           │    │         ├── stats: [rows=37007.6247, distinct(12)=22217.3354, null(12)=0, distinct(13)=9682.13834, null(13)=0, distinct(17)=22217.3354, null(17)=0, distinct(18)=17915.9531, null(18)=0]
+           │    │         ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null) p_partkey:17(int!null)
+           │    │         ├── stats: [rows=37007.6247, distinct(12)=22217.3354, null(12)=0, distinct(13)=9682.13834, null(13)=0, distinct(17)=22217.3354, null(17)=0]
            │    │         ├── key: (13,17)
-           │    │         ├── fd: (17)-->(18), (12)==(17), (17)==(12)
+           │    │         ├── fd: (12)==(17), (17)==(12)
            │    │         └── inner-join (hash)
            │    │              ├── save-table-name: q20_inner_join_8
            │    │              ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null) ps_availqty:14(int!null) p_partkey:17(int!null) p_name:18(varchar!null) sum:42(float)
@@ -6146,13 +6146,11 @@ column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_e
 stats table=q20_project_7
 ----
 column_names  row_count  distinct_count  null_count
-{p_name}      5833       2106            0
 {p_partkey}   5833       2106            0
 {ps_partkey}  5833       2106            0
 {ps_suppkey}  5833       4434            0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{p_name}      37008.00       6.34 <==       17916.00            8.51 <==            0.00            1.00
 {p_partkey}   37008.00       6.34 <==       22217.00            10.55 <==           0.00            1.00
 {ps_partkey}  37008.00       6.34 <==       22217.00            10.55 <==           0.00            1.00
 {ps_suppkey}  37008.00       6.34 <==       9682.00             2.18 <==            0.00            1.00

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -1054,6 +1054,18 @@ func (c *CustomFuncs) GroupingAndConstCols(
 	return result
 }
 
+// GroupingOutputCols returns the output columns of a GroupBy, ScalarGroupBy, or
+// DistinctOn expression.
+func (c *CustomFuncs) GroupingOutputCols(
+	grouping *memo.GroupingPrivate, aggs memo.AggregationsExpr,
+) opt.ColSet {
+	result := grouping.GroupingCols.Copy()
+	for i := range aggs {
+		result.Add(aggs[i].Col)
+	}
+	return result
+}
+
 // GroupingColsAreKey returns true if the input expression's grouping columns
 // form a strict key for its output rows. A strict key means that any two rows
 // will have unique key column values. Nulls are treated as equal to one another

--- a/pkg/sql/opt/norm/rules/groupby.opt
+++ b/pkg/sql/opt/norm/rules/groupby.opt
@@ -17,14 +17,22 @@
 # rows by using grouping columns that are statically known to form a strong key.
 # By definition, a strong key does not allow duplicate values, so the GroupBy is
 # redundant and can be eliminated.
+#
+# Since a DistinctOn operator can serve as a projection operator, we need to
+# replace it with a Project so that the correct columns are projected. The
+# project itself may be eliminated later by other rules.
 [EliminateDistinct, Normalize]
 (DistinctOn
     $input:*
-    *
+    $aggs:*
     $groupingPrivate:* & (GroupingColsAreKey $groupingPrivate $input)
 )
 =>
-$input
+(Project
+  $input
+  []
+  (GroupingOutputCols $groupingPrivate $aggs)
+)
 
 # EliminateGroupByProject discards a nested Project operator that is only
 # removing columns from its input (and not synthesizing new ones). That's

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -136,6 +136,45 @@ distinct-on
       ├── lax-key: (2,3)
       └── ordering: +3,+2
 
+# Regression test for #40295. Ensure that the DistinctOn is replaced with a
+# Project operator to keep the correct number of output columns.
+exec-ddl
+CREATE TABLE table0 (col0 REGTYPE);
+----
+
+exec-ddl
+CREATE TABLE table1 (col0 REGCLASS, col1 REGTYPE, col2 INT4);
+----
+
+opt expect=EliminateDistinct
+SELECT
+  (
+    SELECT
+      t1.col2
+    FROM
+      table1 AS t1
+    JOIN table0 AS t0 ON
+        t1.col1 = t0.col0
+        AND t1.col0 = t0.col0
+    GROUP BY
+      t1.col2
+    HAVING
+      NULL
+  );
+----
+values
+ ├── columns: col2:7(int4)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(7)
+ └── tuple [type=tuple{int4}]
+      └── subquery [type=int4]
+           └── values
+                ├── columns: t1.col2:3(int4!null)
+                ├── cardinality: [0 - 0]
+                ├── key: ()
+                └── fd: ()-->(3)
+
 # --------------------------------------------------
 # EliminateGroupByProject
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -2116,9 +2116,9 @@ sort
            │    │    ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null)
            │    │    ├── key: (12,13)
            │    │    └── project
-           │    │         ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null) p_partkey:17(int!null) p_name:18(varchar!null)
+           │    │         ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null) p_partkey:17(int!null)
            │    │         ├── key: (13,17)
-           │    │         ├── fd: (17)-->(18), (12)==(17), (17)==(12)
+           │    │         ├── fd: (12)==(17), (17)==(12)
            │    │         └── inner-join (hash)
            │    │              ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null) ps_availqty:14(int!null) p_partkey:17(int!null) p_name:18(varchar!null) sum:42(float)
            │    │              ├── key: (13,17)

--- a/pkg/sql/opt/xform/testdata/external/tpch-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpch-no-stats
@@ -1884,32 +1884,37 @@ limit
  │         │    │    │    ├── key: (9)
  │         │    │    │    ├── fd: (9)-->(10,12,13)
  │         │    │    │    ├── ordering: +9
- │         │    │    │    └── inner-join (lookup orders)
- │         │    │    │         ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null) l_orderkey:34(int!null) sum:50(float!null)
- │         │    │    │         ├── key columns: [34] = [9]
+ │         │    │    │    └── project
+ │         │    │    │         ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null) l_orderkey:34(int!null)
  │         │    │    │         ├── key: (34)
- │         │    │    │         ├── fd: (9)-->(10,12,13), (34)-->(50), (9)==(34), (34)==(9)
+ │         │    │    │         ├── fd: (9)-->(10,12,13), (9)==(34), (34)==(9)
  │         │    │    │         ├── ordering: +(9|34) [actual: +34]
- │         │    │    │         ├── select
- │         │    │    │         │    ├── columns: l_orderkey:34(int!null) sum:50(float!null)
- │         │    │    │         │    ├── key: (34)
- │         │    │    │         │    ├── fd: (34)-->(50)
- │         │    │    │         │    ├── ordering: +34
- │         │    │    │         │    ├── group-by
- │         │    │    │         │    │    ├── columns: l_orderkey:34(int!null) sum:50(float)
- │         │    │    │         │    │    ├── grouping columns: l_orderkey:34(int!null)
- │         │    │    │         │    │    ├── key: (34)
- │         │    │    │         │    │    ├── fd: (34)-->(50)
- │         │    │    │         │    │    ├── ordering: +34
- │         │    │    │         │    │    ├── scan lineitem
- │         │    │    │         │    │    │    ├── columns: l_orderkey:34(int!null) l_quantity:38(float!null)
- │         │    │    │         │    │    │    └── ordering: +34
- │         │    │    │         │    │    └── aggregations
- │         │    │    │         │    │         └── sum [type=float, outer=(38)]
- │         │    │    │         │    │              └── variable: l_quantity [type=float]
- │         │    │    │         │    └── filters
- │         │    │    │         │         └── sum > 300.0 [type=bool, outer=(50), constraints=(/50: [/300.00000000000006 - ]; tight)]
- │         │    │    │         └── filters (true)
+ │         │    │    │         └── inner-join (lookup orders)
+ │         │    │    │              ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null) l_orderkey:34(int!null) sum:50(float!null)
+ │         │    │    │              ├── key columns: [34] = [9]
+ │         │    │    │              ├── key: (34)
+ │         │    │    │              ├── fd: (9)-->(10,12,13), (34)-->(50), (9)==(34), (34)==(9)
+ │         │    │    │              ├── ordering: +(9|34) [actual: +34]
+ │         │    │    │              ├── select
+ │         │    │    │              │    ├── columns: l_orderkey:34(int!null) sum:50(float!null)
+ │         │    │    │              │    ├── key: (34)
+ │         │    │    │              │    ├── fd: (34)-->(50)
+ │         │    │    │              │    ├── ordering: +34
+ │         │    │    │              │    ├── group-by
+ │         │    │    │              │    │    ├── columns: l_orderkey:34(int!null) sum:50(float)
+ │         │    │    │              │    │    ├── grouping columns: l_orderkey:34(int!null)
+ │         │    │    │              │    │    ├── key: (34)
+ │         │    │    │              │    │    ├── fd: (34)-->(50)
+ │         │    │    │              │    │    ├── ordering: +34
+ │         │    │    │              │    │    ├── scan lineitem
+ │         │    │    │              │    │    │    ├── columns: l_orderkey:34(int!null) l_quantity:38(float!null)
+ │         │    │    │              │    │    │    └── ordering: +34
+ │         │    │    │              │    │    └── aggregations
+ │         │    │    │              │    │         └── sum [type=float, outer=(38)]
+ │         │    │    │              │    │              └── variable: l_quantity [type=float]
+ │         │    │    │              │    └── filters
+ │         │    │    │              │         └── sum > 300.0 [type=bool, outer=(50), constraints=(/50: [/300.00000000000006 - ]; tight)]
+ │         │    │    │              └── filters (true)
  │         │    │    └── filters (true)
  │         │    └── filters (true)
  │         └── aggregations


### PR DESCRIPTION
This commit fixes an error that could occur due to the `EliminateDistinct`
rule, which eliminates a `DistinctOn` operator when the grouping columns
are known to form a strong key. The problem with eliminating the `DistinctOn`
completely is that it has a secondary purpose as a `Project` operator, and
removing it could result in an incorrect number of output columns. This
commit fixes that rule so that it replaces the `DistinctOn` with a `Project`
operator.

Fixes #40295

Release note (bug fix): Fixed an internal planning error that could
occur when a DISTINCT or GROUP BY expression was contained in a subquery.