### PR TITLE
demo: Add telemetry about usage of new demo features.

### DIFF
--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -348,6 +348,21 @@ func runWorkload(
 	return nil
 }
 
+func incrementTelemetryCounters(cmd *cobra.Command) {
+	if flagSetForCmd(cmd).Lookup(cliflags.DemoNodes.Name).Changed {
+		incrementDemoCounter(nodes)
+	}
+	if demoCtx.localities != nil {
+		incrementDemoCounter(demoLocality)
+	}
+	if demoCtx.runWorkload {
+		incrementDemoCounter(withLoad)
+	}
+	if demoCtx.geoPartitionedReplicas {
+		incrementDemoCounter(geoPartitionedReplicas)
+	}
+}
+
 func runDemo(cmd *cobra.Command, gen workload.Generator) error {
 	if gen == nil && !demoCtx.useEmptyDatabase {
 		// Use a default dataset unless prevented by --empty.
@@ -390,6 +405,9 @@ func runDemo(cmd *cobra.Command, gen workload.Generator) error {
 			return configErr
 		}
 	}
+
+	// Record some telemetry about what flags are being used.
+	incrementTelemetryCounters(cmd)
 
 	// Th geo-partitioned replicas demo only works on a 9 node cluster, so set the node count as such.
 	// Ignore input user localities so that the nodes have the same attributes/localities as expected.

--- a/pkg/cli/demo_telemetry.go
+++ b/pkg/cli/demo_telemetry.go
@@ -1,0 +1,52 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+)
+
+// demoTelemetry corresponds to different sources of telemetry we are recording from cockroach demo.
+type demoTelemetry int
+
+const (
+	_ demoTelemetry = iota
+	// nodes represents when cockroach demo is started with multiple nodes.
+	nodes
+	// demoLocality represents when cockroach demo is started with user defined localities.
+	demoLocality
+	// withLoad represents when cockroach demo is used with a background workload
+	withLoad
+	// geoPartitionedReplicas is used when cockroach demo is started with the geo-partitioned-replicas topology.
+	geoPartitionedReplicas
+)
+
+var demoTelemetryMap = map[demoTelemetry]string{
+	nodes:                  "nodes",
+	demoLocality:           "demo-locality",
+	withLoad:               "withload",
+	geoPartitionedReplicas: "geo-partitioned-replicas",
+}
+
+var demoTelemetryCounters map[demoTelemetry]telemetry.Counter
+
+func init() {
+	demoTelemetryCounters = make(map[demoTelemetry]telemetry.Counter)
+	for ty, s := range demoTelemetryMap {
+		demoTelemetryCounters[ty] = telemetry.GetCounterOnce(fmt.Sprintf("cli.demo.%s", s))
+	}
+}
+
+func incrementDemoCounter(d demoTelemetry) {
+	telemetry.Inc(demoTelemetryCounters[d])
+}

--- a/pkg/server/telemetry/features.go
+++ b/pkg/server/telemetry/features.go
@@ -168,7 +168,7 @@ type ResetCounters bool
 const (
 	// Quantized returns counts quantized to order of magnitude.
 	Quantized QuantizeCounts = true
-	// Raw returns the raw, unquanitzed counter values.
+	// Raw returns the raw, unquantized counter values.
 	Raw QuantizeCounts = false
 	// ResetCounts resets the counter to zero after fetching its value.
 	ResetCounts ResetCounters = true


### PR DESCRIPTION
This PR adds telemetry for some of the new features added to cockroach
demo (nodes, with-load, localities, geo-partitioned-replicas).

It isn't straight forward how to test this, as there seems to be a race
between the background thread that flushes telemetry and actually
querying for the counter's values on startup.

Work towards #228.

Release justification: Low risk monitoring improvement.

Release note: None