### PR TITLE
roachtest: tpcc-max had too low of a timeout

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -312,6 +312,7 @@ func registerTPCC(r *testRegistry) {
 		MinVersion: maybeMinVersionForFixturesImport(cloud),
 		Tags:       []string{`weekly`},
 		Cluster:    makeClusterSpec(4, cpu(16)),
+		Timeout:    time.Duration(6*24)*time.Hour + time.Duration(10)*time.Minute,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			warehouses := 1350
 			runTPCC(ctx, t, c, tpccOptions{


### PR DESCRIPTION
It's supposed to run for 6 days, but used the default timeout of 10
hours.

Closes #38558.

Release note: None
Release justification: test-only change