### PR TITLE
opt: inline single-use WithExprs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/apply_join
+++ b/pkg/sql/logictest/testdata/logic_test/apply_join
@@ -307,7 +307,9 @@ WHERE
           SELECT
             COALESCE(
               tab_9962._string,
-              tab_9963._string
+              tab_9963._string,
+              (SELECT * FROM with_2063),
+              (SELECT * FROM with_2063)
             )
         )
     )

--- a/pkg/sql/logictest/testdata/logic_test/with
+++ b/pkg/sql/logictest/testdata/logic_test/with
@@ -206,7 +206,7 @@ CREATE TABLE ab (a INT PRIMARY KEY, b INT)
 statement ok
 INSERT INTO ab VALUES (1, 2), (3, 4), (5, 6)
 
-query I
+query I rowsort
 WITH a AS (SELECT a FROM ab ORDER BY b) SELECT * FROM a
 ----
 1

--- a/pkg/sql/opt/exec/execbuilder/testdata/with
+++ b/pkg/sql/opt/exec/execbuilder/testdata/with
@@ -31,18 +31,11 @@ query TTTTT
 EXPLAIN (VERBOSE)
   WITH t AS (SELECT a FROM y) SELECT * FROM t
 ----
-root                   ·             ·                (a)  ·
- ├── scan buffer node  ·             ·                (a)  ·
- │                     label         buffer 1 (t)     ·    ·
- └── subquery          ·             ·                (a)  ·
-      │                id            @S1              ·    ·
-      │                original sql  SELECT a FROM y  ·    ·
-      │                exec mode     all rows         ·    ·
-      └── buffer node  ·             ·                (a)  ·
-           │           label         buffer 1 (t)     ·    ·
-           └── scan    ·             ·                (a)  ·
-·                      table         y@primary        ·    ·
-·                      spans         ALL              ·    ·
+render     ·         ·          (a)  ·
+ │         render 0  a          ·    ·
+ └── scan  ·         ·          (a)  ·
+·          table     y@primary  ·    ·
+·          spans     ALL        ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE)
@@ -83,27 +76,11 @@ EXPLAIN (VERBOSE)
   FROM
     w, table39010
 ----
-root                                  ·             ·                                  (col)                          ·
- ├── render                           ·             ·                                  (col)                          ·
- │    │                               render 0      col                                ·                              ·
- │    └── hash-join                   ·             ·                                  ("?column?", "?column?", col)  ·
- │         │                          type          cross                              ·                              ·
- │         ├── render                 ·             ·                                  ("?column?", "?column?")       ·
- │         │    │                     render 0      "?column?"                         ·                              ·
- │         │    │                     render 1      "?column?"                         ·                              ·
- │         │    └── scan buffer node  ·             ·                                  ("?column?")                   ·
- │         │                          label         buffer 1 (w)                       ·                              ·
- │         └── scan                   ·             ·                                  (col)                          ·
- │                                    table         table39010@primary                 ·                              ·
- │                                    spans         ALL                                ·                              ·
- └── subquery                         ·             ·                                  (col)                          ·
-      │                               id            @S1                                ·                              ·
-      │                               original sql  SELECT NULL, NULL FROM table39010  ·                              ·
-      │                               exec mode     all rows                           ·                              ·
-      └── buffer node                 ·             ·                                  ("?column?")                   ·
-           │                          label         buffer 1 (w)                       ·                              ·
-           └── render                 ·             ·                                  ("?column?")                   ·
-                │                     render 0      NULL                               ·                              ·
-                └── scan              ·             ·                                  ()                             ·
-·                                     table         table39010@primary                 ·                              ·
-·                                     spans         ALL                                ·                              ·
+hash-join  ·      ·                   (col)  ·
+ │         type   cross               ·      ·
+ ├── scan  ·      ·                   ()     ·
+ │         table  table39010@primary  ·      ·
+ │         spans  ALL                 ·      ·
+ └── scan  ·      ·                   (col)  ·
+·          table  table39010@primary  ·      ·
+·          spans  ALL                 ·      ·

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -566,6 +566,10 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		if r.JoinSize > 1 {
 			tp.Childf("join-size: %d", r.JoinSize)
 		}
