### PR TITLE
sql: Add a `SHOW RANGES FROM INDEX table@*` command.

### DIFF
--- a/docs/generated/sql/bnf/show_ranges_stmt.bnf
+++ b/docs/generated/sql/bnf/show_ranges_stmt.bnf
@@ -2,3 +2,4 @@ show_ranges_stmt ::=
 	'SHOW' 'RANGES' 'FROM' 'TABLE' table_name
 	| 'SHOW' 'RANGES' 'FROM' 'INDEX' table_index_name
 	| 'SHOW' 'RANGES' 'FROM' 'DATABASE' database_name
+	| 'SHOW' 'RANGES' 'FROM' 'INDEX' table_name '@' '*'

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -511,6 +511,7 @@ show_ranges_stmt ::=
 	'SHOW' 'RANGES' 'FROM' 'TABLE' table_name
 	| 'SHOW' 'RANGES' 'FROM' 'INDEX' table_index_name
 	| 'SHOW' 'RANGES' 'FROM' 'DATABASE' database_name
+	| 'SHOW' 'RANGES' 'FROM' 'INDEX' table_name '@' '*'
 
 show_roles_stmt ::=
 	'SHOW' 'ROLES'

--- a/pkg/sql/delegate/show_ranges.go
+++ b/pkg/sql/delegate/show_ranges.go
@@ -11,9 +11,11 @@
 package delegate
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -24,6 +26,7 @@ import (
 // delegateShowRanges implements the SHOW RANGES statement:
 //   SHOW RANGES FROM TABLE t
 //   SHOW RANGES FROM INDEX t@idx
+//   SHOW RANGES FROM INDEX t@*
 //   SHOW RANGES FROM DATABASE db
 //
 // These statements show the ranges corresponding to the given table or index,
@@ -34,6 +37,7 @@ func (d *delegator) delegateShowRanges(n *tree.ShowRanges) (tree.Statement, erro
 		const dbQuery = `
 		SELECT
 			table_name,
+			CASE WHEN index_name = '' THEN 'primary' ELSE index_name END AS index_name,
 			CASE
 				WHEN crdb_internal.pretty_key(r.start_key, 2) = '' THEN NULL
 				ELSE crdb_internal.pretty_key(r.start_key, 2)
@@ -49,12 +53,74 @@ func (d *delegator) delegateShowRanges(n *tree.ShowRanges) (tree.Statement, erro
 			replicas,
 			replica_localities
 		FROM %[1]s.crdb_internal.ranges AS r
-	  LEFT JOIN crdb_internal.gossip_nodes ON lease_holder = node_id
+	  LEFT JOIN %[1]s.crdb_internal.gossip_nodes ON lease_holder = node_id
 		WHERE database_name=%[2]s
-		ORDER BY table_name, r.start_key
+		ORDER BY table_name, index_name, r.start_key
 		`
 		// Note: n.DatabaseName.String() != string(n.DatabaseName)
 		return parse(fmt.Sprintf(dbQuery, n.DatabaseName.String(), lex.EscapeSQLString(string(n.DatabaseName))))
+	} else if n.AllIndexes {
+		// If n.AllIndexes is true, the request is SHOW RANGES FROM INDEX t@*.
+		flags := cat.Flags{AvoidDescriptorCaches: true, NoTableStats: true}
+		dataSource, resName, err := d.catalog.ResolveDataSource(d.ctx, flags, &n.TableOrIndex.Table)
+		if err != nil {
+			return nil, err
+		}
+		if err := d.catalog.CheckPrivilege(d.ctx, dataSource, privilege.SELECT); err != nil {
+			return nil, err
+		}
+
+		// Get all indexes by taking all keys that are larger than the the smallest key from all indexes, and
+		// smaller than the largest key of all the indexes.
+		startKey := keys.MaxKey
+		endKey := keys.MinKey
+		table := dataSource.(cat.Table)
+		for i := 0; i < table.IndexCount(); i++ {
+			idx := table.Index(i)
+			span := idx.Span()
+			if bytes.Compare(span.Key, startKey) < 0 {
+				startKey = span.Key
+			}
+			if bytes.Compare(span.EndKey, endKey) > 0 {
+				endKey = span.EndKey
+			}
+		}
+
+		fmt.Println(startKey, endKey)
+
+		const query = `
+		SELECT
+			table_name,
+			CASE WHEN index_name = '' THEN 'primary' ELSE index_name END AS index_name,
+			CASE
+				WHEN crdb_internal.pretty_key(r.start_key, 2) = '' THEN NULL
+				ELSE crdb_internal.pretty_key(r.start_key, 2)
+			END AS start_key,
+			CASE
+				WHEN crdb_internal.pretty_key(r.end_key, 2) = '' THEN NULL
+				ELSE crdb_internal.pretty_key(r.end_key, 2)
+			END AS end_key,
+			range_id,
+			range_size / 1000000 as range_size_mb,
+			lease_holder,
+    	gossip_nodes.locality as lease_holder_locality,
+			replicas,
+			replica_localities
+		FROM %[1]s.crdb_internal.ranges AS r
+	  LEFT JOIN %[1]s.crdb_internal.gossip_nodes ON lease_holder = node_id
+		WHERE r.start_key < x'%[4]s' AND r.end_key > x'%[3]s'
+		ORDER BY table_name, index_name, r.start_key
+		`
+		// note: CatalogName.String() != Catalog()
+		return parse(
+			fmt.Sprintf(
+				query,
+				resName.CatalogName.String(),
+				lex.EscapeSQLString(resName.Table()),
+				hex.EncodeToString([]byte(startKey)),
+				hex.EncodeToString([]byte(endKey)),
+			),
+		)
 	}
 
 	idx, resName, err := cat.ResolveTableIndex(

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3858,8 +3858,10 @@ show_zone_stmt:
 // %Help: SHOW RANGES - list ranges
 // %Category: Misc
 // %Text:
+// SHOW RANGES FROM DATABASE <databasename>
 // SHOW RANGES FROM TABLE <tablename>
 // SHOW RANGES FROM INDEX [ <tablename> @ ] <indexname>
+// SHOW RANGES FROM INDEX <tablename>@*
 show_ranges_stmt:
   SHOW RANGES FROM TABLE table_name
   {
@@ -3873,6 +3875,11 @@ show_ranges_stmt:
 | SHOW RANGES FROM DATABASE database_name 
   {
     $$.val = &tree.ShowRanges{DatabaseName: tree.Name($5)}
+  }
+| SHOW RANGES FROM INDEX table_name '@' '*'
+  {
+    name := $5.unresolvedObjectName().ToTableName()
+    $$.val = &tree.ShowRanges{TableOrIndex: tree.TableIndexName{Table: name}, AllIndexes: true}
   }
 | SHOW RANGES error // SHOW HELP: SHOW RANGES
 

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -394,6 +394,7 @@ func (node *ShowRoles) Format(ctx *FmtCtx) {
 type ShowRanges struct {
 	TableOrIndex TableIndexName
 	DatabaseName Name
+	AllIndexes   bool
 }
 
 // Format implements the NodeFormatter interface.
@@ -408,6 +409,9 @@ func (node *ShowRanges) Format(ctx *FmtCtx) {
 	} else {
 		ctx.WriteString("TABLE ")
 		ctx.FormatNode(&node.TableOrIndex)
+		if node.AllIndexes {
+			ctx.WriteString("@*")
+		}
 	}
 }
 


### PR DESCRIPTION
This PR adds the command `SHOW RANGES FROM INDEX table@*`, which
displays ranges for all indexes of a table. This command is functionally
equivalent to `SELECT * FROM [SHOW RANGES FROM DATABASE d] WHERE
table_name='table'`, but is more convenient syntax. However, it should
be known that unlike `SHOW RANGES FROM INDEX t@x` and `SHOW RANGES FROM
TABLE t`, both `SHOW RANGES FROM INDEX t@*` and `SHOW RANGES FROM
DATABASE d` will not show information if a range for a specific
index/table has not been split yet.

Fixes #40544.

Release justification: Low risk UX improvement.

Release note (sql change): Add support for a `SHOW RANGES FROM INDEX table@*`
command.