### PR TITLE
sql: another syntax hint for ALTER PARTITION

### DIFF
--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -2684,6 +2684,14 @@ CREATE STATISTICS a ON col1 FROM t WITH OPTIONS AS OF SYSTEM TIME '-1s' THROTTLI
                                                                                                               ^`,
 		},
 		{
+			`ALTER PARTITION p OF TABLE tbl@idx CONFIGURE ZONE USING num_replicas = 1`,
+			`at or near "idx": syntax error: index name should not be specified in ALTER PARTITION ... OF TABLE
+DETAIL: source SQL:
+ALTER PARTITION p OF TABLE tbl@idx CONFIGURE ZONE USING num_replicas = 1
+                               ^
+HINT: try ALTER PARTITION ... OF INDEX`,
+		},
+		{
 			`ALTER PARTITION p OF TABLE tbl@* CONFIGURE ZONE USING num_replicas = 1`,
 			`at or near "configure": syntax error: index wildcard unsupported in ALTER PARTITION ... OF TABLE
 DETAIL: source SQL:

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1505,6 +1505,12 @@ alter_zone_partition_stmt:
     s.AllIndexes = true
     $$.val = s
   }
+| ALTER PARTITION partition_name OF TABLE table_name '@' error
+  {
+    err := errors.New("index name should not be specified in ALTER PARTITION ... OF TABLE")
+    err = errors.WithHint(err, "try ALTER PARTITION ... OF INDEX")
+    return setErr(sqllex, err)
+  }
 | ALTER PARTITION partition_name OF TABLE table_name '@' '*' error
   {
     err := errors.New("index wildcard unsupported in ALTER PARTITION ... OF TABLE")


### PR DESCRIPTION
If a user tries to specify an index in ALTER PARTITION ... OF TABLE,
they now receive a hint to use ALTER PARTITION ... OF INDEX instead.

I added similar logic recently but only for the index wildcard syntax,
<tablename>@*.

Release justification: Low-risk error messaging improvement

Release note: None