### PR TITLE
colexec: remove unused Int8 and Float32 coltypes

### DIFF
--- a/pkg/col/coldata/vec.go
+++ b/pkg/col/coldata/vec.go
@@ -145,16 +145,12 @@ func NewMemColumn(t coltypes.T, n int) Vec {
 		return &memColumn{t: t, col: make([]bool, n), nulls: nulls}
 	case coltypes.Bytes:
 		return &memColumn{t: t, col: NewBytes(n), nulls: nulls}
-	case coltypes.Int8:
-		return &memColumn{t: t, col: make([]int8, n), nulls: nulls}
 	case coltypes.Int16:
 		return &memColumn{t: t, col: make([]int16, n), nulls: nulls}
 	case coltypes.Int32:
 		return &memColumn{t: t, col: make([]int32, n), nulls: nulls}
 	case coltypes.Int64:
 		return &memColumn{t: t, col: make([]int64, n), nulls: nulls}
-	case coltypes.Float32:
-		return &memColumn{t: t, col: make([]float32, n), nulls: nulls}
 	case coltypes.Float64:
 		return &memColumn{t: t, col: make([]float64, n), nulls: nulls}
 	case coltypes.Decimal:

--- a/pkg/col/colserde/arrowbatchconverter.go
+++ b/pkg/col/colserde/arrowbatchconverter.go
@@ -72,11 +72,9 @@ func NewArrowBatchConverter(typs []coltypes.T) (*ArrowBatchConverter, error) {
 }
 
 const (
-	sizeOfInt8    = int(unsafe.Sizeof(int8(0)))
 	sizeOfInt16   = int(unsafe.Sizeof(int16(0)))
 	sizeOfInt32   = int(unsafe.Sizeof(int32(0)))
 	sizeOfInt64   = int(unsafe.Sizeof(int64(0)))
-	sizeOfFloat32 = int(unsafe.Sizeof(float32(0)))
 	sizeOfFloat64 = int(unsafe.Sizeof(float64(0)))
 )
 
@@ -85,11 +83,9 @@ var supportedTypes = func() map[coltypes.T]struct{} {
 	for _, t := range []coltypes.T{
 		coltypes.Bool,
 		coltypes.Bytes,
-		coltypes.Int8,
 		coltypes.Int16,
 		coltypes.Int32,
 		coltypes.Int64,
-		coltypes.Float32,
 		coltypes.Float64,
 	} {
 		typs[t] = struct{}{}
@@ -150,10 +146,6 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]*array.Data, 
 		)
 
 		switch typ {
-		case coltypes.Int8:
-			ints := vec.Int8()[:n]
-			dataHeader = (*reflect.SliceHeader)(unsafe.Pointer(&ints))
-			datumSize = sizeOfInt8
 		case coltypes.Int16:
 			ints := vec.Int16()[:n]
 			dataHeader = (*reflect.SliceHeader)(unsafe.Pointer(&ints))
@@ -166,10 +158,6 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]*array.Data, 
 			ints := vec.Int64()[:n]
 			dataHeader = (*reflect.SliceHeader)(unsafe.Pointer(&ints))
 			datumSize = sizeOfInt64
-		case coltypes.Float32:
-			floats := vec.Float32()[:n]
-			dataHeader = (*reflect.SliceHeader)(unsafe.Pointer(&floats))
-			datumSize = sizeOfFloat32
 		case coltypes.Float64:
 			floats := vec.Float64()[:n]
 			dataHeader = (*reflect.SliceHeader)(unsafe.Pointer(&floats))
@@ -262,10 +250,6 @@ func (c *ArrowBatchConverter) ArrowToBatch(data []*array.Data, b coldata.Batch) 
 		} else {
 			var col interface{}
 			switch typ {
-			case coltypes.Int8:
-				intArr := array.NewInt8Data(d)
-				col = intArr.Int8Values()
-				arr = intArr
 			case coltypes.Int16:
 				intArr := array.NewInt16Data(d)
 				col = intArr.Int16Values()
@@ -278,10 +262,6 @@ func (c *ArrowBatchConverter) ArrowToBatch(data []*array.Data, b coldata.Batch) 
 				intArr := array.NewInt64Data(d)
 				col = intArr.Int64Values()
 				arr = intArr
-			case coltypes.Float32:
-				floatArr := array.NewFloat32Data(d)
-				col = floatArr.Float32Values()
-				arr = floatArr
 			case coltypes.Float64:
 				floatArr := array.NewFloat64Data(d)
 				col = floatArr.Float64Values()

--- a/pkg/col/colserde/file.go
+++ b/pkg/col/colserde/file.go
@@ -345,12 +345,6 @@ func schema(fb *flatbuffers.Builder, typs []coltypes.T) flatbuffers.UOffsetT {
 			arrowserde.BinaryStart(fb)
 			fbTypOffset = arrowserde.BinaryEnd(fb)
 			fbTyp = arrowserde.TypeBinary
-		case coltypes.Int8:
-			arrowserde.IntStart(fb)
-			arrowserde.IntAddBitWidth(fb, 8)
-			arrowserde.IntAddIsSigned(fb, 1)
-			fbTypOffset = arrowserde.IntEnd(fb)
-			fbTyp = arrowserde.TypeInt
 		case coltypes.Int16:
 			arrowserde.IntStart(fb)
 			arrowserde.IntAddBitWidth(fb, 16)
@@ -369,11 +363,6 @@ func schema(fb *flatbuffers.Builder, typs []coltypes.T) flatbuffers.UOffsetT {
 			arrowserde.IntAddIsSigned(fb, 1)
 			fbTypOffset = arrowserde.IntEnd(fb)
 			fbTyp = arrowserde.TypeInt
-		case coltypes.Float32:
-			arrowserde.FloatingPointStart(fb)
-			arrowserde.FloatingPointAddPrecision(fb, arrowserde.PrecisionSINGLE)
-			fbTypOffset = arrowserde.FloatingPointEnd(fb)
-			fbTyp = arrowserde.TypeFloatingPoint
 		case coltypes.Float64:
 			arrowserde.FloatingPointStart(fb)
 			arrowserde.FloatingPointAddPrecision(fb, arrowserde.PrecisionDOUBLE)
@@ -443,8 +432,6 @@ func typeFromField(field *arrowserde.Field) (coltypes.T, error) {
 		intType.Init(typeTab.Bytes, typeTab.Pos)
 		if intType.IsSigned() > 0 {
 			switch intType.BitWidth() {
-			case 8:
-				return coltypes.Int8, nil
 			case 16:
 				return coltypes.Int16, nil
 			case 32:
@@ -461,8 +448,6 @@ func typeFromField(field *arrowserde.Field) (coltypes.T, error) {
 		switch floatType.Precision() {
 		case arrowserde.PrecisionDOUBLE:
 			return coltypes.Float64, nil
-		case arrowserde.PrecisionSINGLE:
-			return coltypes.Float32, nil
 		default:
 			return coltypes.Unhandled, errors.Errorf(`unhandled float precision %d`, floatType.Precision())
 		}

--- a/pkg/col/colserde/record_batch_test.go
+++ b/pkg/col/colserde/record_batch_test.go
@@ -60,13 +60,6 @@ func randomDataFromType(rng *rand.Rand, t coltypes.T, n int, nullProbability flo
 			}
 		}
 		builder.(*array.BooleanBuilder).AppendValues(data, valid)
-	case coltypes.Int8:
-		builder = array.NewInt8Builder(memory.DefaultAllocator)
-		data := make([]int8, n)
-		for i := range data {
-			data[i] = int8(rng.Uint64())
-		}
-		builder.(*array.Int8Builder).AppendValues(data, valid)
 	case coltypes.Int16:
 		builder = array.NewInt16Builder(memory.DefaultAllocator)
 		data := make([]int16, n)
@@ -88,13 +81,6 @@ func randomDataFromType(rng *rand.Rand, t coltypes.T, n int, nullProbability flo
 			data[i] = int64(rng.Uint64())
 		}
 		builder.(*array.Int64Builder).AppendValues(data, valid)
-	case coltypes.Float32:
-		builder = array.NewFloat32Builder(memory.DefaultAllocator)
-		data := make([]float32, n)
-		for i := range data {
-			data[i] = rng.Float32() * math.MaxFloat32
-		}
-		builder.(*array.Float32Builder).AppendValues(data, valid)
 	case coltypes.Float64:
 		builder = array.NewFloat64Builder(memory.DefaultAllocator)
 		data := make([]float64, n)

--- a/pkg/col/coltypes/t_string.go
+++ b/pkg/col/coltypes/t_string.go
@@ -11,18 +11,16 @@ func _() {
 	_ = x[Bool-0]
 	_ = x[Bytes-1]
 	_ = x[Decimal-2]
-	_ = x[Int8-3]
-	_ = x[Int16-4]
-	_ = x[Int32-5]
-	_ = x[Int64-6]
-	_ = x[Float32-7]
-	_ = x[Float64-8]
-	_ = x[Unhandled-9]
+	_ = x[Int16-3]
+	_ = x[Int32-4]
+	_ = x[Int64-5]
+	_ = x[Float64-6]
+	_ = x[Unhandled-7]
 }
 
-const _T_name = "BoolBytesDecimalInt8Int16Int32Int64Float32Float64Unhandled"
+const _T_name = "BoolBytesDecimalInt16Int32Int64Float64Unhandled"
 
-var _T_index = [...]uint8{0, 4, 9, 16, 20, 25, 30, 35, 42, 49, 58}
+var _T_index = [...]uint8{0, 4, 9, 16, 21, 26, 31, 38, 47}
 
 func (i T) String() string {
 	if i < 0 || i >= T(len(_T_index)-1) {

--- a/pkg/col/coltypes/types.go
+++ b/pkg/col/coltypes/types.go
@@ -30,16 +30,12 @@ const (
 	Bytes
 	// Decimal is a column of type apd.Decimal
 	Decimal
-	// Int8 is a column of type int8
-	Int8
 	// Int16 is a column of type int16
 	Int16
 	// Int32 is a column of type int32
 	Int32
 	// Int64 is a column of type int64
 	Int64
-	// Float32 is a column of type float32
-	Float32
 	// Float64 is a column of type float64
 	Float64
 
@@ -57,13 +53,13 @@ var AllTypes []T
 var CompatibleTypes map[T][]T
 
 // NumberTypes is a slice containing all numeric types.
-var NumberTypes = []T{Int8, Int16, Int32, Int64, Float32, Float64, Decimal}
+var NumberTypes = []T{Int16, Int32, Int64, Float64, Decimal}
 
 // IntTypes is a slice containing all int types.
-var IntTypes = []T{Int8, Int16, Int32, Int64}
+var IntTypes = []T{Int16, Int32, Int64}
 
 // FloatTypes is a slice containing all float types.
-var FloatTypes = []T{Float32, Float64}
+var FloatTypes = []T{Float64}
 
 func init() {
 	for i := Bool; i < Unhandled; i++ {
@@ -74,11 +70,9 @@ func init() {
 	CompatibleTypes[Bool] = append(CompatibleTypes[Bool], Bool)
 	CompatibleTypes[Bytes] = append(CompatibleTypes[Bytes], Bytes)
 	CompatibleTypes[Decimal] = append(CompatibleTypes[Decimal], NumberTypes...)
-	CompatibleTypes[Int8] = append(CompatibleTypes[Int8], NumberTypes...)
 	CompatibleTypes[Int16] = append(CompatibleTypes[Int16], NumberTypes...)
 	CompatibleTypes[Int32] = append(CompatibleTypes[Int32], NumberTypes...)
 	CompatibleTypes[Int64] = append(CompatibleTypes[Int64], NumberTypes...)
-	CompatibleTypes[Float32] = append(CompatibleTypes[Float32], NumberTypes...)
 	CompatibleTypes[Float64] = append(CompatibleTypes[Float64], NumberTypes...)
 }
 
@@ -86,8 +80,6 @@ func init() {
 // runtime.
 func FromGoType(v interface{}) T {
 	switch t := v.(type) {
-	case int8:
-		return Int8
 	case int16:
 		return Int16
 	case int32:
@@ -96,8 +88,6 @@ func FromGoType(v interface{}) T {
 		return Int64
 	case bool:
 		return Bool
-	case float32:
-		return Float32
 	case float64:
 		return Float64
 	case []byte:
@@ -120,16 +110,12 @@ func (t T) GoTypeName() string {
 		return "[]byte"
 	case Decimal:
 		return "apd.Decimal"
-	case Int8:
-		return "int8"
 	case Int16:
 		return "int16"
 	case Int32:
 		return "int32"
 	case Int64:
 		return "int64"
-	case Float32:
-		return "float32"
 	case Float64:
 		return "float64"
 	default:

--- a/pkg/sql/colexec/execgen/cmd/execgen/avg_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/avg_agg_gen.go
@@ -42,9 +42,6 @@ if _, err := tree.DecimalCtx.Quo(&%s, &%s, &%s); err != nil {
 		}`,
 			target, r, target, l, target,
 		)
-	case coltypes.Float32:
-		// TODO(asubiotto): Might not want to support this.
-		return fmt.Sprintf("%s = %s / float32(%s)", target, l, r)
 	case coltypes.Float64:
 		return fmt.Sprintf("%s = %s / float64(%s)", target, l, r)
 	default:
@@ -87,7 +84,7 @@ func genAvgAgg(wr io.Writer) error {
 	}
 
 	// TODO(asubiotto): Support more coltypes.
-	supportedTypes := []coltypes.T{coltypes.Decimal, coltypes.Float32, coltypes.Float64}
+	supportedTypes := []coltypes.T{coltypes.Decimal, coltypes.Float64}
 	spm := make(map[coltypes.T]int)
 	for i, typ := range supportedTypes {
 		spm[typ] = i

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads.go
@@ -343,8 +343,8 @@ func init() {
 				switch to {
 				case coltypes.Bool:
 					ov.AssignFunc = castIdentity
-				case coltypes.Int8, coltypes.Int16, coltypes.Int32,
-					coltypes.Int64, coltypes.Float32, coltypes.Float64:
+				case coltypes.Int16, coltypes.Int32,
+					coltypes.Int64, coltypes.Float64:
 					ov.AssignFunc = func(to, from string) string {
 						convStr := `
 							%[1]s = 0
@@ -385,23 +385,6 @@ func init() {
 				}
 				castOverloads[from] = append(castOverloads[from], ov)
 			}
-		case coltypes.Int8:
-			for _, to := range inputTypes {
-				ov := castOverload{FromTyp: from, ToTyp: to, ToGoTyp: to.GoTypeName()}
-				switch to {
-				case coltypes.Bool:
-					ov.AssignFunc = numToBool
-				case coltypes.Decimal:
-					ov.AssignFunc = intToDecimal
-				case coltypes.Int8:
-					ov.AssignFunc = castIdentity
-				case coltypes.Float32:
-					ov.AssignFunc = intToFloat(32)
-				case coltypes.Float64:
-					ov.AssignFunc = intToFloat(64)
-				}
-				castOverloads[from] = append(castOverloads[from], ov)
-			}
 		case coltypes.Int16:
 			for _, to := range inputTypes {
 				ov := castOverload{FromTyp: from, ToTyp: to, ToGoTyp: to.GoTypeName()}
@@ -412,8 +395,6 @@ func init() {
 					ov.AssignFunc = intToDecimal
 				case coltypes.Int16:
 					ov.AssignFunc = castIdentity
-				case coltypes.Float32:
-					ov.AssignFunc = intToFloat(32)
 				case coltypes.Float64:
 					ov.AssignFunc = intToFloat(64)
 				}
@@ -429,8 +410,6 @@ func init() {
 					ov.AssignFunc = intToDecimal
 				case coltypes.Int32:
 					ov.AssignFunc = castIdentity
-				case coltypes.Float32:
-					ov.AssignFunc = intToFloat(32)
 				case coltypes.Float64:
 					ov.AssignFunc = intToFloat(64)
 				}
@@ -446,31 +425,8 @@ func init() {
 					ov.AssignFunc = intToDecimal
 				case coltypes.Int64:
 					ov.AssignFunc = castIdentity
-				case coltypes.Float32:
-					ov.AssignFunc = intToFloat(32)
 				case coltypes.Float64:
 					ov.AssignFunc = intToFloat(64)
-				}
-				castOverloads[from] = append(castOverloads[from], ov)
-			}
-		case coltypes.Float32:
-			for _, to := range inputTypes {
-				ov := castOverload{FromTyp: from, ToTyp: to, ToGoTyp: to.GoTypeName()}
-				switch to {
-				case coltypes.Bool:
-					ov.AssignFunc = numToBool
-				case coltypes.Decimal:
-					ov.AssignFunc = floatToDecimal
-				case coltypes.Int8:
-					ov.AssignFunc = floatToInt(8, 32)
-				case coltypes.Int16:
-					ov.AssignFunc = floatToInt(16, 32)
-				case coltypes.Int32:
-					ov.AssignFunc = floatToInt(32, 32)
-				case coltypes.Int64:
-					ov.AssignFunc = floatToInt(64, 32)
-				case coltypes.Float32:
-					ov.AssignFunc = castIdentity
 				}
 				castOverloads[from] = append(castOverloads[from], ov)
 			}
@@ -482,8 +438,6 @@ func init() {
 					ov.AssignFunc = numToBool
 				case coltypes.Decimal:
 					ov.AssignFunc = floatToDecimal
-				case coltypes.Int8:
-					ov.AssignFunc = floatToInt(8, 64)
 				case coltypes.Int16:
 					ov.AssignFunc = floatToInt(16, 64)
 				case coltypes.Int32:
@@ -821,9 +775,6 @@ func (c intCustomizer) getBinOpAssignFunc() assignFunc {
 			// integer width.
 			var upperBound, lowerBound string
 			switch c.width {
-			case 8:
-				upperBound = "10"
-				lowerBound = "-10"
 			case 16:
 				upperBound = "math.MaxInt8"
 				lowerBound = "math.MinInt8"
@@ -1062,9 +1013,7 @@ func registerTypeCustomizers() {
 		}
 	}
 	// Use a customizer of appropriate width when widths are the same.
-	registerTypeCustomizer(coltypePair{coltypes.Float32, coltypes.Float32}, floatCustomizer{width: 32})
 	registerTypeCustomizer(coltypePair{coltypes.Float64, coltypes.Float64}, floatCustomizer{width: 64})
-	registerTypeCustomizer(coltypePair{coltypes.Int8, coltypes.Int8}, intCustomizer{width: 8})
 	registerTypeCustomizer(coltypePair{coltypes.Int16, coltypes.Int16}, intCustomizer{width: 16})
 	registerTypeCustomizer(coltypePair{coltypes.Int32, coltypes.Int32}, intCustomizer{width: 32})
 	registerTypeCustomizer(coltypePair{coltypes.Int64, coltypes.Int64}, intCustomizer{width: 64})
@@ -1109,9 +1058,7 @@ func registerBinOpOutputTypes() {
 		}
 		// Use an output type of the same width when input widths are the same.
 		binOpOutputTypes[binOp][coltypePair{coltypes.Decimal, coltypes.Decimal}] = coltypes.Decimal
-		binOpOutputTypes[binOp][coltypePair{coltypes.Float32, coltypes.Float32}] = coltypes.Float32
 		binOpOutputTypes[binOp][coltypePair{coltypes.Float64, coltypes.Float64}] = coltypes.Float64
-		binOpOutputTypes[binOp][coltypePair{coltypes.Int8, coltypes.Int8}] = coltypes.Int8
 		binOpOutputTypes[binOp][coltypePair{coltypes.Int16, coltypes.Int16}] = coltypes.Int16
 		binOpOutputTypes[binOp][coltypePair{coltypes.Int32, coltypes.Int32}] = coltypes.Int32
 		binOpOutputTypes[binOp][coltypePair{coltypes.Int64, coltypes.Int64}] = coltypes.Int64

--- a/pkg/sql/colexec/hash.go
+++ b/pkg/sql/colexec/hash.go
@@ -130,10 +130,6 @@ tail:
 	return uintptr(h)
 }
 
-func memhash8(p unsafe.Pointer, h uintptr) uintptr {
-	return memhash(p, h, 1)
-}
-
 func memhash16(p unsafe.Pointer, h uintptr) uintptr {
 	return memhash(p, h, 2)
 }
@@ -171,20 +167,6 @@ func rotl31(x uint64) uint64 {
 // number of (mostly useless) entries keyed with NaNs.
 // To avoid long hash chains, we assign a random number
 // as the hash value for a NaN.
-
-func f32hash(p unsafe.Pointer, h uintptr) uintptr {
-	f := *(*float32)(p)
-	switch {
-	case f == 0:
-		return c1 * (c0 ^ h) // +0, -0
-	case f != f:
-		// TODO(asubiotto): fastrand relies on some stack internals.
-		//return c1 * (c0 ^ h ^ uintptr(fastrand())) // any kind of NaN
-		return c1 * (c0 ^ h ^ uintptr(rand.Uint32()))
-	default:
-		return memhash(p, h, 4)
-	}
-}
 
 func f64hash(p unsafe.Pointer, h uintptr) uintptr {
 	f := *(*float64)(p)

--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -547,30 +547,30 @@ func TestHashJoinerInt64(t *testing.T) {
 			},
 		},
 		{
-			leftTypes:  []coltypes.T{coltypes.Bytes, coltypes.Bool, coltypes.Int8, coltypes.Int16, coltypes.Int32, coltypes.Int64, coltypes.Bytes},
-			rightTypes: []coltypes.T{coltypes.Int64, coltypes.Int32, coltypes.Int16, coltypes.Int8, coltypes.Bool, coltypes.Bytes},
+			leftTypes:  []coltypes.T{coltypes.Bytes, coltypes.Bool, coltypes.Int16, coltypes.Int32, coltypes.Int64, coltypes.Bytes},
+			rightTypes: []coltypes.T{coltypes.Int64, coltypes.Int32, coltypes.Int16, coltypes.Bool, coltypes.Bytes},
 
 			// Test multiple equality columns of different coltypes.
 			leftTuples: tuples{
-				{"foo", false, int8(10), int16(100), int32(1000), int64(10000), "aaa"},
-				{"foo", true, 10, 100, 1000, 10000, "bbb"},
-				{"foo1", false, 10, 100, 1000, 10000, "ccc"},
-				{"foo", false, 20, 100, 1000, 10000, "ddd"},
-				{"foo", false, 10, 200, 1000, 10000, "eee"},
-				{"bar", true, 30, 300, 3000, 30000, "fff"},
+				{"foo", false, int16(100), int32(1000), int64(10000), "aaa"},
+				{"foo", true, 100, 1000, 10000, "bbb"},
+				{"foo1", false, 100, 1000, 10000, "ccc"},
+				{"foo", false, 200, 1000, 10000, "ddd"},
+				{"foo", false, 100, 2000, 10000, "eee"},
+				{"bar", true, 300, 3000, 30000, "fff"},
 			},
 			rightTuples: tuples{
-				{int64(10000), int32(1000), int16(100), int8(10), false, "foo1"},
-				{10000, 1000, 100, 10, false, "foo"},
-				{30000, 3000, 300, 30, true, "bar"},
-				{10000, 1000, 100, 20, false, "foo"},
-				{30000, 3000, 300, 30, false, "bar"},
-				{10000, 1000, 100, 10, false, "random"},
+				{int64(10000), int32(1000), int16(100), false, "foo1"},
+				{10000, 1000, 100, false, "foo"},
+				{30000, 3000, 300, true, "bar"},
+				{10000, 1000, 200, false, "foo"},
+				{30000, 3000, 300, false, "bar"},
+				{10000, 1000, 100, false, "random"},
 			},
 
-			leftEqCols:   []uint32{0, 1, 2, 3, 4, 5},
-			rightEqCols:  []uint32{5, 4, 3, 2, 1, 0},
-			leftOutCols:  []uint32{6},
+			leftEqCols:   []uint32{0, 1, 2, 3, 4},
+			rightEqCols:  []uint32{4, 3, 2, 1, 0},
+			leftOutCols:  []uint32{5},
 			rightOutCols: []uint32{},
 
 			buildDistinct: true,
@@ -583,32 +583,33 @@ func TestHashJoinerInt64(t *testing.T) {
 			},
 		},
 		{
-			leftTypes:  []coltypes.T{coltypes.Float32, coltypes.Float64},
-			rightTypes: []coltypes.T{coltypes.Float64, coltypes.Float32},
+			leftTypes:  []coltypes.T{coltypes.Float64},
+			rightTypes: []coltypes.T{coltypes.Float64},
 
 			// Test equality columns of type float.
 			leftTuples: tuples{
-				{float32(1.1), float64(33.333)},
-				{float32(1.1), float64(44.4444)},
-				{float32(2.22), float64(55.55555)},
-				{float32(2.22), float64(44.4444)},
+				{float64(33.333)},
+				{float64(44.4444)},
+				{float64(55.55555)},
+				{float64(44.4444)},
 			},
 			rightTuples: tuples{
-				{float64(44.4444), float32(2.22)},
-				{float64(55.55555), float32(1.1)},
-				{float64(33.333), float32(1.1)},
+				{float64(44.4444)},
+				{float64(55.55555)},
+				{float64(33.333)},
 			},
 
-			leftEqCols:   []uint32{0, 1},
-			rightEqCols:  []uint32{1, 0},
-			leftOutCols:  []uint32{0, 1},
+			leftEqCols:   []uint32{0},
+			rightEqCols:  []uint32{0},
+			leftOutCols:  []uint32{0},
 			rightOutCols: []uint32{},
 
 			buildDistinct: true,
 
 			expectedTuples: tuples{
-				{float32(2.22), float64(44.4444)},
-				{float32(1.1), float64(33.333)},
+				{float64(55.55555)},
+				{float64(44.4444)},
+				{float64(33.333)},
 			},
 		},
 		{

--- a/pkg/sql/colexec/mem_estimation.go
+++ b/pkg/sql/colexec/mem_estimation.go
@@ -20,11 +20,9 @@ import (
 
 const (
 	sizeOfBool    = int(unsafe.Sizeof(true))
-	sizeOfInt8    = int(unsafe.Sizeof(int8(0)))
 	sizeOfInt16   = int(unsafe.Sizeof(int16(0)))
 	sizeOfInt32   = int(unsafe.Sizeof(int32(0)))
 	sizeOfInt64   = int(unsafe.Sizeof(int64(0)))
-	sizeOfFloat32 = int(unsafe.Sizeof(float32(0)))
 	sizeOfFloat64 = int(unsafe.Sizeof(float64(0)))
 )
 
@@ -45,16 +43,12 @@ func EstimateBatchSizeBytes(vecTypes []coltypes.T, batchLength int) int {
 			// much space each byte array takes up. Use some default value as a
 			// heuristic right now.
 			acc += 100
-		case coltypes.Int8:
-			acc += sizeOfInt8
 		case coltypes.Int16:
 			acc += sizeOfInt16
 		case coltypes.Int32:
 			acc += sizeOfInt32
 		case coltypes.Int64:
 			acc += sizeOfInt64
-		case coltypes.Float32:
-			acc += sizeOfFloat32
 		case coltypes.Float64:
 			acc += sizeOfFloat64
 		case coltypes.Decimal:

--- a/pkg/sql/colexec/overloads_test.go
+++ b/pkg/sql/colexec/overloads_test.go
@@ -62,8 +62,6 @@ func TestIntegerDivision(t *testing.T) {
 	d := &apd.Decimal{}
 	var res apd.Decimal
 
-	res = performDivInt8Int8(math.MinInt8, -1)
-	require.Equal(t, 0, res.Cmp(d.SetFinite(-math.MinInt8, 0)))
 	res = performDivInt16Int16(math.MinInt16, -1)
 	require.Equal(t, 0, res.Cmp(d.SetFinite(-math.MinInt16, 0)))
 	res = performDivInt32Int32(math.MinInt32, -1)
@@ -75,13 +73,10 @@ func TestIntegerDivision(t *testing.T) {
 	}
 	require.Equal(t, 0, res.Cmp(d))
 
-	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivInt8Int8(10, 0) }))
 	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivInt16Int16(10, 0) }))
 	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivInt32Int32(10, 0) }))
 	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivInt64Int64(10, 0) }))
 
-	res = performDivInt8Int8(math.MaxInt8, -1)
-	require.Equal(t, 0, res.Cmp(d.SetFinite(-math.MaxInt8, 0)))
 	res = performDivInt16Int16(math.MaxInt16, -1)
 	require.Equal(t, 0, res.Cmp(d.SetFinite(-math.MaxInt16, 0)))
 	res = performDivInt32Int32(math.MaxInt32, -1)
@@ -91,11 +86,6 @@ func TestIntegerDivision(t *testing.T) {
 }
 
 func TestIntegerMultiplication(t *testing.T) {
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt8Int8(math.MaxInt8-1, 100) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt8Int8(math.MaxInt8-1, 3) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt8Int8(math.MinInt8+1, 3) }))
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt8Int8(math.MinInt8+1, 100) }))
-
 	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MaxInt16-1, 100) }))
 	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MaxInt16-1, 3) }))
 	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MinInt16+1, 3) }))
