### PR TITLE
ui: fix mixed units in tooltips

### DIFF
--- a/pkg/ui/src/util/format.spec.ts
+++ b/pkg/ui/src/util/format.spec.ts
@@ -1,0 +1,47 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { assert } from "chai";
+import { DurationFitScale, durationUnits, BytesFitScale, byteUnits } from "./format";
+
+describe("Format utils", () => {
+
+  describe("DurationFitScale", () => {
+    it("converts nanoseconds to provided units", () => {
+      // test zero values
+      assert.equal(DurationFitScale(durationUnits[0], undefined), "0.00 ns");
+      assert.equal(DurationFitScale(durationUnits[0], 0), "0.00 ns");
+      // "ns", "µs", "ms", "s"
+      assert.equal(DurationFitScale(durationUnits[0], 32), "32.00 ns");
+      assert.equal(DurationFitScale(durationUnits[1], 32120), "32.12 µs");
+      assert.equal(DurationFitScale(durationUnits[2], 32122300), "32.12 ms");
+      assert.equal(DurationFitScale(durationUnits[3], 32122343000), "32.12 s");
+    });
+  });
+
+  describe("BytesFitScale", () => {
+    it("converts bytes to provided units", () => {
+      // test zero values
+      assert.equal(BytesFitScale(byteUnits[0], undefined), "0.00 B");
+      assert.equal(BytesFitScale(byteUnits[0], 0), "0.00 B");
+      // "B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"
+      assert.equal(BytesFitScale(byteUnits[0], 1), "1.00 B");
+      assert.equal(BytesFitScale(byteUnits[1], 10240), "10.00 KiB");
+      assert.equal(BytesFitScale(byteUnits[2], 12582912), "12.00 MiB");
+      assert.equal(BytesFitScale(byteUnits[3], 12884901888), "12.00 GiB");
+      assert.equal(BytesFitScale(byteUnits[4], 1.319414e+13), "12.00 TiB");
+      assert.equal(BytesFitScale(byteUnits[5], 1.3510799e+16), "12.00 PiB");
+      assert.equal(BytesFitScale(byteUnits[6], 1.3835058e+19), "12.00 EiB");
+      assert.equal(BytesFitScale(byteUnits[7], 1.4167099e+22), "12.00 ZiB");
+      assert.equal(BytesFitScale(byteUnits[8], 1.450711e+25), "12.00 YiB");
+    });
+  });
+
+});

--- a/pkg/ui/src/util/format.ts
+++ b/pkg/ui/src/util/format.ts
@@ -9,8 +9,8 @@
 // licenses/APL.txt.
 
 export const kibi = 1024;
-const byteUnits: string[] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"];
-const durationUnits: string[] = ["ns", "µs", "ms", "s"];
+export const byteUnits: string[] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"];
+export const durationUnits: string[] = ["ns", "µs", "ms", "s"];
 
 interface UnitValue {
   value: number;
@@ -81,6 +81,17 @@ export function BytesWithPrecision(bytes: number, precision: number): string {
 }
 
 /**
+ * Cast bytes to provided scale units
+ */
+export function BytesFitScale(scale: string, bytes: number): string {
+  if (!bytes) {
+    return `0.00 ${scale}`;
+  }
+  const n = byteUnits.indexOf(scale);
+  return `${(bytes / Math.pow(kibi, n)).toFixed(2)} ${scale}`;
+}
+
+/**
  * Percentage creates a string representation of a fraction as a percentage.
  */
 export function Percentage(numerator: number, denominator: number): string {
@@ -111,4 +122,15 @@ export function Duration(nanoseconds: number): string {
   const scale = ComputeDurationScale(nanoseconds);
   const unitVal = nanoseconds / scale.value;
   return unitVal.toFixed(1) + " " + scale.units;
+}
+
+/**
+ * Cast nanonseconds to provided scale units
+ */
+export function DurationFitScale(scale: string, nanoseconds: number): string {
+  if (!nanoseconds) {
+    return `0.00 ${scale}`;
+  }
+  const n = durationUnits.indexOf(scale) ;
+  return `${(nanoseconds / Math.pow(1000, n)).toFixed(2)} ${scale}`;
 }

--- a/pkg/ui/src/views/cluster/util/graphs.ts
+++ b/pkg/ui/src/views/cluster/util/graphs.ts
@@ -16,7 +16,7 @@ import moment from "moment";
 
 import * as protos from "src/js/protos";
 import { NanoToMilli } from "src/util/convert";
-import { Bytes, ComputeByteScale, ComputeDurationScale, Duration } from "src/util/format";
+import { ComputeByteScale, ComputeDurationScale, DurationFitScale, BytesFitScale } from "src/util/format";
 
 import {
   MetricProps, AxisProps, AxisUnits, QueryTimeInfo,
@@ -172,7 +172,7 @@ function ComputeByteAxisDomain(extent: Extent): AxisDomain {
 
   axisDomain.label = scale.units;
 
-  axisDomain.guideFormat = Bytes;
+  axisDomain.guideFormat = BytesFitScale.bind(null, scale.units);
   return axisDomain;
 }
 
@@ -184,7 +184,7 @@ function ComputeDurationAxisDomain(extent: Extent): AxisDomain {
 
   axisDomain.label = scale.units;
 
-  axisDomain.guideFormat = Duration;
+  axisDomain.guideFormat = DurationFitScale.bind(null, scale.units);
   return axisDomain;
 }
 


### PR DESCRIPTION
We already calculate biggest scale for chart axis label, so I take that and cast values in chart tooltips to fit chart scale. So tooltips will show consistent units, matching the biggest unit type in data set and axis label. And also has 2 numbers after dot for better readability. This was done for duration and bytes units.

Resolves: #35467

Release note (ui): consistent units in chart tooltips

result:
![Screen Shot 2019-09-23 at 6 11 50 PM](https://user-images.githubusercontent.com/12850886/65438206-c2868080-de2d-11e9-9058-be07dee2c86a.png)

