### PR TITLE
exec: fix a bug with ON expression support for joiners

### DIFF
--- a/pkg/sql/exec/hashjoiner_test.go
+++ b/pkg/sql/exec/hashjoiner_test.go
@@ -38,6 +38,7 @@ func TestHashJoinerInt64(t *testing.T) {
 		}
 	}
 
+	// TODO(yuzefovich): add unit tests for cases with ON expression.
 	tcs := []struct {
 		leftTypes  []coltypes.T
 		rightTypes []coltypes.T

--- a/pkg/sql/exec/joiner_util_tmpl.go
+++ b/pkg/sql/exec/joiner_util_tmpl.go
@@ -136,6 +136,10 @@ func (f *joinerFilter) setInputBatch(lBatch, rBatch coldata.Batch, lIdx, rIdx in
 		execerror.VectorizedInternalPanic("only one of lBatch and rBatch can be nil")
 	}
 	setOneSide := func(colOffset int, batch coldata.Batch, sourceTypes []coltypes.T, idx int) {
+		sel := batch.Selection()
+		if sel != nil {
+			idx = int(sel[idx])
+		}
 		for colIdx := 0; colIdx < batch.Width(); colIdx++ {
 			colType := sourceTypes[colIdx]
 			col := batch.ColVec(colIdx)

--- a/pkg/sql/exec/mergejoiner_test.go
+++ b/pkg/sql/exec/mergejoiner_test.go
@@ -26,6 +26,8 @@ type mjTestInitializer interface {
 	initWithBatchSize(outBatchSize uint16)
 }
 
+// TODO(yuzefovich): add unit tests for cases with ON expression.
+
 type mjTestCase struct {
 	description     string
 	joinType        sqlbase.JoinType


### PR DESCRIPTION
Previously, a selection vector was ignored when applying a filter
on the batch. Now this is fixed. It is extremely difficult to write
a unit test for this at the moment because the filter planning code
lives in sql/distsqlrun.

Release note: None