### PR TITLE
sql: improve error message for constraint parsing

### DIFF
--- a/pkg/config/zone_yaml.go
+++ b/pkg/config/zone_yaml.go
@@ -16,8 +16,9 @@ import (
 	"sort"
 	"strings"
 
-	proto "github.com/gogo/protobuf/proto"
-	yaml "gopkg.in/yaml.v2"
+	"github.com/cockroachdb/errors"
+	"github.com/gogo/protobuf/proto"
+	"gopkg.in/yaml.v2"
 )
 
 var _ yaml.Marshaler = LeasePreference{}
@@ -141,7 +142,8 @@ func (c *ConstraintsList) UnmarshalYAML(unmarshal func(interface{}) error) error
 	// constraints.
 	constraintsMap := make(map[string]int32)
 	if err := unmarshal(&constraintsMap); err != nil {
-		return err
+		return errors.New(
+			"invalid constraints format. expected an array of strings or a map of strings to ints")
 	}
 
 	constraintsList := make([]Constraints, 0, len(constraintsMap))


### PR DESCRIPTION
We used to throw a cryptic yaml error when zone config constraints could
not be parsed. Now we return a friendlier error message which specifies
what format was expected.

Release justification: Low-risk error messaging improvement

Release note: None