### PR TITLE
sql: bug fixes in column/sequence dependency relationship

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -126,7 +126,9 @@ func (n *alterTableNode) startExec(params runParams) error {
 			// If the new column has a DEFAULT expression that uses a sequence, add references between
 			// its descriptor and this column descriptor.
 			if d.HasDefaultExpr() {
-				changedSeqDescs, err := maybeAddSequenceDependencies(params.ctx, params.p, n.tableDesc, col, expr)
+				changedSeqDescs, err := maybeAddSequenceDependencies(
+					params.ctx, params.p, n.tableDesc, col, expr, nil,
+				)
 				if err != nil {
 					return err
 				}
@@ -824,7 +826,9 @@ func applyColumnMutation(
 			col.DefaultExpr = &s
 
 			// Add references to the sequence descriptors this column is now using.
-			changedSeqDescs, err := maybeAddSequenceDependencies(params.ctx, params.p, tableDesc, col, expr)
+			changedSeqDescs, err := maybeAddSequenceDependencies(
+				params.ctx, params.p, tableDesc, col, expr, nil,
+			)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1033,7 +1033,12 @@ func MakeTableDesc(
 	evalCtx *tree.EvalContext,
 	temporary bool,
 ) (sqlbase.MutableTableDescriptor, error) {
+	// Used to delay establishing Column/Sequence dependency until ColumnIDs have
+	// been populated.
+	columnSequenceExprMap := make(map[int]tree.TypedExpr)
+
 	desc := InitTableDescriptor(id, parentID, n.Table.Table(), creationTime, privileges, temporary)
+
 	for _, def := range n.Defs {
 		if d, ok := def.(*tree.ColumnTableDef); ok {
 			if !desc.IsVirtualTable() {
@@ -1050,22 +1055,18 @@ func MakeTableDesc(
 				return desc, err
 			}
 
+			desc.AddColumn(col)
 			if d.HasDefaultExpr() {
-				changedSeqDescs, err := maybeAddSequenceDependencies(ctx, vt, &desc, col, expr)
-				if err != nil {
-					return desc, err
-				}
-				for _, changedSeqDesc := range changedSeqDescs {
-					affected[changedSeqDesc.ID] = changedSeqDesc
-				}
+				// This resolution must be delayed until ColumnIDs have been populated.
+				columnSequenceExprMap[len(desc.Columns)-1] = expr
 			}
 
-			desc.AddColumn(col)
 			if idx != nil {
 				if err := desc.AddIndex(*idx, d.PrimaryKey); err != nil {
 					return desc, err
 				}
 			}
+
 			if d.HasColumnFamily() {
 				// Pass true for `create` and `ifNotExists` because when we're creating
 				// a table, we always want to create the specified family if it doesn't
@@ -1207,6 +1208,20 @@ func MakeTableDesc(
 			return desc, err
 		}
 		desc.PrimaryIndex.Partitioning = partitioning
+	}
+
+	// Once all the IDs have been allocated, we can add the Sequence dependencies
+	// as maybeAddSequenceDependencies requires ColumnIDs to be correct.
+	for i := range desc.Columns {
+		if expr, ok := columnSequenceExprMap[i]; ok {
+			changedSeqDescs, err := maybeAddSequenceDependencies(ctx, vt, &desc, &desc.Columns[i], expr, affected)
+			if err != nil {
+				return desc, err
+			}
+			for _, changedSeqDesc := range changedSeqDescs {
+				affected[changedSeqDesc.ID] = changedSeqDesc
+			}
+		}
 	}
 
 	// With all structural elements in place and IDs allocated, we can resolve the

--- a/pkg/sql/logictest/testdata/logic_test/dependencies
+++ b/pkg/sql/logictest/testdata/logic_test/dependencies
@@ -136,4 +136,4 @@ query ITIITITT colnames
 SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name LIKE 'blog_posts%'
 ----
 descriptor_id  descriptor_name    index_id  dependedonby_id  dependedonby_type  dependedonby_index_id  dependedonby_name  dependedonby_details
-63             blog_posts_id_seq  NULL      64               sequence           0                      NULL               Columns: [0]
+63             blog_posts_id_seq  NULL      64               sequence           0                      NULL               Columns: [1]

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -901,3 +901,33 @@ select * from generate_series(1,10000000) where generate_series = 0;
 # Clean up
 statement ok
 SET statement_timeout = 0
+
+# Test that multiple columns associated with the same sequence follow correct
+# dependency behavior. Regression test for #40852
+
+statement ok
+SET sql_safe_updates = false
+
+statement ok
+CREATE SEQUENCE seq;
+
+statement ok
+CREATE TABLE abc(a INT DEFAULT nextval('seq'), b INT default nextval('seq'), c int)
+
+statement error pq: cannot drop sequence seq because other objects depend on it
+DROP SEQUENCE seq;
+
+statement ok
+ALTER TABLE abc DROP COLUMN b;
+
+statement error pq: cannot drop sequence seq because other objects depend on it
+DROP SEQUENCE seq;
+
+statement ok
+ALTER TABLE abc DROP COLUMN a;
+
+statement ok
+DROP SEQUENCE seq;
+
+statement ok
+SET sql_safe_updates = true


### PR DESCRIPTION
Currently, if a sequence is used by two columns of the same table, the
dependency relation with the first column can be lost. This PR fixes
that. It also ensures that the dependency relation is established only
after ColumnIDs have been allocated.

Fixes #40852

Release note (bug fix): Tables containing two columns that reference
the same sequence behave correctly.

Release justification: Not part of release/pass linter.