### PR TITLE
githooks: add Release justification hint and lint

### DIFF
--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -6,6 +6,17 @@ source "$(dirname "${0}")/teamcity-support.sh"
 
 tc_prepare
 
+# TODO(jordan): remove this after we cut the 19.2 branch.
+tc_start_block "Ensure commit message contains a release justification"
+# Ensure master branch commits have a release justification until 19.2 goes out the door.
+if [[ $(git log -n1 | grep -ci "Release justification: \S\+") == 0 ]]; then
+  echo "Build Failed. No Release justification in commit message." >&2
+  echo "Commits must have a Release justification of the form:" >&2
+  echo "Release justification: <some description of why this commit is safe to add to the release branch.>" >&2
+  exit 1
+fi
+tc_end_block "Ensure commit message contains a release justification"
+
 tc_start_block "Ensure dependencies are up-to-date"
 run build/builder.sh go install ./vendor/github.com/golang/dep/cmd/dep ./pkg/cmd/github-pull-request-make
 run build/builder.sh env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" TARGET=checkdeps github-pull-request-make

--- a/githooks/commit-msg
+++ b/githooks/commit-msg
@@ -43,8 +43,10 @@ saveIFS=$IFS
 IFS='
 '
 notes=($($grep -iE '^release note' "$1"))
-IFS=$saveIFS
 
+justification=($($grep -iE '^release justification: \S+' "$1"))
+
+IFS=$saveIFS
 
 informed=
 inform() {
@@ -59,6 +61,12 @@ hint() {
     inform
     echo "- $*" >&2
 }
+
+if [ 0 = ${#justification[*]} ]; then
+    warn "No release justification specified."
+    echo "Try: 'Release justification: This commit is safe for 19.2 because..." >&2
+    echo >&2
+fi
 
 if [ 0 = ${#notes[*]} ]; then
     warn "No release note specified."


### PR DESCRIPTION
Commits until 19.2 need a release justification. This commit adds a
prompt to the git commit messages hooks, and adds a step to the linter
to ensure all commits have this justification.

Release note: None
Release justification: Not a code change.