### PR TITLE
storage: improve TestSystemZoneConfigs

### DIFF
--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -1719,28 +1719,24 @@ func TestSystemZoneConfigs(t *testing.T) {
 		expectedSystemRanges, systemNumReplicas, expectedUserRanges, userNumReplicas, expectedReplicas)
 
 	waitForReplicas := func() error {
-		var conflictingID roachpb.RangeID
-		replicas := make(map[roachpb.RangeID]int)
+		replicas := make(map[roachpb.RangeID]roachpb.RangeDescriptor)
 		for _, s := range tc.Servers {
 			if err := storage.IterateRangeDescriptors(ctx, s.Engines()[0], func(desc roachpb.RangeDescriptor) (bool, error) {
-				if existing, ok := replicas[desc.RangeID]; ok && existing != len(desc.InternalReplicas) {
-					conflictingID = desc.RangeID
+				if existing, ok := replicas[desc.RangeID]; ok && !existing.Equal(desc) {
+					return false, fmt.Errorf("mismatch between\n%s\n%s", &existing, &desc)
 				}
-				replicas[desc.RangeID] = len(desc.InternalReplicas)
+				replicas[desc.RangeID] = desc
 				return false, nil
 			}); err != nil {
 				return err
 			}
 		}
-		if conflictingID != 0 {
-			return fmt.Errorf("not all replicas agree on the range descriptor for r%d", conflictingID)
-		}
 		var totalReplicas int
-		for _, count := range replicas {
-			totalReplicas += count
+		for _, desc := range replicas {
+			totalReplicas += len(desc.Replicas().Voters())
 		}
 		if totalReplicas != expectedReplicas {
-			return fmt.Errorf("got %d replicas, want %d; details: %+v", totalReplicas, expectedReplicas, replicas)
+			return fmt.Errorf("got %d voters, want %d; details: %+v", totalReplicas, expectedReplicas, replicas)
 		}
 		return nil
 	}


### PR DESCRIPTION
The failure mode in #40980 didn't give out any actionable information.
It now prints the mismatching descriptors.

With this commit (and at this SHA) we see within a few minutes

```
make stress PKG=./pkg/storage/ TESTS=TestSystemZoneConfigs
--- FAIL: TestSystemZoneConfigs (61.72s)
    client_replica_test.go:1749: condition failed to evaluate within 45s: mismatch between
        r1:/{Min-System/NodeLiveness} [(n2,s2):8, (n7,s7):2, (n5,s5):3, (n6,s6):4, (n3,s3):6, next=9, gen=17]
        r1:/{Min-System/NodeLiveness} [(n1,s1):1, (n7,s7):2, (n5,s5):3, (n6,s6):4, (n3,s3):6, (n4,s4):7LEARNER, next=8, gen=12]
```

Release justification: testing-only improvement.

Release note: None