### PR TITLE
colexec: increase testing of joiners

### DIFF
--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -822,9 +822,7 @@ func createSpecForHashJoiner(tc hjTestCase) *execinfrapb.ProcessorSpec {
 		Type:                 tc.joinType,
 	}
 	projection := make([]uint32, 0, len(tc.leftOutCols)+len(tc.rightOutCols))
-	for _, outCol := range tc.leftOutCols {
-		projection = append(projection, outCol)
-	}
+	projection = append(projection, tc.leftOutCols...)
 	rColOffset := uint32(len(tc.leftTypes))
 	for _, outCol := range tc.rightOutCols {
 		projection = append(projection, rColOffset+outCol)

--- a/pkg/sql/colexec/joiner_util_tmpl.go
+++ b/pkg/sql/colexec/joiner_util_tmpl.go
@@ -68,6 +68,7 @@ func (o *filterFeedOperator) Next(context.Context) coldata.Batch {
 }
 
 func (o *filterFeedOperator) reset() {
+	o.batch.ResetInternalBatch()
 	o.nexted = false
 }
 

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -17,13 +17,15 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/typeconv"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
-
-// TODO(yuzefovich): add unit tests for cases with ON expression.
 
 type mjTestCase struct {
 	description           string
@@ -41,6 +43,7 @@ type mjTestCase struct {
 	expected              []tuple
 	outputBatchSize       uint16
 	skipAllNullsInjection bool
+	onExpr                execinfrapb.Expression
 }
 
 func (tc *mjTestCase) Init() {
@@ -63,8 +66,67 @@ func (tc *mjTestCase) Init() {
 	}
 }
 
+func createSpecForMergeJoiner(tc mjTestCase) *execinfrapb.ProcessorSpec {
+	leftOrdering := execinfrapb.Ordering{}
+	for i, eqCol := range tc.leftEqCols {
+		leftOrdering.Columns = append(
+			leftOrdering.Columns,
+			execinfrapb.Ordering_Column{
+				ColIdx:    eqCol,
+				Direction: tc.leftDirections[i],
+			},
+		)
+	}
+	rightOrdering := execinfrapb.Ordering{}
+	for i, eqCol := range tc.rightEqCols {
+		rightOrdering.Columns = append(
+			rightOrdering.Columns,
+			execinfrapb.Ordering_Column{
+				ColIdx:    eqCol,
+				Direction: tc.rightDirections[i],
+			},
+		)
+	}
+	mjSpec := &execinfrapb.MergeJoinerSpec{
+		LeftOrdering:  leftOrdering,
+		RightOrdering: rightOrdering,
+		OnExpr:        tc.onExpr,
+		Type:          tc.joinType,
+	}
+	projection := make([]uint32, 0, len(tc.leftOutCols)+len(tc.rightOutCols))
+	for _, outCol := range tc.leftOutCols {
+		projection = append(projection, outCol)
+	}
+	rColOffset := uint32(len(tc.leftTypes))
+	for _, outCol := range tc.rightOutCols {
+		projection = append(projection, rColOffset+outCol)
+	}
+	return &execinfrapb.ProcessorSpec{
+		Input: []execinfrapb.InputSyncSpec{
+			{ColumnTypes: typeconv.ToColumnTypes(tc.leftTypes)},
+			{ColumnTypes: typeconv.ToColumnTypes(tc.rightTypes)},
+		},
+		Core: execinfrapb.ProcessorCoreUnion{
+			MergeJoiner: mjSpec,
+		},
+		Post: execinfrapb.PostProcessSpec{
+			Projection:    true,
+			OutputColumns: projection,
+		},
+	}
+}
+
 func TestMergeJoiner(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+	flowCtx := &execinfra.FlowCtx{
+		EvalCtx: &evalCtx,
+		Cfg:     &execinfra.ServerConfig{Settings: st},
+	}
+
 	tcs := []mjTestCase{
 		{
 			description:  "basic test",
@@ -1409,25 +1471,136 @@ func TestMergeJoiner(t *testing.T) {
 			rightEqCols:     []uint32{0},
 			expected:        tuples{{nil}, {nil}, {nil}},
 		},
+		{
+			description:  "INNER JOIN test with ON expression (filter only on left)",
+			joinType:     sqlbase.JoinType_INNER,
+			leftTypes:    []coltypes.T{coltypes.Int64, coltypes.Int64},
+			rightTypes:   []coltypes.T{coltypes.Int64, coltypes.Int64},
+			leftTuples:   tuples{{nil, 0}, {1, 10}, {2, 20}, {3, nil}, {4, 40}},
+			rightTuples:  tuples{{1, nil}, {3, 13}, {4, 14}},
+			leftOutCols:  []uint32{0, 1},
+			rightOutCols: []uint32{},
+			leftEqCols:   []uint32{0},
+			rightEqCols:  []uint32{0},
+			onExpr:       execinfrapb.Expression{Expr: "@1 < 4"},
+			expected:     tuples{{1, 10}, {3, nil}},
+		},
+		{
+			description:  "INNER JOIN test with ON expression (filter only on right)",
+			joinType:     sqlbase.JoinType_INNER,
+			leftTypes:    []coltypes.T{coltypes.Int64, coltypes.Int64},
+			rightTypes:   []coltypes.T{coltypes.Int64, coltypes.Int64},
+			leftTuples:   tuples{{nil, 0}, {1, 10}, {2, 20}, {3, nil}, {4, 40}},
+			rightTuples:  tuples{{1, nil}, {3, 13}, {4, 14}},
+			leftOutCols:  []uint32{0, 1},
+			rightOutCols: []uint32{},
+			leftEqCols:   []uint32{0},
+			rightEqCols:  []uint32{0},
+			onExpr:       execinfrapb.Expression{Expr: "@4 < 14"},
+			expected:     tuples{{3, nil}},
+		},
+		{
+			description:  "INNER JOIN test with ON expression (filter on both)",
+			joinType:     sqlbase.JoinType_INNER,
+			leftTypes:    []coltypes.T{coltypes.Int64, coltypes.Int64},
+			rightTypes:   []coltypes.T{coltypes.Int64, coltypes.Int64},
+			leftTuples:   tuples{{nil, 0}, {1, 10}, {2, 20}, {3, nil}, {4, 40}},
+			rightTuples:  tuples{{1, nil}, {3, 13}, {4, 14}},
+			leftOutCols:  []uint32{0, 1},
+			rightOutCols: []uint32{},
+			leftEqCols:   []uint32{0},
+			rightEqCols:  []uint32{0},
+			onExpr:       execinfrapb.Expression{Expr: "@2 + @3 < 50"},
+			expected:     tuples{{1, 10}, {4, 40}},
+		},
+		{
+			description:  "LEFT SEMI JOIN test with ON expression (filter only on left)",
+			joinType:     sqlbase.JoinType_LEFT_SEMI,
+			leftTypes:    []coltypes.T{coltypes.Int64, coltypes.Int64},
+			rightTypes:   []coltypes.T{coltypes.Int64, coltypes.Int64},
+			leftTuples:   tuples{{nil, 0}, {1, 10}, {2, 20}, {3, nil}, {4, 40}},
+			rightTuples:  tuples{{1, nil}, {3, 13}, {4, 14}},
+			leftOutCols:  []uint32{0, 1},
+			rightOutCols: []uint32{},
+			leftEqCols:   []uint32{0},
+			rightEqCols:  []uint32{0},
+			onExpr:       execinfrapb.Expression{Expr: "@1 < 4"},
+			expected:     tuples{{1, 10}, {3, nil}},
+		},
+		{
+			description:  "LEFT SEMI JOIN test with ON expression (filter only on right)",
+			joinType:     sqlbase.JoinType_LEFT_SEMI,
+			leftTypes:    []coltypes.T{coltypes.Int64, coltypes.Int64},
+			rightTypes:   []coltypes.T{coltypes.Int64, coltypes.Int64},
+			leftTuples:   tuples{{nil, 0}, {1, 10}, {2, 20}, {3, nil}, {4, 40}},
+			rightTuples:  tuples{{1, nil}, {3, 13}, {4, 14}},
+			leftOutCols:  []uint32{0, 1},
+			rightOutCols: []uint32{},
+			leftEqCols:   []uint32{0},
+			rightEqCols:  []uint32{0},
+			onExpr:       execinfrapb.Expression{Expr: "@4 < 14"},
+			expected:     tuples{{3, nil}},
+		},
+		{
+			description:  "LEFT SEMI JOIN test with ON expression (filter on both)",
+			joinType:     sqlbase.JoinType_LEFT_SEMI,
+			leftTypes:    []coltypes.T{coltypes.Int64, coltypes.Int64},
+			rightTypes:   []coltypes.T{coltypes.Int64, coltypes.Int64},
+			leftTuples:   tuples{{nil, 0}, {1, 10}, {2, 20}, {3, nil}, {4, 40}},
+			rightTuples:  tuples{{1, nil}, {3, 13}, {4, 14}},
+			leftOutCols:  []uint32{0, 1},
+			rightOutCols: []uint32{},
+			leftEqCols:   []uint32{0},
+			rightEqCols:  []uint32{0},
+			onExpr:       execinfrapb.Expression{Expr: "@2 + @3 < 50"},
+			expected:     tuples{{1, 10}, {4, 40}},
+		},
+		{
+			description:  "LEFT ANTI JOIN test with ON expression (filter only on left)",
+			joinType:     sqlbase.JoinType_LEFT_ANTI,
+			leftTypes:    []coltypes.T{coltypes.Int64, coltypes.Int64},
+			rightTypes:   []coltypes.T{coltypes.Int64, coltypes.Int64},
+			leftTuples:   tuples{{nil, 0}, {1, 10}, {2, 20}, {3, nil}, {4, 40}},
+			rightTuples:  tuples{{1, nil}, {3, 13}, {4, 14}},
+			leftOutCols:  []uint32{0, 1},
+			rightOutCols: []uint32{},
+			leftEqCols:   []uint32{0},
+			rightEqCols:  []uint32{0},
+			onExpr:       execinfrapb.Expression{Expr: "@1 < 4"},
+			expected:     tuples{{nil, 0}, {2, 20}, {4, 40}},
+		},
+		{
+			description:  "LEFT ANTI JOIN test with ON expression (filter only on right)",
+			joinType:     sqlbase.JoinType_LEFT_ANTI,
+			leftTypes:    []coltypes.T{coltypes.Int64, coltypes.Int64},
+			rightTypes:   []coltypes.T{coltypes.Int64, coltypes.Int64},
+			leftTuples:   tuples{{nil, 0}, {1, 10}, {2, 20}, {3, nil}, {4, 40}},
+			rightTuples:  tuples{{1, nil}, {3, 13}, {4, 14}},
+			leftOutCols:  []uint32{0, 1},
+			rightOutCols: []uint32{},
+			leftEqCols:   []uint32{0},
+			rightEqCols:  []uint32{0},
+			onExpr:       execinfrapb.Expression{Expr: "@4 < 14"},
+			expected:     tuples{{nil, 0}, {1, 10}, {2, 20}, {4, 40}},
+		},
+		{
+			description:  "LEFT ANTI JOIN test with ON expression (filter on both)",
+			joinType:     sqlbase.JoinType_LEFT_ANTI,
+			leftTypes:    []coltypes.T{coltypes.Int64, coltypes.Int64},
+			rightTypes:   []coltypes.T{coltypes.Int64, coltypes.Int64},
+			leftTuples:   tuples{{nil, 0}, {1, 10}, {2, 20}, {3, nil}, {4, 40}},
+			rightTuples:  tuples{{1, nil}, {3, 13}, {4, 14}},
+			leftOutCols:  []uint32{0, 1},
+			rightOutCols: []uint32{},
+			leftEqCols:   []uint32{0},
+			rightEqCols:  []uint32{0},
+			onExpr:       execinfrapb.Expression{Expr: "@2 + @3 < 50"},
+			expected:     tuples{{nil, 0}, {2, 20}, {3, nil}},
+		},
 	}
 
 	for _, tc := range tcs {
 		tc.Init()
-		lOrderings := make([]execinfrapb.Ordering_Column, len(tc.leftEqCols))
-		for i := range tc.leftEqCols {
-			lOrderings[i] = execinfrapb.Ordering_Column{
-				ColIdx:    tc.leftEqCols[i],
-				Direction: tc.leftDirections[i],
-			}
-		}
-
-		rOrderings := make([]execinfrapb.Ordering_Column, len(tc.rightEqCols))
-		for i := range tc.rightEqCols {
-			rOrderings[i] = execinfrapb.Ordering_Column{
-				ColIdx:    tc.rightEqCols[i],
-				Direction: tc.rightDirections[i],
-			}
-		}
 
 		// We use a custom verifier function so that we can get the merge join op
 		// to use a custom output batch size per test, to exercise more cases.
@@ -1435,7 +1608,10 @@ func TestMergeJoiner(t *testing.T) {
 			if mj, ok := output.input.(variableOutputBatchSizeInitializer); ok {
 				mj.initWithOutputBatchSize(tc.outputBatchSize)
 			} else {
-				t.Fatalf("unexpectedly merge joiner doesn't implement mjTestInitializer")
+				// When we have an inner join with ON expression, a filter operator
+				// will be put on top of the merge join, so to make life easier, we'll
+				// just ignore the requested output batch size.
+				output.input.Init()
 			}
 			verify := output.Verify
 			if _, isFullOuter := output.input.(*mergeJoinFullOuterOp); isFullOuter {
@@ -1455,15 +1631,14 @@ func TestMergeJoiner(t *testing.T) {
 		} else {
 			runner = runTestsWithTyps
 		}
-		cols := make([]int, len(tc.leftOutCols)+len(tc.rightOutCols))
-		for i := range cols {
-			cols[i] = i
-		}
 		runner(t, []tuples{tc.leftTuples, tc.rightTuples}, nil /* typs */, tc.expected, mergeJoinVerifier,
 			func(input []Operator) (Operator, error) {
-				return NewMergeJoinOp(tc.joinType, input[0], input[1], tc.leftOutCols,
-					tc.rightOutCols, tc.leftTypes, tc.rightTypes, lOrderings, rOrderings,
-					nil /* filterConstructor */, false /* filterOnlyOnLeft */)
+				spec := createSpecForMergeJoiner(tc)
+				result, err := NewColOperator(ctx, flowCtx, spec, input)
+				if err != nil {
+					return nil, err
+				}
+				return result.Op, nil
 			})
 	}
 }

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -94,9 +94,7 @@ func createSpecForMergeJoiner(tc mjTestCase) *execinfrapb.ProcessorSpec {
 		Type:          tc.joinType,
 	}
 	projection := make([]uint32, 0, len(tc.leftOutCols)+len(tc.rightOutCols))
-	for _, outCol := range tc.leftOutCols {
-		projection = append(projection, outCol)
-	}
+	projection = append(projection, tc.leftOutCols...)
 	rColOffset := uint32(len(tc.leftTypes))
 	for _, outCol := range tc.rightOutCols {
 		projection = append(projection, rColOffset+outCol)

--- a/pkg/sql/colexec/mergejoiner_util.go
+++ b/pkg/sql/colexec/mergejoiner_util.go
@@ -275,13 +275,11 @@ func (bg *mjBufferedGroup) Reset(types []coltypes.T, length int) {
 	execerror.VectorizedInternalPanic("Reset([]coltypes.T, int) should not be called on mjBufferedGroup")
 }
 
-// ResetInternalBatch implements the Batch interface.
+// ResetInternalBatch is not implemented because mjBufferedGroup is not meant
+// to be used by any operator other than the merge joiner, and it should be
+// using reset() instead.
 func (bg *mjBufferedGroup) ResetInternalBatch() {
-	for _, v := range bg.colVecs {
-		if v.Type() == coltypes.Bytes {
-			v.Bytes().Reset()
-		}
-	}
+	execerror.VectorizedInternalPanic("ResetInternalBatch() should not be called on mjBufferedGroup")
 }
 
 // reset resets the state of the buffered group so that we can reuse the
@@ -293,6 +291,9 @@ func (bg *mjBufferedGroup) reset() {
 		// We do not need to reset the column vectors because those will be just
 		// written over, but we do need to reset the nulls.
 		colVec.Nulls().UnsetNulls()
+		if colVec.Type() == coltypes.Bytes {
+			// Bytes type is the only exception to the comment above.
+			colVec.Bytes().Reset()
+		}
 	}
-	bg.ResetInternalBatch()
 }

--- a/pkg/sql/colexec/typeconv/typeconv.go
+++ b/pkg/sql/colexec/typeconv/typeconv.go
@@ -62,6 +62,42 @@ func FromColumnTypes(cts []types.T) ([]coltypes.T, error) {
 	return typs, nil
 }
 
+// ToColumnType converts a types.T that corresponds to the column type. Note
+// that due to the fact that multiple types.T's are represented by a single
+// column type, this conversion might return the type that is unexpected.
+// NOTE: this should only be used in tests.
+func ToColumnType(t coltypes.T) *types.T {
+	switch t {
+	case coltypes.Bool:
+		return types.Bool
+	case coltypes.Bytes:
+		return types.Bytes
+	case coltypes.Decimal:
+		return types.Decimal
+	case coltypes.Int16:
+		return types.Int2
+	case coltypes.Int32:
+		return types.Int4
+	case coltypes.Int64:
+		return types.Int
+	case coltypes.Float64:
+		return types.Float
+	}
+	execerror.VectorizedInternalPanic(fmt.Sprintf("unexpected coltype %s", t.String()))
+	return nil
+}
+
+// ToColumnTypes calls ToColumnType on each element of typs returning the
+// resulting slice.
+func ToColumnTypes(typs []coltypes.T) []types.T {
+	cts := make([]types.T, len(typs))
+	for i := range cts {
+		t := ToColumnType(typs[i])
+		cts[i] = *t
+	}
+	return cts
+}
+
 // GetDatumToPhysicalFn returns a function for converting a datum of the given
 // ColumnType to the corresponding Go type.
 func GetDatumToPhysicalFn(ct *types.T) func(tree.Datum) (interface{}, error) {


### PR DESCRIPTION
**colexec: add unit tests with ON expressions for joiners**

This commit adds unit tests for hash and merge joiners with ON
expression (for join types that are currently supported). Both
tests are refactored to use NewColOperator instead of creating the
operator directly which is needed because ON expression with INNER
join is handled as a filter on top of the joiner.

Fixes: #40634.

**colexec: add post filter when testing joiners against the processors**

This commit adds a filter to the post processing step of testing
hash and merge join operators against the corresponding processors.

Release note: None