### PR TITLE
roachtest: reduce row size in hotspotsplits to fix flake

### DIFF
--- a/pkg/cmd/roachtest/hotspotsplits.go
+++ b/pkg/cmd/roachtest/hotspotsplits.go
@@ -48,7 +48,9 @@ func registerHotSpotSplits(r *testRegistry) {
 			}
 			defer quietL.close()
 
-			const blockSize = 1 << 19 // 512 KB
+			// TODO(rytaft): reset this to 1 << 19 (512 KB) once we can dynamically
+			// size kv batches.
+			const blockSize = 1 << 18 // 256 KB
 			return c.RunL(ctx, quietL, appNode, fmt.Sprintf(
 				"./workload run kv --read-percent=0 --tolerate-errors --concurrency=%d "+
 					"--min-block-bytes=%d --max-block-bytes=%d --duration=%s {pgurl:1-3}",


### PR DESCRIPTION
This commit reduces the kv block size from 512 KB to 256 KB in the
`hotspotsplits/nodes=4` roachtest to fix an out-of-memory condition
that was causing flakiness in the test.

The flakiness is caused by the fact that automatic stats collection
requires a full table scan, and the kv batch size is currently
hard-coded to 10,000 rows. With each row utilizing 512 KB, this
results in a minimum of 5 GB of memory utilization during calculation
of stats.

Once the kv batch size can be dynamically adjusted based on the
size of the rows, we can reset the block size in this roachtest back
to 512 KB.

Informs #33660

Release note: None
Release justification: Non-production code change to fix a flaky test.