### PR TITLE
[DNM] partitionccl: modifity TestRepartitioning in a way that repros #40213

### DIFF
--- a/pkg/cmd/roachprod-stress/main.go
+++ b/pkg/cmd/roachprod-stress/main.go
@@ -95,6 +95,11 @@ func run() error {
 		return fmt.Errorf("%v\n%s", err, out)
 	}
 	nodes := strings.Count(string(out), "\n") - 1
+	const tmpDir = "/mnt/data1/tmp"
+	cmd = exec.Command("roachprod", "run", cluster, "--", "mkdir", "-p", tmpDir)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to make TMPDIR at %s: %v", tmpDir, err)
+	}
 
 	const stressBin = "bin.docker_amd64/stress"
 	cmd = exec.Command("roachprod", "put", cluster, stressBin)
@@ -204,7 +209,7 @@ func run() error {
 			var stderr bytes.Buffer
 			cmd := exec.Command("roachprod",
 				"ssh", fmt.Sprintf("%s:%d", cluster, i), "--",
-				fmt.Sprintf("GOTRACEBACK=all ./stress %s", strings.Join(os.Args[2:], " ")))
+				fmt.Sprintf("TMPDIR="+tmpDir+" GOTRACEBACK=all ./stress %s", strings.Join(os.Args[2:], " ")))
 			cmd.Stdout = stdoutW
 			cmd.Stderr = &stderr
 			if err := cmd.Run(); err != nil {


### PR DESCRIPTION
I changed the partitioning tests to involve more nodes and very rapidly started hitting `setting non-zero HardState.Commit on uninitialized replica` issues. At first I thought it must have been my code not deleting the hard state but I added more logic to read the HardState from the replica immediately after I thought it had been deleted and it was gone. I also added logic to print the batch which should delete it and there was a range deletion for that range. 

@ajkr maybe you'll find this helpful. It reproduces in ~10 minutes under stress on a gceworker. 