### PR TITLE
ui: update wording of tooltip for transactions chart

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -195,7 +195,7 @@ export default function (props: GraphDashboardProps) {
       title="Transactions"
       sources={nodeSources}
       tooltip={
-        `The total number of transactions opened, committed, rolled back,
+        `The total number of transactions initiated, committed, rolled back,
            or aborted per second ${tooltipSelection}.`
       }
     >


### PR DESCRIPTION
Use the word "initiated" instead of "opened" to match the docs better.

closes #40376

Release note: None