### PR TITLE
sql/sem: introduce a way to hack into parts of a sql query in unit tests

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -672,6 +672,8 @@ has no relationship with the commit order of concurrent transactions.</p>
 <tbody>
 <tr><td><code>aclexplode(aclitems: <a href="string.html">string</a>[]) &rarr; tuple{oid AS grantor, oid AS grantee, string AS privilege_type, bool AS is_grantable}</code></td><td><span class="funcdesc"><p>Produces a virtual table containing aclitem stuff (returns no rows as this feature is unsupported in CockroachDB)</p>
 </span></td></tr>
+<tr><td><code>crdb_internal.testing_callback(name: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>For internal CRDB testing only. The function calls a callback identified by <code>name</code> registered with the server by the test.</p>
+</span></td></tr>
 <tr><td><code>crdb_internal.unary_table() &rarr; tuple</code></td><td><span class="funcdesc"><p>Produces a virtual table containing a single row with no values.</p>
 <p>This function is used only by CockroachDB’s developers for testing purposes.</p>
 </span></td></tr>

--- a/pkg/sql/project_set.go
+++ b/pkg/sql/project_set.go
@@ -133,7 +133,7 @@ func (n *projectSetNode) Next(params runParams) (bool, error) {
 					if gen == nil {
 						gen = builtins.EmptyGenerator()
 					}
-					if err := gen.Start(); err != nil {
+					if err := gen.Start(params.ctx, params.extendedEvalCtx.Txn); err != nil {
 						return false, err
 					}
 					n.run.gens[i] = gen
@@ -157,7 +157,7 @@ func (n *projectSetNode) Next(params runParams) (bool, error) {
 				// Yes. Is there still work to do for the current row?
 				if !n.run.done[i] {
 					// Yes; heck whether this source still has some values available.
-					hasVals, err := gen.Next()
+					hasVals, err := gen.Next(params.ctx)
 					if err != nil {
 						return false, err
 					}

--- a/pkg/sql/rowexec/project_set.go
+++ b/pkg/sql/rowexec/project_set.go
@@ -148,7 +148,7 @@ func (ps *projectSetProcessor) nextInputRow() (
 			if gen == nil {
 				gen = builtins.EmptyGenerator()
 			}
-			if err := gen.Start(); err != nil {
+			if err := gen.Start(ps.Ctx, ps.FlowCtx.Txn); err != nil {
 				return nil, nil, err
 			}
 			ps.gens[i] = gen
@@ -170,7 +170,7 @@ func (ps *projectSetProcessor) nextGeneratorValues() (newValAvail bool, err erro
 			numCols := int(ps.spec.NumColsPerGen[i])
 			if !ps.done[i] {
 				// Yes; check whether this source still has some values available.
-				hasVals, err := gen.Next()
+				hasVals, err := gen.Next(ps.Ctx)
 				if err != nil {
 					return false, err
 				}

--- a/pkg/sql/sem/builtins/aggregate_builtins_test.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
@@ -63,102 +64,127 @@ func testAggregateResultDeepCopy(
 }
 
 func TestAvgIntResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newIntAvgAggregate, makeIntTestDatum(10))
 }
 
 func TestAvgFloatResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newFloatAvgAggregate, makeFloatTestDatum(10))
 }
 
 func TestAvgDecimalResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newDecimalAvgAggregate, makeDecimalTestDatum(10))
 }
 
 func TestBoolAndResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newBoolAndAggregate, makeBoolTestDatum(10))
 }
 
 func TestBoolOrResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newBoolOrAggregate, makeBoolTestDatum(10))
 }
 
 func TestCountResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newCountAggregate, makeIntTestDatum(10))
 }
 
 func TestMaxIntResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newMaxAggregate, makeIntTestDatum(10))
 }
 
 func TestMaxFloatResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newMaxAggregate, makeFloatTestDatum(10))
 }
 
 func TestMaxDecimalResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newMaxAggregate, makeDecimalTestDatum(10))
 }
 
 func TestMaxBoolResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newMaxAggregate, makeBoolTestDatum(10))
 }
 
 func TestMinIntResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newMinAggregate, makeIntTestDatum(10))
 }
 
 func TestMinFloatResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newMinAggregate, makeFloatTestDatum(10))
 }
 
 func TestMinDecimalResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newMinAggregate, makeDecimalTestDatum(10))
 }
 
 func TestMinBoolResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newMinAggregate, makeBoolTestDatum(10))
 }
 
 func TestSumSmallIntResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newSmallIntSumAggregate, makeSmallIntTestDatum(10))
 }
 
 func TestSumIntResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newIntSumAggregate, makeIntTestDatum(10))
 }
 
 func TestSumFloatResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newFloatSumAggregate, makeFloatTestDatum(10))
 }
 
 func TestSumDecimalResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newDecimalSumAggregate, makeDecimalTestDatum(10))
 }
 
 func TestSumIntervalResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newIntervalSumAggregate, makeIntervalTestDatum(10))
 }
 
 func TestVarianceIntResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newIntVarianceAggregate, makeIntTestDatum(10))
 }
 
 func TestVarianceFloatResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newFloatVarianceAggregate, makeFloatTestDatum(10))
 }
 
 func TestVarianceDecimalResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newDecimalVarianceAggregate, makeDecimalTestDatum(10))
 }
 
 func TestStdDevIntResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newIntStdDevAggregate, makeIntTestDatum(10))
 }
 
 func TestStdDevFloatResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newFloatStdDevAggregate, makeFloatTestDatum(10))
 }
 
 func TestStdDevDecimalResultDeepCopy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newDecimalStdDevAggregate, makeDecimalTestDatum(10))
 }
 
