### PR TITLE
telemetry: fix potential race in GetCounter

### DIFF
--- a/pkg/server/telemetry/features.go
+++ b/pkg/server/telemetry/features.go
@@ -78,13 +78,16 @@ func GetCounter(feature string) Counter {
 	counters.RLock()
 	i, ok := counters.m[feature]
 	counters.RUnlock()
+	if ok {
+		return i
+	}
 
+	counters.Lock()
+	defer counters.Unlock()
+	i, ok = counters.m[feature]
 	if !ok {
-		counters.Lock()
-		var n int32
-		counters.m[feature] = &n
-		i = &n
-		counters.Unlock()
+		i = new(int32)
+		counters.m[feature] = i
 	}
 	return i
 }

--- a/pkg/server/telemetry/features_test.go
+++ b/pkg/server/telemetry/features_test.go
@@ -1,0 +1,42 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package telemetry_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetCounterDoesNotRace ensures that concurrent calls to GetCounter for
+// the same feature always returns the same pointer. Even when this race was
+// possible this test would fail on every run but would fail rapidly under
+// stressrace.
+func TestGetCounterDoesNotRace(t *testing.T) {
+	const N = 100
+	var wg sync.WaitGroup
+	wg.Add(N)
+	counters := make([]telemetry.Counter, N)
+	for i := 0; i < N; i++ {
+		go func(i int) {
+			counters[i] = telemetry.GetCounter("test.foo")
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+	counterSet := make(map[telemetry.Counter]struct{})
+	for _, c := range counters {
+		counterSet[c] = struct{}{}
+	}
+	require.Len(t, counterSet, 1)
+}


### PR DESCRIPTION
Before this PR it was possible that concurrent calls to GetCounter
for the same feature could return different pointers. This would effectively
mean that we were losing some telemetry data.

Release justification: low risk, high benefit changes to existing functionality

Release note: None