### PR TITLE
storage: remove span declaration for merges

### DIFF
--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -571,7 +571,7 @@ func (r *Replica) executeAdminCommandWithDescriptor(
 // hand side range (the subsumed range). It also updates the range
 // addressing metadata. The handover of responsibility for the
 // reassigned key range is carried out seamlessly through a merge
-// trigger carried out as part of the commit of that transaction.  A
+// trigger carried out as part of the commit of that transaction. A
 // merge requires that the two ranges are collocated on the same set
 // of replicas.
 //


### PR DESCRIPTION
I'm just re-sending #40261 (reverted in #40446). These changes are 
intended for 20.1 and will not be merged until after branching.

---

Prior to #28661, we used to include a snapshot of the RHS in the merge
trigger. Due to this, we declared a read only span over the RHS data
range. Now that we require ranges to be collocated during merges, we
didn't need to include the snapshot nor declare the span.

Orthogonal to this are Subsume requests that block out concurrent
commands to the RHS, with the appropriate span declarations contained
therein.

Release justification: N/A
Release note: None