### PR TITLE
opt: fix TryDecorrelateGroupBy to preserve output columns

### DIFF
--- a/pkg/sql/opt/norm/rules/decorrelate.opt
+++ b/pkg/sql/opt/norm/rules/decorrelate.opt
@@ -306,7 +306,9 @@
 # instead of CONST_AGG.
 #
 # An ordinality column only needs to be synthesized if "left" does not already
-# have a strict key.
+# have a strict key. We wrap the output in a Project operator to ensure that
+# the original output columns are preserved and the ordinality column is not
+# inadvertently added as a new output column.
 #
 # CONST_AGG is an internal aggregation function used when all rows in the
 # grouping set have the same value on the column.
@@ -327,21 +329,25 @@
     $private:*
 )
 =>
-(Select
-    ((OpName $right)
-        (InnerJoinApply
-            $newLeft:(EnsureKey $left)
-            $input
-            []
-            $private
+(Project
+    (Select
+        ((OpName $right)
+            (InnerJoinApply
+                $newLeft:(EnsureKey $left)
+                $input
+                []
+                $private
+            )
+            (AppendAggCols
+                $aggregations
+                ConstAgg (NonKeyCols $newLeft)
+            )
+            (AddColsToGrouping $groupingPrivate (KeyCols $newLeft))
         )
-        (AppendAggCols
-            $aggregations
-            ConstAgg (NonKeyCols $newLeft)
-        )
-        (AddColsToGrouping $groupingPrivate (KeyCols $newLeft))
+        $on
     )
-    $on
+    []
+    (OutputCols2 $left $right)
 )
 
 # TryDecorrelateScalarGroupBy "pushes down" a Join into a ScalarGroupBy

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -2088,6 +2088,220 @@ group-by
       └── const-agg [type=jsonb, outer=(5)]
            └── variable: j [type=jsonb]
 
+# Regression test for #40592. Ensure that no new output columns are added
+# as a result of TryDecorrelateGroupBy.
+exec-ddl
+CREATE TABLE tab_orig (
+    _int2 INT8 NULL,
+    _int8 INT8 NULL,
+    _timestamptz TIMESTAMPTZ NULL,
+    _bool BOOL NULL,
+    _decimal INT8 NULL,
+    _string INT8 NULL,
+    FAMILY "primary" (_int2, _int8, _timestamptz, _bool, _decimal, _string, rowid)
+)
+----
+
+opt expect=TryDecorrelateGroupBy
+SELECT
+  NULL
+FROM
+  tab_orig AS t0
+WHERE
+  EXISTS(
+    SELECT
+      NULL
+    FROM
+      tab_orig
+      JOIN tab_orig AS t1
+        INNER JOIN tab_orig AS t2
+          JOIN tab_orig AS t3 ON true ON
+            EXISTS(
+              WITH
+                w0 AS (SELECT NULL)
+              SELECT
+                t0._string FROM w0 CROSS JOIN w0 as w1
+            ) ON true
+      JOIN tab_orig AS t4 ON
+          t3._timestamptz
+          = t4._timestamptz
+          AND t3._int2 = t4._int8
+      JOIN tab_orig AS t5 ON
+          t1._decimal = t5._decimal
+    WHERE
+      t2._bool
+    ORDER BY
+      t2._decimal
+    LIMIT
+      66
+  );
+----
+project
+ ├── columns: "?column?":58(unknown)
+ ├── fd: ()-->(58)
+ ├── semi-join-apply
+ │    ├── columns: t0._string:6(int)
+ │    ├── scan t0
+ │    │    └── columns: t0._string:6(int)
+ │    ├── limit
+ │    │    ├── columns: tab_orig.rowid:14(int!null) t1._decimal:19(int!null) t1.rowid:21(int!null) t2._bool:25(bool!null) t2._decimal:26(int) t2.rowid:28(int!null) t3._int2:29(int!null) t3._timestamptz:31(timestamptz!null) t3.rowid:35(int!null) true_agg:41(bool!null) t4._int8:44(int!null) t4._timestamptz:45(timestamptz!null) t5._decimal:54(int!null)
+ │    │    ├── internal-ordering: +26 opt(25)
+ │    │    ├── outer: (6)
+ │    │    ├── cardinality: [0 - 66]
+ │    │    ├── fd: ()-->(25), (21)-->(19), (28)-->(26), (35)-->(29,31), (14,21,28,35)-->(19,26,29,31,41), (31)==(45), (45)==(31), (29)==(44), (44)==(29), (19)==(54), (54)==(19)
+ │    │    ├── sort
+ │    │    │    ├── columns: tab_orig.rowid:14(int!null) t1._decimal:19(int!null) t1.rowid:21(int!null) t2._bool:25(bool!null) t2._decimal:26(int) t2.rowid:28(int!null) t3._int2:29(int!null) t3._timestamptz:31(timestamptz!null) t3.rowid:35(int!null) true_agg:41(bool!null) t4._int8:44(int!null) t4._timestamptz:45(timestamptz!null) t5._decimal:54(int!null)
+ │    │    │    ├── outer: (6)
+ │    │    │    ├── fd: ()-->(25), (21)-->(19), (28)-->(26), (35)-->(29,31), (14,21,28,35)-->(19,26,29,31,41), (31)==(45), (45)==(31), (29)==(44), (44)==(29), (19)==(54), (54)==(19)
+ │    │    │    ├── ordering: +26 opt(25) [actual: +26]
+ │    │    │    └── inner-join (hash)
+ │    │    │         ├── columns: tab_orig.rowid:14(int!null) t1._decimal:19(int!null) t1.rowid:21(int!null) t2._bool:25(bool!null) t2._decimal:26(int) t2.rowid:28(int!null) t3._int2:29(int!null) t3._timestamptz:31(timestamptz!null) t3.rowid:35(int!null) true_agg:41(bool!null) t4._int8:44(int!null) t4._timestamptz:45(timestamptz!null) t5._decimal:54(int!null)
+ │    │    │         ├── outer: (6)
+ │    │    │         ├── fd: ()-->(25), (21)-->(19), (28)-->(26), (35)-->(29,31), (14,21,28,35)-->(19,26,29,31,41), (31)==(45), (45)==(31), (29)==(44), (44)==(29), (19)==(54), (54)==(19)
+ │    │    │         ├── project
+ │    │    │         │    ├── columns: tab_orig.rowid:14(int!null) t1._decimal:19(int) t1.rowid:21(int!null) t2._bool:25(bool) t2._decimal:26(int) t2.rowid:28(int!null) t3._int2:29(int) t3._timestamptz:31(timestamptz) t3.rowid:35(int!null) true_agg:41(bool!null) t4._int8:44(int) t4._timestamptz:45(timestamptz)
+ │    │    │         │    ├── outer: (6)
+ │    │    │         │    ├── fd: ()-->(25), (21)-->(19), (28)-->(26), (35)-->(29,31), (31)==(45), (45)==(31), (29)==(44), (44)==(29)
+ │    │    │         │    └── select
+ │    │    │         │         ├── columns: tab_orig.rowid:14(int!null) t1._decimal:19(int) t1.rowid:21(int!null) t2._bool:25(bool) t2._decimal:26(int) t2.rowid:28(int!null) t3._int2:29(int) t3._timestamptz:31(timestamptz) t3.rowid:35(int!null) true_agg:41(bool!null) t4._int8:44(int) t4._timestamptz:45(timestamptz) rownum:60(int!null)
+ │    │    │         │         ├── outer: (6)
+ │    │    │         │         ├── key: (14,21,28,35,60)
+ │    │    │         │         ├── fd: ()-->(25), (60)-->(44,45), (21)-->(19), (28)-->(26), (35)-->(29,31), (31)==(45), (45)==(31), (29)==(44), (44)==(29), (14,21,28,35,60)-->(19,26,29,31,41,44,45)
+ │    │    │         │         ├── group-by
+ │    │    │         │         │    ├── columns: tab_orig.rowid:14(int!null) t1._decimal:19(int) t1.rowid:21(int!null) t2._bool:25(bool) t2._decimal:26(int) t2.rowid:28(int!null) t3._int2:29(int) t3._timestamptz:31(timestamptz) t3.rowid:35(int!null) true_agg:41(bool) t4._int8:44(int) t4._timestamptz:45(timestamptz) rownum:60(int!null)
+ │    │    │         │         │    ├── grouping columns: tab_orig.rowid:14(int!null) t1.rowid:21(int!null) t2.rowid:28(int!null) t3.rowid:35(int!null) rownum:60(int!null)
+ │    │    │         │         │    ├── outer: (6)
+ │    │    │         │         │    ├── key: (14,21,28,35,60)
+ │    │    │         │         │    ├── fd: ()-->(25), (60)-->(44,45), (21)-->(19), (28)-->(26), (35)-->(29,31), (31)==(45), (45)==(31), (29)==(44), (44)==(29), (14,21,28,35,60)-->(19,25,26,29,31,41,44,45)
+ │    │    │         │         │    ├── project
+ │    │    │         │         │    │    ├── columns: true:40(bool!null) tab_orig.rowid:14(int!null) t1._decimal:19(int) t1.rowid:21(int!null) t2._bool:25(bool!null) t2._decimal:26(int) t2.rowid:28(int!null) t3._int2:29(int!null) t3._timestamptz:31(timestamptz!null) t3.rowid:35(int!null) t4._int8:44(int!null) t4._timestamptz:45(timestamptz!null) rownum:60(int!null)
+ │    │    │         │         │    │    ├── outer: (6)
+ │    │    │         │         │    │    ├── key: (14,21,28,35,60)
+ │    │    │         │         │    │    ├── fd: ()-->(25,40), (60)-->(44,45), (21)-->(19), (28)-->(26), (35)-->(29,31), (31)==(45), (45)==(31), (29)==(44), (44)==(29)
+ │    │    │         │         │    │    ├── inner-join (hash)
+ │    │    │         │         │    │    │    ├── columns: tab_orig.rowid:14(int!null) t1._decimal:19(int) t1.rowid:21(int!null) t2._bool:25(bool!null) t2._decimal:26(int) t2.rowid:28(int!null) t3._int2:29(int!null) t3._timestamptz:31(timestamptz!null) t3.rowid:35(int!null) "_string":39(int) t4._int8:44(int!null) t4._timestamptz:45(timestamptz!null) rownum:60(int!null)
+ │    │    │         │         │    │    │    ├── outer: (6)
+ │    │    │         │         │    │    │    ├── key: (14,21,28,35,60)
+ │    │    │         │         │    │    │    ├── fd: ()-->(25,39), (60)-->(44,45), (21)-->(19), (28)-->(26), (35)-->(29,31), (31)==(45), (45)==(31), (29)==(44), (44)==(29)
+ │    │    │         │         │    │    │    ├── inner-join (hash)
+ │    │    │         │         │    │    │    │    ├── columns: tab_orig.rowid:14(int!null) t1._decimal:19(int) t1.rowid:21(int!null) t2._bool:25(bool) t2._decimal:26(int) t2.rowid:28(int!null) t3._int2:29(int) t3._timestamptz:31(timestamptz) t3.rowid:35(int!null) "_string":39(int)
+ │    │    │         │         │    │    │    │    ├── outer: (6)
+ │    │    │         │         │    │    │    │    ├── key: (14,21,28,35)
+ │    │    │         │         │    │    │    │    ├── fd: ()-->(39), (21)-->(19), (28)-->(25,26), (35)-->(29,31)
+ │    │    │         │         │    │    │    │    ├── inner-join (hash)
+ │    │    │         │         │    │    │    │    │    ├── columns: t1._decimal:19(int) t1.rowid:21(int!null) t2._bool:25(bool) t2._decimal:26(int) t2.rowid:28(int!null) t3._int2:29(int) t3._timestamptz:31(timestamptz) t3.rowid:35(int!null) "_string":39(int)
+ │    │    │         │         │    │    │    │    │    ├── outer: (6)
+ │    │    │         │         │    │    │    │    │    ├── key: (21,28,35)
+ │    │    │         │         │    │    │    │    │    ├── fd: ()-->(39), (21)-->(19), (28)-->(25,26), (35)-->(29,31)
+ │    │    │         │         │    │    │    │    │    ├── inner-join (hash)
+ │    │    │         │         │    │    │    │    │    │    ├── columns: t2._bool:25(bool) t2._decimal:26(int) t2.rowid:28(int!null) t3._int2:29(int) t3._timestamptz:31(timestamptz) t3.rowid:35(int!null) "_string":39(int)
+ │    │    │         │         │    │    │    │    │    │    ├── outer: (6)
+ │    │    │         │         │    │    │    │    │    │    ├── key: (28,35)
+ │    │    │         │         │    │    │    │    │    │    ├── fd: ()-->(39), (28)-->(25,26), (35)-->(29,31)
+ │    │    │         │         │    │    │    │    │    │    ├── scan t2
+ │    │    │         │         │    │    │    │    │    │    │    ├── columns: t2._bool:25(bool) t2._decimal:26(int) t2.rowid:28(int!null)
+ │    │    │         │         │    │    │    │    │    │    │    ├── key: (28)
+ │    │    │         │         │    │    │    │    │    │    │    └── fd: (28)-->(25,26)
+ │    │    │         │         │    │    │    │    │    │    ├── inner-join (hash)
+ │    │    │         │         │    │    │    │    │    │    │    ├── columns: t3._int2:29(int) t3._timestamptz:31(timestamptz) t3.rowid:35(int!null) "_string":39(int)
+ │    │    │         │         │    │    │    │    │    │    │    ├── outer: (6)
+ │    │    │         │         │    │    │    │    │    │    │    ├── key: (35)
+ │    │    │         │         │    │    │    │    │    │    │    ├── fd: ()-->(39), (35)-->(29,31)
+ │    │    │         │         │    │    │    │    │    │    │    ├── scan t3
+ │    │    │         │         │    │    │    │    │    │    │    │    ├── columns: t3._int2:29(int) t3._timestamptz:31(timestamptz) t3.rowid:35(int!null)
+ │    │    │         │         │    │    │    │    │    │    │    │    ├── key: (35)
+ │    │    │         │         │    │    │    │    │    │    │    │    └── fd: (35)-->(29,31)
+ │    │    │         │         │    │    │    │    │    │    │    ├── with &1 (w0)
+ │    │    │         │         │    │    │    │    │    │    │    │    ├── columns: "_string":39(int)
+ │    │    │         │         │    │    │    │    │    │    │    │    ├── outer: (6)
+ │    │    │         │         │    │    │    │    │    │    │    │    ├── cardinality: [1 - 1]
+ │    │    │         │         │    │    │    │    │    │    │    │    ├── key: ()
+ │    │    │         │         │    │    │    │    │    │    │    │    ├── fd: ()-->(39)
+ │    │    │         │         │    │    │    │    │    │    │    │    ├── values
+ │    │    │         │         │    │    │    │    │    │    │    │    │    ├── columns: "?column?":36(unknown)
+ │    │    │         │         │    │    │    │    │    │    │    │    │    ├── cardinality: [1 - 1]
+ │    │    │         │         │    │    │    │    │    │    │    │    │    ├── key: ()
+ │    │    │         │         │    │    │    │    │    │    │    │    │    ├── fd: ()-->(36)
+ │    │    │         │         │    │    │    │    │    │    │    │    │    └── (NULL,) [type=tuple{unknown}]
+ │    │    │         │         │    │    │    │    │    │    │    │    └── project
+ │    │    │         │         │    │    │    │    │    │    │    │         ├── columns: "_string":39(int)
+ │    │    │         │         │    │    │    │    │    │    │    │         ├── outer: (6)
+ │    │    │         │         │    │    │    │    │    │    │    │         ├── cardinality: [1 - 1]
+ │    │    │         │         │    │    │    │    │    │    │    │         ├── key: ()
+ │    │    │         │         │    │    │    │    │    │    │    │         ├── fd: ()-->(39)
+ │    │    │         │         │    │    │    │    │    │    │    │         ├── inner-join (hash)
+ │    │    │         │         │    │    │    │    │    │    │    │         │    ├── columns: "?column?":37(unknown) "?column?":38(unknown)
+ │    │    │         │         │    │    │    │    │    │    │    │         │    ├── cardinality: [1 - 1]
+ │    │    │         │         │    │    │    │    │    │    │    │         │    ├── key: ()
+ │    │    │         │         │    │    │    │    │    │    │    │         │    ├── fd: ()-->(37,38)
+ │    │    │         │         │    │    │    │    │    │    │    │         │    ├── with-scan &1 (w0)
+ │    │    │         │         │    │    │    │    │    │    │    │         │    │    ├── columns: "?column?":37(unknown)
+ │    │    │         │         │    │    │    │    │    │    │    │         │    │    ├── mapping:
+ │    │    │         │         │    │    │    │    │    │    │    │         │    │    │    └──  "?column?":36(unknown) => "?column?":37(unknown)
+ │    │    │         │         │    │    │    │    │    │    │    │         │    │    ├── cardinality: [1 - 1]
+ │    │    │         │         │    │    │    │    │    │    │    │         │    │    ├── key: ()
+ │    │    │         │         │    │    │    │    │    │    │    │         │    │    └── fd: ()-->(37)
+ │    │    │         │         │    │    │    │    │    │    │    │         │    ├── with-scan &1 (w0)
+ │    │    │         │         │    │    │    │    │    │    │    │         │    │    ├── columns: "?column?":38(unknown)
+ │    │    │         │         │    │    │    │    │    │    │    │         │    │    ├── mapping:
+ │    │    │         │         │    │    │    │    │    │    │    │         │    │    │    └──  "?column?":36(unknown) => "?column?":38(unknown)
+ │    │    │         │         │    │    │    │    │    │    │    │         │    │    ├── cardinality: [1 - 1]
+ │    │    │         │         │    │    │    │    │    │    │    │         │    │    ├── key: ()
+ │    │    │         │         │    │    │    │    │    │    │    │         │    │    └── fd: ()-->(38)
+ │    │    │         │         │    │    │    │    │    │    │    │         │    └── filters (true)
+ │    │    │         │         │    │    │    │    │    │    │    │         └── projections
+ │    │    │         │         │    │    │    │    │    │    │    │              └── variable: t0._string [type=int, outer=(6)]
+ │    │    │         │         │    │    │    │    │    │    │    └── filters (true)
+ │    │    │         │         │    │    │    │    │    │    └── filters (true)
+ │    │    │         │         │    │    │    │    │    ├── scan t1
+ │    │    │         │         │    │    │    │    │    │    ├── columns: t1._decimal:19(int) t1.rowid:21(int!null)
+ │    │    │         │         │    │    │    │    │    │    ├── key: (21)
+ │    │    │         │         │    │    │    │    │    │    └── fd: (21)-->(19)
+ │    │    │         │         │    │    │    │    │    └── filters (true)
+ │    │    │         │         │    │    │    │    ├── scan tab_orig
+ │    │    │         │         │    │    │    │    │    ├── columns: tab_orig.rowid:14(int!null)
+ │    │    │         │         │    │    │    │    │    └── key: (14)
+ │    │    │         │         │    │    │    │    └── filters (true)
+ │    │    │         │         │    │    │    ├── ordinality
+ │    │    │         │         │    │    │    │    ├── columns: t4._int8:44(int) t4._timestamptz:45(timestamptz) rownum:60(int!null)
+ │    │    │         │         │    │    │    │    ├── key: (60)
+ │    │    │         │         │    │    │    │    ├── fd: (60)-->(44,45)
+ │    │    │         │         │    │    │    │    └── scan t4
+ │    │    │         │         │    │    │    │         └── columns: t4._int8:44(int) t4._timestamptz:45(timestamptz)
+ │    │    │         │         │    │    │    └── filters
+ │    │    │         │         │    │    │         ├── variable: t2._bool [type=bool, outer=(25), constraints=(/25: [/true - /true]; tight), fd=()-->(25)]
+ │    │    │         │         │    │    │         ├── t3._timestamptz = t4._timestamptz [type=bool, outer=(31,45), constraints=(/31: (/NULL - ]; /45: (/NULL - ]), fd=(31)==(45), (45)==(31)]
+ │    │    │         │         │    │    │         └── t3._int2 = t4._int8 [type=bool, outer=(29,44), constraints=(/29: (/NULL - ]; /44: (/NULL - ]), fd=(29)==(44), (44)==(29)]
+ │    │    │         │         │    │    └── projections
+ │    │    │         │         │    │         └── true [type=bool]
+ │    │    │         │         │    └── aggregations
+ │    │    │         │         │         ├── const-not-null-agg [type=bool, outer=(40)]
+ │    │    │         │         │         │    └── variable: true [type=bool]
+ │    │    │         │         │         ├── const-agg [type=bool, outer=(25)]
+ │    │    │         │         │         │    └── variable: t2._bool [type=bool]
+ │    │    │         │         │         ├── const-agg [type=int, outer=(26)]
+ │    │    │         │         │         │    └── variable: t2._decimal [type=int]
+ │    │    │         │         │         ├── const-agg [type=int, outer=(29)]
+ │    │    │         │         │         │    └── variable: t3._int2 [type=int]
+ │    │    │         │         │         ├── const-agg [type=timestamptz, outer=(31)]
+ │    │    │         │         │         │    └── variable: t3._timestamptz [type=timestamptz]
+ │    │    │         │         │         ├── const-agg [type=int, outer=(19)]
+ │    │    │         │         │         │    └── variable: t1._decimal [type=int]
+ │    │    │         │         │         ├── const-agg [type=int, outer=(44)]
+ │    │    │         │         │         │    └── variable: t4._int8 [type=int]
+ │    │    │         │         │         └── const-agg [type=timestamptz, outer=(45)]
+ │    │    │         │         │              └── variable: t4._timestamptz [type=timestamptz]
+ │    │    │         │         └── filters
+ │    │    │         │              └── true_agg IS NOT NULL [type=bool, outer=(41), constraints=(/41: (/NULL - ]; tight)]
+ │    │    │         ├── scan t5
+ │    │    │         │    └── columns: t5._decimal:54(int)
+ │    │    │         └── filters
+ │    │    │              └── t1._decimal = t5._decimal [type=bool, outer=(19,54), constraints=(/19: (/NULL - ]; /54: (/NULL - ]), fd=(19)==(54), (54)==(19)]
+ │    │    └── const: 66 [type=int]
+ │    └── filters (true)
+ └── projections
+      └── null [type=unknown]
+
 # --------------------------------------------------
 # TryDecorrelateScalarGroupBy
 # --------------------------------------------------


### PR DESCRIPTION
This commit fixes the `TryDecorrelateGroupBy` normalization rule to
preserve the output columns of the original expression. Since the
rule may add a `rownum` column to ensure a key, it's possible that this
new column could inadvertently become an output column. This commit
wraps the output in a `Project` expression to ensure that only the original
output columns are projected.

Fixes #40592

Release note: None