### PR TITLE
sqltelemetry,sql: Add telemetry for partitioning related improvements

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -638,6 +638,11 @@ CREATE INDEX x2 ON t2 (x) PARTITION BY LIST (x) (
 statement ok
 ALTER PARTITION p1 OF INDEX t2@* CONFIGURE ZONE USING num_replicas = 1
 
+query T
+SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name='sql.partitioning.alter-all-partitions' AND usage_count > 0
+----
+sql.partitioning.alter-all-partitions
+
 statement error index "t2" does not exist\nHINT: try specifying the index as <tablename>@<indexname>
 ALTER PARTITION p1 OF INDEX t2 CONFIGURE ZONE USING num_replicas = 1
 

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
@@ -270,6 +271,7 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 	// of them.
 	var specifiers []tree.ZoneSpecifier
 	if n.zoneSpecifier.TargetsPartition() && n.allIndexes {
+		sqltelemetry.IncrementPartitioningCounter(sqltelemetry.AlterAllPartitions)
 		for _, idx := range table.AllNonDropIndexes() {
 			if p := idx.FindPartitionByName(string(n.zoneSpecifier.Partition)); p != nil {
 				zs := n.zoneSpecifier

--- a/pkg/sql/sqltelemetry/partitioning.go
+++ b/pkg/sql/sqltelemetry/partitioning.go
@@ -1,0 +1,49 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sqltelemetry
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+)
+
+// PartitioningTelemetryType is an enum used to represent the different partitioning related operations
+// that we are recording telemetry for.
+type PartitioningTelemetryType int
+
+const (
+	_ PartitioningTelemetryType = iota
+	// AlterAllPartitions represents an ALTER ALL PARTITIONS statement (ALTER PARTITION OF INDEX t@*)
+	AlterAllPartitions
+)
+
+var partitioningTelemetryMap = map[PartitioningTelemetryType]string{
+	AlterAllPartitions: "alter-all-partitions",
+}
+
+func (p PartitioningTelemetryType) String() string {
+	return partitioningTelemetryMap[p]
+}
+
+var partitioningTelemetryCounters map[PartitioningTelemetryType]telemetry.Counter
+
+func init() {
+	partitioningTelemetryCounters = make(map[PartitioningTelemetryType]telemetry.Counter)
+	for ty, s := range partitioningTelemetryMap {
+		partitioningTelemetryCounters[ty] = telemetry.GetCounterOnce(fmt.Sprintf("sql.partitioning.%s", s))
+	}
+}
+
+// IncrementPartitioningCounter is used to increment the telemetry counter for a particular partitioning operation.
+func IncrementPartitioningCounter(partitioningType PartitioningTelemetryType) {
+	telemetry.Inc(partitioningTelemetryCounters[partitioningType])
+}


### PR DESCRIPTION
This PR adds telemetry for the ALTER PARTITION FROM INDEX t@* command,
as well as sets up some boilerplate code for adding more partitioning
specific telemetry counters.

We only have one thing that we are recording telemetry of relating to partitioning right now, but I thought it was good to just set up the boilerplate so that we could add some more counters in the future if desired.

Work for https://github.com/cockroachlabs/registration/issues/228.

Release justification: Low risk monitoring improvement.

Release note: None