### PR TITLE
sql: fix table lookup for drop index 

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1690,3 +1690,33 @@ COMMIT
 statement ok
 DROP TABLE t, t2
 
+subtest delete_index_in_other_table
+
+# Test setup
+statement ok
+BEGIN;
+
+statement ok
+CREATE TABLE a ();
+
+statement ok
+CREATE TABLE b ( key INT );
+
+statement ok
+CREATE INDEX b_idx ON b (key);
+
+statement ok
+COMMIT;
+
+# Try to delete an index in the same transaction
+statement ok
+BEGIN;
+
+statement ok
+DROP TABLE a;
+
+statement ok
+DROP INDEX b_idx CASCADE;
+
+statement ok
+COMMIT;

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -401,7 +401,7 @@ func findTableContainingIndex(
 	result = nil
 	for i := range tns {
 		tn := &tns[i]
-		tableDesc, err := ResolveMutableExistingObject(ctx, sc, tn, true, ResolveAnyDescType)
+		tableDesc, err := ResolveMutableExistingObject(ctx, sc, tn, false /*required*/, ResolveAnyDescType)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
Previously, when searching for the table relevant to a particular index
when dropping the index, we would fetch all object names and require that
all those tables exist. However, if a table was deleted in the same
transaction that table name would not be resolvable and we would error.
We already had a check to see if the table being looked up was nil, but
this check would not be used because the `required` flag was set to true.

This PR just sets the flag to false, and looks at moves on to the next
table if one of them no longer is resolvable.

Addresses #38768.

Release note (bug fix): Fix faulty error when trying to delete a table
and an unrelated index in the same transaction.