### PR TITLE
sql,client/txn: rely on AbortSpan poisoning for avoiding missing writes

### DIFF
--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -643,19 +643,6 @@ func (txn *Txn) AddCommitTrigger(trigger func(ctx context.Context)) {
 	txn.commitTriggers = append(txn.commitTriggers, trigger)
 }
 
-// OnCurrentIncarnationFinish adds a closure to be executed when the transaction
-// sender moves from state "ready" to "done" or "aborted".
-// Note that, as the name suggests, this callback is not persistent across
-// different underlying KV transactions. In other words, once a
-// TransactionAbortedError happens, the callback is called, but then it won't be
-// called again after the client restarts. This is not intended to be used by
-// layers above the retries.
-func (txn *Txn) OnCurrentIncarnationFinish(onFinishFn func(error)) {
-	txn.mu.Lock()
-	defer txn.mu.Unlock()
-	txn.mu.sender.OnFinish(onFinishFn)
-}
-
 func endTxnReq(commit bool, deadline *hlc.Timestamp, hasTrigger bool) roachpb.Request {
 	req := &roachpb.EndTransactionRequest{
 		Commit:   commit,


### PR DESCRIPTION
DistSQL had this awkward mechanism for protecting remote flows
from returning results to the gateway's ConnExecutor after the
transaction had been async aborted. This was so that we don't run the
risk of returning results that have missed seeing their own writes
because the intents were cleaned up. The check had been made obsolete the
moment we changed our async aborts to poison the abort spans for all the
intents they clean up - which serves the same purpose.

Release justification: Removing dead code.

Release note: None