### PR TITLE
sql: replace assert with error in EXPERIMENTAL_RELOCATE

### DIFF
--- a/pkg/sql/relocate.go
+++ b/pkg/sql/relocate.go
@@ -163,8 +163,7 @@ func (n *relocateNode) Next(params runParams) (bool, error) {
 				if err := params.extendedEvalCtx.ExecCfg.Gossip.GetInfoProto(
 					gossipStoreKey, &storeDesc,
 				); err != nil {
-					return false, errors.NewAssertionErrorWithWrappedErrf(err,
-						"error looking up store %d", errors.Safe(storeID))
+					return false, errors.Wrapf(err, "error looking up store %d", storeID)
 				}
 				nodeID = storeDesc.Node.NodeID
 				n.run.storeMap[storeID] = nodeID


### PR DESCRIPTION
Resolves #39835
GetInfoProto returns an error in relocateNode.Next,
in case if store doesn't exist. It should not produce a stacktrace.

reverts this line to pre 8cfcbb4 commit state.

Release justification: low-impact assert changed to error
Release note: None