### PR TITLE
release-19.1: sql: apply join outer cols must be typed null 

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/apply_join
+++ b/pkg/sql/logictest/testdata/logic_test/apply_join
@@ -279,3 +279,13 @@ FROM
 ----
 NULL
 NULL
+
+# Regression test for #37454: untyped null produced at top level.
+
+statement ok
+CREATE TABLE x (a INT8); CREATE TABLE y (b INT8); INSERT INTO x VALUES (1); INSERT INTO y VALUES (2);
+
+query II
+SELECT a, (SELECT a FROM y) FROM x
+----
+1  1

--- a/pkg/sql/opt/exec/execbuilder/scalar_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar_builder.go
@@ -143,7 +143,11 @@ func (b *Builder) indexedVar(
 	idx, ok := ctx.ivarMap.Get(int(colID))
 	if !ok {
 		if b.nullifyMissingVarExprs > 0 {
-			return tree.DNull
+			expr, err := tree.ReType(tree.DNull, md.ColumnMeta(colID).Type)
+			if err != nil {
+				panic(pgerror.NewAssertionErrorf("unexpected failure during ReType: %v", err))
+			}
+			return expr
 		}
 		panic(pgerror.NewAssertionErrorf("cannot map variable %d to an indexed var", log.Safe(colID)))
 	}


### PR DESCRIPTION
Backport 1/1 commits from #37597.

Closes #40807.

/cc @cockroachdb/release

---

This commit prevents the apply join "replace outer columns with NULL"
step from generated untyped null expressions, which can cause panics in
certain cases.

Fixes #37454.

Release note (bug fix): fix a crash in apply join
