### PR TITLE
cli: fix the demo licensing code

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -149,6 +149,8 @@ func initCLIDefaults() {
 	demoCtx.runWorkload = false
 	demoCtx.localities = nil
 	demoCtx.geoPartitionedReplicas = false
+	demoCtx.disableTelemetry = false
+	demoCtx.disableLicenseAcquisition = false
 
 	initPreFlagsDefaults()
 
@@ -343,9 +345,11 @@ var sqlfmtCtx struct {
 // demoCtx captures the command-line parameters of the `demo` command.
 // Defaults set by InitCLIDefaults() above.
 var demoCtx struct {
-	nodes                  int
-	useEmptyDatabase       bool
-	runWorkload            bool
-	localities             demoLocalityList
-	geoPartitionedReplicas bool
+	nodes                     int
+	disableTelemetry          bool
+	disableLicenseAcquisition bool
+	useEmptyDatabase          bool
+	runWorkload               bool
+	localities                demoLocalityList
+	geoPartitionedReplicas    bool
 }

--- a/pkg/cli/interactive_tests/test_demo.tcl
+++ b/pkg/cli/interactive_tests/test_demo.tcl
@@ -7,7 +7,7 @@ spawn $argv demo
 # Be polite.
 eexpect "Welcome"
 # Warn the user that they won't get persistence.
-eexpect "Your changes will not be saved!"
+eexpect "your changes to data stored in the demo session will not be saved!"
 # Inform the necessary URL.
 eexpect "Web UI: http:"
 # Ensure same messages as cockroach sql.

--- a/pkg/cli/interactive_tests/test_demo_telemetry.tcl
+++ b/pkg/cli/interactive_tests/test_demo_telemetry.tcl
@@ -7,6 +7,10 @@ start_test "Check cockroach demo telemetry and license check can be disabled"
 # set the proper environment variable
 set env(COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING) "true"
 spawn $argv demo
+
+# Expect an informational message.
+eexpect "Telemetry and automatic license acquisition disabled by configuration."
+
 # wait for the CLI to start up
 eexpect "movr>"
 # send a request for an enterprise feature
@@ -16,4 +20,5 @@ eexpect "use of partitions requires an enterprise license"
 # clean up after the test
 interrupt
 eexpect eof
+
 end_test


### PR DESCRIPTION
Fixes #40734.
Fixes #41024.

Release justification: fixes a flaky test, fixes UX of main new feature

Before this patch, there were multiple problems with the code:

- if the license acquisition was disabled by the env var config,
  the error message would not be clear.
- the licensing code would deadlock silently on OSS-only
  builds (because the license failure channel was not written in that
  control branch).
- the error/warning messages would be interleaved on the same line as
  the input line (missing newline at start of message).
- the test code would fail when the license server is not available.
- the set up of the example database and workload would be performed
  asynchronously, with unclear signalling of when the user
  can expect to use them interactively.

After this patch:
- it's possible to override the license acquisition URL with
  COCKROACH_DEMO_LICENSE_URL, this is used in tests.
- setting up the example database, partitioning and workload is done
  before presenting the interactive prompt.
- partitioning the example database, if requested by
  --geo-partitioned-replicas, waits for license acquisition to
  complete (license acquisition remains asynchronous otherwise).
- impossible configurations are reported early(earlier).

For example:

- OSS-only builds:

```
kena@kenax ~/cockroach % ./cockroach demo --geo-partitioned-replicas
*
* ERROR: enterprise features are required for this demo, cannot run from OSS-only binary
*
Failed running "demo"
```

For license acquisition failures:

```
kena@kenax ~/cockroach % ./cockroach demo --geo-partitioned-replicas
error while contacting licensing server:
Get https://192.168.2.170/api/license?clusterid=5548b310-14b7-46de-8c92-30605bfe95c4&kind=demo&version=v19.2: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
*
* ERROR: license acquisition was unsuccessful.
* Note: enterprise features are needed for --geo-partitioned-replicas.
*
Failed running "demo"
```

Additionally, this change fixes test flakiness that arises from an
unavailable license server.

Release note (cli change): To enable uses of `cockroach demo` with
enterprise features in firewalled network environments, it is now
possible to redirect the license acquisition with the environment
variable COCKROACH_DEMO_LICENSE_URL to a replacement server (for
example a suitably configured HTTP proxy).