### PR TITLE
storageccl: accept batch- synonyms for row- params in workload storage

### DIFF
--- a/pkg/ccl/storageccl/export_storage_test.go
+++ b/pkg/ccl/storageccl/export_storage_test.go
@@ -524,8 +524,8 @@ func TestWorkloadStorage(t *testing.T) {
 
 	settings := cluster.MakeTestingClusterSettings()
 
-	rows, payloadBytes, ranges := 4, 12, 1
-	gen := bank.FromConfig(rows, rows, payloadBytes, ranges)
+	rows, batchSize, payloadBytes, ranges := 4, 2, 12, 1
+	gen := bank.FromConfig(rows, batchSize, payloadBytes, ranges)
 	bankTable := gen.Tables()[0]
 	bankURL := func(extraParams ...map[string]string) *url.URL {
 		params := url.Values{`version`: []string{gen.Meta().Version}}
@@ -560,8 +560,23 @@ func TestWorkloadStorage(t *testing.T) {
 		require.Equal(t, strings.TrimSpace(`
 0,0,initial-dTqn
 1,0,initial-Pkyk
-2,0,initial-eJkM
-3,0,initial-TlNb
+2,0,initial-vOpi
+3,0,initial-Mqnk
+		`), strings.TrimSpace(string(bytes)))
+	}
+
+	{
+		params := map[string]string{
+			`batch-start`: `1`, `batch-end`: `2`, `payload-bytes`: `14`}
+		s, err := ExportStorageFromURI(ctx, bankURL(params).String(), settings)
+		require.NoError(t, err)
+		r, err := s.ReadFile(ctx, ``)
+		require.NoError(t, err)
+		bytes, err := ioutil.ReadAll(r)
+		require.NoError(t, err)
+		require.Equal(t, strings.TrimSpace(`
+2,0,initial-vOpikz
+3,0,initial-Mqnkpf
 		`), strings.TrimSpace(string(bytes)))
 	}
 

--- a/pkg/workload/bank/bank.go
+++ b/pkg/workload/bank/bank.go
@@ -64,7 +64,7 @@ var bankMeta = workload.Meta{
 		g := &bank{}
 		g.flags.FlagSet = pflag.NewFlagSet(`bank`, pflag.ContinueOnError)
 		g.flags.Meta = map[string]workload.FlagMeta{
-			`batch-size`: {RuntimeOnly: true},
+			`batch-size`: {IgnoreForPersistance: true},
 		}
 		g.flags.Uint64Var(&g.seed, `seed`, 1, `Key hash seed.`)
 		g.flags.IntVar(&g.rows, `rows`, defaultRows, `Initial number of accounts in bank table.`)

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -48,6 +48,10 @@ type FlagMeta struct {
 	// RuntimeOnly may be set to true only if the corresponding flag has no
 	// impact on the behavior of any Tables in this workload.
 	RuntimeOnly bool
+	// IgnoreForPersistance may be set to true when the flag has an impact on the
+	// initial data, but should be ignored when constructing a path to persist
+	// that data. In practice, this is used with a flag to control batch sizes.
+	IgnoreForPersistance bool
 	// CheckConsistencyOnly is expected to be true only if the corresponding
 	// flag only has an effect on the CheckConsistency hook.
 	CheckConsistencyOnly bool


### PR DESCRIPTION
The `row-` params are a relic from before workload operated in batches,
but they never got updated and they currently lie.

No release note because this has been an internal detail of fixtures
import (which was itself internal) before 19.2. We could similarly argue
that they should be immediately deleted instead of deprecated, but I'd
like to be extra careful about disrupting roachtests this late in the
release.

Also fix a bug I found in when using fixtures import with the batch-size
param recently added to the bank workload. It's not necessary (or
desired) to include in the gce paths used for `fixtures make/load` but
it definitely has to be passed for `fixtures import`, so add a new bool
on FlagMeta.

Release note: None