### PR TITLE
roleccl: WITH ADMIN check no longer bypassed on admin role

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/role
+++ b/pkg/ccl/logictestccl/testdata/logic_test/role
@@ -602,7 +602,7 @@ CREATE DATABASE db2
 statement error user testuser does not have DROP privilege on database db1
 DROP DATABASE db1
 
-statement error testuser is not a superuser or role admin for role admin
+statement error testuser is not a role admin for role admin
 GRANT admin TO testuser
 
 user root
@@ -633,8 +633,12 @@ statement ok
 DROP DATABASE db1
 
 # Revoke admin privileges. 'newgroup' does not have any privileges.
+user root
+
 statement ok
 REVOKE admin FROM newgroup
+
+user testuser
 
 statement error user testuser does not have SELECT privilege on relation role_members
 SELECT * FROM system.role_members
@@ -691,6 +695,41 @@ REVOKE newgroup FROM testuser
 
 statement error testuser is not a superuser or role admin for role newgroup
 GRANT newgroup TO testuser WITH ADMIN OPTION
+
+# Regression for #31784
+user root
+
+# grant admin to testuser without ADMIN OPTION
+statement ok
+CREATE USER user1;
+GRANT admin TO testuser
+
+user testuser
+
+statement error pq: testuser is not a role admin for role admin
+GRANT admin TO user1
+
+statement error pq: testuser is not a role admin for role admin
+REVOKE admin FROM user1
+
+user root
+
+# WITH ADMIN OPTION means that testuser now has permission to add to the admin role
+statement ok
+GRANT admin TO testuser WITH ADMIN OPTION
+
+user testuser
+
+statement ok
+GRANT admin TO user1
+
+statement ok
+REVOKE admin FROM user1
+
+user root
+
+statement ok
+DROP USER user1
 
 user root
 


### PR DESCRIPTION
For users in the admin role, the check that the user had admin option
was bypassed, which led to users who didn't have the admin option in the
admin role having the permission to add users to the admin role. This
change performs the check on the admin role now.

Fixes #31784.

Release justification: low risk bug fix

Release note (bug fix): Users GRANTing and REVOKEing admin role
must be a member of the admin role with admin option now. This
check was bypassed before.
