### PR TITLE
demo: Adding simulated geographical latencies to cockroach demo 

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -945,6 +945,13 @@ Start with an empty database: avoid pre-loading a default dataset in
 the demo shell.`,
 	}
 
+	Global = FlagInfo{
+		Name: "global",
+		Description: `
+Simulate a global cluster. This adds artificial latencies to nodes in different
+regions. This flag only works with the default node localities. This setting is experimental.`,
+	}
+
 	LogDir = FlagInfo{
 		Name: "log-dir",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -146,6 +146,7 @@ func initCLIDefaults() {
 
 	demoCtx.nodes = 1
 	demoCtx.useEmptyDatabase = false
+	demoCtx.simulateLatency = false
 	demoCtx.runWorkload = false
 	demoCtx.localities = nil
 	demoCtx.geoPartitionedReplicas = false
@@ -352,4 +353,5 @@ var demoCtx struct {
 	runWorkload               bool
 	localities                demoLocalityList
 	geoPartitionedReplicas    bool
+	simulateLatency           bool
 }

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -602,6 +602,9 @@ func init() {
 	// The --empty flag is only valid for the top level demo command,
 	// so we use the regular flag set.
 	BoolFlag(demoCmd.Flags(), &demoCtx.useEmptyDatabase, cliflags.UseEmptyDatabase, false)
+	BoolFlag(demoCmd.Flags(), &demoCtx.simulateLatency, cliflags.Global, false)
+	// Mark the --global flag as hidden until we investigate it more.
+	_ = demoCmd.Flags().MarkHidden(cliflags.Global.Name)
 
 	// sqlfmt command.
 	fmtFlags := sqlfmtCmd.Flags()

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -547,6 +547,17 @@ func (l *Locality) Set(value string) error {
 	return nil
 }
 
+// Find searches the locality's tiers for the input key, returning its value if
+// present.
+func (l *Locality) Find(key string) (value string, ok bool) {
+	for i := range l.Tiers {
+		if l.Tiers[i].Key == key {
+			return l.Tiers[i].Value, true
+		}
+	}
+	return "", false
+}
+
 // DefaultLocationInformation is used to populate the system.locations
 // table. The region values here are specific to GCP.
 var DefaultLocationInformation = []struct {

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -11,7 +11,9 @@
 package rpc
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"math"
@@ -766,6 +768,109 @@ func (ood *onlyOnceDialer) dial(ctx context.Context, addr string) (net.Conn, err
 	return nil, grpcutil.ErrCannotReuseClientConn
 }
 
+type dialerFunc func(context.Context, string) (net.Conn, error)
+
+type artificialLatencyDialer struct {
+	dialerFunc dialerFunc
+	latencyMS  int
+}
+
+func (ald *artificialLatencyDialer) dial(ctx context.Context, addr string) (net.Conn, error) {
+	conn, err := ald.dialerFunc(ctx, addr)
+	if err != nil {
+		return conn, err
+	}
+	return delayingConn{
+		Conn:    conn,
+		latency: time.Duration(ald.latencyMS) * time.Millisecond,
+		readBuf: new(bytes.Buffer),
+	}, nil
+}
+
+type delayingListener struct {
+	net.Listener
+}
+
+// NewDelayingListener creates a net.Listener that introduces a set delay on its connections.
+func NewDelayingListener(l net.Listener) net.Listener {
+	return delayingListener{Listener: l}
+}
+
+func (d delayingListener) Accept() (net.Conn, error) {
+	c, err := d.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	return delayingConn{
+		Conn: c,
+		// Put a default latency as the server's conn. This value will get populated
+		// as packets are exchanged across the delayingConnections.
+		latency: time.Duration(0) * time.Millisecond,
+		readBuf: new(bytes.Buffer),
+	}, nil
+}
+
+type delayingConn struct {
+	net.Conn
+	latency     time.Duration
+	lastSendEnd time.Time
+	readBuf     *bytes.Buffer
+}
+
+func (d delayingConn) Write(b []byte) (n int, err error) {
+	tNow := timeutil.Now()
+	if d.lastSendEnd.Before(tNow) {
+		d.lastSendEnd = tNow
+	}
+	hdr := delayingHeader{
+		Magic:    magic,
+		ReadTime: d.lastSendEnd.Add(d.latency).UnixNano(),
+		Sz:       int32(len(b)),
+		DelayMS:  int32(d.latency / time.Millisecond),
+	}
+	if err := binary.Write(d.Conn, binary.BigEndian, hdr); err != nil {
+		return n, err
+	}
+	x, err := d.Conn.Write(b)
+	n += x
+	return n, err
+}
+
+func (d delayingConn) Read(b []byte) (n int, err error) {
+	if d.readBuf.Len() == 0 {
+		var hdr delayingHeader
+		if err := binary.Read(d.Conn, binary.BigEndian, &hdr); err != nil {
+			return 0, err
+		}
+		// If we somehow don't get our expected magic, throw an error.
+		if hdr.Magic != magic {
+			panic(errors.New("didn't get expected magic bytes header"))
+			// TODO (rohany): I can't get this to work. I suspect that the problem
+			//  is with that maybe the improperly parsed struct is not written back
+			//  into the same binary format that it was read as. I tried this with sending
+			//  the magic integer over first and saw the same thing.
+		} else {
+			d.latency = time.Duration(hdr.DelayMS) * time.Millisecond
+			defer func() {
+				time.Sleep(timeutil.Until(timeutil.Unix(0, hdr.ReadTime)))
+			}()
+			if _, err := io.CopyN(d.readBuf, d.Conn, int64(hdr.Sz)); err != nil {
+				return 0, err
+			}
+		}
+	}
+	return d.readBuf.Read(b)
+}
+
+const magic = 0xfeedfeed
+
+type delayingHeader struct {
+	Magic    int64
+	ReadTime int64
+	Sz       int32
+	DelayMS  int32
+}
+
 // GRPCDialRaw calls grpc.Dial with options appropriate for the context.
 // Unlike GRPCDialNode, it does not start an RPC heartbeat to validate the
 // connection. This connection will not be reconnected automatically;
@@ -773,11 +878,11 @@ func (ood *onlyOnceDialer) dial(ctx context.Context, addr string) (net.Conn, err
 // This method implies a DefaultClass ConnectionClass for the returned
 // ClientConn.
 func (ctx *Context) GRPCDialRaw(target string) (*grpc.ClientConn, <-chan struct{}, error) {
-	return ctx.grpcDialRaw(target, DefaultClass)
+	return ctx.grpcDialRaw(target, 0, DefaultClass)
 }
 
 func (ctx *Context) grpcDialRaw(
-	target string, class ConnectionClass,
+	target string, remoteNodeID roachpb.NodeID, class ConnectionClass,
 ) (*grpc.ClientConn, <-chan struct{}, error) {
 	dialOpts, err := ctx.grpcDialOptions(target, class)
 	if err != nil {
@@ -796,7 +901,18 @@ func (ctx *Context) grpcDialRaw(
 	dialer := onlyOnceDialer{
 		redialChan: make(chan struct{}),
 	}
-	dialOpts = append(dialOpts, grpc.WithContextDialer(dialer.dial))
+	dialerFunc := dialer.dial
+	if ctx.testingKnobs.ArtificialLatencyMap != nil {
+		latency := ctx.testingKnobs.ArtificialLatencyMap[target]
+		log.VEventf(ctx.masterCtx, 1, "Connecting to node %s (%d) with simulated latency %dms", target, remoteNodeID,
+			latency)
+		dialer := artificialLatencyDialer{
+			dialerFunc: dialerFunc,
+			latencyMS:  latency,
+		}
+		dialerFunc = dialer.dial
+	}
+	dialOpts = append(dialOpts, grpc.WithContextDialer(dialerFunc))
 
 	// add testingDialOpts after our dialer because one of our tests
 	// uses a custom dialer (this disables the only-one-connection
@@ -870,7 +986,7 @@ func (ctx *Context) grpcDialNodeInternal(
 		// Either we kick off the heartbeat loop (and clean up when it's done),
 		// or we clean up the connKey entries immediately.
 		var redialChan <-chan struct{}
-		conn.grpcConn, redialChan, conn.dialErr = ctx.grpcDialRaw(target, class)
+		conn.grpcConn, redialChan, conn.dialErr = ctx.grpcDialRaw(target, remoteNodeID, class)
 		if conn.dialErr == nil {
 			if err := ctx.Stopper.RunTask(
 				ctx.masterCtx, "rpc.Context: grpc heartbeat", func(masterCtx context.Context) {

--- a/pkg/rpc/context_testutils.go
+++ b/pkg/rpc/context_testutils.go
@@ -38,6 +38,12 @@ type ContextTestingKnobs struct {
 	// for a given target and class.
 	StreamClientInterceptor func(target string, class ConnectionClass) grpc.StreamClientInterceptor
 
+	// ArtificialLatencyMap if non-nil contains a map from target address
+	// (server.RPCServingAddr() of a remote node) to artificial latency in
+	// milliseconds to inject. Setting this will cause the server to pause for
+	// the given amount of milliseconds on every network write.
+	ArtificialLatencyMap map[string]int
+
 	// ClusterID initializes the Context's ClusterID container to this value if
 	// non-nil at construction time.
 	ClusterID *uuid.UUID

--- a/pkg/server/server_update.go
+++ b/pkg/server/server_update.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -32,6 +33,14 @@ type TestingKnobs struct {
 	DefaultZoneConfigOverride *config.ZoneConfig
 	// DefaultSystemZoneConfigOverride, if set, overrides the default system zone config defined in `pkg/config/zone.go`
 	DefaultSystemZoneConfigOverride *config.ZoneConfig
+	// PauseAfterGettingRPCAddress, if non-nil, instructs the server to wait until
+	// the channel is closed after getting an RPC serving address.
+	PauseAfterGettingRPCAddress chan struct{}
+	// SignalAfterGettingRPCAddress, if non-nil, is closed after the server gets
+	// an RPC server address.
+	SignalAfterGettingRPCAddress chan struct{}
+	// ContextTestingKnobs allows customization of the RPC context testing knobs.
+	ContextTestingKnobs rpc.ContextTestingKnobs
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
This PR adds simulated geographical latencies to the test cluster
that cockroach demo runs. This setting can be activated using the
--global demo flag.

The latency simulation is implemented by creating a custom net.Conn
implementation that is used by gRPC instead of the default Conn. This
conn does the following:
* on writes, send a timestamp at which this message should be read
* on reads, wait until the timestamp on the message to read the data

Release justification: bug fixes and low-risk updates to new functionality

Release note (cli change): An *experimental* feature for simulating
global latencies within the cockroach demo multi node cluster. This can
be enabled with the `--global` flag, which is hidden from the help
message.