### PR TITLE
batcheval: fix empty-span fast-path in AddSSTable collision check

### DIFF
--- a/pkg/storage/batcheval/cmd_add_sstable.go
+++ b/pkg/storage/batcheval/cmd_add_sstable.go
@@ -204,7 +204,7 @@ func checkForKeyCollisions(
 	existingDataIter.Seek(mvccStartKey)
 	if ok, err := existingDataIter.Valid(); err != nil {
 		return emptyMVCCStats, errors.Wrap(err, "checking for key collisions")
-	} else if ok && !existingDataIter.UnsafeKey().Less(mvccEndKey) {
+	} else if !ok {
 		// Target key range is empty, so it is safe to ingest.
 		return emptyMVCCStats, nil
 	}


### PR DESCRIPTION
Given that the iterator has an upper-bound, it should simply be invalid after seeking past the span if empty.

Release note: none.

Release justification: small, low-risk fix for bug in new code that made it slower than expected.