### PR TITLE
sql: enable all configs for union logictest

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -1,7 +1,3 @@
-# TODO(mjibson): The fakedist-disk config produces a panic. When fixed,
-# remove this config line. See #38987.
-# LogicTest: local fakedist fakedist-metadata
-
 query I rowsort
 VALUES (1), (1), (1), (2), (2) UNION VALUES (1), (3), (1)
 ----


### PR DESCRIPTION
There was previously an issue with the fakedist-disk configuration in
this test, but now it passes.

closes #38987

Release justification: Testing-only change.

Release note: None