### PR TITLE
sql/logictest: add logictest for all expected 1PC txn statements

### DIFF
--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -191,6 +191,7 @@ func (d *deleteRangeNode) startExec(params runParams) error {
 			}
 		}
 	} else {
+		log.Event(ctx, "autocommit enabled")
 		// With autocommit, we're going to run the deleteRange in a single batch
 		// without a limit, since limits and deleteRange aren't compatible with 1pc
 		// transactions / autocommit. This isn't inherently safe, because without a

--- a/pkg/sql/opt/exec/execbuilder/testdata/autocommit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/autocommit
@@ -1,22 +1,54 @@
 # LogicTest: local
 
+# This file tests against mutations that we expect to be handled with one-phase
+# commit transactions. Any change to the kv batches produced by these statements
+# should be treated with care.
+
 statement ok
-CREATE TABLE ab (a INT, b INT)
+CREATE TABLE ab (a INT PRIMARY KEY, b INT, FAMILY f1 (a, b))
+
+# Populate table descriptor cache.
+query II
+SELECT * FROM ab
+----
 
 # ------------
 # INSERT tests
 # ------------
 
-# Simple insert should auto-commit.
+# Single-row insert should auto-commit.
 statement ok
 SET TRACING=ON;
-  INSERT INTO ab VALUES (1, 1), (2, 2);
+  INSERT INTO ab VALUES (1, 1);
 SET TRACING=OFF
 
 query B
 SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
 ----
 true
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send  r24: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
+
+# Multi-row insert should auto-commit.
+statement ok
+SET TRACING=ON;
+  INSERT INTO ab VALUES (2, 2), (3, 3);
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+true
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send  r24: sending batch 2 CPut, 1 EndTxn to (n1,s1):1
 
 # No auto-commit inside a transaction.
 statement ok
@@ -24,13 +56,19 @@ BEGIN
 
 statement ok
 SET TRACING=ON;
-  INSERT INTO ab VALUES (1, 1), (2, 2);
+  INSERT INTO ab VALUES (4, 4), (5, 5);
 SET TRACING=OFF
 
 query B
 SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
 ----
 false
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send  r24: sending batch 2 CPut to (n1,s1):1
 
 statement ok
 ROLLBACK
@@ -38,7 +76,7 @@ ROLLBACK
 # Insert with simple RETURNING statement should auto-commit.
 statement ok
 SET TRACING=ON;
-  INSERT INTO ab VALUES (1, 1), (2, 2) RETURNING a, b;
+  INSERT INTO ab VALUES (6, 6), (7, 7) RETURNING a, b;
 SET TRACING=OFF
 
 query B
@@ -46,22 +84,36 @@ SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit 
 ----
 true
 
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send  r24: sending batch 2 CPut, 1 EndTxn to (n1,s1):1
+
 # TODO(radu): allow non-side-effecting projections.
 statement ok
 SET TRACING=ON;
-  INSERT INTO ab VALUES (1, 1), (2, 2) RETURNING a + b;
+  INSERT INTO ab VALUES (8, 8), (9, 9) RETURNING a + b;
 SET TRACING=OFF
 
 query B
 SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
 ----
 false
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send                                         r24: sending batch 2 CPut to (n1,s1):1
+dist sender send                                         r24: sending batch 1 EndTxn to (n1,s1):1
+[async] kv.DistSender: sending pre-commit query intents  r24: sending batch 2 QueryIntent to (n1,s1):1
 
 # Insert with RETURNING statement with side-effects should not auto-commit.
 # In this case division can (in principle) error out.
 statement ok
 SET TRACING=ON;
-  INSERT INTO ab VALUES (1, 1), (2, 2) RETURNING a / b;
+  INSERT INTO ab VALUES (10, 10), (11, 11) RETURNING a / b;
 SET TRACING=OFF
 
 query B
@@ -69,10 +121,18 @@ SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit 
 ----
 false
 
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send                                         r24: sending batch 2 CPut to (n1,s1):1
+dist sender send                                         r24: sending batch 1 EndTxn to (n1,s1):1
+[async] kv.DistSender: sending pre-commit query intents  r24: sending batch 2 QueryIntent to (n1,s1):1
+
 # Another way to test the scenario above: generate an error and ensure that the
 # mutation was not committed.
 statement error division by zero
-INSERT INTO ab VALUES (1, 0) RETURNING a / b
+INSERT INTO ab VALUES (12, 0) RETURNING a / b
 
 query I
 SELECT count(*) FROM ab WHERE b=0
@@ -83,16 +143,39 @@ SELECT count(*) FROM ab WHERE b=0
 # UPSERT tests
 # ------------
 
-# Simple upsert should auto-commit.
+# Single-row upsert should auto-commit.
 statement ok
 SET TRACING=ON;
-  UPSERT INTO ab VALUES (1, 1), (2, 2);
+  UPSERT INTO ab VALUES (1, 1);
 SET TRACING=OFF
 
 query B
 SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
 ----
 true
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send  r24: sending batch 1 Put, 1 EndTxn to (n1,s1):1
+
+# Multi-row upsert should auto-commit.
+statement ok
+SET TRACING=ON;
+  UPSERT INTO ab VALUES (2, 2), (3, 3);
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+true
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send  r24: sending batch 2 Put, 1 EndTxn to (n1,s1):1
 
 # No auto-commit inside a transaction.
 statement ok
@@ -100,13 +183,19 @@ BEGIN
 
 statement ok
 SET TRACING=ON;
-  UPSERT INTO ab VALUES (1, 1), (2, 2);
+  UPSERT INTO ab VALUES (4, 4), (5, 5);
 SET TRACING=OFF
 
 query B
 SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
 ----
 false
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send  r24: sending batch 2 Put to (n1,s1):1
 
 statement ok
 ROLLBACK
@@ -114,7 +203,7 @@ ROLLBACK
 # Upsert with simple RETURNING statement should auto-commit.
 statement ok
 SET TRACING=ON;
-  UPSERT INTO ab VALUES (1, 1), (2, 2) RETURNING a, b;
+  UPSERT INTO ab VALUES (6, 6), (7, 7) RETURNING a, b;
 SET TRACING=OFF
 
 query B
@@ -122,22 +211,36 @@ SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit 
 ----
 true
 
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send  r24: sending batch 2 Put, 1 EndTxn to (n1,s1):1
+
 # TODO(radu): allow non-side-effecting projections.
 statement ok
 SET TRACING=ON;
-  UPSERT INTO ab VALUES (1, 1), (2, 2) RETURNING a + b;
+  UPSERT INTO ab VALUES (8, 8), (9, 9) RETURNING a + b;
 SET TRACING=OFF
 
 query B
 SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
 ----
 false
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send                                         r24: sending batch 2 Put to (n1,s1):1
+dist sender send                                         r24: sending batch 1 EndTxn to (n1,s1):1
+[async] kv.DistSender: sending pre-commit query intents  r24: sending batch 2 QueryIntent to (n1,s1):1
 
 # Upsert with RETURNING statement with side-effects should not auto-commit.
 # In this case division can (in principle) error out.
 statement ok
 SET TRACING=ON;
-  UPSERT INTO ab VALUES (1, 1), (2, 2) RETURNING a / b;
+  UPSERT INTO ab VALUES (10, 10), (11, 11) RETURNING a / b;
 SET TRACING=OFF
 
 query B
@@ -145,10 +248,18 @@ SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit 
 ----
 false
 
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send                                         r24: sending batch 2 Put to (n1,s1):1
+dist sender send                                         r24: sending batch 1 EndTxn to (n1,s1):1
+[async] kv.DistSender: sending pre-commit query intents  r24: sending batch 2 QueryIntent to (n1,s1):1
+
 # Another way to test the scenario above: generate an error and ensure that the
 # mutation was not committed.
 statement error division by zero
-UPSERT INTO ab VALUES (1, 0) RETURNING a / b
+UPSERT INTO ab VALUES (12, 0) RETURNING a / b
 
 query I
 SELECT count(*) FROM ab WHERE b=0
@@ -170,6 +281,13 @@ SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit 
 ----
 true
 
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send  r24: sending batch 1 Scan to (n1,s1):1
+dist sender send  r24: sending batch 2 Put, 1 EndTxn to (n1,s1):1
+
 # No auto-commit inside a transaction.
 statement ok
 BEGIN
@@ -183,6 +301,13 @@ query B
 SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
 ----
 false
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send  r24: sending batch 1 Scan to (n1,s1):1
+dist sender send  r24: sending batch 2 Put to (n1,s1):1
 
 statement ok
 ROLLBACK
@@ -198,6 +323,13 @@ SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit 
 ----
 true
 
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send  r24: sending batch 1 Scan to (n1,s1):1
+dist sender send  r24: sending batch 2 Put, 1 EndTxn to (n1,s1):1
+
 # TODO(radu): allow non-side-effecting projections.
 statement ok
 SET TRACING=ON;
@@ -208,6 +340,15 @@ query B
 SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
 ----
 false
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send                                         r24: sending batch 1 Scan to (n1,s1):1
+dist sender send                                         r24: sending batch 2 Put to (n1,s1):1
+dist sender send                                         r24: sending batch 1 EndTxn to (n1,s1):1
+[async] kv.DistSender: sending pre-commit query intents  r24: sending batch 2 QueryIntent to (n1,s1):1
 
 # Update with RETURNING statement with side-effects should not auto-commit.
 # In this case division can (in principle) error out.
@@ -221,6 +362,15 @@ SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit 
 ----
 false
 
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send                                         r24: sending batch 1 Scan to (n1,s1):1
+dist sender send                                         r24: sending batch 2 Put to (n1,s1):1
+dist sender send                                         r24: sending batch 1 EndTxn to (n1,s1):1
+[async] kv.DistSender: sending pre-commit query intents  r24: sending batch 2 QueryIntent to (n1,s1):1
+
 # Another way to test the scenario above: generate an error and ensure that the
 # mutation was not committed.
 statement error division by zero
@@ -231,15 +381,153 @@ SELECT count(*) FROM ab WHERE b=0
 ----
 0
 
+# ------------
+# DELETE tests
+# ------------
+
+# Single-row delete should auto-commit.
+statement ok
+SET TRACING=ON;
+  DELETE FROM ab WHERE a = 1;
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+true
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send  r24: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
+
+# Multi-row delete should auto-commit.
+statement ok
+SET TRACING=ON;
+  DELETE FROM ab WHERE a IN (2, 3);
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+true
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send  r24: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
+
+# No auto-commit inside a transaction.
+statement ok
+BEGIN
+
+statement ok
+SET TRACING=ON;
+  DELETE FROM ab WHERE a IN (4, 5);
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+false
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send  r24: sending batch 1 DelRng to (n1,s1):1
+
+statement ok
+ROLLBACK
+
+# Delete with simple RETURNING statement should auto-commit.
+statement ok
+SET TRACING=ON;
+  DELETE FROM ab WHERE a IN (6, 7) RETURNING a, b;
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+true
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send  r24: sending batch 1 Scan to (n1,s1):1
+dist sender send  r24: sending batch 2 Del, 1 EndTxn to (n1,s1):1
+
+# TODO(radu): allow non-side-effecting projections.
+statement ok
+SET TRACING=ON;
+  DELETE FROM ab WHERE a IN (8, 9) RETURNING a + b;
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+false
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send                                         r24: sending batch 1 Scan to (n1,s1):1
+dist sender send                                         r24: sending batch 2 Del to (n1,s1):1
+dist sender send                                         r24: sending batch 1 EndTxn to (n1,s1):1
+[async] kv.DistSender: sending pre-commit query intents  r24: sending batch 2 QueryIntent to (n1,s1):1
+
+# Insert with RETURNING statement with side-effects should not auto-commit.
+# In this case division can (in principle) error out.
+statement ok
+SET TRACING=ON;
+  DELETE FROM ab WHERE a IN (10, 11) RETURNING a / b;
+SET TRACING=OFF
+
+query B
+SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
+----
+false
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send                                         r24: sending batch 1 Scan to (n1,s1):1
+dist sender send                                         r24: sending batch 2 Del to (n1,s1):1
+dist sender send                                         r24: sending batch 1 EndTxn to (n1,s1):1
+[async] kv.DistSender: sending pre-commit query intents  r24: sending batch 2 QueryIntent to (n1,s1):1
+
+statement ok
+INSERT INTO ab VALUES (12, 0);
+
+# Another way to test the scenario above: generate an error and ensure that the
+# mutation was not committed.
+statement error division by zero
+DELETE FROM ab WHERE a = 12 RETURNING a / b
+
+query I
+SELECT count(*) FROM ab WHERE b=0
+----
+1
+
 # -----------------------
 # Tests with foreign keys
 # -----------------------
 
 statement ok
-CREATE TABLE fk_parent (p INT PRIMARY KEY, q INT);
+CREATE TABLE fk_parent (p INT PRIMARY KEY, q INT, FAMILY f1 (p, q));
 INSERT INTO fk_parent VALUES (1, 10), (2, 20), (3, 30);
-CREATE TABLE fk_child (a INT, b INT REFERENCES fk_parent(p));
+CREATE TABLE fk_child (a INT, b INT REFERENCES fk_parent(p), FAMILY f1 (a, b));
 SET experimental_optimizer_foreign_keys = true
+
+# Populate table descriptor cache.
+query IIII
+SELECT * FROM fk_parent JOIN fk_child ON p = b
+----
 
 statement ok
 SET TRACING=ON;
@@ -251,6 +539,15 @@ SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit 
 ----
 false
 
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send                                         r24: sending batch 2 CPut, 2 InitPut to (n1,s1):1
+dist sender send                                         r24: sending batch 2 Scan to (n1,s1):1
+dist sender send                                         r24: sending batch 1 EndTxn to (n1,s1):1
+[async] kv.DistSender: sending pre-commit query intents  r24: sending batch 4 QueryIntent to (n1,s1):1
+
 statement ok
 SET TRACING=ON;
   UPDATE fk_child SET b=b+1 WHERE a < 2;
@@ -261,6 +558,16 @@ SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit 
 ----
 false
 
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send                                         r24: sending batch 1 Scan to (n1,s1):1
+dist sender send                                         r24: sending batch 1 Put, 1 CPut, 1 Del to (n1,s1):1
+dist sender send                                         r24: sending batch 1 Scan to (n1,s1):1
+dist sender send                                         r24: sending batch 1 EndTxn to (n1,s1):1
+[async] kv.DistSender: sending pre-commit query intents  r24: sending batch 3 QueryIntent to (n1,s1):1
+
 statement ok
 SET TRACING=ON;
   DELETE FROM fk_parent WHERE p = 3;
@@ -270,6 +577,16 @@ query B
 SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
 ----
 false
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send                                         r24: sending batch 1 Scan to (n1,s1):1
+dist sender send                                         r24: sending batch 1 Del to (n1,s1):1
+dist sender send                                         r24: sending batch 1 Scan to (n1,s1):1
+dist sender send                                         r24: sending batch 1 EndTxn to (n1,s1):1
+[async] kv.DistSender: sending pre-commit query intents  r24: sending batch 1 QueryIntent to (n1,s1):1
 
 # -----------------------
 # Multiple mutation tests
@@ -287,9 +604,18 @@ SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit 
 ----
 false
 
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send                                         r24: sending batch 2 CPut to (n1,s1):1
+dist sender send                                         r24: sending batch 2 CPut to (n1,s1):1
+dist sender send                                         r24: sending batch 1 EndTxn to (n1,s1):1
+[async] kv.DistSender: sending pre-commit query intents  r24: sending batch 4 QueryIntent to (n1,s1):1
+
 statement ok
 SET TRACING=ON;
-  WITH cte AS (INSERT INTO ab VALUES (1, 1), (2, 2) RETURNING a, b)
+  WITH cte AS (INSERT INTO ab VALUES (3, 3), (4, 4) RETURNING a, b)
   INSERT INTO ab (SELECT a*10, b*10 FROM cte);
 SET TRACING=OFF
 
@@ -297,3 +623,12 @@ query B
 SELECT count(*) > 0 FROM [ SHOW TRACE FOR SESSION ] WHERE message = 'autocommit enabled'
 ----
 false
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%sending batch%'
+----
+dist sender send                                         r24: sending batch 2 CPut to (n1,s1):1
+dist sender send                                         r24: sending batch 2 CPut to (n1,s1):1
+dist sender send                                         r24: sending batch 1 EndTxn to (n1,s1):1
+[async] kv.DistSender: sending pre-commit query intents  r24: sending batch 4 QueryIntent to (n1,s1):1


### PR DESCRIPTION
First commit from #41324.

We expect a selection of simple single-statement mutations to hit the
"1-phase commit" transaction fast-path. #41320 demonstrated how critical
this is, as regressions here can cause major (> 50%) performance hits to
benchmarks and user workloads. This commit adds a logic test to validate
that these statements continue to hit this fast-path.

Release justification: Testing only.