@@ -111,22 +101,18 @@ func TestIntegerMultiplication(t *testing.T) {
 	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt64Int64(math.MinInt64+1, 3) }))
 	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt64Int64(math.MinInt64+1, 100) }))
 
-	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt8Int8(math.MinInt8, -1) }))
 	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MinInt16, -1) }))
 	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt32Int32(math.MinInt32, -1) }))
 	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt64Int64(math.MinInt64, -1) }))
 
-	require.Equal(t, int8(-math.MaxInt8), performMultInt8Int8(math.MaxInt8, -1))
 	require.Equal(t, int16(-math.MaxInt16), performMultInt16Int16(math.MaxInt16, -1))
 	require.Equal(t, int32(-math.MaxInt32), performMultInt32Int32(math.MaxInt32, -1))
 	require.Equal(t, int64(-math.MaxInt64), performMultInt64Int64(math.MaxInt64, -1))
 
-	require.Equal(t, int8(0), performMultInt8Int8(math.MinInt8, 0))
 	require.Equal(t, int16(0), performMultInt16Int16(math.MinInt16, 0))
 	require.Equal(t, int32(0), performMultInt32Int32(math.MinInt32, 0))
 	require.Equal(t, int64(0), performMultInt64Int64(math.MinInt64, 0))
 
