### PR TITLE
rocksdb: incorrectly identifying not found folder error on windows

### DIFF
--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -3264,10 +3264,10 @@ func (r *RocksDB) DeleteFile(filename string) error {
 
 // DeleteDirAndFiles deletes the directory and any files it contains but
 // not subdirectories from this RocksDB's env. If dir does not exist,
-// DeleteDirAndFiles returns nil (no error).
+// return os.ErrNotExist.
 func (r *RocksDB) DeleteDirAndFiles(dir string) error {
-	if err := statusToError(C.DBEnvDeleteDirAndFiles(r.rdb, goToCSlice([]byte(dir)))); err != nil && notFoundErrOrDefault(err) != os.ErrNotExist {
-		return err
+	if err := statusToError(C.DBEnvDeleteDirAndFiles(r.rdb, goToCSlice([]byte(dir)))); err != nil {
+		return notFoundErrOrDefault(err)
 	}
 	return nil
 }
@@ -3367,9 +3367,9 @@ func ExportToSst(
 
 func notFoundErrOrDefault(err error) error {
 	errStr := err.Error()
-	if strings.Contains(errStr, "No such file or directory") ||
-		strings.Contains(errStr, "File not found") ||
-		strings.Contains(errStr, "The system cannot find the path specified") {
+	if strings.Contains(errStr, "No such") ||
+		strings.Contains(errStr, "not found") ||
+		strings.Contains(errStr, "cannot find") {
 		return os.ErrNotExist
 	}
 	return err

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -1348,6 +1348,11 @@ func TestRocksDBFileNotFoundError(t *testing.T) {
 		t.Fatalf("expected IsNotExist, but got %v (%T)", err, err)
 	}
 
+	// Verify DeleteDirAndFiles returns os.ErrNotExist if dir does not exist.
+	if err := db.DeleteDirAndFiles("/non/existent/file"); !os.IsNotExist(err) {
+		t.Fatalf("expected IsNotExist, but got %v (%T)", err, err)
+	}
+
 	fname := filepath.Join(dir, "random.file")
 	data := "random data"
 	if f, err := db.OpenFile(fname); err != nil {

--- a/pkg/storage/replica_sideload_disk.go
+++ b/pkg/storage/replica_sideload_disk.go
@@ -256,6 +256,10 @@ func (ss *diskSideloadStorage) purgeFile(ctx context.Context, filename string) (
 // Clear implements SideloadStorage.
 func (ss *diskSideloadStorage) Clear(_ context.Context) error {
 	err := ss.eng.DeleteDirAndFiles(ss.dir)
+	if os.IsNotExist(err) {
+		ss.dirCreated = false
+		return nil
+	}
 	ss.dirCreated = ss.dirCreated && err != nil
 	return err
 }


### PR DESCRIPTION
RocksDB provides different delete folder methods depending on the
environment (windows, posix etc). Unfortunatelly the implementations
treat any error returned as I/O error and convert the error
codes to strings. So on CockroachDB side we can only distinguish a
serious error (disk corruption) from a harmless error
(file or folder doesn't exist) by parsing the error as a string.
Different platforms will return different strings and in case of Windows
the string wasn't in the list that we used to recognize folder not found.

Fixes #37819
Fixes #37427

Release justification: bug fix for existing functionality

Release note: None