### PR TITLE
Makefile: use mkrelease to build portable test binaries for roachprod-stress

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -977,7 +977,7 @@ stress stressrace:
 roachprod-stress roachprod-stressrace: bin/roachprod-stress
 	# The bootstrap target creates, among other things, ./bin/stress.
 	build/builder.sh make bin/.bootstrap
-	build/builder.sh make test GOFLAGS="$(GOFLAGS)" TESTFLAGS="-v -c -o $(notdir $(patsubst %/,%,$(PKG))).test" PKG=$(PKG)
+	build/builder.sh mkrelease amd64-linux-gnu test GOFLAGS="$(GOFLAGS)" TESTFLAGS="-v -c -o $(notdir $(patsubst %/,%,$(PKG))).test" PKG=$(PKG)
 	@if [ -z "$(CLUSTER)" ]; then \
 	  echo "ERROR: missing or empty CLUSTER"; \
 	else \


### PR DESCRIPTION
Before adding these options we could produce test binaries which were not
compatible with the HW on gcp nodes. Especially the n1-standard-32.

I'm open to suggestions to do this better, this just seems to work.

Release justification: only touches roachprod-stress and roachprod-stressrace.

Release note: None