### PR TITLE
sql: SHOW CREATE TABLE warns on partitioned tables without zone configs

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/case_sensitive_names
+++ b/pkg/ccl/logictestccl/testdata/logic_test/case_sensitive_names
@@ -19,3 +19,4 @@ p  CREATE TABLE p (
    PARTITION "P1" VALUES IN ((2)),
    PARTITION "Amélie" VALUES IN ((3))
 )
+-- Warning: Partitioned table with no zone configurations.

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -398,6 +398,7 @@ ok1  CREATE TABLE ok1 (
    PARTITION p1 VALUES IN ((1)),
    PARTITION p2 VALUES IN ((2))
 )
+-- Warning: Partitioned table with no zone configurations.
 
 query T
 EXPLAIN (OPT, CATALOG) SELECT * from ok1
@@ -433,6 +434,7 @@ ok2  CREATE TABLE ok2 (
    PARTITION p1 VALUES IN ((1)),
    PARTITION p2 VALUES IN ((2))
 )
+-- Warning: Partitioned table with no zone configurations.
 
 query T
 EXPLAIN (OPT, CATALOG) SELECT * from ok2
@@ -468,6 +470,7 @@ ok3  CREATE TABLE ok3 (
    PARTITION p1 VALUES IN ((1)),
    PARTITION p2 VALUES IN ((DEFAULT))
 )
+-- Warning: Partitioned table with no zone configurations.
 
 query T
 EXPLAIN (OPT, CATALOG) SELECT * from ok3
@@ -506,6 +509,7 @@ ok4  CREATE TABLE ok4 (
    PARTITION p3 VALUES IN ((2, 3)),
    PARTITION p4 VALUES IN ((DEFAULT, DEFAULT))
 )
+-- Warning: Partitioned table with no zone configurations.
 
 query T
 EXPLAIN (OPT, CATALOG) SELECT * from ok4
@@ -569,6 +573,7 @@ ok5  CREATE TABLE ok5 (
    ),
    PARTITION p3 VALUES IN ((DEFAULT))
 )
+-- Warning: Partitioned table with no zone configurations.
 
 statement ok
 CREATE TABLE ok6 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a) (
@@ -589,6 +594,7 @@ ok6  CREATE TABLE ok6 (
    PARTITION p1 VALUES FROM (0) TO (1),
    PARTITION p2 VALUES FROM (1) TO (2)
 )
+-- Warning: Partitioned table with no zone configurations.
 
 query T
 EXPLAIN (OPT, CATALOG) SELECT * from ok6
@@ -619,6 +625,7 @@ ok7  CREATE TABLE ok7 (
 ) PARTITION BY RANGE (a) (
    PARTITION p1 VALUES FROM (0) TO (1)
 )
+-- Warning: Partitioned table with no zone configurations.
 
 query T
 EXPLAIN (OPT, CATALOG) SELECT * from ok7
@@ -653,6 +660,7 @@ ok8  CREATE TABLE ok8 (
    PARTITION p2 VALUES FROM (1) TO (2),
    PARTITION p3 VALUES FROM (2) TO (MAXVALUE)
 )
+-- Warning: Partitioned table with no zone configurations.
 
 query T
 EXPLAIN (OPT, CATALOG) SELECT * from ok8
@@ -689,6 +697,7 @@ ok9  CREATE TABLE ok9 (
    PARTITION p3 VALUES FROM (3, MINVALUE) TO (3, MAXVALUE),
    PARTITION p4 VALUES FROM (3, MAXVALUE) TO (MAXVALUE, MAXVALUE)
 )
+-- Warning: Partitioned table with no zone configurations.
 
 query T
 EXPLAIN (OPT, CATALOG) SELECT * from ok9
@@ -727,6 +736,7 @@ ok10  CREATE TABLE ok10 (
    PARTITION p4 VALUES FROM (2, MAXVALUE) TO (3, 4),
    PARTITION p5 VALUES FROM (3, 4) TO (MAXVALUE, MAXVALUE)
 )
+-- Warning: Partitioned table with no zone configurations.
 
 query T
 EXPLAIN (OPT, CATALOG) SELECT * from ok10
@@ -773,6 +783,7 @@ ok11  CREATE TABLE ok11 (
      PARTITION p2_1 VALUES FROM (7) TO (8)
    )
 )
