### PR TITLE
libroach: initialize range tombstone counter

### DIFF
--- a/c-deps/libroach/table_props.cc
+++ b/c-deps/libroach/table_props.cc
@@ -130,7 +130,7 @@ class DeleteRangeTblPropCollector : public rocksdb::TablePropertiesCollector {
   }
 
  private:
-  int ntombstones_;
+  int ntombstones_ = 0;
 };
 
 class DeleteRangeTblPropCollectorFactory : public rocksdb::TablePropertiesCollectorFactory {


### PR DESCRIPTION
We forgot to initialize a variable that is used to decide whether a
compaction output file should be marked to undergo another compaction.

Release justification: reduce write-amp by avoiding forcing files
through compactions unnecessarily.

Release note: None