### PR TITLE
colexec: add unit tests for bufferOp and caseOp

### DIFF
--- a/pkg/sql/colexec/buffer.go
+++ b/pkg/sql/colexec/buffer.go
@@ -25,9 +25,8 @@ type bufferOp struct {
 	input Operator
 
 	// read is true if someone has read the current batch already.
-	read     bool
-	batch    *selectionBatch
-	batchLen uint16
+	read  bool
+	batch *selectionBatch
 }
 
 var _ StaticMemoryOperator = &bufferOp{}
@@ -65,8 +64,7 @@ func (b *bufferOp) rewind() {
 // for reads.
 func (b *bufferOp) advance(ctx context.Context) {
 	b.batch.Batch = b.input.Next(ctx)
-	b.batchLen = b.batch.Length()
-	b.read = false
+	b.rewind()
 }
 
 func (b *bufferOp) Next(ctx context.Context) coldata.Batch {

--- a/pkg/sql/colexec/buffer_test.go
+++ b/pkg/sql/colexec/buffer_test.go
@@ -1,0 +1,65 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colexec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBufferOp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	inputTuples := tuples{{int64(1)}, {int64(2)}, {int64(3)}}
+	input := newOpTestInput(coldata.BatchSize(), inputTuples, []coltypes.T{coltypes.Int64})
+	buffer := NewBufferOp(input).(*bufferOp)
+	buffer.Init()
+
+	t.Run("TestBufferReturnsInputCorrectly", func(t *testing.T) {
+		buffer.advance(ctx)
+		b := buffer.Next(ctx)
+		require.Nil(t, b.Selection())
+		require.Equal(t, uint16(len(inputTuples)), b.Length())
+		for i, val := range inputTuples {
+			require.Equal(t, val[0], b.ColVec(0).Int64()[i])
+		}
+
+		// We've read over the batch, so we now should get a zero-length batch.
+		b = buffer.Next(ctx)
+		require.Nil(t, b.Selection())
+		require.Equal(t, uint16(0), b.Length())
+	})
+
+	t.Run("TestBufferRestoresOriginalBatch", func(t *testing.T) {
+		buffer.rewind()
+		b := buffer.Next(ctx)
+		b.SetSelection(true)
+		sel := b.Selection()
+		sel[0] = 1
+		b.SetLength(1)
+
+		// We have modified the selection batch, but rewinding the buffer should
+		// restore the returned batch to the original state.
+		buffer.rewind()
+		b = buffer.Next(ctx)
+		require.Nil(t, b.Selection())
+		require.Equal(t, uint16(len(inputTuples)), b.Length())
+		b = buffer.Next(ctx)
+		require.Nil(t, b.Selection())
+		require.Equal(t, uint16(0), b.Length())
+	})
+}

--- a/pkg/sql/colexec/case.go
+++ b/pkg/sql/colexec/case.go
@@ -111,7 +111,6 @@ func (c *caseOp) Next(ctx context.Context) coldata.Batch {
 
 	outputCol := c.buffer.batch.Batch.ColVec(c.outputIdx)
 	for i := range c.caseOps {
-		c.buffer.rewind()
 		// Run the next case operator chain. It will project its THEN expression
 		// for all tuples that matched its WHEN expression and that were not
 		// already matched.
@@ -208,7 +207,7 @@ func (c *caseOp) Next(ctx context.Context) coldata.Batch {
 	batch.SetLength(origLen)
 	batch.SetSelection(origHasSel)
 	if origHasSel {
-		copy(batch.Selection(), c.origSel)
+		copy(batch.Selection()[:origLen], c.origSel[:origLen])
 	}
 	return batch
 }

--- a/pkg/sql/colexec/case_test.go
+++ b/pkg/sql/colexec/case_test.go
@@ -1,0 +1,92 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colexec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestCaseOp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+	flowCtx := &execinfra.FlowCtx{
+		EvalCtx: &evalCtx,
+		Cfg: &execinfra.ServerConfig{
+			Settings: st,
+		},
+	}
+	spec := &execinfrapb.ProcessorSpec{
+		Input: []execinfrapb.InputSyncSpec{{}},
+		Core: execinfrapb.ProcessorCoreUnion{
+			Noop: &execinfrapb.NoopCoreSpec{},
+		},
+		Post: execinfrapb.PostProcessSpec{
+			RenderExprs: []execinfrapb.Expression{{}},
+		},
+	}
+
+	decs := make([]apd.Decimal, 2)
+	decs[0].SetInt64(0)
+	decs[1].SetInt64(1)
+	zero := decs[0]
+	one := decs[1]
+
+	for _, tc := range []struct {
+		tuples     tuples
+		renderExpr string
+		expected   tuples
+		inputTypes []types.T
+	}{
+		{
+			// Basic test.
+			tuples:     tuples{{1}, {2}, {nil}, {3}},
+			renderExpr: "CASE WHEN @1 = 2 THEN 1 ELSE 0 END",
+			expected:   tuples{{0}, {1}, {0}, {0}},
+			inputTypes: []types.T{*types.Int},
+		},
+		{
+			// Test "reordered when's."
+			tuples:     tuples{{1, 1}, {2, 0}, {nil, nil}, {3, 3}},
+			renderExpr: "CASE WHEN @1 + @2 > 3 THEN 0 WHEN @1 = 2 THEN 1 ELSE 2 END",
+			expected:   tuples{{2}, {1}, {2}, {0}},
+			inputTypes: []types.T{*types.Int, *types.Int},
+		},
+		{
+			// Test the short-circuiting behavior.
+			tuples:     tuples{{1, 2}, {2, 0}, {nil, nil}, {3, 3}},
+			renderExpr: "CASE WHEN @1 = 2 THEN 0::DECIMAL WHEN @1 / @2 = 1 THEN 1::DECIMAL END",
+			expected:   tuples{{nil}, {zero}, {nil}, {one}},
+			inputTypes: []types.T{*types.Int, *types.Int},
+		},
+	} {
+		runTests(t, []tuples{tc.tuples}, tc.expected, orderedVerifier, func(inputs []Operator) (Operator, error) {
+			spec.Input[0].ColumnTypes = tc.inputTypes
+			spec.Post.RenderExprs[0].Expr = tc.renderExpr
+			result, err := NewColOperator(ctx, flowCtx, spec, inputs)
+			if err != nil {
+				return nil, err
+			}
+			return result.Op, nil
+		})
+	}
+}


### PR DESCRIPTION
**colexec: minor tweaks to bufferOp and caseOp**

This commit cleans up a few things:
- removes an unused batchLen field
- reuses rewind() within advance()
- removes the duplicate call to rewind() in caseOp.Next()
- slices up to origLen when restoring the original selection vector.

Release justification: Category 1: Non-production code changes.

**colexec: add unit tests for bufferOp**

Addresses: #40634.

Release justification: Category 1: Non-production code changes.

**colexec: add some unit tests for caseOp**

This commit adds some unit tests for case operator.

Addresses: #40634.

Release justification: Category 1: Non-production code changes.

Release note: None