### PR TITLE
sql: Add telemetry for some partitioning UX improvements

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -401,6 +401,11 @@ ok1  CREATE TABLE ok1 (
 -- Warning: Partitioned table with no zone configurations.
 
 query T
+SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name='sql.show.create' AND usage_count > 0
+----
+sql.show.create
+
+query T
 EXPLAIN (OPT, CATALOG) SELECT * from ok1
 ----
 TABLE ok1
@@ -923,3 +928,8 @@ query TTTTTTTT
 SHOW PARTITIONS FROM INDEX """".t@primary
 ----
 " t p1 NULL x t@primary (1) NULL
+
+query T
+SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name='sql.show.partitions' AND usage_count > 0
+----
+sql.show.partitions

--- a/pkg/sql/delegate/show_partitions.go
+++ b/pkg/sql/delegate/show_partitions.go
@@ -18,10 +18,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/errors"
 )
 
 func (d *delegator) delegateShowPartitions(n *tree.ShowPartitions) (tree.Statement, error) {
+	sqltelemetry.IncrementShowCounter(sqltelemetry.Partitions)
 	if n.IsTable {
 		flags := cat.Flags{AvoidDescriptorCaches: true, NoTableStats: true}
 		tn := n.Table.ToTableName()

--- a/pkg/sql/delegate/show_ranges.go
+++ b/pkg/sql/delegate/show_ranges.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 )
 
 // delegateShowRanges implements the SHOW RANGES statement:
@@ -28,6 +29,7 @@ import (
 // These statements show the ranges corresponding to the given table or index,
 // along with the list of replicas and the lease holder.
 func (d *delegator) delegateShowRanges(n *tree.ShowRanges) (tree.Statement, error) {
+	sqltelemetry.IncrementShowCounter(sqltelemetry.Ranges)
 	if n.DatabaseName != "" {
 		const dbQuery = `
 		SELECT

--- a/pkg/sql/delegate/show_table.go
+++ b/pkg/sql/delegate/show_table.go
@@ -16,9 +16,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 )
 
 func (d *delegator) delegateShowCreate(n *tree.ShowCreate) (tree.Statement, error) {
+	sqltelemetry.IncrementShowCounter(sqltelemetry.Create)
 	const showCreateQuery = `
     SELECT
 			%[3]s AS table_name,

--- a/pkg/sql/delegate/show_var.go
+++ b/pkg/sql/delegate/show_var.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 )
 
 // ValidVars contains the set of variable names; initialized from the SQL
@@ -28,6 +29,10 @@ var ValidVars = make(map[string]struct{})
 func (d *delegator) delegateShowVar(n *tree.ShowVar) (tree.Statement, error) {
 	origName := n.Name
 	name := strings.ToLower(n.Name)
+
+	if name == "locality" {
+		sqltelemetry.IncrementShowCounter(sqltelemetry.Locality)
+	}
 
 	if name == "all" {
 		return parse(

--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -408,3 +408,8 @@ query TT
 SELECT start_key, end_key FROM [SHOW RANGES FROM INDEX """".t@primary]
 ----
 NULL NULL
+
+query T
+SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name='sql.show.ranges' AND usage_count > 0
+----
+sql.show.ranges

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -344,7 +344,7 @@ function  Error
 detail    source SQL: foo ^
 
 
-# Test the SHOW INDEXES FROM DATABSE COMMAND
+# Test the SHOW INDEXES FROM DATABASE COMMAND
 statement ok
 CREATE DATABASE showdbindexestest;
 
@@ -374,3 +374,15 @@ SHOW INDEXES FROM DATABASE "$peci@l";
 ----
 table1 primary false 1 key1 ASC false false
 table2 primary false 1 key2 ASC false false
+
+# Test SHOW LOCALITY telemetry.
+query T
+SHOW LOCALITY
+----
+region=test,dc=dc1
+
+query T
+SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name='sql.show.locality' AND usage_count > 0
+----
+sql.show.locality
+

--- a/pkg/sql/sqltelemetry/show.go
+++ b/pkg/sql/sqltelemetry/show.go
@@ -1,0 +1,58 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sqltelemetry
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+)
+
+// ShowTelemetryType is an enum used to represent the different show commands
+// that we are recording telemetry for.
+type ShowTelemetryType int
+
+const (
+	_ ShowTelemetryType = iota
+	// Ranges represents the SHOW RANGES command.
+	Ranges
+	// Partitions represents the SHOW PARTITIONS command.
+	Partitions
+	// Locality represents the SHOW LOCALITY command.
+	Locality
+	// Create represents the SHOW CREATE command.
+	Create
+)
+
+var showTelemetryNameMap = map[ShowTelemetryType]string{
+	Ranges:     "ranges",
+	Partitions: "partitions",
+	Locality:   "locality",
+	Create:     "create",
+}
+
+func (s ShowTelemetryType) String() string {
+	return showTelemetryNameMap[s]
+}
+
+var showTelemetryCounters map[ShowTelemetryType]telemetry.Counter
+
+func init() {
+	showTelemetryCounters = make(map[ShowTelemetryType]telemetry.Counter)
+	for ty, s := range showTelemetryNameMap {
+		showTelemetryCounters[ty] = telemetry.GetCounterOnce(fmt.Sprintf("sql.show.%s", s))
+	}
+}
+
+// IncrementShowCounter is used to increment the telemetry counter for a particular show command.
+func IncrementShowCounter(showType ShowTelemetryType) {
+	telemetry.Inc(showTelemetryCounters[showType])
+}


### PR DESCRIPTION
Add telemetry for the following operations:
* show partitions
* show ranges
* show locality
* show create table (intending to capture usage of new partitioning info)

Work towards https://github.com/cockroachlabs/registration/issues/228

Release justification: Low risk improvement to monitoring.

Release note: None