### PR TITLE
roachtest: update version map for the 19.1.5 release

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1038,7 +1038,7 @@ func PredecessorVersion(buildVersion version.Version) (string, error) {
 	buildVersionMajorMinor := fmt.Sprintf("%d.%d", buildVersion.Major(), buildVersion.Minor())
 
 	verMap := map[string]string{
-		"19.2": "19.1.3",
+		"19.2": "19.1.5",
 		"19.1": "2.1.8",
 		"2.2":  "2.1.8",
 		"2.1":  "2.0.7",


### PR DESCRIPTION
Release justification: testing only.

Release note: None