### PR TITLE
opt: fix panic when building indirection exprs

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -408,7 +408,7 @@ func (b *Builder) buildIndirection(
 		return nil, err
 	}
 
-	return tree.NewTypedIndirectionExpr(expr, index), nil
+	return tree.NewTypedIndirectionExpr(expr, index, scalar.DataType()), nil
 }
 
 func (b *Builder) buildCollate(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.TypedExpr, error) {

--- a/pkg/sql/opt/norm/fold_constants.go
+++ b/pkg/sql/opt/norm/fold_constants.go
@@ -252,7 +252,7 @@ func (c *CustomFuncs) FoldIndirection(input, index opt.ScalarExpr) opt.ScalarExp
 	// Case 2: The input is a constant DArray.
 	if memo.CanExtractConstDatum(input) {
 		inputD := memo.ExtractConstDatum(input)
-		texpr := tree.NewTypedIndirectionExpr(inputD, indexD)
+		texpr := tree.NewTypedIndirectionExpr(inputD, indexD, input.DataType().ArrayContents())
 		result, err := texpr.Eval(c.f.evalCtx)
 		if err == nil {
 			return c.f.ConstructConstVal(result, texpr.ResolvedType())

--- a/pkg/sql/opt/norm/testdata/rules/fold_constants
+++ b/pkg/sql/opt/norm/testdata/rules/fold_constants
@@ -837,6 +837,24 @@ project
  └── projections
       └── a.arr[0] [type=int, outer=(6)]
 
+# Regression test for #40404.
+norm expect=FoldIndirection
+SELECT (SELECT x[1]) FROM (VALUES(null::oid[])) v(x)
+----
+values
+ ├── columns: x:3(oid)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(3)
+ └── tuple [type=tuple{oid}]
+      └── subquery [type=oid]
+           └── values
+                ├── columns: x:2(oid)
+                ├── cardinality: [1 - 1]
+                ├── key: ()
+                ├── fd: ()-->(2)
+                └── (NULL,) [type=tuple{oid}]
+
 # --------------------------------------------------
 # FoldColumnAccess
 # --------------------------------------------------

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -453,12 +453,12 @@ func NewTypedComparisonExprWithSubOp(
 }
 
 // NewTypedIndirectionExpr returns a new IndirectionExpr that is verified to be well-typed.
-func NewTypedIndirectionExpr(expr, index TypedExpr) *IndirectionExpr {
+func NewTypedIndirectionExpr(expr, index TypedExpr, typ *types.T) *IndirectionExpr {
 	node := &IndirectionExpr{
 		Expr:        expr,
 		Indirection: ArraySubscripts{&ArraySubscript{Begin: index}},
 	}
-	node.typ = expr.(TypedExpr).ResolvedType().ArrayContents()
+	node.typ = typ
 	return node
 }
 


### PR DESCRIPTION
Previously, we would ask a built array datum to tell us its type when
building an IndirectionExpr. This was problematic when the datum was
NULL, since while the optimizer-level NULLs track their inferred type,
built DNulls do not, so we ended up not knowing the element type.

This is fixed by grabbing the type from the opt expression, rather than
the built datum.

Fixes #40404.
Fixes #37794.

Release note (bug fix): fixed an optimizer panic when building array
access expressions.