### PR TITLE
util/log: ensure that secondary loggers do not leak memory

### DIFF
--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -142,7 +142,7 @@ func TestEntryDecoder(t *testing.T) {
 		buf := formatHeader(s, now, gid, file, line, nil)
 		buf.WriteString(msg)
 		buf.WriteString("\n")
-		defer logging.putBuffer(buf)
+		defer putBuffer(buf)
 		return buf.String()
 	}
 
@@ -720,7 +720,7 @@ func TestExitOnFullDisk(t *testing.T) {
 func BenchmarkHeader(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		buf := formatHeader(Severity_INFO, timeutil.Now(), 200, "file.go", 100, nil)
-		logging.putBuffer(buf)
+		putBuffer(buf)
 	}
 }
 

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -257,7 +257,7 @@ func MakeEntry(s Severity, t int64, file string, line int, msg string) Entry {
 // Format writes the log entry to the specified writer.
 func (e Entry) Format(w io.Writer) error {
 	buf := formatLogEntry(e, nil, nil)
-	defer logging.putBuffer(buf)
+	defer putBuffer(buf)
 	_, err := w.Write(buf.Bytes())
 	return err
 }


### PR DESCRIPTION
Fixes #41230.

Note: the primary cause of this issue is removed by #40993 but that PR is blocked until 19.2 is out. I'm cherry-picking the subset of those changes sufficient to solve issue #41230, here.

Prior to this patch, logging via a secondary logger would allocate a
buffer, then add it to the buffer free list of the secondary logger.

This was causing a memory leak because only the free list from the
main logger is used to allocate buffers (even in secondary loggers),
so all the now-unused buffers from secondary logs would remain unused
and accumulate, locked from Go's GC attention because they are
referenced somewhere.

Release justification: bug fix

Release note (bug fix): A memory leak was fixed that affected
secondary logging (SQL audit logs, statement execution, and RocksDB
logging).