### PR TITLE
removed status from repo README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,6 @@ Here’s a quick explainer video:
 <a href='https://www.youtube.com/watch?v=VgXiMcbGwzQ'> <img src='docs/media/explainer-video-preview.png' width='50%'> </a>
 
 
-## Status
-
-CockroachDB is production-ready. See our
-[Roadmap](https://github.com/cockroachdb/cockroach/wiki/Roadmap) for a list of features planned or in development.
-
 ## Docs
 
 For guidance on installation, development, deployment, and administration, see our [User Documentation](https://cockroachlabs.com/docs/stable/).


### PR DESCRIPTION
The status section included a link to our old wiki. 

The issue was brought up in https://github.com/cockroachdb/cockroach/issues/40452

I removed the section entirely.

