### PR TITLE
exec: add UnsetNulls to ResetInternalBatch

### DIFF
--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -173,6 +173,7 @@ func (m *MemBatch) Reset(types []coltypes.T, length int) {
 func (m *MemBatch) ResetInternalBatch() {
 	m.SetSelection(false)
 	for _, v := range m.b {
+		v.Nulls().UnsetNulls()
 		if v.Type() == coltypes.Bytes {
 			v.Bytes().Reset()
 		}

--- a/pkg/sql/exec/hashjoiner.go
+++ b/pkg/sql/exec/hashjoiner.go
@@ -249,16 +249,20 @@ func (hj *hashJoinEqOp) Init() {
 
 func (hj *hashJoinEqOp) Next(ctx context.Context) coldata.Batch {
 	hj.prober.batch.ResetInternalBatch()
+	return hj.nextInternal(ctx)
+}
+
+func (hj *hashJoinEqOp) nextInternal(ctx context.Context) coldata.Batch {
 	switch hj.runningState {
 	case hjBuilding:
 		hj.build(ctx)
-		return hj.Next(ctx)
+		return hj.nextInternal(ctx)
 	case hjProbing:
 		hj.prober.exec(ctx)
 
 		if hj.prober.batch.Length() == 0 && hj.builder.spec.outer {
 			hj.initEmitting()
-			return hj.Next(ctx)
+			return hj.nextInternal(ctx)
 		}
 		return hj.prober.batch
 	case hjEmittingUnmatched:

--- a/pkg/sql/exec/mergejoiner_tmpl.go
+++ b/pkg/sql/exec/mergejoiner_tmpl.go
@@ -1244,11 +1244,6 @@ func (o *mergeJoin_JOIN_TYPE_STRING_FILTER_INFO_STRINGOp) Next(ctx context.Conte
 			if o.needToResetOutput {
 				o.needToResetOutput = false
 				o.output.ResetInternalBatch()
-				for _, vec := range o.output.ColVecs() {
-					// We only need to explicitly reset nulls since the values will be
-					// copied over and the correct length will be set.
-					vec.Nulls().UnsetNulls()
-				}
 			}
 			o.initProberState(ctx)
 


### PR DESCRIPTION
First two commits are fixes related to unsetting nulls in ResetInternalBatch in the aggregator and hashjoiner while the last commit is the actual switch flip as well as the testing addition.