### PR TITLE
makefile: increase test timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,10 +66,10 @@ SUBTESTS :=
 LINTTIMEOUT := 20m
 
 ## Test timeout to use for regular tests.
-TESTTIMEOUT := 12m
+TESTTIMEOUT := 20m
 
 ## Test timeout to use for race tests.
-RACETIMEOUT := 25m
+RACETIMEOUT := 30m
 
 ## Test timeout to use for acceptance tests.
 ACCEPTANCETIMEOUT := 30m


### PR DESCRIPTION
This patch increases the test timeout for every package from 12m to 20m
(and under stress from 25m to 30m).
This is motivated by the sql TestLogic which has been inching towards
the 12m recently (according to TeamCity history) and is sometimes timing
out. Hopefully it's because we've been adding more tests...

Fixes #40572

Release note: None

Release justification: fix timeout flakes