### PR TITLE
roachtest: skip cdc/crdb-chaos/rangefeed=true

### DIFF
--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -536,6 +536,7 @@ func registerCDC(r *testRegistry) {
 	})
 	r.Add(testSpec{
 		Name: fmt.Sprintf("cdc/crdb-chaos/rangefeed=%t", useRangeFeed),
+		Skip: "#37716",
 		// TODO(dan): Re-enable this test on 2.1 if we decide to backport #36852.
 		MinVersion: "v19.1.0",
 		Cluster:    makeClusterSpec(4, cpu(16)),


### PR DESCRIPTION
This max latency failure is definitely interesting and worth looking
into, but not now. It does seem to always get itself started back up,
just taking much longer than we'd expect (this assertion really should
be around 2m, but we've upped it to try and reduce flakes). I don't
think we get a lot of value from running this every night, especially
while cdc is not under active development. I'm going to skip this in the
interest of reducing noise.

Release justification: non-production code changes

Release note: None