### PR TITLE
roachpb: make RangeDesc implement Stringer

### DIFF
--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -299,7 +299,7 @@ func (r *RangeDescriptor) Validate() error {
 	return nil
 }
 
-func (r *RangeDescriptor) String() string {
+func (r RangeDescriptor) String() string {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "r%d:", r.RangeID)
 


### PR DESCRIPTION
We had String() implemented on a pointer receiver, which meant that a
RangeDesc value does not implement the interface, which means that
Printf("%s", rd) is no good. This patch moves the implementation to a
value receiver, which means that both values and pointers implement
Stringer. RangeDesc is a fairly small struct.

I believe this ugly formatting bit me multiple times over the years.

Release note: None