### PR TITLE
exec: add projections of AndExpr

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -887,6 +887,22 @@ func planProjectionOperators(
 		op := exec.NewCaseOp(buffer, caseOps, elseOp, thenIdxs, caseOutputIdx, caseOutputType)
 
 		return op, caseOutputIdx, ct, memUsed, nil
+	case *tree.AndExpr:
+		var leftOp, rightOp exec.Operator
+		var leftIdx, rightIdx, lMemUsed, rMemUsed int
+		leftOp, leftIdx, ct, lMemUsed, err = planProjectionOperators(ctx, t.TypedLeft(), columnTypes, input)
+		if err != nil {
+			return nil, resultIdx, ct, 0, err
+		}
+		rightOp, rightIdx, ct, rMemUsed, err = planProjectionOperators(ctx, t.TypedRight(), ct, leftOp)
+		if err != nil {
+			return nil, resultIdx, ct, 0, err
+		}
+		// Add a new boolean column that ands the two output columns.
+		resultIdx = len(ct)
+		ct = append(ct, *t.ResolvedType())
+		andOp := exec.NewAndOp(rightOp, leftIdx, rightIdx, resultIdx)
+		return andOp, resultIdx, ct, lMemUsed + rMemUsed, nil
 	case *tree.OrExpr:
 		// Rewrite the OR expression as an equivalent CASE expression.
 		// "a OR b" becomes "CASE WHEN a THEN true WHEN b THEN true ELSE false END".

--- a/pkg/sql/exec/and.go
+++ b/pkg/sql/exec/and.go
@@ -1,0 +1,68 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package exec
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+)
+
+type andOp struct {
+	OneInputNode
+
+	leftIdx   int
+	rightIdx  int
+	outputIdx int
+}
+
+// NewAndOp returns a new operator that logical-ANDs the boolean columns at
+// leftIdx and rightIdx, returning the result in outputIdx.
+func NewAndOp(input Operator, leftIdx, rightIdx, outputIdx int) Operator {
+	return &andOp{
+		OneInputNode: NewOneInputNode(input),
+		leftIdx:      leftIdx,
+		rightIdx:     rightIdx,
+		outputIdx:    outputIdx,
+	}
+}
+
+func (a *andOp) Init() {
+	a.input.Init()
+}
+
+func (a *andOp) Next(ctx context.Context) coldata.Batch {
+	batch := a.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return batch
+	}
+	if a.outputIdx == batch.Width() {
+		batch.AppendCol(coltypes.Bool)
+	}
+	leftCol := batch.ColVec(a.leftIdx).Bool()
+	rightCol := batch.ColVec(a.rightIdx).Bool()
+	outputCol := batch.ColVec(a.outputIdx).Bool()
+
+	if sel := batch.Selection(); sel != nil {
+		for _, i := range sel[:n] {
+			outputCol[i] = leftCol[i] && rightCol[i]
+		}
+	} else {
+		_ = rightCol[n-1]
+		_ = outputCol[n-1]
+		for i := range leftCol[:n] {
+			outputCol[i] = leftCol[i] && rightCol[i]
+		}
+	}
+	return batch
+}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -279,11 +279,11 @@ statement ok
 RESET vectorize
 
 # AND expressions.
-query II
-SELECT a, b FROM a WHERE a < 2 AND b > 0 AND a * b != 3
+query IIBB
+SELECT a, b, a < 2 AND b > 0 AND a * b != 3, a < 2 AND b < 2 FROM a WHERE a < 2 AND b > 0 AND a * b != 3
 ----
-0  1
-1  2
+0  1  true  true
+1  2  true  false
 
 statement ok
 CREATE TABLE b (a INT, b STRING, PRIMARY KEY (b,a))


### PR DESCRIPTION
This adds support for TPCH q19, which sees a 3x speedup with vectorized.

Release note: None