### PR TITLE
release-2.1: storage/engine: return WriteIntentError for intents in uncertainty intervals

### DIFF
--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -869,7 +869,7 @@ func mvccGetInternal(
 		// by this transaction or not an intent at all (so there's no
 		// conflict). Note that when reading the own intent, the timestamp
 		// specified is irrelevant; we always want to see the intent (see
-		// TestMVCCReadWithPushedTimestamp).
+		// TestMVCCGetWithPushedTimestamp).
 		seekKey.Timestamp = metaTimestamp
 
 		// Check for case where we're reading our own txn's intent

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -852,18 +852,29 @@ func mvccGetInternal(
 		timestamp = metaTimestamp.Prev()
 	}
 
-	ownIntent := IsIntentOf(*meta, txn) // false if txn == nil
-	if !timestamp.Less(metaTimestamp) && meta.Txn != nil && !ownIntent {
-		// Trying to read the last value, but it's another transaction's intent;
-		// the reader will have to act on this.
-		return nil, nil, safeValue, &roachpb.WriteIntentError{
-			Intents: []roachpb.Intent{{Span: roachpb.Span{Key: metaKey.Key}, Status: roachpb.PENDING, Txn: *meta.Txn}},
+	checkUncertainty := txn != nil && timestamp.Less(txn.MaxTimestamp)
+	isIntent := meta.Txn != nil
+	ownIntent := IsIntentOf(*meta, txn) // false if !isIntent
+	if isIntent && !ownIntent {
+		// Trying to read the last value, but it's another transaction's intent.
+		// The reader will have to act on this if the intent has a low enough
+		// timestamp. Intents for other transactions are visible at or below:
+		//   max(txn.MaxTimestamp, timestamp)
+		maxVisibleTimestamp := timestamp
+		if checkUncertainty {
+			maxVisibleTimestamp = txn.MaxTimestamp
+		}
+		if !maxVisibleTimestamp.Less(metaTimestamp) {
+			return nil, nil, safeValue, &roachpb.WriteIntentError{
+				Intents: []roachpb.Intent{{
+					Span: roachpb.Span{Key: metaKey.Key}, Status: roachpb.PENDING, Txn: *meta.Txn,
+				}},
+			}
 		}
 	}
 
-	var checkValueTimestamp bool
 	seekKey := metaKey
-
+	checkValueTimestamp := false
 	if !timestamp.Less(metaTimestamp) || ownIntent {
 		// We are reading the latest value, which is either an intent written
 		// by this transaction or not an intent at all (so there's no
@@ -892,7 +903,7 @@ func mvccGetInternal(
 				seekKey.Timestamp = metaTimestamp.Prev()
 			}
 		}
-	} else if txn != nil && timestamp.Less(txn.MaxTimestamp) {
+	} else if checkUncertainty {
 		// In this branch, the latest timestamp is ahead, and so the read of an
 		// "old" value in a transactional context at time (timestamp, MaxTimestamp]
 		// occurs, leading to a clock uncertainty error if a version exists in

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -719,72 +719,265 @@ func TestMVCCGetUncertainty(t *testing.T) {
 		t.Run(impl.name, func(t *testing.T) {
 			mvccGet := impl.fn
 
+			ctx := context.Background()
 			engine := createTestEngine()
 			defer engine.Close()
 
-			txn := &roachpb.Transaction{TxnMeta: enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: hlc.Timestamp{WallTime: 5}}, MaxTimestamp: hlc.Timestamp{WallTime: 10}}
-			// Put a value from the past.
-			if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
+			// Txn with read timestamp 7 and MaxTimestamp 10.
+			txn := &roachpb.Transaction{
+				TxnMeta: enginepb.TxnMeta{
+					ID:        uuid.MakeV4(),
+					Timestamp: hlc.Timestamp{WallTime: 7},
+				},
+				MaxTimestamp: hlc.Timestamp{WallTime: 10},
+			}
+
+			// Same txn but with a MaxTimestamp reduced to 9.
+			txnMaxTS9 := txn.Clone()
+			txnMaxTS9.MaxTimestamp = hlc.Timestamp{WallTime: 9}
+
+			// Same txn but with a MaxTimestamp reduced to 7.
+			txnMaxTS7 := txn.Clone()
+			txnMaxTS7.MaxTimestamp = hlc.Timestamp{WallTime: 7}
+
+			// Case 1: One value in the past, one value in the future of read
+			// and ahead of MaxTimestamp of read. Neither should interfere.
+			//
+			// -----------------
+			// - 12: val2
+			// |
+			// - 10: max timestamp
+			// |
+			// -  7: read timestamp
+			// |
+			// -  1: val1
+			// -----------------
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
 				t.Fatal(err)
 			}
-			// Put a value that is ahead of MaxTimestamp, it should not interfere.
-			if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 12}, value2, nil); err != nil {
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 12}, value2, nil); err != nil {
 				t.Fatal(err)
 			}
 			// Read with transaction, should get a value back.
-			val, _, err := mvccGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 7}, true, txn)
-			if err != nil {
+			if val, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 7}, true, txn); err != nil {
 				t.Fatal(err)
+			} else if val == nil || !bytes.Equal(val.RawBytes, value1.RawBytes) {
+				t.Fatalf("wanted %q, got %v", value1.RawBytes, val)
 			}
