### PR TITLE
libroach: Don't assert on nonzero min timestamp hints in iterators

### DIFF
--- a/c-deps/libroach/incremental_iterator.cc
+++ b/c-deps/libroach/incremental_iterator.cc
@@ -42,7 +42,6 @@ DBIncrementalIterator::DBIncrementalIterator(DBEngine* engine, DBIterOptions opt
   // outside of the timestamp range **from iter's perspective**. This allows us
   // to simply ignore discrepancies that we notice in advance(). See #34819.
   if (!EmptyTimestamp(opts.min_timestamp_hint) || !EmptyTimestamp(opts.max_timestamp_hint)) {
-    assert(!EmptyTimestamp(opts.min_timestamp_hint));
     assert(!EmptyTimestamp(opts.max_timestamp_hint));
     DBIterOptions nontimebound_opts = DBIterOptions();
     nontimebound_opts.upper_bound = opts.upper_bound;

--- a/c-deps/libroach/iterator.cc
+++ b/c-deps/libroach/iterator.cc
@@ -26,7 +26,6 @@ DBIterator::DBIterator(std::atomic<int64_t>* iters, DBIterOptions iter_options) 
 
   if (!EmptyTimestamp(iter_options.min_timestamp_hint) ||
       !EmptyTimestamp(iter_options.max_timestamp_hint)) {
-    assert(!EmptyTimestamp(iter_options.min_timestamp_hint));
     assert(!EmptyTimestamp(iter_options.max_timestamp_hint));
     const std::string min = EncodeTimestamp(iter_options.min_timestamp_hint);
     const std::string max = EncodeTimestamp(iter_options.max_timestamp_hint);


### PR DESCRIPTION
Currently, if either a min or max timestamp hint is provided to a
RocksDB iterator, we assert that both are non-zero. In practice,
we only need to assert on the max one being nonzero; a zero min
timestamp hint when encoded would sort before all timestamps, and
would not filter out any SSTs. A zero max timestamp
hint could filter out all SSTs, which would be worth asserting on.

Fixes #41200 .

Release justification: Fixes assertions that are currently failing
in tests, no risk otherwise.

Release note: None