+		if len(relational.Shared.Rule.WithUses) > 0 {
+			// Go map
+			tp.Childf("cte-uses: %v", relational.Shared.Rule.WithUses)
+		}
 	}
 
 	switch t := e.(type) {

--- a/pkg/sql/opt/memo/testdata/logprops/with
+++ b/pkg/sql/opt/memo/testdata/logprops/with
@@ -9,6 +9,7 @@ with &1 (foo)
  ├── columns: x:3(int!null) y:4(int)
  ├── key: (3)
  ├── fd: (3)-->(4)
+ ├── cte-uses: map[1:1]
  ├── scan xy
  │    ├── columns: xy.x:1(int!null) xy.y:2(int)
  │    ├── key: (1)
@@ -21,7 +22,8 @@ with &1 (foo)
       │    ├──  xy.x:1(int) => x:3(int)
       │    └──  xy.y:2(int) => y:4(int)
       ├── key: (3)
-      └── fd: (3)-->(4)
+      ├── fd: (3)-->(4)
+      └── cte-uses: map[1:1]
 
 # Side effects should be propagated up to the top-level from the Binding side
 # of a WITH.
@@ -68,6 +70,7 @@ with &1 (foo)
  ├── side-effects
  ├── key: ()
  ├── fd: ()-->(3)
+ ├── cte-uses: map[1:1]
  ├── project
  │    ├── columns: "?column?":1(int!null)
  │    ├── cardinality: [1 - 1]
@@ -87,13 +90,15 @@ with &1 (foo)
       ├── key: ()
       ├── fd: ()-->(3)
       ├── prune: (3)
+      ├── cte-uses: map[1:1]
       ├── with-scan &1 (foo)
       │    ├── columns: "?column?":2(int!null)
       │    ├── mapping:
       │    │    └──  "?column?":1(int) => "?column?":2(int)
       │    ├── cardinality: [1 - 1]
       │    ├── key: ()
-      │    └── fd: ()-->(2)
+      │    ├── fd: ()-->(2)
+      │    └── cte-uses: map[1:1]
       └── projections
            └── div [type=decimal, side-effects]
                 ├── const: 1 [type=int]
@@ -108,6 +113,7 @@ with &1 (foo)
  ├── has-placeholder
  ├── key: ()
  ├── fd: ()-->(3)
+ ├── cte-uses: map[1:1]
  ├── project
  │    ├── columns: int8:1(int)
  │    ├── cardinality: [1 - 1]
@@ -128,13 +134,15 @@ with &1 (foo)
       ├── key: ()
       ├── fd: ()-->(3)
       ├── prune: (3)
+      ├── cte-uses: map[1:1]
       ├── with-scan &1 (foo)
       │    ├── columns: int8:2(int)
       │    ├── mapping:
       │    │    └──  int8:1(int) => int8:2(int)
       │    ├── cardinality: [1 - 1]
       │    ├── key: ()
-      │    └── fd: ()-->(2)
+      │    ├── fd: ()-->(2)
+      │    └── cte-uses: map[1:1]
       └── projections
            └── const: 1 [type=int]
 
@@ -163,6 +171,7 @@ inner-join-apply
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(3)
+ │    ├── cte-uses: map[1:1]
  │    ├── project
  │    │    ├── columns: "?column?":2(int)
  │    │    ├── outer: (1)
@@ -184,5 +193,6 @@ inner-join-apply
  │         │    └──  "?column?":2(int) => "?column?":3(int)
  │         ├── cardinality: [1 - 1]
  │         ├── key: ()
- │         └── fd: ()-->(3)
+ │         ├── fd: ()-->(3)
+ │         └── cte-uses: map[1:1]
  └── filters (true)

--- a/pkg/sql/opt/memo/testdata/stats/groupby
+++ b/pkg/sql/opt/memo/testdata/stats/groupby
@@ -465,54 +465,50 @@ WITH q (a, b) AS (SELECT * FROM (VALUES (true, NULL), (false, NULL), (true, 5)))
 GROUP BY q.b
   HAVING bool_or(q.a)
 ----
-with &1 (q)
+project
  ├── columns: "?column?":6(int!null)
  ├── cardinality: [0 - 3]
  ├── stats: [rows=0.27]
  ├── fd: ()-->(6)
- ├── values
- │    ├── columns: column1:1(bool!null) column2:2(int)
- │    ├── cardinality: [3 - 3]
- │    ├── stats: [rows=3, distinct(1)=0.3, null(1)=0, distinct(2)=0.3, null(2)=0.03]
- │    ├── (true, NULL) [type=tuple{bool, int}]
- │    ├── (false, NULL) [type=tuple{bool, int}]
- │    └── (true, 5) [type=tuple{bool, int}]
- └── project
-      ├── columns: "?column?":6(int!null)
-      ├── cardinality: [0 - 3]
-      ├── stats: [rows=0.27]
-      ├── fd: ()-->(6)
-      ├── select
-      │    ├── columns: b:4(int) bool_or:5(bool!null)
-      │    ├── cardinality: [0 - 3]
-      │    ├── stats: [rows=0.27, distinct(5)=0.27, null(5)=0]
-      │    ├── key: (4)
-      │    ├── fd: ()-->(5)
-      │    ├── group-by
-      │    │    ├── columns: b:4(int) bool_or:5(bool)
-      │    │    ├── grouping columns: b:4(int)
-      │    │    ├── cardinality: [0 - 3]
-      │    │    ├── stats: [rows=0.3, distinct(4)=0.3, null(4)=0.03, distinct(5)=0.3, null(5)=0.03]
-      │    │    ├── key: (4)
-      │    │    ├── fd: (4)-->(5)
-      │    │    ├── select
-      │    │    │    ├── columns: a:3(bool!null) b:4(int)
-      │    │    │    ├── cardinality: [0 - 3]
-      │    │    │    ├── stats: [rows=3, distinct(3)=0.3, null(3)=0, distinct(4)=0.3, null(4)=0.03]
-      │    │    │    ├── fd: ()-->(3)
-      │    │    │    ├── with-scan &1 (q)
-      │    │    │    │    ├── columns: a:3(bool!null) b:4(int)
-      │    │    │    │    ├── mapping:
-      │    │    │    │    │    ├──  column1:1(bool) => a:3(bool)
-      │    │    │    │    │    └──  column2:2(int) => b:4(int)
-      │    │    │    │    ├── cardinality: [3 - 3]
-      │    │    │    │    └── stats: [rows=3, distinct(3)=0.3, null(3)=0, distinct(4)=0.3, null(4)=0.03]
-      │    │    │    └── filters
-      │    │    │         └── variable: a [type=bool, outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
-      │    │    └── aggregations
-      │    │         └── bool-or [type=bool, outer=(3)]
-      │    │              └── variable: a [type=bool]
-      │    └── filters
-      │         └── variable: bool_or [type=bool, outer=(5), constraints=(/5: [/true - /true]; tight), fd=()-->(5)]
-      └── projections
-           └── const: 1 [type=int]
+ ├── select
+ │    ├── columns: b:4(int) bool_or:5(bool!null)
+ │    ├── cardinality: [0 - 3]
+ │    ├── stats: [rows=0.27, distinct(5)=0.27, null(5)=0]
+ │    ├── key: (4)
+ │    ├── fd: ()-->(5)
+ │    ├── group-by
+ │    │    ├── columns: b:4(int) bool_or:5(bool)
+ │    │    ├── grouping columns: b:4(int)
+ │    │    ├── cardinality: [0 - 3]
+ │    │    ├── stats: [rows=0.3, distinct(4)=0.3, null(4)=0.03, distinct(5)=0.3, null(5)=0.03]
+ │    │    ├── key: (4)
+ │    │    ├── fd: (4)-->(5)
+ │    │    ├── project
+ │    │    │    ├── columns: a:3(bool) b:4(int)
+ │    │    │    ├── cardinality: [0 - 3]
+ │    │    │    ├── stats: [rows=3, distinct(4)=0.3, null(4)=0.03]
+ │    │    │    ├── fd: ()-->(3)
+ │    │    │    ├── select
+ │    │    │    │    ├── columns: column1:1(bool!null) column2:2(int)
+ │    │    │    │    ├── cardinality: [0 - 3]
+ │    │    │    │    ├── stats: [rows=3, distinct(1)=0.3, null(1)=0, distinct(2)=0.3, null(2)=0.03]
+ │    │    │    │    ├── fd: ()-->(1)
+ │    │    │    │    ├── values
+ │    │    │    │    │    ├── columns: column1:1(bool!null) column2:2(int)
+ │    │    │    │    │    ├── cardinality: [3 - 3]
+ │    │    │    │    │    ├── stats: [rows=3, distinct(1)=0.3, null(1)=0, distinct(2)=0.3, null(2)=0.03]
+ │    │    │    │    │    ├── (true, NULL) [type=tuple{bool, int}]
+ │    │    │    │    │    ├── (false, NULL) [type=tuple{bool, int}]
+ │    │    │    │    │    └── (true, 5) [type=tuple{bool, int}]
+ │    │    │    │    └── filters
+ │    │    │    │         └── variable: column1 [type=bool, outer=(1), constraints=(/1: [/true - /true]; tight), fd=()-->(1)]
+ │    │    │    └── projections
+ │    │    │         ├── variable: column1 [type=bool, outer=(1)]
+ │    │    │         └── variable: column2 [type=int, outer=(2)]
+ │    │    └── aggregations
+ │    │         └── bool-or [type=bool, outer=(3)]
+ │    │              └── variable: a [type=bool]
+ │    └── filters
+ │         └── variable: bool_or [type=bool, outer=(5), constraints=(/5: [/true - /true]; tight), fd=()-->(5)]
+ └── projections
+      └── const: 1 [type=int]

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -540,44 +540,34 @@ FROM
 WHERE
   subq.col1;
 ----
-with &1 (subq)
+project
  ├── columns: "?column?":26(int!null)
- ├── stats: [rows=165000]
+ ├── stats: [rows=0.95099005]
  ├── fd: ()-->(26)
- ├── project
- │    ├── columns: col1:23(bool) tab1.g:18(int4!null)
- │    ├── stats: [rows=333333.333, distinct(18)=33333.3333, null(18)=0, distinct(23)=2, null(23)=3333.33333]
- │    ├── inner-join (hash)
- │    │    ├── columns: tab0.e:5(varchar) tab0.f:6("char") tab0.h:8(varchar) tab0.j:10(float!null) tab1.e:16(varchar) tab1.f:17("char") tab1.g:18(int4!null) tab1.j:21(float!null)
- │    │    ├── stats: [rows=333333.333, distinct(10)=100, null(10)=0, distinct(18)=100, null(18)=0, distinct(21)=100, null(21)=0]
- │    │    ├── scan tab0
- │    │    │    ├── columns: tab0.e:5(varchar) tab0.f:6("char") tab0.h:8(varchar) tab0.j:10(float!null)
- │    │    │    └── stats: [rows=1000, distinct(10)=100, null(10)=0]
- │    │    ├── scan tab1
- │    │    │    ├── columns: tab1.e:16(varchar) tab1.f:17("char") tab1.g:18(int4!null) tab1.j:21(float!null)
- │    │    │    └── stats: [rows=1000, distinct(18)=100, null(18)=0, distinct(21)=100, null(21)=0]
- │    │    └── filters
- │    │         └── tab0.j IN (tab1.j,) [type=bool, outer=(10,21)]
- │    └── projections
- │         └── CASE WHEN ilike_escape(regexp_replace(tab0.h, tab1.e, tab0.f, tab0.e::STRING), tab1.f, '') THEN true ELSE false END [type=bool, outer=(5,6,8,16,17)]
- └── project
-      ├── columns: "?column?":26(int!null)
-      ├── stats: [rows=165000]
-      ├── fd: ()-->(26)
-      ├── select
-      │    ├── columns: col0:24(int4!null) col1:25(bool!null)
-      │    ├── stats: [rows=165000, distinct(24)=33300.7812, null(24)=0, distinct(25)=1, null(25)=0]
-      │    ├── fd: ()-->(25)
-      │    ├── with-scan &1 (subq)
-      │    │    ├── columns: col0:24(int4!null) col1:25(bool)
-      │    │    ├── mapping:
-      │    │    │    ├──  tab1.g:18(int4) => col0:24(int4)
-      │    │    │    └──  col1:23(bool) => col1:25(bool)
-      │    │    └── stats: [rows=333333.333, distinct(24)=33333.3333, null(24)=0, distinct(25)=2, null(25)=3333.33333]
-      │    └── filters
-      │         └── variable: col1 [type=bool, outer=(25), constraints=(/25: [/true - /true]; tight), fd=()-->(25)]
-      └── projections
-           └── const: 1 [type=int]
+ ├── select
+ │    ├── columns: col1:25(bool!null)
+ │    ├── stats: [rows=0.95099005, distinct(25)=0.95099005, null(25)=0]
+ │    ├── fd: ()-->(25)
+ │    ├── project
+ │    │    ├── columns: col1:25(bool)
+ │    │    ├── stats: [rows=333333.333, distinct(25)=333333.333, null(25)=16336.65]
+ │    │    ├── inner-join (hash)
+ │    │    │    ├── columns: tab0.e:5(varchar) tab0.f:6("char") tab0.h:8(varchar) tab0.j:10(float!null) tab1.e:16(varchar) tab1.f:17("char") tab1.j:21(float!null)
+ │    │    │    ├── stats: [rows=333333.333, distinct(10)=100, null(10)=0, distinct(21)=100, null(21)=0, distinct(5,6,8,16,17)=333333.333, null(5,6,8,16,17)=16336.65]
+ │    │    │    ├── scan tab0
+ │    │    │    │    ├── columns: tab0.e:5(varchar) tab0.f:6("char") tab0.h:8(varchar) tab0.j:10(float!null)
+ │    │    │    │    └── stats: [rows=1000, distinct(10)=100, null(10)=0, distinct(5,6,8)=1000, null(5,6,8)=29.701]
+ │    │    │    ├── scan tab1
+ │    │    │    │    ├── columns: tab1.e:16(varchar) tab1.f:17("char") tab1.j:21(float!null)
+ │    │    │    │    └── stats: [rows=1000, distinct(21)=100, null(21)=0, distinct(16,17)=1000, null(16,17)=19.9]
+ │    │    │    └── filters
+ │    │    │         └── tab0.j IN (tab1.j,) [type=bool, outer=(10,21)]
+ │    │    └── projections
+ │    │         └── CASE WHEN ilike_escape(regexp_replace(tab0.h, tab1.e, tab0.f, tab0.e::STRING), tab1.f, '') THEN true ELSE false END [type=bool, outer=(5,6,8,16,17)]
+ │    └── filters
+ │         └── variable: col1 [type=bool, outer=(25), constraints=(/25: [/true - /true]; tight), fd=()-->(25)]
+ └── projections
+      └── const: 1 [type=int]
 
 # ---------------------
 # Tests with Histograms

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -1367,7 +1367,7 @@ ALTER TABLE t38344 INJECT STATISTICS '[
 ]'
 ----
 
-norm
+norm disable=InlineWith
 WITH t(x) AS (
   SELECT (t1.x::int << 5533)::bool OR t2.x  AS x
   FROM t38344 AS t1 LEFT JOIN t38344 AS t2 ON true

--- a/pkg/sql/opt/memo/testdata/stats/with
+++ b/pkg/sql/opt/memo/testdata/stats/with
@@ -31,7 +31,7 @@ ALTER TABLE a INJECT STATISTICS '[
 ]'
 ----
 
-build colstat=4 colstat=5 colstat=6
+build colstat=4 colstat=5 colstat=6 disable=InlineWith
 WITH foo AS (SELECT * FROM a) SELECT * FROM foo
 ----
 with &1 (foo)
@@ -55,7 +55,7 @@ with &1 (foo)
       └── fd: (4)-->(5,6)
 
 # Regression test for #40296.
-opt
+opt disable=InlineWith
 WITH
 	t0 AS ((VALUES (0, 0:::OID, NULL, '')) UNION (VALUES (NULL, 0:::OID,'1970-09-08'::DATE, NULL)))
 SELECT

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -1739,3 +1739,101 @@ func (c *CustomFuncs) CanAddConstInts(first tree.Datum, second tree.Datum) bool 
 	_, ok := arith.AddWithOverflow(firstVal, secondVal)
 	return ok
 }
