### PR TITLE
backport-2.0: libroach: disable rocksdb subcompactions

### DIFF
--- a/c-deps/libroach/options.cc
+++ b/c-deps/libroach/options.cc
@@ -159,9 +159,10 @@ rocksdb::Options DBMakeOptions(DBOptions db_opts) {
   // number of cpus. Always use at least 2 threads, otherwise
   // compactions and flushes may fight with each other.
   options.IncreaseParallelism(std::max(db_opts.num_cpu, 2));
-  // Enable subcompactions which will use multiple threads to speed up
-  // a single compaction. The value of num_cpu/2 has not been tuned.
-  options.max_subcompactions = std::max(db_opts.num_cpu / 2, 1);
+  // Disable subcompactions since they're a less stable feature, and not
+  // necessary for our workload, where frequent fsyncs naturally prevent
+  // foreground writes from getting too far ahead of compactions.
+  options.max_subcompactions = 1;
   options.comparator = &kComparator;
   options.create_if_missing = !db_opts.must_exist;
   options.info_log.reset(new DBLogger(db_opts.logging_enabled));


### PR DESCRIPTION
Backport 1/1 commits from #35210.

/cc @cockroachdb/release

---

The feature is not widely used so is not the most stable, especially
when combined with other uncommonly used features like range tombstones.
In my `bin/workload kv --read-percent 0` experiments it is not necessary
since the frequent foreground `fdatasync`s prevent compaction from
falling behind, with or without subcompactions enabled.

Release note: None
