### PR TITLE
workload: remove index hints from TPC-C

### DIFF
--- a/pkg/workload/tpcc/order_status.go
+++ b/pkg/workload/tpcc/order_status.go
@@ -12,7 +12,6 @@ package tpcc
 
 import (
 	"context"
-	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -85,18 +84,12 @@ func createOrderStatus(
 		WHERE c_w_id = $1 AND c_d_id = $2 AND c_id = $3`,
 	)
 
-	// TODO(radu): this is only useful for the heuristic planner.
-	indexStr := "@customer_idx"
-	if o.config.usePostgres {
-		indexStr = ""
-	}
-
 	// Pick the middle row, rounded up, from the selection by last name.
-	o.selectByLastName = o.sr.Define(fmt.Sprintf(`
+	o.selectByLastName = o.sr.Define(`
 		SELECT c_id, c_balance, c_first, c_middle
-		FROM customer%s
+		FROM customer
 		WHERE c_w_id = $1 AND c_d_id = $2 AND c_last = $3
-		ORDER BY c_first ASC`, indexStr),
+		ORDER BY c_first ASC`,
 	)
 
 	// Select the customer's order.

--- a/pkg/workload/tpcc/payment.go
+++ b/pkg/workload/tpcc/payment.go
@@ -109,20 +109,12 @@ func createPayment(ctx context.Context, config *tpcc, mcp *workload.MultiConnPoo
 		RETURNING d_name, d_street_1, d_street_2, d_city, d_state, d_zip`,
 	)
 
-	// TODD(radu): this is no longer necessary with the optimizer. Keep it for now
-	// for comparisons against the heuristic planner.
-	custIndexStr := "@customer_idx"
-	if config.usePostgres {
-		custIndexStr = ""
-	}
-
 	// 2.5.2.2 Case 2: Pick the middle row, rounded up, from the selection by last name.
-	p.selectByLastName = p.sr.Define(fmt.Sprintf(`
+	p.selectByLastName = p.sr.Define(`
 		SELECT c_id
-		FROM customer%s
+		FROM customer
 		WHERE c_w_id = $1 AND c_d_id = $2 AND c_last = $3
 		ORDER BY c_first ASC`,
-		custIndexStr),
 	)
 
 	// Update customer with payment.


### PR DESCRIPTION
The heuristic planner benefitted from index hints in some TPC-C statements, but they're now vestigial with the new optimizer. I have removed them to alleviate some of the fussiness of manipulating TPC-C for things like PostgreSQL compatibility.

Release note: None

Release justification: workload-only change.