### PR TITLE
sql: add a syntax hint for ALTER PARTITION

### DIFF
--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -2683,6 +2683,14 @@ DETAIL: source SQL:
 CREATE STATISTICS a ON col1 FROM t WITH OPTIONS AS OF SYSTEM TIME '-1s' THROTTLING 0.1 AS OF SYSTEM TIME '-2s'
                                                                                                               ^`,
 		},
+		{
+			`ALTER PARTITION p OF TABLE tbl@* CONFIGURE ZONE USING num_replicas = 1`,
+			`at or near "configure": syntax error: index wildcard unsupported in ALTER PARTITION ... OF TABLE
+DETAIL: source SQL:
+ALTER PARTITION p OF TABLE tbl@* CONFIGURE ZONE USING num_replicas = 1
+                                 ^
+HINT: try ALTER PARTITION <partition> OF INDEX <tablename>@*`,
+		},
 	}
 	for _, d := range testData {
 		t.Run(d.sql, func(t *testing.T) {


### PR DESCRIPTION
If a user tries to modify multiple index partitions via ALTER PARTITION
... OF TABLE, they now receive a hint to use ALTER PARTITION ... OF
INDEX instead.

I also improved the help docs for `\h ALTER PARTITION` to specify how to
use the wildcard syntax.

Fixes #40387

Release note: None