-			if val == nil || !bytes.Equal(val.RawBytes, value1.RawBytes) {
+			if kvs, _, _, err := MVCCScan(
+				ctx, engine, testKey1, testKey1.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, true, txn,
+			); err != nil {
+				t.Fatal(err)
+			} else if len(kvs) != 1 {
+				t.Fatalf("wanted 1 kv, got %d", len(kvs))
+			} else if val := kvs[0].Value; !bytes.Equal(val.RawBytes, value1.RawBytes) {
 				t.Fatalf("wanted %q, got %v", value1.RawBytes, val)
 			}
 
-			// Now using testKey2.
-			// Put a value that conflicts with MaxTimestamp.
-			if err := MVCCPut(context.Background(), engine, nil, testKey2, hlc.Timestamp{WallTime: 9}, value2, nil); err != nil {
+			// Case 2a: One value in the future of read but below MaxTimestamp
+			// of read. Should result in a ReadWithinUncertaintyIntervalError
+			// when reading.
+			//
+			// -----------------
+			// - 10: max timestamp
+			// -  9: val2
+			// |
+			// -  7: read timestamp
+			// -----------------
+			if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 9}, value2, nil); err != nil {
 				t.Fatal(err)
 			}
 			// Read with transaction, should get error back.
-			if _, _, err := mvccGet(context.Background(), engine, testKey2, hlc.Timestamp{WallTime: 7}, true, txn); err == nil {
+			if _, _, err := mvccGet(ctx, engine, testKey2, hlc.Timestamp{WallTime: 7}, true, txn); err == nil {
 				t.Fatal("wanted an error")
 			} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
 				t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
 			}
-			if _, _, _, err := MVCCScan(context.Background(), engine, testKey2, testKey2.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, true, txn); err == nil {
+			if _, _, _, err := MVCCScan(
+				ctx, engine, testKey2, testKey2.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, true, txn,
+			); err == nil {
 				t.Fatal("wanted an error")
 			} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
 				t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
 			}
