### PR TITLE
opt: move autocommit logic to the execbuilder

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -365,11 +365,6 @@ func (n *createTableNode) startExec(params runParams) error {
 	return nil
 }
 
-// enableAutoCommit is part of the autoCommitNode interface.
-func (n *createTableNode) enableAutoCommit() {
-	n.run.autoCommit = autoCommitEnabled
-}
-
 func (*createTableNode) Next(runParams) (bool, error) { return false, nil }
 func (*createTableNode) Values() tree.Datums          { return tree.Datums{} }
 

--- a/pkg/sql/delayed.go
+++ b/pkg/sql/delayed.go
@@ -27,9 +27,6 @@ type delayedNode struct {
 	plan        planNode
 }
 
-// delayedNode implements the autoCommitNode interface.
-var _ autoCommitNode = &delayedNode{}
-
 type nodeConstructor func(context.Context, *planner) (planNode, error)
 
 func (d *delayedNode) Next(params runParams) (bool, error) { return d.plan.Next(params) }
@@ -39,13 +36,6 @@ func (d *delayedNode) Close(ctx context.Context) {
 	if d.plan != nil {
 		d.plan.Close(ctx)
 		d.plan = nil
-	}
-}
-
-// enableAutoCommit is part of the autoCommitNode interface.
-func (d *delayedNode) enableAutoCommit() {
-	if ac, ok := d.plan.(autoCommitNode); ok {
-		ac.enableAutoCommit()
 	}
 }
 

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -41,9 +41,6 @@ type deleteNode struct {
 	run deleteRun
 }
 
-// deleteNode implements the autoCommitNode interface.
-var _ autoCommitNode = &deleteNode{}
-
 // Delete removes rows from a table.
 // Privileges: DELETE and SELECT on table. We currently always use a SELECT statement.
 //   Notes: postgres requires DELETE. Also requires SELECT for "USING" and "WHERE" with tables.
@@ -449,7 +446,6 @@ func canDeleteFastInterleaved(table *ImmutableTableDescriptor, fkTables row.FkTa
 	return true
 }
 
-// enableAutoCommit is part of the autoCommitNode interface.
 func (d *deleteNode) enableAutoCommit() {
 	d.run.td.enableAutoCommit()
 }

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -50,9 +50,6 @@ type insertNode struct {
 	run insertRun
 }
 
-// insertNode implements the autoCommitNode interface.
-var _ autoCommitNode = &insertNode{}
-
 // Insert inserts rows into the database.
 // Privileges: INSERT on table. Also requires UPDATE on "ON DUPLICATE KEY UPDATE".
 //   Notes: postgres requires INSERT. No "on duplicate key update" option.
@@ -614,7 +611,7 @@ func (n *insertNode) Close(ctx context.Context) {
 	insertNodePool.Put(n)
 }
 
