### PR TITLE
colexec: fix a couple of issues with outer hash joins

### DIFF
--- a/pkg/col/coldata/vec_tmpl.go
+++ b/pkg/col/coldata/vec_tmpl.go
@@ -78,7 +78,7 @@ func (m *memColumn) Append(args SliceArgs) {
 func _COPY_WITH_SEL(
 	m *memColumn, args CopySliceArgs, fromCol, toCol _GOTYPESLICE, sel interface{}, _SEL_ON_DEST bool,
 ) { // */}}
-	// {{define "copyWithSel"}}
+	// {{define "copyWithSel" -}}
 	if args.Src.MaybeHasNulls() {
 		nulls := args.Src.Nulls()
 		for i, selIdx := range sel[args.SrcStartIdx:args.SrcEndIdx] {

--- a/pkg/sql/colexec/and_or_projection_test.go
+++ b/pkg/sql/colexec/and_or_projection_test.go
@@ -194,7 +194,7 @@ func TestAndOrOps(t *testing.T) {
 				runner(
 					t,
 					[]tuples{tc.tuples},
-					[]coltypes.T{coltypes.Bool, coltypes.Bool},
+					[][]coltypes.T{{coltypes.Bool, coltypes.Bool}},
 					tc.expected,
 					orderedVerifier,
 					func(input []Operator) (Operator, error) {

--- a/pkg/sql/colexec/const_test.go
+++ b/pkg/sql/colexec/const_test.go
@@ -33,7 +33,7 @@ func TestConst(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
-		runTestsWithTyps(t, []tuples{tc.tuples}, []coltypes.T{coltypes.Int64}, tc.expected, orderedVerifier,
+		runTestsWithTyps(t, []tuples{tc.tuples}, [][]coltypes.T{{coltypes.Int64}}, tc.expected, orderedVerifier,
 			func(input []Operator) (Operator, error) {
 				return NewConstOp(input[0], coltypes.Int64, int64(9), 1)
 			})
@@ -56,7 +56,7 @@ func TestConstNull(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
-		runTestsWithTyps(t, []tuples{tc.tuples}, []coltypes.T{coltypes.Int64}, tc.expected, orderedVerifier,
+		runTestsWithTyps(t, []tuples{tc.tuples}, [][]coltypes.T{{coltypes.Int64}}, tc.expected, orderedVerifier,
 			func(input []Operator) (Operator, error) {
 				return NewConstNullOp(input[0], 1, coltypes.Int64), nil
 			})

--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -174,6 +174,36 @@ func init() {
 			leftTypes:  []coltypes.T{coltypes.Int64},
 			rightTypes: []coltypes.T{coltypes.Int64},
 
+			// Test right outer join with non-distinct left build table with an
+			// unmatched row from the right followed by a matched one.
+			leftTuples: tuples{
+				{0},
+				{0},
+				{2},
+			},
+			rightTuples: tuples{
+				{1},
+				{2},
+			},
+
+			leftEqCols:   []uint32{0},
+			rightEqCols:  []uint32{0},
+			leftOutCols:  []uint32{0},
+			rightOutCols: []uint32{0},
+
+			joinType:       sqlbase.JoinType_RIGHT_OUTER,
+			buildDistinct:  false,
+			buildRightSide: false,
+
+			expectedTuples: tuples{
+				{nil, 1},
+				{2, 2},
+			},
+		},
+		{
+			leftTypes:  []coltypes.T{coltypes.Int64},
+			rightTypes: []coltypes.T{coltypes.Int64},
+
 			// Test null handling only on probe column.
 			leftTuples: tuples{
 				{0},

--- a/pkg/sql/colexec/hashjoiner_tmpl.go
+++ b/pkg/sql/colexec/hashjoiner_tmpl.go
@@ -227,15 +227,13 @@ func _COLLECT_RIGHT_OUTER(
 
 			prober.probeRowUnmatched[nResults] = currentID == 0
 			if currentID > 0 {
-				// If currentID == 0, nobody will look at this again since
-				// probeRowUnmatched will have been set - so don't populate this with
-				// a garbage value.
-				// TODO(yuzefovich): the comment above is not entirely correct. In
-				// congregate(), we always copy the full vector of actual values that
-				// correspond to the tuples in buildIdx slice first and then set the
-				// nulls where needed. It would be nice to copy the values only for
-				// those indices for which probeRowUnmatched[i] is false.
 				prober.buildIdx[nResults] = currentID - 1
+			} else {
+				// If currentID == 0, then probeRowUnmatched will have been set - and
+				// we set the corresponding buildIdx to zero so that (as long as the
+				// build hash table has at least one row) we can copy the values vector
+				// without paying attention to probeRowUnmatched.
+				prober.buildIdx[nResults] = 0
 			}
 			// {{if .UseSel}}
 			prober.probeIdx[nResults] = sel[i]

--- a/pkg/sql/colexec/hashjoiner_tmpl.go
+++ b/pkg/sql/colexec/hashjoiner_tmpl.go
@@ -219,20 +219,22 @@ func _COLLECT_RIGHT_OUTER(
 	for i := uint16(0); i < batchSize; i++ {
 		currentID := prober.ht.headID[i]
 
-		if currentID == 0 {
-			prober.probeRowUnmatched[nResults] = true
-		}
-
 		for {
 			if nResults >= coldata.BatchSize() {
 				prober.prevBatch = batch
 				return nResults
 			}
 
+			prober.probeRowUnmatched[nResults] = currentID == 0
 			if currentID > 0 {
 				// If currentID == 0, nobody will look at this again since
 				// probeRowUnmatched will have been set - so don't populate this with
 				// a garbage value.
+				// TODO(yuzefovich): the comment above is not entirely correct. In
+				// congregate(), we always copy the full vector of actual values that
+				// correspond to the tuples in buildIdx slice first and then set the
+				// nulls where needed. It would be nice to copy the values only for
+				// those indices for which probeRowUnmatched[i] is false.
 				prober.buildIdx[nResults] = currentID - 1
 			}
 			// {{if .UseSel}}

--- a/pkg/sql/logictest/testdata/logic_test/exec_hash_join
+++ b/pkg/sql/logictest/testdata/logic_test/exec_hash_join
@@ -109,3 +109,18 @@ SELECT b.a, b.c, c.a FROM b JOIN c ON b.b = c.a AND b.c = c.b ORDER BY 2
 0  a  1
 2  b  1
 0  c  2
+
+# Test hash join with an empty build table.
+statement ok
+CREATE TABLE empty (x INT)
+
+statement ok
+CREATE TABLE onecolumn (x INT); INSERT INTO onecolumn(x) VALUES (44), (NULL), (42)
+
+query II colnames
+SELECT * FROM empty AS a(x) FULL OUTER JOIN onecolumn AS b(y) ON a.x = b.y ORDER BY b.y
+----
+x     y
+NULL  NULL
+NULL  42
+NULL  44

--- a/pkg/sql/logictest/testdata/logic_test/exec_hash_join_dist
+++ b/pkg/sql/logictest/testdata/logic_test/exec_hash_join_dist
@@ -28,3 +28,41 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM xy WHERE x=t.k)
 ----
 2  20
 3  30
+
+# Regression test for #39303.
+statement ok
+CREATE TABLE small (a INT PRIMARY KEY, b INT)
+
+statement ok
+CREATE TABLE large (c INT, d INT)
+
+statement ok
+INSERT INTO small SELECT x, 3*x FROM
+  generate_series(1, 10) AS a(x)
+
+statement ok
+INSERT INTO large SELECT 2*x, 4*x FROM
+  generate_series(1, 10) AS a(x)
+
+statement ok
+ALTER TABLE small SPLIT AT SELECT a FROM small
+
+statement ok
+ALTER TABLE small EXPERIMENTAL_RELOCATE SELECT ARRAY[mod(i, 3) + 1], i FROM generate_series(1, 10) AS g(i)
+
+statement ok
+ALTER TABLE large SPLIT AT SELECT 2*i FROM generate_series(1, 10) AS g(i)
+
+statement ok
+ALTER TABLE large EXPERIMENTAL_RELOCATE SELECT ARRAY[mod(i, 3) + 1], 2*i FROM generate_series(1, 10) as g(i)
+
+# Test that RIGHT OUTER hash join correctly sets probeRowUnmatched on
+# subsequent batches.
+query II rowsort
+SELECT small.b, large.d FROM large RIGHT HASH JOIN small ON small.b = large.c AND large.d < 30 ORDER BY 1 LIMIT 5
+----
+3   NULL
+6   12
+9   NULL
+12  24
+15  NULL


### PR DESCRIPTION
**colexec: fix a bug with RIGHT OUTER hash join**

Previously, probeRowUnmatched was not updated correctly in case of
non-distinct build table - the values were only set to 'true', but the
slice was never reset between subsequent probe batches nor the values
were set to 'false' when they were, in fact, 'false'. Now this is
fixed.

Fixes: #39303.

**colexec: minor refactor of hash joiner**

**colexec: fix hash joiner when the build table is empty**

Previously, with an outer hash join with an empty build table but non-empty
probe table we would hit index out of bounds error. The root problem is
that we always copy the values vector for the build table regardless
of whether the corresponding rows actually matched. Now before copying
we make sure that the hash table is not empty and also for all unmatched
rows we set buildIdx to 0 so that we can copy the garbage zeroth row
(the setting of NULLs later will take care of the correctness).

Fixes: #40371.
Addresses: #38994.

**colexec: add a unit test with an empty build table for hash joiner**

Release note: None