### PR TITLE
util/log: ensure stderr is only redirected to the main log

### DIFF
--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -918,7 +918,7 @@ func (l *loggingT) outputLogEntry(s Severity, file string, line int, msg string)
 		}
 	}
 
-	if s >= l.stderrThreshold.get() || (s == Severity_FATAL && stderrRedirected()) {
+	if s >= l.stderrThreshold.get() || (s == Severity_FATAL && l.stderrRedirected()) {
 		// We force-copy FATAL messages to stderr, because the process is bound
 		// to terminate and the user will want to know why.
 		l.outputToStderr(entry, stacks)
@@ -1116,7 +1116,7 @@ func (sb *syncBuffer) rotateFile(now time.Time) error {
 	// stack traces that are written by the Go runtime to stderr. Note that if
 	// --logtostderr is true we'll never enter this code path and panic stack
 	// traces will go to the original stderr as you would expect.
-	if stderrRedirected() {
+	if sb.logger.stderrRedirected() {
 		// NB: any concurrent output to stderr may straddle the old and new
 		// files. This doesn't apply to log messages as we won't reach this code
 		// unless we're not logging to stderr.

--- a/pkg/util/log/crash_reporting.go
+++ b/pkg/util/log/crash_reporting.go
@@ -206,7 +206,7 @@ func (st SafeType) WithCause(cause interface{}) SafeType {
 func ReportPanic(ctx context.Context, sv *settings.Values, r interface{}, depth int) {
 	Shout(ctx, Severity_ERROR, "a panic has occurred!")
 
-	if stderrRedirected() {
+	if logging.stderrRedirected() {
 		// We do not use Shout() to print the panic details here, because
 		// if stderr is not redirected (e.g. when logging to file is
 		// disabled) Shout() would copy its argument to stderr

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -80,7 +80,7 @@ func Shout(ctx context.Context, sev Severity, args ...interface{}) {
 		})
 		defer t.Stop()
 	}
-	if stderrRedirected() {
+	if logging.stderrRedirected() {
 		fmt.Fprintf(OrigStderr, "*\n* %s: %s\n*\n", sev.String(),
 			strings.Replace(MakeMessage(ctx, "", args), "\n", "\n* ", -1))
 	}

--- a/pkg/util/log/stderr_redirect.go
+++ b/pkg/util/log/stderr_redirect.go
@@ -25,8 +25,8 @@ var OrigStderr = func() *os.File {
 // stderrRedirected returns true if and only if logging captures
 // stderr output to the log file. This is used e.g. by Shout() to
 // determine whether to report to standard error in addition to logs.
-func stderrRedirected() bool {
-	return logging.stderrThreshold > Severity_INFO && !logging.noStderrRedirect
+func (l *loggingT) stderrRedirected() bool {
+	return l.stderrThreshold > Severity_INFO && !l.noStderrRedirect
 }
 
 // hijackStderr replaces stderr with the given file descriptor.


### PR DESCRIPTION
Fixes #40940

Release justification: bug fix for a bug that severely affects our ability to troubleshoot issues

The code that would redirect stderr would kick in on the first log
event for any secondary logger, not just the main one, because the
predicate to activate the redirection was only using the boolean
variable on the main logger (which is always true).

This patch fixes the issue by properly using the per-logger boolean to
make this determination.

Release note (bug fix): Detailed crash reports ("panic messages")
could previously be reported in the wrong file, if SQL audit reporting
or statement logging had been activated. This has been corrected and
crash reports will now properly always appear in the main log file.