### PR TITLE
execinfra: Allow joinreader to parallelize single key spans

### DIFF
--- a/pkg/sql/lookup_join.go
+++ b/pkg/sql/lookup_join.go
@@ -43,6 +43,14 @@ type lookupJoinNode struct {
 	props physicalProps
 }
 
+// CanParallelize indicates whether the fetchers can parallelize the
+// batches of lookups that can be performed. As of now, this is true if
+// the equality columns that the lookup joiner uses form keys that
+// can return at most 1 row.
+func (lj *lookupJoinNode) CanParallelize() bool {
+	return lj.eqColsAreKey
+}
+
 func (lj *lookupJoinNode) startExec(params runParams) error {
 	panic("lookupJoinNode cannot be run in local mode")
 }

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -442,6 +442,24 @@ scan  ·            ·
 ·     spans        /1-/1/# /3-/3/#
 ·     parallel     ·
 
+statement ok
+CREATE TABLE t2 (x INT PRIMARY KEY)
+
+query TTT
+EXPLAIN (PLAN) SELECT * FROM t INNER LOOKUP JOIN t2 ON t.k = t2.x
+----
+·            distributed            false
+·            vectorized             true
+lookup-join  ·                      ·
+ │           table                  t2@primary
+ │           type                   inner
+ │           equality               (k) = (x)
+ │           equality cols are key  ·
+ │           parallel               ·
+ └── scan    ·                      ·
+·            table                  t@primary
+·            spans                  ALL
+
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE k % 2 = 0
 ----

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk_opt
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk_opt
@@ -34,6 +34,7 @@ root                                       ·                      ·           
                 │                          type                   anti               ·                   ·
                 │                          equality               (column2) = (p)    ·                   ·
                 │                          equality cols are key  ·                  ·                   ·
+                │                          parallel               ·                  ·                   ·
                 └── render                 ·                      ·                  (column2)           ·
                      │                     render 0               column2            ·                   ·
                      └── scan buffer node  ·                      ·                  (column1, column2)  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -179,6 +179,7 @@ lookup-join       ·                      ·                                    
  │                type                   inner                                ·       ·
  │                equality               (a) = (a)                            ·       ·
  │                equality cols are key  ·                                    ·       ·
+ │                parallel               ·                                    ·       ·
  │                pred                   @2 @> '{"a": {"b": "c"}, "f": "g"}'  ·       ·
  └── zigzag-join  ·                      ·                                    (a)     ·
       │           type                   inner                                ·       ·
@@ -199,6 +200,7 @@ lookup-join       ·                      ·                                    
  │                type                   inner                                          ·       ·
  │                equality               (a) = (a)                                      ·       ·
  │                equality cols are key  ·                                              ·       ·
+ │                parallel               ·                                              ·       ·
  │                pred                   @2 @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·       ·
  └── zigzag-join  ·                      ·                                              (a)     ·
       │           type                   inner                                          ·       ·
