### PR TITLE
exec: avoid skipping AppendCol calls

### DIFF
--- a/pkg/sql/exec/and.go
+++ b/pkg/sql/exec/and.go
@@ -42,12 +42,12 @@ func (a *andOp) Init() {
 
 func (a *andOp) Next(ctx context.Context) coldata.Batch {
 	batch := a.input.Next(ctx)
+	if a.outputIdx == batch.Width() {
+		batch.AppendCol(coltypes.Bool)
+	}
 	n := batch.Length()
 	if n == 0 {
 		return batch
-	}
-	if a.outputIdx == batch.Width() {
-		batch.AppendCol(coltypes.Bool)
 	}
 	leftCol := batch.ColVec(a.leftIdx).Bool()
 	rightCol := batch.ColVec(a.rightIdx).Bool()

--- a/pkg/sql/exec/builtin_funcs.go
+++ b/pkg/sql/exec/builtin_funcs.go
@@ -113,13 +113,13 @@ func (s *substringFunctionOperator) Init() {
 
 func (s *substringFunctionOperator) Next(ctx context.Context) coldata.Batch {
 	batch := s.input.Next(ctx)
+	if s.outputIdx == batch.Width() {
+		batch.AppendCol(coltypes.Bytes)
+	}
+
 	n := batch.Length()
 	if n == 0 {
 		return batch
-	}
-
-	if s.outputIdx == batch.Width() {
-		batch.AppendCol(coltypes.Bytes)
 	}
 
 	sel := batch.Selection()

--- a/pkg/sql/exec/cast_tmpl.go
+++ b/pkg/sql/exec/cast_tmpl.go
@@ -126,12 +126,12 @@ func (c *castOpNullAny) Init() {
 
 func (c *castOpNullAny) Next(ctx context.Context) coldata.Batch {
 	batch := c.input.Next(ctx)
+	if c.outputIdx == batch.Width() {
+		batch.AppendCol(c.toType)
+	}
 	n := batch.Length()
 	if n == 0 {
 		return batch
-	}
-	if c.outputIdx == batch.Width() {
-		batch.AppendCol(c.toType)
 	}
 	vec := batch.ColVec(c.colIdx)
 	projVec := batch.ColVec(c.outputIdx)


### PR DESCRIPTION
A few of the vectorized operators were not appending their output
column if the input batch was empty. This was sometimes causing errors
in CASE operations, because an "empty" batch might later have its
selection vector altered to be non-empty, and then the expected column
would be missing. I changed around the ordering so that AppendCol is
always called on the first invocation of Next().

This is still somewhat brittle because it's easy enough for someone to
add a new operator with the same bug. It would be better to manage
columns at a higher level, but that is a bigger project.

Fixes #40517

Release note: None