### PR TITLE
sql: fix behavior of SERIAL columns on mixed-case tables

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/serial
+++ b/pkg/sql/logictest/testdata/logic_test/serial
@@ -223,6 +223,26 @@ SELECT count(DISTINCT a), count(DISTINCT b), count(DISTINCT c) FROM serial
 ----
 4  3  4
 
+statement ok
+CREATE TABLE "serial_MixedCase" (
+  a SERIAL PRIMARY KEY,
+  b INT DEFAULT 7,
+  c SERIAL,
+  UNIQUE INDEX (c)
+)
+
+query TT
+SHOW CREATE TABLE "serial_MixedCase"
+----
+"serial_MixedCase"  CREATE TABLE "serial_MixedCase" (
+                    a INT8 NOT NULL DEFAULT nextval('"serial_MixedCase_a_seq"':::STRING),
+                    b INT8 NULL DEFAULT 7:::INT8,
+                    c INT8 NOT NULL DEFAULT nextval('"serial_MixedCase_c_seq"':::STRING),
+                    CONSTRAINT "primary" PRIMARY KEY (a ASC),
+                    UNIQUE INDEX "serial_MixedCase_c_key" (c ASC),
+                    FAMILY "primary" (a, b, c)
+)
+
 statement error multiple default values specified for column "a" of table "s1"
 CREATE TABLE s1 (a SERIAL DEFAULT 7)
 

--- a/pkg/sql/serial.go
+++ b/pkg/sql/serial.go
@@ -132,7 +132,7 @@ func (p *planner) processSerialInColumnDef(
 
 	defaultExpr := &tree.FuncExpr{
 		Func:  tree.WrapFunction("nextval"),
-		Exprs: tree.Exprs{tree.NewStrVal(seqName.Table())},
+		Exprs: tree.Exprs{tree.NewStrVal(seqName.String())},
 	}
 
 	seqType := ""


### PR DESCRIPTION
Closes #40964.

When `experimental_serial_normalization` is set to `sql_sequence`, there
was previously an issue with mixed-case tables - the created sequence
wouldn't be quoted properly. This fixes the issue.

Release note (sql change): fix behavior of SERIAL columns on mixed-case
tables when experimental_serial_normalization=sql_sequence.
Release justification: low-risk bugfix.