### PR TITLE
storage: make queues replica ID aware

### DIFF
--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -221,16 +221,6 @@ func NewTestStorePool(cfg StoreConfig) *StorePool {
 	)
 }
 
-func (r *Replica) ReplicaID() roachpb.ReplicaID {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.ReplicaIDLocked()
-}
-
-func (r *Replica) ReplicaIDLocked() roachpb.ReplicaID {
-	return r.mu.replicaID
-}
-
 func (r *Replica) AssertState(ctx context.Context, reader engine.Reader) {
 	r.raftMu.Lock()
 	defer r.raftMu.Unlock()

--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -59,8 +59,9 @@ type processCallback func(error)
 // A replicaItem holds a replica and metadata about its queue state and
 // processing state.
 type replicaItem struct {
-	value roachpb.RangeID
-	seq   int // enforce FIFO order for equal priorities
+	rangeID   roachpb.RangeID
+	replicaID roachpb.ReplicaID
+	seq       int // enforce FIFO order for equal priorities
 
 	// fields used when a replicaItem is enqueued in a priority queue.
 	priority float64
@@ -77,7 +78,7 @@ func (i *replicaItem) setProcessing() {
 	i.priority = 0
 	if i.index >= 0 {
 		log.Fatalf(context.Background(),
-			"r%d marked as processing but appears in prioQ", i.value,
+			"r%d marked as processing but appears in prioQ", i.rangeID,
 		)
 	}
 	i.processing = true
@@ -180,6 +181,7 @@ func shouldQueueAgain(now, last hlc.Timestamp, minInterval time.Duration) (bool,
 // extraction. Establish a sane interface and use that.
 type replicaInQueue interface {
 	AnnotateCtx(context.Context) context.Context
+	ReplicaID() roachpb.ReplicaID
 	StoreID() roachpb.StoreID
 	GetRangeID() roachpb.RangeID
 	IsInitialized() bool
@@ -487,7 +489,7 @@ func (h baseQueueHelper) MaybeAdd(ctx context.Context, repl replicaInQueue, now 
 }
 
 func (h baseQueueHelper) Add(ctx context.Context, repl replicaInQueue, prio float64) {
-	_, err := h.bq.addInternal(ctx, repl.Desc(), prio)
+	_, err := h.bq.addInternal(ctx, repl.Desc(), repl.ReplicaID(), prio)
 	if err != nil && log.V(1) {
 		log.Infof(ctx, "during Add: %s", err)
 	}
@@ -595,7 +597,7 @@ func (bq *baseQueue) maybeAdd(ctx context.Context, repl replicaInQueue, now hlc.
 	if !should {
 		return
 	}
-	if _, err := bq.addInternal(ctx, repl.Desc(), priority); !isExpectedQueueError(err) {
+	if _, err := bq.addInternal(ctx, repl.Desc(), repl.ReplicaID(), priority); !isExpectedQueueError(err) {
 		log.Errorf(ctx, "unable to add: %+v", err)
 	}
 }
@@ -612,7 +614,7 @@ func (bq *baseQueue) requiresSplit(cfg *config.SystemConfig, repl replicaInQueue
 // the replica is already queued at a lower priority, updates the existing
 // priority. Expects the queue lock to be held by caller.
 func (bq *baseQueue) addInternal(
-	ctx context.Context, desc *roachpb.RangeDescriptor, priority float64,
+	ctx context.Context, desc *roachpb.RangeDescriptor, replicaID roachpb.ReplicaID, priority float64,
 ) (bool, error) {
 	// NB: this is intentionally outside of bq.mu to avoid having to consider
 	// lock ordering constraints.
@@ -665,7 +667,7 @@ func (bq *baseQueue) addInternal(
 	if log.V(3) {
 		log.Infof(ctx, "adding: priority=%0.3f", priority)
 	}
-	item = &replicaItem{value: desc.RangeID, priority: priority}
+	item = &replicaItem{rangeID: desc.RangeID, replicaID: replicaID, priority: priority}
 	bq.addLocked(item)
 
 	// If adding this replica has pushed the queue past its maximum size,
@@ -720,7 +722,7 @@ func (bq *baseQueue) MaybeRemove(rangeID roachpb.RangeID) {
 	if item, ok := bq.mu.replicas[rangeID]; ok {
 		ctx := bq.AnnotateCtx(context.TODO())
 		if log.V(3) {
-			log.Infof(ctx, "%s: removing", item.value)
+			log.Infof(ctx, "%s: removing", item.rangeID)
 		}
 		bq.removeLocked(item)
 	}
@@ -856,6 +858,9 @@ func (bq *baseQueue) processReplica(ctx context.Context, repl replicaInQueue) er
 			if !repl.IsInitialized() {
 				// We checked this when adding the replica, but we need to check it again
 				// in case this is a different replica with the same range ID (see #14193).
+				// This is possible in the case where the replica was enqueued while not
+				// having a replica ID, perhaps due to a pre-emptive snapshot, and has
+				// since been removed and re-added at a different replica ID.
 				return errors.New("cannot process uninitialized replica")
 			}
 
@@ -940,10 +945,10 @@ func (bq *baseQueue) assertInvariants() {
 		if item.processing {
 			log.Fatalf(ctx, "processing item found in prioQ: %v", item)
 		}
-		if _, inReplicas := bq.mu.replicas[item.value]; !inReplicas {
+		if _, inReplicas := bq.mu.replicas[item.rangeID]; !inReplicas {
 			log.Fatalf(ctx, "item found in prioQ but not in mu.replicas: %v", item)
 		}
-		if _, inPurg := bq.mu.purgatory[item.value]; inPurg {
+		if _, inPurg := bq.mu.purgatory[item.rangeID]; inPurg {
 			log.Fatalf(ctx, "item found in prioQ and purgatory: %v", item)
 		}
 	}
@@ -1061,7 +1066,7 @@ func (bq *baseQueue) addToPurgatoryLocked(
 		return
 	}
 
-	item := &replicaItem{value: repl.GetRangeID(), index: -1}
+	item := &replicaItem{rangeID: repl.GetRangeID(), replicaID: repl.ReplicaID(), index: -1}
 	bq.mu.replicas[repl.GetRangeID()] = item
 
 	defer func() {
@@ -1092,21 +1097,21 @@ func (bq *baseQueue) addToPurgatoryLocked(
 
 					// Remove all items from purgatory into a copied slice.
 					bq.mu.Lock()
-					ranges := make([]roachpb.RangeID, 0, len(bq.mu.purgatory))
+					ranges := make([]*replicaItem, 0, len(bq.mu.purgatory))
 					for rangeID := range bq.mu.purgatory {
 						item := bq.mu.replicas[rangeID]
 						if item == nil {
 							log.Fatalf(ctx, "r%d is in purgatory but not in replicas", rangeID)
 						}
 						item.setProcessing()
-						ranges = append(ranges, item.value)
+						ranges = append(ranges, item)
 						bq.removeFromPurgatoryLocked(item)
 					}
 					bq.mu.Unlock()
 
-					for _, id := range ranges {
-						repl, err := bq.getReplica(id)
-						if err != nil {
+					for _, item := range ranges {
+						repl, err := bq.getReplica(item.rangeID)
+						if err != nil || item.replicaID != repl.ReplicaID() {
 							continue
 						}
 						annotatedCtx := repl.AnnotateCtx(ctx)
@@ -1167,14 +1172,14 @@ func (bq *baseQueue) pop() replicaInQueue {
 		bq.pending.Update(int64(bq.mu.priorityQ.Len()))
 		bq.mu.Unlock()
 
-		repl, _ := bq.getReplica(item.value)
-		if repl != nil {
+		repl, _ := bq.getReplica(item.rangeID)
+		if repl != nil && item.replicaID == repl.ReplicaID() {
 			return repl
 		}
-
-		// Replica not found, remove from set and try again.
+		// Replica not found or was recreated with a new replica ID, remove from
+		// set and try again.
 		bq.mu.Lock()
-		bq.removeFromReplicaSetLocked(item.value)
+		bq.removeFromReplicaSetLocked(item.rangeID)
 	}
 }
 
@@ -1182,7 +1187,7 @@ func (bq *baseQueue) pop() replicaInQueue {
 func (bq *baseQueue) addLocked(item *replicaItem) {
 	heap.Push(&bq.mu.priorityQ, item)
 	bq.pending.Update(int64(bq.mu.priorityQ.Len()))
-	bq.mu.replicas[item.value] = item
+	bq.mu.replicas[item.rangeID] = item
 }
 
 // removeLocked removes an element from purgatory (if it's experienced an
@@ -1194,23 +1199,23 @@ func (bq *baseQueue) removeLocked(item *replicaItem) {
 		// it doesn't get requeued.
 		item.requeue = false
 	} else {
-		if _, inPurg := bq.mu.purgatory[item.value]; inPurg {
+		if _, inPurg := bq.mu.purgatory[item.rangeID]; inPurg {
 			bq.removeFromPurgatoryLocked(item)
 		} else if item.index >= 0 {
 			bq.removeFromQueueLocked(item)
 		} else {
 			log.Fatalf(bq.AnnotateCtx(context.Background()),
 				"item for r%d is only in replicas map, but is not processing",
-				item.value,
+				item.rangeID,
 			)
 		}
-		bq.removeFromReplicaSetLocked(item.value)
+		bq.removeFromReplicaSetLocked(item.rangeID)
 	}
 }
 
 // Caller must hold mutex.
 func (bq *baseQueue) removeFromPurgatoryLocked(item *replicaItem) {
-	delete(bq.mu.purgatory, item.value)
+	delete(bq.mu.purgatory, item.rangeID)
 	bq.purgatory.Update(int64(len(bq.mu.purgatory)))
 }
 

--- a/pkg/storage/queue_helpers_testutil.go
+++ b/pkg/storage/queue_helpers_testutil.go
@@ -23,7 +23,7 @@ import (
 func (bq *baseQueue) testingAdd(
 	ctx context.Context, repl replicaInQueue, priority float64,
 ) (bool, error) {
-	return bq.addInternal(ctx, repl.Desc(), priority)
+	return bq.addInternal(ctx, repl.Desc(), repl.ReplicaID(), priority)
 }
 
 func forceScanAndProcess(s *Store, q *baseQueue) error {

--- a/pkg/storage/queue_test.go
+++ b/pkg/storage/queue_test.go
@@ -13,6 +13,7 @@ package storage
 import (
 	"container/heap"
 	"context"
+	"fmt"
 	"strconv"
 	"sync/atomic"
 	"testing"
@@ -33,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 )
 
 // testQueueImpl implements queueImpl with a closure for shouldQueue.
@@ -128,28 +130,28 @@ func TestQueuePriorityQueue(t *testing.T) {
 	pq.sl = make([]*replicaItem, count)
 	for i := 0; i < count; {
 		pq.sl[i] = &replicaItem{
-			value:    roachpb.RangeID(i),
+			rangeID:  roachpb.RangeID(i),
 			priority: float64(i),
 			index:    i,
 		}
-		expRanges[3-i] = pq.sl[i].value
+		expRanges[3-i] = pq.sl[i].rangeID
 		i++
 	}
 	heap.Init(&pq)
 
 	// Insert a new item and then modify its priority.
 	priorityItem := &replicaItem{
-		value:    -1,
+		rangeID:  -1,
 		priority: 1.0,
 	}
 	heap.Push(&pq, priorityItem)
 	pq.update(priorityItem, 4.0)
-	expRanges[0] = priorityItem.value
+	expRanges[0] = priorityItem.rangeID
 
 	// Take the items out; they should arrive in decreasing priority order.
 	for i := 0; pq.Len() > 0; i++ {
 		item := heap.Pop(&pq).(*replicaItem)
-		if item.value != expRanges[i] {
+		if item.rangeID != expRanges[i] {
 			t.Errorf("%d: unexpected range with priority %f", i, item.priority)
 		}
 	}
@@ -1097,6 +1099,51 @@ func TestBaseQueueProcessConcurrently(t *testing.T) {
 
 	pQueue.processBlocker <- struct{}{}
 	assertProcessedAndProcessing(3, 0)
+}
+
+// TestBaseQueueReplicaChange ensures that if a replica is added to the queue
+// with a non-zero replica ID then it is only processed if the retrieved replica
+// from the getReplica() function has the same replica ID.
+func TestBaseQueueChangeReplicaID(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	// The testContext exists only to construct the baseQueue.
+	tc := testContext{}
+	stopper := stop.NewStopper()
+	ctx := context.Background()
+	defer stopper.Stop(ctx)
+	tc.Start(t, stopper)
+	testQueue := &testQueueImpl{
+		shouldQueueFn: func(now hlc.Timestamp, r *Replica) (shouldQueue bool, priority float64) {
+			return true, 1.0
+		},
+	}
+	bq := makeTestBaseQueue("test", testQueue, tc.store, tc.gossip, queueConfig{
+		maxSize:              defaultQueueMaxSize,
+		acceptsUnsplitRanges: true,
+	})
+	r := &fakeReplica{rangeID: 1, replicaID: 1}
+	bq.mu.Lock()
+	bq.getReplica = func(rangeID roachpb.RangeID) (replicaInQueue, error) {
+		if rangeID != 1 {
+			panic(fmt.Errorf("expected range id 1, got %d", rangeID))
+		}
+		return r, nil
+	}
+	bq.mu.Unlock()
+	require.Equal(t, 0, testQueue.getProcessed())
+	bq.maybeAdd(ctx, r, tc.store.Clock().Now())
+	bq.DrainQueue(tc.store.Stopper())
+	require.Equal(t, 1, testQueue.getProcessed())
+	bq.maybeAdd(ctx, r, tc.store.Clock().Now())
+	r.replicaID = 2
+	bq.DrainQueue(tc.store.Stopper())
+	require.Equal(t, 1, testQueue.getProcessed())
+	require.Equal(t, 0, bq.Length())
+	require.Equal(t, 0, bq.PurgatoryLength())
+	bq.mu.Lock()
+	defer bq.mu.Unlock()
+	_, exists := bq.mu.replicas[1]
+	require.False(t, exists, bq.mu.replicas)
 }
 
 func TestBaseQueueRequeue(t *testing.T) {

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -610,6 +610,13 @@ func (r *Replica) String() string {
 	return fmt.Sprintf("[n%d,s%d,r%s]", r.store.Ident.NodeID, r.store.Ident.StoreID, &r.rangeStr)
 }
 
+// ReplicaID returns the ID for the Replica.
+func (r *Replica) ReplicaID() roachpb.ReplicaID {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.mu.replicaID
+}
+
 // cleanupFailedProposal cleans up after a proposal that has failed. It
 // clears any references to the proposal and releases associated quota.
 // It requires that both Replica.mu and Replica.raftMu are exclusively held.


### PR DESCRIPTION
This is the first PR in the series to fix the fallout from learner replicas
due to replicas being added and removed without synchronously receiving
snapshots. Prior to the upcoming changes a replica object may change its ID.

Release Justification: Part of fixing a major release blocker.

Release note: None