### PR TITLE
sql/parser: adjust the precedence of JSONB operators

### DIFF
--- a/pkg/cmd/roachtest/pgjdbc_blacklist.go
+++ b/pkg/cmd/roachtest/pgjdbc_blacklist.go
@@ -1279,8 +1279,6 @@ var pgjdbcBlackList19_2 = blacklist{
 	"org.postgresql.test.jdbc4.DatabaseMetaDataTest.testGetFunctionsWithBlankPatterns":                                                                                         "unknown",
 	"org.postgresql.test.jdbc4.DatabaseMetaDataTest.testGetFunctionsWithSpecificTypes":                                                                                         "17511",
 	"org.postgresql.test.jdbc4.IsValidTest.testIsValidRemoteClose":                                                                                                             "35897",
-	"org.postgresql.test.jdbc4.JsonbTest.testJsonbNonPreparedStatement":                                                                                                        "40855",
-	"org.postgresql.test.jdbc4.JsonbTest.testJsonbPreparedStatement":                                                                                                           "40855",
 	"org.postgresql.test.jdbc4.PGCopyInputStreamTest.testReadBytesCorrectlyHandlesEof":                                                                                         "unknown",
 	"org.postgresql.test.jdbc4.PGCopyInputStreamTest.testReadBytesCorrectlyReadsDataInChunks":                                                                                  "unknown",
 	"org.postgresql.test.jdbc4.PGCopyInputStreamTest.testStreamCanBeClosedAfterReadUp":                                                                                         "unknown",

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -2107,6 +2107,13 @@ func TestParse2(t *testing.T) {
 
 		{`CREATE TABLE a (b INT) PARTITION BY RANGE (b) (PARTITION p1 VALUES FROM (MINVALUE) TO (1), PARTITION p2 VALUES FROM (2, MAXVALUE) TO (4, 4), PARTITION p3 VALUES FROM (4, 4) TO (MAXVALUE))`,
 			`CREATE TABLE a (b INT8) PARTITION BY RANGE (b) (PARTITION p1 VALUES FROM (minvalue) TO (1), PARTITION p2 VALUES FROM (2, maxvalue) TO (4, 4), PARTITION p3 VALUES FROM (4, 4) TO (maxvalue))`},
+
+		// Check that JSONB operators have higher precedence than '='.
+		{`SELECT '{}'::JSONB ? 'a' = false`, `SELECT ('{}'::JSONB ? 'a') = false`},
+		{`SELECT '{}'::JSONB ?| 'a' = false`, `SELECT ('{}'::JSONB ?| 'a') = false`},
+		{`SELECT '{}'::JSONB ?& 'a' = false`, `SELECT ('{}'::JSONB ?& 'a') = false`},
+		{`SELECT '{}'::JSONB @> '{}'::JSONB = false`, `SELECT ('{}'::JSONB @> '{}'::JSONB) = false`},
+		{`SELECT '{}'::JSONB <@ '{}'::JSONB = false`, `SELECT ('{}'::JSONB <@ '{}'::JSONB) = false`},
 	}
 	for _, d := range testData {
 		t.Run(d.sql, func(t *testing.T) {

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1017,9 +1017,10 @@ func newNameFromStr(s string) *tree.Name {
 %left      AND
 %right     NOT
 %nonassoc  IS ISNULL NOTNULL   // IS sets precedence for IS NULL, etc
-%nonassoc  '<' '>' '=' LESS_EQUALS GREATER_EQUALS NOT_EQUALS CONTAINS CONTAINED_BY '?' JSON_SOME_EXISTS JSON_ALL_EXISTS
+%nonassoc  '<' '>' '=' LESS_EQUALS GREATER_EQUALS NOT_EQUALS
 %nonassoc  '~' BETWEEN IN LIKE ILIKE SIMILAR NOT_REGMATCH REGIMATCH NOT_REGIMATCH NOT_LA
 %nonassoc  ESCAPE              // ESCAPE must be just above LIKE/ILIKE/SIMILAR
+%nonassoc  CONTAINS CONTAINED_BY '?' JSON_SOME_EXISTS JSON_ALL_EXISTS
 %nonassoc  OVERLAPS
 %left      POSTFIXOP           // dummy for postfix OP rules
 // To support target_elem without AS, we must give IDENT an explicit priority


### PR DESCRIPTION
Previously, JSONB operators had a precedence different from the one
that Postgres uses. This commit brings it more inline with the latter
and improves the compatibility.

All of the affected operators fall under '(any other operator)'
category in
https://www.postgresql.org/docs/12/sql-syntax-lexical.html#SQL-PRECEDENCE.

Fixes: #40855.

Release justification: Category 4: Low risk, high benefit changes to
existing functionality.

Release note: None