### PR TITLE
opt: detect zero-cardinality semi/anti joins

### DIFF
--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -852,8 +852,10 @@ func (sb *statisticsBuilder) buildJoin(
 			s.RowCount = leftStats.RowCount
 
 		case opt.AntiJoinOp, opt.AntiJoinApplyOp:
-			s.RowCount = 0
-			s.Selectivity = 0
+			// Don't set the row count to 0 since we can't guarantee that the
+			// cardinality is 0.
+			s.RowCount = epsilon
+			s.Selectivity = epsilon
 		}
 		return
 	}

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -1417,3 +1417,16 @@ project
  │    └── filters (true)
  └── projections
       └── variable: mn.m [type=int, outer=(13)]
+
+# Regression test #40456.
+opt
+SELECT NULL
+FROM uv
+WHERE NOT EXISTS(SELECT uv.u);
+----
+values
+ ├── columns: "?column?":5(unknown!null)
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ ├── fd: ()-->(5)
+ └── prune: (5)

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -1380,3 +1380,65 @@ full-join (hash)
            │                   ├── fd: ()-->(7)
            │                   └── (NULL,) [type=tuple{unknown}]
            └── false [type=bool]
+
+expr
+(SemiJoin
+    (Values
+      [ (Tuple [ (Const 1) (Const 2) ] "tuple{int}" ) ]
+      [ (Cols [ (NewColumn "a" "int") (NewColumn "b" "int") ]) ]
+    )
+    (Scan [ (Table "uv") (Cols "u,v,rowid") ])
+    []
+    []
+)
+----
+semi-join (hash)
+ ├── columns: a:1(int!null) b:2(int!null)
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=1]
+ ├── key: ()
+ ├── fd: ()-->(1,2)
+ ├── values
+ │    ├── columns: a:1(int!null) b:2(int!null)
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1,2)
+ │    └── (1, 2) [type=tuple{int}]
+ ├── scan uv
+ │    ├── columns: u:3(int) v:4(int!null) rowid:5(int!null)
+ │    ├── stats: [rows=10000]
+ │    ├── key: (5)
+ │    └── fd: (5)-->(3,4)
+ └── filters (true)
+
+expr
+(AntiJoin
+    (Values
+      [ (Tuple [ (Const 1) (Const 2) ] "tuple{int}" ) ]
+      [ (Cols [ (NewColumn "a" "int") (NewColumn "b" "int") ]) ]
+    )
+    (Scan [ (Table "uv") (Cols "u,v,rowid") ])
+    []
+    []
+)
+----
+anti-join (hash)
+ ├── columns: a:1(int!null) b:2(int!null)
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=1e-10]
+ ├── key: ()
+ ├── fd: ()-->(1,2)
+ ├── values
+ │    ├── columns: a:1(int!null) b:2(int!null)
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1,2)
+ │    └── (1, 2) [type=tuple{int}]
+ ├── scan uv
+ │    ├── columns: u:3(int) v:4(int!null) rowid:5(int!null)
+ │    ├── stats: [rows=10000]
+ │    ├── key: (5)
+ │    └── fd: (5)-->(3,4)
+ └── filters (true)

--- a/pkg/sql/opt/norm/rules/join.opt
+++ b/pkg/sql/opt/norm/rules/join.opt
@@ -325,6 +325,16 @@
 =>
 $left
 
+# SimplifyZeroCardinalitySemiJoin converts a SemiJoin operator to an empty
+# Values when it's known that the right input never returns any rows.
+[SimplifyZeroCardinalitySemiJoin, Normalize]
+(SemiJoin | SemiJoinApply
+    $left:*
+    $right:* & (HasZeroRows $right)
+)
+=>
+(ConstructEmptyValues (OutputCols $left))
+
 # EliminateAntiJoin discards an AntiJoin operator when it's known that the right
 # input never returns any rows.
 [EliminateAntiJoin, Normalize]
@@ -334,6 +344,18 @@ $left
 )
 =>
 $left
+
+# SimplifyZeroCardinalityAntiJoin converts an AntiJoin operator to an empty
+# Values when it's known that the right input never returns zero rows, and
+# there is no join condition.
+[SimplifyZeroCardinalityAntiJoin, Normalize]
+(AntiJoin | AntiJoinApply
+    $left:*
+    $right:* & ^(CanHaveZeroRows $right)
+    []
+)
+=>
+(ConstructEmptyValues (OutputCols $left))
 
 # EliminateJoinNoColsLeft eliminates an InnerJoin with a one row, zero column
 # left input set. These can be produced when a Values, scalar GroupBy, or other

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -1841,6 +1841,27 @@ scan a
  ├── key: (1)
  └── fd: (1)-->(2-5)
 
+opt expect=EliminateSemiJoin
+SELECT * FROM a WHERE EXISTS(VALUES (k))
+----
+scan a
+ ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
+ ├── key: (1)
+ └── fd: (1)-->(2-5)
+
+# --------------------------------------------------
+# SimplifyZeroCardinalitySemiJoin
+# --------------------------------------------------
+# TODO(justin): figure out if there's a good way to make this still apply.
+opt disable=SimplifyZeroCardinalityGroup expect=SimplifyZeroCardinalitySemiJoin
+SELECT * FROM a WHERE EXISTS(SELECT * FROM (VALUES (k)) OFFSET 1)
+----
+values
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb!null)
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1-5)
+
 # --------------------------------------------------
 # EliminateAntiJoin
 # --------------------------------------------------
@@ -1852,6 +1873,27 @@ scan a
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  ├── key: (1)
  └── fd: (1)-->(2-5)
+
+# --------------------------------------------------
+# SimplifyZeroCardinalityAntiJoin
+# --------------------------------------------------
+opt expect=SimplifyZeroCardinalityAntiJoin
+SELECT * FROM a WHERE NOT EXISTS(SELECT count(*) FROM b WHERE x=k)
+----
+values
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb!null)
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1-5)
+
+opt expect=SimplifyZeroCardinalityAntiJoin
+SELECT * FROM a WHERE NOT EXISTS(VALUES (k))
+----
+values
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb!null)
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1-5)
 
 # --------------------------------------------------
 # EliminateJoinNoColsLeft


### PR DESCRIPTION
This commit adds two normalization rules to detect zero-cardinality
semi and anti joins, and replace them with an empty `Values`.

It also updates the stats estimate to ensure that the row count of semi
and anti joins is not zero unless the cardinality is zero.

Fixes #40456
Fixes #40440
Fixes #40394

Release note: None