+
+// ----------------------------------------------------------------------
+//
+// With Rules
+//   Custom match and replace functions used with with.opt rules.
+//
+// ----------------------------------------------------------------------
+
+// CanInlineWith returns whether or not it's valid to inline binding in expr.
+// This is the case when:
+// 1. binding has no side-effects (because once it's inlined, there's no
+//    guarantee it will be executed fully), and
+// 2. binding is referenced at most once in expr.
+func (c *CustomFuncs) CanInlineWith(binding, expr memo.RelExpr, private *memo.WithPrivate) bool {
+	if binding.Relational().CanHaveSideEffects {
+		return false
+	}
+	return c.WithUses(expr)[private.ID] <= 1
+}
+
+// InlineWith replaces all references to the With expression in input (via
+// WithScans) with its definition.
+func (c *CustomFuncs) InlineWith(binding, input memo.RelExpr, priv *memo.WithPrivate) memo.RelExpr {
+	var replace ReplaceFunc
+	replace = func(nd opt.Expr) opt.Expr {
+		switch t := nd.(type) {
+		case *memo.WithScanExpr:
+			if t.ID == priv.ID {
+				// TODO(justin): it might be worth carefully walking the tree and
+				// renaming variables as we do this replacement so that this projection
+				// is unnecessary (assuming there's at most one reference to the
+				// WithScan, which might be false if we heuristically inline multiple
+				// times in the future).
+				projections := make(memo.ProjectionsExpr, len(t.InCols))
+				for i := range t.InCols {
+					projections[i] = memo.ProjectionsItem{
+						Element:    c.f.ConstructVariable(t.InCols[i]),
+						ColPrivate: memo.ColPrivate{Col: t.OutCols[i]},
+					}
+				}
+				return c.f.ConstructProject(binding, projections, opt.ColSet{})
+			}
+			// TODO(justin): should apply joins block inlining because they can lead
+			// to expressions being executed multiple times?
+		}
+		return c.f.Replace(nd, replace)
+	}
+
+	return replace(input).(memo.RelExpr)
+}
+
+// WithUses returns a map mapping WithIDs to the number of times a given With
+// expression is referenced in the given expression.
+func (c *CustomFuncs) WithUses(r opt.Expr) map[opt.WithID]int {
+	switch e := r.(type) {
+	case memo.RelExpr:
+		relProps := e.Relational()
+		if !relProps.IsAvailable(props.WithUses) {
+			relProps.SetAvailable(props.WithUses)
+			relProps.Shared.Rule.WithUses = c.deriveWithUses(r)
+		}
+		return relProps.Shared.Rule.WithUses
+
+	case memo.ScalarPropsExpr:
+		scalarProps := e.ScalarProps(c.mem)
+
+		// Lazily calculate and store the WithUses value.
+		if !scalarProps.IsAvailable(props.WithUses) {
+			scalarProps.Shared.Rule.WithUses = c.deriveWithUses(r)
+			scalarProps.SetAvailable(props.WithUses)
+		}
+		return scalarProps.Shared.Rule.WithUses
+
+	default:
+		return c.deriveWithUses(r)
+	}
+}
+
+// deriveWithUses computes the number of times each WithScan is referenced. It's
+// used to decide if we can inline a With or not.
+func (c *CustomFuncs) deriveWithUses(r opt.Expr) map[opt.WithID]int {
+	var result map[opt.WithID]int
+	switch e := r.(type) {
+	case *memo.WithScanExpr:
+		result = map[opt.WithID]int{e.ID: 1}
+	default:
+		for i, n := 0, r.ChildCount(); i < n; i++ {
+			for id, useCount := range c.WithUses(r.Child(i)) {
+				if result == nil {
+					result = make(map[opt.WithID]int)
+				}
+				result[id] = result[id] + useCount
+			}
+		}
+	}
+
+	return result
+}

