### PR TITLE
Config: validate that subzones have fields in tandem

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -362,7 +362,7 @@ CREATE TABLE t36642 (
 );
 
 statement ok
-ALTER INDEX t36642@secondary CONFIGURE ZONE USING lease_preferences='[[+region=test,+dc=dc1]]'
+ALTER INDEX t36642@secondary CONFIGURE ZONE USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc1]]'
 
 query TTT retry
 EXPLAIN SELECT * FROM t36642 WHERE k=10
@@ -374,10 +374,10 @@ scan  ·            ·
 ·     spans        /10-/11
 
 statement ok
-ALTER INDEX t36642@tertiary CONFIGURE ZONE USING lease_preferences='[[+region=test,+dc=dc1]]'
+ALTER INDEX t36642@tertiary CONFIGURE ZONE USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc1]]'
 
 statement ok
-ALTER INDEX t36642@secondary CONFIGURE ZONE USING lease_preferences='[[+region=test,+dc=dc2]]'
+ALTER INDEX t36642@secondary CONFIGURE ZONE USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc2]]'
 
 query TTT retry
 EXPLAIN SELECT * FROM t36642 WHERE k=10
@@ -806,3 +806,25 @@ t38074 i ALTER INDEX test.public.t38074@i CONFIGURE ZONE USING
                                num_replicas = 3,
                                constraints = '[]',
                                lease_preferences = '[]'
+
+# Regression test for #39994: verify that certain fields have to be set in tandem in indexes and partitions.
+statement ok
+CREATE TABLE validateTandemFields (a INT, b INT, c INT, PRIMARY KEY (a, b))
+  PARTITION BY LIST (a, b) (PARTITION simple VALUES IN ((1, 1), (2, 2), (3, 3)))
+
+statement error pq: could not validate zone config: range_min_bytes and range_max_bytes must be set together
+ALTER PARTITION simple OF TABLE validateTandemFields CONFIGURE ZONE USING range_min_bytes = 66666
+
+statement ok
+CREATE INDEX secondary
+    ON validateTandemFields (b)
+    PARTITION BY LIST (b)
+        (
+            PARTITION indexPartition VALUES IN (2, 3, 4)
+        )
+
+statement error pq: could not validate zone config: range_min_bytes and range_max_bytes must be set together
+ALTER INDEX validateTandemFields@secondary CONFIGURE ZONE USING range_min_bytes = 66666
+
+statement error pq: could not validate zone config: range_min_bytes and range_max_bytes must be set together
+ALTER PARTITION indexPartition OF INDEX validateTandemFields@secondary CONFIGURE ZONE USING range_min_bytes = 66666

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -541,6 +541,20 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 				return pgerror.Newf(pgcode.CheckViolation,
 					"could not validate zone config: %v", err)
 			}
+
+			// Finally check for the extra protection partial zone configs would
+			// require from changes made to parent zones. The extra protections are:
+			//
+			// RangeMinBytes and RangeMaxBytes must be set together
+			// LeasePreferences cannot be set unless Constraints are explicitly set
+			// Per-replica constraints cannot be set unless num_replicas is explicitly set
+			if err := finalZone.ValidateTandemFields(); err != nil {
+				err = errors.Wrap(err, "could not validate zone config")
+				err = pgerror.WithCandidateCode(err, pgcode.InvalidParameterValue)
+				err = errors.WithHint(err,
+					"try ALTER ... CONFIGURE ZONE USING <field_name> = COPY FROM PARENT [, ...] to populate the field")
+				return err
+			}
 		}
 
 		// Write the partial zone configuration.
@@ -548,19 +562,6 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 		execConfig := params.extendedEvalCtx.ExecCfg
 		zoneToWrite := partialZone
 
-		// Finally check for the extra protection partial zone configs would
-		// require from changes made to parent zones. The extra protections are:
-		//
-		// RangeMinBytes and RangeMaxBytes must be set together
-		// LeasePreferences cannot be set unless Constraints are explicitly set
-		// Per-replica constraints cannot be set unless num_replicas is explicitly set
-		if err := zoneToWrite.ValidateTandemFields(); err != nil {
-			err = errors.Wrap(err, "could not validate zone config")
-			err = pgerror.WithCandidateCode(err, pgcode.InvalidParameterValue)
-			err = errors.WithHint(err,
-				"try ALTER ... CONFIGURE ZONE USING <field_name> = COPY FROM PARENT [, ...] to populate the field")
-			return err
-		}
 		n.run.numAffected, err = writeZoneConfig(params.ctx, params.p.txn,
 			targetID, table, zoneToWrite, execConfig, hasNewSubzones)
 		if err != nil {

--- a/pkg/workload/movr/movr.go
+++ b/pkg/workload/movr/movr.go
@@ -298,9 +298,11 @@ func (g *movr) Hooks() workload.Hooks {
 			constraints = '{"+region=us-east1": 1}',
 			lease_preferences = '[[+region=us-east1]]';
 		ALTER INDEX promo_codes@promo_codes_idx_us_west CONFIGURE ZONE USING
+			num_replicas = 3,
 			constraints = '{"+region=us-west1": 1}',
 			lease_preferences = '[[+region=us-west1]]';
 		ALTER INDEX promo_codes@promo_codes_idx_europe_west CONFIGURE ZONE USING
+			num_replicas = 3,
 			constraints = '{"+region=europe-west1": 1}',
 			lease_preferences = '[[+region=europe-west1]]';
 	`


### PR DESCRIPTION
Previously we only validated the zone we were writing
but when we're writing index or partition zones, we write
a subzone inside another zone. Instead of validating this
subzone, we we're incorrectly validating the parent zone.
This change rectifies that.

Change courtesy of @ridwanmsharif. This change basically rebases ridwan's changes in #39995 and removes some semicolons in the logic tests.

Fixes #39994.

Release justification: low risk bug fix

Release note (bug fix): Fix bug where zone configuration changes on
secondary indexes wouldn't perform setting verification (such as
constraints with lease preferences, or setting only one of
min_range_size and max_range size).