### PR TITLE
sql: optimize forEachDatabaseDesc calls in pg_catalog

### DIFF
--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -211,8 +211,10 @@ func (dc *databaseCache) getDatabaseDescByID(
 	ctx context.Context, txn *client.Txn, id sqlbase.ID,
 ) (*sqlbase.DatabaseDescriptor, error) {
 	desc, err := dc.getCachedDatabaseDescByID(id)
-	if err != nil {
-		log.VEventf(ctx, 3, "error getting database descriptor from cache: %s", err)
+	if desc == nil || err != nil {
+		if err != nil {
+			log.VEventf(ctx, 3, "error getting database descriptor from cache: %s", err)
+		}
 		desc, err = MustGetDatabaseDescByID(ctx, txn, id)
 	}
 	return desc, err

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -230,6 +230,23 @@ func GetAllDescriptors(ctx context.Context, txn *client.Txn) ([]sqlbase.Descript
 	return descs, nil
 }
 
+// GetAllDatabaseDescriptorIDs looks up and returns all available database
+// descriptor IDs.
+func GetAllDatabaseDescriptorIDs(ctx context.Context, txn *client.Txn) ([]sqlbase.ID, error) {
+	log.Eventf(ctx, "fetching all database descriptor IDs")
+	nameKey := sqlbase.MakeNameMetadataKey(keys.RootNamespaceID, "" /* name */)
+	kvs, err := txn.Scan(ctx, nameKey, nameKey.PrefixEnd(), 0 /*maxRows */)
+	if err != nil {
+		return nil, err
+	}
+
+	descIDs := make([]sqlbase.ID, 0, len(kvs))
+	for _, kv := range kvs {
+		descIDs = append(descIDs, sqlbase.ID(kv.ValueInt()))
+	}
+	return descIDs, nil
+}
+
 // writeDescToBatch adds a Put command writing a descriptor proto to the
 // descriptors table. It writes the descriptor desc at the id descID. If kvTrace
 // is enabled, it will log an event explaining the put that was performed.


### PR DESCRIPTION
sql: optimize forEachDatabaseDesc calls in pg_catalog

Almost all of the pg_catalog functions call forEachDatabaseDesc. The old
implementation of this function was O(number of descriptors). These
include both database and table descriptors (including ones that were
recently dropped but not garbage collected yet).

The new implementation is improved to be O(number of _database_ descriptors),
which is generally considerably smaller than the total number of all
descriptors.

This improves the latency of some heavily used PGJDBC metadata calls
between 10-100x, in the case where there are a lot of descriptors.
This situation occurs commonly in driver/ORM unit tests that create and
drop tables in each test case.

This also fixes a bug in getDatabaseDescByID, which was not correctly
handling the case where a database descriptor was not present in the
cache.

Release justification: low-effort but high-impact performance improvement

Release note: None