### PR TITLE
sql: require admin role to control jobs

### DIFF
--- a/pkg/sql/control_jobs.go
+++ b/pkg/sql/control_jobs.go
@@ -34,6 +34,9 @@ var jobCommandToDesiredStatus = map[tree.JobCommand]jobs.Status{
 }
 
 func (p *planner) ControlJobs(ctx context.Context, n *tree.ControlJobs) (planNode, error) {
+	if err := p.RequireAdminRole(ctx, n.StatementTag()); err != nil {
+		return nil, err
+	}
 	rows, err := p.newPlan(ctx, n.Jobs, []*types.T{types.Int})
 	if err != nil {
 		return nil, err

--- a/pkg/sql/logictest/testdata/logic_test/run_control
+++ b/pkg/sql/logictest/testdata/logic_test/run_control
@@ -99,3 +99,14 @@ CANCEL SESSION 'aaa'::NAME
 
 query error odd length hex string
 CANCEL QUERY 'aaa'::NAME
+
+user testuser
+
+query error only users with the admin role are allowed to CANCEL JOBS
+CANCEL JOB 1
+
+query error only users with the admin role are allowed to PAUSE JOBS
+PAUSE JOB 1
+
+query error only users with the admin role are allowed to RESUME JOBS
+RESUME JOB 1

--- a/pkg/sql/opt/optbuilder/misc_statements.go
+++ b/pkg/sql/opt/optbuilder/misc_statements.go
@@ -19,6 +19,10 @@ import (
 )
 
 func (b *Builder) buildControlJobs(n *tree.ControlJobs, inScope *scope) (outScope *scope) {
+	if err := b.catalog.RequireAdminRole(b.ctx, n.StatementTag()); err != nil {
+		panic(err)
+	}
+
 	// We don't allow the input statement to reference outer columns, so we
 	// pass a "blank" scope rather than inScope.
 	emptyScope := &scope{builder: b}


### PR DESCRIPTION
Although our docs specify that only admin users can run the CANCEL JOB,
PAUSE JOB, and RESUME JOB commands, this was not enforced. Non-admin
users could not run the SHOW JOBS command, but if they knew the ID of a
job they could modify its status. Having the admin role is now enforced
for all these commands.

Fixes #40916

Release note (bug fix): Users must now have admin privileges to cancel,
pause, or resume jobs.

Release justification: Fix for high priority bug in existing
functionality.