### PR TITLE
sql/logictest: randomly assign column families

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -380,10 +380,16 @@ CREATE TABLE t (a TIMESTAMP PRIMARY KEY) PARTITION BY LIST (a) (
 )
 
 statement ok
-CREATE TABLE ok1 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
-    PARTITION p1 VALUES IN (1),
-    PARTITION p2 VALUES IN (2)
+CREATE TABLE ok1 (
+  a INT, b INT, c INT,
+  PRIMARY KEY (a, b),
+  FAMILY "primary" (a, b, c)
 )
+  PARTITION BY LIST (a)
+    (
+      PARTITION p1 VALUES IN (1),
+      PARTITION p2 VALUES IN (2)
+    )
 
 query TT
 SHOW CREATE TABLE ok1
@@ -421,10 +427,16 @@ TABLE ok1
 scan ok1
 
 statement ok
-CREATE TABLE ok2 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
-    PARTITION p1 VALUES IN ((1)),
-    PARTITION p2 VALUES IN (((2)))
+CREATE TABLE ok2 (
+  a INT, b INT, c INT,
+  PRIMARY KEY (a, b),
+  FAMILY "primary" (a, b, c)
 )
+  PARTITION BY LIST (a)
+    (
+      PARTITION p1 VALUES IN (1),
+      PARTITION p2 VALUES IN (2)
+    )
 
 query TT
 SHOW CREATE TABLE ok2
@@ -457,10 +469,16 @@ TABLE ok2
 scan ok2
 
 statement ok
-CREATE TABLE ok3 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
-    PARTITION p1 VALUES IN (1),
-    PARTITION p2 VALUES IN (DEFAULT)
+CREATE TABLE ok3 (
+  a INT, b INT, c INT,
+  PRIMARY KEY (a, b),
+  FAMILY "primary" (a, b, c)
 )
+  PARTITION BY LIST (a)
+    (
+      PARTITION p1 VALUES IN (1),
+      PARTITION p2 VALUES IN (DEFAULT)
+    )
 
 query TT
 SHOW CREATE TABLE ok3
@@ -492,12 +510,18 @@ TABLE ok3
 scan ok3
 
 statement ok
