### PR TITLE
exec: add nulls injection test to runTests harness

### DIFF
--- a/pkg/sql/exec/and_test.go
+++ b/pkg/sql/exec/and_test.go
@@ -18,8 +18,9 @@ import (
 
 func TestAndOp(t *testing.T) {
 	tcs := []struct {
-		tuples   []tuple
-		expected []tuple
+		tuples                []tuple
+		expected              []tuple
+		skipAllNullsInjection bool
 	}{
 		// All variations of pairs separately first.
 		{
@@ -45,10 +46,14 @@ func TestAndOp(t *testing.T) {
 		{
 			tuples:   tuples{{true, nil}},
 			expected: tuples{{nil}},
+			// The case of {nil, nil} is explicitly tested below.
+			skipAllNullsInjection: true,
 		},
 		{
 			tuples:   tuples{{nil, true}},
 			expected: tuples{{nil}},
+			// The case of {nil, nil} is explicitly tested below.
+			skipAllNullsInjection: true,
 		},
 		{
 			tuples:   tuples{{nil, false}},
@@ -75,7 +80,15 @@ func TestAndOp(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		runTestsWithTyps(
+		var runner testRunner
+		if tc.skipAllNullsInjection {
+			// We're omitting all nulls injection test. See comments for each such
+			// test case.
+			runner = runTestsWithoutAllNullsInjection
+		} else {
+			runner = runTestsWithTyps
+		}
+		runner(
 			t,
 			[]tuples{tc.tuples},
 			[]coltypes.T{coltypes.Bool, coltypes.Bool},

--- a/pkg/sql/exec/count_test.go
+++ b/pkg/sql/exec/count_test.go
@@ -27,7 +27,9 @@ func TestCount(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
-		runTests(t, []tuples{tc.tuples}, tc.expected, orderedVerifier, []int{0}, func(input []Operator) (Operator, error) {
+		// The tuples consisting of all nulls still count as separate rows, so if
+		// we replace all values with nulls, we should get the same output.
+		runTestsWithoutAllNullsInjection(t, []tuples{tc.tuples}, nil /* typs */, tc.expected, orderedVerifier, []int{0}, func(input []Operator) (Operator, error) {
 			return NewCountOp(input[0]), nil
 		})
 	}

--- a/pkg/sql/exec/limit_test.go
+++ b/pkg/sql/exec/limit_test.go
@@ -56,7 +56,9 @@ func TestLimit(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		runTests(t, []tuples{tc.tuples}, tc.expected, orderedVerifier, []int{0}, func(input []Operator) (Operator, error) {
+		// The tuples consisting of all nulls still count as separate rows, so if
+		// we replace all values with nulls, we should get the same output.
+		runTestsWithoutAllNullsInjection(t, []tuples{tc.tuples}, nil /* typs */, tc.expected, orderedVerifier, []int{0}, func(input []Operator) (Operator, error) {
 			return NewLimitOp(input[0], tc.limit), nil
 		})
 	}

--- a/pkg/sql/exec/mergejoiner_test.go
+++ b/pkg/sql/exec/mergejoiner_test.go
@@ -29,21 +29,22 @@ type mjTestInitializer interface {
 // TODO(yuzefovich): add unit tests for cases with ON expression.
 
 type mjTestCase struct {
-	description     string
-	joinType        sqlbase.JoinType
-	leftTuples      []tuple
-	leftTypes       []coltypes.T
-	leftOutCols     []uint32
-	leftEqCols      []uint32
-	leftDirections  []distsqlpb.Ordering_Column_Direction
-	rightTuples     []tuple
-	rightTypes      []coltypes.T
-	rightOutCols    []uint32
-	rightEqCols     []uint32
-	rightDirections []distsqlpb.Ordering_Column_Direction
-	expected        []tuple
-	expectedOutCols []int
-	outputBatchSize uint16
+	description           string
+	joinType              sqlbase.JoinType
+	leftTuples            []tuple
+	leftTypes             []coltypes.T
+	leftOutCols           []uint32
+	leftEqCols            []uint32
+	leftDirections        []distsqlpb.Ordering_Column_Direction
+	rightTuples           []tuple
+	rightTypes            []coltypes.T
+	rightOutCols          []uint32
+	rightEqCols           []uint32
+	rightDirections       []distsqlpb.Ordering_Column_Direction
+	expected              []tuple
+	expectedOutCols       []int
+	outputBatchSize       uint16
+	skipAllNullsInjection bool
 }
 
 func (tc *mjTestCase) Init() {
@@ -1319,6 +1320,9 @@ func TestMergeJoiner(t *testing.T) {
 			rightEqCols:     []uint32{0, 1, 2},
 			expected:        tuples{},
 			expectedOutCols: []int{0, 1, 2},
+			// The expected output here is empty, so will it be during the all nulls
+			// injection, so we want to skip that.
+			skipAllNullsInjection: true,
 		},
 		{
 			description:     "3 equality column LEFT SEMI JOIN test with nulls mixed ordering",
@@ -1335,6 +1339,9 @@ func TestMergeJoiner(t *testing.T) {
 			rightEqCols:     []uint32{1, 2, 0},
 			expected:        tuples{},
 			expectedOutCols: []int{0, 1, 2},
+			// The expected output here is empty, so will it be during the all nulls
+			// injection, so we want to skip that.
+			skipAllNullsInjection: true,
 		},
 		{
 			description:     "single column DESC with nulls on the left LEFT SEMI JOIN",
@@ -1536,7 +1543,15 @@ func TestMergeJoiner(t *testing.T) {
 			return verify()
 		}
 
-		runTests(t, []tuples{tc.leftTuples, tc.rightTuples}, tc.expected, mergeJoinVerifier,
+		var runner testRunner
+		if tc.skipAllNullsInjection {
+			// We're omitting all nulls injection test. See comments for each such
+			// test case.
+			runner = runTestsWithoutAllNullsInjection
+		} else {
+			runner = runTestsWithTyps
+		}
+		runner(t, []tuples{tc.leftTuples, tc.rightTuples}, nil /* typs */, tc.expected, mergeJoinVerifier,
 			tc.expectedOutCols, func(input []Operator) (Operator, error) {
 				return NewMergeJoinOp(tc.joinType, input[0], input[1], tc.leftOutCols,
 					tc.rightOutCols, tc.leftTypes, tc.rightTypes, lOrderings, rOrderings,

--- a/pkg/sql/exec/offset_test.go
+++ b/pkg/sql/exec/offset_test.go
@@ -52,7 +52,9 @@ func TestOffset(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		runTests(t, []tuples{tc.tuples}, tc.expected, unorderedVerifier, []int{0}, func(input []Operator) (Operator, error) {
+		// The tuples consisting of all nulls still count as separate rows, so if
+		// we replace all values with nulls, we should get the same output.
+		runTestsWithoutAllNullsInjection(t, []tuples{tc.tuples}, nil /* typs */, tc.expected, unorderedVerifier, []int{0}, func(input []Operator) (Operator, error) {
 			return NewOffsetOp(input[0], tc.offset), nil
 		})
 	}

--- a/pkg/sql/exec/simple_project_test.go
+++ b/pkg/sql/exec/simple_project_test.go
@@ -64,8 +64,9 @@ func TestSimpleProjectOp(t *testing.T) {
 		})
 	}
 
-	// Empty projection.
-	runTests(t, []tuples{{{1, 2, 3}, {1, 2, 3}}}, tuples{{}, {}}, orderedVerifier, []int{},
+	// Empty projection. The all nulls injection test case will also return
+	// nothing.
+	runTestsWithoutAllNullsInjection(t, []tuples{{{1, 2, 3}, {1, 2, 3}}}, nil /* typs */, tuples{{}, {}}, orderedVerifier, []int{},
 		func(input []Operator) (Operator, error) {
 			return NewSimpleProjectOp(input[0], 3 /* numInputCols */, nil), nil
 		})


### PR DESCRIPTION
This commit adds a nulls injection test to always run with runTests.
The idea is that it runs the operator on two inputs: the original
input tuples that are passed into the test, and only null tuples
(i.e. of the same length and of the same count with only nil values).
Then, the expectation is that unless the original input tuples already
consist only of null values, the output should be different.

This assumption is incorrect for some operators and in some test cases
for other operators. In such cases, runTestsWithoutNullsInjection needs
to be used and the justification needs to be provided for doing so.

Justification: Category 1: Non-production code changes.

Release note: None