### PR TITLE
libroach: enable rocksdb logging to a separate file

### DIFF
--- a/c-deps/libroach/ccl/db.cc
+++ b/c-deps/libroach/ccl/db.cc
@@ -146,9 +146,10 @@ rocksdb::Status DBOpenHookCCL(std::shared_ptr<rocksdb::Logger> info_log, const s
         "on-disk version does not support encryption, but we found encryption flags");
   }
 
-  // We use a logger at V(0) for encryption status instead of the existing info_log.
-  // This should only be used to occasional logging (eg: key loading and rotation).
-  std::shared_ptr<rocksdb::Logger> logger(NewDBLogger(0));
+  // We log to the primary CockroachDB log for encryption status
+  // instead of the RocksDB specific log. This should only be used to
+  // occasional logging (eg: key loading and rotation).
+  std::shared_ptr<rocksdb::Logger> logger(NewDBLogger(true /* use_primary_log */));
 
   // We have encryption options. Check whether the AES instruction set is supported.
   if (!UsesAESNI()) {

--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -242,7 +242,6 @@ DBStatus DBOpen(DBEngine** db, DBSlice dir, DBOptions db_opts) {
   options.env = env_mgr->db_env;
 
   rocksdb::DB* db_ptr;
-
   rocksdb::Status status;
   if (db_opts.read_only) {
     status = rocksdb::DB::OpenForReadOnly(options, db_dir, &db_ptr);

--- a/c-deps/libroach/godefs.cc
+++ b/c-deps/libroach/godefs.cc
@@ -24,7 +24,6 @@ static void __attribute__((noreturn)) die_missing_symbol(const char* name) {
 // complain that these symbols are undefined. Because these stubs are marked
 // "weak", they will be replaced by their proper implementation in
 // storage/engine when the final cockroach binary is linked.
-bool __attribute__((weak)) rocksDBV(int, int) { die_missing_symbol(__func__); }
-void __attribute__((weak)) rocksDBLog(int, char*, int) { die_missing_symbol(__func__); }
+void __attribute__((weak)) rocksDBLog(bool, int, char*, int) { die_missing_symbol(__func__); }
 char* __attribute__((weak)) prettyPrintKey(DBKey) { die_missing_symbol(__func__); }
 }  // extern "C"

--- a/c-deps/libroach/godefs.h
+++ b/c-deps/libroach/godefs.h
@@ -13,7 +13,6 @@
 #include <libroach.h>
 
 extern "C" {
-bool __attribute__((weak)) rocksDBV(int, int);
-void __attribute__((weak)) rocksDBLog(int, char*, int);
+void __attribute__((weak)) rocksDBLog(bool, int, char*, int);
 char* __attribute__((weak)) prettyPrintKey(DBKey);
 }  // extern "C"

--- a/c-deps/libroach/options.h
+++ b/c-deps/libroach/options.h
@@ -15,13 +15,12 @@
 
 namespace cockroach {
 
-static const int kDefaultVerbosityForInfoLogging = 3;
-
-// Make a new rocksdb::Logger that calls back into Go with a translation of
-// RocksDB's log level into a corresponding Go log level.
-// The message is logged if severity is higher than info, or if severity is
-// info and glog verbosity is at least `info_verbosity`.
-rocksdb::Logger* NewDBLogger(int info_verbosity);
+// Make a new rocksdb::Logger that calls back into Go with a
+// translation of RocksDB's log level into a corresponding Go log
+// level. If use_primary_log is true, messages are logged to the
+// primary CockroachDB log. Otherwise they are logged to a RocksDB
+// specific log file.
+rocksdb::Logger* NewDBLogger(bool use_primary_log);
 
 // DBMakeOptions constructs a rocksdb::Options given a DBOptions.
 rocksdb::Options DBMakeOptions(DBOptions db_opts);

--- a/c-deps/libroach/testutils.cc
+++ b/c-deps/libroach/testutils.cc
@@ -22,8 +22,7 @@
 extern "C" {
 // Tests are run in plain C++, we need a symbol for rocksDBLog, normally
 // implemented on the Go side.
-bool __attribute__((weak)) rocksDBV(int, int) { return false; }
-void __attribute__((weak)) rocksDBLog(int, char*, int) {}
+void __attribute__((weak)) rocksDBLog(bool, int, char*, int) {}
 }  // extern "C"
 
 namespace testutils {

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -1141,6 +1141,9 @@ func setupAndInitializeLoggingAndProfiling(
 		// Start the log file GC daemon to remove files that make the log
 		// directory too large.
 		log.StartGCDaemon(ctx)
+
+		// We have a valid logging directory. Configure RocksDB to log into it.
+		engine.InitRocksDBLogger(ctx)
 	}
 
 	outputDirectory := "."

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -671,11 +671,13 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		),
 
 		ExecLogger: log.NewSecondaryLogger(
-			loggerCtx, nil /* dirName */, "sql-exec", true /* enableGc */, false, /*forceSyncWrites*/
+			loggerCtx, nil /* dirName */, "sql-exec",
+			true /* enableGc */, false /*forceSyncWrites*/, true, /* enableMsgCount */
 		),
 
 		AuditLogger: log.NewSecondaryLogger(
-			loggerCtx, s.cfg.SQLAuditLogDirName, "sql-audit", true /*enableGc*/, true, /*forceSyncWrites*/
+			loggerCtx, s.cfg.SQLAuditLogDirName, "sql-audit",
+			true /*enableGc*/, true /*forceSyncWrites*/, true, /* enableMsgCount */
 		),
 
 		QueryCache: querycache.New(s.cfg.SQLQueryCacheSize),

--- a/pkg/util/log/secondary_log_test.go
+++ b/pkg/util/log/secondary_log_test.go
@@ -31,7 +31,7 @@ func TestSecondaryLog(t *testing.T) {
 	defer cancel()
 
 	// Make a new logger, in the same directory.
-	l := NewSecondaryLogger(ctx, &logging.logDir, "woo", true, false)
+	l := NewSecondaryLogger(ctx, &logging.logDir, "woo", true, false, true)
 
 	// Interleave some messages.
 	Infof(context.Background(), "test1")


### PR DESCRIPTION
Use a SecondaryLogger for RocksDB log messages. This functionality is
only enabled for the main `cockroach` binary when file logging is not
disabled (e.g. via `--log-dir=""`). When file logging is enabled a new
`cockroach-rocksdb.*log` set of logs is created with the same GC policy
as the regular `cockroach.*log` debug logs.

Fixes #40648

Release note (general change): Enable RocksDB INFO logs which are stored
adjacent to the CockroahDB debug logs.