### PR TITLE
tla-plus: update ParallelCommit spec with AckImpliesCommit invariant

### DIFF
--- a/docs/tla-plus/ParallelCommits/ParallelCommits.toolbox/ParallelCommits___Model_1.launch
+++ b/docs/tla-plus/ParallelCommits/ParallelCommits.toolbox/ParallelCommits___Model_1.launch
@@ -1,58 +1,63 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.lamport.tla.toolbox.tool.tlc.modelCheck">
-<stringAttribute key="TLCCmdLineParameters" value=""/>
-<stringAttribute key="configurationName" value="Model_1"/>
-<booleanAttribute key="deferLiveness" value="false"/>
-<intAttribute key="dfidDepth" value="100"/>
-<booleanAttribute key="dfidMode" value="false"/>
-<intAttribute key="distributedFPSetCount" value="0"/>
-<stringAttribute key="distributedNetworkInterface" value="192.168.13.240"/>
-<intAttribute key="distributedNodesCount" value="1"/>
-<stringAttribute key="distributedTLC" value="off"/>
-<stringAttribute key="distributedTLCVMArgs" value=""/>
-<intAttribute key="fpBits" value="1"/>
-<intAttribute key="fpIndex" value="1"/>
-<intAttribute key="maxHeapSize" value="25"/>
-<intAttribute key="maxSetSize" value="1000000"/>
-<booleanAttribute key="mcMode" value="true"/>
-<stringAttribute key="modelBehaviorInit" value=""/>
-<stringAttribute key="modelBehaviorNext" value=""/>
-<stringAttribute key="modelBehaviorSpec" value="Spec"/>
-<intAttribute key="modelBehaviorSpecType" value="1"/>
-<stringAttribute key="modelBehaviorVars" value="intent_writes, to_write, txn_epoch, txn_ts, pipelined_keys, to_check, prevent_epoch, pc, commit_ack, to_resolve, record, have_staged_record, found_writes, prevent_ts, parallel_keys, tscache, attempt"/>
-<stringAttribute key="modelComments" value=""/>
-<booleanAttribute key="modelCorrectnessCheckDeadlock" value="true"/>
-<listAttribute key="modelCorrectnessInvariants">
-<listEntry value="1TypeInvariants"/>
-</listAttribute>
-<listAttribute key="modelCorrectnessProperties">
-<listEntry value="1TemporalTxnRecordProperties"/>
-<listEntry value="1TemporalIntentProperties"/>
-<listEntry value="1TemporalTSCacheProperties"/>
-<listEntry value="1ImplicitCommitLeadsToExplicitCommit"/>
-<listEntry value="1AckLeadsToExplicitCommit"/>
-</listAttribute>
-<stringAttribute key="modelExpressionEval" value=""/>
-<stringAttribute key="modelParameterActionConstraint" value=""/>
-<listAttribute key="modelParameterConstants">
-<listEntry value="KEYS;;{k1, k2};1;1"/>
-<listEntry value="PREVENTERS;;{p1, p2};1;1"/>
-<listEntry value="MAX_ATTEMPTS;;3;0;0"/>
-</listAttribute>
-<stringAttribute key="modelParameterContraint" value=""/>
-<listAttribute key="modelParameterDefinitions"/>
-<stringAttribute key="modelParameterModelValues" value="{}"/>
-<stringAttribute key="modelParameterNewDefinitions" value=""/>
-<intAttribute key="numberOfWorkers" value="2"/>
-<booleanAttribute key="recover" value="false"/>
-<stringAttribute key="result.mail.address" value=""/>
-<intAttribute key="simuAril" value="-1"/>
-<intAttribute key="simuDepth" value="100"/>
-<intAttribute key="simuSeed" value="-1"/>
-<stringAttribute key="specName" value="ParallelCommits"/>
-<listAttribute key="traceExploreExpressions">
-<listEntry value="1ImplicitCommit"/>
-</listAttribute>
-<stringAttribute key="view" value=""/>
-<booleanAttribute key="visualizeStateGraph" value="false"/>
+    <stringAttribute key="TLCCmdLineParameters" value=""/>
+    <intAttribute key="collectCoverage" value="1"/>
+    <stringAttribute key="configurationName" value="Model_1"/>
+    <booleanAttribute key="deferLiveness" value="false"/>
+    <intAttribute key="dfidDepth" value="100"/>
+    <booleanAttribute key="dfidMode" value="false"/>
+    <intAttribute key="distributedFPSetCount" value="0"/>
+    <stringAttribute key="distributedNetworkInterface" value="192.168.13.156"/>
+    <intAttribute key="distributedNodesCount" value="1"/>
+    <stringAttribute key="distributedTLC" value="off"/>
+    <stringAttribute key="distributedTLCVMArgs" value=""/>
+    <intAttribute key="fpBits" value="1"/>
+    <intAttribute key="fpIndex" value="111"/>
+    <booleanAttribute key="fpIndexRandom" value="true"/>
+    <intAttribute key="maxHeapSize" value="25"/>
+    <intAttribute key="maxSetSize" value="1000000"/>
+    <booleanAttribute key="mcMode" value="true"/>
+    <stringAttribute key="modelBehaviorInit" value=""/>
+    <stringAttribute key="modelBehaviorNext" value=""/>
+    <stringAttribute key="modelBehaviorSpec" value="Spec"/>
+    <intAttribute key="modelBehaviorSpecType" value="1"/>
+    <stringAttribute key="modelBehaviorVars" value="intent_writes, to_write, txn_epoch, txn_ts, pipelined_keys, to_check, prevent_epoch, pc, commit_ack, to_resolve, record, have_staged_record, found_writes, prevent_ts, parallel_keys, tscache, attempt"/>
+    <stringAttribute key="modelComments" value=""/>
+    <booleanAttribute key="modelCorrectnessCheckDeadlock" value="true"/>
+    <listAttribute key="modelCorrectnessInvariants">
+        <listEntry value="1TypeInvariants"/>
+        <listEntry value="1AckImpliesCommit"/>
+    </listAttribute>
+    <listAttribute key="modelCorrectnessProperties">
+        <listEntry value="1TemporalTxnRecordProperties"/>
+        <listEntry value="1TemporalIntentProperties"/>
+        <listEntry value="1TemporalTSCacheProperties"/>
+        <listEntry value="1ImplicitCommitLeadsToExplicitCommit"/>
+        <listEntry value="1AckLeadsToExplicitCommit"/>
+    </listAttribute>
+    <intAttribute key="modelEditorOpenTabs" value="4"/>
+    <stringAttribute key="modelExpressionEval" value=""/>
+    <stringAttribute key="modelParameterActionConstraint" value=""/>
+    <listAttribute key="modelParameterConstants">
+        <listEntry value="KEYS;;{k1, k2};1;1"/>
+        <listEntry value="PREVENTERS;;{p1, p2};1;1"/>
+        <listEntry value="MAX_ATTEMPTS;;3;0;0"/>
+    </listAttribute>
+    <stringAttribute key="modelParameterContraint" value=""/>
+    <listAttribute key="modelParameterDefinitions"/>
+    <stringAttribute key="modelParameterModelValues" value="{}"/>
+    <stringAttribute key="modelParameterNewDefinitions" value=""/>
+    <intAttribute key="numberOfWorkers" value="8"/>
+    <booleanAttribute key="recover" value="false"/>
+    <stringAttribute key="result.mail.address" value=""/>
+    <intAttribute key="simuAril" value="-1"/>
+    <intAttribute key="simuDepth" value="100"/>
+    <intAttribute key="simuSeed" value="-1"/>
+    <stringAttribute key="specName" value="ParallelCommits"/>
+    <stringAttribute key="tlcResourcesProfile" value="local custom"/>
+    <listAttribute key="traceExploreExpressions">
+        <listEntry value="1ImplicitCommit"/>
+    </listAttribute>
+    <stringAttribute key="view" value=""/>
+    <booleanAttribute key="visualizeStateGraph" value="false"/>
 </launchConfiguration>


### PR DESCRIPTION
The spec is being referenced by the Parallel Commit blog post.
This commit modifies it slightly to be easier to talk about.

Release justification: Documentation only.

Release note: None