### PR TITLE
roachtest: add machinetype flag to tpccbench

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -203,6 +203,8 @@ the test tags.
 			&clusterWipe, "wipe", true,
 			"wipe existing cluster before starting test (for use with --cluster)")
 		cmd.Flags().StringVar(
+			&machine, "machine", machine, "the machine type for tpccbench to use (see https://aws.amazon.com/ec2/instance-types/ or https://cloud.google.com/compute/docs/machine-types")
+		cmd.Flags().StringVar(
 			&zonesF, "zones", "", "Zones for the cluster (use roachprod defaults if empty)")
 		cmd.Flags().IntVar(
 			&cpuQuota, "cpu-quota", 300,

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -517,7 +517,7 @@ func registerTPCCBenchSpec(r *testRegistry, b tpccBenchSpec) {
 		nameParts = append(nameParts, "chaos")
 	}
 
-	opts := []createOption{cpu(b.CPUs)}
+	opts := []createOption{cpu(b.CPUs), machineType(machine)}
 	switch b.Distribution {
 	case singleZone:
 		// No specifier.


### PR DESCRIPTION
Add a flag to roachtests to allow tpccbench to be run on a given machine
type. This is useful when trying to compare machines, such as for the
Cloud Report.

Release note: None