### PR TITLE
sql: Fix a bug with ordinal_position in information_schema.columns

### DIFF
--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -993,8 +993,8 @@ CREATE TABLE t.test (a STRING PRIMARY KEY, b STRING, c STRING, INDEX foo (c));
 		"SHOW COLUMNS FROM t.test",
 		[][]string{
 			{"a", "STRING", "false", "NULL", "", "{primary,ufo}", "false"},
-			{"d", "STRING", "true", "NULL", "", "{ufo}", "false"},
 			{"e", "STRING", "true", "NULL", "", "{}", "false"},
+			{"d", "STRING", "true", "NULL", "", "{ufo}", "false"},
 		},
 	)
 

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -376,10 +376,7 @@ https://www.postgresql.org/docs/9.5/infoschema-columns.html`,
 		return forEachTableDesc(ctx, p, dbContext, virtualMany, func(db *sqlbase.DatabaseDescriptor, scName string, table *sqlbase.TableDescriptor) error {
 			dbNameStr := tree.NewDString(db.Name)
 			scNameStr := tree.NewDString(scName)
-			// Table descriptors already holds columns in-order.
-			visible := 0
 			return forEachColumnInTable(table, func(column *sqlbase.ColumnDescriptor) error {
-				visible++
 				collationCatalog := tree.DNull
 				collationSchema := tree.DNull
 				collationName := tree.DNull
@@ -393,7 +390,7 @@ https://www.postgresql.org/docs/9.5/infoschema-columns.html`,
 					scNameStr,                                            // table_schema
 					tree.NewDString(table.Name),                          // table_name
 					tree.NewDString(column.Name),                         // column_name
-					tree.NewDInt(tree.DInt(visible)),                     // ordinal_position, 1-indexed
+					tree.NewDInt(tree.DInt(column.ID)),                   // ordinal_position
 					dStringPtrOrNull(column.DefaultExpr),                 // column_default
 					yesOrNoDatum(column.Nullable),                        // is_nullable
 					tree.NewDString(column.Type.InformationSchemaName()), // data_type

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -2198,3 +2198,30 @@ SET database = test
 
 statement ok
 DROP DATABASE dfk CASCADE
+
+# Regression test for #39787. Verify information_schema.ordinal_position
+# matches pg_attribute.attnum when a leading column is dropped.
+
+statement ok
+CREATE TABLE ab(a INT, b INT)
+
+statement ok
+ALTER TABLE ab DROP COLUMN a
+
+let $attnum
+SELECT attnum FROM pg_attribute WHERE attrelid = 'ab'::regclass AND attname = 'b'
+
+query I
+SELECT
+	ordinal_position
+FROM
+	information_schema.columns
+WHERE
+	table_name = 'ab'
+	AND column_name = 'b'
+	AND ordinal_position = $attnum;
+----
+2
+
+statement ok
+DROP TABLE ab


### PR DESCRIPTION
When a column other than the last is dropped, ordinal_position in
information_schema.columns virtual table no longer matches attnum from
the pg_attribute table. This PR fixes this issue.

Fixes #39787

Release note (bug fix): ordinal_position in information_schema.columns
matches pg_attribute.attnum after a column is dropped.