### PR TITLE
partitionccl: various improvements to TestRepartitioning

### DIFF
--- a/pkg/ccl/partitionccl/zone_test.go
+++ b/pkg/ccl/partitionccl/zone_test.go
@@ -283,7 +283,7 @@ func TestGenerateSubzoneSpans(t *testing.T) {
 			continue
 		}
 		t.Run(test.name, func(t *testing.T) {
-			if err := test.parse(); err != nil {
+			if err := test.parse(false /* useLeaseholderPrefs */); err != nil {
 				t.Fatalf("%+v", err)
 			}
 			clusterID := uuid.MakeV4()


### PR DESCRIPTION
This PR has two commits:

1) Expand TestRepartitioning to additionally use leaseholders and operate on more nodes
   * This change which dramatically increases the run time of the test overall then adds logic to choose a random subset of the tests to run to shorten the test overall.
2) Add logic which starts the cluster at 19.1 (preemptive snapshots) and then upgrades the cluster during its execution
   * This logic is just temporary and should be removed for 19.2 but would have caught bugs like #41171 and #41148.

Release Justification: just testing.