### PR TITLE
exec: omit some of the operators from EXPLAIN (VEC) output

### DIFF
--- a/pkg/sql/distsqlrun/columnarizer.go
+++ b/pkg/sql/distsqlrun/columnarizer.go
@@ -27,6 +27,7 @@ import (
 type columnarizer struct {
 	ProcessorBase
 	exec.ZeroInputNode
+	exec.NonExplainable
 
 	input RowSource
 	da    sqlbase.DatumAlloc

--- a/pkg/sql/distsqlrun/materializer.go
+++ b/pkg/sql/distsqlrun/materializer.go
@@ -26,6 +26,7 @@ import (
 // materializer converts an exec.Operator input into a RowSource.
 type materializer struct {
 	ProcessorBase
+	exec.NonExplainable
 
 	input exec.Operator
 

--- a/pkg/sql/exec/bool_vec_to_sel.go
+++ b/pkg/sql/exec/bool_vec_to_sel.go
@@ -20,6 +20,7 @@ import (
 // an index to the selection for each true value in the boolean column.
 type boolVecToSelOp struct {
 	OneInputNode
+	NonExplainable
 
 	// outputCol is the boolean output column. It should be shared by other
 	// operators that write to it.
@@ -111,6 +112,7 @@ func NewBoolVecToSelOp(input Operator, colIdx int) Operator {
 // an operator that can see the inside of its input batch for NewBoolVecToSelOp.
 type selBoolOp struct {
 	OneInputNode
+	NonExplainable
 	boolVecToSelOp *boolVecToSelOp
 	colIdx         int
 }

--- a/pkg/sql/exec/buffer.go
+++ b/pkg/sql/exec/buffer.go
@@ -21,6 +21,7 @@ import (
 // and makes it available to be read multiple times by downstream consumers.
 type bufferOp struct {
 	OneInputNode
+	NonExplainable
 
 	// read is true if someone has read the current batch already.
 	read     bool

--- a/pkg/sql/exec/cancel_checker.go
+++ b/pkg/sql/exec/cancel_checker.go
@@ -22,6 +22,7 @@ import (
 // occurred. The check happens on every batch.
 type CancelChecker struct {
 	OneInputNode
+	NonExplainable
 
 	// Number of times check() has been called since last context cancellation
 	// check.

--- a/pkg/sql/exec/coalescer.go
+++ b/pkg/sql/exec/coalescer.go
@@ -21,6 +21,7 @@ import (
 // to return full batches of coldata.BatchSize.
 type coalescerOp struct {
 	OneInputNode
+	NonExplainable
 
 	inputTypes []coltypes.T
 

--- a/pkg/sql/exec/deselector.go
+++ b/pkg/sql/exec/deselector.go
@@ -23,6 +23,7 @@ import (
 // selection vector, it is a noop.
 type deselectorOp struct {
 	OneInputNode
+	NonExplainable
 	inputTypes []coltypes.T
 
 	output coldata.Batch

--- a/pkg/sql/exec/fn_op.go
+++ b/pkg/sql/exec/fn_op.go
@@ -20,6 +20,7 @@ import (
 // once per input batch, passing the input batch unmodified along.
 type fnOp struct {
 	OneInputNode
+	NonExplainable
 
 	fn func()
 }

--- a/pkg/sql/exec/mergejoiner.go
+++ b/pkg/sql/exec/mergejoiner.go
@@ -157,6 +157,7 @@ type mergeJoinInput struct {
 // the next batch.
 type feedOperator struct {
 	ZeroInputNode
+	NonExplainable
 	batch coldata.Batch
 }
 

--- a/pkg/sql/exec/operator.go
+++ b/pkg/sql/exec/operator.go
@@ -47,6 +47,14 @@ type OpNode interface {
 	Child(nth int) OpNode
 }
 
+// NonExplainable is a marker interface which identifies an Operator that
+// should be omitted from the output of EXPLAIN (VEC). Note that VERBOSE
+// explain option will override the omitting behavior.
+type NonExplainable interface {
+	// nonExplainableMarker is just a marker method. It should never be called.
+	nonExplainableMarker()
+}
+
 // NewOneInputNode returns an OpNode with a single Operator input.
 func NewOneInputNode(input Operator) OneInputNode {
 	return OneInputNode{input: input}
@@ -141,6 +149,7 @@ type resettableOperator interface {
 
 type noopOperator struct {
 	OneInputNode
+	NonExplainable
 }
 
 var _ Operator = &noopOperator{}
@@ -166,6 +175,7 @@ func (n *noopOperator) reset() {
 
 type zeroOperator struct {
 	OneInputNode
+	NonExplainable
 }
 
 var _ Operator = &zeroOperator{}
@@ -188,6 +198,7 @@ func (s *zeroOperator) Next(ctx context.Context) coldata.Batch {
 
 type singleTupleNoInputOperator struct {
 	ZeroInputNode
+	NonExplainable
 	batch  coldata.Batch
 	nexted bool
 }

--- a/pkg/sql/exec/simple_project.go
+++ b/pkg/sql/exec/simple_project.go
@@ -22,6 +22,7 @@ import (
 // columns that aren't needed by later operators.
 type simpleProjectOp struct {
 	OneInputNode
+	NonExplainable
 
 	batch *projectingBatch
 }

--- a/pkg/sql/exec/sort.go
+++ b/pkg/sql/exec/sort.go
@@ -81,6 +81,7 @@ type spooler interface {
 // by the general sorter over the whole input.
 type allSpooler struct {
 	OneInputNode
+	NonExplainable
 
 	// inputTypes contains the types of all of the columns from the input.
 	inputTypes []coltypes.T

--- a/pkg/sql/exec/sort_chunks.go
+++ b/pkg/sql/exec/sort_chunks.go
@@ -151,6 +151,7 @@ const (
 // buffer when appropriate.
 type chunker struct {
 	OneInputNode
+	NonExplainable
 	// inputTypes contains the types of all of the columns from input.
 	inputTypes []coltypes.T
 	// inputDone indicates whether input has been fully consumed.

--- a/pkg/sql/exec/stats.go
+++ b/pkg/sql/exec/stats.go
@@ -26,6 +26,7 @@ import (
 // StopWatch.
 type VectorizedStatsCollector struct {
 	Operator
+	NonExplainable
 	execpb.VectorizedStats
 
 	// inputWatch is a single stop watch that is shared with all the input

--- a/pkg/sql/logictest/testdata/logic_test/dist_vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/dist_vectorize
@@ -87,7 +87,7 @@ statement ok
 RESET optimizer
 
 query T
-EXPLAIN (VEC) SELECT count(*) FROM kv
+EXPLAIN (VEC, VERBOSE) SELECT count(*) FROM kv
 ----
  │
  ├── Node 1
@@ -134,7 +134,7 @@ EXPLAIN (VEC) SELECT count(*) FROM kv
                                └── *distsqlrun.colBatchScan
 
 query T
-EXPLAIN (VEC) SELECT count(*) FROM kv NATURAL INNER HASH JOIN kv kv2
+EXPLAIN (VEC, VERBOSE) SELECT count(*) FROM kv NATURAL INNER HASH JOIN kv kv2
 ----
  │
  ├── Node 1

--- a/pkg/sql/logictest/testdata/logic_test/tpch_vec
+++ b/pkg/sql/logictest/testdata/logic_test/tpch_vec
@@ -532,21 +532,17 @@ EXPLAIN (VEC) SELECT l_returnflag, l_linestatus, sum(l_quantity) AS sum_qty, sum
 ----
  │
  └── Node 1
-      └── *distsqlrun.materializer
-           └── *exec.sortOp
-                └── *exec.allSpooler
-                     └── *exec.orderedAggregator
-                          └── *exec.hashGrouper
-                               └── *exec.simpleProjectOp
-                                    └── *exec.projMultFloat64Float64Op
-                                         └── *exec.projPlusFloat64Float64ConstOp
-                                              └── *exec.projMultFloat64Float64Op
-                                                   └── *exec.projMinusFloat64ConstFloat64Op
-                                                        └── *exec.projMultFloat64Float64Op
-                                                             └── *exec.projMinusFloat64ConstFloat64Op
-                                                                  └── *exec.selLEInt64Int64ConstOp
-                                                                       └── *exec.CancelChecker
-                                                                            └── *distsqlrun.colBatchScan
+      └── *exec.sortOp
+           └── *exec.orderedAggregator
+                └── *exec.hashGrouper
+                     └── *exec.projMultFloat64Float64Op
+                          └── *exec.projPlusFloat64Float64ConstOp
+                               └── *exec.projMultFloat64Float64Op
+                                    └── *exec.projMinusFloat64ConstFloat64Op
+                                         └── *exec.projMultFloat64Float64Op
+                                              └── *exec.projMinusFloat64ConstFloat64Op
+                                                   └── *exec.selLEInt64Int64ConstOp
+                                                        └── *distsqlrun.colBatchScan
 
 # Query 2
 query T
@@ -554,41 +550,26 @@ EXPLAIN (VEC) SELECT s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_
 ----
  │
  └── Node 1
-      └── *distsqlrun.materializer
-           └── *exec.limitOp
-                └── *exec.simpleProjectOp
-                     └── *exec.topKSorter
-                          └── *exec.selEQFloat64Float64Op
-                               └── *exec.orderedAggregator
-                                    └── *exec.hashGrouper
-                                         └── *exec.simpleProjectOp
-                                              └── *exec.hashJoinEqOp
-                                                   ├── *exec.hashJoinEqOp
-                                                   │    ├── *exec.simpleProjectOp
-                                                   │    │    └── *exec.CancelChecker
-                                                   │    │         └── *distsqlrun.colBatchScan
-                                                   │    └── *distsqlrun.columnarizer
-                                                   └── *exec.hashJoinEqOp
-                                                        ├── *exec.hashJoinEqOp
-                                                        │    ├── *exec.simpleProjectOp
-                                                        │    │    └── *exec.CancelChecker
-                                                        │    │         └── *distsqlrun.colBatchScan
-                                                        │    └── *exec.hashJoinEqOp
-                                                        │         ├── *exec.CancelChecker
-                                                        │         │    └── *distsqlrun.colBatchScan
-                                                        │         └── *exec.hashJoinEqOp
-                                                        │              ├── *exec.simpleProjectOp
-                                                        │              │    └── *exec.CancelChecker
-                                                        │              │         └── *distsqlrun.colBatchScan
-                                                        │              └── *exec.simpleProjectOp
-                                                        │                   └── *exec.selEQBytesBytesConstOp
-                                                        │                        └── *exec.CancelChecker
-                                                        │                             └── *distsqlrun.colBatchScan
-                                                        └── *exec.simpleProjectOp
-                                                             └── *exec.selSuffixBytesBytesConstOp
-                                                                  └── *exec.selEQInt64Int64ConstOp
-                                                                       └── *exec.CancelChecker
-                                                                            └── *distsqlrun.colBatchScan
+      └── *exec.limitOp
+           └── *exec.topKSorter
+                └── *exec.selEQFloat64Float64Op
+                     └── *exec.orderedAggregator
+                          └── *exec.hashGrouper
+                               └── *exec.hashJoinEqOp
+                                    ├── *exec.hashJoinEqOp
+                                    │    └── *distsqlrun.colBatchScan
+                                    └── *exec.hashJoinEqOp
+                                         ├── *exec.hashJoinEqOp
+                                         │    ├── *distsqlrun.colBatchScan
+                                         │    └── *exec.hashJoinEqOp
+                                         │         ├── *distsqlrun.colBatchScan
+                                         │         └── *exec.hashJoinEqOp
+                                         │              ├── *distsqlrun.colBatchScan
+                                         │              └── *exec.selEQBytesBytesConstOp
+                                         │                   └── *distsqlrun.colBatchScan
+                                         └── *exec.selSuffixBytesBytesConstOp
+                                              └── *exec.selEQInt64Int64ConstOp
+                                                   └── *distsqlrun.colBatchScan
 
 # Query 3
 query T
@@ -596,12 +577,10 @@ EXPLAIN (VEC) SELECT l_orderkey, sum(l_extendedprice * (1 - l_discount)) AS reve
 ----
  │
  └── Node 1
-      └── *distsqlrun.materializer
-           └── *exec.limitOp
-                └── *exec.topKSorter
-                     └── *exec.orderedAggregator
-                          └── *exec.hashGrouper
-                               └── *distsqlrun.columnarizer
+      └── *exec.limitOp
+           └── *exec.topKSorter
+                └── *exec.orderedAggregator
+                     └── *exec.hashGrouper
 
 # Query 4
 query T
@@ -609,18 +588,12 @@ EXPLAIN (VEC) SELECT o_orderpriority, count(*) AS order_count FROM orders WHERE 
 ----
  │
  └── Node 1
-      └── *distsqlrun.materializer
-           └── *exec.sortOp
-                └── *exec.allSpooler
-                     └── *exec.orderedAggregator
-                          └── *exec.hashGrouper
-                               └── *exec.simpleProjectOp
-                                    └── *exec.hashJoinEqOp
-                                         ├── *distsqlrun.columnarizer
-                                         └── *exec.simpleProjectOp
-                                              └── *exec.selLTInt64Int64Op
-                                                   └── *exec.CancelChecker
-                                                        └── *distsqlrun.colBatchScan
+      └── *exec.sortOp
+           └── *exec.orderedAggregator
+                └── *exec.hashGrouper
+                     └── *exec.hashJoinEqOp
+                          └── *exec.selLTInt64Int64Op
+                               └── *distsqlrun.colBatchScan
 
 # Query 5
 query T
@@ -628,25 +601,16 @@ EXPLAIN (VEC) SELECT n_name, sum(l_extendedprice * (1 - l_discount)) AS revenue 
 ----
  │
  └── Node 1
-      └── *distsqlrun.materializer
-           └── *exec.sortOp
-                └── *exec.allSpooler
-                     └── *exec.orderedAggregator
-                          └── *exec.hashGrouper
-                               └── *exec.simpleProjectOp
-                                    └── *exec.projMultFloat64Float64Op
-                                         └── *exec.projMinusFloat64ConstFloat64Op
-                                              └── *exec.hashJoinEqOp
-                                                   ├── *exec.hashJoinEqOp
-                                                   │    ├── *exec.hashJoinEqOp
-                                                   │    │    ├── *exec.simpleProjectOp
-                                                   │    │    │    └── *exec.CancelChecker
-                                                   │    │    │         └── *distsqlrun.colBatchScan
-                                                   │    │    └── *distsqlrun.columnarizer
-                                                   │    └── *distsqlrun.columnarizer
-                                                   └── *exec.simpleProjectOp
-                                                        └── *exec.CancelChecker
-                                                             └── *distsqlrun.colBatchScan
+      └── *exec.sortOp
+           └── *exec.orderedAggregator
+                └── *exec.hashGrouper
+                     └── *exec.projMultFloat64Float64Op
+                          └── *exec.projMinusFloat64ConstFloat64Op
+                               └── *exec.hashJoinEqOp
+                                    ├── *exec.hashJoinEqOp
+                                    │    └── *exec.hashJoinEqOp
+                                    │         └── *distsqlrun.colBatchScan
+                                    └── *distsqlrun.colBatchScan
 
 # Query 6
 query T
@@ -654,11 +618,9 @@ EXPLAIN (VEC) SELECT sum(l_extendedprice * l_discount) AS revenue FROM lineitem 
 ----
  │
  └── Node 1
-      └── *distsqlrun.materializer
-           └── *exec.orderedAggregator
-                └── *exec.oneShotOp
-                     └── *exec.distinctChainOps
-                          └── *distsqlrun.columnarizer
+      └── *exec.orderedAggregator
+           └── *exec.oneShotOp
+                └── *exec.distinctChainOps
 
 # Query 7
 query T
@@ -666,21 +628,15 @@ EXPLAIN (VEC) SELECT supp_nation, cust_nation, l_year, sum(volume) AS revenue FR
 ----
  │
  └── Node 1
-      └── *distsqlrun.materializer
-           └── *exec.sortOp
-                └── *exec.allSpooler
-                     └── *exec.orderedAggregator
-                          └── *exec.hashGrouper
-                               └── *exec.simpleProjectOp
-                                    └── *exec.projMultFloat64Float64Op
-                                         └── *exec.projMinusFloat64ConstFloat64Op
-                                              └── *exec.defaultBuiltinFuncOperator
-                                                   └── *exec.constBytesOp
-                                                        └── *exec.hashJoinEqOp
-                                                             ├── *distsqlrun.columnarizer
-                                                             └── *exec.simpleProjectOp
-                                                                  └── *exec.CancelChecker
-                                                                       └── *distsqlrun.colBatchScan
+      └── *exec.sortOp
+           └── *exec.orderedAggregator
+                └── *exec.hashGrouper
+                     └── *exec.projMultFloat64Float64Op
+                          └── *exec.projMinusFloat64ConstFloat64Op
+                               └── *exec.defaultBuiltinFuncOperator
+                                    └── *exec.constBytesOp
+                                         └── *exec.hashJoinEqOp
+                                              └── *distsqlrun.colBatchScan
 
 # Query 8
 query T
@@ -688,47 +644,28 @@ EXPLAIN (VEC) SELECT o_year, sum(CASE WHEN nation = 'BRAZIL' THEN volume ELSE 0 
 ----
  │
  └── Node 1
-      └── *distsqlrun.materializer
-           └── *exec.simpleProjectOp
-                └── *exec.sortOp
-                     └── *exec.allSpooler
-                          └── *exec.simpleProjectOp
-                               └── *exec.projDivFloat64Float64Op
-                                    └── *exec.orderedAggregator
-                                         └── *exec.hashGrouper
-                                              └── *exec.simpleProjectOp
-                                                   └── *exec.caseOp
-                                                        └── *exec.bufferOp
-                                                             └── *exec.noopOperator
-                                                                  └── *exec.simpleProjectOp
-                                                                       └── *exec.projMultFloat64Float64Op
-                                                                            └── *exec.projMinusFloat64ConstFloat64Op
-                                                                                 └── *exec.defaultBuiltinFuncOperator
-                                                                                      └── *exec.constBytesOp
-                                                                                           └── *exec.hashJoinEqOp
-                                                                                                ├── *exec.hashJoinEqOp
-                                                                                                │    ├── *exec.hashJoinEqOp
-                                                                                                │    │    ├── *exec.simpleProjectOp
-                                                                                                │    │    │    └── *exec.CancelChecker
-                                                                                                │    │    │         └── *distsqlrun.colBatchScan
-                                                                                                │    │    └── *exec.hashJoinEqOp
-                                                                                                │    │         ├── *exec.hashJoinEqOp
-                                                                                                │    │         │    ├── *distsqlrun.columnarizer
-                                                                                                │    │         │    └── *exec.simpleProjectOp
-                                                                                                │    │         │         └── *exec.CancelChecker
-                                                                                                │    │         │              └── *distsqlrun.colBatchScan
-                                                                                                │    │         └── *exec.simpleProjectOp
-                                                                                                │    │              └── *exec.selLEInt64Int64ConstOp
-                                                                                                │    │                   └── *exec.selGEInt64Int64ConstOp
-                                                                                                │    │                        └── *exec.CancelChecker
-                                                                                                │    │                             └── *distsqlrun.colBatchScan
-                                                                                                │    └── *exec.simpleProjectOp
-                                                                                                │         └── *exec.CancelChecker
-                                                                                                │              └── *distsqlrun.colBatchScan
-                                                                                                └── *exec.simpleProjectOp
-                                                                                                     └── *exec.selEQBytesBytesConstOp
-                                                                                                          └── *exec.CancelChecker
-                                                                                                               └── *distsqlrun.colBatchScan
+      └── *exec.sortOp
+           └── *exec.projDivFloat64Float64Op
+                └── *exec.orderedAggregator
+                     └── *exec.hashGrouper
+                          └── *exec.caseOp
+                               └── *exec.projMultFloat64Float64Op
+                                    └── *exec.projMinusFloat64ConstFloat64Op
+                                         └── *exec.defaultBuiltinFuncOperator
+                                              └── *exec.constBytesOp
+                                                   └── *exec.hashJoinEqOp
+                                                        ├── *exec.hashJoinEqOp
+                                                        │    ├── *exec.hashJoinEqOp
+                                                        │    │    ├── *distsqlrun.colBatchScan
+                                                        │    │    └── *exec.hashJoinEqOp
+                                                        │    │         ├── *exec.hashJoinEqOp
+                                                        │    │         │    └── *distsqlrun.colBatchScan
+                                                        │    │         └── *exec.selLEInt64Int64ConstOp
+                                                        │    │              └── *exec.selGEInt64Int64ConstOp
+                                                        │    │                   └── *distsqlrun.colBatchScan
+                                                        │    └── *distsqlrun.colBatchScan
+                                                        └── *exec.selEQBytesBytesConstOp
+                                                             └── *distsqlrun.colBatchScan
 
 # Query 9
 query T
@@ -736,12 +673,9 @@ EXPLAIN (VEC) SELECT nation, o_year, sum(amount) AS sum_profit FROM ( SELECT n_n
 ----
  │
  └── Node 1
-      └── *distsqlrun.materializer
-           └── *exec.sortOp
-                └── *exec.allSpooler
-                     └── *exec.orderedAggregator
-                          └── *exec.hashGrouper
-                               └── *distsqlrun.columnarizer
+      └── *exec.sortOp
+           └── *exec.orderedAggregator
+                └── *exec.hashGrouper
 
 # Query 10
 query T
@@ -749,13 +683,10 @@ EXPLAIN (VEC) SELECT c_custkey, c_name, sum(l_extendedprice * (1 - l_discount)) 
 ----
  │
  └── Node 1
-      └── *distsqlrun.materializer
-           └── *exec.limitOp
-                └── *exec.simpleProjectOp
-                     └── *exec.topKSorter
-                          └── *exec.orderedAggregator
-                               └── *exec.hashGrouper
-                                    └── *distsqlrun.columnarizer
+      └── *exec.limitOp
+           └── *exec.topKSorter
+                └── *exec.orderedAggregator
+                     └── *exec.hashGrouper
 
 # Query 11
 query T
@@ -763,16 +694,12 @@ EXPLAIN (VEC) SELECT ps_partkey, sum(ps_supplycost * ps_availqty::float) AS valu
 ----
  │
  └── Node 1
-      └── *distsqlrun.materializer
-           └── *exec.sortOp
-                └── *exec.allSpooler
-                     └── *exec.simpleProjectOp
-                          └── *exec.selGTFloat64Float64Op
-                               └── *exec.castOpNullAny
-                                    └── *exec.constNullOp
-                                         └── *exec.orderedAggregator
-                                              └── *exec.hashGrouper
-                                                   └── *distsqlrun.columnarizer
+      └── *exec.sortOp
+           └── *exec.selGTFloat64Float64Op
+                └── *exec.castOpNullAny
+                     └── *exec.constNullOp
+                          └── *exec.orderedAggregator
+                               └── *exec.hashGrouper
 
 # Query 12
 query error unable to vectorize execution plan: sum on int cols not supported
@@ -784,23 +711,15 @@ EXPLAIN (VEC) SELECT c_count, count(*) AS custdist FROM ( SELECT c_custkey, coun
 ----
  │
  └── Node 1
-      └── *distsqlrun.materializer
-           └── *exec.sortOp
-                └── *exec.allSpooler
+      └── *exec.sortOp
+           └── *exec.orderedAggregator
+                └── *exec.hashGrouper
                      └── *exec.orderedAggregator
                           └── *exec.hashGrouper
-                               └── *exec.simpleProjectOp
-                                    └── *exec.orderedAggregator
-                                         └── *exec.hashGrouper
-                                              └── *exec.simpleProjectOp
-                                                   └── *exec.hashJoinEqOp
-                                                        ├── *exec.simpleProjectOp
-                                                        │    └── *exec.selNotRegexpBytesBytesConstOp
-                                                        │         └── *exec.CancelChecker
-                                                        │              └── *distsqlrun.colBatchScan
-                                                        └── *exec.simpleProjectOp
-                                                             └── *exec.CancelChecker
-                                                                  └── *distsqlrun.colBatchScan
+                               └── *exec.hashJoinEqOp
+                                    ├── *exec.selNotRegexpBytesBytesConstOp
+                                    │    └── *distsqlrun.colBatchScan
+                                    └── *distsqlrun.colBatchScan
 
 # Query 14
 query T
@@ -808,23 +727,16 @@ EXPLAIN (VEC) SELECT 100.00 * sum(CASE WHEN p_type LIKE 'PROMO%' THEN l_extended
 ----
  │
  └── Node 1
-      └── *distsqlrun.materializer
-           └── *exec.simpleProjectOp
-                └── *exec.projDivFloat64Float64Op
-                     └── *exec.projMultFloat64Float64ConstOp
-                          └── *exec.orderedAggregator
-                               └── *exec.oneShotOp
-                                    └── *exec.distinctChainOps
-                                         └── *exec.simpleProjectOp
-                                              └── *exec.projMultFloat64Float64Op
-                                                   └── *exec.projMinusFloat64ConstFloat64Op
-                                                        └── *exec.caseOp
-                                                             └── *exec.bufferOp
-                                                                  └── *exec.hashJoinEqOp
-                                                                       ├── *exec.simpleProjectOp
-                                                                       │    └── *exec.CancelChecker
-                                                                       │         └── *distsqlrun.colBatchScan
-                                                                       └── *distsqlrun.columnarizer
+      └── *exec.projDivFloat64Float64Op
+           └── *exec.projMultFloat64Float64ConstOp
+                └── *exec.orderedAggregator
+                     └── *exec.oneShotOp
+                          └── *exec.distinctChainOps
+                               └── *exec.projMultFloat64Float64Op
+                                    └── *exec.projMinusFloat64ConstFloat64Op
+                                         └── *exec.caseOp
+                                              └── *exec.hashJoinEqOp
+                                                   └── *distsqlrun.colBatchScan
 
 # Query 15
 #-- TODO(yuzefovich): figure out how to execute this query consisting of three
@@ -841,13 +753,10 @@ EXPLAIN (VEC) SELECT sum(l_extendedprice) / 7.0 AS avg_yearly FROM lineitem, par
 ----
  │
  └── Node 1
-      └── *distsqlrun.materializer
-           └── *exec.simpleProjectOp
-                └── *exec.projDivFloat64Float64ConstOp
-                     └── *exec.orderedAggregator
-                          └── *exec.oneShotOp
-                               └── *exec.distinctChainOps
-                                    └── *distsqlrun.columnarizer
+      └── *exec.projDivFloat64Float64ConstOp
+           └── *exec.orderedAggregator
+                └── *exec.oneShotOp
+                     └── *exec.distinctChainOps
 
 # Query 18
 query T
@@ -855,13 +764,10 @@ EXPLAIN (VEC) SELECT c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, s
 ----
  │
  └── Node 1
-      └── *distsqlrun.materializer
-           └── *exec.limitOp
-                └── *exec.simpleProjectOp
-                     └── *exec.topKSorter
-                          └── *exec.orderedAggregator
-                               └── *exec.hashGrouper
-                                    └── *distsqlrun.columnarizer
+      └── *exec.limitOp
+           └── *exec.topKSorter
+                └── *exec.orderedAggregator
+                     └── *exec.hashGrouper
 
 # Query 19
 query T
@@ -869,28 +775,18 @@ EXPLAIN (VEC) SELECT sum(l_extendedprice* (1 - l_discount)) AS revenue FROM line
 ----
  │
  └── Node 1
-      └── *distsqlrun.materializer
-           └── *exec.orderedAggregator
-                └── *exec.oneShotOp
-                     └── *exec.distinctChainOps
-                          └── *exec.simpleProjectOp
-                               └── *exec.projMultFloat64Float64Op
-                                    └── *exec.projMinusFloat64ConstFloat64Op
-                                         └── *exec.simpleProjectOp
-                                              └── *exec.boolVecToSelOp
-                                                   └── *exec.selBoolOp
-                                                        └── *exec.caseOp
-                                                             └── *exec.bufferOp
-                                                                  └── *exec.hashJoinEqOp
-                                                                       ├── *exec.simpleProjectOp
-                                                                       │    └── *exec.selEQBytesBytesConstOp
-                                                                       │         └── *exec.selectInOpBytes
-                                                                       │              └── *exec.CancelChecker
-                                                                       │                   └── *distsqlrun.colBatchScan
-                                                                       └── *exec.simpleProjectOp
-                                                                            └── *exec.selGEInt64Int64ConstOp
-                                                                                 └── *exec.CancelChecker
-                                                                                      └── *distsqlrun.colBatchScan
+      └── *exec.orderedAggregator
+           └── *exec.oneShotOp
+                └── *exec.distinctChainOps
+                     └── *exec.projMultFloat64Float64Op
+                          └── *exec.projMinusFloat64ConstFloat64Op
+                               └── *exec.caseOp
+                                    └── *exec.hashJoinEqOp
+                                         ├── *exec.selEQBytesBytesConstOp
+                                         │    └── *exec.selectInOpBytes
+                                         │         └── *distsqlrun.colBatchScan
+                                         └── *exec.selGEInt64Int64ConstOp
+                                              └── *distsqlrun.colBatchScan
 
 # Query 20
 query T
@@ -898,36 +794,21 @@ EXPLAIN (VEC) SELECT s_name, s_address FROM supplier, nation WHERE s_suppkey IN 
 ----
  │
  └── Node 1
-      └── *distsqlrun.materializer
-           └── *exec.sortOp
-                └── *exec.allSpooler
-                     └── *exec.simpleProjectOp
-                          └── *exec.hashJoinEqOp
-                               ├── *exec.hashJoinEqOp
-                               │    ├── *exec.simpleProjectOp
-                               │    │    └── *exec.CancelChecker
-                               │    │         └── *distsqlrun.colBatchScan
-                               │    └── *exec.simpleProjectOp
-                               │         └── *exec.hashJoinEqOp
-                               │              ├── *exec.simpleProjectOp
-                               │              │    └── *exec.selGTInt64Float64Op
-                               │              │         └── *exec.projMultFloat64Float64ConstOp
-                               │              │              └── *exec.orderedAggregator
-                               │              │                   └── *exec.hashGrouper
-                               │              │                        └── *exec.simpleProjectOp
-                               │              │                             └── *exec.hashJoinEqOp
-                               │              │                                  ├── *distsqlrun.columnarizer
-                               │              │                                  └── *exec.simpleProjectOp
-                               │              │                                       └── *exec.CancelChecker
-                               │              │                                            └── *distsqlrun.colBatchScan
-                               │              └── *exec.simpleProjectOp
-                               │                   └── *exec.selPrefixBytesBytesConstOp
-                               │                        └── *exec.CancelChecker
-                               │                             └── *distsqlrun.colBatchScan
-                               └── *exec.simpleProjectOp
-                                    └── *exec.selEQBytesBytesConstOp
-                                         └── *exec.CancelChecker
-                                              └── *distsqlrun.colBatchScan
+      └── *exec.sortOp
+           └── *exec.hashJoinEqOp
+                ├── *exec.hashJoinEqOp
+                │    ├── *distsqlrun.colBatchScan
+                │    └── *exec.hashJoinEqOp
+                │         ├── *exec.selGTInt64Float64Op
+                │         │    └── *exec.projMultFloat64Float64ConstOp
+                │         │         └── *exec.orderedAggregator
+                │         │              └── *exec.hashGrouper
+                │         │                   └── *exec.hashJoinEqOp
+                │         │                        └── *distsqlrun.colBatchScan
+                │         └── *exec.selPrefixBytesBytesConstOp
+                │              └── *distsqlrun.colBatchScan
+                └── *exec.selEQBytesBytesConstOp
+                     └── *distsqlrun.colBatchScan
 
 # Query 21
 query error can't plan non-inner hash join with on expressions
@@ -939,9 +820,6 @@ EXPLAIN (VEC) SELECT cntrycode, count(*) AS numcust, sum(c_acctbal) AS totacctba
 ----
  │
  └── Node 1
-      └── *distsqlrun.materializer
-           └── *exec.sortOp
-                └── *exec.allSpooler
-                     └── *exec.orderedAggregator
-                          └── *exec.hashGrouper
-                               └── *distsqlrun.columnarizer
+      └── *exec.sortOp
+           └── *exec.orderedAggregator
+                └── *exec.hashGrouper

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1175,6 +1175,7 @@ func (ef *execFactory) ConstructExplain(
 
 	case tree.ExplainVec:
 		return &explainVecNode{
+			options:       options,
 			plan:          p.plan,
 			subqueryPlans: p.subqueryPlans,
 			stmtType:      stmtType,


### PR DESCRIPTION
This commits adds NonExplainable marker interface which operators
can choose to implement so that they are omitted from the output
of EXPLAIN (VEC). It is intended that non-core operators will be
marked. Additionally, now a VERBOSE explain option is supported
which overrides the omitting behavior.

Release note: None