### PR TITLE
sql: test fix to TestShowSessionPrivileges

### DIFF
--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -803,6 +803,9 @@ func TestShowSessionPrivileges(t *testing.T) {
 			}
 			counts[userName]++
 		}
+		if err := rows.Err(); err != nil {
+			t.Fatal(err)
+		}
 		if counts[security.RootUser] == 0 {
 			t.Fatalf("root session is unable to see its own session: %+v", counts)
 		}
@@ -823,6 +826,9 @@ func TestShowSessionPrivileges(t *testing.T) {
 				t.Fatal(err)
 			}
 			counts[userName]++
+		}
+		if err := rows.Err(); err != nil {
+			t.Fatal(err)
 		}
 		if counts["nonroot"] == 0 {
 			t.Fatal("non-root session is unable to see its own session")


### PR DESCRIPTION
This test was failing to check for errors during row iteration. It's
currently flaky in CI, but it's hard to tell what happened because of
this omission.

Release note: None
Release justification: test-only change