### PR TITLE
roachtest: include learner snapshot error in isExpectedRelocateError whitelist

### DIFF
--- a/pkg/cmd/roachtest/bank.go
+++ b/pkg/cmd/roachtest/bank.go
@@ -336,7 +336,15 @@ func isExpectedRelocateError(err error) bool {
 	// for more failure modes not caught here. We decided to avoid adding
 	// to this catchall and to fix the root causes instead.
 	// We've also seen "breaker open" errors here.
-	return testutils.IsError(err, "(descriptor changed|unable to remove replica .* which is not present|unable to add replica .* which is already present|received invalid ChangeReplicasTrigger .* to remove self)")
+	whitelist := []string{
+		"descriptor changed",
+		"unable to remove replica .* which is not present",
+		"unable to add replica .* which is already present",
+		"received invalid ChangeReplicasTrigger .* to remove self",
+		"failed to apply snapshot: raft group deleted",
+	}
+	pattern := "(" + strings.Join(whitelist, "|") + ")"
+	return testutils.IsError(err, pattern)
 }
 
 func accountDistribution(r *rand.Rand) *rand.Zipf {

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2128,12 +2128,10 @@ func (m *monitor) Go(fn func(context.Context) error) {
 	})
 }
 
-var errTestAlreadyFailed = errors.New("already failed")
-
 func (m *monitor) WaitE() error {
 	if m.t.Failed() {
 		// If the test has failed, don't try to limp along.
-		return errTestAlreadyFailed
+		return errors.New("already failed")
 	}
 
 	return m.wait(roachprod, "monitor", m.nodes)
@@ -2144,7 +2142,7 @@ func (m *monitor) Wait() {
 		// If the test has failed, don't try to limp along.
 		return
 	}
-	if err := m.WaitE(); err != nil && err != errTestAlreadyFailed && !m.t.Failed() {
+	if err := m.WaitE(); err != nil && !m.t.Failed() {
 		m.t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Fixes #40359.

We occasionally see the error "failed to apply snapshot: raft group deleted" during a RELOCATE RANGE statement. This occurs because the newly added learner attempts to send a raft message to another node after it has been removed and then destroys itself in response to a ReplicaTooOldError. We have a similar case in TestLearnerAdminChangeReplicasRace.

The PR also makes a few changes to improve the error reporting both in this test and in general when a command fails due to a context cancellation.

Release justification: Testing only.