### PR TITLE
sql: column family span generation bugfix

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -1549,3 +1549,16 @@ render     ·            ·
  └── scan  ·            ·
 ·          table        t4@primary
 ·          spans        /10-/11
+
+# Regression test for #40890: a point lookup on a single column family of a
+# table should still work properly in the face of a constraint disjunction.
+query TTT
+EXPLAIN SELECT a FROM t4 WHERE a in (1, 5) and b in (1, 5)
+----
+·          distributed  false
+·          vectorized   true
+render     ·            ·
+ └── scan  ·            ·
+·          table        t4@primary
+·          spans        /1/1/0-/1/1/1 /1/5/0-/1/5/1 /5/1/0-/5/1/1 /5/5/0-/5/5/1
+·          parallel     ·

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -167,7 +167,7 @@ func appendSpansFromConstraintSpan(
 		s.Key.Equal(s.EndKey) {
 		neededFamilyIDs := sqlbase.NeededColumnFamilyIDs(tableDesc.ColumnIdxMap(), tableDesc.Families, needed)
 		if len(neededFamilyIDs) < len(tableDesc.Families) {
-			return sqlbase.SplitSpanIntoSeparateFamilies(s, neededFamilyIDs), nil
+			return append(spans, sqlbase.SplitSpanIntoSeparateFamilies(s, neededFamilyIDs)...), nil
 		}
 	}
 


### PR DESCRIPTION
PR #38301 inadvertently introduced a bug that unfortunately wasn't
caught by any tests - in the process of improving the tight span
generation for tables with column families, it accidentally started
throwing away all but the spans for the final constraint passed in from
the optimizer.

This small omission has serious consequences: queries that have a
disjunction of spans to examine (like
`SELECT * FROM t WHERE key IN (values...)`) will return incorrect
results if the table being queried has multiple column families (in
certain cases) - it'll look like rows are missing. This will be
problematic for mutations as well.

Note that this bug was never present in a non-alpha release.

Fixes #40890.

Release note (bug fix): restore correct result generation for queries
with index disjunctions on tables with multiple column families.
Release justification: critical bugfix, low risk