### PR TITLE
opt: Add support for index hints in UPDATE and DELETE statements

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -173,3 +173,21 @@ run             ·            ·
 ·               table        indexed@indexed_value_idx
 ·               spans        /5-/6
 ·               limit        10
+
+# Ensure that index hints in DELETE statements force the choice of a specific index
+# as described in #38799.
+statement ok
+CREATE TABLE t38799 (a INT PRIMARY KEY, b INT, c INT, INDEX foo(b))
+
+query TTTTT
+EXPLAIN (VERBOSE) DELETE FROM t38799@foo
+----
+·               distributed  false       ·       ·
+·               vectorized   false       ·       ·
+count           ·            ·           ()      ·
+ └── delete     ·            ·           ()      ·
+      │         from         t38799      ·       ·
+      │         strategy     deleter     ·       ·
+      └── scan  ·            ·           (a, b)  ·
+·               table        t38799@foo  ·       ·
+·               spans        ALL         ·       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -366,3 +366,31 @@ query TTT
 UPDATE t35364 SET x=2.5 RETURNING *
 ----
 3  2  8
+
+# Ensure that index hints in UPDATE statements force the choice of a specific index
+# as described in #38799.
+statement ok
+CREATE TABLE t38799 (a INT PRIMARY KEY, b INT, c INT, INDEX foo(b))
+
+query TTTTT
+EXPLAIN (VERBOSE) UPDATE t38799@foo SET c=2 WHERE a=1
+----
+·                               distributed  false           ·                   ·
+·                               vectorized   false           ·                   ·
+count                           ·            ·               ()                  ·
+ └── update                     ·            ·               ()                  ·
+      │                         table        t38799          ·                   ·
+      │                         set          c               ·                   ·
+      │                         strategy     updater         ·                   ·
+      └── render                ·            ·               (a, b, c, column7)  ·
+           │                    render 0     a               ·                   ·
+           │                    render 1     b               ·                   ·
+           │                    render 2     c               ·                   ·
+           │                    render 3     2               ·                   ·
+           └── filter           ·            ·               (a, b, c)           ·
+                │               filter       a = 1           ·                   ·
+                └── index-join  ·            ·               (a, b, c)           ·
+                     │          table        t38799@primary  ·                   ·
+                     └── scan   ·            ·               (a, b)              ·
+·                               table        t38799@foo      ·                   ·
+·                               spans        ALL             ·                   ·