@@ -236,10 +262,12 @@ func makeIntervalTestDatum(count int) []tree.Datum {
 }
 
 func TestArrayAggNameOverload(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testArrayAggAliasedTypeOverload(t, types.Name)
 }
 
 func TestArrayAggOidOverload(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testArrayAggAliasedTypeOverload(t, types.Oid)
 }
 

--- a/pkg/sql/sem/builtins/builtins_test.go
+++ b/pkg/sql/sem/builtins/builtins_test.go
@@ -19,9 +19,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
 func TestCategory(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	if expected, actual := categoryString, builtins["lower"].props.Category; expected != actual {
 		t.Fatalf("bad category: expected %q got %q", expected, actual)
 	}
@@ -39,6 +41,7 @@ func TestCategory(t *testing.T) {
 // TestGenerateUniqueIDOrder verifies the expected ordering of
 // GenerateUniqueID.
 func TestGenerateUniqueIDOrder(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	tests := []tree.DInt{
 		GenerateUniqueID(0, 0),
 		GenerateUniqueID(1, 0),
@@ -56,6 +59,7 @@ func TestGenerateUniqueIDOrder(t *testing.T) {
 }
 
 func TestStringToArrayAndBack(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	// s allows us to have a string pointer literal.
 	s := func(x string) *string { return &x }
 	fs := func(x *string) string {
@@ -135,6 +139,7 @@ func TestStringToArrayAndBack(t *testing.T) {
 }
 
 func TestEscapeFormat(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testCases := []struct {
 		bytes []byte
 		str   string
@@ -170,6 +175,7 @@ func TestEscapeFormat(t *testing.T) {
 }
 
 func TestEscapeFormatRandom(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	for i := 0; i < 1000; i++ {
 		b := make([]byte, rand.Intn(100))
 		for j := 0; j < len(b); j++ {
@@ -187,6 +193,7 @@ func TestEscapeFormatRandom(t *testing.T) {
 }
 
 func TestLPadRPad(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testCases := []struct {
 		padFn    func(string, int, string) (string, error)
 		str      string
@@ -236,6 +243,7 @@ func TestLPadRPad(t *testing.T) {
 }
 
 func TestFloatWidthBucket(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testCases := []struct {
 		operand  float64
 		b1       float64

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -72,11 +72,11 @@ var aclexplodeGeneratorType = types.MakeLabeledTuple(
 // aclExplodeGenerator supports the execution of aclexplode.
 type aclexplodeGenerator struct{}
 
-func (aclexplodeGenerator) ResolvedType() *types.T { return aclexplodeGeneratorType }
-func (aclexplodeGenerator) Start() error           { return nil }
-func (aclexplodeGenerator) Close()                 {}
-func (aclexplodeGenerator) Next() (bool, error)    { return false, nil }
-func (aclexplodeGenerator) Values() tree.Datums    { return nil }
+func (aclexplodeGenerator) ResolvedType() *types.T                       { return aclexplodeGeneratorType }
+func (aclexplodeGenerator) Start(_ context.Context, _ *client.Txn) error { return nil }
+func (aclexplodeGenerator) Close()                                       {}
+func (aclexplodeGenerator) Next(_ context.Context) (bool, error)         { return false, nil }
+func (aclexplodeGenerator) Values() tree.Datums                          { return nil }
 
 // generators is a map from name to slice of Builtins for all built-in
 // generators.
@@ -115,6 +115,26 @@ var generators = map[string]builtinDefinition{
 			seriesTSValueGeneratorType,
 			makeTSSeriesGenerator,
 			"Produces a virtual table containing the timestamp values from `start` to `end`, inclusive, by increment of `step`.",
+		),
+	),
+	// crdb_internal.testing_callback is a generator function intended for internal unit tests.
+	// You give it a name and it calls a callback that had to have been installed
+	// on a TestServer through its EvalContextTestingKnobs.CallbackGenerators.
+	"crdb_internal.testing_callback": makeBuiltin(genProps([]string{"testing_callback"}),
+		makeGeneratorOverload(
+			tree.ArgTypes{{"name", types.String}},
+			types.Int,
+			func(ctx *tree.EvalContext, args tree.Datums) (tree.ValueGenerator, error) {
+				name := string(*args[0].(*tree.DString))
+				gen, ok := ctx.TestingKnobs.CallbackGenerators[name]
+				if !ok {
+					return nil, errors.Errorf("callback %q not registered", name)
+				}
+				return gen, nil
+			},
+			"For internal CRDB testing only. "+
+				"The function calls a callback identified by `name` registered with the server by "+
+				"the test.",
 		),
 	),
 
@@ -274,11 +294,11 @@ func (*keywordsValueGenerator) ResolvedType() *types.T { return keywordsValueGen
 func (*keywordsValueGenerator) Close() {}
 
 // Start implements the tree.ValueGenerator interface.
-func (k *keywordsValueGenerator) Start() error {
+func (k *keywordsValueGenerator) Start(_ context.Context, _ *client.Txn) error {
 	k.curKeyword = -1
 	return nil
 }
-func (k *keywordsValueGenerator) Next() (bool, error) {
+func (k *keywordsValueGenerator) Next(_ context.Context) (bool, error) {
 	k.curKeyword++
 	return k.curKeyword < len(lex.KeywordNames), nil
 }
@@ -414,7 +434,7 @@ func (s *seriesValueGenerator) ResolvedType() *types.T {
 }
 
 // Start implements the tree.ValueGenerator interface.
-func (s *seriesValueGenerator) Start() error {
+func (s *seriesValueGenerator) Start(_ context.Context, _ *client.Txn) error {
 	s.nextOK = true
 	s.start = s.origStart
 	s.value = s.origStart
@@ -425,13 +445,14 @@ func (s *seriesValueGenerator) Start() error {
 func (s *seriesValueGenerator) Close() {}
 
 // Next implements the tree.ValueGenerator interface.
-func (s *seriesValueGenerator) Next() (bool, error) {
+func (s *seriesValueGenerator) Next(_ context.Context) (bool, error) {
 	return s.next(s)
 }
 
 // Values implements the tree.ValueGenerator interface.
 func (s *seriesValueGenerator) Values() tree.Datums {
-	return s.genValue(s)
+	x := s.genValue(s)
+	return x
 }
 
 func makeArrayGenerator(_ *tree.EvalContext, args tree.Datums) (tree.ValueGenerator, error) {
@@ -454,7 +475,7 @@ func (s *arrayValueGenerator) ResolvedType() *types.T {
 }
 
 // Start implements the tree.ValueGenerator interface.
-func (s *arrayValueGenerator) Start() error {
+func (s *arrayValueGenerator) Start(_ context.Context, _ *client.Txn) error {
 	s.nextIndex = -1
 	return nil
 }
@@ -463,7 +484,7 @@ func (s *arrayValueGenerator) Start() error {
 func (s *arrayValueGenerator) Close() {}
 
 // Next implements the tree.ValueGenerator interface.
-func (s *arrayValueGenerator) Next() (bool, error) {
+func (s *arrayValueGenerator) Next(_ context.Context) (bool, error) {
 	s.nextIndex++
 	if s.nextIndex >= s.array.Len() {
 		return false, nil
@@ -503,7 +524,7 @@ func (s *expandArrayValueGenerator) ResolvedType() *types.T {
 }
 
 // Start implements the tree.ValueGenerator interface.
-func (s *expandArrayValueGenerator) Start() error {
+func (s *expandArrayValueGenerator) Start(_ context.Context, _ *client.Txn) error {
 	s.avg.nextIndex = -1
 	return nil
 }
@@ -512,7 +533,7 @@ func (s *expandArrayValueGenerator) Start() error {
 func (s *expandArrayValueGenerator) Close() {}
 
 // Next implements the tree.ValueGenerator interface.
-func (s *expandArrayValueGenerator) Next() (bool, error) {
+func (s *expandArrayValueGenerator) Next(_ context.Context) (bool, error) {
 	s.avg.nextIndex++
 	return s.avg.nextIndex < s.avg.array.Len(), nil
 }
@@ -572,7 +593,7 @@ func (s *subscriptsValueGenerator) ResolvedType() *types.T {
 }
 
 // Start implements the tree.ValueGenerator interface.
-func (s *subscriptsValueGenerator) Start() error {
+func (s *subscriptsValueGenerator) Start(_ context.Context, _ *client.Txn) error {
 	if s.reverse {
 		s.avg.nextIndex = s.avg.array.Len()
 	} else {
@@ -587,7 +608,7 @@ func (s *subscriptsValueGenerator) Start() error {
 func (s *subscriptsValueGenerator) Close() {}
 
 // Next implements the tree.ValueGenerator interface.
-func (s *subscriptsValueGenerator) Next() (bool, error) {
+func (s *subscriptsValueGenerator) Next(_ context.Context) (bool, error) {
 	if s.reverse {
 		s.avg.nextIndex--
 		return s.avg.nextIndex >= 0, nil
@@ -623,7 +644,7 @@ func makeUnaryGenerator(_ *tree.EvalContext, args tree.Datums) (tree.ValueGenera
 func (*unaryValueGenerator) ResolvedType() *types.T { return unaryValueGeneratorType }
 
 // Start implements the tree.ValueGenerator interface.
-func (s *unaryValueGenerator) Start() error {
+func (s *unaryValueGenerator) Start(_ context.Context, _ *client.Txn) error {
 	s.done = false
 	return nil
 }
@@ -632,7 +653,7 @@ func (s *unaryValueGenerator) Start() error {
 func (s *unaryValueGenerator) Close() {}
 
 // Next implements the tree.ValueGenerator interface.
-func (s *unaryValueGenerator) Next() (bool, error) {
+func (s *unaryValueGenerator) Next(_ context.Context) (bool, error) {
 	if !s.done {
 		s.done = true
 		return true, nil
@@ -725,7 +746,7 @@ func (g *jsonArrayGenerator) ResolvedType() *types.T {
 }
 
 // Start implements the tree.ValueGenerator interface.
-func (g *jsonArrayGenerator) Start() error {
+func (g *jsonArrayGenerator) Start(_ context.Context, _ *client.Txn) error {
 	g.nextIndex = -1
 	g.json.JSON = g.json.JSON.MaybeDecode()
 	g.buf[0] = nil
@@ -736,7 +757,7 @@ func (g *jsonArrayGenerator) Start() error {
 func (g *jsonArrayGenerator) Close() {}
 
 // Next implements the tree.ValueGenerator interface.
-func (g *jsonArrayGenerator) Next() (bool, error) {
+func (g *jsonArrayGenerator) Next(_ context.Context) (bool, error) {
 	g.nextIndex++
 	next, err := g.json.FetchValIdx(g.nextIndex)
 	if err != nil || next == nil {
@@ -800,13 +821,13 @@ func (g *jsonObjectKeysGenerator) ResolvedType() *types.T {
 }
 
 // Start implements the tree.ValueGenerator interface.
-func (g *jsonObjectKeysGenerator) Start() error { return nil }
+func (g *jsonObjectKeysGenerator) Start(_ context.Context, _ *client.Txn) error { return nil }
 
 // Close implements the tree.ValueGenerator interface.
 func (g *jsonObjectKeysGenerator) Close() {}
 
 // Next implements the tree.ValueGenerator interface.
-func (g *jsonObjectKeysGenerator) Next() (bool, error) {
+func (g *jsonObjectKeysGenerator) Next(_ context.Context) (bool, error) {
 	return g.iter.Next(), nil
 }
 
@@ -879,7 +900,7 @@ func (g *jsonEachGenerator) ResolvedType() *types.T {
 }
 
 // Start implements the tree.ValueGenerator interface.
-func (g *jsonEachGenerator) Start() error {
+func (g *jsonEachGenerator) Start(_ context.Context, _ *client.Txn) error {
 	iter, err := g.target.ObjectIter()
 	if err != nil {
 		return err
@@ -900,7 +921,7 @@ func (g *jsonEachGenerator) Start() error {
 func (g *jsonEachGenerator) Close() {}
 
 // Next implements the tree.ValueGenerator interface.
-func (g *jsonEachGenerator) Next() (bool, error) {
+func (g *jsonEachGenerator) Next(_ context.Context) (bool, error) {
 	if !g.iter.Next() {
 		return false, nil
 	}
@@ -982,7 +1003,7 @@ func (*checkConsistencyGenerator) ResolvedType() *types.T {
 }
 
 // Start is part of the tree.ValueGenerator interface.
-func (c *checkConsistencyGenerator) Start() error {
+func (c *checkConsistencyGenerator) Start(_ context.Context, _ *client.Txn) error {
 	var b client.Batch
 	b.AddRawRequest(&roachpb.CheckConsistencyRequest{
 		RequestHeader: roachpb.RequestHeader{
@@ -1003,7 +1024,7 @@ func (c *checkConsistencyGenerator) Start() error {
 }
 
 // Next is part of the tree.ValueGenerator interface.
-func (c *checkConsistencyGenerator) Next() (bool, error) {
+func (c *checkConsistencyGenerator) Next(_ context.Context) (bool, error) {
 	if len(c.remainingRows) == 0 {
 		return false, nil
 	}

--- a/pkg/sql/sem/builtins/generator_builtins_test.go
+++ b/pkg/sql/sem/builtins/generator_builtins_test.go
@@ -1,0 +1,55 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package builtins
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConcurrentProcessorsReadEpoch(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	params := base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			SQLEvalContext: &tree.EvalContextTestingKnobs{
+				CallbackGenerators: map[string]*tree.CallbackValueGenerator{
+					"my_callback": tree.NewCallbackValueGenerator(
+						func(ctx context.Context, prev int, _ *client.Txn) (int, error) {
+							if prev < 10 {
+								return prev + 1, nil
+							}
+							return -1, nil
+						}),
+				},
+			},
+		},
+	}
+	s, db, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	rows, err := db.Query(` select * from crdb_internal.testing_callback('my_callback')`)
+	require.NoError(t, err)
+	exp := 1
+	for rows.Next() {
+		var got int
+		require.NoError(t, rows.Scan(&got))
+		require.Equal(t, exp, got)
+		exp++
+	}
+}

--- a/pkg/sql/sem/builtins/help_test.go
+++ b/pkg/sql/sem/builtins/help_test.go
@@ -18,9 +18,11 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
 func TestHelpFunctions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	// This test checks that all the built-in functions receive contextual help.
 	for f := range builtins {
 		if unicode.IsUpper(rune(f[0])) {

--- a/pkg/sql/sem/builtins/main_test.go
+++ b/pkg/sql/sem/builtins/main_test.go
@@ -1,0 +1,33 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package builtins_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+//go:generate ../../../util/leaktest/add-leaktest.sh *_test.go
+
+func TestMain(m *testing.M) {
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}

--- a/pkg/sql/sem/builtins/window_frame_builtins_test.go
+++ b/pkg/sql/sem/builtins/window_frame_builtins_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
 const maxInt = 1000000
@@ -250,6 +251,7 @@ func partitionToString(ctx context.Context, partition tree.IndexedRows) string {
 }
 
 func TestSlidingWindow(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	for _, count := range []int{1, 17, 253} {
 		testSlidingWindow(t, count)
 	}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2604,6 +2604,8 @@ type EvalContextTestingKnobs struct {
 	// cost of each expression in the query tree for the purpose of creating
 	// alternate query plans in the optimizer.
 	OptimizerCostPerturbation float64
+
+	CallbackGenerators map[string]*CallbackValueGenerator
 }
 
 var _ base.ModuleTestingKnobs = &EvalContextTestingKnobs{}
@@ -5142,3 +5144,59 @@ func PickFromTuple(ctx *EvalContext, greatest bool, args Datums) (Datum, error) 
 	}
 	return g, nil
 }
+
+// CallbackValueGenerator is a ValueGenerator that calls a supplied callback for
+// producing the values. To be used with
+// EvalContextTestingKnobs.CallbackGenerators.
+type CallbackValueGenerator struct {
+	// cb is the callback to be called for producing values. It gets passed in 0
+	// as prev initially, and the value it previously returned for subsequent
+	// invocations. Once it returns -1 or an error, it will not be invoked any
+	// more.
+	cb  func(ctx context.Context, prev int, txn *client.Txn) (int, error)
+	val int
+	txn *client.Txn
+}
+
+var _ ValueGenerator = &CallbackValueGenerator{}
+
+// NewCallbackValueGenerator creates a new CallbackValueGenerator.
+func NewCallbackValueGenerator(
+	cb func(ctx context.Context, prev int, txn *client.Txn) (int, error),
+) *CallbackValueGenerator {
+	return &CallbackValueGenerator{
+		cb: cb,
+	}
+}
+
+// ResolvedType is part of the ValueGenerator interface.
+func (c *CallbackValueGenerator) ResolvedType() *types.T {
+	return types.Int
+}
+
+// Start is part of the ValueGenerator interface.
+func (c *CallbackValueGenerator) Start(_ context.Context, txn *client.Txn) error {
+	c.txn = txn
+	return nil
+}
+
+// Next is part of the ValueGenerator interface.
+func (c *CallbackValueGenerator) Next(ctx context.Context) (bool, error) {
+	var err error
+	c.val, err = c.cb(ctx, c.val, c.txn)
+	if err != nil {
+		return false, err
+	}
+	if c.val == -1 {
+		return false, nil
+	}
+	return true, nil
+}
+
+// Values is part of the ValueGenerator interface.
+func (c *CallbackValueGenerator) Values() Datums {
+	return Datums{NewDInt(DInt(c.val))}
+}
+
+// Close is part of the ValueGenerator interface.
+func (c *CallbackValueGenerator) Close() {}

--- a/pkg/sql/sem/tree/generators.go
+++ b/pkg/sql/sem/tree/generators.go
@@ -10,7 +10,12 @@
 
 package tree
 
-import "github.com/cockroachdb/cockroach/pkg/sql/types"
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+)
 
 // Table generators, also called "set-generating functions", are
 // special functions that return an entire table.
@@ -40,10 +45,13 @@ type ValueGenerator interface {
 	// Start initializes the generator. Must be called once before
 	// Next() and Values(). It can be called again to restart
 	// the generator after Next() has returned false.
-	Start() error
+	//
+	// txn represents the txn that the generator will run inside of. The generator
+	// is expected to hold on to this txn and use it in Next() calls.
+	Start(ctx context.Context, txn *client.Txn) error
 
 	// Next determines whether there is a row of data available.
-	Next() (bool, error)
+	Next(context.Context) (bool, error)
 
 	// Values retrieves the current row of data.
 	Values() Datums


### PR DESCRIPTION
This patch introduces crdb_internal.testing_callback('foo'), a magic
builtin generator function that hooks up to named callback functions
defined at TestServer creation time through a testing hook. This allows
one inject errors, or block, different parts of a sql query (by
judicious use of this builtin such that it's placed in the part of the
tree that you want).
I've needed this several times over the years. It can be combined with
the various storage level Testing*Filter testing hooks for interacting
with storage from different parts of a query. For example, one can
install one of these testing_callbacks which takes the txn and does,
say, a Scan(), which Scan is further intercepted by a Testing*Filter for
injecting a server-side error into it.

I've also augmented the builtin generator interface so that generators
get access to the query's ctx and txn.

Release note: None