### PR TITLE
distsqlrun: bump version to avoid bug

### DIFF
--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -75,7 +75,7 @@ import (
 //
 // ATTENTION: When updating these fields, add to version_history.txt explaining
 // what changed.
-const Version distsqlpb.DistSQLVersion = 22
+const Version distsqlpb.DistSQLVersion = 23
 
 // MinAcceptedVersion is the oldest version that the server is
 // compatible with; see above.

--- a/pkg/sql/distsqlrun/version_history.txt
+++ b/pkg/sql/distsqlrun/version_history.txt
@@ -89,3 +89,6 @@
 - Version: 22 (MinAcceptedVersion: 21)
     - Change date math to better align with PostgreSQL:
       https://github.com/cockroachdb/cockroach/pull/31146
+- Version: 23 (MinAcceptedVersion: 21)
+    - Permit non-public scans in joinReader to prevent correctness errors during
+      index backfills.


### PR DESCRIPTION
The change to permit non-public scans in joinReader in #38917 failed to
bump the version number, which led to issues. This version bump prevents
further problems of this nature.

Fixes #40408.

Release note (bug fix): prevent problems on mixed-version 19.1 clusters
that are also performing a lookup join on a table that has an ongoing
index backfill.