### PR TITLE
bulk: disable two level index in Pebble

### DIFF
--- a/pkg/storage/bulk/sst_writer.go
+++ b/pkg/storage/bulk/sst_writer.go
@@ -13,6 +13,7 @@ package bulk
 import (
 	"bytes"
 	"io"
+	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
@@ -108,7 +109,9 @@ var pebbleOpts = func() *pebble.Options {
 // MakeSSTWriter creates a new SSTWriter.
 func MakeSSTWriter() SSTWriter {
 	f := &memFile{}
-	sst := sstable.NewWriter(f, pebbleOpts, pebble.LevelOptions{BlockSize: 64 * 1024})
+	// Setting the IndexBlockSize to MaxInt disables twoLevelIndexes in Pebble.
+	// TODO(pbardea): Remove the IndexBlockSize option when https://github.com/cockroachdb/pebble/issues/285 is resolved.
+	sst := sstable.NewWriter(f, pebbleOpts, pebble.LevelOptions{BlockSize: 64 * 1024, IndexBlockSize: math.MaxInt32})
 	return SSTWriter{fw: sst, f: f}
 }
 


### PR DESCRIPTION
Setting the IndexBlockSize to MaxInt disables two level indexes. Using
two level indexes cause issues restoring some registration cluster
backups. This change servers as a work-around until
https://github.com/cockroachdb/pebble/issues/285 is resolved.

Fixes #40670.

Release justification: RESTOREs on registration cluster backups started
failing after enabling two level indexes in Pebble. This was a release
blocking bug and this fix allows these backups to be restored again
until more investigation is done in the two level index issue.

Release note: None