### PR TITLE
sql/execinfra: don't adapt row.Fetcher to RowSource

### DIFF
--- a/pkg/sql/execinfra/joinreader.go
+++ b/pkg/sql/execinfra/joinreader.go
@@ -218,7 +218,7 @@ func NewJoinReader(
 		jr.fetcher = NewRowFetcherStatCollector(&fetcher)
 		jr.FinishTrace = jr.outputStatsToTrace
 	} else {
-		jr.fetcher = &RowFetcherWrapper{Fetcher: &fetcher}
+		jr.fetcher = &fetcher
 	}
 
 	jr.indexKeyPrefix = sqlbase.MakeIndexKeyPrefix(&jr.desc, jr.index.ID)
@@ -495,9 +495,9 @@ func (jr *JoinReader) performLookup() (joinReaderState, *execinfrapb.ProducerMet
 		}
 
 		// Fetch the next row and copy it into the row container.
-		lookedUpRow, meta := jr.fetcher.Next()
-		if meta != nil {
-			jr.MoveToDraining(scrub.UnwrapScrubError(meta.Err))
+		lookedUpRow, _, _, err := jr.fetcher.NextRow(jr.Ctx)
+		if err != nil {
+			jr.MoveToDraining(scrub.UnwrapScrubError(err))
 			return jrStateUnknown, jr.DrainHelper()
 		}
 		if lookedUpRow == nil {
@@ -636,7 +636,6 @@ func (jr *JoinReader) hasNullLookupColumn(row sqlbase.EncDatumRow) bool {
 func (jr *JoinReader) Start(ctx context.Context) context.Context {
 	jr.input.Start(ctx)
 	ctx = jr.StartInternal(ctx, joinReaderProcName)
-	jr.fetcher.Start(ctx)
 	jr.runningState = jrReadingInput
 	return ctx
 }

--- a/pkg/sql/execinfra/rowfetcher.go
+++ b/pkg/sql/execinfra/rowfetcher.go
@@ -26,7 +26,6 @@ import (
 // RowFetcher is an interface used to abstract a row fetcher so that a stat
 // collector wrapper can be plugged in.
 type RowFetcher interface {
-	RowSource
 	StartScan(
 		_ context.Context, _ *client.Txn, _ roachpb.Spans, limitBatches bool, limitHint int64, traceKV bool,
 	) error
@@ -40,6 +39,9 @@ type RowFetcher interface {
 		limitHint int64,
 		traceKV bool,
 	) error
+
+	NextRow(ctx context.Context) (
+		sqlbase.EncDatumRow, *sqlbase.TableDescriptor, *sqlbase.IndexDescriptor, error)
 
 	// PartialKey is not stat-related but needs to be supported.
 	PartialKey(int) (roachpb.Key, error)

--- a/pkg/sql/rowexec/scrub_tablereader.go
+++ b/pkg/sql/rowexec/scrub_tablereader.go
@@ -131,7 +131,7 @@ func newScrubTableReader(
 	); err != nil {
 		return nil, err
 	}
-	tr.fetcher = &execinfra.RowFetcherWrapper{Fetcher: &fetcher}
+	tr.fetcher = &fetcher
 
 	tr.spans = make(roachpb.Spans, len(spec.Spans))
 	for i, s := range spec.Spans {

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -152,29 +152,22 @@ func (tr *tableReader) Start(ctx context.Context) context.Context {
 		log.Fatalf(ctx, "tableReader outside of txn")
 	}
 
-	// Like every processor, the tableReader will have a context with a log tag
-	// and a span. The underlying fetcher inherits the proc's span, but not the
-	// log tag.
-	fetcherCtx := ctx
 	ctx = tr.StartInternal(ctx, tableReaderProcName)
-	if procSpan := opentracing.SpanFromContext(ctx); procSpan != nil {
-		fetcherCtx = opentracing.ContextWithSpan(fetcherCtx, procSpan)
-	}
 
 	// This call doesn't do much; the real "starting" is below.
-	tr.fetcher.Start(fetcherCtx)
+	tr.fetcher.Start(ctx)
 	limitBatches := execinfra.ScanShouldLimitBatches(tr.maxResults, tr.limitHint, tr.FlowCtx)
 	log.VEventf(ctx, 1, "starting scan with limitBatches %t", limitBatches)
 	var err error
 	if tr.maxTimestampAge == 0 {
 		err = tr.fetcher.StartScan(
-			fetcherCtx, tr.FlowCtx.Txn, tr.spans,
+			ctx, tr.FlowCtx.Txn, tr.spans,
 			limitBatches, tr.limitHint, tr.FlowCtx.TraceKV,
 		)
 	} else {
 		initialTS := tr.FlowCtx.Txn.GetTxnCoordMeta(ctx).Txn.OrigTimestamp
 		err = tr.fetcher.StartInconsistentScan(
-			fetcherCtx, tr.FlowCtx.Cfg.DB, initialTS,
+			ctx, tr.FlowCtx.Cfg.DB, initialTS,
 			tr.maxTimestampAge, tr.spans,
 			limitBatches, tr.limitHint, tr.FlowCtx.TraceKV,
 		)


### PR DESCRIPTION
Before this patch, a row.Fetcher could be consumed as a RowSource
through RowFetcherWrapper. This was unnecessary and confusing; the
Fetcher did not quite match that interface. It has its own Start()
methods different from the RowSource's Start (and so now both had to be
called) making clients awkward. Clients were also failing to treat the
fetcher as a RowSource in other ways to: some of them were not draining
it properly. Which is cool, given that there's nothing to drain from a
fetcher. But it was confusing and also the error returned from the
Fetcher were handled awkwardly - wrapped in a meta.
Seemingly the reason why the RowFetcherWrapper was introduced was so
that we can have a common way to collect stats on top of either a
Fetcher or a RowSource (enter RowFetcherStatCollector).
RowFetcherStatsCollector was a very confusing beast since it aliased its
input, referencing it in two ways and only Start()ing one of the
aliases.
Instead I've separated a "RowSource+stats" wrapper from a separate
"Fetcher+stats" wrapper, resulting in a better life.

This change is good on its own, but I've made it particuarly since I'm
trying to change the RowSource interface to take a Txn at Start() time,
which would have made it truly confusing for the fetchers that would
have ended up with multiple Start methods looking now pretty similar.

Release note: None
