### PR TITLE
sqlmigrations: really skip baked-in migrations when asked to skip them

### DIFF
--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -478,8 +478,10 @@ func (m *Manager) EnsureMigrations(ctx context.Context, filter MigrationFilter) 
 		sqlExecutor: m.sqlExecutor,
 	}
 	for _, migration := range backwardCompatibleMigrations {
-		if migration.workFn == nil {
-			// Migration has been baked in. Ignore it.
+		if migration.workFn == nil || // has the migration been baked in?
+			// is the migration unnecessary?
+			(migration.includedInBootstrap &&
+				filter == ExcludeMigrationsIncludedInBootstrap) {
 			continue
 		}
 


### PR DESCRIPTION
EnsureMigrations() optinally can be told to skip the migrations that are
included in the bootstrap schema when the node running the migrations
has just bootstraped the cluster. Except the mechanism wasn't actually
skipping them. This patch fixes that. There are two places in that
function where we check if we can skip a migration, and only one of them
was correct.

The whole idea of skipping these migrations is arguable because the
check only applies to the node that bootstrapped the cluster. All the
other nodes will still run them. So I can also get rid of the thing if
reviewers ask.

Release note: None