### PR TITLE
exec: make the output of explain(vec) more compact

### DIFF
--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -119,7 +119,7 @@ func (n *explainVecNode) startExec(params runParams) error {
 	}
 	// Sort backward, since the first thing you add to a treeprinter will come last.
 	sort.Slice(sortedFlows, func(i, j int) bool { return sortedFlows[i].nodeID < sortedFlows[j].nodeID })
-	tp := treeprinter.New()
+	tp := treeprinter.NewWithIndent(false /* leftPad */, true /* rightPad */, 0 /* edgeLength */)
 	root := tp.Child("")
 	verbose := n.options.Flags.Contains(tree.ExplainFlagVerbose)
 	for _, flow := range sortedFlows {

--- a/pkg/sql/logictest/testdata/logic_test/dist_vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/dist_vectorize
@@ -89,178 +89,178 @@ RESET optimizer
 query T
 EXPLAIN (VEC, VERBOSE) SELECT count(*) FROM kv
 ----
- │
- ├── Node 1
- │    └── *distsqlrun.materializer
- │         └── *exec.orderedAggregator
- │              └── *exec.oneShotOp
- │                   └── *exec.distinctChainOps
- │                        └── *exec.UnorderedSynchronizer
- │                             ├── *exec.countOp
- │                             │    └── *exec.simpleProjectOp
- │                             │         └── *exec.CancelChecker
- │                             │              └── *distsqlrun.colBatchScan
- │                             ├── *colrpc.Inbox
- │                             ├── *colrpc.Inbox
- │                             ├── *colrpc.Inbox
- │                             └── *colrpc.Inbox
- ├── Node 2
- │    └── *colrpc.Outbox
- │         └── *exec.deselectorOp
- │              └── *exec.countOp
- │                   └── *exec.simpleProjectOp
- │                        └── *exec.CancelChecker
- │                             └── *distsqlrun.colBatchScan
- ├── Node 3
- │    └── *colrpc.Outbox
- │         └── *exec.deselectorOp
- │              └── *exec.countOp
- │                   └── *exec.simpleProjectOp
- │                        └── *exec.CancelChecker
- │                             └── *distsqlrun.colBatchScan
- ├── Node 4
- │    └── *colrpc.Outbox
- │         └── *exec.deselectorOp
- │              └── *exec.countOp
- │                   └── *exec.simpleProjectOp
- │                        └── *exec.CancelChecker
- │                             └── *distsqlrun.colBatchScan
- └── Node 5
-      └── *colrpc.Outbox
-           └── *exec.deselectorOp
-                └── *exec.countOp
-                     └── *exec.simpleProjectOp
-                          └── *exec.CancelChecker
-                               └── *distsqlrun.colBatchScan
+│
+├ Node 1
+│ └ *distsqlrun.materializer
+│   └ *exec.orderedAggregator
+│     └ *exec.oneShotOp
+│       └ *exec.distinctChainOps
+│         └ *exec.UnorderedSynchronizer
+│           ├ *exec.countOp
+│           │ └ *exec.simpleProjectOp
+│           │   └ *exec.CancelChecker
+│           │     └ *distsqlrun.colBatchScan
+│           ├ *colrpc.Inbox
+│           ├ *colrpc.Inbox
+│           ├ *colrpc.Inbox
+│           └ *colrpc.Inbox
+├ Node 2
+│ └ *colrpc.Outbox
+│   └ *exec.deselectorOp
+│     └ *exec.countOp
+│       └ *exec.simpleProjectOp
+│         └ *exec.CancelChecker
+│           └ *distsqlrun.colBatchScan
+├ Node 3
+│ └ *colrpc.Outbox
+│   └ *exec.deselectorOp
+│     └ *exec.countOp
+│       └ *exec.simpleProjectOp
+│         └ *exec.CancelChecker
+│           └ *distsqlrun.colBatchScan
+├ Node 4
+│ └ *colrpc.Outbox
+│   └ *exec.deselectorOp
+│     └ *exec.countOp
+│       └ *exec.simpleProjectOp
+│         └ *exec.CancelChecker
+│           └ *distsqlrun.colBatchScan
+└ Node 5
+  └ *colrpc.Outbox
+    └ *exec.deselectorOp
+      └ *exec.countOp
+        └ *exec.simpleProjectOp
+          └ *exec.CancelChecker
+            └ *distsqlrun.colBatchScan
 
 query T
 EXPLAIN (VEC, VERBOSE) SELECT count(*) FROM kv NATURAL INNER HASH JOIN kv kv2
 ----
- │
- ├── Node 1
- │    └── *distsqlrun.materializer
- │         └── *exec.orderedAggregator
- │              └── *exec.oneShotOp
- │                   └── *exec.distinctChainOps
- │                        └── *exec.UnorderedSynchronizer
- │                             ├── *exec.countOp
- │                             │    └── *exec.simpleProjectOp
- │                             │         └── *exec.hashJoinEqOp
- │                             │              ├── *exec.UnorderedSynchronizer
- │                             │              │    ├── *exec.routerOutputOp
- │                             │              │    │    └── *exec.HashRouter
- │                             │              │    │         └── *exec.CancelChecker
- │                             │              │    │              └── *distsqlrun.colBatchScan
- │                             │              │    ├── *colrpc.Inbox
- │                             │              │    ├── *colrpc.Inbox
- │                             │              │    ├── *colrpc.Inbox
- │                             │              │    └── *colrpc.Inbox
- │                             │              └── *exec.UnorderedSynchronizer
- │                             │                   ├── *exec.routerOutputOp
- │                             │                   │    └── *exec.HashRouter
- │                             │                   │         └── *exec.CancelChecker
- │                             │                   │              └── *distsqlrun.colBatchScan
- │                             │                   ├── *colrpc.Inbox
- │                             │                   ├── *colrpc.Inbox
- │                             │                   ├── *colrpc.Inbox
- │                             │                   └── *colrpc.Inbox
- │                             ├── *colrpc.Inbox
- │                             ├── *colrpc.Inbox
- │                             ├── *colrpc.Inbox
- │                             └── *colrpc.Inbox
- ├── Node 2
- │    └── *colrpc.Outbox
- │         └── *exec.deselectorOp
- │              └── *exec.countOp
- │                   └── *exec.simpleProjectOp
- │                        └── *exec.hashJoinEqOp
- │                             ├── *exec.UnorderedSynchronizer
- │                             │    ├── *colrpc.Inbox
- │                             │    ├── *exec.routerOutputOp
- │                             │    │    └── *exec.HashRouter
- │                             │    │         └── *exec.CancelChecker
- │                             │    │              └── *distsqlrun.colBatchScan
- │                             │    ├── *colrpc.Inbox
- │                             │    ├── *colrpc.Inbox
- │                             │    └── *colrpc.Inbox
- │                             └── *exec.UnorderedSynchronizer
- │                                  ├── *colrpc.Inbox
- │                                  ├── *exec.routerOutputOp
- │                                  │    └── *exec.HashRouter
- │                                  │         └── *exec.CancelChecker
- │                                  │              └── *distsqlrun.colBatchScan
- │                                  ├── *colrpc.Inbox
- │                                  ├── *colrpc.Inbox
- │                                  └── *colrpc.Inbox
- ├── Node 3
- │    └── *colrpc.Outbox
- │         └── *exec.deselectorOp
- │              └── *exec.countOp
- │                   └── *exec.simpleProjectOp
- │                        └── *exec.hashJoinEqOp
- │                             ├── *exec.UnorderedSynchronizer
- │                             │    ├── *colrpc.Inbox
- │                             │    ├── *colrpc.Inbox
- │                             │    ├── *exec.routerOutputOp
- │                             │    │    └── *exec.HashRouter
- │                             │    │         └── *exec.CancelChecker
- │                             │    │              └── *distsqlrun.colBatchScan
- │                             │    ├── *colrpc.Inbox
- │                             │    └── *colrpc.Inbox
- │                             └── *exec.UnorderedSynchronizer
- │                                  ├── *colrpc.Inbox
- │                                  ├── *colrpc.Inbox
- │                                  ├── *exec.routerOutputOp
- │                                  │    └── *exec.HashRouter
- │                                  │         └── *exec.CancelChecker
- │                                  │              └── *distsqlrun.colBatchScan
- │                                  ├── *colrpc.Inbox
- │                                  └── *colrpc.Inbox
- ├── Node 4
- │    └── *colrpc.Outbox
- │         └── *exec.deselectorOp
- │              └── *exec.countOp
- │                   └── *exec.simpleProjectOp
- │                        └── *exec.hashJoinEqOp
- │                             ├── *exec.UnorderedSynchronizer
- │                             │    ├── *colrpc.Inbox
- │                             │    ├── *colrpc.Inbox
- │                             │    ├── *colrpc.Inbox
- │                             │    ├── *exec.routerOutputOp
- │                             │    │    └── *exec.HashRouter
- │                             │    │         └── *exec.CancelChecker
- │                             │    │              └── *distsqlrun.colBatchScan
- │                             │    └── *colrpc.Inbox
- │                             └── *exec.UnorderedSynchronizer
- │                                  ├── *colrpc.Inbox
- │                                  ├── *colrpc.Inbox
- │                                  ├── *colrpc.Inbox
- │                                  ├── *exec.routerOutputOp
- │                                  │    └── *exec.HashRouter
- │                                  │         └── *exec.CancelChecker
- │                                  │              └── *distsqlrun.colBatchScan
- │                                  └── *colrpc.Inbox
- └── Node 5
-      └── *colrpc.Outbox
-           └── *exec.deselectorOp
-                └── *exec.countOp
-                     └── *exec.simpleProjectOp
-                          └── *exec.hashJoinEqOp
-                               ├── *exec.UnorderedSynchronizer
-                               │    ├── *colrpc.Inbox
-                               │    ├── *colrpc.Inbox
-                               │    ├── *colrpc.Inbox
-                               │    ├── *colrpc.Inbox
-                               │    └── *exec.routerOutputOp
-                               │         └── *exec.HashRouter
-                               │              └── *exec.CancelChecker
-                               │                   └── *distsqlrun.colBatchScan
-                               └── *exec.UnorderedSynchronizer
-                                    ├── *colrpc.Inbox
-                                    ├── *colrpc.Inbox
-                                    ├── *colrpc.Inbox
-                                    ├── *colrpc.Inbox
-                                    └── *exec.routerOutputOp
-                                         └── *exec.HashRouter
-                                              └── *exec.CancelChecker
-                                                   └── *distsqlrun.colBatchScan
+│
+├ Node 1
+│ └ *distsqlrun.materializer
+│   └ *exec.orderedAggregator
+│     └ *exec.oneShotOp
+│       └ *exec.distinctChainOps
+│         └ *exec.UnorderedSynchronizer
+│           ├ *exec.countOp
+│           │ └ *exec.simpleProjectOp
+│           │   └ *exec.hashJoinEqOp
+│           │     ├ *exec.UnorderedSynchronizer
+│           │     │ ├ *exec.routerOutputOp
+│           │     │ │ └ *exec.HashRouter
+│           │     │ │   └ *exec.CancelChecker
+│           │     │ │     └ *distsqlrun.colBatchScan
+│           │     │ ├ *colrpc.Inbox
+│           │     │ ├ *colrpc.Inbox
+│           │     │ ├ *colrpc.Inbox
+│           │     │ └ *colrpc.Inbox
+│           │     └ *exec.UnorderedSynchronizer
+│           │       ├ *exec.routerOutputOp
+│           │       │ └ *exec.HashRouter
+│           │       │   └ *exec.CancelChecker
+│           │       │     └ *distsqlrun.colBatchScan
+│           │       ├ *colrpc.Inbox
+│           │       ├ *colrpc.Inbox
+│           │       ├ *colrpc.Inbox
+│           │       └ *colrpc.Inbox
+│           ├ *colrpc.Inbox
+│           ├ *colrpc.Inbox
+│           ├ *colrpc.Inbox
+│           └ *colrpc.Inbox
+├ Node 2
+│ └ *colrpc.Outbox
+│   └ *exec.deselectorOp
+│     └ *exec.countOp
+│       └ *exec.simpleProjectOp
+│         └ *exec.hashJoinEqOp
+│           ├ *exec.UnorderedSynchronizer
+│           │ ├ *colrpc.Inbox
+│           │ ├ *exec.routerOutputOp
+│           │ │ └ *exec.HashRouter
+│           │ │   └ *exec.CancelChecker
+│           │ │     └ *distsqlrun.colBatchScan
+│           │ ├ *colrpc.Inbox
+│           │ ├ *colrpc.Inbox
+│           │ └ *colrpc.Inbox
+│           └ *exec.UnorderedSynchronizer
+│             ├ *colrpc.Inbox
+│             ├ *exec.routerOutputOp
+│             │ └ *exec.HashRouter
+│             │   └ *exec.CancelChecker
+│             │     └ *distsqlrun.colBatchScan
+│             ├ *colrpc.Inbox
+│             ├ *colrpc.Inbox
+│             └ *colrpc.Inbox
+├ Node 3
+│ └ *colrpc.Outbox
+│   └ *exec.deselectorOp
+│     └ *exec.countOp
+│       └ *exec.simpleProjectOp
+│         └ *exec.hashJoinEqOp
+│           ├ *exec.UnorderedSynchronizer
+│           │ ├ *colrpc.Inbox
+│           │ ├ *colrpc.Inbox
+│           │ ├ *exec.routerOutputOp
+│           │ │ └ *exec.HashRouter
+│           │ │   └ *exec.CancelChecker
+│           │ │     └ *distsqlrun.colBatchScan
+│           │ ├ *colrpc.Inbox
+│           │ └ *colrpc.Inbox
+│           └ *exec.UnorderedSynchronizer
+│             ├ *colrpc.Inbox
+│             ├ *colrpc.Inbox
+│             ├ *exec.routerOutputOp
+│             │ └ *exec.HashRouter
+│             │   └ *exec.CancelChecker
+│             │     └ *distsqlrun.colBatchScan
+│             ├ *colrpc.Inbox
+│             └ *colrpc.Inbox
+├ Node 4
+│ └ *colrpc.Outbox
+│   └ *exec.deselectorOp
+│     └ *exec.countOp
+│       └ *exec.simpleProjectOp
+│         └ *exec.hashJoinEqOp
+│           ├ *exec.UnorderedSynchronizer
+│           │ ├ *colrpc.Inbox
+│           │ ├ *colrpc.Inbox
+│           │ ├ *colrpc.Inbox
+│           │ ├ *exec.routerOutputOp
+│           │ │ └ *exec.HashRouter
+│           │ │   └ *exec.CancelChecker
+│           │ │     └ *distsqlrun.colBatchScan
+│           │ └ *colrpc.Inbox
+│           └ *exec.UnorderedSynchronizer
+│             ├ *colrpc.Inbox
+│             ├ *colrpc.Inbox
+│             ├ *colrpc.Inbox
+│             ├ *exec.routerOutputOp
+│             │ └ *exec.HashRouter
+│             │   └ *exec.CancelChecker
+│             │     └ *distsqlrun.colBatchScan
+│             └ *colrpc.Inbox
+└ Node 5
+  └ *colrpc.Outbox
+    └ *exec.deselectorOp
+      └ *exec.countOp
+        └ *exec.simpleProjectOp
+          └ *exec.hashJoinEqOp
+            ├ *exec.UnorderedSynchronizer
+            │ ├ *colrpc.Inbox
+            │ ├ *colrpc.Inbox
+            │ ├ *colrpc.Inbox
+            │ ├ *colrpc.Inbox
+            │ └ *exec.routerOutputOp
+            │   └ *exec.HashRouter
+            │     └ *exec.CancelChecker
+            │       └ *distsqlrun.colBatchScan
+            └ *exec.UnorderedSynchronizer
+              ├ *colrpc.Inbox
+              ├ *colrpc.Inbox
+              ├ *colrpc.Inbox
+              ├ *colrpc.Inbox
+              └ *exec.routerOutputOp
+                └ *exec.HashRouter
+                  └ *exec.CancelChecker
+                    └ *distsqlrun.colBatchScan

--- a/pkg/sql/logictest/testdata/logic_test/tpch_vec
+++ b/pkg/sql/logictest/testdata/logic_test/tpch_vec
@@ -530,229 +530,229 @@ ALTER TABLE public.lineitem INJECT STATISTICS '[
 query T
 EXPLAIN (VEC) SELECT l_returnflag, l_linestatus, sum(l_quantity) AS sum_qty, sum(l_extendedprice) AS sum_base_price, sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price, sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge, avg(l_quantity) AS avg_qty, avg(l_extendedprice) AS avg_price, avg(l_discount) AS avg_disc, count(*) AS count_order FROM lineitem WHERE l_shipdate <= DATE '1998-12-01' - INTERVAL '90' DAY GROUP BY l_returnflag, l_linestatus ORDER BY l_returnflag, l_linestatus
 ----
- │
- └── Node 1
-      └── *exec.sortOp
-           └── *exec.orderedAggregator
-                └── *exec.hashGrouper
-                     └── *exec.projMultFloat64Float64Op
-                          └── *exec.projPlusFloat64Float64ConstOp
-                               └── *exec.projMultFloat64Float64Op
-                                    └── *exec.projMinusFloat64ConstFloat64Op
-                                         └── *exec.projMultFloat64Float64Op
-                                              └── *exec.projMinusFloat64ConstFloat64Op
-                                                   └── *exec.selLEInt64Int64ConstOp
-                                                        └── *distsqlrun.colBatchScan
+│
+└ Node 1
+  └ *exec.sortOp
+    └ *exec.orderedAggregator
+      └ *exec.hashGrouper
+        └ *exec.projMultFloat64Float64Op
+          └ *exec.projPlusFloat64Float64ConstOp
+            └ *exec.projMultFloat64Float64Op
+              └ *exec.projMinusFloat64ConstFloat64Op
+                └ *exec.projMultFloat64Float64Op
+                  └ *exec.projMinusFloat64ConstFloat64Op
+                    └ *exec.selLEInt64Int64ConstOp
+                      └ *distsqlrun.colBatchScan
 
 # Query 2
 query T
 EXPLAIN (VEC) SELECT s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment FROM part, supplier, partsupp, nation, region WHERE p_partkey = ps_partkey AND s_suppkey = ps_suppkey AND p_size = 15 AND p_type LIKE '%BRASS' AND s_nationkey = n_nationkey AND n_regionkey = r_regionkey AND r_name = 'EUROPE' AND ps_supplycost = ( SELECT min(ps_supplycost) FROM partsupp, supplier, nation, region WHERE p_partkey = ps_partkey AND s_suppkey = ps_suppkey AND s_nationkey = n_nationkey AND n_regionkey = r_regionkey AND r_name = 'EUROPE') ORDER BY s_acctbal DESC, n_name, s_name, p_partkey LIMIT 100
 ----
- │
- └── Node 1
-      └── *exec.limitOp
-           └── *exec.topKSorter
-                └── *exec.selEQFloat64Float64Op
-                     └── *exec.orderedAggregator
-                          └── *exec.hashGrouper
-                               └── *exec.hashJoinEqOp
-                                    ├── *exec.hashJoinEqOp
-                                    │    ├── *distsqlrun.colBatchScan
-                                    │    └── *distsqlrun.joinReader
-                                    │         └── *distsqlrun.joinReader
-                                    │              └── *exec.selEQBytesBytesConstOp
-                                    │                   └── *distsqlrun.colBatchScan
-                                    └── *exec.hashJoinEqOp
-                                         ├── *exec.hashJoinEqOp
-                                         │    ├── *distsqlrun.colBatchScan
-                                         │    └── *exec.hashJoinEqOp
-                                         │         ├── *distsqlrun.colBatchScan
-                                         │         └── *exec.hashJoinEqOp
-                                         │              ├── *distsqlrun.colBatchScan
-                                         │              └── *exec.selEQBytesBytesConstOp
-                                         │                   └── *distsqlrun.colBatchScan
-                                         └── *exec.selSuffixBytesBytesConstOp
-                                              └── *exec.selEQInt64Int64ConstOp
-                                                   └── *distsqlrun.colBatchScan
+│
+└ Node 1
+  └ *exec.limitOp
+    └ *exec.topKSorter
+      └ *exec.selEQFloat64Float64Op
+        └ *exec.orderedAggregator
+          └ *exec.hashGrouper
+            └ *exec.hashJoinEqOp
+              ├ *exec.hashJoinEqOp
+              │ ├ *distsqlrun.colBatchScan
+              │ └ *distsqlrun.joinReader
+              │   └ *distsqlrun.joinReader
+              │     └ *exec.selEQBytesBytesConstOp
+              │       └ *distsqlrun.colBatchScan
+              └ *exec.hashJoinEqOp
+                ├ *exec.hashJoinEqOp
+                │ ├ *distsqlrun.colBatchScan
+                │ └ *exec.hashJoinEqOp
+                │   ├ *distsqlrun.colBatchScan
+                │   └ *exec.hashJoinEqOp
+                │     ├ *distsqlrun.colBatchScan
+                │     └ *exec.selEQBytesBytesConstOp
+                │       └ *distsqlrun.colBatchScan
+                └ *exec.selSuffixBytesBytesConstOp
+                  └ *exec.selEQInt64Int64ConstOp
+                    └ *distsqlrun.colBatchScan
 
 # Query 3
 query T
 EXPLAIN (VEC) SELECT l_orderkey, sum(l_extendedprice * (1 - l_discount)) AS revenue, o_orderdate, o_shippriority FROM customer, orders, lineitem WHERE c_mktsegment = 'BUILDING' AND c_custkey = o_custkey AND l_orderkey = o_orderkey AND o_orderDATE < DATE '1995-03-15' AND l_shipdate > DATE '1995-03-15' GROUP BY l_orderkey, o_orderdate, o_shippriority ORDER BY revenue DESC, o_orderdate LIMIT 10
 ----
- │
- └── Node 1
-      └── *exec.limitOp
-           └── *exec.topKSorter
-                └── *exec.orderedAggregator
-                     └── *exec.hashGrouper
-                          └── *distsqlrun.joinReader
-                               └── *exec.hashJoinEqOp
-                                    ├── *exec.selLTInt64Int64ConstOp
-                                    │    └── *distsqlrun.colBatchScan
-                                    └── *exec.selEQBytesBytesConstOp
-                                         └── *distsqlrun.colBatchScan
+│
+└ Node 1
+  └ *exec.limitOp
+    └ *exec.topKSorter
+      └ *exec.orderedAggregator
+        └ *exec.hashGrouper
+          └ *distsqlrun.joinReader
+            └ *exec.hashJoinEqOp
+              ├ *exec.selLTInt64Int64ConstOp
+              │ └ *distsqlrun.colBatchScan
+              └ *exec.selEQBytesBytesConstOp
+                └ *distsqlrun.colBatchScan
 
 # Query 4
 query T
 EXPLAIN (VEC) SELECT o_orderpriority, count(*) AS order_count FROM orders WHERE o_orderdate >= DATE '1993-07-01' AND o_orderdate < DATE '1993-07-01' + INTERVAL '3' MONTH AND EXISTS ( SELECT * FROM lineitem WHERE l_orderkey = o_orderkey AND l_commitDATE < l_receiptdate) GROUP BY o_orderpriority ORDER BY o_orderpriority
 ----
- │
- └── Node 1
-      └── *exec.sortOp
-           └── *exec.orderedAggregator
-                └── *exec.hashGrouper
-                     └── *exec.hashJoinEqOp
-                          ├── *distsqlrun.indexJoiner
-                          │    └── *distsqlrun.colBatchScan
-                          └── *exec.selLTInt64Int64Op
-                               └── *distsqlrun.colBatchScan
+│
+└ Node 1
+  └ *exec.sortOp
+    └ *exec.orderedAggregator
+      └ *exec.hashGrouper
+        └ *exec.hashJoinEqOp
+          ├ *distsqlrun.indexJoiner
+          │ └ *distsqlrun.colBatchScan
+          └ *exec.selLTInt64Int64Op
+            └ *distsqlrun.colBatchScan
 
 # Query 5
 query T
 EXPLAIN (VEC) SELECT n_name, sum(l_extendedprice * (1 - l_discount)) AS revenue FROM customer, orders, lineitem, supplier, nation, region WHERE c_custkey = o_custkey AND l_orderkey = o_orderkey AND l_suppkey = s_suppkey AND c_nationkey = s_nationkey AND s_nationkey = n_nationkey AND n_regionkey = r_regionkey AND r_name = 'ASIA' AND o_orderDATE >= DATE '1994-01-01' AND o_orderDATE < DATE '1994-01-01' + INTERVAL '1' YEAR GROUP BY n_name ORDER BY revenue DESC
 ----
- │
- └── Node 1
-      └── *exec.sortOp
-           └── *exec.orderedAggregator
-                └── *exec.hashGrouper
-                     └── *exec.projMultFloat64Float64Op
-                          └── *exec.projMinusFloat64ConstFloat64Op
-                               └── *exec.hashJoinEqOp
-                                    ├── *exec.hashJoinEqOp
-                                    │    ├── *exec.hashJoinEqOp
-                                    │    │    ├── *distsqlrun.colBatchScan
-                                    │    │    └── *distsqlrun.joinReader
-                                    │    │         └── *exec.hashJoinEqOp
-                                    │    │              ├── *distsqlrun.colBatchScan
-                                    │    │              └── *exec.selEQBytesBytesConstOp
-                                    │    │                   └── *distsqlrun.colBatchScan
-                                    │    └── *distsqlrun.indexJoiner
-                                    │         └── *distsqlrun.colBatchScan
-                                    └── *distsqlrun.colBatchScan
+│
+└ Node 1
+  └ *exec.sortOp
+    └ *exec.orderedAggregator
+      └ *exec.hashGrouper
+        └ *exec.projMultFloat64Float64Op
+          └ *exec.projMinusFloat64ConstFloat64Op
+            └ *exec.hashJoinEqOp
+              ├ *exec.hashJoinEqOp
+              │ ├ *exec.hashJoinEqOp
+              │ │ ├ *distsqlrun.colBatchScan
+              │ │ └ *distsqlrun.joinReader
+              │ │   └ *exec.hashJoinEqOp
+              │ │     ├ *distsqlrun.colBatchScan
+              │ │     └ *exec.selEQBytesBytesConstOp
+              │ │       └ *distsqlrun.colBatchScan
+              │ └ *distsqlrun.indexJoiner
+              │   └ *distsqlrun.colBatchScan
+              └ *distsqlrun.colBatchScan
 
 # Query 6
 query T
 EXPLAIN (VEC) SELECT sum(l_extendedprice * l_discount) AS revenue FROM lineitem WHERE l_shipdate >= DATE '1994-01-01' AND l_shipdate < DATE '1994-01-01' + INTERVAL '1' YEAR AND l_discount BETWEEN 0.06 - 0.01 AND 0.06 + 0.01 AND l_quantity < 24
 ----
- │
- └── Node 1
-      └── *exec.orderedAggregator
-           └── *exec.oneShotOp
-                └── *exec.distinctChainOps
-                     └── *distsqlrun.indexJoiner
-                          └── *distsqlrun.colBatchScan
+│
+└ Node 1
+  └ *exec.orderedAggregator
+    └ *exec.oneShotOp
+      └ *exec.distinctChainOps
+        └ *distsqlrun.indexJoiner
+          └ *distsqlrun.colBatchScan
 
 # Query 7
 query T
 EXPLAIN (VEC) SELECT supp_nation, cust_nation, l_year, sum(volume) AS revenue FROM ( SELECT n1.n_name AS supp_nation, n2.n_name AS cust_nation, EXTRACT(year FROM l_shipdate) AS l_year, l_extendedprice * (1 - l_discount) AS volume FROM supplier, lineitem, orders, customer, nation n1, nation n2 WHERE s_suppkey = l_suppkey AND o_orderkey = l_orderkey AND c_custkey = o_custkey AND s_nationkey = n1.n_nationkey AND c_nationkey = n2.n_nationkey AND ( (n1.n_name = 'FRANCE' AND n2.n_name = 'GERMANY') or (n1.n_name = 'GERMANY' AND n2.n_name = 'FRANCE')) AND l_shipdate BETWEEN DATE '1995-01-01' AND DATE '1996-12-31') AS shipping GROUP BY supp_nation, cust_nation, l_year ORDER BY supp_nation, cust_nation, l_year
 ----
- │
- └── Node 1
-      └── *exec.sortOp
-           └── *exec.orderedAggregator
-                └── *exec.hashGrouper
-                     └── *exec.projMultFloat64Float64Op
-                          └── *exec.projMinusFloat64ConstFloat64Op
-                               └── *exec.defaultBuiltinFuncOperator
-                                    └── *exec.constBytesOp
-                                         └── *exec.hashJoinEqOp
-                                              ├── *distsqlrun.joinReader
-                                              │    └── *distsqlrun.joinReader
-                                              │         └── *distsqlrun.joinReader
-                                              │              └── *exec.caseOp
-                                              │                   └── *exec.hashJoinEqOp
-                                              │                        ├── *distsqlrun.colBatchScan
-                                              │                        └── *distsqlrun.colBatchScan
-                                              └── *distsqlrun.colBatchScan
+│
+└ Node 1
+  └ *exec.sortOp
+    └ *exec.orderedAggregator
+      └ *exec.hashGrouper
+        └ *exec.projMultFloat64Float64Op
+          └ *exec.projMinusFloat64ConstFloat64Op
+            └ *exec.defaultBuiltinFuncOperator
+              └ *exec.constBytesOp
+                └ *exec.hashJoinEqOp
+                  ├ *distsqlrun.joinReader
+                  │ └ *distsqlrun.joinReader
+                  │   └ *distsqlrun.joinReader
+                  │     └ *exec.caseOp
+                  │       └ *exec.hashJoinEqOp
+                  │         ├ *distsqlrun.colBatchScan
+                  │         └ *distsqlrun.colBatchScan
+                  └ *distsqlrun.colBatchScan
 
 # Query 8
 query T
 EXPLAIN (VEC) SELECT o_year, sum(CASE WHEN nation = 'BRAZIL' THEN volume ELSE 0 END) / sum(volume) AS mkt_share FROM ( SELECT EXTRACT(year FROM o_orderdate) AS o_year, l_extendedprice * (1 - l_discount) AS volume, n2.n_name AS nation FROM part, supplier, lineitem, orders, customer, nation n1, nation n2, region WHERE p_partkey = l_partkey AND s_suppkey = l_suppkey AND l_orderkey = o_orderkey AND o_custkey = c_custkey AND c_nationkey = n1.n_nationkey AND n1.n_regionkey = r_regionkey AND r_name = 'AMERICA' AND s_nationkey = n2.n_nationkey AND o_orderdate BETWEEN DATE '1995-01-01' AND DATE '1996-12-31' AND p_type = 'ECONOMY ANODIZED STEEL') AS all_nations GROUP BY o_year ORDER BY o_year
 ----
- │
- └── Node 1
-      └── *exec.sortOp
-           └── *exec.projDivFloat64Float64Op
-                └── *exec.orderedAggregator
-                     └── *exec.hashGrouper
-                          └── *exec.caseOp
-                               └── *exec.projMultFloat64Float64Op
-                                    └── *exec.projMinusFloat64ConstFloat64Op
-                                         └── *exec.defaultBuiltinFuncOperator
-                                              └── *exec.constBytesOp
-                                                   └── *exec.hashJoinEqOp
-                                                        ├── *exec.hashJoinEqOp
-                                                        │    ├── *exec.hashJoinEqOp
-                                                        │    │    ├── *distsqlrun.colBatchScan
-                                                        │    │    └── *exec.hashJoinEqOp
-                                                        │    │         ├── *exec.hashJoinEqOp
-                                                        │    │         │    ├── *distsqlrun.joinReader
-                                                        │    │         │    │    └── *distsqlrun.joinReader
-                                                        │    │         │    │         └── *exec.selEQBytesBytesConstOp
-                                                        │    │         │    │              └── *distsqlrun.colBatchScan
-                                                        │    │         │    └── *distsqlrun.colBatchScan
-                                                        │    │         └── *exec.selLEInt64Int64ConstOp
-                                                        │    │              └── *exec.selGEInt64Int64ConstOp
-                                                        │    │                   └── *distsqlrun.colBatchScan
-                                                        │    └── *distsqlrun.colBatchScan
-                                                        └── *exec.selEQBytesBytesConstOp
-                                                             └── *distsqlrun.colBatchScan
+│
+└ Node 1
+  └ *exec.sortOp
+    └ *exec.projDivFloat64Float64Op
+      └ *exec.orderedAggregator
+        └ *exec.hashGrouper
+          └ *exec.caseOp
+            └ *exec.projMultFloat64Float64Op
+              └ *exec.projMinusFloat64ConstFloat64Op
+                └ *exec.defaultBuiltinFuncOperator
+                  └ *exec.constBytesOp
+                    └ *exec.hashJoinEqOp
+                      ├ *exec.hashJoinEqOp
+                      │ ├ *exec.hashJoinEqOp
+                      │ │ ├ *distsqlrun.colBatchScan
+                      │ │ └ *exec.hashJoinEqOp
+                      │ │   ├ *exec.hashJoinEqOp
+                      │ │   │ ├ *distsqlrun.joinReader
+                      │ │   │ │ └ *distsqlrun.joinReader
+                      │ │   │ │   └ *exec.selEQBytesBytesConstOp
+                      │ │   │ │     └ *distsqlrun.colBatchScan
+                      │ │   │ └ *distsqlrun.colBatchScan
+                      │ │   └ *exec.selLEInt64Int64ConstOp
+                      │ │     └ *exec.selGEInt64Int64ConstOp
+                      │ │       └ *distsqlrun.colBatchScan
+                      │ └ *distsqlrun.colBatchScan
+                      └ *exec.selEQBytesBytesConstOp
+                        └ *distsqlrun.colBatchScan
 
 # Query 9
 query T
 EXPLAIN (VEC) SELECT nation, o_year, sum(amount) AS sum_profit FROM ( SELECT n_name AS nation, EXTRACT(year FROM o_orderdate) AS o_year, l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity AS amount FROM part, supplier, lineitem, partsupp, orders, nation WHERE s_suppkey = l_suppkey AND ps_suppkey = l_suppkey AND ps_partkey = l_partkey AND p_partkey = l_partkey AND o_orderkey = l_orderkey AND s_nationkey = n_nationkey AND p_name LIKE '%green%') AS profit GROUP BY nation, o_year ORDER BY nation, o_year DESC
 ----
- │
- └── Node 1
-      └── *exec.sortOp
-           └── *exec.orderedAggregator
-                └── *exec.hashGrouper
-                     └── *distsqlrun.joinReader
-                          └── *exec.hashJoinEqOp
-                               ├── *exec.hashJoinEqOp
-                               │    ├── *distsqlrun.joinReader
-                               │    │    └── *distsqlrun.joinReader
-                               │    │         └── *distsqlrun.joinReader
-                               │    │              └── *distsqlrun.colBatchScan
-                               │    └── *distsqlrun.colBatchScan
-                               └── *distsqlrun.colBatchScan
+│
+└ Node 1
+  └ *exec.sortOp
+    └ *exec.orderedAggregator
+      └ *exec.hashGrouper
+        └ *distsqlrun.joinReader
+          └ *exec.hashJoinEqOp
+            ├ *exec.hashJoinEqOp
+            │ ├ *distsqlrun.joinReader
+            │ │ └ *distsqlrun.joinReader
+            │ │   └ *distsqlrun.joinReader
+            │ │     └ *distsqlrun.colBatchScan
+            │ └ *distsqlrun.colBatchScan
+            └ *distsqlrun.colBatchScan
 
 # Query 10
 query T
 EXPLAIN (VEC) SELECT c_custkey, c_name, sum(l_extendedprice * (1 - l_discount)) AS revenue, c_acctbal, n_name, c_address, c_phone, c_comment FROM customer, orders, lineitem, nation WHERE c_custkey = o_custkey AND l_orderkey = o_orderkey AND o_orderDATE >= DATE '1993-10-01' AND o_orderDATE < DATE '1993-10-01' + INTERVAL '3' MONTH AND l_returnflag = 'R' AND c_nationkey = n_nationkey GROUP BY c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment ORDER BY revenue DESC LIMIT 20
 ----
- │
- └── Node 1
-      └── *exec.limitOp
-           └── *exec.topKSorter
-                └── *exec.orderedAggregator
-                     └── *exec.hashGrouper
-                          └── *distsqlrun.joinReader
-                               └── *exec.hashJoinEqOp
-                                    ├── *exec.hashJoinEqOp
-                                    │    ├── *distsqlrun.colBatchScan
-                                    │    └── *distsqlrun.indexJoiner
-                                    │         └── *distsqlrun.colBatchScan
-                                    └── *distsqlrun.colBatchScan
+│
+└ Node 1
+  └ *exec.limitOp
+    └ *exec.topKSorter
+      └ *exec.orderedAggregator
+        └ *exec.hashGrouper
+          └ *distsqlrun.joinReader
+            └ *exec.hashJoinEqOp
+              ├ *exec.hashJoinEqOp
+              │ ├ *distsqlrun.colBatchScan
+              │ └ *distsqlrun.indexJoiner
+              │   └ *distsqlrun.colBatchScan
+              └ *distsqlrun.colBatchScan
 
 # Query 11
 query T
 EXPLAIN (VEC) SELECT ps_partkey, sum(ps_supplycost * ps_availqty::float) AS value FROM partsupp, supplier, nation WHERE ps_suppkey = s_suppkey AND s_nationkey = n_nationkey AND n_name = 'GERMANY' GROUP BY ps_partkey HAVING sum(ps_supplycost * ps_availqty::float) > ( SELECT sum(ps_supplycost * ps_availqty::float) * 0.0001 FROM partsupp, supplier, nation WHERE ps_suppkey = s_suppkey AND s_nationkey = n_nationkey AND n_name = 'GERMANY') ORDER BY value DESC
 ----
- │
- └── Node 1
-      └── *exec.sortOp
-           └── *exec.selGTFloat64Float64Op
-                └── *exec.castOpNullAny
-                     └── *exec.constNullOp
-                          └── *exec.orderedAggregator
-                               └── *exec.hashGrouper
-                                    └── *distsqlrun.joinReader
-                                         └── *distsqlrun.joinReader
-                                              └── *distsqlrun.joinReader
-                                                   └── *exec.selEQBytesBytesConstOp
-                                                        └── *distsqlrun.colBatchScan
+│
+└ Node 1
+  └ *exec.sortOp
+    └ *exec.selGTFloat64Float64Op
+      └ *exec.castOpNullAny
+        └ *exec.constNullOp
+          └ *exec.orderedAggregator
+            └ *exec.hashGrouper
+              └ *distsqlrun.joinReader
+                └ *distsqlrun.joinReader
+                  └ *distsqlrun.joinReader
+                    └ *exec.selEQBytesBytesConstOp
+                      └ *distsqlrun.colBatchScan
 
 # Query 12
 query error unable to vectorize execution plan: sum on int cols not supported
@@ -762,36 +762,36 @@ EXPLAIN (VEC) SELECT l_shipmode, sum(CASE WHEN o_orderpriority = '1-URGENT' or o
 query T
 EXPLAIN (VEC) SELECT c_count, count(*) AS custdist FROM ( SELECT c_custkey, count(o_orderkey) AS c_count FROM customer LEFT OUTER JOIN orders ON c_custkey = o_custkey AND o_comment NOT LIKE '%special%requests%' GROUP BY c_custkey) AS c_orders GROUP BY c_count ORDER BY custdist DESC, c_count DESC
 ----
- │
- └── Node 1
-      └── *exec.sortOp
-           └── *exec.orderedAggregator
-                └── *exec.hashGrouper
-                     └── *exec.orderedAggregator
-                          └── *exec.hashGrouper
-                               └── *exec.hashJoinEqOp
-                                    ├── *exec.selNotRegexpBytesBytesConstOp
-                                    │    └── *distsqlrun.colBatchScan
-                                    └── *distsqlrun.colBatchScan
+│
+└ Node 1
+  └ *exec.sortOp
+    └ *exec.orderedAggregator
+      └ *exec.hashGrouper
+        └ *exec.orderedAggregator
+          └ *exec.hashGrouper
+            └ *exec.hashJoinEqOp
+              ├ *exec.selNotRegexpBytesBytesConstOp
+              │ └ *distsqlrun.colBatchScan
+              └ *distsqlrun.colBatchScan
 
 # Query 14
 query T
 EXPLAIN (VEC) SELECT 100.00 * sum(CASE WHEN p_type LIKE 'PROMO%' THEN l_extendedprice * (1 - l_discount) ELSE 0 END) / sum(l_extendedprice * (1 - l_discount)) AS promo_revenue FROM lineitem, part WHERE l_partkey = p_partkey AND l_shipdate >= DATE '1995-09-01' AND l_shipdate < DATE '1995-09-01' + INTERVAL '1' MONTH
 ----
- │
- └── Node 1
-      └── *exec.projDivFloat64Float64Op
-           └── *exec.projMultFloat64Float64ConstOp
-                └── *exec.orderedAggregator
-                     └── *exec.oneShotOp
-                          └── *exec.distinctChainOps
-                               └── *exec.projMultFloat64Float64Op
-                                    └── *exec.projMinusFloat64ConstFloat64Op
-                                         └── *exec.caseOp
-                                              └── *exec.hashJoinEqOp
-                                                   ├── *distsqlrun.colBatchScan
-                                                   └── *distsqlrun.indexJoiner
-                                                        └── *distsqlrun.colBatchScan
+│
+└ Node 1
+  └ *exec.projDivFloat64Float64Op
+    └ *exec.projMultFloat64Float64ConstOp
+      └ *exec.orderedAggregator
+        └ *exec.oneShotOp
+          └ *exec.distinctChainOps
+            └ *exec.projMultFloat64Float64Op
+              └ *exec.projMinusFloat64ConstFloat64Op
+                └ *exec.caseOp
+                  └ *exec.hashJoinEqOp
+                    ├ *distsqlrun.colBatchScan
+                    └ *distsqlrun.indexJoiner
+                      └ *distsqlrun.colBatchScan
 
 # Query 15
 #-- TODO(yuzefovich): figure out how to execute this query consisting of three
@@ -806,85 +806,85 @@ EXPLAIN (VEC) SELECT p_brand, p_type, p_size, count(distinct ps_suppkey) AS supp
 query T
 EXPLAIN (VEC) SELECT sum(l_extendedprice) / 7.0 AS avg_yearly FROM lineitem, part WHERE p_partkey = l_partkey AND p_brand = 'Brand#23' AND p_container = 'MED BOX' AND l_quantity < ( SELECT 0.2 * avg(l_quantity) FROM lineitem WHERE l_partkey = p_partkey)
 ----
- │
- └── Node 1
-      └── *exec.projDivFloat64Float64ConstOp
-           └── *exec.orderedAggregator
-                └── *exec.oneShotOp
-                     └── *exec.distinctChainOps
-                          └── *distsqlrun.joinReader
-                               └── *distsqlrun.joinReader
-                                    └── *exec.projMultFloat64Float64ConstOp
-                                         └── *exec.orderedAggregator
-                                              └── *exec.distinctChainOps
-                                                   └── *distsqlrun.joinReader
-                                                        └── *distsqlrun.joinReader
-                                                             └── *exec.selEQBytesBytesConstOp
-                                                                  └── *exec.selEQBytesBytesConstOp
-                                                                       └── *distsqlrun.colBatchScan
+│
+└ Node 1
+  └ *exec.projDivFloat64Float64ConstOp
+    └ *exec.orderedAggregator
+      └ *exec.oneShotOp
+        └ *exec.distinctChainOps
+          └ *distsqlrun.joinReader
+            └ *distsqlrun.joinReader
+              └ *exec.projMultFloat64Float64ConstOp
+                └ *exec.orderedAggregator
+                  └ *exec.distinctChainOps
+                    └ *distsqlrun.joinReader
+                      └ *distsqlrun.joinReader
+                        └ *exec.selEQBytesBytesConstOp
+                          └ *exec.selEQBytesBytesConstOp
+                            └ *distsqlrun.colBatchScan
 
 # Query 18
 query T
 EXPLAIN (VEC) SELECT c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, sum(l_quantity) FROM customer, orders, lineitem WHERE o_orderkey IN ( SELECT l_orderkey FROM lineitem GROUP BY l_orderkey HAVING sum(l_quantity) > 300) AND c_custkey = o_custkey AND o_orderkey = l_orderkey GROUP BY c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice ORDER BY o_totalprice DESC, o_orderdate LIMIT 100
 ----
- │
- └── Node 1
-      └── *exec.limitOp
-           └── *exec.topKSorter
-                └── *exec.orderedAggregator
-                     └── *exec.hashGrouper
-                          └── *distsqlrun.joinReader
-                               └── *exec.hashJoinEqOp
-                                    ├── *exec.mergeJoinLeftSemiOp
-                                    │    ├── *distsqlrun.colBatchScan
-                                    │    └── *exec.selGTFloat64Float64ConstOp
-                                    │         └── *exec.orderedAggregator
-                                    │              └── *exec.distinctChainOps
-                                    │                   └── *distsqlrun.colBatchScan
-                                    └── *distsqlrun.colBatchScan
+│
+└ Node 1
+  └ *exec.limitOp
+    └ *exec.topKSorter
+      └ *exec.orderedAggregator
+        └ *exec.hashGrouper
+          └ *distsqlrun.joinReader
+            └ *exec.hashJoinEqOp
+              ├ *exec.mergeJoinLeftSemiOp
+              │ ├ *distsqlrun.colBatchScan
+              │ └ *exec.selGTFloat64Float64ConstOp
+              │   └ *exec.orderedAggregator
+              │     └ *exec.distinctChainOps
+              │       └ *distsqlrun.colBatchScan
+              └ *distsqlrun.colBatchScan
 
 # Query 19
 query T
 EXPLAIN (VEC) SELECT sum(l_extendedprice* (1 - l_discount)) AS revenue FROM lineitem, part WHERE ( p_partkey = l_partkey AND p_brand = 'Brand#12' AND p_container IN ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG') AND l_quantity >= 1 AND l_quantity <= 1 + 10 AND p_size BETWEEN 1 AND 5 AND l_shipmode IN ('AIR', 'AIR REG') AND l_shipinstruct = 'DELIVER IN PERSON') OR ( p_partkey = l_partkey AND p_brand = 'Brand#23' AND p_container IN ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK') AND l_quantity >= 10 AND l_quantity <= 10 + 10 AND p_size BETWEEN 1 AND 10 AND l_shipmode IN ('AIR', 'AIR REG') AND l_shipinstruct = 'DELIVER IN PERSON') OR ( p_partkey = l_partkey AND p_brand = 'Brand#34' AND p_container IN ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG') AND l_quantity >= 20 AND l_quantity <= 20 + 10 AND p_size BETWEEN 1 AND 15 AND l_shipmode IN ('AIR', 'AIR REG') AND l_shipinstruct = 'DELIVER IN PERSON')
 ----
- │
- └── Node 1
-      └── *exec.orderedAggregator
-           └── *exec.oneShotOp
-                └── *exec.distinctChainOps
-                     └── *exec.projMultFloat64Float64Op
-                          └── *exec.projMinusFloat64ConstFloat64Op
-                               └── *exec.caseOp
-                                    └── *exec.hashJoinEqOp
-                                         ├── *exec.selEQBytesBytesConstOp
-                                         │    └── *exec.selectInOpBytes
-                                         │         └── *distsqlrun.colBatchScan
-                                         └── *exec.selGEInt64Int64ConstOp
-                                              └── *distsqlrun.colBatchScan
+│
+└ Node 1
+  └ *exec.orderedAggregator
+    └ *exec.oneShotOp
+      └ *exec.distinctChainOps
+        └ *exec.projMultFloat64Float64Op
+          └ *exec.projMinusFloat64ConstFloat64Op
+            └ *exec.caseOp
+              └ *exec.hashJoinEqOp
+                ├ *exec.selEQBytesBytesConstOp
+                │ └ *exec.selectInOpBytes
+                │   └ *distsqlrun.colBatchScan
+                └ *exec.selGEInt64Int64ConstOp
+                  └ *distsqlrun.colBatchScan
 
 # Query 20
 query T
 EXPLAIN (VEC) SELECT s_name, s_address FROM supplier, nation WHERE s_suppkey IN ( SELECT ps_suppkey FROM partsupp WHERE ps_partkey IN ( SELECT p_partkey FROM part WHERE p_name LIKE 'forest%') AND ps_availqty > ( SELECT 0.5 * sum(l_quantity) FROM lineitem WHERE l_partkey = ps_partkey AND l_suppkey = ps_suppkey AND l_shipdate >= DATE '1994-01-01' AND l_shipdate < DATE '1994-01-01' + INTERVAL '1' YEAR)) AND s_nationkey = n_nationkey AND n_name = 'CANADA' ORDER BY s_name
 ----
- │
- └── Node 1
-      └── *exec.sortOp
-           └── *exec.hashJoinEqOp
-                ├── *exec.hashJoinEqOp
-                │    ├── *distsqlrun.colBatchScan
-                │    └── *exec.hashJoinEqOp
-                │         ├── *exec.selGTInt64Float64Op
-                │         │    └── *exec.projMultFloat64Float64ConstOp
-                │         │         └── *exec.orderedAggregator
-                │         │              └── *exec.hashGrouper
-                │         │                   └── *exec.hashJoinEqOp
-                │         │                        ├── *distsqlrun.indexJoiner
-                │         │                        │    └── *distsqlrun.colBatchScan
-                │         │                        └── *distsqlrun.colBatchScan
-                │         └── *exec.selPrefixBytesBytesConstOp
-                │              └── *distsqlrun.colBatchScan
-                └── *exec.selEQBytesBytesConstOp
-                     └── *distsqlrun.colBatchScan
+│
+└ Node 1
+  └ *exec.sortOp
+    └ *exec.hashJoinEqOp
+      ├ *exec.hashJoinEqOp
+      │ ├ *distsqlrun.colBatchScan
+      │ └ *exec.hashJoinEqOp
+      │   ├ *exec.selGTInt64Float64Op
+      │   │ └ *exec.projMultFloat64Float64ConstOp
+      │   │   └ *exec.orderedAggregator
+      │   │     └ *exec.hashGrouper
+      │   │       └ *exec.hashJoinEqOp
+      │   │         ├ *distsqlrun.indexJoiner
+      │   │         │ └ *distsqlrun.colBatchScan
+      │   │         └ *distsqlrun.colBatchScan
+      │   └ *exec.selPrefixBytesBytesConstOp
+      │     └ *distsqlrun.colBatchScan
+      └ *exec.selEQBytesBytesConstOp
+        └ *distsqlrun.colBatchScan
 
 # Query 21
 query error can't plan non-inner hash join with on expressions
@@ -894,17 +894,17 @@ EXPLAIN (VEC) SELECT s_name, count(*) AS numwait FROM supplier, lineitem l1, ord
 query T
 EXPLAIN (VEC) SELECT cntrycode, count(*) AS numcust, sum(c_acctbal) AS totacctbal FROM ( SELECT substring(c_phone FROM 1 FOR 2) AS cntrycode, c_acctbal FROM customer WHERE substring(c_phone FROM 1 FOR 2) in ('13', '31', '23', '29', '30', '18', '17') AND c_acctbal > ( SELECT avg(c_acctbal) FROM customer WHERE c_acctbal > 0.00 AND substring(c_phone FROM 1 FOR 2) in ('13', '31', '23', '29', '30', '18', '17')) AND NOT EXISTS ( SELECT * FROM orders WHERE o_custkey = c_custkey)) AS custsale GROUP BY cntrycode ORDER BY cntrycode
 ----
- │
- └── Node 1
-      └── *exec.sortOp
-           └── *exec.orderedAggregator
-                └── *exec.hashGrouper
-                     └── *distsqlrun.joinReader
-                          └── *exec.selGTFloat64Float64Op
-                               └── *exec.castOpNullAny
-                                    └── *exec.constNullOp
-                                         └── *exec.selectInOpBytes
-                                              └── *exec.substringFunctionOperator
-                                                   └── *exec.constInt64Op
-                                                        └── *exec.constInt64Op
-                                                             └── *distsqlrun.colBatchScan
+│
+└ Node 1
+  └ *exec.sortOp
+    └ *exec.orderedAggregator
+      └ *exec.hashGrouper
+        └ *distsqlrun.joinReader
+          └ *exec.selGTFloat64Float64Op
+            └ *exec.castOpNullAny
+              └ *exec.constNullOp
+                └ *exec.selectInOpBytes
+                  └ *exec.substringFunctionOperator
+                    └ *exec.constInt64Op
+                      └ *exec.constInt64Op
+                        └ *distsqlrun.colBatchScan

--- a/pkg/util/treeprinter/tree_printer.go
+++ b/pkg/util/treeprinter/tree_printer.go
@@ -17,9 +17,9 @@ import (
 )
 
 var (
-	edgeLink = []rune(" │")
-	edgeMid  = []rune(" ├── ")
-	edgeLast = []rune(" └── ")
+	edgeLinkChr = rune('│')
+	edgeMidChr  = rune('├')
+	edgeLastChr = rune('└')
 )
 
 // Node is a handle associated with a specific depth in a tree. See below for
@@ -52,8 +52,37 @@ type Node struct {
 // Note that the Child calls can't be rearranged arbitrarily; they have
 // to be in the order they need to be displayed (depth-first pre-order).
 func New() Node {
+	return NewWithIndent(true, true, 2)
+}
+
+// NewWithIndent creates a tree printer like New, permitting customization of
+// the width of the outputted tree.
+// leftPad controls whether the tree lines are padded from the first character
+// of their parent.
+// rightPad controls whether children are separated from their edges by a space.
+// edgeLength controls how many characters wide each edge is.
+func NewWithIndent(leftPad, rightPad bool, edgeLength int) Node {
+	var leftPadStr, rightPadStr string
+	var edgeBuilder strings.Builder
+	for i := 0; i < edgeLength; i++ {
+		edgeBuilder.WriteRune('─')
+	}
+	edgeStr := edgeBuilder.String()
+	if leftPad {
+		leftPadStr = " "
+	}
+	if rightPad {
+		rightPadStr = " "
+	}
+	edgeLink := fmt.Sprintf("%s%c", leftPadStr, edgeLinkChr)
+	edgeMid := fmt.Sprintf("%s%c%s%s", leftPadStr, edgeMidChr, edgeStr, rightPadStr)
+	edgeLast := fmt.Sprintf("%s%c%s%s", leftPadStr, edgeLastChr, edgeStr, rightPadStr)
 	return Node{
-		tree:  &tree{},
+		tree: &tree{
+			edgeLink: []rune(edgeLink),
+			edgeMid:  []rune(edgeMid),
+			edgeLast: []rune(edgeLast),
+		},
 		level: 0,
 	}
 }
@@ -67,6 +96,10 @@ type tree struct {
 
 	// row index of the last row for a given level. Grows as needed.
 	lastNode []int
+
+	edgeLink []rune
+	edgeMid  []rune
+	edgeLast []rune
 }
 
 // Childf adds a node as a child of the given node.
@@ -91,7 +124,7 @@ func (n Node) Child(text string) Node {
 // AddLine adds a new line to a child node without an edge.
 func (n Node) AddLine(v string) {
 	// Each level indents by this much.
-	k := len(edgeLast)
+	k := len(n.tree.edgeLast)
 	indent := n.level * k
 	row := make([]rune, indent+len(v))
 	for i := 0; i < indent; i++ {
@@ -108,7 +141,7 @@ func (n Node) childLine(text string) Node {
 	runes := []rune(text)
 
 	// Each level indents by this much.
-	k := len(edgeLast)
+	k := len(n.tree.edgeLast)
 	indent := n.level * k
 	row := make([]rune, indent+len(runes))
 	for i := 0; i < indent-k; i++ {
@@ -117,13 +150,13 @@ func (n Node) childLine(text string) Node {
 	if indent >= k {
 		// Connect through any empty lines.
 		for i := len(n.tree.rows) - 1; i >= 0 && len(n.tree.rows[i]) == 0; i-- {
-			n.tree.rows[i] = make([]rune, indent-k+len(edgeLink))
-			for j := 0; j < indent-k+len(edgeLink); j++ {
+			n.tree.rows[i] = make([]rune, indent-k+len(n.tree.edgeLink))
+			for j := 0; j < indent-k+len(n.tree.edgeLink); j++ {
 				n.tree.rows[i][j] = ' '
 			}
-			copy(n.tree.rows[i][indent-k:], edgeLink)
+			copy(n.tree.rows[i][indent-k:], n.tree.edgeLink)
 		}
-		copy(row[indent-k:], edgeLast)
+		copy(row[indent-k:], n.tree.edgeLast)
 	}
 	copy(row[indent:], runes)
 
@@ -137,13 +170,13 @@ func (n Node) childLine(text string) Node {
 			panic("multiple root nodes")
 		}
 		// Connect to the previous sibling.
-		copy(n.tree.rows[last][indent-k:], edgeMid)
+		copy(n.tree.rows[last][indent-k:], n.tree.edgeMid)
 		for i := last + 1; i < len(n.tree.rows); i++ {
 			// Add spaces if necessary.
-			for len(n.tree.rows[i]) < indent-k+len(edgeLink) {
+			for len(n.tree.rows[i]) < indent-k+len(n.tree.edgeLink) {
 				n.tree.rows[i] = append(n.tree.rows[i], ' ')
 			}
-			copy(n.tree.rows[i][indent-k:], edgeLink)
+			copy(n.tree.rows[i][indent-k:], n.tree.edgeLink)
 		}
 	}
 


### PR DESCRIPTION
The treeprinter was extended to learn about different indentation width,
and explain(vec) now uses a rather compact setting.

Release note: None