### PR TITLE
colexec: refactor selection ops template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1494,6 +1494,7 @@ pkg/sql/colexec/rank.eg.go: pkg/sql/colexec/rank_tmpl.go
 pkg/sql/colexec/row_number.eg.go: pkg/sql/colexec/row_number_tmpl.go
 pkg/sql/colexec/rowstovec.eg.go: pkg/sql/colexec/rowstovec_tmpl.go
 pkg/sql/colexec/select_in.eg.go: pkg/sql/colexec/select_in_tmpl.go
+pkg/sql/colexec/selection_ops.eg.go: pkg/sql/colexec/selection_ops_tmpl.go
 pkg/sql/colexec/sort.eg.go: pkg/sql/colexec/sort_tmpl.go
 pkg/sql/colexec/sum_agg.eg.go: pkg/sql/colexec/sum_agg_tmpl.go
 pkg/sql/colexec/tuples_differ.eg.go: pkg/sql/colexec/tuples_differ_tmpl.go

--- a/pkg/sql/colexec/execgen/cmd/execgen/like_ops_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/like_ops_gen.go
@@ -41,9 +41,7 @@ import (
 `
 
 func genLikeOps(wr io.Writer) error {
-	tmpl := template.New("like_sel_ops").Funcs(template.FuncMap{"buildDict": buildDict})
-	var err error
-	tmpl, err = tmpl.Parse(selTemplate)
+	tmpl, err := getSelectionOpsTmpl()
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/colexec/execgen/cmd/execgen/selection_ops_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/selection_ops_gen.go
@@ -12,259 +12,52 @@ package main
 
 import (
 	"io"
+	"io/ioutil"
+	"regexp"
+	"strings"
 	"text/template"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 )
 
-const selTemplate = `
-package colexec
-
-import (
-	"bytes"
-  "context"
-  "math"
-
-	"github.com/cockroachdb/apd"
-	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/typeconv"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/pkg/errors"
-)
-
-{{define "opConstName"}}sel{{.Name}}{{.LTyp}}{{.RTyp}}ConstOp{{end}}
-{{define "opName"}}sel{{.Name}}{{.LTyp}}{{.RTyp}}Op{{end}}
-
-{{define "selConstLoop"}}
-if sel := batch.Selection(); sel != nil {
-	sel = sel[:n]
-	for _, i := range sel {
-		var cmp bool
-		arg := {{.Global.LTyp.Get "col" "int(i)"}}
-		{{(.Global.Assign "cmp" "arg" "p.constArg")}}
-		if cmp {{if .HasNulls}}&& !nulls.NullAt(i) {{end}}{
-			sel[idx] = i
-			idx++
-		}
-	}
-} else {
-	batch.SetSelection(true)
-	sel := batch.Selection()
-	col = {{.Global.LTyp.Slice "col" "0" "int(n)"}}
-	for {{.Global.LTyp.Range "i" "col"}} {
-		var cmp bool
-		arg := {{.Global.LTyp.Get "col" "i"}}
-		{{(.Global.Assign "cmp" "arg" "p.constArg")}}
-		if cmp {{if .HasNulls}}&& !nulls.NullAt(uint16(i)) {{end}}{
-			sel[idx] = uint16(i)
-			idx++
-		}
-	}
-}
-{{end}}
-
-{{define "selLoop"}}
-if sel := batch.Selection(); sel != nil {
-	sel = sel[:n]
-	for _, i := range sel {
-		var cmp bool
-		arg1 := {{.Global.LTyp.Get "col1" "int(i)"}}
-		arg2 := {{.Global.RTyp.Get "col2" "int(i)"}}
-		{{(.Global.Assign "cmp" "arg1" "arg2")}}
-		if cmp {{if .HasNulls}}&& !nulls.NullAt(i) {{end}}{
-			sel[idx] = i
-			idx++
-		}
-	}
-} else {
-	batch.SetSelection(true)
-	sel := batch.Selection()
-	col1 = {{.Global.LTyp.Slice "col1" "0" "int(n)"}}
-	col1Len := {{.Global.LTyp.Len "col1"}}
-	col2 = {{.Global.RTyp.Slice "col2" "0" "col1Len"}}
-	for {{.Global.LTyp.Range "i" "col1"}} {
-		var cmp bool
-		arg1 := {{.Global.LTyp.Get "col1" "i"}}
-		arg2 := {{.Global.RTyp.Get "col2" "i"}}
-		{{(.Global.Assign "cmp" "arg1" "arg2")}}
-		if cmp {{if .HasNulls}}&& !nulls.NullAt(uint16(i)) {{end}}{
-			sel[idx] = uint16(i)
-			idx++
-		}
-	}
-}
-{{end}}
-
-{{define "selConstOp"}}
-type {{template "opConstName" .}} struct {
-  selConstOpBase
-	constArg {{.RGoType}}
-}
-
-func (p *{{template "opConstName" .}}) Next(ctx context.Context) coldata.Batch {
-	for {
-		batch := p.input.Next(ctx)
-		if batch.Length() == 0 {
-			return batch
-		}
-
-		vec := batch.ColVec(p.colIdx)
-		col := vec.{{.LTyp}}()
-		var idx uint16
-		n := batch.Length()
-		if vec.MaybeHasNulls() {
-			nulls := vec.Nulls()
-			{{template "selConstLoop" buildDict "Global" . "HasNulls" true }}
-		} else {
-			{{template "selConstLoop" buildDict "Global" . "HasNulls" false }}
-		}
-		if idx > 0 {
-			batch.SetLength(idx)
-			return batch
-		}
-	}
-}
-
-func (p {{template "opConstName" .}}) Init() {
-	p.input.Init()
-}
-{{end}}
-
-{{define "selOp"}}
-type {{template "opName" .}} struct {
-  selOpBase
-}
-
-func (p *{{template "opName" .}}) Next(ctx context.Context) coldata.Batch {
-	for {
-		batch := p.input.Next(ctx)
-		if batch.Length() == 0 {
-			return batch
-		}
-
-		vec1 := batch.ColVec(p.col1Idx)
-		vec2 := batch.ColVec(p.col2Idx)
-		col1 := vec1.{{.LTyp}}()
-		col2 := vec2.{{.RTyp}}()
-		n := batch.Length()
-
-		var idx uint16
-		if vec1.MaybeHasNulls() || vec2.MaybeHasNulls() {
-			nulls := vec1.Nulls().Or(vec2.Nulls())
-			{{template "selLoop" buildDict "Global" . "HasNulls" true }}
-		} else {
-			{{template "selLoop" buildDict "Global" . "HasNulls" false }}
-		}
-		if idx > 0 {
-			batch.SetLength(idx)
-			return batch
-		}
-	}
-}
-
-func (p {{template "opName" .}}) Init() {
-	p.input.Init()
-}
-{{end}}
-
-{{/* The outer range is a coltypes.T (the left type). The middle range is also a
-     coltypes.T (the right type). The inner is the overloads associated with
-     those two types. */}}
-{{range .}}
-{{range .}}
-{{range .}}
-{{template "selConstOp" .}}
-{{template "selOp" .}}
-{{end}}
-{{end}}
-{{end}}
-
-// GetSelectionConstOperator returns the appropriate constant selection operator
-// for the given left and right column types and comparison.
-func GetSelectionConstOperator(
-  leftColType *types.T,
-  constColType *types.T,
-	cmpOp tree.ComparisonOperator,
-	input Operator,
-	colIdx int,
-	constArg tree.Datum,
-) (Operator, error) {
-	c, err := typeconv.GetDatumToPhysicalFn(constColType)(constArg)
+func getSelectionOpsTmpl() (*template.Template, error) {
+	t, err := ioutil.ReadFile("pkg/sql/colexec/selection_ops_tmpl.go")
 	if err != nil {
 		return nil, err
 	}
-  selConstOpBase := selConstOpBase {
-		OneInputNode: NewOneInputNode(input),
-		colIdx: colIdx,
-  }
-	switch leftType := typeconv.FromColumnType(leftColType); leftType {
-	{{range $lTyp, $rTypToOverloads := . -}}
-	case coltypes.{{$lTyp}}:
-		switch rightType := typeconv.FromColumnType(constColType); rightType {
-		{{range $rTyp, $overloads := $rTypToOverloads}}
-		case coltypes.{{$rTyp}}:
-			switch cmpOp {
-			{{range $overloads -}}
-			case tree.{{.Name}}:
-				return &{{template "opConstName" .}}{selConstOpBase: selConstOpBase, constArg: c.({{.RGoType}})}, nil
-			{{end -}}
-			default:
-				return nil, errors.Errorf("unhandled comparison operator: %s", cmpOp)
-			}
-		{{end -}}
-		default:
-			return nil, errors.Errorf("unhandled right type: %s", rightType)
-		}
-	{{end -}}
-	default:
-		return nil, errors.Errorf("unhandled left type: %s", leftType)
-	}
-}
 
-// GetSelectionOperator returns the appropriate two column selection operator
-// for the given left and right column types and comparison.
-func GetSelectionOperator(
-  leftColType *types.T,
-  rightColType *types.T,
-	cmpOp tree.ComparisonOperator,
-	input Operator,
-	col1Idx int,
-	col2Idx int,
-) (Operator, error) {
-  selOpBase := selOpBase {
-		OneInputNode: NewOneInputNode(input),
-		col1Idx: col1Idx,
-		col2Idx: col2Idx,
-  }
-	switch leftType := typeconv.FromColumnType(leftColType); leftType {
-	{{range $lTyp, $rTypToOverloads := . -}}
-	case coltypes.{{$lTyp}}:
-		switch rightType := typeconv.FromColumnType(rightColType); rightType {
-		{{range $rTyp, $overloads := $rTypToOverloads}}
-		case coltypes.{{$rTyp}}:
-			switch cmpOp {
-			{{range $overloads -}}
-			case tree.{{.Name}}:
-				return &{{template "opName" .}}{selOpBase: selOpBase}, nil
-			{{end -}}
-			default:
-				return nil, errors.Errorf("unhandled comparison operator: %s", cmpOp)
-			}
-		{{end -}}
-		default:
-			return nil, errors.Errorf("unhandled right type: %s", rightType)
-		}
-	{{end -}}
-	default:
-		return nil, errors.Errorf("unhandled left type: %s", leftType)
-	}
+	s := string(t)
+	s = strings.Replace(s, "_OP_CONST_NAME", "sel{{.Name}}{{.LTyp}}{{.RTyp}}ConstOp", -1)
+	s = strings.Replace(s, "_OP_NAME", "sel{{.Name}}{{.LTyp}}{{.RTyp}}Op", -1)
+	s = strings.Replace(s, "_R_GO_TYPE", "{{.RGoType}}", -1)
+	s = strings.Replace(s, "_L_TYP_VAR", "{{$lTyp}}", -1)
+	s = strings.Replace(s, "_R_TYP_VAR", "{{$rTyp}}", -1)
+	s = strings.Replace(s, "_L_TYP", "{{.LTyp}}", -1)
+	s = strings.Replace(s, "_R_TYP", "{{.RTyp}}", -1)
+	s = strings.Replace(s, "_NAME", "{{.Name}}", -1)
+
+	assignCmpRe := regexp.MustCompile(`_ASSIGN_CMP\((.*),(.*),(.*)\)`)
+	s = assignCmpRe.ReplaceAllString(s, "{{.Assign $1 $2 $3}}")
+
+	s = replaceManipulationFuncs(".LTyp", s)
+	s = strings.Replace(s, "_R_UNSAFEGET", "execgen.UNSAFEGET", -1)
+	s = strings.Replace(s, "_R_SLICE", "execgen.SLICE", -1)
+	s = replaceManipulationFuncs(".RTyp", s)
+
+	s = strings.Replace(s, "_HAS_NULLS", "$hasNulls", -1)
+	selConstLoop := makeFunctionRegex("_SEL_CONST_LOOP", 1)
+	s = selConstLoop.ReplaceAllString(s, `{{template "selConstLoop" buildDict "Global" $ "HasNulls" $1 "Overload" .}}`)
+	selLoop := makeFunctionRegex("_SEL_LOOP", 1)
+	s = selLoop.ReplaceAllString(s, `{{template "selLoop" buildDict "Global" $ "HasNulls" $1 "Overload" .}}`)
+
+	return template.New("selection_ops").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)
 }
-`
 
 func genSelectionOps(wr io.Writer) error {
+	tmpl, err := getSelectionOpsTmpl()
+	if err != nil {
+		return err
+	}
 	lTypToRTypToOverloads := make(map[coltypes.T]map[coltypes.T][]*overload)
 	for _, ov := range comparisonOpOverloads {
 		lTyp := ov.LTyp
@@ -275,12 +68,6 @@ func genSelectionOps(wr io.Writer) error {
 			lTypToRTypToOverloads[lTyp] = rTypToOverloads
 		}
 		rTypToOverloads[rTyp] = append(rTypToOverloads[rTyp], ov)
-	}
-	tmpl := template.New("selection_ops").Funcs(template.FuncMap{"buildDict": buildDict})
-	var err error
-	tmpl, err = tmpl.Parse(selTemplate)
-	if err != nil {
-		return err
 	}
 	return tmpl.Execute(wr, lTypToRTypToOverloads)
 }

--- a/pkg/sql/colexec/selection_ops_tmpl.go
+++ b/pkg/sql/colexec/selection_ops_tmpl.go
@@ -1,0 +1,327 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// {{/*
+// +build execgen_template
+//
+// This file is the execgen template for selection_ops.eg.go. It's formatted in
+// a special way, so it's both valid Go and a valid text/template input. This
+// permits editing this file with editor support.
+//
+// */}}
+
+package colexec
+
+import (
+	"bytes"
+	"context"
+	"math"
+
+	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
+	// {{/*
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
+	// */}}
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/typeconv"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/pkg/errors"
+)
+
+// {{/*
+// Declarations to make the template compile properly.
+
+// Dummy import to pull in "bytes" package.
+var _ bytes.Buffer
+
+// Dummy import to pull in "apd" package.
+var _ apd.Decimal
+
+// Dummy import to pull in "tree" package.
+var _ tree.Datum
+
+// Dummy import to pull in "math" package.
+var _ = math.MaxInt64
+
+// Dummy import to pull in "coltypes" package.
+var _ = coltypes.Bool
+
+// _ASSIGN_CMP is the template function for assigning the result of comparing
+// the second input to the third input into the first input.
+func _ASSIGN_CMP(_, _, _ interface{}) uint64 {
+	execerror.VectorizedInternalPanic("")
+}
+
+// */}}
+
+// {{/*
+func _SEL_CONST_LOOP(_HAS_NULLS bool) { // */}}
+	// {{define "selConstLoop" -}}
+	// {{$hasNulls := $.HasNulls}}
+	// {{with $.Overload}}
+	if sel := batch.Selection(); sel != nil {
+		sel = sel[:n]
+		for _, i := range sel {
+			var cmp bool
+			arg := execgen.UNSAFEGET(col, int(i))
+			_ASSIGN_CMP("cmp", "arg", "p.constArg")
+			// {{if _HAS_NULLS}}
+			isNull := nulls.NullAt(i)
+			// {{else}}
+			isNull := false
+			// {{end}}
+			if cmp && !isNull {
+				sel[idx] = i
+				idx++
+			}
+		}
+	} else {
+		batch.SetSelection(true)
+		sel := batch.Selection()
+		col = execgen.SLICE(col, 0, int(n))
+		for execgen.RANGE(i, col) {
+			var cmp bool
+			arg := execgen.UNSAFEGET(col, i)
+			_ASSIGN_CMP("cmp", "arg", "p.constArg")
+			// {{if _HAS_NULLS}}
+			isNull := nulls.NullAt(uint16(i))
+			// {{else}}
+			isNull := false
+			// {{end}}
+			if cmp && !isNull {
+				sel[idx] = uint16(i)
+				idx++
+			}
+		}
+	}
+	// {{end}}
+	// {{end}}
+	// {{/*
+} // */}}
+
+// {{/*
+func _SEL_LOOP(_HAS_NULLS bool) { // */}}
+	// {{define "selLoop" -}}
+	// {{$hasNulls := $.HasNulls}}
+	// {{with $.Overload}}
+	if sel := batch.Selection(); sel != nil {
+		sel = sel[:n]
+		for _, i := range sel {
+			var cmp bool
+			arg1 := execgen.UNSAFEGET(col1, int(i))
+			arg2 := _R_UNSAFEGET(col2, int(i))
+			_ASSIGN_CMP("cmp", "arg1", "arg2")
+			// {{if _HAS_NULLS}}
+			isNull := nulls.NullAt(i)
+			// {{else}}
+			isNull := false
+			// {{end}}
+			if cmp && !isNull {
+				sel[idx] = i
+				idx++
+			}
+		}
+	} else {
+		batch.SetSelection(true)
+		sel := batch.Selection()
+		col1 = execgen.SLICE(col1, 0, int(n))
+		col1Len := execgen.LEN(col1)
+		col2 = _R_SLICE(col2, 0, col1Len)
+		for execgen.RANGE(i, col1) {
+			var cmp bool
+			arg1 := execgen.UNSAFEGET(col1, i)
+			arg2 := _R_UNSAFEGET(col2, i)
+			_ASSIGN_CMP("cmp", "arg1", "arg2")
+			// {{if _HAS_NULLS}}
+			isNull := nulls.NullAt(uint16(i))
+			// {{else}}
+			isNull := false
+			// {{end}}
+			if cmp && !isNull {
+				sel[idx] = uint16(i)
+				idx++
+			}
+		}
+	}
+	// {{end}}
+	// {{end}}
+	// {{/*
+} // */}}
+
+// {{define "selConstOp"}}
+type _OP_CONST_NAME struct {
+	selConstOpBase
+	constArg _R_GO_TYPE
+}
+
+func (p *_OP_CONST_NAME) Next(ctx context.Context) coldata.Batch {
+	for {
+		batch := p.input.Next(ctx)
+		if batch.Length() == 0 {
+			return batch
+		}
+
+		vec := batch.ColVec(p.colIdx)
+		col := vec._L_TYP()
+		var idx uint16
+		n := batch.Length()
+		if vec.MaybeHasNulls() {
+			nulls := vec.Nulls()
+			_SEL_CONST_LOOP(true)
+		} else {
+			_SEL_CONST_LOOP(false)
+		}
+		if idx > 0 {
+			batch.SetLength(idx)
+			return batch
+		}
+	}
+}
+
+func (p *_OP_CONST_NAME) Init() {
+	p.input.Init()
+}
+
+// {{end}}
+
+// {{define "selOp"}}
+type _OP_NAME struct {
+	selOpBase
+}
+
+func (p *_OP_NAME) Next(ctx context.Context) coldata.Batch {
+	for {
+		batch := p.input.Next(ctx)
+		if batch.Length() == 0 {
+			return batch
+		}
+
+		vec1 := batch.ColVec(p.col1Idx)
+		vec2 := batch.ColVec(p.col2Idx)
+		col1 := vec1._L_TYP()
+		col2 := vec2._R_TYP()
+		n := batch.Length()
+
+		var idx uint16
+		if vec1.MaybeHasNulls() || vec2.MaybeHasNulls() {
+			nulls := vec1.Nulls().Or(vec2.Nulls())
+			_SEL_LOOP(true)
+		} else {
+			_SEL_LOOP(false)
+		}
+		if idx > 0 {
+			batch.SetLength(idx)
+			return batch
+		}
+	}
+}
+
+func (p *_OP_NAME) Init() {
+	p.input.Init()
+}
+
+// {{end}}
+
+// {{/*
+// The outer range is a coltypes.T (the left type). The middle range is also a
+// coltypes.T (the right type). The inner is the overloads associated with
+// those two types.
+// */}}
+// {{range .}}
+// {{range .}}
+// {{range .}}
+// {{template "selConstOp" .}}
+// {{template "selOp" .}}
+// {{end}}
+// {{end}}
+// {{end}}
+
+// GetSelectionConstOperator returns the appropriate constant selection operator
+// for the given left and right column types and comparison.
+func GetSelectionConstOperator(
+	leftColType *types.T,
+	constColType *types.T,
+	cmpOp tree.ComparisonOperator,
+	input Operator,
+	colIdx int,
+	constArg tree.Datum,
+) (Operator, error) {
+	c, err := typeconv.GetDatumToPhysicalFn(constColType)(constArg)
+	if err != nil {
+		return nil, err
+	}
+	selConstOpBase := selConstOpBase{
+		OneInputNode: NewOneInputNode(input),
+		colIdx:       colIdx,
+	}
+	switch leftType := typeconv.FromColumnType(leftColType); leftType {
+	// {{range $lTyp, $rTypToOverloads := .}}
+	case coltypes._L_TYP_VAR:
+		switch rightType := typeconv.FromColumnType(constColType); rightType {
+		// {{range $rTyp, $overloads := $rTypToOverloads}}
+		case coltypes._R_TYP_VAR:
+			switch cmpOp {
+			// {{range $overloads}}
+			case tree._NAME:
+				return &_OP_CONST_NAME{selConstOpBase: selConstOpBase, constArg: c.(_R_GO_TYPE)}, nil
+				// {{end}}
+			default:
+				return nil, errors.Errorf("unhandled comparison operator: %s", cmpOp)
+			}
+			// {{end}}
+		default:
+			return nil, errors.Errorf("unhandled right type: %s", rightType)
+		}
+		// {{end}}
+	default:
+		return nil, errors.Errorf("unhandled left type: %s", leftType)
+	}
+}
+
+// GetSelectionOperator returns the appropriate two column selection operator
+// for the given left and right column types and comparison.
+func GetSelectionOperator(
+	leftColType *types.T,
+	rightColType *types.T,
+	cmpOp tree.ComparisonOperator,
+	input Operator,
+	col1Idx int,
+	col2Idx int,
+) (Operator, error) {
+	selOpBase := selOpBase{
+		OneInputNode: NewOneInputNode(input),
+		col1Idx:      col1Idx,
+		col2Idx:      col2Idx,
+	}
+	switch leftType := typeconv.FromColumnType(leftColType); leftType {
+	// {{range $lTyp, $rTypToOverloads := .}}
+	case coltypes._L_TYP_VAR:
+		switch rightType := typeconv.FromColumnType(rightColType); rightType {
+		// {{range $rTyp, $overloads := $rTypToOverloads}}
+		case coltypes._R_TYP_VAR:
+			switch cmpOp {
+			// {{range $overloads}}
+			case tree._NAME:
+				return &_OP_NAME{selOpBase: selOpBase}, nil
+				// {{end }}
+			default:
+				return nil, errors.Errorf("unhandled comparison operator: %s", cmpOp)
+			}
+			// {{end}}
+		default:
+			return nil, errors.Errorf("unhandled right type: %s", rightType)
+		}
+		// {{end}}
+	default:
+		return nil, errors.Errorf("unhandled left type: %s", leftType)
+	}
+}


### PR DESCRIPTION
Selection ops template similarly to projection ops template
pre-dates our current way of using templates. This commit brings it
in line with others.

Release justification: Category 1: Non-production code changes.

Release note: None