### PR TITLE
storage: Deflake TestReplicaReproposalWithNewLeaseIndexError

### DIFF
--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -76,7 +76,7 @@ type ProposalData struct {
 	// containing the command ID.
 	encodedCommand []byte
 
-	// quotaAlloc is the allocation retreived from the proposalQuota.
+	// quotaAlloc is the allocation retrieved from the proposalQuota.
 	// Once a proposal has been passed to raft modifying this field requires
 	// holding the raftMu.
 	quotaAlloc *quotapool.IntAlloc

--- a/pkg/storage/replica_proposal_buf.go
+++ b/pkg/storage/replica_proposal_buf.go
@@ -400,6 +400,11 @@ func (b *propBuf) FlushLockedWithRaftGroup(raftGroup *raft.RawNode) error {
 	// stop trying to propose commands to raftGroup.
 	var firstErr error
 	for i, p := range buf {
+		if p == nil {
+			// If we run into an error during proposal insertion, we may have reserved
+			// an array index without actually inserting a proposal.
+			continue
+		}
 		buf[i] = nil // clear buffer
 
 		// Raft processing bookkeeping.


### PR DESCRIPTION
Fixes #39739. When inserting a new command into the proposal buffer, we
first reserve an index into the buffer's array and an offset from the
buffer's base lease index. If we subsequently fail to insert the
proposal, we should undo the index and offset reservation.

When we error out in `(*propBuf).Insert`, if we don't undo the index
reservation we expect a proposal at said index during consumption, but
don't find one.

Release note: None