### PR TITLE
storage: deflake TestStoreRangeWaitForApplication

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -4052,14 +4052,14 @@ func TestStoreRangeRemovalCompactionSuggestion(t *testing.T) {
 func TestStoreRangeWaitForApplication(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	var filterEnabled int32
+	var filterRangeIDAtomic int64
 
 	ctx := context.Background()
 	sc := storage.TestStoreConfig(nil)
 	sc.TestingKnobs.DisableReplicateQueue = true
 	sc.TestingKnobs.DisableReplicaGCQueue = true
-	sc.TestingKnobs.TestingRequestFilter = func(ba roachpb.BatchRequest) *roachpb.Error {
-		if ba.RangeID != 2 || atomic.LoadInt32(&filterEnabled) == 0 {
+	sc.TestingKnobs.TestingRequestFilter = func(ba roachpb.BatchRequest) (retErr *roachpb.Error) {
+		if rangeID := roachpb.RangeID(atomic.LoadInt64(&filterRangeIDAtomic)); rangeID != ba.RangeID {
 			return nil
 		}
 		pErr := roachpb.NewErrorf("blocking %s in this test", ba.Summary())
@@ -4092,7 +4092,7 @@ func TestStoreRangeWaitForApplication(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	atomic.StoreInt32(&filterEnabled, 1)
+	atomic.StoreInt64(&filterRangeIDAtomic, int64(rangeID))
 
 	leaseIndex0 := repl0.LastAssignedLeaseIndex()
 
@@ -4173,7 +4173,7 @@ func TestStoreRangeWaitForApplication(t *testing.T) {
 		}
 	}
 
-	atomic.StoreInt32(&filterEnabled, 0)
+	atomic.StoreInt64(&filterRangeIDAtomic, 0)
 
 	// GC the replica while a request is in progress. The request should return
 	// an error.


### PR DESCRIPTION
It had hardcoded rangeID 2 as the data range, but this stopped being
true when MTC started splitting the initial ranges.

The question is then how it ever worked. Seems like the filter is really
only necessary to prevent anything other than the Put explictly sent by
that test from applying. In practice, it looks like we were occasionally
getting a GC request (from where? the gc queue is disabled).

Closes #41040

Release note: None

Release justification: test-only change to deflake