### PR TITLE
docs: Update roadmap link to the new wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Here’s a quick explainer video:
 ## Status
 
 CockroachDB is production-ready. See our
-[Roadmap](https://github.com/cockroachdb/cockroach/wiki/Roadmap) for a list of features planned or in development.
+[Roadmap](https://wiki.crdb.io/wiki/spaces/CRDB/overview) for a list of features planned or in development.
 
 ## Docs
 


### PR DESCRIPTION
This PR updates the "Roadmap" link to the new wiki link as it is currently linked to `https://github.com/cockroachdb/cockroach/wiki`.

This is referenced to issue #40452 which is similar to #2120.