### PR TITLE
sql: fix lease interaction with offline tables

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1597,7 +1597,7 @@ func TestImportIntoCSV(t *testing.T) {
 			<-importBodyFinished
 
 			err := sqlDB.DB.QueryRowContext(ctx, `SELECT 1 FROM t`).Scan(&unused)
-			if !testutils.IsError(err, "table \"t\" is offline: importing") {
+			if !testutils.IsError(err, "relation \"t\" does not exist") {
 				return err
 			}
 			return nil


### PR DESCRIPTION
This updates the lease management code to handle offline tables the
same way dropped tables are handled. We are not supposed to be able
to acquire a lease on offline tables (as well as dropped tables).

Fixes #40951 and therefore #40361.

Release justification: Fixes test flakes where a table descriptor lease
is being taken on an offline table.

Release note: None