### PR TITLE
opt: minor fix to square bracket handling

### DIFF
--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -1312,3 +1312,50 @@ WITH cte AS (VALUES (1), (2))
 SELECT * FROM (VALUES (3)) AS t (x), [SELECT * FROM cte]
 ----
 error (42P01): no data source matches prefix: "cte"
+
+# Projection list should still be able to refer to outer columns or CTEs.
+build
+WITH cte AS (SELECT 1) SELECT 1 + (SELECT * FROM cte) FROM [SELECT * from xyzw]
+----
+with &1 (cte)
+ ├── columns: "?column?":7(int)
+ ├── project
+ │    ├── columns: "?column?":1(int!null)
+ │    ├── values
+ │    │    └── tuple [type=tuple]
+ │    └── projections
+ │         └── const: 1 [type=int]
+ └── project
+      ├── columns: "?column?":7(int)
+      ├── scan xyzw
+      │    └── columns: x:2(int!null) y:3(int) z:4(int) w:5(int)
+      └── projections
+           └── plus [type=int]
+                ├── const: 1 [type=int]
+                └── subquery [type=int]
+                     └── max1-row
+                          ├── columns: "?column?":6(int!null)
+                          └── with-scan &1 (cte)
+                               ├── columns: "?column?":6(int!null)
+                               └── mapping:
+                                    └──  "?column?":1(int) => "?column?":6(int)
+
+build
+SELECT a, (SELECT a+x FROM [SELECT * from xyzw]) FROM abc
+----
+project
+ ├── columns: a:1(int!null) "?column?":9(int)
+ ├── scan abc
+ │    └── columns: a:1(int!null) b:2(int) c:3(int)
+ └── projections
+      └── subquery [type=int]
+           └── max1-row
+                ├── columns: "?column?":8(int)
+                └── project
+                     ├── columns: "?column?":8(int)
+                     ├── scan xyzw
+                     │    └── columns: x:4(int!null) y:5(int) z:6(int) w:7(int)
+                     └── projections
+                          └── plus [type=int]
+                               ├── variable: a [type=int]
+                               └── variable: x [type=int]


### PR DESCRIPTION
In #41158 special handling was added to disallow correlation with the
square bracket syntax.

The scope handling in that change is not correct - we return a scope
that isn't attached to the input hierarchy, so we can't refer to
output columns on the projection list (ousitde of the brackets). The
fix is to push a new scope and copy the columns and expression
(equivalent to "grafting" the scope onto the hierarchy).

Release justification: low-risk fix to new functionality.

Release note: None