### PR TITLE
opt: fix scalar building error handling

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/apply_join
+++ b/pkg/sql/logictest/testdata/logic_test/apply_join
@@ -278,3 +278,36 @@ query II
 SELECT a, (SELECT a FROM y) FROM x
 ----
 1  1
+
+# Regression test for #40590: non-executable apply join inside apply join.
+
+statement ok
+CREATE TABLE IF NOT EXISTS tab_orig AS
+  SELECT
+    '2001-01-01'::TIMESTAMP + g * '1 day' AS _timestamp,
+    g AS _string
+  FROM
+    generate_series(NULL, NULL) AS g;
+
+statement error could not decorrelate subquery
+SELECT
+  NULL
+FROM
+  tab_orig AS tab_9962,
+  tab_orig AS tab_9963
+  JOIN tab_orig AS tab_9964 ON true
+WHERE
+  NOT
+    (
+      tab_9964._timestamp
+      IN (SELECT tab_9962._timestamp)
+      OR EXISTS(
+          WITH
+            with_2063 AS (SELECT NULL)
+          SELECT
+            COALESCE(
+              tab_9962._string,
+              tab_9963._string
+            )
+        )
+    )

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -666,7 +666,7 @@ func (b *Builder) buildApplyJoin(join memo.RelExpr) (execPlan, error) {
 	if len(*filters) != 0 {
 		onExpr, err = b.buildScalar(&ctx, filters)
 		if err != nil {
-			return execPlan{}, nil
+			return execPlan{}, err
 		}
 	}
 


### PR DESCRIPTION
We are incorrectly returning `nil` error in an error case. This leads
to an assertion error instead of a "could not decorrelate subquery"
error.

Fixes #40590.

Release note: None