### PR TITLE
sql/row: support IMPORT of tables with multiple column families

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -68,7 +68,7 @@ func TestAllRegisteredImportFixture(t *testing.T) {
 		}
 
 		switch meta.Name {
-		case `ycsb`, `startrek`, `roachmart`, `interleavedpartitioned`:
+		case `startrek`, `roachmart`, `interleavedpartitioned`:
 			// These don't work with IMPORT.
 			continue
 		case `tpch`:

--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -298,3 +298,13 @@ foo13  CREATE TABLE foo13 (
             FAMILY pk (a, b),
             FAMILY fam_1_c_d (e, z)
 )
+
+# Regression test for #41004
+statement ok
+CREATE TABLE foo41004 (x, y, z, FAMILY (y), FAMILY (x), FAMILY (z)) AS
+    VALUES (1, 2, NULL::INT)
+
+query III
+SELECT * FROM foo41004
+----
+1  2  NULL

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -32,7 +32,18 @@ func (i KVInserter) CPut(key, value interface{}, expValue *roachpb.Value) {
 
 // Del is not implemented.
 func (i KVInserter) Del(key ...interface{}) {
-	panic("unimplemented")
+	// This is called when there are multiple column families to ensure that
+	// existing data is cleared. With the exception of IMPORT INTO, the entire
+	// existing keyspace in any IMPORT is guaranteed to be empty, so we don't have
+	// to worry about it.
+	//
+	// IMPORT INTO disallows overwriting an existing row, so we're also okay here.
+	// The reason this works is that row existence is precisely defined as whether
+	// column family 0 exists, meaning that we write column family 0 even if all
+	// the non-pk columns in it are NULL. It follows that either the row does
+	// exist and the imported column family 0 will conflict (and the IMPORT INTO
+	// will fail) or the row does not exist (and thus the column families are all
+	// empty).
 }
 
 // Put method of the putter interface.


### PR DESCRIPTION
When importing a table with multiple column families, if one of the
families is all NULL, we omit it from KV. A delete is issued to remove
the previous value of that column family. This was previously hitting an
unimplemented panic when used with IMPORT.

This delete is called when there are multiple column families to ensure
that existing data is cleared. With the exception of IMPORT INTO, the
entire existing keyspace in any IMPORT is guaranteed to be empty, so we
don't have to worry about it.

IMPORT INTO disallows overwriting an existing row, so we're also okay
here. The reason this works is that row existence is precisely defined
as whether column family 0 exists, meaning that we write column family 0
even if all the non-pk columns in it are NULL. It follows that either
the row does exist and the imported column family 0 will conflict (and
the IMPORT INTO will fail) or the row does not exist (and thus the
column families are all // empty).

Closes #41004

Release note (bug fix): `workload init ycsb` now works with
`--data-loader=import`

Release justification: Low risk update to fix "--data-loader=import"
when used with ycsb workload