### PR TITLE
sql: replace an internal error in EXPLAIN (DISTSQL) and EXPLAIN (VEC)

### DIFF
--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/errors"
 	"github.com/opentracing/opentracing-go"
 )
 
@@ -116,6 +117,10 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 
 	plan, err := makePhysicalPlan(planCtx, distSQLPlanner, n.plan)
 	if err != nil {
+		if len(n.subqueryPlans) > 0 {
+			return errors.New("running EXPLAIN (DISTSQL) on this query is " +
+				"unsupported because of the presence of subqueries")
+		}
 		return err
 	}
 

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
+	"github.com/cockroachdb/errors"
 )
 
 // explainVecNode is a planNode that wraps a plan and returns
@@ -61,6 +62,10 @@ func (n *explainVecNode) startExec(params runParams) error {
 	}()
 	plan, err := makePhysicalPlan(planCtx, distSQLPlanner, n.plan)
 	if err != nil {
+		if len(n.subqueryPlans) > 0 {
+			return errors.New("running EXPLAIN (VEC) on this query is " +
+				"unsupported because of the presence of subqueries")
+		}
 		return err
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -1,0 +1,15 @@
+# LogicTest: local local-vec-off
+
+statement ok
+CREATE TABLE t (a INT PRIMARY KEY)
+
+# Test that EXPLAIN (DISTSQL) on a query with a subquery works.
+query T
+SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM (SELECT avg(a) OVER () FROM t)]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJyUkDFLBDEQhXt_xfEqhchttky1VnKNJ6doISniZjgCe0nIzKJy7H-X3RR6womW8ybf-8IcEZOnO3cghnmBhlXIJfXEnMoc1Qcb_w7TKISYR5ljq9CnQjBHSJCBYPDoXgfakfNU1g0UPIkLw1KbSzi48tEJFB6yi2xW17CTQhrlq5DF7QlGT-rv0ucQfXqjstanxpun28tOX0FhO4pZde1ZXfsf3Y44p8h0IjvX3ExWgfye6h05jaWn-5L6RVPH7cItgSeWutV12MS6mj_4Hda_wu0P2E4XnwEAAP__EY6e-w==
+
+# Test that explaining a query that contains a subquery the result of which is
+# needed to make the physical plan is rejected. See #40677.
+statement error running EXPLAIN \(DISTSQL\) on this query is unsupported because of the presence of subqueries
+EXPLAIN (DISTSQL) SELECT avg(a) OVER (ROWS (SELECT count(*) FROM t) PRECEDING) FROM t


### PR DESCRIPTION
Currently, when we're explaining a query that has a subquery value
of which is needed to construct the physical plan, we error out with
an internal error. This commit replaces that stack trace with a more
user-friendly message saying that explaining such a query is not
supported.

Addresses: #40677.

Release justification: Category 2: Bug fixes and low-risk updates to
new functionality.

Release note: None