### PR TITLE
release-2.0: storage: correctly handle empty forwarded proposals

### DIFF
--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -8076,7 +8076,7 @@ func TestReplicaShouldDropForwardedProposal(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	cmdSeen, cmdNotSeen := makeIDKey(), makeIDKey()
-	data, noData := []byte("data"), []byte("")
+	data := []byte("data")
 
 	testCases := []struct {
 		name                string
@@ -8085,6 +8085,30 @@ func TestReplicaShouldDropForwardedProposal(t *testing.T) {
 		expDrop             bool
 		expRemotePropsAfter int
 	}{
+		{
+			name:   "empty proposal (nil):",
+			leader: true,
+			msg: raftpb.Message{
+				Type: raftpb.MsgProp,
+				Entries: []raftpb.Entry{
+					{Type: raftpb.EntryNormal, Data: nil},
+				},
+			},
+			expDrop:             false,
+			expRemotePropsAfter: 1,
+		},
+		{
+			name:   "empty proposal (zero)",
+			leader: true,
+			msg: raftpb.Message{
+				Type: raftpb.MsgProp,
+				Entries: []raftpb.Entry{
+					{Type: raftpb.EntryNormal, Data: []byte{}},
+				},
+			},
+			expDrop:             false,
+			expRemotePropsAfter: 1,
+		},
 		{
 			name:   "new proposal",
 			leader: true,
@@ -8123,16 +8147,16 @@ func TestReplicaShouldDropForwardedProposal(t *testing.T) {
 			expRemotePropsAfter: 2,
 		},
 		{
-			name:   "empty proposal",
+			name:   "proposal with no data (not an empty proposal)",
 			leader: true,
 			msg: raftpb.Message{
 				Type: raftpb.MsgProp,
 				Entries: []raftpb.Entry{
-					{Type: raftpb.EntryNormal, Data: encodeRaftCommandV1(cmdNotSeen, noData)},
+					{Type: raftpb.EntryNormal, Data: encodeRaftCommandV1(cmdNotSeen, nil)},
 				},
 			},
 			expDrop:             false,
-			expRemotePropsAfter: 1,
+			expRemotePropsAfter: 2,
 		},
 		{
 			name:   "conf change",


### PR DESCRIPTION
Backport 1/1 commits from #31066.

/cc @cockroachdb/release

---

The code assumed that an empty proposal would be a command ID with empty
data, but it's really the empty slice (command IDs+data is our encoding;
Raft itself emits an entry with completely blank data).

Fixes #31050.

Release note: Fix a bug where forwarded empty proposals caused a null
pointer panic.