### PR TITLE
kv: avoid allocations in client.Txn constructor

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -195,6 +195,9 @@ type DistSender struct {
 	// It is copied out of the rpcContext at construction time and used in
 	// testing.
 	clusterID *base.ClusterIDContainer
+	// rangeIteratorGen returns a range iterator bound to the DistSender.
+	// Used to avoid allocations.
+	rangeIteratorGen RangeIteratorGen
 
 	// disableFirstRangeUpdates disables updates of the first range via
 	// gossip. Used by tests which want finer control of the contents of the
@@ -280,6 +283,7 @@ func NewDistSender(cfg DistSenderConfig, g *gossip.Gossip) *DistSender {
 	ds.clusterID = &cfg.RPCContext.ClusterID
 	ds.nodeDialer = cfg.NodeDialer
 	ds.asyncSenderSem = make(chan struct{}, defaultSenderConcurrency)
+	ds.rangeIteratorGen = func() *RangeIterator { return NewRangeIterator(ds) }
 
 	if g != nil {
 		ctx := ds.AnnotateCtx(context.Background())

--- a/pkg/kv/range_iter.go
+++ b/pkg/kv/range_iter.go
@@ -33,6 +33,9 @@ type RangeIterator struct {
 	pErr    *roachpb.Error
 }
 
+// RangeIteratorGen is a generator of RangeIterators.
+type RangeIteratorGen func() *RangeIterator
+
 // NewRangeIterator creates a new RangeIterator.
 func NewRangeIterator(ds *DistSender) *RangeIterator {
 	return &RangeIterator{
@@ -113,6 +116,9 @@ func (ri *RangeIterator) Error() *roachpb.Error {
 func (ri *RangeIterator) Reset() {
 	*ri = RangeIterator{ds: ri.ds}
 }
+
+// Silence unused warning.
+var _ = (*RangeIterator)(nil).Reset
 
 // Next advances the iterator to the next range. The direction of
 // advance is dependent on whether the iterator is reversed. The

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -476,9 +476,9 @@ func (tcf *TxnCoordSenderFactory) TransactionalSender(
 	// txnLockGatekeeper at the bottom of the stack to connect it with the
 	// TxnCoordSender's wrapped sender. First, each of the interceptor objects
 	// is initialized.
-	var ri *RangeIterator
+	var riGen RangeIteratorGen
 	if ds, ok := tcf.wrapped.(*DistSender); ok {
-		ri = NewRangeIterator(ds)
+		riGen = ds.rangeIteratorGen
 	}
 	// Some interceptors are only needed by roots.
 	if typ == client.RootTxn {
@@ -504,8 +504,8 @@ func (tcf *TxnCoordSenderFactory) TransactionalSender(
 		}
 	}
 	tcs.interceptorAlloc.txnPipeliner = txnPipeliner{
-		st: tcf.st,
-		ri: ri,
+		st:    tcf.st,
+		riGen: riGen,
 	}
 	tcs.interceptorAlloc.txnSpanRefresher = txnSpanRefresher{
 		st:    tcf.st,

--- a/pkg/kv/txn_interceptor_span_refresher.go
+++ b/pkg/kv/txn_interceptor_span_refresher.go
@@ -412,12 +412,16 @@ func (sr *txnSpanRefresher) augmentMetaLocked(meta roachpb.TxnCoordMeta) {
 		sr.refreshReads = nil
 		sr.refreshWrites = nil
 	} else if !sr.refreshInvalid {
-		sr.refreshReads, _ = roachpb.MergeSpans(
-			append(append([]roachpb.Span(nil), sr.refreshReads...), meta.RefreshReads...),
-		)
-		sr.refreshWrites, _ = roachpb.MergeSpans(
-			append(append([]roachpb.Span(nil), sr.refreshWrites...), meta.RefreshWrites...),
-		)
+		if meta.RefreshReads != nil {
+			sr.refreshReads, _ = roachpb.MergeSpans(
+				append(append([]roachpb.Span(nil), sr.refreshReads...), meta.RefreshReads...),
+			)
+		}
+		if meta.RefreshWrites != nil {
+			sr.refreshWrites, _ = roachpb.MergeSpans(
+				append(append([]roachpb.Span(nil), sr.refreshWrites...), meta.RefreshWrites...),
+			)
+		}
 	}
 	// Recompute the size of the refreshes.
 	sr.refreshSpansBytes = 0


### PR DESCRIPTION
This PR contains two small wins that help speed up the client.Txn constructor, which is responsible for **2.90%** of a CPU profile when running Sysbench's `oltp_point_select` workload. The biggest win here will come from addressing https://github.com/cockroachdb/cockroach/issues/32508.

#### kv: lazily create *RangeIterator in txnPipeliner

This allocation was responsible for **0.34%** of a CPU profile when running Sysbench's `oltp_point_select` workload.

#### kv: only re-alloc refresh spans in augmentMetaLocked if necessary

This was responsible for **0.057%** of a CPU profile when running Sysbench's `oltp_point_select` workload.

Release justification: None. These can wait for the branch to split.