-	require.Equal(t, int8(120), performMultInt8Int8(10, 12))
 	require.Equal(t, int16(120), performMultInt16Int16(-10, -12))
 	require.Equal(t, int32(-120), performMultInt32Int32(-12, 10))
 	require.Equal(t, int64(-120), performMultInt64Int64(12, -10))
@@ -166,7 +152,6 @@ func TestDecimalDivByZero(t *testing.T) {
 	nonZeroDec.SetFinite(4, 0)
 	zeroDec.SetFinite(0, 0)
 
-	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivDecimalInt8(nonZeroDec, 0) }))
 	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivDecimalInt16(nonZeroDec, 0) }))
 	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivDecimalInt32(nonZeroDec, 0) }))
 	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivDecimalInt64(nonZeroDec, 0) }))
@@ -174,7 +159,6 @@ func TestDecimalDivByZero(t *testing.T) {
 	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivInt64Decimal(2, zeroDec) }))
 	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivInt32Decimal(2, zeroDec) }))
 	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivInt16Decimal(2, zeroDec) }))
-	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivInt8Decimal(2, zeroDec) }))
 
 	require.Equal(t, tree.ErrDivByZero, execerror.CatchVectorizedRuntimeError(func() { performDivDecimalDecimal(nonZeroDec, zeroDec) }))
 }
