### PR TITLE
roachtest: ignore known failure in TypeORM test

### DIFF
--- a/pkg/cmd/roachtest/typeorm.go
+++ b/pkg/cmd/roachtest/typeorm.go
@@ -113,6 +113,16 @@ func registerTypeORM(r *testRegistry) {
 			ctx,
 			c,
 			node,
+			"patch TypeORM test script to run all tests even on failure",
+			`sed -i 's/--bail //' /mnt/data1/typeorm/package.json`,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repeatRunE(
+			ctx,
+			c,
+			node,
 			"building TypeORM",
 			`cd /mnt/data1/typeorm/ && sudo npm install --unsafe-perm=true --allow-root`,
 		); err != nil {


### PR DESCRIPTION
Informs #38180.

We expect one of the tests to fail due to https://github.com/typeorm/typeorm/pull/4298, so ignore its failure for the time being.

The PR also patches the TypeORM test script to run all tests even when one fails. This allows us to get the full picture of which tests failed instead of having the script bail after the first failed test.

Release justification: Testing only.