### PR TITLE
coldata: respect SelOnDest flag when setting nulls

### DIFF
--- a/pkg/col/coldata/vec_tmpl.go
+++ b/pkg/col/coldata/vec_tmpl.go
@@ -83,7 +83,13 @@ func _COPY_WITH_SEL(
 		nulls := args.Src.Nulls()
 		for i, selIdx := range sel[args.SrcStartIdx:args.SrcEndIdx] {
 			if nulls.NullAt64(uint64(selIdx)) {
+				// {{if .SelOnDest}}
+				// Remove an unused warning in some cases.
+				_ = i
+				m.nulls.SetNull64(uint64(selIdx))
+				// {{else}}
 				m.nulls.SetNull64(uint64(i) + args.DestIdx)
+				// {{end}}
 			} else {
 				v := execgen.UNSAFEGET(fromCol, int(selIdx))
 				// {{if .SelOnDest}}

--- a/pkg/sql/logictest/testdata/logic_test/dist_vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/dist_vectorize
@@ -264,3 +264,17 @@ EXPLAIN (VEC, VERBOSE) SELECT count(*) FROM kv NATURAL INNER HASH JOIN kv kv2
                 └ *exec.HashRouter
                   └ *exec.CancelChecker
                     └ *distsqlrun.colBatchScan
+
+# Test that SelOnDest flag of coldata.SliceArgs is respected when setting
+# nulls.
+statement ok
+CREATE TABLE t1(a INT PRIMARY KEY, b INT)
+
+statement ok
+INSERT INTO t1 VALUES (1, NULL), (2, NULL)
+
+query I rowsort
+SELECT CASE WHEN a>1 THEN b*2 ELSE b*10 END FROM t1
+----
+NULL
+NULL


### PR DESCRIPTION
Previously, when setting nulls, we would always set it at the offset
from DestIdx. However, this is incorrect when SelOnDest flag is true -
we need to set the null at selIdx. Now this is fixed.

Release note: None