### PR TITLE
roachtest: stop skipping jepsen/multi-register

### DIFF
--- a/pkg/cmd/roachtest/jepsen.go
+++ b/pkg/cmd/roachtest/jepsen.go
@@ -319,9 +319,6 @@ func registerJepsen(r *testRegistry) {
 				// initialized.
 				Cluster: makeClusterSpec(6, reuseTagged("jepsen")),
 				Run: func(ctx context.Context, t *test, c *cluster) {
-					if testName == "multi-register" {
-						t.Skip("#36431", "" /* details */)
-					}
 					runJepsen(ctx, t, c, testName, nemesis.config)
 				},
 			}


### PR DESCRIPTION
Now that #40600 is merged, this seems to be pretty stable. I still
expect it to fail due to #36431, but I've never managed to repro that.

Release note: None