### PR TITLE
build: fix the deletion of old pkg/sql/exec/*.eg.go files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -821,7 +821,7 @@ execgen-exclusions = $(addprefix -not -path ,$(EXECGEN_TARGETS))
 
 $(info Cleaning old generated files.)
 $(shell find pkg/sql/colexec -type f -name '*.eg.go' $(execgen-exclusions) -delete)
-$(shell find pkg/sql/exec -type f -name '*.eg.go' $(execgen-exclusions) -delete || true)
+$(shell find pkg/sql/exec -type f -name '*.eg.go' $(execgen-exclusions) -delete 2>/dev/null)
 
 OPTGEN_TARGETS = \
 	pkg/sql/opt/memo/expr.og.go \
@@ -1496,9 +1496,6 @@ pkg/sql/colexec/vecbuiltins/row_number.eg.go: pkg/sql/colexec/vecbuiltins/row_nu
 pkg/sql/colexec/zerocolumns.eg.go: pkg/sql/colexec/zerocolumns_tmpl.go
 
 $(EXECGEN_TARGETS): bin/execgen
-	@# Remove generated files with the old suffix to avoid conflicts.
-	@# See https://github.com/cockroachdb/cockroach/pull/32265.
-	@rm -f pkg/sql/colexec/*.og.go
 	execgen $@
 
 optgen-defs := pkg/sql/opt/ops/*.opt
@@ -1551,7 +1548,7 @@ unsafe-clean-c-deps:
 .PHONY: clean-execgen-files
 clean-execgen-files:
 	find ./pkg/sql/colexec -type f -name '*.eg.go' -exec rm {} +
-	find ./pkg/sql/exec -type f -name '*.eg.go' -exec rm {} + || true
+	test -d ./pkg/sql/exec && find ./pkg/sql/exec -type f -name '*.eg.go' -exec rm {} + || true
 
 .PHONY: clean
 clean: ## Remove build artifacts.


### PR DESCRIPTION
With the recent renaming of pkg/sql/exec to pkg/sql/colexec, we
want to remove the files generated into the old directory. However,
the previous commands were not error-prone, i.e. if the directory
didn't exist, the command would fail which would in turn could fail
the build. Now this is fixed by either redirecting the error into
/dev/null or testing for presence of the old directory.

Also, remove the unnecessary command to delete pkg/sql/exec/*.og.go
files (this was needed only for a few weeks in the Fall of 2018).

Release justification: Category 1: Non-production code changes.

Release note: None