### PR TITLE
sql: fix getPlanColumns for hookFnNode

### DIFF
--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -49,8 +49,6 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		return n.columns
 	case *groupNode:
 		return n.columns
-	case *hookFnNode:
-		return n.header
 	case *joinNode:
 		return n.columns
 	case *ordinalityNode:
@@ -119,6 +117,11 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		return n.getColumns(mut, sqlbase.SequenceSelectColumns)
 	case *exportNode:
 		return n.getColumns(mut, sqlbase.ExportColumns)
+
+	// The columns in the hookFnNode are returned by the hook function; we don't
+	// know if they can be modified in place or not.
+	case *hookFnNode:
+		return n.getColumns(mut, n.header)
 
 	// Nodes that have the same schema as their source or their
 	// valueNode helper.

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -110,6 +110,8 @@ func AddWrappedPlanHook(f wrappedPlanHookFn) {
 // provided function during Start and serves the results it returns over the
 // channel.
 type hookFnNode struct {
+	optColumnsSlot
+
 	f        PlanHookRowFn
 	header   sqlbase.ResultColumns
 	subplans []planNode


### PR DESCRIPTION
`getPlanColumns` allows the caller to directly mutate the columns of a
`hookFnNode`; but these columns can be defined globally and should not
be modified in place.

Fixes #40585.

Release note: None