### PR TITLE
testutils: SucceedsSoonError shouldn't take a t

### DIFF
--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -3565,7 +3565,7 @@ func TestEvictionTokenCoalesce(t *testing.T) {
 		// in separate requests because there is no prior eviction token.
 		if _, ok := queriedMetaKeys.Load(string(rs.Key)); ok {
 			// Wait until we have two in-flight requests.
-			if err := testutils.SucceedsSoonError(t, func() error {
+			if err := testutils.SucceedsSoonError(func() error {
 				// Since the previously fetched RangeDescriptor was ["a", "d"), the request keys
 				// would be coalesced to "a".
 				numCalls := ds.rangeCache.lookupRequests.NumCalls(string(roachpb.RKey("a")) + ":false")

--- a/pkg/testutils/soon.go
+++ b/pkg/testutils/soon.go
@@ -31,7 +31,8 @@ const DefaultSucceedsSoonDuration = 45 * time.Second
 // function is invoked immediately at first and then successively with
 // an exponential backoff starting at 1ns and ending at around 1s.
 func SucceedsSoon(t testing.TB, fn func() error) {
-	if err := SucceedsSoonError(t, fn); err != nil {
+	t.Helper()
+	if err := SucceedsSoonError(fn); err != nil {
 		t.Fatalf("condition failed to evaluate within %s: %s\n%s",
 			DefaultSucceedsSoonDuration, err, string(debug.Stack()))
 	}
@@ -41,8 +42,7 @@ func SucceedsSoon(t testing.TB, fn func() error) {
 // error within a preset maximum duration. The function is invoked immediately
 // at first and then successively with an exponential backoff starting at 1ns
 // and ending at around 1s.
-func SucceedsSoonError(t testing.TB, fn func() error) error {
-	t.Helper()
+func SucceedsSoonError(fn func() error) error {
 	tBegin := timeutil.Now()
 	wrappedFn := func() error {
 		err := fn()


### PR DESCRIPTION
A function whose whole point was to not depend on a t was taking a t
because of a botched refactoring.

Release note: None