### PR TITLE
storage/reports: fix NPE in zone visiting

### DIFF
--- a/pkg/storage/reports/constraint_report.go
+++ b/pkg/storage/reports/constraint_report.go
@@ -427,7 +427,7 @@ func (v *constraintConformanceVisitor) visit(ctx context.Context, r roachpb.Rang
 	// Find the applicable constraints, which may be inherited.
 	var constraints []config.Constraints
 	var zKey ZoneKey
-	err := visitZones(ctx, r, v.cfg,
+	_, err := visitZones(ctx, r, v.cfg,
 		func(_ context.Context, zone *config.ZoneConfig, key ZoneKey) bool {
 			if zone.Constraints == nil {
 				return false

--- a/pkg/storage/reports/locality_report.go
+++ b/pkg/storage/reports/locality_report.go
@@ -318,15 +318,20 @@ func processLocalityForRange(
 ) {
 	// Get the zone.
 	var zKey ZoneKey
-	if err := visitZones(ctx, r, cfg,
+	found, err := visitZones(ctx, r, cfg,
 		func(_ context.Context, zone *config.ZoneConfig, key ZoneKey) bool {
 			if zone.IsSubzonePlaceholder() {
 				return false
 			}
 			zKey = key
 			return true
-		}); err != nil {
+		})
+	if err != nil {
 		log.Fatalf(ctx, "unexpected error visiting zones: %s", err)
+	}
+	if !found {
+		log.Errorf(ctx, "no suitable zone config found for range: %s", &r)
+		return
 	}
 
 	// Compute the required quorum and the number of live nodes. If the number of live nodes gets lower


### PR DESCRIPTION
We were inadvertently returning early from visitZones() without
exhausting the hierarchy, resulting in NPE in the replication_stats
visitor and I think wrong results in the critical localities visitor.

Release note: None