### PR TITLE
opt: disallow correlation with brackets syntax

### DIFF
--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -130,7 +130,11 @@ func (b *Builder) buildDataSource(
 		return outScope
 
 	case *tree.StatementSource:
-		outScope = b.buildStmt(source.Statement, nil /* desiredTypes */, inScope)
+		// This is the special '[ ... ]' syntax. We treat this as syntactic sugar
+		// for a top-level CTE, so it cannot refer to anything in the input scope.
+		// See #41078.
+		emptyScope := &scope{builder: b}
+		outScope = b.buildStmt(source.Statement, nil /* desiredTypes */, emptyScope)
 		if len(outScope.cols) == 0 {
 			panic(pgerror.Newf(pgcode.UndefinedColumn,
 				"statement source \"%v\" does not return any columns", source.Statement))

--- a/pkg/sql/opt/optbuilder/testdata/delete
+++ b/pkg/sql/opt/optbuilder/testdata/delete
@@ -187,29 +187,6 @@ delete xyz
       │                   └── placeholder: $2 [type=int]
       └── const: 2 [type=int]
 
-# Correlated subquery.
-build
-SELECT * FROM xyz WHERE EXISTS (SELECT * FROM [DELETE FROM abcde WHERE b=y RETURNING *])
-----
-select
- ├── columns: x:1(string!null) y:2(int) z:3(float)
- ├── scan xyz
- │    └── columns: x:1(string!null) y:2(int) z:3(float)
- └── filters
-      └── exists [type=bool]
-           └── project
-                ├── columns: a:4(int!null) b:5(int!null) c:6(int) d:7(int) e:8(int)
-                └── delete abcde
-                     ├── columns: a:4(int!null) b:5(int!null) c:6(int) d:7(int) e:8(int) rowid:9(int!null)
-                     ├── fetch columns: a:10(int) b:11(int) c:12(int) d:13(int) e:14(int) rowid:15(int)
-                     └── select
-                          ├── columns: a:10(int!null) b:11(int!null) c:12(int) d:13(int) e:14(int) rowid:15(int!null)
-                          ├── scan abcde
-                          │    └── columns: a:10(int!null) b:11(int) c:12(int) d:13(int) e:14(int) rowid:15(int!null)
-                          └── filters
-                               └── eq [type=bool]
-                                    ├── variable: b [type=int]
-                                    └── variable: y [type=int]
 
 # Use CTE within WHERE clause.
 build
@@ -400,31 +377,6 @@ delete mutation
                 ├── variable: m [type=int]
                 └── const: 1 [type=int]
 
-# Use column "p" from higher scope that is shadowed by mutation column "p".
-build
-SELECT *
-FROM abcde AS mno(m, n, p)
-WHERE EXISTS(SELECT * FROM [DELETE FROM mutation WHERE m=p RETURNING *])
-----
-project
- ├── columns: m:1(int!null) n:2(int) p:3(int) d:4(int) e:5(int)
- └── select
-      ├── columns: mno.m:1(int!null) mno.n:2(int) mno.p:3(int) d:4(int) e:5(int) rowid:6(int!null)
-      ├── scan mno
-      │    └── columns: mno.m:1(int!null) mno.n:2(int) mno.p:3(int) d:4(int) e:5(int) rowid:6(int!null)
-      └── filters
-           └── exists [type=bool]
-                └── delete mutation
-                     ├── columns: mutation.m:7(int!null) mutation.n:8(int)
-                     ├── fetch columns: mutation.m:11(int) mutation.n:12(int) o:13(int) mutation.p:14(int)
-                     └── select
-                          ├── columns: mutation.m:11(int!null) mutation.n:12(int) o:13(int) mutation.p:14(int)
-                          ├── scan mutation
-                          │    └── columns: mutation.m:11(int!null) mutation.n:12(int) o:13(int) mutation.p:14(int)
-                          └── filters
-                               └── eq [type=bool]
-                                    ├── variable: mutation.m [type=int]
-                                    └── variable: mno.p [type=int]
 
 # Try to return a mutation column.
 build

--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -679,48 +679,6 @@ INSERT INTO abcde VALUES (1) RETURNING generate_series(1, 100)
 ----
 error (0A000): generate_series(): generator functions are not allowed in RETURNING
 
-# Correlated subquery.
-build
-SELECT * FROM xyz WHERE EXISTS (SELECT * FROM [INSERT INTO abcde VALUES (y, y+1) RETURNING *])
-----
-select
- ├── columns: x:1(string!null) y:2(int) z:3(float)
- ├── scan xyz
- │    └── columns: x:1(string!null) y:2(int) z:3(float)
- └── filters
-      └── exists [type=bool]
-           └── project
-                ├── columns: a:4(int!null) b:5(int) c:6(int!null) d:7(int) e:8(int)
-                └── insert abcde
-                     ├── columns: a:4(int!null) b:5(int) c:6(int!null) d:7(int) e:8(int) rowid:9(int!null)
-                     ├── insert-mapping:
-                     │    ├──  column1:10 => a:4
-                     │    ├──  column2:11 => b:5
-                     │    ├──  column12:12 => c:6
-                     │    ├──  column14:14 => d:7
-                     │    ├──  column1:10 => e:8
-                     │    └──  column13:13 => rowid:9
-                     └── project
-                          ├── columns: column14:14(int) column1:10(int) column2:11(int) column12:12(int!null) column13:13(int)
-                          ├── project
-                          │    ├── columns: column12:12(int!null) column13:13(int) column1:10(int) column2:11(int)
-                          │    ├── values
-                          │    │    ├── columns: column1:10(int) column2:11(int)
-                          │    │    └── tuple [type=tuple{int, int}]
-                          │    │         ├── variable: y [type=int]
-                          │    │         └── plus [type=int]
-                          │    │              ├── variable: y [type=int]
-                          │    │              └── const: 1 [type=int]
-                          │    └── projections
-                          │         ├── const: 10 [type=int]
-                          │         └── function: unique_rowid [type=int]
-                          └── projections
-                               └── plus [type=int]
-                                    ├── plus [type=int]
-                                    │    ├── variable: column2 [type=int]
-                                    │    └── variable: column12 [type=int]
-                                    └── const: 1 [type=int]
-
 # ------------------------------------------------------------------------------
 # Tests with target column names.
 # ------------------------------------------------------------------------------

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -1269,3 +1269,46 @@ with &1 (cte)
  │    └── const: 1 [type=int]
  └── scan abc
       └── columns: a:6(int!null) b:7(int) c:8(int)
+
+# Tests for the square bracket syntax.
+build
+SELECT * FROM [SELECT * FROM abc]
+----
+scan abc
+ └── columns: a:1(int!null) b:2(int) c:3(int)
+
+build
+SELECT * FROM [INSERT INTO abc VALUES (1, 2, 3) RETURNING a]
+----
+project
+ ├── columns: a:1(int!null)
+ └── insert abc
+      ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+      ├── insert-mapping:
+      │    ├──  column1:4 => a:1
+      │    ├──  column2:5 => b:2
+      │    └──  column3:6 => c:3
+      └── values
+           ├── columns: column1:4(int!null) column2:5(int!null) column3:6(int!null)
+           └── tuple [type=tuple{int, int, int}]
+                ├── const: 1 [type=int]
+                ├── const: 2 [type=int]
+                └── const: 3 [type=int]
+
+# Statement inside brackets cannot refer to outer column.
+build
+SELECT a, b FROM abc WHERE b = (SELECT x FROM [SELECT * FROM xyzw WHERE x = a])
+----
+error (42703): column "a" does not exist
+
+build
+SELECT a, b FROM abc, LATERAL (SELECT * FROM [SELECT * FROM xyzw WHERE a = x])
+----
+error (42703): column "a" does not exist
+
+# Statement inside brackets cannot refer to outer CTEs.
+build
+WITH cte AS (VALUES (1), (2))
+SELECT * FROM (VALUES (3)) AS t (x), [SELECT * FROM cte]
+----
+error (42P01): no data source matches prefix: "cte"

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -483,44 +483,6 @@ update abcde
                 │    └── variable: c [type=int]
                 └── const: 1 [type=int]
 
-# Correlated subquery.
-build
-SELECT * FROM xyz WHERE EXISTS (SELECT * FROM [UPDATE abcde SET b=y, c=z::int+1 RETURNING *])
-----
-select
- ├── columns: x:1(string!null) y:2(int) z:3(float)
- ├── scan xyz
- │    └── columns: x:1(string!null) xyz.y:2(int) z:3(float)
- └── filters
-      └── exists [type=bool]
-           └── project
-                ├── columns: a:4(int!null) b:5(int) c:6(int) d:7(int) e:8(int!null)
-                └── update abcde
-                     ├── columns: a:4(int!null) b:5(int) c:6(int) d:7(int) e:8(int!null) rowid:9(int!null)
-                     ├── fetch columns: a:10(int) b:11(int) c:12(int) d:13(int) e:14(int) rowid:15(int)
-                     ├── update-mapping:
-                     │    ├──  y:16 => b:5
-                     │    ├──  column17:17 => c:6
-                     │    ├──  column18:18 => d:7
-                     │    └──  a:10 => e:8
-                     └── project
-                          ├── columns: column18:18(int) a:10(int!null) b:11(int) c:12(int) d:13(int) e:14(int) rowid:15(int!null) y:16(int) column17:17(int)
-                          ├── project
-                          │    ├── columns: y:16(int) column17:17(int) a:10(int!null) b:11(int) c:12(int) d:13(int) e:14(int) rowid:15(int!null)
-                          │    ├── scan abcde
-                          │    │    └── columns: a:10(int!null) b:11(int) c:12(int) d:13(int) e:14(int) rowid:15(int!null)
-                          │    └── projections
-                          │         ├── variable: xyz.y [type=int]
-                          │         └── plus [type=int]
-                          │              ├── cast: INT8 [type=int]
-                          │              │    └── variable: z [type=float]
-                          │              └── const: 1 [type=int]
-                          └── projections
-                               └── plus [type=int]
-                                    ├── plus [type=int]
-                                    │    ├── variable: y [type=int]
-                                    │    └── variable: column17 [type=int]
-                                    └── const: 1 [type=int]
 
 # Unknown target table.
 build
@@ -1465,44 +1427,6 @@ update mutation
            └── gt [type=bool]
                 ├── variable: column11 [type=int]
                 └── const: 0 [type=int]
-
-# Use column "o" from higher scope that is shadowed by mutation column "o".
-build
-SELECT * FROM abcde AS mno(m, n, o) WHERE EXISTS(SELECT * FROM [UPDATE mutation SET m=o RETURNING *])
-----
-project
- ├── columns: m:1(int!null) n:2(int) o:3(int) d:4(int) e:5(int)
- └── select
-      ├── columns: mno.m:1(int!null) mno.n:2(int) mno.o:3(int) d:4(int) e:5(int) rowid:6(int!null)
-      ├── scan mno
-      │    └── columns: mno.m:1(int!null) mno.n:2(int) mno.o:3(int) d:4(int) e:5(int) rowid:6(int!null)
-      └── filters
-           └── exists [type=bool]
-                └── update mutation
-                     ├── columns: mutation.m:7(int!null) mutation.n:8(int)
-                     ├── fetch columns: mutation.m:12(int) mutation.n:13(int) mutation.o:14(int) p:15(int) q:16(int)
-                     ├── update-mapping:
-                     │    ├──  o:17 => mutation.m:7
-                     │    └──  column18:18 => p:10
-                     ├── check columns: check1:19(bool)
-                     └── project
-                          ├── columns: check1:19(bool) mutation.m:12(int!null) mutation.n:13(int) mutation.o:14(int) p:15(int) q:16(int) o:17(int) column18:18(int)
-                          ├── project
-                          │    ├── columns: column18:18(int) mutation.m:12(int!null) mutation.n:13(int) mutation.o:14(int) p:15(int) q:16(int) o:17(int)
-                          │    ├── project
-                          │    │    ├── columns: o:17(int) mutation.m:12(int!null) mutation.n:13(int) mutation.o:14(int) p:15(int) q:16(int)
-                          │    │    ├── scan mutation
-                          │    │    │    └── columns: mutation.m:12(int!null) mutation.n:13(int) mutation.o:14(int) p:15(int) q:16(int)
-                          │    │    └── projections
-                          │    │         └── variable: mno.o [type=int]
-                          │    └── projections
-                          │         └── plus [type=int]
-                          │              ├── variable: mutation.o [type=int]
-                          │              └── variable: mutation.n [type=int]
-                          └── projections
-                               └── gt [type=bool]
-                                    ├── variable: o [type=int]
-                                    └── const: 0 [type=int]
 
 # Try to return a mutation column.
 build


### PR DESCRIPTION
This change enforces the desired semantics of `[ ... ]`, which is
syntactic sugar for a top-level CTE. Specifically, the statement
inside cannot refer to anything outside of it (outer columns, CTEs).

Informs #41078.

Release justification: low-risk fix that prevents more incorrect uses
of the syntax (which will not work in 20.1).

Release note (bug fix): Statements inside `[ ... ]` cannot refer to
outer columns or CTEs.