### PR TITLE
sql: Add telemetry for interleaved table join

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/interleaved_join
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved_join
@@ -584,3 +584,8 @@ query TTTTTTTT
 SELECT * FROM small_child_fam JOIN large_parent_fam USING (a)
 ----
 first  second  third_child  second  third  fourth  fifth  sixth
+
+query T
+SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name='sql.plan.interleaved-table-join' AND usage_count > 0
+----
+sql.plan.interleaved-table-join

--- a/pkg/sql/rowexec/interleaved_reader_joiner.go
+++ b/pkg/sql/rowexec/interleaved_reader_joiner.go
@@ -14,11 +14,13 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/scrub"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
@@ -280,6 +282,9 @@ func newInterleavedReaderJoiner(
 	if flowCtx.NodeID == 0 {
 		return nil, errors.AssertionFailedf("attempting to create an interleavedReaderJoiner with uninitialized NodeID")
 	}
+
+	// Increment some telemetry counters about use of the interleaved table join feature.
+	telemetry.Inc(sqltelemetry.InterleavedTableJoinCounter)
 
 	// TODO(richardwu): We can relax this to < 2 (i.e. permit 2+ tables).
 	// This will require modifying JoinerBase init logic.

--- a/pkg/sql/sqltelemetry/planning.go
+++ b/pkg/sql/sqltelemetry/planning.go
@@ -44,6 +44,9 @@ var LookupJoinHintUseCounter = telemetry.GetCounterOnce("sql.plan.hints.lookup-j
 // hint.
 var IndexHintUseCounter = telemetry.GetCounterOnce("sql.plan.hints.index")
 
+// InterleavedTableJoinCounter is to be incremented whenever an InterleavedTableJoin is planned.
+var InterleavedTableJoinCounter = telemetry.GetCounterOnce("sql.plan.interleaved-table-join")
+
 // ExplainPlanUseCounter is to be incremented whenever vanilla EXPLAIN is run.
 var ExplainPlanUseCounter = telemetry.GetCounterOnce("sql.plan.explain")
 


### PR DESCRIPTION
Adds some telemetry for how often the interleaved table join operation
gets planned, under the key "sql.plan.interleaved-table-join".

Fixes #39360.

Release justification: Low risk monitoring improvement.

Release note: None