### PR TITLE
demo: Fix flaky demo workload test

### DIFF
--- a/pkg/cli/interactive_tests/test_demo_workload.tcl
+++ b/pkg/cli/interactive_tests/test_demo_workload.tcl
@@ -4,6 +4,12 @@ source [file join [file dirname $argv0] common.tcl]
 
 start_test "Check cockroach demo --with-load runs the movr workload"
 
+# Disable trying to acquire the demo license. This test does not
+# need enterprise features, and sometimes if the licensing server
+# is unavailable, the error message from failing to receive the
+# testing license pollutes the test output.
+set env(COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING) "true"
+
 # Start demo with movr and the movr workload.
 spawn $argv demo movr --with-load
 


### PR DESCRIPTION
Investigation of related failures showed that sometimes the error
message from failing to get a license would pollute the output of this
test. However, the test does not need the license to succeed, so we
disable license acquisition for this test.

Fixes #41100

Release justification: Low risk flaky test fix

Release note: None