### PR TITLE
roachtest: include branch name in issue filing

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -606,7 +606,7 @@ func (r *testRunner) runTest(
 
 				if err := issues.Post(
 					context.Background(),
-					fmt.Sprintf("roachtest: %s failed", t.Name()),
+					fmt.Sprintf("roachtest-%s: %s failed", branch, t.Name()),
 					"roachtest", t.Name(), msg, artifacts, authorEmail, []string{"O-roachtest"},
 				); err != nil {
 					shout(ctx, l, stdout, "failed to post issue: %s", err)


### PR DESCRIPTION
This changes the roachtest issue filer to include the branch name in the title of the issue, so that roachtest issues are grouped by version.

This may have somewhat weird side effects as the "branch name" in this case could be either something normal like `master` or `release-19.1`, or something funky like `provisional_2019...`. I think around release time it might actually make the grouping slightly worse, but overall I'd expect the groupings to be better than they are today.

Release note: None
Release justification: Test-only changes