-			// Adjust MaxTimestamp and retry.
-			txn.MaxTimestamp = hlc.Timestamp{WallTime: 7}
-			if _, _, err := mvccGet(context.Background(), engine, testKey2, hlc.Timestamp{WallTime: 7}, true, txn); err != nil {
+			// Case 2b: Reduce MaxTimestamp to exactly that of value in future.
+			// Should result in a ReadWithinUncertaintyIntervalError when
+			// reading.
+			//
+			// -----------------
+			// -  9: val2 & max timestamp
+			// |
+			// -  7: read timestamp
+			// -----------------
+			if _, _, err := mvccGet(ctx, engine, testKey2, hlc.Timestamp{WallTime: 7}, true, &txnMaxTS9); err == nil {
+				t.Fatal("wanted an error")
+			} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
+				t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
+			}
+			if _, _, _, err := MVCCScan(
+				ctx, engine, testKey2, testKey2.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, true, &txnMaxTS9,
+			); err == nil {
+				t.Fatal("wanted an error")
+			} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
+				t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
+			}
+			// Case 2c: Reduce MaxTimestamp below value in future. Value should
+			// no longer interfere when reading.
+			//
+			// -----------------
+			// -  9: val2
+			// |
+			// -  7: read timestamp & max timestamp
+			// -----------------
+			if _, _, err := mvccGet(ctx, engine, testKey2, hlc.Timestamp{WallTime: 7}, true, &txnMaxTS7); err != nil {
 				t.Fatal(err)
 			}
-			if _, _, _, err := MVCCScan(context.Background(), engine, testKey2, testKey2.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, true, txn); err != nil {
+			if _, _, _, err := MVCCScan(
+				ctx, engine, testKey2, testKey2.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, true, &txnMaxTS7,
+			); err != nil {
 				t.Fatal(err)
 			}
 
-			txn.MaxTimestamp = hlc.Timestamp{WallTime: 10}
-			// Now using testKey3.
-			// Put a value that conflicts with MaxTimestamp and another write further
-			// ahead and not conflicting any longer. The first write should still ruin
-			// it.
-			if err := MVCCPut(context.Background(), engine, nil, testKey3, hlc.Timestamp{WallTime: 9}, value2, nil); err != nil {
+			// Case 3a: One intent in the future of read but below MaxTimestamp
+			// of read. Should result in a WriteIntentError when reading.
+			//
+			// -----------------
+			// - 10: max timestamp
+			// -  9: val2 (intent)
+			// |
+			// -  7: read timestamp
+			// -----------------
+			intentTxn := &roachpb.Transaction{
+				TxnMeta: enginepb.TxnMeta{
+					ID:        uuid.MakeV4(),
+					Timestamp: hlc.Timestamp{WallTime: 9},
+				},
+				OrigTimestamp: hlc.Timestamp{WallTime: 9},
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey3, hlc.Timestamp{WallTime: 9}, value2, intentTxn); err != nil {
 				t.Fatal(err)
 			}
-			if err := MVCCPut(context.Background(), engine, nil, testKey3, hlc.Timestamp{WallTime: 99}, value2, nil); err != nil {
+			// Read with transaction, should get error back.
+			if _, _, err := mvccGet(ctx, engine, testKey3, hlc.Timestamp{WallTime: 7}, true, txn); err == nil {
+				t.Fatal("wanted an error")
+			} else if _, ok := err.(*roachpb.WriteIntentError); !ok {
+				t.Fatalf("wanted a WriteIntentError, got %+v", err)
+			}
+			if _, _, _, err := MVCCScan(
+				ctx, engine, testKey3, testKey3.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, true, txn,
+			); err == nil {
+				t.Fatal("wanted an error")
+			} else if _, ok := err.(*roachpb.WriteIntentError); !ok {
+				t.Fatalf("wanted a WriteIntentError, got %+v", err)
+			}
+			// Case 3b: Reduce MaxTimestamp to exactly that of intent in future.
+			// Should result in a WriteIntentError when reading.
+			//
+			// -----------------
+			// -  9: val2 (intent) & max timestamp
+			// |
+			// -  7: read timestamp
+			// -----------------
+			if _, _, err := mvccGet(ctx, engine, testKey3, hlc.Timestamp{WallTime: 7}, true, &txnMaxTS9); err == nil {
+				t.Fatal("wanted an error")
+			} else if _, ok := err.(*roachpb.WriteIntentError); !ok {
+				t.Fatalf("wanted a WriteIntentError, got %+v", err)
+			}
+			if _, _, _, err := MVCCScan(
+				ctx, engine, testKey3, testKey3.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, true, &txnMaxTS9,
+			); err == nil {
+				t.Fatal("wanted an error")
+			} else if _, ok := err.(*roachpb.WriteIntentError); !ok {
+				t.Fatalf("wanted a WriteIntentError, got %+v", err)
+			}
+			// Case 3c: Reduce MaxTimestamp below intent in future. Intent should
+			// no longer interfere when reading.
+			//
+			// -----------------
+			// -  9: val2 (intent)
+			// |
+			// -  7: read timestamp & max timestamp
+			// -----------------
+			if _, _, err := mvccGet(ctx, engine, testKey3, hlc.Timestamp{WallTime: 7}, true, &txnMaxTS7); err != nil {
 				t.Fatal(err)
 			}
-			if _, _, _, err := MVCCScan(context.Background(), engine, testKey3, testKey3.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, true, txn); err == nil {
+			if _, _, _, err := MVCCScan(
+				ctx, engine, testKey3, testKey3.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, true, &txnMaxTS7,
+			); err != nil {
+				t.Fatal(err)
+			}
+
+			// Case 4a: Two values in future of read. One is ahead of
+			// MaxTimestamp of read and one is below MaxTimestamp of read. The
+			// value within the read's uncertainty interval should result in a
+			// ReadWithinUncertaintyIntervalError when reading.
+			//
+			// -----------------
+			// - 99: val3
+			// |
+			// - 10: max timestamp
+			// -  9: val2
+			// |
+			// -  7: read timestamp
+			// -----------------
+			if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 9}, value2, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 99}, value3, nil); err != nil {
+				t.Fatal(err)
+			}
+			if _, _, err := mvccGet(ctx, engine, testKey4, hlc.Timestamp{WallTime: 7}, true, txn); err == nil {
+				t.Fatalf("wanted an error")
+			} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
+				t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
+			}
+			if _, _, _, err := MVCCScan(
+				ctx, engine, testKey4, testKey4.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, true, txn,
+			); err == nil {
 				t.Fatal("wanted an error")
 			} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
 				t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
 			}
