### PR TITLE
cli: ensure SQL commands work when `defaultdb` does not exist

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1437,6 +1437,8 @@ func Example_user() {
 	c.Run("user ls --format=table")
 	c.Run("user rm foo")
 	c.Run("user ls --format=table")
+	c.RunWithArgs([]string{"sql", "-e", "drop database defaultdb"})
+	c.Run("user set foo")
 
 	// Output:
 	// user ls
@@ -1546,6 +1548,11 @@ func Example_user() {
 	//   table
 	//   ομηρος
 	// (10 rows)
+	// sql -e drop database defaultdb
+	// DROP DATABASE
+	// user set foo
+	// warning: This command is deprecated. Use CREATE USER or ALTER USER ... WITH PASSWORD ... in a SQL session.
+	// CREATE USER 1
 }
 
 func Example_cert() {
@@ -1671,6 +1678,8 @@ func Example_node() {
 	c.Run("node ls")
 	c.Run("node ls --format=table")
 	c.Run("node status 10000")
+	c.RunWithArgs([]string{"sql", "-e", "drop database defaultdb"})
+	c.Run("node ls")
 
 	// Output:
 	// node ls
@@ -1683,6 +1692,11 @@ func Example_node() {
 	// (1 row)
 	// node status 10000
 	// Error: node 10000 doesn't exist
+	// sql -e drop database defaultdb
+	// DROP DATABASE
+	// node ls
+	// id
+	// 1
 }
 
 func TestCLITimeout(t *testing.T) {

--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -52,7 +52,7 @@ var verDump = version.MustParse("v2.1.0-alpha.20180416-0")
 // The approach here and its current flaws are summarized
 // in https://github.com/cockroachdb/cockroach/issues/28948.
 func runDump(cmd *cobra.Command, args []string) error {
-	conn, err := getPasswordAndMakeSQLClient("cockroach dump")
+	conn, err := makeSQLClient("cockroach dump", useDefaultDb)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -46,7 +46,7 @@ To retrieve the IDs for inactive members, see 'node status --decommission'.
 }
 
 func runLsNodes(cmd *cobra.Command, args []string) error {
-	conn, err := getPasswordAndMakeSQLClient("cockroach node ls")
+	conn, err := makeSQLClient("cockroach node ls", useSystemDb)
 	if err != nil {
 		return err
 	}
@@ -188,7 +188,7 @@ SELECT node_id AS id,
        draining AS is_draining
 FROM crdb_internal.gossip_liveness LEFT JOIN crdb_internal.gossip_nodes USING (node_id)`
 
-	conn, err := getPasswordAndMakeSQLClient("cockroach node status")
+	conn, err := makeSQLClient("cockroach node status", useSystemDb)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -1448,7 +1448,7 @@ func runTerm(cmd *cobra.Command, args []string) error {
 		fmt.Print(welcomeMessage)
 	}
 
-	conn, err := getPasswordAndMakeSQLClient("cockroach sql")
+	conn, err := makeSQLClient("cockroach sql", useDefaultDb)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -480,25 +480,44 @@ func makeSQLConn(url string) *sqlConn {
 	}
 }
 
-// getPasswordAndMakeSQLClient prompts for a password if running in secure mode
-// and no certificates have been supplied.
-// Attempting to use security.RootUser without valid certificates will return an error.
-func getPasswordAndMakeSQLClient(appName string) (*sqlConn, error) {
-	return makeSQLClient(appName)
-}
-
 var sqlConnTimeout = envutil.EnvOrDefaultString("COCKROACH_CONNECT_TIMEOUT", "5")
+
+// defaultSQLDb describes how a missing database part in the SQL
+// connection string is processed when creating a client connection.
+type defaultSQLDb int
+
+const (
+	// useSystemDb means that a missing database will be overridden with
+	// "system".
+	useSystemDb defaultSQLDb = iota
+	// useDefaultDb means that a missing database will be left as-is so
+	// that the server can default to "defaultdb".
+	useDefaultDb
+)
 
 // makeSQLClient connects to the database using the connection
 // settings set by the command-line flags.
+// If a password is needed, it also prompts for the password.
+//
+// If forceSystemDB is set, it also connects it to the `system`
+// database. The --database flag or database part in the URL is then
+// ignored.
 //
 // The appName given as argument is added to the URL even if --url is
 // specified, but only if the URL didn't already specify
 // application_name. It is prefixed with '$ ' to mark it as internal.
-func makeSQLClient(appName string) (*sqlConn, error) {
+func makeSQLClient(appName string, defaultMode defaultSQLDb) (*sqlConn, error) {
 	baseURL, err := cliCtx.makeClientConnURL()
 	if err != nil {
 		return nil, err
+	}
+
+	if defaultMode == useSystemDb && baseURL.Path == "" {
+		// Override the target database. This is because the current
+		// database can influence the output of CLI commands, and in the
+		// case where the database is missing it will default server-wise to
+		// `defaultdb` which may not exist.
+		baseURL.Path = "system"
 	}
 
 	// If there is no user in the URL already, fill in the default user.

--- a/pkg/cli/user.go
+++ b/pkg/cli/user.go
@@ -44,7 +44,7 @@ var verSetUser = version.MustParse("v1.2.0-alpha.20171113")
 
 func runGetUser(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(stderr, "warning: %s\n", strings.ReplaceAll(strings.TrimSpace(cmd.Long), "\n", " "))
-	conn, err := getPasswordAndMakeSQLClient("cockroach user")
+	conn, err := makeSQLClient("cockroach user", useSystemDb)
 	if err != nil {
 		return err
 	}
@@ -76,7 +76,7 @@ Use SHOW USERS or SHOW ROLES in a SQL session.`,
 
 func runLsUsers(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(stderr, "warning: %s\n", strings.ReplaceAll(strings.TrimSpace(cmd.Long), "\n", " "))
-	conn, err := getPasswordAndMakeSQLClient("cockroach user")
+	conn, err := makeSQLClient("cockroach user", useSystemDb)
 	if err != nil {
 		return err
 	}
@@ -98,7 +98,7 @@ Use DROP USER or DROP ROLE in a SQL session.`,
 
 func runRmUser(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(stderr, "warning: %s\n", strings.ReplaceAll(strings.TrimSpace(cmd.Long), "\n", " "))
-	conn, err := getPasswordAndMakeSQLClient("cockroach user")
+	conn, err := makeSQLClient("cockroach user", useSystemDb)
 	if err != nil {
 		return err
 	}
@@ -140,7 +140,7 @@ func runSetUser(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	conn, err := getPasswordAndMakeSQLClient("cockroach user")
+	conn, err := makeSQLClient("cockroach user", useSystemDb)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -219,7 +219,7 @@ func runDebugZip(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	sqlConn, err := getPasswordAndMakeSQLClient("cockroach zip")
+	sqlConn, err := makeSQLClient("cockroach zip", useSystemDb)
 	if err != nil {
 		log.Warningf(baseCtx, "unable to open a SQL session. Debug information will be incomplete: %s", err)
 	}


### PR DESCRIPTION
Fixes #40967.

All the various CLI commands that establish a SQL connection require
the target database to exist. If no database is specified via
`--database` or `--url`, the server automatically defaults to
`defaultdb`.

Prior to this patch, the CLI commands that do not strictly require a
user database to function properly would fail if `defaultdb` did not
exist (e.g. because a user chooses to drop it).

This patch changes them to adopt the `system` database instead.

The two commands that are operate on a user database, namely
`cockroach sql` and `cockroach dump`, continue to work as prior.

Release justification: fixes a bug

Release note (bug fix): `cockroach zip`, `cockroach node` and
`cockroach user` now work properly if the `defaultdb` database has
been manually dropped  and the connection URL does not specify a
database. (Note that `cockroach user` is deprecated in 19.2).