@@ -185,25 +169,19 @@ func TestDecimalComparison(t *testing.T) {
 		t.Error(err)
 	}
 	require.Equal(t, true, performEQDecimalDecimal(d, d))
-	require.Equal(t, false, performEQDecimalFloat32(d, 0.43))
 	require.Equal(t, true, performEQDecimalFloat64(d, 1.234))
-	require.Equal(t, false, performEQDecimalInt8(d, 0))
 	require.Equal(t, false, performEQDecimalInt16(d, 1))
 	require.Equal(t, false, performEQDecimalInt32(d, 2))
 	require.Equal(t, false, performEQDecimalInt64(d, 3))
 
 	require.Equal(t, false, performLTDecimalDecimal(d, d))
-	require.Equal(t, false, performLTDecimalFloat32(d, 0.43))
 	require.Equal(t, true, performLTDecimalFloat64(d, 4.234))
-	require.Equal(t, false, performLTDecimalInt8(d, 0))
 	require.Equal(t, false, performLTDecimalInt16(d, 1))
 	require.Equal(t, true, performLTDecimalInt32(d, 2))
 	require.Equal(t, true, performLTDecimalInt64(d, 3))
 
 	require.Equal(t, true, performGEDecimalDecimal(d, d))
-	require.Equal(t, true, performGEDecimalFloat32(d, 0.43))
 	require.Equal(t, false, performGEDecimalFloat64(d, 4.234))
