### PR TITLE
sql: add hint for ALTER PARTITION OF INDEX error

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -608,6 +608,9 @@ CREATE INDEX x2 ON t2 (x) PARTITION BY LIST (x) (
 statement ok
 ALTER PARTITION p1 OF INDEX t2@* CONFIGURE ZONE USING num_replicas = 1
 
+statement error index "t2" does not exist\nHINT: try specifying the index as <tablename>@<indexname>
+ALTER PARTITION p1 OF INDEX t2 CONFIGURE ZONE USING num_replicas = 1
+
 query TT
 SELECT * FROM [SHOW ALL ZONE CONFIGURATIONS] WHERE target LIKE '%t2@%'
 ----

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -240,6 +240,9 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 	// descriptor.
 	table, err := params.p.resolveTableForZone(params.ctx, &n.zoneSpecifier)
 	if err != nil {
+		if n.zoneSpecifier.TargetsIndex() && n.zoneSpecifier.TableOrIndex.Table.TableName == "" {
+			return errors.WithHint(err, "try specifying the index as <tablename>@<indexname>")
+		}
 		return err
 	}
 


### PR DESCRIPTION
If a user accidentally passes a table name (or some other non-existent
index name) to ALTER PARTITION ... OF INDEX, they now get a helpful hint
suggesting that the use the `<tablename>@<indexname>` syntax to specify
the index.

Fixes #39477

Release note: None