### PR TITLE
row: Add a check for integrity of neededValueColsByIdx in row fetcher

### DIFF
--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -359,6 +359,18 @@ func (rf *Fetcher) Init(
 			}
 		}
 
+		// In order to track #40410 more effectively, check that the contents of
+		// table.neededValueColsByIdx are valid.
+		for idx, ok := table.neededValueColsByIdx.Next(0); ok; idx, ok = table.neededValueColsByIdx.Next(idx + 1) {
+			if idx >= len(table.row) || idx < 0 {
+				return errors.AssertionFailedf(
+					"neededValueColsByIdx contains an invalid index. column %d requested, but table has %d columns",
+					idx,
+					len(table.row),
+				)
+			}
+		}
+
 		// - If there is more than one table, we have to decode the index key to
 		//   figure out which table the row belongs to.
 		// - If there are interleaves, we need to read the index key in order to


### PR DESCRIPTION
The panic #40410 arises when a value in neededValueColsByIdx is out of
bounds of the row buffer used in the fetcher. The length of the row
buffer is equal to the number of columns in the table, so this panic is
most likely caused by the neededValueColsByIdx containing an invalid
column ID. To guard against this / have more information about debugging
this in the future, we verify during fetcher setup that all the values
in neededValueColsByIdx are within range of the table's row buffer.

Fixes #40410.

Release justification: Low risk assertion of valid behavior.

Release note: None