### PR TITLE
roachtest: improve/fix Jepsen error whitelist

### DIFF
--- a/pkg/cmd/roachtest/jepsen.go
+++ b/pkg/cmd/roachtest/jepsen.go
@@ -235,7 +235,7 @@ cd /mnt/data1/jepsen/cockroachdb && set -eo pipefail && \
 		// once the respective issues are fixed.
 		ignoreErr := false
 		if err := runE(c, ctx, controller,
-			`grep "Oh jeez, I'm sorry, Jepsen broke. Here's why" /mnt/data1/jepsen/cockroachdb/invoke.log -A1 `+
+			`grep -E "(Oh jeez, I'm sorry, Jepsen broke. Here's why|Caused by)" /mnt/data1/jepsen/cockroachdb/invoke.log -A1 `+
 				`| grep -e BrokenBarrierException -e InterruptedException -e com.jcraft.jsch.JSchException `+
 				// And one more ssh failure we've seen, apparently encountered when
 				// downloading logs.

--- a/pkg/cmd/roachtest/overload_tpcc_olap.go
+++ b/pkg/cmd/roachtest/overload_tpcc_olap.go
@@ -96,8 +96,8 @@ func verifyNodeLiveness(ctx context.Context, c *cluster, t *test, runDuration ti
 		t.Fatalf("not enough datapoints in timeseries query response: %+v", response)
 	}
 	datapoints := response.Results[0].Datapoints
-	finalCount := datapoints[len(datapoints)-1].Value
-	initialCount := datapoints[0].Value
+	finalCount := int(datapoints[len(datapoints)-1].Value)
+	initialCount := int(datapoints[0].Value)
 	if failures := finalCount - initialCount; failures > maxFailures {
 		t.Fatalf("Node liveness failed %d times, expected no more than %d",
 			failures, maxFailures)


### PR DESCRIPTION
The `invoke.log` often contained a chain of error causes like:
```
ERROR [2019-09-20 18:52:50,463] main - jepsen.cli Oh jeez, I'm sorry, Jepsen broke. Here's why:
java.util.concurrent.ExecutionException: clojure.lang.ExceptionInfo: clj-ssh open-channel failure: session is down {:type :clj-ssh/open-channel-failure, :reason :clj-ssh/session-down}
        at java.util.concurrent.FutureTask.report(FutureTask.java:122) ~[na:1.8.0_222]
        at java.util.concurrent.FutureTask.get(FutureTask.java:192) ~[na:1.8.0_222]
...
        at clojure.main.main(main.java:37) [clojure-1.8.0.jar:na]
Caused by: clojure.lang.ExceptionInfo: clj-ssh open-channel failure: session is down
        at clojure.core$ex_info.invokeStatic(core.clj:4617) ~[clojure-1.8.0.jar:na]
        at clojure.core$ex_info.invoke(core.clj:4617) ~[clojure-1.8.0.jar:na]
...
        at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_222]
Caused by: com.jcraft.jsch.JSchException: session is down
        at com.jcraft.jsch.Session.openChannel(Session.java:853) ~[jsch-0.1.53.jar:na]
        at clj_ssh.ssh$open_channel.invokeStatic(ssh.clj:540) ~[jepsen-0.1.9-SNAPSHOT.jar:na]
```

This commit updates the grep to match against both the primary cause and
these secondary causes, which we've seen in flakes like #40946 would have
matched against the whitelist.

Release justification: Testing only.

Release note: None