-	require.Equal(t, true, performGEDecimalInt8(d, 0))
 	require.Equal(t, true, performGEDecimalInt16(d, 1))
 	require.Equal(t, false, performGEDecimalInt32(d, 2))
 	require.Equal(t, false, performGEDecimalInt64(d, 3))
@@ -216,25 +194,19 @@ func TestFloatComparison(t *testing.T) {
 		t.Error(err)
 	}
 	require.Equal(t, true, performEQFloat64Decimal(f, d))
-	require.Equal(t, false, performEQFloat64Float32(f, 0.43))
 	require.Equal(t, true, performEQFloat64Float64(f, 1.234))
-	require.Equal(t, false, performEQFloat64Int8(f, 0))
 	require.Equal(t, false, performEQFloat64Int16(f, 1))
 	require.Equal(t, false, performEQFloat64Int32(f, 2))
 	require.Equal(t, false, performEQFloat64Int64(f, 3))
 
 	require.Equal(t, false, performLTFloat64Decimal(f, d))
-	require.Equal(t, false, performLTFloat64Float32(f, 0.43))
 	require.Equal(t, true, performLTFloat64Float64(f, 4.234))
-	require.Equal(t, false, performLTFloat64Int8(f, 0))
 	require.Equal(t, false, performLTFloat64Int16(f, 1))
 	require.Equal(t, true, performLTFloat64Int32(f, 2))
 	require.Equal(t, true, performLTFloat64Int64(f, 3))
 
 	require.Equal(t, true, performGEFloat64Decimal(f, d))
