### PR TITLE
roachtest: limit number of workers for schemachange tests

### DIFF
--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -299,7 +299,9 @@ func makeIndexAddTpccTest(spec clusterSpec, warehouses int, length time.Duration
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses: warehouses,
-				Extra:      "--wait=false --tolerate-errors",
+				// We limit the number of workers because the default results in a lot
+				// of connections which can lead to OOM issues (see #40566).
+				Extra: fmt.Sprintf("--wait=false --tolerate-errors --workers=%d", warehouses),
 				During: func(ctx context.Context) error {
 					return runAndLogStmts(ctx, t, c, "addindex", []string{
 						`CREATE UNIQUE INDEX ON tpcc.order (o_entry_d, o_w_id, o_d_id, o_carrier_id, o_id);`,
@@ -409,7 +411,9 @@ func makeMixedSchemaChanges(spec clusterSpec, warehouses int, length time.Durati
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses: warehouses,
-				Extra:      "--wait=false --tolerate-errors",
+				// We limit the number of workers because the default results in a lot
+				// of connections which can lead to OOM issues (see #40566).
+				Extra: fmt.Sprintf("--wait=false --tolerate-errors --workers=%d", warehouses),
 				During: func(ctx context.Context) error {
 					if t.IsBuildVersion(`v19.2.0`) {
 						if err := runAndLogStmts(ctx, t, c, "mixed-schema-changes-19.2", []string{


### PR DESCRIPTION
With `--wait=false`, tpcc defaults to `10*W` workers and connections.
The opt catalog objects are per-connection, so this ends up using a
lot of memory. The schema change part makes it worse because we keep
multiple versions of the changed tables.

Reduce the number of connections in the tests, at least until we
implement sharing of opt catalog objects between connections.

Fixes #40566.

Release justification: non-production code change.

Release note: None