### PR TITLE
storage: campaign eagerly upon removing raft leader

### DIFF
--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -47,10 +47,11 @@ import (
 //
 // TODO(ajwerner): add metrics to go with these stats.
 type applyCommittedEntriesStats struct {
-	batchesProcessed int
-	entriesProcessed int
-	stateAssertions  int
-	numEmptyEntries  int
+	batchesProcessed     int
+	entriesProcessed     int
+	stateAssertions      int
+	numEmptyEntries      int
+	numConfChangeEntries int
 }
 
 // nonDeterministicFailure is an error type that indicates that a state machine
@@ -1163,13 +1164,14 @@ func (sm *replicaStateMachine) maybeApplyConfChange(ctx context.Context, cmd *re
 		}
 		return nil
 	case raftpb.EntryConfChange, raftpb.EntryConfChangeV2:
+		sm.stats.numConfChangeEntries++
 		if cmd.replicatedResult().ChangeReplicas == nil {
 			// The command was rejected. There is no need to report a ConfChange
 			// to raft.
 			return nil
 		}
-		return sm.r.withRaftGroup(true, func(raftGroup *raft.RawNode) (bool, error) {
-			raftGroup.ApplyConfChange(cmd.confChange.ConfChangeI)
+		return sm.r.withRaftGroup(true, func(rn *raft.RawNode) (bool, error) {
+			rn.ApplyConfChange(cmd.confChange.ConfChangeI)
 			return true, nil
 		})
 	default:

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -758,8 +758,17 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	// the fact that we'll refuse to process messages intended for a higher
 	// replica ID ensures that our replica ID could not have changed.
 	const expl = "during advance"
-	err = r.withRaftGroup(true, func(raftGroup *raft.RawNode) (bool, error) {
+
+	r.mu.Lock()
+	err = r.withRaftGroupLocked(true, func(raftGroup *raft.RawNode) (bool, error) {
 		raftGroup.Advance(rd)
+		if stats.numConfChangeEntries > 0 {
+			// If the raft leader got removed, campaign the first remaining voter.
+			//
+			// NB: this must be called after Advance() above since campaigning is
+			// a no-op in the presence of unapplied conf changes.
+			maybeCampaignAfterConfChange(ctx, r.store.StoreID(), r.descRLocked(), raftGroup)
+		}
 
 		// If the Raft group still has more to process then we immediately
 		// re-enqueue it for another round of processing. This is possible if
@@ -770,6 +779,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 		}
 		return true, nil
 	})
+	r.mu.Unlock()
 	if err != nil {
 		return stats, expl, errors.Wrap(err, expl)
 	}
@@ -1700,4 +1710,39 @@ func ComputeRaftLogSize(
 		}
 	}
 	return ms.SysBytes + totalSideloaded, nil
+}
+
+func maybeCampaignAfterConfChange(
+	ctx context.Context,
+	storeID roachpb.StoreID,
+	desc *roachpb.RangeDescriptor,
+	raftGroup *raft.RawNode,
+) {
+	// If a config change was carried out, it's possible that the Raft
+	// leader was removed. Verify that, and if so, campaign if we are
+	// the first remaining voter replica. Without this, the range will
+	// be leaderless (and thus unavailable) for a few seconds.
+	//
+	// We can't (or rather shouldn't) campaign on all remaining voters
+	// because that can lead to a stalemate. For example, three voters
+	// may all make it through PreVote and then reject each other.
+	st := raftGroup.BasicStatus()
+	if st.Lead == 0 {
+		// Leader unknown. This isn't what we expect in steady state, so we
+		// don't do anything.
+		return
+	}
+	if !desc.IsInitialized() {
+		// We don't have an initialized, so we can't figure out who is supposed
+		// to campaign. It's possible that it's us and we're waiting for the
+		// initial snapshot, but it's hard to tell. Don't do anything.
+		return
+	}
+	// If the leader is no longer in the descriptor but we are the first voter,
+	// campaign.
+	_, leaderStillThere := desc.GetReplicaDescriptorByID(roachpb.ReplicaID(st.Lead))
+	if !leaderStillThere && storeID == desc.Replicas().Voters()[0].StoreID {
+		log.VEventf(ctx, 3, "leader got removed by conf change; campaigning")
+		_ = raftGroup.Campaign()
+	}
 }


### PR DESCRIPTION
Prior to this change,

```
make test PKG=./pkg/storage/ TESTS='TestAdminRelocateRange$$' \
    TESTFLAGS='-v -count 100 --vmodule=raft=1 -failfast'
```

would reliably fail with the following patch

```diff
diff --git a/pkg/storage/client_relocate_range_test.go b/pkg/storage/client_relocate_range_test.go
index db7ffa2c0d..65cdf12405 100644
--- a/pkg/storage/client_relocate_range_test.go
+++ b/pkg/storage/client_relocate_range_test.go
@@ -140,6 +142,8 @@ func TestAdminRelocateRange(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, 6, args)
 	defer tc.Stopper().Stop(ctx)

+	tBegin := timeutil.Now()
+
 	// s1 (LH) ---> s2 (LH) s1 s3
 	// Pure upreplication.
 	k := keys.MustAddr(tc.ScratchRange(t))
@@ -198,4 +202,8 @@ func TestAdminRelocateRange(t *testing.T) {
 			return relocateAndCheck(t, tc, k, tc.Targets(2, 4))
 		})
 	}
+
+	if dur := timeutil.Since(tBegin); dur > 4*time.Second {
+		t.Errorf("test took %.2fs", dur.Seconds())
+	}
 }
```

because whenever the raft leader would end up getting removed, the range
would be unavailable for a few seconds (until the raft election timeout
fired and a new leader was elected).

This patch detects removal of the leader in the raft handling loop, and
lets the first remaining voter campaign.

Release justification: fixes a bug.
Release note (bug fix): fixed a short (3s) period of unavailability that
could occur on a range after removing a replica.