### PR TITLE
exec: bugfix to constNull op; add tests

### DIFF
--- a/pkg/sql/exec/const_test.go
+++ b/pkg/sql/exec/const_test.go
@@ -25,9 +25,13 @@ func TestConst(t *testing.T) {
 			tuples:   tuples{{1}, {1}},
 			expected: tuples{{1, 9}, {1, 9}},
 		},
+		{
+			tuples:   tuples{},
+			expected: tuples{},
+		},
 	}
 	for _, tc := range tcs {
-		runTests(t, []tuples{tc.tuples}, tc.expected, orderedVerifier, []int{0, 1},
+		runTestsWithTyps(t, []tuples{tc.tuples}, []coltypes.T{coltypes.Int64}, tc.expected, orderedVerifier, []int{0, 1},
 			func(input []Operator) (Operator, error) {
 				return NewConstOp(input[0], coltypes.Int64, int64(9), 1)
 			})
@@ -43,9 +47,13 @@ func TestConstNull(t *testing.T) {
 			tuples:   tuples{{1}, {1}},
 			expected: tuples{{1, nil}, {1, nil}},
 		},
+		{
+			tuples:   tuples{},
+			expected: tuples{},
+		},
 	}
 	for _, tc := range tcs {
-		runTests(t, []tuples{tc.tuples}, tc.expected, orderedVerifier, []int{0, 1},
+		runTestsWithTyps(t, []tuples{tc.tuples}, []coltypes.T{coltypes.Int64}, tc.expected, orderedVerifier, []int{0, 1},
 			func(input []Operator) (Operator, error) {
 				return NewConstNullOp(input[0], 1), nil
 			})

--- a/pkg/sql/exec/const_tmpl.go
+++ b/pkg/sql/exec/const_tmpl.go
@@ -130,13 +130,13 @@ func (c constNullOp) Init() {
 func (c constNullOp) Next(ctx context.Context) coldata.Batch {
 	batch := c.input.Next(ctx)
 	n := batch.Length()
+	if batch.Width() == c.outputIdx {
+		batch.AppendCol(coltypes.Int8)
+	}
 	if n == 0 {
 		return batch
 	}
 
-	if batch.Width() == c.outputIdx {
-		batch.AppendCol(coltypes.Int8)
-	}
 	col := batch.ColVec(c.outputIdx)
 	nulls := col.Nulls()
 	if sel := batch.Selection(); sel != nil {

--- a/pkg/sql/exec/utils_test.go
+++ b/pkg/sql/exec/utils_test.go
@@ -413,11 +413,11 @@ func newOpTestSelInput(
 }
 
 func (s *opTestInput) Init() {
-	if len(s.tuples) == 0 {
-		execerror.VectorizedInternalPanic("empty tuple source")
-	}
-
 	if s.typs == nil {
+		if len(s.tuples) == 0 {
+			execerror.VectorizedInternalPanic("empty tuple source with no specified types")
+		}
+
 		// The type schema was not provided, so we need to determine it based on
 		// the input tuple.
 		s.typs = make([]coltypes.T, len(s.tuples[0]))


### PR DESCRIPTION
This fixes a bug in constNullOp, which wasn't always widening the batch
if there were no input tuples.

Also, add tests for this behavior in both const ops.

Release note: None
Release justification: low-risk bugfix.