### PR TITLE
sql: fix a funky zone config in a test

### DIFF
--- a/pkg/sql/zone_config_test.go
+++ b/pkg/sql/zone_config_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 )
 
 var configID = sqlbase.ID(1)
@@ -88,8 +89,9 @@ func TestGetZoneConfig(t *testing.T) {
 	defaultZoneConfig := config.DefaultSystemZoneConfig()
 	defaultZoneConfig.NumReplicas = proto.Int32(1)
 	defaultZoneConfig.RangeMinBytes = proto.Int64(1 << 20)
-	defaultZoneConfig.RangeMaxBytes = proto.Int64(1 << 20)
+	defaultZoneConfig.RangeMaxBytes = proto.Int64(1 << 21)
 	defaultZoneConfig.GC = &config.GCPolicy{TTLSeconds: 60}
+	require.NoError(t, defaultZoneConfig.Validate())
 	params.Knobs.Server = &server.TestingKnobs{
 		DefaultZoneConfigOverride:       &defaultZoneConfig,
 		DefaultSystemZoneConfigOverride: &defaultZoneConfig,
@@ -323,8 +325,9 @@ func TestCascadingZoneConfig(t *testing.T) {
 	defaultZoneConfig := config.DefaultZoneConfig()
 	defaultZoneConfig.NumReplicas = proto.Int32(1)
 	defaultZoneConfig.RangeMinBytes = proto.Int64(1 << 20)
-	defaultZoneConfig.RangeMaxBytes = proto.Int64(1 << 20)
+	defaultZoneConfig.RangeMaxBytes = proto.Int64(1 << 21)
 	defaultZoneConfig.GC = &config.GCPolicy{TTLSeconds: 60}
+	require.NoError(t, defaultZoneConfig.Validate())
 	params.Knobs.Server = &server.TestingKnobs{
 		DefaultZoneConfigOverride:       &defaultZoneConfig,
 		DefaultSystemZoneConfigOverride: &defaultZoneConfig,


### PR DESCRIPTION
The zone config in question was invalid (min bytes = max byte), but the
test didn't care cause it's a hacky test that happened to never validate
it. But as soon as you do unrelated changes to the system (e.g.
introduce a system zone config that inherits from another system zone
config), this test unexpectedly starts yelling.

Release note: None