### PR TITLE
colflow: wrap SupportsVectorized with an error catcher

### DIFF
--- a/pkg/sql/colexec/execerror/error.go
+++ b/pkg/sql/colexec/execerror/error.go
@@ -97,6 +97,7 @@ const (
 	colexecPackagePrefix      = "github.com/cockroachdb/cockroach/pkg/sql/colexec"
 	colflowsetupPackagePrefix = "github.com/cockroachdb/cockroach/pkg/sql/colflow"
 	cFetcherPrefix            = "github.com/cockroachdb/cockroach/pkg/sql/row.(*CFetcher)"
+	treePackagePrefix         = "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
 // isPanicFromVectorizedEngine checks whether the panic that was emitted from
@@ -114,7 +115,8 @@ func isPanicFromVectorizedEngine(panicEmittedFrom string) bool {
 	return strings.HasPrefix(panicEmittedFrom, colPackagePrefix) ||
 		strings.HasPrefix(panicEmittedFrom, colexecPackagePrefix) ||
 		strings.HasPrefix(panicEmittedFrom, colflowsetupPackagePrefix) ||
-		strings.HasPrefix(panicEmittedFrom, cFetcherPrefix)
+		strings.HasPrefix(panicEmittedFrom, cFetcherPrefix) ||
+		strings.HasPrefix(panicEmittedFrom, treePackagePrefix)
 }
 
 // StorageError is an error that was created by a component below the sql

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -801,5 +801,10 @@ func SupportsVectorized(
 	defer memoryMonitor.Stop(ctx)
 	acc := memoryMonitor.MakeBoundAccount()
 	defer acc.Close(ctx)
-	return creator.setupFlow(ctx, flowCtx, processorSpecs, &acc)
+	if vecErr := execerror.CatchVectorizedRuntimeError(func() {
+		leaves, err = creator.setupFlow(ctx, flowCtx, processorSpecs, &acc)
+	}); vecErr != nil {
+		return leaves, vecErr
+	}
+	return leaves, err
 }


### PR DESCRIPTION
We should be wrapping a call to SupportsVectorized check with
CatchVectorizedRuntimeError which this commit adds. Also, it adds
sem/tree package as a part of the vectorized engine from the panic
catching perspective.

Release justification: Category 2: Bug fixes and low-risk updates
to new functionality.

Release note: None