### PR TITLE
colexec: drain Columnarizer's inputs

### DIFF
--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -130,8 +130,13 @@ var _ execinfrapb.MetadataSource = &Columnarizer{}
 
 // DrainMeta is part of the MetadataSource interface.
 func (c *Columnarizer) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
-	if src, ok := c.input.(execinfrapb.MetadataSource); ok {
-		c.accumulatedMeta = append(c.accumulatedMeta, src.DrainMeta(ctx)...)
+	c.MoveToDraining(nil /* err */)
+	for {
+		meta := c.DrainHelper()
+		if meta == nil {
+			break
+		}
+		c.accumulatedMeta = append(c.accumulatedMeta, *meta)
 	}
 	return c.accumulatedMeta
 }


### PR DESCRIPTION
The Columnarizer would previously drain its input by checking whether it
implemented the DrainMeta interface and accumulated upstream metadata if
so. However, since the Columnarizer is part of a rowexec flow, it must
also either call ConsumerDone or ConsumerClosed on its input when it
knows that no more rows will be requested.

This patch changes the Columnarizer's DrainMeta behavior to follow that
of all rowexec processors: MoveToDraining and then call DrainHelper
until nil, nil is returned, which takes care of input state transitions.

Release note: None

Release justification: Category 2 bug fix, any vectorized queries that use
a wrapped RowSource (e.g. a joinReader) and encounters an error, would be
unable to drain properly.

Addresses #40621 