### PR TITLE
roachprod: Add provisioning of GCP n2-class machines w/ local SSDs

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -1581,6 +1581,8 @@ func main() {
 		"lifetime", "l", 12*time.Hour, "Lifetime of the cluster")
 	createCmd.Flags().BoolVar(&createVMOpts.SSDOpts.UseLocalSSD,
 		"local-ssd", true, "Use local SSD")
+	createCmd.Flags().IntVar(&createVMOpts.SSDOpts.GCESSDCount,
+		"gce-local-ssd-count", 1, "Number of local SSDs to create on GCE instance")
 	createCmd.Flags().BoolVar(&createVMOpts.SSDOpts.NoExt4Barrier,
 		"local-ssd-no-ext4-barrier", true,
 		`Mount the local SSD with the "-o nobarrier" flag. `+

--- a/pkg/cmd/roachprod/vm/vm.go
+++ b/pkg/cmd/roachprod/vm/vm.go
@@ -119,6 +119,7 @@ type CreateOpts struct {
 	VMProviders    []string
 	SSDOpts        struct {
 		UseLocalSSD bool
+		GCESSDCount int
 		// NoExt4Barrier, if set, makes the "-o nobarrier" flag be used when
 		// mounting the SSD. Ignored if UseLocalSSD is not set.
 		NoExt4Barrier bool


### PR DESCRIPTION
n2-class machines in GCP allow only [0, 2, 4, 8] local SSDs to be requested. When roachprod requested local SSDs on these machine types, it only requested 1, which prevented the request to provision n2-class machines from ever completing.

To solve this problem, this PR adds a flag to request any number of local SSDs on a machine and automatically adjusts the requests for n2-class machines to contain 2 SSDs.

Note that this change only supports the "default" case; if one manually sets `--gce-local-ssd-count` to some higher value that's incompatible with the n2-class machines, `roachprod` will still error out. I think this is a good compromise so we're not expected to encode the VM's requirements into `roachprod` but still provides some sane defaults to actually let users create clusters without stubbing their toes.

Release note: None