### PR TITLE
debug-zip: include raw job and schema info

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -2089,6 +2089,8 @@ ORDER BY name ASC`)
 		assert.NoError(t, rows.Scan(&table))
 		tables = append(tables, table)
 	}
+	tables = append(tables, "system.jobs", "system.descriptor", "system.namespace")
+	sort.Strings(tables)
 
 	var exp []string
 	exp = append(exp, debugZipTablesPerNode...)
@@ -2127,6 +2129,9 @@ writing ` + os.DevNull + `
   debug/crdb_internal.cluster_sessions.txt
   debug/crdb_internal.cluster_settings.txt
   debug/crdb_internal.jobs.txt
+  debug/system.jobs.txt
+  debug/system.descriptor.txt
+  debug/system.namespace.txt
   debug/crdb_internal.kv_node_status.txt
   debug/crdb_internal.kv_store_status.txt
   debug/crdb_internal.schema_changes.txt

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -57,6 +57,9 @@ var debugZipTablesPerCluster = []string{
 	"crdb_internal.cluster_settings",
 
 	"crdb_internal.jobs",
+	"system.jobs",       // get the raw, restorable jobs records too.
+	"system.descriptor", // descriptors also contain job-like mutation state.
+	"system.namespace",
 
 	"crdb_internal.kv_node_status",
 	"crdb_internal.kv_store_status",


### PR DESCRIPTION
The debug.zip already contains some human-readable schema info scraped
from the admin API to help with query debugging, but this human-readable
form is pretty far removed from the low-level, raw metadata (for example
it doesn't include "dropped" tables that still exist).

Being able to restore (via some creative inserts) the actual descriptors
and jobs has proved instrumental in reproducing and troubleshooting some
issues with long-running jobs and schema changes. This adds those raw
tables, since they serve a different purpose from their human-readable
counterparts.

Release note: None