### PR TITLE
sql: fix bug with needed column families and nulls

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/family
+++ b/pkg/sql/logictest/testdata/logic_test/family
@@ -249,3 +249,26 @@ rename_col  CREATE TABLE rename_col (
             FAMILY fam_0_a_b (a, d),
             FAMILY fam_1_c (e)
 )
+
+# Regression tests for https://github.com/cockroachdb/cockroach/issues/41007.
+statement ok
+CREATE TABLE xyz (x INT PRIMARY KEY, y INT, z INT, FAMILY (x, y), FAMILY (z), INDEX (y))
+
+statement ok
+INSERT INTO xyz VALUES (1, 1, NULL)
+
+query I
+SELECT z FROM xyz WHERE y = 1
+----
+NULL
+
+statement ok
+CREATE TABLE y (y INT)
+
+statement ok
+INSERT INTO y VALUES (1)
+
+query I
+SELECT xyz.z FROM y INNER LOOKUP JOIN xyz ON y.y = xyz.y
+----
+NULL

--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -610,9 +610,9 @@ statement ok
 SET tracing = off
 
 query T
-SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE 'Scan /Table/71/1/1/1/{1-2}, /Table/71/1/1/3/{1-2}'
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE 'Scan /Table/71/1/%'
 ----
-Scan /Table/71/1/1/1/{1-2}, /Table/71/1/1/3/{1-2}
+Scan /Table/71/1/1/{0-1/2}, /Table/71/1/1/3/{1-2}
 
 # Test generating tighter spans on interleaved tables.
 statement ok

--- a/pkg/sql/sqlbase/index_encoding.go
+++ b/pkg/sql/sqlbase/index_encoding.go
@@ -242,9 +242,15 @@ func MakeSpanFromEncDatums(
 func NeededColumnFamilyIDs(
 	colIdxMap map[ColumnID]int, families []ColumnFamilyDescriptor, neededCols util.FastIntSet,
 ) []FamilyID {
-	var needed []FamilyID
+	// Column family 0 is always included so we can distinguish null rows from
+	// absent rows.
+	needed := []FamilyID{0}
 	for i := range families {
 		family := &families[i]
+		if family.ID == 0 {
+			// Already added above.
+			continue
+		}
 		for _, columnID := range family.ColumnIDs {
 			columnOrdinal := colIdxMap[columnID]
 			if neededCols.Contains(columnOrdinal) {


### PR DESCRIPTION
When doing point lookups, we have logic to only scan column families
which are needed for the requested columns. However, this logic had a
bug concerning NULL values. Column families other than the one with ID 0
do not store a row if all their columns are NULL. This means that if you
only scan those families, you can't distinguish between the absence of a
row and all NULL values. Since we didn't account for this, some queries
which should have returned an all NULL row were instead returning no
row. See the referenced issue for specific examples.

For now I have fixed this by always including column family 0 in the
needed column families. There are some special cases where we could omit
it, but we'll save those for the 20.1 release.

Fixes #41007

Release note: None

Release justification: Correctness bug fix