### PR TITLE
storage: deflake TestSnapshotAfterTruncationWithUncommittedTail

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -955,6 +955,7 @@ func TestSnapshotAfterTruncationWithUncommittedTail(t *testing.T) {
 	// includes the increment).
 	truncArgs := truncateLogArgs(index+1, 1)
 	testutils.SucceedsSoon(t, func() error {
+		mtc.advanceClock(ctx)
 		_, pErr := client.SendWrapped(ctx, newLeaderReplSender, truncArgs)
 		if _, ok := pErr.GetDetail().(*roachpb.NotLeaseHolderError); ok {
 			return pErr.GoError()


### PR DESCRIPTION
Fixes #40608. Between sending out the increment and log truncation
requests, the leaseholder may have changed from underneath us. Since the
range in question is using an expiration based lease, when we run into a
NotLeaseHolderError and don't correct for it, we're stuck trying to send
the request to a non-leaseholder.

Release note: None