-	require.Equal(t, true, performGEFloat64Float32(f, 0.43))
 	require.Equal(t, false, performGEFloat64Float64(f, 4.234))
-	require.Equal(t, true, performGEFloat64Int8(f, 0))
 	require.Equal(t, true, performGEFloat64Int16(f, 1))
 	require.Equal(t, false, performGEFloat64Int32(f, 2))
 	require.Equal(t, false, performGEFloat64Int64(f, 3))
@@ -247,25 +219,19 @@ func TestIntComparison(t *testing.T) {
 		t.Error(err)
 	}
 	require.Equal(t, false, performEQInt64Decimal(i, d))
-	require.Equal(t, false, performEQInt64Float32(i, 0.43))
 	require.Equal(t, false, performEQInt64Float64(i, 1.234))
-	require.Equal(t, false, performEQInt64Int8(i, 0))
 	require.Equal(t, false, performEQInt64Int16(i, 1))
 	require.Equal(t, true, performEQInt64Int32(i, 2))
 	require.Equal(t, false, performEQInt64Int64(i, 3))
 
 	require.Equal(t, false, performLTInt64Decimal(i, d))
-	require.Equal(t, false, performLTInt64Float32(i, 0.43))
 	require.Equal(t, true, performLTInt64Float64(i, 4.234))
