### PR TITLE
backup: add wait to flaky test

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1893,6 +1893,13 @@ func TestBackupRestoreWithConcurrentWrites(t *testing.T) {
 	sqlDB.Exec(t, `RESTORE data.* FROM $1`, localFoo)
 	atomic.StoreInt32(&allowErrors, 0)
 
+	// TODO(pbardea): Without this wait we see this test flake under stress.
+	// See #40951 for the tracking issue.
+	testutils.SucceedsSoon(t, func() error {
+		_, err := tc.Conns[0].Exec("SELECT * FROM data.bank LIMIT 1")
+		return err
+	})
+
 	bad := sqlDB.QueryStr(t, `SELECT id, balance, payload FROM data.bank WHERE id != balance`)
 	for _, r := range bad {
 		t.Errorf("bad row ID %s = bal %s (payload: %q)", r[0], r[1], r[2])


### PR DESCRIPTION
This test has been flaky because the TableDescriptor being read is being
seen as OFFLINE. This issue seems to disappear after waiting a bit. This
also happens during IMPORT and this issue was avoided in a similar way
(see #36832).

This should be removed and #40951 is tracking this issue.

Release justification: Work-around for a flaky test.

Release note: None