### PR TITLE
colexec: refactor and fix the template for projection operators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -804,9 +804,11 @@ EXECGEN_TARGETS = \
   pkg/sql/colexec/mergejoiner_rightouter.eg.go \
   pkg/sql/colexec/min_max_agg.eg.go \
   pkg/sql/colexec/overloads_test_utils.eg.go \
+  pkg/sql/colexec/proj_const_left_ops.eg.go \
+  pkg/sql/colexec/proj_const_right_ops.eg.go \
+  pkg/sql/colexec/proj_non_const_ops.eg.go \
   pkg/sql/colexec/rank.eg.go \
   pkg/sql/colexec/row_number.eg.go \
-  pkg/sql/colexec/projection_ops.eg.go \
   pkg/sql/colexec/quicksort.eg.go \
   pkg/sql/colexec/rowstovec.eg.go \
   pkg/sql/colexec/selection_ops.eg.go \
@@ -1484,6 +1486,9 @@ pkg/sql/colexec/mergejoiner_leftouter.eg.go: pkg/sql/colexec/mergejoiner_tmpl.go
 pkg/sql/colexec/mergejoiner_leftsemi.eg.go: pkg/sql/colexec/mergejoiner_tmpl.go
 pkg/sql/colexec/mergejoiner_rightouter.eg.go: pkg/sql/colexec/mergejoiner_tmpl.go
 pkg/sql/colexec/min_max_agg.eg.go: pkg/sql/colexec/min_max_agg_tmpl.go
+pkg/sql/colexec/proj_const_left_ops.eg.go: pkg/sql/colexec/proj_const_ops_tmpl.go
+pkg/sql/colexec/proj_const_right_ops.eg.go: pkg/sql/colexec/proj_const_ops_tmpl.go
+pkg/sql/colexec/proj_non_const_ops.eg.go: pkg/sql/colexec/proj_non_const_ops_tmpl.go
 pkg/sql/colexec/quicksort.eg.go: pkg/sql/colexec/quicksort_tmpl.go
 pkg/sql/colexec/rank.eg.go: pkg/sql/colexec/rank_tmpl.go
 pkg/sql/colexec/row_number.eg.go: pkg/sql/colexec/row_number_tmpl.go

--- a/pkg/sql/colexec/.gitignore
+++ b/pkg/sql/colexec/.gitignore
@@ -16,7 +16,9 @@ mergejoiner_leftsemi.eg.go
 mergejoiner_rightouter.eg.go
 min_max_agg.eg.go
 overloads_test_utils.eg.go
-projection_ops.eg.go
+proj_const_left_ops.eg.go
+proj_const_right_ops.eg.go
+proj_non_const_ops.eg.go
 quicksort.eg.go
 rank.eg.go
 row_number.eg.go

