### PR TITLE
roachprod: fix `roachprod status -h` to specify cluster param

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -1016,7 +1016,7 @@ other signals.
 }
 
 var statusCmd = &cobra.Command{
-	Use:   "status",
+	Use:   "status <cluster>",
 	Short: "retrieve the status of nodes in a cluster",
 	Long: `Retrieve the status of nodes in a cluster.
 


### PR DESCRIPTION
Release justification: Category 1: Non-production code changes
Release note: None