### PR TITLE
colexec: miscellaneous cleanups

### DIFF
--- a/pkg/col/coldata/vec.go
+++ b/pkg/col/coldata/vec.go
@@ -63,16 +63,12 @@ type Vec interface {
 	// TODO(jordan): is a bitmap or slice of bools better?
 	// Bool returns a bool list.
 	Bool() []bool
-	// Int8 returns an int8 slice.
-	Int8() []int8
 	// Int16 returns an int16 slice.
 	Int16() []int16
 	// Int32 returns an int32 slice.
 	Int32() []int32
 	// Int64 returns an int64 slice.
 	Int64() []int64
-	// Float32 returns a float32 slice.
-	Float32() []float32
 	// Float64 returns a float64 slice.
 	Float64() []float64
 	// Bytes returns a flat Bytes representation.
@@ -172,10 +168,6 @@ func (m *memColumn) Bool() []bool {
 	return m.col.([]bool)
 }
 
-func (m *memColumn) Int8() []int8 {
-	return m.col.([]int8)
-}
-
 func (m *memColumn) Int16() []int16 {
 	return m.col.([]int16)
 }
@@ -186,10 +178,6 @@ func (m *memColumn) Int32() []int32 {
 
 func (m *memColumn) Int64() []int64 {
 	return m.col.([]int64)
-}
-
-func (m *memColumn) Float32() []float32 {
-	return m.col.([]float32)
 }
 
 func (m *memColumn) Float64() []float64 {

--- a/pkg/sql/colencoding/key_encoding.go
+++ b/pkg/sql/colencoding/key_encoding.go
@@ -186,8 +186,6 @@ func decodeTableKeyToCol(
 			rkey, i, err = encoding.DecodeVarintDescending(key)
 		}
 		switch valType.Width() {
-		case 8:
-			vec.Int8()[idx] = int8(i)
 		case 16:
 			vec.Int16()[idx] = int16(i)
 		case 32:
@@ -305,8 +303,6 @@ func UnmarshalColumnValueToCol(
 		var v int64
 		v, err = value.GetInt()
 		switch typ.Width() {
-		case 8:
-			vec.Int8()[idx] = int8(v)
 		case 16:
 			vec.Int16()[idx] = int16(v)
 		case 32:

--- a/pkg/sql/colencoding/value_encoding.go
+++ b/pkg/sql/colencoding/value_encoding.go
@@ -73,8 +73,6 @@ func decodeUntaggedDatumToCol(vec coldata.Vec, idx uint16, t *types.T, buf []byt
 		var i int64
 		buf, i, err = encoding.DecodeUntaggedIntValue(buf)
 		switch t.Width() {
-		case 8:
-			vec.Int8()[idx] = int8(i)
 		case 16:
 			vec.Int16()[idx] = int16(i)
 		case 32:

--- a/pkg/sql/colexec/aggregator_test.go
+++ b/pkg/sql/colexec/aggregator_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
@@ -124,6 +125,7 @@ func (tc *aggregatorTestCase) init() error {
 }
 
 func TestAggregatorOneFunc(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testCases := []aggregatorTestCase{
 		{
 			input: tuples{
@@ -307,6 +309,7 @@ func TestAggregatorOneFunc(t *testing.T) {
 }
 
 func TestAggregatorMultiFunc(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testCases := []aggregatorTestCase{
 		{
 			aggFns: []execinfrapb.AggregatorSpec_Func{execinfrapb.AggregatorSpec_SUM, execinfrapb.AggregatorSpec_SUM},
@@ -380,6 +383,7 @@ func TestAggregatorMultiFunc(t *testing.T) {
 }
 
 func TestAggregatorAllFunctions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testCases := []aggregatorTestCase{
 		{
 			aggFns: []execinfrapb.AggregatorSpec_Func{
@@ -462,6 +466,7 @@ func TestAggregatorAllFunctions(t *testing.T) {
 }
 
 func TestAggregatorRandom(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	// This test aggregates random inputs, keeping track of the expected results
 	// to make sure the aggregations are correct.
 	rng, _ := randutil.NewPseudoRand()
@@ -709,6 +714,7 @@ func BenchmarkAggregator(b *testing.B) {
 }
 
 func TestHashAggregator(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	tcs := []aggregatorTestCase{
 		{
 			// Test carry between output batches.

--- a/pkg/sql/colexec/and_test.go
+++ b/pkg/sql/colexec/and_test.go
@@ -14,9 +14,11 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
 func TestAndOp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	tcs := []struct {
 		tuples                []tuple
 		expected              []tuple

--- a/pkg/sql/colexec/bool_vec_to_sel_test.go
+++ b/pkg/sql/colexec/bool_vec_to_sel_test.go
@@ -10,9 +10,14 @@
 
 package colexec
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
 
 func TestBoolVecToSelOp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	tcs := []struct {
 		boolCol  uint32
 		tuples   tuples

--- a/pkg/sql/colexec/builtin_funcs_test.go
+++ b/pkg/sql/colexec/builtin_funcs_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
 // Mock typing context for the typechecker.
@@ -45,6 +46,7 @@ func (p *mockTypeContext) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
 }
 
 func TestBasicBuiltinFunctions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	// Trick to get the init() for the builtins package to run.
 	_ = builtins.AllBuiltinNames
 

--- a/pkg/sql/colexec/cancel_checker_test.go
+++ b/pkg/sql/colexec/cancel_checker_test.go
@@ -18,12 +18,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/stretchr/testify/require"
 )
 
 // TestCancelChecker verifies that CancelChecker panics with appropriate error
 // when the context is canceled.
 func TestCancelChecker(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	ctx, cancel := context.WithCancel(context.Background())
 	batch := coldata.NewMemBatch([]coltypes.T{coltypes.Int64})
 	op := NewCancelChecker(NewNoop(NewRepeatableBatchSource(batch)))

--- a/pkg/sql/colexec/cast_test.go
+++ b/pkg/sql/colexec/cast_test.go
@@ -18,10 +18,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
 func TestRandomizedCast(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 
 	datumAsBool := func(d tree.Datum) interface{} {
 		return bool(tree.MustBeDBool(d))

--- a/pkg/sql/colexec/cfetcher_test.go
+++ b/pkg/sql/colexec/cfetcher_test.go
@@ -13,10 +13,12 @@ package colexec
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCFetcherUninitialized(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	// Regression test for #36570: make sure it's okay to call GetRangesInfo even
 	// before the fetcher was fully initialized.
 	var fetcher cFetcher

--- a/pkg/sql/colexec/coalescer_test.go
+++ b/pkg/sql/colexec/coalescer_test.go
@@ -17,9 +17,11 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
 func TestCoalescer(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	// Large tuple number for coalescing.
 	nRows := int(coldata.BatchSize()*3 + 7)
 	large := make(tuples, nRows)

--- a/pkg/sql/colexec/const_test.go
+++ b/pkg/sql/colexec/const_test.go
@@ -14,9 +14,11 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
 func TestConst(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	tcs := []struct {
 		tuples   tuples
 		expected tuples
@@ -39,6 +41,7 @@ func TestConst(t *testing.T) {
 }
 
 func TestConstNull(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	tcs := []struct {
 		tuples   tuples
 		expected tuples

--- a/pkg/sql/colexec/count_test.go
+++ b/pkg/sql/colexec/count_test.go
@@ -10,9 +10,14 @@
 
 package colexec
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
 
 func TestCount(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	tcs := []struct {
 		tuples   tuples
 		expected tuples

--- a/pkg/sql/colexec/deselector_test.go
+++ b/pkg/sql/colexec/deselector_test.go
@@ -17,10 +17,12 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
 func TestDeselector(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	tcs := []struct {
 		colTypes []coltypes.T
 		tuples   []tuple

--- a/pkg/sql/colexec/distinct_test.go
+++ b/pkg/sql/colexec/distinct_test.go
@@ -17,10 +17,12 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
 func TestSortedDistinct(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	tcs := []struct {
 		distinctCols []uint32
 		colTypes     []coltypes.T

--- a/pkg/sql/colexec/execerror/error.go
+++ b/pkg/sql/colexec/execerror/error.go
@@ -96,7 +96,6 @@ const (
 	colPackagePrefix          = "github.com/cockroachdb/cockroach/pkg/col"
 	colexecPackagePrefix      = "github.com/cockroachdb/cockroach/pkg/sql/colexec"
 	colflowsetupPackagePrefix = "github.com/cockroachdb/cockroach/pkg/sql/colflow"
-	cFetcherPrefix            = "github.com/cockroachdb/cockroach/pkg/sql/row.(*CFetcher)"
 	treePackagePrefix         = "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -115,7 +114,6 @@ func isPanicFromVectorizedEngine(panicEmittedFrom string) bool {
 	return strings.HasPrefix(panicEmittedFrom, colPackagePrefix) ||
 		strings.HasPrefix(panicEmittedFrom, colexecPackagePrefix) ||
 		strings.HasPrefix(panicEmittedFrom, colflowsetupPackagePrefix) ||
-		strings.HasPrefix(panicEmittedFrom, cFetcherPrefix) ||
 		strings.HasPrefix(panicEmittedFrom, treePackagePrefix)
 }
 

--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -855,7 +855,7 @@ func BenchmarkHashJoiner(b *testing.B) {
 // TestHashingDoesNotAllocate ensures that our use of the noescape hack to make
 // sure hashing with unsafe.Pointer doesn't allocate still works correctly.
 func TestHashingDoesNotAllocate(t *testing.T) {
-	defer leaktest.AfterTest(t)
+	defer leaktest.AfterTest(t)()
 
 	var sum uintptr
 	foundAllocations := 0

--- a/pkg/sql/colexec/like_ops_test.go
+++ b/pkg/sql/colexec/like_ops_test.go
@@ -20,10 +20,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
 func TestLikeOperators(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	for _, tc := range []struct {
 		pattern  string
 		negate   bool

--- a/pkg/sql/colexec/limit_test.go
+++ b/pkg/sql/colexec/limit_test.go
@@ -10,9 +10,14 @@
 
 package colexec
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
 
 func TestLimit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	tcs := []struct {
 		limit    uint64
 		tuples   []tuple

--- a/pkg/sql/colexec/main_test.go
+++ b/pkg/sql/colexec/main_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
+//go:generate ../../util/leaktest/add-leaktest.sh *_test.go
+
 func TestMain(m *testing.M) {
 	randutil.SeedForTests()
 	os.Exit(m.Run())

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
@@ -63,6 +64,7 @@ func (tc *mjTestCase) Init() {
 }
 
 func TestMergeJoiner(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	tcs := []mjTestCase{
 		{
 			description:  "basic test",
@@ -1470,6 +1472,7 @@ func TestMergeJoiner(t *testing.T) {
 // track of the expected output to make sure the join output is batched
 // correctly.
 func TestMergeJoinerMultiBatch(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 	for _, numInputBatches := range []int{1, 2, 16} {
 		for _, outBatchSize := range []uint16{1, 16, coldata.BatchSize()} {
@@ -1534,6 +1537,7 @@ func TestMergeJoinerMultiBatch(t *testing.T) {
 // keeps track of the expected count to make sure the join output is batched
 // correctly.
 func TestMergeJoinerMultiBatchRuns(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 	for _, groupSize := range []int{int(coldata.BatchSize()) / 8, int(coldata.BatchSize()) / 4, int(coldata.BatchSize()) / 2} {
 		for _, numInputBatches := range []int{1, 2, 16} {
@@ -1601,6 +1605,7 @@ func TestMergeJoinerMultiBatchRuns(t *testing.T) {
 // keeps track of the expected count to make sure the join output is batched
 // correctly.
 func TestMergeJoinerLongMultiBatchCount(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 	for _, groupSize := range []int{1, 2, int(coldata.BatchSize()) / 4, int(coldata.BatchSize()) / 2} {
 		for _, numInputBatches := range []int{1, 2, 16} {
@@ -1655,6 +1660,7 @@ func TestMergeJoinerLongMultiBatchCount(t *testing.T) {
 // keeps track of the expected count to make sure the join output is batched
 // correctly.
 func TestMergeJoinerMultiBatchCountRuns(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 	for _, groupSize := range []int{int(coldata.BatchSize()) / 8, int(coldata.BatchSize()) / 4, int(coldata.BatchSize()) / 2} {
 		for _, numInputBatches := range []int{1, 2, 16} {
@@ -1775,6 +1781,7 @@ func newBatchesOfRandIntRows(
 }
 
 func TestMergeJoinerRandomized(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 	for _, numInputBatches := range []int{1, 2, 16, 256} {
 		for _, maxRunLength := range []int64{2, 3, 100} {

--- a/pkg/sql/colexec/offset_test.go
+++ b/pkg/sql/colexec/offset_test.go
@@ -16,9 +16,11 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
 func TestOffset(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	tcs := []struct {
 		offset   uint64
 		tuples   []tuple

--- a/pkg/sql/colexec/orderedsynchronizer_test.go
+++ b/pkg/sql/colexec/orderedsynchronizer_test.go
@@ -20,10 +20,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
 // Adapted from the same-named test in the rowflow package.
 func TestOrderedSync(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testCases := []struct {
 		sources  []tuples
 		ordering sqlbase.ColumnOrdering
@@ -150,6 +152,7 @@ func TestOrderedSync(t *testing.T) {
 }
 
 func TestOrderedSyncRandomInput(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	numInputs := 3
 	inputLen := 1024
 	batchSize := uint16(16)

--- a/pkg/sql/colexec/ordinality_test.go
+++ b/pkg/sql/colexec/ordinality_test.go
@@ -16,9 +16,11 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
 func TestOrdinality(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	tcs := []struct {
 		tuples   []tuple
 		expected []tuple

--- a/pkg/sql/colexec/overloads_test.go
+++ b/pkg/sql/colexec/overloads_test.go
@@ -17,10 +17,12 @@ import (
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/stretchr/testify/require"
 )
 
 func TestIntegerAddition(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	// The addition overload is the same for all integer widths, so we only test
 	// one of them.
 	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performPlusInt16Int16(1, math.MaxInt16) }))
@@ -40,6 +42,7 @@ func TestIntegerAddition(t *testing.T) {
 }
 
 func TestIntegerSubtraction(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	// The subtraction overload is the same for all integer widths, so we only
 	// test one of them.
 	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMinusInt16Int16(1, -math.MaxInt16) }))
@@ -59,6 +62,7 @@ func TestIntegerSubtraction(t *testing.T) {
 }
 
 func TestIntegerDivision(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	d := &apd.Decimal{}
 	var res apd.Decimal
 
@@ -86,6 +90,7 @@ func TestIntegerDivision(t *testing.T) {
 }
 
 func TestIntegerMultiplication(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MaxInt16-1, 100) }))
 	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MaxInt16-1, 3) }))
 	require.Equal(t, tree.ErrIntOutOfRange, execerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MinInt16+1, 3) }))
@@ -119,6 +124,7 @@ func TestIntegerMultiplication(t *testing.T) {
 }
 
 func TestMixedTypeInteger(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	require.Equal(t, int64(22), performPlusInt16Int32(10, 12))
 	require.Equal(t, int64(-22), performPlusInt16Int64(-10, -12))
 	require.Equal(t, int64(2), performPlusInt64Int32(-10, 12))
@@ -148,6 +154,7 @@ func TestMixedTypeInteger(t *testing.T) {
 }
 
 func TestDecimalDivByZero(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	nonZeroDec, zeroDec := apd.Decimal{}, apd.Decimal{}
 	nonZeroDec.SetFinite(4, 0)
 	zeroDec.SetFinite(0, 0)
@@ -164,6 +171,7 @@ func TestDecimalDivByZero(t *testing.T) {
 }
 
 func TestDecimalComparison(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	d := apd.Decimal{}
 	if _, err := d.SetFloat64(1.234); err != nil {
 		t.Error(err)
@@ -188,6 +196,7 @@ func TestDecimalComparison(t *testing.T) {
 }
 
 func TestFloatComparison(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	f := 1.234
 	d := apd.Decimal{}
 	if _, err := d.SetFloat64(f); err != nil {
@@ -213,6 +222,7 @@ func TestFloatComparison(t *testing.T) {
 }
 
 func TestIntComparison(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	i := int64(2)
 	d := apd.Decimal{}
 	if _, err := d.SetFloat64(1.234); err != nil {

--- a/pkg/sql/colexec/projection_ops_test.go
+++ b/pkg/sql/colexec/projection_ops_test.go
@@ -21,9 +21,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
 func TestProjPlusInt64Int64ConstOp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	runTests(t, []tuples{{{1}, {2}, {nil}}}, tuples{{1, 2}, {2, 3}, {nil, nil}}, orderedVerifier,
 		func(input []Operator) (Operator, error) {
 			return &projPlusInt64Int64ConstOp{
@@ -38,6 +40,7 @@ func TestProjPlusInt64Int64ConstOp(t *testing.T) {
 }
 
 func TestProjPlusInt64Int64Op(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	runTests(t, []tuples{{{1, 2}, {3, 4}, {5, nil}}}, tuples{{1, 2, 3}, {3, 4, 7}, {5, nil, nil}},
 		orderedVerifier,
 		func(input []Operator) (Operator, error) {
@@ -53,6 +56,7 @@ func TestProjPlusInt64Int64Op(t *testing.T) {
 }
 
 func TestProjDivFloat64Float64Op(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	runTests(t, []tuples{{{1.0, 2.0}, {3.0, 4.0}, {5.0, nil}}}, tuples{{1.0, 2.0, 0.5}, {3.0, 4.0, 0.75}, {5.0, nil, nil}},
 		orderedVerifier,
 		func(input []Operator) (Operator, error) {
@@ -120,6 +124,7 @@ func BenchmarkProjPlusInt64Int64ConstOp(b *testing.B) {
 }
 
 func TestGetProjectionConstOperator(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	binOp := tree.Mult
 	var input Operator
 	colIdx := 3
@@ -144,6 +149,7 @@ func TestGetProjectionConstOperator(t *testing.T) {
 }
 
 func TestGetProjectionConstMixedTypeOperator(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	binOp := tree.GE
 	var input Operator
 	colIdx := 3
@@ -168,6 +174,7 @@ func TestGetProjectionConstMixedTypeOperator(t *testing.T) {
 }
 
 func TestGetProjectionOperator(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	ct := types.Int2
 	binOp := tree.Mult
 	var input Operator

--- a/pkg/sql/colexec/rowstovec_test.go
+++ b/pkg/sql/colexec/rowstovec_test.go
@@ -19,11 +19,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
 var alloc = sqlbase.DatumAlloc{}
 
 func TestEncDatumRowsToColVecBool(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	// Test input: [[false, true], [true, false]]
 	rows := sqlbase.EncDatumRows{
 		sqlbase.EncDatumRow{
@@ -61,6 +63,7 @@ func TestEncDatumRowsToColVecBool(t *testing.T) {
 }
 
 func TestEncDatumRowsToColVecInt16(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	rows := sqlbase.EncDatumRows{
 		sqlbase.EncDatumRow{sqlbase.EncDatum{Datum: tree.NewDInt(17)}},
 		sqlbase.EncDatumRow{sqlbase.EncDatum{Datum: tree.NewDInt(42)}},
@@ -78,6 +81,7 @@ func TestEncDatumRowsToColVecInt16(t *testing.T) {
 }
 
 func TestEncDatumRowsToColVecString(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	rows := sqlbase.EncDatumRows{
 		sqlbase.EncDatumRow{sqlbase.EncDatum{Datum: tree.NewDString("foo")}},
 		sqlbase.EncDatumRow{sqlbase.EncDatum{Datum: tree.NewDString("bar")}},
@@ -99,6 +103,7 @@ func TestEncDatumRowsToColVecString(t *testing.T) {
 }
 
 func TestEncDatumRowsToColVecDecimal(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	nRows := 3
 	rows := make(sqlbase.EncDatumRows, nRows)
 	expected := coldata.NewMemColumn(coltypes.Decimal, 3)

--- a/pkg/sql/colexec/select_in_test.go
+++ b/pkg/sql/colexec/select_in_test.go
@@ -18,9 +18,11 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
 func TestSelectInInt64(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testCases := []struct {
 		desc         string
 		inputTuples  tuples
@@ -148,6 +150,7 @@ func BenchmarkSelectInInt64(b *testing.B) {
 }
 
 func TestProjectInInt64(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testCases := []struct {
 		desc         string
 		inputTuples  tuples

--- a/pkg/sql/colexec/selection_ops_test.go
+++ b/pkg/sql/colexec/selection_ops_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 )
 
@@ -30,6 +31,7 @@ const (
 )
 
 func TestSelLTInt64Int64ConstOp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	tups := tuples{{0}, {1}, {2}, {nil}}
 	runTests(t, []tuples{tups}, tuples{{0}, {1}}, orderedVerifier, func(input []Operator) (Operator, error) {
 		return &selLTInt64Int64ConstOp{
@@ -43,6 +45,7 @@ func TestSelLTInt64Int64ConstOp(t *testing.T) {
 }
 
 func TestSelLTInt64Int64(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	tups := tuples{
 		{0, 0},
 		{0, 1},
@@ -64,6 +67,7 @@ func TestSelLTInt64Int64(t *testing.T) {
 }
 
 func TestGetSelectionConstOperator(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	cmpOp := tree.LT
 	var input Operator
 	colIdx := 3
@@ -86,6 +90,7 @@ func TestGetSelectionConstOperator(t *testing.T) {
 }
 
 func TestGetSelectionConstMixedTypeOperator(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	cmpOp := tree.LT
 	var input Operator
 	colIdx := 3
@@ -108,6 +113,7 @@ func TestGetSelectionConstMixedTypeOperator(t *testing.T) {
 }
 
 func TestGetSelectionOperator(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	ct := types.Int2
 	cmpOp := tree.GE
 	var input Operator

--- a/pkg/sql/colexec/simple_project_test.go
+++ b/pkg/sql/colexec/simple_project_test.go
@@ -15,10 +15,12 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSimpleProjectOp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	tcs := []struct {
 		tuples     tuples
 		expected   tuples

--- a/pkg/sql/colexec/sort_chunks_test.go
+++ b/pkg/sql/colexec/sort_chunks_test.go
@@ -199,6 +199,7 @@ func TestSortChunks(t *testing.T) {
 }
 
 func TestSortChunksRandomized(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	rng, _ := randutil.NewPseudoRand()
 	nTups := 8
 	maxCols := 5

--- a/pkg/sql/colexec/sort_test.go
+++ b/pkg/sql/colexec/sort_test.go
@@ -145,6 +145,7 @@ func TestSort(t *testing.T) {
 }
 
 func TestSortRandomized(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	rng, _ := randutil.NewPseudoRand()
 	nTups := 1025
 	k := uint16(4)

--- a/pkg/sql/colexec/stats_test.go
+++ b/pkg/sql/colexec/stats_test.go
@@ -19,12 +19,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"
 )
 
 // TestNumBatches is a unit test for NumBatches field of VectorizedStats.
 func TestNumBatches(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	nBatches := 10
 	noop := NewNoop(makeFiniteChunksSourceWithBatchSize(nBatches, int(coldata.BatchSize())))
 	vsc := NewVectorizedStatsCollector(noop, 0 /* id */, true /* isStall */, timeutil.NewStopWatch())
@@ -40,6 +42,7 @@ func TestNumBatches(t *testing.T) {
 
 // TestNumTuples is a unit test for NumTuples field of VectorizedStats.
 func TestNumTuples(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	nBatches := 10
 	for _, batchSize := range []int{1, 16, 1024} {
 		noop := NewNoop(makeFiniteChunksSourceWithBatchSize(nBatches, batchSize))
@@ -60,6 +63,7 @@ func TestNumTuples(t *testing.T) {
 // merge joiner and makes sure that all the stats measured on the latter are as
 // expected.
 func TestVectorizedStatsCollector(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	for nBatches := 1; nBatches < 5; nBatches++ {
 		timeSource := timeutil.NewTestTimeSource()
 		mjInputWatch := timeutil.NewTestStopWatch(timeSource.Now)

--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/pkg/errors"
 	"github.com/pmezard/go-difflib/difflib"
@@ -988,6 +989,7 @@ func (f *finiteChunksSource) Next(ctx context.Context) coldata.Batch {
 }
 
 func TestOpTestInputOutput(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	inputs := []tuples{
 		{
 			{1, 2, 100},
@@ -1006,6 +1008,7 @@ func TestOpTestInputOutput(t *testing.T) {
 }
 
 func TestRepeatableBatchSource(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	batch := coldata.NewMemBatch([]coltypes.T{coltypes.Int64})
 	batchLen := uint16(10)
 	batch.SetLength(batchLen)
@@ -1025,6 +1028,7 @@ func TestRepeatableBatchSource(t *testing.T) {
 }
 
 func TestRepeatableBatchSourceWithFixedSel(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	batch := coldata.NewMemBatch([]coltypes.T{coltypes.Int64})
 	rng, _ := randutil.NewPseudoRand()
 	sel := randomSel(rng, 10 /* batchSize */, 0 /* probOfOmitting */)

--- a/pkg/sql/colexec/vec_elem_to_datum.go
+++ b/pkg/sql/colexec/vec_elem_to_datum.go
@@ -42,8 +42,6 @@ func PhysicalTypeColElemToDatum(
 		return tree.DBoolFalse
 	case types.IntFamily:
 		switch ct.Width() {
-		case 8:
-			return da.NewDInt(tree.DInt(col.Int8()[rowIdx]))
 		case 16:
 			return da.NewDInt(tree.DInt(col.Int16()[rowIdx]))
 		case 32:


### PR DESCRIPTION
This commit cleans up a few things:
- removes Int8 and Float32 methods from Vec interface (these types were
recently removed)
- removes special casing for CFetcher when catching a vectorized panic
(CFetcher has been recently moved into colexec package)
- adds leaktest to all tests in colexec package.

Release justification: Category 1: Non-production code changes.

Release note: None