### PR TITLE
sql: Reorder show ranges output to be clearer

### DIFF
--- a/pkg/sql/delegate/show_ranges.go
+++ b/pkg/sql/delegate/show_ranges.go
@@ -42,10 +42,12 @@ func (d *delegator) delegateShowRanges(n *tree.ShowRanges) (tree.Statement, erro
 			END AS end_key,
 			range_id,
 			range_size / 1000000 as range_size_mb,
-			replicas,
 			lease_holder,
-			replica_localities,
+    	gossip_nodes.locality as lease_holder_locality,
+			replicas,
+			replica_localities
 		FROM %[1]s.crdb_internal.ranges AS r
+	  LEFT JOIN crdb_internal.gossip_nodes ON lease_holder = node_id
 		WHERE database_name=%[2]s
 		ORDER BY table_name, r.start_key
 		`
@@ -71,10 +73,12 @@ SELECT
   CASE WHEN r.end_key >= x'%s' THEN NULL ELSE crdb_internal.pretty_key(r.end_key, 2) END AS end_key,
   range_id,
   range_size / 1000000 as range_size_mb,
-  replicas,
   lease_holder,
+  gossip_nodes.locality as lease_holder_locality,
+  replicas,
   replica_localities
 FROM crdb_internal.ranges AS r
+LEFT JOIN crdb_internal.gossip_nodes ON lease_holder = node_id
 WHERE (r.start_key < x'%s')
   AND (r.end_key   > x'%s') ORDER BY r.start_key
 `,


### PR DESCRIPTION
The output of show ranges had column orderings that at a quick glance
could lead to users making the wrong conclusions about their
partitioning setup. This PR adjusts the columns and adds more readily
accessible information about the lease_holder node's locality.

Fixes #40467.

Release note (sql change): Reorder columns in show ranges output