-			if _, _, err := mvccGet(context.Background(), engine, testKey3, hlc.Timestamp{WallTime: 7}, true, txn); err == nil {
+			// Case 4b: Reduce MaxTimestamp to exactly that of second value in
+			// future. The value within the read's uncertainty interval should
+			// result in a ReadWithinUncertaintyIntervalError when reading.
+			//
+			// -----------------
+			// - 99: val3
+			// |
+			// -  9: val2 & max timestamp
+			// |
+			// -  7: read timestamp
+			// -----------------
+			if _, _, err := mvccGet(ctx, engine, testKey4, hlc.Timestamp{WallTime: 7}, true, &txnMaxTS9); err == nil {
 				t.Fatalf("wanted an error")
 			} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
 				t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
+			}
+			if _, _, _, err := MVCCScan(
+				ctx, engine, testKey4, testKey4.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, true, &txnMaxTS9,
+			); err == nil {
+				t.Fatal("wanted an error")
+			} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
+				t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
+			}
+			// Case 4c: Reduce MaxTimestamp below second value in future. Value should
+			// no longer interfere when reading.
+			//
+			// -----------------
+			// - 99: val3
+			// |
+			// -  9: val2
+			// |
+			// -  7: read timestamp & max timestamp
+			// -----------------
+			if _, _, err := mvccGet(ctx, engine, testKey4, hlc.Timestamp{WallTime: 7}, true, &txnMaxTS7); err != nil {
+				t.Fatal(err)
+			}
+			if _, _, _, err := MVCCScan(
+				ctx, engine, testKey4, testKey4.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, true, &txnMaxTS7,
+			); err != nil {
+				t.Fatal(err)
 			}
 		})
 	}

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -3121,6 +3121,80 @@ func TestMVCCGetWithDiffEpochs(t *testing.T) {
 	}
 }
 
