### PR TITLE
sql: Fix translation bug in show ranges from database

### DIFF
--- a/pkg/sql/delegate/show_ranges.go
+++ b/pkg/sql/delegate/show_ranges.go
@@ -44,7 +44,7 @@ func (d *delegator) delegateShowRanges(n *tree.ShowRanges) (tree.Statement, erro
 			range_size / 1000000 as range_size_mb,
 			replicas,
 			lease_holder,
-			replica_localities,
+			replica_localities
 		FROM %[1]s.crdb_internal.ranges AS r
 		WHERE database_name=%[2]s
 		ORDER BY table_name, r.start_key

--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -356,3 +356,8 @@ start_key                          start_pretty                   end_key       
 [196 137 246 123]                  /Table/60/1/123                Ċ                                  /Table/60/2                    d              c                 ·           {1}       1
 Ċ                                  /Table/60/2                    [196 138 136]                      /Table/60/2/0                  d              c                 c_i_idx     {1}       1
 [196 138 136]                      /Table/60/2/0                  [255 255]                          /Max                           d              c                 c_i_idx     {1}       1
+
+# Due to some asynchronous conditions under when ranges get split, just validate
+# that the show ranges from database command gets translated correctly.
+statement ok
+SHOW RANGES FROM DATABASE test


### PR DESCRIPTION
Fixing a small translation bug in show ranges from database, and adding a test so it doesn't happen again.

Release note: None