### PR TITLE
storage: print a pretty.Diff with the descriptor changed error

### DIFF
--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -40,6 +40,7 @@ import (
 	crdberrors "github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/gogo/protobuf/proto"
+	"github.com/kr/pretty"
 	"github.com/pkg/errors"
 	"go.etcd.io/etcd/raft"
 	"go.etcd.io/etcd/raft/raftpb"
@@ -71,7 +72,8 @@ func maybeDescriptorChangedError(desc *roachpb.RangeDescriptor, err error) (stri
 			return fmt.Sprintf("descriptor changed: expected %s != [actual] nil (range subsumed)", desc), true
 		} else if err := detail.ActualValue.GetProto(&actualDesc); err == nil &&
 			desc.RangeID == actualDesc.RangeID && !desc.Equal(actualDesc) {
-			return fmt.Sprintf("descriptor changed: [expected] %s != [actual] %s", desc, &actualDesc), true
+			return fmt.Sprintf("descriptor changed: [expected] %s != [actual] %s: %v",
+				desc, &actualDesc, pretty.Diff(desc, actualDesc)), true
 		}
 	}
 	return "", false


### PR DESCRIPTION
In #39072 we see:

```
Error: importing fixture: importing table stock: pq: descriptor changed: [expected] r1155:/Table/5{7/2-8} [(n16,s16):1, (n8,s8):5, (n30,s30):11, next=13, gen=239] != [actual] r1155:/Table/5{7/2-8} [(n16,s16):1, (n8,s8):5, (n30,s30):11, next=13, gen=239]: unexpected value: raw_bytes:"\363P\244T\003\010\203\t\022\002\301\212\032\001\302\"\006\010\020\020\020\030\001\"\006\010\010\020\010\030\005\"\006\010\036\020\036\030\013(\r0\357\001:\n\010\234\366\273\371\232\322\204\341\025@\001" timestamp:<wall_time:1567832452567360492 logical:1 >
```

Which is frustrating because those stringified values look identical to me.
Hopefully this debugging will reveal something in any future repros.

Release note: None