-CREATE TABLE ok4 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a, b) (
-    PARTITION p1 VALUES IN ((1, 1)),
-    PARTITION p2 VALUES IN ((1, DEFAULT)),
-    PARTITION p3 VALUES IN ((2, 3)),
-    PARTITION p4 VALUES IN ((DEFAULT, DEFAULT))
+CREATE TABLE ok4 (
+  a INT, b INT, c INT,
+  PRIMARY KEY (a, b),
+  FAMILY "primary" (a, b, c)
 )
+  PARTITION BY LIST (a, b)
+    (
+      PARTITION p1 VALUES IN ((1, 1)),
+      PARTITION p2 VALUES IN ((1, DEFAULT)),
+      PARTITION p3 VALUES IN ((2, 3)),
+      PARTITION p4 VALUES IN ((DEFAULT, DEFAULT))
+    )
 
 query TT
 SHOW CREATE TABLE ok4
@@ -533,16 +557,26 @@ TABLE ok4
 scan ok4
 
 statement ok
-CREATE TABLE ok5 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
-    PARTITION p1 VALUES IN (1) PARTITION BY LIST (b) (
-        PARTITION p1_1 VALUES IN (1),
-        PARTITION p1_2 VALUES IN (DEFAULT)
-    ),
-    PARTITION p2 VALUES IN (2) PARTITION BY LIST (b) (
-        PARTITION p2_1 VALUES IN (3)
-    ),
-    PARTITION p3 VALUES IN (DEFAULT)
+CREATE TABLE ok5 (
+  a INT, b INT, c INT,
+  PRIMARY KEY (a, b),
+  FAMILY "primary" (a, b, c)
 )
+  PARTITION BY LIST (a)
+    (
+      PARTITION p1
+        VALUES IN (1)
+        PARTITION BY LIST (b)
+          (
+            PARTITION p1_1 VALUES IN (1),
+            PARTITION p1_2 VALUES IN (DEFAULT)
+          ),
+      PARTITION p2
+        VALUES IN (2)
+        PARTITION BY LIST (b)
+          (PARTITION p2_1 VALUES IN (3)),
+      PARTITION p3 VALUES IN (DEFAULT)
+    )
 
 query T
 EXPLAIN (OPT, CATALOG) SELECT * from ok5
@@ -581,10 +615,16 @@ ok5  CREATE TABLE ok5 (
 -- Warning: Partitioned table with no zone configurations.
 
 statement ok
-CREATE TABLE ok6 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a) (
-    PARTITION p1 VALUES FROM (0) TO (1),
-    PARTITION p2 VALUES FROM (1) TO (2)
+CREATE TABLE ok6 (
+  a INT, b INT, c INT,
+  PRIMARY KEY (a, b),
+  FAMILY "primary" (a, b, c)
 )
+  PARTITION BY RANGE (a)
+    (
+      PARTITION p1 VALUES FROM (0) TO (1),
+      PARTITION p2 VALUES FROM (1) TO (2)
+    )
 
 query TT
 SHOW CREATE TABLE ok6
@@ -614,9 +654,13 @@ TABLE ok6
 scan ok6
 
 statement ok
-CREATE TABLE ok7 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a) (
-    PARTITION p1 VALUES FROM ((0)) TO (((1)))
+CREATE TABLE ok7 (
+  a INT, b INT, c INT,
+  PRIMARY KEY (a, b),
+  FAMILY "primary" (a, b, c)
 )
+  PARTITION BY RANGE (a)
+    (PARTITION p1 VALUES FROM (0) TO (1))
 
 query TT
 SHOW CREATE TABLE ok7
@@ -645,11 +689,17 @@ TABLE ok7
 scan ok7
 
 statement ok
-CREATE TABLE ok8 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a) (
-    PARTITION p1 VALUES FROM (MINVALUE) TO (1),
-    PARTITION p2 VALUES FROM (1) TO (2),
-    PARTITION p3 VALUES FROM (2) TO (MAXVALUE)
+CREATE TABLE ok8 (
+  a INT, b INT, c INT,
+  PRIMARY KEY (a, b),
+  FAMILY "primary" (a, b, c)
 )
+  PARTITION BY RANGE (a)
+    (
+      PARTITION p1 VALUES FROM (minvalue) TO (1),
+      PARTITION p2 VALUES FROM (1) TO (2),
+      PARTITION p3 VALUES FROM (2) TO (maxvalue)
+    )
 
 query TT
 SHOW CREATE TABLE ok8
@@ -680,12 +730,18 @@ TABLE ok8
 scan ok8
 
 statement ok
-CREATE TABLE ok9 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a, b) (
-    PARTITION p1 VALUES FROM (MINVALUE, MINVALUE) TO (1, MAXVALUE),
-    PARTITION p2 VALUES FROM (1, MAXVALUE) TO (3, MINVALUE),
-    PARTITION p3 VALUES FROM (3, MINVALUE) TO (3, MAXVALUE),
-    PARTITION p4 VALUES FROM (3, MAXVALUE) TO (MAXVALUE, MAXVALUE)
+CREATE TABLE ok9 (
+  a INT, b INT, c INT,
+  PRIMARY KEY (a, b),
+  FAMILY "primary" (a, b, c)
 )
+  PARTITION BY RANGE (a, b)
+    (
+      PARTITION p1 VALUES FROM (minvalue, minvalue) TO (1, maxvalue),
+      PARTITION p2 VALUES FROM (1, maxvalue) TO (3, minvalue),
+      PARTITION p3 VALUES FROM (3, minvalue) TO (3, maxvalue),
+      PARTITION p4 VALUES FROM (3, maxvalue) TO (maxvalue, maxvalue)
+    )
 
 query TT
 SHOW CREATE TABLE ok9
@@ -717,13 +773,19 @@ TABLE ok9
 scan ok9
 
 statement ok
-CREATE TABLE ok10 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a, b) (
-    PARTITION p1 VALUES FROM (MINVALUE, MINVALUE) TO (1, 1),
-    PARTITION p2 VALUES FROM (1, 1) TO (1, MAXVALUE),
-    PARTITION p3 VALUES FROM (1, MAXVALUE) TO (2, MAXVALUE),
-    PARTITION p4 VALUES FROM (2, MAXVALUE) TO (3, 4),
-    PARTITION p5 VALUES FROM (3, 4) TO (MAXVALUE, MAXVALUE)
+CREATE TABLE ok10 (
+  a INT, b INT, c INT,
+  PRIMARY KEY (a, b),
+  FAMILY "primary" (a, b, c)
 )
+  PARTITION BY RANGE (a, b)
+    (
+      PARTITION p1 VALUES FROM (minvalue, minvalue) TO (1, 1),
+      PARTITION p2 VALUES FROM (1, 1) TO (1, maxvalue),
+      PARTITION p3 VALUES FROM (1, maxvalue) TO (2, maxvalue),
+      PARTITION p4 VALUES FROM (2, maxvalue) TO (3, 4),
+      PARTITION p5 VALUES FROM (3, 4) TO (maxvalue, maxvalue)
+    )
 
 query TT
 SHOW CREATE TABLE ok10
@@ -756,17 +818,24 @@ TABLE ok10
 scan ok10
 
 statement ok
-CREATE TABLE ok11 (a INT, b INT, c INT, PRIMARY KEY (a, b, c)) PARTITION BY LIST (a) (
-    PARTITION p1 VALUES IN (1) PARTITION BY LIST (b) (
-        PARTITION p1_1 VALUES IN (3) PARTITION BY LIST (c) (
-            PARTITION p1_1_1 VALUES IN (8)
-        ),
-        PARTITION p1_2 VALUES IN (4)
-    ),
-    PARTITION p2 VALUES IN (6) PARTITION BY RANGE (b) (
-        PARTITION p2_1 VALUES FROM (7) TO (8)
-    )
+CREATE TABLE ok11 (
+  a INT, b INT, c INT,
+  PRIMARY KEY (a, b, c),
+  FAMILY "primary" (a, b, c)
 )
+  PARTITION BY LIST (a)
+    (
+      PARTITION p1
+        VALUES IN (1)
+        PARTITION BY LIST (b)
+          (
+            PARTITION p1_1
+              VALUES IN (3) PARTITION BY LIST (c) (PARTITION p1_1_1 VALUES IN (8)),
+            PARTITION p1_2 VALUES IN (4)
+          ),
+      PARTITION p2
+        VALUES IN (6) PARTITION BY RANGE (b) (PARTITION p2_1 VALUES FROM (7) TO (8))
+    )
 
 query TT
 SHOW CREATE TABLE ok11
@@ -807,12 +876,17 @@ TABLE ok11
 scan ok11
 
 statement ok
-CREATE TABLE IF NOT EXISTS ok12 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
-    PARTITION pu VALUES IN (NULL),
-    PARTITION p1 VALUES IN (1),
-    PARTITION p2 VALUES IN (2)
+CREATE TABLE IF NOT EXISTS ok12 (
+  a INT, b INT, c INT,
+  PRIMARY KEY (a, b),
+  FAMILY "primary" (a, b, c)
 )
-
+  PARTITION BY LIST (a)
+    (
+      PARTITION pu VALUES IN (NULL),
+      PARTITION p1 VALUES IN (1),
+      PARTITION p2 VALUES IN (2)
+    )
 
 query TT
 SHOW CREATE TABLE ok12

--- a/pkg/sql/logictest/testdata/logic_test/bit
+++ b/pkg/sql/logictest/testdata/logic_test/bit
@@ -7,7 +7,10 @@ SELECT B'1000101'::BIT(4)::STRING,
 
 
 statement ok
-CREATE TABLE bits(a BIT, b BIT(4), c VARBIT, d VARBIT(4))
+CREATE TABLE bits (
+  a BIT, b BIT(4), c VARBIT, d VARBIT(4),
+  FAMILY "primary" (a, b, c, d, rowid)
+)
 
 query TT colnames
 SHOW CREATE TABLE bits

--- a/pkg/sql/logictest/testdata/logic_test/check_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/check_constraints
@@ -212,7 +212,8 @@ CREATE TABLE t7 (
   CHECK (x + y > 0),
   CHECK (y + z > 0),
   CHECK (y + z = 0),
-  CONSTRAINT named_constraint CHECK (z = 1)
+  CONSTRAINT named_constraint CHECK (z = 1),
+  FAMILY "primary" (x, y, z, rowid)
 )
 
 query TT

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -341,7 +341,8 @@ CREATE TABLE quoted_coll (
   b STRING COLLATE "en_US",
   c STRING COLLATE "en-Us" DEFAULT ('c' COLLATE "en-Us"),
   d STRING COLLATE "en-u-ks-level1" DEFAULT ('d'::STRING COLLATE "en-u-ks-level1"),
-  e STRING COLLATE "en-us" AS (a COLLATE "en-us") STORED
+  e STRING COLLATE "en-us" AS (a COLLATE "en-us") STORED,
+  FAMILY "primary" (a, b, c, d, e, rowid)
 )
 
 query TT

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -2,7 +2,8 @@ statement ok
 CREATE TABLE with_no_column_refs (
   a INT,
   b INT,
-  c INT AS (3) STORED
+  c INT AS (3) STORED,
+  FAMILY "primary" (a, b, c, rowid)
 )
 
 query TT
@@ -19,7 +20,8 @@ statement ok
 CREATE TABLE extra_parens (
   a INT,
   b INT,
-  c INT AS ((3)) STORED
+  c INT AS ((3)) STORED,
+  FAMILY "primary" (a, b, c, rowid)
 )
 
 query TT
@@ -71,7 +73,8 @@ CREATE TABLE x (
   a INT DEFAULT 3,
   b INT DEFAULT 7,
   c INT AS (a) STORED,
-  d INT AS (a + b) STORED
+  d INT AS (a + b) STORED,
+  FAMILY "primary" (a, b, c, d, rowid)
 )
 
 query TT
@@ -599,7 +602,8 @@ DROP TABLE x
 statement ok
 CREATE TABLE x (
   a INT,
-  b INT as (x.a) STORED
+  b INT as (x.a) STORED,
+  FAMILY "primary" (a, b, rowid)
 )
 
 query TT
@@ -618,7 +622,8 @@ DROP TABLE x
 statement ok
 CREATE TABLE x (
   a INT,
-  b INT AS (a) STORED
+  b INT AS (a) STORED,
+  FAMILY "primary" (a, b, rowid)
 )
 
 statement ok
@@ -639,7 +644,8 @@ DROP TABLE x
 statement ok
 CREATE TABLE x (
   a INT,
-  b INT AS (a * 2) STORED
+  b INT AS (a * 2) STORED,
+  FAMILY "primary" (a, b, rowid)
 )
 
 query T colnames

--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -147,7 +147,11 @@ a  b  c
 
 # Check that CREATE TABLE AS allows users to specify primary key (#20940)
 statement ok
-CREATE TABLE foo5 (a, b PRIMARY KEY, c) AS SELECT * FROM baz
+CREATE TABLE foo5 (
+  a , b PRIMARY KEY, c,
+  FAMILY "primary" (a, b, c)
+) AS
+  SELECT * FROM baz
 
 query TT
 SHOW CREATE TABLE foo5
@@ -161,7 +165,11 @@ foo5  CREATE TABLE foo5 (
     )
 
 statement ok
-CREATE TABLE foo6 (a PRIMARY KEY, b, c) AS SELECT * FROM baz
+CREATE TABLE foo6 (
+  a PRIMARY KEY, b , c,
+  FAMILY "primary" (a, b, c)
+) AS
+  SELECT * FROM baz
 
 query TT
 SHOW CREATE TABLE foo6
@@ -192,7 +200,12 @@ foo8  CREATE TABLE foo8 (
 
 # Allow CREATE TABLE AS to specify composite primary keys.
 statement ok
-CREATE TABLE foo9 (a, b, c, PRIMARY KEY (a, c)) AS SELECT * FROM baz
+CREATE TABLE foo9 (
+  a , b , c,
+  PRIMARY KEY (a, c),
+  FAMILY "primary" (a, b, c)
+) AS
+  SELECT * FROM baz
 
 query TT
 SHOW CREATE TABLE foo9
@@ -220,7 +233,12 @@ foo10  CREATE TABLE foo10 (
     )
 
 statement ok
-CREATE TABLE foo11 (x, y, z, PRIMARY KEY(x, z)) AS VALUES (1, 3, 4), (10, 20, 40);
+CREATE TABLE foo11 (
+  x , y , z,
+  PRIMARY KEY (x, z),
+  FAMILY "primary" (x, y, z)
+) AS
+  VALUES (1, 3, 4), (10, 20, 40);
 
 query TT
 SHOW CREATE TABLE foo11

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -4,10 +4,16 @@
 # CREATE TABLE statements. See #39504.
 
 statement ok
-CREATE TABLE t (a INT REFERENCES t)
+CREATE TABLE t (
+  a INT REFERENCES t,
+  FAMILY "primary" (a, rowid)
+)
 
 statement ok
-CREATE TABLE v ("'" INT REFERENCES t, s STRING UNIQUE REFERENCES v (s))
+CREATE TABLE v (
+  "'" INT REFERENCES t, s STRING UNIQUE REFERENCES v (s),
+  FAMILY "primary" ("'", s, rowid)
+)
 
 query TTTT colnames
 SELECT create_statement, create_nofks, alter_statements, validate_statements FROM crdb_internal.create_statements WHERE database_name = 'test'

--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -35,13 +35,15 @@ INSERT INTO t VALUES
   ('2015-08-30 03:34:45.34567-07:00', '2015-08-31', '35h2s')
 
 # Check that time/date/interval representations outside of the index are okay.
+# TODO(mjibson): Remove family definition once #41283 is fixed.
 statement ok
 CREATE TABLE u (
   a BIGINT PRIMARY KEY,
   b TIMESTAMP,
   c TIMESTAMPTZ,
   d DATE,
-  e INTERVAL
+  e INTERVAL,
+  FAMILY "primary" (a, b, c, d, e)
 )
 
 statement ok
@@ -1006,12 +1008,14 @@ SELECT d::timestamp FROM u WHERE a = 123
 statement ok
 SET TIME ZONE UTC
 
+# TODO(mjibson): Remove family definition once #41283 is fixed.
 statement ok
 CREATE TABLE tz (
   a INT PRIMARY KEY,
   b TIMESTAMP,
   c TIMESTAMPTZ,
-  d TIMESTAMPTZ
+  d TIMESTAMPTZ,
+  FAMILY "primary" (a, b, c, d)
 )
 
 query TTBTTTB

--- a/pkg/sql/logictest/testdata/logic_test/edge
+++ b/pkg/sql/logictest/testdata/logic_test/edge
@@ -6,6 +6,7 @@
 # in the parse or normalization phases, forcing it to be handled by the
 # execution engine itself.
 
+# TODO(mjibson): Remove family definition when #41277 is fixed.
 statement ok
 CREATE TABLE t (
     key
@@ -21,7 +22,8 @@ CREATE TABLE t (
     _int4
         INT4,
     _int8
-        INT8
+        INT8,
+    FAMILY "primary" (key, _date, _float4, _float8, _int2, _int4, _int8)
 )
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/family
+++ b/pkg/sql/logictest/testdata/logic_test/family
@@ -184,7 +184,10 @@ abcd  CREATE TABLE abcd (
 )
 
 statement ok
-CREATE TABLE f1 (a INT PRIMARY KEY, b STRING, c STRING)
+CREATE TABLE f1 (
+  a INT PRIMARY KEY, b STRING, c STRING,
+  FAMILY "primary" (a, b, c)
+)
 
 query TT
 SHOW CREATE TABLE f1

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -255,7 +255,8 @@ CREATE TABLE delivery (
   shipment int,
   item STRING REFERENCES products (upc),
   FOREIGN KEY ("order", shipment) REFERENCES orders (id, shipment),
-  INDEX (item)
+  INDEX (item),
+  FAMILY "primary" (ts, "order", shipment, item, rowid)
 )
 
 query TT
@@ -580,7 +581,8 @@ CREATE TABLE refpairs (
   b STRING,
   c INT,
   FOREIGN KEY (a, b) REFERENCES pairs (src, dest) ON UPDATE RESTRICT,
-  INDEX (a, b, c)
+  INDEX (a, b, c),
+  FAMILY "primary" (a, b, c, rowid)
 )
 
 query TTBITTBB colnames
@@ -815,7 +817,8 @@ statement ok
 CREATE TABLE refers (
   a INT REFERENCES referee,
   b INT,
-  INDEX b_idx (b)
+  INDEX b_idx (b),
+  FAMILY "primary" (a, b, rowid)
 )
 
 # Add some schema changes within the same transaction to verify that a

--- a/pkg/sql/logictest/testdata/logic_test/fk-mixed-19.1-19.2
+++ b/pkg/sql/logictest/testdata/logic_test/fk-mixed-19.1-19.2
@@ -258,7 +258,8 @@ CREATE TABLE delivery (
   FOREIGN KEY ("order", shipment) REFERENCES orders (id, shipment),
   FOREIGN KEY (item) REFERENCES products (upc),
   INDEX ("order", shipment),
-  INDEX (item)
+  INDEX (item),
+  FAMILY "primary" (ts, "order", shipment, item, rowid)
 )
 
 query TT
@@ -597,7 +598,8 @@ CREATE TABLE refpairs (
   b STRING,
   c INT,
   FOREIGN KEY (a, b) REFERENCES pairs (src, dest) ON UPDATE RESTRICT,
-  INDEX (a, b, c)
+  INDEX (a, b, c),
+  FAMILY "primary" (a, b, c, rowid)
 )
 
 query TTBITTBB colnames
@@ -832,7 +834,8 @@ statement ok
 CREATE TABLE refers (
   a INT REFERENCES referee,
   b INT,
-  INDEX b_idx (b)
+  INDEX b_idx (b),
+  FAMILY "primary" (a, b, rowid)
 )
 
 # Add some schema changes within the same transaction to verify that a

--- a/pkg/sql/logictest/testdata/logic_test/fk_opt
+++ b/pkg/sql/logictest/testdata/logic_test/fk_opt
@@ -361,7 +361,8 @@ CREATE TABLE delivery (
   shipment int,
   item STRING REFERENCES products (upc),
   FOREIGN KEY ("order", shipment) REFERENCES orders (id, shipment),
-  INDEX (item)
+  INDEX (item),
+  FAMILY "primary" (ts, "order", shipment, item, rowid)
 )
 
 query TT
@@ -687,7 +688,8 @@ CREATE TABLE refpairs (
   b STRING,
   c INT,
   FOREIGN KEY (a, b) REFERENCES pairs (src, dest) ON UPDATE RESTRICT,
-  INDEX (a, b, c)
+  INDEX (a, b, c),
+  FAMILY "primary" (a, b, c, rowid)
 )
 
 query TTBITTBB colnames
@@ -896,7 +898,8 @@ statement ok
 CREATE TABLE refers (
   a INT REFERENCES referee,
   b INT,
-  INDEX b_idx (b)
+  INDEX b_idx (b),
+  FAMILY "primary" (a, b, rowid)
 )
 
 # Add some schema changes within the same transaction to verify that a

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -465,7 +465,8 @@ CREATE TABLE sw (
  cc VARCHAR COLLATE en,
  dc VARCHAR(3) COLLATE en,
  ec STRING COLLATE en,
- fc STRING(3) COLLATE en
+ fc STRING(3) COLLATE en,
+ FAMILY "primary" (a, b, c, d, e, f, g, ac, bc, cc, dc, ec, fc, rowid)
 )
 
 query T
@@ -620,7 +621,10 @@ COMMIT
 subtest regression_32759_33012
 
 statement ok
-CREATE TABLE t32759(x INT, y STRING NOT NULL DEFAULT 'b', z INT)
+CREATE TABLE t32759 (
+  x INT, y STRING DEFAULT 'b' NOT NULL, z INT,
+  FAMILY "primary" (x, z, rowid)
+)
 
 statement ok
 BEGIN; ALTER TABLE t32759 DROP COLUMN y

--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -208,7 +208,8 @@ CREATE TABLE all_interleaves (
   c INT,
   d INT,
   INDEX (c),
-  UNIQUE INDEX (d)
+  UNIQUE INDEX (d),
+  FAMILY "primary" (b, c, d)
 ) INTERLEAVE IN PARENT p1_1 (b)
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -28,7 +28,8 @@ CREATE TABLE c (
   foo JSON,
   bar JSON,
   INVERTED INDEX (foo),
-  INVERTED INDEX (bar)
+  INVERTED INDEX (bar),
+  FAMILY "primary" (id, foo, bar)
 )
 
 query TT

--- a/pkg/sql/logictest/testdata/logic_test/rename_constraint
+++ b/pkg/sql/logictest/testdata/logic_test/rename_constraint
@@ -3,7 +3,8 @@ CREATE TABLE t (
   x INT, y INT,
   CONSTRAINT cu UNIQUE (x),
   CONSTRAINT cc CHECK (x > 10),
-  CONSTRAINT cf FOREIGN KEY (x) REFERENCES t(x)
+  CONSTRAINT cf FOREIGN KEY (x) REFERENCES t(x),
+  FAMILY "primary" (x, y, rowid)
   )
 
 query T

--- a/pkg/sql/logictest/testdata/logic_test/scrub
+++ b/pkg/sql/logictest/testdata/logic_test/scrub
@@ -2,13 +2,15 @@ statement error pgcode 42P01 relation "t" does not exist
 EXPERIMENTAL SCRUB TABLE t
 -----
 
+# TODO(mjibson): remove FAMILY definition after #41002 is fixed.
 statement ok
 CREATE TABLE t (
   id int PRIMARY KEY,
   name STRING,
   data INT DEFAULT 2,
   CONSTRAINT abc CHECK (name > 'he'),
-  INDEX name_idx (name)
+  INDEX name_idx (name),
+  FAMILY "primary" (id, name, data)
 )
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/serial
+++ b/pkg/sql/logictest/testdata/logic_test/serial
@@ -5,7 +5,8 @@ CREATE TABLE serial (
   a SERIAL PRIMARY KEY,
   b INT DEFAULT 7,
   c SERIAL,
-  UNIQUE INDEX (c)
+  UNIQUE INDEX (c),
+  FAMILY "primary" (a, b, c)
 )
 
 query TT
@@ -38,7 +39,10 @@ statement error conflicting NULL/NOT NULL declarations for column "a" of table "
 CREATE TABLE s1 (a SERIAL NULL)
 
 statement ok
-CREATE TABLE smallbig (a SMALLSERIAL, b BIGSERIAL, c INT)
+CREATE TABLE smallbig (
+  a SMALLSERIAL, b BIGSERIAL, c INT,
+  FAMILY "primary" (a, b, c, rowid)
+)
 
 statement ok
 INSERT INTO smallbig (c) VALUES (7), (7)
@@ -59,7 +63,10 @@ SELECT count(DISTINCT a), count(DISTINCT b), count(DISTINCT c) FROM smallbig
 2 2 1
 
 statement ok
-CREATE TABLE serials (a SERIAL2, b SERIAL4, c SERIAL8, d INT)
+CREATE TABLE serials (
+  a SERIAL2, b SERIAL4, c SERIAL8, d INT,
+  FAMILY "primary" (a, b, c, d, rowid)
+)
 
 query TT
 SHOW CREATE TABLE serials
@@ -98,7 +105,8 @@ CREATE TABLE serial (
   a SERIAL PRIMARY KEY,
   b INT DEFAULT 7,
   c SERIAL,
-  UNIQUE INDEX (c)
+  UNIQUE INDEX (c),
+  FAMILY "primary" (a, b, c)
 )
 
 query TT
@@ -136,7 +144,10 @@ statement error conflicting NULL/NOT NULL declarations for column "a" of table "
 CREATE TABLE s1 (a SERIAL NULL)
 
 statement ok
-CREATE TABLE smallbig (a SMALLSERIAL, b BIGSERIAL, c INT)
+CREATE TABLE smallbig (
+  a SMALLSERIAL, b BIGSERIAL, c INT,
+  FAMILY "primary" (a, b, c, rowid)
+)
 
 statement ok
 INSERT INTO smallbig (c) VALUES (7), (7)
@@ -157,7 +168,10 @@ SELECT count(DISTINCT a), count(DISTINCT b), count(DISTINCT c) FROM smallbig
 2 2 1
 
 statement ok
-CREATE TABLE serials (a SERIAL2, b SERIAL4, c SERIAL8, d INT)
+CREATE TABLE serials (
+  a SERIAL2, b SERIAL4, c SERIAL8, d INT,
+  FAMILY "primary" (a, b, c, d, rowid)
+)
 
 query TT
 SHOW CREATE TABLE serials
@@ -192,7 +206,8 @@ CREATE TABLE serial (
   a SERIAL PRIMARY KEY,
   b INT DEFAULT 7,
   c SERIAL,
-  UNIQUE INDEX (c)
+  UNIQUE INDEX (c),
+  FAMILY "primary" (a, b, c)
 )
 
 query TT
@@ -228,7 +243,8 @@ CREATE TABLE "serial_MixedCase" (
   a SERIAL PRIMARY KEY,
   b INT DEFAULT 7,
   c SERIAL,
-  UNIQUE INDEX (c)
+  UNIQUE INDEX (c),
+  FAMILY "primary" (a, b, c)
 )
 
 query TT
@@ -250,7 +266,10 @@ statement error conflicting NULL/NOT NULL declarations for column "a" of table "
 CREATE TABLE s1 (a SERIAL NULL)
 
 statement ok
-CREATE TABLE smallbig (a SMALLSERIAL, b BIGSERIAL, c INT)
+CREATE TABLE smallbig (
+  a SMALLSERIAL, b BIGSERIAL, c INT,
+  FAMILY "primary" (a, b, c, rowid)
+)
 
 statement ok
 INSERT INTO smallbig (c) VALUES (7), (7)
@@ -271,7 +290,10 @@ SELECT count(DISTINCT a), count(DISTINCT b), count(DISTINCT c) FROM smallbig
 2 2 1
 
 statement ok
-CREATE TABLE serials (a SERIAL2, b SERIAL4, c SERIAL8, d INT)
+CREATE TABLE serials (
+  a SERIAL2, b SERIAL4, c SERIAL8, d INT,
+  FAMILY "primary" (a, b, c, d, rowid)
+)
 
 query TT
 SHOW CREATE TABLE serials

--- a/pkg/sql/opt/exec/execbuilder/testdata/catalog
+++ b/pkg/sql/opt/exec/execbuilder/testdata/catalog
@@ -5,7 +5,8 @@ CREATE TABLE xyz (
   x INT PRIMARY KEY,
   y INT,
   z INT,
-  INDEX foo (z, y)
+  INDEX foo (z, y),
+  FAMILY "primary" (x, y, z)
 )
 
 query T
@@ -32,7 +33,8 @@ CREATE TABLE abcdef (
     c INT DEFAULT (10),
     d INT AS (abcdef.b + c + 1) STORED,
     e INT AS (a) STORED,
-    f INT CHECK (test.abcdef.f > 2)
+    f INT CHECK (test.abcdef.f > 2),
+    FAMILY "primary" (a, b, c, d, e, f, rowid)
 )
 
 query T
@@ -83,14 +85,15 @@ scan uvwxy
 
 # Test foreign keys.
 statement ok
-CREATE TABLE parent (p INT, q INT, r INT, other INT, PRIMARY KEY (p, q, r))
+CREATE TABLE parent (p INT, q INT, r INT, other INT, PRIMARY KEY (p, q, r), FAMILY "primary" (p, q, r, other))
 
 # Simple FK.
 statement ok
 CREATE TABLE child  (
   c INT PRIMARY KEY,
   p INT, q INT, r INT,
-  CONSTRAINT fk FOREIGN KEY (p,q,r) REFERENCES parent(p,q,r)
+  CONSTRAINT fk FOREIGN KEY (p,q,r) REFERENCES parent(p,q,r),
+  FAMILY "primary" (c, p, q, r)
 )
 
 query T
@@ -131,7 +134,8 @@ statement ok
 CREATE TABLE child2  (
   c INT PRIMARY KEY,
   p INT, q INT, r INT,
-  CONSTRAINT fk FOREIGN KEY (p,q,r) REFERENCES parent(p,q,r) MATCH FULL ON DELETE SET NULL ON UPDATE SET DEFAULT
+  CONSTRAINT fk FOREIGN KEY (p,q,r) REFERENCES parent(p,q,r) MATCH FULL ON DELETE SET NULL ON UPDATE SET DEFAULT,
+  FAMILY "primary" (c, p, q, r)
 )
 
 # TODO(radu, justin): we are missing the ON UPDATE part.

--- a/pkg/sql/opt/exec/execbuilder/testdata/ddl
+++ b/pkg/sql/opt/exec/execbuilder/testdata/ddl
@@ -183,7 +183,8 @@ statement ok
 CREATE TABLE t (
   a INT PRIMARY KEY,
   b INT,
-  c INT
+  c INT,
+  FAMILY "primary" (a, b, c)
 )
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -510,7 +510,7 @@ limit                ·            ·
 ·                    spans        ALL
 
 statement ok
-CREATE TABLE tc (a INT, b INT, INDEX c(a))
+CREATE TABLE tc (a INT, b INT, INDEX c(a), FAMILY "primary" (a, b, rowid))
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM tc WHERE a = 10 ORDER BY b

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -4,7 +4,8 @@ statement ok
 CREATE TABLE t (
   a INT PRIMARY KEY,
   b INT,
-  c BOOLEAN
+  c BOOLEAN,
+  FAMILY "primary" (a, b, c)
 )
 
 query TTT

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index_vectorize_off
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index_vectorize_off
@@ -12,7 +12,10 @@ SET vectorize=off
 # then test the results.
 
 statement ok
-CREATE TABLE test2 (id BIGSERIAL PRIMARY KEY, k TEXT UNIQUE, v INT DEFAULT 42);
+CREATE TABLE test2 (
+  id BIGSERIAL PRIMARY KEY, k TEXT UNIQUE, v INT DEFAULT 42,
+  FAMILY "primary" (id, k, v)
+);
 INSERT INTO test2(k)
      VALUES ('001'),('002'),('003'),('004'),('005'),('006'),('007'),('008'),('009'),('010'),
             ('011'),('012'),('013'),('014'),('015'),('016'),('017'),('018'),('019'),('020'),

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -370,7 +370,7 @@ UPDATE t35364 SET x=2.5 RETURNING *
 # Ensure that index hints in UPDATE statements force the choice of a specific index
 # as described in #38799.
 statement ok
-CREATE TABLE t38799 (a INT PRIMARY KEY, b INT, c INT, INDEX foo(b))
+CREATE TABLE t38799 (a INT PRIMARY KEY, b INT, c INT, INDEX foo(b), FAMILY "primary" (a, b, c))
 
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE t38799@foo SET c=2 WHERE a=1


### PR DESCRIPTION
By default, a CREATE TABLE statement in the logic tests will now randomly
create column families. Needed because we regularly forget to test things
with column families. Random testing like this doesn't require anyone
to remember to do anything. Although it is not exhaustive on each run,
it is over the aggregate of our testing. Tests will appear as flakey if
they don't work with column families. This has already found at least
3 bugs, so appears to be worth it.

Release note: None

Release justification: Category 1: Non-production code changes