### PR TITLE
cli/sql: new parameter --watch to repeat the -e statements

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -625,6 +625,24 @@ func Example_sql() {
 	// invalid syntax
 }
 
+func Example_sql_watch() {
+	c := newCLITest(cliTestParams{})
+	defer c.cleanup()
+
+	c.RunWithArgs([]string{`sql`, `-e`, `create table d(x int); insert into d values(3)`})
+	c.RunWithArgs([]string{`sql`, `--watch`, `.1s`, `-e`, `update d set x=x-1 returning 1/x as dec`})
+
+	// Output:
+	// sql -e create table d(x int); insert into d values(3)
+	// INSERT 1
+	// sql --watch .1s -e update d set x=x-1 returning 1/x as dec
+	// dec
+	// 0.5
+	// dec
+	// 1
+	// pq: division by zero
+}
+
 func Example_sql_format() {
 	c := newCLITest(cliTestParams{})
 	defer c.cleanup()

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -238,6 +238,14 @@ with a non-zero status code and further statements are not executed. The
 results of each SQL statement are printed on the standard output.`,
 	}
 
+	Watch = FlagInfo{
+		Name: "watch",
+		Description: `
+Repeat the SQL statement(s) specified with --execute
+with the specified period. The client will stop watching
+if an execution of the SQL statement(s) fail.`,
+	}
+
 	EchoSQL = FlagInfo{
 		Name: "echo-sql",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -83,6 +83,7 @@ func initCLIDefaults() {
 
 	sqlCtx.setStmts = nil
 	sqlCtx.execStmts = nil
+	sqlCtx.repeatDelay = 0
 	sqlCtx.safeUpdates = false
 	sqlCtx.showTimes = false
 	sqlCtx.debugMode = false
@@ -216,6 +217,11 @@ var sqlCtx = struct {
 
 	// execStmts is a list of statements to execute.
 	execStmts statementsValue
+
+	// repeatDelay indicates that the execStmts should be "watched"
+	// at the specified time interval. Zero disables
+	// the watch.
+	repeatDelay time.Duration
 
 	// safeUpdates indicates whether to set sql_safe_updates in the CLI
 	// shell.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -527,6 +527,7 @@ func init() {
 		f := cmd.Flags()
 		VarFlag(f, &sqlCtx.setStmts, cliflags.Set)
 		VarFlag(f, &sqlCtx.execStmts, cliflags.Execute)
+		DurationFlag(f, &sqlCtx.repeatDelay, cliflags.Watch, sqlCtx.repeatDelay)
 		BoolFlag(f, &sqlCtx.safeUpdates, cliflags.SafeUpdates, sqlCtx.safeUpdates)
 		BoolFlag(f, &sqlCtx.debugMode, cliflags.CliDebugMode, sqlCtx.debugMode)
 	}


### PR DESCRIPTION
Release justification: needed in tests

I found myself needing this for scenario-based testing.
The importance of this compared to enclosing `cockroach sql` in a shell loop is that I want/need to avoid the overhead of establishing a new SQL connection each time.

It would greatly simplify my workflow to have this on `master` ASAP, but if the TL in charge thinks "too late" I'll accept (a little reluctantly) delaying until the branch is cut.