### PR TITLE
sql: remove unimplemented error message from COMMENT ON statement

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2166,10 +2166,6 @@ comment_stmt:
 
     $$.val = &tree.CommentOnColumn{ColumnItem: columnItem, Comment: $6.strPtr()}
   }
-| COMMENT ON error
-  {
-    return unimplementedWithIssue(sqllex, 19472)
-  }
 
 comment_text:
   SCONST


### PR DESCRIPTION
Any syntax error while using the COMMENT ON statement returns an error
referencing #19472. With #19472 closed, we should no longer reference
it when the syntax is wrong.

Fixes #40713

Release note: None

Release Justification: Very minor change