### PR TITLE
server: hang the reporter from the server, not from the node

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
-	"github.com/cockroachdb/cockroach/pkg/storage/reports"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/growstack"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
@@ -143,19 +142,18 @@ func (nm nodeMetrics) callComplete(d time.Duration, pErr *roachpb.Error) {
 // IDs for bootstrapping the node itself or new stores as they're added
 // on subsequent instantiations.
 type Node struct {
-	stopper                  *stop.Stopper
-	clusterID                *base.ClusterIDContainer // UUID for Cockroach cluster
-	Descriptor               roachpb.NodeDescriptor   // Node ID, network/physical topology
-	storeCfg                 storage.StoreConfig      // Config to use and pass to stores
-	eventLogger              sql.EventLogger
-	stores                   *storage.Stores // Access to node-local stores
-	metrics                  nodeMetrics
-	recorder                 *status.MetricsRecorder
-	constraintStatsCollector *reports.Reporter
-	startedAt                int64
-	lastUp                   int64
-	initialBoot              bool // True if this is the first time this node has started.
-	txnMetrics               kv.TxnMetrics
+	stopper     *stop.Stopper
+	clusterID   *base.ClusterIDContainer // UUID for Cockroach cluster
+	Descriptor  roachpb.NodeDescriptor   // Node ID, network/physical topology
+	storeCfg    storage.StoreConfig      // Config to use and pass to stores
+	eventLogger sql.EventLogger
+	stores      *storage.Stores // Access to node-local stores
+	metrics     nodeMetrics
+	recorder    *status.MetricsRecorder
+	startedAt   int64
+	lastUp      int64
+	initialBoot bool // True if this is the first time this node has started.
+	txnMetrics  kv.TxnMetrics
 
 	perReplicaServer storage.Server
 }
@@ -273,7 +271,6 @@ func NewNode(
 		eventLogger: eventLogger,
 		clusterID:   clusterID,
 	}
-	n.constraintStatsCollector = reports.NewReporter(n.stores, &n.storeCfg)
 	n.perReplicaServer = storage.MakeServer(&n.Descriptor, n.stores)
 	return n
 }
@@ -500,8 +497,6 @@ func (n *Node) start(
 	// cluster version, but not if the server starts with a lower one and gets
 	// bumped immediately, which would be possible if gossip got started earlier).
 	n.startGossip(ctx, n.stopper)
-
-	n.constraintStatsCollector.Start(ctx, n.stopper)
 
 	allEngines := append([]engine.Engine(nil), initializedEngines...)
 	allEngines = append(allEngines, emptyEngines...)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -495,7 +495,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	roachpb.RegisterInternalServer(s.grpc.Server, s.node)
 	storage.RegisterPerReplicaServer(s.grpc.Server, s.node.perReplicaServer)
 	s.node.storeCfg.ClosedTimestamp.RegisterClosedTimestampServer(s.grpc.Server)
-	s.replicationReporter = reports.NewReporter(s.node.stores, &s.node.storeCfg)
+	s.replicationReporter = reports.NewReporter(
+		s.db, s.node.stores, s.storePool,
+		s.ClusterSettings(), s.nodeLiveness, internalExecutor)
 
 	s.sessionRegistry = sql.NewSessionRegistry()
 	s.jobRegistry = jobs.MakeRegistry(

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -59,6 +59,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/bulk"
 	"github.com/cockroachdb/cockroach/pkg/storage/closedts/container"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/reports"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/ui"
@@ -78,7 +79,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/logtags"
-	"github.com/getsentry/raven-go"
+	raven "github.com/getsentry/raven-go"
 	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -184,12 +185,13 @@ type Server struct {
 	leaseMgr         *sql.LeaseManager
 	// sessionRegistry can be queried for info on running SQL sessions. It is
 	// shared between the sql.Server and the statusServer.
-	sessionRegistry    *sql.SessionRegistry
-	jobRegistry        *jobs.Registry
-	statsRefresher     *stats.Refresher
-	engines            Engines
-	internalMemMetrics sql.MemoryMetrics
-	adminMemMetrics    sql.MemoryMetrics
+	sessionRegistry     *sql.SessionRegistry
+	jobRegistry         *jobs.Registry
+	statsRefresher      *stats.Refresher
+	replicationReporter *reports.Reporter
+	engines             Engines
+	internalMemMetrics  sql.MemoryMetrics
+	adminMemMetrics     sql.MemoryMetrics
 	// sqlMemMetrics are used to track memory usage of sql sessions.
 	sqlMemMetrics sql.MemoryMetrics
 }
@@ -493,6 +495,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	roachpb.RegisterInternalServer(s.grpc.Server, s.node)
 	storage.RegisterPerReplicaServer(s.grpc.Server, s.node.perReplicaServer)
 	s.node.storeCfg.ClosedTimestamp.RegisterClosedTimestampServer(s.grpc.Server)
+	s.replicationReporter = reports.NewReporter(s.node.stores, &s.node.storeCfg)
 
 	s.sessionRegistry = sql.NewSessionRegistry()
 	s.jobRegistry = jobs.MakeRegistry(
@@ -1427,6 +1430,7 @@ func (s *Server) Start(ctx context.Context) error {
 		},
 		time.NewTicker,
 	)
+	s.replicationReporter.Start(ctx, s.stopper)
 
 	// Cluster ID should have been determined by this point.
 	if s.rpcContext.ClusterID.Get() == uuid.Nil {


### PR DESCRIPTION
Because the reporter needs many server components (indirectly, through
the dependency on the InternalExecutor), and the Node is not always
configured with an InternalExecutor (in particular, in tests using
createTestNode()).

Fixes #40782

Release justification: fix to flaky test