### PR TITLE
githooks: add 'Release justification' prompt to commit message template

### DIFF
--- a/githooks/prepare-commit-msg
+++ b/githooks/prepare-commit-msg
@@ -37,10 +37,18 @@ $cchar     <pkg>: <short description>\\
 $cchar\\
 $cchar     <long description>\\
 $cchar\\
+$cchar     Release justification (category): <release justification>\\
+$cchar\\
 $cchar     Release note (category): <release note description>\\
 $cchar     ---\\
 $cchar\\
 $cchar Wrap long lines! 72 columns is best.\\
+$cchar\\
+$cchar Categories for release justification:\\
+$cchar     - non-production code changes\\
+$cchar     - bug fixes and low-risk updates to new functionality\\
+$cchar     - fixes for high-priority or high-severity bugs in existing functionality\\
+$cchar     - low risk, high benefit changes to existing functionality\\
 $cchar\\
 $cchar The release note must be present if your commit has user-facing\\
 $cchar changes. Leave the default above if not.\\
@@ -56,6 +64,15 @@ $cchar     - backwards-incompatible change\\
 $cchar     - performance improvement\\
 $cchar     - bug fix\\
 "
+
+# Add an explicit "Release justification: None" if no release justification was specified.
+if ! grep -q '^Release justification' "$1"; then
+	sed_script+="
+;/$cchar Please enter the commit message for your changes./i\\
+\\
+$cchar Release justification:\\
+"
+fi
 
 # Add an explicit "Release note: None" if no release note was specified.
 if ! grep -q '^Release note' "$1"; then


### PR DESCRIPTION
This looks like:

<img width="1680" alt="Screen Shot 2019-09-25 at 3 33 36 PM" src="https://user-images.githubusercontent.com/5438456/65633390-ff778200-dfa9-11e9-8bfc-4c7103ec441f.png">

We can revert this once we're ready to stop using release justification tags again.

Release justification: non-production code changes.

Release note: None