-	require.Equal(t, false, performLTInt64Int8(i, 0))
 	require.Equal(t, false, performLTInt64Int16(i, 1))
 	require.Equal(t, false, performLTInt64Int32(i, 2))
 	require.Equal(t, true, performLTInt64Int64(i, 3))
 
 	require.Equal(t, true, performGEInt64Decimal(i, d))
-	require.Equal(t, true, performGEInt64Float32(i, 0.43))
 	require.Equal(t, false, performGEInt64Float64(i, 4.234))
-	require.Equal(t, true, performGEInt64Int8(i, 0))
 	require.Equal(t, true, performGEInt64Int16(i, 1))
 	require.Equal(t, true, performGEInt64Int32(i, 2))
 	require.Equal(t, false, performGEInt64Int64(i, 3))

--- a/pkg/sql/colexec/random_testutils.go
+++ b/pkg/sql/colexec/random_testutils.go
@@ -64,11 +64,6 @@ func RandomVec(rng *rand.Rand, typ coltypes.T, vec coldata.Vec, n int, nullProba
 			// int64(rng.Uint64()) to get negative numbers, too
 			decs[i].SetFinite(int64(rng.Uint64()), int32(rng.Intn(40)-20))
 		}
-	case coltypes.Int8:
-		ints := vec.Int8()
-		for i := 0; i < n; i++ {
-			ints[i] = int8(rng.Uint64())
-		}
 	case coltypes.Int16:
 		ints := vec.Int16()
 		for i := 0; i < n; i++ {
@@ -83,11 +78,6 @@ func RandomVec(rng *rand.Rand, typ coltypes.T, vec coldata.Vec, n int, nullProba
 		ints := vec.Int64()
 		for i := 0; i < n; i++ {
 			ints[i] = int64(rng.Uint64())
-		}
-	case coltypes.Float32:
-		floats := vec.Float32()
-		for i := 0; i < n; i++ {
-			floats[i] = rng.Float32()
 		}
 	case coltypes.Float64:
 		floats := vec.Float64()

--- a/pkg/sql/colexec/typeconv/typeconv.go
+++ b/pkg/sql/colexec/typeconv/typeconv.go
@@ -35,8 +35,6 @@ func FromColumnType(ct *types.T) coltypes.T {
 		return coltypes.Decimal
 	case types.IntFamily:
 		switch ct.Width() {
-		case 8:
-			return coltypes.Int8
 		case 16:
 			return coltypes.Int16
 		case 32:


### PR DESCRIPTION
We have two types (Int8 and Float32) which are not used at all, yet
the code is generated for them which inflates the footprint of the
generated code even further. Now those two types are removed which
reduces the binary size by 8% or so.

Int8 doesn't even have an equivalent types in sql/types, but Float32
does, and if we ever start using it, we can always bring it back later.

Release justification: Category 1: Non-production code changes.

Release note: None