### PR TITLE
roachtest/sysbench: enable oltp_read_write and oltp_write_only workloads

### DIFF
--- a/pkg/cmd/roachtest/sysbench.go
+++ b/pkg/cmd/roachtest/sysbench.go
@@ -25,11 +25,8 @@ const (
 	oltpUpdateIndex
 	oltpUpdateNonIndex
 	oltpReadOnly
-
-	// TODO(nvanbenschoten): transactional workloads are not supported
-	// because sysbench does not contain client-side retry loops.
-	// oltpReadWrite
-	// oltpWriteOnly
+	oltpReadWrite
+	oltpWriteOnly
 
 	numSysbenchWorkloads
 )
@@ -41,8 +38,8 @@ var sysbenchWorkloadName = map[sysbenchWorkload]string{
 	oltpUpdateIndex:    "oltp_update_index",
 	oltpUpdateNonIndex: "oltp_update_non_index",
 	oltpReadOnly:       "oltp_read_only",
-	// oltpReadWrite: "oltp_read_write",
-	// oltpWriteOnly: "oltp_write_only",
+	oltpReadWrite:      "oltp_read_write",
+	oltpWriteOnly:      "oltp_write_only",
 }
 
 func (w sysbenchWorkload) String() string {


### PR DESCRIPTION
These workloads used to create significantly more retryable errors than they do
now. In `oltp_read_write` we now see around 10 retryable errors per second while
pushing around 2,500 tps and 47,000 qps. In `oltp_write_only` we now see around
1 retryable error per second while pushing around 5,000 tps and 30,000 qps.

Sysbench doesn't fail on these errors (which I thought it used to), so we might
as well enable the workloads.

Release justification: Testing only.

Release note: None