### PR TITLE
exec: minor clean up

### DIFF
--- a/pkg/sql/exec/builtin_funcs.go
+++ b/pkg/sql/exec/builtin_funcs.go
@@ -63,12 +63,8 @@ func (b *defaultBuiltinFuncOperator) Next(ctx context.Context) coldata.Batch {
 
 		for j := range b.argumentCols {
 			col := batch.ColVec(b.argumentCols[j])
-			if col.MaybeHasNulls() && col.Nulls().NullAt(rowIdx) {
-				hasNulls = true
-				b.row[j] = tree.DNull
-			} else {
-				b.row[j] = PhysicalTypeColElemToDatum(col, rowIdx, b.da, b.columnTypes[b.argumentCols[j]])
-			}
+			b.row[j] = PhysicalTypeColElemToDatum(col, rowIdx, b.da, b.columnTypes[b.argumentCols[j]])
+			hasNulls = hasNulls || b.row[j] == tree.DNull
 		}
 
 		var (

--- a/pkg/sql/exec/vec_elem_to_datum.go
+++ b/pkg/sql/exec/vec_elem_to_datum.go
@@ -23,10 +23,17 @@ import (
 	"github.com/lib/pq/oid"
 )
 
-// PhysicalTypeColElemToDatum converts an element in a colvec to a datum of semtype ct.
+// PhysicalTypeColElemToDatum converts an element in a colvec to a datum of
+// semtype ct. Note that this function handles nulls as well, so there is no
+// need for a separate null check.
 func PhysicalTypeColElemToDatum(
 	col coldata.Vec, rowIdx uint16, da sqlbase.DatumAlloc, ct types.T,
 ) tree.Datum {
+	if col.MaybeHasNulls() {
+		if col.Nulls().NullAt(rowIdx) {
+			return tree.DNull
+		}
+	}
 	switch ct.Family() {
 	case types.BoolFamily:
 		if col.Bool()[rowIdx] {

--- a/pkg/sql/row/cfetcher.go
+++ b/pkg/sql/row/cfetcher.go
@@ -786,9 +786,6 @@ func (rf *CFetcher) pushState(state fetcherState) {
 // getDatumAt returns the converted datum object at the given (colIdx, rowIdx).
 // This function is meant for tracing and should not be used in hot paths.
 func (rf *CFetcher) getDatumAt(colIdx int, rowIdx uint16, typ types.T) tree.Datum {
-	if rf.machine.colvecs[colIdx].Nulls().NullAt(rowIdx) {
-		return tree.DNull
-	}
 	return exec.PhysicalTypeColElemToDatum(rf.machine.colvecs[colIdx], rowIdx, rf.table.da, typ)
 }
 

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1326,7 +1326,8 @@ func (node *FuncExpr) IsDistSQLBlacklist() bool {
 	return node.fnProps != nil && node.fnProps.DistsqlBlacklist
 }
 
-// CanHandleNulls returns whether or not
+// CanHandleNulls returns whether or not the function can handle null
+// arguments.
 func (node *FuncExpr) CanHandleNulls() bool {
 	return node.fnProps != nil && node.fnProps.NullableArgs
 }


### PR DESCRIPTION
Previously, when converting a columnar value to a tree.Datum, we
would check for nulls separately. Now this is done as part of the
conversion which cleans up the code a bit.

Release note: None