### PR TITLE
sql: exec_log protects internal execs behind V(3)

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -533,7 +533,8 @@ func (s *Server) newConnExecutor(
 
 		// ctxHolder will be reset at the start of run(). We only define
 		// it here so that an early call to close() doesn't panic.
-		ctxHolder: ctxHolder{connCtx: ctx},
+		ctxHolder:    ctxHolder{connCtx: ctx},
+		executorType: executorTypeExec,
 	}
 
 	ex.state.txnAbortCount = ex.metrics.EngineMetrics.TxnAbortCount
@@ -953,6 +954,10 @@ type connExecutor struct {
 	// draining is set if we've received a DrainRequest. Once this is set, we're
 	// going to find a suitable time to close the connection.
 	draining bool
+
+	// executorType is set to whether this executor is an ordinary executor which
+	// responds to user queries or an internal one.
+	executorType executorType
 }
 
 // ctxHolder contains a connection's context and, while session tracing is

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -647,7 +647,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	defer func() {
 		planner.maybeLogStatement(
 			ctx,
-			"exec",
+			ex.executorType,
 			ex.extraTxnState.autoRetryCounter,
 			res.RowsAffected(),
 			res.Err(),

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -194,6 +194,7 @@ func (ie *internalExecutorImpl) initConnEx(
 	if err != nil {
 		return nil, nil, err
 	}
+	ex.executorType = executorTypeInternal
 
 	var wg sync.WaitGroup
 	wg.Add(1)


### PR DESCRIPTION
Previously, the exec_log vmodule would always include all internal
execs. This was pretty annoying for debugging. This change moves
internal execs behind V(3) instead of V(2).

Additionally, it restores the `exec-internal` vs `exec` label
distinction, which had apparently been lost in a refactor at some point.

Release justification: low risk, high benefit changes to existing
functionality
Release note (cli change): the exec_log vmodule now does not log
internally-generated statements unless the vmodule is set to 3 instead
of 2.