### PR TITLE
sql: remove last 2 blockers for pgcli support

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1096,7 +1096,6 @@ cast_target ::=
 typename ::=
 	simple_typename opt_array_bounds
 	| simple_typename 'ARRAY'
-	| postgres_oid
 
 collation_name ::=
 	unrestricted_name
@@ -1496,17 +1495,11 @@ simple_typename ::=
 	| bit_with_length
 	| character_with_length
 	| const_interval
+	| postgres_oid
 
 opt_array_bounds ::=
 	'[' ']'
 	| 
-
-postgres_oid ::=
-	'REGPROC'
-	| 'REGPROCEDURE'
-	| 'REGCLASS'
-	| 'REGTYPE'
-	| 'REGNAMESPACE'
 
 expr_tuple1_ambiguous ::=
 	'(' ')'
@@ -1852,6 +1845,13 @@ character_with_length ::=
 
 const_interval ::=
 	'INTERVAL'
+
+postgres_oid ::=
+	'REGPROC'
+	| 'REGPROCEDURE'
+	| 'REGCLASS'
+	| 'REGTYPE'
+	| 'REGNAMESPACE'
 
 tuple1_ambiguous_values ::=
 	a_expr

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -313,3 +313,9 @@ SELECT proargtypes::REGTYPE[] FROM pg_proc WHERE proname = 'obj_description'
 ----
 {oid}
 {oid,text}
+
+# Ensure that you can get a regtype for the trigger type.
+query I
+SELECT 'trigger'::REGTYPE::INT
+----
+-1

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -306,3 +306,10 @@ query OO
 VALUES ('pg_constraint'::REGCLASS, 'pg_catalog.pg_constraint'::REGCLASS)
 ----
 pg_constraint  pg_constraint
+
+# Ensure that arrays of reg* types work okay.
+query T
+SELECT proargtypes::REGTYPE[] FROM pg_proc WHERE proname = 'obj_description'
+----
+{oid}
+{oid,text}

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -6751,10 +6751,6 @@ typename:
       return setErr(sqllex, err)
     }
   }
-| postgres_oid
-  {
-    $$.val = $1.colType()
-  }
 
 cast_target:
   typename
@@ -6790,6 +6786,7 @@ simple_typename:
 | const_interval
 | const_interval interval_qualifier { return unimplemented(sqllex, "interval with unit qualifier") }
 | const_interval '(' ICONST ')' { return unimplementedWithIssue(sqllex, 32564) }
+| postgres_oid
 
 // We have a separate const_typename to allow defaulting fixed-length types
 // such as CHAR() and BIT() to an unspecified length. SQL9x requires that these

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3638,7 +3638,29 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 				// every postgres type that we understand OIDs for.
 				// Trim type modifiers, e.g. `numeric(10,3)` becomes `numeric`.
 				s = pgSignatureRegexp.ReplaceAllString(s, "$1")
-				return queryOid(ctx, t, NewDString(s))
+				dOid, missingTypeErr := queryOid(ctx, t, NewDString(s))
+				if missingTypeErr == nil {
+					return dOid, missingTypeErr
+				}
+				// Fall back to some special cases that we support for compatibility
+				// only. Client use syntax like 'sometype'::regtype to produce the oid
+				// for a type that they want to search a catalog table for. Since we
+				// don't support that type, we return an artificial OID that will never
+				// match anything.
+				switch s {
+				// We don't support triggers, but some tools search for them
+				// specifically.
+				case "trigger":
+				default:
+					return nil, missingTypeErr
+				}
+				return &DOid{
+					semanticType: t,
+					// Types we don't support get OID -1, so they won't match anything
+					// in catalogs.
+					DInt: -1,
+					name: s,
+				}, nil
 
 			case oid.T_regclass:
 				tn, err := ctx.Planner.ParseQualifiedTableName(ctx.Ctx(), origS)


### PR DESCRIPTION
```
sql: add syntax for arrays of oid wrapper types

Previously, syntax for the special oid wrapper types (like REGCLASS,
REGTYPE, and so on) was not available, despite the backend being able to
handle these types just fine.

This commit adds syntax for this (e.g. `select t::regclass[]`) to the
parser and hooks it up to the type system.
```

```
tree: add support for REGTYPE casts of the trigger type
```

Release note (sql change): support the syntax for oid wrapper arrays, like REGCLASS[], and REGTYPE casts for the unsupported `trigger` type.
Release justification: low risk, cosmetic compatibility improvement.
