### PR TITLE
storage/engine: adjust pending_compaction_threshold setting

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -66,7 +66,7 @@
 <tr><td><code>kv.transaction.write_pipelining_max_outstanding_size</code></td><td>byte size</td><td><code>256 KiB</code></td><td>maximum number of bytes used to track in-flight pipelined writes before disabling pipelining</td></tr>
 <tr><td><code>rocksdb.ingest_backpressure.l0_file_count_threshold</code></td><td>integer</td><td><code>20</code></td><td>number of L0 files after which to backpressure SST ingestions</td></tr>
 <tr><td><code>rocksdb.ingest_backpressure.max_delay</code></td><td>duration</td><td><code>5s</code></td><td>maximum amount of time to backpressure a single SST ingestion</td></tr>
-<tr><td><code>rocksdb.ingest_backpressure.pending_compaction_threshold</code></td><td>byte size</td><td><code>64 GiB</code></td><td>pending compaction estimate above which to backpressure SST ingestions</td></tr>
+<tr><td><code>rocksdb.ingest_backpressure.pending_compaction_threshold</code></td><td>byte size</td><td><code>2.0 GiB</code></td><td>pending compaction estimate above which to backpressure SST ingestions</td></tr>
 <tr><td><code>rocksdb.min_wal_sync_interval</code></td><td>duration</td><td><code>0s</code></td><td>minimum duration between syncs of the RocksDB WAL</td></tr>
 <tr><td><code>schemachanger.backfiller.buffer_increment</code></td><td>byte size</td><td><code>32 MiB</code></td><td>the size by which the BulkAdder attempts to grow its buffer before flushing</td></tr>
 <tr><td><code>schemachanger.backfiller.buffer_size</code></td><td>byte size</td><td><code>32 MiB</code></td><td>the initial size of the BulkAdder buffer handling index backfills</td></tr>

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -84,7 +84,7 @@ var ingestDelayL0Threshold = settings.RegisterIntSetting(
 var ingestDelayPendingLimit = settings.RegisterByteSizeSetting(
 	"rocksdb.ingest_backpressure.pending_compaction_threshold",
 	"pending compaction estimate above which to backpressure SST ingestions",
-	64<<30,
+	2<<30, /* 2 GiB */
 )
 
 var ingestDelayTime = settings.RegisterDurationSetting(

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -1827,7 +1827,7 @@ func TestIngestDelayLimit(t *testing.T) {
 		{ramp, Stats{L0FileCount: 21}},
 		{ramp * 2, Stats{L0FileCount: 22}},
 		{max, Stats{L0FileCount: 55}},
-		{0, Stats{PendingCompactionBytesEstimate: 20 << 30}},
+		{0, Stats{PendingCompactionBytesEstimate: (2 << 30) - 1}},
 		{max, Stats{L0FileCount: 25, PendingCompactionBytesEstimate: 80 << 30}},
 		{max, Stats{L0FileCount: 35, PendingCompactionBytesEstimate: 20 << 30}},
 	} {


### PR DESCRIPTION
Deflake the `clearrange` roachtests by adjusting the default value for
`rocksdb.ingest_backpressure.pending_compaction_threshold` from 64 GiB
to 2 GiB. The previous value was taken from the default RocksDB setting
for determining write-stalls when compaction is falling too far
behind. This value appears to be way too large. In particular, it allows
RocksDB to get into a situation where L0->Lbase compactions take so long
that by the time they complete another L0->Lbase compaction is
required. While these compactions are occurring, Lbase->Lbase+1
compactions are starved. Over time, every thing becomes slower and
slower on the affected node. Changing the backpressure setting to 2 GiB
applies ingestion backpressure earlier allowing RocksDB to recover. This
is a bit of a bandaid, but a decent one for late in the release.

Removed `zfs` from the `clearrange` roachtest. `zfs` appears to be about
half as fast as `ext4` for this test.

Release justification: Settings only change which improves the stable
performance of imports and restores.

Release note: Changed the default value of
`rocksdb.ingest_backpressure.pending_compaction_threshold` from 64 GiB
to 2 GiB in order to provide more stable performance for IMPORT and
RESTORE.