### PR TITLE
backport-19.1: two CLI fixes and test deflakes

### DIFF
--- a/pkg/cli/client_url.go
+++ b/pkg/cli/client_url.go
@@ -101,12 +101,13 @@ func (u urlParser) Set(v string) error {
 	}
 
 	cliCtx := u.cliCtx
+	fl := flagSetForCmd(u.cmd)
 
 	// If user name / password information is available, forward it to
 	// --user. We store the password for later re-collection by
 	// makeClientConnURL().
 	if parsedURL.User != nil {
-		f := u.cmd.Flags().Lookup(cliflags.User.Name)
+		f := fl.Lookup(cliflags.User.Name)
 		if f == nil {
 			// A client which does not support --user will also not use
 			// makeClientConnURL(), so we can ignore/forget about the
@@ -145,7 +146,7 @@ func (u urlParser) Set(v string) error {
 	// If a database path is available, forward it to --database.
 	if parsedURL.Path != "" {
 		dbPath := strings.TrimLeft(parsedURL.Path, "/")
-		f := u.cmd.Flags().Lookup(cliflags.Database.Name)
+		f := fl.Lookup(cliflags.Database.Name)
 		if f == nil {
 			// A client which does not support --database does not need this
 			// bit of information, so we can ignore/forget about it. We do
@@ -172,8 +173,6 @@ func (u urlParser) Set(v string) error {
 		}
 
 		cliCtx.extraConnURLOptions = options
-
-		fl := u.cmd.Flags()
 
 		switch sslMode := options.Get("sslmode"); sslMode {
 		case "disable":

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -78,7 +78,7 @@ func setupTransientServer(
 	// Set up logging. For demo/transient server we use non-standard
 	// behavior where we avoid file creation if possible.
 	df := startCtx.logDirFlag
-	sf := cmd.Flags().Lookup(logflags.LogToStderrName)
+	sf := flagSetForCmd(cmd).Lookup(logflags.LogToStderrName)
 	if !df.Changed && !sf.Changed {
 		// User did not request logging flags; shut down logging under
 		// errors and make logs appear on stderr.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logflags"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -84,35 +85,25 @@ func AddPersistentPreRunE(cmd *cobra.Command, fn func(*cobra.Command, []string) 
 	}
 }
 
-func setFlagFromEnv(f *pflag.FlagSet, flagInfo cliflags.FlagInfo) {
-	if flagInfo.EnvVar != "" {
-		if value, set := envutil.EnvString(flagInfo.EnvVar, 2); set {
-			if err := f.Set(flagInfo.Name, value); err != nil {
-				panic(err)
-			}
-		}
-	}
-}
-
 // StringFlag creates a string flag and registers it with the FlagSet.
 func StringFlag(f *pflag.FlagSet, valPtr *string, flagInfo cliflags.FlagInfo, defaultVal string) {
 	f.StringVarP(valPtr, flagInfo.Name, flagInfo.Shorthand, defaultVal, flagInfo.Usage())
 
-	setFlagFromEnv(f, flagInfo)
+	registerEnvVarDefault(f, flagInfo)
 }
 
 // IntFlag creates an int flag and registers it with the FlagSet.
 func IntFlag(f *pflag.FlagSet, valPtr *int, flagInfo cliflags.FlagInfo, defaultVal int) {
 	f.IntVarP(valPtr, flagInfo.Name, flagInfo.Shorthand, defaultVal, flagInfo.Usage())
 
-	setFlagFromEnv(f, flagInfo)
+	registerEnvVarDefault(f, flagInfo)
 }
 
 // BoolFlag creates a bool flag and registers it with the FlagSet.
 func BoolFlag(f *pflag.FlagSet, valPtr *bool, flagInfo cliflags.FlagInfo, defaultVal bool) {
 	f.BoolVarP(valPtr, flagInfo.Name, flagInfo.Shorthand, defaultVal, flagInfo.Usage())
 
-	setFlagFromEnv(f, flagInfo)
+	registerEnvVarDefault(f, flagInfo)
 }
 
 // DurationFlag creates a duration flag and registers it with the FlagSet.
@@ -121,14 +112,14 @@ func DurationFlag(
 ) {
 	f.DurationVarP(valPtr, flagInfo.Name, flagInfo.Shorthand, defaultVal, flagInfo.Usage())
 
-	setFlagFromEnv(f, flagInfo)
+	registerEnvVarDefault(f, flagInfo)
 }
 
 // VarFlag creates a custom-variable flag and registers it with the FlagSet.
 func VarFlag(f *pflag.FlagSet, value pflag.Value, flagInfo cliflags.FlagInfo) {
 	f.VarP(value, flagInfo.Name, flagInfo.Shorthand, flagInfo.Usage())
 
-	setFlagFromEnv(f, flagInfo)
+	registerEnvVarDefault(f, flagInfo)
 }
 
 // StringSlice creates a string slice flag and registers it with the FlagSet.
@@ -136,7 +127,7 @@ func StringSlice(
 	f *pflag.FlagSet, valPtr *[]string, flagInfo cliflags.FlagInfo, defaultVal []string,
 ) {
 	f.StringSliceVar(valPtr, flagInfo.Name, defaultVal, flagInfo.Usage())
-	setFlagFromEnv(f, flagInfo)
+	registerEnvVarDefault(f, flagInfo)
 }
 
 // aliasStrVar wraps a string configuration option and is meant
@@ -217,6 +208,11 @@ func flagSetForCmd(cmd *cobra.Command) *pflag.FlagSet {
 
 func init() {
 	initCLIDefaults()
+	defer func() {
+		if err := processEnvVarDefaults(); err != nil {
+			panic(err)
+		}
+	}()
 
 	// Every command but start will inherit the following setting.
 	cockroachCmd.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
@@ -577,6 +573,51 @@ func init() {
 	{
 		f := debugBallastCmd.Flags()
 		VarFlag(f, &debugCtx.ballastSize, cliflags.Size)
+	}
+}
+
+// processEnvVarDefaults injects the current value of flag-related
+// environment variables into the initial value of the settings linked
+// to the flags, during initialization and before the command line is
+// actually parsed. For example, it will inject the value of
+// $COCKROACH_URL into the urlParser object linked to the --url flag.
+func processEnvVarDefaults() error {
+	for envVar, d := range envVarDefaults {
+		if err := d.flagSet.Set(d.flagName, d.envValue); err != nil {
+			return errors.Wrapf(err, "setting --%s from %s", d.flagName, envVar)
+		}
+	}
+	return nil
+}
+
+// envVarDefault describes a delayed default initialization of the
+// setting covered by a flag from the value of an environment
+// variable.
+type envVarDefault struct {
+	envValue string
+	flagName string
+	flagSet  *pflag.FlagSet
+}
+
+// envVarDefaults records the initializations from environment variables
+// for processing at the end of initialization, before flag parsing.
+var envVarDefaults = map[string]envVarDefault{}
+
+// registerEnvVarDefault registers a deferred initialization of a flag
+// from an environment variable.
+func registerEnvVarDefault(f *pflag.FlagSet, flagInfo cliflags.FlagInfo) {
+	if flagInfo.EnvVar == "" {
+		return
+	}
+	value, set := envutil.EnvString(flagInfo.EnvVar, 2)
+	if !set {
+		// Env var not set. Nothing to do.
+		return
+	}
+	envVarDefaults[flagInfo.EnvVar] = envVarDefault{
+		envValue: value,
+		flagName: flagInfo.Name,
+		flagSet:  f,
 	}
 }
 

--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -96,20 +96,21 @@ proc start_server {argv} {
 proc stop_server {argv} {
     report "BEGIN STOP SERVER"
     # Trigger a normal shutdown.
-    system "$argv quit"
-    # If after 5 seconds the server hasn't shut down, trigger an error.
-    system "for i in `seq 1 5`; do
+    # If after 30 seconds the server hasn't shut down, kill the process and trigger an error.
+    # Note: kill -CONT tests whether the PID exists (SIGCONT is a no-op for the process).
+    system "kill -TERM `cat server_pid` 2>/dev/null;
+            for i in `seq 1 30`; do
               kill -CONT `cat server_pid` 2>/dev/null || exit 0
               echo still waiting
               sleep 1
             done
             echo 'server still running?'
             # Send an unclean shutdown signal to trigger a stack trace dump.
-            kill -ABRT `cat server_pid`
+            kill -ABRT `cat server_pid` 2>/dev/null
             # Sleep to increase the probability that the stack trace actually
             # makes it to disk before we force-kill the process.
             sleep 1
-            kill -KILL `cat server_pid`
+            kill -KILL `cat server_pid` 2>/dev/null
             exit 1"
 
     report "END STOP SERVER"
@@ -131,13 +132,6 @@ proc flush_server_logs {} {
 
 proc force_stop_server {argv} {
     report "BEGIN FORCE STOP SERVER"
-    system "$argv quit & sleep 1
-            if kill -CONT `cat server_pid` 2>/dev/null; then
-              kill -TERM `cat server_pid`
-              sleep 1
-              if kill -CONT `cat server_pid` 2>/dev/null; then
-                kill -KILL `cat server_pid`
-              fi
-            fi"
+    system "kill -KILL `cat server_pid`"
     report "END FORCE STOP SERVER"
 }

--- a/pkg/cli/interactive_tests/test_flags.tcl
+++ b/pkg/cli/interactive_tests/test_flags.tcl
@@ -69,5 +69,19 @@ send "$argv --vmodule=*=2 --garbage\r"
 eexpect {Failed running "cockroach"}
 end_test
 
+
+start_server $argv
+
+start_test "Check that a client can connect using the URL env var"
+send "export COCKROACH_URL=`cat server_url`;\r"
+eexpect ":/# "
+send "$argv sql\r"
+eexpect "defaultdb>"
+interrupt
+eexpect ":/# "
+end_test
+
+stop_server $argv
+
 send "exit 0\r"
 eexpect eof

--- a/pkg/cli/interactive_tests/test_log_config_msg.tcl
+++ b/pkg/cli/interactive_tests/test_log_config_msg.tcl
@@ -6,11 +6,14 @@ source [file join [file dirname $argv0] common.tcl]
 # flushed and not in the middle of a rotation.
 
 start_server $argv
-stop_server $argv
 
 start_test "Check that the cluster ID is reported at the start of the first log file."
-system "grep -qF '\[config\] clusterID:' logs/db/logs/cockroach.log"
+spawn tail -n 1000 -F logs/db/logs/cockroach.log
+eexpect "\\\[config\\\] clusterID:"
+eexpect "node startup completed"
 end_test
+
+stop_server $argv
 
 
 # Make a server with a tiny log buffer so as to force frequent log rotation.

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -886,7 +886,7 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 }
 
 func hintServerCmdFlags(ctx context.Context, cmd *cobra.Command) {
-	pf := cmd.Flags()
+	pf := flagSetForCmd(cmd)
 
 	listenAddrSpecified := pf.Lookup(cliflags.ListenAddr.Name).Changed || pf.Lookup(cliflags.ServerHost.Name).Changed
 	advAddrSpecified := pf.Lookup(cliflags.AdvertiseAddr.Name).Changed || pf.Lookup(cliflags.AdvertiseHost.Name).Changed


### PR DESCRIPTION
Backporting 2/2 commits from #40821 
Backporting 2/2 commits from #40824

Release justification: fixes test flakes and a feature
