### PR TITLE
util: bugfix to FastIntSet.CopyFrom

### DIFF
--- a/pkg/util/fast_int_set.go
+++ b/pkg/util/fast_int_set.go
@@ -196,16 +196,16 @@ func (s FastIntSet) Copy() FastIntSet {
 	return c
 }
 
-// CopyFrom sets the receiver to a copy of c, which can then be modified
+// CopyFrom sets the receiver to a copy of other, which can then be modified
 // independently.
-func (s *FastIntSet) CopyFrom(c FastIntSet) {
-	if c.large != nil {
+func (s *FastIntSet) CopyFrom(other FastIntSet) {
+	if other.large != nil {
 		if s.large == nil {
 			s.large = new(intsets.Sparse)
 		}
-		s.large.Copy(s.large)
+		s.large.Copy(other.large)
 	} else {
-		s.small = c.small
+		s.small = other.small
 		if s.large != nil {
 			s.large.Clear()
 		}

--- a/pkg/util/fast_int_set_test.go
+++ b/pkg/util/fast_int_set_test.go
@@ -67,20 +67,32 @@ func TestFastIntSet(t *testing.T) {
 				if o := s.Ordered(); !reflect.DeepEqual(vals, o) {
 					t.Fatalf("set built with Next doesn't match Ordered: %v vs %v", vals, o)
 				}
+				assertSame := func(orig, copy FastIntSet) {
+					if !orig.Equals(copy) || !copy.Equals(orig) {
+						t.Fatalf("expected equality: %v, %v", orig, copy)
+					}
+					if col, ok := copy.Next(0); ok {
+						copy.Remove(col)
+						if orig.Equals(copy) || copy.Equals(orig) {
+							t.Fatalf("unexpected equality: %v, %v", orig, copy)
+						}
+						copy.Add(col)
+						if !orig.Equals(copy) || !copy.Equals(orig) {
+							t.Fatalf("expected equality: %v, %v", orig, copy)
+						}
+					}
+				}
+				// Test Copy.
 				s2 := s.Copy()
-				if !s.Equals(s2) || !s2.Equals(s) {
-					t.Fatalf("expected equality: %v, %v", s, s2)
-				}
-				if col, ok := s2.Next(0); ok {
-					s2.Remove(col)
-					if s.Equals(s2) || s2.Equals(s) {
-						t.Fatalf("unexpected equality: %v, %v", s, s2)
-					}
-					s2.Add(col)
-					if !s.Equals(s2) || !s2.Equals(s) {
-						t.Fatalf("expected equality: %v, %v", s, s2)
-					}
-				}
+				assertSame(s, s2)
+				// Test CopyFrom.
+				var s3 FastIntSet
+				s3.CopyFrom(s)
+				assertSame(s, s3)
+				// Make sure CopyFrom into a non-empty set still works.
+				s.Shift(100)
+				s.CopyFrom(s3)
+				assertSame(s, s3)
 			}
 		})
 	}


### PR DESCRIPTION
Previously, FastIntSet.CopyFrom was broken when the receiver had a
non-empty large set. This could produce incorrect results on the
vectorized engine on queries with more than 64 required columns.

Release justification: low-risk bugfix to existing functionality
Release note: None