### PR TITLE
exec: bugfix to CASE operator with no input

### DIFF
--- a/pkg/sql/exec/buffer.go
+++ b/pkg/sql/exec/buffer.go
@@ -20,8 +20,9 @@ import (
 // bufferOp is an operator that buffers a single batch at a time from an input,
 // and makes it available to be read multiple times by downstream consumers.
 type bufferOp struct {
-	OneInputNode
+	ZeroInputNode
 	NonExplainable
+	input Operator
 
 	// read is true if someone has read the current batch already.
 	read     bool
@@ -35,7 +36,7 @@ var _ StaticMemoryOperator = &bufferOp{}
 // supplied input.
 func NewBufferOp(input Operator) Operator {
 	return &bufferOp{
-		OneInputNode: NewOneInputNode(input),
+		input: input,
 		batch: &selectionBatch{
 			sel: make([]uint16, coldata.BatchSize),
 		},

--- a/pkg/sql/exec/case.go
+++ b/pkg/sql/exec/case.go
@@ -99,9 +99,9 @@ func (c *caseOp) Next(ctx context.Context) coldata.Batch {
 	if c.buffer.batch.Width() == c.outputIdx {
 		c.buffer.batch.AppendCol(c.typ)
 	}
-	if origLen == 0 {
-		return c.buffer.batch.Batch
-	}
+	// NB: we don't short-circuit if the batch is length 0 here, because we have
+	// to make sure to run all of our case arms. This is unfortunate.
+	// TODO(jordan): add this back in once batches are right-sized by planning.
 	var origHasSel bool
 	if sel := c.buffer.batch.Batch.Selection(); sel != nil {
 		origHasSel = true

--- a/pkg/sql/exec/case.go
+++ b/pkg/sql/exec/case.go
@@ -36,12 +36,16 @@ type caseOp struct {
 }
 
 func (c *caseOp) ChildCount() int {
-	return 1
+	return 1 + len(c.caseOps) + 1
 }
 
 func (c *caseOp) Child(nth int) OpNode {
 	if nth == 0 {
-		return c.buffer
+		return c.buffer.input
+	} else if nth < len(c.caseOps)+1 {
+		return c.caseOps[nth-1]
+	} else if nth == 1+len(c.caseOps) {
+		return c.elseOp
 	}
 	execerror.VectorizedInternalPanic(fmt.Sprintf("invalid idx %d", nth))
 	// This code is unreachable, but the compiler cannot infer that.

--- a/pkg/sql/logictest/testdata/logic_test/tpch_vec
+++ b/pkg/sql/logictest/testdata/logic_test/tpch_vec
@@ -661,9 +661,18 @@ EXPLAIN (VEC) SELECT supp_nation, cust_nation, l_year, sum(volume) AS revenue FR
                   │ └ *distsqlrun.joinReader
                   │   └ *distsqlrun.joinReader
                   │     └ *exec.caseOp
-                  │       └ *exec.hashJoinEqOp
-                  │         ├ *distsqlrun.colBatchScan
-                  │         └ *distsqlrun.colBatchScan
+                  │       ├ *exec.hashJoinEqOp
+                  │       │ ├ *distsqlrun.colBatchScan
+                  │       │ └ *distsqlrun.colBatchScan
+                  │       ├ *exec.constBoolOp
+                  │       │ └ *exec.andOp
+                  │       │   └ *exec.projEQBytesBytesConstOp
+                  │       │     └ *exec.projEQBytesBytesConstOp
+                  │       ├ *exec.constBoolOp
+                  │       │ └ *exec.andOp
+                  │       │   └ *exec.projEQBytesBytesConstOp
+                  │       │     └ *exec.projEQBytesBytesConstOp
+                  │       └ *exec.constBoolOp
                   └ *distsqlrun.colBatchScan
 
 # Query 8
@@ -677,27 +686,29 @@ EXPLAIN (VEC) SELECT o_year, sum(CASE WHEN nation = 'BRAZIL' THEN volume ELSE 0 
       └ *exec.orderedAggregator
         └ *exec.hashGrouper
           └ *exec.caseOp
-            └ *exec.projMultFloat64Float64Op
-              └ *exec.projMinusFloat64ConstFloat64Op
-                └ *exec.defaultBuiltinFuncOperator
-                  └ *exec.constBytesOp
-                    └ *exec.hashJoinEqOp
-                      ├ *exec.hashJoinEqOp
-                      │ ├ *exec.hashJoinEqOp
-                      │ │ ├ *distsqlrun.colBatchScan
-                      │ │ └ *exec.hashJoinEqOp
-                      │ │   ├ *exec.hashJoinEqOp
-                      │ │   │ ├ *distsqlrun.joinReader
-                      │ │   │ │ └ *distsqlrun.joinReader
-                      │ │   │ │   └ *exec.selEQBytesBytesConstOp
-                      │ │   │ │     └ *distsqlrun.colBatchScan
-                      │ │   │ └ *distsqlrun.colBatchScan
-                      │ │   └ *exec.selLEInt64Int64ConstOp
-                      │ │     └ *exec.selGEInt64Int64ConstOp
-                      │ │       └ *distsqlrun.colBatchScan
-                      │ └ *distsqlrun.colBatchScan
-                      └ *exec.selEQBytesBytesConstOp
-                        └ *distsqlrun.colBatchScan
+            ├ *exec.projMultFloat64Float64Op
+            │ └ *exec.projMinusFloat64ConstFloat64Op
+            │   └ *exec.defaultBuiltinFuncOperator
+            │     └ *exec.constBytesOp
+            │       └ *exec.hashJoinEqOp
+            │         ├ *exec.hashJoinEqOp
+            │         │ ├ *exec.hashJoinEqOp
+            │         │ │ ├ *distsqlrun.colBatchScan
+            │         │ │ └ *exec.hashJoinEqOp
+            │         │ │   ├ *exec.hashJoinEqOp
+            │         │ │   │ ├ *distsqlrun.joinReader
+            │         │ │   │ │ └ *distsqlrun.joinReader
+            │         │ │   │ │   └ *exec.selEQBytesBytesConstOp
+            │         │ │   │ │     └ *distsqlrun.colBatchScan
+            │         │ │   │ └ *distsqlrun.colBatchScan
+            │         │ │   └ *exec.selLEInt64Int64ConstOp
+            │         │ │     └ *exec.selGEInt64Int64ConstOp
+            │         │ │       └ *distsqlrun.colBatchScan
+            │         │ └ *distsqlrun.colBatchScan
+            │         └ *exec.selEQBytesBytesConstOp
+            │           └ *distsqlrun.colBatchScan
+            ├ *exec.projEQBytesBytesConstOp
+            └ *exec.constFloat64Op
 
 # Query 9
 query T
@@ -788,10 +799,14 @@ EXPLAIN (VEC) SELECT 100.00 * sum(CASE WHEN p_type LIKE 'PROMO%' THEN l_extended
             └ *exec.projMultFloat64Float64Op
               └ *exec.projMinusFloat64ConstFloat64Op
                 └ *exec.caseOp
-                  └ *exec.hashJoinEqOp
-                    ├ *distsqlrun.colBatchScan
-                    └ *distsqlrun.indexJoiner
-                      └ *distsqlrun.colBatchScan
+                  ├ *exec.hashJoinEqOp
+                  │ ├ *distsqlrun.colBatchScan
+                  │ └ *distsqlrun.indexJoiner
+                  │   └ *distsqlrun.colBatchScan
+                  ├ *exec.projMultFloat64Float64Op
+                  │ └ *exec.projMinusFloat64ConstFloat64Op
+                  │   └ *exec.projPrefixBytesBytesConstOp
+                  └ *exec.constFloat64Op
 
 # Query 15
 #-- TODO(yuzefovich): figure out how to execute this query consisting of three
@@ -855,12 +870,46 @@ EXPLAIN (VEC) SELECT sum(l_extendedprice* (1 - l_discount)) AS revenue FROM line
         └ *exec.projMultFloat64Float64Op
           └ *exec.projMinusFloat64ConstFloat64Op
             └ *exec.caseOp
-              └ *exec.hashJoinEqOp
-                ├ *exec.selEQBytesBytesConstOp
-                │ └ *exec.selectInOpBytes
-                │   └ *distsqlrun.colBatchScan
-                └ *exec.selGEInt64Int64ConstOp
-                  └ *distsqlrun.colBatchScan
+              ├ *exec.hashJoinEqOp
+              │ ├ *exec.selEQBytesBytesConstOp
+              │ │ └ *exec.selectInOpBytes
+              │ │   └ *distsqlrun.colBatchScan
+              │ └ *exec.selGEInt64Int64ConstOp
+              │   └ *distsqlrun.colBatchScan
+              ├ *exec.constBoolOp
+              │ └ *exec.caseOp
+              │   ├ *exec.constBoolOp
+              │   │ └ *exec.andOp
+              │   │   └ *exec.projLEInt64Int64ConstOp
+              │   │     └ *exec.andOp
+              │   │       └ *exec.projLEFloat64Float64ConstOp
+              │   │         └ *exec.andOp
+              │   │           └ *exec.projGEFloat64Float64ConstOp
+              │   │             └ *exec.andOp
+              │   │               └ *exec.projectInOpBytes
+              │   │                 └ *exec.projEQBytesBytesConstOp
+              │   ├ *exec.constBoolOp
+              │   │ └ *exec.andOp
+              │   │   └ *exec.projLEInt64Int64ConstOp
+              │   │     └ *exec.andOp
+              │   │       └ *exec.projLEFloat64Float64ConstOp
+              │   │         └ *exec.andOp
+              │   │           └ *exec.projGEFloat64Float64ConstOp
+              │   │             └ *exec.andOp
+              │   │               └ *exec.projectInOpBytes
+              │   │                 └ *exec.projEQBytesBytesConstOp
+              │   └ *exec.constBoolOp
+              ├ *exec.constBoolOp
+              │ └ *exec.andOp
+              │   └ *exec.projLEInt64Int64ConstOp
+              │     └ *exec.andOp
+              │       └ *exec.projLEFloat64Float64ConstOp
+              │         └ *exec.andOp
+              │           └ *exec.projGEFloat64Float64ConstOp
+              │             └ *exec.andOp
+              │               └ *exec.projectInOpBytes
+              │                 └ *exec.projEQBytesBytesConstOp
+              └ *exec.constBoolOp
 
 # Query 20
 query T

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -20,6 +20,14 @@ SELECT a, CASE WHEN a = 0 THEN 0 WHEN a = 1 THEN 3 ELSE 5 END FROM a LIMIT 6
 2  5
 2  5
 
+# Regression test for 40574.
+statement ok
+CREATE TABLE t40574(pk INTEGER PRIMARY KEY, col0 INTEGER, col1 FLOAT, col2 TEXT, col3 INTEGER, col4 FLOAT, col5 TEXT)
+
+query I
+SELECT pk FROM t40574 WHERE (col0 > 9 AND (col1 <= 6.38 OR col0 =5) AND (col0 = 7 OR col4 = 7))
+----
+
 # OR expression as projection.
 query IB
 SELECT b, b = 0 OR b = 2 FROM a WHERE b < 4
@@ -701,14 +709,14 @@ SET tracing = on; SELECT * FROM tpar WHERE a = 0 OR a = 10; SET tracing = off
 # tpar, this query will need an adjustment.
 query T
 SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message IN 
-    ('querying next range at /Table/72/1/0',
-     'querying next range at /Table/72/1/10',
+    ('querying next range at /Table/73/1/0',
+     'querying next range at /Table/73/1/10',
      '=== SPAN START: kv.DistSender: sending partial batch ==='
     )
 ----
-querying next range at /Table/72/1/0
+querying next range at /Table/73/1/0
 === SPAN START: kv.DistSender: sending partial batch ===
-querying next range at /Table/72/1/10
+querying next range at /Table/73/1/10
 
 # Test for #38858 -- handle aggregates correctly on an empty table.
 statement ok


### PR DESCRIPTION
Previously, the CASE operator short-circuited if there were no input
rows. This was problematic, because without running all of the arms of
the operator at least once, its output batch might not get extended to
the width that downstream operators expect.

Also, add CASE arms to EXPLAIN(VEC) to help with debugging.
The first child of CASE is its input. The 2nd-(n-1)th children are the
CASE arms. The nth child is the ELSE arm.

Fixes #40574.

Release note: None
