### PR TITLE
opt: allow any AST node in subquery

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1408,9 +1408,7 @@ func (b *Builder) buildWith(with *memo.WithExpr) (execPlan, error) {
 	// Add the buffer as a subquery so it gets executed ahead of time, and is
 	// available to be referenced by other queries.
 	b.subqueries = append(b.subqueries, exec.Subquery{
-		ExprNode: &tree.Subquery{
-			Select: with.OriginalExpr.Select,
-		},
+		ExprNode: with.OriginalExpr,
 		// TODO(justin): this is wasteful: both the subquery and the bufferNode
 		// will buffer up all the results.  This should be fixed by either making
 		// the buffer point directly to the subquery results or adding a new
@@ -1423,7 +1421,7 @@ func (b *Builder) buildWith(with *memo.WithExpr) (execPlan, error) {
 
 	b.addBuiltWithExpr(with.ID, value.outputCols, buffer)
 
-	return b.buildRelational(with.Input)
+	return b.buildRelational(with.Main)
 }
 
 func (b *Builder) buildWithScan(withScan *memo.WithScanExpr) (execPlan, error) {

--- a/pkg/sql/opt/exec/execbuilder/testdata/spool
+++ b/pkg/sql/opt/exec/execbuilder/testdata/spool
@@ -20,7 +20,7 @@ root                                ·             ·
  │                                  label         buffer 1 (a)
  └── subquery                       ·             ·
       │                             id            @S1
-      │                             original sql  <unknown>
+      │                             original sql  INSERT INTO t SELECT * FROM t2 RETURNING x
       │                             exec mode     all rows
       └── buffer node               ·             ·
            │                        label         buffer 1 (a)
@@ -46,7 +46,7 @@ root                                ·             ·
  │                                  label         buffer 1 (a)
  └── subquery                       ·             ·
       │                             id            @S1
-      │                             original sql  <unknown>
+      │                             original sql  DELETE FROM t RETURNING x
       │                             exec mode     all rows
       └── buffer node               ·             ·
            │                        label         buffer 1 (a)
@@ -73,7 +73,7 @@ root                                     ·             ·
  │                                       label         buffer 1 (a)
  └── subquery                            ·             ·
       │                                  id            @S1
-      │                                  original sql  <unknown>
+      │                                  original sql  UPDATE t SET x = x + 1 RETURNING x
       │                                  exec mode     all rows
       └── buffer node                    ·             ·
            │                             label         buffer 1 (a)
@@ -101,7 +101,7 @@ root                                  ·             ·
  │                                    label         buffer 1 (a)
  └── subquery                         ·             ·
       │                               id            @S1
-      │                               original sql  <unknown>
+      │                               original sql  UPSERT INTO t VALUES (2), (3) RETURNING x
       │                               exec mode     all rows
       └── buffer node                 ·             ·
            │                          label         buffer 1 (a)
@@ -238,7 +238,7 @@ root                                                 ·             ·
  │                                                   label         buffer 2 (b)
  ├── subquery                                        ·             ·
  │    │                                              id            @S1
- │    │                                              original sql  <unknown>
+ │    │                                              original sql  INSERT INTO t SELECT * FROM t2 RETURNING x
  │    │                                              exec mode     all rows
  │    └── buffer node                                ·             ·
  │         │                                         label         buffer 1 (a)
@@ -252,7 +252,7 @@ root                                                 ·             ·
  │                                                   spans         ALL
  └── subquery                                        ·             ·
       │                                              id            @S2
-      │                                              original sql  <unknown>
+      │                                              original sql  INSERT INTO t SELECT x + 1 FROM a RETURNING x
       │                                              exec mode     all rows
       └── buffer node                                ·             ·
            │                                         label         buffer 2 (b)

--- a/pkg/sql/opt/exec/execbuilder/testdata/with
+++ b/pkg/sql/opt/exec/execbuilder/testdata/with
@@ -45,28 +45,28 @@ query TTTTT
 EXPLAIN (VERBOSE)
   WITH t AS (INSERT INTO x VALUES (1) RETURNING a) SELECT * FROM t
 ----
-·                                          distributed    false             ·                   ·
-·                                          vectorized     false             ·                   ·
-root                                       ·              ·                 (a)                 ·
- ├── scan buffer node                      ·              ·                 (a)                 ·
- │                                         label          buffer 1 (t)      ·                   ·
- └── subquery                              ·              ·                 (a)                 ·
-      │                                    id             @S1               ·                   ·
-      │                                    original sql   <unknown>         ·                   ·
-      │                                    exec mode      all rows          ·                   ·
-      └── buffer node                      ·              ·                 (a)                 ·
-           │                               label          buffer 1 (t)      ·                   ·
-           └── spool                       ·              ·                 (a)                 ·
-                └── render                 ·              ·                 (a)                 ·
-                     │                     render 0       a                 ·                   ·
-                     └── run               ·              ·                 (a, rowid[hidden])  ·
-                          └── insert       ·              ·                 (a, rowid[hidden])  ·
-                               │           into           x(a, rowid)       ·                   ·
-                               │           strategy       inserter          ·                   ·
-                               └── values  ·              ·                 (column1, column4)  ·
-·                                          size           2 columns, 1 row  ·                   ·
-·                                          row 0, expr 0  1                 ·                   ·
-·                                          row 0, expr 1  unique_rowid()    ·                   ·
+·                                          distributed    false                                 ·                   ·
+·                                          vectorized     false                                 ·                   ·
+root                                       ·              ·                                     (a)                 ·
+ ├── scan buffer node                      ·              ·                                     (a)                 ·
+ │                                         label          buffer 1 (t)                          ·                   ·
+ └── subquery                              ·              ·                                     (a)                 ·
+      │                                    id             @S1                                   ·                   ·
+      │                                    original sql   INSERT INTO x VALUES (1) RETURNING a  ·                   ·
+      │                                    exec mode      all rows                              ·                   ·
+      └── buffer node                      ·              ·                                     (a)                 ·
+           │                               label          buffer 1 (t)                          ·                   ·
+           └── spool                       ·              ·                                     (a)                 ·
+                └── render                 ·              ·                                     (a)                 ·
+                     │                     render 0       a                                     ·                   ·
+                     └── run               ·              ·                                     (a, rowid[hidden])  ·
+                          └── insert       ·              ·                                     (a, rowid[hidden])  ·
+                               │           into           x(a, rowid)                           ·                   ·
+                               │           strategy       inserter                              ·                   ·
+                               └── values  ·              ·                                     (column1, column4)  ·
+·                                          size           2 columns, 1 row                      ·                   ·
+·                                          row 0, expr 0  1                                     ·                   ·
+·                                          row 0, expr 1  unique_rowid()                        ·                   ·
 
 # Regression test for #39010.
 

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -516,9 +516,9 @@ type OutputOrdering sqlbase.ColumnOrdering
 
 // Subquery encapsulates information about a subquery that is part of a plan.
 type Subquery struct {
-	// ExprNode is a reference to a tree.Subquery node that has been created for
-	// this query; it is part of a scalar expression inside some Node.
-	ExprNode *tree.Subquery
+	// ExprNode is a reference to a AST node that can be used for printing the SQL
+	// of the subquery (for EXPLAIN).
+	ExprNode tree.NodeFormatter
 	Mode     SubqueryMode
 	// Root is the root Node of the plan for this subquery. This Node returns
 	// results as required for the specific Type.

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -395,6 +395,10 @@ func (h *hasher) HashTypedExpr(val tree.TypedExpr) {
 	h.HashUint64(uint64(reflect.ValueOf(val).Pointer()))
 }
 
+func (h *hasher) HashStatement(val tree.Statement) {
+	h.HashUint64(uint64(reflect.ValueOf(val).Pointer()))
+}
+
 func (h *hasher) HashColumnID(val opt.ColumnID) {
 	h.HashUint64(uint64(val))
 }
@@ -746,6 +750,10 @@ func (h *hasher) areDatumsWithTypeEqual(ldatums, rdatums tree.Datums, ltyp, rtyp
 }
 
 func (h *hasher) IsTypedExprEqual(l, r tree.TypedExpr) bool {
+	return l == r
+}
+
+func (h *hasher) IsStatementEqual(l, r tree.Statement) bool {
 	return l == r
 }
 

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -712,7 +712,7 @@ func (b *logicalPropsBuilder) buildBasicProps(e opt.Expr, cols opt.ColList, rel 
 
 func (b *logicalPropsBuilder) buildWithProps(with *WithExpr, rel *props.Relational) {
 	// Copy over the props from the input.
-	inputProps := with.Input.Relational()
+	inputProps := with.Main.Relational()
 
 	BuildSharedProps(b.mem, with, &rel.Shared)
 

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -810,13 +810,13 @@ define WindowPrivate {
     Ordering OrderingChoice
 }
 
-# With executes Binding, making its results available to Input. Within Input,
-# Binding may be referenced by a WithScan expression containing the ID of this
-# With.
+# With executes Binding, making its results available to Main. Within Main, the
+# results of Binding may be referenced by a WithScan expression containing the
+# ID of this With.
 [Relational]
 define With {
     Binding RelExpr
-    Input   RelExpr
+    Main    RelExpr
 
     _ WithPrivate
 }
@@ -825,9 +825,9 @@ define With {
 define WithPrivate {
     ID WithID
 
-    # OriginalExpr contains the original Subquery expression if it's a SELECT
-    # so that we can display it in the EXPLAIN plan.
-    OriginalExpr Subquery
+    # OriginalExpr contains the original CTE expression (so that we can display
+    # it in the EXPLAIN plan).
+    OriginalExpr Statement
 
     # Name is used to identify the with for debugging purposes.
     Name string

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -96,7 +96,7 @@ type scope struct {
 type cteSource struct {
 	name         tree.AliasClause
 	cols         []scopeColumn
-	originalExpr tree.SelectStatement
+	originalExpr tree.Statement
 	expr         memo.RelExpr
 	id           opt.WithID
 }

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -622,16 +622,10 @@ func (b *Builder) buildCTE(
 
 		id := b.factory.Memo().NextWithID()
 
-		// No good way to show non-select expressions, like INSERT, here.
-		var stmt tree.SelectStatement
-		if sel, ok := ctes[i].Stmt.(*tree.Select); ok {
-			stmt = sel.Select
-		}
-
 		b.ctes = append(b.ctes, cteSource{
 			name:         ctes[i].Name,
 			cols:         cols,
-			originalExpr: stmt,
+			originalExpr: ctes[i].Stmt,
 			expr:         cteScope.expr,
 			id:           id,
 		})
@@ -655,7 +649,7 @@ func (b *Builder) wrapWithCTEs(expr memo.RelExpr, ctes []cteSource) memo.RelExpr
 			&memo.WithPrivate{
 				ID:           ctes[i].id,
 				Name:         string(ctes[i].name.Alias),
-				OriginalExpr: &tree.Subquery{Select: ctes[i].originalExpr},
+				OriginalExpr: ctes[i].originalExpr,
 			},
 		)
 	}

--- a/pkg/sql/opt/optgen/cmd/optgen/metadata.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/metadata.go
@@ -167,6 +167,7 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"Type":           {fullName: "*types.T", isPointer: true},
 		"Datum":          {fullName: "tree.Datum", isPointer: true},
 		"TypedExpr":      {fullName: "tree.TypedExpr", isPointer: true},
+		"Statement":      {fullName: "tree.Statement", isPointer: true},
 		"Subquery":       {fullName: "*tree.Subquery", isPointer: true, usePointerIntern: true},
 		"CreateTable":    {fullName: "*tree.CreateTable", isPointer: true, usePointerIntern: true},
 		"Constraint":     {fullName: "*constraint.Constraint", isPointer: true, usePointerIntern: true},

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -28,7 +28,8 @@ import (
 // after it has been converted to a query plan. It is stored in
 // planTop.subqueryPlans.
 type subquery struct {
-	subquery *tree.Subquery
+	// subquery is used to show the subquery SQL when explaining plans.
+	subquery tree.NodeFormatter
 	execMode rowexec.SubqueryExecMode
 	expanded bool
 	started  bool


### PR DESCRIPTION
The `sql.subquery.subquery` field is only used to print out the SQL.
As such, it can be any node and not just a `*tree.Subquery`. We are
using the same structure for `With` where the input is a
`tree.Statement`.

This field is changed to a `tree.NodeFormatter` which better reflects
its usage and allows using any `tree.Statement`. With some cleanup on
the optimizer side, we can now show any CTE statement in EXPLAIN.

Release justification: low-risk fix to new functionality.

Release note (bug fix): The SQL for non-SELECT CTEs now shows up in
EXPLAIN output.