### PR TITLE
importccl: replace the undocumented data format MYSQLOUTFILE with DELIMITED

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -243,7 +243,7 @@ func importPlanHook(
 				}
 				format.Csv.Skip = uint32(skip)
 			}
-		case "MYSQLOUTFILE":
+		case "DELIMITED":
 			telemetry.Count("import.format.mysqlout")
 			format.Format = roachpb.IOFileFormat_MysqlOutfile
 			format.MysqlOut = roachpb.MySQLOutfileOptions{

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -239,14 +239,14 @@ d
 		{
 			name:   "too many imported columns",
 			create: `i int8`,
-			typ:    "MYSQLOUTFILE",
+			typ:    "DELIMITED",
 			data:   "1\t2",
 			err:    "row 1: too many columns, expected 1",
 		},
 		{
 			name:   "unexpected number of columns",
 			create: `a string, b string`,
-			typ:    "MYSQLOUTFILE",
+			typ:    "DELIMITED",
 			data:   "1,2",
 			err:    "row 1: unexpected number of columns, expected 2 got 1",
 		},
@@ -254,7 +254,7 @@ d
 			name:   "unmatched field enclosure",
 			create: `i int8`,
 			with:   `WITH fields_enclosed_by = '"'`,
-			typ:    "MYSQLOUTFILE",
+			typ:    "DELIMITED",
 			data:   "\"1",
 			err:    "row 1: unmatched field enclosure",
 		},
@@ -262,7 +262,7 @@ d
 			name:   "unmatched literal",
 			create: `i int8`,
 			with:   `WITH fields_escaped_by = '\'`,
-			typ:    "MYSQLOUTFILE",
+			typ:    "DELIMITED",
 			data:   `\`,
 			err:    "row 1: unmatched literal",
 		},
@@ -270,7 +270,7 @@ d
 			name:   "weird escape char",
 			create: `s STRING`,
 			with:   `WITH fields_escaped_by = '@'`,
-			typ:    "MYSQLOUTFILE",
+			typ:    "DELIMITED",
 			data:   "@N\nN@@\nNULL",
 			query: map[string][][]string{
 				`SELECT COALESCE(s, '(null)') from t`: {{"(null)"}, {"N@"}, {"NULL"}},
@@ -280,7 +280,7 @@ d
 			name:   `null and \N with escape`,
 			create: `s STRING`,
 			with:   `WITH fields_escaped_by = '\'`,
-			typ:    "MYSQLOUTFILE",
+			typ:    "DELIMITED",
 			data:   "\\N\n\\\\N\nNULL",
 			query: map[string][][]string{
 				`SELECT COALESCE(s, '(null)') from t`: {{"(null)"}, {`\N`}, {"NULL"}},
@@ -290,7 +290,7 @@ d
 			name:   `\N with trailing char`,
 			create: `s STRING`,
 			with:   `WITH fields_escaped_by = '\'`,
-			typ:    "MYSQLOUTFILE",
+			typ:    "DELIMITED",
 			data:   "\\N1",
 			err:    "row 1: unexpected data after null encoding",
 		},
@@ -298,14 +298,14 @@ d
 			name:   `double null`,
 			create: `s STRING`,
 			with:   `WITH fields_escaped_by = '\'`,
-			typ:    "MYSQLOUTFILE",
+			typ:    "DELIMITED",
 			data:   "\\N\\N",
 			err:    "row 1: unexpected null encoding",
 		},
 		{
 			name:   `null and \N without escape`,
 			create: `s STRING`,
-			typ:    "MYSQLOUTFILE",
+			typ:    "DELIMITED",
 			data:   "\\N\n\\\\N\nNULL",
 			query: map[string][][]string{
 				`SELECT COALESCE(s, '(null)') from t`: {{`\N`}, {`\\N`}, {"(null)"}},
@@ -314,7 +314,7 @@ d
 		{
 			name:   `bytes with escape`,
 			create: `b BYTES`,
-			typ:    "MYSQLOUTFILE",
+			typ:    "DELIMITED",
 			data:   `\x`,
 			query: map[string][][]string{
 				`SELECT * from t`: {{`\x`}},
@@ -712,7 +712,7 @@ COPY t (a, b, c) FROM stdin;
 	t.Run("mysqlout multiple", func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE DATABASE mysqlout; USE mysqlout`)
 		dataString = "1"
-		sqlDB.Exec(t, `IMPORT TABLE t (s STRING) MYSQLOUTFILE DATA ($1, $1)`, srv.URL)
+		sqlDB.Exec(t, `IMPORT TABLE t (s STRING) DELIMITED DATA ($1, $1)`, srv.URL)
 		sqlDB.CheckQueryResults(t, `SELECT * FROM t`, [][]string{{"1"}, {"1"}})
 	})
 }
@@ -2683,7 +2683,7 @@ func TestImportMysqlOutfile(t *testing.T) {
 		t.Run(cfg.name, func(t *testing.T) {
 			var opts []interface{}
 
-			cmd := fmt.Sprintf(`IMPORT TABLE test%d (i INT8 PRIMARY KEY, s text, b bytea) MYSQLOUTFILE DATA ($1)`, i)
+			cmd := fmt.Sprintf(`IMPORT TABLE test%d (i INT8 PRIMARY KEY, s text, b bytea) DELIMITED DATA ($1)`, i)
 			opts = append(opts, fmt.Sprintf("nodelocal://%s", strings.TrimPrefix(cfg.filename, baseDir)))
 
 			var flags []string

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1314,7 +1314,7 @@ func TestParse(t *testing.T) {
 
 		{`IMPORT TABLE foo CREATE USING 'nodelocal:///some/file' CSV DATA ('path/to/some/file', $1) WITH temp = 'path/to/temp'`},
 		{`EXPLAIN IMPORT TABLE foo CREATE USING 'nodelocal:///some/file' CSV DATA ('path/to/some/file', $1) WITH temp = 'path/to/temp'`},
-		{`IMPORT TABLE foo CREATE USING 'nodelocal:///some/file' MYSQLOUTFILE DATA ('path/to/some/file', $1)`},
+		{`IMPORT TABLE foo CREATE USING 'nodelocal:///some/file' DELIMITED DATA ('path/to/some/file', $1)`},
 		{`IMPORT TABLE foo (id INT8 PRIMARY KEY, email STRING, age INT8) CSV DATA ('path/to/some/file', $1) WITH temp = 'path/to/temp'`},
 		{`IMPORT TABLE foo (id INT8, email STRING, age INT8) CSV DATA ('path/to/some/file', $1) WITH comma = ',', "nullif" = 'n/a', temp = $2`},
 		{`IMPORT TABLE foo FROM PGDUMPCREATE 'nodelocal:///foo/bar' WITH temp = 'path/to/temp'`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1860,7 +1860,7 @@ import_format:
 //
 // Formats:
 //    CSV
-//    MYSQLOUTFILE
+//    DELIMITED
 //    MYSQLDUMP
 //    PGCOPY
 //    PGDUMP


### PR DESCRIPTION
MYSQLOUTFILE was originally used to help a client import data that was
not in csv proper format. This turns out to be useful for other users so
we call the new format DELIMITED. It's very fast and simple format for importing
delimited data disregarding issues with quoting. For example the csv format forbids
`field1,fieldsth2` as such fields that contain  quotes have to be enclosed in
quotes themselves. The whole format is fully described here
https://dev.mysql.com/doc/refman/8.0/en/load-data.html.

Fixes #39820.

Release note (cli change): add a new IMPORT DATA format DELIMITED.