--- a/pkg/sql/opt/optbuilder/delete.go
+++ b/pkg/sql/opt/optbuilder/delete.go
@@ -68,7 +68,7 @@ func (b *Builder) buildDelete(del *tree.Delete, inScope *scope) (outScope *scope
 	//   ORDER BY <order-by> LIMIT <limit>
 	//
 	// All columns from the delete table will be projected.
-	mb.buildInputForDelete(inScope, del.Where, del.Limit, del.OrderBy)
+	mb.buildInputForDelete(inScope, del.Table, del.Where, del.Limit, del.OrderBy)
 
 	// Build the final delete statement, including any returned expressions.
 	if resultsNeeded(del.Returning) {

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -208,8 +208,18 @@ func (mb *mutationBuilder) fetchColID(tabOrd int) opt.ColumnID {
 // the query (RETURNING clause).
 // TODO(andyk): Do needed column analysis to project fewer columns if possible.
 func (mb *mutationBuilder) buildInputForUpdate(
-	inScope *scope, from tree.TableExprs, where *tree.Where, limit *tree.Limit, orderBy tree.OrderBy,
+	inScope *scope,
+	texpr tree.TableExpr,
+	from tree.TableExprs,
+	where *tree.Where,
+	limit *tree.Limit,
+	orderBy tree.OrderBy,
 ) {
+	var indexFlags *tree.IndexFlags
+	if source, ok := texpr.(*tree.AliasedTableExpr); ok {
+		indexFlags = source.IndexFlags
+	}
+
 	// Fetch columns from different instance of the table metadata, so that it's
 	// possible to remap columns, as in this example:
 	//
@@ -220,7 +230,7 @@ func (mb *mutationBuilder) buildInputForUpdate(
 	mb.outScope = mb.b.buildScan(
 		mb.b.addTable(mb.tab, &mb.alias),
 		nil, /* ordinals */
-		nil, /* indexFlags */
+		indexFlags,
 		includeMutations,
 		inScope,
 	)
@@ -306,8 +316,13 @@ func (mb *mutationBuilder) buildInputForUpdate(
 // All columns from the table to update are added to fetchColList.
 // TODO(andyk): Do needed column analysis to project fewer columns if possible.
 func (mb *mutationBuilder) buildInputForDelete(
-	inScope *scope, where *tree.Where, limit *tree.Limit, orderBy tree.OrderBy,
+	inScope *scope, texpr tree.TableExpr, where *tree.Where, limit *tree.Limit, orderBy tree.OrderBy,
 ) {
+	var indexFlags *tree.IndexFlags
+	if source, ok := texpr.(*tree.AliasedTableExpr); ok {
+		indexFlags = source.IndexFlags
+	}
+
 	// Fetch columns from different instance of the table metadata, so that it's
 	// possible to remap columns, as in this example:
 	//
@@ -316,7 +331,7 @@ func (mb *mutationBuilder) buildInputForDelete(
 	mb.outScope = mb.b.buildScan(
 		mb.b.addTable(mb.tab, &mb.alias),
 		nil, /* ordinals */
-		nil, /* indexFlags */
+		indexFlags,
 		includeMutations,
 		inScope,
 	)

--- a/pkg/sql/opt/optbuilder/testdata/delete
+++ b/pkg/sql/opt/optbuilder/testdata/delete
@@ -92,6 +92,72 @@ delete foo
       │                   └── const: 0 [type=int]
       └── const: 10 [type=int]
 
+# DELETE with index hints.
+exec-ddl
+CREATE TABLE xyzw (
+  x INT PRIMARY KEY,
+  y INT,
+  z INT,
+  w INT,
+  INDEX foo (z, y)
+)
+----
+
+build
+DELETE FROM xyzw@primary
+----
+delete xyzw
+ ├── columns: <none>
+ ├── fetch columns: x:5(int) y:6(int) z:7(int) w:8(int)
+ └── scan xyzw
+      ├── columns: x:5(int!null) y:6(int) z:7(int) w:8(int)
+      └── flags: force-index=primary
+
+build
+DELETE FROM xyzw@foo
+----
+delete xyzw
+ ├── columns: <none>
+ ├── fetch columns: x:5(int) y:6(int) z:7(int) w:8(int)
+ └── scan xyzw
+      ├── columns: x:5(int!null) y:6(int) z:7(int) w:8(int)
+      └── flags: force-index=foo
+
+build
+DELETE FROM xyzw@{FORCE_INDEX=foo,ASC}
+----
+delete xyzw
+ ├── columns: <none>
+ ├── fetch columns: x:5(int) y:6(int) z:7(int) w:8(int)
+ └── scan xyzw
+      ├── columns: x:5(int!null) y:6(int) z:7(int) w:8(int)
+      └── flags: force-index=foo,fwd
+
+build
+DELETE FROM xyzw@{FORCE_INDEX=foo,DESC}
+----
+delete xyzw
+ ├── columns: <none>
+ ├── fetch columns: x:5(int) y:6(int) z:7(int) w:8(int)
+ └── scan xyzw,rev
+      ├── columns: x:5(int!null) y:6(int) z:7(int) w:8(int)
+      └── flags: force-index=foo,rev
+
+build
+DELETE FROM xyzw@{NO_INDEX_JOIN}
+----
+delete xyzw
+ ├── columns: <none>
+ ├── fetch columns: x:5(int) y:6(int) z:7(int) w:8(int)
+ └── scan xyzw
+      ├── columns: x:5(int!null) y:6(int) z:7(int) w:8(int)
+      └── flags: no-index-join
+
+build
+DELETE FROM xyzw@bad_idx
+----
+error: index "bad_idx" not found
+
 # Use placeholders.
 build
 DELETE FROM xyz WHERE x=$1 ORDER BY y+$2 DESC LIMIT 2

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -283,6 +283,133 @@ update abcde
                 │    └── variable: c [type=int]
                 └── const: 1 [type=int]
 
+# UPDATE with index hints.
+exec-ddl
+CREATE TABLE xyzw (
+  x INT PRIMARY KEY,
+  y INT,
+  z INT,
+  w INT,
+  INDEX foo (z, y)
+)
+----
+
+build
+UPDATE xyzw@primary SET x=2 WHERE z=1
+----
+update xyzw
+ ├── columns: <none>
+ ├── fetch columns: x:5(int) y:6(int) z:7(int) w:8(int)
+ ├── update-mapping:
+ │    └──  column9:9 => x:1
+ └── project
+      ├── columns: column9:9(int!null) x:5(int!null) y:6(int) z:7(int!null) w:8(int)
+      ├── select
+      │    ├── columns: x:5(int!null) y:6(int) z:7(int!null) w:8(int)
+      │    ├── scan xyzw
+      │    │    ├── columns: x:5(int!null) y:6(int) z:7(int) w:8(int)
+      │    │    └── flags: force-index=primary
+      │    └── filters
+      │         └── eq [type=bool]
+      │              ├── variable: z [type=int]
+      │              └── const: 1 [type=int]
+      └── projections
+           └── const: 2 [type=int]
+
+build
+UPDATE xyzw@foo SET x=2 WHERE z=1
+----
+update xyzw
+ ├── columns: <none>
+ ├── fetch columns: x:5(int) y:6(int) z:7(int) w:8(int)
+ ├── update-mapping:
+ │    └──  column9:9 => x:1
+ └── project
+      ├── columns: column9:9(int!null) x:5(int!null) y:6(int) z:7(int!null) w:8(int)
+      ├── select
+      │    ├── columns: x:5(int!null) y:6(int) z:7(int!null) w:8(int)
+      │    ├── scan xyzw
+      │    │    ├── columns: x:5(int!null) y:6(int) z:7(int) w:8(int)
+      │    │    └── flags: force-index=foo
+      │    └── filters
+      │         └── eq [type=bool]
+      │              ├── variable: z [type=int]
+      │              └── const: 1 [type=int]
+      └── projections
+           └── const: 2 [type=int]
+
+build
+UPDATE xyzw@{FORCE_INDEX=foo,ASC} SET x=2 WHERE z=1
+----
+update xyzw
+ ├── columns: <none>
+ ├── fetch columns: x:5(int) y:6(int) z:7(int) w:8(int)
+ ├── update-mapping:
+ │    └──  column9:9 => x:1
+ └── project
+      ├── columns: column9:9(int!null) x:5(int!null) y:6(int) z:7(int!null) w:8(int)
+      ├── select
+      │    ├── columns: x:5(int!null) y:6(int) z:7(int!null) w:8(int)
+      │    ├── scan xyzw
+      │    │    ├── columns: x:5(int!null) y:6(int) z:7(int) w:8(int)
+      │    │    └── flags: force-index=foo,fwd
+      │    └── filters
+      │         └── eq [type=bool]
+      │              ├── variable: z [type=int]
+      │              └── const: 1 [type=int]
+      └── projections
+           └── const: 2 [type=int]
+
+build
+UPDATE xyzw@{FORCE_INDEX=foo,DESC} SET x=2 WHERE z=1
+----
+update xyzw
+ ├── columns: <none>
+ ├── fetch columns: x:5(int) y:6(int) z:7(int) w:8(int)
+ ├── update-mapping:
+ │    └──  column9:9 => x:1
+ └── project
+      ├── columns: column9:9(int!null) x:5(int!null) y:6(int) z:7(int!null) w:8(int)
+      ├── select
+      │    ├── columns: x:5(int!null) y:6(int) z:7(int!null) w:8(int)
+      │    ├── scan xyzw,rev
+      │    │    ├── columns: x:5(int!null) y:6(int) z:7(int) w:8(int)
+      │    │    └── flags: force-index=foo,rev
+      │    └── filters
+      │         └── eq [type=bool]
+      │              ├── variable: z [type=int]
+      │              └── const: 1 [type=int]
+      └── projections
+           └── const: 2 [type=int]
+
+build
+UPDATE xyzw@{NO_INDEX_JOIN} SET x=2 WHERE z=1
+----
+update xyzw
+ ├── columns: <none>
+ ├── fetch columns: x:5(int) y:6(int) z:7(int) w:8(int)
+ ├── update-mapping:
+ │    └──  column9:9 => x:1
+ └── project
+      ├── columns: column9:9(int!null) x:5(int!null) y:6(int) z:7(int!null) w:8(int)
+      ├── select
+      │    ├── columns: x:5(int!null) y:6(int) z:7(int!null) w:8(int)
+      │    ├── scan xyzw
+      │    │    ├── columns: x:5(int!null) y:6(int) z:7(int) w:8(int)
+      │    │    └── flags: no-index-join
+      │    └── filters
+      │         └── eq [type=bool]
+      │              ├── variable: z [type=int]
+      │              └── const: 1 [type=int]
+      └── projections
+           └── const: 2 [type=int]
+
+build
+UPDATE xyzw@bad_idx SET x=2 WHERE z=1
+----
+error: index "bad_idx" not found
+
+
 # Infer types.
 build
 UPDATE xyz SET y=1, z=1

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -103,7 +103,7 @@ func (b *Builder) buildUpdate(upd *tree.Update, inScope *scope) (outScope *scope
 	//   ORDER BY <order-by> LIMIT <limit>
 	//
 	// All columns from the update table will be projected.
-	mb.buildInputForUpdate(inScope, upd.From, upd.Where, upd.Limit, upd.OrderBy)
+	mb.buildInputForUpdate(inScope, upd.Table, upd.From, upd.Where, upd.Limit, upd.OrderBy)
 
 	// Derive the columns that will be updated from the SET expressions.
 	mb.addTargetColsForUpdate(upd.Exprs)


### PR DESCRIPTION
Client can now override index selection in UPDATE and DELETE statements (as was already possible with SELECT). While the index hints are not rejected in parsing, in query planning the index hint has previously been ignored.

An example of index hinting syntax that is now passed down into planning:

```
UPDATE t@primary SET ...
DELETE FROM t@idx ...
```

Fixes #38799

Related: #31012

Release justification: Low risk, high benefit changes to existing functionality.