-// enableAutoCommit is part of the autoCommitNode interface.
+// See planner.autoCommit.
 func (n *insertNode) enableAutoCommit() {
 	n.run.ti.enableAutoCommit()
 }

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -228,6 +228,7 @@ func (f *stubFactory) ConstructInsert(
 	insertCols exec.ColumnOrdinalSet,
 	returnCols exec.ColumnOrdinalSet,
 	checks exec.CheckOrdinalSet,
+	allowAutoCommit bool,
 	skipFKChecks bool,
 ) (exec.Node, error) {
 	return struct{}{}, nil
@@ -241,6 +242,7 @@ func (f *stubFactory) ConstructUpdate(
 	returnCols exec.ColumnOrdinalSet,
 	checks exec.CheckOrdinalSet,
 	passthrough sqlbase.ResultColumns,
+	allowAutoCommit bool,
 	skipFKChecks bool,
 ) (exec.Node, error) {
 	return struct{}{}, nil
@@ -255,6 +257,7 @@ func (f *stubFactory) ConstructUpsert(
 	updateCols exec.ColumnOrdinalSet,
 	returnCols exec.ColumnOrdinalSet,
 	checks exec.CheckOrdinalSet,
+	allowAutoCommit bool,
 ) (exec.Node, error) {
 	return struct{}{}, nil
 }
@@ -264,6 +267,7 @@ func (f *stubFactory) ConstructDelete(
 	table cat.Table,
 	fetchCols exec.ColumnOrdinalSet,
 	returnCols exec.ColumnOrdinalSet,
+	allowAutoCommit bool,
 	skipFKChecks bool,
 ) (exec.Node, error) {
 	return struct{}{}, nil

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -56,6 +56,11 @@ type Builder struct {
 	// TODO(justin): set this up so that we can look them up by index lookups
 	// rather than scans.
 	withExprs []builtWithExpr
+
+	// autoCommit is passed through to factory methods for mutation operators. It
+	// allows execution to commit the transaction as part of the mutation itself.
+	// See canAutoCommit().
+	autoCommit bool
 }
 
 // New constructs an instance of the execution node builder using the
@@ -114,6 +119,9 @@ func (b *Builder) build(e opt.Expr) (exec.Node, error) {
 	if !ok {
 		return nil, errors.AssertionFailedf("building execution for non-relational operator %s", log.Safe(e.Op()))
 	}
+
+	b.autoCommit = b.canAutoCommit(rel)
+
 	plan, err := b.buildRelational(rel)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -520,12 +520,12 @@ func (b *Builder) buildExistsSubquery(
 
 	// Build the execution plan for the subquery. Note that the subquery could
 	// have subqueries of its own which are added to b.subqueries.
-	root, err := b.build(exists.Input)
+	plan, err := b.buildRelational(exists.Input)
 	if err != nil {
 		return nil, err
 	}
 
-	return b.addSubquery(exec.SubqueryExists, types.Bool, root, exists.OriginalExpr), nil
+	return b.addSubquery(exec.SubqueryExists, types.Bool, plan.root, exists.OriginalExpr), nil
 }
 
 func (b *Builder) buildSubquery(
@@ -547,12 +547,12 @@ func (b *Builder) buildSubquery(
 
 	// Build the execution plan for the subquery. Note that the subquery could
 	// have subqueries of its own which are added to b.subqueries.
-	root, err := b.build(input)
+	plan, err := b.buildRelational(input)
 	if err != nil {
 		return nil, err
 	}
 
-	return b.addSubquery(exec.SubqueryOneRow, subquery.Typ, root, subquery.OriginalExpr), nil
+	return b.addSubquery(exec.SubqueryOneRow, subquery.Typ, plan.root, subquery.OriginalExpr), nil
 }
 
 // addSubquery adds an entry to b.subqueries and creates a tree.Subquery

--- a/pkg/sql/opt/exec/execbuilder/testdata/autocommit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/autocommit
@@ -1,0 +1,299 @@
+# LogicTest: local
+
+statement ok
+CREATE TABLE ab (a INT, b INT)
+
+# ------------
+# INSERT tests
+# ------------
+
+# Simple insert should auto-commit.
+statement ok
+SET TRACING=ON;
+  INSERT INTO ab VALUES (1, 1), (2, 2);
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+true
+
+# No auto-commit inside a transaction.
+statement ok
+BEGIN
+
+statement ok
+SET TRACING=ON;
+  INSERT INTO ab VALUES (1, 1), (2, 2);
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+false
+
+statement ok
+ROLLBACK
+
+# Insert with simple RETURNING statement should auto-commit.
+statement ok
+SET TRACING=ON;
+  INSERT INTO ab VALUES (1, 1), (2, 2) RETURNING a, b;
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+true
+
+# TODO(radu): allow non-side-effecting projections.
+statement ok
+SET TRACING=ON;
+  INSERT INTO ab VALUES (1, 1), (2, 2) RETURNING a + b;
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+false
+
+# Insert with RETURNING statement with side-effects should not auto-commit.
+# In this case division can (in principle) error out.
+statement ok
+SET TRACING=ON;
+  INSERT INTO ab VALUES (1, 1), (2, 2) RETURNING a / b;
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+false
+
+# Another way to test the scenario above: generate an error and ensure that the
+# mutation was not committed.
+statement error division by zero
+INSERT INTO ab VALUES (1, 0) RETURNING a / b
+
+query I
+SELECT count(*) FROM ab WHERE b=0
+----
+0
+
+# ------------
+# UPSERT tests
+# ------------
+
+# Simple upsert should auto-commit.
+statement ok
+SET TRACING=ON;
+  UPSERT INTO ab VALUES (1, 1), (2, 2);
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+true
+
+# No auto-commit inside a transaction.
+statement ok
+BEGIN
+
+statement ok
+SET TRACING=ON;
+  UPSERT INTO ab VALUES (1, 1), (2, 2);
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+false
+
+statement ok
+ROLLBACK
+
+# Upsert with simple RETURNING statement should auto-commit.
+statement ok
+SET TRACING=ON;
+  UPSERT INTO ab VALUES (1, 1), (2, 2) RETURNING a, b;
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+true
+
+# TODO(radu): allow non-side-effecting projections.
+statement ok
+SET TRACING=ON;
+  UPSERT INTO ab VALUES (1, 1), (2, 2) RETURNING a + b;
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+false
+
+# Upsert with RETURNING statement with side-effects should not auto-commit.
+# In this case division can (in principle) error out.
+statement ok
+SET TRACING=ON;
+  UPSERT INTO ab VALUES (1, 1), (2, 2) RETURNING a / b;
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+false
+
+# Another way to test the scenario above: generate an error and ensure that the
+# mutation was not committed.
+statement error division by zero
+UPSERT INTO ab VALUES (1, 0) RETURNING a / b
+
+query I
+SELECT count(*) FROM ab WHERE b=0
+----
+0
+
+# ------------
+# UPDATE tests
+# ------------
+
+# Simple update should auto-commit.
+statement ok
+SET TRACING=ON;
+  UPDATE ab SET b=b+1 WHERE a < 3;
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+true
+
+# No auto-commit inside a transaction.
+statement ok
+BEGIN
+
+statement ok
+SET TRACING=ON;
+  UPDATE ab SET b=b+1 WHERE a < 3;
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+false
+
+statement ok
+ROLLBACK
+
+# Update with simple RETURNING statement should auto-commit.
+statement ok
+SET TRACING=ON;
+  UPDATE ab SET b=b+1 WHERE a < 3 RETURNING a, b;
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+true
+
+# TODO(radu): allow non-side-effecting projections.
+statement ok
+SET TRACING=ON;
+  UPDATE ab SET b=b+1 WHERE a < 3 RETURNING a + b;
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+false
+
+# Update with RETURNING statement with side-effects should not auto-commit.
+# In this case division can (in principle) error out.
+statement ok
+SET TRACING=ON;
+  UPDATE ab SET b=b+1 WHERE a < 3 RETURNING a / b;
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+false
+
+# Another way to test the scenario above: generate an error and ensure that the
+# mutation was not committed.
+statement error division by zero
+UPDATE ab SET b=0 WHERE a < 3 RETURNING a / b;
+
+query I
+SELECT count(*) FROM ab WHERE b=0
+----
+0
+
+# -----------------------
+# Tests with foreign keys
+# -----------------------
+
+statement ok
+CREATE TABLE fk_parent (p INT PRIMARY KEY, q INT);
+INSERT INTO fk_parent VALUES (1, 10), (2, 20), (3, 30);
+CREATE TABLE fk_child (a INT, b INT REFERENCES fk_parent(p));
+SET experimental_optimizer_foreign_keys = true
+
+statement ok
+SET TRACING=ON;
+  INSERT INTO fk_child VALUES (1, 1), (2, 2);
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+false
+
+statement ok
+SET TRACING=ON;
+  UPDATE fk_child SET b=b+1 WHERE a < 2;
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+false
+
+statement ok
+SET TRACING=ON;
+  DELETE FROM fk_parent WHERE p = 3;
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+false
+
+# -----------------------
+# Multiple mutation tests
+# -----------------------
+
+statement ok
+SET TRACING=ON;
+  INSERT INTO ab (
+    SELECT a*10, b*10 FROM [ INSERT INTO ab VALUES (1, 1), (2, 2) RETURNING a, b ]
+  );
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+false
+
+statement ok
+SET TRACING=ON;
+  WITH cte AS (INSERT INTO ab VALUES (1, 1), (2, 2) RETURNING a, b)
+  INSERT INTO ab (SELECT a*10, b*10 FROM cte);
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+false

--- a/pkg/sql/plan_batch.go
+++ b/pkg/sql/plan_batch.go
@@ -28,13 +28,6 @@ import (
 // - batchedPlanNode *replaces* planNode for the purpose of local
 //   execution.
 type batchedPlanNode interface {
-	// batchedPlanNode is currently intended for use by data-modifying
-	// statements. These are all sensitive to the auto commit bit, so
-	// ensure the autoCommitNode interface is implemented. This
-	// simplifies the definition of this interface by serializeNode and
-	// rowCountNode below.
-	autoCommitNode
-
 	// batchedPlanNode specializes planNode for the purpose of the recursions
 	// on planNode trees performed during logical planning, so it should "inherit"
 	// planNode. However this interface inheritance does not imply that
@@ -139,9 +132,6 @@ func (s *serializeNode) FastPathResults() (int, bool) {
 // requireSpool implements the planNodeRequireSpool interface.
 func (s *serializeNode) requireSpool() {}
 
-// enableAutocommit implements the autoCommitNode interface.
-func (s *serializeNode) enableAutoCommit() { s.source.enableAutoCommit() }
-
 // rowCountNode serializes the results of a batchedPlanNode into a
 // plain planNode interface that has guaranteed FastPathResults
 // behavior and no result columns (i.e. just the count of rows
@@ -181,6 +171,3 @@ func (r *rowCountNode) Close(ctx context.Context)           { r.source.Close(ctx
 
 // FastPathResults implements the planNodeFastPath interface.
 func (r *rowCountNode) FastPathResults() (int, bool) { return r.rowCount, true }
-
-// enableAutocommit implements the autoCommitNode interface.
-func (r *rowCountNode) enableAutoCommit() { r.source.enableAutoCommit() }

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -129,8 +129,8 @@ type planner struct {
 	// transaction along with other KV operations. Committing the txn might be
 	// beneficial because it may enable the 1PC optimization.
 	//
-	// NOTE: This member is for internal use of the planner only. PlanNodes that
-	// want to do 1PC transactions have to implement the autoCommitNode interface.
+	// NOTE: plan node must be configured appropriately to actually perform an
+	// auto-commit. This is dependent on information from the optimizer.
 	autoCommit bool
 
 	// discardRows is set if we want to discard any results rather than sending

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // expressionCarrier handles visiting sub-expressions.
@@ -152,6 +153,7 @@ func (tb *tableWriterBase) finalize(
 	ctx context.Context, tableDesc *sqlbase.ImmutableTableDescriptor,
 ) (err error) {
 	if tb.autoCommit == autoCommitEnabled {
+		log.Event(ctx, "autocommit enabled")
 		// An auto-txn can commit the transaction with the batch. This is an
 		// optimization to avoid an extra round-trip to the transaction
 		// coordinator.

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -46,9 +46,6 @@ type updateNode struct {
 	run updateRun
 }
 
-// updateNode implements the autoCommitNode interface.
-var _ autoCommitNode = &updateNode{}
-
 // Update updates columns for a selection of rows from a table.
 // Privileges: UPDATE and SELECT on table. We currently always use a select statement.
 //   Notes: postgres requires UPDATE. Requires SELECT with WHERE clause with table.
@@ -772,7 +769,6 @@ func (u *updateNode) Close(ctx context.Context) {
 	updateNodePool.Put(u)
 }
 
-// enableAutoCommit implements the autoCommitNode interface.
 func (u *updateNode) enableAutoCommit() {
 	u.run.tu.enableAutoCommit()
 }

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -42,9 +42,6 @@ type upsertNode struct {
 	run upsertRun
 }
 
-// upsertNode implements the autoCommitNode interface.
-var _ autoCommitNode = &upsertNode{}
-
 func (p *planner) newUpsertNode(
 	ctx context.Context,
 	n *tree.Insert,
@@ -418,7 +415,6 @@ func (n *upsertNode) Close(ctx context.Context) {
 	upsertNodePool.Put(n)
 }
 
-// enableAutoCommit is part of the autoCommitNode interface.
 func (n *upsertNode) enableAutoCommit() {
 	n.run.tw.enableAutoCommit()
 }


### PR DESCRIPTION
Auto-commit refers to the optimization of committing the txn as part
of the last batch of the mutation. This is only correct to do in
certain cases. Currently this logic is inside the execution layer and
is very simplistic (the root node must implement `enableAutoCommit`).

This change moves the auto-commit logic to the execbuilder and
improves the logic to allow RETURNING statements (as long as
projections have no side effects). Whether we auto-commit is then sent
down via the exec factory.

Fixes #34504.

Release note (performance improvement): Mutation statements with
RETURNING and not inside an explicit transaction are faster in some
cases.

Release justification: Low risk, high benefit changes to existing
functionality (we know of at least one customer workload that
benefits).
