### PR TITLE
sql: support wildcard in SHOW PARTITIONS FROM INDEX

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -493,6 +493,7 @@ show_partitions_stmt ::=
 	'SHOW' 'PARTITIONS' 'FROM' 'TABLE' table_name
 	| 'SHOW' 'PARTITIONS' 'FROM' 'DATABASE' database_name
 	| 'SHOW' 'PARTITIONS' 'FROM' 'INDEX' table_index_name
+	| 'SHOW' 'PARTITIONS' 'FROM' 'INDEX' table_name '@' '*'
 
 show_jobs_stmt ::=
 	'SHOW' 'AUTOMATIC' 'JOBS'

--- a/pkg/ccl/logictestccl/testdata/logic_test/distsql_partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/distsql_partitioning
@@ -111,6 +111,14 @@ test t3 p3 NULL y t3@sec      (3)  constraints = '[+dc=dc3]'
 test t3 p4 NULL y t3@sec      (4)  constraints = '[+dc=dc4]'
 
 query TTTTTTTT
+SHOW PARTITIONS FROM INDEX t3@*
+----
+test t3 p1 NULL x t3@primary  (1)  constraints = '[+dc=dc1]'
+test t3 p2 NULL x t3@primary  (2)  constraints = '[+dc=dc2]'
+test t3 p3 NULL y t3@sec      (3)  constraints = '[+dc=dc3]'
+test t3 p4 NULL y t3@sec      (4)  constraints = '[+dc=dc4]'
+
+query TTTTTTTT
 SHOW PARTITIONS FROM INDEX t3@sec
 ----
 test t3 p3 NULL y t3@sec      (3)  constraints = '[+dc=dc3]'

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3455,6 +3455,10 @@ show_partitions_stmt:
   {
     $$.val = &tree.ShowPartitions{IsIndex: true, Index: $5.tableIndexName()}
   }
+| SHOW PARTITIONS FROM INDEX table_name '@' '*'
+  {
+    $$.val = &tree.ShowPartitions{IsTable: true, Table: $5.unresolvedObjectName()}
+  }
 | SHOW PARTITIONS error // SHOW HELP: SHOW PARTITIONS
 
 // %Help: SHOW DATABASES - list databases


### PR DESCRIPTION
The SHOW PARTITIONS FROM INDEX command now supports the same `tbl@*`
syntax which `ALTER PARTITION OF INDEX` does. It behaves identically to
SHOW PARTITIONS FROM TABLE.

Fixes #40382

Release note: None