### PR TITLE
roachtest: update tpccbench/nodes=9/cpu=4/multi-region configuration

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -385,8 +385,8 @@ func registerTPCC(r *testRegistry) {
 		Distribution: multiRegion,
 		LoadConfig:   multiLoadgen,
 
-		LoadWarehouses: 2000,
-		EstimatedMax:   1000,
+		LoadWarehouses: 5000,
+		EstimatedMax:   2200,
 
 		MinVersion: "v19.1.0",
 	})
@@ -931,8 +931,10 @@ func registerTPCCBench(r *testRegistry) {
 			Distribution: multiRegion,
 			LoadConfig:   multiLoadgen,
 
-			LoadWarehouses: 5000,
-			EstimatedMax:   2200,
+			LoadWarehouses: 12000,
+			EstimatedMax:   8000,
+
+			MinVersion: "v19.1.0",
 		},
 		// objective 4, key result 2.
 		{


### PR DESCRIPTION
We seem to do pass at 2000 warehouses every night. Interestingly I took this
configuration from the "bench" version of this test which uses bigger nodes (cpu=16).
I suspect the larger node configuration is too low but it never runs and
it takes a while. I'll run it and figure out what it gets. 

Release justification: testing change.

Release note: None