### PR TITLE
movr: Update description to vehicle sharing company

### DIFF
--- a/pkg/workload/movr/movr.go
+++ b/pkg/workload/movr/movr.go
@@ -135,7 +135,7 @@ func init() {
 
 var movrMeta = workload.Meta{
 	Name:         `movr`,
-	Description:  `MovR is a fictional ride sharing company`,
+	Description:  `MovR is a fictional vehicle sharing company`,
 	Version:      `1.0.0`,
 	PublicFacing: true,
 	New: func() workload.Generator {


### PR DESCRIPTION
As pointed out by @ericharmeling , movr is a vehicle sharing company,
not a ride sharing company.

Release justification: text only fix

Release note: None