### PR TITLE
cli/interactive_tests: deflake and accelerate test_multiple_nodes

### DIFF
--- a/pkg/cli/interactive_tests/test_multiple_nodes.tcl
+++ b/pkg/cli/interactive_tests/test_multiple_nodes.tcl
@@ -18,10 +18,8 @@ eexpect id
 eexpect "3 rows"
 eexpect eof
 
-# Remove the additional nodes.
-system "$argv quit --port=26258"
-system "$argv quit --port=26259"
-
 end_test
 
-stop_server $argv
+# Kill the cluster. We don't care about what happens next in this test,
+# and this makes the test complete faster.
+system "kill -KILL `cat server_pid` `cat server_pid2` `cat server_pid3`"


### PR DESCRIPTION
Release justification: deflakes a test and makes CI run faster

Prior to this patch the test would attempt to shut down the cluster
gracefully after asserting that the 3 nodes are properly joined.

Unfortunately this wait is running into separate issue
https://github.com/cockroachdb/cockroach/issues/40834 and this makes
the test clean-up flaky.

Since this unit test is not about quitting a cluster but merely
checking that the join is successful, this patch both works around the
related issue and accelerates the test by simply killing the nodes.

Release note: None