### PR TITLE
roachtest: remove wait loop in backup2TB roachtest

### DIFF
--- a/pkg/cmd/roachtest/backup.go
+++ b/pkg/cmd/roachtest/backup.go
@@ -48,22 +48,6 @@ func registerBackup(r *testRegistry) {
 				"--db=bank", "--payload-bytes=10240", "--ranges=0", "--csv-server", "http://localhost:8081",
 				fmt.Sprintf("--rows=%d", rows), "--seed=1", "{pgurl:1}")
 
-			// NB: without this delay, the BACKUP operation sometimes claims that
-			// bank.bank doesn't exist, probably due to some gossip propagation
-			// delay.
-			//
-			// See https://github.com/cockroachdb/cockroach/issues/36841.
-			for i := 0; i < 5; i++ {
-				_, err := c.Conn(ctx, 1).ExecContext(ctx, "SELECT * FROM bank.bank LIMIT 1")
-				if err != nil {
-					c.l.Printf("%s", err)
-					time.Sleep(time.Second)
-					continue
-				}
-				c.l.Printf("found the table")
-				break
-			}
-
 			m := newMonitor(ctx, c)
 			m.Go(func(ctx context.Context) error {
 				t.Status(`running backup`)


### PR DESCRIPTION
Previously a wait loop was needed in the backup2TB roachtest because the
test was reporting the table as offline when it shouldn't have seen it
as OFFLINE. This was fixed by #40996, and therefore we should no longer
need this wait loop.

Closes #36841.

Release justification: Only touches tests.

Release note: None