### PR TITLE
sql: no more concurrent requests on RootTxns

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -712,6 +712,8 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><code>pg_get_keywords() &rarr; tuple{string AS word, string AS catcode, string AS catdesc}</code></td><td><span class="funcdesc"><p>Produces a virtual table containing the keywords known to the SQL parser.</p>
 </span></td></tr>
+<tr><td><code>testing_callback(name: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>For internal CRDB testing only. The function calls a callback identified by <code>name</code> registered with the server by the test.</p>
+</span></td></tr>
 <tr><td><code>unnest(input: anyelement[]) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Returns the input array as a set of rows</p>
 </span></td></tr></tbody>
 </table>

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -14,6 +14,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -115,7 +116,7 @@ func (ca *changeAggregator) OutputTypes() []types.T {
 }
 
 // Start is part of the RowSource interface.
-func (ca *changeAggregator) Start(ctx context.Context) context.Context {
+func (ca *changeAggregator) Start(ctx context.Context, _ *client.Txn) context.Context {
 	ctx, ca.cancel = context.WithCancel(ctx)
 	// StartInternal called at the beginning of the function because there are
 	// early returns if errors are detected.
@@ -412,8 +413,8 @@ func (cf *changeFrontier) OutputTypes() []types.T {
 }
 
 // Start is part of the RowSource interface.
-func (cf *changeFrontier) Start(ctx context.Context) context.Context {
-	cf.input.Start(ctx)
+func (cf *changeFrontier) Start(ctx context.Context, txn *client.Txn) context.Context {
+	cf.input.Start(ctx, txn)
 
 	// StartInternal called at the beginning of the function because there are
 	// early returns if errors are detected.

--- a/pkg/ccl/importccl/exportcsv.go
+++ b/pkg/ccl/importccl/exportcsv.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -80,7 +81,7 @@ func (sp *csvWriter) OutputTypes() []types.T {
 	return res
 }
 
-func (sp *csvWriter) Run(ctx context.Context) {
+func (sp *csvWriter) Run(ctx context.Context, txn *client.Txn) {
 	ctx, span := tracing.ChildSpan(ctx, "csvWriter")
 	defer tracing.FinishSpan(span)
 
@@ -91,7 +92,7 @@ func (sp *csvWriter) Run(ctx context.Context) {
 		}
 
 		typs := sp.input.OutputTypes()
-		sp.input.Start(ctx)
+		sp.input.Start(ctx, txn)
 		input := execinfra.MakeNoMetadataRowSource(sp.input, sp.output)
 
 		alloc := &sqlbase.DatumAlloc{}

--- a/pkg/ccl/importccl/import_processor.go
+++ b/pkg/ccl/importccl/import_processor.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -65,7 +66,7 @@ func newReadImportDataProcessor(
 	return cp, nil
 }
 
-func (cp *readImportDataProcessor) Run(ctx context.Context) {
+func (cp *readImportDataProcessor) Run(ctx context.Context, _ *client.Txn) {
 	ctx, span := tracing.ChildSpan(ctx, "readImportDataProcessor")
 	defer tracing.FinishSpan(span)
 

--- a/pkg/ccl/importccl/sst_writer_proc.go
+++ b/pkg/ccl/importccl/sst_writer_proc.go
@@ -64,7 +64,6 @@ func newSSTWriterProcessor(
 		settings:    flowCtx.Cfg.Settings,
 		registry:    flowCtx.Cfg.JobRegistry,
 		progress:    spec.Progress,
-		db:          flowCtx.EvalCtx.Txn.DB(),
 	}
 	if err := sp.out.Init(&execinfrapb.PostProcessSpec{}, sstOutputTypes, flowCtx.NewEvalCtx(), output); err != nil {
 		return nil, err
@@ -96,8 +95,9 @@ func (sp *sstWriter) OutputTypes() []types.T {
 	return sstOutputTypes
 }
 
-func (sp *sstWriter) Run(ctx context.Context) {
-	sp.input.Start(ctx)
+func (sp *sstWriter) Run(ctx context.Context, txn *client.Txn) {
+	sp.input.Start(ctx, txn)
+	sp.db = txn.DB()
 
 	ctx, span := tracing.ChildSpan(ctx, "sstWriter")
 	defer tracing.FinishSpan(span)

--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -1025,3 +1025,8 @@ func (txn *Txn) deadline() *hlc.Timestamp {
 	defer txn.mu.Unlock()
 	return txn.mu.deadline
 }
+
+// GatewayNodeID exposes the transaction's gateway node.
+func (txn *Txn) GatewayNodeID() roachpb.NodeID {
+	return txn.gatewayNodeID
+}

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -1266,3 +1266,8 @@ func (tc *TxnCoordSender) IsTracking() bool {
 	defer tc.mu.Unlock()
 	return tc.interceptorAlloc.txnHeartbeater.heartbeatLoopRunningLocked()
 }
+
+// PrepareForConcurrentReads is part of the client.TxnSender interface.
+func (tc *TxnCoordSender) PrepareForConcurrentReads() (func(), error) {
+	return tc.interceptorAlloc.txnSpanRefresher.SuspendRefreshing()
+}

--- a/pkg/kv/txn_interceptor_span_refresher.go
+++ b/pkg/kv/txn_interceptor_span_refresher.go
@@ -305,6 +305,7 @@ func (sr *txnSpanRefresher) maybeRetrySend(
 func (sr *txnSpanRefresher) tryUpdatingTxnSpans(
 	ctx context.Context, refreshTxn *roachpb.Transaction,
 ) bool {
+	log.Infof(ctx, "!!! refreshing: %s", refreshTxn)
 	// Forward the refreshed timestamp under lock. This in conjunction with a
 	// check in appendRefreshSpans prevents a race where a concurrent request
 	// may add new refresh spans only "verified" up to its batch timestamp after
@@ -416,6 +417,7 @@ func (sr *txnSpanRefresher) populateMetaLocked(meta *roachpb.TxnCoordMeta) {
 
 // augmentMetaLocked implements the txnInterceptor interface.
 func (sr *txnSpanRefresher) augmentMetaLocked(meta roachpb.TxnCoordMeta) {
+	log.Infof(context.TODO(), "!!! augmentMeta with: %s", meta.RefreshReads)
 	// Do not modify existing span slices when copying.
 	if meta.RefreshInvalid {
 		sr.refreshInvalid = true

--- a/pkg/sql/colexec/colexec.go
+++ b/pkg/sql/colexec/colexec.go
@@ -1,0 +1,53 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colexec
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+)
+
+// KVOp is implemented by OpNodes that need to perform KV operations. It
+// contains the SetTxn method through which they get the transaction that they
+// need to use.
+type KVOp interface {
+	SetTxn(context.Context, *client.Txn)
+}
+
+// SetTxn explores a tree of OpNodes, calling SetTxn on every node implementing
+// KVOp. Everything above an UnorderedSynchronizer gets txn. Everything below
+// gets a derived LeafTxn in case txn is a RootTxn.
+//
+// An UnorderedSynchronizer is the only node that introduces concurrency in a
+// tree.
+func SetTxn(ctx context.Context, n execinfra.OpNode, txn *client.Txn) {
+	// Check if this node is forcing us to use switch to a LeafTxn for it and all
+	// its children.
+	if txn.Type() == client.RootTxn {
+		// An UnorderedSynchronizer wants a LeafTxn for all its children because the
+		// children execute concurrently (with one another and with other parts of
+		// the flow).
+		if _, ok := n.(*UnorderedSynchronizer); ok {
+			meta := txn.GetTxnCoordMeta(ctx)
+			txn = client.NewTxnWithCoordMeta(ctx, txn.DB(), txn.GatewayNodeID(), client.LeafTxn, meta)
+		}
+	}
+
+	kvOp, ok := n.(KVOp)
+	if ok {
+		kvOp.SetTxn(ctx, txn)
+	}
+	for i := 0; i < n.ChildCount(); i++ {
+		SetTxn(ctx, n.Child(i), txn)
+	}
+}

--- a/pkg/sql/colexec/materializer.go
+++ b/pkg/sql/colexec/materializer.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -128,7 +129,11 @@ func (m *Materializer) Child(nth int) execinfra.OpNode {
 }
 
 // Start is part of the execinfra.RowSource interface.
-func (m *Materializer) Start(ctx context.Context) context.Context {
+//
+// The txn passed in is ignored. Being part of a vectorizedFlow, all the
+// Operators that need the txn have already gotten it through the SetTxn( )
+// methods at flow start time.
+func (m *Materializer) Start(ctx context.Context, _ *client.Txn) context.Context {
 	m.input.Init()
 	return m.ProcessorBase.StartInternal(ctx, materializerProcName)
 }

--- a/pkg/sql/colexec/materializer_test.go
+++ b/pkg/sql/colexec/materializer_test.go
@@ -63,7 +63,7 @@ func TestColumnarizeMaterialize(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	m.Start(ctx)
+	m.Start(ctx, nil /* txn */)
 
 	for i := 0; i < nRows; i++ {
 		row, meta := m.Next()
@@ -148,7 +148,7 @@ func TestMaterializeTypes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	m.Start(ctx)
+	m.Start(ctx, nil /* txn */)
 
 	row, meta := m.Next()
 	if meta != nil {
@@ -202,7 +202,7 @@ func BenchmarkColumnarizeMaterialize(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		m.Start(ctx)
+		m.Start(ctx, nil /* txn */)
 
 		foundRows := 0
 		for {

--- a/pkg/sql/colflow/colbatch_scan_test.go
+++ b/pkg/sql/colflow/colbatch_scan_test.go
@@ -70,10 +70,10 @@ func BenchmarkColBatchScan(b *testing.B) {
 			flowCtx := execinfra.FlowCtx{
 				EvalCtx: &evalCtx,
 				Cfg:     &execinfra.ServerConfig{Settings: s.ClusterSettings()},
-				Txn:     client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
 				NodeID:  s.NodeID(),
 			}
 
+			txn := client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn)
 			b.SetBytes(int64(numRows * numCols * 8))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -83,6 +83,7 @@ func BenchmarkColBatchScan(b *testing.B) {
 					b.Fatal(err)
 				}
 				tr := res.Op
+				tr.(colexec.KVOp).SetTxn(ctx, txn)
 				tr.Init()
 				b.StartTimer()
 				for {

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/logtags"
@@ -69,6 +70,8 @@ type Outbox struct {
 	// Used to pass a clean context to the input.Next.
 	runnerCtx context.Context
 }
+
+var _ execinfra.OpNode = &Outbox{}
 
 // NewOutbox creates a new Outbox.
 func NewOutbox(

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -140,11 +140,10 @@ func (f *vectorizedFlow) Run(ctx context.Context, txn *client.Txn, doneFn func()
 //
 // If we've been given a LeafTxn, there's nothing more to do.
 func (f *vectorizedFlow) setTxn(ctx context.Context, txn *client.Txn) (bool, error) {
-	// If we've been given a RootTxn,
-	// figure out which components of the flow need a   Look for a leaf Materializer.
-	// That guy needs to get the RootTxn because
-	// there might be mutations feeding into it.
-	// leaves will contain f.leaves - the Materializer (if any).
+	// If we've been given a RootTxn, figure out which components of the flow need
+	// a LeafTxn. Look for a leaf Materializer. That guy needs to get the RootTxn
+	// because there might be mutations feeding into it.
+	// leaves will contain f.leaves without the Materializer (if any).
 	leaves := f.leaves[:0]
 	if txn.Type() == client.RootTxn {
 		foundMaterializer := false

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -253,7 +253,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					func() context.CancelFunc { return cancelLocal },
 				)
 				require.NoError(t, err)
-				materializer.Start(ctxLocal)
+				materializer.Start(ctxLocal, nil /* txn */)
 
 				for i := 0; i < 10; i++ {
 					row, meta := materializer.Next()

--- a/pkg/sql/colflow/vectorized_meta_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_meta_propagation_test.go
@@ -97,7 +97,7 @@ func TestVectorizedMetaPropagation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	mtr.Start(ctx)
+	mtr.Start(ctx, nil /* txn */)
 
 	rowCount, metaCount := 0, 0
 	for {

--- a/pkg/sql/colflow/vectorized_panic_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_panic_propagation_test.go
@@ -66,7 +66,7 @@ func TestVectorizedInternalPanic(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	mat.Start(ctx)
+	mat.Start(ctx, nil /* txn */)
 
 	var meta *execinfrapb.ProducerMetadata
 	require.NotPanics(t, func() { _, meta = mat.Next() }, "VectorizedInternalPanic was not caught")
@@ -113,7 +113,7 @@ func TestNonVectorizedPanicPropagation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	mat.Start(ctx)
+	mat.Start(ctx, nil /* txn */)
 
 	require.Panics(t, func() { mat.Next() }, "NonVectorizedPanic was caught by the operators")
 }

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -104,8 +104,8 @@ func verifyColOperator(
 		return err
 	}
 
-	outProc.Start(ctx)
-	outColOp.Start(ctx)
+	outProc.Start(ctx, nil /* txn */)
+	outColOp.Start(ctx, nil /* txn */)
 	defer outProc.ConsumerClosed()
 	defer outColOp.ConsumerClosed()
 

--- a/pkg/sql/distsql/sync_flow_after_drain_test.go
+++ b/pkg/sql/distsql/sync_flow_after_drain_test.go
@@ -73,7 +73,7 @@ func TestSyncFlowAfterDrain(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := flow.Start(ctx, func() {}); err != nil {
+	if err := flow.Start(ctx, nil /* txn */, func() {} /* doneFn */); err != nil {
 		t.Fatal(err)
 	}
 	flow.Wait()

--- a/pkg/sql/distsql/vectorized_panic_propagation_test.go
+++ b/pkg/sql/distsql/vectorized_panic_propagation_test.go
@@ -85,5 +85,5 @@ func TestNonVectorizedPanicDoesntHangServer(t *testing.T) {
 		}),
 	)
 
-	require.Panics(t, func() { require.NoError(t, flow.Run(ctx, nil)) })
+	require.Panics(t, func() { require.NoError(t, flow.Run(ctx, nil, nil)) })
 }

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -275,7 +275,6 @@ func (dsp *DistSQLPlanner) Run(
 	finishedSetupFn func(),
 ) (cleanup func()) {
 	ctx := planCtx.ctx
-
 	var (
 		localState   distsql.LocalState
 		txnCoordMeta *roachpb.TxnCoordMeta
@@ -338,7 +337,7 @@ func (dsp *DistSQLPlanner) Run(
 	}
 
 	// TODO(radu): this should go through the flow scheduler.
-	if err := flow.Run(ctx, func() {}); err != nil {
+	if err := flow.Run(ctx, txn, func() {}); err != nil {
 		log.Fatalf(ctx, "unexpected error from syncFlow.Start(): %s "+
 			"The error should have gone to the consumer.", err)
 	}

--- a/pkg/sql/execinfra/base_test.go
+++ b/pkg/sql/execinfra/base_test.go
@@ -35,7 +35,7 @@ func TestRunDrain(t *testing.T) {
 	src.InitWithBufSizeAndNumSenders(nil, 10, 1)
 	src.Push(nil /* row */, &execinfrapb.ProducerMetadata{Err: fmt.Errorf("test")})
 	src.Push(nil /* row */, nil /* meta */)
-	src.Start(ctx)
+	src.Start(ctx, nil /* txn */)
 
 	// A receiver that is marked as done consuming rows so that Run will
 	// immediately move from forwarding rows and metadata to draining metadata.

--- a/pkg/sql/execinfra/flow_context.go
+++ b/pkg/sql/execinfra/flow_context.go
@@ -13,7 +13,6 @@
 package execinfra
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -44,12 +43,6 @@ type FlowCtx struct {
 	// TODO(andrei): Get rid of this field and pass a non-shared EvalContext to
 	// cores of the processors that need it.
 	EvalCtx *tree.EvalContext
-
-	// The transaction in which kv operations performed by processors in the flow
-	// must be performed. Processors in the Flow will use this txn concurrently.
-	// This field is generally not nil, except for flows that don't run in a
-	// higher-level txn (like backfills).
-	Txn *client.Txn
 
 	// nodeID is the ID of the node on which the processors using this FlowCtx
 	// run.

--- a/pkg/sql/execinfra/joinreader.go
+++ b/pkg/sql/execinfra/joinreader.go
@@ -218,7 +218,7 @@ func NewJoinReader(
 		jr.fetcher = NewRowFetcherStatCollector(&fetcher)
 		jr.FinishTrace = jr.outputStatsToTrace
 	} else {
-		jr.fetcher = &RowFetcherWrapper{Fetcher: &fetcher}
+		jr.fetcher = &fetcher
 	}
 
 	jr.indexKeyPrefix = sqlbase.MakeIndexKeyPrefix(&jr.desc, jr.index.ID)
@@ -495,9 +495,9 @@ func (jr *JoinReader) performLookup() (joinReaderState, *execinfrapb.ProducerMet
 		}
 
 		// Fetch the next row and copy it into the row container.
-		lookedUpRow, meta := jr.fetcher.Next()
-		if meta != nil {
-			jr.MoveToDraining(scrub.UnwrapScrubError(meta.Err))
+		lookedUpRow, _, _, err := jr.fetcher.NextRow(jr.Ctx)
+		if err != nil {
+			jr.MoveToDraining(scrub.UnwrapScrubError(err))
 			return jrStateUnknown, jr.DrainHelper()
 		}
 		if lookedUpRow == nil {
@@ -636,7 +636,6 @@ func (jr *JoinReader) hasNullLookupColumn(row sqlbase.EncDatumRow) bool {
 func (jr *JoinReader) Start(ctx context.Context) context.Context {
 	jr.input.Start(ctx)
 	ctx = jr.StartInternal(ctx, joinReaderProcName)
-	jr.fetcher.Start(ctx)
 	jr.runningState = jrReadingInput
 	return ctx
 }

--- a/pkg/sql/execinfra/metadata_test_receiver.go
+++ b/pkg/sql/execinfra/metadata_test_receiver.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -139,8 +140,8 @@ func (mtr *MetadataTestReceiver) checkRowNumMetadata() *execinfrapb.ProducerMeta
 }
 
 // Start is part of the RowSource interface.
-func (mtr *MetadataTestReceiver) Start(ctx context.Context) context.Context {
-	mtr.input.Start(ctx)
+func (mtr *MetadataTestReceiver) Start(ctx context.Context, txn *client.Txn) context.Context {
+	mtr.input.Start(ctx, txn)
 	return mtr.StartInternal(ctx, metadataTestReceiverProcName)
 }
 

--- a/pkg/sql/execinfra/metadata_test_sender.go
+++ b/pkg/sql/execinfra/metadata_test_sender.go
@@ -13,6 +13,7 @@ package execinfra
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
@@ -74,8 +75,8 @@ func NewMetadataTestSender(
 }
 
 // Start is part of the RowSource interface.
-func (mts *MetadataTestSender) Start(ctx context.Context) context.Context {
-	mts.input.Start(ctx)
+func (mts *MetadataTestSender) Start(ctx context.Context, txn *client.Txn) context.Context {
+	mts.input.Start(ctx, txn)
 	return mts.StartInternal(ctx, metadataTestSenderProcName)
 }
 

--- a/pkg/sql/execinfra/operator.go
+++ b/pkg/sql/execinfra/operator.go
@@ -10,7 +10,8 @@
 
 package execinfra
 
-// OpNode is an interface to operator-like structures with children.
+// OpNode is an interface to operator-like structures with children. A node's
+// children represent the node's inputs.
 type OpNode interface {
 	// ChildCount returns the number of children (inputs) of the operator.
 	ChildCount() int

--- a/pkg/sql/execinfra/processorbase_test.go
+++ b/pkg/sql/execinfra/processorbase_test.go
@@ -1,0 +1,221 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package execinfra
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/jackc/pgx"
+)
+
+// Test that processors swallow ReadWithinUncertaintyIntervalErrors once they
+// started draining. The code that this test is checking is in ProcessorBase.
+// The test is written using high-level interfaces since what's truly
+// interesting to test is the integration between DistSQL and KV.
+func TestDrainingProcessorSwallowsUncertaintyError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// We're going to test by running a query that selects rows 1..10 with limit
+	// 5. Out of these, rows 1..5 are on node 1, 6..10 on node 2. We're going to
+	// block the read on node 1 until the client gets the 5 rows from node 2. Then
+	// we're going to inject an uncertainty error in the blocked read. The point
+	// of the test is to check that the error is swallowed, because the processor
+	// on the gateway is already draining.
+	// We need to construct this scenario with multiple nodes since you can't have
+	// uncertainty errors if all the data is on the gateway. Then, we'll use a
+	// UNION query to force DistSQL to plan multiple TableReaders (otherwise it
+	// plans just one for LIMIT queries). The point of the test is to force one
+	// extra batch to be read without its rows actually being needed. This is not
+	// entirely easy to cause given the current implementation details.
+
+	var (
+		// trapRead is set, atomically, once the test wants to block a read on the
+		// first node.
+		trapRead    int64
+		blockedRead struct {
+			syncutil.Mutex
+			unblockCond   *sync.Cond
+			shouldUnblock bool
+		}
+	)
+
+	blockedRead.unblockCond = sync.NewCond(&blockedRead.Mutex)
+
+	tc := serverutils.StartTestCluster(t, 3, /* numNodes */
+		base.TestClusterArgs{
+			ReplicationMode: base.ReplicationManual,
+			ServerArgs: base.TestServerArgs{
+				UseDatabase: "test",
+			},
+			ServerArgsPerNode: map[int]base.TestServerArgs{
+				0: {
+					Knobs: base.TestingKnobs{
+						Store: &storage.StoreTestingKnobs{
+							TestingRequestFilter: func(ba roachpb.BatchRequest) *roachpb.Error {
+								if atomic.LoadInt64(&trapRead) == 0 {
+									return nil
+								}
+								// We're going to trap a read for the rows [1,5].
+								req, ok := ba.GetArg(roachpb.Scan)
+								if !ok {
+									return nil
+								}
+								key := req.(*roachpb.ScanRequest).Key.String()
+								endKey := req.(*roachpb.ScanRequest).EndKey.String()
+								if strings.Contains(key, "/1") && strings.Contains(endKey, "5/") {
+									blockedRead.Lock()
+									for !blockedRead.shouldUnblock {
+										blockedRead.unblockCond.Wait()
+									}
+									blockedRead.Unlock()
+									return roachpb.NewError(
+										roachpb.NewReadWithinUncertaintyIntervalError(
+											ba.Timestamp,           /* readTs */
+											ba.Timestamp.Add(1, 0), /* existingTs */
+											ba.Txn))
+								}
+								return nil
+							},
+						},
+					},
+					UseDatabase: "test",
+				},
+			},
+		})
+	defer tc.Stopper().Stop(context.TODO())
+
+	origDB0 := tc.ServerConn(0)
+	sqlutils.CreateTable(t, origDB0, "t",
+		"x INT PRIMARY KEY",
+		10, /* numRows */
+		sqlutils.ToRowFn(sqlutils.RowIdxFn))
+
+	// Split the table and move half of the rows to the 2nd node. We'll block the
+	// read on the first node, and so the rows we're going to be expecting are the
+	// ones from the second node.
+	_, err := origDB0.Exec(fmt.Sprintf(`
+	ALTER TABLE "t" SPLIT AT VALUES (6);
+	ALTER TABLE "t" EXPERIMENTAL_RELOCATE VALUES (ARRAY[%d], 0), (ARRAY[%d], 6);
+	`,
+		tc.Server(0).GetFirstStoreID(),
+		tc.Server(1).GetFirstStoreID()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure that the range cache is populated.
+	if _, err = origDB0.Exec(`SELECT count(1) FROM t`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Disable results buffering - we want to ensure that the server doesn't do
+	// any automatic retries, and also we use the client to know when to unblock
+	// the read.
+	if _, err := origDB0.Exec(
+		`SET CLUSTER SETTING sql.defaults.results_buffer.size = '0'`,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	pgURL, cleanup := sqlutils.PGUrl(
+		t, tc.Server(0).ServingSQLAddr(), t.Name(), url.User(security.RootUser))
+	defer cleanup()
+	pgURL.Path = `test`
+	pgxConfig, err := pgx.ParseConnectionString(pgURL.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := pgx.Connect(pgxConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	atomic.StoreInt64(&trapRead, 1)
+
+	// Run with the default vectorize mode and the explicit "on" mode.
+	testutils.RunTrueAndFalse(t, "vectorize", func(t *testing.T, vectorize bool) {
+		// We're going to run the test twice in each vectorize configuration. Once
+		// in "dummy" node, which just verifies that the test is not fooling itself
+		// by increasing the limit from 5 to 6 and checking that we get the injected
+		// error in that case.
+		testutils.RunTrueAndFalse(t, "dummy", func(t *testing.T, dummy bool) {
+			// Force DistSQL to distribute the query. Otherwise, as of Nov 2018, it's hard
+			// to convince it to distribute a query that uses an index.
+			if _, err := conn.Exec("set distsql='always'"); err != nil {
+				t.Fatal(err)
+			}
+			if vectorize {
+				if _, err := conn.Exec("set vectorize='experimental_on'"); err != nil {
+					t.Fatal(err)
+				}
+			}
+			limit := 5
+			if dummy {
+				limit = 6
+			}
+			query := fmt.Sprintf(
+				"select x from t where x <= 5 union all select x from t where x > 5 limit %d",
+				limit)
+			rows, err := conn.Query(query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer rows.Close()
+			i := 6
+			for rows.Next() {
+				var n int
+				if err := rows.Scan(&n); err != nil {
+					t.Fatal(err)
+				}
+				if n != i {
+					t.Fatalf("expected row: %d but got: %d", i, n)
+				}
+				i++
+				// After we've gotten all the rows from the second node, let the first node
+				// return an uncertainty error.
+				if n == 10 {
+					blockedRead.Lock()
+					// Set shouldUnblock to true to have any reads that would block return
+					// an uncertainty error. Signal the cond to wake up any reads that have
+					// already been blocked.
+					blockedRead.shouldUnblock = true
+					blockedRead.unblockCond.Signal()
+					blockedRead.Unlock()
+				}
+			}
+			err = rows.Err()
+			if !dummy {
+				if err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				if !testutils.IsError(err, "ReadWithinUncertaintyIntervalError") {
+					t.Fatalf("expected injected error, got: %v", err)
+				}
+			}
+		})
+	})
+}

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"math"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -35,7 +36,7 @@ type Processor interface {
 	OutputTypes() []types.T
 
 	// Run is the main loop of the processor.
-	Run(context.Context)
+	Run(context.Context, *client.Txn)
 }
 
 // ProcOutputHelper is a helper type that performs filtering and projection on
@@ -717,11 +718,11 @@ func (pb *ProcessorBase) OutputTypes() []types.T {
 }
 
 // Run is part of the processor interface.
-func (pb *ProcessorBase) Run(ctx context.Context) {
+func (pb *ProcessorBase) Run(ctx context.Context, txn *client.Txn) {
 	if pb.Out.output == nil {
 		panic("processor output not initialized for emitting rows")
 	}
-	ctx = pb.self.Start(ctx)
+	ctx = pb.self.Start(ctx, txn)
 	Run(ctx, pb.self, pb.Out.output)
 }
 

--- a/pkg/sql/execinfra/rowfetcher.go
+++ b/pkg/sql/execinfra/rowfetcher.go
@@ -26,7 +26,6 @@ import (
 // RowFetcher is an interface used to abstract a row fetcher so that a stat
 // collector wrapper can be plugged in.
 type RowFetcher interface {
-	RowSource
 	StartScan(
 		_ context.Context, _ *client.Txn, _ roachpb.Spans, limitBatches bool, limitHint int64, traceKV bool,
 	) error
@@ -40,6 +39,9 @@ type RowFetcher interface {
 		limitHint int64,
 		traceKV bool,
 	) error
+
+	NextRow(ctx context.Context) (
+		sqlbase.EncDatumRow, *sqlbase.TableDescriptor, *sqlbase.IndexDescriptor, error)
 
 	// PartialKey is not stat-related but needs to be supported.
 	PartialKey(int) (roachpb.Key, error)

--- a/pkg/sql/execinfra/stats.go
+++ b/pkg/sql/execinfra/stats.go
@@ -31,11 +31,22 @@ type InputStatCollector struct {
 }
 
 var _ RowSource = &InputStatCollector{}
+var _ OpNode = &InputStatCollector{}
 
 // NewInputStatCollector creates a new InputStatCollector that wraps the given
 // input.
 func NewInputStatCollector(input RowSource) *InputStatCollector {
 	return &InputStatCollector{RowSource: input}
+}
+
+// ChildCount is part of the OpNode interface.
+func (isc *InputStatCollector) ChildCount() int {
+	return 1
+}
+
+// Child is part of the OpNode interface.
+func (isc *InputStatCollector) Child(nth int) OpNode {
+	return isc.RowSource.(OpNode)
 }
 
 // Next implements the RowSource interface. It calls Next on the embedded

--- a/pkg/sql/execinfra/testutils.go
+++ b/pkg/sql/execinfra/testutils.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"math"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -53,7 +54,9 @@ func (r *RepeatableRowSource) OutputTypes() []types.T {
 }
 
 // Start is part of the RowSource interface.
-func (r *RepeatableRowSource) Start(ctx context.Context) context.Context { return ctx }
+func (r *RepeatableRowSource) Start(ctx context.Context, _ *client.Txn) context.Context {
+	return ctx
+}
 
 // Next is part of the RowSource interface.
 func (r *RepeatableRowSource) Next() (sqlbase.EncDatumRow, *execinfrapb.ProducerMetadata) {

--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -269,6 +269,7 @@ func (f *FlowBase) startInternal(
 	log.VEventf(
 		ctx, 1, "starting (%d processors, %d startables)", len(f.processors), len(f.startables),
 	)
+	log.Infof(ctx, "!!! startInternal. procs: %s", f.processors)
 
 	ctx, f.ctxCancel = contextutil.WithCancel(ctx)
 	f.ctxDone = ctx.Done()
@@ -304,6 +305,7 @@ func (f *FlowBase) startInternal(
 	// already extracted the head processor and all the others that were fused
 	// with it), and RootTxns don't permit concurrent operations.
 	if len(f.processors) > 0 && txn != nil && txn.Type() == client.RootTxn {
+		log.Infof(ctx, "!!! creating leaf txn")
 		meta := txn.GetTxnCoordMeta(ctx)
 		txn = client.NewTxnWithCoordMeta(ctx, txn.DB(), txn.GatewayNodeID(), client.LeafTxn, meta)
 		// Since some processors execute concurrently with others, we need to

--- a/pkg/sql/physicalplan/aggregator_funcs_test.go
+++ b/pkg/sql/physicalplan/aggregator_funcs_test.go
@@ -58,11 +58,8 @@ func runTestFlow(
 ) sqlbase.EncDatumRows {
 	distSQLSrv := srv.DistSQLServer().(*distsql.ServerImpl)
 
-	txnCoordMeta := txn.GetTxnCoordMeta(context.TODO())
-	txnCoordMeta.StripRootToLeaf()
 	req := execinfrapb.SetupFlowRequest{
-		Version:      execinfra.Version,
-		TxnCoordMeta: &txnCoordMeta,
+		Version: execinfra.Version,
 		Flow: execinfrapb.FlowSpec{
 			FlowID:     execinfrapb.FlowID{UUID: uuid.MakeV4()},
 			Processors: procs,
@@ -75,7 +72,7 @@ func runTestFlow(
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := flow.Start(ctx, func() {}); err != nil {
+	if err := flow.Start(ctx, txn, func() {}); err != nil {
 		t.Fatal(err)
 	}
 	flow.Wait()

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -13,6 +13,7 @@ package sql
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -106,7 +107,11 @@ func (p *planNodeToRowSource) SetInput(ctx context.Context, input execinfra.RowS
 	})
 }
 
-func (p *planNodeToRowSource) Start(ctx context.Context) context.Context {
+// Start is part of the RowSource interface.
+//
+// The txn passed here is ignored. The plan nodes use the bound planner's txn.
+// Hopefully that's the same as this txn.
+func (p *planNodeToRowSource) Start(ctx context.Context, _ *client.Txn) context.Context {
 	// We do not call p.StartInternal to avoid creating a span. Only the context
 	// needs to be set.
 	p.Ctx = ctx

--- a/pkg/sql/project_set.go
+++ b/pkg/sql/project_set.go
@@ -272,7 +272,7 @@ func (n *projectSetNode) Next(params runParams) (bool, error) {
 					if gen == nil {
 						gen = builtins.EmptyGenerator()
 					}
-					if err := gen.Start(); err != nil {
+					if err := gen.Start(params.ctx, params.extendedEvalCtx.Txn); err != nil {
 						return false, err
 					}
 					n.run.gens[i] = gen
@@ -296,7 +296,7 @@ func (n *projectSetNode) Next(params runParams) (bool, error) {
 				// Yes. Is there still work to do for the current row?
 				if !n.run.done[i] {
 					// Yes; heck whether this source still has some values available.
-					hasVals, err := gen.Next()
+					hasVals, err := gen.Next(params.ctx)
 					if err != nil {
 						return false, err
 					}

--- a/pkg/sql/row_source_to_plan_node.go
+++ b/pkg/sql/row_source_to_plan_node.go
@@ -65,7 +65,7 @@ func makeRowSourceToPlanNode(
 }
 
 func (r *rowSourceToPlanNode) startExec(params runParams) error {
-	r.source.Start(params.ctx)
+	r.source.Start(params.ctx, params.p.Txn())
 	return nil
 }
 

--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"unsafe"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -325,17 +326,19 @@ func newOrderedAggregator(
 }
 
 // Start is part of the RowSource interface.
-func (ag *hashAggregator) Start(ctx context.Context) context.Context {
-	return ag.start(ctx, hashAggregatorProcName)
+func (ag *hashAggregator) Start(ctx context.Context, txn *client.Txn) context.Context {
+	return ag.start(ctx, hashAggregatorProcName, txn)
 }
 
 // Start is part of the RowSource interface.
-func (ag *orderedAggregator) Start(ctx context.Context) context.Context {
-	return ag.start(ctx, orderedAggregatorProcName)
+func (ag *orderedAggregator) Start(ctx context.Context, txn *client.Txn) context.Context {
+	return ag.start(ctx, orderedAggregatorProcName, txn)
 }
 
-func (ag *aggregatorBase) start(ctx context.Context, procName string) context.Context {
-	ag.input.Start(ctx)
+func (ag *aggregatorBase) start(
+	ctx context.Context, procName string, txn *client.Txn,
+) context.Context {
+	ag.input.Start(ctx, txn)
 	ctx = ag.StartInternal(ctx, procName)
 	ag.cancelChecker = sqlbase.NewCancelChecker(ctx)
 	ag.runningState = aggAccumulating

--- a/pkg/sql/rowexec/aggregator_test.go
+++ b/pkg/sql/rowexec/aggregator_test.go
@@ -442,7 +442,7 @@ func BenchmarkAggregation(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				d.Run(context.TODO())
+				d.Run(context.Background(), nil /* txn */)
 				input.Reset()
 			}
 			b.StopTimer()
@@ -481,7 +481,7 @@ func BenchmarkCountRows(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		d.Run(context.TODO())
+		d.Run(context.Background(), nil /* txn */)
 		input.Reset()
 	}
 }
@@ -513,7 +513,7 @@ func BenchmarkGrouping(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		d.Run(context.Background())
+		d.Run(context.Background(), nil /* txn */)
 		input.Reset()
 	}
 	b.StopTimer()
@@ -571,7 +571,7 @@ func benchmarkAggregationWithGrouping(b *testing.B, numOrderedCols int) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				d.Run(context.Background())
+				d.Run(context.Background(), nil /* txn */)
 				input.Reset()
 			}
 			b.StopTimer()

--- a/pkg/sql/rowexec/backfiller.go
+++ b/pkg/sql/rowexec/backfiller.go
@@ -112,7 +112,7 @@ func (b backfiller) getMutationsToProcess(
 }
 
 // Run is part of the Processor interface.
-func (b *backfiller) Run(ctx context.Context) {
+func (b *backfiller) Run(ctx context.Context, _ *client.Txn) {
 	opName := fmt.Sprintf("%sBackfiller", b.name)
 	ctx = logtags.AddTag(ctx, opName, int(b.spec.Table.ID))
 	ctx, span := execinfra.ProcessorSpan(ctx, opName)

--- a/pkg/sql/rowexec/bulk_row_writer.go
+++ b/pkg/sql/rowexec/bulk_row_writer.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"sync/atomic"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -177,7 +178,7 @@ func (sp *bulkRowWriter) convertLoop(
 	return nil
 }
 
-func (sp *bulkRowWriter) Run(ctx context.Context) {
+func (sp *bulkRowWriter) Run(ctx context.Context, txn *client.Txn) {
 	ctx, span := tracing.ChildSpan(ctx, "bulkRowWriter")
 	defer tracing.FinishSpan(span)
 
@@ -188,7 +189,7 @@ func (sp *bulkRowWriter) Run(ctx context.Context) {
 	// collationenv, which can't be accessed in parallel.
 	evalCtx := sp.flowCtx.EvalCtx.Copy()
 
-	sp.input.Start(ctx)
+	sp.input.Start(ctx, txn)
 
 	conv, err := row.NewDatumRowConverter(&sp.spec.Table, nil /* targetColNames */, evalCtx, kvCh)
 	if err != nil {

--- a/pkg/sql/rowexec/countrows.go
+++ b/pkg/sql/rowexec/countrows.go
@@ -13,6 +13,7 @@ package rowexec
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -71,8 +72,8 @@ func newCountAggregator(
 	return ag, nil
 }
 
-func (ag *countAggregator) Start(ctx context.Context) context.Context {
-	ag.input.Start(ctx)
+func (ag *countAggregator) Start(ctx context.Context, txn *client.Txn) context.Context {
+	ag.input.Start(ctx, txn)
 	return ag.StartInternal(ctx, countRowsProcName)
 }
 

--- a/pkg/sql/rowexec/distinct.go
+++ b/pkg/sql/rowexec/distinct.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -135,14 +136,14 @@ func NewDistinct(
 }
 
 // Start is part of the RowSource interface.
-func (d *Distinct) Start(ctx context.Context) context.Context {
-	d.input.Start(ctx)
+func (d *Distinct) Start(ctx context.Context, txn *client.Txn) context.Context {
+	d.input.Start(ctx, txn)
 	return d.StartInternal(ctx, distinctProcName)
 }
 
 // Start is part of the RowSource interface.
-func (d *SortedDistinct) Start(ctx context.Context) context.Context {
-	d.input.Start(ctx)
+func (d *SortedDistinct) Start(ctx context.Context, txn *client.Txn) context.Context {
+	d.input.Start(ctx, txn)
 	return d.StartInternal(ctx, sortedDistinctProcName)
 }
 

--- a/pkg/sql/rowexec/distinct_test.go
+++ b/pkg/sql/rowexec/distinct_test.go
@@ -126,7 +126,7 @@ func TestDistinct(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			d.Run(context.Background())
+			d.Run(context.Background(), nil /* txn */)
 			if !out.ProducerClosed() {
 				t.Fatalf("output RowReceiver not closed")
 			}
@@ -175,7 +175,7 @@ func benchmarkDistinct(b *testing.B, orderedColumns []uint32) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				d.Run(context.Background())
+				d.Run(context.Background(), nil /* txn */)
 				input.Reset()
 			}
 		})

--- a/pkg/sql/rowexec/hashjoiner.go
+++ b/pkg/sql/rowexec/hashjoiner.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -214,9 +215,9 @@ func newHashJoiner(
 }
 
 // Start is part of the RowSource interface.
-func (h *hashJoiner) Start(ctx context.Context) context.Context {
-	h.leftSource.Start(ctx)
-	h.rightSource.Start(ctx)
+func (h *hashJoiner) Start(ctx context.Context, txn *client.Txn) context.Context {
+	h.leftSource.Start(ctx, txn)
+	h.rightSource.Start(ctx, txn)
 	ctx = h.StartInternal(ctx, hashJoinerProcName)
 	h.cancelChecker = sqlbase.NewCancelChecker(ctx)
 	h.runningState = hjBuilding

--- a/pkg/sql/rowexec/hashjoiner_test.go
+++ b/pkg/sql/rowexec/hashjoiner_test.go
@@ -113,7 +113,7 @@ func TestHashJoiner(t *testing.T) {
 				if i == 1 {
 					h.forcedStoredSide = &side
 				}
-				h.Run(context.Background())
+				h.Run(context.Background(), nil /* txn */)
 				side = execinfra.OtherSide(h.storedSide)
 
 				if !out.ProducerClosed() {
@@ -212,7 +212,7 @@ func TestHashJoinerError(t *testing.T) {
 			}
 			outTypes := h.OutputTypes()
 			setup(h)
-			h.Run(context.Background())
+			h.Run(context.Background(), nil /* txn */)
 
 			if !out.ProducerClosed() {
 				return errors.New("output RowReceiver not closed")
@@ -347,7 +347,7 @@ func TestHashJoinerDrain(t *testing.T) {
 	h.initialBufferSize = 0
 
 	out.ConsumerDone()
-	h.Run(context.Background())
+	h.Run(context.Background(), nil /* txn */)
 
 	if !out.ProducerClosed() {
 		t.Fatalf("output RowReceiver not closed")
@@ -470,7 +470,7 @@ func TestHashJoinerDrainAfterBuildPhaseError(t *testing.T) {
 	// Disable initial buffering. We always store the right stream in this case.
 	h.initialBufferSize = 0
 
-	h.Run(context.Background())
+	h.Run(context.Background(), nil /* txn */)
 
 	if !out.ProducerClosed() {
 		t.Fatalf("output RowReceiver not closed")
@@ -555,7 +555,7 @@ func BenchmarkHashJoiner(b *testing.B) {
 						if err != nil {
 							b.Fatal(err)
 						}
-						h.Run(context.Background())
+						h.Run(context.Background(), nil /* txn */)
 						leftInput.Reset()
 						rightInput.Reset()
 					}

--- a/pkg/sql/rowexec/mergejoiner.go
+++ b/pkg/sql/rowexec/mergejoiner.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -111,8 +112,8 @@ func newMergeJoiner(
 }
 
 // Start is part of the RowSource interface.
-func (m *mergeJoiner) Start(ctx context.Context) context.Context {
-	m.streamMerger.start(ctx)
+func (m *mergeJoiner) Start(ctx context.Context, txn *client.Txn) context.Context {
+	m.streamMerger.start(ctx, txn)
 	ctx = m.StartInternal(ctx, mergeJoinerProcName)
 	m.cancelChecker = sqlbase.NewCancelChecker(ctx)
 	return ctx

--- a/pkg/sql/rowexec/mergejoiner_test.go
+++ b/pkg/sql/rowexec/mergejoiner_test.go
@@ -712,7 +712,7 @@ func TestMergeJoiner(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			m.Run(context.Background())
+			m.Run(context.Background(), nil /* txn */)
 
 			if !out.ProducerClosed() {
 				t.Fatalf("output RowReceiver not closed")
@@ -817,7 +817,7 @@ func TestConsumerClosed(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			m.Run(context.Background())
+			m.Run(context.Background(), nil /* txn */)
 
 			if !out.ProducerClosed() {
 				t.Fatalf("output RowReceiver not closed")
@@ -864,7 +864,7 @@ func BenchmarkMergeJoiner(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				m.Run(context.Background())
+				m.Run(context.Background(), nil /* txn */)
 				leftInput.Reset()
 				rightInput.Reset()
 			}
@@ -883,7 +883,7 @@ func BenchmarkMergeJoiner(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				m.Run(context.Background())
+				m.Run(context.Background(), nil /* txn */)
 				leftInput.Reset()
 				rightInput.Reset()
 			}
@@ -903,7 +903,7 @@ func BenchmarkMergeJoiner(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				m.Run(context.Background())
+				m.Run(context.Background(), nil /* txn */)
 				leftInput.Reset()
 				rightInput.Reset()
 			}

--- a/pkg/sql/rowexec/noop.go
+++ b/pkg/sql/rowexec/noop.go
@@ -13,6 +13,7 @@ package rowexec
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -56,8 +57,8 @@ func newNoopProcessor(
 }
 
 // Start is part of the RowSource interface.
-func (n *noopProcessor) Start(ctx context.Context) context.Context {
-	n.input.Start(ctx)
+func (n *noopProcessor) Start(ctx context.Context, txn *client.Txn) context.Context {
+	n.input.Start(ctx, txn)
 	return n.StartInternal(ctx, noopProcName)
 }
 

--- a/pkg/sql/rowexec/noop_test.go
+++ b/pkg/sql/rowexec/noop_test.go
@@ -52,7 +52,7 @@ func BenchmarkNoop(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				d.Run(context.Background())
+				d.Run(context.Background(), nil /* txn */)
 				input.Reset()
 			}
 		})

--- a/pkg/sql/rowexec/ordinality.go
+++ b/pkg/sql/rowexec/ordinality.go
@@ -13,6 +13,7 @@ package rowexec
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -77,8 +78,8 @@ func newOrdinalityProcessor(
 }
 
 // Start is part of the RowSource interface.
-func (o *ordinalityProcessor) Start(ctx context.Context) context.Context {
-	o.input.Start(ctx)
+func (o *ordinalityProcessor) Start(ctx context.Context, txn *client.Txn) context.Context {
+	o.input.Start(ctx, txn)
 	return o.StartInternal(ctx, ordinalityProcName)
 }
 

--- a/pkg/sql/rowexec/ordinality_test.go
+++ b/pkg/sql/rowexec/ordinality_test.go
@@ -120,7 +120,7 @@ func TestOrdinality(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			d.Run(context.Background())
+			d.Run(context.Background(), nil /* txn */)
 			if !out.ProducerClosed() {
 				t.Fatalf("output RowReceiver not closed")
 			}
@@ -173,7 +173,7 @@ func BenchmarkOrdinality(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				o.Run(ctx)
+				o.Run(ctx, nil /* txn */)
 				input.Reset()
 			}
 		})

--- a/pkg/sql/rowexec/processor_utils_test.go
+++ b/pkg/sql/rowexec/processor_utils_test.go
@@ -161,7 +161,7 @@ func (p *ProcessorTest) RunTestCases(
 			p.config.BeforeTestCase(processor, inputs, output)
 		}
 
-		processor.Run(ctx)
+		processor.Run(ctx, nil /* txn */)
 
 		if p.config.AfterTestCase != nil {
 			p.config.AfterTestCase(processor, inputs, output)

--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -424,7 +424,7 @@ func TestProcessorBaseContext(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		noop.Start(ctx)
+		noop.Start(ctx, nil /* txn */)
 		origCtx := noop.Ctx
 
 		// The context should be valid after Start but before Next is called in case

--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -12,31 +12,18 @@ package rowexec
 
 import (
 	"context"
-	"fmt"
-	"net/url"
 	"strconv"
 	"strings"
-	"sync"
-	"sync/atomic"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/storage"
-	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/jackc/pgx"
 )
 
 func TestPostProcess(t *testing.T) {
@@ -478,195 +465,6 @@ func TestProcessorBaseContext(t *testing.T) {
 			noop.Next()
 			noop.ConsumerClosed()
 			noop.ConsumerClosed()
-		})
-	})
-}
-
-// Test that processors swallow ReadWithinUncertaintyIntervalErrors once they
-// started draining. The code that this test is checking is in ProcessorBase.
-// The test is written using high-level interfaces since what's truly
-// interesting to test is the integration between DistSQL and KV.
-func TestDrainingProcessorSwallowsUncertaintyError(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	// We're going to test by running a query that selects rows 1..10 with limit
-	// 5. Out of these, rows 1..5 are on node 1, 6..10 on node 2. We're going to
-	// block the read on node 1 until the client gets the 5 rows from node 2. Then
-	// we're going to inject an uncertainty error in the blocked read. The point
-	// of the test is to check that the error is swallowed, because the processor
-	// on the gateway is already draining.
-	// We need to construct this scenario with multiple nodes since you can't have
-	// uncertainty errors if all the data is on the gateway. Then, we'll use a
-	// UNION query to force DistSQL to plan multiple TableReaders (otherwise it
-	// plans just one for LIMIT queries). The point of the test is to force one
-	// extra batch to be read without its rows actually being needed. This is not
-	// entirely easy to cause given the current implementation details.
-
-	var (
-		// trapRead is set, atomically, once the test wants to block a read on the
-		// first node.
-		trapRead    int64
-		blockedRead struct {
-			syncutil.Mutex
-			unblockCond   *sync.Cond
-			shouldUnblock bool
-		}
-	)
-
-	blockedRead.unblockCond = sync.NewCond(&blockedRead.Mutex)
-
-	tc := serverutils.StartTestCluster(t, 3, /* numNodes */
-		base.TestClusterArgs{
-			ReplicationMode: base.ReplicationManual,
-			ServerArgs: base.TestServerArgs{
-				UseDatabase: "test",
-			},
-			ServerArgsPerNode: map[int]base.TestServerArgs{
-				0: {
-					Knobs: base.TestingKnobs{
-						Store: &storage.StoreTestingKnobs{
-							TestingRequestFilter: func(ba roachpb.BatchRequest) *roachpb.Error {
-								if atomic.LoadInt64(&trapRead) == 0 {
-									return nil
-								}
-								// We're going to trap a read for the rows [1,5].
-								req, ok := ba.GetArg(roachpb.Scan)
-								if !ok {
-									return nil
-								}
-								key := req.(*roachpb.ScanRequest).Key.String()
-								endKey := req.(*roachpb.ScanRequest).EndKey.String()
-								if strings.Contains(key, "/1") && strings.Contains(endKey, "5/") {
-									blockedRead.Lock()
-									for !blockedRead.shouldUnblock {
-										blockedRead.unblockCond.Wait()
-									}
-									blockedRead.Unlock()
-									return roachpb.NewError(
-										roachpb.NewReadWithinUncertaintyIntervalError(
-											ba.Timestamp,           /* readTs */
-											ba.Timestamp.Add(1, 0), /* existingTs */
-											ba.Txn))
-								}
-								return nil
-							},
-						},
-					},
-					UseDatabase: "test",
-				},
-			},
-		})
-	defer tc.Stopper().Stop(context.TODO())
-
-	origDB0 := tc.ServerConn(0)
-	sqlutils.CreateTable(t, origDB0, "t",
-		"x INT PRIMARY KEY",
-		10, /* numRows */
-		sqlutils.ToRowFn(sqlutils.RowIdxFn))
-
-	// Split the table and move half of the rows to the 2nd node. We'll block the
-	// read on the first node, and so the rows we're going to be expecting are the
-	// ones from the second node.
-	_, err := origDB0.Exec(fmt.Sprintf(`
-	ALTER TABLE "t" SPLIT AT VALUES (6);
-	ALTER TABLE "t" EXPERIMENTAL_RELOCATE VALUES (ARRAY[%d], 0), (ARRAY[%d], 6);
-	`,
-		tc.Server(0).GetFirstStoreID(),
-		tc.Server(1).GetFirstStoreID()))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Ensure that the range cache is populated.
-	if _, err = origDB0.Exec(`SELECT count(1) FROM t`); err != nil {
-		t.Fatal(err)
-	}
-
-	// Disable results buffering - we want to ensure that the server doesn't do
-	// any automatic retries, and also we use the client to know when to unblock
-	// the read.
-	if _, err := origDB0.Exec(
-		`SET CLUSTER SETTING sql.defaults.results_buffer.size = '0'`,
-	); err != nil {
-		t.Fatal(err)
-	}
-
-	pgURL, cleanup := sqlutils.PGUrl(
-		t, tc.Server(0).ServingSQLAddr(), t.Name(), url.User(security.RootUser))
-	defer cleanup()
-	pgURL.Path = `test`
-	pgxConfig, err := pgx.ParseConnectionString(pgURL.String())
-	if err != nil {
-		t.Fatal(err)
-	}
-	conn, err := pgx.Connect(pgxConfig)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	atomic.StoreInt64(&trapRead, 1)
-
-	// Run with the default vectorize mode and the explicit "on" mode.
-	testutils.RunTrueAndFalse(t, "vectorize", func(t *testing.T, vectorize bool) {
-		// We're going to run the test twice in each vectorize configuration. Once
-		// in "dummy" node, which just verifies that the test is not fooling itself
-		// by increasing the limit from 5 to 6 and checking that we get the injected
-		// error in that case.
-		testutils.RunTrueAndFalse(t, "dummy", func(t *testing.T, dummy bool) {
-			// Force DistSQL to distribute the query. Otherwise, as of Nov 2018, it's hard
-			// to convince it to distribute a query that uses an index.
-			if _, err := conn.Exec("set distsql='always'"); err != nil {
-				t.Fatal(err)
-			}
-			if vectorize {
-				if _, err := conn.Exec("set vectorize='experimental_on'"); err != nil {
-					t.Fatal(err)
-				}
-			}
-			limit := 5
-			if dummy {
-				limit = 6
-			}
-			query := fmt.Sprintf(
-				"select x from t where x <= 5 union all select x from t where x > 5 limit %d",
-				limit)
-			rows, err := conn.Query(query)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer rows.Close()
-			i := 6
-			for rows.Next() {
-				var n int
-				if err := rows.Scan(&n); err != nil {
-					t.Fatal(err)
-				}
-				if n != i {
-					t.Fatalf("expected row: %d but got: %d", i, n)
-				}
-				i++
-				// After we've gotten all the rows from the second node, let the first node
-				// return an uncertainty error.
-				if n == 10 {
-					blockedRead.Lock()
-					// Set shouldUnblock to true to have any reads that would block return
-					// an uncertainty error. Signal the cond to wake up any reads that have
-					// already been blocked.
-					blockedRead.shouldUnblock = true
-					blockedRead.unblockCond.Signal()
-					blockedRead.Unlock()
-				}
-			}
-			err = rows.Err()
-			if !dummy {
-				if err != nil {
-					t.Fatal(err)
-				}
-			} else {
-				if !testutils.IsError(err, "ReadWithinUncertaintyIntervalError") {
-					t.Fatalf("expected injected error, got: %v", err)
-				}
-			}
 		})
 	})
 }

--- a/pkg/sql/rowexec/project_set.go
+++ b/pkg/sql/rowexec/project_set.go
@@ -13,6 +13,7 @@ package rowexec
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
@@ -99,8 +100,8 @@ func newProjectSetProcessor(
 }
 
 // Start is part of the RowSource interface.
-func (ps *projectSetProcessor) Start(ctx context.Context) context.Context {
-	ps.input.Start(ctx)
+func (ps *projectSetProcessor) Start(ctx context.Context, txn *client.Txn) context.Context {
+	ps.input.Start(ctx, txn)
 	ctx = ps.StartInternal(ctx, projectSetProcName)
 
 	// Initialize exprHelpers.

--- a/pkg/sql/rowexec/project_set_test.go
+++ b/pkg/sql/rowexec/project_set_test.go
@@ -171,7 +171,7 @@ func BenchmarkProjectSet(b *testing.B) {
 					b.Fatal(err)
 				}
 
-				p.Run(context.Background())
+				p.Run(context.Background(), nil /* txn */)
 			}
 		})
 	}

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -139,8 +139,8 @@ func (s *sampleAggregator) pushTrailingMeta(ctx context.Context) {
 }
 
 // Run is part of the Processor interface.
-func (s *sampleAggregator) Run(ctx context.Context) {
-	s.input.Start(ctx)
+func (s *sampleAggregator) Run(ctx context.Context, txn *client.Txn) {
+	s.input.Start(ctx, txn)
 	s.StartInternal(ctx, sampleAggregatorProcName)
 
 	earlyExit, err := s.mainLoop(s.Ctx)

--- a/pkg/sql/rowexec/sample_aggregator_test.go
+++ b/pkg/sql/rowexec/sample_aggregator_test.go
@@ -121,7 +121,7 @@ func TestSampleAggregator(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			p.Run(context.Background())
+			p.Run(context.Background(), nil /* txn */)
 		}
 		// Randomly interleave the output rows from the samplers into a single buffer.
 		samplerResults := distsqlutils.NewRowBuffer(samplerOutTypes, nil /* rows */, distsqlutils.RowBufferArgs{})
@@ -154,7 +154,7 @@ func TestSampleAggregator(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		agg.Run(context.Background())
+		agg.Run(context.Background(), nil /* txn */)
 		// Make sure there was no error.
 		finalOut.GetRowsNoMeta(t)
 		r := sqlutils.MakeSQLRunner(sqlDB)

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/axiomhq/hyperloglog"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -174,8 +175,8 @@ func (s *samplerProcessor) pushTrailingMeta(ctx context.Context) {
 }
 
 // Run is part of the Processor interface.
-func (s *samplerProcessor) Run(ctx context.Context) {
-	s.input.Start(ctx)
+func (s *samplerProcessor) Run(ctx context.Context, txn *client.Txn) {
+	s.input.Start(ctx, txn)
 	s.StartInternal(ctx, samplerProcName)
 
 	earlyExit, err := s.mainLoop(s.Ctx)

--- a/pkg/sql/rowexec/sampler_test.go
+++ b/pkg/sql/rowexec/sampler_test.go
@@ -64,7 +64,7 @@ func runSampler(
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.Run(context.Background())
+	p.Run(context.Background(), nil /* txn */)
 
 	// Verify we have numSamples distinct rows.
 	res := make([]int, 0, numSamples)
@@ -219,7 +219,7 @@ func TestSamplerSketch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.Run(context.Background())
+	p.Run(context.Background(), nil /* txn */)
 
 	// Collect the rows, excluding metadata.
 	rows = rows[:0]

--- a/pkg/sql/rowexec/scrub_tablereader.go
+++ b/pkg/sql/rowexec/scrub_tablereader.go
@@ -131,7 +131,7 @@ func newScrubTableReader(
 	); err != nil {
 		return nil, err
 	}
-	tr.fetcher = &execinfra.RowFetcherWrapper{Fetcher: &fetcher}
+	tr.fetcher = &fetcher
 
 	tr.spans = make(roachpb.Spans, len(spec.Spans))
 	for i, s := range spec.Spans {

--- a/pkg/sql/rowexec/sorter.go
+++ b/pkg/sql/rowexec/sorter.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
@@ -270,8 +271,8 @@ func newSortAllProcessor(
 }
 
 // Start is part of the RowSource interface.
-func (s *sortAllProcessor) Start(ctx context.Context) context.Context {
-	s.input.Start(ctx)
+func (s *sortAllProcessor) Start(ctx context.Context, txn *client.Txn) context.Context {
+	s.input.Start(ctx, txn)
 	ctx = s.StartInternal(ctx, sortAllProcName)
 
 	valid, err := s.fill()
@@ -388,8 +389,8 @@ func newSortTopKProcessor(
 }
 
 // Start is part of the RowSource interface.
-func (s *sortTopKProcessor) Start(ctx context.Context) context.Context {
-	s.input.Start(ctx)
+func (s *sortTopKProcessor) Start(ctx context.Context, txn *client.Txn) context.Context {
+	s.input.Start(ctx, txn)
 	ctx = s.StartInternal(ctx, sortTopKProcName)
 
 	// The execution loop for the SortTopK processor is similar to that of the
@@ -577,8 +578,8 @@ func (s *sortChunksProcessor) fill() (bool, error) {
 }
 
 // Start is part of the RowSource interface.
-func (s *sortChunksProcessor) Start(ctx context.Context) context.Context {
-	s.input.Start(ctx)
+func (s *sortChunksProcessor) Start(ctx context.Context, txn *client.Txn) context.Context {
+	s.input.Start(ctx, txn)
 	return s.StartInternal(ctx, sortChunksProcName)
 }
 

--- a/pkg/sql/rowexec/sorter_test.go
+++ b/pkg/sql/rowexec/sorter_test.go
@@ -333,7 +333,7 @@ func TestSorter(t *testing.T) {
 								t.Fatal(err)
 							}
 						}
-						s.Run(context.Background())
+						s.Run(context.Background(), nil /* txn */)
 						if !out.ProducerClosed() {
 							t.Fatalf("output RowReceiver not closed")
 						}
@@ -442,7 +442,7 @@ func BenchmarkSortAll(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				s.Run(context.Background())
+				s.Run(context.Background(), nil /* txn */)
 				input.Reset()
 			}
 		})
@@ -486,7 +486,7 @@ func BenchmarkSortLimit(b *testing.B) {
 					if err != nil {
 						b.Fatal(err)
 					}
-					s.Run(context.Background())
+					s.Run(context.Background(), nil /* txn */)
 					input.Reset()
 				}
 			})
@@ -536,7 +536,7 @@ func BenchmarkSortChunks(b *testing.B) {
 					if err != nil {
 						b.Fatal(err)
 					}
-					s.Run(context.Background())
+					s.Run(context.Background(), nil /* txn */)
 					input.Reset()
 				}
 			})

--- a/pkg/sql/rowexec/stream_group_accumulator.go
+++ b/pkg/sql/rowexec/stream_group_accumulator.go
@@ -13,6 +13,7 @@ package rowexec
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -57,8 +58,8 @@ func makeStreamGroupAccumulator(
 	}
 }
 
-func (s *streamGroupAccumulator) start(ctx context.Context) {
-	s.src.Start(ctx)
+func (s *streamGroupAccumulator) start(ctx context.Context, txn *client.Txn) {
+	s.src.Start(ctx, txn)
 }
 
 // nextGroup returns the next group from the inputs. The returned slice is not safe

--- a/pkg/sql/rowexec/stream_merger.go
+++ b/pkg/sql/rowexec/stream_merger.go
@@ -13,6 +13,7 @@ package rowexec
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -39,9 +40,9 @@ type streamMerger struct {
 	datumAlloc   sqlbase.DatumAlloc
 }
 
-func (sm *streamMerger) start(ctx context.Context) {
-	sm.left.start(ctx)
-	sm.right.start(ctx)
+func (sm *streamMerger) start(ctx context.Context, txn *client.Txn) {
+	sm.left.start(ctx, txn)
+	sm.right.start(ctx, txn)
 }
 
 // NextBatch returns a set of rows from the left stream and a set of rows from

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -152,29 +152,22 @@ func (tr *tableReader) Start(ctx context.Context) context.Context {
 		log.Fatalf(ctx, "tableReader outside of txn")
 	}
 
-	// Like every processor, the tableReader will have a context with a log tag
-	// and a span. The underlying fetcher inherits the proc's span, but not the
-	// log tag.
-	fetcherCtx := ctx
 	ctx = tr.StartInternal(ctx, tableReaderProcName)
-	if procSpan := opentracing.SpanFromContext(ctx); procSpan != nil {
-		fetcherCtx = opentracing.ContextWithSpan(fetcherCtx, procSpan)
-	}
 
 	// This call doesn't do much; the real "starting" is below.
-	tr.fetcher.Start(fetcherCtx)
+	tr.fetcher.Start(ctx)
 	limitBatches := execinfra.ScanShouldLimitBatches(tr.maxResults, tr.limitHint, tr.FlowCtx)
 	log.VEventf(ctx, 1, "starting scan with limitBatches %t", limitBatches)
 	var err error
 	if tr.maxTimestampAge == 0 {
 		err = tr.fetcher.StartScan(
-			fetcherCtx, tr.FlowCtx.Txn, tr.spans,
+			ctx, tr.FlowCtx.Txn, tr.spans,
 			limitBatches, tr.limitHint, tr.FlowCtx.TraceKV,
 		)
 	} else {
 		initialTS := tr.FlowCtx.Txn.GetTxnCoordMeta(ctx).Txn.OrigTimestamp
 		err = tr.fetcher.StartInconsistentScan(
-			fetcherCtx, tr.FlowCtx.Cfg.DB, initialTS,
+			ctx, tr.FlowCtx.Cfg.DB, initialTS,
 			tr.maxTimestampAge, tr.spans,
 			limitBatches, tr.limitHint, tr.FlowCtx.TraceKV,
 		)

--- a/pkg/sql/rowexec/utils_test.go
+++ b/pkg/sql/rowexec/utils_test.go
@@ -46,7 +46,6 @@ func runProcessorTest(
 	flowCtx := execinfra.FlowCtx{
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
-		Txn:     txn,
 	}
 
 	p, err := NewProcessor(
@@ -65,7 +64,7 @@ func runProcessorTest(
 		pt.SetBatchSize(2 /* batchSize */)
 	}
 
-	p.Run(context.Background())
+	p.Run(context.Background(), txn)
 	if !out.ProducerClosed() {
 		t.Fatalf("output RowReceiver not closed")
 	}

--- a/pkg/sql/rowexec/values.go
+++ b/pkg/sql/rowexec/values.go
@@ -13,6 +13,7 @@ package rowexec
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
@@ -66,7 +67,7 @@ func newValuesProcessor(
 }
 
 // Start is part of the RowSource interface.
-func (v *valuesProcessor) Start(ctx context.Context) context.Context {
+func (v *valuesProcessor) Start(ctx context.Context, _ *client.Txn) context.Context {
 	ctx = v.StartInternal(ctx, valuesProcName)
 
 	// Add a bogus header to appease the StreamDecoder, which wants to receive a

--- a/pkg/sql/rowexec/values_test.go
+++ b/pkg/sql/rowexec/values_test.go
@@ -52,7 +52,7 @@ func TestValuesProcessor(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					v.Run(context.Background())
+					v.Run(context.Background(), nil /* txn */)
 					if !out.ProducerClosed() {
 						t.Fatalf("output RowReceiver not closed")
 					}
@@ -124,7 +124,7 @@ func BenchmarkValuesProcessor(b *testing.B) {
 					if err != nil {
 						b.Fatal(err)
 					}
-					v.Run(context.Background())
+					v.Run(context.Background(), nil /* txn */)
 				}
 			})
 		}

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"unsafe"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
@@ -269,8 +270,8 @@ func newWindower(
 }
 
 // Start is part of the RowSource interface.
-func (w *windower) Start(ctx context.Context) context.Context {
-	w.input.Start(ctx)
+func (w *windower) Start(ctx context.Context, txn *client.Txn) context.Context {
+	w.input.Start(ctx, txn)
 	ctx = w.StartInternal(ctx, windowerProcName)
 	w.cancelChecker = sqlbase.NewCancelChecker(ctx)
 	w.runningState = windowerAccumulating

--- a/pkg/sql/rowexec/windower_test.go
+++ b/pkg/sql/rowexec/windower_test.go
@@ -95,7 +95,7 @@ func TestWindowerAccountingForResults(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d.Run(ctx)
+	d.Run(ctx, nil /* txn */)
 	for {
 		row, meta := output.Next()
 		if row != nil {
@@ -252,7 +252,7 @@ func BenchmarkWindower(b *testing.B) {
 					if err != nil {
 						b.Fatal(err)
 					}
-					d.Run(context.TODO())
+					d.Run(context.Background(), nil /* txn */)
 					input.Reset()
 				}
 				b.StopTimer()

--- a/pkg/sql/rowexec/zigzagjoiner_test.go
+++ b/pkg/sql/rowexec/zigzagjoiner_test.go
@@ -502,7 +502,6 @@ func TestZigzagJoiner(t *testing.T) {
 			flowCtx := execinfra.FlowCtx{
 				EvalCtx: &evalCtx,
 				Cfg:     &execinfra.ServerConfig{Settings: st},
-				Txn:     client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
 			}
 
 			out := &distsqlutils.RowBuffer{}
@@ -512,7 +511,8 @@ func TestZigzagJoiner(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			z.Run(ctx)
+			txn := client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn)
+			z.Run(ctx, txn)
 
 			if !out.ProducerClosed() {
 				t.Fatalf("output RowReceiver not closed")
@@ -565,7 +565,6 @@ func TestZigzagJoinerDrain(t *testing.T) {
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
 		Cfg:     &execinfra.ServerConfig{Settings: s.ClusterSettings()},
-		Txn:     client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn),
 	}
 
 	encRow := make(sqlbase.EncDatumRow, 1)
@@ -592,7 +591,8 @@ func TestZigzagJoinerDrain(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		zz.Run(ctx)
+		txn := client.NewTxn(ctx, s.DB(), s.NodeID(), client.RootTxn)
+		zz.Run(ctx, txn)
 	})
 
 	//TODO(pbardea): When RowSource inputs are added, ensure that meta is

--- a/pkg/sql/rowflow/input_sync.go
+++ b/pkg/sql/rowflow/input_sync.go
@@ -17,6 +17,7 @@ import (
 	"container/heap"
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -269,9 +270,9 @@ func (s *orderedSynchronizer) drainSources() {
 }
 
 // Start is part of the RowSource interface.
-func (s *orderedSynchronizer) Start(ctx context.Context) context.Context {
+func (s *orderedSynchronizer) Start(ctx context.Context, txn *client.Txn) context.Context {
 	for _, src := range s.sources {
-		src.src.Start(ctx)
+		src.src.Start(ctx, txn)
 	}
 	return ctx
 }

--- a/pkg/sql/rowflow/input_sync_test.go
+++ b/pkg/sql/rowflow/input_sync_test.go
@@ -118,7 +118,7 @@ func TestOrderedSync(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		src.Start(context.Background())
+		src.Start(context.Background(), nil /* txn */)
 		var retRows sqlbase.EncDatumRows
 		for {
 			row, meta := src.Next()
@@ -158,7 +158,7 @@ func TestOrderedSyncDrainBeforeNext(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	o.Start(ctx)
+	o.Start(ctx, nil /* txn */)
 
 	// Call ConsumerDone before Next has been called.
 	o.ConsumerDone()

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/arith"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
 
@@ -72,11 +73,11 @@ var aclexplodeGeneratorType = types.MakeLabeledTuple(
 // aclExplodeGenerator supports the execution of aclexplode.
 type aclexplodeGenerator struct{}
 
-func (aclexplodeGenerator) ResolvedType() *types.T { return aclexplodeGeneratorType }
-func (aclexplodeGenerator) Start() error           { return nil }
-func (aclexplodeGenerator) Close()                 {}
-func (aclexplodeGenerator) Next() (bool, error)    { return false, nil }
-func (aclexplodeGenerator) Values() tree.Datums    { return nil }
+func (aclexplodeGenerator) ResolvedType() *types.T                       { return aclexplodeGeneratorType }
+func (aclexplodeGenerator) Start(_ context.Context, _ *client.Txn) error { return nil }
+func (aclexplodeGenerator) Close()                                       {}
+func (aclexplodeGenerator) Next(_ context.Context) (bool, error)         { return false, nil }
+func (aclexplodeGenerator) Values() tree.Datums                          { return nil }
 
 // generators is a map from name to slice of Builtins for all built-in
 // generators.
@@ -115,6 +116,24 @@ var generators = map[string]builtinDefinition{
 			seriesTSValueGeneratorType,
 			makeTSSeriesGenerator,
 			"Produces a virtual table containing the timestamp values from `start` to `end`, inclusive, by increment of `step`.",
+		),
+	),
+	// !!! how do I put it in crdb_internal?
+	"testing_callback": makeBuiltin(genProps([]string{"testing_callback"}),
+		makeGeneratorOverload(
+			tree.ArgTypes{{"name", types.String}},
+			types.Int,
+			func(ctx *tree.EvalContext, args tree.Datums) (tree.ValueGenerator, error) {
+				name := string(*args[0].(*tree.DString))
+				gen, ok := ctx.TestingKnobs.CallbackGenerators[name]
+				if !ok {
+					return nil, fmt.Errorf("callback %q not registered", name)
+				}
+				return gen, nil
+			},
+			"For internal CRDB testing only. "+
+				"The function calls a callback identified by `name` registered with the server by"+
+				" the test.",
 		),
 	),
 
@@ -274,11 +293,11 @@ func (*keywordsValueGenerator) ResolvedType() *types.T { return keywordsValueGen
 func (*keywordsValueGenerator) Close() {}
 
 // Start implements the tree.ValueGenerator interface.
-func (k *keywordsValueGenerator) Start() error {
+func (k *keywordsValueGenerator) Start(_ context.Context, _ *client.Txn) error {
 	k.curKeyword = -1
 	return nil
 }
-func (k *keywordsValueGenerator) Next() (bool, error) {
+func (k *keywordsValueGenerator) Next(_ context.Context) (bool, error) {
 	k.curKeyword++
 	return k.curKeyword < len(lex.KeywordNames), nil
 }
@@ -414,7 +433,7 @@ func (s *seriesValueGenerator) ResolvedType() *types.T {
 }
 
 // Start implements the tree.ValueGenerator interface.
-func (s *seriesValueGenerator) Start() error {
+func (s *seriesValueGenerator) Start(_ context.Context, _ *client.Txn) error {
 	s.nextOK = true
 	s.start = s.origStart
 	s.value = s.origStart
@@ -425,13 +444,15 @@ func (s *seriesValueGenerator) Start() error {
 func (s *seriesValueGenerator) Close() {}
 
 // Next implements the tree.ValueGenerator interface.
-func (s *seriesValueGenerator) Next() (bool, error) {
+func (s *seriesValueGenerator) Next(_ context.Context) (bool, error) {
 	return s.next(s)
 }
 
 // Values implements the tree.ValueGenerator interface.
 func (s *seriesValueGenerator) Values() tree.Datums {
-	return s.genValue(s)
+	x := s.genValue(s)
+	log.Infof(context.TODO(), "series returning: %s", x)
+	return x
 }
 
 func makeArrayGenerator(_ *tree.EvalContext, args tree.Datums) (tree.ValueGenerator, error) {
@@ -454,7 +475,7 @@ func (s *arrayValueGenerator) ResolvedType() *types.T {
 }
 
 // Start implements the tree.ValueGenerator interface.
-func (s *arrayValueGenerator) Start() error {
+func (s *arrayValueGenerator) Start(_ context.Context, _ *client.Txn) error {
 	s.nextIndex = -1
 	return nil
 }
@@ -463,7 +484,7 @@ func (s *arrayValueGenerator) Start() error {
 func (s *arrayValueGenerator) Close() {}
 
 // Next implements the tree.ValueGenerator interface.
-func (s *arrayValueGenerator) Next() (bool, error) {
+func (s *arrayValueGenerator) Next(_ context.Context) (bool, error) {
 	s.nextIndex++
 	if s.nextIndex >= s.array.Len() {
 		return false, nil
@@ -503,7 +524,7 @@ func (s *expandArrayValueGenerator) ResolvedType() *types.T {
 }
 
 // Start implements the tree.ValueGenerator interface.
-func (s *expandArrayValueGenerator) Start() error {
+func (s *expandArrayValueGenerator) Start(_ context.Context, _ *client.Txn) error {
 	s.avg.nextIndex = -1
 	return nil
 }
@@ -512,7 +533,7 @@ func (s *expandArrayValueGenerator) Start() error {
 func (s *expandArrayValueGenerator) Close() {}
 
 // Next implements the tree.ValueGenerator interface.
-func (s *expandArrayValueGenerator) Next() (bool, error) {
+func (s *expandArrayValueGenerator) Next(_ context.Context) (bool, error) {
 	s.avg.nextIndex++
 	return s.avg.nextIndex < s.avg.array.Len(), nil
 }
@@ -569,7 +590,7 @@ func (s *subscriptsValueGenerator) ResolvedType() *types.T {
 }
 
 // Start implements the tree.ValueGenerator interface.
-func (s *subscriptsValueGenerator) Start() error {
+func (s *subscriptsValueGenerator) Start(_ context.Context, _ *client.Txn) error {
 	if s.reverse {
 		s.avg.nextIndex = s.avg.array.Len()
 	} else {
@@ -582,7 +603,7 @@ func (s *subscriptsValueGenerator) Start() error {
 func (s *subscriptsValueGenerator) Close() {}
 
 // Next implements the tree.ValueGenerator interface.
-func (s *subscriptsValueGenerator) Next() (bool, error) {
+func (s *subscriptsValueGenerator) Next(_ context.Context) (bool, error) {
 	if s.reverse {
 		s.avg.nextIndex--
 		return s.avg.nextIndex >= 0, nil
@@ -619,7 +640,7 @@ func makeUnaryGenerator(_ *tree.EvalContext, args tree.Datums) (tree.ValueGenera
 func (*unaryValueGenerator) ResolvedType() *types.T { return unaryValueGeneratorType }
 
 // Start implements the tree.ValueGenerator interface.
-func (s *unaryValueGenerator) Start() error {
+func (s *unaryValueGenerator) Start(_ context.Context, _ *client.Txn) error {
 	s.done = false
 	return nil
 }
@@ -628,7 +649,7 @@ func (s *unaryValueGenerator) Start() error {
 func (s *unaryValueGenerator) Close() {}
 
 // Next implements the tree.ValueGenerator interface.
-func (s *unaryValueGenerator) Next() (bool, error) {
+func (s *unaryValueGenerator) Next(_ context.Context) (bool, error) {
 	if !s.done {
 		s.done = true
 		return true, nil
@@ -721,7 +742,7 @@ func (g *jsonArrayGenerator) ResolvedType() *types.T {
 }
 
 // Start implements the tree.ValueGenerator interface.
-func (g *jsonArrayGenerator) Start() error {
+func (g *jsonArrayGenerator) Start(_ context.Context, _ *client.Txn) error {
 	g.nextIndex = -1
 	g.json.JSON = g.json.JSON.MaybeDecode()
 	g.buf[0] = nil
@@ -732,7 +753,7 @@ func (g *jsonArrayGenerator) Start() error {
 func (g *jsonArrayGenerator) Close() {}
 
 // Next implements the tree.ValueGenerator interface.
-func (g *jsonArrayGenerator) Next() (bool, error) {
+func (g *jsonArrayGenerator) Next(_ context.Context) (bool, error) {
 	g.nextIndex++
 	next, err := g.json.FetchValIdx(g.nextIndex)
 	if err != nil || next == nil {
@@ -796,13 +817,13 @@ func (g *jsonObjectKeysGenerator) ResolvedType() *types.T {
 }
 
 // Start implements the tree.ValueGenerator interface.
-func (g *jsonObjectKeysGenerator) Start() error { return nil }
+func (g *jsonObjectKeysGenerator) Start(_ context.Context, _ *client.Txn) error { return nil }
 
 // Close implements the tree.ValueGenerator interface.
 func (g *jsonObjectKeysGenerator) Close() {}
 
 // Next implements the tree.ValueGenerator interface.
-func (g *jsonObjectKeysGenerator) Next() (bool, error) {
+func (g *jsonObjectKeysGenerator) Next(_ context.Context) (bool, error) {
 	return g.iter.Next(), nil
 }
 
@@ -875,7 +896,7 @@ func (g *jsonEachGenerator) ResolvedType() *types.T {
 }
 
 // Start implements the tree.ValueGenerator interface.
-func (g *jsonEachGenerator) Start() error {
+func (g *jsonEachGenerator) Start(_ context.Context, _ *client.Txn) error {
 	iter, err := g.target.ObjectIter()
 	if err != nil {
 		return err
@@ -896,7 +917,7 @@ func (g *jsonEachGenerator) Start() error {
 func (g *jsonEachGenerator) Close() {}
 
 // Next implements the tree.ValueGenerator interface.
-func (g *jsonEachGenerator) Next() (bool, error) {
+func (g *jsonEachGenerator) Next(_ context.Context) (bool, error) {
 	if !g.iter.Next() {
 		return false, nil
 	}
@@ -978,7 +999,7 @@ func (*checkConsistencyGenerator) ResolvedType() *types.T {
 }
 
 // Start is part of the tree.ValueGenerator interface.
-func (c *checkConsistencyGenerator) Start() error {
+func (c *checkConsistencyGenerator) Start(_ context.Context, _ *client.Txn) error {
 	var b client.Batch
 	b.AddRawRequest(&roachpb.CheckConsistencyRequest{
 		RequestHeader: roachpb.RequestHeader{
@@ -999,7 +1020,7 @@ func (c *checkConsistencyGenerator) Start() error {
 }
 
 // Next is part of the tree.ValueGenerator interface.
-func (c *checkConsistencyGenerator) Next() (bool, error) {
+func (c *checkConsistencyGenerator) Next(_ context.Context) (bool, error) {
 	if len(c.remainingRows) == 0 {
 		return false, nil
 	}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2693,6 +2693,10 @@ type EvalContext struct {
 	Sequence SequenceOperators
 
 	// The transaction in which the statement is executing.
+	// TODO(andrei): In the context of DistSQL flows, this field is funky. It's
+	// shared between all processors, although it shouldn't be; different procs
+	// sometimes need to use different txn objects (e.g. Root vs Leaf).
+	// Also see #41222.
 	Txn *client.Txn
 	// A handle to the database.
 	DB *client.DB

--- a/pkg/sql/sem/tree/generators.go
+++ b/pkg/sql/sem/tree/generators.go
@@ -10,7 +10,12 @@
 
 package tree
 
-import "github.com/cockroachdb/cockroach/pkg/sql/types"
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+)
 
 // Table generators, also called "set-generating functions", are
 // special functions that return an entire table.
@@ -40,10 +45,13 @@ type ValueGenerator interface {
 	// Start initializes the generator. Must be called once before
 	// Next() and Values(). It can be called again to restart
 	// the generator after Next() has returned false.
-	Start() error
+	//
+	// txn represents the txn that the generator will run inside of. The generator
+	// is expected to hold on to this txn and use it in Next() calls.
+	Start(ctx context.Context, txn *client.Txn) error
 
 	// Next determines whether there is a row of data available.
-	Next() (bool, error)
+	Next(context.Context) (bool, error)
 
 	// Values retrieves the current row of data.
 	Values() Datums

--- a/pkg/testutils/distsqlutils/row_buffer.go
+++ b/pkg/testutils/distsqlutils/row_buffer.go
@@ -15,6 +15,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -163,7 +164,7 @@ func (rb *RowBuffer) OutputTypes() []types.T {
 }
 
 // Start is part of the RowSource interface.
-func (rb *RowBuffer) Start(ctx context.Context) context.Context { return ctx }
+func (rb *RowBuffer) Start(ctx context.Context, _ *client.Txn) context.Context { return ctx }
 
 // Next is part of the RowSource interface.
 //


### PR DESCRIPTION
**sql: no more concurrent requests on RootTxns**

Before this patch, a DistSQL flow running on its gateway node would use
the RootTxn for all its processors for row-based flows / all of its
operators for vectorized flows. Some of these processors/operator can
execute concurrently with one another. RootTxns don't support concurrent
requests (see #25329), resulting in some reads possibly missing to see
the transaction's own writes.

This patch rectifies the situation by being discriminate about what
parts of the gateway flow use the RootTxn and what parts use LeafTxns.
LeafTxns can be used concurrently (and they can be used concurrently
with a RootTxn too). Some things need the RootTxn - mutations.
Since #40975, mutations can no longer run concurrently with other
mutations. So, we use the RootTxn for all processors/operators fused
with the DistSQLReceiver, and we use LeafTxns for all others.

Processors and operators no longer use the txn from the FlowCtx (that
field goes away). The exact details on how we determine what runs in
what transactions depend on the type of flow.

i) For row-based flows, the "head processor" and everything fused with
it will use the RootTxn. All the other processors will use the Leaf.
This is done in FlowBase.startInternal().
Processors get the txn to use through Run() and Start() (if they
implement RowSource).

ii) For vectorized flows, I went a different route. These guys don't
have Run() method (they have an Init() but that's more inconvenient to
pass a txn to). They do, however, have facilities for visiting trees of
OpNodes. So, the operators that need a txn declare that by implementing
a new KVOp interface. At flow setup time we visit all the operators and
give them the right txn - in colexec.SetTxn().

Fixes #40487

Release justification: bug fix

Release note (bug fix): Fix the possibility of confusing error messages
caused by transactions that are about to abort missing to see previous
writes performed by the same transaction.


**sql,kv: suspend refreshes while Leaf txns are in use**

Before this patch, races between ingesting leaf txn metadata into the
root and the root performing span refreshes could lead to the failure to
refresh some spans and thus write skew (see #41173).
This patches fixes that by suspending root refreshes while there are
leaves in operation - namely while DistSQL flows that use leaves (either
remotely or locally) are running. So, with this patch, while a
distributed query is running there's going to be no refreshes, but once
it finishes and all leaf metadata has been collected, refreshes are
enabled again.

Refreshes are disabled at different levels depending on the reason:
- they're disabled at the DistSQLPlanner.Run() level for distributed
queries
- they're disabled at the FlowBase level for flows that use leaves
because of concurrency between Processors
- they're disabled at the vectorizedFlow level for vectorized flows that
use leaves internal in their operators

The former two bullets build on facilities built in the previous commit
for detecting concurrency within flows.

Fixes #41173
Touches #24798

Release justification: bug fix

Release note (bug fix): Fix a bug possibly leading to write skew after distributed
queries (#41173).