### PR TITLE
sql/logictest: specify column family for an upsert test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -308,8 +308,9 @@ statement error ambiguous source name: "excluded"
 INSERT INTO excluded VALUES (1, 1) ON CONFLICT (a) DO UPDATE SET b = excluded.b
 
 # Tests for upsert/on conflict returning
+# TODO(mjibson): Remove family definition once #41313 is fixed.
 statement ok
-CREATE TABLE upsert_returning (a INT PRIMARY KEY, b INT, c INT, d INT DEFAULT -1)
+CREATE TABLE upsert_returning (a INT PRIMARY KEY, b INT, c INT, d INT DEFAULT -1, FAMILY "primary" (a, b, c, d))
 
 statement count 1
 INSERT INTO upsert_returning VALUES (1, 1, NULL)


### PR DESCRIPTION
Prevents #41313 from flaking until we fix the root cause.

Release justification: category 1: test only change

Release note: None