### PR TITLE
cli: Add 'pebble' debug command to run Pebble tool commands

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -427,13 +427,15 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b9896d01af74ea562a587ee910c31e4cc4151c776e2b1b432cf0e91fa210c1ba"
+  digest = "1:b4ac25b2f3481ae74da6165e66e1287546b99579ffc536daa6bd19f4aa259a47"
   name = "github.com/cockroachdb/pebble"
   packages = [
     ".",
+    "bloom",
     "cache",
     "internal/arenaskl",
     "internal/base",
+    "internal/batch",
     "internal/batchskl",
     "internal/bytealloc",
     "internal/crc",
@@ -444,10 +446,11 @@
     "internal/rawalloc",
     "internal/record",
     "sstable",
+    "tool",
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "81a672554d538e50d6a7e11ae8b2878f093f6e32"
+  revision = "efdb7f6d67b47189a442e2235a57bf9ae9c25bdb"
 
 [[projects]]
   branch = "master"
@@ -1952,6 +1955,7 @@
     "github.com/cockroachdb/pebble",
     "github.com/cockroachdb/pebble/cache",
     "github.com/cockroachdb/pebble/sstable",
+    "github.com/cockroachdb/pebble/tool",
     "github.com/cockroachdb/pebble/vfs",
     "github.com/cockroachdb/returncheck",
     "github.com/cockroachdb/stress",

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -26,7 +26,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/pkg/errors"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble"
 )
 
 const (
@@ -121,6 +122,11 @@ func (k MVCCKey) String() string {
 		return k.Key.String()
 	}
 	return fmt.Sprintf("%s/%s", k.Key, k.Timestamp)
+}
+
+// Format implements the fmt.Formatter interface.
+func (k MVCCKey) Format(f fmt.State, c rune) {
+	fmt.Fprintf(f, "%s/%s", k.Key, k.Timestamp)
 }
 
 // Len returns the size of the MVCCKey when encoded. Implements the
@@ -1859,6 +1865,68 @@ func mvccInitPutUsingIter(
 			}
 			return value.RawBytes, nil
 		})
+}
+
+// mvccKeyFormatter is an fmt.Formatter for MVCC Keys.
+type mvccKeyFormatter struct {
+	key MVCCKey
+	err error
+}
+
+var _ fmt.Formatter = mvccKeyFormatter{}
+
+// Format implements the fmt.Formatter interface.
+func (m mvccKeyFormatter) Format(f fmt.State, c rune) {
+	if m.err != nil {
+		errors.FormatError(m.err, f, c)
+		return
+	}
+	m.key.Format(f, c)
+}
+
+// MVCCComparer is a pebble.Comparer object that implements MVCC-specific
+// comparator settings for use with Pebble.
+//
+// TODO(itsbilal): Move this to a new file pebble.go.
+var MVCCComparer = &pebble.Comparer{
+	Compare: MVCCKeyCompare,
+	AbbreviatedKey: func(k []byte) uint64 {
+		key, _, ok := enginepb.SplitMVCCKey(k)
+		if !ok {
+			return 0
+		}
+		return pebble.DefaultComparer.AbbreviatedKey(key)
+	},
+
+	Format: func(k []byte) fmt.Formatter {
+		decoded, err := DecodeMVCCKey(k)
+		if err != nil {
+			return mvccKeyFormatter{err: err}
+		}
+		return mvccKeyFormatter{key: decoded}
+	},
+
+	Separator: func(dst, a, b []byte) []byte {
+		return append(dst, a...)
+	},
+
+	Successor: func(dst, a []byte) []byte {
+		return append(dst, a...)
+	},
+	Split: func(k []byte) int {
+		if len(k) == 0 {
+			return len(k)
+		}
+		// This is similar to what enginepb.SplitMVCCKey does.
+		tsLen := int(k[len(k)-1])
+		keyPartEnd := len(k) - 1 - tsLen
+		if keyPartEnd < 0 {
+			return len(k)
+		}
+		return keyPartEnd
+	},
+
+	Name: "cockroach_comparator",
 }
 
 // MVCCMerge implements a merge operation. Merge adds integer values,


### PR DESCRIPTION
Command-ception: Add a `debug pebble` command similar to `debug
rocksdb` that nests pebble commands like sstable scan, manifest
dump, etc right in the cockroach binary.

Also move the pebble.Compare definition to engine, which is a more
fitting place for it than bulk.

Fixes #40509

Release note: None

Release justification: Adds debug tools for internal use, no impact
on general operation.