### PR TITLE
cli: avoid running Example_demo_locality in the race detector

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -470,45 +470,6 @@ func Example_logging() {
 	// 1
 }
 
-func Example_demo_locality() {
-	c := newCLITest(cliTestParams{noServer: true})
-	defer c.cleanup()
-
-	testData := [][]string{
-		{`demo`, `--nodes`, `3`, `-e`, `select node_id, locality from crdb_internal.gossip_nodes order by node_id`},
-		{`demo`, `--nodes`, `9`, `-e`, `select node_id, locality from crdb_internal.gossip_nodes order by node_id`},
-		{`demo`, `--nodes`, `3`, `--demo-locality=region=us-east1:region=us-east2:region=us-east3`,
-			`-e`, `select node_id, locality from crdb_internal.gossip_nodes order by node_id`},
-	}
-	setCLIDefaultsForTests()
-	for _, cmd := range testData {
-		c.RunWithArgs(cmd)
-	}
-
-	// Output:
-	// demo --nodes 3 -e select node_id, locality from crdb_internal.gossip_nodes order by node_id
-	// node_id	locality
-	// 1	region=us-east1,az=b
-	// 2	region=us-east1,az=c
-	// 3	region=us-east1,az=d
-	// demo --nodes 9 -e select node_id, locality from crdb_internal.gossip_nodes order by node_id
-	// node_id	locality
-	// 1	region=us-east1,az=b
-	// 2	region=us-east1,az=c
-	// 3	region=us-east1,az=d
-	// 4	region=us-west1,az=a
-	// 5	region=us-west1,az=b
-	// 6	region=us-west1,az=c
-	// 7	region=europe-west1,az=b
-	// 8	region=europe-west1,az=c
-	// 9	region=europe-west1,az=d
-	// demo --nodes 3 --demo-locality=region=us-east1:region=us-east2:region=us-east3 -e select node_id, locality from crdb_internal.gossip_nodes order by node_id
-	// node_id	locality
-	// 1	region=us-east1
-	// 2	region=us-east2
-	// 3	region=us-east3
-}
-
 func Example_demo() {
 	c := newCLITest(cliTestParams{noServer: true})
 	defer c.cleanup()

--- a/pkg/cli/demo_locality_test.go
+++ b/pkg/cli/demo_locality_test.go
@@ -1,0 +1,52 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// +build !race
+
+package cli
+
+func Example_demo_locality() {
+	c := newCLITest(cliTestParams{noServer: true})
+	defer c.cleanup()
+
+	testData := [][]string{
+		{`demo`, `--nodes`, `3`, `-e`, `select node_id, locality from crdb_internal.gossip_nodes order by node_id`},
+		{`demo`, `--nodes`, `9`, `-e`, `select node_id, locality from crdb_internal.gossip_nodes order by node_id`},
+		{`demo`, `--nodes`, `3`, `--demo-locality=region=us-east1:region=us-east2:region=us-east3`,
+			`-e`, `select node_id, locality from crdb_internal.gossip_nodes order by node_id`},
+	}
+	setCLIDefaultsForTests()
+	for _, cmd := range testData {
+		c.RunWithArgs(cmd)
+	}
+
+	// Output:
+	// demo --nodes 3 -e select node_id, locality from crdb_internal.gossip_nodes order by node_id
+	// node_id	locality
+	// 1	region=us-east1,az=b
+	// 2	region=us-east1,az=c
+	// 3	region=us-east1,az=d
+	// demo --nodes 9 -e select node_id, locality from crdb_internal.gossip_nodes order by node_id
+	// node_id	locality
+	// 1	region=us-east1,az=b
+	// 2	region=us-east1,az=c
+	// 3	region=us-east1,az=d
+	// 4	region=us-west1,az=a
+	// 5	region=us-west1,az=b
+	// 6	region=us-west1,az=c
+	// 7	region=europe-west1,az=b
+	// 8	region=europe-west1,az=c
+	// 9	region=europe-west1,az=d
+	// demo --nodes 3 --demo-locality=region=us-east1:region=us-east2:region=us-east3 -e select node_id, locality from crdb_internal.gossip_nodes order by node_id
+	// node_id	locality
+	// 1	region=us-east1
+	// 2	region=us-east2
+	// 3	region=us-east3
+}


### PR DESCRIPTION
Fixes  #41045.

See the discussion on #41045: running a 9-node demo cluster under the race detector results in large CPU and ram usage that exceeds the CI budget.

Since the various moving pieces in the code are race-tested in other places, we are solely interested here to unit test functionality, and it's not necessary to run in `testrace`.

Release justification: removes test flakiness

Release note: None