### PR TITLE
parser,tree: LIMIT ALL roundtrips parser

### DIFF
--- a/docs/generated/sql/bnf/limit_clause.bnf
+++ b/docs/generated/sql/bnf/limit_clause.bnf
@@ -1,5 +1,6 @@
 limit_clause ::=
-	'LIMIT' count
+	'LIMIT' 'ALL'
+	| 'LIMIT' a_expr
 	| 'FETCH' 'FIRST' count 'ROW' 'ONLY'
 	| 'FETCH' 'FIRST' count 'ROWS' 'ONLY'
 	| 'FETCH' 'NEXT' count 'ROW' 'ONLY'

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1036,7 +1036,8 @@ sort_clause ::=
 	'ORDER' 'BY' sortby_list
 
 limit_clause ::=
-	'LIMIT' select_limit_value
+	'LIMIT' 'ALL'
+	| 'LIMIT' a_expr
 	| 'FETCH' first_or_next opt_select_fetch_first_value row_or_rows 'ONLY'
 
 target_list ::=
@@ -1409,10 +1410,6 @@ opt_index_flags ::=
 
 sortby_list ::=
 	( sortby ) ( ( ',' sortby ) )*
-
-select_limit_value ::=
-	a_expr
-	| 'ALL'
 
 first_or_next ::=
 	'FIRST'

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -974,6 +974,9 @@ func TestParse(t *testing.T) {
 		{`SELECT a FROM t1, t2 AS OF SYSTEM TIME '2016-01-01'`},
 		{`SELECT a FROM t1 AS OF SYSTEM TIME -('a' || 'b')::INTERVAL`},
 
+		{`SELECT * FROM t LIMIT ALL`},
+		{`SELECT EXISTS ((((TABLE error FOR KEY SHARE)) LIMIT ALL FOR KEY SHARE)) AS is FROM ident`},
+
 		{`SELECT a FROM t LIMIT a`},
 		{`SELECT a FROM t OFFSET b`},
 		{`SELECT a FROM t LIMIT a OFFSET b`},
@@ -1346,17 +1349,15 @@ func TestParse(t *testing.T) {
 	}
 	var p parser.Parser // Verify that the same parser can be reused.
 	for _, d := range testData {
-		t.Run(d.sql, func(t *testing.T) {
-			stmts, err := p.Parse(d.sql)
-			if err != nil {
-				t.Fatalf("%s: expected success, but found %s", d.sql, err)
-			}
-			s := stmts.String()
-			if d.sql != s {
-				t.Errorf("expected \n%q\n, but found \n%q", d.sql, s)
-			}
-			sqlutils.VerifyStatementPrettyRoundtrip(t, d.sql)
-		})
+		stmts, err := p.Parse(d.sql)
+		if err != nil {
+			t.Fatalf("%s: expected success, but found %s", d.sql, err)
+		}
+		s := stmts.String()
+		if d.sql != s {
+			t.Errorf("expected \n%q\n, but found \n%q", d.sql, s)
+		}
+		sqlutils.VerifyStatementPrettyRoundtrip(t, d.sql)
 	}
 }
 

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -496,6 +496,8 @@ func (node *Limit) docTable(p *PrettyCfg) []pretty.TableRow {
 			e = StripParens(e)
 		}
 		res = append(res, p.row("LIMIT", p.Doc(e)))
+	} else if node.LimitAll {
+		res = append(res, p.row("LIMIT", pretty.Keyword("ALL")))
 	}
 	if node.Offset != nil {
 		e := node.Offset

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -698,6 +698,7 @@ func (node *Order) Equal(other *Order) bool {
 // Limit represents a LIMIT clause.
 type Limit struct {
 	Offset, Count Expr
+	LimitAll      bool
 }
 
 // Format implements the NodeFormatter interface.
@@ -706,6 +707,9 @@ func (node *Limit) Format(ctx *FmtCtx) {
 	if node.Count != nil {
 		ctx.WriteString("LIMIT ")
 		ctx.FormatNode(node.Count)
+		needSpace = true
+	} else if node.LimitAll {
+		ctx.WriteString("LIMIT ALL")
 		needSpace = true
 	}
 	if node.Offset != nil {


### PR DESCRIPTION
Previously, LIMIT ALL was thrown away as syntactic sugar of a non-limit.
This commit changes the tree to remember whether or not LIMIT ALL was
written, and output it if so.

Fixes #40458.

Release note: None