--- a/pkg/sql/opt/norm/rules/with.opt
+++ b/pkg/sql/opt/norm/rules/with.opt
@@ -1,0 +1,18 @@
+# =============================================================================
+# with.opt contains normalization rules for the With operator.
+# =============================================================================
+
+# InlineWith replaces use of a With which is referenced at most one time with
+# the contents of the With itself.
+[InlineWith, Normalize]
+(With
+    $binding:*
+    $input:*
+    $withPrivate:* & (CanInlineWith $binding $input $withPrivate)
+)
+=>
+(InlineWith
+    $binding
+    $input
+    $withPrivate
+)

--- a/pkg/sql/opt/norm/testdata/rules/with
+++ b/pkg/sql/opt/norm/testdata/rules/with
@@ -1,0 +1,490 @@
+build format=show-all
+WITH foo AS (SELECT 1) (SELECT * FROM foo) UNION ALL (SELECT * FROM foo)
+----
+with &1 (foo)
+ ├── columns: "?column?":4(int!null)
+ ├── cardinality: [2 - 2]
+ ├── stats: [rows=2]
+ ├── cost: 0.11
+ ├── cte-uses: map[1:2]
+ ├── project
+ │    ├── columns: "?column?":1(int!null)
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1]
+ │    ├── cost: 0.05
+ │    ├── key: ()
+ │    ├── fd: ()-->(1)
+ │    ├── prune: (1)
+ │    ├── values
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── stats: [rows=1]
+ │    │    ├── cost: 0.02
+ │    │    ├── key: ()
+ │    │    └── tuple [type=tuple]
+ │    └── projections
+ │         └── const: 1 [type=int]
+ └── union-all
+      ├── columns: "?column?":4(int!null)
+      ├── left columns: "?column?":2(int)
+      ├── right columns: "?column?":3(int)
+      ├── cardinality: [2 - 2]
+      ├── stats: [rows=2]
+      ├── cost: 0.05
+      ├── cte-uses: map[1:2]
+      ├── with-scan &1 (foo)
+      │    ├── columns: "?column?":2(int!null)
+      │    ├── mapping:
+      │    │    └──  "?column?":1(int) => "?column?":2(int)
+      │    ├── cardinality: [1 - 1]
+      │    ├── stats: [rows=1]
+      │    ├── cost: 0.01
+      │    ├── key: ()
+      │    ├── fd: ()-->(2)
+      │    └── cte-uses: map[1:1]
+      └── with-scan &1 (foo)
+           ├── columns: "?column?":3(int!null)
+           ├── mapping:
+           │    └──  "?column?":1(int) => "?column?":3(int)
+           ├── cardinality: [1 - 1]
+           ├── stats: [rows=1]
+           ├── cost: 0.01
+           ├── key: ()
+           ├── fd: ()-->(3)
+           └── cte-uses: map[1:1]
+
+norm format=show-all expect=InlineWith
+WITH foo AS (SELECT 1) SELECT * FROM foo
+----
+values
+ ├── columns: "?column?":2(int!null)
+ ├── cardinality: [1 - 1]
+ ├── stats: [rows=1]
+ ├── cost: 0.02
+ ├── key: ()
+ ├── fd: ()-->(2)
+ ├── prune: (2)
+ └── tuple [type=tuple{int}]
+      └── const: 1 [type=int]
+
+norm format=show-all expect=InlineWith
+WITH foo AS (SELECT 1) SELECT * FROM foo CROSS JOIN (VALUES (2))
+----
+inner-join (hash)
+ ├── columns: "?column?":2(int!null) column1:3(int!null)
+ ├── cardinality: [1 - 1]
+ ├── stats: [rows=1]
+ ├── cost: 0.09
+ ├── key: ()
+ ├── fd: ()-->(2,3)
+ ├── prune: (2,3)
+ ├── values
+ │    ├── columns: "?column?":2(int!null)
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1]
+ │    ├── cost: 0.02
+ │    ├── key: ()
+ │    ├── fd: ()-->(2)
+ │    ├── prune: (2)
+ │    └── tuple [type=tuple{int}]
+ │         └── const: 1 [type=int]
+ ├── values
+ │    ├── columns: column1:3(int!null)
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1]
+ │    ├── cost: 0.02
+ │    ├── key: ()
+ │    ├── fd: ()-->(3)
+ │    ├── prune: (3)
+ │    └── tuple [type=tuple{int}]
+ │         └── const: 2 [type=int]
+ └── filters (true)
+
+norm expect=InlineWith
+WITH foo AS (SELECT 1), bar AS (SELECT 2) SELECT * FROM foo CROSS JOIN bar
+----
+inner-join (hash)
+ ├── columns: "?column?":3(int!null) "?column?":4(int!null)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(3,4)
+ ├── values
+ │    ├── columns: "?column?":3(int!null)
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(3)
+ │    └── (1,) [type=tuple{int}]
+ ├── values
+ │    ├── columns: "?column?":4(int!null)
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(4)
+ │    └── (2,) [type=tuple{int}]
+ └── filters (true)
+
+# Descend into scalar expressions.
+
+norm expect=InlineWith
+WITH foo AS (SELECT 1), bar AS (SELECT 2) SELECT (SELECT * FROM foo) + (SELECT * FROM bar)
+----
+values
+ ├── columns: "?column?":5(int)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(5)
+ └── tuple [type=tuple{int}]
+      └── plus [type=int]
+           ├── subquery [type=int]
+           │    └── values
+           │         ├── columns: "?column?":3(int!null)
+           │         ├── cardinality: [1 - 1]
+           │         ├── key: ()
+           │         ├── fd: ()-->(3)
+           │         └── (1,) [type=tuple{int}]
+           └── subquery [type=int]
+                └── values
+                     ├── columns: "?column?":4(int!null)
+                     ├── cardinality: [1 - 1]
+                     ├── key: ()
+                     ├── fd: ()-->(4)
+                     └── (2,) [type=tuple{int}]
+
+norm expect=InlineWith
+WITH foo AS (SELECT 1), bar AS (SELECT 2) SELECT (SELECT * FROM foo) + (SELECT * FROM bar) + (SELECT * FROM bar)
+----
+with &2 (bar)
+ ├── columns: "?column?":6(int)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(6)
+ ├── values
+ │    ├── columns: "?column?":2(int!null)
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(2)
+ │    └── (2,) [type=tuple{int}]
+ └── values
+      ├── columns: "?column?":6(int)
+      ├── cardinality: [1 - 1]
+      ├── key: ()
+      ├── fd: ()-->(6)
+      └── tuple [type=tuple{int}]
+           └── plus [type=int]
+                ├── plus [type=int]
+                │    ├── subquery [type=int]
+                │    │    └── values
+                │    │         ├── columns: "?column?":3(int!null)
+                │    │         ├── cardinality: [1 - 1]
+                │    │         ├── key: ()
+                │    │         ├── fd: ()-->(3)
+                │    │         └── (1,) [type=tuple{int}]
+                │    └── subquery [type=int]
+                │         └── with-scan &2 (bar)
+                │              ├── columns: "?column?":4(int!null)
+                │              ├── mapping:
+                │              │    └──  "?column?":2(int) => "?column?":4(int)
+                │              ├── cardinality: [1 - 1]
+                │              ├── key: ()
+                │              └── fd: ()-->(4)
+                └── subquery [type=int]
+                     └── with-scan &2 (bar)
+                          ├── columns: "?column?":5(int!null)
+                          ├── mapping:
+                          │    └──  "?column?":2(int) => "?column?":5(int)
+                          ├── cardinality: [1 - 1]
+                          ├── key: ()
+                          └── fd: ()-->(5)
+
+# We should inline foo, but not bar.
+norm expect=InlineWith
+WITH foo AS (SELECT 1), bar AS (SELECT 2) SELECT * FROM foo CROSS JOIN bar CROSS JOIN bar AS bar2
+----
+with &2 (bar)
+ ├── columns: "?column?":3(int!null) "?column?":4(int!null) "?column?":5(int!null)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(3-5)
+ ├── values
+ │    ├── columns: "?column?":2(int!null)
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(2)
+ │    └── (2,) [type=tuple{int}]
+ └── inner-join (hash)
+      ├── columns: "?column?":3(int!null) "?column?":4(int!null) "?column?":5(int!null)
+      ├── cardinality: [1 - 1]
+      ├── key: ()
+      ├── fd: ()-->(3-5)
+      ├── inner-join (hash)
+      │    ├── columns: "?column?":3(int!null) "?column?":4(int!null)
+      │    ├── cardinality: [1 - 1]
+      │    ├── key: ()
+      │    ├── fd: ()-->(3,4)
+      │    ├── values
+      │    │    ├── columns: "?column?":3(int!null)
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(3)
+      │    │    └── (1,) [type=tuple{int}]
+      │    ├── with-scan &2 (bar)
+      │    │    ├── columns: "?column?":4(int!null)
+      │    │    ├── mapping:
+      │    │    │    └──  "?column?":2(int) => "?column?":4(int)
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── key: ()
+      │    │    └── fd: ()-->(4)
+      │    └── filters (true)
+      ├── with-scan &2 (bar)
+      │    ├── columns: "?column?":5(int!null)
+      │    ├── mapping:
+      │    │    └──  "?column?":2(int) => "?column?":5(int)
+      │    ├── cardinality: [1 - 1]
+      │    ├── key: ()
+      │    └── fd: ()-->(5)
+      └── filters (true)
+
+norm format=show-all
+WITH
+    foo AS (SELECT 1), bar AS (SELECT 2)
+SELECT
+    *
+FROM
+    foo CROSS JOIN bar CROSS JOIN bar AS bar2 CROSS JOIN foo AS foo2
+----
+with &1 (foo)
+ ├── columns: "?column?":3(int!null) "?column?":4(int!null) "?column?":5(int!null) "?column?":6(int!null)
+ ├── cardinality: [1 - 1]
+ ├── stats: [rows=1]
+ ├── cost: 0.25
+ ├── key: ()
+ ├── fd: ()-->(3-6)
+ ├── cte-uses: map[1:2 2:2]
+ ├── values
+ │    ├── columns: "?column?":1(int!null)
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1]
+ │    ├── cost: 0.02
+ │    ├── key: ()
+ │    ├── fd: ()-->(1)
+ │    ├── prune: (1)
+ │    └── tuple [type=tuple{int}]
+ │         └── const: 1 [type=int]
+ └── with &2 (bar)
+      ├── columns: "?column?":3(int!null) "?column?":4(int!null) "?column?":5(int!null) "?column?":6(int!null)
+      ├── cardinality: [1 - 1]
+      ├── stats: [rows=1]
+      ├── cost: 0.22
+      ├── key: ()
+      ├── fd: ()-->(3-6)
+      ├── cte-uses: map[1:2 2:2]
+      ├── values
+      │    ├── columns: "?column?":2(int!null)
+      │    ├── cardinality: [1 - 1]
+      │    ├── stats: [rows=1]
+      │    ├── cost: 0.02
+      │    ├── key: ()
+      │    ├── fd: ()-->(2)
+      │    ├── prune: (2)
+      │    └── tuple [type=tuple{int}]
+      │         └── const: 2 [type=int]
+      └── inner-join (hash)
+           ├── columns: "?column?":3(int!null) "?column?":4(int!null) "?column?":5(int!null) "?column?":6(int!null)
+           ├── cardinality: [1 - 1]
+           ├── stats: [rows=1]
+           ├── cost: 0.19
+           ├── key: ()
+           ├── fd: ()-->(3-6)
+           ├── cte-uses: map[1:2 2:2]
+           ├── inner-join (hash)
+           │    ├── columns: "?column?":3(int!null) "?column?":4(int!null) "?column?":5(int!null)
+           │    ├── cardinality: [1 - 1]
+           │    ├── stats: [rows=1]
+           │    ├── cost: 0.13
+           │    ├── key: ()
+           │    ├── fd: ()-->(3-5)
+           │    ├── join-size: 3
+           │    ├── cte-uses: map[1:1 2:2]
+           │    ├── inner-join (hash)
+           │    │    ├── columns: "?column?":3(int!null) "?column?":4(int!null)
+           │    │    ├── cardinality: [1 - 1]
+           │    │    ├── stats: [rows=1]
+           │    │    ├── cost: 0.07
+           │    │    ├── key: ()
+           │    │    ├── fd: ()-->(3,4)
+           │    │    ├── join-size: 2
+           │    │    ├── cte-uses: map[1:1 2:1]
+           │    │    ├── with-scan &1 (foo)
+           │    │    │    ├── columns: "?column?":3(int!null)
+           │    │    │    ├── mapping:
+           │    │    │    │    └──  "?column?":1(int) => "?column?":3(int)
+           │    │    │    ├── cardinality: [1 - 1]
+           │    │    │    ├── stats: [rows=1]
+           │    │    │    ├── cost: 0.01
+           │    │    │    ├── key: ()
+           │    │    │    ├── fd: ()-->(3)
+           │    │    │    └── cte-uses: map[1:1]
+           │    │    ├── with-scan &2 (bar)
+           │    │    │    ├── columns: "?column?":4(int!null)
+           │    │    │    ├── mapping:
+           │    │    │    │    └──  "?column?":2(int) => "?column?":4(int)
+           │    │    │    ├── cardinality: [1 - 1]
+           │    │    │    ├── stats: [rows=1]
+           │    │    │    ├── cost: 0.01
+           │    │    │    ├── key: ()
+           │    │    │    ├── fd: ()-->(4)
+           │    │    │    └── cte-uses: map[2:1]
+           │    │    └── filters (true)
+           │    ├── with-scan &2 (bar)
+           │    │    ├── columns: "?column?":5(int!null)
+           │    │    ├── mapping:
+           │    │    │    └──  "?column?":2(int) => "?column?":5(int)
+           │    │    ├── cardinality: [1 - 1]
+           │    │    ├── stats: [rows=1]
+           │    │    ├── cost: 0.01
+           │    │    ├── key: ()
+           │    │    ├── fd: ()-->(5)
+           │    │    └── cte-uses: map[2:1]
+           │    └── filters (true)
+           ├── with-scan &1 (foo)
+           │    ├── columns: "?column?":6(int!null)
+           │    ├── mapping:
+           │    │    └──  "?column?":1(int) => "?column?":6(int)
+           │    ├── cardinality: [1 - 1]
+           │    ├── stats: [rows=1]
+           │    ├── cost: 0.01
+           │    ├── key: ()
+           │    ├── fd: ()-->(6)
+           │    └── cte-uses: map[1:1]
+           └── filters (true)
+
+exec-ddl
+CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON)
+----
+
+norm
+WITH foo AS (VALUES (1))
+SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM (VALUES (k), ((SELECT * FROM foo))) WHERE column1=k)
+----
+anti-join-apply
+ ├── columns: k:2(int!null) i:3(int) f:4(float) s:5(string) j:6(jsonb)
+ ├── key: (2)
+ ├── fd: (2)-->(3-6)
+ ├── scan a
+ │    ├── columns: k:2(int!null) i:3(int) f:4(float) s:5(string) j:6(jsonb)
+ │    ├── key: (2)
+ │    └── fd: (2)-->(3-6)
+ ├── values
+ │    ├── columns: column1:8(int)
+ │    ├── outer: (2)
+ │    ├── cardinality: [2 - 2]
+ │    ├── (k,) [type=tuple{int}]
+ │    └── tuple [type=tuple{int}]
+ │         └── subquery [type=int]
+ │              └── values
+ │                   ├── columns: column1:7(int!null)
+ │                   ├── cardinality: [1 - 1]
+ │                   ├── key: ()
+ │                   ├── fd: ()-->(7)
+ │                   └── (1,) [type=tuple{int}]
+ └── filters
+      └── column1 = k [type=bool, outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+
+# Don't inline side-effecting expressions.
+norm
+WITH foo AS (INSERT INTO a VALUES (1) RETURNING *) SELECT * FROM foo
+----
+with &1 (foo)
+ ├── columns: k:11(int!null) i:12(int) f:13(float) s:14(string) j:15(jsonb)
+ ├── cardinality: [1 - 1]
+ ├── side-effects, mutations
+ ├── key: ()
+ ├── fd: ()-->(11-15)
+ ├── insert a
+ │    ├── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ │    ├── insert-mapping:
+ │    │    ├──  column1:6 => a.k:1
+ │    │    ├──  column7:7 => a.i:2
+ │    │    ├──  column8:8 => a.f:3
+ │    │    ├──  column9:9 => a.s:4
+ │    │    └──  column10:10 => a.j:5
+ │    ├── cardinality: [1 - 1]
+ │    ├── side-effects, mutations
+ │    ├── key: ()
+ │    ├── fd: ()-->(1-5)
+ │    └── values
+ │         ├── columns: column1:6(int!null) column7:7(int) column8:8(float) column9:9(string) column10:10(jsonb)
+ │         ├── cardinality: [1 - 1]
+ │         ├── key: ()
+ │         ├── fd: ()-->(6-10)
+ │         └── (1, NULL, NULL, NULL, NULL) [type=tuple{int, int, float, string, jsonb}]
+ └── with-scan &1 (foo)
+      ├── columns: k:11(int!null) i:12(int) f:13(float) s:14(string) j:15(jsonb)
+      ├── mapping:
+      │    ├──  a.k:1(int) => k:11(int)
+      │    ├──  a.i:2(int) => i:12(int)
+      │    ├──  a.f:3(float) => f:13(float)
+      │    ├──  a.s:4(string) => s:14(string)
+      │    └──  a.j:5(jsonb) => j:15(jsonb)
+      ├── cardinality: [1 - 1]
+      ├── mutations
+      ├── key: ()
+      └── fd: ()-->(11-15)
+
+norm expect-not=InlineWith
+WITH foo AS (SELECT 1/0) SELECT * FROM foo
+----
+with &1 (foo)
+ ├── columns: "?column?":2(decimal)
+ ├── cardinality: [1 - 1]
+ ├── side-effects
+ ├── key: ()
+ ├── fd: ()-->(2)
+ ├── values
+ │    ├── columns: "?column?":1(decimal)
+ │    ├── cardinality: [1 - 1]
+ │    ├── side-effects
+ │    ├── key: ()
+ │    ├── fd: ()-->(1)
+ │    └── (1 / 0,) [type=tuple{decimal}]
+ └── with-scan &1 (foo)
+      ├── columns: "?column?":2(decimal)
+      ├── mapping:
+      │    └──  "?column?":1(decimal) => "?column?":2(decimal)
+      ├── cardinality: [1 - 1]
+      ├── key: ()
+      └── fd: ()-->(2)
+
+norm expect=InlineWith
+WITH foo AS (SELECT 1), bar AS (SELECT * FROM foo) SELECT * FROM foo
+----
+values
+ ├── columns: "?column?":3(int!null)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(3)
+ └── (1,) [type=tuple{int}]
+
+norm expect=InlineWith
+WITH foo AS (SELECT 1), bar AS (SELECT * FROM foo) SELECT * FROM foo
+----
+values
+ ├── columns: "?column?":3(int!null)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(3)
+ └── (1,) [type=tuple{int}]
+
+# Inline nested Withs.
+norm expect=InlineWith
+WITH
+    t (x) AS (WITH t (x) AS (SELECT 1) SELECT x * 10 FROM t)
+SELECT
+    x + 2
+FROM
+    t
+----
+values
+ ├── columns: "?column?":5(int!null)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(5)
+ └── (12,) [type=tuple{int}]

--- a/pkg/sql/opt/props/logical.go
+++ b/pkg/sql/opt/props/logical.go
@@ -41,8 +41,11 @@ const (
 	// is populated.
 	HasHoistableSubquery
 
-	// JoinSize is set when the Scalar.Rule.JoinSize field is populated.
+	// JoinSize is set when the Relational.Rule.JoinSize field is populated.
 	JoinSize
+
+	// WithUses is set when the Shared.Rule.WithUses field is populated.
+	WithUses
 )
 
 // Shared are properties that are shared by both relational and scalar
@@ -161,6 +164,14 @@ type Shared struct {
 	// HasPlaceholder is true if the subtree rooted at this expression contains
 	// at least one Placeholder operator.
 	HasPlaceholder bool
+
+	// Rule props are lazily calculated and typically only apply to a single
+	// rule. See the comment above Relational.Rule for more details.
+	Rule struct {
+		// WithUses tracks the number of times each With expression has been
+		// referenced in the given expression.
+		WithUses map[opt.WithID]int
+	}
 }
 
 // Relational properties describe the content and characteristics of relational

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -66,7 +66,7 @@ CREATE TABLE zz (
 memo
 SELECT * FROM abc JOIN xyz ON a=z
 ----
-memo (optimized, ~9KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
+memo (optimized, ~10KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+7) (lookup-join G3 G5 abc@ab,keyCols=[7],outCols=(1-3,5-7))
  │    └── [presentation: a:1,b:2,c:3,x:5,y:6,z:7]
  │         ├── best: (inner-join G2 G3 G4)
@@ -94,7 +94,7 @@ memo (optimized, ~9KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
 memo
 SELECT * FROM abc FULL OUTER JOIN xyz ON a=z
 ----
-memo (optimized, ~8KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
+memo (optimized, ~9KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
  ├── G1: (full-join G2 G3 G4) (full-join G3 G2 G4) (merge-join G2 G3 G5 full-join,+1,+7)
  │    └── [presentation: a:1,b:2,c:3,x:5,y:6,z:7]
  │         ├── best: (full-join G2 G3 G4)
@@ -183,7 +183,7 @@ memo (optimized, ~8KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
 memo
 SELECT * FROM abc LEFT OUTER JOIN xyz ON a=z
 ----
-memo (optimized, ~8KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
+memo (optimized, ~9KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
  ├── G1: (left-join G2 G3 G4) (right-join G3 G2 G4) (merge-join G2 G3 G5 left-join,+1,+7)
  │    └── [presentation: a:1,b:2,c:3,x:5,y:6,z:7]
  │         ├── best: (left-join G2 G3 G4)
@@ -259,7 +259,7 @@ memo (optimized, ~8KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
 memo
 SELECT * FROM abc RIGHT OUTER JOIN xyz ON a=z
 ----
-memo (optimized, ~9KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
+memo (optimized, ~10KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
  ├── G1: (right-join G2 G3 G4) (left-join G3 G2 G4) (merge-join G2 G3 G5 right-join,+1,+7) (lookup-join G3 G5 abc@ab,keyCols=[7],outCols=(1-3,5-7))
  │    └── [presentation: a:1,b:2,c:3,x:5,y:6,z:7]
  │         ├── best: (right-join G2 G3 G4)
@@ -1789,7 +1789,7 @@ select
 memo
 SELECT p,q,r,s FROM pqr WHERE q = 1 AND r = 1 AND s = 'foo'
 ----
-memo (optimized, ~41KB, required=[presentation: p:1,q:2,r:3,s:4])
+memo (optimized, ~42KB, required=[presentation: p:1,q:2,r:3,s:4])
  ├── G1: (select G2 G3) (lookup-join G4 G5 pqr,keyCols=[1],outCols=(1-4)) (zigzag-join G3 pqr@q pqr@s) (zigzag-join G3 pqr@q pqr@rs) (lookup-join G6 G7 pqr,keyCols=[1],outCols=(1-4)) (lookup-join G8 G7 pqr,keyCols=[1],outCols=(1-4)) (lookup-join G9 G7 pqr,keyCols=[1],outCols=(1-4)) (select G10 G11) (select G12 G13) (select G14 G7) (select G15 G7)
  │    └── [presentation: p:1,q:2,r:3,s:4]
  │         ├── best: (zigzag-join G3 pqr@q pqr@s)
@@ -1889,7 +1889,7 @@ select
 memo
 SELECT q,t FROM pqr WHERE q = 1 AND t = 'foo'
 ----
-memo (optimized, ~8KB, required=[presentation: q:2,t:5])
+memo (optimized, ~9KB, required=[presentation: q:2,t:5])
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7)
  │    └── [presentation: q:2,t:5]
  │         ├── best: (select G4 G5)

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -127,7 +127,7 @@ inner-join (lookup bx)
 memo join-limit=3
 SELECT * FROM bx, cy, abc WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
-memo (optimized, ~30KB, required=[presentation: b:1,x:2,c:3,y:4,a:5,b:6,c:7,d:8])
+memo (optimized, ~31KB, required=[presentation: b:1,x:2,c:3,y:4,a:5,b:6,c:7,d:8])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+6) (lookup-join G3 G5 bx,keyCols=[6],outCols=(1-8)) (inner-join G6 G7 G8) (inner-join G9 G10 G11) (inner-join G7 G6 G8) (merge-join G6 G7 G5 inner-join,+3,+7) (inner-join G10 G9 G11) (lookup-join G7 G5 cy,keyCols=[7],outCols=(1-8)) (lookup-join G12 G11 abc,keyCols=[11],outCols=(1-8))
  │    └── [presentation: b:1,x:2,c:3,y:4,a:5,b:6,c:7,d:8]
  │         ├── best: (lookup-join G3 G5 bx,keyCols=[6],outCols=(1-8))
@@ -512,7 +512,7 @@ FROM
     JOIN x ON true
     JOIN [UPDATE x SET a = 1 RETURNING 1] ON true
 ----
-memo (optimized, ~58KB, required=[presentation: a:1,?column?:5,a:6,?column?:10])
+memo (optimized, ~59KB, required=[presentation: a:1,?column?:5,a:6,?column?:10])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G4) (inner-join G7 G8 G4) (inner-join G9 G10 G4) (inner-join G11 G12 G4) (inner-join G13 G14 G4) (inner-join G15 G16 G4) (inner-join G11 G17 G4) (inner-join G18 G16 G4) (inner-join G6 G5 G4) (inner-join G11 G19 G4) (inner-join G8 G7 G4) (inner-join G10 G9 G4) (inner-join G12 G11 G4) (inner-join G14 G13 G4) (inner-join G11 G20 G4) (inner-join G16 G15 G4) (inner-join G17 G11 G4) (inner-join G16 G18 G4) (inner-join G19 G11 G4) (inner-join G16 G21 G4) (inner-join G16 G22 G4) (inner-join G20 G11 G4) (inner-join G3 G23 G4) (inner-join G24 G16 G4) (inner-join G21 G16 G4) (inner-join G11 G25 G4) (inner-join G3 G26 G4) (inner-join G22 G16 G4) (inner-join G11 G27 G4) (inner-join G3 G28 G4) (inner-join G3 G29 G4) (inner-join G30 G16 G4) (inner-join G23 G3 G4) (inner-join G16 G24 G4) (inner-join G25 G11 G4) (inner-join G26 G3 G4) (inner-join G27 G11 G4) (inner-join G28 G3 G4) (inner-join G29 G3 G4) (inner-join G16 G30 G4)
  │    └── [presentation: a:1,?column?:5,a:6,?column?:10]
  │         ├── best: (inner-join G3 G2 G4)


### PR DESCRIPTION
This commit adds a rule to inline With expressions which are referenced
at most once. This avoid buffering in the common case and also allows
optimizations to cross this boundary.

Release note (sql change): CTEs which are used a single time will no
longer create an optimization fence.