### PR TITLE
backupccl: allow backups with proto named BACKUP_MANIFEST

### DIFF
--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -54,6 +54,10 @@ const (
 	// BackupDescriptorName is the file name used for serialized
 	// BackupDescriptor protos.
 	BackupDescriptorName = "BACKUP"
+	// BackupManifestName is a future name for the serialized
+	// BackupDescriptor proto.
+	BackupManifestName = "BACKUP_MANIFEST"
+
 	// BackupPartitionDescriptorPrefix is the file name prefix for serialized
 	// BackupPartitionDescriptor protos.
 	BackupPartitionDescriptorPrefix = "BACKUP_PART"
@@ -91,7 +95,11 @@ func ReadBackupDescriptorFromURI(
 	defer exportStore.Close()
 	backupDesc, err := readBackupDescriptor(ctx, exportStore, BackupDescriptorName)
 	if err != nil {
-		return BackupDescriptor{}, err
+		backupManifest, manifestErr := readBackupDescriptor(ctx, exportStore, BackupManifestName)
+		if manifestErr != nil {
+			return BackupDescriptor{}, err
+		}
+		backupDesc = backupManifest
 	}
 	backupDesc.Dir = exportStore.Conf()
 	// TODO(dan): Sanity check this BackupDescriptor: non-empty EndTime,
@@ -898,6 +906,14 @@ func VerifyUsableExportTarget(
 		return pgerror.Newf(pgcode.DuplicateFile,
 			"%s already contains a %s file",
 			readable, BackupDescriptorName)
+	}
+	if r, err := exportStore.ReadFile(ctx, BackupManifestName); err == nil {
+		// TODO(dt): If we audit exactly what not-exists error each ExportStorage
+		// returns (and then wrap/tag them), we could narrow this check.
+		r.Close()
+		return pgerror.Newf(pgcode.DuplicateFile,
+			"%s already contains a %s file",
+			readable, BackupManifestName)
 	}
 	if r, err := exportStore.ReadFile(ctx, BackupDescriptorCheckpointName); err == nil {
 		r.Close()

--- a/pkg/ccl/backupccl/restore.go
+++ b/pkg/ccl/backupccl/restore.go
@@ -114,7 +114,11 @@ func getBackupLocalityInfo(
 	// upgrade them.
 	mainBackupDesc, err := readBackupDescriptor(ctx, stores[0], BackupDescriptorName)
 	if err != nil {
-		return info, err
+		manifest, manifestErr := readBackupDescriptor(ctx, stores[0], BackupManifestName)
+		if manifestErr != nil {
+			return info, err
+		}
+		mainBackupDesc = manifest
 	}
 
 	// Now get the list of expected partial per-store backup manifest filenames


### PR DESCRIPTION
This does *not* change the writing of the current manifest file at the current name -- it only checks for the new name when reading the old one fails.

Adding this check now will allow a future-version to only write at the new name, but still play nice with any old nodes, as during the upgrade all nodes will look at both names.

Release justification: this is a low-risk change with high value, in that it establishes compatibility for a UX polish change we want to do in 20.1.

Release note: none.