### PR TITLE
sql/sem/builtins: fix width_bucket for 0-length arrays

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2265,6 +2265,12 @@ SELECT width_bucket(now(), array['yesterday', 'today', 'tomorrow']::timestamptz[
 query error pq: width_bucket\(\): Operand and thresholds must be of the same type
 SELECT width_bucket(1, array['a', 'h', 'l', 'z']);
 
+# Regression for #40623
+query I
+SELECT width_bucket(1, array[]::int[]);
+----
+0
+
 # Sanity check pg_type_is_visible.
 query BBB
 SELECT pg_type_is_visible('int'::regtype), pg_type_is_visible(NULL), pg_type_is_visible(99999)

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2408,7 +2408,7 @@ may increase either contention or retry errors, or both.`,
 				operand := args[0]
 				thresholds := tree.MustBeDArray(args[1])
 
-				if !operand.ResolvedType().Equivalent(thresholds.Array[0].ResolvedType()) {
+				if !operand.ResolvedType().Equivalent(thresholds.ParamTyp) {
 					return tree.NewDInt(0), errors.New("Operand and thresholds must be of the same type")
 				}
 


### PR DESCRIPTION
Fixes #40623

Release note (bug fix): width_bucket no longer errors on 0-length arrays