+-- Warning: Partitioned table with no zone configurations.
 
 query T
 EXPLAIN (OPT, CATALOG) SELECT * from ok11
@@ -812,6 +823,7 @@ ok12  CREATE TABLE ok12 (
    PARTITION p1 VALUES IN ((1)),
    PARTITION p2 VALUES IN ((2))
 )
+-- Warning: Partitioned table with no zone configurations.
 
 query T
 EXPLAIN (OPT, CATALOG) SELECT * from ok12

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_index
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_index
@@ -22,6 +22,7 @@ ok1  CREATE TABLE ok1 (
      ),
      FAMILY "primary" (a, b)
 )
+-- Warning: Partitioned table with no zone configurations.
 
 # Verify that secondary indexes with a partition for NULLs can actually store
 # NULLs.
@@ -48,6 +49,7 @@ ok2  CREATE TABLE ok2 (
      ),
      FAMILY "primary" (a, b)
 )
+-- Warning: Partitioned table with no zone configurations.
 
 statement ok
 CREATE TABLE ok3 (
@@ -80,6 +82,7 @@ ok3  CREATE TABLE ok3 (
      ),
      FAMILY "primary" (a, b)
 )
+-- Warning: Partitioned table with no zone configurations.
 
 statement ok
 CREATE TABLE indexes (a INT PRIMARY KEY, b INT)
@@ -143,3 +146,4 @@ indexes  CREATE TABLE indexes (
          ),
          FAMILY "primary" (a, b)
 )
+-- Warning: Partitioned table with no zone configurations.

--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -567,6 +567,25 @@ ALTER PARTITION p1 OF INDEX "my database".public.show_test@primary CONFIGURE ZON
 ALTER PARTITION p2 OF INDEX "my database".public.show_test@primary CONFIGURE ZONE USING
   constraints = '[+dc=dc2]'
 
+# test warnings on table creation
+statement ok
+CREATE TABLE warning (x INT PRIMARY KEY)
+
+statement ok
+ALTER TABLE warning PARTITION BY LIST (x) (PARTITION p1 VALUES IN (1))
+
+query TT
+SHOW CREATE warning
+----
+warning  CREATE TABLE warning (
+         x INT8 NOT NULL,
+         CONSTRAINT "primary" PRIMARY KEY (x ASC),
+         FAMILY "primary" (x)
+) PARTITION BY LIST (x) (
+  PARTITION p1 VALUES IN ((1))
+)
+-- Warning: Partitioned table with no zone configurations.
+
 subtest alter_partition_across_all_indexes
 
 statement ok

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1265,6 +1265,19 @@ CREATE TABLE crdb_internal.create_statements (
 							return err
 						}
 					}
+				} else {
+					// If there are partitions applied to this table and no zone configurations, display a warning.
+					hasPartitions := false
+					for i := range table.Indexes {
+						if table.Indexes[i].Partitioning.NumColumns != 0 {
+							hasPartitions = true
+							break
+						}
+					}
+					hasPartitions = hasPartitions || table.PrimaryIndex.Partitioning.NumColumns != 0
+					if hasPartitions {
+						stmt += "\n-- Warning: Partitioned table with no zone configurations."
+					}
 				}
 
 				descID := tree.NewDInt(tree.DInt(table.ID))

--- a/pkg/sql/partition_test.go
+++ b/pkg/sql/partition_test.go
@@ -72,7 +72,8 @@ func TestRemovePartitioningOSS(t *testing.T) {
 	FAMILY fam_1_v (v)
 ) PARTITION BY RANGE (k) (
 	PARTITION p1 VALUES FROM (1) TO (2)
-)`
+)
+-- Warning: Partitioned table with no zone configurations.`
 	if a := sqlDB.QueryStr(t, "SHOW CREATE t.kv")[0][1]; exp != a {
 		t.Fatalf("expected:\n%s\n\ngot:\n%s\n\n", exp, a)
 	}


### PR DESCRIPTION
SHOW CREATE displays partitioning and zone configuration information,
but it would be helpful as well to notify to users if they have a
partitioned table that doesn't have any zone configurations.

Fixes #40384.

Release note (sql change): SHOW CREATE TABLE now warns users if they
have a partitioned table that does not contain any zone configurations