### PR TITLE
storageccl: add http header(s) to the changefeed request

### DIFF
--- a/pkg/storage/cloud/external_storage.go
+++ b/pkg/storage/cloud/external_storage.go
@@ -371,6 +371,7 @@ type httpStorage struct {
 	base     *url.URL
 	client   *http.Client
 	hosts    []string
+	headers  map[string]string
 	settings *cluster.Settings
 }
 
@@ -423,6 +424,7 @@ func makeHTTPStorage(base string, settings *cluster.Settings) (ExternalStorage, 
 		base:     uri,
 		client:   client,
 		hosts:    strings.Split(uri.Host, ","),
+		headers:  map[string]string{"Content-Type": "application/x-ndjson"},
 		settings: settings,
 	}, nil
 }
@@ -512,6 +514,11 @@ func (h *httpStorage) req(
 	req = req.WithContext(ctx)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error constructing request %s %q", method, url)
+	}
+	if h.headers != nil {
+		for k, v := range h.headers {
+			req.Header.Set(k, v)
+		}
 	}
 	resp, err := h.client.Do(req)
 	if err != nil {


### PR DESCRIPTION
Resolves: #41211
Added the ability to specify http headers for a httpStorage request,
used by HTTP changefeed sink in order to set
content-type to application/x-ndjson.

Release justification: Minor changefeed http header change
Release note: None