### PR TITLE
roachtest: Fix backwards compatibility of node status in roachtest

### DIFF
--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -349,6 +349,9 @@ func runDecommissionAcceptance(ctx context.Context, t *test, c *cluster) {
 	statusHeaderNoLocality := []string{
 		"id", "address", "sql_address", "build", "started_at", "updated_at", "is_available", "is_live",
 	}
+	statusHeaderNoLocalityNoSQLAddress := []string{
+		"id", "address", "build", "started_at", "updated_at", "is_available", "is_live",
+	}
 	getStatusCsvOutput := func(ids []string, numCols int) [][]string {
 		var res [][]string
 		switch numCols {
@@ -356,8 +359,16 @@ func runDecommissionAcceptance(ctx context.Context, t *test, c *cluster) {
 			res = append(res, statusHeaderNoLocality)
 		case len(statusHeaderWithLocality):
 			res = append(res, statusHeaderWithLocality)
+		case len(statusHeaderNoLocalityNoSQLAddress):
+			res = append(res, statusHeaderNoLocalityNoSQLAddress)
 		default:
-			t.Fatalf("Expected status output numCols to be either %d or %d, found %d", len(statusHeaderNoLocality), len(statusHeaderWithLocality), numCols)
+			t.Fatalf(
+				"Expected status output numCols to be either %d, %d or %d, found %d",
+				len(statusHeaderNoLocalityNoSQLAddress),
+				len(statusHeaderNoLocality),
+				len(statusHeaderWithLocality),
+				numCols,
+			)
 		}
 		for _, id := range ids {
 			build := []string{id}


### PR DESCRIPTION
The `cockroach node status` command in v2.1 only return 7 columns,
instead of 8 or 9 like in versions 19.1/2. This PR updates the
acceptance/decommission roachtest to handle all of these cases.

Release justification: Low risk fix to a failing test.

Fixes #39612.

Release note: None