### PR TITLE
workload: don't panic on limiter error

### DIFF
--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -225,10 +225,7 @@ func workerRun(
 		// Limit how quickly the load generator sends requests based on --max-rate.
 		if limiter != nil {
 			if err := limiter.Wait(ctx); err != nil {
-				if err == ctx.Err() {
-					return
-				}
-				panic(err)
+				return
 			}
 		}
 


### PR DESCRIPTION
`limiter.Wait` can throw the error `Wait(n=1) would exceed context deadline`
if it is asked to wait for longer than a context deadline. This seems to
happen reliably with a workload wait of 2m. There's no reason we need to
turn this into an panic.

Release justification: Testing only.

Release note: None