### PR TITLE
release-19.1: libroach: initialize range tombstone counter

### DIFF
--- a/c-deps/libroach/table_props.cc
+++ b/c-deps/libroach/table_props.cc
@@ -133,7 +133,7 @@ class DeleteRangeTblPropCollector : public rocksdb::TablePropertiesCollector {
   }
 
  private:
-  int ntombstones_;
+  int ntombstones_ = 0;
 };
 
 class DeleteRangeTblPropCollectorFactory : public rocksdb::TablePropertiesCollectorFactory {


### PR DESCRIPTION
Backport 1/1 commits from #41244.

/cc @cockroachdb/release

---

We forgot to initialize a variable that is used to decide whether a
compaction output file should be marked to undergo another compaction.

Release note (bug fix): reduce write-amp by avoiding forcing files
through compactions unnecessarily.
