### PR TITLE
opt: disallow mutations under union

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -286,3 +286,28 @@ SELECT a FROM (SELECT a FROM c UNION ALL SELECT a FROM a) WHERE a > 0 AND a < 3
 ----
 1
 1
+
+# Ensure that mutations under a UNION or UNION ALL error out (#40853).
+statement error mutations not supported under UNION
+SELECT * FROM uniontest
+UNION SELECT * FROM [INSERT INTO uniontest VALUES (1), (1) RETURNING k, v]
+
+statement error mutations not supported under UNION
+SELECT * FROM [INSERT INTO uniontest VALUES (1), (1) RETURNING k, v]
+UNION ALL SELECT * FROM uniontest
+
+statement error mutations not supported under UNION
+SELECT * FROM uniontest
+UNION SELECT * FROM (
+  WITH cte AS (INSERT INTO uniontest VALUES (1), (1) RETURNING k, v) SELECT * FROM cte
+)
+
+# The right way to run such a query is to use WITH above the union.
+statement ok
+WITH cte AS (INSERT INTO uniontest VALUES (1), (1) RETURNING k, v)
+(SELECT * FROM cte UNION SELECT * FROM uniontest)
+
+# Other set ops are allowed.
+statement ok
+SELECT * FROM uniontest
+EXCEPT SELECT * FROM [INSERT INTO uniontest VALUES (1), (1) RETURNING k, v]

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -373,12 +373,13 @@ upsert INTO upsert_returning VALUES (1, 5, 4, 3), (6, 5, 4, 3) RETURNING *
 statement ok
 COMMIT
 
-# For #22300. Test UPSERT ... RETURNING with UNION.
-query I rowsort
-SELECT a FROM [UPSERT INTO upsert_returning VALUES (7) RETURNING a] UNION VALUES (8)
-----
-7
-8
+# TODO(justin): reenable when we fix #35060 / #40853.
+## For #22300. Test UPSERT ... RETURNING with UNION.
+#query I rowsort
+#SELECT a FROM [UPSERT INTO upsert_returning VALUES (7) RETURNING a] UNION VALUES (8)
+#----
+#7
+#8
 
 # For #6710. Add an unused column to disable the fast path which doesn't have this bug.
 statement ok

--- a/pkg/sql/opt/memo/testdata/logprops/with
+++ b/pkg/sql/opt/memo/testdata/logprops/with
@@ -9,7 +9,6 @@ with &1 (foo)
  ├── columns: x:3(int!null) y:4(int)
  ├── key: (3)
  ├── fd: (3)-->(4)
- ├── cte-uses: map[1:1]
  ├── scan xy
  │    ├── columns: xy.x:1(int!null) xy.y:2(int)
  │    ├── key: (1)
@@ -70,7 +69,6 @@ with &1 (foo)
  ├── side-effects
  ├── key: ()
  ├── fd: ()-->(3)
- ├── cte-uses: map[1:1]
  ├── project
  │    ├── columns: "?column?":1(int!null)
  │    ├── cardinality: [1 - 1]
@@ -113,7 +111,6 @@ with &1 (foo)
  ├── has-placeholder
  ├── key: ()
  ├── fd: ()-->(3)
- ├── cte-uses: map[1:1]
  ├── project
  │    ├── columns: int8:1(int)
  │    ├── cardinality: [1 - 1]
@@ -171,7 +168,6 @@ inner-join-apply
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(3)
- │    ├── cte-uses: map[1:1]
  │    ├── project
  │    │    ├── columns: "?column?":2(int)
  │    │    ├── outer: (1)

--- a/pkg/sql/opt/norm/testdata/rules/with
+++ b/pkg/sql/opt/norm/testdata/rules/with
@@ -6,7 +6,6 @@ with &1 (foo)
  ├── cardinality: [2 - 2]
  ├── stats: [rows=2]
  ├── cost: 0.11
- ├── cte-uses: map[1:2]
  ├── project
  │    ├── columns: "?column?":1(int!null)
  │    ├── cardinality: [1 - 1]
@@ -257,7 +256,6 @@ with &1 (foo)
  ├── cost: 0.25
  ├── key: ()
  ├── fd: ()-->(3-6)
- ├── cte-uses: map[1:2 2:2]
  ├── values
  │    ├── columns: "?column?":1(int!null)
  │    ├── cardinality: [1 - 1]
@@ -425,7 +423,6 @@ with &1 (foo)
       │    ├──  a.s:4(string) => s:14(string)
       │    └──  a.j:5(jsonb) => j:15(jsonb)
       ├── cardinality: [1 - 1]
-      ├── mutations
       ├── key: ()
       └── fd: ()-->(11-15)
 

--- a/pkg/sql/opt/props/logical.go
+++ b/pkg/sql/opt/props/logical.go
@@ -435,6 +435,9 @@ func (s *Shared) Verify() {
 	if s.HasCorrelatedSubquery && !s.HasSubquery {
 		panic(errors.AssertionFailedf("HasSubquery cannot be false if HasCorrelatedSubquery is true"))
 	}
+	if s.CanMutate && !s.CanHaveSideEffects {
+		panic(errors.AssertionFailedf("CanHaveSideEffects cannot be false if CanMutate is true"))
+	}
 }
 
 // Verify runs consistency checks against the relational properties, in order to


### PR DESCRIPTION
#### opt: fix With and WithScan properties

The `With` and `WithScan` property builders start by copying the input
props and then correcting things. This is error-prone: we have in time
identified multiple things that were being incorrectly inherited.

This change rewrites the code to start with empty properties and then
fill things in explicitly (like most other operators). Known problems
that are fixed by this change:
 - `CanMutate` was incorrectly set for `WithScan`
 - Rule props like `PruneCols` and `WithUses` were incorrectly
   inherited by `With`.

Release note: None

#### opt: disallow mutations under union

Because the inputs of a UNION or UNION ALL are run in parallel, it is
not possible for either of them to be mutations. The right way to do
this is to use WITH (above the union). The optimizer will have code to
pull up mutations into top-level WITHs, but until then we want to
disallow such queries from executing. This change adds a check for
this condition in the execbuilder.

Informs #40853.

Release note (sql change): Mutations under UNION or UNION ALL are
disallowed; WITH should be used on top of the union operation instead.

Release justification: low-risk fix for high-severity bug (category
3).