### PR TITLE
roachtest: bump up index KV buffer size in TPCH import test

### DIFF
--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -167,6 +167,7 @@ func registerImportTPCH(r *testRegistry) {
 					t.WorkerStatus(`running import`)
 					defer t.WorkerStatus()
 					_, err := conn.Exec(`
+					SET CLUSTER SETTING kv.bulk_ingest.max_index_buffer_size = '2gb';
 				IMPORT TABLE csv.lineitem
 				CREATE USING 'gs://cockroach-fixtures/tpch-csv/schema/lineitem.sql'
 				CSV DATA (


### PR DESCRIPTION
This table has 8 secondary indexes so the default buffer size, which is smaller to make workload's concurrent imports of many tables work, isn't doing it any favors. Since this test only runs one IMPORT, we can let it use 4x more buffer than usual.

Release note: none