### PR TITLE
opt: fix calculation of stats for join when right side has 0 cardinality

### DIFF
--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -924,7 +924,9 @@ func (sb *statisticsBuilder) buildJoin(
 		if h.rightProps.FuncDeps.ColsAreStrictKey(h.selfJoinCols) {
 			// This is like an index join, so apply a selectivity that will result
 			// in leftStats.RowCount rows.
-			s.ApplySelectivity(1 / rightStats.RowCount)
+			if rightStats.RowCount != 0 {
+				s.ApplySelectivity(1 / rightStats.RowCount)
+			}
 		} else {
 			// Add the self join columns to equivReps so they are included in the
 			// calculation for selectivityFromEquivalencies below.

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -1334,3 +1334,49 @@ anti-join (lookup def)
  │    └── interesting orderings: (+1,+2)
  └── filters
       └── false [type=bool]
+
+# Regression test for #40460.
+opt
+SELECT
+    *
+FROM
+    abc
+    FULL JOIN (SELECT * FROM abc WHERE false) ON
+            false
+            IS NOT DISTINCT FROM not_like_escape(
+                    '',
+                    NULL::STRING,
+                    (SELECT NULL)::STRING
+                );
+----
+full-join (hash)
+ ├── columns: a:1(int) b:2(int) c:3(int) a:4(int) b:5(int) c:6(int)
+ ├── stats: [rows=100]
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3-6), ()~~>(4-6)
+ ├── scan abc
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int)
+ │    ├── stats: [rows=100]
+ │    ├── key: (1,2)
+ │    └── fd: (1,2)-->(3)
+ ├── values
+ │    ├── columns: a:4(int!null) b:5(int!null) c:6(int!null)
+ │    ├── cardinality: [0 - 0]
+ │    ├── stats: [rows=0]
+ │    ├── key: ()
+ │    └── fd: ()-->(4-6)
+ └── filters
+      └── is [type=bool, subquery]
+           ├── function: not_like_escape [type=bool]
+           │    ├── const: '' [type=string]
+           │    ├── null [type=string]
+           │    └── cast: STRING [type=string]
+           │         └── subquery [type=unknown]
+           │              └── values
+           │                   ├── columns: "?column?":7(unknown)
+           │                   ├── cardinality: [1 - 1]
+           │                   ├── stats: [rows=1]
+           │                   ├── key: ()
+           │                   ├── fd: ()-->(7)
+           │                   └── (NULL,) [type=tuple{unknown}]
+           └── false [type=bool]


### PR DESCRIPTION
This commit fixes a divide-by-zero error in the `statisticsBuilder` that
was causing the cost of a join to be infinite.

Fixes #40460

Release note: None