### PR TITLE
tree: fix LIKE suboperator with NULL LHS

### DIFF
--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2453,6 +2453,9 @@ func ConvertLikeToRegexp(
 }
 
 func matchLike(ctx *EvalContext, left, right Datum, caseInsensitive bool) (Datum, error) {
+	if left == DNull || right == DNull {
+		return DNull, nil
+	}
 	s, pattern := string(MustBeDString(left)), string(MustBeDString(right))
 	if len(s) == 0 {
 		// An empty string only matches with an empty pattern or a pattern

--- a/pkg/sql/sem/tree/testdata/eval/any_some_all
+++ b/pkg/sql/sem/tree/testdata/eval/any_some_all
@@ -26,6 +26,21 @@ eval
 false
 
 eval
+'foo' LIKE ANY ARRAY[]
+----
+false
+
+eval
+'foo' LIKE ANY (ARRAY['bar', 'baz'])
+----
+false
+
+eval
+'foo' LIKE ANY (ARRAY['foo', 'bar', 'baz'])
+----
+true
+
+eval
 1+1 = SOME (ARRAY[1, 3, 4])
 ----
 false
@@ -47,6 +62,21 @@ false
 
 eval
 1+1 = ALL (ARRAY[2, 2, 2])
+----
+true
+
+eval
+'foo' LIKE ALL ARRAY[]
+----
+true
+
+eval
+'foo' LIKE ALL (ARRAY['foo', 'bar', 'baz'])
+----
+false
+
+eval
+'foo' LIKE ALL (ARRAY['foo', 'foo'])
 ----
 true
 
@@ -88,6 +118,11 @@ eval
 NULL
 
 eval
+'foo' LIKE ANY(NULL::string[])
+----
+NULL
+
+eval
 NULL::int = ANY(NULL::int[])
 ----
 NULL
@@ -99,6 +134,11 @@ NULL
 
 eval
 NULL::int = ALL(NULL::int[])
+----
+NULL
+
+eval
+NULL::string LIKE ANY(NULL::string[])
 ----
 NULL
 
@@ -130,6 +170,21 @@ false
 
 eval
 NULL::int = ALL(ARRAY[]::int[])
+----
+true
+
+eval
+NULL::string LIKE ANY(ARRAY[]::string[])
+----
+false
+
+eval
+NULL::string LIKE SOME(ARRAY[]::string[])
+----
+false
+
+eval
+NULL::string LIKE ALL(ARRAY[]::string[])
 ----
 true
 
@@ -232,3 +287,19 @@ eval
 'aaa' NOT ILIKE ANY (ARRAY['%A%', '%A%'])
 ----
 false
+
+# Regression test for #40841 -- make sure LIKE can handle nulls.
+eval
+NULL::string LIKE ANY(ARRAY['bar', 'baz'])
+----
+NULL
+
+eval
+NULL::string ILIKE ANY(ARRAY['bar%', 'baz'])
+----
+NULL
+
+eval
+NULL::string LIKE ANY(ARRAY['bar', NULL])
+----
+NULL


### PR DESCRIPTION
If a NULL value was present in the LHS of a suboperator with a LIKE
comparison, then previously the server would crash with a panic. Now it
is handled and there are tests.

closes #40841

Release justification: Low impact bug fix that prevents a server crash.

Release note: None