### PR TITLE
zone: Fix zone configuration application bug

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -762,3 +762,18 @@ ALTER RANGE default CONFIGURE ZONE USING num_replicas = 3
 
 statement ok
 ALTER TABLE system.jobs CONFIGURE ZONE USING num_replicas = 3
+
+# Test that index configurations don't infect partition configurations.
+# Specifically we are testing that values written to infect@primary's
+# zone configuration does not appear in partition p1 of infect@primary's zone config.
+statement ok
+CREATE TABLE infect (x INT PRIMARY KEY);
+ALTER TABLE infect PARTITION BY LIST (x) ( PARTITION p1 VALUES IN (1));
+ALTER INDEX infect@primary CONFIGURE ZONE USING num_replicas=5;
+ALTER PARTITION p1 OF TABLE infect CONFIGURE ZONE USING constraints='[+dc=dc1]'
+
+query TT
+SELECT partition_name, zone_config FROM [SHOW PARTITIONS FROM TABLE infect]
+----
+p1 constraints = '[+dc=dc1]'
+

--- a/pkg/config/zone.go
+++ b/pkg/config/zone.go
@@ -516,6 +516,19 @@ func (z *ZoneConfig) GetSubzone(indexID uint32, partition string) *Subzone {
 	return nil
 }
 
+// GetSubzoneExact is similar to GetSubzone but does not find the most specific
+// subzone that applies to a specified index and partition, as it finds either the
+// exact config that applies, or returns nil.
+func (z *ZoneConfig) GetSubzoneExact(indexID uint32, partition string) *Subzone {
+	for _, s := range z.Subzones {
+		if s.IndexID == indexID && s.PartitionName == partition {
+			copySubzone := s
+			return &copySubzone
+		}
+	}
+	return nil
+}
+
 // GetSubzoneForKeySuffix returns the ZoneConfig for the subzone that contains
 // keySuffix, if it exists and its position in the subzones slice.
 func (z ZoneConfig) GetSubzoneForKeySuffix(keySuffix []byte) (*Subzone, int32) {

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -356,7 +356,7 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 
 		var partialSubzone *config.Subzone
 		if index != nil {
-			partialSubzone = partialZone.GetSubzone(uint32(index.ID), partition)
+			partialSubzone = partialZone.GetSubzoneExact(uint32(index.ID), partition)
 			if partialSubzone == nil {
 				partialSubzone = &config.Subzone{Config: *config.NewZoneConfig()}
 			}


### PR DESCRIPTION
There was a bug that allowed zone configuration application on indexes
to leak into the zone configurations for partitions, due to a subtlety in
ZoneConfig.GetSubzone. This PR fixes the bug with zone configuration
application and adds a test.

This PR is necessary for #40493 to land.

An example of this is as follows:

```
CREATE TABLE infect (x INT PRIMARY KEY);
ALTER TABLE infect PARTITION BY LIST (x) ( PARTITION p1 VALUES IN (1));
ALTER INDEX infect@primary CONFIGURE ZONE USING num_replicas=5;
ALTER PARTITION p1 OF TABLE infect CONFIGURE ZONE USING
constraints='[+dc=dc1]';
```
Before, the zone configuration for p1 would *also have* num_replicas=5
set, which should not be the case. This PR ensures that the zone
configuration for p1 only has constraints set.

Release Justification: Important bug fix.

Release note (bug fix): Fixing bug where zone configuration application
on indexes could leak into configurations on partitions.