### PR TITLE
release-2.1: storage: don't panic on absent store in StorePool.getStoreListFromIDs

### DIFF
--- a/pkg/storage/store_pool.go
+++ b/pkg/storage/store_pool.go
@@ -650,11 +650,16 @@ func (sp *StorePool) getStoreListFromIDsRLocked(
 	var aliveStoreCount int
 	var throttledStoreCount int
 	var storeDescriptors []roachpb.StoreDescriptor
+	timeUntilStoreDead := TimeUntilStoreDead.Get(&sp.st.SV)
 
 	now := sp.clock.PhysicalTime()
 	for _, storeID := range storeIDs {
-		detail := sp.detailsMu.storeDetails[storeID]
-		switch s := detail.status(now, TimeUntilStoreDead.Get(&sp.st.SV), rangeID, sp.nodeLivenessFn); s {
+		detail, ok := sp.detailsMu.storeDetails[storeID]
+		if !ok {
+			// Do nothing; this store is not in the StorePool.
+			continue
+		}
+		switch s := detail.status(now, timeUntilStoreDead, rangeID, sp.nodeLivenessFn); s {
 		case storeStatusThrottled:
 			aliveStoreCount++
 			throttledStoreCount++
@@ -667,7 +672,7 @@ func (sp *StorePool) getStoreListFromIDsRLocked(
 			aliveStoreCount++
 			storeDescriptors = append(storeDescriptors, *detail.desc)
 		case storeStatusDead, storeStatusUnknown, storeStatusDecommissioning:
-			// Do nothing; this node cannot be used.
+			// Do nothing; this store cannot be used.
 		default:
 			panic(fmt.Sprintf("unknown store status: %d", s))
 		}


### PR DESCRIPTION
Backport 1/1 commits from #40645.

/cc @cockroachdb/release

---

Fixes #40598.

The store ID filter is passed to the StorePool from outside of the lock,
so it's possible that the removal of the store from the StorePool raced
with the goroutine calling getStoreListFromIDs. This should be handled
by ignoring the StoreID, which is already the case if a store is found
with the status `storeStatusDead`, `storeStatusUnknown`, or
`storeStatusDecommissioning`.

Will need to be backported to 19.1 and 2.1.

Release note: None
