### PR TITLE
kv: avoid letting BatchRequest escape to heap in TxnCoordSender.Send

### DIFF
--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -883,7 +883,7 @@ func (tc *TxnCoordSender) maybeRejectClientLocked(
 		return tc.mu.storedErr
 	case txnFinalized:
 		msg := fmt.Sprintf("client already committed or rolled back the transaction. "+
-			"Trying to execute: %s", ba)
+			"Trying to execute: %s", ba.Summary())
 		stack := string(debug.Stack())
 		log.Errorf(ctx, "%s. stack:\n%s", msg, stack)
 		return roachpb.NewErrorWithTxn(roachpb.NewTransactionStatusError(msg), &tc.mu.txn)


### PR DESCRIPTION
This allocation was responsible for **0.34%** of a CPU profile when running
Sysbench's oltp_point_select workload.

Release justification: Very safe and avoids perf regression due to newly
introduced memory allocations.

Release note: None