### PR TITLE
engine: Implement Engine, Iterator interfaces for Pebble

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -53,7 +53,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
-	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/tool"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/kr/pretty"
@@ -1394,14 +1393,7 @@ func init() {
 	// To be able to read Cockroach-written RocksDB manifests/SSTables, comparator
 	// and merger functions must be specified to pebble that match the ones used
 	// to write those files.
-	//
-	// TODO(itsbilal): Port the Cockroach merger over from libroach/merge.cc to go
-	// and use that here. Until this happens, some data (eg. timeseries) will be
-	// printed incorrectly by this tool: it will be concatenated instead of being
-	// properly merged.
-	merger := *pebble.DefaultMerger
-	merger.Name = "cockroach_merge_operator"
-	pebbleTool.RegisterMerger(&merger)
+	pebbleTool.RegisterMerger(engine.MVCCMerger)
 	pebbleTool.RegisterComparer(engine.MVCCComparer)
 	debugPebbleCmd.AddCommand(pebbleTool.Commands...)
 	DebugCmd.AddCommand(debugPebbleCmd)

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -182,7 +182,12 @@ type Reader interface {
 	// function f on each key value pair. If f returns an error or if the scan
 	// itself encounters an error, the iteration will stop and return the error.
 	// If the first result of f is true, the iteration stops and returns a nil
-	// error.
+	// error. Note that this method is not expected take into account the
+	// timestamp of the end key; all MVCCKeys at end.Key are considered excluded
+	// in the iteration.
+	//
+	// TODO(itsbilal): Change type of start and end to roachpb.Key instead of
+	// MVCCKey. All keys passed in have zero timestamps anyway.
 	Iterate(start, end MVCCKey, f func(MVCCKeyValue) (stop bool, err error)) error
 	// NewIterator returns a new instance of an Iterator over this
 	// engine. The caller must invoke Iterator.Close() when finished
@@ -389,6 +394,9 @@ type Batch interface {
 	// TODO(tbg): it seems insane that you cannot read from a WriteOnlyBatch but
 	// you can read from a Distinct on top of a WriteOnlyBatch but randomly don't
 	// see the batch at all. I was personally just bitten by this.
+	//
+	// TODO(itsbilal): Improve comments around how/why distinct batches are an
+	// optimization in the rocksdb write path.
 	Distinct() ReadWriter
 	// Empty returns whether the batch has been written to or not.
 	Empty() bool

--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -1,0 +1,602 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package engine
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/pkg/errors"
+)
+
+// MVCCComparer is a pebble.Comparer object that implements MVCC-specific
+// comparator settings for use with Pebble.
+var MVCCComparer = &pebble.Comparer{
+	Compare: MVCCKeyCompare,
+
+	AbbreviatedKey: func(k []byte) uint64 {
+		key, _, ok := enginepb.SplitMVCCKey(k)
+		if !ok {
+			return 0
+		}
+		return pebble.DefaultComparer.AbbreviatedKey(key)
+	},
+
+	Format: func(k []byte) fmt.Formatter {
+		decoded, err := DecodeMVCCKey(k)
+		if err != nil {
+			return mvccKeyFormatter{err: err}
+		}
+		return mvccKeyFormatter{key: decoded}
+	},
+
+	// TODO(itsbilal): Improve separator to shorten index blocks in SSTables.
+	// Current implementation mimics what we use with RocksDB.
+	Separator: func(dst, a, b []byte) []byte {
+		return append(dst, a...)
+	},
+
+	Successor: func(dst, a []byte) []byte {
+		return append(dst, a...)
+	},
+
+	Split: func(k []byte) int {
+		if len(k) == 0 {
+			return len(k)
+		}
+		// This is similar to what enginepb.SplitMVCCKey does.
+		tsLen := int(k[len(k)-1])
+		keyPartEnd := len(k) - 1 - tsLen
+		if keyPartEnd < 0 {
+			return len(k)
+		}
+		return keyPartEnd
+	},
+
+	Name: "cockroach_comparator",
+}
+
+// MVCCMerger is a pebble.Merger object that implements the merge operator used
+// by Cockroach.
+var MVCCMerger = &pebble.Merger{
+	Name: "cockroach_merge_operator",
+
+	Merge: func(key, oldValue, newValue, buf []byte) []byte {
+		// TODO(itsbilal): Port the merge operator from C++ to Go.
+		// Until then, call the C++ merge operator directly.
+		ret, err := goMerge(oldValue, newValue)
+		if err != nil {
+			return nil
+		}
+		return ret
+	},
+}
+
+// Pebble is a wrapper around a Pebble database instance.
+type Pebble struct {
+	db *pebble.DB
+
+	closed bool
+	path   string
+
+	// Relevant options copied over from pebble.Options.
+	fs       vfs.FS
+	readOnly bool
+}
+
+var _ Engine = &Pebble{}
+
+// NewPebble creates a new Pebble instance, at the specified path.
+func NewPebble(path string, cfg *pebble.Options) (*Pebble, error) {
+	cfg.Comparer = MVCCComparer
+	cfg.Merger = MVCCMerger
+
+	// pebble.Open also calls EnsureDefaults, but only after doing a clone. Call
+	// EnsureDefaults beforehand so we have a matching cfg here for when we save
+	// cfg.FS and cfg.ReadOnly later on.
+	cfg.EnsureDefaults()
+
+	db, err := pebble.Open(path, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Pebble{
+		db:       db,
+		path:     path,
+		fs:       cfg.FS,
+		readOnly: cfg.ReadOnly,
+	}, nil
+}
+
+// Close implements the Engine interface.
+func (p *Pebble) Close() {
+	p.closed = true
+
+	if p.readOnly {
+		// Don't close the underlying handle; the non-ReadOnly instance will handle
+		// that.
+		return
+	}
+	_ = p.db.Close()
+}
+
+// Closed implements the Engine interface.
+func (p *Pebble) Closed() bool {
+	return p.closed
+}
+
+// Get implements the Engine interface.
+func (p *Pebble) Get(key MVCCKey) ([]byte, error) {
+	if len(key.Key) == 0 {
+		return nil, emptyKeyError()
+	}
+	ret, err := p.db.Get(EncodeKey(key))
+	if err == pebble.ErrNotFound || len(ret) == 0 {
+		return nil, nil
+	}
+	return ret, err
+}
+
+// GetProto implements the Engine interface.
+func (p *Pebble) GetProto(
+	key MVCCKey, msg protoutil.Message,
+) (ok bool, keyBytes, valBytes int64, err error) {
+	if len(key.Key) == 0 {
+		return false, 0, 0, emptyKeyError()
+	}
+	val, err := p.Get(key)
+	if err != nil || val == nil {
+		return false, 0, 0, err
+	}
+
+	err = protoutil.Unmarshal(val, msg)
+	keyBytes = int64(key.Len())
+	valBytes = int64(len(val))
+	return true, keyBytes, valBytes, err
+}
+
+// Helper function to implement Iterate() on Pebble, pebbleSnapshot,
+// and pebbleBatch.
+func iterateOnReader(
+	reader Reader, start, end MVCCKey, f func(MVCCKeyValue) (stop bool, err error),
+) error {
+	if reader.Closed() {
+		return errors.New("cannot call Iterate on a closed batch")
+	}
+	if !start.Less(end) {
+		return nil
+	}
+
+	it := reader.NewIterator(IterOptions{UpperBound: end.Key})
+	defer it.Close()
+
+	it.Seek(start)
+	for ; ; it.Next() {
+		ok, err := it.Valid()
+		if err != nil {
+			return err
+		} else if !ok {
+			break
+		}
+
+		if done, err := f(MVCCKeyValue{Key: it.Key(), Value: it.Value()}); done || err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Iterate implements the Engine interface.
+func (p *Pebble) Iterate(start, end MVCCKey, f func(MVCCKeyValue) (stop bool, err error)) error {
+	return iterateOnReader(p, start, end, f)
+}
+
+// NewIterator implements the Engine interface.
+func (p *Pebble) NewIterator(opts IterOptions) Iterator {
+	iter := newPebbleIterator(p.db, opts)
+	if iter == nil {
+		panic("couldn't create a new iterator")
+	}
+	return iter
+}
+
+// ApplyBatchRepr implements the Engine interface.
+func (p *Pebble) ApplyBatchRepr(repr []byte, sync bool) error {
+	if p.readOnly {
+		panic("write operation called on read-only pebble instance")
+	}
+	// batch.SetRepr takes ownership of the underlying slice, so make a copy.
+	reprCopy := make([]byte, len(repr))
+	copy(reprCopy, repr)
+
+	batch := p.db.NewBatch()
+	if err := batch.SetRepr(reprCopy); err != nil {
+		return err
+	}
+
+	opts := pebble.NoSync
+	if sync {
+		opts = pebble.Sync
+	}
+	return batch.Commit(opts)
+}
+
+// Clear implements the Engine interface.
+func (p *Pebble) Clear(key MVCCKey) error {
+	if p.readOnly {
+		panic("write operation called on read-only pebble instance")
+	}
+	if len(key.Key) == 0 {
+		return emptyKeyError()
+	}
+
+	return p.db.Delete(EncodeKey(key), pebble.Sync)
+}
+
+// SingleClear implements the Engine interface.
+func (p *Pebble) SingleClear(key MVCCKey) error {
+	if p.readOnly {
+		panic("write operation called on read-only pebble instance")
+	}
+	if len(key.Key) == 0 {
+		return emptyKeyError()
+	}
+
+	return p.db.SingleDelete(EncodeKey(key), pebble.Sync)
+}
+
+// ClearRange implements the Engine interface.
+func (p *Pebble) ClearRange(start, end MVCCKey) error {
+	if p.readOnly {
+		panic("write operation called on read-only pebble instance")
+	}
+
+	bufStart := EncodeKey(start)
+	bufEnd := EncodeKey(end)
+	return p.db.DeleteRange(bufStart, bufEnd, pebble.Sync)
+}
+
+// ClearIterRange implements the Engine interface.
+func (p *Pebble) ClearIterRange(iter Iterator, start, end MVCCKey) error {
+	if p.readOnly {
+		panic("write operation called on read-only pebble instance")
+	}
+
+	pebbleIter, ok := iter.(*pebbleIterator)
+	if !ok {
+		return errors.Errorf("%T is not a pebble iterator", iter)
+	}
+	// Note that this method has the side effect of modifying iter's bounds.
+	// Since all calls to `ClearIterRange` are on new throwaway iterators, this
+	// should be fine.
+	pebbleIter.lowerBoundBuf = EncodeKeyToBuf(pebbleIter.lowerBoundBuf[:0], start)
+	pebbleIter.options.LowerBound = pebbleIter.lowerBoundBuf
+	pebbleIter.upperBoundBuf = EncodeKeyToBuf(pebbleIter.upperBoundBuf[:0], end)
+	pebbleIter.options.UpperBound = pebbleIter.upperBoundBuf
+	pebbleIter.iter.SetBounds(pebbleIter.lowerBoundBuf, pebbleIter.upperBoundBuf)
+
+	pebbleIter.Seek(start)
+	for ; ; pebbleIter.Next() {
+		ok, err := pebbleIter.Valid()
+		if err != nil {
+			return err
+		} else if !ok || !pebbleIter.UnsafeKey().Less(end) {
+			break
+		}
+
+		err = p.db.Delete(pebbleIter.iter.Key(), pebble.Sync)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Merge implements the Engine interface.
+func (p *Pebble) Merge(key MVCCKey, value []byte) error {
+	if p.readOnly {
+		panic("write operation called on read-only pebble instance")
+	}
+	if len(key.Key) == 0 {
+		return emptyKeyError()
+	}
+
+	return p.db.Merge(EncodeKey(key), value, pebble.Sync)
+}
+
+// Put implements the Engine interface.
+func (p *Pebble) Put(key MVCCKey, value []byte) error {
+	if p.readOnly {
+		panic("write operation called on read-only pebble instance")
+	}
+	if len(key.Key) == 0 {
+		return emptyKeyError()
+	}
+
+	return p.db.Set(EncodeKey(key), value, pebble.Sync)
+}
+
+// LogData implements the Engine interface.
+func (p *Pebble) LogData(data []byte) error {
+	return p.db.LogData(data, pebble.Sync)
+}
+
+// LogLogicalOp implements the Engine interface.
+func (p *Pebble) LogLogicalOp(op MVCCLogicalOpType, details MVCCLogicalOpDetails) {
+	// No-op. Logical logging disabled.
+}
+
+// Attrs implements the Engine interface.
+func (p *Pebble) Attrs() roachpb.Attributes {
+	// TODO(itsbilal): Implement this.
+	return roachpb.Attributes{}
+}
+
+// Capacity implements the Engine interface.
+func (p *Pebble) Capacity() (roachpb.StoreCapacity, error) {
+	// Pebble doesn't have a capacity limiting parameter, so pass 0 for
+	// maxSizeBytes to denote no limit.
+	return computeCapacity(p.path, 0)
+}
+
+// Flush implements the Engine interface.
+func (p *Pebble) Flush() error {
+	return p.db.Flush()
+}
+
+// GetStats implements the Engine interface.
+func (p *Pebble) GetStats() (*Stats, error) {
+	// TODO(itsbilal): Implement this.
+	return &Stats{}, nil
+}
+
+// GetEnvStats implements the Engine interface.
+func (p *Pebble) GetEnvStats() (*EnvStats, error) {
+	// TODO(itsbilal): Implement this.
+	return &EnvStats{}, nil
+}
+
+// GetAuxiliaryDir implements the Engine interface.
+func (p *Pebble) GetAuxiliaryDir() string {
+	// Suggest an auxiliary subdirectory within the pebble data path.
+	return p.fs.PathJoin(p.path, "auxiliary")
+}
+
+// NewBatch implements the Engine interface.
+func (p *Pebble) NewBatch() Batch {
+	if p.readOnly {
+		panic("write operation called on read-only pebble instance")
+	}
+	return newPebbleBatch(p.db.NewIndexedBatch())
+}
+
+// NewReadOnly implements the Engine interface.
+func (p *Pebble) NewReadOnly() ReadWriter {
+	peb := &Pebble{
+		db:       p.db,
+		path:     p.path,
+		readOnly: true,
+		fs:       p.fs,
+	}
+	return peb
+}
+
+// NewWriteOnlyBatch implements the Engine interface.
+func (p *Pebble) NewWriteOnlyBatch() Batch {
+	if p.readOnly {
+		panic("write operation called on read-only pebble instance")
+	}
+	return newPebbleBatch(p.db.NewBatch())
+}
+
+// NewSnapshot implements the Engine interface.
+func (p *Pebble) NewSnapshot() Reader {
+	return &pebbleSnapshot{
+		snapshot: p.db.NewSnapshot(),
+	}
+}
+
+// IngestExternalFiles implements the Engine interface.
+func (p *Pebble) IngestExternalFiles(
+	ctx context.Context, paths []string, skipWritingSeqNo, allowFileModifications bool,
+) error {
+	return p.db.Ingest(paths)
+}
+
+// PreIngestDelay implements the Engine interface.
+func (p *Pebble) PreIngestDelay(_ context.Context) {
+	// TODO(itsbilal): See if we need to add pre-ingestion delays, similar to
+	// how we do with rocksdb.
+}
+
+// ApproximateDiskBytes implements the Engine interface.
+func (p *Pebble) ApproximateDiskBytes(from, to roachpb.Key) (uint64, error) {
+	// TODO(itsbilal): Add functionality in Pebble to do this count internally,
+	// instead of iterating over the range.
+	count := uint64(0)
+	_ = p.Iterate(MVCCKey{from, hlc.Timestamp{}}, MVCCKey{to, hlc.Timestamp{}}, func(kv MVCCKeyValue) (bool, error) {
+		count += uint64(kv.Key.Len() + len(kv.Value))
+		return false, nil
+	})
+	return count, nil
+}
+
+// CompactRange implements the Engine interface.
+func (p *Pebble) CompactRange(start, end roachpb.Key, forceBottommost bool) error {
+	bufStart := EncodeKey(MVCCKey{start, hlc.Timestamp{}})
+	bufEnd := EncodeKey(MVCCKey{end, hlc.Timestamp{}})
+	return p.db.Compact(bufStart, bufEnd)
+}
+
+// OpenFile implements the Engine interface.
+func (p *Pebble) OpenFile(filename string) (DBFile, error) {
+	file, err := p.fs.Open(p.fs.PathJoin(p.path, filename))
+	if err != nil {
+		return nil, err
+	}
+
+	pebbleFile := &pebbleFile{
+		file: file,
+	}
+	return pebbleFile, nil
+}
+
+// ReadFile implements the Engine interface.
+func (p *Pebble) ReadFile(filename string) ([]byte, error) {
+	file, err := p.fs.Open(p.fs.PathJoin(p.path, filename))
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	return ioutil.ReadAll(file)
+}
+
+// DeleteFile implements the Engine interface.
+func (p *Pebble) DeleteFile(filename string) error {
+	return p.fs.Remove(filename)
+}
+
+// DeleteDirAndFiles implements the Engine interface.
+func (p *Pebble) DeleteDirAndFiles(dir string) error {
+	// TODO(itsbilal): Implement FS.RemoveAll then call that here instead.
+	files, err := p.fs.List(dir)
+	if err != nil {
+		return err
+	}
+
+	// Recurse through all files, calling DeleteFile or DeleteDirAndFiles as
+	// appropriate.
+	for _, filename := range files {
+		path := p.fs.PathJoin(dir, filename)
+		stat, err := p.fs.Stat(path)
+		if err != nil {
+			return err
+		}
+
+		if stat.IsDir() {
+			err = p.DeleteDirAndFiles(path)
+		} else {
+			err = p.DeleteFile(path)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// LinkFile implements the Engine interface.
+func (p *Pebble) LinkFile(oldname, newname string) error {
+	oldPath := p.fs.PathJoin(p.path, oldname)
+	newPath := p.fs.PathJoin(p.path, newname)
+	return p.fs.Link(oldPath, newPath)
+}
+
+// CreateCheckpoint implements the Engine interface.
+func (p *Pebble) CreateCheckpoint(dir string) error {
+	return p.db.Checkpoint(dir)
+}
+
+// pebbleFile wraps a pebble File and implements the DBFile interface.
+type pebbleFile struct {
+	file vfs.File
+}
+
+var _ DBFile = &pebbleFile{}
+
+// Append implements the DBFile interface.
+func (p *pebbleFile) Append(data []byte) error {
+	_, err := p.file.Write(data)
+	return err
+}
+
+// Close implements the DBFile interface.
+func (p *pebbleFile) Close() error {
+	return p.file.Close()
+}
+
+// Close implements the DBFile interface.
+func (p *pebbleFile) Sync() error {
+	return p.file.Sync()
+}
+
+// pebbleSnapshot represents a snapshot created using Pebble.NewSnapshot().
+type pebbleSnapshot struct {
+	snapshot *pebble.Snapshot
+	closed   bool
+}
+
+var _ Reader = &pebbleSnapshot{}
+
+// Close implements the Reader interface.
+func (p *pebbleSnapshot) Close() {
+	_ = p.snapshot.Close()
+	p.closed = true
+}
+
+// Closed implements the Reader interface.
+func (p *pebbleSnapshot) Closed() bool {
+	return p.closed
+}
+
+// Get implements the Reader interface.
+func (p *pebbleSnapshot) Get(key MVCCKey) ([]byte, error) {
+	if len(key.Key) == 0 {
+		return nil, emptyKeyError()
+	}
+
+	ret, err := p.snapshot.Get(EncodeKey(key))
+	if err == pebble.ErrNotFound || len(ret) == 0 {
+		return nil, nil
+	}
+	return ret, err
+}
+
+// GetProto implements the Reader interface.
+func (p *pebbleSnapshot) GetProto(
+	key MVCCKey, msg protoutil.Message,
+) (ok bool, keyBytes, valBytes int64, err error) {
+	if len(key.Key) == 0 {
+		return false, 0, 0, emptyKeyError()
+	}
+
+	val, err := p.snapshot.Get(EncodeKey(key))
+	if err != nil || val == nil {
+		return false, 0, 0, err
+	}
+
+	err = protoutil.Unmarshal(val, msg)
+	keyBytes = int64(key.Len())
+	valBytes = int64(len(val))
+	return true, keyBytes, valBytes, err
+}
+
+// Iterate implements the Reader interface.
+func (p *pebbleSnapshot) Iterate(
+	start, end MVCCKey, f func(MVCCKeyValue) (stop bool, err error),
+) error {
+	return iterateOnReader(p, start, end, f)
+}
+
+// NewIterator implements the Reader interface.
+func (p pebbleSnapshot) NewIterator(opts IterOptions) Iterator {
+	return newPebbleIterator(p.snapshot, opts)
+}

--- a/pkg/storage/engine/pebble_batch.go
+++ b/pkg/storage/engine/pebble_batch.go
@@ -1,0 +1,349 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package engine
+
+import (
+	"sync"
+
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble"
+)
+
+// Wrapper struct around a pebble.Batch.
+type pebbleBatch struct {
+	batch        *pebble.Batch
+	buf          []byte
+	iter         pebbleBatchIterator
+	closed       bool
+	isDistinct   bool
+	distinctOpen bool
+	parentBatch  *pebbleBatch
+}
+
+var _ Batch = &pebbleBatch{}
+
+var pebbleBatchPool = sync.Pool{
+	New: func() interface{} {
+		return &pebbleBatch{}
+	},
+}
+
+// Instantiates a new pebbleBatch.
+func newPebbleBatch(batch *pebble.Batch) *pebbleBatch {
+	pb := pebbleBatchPool.Get().(*pebbleBatch)
+	*pb = pebbleBatch{
+		batch: batch,
+		buf:   pb.buf,
+		iter: pebbleBatchIterator{
+			pebbleIterator: pebbleIterator{
+				lowerBoundBuf: pb.iter.lowerBoundBuf,
+				upperBoundBuf: pb.iter.upperBoundBuf,
+			},
+		},
+	}
+
+	return pb
+}
+
+// Close implements the Batch interface.
+func (p *pebbleBatch) Close() {
+	if p.iter.iter != nil {
+		_ = p.iter.iter.Close()
+		p.iter.destroy()
+	}
+	if !p.isDistinct {
+		_ = p.batch.Close()
+		p.batch = nil
+	} else {
+		p.parentBatch.distinctOpen = false
+		p.isDistinct = false
+	}
+	p.closed = true
+	pebbleBatchPool.Put(p)
+}
+
+// Closed implements the Batch interface.
+func (p *pebbleBatch) Closed() bool {
+	return p.closed
+}
+
+// Get implements the Batch interface.
+func (p *pebbleBatch) Get(key MVCCKey) ([]byte, error) {
+	if len(key.Key) == 0 {
+		return nil, emptyKeyError()
+	}
+	p.buf = EncodeKeyToBuf(p.buf[:0], key)
+	ret, err := p.batch.Get(p.buf)
+	if err == pebble.ErrNotFound || len(ret) == 0 {
+		return nil, nil
+	}
+	return ret, err
+}
+
+// GetProto implements the Batch interface.
+func (p *pebbleBatch) GetProto(
+	key MVCCKey, msg protoutil.Message,
+) (ok bool, keyBytes, valBytes int64, err error) {
+	if len(key.Key) == 0 {
+		return false, 0, 0, emptyKeyError()
+	}
+	p.buf = EncodeKeyToBuf(p.buf[:0], key)
+	val, err := p.batch.Get(p.buf)
+	if err != nil || val == nil {
+		return false, 0, 0, err
+	}
+
+	err = protoutil.Unmarshal(val, msg)
+	keyBytes = int64(len(p.buf))
+	valBytes = int64(len(val))
+	return true, keyBytes, valBytes, err
+}
+
+// Iterate implements the Batch interface.
+func (p *pebbleBatch) Iterate(
+	start, end MVCCKey, f func(MVCCKeyValue) (stop bool, err error),
+) error {
+	return iterateOnReader(p, start, end, f)
+}
+
+// NewIterator implements the Batch interface.
+func (p *pebbleBatch) NewIterator(opts IterOptions) Iterator {
+	if !opts.Prefix && len(opts.UpperBound) == 0 && len(opts.LowerBound) == 0 {
+		panic("iterator must set prefix or upper bound or lower bound")
+	}
+
+	// Use the cached iterator.
+	//
+	// TODO(itsbilal): Investigate if it's equally or more efficient to just call
+	// newPebbleIterator with p.batch as the handle, instead of caching an
+	// iterator in pebbleBatch. This would clean up some of the oddities around
+	// pebbleBatchIterator.Close() (which doesn't close the underlying pebble
+	// Iterator), vs pebbleIterator.Close(), and the way memory is managed for
+	// the two iterators.
+	if p.iter.batch != nil {
+		panic("iterator already in use")
+	} else if p.iter.iter != nil {
+		_ = p.iter.iter.Close()
+	}
+
+	p.iter.init(p.batch, opts)
+	p.iter.batch = p
+	return &p.iter
+}
+
+// NewIterator implements the Batch interface.
+func (p *pebbleBatch) ApplyBatchRepr(repr []byte, sync bool) error {
+	if p.distinctOpen {
+		panic("distinct batch open")
+	}
+
+	var batch pebble.Batch
+	if err := batch.SetRepr(repr); err != nil {
+		return err
+	}
+
+	return p.batch.Apply(&batch, nil)
+}
+
+// Clear implements the Batch interface.
+func (p *pebbleBatch) Clear(key MVCCKey) error {
+	if p.distinctOpen {
+		panic("distinct batch open")
+	}
+	if len(key.Key) == 0 {
+		return emptyKeyError()
+	}
+
+	p.buf = EncodeKeyToBuf(p.buf[:0], key)
+	return p.batch.Delete(p.buf, nil)
+}
+
+// SingleClear implements the Batch interface.
+func (p *pebbleBatch) SingleClear(key MVCCKey) error {
+	if p.distinctOpen {
+		panic("distinct batch open")
+	}
+	if len(key.Key) == 0 {
+		return emptyKeyError()
+	}
+
+	p.buf = EncodeKeyToBuf(p.buf[:0], key)
+	return p.batch.SingleDelete(p.buf, nil)
+}
+
+// ClearRange implements the Batch interface.
+func (p *pebbleBatch) ClearRange(start, end MVCCKey) error {
+	if p.distinctOpen {
+		panic("distinct batch open")
+	}
+
+	p.buf = EncodeKeyToBuf(p.buf[:0], start)
+	buf2 := EncodeKey(end)
+	return p.batch.DeleteRange(p.buf, buf2, nil)
+}
+
+// Clear implements the Batch interface.
+func (p *pebbleBatch) ClearIterRange(iter Iterator, start, end MVCCKey) error {
+	if p.distinctOpen {
+		panic("distinct batch open")
+	}
+
+	pebbleIter, ok := iter.(*pebbleIterator)
+	if !ok {
+		return errors.Errorf("%T is not a pebble iterator", iter)
+	}
+	// Note that this method has the side effect of modifying iter's bounds.
+	// Since all calls to `ClearIterRange` are on new throwaway iterators, this
+	// should be fine.
+	pebbleIter.lowerBoundBuf = EncodeKeyToBuf(pebbleIter.lowerBoundBuf[:0], start)
+	pebbleIter.options.LowerBound = pebbleIter.lowerBoundBuf
+	pebbleIter.upperBoundBuf = EncodeKeyToBuf(pebbleIter.upperBoundBuf[:0], end)
+	pebbleIter.options.UpperBound = pebbleIter.upperBoundBuf
+	pebbleIter.iter.SetBounds(pebbleIter.lowerBoundBuf, pebbleIter.upperBoundBuf)
+
+	for ; ; iter.Next() {
+		valid, err := iter.Valid()
+		if err != nil {
+			return err
+		} else if !valid {
+			break
+		}
+
+		p.buf = EncodeKeyToBuf(p.buf[:0], iter.Key())
+		err = p.batch.Delete(p.buf, nil)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Merge implements the Batch interface.
+func (p *pebbleBatch) Merge(key MVCCKey, value []byte) error {
+	if p.distinctOpen {
+		panic("distinct batch open")
+	}
+	if len(key.Key) == 0 {
+		return emptyKeyError()
+	}
+
+	p.buf = EncodeKeyToBuf(p.buf[:0], key)
+	return p.batch.Merge(p.buf, value, nil)
+}
+
+// Put implements the Batch interface.
+func (p *pebbleBatch) Put(key MVCCKey, value []byte) error {
+	if p.distinctOpen {
+		panic("distinct batch open")
+	}
+	if len(key.Key) == 0 {
+		return emptyKeyError()
+	}
+
+	p.buf = EncodeKeyToBuf(p.buf[:0], key)
+	return p.batch.Set(p.buf, value, nil)
+}
+
+// LogData implements the Batch interface.
+func (p *pebbleBatch) LogData(data []byte) error {
+	return p.batch.LogData(data, nil)
+}
+
+func (p *pebbleBatch) LogLogicalOp(op MVCCLogicalOpType, details MVCCLogicalOpDetails) {
+	// No-op.
+}
+
+// Commit implements the Batch interface.
+func (p *pebbleBatch) Commit(sync bool) error {
+	opts := pebble.NoSync
+	if sync {
+		opts = pebble.Sync
+	}
+	if p.batch == nil {
+		panic("called with nil batch")
+	}
+	err := p.batch.Commit(opts)
+	if err != nil {
+		panic(err)
+	}
+	return err
+}
+
+// Distinct implements the Batch interface.
+func (p *pebbleBatch) Distinct() ReadWriter {
+	// Distinct batches are regular batches with isDistinct set to true.
+	// The parent batch is stored in parentBatch, and all writes on it are
+	// disallowed while the distinct batch is open. Both the distinct batch and
+	// the parent batch share the same underlying pebble.Batch instance.
+	//
+	// TODO(itsbilal): Investigate if we need to distinguish between distinct
+	// and non-distinct batches.
+	batch := &pebbleBatch{}
+	batch.batch = p.batch
+	batch.isDistinct = true
+	p.distinctOpen = true
+	batch.parentBatch = p
+
+	return batch
+}
+
+// Empty implements the Batch interface.
+func (p *pebbleBatch) Empty() bool {
+	return p.batch.Count() == 0
+}
+
+// Len implements the Batch interface.
+func (p *pebbleBatch) Len() int {
+	return len(p.batch.Repr())
+}
+
+// Repr implements the Batch interface.
+func (p *pebbleBatch) Repr() []byte {
+	// Repr expects a "safe" byte slice as its output. The return value of
+	// p.batch.Repr() is an unsafe byte slice owned by p.batch. Since we could be
+	// sending this slice over the wire, we need to make a copy.
+	repr := p.batch.Repr()
+	reprCopy := make([]byte, len(p.batch.Repr()))
+	copy(reprCopy, repr)
+	return reprCopy
+}
+
+// pebbleBatchIterator extends pebbleIterator and is meant to be embedded inside
+// a pebbleBatch.
+type pebbleBatchIterator struct {
+	pebbleIterator
+	batch *pebbleBatch
+}
+
+// Close implements the Iterator interface. There are two notable differences
+// from pebbleIterator.Close: 1. don't close the underlying p.iter (this is done
+// when the batch is closed), and 2. don't release the pebbleIterator back into
+// pebbleIterPool, since this memory is managed by pebbleBatch instead.
+func (p *pebbleBatchIterator) Close() {
+	if p.batch == nil {
+		panic("closing idle iterator")
+	}
+	p.batch = nil
+}
+
+// destroy resets all fields in a pebbleBatchIterator, while holding onto
+// some buffers to reduce allocations down the line. Assumes the underlying
+// pebble.Iterator has been closed already.
+func (p *pebbleBatchIterator) destroy() {
+	*p = pebbleBatchIterator{
+		pebbleIterator: pebbleIterator{
+			lowerBoundBuf: p.lowerBoundBuf,
+			upperBoundBuf: p.upperBoundBuf,
+		},
+		batch: nil,
+	}
+}

--- a/pkg/storage/engine/pebble_iterator.go
+++ b/pkg/storage/engine/pebble_iterator.go
@@ -1,0 +1,329 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package engine
+
+import (
+	"bytes"
+	"math"
+	"sync"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/pebble"
+)
+
+// pebbleIterator is a wrapper around a pebble.Iterator that implements the
+// Iterator interface.
+type pebbleIterator struct {
+	// Underlying iterator for the DB.
+	iter    *pebble.Iterator
+	options pebble.IterOptions
+	// Reusable buffer for MVCC key encoding.
+	keyBuf []byte
+	// Buffers for copying iterator bounds to. Note that the underlying memory
+	// is not GCed upon Close(), to reduce the number of overall allocations.
+	lowerBoundBuf []byte
+	upperBoundBuf []byte
+	// Set to true to govern whether to call SeekPrefixGE or SeekGE. Skips
+	// SSTables based on MVCC key when true.
+	prefix bool
+}
+
+var _ Iterator = &pebbleIterator{}
+
+var pebbleIterPool = sync.Pool{
+	New: func() interface{} {
+		return &pebbleIterator{}
+	},
+}
+
+// Instantiates a new Pebble iterator, or gets one from the pool.
+func newPebbleIterator(handle pebble.Reader, opts IterOptions) Iterator {
+	iter := pebbleIterPool.Get().(*pebbleIterator)
+	iter.init(handle, opts)
+	return iter
+}
+
+// init resets this pebbleIterator for use with the specified arguments. The
+// current instance could either be a cached iterator (eg. in pebbleBatch), or
+// a newly-instantiated one through newPebbleIterator.
+func (p *pebbleIterator) init(handle pebble.Reader, opts IterOptions) {
+	*p = pebbleIterator{
+		lowerBoundBuf: p.lowerBoundBuf,
+		upperBoundBuf: p.upperBoundBuf,
+		prefix:        opts.Prefix,
+	}
+
+	if !opts.Prefix && len(opts.UpperBound) == 0 && len(opts.LowerBound) == 0 {
+		panic("iterator must set prefix or upper bound or lower bound")
+	}
+
+	if opts.LowerBound != nil {
+		// This is the same as
+		// p.options.LowerBound = EncodeKeyToBuf(p.lowerBoundBuf[:0], MVCCKey{Key: opts.LowerBound}) .
+		// Since we are encoding zero-timestamp MVCC Keys anyway, we can just append
+		// the NUL byte instead of calling EncodeKey which will do the same thing.
+		p.lowerBoundBuf = append(p.lowerBoundBuf[:0], opts.LowerBound...)
+		p.lowerBoundBuf = append(p.lowerBoundBuf, 0x00)
+		p.options.LowerBound = p.lowerBoundBuf
+	}
+	if opts.UpperBound != nil {
+		// Same as above.
+		p.upperBoundBuf = append(p.upperBoundBuf[:0], opts.UpperBound...)
+		p.upperBoundBuf = append(p.upperBoundBuf, 0x00)
+		p.options.UpperBound = p.upperBoundBuf
+	}
+
+	p.iter = handle.NewIter(&p.options)
+	if p.iter == nil {
+		panic("unable to create iterator")
+	}
+}
+
+// Close implements the Iterator interface.
+func (p *pebbleIterator) Close() {
+	if p.iter != nil {
+		err := p.iter.Close()
+		if err != nil {
+			panic(err)
+		}
+		p.iter = nil
+	}
+	// Reset all fields except for the lower/upper bound buffers. Holding onto
+	// their underlying memory is more efficient to prevent extra allocations
+	// down the line.
+	*p = pebbleIterator{
+		lowerBoundBuf: p.lowerBoundBuf,
+		upperBoundBuf: p.upperBoundBuf,
+	}
+
+	pebbleIterPool.Put(p)
+}
+
+// Seek implements the Iterator interface.
+func (p *pebbleIterator) Seek(key MVCCKey) {
+	p.keyBuf = EncodeKeyToBuf(p.keyBuf[:0], key)
+	if p.prefix {
+		p.iter.SeekPrefixGE(p.keyBuf)
+	} else {
+		p.iter.SeekGE(p.keyBuf)
+	}
+}
+
+// Valid implements the Iterator interface.
+func (p *pebbleIterator) Valid() (bool, error) {
+	return p.iter.Valid(), p.iter.Error()
+}
+
+// Next implements the Iterator interface.
+func (p *pebbleIterator) Next() {
+	p.iter.Next()
+}
+
+// NextKey implements the Iterator interface.
+func (p *pebbleIterator) NextKey() {
+	if valid, err := p.Valid(); err != nil || !valid {
+		return
+	}
+	p.keyBuf = append(p.keyBuf[:0], p.UnsafeKey().Key...)
+
+	for p.iter.Next() {
+		if !bytes.Equal(p.keyBuf, p.UnsafeKey().Key) {
+			break
+		}
+	}
+}
+
+// UnsafeKey implements the Iterator interface.
+func (p *pebbleIterator) UnsafeKey() MVCCKey {
+	if valid, err := p.Valid(); err != nil || !valid {
+		return MVCCKey{}
+	}
+
+	mvccKey, err := DecodeMVCCKey(p.iter.Key())
+	if err != nil {
+		return MVCCKey{}
+	}
+
+	return mvccKey
+}
+
+// UnsafeValue implements the Iterator interface.
+func (p *pebbleIterator) UnsafeValue() []byte {
+	if valid, err := p.Valid(); err != nil || !valid {
+		return nil
+	}
+	return p.iter.Value()
+}
+
+// SeekReverse implements the Iterator interface.
+func (p *pebbleIterator) SeekReverse(key MVCCKey) {
+	// Do a SeekGE, not a SeekLT. This is because SeekReverse seeks to the
+	// greatest key that's less than or equal to the specified key.
+	p.Seek(key)
+	p.keyBuf = EncodeKeyToBuf(p.keyBuf[:0], key)
+
+	// The new key could either be greater or equal to the supplied key.
+	// Backtrack one step if it is greater.
+	comp := MVCCKeyCompare(p.keyBuf, p.iter.Key())
+	if comp < 0 && p.iter.Valid() {
+		p.Prev()
+	}
+}
+
+// Prev implements the Iterator interface.
+func (p *pebbleIterator) Prev() {
+	p.iter.Prev()
+}
+
+// PrevKey implements the Iterator interface.
+func (p *pebbleIterator) PrevKey() {
+	if valid, err := p.Valid(); err != nil || !valid {
+		return
+	}
+	curKey := p.Key()
+	for p.iter.Prev() {
+		if !bytes.Equal(curKey.Key, p.UnsafeKey().Key) {
+			break
+		}
+	}
+}
+
+// Key implements the Iterator interface.
+func (p *pebbleIterator) Key() MVCCKey {
+	key := p.UnsafeKey()
+	keyCopy := make([]byte, len(key.Key))
+	copy(keyCopy, key.Key)
+	key.Key = keyCopy
+	return key
+}
+
+// Value implements the Iterator interface.
+func (p *pebbleIterator) Value() []byte {
+	value := p.UnsafeValue()
+	valueCopy := make([]byte, len(value))
+	copy(valueCopy, value)
+	return valueCopy
+}
+
+// ValueProto implements the Iterator interface.
+func (p *pebbleIterator) ValueProto(msg protoutil.Message) error {
+	value := p.UnsafeValue()
+
+	return protoutil.Unmarshal(value, msg)
+}
+
+// ComputeStats implements the Iterator interface.
+func (p *pebbleIterator) ComputeStats(
+	start, end MVCCKey, nowNanos int64,
+) (enginepb.MVCCStats, error) {
+	return ComputeStatsGo(p, start, end, nowNanos)
+}
+
+// Go-only version of IsValidSplitKey. Checks if the specified key is in
+// NoSplitSpans.
+func isValidSplitKey(key roachpb.Key) bool {
+	for _, noSplitSpan := range keys.NoSplitSpans {
+		if noSplitSpan.ContainsKey(key) {
+			return false
+		}
+	}
+	return true
+}
+
+// FindSplitKey implements the Iterator interface.
+func (p *pebbleIterator) FindSplitKey(
+	start, end, minSplitKey MVCCKey, targetSize int64,
+) (MVCCKey, error) {
+	const timestampLen = int64(12)
+	p.Seek(start)
+	p.keyBuf = EncodeKeyToBuf(p.keyBuf[:0], end)
+	minSplitKeyBuf := EncodeKey(minSplitKey)
+	prevKey := make([]byte, 0)
+
+	sizeSoFar := int64(0)
+	bestDiff := int64(math.MaxInt64)
+	bestSplitKey := MVCCKey{}
+
+	for ; p.iter.Valid() && MVCCKeyCompare(p.iter.Key(), p.keyBuf) < 0; p.iter.Next() {
+		mvccKey, err := DecodeMVCCKey(p.iter.Key())
+		if err != nil {
+			return MVCCKey{}, err
+		}
+
+		diff := targetSize - sizeSoFar
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff < bestDiff && MVCCKeyCompare(p.iter.Key(), minSplitKeyBuf) >= 0 && isValidSplitKey(mvccKey.Key) {
+			// We are going to have to copy bestSplitKey, since by the time we find
+			// out it's the actual best split key, the underlying slice would have
+			// changed (due to the iter.Next() call).
+			//
+			// TODO(itsbilal): Instead of copying into bestSplitKey each time,
+			// consider just calling iter.Prev() at the end to get to the same key.
+			bestDiff = diff
+			bestSplitKey.Key = append(bestSplitKey.Key[:0], mvccKey.Key...)
+			bestSplitKey.Timestamp = mvccKey.Timestamp
+		}
+		if diff > bestDiff && bestSplitKey.Key != nil {
+			break
+		}
+
+		sizeSoFar += int64(len(p.iter.Value()))
+		if mvccKey.IsValue() && bytes.Equal(prevKey, mvccKey.Key) {
+			// We only advanced timestamps, but not new mvcc keys.
+			sizeSoFar += timestampLen
+		} else {
+			sizeSoFar += int64(len(mvccKey.Key) + 1)
+			if mvccKey.IsValue() {
+				sizeSoFar += timestampLen
+			}
+		}
+
+		prevKey = append(prevKey[:0], mvccKey.Key...)
+	}
+
+	return bestSplitKey, nil
+}
+
+// MVCCGet implements the Iterator interface.
+func (p *pebbleIterator) MVCCGet(
+	key roachpb.Key, timestamp hlc.Timestamp, opts MVCCGetOptions,
+) (value *roachpb.Value, intent *roachpb.Intent, err error) {
+	// TODO(itsbilal): Implement in a separate PR. See #39674.
+	panic("unimplemented for now, see #39674")
+}
+
+// MVCCScan implements the Iterator interface.
+func (p *pebbleIterator) MVCCScan(
+	start, end roachpb.Key, max int64, timestamp hlc.Timestamp, opts MVCCScanOptions,
+) (kvData []byte, numKVs int64, resumeSpan *roachpb.Span, intents []roachpb.Intent, err error) {
+	// TODO(itsbilal): Implement in a separate PR. See #39674.
+	panic("unimplemented for now, see #39674")
+}
+
+// SetUpperBound implements the Iterator interface.
+func (p *pebbleIterator) SetUpperBound(upperBound roachpb.Key) {
+	p.upperBoundBuf = append(p.upperBoundBuf[:0], upperBound...)
+	p.upperBoundBuf = append(p.upperBoundBuf, 0x00)
+	p.options.UpperBound = p.upperBoundBuf
+	p.iter.SetBounds(p.options.LowerBound, p.options.UpperBound)
+}
+
+// Stats implements the Iterator interface.
+func (p *pebbleIterator) Stats() IteratorStats {
+	// TODO(itsbilal): Implement this.
+	panic("implement me")
+}

--- a/pkg/storage/replica_application_result.go
+++ b/pkg/storage/replica_application_result.go
@@ -370,6 +370,10 @@ func (r *Replica) handleNoRaftLogDeltaResult(ctx context.Context) {
 func (r *Replica) handleSuggestedCompactionsResult(
 	ctx context.Context, scs []storagepb.SuggestedCompaction,
 ) {
+	// TODO(itsbilal): Remove this check once Pebble supports GetSSTables
+	if r.store.compactor == nil {
+		return
+	}
 	for _, sc := range scs {
 		r.store.compactor.Suggest(ctx, sc)
 	}

--- a/pkg/storage/replica_destroy.go
+++ b/pkg/storage/replica_destroy.go
@@ -98,7 +98,10 @@ func (r *Replica) postDestroyRaftMuLocked(ctx context.Context, ms enginepb.MVCCS
 	//
 	// TODO(benesch): we would ideally atomically suggest the compaction with
 	// the deletion of the data itself.
-	if ms != (enginepb.MVCCStats{}) {
+	//
+	// TODO(itsbilal): Remove the compactor != nil check once Pebble supports
+	// GetSSTables.
+	if ms != (enginepb.MVCCStats{}) && r.store.compactor != nil {
 		desc := r.Desc()
 		r.store.compactor.Suggest(ctx, storagepb.SuggestedCompaction{
 			StartKey: roachpb.Key(desc.StartKey),


### PR DESCRIPTION
This change implements the interfaces defined in
`pkg/storage/engine/engine.go` for Pebble, in particular `Engine`,
`Iterator`, and related ones.

The MVCC scanner is implemented in a separate commit, so `MVCCGet`
and `MVCCScan` are currently stubs that do nothing.

Other related changes elsewhere in the codebase to let an incomplete
Engine implementer (i.e. without WithSSTables, and without a compactor)
run otherwise.

One part of the work for #39674.

TODO:
- [ ] Add more test coverage, especially around batches

Release note: None