### PR TITLE
sql: add telemetry for when distsql/vectorized is used

### DIFF
--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/colflow"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -27,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -335,6 +337,10 @@ func (ds *ServerImpl) setupFlow(
 	if !f.IsLocal() {
 		flowCtx.AddLogTag("f", f.GetFlowCtx().ID.Short())
 		flowCtx.AnnotateCtx(ctx)
+		telemetry.Inc(sqltelemetry.DistSQLExecCounter)
+	}
+	if f.IsVectorized() {
+		telemetry.Inc(sqltelemetry.VecExecCounter)
 	}
 	return ctx, f, nil
 }

--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -77,6 +77,9 @@ type Flow interface {
 	// IsLocal returns whether this flow does not have any remote execution.
 	IsLocal() bool
 
+	// IsVectorized returns whether this flow will run with vectorized execution.
+	IsVectorized() bool
+
 	// GetFlowCtx returns the flow context of this flow.
 	GetFlowCtx() *execinfra.FlowCtx
 
@@ -292,6 +295,11 @@ func (f *FlowBase) startInternal(ctx context.Context, doneFn func()) (context.Co
 // IsLocal returns whether this flow does not have any remote execution.
 func (f *FlowBase) IsLocal() bool {
 	return len(f.inboundStreams) == 0
+}
+
+// IsVectorized returns whether this flow will run with vectorized execution.
+func (f *FlowBase) IsVectorized() bool {
+	return f.isVectorized
 }
 
 // Start is part of the Flow interface.

--- a/pkg/sql/logictest/testdata/logic_test/distsql_join
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_join
@@ -54,3 +54,8 @@ query III
 SELECT pk, a, b FROM tab0 WHERE a < 10 AND b = 2 ORDER BY a DESC, pk;
 ----
 0 1 2
+
+query T
+SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name='sql.exec.query.is-distributed' AND usage_count > 0
+----
+sql.exec.query.is-distributed

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -897,7 +897,6 @@ query I
 SELECT * FROM t_case_null WHERE x = 0 AND NULL
 ----
 
-
 # Regression test for #40732.
 statement ok
 CREATE TABLE t40732 AS SELECT g::INT8 AS _int8,
@@ -935,3 +934,8 @@ ORDER BY col_2976
 4
 4
 4
+
+query T
+SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name='sql.exec.query.is-vectorized' AND usage_count > 0
+----
+sql.exec.query.is-vectorized

--- a/pkg/sql/sqltelemetry/exec.go
+++ b/pkg/sql/sqltelemetry/exec.go
@@ -1,0 +1,21 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sqltelemetry
+
+import "github.com/cockroachdb/cockroach/pkg/server/telemetry"
+
+// DistSQLExecCounter is to be incremented whenever a query is distributed
+// across multiple nodes.
+var DistSQLExecCounter = telemetry.GetCounterOnce("sql.exec.query.is-distributed")
+
+// VecExecCounter is to be incremented whenever a query runs with the vectorized
+// execution engine.
+var VecExecCounter = telemetry.GetCounterOnce("sql.exec.query.is-vectorized")


### PR DESCRIPTION
This adds two new features that are incremented whenever a query is
executed with distsql or vectorized. The feature names are:

- sql.exec.query.is-distributed
- sql.exec.query.is-vectorized

touches #40418 and cockroachlabs/registration#227

Release justification: low impact monitoring improvement

Release note: None