### PR TITLE
storage: don't crash when applying side-effects of old ChangeReplicas trigger

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1343,6 +1343,14 @@ func (crt ChangeReplicasTrigger) Replicas() []ReplicaDescriptor {
 	return crt.DeprecatedUpdatedReplicas
 }
 
+// NextReplicaID returns the next replica id to use after this trigger applies.
+func (crt ChangeReplicasTrigger) NextReplicaID() ReplicaID {
+	if crt.Desc != nil {
+		return crt.Desc.NextReplicaID
+	}
+	return crt.DeprecatedNextReplicaID
+}
+
 // ConfChange returns the configuration change described by the trigger.
 func (crt ChangeReplicasTrigger) ConfChange(encodedCtx []byte) (raftpb.ConfChangeI, error) {
 	return confChangeImpl(crt, encodedCtx)

--- a/pkg/storage/replica_application_result.go
+++ b/pkg/storage/replica_application_result.go
@@ -320,7 +320,7 @@ func (r *Replica) handleChangeReplicasResult(
 		log.Fatalf(ctx, "failed to run Replica postDestroy: %v", err)
 	}
 
-	if err := r.store.removeInitializedReplicaRaftMuLocked(ctx, r, chng.Desc.NextReplicaID, RemoveOptions{
+	if err := r.store.removeInitializedReplicaRaftMuLocked(ctx, r, chng.NextReplicaID(), RemoveOptions{
 		// We destroyed the data when the batch committed so don't destroy it again.
 		DestroyData: false,
 		// In order to detect the GC queue racing with other causes of replica removal

--- a/pkg/storage/replica_application_state_machine.go
+++ b/pkg/storage/replica_application_state_machine.go
@@ -668,16 +668,6 @@ func (b *replicaAppBatch) runPreApplyTriggers(ctx context.Context, cmd *replicat
 		b.r.mu.Unlock()
 		b.changeRemovesReplica = true
 
-		// In 19.1 and before we used DeprecatedNextReplicaID to carry the next
-		// replica id to use once this change is applied. In 19.2 we started
-		// providing a new range descriptor directly, which includes this info.
-		var nextReplID roachpb.ReplicaID
-		if change.Desc != nil {
-			nextReplID = change.Desc.NextReplicaID
-		} else {
-			nextReplID = change.DeprecatedNextReplicaID
-		}
-
 		// Delete all of the local data. We're going to delete the hard state too.
 		// In order for this to be safe we need code above this to promise that we're
 		// never going to write hard state in response to a message for a later
@@ -686,7 +676,7 @@ func (b *replicaAppBatch) runPreApplyTriggers(ctx context.Context, cmd *replicat
 			ctx,
 			b.batch,
 			b.batch,
-			nextReplID,
+			change.NextReplicaID(),
 			false, /* clearRangeIDLocalOnly */
 			false, /* mustUseClearRange */
 		); err != nil {


### PR DESCRIPTION
Fixes #41155.
Fixes #41147.

The fix in #41148 avoided a crash when staging a ChangeReplicas trigger with
a DeprecatedNextReplicaID in an application batch, but there was another bug
where applying the side-effects of such a command still caused a crash. This
commit fixes the crash and extends the test added in #41148 to go through the
whole process of applying the command (which would have caught the second
crash as well).

Release justification: fixes a crash in mixed version clusters.

Release note: None