### PR TITLE
sql: EXPLAIN shows if a query will execute with vec/distsql

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -26,9 +26,11 @@ ALTER INDEX t@secondary CONFIGURE ZONE USING constraints='[+region=test,+dc=dc1]
 query TTT retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
-scan  ·      ·
-·     table  t@secondary
-·     spans  /10-/11
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        t@secondary
+·     spans        /10-/11
 
 query T retry
 EXPLAIN (OPT, CATALOG) SELECT * FROM t
@@ -66,9 +68,11 @@ ALTER INDEX t@tertiary CONFIGURE ZONE USING constraints='[+region=test,+dc=dc1]'
 query TTT retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
-scan  ·      ·
-·     table  t@tertiary
-·     spans  /10-/11
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        t@tertiary
+·     spans        /10-/11
 
 query T retry
 EXPLAIN (OPT, CATALOG) SELECT * FROM t
@@ -106,9 +110,11 @@ ALTER INDEX t@tertiary CONFIGURE ZONE USING constraints='[+region=test,+dc=dc3]'
 query TTT retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
-scan  ·      ·
-·     table  t@secondary
-·     spans  /10-/11
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        t@secondary
+·     spans        /10-/11
 
 # ------------------------------------------------------------------------------
 # Swap location of primary and secondary indexes and ensure that primary index
@@ -124,9 +130,11 @@ ALTER INDEX t@secondary CONFIGURE ZONE USING constraints='[+region=test,+dc=dc2]
 query TTT retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
-scan  ·      ·
-·     table  t@primary
-·     spans  /10-/10/#
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        t@primary
+·     spans        /10-/10/#
 
 query T retry
 EXPLAIN (OPT, CATALOG) SELECT * FROM t
@@ -161,9 +169,11 @@ PREPARE p AS SELECT tree, field, description FROM [EXPLAIN SELECT k, v FROM t WH
 query TTT retry
 EXECUTE p
 ----
-scan  ·      ·
-·     table  t@primary
-·     spans  /10-/10/#
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        t@primary
+·     spans        /10-/10/#
 
 statement ok
 ALTER TABLE t CONFIGURE ZONE USING constraints='[+region=test,+dc=dc2]'
@@ -174,9 +184,11 @@ ALTER INDEX t@secondary CONFIGURE ZONE USING constraints='[+region=test,+dc=dc1]
 query TTT retry
 EXECUTE p
 ----
-scan  ·      ·
-·     table  t@secondary
-·     spans  /10-/11
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        t@secondary
+·     spans        /10-/11
 
 statement ok
 DEALLOCATE p
@@ -197,9 +209,11 @@ USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc1]]'
 query TTT retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
-scan  ·      ·
-·     table  t@secondary
-·     spans  /10-/11
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        t@secondary
+·     spans        /10-/11
 
 # ------------------------------------------------------------------------------
 # Move secondary lease preference to dc3 and put tertiary lease preference in
@@ -217,9 +231,11 @@ USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc1]]'
 query TTT retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
-scan  ·      ·
-·     table  t@tertiary
-·     spans  /10-/11
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        t@tertiary
+·     spans        /10-/11
 
 query T retry
 EXPLAIN (OPT, CATALOG) SELECT * FROM t
@@ -267,9 +283,11 @@ USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc1]]'
 query TTT retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
-scan  ·      ·
-·     table  t@secondary
-·     spans  /10-/11
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        t@secondary
+·     spans        /10-/11
 
 query T retry
 EXPLAIN (OPT, CATALOG) SELECT * FROM t
@@ -307,9 +325,11 @@ PREPARE p AS SELECT tree, field, description FROM [EXPLAIN SELECT k, v FROM t WH
 query TTT retry
 EXECUTE p
 ----
-scan  ·      ·
-·     table  t@secondary
-·     spans  /10-/11
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        t@secondary
+·     spans        /10-/11
 
 statement ok
 ALTER INDEX t@secondary CONFIGURE ZONE
@@ -318,9 +338,11 @@ USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc2]]'
 query TTT retry
 EXECUTE p
 ----
-scan  ·      ·
-·     table  t@primary
-·     spans  /10-/10/#
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        t@primary
+·     spans        /10-/10/#
 
 statement ok
 DEALLOCATE p
@@ -345,9 +367,11 @@ ALTER INDEX t36642@secondary CONFIGURE ZONE USING lease_preferences='[[+region=t
 query TTT retry
 EXPLAIN SELECT * FROM t36642 WHERE k=10
 ----
-scan  ·      ·
-·     table  t36642@secondary
-·     spans  /10-/11
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        t36642@secondary
+·     spans        /10-/11
 
 statement ok
 ALTER INDEX t36642@tertiary CONFIGURE ZONE USING lease_preferences='[[+region=test,+dc=dc1]]'
@@ -358,9 +382,11 @@ ALTER INDEX t36642@secondary CONFIGURE ZONE USING lease_preferences='[[+region=t
 query TTT retry
 EXPLAIN SELECT * FROM t36642 WHERE k=10
 ----
-scan  ·      ·
-·     table  t36642@tertiary
-·     spans  /10-/11
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        t36642@tertiary
+·     spans        /10-/11
 
 query T retry
 EXPLAIN (OPT, CATALOG) SELECT * FROM t
@@ -408,9 +434,11 @@ CONFIGURE ZONE USING constraints='[+region=test]', lease_preferences='[[+dc=dc1]
 query TTT retry
 EXPLAIN SELECT * FROM t36644 WHERE k=10
 ----
-scan  ·      ·
-·     table  t36644@secondary
-·     spans  /10-/11
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        t36644@secondary
+·     spans        /10-/11
 
 statement ok
 ALTER INDEX t36644@secondary CONFIGURE ZONE USING lease_preferences='[[+dc=dc3]]'
@@ -422,9 +450,11 @@ CONFIGURE ZONE USING constraints='[+region=test]', lease_preferences='[[+dc=dc1]
 query TTT retry
 EXPLAIN SELECT * FROM t36644 WHERE k=10
 ----
-scan  ·      ·
-·     table  t36644@tertiary
-·     spans  /10-/11
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        t36644@tertiary
+·     spans        /10-/11
 
 subtest regression_35756
 

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1374,13 +1374,15 @@ func Example_misc_table() {
 	//     hai
 	// (1 row)
 	// sql --format=table -e explain select s, 'foo' from t.t
-	//     tree    | field | description
-	// +-----------+-------+-------------+
-	//   render    |       |
-	//    └── scan |       |
-	//             | table | t@primary
-	//             | spans | ALL
-	// (4 rows)
+	//     tree    |    field    | description
+	// +-----------+-------------+-------------+
+	//             | distributed | true
+	//             | vectorized  | true
+	//   render    |             |
+	//    └── scan |             |
+	//             | table       | t@primary
+	//             | spans       | ALL
+	// (6 rows)
 }
 
 func Example_user() {

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -62,20 +62,10 @@ type distSQLExplainable interface {
 }
 
 func (n *explainDistSQLNode) startExec(params runParams) error {
-	// Trigger limit propagation.
-	params.p.prepareForDistSQLSupportCheck()
-
 	distSQLPlanner := params.extendedEvalCtx.DistSQLPlanner
-
-	var recommendation distRecommendation
-	if _, ok := n.plan.(distSQLExplainable); ok {
-		recommendation = shouldDistribute
-	} else {
-		recommendation, _ = distSQLPlanner.checkSupportForNode(n.plan)
-	}
-
+	shouldPlanDistribute, recommendation := willDistributePlan(distSQLPlanner, n.plan, params)
 	planCtx := distSQLPlanner.NewPlanningCtx(params.ctx, params.extendedEvalCtx, params.p.txn)
-	planCtx.isLocal = !shouldDistributeGivenRecAndMode(recommendation, params.SessionData().DistSQLMode)
+	planCtx.isLocal = !shouldPlanDistribute
 	planCtx.ignoreClose = true
 	planCtx.planner = params.p
 	planCtx.stmtType = n.stmtType
@@ -124,19 +114,12 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 		}
 	}
 
-	var plan PhysicalPlan
-	var err error
-	if planNode, ok := n.plan.(distSQLExplainable); ok {
-		plan, err = planNode.makePlanForExplainDistSQL(planCtx, distSQLPlanner)
-	} else {
-		plan, err = distSQLPlanner.createPlanForNode(planCtx, n.plan)
-	}
+	plan, err := makePhysicalPlan(planCtx, distSQLPlanner, n.plan)
 	if err != nil {
 		return err
 	}
 
 	distSQLPlanner.FinalizePlan(planCtx, &plan)
-
 	flows := plan.GenerateFlowSpecs(params.extendedEvalCtx.NodeID)
 	diagram, err := distsqlpb.GeneratePlanDiagram(flows)
 	if err != nil {
@@ -238,4 +221,38 @@ func (n *explainDistSQLNode) Close(ctx context.Context) {
 			n.subqueryPlans[i].plan = nil
 		}
 	}
+}
+
+// willDistributePlan checks if the given plan will run with distributed
+// execution. It takes into account whether a distSQL plan can be made at all
+// and the session setting for distSQL.
+func willDistributePlan(
+	distSQLPlanner *DistSQLPlanner, plan planNode, params runParams,
+) (bool, distRecommendation) {
+	// Trigger limit propagation.
+	params.p.prepareForDistSQLSupportCheck()
+	var recommendation distRecommendation
+	if _, ok := plan.(distSQLExplainable); ok {
+		recommendation = shouldDistribute
+	} else {
+		recommendation, _ = distSQLPlanner.checkSupportForNode(plan)
+	}
+	shouldDistribute := shouldDistributeGivenRecAndMode(recommendation, params.SessionData().DistSQLMode)
+	return shouldDistribute, recommendation
+}
+
+func makePhysicalPlan(
+	planCtx *PlanningCtx, distSQLPlanner *DistSQLPlanner, plan planNode,
+) (PhysicalPlan, error) {
+	var physPlan PhysicalPlan
+	var err error
+	if planNode, ok := plan.(distSQLExplainable); ok {
+		physPlan, err = planNode.makePlanForExplainDistSQL(planCtx, distSQLPlanner)
+	} else {
+		physPlan, err = distSQLPlanner.createPlanForNode(planCtx, plan)
+	}
+	if err != nil {
+		return PhysicalPlan{}, err
+	}
+	return physPlan, nil
 }

--- a/pkg/sql/logictest/testdata/logic_test/rename_column
+++ b/pkg/sql/logictest/testdata/logic_test/rename_column
@@ -120,7 +120,9 @@ species
 query TTT
 EXPLAIN ALTER TABLE users RENAME COLUMN species TO woo
 ----
-alter table  ·  ·
+·            distributed  false
+·            vectorized   false
+alter table  ·            ·
 
 # Verify that EXPLAIN did not actually rename the column
 query T

--- a/pkg/sql/logictest/testdata/logic_test/rename_database
+++ b/pkg/sql/logictest/testdata/logic_test/rename_database
@@ -157,7 +157,9 @@ v
 query TTT
 EXPLAIN ALTER DATABASE v RENAME TO x
 ----
-rename database  ·  ·
+·                distributed  false
+·                vectorized   false
+rename database  ·            ·
 
 # Verify that the EXPLAIN above does not actually rename the database (#30543)
 query T colnames

--- a/pkg/sql/logictest/testdata/logic_test/rename_index
+++ b/pkg/sql/logictest/testdata/logic_test/rename_index
@@ -103,7 +103,9 @@ SELECT * FROM users@pk
 query TTT
 EXPLAIN ALTER INDEX users@bar RENAME TO woo
 ----
-rename index  ·  ·
+·             distributed  false
+·             vectorized   false
+rename index  ·            ·
 
 # Verify that EXPLAIN did not actually rename the index (#30543)
 query T rowsort

--- a/pkg/sql/logictest/testdata/logic_test/rename_table
+++ b/pkg/sql/logictest/testdata/logic_test/rename_table
@@ -271,7 +271,9 @@ kv
 query TTT
 EXPLAIN ALTER TABLE kv RENAME TO kv2
 ----
-rename table  ·  ·
+·             distributed  false
+·             vectorized   false
+rename table  ·            ·
 
 # Verify that the EXPLAIN above does not actually rename the table (#30543)
 query T

--- a/pkg/sql/logictest/testdata/logic_test/truncate
+++ b/pkg/sql/logictest/testdata/logic_test/truncate
@@ -163,7 +163,9 @@ CREATE TABLE tt AS SELECT 'foo'
 query TTT
 EXPLAIN TRUNCATE TABLE tt
 ----
-truncate  ·  ·
+·         distributed  false
+·         vectorized   false
+truncate  ·            ·
 
 # Verify that EXPLAIN did not cause the truncate to be performed.
 query T

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -11,6 +11,8 @@ CREATE TABLE kv (
 query TTTTT
 EXPLAIN (TYPES) SELECT min(1), max(1), count(1), sum_int(1), avg(1), sum(1), stddev(1), variance(1), bool_and(true), bool_or(false), xor_agg(b'\x01') FROM kv
 ----
+·               distributed   false               ·                                                                                                                                                   ·
+·               vectorized    false               ·                                                                                                                                                   ·
 group           ·             ·                   (min int, max int, count int, sum_int int, avg decimal, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_or bool, xor_agg bytes)  ·
  │              aggregate 0   min(column5)        ·                                                                                                                                                   ·
  │              aggregate 1   max(column5)        ·                                                                                                                                                   ·
@@ -36,6 +38,8 @@ group           ·             ·                   (min int, max int, count int
 query TTTTT
 EXPLAIN (TYPES) SELECT min(v), max(v), count(v), sum_int(1), avg(v), sum(v), stddev(v), variance(v), bool_and(v = 1), bool_and(v = 1), xor_agg(s::bytes) FROM kv
 ----
+·                    distributed  false                        ·                                                                                                                                                    ·
+·                    vectorized   false                        ·                                                                                                                                                    ·
 render               ·            ·                            (min int, max int, count int, sum_int int, avg decimal, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_and bool, xor_agg bytes)  ·
  │                   render 0     (min)[int]                   ·                                                                                                                                                    ·
  │                   render 1     (max)[int]                   ·                                                                                                                                                    ·
@@ -73,6 +77,8 @@ render               ·            ·                            (min int, max i
 query TTTTT
 EXPLAIN (TYPES) SELECT min(1), count(1), max(1), sum_int(1), avg(1)::float, sum(1), stddev(1), variance(1), bool_and(true), bool_or(true), to_hex(xor_agg(b'\x01'))
 ----
+·                 distributed    false                               ·                                                                                                                                                   ·
+·                 vectorized     false                               ·                                                                                                                                                   ·
 render            ·              ·                                   (min int, count int, max int, sum_int int, avg float, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_or bool, to_hex string)    ·
  │                render 0       (min)[int]                          ·                                                                                                                                                   ·
  │                render 1       (count)[int]                        ·                                                                                                                                                   ·
@@ -107,6 +113,8 @@ render            ·              ·                                   (min int,
 query TTTTT
 EXPLAIN (TYPES) SELECT count(*), k FROM kv GROUP BY 2
 ----
+·               distributed  false              ·                        ·
+·               vectorized   true               ·                        ·
 render          ·            ·                  (count int, k int)       ·
  │              render 0     (count_rows)[int]  ·                        ·
  │              render 1     (k)[int]           ·                        ·
@@ -123,6 +131,8 @@ render          ·            ·                  (count int, k int)       ·
 query TTTTT
 EXPLAIN (TYPES) SELECT count(*), k+v AS r FROM kv GROUP BY k+v
 ----
+·                    distributed  false                       ·                              ·
+·                    vectorized   false                       ·                              ·
 render               ·            ·                           (count int, r int)             ·
  │                   render 0     (count_rows)[int]           ·                              ·
  │                   render 1     (column6)[int]              ·                              ·
@@ -140,6 +150,8 @@ render               ·            ·                           (count int, r in
 query TTTTT
 EXPLAIN (TYPES) SELECT count(*), k+v AS r FROM kv GROUP BY k, v
 ----
+·               distributed  false                                  ·                                          ·
+·               vectorized   true                                   ·                                          ·
 render          ·            ·                                      (count int, r int)                         ·
  │              render 0     (count_rows)[int]                      ·                                          ·
  │              render 1     ((k)[int] + (any_not_null)[int])[int]  ·                                          ·
@@ -156,6 +168,8 @@ render          ·            ·                                      (count int
 query TTTTT
 EXPLAIN (TYPES) SELECT count(k) FROM kv
 ----
+·          distributed  false       ·            ·
+·          vectorized   true        ·            ·
 group      ·            ·           (count int)  ·
  │         aggregate 0  count(k)    ·            ·
  │         scalar       ·           ·            ·
@@ -166,6 +180,8 @@ group      ·            ·           (count int)  ·
 query TTTTT
 EXPLAIN (TYPES) SELECT count(k), sum(k), max(k) FROM kv
 ----
+·          distributed  false       ·                                  ·
+·          vectorized   false       ·                                  ·
 group      ·            ·           (count int, sum decimal, max int)  ·
  │         aggregate 0  count(k)    ·                                  ·
  │         aggregate 1  sum(k)      ·                                  ·
@@ -178,6 +194,8 @@ group      ·            ·           (count int, sum decimal, max int)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT count(v), count(DISTINCT v), sum(v), sum(DISTINCT v), min(v), min(DISTINCT v) FROM kv
 ----
+·          distributed  false              ·                                   ·
+·          vectorized   false              ·                                   ·
 group      ·            ·                  (count, count, sum, sum, min, min)  ·
  │         aggregate 0  count(v)           ·                                   ·
  │         aggregate 1  count(DISTINCT v)  ·                                   ·
@@ -193,6 +211,8 @@ group      ·            ·                  (count, count, sum, sum, min, min) 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT count(DISTINCT a.*) FROM kv a, kv b
 ----
+·                    distributed  false                         ·             ·
+·                    vectorized   false                         ·             ·
 group                ·            ·                             (count)       ·
  │                   aggregate 0  count(DISTINCT column9)       ·             ·
  │                   scalar       ·                             ·             ·
@@ -212,6 +232,8 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT min(b.k) FROM kv a, kv b GROUP BY a.*
 ]
 ----
+·                    distributed  false
+·                    vectorized   false
 render               ·            ·
  │                   render 0     min
  └── group           ·            ·
@@ -232,6 +254,8 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT min(b.k) FROM kv a, kv b GROUP BY (1, (a.*))
 ]
 ----
+·                    distributed  false
+·                    vectorized   false
 render               ·            ·
  │                   render 0     min
  └── group           ·            ·
@@ -253,6 +277,8 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT min(b.k) FROM kv a, kv b GROUP BY (a.*)
 ]
 ----
+·                    distributed  false
+·                    vectorized   false
 render               ·            ·
  │                   render 0     min
  └── group           ·            ·
@@ -274,6 +300,8 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT a.v FROM kv a, kv b GROUP BY a.v, a.w, a.s
 ]
 ----
+·                    distributed  false
+·                    vectorized   false
 render               ·            ·
  │                   render 0     v
  └── distinct        ·            ·
@@ -298,6 +326,8 @@ CREATE TABLE abc (
 query TTTTT
 EXPLAIN (TYPES) SELECT min(a) FROM abc
 ----
+·          distributed  false            ·           ·
+·          vectorized   true             ·           ·
 group      ·            ·                (min char)  ·
  │         aggregate 0  any_not_null(a)  ·           ·
  │         scalar       ·                ·           ·
@@ -324,6 +354,8 @@ INSERT INTO xyz VALUES (1, 2, 3.0), (4, 5, 6.0), (7, NULL, 8.0)
 query TTTTT
 EXPLAIN (TYPES) SELECT min(x) FROM xyz
 ----
+·          distributed  false            ·          ·
+·          vectorized   true             ·          ·
 group      ·            ·                (min int)  ·
  │         aggregate 0  any_not_null(x)  ·          ·
  │         scalar       ·                ·          ·
@@ -335,6 +367,8 @@ group      ·            ·                (min int)  ·
 query TTTTT
 EXPLAIN (TYPES) SELECT min(x) FROM xyz WHERE x in (0, 4, 7)
 ----
+·          distributed  false              ·          ·
+·          vectorized   true               ·          ·
 group      ·            ·                  (min int)  ·
  │         aggregate 0  any_not_null(x)    ·          ·
  │         scalar       ·                  ·          ·
@@ -346,6 +380,8 @@ group      ·            ·                  (min int)  ·
 query TTTTT
 EXPLAIN (TYPES) SELECT max(x) FROM xyz
 ----
+·             distributed  false            ·          ·
+·             vectorized   true             ·          ·
 group         ·            ·                (max int)  ·
  │            aggregate 0  any_not_null(x)  ·          ·
  │            scalar       ·                ·          ·
@@ -357,6 +393,8 @@ group         ·            ·                (max int)  ·
 query TTTTT
 EXPLAIN (TYPES) SELECT min(y) FROM xyz WHERE x = 1
 ----
+·               distributed  false            ·               ·
+·               vectorized   true             ·               ·
 group           ·            ·                (min int)       ·
  │              aggregate 0  any_not_null(y)  ·               ·
  │              scalar       ·                ·               ·
@@ -369,6 +407,8 @@ group           ·            ·                (min int)       ·
 query TTTTT
 EXPLAIN (TYPES) SELECT max(y) FROM xyz WHERE x = 1
 ----
+·               distributed  false            ·               ·
+·               vectorized   true             ·               ·
 group           ·            ·                (max int)       ·
  │              aggregate 0  any_not_null(y)  ·               ·
  │              scalar       ·                ·               ·
@@ -381,6 +421,8 @@ group           ·            ·                (max int)       ·
 query TTTTT
 EXPLAIN (TYPES) SELECT min(y) FROM xyz WHERE z = 7
 ----
+·               distributed  false                        ·                 ·
+·               vectorized   true                         ·                 ·
 group           ·            ·                            (min int)         ·
  │              aggregate 0  any_not_null(y)              ·                 ·
  │              scalar       ·                            ·                 ·
@@ -394,6 +436,8 @@ group           ·            ·                            (min int)         ·
 query TTTTT
 EXPLAIN (TYPES) SELECT max(y) FROM xyz WHERE z = 7
 ----
+·                  distributed  false                        ·                 ·
+·                  vectorized   true                         ·                 ·
 group              ·            ·                            (max int)         ·
  │                 aggregate 0  any_not_null(y)              ·                 ·
  │                 scalar       ·                            ·                 ·
@@ -407,6 +451,8 @@ group              ·            ·                            (max int)        
 query TTTTT
 EXPLAIN (TYPES) SELECT min(x) FROM xyz WHERE (y, z) = (2, 3.0)
 ----
+·               distributed  false      ·                        ·
+·               vectorized   true       ·                        ·
 group           ·            ·          (min int)                ·
  │              aggregate 0  min(x)     ·                        ·
  │              scalar       ·          ·                        ·
@@ -430,6 +476,8 @@ output row: [1]
 query TTTTT
 EXPLAIN (TYPES) SELECT max(x) FROM xyz WHERE (z, y) = (3.0, 2)
 ----
+·               distributed  false      ·                        ·
+·               vectorized   true       ·                        ·
 group           ·            ·          (max int)                ·
  │              aggregate 0  max(x)     ·                        ·
  │              scalar       ·          ·                        ·
@@ -462,6 +510,8 @@ output row: [9 4.5 6.33333333333333]
 query TTTTT
 EXPLAIN (TYPES) SELECT variance(x) FROM xyz WHERE x = 1
 ----
+·          distributed  false        ·                   ·
+·          vectorized   false        ·                   ·
 group      ·            ·            (variance decimal)  ·
  │         aggregate 0  variance(x)  ·                   ·
  │         scalar       ·            ·                   ·
@@ -531,6 +581,8 @@ INSERT INTO ab VALUES
 query TTTTT
 EXPLAIN (TYPES) SELECT v, count(k) FROM kv GROUP BY v ORDER BY count(k)
 ----
+·               distributed  false       ·                   ·
+·               vectorized   false       ·                   ·
 sort            ·            ·           (v int, count int)  +count
  │              order        +count      ·                   ·
  └── group      ·            ·           (v int, count int)  ·
@@ -544,6 +596,8 @@ sort            ·            ·           (v int, count int)  +count
 query TTTTT
 EXPLAIN (TYPES) SELECT v, count(*) FROM kv GROUP BY v ORDER BY count(*)
 ----
+·               distributed  false         ·                   ·
+·               vectorized   false         ·                   ·
 sort            ·            ·             (v int, count int)  +count
  │              order        +count        ·                   ·
  └── group      ·            ·             (v int, count int)  ·
@@ -557,6 +611,8 @@ sort            ·            ·             (v int, count int)  +count
 query TTTTT
 EXPLAIN (TYPES) SELECT v, count(1) FROM kv GROUP BY v ORDER BY count(1)
 ----
+·                    distributed  false           ·                     ·
+·                    vectorized   false           ·                     ·
 sort                 ·            ·               (v int, count int)    +count
  │                   order        +count          ·                     ·
  └── group           ·            ·               (v int, count int)    ·
@@ -574,6 +630,8 @@ sort                 ·            ·               (v int, count int)    +count
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT v, count(1) FROM kv GROUP BY v) WHERE v > 10
 ----
+·               distributed  false           ·             ·
+·               vectorized   false           ·             ·
 group           ·            ·               (v, count)    ·
  │              aggregate 0  v               ·             ·
  │              aggregate 1  count(column5)  ·             ·
@@ -599,6 +657,8 @@ CREATE TABLE filter_test (
 query TTTTT
 EXPLAIN (VERBOSE) SELECT count(*) FILTER (WHERE k>5), max(k>5) FILTER(WHERE k>5) FROM filter_test GROUP BY v
 ----
+·                    distributed  false                                  ·                      ·
+·                    vectorized   false                                  ·                      ·
 render               ·            ·                                      (count, max)           ·
  │                   render 0     count                                  ·                      ·
  │                   render 1     max                                    ·                      ·
@@ -618,6 +678,8 @@ render               ·            ·                                      (coun
 query TTTTT
 EXPLAIN (VERBOSE) SELECT count(*) FILTER (WHERE k > 5) FROM filter_test GROUP BY v
 ----
+·                    distributed  false                                  ·                      ·
+·                    vectorized   false                                  ·                      ·
 render               ·            ·                                      (count)                ·
  │                   render 0     count                                  ·                      ·
  └── group           ·            ·                                      (v, count)             ·
@@ -636,15 +698,19 @@ render               ·            ·                                      (coun
 query TTTTT
 EXPLAIN (TYPES) SELECT 1 a FROM kv GROUP BY kv.*;
 ----
-render     ·         ·           (a int)  ·
- │         render 0  (1)[int]    ·        ·
- └── scan  ·         ·           ()       ·
-·          table     kv@primary  ·        ·
-·          spans     ALL         ·        ·
+·          distributed  false       ·        ·
+·          vectorized   true        ·        ·
+render     ·            ·           (a int)  ·
+ │         render 0     (1)[int]    ·        ·
+ └── scan  ·            ·           ()       ·
+·          table        kv@primary  ·        ·
+·          spans        ALL         ·        ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT sum(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*;
 ----
+·                    distributed  false                             ·                     ·
+·                    vectorized   false                             ·                     ·
 render               ·            ·                                 (sum decimal)         ·
  │                   render 0     (sum)[decimal]                    ·                     ·
  └── group           ·            ·                                 (k int, sum decimal)  ·
@@ -669,6 +735,8 @@ CREATE TABLE opt_test (k INT PRIMARY KEY, v INT, INDEX v(v))
 query TTTTT
 EXPLAIN (TYPES) SELECT min(v) FROM opt_test
 ----
+·          distributed  false            ·          ·
+·          vectorized   true             ·          ·
 group      ·            ·                (min int)  ·
  │         aggregate 0  any_not_null(v)  ·          ·
  │         scalar       ·                ·          ·
@@ -683,6 +751,8 @@ group      ·            ·                (min int)  ·
 query TTTTT
 EXPLAIN (TYPES) SELECT min(v) FROM opt_test WHERE k <> 4
 ----
+·               distributed  false             ·               ·
+·               vectorized   true              ·               ·
 group           ·            ·                 (min int)       ·
  │              aggregate 0  min(v)            ·               ·
  │              scalar       ·                 ·               ·
@@ -697,6 +767,8 @@ group           ·            ·                 (min int)       ·
 query TTTTT
 EXPLAIN (TYPES) SELECT min(v+1) FROM opt_test
 ----
+·               distributed  false                       ·              ·
+·               vectorized   true                        ·              ·
 group           ·            ·                           (min int)      ·
  │              aggregate 0  min(column3)                ·              ·
  │              scalar       ·                           ·              ·
@@ -710,6 +782,8 @@ group           ·            ·                           (min int)      ·
 query TTTTT
 EXPLAIN (TYPES) SELECT min(v) FROM opt_test GROUP BY k
 ----
+·               distributed  false             ·                 ·
+·               vectorized   true              ·                 ·
 render          ·            ·                 (min int)         ·
  │              render 0     (min)[int]        ·                 ·
  └── group      ·            ·                 (k int, min int)  ·
@@ -727,15 +801,19 @@ CREATE TABLE xy(x STRING, y STRING);
 query TTTTT
 EXPLAIN (TYPES) SELECT (b, a) r FROM ab GROUP BY (b, a)
 ----
-render     ·         ·                                        (r tuple{int, int})  ·
- │         render 0  (((b)[int], (a)[int]))[tuple{int, int}]  ·                    ·
- └── scan  ·         ·                                        (a int, b int)       ·
-·          table     ab@primary                               ·                    ·
-·          spans     ALL                                      ·                    ·
+·          distributed  false                                    ·                    ·
+·          vectorized   false                                    ·                    ·
+render     ·            ·                                        (r tuple{int, int})  ·
+ │         render 0     (((b)[int], (a)[int]))[tuple{int, int}]  ·                    ·
+ └── scan  ·            ·                                        (a int, b int)       ·
+·          table        ab@primary                               ·                    ·
+·          spans        ALL                                      ·                    ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT min(y), (b, a) r FROM ab, xy GROUP BY (x, (a, b))
 ----
+·                    distributed  false                                               ·                                                ·
+·                    vectorized   false                                               ·                                                ·
 render               ·            ·                                                   (min string, r tuple{int, int})                  ·
  │                   render 0     (min)[string]                                       ·                                                ·
  │                   render 1     (((any_not_null)[int], (a)[int]))[tuple{int, int}]  ·                                                ·
@@ -872,6 +950,8 @@ render               ·            ·                                           
 query TTTTT
 EXPLAIN (TYPES) SELECT 1 a FROM kv GROUP BY v, w::DECIMAL HAVING w::DECIMAL > 1;
 ----
+·                         distributed  false                                      ·                         ·
+·                         vectorized   false                                      ·                         ·
 render                    ·            ·                                          (a int)                   ·
  │                        render 0     (1)[int]                                   ·                         ·
  └── distinct             ·            ·                                          (column5 decimal, v int)  weak-key(column5,v)
@@ -892,6 +972,8 @@ CREATE TABLE foo(a INT, b CHAR)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @1
 ----
+·                    distributed  false        ·               ·
+·                    vectorized   false        ·               ·
 render               ·            ·            (m)             ·
  │                   render 0     min          ·               ·
  └── group           ·            ·            (column5, min)  ·
@@ -908,6 +990,8 @@ render               ·            ·            (m)             ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @2
 ----
+·                    distributed  false        ·               ·
+·                    vectorized   false        ·               ·
 render               ·            ·            (m)             ·
  │                   render 0     min          ·               ·
  └── group           ·            ·            (column5, min)  ·
@@ -924,6 +1008,8 @@ render               ·            ·            (m)             ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT array_agg(v) FROM (SELECT * FROM kv ORDER BY v)
 ----
+·               distributed  false         ·            ·
+·               vectorized   false         ·            ·
 group           ·            ·             (array_agg)  ·
  │              aggregate 0  array_agg(v)  ·            ·
  │              scalar       ·             ·            ·
@@ -936,17 +1022,21 @@ group           ·            ·             (array_agg)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY s
 ----
-render          ·         ·           (k)     ·
- │              render 0  k           ·       ·
- └── sort       ·         ·           (k, s)  +s
-      │         order     +s          ·       ·
-      └── scan  ·         ·           (k, s)  ·
-·               table     kv@primary  ·       ·
-·               spans     ALL         ·       ·
+·               distributed  false       ·       ·
+·               vectorized   false       ·       ·
+render          ·            ·           (k)     ·
+ │              render 0     k           ·       ·
+ └── sort       ·            ·           (k, s)  +s
+      │         order        +s          ·       ·
+      └── scan  ·            ·           (k, s)  ·
+·               table        kv@primary  ·       ·
+·               spans        ALL         ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT concat_agg(s) FROM (SELECT s FROM kv ORDER BY k)
 ----
+·          distributed  false          ·             ·
+·          vectorized   false          ·             ·
 group      ·            ·              (concat_agg)  ·
  │         aggregate 0  concat_agg(s)  ·             ·
  │         scalar       ·              ·             ·
@@ -957,6 +1047,8 @@ group      ·            ·              (concat_agg)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT array_agg(k) FROM (SELECT k FROM kv ORDER BY s)
 ----
+·               distributed  false         ·            ·
+·               vectorized   false         ·            ·
 group           ·            ·             (array_agg)  ·
  │              aggregate 0  array_agg(k)  ·            ·
  │              scalar       ·             ·            ·
@@ -969,6 +1061,8 @@ group           ·            ·             (array_agg)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT string_agg(s, ',') FROM (SELECT s FROM kv ORDER BY k)
 ----
+·               distributed  false          ·             ·
+·               vectorized   false          ·             ·
 group           ·            ·              (string_agg)  ·
  │              aggregate 0  string_agg(s)  ·             ·
  │              scalar       ·              ·             ·
@@ -983,6 +1077,8 @@ group           ·            ·              (string_agg)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT count(*) FROM xyz JOIN kv ON y=v
 ----
+·                    distributed  false         ·        ·
+·                    vectorized   false         ·        ·
 group                ·            ·             (count)  ·
  │                   aggregate 0  count_rows()  ·        ·
  │                   scalar       ·             ·        ·
@@ -1006,6 +1102,8 @@ CREATE TABLE uvw (u INT, v INT, w INT, INDEX uvw(u, v, w))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT u, v, array_agg(w) AS s FROM (SELECT * FROM uvw ORDER BY w) GROUP BY u, v
 ----
+·          distributed  false         ·          ·
+·          vectorized   false         ·          ·
 group      ·            ·             (u, v, s)  ·
  │         aggregate 0  u             ·          ·
  │         aggregate 1  v             ·          ·
@@ -1019,6 +1117,8 @@ group      ·            ·             (u, v, s)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT string_agg(s, ', ') FROM kv
 ----
+·               distributed  false          ·             ·
+·               vectorized   false          ·             ·
 group           ·            ·              (string_agg)  ·
  │              aggregate 0  string_agg(s)  ·             ·
  │              scalar       ·              ·             ·
@@ -1046,6 +1146,8 @@ EXPLAIN (VERBOSE)
     ORDER BY
         company_id
 ----
+·               distributed  false                    ·                         ·
+·               vectorized   false                    ·                         ·
 sort            ·            ·                        (company_id, string_agg)  +company_id
  │              order        +company_id              ·                         ·
  └── group      ·            ·                        (company_id, string_agg)  ·
@@ -1067,6 +1169,8 @@ EXPLAIN (VERBOSE)
     ORDER BY
         company_id
 ----
+·                    distributed  false                    ·                         ·
+·                    vectorized   false                    ·                         ·
 sort                 ·            ·                        (company_id, string_agg)  +company_id
  │                   order        +company_id              ·                         ·
  └── group           ·            ·                        (company_id, string_agg)  ·
@@ -1091,6 +1195,8 @@ EXPLAIN (VERBOSE)
     ORDER BY
         company_id
 ----
+·               distributed  false                    ·                         ·
+·               vectorized   false                    ·                         ·
 sort            ·            ·                        (company_id, string_agg)  +company_id
  │              order        +company_id              ·                         ·
  └── group      ·            ·                        (company_id, string_agg)  ·
@@ -1112,6 +1218,8 @@ EXPLAIN (VERBOSE)
     ORDER BY
         company_id
 ----
+·                    distributed  false                    ·                         ·
+·                    vectorized   false                    ·                         ·
 sort                 ·            ·                        (company_id, string_agg)  +company_id
  │                   order        +company_id              ·                         ·
  └── group           ·            ·                        (company_id, string_agg)  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/check_constraints
+++ b/pkg/sql/opt/exec/execbuilder/testdata/check_constraints
@@ -21,44 +21,48 @@ CREATE TABLE t9 (
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE t9 SET b = b + 1 WHERE a = 5
 ----
-count                     ·         ·                          ()                                ·
- └── update               ·         ·                          ()                                ·
-      │                   table     t9                         ·                                 ·
-      │                   set       b                          ·                                 ·
-      │                   strategy  updater                    ·                                 ·
-      └── render          ·         ·                          (a, b, column11, check1, check2)  ·
-           │              render 0  a                          ·                                 ·
-           │              render 1  b                          ·                                 ·
-           │              render 2  column11                   ·                                 ·
-           │              render 3  a > column11               ·                                 ·
-           │              render 4  d IS NULL                  ·                                 ·
-           └── render     ·         ·                          (column11, a, b, d)               ·
-                │         render 0  b + 1                      ·                                 ·
-                │         render 1  a                          ·                                 ·
-                │         render 2  b                          ·                                 ·
-                │         render 3  d                          ·                                 ·
-                └── scan  ·         ·                          (a, b, d)                         ·
-·                         table     t9@primary                 ·                                 ·
-·                         spans     /5/0-/5/1/2 /5/3/1-/5/3/2  ·                                 ·
-·                         parallel  ·                          ·                                 ·
+·                         distributed  false                      ·                                 ·
+·                         vectorized   false                      ·                                 ·
+count                     ·            ·                          ()                                ·
+ └── update               ·            ·                          ()                                ·
+      │                   table        t9                         ·                                 ·
+      │                   set          b                          ·                                 ·
+      │                   strategy     updater                    ·                                 ·
+      └── render          ·            ·                          (a, b, column11, check1, check2)  ·
+           │              render 0     a                          ·                                 ·
+           │              render 1     b                          ·                                 ·
+           │              render 2     column11                   ·                                 ·
+           │              render 3     a > column11               ·                                 ·
+           │              render 4     d IS NULL                  ·                                 ·
+           └── render     ·            ·                          (column11, a, b, d)               ·
+                │         render 0     b + 1                      ·                                 ·
+                │         render 1     a                          ·                                 ·
+                │         render 2     b                          ·                                 ·
+                │         render 3     d                          ·                                 ·
+                └── scan  ·            ·                          (a, b, d)                         ·
+·                         table        t9@primary                 ·                                 ·
+·                         spans        /5/0-/5/1/2 /5/3/1-/5/3/2  ·                                 ·
+·                         parallel     ·                          ·                                 ·
 
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE t9 SET a = 2 WHERE a = 5
 ----
-count                ·         ·           ()                                         ·
- └── update          ·         ·           ()                                         ·
-      │              table     t9          ·                                          ·
-      │              set       a           ·                                          ·
-      │              strategy  updater     ·                                          ·
-      └── render     ·         ·           (a, b, c, d, e, column11, check1, check2)  ·
-           │         render 0  a           ·                                          ·
-           │         render 1  b           ·                                          ·
-           │         render 2  c           ·                                          ·
-           │         render 3  d           ·                                          ·
-           │         render 4  e           ·                                          ·
-           │         render 5  2           ·                                          ·
-           │         render 6  b < 2       ·                                          ·
-           │         render 7  d IS NULL   ·                                          ·
-           └── scan  ·         ·           (a, b, c, d, e)                            ·
-·                    table     t9@primary  ·                                          ·
-·                    spans     /5-/5/#     ·                                          ·
+·                    distributed  false       ·                                          ·
+·                    vectorized   false       ·                                          ·
+count                ·            ·           ()                                         ·
+ └── update          ·            ·           ()                                         ·
+      │              table        t9          ·                                          ·
+      │              set          a           ·                                          ·
+      │              strategy     updater     ·                                          ·
+      └── render     ·            ·           (a, b, c, d, e, column11, check1, check2)  ·
+           │         render 0     a           ·                                          ·
+           │         render 1     b           ·                                          ·
+           │         render 2     c           ·                                          ·
+           │         render 3     d           ·                                          ·
+           │         render 4     e           ·                                          ·
+           │         render 5     2           ·                                          ·
+           │         render 6     b < 2       ·                                          ·
+           │         render 7     d IS NULL   ·                                          ·
+           └── scan  ·            ·           (a, b, c, d, e)                            ·
+·                    table        t9@primary  ·                                          ·
+·                    spans        /5-/5/#     ·                                          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/ddl
+++ b/pkg/sql/opt/exec/execbuilder/testdata/ddl
@@ -95,12 +95,14 @@ CREATE TABLE s (k1 INT, k2 INT, v INT, PRIMARY KEY (k1,k2))
 query TTTTT colnames
 EXPLAIN (VERBOSE) ALTER TABLE s SPLIT AT SELECT k1,k2 FROM s ORDER BY k1 LIMIT 3
 ----
-tree       field  description  columns                              ordering
-split      ·      ·            (key, pretty, split_enforced_until)  ·
- └── scan  ·      ·            (k1, k2)                             +k1
-·          table  s@primary    ·                                    ·
-·          spans  ALL          ·                                    ·
-·          limit  3            ·                                    ·
+tree       field        description  columns                              ordering
+·          distributed  false        ·                                    ·
+·          vectorized   false        ·                                    ·
+split      ·            ·            (key, pretty, split_enforced_until)  ·
+ └── scan  ·            ·            (k1, k2)                             +k1
+·          table        s@primary    ·                                    ·
+·          spans        ALL          ·                                    ·
+·          limit        3            ·                                    ·
 
 statement ok
 DROP TABLE t; DROP TABLE other

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -60,49 +60,57 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
 query TTT colnames
 EXPLAIN DELETE FROM unindexed
 ----
-tree          field  description
-delete range  ·      ·
-·             from   unindexed
-·             spans  ALL
+tree          field        description
+·             distributed  false
+·             vectorized   false
+delete range  ·            ·
+·             from         unindexed
+·             spans        ALL
 
 query TTT
 EXPLAIN DELETE FROM unindexed WHERE v = 7 ORDER BY v LIMIT 10
 ----
-count                     ·         ·
- └── delete               ·         ·
-      │                   from      unindexed
-      │                   strategy  deleter
-      └── render          ·         ·
-           └── limit      ·         ·
-                │         count     10
-                └── scan  ·         ·
-·                         table     unindexed@primary
-·                         spans     ALL
-·                         filter    v = 7
+·                         distributed  false
+·                         vectorized   false
+count                     ·            ·
+ └── delete               ·            ·
+      │                   from         unindexed
+      │                   strategy     deleter
+      └── render          ·            ·
+           └── limit      ·            ·
+                │         count        10
+                └── scan  ·            ·
+·                         table        unindexed@primary
+·                         spans        ALL
+·                         filter       v = 7
 
 # Check DELETE with LIMIT clause (MySQL extension)
 query TTT
 EXPLAIN DELETE FROM unindexed WHERE v = 5 LIMIT 10
 ----
-count                     ·         ·
- └── delete               ·         ·
-      │                   from      unindexed
-      │                   strategy  deleter
-      └── render          ·         ·
-           └── limit      ·         ·
-                │         count     10
-                └── scan  ·         ·
-·                         table     unindexed@primary
-·                         spans     ALL
-·                         filter    v = 5
+·                         distributed  false
+·                         vectorized   false
+count                     ·            ·
+ └── delete               ·            ·
+      │                   from         unindexed
+      │                   strategy     deleter
+      └── render          ·            ·
+           └── limit      ·            ·
+                │         count        10
+                └── scan  ·            ·
+·                         table        unindexed@primary
+·                         spans        ALL
+·                         filter       v = 5
 
 # Check fast DELETE.
 query TTT
 EXPLAIN DELETE FROM unindexed WHERE k > 0
 ----
-delete range  ·      ·
-·             from   unindexed
-·             spans  /1-
+·             distributed  false
+·             vectorized   false
+delete range  ·            ·
+·             from         unindexed
+·             spans        /1-
 
 # Check fast DELETE with reverse scans (not supported by optimizer).
 query error DELETE statement requires LIMIT when ORDER BY is used
@@ -112,48 +120,56 @@ EXPLAIN DELETE FROM unindexed WHERE true ORDER BY k DESC
 query TTT
 EXPLAIN DELETE FROM unindexed WHERE k > 0 LIMIT 1
 ----
-count           ·         ·
- └── delete     ·         ·
-      │         from      unindexed
-      │         strategy  deleter
-      └── scan  ·         ·
-·               table     unindexed@primary
-·               spans     /1-
-·               limit     1
+·               distributed  false
+·               vectorized   false
+count           ·            ·
+ └── delete     ·            ·
+      │         from         unindexed
+      │         strategy     deleter
+      └── scan  ·            ·
+·               table        unindexed@primary
+·               spans        /1-
+·               limit        1
 
 query TTT
 EXPLAIN DELETE FROM indexed WHERE value = 5 LIMIT 10
 ----
-count           ·         ·
- └── delete     ·         ·
-      │         from      indexed
-      │         strategy  deleter
-      └── scan  ·         ·
-·               table     indexed@indexed_value_idx
-·               spans     /5-/6
-·               limit     10
+·               distributed  false
+·               vectorized   false
+count           ·            ·
+ └── delete     ·            ·
+      │         from         indexed
+      │         strategy     deleter
+      └── scan  ·            ·
+·               table        indexed@indexed_value_idx
+·               spans        /5-/6
+·               limit        10
 
 query TTT
 EXPLAIN DELETE FROM indexed LIMIT 10
 ----
-count           ·         ·
- └── delete     ·         ·
-      │         from      indexed
-      │         strategy  deleter
-      └── scan  ·         ·
-·               table     indexed@indexed_value_idx
-·               spans     ALL
-·               limit     10
+·               distributed  false
+·               vectorized   false
+count           ·            ·
+ └── delete     ·            ·
+      │         from         indexed
+      │         strategy     deleter
+      └── scan  ·            ·
+·               table        indexed@indexed_value_idx
+·               spans        ALL
+·               limit        10
 
 # TODO(andyk): Prune columns so that index-join is not necessary.
 query TTT
 EXPLAIN DELETE FROM indexed WHERE value = 5 LIMIT 10 RETURNING id
 ----
-run             ·         ·
- └── delete     ·         ·
-      │         from      indexed
-      │         strategy  deleter
-      └── scan  ·         ·
-·               table     indexed@indexed_value_idx
-·               spans     /5-/6
-·               limit     10
+·               distributed  false
+·               vectorized   false
+run             ·            ·
+ └── delete     ·            ·
+      │         from         indexed
+      │         strategy     deleter
+      └── scan  ·            ·
+·               table        indexed@indexed_value_idx
+·               spans        /5-/6
+·               limit        10

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct
@@ -11,6 +11,8 @@ CREATE TABLE xyz (
 query TTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz
 ----
+·          distributed  false
+·          vectorized   true
 distinct   ·            ·
  │         distinct on  y, z
  │         order key    y, z
@@ -21,6 +23,8 @@ distinct   ·            ·
 query TTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY z
 ----
+·          distributed  false
+·          vectorized   true
 distinct   ·            ·
  │         distinct on  y, z
  │         order key    y, z
@@ -31,6 +35,8 @@ distinct   ·            ·
 query TTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y
 ----
+·               distributed  false
+·               vectorized   false
 sort            ·            ·
  │              order        +y
  └── distinct   ·            ·
@@ -43,6 +49,8 @@ sort            ·            ·
 query TTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y, z
 ----
+·               distributed  false
+·               vectorized   false
 sort            ·            ·
  │              order        +y,+z
  └── distinct   ·            ·
@@ -55,6 +63,8 @@ sort            ·            ·
 query TTT
 EXPLAIN SELECT DISTINCT y + z AS r FROM xyz ORDER BY y + z
 ----
+·                    distributed  false
+·                    vectorized   false
 distinct             ·            ·
  │                   distinct on  r
  │                   order key    r
@@ -68,6 +78,8 @@ distinct             ·            ·
 query TTT
 EXPLAIN SELECT DISTINCT y AS w, z FROM xyz ORDER BY z
 ----
+·          distributed  false
+·          vectorized   true
 distinct   ·            ·
  │         distinct on  w, z
  │         order key    w, z
@@ -78,6 +90,8 @@ distinct   ·            ·
 query TTT
 EXPLAIN SELECT DISTINCT y AS w FROM xyz ORDER BY y
 ----
+·               distributed  false
+·               vectorized   false
 sort            ·            ·
  │              order        +w
  └── distinct   ·            ·
@@ -89,21 +103,27 @@ sort            ·            ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT x FROM xyz
 ----
-scan  ·      ·            (x)  ·
-·     table  xyz@primary  ·    ·
-·     spans  ALL          ·    ·
+·     distributed  false        ·    ·
+·     vectorized   true         ·    ·
+scan  ·            ·            (x)  ·
+·     table        xyz@primary  ·    ·
+·     spans        ALL          ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT x, y, z FROM xyz
 ----
-scan  ·      ·            (x, y, z)  ·
-·     table  xyz@primary  ·          ·
-·     spans  ALL          ·          ·
+·     distributed  false        ·          ·
+·     vectorized   true         ·          ·
+scan  ·            ·            (x, y, z)  ·
+·     table        xyz@primary  ·          ·
+·     spans        ALL          ·          ·
 
 # Test the case when the DistinctOn operator is projecting away a column.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT z FROM (SELECT y, z FROM xyz WHERE y > 1)
 ----
+·               distributed  false    ·       ·
+·               vectorized   true     ·       ·
 distinct        ·            ·        (z)     weak-key(z); +z
  │              distinct on  z        ·       ·
  │              order key    z        ·       ·
@@ -127,17 +147,21 @@ CREATE TABLE abcd (
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT 1 AS z, d, b FROM abcd ORDER BY d, b
 ----
-render     ·         ·                  (z, d, b)  ·
- │         render 0  1                  ·          ·
- │         render 1  d                  ·          ·
- │         render 2  b                  ·          ·
- └── scan  ·         ·                  (b, d)     +d,+b
-·          table     abcd@abcd_d_b_key  ·          ·
-·          spans     ALL                ·          ·
+·          distributed  false              ·          ·
+·          vectorized   true               ·          ·
+render     ·            ·                  (z, d, b)  ·
+ │         render 0     1                  ·          ·
+ │         render 1     d                  ·          ·
+ │         render 2     b                  ·          ·
+ └── scan  ·            ·                  (b, d)     +d,+b
+·          table        abcd@abcd_d_b_key  ·          ·
+·          spans        ALL                ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT a, b FROM abcd
 ----
+·          distributed  false         ·       ·
+·          vectorized   true          ·       ·
 distinct   ·            ·             (a, b)  weak-key(a,b); +a,+b
  │         distinct on  a, b          ·       ·
  │         order key    a, b          ·       ·
@@ -148,16 +172,20 @@ distinct   ·            ·             (a, b)  weak-key(a,b); +a,+b
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT a, b, c FROM abcd
 ----
-scan  ·      ·             (a, b, c)  ·
-·     table  abcd@primary  ·          ·
-·     spans  ALL           ·          ·
+·     distributed  false         ·          ·
+·     vectorized   true          ·          ·
+scan  ·            ·             (a, b, c)  ·
+·     table        abcd@primary  ·          ·
+·     spans        ALL           ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT a, b, c, d FROM abcd
 ----
-scan  ·      ·             (a, b, c, d)  ·
-·     table  abcd@primary  ·             ·
-·     spans  ALL           ·             ·
+·     distributed  false         ·             ·
+·     vectorized   true          ·             ·
+scan  ·            ·             (a, b, c, d)  ·
+·     table        abcd@primary  ·             ·
+·     spans        ALL           ·             ·
 
 statement ok
 CREATE TABLE kv (k INT PRIMARY KEY, v INT, UNIQUE INDEX idx(v))
@@ -165,6 +193,8 @@ CREATE TABLE kv (k INT PRIMARY KEY, v INT, UNIQUE INDEX idx(v))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv
 ----
+·          distributed  false   ·    ·
+·          vectorized   true    ·    ·
 distinct   ·            ·       (v)  weak-key(v); +v
  │         distinct on  v       ·    ·
  │         order key    v       ·    ·
@@ -176,6 +206,8 @@ distinct   ·            ·       (v)  weak-key(v); +v
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv@idx
 ----
+·          distributed  false   ·    ·
+·          vectorized   true    ·    ·
 distinct   ·            ·       (v)  weak-key(v); +v
  │         distinct on  v       ·    ·
  │         order key    v       ·    ·
@@ -187,9 +219,11 @@ distinct   ·            ·       (v)  weak-key(v); +v
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv@idx WHERE v > 0
 ----
-scan  ·      ·       (v)  ·
-·     table  kv@idx  ·    ·
-·     spans  /1-     ·    ·
+·     distributed  false   ·    ·
+·     vectorized   true    ·    ·
+scan  ·            ·       (v)  ·
+·     table        kv@idx  ·    ·
+·     spans        /1-     ·    ·
 
 statement ok
 CREATE TABLE kv2 (k INT PRIMARY KEY, v INT NOT NULL, UNIQUE INDEX idx(v))
@@ -198,6 +232,8 @@ CREATE TABLE kv2 (k INT PRIMARY KEY, v INT NOT NULL, UNIQUE INDEX idx(v))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv2@idx
 ----
-scan  ·      ·        (v)  ·
-·     table  kv2@idx  ·    ·
-·     spans  ALL      ·    ·
+·     distributed  false    ·    ·
+·     vectorized   true     ·    ·
+scan  ·            ·        (v)  ·
+·     table        kv2@idx  ·    ·
+·     spans        ALL      ·    ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
@@ -27,6 +27,8 @@ CREATE TABLE abc (
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y, z) x, y, z FROM xyz
 ----
+·          distributed  false        ·          ·
+·          vectorized   false        ·          ·
 distinct   ·            ·            (x, y, z)  weak-key(x,y,z)
  │         distinct on  x, y, z      ·          ·
  └── scan  ·            ·            (x, y, z)  ·
@@ -36,6 +38,8 @@ distinct   ·            ·            (x, y, z)  weak-key(x,y,z)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (z, x, y) x FROM xyz
 ----
+·               distributed  false        ·          ·
+·               vectorized   false        ·          ·
 render          ·            ·            (x)        ·
  │              render 0     x            ·          ·
  └── distinct   ·            ·            (x, y, z)  weak-key(x,y,z)
@@ -47,31 +51,37 @@ render          ·            ·            (x)        ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (b, c, a) a, c, b FROM abc
 ----
-render     ·         ·            (a, c, b)  ·
- │         render 0  a            ·          ·
- │         render 1  c            ·          ·
- │         render 2  b            ·          ·
- └── scan  ·         ·            (a, b, c)  ·
-·          table     abc@primary  ·          ·
-·          spans     ALL          ·          ·
+·          distributed  false        ·          ·
+·          vectorized   true         ·          ·
+render     ·            ·            (a, c, b)  ·
+ │         render 0     a            ·          ·
+ │         render 1     c            ·          ·
+ │         render 2     b            ·          ·
+ └── scan  ·            ·            (a, b, c)  ·
+·          table        abc@primary  ·          ·
+·          spans        ALL          ·          ·
 
 # Distinct node should be elided since we have a strong key.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (b, c, a) a FROM abc
 ----
-scan  ·      ·            (a)  ·
-·     table  abc@primary  ·    ·
-·     spans  ALL          ·    ·
+·     distributed  false        ·    ·
+·     vectorized   true         ·    ·
+scan  ·            ·            (a)  ·
+·     table        abc@primary  ·    ·
+·     spans        ALL          ·    ·
 
 # Distinct node should be elided since we have a strong key.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (c, a, b) b FROM abc ORDER BY b
 ----
-sort       ·      ·            (b)  +b
- │         order  +b           ·    ·
- └── scan  ·      ·            (b)  ·
-·          table  abc@primary  ·    ·
-·          spans  ALL          ·    ·
+·          distributed  false        ·    ·
+·          vectorized   false        ·    ·
+sort       ·            ·            (b)  +b
+ │         order        +b           ·    ·
+ └── scan  ·            ·            (b)  ·
+·          table        abc@primary  ·    ·
+·          spans        ALL          ·    ·
 
 
 # 2/3 columns
@@ -79,6 +89,8 @@ sort       ·      ·            (b)  +b
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y) y, x FROM xyz
 ----
+·               distributed  false        ·       ·
+·               vectorized   false        ·       ·
 render          ·            ·            (y, x)  ·
  │              render 0     y            ·       ·
  │              render 1     x            ·       ·
@@ -91,6 +103,8 @@ render          ·            ·            (y, x)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (y, x) x FROM xyz
 ----
+·               distributed  false        ·       ·
+·               vectorized   false        ·       ·
 render          ·            ·            (x)     ·
  │              render 0     x            ·       ·
  └── distinct   ·            ·            (x, y)  weak-key(x,y)
@@ -102,6 +116,8 @@ render          ·            ·            (x)     ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (y, x, x, y, x) x, y FROM xyz
 ----
+·          distributed  false        ·       ·
+·          vectorized   false        ·       ·
 distinct   ·            ·            (x, y)  weak-key(x,y)
  │         distinct on  x, y         ·       ·
  └── scan  ·            ·            (x, y)  ·
@@ -111,6 +127,8 @@ distinct   ·            ·            (x, y)  weak-key(x,y)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(pk1, x) pk1, x FROM xyz ORDER BY pk1
 ----
+·               distributed  false        ·         ·
+·               vectorized   false        ·         ·
 render          ·            ·            (pk1, x)  ·
  │              render 0     pk1          ·         ·
  │              render 1     x            ·         ·
@@ -124,6 +142,8 @@ render          ·            ·            (pk1, x)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a, c) a, b FROM abc
 ----
+·               distributed  false        ·          ·
+·               vectorized   false        ·          ·
 render          ·            ·            (a, b)     ·
  │              render 0     a            ·          ·
  │              render 1     b            ·          ·
@@ -137,6 +157,8 @@ render          ·            ·            (a, b)     ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (c, a) b, c, a FROM abc
 ----
+·               distributed  false        ·          ·
+·               vectorized   false        ·          ·
 render          ·            ·            (b, c, a)  ·
  │              render 0     b            ·          ·
  │              render 1     c            ·          ·
@@ -156,6 +178,8 @@ render          ·            ·            (b, c, a)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (pk1) pk1, pk2 FROM xyz
 ----
+·          distributed  false        ·           ·
+·          vectorized   true         ·           ·
 distinct   ·            ·            (pk1, pk2)  weak-key(pk1); +pk1
  │         distinct on  pk1          ·           ·
  │         order key    pk1          ·           ·
@@ -168,6 +192,8 @@ distinct   ·            ·            (pk1, pk2)  weak-key(pk1); +pk1
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a) a, c FROM abc ORDER BY a, c DESC, b
 ----
+·                    distributed  false        ·          ·
+·                    vectorized   false        ·          ·
 render               ·            ·            (a, c)     +a
  │                   render 0     a            ·          ·
  │                   render 1     c            ·          ·
@@ -187,6 +213,8 @@ render               ·            ·            (a, c)     +a
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) x FROM xyz ORDER BY x DESC
 ----
+·               distributed  false        ·    ·
+·               vectorized   false        ·    ·
 sort            ·            ·            (x)  weak-key(x); -x
  │              order        -x           ·    ·
  └── distinct   ·            ·            (x)  weak-key(x)
@@ -198,6 +226,8 @@ sort            ·            ·            (x)  weak-key(x); -x
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, z) y, z, x FROM xyz ORDER BY z
 ----
+·                    distributed  false        ·          ·
+·                    vectorized   false        ·          ·
 render               ·            ·            (y, z, x)  ·
  │                   render 0     y            ·          ·
  │                   render 1     z            ·          ·
@@ -214,6 +244,8 @@ render               ·            ·            (y, z, x)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) y, z, x FROM xyz ORDER BY x ASC, z DESC, y DESC
 ----
+·                    distributed  false        ·          ·
+·                    vectorized   false        ·          ·
 render               ·            ·            (y, z, x)  ·
  │                   render 0     y            ·          ·
  │                   render 1     z            ·          ·
@@ -234,6 +266,8 @@ render               ·            ·            (y, z, x)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (max(y)) max(x) FROM xyz
 ----
+·               distributed  false        ·       ·
+·               vectorized   true         ·       ·
 group           ·            ·            (max)   ·
  │              aggregate 0  max(x)       ·       ·
  │              scalar       ·            ·       ·
@@ -246,6 +280,8 @@ group           ·            ·            (max)   ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(min(a), max(b), min(c)) max(a) FROM abc
 ----
+·                  distributed  false            ·          ·
+·                  vectorized   true             ·          ·
 group              ·            ·                (max)      ·
  │                 aggregate 0  any_not_null(a)  ·          ·
  │                 scalar       ·                ·          ·
@@ -264,6 +300,8 @@ group              ·            ·                (max)      ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(y) min(x) FROM xyz GROUP BY y
 ----
+·               distributed  false        ·         ·
+·               vectorized   false        ·         ·
 render          ·            ·            (min)     ·
  │              render 0     min          ·         ·
  └── group      ·            ·            (y, min)  ·
@@ -277,6 +315,8 @@ render          ·            ·            (min)     ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(min(x)) min(x) FROM xyz GROUP BY y HAVING min(x) = 1
 ----
+·                         distributed  false        ·         ·
+·                         vectorized   false        ·         ·
 render                    ·            ·            (min)     ·
  │                        render 0     min          ·         ·
  └── limit                ·            ·            (y, min)  ·
@@ -298,6 +338,8 @@ render                    ·            ·            (min)     ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(row_number() OVER()) y FROM xyz
 ----
+·                    distributed  false                                                                  ·                ·
+·                    vectorized   false                                                                  ·                ·
 render               ·            ·                                                                      (y)              ·
  │                   render 0     y                                                                      ·                ·
  └── distinct        ·            ·                                                                      (y, row_number)  weak-key(row_number)
@@ -316,6 +358,8 @@ render               ·            ·                                           
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (1) x, y, z FROM xyz
 ----
+·          distributed  false        ·          ·
+·          vectorized   false        ·          ·
 distinct   ·            ·            (x, y, z)  weak-key(x)
  │         distinct on  x            ·          ·
  └── scan  ·            ·            (x, y, z)  ·
@@ -326,9 +370,11 @@ distinct   ·            ·            (x, y, z)  weak-key(x)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (1,2,3) a, b, c FROM abc
 ----
-scan  ·      ·            (a, b, c)  ·
-·     table  abc@primary  ·          ·
-·     spans  ALL          ·          ·
+·     distributed  false        ·          ·
+·     vectorized   true         ·          ·
+scan  ·            ·            (a, b, c)  ·
+·     table        abc@primary  ·          ·
+·     spans        ALL          ·          ·
 
 #########################
 # With alias references #
@@ -338,6 +384,8 @@ scan  ·      ·            (a, b, c)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(y) x AS y, y AS x FROM xyz
 ----
+·          distributed  false        ·       ·
+·          vectorized   false        ·       ·
 distinct   ·            ·            (y, x)  weak-key(y)
  │         distinct on  y            ·       ·
  └── scan  ·            ·            (y, x)  ·
@@ -348,6 +396,8 @@ distinct   ·            ·            (y, x)  weak-key(y)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(x) x AS y FROM xyz
 ----
+·          distributed  false        ·    ·
+·          vectorized   false        ·    ·
 distinct   ·            ·            (y)  weak-key(y)
  │         distinct on  y            ·    ·
  └── scan  ·            ·            (y)  ·
@@ -361,6 +411,8 @@ distinct   ·            ·            (y)  weak-key(y)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(((x)), (x, y)) x, y FROM xyz
 ----
+·          distributed  false        ·       ·
+·          vectorized   false        ·       ·
 distinct   ·            ·            (x, y)  weak-key(x,y)
  │         distinct on  x, y         ·       ·
  └── scan  ·            ·            (x, y)  ·
@@ -375,15 +427,19 @@ distinct   ·            ·            (x, y)  weak-key(x,y)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(pk1, pk2, x, y) x, y, z FROM xyz ORDER BY x, y
 ----
-sort       ·      ·            (x, y, z)  +x,+y
- │         order  +x,+y        ·          ·
- └── scan  ·      ·            (x, y, z)  ·
-·          table  xyz@primary  ·          ·
-·          spans  ALL          ·          ·
+·          distributed  false        ·          ·
+·          vectorized   false        ·          ·
+sort       ·            ·            (x, y, z)  +x,+y
+ │         order        +x,+y        ·          ·
+ └── scan  ·            ·            (x, y, z)  ·
+·          table        xyz@primary  ·          ·
+·          spans        ALL          ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y, z) pk1 FROM xyz ORDER BY x
 ----
+·                    distributed  false        ·               ·
+·                    vectorized   false        ·               ·
 render               ·            ·            (pk1)           ·
  │                   render 0     pk1          ·               ·
  └── distinct        ·            ·            (x, y, z, pk1)  weak-key(x,y,z); +x
@@ -399,18 +455,22 @@ render               ·            ·            (pk1)           ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) x, y FROM xyz WHERE x = 1 ORDER BY x, y
 ----
-limit           ·       ·            (x, y)  +y
- │              count   1            ·       ·
- └── sort       ·       ·            (x, y)  +y
-      │         order   +y           ·       ·
-      └── scan  ·       ·            (x, y)  ·
-·               table   xyz@primary  ·       ·
-·               spans   ALL          ·       ·
-·               filter  x = 1        ·       ·
+·               distributed  false        ·       ·
+·               vectorized   true         ·       ·
+limit           ·            ·            (x, y)  +y
+ │              count        1            ·       ·
+ └── sort       ·            ·            (x, y)  +y
+      │         order        +y           ·       ·
+      └── scan  ·            ·            (x, y)  ·
+·               table        xyz@primary  ·       ·
+·               spans        ALL          ·       ·
+·               filter       x = 1        ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT count(*) FROM (SELECT DISTINCT ON (x) x, y FROM xyz WHERE x = 1 ORDER BY x, y)
 ----
+·                         distributed  false         ·        ·
+·                         vectorized   true          ·        ·
 group                     ·            ·             (count)  ·
  │                        aggregate 0  count_rows()  ·        ·
  │                        scalar       ·             ·        ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
@@ -353,6 +353,8 @@ group-by
 query TTTTT
 EXPLAIN (verbose) SELECT b, count(*) FROM data2 WHERE a=1 GROUP BY b
 ----
+·               distributed  true           ·           ·
+·               vectorized   false          ·           ·
 group           ·            ·              (b, count)  ·
  │              aggregate 0  b              ·           ·
  │              aggregate 1  count_rows()   ·           ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
@@ -67,6 +67,8 @@ NULL             /NULL/NULL/NULL  {5}       5
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz
 ----
+·          distributed  true         ·          ·
+·          vectorized   false        ·          ·
 distinct   ·            ·            (x, y, z)  weak-key(x,y,z)
  │         distinct on  x, y, z      ·          ·
  └── scan  ·            ·            (x, y, z)  ·
@@ -82,6 +84,8 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJyslMGuojAUhvfzFOasS6Clor
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz ORDER BY x
 ----
+·               distributed  true         ·          ·
+·               vectorized   false        ·          ·
 distinct        ·            ·            (x, y, z)  weak-key(x,y,z); +x
  │              distinct on  x, y, z      ·          ·
  │              order key    x            ·          ·
@@ -101,6 +105,8 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJy0lT9v2zAQxfd-CuPWUpCPov
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (y) x, y FROM xyz ORDER BY y, x
 ----
+·               distributed  true         ·       ·
+·               vectorized   false        ·       ·
 distinct        ·            ·            (x, y)  weak-key(y); +y,+x
  │              distinct on  y            ·       ·
  │              order key    y            ·       ·
@@ -119,9 +125,11 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJyslU1vm0AQhu_9FdFcswjPsv
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a,b,c) a, b, c FROM abc
 ----
-scan  ·      ·            (a, b, c)  ·
-·     table  abc@primary  ·          ·
-·     spans  ALL          ·          ·
+·     distributed  true         ·          ·
+·     vectorized   true         ·          ·
+scan  ·            ·            (a, b, c)  ·
+·     table        abc@primary  ·          ·
+·     spans        ALL          ·          ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (a,b,c) a, b, c FROM abc]
@@ -131,6 +139,8 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJykk01r4zAQhu_7K8x7lvH3Hn
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a, b) a, b FROM abc ORDER BY a, b, c
 ----
+·               distributed  true         ·          ·
+·               vectorized   true         ·          ·
 render          ·            ·            (a, b)     +a,+b
  │              render 0     a            ·          ·
  │              render 1     b            ·          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
@@ -254,6 +254,8 @@ EXPLAIN SELECT * FROM grandchild2 JOIN parent1 USING(pid1) WHERE
   OR pid1 >= 31 AND pid1 <= 33
   OR pa1 > 0
 ----
+·                distributed         true
+·                vectorized          false
 render           ·                   ·
  └── merge-join  ·                   ·
       │          type                inner
@@ -296,6 +298,8 @@ EXPLAIN
     OR child2.cid2 >= 12 AND child2.cid2 <= 14
     OR gcid2 >= 49 AND gcid2 <= 51
 ----
+·           distributed        true
+·           vectorized         false
 merge-join  ·                  ·
  │          type               inner
  │          equality           (pid1, cid2, cid3) = (pid1, cid2, cid3)

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
@@ -32,6 +32,8 @@ NULL       /1       {1}       1
 query TTTTT
 EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data) NATURAL JOIN (SELECT a,b FROM data AS data2))
 ----
+·                distributed     true               ·             ·
+·                vectorized      false              ·             ·
 render           ·               ·                  (a, b)        ·
  │               render 0        a                  ·             ·
  │               render 1        b                  ·             ·
@@ -110,17 +112,19 @@ render           ·               ·                  (a, b)        ·
 query TTTTT
 EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d ORDER BY b,a)
 ----
-sort            ·         ·                (a, b, c, d)  +b,+a
- │              order     +b,+a            ·             ·
- └── hash-join  ·         ·                (a, b, c, d)  ·
-      │         type      inner            ·             ·
-      │         equality  (a, b) = (c, d)  ·             ·
-      ├── scan  ·         ·                (a, b)        ·
-      │         table     data@primary     ·             ·
-      │         spans     ALL              ·             ·
-      └── scan  ·         ·                (c, d)        ·
-·               table     data@primary     ·             ·
-·               spans     ALL              ·             ·
+·               distributed  true             ·             ·
+·               vectorized   false            ·             ·
+sort            ·            ·                (a, b, c, d)  +b,+a
+ │              order        +b,+a            ·             ·
+ └── hash-join  ·            ·                (a, b, c, d)  ·
+      │         type         inner            ·             ·
+      │         equality     (a, b) = (c, d)  ·             ·
+      ├── scan  ·            ·                (a, b)        ·
+      │         table        data@primary     ·             ·
+      │         spans        ALL              ·             ·
+      └── scan  ·            ·                (c, d)        ·
+·               table        data@primary     ·             ·
+·               spans        ALL              ·             ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d ORDER BY b,a)]

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
@@ -80,6 +80,8 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJy8lU2L2zAQhu_9FWFOu6AQS7
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x, str FROM NumToSquare JOIN NumToStr ON x = y WHERE x % 2 = 0
 ----
+·                distributed         true                 ·            ·
+·                vectorized          false                ·            ·
 render           ·                   ·                    (x, str)     ·
  │               render 0            x                    ·            ·
  │               render 1            str                  ·            ·
@@ -148,9 +150,11 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJyMkDFrwzAQhff-CnFdFWwHMl
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x FROM (SELECT x, 2*x, x+1 FROM NumToSquare)
 ----
-scan  ·      ·                    (x)  ·
-·     table  numtosquare@primary  ·    ·
-·     spans  ALL                  ·    ·
+·     distributed  true                 ·    ·
+·     vectorized   true                 ·    ·
+scan  ·            ·                    (x)  ·
+·     table        numtosquare@primary  ·    ·
+·     spans        ALL                  ·    ·
 
 # Verifies that unused renders don't cause us to do rendering instead of a
 # simple projection.
@@ -162,38 +166,42 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJyMj7FOAzEQRHu-IpraiLvWVd
 query TTTTT
 EXPLAIN (VERBOSE) SELECT y, str, repeat('test', y) AS res FROM NumToStr ORDER BY res
 ----
-render               ·         ·                  (y, str, res)  ·
- │                   render 0  y                  ·              ·
- │                   render 1  str                ·              ·
- │                   render 2  res                ·              ·
- └── sort            ·         ·                  (res, y, str)  +res
-      │              order     +res               ·              ·
-      └── render     ·         ·                  (res, y, str)  ·
-           │         render 0  repeat('test', y)  ·              ·
-           │         render 1  y                  ·              ·
-           │         render 2  str                ·              ·
-           └── scan  ·         ·                  (y, str)       ·
-·                    table     numtostr@primary   ·              ·
-·                    spans     ALL                ·              ·
+·                    distributed  true               ·              ·
+·                    vectorized   false              ·              ·
+render               ·            ·                  (y, str, res)  ·
+ │                   render 0     y                  ·              ·
+ │                   render 1     str                ·              ·
+ │                   render 2     res                ·              ·
+ └── sort            ·            ·                  (res, y, str)  +res
+      │              order        +res               ·              ·
+      └── render     ·            ·                  (res, y, str)  ·
+           │         render 0     repeat('test', y)  ·              ·
+           │         render 1     y                  ·              ·
+           │         render 2     str                ·              ·
+           └── scan  ·            ·                  (y, str)       ·
+·                    table        numtostr@primary   ·              ·
+·                    spans        ALL                ·              ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT y, str, repeat('test', y) AS res FROM NumToStr ORDER BY res LIMIT 10
 ----
-render                    ·         ·                  (y, str, res)  ·
- │                        render 0  y                  ·              ·
- │                        render 1  str                ·              ·
- │                        render 2  res                ·              ·
- └── limit                ·         ·                  (res, y, str)  +res
-      │                   count     10                 ·              ·
-      └── sort            ·         ·                  (res, y, str)  +res
-           │              order     +res               ·              ·
-           └── render     ·         ·                  (res, y, str)  ·
-                │         render 0  repeat('test', y)  ·              ·
-                │         render 1  y                  ·              ·
-                │         render 2  str                ·              ·
-                └── scan  ·         ·                  (y, str)       ·
-·                         table     numtostr@primary   ·              ·
-·                         spans     ALL                ·              ·
+·                         distributed  true               ·              ·
+·                         vectorized   true               ·              ·
+render                    ·            ·                  (y, str, res)  ·
+ │                        render 0     y                  ·              ·
+ │                        render 1     str                ·              ·
+ │                        render 2     res                ·              ·
+ └── limit                ·            ·                  (res, y, str)  +res
+      │                   count        10                 ·              ·
+      └── sort            ·            ·                  (res, y, str)  +res
+           │              order        +res               ·              ·
+           └── render     ·            ·                  (res, y, str)  ·
+                │         render 0     repeat('test', y)  ·              ·
+                │         render 1     y                  ·              ·
+                │         render 2     str                ·              ·
+                └── scan  ·            ·                  (y, str)       ·
+·                         table        numtostr@primary   ·              ·
+·                         spans        ALL                ·              ·
 
 # Regression test for #20481.
 query T

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_ordinality
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_ordinality
@@ -33,10 +33,12 @@ NULL       /2       {1}       1
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x, y, z, ordinality FROM xyz WITH ORDINALITY
 ----
-ordinality  ·      ·            (x, y, z, "ordinality")  ·
- └── scan   ·      ·            (x, y, z)                ·
-·           table  xyz@primary  ·                        ·
-·           spans  ALL          ·                        ·
+·           distributed  false        ·                        ·
+·           vectorized   true         ·                        ·
+ordinality  ·            ·            (x, y, z, "ordinality")  ·
+ └── scan   ·            ·            (x, y, z)                ·
+·           table        xyz@primary  ·                        ·
+·           spans        ALL          ·                        ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT x, y, z, ordinality FROM xyz WITH ORDINALITY]

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_tighten_spans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_tighten_spans
@@ -135,75 +135,93 @@ NULL       /0         {1}       1
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE b <= 3
 ----
-scan  ·      ·
-·     table  p1@b
-·     spans  -/4
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        p1@b
+·     spans        -/4
 
 # Partial predicate on primary key should not be tightened.
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a <= 3
 ----
-scan  ·      ·
-·     table  p1@primary
-·     spans  -/4
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        p1@primary
+·     spans        -/4
 
 # Tighten end key if span contains full primary key.
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a <= 3 AND b <= 3
 ----
-scan  ·       ·
-·     table   p1@primary
-·     spans   -/3/3/#
-·     filter  b <= 3
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        p1@primary
+·     spans        -/3/3/#
+·     filter       b <= 3
 
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a <= 3 AND b < 4
 ----
-scan  ·       ·
-·     table   p1@primary
-·     spans   -/3/3/#
-·     filter  b < 4
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        p1@primary
+·     spans        -/3/3/#
+·     filter       b < 4
 
 # Mixed bounds.
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a >= 2 AND b <= 3
 ----
-scan  ·       ·
-·     table   p1@primary
-·     spans   /2-
-·     filter  b <= 3
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        p1@primary
+·     spans        /2-
+·     filter       b <= 3
 
 # Edge cases.
 
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a <= 0 AND b <= 0
 ----
-scan  ·       ·
-·     table   p1@primary
-·     spans   -/0/0/#
-·     filter  b <= 0
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        p1@primary
+·     spans        -/0/0/#
+·     filter       b <= 0
 
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a <= -1 AND b <= -1
 ----
-scan  ·       ·
-·     table   p1@primary
-·     spans   -/-1/-1/#
-·     filter  b <= -1
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        p1@primary
+·     spans        -/-1/-1/#
+·     filter       b <= -1
 
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a = 1 AND b <= -9223372036854775808
 ----
-scan  ·      ·
-·     table  p1@primary
-·     spans  /1-/1/-9223372036854775808/#
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        p1@primary
+·     spans        /1-/1/-9223372036854775808/#
 
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a = 1 AND b <= 9223372036854775807
 ----
-scan  ·      ·
-·     table  p1@primary
-·     spans  /1-/1/9223372036854775807/#
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        p1@primary
+·     spans        /1-/1/9223372036854775807/#
 
 # Table c1 (interleaved table)
 
@@ -212,18 +230,22 @@ scan  ·      ·
 query TTT
 EXPLAIN SELECT * FROM c1 WHERE a <= 3
 ----
-scan  ·      ·
-·     table  c1@primary
-·     spans  -/4
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        c1@primary
+·     spans        -/4
 
 # Tighten span on fully primary key.
 query TTT
 EXPLAIN SELECT * FROM c1 WHERE a <= 3 AND b <= 3
 ----
-scan  ·       ·
-·     table   c1@primary
-·     spans   -/3/3/#/54/1/#
-·     filter  b <= 3
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        c1@primary
+·     spans        -/3/3/#/54/1/#
+·     filter       b <= 3
 
 # Table p2 with interleaved index.
 
@@ -233,18 +255,22 @@ scan  ·       ·
 query TTT
 EXPLAIN SELECT * FROM p2 WHERE i >= 2
 ----
-scan  ·      ·
-·     table  p2@primary
-·     spans  /2-
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        p2@primary
+·     spans        /2-
 
 # Upper bound (i <= 5)
 
 query TTT
 EXPLAIN SELECT * FROM p2 WHERE i <= 5
 ----
-scan  ·      ·
-·     table  p2@primary
-·     spans  -/5/#
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        p2@primary
+·     spans        -/5/#
 
 # From the interleaved index: no tightening at all.
 
@@ -254,75 +280,91 @@ scan  ·      ·
 query TTT
 EXPLAIN SELECT * FROM p2@p2_id WHERE i >= 1 AND d >= 2
 ----
-scan  ·       ·
-·     table   p2@p2_id
-·     spans   /1/#/55/2/2-
-·     filter  d >= 2
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        p2@p2_id
+·     spans        /1/#/55/2/2-
+·     filter       d >= 2
 
 # Upper bound (i <= 6 AND d <= 5)
 
 query TTT
 EXPLAIN SELECT * FROM p2@p2_id WHERE i <= 6 AND d <= 5
 ----
-scan  ·       ·
-·     table   p2@p2_id
-·     spans   -/6/#/55/2/6
-·     filter  d <= 5
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        p2@p2_id
+·     spans        -/6/#/55/2/6
+·     filter       d <= 5
 
 # IS NULL
 
 query TTT
 EXPLAIN SELECT * FROM p2@p2_id WHERE i >= 1 AND d IS NULL
 ----
-scan  ·       ·
-·     table   p2@p2_id
-·     spans   /1/#/55/2/NULL-
-·     filter  d IS NULL
+·     distributed  true
+·     vectorized   false
+scan  ·            ·
+·     table        p2@p2_id
+·     spans        /1/#/55/2/NULL-
+·     filter       d IS NULL
 
 # IS NOT NULL
 
 query TTT
 EXPLAIN SELECT * FROM p2@p2_id WHERE i >= 1 AND d IS NOT NULL
 ----
-scan  ·       ·
-·     table   p2@p2_id
-·     spans   /1/#/55/2/!NULL-
-·     filter  d IS NOT NULL
+·     distributed  true
+·     vectorized   false
+scan  ·            ·
+·     table        p2@p2_id
+·     spans        /1/#/55/2/!NULL-
+·     filter       d IS NOT NULL
 
 # String table
 
 query TTT colnames
 EXPLAIN SELECT * FROM bytes_t WHERE a = 'a'
 ----
-tree  field  description
-scan  ·      ·
-·     table  bytes_t@primary
-·     spans  /"a"-/"a"/#
+tree  field        description
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        bytes_t@primary
+·     spans        /"a"-/"a"/#
 
 # No tightening.
 
 query TTT colnames
 EXPLAIN SELECT * FROM bytes_t WHERE a < 'aa'
 ----
-tree  field  description
-scan  ·      ·
-·     table  bytes_t@primary
-·     spans  -/"aa"
+tree  field        description
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        bytes_t@primary
+·     spans        -/"aa"
 
 query TTT colnames
 EXPLAIN SELECT * FROM decimal_t WHERE a = 1.00
 ----
-tree  field  description
-scan  ·      ·
-·     table  decimal_t@primary
-·     spans  /1-/1/#
+tree  field        description
+·     distributed  true
+·     vectorized   false
+scan  ·            ·
+·     table        decimal_t@primary
+·     spans        /1-/1/#
 
 # No tightening.
 
 query TTT colnames
 EXPLAIN SELECT * FROM decimal_t WHERE a < 2
 ----
-tree  field  description
-scan  ·      ·
-·     table  decimal_t@primary
-·     spans  -/2
+tree  field        description
+·     distributed  true
+·     vectorized   false
+scan  ·            ·
+·     table        decimal_t@primary
+·     spans        -/2

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -3,28 +3,36 @@
 query TTT colnames
 EXPLAIN (PLAN) SELECT 1 FROM system.jobs WHERE FALSE
 ----
-tree    field  description
-norows  ·      ·
+tree    field        description
+·       distributed  false
+·       vectorized   false
+norows  ·            ·
 
 query TTT colnames
 EXPLAIN (PLAN) SELECT 1 FROM system.jobs WHERE NULL
 ----
-tree    field  description
-norows  ·      ·
+tree    field        description
+·       distributed  false
+·       vectorized   false
+norows  ·            ·
 
 query TTT colnames
 EXPLAIN (PLAN) SELECT 1 FROM system.jobs WHERE TRUE
 ----
-tree       field  description
-render     ·      ·
- └── scan  ·      ·
-·          table  jobs@jobs_status_created_idx
-·          spans  ALL
+tree       field        description
+·          distributed  false
+·          vectorized   false
+render     ·            ·
+ └── scan  ·            ·
+·          table        jobs@jobs_status_created_idx
+·          spans        ALL
 
 query TTTTT colnames
 EXPLAIN (PLAN, VERBOSE) SELECT 1 a
 ----
 tree    field          description      columns  ordering
+·       distributed    false            ·        ·
+·       vectorized     false            ·        ·
 values  ·              ·                (a)      ·
 ·       size           1 column, 1 row  ·        ·
 ·       row 0, expr 0  1                ·        ·
@@ -33,6 +41,8 @@ query TTTTT colnames
 EXPLAIN (VERBOSE,PLAN) SELECT 1 a
 ----
 tree    field          description      columns  ordering
+·       distributed    false            ·        ·
+·       vectorized     false            ·        ·
 values  ·              ·                (a)      ·
 ·       size           1 column, 1 row  ·        ·
 ·       row 0, expr 0  1                ·        ·
@@ -42,6 +52,8 @@ query TTTTT colnames
 EXPLAIN (TYPES) SELECT 1 a
 ----
 tree    field          description      columns  ordering
+·       distributed    false            ·        ·
+·       vectorized     false            ·        ·
 values  ·              ·                (a int)  ·
 ·       size           1 column, 1 row  ·        ·
 ·       row 0, expr 0  (1)[int]         ·        ·
@@ -72,12 +84,16 @@ EXPLAIN (TYPES) SELECT $1
 query TTT
 EXPLAIN CREATE DATABASE foo
 ----
-create database  ·  ·
+·                distributed  false
+·                vectorized   false
+create database  ·            ·
 
 query TTT
 EXPLAIN CREATE TABLE foo (x INT)
 ----
-create table  ·  ·
+·             distributed  false
+·             vectorized   false
+create table  ·            ·
 
 statement ok
 CREATE TABLE foo (x INT)
@@ -85,7 +101,9 @@ CREATE TABLE foo (x INT)
 query TTT
 EXPLAIN CREATE INDEX a ON foo(x)
 ----
-create index  ·  ·
+·             distributed  false
+·             vectorized   false
+create index  ·            ·
 
 statement ok
 CREATE DATABASE foo
@@ -93,7 +111,9 @@ CREATE DATABASE foo
 query TTT
 EXPLAIN DROP DATABASE foo
 ----
-drop database  ·  ·
+·              distributed  false
+·              vectorized   false
+drop database  ·            ·
 
 # explain SHOW JOBS - beware to test this before the CREATE INDEX
 # below, otherwise the result becomes non-deterministic.
@@ -101,14 +121,16 @@ drop database  ·  ·
 query TTT
 SELECT * FROM [EXPLAIN SHOW JOBS] WHERE field != 'size'
 ----
-render                             ·       ·
- └── sort                          ·       ·
-      │                            order   -column17,-started
-      └── render                   ·       ·
-           └── filter              ·       ·
-                │                  filter  ((job_type IS NULL) OR (job_type != 'AUTO CREATE STATS')) AND ((finished IS NULL) OR (finished > (now() - '12:00:00')))
-                └── virtual table  ·       ·
-·                                  source  ·
+·                                  distributed  false
+·                                  vectorized   false
+render                             ·            ·
+ └── sort                          ·            ·
+      │                            order        -column17,-started
+      └── render                   ·            ·
+           └── filter              ·            ·
+                │                  filter       ((job_type IS NULL) OR (job_type != 'AUTO CREATE STATS')) AND ((finished IS NULL) OR (finished > (now() - '12:00:00')))
+                └── virtual table  ·            ·
+·                                  source       ·
 
 statement ok
 CREATE INDEX a ON foo(x)
@@ -116,16 +138,22 @@ CREATE INDEX a ON foo(x)
 query TTT
 EXPLAIN DROP INDEX foo@a
 ----
-drop index  ·  ·
+·           distributed  false
+·           vectorized   false
+drop index  ·            ·
 
 query TTT
 EXPLAIN ALTER TABLE foo ADD COLUMN y INT
 ----
-alter table  ·  ·
+·            distributed  false
+·            vectorized   false
+alter table  ·            ·
 
 query TTT
 SELECT tree, field, description FROM [EXPLAIN (VERBOSE) ALTER TABLE foo SPLIT AT VALUES (42)]
 ----
+·            distributed    false
+·            vectorized     false
 split        ·              ·
  └── values  ·              ·
 ·            size           1 column, 1 row
@@ -134,11 +162,15 @@ split        ·              ·
 query TTT
 EXPLAIN DROP TABLE foo
 ----
-drop table  ·  ·
+·           distributed  false
+·           vectorized   false
+drop table  ·            ·
 
 query TTT
 EXPLAIN SHOW DATABASES
 ----
+·                             distributed  false
+·                             vectorized   false
 sort                          ·            ·
  │                            order        +database_name
  └── distinct                 ·            ·
@@ -150,85 +182,101 @@ sort                          ·            ·
 query TTT
 SELECT * FROM [EXPLAIN SHOW TABLES] WHERE field != 'size'
 ----
-sort                          ·       ·
- │                            order   +table_name
- └── render                   ·       ·
-      └── filter              ·       ·
-           │                  filter  table_schema = 'public'
-           └── virtual table  ·       ·
-·                             source  ·
+·                             distributed  false
+·                             vectorized   false
+sort                          ·            ·
+ │                            order        +table_name
+ └── render                   ·            ·
+      └── filter              ·            ·
+           │                  filter       table_schema = 'public'
+           └── virtual table  ·            ·
+·                             source       ·
 
 query TTT
 SELECT * FROM [EXPLAIN SHOW TABLES WITH COMMENT] WHERE field != 'size'
 ----
-render                             ·         ·
- └── hash-join                     ·         ·
-      │                            type      left outer
-      │                            equality  (oid) = (objoid)
-      ├── hash-join                ·         ·
-      │    │                       type      inner
-      │    │                       equality  (relnamespace) = (oid)
-      │    ├── filter              ·         ·
-      │    │    │                  filter    relkind IN ('r', 'v')
-      │    │    └── virtual table  ·         ·
-      │    │                       source    ·
-      │    └── filter              ·         ·
-      │         │                  filter    nspname = 'public'
-      │         └── virtual table  ·         ·
-      │                            source    ·
-      └── filter                   ·         ·
-           │                       filter    objsubid = 0
-           └── virtual table       ·         ·
-·                                  source    ·
+·                                  distributed  false
+·                                  vectorized   false
+render                             ·            ·
+ └── hash-join                     ·            ·
+      │                            type         left outer
+      │                            equality     (oid) = (objoid)
+      ├── hash-join                ·            ·
+      │    │                       type         inner
+      │    │                       equality     (relnamespace) = (oid)
+      │    ├── filter              ·            ·
+      │    │    │                  filter       relkind IN ('r', 'v')
+      │    │    └── virtual table  ·            ·
+      │    │                       source       ·
+      │    └── filter              ·            ·
+      │         │                  filter       nspname = 'public'
+      │         └── virtual table  ·            ·
+      │                            source       ·
+      └── filter                   ·            ·
+           │                       filter       objsubid = 0
+           └── virtual table       ·            ·
+·                                  source       ·
 
 query TTT
 SELECT * FROM [EXPLAIN SHOW DATABASE] WHERE field != 'size'
 ----
-render                   ·       ·
- └── filter              ·       ·
-      │                  filter  variable = 'database'
-      └── virtual table  ·       ·
-·                        source  ·
+·                        distributed  false
+·                        vectorized   false
+render                   ·            ·
+ └── filter              ·            ·
+      │                  filter       variable = 'database'
+      └── virtual table  ·            ·
+·                        source       ·
 
 query TTT
 SELECT * FROM [EXPLAIN SHOW TIME ZONE] WHERE field != 'size'
 ----
-render                   ·       ·
- └── filter              ·       ·
-      │                  filter  variable = 'timezone'
-      └── virtual table  ·       ·
-·                        source  ·
+·                        distributed  false
+·                        vectorized   false
+render                   ·            ·
+ └── filter              ·            ·
+      │                  filter       variable = 'timezone'
+      └── virtual table  ·            ·
+·                        source       ·
 
 query TTT
 SELECT * FROM [EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION] WHERE field != 'size'
 ----
-render                   ·       ·
- └── filter              ·       ·
-      │                  filter  variable = 'default_transaction_isolation'
-      └── virtual table  ·       ·
-·                        source  ·
+·                        distributed  false
+·                        vectorized   false
+render                   ·            ·
+ └── filter              ·            ·
+      │                  filter       variable = 'default_transaction_isolation'
+      └── virtual table  ·            ·
+·                        source       ·
 
 query TTT
 SELECT * FROM [EXPLAIN SHOW TRANSACTION ISOLATION LEVEL] WHERE field != 'size'
 ----
-render                   ·       ·
- └── filter              ·       ·
-      │                  filter  variable = 'transaction_isolation'
-      └── virtual table  ·       ·
-·                        source  ·
+·                        distributed  false
+·                        vectorized   false
+render                   ·            ·
+ └── filter              ·            ·
+      │                  filter       variable = 'transaction_isolation'
+      └── virtual table  ·            ·
+·                        source       ·
 
 query TTT
 SELECT * FROM [EXPLAIN SHOW TRANSACTION PRIORITY] WHERE field != 'size'
 ----
-render                   ·       ·
- └── filter              ·       ·
-      │                  filter  variable = 'transaction_priority'
-      └── virtual table  ·       ·
-·                        source  ·
+·                        distributed  false
+·                        vectorized   false
+render                   ·            ·
+ └── filter              ·            ·
+      │                  filter       variable = 'transaction_priority'
+      └── virtual table  ·            ·
+·                        source       ·
 
 query TTT
 EXPLAIN SHOW COLUMNS FROM foo
 ----
+·                                            distributed  false
+·                                            vectorized   false
 render                                       ·            ·
  └── group                                   ·            ·
       │                                      aggregate 0  column_name
@@ -259,56 +307,64 @@ render                                       ·            ·
 query TTT
 SELECT * FROM [EXPLAIN SHOW GRANTS ON foo] WHERE field != 'size'
 ----
-render                             ·       ·
- └── sort                          ·       ·
-      │                            order   +grantee,+privilege_type
-      └── render                   ·       ·
-           └── filter              ·       ·
-                │                  filter  (table_catalog, table_schema, table_name) IN (('test', 'public', 'foo'),)
-                └── virtual table  ·       ·
-·                                  source  ·
+·                                  distributed  false
+·                                  vectorized   false
+render                             ·            ·
+ └── sort                          ·            ·
+      │                            order        +grantee,+privilege_type
+      └── render                   ·            ·
+           └── filter              ·            ·
+                │                  filter       (table_catalog, table_schema, table_name) IN (('test', 'public', 'foo'),)
+                └── virtual table  ·            ·
+·                                  source       ·
 
 query TTT
 EXPLAIN SHOW INDEX FROM foo
 ----
-render                   ·       ·
- └── filter              ·       ·
-      │                  filter  ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
-      └── virtual table  ·       ·
-·                        source  ·
+·                        distributed  false
+·                        vectorized   false
+render                   ·            ·
+ └── filter              ·            ·
+      │                  filter       ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
+      └── virtual table  ·            ·
+·                        source       ·
 
 query TTT
 EXPLAIN SHOW CONSTRAINTS FROM foo
 ----
-render                                       ·         ·
- └── sort                                    ·         ·
-      │                                      order     +conname
-      └── render                             ·         ·
-           └── hash-join                     ·         ·
-                │                            type      inner
-                │                            equality  (conrelid) = (oid)
-                ├── virtual table            ·         ·
-                │                            source    ·
-                └── hash-join                ·         ·
-                     │                       type      inner
-                     │                       equality  (oid) = (relnamespace)
-                     ├── filter              ·         ·
-                     │    │                  filter    nspname = 'public'
-                     │    └── virtual table  ·         ·
-                     │                       source    ·
-                     └── filter              ·         ·
-                          │                  filter    relname = 'foo'
-                          └── virtual table  ·         ·
-·                                            source    ·
+·                                            distributed  false
+·                                            vectorized   false
+render                                       ·            ·
+ └── sort                                    ·            ·
+      │                                      order        +conname
+      └── render                             ·            ·
+           └── hash-join                     ·            ·
+                │                            type         inner
+                │                            equality     (conrelid) = (oid)
+                ├── virtual table            ·            ·
+                │                            source       ·
+                └── hash-join                ·            ·
+                     │                       type         inner
+                     │                       equality     (oid) = (relnamespace)
+                     ├── filter              ·            ·
+                     │    │                  filter       nspname = 'public'
+                     │    └── virtual table  ·            ·
+                     │                       source       ·
+                     └── filter              ·            ·
+                          │                  filter       relname = 'foo'
+                          └── virtual table  ·            ·
+·                                            source       ·
 
 query TTT
 EXPLAIN SHOW USERS
 ----
-render     ·       ·
- └── scan  ·       ·
-·          table   users@primary
-·          spans   ALL
-·          filter  "isRole" = false
+·          distributed  false
+·          vectorized   true
+render     ·            ·
+ └── scan  ·            ·
+·          table        users@primary
+·          spans        ALL
+·          filter       "isRole" = false
 
 # EXPLAIN selecting from a sequence.
 statement ok
@@ -317,16 +373,20 @@ CREATE SEQUENCE select_test
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM select_test
 ----
-tree             field  description  columns                           ordering
-sequence select  ·      ·            (last_value, log_cnt, is_called)  ·
+tree             field        description  columns                           ordering
+·                distributed  false        ·                                 ·
+·                vectorized   false        ·                                 ·
+sequence select  ·            ·            (last_value, log_cnt, is_called)  ·
 
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT @1 FROM select_test
 ----
-tree                  field     description  columns                           ordering
-render                ·         ·            ("?column?")                      ·
- │                    render 0  last_value   ·                                 ·
- └── sequence select  ·         ·            (last_value, log_cnt, is_called)  ·
+tree                  field        description  columns                           ordering
+·                     distributed  false        ·                                 ·
+·                     vectorized   false        ·                                 ·
+render                ·            ·            ("?column?")                      ·
+ │                    render 0     last_value   ·                                 ·
+ └── sequence select  ·            ·            (last_value, log_cnt, is_called)  ·
 
 statement ok
 CREATE TABLE t (
@@ -337,12 +397,14 @@ CREATE TABLE t (
 query TTT
 EXPLAIN INSERT INTO t VALUES (1, 2)
 ----
-count             ·         ·
- └── insert       ·         ·
-      │           into      t(k, v)
-      │           strategy  inserter
-      └── values  ·         ·
-·                 size      2 columns, 1 row
+·                 distributed  false
+·                 vectorized   false
+count             ·            ·
+ └── insert       ·            ·
+      │           into         t(k, v)
+      │           strategy     inserter
+      └── values  ·            ·
+·                 size         2 columns, 1 row
 
 query I
 SELECT max(level) FROM [EXPLAIN (VERBOSE) INSERT INTO t VALUES (1, 2)]
@@ -355,61 +417,77 @@ INSERT INTO t VALUES (1, 2)
 query TTT
 EXPLAIN SELECT * FROM t
 ----
-scan  ·      ·
-·     table  t@primary
-·     spans  ALL
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        t@primary
+·     spans        ALL
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t
 ----
-scan  ·      ·          (k, v)  ·
-·     table  t@primary  ·       ·
-·     spans  ALL        ·       ·
+·     distributed  false      ·       ·
+·     vectorized   true       ·       ·
+scan  ·            ·          (k, v)  ·
+·     table        t@primary  ·       ·
+·     spans        ALL        ·       ·
 
 query TTT
 EXPLAIN SELECT * FROM t WHERE k = 1 OR k = 3
 ----
-scan  ·         ·
-·     table     t@primary
-·     spans     /1-/1/# /3-/3/#
-·     parallel  ·
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        t@primary
+·     spans        /1-/1/# /3-/3/#
+·     parallel     ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE k % 2 = 0
 ----
-scan  ·       ·            (k, v)  ·
-·     table   t@primary    ·       ·
-·     spans   ALL          ·       ·
-·     filter  (k % 2) = 0  ·       ·
+·     distributed  false        ·       ·
+·     vectorized   false        ·       ·
+scan  ·            ·            (k, v)  ·
+·     table        t@primary    ·       ·
+·     spans        ALL          ·       ·
+·     filter       (k % 2) = 0  ·       ·
 
 query TTT
 EXPLAIN VALUES (1, 2, 3), (4, 5, 6)
 ----
-values  ·     ·
-·       size  3 columns, 2 rows
+·       distributed  false
+·       vectorized   false
+values  ·            ·
+·       size         3 columns, 2 rows
 
 query TTT
 EXPLAIN VALUES (1)
 ----
-values  ·     ·
-·       size  1 column, 1 row
+·       distributed  false
+·       vectorized   false
+values  ·            ·
+·       size         1 column, 1 row
 
 query TTT
 SELECT tree, field, description FROM [EXPLAIN (VERBOSE) SELECT * FROM t WITH ORDINALITY LIMIT 1 OFFSET 1]
 ----
-limit                 ·       ·
- │                    offset  1
- └── limit            ·       ·
-      │               count   2
-      └── ordinality  ·       ·
-           └── scan   ·       ·
-·                     table   t@primary
-·                     spans   ALL
-·                     limit   2
+·                     distributed  false
+·                     vectorized   true
+limit                 ·            ·
+ │                    offset       1
+ └── limit            ·            ·
+      │               count        2
+      └── ordinality  ·            ·
+           └── scan   ·            ·
+·                     table        t@primary
+·                     spans        ALL
+·                     limit        2
 
 query TTT
 EXPLAIN SELECT DISTINCT v FROM t
 ----
+·          distributed  false
+·          vectorized   false
 distinct   ·            ·
  │         distinct on  v
  └── scan  ·            ·
@@ -419,6 +497,8 @@ distinct   ·            ·
 query TTT
 SELECT tree, field, description FROM [EXPLAIN (VERBOSE) SELECT DISTINCT v FROM t LIMIT 1 OFFSET 1]
 ----
+·                    distributed  false
+·                    vectorized   false
 limit                ·            ·
  │                   offset       1
  └── limit           ·            ·
@@ -435,18 +515,22 @@ CREATE TABLE tc (a INT, b INT, INDEX c(a))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM tc WHERE a = 10 ORDER BY b
 ----
-sort             ·      ·           (a, b)              +b
- │               order  +b          ·                   ·
- └── index-join  ·      ·           (a, b)              ·
-      │          table  tc@primary  ·                   ·
-      └── scan   ·      ·           (a, rowid[hidden])  ·
-·                table  tc@c        ·                   ·
-·                spans  /10-/11     ·                   ·
+·                distributed  false       ·                   ·
+·                vectorized   false       ·                   ·
+sort             ·            ·           (a, b)              +b
+ │               order        +b          ·                   ·
+ └── index-join  ·            ·           (a, b)              ·
+      │          table        tc@primary  ·                   ·
+      └── scan   ·            ·           (a, rowid[hidden])  ·
+·                table        tc@c        ·                   ·
+·                spans        /10-/11     ·                   ·
 
 query TTTTT colnames
 EXPLAIN (TYPES) INSERT INTO t VALUES (1, 2)
 ----
 tree              field          description       columns                     ordering
+·                 distributed    false             ·                           ·
+·                 vectorized     false             ·                           ·
 count             ·              ·                 ()                          ·
  └── insert       ·              ·                 ()                          ·
       │           into           t(k, v)           ·                           ·
@@ -459,6 +543,8 @@ count             ·              ·                 ()                         
 query TTTTT
 EXPLAIN (TYPES) SELECT 42 AS a
 ----
+·       distributed    false            ·        ·
+·       vectorized     false            ·        ·
 values  ·              ·                (a int)  ·
 ·       size           1 column, 1 row  ·        ·
 ·       row 0, expr 0  (42)[int]        ·        ·
@@ -466,35 +552,45 @@ values  ·              ·                (a int)  ·
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM t
 ----
-scan  ·      ·          (k int, v int)  ·
-·     table  t@primary  ·               ·
-·     spans  ALL        ·               ·
+·     distributed  false      ·               ·
+·     vectorized   true       ·               ·
+scan  ·            ·          (k int, v int)  ·
+·     table        t@primary  ·               ·
+·     spans        ALL        ·               ·
 
 query TTTTT
 EXPLAIN (TYPES,SYMVARS) SELECT k FROM t
 ----
-scan  ·      ·          (k int)  ·
-·     table  t@primary  ·        ·
-·     spans  ALL        ·        ·
+·     distributed  false      ·        ·
+·     vectorized   true       ·        ·
+scan  ·            ·          (k int)  ·
+·     table        t@primary  ·        ·
+·     spans        ALL        ·        ·
 
 query TTTTT
 EXPLAIN (TYPES,VERBOSE) SELECT k FROM t
 ----
-scan  ·      ·          (k int)  ·
-·     table  t@primary  ·        ·
-·     spans  ALL        ·        ·
+·     distributed  false      ·        ·
+·     vectorized   true       ·        ·
+scan  ·            ·          (k int)  ·
+·     table        t@primary  ·        ·
+·     spans        ALL        ·        ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM t WHERE v > 123
 ----
-scan  ·       ·                              (k int, v int)  ·
-·     table   t@primary                      ·               ·
-·     spans   ALL                            ·               ·
-·     filter  ((v)[int] > (123)[int])[bool]  ·               ·
+·     distributed  false                          ·               ·
+·     vectorized   true                           ·               ·
+scan  ·            ·                              (k int, v int)  ·
+·     table        t@primary                      ·               ·
+·     spans        ALL                            ·               ·
+·     filter       ((v)[int] > (123)[int])[bool]  ·               ·
 
 query TTTTT
 EXPLAIN (TYPES) VALUES (1, 2, 3), (4, 5, 6)
 ----
+·       distributed    false              ·                                        ·
+·       vectorized     false              ·                                        ·
 values  ·              ·                  (column1 int, column2 int, column3 int)  ·
 ·       size           3 columns, 2 rows  ·                                        ·
 ·       row 0, expr 0  (1)[int]           ·                                        ·
@@ -507,45 +603,53 @@ values  ·              ·                  (column1 int, column2 int, column3 i
 query TTTTT
 EXPLAIN (TYPES) SELECT 2*count(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v<2 AND count(k)>1
 ----
-render       ·         ·         (z int, v int)  ·
- │           render 0  (z)[int]  ·               ·
- │           render 1  (v)[int]  ·               ·
- └── norows  ·         ·         (v int, z int)  ·
+·            distributed  false     ·               ·
+·            vectorized   false     ·               ·
+render       ·            ·         (z int, v int)  ·
+ │           render 0     (z)[int]  ·               ·
+ │           render 1     (v)[int]  ·               ·
+ └── norows  ·            ·         (v int, z int)  ·
 
 query TTTTT
 EXPLAIN (TYPES) DELETE FROM t WHERE v > 1
 ----
-count                ·         ·                            ()              ·
- └── delete          ·         ·                            ()              ·
-      │              from      t                            ·               ·
-      │              strategy  deleter                      ·               ·
-      └── render     ·         ·                            (k int)         ·
-           │         render 0  (k)[int]                     ·               ·
-           └── scan  ·         ·                            (k int, v int)  ·
-·                    table     t@primary                    ·               ·
-·                    spans     ALL                          ·               ·
-·                    filter    ((v)[int] > (1)[int])[bool]  ·               ·
+·                    distributed  false                        ·               ·
+·                    vectorized   false                        ·               ·
+count                ·            ·                            ()              ·
+ └── delete          ·            ·                            ()              ·
+      │              from         t                            ·               ·
+      │              strategy     deleter                      ·               ·
+      └── render     ·            ·                            (k int)         ·
+           │         render 0     (k)[int]                     ·               ·
+           └── scan  ·            ·                            (k int, v int)  ·
+·                    table        t@primary                    ·               ·
+·                    spans        ALL                          ·               ·
+·                    filter       ((v)[int] > (1)[int])[bool]  ·               ·
 
 query TTTTT
 EXPLAIN (TYPES) UPDATE t SET v = k + 1 WHERE v > 123
 ----
-count                ·         ·                              ()                           ·
- └── update          ·         ·                              ()                           ·
-      │              table     t                              ·                            ·
-      │              set       v                              ·                            ·
-      │              strategy  updater                        ·                            ·
-      └── render     ·         ·                              (k int, v int, column5 int)  ·
-           │         render 0  (k)[int]                       ·                            ·
-           │         render 1  (v)[int]                       ·                            ·
-           │         render 2  ((k)[int] + (1)[int])[int]     ·                            ·
-           └── scan  ·         ·                              (k int, v int)               ·
-·                    table     t@primary                      ·                            ·
-·                    spans     ALL                            ·                            ·
-·                    filter    ((v)[int] > (123)[int])[bool]  ·                            ·
+·                    distributed  false                          ·                            ·
+·                    vectorized   false                          ·                            ·
+count                ·            ·                              ()                           ·
+ └── update          ·            ·                              ()                           ·
+      │              table        t                              ·                            ·
+      │              set          v                              ·                            ·
+      │              strategy     updater                        ·                            ·
+      └── render     ·            ·                              (k int, v int, column5 int)  ·
+           │         render 0     (k)[int]                       ·                            ·
+           │         render 1     (v)[int]                       ·                            ·
+           │         render 2     ((k)[int] + (1)[int])[int]     ·                            ·
+           └── scan  ·            ·                              (k int, v int)               ·
+·                    table        t@primary                      ·                            ·
+·                    spans        ALL                            ·                            ·
+·                    filter       ((v)[int] > (123)[int])[bool]  ·                            ·
 
 query TTTTT
 EXPLAIN (TYPES) VALUES (1) UNION VALUES (2)
 ----
+·            distributed    false            ·              ·
+·            vectorized     false            ·              ·
 union        ·              ·                (column1 int)  ·
  ├── values  ·              ·                (column1 int)  ·
  │           size           1 column, 1 row  ·              ·
@@ -557,26 +661,32 @@ union        ·              ·                (column1 int)  ·
 query TTTTT
 EXPLAIN (TYPES) SELECT DISTINCT k FROM t
 ----
-scan  ·      ·          (k int)  ·
-·     table  t@primary  ·        ·
-·     spans  ALL        ·        ·
+·     distributed  false      ·        ·
+·     vectorized   true       ·        ·
+scan  ·            ·          (k int)  ·
+·     table        t@primary  ·        ·
+·     spans        ALL        ·        ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT v FROM t ORDER BY v
 ----
-sort       ·      ·          (v int)  +v
- │         order  +v         ·        ·
- └── scan  ·      ·          (v int)  ·
-·          table  t@primary  ·        ·
-·          spans  ALL        ·        ·
+·          distributed  false      ·        ·
+·          vectorized   false      ·        ·
+sort       ·            ·          (v int)  +v
+ │         order        +v         ·        ·
+ └── scan  ·            ·          (v int)  ·
+·          table        t@primary  ·        ·
+·          spans        ALL        ·        ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT v FROM t LIMIT 1
 ----
-scan  ·      ·          (v int)  ·
-·     table  t@primary  ·        ·
-·     spans  ALL        ·        ·
-·     limit  1          ·        ·
+·     distributed  false      ·        ·
+·     vectorized   true       ·        ·
+scan  ·            ·          (v int)  ·
+·     table        t@primary  ·        ·
+·     spans        ALL        ·        ·
+·     limit        1          ·        ·
 
 statement ok
 CREATE TABLE tt (x INT, y INT, INDEX a(x), INDEX b(y))
@@ -584,10 +694,12 @@ CREATE TABLE tt (x INT, y INT, INDEX a(x), INDEX b(y))
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM tt WHERE x < 10 AND y > 10
 ----
-scan  ·       ·                                                                          (x int, y int)  ·
-·     table   tt@primary                                                                 ·               ·
-·     spans   ALL                                                                        ·               ·
-·     filter  ((((x)[int] < (10)[int])[bool]) AND (((y)[int] > (10)[int])[bool]))[bool]  ·               ·
+·     distributed  false                                                                      ·               ·
+·     vectorized   true                                                                       ·               ·
+scan  ·            ·                                                                          (x int, y int)  ·
+·     table        tt@primary                                                                 ·               ·
+·     spans        ALL                                                                        ·               ·
+·     filter       ((((x)[int] < (10)[int])[bool]) AND (((y)[int] > (10)[int])[bool]))[bool]  ·               ·
 
 # TODO(radu): we don't support placeholders with no values.
 #query TTTTT
@@ -600,6 +712,8 @@ scan  ·       ·                                                               
 query TTTTT
 EXPLAIN (TYPES) SELECT abs(2-3) AS a
 ----
+·       distributed    false            ·        ·
+·       vectorized     false            ·        ·
 values  ·              ·                (a int)  ·
 ·       size           1 column, 1 row  ·        ·
 ·       row 0, expr 0  (1)[int]         ·        ·
@@ -608,6 +722,8 @@ values  ·              ·                (a int)  ·
 query TTTTT
 EXPLAIN (TYPES) SELECT x[1] FROM (SELECT ARRAY[1,2,3] AS x)
 ----
+·       distributed    false            ·        ·
+·       vectorized     false            ·        ·
 values  ·              ·                (x int)  ·
 ·       size           1 column, 1 row  ·        ·
 ·       row 0, expr 0  (1)[int]         ·        ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/fakedist_union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fakedist_union
@@ -1,4 +1,4 @@
-# LogicTest: local
+# LogicTest: fakedist
 
 statement ok
 CREATE TABLE uniontest (
@@ -9,7 +9,7 @@ CREATE TABLE uniontest (
 query TTT
 EXPLAIN SELECT v FROM uniontest UNION SELECT k FROM uniontest
 ----
-·          distributed  false
+·          distributed  true
 ·          vectorized   false
 union      ·            ·
  ├── scan  ·            ·
@@ -22,7 +22,7 @@ union      ·            ·
 query TTT
 EXPLAIN SELECT v FROM uniontest UNION ALL SELECT k FROM uniontest
 ----
-·          distributed  false
+·          distributed  true
 ·          vectorized   true
 append     ·            ·
  ├── scan  ·            ·
@@ -51,7 +51,7 @@ CREATE TABLE abc (a INT, b INT, c INT)
 query TTTTT
 EXPLAIN (VERBOSE) (SELECT a FROM abc ORDER BY b) INTERSECT (SELECT a FROM abc ORDER BY c) ORDER BY a
 ----
-·                    distributed  false        ·       ·
+·                    distributed  true         ·       ·
 ·                    vectorized   false        ·       ·
 sort                 ·            ·            (a)     +a
  │                   order        +a           ·       ·
@@ -71,7 +71,7 @@ sort                 ·            ·            (a)     +a
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM ((SELECT '' AS a , '') EXCEPT ALL (SELECT '', ''))
 ----
-·                      distributed    false            ·                         ·
+·                      distributed    true             ·                         ·
 ·                      vectorized     false            ·                         ·
 render                 ·              ·                (a)                       ·
  │                     render 0       a                ·                         ·
@@ -93,7 +93,7 @@ query TTTTT
 EXPLAIN (VERBOSE) ((SELECT '', '', 'x' WHERE false))
 UNION ALL ((SELECT '', '', 'x') EXCEPT (VALUES ('', '', 'x')))
 ----
-·                      distributed    false             ·                                     ·
+·                      distributed    true              ·                                     ·
 ·                      vectorized     false             ·                                     ·
 render                 ·              ·                 ("?column?", "?column?", "?column?")  ·
  │                     render 0       "?column?"        ·                                     ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -34,6 +34,8 @@ WHERE
   t.z IS NULL
 ----
 tree                  field               description
+·                     distributed         false
+·                     vectorized          false
 render                ·                   ·
  └── filter           ·                   ·
       │               filter              z IS NULL
@@ -63,6 +65,8 @@ FROM
 WHERE
   t.z IS NULL
 ----
-tree         field  description
-render       ·      ·
- └── norows  ·      ·
+tree         field        description
+·            distributed  false
+·            vectorized   false
+render       ·            ·
+ └── norows  ·            ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk_opt
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk_opt
@@ -12,6 +12,8 @@ CREATE TABLE child (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(p))
 query TTTTT
 EXPLAIN (VERBOSE) INSERT INTO child VALUES (1,1), (2,2)
 ----
+·                                          distributed            false              ·                   ·
+·                                          vectorized             false              ·                   ·
 root                                       ·                      ·                  ()                  ·
  ├── count                                 ·                      ·                  ()                  ·
  │    └── insert                           ·                      ·                  ()                  ·
@@ -44,6 +46,8 @@ CREATE TABLE xy (x INT, y INT)
 query TTTTT
 EXPLAIN (VERBOSE) INSERT INTO child SELECT x,y FROM xy
 ----
+·                                          distributed         false           ·       ·
+·                                          vectorized          false           ·       ·
 root                                       ·                   ·               ()      ·
  ├── count                                 ·                   ·               ()      ·
  │    └── insert                           ·                   ·               ()      ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/information_schema
+++ b/pkg/sql/opt/exec/execbuilder/testdata/information_schema
@@ -3,13 +3,17 @@
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM system.information_schema.schemata
 ----
-virtual table  ·       ·  (catalog_name, schema_name, default_character_set_name, sql_path)  ·
-·              source  ·  ·                                                                  ·
+·              distributed  false  ·                                                                  ·
+·              vectorized   false  ·                                                                  ·
+virtual table  ·            ·      (catalog_name, schema_name, default_character_set_name, sql_path)  ·
+·              source       ·      ·                                                                  ·
 
 query TTT
 EXPLAIN SELECT * FROM system.information_schema.tables WHERE table_name='foo'
 ----
-filter              ·       ·
- │                  filter  table_name = 'foo'
- └── virtual table  ·       ·
-·                   source  ·
+·                   distributed  false
+·                   vectorized   false
+filter              ·            ·
+ │                  filter       table_name = 'foo'
+ └── virtual table  ·            ·
+·                   source       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -307,21 +307,23 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) INSERT INTO insert_t TABLE select_t ORDER BY v DESC LIMIT 10
 ]
 ----
-count                          ·         ·
- └── insert                    ·         ·
-      │                        into      insert_t(x, v, rowid)
-      │                        strategy  inserter
-      └── render               ·         ·
-           │                   render 0  x
-           │                   render 1  v
-           │                   render 2  unique_rowid()
-           └── limit           ·         ·
-                │              count     10
-                └── sort       ·         ·
-                     │         order     -v
-                     └── scan  ·         ·
-·                              table     select_t@primary
-·                              spans     ALL
+·                              distributed  false
+·                              vectorized   false
+count                          ·            ·
+ └── insert                    ·            ·
+      │                        into         insert_t(x, v, rowid)
+      │                        strategy     inserter
+      └── render               ·            ·
+           │                   render 0     x
+           │                   render 1     v
+           │                   render 2     unique_rowid()
+           └── limit           ·            ·
+                │              count        10
+                └── sort       ·            ·
+                     │         order        -v
+                     └── scan  ·            ·
+·                              table        select_t@primary
+·                              spans        ALL
 
 # Check that INSERT supports LIMIT (MySQL extension)
 query TTT
@@ -329,104 +331,116 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) INSERT INTO insert_t SELECT * FROM select_t LIMIT 1
 ]
 ----
-count                ·         ·
- └── insert          ·         ·
-      │              into      insert_t(x, v, rowid)
-      │              strategy  inserter
-      └── render     ·         ·
-           │         render 0  x
-           │         render 1  v
-           │         render 2  unique_rowid()
-           └── scan  ·         ·
-·                    table     select_t@primary
-·                    spans     ALL
-·                    limit     1
+·                    distributed  false
+·                    vectorized   false
+count                ·            ·
+ └── insert          ·            ·
+      │              into         insert_t(x, v, rowid)
+      │              strategy     inserter
+      └── render     ·            ·
+           │         render 0     x
+           │         render 1     v
+           │         render 2     unique_rowid()
+           └── scan  ·            ·
+·                    table        select_t@primary
+·                    spans        ALL
+·                    limit        1
 
 # Check the grouping of LIMIT and ORDER BY
 query TTT
 EXPLAIN (PLAN) INSERT INTO insert_t VALUES (1,1), (2,2) LIMIT 1
 ----
-count                       ·         ·
- └── insert                 ·         ·
-      │                     into      insert_t(x, v, rowid)
-      │                     strategy  inserter
-      └── render            ·         ·
-           └── limit        ·         ·
-                │           count     1
-                └── values  ·         ·
-·                           size      2 columns, 2 rows
+·                           distributed  false
+·                           vectorized   false
+count                       ·            ·
+ └── insert                 ·            ·
+      │                     into         insert_t(x, v, rowid)
+      │                     strategy     inserter
+      └── render            ·            ·
+           └── limit        ·            ·
+                │           count        1
+                └── values  ·            ·
+·                           size         2 columns, 2 rows
 
 query TTT
 EXPLAIN (PLAN) INSERT INTO insert_t VALUES (1,1), (2,2) ORDER BY 2 LIMIT 1
 ----
-count                            ·         ·
- └── insert                      ·         ·
-      │                          into      insert_t(x, v, rowid)
-      │                          strategy  inserter
-      └── render                 ·         ·
-           └── limit             ·         ·
-                │                count     1
-                └── sort         ·         ·
-                     │           order     +column2
-                     └── values  ·         ·
-·                                size      2 columns, 2 rows
+·                                distributed  false
+·                                vectorized   false
+count                            ·            ·
+ └── insert                      ·            ·
+      │                          into         insert_t(x, v, rowid)
+      │                          strategy     inserter
+      └── render                 ·            ·
+           └── limit             ·            ·
+                │                count        1
+                └── sort         ·            ·
+                     │           order        +column2
+                     └── values  ·            ·
+·                                size         2 columns, 2 rows
 
 query TTT
 EXPLAIN (PLAN) INSERT INTO insert_t (VALUES (1,1), (2,2) ORDER BY 2) LIMIT 1
 ----
-count                            ·         ·
- └── insert                      ·         ·
-      │                          into      insert_t(x, v, rowid)
-      │                          strategy  inserter
-      └── render                 ·         ·
-           └── limit             ·         ·
-                │                count     1
-                └── sort         ·         ·
-                     │           order     +column2
-                     └── values  ·         ·
-·                                size      2 columns, 2 rows
+·                                distributed  false
+·                                vectorized   false
+count                            ·            ·
+ └── insert                      ·            ·
+      │                          into         insert_t(x, v, rowid)
+      │                          strategy     inserter
+      └── render                 ·            ·
+           └── limit             ·            ·
+                │                count        1
+                └── sort         ·            ·
+                     │           order        +column2
+                     └── values  ·            ·
+·                                size         2 columns, 2 rows
 
 query TTT
 EXPLAIN (PLAN) INSERT INTO insert_t (VALUES (1,1), (2,2) ORDER BY 2 LIMIT 1)
 ----
-count                            ·         ·
- └── insert                      ·         ·
-      │                          into      insert_t(x, v, rowid)
-      │                          strategy  inserter
-      └── render                 ·         ·
-           └── limit             ·         ·
-                │                count     1
-                └── sort         ·         ·
-                     │           order     +column2
-                     └── values  ·         ·
-·                                size      2 columns, 2 rows
+·                                distributed  false
+·                                vectorized   false
+count                            ·            ·
+ └── insert                      ·            ·
+      │                          into         insert_t(x, v, rowid)
+      │                          strategy     inserter
+      └── render                 ·            ·
+           └── limit             ·            ·
+                │                count        1
+                └── sort         ·            ·
+                     │           order        +column2
+                     └── values  ·            ·
+·                                size         2 columns, 2 rows
 
 # ORDER BY expression that's not inserted into table.
 query TTTTT
 EXPLAIN (VERBOSE)
 INSERT INTO insert_t (SELECT length(k), 2 FROM kv ORDER BY k || v LIMIT 10) RETURNING x+v
 ----
-render                                   ·         ·                      ("?column?")                   ·
- │                                       render 0  x + v                  ·                              ·
- └── run                                 ·         ·                      (x, v, rowid[hidden])          ·
-      └── insert                         ·         ·                      (x, v, rowid[hidden])          ·
-           │                             into      insert_t(x, v, rowid)  ·                              ·
-           │                             strategy  inserter               ·                              ·
-           └── render                    ·         ·                      (length, "?column?", column9)  ·
-                │                        render 0  length                 ·                              ·
-                │                        render 1  "?column?"             ·                              ·
-                │                        render 2  unique_rowid()         ·                              ·
-                └── limit                ·         ·                      (length, "?column?", column8)  +column8
-                     │                   count     10                     ·                              ·
-                     └── sort            ·         ·                      (length, "?column?", column8)  +column8
-                          │              order     +column8               ·                              ·
-                          └── render     ·         ·                      (length, "?column?", column8)  ·
-                               │         render 0  length(k)              ·                              ·
-                               │         render 1  2                      ·                              ·
-                               │         render 2  k || v                 ·                              ·
-                               └── scan  ·         ·                      (k, v)                         ·
-·                                        table     kv@primary             ·                              ·
-·                                        spans     ALL                    ·                              ·
+·                                        distributed  false                  ·                              ·
+·                                        vectorized   false                  ·                              ·
+render                                   ·            ·                      ("?column?")                   ·
+ │                                       render 0     x + v                  ·                              ·
+ └── run                                 ·            ·                      (x, v, rowid[hidden])          ·
+      └── insert                         ·            ·                      (x, v, rowid[hidden])          ·
+           │                             into         insert_t(x, v, rowid)  ·                              ·
+           │                             strategy     inserter               ·                              ·
+           └── render                    ·            ·                      (length, "?column?", column9)  ·
+                │                        render 0     length                 ·                              ·
+                │                        render 1     "?column?"             ·                              ·
+                │                        render 2     unique_rowid()         ·                              ·
+                └── limit                ·            ·                      (length, "?column?", column8)  +column8
+                     │                   count        10                     ·                              ·
+                     └── sort            ·            ·                      (length, "?column?", column8)  +column8
+                          │              order        +column8               ·                              ·
+                          └── render     ·            ·                      (length, "?column?", column8)  ·
+                               │         render 0     length(k)              ·                              ·
+                               │         render 1     2                      ·                              ·
+                               │         render 2     k || v                 ·                              ·
+                               └── scan  ·            ·                      (k, v)                         ·
+·                                        table        kv@primary             ·                              ·
+·                                        spans        ALL                    ·                              ·
 
 # ------------------------------------------------------------------------------
 # Insert rows into table during schema changes.
@@ -442,6 +456,8 @@ BEGIN; ALTER TABLE mutation DROP COLUMN y
 query TTTTT
 EXPLAIN (VERBOSE) INSERT INTO mutation(x) VALUES (2) RETURNING *
 ----
+·                      distributed    false                  ·                            ·
+·                      vectorized     false                  ·                            ·
 render                 ·              ·                      (x)                          ·
  │                     render 0       x                      ·                            ·
  └── run               ·              ·                      (x, rowid[hidden])           ·
@@ -464,6 +480,8 @@ BEGIN; ALTER TABLE mutation ADD COLUMN z INT AS (x + y) STORED
 query TTTTT
 EXPLAIN (VERBOSE) INSERT INTO mutation(x, y) VALUES (2, 2)
 ----
+·                 distributed    false                  ·                            ·
+·                 vectorized     false                  ·                            ·
 count             ·              ·                      ()                           ·
  └── insert       ·              ·                      ()                           ·
       │           into           mutation(x, y, rowid)  ·                            ·
@@ -489,20 +507,22 @@ CREATE TABLE xyz (x INT, y INT, z INT)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [INSERT INTO xyz SELECT a, b, c FROM abc RETURNING z] ORDER BY z
 ----
-render                    ·         ·                    (z)                 +z
- │                        render 0  z                    ·                   ·
- └── run                  ·         ·                    (z, rowid[hidden])  ·
-      └── insert          ·         ·                    (z, rowid[hidden])  ·
-           │              into      xyz(x, y, z, rowid)  ·                   ·
-           │              strategy  inserter             ·                   ·
-           └── render     ·         ·                    (a, b, c, column9)  +c
-                │         render 0  a                    ·                   ·
-                │         render 1  b                    ·                   ·
-                │         render 2  c                    ·                   ·
-                │         render 3  unique_rowid()       ·                   ·
-                └── scan  ·         ·                    (a, b, c)           +c
-·                         table     abc@abc_c_idx        ·                   ·
-·                         spans     ALL                  ·                   ·
+·                         distributed  false                ·                   ·
+·                         vectorized   false                ·                   ·
+render                    ·            ·                    (z)                 +z
+ │                        render 0     z                    ·                   ·
+ └── run                  ·            ·                    (z, rowid[hidden])  ·
+      └── insert          ·            ·                    (z, rowid[hidden])  ·
+           │              into         xyz(x, y, z, rowid)  ·                   ·
+           │              strategy     inserter             ·                   ·
+           └── render     ·            ·                    (a, b, c, column9)  +c
+                │         render 0     a                    ·                   ·
+                │         render 1     b                    ·                   ·
+                │         render 2     c                    ·                   ·
+                │         render 3     unique_rowid()       ·                   ·
+                └── scan  ·            ·                    (a, b, c)           +c
+·                         table        abc@abc_c_idx        ·                   ·
+·                         spans        ALL                  ·                   ·
 
 # ------------------------------------------------------------------------------
 # Regression for #35364. This tests behavior that is different between the CBO

--- a/pkg/sql/opt/exec/execbuilder/testdata/interleaved
+++ b/pkg/sql/opt/exec/execbuilder/testdata/interleaved
@@ -38,9 +38,11 @@ CREATE TABLE level4 (
 query TTT
 EXPLAIN SELECT * FROM level4
 ----
-scan  ·      ·
-·     table  level4@primary
-·     spans  ALL
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        level4@primary
+·     spans        ALL
 
 # The span below ends at the end of the first index of table 53, and is not
 # constraining the value of k2 or k3. This is confusing on first glance because
@@ -49,31 +51,39 @@ scan  ·      ·
 query TTT
 EXPLAIN SELECT * FROM level4 WHERE k1 > 1 AND k1 < 3
 ----
-scan  ·      ·
-·     table  level4@primary
-·     spans  /2/#/54/1/#/55/1-/2/#/54/1/#/55/2
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        level4@primary
+·     spans        /2/#/54/1/#/55/1-/2/#/54/1/#/55/2
 
 query TTT
 EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 > 10 AND k2 < 30
 ----
-scan  ·      ·
-·     table  level4@primary
-·     spans  /2/#/54/1/#/55/1/11-/2/#/54/1/#/55/1/30
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        level4@primary
+·     spans        /2/#/54/1/#/55/1/11-/2/#/54/1/#/55/1/30
 
 query TTT
 EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 > 100 AND k3 < 300
 ----
-scan  ·         ·
-·     table     level4@primary
-·     spans     /2/#/54/1/#/55/1/20/101/#/56/1-/2/#/54/1/#/55/1/20/299/#/56/1/#
-·     parallel  ·
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        level4@primary
+·     spans        /2/#/54/1/#/55/1/20/101/#/56/1-/2/#/54/1/#/55/1/20/299/#/56/1/#
+·     parallel     ·
 
 query TTT
 EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 = 200
 ----
-scan  ·      ·
-·     table  level4@primary
-·     spans  /2/#/54/1/#/55/1/20/200/#/56/1-/2/#/54/1/#/55/1/20/200/#/56/1/#
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        level4@primary
+·     spans        /2/#/54/1/#/55/1/20/200/#/56/1-/2/#/54/1/#/55/1/20/200/#/56/1/#
 
 # ------------------------------------------------------------------------------
 # Trace of interleaved fetches from interesting interleaved hierarchy.

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -12,136 +12,168 @@ CREATE INVERTED INDEX foo_inv ON d(b)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": "b"}'
 ----
-index-join  ·      ·                            (a, b)  ·
- │          table  d@primary                    ·       ·
- └── scan   ·      ·                            (a)     ·
-·           table  d@foo_inv                    ·       ·
-·           spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
+·           distributed  false                        ·       ·
+·           vectorized   false                        ·       ·
+index-join  ·            ·                            (a, b)  ·
+ │          table        d@primary                    ·       ·
+ └── scan   ·            ·                            (a)     ·
+·           table        d@foo_inv                    ·       ·
+·           spans        /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": {"b": [1]}}'
 ----
-index-join  ·      ·                                        (a, b)  ·
- │          table  d@primary                                ·       ·
- └── scan   ·      ·                                        (a)     ·
-·           table  d@foo_inv                                ·       ·
-·           spans  /"a"/"b"/Arr/1-/"a"/"b"/Arr/1/PrefixEnd  ·       ·
+·           distributed  false                                    ·       ·
+·           vectorized   false                                    ·       ·
+index-join  ·            ·                                        (a, b)  ·
+ │          table        d@primary                                ·       ·
+ └── scan   ·            ·                                        (a)     ·
+·           table        d@foo_inv                                ·       ·
+·           spans        /"a"/"b"/Arr/1-/"a"/"b"/Arr/1/PrefixEnd  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": [[2]]}}';
 ----
-index-join  ·      ·                                                (a, b)  ·
- │          table  d@primary                                        ·       ·
- └── scan   ·      ·                                                (a)     ·
-·           table  d@foo_inv                                        ·       ·
-·           spans  /"a"/"b"/Arr/Arr/2-/"a"/"b"/Arr/Arr/2/PrefixEnd  ·       ·
+·           distributed  false                                            ·       ·
+·           vectorized   false                                            ·       ·
+index-join  ·            ·                                                (a, b)  ·
+ │          table        d@primary                                        ·       ·
+ └── scan   ·            ·                                                (a)     ·
+·           table        d@foo_inv                                        ·       ·
+·           spans        /"a"/"b"/Arr/Arr/2-/"a"/"b"/Arr/Arr/2/PrefixEnd  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b":true}}';
 ----
-index-join  ·      ·                             (a, b)  ·
- │          table  d@primary                     ·       ·
- └── scan   ·      ·                             (a)     ·
-·           table  d@foo_inv                     ·       ·
-·           spans  /"a"/"b"/True-/"a"/"b"/False  ·       ·
+·           distributed  false                         ·       ·
+·           vectorized   false                         ·       ·
+index-join  ·            ·                             (a, b)  ·
+ │          table        d@primary                     ·       ·
+ └── scan   ·            ·                             (a)     ·
+·           table        d@foo_inv                     ·       ·
+·           spans        /"a"/"b"/True-/"a"/"b"/False  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'[1]'
 ----
-index-join  ·      ·                        (a, b)  ·
- │          table  d@primary                ·       ·
- └── scan   ·      ·                        (a)     ·
-·           table  d@foo_inv                ·       ·
-·           spans  /Arr/1-/Arr/1/PrefixEnd  ·       ·
+·           distributed  false                    ·       ·
+·           vectorized   false                    ·       ·
+index-join  ·            ·                        (a, b)  ·
+ │          table        d@primary                ·       ·
+ └── scan   ·            ·                        (a)     ·
+·           table        d@foo_inv                ·       ·
+·           spans        /Arr/1-/Arr/1/PrefixEnd  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'[{"a": {"b": [1]}}]'
 ----
-index-join  ·      ·                                                (a, b)  ·
- │          table  d@primary                                        ·       ·
- └── scan   ·      ·                                                (a)     ·
-·           table  d@foo_inv                                        ·       ·
-·           spans  /Arr/"a"/"b"/Arr/1-/Arr/"a"/"b"/Arr/1/PrefixEnd  ·       ·
+·           distributed  false                                            ·       ·
+·           vectorized   false                                            ·       ·
+index-join  ·            ·                                                (a, b)  ·
+ │          table        d@primary                                        ·       ·
+ └── scan   ·            ·                                                (a)     ·
+·           table        d@foo_inv                                        ·       ·
+·           spans        /Arr/"a"/"b"/Arr/1-/Arr/"a"/"b"/Arr/1/PrefixEnd  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '[]';
 ----
-scan  ·       ·          (a, b)  ·
-·     table   d@primary  ·       ·
-·     spans   ALL        ·       ·
-·     filter  b @> '[]'  ·       ·
+·     distributed  false      ·       ·
+·     vectorized   false      ·       ·
+scan  ·            ·          (a, b)  ·
+·     table        d@primary  ·       ·
+·     spans        ALL        ·       ·
+·     filter       b @> '[]'  ·       ·
 
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{}';
 ----
-scan  ·       ·          (a, b)  ·
-·     table   d@primary  ·       ·
-·     spans   ALL        ·       ·
-·     filter  b @> '{}'  ·       ·
+·     distributed  false      ·       ·
+·     vectorized   false      ·       ·
+scan  ·            ·          (a, b)  ·
+·     table        d@primary  ·       ·
+·     spans        ALL        ·       ·
+·     filter       b @> '{}'  ·       ·
 
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b->'a' = '"b"'
 ----
-index-join  ·      ·                            (a, b)  ·
- │          table  d@primary                    ·       ·
- └── scan   ·      ·                            (a)     ·
-·           table  d@foo_inv                    ·       ·
-·           spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
+·           distributed  false                        ·       ·
+·           vectorized   false                        ·       ·
+index-join  ·            ·                            (a, b)  ·
+ │          table        d@primary                    ·       ·
+ └── scan   ·            ·                            (a)     ·
+·           table        d@foo_inv                    ·       ·
+·           spans        /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b->'a'->'c' = '"b"'
 ----
-index-join  ·      ·                                    (a, b)  ·
- │          table  d@primary                            ·       ·
- └── scan   ·      ·                                    (a)     ·
-·           table  d@foo_inv                            ·       ·
-·           spans  /"a"/"c"/"b"-/"a"/"c"/"b"/PrefixEnd  ·       ·
+·           distributed  false                                ·       ·
+·           vectorized   false                                ·       ·
+index-join  ·            ·                                    (a, b)  ·
+ │          table        d@primary                            ·       ·
+ └── scan   ·            ·                                    (a)     ·
+·           table        d@foo_inv                            ·       ·
+·           spans        /"a"/"c"/"b"-/"a"/"c"/"b"/PrefixEnd  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b->(NULL::STRING) = '"b"'
 ----
-norows  ·  ·  (a, b)  ·
+·       distributed  false  ·       ·
+·       vectorized   false  ·       ·
+norows  ·            ·      (a, b)  ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where '"b"' = b->'a'
 ----
-index-join  ·      ·                            (a, b)  ·
- │          table  d@primary                    ·       ·
- └── scan   ·      ·                            (a)     ·
-·           table  d@foo_inv                    ·       ·
-·           spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
+·           distributed  false                        ·       ·
+·           vectorized   false                        ·       ·
+index-join  ·            ·                            (a, b)  ·
+ │          table        d@primary                    ·       ·
+ └── scan   ·            ·                            (a)     ·
+·           table        d@foo_inv                    ·       ·
+·           spans        /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b IS NULL
 ----
-scan  ·       ·          (a, b)  ·
-·     table   d@primary  ·       ·
-·     spans   ALL        ·       ·
-·     filter  b IS NULL  ·       ·
+·     distributed  false      ·       ·
+·     vectorized   false      ·       ·
+scan  ·            ·          (a, b)  ·
+·     table        d@primary  ·       ·
+·     spans        ALL        ·       ·
+·     filter       b IS NULL  ·       ·
 
 query TTT
 EXPLAIN SELECT * from d where b @> '{"a": []}' ORDER BY a;
 ----
-scan  ·       ·
-·     table   d@primary
-·     spans   ALL
-·     filter  b @> '{"a": []}'
+·     distributed  false
+·     vectorized   false
+scan  ·            ·
+·     table        d@primary
+·     spans        ALL
+·     filter       b @> '{"a": []}'
 
 query TTT
 EXPLAIN SELECT * from d where b @> '{"a": {}}' ORDER BY a;
 ----
-scan  ·       ·
-·     table   d@primary
-·     spans   ALL
-·     filter  b @> '{"a": {}}'
+·     distributed  false
+·     vectorized   false
+scan  ·            ·
+·     table        d@primary
+·     spans        ALL
+·     filter       b @> '{"a": {}}'
 
 # Multi-path contains queries. Should create zigzag joins.
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
 ----
+·                 distributed            false                                ·       ·
+·                 vectorized             false                                ·       ·
 lookup-join       ·                      ·                                    (a, b)  ·
  │                table                  d@primary                            ·       ·
  │                type                   inner                                ·       ·
@@ -160,6 +192,8 @@ lookup-join       ·                      ·                                    
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
 ----
+·                 distributed            false                                          ·       ·
+·                 vectorized             false                                          ·       ·
 lookup-join       ·                      ·                                              (a, b)  ·
  │                table                  d@primary                                      ·       ·
  │                type                   inner                                          ·       ·
@@ -178,6 +212,8 @@ lookup-join       ·                      ·                                    
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
 ----
+·                 distributed            false                               ·       ·
+·                 vectorized             false                               ·       ·
 lookup-join       ·                      ·                                   (a, b)  ·
  │                table                  d@primary                           ·       ·
  │                type                   inner                               ·       ·
@@ -199,6 +235,8 @@ SET enable_zigzag_join = true
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
 ----
+·                 distributed            false                                ·       ·
+·                 vectorized             false                                ·       ·
 lookup-join       ·                      ·                                    (a, b)  ·
  │                table                  d@primary                            ·       ·
  │                type                   inner                                ·       ·
@@ -217,6 +255,8 @@ lookup-join       ·                      ·                                    
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
 ----
+·                 distributed            false                                          ·       ·
+·                 vectorized             false                                          ·       ·
 lookup-join       ·                      ·                                              (a, b)  ·
  │                table                  d@primary                                      ·       ·
  │                type                   inner                                          ·       ·
@@ -235,6 +275,8 @@ lookup-join       ·                      ·                                    
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
 ----
+·                 distributed            false                               ·       ·
+·                 vectorized             false                               ·       ·
 lookup-join       ·                      ·                                   (a, b)  ·
  │                table                  d@primary                           ·       ·
  │                type                   inner                               ·       ·
@@ -253,18 +295,22 @@ lookup-join       ·                      ·                                   (
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": 2}'
 ----
-filter           ·       ·                         (a, b)  ·
- │               filter  b @> '{"a": {}, "b": 2}'  ·       ·
- └── index-join  ·       ·                         (a, b)  ·
-      │          table   d@primary                 ·       ·
-      └── scan   ·       ·                         (a)     ·
-·                table   d@foo_inv                 ·       ·
-·                spans   /"b"/2-/"b"/2/PrefixEnd   ·       ·
+·                distributed  false                     ·       ·
+·                vectorized   false                     ·       ·
+filter           ·            ·                         (a, b)  ·
+ │               filter       b @> '{"a": {}, "b": 2}'  ·       ·
+ └── index-join  ·            ·                         (a, b)  ·
+      │          table        d@primary                 ·       ·
+      └── scan   ·            ·                         (a)     ·
+·                table        d@foo_inv                 ·       ·
+·                spans        /"b"/2-/"b"/2/PrefixEnd   ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": {}}'
 ----
-scan  ·       ·                          (a, b)  ·
-·     table   d@primary                  ·       ·
-·     spans   ALL                        ·       ·
-·     filter  b @> '{"a": {}, "b": {}}'  ·       ·
+·     distributed  false                      ·       ·
+·     vectorized   false                      ·       ·
+scan  ·            ·                          (a, b)  ·
+·     table        d@primary                  ·       ·
+·     spans        ALL                        ·       ·
+·     filter       b @> '{"a": {}, "b": {}}'  ·       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -11,70 +11,79 @@ CREATE TABLE twocolumn (x INT, y INT); INSERT INTO twocolumn(x, y) VALUES (44,51
 query TTT
 EXPLAIN SELECT * FROM onecolumn JOIN twocolumn USING(x)
 ----
-render          ·         ·
- └── hash-join  ·         ·
-      │         type      inner
-      │         equality  (x) = (x)
-      ├── scan  ·         ·
-      │         table     onecolumn@primary
-      │         spans     ALL
-      └── scan  ·         ·
-·               table     twocolumn@primary
-·               spans     ALL
+·               distributed  false
+·               vectorized   false
+render          ·            ·
+ └── hash-join  ·            ·
+      │         type         inner
+      │         equality     (x) = (x)
+      ├── scan  ·            ·
+      │         table        onecolumn@primary
+      │         spans        ALL
+      └── scan  ·            ·
+·               table        twocolumn@primary
+·               spans        ALL
 
 query TTT
 EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
 ----
-hash-join  ·         ·
- │         type      inner
- │         equality  (x) = (y)
- ├── scan  ·         ·
- │         table     twocolumn@primary
- │         spans     ALL
- └── scan  ·         ·
-·          table     twocolumn@primary
-·          spans     ALL
+·          distributed  false
+·          vectorized   false
+hash-join  ·            ·
+ │         type         inner
+ │         equality     (x) = (y)
+ ├── scan  ·            ·
+ │         table        twocolumn@primary
+ │         spans        ALL
+ └── scan  ·            ·
+·          table        twocolumn@primary
+·          spans        ALL
 
 query TTT
 EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
 ----
-render          ·       ·
- └── hash-join  ·       ·
-      │         type    cross
-      ├── scan  ·       ·
-      │         table   twocolumn@primary
-      │         spans   ALL
-      └── scan  ·       ·
-·               table   twocolumn@primary
-·               spans   ALL
-·               filter  x = 44
+·               distributed  false
+·               vectorized   false
+render          ·            ·
+ └── hash-join  ·            ·
+      │         type         cross
+      ├── scan  ·            ·
+      │         table        twocolumn@primary
+      │         spans        ALL
+      └── scan  ·            ·
+·               table        twocolumn@primary
+·               spans        ALL
+·               filter       x = 44
 
 query TTT
 EXPLAIN SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b.y))
 ----
-hash-join  ·         ·
- │         type      inner
- │         equality  (x) = (y)
- ├── scan  ·         ·
- │         table     onecolumn@primary
- │         spans     ALL
- └── scan  ·         ·
-·          table     twocolumn@primary
-·          spans     ALL
+·          distributed  false
+·          vectorized   false
+hash-join  ·            ·
+ │         type         inner
+ │         equality     (x) = (y)
+ ├── scan  ·            ·
+ │         table        onecolumn@primary
+ │         spans        ALL
+ └── scan  ·            ·
+·          table        twocolumn@primary
+·          spans        ALL
 
 query TTT
 EXPLAIN SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn.y
 ----
-hash-join  ·         ·
- │         type      inner
- │         equality  (x) = (y)
- ├── scan  ·         ·
- │         table     onecolumn@primary
- │         spans     ALL
- └── scan  ·         ·
-·          table     twocolumn@primary
-·          spans     ALL
-
+·          distributed  false
+·          vectorized   false
+hash-join  ·            ·
+ │         type         inner
+ │         equality     (x) = (y)
+ ├── scan  ·            ·
+ │         table        onecolumn@primary
+ │         spans        ALL
+ └── scan  ·            ·
+·          table        twocolumn@primary
+·          spans        ALL
 
 query TTT
 EXPLAIN SELECT * FROM
@@ -84,117 +93,131 @@ EXPLAIN SELECT * FROM
   JOIN twocolumn AS c (d, e) ON a.b = c.d AND c.d = onecolumn.x
 LIMIT 1
 ----
-render                    ·         ·
- └── limit                ·         ·
-      │                   count     1
-      └── hash-join       ·         ·
-           │              type      inner
-           │              equality  (x) = (x)
-           ├── hash-join  ·         ·
-           │    │         type      inner
-           │    │         equality  (x) = (x)
-           │    ├── scan  ·         ·
-           │    │         table     twocolumn@primary
-           │    │         spans     ALL
-           │    └── scan  ·         ·
-           │              table     onecolumn@primary
-           │              spans     ALL
-           └── hash-join  ·         ·
-                │         type      inner
-                │         equality  (x) = (x)
-                ├── scan  ·         ·
-                │         table     onecolumn@primary
-                │         spans     ALL
-                └── scan  ·         ·
-·                         table     twocolumn@primary
-·                         spans     ALL
+·                         distributed  false
+·                         vectorized   false
+render                    ·            ·
+ └── limit                ·            ·
+      │                   count        1
+      └── hash-join       ·            ·
+           │              type         inner
+           │              equality     (x) = (x)
+           ├── hash-join  ·            ·
+           │    │         type         inner
+           │    │         equality     (x) = (x)
+           │    ├── scan  ·            ·
+           │    │         table        twocolumn@primary
+           │    │         spans        ALL
+           │    └── scan  ·            ·
+           │              table        onecolumn@primary
+           │              spans        ALL
+           └── hash-join  ·            ·
+                │         type         inner
+                │         equality     (x) = (x)
+                ├── scan  ·            ·
+                │         table        onecolumn@primary
+                │         spans        ALL
+                └── scan  ·            ·
+·                         table        twocolumn@primary
+·                         spans        ALL
 
 # The following queries verify that only the necessary columns are scanned.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
 ----
-hash-join  ·      ·                  (x, y)  ·
- │         type   cross              ·       ·
- ├── scan  ·      ·                  (x)     ·
- │         table  twocolumn@primary  ·       ·
- │         spans  ALL                ·       ·
- └── scan  ·      ·                  (y)     ·
-·          table  twocolumn@primary  ·       ·
-·          spans  ALL                ·       ·
+·          distributed  false              ·       ·
+·          vectorized   false              ·       ·
+hash-join  ·            ·                  (x, y)  ·
+ │         type         cross              ·       ·
+ ├── scan  ·            ·                  (x)     ·
+ │         table        twocolumn@primary  ·       ·
+ │         spans        ALL                ·       ·
+ └── scan  ·            ·                  (y)     ·
+·          table        twocolumn@primary  ·       ·
+·          spans        ALL                ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
 ----
-render          ·         ·                  (y)        ·
- │              render 0  y                  ·          ·
- └── hash-join  ·         ·                  (x, x, y)  ·
-      │         type      inner              ·          ·
-      │         equality  (x) = (x)          ·          ·
-      ├── scan  ·         ·                  (x)        ·
-      │         table     twocolumn@primary  ·          ·
-      │         spans     ALL                ·          ·
-      └── scan  ·         ·                  (x, y)     ·
-·               table     twocolumn@primary  ·          ·
-·               spans     ALL                ·          ·
+·               distributed  false              ·          ·
+·               vectorized   false              ·          ·
+render          ·            ·                  (y)        ·
+ │              render 0     y                  ·          ·
+ └── hash-join  ·            ·                  (x, x, y)  ·
+      │         type         inner              ·          ·
+      │         equality     (x) = (x)          ·          ·
+      ├── scan  ·            ·                  (x)        ·
+      │         table        twocolumn@primary  ·          ·
+      │         spans        ALL                ·          ·
+      └── scan  ·            ·                  (x, y)     ·
+·               table        twocolumn@primary  ·          ·
+·               spans        ALL                ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = b.x)
 ----
-render          ·         ·                  (y)        ·
- │              render 0  y                  ·          ·
- └── hash-join  ·         ·                  (x, x, y)  ·
-      │         type      inner              ·          ·
-      │         equality  (x) = (x)          ·          ·
-      ├── scan  ·         ·                  (x)        ·
-      │         table     twocolumn@primary  ·          ·
-      │         spans     ALL                ·          ·
-      └── scan  ·         ·                  (x, y)     ·
-·               table     twocolumn@primary  ·          ·
-·               spans     ALL                ·          ·
+·               distributed  false              ·          ·
+·               vectorized   false              ·          ·
+render          ·            ·                  (y)        ·
+ │              render 0     y                  ·          ·
+ └── hash-join  ·            ·                  (x, x, y)  ·
+      │         type         inner              ·          ·
+      │         equality     (x) = (x)          ·          ·
+      ├── scan  ·            ·                  (x)        ·
+      │         table        twocolumn@primary  ·          ·
+      │         spans        ALL                ·          ·
+      └── scan  ·            ·                  (x, y)     ·
+·               table        twocolumn@primary  ·          ·
+·               spans        ALL                ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b.y)
 ----
-render          ·         ·                  (x)     ·
- │              render 0  x                  ·       ·
- └── hash-join  ·         ·                  (x, y)  ·
-      │         type      inner              ·       ·
-      │         pred      x < y              ·       ·
-      ├── scan  ·         ·                  (x)     ·
-      │         table     twocolumn@primary  ·       ·
-      │         spans     ALL                ·       ·
-      └── scan  ·         ·                  (y)     ·
-·               table     twocolumn@primary  ·       ·
-·               spans     ALL                ·       ·
+·               distributed  false              ·       ·
+·               vectorized   false              ·       ·
+render          ·            ·                  (x)     ·
+ │              render 0     x                  ·       ·
+ └── hash-join  ·            ·                  (x, y)  ·
+      │         type         inner              ·       ·
+      │         pred         x < y              ·       ·
+      ├── scan  ·            ·                  (x)     ·
+      │         table        twocolumn@primary  ·       ·
+      │         spans        ALL                ·       ·
+      └── scan  ·            ·                  (y)     ·
+·               table        twocolumn@primary  ·       ·
+·               spans        ALL                ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT x, 2 two FROM onecolumn) NATURAL FULL JOIN (SELECT x, y+1 plus1 FROM twocolumn)
 ----
-render               ·         ·                  (x, two, plus1)     ·
- │                   render 0  COALESCE(x, x)     ·                   ·
- │                   render 1  two                ·                   ·
- │                   render 2  plus1              ·                   ·
- └── hash-join       ·         ·                  (two, x, plus1, x)  ·
-      │              type      full outer         ·                   ·
-      │              equality  (x) = (x)          ·                   ·
-      ├── render     ·         ·                  (two, x)            ·
-      │    │         render 0  2                  ·                   ·
-      │    │         render 1  x                  ·                   ·
-      │    └── scan  ·         ·                  (x)                 ·
-      │              table     onecolumn@primary  ·                   ·
-      │              spans     ALL                ·                   ·
-      └── render     ·         ·                  (plus1, x)          ·
-           │         render 0  y + 1              ·                   ·
-           │         render 1  x                  ·                   ·
-           └── scan  ·         ·                  (x, y)              ·
-·                    table     twocolumn@primary  ·                   ·
-·                    spans     ALL                ·                   ·
+·                    distributed  false              ·                   ·
+·                    vectorized   false              ·                   ·
+render               ·            ·                  (x, two, plus1)     ·
+ │                   render 0     COALESCE(x, x)     ·                   ·
+ │                   render 1     two                ·                   ·
+ │                   render 2     plus1              ·                   ·
+ └── hash-join       ·            ·                  (two, x, plus1, x)  ·
+      │              type         full outer         ·                   ·
+      │              equality     (x) = (x)          ·                   ·
+      ├── render     ·            ·                  (two, x)            ·
+      │    │         render 0     2                  ·                   ·
+      │    │         render 1     x                  ·                   ·
+      │    └── scan  ·            ·                  (x)                 ·
+      │              table        onecolumn@primary  ·                   ·
+      │              spans        ALL                ·                   ·
+      └── render     ·            ·                  (plus1, x)          ·
+           │         render 0     y + 1              ·                   ·
+           │         render 1     x                  ·                   ·
+           └── scan  ·            ·                  (x, y)              ·
+·                    table        twocolumn@primary  ·                   ·
+·                    spans        ALL                ·                   ·
 
 # Ensure that the ordering information for the result of joins is sane. (#12037)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES (9, 1), (8, 2)) AS a (u, k) ORDER BY k)
                   INNER JOIN (VALUES (1, 1), (2, 2)) AS b (k, w) USING (k) ORDER BY u
 ----
+·                           distributed    false                  ·                                     ·
+·                           vectorized     false                  ·                                     ·
 render                      ·              ·                      (k, u, w)                             ·
  │                          render 0       column2                ·                                     ·
  │                          render 1       column1                ·                                     ·
@@ -290,92 +313,94 @@ SELECT level, node_type, field, description FROM [EXPLAIN (VERBOSE) SELECT
            pos.n
   ] WHERE node_type <> 'values' AND field <> 'size'
 ----
-0   render         ·          ·
-0   ·              render 0   pktable_cat
-0   ·              render 1   nspname
-0   ·              render 2   relname
-0   ·              render 3   attname
-0   ·              render 4   pktable_cat
-0   ·              render 5   nspname
-0   ·              render 6   relname
-0   ·              render 7   attname
-0   ·              render 8   generate_series
-0   ·              render 9   update_rule
-0   ·              render 10  delete_rule
-0   ·              render 11  conname
-0   ·              render 12  relname
-0   ·              render 13  deferrability
-1   sort           ·          ·
-1   ·              order      +nspname,+relname,+conname,+generate_series
-2   render         ·          ·
-2   ·              render 0   CAST(NULL AS STRING)
-2   ·              render 1   CASE confupdtype WHEN 'c' THEN 0 WHEN 'n' THEN 2 WHEN 'd' THEN 4 WHEN 'r' THEN 1 WHEN 'a' THEN 3 END
-2   ·              render 2   CASE confdeltype WHEN 'c' THEN 0 WHEN 'n' THEN 2 WHEN 'd' THEN 4 WHEN 'r' THEN 1 WHEN 'a' THEN 3 END
-2   ·              render 3   CASE WHEN condeferrable AND condeferred THEN 5 WHEN condeferrable THEN 6 ELSE 7 END
-2   ·              render 4   nspname
-2   ·              render 5   relname
-2   ·              render 6   attname
-2   ·              render 7   nspname
-2   ·              render 8   relname
-2   ·              render 9   attname
-2   ·              render 10  conname
-2   ·              render 11  generate_series
-2   ·              render 12  relname
-3   hash-join      ·          ·
-3   ·              type       inner
-3   ·              equality   (refobjid) = (oid)
-4   hash-join      ·          ·
-4   ·              type       inner
-4   ·              equality   (oid) = (objid)
-5   hash-join      ·          ·
-5   ·              type       inner
-5   ·              pred       (attnum = confkey[generate_series]) AND (attnum = conkey[generate_series])
-6   hash-join      ·          ·
-6   ·              type       inner
-6   ·              equality   (oid, oid) = (confrelid, conrelid)
-7   hash-join      ·          ·
-7   ·              type       inner
-7   ·              equality   (oid) = (attrelid)
-8   hash-join      ·          ·
-8   ·              type       inner
-8   ·              equality   (oid) = (relnamespace)
-9   hash-join      ·          ·
-9   ·              type       inner
-9   ·              equality   (oid) = (attrelid)
-10  hash-join      ·          ·
-10  ·              type       inner
-10  ·              equality   (oid) = (relnamespace)
-11  virtual table  ·          ·
-11  ·              source     ·
-11  virtual table  ·          ·
-11  ·              source     ·
-10  hash-join      ·          ·
-10  ·              type       cross
-11  virtual table  ·          ·
-11  ·              source     ·
-11  filter         ·          ·
-11  ·              filter     nspname = 'public'
-12  virtual table  ·          ·
-12  ·              source     ·
-9   filter         ·          ·
-9   ·              filter     relname = 'orders'
-10  virtual table  ·          ·
-10  ·              source     ·
-8   virtual table  ·          ·
-8   ·              source     ·
-7   filter         ·          ·
-7   ·              filter     contype = 'f'
-8   virtual table  ·          ·
-8   ·              source     ·
-6   project set    ·          ·
-6   ·              render 0   generate_series(1, 32)
-7   emptyrow       ·          ·
-5   virtual table  ·          ·
-5   ·              source     ·
-4   filter         ·          ·
-4   ·              filter     relkind = 'i'
-5   virtual table  ·          ·
-5   ·              source     ·
+0   ·              distributed  false
+0   ·              vectorized   false
+0   render         ·            ·
+0   ·              render 0     pktable_cat
+0   ·              render 1     nspname
+0   ·              render 2     relname
+0   ·              render 3     attname
+0   ·              render 4     pktable_cat
+0   ·              render 5     nspname
+0   ·              render 6     relname
+0   ·              render 7     attname
+0   ·              render 8     generate_series
+0   ·              render 9     update_rule
+0   ·              render 10    delete_rule
+0   ·              render 11    conname
+0   ·              render 12    relname
+0   ·              render 13    deferrability
+1   sort           ·            ·
+1   ·              order        +nspname,+relname,+conname,+generate_series
+2   render         ·            ·
+2   ·              render 0     CAST(NULL AS STRING)
+2   ·              render 1     CASE confupdtype WHEN 'c' THEN 0 WHEN 'n' THEN 2 WHEN 'd' THEN 4 WHEN 'r' THEN 1 WHEN 'a' THEN 3 END
+2   ·              render 2     CASE confdeltype WHEN 'c' THEN 0 WHEN 'n' THEN 2 WHEN 'd' THEN 4 WHEN 'r' THEN 1 WHEN 'a' THEN 3 END
+2   ·              render 3     CASE WHEN condeferrable AND condeferred THEN 5 WHEN condeferrable THEN 6 ELSE 7 END
+2   ·              render 4     nspname
+2   ·              render 5     relname
+2   ·              render 6     attname
+2   ·              render 7     nspname
+2   ·              render 8     relname
+2   ·              render 9     attname
+2   ·              render 10    conname
+2   ·              render 11    generate_series
+2   ·              render 12    relname
+3   hash-join      ·            ·
+3   ·              type         inner
+3   ·              equality     (refobjid) = (oid)
+4   hash-join      ·            ·
+4   ·              type         inner
+4   ·              equality     (oid) = (objid)
+5   hash-join      ·            ·
+5   ·              type         inner
+5   ·              pred         (attnum = confkey[generate_series]) AND (attnum = conkey[generate_series])
+6   hash-join      ·            ·
+6   ·              type         inner
+6   ·              equality     (oid, oid) = (confrelid, conrelid)
+7   hash-join      ·            ·
+7   ·              type         inner
+7   ·              equality     (oid) = (attrelid)
+8   hash-join      ·            ·
+8   ·              type         inner
+8   ·              equality     (oid) = (relnamespace)
+9   hash-join      ·            ·
+9   ·              type         inner
+9   ·              equality     (oid) = (attrelid)
+10  hash-join      ·            ·
+10  ·              type         inner
+10  ·              equality     (oid) = (relnamespace)
+11  virtual table  ·            ·
+11  ·              source       ·
+11  virtual table  ·            ·
+11  ·              source       ·
+10  hash-join      ·            ·
+10  ·              type         cross
+11  virtual table  ·            ·
+11  ·              source       ·
+11  filter         ·            ·
+11  ·              filter       nspname = 'public'
+12  virtual table  ·            ·
+12  ·              source       ·
+9   filter         ·            ·
+9   ·              filter       relname = 'orders'
+10  virtual table  ·            ·
+10  ·              source       ·
+8   virtual table  ·            ·
+8   ·              source       ·
+7   filter         ·            ·
+7   ·              filter       contype = 'f'
+8   virtual table  ·            ·
+8   ·              source       ·
+6   project set    ·            ·
+6   ·              render 0     generate_series(1, 32)
+7   emptyrow       ·            ·
+5   virtual table  ·            ·
+5   ·              source       ·
+4   filter         ·            ·
+4   ·              filter       relkind = 'i'
+5   virtual table  ·            ·
+5   ·              source       ·
 
 # Ensure that left joins on non-null foreign keys turn into inner joins
 statement ok
@@ -384,6 +409,8 @@ CREATE TABLE cards(id INT PRIMARY KEY, cust INT NOT NULL REFERENCES customers(id
 query TTT
 EXPLAIN SELECT * FROM cards LEFT OUTER JOIN customers ON customers.id = cards.cust
 ----
+·           distributed         false
+·           vectorized          false
 merge-join  ·                   ·
  │          type                inner
  │          equality            (cust) = (id)
@@ -408,6 +435,8 @@ CREATE TABLE pairs (a INT, b INT)
 query TTT
 EXPLAIN SELECT * FROM pairs, square WHERE pairs.b = square.n
 ----
+·          distributed         false
+·          vectorized          false
 hash-join  ·                   ·
  │         type                inner
  │         equality            (b) = (n)
@@ -423,98 +452,106 @@ hash-join  ·                   ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pairs, square WHERE pairs.a + pairs.b = square.sq
 ----
-render               ·         ·                 (a, b, n, sq)           ·
- │                   render 0  a                 ·                       ·
- │                   render 1  b                 ·                       ·
- │                   render 2  n                 ·                       ·
- │                   render 3  sq                ·                       ·
- └── hash-join       ·         ·                 (column6, a, b, n, sq)  ·
-      │              type      inner             ·                       ·
-      │              equality  (column6) = (sq)  ·                       ·
-      ├── render     ·         ·                 (column6, a, b)         ·
-      │    │         render 0  a + b             ·                       ·
-      │    │         render 1  a                 ·                       ·
-      │    │         render 2  b                 ·                       ·
-      │    └── scan  ·         ·                 (a, b)                  ·
-      │              table     pairs@primary     ·                       ·
-      │              spans     ALL               ·                       ·
-      └── scan       ·         ·                 (n, sq)                 ·
-·                    table     square@primary    ·                       ·
-·                    spans     ALL               ·                       ·
+·                    distributed  false             ·                       ·
+·                    vectorized   false             ·                       ·
+render               ·            ·                 (a, b, n, sq)           ·
+ │                   render 0     a                 ·                       ·
+ │                   render 1     b                 ·                       ·
+ │                   render 2     n                 ·                       ·
+ │                   render 3     sq                ·                       ·
+ └── hash-join       ·            ·                 (column6, a, b, n, sq)  ·
+      │              type         inner             ·                       ·
+      │              equality     (column6) = (sq)  ·                       ·
+      ├── render     ·            ·                 (column6, a, b)         ·
+      │    │         render 0     a + b             ·                       ·
+      │    │         render 1     a                 ·                       ·
+      │    │         render 2     b                 ·                       ·
+      │    └── scan  ·            ·                 (a, b)                  ·
+      │              table        pairs@primary     ·                       ·
+      │              spans        ALL               ·                       ·
+      └── scan       ·            ·                 (n, sq)                 ·
+·                    table        square@primary    ·                       ·
+·                    spans        ALL               ·                       ·
 
 # Query similar to the one above, but the filter refers to a rendered
 # expression and can't "break through".
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a, b, n, sq FROM (SELECT a, b, a * b / 2 AS div, n, sq FROM pairs, square) WHERE div = sq
 ----
-render                    ·         ·               (a, b, n, sq)       ·
- │                        render 0  a               ·                   ·
- │                        render 1  b               ·                   ·
- │                        render 2  n               ·                   ·
- │                        render 3  sq              ·                   ·
- └── filter               ·         ·               (div, a, b, n, sq)  ·
-      │                   filter    div = sq        ·                   ·
-      └── render          ·         ·               (div, a, b, n, sq)  ·
-           │              render 0  (a * b) / 2     ·                   ·
-           │              render 1  a               ·                   ·
-           │              render 2  b               ·                   ·
-           │              render 3  n               ·                   ·
-           │              render 4  sq              ·                   ·
-           └── hash-join  ·         ·               (a, b, n, sq)       ·
-                │         type      cross           ·                   ·
-                ├── scan  ·         ·               (a, b)              ·
-                │         table     pairs@primary   ·                   ·
-                │         spans     ALL             ·                   ·
-                └── scan  ·         ·               (n, sq)             ·
-·                         table     square@primary  ·                   ·
-·                         spans     ALL             ·                   ·
+·                         distributed  false           ·                   ·
+·                         vectorized   false           ·                   ·
+render                    ·            ·               (a, b, n, sq)       ·
+ │                        render 0     a               ·                   ·
+ │                        render 1     b               ·                   ·
+ │                        render 2     n               ·                   ·
+ │                        render 3     sq              ·                   ·
+ └── filter               ·            ·               (div, a, b, n, sq)  ·
+      │                   filter       div = sq        ·                   ·
+      └── render          ·            ·               (div, a, b, n, sq)  ·
+           │              render 0     (a * b) / 2     ·                   ·
+           │              render 1     a               ·                   ·
+           │              render 2     b               ·                   ·
+           │              render 3     n               ·                   ·
+           │              render 4     sq              ·                   ·
+           └── hash-join  ·            ·               (a, b, n, sq)       ·
+                │         type         cross           ·                   ·
+                ├── scan  ·            ·               (a, b)              ·
+                │         table        pairs@primary   ·                   ·
+                │         spans        ALL             ·                   ·
+                └── scan  ·            ·               (n, sq)             ·
+·                         table        square@primary  ·                   ·
+·                         spans        ALL             ·                   ·
 
 # The filter expression must stay on top of the outer join.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq
 ----
-render               ·         ·                 (a, b, n, sq)           ·
- │                   render 0  a                 ·                       ·
- │                   render 1  b                 ·                       ·
- │                   render 2  n                 ·                       ·
- │                   render 3  sq                ·                       ·
- └── hash-join       ·         ·                 (column6, a, b, n, sq)  ·
-      │              type      full outer        ·                       ·
-      │              equality  (column6) = (sq)  ·                       ·
-      ├── render     ·         ·                 (column6, a, b)         ·
-      │    │         render 0  a + b             ·                       ·
-      │    │         render 1  a                 ·                       ·
-      │    │         render 2  b                 ·                       ·
-      │    └── scan  ·         ·                 (a, b)                  ·
-      │              table     pairs@primary     ·                       ·
-      │              spans     ALL               ·                       ·
-      └── scan       ·         ·                 (n, sq)                 ·
-·                    table     square@primary    ·                       ·
-·                    spans     ALL               ·                       ·
+·                    distributed  false             ·                       ·
+·                    vectorized   false             ·                       ·
+render               ·            ·                 (a, b, n, sq)           ·
+ │                   render 0     a                 ·                       ·
+ │                   render 1     b                 ·                       ·
+ │                   render 2     n                 ·                       ·
+ │                   render 3     sq                ·                       ·
+ └── hash-join       ·            ·                 (column6, a, b, n, sq)  ·
+      │              type         full outer        ·                       ·
+      │              equality     (column6) = (sq)  ·                       ·
+      ├── render     ·            ·                 (column6, a, b)         ·
+      │    │         render 0     a + b             ·                       ·
+      │    │         render 1     a                 ·                       ·
+      │    │         render 2     b                 ·                       ·
+      │    └── scan  ·            ·                 (a, b)                  ·
+      │              table        pairs@primary     ·                       ·
+      │              spans        ALL               ·                       ·
+      └── scan       ·            ·                 (n, sq)                 ·
+·                    table        square@primary    ·                       ·
+·                    spans        ALL               ·                       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq WHERE pairs.b%2 <> square.sq%2
 ----
-render                    ·         ·                    (a, b, n, sq)           ·
- │                        render 0  a                    ·                       ·
- │                        render 1  b                    ·                       ·
- │                        render 2  n                    ·                       ·
- │                        render 3  sq                   ·                       ·
- └── filter               ·         ·                    (column6, a, b, n, sq)  ·
-      │                   filter    (b % 2) != (sq % 2)  ·                       ·
-      └── hash-join       ·         ·                    (column6, a, b, n, sq)  ·
-           │              type      full outer           ·                       ·
-           │              equality  (column6) = (sq)     ·                       ·
-           ├── render     ·         ·                    (column6, a, b)         ·
-           │    │         render 0  a + b                ·                       ·
-           │    │         render 1  a                    ·                       ·
-           │    │         render 2  b                    ·                       ·
-           │    └── scan  ·         ·                    (a, b)                  ·
-           │              table     pairs@primary        ·                       ·
-           │              spans     ALL                  ·                       ·
-           └── scan       ·         ·                    (n, sq)                 ·
-·                         table     square@primary       ·                       ·
-·                         spans     ALL                  ·                       ·
+·                         distributed  false                ·                       ·
+·                         vectorized   false                ·                       ·
+render                    ·            ·                    (a, b, n, sq)           ·
+ │                        render 0     a                    ·                       ·
+ │                        render 1     b                    ·                       ·
+ │                        render 2     n                    ·                       ·
+ │                        render 3     sq                   ·                       ·
+ └── filter               ·            ·                    (column6, a, b, n, sq)  ·
+      │                   filter       (b % 2) != (sq % 2)  ·                       ·
+      └── hash-join       ·            ·                    (column6, a, b, n, sq)  ·
+           │              type         full outer           ·                       ·
+           │              equality     (column6) = (sq)     ·                       ·
+           ├── render     ·            ·                    (column6, a, b)         ·
+           │    │         render 0     a + b                ·                       ·
+           │    │         render 1     a                    ·                       ·
+           │    │         render 2     b                    ·                       ·
+           │    └── scan  ·            ·                    (a, b)                  ·
+           │              table        pairs@primary        ·                       ·
+           │              spans        ALL                  ·                       ·
+           └── scan       ·            ·                    (n, sq)                 ·
+·                         table        square@primary       ·                       ·
+·                         spans        ALL                  ·                       ·
 
 # Filter propagation through outer joins.
 
@@ -526,20 +563,22 @@ SELECT *
  WHERE b > 1 AND (n IS NULL OR n > 1) AND (n IS NULL OR a  < sq)
 ]
 ----
-filter          ·         ·
- │              filter    ((n IS NULL) OR (n > 1)) AND ((n IS NULL) OR (a < sq))
- └── hash-join  ·         ·
-      │         type      left outer
-      │         equality  (b) = (sq)
-      │         pred      a > 1
-      ├── scan  ·         ·
-      │         table     pairs@primary
-      │         spans     ALL
-      │         filter    b > 1
-      └── scan  ·         ·
-·               table     square@primary
-·               spans     -/5/#
-·               filter    sq > 1
+·               distributed  false
+·               vectorized   false
+filter          ·            ·
+ │              filter       ((n IS NULL) OR (n > 1)) AND ((n IS NULL) OR (a < sq))
+ └── hash-join  ·            ·
+      │         type         left outer
+      │         equality     (b) = (sq)
+      │         pred         a > 1
+      ├── scan  ·            ·
+      │         table        pairs@primary
+      │         spans        ALL
+      │         filter       b > 1
+      └── scan  ·            ·
+·               table        square@primary
+·               spans        -/5/#
+·               filter       sq > 1
 
 query TTT
 SELECT tree, field, description FROM [
@@ -549,24 +588,26 @@ SELECT *
  WHERE (a IS NULL OR a > 2) AND n > 1 AND (a IS NULL OR a < sq)
 ]
 ----
-render               ·         ·
- │                   render 0  a
- │                   render 1  b
- │                   render 2  n
- │                   render 3  sq
- └── filter          ·         ·
-      │              filter    ((a IS NULL) OR (a > 2)) AND ((a IS NULL) OR (a < sq))
-      └── hash-join  ·         ·
-           │         type      left outer
-           │         equality  (sq) = (b)
-           │         pred      n < 6
-           ├── scan  ·         ·
-           │         table     square@primary
-           │         spans     /2-
-           └── scan  ·         ·
-·                    table     pairs@primary
-·                    spans     ALL
-·                    filter    a > 1
+·                    distributed  false
+·                    vectorized   false
+render               ·            ·
+ │                   render 0     a
+ │                   render 1     b
+ │                   render 2     n
+ │                   render 3     sq
+ └── filter          ·            ·
+      │              filter       ((a IS NULL) OR (a > 2)) AND ((a IS NULL) OR (a < sq))
+      └── hash-join  ·            ·
+           │         type         left outer
+           │         equality     (sq) = (b)
+           │         pred         n < 6
+           ├── scan  ·            ·
+           │         table        square@primary
+           │         spans        /2-
+           └── scan  ·            ·
+·                    table        pairs@primary
+·                    spans        ALL
+·                    filter       a > 1
 
 # The simpler plan for an inner join, to compare.
 query TTT
@@ -577,17 +618,19 @@ SELECT *
  WHERE (a IS NULL OR a > 2) AND n > 1 AND (a IS NULL OR a < sq)
 ]
 ----
-hash-join  ·         ·
- │         type      inner
- │         equality  (b) = (sq)
- ├── scan  ·         ·
- │         table     pairs@primary
- │         spans     ALL
- │         filter    ((a > 1) AND ((a IS NULL) OR (a > 2))) AND ((a IS NULL) OR (a < b))
- └── scan  ·         ·
-·          table     square@primary
-·          spans     /2-/5/#
-·          parallel  ·
+·          distributed  false
+·          vectorized   false
+hash-join  ·            ·
+ │         type         inner
+ │         equality     (b) = (sq)
+ ├── scan  ·            ·
+ │         table        pairs@primary
+ │         spans        ALL
+ │         filter       ((a > 1) AND ((a IS NULL) OR (a > 2))) AND ((a IS NULL) OR (a < b))
+ └── scan  ·            ·
+·          table        square@primary
+·          spans        /2-/5/#
+·          parallel     ·
 
 
 statement ok
@@ -599,17 +642,19 @@ CREATE TABLE t2 (col3 INT, y INT, x INT, col4 INT)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x FROM t1 NATURAL JOIN (SELECT * FROM t2)
 ----
-render          ·         ·                (x)           ·
- │              render 0  x                ·             ·
- └── hash-join  ·         ·                (x, y, y, x)  ·
-      │         type      inner            ·             ·
-      │         equality  (x, y) = (x, y)  ·             ·
-      ├── scan  ·         ·                (x, y)        ·
-      │         table     t1@primary       ·             ·
-      │         spans     ALL              ·             ·
-      └── scan  ·         ·                (y, x)        ·
-·               table     t2@primary       ·             ·
-·               spans     ALL              ·             ·
+·               distributed  false            ·             ·
+·               vectorized   false            ·             ·
+render          ·            ·                (x)           ·
+ │              render 0     x                ·             ·
+ └── hash-join  ·            ·                (x, y, y, x)  ·
+      │         type         inner            ·             ·
+      │         equality     (x, y) = (x, y)  ·             ·
+      ├── scan  ·            ·                (x, y)        ·
+      │         table        t1@primary       ·             ·
+      │         spans        ALL              ·             ·
+      └── scan  ·            ·                (y, x)        ·
+·               table        t2@primary       ·             ·
+·               spans        ALL              ·             ·
 
 # Tests for merge join ordering information.
 statement ok
@@ -627,6 +672,8 @@ CREATE TABLE pkBAD (a INT, b INT, c INT, d INT, PRIMARY KEY(b,a,d))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBA AS l JOIN pkBC AS r ON l.a = r.a AND l.b = r.b AND l.c = r.c
 ----
+·          distributed         false                  ·                         ·
+·          vectorized          false                  ·                         ·
 hash-join  ·                   ·                      (a, b, c, d, a, b, c, d)  ·
  │         type                inner                  ·                         ·
  │         equality            (a, b, c) = (a, b, c)  ·                         ·
@@ -642,6 +689,8 @@ hash-join  ·                   ·                      (a, b, c, d, a, b, c, d)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBA NATURAL JOIN pkBAD
 ----
+·               distributed         false                        ·                         ·
+·               vectorized          false                        ·                         ·
 render          ·                   ·                            (a, b, c, d)              ·
  │              render 0            a                            ·                         ·
  │              render 1            b                            ·                         ·
@@ -662,6 +711,8 @@ render          ·                   ·                            (a, b, c, d) 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBAC AS l JOIN pkBAC AS r USING(a, b, c)
 ----
+·                distributed         false                       ·                         ·
+·                vectorized          true                        ·                         ·
 render           ·                   ·                           (a, b, c, d, d)           ·
  │               render 0            a                           ·                         ·
  │               render 1            b                           ·                         ·
@@ -684,6 +735,8 @@ render           ·                   ·                           (a, b, c, d, 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBAC AS l JOIN pkBAD AS r ON l.c = r.d AND l.a = r.a AND l.b = r.b
 ----
+·           distributed         false                       ·                         ·
+·           vectorized          true                        ·                         ·
 merge-join  ·                   ·                           (a, b, c, d, a, b, c, d)  ·
  │          type                inner                       ·                         ·
  │          equality            (b, a, c) = (b, a, d)       ·                         ·
@@ -707,76 +760,86 @@ CREATE TABLE str2 (a INT PRIMARY KEY, s STRING COLLATE en_u_ks_level1)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 INNER JOIN str2 USING(s)
 ----
-render          ·         ·             (s, s, s)  ·
- │              render 0  s             ·          ·
- │              render 1  s             ·          ·
- │              render 2  s             ·          ·
- └── hash-join  ·         ·             (s, s)     ·
-      │         type      inner         ·          ·
-      │         equality  (s) = (s)     ·          ·
-      ├── scan  ·         ·             (s)        ·
-      │         table     str1@primary  ·          ·
-      │         spans     ALL           ·          ·
-      └── scan  ·         ·             (s)        ·
-·               table     str2@primary  ·          ·
-·               spans     ALL           ·          ·
+·               distributed  false         ·          ·
+·               vectorized   false         ·          ·
+render          ·            ·             (s, s, s)  ·
+ │              render 0     s             ·          ·
+ │              render 1     s             ·          ·
+ │              render 2     s             ·          ·
+ └── hash-join  ·            ·             (s, s)     ·
+      │         type         inner         ·          ·
+      │         equality     (s) = (s)     ·          ·
+      ├── scan  ·            ·             (s)        ·
+      │         table        str1@primary  ·          ·
+      │         spans        ALL           ·          ·
+      └── scan  ·            ·             (s)        ·
+·               table        str2@primary  ·          ·
+·               spans        ALL           ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 LEFT OUTER JOIN str2 USING(s)
 ----
-render          ·         ·             (s, s, s)  ·
- │              render 0  s             ·          ·
- │              render 1  s             ·          ·
- │              render 2  s             ·          ·
- └── hash-join  ·         ·             (s, s)     ·
-      │         type      left outer    ·          ·
-      │         equality  (s) = (s)     ·          ·
-      ├── scan  ·         ·             (s)        ·
-      │         table     str1@primary  ·          ·
-      │         spans     ALL           ·          ·
-      └── scan  ·         ·             (s)        ·
-·               table     str2@primary  ·          ·
-·               spans     ALL           ·          ·
+·               distributed  false         ·          ·
+·               vectorized   false         ·          ·
+render          ·            ·             (s, s, s)  ·
+ │              render 0     s             ·          ·
+ │              render 1     s             ·          ·
+ │              render 2     s             ·          ·
+ └── hash-join  ·            ·             (s, s)     ·
+      │         type         left outer    ·          ·
+      │         equality     (s) = (s)     ·          ·
+      ├── scan  ·            ·             (s)        ·
+      │         table        str1@primary  ·          ·
+      │         spans        ALL           ·          ·
+      └── scan  ·            ·             (s)        ·
+·               table        str2@primary  ·          ·
+·               spans        ALL           ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 RIGHT OUTER JOIN str2 USING(s)
 ----
-render          ·         ·               (s, s, s)  ·
- │              render 0  COALESCE(s, s)  ·          ·
- │              render 1  s               ·          ·
- │              render 2  s               ·          ·
- └── hash-join  ·         ·               (s, s)     ·
-      │         type      right outer     ·          ·
-      │         equality  (s) = (s)       ·          ·
-      ├── scan  ·         ·               (s)        ·
-      │         table     str1@primary    ·          ·
-      │         spans     ALL             ·          ·
-      └── scan  ·         ·               (s)        ·
-·               table     str2@primary    ·          ·
-·               spans     ALL             ·          ·
+·               distributed  false           ·          ·
+·               vectorized   false           ·          ·
+render          ·            ·               (s, s, s)  ·
+ │              render 0     COALESCE(s, s)  ·          ·
+ │              render 1     s               ·          ·
+ │              render 2     s               ·          ·
+ └── hash-join  ·            ·               (s, s)     ·
+      │         type         right outer     ·          ·
+      │         equality     (s) = (s)       ·          ·
+      ├── scan  ·            ·               (s)        ·
+      │         table        str1@primary    ·          ·
+      │         spans        ALL             ·          ·
+      └── scan  ·            ·               (s)        ·
+·               table        str2@primary    ·          ·
+·               spans        ALL             ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 FULL OUTER JOIN str2 USING(s)
 ----
-render          ·         ·               (s, s, s)  ·
- │              render 0  COALESCE(s, s)  ·          ·
- │              render 1  s               ·          ·
- │              render 2  s               ·          ·
- └── hash-join  ·         ·               (s, s)     ·
-      │         type      full outer      ·          ·
-      │         equality  (s) = (s)       ·          ·
-      ├── scan  ·         ·               (s)        ·
-      │         table     str1@primary    ·          ·
-      │         spans     ALL             ·          ·
-      └── scan  ·         ·               (s)        ·
-·               table     str2@primary    ·          ·
-·               spans     ALL             ·          ·
+·               distributed  false           ·          ·
+·               vectorized   false           ·          ·
+render          ·            ·               (s, s, s)  ·
+ │              render 0     COALESCE(s, s)  ·          ·
+ │              render 1     s               ·          ·
+ │              render 2     s               ·          ·
+ └── hash-join  ·            ·               (s, s)     ·
+      │         type         full outer      ·          ·
+      │         equality     (s) = (s)       ·          ·
+      ├── scan  ·            ·               (s)        ·
+      │         table        str1@primary    ·          ·
+      │         spans        ALL             ·          ·
+      └── scan  ·            ·               (s)        ·
+·               table        str2@primary    ·          ·
+·               spans        ALL             ·          ·
 
 # Verify that we resolve the merged column a to str2.a but use IFNULL for
 # column s which is a collated string.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM str1 RIGHT OUTER JOIN str2 USING(a, s)
 ----
+·               distributed         false            ·             ·
+·               vectorized          false            ·             ·
 render          ·                   ·                (a, s)        ·
  │              render 0            a                ·             ·
  │              render 1            COALESCE(s, s)   ·             ·
@@ -802,6 +865,8 @@ CREATE TABLE xyv (x INT, y INT, v INT, PRIMARY KEY(x,y,v))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv USING(x, y) WHERE x > 2
 ----
+·                distributed     false              ·                   ·
+·                vectorized      false              ·                   ·
 render           ·               ·                  (x, y, u, v)        ·
  │               render 0        x                  ·                   ·
  │               render 1        y                  ·                   ·
@@ -821,6 +886,8 @@ render           ·               ·                  (x, y, u, v)        ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu LEFT OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
+·                distributed     false              ·                   ·
+·                vectorized      false              ·                   ·
 render           ·               ·                  (x, y, u, v)        ·
  │               render 0        x                  ·                   ·
  │               render 1        y                  ·                   ·
@@ -840,6 +907,8 @@ render           ·               ·                  (x, y, u, v)        ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
+·                distributed     false              ·                   ·
+·                vectorized      false              ·                   ·
 render           ·               ·                  (x, y, u, v)        ·
  │               render 0        x                  ·                   ·
  │               render 1        y                  ·                   ·
@@ -859,6 +928,8 @@ render           ·               ·                  (x, y, u, v)        ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu FULL OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
+·                     distributed     false              ·                   ·
+·                     vectorized      false              ·                   ·
 filter                ·               ·                  (x, y, u, v)        ·
  │                    filter          x > 2              ·                   ·
  └── render           ·               ·                  (x, y, u, v)        ·
@@ -881,6 +952,8 @@ filter                ·               ·                  (x, y, u, v)        �
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y WHERE xyu.x = 1 AND xyu.y < 10
 ----
+·           distributed     false              ·                   ·
+·           vectorized      false              ·                   ·
 merge-join  ·               ·                  (x, y, u, x, y, v)  ·
  │          type            inner              ·                   ·
  │          equality        (x, y) = (x, y)    ·                   ·
@@ -895,6 +968,8 @@ merge-join  ·               ·                  (x, y, u, x, y, v)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
+·           distributed     false              ·                   ·
+·           vectorized      false              ·                   ·
 merge-join  ·               ·                  (x, y, u, x, y, v)  ·
  │          type            inner              ·                   ·
  │          equality        (x, y) = (x, y)    ·                   ·
@@ -909,6 +984,8 @@ merge-join  ·               ·                  (x, y, u, x, y, v)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu LEFT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
+·           distributed     false              ·                   ·
+·           vectorized      false              ·                   ·
 merge-join  ·               ·                  (x, y, u, x, y, v)  ·
  │          type            left outer         ·                   ·
  │          equality        (x, y) = (x, y)    ·                   ·
@@ -923,6 +1000,8 @@ merge-join  ·               ·                  (x, y, u, x, y, v)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
+·           distributed     false              ·                   ·
+·           vectorized      false              ·                   ·
 merge-join  ·               ·                  (x, y, u, x, y, v)  ·
  │          type            right outer        ·                   ·
  │          equality        (x, y) = (x, y)    ·                   ·
@@ -940,6 +1019,8 @@ merge-join  ·               ·                  (x, y, u, x, y, v)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
+·                distributed     false              ·                   ·
+·                vectorized      false              ·                   ·
 render           ·               ·                  (x, y, u, v)        ·
  │               render 0        x                  ·                   ·
  │               render 1        y                  ·                   ·
@@ -959,6 +1040,8 @@ render           ·               ·                  (x, y, u, v)        ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu RIGHT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
+·                distributed     false              ·                   ·
+·                vectorized      false              ·                   ·
 render           ·               ·                  (x, y, u, v)        ·
  │               render 0        x                  ·                   ·
  │               render 1        y                  ·                   ·
@@ -978,6 +1061,8 @@ render           ·               ·                  (x, y, u, v)        ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu FULL OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
+·                     distributed     false              ·                   ·
+·                     vectorized      false              ·                   ·
 filter                ·               ·                  (x, y, u, v)        ·
  │                    filter          x > 2              ·                   ·
  └── render           ·               ·                  (x, y, u, v)        ·
@@ -999,6 +1084,8 @@ filter                ·               ·                  (x, y, u, v)        �
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
+·           distributed     false              ·                   ·
+·           vectorized      false              ·                   ·
 merge-join  ·               ·                  (x, y, u, x, y, v)  ·
  │          type            left outer         ·                   ·
  │          equality        (x, y) = (x, y)    ·                   ·
@@ -1013,6 +1100,8 @@ merge-join  ·               ·                  (x, y, u, x, y, v)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
+·           distributed     false              ·                   ·
+·           vectorized      false              ·                   ·
 merge-join  ·               ·                  (x, y, u, x, y, v)  ·
  │          type            right outer        ·                   ·
  │          equality        (x, y) = (x, y)    ·                   ·
@@ -1028,6 +1117,8 @@ merge-join  ·               ·                  (x, y, u, x, y, v)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu JOIN xyv USING(x, y) WHERE (x, y, u) > (1, 2, 3)
 ----
+·                distributed     false              ·                   ·
+·                vectorized      false              ·                   ·
 render           ·               ·                  (x, y, u, v)        ·
  │               render 0        x                  ·                   ·
  │               render 1        y                  ·                   ·
@@ -1058,6 +1149,8 @@ CREATE TABLE r (a INT PRIMARY KEY)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l LEFT OUTER JOIN r USING(a) WHERE a = 3;
 ----
+·                distributed         false       ·       ·
+·                vectorized          true        ·       ·
 render           ·                   ·           (a)     ·
  │               render 0            a           ·       ·
  └── merge-join  ·                   ·           (a, a)  ·
@@ -1076,6 +1169,8 @@ render           ·                   ·           (a)     ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l LEFT OUTER JOIN r ON l.a = r.a WHERE l.a = 3;
 ----
+·           distributed         false       ·       ·
+·           vectorized          true        ·       ·
 merge-join  ·                   ·           (a, a)  ·
  │          type                left outer  ·       ·
  │          equality            (a) = (a)   ·       ·
@@ -1092,6 +1187,8 @@ merge-join  ·                   ·           (a, a)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l RIGHT OUTER JOIN r USING(a) WHERE a = 3;
 ----
+·                distributed         false        ·       ·
+·                vectorized          true         ·       ·
 render           ·                   ·            (a)     ·
  │               render 0            a            ·       ·
  └── merge-join  ·                   ·            (a, a)  ·
@@ -1110,6 +1207,8 @@ render           ·                   ·            (a)     ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l RIGHT OUTER JOIN r ON l.a = r.a WHERE r.a = 3;
 ----
+·           distributed         false        ·       ·
+·           vectorized          true         ·       ·
 merge-join  ·                   ·            (a, a)  ·
  │          type                right outer  ·       ·
  │          equality            (a) = (a)    ·       ·
@@ -1146,6 +1245,8 @@ CREATE TABLE abg (
 query TTT
 EXPLAIN SELECT * FROM abcdef join (select * from abg) USING (a,b) WHERE ((a,b)>(1,2) OR ((a,b)=(1,2) AND c < 6) OR ((a,b,c)=(1,2,6) AND d > 8))
 ----
+·                distributed         false
+·                vectorized          false
 render           ·                   ·
  └── merge-join  ·                   ·
       │          type                inner
@@ -1183,21 +1284,23 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo NATURAL JOIN bar
 ]
 ----
-render          ·         ·
- │              render 0  a
- │              render 1  b
- │              render 2  c
- │              render 3  d
- └── hash-join  ·         ·
-      │         type      inner
-      │         equality  (a, c) = (a, c)
-      │         pred      (b = b) AND (d = d)
-      ├── scan  ·         ·
-      │         table     foo@primary
-      │         spans     ALL
-      └── scan  ·         ·
-·               table     bar@primary
-·               spans     ALL
+·               distributed  false
+·               vectorized   false
+render          ·            ·
+ │              render 0     a
+ │              render 1     b
+ │              render 2     c
+ │              render 3     d
+ └── hash-join  ·            ·
+      │         type         inner
+      │         equality     (a, c) = (a, c)
+      │         pred         (b = b) AND (d = d)
+      ├── scan  ·            ·
+      │         table        foo@primary
+      │         spans        ALL
+      └── scan  ·            ·
+·               table        bar@primary
+·               spans        ALL
 
 # b can't be an equality column.
 query TTT
@@ -1205,23 +1308,25 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar USING (b)
 ]
 ----
-render          ·         ·
- │              render 0  b
- │              render 1  a
- │              render 2  c
- │              render 3  d
- │              render 4  a
- │              render 5  c
- │              render 6  d
- └── hash-join  ·         ·
-      │         type      inner
-      │         pred      b = b
-      ├── scan  ·         ·
-      │         table     foo@primary
-      │         spans     ALL
-      └── scan  ·         ·
-·               table     bar@primary
-·               spans     ALL
+·               distributed  false
+·               vectorized   false
+render          ·            ·
+ │              render 0     b
+ │              render 1     a
+ │              render 2     c
+ │              render 3     d
+ │              render 4     a
+ │              render 5     c
+ │              render 6     d
+ └── hash-join  ·            ·
+      │         type         inner
+      │         pred         b = b
+      ├── scan  ·            ·
+      │         table        foo@primary
+      │         spans        ALL
+      └── scan  ·            ·
+·               table        bar@primary
+·               spans        ALL
 
 # Only a can be an equality column.
 query TTT
@@ -1229,23 +1334,25 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar USING (a, b)
 ]
 ----
-render          ·         ·
- │              render 0  a
- │              render 1  b
- │              render 2  c
- │              render 3  d
- │              render 4  c
- │              render 5  d
- └── hash-join  ·         ·
-      │         type      inner
-      │         equality  (a) = (a)
-      │         pred      b = b
-      ├── scan  ·         ·
-      │         table     foo@primary
-      │         spans     ALL
-      └── scan  ·         ·
-·               table     bar@primary
-·               spans     ALL
+·               distributed  false
+·               vectorized   false
+render          ·            ·
+ │              render 0     a
+ │              render 1     b
+ │              render 2     c
+ │              render 3     d
+ │              render 4     c
+ │              render 5     d
+ └── hash-join  ·            ·
+      │         type         inner
+      │         equality     (a) = (a)
+      │         pred         b = b
+      ├── scan  ·            ·
+      │         table        foo@primary
+      │         spans        ALL
+      └── scan  ·            ·
+·               table        bar@primary
+·               spans        ALL
 
 # Only a and c can be equality columns.
 query TTT
@@ -1253,22 +1360,24 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar USING (a, b, c)
 ]
 ----
-render          ·         ·
- │              render 0  a
- │              render 1  b
- │              render 2  c
- │              render 3  d
- │              render 4  d
- └── hash-join  ·         ·
-      │         type      inner
-      │         equality  (a, c) = (a, c)
-      │         pred      b = b
-      ├── scan  ·         ·
-      │         table     foo@primary
-      │         spans     ALL
-      └── scan  ·         ·
-·               table     bar@primary
-·               spans     ALL
+·               distributed  false
+·               vectorized   false
+render          ·            ·
+ │              render 0     a
+ │              render 1     b
+ │              render 2     c
+ │              render 3     d
+ │              render 4     d
+ └── hash-join  ·            ·
+      │         type         inner
+      │         equality     (a, c) = (a, c)
+      │         pred         b = b
+      ├── scan  ·            ·
+      │         table        foo@primary
+      │         spans        ALL
+      └── scan  ·            ·
+·               table        bar@primary
+·               spans        ALL
 
 # b can't be an equality column.
 query TTT
@@ -1276,15 +1385,17 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar ON foo.b = bar.b
 ]
 ----
-hash-join  ·      ·
- │         type   inner
- │         pred   b = b
- ├── scan  ·      ·
- │         table  foo@primary
- │         spans  ALL
- └── scan  ·      ·
-·          table  bar@primary
-·          spans  ALL
+·          distributed  false
+·          vectorized   false
+hash-join  ·            ·
+ │         type         inner
+ │         pred         b = b
+ ├── scan  ·            ·
+ │         table        foo@primary
+ │         spans        ALL
+ └── scan  ·            ·
+·          table        bar@primary
+·          spans        ALL
 
 # Only a can be an equality column.
 query TTT
@@ -1292,31 +1403,35 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar ON foo.a = bar.a AND foo.b = bar.b
 ]
 ----
-hash-join  ·         ·
- │         type      inner
- │         equality  (a) = (a)
- │         pred      b = b
- ├── scan  ·         ·
- │         table     foo@primary
- │         spans     ALL
- └── scan  ·         ·
-·          table     bar@primary
-·          spans     ALL
+·          distributed  false
+·          vectorized   false
+hash-join  ·            ·
+ │         type         inner
+ │         equality     (a) = (a)
+ │         pred         b = b
+ ├── scan  ·            ·
+ │         table        foo@primary
+ │         spans        ALL
+ └── scan  ·            ·
+·          table        bar@primary
+·          spans        ALL
 
 query TTT
 SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo, bar WHERE foo.b = bar.b
 ]
 ----
-hash-join  ·      ·
- │         type   inner
- │         pred   b = b
- ├── scan  ·      ·
- │         table  foo@primary
- │         spans  ALL
- └── scan  ·      ·
-·          table  bar@primary
-·          spans  ALL
+·          distributed  false
+·          vectorized   false
+hash-join  ·            ·
+ │         type         inner
+ │         pred         b = b
+ ├── scan  ·            ·
+ │         table        foo@primary
+ │         spans        ALL
+ └── scan  ·            ·
+·          table        bar@primary
+·          spans        ALL
 
 # Only a can be an equality column.
 query TTT
@@ -1324,32 +1439,36 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo, bar WHERE foo.a = bar.a AND foo.b = bar.b
 ]
 ----
-hash-join  ·         ·
- │         type      inner
- │         equality  (a) = (a)
- │         pred      b = b
- ├── scan  ·         ·
- │         table     foo@primary
- │         spans     ALL
- └── scan  ·         ·
-·          table     bar@primary
-·          spans     ALL
+·          distributed  false
+·          vectorized   false
+hash-join  ·            ·
+ │         type         inner
+ │         equality     (a) = (a)
+ │         pred         b = b
+ ├── scan  ·            ·
+ │         table        foo@primary
+ │         spans        ALL
+ └── scan  ·            ·
+·          table        bar@primary
+·          spans        ALL
 
 # Only a and c can be equality columns.
 query TTT
 EXPLAIN SELECT * FROM foo JOIN bar USING (a,b) WHERE foo.c = bar.c AND foo.d = bar.d
 ----
-render          ·         ·
- └── hash-join  ·         ·
-      │         type      inner
-      │         equality  (a, c) = (a, c)
-      │         pred      (b = b) AND (d = d)
-      ├── scan  ·         ·
-      │         table     foo@primary
-      │         spans     ALL
-      └── scan  ·         ·
-·               table     bar@primary
-·               spans     ALL
+·               distributed  false
+·               vectorized   false
+render          ·            ·
+ └── hash-join  ·            ·
+      │         type         inner
+      │         equality     (a, c) = (a, c)
+      │         pred         (b = b) AND (d = d)
+      ├── scan  ·            ·
+      │         table        foo@primary
+      │         spans        ALL
+      └── scan  ·            ·
+·               table        bar@primary
+·               spans        ALL
 
 # Zigzag join tests.
 statement ok
@@ -1369,13 +1488,15 @@ SET enable_zigzag_join = false
 query TTT
 EXPLAIN SELECT a,b,c FROM zigzag WHERE b = 5 AND c = 6.0
 ----
-filter           ·       ·
- │               filter  c = 6.0
- └── index-join  ·       ·
-      │          table   zigzag@primary
-      └── scan   ·       ·
-·                table   zigzag@b_idx
-·                spans   /5-/6
+·                distributed  false
+·                vectorized   true
+filter           ·            ·
+ │               filter       c = 6.0
+ └── index-join  ·            ·
+      │          table        zigzag@primary
+      └── scan   ·            ·
+·                table        zigzag@b_idx
+·                spans        /5-/6
 
 # Enable zigzag joins.
 statement ok
@@ -1385,21 +1506,25 @@ SET enable_zigzag_join = true
 query TTT
 EXPLAIN SELECT a,b,c FROM zigzag WHERE b = 5 AND c = 6.0
 ----
-zigzag-join  ·          ·
- │           type       inner
- │           pred       (@2 = 5) AND (@3 = 6.0)
- ├── scan    ·          ·
- │           table      zigzag@b_idx
- │           fixedvals  1 column
- └── scan    ·          ·
-·            table      zigzag@c_idx
-·            fixedvals  1 column
+·            distributed  false
+·            vectorized   false
+zigzag-join  ·            ·
+ │           type         inner
+ │           pred         (@2 = 5) AND (@3 = 6.0)
+ ├── scan    ·            ·
+ │           table        zigzag@b_idx
+ │           fixedvals    1 column
+ └── scan    ·            ·
+·            table        zigzag@c_idx
+·            fixedvals    1 column
 
 
 # Zigzag join nested inside a lookup.
 query TTT
 EXPLAIN SELECT a,b,c,d FROM zigzag WHERE b = 5 AND c = 6.0
 ----
+·                 distributed            false
+·                 vectorized             false
 lookup-join       ·                      ·
  │                table                  zigzag@primary
  │                type                   inner
@@ -1419,6 +1544,8 @@ lookup-join       ·                      ·
 query TTT
 EXPLAIN SELECT a,b,c,d FROM zigzag WHERE b = 5 AND c = 6.0 AND d > 4
 ----
+·                 distributed            false
+·                 vectorized             false
 lookup-join       ·                      ·
  │                table                  zigzag@primary
  │                type                   inner
@@ -1452,18 +1579,22 @@ CREATE TABLE zigzag2 (
 query TTT
 EXPLAIN SELECT * FROM zigzag2 WHERE a = 1 AND b = 2 AND c IS NULL
 ----
-filter           ·       ·
- │               filter  c IS NULL
- └── index-join  ·       ·
-      │          table   zigzag2@primary
-      └── scan   ·       ·
-·                table   zigzag2@a_b_idx
-·                spans   /1/2-/1/3
+·                distributed  false
+·                vectorized   true
+filter           ·            ·
+ │               filter       c IS NULL
+ └── index-join  ·            ·
+      │          table        zigzag2@primary
+      └── scan   ·            ·
+·                table        zigzag2@a_b_idx
+·                spans        /1/2-/1/3
 
 # Test that we can force a merge join.
 query TTT
 EXPLAIN SELECT * FROM onecolumn INNER MERGE JOIN twocolumn USING(x)
 ----
+·                    distributed     false
+·                    vectorized      false
 render               ·               ·
  └── merge-join      ·               ·
       │              type            inner
@@ -1484,6 +1615,8 @@ render               ·               ·
 query TTT
 EXPLAIN SELECT * FROM onecolumn NATURAL INNER MERGE JOIN twocolumn
 ----
+·                    distributed     false
+·                    vectorized      false
 render               ·               ·
  └── merge-join      ·               ·
       │              type            inner
@@ -1504,6 +1637,8 @@ render               ·               ·
 query TTT
 EXPLAIN SELECT * FROM onecolumn CROSS MERGE JOIN twocolumn WHERE onecolumn.x = twocolumn.x
 ----
+·               distributed     false
+·               vectorized      false
 merge-join      ·               ·
  │              type            inner
  │              equality        (x) = (x)
@@ -1532,6 +1667,8 @@ EXPLAIN SELECT * FROM onecolumn INNER MERGE JOIN twocolumn ON onecolumn.x > twoc
 query TTT
 EXPLAIN SELECT * FROM cards LEFT OUTER HASH JOIN customers ON customers.id = cards.cust
 ----
+·          distributed         false
+·          vectorized          false
 hash-join  ·                   ·
  │         type                inner
  │         equality            (cust) = (id)

--- a/pkg/sql/opt/exec/execbuilder/testdata/join_order
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join_order
@@ -35,6 +35,8 @@ SET CLUSTER SETTING sql.defaults.reorder_joins_limit = -1
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc, bx, cy WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
+·                    distributed         false            ·                         ·
+·                    vectorized          false            ·                         ·
 render               ·                   ·                (a, b, c, d, b, x, c, y)  ·
  │                   render 0            a                ·                         ·
  │                   render 1            b                ·                         ·
@@ -67,6 +69,8 @@ SET reorder_joins_limit = 3
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc, bx, cy WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
+·                      distributed            false        ·                         ·
+·                      vectorized             true         ·                         ·
 render                 ·                      ·            (a, b, c, d, b, x, c, y)  ·
  │                     render 0               a            ·                         ·
  │                     render 1               b            ·                         ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -7,16 +7,18 @@ CREATE TABLE t (k INT PRIMARY KEY, v INT, w INT, INDEX(v))
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE v > 4 AND v < 8 AND w > 30 ORDER BY v LIMIT 2
 ----
-tree                  field   description  columns    ordering
-limit                 ·       ·            (k, v, w)  +v
- │                    count   2            ·          ·
- └── filter           ·       ·            (k, v, w)  +v
-      │               filter  w > 30       ·          ·
-      └── index-join  ·       ·            (k, v, w)  +v
-           │          table   t@primary    ·          ·
-           └── scan   ·       ·            (k, v)     +v
-·                     table   t@t_v_idx    ·          ·
-·                     spans   /5-/8        ·          ·
+tree                  field        description  columns    ordering
+·                     distributed  false        ·          ·
+·                     vectorized   true         ·          ·
+limit                 ·            ·            (k, v, w)  +v
+ │                    count        2            ·          ·
+ └── filter           ·            ·            (k, v, w)  +v
+      │               filter       w > 30       ·          ·
+      └── index-join  ·            ·            (k, v, w)  +v
+           │          table        t@primary    ·          ·
+           └── scan   ·            ·            (k, v)     +v
+·                     table        t@t_v_idx    ·          ·
+·                     spans        /5-/8        ·          ·
 
 # This kind of query can be used to work around memory usage limits. We need to
 # choose the "hard" limit of 100 over the "soft" limit of 25 (with the hard
@@ -25,6 +27,8 @@ query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT DISTINCT w FROM (SELECT w FROM t ORDER BY w LIMIT 100) ORDER BY w LIMIT 25
 ----
 tree                      field        description  columns  ordering
+·                         distributed  false        ·        ·
+·                         vectorized   true         ·        ·
 limit                     ·            ·            (w)      weak-key(w); +w
  │                        count        25           ·        ·
  └── distinct             ·            ·            (w)      weak-key(w); +w
@@ -41,43 +45,53 @@ limit                     ·            ·            (w)      weak-key(w); +w
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, v FROM t ORDER BY k LIMIT 5
 ----
-scan  ·      ·          (k, v)  +k
-·     table  t@primary  ·       ·
-·     spans  ALL        ·       ·
-·     limit  5          ·       ·
+·     distributed  false      ·       ·
+·     vectorized   true       ·       ·
+scan  ·            ·          (k, v)  +k
+·     table        t@primary  ·       ·
+·     spans        ALL        ·       ·
+·     limit        5          ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, v FROM t ORDER BY k OFFSET 5
 ----
-limit      ·       ·          (k, v)  +k
- │         offset  5          ·       ·
- └── scan  ·       ·          (k, v)  +k
-·          table   t@primary  ·       ·
-·          spans   ALL        ·       ·
+·          distributed  false      ·       ·
+·          vectorized   true       ·       ·
+limit      ·            ·          (k, v)  +k
+ │         offset       5          ·       ·
+ └── scan  ·            ·          (k, v)  +k
+·          table        t@primary  ·       ·
+·          spans        ALL        ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, v FROM t ORDER BY v LIMIT (1+4) OFFSET 1
 ----
-limit      ·       ·          (k, v)  +v
- │         offset  1          ·       ·
- └── scan  ·       ·          (k, v)  +v
-·          table   t@t_v_idx  ·       ·
-·          spans   ALL        ·       ·
-·          limit   6          ·       ·
+·          distributed  false      ·       ·
+·          vectorized   true       ·       ·
+limit      ·            ·          (k, v)  +v
+ │         offset       1          ·       ·
+ └── scan  ·            ·          (k, v)  +v
+·          table        t@t_v_idx  ·       ·
+·          spans        ALL        ·       ·
+·          limit        6          ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, v FROM t ORDER BY v DESC LIMIT (1+4) OFFSET 1
 ----
-limit         ·       ·          (k, v)  -v
- │            offset  1          ·       ·
- └── revscan  ·       ·          (k, v)  -v
-·             table   t@t_v_idx  ·       ·
-·             spans   ALL        ·       ·
-·             limit   6          ·       ·
+·             distributed  false      ·       ·
+·             vectorized   true       ·       ·
+limit         ·            ·          (k, v)  -v
+ │            offset       1          ·       ·
+ └── revscan  ·            ·          (k, v)  -v
+·             table        t@t_v_idx  ·       ·
+·             spans        ALL        ·       ·
+·             limit        6          ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT sum(w) FROM t GROUP BY k, v ORDER BY v DESC LIMIT 10
 ----
+·                         distributed  false            ·                       ·
+·                         vectorized   false            ·                       ·
 render                    ·            ·                (sum)                   ·
  │                        render 0     sum              ·                       ·
  └── limit                ·            ·                (k, sum, any_not_null)  -any_not_null
@@ -97,70 +111,82 @@ render                    ·            ·                (sum)                 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM (SELECT k, v FROM t ORDER BY v LIMIT 4)
 ----
-render     ·         ·          (k)     ·
- │         render 0  k          ·       ·
- └── scan  ·         ·          (k, v)  ·
-·          table     t@t_v_idx  ·       ·
-·          spans     ALL        ·       ·
-·          limit     4          ·       ·
+·          distributed  false      ·       ·
+·          vectorized   true       ·       ·
+render     ·            ·          (k)     ·
+ │         render 0     k          ·       ·
+ └── scan  ·            ·          (k, v)  ·
+·          table        t@t_v_idx  ·       ·
+·          spans        ALL        ·       ·
+·          limit        4          ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM (SELECT k, v, w FROM t ORDER BY v LIMIT 4)
 ----
-render     ·         ·          (k)     ·
- │         render 0  k          ·       ·
- └── scan  ·         ·          (k, v)  ·
-·          table     t@t_v_idx  ·       ·
-·          spans     ALL        ·       ·
-·          limit     4          ·       ·
+·          distributed  false      ·       ·
+·          vectorized   true       ·       ·
+render     ·            ·          (k)     ·
+ │         render 0     k          ·       ·
+ └── scan  ·            ·          (k, v)  ·
+·          table        t@t_v_idx  ·       ·
+·          spans        ALL        ·       ·
+·          limit        4          ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM (SELECT k FROM t LIMIT 5) WHERE k != 2
 ----
-filter     ·       ·          (k)  ·
- │         filter  k != 2     ·    ·
- └── scan  ·       ·          (k)  ·
-·          table   t@t_v_idx  ·    ·
-·          spans   ALL        ·    ·
-·          limit   5          ·    ·
+·          distributed  false      ·    ·
+·          vectorized   true       ·    ·
+filter     ·            ·          (k)  ·
+ │         filter       k != 2     ·    ·
+ └── scan  ·            ·          (k)  ·
+·          table        t@t_v_idx  ·    ·
+·          spans        ALL        ·    ·
+·          limit        5          ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, w FROM t WHERE v >= 1 AND v <= 100 LIMIT 10
 ----
-render           ·         ·          (k, w)     ·
- │               render 0  k          ·          ·
- │               render 1  w          ·          ·
- └── index-join  ·         ·          (k, v, w)  ·
-      │          table     t@primary  ·          ·
-      └── scan   ·         ·          (k, v)     ·
-·                table     t@t_v_idx  ·          ·
-·                spans     /1-/101    ·          ·
-·                limit     10         ·          ·
+·                distributed  false      ·          ·
+·                vectorized   true       ·          ·
+render           ·            ·          (k, w)     ·
+ │               render 0     k          ·          ·
+ │               render 1     w          ·          ·
+ └── index-join  ·            ·          (k, v, w)  ·
+      │          table        t@primary  ·          ·
+      └── scan   ·            ·          (k, v)     ·
+·                table        t@t_v_idx  ·          ·
+·                spans        /1-/101    ·          ·
+·                limit        10         ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, w FROM t WHERE v >= 1 AND v <= 100 ORDER BY v LIMIT 10
 ----
-render           ·         ·          (k, w)     ·
- │               render 0  k          ·          ·
- │               render 1  w          ·          ·
- └── index-join  ·         ·          (k, v, w)  +v
-      │          table     t@primary  ·          ·
-      └── scan   ·         ·          (k, v)     +v
-·                table     t@t_v_idx  ·          ·
-·                spans     /1-/101    ·          ·
-·                limit     10         ·          ·
+·                distributed  false      ·          ·
+·                vectorized   true       ·          ·
+render           ·            ·          (k, w)     ·
+ │               render 0     k          ·          ·
+ │               render 1     w          ·          ·
+ └── index-join  ·            ·          (k, v, w)  +v
+      │          table        t@primary  ·          ·
+      └── scan   ·            ·          (k, v)     +v
+·                table        t@t_v_idx  ·          ·
+·                spans        /1-/101    ·          ·
+·                limit        10         ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, w FROM (SELECT * FROM t WHERE v >= 1 AND v <= 100 ORDER BY k LIMIT 10) ORDER BY v
 ----
-render               ·         ·                        (k, w)     ·
- │                   render 0  k                        ·          ·
- │                   render 1  w                        ·          ·
- └── sort            ·         ·                        (k, v, w)  +v
-      │              order     +v                       ·          ·
-      └── limit      ·         ·                        (k, v, w)  +k
-           │         count     10                       ·          ·
-           └── scan  ·         ·                        (k, v, w)  +k
-·                    table     t@primary                ·          ·
-·                    spans     ALL                      ·          ·
-·                    filter    (v >= 1) AND (v <= 100)  ·          ·
+·                    distributed  false                    ·          ·
+·                    vectorized   false                    ·          ·
+render               ·            ·                        (k, w)     ·
+ │                   render 0     k                        ·          ·
+ │                   render 1     w                        ·          ·
+ └── sort            ·            ·                        (k, v, w)  +v
+      │              order        +v                       ·          ·
+      └── limit      ·            ·                        (k, v, w)  +k
+           │         count        10                       ·          ·
+           └── scan  ·            ·                        (k, v, w)  +k
+·                    table        t@primary                ·          ·
+·                    spans        ALL                      ·          ·
+·                    filter       (v >= 1) AND (v <= 100)  ·          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -31,19 +31,23 @@ ALTER TABLE def INJECT STATISTICS '[
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b
 ----
-tree         field     description  columns             ordering
-lookup-join  ·         ·            (a, b, c, d, e, f)  ·
- │           table     def@primary  ·                   ·
- │           type      inner        ·                   ·
- │           equality  (b) = (f)    ·                   ·
- └── scan    ·         ·            (a, b, c)           ·
-·            table     abc@primary  ·                   ·
-·            spans     ALL          ·                   ·
+tree         field        description  columns             ordering
+·            distributed  true         ·                   ·
+·            vectorized   true         ·                   ·
+lookup-join  ·            ·            (a, b, c, d, e, f)  ·
+ │           table        def@primary  ·                   ·
+ │           type         inner        ·                   ·
+ │           equality     (b) = (f)    ·                   ·
+ └── scan    ·            ·            (a, b, c)           ·
+·            table        abc@primary  ·                   ·
+·            spans        ALL          ·                   ·
 
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b AND e = c
 ----
 tree         field                  description      columns             ordering
+·            distributed            true             ·                   ·
+·            vectorized             true             ·                   ·
 lookup-join  ·                      ·                (a, b, c, d, e, f)  ·
  │           table                  def@primary      ·                   ·
  │           type                   inner            ·                   ·
@@ -56,54 +60,62 @@ lookup-join  ·                      ·                (a, b, c, d, e, f)  ·
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b WHERE a > 1 AND e > 1
 ----
-tree         field     description  columns             ordering
-lookup-join  ·         ·            (a, b, c, d, e, f)  ·
- │           table     def@primary  ·                   ·
- │           type      inner        ·                   ·
- │           equality  (b) = (f)    ·                   ·
- │           pred      @5 > 1       ·                   ·
- └── scan    ·         ·            (a, b, c)           ·
-·            table     abc@primary  ·                   ·
-·            spans     /2-          ·                   ·
+tree         field        description  columns             ordering
+·            distributed  true         ·                   ·
+·            vectorized   true         ·                   ·
+lookup-join  ·            ·            (a, b, c, d, e, f)  ·
+ │           table        def@primary  ·                   ·
+ │           type         inner        ·                   ·
+ │           equality     (b) = (f)    ·                   ·
+ │           pred         @5 > 1       ·                   ·
+ └── scan    ·            ·            (a, b, c)           ·
+·            table        abc@primary  ·                   ·
+·            spans        /2-          ·                   ·
 
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = a WHERE f > 1
 ----
-tree         field     description  columns             ordering
-lookup-join  ·         ·            (a, b, c, d, e, f)  ·
- │           table     def@primary  ·                   ·
- │           type      inner        ·                   ·
- │           equality  (a) = (f)    ·                   ·
- │           pred      @6 > 1       ·                   ·
- └── scan    ·         ·            (a, b, c)           ·
-·            table     abc@primary  ·                   ·
-·            spans     /2-          ·                   ·
+tree         field        description  columns             ordering
+·            distributed  true         ·                   ·
+·            vectorized   true         ·                   ·
+lookup-join  ·            ·            (a, b, c, d, e, f)  ·
+ │           table        def@primary  ·                   ·
+ │           type         inner        ·                   ·
+ │           equality     (a) = (f)    ·                   ·
+ │           pred         @6 > 1       ·                   ·
+ └── scan    ·            ·            (a, b, c)           ·
+·            table        abc@primary  ·                   ·
+·            spans        /2-          ·                   ·
 
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b WHERE a >= e
 ----
-tree         field     description  columns             ordering
-lookup-join  ·         ·            (a, b, c, d, e, f)  ·
- │           table     def@primary  ·                   ·
- │           type      inner        ·                   ·
- │           equality  (b) = (f)    ·                   ·
- │           pred      @1 >= @5     ·                   ·
- └── scan    ·         ·            (a, b, c)           ·
-·            table     abc@primary  ·                   ·
-·            spans     ALL          ·                   ·
+tree         field        description  columns             ordering
+·            distributed  true         ·                   ·
+·            vectorized   true         ·                   ·
+lookup-join  ·            ·            (a, b, c, d, e, f)  ·
+ │           table        def@primary  ·                   ·
+ │           type         inner        ·                   ·
+ │           equality     (b) = (f)    ·                   ·
+ │           pred         @1 >= @5     ·                   ·
+ └── scan    ·            ·            (a, b, c)           ·
+·            table        abc@primary  ·                   ·
+·            spans        ALL          ·                   ·
 
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b AND a >= e
 ----
-tree         field     description  columns             ordering
-lookup-join  ·         ·            (a, b, c, d, e, f)  ·
- │           table     def@primary  ·                   ·
- │           type      inner        ·                   ·
- │           equality  (b) = (f)    ·                   ·
- │           pred      @1 >= @5     ·                   ·
- └── scan    ·         ·            (a, b, c)           ·
-·            table     abc@primary  ·                   ·
-·            spans     ALL          ·                   ·
+tree         field        description  columns             ordering
+·            distributed  true         ·                   ·
+·            vectorized   true         ·                   ·
+lookup-join  ·            ·            (a, b, c, d, e, f)  ·
+ │           table        def@primary  ·                   ·
+ │           type         inner        ·                   ·
+ │           equality     (b) = (f)    ·                   ·
+ │           pred         @1 >= @5     ·                   ·
+ └── scan    ·            ·            (a, b, c)           ·
+·            table        abc@primary  ·                   ·
+·            spans        ALL          ·                   ·
 
 # Verify a distsql plan.
 statement ok
@@ -137,6 +149,8 @@ NULL       /1       {1}       1
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM data WHERE c = 1) AS l NATURAL JOIN data AS r
 ----
+·                 distributed            true                         ·                         ·
+·                 vectorized             true                         ·                         ·
 render            ·                      ·                            (a, b, c, d)              ·
  │                render 0               a                            ·                         ·
  │                render 1               b                            ·                         ·
@@ -187,6 +201,8 @@ query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT DISTINCT b1.title FROM books as b1 JOIN books2 as b2 ON b1.title = b2.title WHERE b1.shelf <> b2.shelf
 ----
 tree                   field        description        columns                       ordering
+·                      distributed  true               ·                             ·
+·                      vectorized   true               ·                             ·
 distinct               ·            ·                  (title)                       weak-key(title); +title
  │                     distinct on  title              ·                             ·
  │                     order key    title              ·                             ·
@@ -218,6 +234,8 @@ query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT DISTINCT authors.name FROM books AS b1, books2 AS b2, authors WHERE b1.title = b2.title AND authors.book = b1.title AND b1.shelf <> b2.shelf
 ----
 tree                      field        description        columns                                   ordering
+·                         distributed  true               ·                                         ·
+·                         vectorized   false              ·                                         ·
 distinct                  ·            ·                  (name)                                    weak-key(name)
  │                        distinct on  name               ·                                         ·
  └── render               ·            ·                  (name)                                    ·
@@ -252,40 +270,43 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJyck89q3DAQh-99CnVOCSjsyn
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT a.name FROM authors AS a JOIN books2 AS b2 ON a.book = b2.title ORDER BY a.name
 ----
-tree                 field     description       columns              ordering
-render               ·         ·                 (name)               +name
- │                   render 0  name              ·                    ·
- └── lookup-join     ·         ·                 (name, book, title)  +name
-      │              table     books2@primary    ·                    ·
-      │              type      inner             ·                    ·
-      │              equality  (book) = (title)  ·                    ·
-      └── sort       ·         ·                 (name, book)         +name
-           │         order     +name             ·                    ·
-           └── scan  ·         ·                 (name, book)         ·
-·                    table     authors@primary   ·                    ·
-·                    spans     ALL               ·                    ·
+tree                 field        description       columns              ordering
+·                    distributed  true              ·                    ·
+·                    vectorized   false             ·                    ·
+render               ·            ·                 (name)               +name
+ │                   render 0     name              ·                    ·
+ └── lookup-join     ·            ·                 (name, book, title)  +name
+      │              table        books2@primary    ·                    ·
+      │              type         inner             ·                    ·
+      │              equality     (book) = (title)  ·                    ·
+      └── sort       ·            ·                 (name, book)         +name
+           │         order        +name             ·                    ·
+           └── scan  ·            ·                 (name, book)         ·
+·                    table        authors@primary   ·                    ·
+·                    spans        ALL               ·                    ·
 
 # Cross joins should not be planned as lookup joins.
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM books CROSS JOIN books2
 ----
-tree            field     description     columns                                         ordering
-render          ·         ·               (title, edition, shelf, title, edition, shelf)  ·
- │              render 0  title           ·                                               ·
- │              render 1  edition         ·                                               ·
- │              render 2  shelf           ·                                               ·
- │              render 3  title           ·                                               ·
- │              render 4  edition         ·                                               ·
- │              render 5  shelf           ·                                               ·
- └── hash-join  ·         ·               (title, edition, shelf, title, edition, shelf)  ·
-      │         type      cross           ·                                               ·
-      ├── scan  ·         ·               (title, edition, shelf)                         ·
-      │         table     books2@primary  ·                                               ·
-      │         spans     ALL             ·                                               ·
-      └── scan  ·         ·               (title, edition, shelf)                         ·
-·               table     books@primary   ·                                               ·
-·               spans     ALL             ·                                               ·
-
+tree            field        description     columns                                         ordering
+·               distributed  true            ·                                               ·
+·               vectorized   false           ·                                               ·
+render          ·            ·               (title, edition, shelf, title, edition, shelf)  ·
+ │              render 0     title           ·                                               ·
+ │              render 1     edition         ·                                               ·
+ │              render 2     shelf           ·                                               ·
+ │              render 3     title           ·                                               ·
+ │              render 4     edition         ·                                               ·
+ │              render 5     shelf           ·                                               ·
+ └── hash-join  ·            ·               (title, edition, shelf, title, edition, shelf)  ·
+      │         type         cross           ·                                               ·
+      ├── scan  ·            ·               (title, edition, shelf)                         ·
+      │         table        books2@primary  ·                                               ·
+      │         spans        ALL             ·                                               ·
+      └── scan  ·            ·               (title, edition, shelf)                         ·
+·               table        books@primary   ·                                               ·
+·               spans        ALL             ·                                               ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM authors INNER JOIN books2 ON books2.edition = 1 WHERE books2.title = authors.book]
@@ -337,21 +358,25 @@ ALTER TABLE large INJECT STATISTICS '[
 query TTTTT
 EXPLAIN (VERBOSE) SELECT small.a, large.c FROM small JOIN large ON small.a = large.b
 ----
-render            ·         ·              (a, c)     ·
- │                render 0  a              ·          ·
- │                render 1  c              ·          ·
- └── lookup-join  ·         ·              (a, b, c)  ·
-      │           table     large@bc       ·          ·
-      │           type      inner          ·          ·
-      │           equality  (a) = (b)      ·          ·
-      └── scan    ·         ·              (a)        ·
-·                 table     small@primary  ·          ·
-·                 spans     ALL            ·          ·
+·                 distributed  true           ·          ·
+·                 vectorized   true           ·          ·
+render            ·            ·              (a, c)     ·
+ │                render 0     a              ·          ·
+ │                render 1     c              ·          ·
+ └── lookup-join  ·            ·              (a, b, c)  ·
+      │           table        large@bc       ·          ·
+      │           type         inner          ·          ·
+      │           equality     (a) = (b)      ·          ·
+      └── scan    ·            ·              (a)        ·
+·                 table        small@primary  ·          ·
+·                 spans        ALL            ·          ·
 
 # Lookup join on non-covering secondary index
 query TTTTT
 EXPLAIN (VERBOSE) SELECT small.a, large.d FROM small JOIN large ON small.a = large.b
 ----
+·                      distributed            true             ·             ·
+·                      vectorized             true             ·             ·
 render                 ·                      ·                (a, d)        ·
  │                     render 0               a                ·             ·
  │                     render 1               d                ·             ·
@@ -376,29 +401,33 @@ render                 ·                      ·                (a, d)        �
 query TTTTT
 EXPLAIN (VERBOSE) SELECT small.b, large.a FROM small LEFT JOIN large ON small.b = large.a
 ----
-lookup-join  ·         ·              (b, a)  ·
- │           table     large@primary  ·       ·
- │           type      left outer     ·       ·
- │           equality  (b) = (a)      ·       ·
- └── scan    ·         ·              (b)     ·
-·            table     small@primary  ·       ·
-·            spans     ALL            ·       ·
+·            distributed  true           ·       ·
+·            vectorized   true           ·       ·
+lookup-join  ·            ·              (b, a)  ·
+ │           table        large@primary  ·       ·
+ │           type         left outer     ·       ·
+ │           equality     (b) = (a)      ·       ·
+ └── scan    ·            ·              (b)     ·
+·            table        small@primary  ·       ·
+·            spans        ALL            ·       ·
 
 # Left join should preserve input order.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT t1.a, t2.b FROM small t1 LEFT JOIN large t2 ON t1.a = t2.a AND t2.b % 6 = 0 ORDER BY t1.a
 ----
-render            ·         ·              (a, b)     +a
- │                render 0  a              ·          ·
- │                render 1  b              ·          ·
- └── lookup-join  ·         ·              (a, a, b)  +a
-      │           table     large@primary  ·          ·
-      │           type      left outer     ·          ·
-      │           equality  (a) = (a)      ·          ·
-      │           pred      (@3 % 6) = 0   ·          ·
-      └── scan    ·         ·              (a)        +a
-·                 table     small@primary  ·          ·
-·                 spans     ALL            ·          ·
+·                 distributed  true           ·          ·
+·                 vectorized   true           ·          ·
+render            ·            ·              (a, b)     +a
+ │                render 0     a              ·          ·
+ │                render 1     b              ·          ·
+ └── lookup-join  ·            ·              (a, a, b)  +a
+      │           table        large@primary  ·          ·
+      │           type         left outer     ·          ·
+      │           equality     (a) = (a)      ·          ·
+      │           pred         (@3 % 6) = 0   ·          ·
+      └── scan    ·            ·              (a)        +a
+·                 table        small@primary  ·          ·
+·                 spans        ALL            ·          ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT t1.a, t2.b FROM small t1 LEFT JOIN large t2 ON t1.a = t2.a AND t2.b % 6 = 0 ORDER BY t1.a]
@@ -409,21 +438,25 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJzMlcGK2zwUhff_U4gLP7RUxp
 query TTTTT
 EXPLAIN (VERBOSE) SELECT small.c, large.c FROM small LEFT JOIN large ON small.c = large.b
 ----
-render            ·         ·              (c, c)     ·
- │                render 0  c              ·          ·
- │                render 1  c              ·          ·
- └── lookup-join  ·         ·              (c, b, c)  ·
-      │           table     large@bc       ·          ·
-      │           type      left outer     ·          ·
-      │           equality  (c) = (b)      ·          ·
-      └── scan    ·         ·              (c)        ·
-·                 table     small@primary  ·          ·
-·                 spans     ALL            ·          ·
+·                 distributed  true           ·          ·
+·                 vectorized   true           ·          ·
+render            ·            ·              (c, c)     ·
+ │                render 0     c              ·          ·
+ │                render 1     c              ·          ·
+ └── lookup-join  ·            ·              (c, b, c)  ·
+      │           table        large@bc       ·          ·
+      │           type         left outer     ·          ·
+      │           equality     (c) = (b)      ·          ·
+      └── scan    ·            ·              (c)        ·
+·                 table        small@primary  ·          ·
+·                 spans        ALL            ·          ·
 
 # Left join against non-covering secondary index
 query TTTTT
 EXPLAIN (VERBOSE) SELECT small.c, large.d FROM small LEFT JOIN large ON small.c = large.b
 ----
+·                      distributed            true             ·             ·
+·                      vectorized             true             ·             ·
 render                 ·                      ·                (c, d)        ·
  │                     render 0               c                ·             ·
  │                     render 1               d                ·             ·
@@ -444,17 +477,19 @@ render                 ·                      ·                (c, d)        �
 query TTTTT
 EXPLAIN (VERBOSE) SELECT small.c, large.c FROM small LEFT JOIN large ON small.c = large.b AND large.c < 20
 ----
-render            ·         ·              (c, c)     ·
- │                render 0  c              ·          ·
- │                render 1  c              ·          ·
- └── lookup-join  ·         ·              (c, b, c)  ·
-      │           table     large@bc       ·          ·
-      │           type      left outer     ·          ·
-      │           equality  (c) = (b)      ·          ·
-      │           pred      @3 < 20        ·          ·
-      └── scan    ·         ·              (c)        ·
-·                 table     small@primary  ·          ·
-·                 spans     ALL            ·          ·
+·                 distributed  true           ·          ·
+·                 vectorized   true           ·          ·
+render            ·            ·              (c, c)     ·
+ │                render 0     c              ·          ·
+ │                render 1     c              ·          ·
+ └── lookup-join  ·            ·              (c, b, c)  ·
+      │           table        large@bc       ·          ·
+      │           type         left outer     ·          ·
+      │           equality     (c) = (b)      ·          ·
+      │           pred         @3 < 20        ·          ·
+      └── scan    ·            ·              (c)        ·
+·                 table        small@primary  ·          ·
+·                 spans        ALL            ·          ·
 
 # Left join with ON filter on non-covering index
 # TODO(radu): this doesn't use lookup join yet, the current rules don't cover
@@ -462,19 +497,21 @@ render            ·         ·              (c, c)     ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT small.c, large.d FROM small LEFT JOIN large ON small.c = large.b AND large.d < 30
 ----
-render          ·         ·              (c, d)     ·
- │              render 0  c              ·          ·
- │              render 1  d              ·          ·
- └── hash-join  ·         ·              (b, d, c)  ·
-      │         type      right outer    ·          ·
-      │         equality  (b) = (c)      ·          ·
-      ├── scan  ·         ·              (b, d)     ·
-      │         table     large@primary  ·          ·
-      │         spans     ALL            ·          ·
-      │         filter    d < 30         ·          ·
-      └── scan  ·         ·              (c)        ·
-·               table     small@primary  ·          ·
-·               spans     ALL            ·          ·
+·               distributed  true           ·          ·
+·               vectorized   false          ·          ·
+render          ·            ·              (c, d)     ·
+ │              render 0     c              ·          ·
+ │              render 1     d              ·          ·
+ └── hash-join  ·            ·              (b, d, c)  ·
+      │         type         right outer    ·          ·
+      │         equality     (b) = (c)      ·          ·
+      ├── scan  ·            ·              (b, d)     ·
+      │         table        large@primary  ·          ·
+      │         spans        ALL            ·          ·
+      │         filter       d < 30         ·          ·
+      └── scan  ·            ·              (c)        ·
+·               table        small@primary  ·          ·
+·               spans        ALL            ·          ·
 
 ###########################################################
 #  LOOKUP JOINS ON IMPLICIT INDEX KEY COLUMNS             #
@@ -493,16 +530,18 @@ CREATE INDEX idx ON u (d)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a WHERE t.e = 5
 ----
-render            ·         ·                (a)              ·
- │                render 0  a                ·                ·
- └── lookup-join  ·         ·                (a, d, e, a, d)  ·
-      │           table     u@idx            ·                ·
-      │           type      inner            ·                ·
-      │           equality  (d, a) = (d, a)  ·                ·
-      └── scan    ·         ·                (a, d, e)        ·
-·                 table     t@primary        ·                ·
-·                 spans     ALL              ·                ·
-·                 filter    e = 5            ·                ·
+·                 distributed  true             ·                ·
+·                 vectorized   true             ·                ·
+render            ·            ·                (a)              ·
+ │                render 0     a                ·                ·
+ └── lookup-join  ·            ·                (a, d, e, a, d)  ·
+      │           table        u@idx            ·                ·
+      │           type         inner            ·                ·
+      │           equality     (d, a) = (d, a)  ·                ·
+      └── scan    ·            ·                (a, d, e)        ·
+·                 table        t@primary        ·                ·
+·                 spans        ALL              ·                ·
+·                 filter       e = 5            ·                ·
 
 # Test unique version of same index. (Lookup join should not use column a.)
 statement ok
@@ -514,17 +553,19 @@ CREATE UNIQUE INDEX idx ON u (d)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a WHERE t.e = 5
 ----
-render            ·         ·          (a)              ·
- │                render 0  a          ·                ·
- └── lookup-join  ·         ·          (a, d, e, a, d)  ·
-      │           table     u@idx      ·                ·
-      │           type      inner      ·                ·
-      │           equality  (d) = (d)  ·                ·
-      │           pred      @1 = @4    ·                ·
-      └── scan    ·         ·          (a, d, e)        ·
-·                 table     t@primary  ·                ·
-·                 spans     ALL        ·                ·
-·                 filter    e = 5      ·                ·
+·                 distributed  true       ·                ·
+·                 vectorized   true       ·                ·
+render            ·            ·          (a)              ·
+ │                render 0     a          ·                ·
+ └── lookup-join  ·            ·          (a, d, e, a, d)  ·
+      │           table        u@idx      ·                ·
+      │           type         inner      ·                ·
+      │           equality     (d) = (d)  ·                ·
+      │           pred         @1 = @4    ·                ·
+      └── scan    ·            ·          (a, d, e)        ·
+·                 table        t@primary  ·                ·
+·                 spans        ALL        ·                ·
+·                 filter       e = 5      ·                ·
 
 # Test index with first primary key column explicit and the rest implicit.
 statement ok
@@ -536,16 +577,18 @@ CREATE INDEX idx ON u (d, a)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.b = u.b WHERE t.e = 5
 ----
-render            ·         ·                      (a)                    ·
- │                render 0  a                      ·                      ·
- └── lookup-join  ·         ·                      (a, b, d, e, a, b, d)  ·
-      │           table     u@idx                  ·                      ·
-      │           type      inner                  ·                      ·
-      │           equality  (d, a, b) = (d, a, b)  ·                      ·
-      └── scan    ·         ·                      (a, b, d, e)           ·
-·                 table     t@primary              ·                      ·
-·                 spans     ALL                    ·                      ·
-·                 filter    e = 5                  ·                      ·
+·                 distributed  true                   ·                      ·
+·                 vectorized   true                   ·                      ·
+render            ·            ·                      (a)                    ·
+ │                render 0     a                      ·                      ·
+ └── lookup-join  ·            ·                      (a, b, d, e, a, b, d)  ·
+      │           table        u@idx                  ·                      ·
+      │           type         inner                  ·                      ·
+      │           equality     (d, a, b) = (d, a, b)  ·                      ·
+      └── scan    ·            ·                      (a, b, d, e)           ·
+·                 table        t@primary              ·                      ·
+·                 spans        ALL                    ·                      ·
+·                 filter       e = 5                  ·                      ·
 
 # Test index with middle primary key column explicit and the rest implicit.
 statement ok
@@ -557,16 +600,18 @@ CREATE INDEX idx ON u (d, b)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.b = u.b WHERE t.e = 5
 ----
-render            ·         ·                      (a)                    ·
- │                render 0  a                      ·                      ·
- └── lookup-join  ·         ·                      (a, b, d, e, a, b, d)  ·
-      │           table     u@idx                  ·                      ·
-      │           type      inner                  ·                      ·
-      │           equality  (d, b, a) = (d, b, a)  ·                      ·
-      └── scan    ·         ·                      (a, b, d, e)           ·
-·                 table     t@primary              ·                      ·
-·                 spans     ALL                    ·                      ·
-·                 filter    e = 5                  ·                      ·
+·                 distributed  true                   ·                      ·
+·                 vectorized   true                   ·                      ·
+render            ·            ·                      (a)                    ·
+ │                render 0     a                      ·                      ·
+ └── lookup-join  ·            ·                      (a, b, d, e, a, b, d)  ·
+      │           table        u@idx                  ·                      ·
+      │           type         inner                  ·                      ·
+      │           equality     (d, b, a) = (d, b, a)  ·                      ·
+      └── scan    ·            ·                      (a, b, d, e)           ·
+·                 table        t@primary              ·                      ·
+·                 spans        ALL                    ·                      ·
+·                 filter       e = 5                  ·                      ·
 
 # Test index with last primary key column explicit and the rest implicit.
 statement ok
@@ -578,40 +623,46 @@ CREATE INDEX idx ON u (d, c)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.d = u.d WHERE t.e = 5
 ----
-render            ·         ·          (a)              ·
- │                render 0  a          ·                ·
- └── lookup-join  ·         ·          (a, d, e, a, d)  ·
-      │           table     u@idx      ·                ·
-      │           type      inner      ·                ·
-      │           equality  (d) = (d)  ·                ·
-      │           pred      @1 = @4    ·                ·
-      └── scan    ·         ·          (a, d, e)        ·
-·                 table     t@primary  ·                ·
-·                 spans     ALL        ·                ·
-·                 filter    e = 5      ·                ·
+·                 distributed  true       ·                ·
+·                 vectorized   true       ·                ·
+render            ·            ·          (a)              ·
+ │                render 0     a          ·                ·
+ └── lookup-join  ·            ·          (a, d, e, a, d)  ·
+      │           table        u@idx      ·                ·
+      │           type         inner      ·                ·
+      │           equality     (d) = (d)  ·                ·
+      │           pred         @1 = @4    ·                ·
+      └── scan    ·            ·          (a, d, e)        ·
+·                 table        t@primary  ·                ·
+·                 spans        ALL        ·                ·
+·                 filter       e = 5      ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM def JOIN abc ON a=f ORDER BY a
 ----
-render            ·         ·            (d, e, f, a, b, c)  ·
- │                render 0  d            ·                   ·
- │                render 1  e            ·                   ·
- │                render 2  f            ·                   ·
- │                render 3  a            ·                   ·
- │                render 4  b            ·                   ·
- │                render 5  c            ·                   ·
- └── lookup-join  ·         ·            (a, b, c, d, e, f)  +a
-      │           table     def@primary  ·                   ·
-      │           type      inner        ·                   ·
-      │           equality  (a) = (f)    ·                   ·
-      └── scan    ·         ·            (a, b, c)           +a
-·                 table     abc@primary  ·                   ·
-·                 spans     ALL          ·                   ·
+·                 distributed  true         ·                   ·
+·                 vectorized   true         ·                   ·
+render            ·            ·            (d, e, f, a, b, c)  ·
+ │                render 0     d            ·                   ·
+ │                render 1     e            ·                   ·
+ │                render 2     f            ·                   ·
+ │                render 3     a            ·                   ·
+ │                render 4     b            ·                   ·
+ │                render 5     c            ·                   ·
+ └── lookup-join  ·            ·            (a, b, c, d, e, f)  +a
+      │           table        def@primary  ·                   ·
+      │           type         inner        ·                   ·
+      │           equality     (a) = (f)    ·                   ·
+      └── scan    ·            ·            (a, b, c)           +a
+·                 table        abc@primary  ·                   ·
+·                 spans        ALL          ·                   ·
 
 # Test that we don't get a lookup join if we force a merge join.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM def INNER MERGE JOIN abc ON a=f ORDER BY a
 ----
+·           distributed     true         ·                   ·
+·           vectorized      false        ·                   ·
 merge-join  ·               ·            (d, e, f, a, b, c)  +f
  │          type            inner        ·                   ·
  │          equality        (f) = (a)    ·                   ·
@@ -627,44 +678,52 @@ merge-join  ·               ·            (d, e, f, a, b, c)  +f
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM def INNER HASH JOIN abc ON a=f ORDER BY a
 ----
-sort            ·         ·            (d, e, f, a, b, c)  +f
- │              order     +f           ·                   ·
- └── hash-join  ·         ·            (d, e, f, a, b, c)  ·
-      │         type      inner        ·                   ·
-      │         equality  (f) = (a)    ·                   ·
-      ├── scan  ·         ·            (d, e, f)           ·
-      │         table     def@primary  ·                   ·
-      │         spans     ALL          ·                   ·
-      └── scan  ·         ·            (a, b, c)           ·
-·               table     abc@primary  ·                   ·
-·               spans     ALL          ·                   ·
+·               distributed  true         ·                   ·
+·               vectorized   false        ·                   ·
+sort            ·            ·            (d, e, f, a, b, c)  +f
+ │              order        +f           ·                   ·
+ └── hash-join  ·            ·            (d, e, f, a, b, c)  ·
+      │         type         inner        ·                   ·
+      │         equality     (f) = (a)    ·                   ·
+      ├── scan  ·            ·            (d, e, f)           ·
+      │         table        def@primary  ·                   ·
+      │         spans        ALL          ·                   ·
+      └── scan  ·            ·            (a, b, c)           ·
+·               table        abc@primary  ·                   ·
+·               spans        ALL          ·                   ·
 
 # Test lookup semi and anti join.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from abc WHERE EXISTS (SELECT * FROM def WHERE a=f)
 ----
-lookup-join  ·         ·            (a, b, c)  ·
- │           table     def@primary  ·          ·
- │           type      semi         ·          ·
- │           equality  (a) = (f)    ·          ·
- └── scan    ·         ·            (a, b, c)  ·
-·            table     abc@primary  ·          ·
-·            spans     ALL          ·          ·
+·            distributed  true         ·          ·
+·            vectorized   true         ·          ·
+lookup-join  ·            ·            (a, b, c)  ·
+ │           table        def@primary  ·          ·
+ │           type         semi         ·          ·
+ │           equality     (a) = (f)    ·          ·
+ └── scan    ·            ·            (a, b, c)  ·
+·            table        abc@primary  ·          ·
+·            spans        ALL          ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=f)
 ----
-lookup-join  ·         ·            (a, b, c)  ·
- │           table     def@primary  ·          ·
- │           type      anti         ·          ·
- │           equality  (a) = (f)    ·          ·
- └── scan    ·         ·            (a, b, c)  ·
-·            table     abc@primary  ·          ·
-·            spans     ALL          ·          ·
+·            distributed  true         ·          ·
+·            vectorized   true         ·          ·
+lookup-join  ·            ·            (a, b, c)  ·
+ │           table        def@primary  ·          ·
+ │           type         anti         ·          ·
+ │           equality     (a) = (f)    ·          ·
+ └── scan    ·            ·            (a, b, c)  ·
+·            table        abc@primary  ·          ·
+·            spans        ALL          ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from abc WHERE EXISTS (SELECT * FROM def WHERE a=f AND c=e)
 ----
+·            distributed            true             ·          ·
+·            vectorized             true             ·          ·
 lookup-join  ·                      ·                (a, b, c)  ·
  │           table                  def@primary      ·          ·
  │           type                   semi             ·          ·
@@ -677,6 +736,8 @@ lookup-join  ·                      ·                (a, b, c)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=f AND c=e)
 ----
+·            distributed            true             ·          ·
+·            vectorized             true             ·          ·
 lookup-join  ·                      ·                (a, b, c)  ·
  │           table                  def@primary      ·          ·
  │           type                   anti             ·          ·
@@ -689,26 +750,30 @@ lookup-join  ·                      ·                (a, b, c)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from abc WHERE EXISTS (SELECT * FROM def WHERE a=f AND d+b>1)
 ----
-lookup-join  ·         ·              (a, b, c)  ·
- │           table     def@primary    ·          ·
- │           type      semi           ·          ·
- │           equality  (a) = (f)      ·          ·
- │           pred      (@4 + @2) > 1  ·          ·
- └── scan    ·         ·              (a, b, c)  ·
-·            table     abc@primary    ·          ·
-·            spans     ALL            ·          ·
+·            distributed  true           ·          ·
+·            vectorized   true           ·          ·
+lookup-join  ·            ·              (a, b, c)  ·
+ │           table        def@primary    ·          ·
+ │           type         semi           ·          ·
+ │           equality     (a) = (f)      ·          ·
+ │           pred         (@4 + @2) > 1  ·          ·
+ └── scan    ·            ·              (a, b, c)  ·
+·            table        abc@primary    ·          ·
+·            spans        ALL            ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=f AND d+b>1)
 ----
-lookup-join  ·         ·              (a, b, c)  ·
- │           table     def@primary    ·          ·
- │           type      anti           ·          ·
- │           equality  (a) = (f)      ·          ·
- │           pred      (@4 + @2) > 1  ·          ·
- └── scan    ·         ·              (a, b, c)  ·
-·            table     abc@primary    ·          ·
-·            spans     ALL            ·          ·
+·            distributed  true           ·          ·
+·            vectorized   true           ·          ·
+lookup-join  ·            ·              (a, b, c)  ·
+ │           table        def@primary    ·          ·
+ │           type         anti           ·          ·
+ │           equality     (a) = (f)      ·          ·
+ │           pred         (@4 + @2) > 1  ·          ·
+ └── scan    ·            ·              (a, b, c)  ·
+·            table        abc@primary    ·          ·
+·            spans        ALL            ·          ·
 
 query T
 SELECT url FROM [ EXPLAIN (DISTSQL)
@@ -743,6 +808,8 @@ INSERT INTO b VALUES(1)
 query TTT
 EXPLAIN SELECT count(*) FROM (SELECT * FROM b NATURAL INNER LOOKUP JOIN a)
 ----
+·                      distributed  true
+·                      vectorized   false
 group                  ·            ·
  │                     aggregate 0  count_rows()
  │                     scalar       ·
@@ -1330,6 +1397,8 @@ GROUP BY s_name
 ORDER BY numwait DESC, s_name
    LIMIT 100;
 ----
+·                                                   distributed            true
+·                                                   vectorized             false
 limit                                               ·                      ·
  │                                                  count                  100
  └── sort                                           ·                      ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -10,36 +10,44 @@ CREATE TABLE t (
 query TTT
 EXPLAIN SELECT a, b FROM t ORDER BY b
 ----
-sort       ·      ·
- │         order  +b
- └── scan  ·      ·
-·          table  t@primary
-·          spans  ALL
+·          distributed  false
+·          vectorized   false
+sort       ·            ·
+ │         order        +b
+ └── scan  ·            ·
+·          table        t@primary
+·          spans        ALL
 
 query TTT
 EXPLAIN SELECT a, b FROM t ORDER BY b DESC
 ----
-sort       ·      ·
- │         order  -b
- └── scan  ·      ·
-·          table  t@primary
-·          spans  ALL
+·          distributed  false
+·          vectorized   false
+sort       ·            ·
+ │         order        -b
+ └── scan  ·            ·
+·          table        t@primary
+·          spans        ALL
 
 # TODO(radu): Should set "strategy top 2" on sort node
 query TTT
 EXPLAIN SELECT a, b FROM t ORDER BY b LIMIT 2
 ----
-limit           ·      ·
- │              count  2
- └── sort       ·      ·
-      │         order  +b
-      └── scan  ·      ·
-·               table  t@primary
-·               spans  ALL
+·               distributed  false
+·               vectorized   true
+limit           ·            ·
+ │              count        2
+ └── sort       ·            ·
+      │         order        +b
+      └── scan  ·            ·
+·               table        t@primary
+·               spans        ALL
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT c, b FROM t ORDER BY b LIMIT 2
 ----
+·                         distributed  false      ·       ·
+·                         vectorized   false      ·       ·
 render                    ·            ·          (c, b)  ·
  │                        render 0     c          ·       ·
  │                        render 1     b          ·       ·
@@ -56,119 +64,145 @@ render                    ·            ·          (c, b)  ·
 query TTT
 EXPLAIN SELECT b FROM t ORDER BY a DESC
 ----
-render        ·      ·
- └── revscan  ·      ·
-·             table  t@primary
-·             spans  ALL
+·             distributed  false
+·             vectorized   true
+render        ·            ·
+ └── revscan  ·            ·
+·             table        t@primary
+·             spans        ALL
 
 # Check that LIMIT propagates past nosort nodes.
 query TTT
 EXPLAIN SELECT b FROM t ORDER BY a LIMIT 1
 ----
-render     ·      ·
- └── scan  ·      ·
-·          table  t@primary
-·          spans  ALL
-·          limit  1
+·          distributed  false
+·          vectorized   true
+render     ·            ·
+ └── scan  ·            ·
+·          table        t@primary
+·          spans        ALL
+·          limit        1
 
 query TTT
 EXPLAIN SELECT b FROM t ORDER BY a DESC, b ASC
 ----
-render        ·      ·
- └── revscan  ·      ·
-·             table  t@primary
-·             spans  ALL
+·             distributed  false
+·             vectorized   true
+render        ·            ·
+ └── revscan  ·            ·
+·             table        t@primary
+·             spans        ALL
 
 query TTT
 EXPLAIN SELECT b FROM t ORDER BY a DESC, b DESC
 ----
-render        ·      ·
- └── revscan  ·      ·
-·             table  t@primary
-·             spans  ALL
+·             distributed  false
+·             vectorized   true
+render        ·            ·
+ └── revscan  ·            ·
+·             table        t@primary
+·             spans        ALL
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY (b, t.*)
 ----
-sort       ·      ·          (a, b, c)  +b,+a
- │         order  +b,+a      ·          ·
- └── scan  ·      ·          (a, b, c)  ·
-·          table  t@primary  ·          ·
-·          spans  ALL        ·          ·
+·          distributed  false      ·          ·
+·          vectorized   false      ·          ·
+sort       ·            ·          (a, b, c)  +b,+a
+ │         order        +b,+a      ·          ·
+ └── scan  ·            ·          (a, b, c)  ·
+·          table        t@primary  ·          ·
+·          spans        ALL        ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY (b, a), c
 ----
-sort       ·      ·          (a, b, c)  +b,+a
- │         order  +b,+a      ·          ·
- └── scan  ·      ·          (a, b, c)  ·
-·          table  t@primary  ·          ·
-·          spans  ALL        ·          ·
+·          distributed  false      ·          ·
+·          vectorized   false      ·          ·
+sort       ·            ·          (a, b, c)  +b,+a
+ │         order        +b,+a      ·          ·
+ └── scan  ·            ·          (a, b, c)  ·
+·          table        t@primary  ·          ·
+·          spans        ALL        ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY b, (a, c)
 ----
-sort       ·      ·          (a, b, c)  +b,+a
- │         order  +b,+a      ·          ·
- └── scan  ·      ·          (a, b, c)  ·
-·          table  t@primary  ·          ·
-·          spans  ALL        ·          ·
+·          distributed  false      ·          ·
+·          vectorized   false      ·          ·
+sort       ·            ·          (a, b, c)  +b,+a
+ │         order        +b,+a      ·          ·
+ └── scan  ·            ·          (a, b, c)  ·
+·          table        t@primary  ·          ·
+·          spans        ALL        ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY (b, (a, c))
 ----
-sort       ·      ·          (a, b, c)  +b,+a
- │         order  +b,+a      ·          ·
- └── scan  ·      ·          (a, b, c)  ·
-·          table  t@primary  ·          ·
-·          spans  ALL        ·          ·
+·          distributed  false      ·          ·
+·          vectorized   false      ·          ·
+sort       ·            ·          (a, b, c)  +b,+a
+ │         order        +b,+a      ·          ·
+ └── scan  ·            ·          (a, b, c)  ·
+·          table        t@primary  ·          ·
+·          spans        ALL        ·          ·
 
 # Check that sort is skipped if the ORDER BY clause is constant.
 query TTT
 EXPLAIN SELECT * FROM t ORDER BY 1+2
 ----
-scan  ·      ·
-·     table  t@primary
-·     spans  ALL
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        t@primary
+·     spans        ALL
 
 query TTT
 EXPLAIN SELECT 1, * FROM t ORDER BY 1
 ----
-render     ·      ·
- └── scan  ·      ·
-·          table  t@primary
-·          spans  ALL
+·          distributed  false
+·          vectorized   true
+render     ·            ·
+ └── scan  ·            ·
+·          table        t@primary
+·          spans        ALL
 
 query TTT
 EXPLAIN SELECT * FROM t ORDER BY length('abc')
 ----
-scan  ·      ·
-·     table  t@primary
-·     spans  ALL
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        t@primary
+·     spans        ALL
 
 # Check that the sort key reuses the existing render.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT b+2 r FROM t ORDER BY b+2
 ----
-sort            ·         ·          (r)  +r
- │              order     +r         ·    ·
- └── render     ·         ·          (r)  ·
-      │         render 0  b + 2      ·    ·
-      └── scan  ·         ·          (b)  ·
-·               table     t@primary  ·    ·
-·               spans     ALL        ·    ·
+·               distributed  false      ·    ·
+·               vectorized   false      ·    ·
+sort            ·            ·          (r)  +r
+ │              order        +r         ·    ·
+ └── render     ·            ·          (r)  ·
+      │         render 0     b + 2      ·    ·
+      └── scan  ·            ·          (b)  ·
+·               table        t@primary  ·    ·
+·               spans        ALL        ·    ·
 
 # Check that the sort picks up a renamed render properly.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT b+2 AS y FROM t ORDER BY y
 ----
-sort            ·         ·          (y)  +y
- │              order     +y         ·    ·
- └── render     ·         ·          (y)  ·
-      │         render 0  b + 2      ·    ·
-      └── scan  ·         ·          (b)  ·
-·               table     t@primary  ·    ·
-·               spans     ALL        ·    ·
+·               distributed  false      ·    ·
+·               vectorized   false      ·    ·
+sort            ·            ·          (y)  +y
+ │              order        +y         ·    ·
+ └── render     ·            ·          (y)  ·
+      │         render 0     b + 2      ·    ·
+      └── scan  ·            ·          (b)  ·
+·               table        t@primary  ·    ·
+·               spans        ALL        ·    ·
 
 statement ok
 CREATE TABLE abc (
@@ -219,34 +253,40 @@ output row: [4 5]
 query TTT
 EXPLAIN SELECT a, b, c FROM abc ORDER BY b, a, c
 ----
-scan  ·      ·
-·     table  abc@ba
-·     spans  ALL
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        abc@ba
+·     spans        ALL
 
 # We use the WHERE condition to force the use of the index.
 query TTT
 EXPLAIN SELECT a, b, c FROM abc WHERE b > 10 AND b < 30 ORDER BY b, a, d
 ----
-render                ·      ·
- └── sort             ·      ·
-      │               order  +b,+a,+d
-      └── index-join  ·      ·
-           │          table  abc@primary
-           └── scan   ·      ·
-·                     table  abc@ba
-·                     spans  /11-/30
+·                     distributed  false
+·                     vectorized   false
+render                ·            ·
+ └── sort             ·            ·
+      │               order        +b,+a,+d
+      └── index-join  ·            ·
+           │          table        abc@primary
+           └── scan   ·            ·
+·                     table        abc@ba
+·                     spans        /11-/30
 
 # An inequality should not be enough to force the use of the index.
 query TTT
 EXPLAIN SELECT a, b, c FROM abc WHERE b > 10 ORDER BY b, a, d
 ----
-render          ·       ·
- └── sort       ·       ·
-      │         order   +b,+a,+d
-      └── scan  ·       ·
-·               table   abc@primary
-·               spans   ALL
-·               filter  b > 10
+·               distributed  false
+·               vectorized   false
+render          ·            ·
+ └── sort       ·            ·
+      │         order        +b,+a,+d
+      └── scan  ·            ·
+·               table        abc@primary
+·               spans        ALL
+·               filter       b > 10
 
 query III
 SELECT a, b, c FROM abc WHERE b > 4 ORDER BY b, a, d
@@ -263,46 +303,56 @@ SELECT a, b, c FROM abc WHERE b > 4 ORDER BY b, a, d
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a, b, c, d FROM abc WHERE b > 10 ORDER BY b, a, c, d
 ----
-sort       ·       ·            (a, b, c, d)  +b,+a,+c
- │         order   +b,+a,+c     ·             ·
- └── scan  ·       ·            (a, b, c, d)  ·
-·          table   abc@primary  ·             ·
-·          spans   ALL          ·             ·
-·          filter  b > 10       ·             ·
+·          distributed  false        ·             ·
+·          vectorized   false        ·             ·
+sort       ·            ·            (a, b, c, d)  +b,+a,+c
+ │         order        +b,+a,+c     ·             ·
+ └── scan  ·            ·            (a, b, c, d)  ·
+·          table        abc@primary  ·             ·
+·          spans        ALL          ·             ·
+·          filter       b > 10       ·             ·
 
 query TTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c
 ----
-render     ·      ·
- └── scan  ·      ·
-·          table  abc@bc
-·          spans  ALL
+·          distributed  false
+·          vectorized   true
+render     ·            ·
+ └── scan  ·            ·
+·          table        abc@bc
+·          spans        ALL
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a, b FROM abc ORDER BY b, c
 ----
-render     ·         ·       (a, b)     ·
- │         render 0  a       ·          ·
- │         render 1  b       ·          ·
- └── scan  ·         ·       (a, b, c)  +b,+c
-·          table     abc@bc  ·          ·
-·          spans     ALL     ·          ·
+·          distributed  false   ·          ·
+·          vectorized   true    ·          ·
+render     ·            ·       (a, b)     ·
+ │         render 0     a       ·          ·
+ │         render 1     b       ·          ·
+ └── scan  ·            ·       (a, b, c)  +b,+c
+·          table        abc@bc  ·          ·
+·          spans        ALL     ·          ·
 
 query TTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a
 ----
-render     ·      ·
- └── scan  ·      ·
-·          table  abc@bc
-·          spans  ALL
+·          distributed  false
+·          vectorized   true
+render     ·            ·
+ └── scan  ·            ·
+·          table        abc@bc
+·          spans        ALL
 
 query TTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a DESC
 ----
-render     ·      ·
- └── scan  ·      ·
-·          table  abc@bc
-·          spans  ALL
+·          distributed  false
+·          vectorized   true
+render     ·            ·
+ └── scan  ·            ·
+·          table        abc@bc
+·          spans        ALL
 
 statement ok
 SET tracing = on,kv,results; SELECT b, c FROM abc ORDER BY b, c; SET tracing = off
@@ -348,36 +398,44 @@ output row: [1]
 query TTT
 EXPLAIN SELECT a FROM abc ORDER BY a DESC
 ----
-revscan  ·      ·
-·        table  abc@primary
-·        spans  ALL
+·        distributed  false
+·        vectorized   true
+revscan  ·            ·
+·        table        abc@primary
+·        spans        ALL
 
 query TTT
 EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c
 ----
-render     ·      ·
- └── scan  ·      ·
-·          table  abc@bc
-·          spans  /2-/3
+·          distributed  false
+·          vectorized   true
+render     ·            ·
+ └── scan  ·            ·
+·          table        abc@bc
+·          spans        /2-/3
 
 query TTT
 EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c DESC
 ----
-render        ·      ·
- └── revscan  ·      ·
-·             table  abc@bc
-·             spans  /2-/3
+·             distributed  false
+·             vectorized   true
+render        ·            ·
+ └── revscan  ·            ·
+·             table        abc@bc
+·             spans        /2-/3
 
 # Verify that the ordering of the primary index is still used for the outer sort.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT b, c FROM abc WHERE a=1 ORDER BY a,b) ORDER BY b,c
 ----
-render     ·         ·            (b, c)     +b,+c
- │         render 0  b            ·          ·
- │         render 1  c            ·          ·
- └── scan  ·         ·            (a, b, c)  +b,+c
-·          table     abc@primary  ·          ·
-·          spans     /1-/2        ·          ·
+·          distributed  false        ·          ·
+·          vectorized   true         ·          ·
+render     ·            ·            (b, c)     +b,+c
+ │         render 0     b            ·          ·
+ │         render 1     c            ·          ·
+ └── scan  ·            ·            (a, b, c)  +b,+c
+·          table        abc@primary  ·          ·
+·          spans        /1-/2        ·          ·
 
 statement ok
 CREATE TABLE bar (id INT PRIMARY KEY, baz STRING, UNIQUE INDEX i_bar (baz))
@@ -385,9 +443,11 @@ CREATE TABLE bar (id INT PRIMARY KEY, baz STRING, UNIQUE INDEX i_bar (baz))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM bar ORDER BY baz, id
 ----
-scan  ·      ·          (id, baz)  +baz,+id
-·     table  bar@i_bar  ·          ·
-·     spans  ALL        ·          ·
+·     distributed  false      ·          ·
+·     vectorized   true       ·          ·
+scan  ·            ·          (id, baz)  +baz,+id
+·     table        bar@i_bar  ·          ·
+·     spans        ALL        ·          ·
 
 statement ok
 CREATE TABLE abcd (
@@ -407,30 +467,38 @@ CREATE TABLE abcd (
 query TTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c
 ----
-scan  ·      ·
-·     table  abcd@abc
-·     spans  /1/4-/1/5
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        abcd@abc
+·     spans        /1/4-/1/5
 
 query TTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c, b, a
 ----
-scan  ·      ·
-·     table  abcd@abc
-·     spans  /1/4-/1/5
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        abcd@abc
+·     spans        /1/4-/1/5
 
 query TTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, a, c
 ----
-scan  ·      ·
-·     table  abcd@abc
-·     spans  /1/4-/1/5
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        abcd@abc
+·     spans        /1/4-/1/5
 
 query TTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, c, a
 ----
-scan  ·      ·
-·     table  abcd@abc
-·     spans  /1/4-/1/5
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        abcd@abc
+·     spans        /1/4-/1/5
 
 statement ok
 CREATE TABLE nan (id INT PRIMARY KEY, x REAL)
@@ -438,6 +506,8 @@ CREATE TABLE nan (id INT PRIMARY KEY, x REAL)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x)
 ----
+·       distributed    false             ·    ·
+·       vectorized     false             ·    ·
 values  ·              ·                 (x)  ·
 ·       size           1 column, 3 rows  ·    ·
 ·       row 0, expr 0  'a'               ·    ·
@@ -447,22 +517,28 @@ values  ·              ·                 (x)  ·
 query TTT
 EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality ASC
 ----
-ordinality   ·     ·
- └── values  ·     ·
-·            size  1 column, 3 rows
+·            distributed  false
+·            vectorized   false
+ordinality   ·            ·
+ └── values  ·            ·
+·            size         1 column, 3 rows
 
 query TTT
 EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality DESC
 ----
-sort              ·      ·
- │                order  -"ordinality"
- └── ordinality   ·      ·
-      └── values  ·      ·
-·                 size   1 column, 3 rows
+·                 distributed  false
+·                 vectorized   false
+sort              ·            ·
+ │                order        -"ordinality"
+ └── ordinality   ·            ·
+      └── values  ·            ·
+·                 size         1 column, 3 rows
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x)) WITH ORDINALITY
 ----
+·            distributed    false             ·                  ·
+·            vectorized     false             ·                  ·
 ordinality   ·              ·                 (x, "ordinality")  ·
  └── values  ·              ·                 (column1)          ·
 ·            size           1 column, 3 rows  ·                  ·
@@ -473,6 +549,8 @@ ordinality   ·              ·                 (x, "ordinality")  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x) WITH ORDINALITY
 ----
+·                 distributed    false             ·                  ·
+·                 vectorized     false             ·                  ·
 ordinality        ·              ·                 (x, "ordinality")  ·
  └── sort         ·              ·                 (column1)          +column1
       │           order          +column1          ·                  ·
@@ -486,6 +564,8 @@ ordinality        ·              ·                 (x, "ordinality")  ·
 query TTTTT
 EXPLAIN (VERBOSE) INSERT INTO t(a, b) SELECT * FROM (SELECT 1 AS x, 2 AS y) ORDER BY x RETURNING b
 ----
+·                      distributed    false               ·                ·
+·                      vectorized     false               ·                ·
 render                 ·              ·                   (b)              ·
  │                     render 0       b                   ·                ·
  └── run               ·              ·                   (a, b)           ·
@@ -501,34 +581,38 @@ render                 ·              ·                   (b)              ·
 query TTTTT
 EXPLAIN (VERBOSE) DELETE FROM t WHERE a = 3 RETURNING b
 ----
-render               ·         ·          (b)     ·
- │                   render 0  b          ·       ·
- └── run             ·         ·          (a, b)  ·
-      └── delete     ·         ·          (a, b)  ·
-           │         from      t          ·       ·
-           │         strategy  deleter    ·       ·
-           └── scan  ·         ·          (a, b)  ·
-·                    table     t@primary  ·       ·
-·                    spans     /3-/3/#    ·       ·
+·                    distributed  false      ·       ·
+·                    vectorized   false      ·       ·
+render               ·            ·          (b)     ·
+ │                   render 0     b          ·       ·
+ └── run             ·            ·          (a, b)  ·
+      └── delete     ·            ·          (a, b)  ·
+           │         from         t          ·       ·
+           │         strategy     deleter    ·       ·
+           └── scan  ·            ·          (a, b)  ·
+·                    table        t@primary  ·       ·
+·                    spans        /3-/3/#    ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE t SET c = TRUE RETURNING b
 ----
-render                    ·         ·          (b)                 ·
- │                        render 0  b          ·                   ·
- └── run                  ·         ·          (a, b)              ·
-      └── update          ·         ·          (a, b)              ·
-           │              table     t          ·                   ·
-           │              set       c          ·                   ·
-           │              strategy  updater    ·                   ·
-           └── render     ·         ·          (a, b, c, column7)  ·
-                │         render 0  a          ·                   ·
-                │         render 1  b          ·                   ·
-                │         render 2  c          ·                   ·
-                │         render 3  true       ·                   ·
-                └── scan  ·         ·          (a, b, c)           ·
-·                         table     t@primary  ·                   ·
-·                         spans     ALL        ·                   ·
+·                         distributed  false      ·                   ·
+·                         vectorized   false      ·                   ·
+render                    ·            ·          (b)                 ·
+ │                        render 0     b          ·                   ·
+ └── run                  ·            ·          (a, b)              ·
+      └── update          ·            ·          (a, b)              ·
+           │              table        t          ·                   ·
+           │              set          c          ·                   ·
+           │              strategy     updater    ·                   ·
+           └── render     ·            ·          (a, b, c, column7)  ·
+                │         render 0     a          ·                   ·
+                │         render 1     b          ·                   ·
+                │         render 2     c          ·                   ·
+                │         render 3     true       ·                   ·
+                └── scan  ·            ·          (a, b, c)           ·
+·                         table        t@primary  ·                   ·
+·                         spans        ALL        ·                   ·
 
 statement ok
 CREATE TABLE uvwxyz (
@@ -547,13 +631,15 @@ CREATE TABLE uvwxyz (
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT y, w, x FROM uvwxyz WHERE y = 1 ORDER BY w) ORDER BY w, x
 ----
-render     ·         ·            (y, w, x)  ·
- │         render 0  y            ·          ·
- │         render 1  w            ·          ·
- │         render 2  x            ·          ·
- └── scan  ·         ·            (w, x, y)  +w,+x
-·          table     uvwxyz@ywxz  ·          ·
-·          spans     /1-/2        ·          ·
+·          distributed  false        ·          ·
+·          vectorized   true         ·          ·
+render     ·            ·            (y, w, x)  ·
+ │         render 0     y            ·          ·
+ │         render 1     w            ·          ·
+ │         render 2     x            ·          ·
+ └── scan  ·            ·            (w, x, y)  +w,+x
+·          table        uvwxyz@ywxz  ·          ·
+·          spans        /1-/2        ·          ·
 
 
 statement ok
@@ -574,15 +660,17 @@ CREATE TABLE blocks (
 query TTTTT
 EXPLAIN (VERBOSE) SELECT block_id,writer_id,block_num,block_id FROM blocks ORDER BY block_id, writer_id, block_num LIMIT 1
 ----
-render     ·         ·               (block_id, writer_id, block_num, block_id)  ·
- │         render 0  block_id        ·                                           ·
- │         render 1  writer_id       ·                                           ·
- │         render 2  block_num       ·                                           ·
- │         render 3  block_id        ·                                           ·
- └── scan  ·         ·               (block_id, writer_id, block_num)            ·
-·          table     blocks@primary  ·                                           ·
-·          spans     ALL             ·                                           ·
-·          limit     1               ·                                           ·
+·          distributed  false           ·                                           ·
+·          vectorized   true            ·                                           ·
+render     ·            ·               (block_id, writer_id, block_num, block_id)  ·
+ │         render 0     block_id        ·                                           ·
+ │         render 1     writer_id       ·                                           ·
+ │         render 2     block_num       ·                                           ·
+ │         render 3     block_id        ·                                           ·
+ └── scan  ·            ·               (block_id, writer_id, block_num)            ·
+·          table        blocks@primary  ·                                           ·
+·          spans        ALL             ·                                           ·
+·          limit        1               ·                                           ·
 
 statement ok
 CREATE TABLE foo(a INT, b CHAR)
@@ -591,34 +679,38 @@ CREATE TABLE foo(a INT, b CHAR)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT b, a FROM foo ORDER BY @1
 ----
-render               ·         ·            (b, a)           ·
- │                   render 0  b            ·                ·
- │                   render 1  a            ·                ·
- └── sort            ·         ·            (column4, a, b)  +column4
-      │              order     +column4     ·                ·
-      └── render     ·         ·            (column4, a, b)  ·
-           │         render 0  a            ·                ·
-           │         render 1  a            ·                ·
-           │         render 2  b            ·                ·
-           └── scan  ·         ·            (a, b)           ·
-·                    table     foo@primary  ·                ·
-·                    spans     ALL          ·                ·
+·                    distributed  false        ·                ·
+·                    vectorized   false        ·                ·
+render               ·            ·            (b, a)           ·
+ │                   render 0     b            ·                ·
+ │                   render 1     a            ·                ·
+ └── sort            ·            ·            (column4, a, b)  +column4
+      │              order        +column4     ·                ·
+      └── render     ·            ·            (column4, a, b)  ·
+           │         render 0     a            ·                ·
+           │         render 1     a            ·                ·
+           │         render 2     b            ·                ·
+           └── scan  ·            ·            (a, b)           ·
+·                    table        foo@primary  ·                ·
+·                    spans        ALL          ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT b, a FROM foo ORDER BY @2
 ----
-render               ·         ·            (b, a)           ·
- │                   render 0  b            ·                ·
- │                   render 1  a            ·                ·
- └── sort            ·         ·            (column4, a, b)  +column4
-      │              order     +column4     ·                ·
-      └── render     ·         ·            (column4, a, b)  ·
-           │         render 0  b            ·                ·
-           │         render 1  a            ·                ·
-           │         render 2  b            ·                ·
-           └── scan  ·         ·            (a, b)           ·
-·                    table     foo@primary  ·                ·
-·                    spans     ALL          ·                ·
+·                    distributed  false        ·                ·
+·                    vectorized   false        ·                ·
+render               ·            ·            (b, a)           ·
+ │                   render 0     b            ·                ·
+ │                   render 1     a            ·                ·
+ └── sort            ·            ·            (column4, a, b)  +column4
+      │              order        +column4     ·                ·
+      └── render     ·            ·            (column4, a, b)  ·
+           │         render 0     b            ·                ·
+           │         render 1     a            ·                ·
+           │         render 2     b            ·                ·
+           └── scan  ·            ·            (a, b)           ·
+·                    table        foo@primary  ·                ·
+·                    spans        ALL          ·                ·
 
 # ------------------------------------------------------------------------------
 # Check star expansion in ORDER BY.
@@ -631,22 +723,26 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM a ORDER BY a.*
 ]
 ----
-sort       ·      ·
- │         order  +x,+y
- └── scan  ·      ·
-·          table  a@primary
-·          spans  ALL
+·          distributed  false
+·          vectorized   false
+sort       ·            ·
+ │         order        +x,+y
+ └── scan  ·            ·
+·          table        a@primary
+·          spans        ALL
 
 query TTT
 SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM a ORDER BY (a.*)
 ]
 ----
-sort       ·      ·
- │         order  +x,+y
- └── scan  ·      ·
-·          table  a@primary
-·          spans  ALL
+·          distributed  false
+·          vectorized   false
+sort       ·            ·
+ │         order        +x,+y
+ └── scan  ·            ·
+·          table        a@primary
+·          spans        ALL
 
 # ------------------------------------------------------------------------------
 # ORDER BY INDEX test cases.
@@ -659,76 +755,92 @@ CREATE TABLE kv(k INT PRIMARY KEY, v INT); CREATE INDEX foo ON kv(v DESC)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT v FROM kv ORDER BY PRIMARY KEY kv
 ----
-render     ·         ·           (v)     ·
- │         render 0  v           ·       ·
- └── scan  ·         ·           (k, v)  +k
-·          table     kv@primary  ·       ·
-·          spans     ALL         ·       ·
+·          distributed  false       ·       ·
+·          vectorized   true        ·       ·
+render     ·            ·           (v)     ·
+ │         render 0     v           ·       ·
+ └── scan  ·            ·           (k, v)  +k
+·          table        kv@primary  ·       ·
+·          spans        ALL         ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT v FROM kv ORDER BY PRIMARY KEY kv ASC
 ----
-render     ·         ·           (v)     ·
- │         render 0  v           ·       ·
- └── scan  ·         ·           (k, v)  +k
-·          table     kv@primary  ·       ·
-·          spans     ALL         ·       ·
+·          distributed  false       ·       ·
+·          vectorized   true        ·       ·
+render     ·            ·           (v)     ·
+ │         render 0     v           ·       ·
+ └── scan  ·            ·           (k, v)  +k
+·          table        kv@primary  ·       ·
+·          spans        ALL         ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT v FROM kv ORDER BY PRIMARY KEY kv DESC
 ----
-render        ·         ·           (v)     ·
- │            render 0  v           ·       ·
- └── revscan  ·         ·           (k, v)  -k
-·             table     kv@primary  ·       ·
-·             spans     ALL         ·       ·
+·             distributed  false       ·       ·
+·             vectorized   true        ·       ·
+render        ·            ·           (v)     ·
+ │            render 0     v           ·       ·
+ └── revscan  ·            ·           (k, v)  -k
+·             table        kv@primary  ·       ·
+·             spans        ALL         ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY v, PRIMARY KEY kv, v-2
 ----
-render          ·         ·           (k)     ·
- │              render 0  k           ·       ·
- └── sort       ·         ·           (k, v)  +v,+k
-      │         order     +v,+k       ·       ·
-      └── scan  ·         ·           (k, v)  ·
-·               table     kv@primary  ·       ·
-·               spans     ALL         ·       ·
+·               distributed  false       ·       ·
+·               vectorized   false       ·       ·
+render          ·            ·           (k)     ·
+ │              render 0     k           ·       ·
+ └── sort       ·            ·           (k, v)  +v,+k
+      │         order        +v,+k       ·       ·
+      └── scan  ·            ·           (k, v)  ·
+·               table        kv@primary  ·       ·
+·               spans        ALL         ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo
 ----
-render     ·         ·       (k)     ·
- │         render 0  k       ·       ·
- └── scan  ·         ·       (k, v)  -v,+k
-·          table     kv@foo  ·       ·
-·          spans     ALL     ·       ·
+·          distributed  false   ·       ·
+·          vectorized   true    ·       ·
+render     ·            ·       (k)     ·
+ │         render 0     k       ·       ·
+ └── scan  ·            ·       (k, v)  -v,+k
+·          table        kv@foo  ·       ·
+·          spans        ALL     ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo ASC
 ----
-render     ·         ·       (k)     ·
- │         render 0  k       ·       ·
- └── scan  ·         ·       (k, v)  -v,+k
-·          table     kv@foo  ·       ·
-·          spans     ALL     ·       ·
+·          distributed  false   ·       ·
+·          vectorized   true    ·       ·
+render     ·            ·       (k)     ·
+ │         render 0     k       ·       ·
+ └── scan  ·            ·       (k, v)  -v,+k
+·          table        kv@foo  ·       ·
+·          spans        ALL     ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo DESC
 ----
-render        ·         ·       (k)     ·
- │            render 0  k       ·       ·
- └── revscan  ·         ·       (k, v)  +v,-k
-·             table     kv@foo  ·       ·
-·             spans     ALL     ·       ·
+·             distributed  false   ·       ·
+·             vectorized   true    ·       ·
+render        ·            ·       (k)     ·
+ │            render 0     k       ·       ·
+ └── revscan  ·            ·       (k, v)  +v,-k
+·             table        kv@foo  ·       ·
+·             spans        ALL     ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo, k
 ----
-render     ·         ·       (k)     ·
- │         render 0  k       ·       ·
- └── scan  ·         ·       (k, v)  -v,+k
-·          table     kv@foo  ·       ·
-·          spans     ALL     ·       ·
+·          distributed  false   ·       ·
+·          vectorized   true    ·       ·
+render     ·            ·       (k)     ·
+ │         render 0     k       ·       ·
+ └── scan  ·            ·       (k, v)  -v,+k
+·          table        kv@foo  ·       ·
+·          spans        ALL     ·       ·
 
 # Check the syntax can be used with joins.
 #
@@ -740,6 +852,8 @@ query TTTTT
 EXPLAIN (VERBOSE)
 SELECT k FROM kv JOIN (VALUES (1,2), (3,4)) AS z(a,b) ON kv.k = z.a ORDER BY INDEX kv@foo
 ----
+·                           distributed            false             ·                ·
+·                           vectorized             false             ·                ·
 render                      ·                      ·                 (k)              ·
  │                          render 0               k                 ·                ·
  └── sort                   ·                      ·                 (k, v)           -v,+k
@@ -760,6 +874,8 @@ render                      ·                      ·                 (k)      
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv a NATURAL JOIN kv ORDER BY INDEX kv@foo
 ----
+·                distributed         false              ·             ·
+·                vectorized          true               ·             ·
 render           ·                   ·                  (k)           ·
  │               render 0            k                  ·             ·
  └── merge-join  ·                   ·                  (k, v, k, v)  -v,+k
@@ -782,12 +898,14 @@ CREATE TABLE xyz (x INT, y INT, z INT, INDEX(z,y))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyz WHERE z=1 AND x=y ORDER BY x;
 ----
-sort                  ·       ·                (x, y, z)              +x
- │                    order   +x               ·                      ·
- └── filter           ·       ·                (x, y, z)              ·
-      │               filter  x = y            ·                      ·
-      └── index-join  ·       ·                (x, y, z)              ·
-           │          table   xyz@primary      ·                      ·
-           └── scan   ·       ·                (y, z, rowid[hidden])  ·
-·                     table   xyz@xyz_z_y_idx  ·                      ·
-·                     spans   /1/!NULL-/2      ·                      ·
+·                     distributed  false            ·                      ·
+·                     vectorized   false            ·                      ·
+sort                  ·            ·                (x, y, z)              +x
+ │                    order        +x               ·                      ·
+ └── filter           ·            ·                (x, y, z)              ·
+      │               filter       x = y            ·                      ·
+      └── index-join  ·            ·                (x, y, z)              ·
+           │          table        xyz@primary      ·                      ·
+           └── scan   ·            ·                (y, z, rowid[hidden])  ·
+·                     table        xyz@xyz_z_y_idx  ·                      ·
+·                     spans        /1/!NULL-/2      ·                      ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/ordinality
+++ b/pkg/sql/opt/exec/execbuilder/testdata/ordinality
@@ -6,6 +6,8 @@ CREATE TABLE foo (x CHAR PRIMARY KEY); INSERT INTO foo(x) VALUES ('a'), ('b')
 query TTTTT
 EXPLAIN (VERBOSE) SELECT max(ordinality) FROM foo WITH ORDINALITY
 ----
+·                distributed  false            ·               ·
+·                vectorized   true             ·               ·
 group            ·            ·                (max)           ·
  │               aggregate 0  max(ordinality)  ·               ·
  │               scalar       ·                ·               ·
@@ -17,42 +19,50 @@ group            ·            ·                (max)           ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM foo WITH ORDINALITY WHERE ordinality > 1 ORDER BY ordinality
 ----
-filter           ·       ·                 (x, "ordinality")  +"ordinality"
- │               filter  "ordinality" > 1  ·                  ·
- └── ordinality  ·       ·                 (x, "ordinality")  ·
-      └── scan   ·       ·                 (x)                ·
-·                table   foo@primary       ·                  ·
-·                spans   ALL               ·                  ·
+·                distributed  false             ·                  ·
+·                vectorized   true              ·                  ·
+filter           ·            ·                 (x, "ordinality")  +"ordinality"
+ │               filter       "ordinality" > 1  ·                  ·
+ └── ordinality  ·            ·                 (x, "ordinality")  ·
+      └── scan   ·            ·                 (x)                ·
+·                table        foo@primary       ·                  ·
+·                spans        ALL               ·                  ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM foo WITH ORDINALITY WHERE ordinality > 1 ORDER BY ordinality DESC
 ----
-sort                  ·       ·                 (x, "ordinality")  -"ordinality"
- │                    order   -"ordinality"     ·                  ·
- └── filter           ·       ·                 (x, "ordinality")  ·
-      │               filter  "ordinality" > 1  ·                  ·
-      └── ordinality  ·       ·                 (x, "ordinality")  ·
-           └── scan   ·       ·                 (x)                ·
-·                     table   foo@primary       ·                  ·
-·                     spans   ALL               ·                  ·
+·                     distributed  false             ·                  ·
+·                     vectorized   false             ·                  ·
+sort                  ·            ·                 (x, "ordinality")  -"ordinality"
+ │                    order        -"ordinality"     ·                  ·
+ └── filter           ·            ·                 (x, "ordinality")  ·
+      │               filter       "ordinality" > 1  ·                  ·
+      └── ordinality  ·            ·                 (x, "ordinality")  ·
+           └── scan   ·            ·                 (x)                ·
+·                     table        foo@primary       ·                  ·
+·                     spans        ALL               ·                  ·
 
 # Show that the primary key is used under ordinalityNode.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM foo WHERE x > 'a') WITH ORDINALITY
 ----
-ordinality  ·      ·            (x, "ordinality")  ·
- └── scan   ·      ·            (x)                ·
-·           table  foo@primary  ·                  ·
-·           spans  /"a\x00"-    ·                  ·
+·           distributed  false        ·                  ·
+·           vectorized   true         ·                  ·
+ordinality  ·            ·            (x, "ordinality")  ·
+ └── scan   ·            ·            (x)                ·
+·           table        foo@primary  ·                  ·
+·           spans        /"a\x00"-    ·                  ·
 
 # Show that the primary key cannot be used with a PK predicate
 # outside of ordinalityNode.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM foo WITH ORDINALITY WHERE x > 'a'
 ----
-filter           ·       ·            (x, "ordinality")  ·
- │               filter  x > 'a'      ·                  ·
- └── ordinality  ·       ·            (x, "ordinality")  ·
-      └── scan   ·       ·            (x)                ·
-·                table   foo@primary  ·                  ·
-·                spans   ALL          ·                  ·
+·                distributed  false        ·                  ·
+·                vectorized   true         ·                  ·
+filter           ·            ·            (x, "ordinality")  ·
+ │               filter       x > 'a'      ·                  ·
+ └── ordinality  ·            ·            (x, "ordinality")  ·
+      └── scan   ·            ·            (x)                ·
+·                table        foo@primary  ·                  ·
+·                spans        ALL          ·                  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -11,10 +11,12 @@ PREPARE change_index AS SELECT * FROM [EXPLAIN SELECT * FROM ab WHERE b=10]
 query TTT
 EXECUTE change_index
 ----
-scan  ·       ·
-·     table   ab@primary
-·     spans   ALL
-·     filter  b = 10
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        ab@primary
+·     spans        ALL
+·     filter       b = 10
 
 statement ok
 CREATE INDEX bindex ON ab (b)
@@ -22,9 +24,11 @@ CREATE INDEX bindex ON ab (b)
 query TTT
 EXECUTE change_index
 ----
-scan  ·      ·
-·     table  ab@bindex
-·     spans  /10-/11
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        ab@bindex
+·     spans        /10-/11
 
 statement ok
 DROP INDEX bindex
@@ -32,10 +36,12 @@ DROP INDEX bindex
 query TTT
 EXECUTE change_index
 ----
-scan  ·       ·
-·     table   ab@primary
-·     spans   ALL
-·     filter  b = 10
+·     distributed  true
+·     vectorized   true
+scan  ·            ·
+·     table        ab@primary
+·     spans        ALL
+·     filter       b = 10
 
 ## Statistics change: Create statistics and ensure that the plan is recalculated.
 statement ok
@@ -47,6 +53,8 @@ PREPARE change_stats AS SELECT * FROM [EXPLAIN SELECT * FROM ab JOIN cd ON a=c]
 query TTT
 EXECUTE change_stats
 ----
+·           distributed         true
+·           vectorized          false
 merge-join  ·                   ·
  │          type                inner
  │          equality            (a) = (c)
@@ -69,6 +77,8 @@ CREATE STATISTICS s FROM ab
 query TTT retry
 EXECUTE change_stats
 ----
+·            distributed            true
+·            vectorized             true
 lookup-join  ·                      ·
  │           table                  cd@primary
  │           type                   inner

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -10,6 +10,8 @@ CREATE TABLE t (a INT, b INT, c INT, d INT, j JSONB, s STRING)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 + 2 AS r
 ----
+·       distributed    false            ·    ·
+·       vectorized     false            ·    ·
 values  ·              ·                (r)  ·
 ·       size           1 column, 1 row  ·    ·
 ·       row 0, expr 0  3                ·    ·
@@ -17,6 +19,8 @@ values  ·              ·                (r)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT true AS r
 ----
+·       distributed    false            ·    ·
+·       vectorized     false            ·    ·
 values  ·              ·                (r)  ·
 ·       size           1 column, 1 row  ·    ·
 ·       row 0, expr 0  true             ·    ·
@@ -24,6 +28,8 @@ values  ·              ·                (r)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT false AS r
 ----
+·       distributed    false            ·    ·
+·       vectorized     false            ·    ·
 values  ·              ·                (r)  ·
 ·       size           1 column, 1 row  ·    ·
 ·       row 0, expr 0  false            ·    ·
@@ -31,6 +37,8 @@ values  ·              ·                (r)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT (1, 2) AS r
 ----
+·       distributed    false            ·    ·
+·       vectorized     false            ·    ·
 values  ·              ·                (r)  ·
 ·       size           1 column, 1 row  ·    ·
 ·       row 0, expr 0  (1, 2)           ·    ·
@@ -38,6 +46,8 @@ values  ·              ·                (r)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT (true, false) AS r
 ----
+·       distributed    false            ·    ·
+·       vectorized     false            ·    ·
 values  ·              ·                (r)  ·
 ·       size           1 column, 1 row  ·    ·
 ·       row 0, expr 0  (true, false)    ·    ·
@@ -45,237 +55,289 @@ values  ·              ·                (r)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 + 2 AS r FROM t
 ----
-render     ·         ·          (r)  ·
- │         render 0  3          ·    ·
- └── scan  ·         ·          ()   ·
-·          table     t@primary  ·    ·
-·          spans     ALL        ·    ·
+·          distributed  false      ·    ·
+·          vectorized   false      ·    ·
+render     ·            ·          (r)  ·
+ │         render 0     3          ·    ·
+ └── scan  ·            ·          ()   ·
+·          table        t@primary  ·    ·
+·          spans        ALL        ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a + 2 AS r FROM t
 ----
-render     ·         ·          (r)  ·
- │         render 0  a + 2      ·    ·
- └── scan  ·         ·          (a)  ·
-·          table     t@primary  ·    ·
-·          spans     ALL        ·    ·
+·          distributed  false      ·    ·
+·          vectorized   false      ·    ·
+render     ·            ·          (r)  ·
+ │         render 0     a + 2      ·    ·
+ └── scan  ·            ·          (a)  ·
+·          table        t@primary  ·    ·
+·          spans        ALL        ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a >= 5 AND b <= 10 AND c < 4 AS r FROM t
 ----
-render     ·         ·                                     (r)        ·
- │         render 0  ((a >= 5) AND (b <= 10)) AND (c < 4)  ·          ·
- └── scan  ·         ·                                     (a, b, c)  ·
-·          table     t@primary                             ·          ·
-·          spans     ALL                                   ·          ·
+·          distributed  false                                 ·          ·
+·          vectorized   false                                 ·          ·
+render     ·            ·                                     (r)        ·
+ │         render 0     ((a >= 5) AND (b <= 10)) AND (c < 4)  ·          ·
+ └── scan  ·            ·                                     (a, b, c)  ·
+·          table        t@primary                             ·          ·
+·          spans        ALL                                   ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a >= 5 OR b <= 10 OR c < 4 AS r FROM t
 ----
-render     ·         ·                                   (r)        ·
- │         render 0  ((a >= 5) OR (b <= 10)) OR (c < 4)  ·          ·
- └── scan  ·         ·                                   (a, b, c)  ·
-·          table     t@primary                           ·          ·
-·          spans     ALL                                 ·          ·
+·          distributed  false                               ·          ·
+·          vectorized   false                               ·          ·
+render     ·            ·                                   (r)        ·
+ │         render 0     ((a >= 5) OR (b <= 10)) OR (c < 4)  ·          ·
+ └── scan  ·            ·                                   (a, b, c)  ·
+·          table        t@primary                           ·          ·
+·          spans        ALL                                 ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT NOT (a = 5) AS r FROM t
 ----
-render     ·         ·          (r)  ·
- │         render 0  a != 5     ·    ·
- └── scan  ·         ·          (a)  ·
-·          table     t@primary  ·    ·
-·          spans     ALL        ·    ·
+·          distributed  false      ·    ·
+·          vectorized   false      ·    ·
+render     ·            ·          (r)  ·
+ │         render 0     a != 5     ·    ·
+ └── scan  ·            ·          (a)  ·
+·          table        t@primary  ·    ·
+·          spans        ALL        ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT NOT (a > 5 AND b >= 10) AS r FROM t
 ----
-render     ·         ·                     (r)     ·
- │         render 0  (a <= 5) OR (b < 10)  ·       ·
- └── scan  ·         ·                     (a, b)  ·
-·          table     t@primary             ·       ·
-·          spans     ALL                   ·       ·
+·          distributed  false                 ·       ·
+·          vectorized   false                 ·       ·
+render     ·            ·                     (r)     ·
+ │         render 0     (a <= 5) OR (b < 10)  ·       ·
+ └── scan  ·            ·                     (a, b)  ·
+·          table        t@primary             ·       ·
+·          spans        ALL                   ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT (a >= 5 AND b <= 10) OR (a <= 10 AND c > 5) AS r FROM t
 ----
-render     ·         ·                                                    (r)        ·
- │         render 0  ((a >= 5) AND (b <= 10)) OR ((a <= 10) AND (c > 5))  ·          ·
- └── scan  ·         ·                                                    (a, b, c)  ·
-·          table     t@primary                                            ·          ·
-·          spans     ALL                                                  ·          ·
+·          distributed  false                                                ·          ·
+·          vectorized   false                                                ·          ·
+render     ·            ·                                                    (r)        ·
+ │         render 0     ((a >= 5) AND (b <= 10)) OR ((a <= 10) AND (c > 5))  ·          ·
+ └── scan  ·            ·                                                    (a, b, c)  ·
+·          table        t@primary                                            ·          ·
+·          spans        ALL                                                  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT NOT (a >= 5 OR b <= 10) AND NOT (c >= 10) AS r FROM t
 ----
-render     ·         ·                                    (r)        ·
- │         render 0  ((a < 5) AND (b > 10)) AND (c < 10)  ·          ·
- └── scan  ·         ·                                    (a, b, c)  ·
-·          table     t@primary                            ·          ·
-·          spans     ALL                                  ·          ·
+·          distributed  false                                ·          ·
+·          vectorized   false                                ·          ·
+render     ·            ·                                    (r)        ·
+ │         render 0     ((a < 5) AND (b > 10)) AND (c < 10)  ·          ·
+ └── scan  ·            ·                                    (a, b, c)  ·
+·          table        t@primary                            ·          ·
+·          spans        ALL                                  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT (a, b) = (1, 2)  AS r FROM t
 ----
-render     ·         ·                    (r)     ·
- │         render 0  (a = 1) AND (b = 2)  ·       ·
- └── scan  ·         ·                    (a, b)  ·
-·          table     t@primary            ·       ·
-·          spans     ALL                  ·       ·
+·          distributed  false                ·       ·
+·          vectorized   false                ·       ·
+render     ·            ·                    (r)     ·
+ │         render 0     (a = 1) AND (b = 2)  ·       ·
+ └── scan  ·            ·                    (a, b)  ·
+·          table        t@primary            ·       ·
+·          spans        ALL                  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a IN (1, 2) AS r FROM t
 ----
-render     ·         ·            (r)  ·
- │         render 0  a IN (1, 2)  ·    ·
- └── scan  ·         ·            (a)  ·
-·          table     t@primary    ·    ·
-·          spans     ALL          ·    ·
+·          distributed  false        ·    ·
+·          vectorized   false        ·    ·
+render     ·            ·            (r)  ·
+ │         render 0     a IN (1, 2)  ·    ·
+ └── scan  ·            ·            (a)  ·
+·          table        t@primary    ·    ·
+·          spans        ALL          ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT (a, b) IN ((1, 2), (3, 4)) AS r FROM t
 ----
-render     ·         ·                           (r)     ·
- │         render 0  (a, b) IN ((1, 2), (3, 4))  ·       ·
- └── scan  ·         ·                           (a, b)  ·
-·          table     t@primary                   ·       ·
-·          spans     ALL                         ·       ·
+·          distributed  false                       ·       ·
+·          vectorized   false                       ·       ·
+render     ·            ·                           (r)     ·
+ │         render 0     (a, b) IN ((1, 2), (3, 4))  ·       ·
+ └── scan  ·            ·                           (a, b)  ·
+·          table        t@primary                   ·       ·
+·          spans        ALL                         ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT (a, b + c, 5 + d * 2) = (b+c, 8, a - c)  AS r FROM t
 ----
-render     ·         ·                                                                (r)           ·
- │         render 0  ((a = (b + c)) AND ((b + c) = 8)) AND (((d * 2) + 5) = (a - c))  ·             ·
- └── scan  ·         ·                                                                (a, b, c, d)  ·
-·          table     t@primary                                                        ·             ·
-·          spans     ALL                                                              ·             ·
+·          distributed  false                                                            ·             ·
+·          vectorized   false                                                            ·             ·
+render     ·            ·                                                                (r)           ·
+ │         render 0     ((a = (b + c)) AND ((b + c) = 8)) AND (((d * 2) + 5) = (a - c))  ·             ·
+ └── scan  ·            ·                                                                (a, b, c, d)  ·
+·          table        t@primary                                                        ·             ·
+·          spans        ALL                                                              ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ((a, b), (c, d)) = ((1, 2), (3, 4))  AS r FROM t
 ----
-render     ·         ·                                                (r)           ·
- │         render 0  (((a = 1) AND (b = 2)) AND (c = 3)) AND (d = 4)  ·             ·
- └── scan  ·         ·                                                (a, b, c, d)  ·
-·          table     t@primary                                        ·             ·
-·          spans     ALL                                              ·             ·
+·          distributed  false                                            ·             ·
+·          vectorized   false                                            ·             ·
+render     ·            ·                                                (r)           ·
+ │         render 0     (((a = 1) AND (b = 2)) AND (c = 3)) AND (d = 4)  ·             ·
+ └── scan  ·            ·                                                (a, b, c, d)  ·
+·          table        t@primary                                        ·             ·
+·          spans        ALL                                              ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT (a, (b, 'a'), (c, 'b', 5)) = (9, (a+c, s), (5, s, a)) AS r FROM t
 ----
-render     ·         ·                                                                                      (r)           ·
- │         render 0  (((((a = 9) AND (b = (a + c))) AND (s = 'a')) AND (c = 5)) AND (s = 'b')) AND (a = 5)  ·             ·
- └── scan  ·         ·                                                                                      (a, b, c, s)  ·
-·          table     t@primary                                                                              ·             ·
-·          spans     ALL                                                                                    ·             ·
+·          distributed  false                                                                                  ·             ·
+·          vectorized   false                                                                                  ·             ·
+render     ·            ·                                                                                      (r)           ·
+ │         render 0     (((((a = 9) AND (b = (a + c))) AND (s = 'a')) AND (c = 5)) AND (s = 'b')) AND (a = 5)  ·             ·
+ └── scan  ·            ·                                                                                      (a, b, c, s)  ·
+·          table        t@primary                                                                              ·             ·
+·          spans        ALL                                                                                    ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a IS NULL AS r FROM t
 ----
-render     ·         ·          (r)  ·
- │         render 0  a IS NULL  ·    ·
- └── scan  ·         ·          (a)  ·
-·          table     t@primary  ·    ·
-·          spans     ALL        ·    ·
+·          distributed  false      ·    ·
+·          vectorized   false      ·    ·
+render     ·            ·          (r)  ·
+ │         render 0     a IS NULL  ·    ·
+ └── scan  ·            ·          (a)  ·
+·          table        t@primary  ·    ·
+·          spans        ALL        ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a IS NOT DISTINCT FROM NULL AS r FROM t
 ----
-render     ·         ·          (r)  ·
- │         render 0  a IS NULL  ·    ·
- └── scan  ·         ·          (a)  ·
-·          table     t@primary  ·    ·
-·          spans     ALL        ·    ·
+·          distributed  false      ·    ·
+·          vectorized   false      ·    ·
+render     ·            ·          (r)  ·
+ │         render 0     a IS NULL  ·    ·
+ └── scan  ·            ·          (a)  ·
+·          table        t@primary  ·    ·
+·          spans        ALL        ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a IS NOT DISTINCT FROM b AS r FROM t
 ----
-render     ·         ·                         (r)     ·
- │         render 0  a IS NOT DISTINCT FROM b  ·       ·
- └── scan  ·         ·                         (a, b)  ·
-·          table     t@primary                 ·       ·
-·          spans     ALL                       ·       ·
+·          distributed  false                     ·       ·
+·          vectorized   false                     ·       ·
+render     ·            ·                         (r)     ·
+ │         render 0     a IS NOT DISTINCT FROM b  ·       ·
+ └── scan  ·            ·                         (a, b)  ·
+·          table        t@primary                 ·       ·
+·          spans        ALL                       ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a IS NOT NULL AS r FROM t
 ----
-render     ·         ·              (r)  ·
- │         render 0  a IS NOT NULL  ·    ·
- └── scan  ·         ·              (a)  ·
-·          table     t@primary      ·    ·
-·          spans     ALL            ·    ·
+·          distributed  false          ·    ·
+·          vectorized   false          ·    ·
+render     ·            ·              (r)  ·
+ │         render 0     a IS NOT NULL  ·    ·
+ └── scan  ·            ·              (a)  ·
+·          table        t@primary      ·    ·
+·          spans        ALL            ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a IS DISTINCT FROM NULL AS r FROM t
 ----
-render     ·         ·              (r)  ·
- │         render 0  a IS NOT NULL  ·    ·
- └── scan  ·         ·              (a)  ·
-·          table     t@primary      ·    ·
-·          spans     ALL            ·    ·
+·          distributed  false          ·    ·
+·          vectorized   false          ·    ·
+render     ·            ·              (r)  ·
+ │         render 0     a IS NOT NULL  ·    ·
+ └── scan  ·            ·              (a)  ·
+·          table        t@primary      ·    ·
+·          spans        ALL            ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a IS DISTINCT FROM b AS r FROM t
 ----
-render     ·         ·                     (r)     ·
- │         render 0  a IS DISTINCT FROM b  ·       ·
- └── scan  ·         ·                     (a, b)  ·
-·          table     t@primary             ·       ·
-·          spans     ALL                   ·       ·
+·          distributed  false                 ·       ·
+·          vectorized   false                 ·       ·
+render     ·            ·                     (r)     ·
+ │         render 0     a IS DISTINCT FROM b  ·       ·
+ └── scan  ·            ·                     (a, b)  ·
+·          table        t@primary             ·       ·
+·          spans        ALL                   ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT +a + (-b) AS r FROM t
 ----
-render     ·         ·          (r)     ·
- │         render 0  a + (-b)   ·       ·
- └── scan  ·         ·          (a, b)  ·
-·          table     t@primary  ·       ·
-·          spans     ALL        ·       ·
+·          distributed  false      ·       ·
+·          vectorized   false      ·       ·
+render     ·            ·          (r)     ·
+ │         render 0     a + (-b)   ·       ·
+ └── scan  ·            ·          (a, b)  ·
+·          table        t@primary  ·       ·
+·          spans        ALL        ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END AS r FROM t
 ----
-render     ·         ·                                              (r)  ·
- │         render 0  CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END  ·    ·
- └── scan  ·         ·                                              (a)  ·
-·          table     t@primary                                      ·    ·
-·          spans     ALL                                            ·    ·
+·          distributed  false                                          ·    ·
+·          vectorized   false                                          ·    ·
+render     ·            ·                                              (r)  ·
+ │         render 0     CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END  ·    ·
+ └── scan  ·            ·                                              (a)  ·
+·          table        t@primary                                      ·    ·
+·          spans        ALL                                            ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT CASE WHEN a = 2 THEN 1 ELSE 2 END AS r FROM t
 ----
-render     ·         ·                                  (r)  ·
- │         render 0  CASE WHEN a = 2 THEN 1 ELSE 2 END  ·    ·
- └── scan  ·         ·                                  (a)  ·
-·          table     t@primary                          ·    ·
-·          spans     ALL                                ·    ·
+·          distributed  false                              ·    ·
+·          vectorized   false                              ·    ·
+render     ·            ·                                  (r)  ·
+ │         render 0     CASE WHEN a = 2 THEN 1 ELSE 2 END  ·    ·
+ └── scan  ·            ·                                  (a)  ·
+·          table        t@primary                          ·    ·
+·          spans        ALL                                ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT CASE a + 3 WHEN 5 * b THEN 1 % b WHEN 6 THEN 2 ELSE -1 END AS r FROM t
 ----
-render     ·         ·                                                           (r)     ·
- │         render 0  CASE a + 3 WHEN b * 5 THEN 1 % b WHEN 6 THEN 2 ELSE -1 END  ·       ·
- └── scan  ·         ·                                                           (a, b)  ·
-·          table     t@primary                                                   ·       ·
-·          spans     ALL                                                         ·       ·
+·          distributed  false                                                       ·       ·
+·          vectorized   false                                                       ·       ·
+render     ·            ·                                                           (r)     ·
+ │         render 0     CASE a + 3 WHEN b * 5 THEN 1 % b WHEN 6 THEN 2 ELSE -1 END  ·       ·
+ └── scan  ·            ·                                                           (a, b)  ·
+·          table        t@primary                                                   ·       ·
+·          spans        ALL                                                         ·       ·
 
 # Tests for CASE with no ELSE statement
 query TTTTT
 EXPLAIN (VERBOSE) SELECT CASE WHEN a = 2 THEN 1 END AS r FROM t
 ----
-render     ·         ·                           (r)  ·
- │         render 0  CASE WHEN a = 2 THEN 1 END  ·    ·
- └── scan  ·         ·                           (a)  ·
-·          table     t@primary                   ·    ·
-·          spans     ALL                         ·    ·
+·          distributed  false                       ·    ·
+·          vectorized   false                       ·    ·
+render     ·            ·                           (r)  ·
+ │         render 0     CASE WHEN a = 2 THEN 1 END  ·    ·
+ └── scan  ·            ·                           (a)  ·
+·          table        t@primary                   ·    ·
+·          spans        ALL                         ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT CASE a WHEN 2 THEN 1 END AS r FROM t
 ----
-render     ·         ·                         (r)  ·
- │         render 0  CASE a WHEN 2 THEN 1 END  ·    ·
- └── scan  ·         ·                         (a)  ·
-·          table     t@primary                 ·    ·
-·          spans     ALL                       ·    ·
+·          distributed  false                     ·    ·
+·          vectorized   false                     ·    ·
+render     ·            ·                         (r)  ·
+ │         render 0     CASE a WHEN 2 THEN 1 END  ·    ·
+ └── scan  ·            ·                         (a)  ·
+·          table        t@primary                 ·    ·
+·          spans        ALL                       ·    ·
 
 # TODO(radu): IS OF not supported yet.
 #query TTTTT
@@ -290,125 +352,153 @@ render     ·         ·                         (r)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT length(s) FROM t
 ----
-render     ·         ·          (length)  ·
- │         render 0  length(s)  ·         ·
- └── scan  ·         ·          (s)       ·
-·          table     t@primary  ·         ·
-·          spans     ALL        ·         ·
+·          distributed  false      ·         ·
+·          vectorized   false      ·         ·
+render     ·            ·          (length)  ·
+ │         render 0     length(s)  ·         ·
+ └── scan  ·            ·          (s)       ·
+·          table        t@primary  ·         ·
+·          spans        ALL        ·         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j @> '{"a": 1}' AS r FROM t
 ----
-render     ·         ·                (r)  ·
- │         render 0  j @> '{"a": 1}'  ·    ·
- └── scan  ·         ·                (j)  ·
-·          table     t@primary        ·    ·
-·          spans     ALL              ·    ·
+·          distributed  false            ·    ·
+·          vectorized   false            ·    ·
+render     ·            ·                (r)  ·
+ │         render 0     j @> '{"a": 1}'  ·    ·
+ └── scan  ·            ·                (j)  ·
+·          table        t@primary        ·    ·
+·          spans        ALL              ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT '{"a": 1}' <@ j AS r FROM t
 ----
-render     ·         ·                (r)  ·
- │         render 0  j @> '{"a": 1}'  ·    ·
- └── scan  ·         ·                (j)  ·
-·          table     t@primary        ·    ·
-·          spans     ALL              ·    ·
+·          distributed  false            ·    ·
+·          vectorized   false            ·    ·
+render     ·            ·                (r)  ·
+ │         render 0     j @> '{"a": 1}'  ·    ·
+ └── scan  ·            ·                (j)  ·
+·          table        t@primary        ·    ·
+·          spans        ALL              ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j->>'a' AS r FROM t
 ----
-render     ·         ·          (r)  ·
- │         render 0  j->>'a'    ·    ·
- └── scan  ·         ·          (j)  ·
-·          table     t@primary  ·    ·
-·          spans     ALL        ·    ·
+·          distributed  false      ·    ·
+·          vectorized   false      ·    ·
+render     ·            ·          (r)  ·
+ │         render 0     j->>'a'    ·    ·
+ └── scan  ·            ·          (j)  ·
+·          table        t@primary  ·    ·
+·          spans        ALL        ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j->'a' AS r FROM t
 ----
-render     ·         ·          (r)  ·
- │         render 0  j->'a'     ·    ·
- └── scan  ·         ·          (j)  ·
-·          table     t@primary  ·    ·
-·          spans     ALL        ·    ·
+·          distributed  false      ·    ·
+·          vectorized   false      ·    ·
+render     ·            ·          (r)  ·
+ │         render 0     j->'a'     ·    ·
+ └── scan  ·            ·          (j)  ·
+·          table        t@primary  ·    ·
+·          spans        ALL        ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j ? 'a' AS r FROM t
 ----
-render     ·         ·          (r)  ·
- │         render 0  j ? 'a'    ·    ·
- └── scan  ·         ·          (j)  ·
-·          table     t@primary  ·    ·
-·          spans     ALL        ·    ·
+·          distributed  false      ·    ·
+·          vectorized   false      ·    ·
+render     ·            ·          (r)  ·
+ │         render 0     j ? 'a'    ·    ·
+ └── scan  ·            ·          (j)  ·
+·          table        t@primary  ·    ·
+·          spans        ALL        ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j ?| ARRAY['a', 'b', 'c'] AS r FROM t
 ----
-render     ·         ·                        (r)  ·
- │         render 0  j ?| ARRAY['a','b','c']  ·    ·
- └── scan  ·         ·                        (j)  ·
-·          table     t@primary                ·    ·
-·          spans     ALL                      ·    ·
+·          distributed  false                    ·    ·
+·          vectorized   false                    ·    ·
+render     ·            ·                        (r)  ·
+ │         render 0     j ?| ARRAY['a','b','c']  ·    ·
+ └── scan  ·            ·                        (j)  ·
+·          table        t@primary                ·    ·
+·          spans        ALL                      ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j ?& ARRAY['a', 'b', 'c'] AS r FROM t
 ----
-render     ·         ·                        (r)  ·
- │         render 0  j ?& ARRAY['a','b','c']  ·    ·
- └── scan  ·         ·                        (j)  ·
-·          table     t@primary                ·    ·
-·          spans     ALL                      ·    ·
+·          distributed  false                    ·    ·
+·          vectorized   false                    ·    ·
+render     ·            ·                        (r)  ·
+ │         render 0     j ?& ARRAY['a','b','c']  ·    ·
+ └── scan  ·            ·                        (j)  ·
+·          table        t@primary                ·    ·
+·          spans        ALL                      ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j#>ARRAY['a'] AS r FROM t
 ----
-render     ·         ·              (r)  ·
- │         render 0  j#>ARRAY['a']  ·    ·
- └── scan  ·         ·              (j)  ·
-·          table     t@primary      ·    ·
-·          spans     ALL            ·    ·
+·          distributed  false          ·    ·
+·          vectorized   false          ·    ·
+render     ·            ·              (r)  ·
+ │         render 0     j#>ARRAY['a']  ·    ·
+ └── scan  ·            ·              (j)  ·
+·          table        t@primary      ·    ·
+·          spans        ALL            ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j#>>ARRAY['a'] AS r FROM t
 ----
-render     ·         ·               (r)  ·
- │         render 0  j#>>ARRAY['a']  ·    ·
- └── scan  ·         ·               (j)  ·
-·          table     t@primary       ·    ·
-·          spans     ALL             ·    ·
+·          distributed  false           ·    ·
+·          vectorized   false           ·    ·
+render     ·            ·               (r)  ·
+ │         render 0     j#>>ARRAY['a']  ·    ·
+ └── scan  ·            ·               (j)  ·
+·          table        t@primary       ·    ·
+·          spans        ALL             ·    ·
 
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT CAST(a AS string), b::float FROM t
 ----
-render     ·         ·          (a, b)  ·
- │         render 0  a::STRING  ·       ·
- │         render 1  b::FLOAT8  ·       ·
- └── scan  ·         ·          (a, b)  ·
-·          table     t@primary  ·       ·
-·          spans     ALL        ·       ·
+·          distributed  false      ·       ·
+·          vectorized   false      ·       ·
+render     ·            ·          (a, b)  ·
+ │         render 0     a::STRING  ·       ·
+ │         render 1     b::FLOAT8  ·       ·
+ └── scan  ·            ·          (a, b)  ·
+·          table        t@primary  ·       ·
+·          spans        ALL        ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT CAST(a + b + c AS string) FROM t
 ----
-render     ·         ·                      (text)     ·
- │         render 0  (c + (a + b))::STRING  ·          ·
- └── scan  ·         ·                      (a, b, c)  ·
-·          table     t@primary              ·          ·
-·          spans     ALL                    ·          ·
+·          distributed  false                  ·          ·
+·          vectorized   false                  ·          ·
+render     ·            ·                      (text)     ·
+ │         render 0     (c + (a + b))::STRING  ·          ·
+ └── scan  ·            ·                      (a, b, c)  ·
+·          table        t@primary              ·          ·
+·          spans        ALL                    ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT s::VARCHAR(2) FROM t
 ----
-render     ·         ·              (s)  ·
- │         render 0  s::VARCHAR(2)  ·    ·
- └── scan  ·         ·              (s)  ·
-·          table     t@primary      ·    ·
-·          spans     ALL            ·    ·
+·          distributed  false          ·    ·
+·          vectorized   false          ·    ·
+render     ·            ·              (s)  ·
+ │         render 0     s::VARCHAR(2)  ·    ·
+ └── scan  ·            ·              (s)  ·
+·          table        t@primary      ·    ·
+·          spans        ALL            ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT COALESCE(a, b) FROM (VALUES (1, 2), (3, NULL), (NULL, 4), (NULL, NULL)) AS v(a, b)
 ----
+·            distributed    false                       ·                   ·
+·            vectorized     false                       ·                   ·
 render       ·              ·                           ("coalesce")        ·
  │           render 0       COALESCE(column1, column2)  ·                   ·
  └── values  ·              ·                           (column1, column2)  ·
@@ -425,6 +515,8 @@ render       ·              ·                           ("coalesce")        ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT COALESCE(a, b, c) FROM (VALUES (1, 2, 3), (NULL, 4, 5), (NULL, NULL, 6), (NULL, NULL, NULL)) AS v(a, b, c)
 ----
+·            distributed    false                                ·                            ·
+·            vectorized     false                                ·                            ·
 render       ·              ·                                    ("coalesce")                 ·
  │           render 0       COALESCE(column1, column2, column3)  ·                            ·
  └── values  ·              ·                                    (column1, column2, column3)  ·
@@ -445,115 +537,141 @@ render       ·              ·                                    ("coalesce") 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE a BETWEEN b AND d
 ----
-render     ·         ·                      (a)        ·
- │         render 0  a                      ·          ·
- └── scan  ·         ·                      (a, b, d)  ·
-·          table     t@primary              ·          ·
-·          spans     ALL                    ·          ·
-·          filter    (a >= b) AND (a <= d)  ·          ·
+·          distributed  false                  ·          ·
+·          vectorized   false                  ·          ·
+render     ·            ·                      (a)        ·
+ │         render 0     a                      ·          ·
+ └── scan  ·            ·                      (a, b, d)  ·
+·          table        t@primary              ·          ·
+·          spans        ALL                    ·          ·
+·          filter       (a >= b) AND (a <= d)  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE a NOT BETWEEN b AND d
 ----
-render     ·         ·                   (a)        ·
- │         render 0  a                   ·          ·
- └── scan  ·         ·                   (a, b, d)  ·
-·          table     t@primary           ·          ·
-·          spans     ALL                 ·          ·
-·          filter    (a < b) OR (a > d)  ·          ·
+·          distributed  false               ·          ·
+·          vectorized   false               ·          ·
+render     ·            ·                   (a)        ·
+ │         render 0     a                   ·          ·
+ └── scan  ·            ·                   (a, b, d)  ·
+·          table        t@primary           ·          ·
+·          spans        ALL                 ·          ·
+·          filter       (a < b) OR (a > d)  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a BETWEEN SYMMETRIC b AND d AS r FROM t
 ----
-render     ·         ·                                                   (r)        ·
- │         render 0  ((a >= b) AND (a <= d)) OR ((a >= d) AND (a <= b))  ·          ·
- └── scan  ·         ·                                                   (a, b, d)  ·
-·          table     t@primary                                           ·          ·
-·          spans     ALL                                                 ·          ·
+·          distributed  false                                               ·          ·
+·          vectorized   false                                               ·          ·
+render     ·            ·                                                   (r)        ·
+ │         render 0     ((a >= b) AND (a <= d)) OR ((a >= d) AND (a <= b))  ·          ·
+ └── scan  ·            ·                                                   (a, b, d)  ·
+·          table        t@primary                                           ·          ·
+·          spans        ALL                                                 ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a NOT BETWEEN SYMMETRIC b AND d AS r FROM t
 ----
-render     ·         ·                                              (r)        ·
- │         render 0  ((a < b) OR (a > d)) AND ((a < d) OR (a > b))  ·          ·
- └── scan  ·         ·                                              (a, b, d)  ·
-·          table     t@primary                                      ·          ·
-·          spans     ALL                                            ·          ·
+·          distributed  false                                          ·          ·
+·          vectorized   false                                          ·          ·
+render     ·            ·                                              (r)        ·
+ │         render 0     ((a < b) OR (a > d)) AND ((a < d) OR (a > b))  ·          ·
+ └── scan  ·            ·                                              (a, b, d)  ·
+·          table        t@primary                                      ·          ·
+·          spans        ALL                                            ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ARRAY[]:::int[] FROM t
 ----
-render     ·         ·          ("array")  ·
- │         render 0  ARRAY[]    ·          ·
- └── scan  ·         ·          ()         ·
-·          table     t@primary  ·          ·
-·          spans     ALL        ·          ·
+·          distributed  false      ·          ·
+·          vectorized   false      ·          ·
+render     ·            ·          ("array")  ·
+ │         render 0     ARRAY[]    ·          ·
+ └── scan  ·            ·          ()         ·
+·          table        t@primary  ·          ·
+·          spans        ALL        ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ARRAY[1, 2, 3] FROM t
 ----
-render     ·         ·             ("array")  ·
- │         render 0  ARRAY[1,2,3]  ·          ·
- └── scan  ·         ·             ()         ·
-·          table     t@primary     ·          ·
-·          spans     ALL           ·          ·
+·          distributed  false         ·          ·
+·          vectorized   false         ·          ·
+render     ·            ·             ("array")  ·
+ │         render 0     ARRAY[1,2,3]  ·          ·
+ └── scan  ·            ·             ()         ·
+·          table        t@primary     ·          ·
+·          spans        ALL           ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ARRAY[a + 1, 2, 3] FROM t
 ----
-render     ·         ·                   ("array")  ·
- │         render 0  ARRAY[a + 1, 2, 3]  ·          ·
- └── scan  ·         ·                   (a)        ·
-·          table     t@primary           ·          ·
-·          spans     ALL                 ·          ·
+·          distributed  false               ·          ·
+·          vectorized   false               ·          ·
+render     ·            ·                   ("array")  ·
+ │         render 0     ARRAY[a + 1, 2, 3]  ·          ·
+ └── scan  ·            ·                   (a)        ·
+·          table        t@primary           ·          ·
+·          spans        ALL                 ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 > ANY ARRAY[a + 1, 2, 3] FROM t
 ----
-render     ·         ·                           ("?column?")  ·
- │         render 0  1 > ANY ARRAY[a + 1, 2, 3]  ·             ·
- └── scan  ·         ·                           (a)           ·
-·          table     t@primary                   ·             ·
-·          spans     ALL                         ·             ·
+·          distributed  false                       ·             ·
+·          vectorized   false                       ·             ·
+render     ·            ·                           ("?column?")  ·
+ │         render 0     1 > ANY ARRAY[a + 1, 2, 3]  ·             ·
+ └── scan  ·            ·                           (a)           ·
+·          table        t@primary                   ·             ·
+·          spans        ALL                         ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 = ANY (1, 2, 3) FROM t
 ----
-render     ·         ·          ("?column?")  ·
- │         render 0  true       ·             ·
- └── scan  ·         ·          ()            ·
-·          table     t@primary  ·             ·
-·          spans     ALL        ·             ·
+·          distributed  false      ·             ·
+·          vectorized   false      ·             ·
+render     ·            ·          ("?column?")  ·
+ │         render 0     true       ·             ·
+ └── scan  ·            ·          ()            ·
+·          table        t@primary  ·             ·
+·          spans        ALL        ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 = ANY () FROM t
 ----
-render     ·         ·          ("?column?")  ·
- │         render 0  false      ·             ·
- └── scan  ·         ·          ()            ·
-·          table     t@primary  ·             ·
-·          spans     ALL        ·             ·
+·          distributed  false      ·             ·
+·          vectorized   false      ·             ·
+render     ·            ·          ("?column?")  ·
+ │         render 0     false      ·             ·
+ └── scan  ·            ·          ()            ·
+·          table        t@primary  ·             ·
+·          spans        ALL        ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT least(NULL, greatest(NULL, least(1, NULL), 2, 3), greatest(5, 6), a) FROM t
 ----
-render     ·         ·                     ("least")  ·
- │         render 0  least(NULL, 3, 6, a)  ·          ·
- └── scan  ·         ·                     (a)        ·
-·          table     t@primary             ·          ·
-·          spans     ALL                   ·          ·
+·          distributed  false                 ·          ·
+·          vectorized   false                 ·          ·
+render     ·            ·                     ("least")  ·
+ │         render 0     least(NULL, 3, 6, a)  ·          ·
+ └── scan  ·            ·                     (a)        ·
+·          table        t@primary             ·          ·
+·          spans        ALL                   ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pg_attribute WHERE attrelid='foo'::regclass
 ----
-filter              ·       ·                           (attrelid, attname, atttypid, attstattarget, attlen, attnum, attndims, attcacheoff, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef, attisdropped, attislocal, attinhcount, attcollation, attacl, attoptions, attfdwoptions)  ·
- │                  filter  attrelid = 'foo'::REGCLASS  ·                                                                                                                                                                                                                                              ·
- └── virtual table  ·       ·                           (attrelid, attname, atttypid, attstattarget, attlen, attnum, attndims, attcacheoff, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef, attisdropped, attislocal, attinhcount, attcollation, attacl, attoptions, attfdwoptions)  ·
-·                   source  ·                           ·                                                                                                                                                                                                                                              ·
+·                   distributed  false                       ·                                                                                                                                                                                                                                              ·
+·                   vectorized   false                       ·                                                                                                                                                                                                                                              ·
+filter              ·            ·                           (attrelid, attname, atttypid, attstattarget, attlen, attnum, attndims, attcacheoff, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef, attisdropped, attislocal, attinhcount, attcollation, attacl, attoptions, attfdwoptions)  ·
+ │                  filter       attrelid = 'foo'::REGCLASS  ·                                                                                                                                                                                                                                              ·
+ └── virtual table  ·            ·                           (attrelid, attname, atttypid, attstattarget, attlen, attnum, attndims, attcacheoff, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef, attisdropped, attislocal, attinhcount, attcollation, attacl, attoptions, attfdwoptions)  ·
+·                   source       ·                           ·                                                                                                                                                                                                                                              ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT CASE WHEN current_database() = 'test' THEN 42 ELSE 1/3 END
 ----
+·       distributed    false            ·         ·
+·       vectorized     false            ·         ·
 values  ·              ·                ("case")  ·
 ·       size           1 column, 1 row  ·         ·
 ·       row 0, expr 0  42               ·         ·
@@ -562,6 +680,8 @@ values  ·              ·                ("case")  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT CASE WHEN current_database() = 'test' THEN 42 ELSE 1/0 END
 ----
+·       distributed    false                                  ·         ·
+·       vectorized     false                                  ·         ·
 values  ·              ·                                      ("case")  ·
 ·       size           1 column, 1 row                        ·         ·
 ·       row 0, expr 0  CASE WHEN true THEN 42 ELSE 1 / 0 END  ·         ·
@@ -570,6 +690,8 @@ values  ·              ·                                      ("case")  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT random(), current_database(), now()
 ----
+·       distributed    false             ·                                ·
+·       vectorized     false             ·                                ·
 values  ·              ·                 (random, current_database, now)  ·
 ·       size           3 columns, 1 row  ·                                ·
 ·       row 0, expr 0  random()          ·                                ·
@@ -581,16 +703,20 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT 1::FLOAT + length(upper(concat('a', 'b', 'c')))::FLOAT AS r1,
                          1::FLOAT + length(upper(concat('a', 'b', s)))::FLOAT AS r2 FROM t
 ----
-render     ·         ·                                                 (r1, r2)  ·
- │         render 0  4.0                                               ·         ·
- │         render 1  length(upper(concat('a', 'b', s)))::FLOAT8 + 1.0  ·         ·
- └── scan  ·         ·                                                 (s)       ·
-·          table     t@primary                                         ·         ·
-·          spans     ALL                                               ·         ·
+·          distributed  false                                             ·         ·
+·          vectorized   false                                             ·         ·
+render     ·            ·                                                 (r1, r2)  ·
+ │         render 0     4.0                                               ·         ·
+ │         render 1     length(upper(concat('a', 'b', s)))::FLOAT8 + 1.0  ·         ·
+ └── scan  ·            ·                                                 (s)       ·
+·          table        t@primary                                         ·         ·
+·          spans        ALL                                               ·         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ARRAY(SELECT generate_series(1,10) ORDER BY 1 DESC)
 ----
+·                             distributed    false                                            ·                  ·
+·                             vectorized     false                                            ·                  ·
 root                          ·              ·                                                ("array")          ·
  ├── values                   ·              ·                                                ("array")          ·
  │                            size           1 column, 1 row                                  ·                  ·
@@ -608,6 +734,8 @@ root                          ·              ·                                
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ARRAY(SELECT a FROM t ORDER BY b)
 ----
+·                         distributed    false                         ·          ·
+·                         vectorized     false                         ·          ·
 root                      ·              ·                             ("array")  ·
  ├── values               ·              ·                             ("array")  ·
  │                        size           1 column, 1 row               ·          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -64,148 +64,185 @@ ALTER TABLE num_ref DROP COLUMN xx
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53 AS num_ref_alias]
 ----
-scan  ·      ·                (p, d, c)  ·
-·     table  num_ref@primary  ·          ·
-·     spans  ALL              ·          ·
+·     distributed  false            ·          ·
+·     vectorized   true             ·          ·
+scan  ·            ·                (p, d, c)  ·
+·     table        num_ref@primary  ·          ·
+·     spans        ALL              ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(4) AS num_ref_alias]
 ----
-scan  ·      ·                (c)  ·
-·     table  num_ref@primary  ·    ·
-·     spans  ALL              ·    ·
+·     distributed  false            ·    ·
+·     vectorized   true             ·    ·
+scan  ·            ·                (c)  ·
+·     table        num_ref@primary  ·    ·
+·     spans        ALL              ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(1,4) AS num_ref_alias]
 ----
-scan  ·      ·                (p, c)  ·
-·     table  num_ref@primary  ·       ·
-·     spans  ALL              ·       ·
+·     distributed  false            ·       ·
+·     vectorized   true             ·       ·
+scan  ·            ·                (p, c)  ·
+·     table        num_ref@primary  ·       ·
+·     spans        ALL              ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(1,3,4) AS num_ref_alias]
 ----
-scan  ·      ·                (p, d, c)  ·
-·     table  num_ref@primary  ·          ·
-·     spans  ALL              ·          ·
+·     distributed  false            ·          ·
+·     vectorized   true             ·          ·
+scan  ·            ·                (p, d, c)  ·
+·     table        num_ref@primary  ·          ·
+·     spans        ALL              ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(4,3,1) AS num_ref_alias]
 ----
-render     ·         ·                (c, d, p)  ·
- │         render 0  c                ·          ·
- │         render 1  d                ·          ·
- │         render 2  p                ·          ·
- └── scan  ·         ·                (p, d, c)  ·
-·          table     num_ref@primary  ·          ·
-·          spans     ALL              ·          ·
+·          distributed  false            ·          ·
+·          vectorized   true             ·          ·
+render     ·            ·                (c, d, p)  ·
+ │         render 0     c                ·          ·
+ │         render 1     d                ·          ·
+ │         render 2     p                ·          ·
+ └── scan  ·            ·                (p, d, c)  ·
+·          table        num_ref@primary  ·          ·
+·          spans        ALL              ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(4,3,1) AS num_ref_alias(col1,col2,col3)]
 ----
-render     ·         ·                (col1, col2, col3)  ·
- │         render 0  c                ·                   ·
- │         render 1  d                ·                   ·
- │         render 2  p                ·                   ·
- └── scan  ·         ·                (p, d, c)           ·
-·          table     num_ref@primary  ·                   ·
-·          spans     ALL              ·                   ·
+·          distributed  false            ·                   ·
+·          vectorized   true             ·                   ·
+render     ·            ·                (col1, col2, col3)  ·
+ │         render 0     c                ·                   ·
+ │         render 1     d                ·                   ·
+ │         render 2     p                ·                   ·
+ └── scan  ·            ·                (p, d, c)           ·
+·          table        num_ref@primary  ·                   ·
+·          spans        ALL              ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(4,3,1) AS num_ref_alias]@bc
 ----
-render     ·         ·           (c, d, p)  ·
- │         render 0  c           ·          ·
- │         render 1  d           ·          ·
- │         render 2  p           ·          ·
- └── scan  ·         ·           (p, d, c)  ·
-·          table     num_ref@bc  ·          ·
-·          spans     ALL         ·          ·
+·          distributed  false       ·          ·
+·          vectorized   true        ·          ·
+render     ·            ·           (c, d, p)  ·
+ │         render 0     c           ·          ·
+ │         render 1     d           ·          ·
+ │         render 2     p           ·          ·
+ └── scan  ·            ·           (p, d, c)  ·
+·          table        num_ref@bc  ·          ·
+·          spans        ALL         ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(4) AS num_ref_alias]@bc
 ----
-scan  ·      ·           (c)  ·
-·     table  num_ref@bc  ·    ·
-·     spans  ALL         ·    ·
+·     distributed  false       ·    ·
+·     vectorized   true        ·    ·
+scan  ·            ·           (c)  ·
+·     table        num_ref@bc  ·    ·
+·     spans        ALL         ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(3) AS num_ref_alias]@bc
 ----
-scan  ·      ·           (d)  ·
-·     table  num_ref@bc  ·    ·
-·     spans  ALL         ·    ·
+·     distributed  false       ·    ·
+·     vectorized   true        ·    ·
+scan  ·            ·           (d)  ·
+·     table        num_ref@bc  ·    ·
+·     spans        ALL         ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(1) AS num_ref_alias]@bc
 ----
-scan  ·      ·           (p)  ·
-·     table  num_ref@bc  ·    ·
-·     spans  ALL         ·    ·
+·     distributed  false       ·    ·
+·     vectorized   true        ·    ·
+scan  ·            ·           (p)  ·
+·     table        num_ref@bc  ·    ·
+·     spans        ALL         ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(1) AS num_ref_alias]@[1]
 ----
-scan  ·      ·                (p)  ·
-·     table  num_ref@primary  ·    ·
-·     spans  ALL              ·    ·
+·     distributed  false            ·    ·
+·     vectorized   true             ·    ·
+scan  ·            ·                (p)  ·
+·     table        num_ref@primary  ·    ·
+·     spans        ALL              ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(1) AS num_ref_alias]@[2]
 ----
-scan  ·      ·           (p)  ·
-·     table  num_ref@bc  ·    ·
-·     spans  ALL         ·    ·
+·     distributed  false       ·    ·
+·     vectorized   true        ·    ·
+scan  ·            ·           (p)  ·
+·     table        num_ref@bc  ·    ·
+·     spans        ALL         ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(3) AS num_ref_alias]@[1]
 ----
-scan  ·      ·                (d)  ·
-·     table  num_ref@primary  ·    ·
-·     spans  ALL              ·    ·
+·     distributed  false            ·    ·
+·     vectorized   true             ·    ·
+scan  ·            ·                (d)  ·
+·     table        num_ref@primary  ·    ·
+·     spans        ALL              ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(3) AS num_ref_alias]@[2]
 ----
-scan  ·      ·           (d)  ·
-·     table  num_ref@bc  ·    ·
-·     spans  ALL         ·    ·
+·     distributed  false       ·    ·
+·     vectorized   true        ·    ·
+scan  ·            ·           (d)  ·
+·     table        num_ref@bc  ·    ·
+·     spans        ALL         ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(4) AS num_ref_alias]@[1]
 ----
-scan  ·      ·                (c)  ·
-·     table  num_ref@primary  ·    ·
-·     spans  ALL              ·    ·
+·     distributed  false            ·    ·
+·     vectorized   true             ·    ·
+scan  ·            ·                (c)  ·
+·     table        num_ref@primary  ·    ·
+·     spans        ALL              ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(4) AS num_ref_alias]@[2]
 ----
-scan  ·      ·           (c)  ·
-·     table  num_ref@bc  ·    ·
-·     spans  ALL         ·    ·
+·     distributed  false       ·    ·
+·     vectorized   true        ·    ·
+scan  ·            ·           (c)  ·
+·     table        num_ref@bc  ·    ·
+·     spans        ALL         ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [54(1,3) AS num_ref_alias]
 ----
-scan  ·      ·                       (a)  ·
-·     table  num_ref_hidden@primary  ·    ·
-·     spans  ALL                     ·    ·
-
+·     distributed  false                   ·    ·
+·     vectorized   true                    ·    ·
+scan  ·            ·                       (a)  ·
+·     table        num_ref_hidden@primary  ·    ·
+·     spans        ALL                     ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [54(3) AS num_ref_alias]
 ----
-scan  ·      ·                       ()  ·
-·     table  num_ref_hidden@primary  ·   ·
-·     spans  ALL                     ·   ·
+·     distributed  false                   ·   ·
+·     vectorized   true                    ·   ·
+scan  ·            ·                       ()  ·
+·     table        num_ref_hidden@primary  ·   ·
+·     spans        ALL                     ·   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT rowid FROM [54(3) AS num_ref_alias]
 ----
-scan  ·      ·                       (rowid[hidden])  ·
-·     table  num_ref_hidden@primary  ·                ·
-·     spans  ALL                     ·                ·
+·     distributed  false                   ·                ·
+·     vectorized   true                    ·                ·
+scan  ·            ·                       (rowid[hidden])  ·
+·     table        num_ref_hidden@primary  ·                ·
+·     spans        ALL                     ·                ·
 
 query error pq: \[666\(1\) AS num_ref_alias\]: relation \"\[666\]\" does not exist
 EXPLAIN (VERBOSE) SELECT * FROM [666(1) AS num_ref_alias]
@@ -237,89 +274,107 @@ CREATE TABLE a (x INT PRIMARY KEY, y INT);
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE x > 1
 ----
-scan  ·      ·          (x, y)  ·
-·     table  a@primary  ·       ·
-·     spans  /2-        ·       ·
+·     distributed  false      ·       ·
+·     vectorized   true       ·       ·
+scan  ·            ·          (x, y)  ·
+·     table        a@primary  ·       ·
+·     spans        /2-        ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE y > 10
 ----
-scan  ·       ·          (x, y)  ·
-·     table   a@primary  ·       ·
-·     spans   ALL        ·       ·
-·     filter  y > 10     ·       ·
+·     distributed  false      ·       ·
+·     vectorized   true       ·       ·
+scan  ·            ·          (x, y)  ·
+·     table        a@primary  ·       ·
+·     spans        ALL        ·       ·
+·     filter       y > 10     ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE x > 1 AND x < 3
 ----
-scan  ·      ·          (x, y)  ·
-·     table  a@primary  ·       ·
-·     spans  /2-/2/#    ·       ·
+·     distributed  false      ·       ·
+·     vectorized   true       ·       ·
+scan  ·            ·          (x, y)  ·
+·     table        a@primary  ·       ·
+·     spans        /2-/2/#    ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE x > 1 AND y < 30
 ----
-scan  ·       ·          (x, y)  ·
-·     table   a@primary  ·       ·
-·     spans   /2-        ·       ·
-·     filter  y < 30     ·       ·
+·     distributed  false      ·       ·
+·     vectorized   true       ·       ·
+scan  ·            ·          (x, y)  ·
+·     table        a@primary  ·       ·
+·     spans        /2-        ·       ·
+·     filter       y < 30     ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x + 1 AS r FROM a
 ----
-render     ·         ·          (r)  ·
- │         render 0  x + 1      ·    ·
- └── scan  ·         ·          (x)  ·
-·          table     a@primary  ·    ·
-·          spans     ALL        ·    ·
+·          distributed  false      ·    ·
+·          vectorized   true       ·    ·
+render     ·            ·          (r)  ·
+ │         render 0     x + 1      ·    ·
+ └── scan  ·            ·          (x)  ·
+·          table        a@primary  ·    ·
+·          spans        ALL        ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x AS a, x + 1 AS b, y, y + 1 AS c, x + y AS d FROM a
 ----
-render     ·         ·          (a, b, y, c, d)  ·
- │         render 0  x          ·                ·
- │         render 1  x + 1      ·                ·
- │         render 2  y          ·                ·
- │         render 3  y + 1      ·                ·
- │         render 4  x + y      ·                ·
- └── scan  ·         ·          (x, y)           ·
-·          table     a@primary  ·                ·
-·          spans     ALL        ·                ·
+·          distributed  false      ·                ·
+·          vectorized   true       ·                ·
+render     ·            ·          (a, b, y, c, d)  ·
+ │         render 0     x          ·                ·
+ │         render 1     x + 1      ·                ·
+ │         render 2     y          ·                ·
+ │         render 3     y + 1      ·                ·
+ │         render 4     x + y      ·                ·
+ └── scan  ·            ·          (x, y)           ·
+·          table        a@primary  ·                ·
+·          spans        ALL        ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT u * v + v AS r FROM (SELECT x + 3, y + 10 FROM a) AS foo(u, v)
 ----
-render          ·         ·                                       (r)                       ·
- │              render 0  "?column?" + ("?column?" * "?column?")  ·                         ·
- └── render     ·         ·                                       ("?column?", "?column?")  ·
-      │         render 0  x + 3                                   ·                         ·
-      │         render 1  y + 10                                  ·                         ·
-      └── scan  ·         ·                                       (x, y)                    ·
-·               table     a@primary                               ·                         ·
-·               spans     ALL                                     ·                         ·
+·               distributed  false                                   ·                         ·
+·               vectorized   true                                    ·                         ·
+render          ·            ·                                       (r)                       ·
+ │              render 0     "?column?" + ("?column?" * "?column?")  ·                         ·
+ └── render     ·            ·                                       ("?column?", "?column?")  ·
+      │         render 0     x + 3                                   ·                         ·
+      │         render 1     y + 10                                  ·                         ·
+      └── scan  ·            ·                                       (x, y)                    ·
+·               table        a@primary                               ·                         ·
+·               spans        ALL                                     ·                         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x, x, y, x FROM a
 ----
-render     ·         ·          (x, x, y, x)  ·
- │         render 0  x          ·             ·
- │         render 1  x          ·             ·
- │         render 2  y          ·             ·
- │         render 3  x          ·             ·
- └── scan  ·         ·          (x, y)        ·
-·          table     a@primary  ·             ·
-·          spans     ALL        ·             ·
+·          distributed  false      ·             ·
+·          vectorized   true       ·             ·
+render     ·            ·          (x, x, y, x)  ·
+ │         render 0     x          ·             ·
+ │         render 1     x          ·             ·
+ │         render 2     y          ·             ·
+ │         render 3     x          ·             ·
+ └── scan  ·            ·          (x, y)        ·
+·          table        a@primary  ·             ·
+·          spans        ALL        ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x + 1 AS a, x + y AS b FROM a WHERE x + y > 20
 ----
-render     ·         ·             (a, b)  ·
- │         render 0  x + 1         ·       ·
- │         render 1  x + y         ·       ·
- └── scan  ·         ·             (x, y)  ·
-·          table     a@primary     ·       ·
-·          spans     ALL           ·       ·
-·          filter    (x + y) > 20  ·       ·
+·          distributed  false         ·       ·
+·          vectorized   true          ·       ·
+render     ·            ·             (a, b)  ·
+ │         render 0     x + 1         ·       ·
+ │         render 1     x + y         ·       ·
+ └── scan  ·            ·             (x, y)  ·
+·          table        a@primary     ·       ·
+·          spans        ALL           ·       ·
+·          filter       (x + y) > 20  ·       ·
 
 statement ok
 DROP TABLE a
@@ -333,16 +388,20 @@ CREATE TABLE b (x INT, y INT);
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM b
 ----
-scan  ·      ·          (x, y)  ·
-·     table  b@primary  ·       ·
-·     spans  ALL        ·       ·
+·     distributed  false      ·       ·
+·     vectorized   true       ·       ·
+scan  ·            ·          (x, y)  ·
+·     table        b@primary  ·       ·
+·     spans        ALL        ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x, y, rowid FROM b WHERE rowid > 0
 ----
-scan  ·      ·          (x, y, rowid[hidden])  ·
-·     table  b@primary  ·                      ·
-·     spans  /1-        ·                      ·
+·     distributed  false      ·                      ·
+·     vectorized   true       ·                      ·
+scan  ·            ·          (x, y, rowid[hidden])  ·
+·     table        b@primary  ·                      ·
+·     spans        /1-        ·                      ·
 
 statement ok
 DROP TABLE b
@@ -462,9 +521,11 @@ CREATE INDEX i14601 ON t14601 (a) STORING (b)
 query TTT
 EXPLAIN SELECT a FROM t14601 ORDER BY a
 ----
-scan  ·      ·
-·     table  t14601@i14601
-·     spans  ALL
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        t14601@i14601
+·     spans        ALL
 
 # Updates were broken too.
 
@@ -484,9 +545,11 @@ CREATE INDEX i14601a ON t14601a (a) STORING (b, c)
 query TTT
 EXPLAIN SELECT a, b FROM t14601a ORDER BY a
 ----
-scan  ·      ·
-·     table  t14601a@i14601a
-·     spans  ALL
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        t14601a@i14601a
+·     spans        ALL
 
 statement ok
 DROP index i14601a
@@ -497,9 +560,11 @@ CREATE UNIQUE INDEX i14601a ON t14601a (a) STORING (b)
 query TTT
 EXPLAIN SELECT a, b FROM t14601a ORDER BY a
 ----
-scan  ·      ·
-·     table  t14601a@i14601a
-·     spans  ALL
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        t14601a@i14601a
+·     spans        ALL
 
 statement ok
 DROP TABLE t; DROP TABLE t14601; DROP TABLE t14601a
@@ -513,9 +578,11 @@ CREATE TABLE c (n INT PRIMARY KEY, str STRING, INDEX str(str DESC));
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM c WHERE str >= 'moo'
 ----
-scan  ·      ·                  (n, str)  ·
-·     table  c@str              ·         ·
-·     spans  -/"moo"/PrefixEnd  ·         ·
+·     distributed  false              ·         ·
+·     vectorized   true               ·         ·
+scan  ·            ·                  (n, str)  ·
+·     table        c@str              ·         ·
+·     spans        -/"moo"/PrefixEnd  ·         ·
 
 statement ok
 DROP TABLE c
@@ -529,11 +596,13 @@ CREATE TABLE nocols(x INT); ALTER TABLE nocols DROP COLUMN x
 query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 AS a, * FROM nocols
 ----
-render     ·         ·               (a)  ·
- │         render 0  1               ·    ·
- └── scan  ·         ·               ()   ·
-·          table     nocols@primary  ·    ·
-·          spans     ALL             ·    ·
+·          distributed  false           ·    ·
+·          vectorized   true            ·    ·
+render     ·            ·               (a)  ·
+ │         render 0     1               ·    ·
+ └── scan  ·            ·               ()   ·
+·          table        nocols@primary  ·    ·
+·          spans        ALL             ·    ·
 
 statement ok
 DROP TABLE nocols
@@ -553,19 +622,23 @@ CREATE TABLE coll (
 query TTTTT
 EXPLAIN (TYPES) SELECT a, b FROM coll ORDER BY a, b
 ----
-scan  ·      ·             (a collatedstring{da}, b int)  +a,+b
-·     table  coll@primary  ·                              ·
-·     spans  ALL           ·                              ·
+·     distributed  false         ·                              ·
+·     vectorized   false         ·                              ·
+scan  ·            ·             (a collatedstring{da}, b int)  +a,+b
+·     table        coll@primary  ·                              ·
+·     spans        ALL           ·                              ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT b, a FROM coll ORDER BY b, a
 ----
-render     ·         ·                        (b int, a collatedstring{da})  ·
- │         render 0  (b)[int]                 ·                              ·
- │         render 1  (a)[collatedstring{da}]  ·                              ·
- └── scan  ·         ·                        (a collatedstring{da}, b int)  +b,+a
-·          table     coll@coll_b_a_idx        ·                              ·
-·          spans     ALL                      ·                              ·
+·          distributed  false                    ·                              ·
+·          vectorized   false                    ·                              ·
+render     ·            ·                        (b int, a collatedstring{da})  ·
+ │         render 0     (b)[int]                 ·                              ·
+ │         render 1     (a)[collatedstring{da}]  ·                              ·
+ └── scan  ·            ·                        (a collatedstring{da}, b int)  +b,+a
+·          table        coll@coll_b_a_idx        ·                              ·
+·          spans        ALL                      ·                              ·
 
 statement ok
 DROP TABLE coll
@@ -584,9 +657,11 @@ CREATE TABLE computed (
 query TTTTT
 EXPLAIN (TYPES) SELECT b FROM computed ORDER BY b
 ----
-scan  ·      ·                        (b string)  +b
-·     table  computed@computed_b_idx  ·           ·
-·     spans  ALL                      ·           ·
+·     distributed  false                    ·           ·
+·     vectorized   false                    ·           ·
+scan  ·            ·                        (b string)  +b
+·     table        computed@computed_b_idx  ·           ·
+·     spans        ALL                      ·           ·
 
 statement ok
 DROP TABLE computed
@@ -662,24 +737,30 @@ CREATE TABLE dec (d decimal, v decimal(3, 1), primary key (d, v))
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM dec WHERE d IS NaN and v IS NaN
 ----
-scan  ·      ·                    (d decimal, v decimal)  ·
-·     table  dec@primary          ·                       ·
-·     spans  /NaN/NaN-/NaN/NaN/#  ·                       ·
+·     distributed  false                ·                       ·
+·     vectorized   true                 ·                       ·
+scan  ·            ·                    (d decimal, v decimal)  ·
+·     table        dec@primary          ·                       ·
+·     spans        /NaN/NaN-/NaN/NaN/#  ·                       ·
 
 # The NaN suffix is decimalNaNDesc, not decimalNaN(Asc).
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM dec WHERE d = 'Infinity' and v = 'Infinity'
 ----
-scan  ·      ·                                        (d decimal, v decimal)  ·
-·     table  dec@primary                              ·                       ·
-·     spans  /Infinity/Infinity-/Infinity/Infinity/#  ·                       ·
+·     distributed  false                                    ·                       ·
+·     vectorized   true                                     ·                       ·
+scan  ·            ·                                        (d decimal, v decimal)  ·
+·     table        dec@primary                              ·                       ·
+·     spans        /Infinity/Infinity-/Infinity/Infinity/#  ·                       ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM dec WHERE d = '-Infinity' and v = '-Infinity'
 ----
-scan  ·      ·                                            (d decimal, v decimal)  ·
-·     table  dec@primary                                  ·                       ·
-·     spans  /-Infinity/-Infinity-/-Infinity/-Infinity/#  ·                       ·
+·     distributed  false                                        ·                       ·
+·     vectorized   true                                         ·                       ·
+scan  ·            ·                                            (d decimal, v decimal)  ·
+·     table        dec@primary                                  ·                       ·
+·     spans        /-Infinity/-Infinity-/-Infinity/-Infinity/#  ·                       ·
 
 statement ok
 DROP TABLE dec
@@ -729,24 +810,30 @@ CREATE TABLE dec2 (d decimal null, index (d))
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM dec2 WHERE d IS NaN
 ----
-scan  ·      ·                (d decimal)  ·
-·     table  dec2@dec2_d_idx  ·            ·
-·     spans  /NaN-/-Infinity  ·            ·
+·     distributed  false            ·            ·
+·     vectorized   true             ·            ·
+scan  ·            ·                (d decimal)  ·
+·     table        dec2@dec2_d_idx  ·            ·
+·     spans        /NaN-/-Infinity  ·            ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM dec2 WHERE d = 'NaN'
 ----
-scan  ·      ·                (d decimal)  ·
-·     table  dec2@dec2_d_idx  ·            ·
-·     spans  /NaN-/-Infinity  ·            ·
+·     distributed  false            ·            ·
+·     vectorized   true             ·            ·
+scan  ·            ·                (d decimal)  ·
+·     table        dec2@dec2_d_idx  ·            ·
+·     spans        /NaN-/-Infinity  ·            ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM dec2 WHERE isnan(d)
 ----
-scan  ·       ·                            (d decimal)  ·
-·     table   dec2@primary                 ·            ·
-·     spans   ALL                          ·            ·
-·     filter  (isnan((d)[decimal]))[bool]  ·            ·
+·     distributed  false                        ·            ·
+·     vectorized   false                        ·            ·
+scan  ·            ·                            (d decimal)  ·
+·     table        dec2@primary                 ·            ·
+·     spans        ALL                          ·            ·
+·     filter       (isnan((d)[decimal]))[bool]  ·            ·
 
 statement ok
 DROP TABLE dec2
@@ -763,24 +850,30 @@ CREATE TABLE flt (f float null, unique index (f))
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM flt WHERE f IS NaN
 ----
-scan  ·      ·                    (f float)  ·
-·     table  flt@flt_f_key        ·          ·
-·     spans  /NaN-/NaN/PrefixEnd  ·          ·
+·     distributed  false                ·          ·
+·     vectorized   true                 ·          ·
+scan  ·            ·                    (f float)  ·
+·     table        flt@flt_f_key        ·          ·
+·     spans        /NaN-/NaN/PrefixEnd  ·          ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM flt WHERE f = 'NaN'
 ----
-scan  ·      ·                    (f float)  ·
-·     table  flt@flt_f_key        ·          ·
-·     spans  /NaN-/NaN/PrefixEnd  ·          ·
+·     distributed  false                ·          ·
+·     vectorized   true                 ·          ·
+scan  ·            ·                    (f float)  ·
+·     table        flt@flt_f_key        ·          ·
+·     spans        /NaN-/NaN/PrefixEnd  ·          ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM flt WHERE isnan(f)
 ----
-scan  ·       ·                          (f float)  ·
-·     table   flt@primary                ·          ·
-·     spans   ALL                        ·          ·
-·     filter  (isnan((f)[float]))[bool]  ·          ·
+·     distributed  false                      ·          ·
+·     vectorized   false                      ·          ·
+scan  ·            ·                          (f float)  ·
+·     table        flt@primary                ·          ·
+·     spans        ALL                        ·          ·
+·     filter       (isnan((f)[float]))[bool]  ·          ·
 
 statement ok
 DROP TABLE flt
@@ -805,30 +898,38 @@ CREATE TABLE num (
 query TTTTT
 EXPLAIN (TYPES) SELECT i FROM num WHERE i = -1:::INT
 ----
-scan  ·      ·              (i int)  ·
-·     table  num@num_i_key  ·        ·
-·     spans  /-1-/0         ·        ·
+·     distributed  false          ·        ·
+·     vectorized   false          ·        ·
+scan  ·            ·              (i int)  ·
+·     table        num@num_i_key  ·        ·
+·     spans        /-1-/0         ·        ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT f FROM num WHERE f = -1:::FLOAT
 ----
-scan  ·      ·                  (f float)  ·
-·     table  num@num_f_key      ·          ·
-·     spans  /-1-/-1/PrefixEnd  ·          ·
+·     distributed  false              ·          ·
+·     vectorized   false              ·          ·
+scan  ·            ·                  (f float)  ·
+·     table        num@num_f_key      ·          ·
+·     spans        /-1-/-1/PrefixEnd  ·          ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT d FROM num WHERE d = -1:::DECIMAL
 ----
-scan  ·      ·                  (d decimal)  ·
-·     table  num@num_d_key      ·            ·
-·     spans  /-1-/-1/PrefixEnd  ·            ·
+·     distributed  false              ·            ·
+·     vectorized   false              ·            ·
+scan  ·            ·                  (d decimal)  ·
+·     table        num@num_d_key      ·            ·
+·     spans        /-1-/-1/PrefixEnd  ·            ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT n FROM num WHERE n = -'1h':::INTERVAL
 ----
-scan  ·      ·                            (n interval)  ·
-·     table  num@num_n_key                ·             ·
-·     spans  /-01:00:00-/1 day -25:00:00  ·             ·
+·     distributed  false                        ·             ·
+·     vectorized   false                        ·             ·
+scan  ·            ·                            (n interval)  ·
+·     table        num@num_n_key                ·             ·
+·     spans        /-01:00:00-/1 day -25:00:00  ·             ·
 
 statement ok
 DROP TABLE num
@@ -1029,77 +1130,91 @@ CREATE TABLE abcd (a INT, b INT, c INT, d INT, PRIMARY KEY (a, b))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a + x FROM (SELECT a, b + c AS x FROM abcd) ORDER BY a
 ----
-render     ·         ·             ("?column?")  ·
- │         render 0  a + (b + c)   ·             ·
- └── scan  ·         ·             (a, b, c)     +a
-·          table     abcd@primary  ·             ·
-·          spans     ALL           ·             ·
+·          distributed  false         ·             ·
+·          vectorized   true          ·             ·
+render     ·            ·             ("?column?")  ·
+ │         render 0     a + (b + c)   ·             ·
+ └── scan  ·            ·             (a, b, c)     +a
+·          table        abcd@primary  ·             ·
+·          spans        ALL           ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a + x FROM (SELECT a, b, a + b + c AS x FROM abcd) ORDER BY b
 ----
-render               ·         ·                  ("?column?")     ·
- │                   render 0  "?column?"         ·                ·
- └── sort            ·         ·                  ("?column?", b)  +b
-      │              order     +b                 ·                ·
-      └── render     ·         ·                  ("?column?", b)  ·
-           │         render 0  a + (c + (a + b))  ·                ·
-           │         render 1  b                  ·                ·
-           └── scan  ·         ·                  (a, b, c)        ·
-·                    table     abcd@primary       ·                ·
-·                    spans     ALL                ·                ·
+·                    distributed  false              ·                ·
+·                    vectorized   false              ·                ·
+render               ·            ·                  ("?column?")     ·
+ │                   render 0     "?column?"         ·                ·
+ └── sort            ·            ·                  ("?column?", b)  +b
+      │              order        +b                 ·                ·
+      └── render     ·            ·                  ("?column?", b)  ·
+           │         render 0     a + (c + (a + b))  ·                ·
+           │         render 1     b                  ·                ·
+           └── scan  ·            ·                  (a, b, c)        ·
+·                    table        abcd@primary       ·                ·
+·                    spans        ALL                ·                ·
 
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a + x FROM (SELECT a, b, a + b + c AS x FROM abcd) ORDER BY a DESC, b DESC
 ----
-render        ·         ·                  ("?column?")  ·
- │            render 0  a + (c + (a + b))  ·             ·
- └── revscan  ·         ·                  (a, b, c)     -a,-b
-·             table     abcd@primary       ·             ·
-·             spans     ALL                ·             ·
+·             distributed  false              ·             ·
+·             vectorized   true               ·             ·
+render        ·            ·                  ("?column?")  ·
+ │            render 0     a + (c + (a + b))  ·             ·
+ └── revscan  ·            ·                  (a, b, c)     -a,-b
+·             table        abcd@primary       ·             ·
+·             spans        ALL                ·             ·
 
 # Ensure that filter nodes (and filtered scan nodes) get populated with the correct ordering.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE a > b ORDER BY a
 ----
-scan  ·       ·             (a, b, c, d)  +a
-·     table   abcd@primary  ·             ·
-·     spans   ALL           ·             ·
-·     filter  a > b         ·             ·
+·     distributed  false         ·             ·
+·     vectorized   true          ·             ·
+scan  ·            ·             (a, b, c, d)  +a
+·     table        abcd@primary  ·             ·
+·     spans        ALL           ·             ·
+·     filter       a > b         ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE a > b ORDER BY a DESC, b DESC
 ----
-sort       ·       ·             (a, b, c, d)  -a,-b
- │         order   -a,-b         ·             ·
- └── scan  ·       ·             (a, b, c, d)  ·
-·          table   abcd@primary  ·             ·
-·          spans   ALL           ·             ·
-·          filter  a > b         ·             ·
+·          distributed  false         ·             ·
+·          vectorized   false         ·             ·
+sort       ·            ·             (a, b, c, d)  -a,-b
+ │         order        -a,-b         ·             ·
+ └── scan  ·            ·             (a, b, c, d)  ·
+·          table        abcd@primary  ·             ·
+·          spans        ALL           ·             ·
+·          filter       a > b         ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a, b FROM abcd LIMIT 10) WHERE a > b ORDER BY a
 ----
-filter     ·       ·             (a, b)  +a
- │         filter  a > b         ·       ·
- └── scan  ·       ·             (a, b)  +a
-·          table   abcd@primary  ·       ·
-·          spans   ALL           ·       ·
-·          limit   10            ·       ·
+·          distributed  false         ·       ·
+·          vectorized   true          ·       ·
+filter     ·            ·             (a, b)  +a
+ │         filter       a > b         ·       ·
+ └── scan  ·            ·             (a, b)  +a
+·          table        abcd@primary  ·       ·
+·          spans        ALL           ·       ·
+·          limit        10            ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a, a+b+c AS x FROM (SELECT * FROM abcd LIMIT 10)) WHERE x > 100 ORDER BY a
 ----
-render          ·         ·                    (a, x)     ·
- │              render 0  a                    ·          ·
- │              render 1  c + (a + b)          ·          ·
- └── filter     ·         ·                    (a, b, c)  +a
-      │         filter    (c + (a + b)) > 100  ·          ·
-      └── scan  ·         ·                    (a, b, c)  +a
-·               table     abcd@primary         ·          ·
-·               spans     ALL                  ·          ·
-·               limit     10                   ·          ·
+·               distributed  false                ·          ·
+·               vectorized   true                 ·          ·
+render          ·            ·                    (a, x)     ·
+ │              render 0     a                    ·          ·
+ │              render 1     c + (a + b)          ·          ·
+ └── filter     ·            ·                    (a, b, c)  +a
+      │         filter       (c + (a + b)) > 100  ·          ·
+      └── scan  ·            ·                    (a, b, c)  +a
+·               table        abcd@primary         ·          ·
+·               spans        ALL                  ·          ·
+·               limit        10                   ·          ·
 
 statement ok
 CREATE TABLE xyz (x INT, y INT, z INT, INDEX(x,y,z))
@@ -1108,12 +1223,14 @@ CREATE TABLE xyz (x INT, y INT, z INT, INDEX(x,y,z))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyz LIMIT 10) WHERE y = 1 ORDER BY x, y, z
 ----
-filter     ·       ·                  (x, y, z)  +x,+z
- │         filter  y = 1              ·          ·
- └── scan  ·       ·                  (x, y, z)  +x,+y,+z
-·          table   xyz@xyz_x_y_z_idx  ·          ·
-·          spans   ALL                ·          ·
-·          limit   10                 ·          ·
+·          distributed  false              ·          ·
+·          vectorized   true               ·          ·
+filter     ·            ·                  (x, y, z)  +x,+z
+ │         filter       y = 1              ·          ·
+ └── scan  ·            ·                  (x, y, z)  +x,+y,+z
+·          table        xyz@xyz_x_y_z_idx  ·          ·
+·          spans        ALL                ·          ·
+·          limit        10                 ·          ·
 
 # ------------------------------------------------------
 # Verify that multi-span point lookups are parallelized.
@@ -1128,51 +1245,63 @@ CREATE TABLE b (a INT, b INT, c INT NULL, d INT NULL, PRIMARY KEY (a, b))
 query TTT
 EXPLAIN SELECT * FROM a WHERE a = 10
 ----
-scan  ·         ·
-·     table     a@primary
-·     spans     /10-/10/#
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        a@primary
+·     spans        /10-/10/#
 
 query TTT
 EXPLAIN SELECT * FROM a WHERE a = 10 OR a = 20
 ----
-scan  ·         ·
-·     table     a@primary
-·     spans     /10-/10/# /20-/20/#
-·     parallel  ·
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        a@primary
+·     spans        /10-/10/# /20-/20/#
+·     parallel     ·
 
 query TTT
 EXPLAIN SELECT * FROM a WHERE a IN (10, 20)
 ----
-scan  ·         ·
-·     table     a@primary
-·     spans     /10-/10/# /20-/20/#
-·     parallel  ·
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        a@primary
+·     spans        /10-/10/# /20-/20/#
+·     parallel     ·
 
 # Verify that consolidated point spans are still parallelized.
 query TTT
 EXPLAIN SELECT * FROM a WHERE a in (10, 11)
 ----
-scan  ·         ·
-·     table     a@primary
-·     spans     /10-/11/#
-·     parallel  ·
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        a@primary
+·     spans        /10-/11/#
+·     parallel     ·
 
 query TTT
 EXPLAIN SELECT * FROM a WHERE a > 10 AND a < 20
 ----
-scan  ·         ·
-·     table     a@primary
-·     spans     /11-/19/#
-·     parallel  ·
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        a@primary
+·     spans        /11-/19/#
+·     parallel     ·
 
 # This ticks all the boxes for parallelization apart from the fact that there
 # is no end key in the span.
 query TTT
 EXPLAIN SELECT * FROM a WHERE a > 10
 ----
-scan  ·         ·
-·     table     a@primary
-·     spans     /11-
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        a@primary
+·     spans        /11-
 
 # Test non-int types.
 
@@ -1180,26 +1309,30 @@ scan  ·         ·
 query TTT
 EXPLAIN SELECT price FROM a WHERE item IN ('sock', 'ball')
 ----
-render           ·         ·
- └── index-join  ·         ·
-      │          table     a@primary
-      └── scan   ·         ·
-·                table     a@item
-·                spans     /"ball"-/"ball"/PrefixEnd /"sock"-/"sock"/PrefixEnd
-·                parallel  ·
+·                distributed  false
+·                vectorized   true
+render           ·            ·
+ └── index-join  ·            ·
+      │          table        a@primary
+      └── scan   ·            ·
+·                table        a@item
+·                spans        /"ball"-/"ball"/PrefixEnd /"sock"-/"sock"/PrefixEnd
+·                parallel     ·
 
 # Range queries on non-int types are not parallel due to unbounded number of
 # results.
 query TTT
 EXPLAIN SELECT item FROM a WHERE price > 5 AND price < 10 OR price > 20 AND price < 40
 ----
-render           ·       ·
- └── index-join  ·       ·
-      │          table   a@primary
-      └── scan   ·       ·
-·                table   a@p
-·                spans   /5.000000000000001-/9.999999999999998/PrefixEnd /20.000000000000004-/39.99999999999999/PrefixEnd
-·                filter  (price < 10.0) OR (price > 20.0)
+·                distributed  false
+·                vectorized   true
+render           ·            ·
+ └── index-join  ·            ·
+      │          table        a@primary
+      └── scan   ·            ·
+·                table        a@p
+·                spans        /5.000000000000001-/9.999999999999998/PrefixEnd /20.000000000000004-/39.99999999999999/PrefixEnd
+·                filter       (price < 10.0) OR (price > 20.0)
 
 statement ok
 SET CLUSTER SETTING sql.parallel_scans.enabled = false
@@ -1207,9 +1340,11 @@ SET CLUSTER SETTING sql.parallel_scans.enabled = false
 query TTT
 EXPLAIN SELECT * FROM a WHERE a IN (10, 20)
 ----
-scan  ·         ·
-·     table     a@primary
-·     spans     /10-/10/# /20-/20/#
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        a@primary
+·     spans        /10-/10/# /20-/20/#
 
 statement ok
 SET CLUSTER SETTING sql.parallel_scans.enabled = true
@@ -1218,29 +1353,35 @@ SET CLUSTER SETTING sql.parallel_scans.enabled = true
 query TTT
 EXPLAIN SELECT * FROM b WHERE (a = 10 AND b = 10) OR (a = 20 AND b = 20)
 ----
-scan  ·         ·
-·     table     b@primary
-·     spans     /10/10-/10/10/# /20/20-/20/20/#
-·     parallel  ·
-·     filter    ((a = 10) AND (b = 10)) OR ((a = 20) AND (b = 20))
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        b@primary
+·     spans        /10/10-/10/10/# /20/20-/20/20/#
+·     parallel     ·
+·     filter       ((a = 10) AND (b = 10)) OR ((a = 20) AND (b = 20))
 
 # This one isn't parallelizable because it's not a point lookup - only part of
 # the primary key is specified.
 query TTT
 EXPLAIN SELECT * FROM b WHERE a = 10 OR a = 20
 ----
-scan  ·      ·
-·     table  b@primary
-·     spans  /10-/11 /20-/21
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        b@primary
+·     spans        /10-/11 /20-/21
 
 # This one isn't parallelizable because it has a LIMIT clause.
 query TTT
 EXPLAIN SELECT * FROM a WHERE a = 10 OR a = 20 LIMIT 1
 ----
-scan  ·      ·
-·     table  a@primary
-·     spans  /10-/10/# /20-/20/#
-·     limit  1
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        a@primary
+·     spans        /10-/10/# /20-/20/#
+·     limit        1
 
 statement ok
 CREATE INDEX on b(b) STORING (c)
@@ -1249,9 +1390,11 @@ CREATE INDEX on b(b) STORING (c)
 query TTT
 EXPLAIN SELECT b FROM b WHERE b = 10 OR b = 20
 ----
-scan  ·      ·
-·     table  b@b_b_idx
-·     spans  /10-/11 /20-/21
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        b@b_b_idx
+·     spans        /10-/11 /20-/21
 
 statement ok
 CREATE UNIQUE INDEX on b(c)
@@ -1261,17 +1404,21 @@ CREATE UNIQUE INDEX on b(c)
 query TTT
 EXPLAIN SELECT c FROM b WHERE c = 10 OR c = 20
 ----
-scan  ·         ·
-·     table     b@b_c_key
-·     spans     /10-/11 /20-/21
-·     parallel  ·
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        b@b_c_key
+·     spans        /10-/11 /20-/21
+·     parallel     ·
 
 query TTT
 EXPLAIN SELECT c FROM b WHERE c = 10 OR c < 2
 ----
-scan  ·      ·
-·     table  b@b_c_key
-·     spans  /!NULL-/2 /10-/11
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        b@b_c_key
+·     spans        /!NULL-/2 /10-/11
 
 statement ok
 CREATE UNIQUE INDEX on b(d DESC)
@@ -1281,9 +1428,11 @@ CREATE UNIQUE INDEX on b(d DESC)
 query TTT
 EXPLAIN SELECT d FROM b WHERE d = 10 OR d < 2
 ----
-scan  ·      ·
-·     table  b@b_d_key
-·     spans  /10-/9 /1-/NULL
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        b@b_d_key
+·     spans        /10-/9 /1-/NULL
 
 statement ok
 CREATE UNIQUE INDEX ON b(c, d)
@@ -1293,11 +1442,13 @@ CREATE UNIQUE INDEX ON b(c, d)
 query TTT
 EXPLAIN SELECT d FROM b WHERE c = 10 AND d = 10 OR c IS NULL AND d > 0 AND d < 2
 ----
-render     ·       ·
- └── scan  ·       ·
-·          table   b@b_c_d_key
-·          spans   /NULL/1-/NULL/2 /10/10-/10/11
-·          filter  ((c = 10) AND (d = 10)) OR ((c IS NULL) AND (d < 2))
+·          distributed  false
+·          vectorized   false
+render     ·            ·
+ └── scan  ·            ·
+·          table        b@b_c_d_key
+·          spans        /NULL/1-/NULL/2 /10/10-/10/11
+·          filter       ((c = 10) AND (d = 10)) OR ((c IS NULL) AND (d < 2))
 
 statement ok
 DROP INDEX b_b_idx
@@ -1309,10 +1460,12 @@ CREATE UNIQUE INDEX on b(b) STORING (c)
 query TTT
 EXPLAIN SELECT b FROM b WHERE b = 10 OR b = 20
 ----
-scan  ·         ·
-·     table     b@b_b_key
-·     spans     /10-/11 /20-/21
-·     parallel  ·
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        b@b_b_key
+·     spans        /10-/11 /20-/21
+·     parallel     ·
 
 statement ok
 ALTER TABLE a SPLIT AT VALUES(5)

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -195,6 +195,8 @@ output row: [2]
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t x JOIN t y USING(b) WHERE x.b = '3'
 ----
+·                     distributed     false                ·                         ·
+·                     vectorized      false                ·                         ·
 render                ·               ·                    (b, a, c, d, a, c, d)     ·
  │                    render 0        b                    ·                         ·
  │                    render 1        a                    ·                         ·
@@ -261,7 +263,9 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
 query TTT
 EXPLAIN SELECT * FROM t WHERE a > 1 AND a < 2
 ----
-norows  ·  ·
+·       distributed  false
+·       vectorized   false
+norows  ·            ·
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE a = 1 AND 'a' < b AND 'c' > b; SET tracing = off
@@ -427,17 +431,23 @@ output row: [3 4]
 query TTT
 EXPLAIN SELECT * FROM t WHERE a = 1 AND false
 ----
-norows  ·  ·
+·       distributed  false
+·       vectorized   false
+norows  ·            ·
 
 query TTT
 EXPLAIN SELECT * FROM t WHERE a = 1 AND NULL
 ----
-norows  ·  ·
+·       distributed  false
+·       vectorized   false
+norows  ·            ·
 
 query TTT
 EXPLAIN SELECT * FROM t WHERE a = NULL AND a != NULL
 ----
-norows  ·  ·
+·       distributed  false
+·       vectorized   false
+norows  ·            ·
 
 # Make sure that mixed type comparison operations are not used
 # for selecting indexes.
@@ -457,100 +467,120 @@ CREATE TABLE t (
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE c > 1
 ----
-render     ·         ·          (a)     ·
- │         render 0  a          ·       ·
- └── scan  ·         ·          (a, c)  ·
-·          table     t@primary  ·       ·
-·          spans     ALL        ·       ·
-·          filter    c > 1      ·       ·
+·          distributed  false      ·       ·
+·          vectorized   true       ·       ·
+render     ·            ·          (a)     ·
+ │         render 0     a          ·       ·
+ └── scan  ·            ·          (a, c)  ·
+·          table        t@primary  ·       ·
+·          spans        ALL        ·       ·
+·          filter       c > 1      ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE c < 1 AND b < 5
 ----
-render     ·         ·            (a)        ·
- │         render 0  a            ·          ·
- └── scan  ·         ·            (a, b, c)  ·
-·          table     t@bc         ·          ·
-·          spans     /!NULL-/4/1  ·          ·
-·          filter    c < 1        ·          ·
+·          distributed  false        ·          ·
+·          vectorized   true         ·          ·
+render     ·            ·            (a)        ·
+ │         render 0     a            ·          ·
+ └── scan  ·            ·            (a, b, c)  ·
+·          table        t@bc         ·          ·
+·          spans        /!NULL-/4/1  ·          ·
+·          filter       c < 1        ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE c > 1.0
 ----
-render     ·         ·          (a)     ·
- │         render 0  a          ·       ·
- └── scan  ·         ·          (a, c)  ·
-·          table     t@primary  ·       ·
-·          spans     ALL        ·       ·
-·          filter    c > 1      ·       ·
+·          distributed  false      ·       ·
+·          vectorized   true       ·       ·
+render     ·            ·          (a)     ·
+ │         render 0     a          ·       ·
+ └── scan  ·            ·          (a, c)  ·
+·          table        t@primary  ·       ·
+·          spans        ALL        ·       ·
+·          filter       c > 1      ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE c < 1.0
 ----
-render     ·         ·          (a)     ·
- │         render 0  a          ·       ·
- └── scan  ·         ·          (a, c)  ·
-·          table     t@primary  ·       ·
-·          spans     ALL        ·       ·
-·          filter    c < 1      ·       ·
+·          distributed  false      ·       ·
+·          vectorized   true       ·       ·
+render     ·            ·          (a)     ·
+ │         render 0     a          ·       ·
+ └── scan  ·            ·          (a, c)  ·
+·          table        t@primary  ·       ·
+·          spans        ALL        ·       ·
+·          filter       c < 1      ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE c > 1.0 AND b < 5
 ----
-render     ·         ·          (a)        ·
- │         render 0  a          ·          ·
- └── scan  ·         ·          (a, b, c)  ·
-·          table     t@bc       ·          ·
-·          spans     /!NULL-/5  ·          ·
-·          filter    c > 1      ·          ·
+·          distributed  false      ·          ·
+·          vectorized   true       ·          ·
+render     ·            ·          (a)        ·
+ │         render 0     a          ·          ·
+ └── scan  ·            ·          (a, b, c)  ·
+·          table        t@bc       ·          ·
+·          spans        /!NULL-/5  ·          ·
+·          filter       c > 1      ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE b < 5.0 AND c < 1
 ----
-render     ·         ·            (a)        ·
- │         render 0  a            ·          ·
- └── scan  ·         ·            (a, b, c)  ·
-·          table     t@bc         ·          ·
-·          spans     /!NULL-/4/1  ·          ·
-·          filter    c < 1        ·          ·
+·          distributed  false        ·          ·
+·          vectorized   true         ·          ·
+render     ·            ·            (a)        ·
+ │         render 0     a            ·          ·
+ └── scan  ·            ·            (a, b, c)  ·
+·          table        t@bc         ·          ·
+·          spans        /!NULL-/4/1  ·          ·
+·          filter       c < 1        ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE (b, c) = (5, 1)
 ----
-render     ·         ·          (a)        ·
- │         render 0  a          ·          ·
- └── scan  ·         ·          (a, b, c)  ·
-·          table     t@bc       ·          ·
-·          spans     /5/1-/5/2  ·          ·
+·          distributed  false      ·          ·
+·          vectorized   true       ·          ·
+render     ·            ·          (a)        ·
+ │         render 0     a          ·          ·
+ └── scan  ·            ·          (a, b, c)  ·
+·          table        t@bc       ·          ·
+·          spans        /5/1-/5/2  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE (b, c) = (5.0, 1)
 ----
-render     ·         ·          (a)        ·
- │         render 0  a          ·          ·
- └── scan  ·         ·          (a, b, c)  ·
-·          table     t@bc       ·          ·
-·          spans     /5/1-/5/2  ·          ·
+·          distributed  false      ·          ·
+·          vectorized   true       ·          ·
+render     ·            ·          (a)        ·
+ │         render 0     a          ·          ·
+ └── scan  ·            ·          (a, b, c)  ·
+·          table        t@bc       ·          ·
+·          spans        /5/1-/5/2  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE (b, c) = (5.1, 1)
 ----
-render     ·         ·                      (a)        ·
- │         render 0  a                      ·          ·
- └── scan  ·         ·                      (a, b, c)  ·
-·          table     t@bc                   ·          ·
-·          spans     /!NULL-                ·          ·
-·          filter    (b = 5.1) AND (c = 1)  ·          ·
+·          distributed  false                  ·          ·
+·          vectorized   true                   ·          ·
+render     ·            ·                      (a)        ·
+ │         render 0     a                      ·          ·
+ └── scan  ·            ·                      (a, b, c)  ·
+·          table        t@bc                   ·          ·
+·          spans        /!NULL-                ·          ·
+·          filter       (b = 5.1) AND (c = 1)  ·          ·
 
 # Note the span is reversed because of #20203.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE b IN (5.0, 1)
 ----
-render     ·         ·            (a)     ·
- │         render 0  a            ·       ·
- └── scan  ·         ·            (a, b)  ·
-·          table     t@b_desc     ·       ·
-·          spans     /5-/4 /1-/0  ·       ·
+·          distributed  false        ·       ·
+·          vectorized   true         ·       ·
+render     ·            ·            (a)     ·
+ │         render 0     a            ·       ·
+ └── scan  ·            ·            (a, b)  ·
+·          table        t@b_desc     ·       ·
+·          spans        /5-/4 /1-/0  ·       ·
 
 statement ok
 CREATE TABLE abcd (
@@ -567,20 +597,24 @@ CREATE TABLE abcd (
 query TTTTT
 EXPLAIN (VERBOSE) SELECT b FROM abcd WHERE (a, b) = (1, 4)
 ----
-render     ·         ·          (b)     ·
- │         render 0  b          ·       ·
- └── scan  ·         ·          (a, b)  ·
-·          table     abcd@abcd  ·       ·
-·          spans     /1/4-/1/5  ·       ·
+·          distributed  false      ·       ·
+·          vectorized   true       ·       ·
+render     ·            ·          (b)     ·
+ │         render 0     b          ·       ·
+ └── scan  ·            ·          (a, b)  ·
+·          table        abcd@abcd  ·       ·
+·          spans        /1/4-/1/5  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT b FROM abcd WHERE (a, b) IN ((1, 4), (2, 9))
 ----
-render     ·         ·                     (b)     ·
- │         render 0  b                     ·       ·
- └── scan  ·         ·                     (a, b)  ·
-·          table     abcd@abcd             ·       ·
-·          spans     /1/4-/1/5 /2/9-/2/10  ·       ·
+·          distributed  false                 ·       ·
+·          vectorized   true                  ·       ·
+render     ·            ·                     (b)     ·
+ │         render 0     b                     ·       ·
+ └── scan  ·            ·                     (a, b)  ·
+·          table        abcd@abcd             ·       ·
+·          spans        /1/4-/1/5 /2/9-/2/10  ·       ·
 
 statement ok
 CREATE TABLE ab (
@@ -591,13 +625,15 @@ CREATE TABLE ab (
 query TTTTT
 EXPLAIN (VERBOSE) SELECT i, s FROM ab WHERE (i, s) < (1, 'c')
 ----
-render     ·         ·                  (i, s)  ·
- │         render 0  i                  ·       ·
- │         render 1  s                  ·       ·
- └── scan  ·         ·                  (s, i)  ·
-·          table     ab@primary         ·       ·
-·          spans     ALL                ·       ·
-·          filter    (i, s) < (1, 'c')  ·       ·
+·          distributed  false              ·       ·
+·          vectorized   false              ·       ·
+render     ·            ·                  (i, s)  ·
+ │         render 0     i                  ·       ·
+ │         render 1     s                  ·       ·
+ └── scan  ·            ·                  (s, i)  ·
+·          table        ab@primary         ·       ·
+·          spans        ALL                ·       ·
+·          filter       (i, s) < (1, 'c')  ·       ·
 
 statement ok
 CREATE INDEX baz ON ab (i, s)
@@ -605,13 +641,15 @@ CREATE INDEX baz ON ab (i, s)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT i, s FROM ab@baz WHERE (i, s) < (1, 'c')
 ----
-render     ·         ·                  (i, s)  ·
- │         render 0  i                  ·       ·
- │         render 1  s                  ·       ·
- └── scan  ·         ·                  (s, i)  ·
-·          table     ab@baz             ·       ·
-·          spans     /!NULL-/1/"c"      ·       ·
-·          filter    (i, s) < (1, 'c')  ·       ·
+·          distributed  false              ·       ·
+·          vectorized   false              ·       ·
+render     ·            ·                  (i, s)  ·
+ │         render 0     i                  ·       ·
+ │         render 1     s                  ·       ·
+ └── scan  ·            ·                  (s, i)  ·
+·          table        ab@baz             ·       ·
+·          spans        /!NULL-/1/"c"      ·       ·
+·          filter       (i, s) < (1, 'c')  ·       ·
 
 # Check that primary key definitions can indicate index ordering,
 # and this information is subsequently used during index selection
@@ -628,18 +666,22 @@ abz  abz_c_b_key  false  3  a  ASC   false  true
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM abz ORDER BY a DESC LIMIT 1
 ----
-scan  ·      ·            (a)  ·
-·     table  abz@primary  ·    ·
-·     spans  ALL          ·    ·
-·     limit  1            ·    ·
+·     distributed  false        ·    ·
+·     vectorized   true         ·    ·
+scan  ·            ·            (a)  ·
+·     table        abz@primary  ·    ·
+·     spans        ALL          ·    ·
+·     limit        1            ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT c FROM abz ORDER BY c DESC LIMIT 1
 ----
-scan  ·      ·                (c)  ·
-·     table  abz@abz_c_b_key  ·    ·
-·     spans  ALL              ·    ·
-·     limit  1                ·    ·
+·     distributed  false            ·    ·
+·     vectorized   true             ·    ·
+scan  ·            ·                (c)  ·
+·     table        abz@abz_c_b_key  ·    ·
+·     spans        ALL              ·    ·
+·     limit        1                ·    ·
 
 # Issue #14426: verify we don't have an internal filter that contains "a IN ()"
 # (which causes an error in DistSQL due to expression serialization).
@@ -653,12 +695,14 @@ CREATE TABLE tab0(
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM tab0 WHERE (a IN (6) AND a > 6) OR b >= 4
 ----
-render     ·         ·                                      (k)        ·
- │         render 0  k                                      ·          ·
- └── scan  ·         ·                                      (k, a, b)  ·
-·          table     tab0@primary                           ·          ·
-·          spans     ALL                                    ·          ·
-·          filter    ((a IN (6,)) AND (a > 6)) OR (b >= 4)  ·          ·
+·          distributed  false                                  ·          ·
+·          vectorized   true                                   ·          ·
+render     ·            ·                                      (k)        ·
+ │         render 0     k                                      ·          ·
+ └── scan  ·            ·                                      (k, a, b)  ·
+·          table        tab0@primary                           ·          ·
+·          spans        ALL                                    ·          ·
+·          filter       ((a IN (6,)) AND (a > 6)) OR (b >= 4)  ·          ·
 
 # Check that no extraneous rows are fetched due to excessive batching (#15910)
 # The test is composed of three parts: populate a table, check
@@ -678,12 +722,14 @@ INSERT INTO test2(k)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM test2 WHERE k <= '100' ORDER BY k DESC LIMIT 20
 ----
-index-join    ·      ·                        (id, k, v)  -k
- │            table  test2@primary            ·           ·
- └── revscan  ·      ·                        (id, k)     -k
-·             table  test2@test2_k_key        ·           ·
-·             spans  /!NULL-/"100"/PrefixEnd  ·           ·
-·             limit  20                       ·           ·
+·             distributed  false                    ·           ·
+·             vectorized   true                     ·           ·
+index-join    ·            ·                        (id, k, v)  -k
+ │            table        test2@primary            ·           ·
+ └── revscan  ·            ·                        (id, k)     -k
+·             table        test2@test2_k_key        ·           ·
+·             spans        /!NULL-/"100"/PrefixEnd  ·           ·
+·             limit        20                       ·           ·
 
 # The result output of this test requires that vectorized execution
 # is not used, so it has been moved to select_index_vectorize_off.
@@ -732,6 +778,8 @@ AND   f1.resource_key IN ('ts', 'ts2', 'ts3')
 GROUP BY resource_key
 ORDER BY total DESC
 ----
+·                    distributed  false
+·                    vectorized   false
 sort                 ·            ·
  │                   order        -total
  └── group           ·            ·
@@ -765,30 +813,38 @@ ts3 1
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a IS NULL AND b > 5
 ----
-scan  ·      ·               (a, b, c, d)  ·
-·     table  abcd@abcd       ·             ·
-·     spans  /NULL/6-/!NULL  ·             ·
+·     distributed  false           ·             ·
+·     vectorized   true            ·             ·
+scan  ·            ·               (a, b, c, d)  ·
+·     table        abcd@abcd       ·             ·
+·     spans        /NULL/6-/!NULL  ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a IS NULL AND b < 5
 ----
-scan  ·      ·                    (a, b, c, d)  ·
-·     table  abcd@abcd            ·             ·
-·     spans  /NULL/!NULL-/NULL/5  ·             ·
+·     distributed  false                ·             ·
+·     vectorized   true                 ·             ·
+scan  ·            ·                    (a, b, c, d)  ·
+·     table        abcd@abcd            ·             ·
+·     spans        /NULL/!NULL-/NULL/5  ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a IS NULL ORDER BY b
 ----
-scan  ·      ·             (a, b, c, d)  +b
-·     table  abcd@abcd     ·             ·
-·     spans  /NULL-/!NULL  ·             ·
+·     distributed  false         ·             ·
+·     vectorized   true          ·             ·
+scan  ·            ·             (a, b, c, d)  +b
+·     table        abcd@abcd     ·             ·
+·     spans        /NULL-/!NULL  ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a = 1 AND b IS NULL AND c > 0 AND c < 10 ORDER BY c
 ----
-scan  ·      ·                     (a, b, c, d)  +c
-·     table  abcd@abcd             ·             ·
-·     spans  /1/NULL/1-/1/NULL/10  ·             ·
+·     distributed  false                 ·             ·
+·     vectorized   true                  ·             ·
+scan  ·            ·                     (a, b, c, d)  +c
+·     table        abcd@abcd             ·             ·
+·     spans        /1/NULL/1-/1/NULL/10  ·             ·
 
 # Regression test for #3548: verify we create constraints on implicit columns
 # when they are part of the key (non-unique index).
@@ -798,11 +854,13 @@ CREATE TABLE abc (a INT, b INT, c INT, PRIMARY KEY(a,b), INDEX(c))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT c FROM abc WHERE c = 1 and a = 3
 ----
-render     ·         ·              (c)     ·
- │         render 0  c              ·       ·
- └── scan  ·         ·              (a, c)  ·
-·          table     abc@abc_c_idx  ·       ·
-·          spans     /1/3-/1/4      ·       ·
+·          distributed  false          ·       ·
+·          vectorized   true           ·       ·
+render     ·            ·              (c)     ·
+ │         render 0     c              ·       ·
+ └── scan  ·            ·              (a, c)  ·
+·          table        abc@abc_c_idx  ·       ·
+·          spans        /1/3-/1/4      ·       ·
 
 # Verify we don't create constraints on implicit columns when they may be part
 # of the key (unique index on nullable column).
@@ -812,12 +870,14 @@ CREATE TABLE def (d INT, e INT, f INT, PRIMARY KEY(d,e), UNIQUE INDEX(f))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT f FROM def WHERE f = 1 and d = 3
 ----
-render     ·         ·              (f)     ·
- │         render 0  f              ·       ·
- └── scan  ·         ·              (d, f)  ·
-·          table     def@def_f_key  ·       ·
-·          spans     /1-/2          ·       ·
-·          filter    d = 3          ·       ·
+·          distributed  false          ·       ·
+·          vectorized   true           ·       ·
+render     ·            ·              (f)     ·
+ │         render 0     f              ·       ·
+ └── scan  ·            ·              (d, f)  ·
+·          table        def@def_f_key  ·       ·
+·          spans        /1-/2          ·       ·
+·          filter       d = 3          ·       ·
 
 statement ok
 DROP TABLE def
@@ -830,20 +890,24 @@ CREATE TABLE def (d INT, e INT, f INT NOT NULL, PRIMARY KEY(d,e), UNIQUE INDEX(f
 query TTTTT
 EXPLAIN (VERBOSE) SELECT f FROM def WHERE f = 1 and d = 3
 ----
-render     ·         ·              (f)     ·
- │         render 0  f              ·       ·
- └── scan  ·         ·              (d, f)  ·
-·          table     def@def_f_key  ·       ·
-·          spans     /1-/2          ·       ·
-·          filter    d = 3          ·       ·
+·          distributed  false          ·       ·
+·          vectorized   true           ·       ·
+render     ·            ·              (f)     ·
+ │         render 0     f              ·       ·
+ └── scan  ·            ·              (d, f)  ·
+·          table        def@def_f_key  ·       ·
+·          spans        /1-/2          ·       ·
+·          filter       d = 3          ·       ·
 
 # Regression test for #20504.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a, b FROM abc WHERE (a, b) BETWEEN (1, 2) AND (3, 4)
 ----
-scan  ·      ·            (a, b)  ·
-·     table  abc@primary  ·       ·
-·     spans  /1/2-/3/4/#  ·       ·
+·     distributed  false        ·       ·
+·     vectorized   true         ·       ·
+scan  ·            ·            (a, b)  ·
+·     table        abc@primary  ·       ·
+·     spans        /1/2-/3/4/#  ·       ·
 
 # Regression test for #21831.
 statement ok
@@ -852,25 +916,31 @@ CREATE TABLE str (k INT PRIMARY KEY, v STRING, INDEX(v))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, v FROM str WHERE v LIKE 'ABC%'
 ----
-scan  ·      ·              (k, v)  ·
-·     table  str@str_v_idx  ·       ·
-·     spans  /"ABC"-/"ABD"  ·       ·
+·     distributed  false          ·       ·
+·     vectorized   true           ·       ·
+scan  ·            ·              (k, v)  ·
+·     table        str@str_v_idx  ·       ·
+·     spans        /"ABC"-/"ABD"  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, v FROM str WHERE v LIKE 'ABC%Z'
 ----
-scan  ·       ·               (k, v)  ·
-·     table   str@str_v_idx   ·       ·
-·     spans   /"ABC"-/"ABD"   ·       ·
-·     filter  v LIKE 'ABC%Z'  ·       ·
+·     distributed  false           ·       ·
+·     vectorized   true            ·       ·
+scan  ·            ·               (k, v)  ·
+·     table        str@str_v_idx   ·       ·
+·     spans        /"ABC"-/"ABD"   ·       ·
+·     filter       v LIKE 'ABC%Z'  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, v FROM str WHERE v SIMILAR TO 'ABC_*'
 ----
-scan  ·       ·                     (k, v)  ·
-·     table   str@str_v_idx         ·       ·
-·     spans   /"ABC"-/"ABD"         ·       ·
-·     filter  v SIMILAR TO 'ABC_*'  ·       ·
+·     distributed  false                 ·       ·
+·     vectorized   false                 ·       ·
+scan  ·            ·                     (k, v)  ·
+·     table        str@str_v_idx         ·       ·
+·     spans        /"ABC"-/"ABD"         ·       ·
+·     filter       v SIMILAR TO 'ABC_*'  ·       ·
 
 # Test that we generate spans for IS (NOT) DISTINCT FROM.
 statement ok
@@ -879,47 +949,57 @@ CREATE TABLE xy (x INT, y INT, INDEX (y))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS NOT DISTINCT FROM NULL
 ----
-index-join  ·      ·             (x, y)              ·
- │          table  xy@primary    ·                   ·
- └── scan   ·      ·             (y, rowid[hidden])  ·
-·           table  xy@xy_y_idx   ·                   ·
-·           spans  /NULL-/!NULL  ·                   ·
+·           distributed  false         ·                   ·
+·           vectorized   true          ·                   ·
+index-join  ·            ·             (x, y)              ·
+ │          table        xy@primary    ·                   ·
+ └── scan   ·            ·             (y, rowid[hidden])  ·
+·           table        xy@xy_y_idx   ·                   ·
+·           spans        /NULL-/!NULL  ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS NOT DISTINCT FROM 4
 ----
-index-join  ·      ·            (x, y)              ·
- │          table  xy@primary   ·                   ·
- └── scan   ·      ·            (y, rowid[hidden])  ·
-·           table  xy@xy_y_idx  ·                   ·
-·           spans  /4-/5        ·                   ·
+·           distributed  false        ·                   ·
+·           vectorized   true         ·                   ·
+index-join  ·            ·            (x, y)              ·
+ │          table        xy@primary   ·                   ·
+ └── scan   ·            ·            (y, rowid[hidden])  ·
+·           table        xy@xy_y_idx  ·                   ·
+·           spans        /4-/5        ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x FROM xy WHERE y > 0 AND y < 2 ORDER BY y
 ----
-render           ·         ·            (x)                 ·
- │               render 0  x            ·                   ·
- └── index-join  ·         ·            (x, y)              ·
-      │          table     xy@primary   ·                   ·
-      └── scan   ·         ·            (y, rowid[hidden])  ·
-·                table     xy@xy_y_idx  ·                   ·
-·                spans     /1-/2        ·                   ·
+·                distributed  false        ·                   ·
+·                vectorized   true         ·                   ·
+render           ·            ·            (x)                 ·
+ │               render 0     x            ·                   ·
+ └── index-join  ·            ·            (x, y)              ·
+      │          table        xy@primary   ·                   ·
+      └── scan   ·            ·            (y, rowid[hidden])  ·
+·                table        xy@xy_y_idx  ·                   ·
+·                spans        /1-/2        ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS DISTINCT FROM NULL
 ----
-scan  ·       ·              (x, y)  ·
-·     table   xy@primary     ·       ·
-·     spans   ALL            ·       ·
-·     filter  y IS NOT NULL  ·       ·
+·     distributed  false          ·       ·
+·     vectorized   false          ·       ·
+scan  ·            ·              (x, y)  ·
+·     table        xy@primary     ·       ·
+·     spans        ALL            ·       ·
+·     filter       y IS NOT NULL  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS DISTINCT FROM 4
 ----
-scan  ·       ·                     (x, y)  ·
-·     table   xy@primary            ·       ·
-·     spans   ALL                   ·       ·
-·     filter  y IS DISTINCT FROM 4  ·       ·
+·     distributed  false                 ·       ·
+·     vectorized   false                 ·       ·
+scan  ·            ·                     (x, y)  ·
+·     table        xy@primary            ·       ·
+·     spans        ALL                   ·       ·
+·     filter       y IS DISTINCT FROM 4  ·       ·
 
 # Regression tests for #22670.
 statement ok
@@ -931,16 +1011,20 @@ INSERT INTO xy VALUES (NULL, NULL), (1, NULL), (NULL, 1), (1, 1)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE x IN (NULL, 1, 2)
 ----
-scan  ·      ·          (x, y)  ·
-·     table  xy@xy_idx  ·       ·
-·     spans  /1-/3      ·       ·
+·     distributed  false      ·       ·
+·     vectorized   true       ·       ·
+scan  ·            ·          (x, y)  ·
+·     table        xy@xy_idx  ·       ·
+·     spans        /1-/3      ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE (x, y) IN ((NULL, NULL), (1, NULL), (NULL, 1), (1, 1), (1, 2))
 ----
-scan  ·      ·          (x, y)  ·
-·     table  xy@xy_idx  ·       ·
-·     spans  /1/1-/1/3  ·       ·
+·     distributed  false      ·       ·
+·     vectorized   true       ·       ·
+scan  ·            ·          (x, y)  ·
+·     table        xy@xy_idx  ·       ·
+·     spans        /1/1-/1/3  ·       ·
 
 # ------------------------------------------------------------------------------
 # Non-covering index
@@ -965,11 +1049,13 @@ INSERT INTO noncover VALUES (1, 2, 3, 4), (5, 6, 7, 8)
 query TTT
 EXPLAIN SELECT * FROM noncover WHERE b = 2
 ----
-index-join  ·      ·
- │          table  noncover@primary
- └── scan   ·      ·
-·           table  noncover@b
-·           spans  /2-/3
+·           distributed  false
+·           vectorized   true
+index-join  ·            ·
+ │          table        noncover@primary
+ └── scan   ·            ·
+·           table        noncover@b
+·           spans        /2-/3
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM noncover WHERE b = 2; SET tracing = off
@@ -989,11 +1075,13 @@ output row: [1 2 3 4]
 query TTT
 EXPLAIN SELECT * FROM noncover WHERE c = 6
 ----
-index-join  ·      ·
- │          table  noncover@primary
- └── scan   ·      ·
-·           table  noncover@c
-·           spans  /6-/7
+·           distributed  false
+·           vectorized   true
+index-join  ·            ·
+ │          table        noncover@primary
+ └── scan   ·            ·
+·           table        noncover@c
+·           spans        /6-/7
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM noncover WHERE c = 7; SET tracing = off
@@ -1013,30 +1101,36 @@ output row: [5 6 7 8]
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM noncover WHERE c > 0 ORDER BY c DESC
 ----
-sort       ·       ·                 (a, b, c, d)  -c
- │         order   -c                ·             ·
- └── scan  ·       ·                 (a, b, c, d)  ·
-·          table   noncover@primary  ·             ·
-·          spans   ALL               ·             ·
-·          filter  c > 0             ·             ·
+·          distributed  false             ·             ·
+·          vectorized   false             ·             ·
+sort       ·            ·                 (a, b, c, d)  -c
+ │         order        -c                ·             ·
+ └── scan  ·            ·                 (a, b, c, d)  ·
+·          table        noncover@primary  ·             ·
+·          spans        ALL               ·             ·
+·          filter       c > 0             ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM noncover WHERE c > 0 ORDER BY c
 ----
-sort       ·       ·                 (a, b, c, d)  +c
- │         order   +c                ·             ·
- └── scan  ·       ·                 (a, b, c, d)  ·
-·          table   noncover@primary  ·             ·
-·          spans   ALL               ·             ·
-·          filter  c > 0             ·             ·
+·          distributed  false             ·             ·
+·          vectorized   false             ·             ·
+sort       ·            ·                 (a, b, c, d)  +c
+ │         order        +c                ·             ·
+ └── scan  ·            ·                 (a, b, c, d)  ·
+·          table        noncover@primary  ·             ·
+·          spans        ALL               ·             ·
+·          filter       c > 0             ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM noncover WHERE c > 0 AND d = 8
 ----
-scan  ·       ·                    (a, b, c, d)  ·
-·     table   noncover@primary     ·             ·
-·     spans   ALL                  ·             ·
-·     filter  (c > 0) AND (d = 8)  ·             ·
+·     distributed  false                ·             ·
+·     vectorized   true                 ·             ·
+scan  ·            ·                    (a, b, c, d)  ·
+·     table        noncover@primary     ·             ·
+·     spans        ALL                  ·             ·
+·     filter       (c > 0) AND (d = 8)  ·             ·
 
 # The following testcases verify that when we have a small limit, we prefer an
 # order-matching index.
@@ -1044,34 +1138,40 @@ scan  ·       ·                    (a, b, c, d)  ·
 query TTT
 EXPLAIN SELECT * FROM noncover ORDER BY c
 ----
-sort       ·      ·
- │         order  +c
- └── scan  ·      ·
-·          table  noncover@primary
-·          spans  ALL
+·          distributed  false
+·          vectorized   false
+sort       ·            ·
+ │         order        +c
+ └── scan  ·            ·
+·          table        noncover@primary
+·          spans        ALL
 
 query TTT
 EXPLAIN SELECT * FROM noncover ORDER BY c LIMIT 5
 ----
-index-join  ·      ·
- │          table  noncover@primary
- └── scan   ·      ·
-·           table  noncover@c
-·           spans  ALL
-·           limit  5
+·           distributed  false
+·           vectorized   true
+index-join  ·            ·
+ │          table        noncover@primary
+ └── scan   ·            ·
+·           table        noncover@c
+·           spans        ALL
+·           limit        5
 
 query TTT
 SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM noncover ORDER BY c OFFSET 5
 ]
 ----
-limit           ·       ·
- │              offset  5
- └── sort       ·       ·
-      │         order   +c
-      └── scan  ·       ·
-·               table   noncover@primary
-·               spans   ALL
+·               distributed  false
+·               vectorized   false
+limit           ·            ·
+ │              offset       5
+ └── sort       ·            ·
+      │         order        +c
+      └── scan  ·            ·
+·               table        noncover@primary
+·               spans        ALL
 
 # TODO(radu): need to prefer the order-matching index when OFFSET is present.
 query TTT
@@ -1079,27 +1179,31 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM noncover ORDER BY c LIMIT 5 OFFSET 5
 ]
 ----
-limit            ·       ·
- │               offset  5
- └── index-join  ·       ·
-      │          table   noncover@primary
-      └── scan   ·       ·
-·                table   noncover@c
-·                spans   ALL
-·                limit   10
+·                distributed  false
+·                vectorized   true
+limit            ·            ·
+ │               offset       5
+ └── index-join  ·            ·
+      │          table        noncover@primary
+      └── scan   ·            ·
+·                table        noncover@c
+·                spans        ALL
+·                limit        10
 
 query TTT
 SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM noncover ORDER BY c LIMIT 1000000
 ]
 ----
-limit           ·      ·
- │              count  1000000
- └── sort       ·      ·
-      │         order  +c
-      └── scan  ·      ·
-·               table  noncover@primary
-·               spans  ALL
+·               distributed  false
+·               vectorized   false
+limit           ·            ·
+ │              count        1000000
+ └── sort       ·            ·
+      │         order        +c
+      └── scan  ·            ·
+·               table        noncover@primary
+·               spans        ALL
 
 # ------------------------------------------------------------------------------
 # These tests verify that while we are joining an index with the table, we
@@ -1147,12 +1251,14 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM t2 WHERE b = 2 AND c % 2 = 0
 ]
 ----
-index-join  ·       ·
- │          table   t2@primary
- └── scan   ·       ·
-·           table   t2@bc
-·           spans   /2-/3
-·           filter  (c % 2) = 0
+·           distributed  false
+·           vectorized   false
+index-join  ·            ·
+ │          table        t2@primary
+ └── scan   ·            ·
+·           table        t2@bc
+·           spans        /2-/3
+·           filter       (c % 2) = 0
 
 # We do NOT look up the table row for '21' and '23'.
 statement ok
@@ -1177,12 +1283,14 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM t2 WHERE b = 2 AND c != b
 ]
 ----
-index-join  ·       ·
- │          table   t2@primary
- └── scan   ·       ·
-·           table   t2@bc
-·           spans   /2/!NULL-/3
-·           filter  c != b
+·           distributed  false
+·           vectorized   true
+index-join  ·            ·
+ │          table        t2@primary
+ └── scan   ·            ·
+·           table        t2@bc
+·           spans        /2/!NULL-/3
+·           filter       c != b
 
 # We do NOT look up the table row for '22'.
 statement ok
@@ -1284,13 +1392,15 @@ output row: [9 3 3 '33']
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t2 WHERE b = 2 OR ((b BETWEEN 2 AND 1) AND ((s != 'a') OR (s = 'a')))
 ----
-render           ·         ·           (a)        ·
- │               render 0  a           ·          ·
- └── index-join  ·         ·           (a, b, s)  ·
-      │          table     t2@primary  ·          ·
-      └── scan   ·         ·           (a, b)     ·
-·                table     t2@bc       ·          ·
-·                spans     /2-/3       ·          ·
+·                distributed  false       ·          ·
+·                vectorized   true        ·          ·
+render           ·            ·           (a)        ·
+ │               render 0     a           ·          ·
+ └── index-join  ·            ·           (a, b, s)  ·
+      │          table        t2@primary  ·          ·
+      └── scan   ·            ·           (a, b)     ·
+·                table        t2@bc       ·          ·
+·                spans        /2-/3       ·          ·
 
 statement ok
 CREATE TABLE t3 (k INT PRIMARY KEY, v INT, w INT, INDEX v(v))
@@ -1298,13 +1408,15 @@ CREATE TABLE t3 (k INT PRIMARY KEY, v INT, w INT, INDEX v(v))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT w FROM t3 WHERE v > 0 AND v < 10 ORDER BY v
 ----
-render           ·         ·           (w)     ·
- │               render 0  w           ·       ·
- └── index-join  ·         ·           (v, w)  +v
-      │          table     t3@primary  ·       ·
-      └── scan   ·         ·           (k, v)  +v
-·                table     t3@v        ·       ·
-·                spans     /1-/10      ·       ·
+·                distributed  false       ·       ·
+·                vectorized   true        ·       ·
+render           ·            ·           (w)     ·
+ │               render 0     w           ·       ·
+ └── index-join  ·            ·           (v, w)  +v
+      │          table        t3@primary  ·       ·
+      └── scan   ·            ·           (k, v)  +v
+·                table        t3@v        ·       ·
+·                spans        /1-/10      ·       ·
 
 # ------------------------------------------------------------------------------
 # These tests are for the point lookup optimization: for single row lookups on
@@ -1333,10 +1445,12 @@ INSERT INTO t4 VALUES (10, 20, 30, 40, 50)
 query TTT
 EXPLAIN SELECT c FROM t4 WHERE a = 10 and b = 20
 ----
-render     ·      ·
- └── scan  ·      ·
-·          table  t4@primary
-·          spans  /10/20/0-/10/20/1/2
+·          distributed  false
+·          vectorized   true
+render     ·            ·
+ └── scan  ·            ·
+·          table        t4@primary
+·          spans        /10/20/0-/10/20/1/2
 
 statement ok
 SET tracing = on,kv,results; SELECT c FROM t4 WHERE a = 10 and b = 20; SET tracing = off
@@ -1354,11 +1468,13 @@ output row: [30]
 query TTT
 EXPLAIN SELECT d FROM t4 WHERE a = 10 and b = 20
 ----
-render     ·         ·
- └── scan  ·         ·
-·          table     t4@primary
-·          spans     /10/20/0-/10/20/1 /10/20/2/1-/10/20/2/2
-·          parallel  ·
+·          distributed  false
+·          vectorized   true
+render     ·            ·
+ └── scan  ·            ·
+·          table        t4@primary
+·          spans        /10/20/0-/10/20/1 /10/20/2/1-/10/20/2/2
+·          parallel     ·
 
 statement ok
 SET tracing = on,kv,results; SELECT d FROM t4 WHERE a = 10 and b = 20; SET tracing = off
@@ -1377,49 +1493,59 @@ output row: [40]
 query TTT
 EXPLAIN SELECT d, e FROM t4 WHERE a = 10 and b = 20
 ----
-render     ·         ·
- └── scan  ·         ·
-·          table     t4@primary
-·          spans     /10/20/0-/10/20/1 /10/20/2/1-/10/20/3/2
-·          parallel  ·
+·          distributed  false
+·          vectorized   true
+render     ·            ·
+ └── scan  ·            ·
+·          table        t4@primary
+·          spans        /10/20/0-/10/20/1 /10/20/2/1-/10/20/3/2
+·          parallel     ·
 
 # Optimization should also be applied for updates.
 query TTT
 EXPLAIN UPDATE t4 SET c = 30 WHERE a = 10 and b = 20
 ----
-count                ·         ·
- └── update          ·         ·
-      │              table     t4
-      │              set       c
-      │              strategy  updater
-      └── render     ·         ·
-           └── scan  ·         ·
-·                    table     t4@primary
-·                    spans     /10/20/0-/10/20/1/2
+·                    distributed  false
+·                    vectorized   false
+count                ·            ·
+ └── update          ·            ·
+      │              table        t4
+      │              set          c
+      │              strategy     updater
+      └── render     ·            ·
+           └── scan  ·            ·
+·                    table        t4@primary
+·                    spans        /10/20/0-/10/20/1/2
 
 # Optimization should not be applied for deletes.
 query TTT
 EXPLAIN DELETE FROM t4 WHERE a = 10 and b = 20
 ----
-delete range  ·      ·
-·             from   t4
-·             spans  /10/20-/10/20/#
+·             distributed  false
+·             vectorized   false
+delete range  ·            ·
+·             from         t4
+·             spans        /10/20-/10/20/#
 
 # Optimization should not be applied for non point lookups.
 query TTT
 EXPLAIN SELECT c FROM t4 WHERE a = 10 and b >= 20 and b < 22
 ----
-render     ·         ·
- └── scan  ·         ·
-·          table     t4@primary
-·          spans     /10/20-/10/21/#
-·          parallel  ·
+·          distributed  false
+·          vectorized   true
+render     ·            ·
+ └── scan  ·            ·
+·          table        t4@primary
+·          spans        /10/20-/10/21/#
+·          parallel     ·
 
 # Optimization should not be applied for partial primary key filter.
 query TTT
 EXPLAIN SELECT c FROM t4 WHERE a = 10
 ----
-render     ·      ·
- └── scan  ·      ·
-·          table  t4@primary
-·          spans  /10-/11
+·          distributed  false
+·          vectorized   true
+render     ·            ·
+ └── scan  ·            ·
+·          table        t4@primary
+·          spans        /10-/11

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
@@ -15,233 +15,278 @@ CREATE TABLE abcd (
 query TTT
 EXPLAIN SELECT * FROM abcd WHERE a >= 20 AND a <= 30
 ----
-scan  ·         ·
-·     table     abcd@primary
-·     spans     /20-/30/#
-·     parallel  ·
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        abcd@primary
+·     spans        /20-/30/#
+·     parallel     ·
 
 # No hint, reverse scan.
 query TTT
 EXPLAIN SELECT * FROM abcd WHERE a >= 20 AND a <= 30 ORDER BY a DESC
 ----
-revscan  ·         ·
-·        table     abcd@primary
-·        spans     /20-/30/#
-·        parallel  ·
+·        distributed  false
+·        vectorized   true
+revscan  ·            ·
+·        table        abcd@primary
+·        spans        /20-/30/#
+·        parallel     ·
 
 # Force primary
 query TTT
 EXPLAIN SELECT * FROM abcd@primary WHERE a >= 20 AND a <= 30
 ----
-scan  ·         ·
-·     table     abcd@primary
-·     spans     /20-/30/#
-·     parallel  ·
-
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        abcd@primary
+·     spans        /20-/30/#
+·     parallel     ·
 
 # Force primary, reverse scan.
 query TTT
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=primary,DESC} WHERE a >= 20 AND a <= 30
 ----
-revscan  ·         ·
-·        table     abcd@primary
-·        spans     /20-/30/#
-·        parallel  ·
+·        distributed  false
+·        vectorized   true
+revscan  ·            ·
+·        table        abcd@primary
+·        spans        /20-/30/#
+·        parallel     ·
 
 # Force primary, allow reverse scan.
 query TTT
 EXPLAIN SELECT * FROM abcd@primary WHERE a >= 20 AND a <= 30 ORDER BY a DESC
 ----
-revscan  ·         ·
-·        table     abcd@primary
-·        spans     /20-/30/#
-·        parallel  ·
+·        distributed  false
+·        vectorized   true
+revscan  ·            ·
+·        table        abcd@primary
+·        spans        /20-/30/#
+·        parallel     ·
 
 # Force primary, forward scan.
 query TTT
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=primary,ASC} WHERE a >= 20 AND a <= 30 ORDER BY a DESC
 ----
-sort       ·         ·
- │         order     -a
- └── scan  ·         ·
-·          table     abcd@primary
-·          spans     /20-/30/#
-·          parallel  ·
+·          distributed  false
+·          vectorized   false
+sort       ·            ·
+ │         order        -a
+ └── scan  ·            ·
+·          table        abcd@primary
+·          spans        /20-/30/#
+·          parallel     ·
 
 # Force index b
 query TTT
 EXPLAIN SELECT * FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
-filter           ·       ·
- │               filter  (a >= 20) AND (a <= 30)
- └── index-join  ·       ·
-      │          table   abcd@primary
-      └── scan   ·       ·
-·                table   abcd@b
-·                spans   ALL
+·                distributed  false
+·                vectorized   true
+filter           ·            ·
+ │               filter       (a >= 20) AND (a <= 30)
+ └── index-join  ·            ·
+      │          table        abcd@primary
+      └── scan   ·            ·
+·                table        abcd@b
+·                spans        ALL
 
 # Force index b, reverse scan.
 query TTT
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b,DESC} WHERE a >= 20 AND a <= 30
 ----
-filter             ·       ·
- │                 filter  (a >= 20) AND (a <= 30)
- └── index-join    ·       ·
-      │            table   abcd@primary
-      └── revscan  ·       ·
-·                  table   abcd@b
-·                  spans   ALL
+·                  distributed  false
+·                  vectorized   true
+filter             ·            ·
+ │                 filter       (a >= 20) AND (a <= 30)
+ └── index-join    ·            ·
+      │            table        abcd@primary
+      └── revscan  ·            ·
+·                  table        abcd@b
+·                  spans        ALL
 
 # Force index b, allowing reverse scan.
 query TTT
 EXPLAIN SELECT * FROM abcd@b ORDER BY b DESC LIMIT 5
 ----
-index-join    ·      ·
- │            table  abcd@primary
- └── revscan  ·      ·
-·             table  abcd@b
-·             spans  ALL
-·             limit  5
+·             distributed  false
+·             vectorized   true
+index-join    ·            ·
+ │            table        abcd@primary
+ └── revscan  ·            ·
+·             table        abcd@b
+·             spans        ALL
+·             limit        5
 
 # Force index b, reverse scan.
 query TTT
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b,DESC} ORDER BY b DESC LIMIT 5
 ----
-index-join    ·      ·
- │            table  abcd@primary
- └── revscan  ·      ·
-·             table  abcd@b
-·             spans  ALL
-·             limit  5
+·             distributed  false
+·             vectorized   true
+index-join    ·            ·
+ │            table        abcd@primary
+ └── revscan  ·            ·
+·             table        abcd@b
+·             spans        ALL
+·             limit        5
 
 
 # Force index b, forward scan.
 query TTT
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b,ASC} ORDER BY b DESC LIMIT 5
 ----
-limit                 ·      ·
- │                    count  5
- └── sort             ·      ·
-      │               order  -b
-      └── index-join  ·      ·
-           │          table  abcd@primary
-           └── scan   ·      ·
-·                     table  abcd@b
-·                     spans  ALL
+·                     distributed  false
+·                     vectorized   true
+limit                 ·            ·
+ │                    count        5
+ └── sort             ·            ·
+      │               order        -b
+      └── index-join  ·            ·
+           │          table        abcd@primary
+           └── scan   ·            ·
+·                     table        abcd@b
+·                     spans        ALL
 
 # Force index cd
 query TTT
 EXPLAIN SELECT * FROM abcd@cd WHERE a >= 20 AND a <= 30
 ----
-filter           ·       ·
- │               filter  (a >= 20) AND (a <= 30)
- └── index-join  ·       ·
-      │          table   abcd@primary
-      └── scan   ·       ·
-·                table   abcd@cd
-·                spans   ALL
+·                distributed  false
+·                vectorized   true
+filter           ·            ·
+ │               filter       (a >= 20) AND (a <= 30)
+ └── index-join  ·            ·
+      │          table        abcd@primary
+      └── scan   ·            ·
+·                table        abcd@cd
+·                spans        ALL
 
 # Force index bcd
 query TTT
 EXPLAIN SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
 ----
-scan  ·       ·
-·     table   abcd@bcd
-·     spans   ALL
-·     filter  (a >= 20) AND (a <= 30)
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        abcd@bcd
+·     spans        ALL
+·     filter       (a >= 20) AND (a <= 30)
 
 # Force index b (covering)
 query TTT
 EXPLAIN SELECT b FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
-render     ·       ·
- └── scan  ·       ·
-·          table   abcd@b
-·          spans   ALL
-·          filter  (a >= 20) AND (a <= 30)
+·          distributed  false
+·          vectorized   true
+render     ·            ·
+ └── scan  ·            ·
+·          table        abcd@b
+·          spans        ALL
+·          filter       (a >= 20) AND (a <= 30)
 
 # Force index b (non-covering due to WHERE clause)
 query TTT
 EXPLAIN SELECT b FROM abcd@b WHERE c >= 20 AND c <= 30
 ----
-render                ·       ·
- └── filter           ·       ·
-      │               filter  (c >= 20) AND (c <= 30)
-      └── index-join  ·       ·
-           │          table   abcd@primary
-           └── scan   ·       ·
-·                     table   abcd@b
-·                     spans   ALL
+·                     distributed  false
+·                     vectorized   true
+render                ·            ·
+ └── filter           ·            ·
+      │               filter       (c >= 20) AND (c <= 30)
+      └── index-join  ·            ·
+           │          table        abcd@primary
+           └── scan   ·            ·
+·                     table        abcd@b
+·                     spans        ALL
 
 # No hint, should be using index cd
 query TTT
 EXPLAIN SELECT c, d FROM abcd WHERE c >= 20 AND c < 40
 ----
-scan  ·      ·
-·     table  abcd@cd
-·     spans  /20-/40
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        abcd@cd
+·     spans        /20-/40
 
 # Force primary index
 query TTT
 EXPLAIN SELECT c, d FROM abcd@primary WHERE c >= 20 AND c < 40
 ----
-scan  ·       ·
-·     table   abcd@primary
-·     spans   ALL
-·     filter  (c >= 20) AND (c < 40)
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        abcd@primary
+·     spans        ALL
+·     filter       (c >= 20) AND (c < 40)
 
 # Force index b
 query TTT
 EXPLAIN SELECT c, d FROM abcd@b WHERE c >= 20 AND c < 40
 ----
-filter           ·       ·
- │               filter  (c >= 20) AND (c < 40)
- └── index-join  ·       ·
-      │          table   abcd@primary
-      └── scan   ·       ·
-·                table   abcd@b
-·                spans   ALL
+·                distributed  false
+·                vectorized   true
+filter           ·            ·
+ │               filter       (c >= 20) AND (c < 40)
+ └── index-join  ·            ·
+      │          table        abcd@primary
+      └── scan   ·            ·
+·                table        abcd@b
+·                spans        ALL
 
 query TTT
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b} WHERE a >= 20 AND a <= 30
 ----
-filter           ·       ·
- │               filter  (a >= 20) AND (a <= 30)
- └── index-join  ·       ·
-      │          table   abcd@primary
-      └── scan   ·       ·
-·                table   abcd@b
-·                spans   ALL
+·                distributed  false
+·                vectorized   true
+filter           ·            ·
+ │               filter       (a >= 20) AND (a <= 30)
+ └── index-join  ·            ·
+      │          table        abcd@primary
+      └── scan   ·            ·
+·                table        abcd@b
+·                spans        ALL
 
 query TTT
 EXPLAIN SELECT b, c, d FROM abcd WHERE c = 10
 ----
-index-join  ·      ·
- │          table  abcd@primary
- └── scan   ·      ·
-·           table  abcd@cd
-·           spans  /10-/11
+·           distributed  false
+·           vectorized   true
+index-join  ·            ·
+ │          table        abcd@primary
+ └── scan   ·            ·
+·           table        abcd@cd
+·           spans        /10-/11
 
 query TTT
 EXPLAIN SELECT b, c, d FROM abcd@{NO_INDEX_JOIN} WHERE c = 10
 ----
-scan  ·       ·
-·     table   abcd@primary
-·     spans   ALL
-·     filter  c = 10
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        abcd@primary
+·     spans        ALL
+·     filter       c = 10
 
 query TTT
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=bcd} WHERE c = 10
 ----
-scan  ·       ·
-·     table   abcd@bcd
-·     spans   ALL
-·     filter  c = 10
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        abcd@bcd
+·     spans        ALL
+·     filter       c = 10
 
 query TTT
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=primary} WHERE c = 10
 ----
-scan  ·       ·
-·     table   abcd@primary
-·     spans   ALL
-·     filter  c = 10
+·     distributed  false
+·     vectorized   true
+scan  ·            ·
+·     table        abcd@primary
+·     spans        ALL
+·     filter       c = 10

--- a/pkg/sql/opt/exec/execbuilder/testdata/spool
+++ b/pkg/sql/opt/exec/execbuilder/testdata/spool
@@ -11,6 +11,8 @@ query TTT
 EXPLAIN WITH a AS (INSERT INTO t SELECT * FROM t2 RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
+·                                   distributed   false
+·                                   vectorized    false
 root                                ·             ·
  ├── limit                          ·             ·
  │    │                             count         1
@@ -35,6 +37,8 @@ query TTT
 EXPLAIN WITH a AS (DELETE FROM t RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
+·                                   distributed   false
+·                                   vectorized    false
 root                                ·             ·
  ├── limit                          ·             ·
  │    │                             count         1
@@ -60,6 +64,8 @@ query TTT
 EXPLAIN WITH a AS (UPDATE t SET x = x + 1 RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
+·                                        distributed   false
+·                                        vectorized    false
 root                                     ·             ·
  ├── limit                               ·             ·
  │    │                                  count         1
@@ -86,6 +92,8 @@ query TTT
 EXPLAIN WITH a AS (UPSERT INTO t VALUES (2), (3) RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
+·                                     distributed   false
+·                                     vectorized    false
 root                                  ·             ·
  ├── limit                            ·             ·
  │    │                               count         1
@@ -109,68 +117,78 @@ root                                  ·             ·
 query TTT
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x] LIMIT 1
 ----
-limit                     ·         ·
- │                        count     1
- └── spool                ·         ·
-      │                   limit     1
-      └── run             ·         ·
-           └── insert     ·         ·
-                │         into      t(x)
-                │         strategy  inserter
-                └── scan  ·         ·
-·                         table     t2@primary
-·                         spans     ALL
+·                         distributed  false
+·                         vectorized   false
+limit                     ·            ·
+ │                        count        1
+ └── spool                ·            ·
+      │                   limit        1
+      └── run             ·            ·
+           └── insert     ·            ·
+                │         into         t(x)
+                │         strategy     inserter
+                └── scan  ·            ·
+·                         table        t2@primary
+·                         spans        ALL
 
 query TTT
 EXPLAIN SELECT * FROM [DELETE FROM t RETURNING x] LIMIT 1
 ----
-limit                     ·         ·
- │                        count     1
- └── spool                ·         ·
-      │                   limit     1
-      └── run             ·         ·
-           └── delete     ·         ·
-                │         from      t
-                │         strategy  deleter
-                └── scan  ·         ·
-·                         table     t@primary
-·                         spans     ALL
+·                         distributed  false
+·                         vectorized   false
+limit                     ·            ·
+ │                        count        1
+ └── spool                ·            ·
+      │                   limit        1
+      └── run             ·            ·
+           └── delete     ·            ·
+                │         from         t
+                │         strategy     deleter
+                └── scan  ·            ·
+·                         table        t@primary
+·                         spans        ALL
 
 query TTT
 EXPLAIN SELECT * FROM [UPDATE t SET x = x + 1 RETURNING x] LIMIT 1
 ----
-limit                          ·         ·
- │                             count     1
- └── spool                     ·         ·
-      │                        limit     1
-      └── run                  ·         ·
-           └── update          ·         ·
-                │              table     t
-                │              set       x
-                │              strategy  updater
-                └── render     ·         ·
-                     └── scan  ·         ·
-·                              table     t@primary
-·                              spans     ALL
+·                              distributed  false
+·                              vectorized   false
+limit                          ·            ·
+ │                             count        1
+ └── spool                     ·            ·
+      │                        limit        1
+      └── run                  ·            ·
+           └── update          ·            ·
+                │              table        t
+                │              set          x
+                │              strategy     updater
+                └── render     ·            ·
+                     └── scan  ·            ·
+·                              table        t@primary
+·                              spans        ALL
 
 query TTT
 EXPLAIN SELECT * FROM [UPSERT INTO t VALUES (2), (3) RETURNING x] LIMIT 1
 ----
-limit                       ·         ·
- │                          count     1
- └── spool                  ·         ·
-      │                     limit     1
-      └── run               ·         ·
-           └── upsert       ·         ·
-                │           into      t(x)
-                │           strategy  opt upserter
-                └── values  ·         ·
-·                           size      1 column, 2 rows
+·                           distributed  false
+·                           vectorized   false
+limit                       ·            ·
+ │                          count        1
+ └── spool                  ·            ·
+      │                     limit        1
+      └── run               ·            ·
+           └── upsert       ·            ·
+                │           into         t(x)
+                │           strategy     opt upserter
+                └── values  ·            ·
+·                           size         1 column, 2 rows
 
 # Check that a spool is also inserted for other processings than LIMIT.
 query TTT
 EXPLAIN SELECT count(*) FROM [INSERT INTO t SELECT * FROM t2 RETURNING x]
 ----
+·                              distributed  false
+·                              vectorized   false
 group                          ·            ·
  │                             aggregate 0  count_rows()
  │                             scalar       ·
@@ -187,19 +205,21 @@ group                          ·            ·
 query TTT
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x], t
 ----
-hash-join                 ·         ·
- │                        type      cross
- ├── spool                ·         ·
- │    └── run             ·         ·
- │         └── insert     ·         ·
- │              │         into      t(x)
- │              │         strategy  inserter
- │              └── scan  ·         ·
- │                        table     t2@primary
- │                        spans     ALL
- └── scan                 ·         ·
-·                         table     t@primary
-·                         spans     ALL
+·                         distributed  false
+·                         vectorized   false
+hash-join                 ·            ·
+ │                        type         cross
+ ├── spool                ·            ·
+ │    └── run             ·            ·
+ │         └── insert     ·            ·
+ │              │         into         t(x)
+ │              │         strategy     inserter
+ │              └── scan  ·            ·
+ │                        table        t2@primary
+ │                        spans        ALL
+ └── scan                 ·            ·
+·                         table        t@primary
+·                         spans        ALL
 
 # Check that if a spool is already added at some level, then it is not added
 # again at levels below.
@@ -209,6 +229,8 @@ EXPLAIN WITH a AS (INSERT INTO t SELECT * FROM t2 RETURNING x),
              b AS (INSERT INTO t SELECT x+1 FROM a RETURNING x)
         SELECT * FROM b LIMIT 1
 ----
+·                                                    distributed   false
+·                                                    vectorized    false
 root                                                 ·             ·
  ├── limit                                           ·             ·
  │    │                                              count         1
@@ -247,63 +269,71 @@ root                                                 ·             ·
 query TTT
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x]
 ----
-run             ·         ·
- └── insert     ·         ·
-      │         into      t(x)
-      │         strategy  inserter
-      └── scan  ·         ·
-·               table     t2@primary
-·               spans     ALL
+·               distributed  false
+·               vectorized   false
+run             ·            ·
+ └── insert     ·            ·
+      │         into         t(x)
+      │         strategy     inserter
+      └── scan  ·            ·
+·               table        t2@primary
+·               spans        ALL
 
 # Check that no spool is used for a top-level INSERT, but
 # sub-INSERTs still get a spool.
 query TTT
 EXPLAIN INSERT INTO t SELECT x+1 FROM [INSERT INTO t SELECT * FROM t2 RETURNING x]
 ----
-count                               ·         ·
- └── insert                         ·         ·
-      │                             into      t(x)
-      │                             strategy  inserter
-      └── spool                     ·         ·
-           └── render               ·         ·
-                └── run             ·         ·
-                     └── insert     ·         ·
-                          │         into      t(x)
-                          │         strategy  inserter
-                          └── scan  ·         ·
-·                                   table     t2@primary
-·                                   spans     ALL
+·                                   distributed  false
+·                                   vectorized   false
+count                               ·            ·
+ └── insert                         ·            ·
+      │                             into         t(x)
+      │                             strategy     inserter
+      └── spool                     ·            ·
+           └── render               ·            ·
+                └── run             ·            ·
+                     └── insert     ·            ·
+                          │         into         t(x)
+                          │         strategy     inserter
+                          └── scan  ·            ·
+·                                   table        t2@primary
+·                                   spans        ALL
 
 # Check that simple computations using RETURNING get their spool pulled up.
 query TTT
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x+10] WHERE @1 < 3 LIMIT 10
 ----
-render                              ·         ·
- └── limit                          ·         ·
-      │                             count     10
-      └── spool                     ·         ·
-           │                        limit     10
-           └── filter               ·         ·
-                │                   filter    x < -7
-                └── run             ·         ·
-                     └── insert     ·         ·
-                          │         into      t(x)
-                          │         strategy  inserter
-                          └── scan  ·         ·
-·                                   table     t2@primary
-·                                   spans     ALL
+·                                   distributed  false
+·                                   vectorized   false
+render                              ·            ·
+ └── limit                          ·            ·
+      │                             count        10
+      └── spool                     ·            ·
+           │                        limit        10
+           └── filter               ·            ·
+                │                   filter       x < -7
+                └── run             ·            ·
+                     └── insert     ·            ·
+                          │         into         t(x)
+                          │         strategy     inserter
+                          └── scan  ·            ·
+·                                   table        t2@primary
+·                                   spans        ALL
 
 # Check that a pulled up spool gets elided at the top level.
 query TTT
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x+10] WHERE @1 < 3
 ----
-render                    ·         ·
- └── filter               ·         ·
-      │                   filter    x < -7
-      └── run             ·         ·
-           └── insert     ·         ·
-                │         into      t(x)
-                │         strategy  inserter
-                └── scan  ·         ·
-·                         table     t2@primary
-·                         spans     ALL
+·                         distributed  false
+·                         vectorized   false
+render                    ·            ·
+ └── filter               ·            ·
+      │                   filter       x < -7
+      └── run             ·            ·
+           └── insert     ·            ·
+                │         into         t(x)
+                │         strategy     inserter
+                └── scan  ·            ·
+·                         table        t2@primary
+·                         spans        ALL

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -5,30 +5,38 @@ subtest generate_series
 query TTT
 EXPLAIN SELECT * FROM generate_series(1, 3)
 ----
-project set    ·  ·
- └── emptyrow  ·  ·
+·              distributed  false
+·              vectorized   false
+project set    ·            ·
+ └── emptyrow  ·            ·
 
 query TTT
 EXPLAIN SELECT * FROM generate_series(1, 2), generate_series(1, 2)
 ----
-hash-join           ·     ·
- │                  type  cross
- ├── project set    ·     ·
- │    └── emptyrow  ·     ·
- └── project set    ·     ·
-      └── emptyrow  ·     ·
+·                   distributed  false
+·                   vectorized   false
+hash-join           ·            ·
+ │                  type         cross
+ ├── project set    ·            ·
+ │    └── emptyrow  ·            ·
+ └── project set    ·            ·
+      └── emptyrow  ·            ·
 
 query TTT
 EXPLAIN SELECT * FROM ROWS FROM (cos(1))
 ----
-project set    ·  ·
- └── emptyrow  ·  ·
+·              distributed  false
+·              vectorized   false
+project set    ·            ·
+ └── emptyrow  ·            ·
 
 query TTT
 EXPLAIN SELECT generate_series(1, 3)
 ----
-project set    ·  ·
- └── emptyrow  ·  ·
+·              distributed  false
+·              vectorized   false
+project set    ·            ·
+ └── emptyrow  ·            ·
 
 subtest multiple_SRFs
 # See #20511
@@ -36,8 +44,10 @@ subtest multiple_SRFs
 query TTT
 EXPLAIN SELECT generate_series(1, 2), generate_series(1, 2)
 ----
-project set    ·  ·
- └── emptyrow  ·  ·
+·              distributed  false
+·              vectorized   false
+project set    ·            ·
+ └── emptyrow  ·            ·
 
 statement ok
 CREATE TABLE t (a string)
@@ -48,25 +58,27 @@ CREATE TABLE u (b string)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT t.*, u.*, generate_series(1,2), generate_series(3, 4) FROM t, u
 ----
-render                        ·         ·                      (a, b, generate_series, generate_series)  ·
- │                            render 0  a                      ·                                         ·
- │                            render 1  b                      ·                                         ·
- │                            render 2  generate_series        ·                                         ·
- │                            render 3  generate_series        ·                                         ·
- └── hash-join                ·         ·                      (b, generate_series, generate_series, a)  ·
-      │                       type      cross                  ·                                         ·
-      ├── hash-join           ·         ·                      (b, generate_series, generate_series)     ·
-      │    │                  type      cross                  ·                                         ·
-      │    ├── scan           ·         ·                      (b)                                       ·
-      │    │                  table     u@primary              ·                                         ·
-      │    │                  spans     ALL                    ·                                         ·
-      │    └── project set    ·         ·                      (generate_series, generate_series)        ·
-      │         │             render 0  generate_series(1, 2)  ·                                         ·
-      │         │             render 1  generate_series(3, 4)  ·                                         ·
-      │         └── emptyrow  ·         ·                      ()                                        ·
-      └── scan                ·         ·                      (a)                                       ·
-·                             table     t@primary              ·                                         ·
-·                             spans     ALL                    ·                                         ·
+·                             distributed  false                  ·                                         ·
+·                             vectorized   false                  ·                                         ·
+render                        ·            ·                      (a, b, generate_series, generate_series)  ·
+ │                            render 0     a                      ·                                         ·
+ │                            render 1     b                      ·                                         ·
+ │                            render 2     generate_series        ·                                         ·
+ │                            render 3     generate_series        ·                                         ·
+ └── hash-join                ·            ·                      (b, generate_series, generate_series, a)  ·
+      │                       type         cross                  ·                                         ·
+      ├── hash-join           ·            ·                      (b, generate_series, generate_series)     ·
+      │    │                  type         cross                  ·                                         ·
+      │    ├── scan           ·            ·                      (b)                                       ·
+      │    │                  table        u@primary              ·                                         ·
+      │    │                  spans        ALL                    ·                                         ·
+      │    └── project set    ·            ·                      (generate_series, generate_series)        ·
+      │         │             render 0     generate_series(1, 2)  ·                                         ·
+      │         │             render 1     generate_series(3, 4)  ·                                         ·
+      │         └── emptyrow  ·            ·                      ()                                        ·
+      └── scan                ·            ·                      (a)                                       ·
+·                             table        t@primary              ·                                         ·
+·                             spans        ALL                    ·                                         ·
 
 subtest correlated_SRFs
 
@@ -76,13 +88,15 @@ CREATE TABLE data (a INT PRIMARY KEY)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a, generate_series(a, a + 1) FROM data ORDER BY 1, 2
 ----
-sort              ·         ·                            (a, generate_series)  +a,+generate_series
- │                order     +a,+generate_series          ·                     ·
- └── project set  ·         ·                            (a, generate_series)  ·
-      │           render 0  generate_series(@1, @1 + 1)  ·                     ·
-      └── scan    ·         ·                            (a)                   ·
-·                 table     data@primary                 ·                     ·
-·                 spans     ALL                          ·                     ·
+·                 distributed  false                        ·                     ·
+·                 vectorized   false                        ·                     ·
+sort              ·            ·                            (a, generate_series)  +a,+generate_series
+ │                order        +a,+generate_series          ·                     ·
+ └── project set  ·            ·                            (a, generate_series)  ·
+      │           render 0     generate_series(@1, @1 + 1)  ·                     ·
+      └── scan    ·            ·                            (a)                   ·
+·                 table        data@primary                 ·                     ·
+·                 spans        ALL                          ·                     ·
 
 statement ok
 CREATE TABLE xy (x INT PRIMARY KEY, y INT)
@@ -94,6 +108,8 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT x, y, z, information_schema._pg_expandarray(ARRAY[x, y, z])
   FROM xy NATURAL JOIN xz WHERE y < z ORDER BY 1, 2, 3
 ----
+·                               distributed         false                                                  ·                                                ·
+·                               vectorized          false                                                  ·                                                ·
 render                          ·                   ·                                                      (x, y, z, "information_schema._pg_expandarray")  ·
  │                              render 0            x                                                      ·                                                ·
  │                              render 1            y                                                      ·                                                ·
@@ -125,26 +141,30 @@ render                          ·                   ·                         
 query TTTTT
 EXPLAIN (VERBOSE) SELECT generate_series(x, z) FROM xz WHERE z < ANY(SELECT generate_series(x, y) FROM xy)
 ----
-render                      ·         ·                        (generate_series)        ·
- │                          render 0  generate_series          ·                        ·
- └── project set            ·         ·                        (x, z, generate_series)  ·
-      │                     render 0  generate_series(@1, @2)  ·                        ·
-      └── hash-join         ·         ·                        (x, z)                   ·
-           │                type      semi                     ·                        ·
-           │                pred      z < generate_series      ·                        ·
-           ├── scan         ·         ·                        (x, z)                   ·
-           │                table     xz@primary               ·                        ·
-           │                spans     ALL                      ·                        ·
-           └── project set  ·         ·                        (x, y, generate_series)  ·
-                │           render 0  generate_series(@1, @2)  ·                        ·
-                └── scan    ·         ·                        (x, y)                   ·
-·                           table     xy@primary               ·                        ·
-·                           spans     ALL                      ·                        ·
+·                           distributed  false                    ·                        ·
+·                           vectorized   false                    ·                        ·
+render                      ·            ·                        (generate_series)        ·
+ │                          render 0     generate_series          ·                        ·
+ └── project set            ·            ·                        (x, z, generate_series)  ·
+      │                     render 0     generate_series(@1, @2)  ·                        ·
+      └── hash-join         ·            ·                        (x, z)                   ·
+           │                type         semi                     ·                        ·
+           │                pred         z < generate_series      ·                        ·
+           ├── scan         ·            ·                        (x, z)                   ·
+           │                table        xz@primary               ·                        ·
+           │                spans        ALL                      ·                        ·
+           └── project set  ·            ·                        (x, y, generate_series)  ·
+                │           render 0     generate_series(@1, @2)  ·                        ·
+                └── scan    ·            ·                        (x, y)                   ·
+·                           table        xy@primary               ·                        ·
+·                           spans        ALL                      ·                        ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT generate_subscripts(ARRAY[0, x, 1, 2]), generate_series(x, y), unnest(ARRAY[0, x, y, z]), y, z
   FROM xy NATURAL LEFT OUTER JOIN xz
 ----
+·                     distributed         false                                    ·                                                           ·
+·                     vectorized          false                                    ·                                                           ·
 render                ·                   ·                                        (generate_subscripts, generate_series, unnest, y, z)        ·
  │                    render 0            generate_subscripts                      ·                                                           ·
  │                    render 1            generate_series                          ·                                                           ·
@@ -171,6 +191,8 @@ render                ·                   ·                                   
 query TTTTT
 EXPLAIN (VERBOSE) SELECT generate_series((SELECT unnest(ARRAY[x, y]) FROM xy), z) FROM xz
 ----
+·                                distributed   false                                 ·                     ·
+·                                vectorized    false                                 ·                     ·
 root                             ·             ·                                     (generate_series)     ·
  ├── render                      ·             ·                                     (generate_series)     ·
  │    │                          render 0      generate_series                       ·                     ·
@@ -207,24 +229,28 @@ EXPLAIN (VERBOSE) SELECT
 FROM
   groups g
 ----
-render                ·         ·                         (group_name, jsonb_array_elements)        ·
- │                    render 0  data->>'name'             ·                                         ·
- │                    render 1  jsonb_array_elements      ·                                         ·
- └── project set      ·         ·                         (data, "?column?", jsonb_array_elements)  ·
-      │               render 0  jsonb_array_elements(@2)  ·                                         ·
-      └── apply-join  ·         ·                         (data, "?column?")                        ·
-           │          type      left outer                ·                                         ·
-           └── scan   ·         ·                         (data)                                    ·
-·                     table     groups@primary            ·                                         ·
-·                     spans     ALL                       ·                                         ·
+·                     distributed  false                     ·                                         ·
+·                     vectorized   false                     ·                                         ·
+render                ·            ·                         (group_name, jsonb_array_elements)        ·
+ │                    render 0     data->>'name'             ·                                         ·
+ │                    render 1     jsonb_array_elements      ·                                         ·
+ └── project set      ·            ·                         (data, "?column?", jsonb_array_elements)  ·
+      │               render 0     jsonb_array_elements(@2)  ·                                         ·
+      └── apply-join  ·            ·                         (data, "?column?")                        ·
+           │          type         left outer                ·                                         ·
+           └── scan   ·            ·                         (data)                                    ·
+·                     table        groups@primary            ·                                         ·
+·                     spans        ALL                       ·                                         ·
 
 # Regression test for #32162.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM ROWS FROM (IF(length('abc') = length('def'), 1, 0))
 ----
-project set    ·         ·  ("if")  ·
- │             render 0  1  ·       ·
- └── emptyrow  ·         ·  ()      ·
+·              distributed  false  ·       ·
+·              vectorized   false  ·       ·
+project set    ·            ·      ("if")  ·
+ │             render 0     1      ·       ·
+ └── emptyrow  ·            ·      ()      ·
 
 statement ok
 CREATE TABLE articles (
@@ -248,6 +274,8 @@ ORDER BY a0.created_at
    LIMIT 10
   OFFSET 0;
 ----
+·                                     distributed  false                      ·                                                                                        ·
+·                                     vectorized   false                      ·                                                                                        ·
 limit                                 ·            ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)          +created_at
  │                                    count        10                         ·                                                                                        ·
  └── sort                             ·            ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)          +created_at
@@ -289,6 +317,8 @@ EXPLAIN (VERBOSE)
     FROM
         (SELECT a FROM ((SELECT 1 AS a, 1) EXCEPT ALL (SELECT 0, 0)))
 ----
+·                           distributed    false                            ·                         ·
+·                           vectorized     false                            ·                         ·
 render                      ·              ·                                (generate_series)         ·
  │                          render 0       generate_series                  ·                         ·
  └── project set            ·              ·                                (a, a, generate_series)   ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/stats
@@ -18,10 +18,12 @@ set enable_zigzag_join = false
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uv WHERE u = 1 AND v = 1
 ----
-scan  ·       ·            (u, v)  ·
-·     table   uv@uv_v_idx  ·       ·
-·     spans   /1-/2        ·       ·
-·     filter  u = 1        ·       ·
+·     distributed  true         ·       ·
+·     vectorized   true         ·       ·
+scan  ·            ·            (u, v)  ·
+·     table        uv@uv_v_idx  ·       ·
+·     spans        /1-/2        ·       ·
+·     filter       u = 1        ·       ·
 
 # Verify that injecting different statistics changes the plan.
 statement ok
@@ -43,10 +45,12 @@ ALTER TABLE uv INJECT STATISTICS '[
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uv WHERE u = 1 AND v = 1
 ----
-scan  ·       ·            (u, v)  ·
-·     table   uv@uv_u_idx  ·       ·
-·     spans   /1-/2        ·       ·
-·     filter  v = 1        ·       ·
+·     distributed  true         ·       ·
+·     vectorized   true         ·       ·
+scan  ·            ·            (u, v)  ·
+·     table        uv@uv_u_idx  ·       ·
+·     spans        /1-/2        ·       ·
+·     filter       v = 1        ·       ·
 
 # Verify that injecting different statistics with null counts
 # changes the plan.
@@ -71,10 +75,12 @@ ALTER TABLE uv INJECT STATISTICS '[
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uv WHERE u = 1 AND v = 1
 ----
-scan  ·       ·            (u, v)  ·
-·     table   uv@uv_u_idx  ·       ·
-·     spans   /1-/2        ·       ·
-·     filter  v = 1        ·       ·
+·     distributed  true         ·       ·
+·     vectorized   true         ·       ·
+scan  ·            ·            (u, v)  ·
+·     table        uv@uv_u_idx  ·       ·
+·     spans        /1-/2        ·       ·
+·     filter       v = 1        ·       ·
 
 statement ok
 ALTER TABLE uv INJECT STATISTICS '[
@@ -97,7 +103,9 @@ ALTER TABLE uv INJECT STATISTICS '[
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uv WHERE u = 1 AND v = 1
 ----
-scan  ·       ·            (u, v)  ·
-·     table   uv@uv_v_idx  ·       ·
-·     spans   /1-/2        ·       ·
-·     filter  u = 1        ·       ·
+·     distributed  true         ·       ·
+·     vectorized   true         ·       ·
+scan  ·            ·            (u, v)  ·
+·     table        uv@uv_v_idx  ·       ·
+·     spans        /1-/2        ·       ·
+·     filter       u = 1        ·       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -9,6 +9,8 @@ CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT)
 query TTT
 EXPLAIN ALTER TABLE abc SPLIT AT VALUES ((SELECT 42))
 ----
+·                 distributed   false
+·                 vectorized    false
 root              ·             ·
  ├── split        ·             ·
  │    └── values  ·             ·
@@ -26,6 +28,8 @@ ALTER TABLE abc SPLIT AT VALUES ((SELECT 1))
 query TTT
 EXPLAIN SELECT EXISTS (SELECT a FROM abc)
 ----
+·               distributed   false
+·               vectorized    false
 root            ·             ·
  ├── values     ·             ·
  │              size          1 column, 1 row
@@ -41,6 +45,8 @@ root            ·             ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc WHERE a = (SELECT max(a) FROM abc WHERE EXISTS(SELECT * FROM abc WHERE c=a+3))
 ----
+·                    distributed   false                                                                        ·          ·
+·                    vectorized    false                                                                        ·          ·
 root                 ·             ·                                                                            (a, b, c)  ·
  ├── scan            ·             ·                                                                            (a, b, c)  ·
  │                   table         abc@primary                                                                  ·          ·
@@ -72,6 +78,8 @@ root                 ·             ·                                          
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM abc WHERE a IN (SELECT a FROM abc)
 ----
+·           distributed         false        ·    ·
+·           vectorized          true         ·    ·
 merge-join  ·                   ·            (a)  ·
  │          type                semi         ·    ·
  │          equality            (a) = (a)    ·    ·
@@ -88,15 +96,19 @@ merge-join  ·                   ·            (a)  ·
 query TTT
 EXPLAIN SELECT * FROM (SELECT * FROM (VALUES (1, 8, 8), (3, 1, 1), (2, 4, 4)) AS moo (moo1, moo2, moo3) ORDER BY moo2) as foo (foo1) ORDER BY foo1
 ----
-sort         ·      ·
- │           order  +foo1
- └── values  ·      ·
-·            size   3 columns, 3 rows
+·            distributed  false
+·            vectorized   false
+sort         ·            ·
+ │           order        +foo1
+ └── values  ·            ·
+·            size         3 columns, 3 rows
 
 # the subquery's plan must be visible in EXPLAIN
 query TTT
 EXPLAIN VALUES (1), ((SELECT 2))
 ----
+·                 distributed   false
+·                 vectorized    false
 root              ·             ·
  ├── values       ·             ·
  │                size          1 column, 2 rows
@@ -125,6 +137,8 @@ WHERE
     OR (col4 IN (SELECT col1 FROM tab4 WHERE col1 > 8.27))
     AND (col3 <= 5 AND (col3 BETWEEN 7 AND 9))
 ----
+·               distributed   false                                                                                                       ·                   ·
+·               vectorized    false                                                                                                       ·                   ·
 root            ·             ·                                                                                                           (col0)              ·
  ├── render     ·             ·                                                                                                           (col0)              ·
  │    │         render 0      col0                                                                                                        ·                   ·
@@ -151,6 +165,8 @@ CREATE TABLE b (x INT PRIMARY KEY, z INT);
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE EXISTS(SELECT * FROM b WHERE a.x=b.x)
 ----
+·           distributed         false      ·       ·
+·           vectorized          true       ·       ·
 merge-join  ·                   ·          (x, y)  ·
  │          type                semi       ·       ·
  │          equality            (x) = (x)  ·       ·
@@ -167,6 +183,8 @@ merge-join  ·                   ·          (x, y)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE EXISTS(SELECT * FROM b WHERE b.x-1 = a.x)
 ----
+·               distributed        false            ·          ·
+·               vectorized         false            ·          ·
 hash-join       ·                  ·                (x, y)     ·
  │              type               semi             ·          ·
  │              equality           (x) = (column5)  ·          ·
@@ -183,6 +201,8 @@ hash-join       ·                  ·                (x, y)     ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM b WHERE b.x = a.x)
 ----
+·           distributed         false      ·       ·
+·           vectorized          true       ·       ·
 merge-join  ·                   ·          (x, y)  ·
  │          type                anti       ·       ·
  │          equality            (x) = (x)  ·       ·
@@ -199,6 +219,8 @@ merge-join  ·                   ·          (x, y)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM b WHERE NOT EXISTS(SELECT * FROM a WHERE x-1 = b.x)
 ----
+·               distributed        false            ·          ·
+·               vectorized         false            ·          ·
 hash-join       ·                  ·                (x, z)     ·
  │              type               anti             ·          ·
  │              equality           (x) = (column5)  ·          ·
@@ -215,6 +237,8 @@ hash-join       ·                  ·                (x, z)     ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ARRAY(SELECT x FROM b)
 ----
+·               distributed    false              ·          ·
+·               vectorized     false              ·          ·
 root            ·              ·                  ("array")  ·
  ├── values     ·              ·                  ("array")  ·
  │              size           1 column, 1 row    ·          ·
@@ -231,12 +255,14 @@ root            ·              ·                  ("array")  ·
 query TTTTT
 EXPLAIN(verbose) SELECT * FROM abc WHERE EXISTS(SELECT * FROM (VALUES (a), (b)) WHERE column1=a)
 ----
-apply-join  ·      ·            (a, b, c)  ·
- │          type   semi         ·          ·
- │          pred   column1 = a  ·          ·
- └── scan   ·      ·            (a, b, c)  ·
-·           table  abc@primary  ·          ·
-·           spans  ALL          ·          ·
+·           distributed  false        ·          ·
+·           vectorized   false        ·          ·
+apply-join  ·            ·            (a, b, c)  ·
+ │          type         semi         ·          ·
+ │          pred         column1 = a  ·          ·
+ └── scan   ·            ·            (a, b, c)  ·
+·           table        abc@primary  ·          ·
+·           spans        ALL          ·          ·
 
 # Case where the EXISTS subquery still has outer columns in the subquery
 # (regression test for #28816).

--- a/pkg/sql/opt/exec/execbuilder/testdata/tuple
+++ b/pkg/sql/opt/exec/execbuilder/testdata/tuple
@@ -11,54 +11,68 @@ CREATE TABLE uvw (
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) >= (1, 2, 3) ORDER BY u, v, w
 ----
-scan  ·      ·                  (u, v, w)  +u,+v,+w
-·     table  uvw@uvw_u_v_w_idx  ·          ·
-·     spans  /1/2/3-            ·          ·
+·     distributed  false              ·          ·
+·     vectorized   true               ·          ·
+scan  ·            ·                  (u, v, w)  +u,+v,+w
+·     table        uvw@uvw_u_v_w_idx  ·          ·
+·     spans        /1/2/3-            ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) > (2, 1, 1) ORDER BY u, v, w
 ----
-scan  ·      ·                  (u, v, w)  +u,+v,+w
-·     table  uvw@uvw_u_v_w_idx  ·          ·
-·     spans  /2/1/2-            ·          ·
+·     distributed  false              ·          ·
+·     vectorized   true               ·          ·
+scan  ·            ·                  (u, v, w)  +u,+v,+w
+·     table        uvw@uvw_u_v_w_idx  ·          ·
+·     spans        /2/1/2-            ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) <= (2, 3, 1) ORDER BY u, v, w
 ----
-scan  ·       ·                       (u, v, w)  +u,+v,+w
-·     table   uvw@uvw_u_v_w_idx       ·          ·
-·     spans   /!NULL-/2/3/2           ·          ·
-·     filter  (u, v, w) <= (2, 3, 1)  ·          ·
+·     distributed  false                   ·          ·
+·     vectorized   false                   ·          ·
+scan  ·            ·                       (u, v, w)  +u,+v,+w
+·     table        uvw@uvw_u_v_w_idx       ·          ·
+·     spans        /!NULL-/2/3/2           ·          ·
+·     filter       (u, v, w) <= (2, 3, 1)  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) < (2, 2, 2) ORDER BY u, v, w
 ----
-scan  ·       ·                      (u, v, w)  +u,+v,+w
-·     table   uvw@uvw_u_v_w_idx      ·          ·
-·     spans   /!NULL-/2/2/2          ·          ·
-·     filter  (u, v, w) < (2, 2, 2)  ·          ·
+·     distributed  false                  ·          ·
+·     vectorized   false                  ·          ·
+scan  ·            ·                      (u, v, w)  +u,+v,+w
+·     table        uvw@uvw_u_v_w_idx      ·          ·
+·     spans        /!NULL-/2/2/2          ·          ·
+·     filter       (u, v, w) < (2, 2, 2)  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) != (1, 2, 3) ORDER BY u, v, w
 ----
-scan  ·       ·                       (u, v, w)  +u,+v,+w
-·     table   uvw@uvw_u_v_w_idx       ·          ·
-·     spans   -/1/2/3 /1/2/4-         ·          ·
-·     filter  (u, v, w) != (1, 2, 3)  ·          ·
+·     distributed  false                   ·          ·
+·     vectorized   false                   ·          ·
+scan  ·            ·                       (u, v, w)  +u,+v,+w
+·     table        uvw@uvw_u_v_w_idx       ·          ·
+·     spans        -/1/2/3 /1/2/4-         ·          ·
+·     filter       (u, v, w) != (1, 2, 3)  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) >= (1, NULL, 3) ORDER BY u, v, w
 ----
-scan  ·      ·                  (u, v, w)  +u,+v,+w
-·     table  uvw@uvw_u_v_w_idx  ·          ·
-·     spans  /2-                ·          ·
+·     distributed  false              ·          ·
+·     vectorized   true               ·          ·
+scan  ·            ·                  (u, v, w)  +u,+v,+w
+·     table        uvw@uvw_u_v_w_idx  ·          ·
+·     spans        /2-                ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) < (2, NULL, 3) ORDER BY u, v, w
 ----
-scan  ·      ·                  (u, v, w)  +u,+v,+w
-·     table  uvw@uvw_u_v_w_idx  ·          ·
-·     spans  /!NULL-/2          ·          ·
+·     distributed  false              ·          ·
+·     vectorized   true               ·          ·
+scan  ·            ·                  (u, v, w)  +u,+v,+w
+·     table        uvw@uvw_u_v_w_idx  ·          ·
+·     spans        /!NULL-/2          ·          ·
 
 statement ok
 DROP TABLE uvw
@@ -70,13 +84,15 @@ CREATE TABLE abc (a INT, b INT, c INT, INDEX(a, b))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc WHERE (a, b, c) > (1, 2, 3) AND (a,b,c) < (8, 9, 10)
 ----
-filter           ·       ·                                                     (a, b, c)              ·
- │               filter  ((a, b, c) > (1, 2, 3)) AND ((a, b, c) < (8, 9, 10))  ·                      ·
- └── index-join  ·       ·                                                     (a, b, c)              ·
-      │          table   abc@primary                                           ·                      ·
-      └── scan   ·       ·                                                     (a, b, rowid[hidden])  ·
-·                table   abc@abc_a_b_idx                                       ·                      ·
-·                spans   /1/2-/8/10                                            ·                      ·
+·                distributed  false                                                 ·                      ·
+·                vectorized   true                                                  ·                      ·
+filter           ·            ·                                                     (a, b, c)              ·
+ │               filter       ((a, b, c) > (1, 2, 3)) AND ((a, b, c) < (8, 9, 10))  ·                      ·
+ └── index-join  ·            ·                                                     (a, b, c)              ·
+      │          table        abc@primary                                           ·                      ·
+      └── scan   ·            ·                                                     (a, b, rowid[hidden])  ·
+·                table        abc@abc_a_b_idx                                       ·                      ·
+·                spans        /1/2-/8/10                                            ·                      ·
 
 statement ok
 DROP TABLE abc
@@ -87,10 +103,12 @@ CREATE TABLE abc (a INT, b INT, c INT, INDEX(a, b DESC, c))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc WHERE (a, b, c) > (1, 2, 3)
 ----
-scan  ·       ·                      (a, b, c)  ·
-·     table   abc@abc_a_b_c_idx      ·          ·
-·     spans   /1-                    ·          ·
-·     filter  (a, b, c) > (1, 2, 3)  ·          ·
+·     distributed  false                  ·          ·
+·     vectorized   false                  ·          ·
+scan  ·            ·                      (a, b, c)  ·
+·     table        abc@abc_a_b_c_idx      ·          ·
+·     spans        /1-                    ·          ·
+·     filter       (a, b, c) > (1, 2, 3)  ·          ·
 
 statement ok
 DROP TABLE abc
@@ -103,24 +121,28 @@ CREATE TABLE kv (k INT PRIMARY KEY, v INT)
 query TTTTT
 EXPLAIN (VERBOSE, TYPES) SELECT x FROM (SELECT (row(v,v,v) AS a,b,c) AS x FROM kv)
 ----
-render     ·         ·                                                                                   (x tuple{int AS a, int AS b, int AS c})  ·
- │         render 0  ((((v)[int], (v)[int], (v)[int]) AS a, b, c))[tuple{int AS a, int AS b, int AS c}]  ·                                        ·
- └── scan  ·         ·                                                                                   (v int)                                  ·
-·          table     kv@primary                                                                          ·                                        ·
-·          spans     ALL                                                                                 ·                                        ·
+·          distributed  false                                                                               ·                                        ·
+·          vectorized   false                                                                               ·                                        ·
+render     ·            ·                                                                                   (x tuple{int AS a, int AS b, int AS c})  ·
+ │         render 0     ((((v)[int], (v)[int], (v)[int]) AS a, b, c))[tuple{int AS a, int AS b, int AS c}]  ·                                        ·
+ └── scan  ·            ·                                                                                   (v int)                                  ·
+·          table        kv@primary                                                                          ·                                        ·
+·          spans        ALL                                                                                 ·                                        ·
 
 query TTTTT
 EXPLAIN (VERBOSE, TYPES) SELECT (x).a, (x).b, (x).c FROM (SELECT (row(v,v,v) AS a,b,c) AS x FROM kv)
 ----
-render          ·         ·                                                                                   (a int, b int, c int)                    ·
- │              render 0  (((x)[tuple{int AS a, int AS b, int AS c}]).a)[int]                                 ·                                        ·
- │              render 1  (((x)[tuple{int AS a, int AS b, int AS c}]).b)[int]                                 ·                                        ·
- │              render 2  (((x)[tuple{int AS a, int AS b, int AS c}]).c)[int]                                 ·                                        ·
- └── render     ·         ·                                                                                   (x tuple{int AS a, int AS b, int AS c})  ·
-      │         render 0  ((((v)[int], (v)[int], (v)[int]) AS a, b, c))[tuple{int AS a, int AS b, int AS c}]  ·                                        ·
-      └── scan  ·         ·                                                                                   (v int)                                  ·
-·               table     kv@primary                                                                          ·                                        ·
-·               spans     ALL                                                                                 ·                                        ·
+·               distributed  false                                                                               ·                                        ·
+·               vectorized   false                                                                               ·                                        ·
+render          ·            ·                                                                                   (a int, b int, c int)                    ·
+ │              render 0     (((x)[tuple{int AS a, int AS b, int AS c}]).a)[int]                                 ·                                        ·
+ │              render 1     (((x)[tuple{int AS a, int AS b, int AS c}]).b)[int]                                 ·                                        ·
+ │              render 2     (((x)[tuple{int AS a, int AS b, int AS c}]).c)[int]                                 ·                                        ·
+ └── render     ·            ·                                                                                   (x tuple{int AS a, int AS b, int AS c})  ·
+      │         render 0     ((((v)[int], (v)[int], (v)[int]) AS a, b, c))[tuple{int AS a, int AS b, int AS c}]  ·                                        ·
+      └── scan  ·            ·                                                                                   (v int)                                  ·
+·               table        kv@primary                                                                          ·                                        ·
+·               spans        ALL                                                                                 ·                                        ·
 
 query TTTTT
 EXPLAIN (VERBOSE, TYPES) SELECT (x).e, (x).f, (x).g
@@ -128,6 +150,8 @@ FROM (
   SELECT ((1,'2',true) AS e,f,g) AS x
 )
 ----
+·            distributed    false                                                                                            ·                                            ·
+·            vectorized     false                                                                                            ·                                            ·
 render       ·              ·                                                                                                (e int, f string, g bool)                    ·
  │           render 0       (((x)[tuple{int AS e, string AS f, bool AS g}]).e)[int]                                          ·                                            ·
  │           render 1       (((x)[tuple{int AS e, string AS f, bool AS g}]).f)[string]                                       ·                                            ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -101,74 +101,82 @@ CREATE TABLE xyz (
 query TTT
 EXPLAIN UPDATE xyz SET y = x
 ----
-count                ·         ·
- └── update          ·         ·
-      │              table     xyz
-      │              set       y
-      │              strategy  updater
-      └── render     ·         ·
-           └── scan  ·         ·
-·                    table     xyz@primary
-·                    spans     ALL
+·                    distributed  false
+·                    vectorized   false
+count                ·            ·
+ └── update          ·            ·
+      │              table        xyz
+      │              set          y
+      │              strategy     updater
+      └── render     ·            ·
+           └── scan  ·            ·
+·                    table        xyz@primary
+·                    spans        ALL
 
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (1, 2)
 ----
-count                ·         ·            ()                           ·
- └── update          ·         ·            ()                           ·
-      │              table     xyz          ·                            ·
-      │              set       x, y         ·                            ·
-      │              strategy  updater      ·                            ·
-      └── render     ·         ·            (x, y, z, column7, column8)  ·
-           │         render 0  x            ·                            ·
-           │         render 1  y            ·                            ·
-           │         render 2  z            ·                            ·
-           │         render 3  1            ·                            ·
-           │         render 4  2            ·                            ·
-           └── scan  ·         ·            (x, y, z)                    ·
-·                    table     xyz@primary  ·                            ·
-·                    spans     ALL          ·                            ·
+·                    distributed  false        ·                            ·
+·                    vectorized   false        ·                            ·
+count                ·            ·            ()                           ·
+ └── update          ·            ·            ()                           ·
+      │              table        xyz          ·                            ·
+      │              set          x, y         ·                            ·
+      │              strategy     updater      ·                            ·
+      └── render     ·            ·            (x, y, z, column7, column8)  ·
+           │         render 0     x            ·                            ·
+           │         render 1     y            ·                            ·
+           │         render 2     z            ·                            ·
+           │         render 3     1            ·                            ·
+           │         render 4     2            ·                            ·
+           └── scan  ·            ·            (x, y, z)                    ·
+·                    table        xyz@primary  ·                            ·
+·                    spans        ALL          ·                            ·
 
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (y, x)
 ----
-count                ·         ·            ()               ·
- └── update          ·         ·            ()               ·
-      │              table     xyz          ·                ·
-      │              set       x, y         ·                ·
-      │              strategy  updater      ·                ·
-      └── render     ·         ·            (x, y, z, y, x)  ·
-           │         render 0  x            ·                ·
-           │         render 1  y            ·                ·
-           │         render 2  z            ·                ·
-           │         render 3  y            ·                ·
-           │         render 4  x            ·                ·
-           └── scan  ·         ·            (x, y, z)        ·
-·                    table     xyz@primary  ·                ·
-·                    spans     ALL          ·                ·
+·                    distributed  false        ·                ·
+·                    vectorized   false        ·                ·
+count                ·            ·            ()               ·
+ └── update          ·            ·            ()               ·
+      │              table        xyz          ·                ·
+      │              set          x, y         ·                ·
+      │              strategy     updater      ·                ·
+      └── render     ·            ·            (x, y, z, y, x)  ·
+           │         render 0     x            ·                ·
+           │         render 1     y            ·                ·
+           │         render 2     z            ·                ·
+           │         render 3     y            ·                ·
+           │         render 4     x            ·                ·
+           └── scan  ·            ·            (x, y, z)        ·
+·                    table        xyz@primary  ·                ·
+·                    spans        ALL          ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (2, 2)
 ----
-count                     ·         ·            ()                           ·
- └── update               ·         ·            ()                           ·
-      │                   table     xyz          ·                            ·
-      │                   set       x, y         ·                            ·
-      │                   strategy  updater      ·                            ·
-      └── render          ·         ·            (x, y, z, column7, column7)  ·
-           │              render 0  x            ·                            ·
-           │              render 1  y            ·                            ·
-           │              render 2  z            ·                            ·
-           │              render 3  column7      ·                            ·
-           │              render 4  column7      ·                            ·
-           └── render     ·         ·            (column7, x, y, z)           ·
-                │         render 0  2            ·                            ·
-                │         render 1  x            ·                            ·
-                │         render 2  y            ·                            ·
-                │         render 3  z            ·                            ·
-                └── scan  ·         ·            (x, y, z)                    ·
-·                         table     xyz@primary  ·                            ·
-·                         spans     ALL          ·                            ·
+·                         distributed  false        ·                            ·
+·                         vectorized   false        ·                            ·
+count                     ·            ·            ()                           ·
+ └── update               ·            ·            ()                           ·
+      │                   table        xyz          ·                            ·
+      │                   set          x, y         ·                            ·
+      │                   strategy     updater      ·                            ·
+      └── render          ·            ·            (x, y, z, column7, column7)  ·
+           │              render 0     x            ·                            ·
+           │              render 1     y            ·                            ·
+           │              render 2     z            ·                            ·
+           │              render 3     column7      ·                            ·
+           │              render 4     column7      ·                            ·
+           └── render     ·            ·            (column7, x, y, z)           ·
+                │         render 0     2            ·                            ·
+                │         render 1     x            ·                            ·
+                │         render 2     y            ·                            ·
+                │         render 3     z            ·                            ·
+                └── scan  ·            ·            (x, y, z)                    ·
+·                         table        xyz@primary  ·                            ·
+·                         spans        ALL          ·                            ·
 
 statement ok
 CREATE TABLE pks (
@@ -215,34 +223,38 @@ CREATE TABLE kv (
 query TTT
 EXPLAIN UPDATE kv SET v = v + 1 ORDER BY v DESC LIMIT 10
 ----
-count                          ·         ·
- └── update                    ·         ·
-      │                        table     kv
-      │                        set       v
-      │                        strategy  updater
-      └── render               ·         ·
-           └── limit           ·         ·
-                │              count     10
-                └── sort       ·         ·
-                     │         order     -v
-                     └── scan  ·         ·
-·                              table     kv@primary
-·                              spans     ALL
+·                              distributed  false
+·                              vectorized   false
+count                          ·            ·
+ └── update                    ·            ·
+      │                        table        kv
+      │                        set          v
+      │                        strategy     updater
+      └── render               ·            ·
+           └── limit           ·            ·
+                │              count        10
+                └── sort       ·            ·
+                     │         order        -v
+                     └── scan  ·            ·
+·                              table        kv@primary
+·                              spans        ALL
 
 # Use case for UPDATE ... ORDER BY: renumbering a PK without unique violation.
 query TTT
 EXPLAIN UPDATE kv SET v = v - 1 WHERE k < 3 LIMIT 1
 ----
-count                ·         ·
- └── update          ·         ·
-      │              table     kv
-      │              set       v
-      │              strategy  updater
-      └── render     ·         ·
-           └── scan  ·         ·
-·                    table     kv@primary
-·                    spans     -/2/#
-·                    limit     1
+·                    distributed  false
+·                    vectorized   false
+count                ·            ·
+ └── update          ·            ·
+      │              table        kv
+      │              set          v
+      │              strategy     updater
+      └── render     ·            ·
+           └── scan  ·            ·
+·                    table        kv@primary
+·                    spans        -/2/#
+·                    limit        1
 
 # Check that updates on tables with multiple column families behave as
 # they should.
@@ -257,19 +269,21 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) UPDATE tu SET c=c+1
 ]
 ----
-count                ·         ·
- └── update          ·         ·
-      │              table     tu
-      │              set       c
-      │              strategy  updater
-      └── render     ·         ·
-           │         render 0  a
-           │         render 1  c
-           │         render 2  d
-           │         render 3  c + 1
-           └── scan  ·         ·
-·                    table     tu@primary
-·                    spans     ALL
+·                    distributed  false
+·                    vectorized   false
+count                ·            ·
+ └── update          ·            ·
+      │              table        tu
+      │              set          c
+      │              strategy     updater
+      └── render     ·            ·
+           │         render 0     a
+           │         render 1     c
+           │         render 2     d
+           │         render 3     c + 1
+           └── scan  ·            ·
+·                    table        tu@primary
+·                    spans        ALL
 
 statement ok
 SET tracing = on,kv,results; UPDATE tu SET c=c+1; SET tracing = off
@@ -311,22 +325,24 @@ CREATE TABLE abc (a INT, b INT, c INT, INDEX(c) STORING(a,b))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [ UPDATE abc SET a=c RETURNING a ] ORDER BY a
 ----
-render                    ·         ·              (a)                       +a
- │                        render 0  a              ·                         ·
- └── run                  ·         ·              (a, rowid[hidden])        ·
-      └── update          ·         ·              (a, rowid[hidden])        ·
-           │              table     abc            ·                         ·
-           │              set       a              ·                         ·
-           │              strategy  updater        ·                         ·
-           └── render     ·         ·              (a, b, c, rowid, c)       +c
-                │         render 0  a              ·                         ·
-                │         render 1  b              ·                         ·
-                │         render 2  c              ·                         ·
-                │         render 3  rowid          ·                         ·
-                │         render 4  c              ·                         ·
-                └── scan  ·         ·              (a, b, c, rowid[hidden])  +c
-·                         table     abc@abc_c_idx  ·                         ·
-·                         spans     ALL            ·                         ·
+·                         distributed  false          ·                         ·
+·                         vectorized   false          ·                         ·
+render                    ·            ·              (a)                       +a
+ │                        render 0     a              ·                         ·
+ └── run                  ·            ·              (a, rowid[hidden])        ·
+      └── update          ·            ·              (a, rowid[hidden])        ·
+           │              table        abc            ·                         ·
+           │              set          a              ·                         ·
+           │              strategy     updater        ·                         ·
+           └── render     ·            ·              (a, b, c, rowid, c)       +c
+                │         render 0     a              ·                         ·
+                │         render 1     b              ·                         ·
+                │         render 2     c              ·                         ·
+                │         render 3     rowid          ·                         ·
+                │         render 4     c              ·                         ·
+                └── scan  ·            ·              (a, b, c, rowid[hidden])  +c
+·                         table        abc@abc_c_idx  ·                         ·
+·                         spans        ALL            ·                         ·
 
 # ------------------------------------------------------------------------------
 # Regression for #35364. This tests behavior that is different between the CBO

--- a/pkg/sql/opt/exec/execbuilder/testdata/update_from
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update_from
@@ -7,6 +7,8 @@ CREATE TABLE abc (a int primary key, b int, c int)
 query TTT
 EXPLAIN UPDATE abc SET b = other.b + 1, c = other.c + 1 FROM abc AS other WHERE abc.a = other.a
 ----
+·                          distributed         false
+·                          vectorized          false
 count                      ·                   ·
  └── update                ·                   ·
       │                    table               abc
@@ -33,6 +35,8 @@ CREATE TABLE new_abc (a int, b int, c int)
 query TTT
 EXPLAIN UPDATE abc SET b = other.b, c = other.c FROM new_abc AS other WHERE abc.a = other.a
 ----
+·                              distributed        false
+·                              vectorized         false
 count                          ·                  ·
  └── update                    ·                  ·
       │                        table              abc
@@ -64,6 +68,8 @@ WHERE
 RETURNING
   abc.a, abc.b AS new_b, old.b as old_b, abc.c as new_c, old.c as old_c
 ----
+·                               distributed         false
+·                               vectorized          false
 render                          ·                   ·
  └── run                        ·                   ·
       └── update                ·                   ·
@@ -88,6 +94,8 @@ render                          ·                   ·
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE abc SET b = old.b + 1, c = old.c + 2 FROM abc AS old WHERE abc.a = old.a RETURNING *
 ----
+·                          distributed         false        ·                                       ·
+·                          vectorized          false        ·                                       ·
 run                        ·                   ·            (a, b, c, a, b, c)                      ·
  └── update                ·                   ·            (a, b, c, a, b, c)                      ·
       │                    table               abc          ·                                       ·
@@ -119,6 +127,8 @@ run                        ·                   ·            (a, b, c, a, b, c)
 query TTT
 EXPLAIN UPDATE abc SET b = other.b, c = other.c FROM (values (1, 2, 3), (2, 3, 4)) as other ("a", "b", "c") WHERE abc.a = other.a
 ----
+·                                distributed            false
+·                                vectorized             false
 count                            ·                      ·
  └── update                      ·                      ·
       │                          table                  abc
@@ -145,6 +155,8 @@ CREATE TABLE ac (a INT, c INT)
 query TTT
 EXPLAIN UPDATE abc SET b = ab.b, c = ac.c FROM ab, ac WHERE abc.a = ab.a AND abc.a = ac.a
 ----
+·                                        distributed        false
+·                                        vectorized         false
 count                                    ·                  ·
  └── update                              ·                  ·
       │                                  table              abc
@@ -190,6 +202,8 @@ WHERE
 RETURNING
   *
 ----
+·                                   distributed         false
+·                                   vectorized          false
 run                                 ·                   ·
  └── update                         ·                   ·
       │                             table               abc

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -12,21 +12,23 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) UPSERT INTO kv TABLE kv ORDER BY v DESC LIMIT 2
 ]
 ----
-count                          ·         ·
- └── upsert                    ·         ·
-      │                        into      kv(k, v)
-      │                        strategy  opt upserter
-      └── render               ·         ·
-           │                   render 0  k
-           │                   render 1  v
-           │                   render 2  v
-           └── limit           ·         ·
-                │              count     2
-                └── sort       ·         ·
-                     │         order     -v
-                     └── scan  ·         ·
-·                              table     kv@primary
-·                              spans     ALL
+·                              distributed  false
+·                              vectorized   false
+count                          ·            ·
+ └── upsert                    ·            ·
+      │                        into         kv(k, v)
+      │                        strategy     opt upserter
+      └── render               ·            ·
+           │                   render 0     k
+           │                   render 1     v
+           │                   render 2     v
+           └── limit           ·            ·
+                │              count        2
+                └── sort       ·            ·
+                     │         order        -v
+                     └── scan  ·            ·
+·                              table        kv@primary
+·                              spans        ALL
 
 # Use explicit target columns (which can use blind KV Put).
 query TTT
@@ -34,21 +36,23 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) UPSERT INTO kv (k, v) TABLE kv ORDER BY v DESC LIMIT 2
 ]
 ----
-count                          ·         ·
- └── upsert                    ·         ·
-      │                        into      kv(k, v)
-      │                        strategy  opt upserter
-      └── render               ·         ·
-           │                   render 0  k
-           │                   render 1  v
-           │                   render 2  v
-           └── limit           ·         ·
-                │              count     2
-                └── sort       ·         ·
-                     │         order     -v
-                     └── scan  ·         ·
-·                              table     kv@primary
-·                              spans     ALL
+·                              distributed  false
+·                              vectorized   false
+count                          ·            ·
+ └── upsert                    ·            ·
+      │                        into         kv(k, v)
+      │                        strategy     opt upserter
+      └── render               ·            ·
+           │                   render 0     k
+           │                   render 1     v
+           │                   render 2     v
+           └── limit           ·            ·
+                │              count        2
+                └── sort       ·            ·
+                     │         order        -v
+                     └── scan  ·            ·
+·                              table        kv@primary
+·                              spans        ALL
 
 # Add RETURNING clause (should still use blind KV Put).
 query TTT
@@ -56,21 +60,23 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) UPSERT INTO kv (k, v) TABLE kv ORDER BY v DESC LIMIT 2 RETURNING *
 ]
 ----
-run                            ·         ·
- └── upsert                    ·         ·
-      │                        into      kv(k, v)
-      │                        strategy  opt upserter
-      └── render               ·         ·
-           │                   render 0  k
-           │                   render 1  v
-           │                   render 2  v
-           └── limit           ·         ·
-                │              count     2
-                └── sort       ·         ·
-                     │         order     -v
-                     └── scan  ·         ·
-·                              table     kv@primary
-·                              spans     ALL
+·                              distributed  false
+·                              vectorized   false
+run                            ·            ·
+ └── upsert                    ·            ·
+      │                        into         kv(k, v)
+      │                        strategy     opt upserter
+      └── render               ·            ·
+           │                   render 0     k
+           │                   render 1     v
+           │                   render 2     v
+           └── limit           ·            ·
+                │              count        2
+                └── sort       ·            ·
+                     │         order        -v
+                     └── scan  ·            ·
+·                              table        kv@primary
+·                              spans        ALL
 
 # Use subset of explicit target columns (which cannot use blind KV Put).
 query TTT
@@ -78,6 +84,8 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) UPSERT INTO kv (k) SELECT k FROM kv ORDER BY v DESC LIMIT 2
 ]
 ----
+·                                        distributed            false
+·                                        vectorized             false
 count                                    ·                      ·
  └── upsert                              ·                      ·
       │                                  into                   kv(k, v)
@@ -120,6 +128,8 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) UPSERT INTO indexed VALUES (1)
 ]
 ----
+·                                distributed    false
+·                                vectorized     false
 count                            ·              ·
  └── upsert                      ·              ·
       │                          into           indexed(a, b, c, d)
@@ -169,6 +179,8 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) UPSERT INTO indexed VALUES (1) RETURNING *
 ]
 ----
+·                      distributed    false
+·                      vectorized     false
 run                    ·              ·
  └── upsert            ·              ·
       │                into           indexed(a, b, c, d)
@@ -325,28 +337,30 @@ CREATE TABLE xyz (x INT, y INT, z INT)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [UPSERT INTO xyz SELECT a, b, c FROM abc RETURNING z] ORDER BY z
 ----
-render                         ·         ·                    (z)                          +z
- │                             render 0  z                    ·                            ·
- └── run                       ·         ·                    (z, rowid[hidden])           ·
-      └── upsert               ·         ·                    (z, rowid[hidden])           ·
-           │                   into      xyz(x, y, z, rowid)  ·                            ·
-           │                   strategy  opt upserter         ·                            ·
-           └── render          ·         ·                    (a, b, c, column9, a, b, c)  +c
-                │              render 0  a                    ·                            ·
-                │              render 1  b                    ·                            ·
-                │              render 2  c                    ·                            ·
-                │              render 3  column9              ·                            ·
-                │              render 4  a                    ·                            ·
-                │              render 5  b                    ·                            ·
-                │              render 6  c                    ·                            ·
-                └── render     ·         ·                    (column9, a, b, c)           +c
-                     │         render 0  unique_rowid()       ·                            ·
-                     │         render 1  a                    ·                            ·
-                     │         render 2  b                    ·                            ·
-                     │         render 3  c                    ·                            ·
-                     └── scan  ·         ·                    (a, b, c)                    +c
-·                              table     abc@abc_c_idx        ·                            ·
-·                              spans     ALL                  ·                            ·
+·                              distributed  false                ·                            ·
+·                              vectorized   false                ·                            ·
+render                         ·            ·                    (z)                          +z
+ │                             render 0     z                    ·                            ·
+ └── run                       ·            ·                    (z, rowid[hidden])           ·
+      └── upsert               ·            ·                    (z, rowid[hidden])           ·
+           │                   into         xyz(x, y, z, rowid)  ·                            ·
+           │                   strategy     opt upserter         ·                            ·
+           └── render          ·            ·                    (a, b, c, column9, a, b, c)  +c
+                │              render 0     a                    ·                            ·
+                │              render 1     b                    ·                            ·
+                │              render 2     c                    ·                            ·
+                │              render 3     column9              ·                            ·
+                │              render 4     a                    ·                            ·
+                │              render 5     b                    ·                            ·
+                │              render 6     c                    ·                            ·
+                └── render     ·            ·                    (column9, a, b, c)           +c
+                     │         render 0     unique_rowid()       ·                            ·
+                     │         render 1     a                    ·                            ·
+                     │         render 2     b                    ·                            ·
+                     │         render 3     c                    ·                            ·
+                     └── scan  ·            ·                    (a, b, c)                    +c
+·                              table        abc@abc_c_idx        ·                            ·
+·                              spans        ALL                  ·                            ·
 
 # ------------------------------------------------------------------------------
 # Regression for #35364. This tests behavior that is different between the CBO
@@ -394,6 +408,8 @@ BEGIN; ALTER TABLE table38627 ADD COLUMN c INT NOT NULL DEFAULT 5
 query TTTTT
 EXPLAIN (VERBOSE) UPSERT INTO table38627 SELECT * FROM table38627 WHERE a=1
 ----
+·                           distributed            false               ·                      ·
+·                           vectorized             false               ·                      ·
 count                       ·                      ·                   ()                     ·
  └── upsert                 ·                      ·                   ()                     ·
       │                     into                   table38627(a, b)    ·                      ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/values
+++ b/pkg/sql/opt/exec/execbuilder/testdata/values
@@ -4,6 +4,8 @@
 query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 a
 ----
+·       distributed    false            ·    ·
+·       vectorized     false            ·    ·
 values  ·              ·                (a)  ·
 ·       size           1 column, 1 row  ·    ·
 ·       row 0, expr 0  1                ·    ·
@@ -11,6 +13,8 @@ values  ·              ·                (a)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 + 2 a
 ----
+·       distributed    false            ·    ·
+·       vectorized     false            ·    ·
 values  ·              ·                (a)  ·
 ·       size           1 column, 1 row  ·    ·
 ·       row 0, expr 0  3                ·    ·
@@ -18,6 +22,8 @@ values  ·              ·                (a)  ·
 query TTTTT
 EXPLAIN (VERBOSE) VALUES (1, 2, 3), (4, 5, 6)
 ----
+·       distributed    false              ·                            ·
+·       vectorized     false              ·                            ·
 values  ·              ·                  (column1, column2, column3)  ·
 ·       size           3 columns, 2 rows  ·                            ·
 ·       row 0, expr 0  1                  ·                            ·
@@ -30,6 +36,8 @@ values  ·              ·                  (column1, column2, column3)  ·
 query TTTTT
 EXPLAIN (VERBOSE) VALUES (length('a')), (1 + length('a')), (length('abc')), (length('ab') * 2)
 ----
+·       distributed    false             ·          ·
+·       vectorized     false             ·          ·
 values  ·              ·                 (column1)  ·
 ·       size           1 column, 4 rows  ·          ·
 ·       row 0, expr 0  1                 ·          ·
@@ -40,6 +48,8 @@ values  ·              ·                 (column1)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a + b AS r FROM (VALUES (1, 2), (3, 4), (5, 6)) AS v(a, b)
 ----
+·            distributed    false              ·                   ·
+·            vectorized     false              ·                   ·
 render       ·              ·                  (r)                 ·
  │           render 0       column1 + column2  ·                   ·
  └── values  ·              ·                  (column1, column2)  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/window
+++ b/pkg/sql/opt/exec/execbuilder/testdata/window
@@ -58,31 +58,35 @@ output row: [8 3.5355339059327376220]
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ntile(1) OVER () FROM kv
 ----
-render               ·         ·                                                                   (ntile)                ·
- │                   render 0  ntile                                                               ·                      ·
- └── window          ·         ·                                                                   (ntile_1_arg1, ntile)  ·
-      │              window 0  ntile(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                      ·
-      │              render 1  ntile(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                      ·
-      └── render     ·         ·                                                                   (ntile_1_arg1)         ·
-           │         render 0  1                                                                   ·                      ·
-           └── scan  ·         ·                                                                   ()                     ·
-·                    table     kv@primary                                                          ·                      ·
-·                    spans     ALL                                                                 ·                      ·
+·                    distributed  false                                                               ·                      ·
+·                    vectorized   false                                                               ·                      ·
+render               ·            ·                                                                   (ntile)                ·
+ │                   render 0     ntile                                                               ·                      ·
+ └── window          ·            ·                                                                   (ntile_1_arg1, ntile)  ·
+      │              window 0     ntile(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                      ·
+      │              render 1     ntile(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                      ·
+      └── render     ·            ·                                                                   (ntile_1_arg1)         ·
+           │         render 0     1                                                                   ·                      ·
+           └── scan  ·            ·                                                                   ()                     ·
+·                    table        kv@primary                                                          ·                      ·
+·                    spans        ALL                                                                 ·                      ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT nth_value(1, 2) OVER () FROM kv
 ----
-render               ·         ·                                                                           (nth_value)                                      ·
- │                   render 0  nth_value                                                                   ·                                                ·
- └── window          ·         ·                                                                           (nth_value_1_arg1, nth_value_1_arg2, nth_value)  ·
-      │              window 0  nth_value(@1, @2) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                                                ·
-      │              render 2  nth_value(@1, @2) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                                                ·
-      └── render     ·         ·                                                                           (nth_value_1_arg1, nth_value_1_arg2)             ·
-           │         render 0  1                                                                           ·                                                ·
-           │         render 1  2                                                                           ·                                                ·
-           └── scan  ·         ·                                                                           ()                                               ·
-·                    table     kv@primary                                                                  ·                                                ·
-·                    spans     ALL                                                                         ·                                                ·
+·                    distributed  false                                                                       ·                                                ·
+·                    vectorized   false                                                                       ·                                                ·
+render               ·            ·                                                                           (nth_value)                                      ·
+ │                   render 0     nth_value                                                                   ·                                                ·
+ └── window          ·            ·                                                                           (nth_value_1_arg1, nth_value_1_arg2, nth_value)  ·
+      │              window 0     nth_value(@1, @2) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                                                ·
+      │              render 2     nth_value(@1, @2) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                                                ·
+      └── render     ·            ·                                                                           (nth_value_1_arg1, nth_value_1_arg2)             ·
+           │         render 0     1                                                                           ·                                                ·
+           │         render 1     2                                                                           ·                                                ·
+           └── scan  ·            ·                                                                           ()                                               ·
+·                    table        kv@primary                                                                  ·                                                ·
+·                    spans        ALL                                                                         ·                                                ·
 
 statement error column "v" must appear in the GROUP BY clause or be used in an aggregate function
 EXPLAIN (VERBOSE) SELECT max(v) OVER (), min(v) FROM kv ORDER BY 1
@@ -90,98 +94,110 @@ EXPLAIN (VERBOSE) SELECT max(v) OVER (), min(v) FROM kv ORDER BY 1
 query TTT
 EXPLAIN SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
 ----
-render                    ·      ·
- └── sort                 ·      ·
-      │                   order  +variance,+k
-      └── render          ·      ·
-           └── window     ·      ·
-                └── scan  ·      ·
-·                         table  kv@primary
-·                         spans  ALL
+·                         distributed  false
+·                         vectorized   false
+render                    ·            ·
+ └── sort                 ·            ·
+      │                   order        +variance,+k
+      └── render          ·            ·
+           └── window     ·            ·
+                └── scan  ·            ·
+·                         table        kv@primary
+·                         spans        ALL
 
 query TTTTT
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
 ----
-render                    ·         ·                                                                                                                   (k int, stddev decimal)                                      ·
- │                        render 0  (k)[int]                                                                                                            ·                                                            ·
- │                        render 1  (stddev)[decimal]                                                                                                   ·                                                            ·
- └── sort                 ·         ·                                                                                                                   (k int, stddev decimal, variance decimal)                    +variance,+k
-      │                   order     +variance,+k                                                                                                        ·                                                            ·
-      └── render          ·         ·                                                                                                                   (k int, stddev decimal, variance decimal)                    ·
-           │              render 0  (k)[int]                                                                                                            ·                                                            ·
-           │              render 1  (stddev)[decimal]                                                                                                   ·                                                            ·
-           │              render 2  (variance)[decimal]                                                                                                 ·                                                            ·
-           └── window     ·         ·                                                                                                                   (k int, v int, d decimal, stddev decimal, variance decimal)  ·
-                │         window 0  (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
-                │         window 1  (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
-                │         render 3  (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
-                │         render 4  (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
-                └── scan  ·         ·                                                                                                                   (k int, v int, d decimal)                                    ·
-·                         table     kv@primary                                                                                                          ·                                                            ·
-·                         spans     ALL                                                                                                                 ·                                                            ·
+·                         distributed  false                                                                                                               ·                                                            ·
+·                         vectorized   false                                                                                                               ·                                                            ·
+render                    ·            ·                                                                                                                   (k int, stddev decimal)                                      ·
+ │                        render 0     (k)[int]                                                                                                            ·                                                            ·
+ │                        render 1     (stddev)[decimal]                                                                                                   ·                                                            ·
+ └── sort                 ·            ·                                                                                                                   (k int, stddev decimal, variance decimal)                    +variance,+k
+      │                   order        +variance,+k                                                                                                        ·                                                            ·
+      └── render          ·            ·                                                                                                                   (k int, stddev decimal, variance decimal)                    ·
+           │              render 0     (k)[int]                                                                                                            ·                                                            ·
+           │              render 1     (stddev)[decimal]                                                                                                   ·                                                            ·
+           │              render 2     (variance)[decimal]                                                                                                 ·                                                            ·
+           └── window     ·            ·                                                                                                                   (k int, v int, d decimal, stddev decimal, variance decimal)  ·
+                │         window 0     (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
+                │         window 1     (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
+                │         render 3     (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
+                │         render 4     (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
+                └── scan  ·            ·                                                                                                                   (k int, v int, d decimal)                                    ·
+·                         table        kv@primary                                                                                                          ·                                                            ·
+·                         spans        ALL                                                                                                                 ·                                                            ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
 ----
-render                         ·         ·                                                                                                                   (k int, stddev decimal)                                      ·
- │                             render 0  (k)[int]                                                                                                            ·                                                            ·
- │                             render 1  (stddev)[decimal]                                                                                                   ·                                                            ·
- └── sort                      ·         ·                                                                                                                   (k int, stddev decimal, variance decimal)                    +variance,+k
-      │                        order     +variance,+k                                                                                                        ·                                                            ·
-      └── render               ·         ·                                                                                                                   (k int, stddev decimal, variance decimal)                    ·
-           │                   render 0  (k)[int]                                                                                                            ·                                                            ·
-           │                   render 1  (stddev)[decimal]                                                                                                   ·                                                            ·
-           │                   render 2  (variance)[decimal]                                                                                                 ·                                                            ·
-           └── window          ·         ·                                                                                                                   (k int, v int, d decimal, stddev decimal, variance decimal)  ·
-                │              window 0  (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
-                │              render 4  (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
-                └── window     ·         ·                                                                                                                   (k int, v int, d decimal, stddev decimal)                    ·
-                     │         window 0  (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
-                     │         render 3  (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
-                     └── scan  ·         ·                                                                                                                   (k int, v int, d decimal)                                    ·
-·                              table     kv@primary                                                                                                          ·                                                            ·
-·                              spans     ALL                                                                                                                 ·                                                            ·
+·                              distributed  false                                                                                                               ·                                                            ·
+·                              vectorized   false                                                                                                               ·                                                            ·
+render                         ·            ·                                                                                                                   (k int, stddev decimal)                                      ·
+ │                             render 0     (k)[int]                                                                                                            ·                                                            ·
+ │                             render 1     (stddev)[decimal]                                                                                                   ·                                                            ·
+ └── sort                      ·            ·                                                                                                                   (k int, stddev decimal, variance decimal)                    +variance,+k
+      │                        order        +variance,+k                                                                                                        ·                                                            ·
+      └── render               ·            ·                                                                                                                   (k int, stddev decimal, variance decimal)                    ·
+           │                   render 0     (k)[int]                                                                                                            ·                                                            ·
+           │                   render 1     (stddev)[decimal]                                                                                                   ·                                                            ·
+           │                   render 2     (variance)[decimal]                                                                                                 ·                                                            ·
+           └── window          ·            ·                                                                                                                   (k int, v int, d decimal, stddev decimal, variance decimal)  ·
+                │              window 0     (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
+                │              render 4     (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
+                └── window     ·            ·                                                                                                                   (k int, v int, d decimal, stddev decimal)                    ·
+                     │         window 0     (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
+                     │         render 3     (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
+                     └── scan  ·            ·                                                                                                                   (k int, v int, d decimal)                                    ·
+·                              table        kv@primary                                                                                                          ·                                                            ·
+·                              spans        ALL                                                                                                                 ·                                                            ·
 
 query TTTTT
 EXPLAIN (TYPES,NONORMALIZE) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY k
 ----
-sort                 ·         ·                                                                                                                 (k int, stddev decimal)                    +k
- │                   order     +k                                                                                                                ·                                          ·
- └── render          ·         ·                                                                                                                 (k int, stddev decimal)                    ·
-      │              render 0  (k)[int]                                                                                                          ·                                          ·
-      │              render 1  (stddev)[decimal]                                                                                                 ·                                          ·
-      └── window     ·         ·                                                                                                                 (k int, v int, d decimal, stddev decimal)  ·
-           │         window 0  (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                          ·
-           │         render 3  (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                          ·
-           └── scan  ·         ·                                                                                                                 (k int, v int, d decimal)                  ·
-·                    table     kv@primary                                                                                                        ·                                          ·
-·                    spans     ALL                                                                                                               ·                                          ·
+·                    distributed  false                                                                                                             ·                                          ·
+·                    vectorized   false                                                                                                             ·                                          ·
+sort                 ·            ·                                                                                                                 (k int, stddev decimal)                    +k
+ │                   order        +k                                                                                                                ·                                          ·
+ └── render          ·            ·                                                                                                                 (k int, stddev decimal)                    ·
+      │              render 0     (k)[int]                                                                                                          ·                                          ·
+      │              render 1     (stddev)[decimal]                                                                                                 ·                                          ·
+      └── window     ·            ·                                                                                                                 (k int, v int, d decimal, stddev decimal)  ·
+           │         window 0     (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                          ·
+           │         render 3     (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                          ·
+           └── scan  ·            ·                                                                                                                 (k int, v int, d decimal)                  ·
+·                    table        kv@primary                                                                                                        ·                                          ·
+·                    spans        ALL                                                                                                               ·                                          ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT k, k + stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
 ----
-render                         ·         ·                                                                                                                   (k int, "?column?" decimal)                                  ·
- │                             render 0  (k)[int]                                                                                                            ·                                                            ·
- │                             render 1  ("?column?")[decimal]                                                                                               ·                                                            ·
- └── sort                      ·         ·                                                                                                                   ("?column?" decimal, k int, variance decimal)                +variance,+k
-      │                        order     +variance,+k                                                                                                        ·                                                            ·
-      └── render               ·         ·                                                                                                                   ("?column?" decimal, k int, variance decimal)                ·
-           │                   render 0  ((k)[int] + (stddev)[decimal])[decimal]                                                                             ·                                                            ·
-           │                   render 1  (k)[int]                                                                                                            ·                                                            ·
-           │                   render 2  (variance)[decimal]                                                                                                 ·                                                            ·
-           └── window          ·         ·                                                                                                                   (k int, v int, d decimal, stddev decimal, variance decimal)  ·
-                │              window 0  (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
-                │              render 4  (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
-                └── window     ·         ·                                                                                                                   (k int, v int, d decimal, stddev decimal)                    ·
-                     │         window 0  (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
-                     │         render 3  (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
-                     └── scan  ·         ·                                                                                                                   (k int, v int, d decimal)                                    ·
-·                              table     kv@primary                                                                                                          ·                                                            ·
-·                              spans     ALL                                                                                                                 ·                                                            ·
+·                              distributed  false                                                                                                               ·                                                            ·
+·                              vectorized   false                                                                                                               ·                                                            ·
+render                         ·            ·                                                                                                                   (k int, "?column?" decimal)                                  ·
+ │                             render 0     (k)[int]                                                                                                            ·                                                            ·
+ │                             render 1     ("?column?")[decimal]                                                                                               ·                                                            ·
+ └── sort                      ·            ·                                                                                                                   ("?column?" decimal, k int, variance decimal)                +variance,+k
+      │                        order        +variance,+k                                                                                                        ·                                                            ·
+      └── render               ·            ·                                                                                                                   ("?column?" decimal, k int, variance decimal)                ·
+           │                   render 0     ((k)[int] + (stddev)[decimal])[decimal]                                                                             ·                                                            ·
+           │                   render 1     (k)[int]                                                                                                            ·                                                            ·
+           │                   render 2     (variance)[decimal]                                                                                                 ·                                                            ·
+           └── window          ·            ·                                                                                                                   (k int, v int, d decimal, stddev decimal, variance decimal)  ·
+                │              window 0     (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
+                │              render 4     (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
+                └── window     ·            ·                                                                                                                   (k int, v int, d decimal, stddev decimal)                    ·
+                     │         window 0     (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
+                     │         render 3     (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
+                     └── scan  ·            ·                                                                                                                   (k int, v int, d decimal)                                    ·
+·                              table        kv@primary                                                                                                          ·                                                            ·
+·                              spans        ALL                                                                                                                 ·                                                            ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT max(k), max(k) + stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROUP BY d, v ORDER BY variance(d) OVER (PARTITION BY v, 100)
 ----
+·                                   distributed  false                                                                                                               ·                                                              ·
+·                                   vectorized   false                                                                                                               ·                                                              ·
 render                              ·            ·                                                                                                                   (max int, "?column?" decimal)                                  ·
  │                                  render 0     (max)[int]                                                                                                          ·                                                              ·
  │                                  render 1     ("?column?")[decimal]                                                                                               ·                                                              ·
@@ -209,6 +225,8 @@ render                              ·            ·                            
 query TTTTT
 EXPLAIN (TYPES) SELECT max(k), stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROUP BY d, v ORDER BY 1
 ----
+·                         distributed  false                                                                                                             ·                                            ·
+·                         vectorized   false                                                                                                             ·                                            ·
 sort                      ·            ·                                                                                                                 (max int, stddev decimal)                    +max
  │                        order        +max                                                                                                              ·                                            ·
  └── render               ·            ·                                                                                                                 (max int, stddev decimal)                    ·
@@ -231,41 +249,45 @@ sort                      ·            ·                                      
 query TTTTT
 EXPLAIN (VERBOSE) SELECT lag(1) OVER (PARTITION BY 2), lead(2) OVER (PARTITION BY 1) FROM kv
 ----
-render                         ·         ·                                                                          (lag, lead)                                             ·
- │                             render 0  lag                                                                        ·                                                       ·
- │                             render 1  lead                                                                       ·                                                       ·
- └── window                    ·         ·                                                                          (lag, lag_1_arg1, lag_1_arg3, lag_1_partition_1, lead)  ·
-      │                        window 0  lead(@4, @2, @3) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                                                       ·
-      │                        render 4  lead(@4, @2, @3) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                                                       ·
-      └── render               ·         ·                                                                          (lag, lag_1_arg1, lag_1_arg3, lag_1_partition_1)        ·
-           │                   render 0  lag                                                                        ·                                                       ·
-           │                   render 1  lag_1_arg1                                                                 ·                                                       ·
-           │                   render 2  lag_1_arg3                                                                 ·                                                       ·
-           │                   render 3  lag_1_partition_1                                                          ·                                                       ·
-           └── window          ·         ·                                                                          (lag_1_arg1, lag_1_arg3, lag_1_partition_1, lag)        ·
-                │              window 0  lag(@1, @1, @2) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)   ·                                                       ·
-                │              render 3  lag(@1, @1, @2) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)   ·                                                       ·
-                └── render     ·         ·                                                                          (lag_1_arg1, lag_1_arg3, lag_1_partition_1)             ·
-                     │         render 0  1                                                                          ·                                                       ·
-                     │         render 1  CAST(NULL AS INT8)                                                         ·                                                       ·
-                     │         render 2  2                                                                          ·                                                       ·
-                     └── scan  ·         ·                                                                          ()                                                      ·
-·                              table     kv@primary                                                                 ·                                                       ·
-·                              spans     ALL                                                                        ·                                                       ·
+·                              distributed  false                                                                      ·                                                       ·
+·                              vectorized   false                                                                      ·                                                       ·
+render                         ·            ·                                                                          (lag, lead)                                             ·
+ │                             render 0     lag                                                                        ·                                                       ·
+ │                             render 1     lead                                                                       ·                                                       ·
+ └── window                    ·            ·                                                                          (lag, lag_1_arg1, lag_1_arg3, lag_1_partition_1, lead)  ·
+      │                        window 0     lead(@4, @2, @3) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                                                       ·
+      │                        render 4     lead(@4, @2, @3) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                                                       ·
+      └── render               ·            ·                                                                          (lag, lag_1_arg1, lag_1_arg3, lag_1_partition_1)        ·
+           │                   render 0     lag                                                                        ·                                                       ·
+           │                   render 1     lag_1_arg1                                                                 ·                                                       ·
+           │                   render 2     lag_1_arg3                                                                 ·                                                       ·
+           │                   render 3     lag_1_partition_1                                                          ·                                                       ·
+           └── window          ·            ·                                                                          (lag_1_arg1, lag_1_arg3, lag_1_partition_1, lag)        ·
+                │              window 0     lag(@1, @1, @2) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)   ·                                                       ·
+                │              render 3     lag(@1, @1, @2) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)   ·                                                       ·
+                └── render     ·            ·                                                                          (lag_1_arg1, lag_1_arg3, lag_1_partition_1)             ·
+                     │         render 0     1                                                                          ·                                                       ·
+                     │         render 1     CAST(NULL AS INT8)                                                         ·                                                       ·
+                     │         render 2     2                                                                          ·                                                       ·
+                     └── scan  ·            ·                                                                          ()                                                      ·
+·                              table        kv@primary                                                                 ·                                                       ·
+·                              spans        ALL                                                                        ·                                                       ·
 
 # Ordering
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, v, rank() OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
-sort            ·         ·                                                                                (k, v, rank)  +k
- │              order     +k                                                                               ·             ·
- └── window     ·         ·                                                                                (k, v, rank)  ·
-      │         window 0  rank() OVER (ORDER BY @1 ASC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·             ·
-      │         render 2  rank() OVER (ORDER BY @1 ASC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·             ·
-      └── scan  ·         ·                                                                                (k, v)        ·
-·               table     kv@primary                                                                       ·             ·
-·               spans     ALL                                                                              ·             ·
+·               distributed  false                                                                            ·             ·
+·               vectorized   false                                                                            ·             ·
+sort            ·            ·                                                                                (k, v, rank)  +k
+ │              order        +k                                                                               ·             ·
+ └── window     ·            ·                                                                                (k, v, rank)  ·
+      │         window 0     rank() OVER (ORDER BY @1 ASC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·             ·
+      │         render 2     rank() OVER (ORDER BY @1 ASC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·             ·
+      └── scan  ·            ·                                                                                (k, v)        ·
+·               table        kv@primary                                                                       ·             ·
+·               spans        ALL                                                                              ·             ·
 
 
 # Frames
@@ -273,38 +295,44 @@ sort            ·         ·                                                   
 query TTTTT
 EXPLAIN (VERBOSE) SELECT avg(k) OVER () FROM kv
 ----
-render          ·         ·                                                                 (avg)     ·
- │              render 0  avg                                                               ·         ·
- └── window     ·         ·                                                                 (k, avg)  ·
-      │         window 0  avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·         ·
-      │         render 1  avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·         ·
-      └── scan  ·         ·                                                                 (k)       ·
-·               table     kv@primary                                                        ·         ·
-·               spans     ALL                                                               ·         ·
+·               distributed  false                                                             ·         ·
+·               vectorized   false                                                             ·         ·
+render          ·            ·                                                                 (avg)     ·
+ │              render 0     avg                                                               ·         ·
+ └── window     ·            ·                                                                 (k, avg)  ·
+      │         window 0     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·         ·
+      │         render 1     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·         ·
+      └── scan  ·            ·                                                                 (k)       ·
+·               table        kv@primary                                                        ·         ·
+·               spans        ALL                                                               ·         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) FROM kv
 ----
-render          ·         ·                                                                         (avg)     ·
- │              render 0  avg                                                                       ·         ·
- └── window     ·         ·                                                                         (k, avg)  ·
-      │         window 0  avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)  ·         ·
-      │         render 1  avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)  ·         ·
-      └── scan  ·         ·                                                                         (k)       ·
-·               table     kv@primary                                                                ·         ·
-·               spans     ALL                                                                       ·         ·
+·               distributed  false                                                                     ·         ·
+·               vectorized   false                                                                     ·         ·
+render          ·            ·                                                                         (avg)     ·
+ │              render 0     avg                                                                       ·         ·
+ └── window     ·            ·                                                                         (k, avg)  ·
+      │         window 0     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)  ·         ·
+      │         render 1     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)  ·         ·
+      └── scan  ·            ·                                                                         (k)       ·
+·               table        kv@primary                                                                ·         ·
+·               spans        ALL                                                                       ·         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM kv
 ----
-render          ·         ·                                                                 (avg)     ·
- │              render 0  avg                                                               ·         ·
- └── window     ·         ·                                                                 (k, avg)  ·
-      │         window 0  avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·         ·
-      │         render 1  avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·         ·
-      └── scan  ·         ·                                                                 (k)       ·
-·               table     kv@primary                                                        ·         ·
-·               spans     ALL                                                               ·         ·
+·               distributed  false                                                             ·         ·
+·               vectorized   false                                                             ·         ·
+render          ·            ·                                                                 (avg)     ·
+ │              render 0     avg                                                               ·         ·
+ └── window     ·            ·                                                                 (k, avg)  ·
+      │         window 0     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·         ·
+      │         render 1     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·         ·
+      └── scan  ·            ·                                                                 (k)       ·
+·               table        kv@primary                                                        ·         ·
+·               spans        ALL                                                               ·         ·
 
 query TTTTT
 EXPLAIN (VERBOSE)
@@ -324,48 +352,50 @@ EXPLAIN (VERBOSE)
     FROM
         kv
 ----
-render               ·          ·                                                                                          (avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg)     ·
- │                   render 0   avg                                                                                        ·                                                                ·
- │                   render 1   avg                                                                                        ·                                                                ·
- │                   render 2   avg                                                                                        ·                                                                ·
- │                   render 3   avg                                                                                        ·                                                                ·
- │                   render 4   avg                                                                                        ·                                                                ·
- │                   render 5   avg                                                                                        ·                                                                ·
- │                   render 6   avg                                                                                        ·                                                                ·
- │                   render 7   avg                                                                                        ·                                                                ·
- │                   render 8   avg                                                                                        ·                                                                ·
- │                   render 9   avg                                                                                        ·                                                                ·
- │                   render 10  avg                                                                                        ·                                                                ·
- │                   render 11  avg                                                                                        ·                                                                ·
- └── window          ·          ·                                                                                          (k, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg)  ·
-      │              window 0   avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)  ·                                                                ·
-      │              window 1   avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)          ·                                                                ·
-      │              window 2   avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)          ·                                                                ·
-      │              window 3   avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN CURRENT ROW AND CURRENT ROW)                  ·                                                                ·
-      │              render 9   avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)  ·                                                                ·
-      │              render 10  avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)          ·                                                                ·
-      │              render 11  avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)          ·                                                                ·
-      │              render 12  avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN CURRENT ROW AND CURRENT ROW)                  ·                                                                ·
-      └── window     ·          ·                                                                                          (k, avg, avg, avg, avg, avg, avg, avg, avg)                      ·
-           │         window 0   avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)                   ·                                                                ·
-           │         window 1   avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                           ·                                                                ·
-           │         window 2   avg(@1) OVER (RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)                           ·                                                                ·
-           │         window 3   avg(@1) OVER (RANGE BETWEEN CURRENT ROW AND CURRENT ROW)                                   ·                                                                ·
-           │         window 4   avg(@1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)                    ·                                                                ·
-           │         window 5   avg(@1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                            ·                                                                ·
-           │         window 6   avg(@1) OVER (ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)                            ·                                                                ·
-           │         window 7   avg(@1) OVER (ROWS BETWEEN CURRENT ROW AND CURRENT ROW)                                    ·                                                                ·
-           │         render 1   avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)                   ·                                                                ·
-           │         render 2   avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                           ·                                                                ·
-           │         render 3   avg(@1) OVER (RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)                           ·                                                                ·
-           │         render 4   avg(@1) OVER (RANGE BETWEEN CURRENT ROW AND CURRENT ROW)                                   ·                                                                ·
-           │         render 5   avg(@1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)                    ·                                                                ·
-           │         render 6   avg(@1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                            ·                                                                ·
-           │         render 7   avg(@1) OVER (ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)                            ·                                                                ·
-           │         render 8   avg(@1) OVER (ROWS BETWEEN CURRENT ROW AND CURRENT ROW)                                    ·                                                                ·
-           └── scan  ·          ·                                                                                          (k)                                                              ·
-·                    table      kv@primary                                                                                 ·                                                                ·
-·                    spans      ALL                                                                                        ·                                                                ·
+·                    distributed  false                                                                                      ·                                                                ·
+·                    vectorized   false                                                                                      ·                                                                ·
+render               ·            ·                                                                                          (avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg)     ·
+ │                   render 0     avg                                                                                        ·                                                                ·
+ │                   render 1     avg                                                                                        ·                                                                ·
+ │                   render 2     avg                                                                                        ·                                                                ·
+ │                   render 3     avg                                                                                        ·                                                                ·
+ │                   render 4     avg                                                                                        ·                                                                ·
+ │                   render 5     avg                                                                                        ·                                                                ·
+ │                   render 6     avg                                                                                        ·                                                                ·
+ │                   render 7     avg                                                                                        ·                                                                ·
+ │                   render 8     avg                                                                                        ·                                                                ·
+ │                   render 9     avg                                                                                        ·                                                                ·
+ │                   render 10    avg                                                                                        ·                                                                ·
+ │                   render 11    avg                                                                                        ·                                                                ·
+ └── window          ·            ·                                                                                          (k, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg)  ·
+      │              window 0     avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)  ·                                                                ·
+      │              window 1     avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)          ·                                                                ·
+      │              window 2     avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)          ·                                                                ·
+      │              window 3     avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN CURRENT ROW AND CURRENT ROW)                  ·                                                                ·
+      │              render 9     avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)  ·                                                                ·
+      │              render 10    avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)          ·                                                                ·
+      │              render 11    avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)          ·                                                                ·
+      │              render 12    avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN CURRENT ROW AND CURRENT ROW)                  ·                                                                ·
+      └── window     ·            ·                                                                                          (k, avg, avg, avg, avg, avg, avg, avg, avg)                      ·
+           │         window 0     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)                   ·                                                                ·
+           │         window 1     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                           ·                                                                ·
+           │         window 2     avg(@1) OVER (RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)                           ·                                                                ·
+           │         window 3     avg(@1) OVER (RANGE BETWEEN CURRENT ROW AND CURRENT ROW)                                   ·                                                                ·
+           │         window 4     avg(@1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)                    ·                                                                ·
+           │         window 5     avg(@1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                            ·                                                                ·
+           │         window 6     avg(@1) OVER (ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)                            ·                                                                ·
+           │         window 7     avg(@1) OVER (ROWS BETWEEN CURRENT ROW AND CURRENT ROW)                                    ·                                                                ·
+           │         render 1     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)                   ·                                                                ·
+           │         render 2     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                           ·                                                                ·
+           │         render 3     avg(@1) OVER (RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)                           ·                                                                ·
+           │         render 4     avg(@1) OVER (RANGE BETWEEN CURRENT ROW AND CURRENT ROW)                                   ·                                                                ·
+           │         render 5     avg(@1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)                    ·                                                                ·
+           │         render 6     avg(@1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                            ·                                                                ·
+           │         render 7     avg(@1) OVER (ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)                            ·                                                                ·
+           │         render 8     avg(@1) OVER (ROWS BETWEEN CURRENT ROW AND CURRENT ROW)                                    ·                                                                ·
+           └── scan  ·            ·                                                                                          (k)                                                              ·
+·                    table        kv@primary                                                                                 ·                                                                ·
+·                    spans        ALL                                                                                        ·                                                                ·
 
 query TTTTT
 EXPLAIN (VERBOSE)
@@ -379,6 +409,8 @@ EXPLAIN (VERBOSE)
     FROM
         kv
 ----
+·                    distributed   false                                                                      ·             ·
+·                    vectorized    false                                                                      ·             ·
 root                 ·             ·                                                                          (avg)         ·
  ├── render          ·             ·                                                                          (avg)         ·
  │    │              render 0      avg                                                                        ·             ·
@@ -409,20 +441,22 @@ EXPLAIN (VERBOSE)
     FROM
         kv
 ----
-render          ·         ·                                                                                     (avg, avg, avg, avg)     ·
- │              render 0  avg                                                                                   ·                        ·
- │              render 1  avg                                                                                   ·                        ·
- │              render 2  avg                                                                                   ·                        ·
- │              render 3  avg                                                                                   ·                        ·
- └── window     ·         ·                                                                                     (k, avg, avg, avg, avg)  ·
-      │         window 0  avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE CURRENT ROW)  ·                        ·
-      │         window 1  avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE GROUP)        ·                        ·
-      │         window 2  avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES)         ·                        ·
-      │         window 3  avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                      ·                        ·
-      │         render 1  avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE CURRENT ROW)  ·                        ·
-      │         render 2  avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE GROUP)        ·                        ·
-      │         render 3  avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES)         ·                        ·
-      │         render 4  avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                      ·                        ·
-      └── scan  ·         ·                                                                                     (k)                      ·
-·               table     kv@primary                                                                            ·                        ·
-·               spans     ALL                                                                                   ·                        ·
+·               distributed  false                                                                                 ·                        ·
+·               vectorized   false                                                                                 ·                        ·
+render          ·            ·                                                                                     (avg, avg, avg, avg)     ·
+ │              render 0     avg                                                                                   ·                        ·
+ │              render 1     avg                                                                                   ·                        ·
+ │              render 2     avg                                                                                   ·                        ·
+ │              render 3     avg                                                                                   ·                        ·
+ └── window     ·            ·                                                                                     (k, avg, avg, avg, avg)  ·
+      │         window 0     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE CURRENT ROW)  ·                        ·
+      │         window 1     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE GROUP)        ·                        ·
+      │         window 2     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES)         ·                        ·
+      │         window 3     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                      ·                        ·
+      │         render 1     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE CURRENT ROW)  ·                        ·
+      │         render 2     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE GROUP)        ·                        ·
+      │         render 3     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES)         ·                        ·
+      │         render 4     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                      ·                        ·
+      └── scan  ·            ·                                                                                     (k)                      ·
+·               table        kv@primary                                                                            ·                        ·
+·               spans        ALL                                                                                   ·                        ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/with
+++ b/pkg/sql/opt/exec/execbuilder/testdata/with
@@ -10,6 +10,8 @@ query TTTTT
 EXPLAIN (VERBOSE)
   WITH t AS (SELECT a FROM y) SELECT * FROM t JOIN t AS q ON true
 ----
+·                           distributed   false            ·       ·
+·                           vectorized    false            ·       ·
 root                        ·             ·                (a, a)  ·
  ├── hash-join              ·             ·                (a, a)  ·
  │    │                     type          cross            ·       ·
@@ -31,16 +33,20 @@ query TTTTT
 EXPLAIN (VERBOSE)
   WITH t AS (SELECT a FROM y) SELECT * FROM t
 ----
-render     ·         ·          (a)  ·
- │         render 0  a          ·    ·
- └── scan  ·         ·          (a)  ·
-·          table     y@primary  ·    ·
-·          spans     ALL        ·    ·
+·          distributed  false      ·    ·
+·          vectorized   true       ·    ·
+render     ·            ·          (a)  ·
+ │         render 0     a          ·    ·
+ └── scan  ·            ·          (a)  ·
+·          table        y@primary  ·    ·
+·          spans        ALL        ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE)
   WITH t AS (INSERT INTO x VALUES (1) RETURNING a) SELECT * FROM t
 ----
+·                                          distributed    false             ·                   ·
+·                                          vectorized     false             ·                   ·
 root                                       ·              ·                 (a)                 ·
  ├── scan buffer node                      ·              ·                 (a)                 ·
  │                                         label          buffer 1 (t)      ·                   ·
@@ -76,11 +82,13 @@ EXPLAIN (VERBOSE)
   FROM
     w, table39010
 ----
-hash-join  ·      ·                   (col)  ·
- │         type   cross               ·      ·
- ├── scan  ·      ·                   ()     ·
- │         table  table39010@primary  ·      ·
- │         spans  ALL                 ·      ·
- └── scan  ·      ·                   (col)  ·
-·          table  table39010@primary  ·      ·
-·          spans  ALL                 ·      ·
+·          distributed  false               ·      ·
+·          vectorized   false               ·      ·
+hash-join  ·            ·                   (col)  ·
+ │         type         cross               ·      ·
+ ├── scan  ·            ·                   ()     ·
+ │         table        table39010@primary  ·      ·
+ │         spans        ALL                 ·      ·
+ └── scan  ·            ·                   (col)  ·
+·          table        table39010@primary  ·      ·
+·          spans        ALL                 ·      ·

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1191,6 +1191,7 @@ func (ef *execFactory) ConstructExplain(
 			p.plan,
 			p.subqueryPlans,
 			p.postqueryPlans,
+			stmtType,
 		)
 
 	default:

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -902,7 +902,11 @@ func TestPGPreparedQuery(t *testing.T) {
 		}},
 		// #14238
 		{"EXPLAIN SELECT 1", []preparedQueryTest{
-			baseTest.SetArgs().Results("values", "", "").Results("", "size", "1 column, 1 row"),
+			baseTest.SetArgs().
+				Results("", "distributed", "false").
+				Results("", "vectorized", "false").
+				Results("values", "", "").
+				Results("", "size", "1 column, 1 row"),
 		}},
 		// #14245
 		{"SELECT 1::oid = $1", []preparedQueryTest{

--- a/pkg/sql/table_ref_test.go
+++ b/pkg/sql/table_ref_test.go
@@ -115,7 +115,7 @@ ALTER TABLE test.t DROP COLUMN xx;
 
 	for i, d := range testData {
 		t.Run(d.tableExpr, func(t *testing.T) {
-			sql := `SELECT columns FROM [EXPLAIN(VERBOSE) SELECT * FROM ` + d.tableExpr + "]"
+			sql := `SELECT columns FROM [EXPLAIN(VERBOSE) SELECT * FROM ` + d.tableExpr + "] WHERE columns != ''"
 			var columns string
 			if err := db.QueryRow(sql).Scan(&columns); err != nil {
 				if d.expectedError != "" {


### PR DESCRIPTION
Given the session settings and the logical plan, EXPLAIN will now show
if the plan will be executed with the vectorized engine and if the plan
will be distributed across nodes.

This information appears as two new rows in the output. The output looks
like this:

```
                 tree                 |         field         |                                              description
+-------------------------------------+-----------------------+-------------------------------------------------------------------------------------------------------+
                                      | distributed           | true
                                      | vectorized            | false
  sort                                |                       |
   │                                  | order                 | +l_shipmode
   └── group                          |                       |
        │                             | aggregate 0           | l_shipmode
        │                             | aggregate 1           | sum(column26)
        │                             | aggregate 2           | sum(column28)
        │                             | group by              | l_shipmode
        └── render                    |                       |
             └── lookup-join          |                       |
                  │                   | table                 | orders@primary
                  │                   | type                  | inner
                  │                   | equality              | (l_orderkey) = (o_orderkey)
                  │                   | equality cols are key |
                  └── filter          |                       |
                       │              | filter                | ((l_shipmode IN ('MAIL', 'SHIP')) AND (l_commitdate < l_receiptdate)) AND (l_shipdate < l_commitdate)
                       └── index-join |                       |
                            │         | table                 | lineitem@primary
                            └── scan  |                       |
                                      | table                 | lineitem@l_rd
                                      | spans                 | /8766-/9131
```

closes #39523

Release justification: This UX is important for users to be able to
understand when the new vectorized engine being released in 19.2 is
getting used.

Release note (sql change): EXPLAIN now has additional output that
shows if a query will run with the vectorized execution engine,
and if the query will be distributed across nodes.