### PR TITLE
opt: fix functional deps and stats for WithScanExpr

### DIFF
--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -743,9 +743,7 @@ func (b *logicalPropsBuilder) buildWithProps(with *WithExpr, rel *props.Relation
 
 	// Statistics
 	// ----------
-	if !b.disableStats {
-		b.sb.statsFromChild(with, 1)
-	}
+	// Passed through from the call above to b.buildProps.
 }
 
 func (b *logicalPropsBuilder) buildWithScanProps(ref *WithScanExpr, rel *props.Relational) {
@@ -780,8 +778,9 @@ func (b *logicalPropsBuilder) buildWithScanProps(ref *WithScanExpr, rel *props.R
 	rel.FuncDeps = props.FuncDepSet{}
 	rel.FuncDeps.CopyFrom(&ref.BindingProps.FuncDeps)
 	for i := range ref.InCols {
-		rel.FuncDeps.AddSynthesizedCol(opt.MakeColSet(ref.InCols[i]), ref.OutCols[i])
+		rel.FuncDeps.AddEquivalency(ref.InCols[i], ref.OutCols[i])
 	}
+	rel.FuncDeps.ProjectCols(ref.OutCols.ToSet())
 
 	// Cardinality
 	// -----------
@@ -789,7 +788,10 @@ func (b *logicalPropsBuilder) buildWithScanProps(ref *WithScanExpr, rel *props.R
 
 	// Statistics
 	// ----------
-	// Copied from the referenced expression.
+	rel.Stats = props.Statistics{}
+	if !b.disableStats {
+		b.sb.buildWithScan(ref, rel)
+	}
 }
 
 func (b *logicalPropsBuilder) buildExplainProps(explain *ExplainExpr, rel *props.Relational) {

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -216,6 +216,9 @@ func (sb *statisticsBuilder) availabilityFromInput(e RelExpr) bool {
 	case *ZigzagJoinExpr:
 		ensureZigzagJoinInputProps(t, sb)
 		return t.leftProps.Stats.Available
+
+	case *WithScanExpr:
+		return t.BindingProps.Stats.Available
 	}
 
 	available := true
@@ -366,6 +369,9 @@ func (sb *statisticsBuilder) colStat(colSet opt.ColSet, e RelExpr) *props.Column
 	case opt.ProjectSetOp:
 		return sb.colStatProjectSet(colSet, e.(*ProjectSetExpr))
 
+	case opt.WithScanOp:
+		return sb.colStatWithScan(colSet, e.(*WithScanExpr))
+
 	case opt.InsertOp, opt.UpdateOp, opt.UpsertOp, opt.DeleteOp:
 		return sb.colStatMutation(colSet, e)
 
@@ -378,13 +384,6 @@ func (sb *statisticsBuilder) colStat(colSet opt.ColSet, e RelExpr) *props.Column
 
 	case opt.WithOp:
 		return sb.colStat(colSet, e.Child(1).(RelExpr))
-
-	case opt.WithScanOp:
-		// This is tricky, since if we deferred to the expression being referenced,
-		// the computation of stats for a WithScan would depend on something
-		// outside of the expression itself. Just call it unknown for now.
-		// TODO(justin): find a real solution for this.
-		return sb.colStatUnknown(colSet, e.Relational())
 
 	case opt.FakeRelOp:
 		panic(errors.AssertionFailedf("FakeRelOp does not contain col stat for %v", colSet))
@@ -2098,6 +2097,42 @@ func (sb *statisticsBuilder) colStatProjectSet(
 	if colSet.SubsetOf(projectSet.Relational().NotNullCols) {
 		colStat.NullCount = 0
 	}
+	sb.finalizeFromRowCount(colStat, s.RowCount)
+	return colStat
+}
+
+// +----------+
+// | WithScan |
+// +----------+
+
+func (sb *statisticsBuilder) buildWithScan(withScan *WithScanExpr, relProps *props.Relational) {
+	s := &relProps.Stats
+	if zeroCardinality := s.Init(relProps); zeroCardinality {
+		// Short cut if cardinality is 0.
+		return
+	}
+	s.Available = sb.availabilityFromInput(withScan)
+
+	inputStats := withScan.BindingProps.Stats
+
+	s.RowCount = inputStats.RowCount
+	sb.finalizeFromCardinality(relProps)
+}
+
+func (sb *statisticsBuilder) colStatWithScan(
+	colSet opt.ColSet, withScan *WithScanExpr,
+) *props.ColumnStatistic {
+	s := &withScan.Relational().Stats
+	withProps := withScan.BindingProps
+	inColSet := translateColSet(colSet, withScan.OutCols, withScan.InCols)
+
+	// TODO(rytaft): This would be more accurate if we could access the WithExpr
+	// itself.
+	inColStat := sb.colStatLeaf(inColSet, &withProps.Stats, &withProps.FuncDeps, withProps.NotNullCols)
+
+	colStat, _ := s.ColStats.Add(colSet)
+	colStat.DistinctCount = inColStat.DistinctCount
+	colStat.NullCount = inColStat.NullCount
 	sb.finalizeFromRowCount(colStat, s.RowCount)
 	return colStat
 }

--- a/pkg/sql/opt/memo/testdata/logprops/with
+++ b/pkg/sql/opt/memo/testdata/logprops/with
@@ -7,8 +7,8 @@ WITH foo AS (SELECT * FROM xy) SELECT * FROM foo
 ----
 with &1 (foo)
  ├── columns: x:3(int!null) y:4(int)
- ├── key: (1)
- ├── fd: (1)-->(2,3), (2)-->(4)
+ ├── key: (3)
+ ├── fd: (3)-->(4)
  ├── scan xy
  │    ├── columns: xy.x:1(int!null) xy.y:2(int)
  │    ├── key: (1)
@@ -20,8 +20,8 @@ with &1 (foo)
       ├── mapping:
       │    ├──  xy.x:1(int) => x:3(int)
       │    └──  xy.y:2(int) => y:4(int)
-      ├── key: (1)
-      └── fd: (1)-->(2,3), (2)-->(4)
+      ├── key: (3)
+      └── fd: (3)-->(4)
 
 # Side effects should be propagated up to the top-level from the Binding side
 # of a WITH.
@@ -33,7 +33,7 @@ with &1 (foo)
  ├── cardinality: [1 - 1]
  ├── side-effects
  ├── key: ()
- ├── fd: ()-->(1), (1)-->(2)
+ ├── fd: ()-->(2)
  ├── project
  │    ├── columns: "?column?":1(decimal)
  │    ├── cardinality: [1 - 1]
@@ -55,7 +55,7 @@ with &1 (foo)
       │    └──  "?column?":1(decimal) => "?column?":2(decimal)
       ├── cardinality: [1 - 1]
       ├── key: ()
-      └── fd: ()-->(1), (1)-->(2)
+      └── fd: ()-->(2)
 
 # Side effects should be propagated up to the top-level from the Input side of
 # a With.
@@ -93,7 +93,7 @@ with &1 (foo)
       │    │    └──  "?column?":1(int) => "?column?":2(int)
       │    ├── cardinality: [1 - 1]
       │    ├── key: ()
-      │    └── fd: ()-->(1), (1)-->(2)
+      │    └── fd: ()-->(2)
       └── projections
            └── div [type=decimal, side-effects]
                 ├── const: 1 [type=int]
@@ -134,7 +134,7 @@ with &1 (foo)
       │    │    └──  int8:1(int) => int8:2(int)
       │    ├── cardinality: [1 - 1]
       │    ├── key: ()
-      │    └── fd: ()-->(1), (1)-->(2)
+      │    └── fd: ()-->(2)
       └── projections
            └── const: 1 [type=int]
 
@@ -162,7 +162,7 @@ inner-join-apply
  │    ├── outer: (1)
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
- │    ├── fd: ()-->(2), (2)-->(3)
+ │    ├── fd: ()-->(3)
  │    ├── project
  │    │    ├── columns: "?column?":2(int)
  │    │    ├── outer: (1)
@@ -184,5 +184,5 @@ inner-join-apply
  │         │    └──  "?column?":2(int) => "?column?":3(int)
  │         ├── cardinality: [1 - 1]
  │         ├── key: ()
- │         └── fd: ()-->(2), (2)-->(3)
+ │         └── fd: ()-->(3)
  └── filters (true)

--- a/pkg/sql/opt/memo/testdata/stats/groupby
+++ b/pkg/sql/opt/memo/testdata/stats/groupby
@@ -468,37 +468,37 @@ GROUP BY q.b
 with &1 (q)
  ├── columns: "?column?":6(int!null)
  ├── cardinality: [0 - 3]
- ├── stats: [rows=1]
+ ├── stats: [rows=0.27]
  ├── fd: ()-->(6)
  ├── values
  │    ├── columns: column1:1(bool!null) column2:2(int)
  │    ├── cardinality: [3 - 3]
- │    ├── stats: [rows=3]
+ │    ├── stats: [rows=3, distinct(1)=0.3, null(1)=0, distinct(2)=0.3, null(2)=0.03]
  │    ├── (true, NULL) [type=tuple{bool, int}]
  │    ├── (false, NULL) [type=tuple{bool, int}]
  │    └── (true, 5) [type=tuple{bool, int}]
  └── project
       ├── columns: "?column?":6(int!null)
       ├── cardinality: [0 - 3]
-      ├── stats: [rows=1]
+      ├── stats: [rows=0.27]
       ├── fd: ()-->(6)
       ├── select
       │    ├── columns: b:4(int) bool_or:5(bool!null)
       │    ├── cardinality: [0 - 3]
-      │    ├── stats: [rows=1, distinct(5)=1, null(5)=0]
+      │    ├── stats: [rows=0.27, distinct(5)=0.27, null(5)=0]
       │    ├── key: (4)
       │    ├── fd: ()-->(5)
       │    ├── group-by
       │    │    ├── columns: b:4(int) bool_or:5(bool)
       │    │    ├── grouping columns: b:4(int)
       │    │    ├── cardinality: [0 - 3]
-      │    │    ├── stats: [rows=1, distinct(4)=1, null(4)=0, distinct(5)=1, null(5)=0]
+      │    │    ├── stats: [rows=0.3, distinct(4)=0.3, null(4)=0.03, distinct(5)=0.3, null(5)=0.03]
       │    │    ├── key: (4)
       │    │    ├── fd: (4)-->(5)
       │    │    ├── select
       │    │    │    ├── columns: a:3(bool!null) b:4(int)
       │    │    │    ├── cardinality: [0 - 3]
-      │    │    │    ├── stats: [rows=1, distinct(3)=1, null(3)=0, distinct(4)=1, null(4)=0]
+      │    │    │    ├── stats: [rows=3, distinct(3)=0.3, null(3)=0, distinct(4)=0.3, null(4)=0.03]
       │    │    │    ├── fd: ()-->(3)
       │    │    │    ├── with-scan &1 (q)
       │    │    │    │    ├── columns: a:3(bool!null) b:4(int)
@@ -506,8 +506,7 @@ with &1 (q)
       │    │    │    │    │    ├──  column1:1(bool) => a:3(bool)
       │    │    │    │    │    └──  column2:2(int) => b:4(int)
       │    │    │    │    ├── cardinality: [3 - 3]
-      │    │    │    │    ├── stats: [rows=3]
-      │    │    │    │    └── fd: (1)-->(3), (2)-->(4)
+      │    │    │    │    └── stats: [rows=3, distinct(3)=0.3, null(3)=0, distinct(4)=0.3, null(4)=0.03]
       │    │    │    └── filters
       │    │    │         └── variable: a [type=bool, outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
       │    │    └── aggregations

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -542,11 +542,11 @@ WHERE
 ----
 with &1 (subq)
  ├── columns: "?column?":26(int!null)
- ├── stats: [rows=1]
+ ├── stats: [rows=165000]
  ├── fd: ()-->(26)
  ├── project
  │    ├── columns: col1:23(bool) tab1.g:18(int4!null)
- │    ├── stats: [rows=333333.333]
+ │    ├── stats: [rows=333333.333, distinct(18)=33333.3333, null(18)=0, distinct(23)=2, null(23)=3333.33333]
  │    ├── inner-join (hash)
  │    │    ├── columns: tab0.e:5(varchar) tab0.f:6("char") tab0.h:8(varchar) tab0.j:10(float!null) tab1.e:16(varchar) tab1.f:17("char") tab1.g:18(int4!null) tab1.j:21(float!null)
  │    │    ├── stats: [rows=333333.333, distinct(10)=100, null(10)=0, distinct(18)=100, null(18)=0, distinct(21)=100, null(21)=0]
@@ -562,19 +562,18 @@ with &1 (subq)
  │         └── CASE WHEN ilike_escape(regexp_replace(tab0.h, tab1.e, tab0.f, tab0.e::STRING), tab1.f, '') THEN true ELSE false END [type=bool, outer=(5,6,8,16,17)]
  └── project
       ├── columns: "?column?":26(int!null)
-      ├── stats: [rows=1]
+      ├── stats: [rows=165000]
       ├── fd: ()-->(26)
       ├── select
       │    ├── columns: col0:24(int4!null) col1:25(bool!null)
-      │    ├── stats: [rows=1, distinct(24)=1, null(24)=0, distinct(25)=1, null(25)=0]
+      │    ├── stats: [rows=165000, distinct(24)=33300.7812, null(24)=0, distinct(25)=1, null(25)=0]
       │    ├── fd: ()-->(25)
       │    ├── with-scan &1 (subq)
       │    │    ├── columns: col0:24(int4!null) col1:25(bool)
       │    │    ├── mapping:
       │    │    │    ├──  tab1.g:18(int4) => col0:24(int4)
       │    │    │    └──  col1:23(bool) => col1:25(bool)
-      │    │    ├── stats: [rows=333333.333]
-      │    │    └── fd: (18)-->(24), (23)-->(25)
+      │    │    └── stats: [rows=333333.333, distinct(24)=33333.3333, null(24)=0, distinct(25)=2, null(25)=3333.33333]
       │    └── filters
       │         └── variable: col1 [type=bool, outer=(25), constraints=(/25: [/true - /true]; tight), fd=()-->(25)]
       └── projections

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -1376,11 +1376,11 @@ SELECT x FROM t WHERE x
 ----
 with &1 (t)
  ├── columns: x:6(bool!null)
- ├── stats: [rows=1, distinct(6)=1, null(6)=0]
+ ├── stats: [rows=1.98e+20, distinct(6)=1, null(6)=0]
  ├── fd: ()-->(6)
  ├── project
  │    ├── columns: x:5(bool)
- │    ├── stats: [rows=4e+20]
+ │    ├── stats: [rows=4e+20, distinct(5)=2, null(5)=4e+18]
  │    ├── left-join (hash)
  │    │    ├── columns: t1.x:1(bool) t2.x:3(bool)
  │    │    ├── stats: [rows=4e+20]
@@ -1395,14 +1395,13 @@ with &1 (t)
  │         └── (t1.x::INT8 << 5533)::BOOL OR t2.x [type=bool, outer=(1,3)]
  └── select
       ├── columns: x:6(bool!null)
-      ├── stats: [rows=1, distinct(6)=1, null(6)=0]
+      ├── stats: [rows=1.98e+20, distinct(6)=1, null(6)=0]
       ├── fd: ()-->(6)
       ├── with-scan &1 (t)
       │    ├── columns: x:6(bool)
       │    ├── mapping:
       │    │    └──  x:5(bool) => x:6(bool)
-      │    ├── stats: [rows=4e+20]
-      │    └── fd: (5)-->(6)
+      │    └── stats: [rows=4e+20, distinct(6)=2, null(6)=4e+18]
       └── filters
            └── variable: x [type=bool, outer=(6), constraints=(/6: [/true - /true]; tight), fd=()-->(6)]
 

--- a/pkg/sql/opt/memo/testdata/stats/with
+++ b/pkg/sql/opt/memo/testdata/stats/with
@@ -37,11 +37,11 @@ WITH foo AS (SELECT * FROM a) SELECT * FROM foo
 with &1 (foo)
  ├── columns: x:4(int!null) y:5(int) s:6(string)
  ├── stats: [rows=5000]
- ├── key: (1)
- ├── fd: (1)-->(2-4), (2)-->(5), (3)-->(6)
+ ├── key: (4)
+ ├── fd: (4)-->(5,6)
  ├── scan a
  │    ├── columns: a.x:1(int!null) a.y:2(int) a.s:3(string)
- │    ├── stats: [rows=5000]
+ │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=500, null(2)=50, distinct(3)=500, null(3)=50]
  │    ├── key: (1)
  │    └── fd: (1)-->(2,3)
  └── with-scan &1 (foo)
@@ -50,6 +50,128 @@ with &1 (foo)
       │    ├──  a.x:1(int) => x:4(int)
       │    ├──  a.y:2(int) => y:5(int)
       │    └──  a.s:3(string) => s:6(string)
-      ├── stats: [rows=5000]
-      ├── key: (1)
-      └── fd: (1)-->(2-4), (2)-->(5), (3)-->(6)
+      ├── stats: [rows=5000, distinct(4)=5000, null(4)=0, distinct(5)=500, null(5)=50, distinct(6)=500, null(6)=50]
+      ├── key: (4)
+      └── fd: (4)-->(5,6)
+
+# Regression test for #40296.
+opt
+WITH
+	t0 AS ((VALUES (0, 0:::OID, NULL, '')) UNION (VALUES (NULL, 0:::OID,'1970-09-08'::DATE, NULL)))
+SELECT
+	NULL
+FROM
+	a, t0
+WHERE
+	EXISTS(
+		WITH
+			t1 AS (SELECT NULL)
+		SELECT
+			t0.column2, a.y
+	);
+----
+with &1 (t0)
+ ├── columns: "?column?":27(unknown)
+ ├── stats: [rows=1e-06]
+ ├── fd: ()-->(27)
+ ├── union
+ │    ├── columns: column1:9(int) column2:10(oid!null) column3:11(date) column4:12(string)
+ │    ├── left columns: column1:1(int) column2:2(oid) column3:13(date) column4:4(string)
+ │    ├── right columns: column1:5(int) column2:6(oid) column3:7(date) column4:8(string)
+ │    ├── cardinality: [1 - 2]
+ │    ├── stats: [rows=2, distinct(10)=0.2, null(10)=0, distinct(9-12)=2, null(9-12)=2]
+ │    ├── key: (9-12)
+ │    ├── values
+ │    │    ├── columns: column1:1(int!null) column2:2(oid!null) column4:4(string!null) column3:13(date)
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── stats: [rows=1, distinct(1,2,4,13)=1, null(1,2,4,13)=1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,2,4,13)
+ │    │    └── (0, 0, '', NULL) [type=tuple{int, oid, string, date}]
+ │    └── values
+ │         ├── columns: column1:5(int) column2:6(oid!null) column3:7(date!null) column4:8(string)
+ │         ├── cardinality: [1 - 1]
+ │         ├── stats: [rows=1, distinct(5-8)=1, null(5-8)=1]
+ │         ├── key: ()
+ │         ├── fd: ()-->(5-8)
+ │         └── (NULL, 0, '1970-09-08', NULL) [type=tuple{int, oid, date, string}]
+ └── project
+      ├── columns: "?column?":27(unknown)
+      ├── stats: [rows=1e-06]
+      ├── fd: ()-->(27)
+      ├── select
+      │    ├── columns: x:14(int!null) column1:17(int) column2:18(oid!null) column3:19(date) column4:20(string) true_agg:25(bool!null)
+      │    ├── stats: [rows=1e-06, distinct(14)=1e-06, null(14)=0, distinct(18)=1e-06, null(18)=0, distinct(25)=1e-06, null(25)=0]
+      │    ├── key: (14,17-20)
+      │    ├── fd: (14,17-20)-->(25)
+      │    ├── group-by
+      │    │    ├── columns: x:14(int!null) column1:17(int) column2:18(oid!null) column3:19(date) column4:20(string) true_agg:25(bool)
+      │    │    ├── grouping columns: x:14(int!null) column1:17(int) column2:18(oid!null) column3:19(date) column4:20(string)
+      │    │    ├── stats: [rows=10000, distinct(14)=5000, null(14)=0, distinct(18)=0.2, null(18)=0, distinct(25)=10000, null(25)=10000, distinct(14,17-20)=10000, null(14,17-20)=10000]
+      │    │    ├── key: (14,17-20)
+      │    │    ├── fd: (14,17-20)-->(25)
+      │    │    ├── project
+      │    │    │    ├── columns: true:24(bool!null) x:14(int!null) column1:17(int) column2:18(oid!null) column3:19(date) column4:20(string)
+      │    │    │    ├── stats: [rows=10000, distinct(14)=5000, null(14)=0, distinct(18)=0.2, null(18)=0, distinct(14,17-20)=10000, null(14,17-20)=10000]
+      │    │    │    ├── key: (14,17-20)
+      │    │    │    ├── fd: ()-->(24)
+      │    │    │    ├── inner-join-apply
+      │    │    │    │    ├── columns: x:14(int!null) a.y:15(int) column1:17(int) column2:18(oid!null) column3:19(date) column4:20(string) column2:22(oid) y:23(int)
+      │    │    │    │    ├── stats: [rows=10000, distinct(14)=5000, null(14)=0, distinct(18)=0.2, null(18)=0, distinct(14,17-20)=10000, null(14,17-20)=10000]
+      │    │    │    │    ├── key: (14,17-20)
+      │    │    │    │    ├── fd: (14)-->(15), (14,17-20)-->(22,23)
+      │    │    │    │    ├── scan a
+      │    │    │    │    │    ├── columns: x:14(int!null) a.y:15(int)
+      │    │    │    │    │    ├── stats: [rows=5000, distinct(14)=5000, null(14)=0]
+      │    │    │    │    │    ├── key: (14)
+      │    │    │    │    │    └── fd: (14)-->(15)
+      │    │    │    │    ├── inner-join-apply
+      │    │    │    │    │    ├── columns: column1:17(int) column2:18(oid!null) column3:19(date) column4:20(string) column2:22(oid) y:23(int)
+      │    │    │    │    │    ├── outer: (15)
+      │    │    │    │    │    ├── cardinality: [1 - 2]
+      │    │    │    │    │    ├── stats: [rows=2, distinct(18)=0.2, null(18)=0, distinct(17-20)=2, null(17-20)=2]
+      │    │    │    │    │    ├── key: (17-20)
+      │    │    │    │    │    ├── fd: (17-20)-->(22,23)
+      │    │    │    │    │    ├── with-scan &1 (t0)
+      │    │    │    │    │    │    ├── columns: column1:17(int) column2:18(oid!null) column3:19(date) column4:20(string)
+      │    │    │    │    │    │    ├── mapping:
+      │    │    │    │    │    │    │    ├──  column1:9(int) => column1:17(int)
+      │    │    │    │    │    │    │    ├──  column2:10(oid) => column2:18(oid)
+      │    │    │    │    │    │    │    ├──  column3:11(date) => column3:19(date)
+      │    │    │    │    │    │    │    └──  column4:12(string) => column4:20(string)
+      │    │    │    │    │    │    ├── cardinality: [1 - 2]
+      │    │    │    │    │    │    ├── stats: [rows=2, distinct(18)=0.2, null(18)=0, distinct(17-20)=2, null(17-20)=2]
+      │    │    │    │    │    │    └── key: (17-20)
+      │    │    │    │    │    ├── with &2 (t1)
+      │    │    │    │    │    │    ├── columns: column2:22(oid) y:23(int)
+      │    │    │    │    │    │    ├── outer: (15,18)
+      │    │    │    │    │    │    ├── cardinality: [1 - 1]
+      │    │    │    │    │    │    ├── stats: [rows=1]
+      │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    ├── fd: ()-->(22,23)
+      │    │    │    │    │    │    ├── values
+      │    │    │    │    │    │    │    ├── columns: "?column?":21(unknown)
+      │    │    │    │    │    │    │    ├── cardinality: [1 - 1]
+      │    │    │    │    │    │    │    ├── stats: [rows=1]
+      │    │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    │    ├── fd: ()-->(21)
+      │    │    │    │    │    │    │    └── (NULL,) [type=tuple{unknown}]
+      │    │    │    │    │    │    └── values
+      │    │    │    │    │    │         ├── columns: column2:22(oid) y:23(int)
+      │    │    │    │    │    │         ├── outer: (15,18)
+      │    │    │    │    │    │         ├── cardinality: [1 - 1]
+      │    │    │    │    │    │         ├── stats: [rows=1]
+      │    │    │    │    │    │         ├── key: ()
+      │    │    │    │    │    │         ├── fd: ()-->(22,23)
+      │    │    │    │    │    │         └── (column2, a.y) [type=tuple{oid, int}]
+      │    │    │    │    │    └── filters (true)
+      │    │    │    │    └── filters (true)
+      │    │    │    └── projections
+      │    │    │         └── true [type=bool]
+      │    │    └── aggregations
+      │    │         └── const-not-null-agg [type=bool, outer=(24)]
+      │    │              └── variable: true [type=bool]
+      │    └── filters
+      │         └── true_agg IS NOT NULL [type=bool, outer=(25), constraints=(/25: (/NULL - ]; tight)]
+      └── projections
+           └── null [type=unknown]

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -180,7 +180,7 @@ insert "order"
  ├── values
  │    ├── columns: column1:9(int!null) column2:10(int!null) column3:11(int!null) column4:12(int!null) column5:13(timestamp!null) column6:14(int!null) column7:15(int!null) column16:16(int)
  │    ├── cardinality: [1 - 1]
- │    ├── stats: [rows=1]
+ │    ├── stats: [rows=1, distinct(10)=1, null(10)=0, distinct(11)=1, null(11)=0, distinct(12)=1, null(12)=0]
  │    ├── cost: 0.02
  │    ├── key: ()
  │    ├── fd: ()-->(9-16)
@@ -203,7 +203,7 @@ insert "order"
                 ├── stats: [rows=1e-10]
                 ├── cost: 6.26
                 ├── key: ()
-                ├── fd: ()-->(9-16), (11)-->(38), (10)-->(39), (12)-->(40)
+                ├── fd: ()-->(38-40)
                 ├── with-scan &1
                 │    ├── columns: column3:38(int!null) column2:39(int!null) column4:40(int!null)
                 │    ├── mapping:
@@ -211,10 +211,10 @@ insert "order"
                 │    │    ├──  column2:10(int) => column2:39(int)
                 │    │    └──  column4:12(int) => column4:40(int)
                 │    ├── cardinality: [1 - 1]
-                │    ├── stats: [rows=1]
+                │    ├── stats: [rows=1, distinct(38)=1, null(38)=0, distinct(39)=1, null(39)=0, distinct(40)=1, null(40)=0]
                 │    ├── cost: 0.01
                 │    ├── key: ()
-                │    └── fd: ()-->(9-16), (11)-->(38), (10)-->(39), (12)-->(40)
+                │    └── fd: ()-->(38-40)
                 └── filters (true)
 
 opt format=hide-qual
@@ -234,7 +234,7 @@ insert new_order
  ├── values
  │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
  │    ├── cardinality: [1 - 1]
- │    ├── stats: [rows=1]
+ │    ├── stats: [rows=1, distinct(4)=1, null(4)=0, distinct(5)=1, null(5)=0, distinct(6)=1, null(6)=0]
  │    ├── cost: 0.02
  │    ├── key: ()
  │    ├── fd: ()-->(4-6)
@@ -252,7 +252,7 @@ insert new_order
                 ├── stats: [rows=1e-10]
                 ├── cost: 6.13
                 ├── key: ()
-                ├── fd: ()-->(4-6), (6)-->(15), (5)-->(16), (4)-->(17)
+                ├── fd: ()-->(15-17)
                 ├── with-scan &1
                 │    ├── columns: column3:15(int!null) column2:16(int!null) column1:17(int!null)
                 │    ├── mapping:
@@ -260,10 +260,10 @@ insert new_order
                 │    │    ├──  column2:5(int) => column2:16(int)
                 │    │    └──  column1:4(int) => column1:17(int)
                 │    ├── cardinality: [1 - 1]
-                │    ├── stats: [rows=1]
+                │    ├── stats: [rows=1, distinct(15)=1, null(15)=0, distinct(16)=1, null(16)=0, distinct(17)=1, null(17)=0]
                 │    ├── cost: 0.01
                 │    ├── key: ()
-                │    └── fd: ()-->(4-6), (6)-->(15), (5)-->(16), (4)-->(17)
+                │    └── fd: ()-->(15-17)
                 └── filters (true)
 
 opt format=hide-qual
@@ -701,7 +701,7 @@ insert order_line
  ├── project
  │    ├── columns: ol_amount:21(decimal) column20:20(timestamp) column1:11(int!null) column2:12(int!null) column3:13(int!null) column4:14(int!null) column5:15(int!null) column6:16(int!null) column7:17(int!null) column9:19(string!null)
  │    ├── cardinality: [6 - 6]
- │    ├── stats: [rows=6]
+ │    ├── stats: [rows=6, distinct(11)=0.6, null(11)=0, distinct(12)=0.6, null(12)=0, distinct(13)=0.6, null(13)=0, distinct(15)=0.6, null(15)=0, distinct(16)=0.6, null(16)=0]
  │    ├── cost: 0.26
  │    ├── fd: ()-->(20)
  │    ├── prune: (11-17,19-21)
@@ -784,7 +784,6 @@ insert order_line
       │         ├── cardinality: [0 - 6]
       │         ├── stats: [rows=1e-10]
       │         ├── cost: 36.68
-      │         ├── fd: ()-->(20), (13)-->(30), (12)-->(31), (11)-->(32)
       │         ├── with-scan &1
       │         │    ├── columns: column3:30(int!null) column2:31(int!null) column1:32(int!null)
       │         │    ├── mapping:
@@ -792,9 +791,8 @@ insert order_line
       │         │    │    ├──  column2:12(int) => column2:31(int)
       │         │    │    └──  column1:11(int) => column1:32(int)
       │         │    ├── cardinality: [6 - 6]
-      │         │    ├── stats: [rows=6]
-      │         │    ├── cost: 0.01
-      │         │    └── fd: ()-->(20), (13)-->(30), (12)-->(31), (11)-->(32)
+      │         │    ├── stats: [rows=6, distinct(30)=0.6, null(30)=0, distinct(31)=0.6, null(31)=0, distinct(32)=0.6, null(32)=0]
+      │         │    └── cost: 0.01
       │         └── filters (true)
       └── f-k-checks-item: order_line(ol_supply_w_id,ol_i_id) -> stock(s_w_id,s_i_id)
            └── anti-join (lookup stock@stock_item_fk_idx)
@@ -803,16 +801,14 @@ insert order_line
                 ├── cardinality: [0 - 6]
                 ├── stats: [rows=1e-10]
                 ├── cost: 36.1061434
-                ├── fd: ()-->(20), (16)-->(50), (15)-->(51)
                 ├── with-scan &1
                 │    ├── columns: column6:50(int!null) column5:51(int!null)
                 │    ├── mapping:
                 │    │    ├──  column6:16(int) => column6:50(int)
                 │    │    └──  column5:15(int) => column5:51(int)
                 │    ├── cardinality: [6 - 6]
-                │    ├── stats: [rows=6]
-                │    ├── cost: 0.01
-                │    └── fd: ()-->(20), (16)-->(50), (15)-->(51)
+                │    ├── stats: [rows=6, distinct(50)=0.6, null(50)=0, distinct(51)=0.6, null(51)=0]
+                │    └── cost: 0.01
                 └── filters (true)
 
 # --------------------------------------------------
@@ -1106,7 +1102,7 @@ insert history
  │    ├── columns: column1:10(int!null) column2:11(int!null) column3:12(int!null) column4:13(int!null) column5:14(int!null) column7:16(timestamp!null) column8:17(string!null) column18:18(uuid) h_amount:19(decimal)
  │    ├── cardinality: [1 - 1]
  │    ├── side-effects
- │    ├── stats: [rows=1]
+ │    ├── stats: [rows=1, distinct(10)=1, null(10)=0, distinct(11)=1, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=1, null(13)=0, distinct(14)=1, null(14)=0]
  │    ├── cost: 0.02
  │    ├── key: ()
  │    ├── fd: ()-->(10-14,16-19)
@@ -1132,7 +1128,7 @@ insert history
       │         ├── stats: [rows=1e-10]
       │         ├── cost: 6.26
       │         ├── key: ()
-      │         ├── fd: ()-->(10-14,16-19), (12)-->(41), (11)-->(42), (10)-->(43)
+      │         ├── fd: ()-->(41-43)
       │         ├── with-scan &1
       │         │    ├── columns: column3:41(int!null) column2:42(int!null) column1:43(int!null)
       │         │    ├── mapping:
@@ -1140,10 +1136,10 @@ insert history
       │         │    │    ├──  column2:11(int) => column2:42(int)
       │         │    │    └──  column1:10(int) => column1:43(int)
       │         │    ├── cardinality: [1 - 1]
-      │         │    ├── stats: [rows=1]
+      │         │    ├── stats: [rows=1, distinct(41)=1, null(41)=0, distinct(42)=1, null(42)=0, distinct(43)=1, null(43)=0]
       │         │    ├── cost: 0.01
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(10-14,16-19), (12)-->(41), (11)-->(42), (10)-->(43)
+      │         │    └── fd: ()-->(41-43)
       │         └── filters (true)
       └── f-k-checks-item: history(h_w_id,h_d_id) -> district(d_w_id,d_id)
            └── anti-join (lookup district)
@@ -1153,17 +1149,17 @@ insert history
                 ├── stats: [rows=1e-10]
                 ├── cost: 6.15
                 ├── key: ()
-                ├── fd: ()-->(10-14,16-19), (14)-->(55), (13)-->(56)
+                ├── fd: ()-->(55,56)
                 ├── with-scan &1
                 │    ├── columns: column5:55(int!null) column4:56(int!null)
                 │    ├── mapping:
                 │    │    ├──  column5:14(int) => column5:55(int)
                 │    │    └──  column4:13(int) => column4:56(int)
                 │    ├── cardinality: [1 - 1]
-                │    ├── stats: [rows=1]
+                │    ├── stats: [rows=1, distinct(55)=1, null(55)=0, distinct(56)=1, null(56)=0]
                 │    ├── cost: 0.01
                 │    ├── key: ()
-                │    └── fd: ()-->(10-14,16-19), (14)-->(55), (13)-->(56)
+                │    └── fd: ()-->(55,56)
                 └── filters (true)
 
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
@@ -183,7 +183,7 @@ insert "order"
  ├── values
  │    ├── columns: column1:9(int!null) column2:10(int!null) column3:11(int!null) column4:12(int!null) column5:13(timestamp!null) column6:14(int!null) column7:15(int!null) column16:16(int)
  │    ├── cardinality: [1 - 1]
- │    ├── stats: [rows=1]
+ │    ├── stats: [rows=1, distinct(10)=1, null(10)=0, distinct(11)=1, null(11)=0, distinct(12)=1, null(12)=0]
  │    ├── cost: 0.02
  │    ├── key: ()
  │    ├── fd: ()-->(9-16)
@@ -206,7 +206,7 @@ insert "order"
                 ├── stats: [rows=1e-10]
                 ├── cost: 6.26
                 ├── key: ()
-                ├── fd: ()-->(9-16), (11)-->(38), (10)-->(39), (12)-->(40)
+                ├── fd: ()-->(38-40)
                 ├── with-scan &1
                 │    ├── columns: column3:38(int!null) column2:39(int!null) column4:40(int!null)
                 │    ├── mapping:
@@ -214,10 +214,10 @@ insert "order"
                 │    │    ├──  column2:10(int) => column2:39(int)
                 │    │    └──  column4:12(int) => column4:40(int)
                 │    ├── cardinality: [1 - 1]
-                │    ├── stats: [rows=1]
+                │    ├── stats: [rows=1, distinct(38)=1, null(38)=0, distinct(39)=1, null(39)=0, distinct(40)=1, null(40)=0]
                 │    ├── cost: 0.01
                 │    ├── key: ()
-                │    └── fd: ()-->(9-16), (11)-->(38), (10)-->(39), (12)-->(40)
+                │    └── fd: ()-->(38-40)
                 └── filters (true)
 
 opt format=hide-qual
@@ -237,7 +237,7 @@ insert new_order
  ├── values
  │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
  │    ├── cardinality: [1 - 1]
- │    ├── stats: [rows=1]
+ │    ├── stats: [rows=1, distinct(4)=1, null(4)=0, distinct(5)=1, null(5)=0, distinct(6)=1, null(6)=0]
  │    ├── cost: 0.02
  │    ├── key: ()
  │    ├── fd: ()-->(4-6)
@@ -255,7 +255,7 @@ insert new_order
                 ├── stats: [rows=1e-10]
                 ├── cost: 6.11975196
                 ├── key: ()
-                ├── fd: ()-->(4-6), (6)-->(15), (5)-->(16), (4)-->(17)
+                ├── fd: ()-->(15-17)
                 ├── with-scan &1
                 │    ├── columns: column3:15(int!null) column2:16(int!null) column1:17(int!null)
                 │    ├── mapping:
@@ -263,10 +263,10 @@ insert new_order
                 │    │    ├──  column2:5(int) => column2:16(int)
                 │    │    └──  column1:4(int) => column1:17(int)
                 │    ├── cardinality: [1 - 1]
-                │    ├── stats: [rows=1]
+                │    ├── stats: [rows=1, distinct(15)=1, null(15)=0, distinct(16)=1, null(16)=0, distinct(17)=1, null(17)=0]
                 │    ├── cost: 0.01
                 │    ├── key: ()
-                │    └── fd: ()-->(4-6), (6)-->(15), (5)-->(16), (4)-->(17)
+                │    └── fd: ()-->(15-17)
                 └── filters (true)
 
 opt format=hide-qual
@@ -704,7 +704,7 @@ insert order_line
  ├── project
  │    ├── columns: ol_amount:21(decimal) column20:20(timestamp) column1:11(int!null) column2:12(int!null) column3:13(int!null) column4:14(int!null) column5:15(int!null) column6:16(int!null) column7:17(int!null) column9:19(string!null)
  │    ├── cardinality: [6 - 6]
- │    ├── stats: [rows=6]
+ │    ├── stats: [rows=6, distinct(11)=0.6, null(11)=0, distinct(12)=0.6, null(12)=0, distinct(13)=0.6, null(13)=0, distinct(15)=0.6, null(15)=0, distinct(16)=0.6, null(16)=0]
  │    ├── cost: 0.26
  │    ├── fd: ()-->(20)
  │    ├── prune: (11-17,19-21)
@@ -787,7 +787,6 @@ insert order_line
       │         ├── cardinality: [0 - 6]
       │         ├── stats: [rows=1e-10]
       │         ├── cost: 36.6185118
-      │         ├── fd: ()-->(20), (13)-->(30), (12)-->(31), (11)-->(32)
       │         ├── with-scan &1
       │         │    ├── columns: column3:30(int!null) column2:31(int!null) column1:32(int!null)
       │         │    ├── mapping:
@@ -795,9 +794,8 @@ insert order_line
       │         │    │    ├──  column2:12(int) => column2:31(int)
       │         │    │    └──  column1:11(int) => column1:32(int)
       │         │    ├── cardinality: [6 - 6]
-      │         │    ├── stats: [rows=6]
-      │         │    ├── cost: 0.01
-      │         │    └── fd: ()-->(20), (13)-->(30), (12)-->(31), (11)-->(32)
+      │         │    ├── stats: [rows=6, distinct(30)=0.6, null(30)=0, distinct(31)=0.6, null(31)=0, distinct(32)=0.6, null(32)=0]
+      │         │    └── cost: 0.01
       │         └── filters (true)
       └── f-k-checks-item: order_line(ol_supply_w_id,ol_i_id) -> stock(s_w_id,s_i_id)
            └── anti-join (lookup stock@stock_item_fk_idx)
@@ -806,16 +804,14 @@ insert order_line
                 ├── cardinality: [0 - 6]
                 ├── stats: [rows=1e-10]
                 ├── cost: 36.1061434
-                ├── fd: ()-->(20), (16)-->(50), (15)-->(51)
                 ├── with-scan &1
                 │    ├── columns: column6:50(int!null) column5:51(int!null)
                 │    ├── mapping:
                 │    │    ├──  column6:16(int) => column6:50(int)
                 │    │    └──  column5:15(int) => column5:51(int)
                 │    ├── cardinality: [6 - 6]
-                │    ├── stats: [rows=6]
-                │    ├── cost: 0.01
-                │    └── fd: ()-->(20), (16)-->(50), (15)-->(51)
+                │    ├── stats: [rows=6, distinct(50)=0.6, null(50)=0, distinct(51)=0.6, null(51)=0]
+                │    └── cost: 0.01
                 └── filters (true)
 
 # --------------------------------------------------
@@ -1109,7 +1105,7 @@ insert history
  │    ├── columns: column1:10(int!null) column2:11(int!null) column3:12(int!null) column4:13(int!null) column5:14(int!null) column7:16(timestamp!null) column8:17(string!null) column18:18(uuid) h_amount:19(decimal)
  │    ├── cardinality: [1 - 1]
  │    ├── side-effects
- │    ├── stats: [rows=1]
+ │    ├── stats: [rows=1, distinct(10)=1, null(10)=0, distinct(11)=1, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=1, null(13)=0, distinct(14)=1, null(14)=0]
  │    ├── cost: 0.02
  │    ├── key: ()
  │    ├── fd: ()-->(10-14,16-19)
@@ -1135,7 +1131,7 @@ insert history
       │         ├── stats: [rows=1e-10]
       │         ├── cost: 6.26
       │         ├── key: ()
-      │         ├── fd: ()-->(10-14,16-19), (12)-->(41), (11)-->(42), (10)-->(43)
+      │         ├── fd: ()-->(41-43)
       │         ├── with-scan &1
       │         │    ├── columns: column3:41(int!null) column2:42(int!null) column1:43(int!null)
       │         │    ├── mapping:
@@ -1143,10 +1139,10 @@ insert history
       │         │    │    ├──  column2:11(int) => column2:42(int)
       │         │    │    └──  column1:10(int) => column1:43(int)
       │         │    ├── cardinality: [1 - 1]
-      │         │    ├── stats: [rows=1]
+      │         │    ├── stats: [rows=1, distinct(41)=1, null(41)=0, distinct(42)=1, null(42)=0, distinct(43)=1, null(43)=0]
       │         │    ├── cost: 0.01
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(10-14,16-19), (12)-->(41), (11)-->(42), (10)-->(43)
+      │         │    └── fd: ()-->(41-43)
       │         └── filters (true)
       └── f-k-checks-item: history(h_w_id,h_d_id) -> district(d_w_id,d_id)
            └── anti-join (lookup district)
@@ -1156,17 +1152,17 @@ insert history
                 ├── stats: [rows=1e-10]
                 ├── cost: 6.15
                 ├── key: ()
-                ├── fd: ()-->(10-14,16-19), (14)-->(55), (13)-->(56)
+                ├── fd: ()-->(55,56)
                 ├── with-scan &1
                 │    ├── columns: column5:55(int!null) column4:56(int!null)
                 │    ├── mapping:
                 │    │    ├──  column5:14(int) => column5:55(int)
                 │    │    └──  column4:13(int) => column4:56(int)
                 │    ├── cardinality: [1 - 1]
-                │    ├── stats: [rows=1]
+                │    ├── stats: [rows=1, distinct(55)=1, null(55)=0, distinct(56)=1, null(56)=0]
                 │    ├── cost: 0.01
                 │    ├── key: ()
-                │    └── fd: ()-->(10-14,16-19), (14)-->(55), (13)-->(56)
+                │    └── fd: ()-->(55,56)
                 └── filters (true)
 
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -177,7 +177,7 @@ insert "order"
  ├── values
  │    ├── columns: column1:9(int!null) column2:10(int!null) column3:11(int!null) column4:12(int!null) column5:13(timestamp!null) column6:14(int!null) column7:15(int!null) column16:16(int)
  │    ├── cardinality: [1 - 1]
- │    ├── stats: [rows=1]
+ │    ├── stats: [rows=1, distinct(10)=1, null(10)=0, distinct(11)=1, null(11)=0, distinct(12)=1, null(12)=0]
  │    ├── cost: 0.02
  │    ├── key: ()
  │    ├── fd: ()-->(9-16)
@@ -200,7 +200,7 @@ insert "order"
                 ├── stats: [rows=1e-10]
                 ├── cost: 4.02224
                 ├── key: ()
-                ├── fd: ()-->(9-16), (11)-->(38), (10)-->(39), (12)-->(40)
+                ├── fd: ()-->(38-40)
                 ├── with-scan &1
                 │    ├── columns: column3:38(int!null) column2:39(int!null) column4:40(int!null)
                 │    ├── mapping:
@@ -208,10 +208,10 @@ insert "order"
                 │    │    ├──  column2:10(int) => column2:39(int)
                 │    │    └──  column4:12(int) => column4:40(int)
                 │    ├── cardinality: [1 - 1]
-                │    ├── stats: [rows=1]
+                │    ├── stats: [rows=1, distinct(38)=1, null(38)=0, distinct(39)=1, null(39)=0, distinct(40)=1, null(40)=0]
                 │    ├── cost: 0.01
                 │    ├── key: ()
-                │    └── fd: ()-->(9-16), (11)-->(38), (10)-->(39), (12)-->(40)
+                │    └── fd: ()-->(38-40)
                 └── filters (true)
 
 opt format=hide-qual
@@ -231,7 +231,7 @@ insert new_order
  ├── values
  │    ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
  │    ├── cardinality: [1 - 1]
- │    ├── stats: [rows=1]
+ │    ├── stats: [rows=1, distinct(4)=1, null(4)=0, distinct(5)=1, null(5)=0, distinct(6)=1, null(6)=0]
  │    ├── cost: 0.02
  │    ├── key: ()
  │    ├── fd: ()-->(4-6)
@@ -249,7 +249,7 @@ insert new_order
                 ├── stats: [rows=1e-10]
                 ├── cost: 4.02211
                 ├── key: ()
-                ├── fd: ()-->(4-6), (6)-->(15), (5)-->(16), (4)-->(17)
+                ├── fd: ()-->(15-17)
                 ├── with-scan &1
                 │    ├── columns: column3:15(int!null) column2:16(int!null) column1:17(int!null)
                 │    ├── mapping:
@@ -257,10 +257,10 @@ insert new_order
                 │    │    ├──  column2:5(int) => column2:16(int)
                 │    │    └──  column1:4(int) => column1:17(int)
                 │    ├── cardinality: [1 - 1]
-                │    ├── stats: [rows=1]
+                │    ├── stats: [rows=1, distinct(15)=1, null(15)=0, distinct(16)=1, null(16)=0, distinct(17)=1, null(17)=0]
                 │    ├── cost: 0.01
                 │    ├── key: ()
-                │    └── fd: ()-->(4-6), (6)-->(15), (5)-->(16), (4)-->(17)
+                │    └── fd: ()-->(15-17)
                 └── filters (true)
 
 opt format=hide-qual
@@ -698,7 +698,7 @@ insert order_line
  ├── project
  │    ├── columns: ol_amount:21(decimal) column20:20(timestamp) column1:11(int!null) column2:12(int!null) column3:13(int!null) column4:14(int!null) column5:15(int!null) column6:16(int!null) column7:17(int!null) column9:19(string!null)
  │    ├── cardinality: [6 - 6]
- │    ├── stats: [rows=6]
+ │    ├── stats: [rows=6, distinct(11)=0.6, null(11)=0, distinct(12)=0.6, null(12)=0, distinct(13)=0.6, null(13)=0, distinct(15)=0.6, null(15)=0, distinct(16)=0.6, null(16)=0]
  │    ├── cost: 0.26
  │    ├── fd: ()-->(20)
  │    ├── prune: (11-17,19-21)
@@ -781,7 +781,6 @@ insert order_line
       │         ├── cardinality: [0 - 6]
       │         ├── stats: [rows=1e-10]
       │         ├── cost: 24.03266
-      │         ├── fd: ()-->(20), (13)-->(30), (12)-->(31), (11)-->(32)
       │         ├── with-scan &1
       │         │    ├── columns: column3:30(int!null) column2:31(int!null) column1:32(int!null)
       │         │    ├── mapping:
@@ -789,9 +788,8 @@ insert order_line
       │         │    │    ├──  column2:12(int) => column2:31(int)
       │         │    │    └──  column1:11(int) => column1:32(int)
       │         │    ├── cardinality: [6 - 6]
-      │         │    ├── stats: [rows=6]
-      │         │    ├── cost: 0.01
-      │         │    └── fd: ()-->(20), (13)-->(30), (12)-->(31), (11)-->(32)
+      │         │    ├── stats: [rows=6, distinct(30)=0.6, null(30)=0, distinct(31)=0.6, null(31)=0, distinct(32)=0.6, null(32)=0]
+      │         │    └── cost: 0.01
       │         └── filters (true)
       └── f-k-checks-item: order_line(ol_supply_w_id,ol_i_id) -> stock(s_w_id,s_i_id)
            └── anti-join (lookup stock@stock_item_fk_idx)
@@ -800,16 +798,14 @@ insert order_line
                 ├── cardinality: [0 - 6]
                 ├── stats: [rows=1e-10]
                 ├── cost: 25.244
-                ├── fd: ()-->(20), (16)-->(50), (15)-->(51)
                 ├── with-scan &1
                 │    ├── columns: column6:50(int!null) column5:51(int!null)
                 │    ├── mapping:
                 │    │    ├──  column6:16(int) => column6:50(int)
                 │    │    └──  column5:15(int) => column5:51(int)
                 │    ├── cardinality: [6 - 6]
-                │    ├── stats: [rows=6]
-                │    ├── cost: 0.01
-                │    └── fd: ()-->(20), (16)-->(50), (15)-->(51)
+                │    ├── stats: [rows=6, distinct(50)=0.6, null(50)=0, distinct(51)=0.6, null(51)=0]
+                │    └── cost: 0.01
                 └── filters (true)
 
 # --------------------------------------------------
@@ -1103,7 +1099,7 @@ insert history
  │    ├── columns: column1:10(int!null) column2:11(int!null) column3:12(int!null) column4:13(int!null) column5:14(int!null) column7:16(timestamp!null) column8:17(string!null) column18:18(uuid) h_amount:19(decimal)
  │    ├── cardinality: [1 - 1]
  │    ├── side-effects
- │    ├── stats: [rows=1]
+ │    ├── stats: [rows=1, distinct(10)=1, null(10)=0, distinct(11)=1, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=1, null(13)=0, distinct(14)=1, null(14)=0]
  │    ├── cost: 0.02
  │    ├── key: ()
  │    ├── fd: ()-->(10-14,16-19)
@@ -1129,7 +1125,7 @@ insert history
       │         ├── stats: [rows=1e-10]
       │         ├── cost: 4.02224
       │         ├── key: ()
-      │         ├── fd: ()-->(10-14,16-19), (12)-->(41), (11)-->(42), (10)-->(43)
+      │         ├── fd: ()-->(41-43)
       │         ├── with-scan &1
       │         │    ├── columns: column3:41(int!null) column2:42(int!null) column1:43(int!null)
       │         │    ├── mapping:
@@ -1137,10 +1133,10 @@ insert history
       │         │    │    ├──  column2:11(int) => column2:42(int)
       │         │    │    └──  column1:10(int) => column1:43(int)
       │         │    ├── cardinality: [1 - 1]
-      │         │    ├── stats: [rows=1]
+      │         │    ├── stats: [rows=1, distinct(41)=1, null(41)=0, distinct(42)=1, null(42)=0, distinct(43)=1, null(43)=0]
       │         │    ├── cost: 0.01
       │         │    ├── key: ()
-      │         │    └── fd: ()-->(10-14,16-19), (12)-->(41), (11)-->(42), (10)-->(43)
+      │         │    └── fd: ()-->(41-43)
       │         └── filters (true)
       └── f-k-checks-item: history(h_w_id,h_d_id) -> district(d_w_id,d_id)
            └── anti-join (lookup district)
@@ -1150,17 +1146,17 @@ insert history
                 ├── stats: [rows=1e-10]
                 ├── cost: 4.233
                 ├── key: ()
-                ├── fd: ()-->(10-14,16-19), (14)-->(55), (13)-->(56)
+                ├── fd: ()-->(55,56)
                 ├── with-scan &1
                 │    ├── columns: column5:55(int!null) column4:56(int!null)
                 │    ├── mapping:
                 │    │    ├──  column5:14(int) => column5:55(int)
                 │    │    └──  column4:13(int) => column4:56(int)
                 │    ├── cardinality: [1 - 1]
-                │    ├── stats: [rows=1]
+                │    ├── stats: [rows=1, distinct(55)=1, null(55)=0, distinct(56)=1, null(56)=0]
                 │    ├── cost: 0.01
                 │    ├── key: ()
-                │    └── fd: ()-->(10-14,16-19), (14)-->(55), (13)-->(56)
+                │    └── fd: ()-->(55,56)
                 └── filters (true)
 
 # --------------------------------------------------


### PR DESCRIPTION
This commit fixes the functional dependencies and stats calculation
for `WithScanExpr` so they use the output columns rather than the input
columns.

Fixes #40296

Release note: None