### PR TITLE
roachtest: fix panic when tests fail using an existing cluster

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1071,7 +1071,9 @@ func (c *cluster) setTest(t testI) {
 func (c *cluster) Save(ctx context.Context, msg string, l *logger) {
 	l.PrintfCtx(ctx, "saving cluster %s for debugging (--debug specified)", c)
 	// TODO(andrei): should we extend the cluster here? For how long?
-	c.destroyState.alloc.Freeze()
+	if c.destroyState.owned { // we won't have an alloc for an unowned cluster
+		c.destroyState.alloc.Freeze()
+	}
 	c.r.markClusterAsSaved(c, msg)
 	c.destroyState.mu.Lock()
 	c.destroyState.mu.saved = true


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
    panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x61498e6]

goroutine 67 [running]:
github.com/cockroachdb/cockroach/pkg/util/stop.(*Stopper).Recover(0xc0000e9560, 0x7942500, 0xc0005beb10)
    /Users/lucy/go/src/github.com/cockroachdb/cockroach/pkg/util/stop/stopper.go:181 +0x121
panic(0x6ce8ee0, 0x9b12c10)
    /usr/local/go/src/runtime/panic.go:522 +0x1b5
github.com/cockroachdb/cockroach/pkg/util/quotapool.(*IntAlloc).Freeze(0x0)
```

Release justification: Not production code.

Release note: None