### PR TITLE
stats: add logging to TestDefaultColumns to help debug flake

### DIFF
--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -429,6 +429,17 @@ func TestDefaultColumns(t *testing.T) {
 
 	sqlRun.Exec(t, `CREATE STATISTICS s FROM t.a`)
 
+	// TODO(rytaft): this extra logging was added to help debug issue #38572.
+	// Remove it once that issue is resolved.
+	// === BEGINNING OF EXTRA LOGGING ===
+	res := sqlRun.QueryStr(t, `SHOW CREATE TABLE t.a`)
+	t.Log(sqlutils.MatrixToStr(res))
+	res = sqlRun.QueryStr(t, `EXPLAIN (DISTSQL) CREATE STATISTICS s FROM t.a`)
+	t.Log(sqlutils.MatrixToStr(res))
+	res = sqlRun.QueryStr(t, `SHOW STATISTICS FOR TABLE t.a`)
+	t.Log(sqlutils.MatrixToStr(res))
+	// === END OF EXTRA LOGGING ===
+
 	// There should be 101 stats. One for the primary index, plus 100 other
 	// columns.
 	sqlRun.CheckQueryResults(t,


### PR DESCRIPTION
This commit adds some logging to the `TestDefaultColumns` test in order
to help debug a test failure.

Informs #38572

Release note: None
Release justification: category 1, non-production code change