### PR TITLE
cmd/roachtest: remove zfs vestiges

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1774,6 +1774,9 @@ func (c *cluster) Reformat(ctx context.Context, node nodeListOption, args ...str
 	}
 }
 
+// Silence unused warning.
+var _ = (&cluster{}).Reformat
+
 // Install a package in a node
 func (c *cluster) Install(
 	ctx context.Context, l *logger, node nodeListOption, args ...string,

--- a/pkg/cmd/roachtest/overload_tpcc_olap.go
+++ b/pkg/cmd/roachtest/overload_tpcc_olap.go
@@ -43,7 +43,7 @@ type tpccOLAPSpec struct {
 }
 
 func (s tpccOLAPSpec) run(ctx context.Context, t *test, c *cluster) {
-	crdbNodes, workloadNode := setupTPCC(ctx, t, c, s.Warehouses, false /* zfs */, nil /* versions */)
+	crdbNodes, workloadNode := setupTPCC(ctx, t, c, s.Warehouses, nil /* versions */)
 	const queryFileName = "queries.sql"
 	// querybench expects the entire query to be on a single line.
 	queryLine := `"` + strings.Replace(tpccOlapQuery, "\n", " ", -1) + `"`


### PR DESCRIPTION
A previous commit removed the use of zfs by the `clearrange`
roachtest. This commit removes the other vestiges of zfs from the tpcc
roachtests. Zfs is significantly slower (as configured out of the box)
than ext4 which makes its usage for tpcc testing a nice way to stub your
toe.

Release justification: non-production test-only change

Release note: None