### PR TITLE
opt: don't report invalid PruneCols from WithScan

### DIFF
--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -751,6 +751,9 @@ func (b *logicalPropsBuilder) buildWithScanProps(ref *WithScanExpr, rel *props.R
 	// references.
 	*rel = *ref.BindingProps
 
+	// Things like PruneCols are not valid here.
+	rel.Rule = props.Relational{}.Rule
+
 	// Has Placeholder
 	// ---------------
 	// Overwrite this from the copied props.

--- a/pkg/sql/opt/memo/testdata/logprops/with
+++ b/pkg/sql/opt/memo/testdata/logprops/with
@@ -196,3 +196,36 @@ inner-join-apply
  │         ├── fd: ()-->(3)
  │         └── cte-uses: map[1:1]
  └── filters (true)
+
+# Regression test for #40930.
+
+exec-ddl
+CREATE TABLE t40930 (
+  s string
+)
+----
+
+opt
+WITH
+    with_4189
+        AS (
+            SELECT
+                tab_10102.s
+            FROM
+                t40930 AS tab_10102, (SELECT NULL) AS tab_10103 (col_24444)
+        )
+SELECT
+    NULL
+FROM
+    t40930, with_4189
+----
+project
+ ├── columns: "?column?":7(unknown)
+ ├── fd: ()-->(7)
+ ├── prune: (7)
+ ├── inner-join (hash)
+ │    ├── scan t40930
+ │    ├── scan tab_10102
+ │    └── filters (true)
+ └── projections
+      └── null [type=unknown]

--- a/pkg/sql/opt/props/logical.go
+++ b/pkg/sql/opt/props/logical.go
@@ -464,6 +464,12 @@ func (r *Relational) Verify() {
 				"max cardinality must be <= 1 if FDs have max 1 row: %s", r.Cardinality))
 		}
 	}
+	if r.IsAvailable(PruneCols) {
+		if !r.Rule.PruneCols.SubsetOf(r.OutputCols) {
+			panic(errors.AssertionFailedf("prune cols %s must be a subset of output cols %s",
+				log.Safe(r.Rule.PruneCols), log.Safe(r.OutputCols)))
+		}
+	}
 }
 
 // VerifyAgainst checks that the two properties don't contradict each other.


### PR DESCRIPTION
Fixes #40930.

This commit zeroes out the Rule field on the relational props copied
from the With node. Follow-up for post branching will be to correctly
prune the columns from the WithScan.

Release note (bug fix): Fixed a stack overflow that could occur via use
of WITH.

Release justification: Category 2: Low risk and important bugfix.