### PR TITLE
sql: Improve AS OF SYSTEM TIME error message

### DIFF
--- a/pkg/sql/as_of_test.go
+++ b/pkg/sql/as_of_test.go
@@ -225,11 +225,23 @@ func TestAsOfTime(t *testing.T) {
 		t.Fatalf("expected %v, got %v", val1, i)
 	}
 
-	// Can't use in a transaction.
+	// Can use in a transaction by using the SET TRANSACTION syntax
+	if err := db.QueryRow(fmt.Sprintf(`
+			BEGIN;
+			SET TRANSACTION AS OF SYSTEM TIME %s;
+			SELECT a FROM d.t;
+			COMMIT;
+	`, tsVal1)).Scan(&i); err != nil {
+		t.Fatal(err)
+	} else if i != val1 {
+		t.Fatalf("expected %v, got %v", val1, i)
+	}
+
+	// Can't use in a transaction without SET TRANSACTION AS OF SYSTEM TIME syntax
 	_, err = db.Query(
 		fmt.Sprintf("BEGIN; SELECT a FROM d.t AS OF SYSTEM TIME %s; COMMIT;", tsVal1))
-	if !testutils.IsError(err, "cannot be used inside a transaction") {
-		t.Fatalf("expected not supported, got: %v", err)
+	if !testutils.IsError(err, "try SET TRANSACTION AS OF SYSTEM TIME") {
+		t.Fatalf("expected try SET TRANSACTION AS OF SYSTEM TIME, got: %v", err)
 	}
 }
 

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -388,8 +388,7 @@ func (ex *connExecutor) execStmtInOpenState(
 			if origTs := ex.state.getOrigTimestamp(); *ts != origTs {
 				err = pgerror.Newf(pgcode.Syntax,
 					"inconsistent AS OF SYSTEM TIME timestamp; expected: %s", origTs)
-				err = errors.WithHint(err,
-					"Generally AS OF SYSTEM TIME cannot be used inside a transaction.")
+				err = errors.WithHint(err, "try SET TRANSACTION AS OF SYSTEM TIME")
 				return makeErrEvent(err)
 			}
 			p.semaCtx.AsOfTimestamp = ts


### PR DESCRIPTION
Improve the error message to hint the SET TRANSACTION syntax  instead
of saying AOST can't be generally used inside a transaction.

Fixes #40204

Release note: None

Release justification: Minor change