+// TestMVCCGetWithDiffEpochsAndTimestamps writes a value first using
+// epoch 1, then reads using epoch 2 with different timestamps to verify
+// that values written during different transaction epochs are not visible.
+//
+// The test includes the case where the read at epoch 2 is at a *lower*
+// timestamp than the intent write at epoch 1. This is not expected to
+// happen commonly, but caused issues in #36089.
+func TestMVCCGetWithDiffEpochsAndTimestamps(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	for _, impl := range mvccGetImpls {
+		t.Run(impl.name, func(t *testing.T) {
+			mvccGet := impl.fn
+
+			ctx := context.Background()
+			engine := createTestEngine()
+			defer engine.Close()
+
+			// Write initial value without a txn at timestamp 1.
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
+				t.Fatal(err)
+			}
+			// Write another value without a txn at timestamp 3.
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, value2, nil); err != nil {
+				t.Fatal(err)
+			}
+			// Now write using txn1, epoch 1.
+			txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
+			// Bump epoch 1's write timestamp to timestamp 4.
+			txn1ts.Timestamp = hlc.Timestamp{WallTime: 4}
+			// Expected to hit WriteTooOld error but to still lay down intent.
+			err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value3, txn1ts)
+			if _, ok := err.(*roachpb.WriteTooOldError); !ok {
+				t.Fatalf("unexpectedly not WriteTooOld: %s", err)
+			}
+			// Try reading using different epochs & timestamps.
+			testCases := []struct {
+				txn      *roachpb.Transaction
+				readTS   hlc.Timestamp
+				expValue *roachpb.Value
+			}{
+				// Epoch 1, read 1; should see new value3.
+				{txn1, hlc.Timestamp{WallTime: 1}, &value3},
+				// Epoch 1, read 2; should see new value3.
+				{txn1, hlc.Timestamp{WallTime: 2}, &value3},
+				// Epoch 1, read 3; should see new value3.
+				{txn1, hlc.Timestamp{WallTime: 3}, &value3},
+				// Epoch 1, read 4; should see new value3.
+				{txn1, hlc.Timestamp{WallTime: 4}, &value3},
+				// Epoch 1, read 5; should see new value3.
+				{txn1, hlc.Timestamp{WallTime: 5}, &value3},
+				// Epoch 2, read 1; should see committed value1.
+				{txn1e2, hlc.Timestamp{WallTime: 1}, &value1},
+				// Epoch 2, read 2; should see committed value1.
+				{txn1e2, hlc.Timestamp{WallTime: 2}, &value1},
+				// Epoch 2, read 3; should see committed value2.
+				{txn1e2, hlc.Timestamp{WallTime: 3}, &value2},
+				// Epoch 2, read 4; should see committed value2.
+				{txn1e2, hlc.Timestamp{WallTime: 4}, &value2},
+				// Epoch 2, read 5; should see committed value2.
+				{txn1e2, hlc.Timestamp{WallTime: 5}, &value2},
+			}
+			for i, test := range testCases {
+				t.Run(strconv.Itoa(i), func(t *testing.T) {
+					value, _, err := mvccGet(ctx, engine, testKey1, test.readTS, true, test.txn)
+					if err != nil || value == nil || !bytes.Equal(test.expValue.RawBytes, value.RawBytes) {
+						t.Errorf("test %d: expected value %q, err nil; got %+v, %v", i, test.expValue.RawBytes, value, err)
+					}
+				})
+			}
+		})
+	}
+}
+
 // TestMVCCGetWithOldEpoch writes a value first using epoch 2, then
 // reads using epoch 1 to verify that the read will fail.
 func TestMVCCGetWithOldEpoch(t *testing.T) {


### PR DESCRIPTION
Backport:
  * 2/2 commits from "engine: correctly handle intents from previous epochs above read timestamp" (#38085)
  * 1/1 commits from "storage/engine: return WriteIntentError for intents in uncertainty intervals" (#40600)

Please see individual PRs for details.

Unlike #40611, all three of these commits took some tweaking. None of it was large though and it mostly had to do with testing and https://github.com/cockroachdb/cockroach/commit/57d02014e661aa4f153e56c558950d4c55c7877d + https://github.com/cockroachdb/cockroach/commit/4678a31a2f5f5f95369d8c67e3248688c6830acf.

/cc @cockroachdb/release
