### PR TITLE
sql: Add support for JOIN LATERAL syntax

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/subquery_correlated
+++ b/pkg/sql/logictest/testdata/logic_test/subquery_correlated
@@ -1170,3 +1170,48 @@ LIMIT 5;
 {}
 {}
 {}
+
+# Customers, their billing address, and all orders not going to their billing address
+query ITT rowsort
+SELECT
+    c_id, bill, states
+FROM
+    c
+    JOIN LATERAL (
+            SELECT
+                COALESCE(array_agg(o.ship), '{}') AS states
+            FROM
+                o
+            WHERE
+                o.c_id = c.c_id AND o.ship != c.bill
+        ) ON true;
+----
+1  CA    {}
+3  MA    {}
+4  TX    {WY}
+5  NULL  {}
+6  FL    {WA}
+2  TX    {CA}
+
+# Customers that have billing addresses and all orders not going to their billing address
+query IT rowsort
+SELECT
+    c_id, states
+FROM
+    c
+    LEFT JOIN LATERAL (
+            SELECT
+                COALESCE(array_agg(o.ship), '{}') AS states
+            FROM
+                o
+            WHERE
+                o.c_id = c.c_id AND o.ship != c.bill
+        ) ON true
+WHERE
+    bill IS NOT NULL;
+----
+1  {}
+3  {}
+2  {CA}
+4  {WY}
+6  {WA}

--- a/pkg/sql/opt/optbuilder/testdata/lateral
+++ b/pkg/sql/opt/optbuilder/testdata/lateral
@@ -287,3 +287,49 @@ inner-join-apply
  │                                       ├── variable: j2.j [type=jsonb]
  │                                       └── const: 'members' [type=string]
  └── filters (true)
+
+build
+SELECT * FROM x JOIN LATERAL (SELECT * FROM y WHERE b = x.a) ON true
+----
+inner-join-apply
+ ├── columns: a:1(int!null) b:2(int!null)
+ ├── scan x
+ │    └── columns: a:1(int!null)
+ ├── select
+ │    ├── columns: b:2(int!null)
+ │    ├── scan y
+ │    │    └── columns: b:2(int!null)
+ │    └── filters
+ │         └── eq [type=bool]
+ │              ├── variable: b [type=int]
+ │              └── variable: a [type=int]
+ └── filters
+      └── true [type=bool]
+
+build
+SELECT * FROM x LEFT JOIN LATERAL (SELECT * FROM y WHERE b = x.a) ON true
+----
+left-join-apply
+ ├── columns: a:1(int!null) b:2(int)
+ ├── scan x
+ │    └── columns: a:1(int!null)
+ ├── select
+ │    ├── columns: b:2(int!null)
+ │    ├── scan y
+ │    │    └── columns: b:2(int!null)
+ │    └── filters
+ │         └── eq [type=bool]
+ │              ├── variable: b [type=int]
+ │              └── variable: a [type=int]
+ └── filters
+      └── true [type=bool]
+
+build
+SELECT * FROM x RIGHT JOIN LATERAL (SELECT * FROM y WHERE b = x.a) ON true
+----
+error (42601): The combining JOIN type must be INNER or LEFT for a LATERAL reference
+
+build
+SELECT * FROM x FULL OUTER JOIN LATERAL (SELECT * FROM y WHERE b = x.a) ON true
+----
+error (42601): The combining JOIN type must be INNER or LEFT for a LATERAL reference


### PR DESCRIPTION
As correlated subqueries are already supported, only minor scoping
changes are required to fully support Postgres' JOIN LATERAL syntax.

h/t @justinj for the support

Release note (sql change): Adds support for JOIN LATERAL syntax.