@@ -219,6 +221,7 @@ lookup-join       ·                      ·                                   (
  │                type                   inner                               ·       ·
  │                equality               (a) = (a)                           ·       ·
  │                equality cols are key  ·                                   ·       ·
+ │                parallel               ·                                   ·       ·
  │                pred                   @2 @> '[{"a": {"b": [[2]]}}, "d"]'  ·       ·
  └── zigzag-join  ·                      ·                                   (a)     ·
       │           type                   inner                               ·       ·
@@ -242,6 +245,7 @@ lookup-join       ·                      ·                                    
  │                type                   inner                                ·       ·
  │                equality               (a) = (a)                            ·       ·
  │                equality cols are key  ·                                    ·       ·
+ │                parallel               ·                                    ·       ·
  │                pred                   @2 @> '{"a": {"b": "c"}, "f": "g"}'  ·       ·
  └── zigzag-join  ·                      ·                                    (a)     ·
       │           type                   inner                                ·       ·
@@ -262,6 +266,7 @@ lookup-join       ·                      ·                                    
  │                type                   inner                                          ·       ·
  │                equality               (a) = (a)                                      ·       ·
  │                equality cols are key  ·                                              ·       ·
+ │                parallel               ·                                              ·       ·
  │                pred                   @2 @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·       ·
  └── zigzag-join  ·                      ·                                              (a)     ·
       │           type                   inner                                          ·       ·
@@ -282,6 +287,7 @@ lookup-join       ·                      ·                                   (
  │                type                   inner                               ·       ·
  │                equality               (a) = (a)                           ·       ·
  │                equality cols are key  ·                                   ·       ·
+ │                parallel               ·                                   ·       ·
  │                pred                   @2 @> '[{"a": {"b": [[2]]}}, "d"]'  ·       ·
  └── zigzag-join  ·                      ·                                   (a)     ·
       │           type                   inner                               ·       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -1530,6 +1530,7 @@ lookup-join       ·                      ·
  │                type                   inner
  │                equality               (a) = (a)
  │                equality cols are key  ·
+ │                parallel               ·
  └── zigzag-join  ·                      ·
       │           type                   inner
       │           pred                   (@2 = 5) AND (@3 = 6.0)
@@ -1551,6 +1552,7 @@ lookup-join       ·                      ·
  │                type                   inner
  │                equality               (a) = (a)
  │                equality cols are key  ·
+ │                parallel               ·
  │                pred                   @4 > 4.0
  └── zigzag-join  ·                      ·
       │           type                   inner

--- a/pkg/sql/opt/exec/execbuilder/testdata/join_order
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join_order
@@ -85,11 +85,13 @@ render                 ·                      ·            (a, b, c, d, b, x, 
       │                type                   inner        ·                         ·
       │                equality               (b) = (b)    ·                         ·
       │                equality cols are key  ·            ·                         ·
+      │                parallel               ·            ·                         ·
       └── lookup-join  ·                      ·            (a, b, c, d, c, y)        ·
            │           table                  cy@primary   ·                         ·
            │           type                   inner        ·                         ·
            │           equality               (c) = (c)    ·                         ·
            │           equality cols are key  ·            ·                         ·
+           │           parallel               ·            ·                         ·
            └── scan    ·                      ·            (a, b, c, d)              ·
 ·                      table                  abc@primary  ·                         ·
 ·                      spans                  /1-/1/#      ·                         ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -53,6 +53,7 @@ lookup-join  ·                      ·                (a, b, c, d, e, f)  ·
  │           type                   inner            ·                   ·
  │           equality               (b, c) = (f, e)  ·                   ·
  │           equality cols are key  ·                ·                   ·
+ │           parallel               ·                ·                   ·
  └── scan    ·                      ·                (a, b, c)           ·
 ·            table                  abc@primary      ·                   ·
 ·            spans                  ALL              ·                   ·
@@ -161,6 +162,7 @@ render            ·                      ·                            (a, b, c
       │           type                   inner                        ·                         ·
       │           equality               (a, b, c, d) = (a, b, c, d)  ·                         ·
       │           equality cols are key  ·                            ·                         ·
+      │           parallel               ·                            ·                         ·
       └── scan    ·                      ·                            (a, b, c, d)              ·
 ·                 table                  data@primary                 ·                         ·
 ·                 spans                  ALL                          ·                         ·
@@ -385,6 +387,7 @@ render                 ·                      ·                (a, d)        �
       │                type                   inner            ·             ·
       │                equality               (a, b) = (a, b)  ·             ·
       │                equality cols are key  ·                ·             ·
+      │                parallel               ·                ·             ·
       └── lookup-join  ·                      ·                (a, a, b)     ·
            │           table                  large@bc         ·             ·
            │           type                   inner            ·             ·
@@ -465,6 +468,7 @@ render                 ·                      ·                (c, d)        �
       │                type                   left outer       ·             ·
       │                equality               (a, b) = (a, b)  ·             ·
       │                equality cols are key  ·                ·             ·
+      │                parallel               ·                ·             ·
       └── lookup-join  ·                      ·                (c, a, b)     ·
            │           table                  large@bc         ·             ·
            │           type                   left outer       ·             ·
@@ -729,6 +733,7 @@ lookup-join  ·                      ·                (a, b, c)  ·
  │           type                   semi             ·          ·
  │           equality               (a, c) = (f, e)  ·          ·
  │           equality cols are key  ·                ·          ·
+ │           parallel               ·                ·          ·
  └── scan    ·                      ·                (a, b, c)  ·
 ·            table                  abc@primary      ·          ·
 ·            spans                  ALL              ·          ·
@@ -743,6 +748,7 @@ lookup-join  ·                      ·                (a, b, c)  ·
  │           type                   anti             ·          ·
  │           equality               (a, c) = (f, e)  ·          ·
  │           equality cols are key  ·                ·          ·
+ │           parallel               ·                ·          ·
  └── scan    ·                      ·                (a, b, c)  ·
 ·            table                  abc@primary      ·          ·
 ·            spans                  ALL              ·          ·
@@ -1413,18 +1419,21 @@ limit                                               ·                      ·
                      │                              type                   inner
                      │                              equality               (l_orderkey) = (o_orderkey)
                      │                              equality cols are key  ·
+                     │                              parallel               ·
                      │                              pred                   @11 = 'F'
                      └── lookup-join                ·                      ·
                           │                         table                  nation@primary
                           │                         type                   inner
                           │                         equality               (s_nationkey) = (n_nationkey)
                           │                         equality cols are key  ·
+                          │                         parallel               ·
                           │                         pred                   @9 = 'SAUDI ARABIA'
                           └── lookup-join           ·                      ·
                                │                    table                  supplier@primary
                                │                    type                   inner
                                │                    equality               (l_suppkey) = (s_suppkey)
                                │                    equality cols are key  ·
+                               │                    parallel               ·
                                └── lookup-join      ·                      ·
                                     │               table                  lineitem@primary
                                     │               type                   semi

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -867,6 +867,7 @@ render                      ·                      ·                 (k)      
                 │           type                   inner             ·                ·
                 │           equality               (column1) = (k)   ·                ·
                 │           equality cols are key  ·                 ·                ·
+                │           parallel               ·                 ·                ·
                 └── values  ·                      ·                 (column1)        ·
 ·                           size                   1 column, 2 rows  ·                ·
 ·                           row 0, expr 0          1                 ·                ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -84,6 +84,7 @@ lookup-join  ·                      ·
  │           type                   inner
  │           equality               (a) = (c)
  │           equality cols are key  ·
+ │           parallel               ·
  └── scan    ·                      ·
 ·            table                  ab@primary
 ·            spans                  ALL

--- a/pkg/sql/opt/exec/execbuilder/testdata/update_from
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update_from
@@ -142,6 +142,7 @@ count                            ·                      ·
                      │           type                   inner
                      │           equality               (column1) = (a)
                      │           equality cols are key  ·
+                     │           parallel               ·
                      └── values  ·                      ·
 ·                                size                   3 columns, 2 rows
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -99,6 +99,7 @@ count                                    ·                      ·
                 │                        type                   inner
                 │                        equality               (k) = (k)
                 │                        equality cols are key  ·
+                │                        parallel               ·
                 └── render               ·                      ·
                      │                   render 0               CAST(NULL AS INT8)
                      │                   render 1               k
@@ -427,6 +428,7 @@ count                       ·                      ·                   ()     
                 │           type                   inner               ·                      ·
                 │           equality               (a) = (a)           ·                      ·
                 │           equality cols are key  ·                   ·                      ·
+                │           parallel               ·                   ·                      ·
                 └── scan    ·                      ·                   (a, b)                 ·
 ·                           table                  table38627@primary  ·                      ·
 ·                           spans                  /1-/1/#             ·                      ·

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -263,6 +263,9 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 		if n.eqColsAreKey {
 			v.observer.attr(name, "equality cols are key", "")
 		}
+		if n.CanParallelize() {
+			v.observer.attr(name, "parallel", "")
+		}
 		if v.observer.expr != nil && n.onCond != nil && n.onCond != tree.DBoolTrue {
 			v.expr(name, "pred", -1, n.onCond)
 		}


### PR DESCRIPTION
This PR allows the joinreader to use the `LookupColumnsAreKey` flag
in the processor spec to turn of batch limits in the fetcher to
parallelize these lookups.

Fixes #40748.

Release justification: unsure if this should go into the release.

Release note: None