### PR TITLE
storage: don't count uninitialized replicas in ReplicaCount metric

### DIFF
--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -968,7 +968,7 @@ type StoreMetrics struct {
 	registry *metric.Registry
 
 	// Replica metrics.
-	ReplicaCount                  *metric.Gauge // Does not include reserved replicas.
+	ReplicaCount                  *metric.Gauge // Does not include uninitialized or reserved replicas.
 	ReservedReplicaCount          *metric.Gauge
 	RaftLeaderCount               *metric.Gauge
 	RaftLeaderNotLeaseHolderCount *metric.Gauge

--- a/pkg/storage/store_remove_replica.go
+++ b/pkg/storage/store_remove_replica.go
@@ -245,8 +245,6 @@ func (s *Store) removeUninitializedReplicaRaftMuLocked(
 		log.Fatalf(ctx, "uninitialized replica %v was unexpectedly replaced", existing)
 	}
 
-	s.metrics.ReplicaCount.Dec(1)
-
 	// Only an uninitialized replica can have a placeholder since, by
 	// definition, an initialized replica will be present in the
 	// replicasByKey map. While the replica will usually consume the


### PR DESCRIPTION
Fixes #41271.

This was accidentally added in 2020115.

Release justification: Fixes crash.

Release note: None