### PR TITLE
issues: link to roachtest artifact directory, not build log

### DIFF
--- a/pkg/cmd/github-post/main.go
+++ b/pkg/cmd/github-post/main.go
@@ -44,7 +44,7 @@ func main() {
 
 	f := func(ctx context.Context, title, packageName, testName, testMessage, authorEmail string) error {
 		log.Printf("filing issue with title: %s", title)
-		return issues.Post(ctx, title, packageName, testName, testMessage, authorEmail, nil)
+		return issues.Post(ctx, title, packageName, testName, testMessage, "" /* artifacts */, authorEmail, nil)
 	}
 
 	if err := listFailures(ctx, os.Stdin, f); err != nil {

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -602,11 +602,12 @@ func (r *testRunner) runTest(
 				}
 				msg := fmt.Sprintf("The test failed on branch=%s, cloud=%s:\n%s",
 					branch, cloud, output)
+				artifacts := fmt.Sprintf("/%s", t.Name())
 
 				if err := issues.Post(
 					context.Background(),
 					fmt.Sprintf("roachtest: %s failed", t.Name()),
-					"roachtest", t.Name(), msg, authorEmail, []string{"O-roachtest"},
+					"roachtest", t.Name(), msg, artifacts, authorEmail, []string{"O-roachtest"},
 				); err != nil {
 					shout(ctx, l, stdout, "failed to post issue: %s", err)
 				}


### PR DESCRIPTION
Debugging roachtests always begins with a dance just to find the failing
test's artifacts. This commit removes the first few steps here by linking
straight to the artifacts directory instead of linking to the useless
TeamCity build log.

Release justification: testing only.

Release note: None