### PR TITLE
demo: add artificial latency based on region

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -937,6 +937,13 @@ Start with an empty database: avoid pre-loading a default dataset in
 the demo shell.`,
 	}
 
+	Global = FlagInfo{
+		Name: "global",
+		Description: `
+Simulate a global cluster. This adds artificial latencies to nodes in different
+regions.`,
+	}
+
 	LogDir = FlagInfo{
 		Name: "log-dir",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -145,6 +145,7 @@ func initCLIDefaults() {
 
 	demoCtx.nodes = 1
 	demoCtx.useEmptyDatabase = false
+	demoCtx.simulateLatency = false
 	demoCtx.runWorkload = false
 	demoCtx.localities = nil
 	demoCtx.geoPartitionedReplicas = false
@@ -342,4 +343,5 @@ var demoCtx struct {
 	runWorkload            bool
 	localities             demoLocalityList
 	geoPartitionedReplicas bool
+	simulateLatency        bool
 }

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -15,11 +15,13 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -80,6 +82,38 @@ var defaultLocalities = demoLocalityList{
 	{Tiers: []roachpb.Tier{{Key: "region", Value: "europe-west1"}, {Key: "az", Value: "b"}}},
 	{Tiers: []roachpb.Tier{{Key: "region", Value: "europe-west1"}, {Key: "az", Value: "c"}}},
 	{Tiers: []roachpb.Tier{{Key: "region", Value: "europe-west1"}, {Key: "az", Value: "d"}}},
+}
+
+type regionPair struct {
+	regionA string
+	regionB string
+}
+
+var regionToRegionToLatency map[string]map[string]int
+
+func insertPair(pair regionPair, latency int) {
+	regionToLatency, ok := regionToRegionToLatency[pair.regionA]
+	if !ok {
+		regionToLatency = make(map[string]int)
+		regionToRegionToLatency[pair.regionA] = regionToLatency
+	}
+	regionToLatency[pair.regionB] = latency
+}
+
+func init() {
+	regionToRegionToLatency = make(map[string]map[string]int)
+	// Latencies collected from http://cloudping.co on 9/11/2019.
+	for pair, latency := range map[regionPair]int{
+		{regionA: "us-east1", regionB: "us-west1"}:     66,
+		{regionA: "us-east1", regionB: "europe-west1"}: 64,
+		{regionA: "us-west1", regionB: "europe-west1"}: 146,
+	} {
+		insertPair(pair, latency)
+		insertPair(regionPair{
+			regionA: pair.regionB,
+			regionB: pair.regionA,
+		}, latency)
+	}
 }
 
 func init() {
@@ -157,16 +191,29 @@ func setupTransientServers(
 	}
 	cleanup = func() { stopper.Stop(ctx) }
 
-	// Create the first transient server. The others will join this one.
-	args := base.TestServerArgs{
-		PartOfCluster: true,
-		Insecure:      true,
-		Stopper:       stopper,
-	}
-
 	serverFactory := server.TestServerFactory
 	var s *server.TestServer
+	var servers []*server.TestServer
+	wg := new(sync.WaitGroup)
+	waitCh := make(chan struct{})
+	errCh := make(chan error)
 	for i := 0; i < demoCtx.nodes; i++ {
+		readyCh := make(chan struct{})
+		args := base.TestServerArgs{
+			PartOfCluster: true,
+			Insecure:      true,
+			Stopper:       stopper,
+			Knobs: base.TestingKnobs{
+				Server: &server.TestingKnobs{
+					PauseAfterGettingRPCAddress:  waitCh,
+					SignalAfterGettingRPCAddress: readyCh,
+					ContextTestingKnobs: rpc.ContextTestingKnobs{
+						ArtificialLatencyMap: make(map[string]int),
+					},
+				},
+			},
+		}
+
 		// All the nodes connect to the address of the first server created.
 		if s != nil {
 			args.JoinAddr = s.ServingRPCAddr()
@@ -175,13 +222,56 @@ func setupTransientServers(
 			args.Locality = demoCtx.localities[i]
 		}
 		serv := serverFactory.New(args).(*server.TestServer)
-		if err := serv.Start(args); err != nil {
-			return connURL, adminURL, cleanup, err
-		}
 		// Remember the first server created.
 		if i == 0 {
 			s = serv
 		}
+		servers = append(servers, serv)
+		wg.Add(1)
+		go func() {
+			if err := serv.Start(args); err != nil {
+				errCh <- err
+			}
+			wg.Done()
+		}()
+		<-readyCh
+	}
+	// Now, all servers have been started enough to know their own RPC serving
+	// addresses, but nothing else. Assemble the artificial latency map.
+
+	for i, src := range servers {
+		latencyMap := src.Cfg.TestingKnobs.Server.(*server.TestingKnobs).ContextTestingKnobs.ArtificialLatencyMap
+		srcLocality, ok := src.Cfg.Locality.Find("region")
+		if !ok {
+			continue
+		}
+		srcLocalityMap, ok := regionToRegionToLatency[srcLocality]
+		if !ok {
+			continue
+		}
+		for j, dst := range servers {
+			if i == j {
+				continue
+			}
+			dstLocality, ok := dst.Cfg.Locality.Find("region")
+			if !ok {
+				continue
+			}
+			latency := srcLocalityMap[dstLocality]
+			latencyMap[dst.ServingRPCAddr()] = latency
+		}
+	}
+
+	// We've assembled our latency maps and are ready for all servers to proceed
+	// through bootstrapping.
+	close(waitCh)
+	wg.Wait()
+
+	// Finally, check for errors.
+	select {
+	case err := <-errCh:
+		return connURL, adminURL, cleanup, err
+	default:
 	}
 
 	if demoCtx.nodes < 3 {
@@ -196,16 +286,16 @@ func setupTransientServers(
 	options := url.Values{}
 	options.Add("sslmode", "disable")
 	options.Add("application_name", sqlbase.ReportableAppNamePrefix+"cockroach demo")
-	url := url.URL{
+	sqlURL := url.URL{
 		Scheme:   "postgres",
 		User:     url.User(security.RootUser),
 		Host:     s.ServingSQLAddr(),
 		RawQuery: options.Encode(),
 	}
 	if gen != nil {
-		url.Path = gen.Meta().Name
+		sqlURL.Path = gen.Meta().Name
 	}
-	urlStr := url.String()
+	urlStr := sqlURL.String()
 
 	// Communicate information about license acquisition to services
 	// that depend on it.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -590,6 +590,7 @@ func init() {
 	// The --empty flag is only valid for the top level demo command,
 	// so we use the regular flag set.
 	BoolFlag(demoCmd.Flags(), &demoCtx.useEmptyDatabase, cliflags.UseEmptyDatabase, false)
+	BoolFlag(demoCmd.Flags(), &demoCtx.simulateLatency, cliflags.Global, false)
 
 	// sqlfmt command.
 	fmtFlags := sqlfmtCmd.Flags()

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -547,6 +547,17 @@ func (l *Locality) Set(value string) error {
 	return nil
 }
 
+// Find searches the locality's tiers for the input key, returning its value if
+// present.
+func (l *Locality) Find(key string) (value string, ok bool) {
+	for i := range l.Tiers {
+		if l.Tiers[i].Key == key {
+			return l.Tiers[i].Value, true
+		}
+	}
+	return "", false
+}
+
 // DefaultLocationInformation is used to populate the system.locations
 // table. The region values here are specific to GCP.
 var DefaultLocationInformation = []struct {

--- a/pkg/rpc/context_testutils.go
+++ b/pkg/rpc/context_testutils.go
@@ -38,6 +38,12 @@ type ContextTestingKnobs struct {
 	// for a given target and class.
 	StreamClientInterceptor func(target string, class ConnectionClass) grpc.StreamClientInterceptor
 
+	// ArtificialLatencyMap if non-nil contains a map from target address
+	// (server.RPCServingAddr() of a remote node) to artificial latency in
+	// milliseconds to inject. Setting this will cause the server to pause for
+	// the given amount of milliseconds on every network write.
+	ArtificialLatencyMap map[string]int
+
 	// ClusterID initializes the Context's ClusterID container to this value if
 	// non-nil at construction time.
 	ClusterID *uuid.UUID

--- a/pkg/server/server_update.go
+++ b/pkg/server/server_update.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -32,6 +33,14 @@ type TestingKnobs struct {
 	DefaultZoneConfigOverride *config.ZoneConfig
 	// DefaultSystemZoneConfigOverride, if set, overrides the default system zone config defined in `pkg/config/zone.go`
 	DefaultSystemZoneConfigOverride *config.ZoneConfig
+	// PauseAfterGettingRPCAddress, if non-nil, instructs the server to wait until
+	// the channel is closed after getting an RPC serving address.
+	PauseAfterGettingRPCAddress chan struct{}
+	// SignalAfterGettingRPCAddress, if non-nil, is closed after the server gets
+	// an RPC server address.
+	SignalAfterGettingRPCAddress chan struct{}
+	// ContextTestingKnobs allows customization of the RPC context testing knobs.
+	ContextTestingKnobs rpc.ContextTestingKnobs
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
This commit introduces a simple artificial latency model between regions
in cockroach demo, based on some latencies reported by
https://www.cloudping.co/ between different AWS regions.

This will only show up with more than 3 nodes, since each group of 3
nodes lives in the same region.

Here's an example screenshot from the admin ui of `./cockroach demo --nodes=9` with this patch enabled, demonstrating the correct inter-region latencies:

![image](https://user-images.githubusercontent.com/43821/64746955-938e1780-d4db-11e9-938a-19b692d56370.png)

Closes #40224.

Release note: None