### PR TITLE
sql: fix bug with needed column families and nulls

### DIFF
--- a/pkg/sql/execinfra/indexjoiner.go
+++ b/pkg/sql/execinfra/indexjoiner.go
@@ -124,11 +124,7 @@ func NewIndexJoiner(
 		ij.fetcher = &RowFetcherWrapper{Fetcher: &fetcher}
 	}
 
-	ij.neededFamilies = sqlbase.NeededColumnFamilyIDs(
-		spec.Table.ColumnIdxMap(),
-		spec.Table.Families,
-		ij.Out.NeededColumns(),
-	)
+	ij.neededFamilies = sqlbase.NeededColumnFamilyIDs(ij.Out.NeededColumns(), &spec.Table)
 
 	return ij, nil
 }

--- a/pkg/sql/execinfra/joinreader.go
+++ b/pkg/sql/execinfra/joinreader.go
@@ -223,11 +223,7 @@ func NewJoinReader(
 
 	jr.indexKeyPrefix = sqlbase.MakeIndexKeyPrefix(&jr.desc, jr.index.ID)
 
-	jr.neededFamilies = sqlbase.NeededColumnFamilyIDs(
-		spec.Table.ColumnIdxMap(),
-		spec.Table.Families,
-		jr.neededRightCols(),
-	)
+	jr.neededFamilies = sqlbase.NeededColumnFamilyIDs(jr.neededRightCols(), &spec.Table)
 
 	// Initialize memory monitors and row container for looked up rows.
 	st := flowCtx.Cfg.Settings

--- a/pkg/sql/logictest/testdata/logic_test/family
+++ b/pkg/sql/logictest/testdata/logic_test/family
@@ -249,3 +249,26 @@ rename_col  CREATE TABLE rename_col (
             FAMILY fam_0_a_b (a, d),
             FAMILY fam_1_c (e)
 )
+
+# Regression tests for https://github.com/cockroachdb/cockroach/issues/41007.
+statement ok
+CREATE TABLE xyz (x INT PRIMARY KEY, y INT, z INT, FAMILY (x, y), FAMILY (z), INDEX (y))
+
+statement ok
+INSERT INTO xyz VALUES (1, 1, NULL)
+
+query I
+SELECT z FROM xyz WHERE y = 1
+----
+NULL
+
+statement ok
+CREATE TABLE y (y INT)
+
+statement ok
+INSERT INTO y VALUES (1)
+
+query I
+SELECT xyz.z FROM y INNER LOOKUP JOIN xyz ON y.y = xyz.y
+----
+NULL

--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -593,7 +593,7 @@ SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE 'Scan /Table/70/
 Scan /Table/70/1/1/{0-1}, /Table/70/1/1/2/{1-2}
 
 statement ok
-CREATE TABLE family_index_join (x INT PRIMARY KEY, y INT, z INT, w INT, INDEX (y), FAMILY f1 (x), FAMILY f2 (y), FAMILY f3 (z), FAMILY f4(w))
+CREATE TABLE family_index_join (x INT PRIMARY KEY, y INT, z INT, w INT NOT NULL, INDEX (y), FAMILY f1 (x), FAMILY f2 (y), FAMILY f3 (z), FAMILY f4(w))
 
 statement ok
 INSERT INTO family_index_join VALUES (1, 2, 3, 4)

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -165,7 +165,7 @@ func appendSpansFromConstraintSpan(
 		len(tableDesc.Families) > 1 &&
 		cs.StartKey().Length() == len(tableDesc.PrimaryIndex.ColumnIDs) &&
 		s.Key.Equal(s.EndKey) {
-		neededFamilyIDs := sqlbase.NeededColumnFamilyIDs(tableDesc.ColumnIdxMap(), tableDesc.Families, needed)
+		neededFamilyIDs := sqlbase.NeededColumnFamilyIDs(needed, tableDesc.TableDesc())
 		if len(neededFamilyIDs) < len(tableDesc.Families) {
 			return append(spans, sqlbase.SplitSpanIntoSeparateFamilies(s, neededFamilyIDs)...), nil
 		}


### PR DESCRIPTION
When doing point lookups, we have logic to only scan column families
which are needed for the requested columns. However, this logic had a
bug concerning NULL values. Column families other than the one with ID 0
do not store a row if all their columns are NULL. This means that if you
only scan those families, you can't distinguish between the absence of a
row and all NULL values. Since we didn't account for this, some queries
which should have returned an all NULL row were instead returning no
row. See the referenced issue for specific examples.

I added new logic to determine whether it is necessary to scan column
family 0. It must be scanned if any of the following is true:
- It includes one of the needed columns which is not in the primary key.
- It includes one of the needed columns which uses composite encoding.
- All the columns in the other needed families are nullable.

Fixes #41007

Release note: None

Release justification: Correctness bug fix