--- a/pkg/sql/colexec/execgen/cmd/execgen/like_ops_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/like_ops_gen.go
@@ -51,7 +51,7 @@ func genLikeOps(wr io.Writer) error {
 	if err != nil {
 		return err
 	}
-	tmpl, err = tmpl.Parse(projTemplate)
+	tmpl, err = tmpl.Funcs(template.FuncMap{"buildDict": buildDict}).Parse(projTemplate)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/colexec/execgen/cmd/execgen/like_ops_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/like_ops_gen.go
@@ -36,7 +36,7 @@ import (
 
 {{range .}}
 {{template "selConstOp" .}}
-{{template "projRConstOp" .}}
+{{template "projConstOp" .}}
 {{end}}
 `
 
@@ -44,6 +44,10 @@ func genLikeOps(wr io.Writer) error {
 	tmpl := template.New("like_sel_ops").Funcs(template.FuncMap{"buildDict": buildDict})
 	var err error
 	tmpl, err = tmpl.Parse(selTemplate)
+	if err != nil {
+		return err
+	}
+	projTemplate, err := getProjConstOpTmplString(false /* isConstLeft */)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/colexec/execgen/cmd/execgen/projection_ops_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/projection_ops_gen.go
@@ -12,350 +12,95 @@ package main
 
 import (
 	"io"
+	"io/ioutil"
+	"regexp"
+	"strings"
 	"text/template"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 )
 
-const projTemplate = `
-package colexec
-
-import (
-	"bytes"
-  "context"
-  "math"
-
-	"github.com/cockroachdb/apd"
-	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/typeconv"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/pkg/errors"
-)
-
-{{define "opRConstName"}}proj{{.Name}}{{.LTyp}}{{.RTyp}}ConstOp{{end}}
-{{define "opLConstName"}}proj{{.Name}}{{.LTyp}}Const{{.RTyp}}Op{{end}}
-{{define "opName"}}proj{{.Name}}{{.LTyp}}{{.RTyp}}Op{{end}}
-
-{{define "projRConstOp"}}
-type {{template "opRConstName" .}} struct {
-  projConstOpBase
-	constArg {{.RGoType}}
-}
-
-func (p {{template "opRConstName" .}}) EstimateStaticMemoryUsage() int {
-	return EstimateBatchSizeBytes([]coltypes.T{coltypes.{{.RetTyp}}}, int(coldata.BatchSize()))
-}
-
-func (p {{template "opRConstName" .}}) Next(ctx context.Context) coldata.Batch {
-	batch := p.input.Next(ctx)
-	n := batch.Length()
-	if p.outputIdx == batch.Width() {
-		batch.AppendCol(coltypes.{{.RetTyp}})
-	}
-	if n == 0 {
-		return batch
-	}
-	vec := batch.ColVec(p.colIdx)
-	col := vec.{{.LTyp}}()
-	projVec := batch.ColVec(p.outputIdx)
-	projCol := projVec.{{.RetTyp}}()
-	if sel := batch.Selection(); sel != nil {
-		sel = sel[:n]
-		for _, i := range sel {
-			arg := {{.LTyp.Get "col" "int(i)"}}
-			{{(.Assign "projCol[i]" "arg" "p.constArg")}}
-		}
-	} else {
-		col = {{.LTyp.Slice "col" "0" "int(n)"}}
-		colLen := {{.LTyp.Len "col"}}
-		_ = {{.RetTyp.Get "projCol" "colLen-1"}}
-		for {{.LTyp.Range "i" "col"}} {
-			arg := {{.LTyp.Get "col" "i"}}
-			{{(.Assign "projCol[i]" "arg" "p.constArg")}}
-		}
-	}
-	if vec.Nulls().MaybeHasNulls() {
-		nulls := vec.Nulls().Copy()
-		projVec.SetNulls(&nulls)
-	}
-	return batch
-}
-
-func (p {{template "opRConstName" .}}) Init() {
-	p.input.Init()
-}
-{{end -}}
-
-{{define "projLConstOp"}}
-type {{template "opLConstName" .}} struct {
-  projConstOpBase
-	constArg {{.LGoType}}
-}
-
-func (p {{template "opLConstName" .}}) EstimateStaticMemoryUsage() int {
-	return EstimateBatchSizeBytes([]coltypes.T{coltypes.{{.RetTyp}}}, int(coldata.BatchSize()))
-}
-
-func (p {{template "opLConstName" .}}) Next(ctx context.Context) coldata.Batch {
-	batch := p.input.Next(ctx)
-	n := batch.Length()
-	if p.outputIdx == batch.Width() {
-		batch.AppendCol(coltypes.{{.RetTyp}})
-	}
-	if n == 0 {
-		return batch
-	}
-	vec := batch.ColVec(p.colIdx)
-	col := vec.{{.RTyp}}()
-	projVec := batch.ColVec(p.outputIdx)
-	projCol := projVec.{{.RetTyp}}()
-	if sel := batch.Selection(); sel != nil {
-		sel = sel[:n]
-		for _, i := range sel {
-			arg := {{.RTyp.Get "col" "int(i)"}}
-			{{(.Assign "projCol[i]" "p.constArg" "arg")}}
-		}
-	} else {
-		col = {{.RTyp.Slice "col" "0" "int(n)"}}
-		colLen := {{.RTyp.Len "col"}}
-		_ = {{.RetTyp.Get "projCol" "colLen-1"}}
-		for {{.RTyp.Range "i" "col"}} {
-			arg := {{.RTyp.Get "col" "i"}}
-			{{(.Assign "projCol[i]" "p.constArg" "arg")}}
-		}
-	}
-	if vec.Nulls().MaybeHasNulls() {
-		nulls := vec.Nulls().Copy()
-		projVec.SetNulls(&nulls)
-	}
-	return batch
-}
-
-func (p {{template "opLConstName" .}}) Init() {
-	p.input.Init()
-}
-{{end}}
-
-{{define "projOp"}}
-type {{template "opName" .}} struct {
-  projOpBase
-}
-
-func (p {{template "opName" .}}) EstimateStaticMemoryUsage() int {
-	return EstimateBatchSizeBytes([]coltypes.T{coltypes.{{.RetTyp}}}, int(coldata.BatchSize()))
-}
-
-func (p {{template "opName" .}}) Next(ctx context.Context) coldata.Batch {
-	batch := p.input.Next(ctx)
-	n := batch.Length()
-	if p.outputIdx == batch.Width() {
-		batch.AppendCol(coltypes.{{.RetTyp}})
-	}
-	if n == 0 {
-		return batch
-	}
-	projVec := batch.ColVec(p.outputIdx)
-	projCol := projVec.{{.RetTyp}}()
-	vec1 := batch.ColVec(p.col1Idx)
-	vec2 := batch.ColVec(p.col2Idx)
-	col1 := vec1.{{.LTyp}}()
-	col2 := vec2.{{.RTyp}}()
-	if sel := batch.Selection(); sel != nil {
-		sel = sel[:n]
-		for _, i := range sel {
-			arg1 := {{.LTyp.Get "col1" "int(i)"}}
-			arg2 := {{.RTyp.Get "col2" "int(i)"}}
-			{{(.Assign "projCol[i]" "arg1" "arg2")}}
-		}
-	} else {
-		col1 = {{.LTyp.Slice "col1" "0" "int(n)"}}
-		colLen := {{.LTyp.Len "col1"}}
-		_ = {{.RetTyp.Get "projCol" "colLen-1"}}
-		_ = {{.RTyp.Get "col2" "colLen-1"}}
-		for {{.LTyp.Range "i" "col1"}} {
-			arg1 := {{.LTyp.Get "col1" "i"}}
-			arg2 := {{.RTyp.Get "col2" "i"}}
-			{{(.Assign "projCol[i]" "arg1" "arg2")}}
-		}
-	}
-	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
-		projVec.SetNulls(vec1.Nulls().Or(vec2.Nulls()))
-	}
-	return batch
-}
-
-func (p {{template "opName" .}}) Init() {
-	p.input.Init()
-}
-{{end}}
-
-{{/* The outer range is a coltypes.T (the left type). The middle range is also a
-     coltypes.T (the right type). The inner is the overloads associated with
-     those two types. */}}
-{{range .LTypToRTypToOverloads}}
-{{range .}}
-{{range .}}
-{{template "projRConstOp" .}}
-{{template "projLConstOp" .}}
-{{template "projOp" .}}
-{{end}}
-{{end}}
-{{end}}
-
-{{/* Range over true and false. $left will be true when outputting a left-const
-     operator, and false when outputting a right-const operator. */}}
-{{range $left := .ConstSides}}
-// GetProjectionConstOperator returns the appropriate constant projection
-// operator for the given left and right column types and comparison.
-func GetProjection{{if $left}}L{{else}}R{{end}}ConstOperator(
-	leftColType *types.T,
-	rightColType *types.T,
-	op tree.Operator,
-	input Operator,
-	colIdx int,
-	constArg tree.Datum,
-  outputIdx int,
-) (Operator, error) {
-  projConstOpBase := projConstOpBase {
-    OneInputNode: NewOneInputNode(input),
-    colIdx: colIdx,
-    outputIdx: outputIdx,
-  }
-	c, err := typeconv.GetDatumToPhysicalFn({{if $left}}leftColType{{else}}rightColType{{end}})(constArg)
+// getProjConstOpTmplString returns a "projConstOp" template with isConstLeft
+// determining whether the constant is on the left or on the right.
+func getProjConstOpTmplString(isConstLeft bool) (string, error) {
+	t, err := ioutil.ReadFile("pkg/sql/colexec/proj_const_ops_tmpl.go")
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	switch leftType := typeconv.FromColumnType(leftColType); leftType {
-	{{range $lTyp, $rTypToOverloads := $.LTypToRTypToOverloads}}
-	case coltypes.{{$lTyp}}:
-		switch rightType := typeconv.FromColumnType(rightColType); rightType {
-		{{range $rTyp, $overloads := $rTypToOverloads}}
-		case coltypes.{{$rTyp}}:
-			switch op.(type) {
-			case tree.BinaryOperator:
-				switch op {
-				{{range $overloads -}}
-				{{if .IsBinOp -}}
-				case tree.{{.Name}}:
-					return &{{if $left -}}
-                  {{template "opLConstName" . -}}
-                  {{else -}}
-                  {{template "opRConstName" . -}}
-                  {{end -}}
-                  {projConstOpBase: projConstOpBase, constArg: c.({{if $left -}}
-                                                                  {{.LGoType -}}
-                                                                  {{else -}}
-                                                                  {{.RGoType -}}
-                                                                  {{end}})}, nil
-				{{end -}}
-				{{end -}}
-				default:
-					return nil, errors.Errorf("unhandled binary operator: %s", op)
-				}
-			case tree.ComparisonOperator:
-				switch op {
-				{{range $overloads -}}
-				{{if .IsCmpOp -}}
-				case tree.{{.Name}}:
-					return &{{if $left -}}
-                  {{template "opLConstName" . -}}
-                  {{else -}}
-                  {{template "opRConstName" . -}}
-                  {{end -}}
-                  {projConstOpBase: projConstOpBase, constArg: c.({{if $left -}}
-                                                                  {{.LGoType -}}
-                                                                  {{else -}}
-                                                                  {{.RGoType -}}
-                                                                  {{end}})}, nil
-				{{end -}}
-				{{end -}}
-				default:
-					return nil, errors.Errorf("unhandled comparison operator: %s", op)
-				}
-			default:
-				return nil, errors.New("unhandled operator type")
-			}
-		{{end -}}
-		default:
-			return nil, errors.Errorf("unhandled right type: %s", rightType)
-		}
-	{{end -}}
-	default:
-		return nil, errors.Errorf("unhandled left type: %s", leftType)
-	}
-}
-{{end -}}
 
-// GetProjectionOperator returns the appropriate projection operator for the
-// given left and right column types and comparison.
-func GetProjectionOperator(
-  leftColType *types.T,
-  rightColType *types.T,
-	op tree.Operator,
-	input Operator,
-	col1Idx int,
-	col2Idx int,
-  outputIdx int,
-) (Operator, error) {
-  projOpBase := projOpBase{OneInputNode: NewOneInputNode(input), col1Idx: col1Idx, col2Idx: col2Idx, outputIdx: outputIdx}
-	switch leftType := typeconv.FromColumnType(leftColType); leftType {
-	{{range $lTyp, $rTypToOverloads := .LTypToRTypToOverloads}}
-	case coltypes.{{$lTyp}}:
-		switch rightType := typeconv.FromColumnType(rightColType); rightType {
-		{{range $rTyp, $overloads := $rTypToOverloads}}
-		case coltypes.{{$rTyp}}:
-			switch op.(type) {
-			case tree.BinaryOperator:
-				switch op {
-				{{range $overloads -}}
-				{{if .IsBinOp -}}
-				case tree.{{.Name}}: return &{{template "opName" .}}{projOpBase: projOpBase}, nil
-				{{end -}}
-				{{end -}}
-				default:
-					return nil, errors.Errorf("unhandled binary operator: %s", op)
-				}
-			case tree.ComparisonOperator:
-				switch op {
-				{{range $overloads -}}
-				{{if .IsCmpOp -}}
-				case tree.{{.Name}}: return &{{template "opName" .}}{projOpBase: projOpBase}, nil
-				{{end -}}
-				{{end -}}
-				default:
-					return nil, errors.Errorf("unhandled comparison operator: %s", op)
-				}
-			default:
-				return nil, errors.New("unhandled operator type")
-			}
-		{{end -}}
-		default:
-			return nil, errors.Errorf("unhandled right type: %s", rightType)
-		}
-	{{end -}}
-	default:
-		return nil, errors.Errorf("unhandled left type: %s", leftType)
-	}
-}
-`
-
-type genInput struct {
-	LTypToRTypToOverloads map[coltypes.T]map[coltypes.T][]*overload
-	// ConstSides is a boolean array that contains two elements, true and false.
-	// It's used by the template to generate both variants of the const projection
-	// op - once where the left is const, and one where the right is const.
-	ConstSides []bool
+	s := string(t)
+	s = replaceProjConstTmplVariables(s, isConstLeft)
+	return s, nil
 }
 
-func genProjectionOps(wr io.Writer) error {
-	tmpl, err := template.New("projection_ops").Parse(projTemplate)
+// replaceProjTmplVariables replaces template variables used in the templates
+// for projection operators. It should only be used within this file.
+// Note that not all template variables can be present in the template, and it
+// is ok - such replacements will be noops.
+func replaceProjTmplVariables(tmpl string) string {
+	tmpl = strings.Replace(tmpl, "_L_UNSAFEGET", "execgen.UNSAFEGET", -1)
+	tmpl = replaceManipulationFuncs(".LTyp", tmpl)
+	tmpl = strings.Replace(tmpl, "_R_UNSAFEGET", "execgen.UNSAFEGET", -1)
+	tmpl = replaceManipulationFuncs(".RTyp", tmpl)
+	tmpl = strings.Replace(tmpl, "_RET_UNSAFEGET", "execgen.UNSAFEGET", -1)
+	tmpl = replaceManipulationFuncs(".RetTyp", tmpl)
+
+	// The order in which variables are replaced is important - since some
+	// variable names are prefixes of others, we need to replace the longer names
+	// first.
+	tmpl = strings.Replace(tmpl, "_OP_NAME", "proj{{.Name}}{{.LTyp}}{{.RTyp}}Op", -1)
+	tmpl = strings.Replace(tmpl, "_NAME", "{{.Name}}", -1)
+	tmpl = strings.Replace(tmpl, "_L_GO_TYPE", "{{.LGoType}}", -1)
+	tmpl = strings.Replace(tmpl, "_R_GO_TYPE", "{{.RGoType}}", -1)
+	tmpl = strings.Replace(tmpl, "_L_TYP_VAR", "{{$lTyp}}", -1)
+	tmpl = strings.Replace(tmpl, "_R_TYP_VAR", "{{$rTyp}}", -1)
+	tmpl = strings.Replace(tmpl, "_L_TYP", "{{.LTyp}}", -1)
+	tmpl = strings.Replace(tmpl, "_R_TYP", "{{.RTyp}}", -1)
+	tmpl = strings.Replace(tmpl, "_RET_TYP", "{{.RetTyp}}", -1)
+
+	assignRe := regexp.MustCompile(`_ASSIGN\((.*),(.*),(.*)\)`)
+	tmpl = assignRe.ReplaceAllString(tmpl, "{{.Assign $1 $2 $3}}")
+
+	return tmpl
+}
+
+// replaceProjConstTmplVariables replaces template variables that are specific
+// to projection operators with a constant argument. isConstLeft is true when
+// the constant is on the left side. It should only be used within this file.
+func replaceProjConstTmplVariables(tmpl string, isConstLeft bool) string {
+	if isConstLeft {
+		tmpl = strings.Replace(tmpl, "_CONST_SIDE", "L", -1)
+		tmpl = strings.Replace(tmpl, "_IS_CONST_LEFT", "true", -1)
+		tmpl = strings.Replace(tmpl, "_OP_CONST_NAME", "proj{{.Name}}{{.LTyp}}Const{{.RTyp}}Op", -1)
+		tmpl = replaceManipulationFuncs(".RTyp", tmpl)
+	} else {
+		tmpl = strings.Replace(tmpl, "_CONST_SIDE", "R", -1)
+		tmpl = strings.Replace(tmpl, "_IS_CONST_LEFT", "false", -1)
+		tmpl = strings.Replace(tmpl, "_OP_CONST_NAME", "proj{{.Name}}{{.LTyp}}{{.RTyp}}ConstOp", -1)
+		tmpl = replaceManipulationFuncs(".LTyp", tmpl)
+	}
+	return replaceProjTmplVariables(tmpl)
+}
+
+// genProjNonConstOps is the generator for projection operators on two vectors.
+func genProjNonConstOps(wr io.Writer) error {
+	t, err := ioutil.ReadFile("pkg/sql/colexec/proj_non_const_ops_tmpl.go")
 	if err != nil {
 		return err
 	}
 
+	s := string(t)
+	s = replaceProjTmplVariables(s)
+
+	tmpl, err := template.New("proj_non_const_ops").Parse(s)
+	if err != nil {
+		return err
+	}
+
+	return tmpl.Execute(wr, getLTypToRTypToOverloads())
+}
+
+func getLTypToRTypToOverloads() map[coltypes.T]map[coltypes.T][]*overload {
 	var allOverloads []*overload
 	allOverloads = append(allOverloads, binaryOpOverloads...)
 	allOverloads = append(allOverloads, comparisonOpOverloads...)
@@ -371,9 +116,26 @@ func genProjectionOps(wr io.Writer) error {
 		}
 		rTypToOverloads[rTyp] = append(rTypToOverloads[rTyp], ov)
 	}
-	return tmpl.Execute(wr, genInput{lTypToRTypToOverloads, []bool{false, true}})
+	return lTypToRTypToOverloads
 }
 
 func init() {
-	registerGenerator(genProjectionOps, "projection_ops.eg.go")
+	projConstOpsGenerator := func(isConstLeft bool) generator {
+		return func(wr io.Writer) error {
+			// First we get the template for the projection operators.
+			tmplString, err := getProjConstOpTmplString(isConstLeft)
+			if err != nil {
+				return err
+			}
+			tmpl, err := template.New("proj_const_ops").Parse(tmplString)
+			if err != nil {
+				return err
+			}
+			return tmpl.Execute(wr, getLTypToRTypToOverloads())
+		}
+	}
+
+	registerGenerator(projConstOpsGenerator(true /* isConstLeft */), "proj_const_left_ops.eg.go")
+	registerGenerator(projConstOpsGenerator(false /* isConstLeft */), "proj_const_right_ops.eg.go")
+	registerGenerator(genProjNonConstOps, "proj_non_const_ops.eg.go")
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/projection_ops_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/projection_ops_gen.go
@@ -71,7 +71,7 @@ func (p {{template "opRConstName" .}}) Next(ctx context.Context) coldata.Batch {
 	} else {
 		col = {{.LTyp.Slice "col" "0" "int(n)"}}
 		colLen := {{.LTyp.Len "col"}}
-		_ = projCol[colLen-1]
+		_ = {{.RetTyp.Get "projCol" "colLen-1"}}
 		for {{.LTyp.Range "i" "col"}} {
 			arg := {{.LTyp.Get "col" "i"}}
 			{{(.Assign "projCol[i]" "arg" "p.constArg")}}
@@ -121,7 +121,7 @@ func (p {{template "opLConstName" .}}) Next(ctx context.Context) coldata.Batch {
 	} else {
 		col = {{.RTyp.Slice "col" "0" "int(n)"}}
 		colLen := {{.RTyp.Len "col"}}
-		_ = projCol[colLen-1]
+		_ = {{.RetTyp.Get "projCol" "colLen-1"}}
 		for {{.RTyp.Range "i" "col"}} {
 			arg := {{.RTyp.Get "col" "i"}}
 			{{(.Assign "projCol[i]" "p.constArg" "arg")}}
@@ -173,11 +173,11 @@ func (p {{template "opName" .}}) Next(ctx context.Context) coldata.Batch {
 	} else {
 		col1 = {{.LTyp.Slice "col1" "0" "int(n)"}}
 		colLen := {{.LTyp.Len "col1"}}
-		_ = projCol[colLen-1]
-		_ = {{.LTyp.Get "col2" "colLen-1"}}
+		_ = {{.RetTyp.Get "projCol" "colLen-1"}}
+		_ = {{.RTyp.Get "col2" "colLen-1"}}
 		for {{.LTyp.Range "i" "col1"}} {
 			arg1 := {{.LTyp.Get "col1" "i"}}
-			arg2 := {{.LTyp.Get "col2" "i"}}
+			arg2 := {{.RTyp.Get "col2" "i"}}
 			{{(.Assign "projCol[i]" "arg1" "arg2")}}
 		}
 	}

--- a/pkg/sql/colexec/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/mergejoiner_tmpl.go
@@ -59,7 +59,7 @@ const _TYPES_T = coltypes.Unhandled
 type _GOTYPE interface{}
 
 // _ASSIGN_EQ is the template equality function for assigning the first input
-// to the result of the the second input == the third input.
+// to the result of the second input == the third input.
 func _ASSIGN_EQ(_, _, _ interface{}) uint64 {
 	execerror.VectorizedInternalPanic("")
 }

--- a/pkg/sql/colexec/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/min_max_agg_tmpl.go
@@ -11,7 +11,7 @@
 // {{/*
 // +build execgen_template
 //
-// This file is the execgen template for min_agg.eg.go. It's formatted in a
+// This file is the execgen template for min_max_agg.eg.go. It's formatted in a
 // special way, so it's both valid Go and a valid text/template input. This
 // permits editing this file with editor support.
 //
@@ -35,7 +35,7 @@ import (
 )
 
 // {{/*
-// Declarations to make the template compile properly
+// Declarations to make the template compile properly.
 
 // Dummy import to pull in "bytes" package.
 var _ bytes.Buffer

--- a/pkg/sql/colexec/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_const_ops_tmpl.go
@@ -1,0 +1,230 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// {{/*
+// +build execgen_template
+//
+// This file is the execgen template for proj_const_{left,right}_ops.eg.go.
+// It's formatted in a special way, so it's both valid Go and a valid
+// text/template input. This permits editing this file with editor support.
+//
+// */}}
+
+package colexec
+
+import (
+	"bytes"
+	"context"
+	"math"
+
+	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
+	// {{/*
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
+	// */}}
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/typeconv"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/pkg/errors"
+)
+
+// {{/*
+// Declarations to make the template compile properly.
+
+// Dummy import to pull in "bytes" package.
+var _ bytes.Buffer
+
+// Dummy import to pull in "apd" package.
+var _ apd.Decimal
+
+// Dummy import to pull in "tree" package.
+var _ tree.Datum
+
+// Dummy import to pull in "math" package.
+var _ = math.MaxInt64
+
+// _ASSIGN is the template function for assigning the first input to the result
+// of computation an operation on the second and the third inputs.
+func _ASSIGN(_, _, _ interface{}) {
+	execerror.VectorizedInternalPanic("")
+}
+
+// _RET_UNSAFEGET is the template function that will be replaced by
+// "execgen.UNSAFEGET" which uses _RET_TYP.
+func _RET_UNSAFEGET(_, _ interface{}) interface{} {
+	execerror.VectorizedInternalPanic("")
+}
+
+// */}}
+
+// {{define "projConstOp" }}
+
+type _OP_CONST_NAME struct {
+	projConstOpBase
+	// {{ if _IS_CONST_LEFT }}
+	constArg _L_GO_TYPE
+	// {{ else }}
+	constArg _R_GO_TYPE
+	// {{ end }}
+}
+
+func (p _OP_CONST_NAME) EstimateStaticMemoryUsage() int {
+	return EstimateBatchSizeBytes([]coltypes.T{coltypes._RET_TYP}, int(coldata.BatchSize()))
+}
+
+func (p _OP_CONST_NAME) Next(ctx context.Context) coldata.Batch {
+	batch := p.input.Next(ctx)
+	n := batch.Length()
+	if p.outputIdx == batch.Width() {
+		batch.AppendCol(coltypes._RET_TYP)
+	}
+	if n == 0 {
+		return batch
+	}
+	vec := batch.ColVec(p.colIdx)
+	// {{if _IS_CONST_LEFT}}
+	col := vec._R_TYP()
+	// {{else}}
+	col := vec._L_TYP()
+	// {{end}}
+	projVec := batch.ColVec(p.outputIdx)
+	projCol := projVec._RET_TYP()
+	if sel := batch.Selection(); sel != nil {
+		sel = sel[:n]
+		for _, i := range sel {
+			arg := execgen.UNSAFEGET(col, int(i))
+			// {{if _IS_CONST_LEFT}}
+			_ASSIGN("projCol[i]", "p.constArg", "arg")
+			// {{else}}
+			_ASSIGN("projCol[i]", "arg", "p.constArg")
+			// {{end}}
+		}
+	} else {
+		col = execgen.SLICE(col, 0, int(n))
+		colLen := execgen.LEN(col)
+		_ = _RET_UNSAFEGET(projCol, colLen-1)
+		for execgen.RANGE(i, col) {
+			arg := execgen.UNSAFEGET(col, i)
+			// {{if _IS_CONST_LEFT}}
+			_ASSIGN("projCol[i]", "p.constArg", "arg")
+			// {{else}}
+			_ASSIGN("projCol[i]", "arg", "p.constArg")
+			// {{end}}
+		}
+	}
+	if vec.Nulls().MaybeHasNulls() {
+		nulls := vec.Nulls().Copy()
+		projVec.SetNulls(&nulls)
+	}
+	return batch
+}
+
+func (p _OP_CONST_NAME) Init() {
+	p.input.Init()
+}
+
+// {{end}}
+
+// {{/*
+// The outer range is a coltypes.T (the left type). The middle range is also a
+// coltypes.T (the right type). The inner is the overloads associated with
+// those two types.
+// */}}
+// {{range .}}
+// {{range .}}
+// {{range .}}
+
+// {{template "projConstOp" .}}
+
+// {{end}}
+// {{end}}
+// {{end}}
+
+// GetProjection_CONST_SIDEConstOperator returns the appropriate constant
+// projection operator for the given left and right column types and operation.
+func GetProjection_CONST_SIDEConstOperator(
+	leftColType *types.T,
+	rightColType *types.T,
+	op tree.Operator,
+	input Operator,
+	colIdx int,
+	constArg tree.Datum,
+	outputIdx int,
+) (Operator, error) {
+	projConstOpBase := projConstOpBase{
+		OneInputNode: NewOneInputNode(input),
+		colIdx:       colIdx,
+		outputIdx:    outputIdx,
+	}
+	// {{if _IS_CONST_LEFT}}
+	c, err := typeconv.GetDatumToPhysicalFn(leftColType)(constArg)
+	// {{else}}
+	c, err := typeconv.GetDatumToPhysicalFn(rightColType)(constArg)
+	// {{end}}
+	if err != nil {
+		return nil, err
+	}
+	switch leftType := typeconv.FromColumnType(leftColType); leftType {
+	// {{range $lTyp, $rTypToOverloads := .}}
+	case coltypes._L_TYP_VAR:
+		switch rightType := typeconv.FromColumnType(rightColType); rightType {
+		// {{range $rTyp, $overloads := $rTypToOverloads}}
+		case coltypes._R_TYP_VAR:
+			switch op.(type) {
+			case tree.BinaryOperator:
+				switch op {
+				// {{range $overloads}}
+				// {{if .IsBinOp}}
+				case tree._NAME:
+					return &_OP_CONST_NAME{
+						projConstOpBase: projConstOpBase,
+						// {{if _IS_CONST_LEFT}}
+						constArg: c.(_L_GO_TYPE),
+						// {{else}}
+						constArg: c.(_R_GO_TYPE),
+						// {{end}}
+					}, nil
+				// {{end}}
+				// {{end}}
+				default:
+					return nil, errors.Errorf("unhandled binary operator: %s", op)
+				}
+			case tree.ComparisonOperator:
+				switch op {
+				// {{range $overloads}}
+				// {{if .IsCmpOp}}
+				case tree._NAME:
+					return &_OP_CONST_NAME{
+						projConstOpBase: projConstOpBase,
+						// {{if _IS_CONST_LEFT}}
+						constArg: c.(_L_GO_TYPE),
+						// {{else}}
+						constArg: c.(_R_GO_TYPE),
+						// {{end}}
+					}, nil
+				// {{end}}
+				// {{end}}
+				default:
+					return nil, errors.Errorf("unhandled comparison operator: %s", op)
+				}
+			default:
+				return nil, errors.New("unhandled operator type")
+			}
+		// {{end}}
+		default:
+			return nil, errors.Errorf("unhandled right type: %s", rightType)
+		}
+	// {{end}}
+	default:
+		return nil, errors.Errorf("unhandled left type: %s", leftType)
+	}
+}

--- a/pkg/sql/colexec/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_non_const_ops_tmpl.go
@@ -78,7 +78,7 @@ func _RET_UNSAFEGET(_, _ interface{}) interface{} {
 
 // */}}
 
-// {{define "projOp" }}
+// {{define "projOp"}}
 
 type _OP_NAME struct {
 	projOpBase
@@ -103,27 +103,12 @@ func (p _OP_NAME) Next(ctx context.Context) coldata.Batch {
 	vec2 := batch.ColVec(p.col2Idx)
 	col1 := vec1._L_TYP()
 	col2 := vec2._R_TYP()
-	if sel := batch.Selection(); sel != nil {
-		sel = sel[:n]
-		for _, i := range sel {
-			arg1 := _L_UNSAFEGET(col1, int(i))
-			arg2 := _R_UNSAFEGET(col2, int(i))
-			_ASSIGN("projCol[i]", "arg1", "arg2")
-		}
-	} else {
-		col1 = execgen.SLICE(col1, 0, int(n))
-		colLen := execgen.LEN(col1)
-		_ = _RET_UNSAFEGET(projCol, colLen-1)
-		_ = _R_UNSAFEGET(col2, colLen-1)
-		for execgen.RANGE(i, col1) {
-			arg1 := _L_UNSAFEGET(col1, i)
-			arg2 := _R_UNSAFEGET(col2, i)
-			_ASSIGN("projCol[i]", "arg1", "arg2")
-		}
-	}
 	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
-		projVec.SetNulls(vec1.Nulls().Or(vec2.Nulls()))
+		_SET_PROJECTION(true)
+	} else {
+		_SET_PROJECTION(false)
 	}
+
 	return batch
 }
 
@@ -132,6 +117,63 @@ func (p _OP_NAME) Init() {
 }
 
 // {{end}}
+
+// {{/*
+func _SET_PROJECTION(_HAS_NULLS bool) {
+	// */}}
+	// {{define "setProjection" -}}
+	// {{$hasNulls := $.HasNulls}}
+	// {{with $.Overload}}
+	// {{if _HAS_NULLS}}
+	col1Nulls := vec1.Nulls()
+	col2Nulls := vec2.Nulls()
+	// {{end}}
+	if sel := batch.Selection(); sel != nil {
+		sel = sel[:n]
+		for _, i := range sel {
+			_SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS)
+		}
+	} else {
+		col1 = execgen.SLICE(col1, 0, int(n))
+		colLen := execgen.LEN(col1)
+		_ = _RET_UNSAFEGET(projCol, colLen-1)
+		_ = _R_UNSAFEGET(col2, colLen-1)
+		for execgen.RANGE(i, col1) {
+			_SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS)
+		}
+	}
+	// {{if _HAS_NULLS}}
+	projVec.SetNulls(col1Nulls.Or(col2Nulls))
+	// {{end}}
+	// {{end}}
+	// {{end}}
+	// {{/*
+}
+
+// */}}
+
+// {{/*
+func _SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS bool) { // */}}
+	// {{define "setSingleTupleProjection" -}}
+	// {{$hasNulls := $.HasNulls}}
+	// {{with $.Overload}}
+	// {{if _HAS_NULLS}}
+	if !col1Nulls.NullAt(uint16(i)) && !col2Nulls.NullAt(uint16(i)) {
+		// We only want to perform the projection operation if both values are not
+		// null.
+		// {{end}}
+		arg1 := _L_UNSAFEGET(col1, int(i))
+		arg2 := _R_UNSAFEGET(col2, int(i))
+		_ASSIGN("projCol[i]", "arg1", "arg2")
+		// {{if _HAS_NULLS }}
+	}
+	// {{end}}
+	// {{end}}
+	// {{end}}
+	// {{/*
+}
+
+// */}}
 
 // {{/*
 // The outer range is a coltypes.T (the left type). The middle range is also a

--- a/pkg/sql/colexec/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_non_const_ops_tmpl.go
@@ -1,0 +1,203 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// {{/*
+// +build execgen_template
+//
+// This file is the execgen template for proj_non_const_ops.eg.go. It's
+// formatted in a special way, so it's both valid Go and a valid text/template
+// input. This permits editing this file with editor support.
+//
+// */}}
+
+package colexec
+
+import (
+	"bytes"
+	"context"
+	"math"
+
+	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
+	// {{/*
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
+	// */}}
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/typeconv"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/pkg/errors"
+)
+
+// {{/*
+// Declarations to make the template compile properly.
+
+// Dummy import to pull in "bytes" package.
+var _ bytes.Buffer
+
+// Dummy import to pull in "apd" package.
+var _ apd.Decimal
+
+// Dummy import to pull in "tree" package.
+var _ tree.Datum
+
+// Dummy import to pull in "math" package.
+var _ = math.MaxInt64
+
+// _ASSIGN is the template function for assigning the first input to the result
+// of computation an operation on the second and the third inputs.
+func _ASSIGN(_, _, _ interface{}) {
+	execerror.VectorizedInternalPanic("")
+}
+
+// _L_UNSAFEGET is the template function that will be replaced by
+// "execgen.UNSAFEGET" which uses _L_TYP.
+func _L_UNSAFEGET(_, _ interface{}) interface{} {
+	execerror.VectorizedInternalPanic("")
+}
+
+// _R_UNSAFEGET is the template function that will be replaced by
+// "execgen.UNSAFEGET" which uses _R_TYP.
+func _R_UNSAFEGET(_, _ interface{}) interface{} {
+	execerror.VectorizedInternalPanic("")
+}
+
+// _RET_UNSAFEGET is the template function that will be replaced by
+// "execgen.UNSAFEGET" which uses _RET_TYP.
+func _RET_UNSAFEGET(_, _ interface{}) interface{} {
+	execerror.VectorizedInternalPanic("")
+}
+
+// */}}
+
+// {{define "projOp" }}
+
+type _OP_NAME struct {
+	projOpBase
+}
+
+func (p _OP_NAME) EstimateStaticMemoryUsage() int {
+	return EstimateBatchSizeBytes([]coltypes.T{coltypes._RET_TYP}, int(coldata.BatchSize()))
+}
+
+func (p _OP_NAME) Next(ctx context.Context) coldata.Batch {
+	batch := p.input.Next(ctx)
+	n := batch.Length()
+	if p.outputIdx == batch.Width() {
+		batch.AppendCol(coltypes._RET_TYP)
+	}
+	if n == 0 {
+		return batch
+	}
+	projVec := batch.ColVec(p.outputIdx)
+	projCol := projVec._RET_TYP()
+	vec1 := batch.ColVec(p.col1Idx)
+	vec2 := batch.ColVec(p.col2Idx)
+	col1 := vec1._L_TYP()
+	col2 := vec2._R_TYP()
+	if sel := batch.Selection(); sel != nil {
+		sel = sel[:n]
+		for _, i := range sel {
+			arg1 := _L_UNSAFEGET(col1, int(i))
+			arg2 := _R_UNSAFEGET(col2, int(i))
+			_ASSIGN("projCol[i]", "arg1", "arg2")
+		}
+	} else {
+		col1 = execgen.SLICE(col1, 0, int(n))
+		colLen := execgen.LEN(col1)
+		_ = _RET_UNSAFEGET(projCol, colLen-1)
+		_ = _R_UNSAFEGET(col2, colLen-1)
+		for execgen.RANGE(i, col1) {
+			arg1 := _L_UNSAFEGET(col1, i)
+			arg2 := _R_UNSAFEGET(col2, i)
+			_ASSIGN("projCol[i]", "arg1", "arg2")
+		}
+	}
+	if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+		projVec.SetNulls(vec1.Nulls().Or(vec2.Nulls()))
+	}
+	return batch
+}
+
+func (p _OP_NAME) Init() {
+	p.input.Init()
+}
+
+// {{end}}
+
+// {{/*
+// The outer range is a coltypes.T (the left type). The middle range is also a
+// coltypes.T (the right type). The inner is the overloads associated with
+// those two types.
+// */}}
+// {{range .}}
+// {{range .}}
+// {{range .}}
+
+// {{template "projOp" .}}
+
+// {{end}}
+// {{end}}
+// {{end}}
+
+// GetProjectionOperator returns the appropriate projection operator for the
+// given left and right column types and operation.
+func GetProjectionOperator(
+	leftColType *types.T,
+	rightColType *types.T,
+	op tree.Operator,
+	input Operator,
+	col1Idx int,
+	col2Idx int,
+	outputIdx int,
+) (Operator, error) {
+	projOpBase := projOpBase{OneInputNode: NewOneInputNode(input), col1Idx: col1Idx, col2Idx: col2Idx, outputIdx: outputIdx}
+	switch leftType := typeconv.FromColumnType(leftColType); leftType {
+	// {{range $lTyp, $rTypToOverloads := .}}
+	case coltypes._L_TYP_VAR:
+		switch rightType := typeconv.FromColumnType(rightColType); rightType {
+		// {{range $rTyp, $overloads := $rTypToOverloads}}
+		case coltypes._R_TYP_VAR:
+			switch op.(type) {
+			case tree.BinaryOperator:
+				switch op {
+				// {{range $overloads}}
+				// {{if .IsBinOp}}
+				case tree._NAME:
+					return &_OP_NAME{projOpBase: projOpBase}, nil
+				// {{end}}
+				// {{end}}
+				default:
+					return nil, errors.Errorf("unhandled binary operator: %s", op)
+				}
+			case tree.ComparisonOperator:
+				switch op {
+				// {{range $overloads}}
+				// {{if .IsCmpOp}}
+				case tree._NAME:
+					return &_OP_NAME{projOpBase: projOpBase}, nil
+				// {{end}}
+				// {{end}}
+				default:
+					return nil, errors.Errorf("unhandled comparison operator: %s", op)
+				}
+			default:
+				return nil, errors.New("unhandled operator type")
+			}
+			// {{end}}
+		default:
+			return nil, errors.Errorf("unhandled right type: %s", rightType)
+		}
+		// {{end}}
+	default:
+		return nil, errors.Errorf("unhandled left type: %s", leftType)
+	}
+}

--- a/pkg/sql/colexec/projection_ops_test.go
+++ b/pkg/sql/colexec/projection_ops_test.go
@@ -52,6 +52,21 @@ func TestProjPlusInt64Int64Op(t *testing.T) {
 		})
 }
 
+func TestProjDivFloat64Float64Op(t *testing.T) {
+	runTests(t, []tuples{{{1.0, 2.0}, {3.0, 4.0}, {5.0, nil}}}, tuples{{1.0, 2.0, 0.5}, {3.0, 4.0, 0.75}, {5.0, nil, nil}},
+		orderedVerifier,
+		func(input []Operator) (Operator, error) {
+			return &projDivFloat64Float64Op{
+				projOpBase: projOpBase{
+					OneInputNode: NewOneInputNode(input[0]),
+					col1Idx:      0,
+					col2Idx:      1,
+					outputIdx:    2,
+				},
+			}, nil
+		})
+}
+
 func benchmarkProjPlusInt64Int64ConstOp(b *testing.B, useSelectionVector bool, hasNulls bool) {
 	ctx := context.Background()
 


### PR DESCRIPTION
**colexec: fix a few typos in the projection ops template**

Release justification: Category 1: Non-production code changes.

**colexec: refactor the template for projection operators**

The old version of the template for projection operators was written
before we gained more familiarity with the templates in general, so
it was a huge single string. This commit refactor that huge single
string template into a newer version.

Besides giving us a benefit of taking a step towards unifying our
templates, this will allow us to customize the behavior when nulls
are present with a lot less effort.

Release justification: Category 1: Non-production code changes.

**colexec: fix handling of NULLs by projection operators**

Previously, the projection operators would always perform its operation
on the full vectors of values, and only after the fact would set the
nulls vector. However, this is incorrect since this can trigger wrong
side effects (like division by zero when the value is actually NULL).
Now this is fixed.

Release justification: Category 2: Bug fixes and low-risk updates to
new functionality.

Fixes: #40915.

Release note: None