### PR TITLE
sql/pgwire: don't start and stop timers in BenchmarkEncodings

### DIFF
--- a/pkg/sql/pgwire/encoding_test.go
+++ b/pkg/sql/pgwire/encoding_test.go
@@ -235,22 +235,16 @@ func BenchmarkEncodings(b *testing.B) {
 			d := tc.Datum
 
 			b.Run("text", func(b *testing.B) {
-				b.StopTimer()
 				for i := 0; i < b.N; i++ {
 					buf.reset()
 					buf.textFormatter.Buffer.Reset()
-					b.StartTimer()
 					buf.writeTextDatum(ctx, d, conv)
-					b.StopTimer()
 				}
 			})
 			b.Run("binary", func(b *testing.B) {
-				b.StopTimer()
 				for i := 0; i < b.N; i++ {
 					buf.reset()
-					b.StartTimer()
 					buf.writeBinaryDatum(ctx, d, time.UTC, tc.Oid)
-					b.StopTimer()
 				}
 			})
 		})


### PR DESCRIPTION
Go bench doesn't like benchmarks that take O(10ns) and continuously
start and stop timers. A single run of one of these benchmarks used
to take ~3m. Now they take the expected 1s.

Release justification: Testing only.

Release note: None