### PR TITLE
githooks: enhance Release justification error message

### DIFF
--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -10,7 +10,7 @@ tc_prepare
 tc_start_block "Ensure commit message contains a release justification"
 # Ensure master branch commits have a release justification until 19.2 goes out the door.
 if [[ $(git log -n1 | grep -ci "Release justification: \S\+") == 0 ]]; then
-  echo "Build Failed. No Release justification in commit message." >&2
+  echo "Build Failed. No Release justification in the commit message or in the PR description." >&2
   echo "Commits must have a Release justification of the form:" >&2
   echo "Release justification: <some description of why this commit is safe to add to the release branch.>" >&2
   exit 1


### PR DESCRIPTION
Commits until 19.2 need a release justification. This commit extends
an error message, hinting that release justification might be absent
either in a commit message, or in a PR description (when bors build happens).

Release justification: Not a code change.
Release note: None