### PR TITLE
exec: Bug fixes in vectorized casts

### DIFF
--- a/pkg/sql/exec/cast_tmpl.go
+++ b/pkg/sql/exec/cast_tmpl.go
@@ -50,6 +50,21 @@ func _ASSIGN_CAST(to, from interface{}) {
 	execerror.VectorizedInternalPanic("")
 }
 
+// This will be replaced with execgen.GET.
+func _FROM_TYPE_GET(to, from interface{}) interface{} {
+	execerror.VectorizedInternalPanic("")
+}
+
+// This will be replaced with execgen.SET.
+func _TO_TYPE_SET(to, from interface{}) {
+	execerror.VectorizedInternalPanic("")
+}
+
+// This will be replaced with execgen.SLICE.
+func _FROM_TYPE_SLICE(col, i, j interface{}) interface{} {
+	execerror.VectorizedInternalPanic("")
+}
+
 // */}}
 
 // Use execgen package to remove unused import warning.
@@ -127,21 +142,22 @@ func (c *castOp_FROMTYPE_TOTYPE) Next(ctx context.Context) coldata.Batch {
 				if vecNulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
-					v := execgen.GET(col, int(i))
+					v := _FROM_TYPE_GET(col, int(i))
 					var r _GOTYPE
 					_ASSIGN_CAST(r, v)
-					execgen.SET(projCol, int(i), r)
+					_TO_TYPE_SET(projCol, int(i), r)
 				}
 			}
 		} else {
+			col = _FROM_TYPE_SLICE(col, 0, int(n))
 			for execgen.RANGE(i, col) {
 				if vecNulls.NullAt(uint16(i)) {
 					projNulls.SetNull(uint16(i))
 				} else {
-					v := execgen.GET(col, i)
+					v := _FROM_TYPE_GET(col, int(i))
 					var r _GOTYPE
 					_ASSIGN_CAST(r, v)
-					execgen.SET(projCol, int(i), r)
+					_TO_TYPE_SET(projCol, int(i), r)
 				}
 			}
 		}
@@ -149,17 +165,18 @@ func (c *castOp_FROMTYPE_TOTYPE) Next(ctx context.Context) coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				v := execgen.GET(col, int(i))
+				v := _FROM_TYPE_GET(col, int(i))
 				var r _GOTYPE
 				_ASSIGN_CAST(r, v)
-				execgen.SET(projCol, int(i), r)
+				_TO_TYPE_SET(projCol, int(i), r)
 			}
 		} else {
+			col = _FROM_TYPE_SLICE(col, 0, int(n))
 			for execgen.RANGE(i, col) {
-				v := execgen.GET(col, i)
+				v := _FROM_TYPE_GET(col, int(i))
 				var r _GOTYPE
 				_ASSIGN_CAST(r, v)
-				execgen.SET(projCol, int(i), r)
+				_TO_TYPE_SET(projCol, int(i), r)
 			}
 		}
 	}

--- a/pkg/sql/exec/execgen/cmd/execgen/cast_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/cast_gen.go
@@ -33,7 +33,17 @@ func genCastOperators(wr io.Writer) error {
 	s = strings.Replace(s, "_TOTYPE", "{{.ToTyp}}", -1)
 	s = strings.Replace(s, "_GOTYPE", "{{.ToGoTyp}}", -1)
 
+	// replace _FROM_TYPE_SLICE's with execgen.SLICE's of the correct type.
+	s = strings.Replace(s, "_FROM_TYPE_SLICE", "execgen.SLICE", -1)
 	s = replaceManipulationFuncs(".FromTyp", s)
+
+	// replace the _FROM_TYPE_GET's with execgen.GET's of the correct type.
+	s = strings.Replace(s, "_FROM_TYPE_GET", "execgen.GET", -1)
+	s = replaceManipulationFuncs(".FromTyp", s)
+
+	// replace the _TO_TYPE_GET's with execgen.SET's of the correct type
+	s = strings.Replace(s, "_TO_TYPE_SET", "execgen.SET", -1)
+	s = replaceManipulationFuncs(".ToTyp", s)
 
 	isCastFuncSet := func(ov castOverload) bool {
 		return ov.AssignFunc != nil


### PR DESCRIPTION
* Fixed a bug where the appropriate setters and getters were not being
generated for the casts.

* Fixed a bug where columns were not getting sliced, causing column
length mismatches.

Fixes #40461.

Release note: None