### PR TITLE
backport-19.1: opt: fix panic when building indirection exprs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/apply_join
+++ b/pkg/sql/logictest/testdata/logic_test/apply_join
@@ -268,3 +268,14 @@ LIMIT
     89:::INT8;
 ----
 true
+
+# Regression test for #40404.
+
+query I
+SELECT
+    (SELECT i FROM (SELECT * FROM generate_series(1, 1) AS g (i)) WHERE x[i] = 3)
+FROM
+    (VALUES (ARRAY[1]), (NULL)) AS v (x)
+----
+NULL
+NULL

--- a/pkg/sql/opt/exec/execbuilder/scalar_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar_builder.go
@@ -408,7 +408,7 @@ func (b *Builder) buildIndirection(
 		return nil, err
 	}
 
-	return tree.NewTypedIndirectionExpr(expr, index), nil
+	return tree.NewTypedIndirectionExpr(expr, index, scalar.DataType()), nil
 }
 
 func (b *Builder) buildCollate(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.TypedExpr, error) {

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -453,12 +453,12 @@ func NewTypedComparisonExprWithSubOp(
 }
 
 // NewTypedIndirectionExpr returns a new IndirectionExpr that is verified to be well-typed.
-func NewTypedIndirectionExpr(expr, index TypedExpr) *IndirectionExpr {
+func NewTypedIndirectionExpr(expr, index TypedExpr, typ types.T) *IndirectionExpr {
 	node := &IndirectionExpr{
 		Expr:        expr,
 		Indirection: ArraySubscripts{&ArraySubscript{Begin: index}},
 	}
-	node.typ = types.UnwrapType(expr.(TypedExpr).ResolvedType()).(types.TArray).Typ
+	node.typ = typ
 	return node
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #40469.

It turned out the test case I came up with to test this on master didn't apply here because it depended on a rule that was added post-19.1, so I wrote a new one (which is a little more gnarly since it depends on an apply join being executed). I confirmed this test case fails on 19.1.

/cc @cockroachdb/release

---

Previously, we would ask a built array datum to tell us its type when
building an IndirectionExpr. This was problematic when the datum was
NULL, since while the optimizer-level NULLs track their inferred type,
built DNulls do not, so we ended up not knowing the element type.

This is fixed by grabbing the type from the opt expression, rather than
the built datum.

Fixes #40404.
Fixes #37794.

Release note (bug fix): fixed an optimizer panic when building array
access expressions.
