### PR TITLE
start-single-node: hide more flags from --help

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -375,11 +375,19 @@ func init() {
 		VarFlag(f, &serverCfg.JoinList, cliflags.Join)
 		VarFlag(f, clusterNameSetter{&baseCfg.ClusterName}, cliflags.ClusterName)
 		BoolFlag(f, &baseCfg.DisableClusterNameVerification, cliflags.DisableClusterNameVerification, false)
-		// We also hide it from help for 'start-single-node'.
 		if cmd == startSingleNodeCmd {
+			// Even though all server flags are supported for
+			// 'start-single-node', we intend that command to be used by
+			// beginners / developers running on a single machine. To
+			// enhance the UX, we hide the flags since they are not directly
+			// relevant when running a single node.
 			_ = f.MarkHidden(cliflags.Join.Name)
 			_ = f.MarkHidden(cliflags.ClusterName.Name)
 			_ = f.MarkHidden(cliflags.DisableClusterNameVerification.Name)
+			_ = f.MarkHidden(cliflags.MaxOffset.Name)
+			_ = f.MarkHidden(cliflags.LocalityAdvertiseAddr.Name)
+			_ = f.MarkHidden(cliflags.AdvertiseAddr.Name)
+			_ = f.MarkHidden(cliflags.SQLAdvertiseAddr.Name)
 		}
 
 		// Engine flags.


### PR DESCRIPTION
Release justification: no impact on functionality, needed for product polish

The new command `cockroach start-single-node`, as its name implies, is
intended for use by beginners / developers running single-node
clusters. It is thus important not to overwhelm them with details that
are not directly relevant when they explore the program with
e.g. `--help`.

To enhance their experience, this patch hides a few more parameters
from `start-single-node --help`:

`--max-offset`
`--locality-advertise-addr`
`--advertise-addr`
`--advertise-sql-addr`

Release note: None