### PR TITLE
pkg/sql: use ring.Buffer in StmtBuf

### DIFF
--- a/pkg/sql/conn_io_test.go
+++ b/pkg/sql/conn_io_test.go
@@ -177,7 +177,7 @@ func TestStmtBufLtrim(t *testing.T) {
 	buf.AdvanceOne()
 	trimPos := CmdPos(2)
 	buf.ltrim(ctx, trimPos)
-	if l := len(buf.mu.data); l != 3 {
+	if l := buf.mu.data.Len(); l != 3 {
 		t.Fatalf("expected 3 left, got: %d", l)
 	}
 	if s := buf.mu.startPos; s != 2 {

--- a/pkg/util/ring/ring_buffer.go
+++ b/pkg/util/ring/ring_buffer.go
@@ -10,22 +10,22 @@
 
 package ring
 
-const bufferInitialSize = 8
-
-// Buffer is a deque maintained over a ring buffer. Note: it is backed by
-// a slice (unlike container/ring one that is backed by a linked list).
+// Buffer is a deque maintained over a ring buffer.
+//
+// Note: it is backed by a slice (unlike container/ring which is backed by a
+// linked list).
 type Buffer struct {
 	buffer []interface{}
-	head   int // the index of the front of the deque.
-	tail   int // the index of the first position right after the end of the deque.
+	head   int // the index of the front of the buffer
+	tail   int // the index of the first position after the end of the buffer
 
-	// indicates whether the deque is empty, necessary to distinguish
-	// between an empty deque and a deque that uses all of its capacity.
+	// Indicates whether the buffer is empty. Necessary to distinguish
+	// between an empty buffer and a buffer that uses all of its capacity.
 	nonEmpty bool
 }
 
-// Len returns the number of elements in the deque.
-func (r Buffer) Len() int {
+// Len returns the number of elements in the Buffer.
+func (r *Buffer) Len() int {
 	if !r.nonEmpty {
 		return 0
 	}
@@ -38,83 +38,78 @@ func (r Buffer) Len() int {
 	}
 }
 
-// AddFirst add element to the front of the deque
-// and doubles it's underlying slice if necessary.
-func (r *Buffer) AddFirst(element interface{}) {
-	if cap(r.buffer) == 0 {
-		r.buffer = make([]interface{}, bufferInitialSize)
-		r.buffer[0] = element
-		r.tail = 1
-	} else {
-		if r.Len() == cap(r.buffer) {
-			newBuffer := make([]interface{}, 2*cap(r.buffer))
-			if r.head < r.tail {
-				copy(newBuffer[:r.Len()], r.buffer[r.head:r.tail])
-			} else {
-				copy(newBuffer[:cap(r.buffer)-r.head], r.buffer[r.head:])
-				copy(newBuffer[cap(r.buffer)-r.head:r.Len()], r.buffer[:r.tail])
-			}
-			r.head = 0
-			r.tail = cap(r.buffer)
-			r.buffer = newBuffer
-		}
-		r.head = (cap(r.buffer) + r.head - 1) % cap(r.buffer)
-		r.buffer[r.head] = element
-	}
-	r.nonEmpty = true
+// Cap returns the capacity of the Buffer.
+func (r *Buffer) Cap() int {
+	return cap(r.buffer)
 }
 
-// AddLast adds element to the end of the deque
-// and doubles it's underlying slice if necessary.
-func (r *Buffer) AddLast(element interface{}) {
-	if cap(r.buffer) == 0 {
-		r.buffer = make([]interface{}, bufferInitialSize)
-		r.buffer[0] = element
-		r.tail = 1
-	} else {
-		if r.Len() == cap(r.buffer) {
-			newBuffer := make([]interface{}, 2*cap(r.buffer))
-			if r.head < r.tail {
-				copy(newBuffer[:r.Len()], r.buffer[r.head:r.tail])
-			} else {
-				copy(newBuffer[:cap(r.buffer)-r.head], r.buffer[r.head:])
-				copy(newBuffer[cap(r.buffer)-r.head:r.Len()], r.buffer[:r.tail])
-			}
-			r.head = 0
-			r.tail = cap(r.buffer)
-			r.buffer = newBuffer
-		}
-		r.buffer[r.tail] = element
-		r.tail = (r.tail + 1) % cap(r.buffer)
-	}
-	r.nonEmpty = true
-}
-
-// Get returns an element at position pos in the deque (zero-based).
-func (r Buffer) Get(pos int) interface{} {
+// Get returns an element at position pos in the Buffer (zero-based).
+func (r *Buffer) Get(pos int) interface{} {
 	if !r.nonEmpty || pos < 0 || pos >= r.Len() {
-		panic("unexpected behavior: index out of bounds")
+		panic("index out of bounds")
 	}
 	return r.buffer[(pos+r.head)%cap(r.buffer)]
 }
 
-// GetFirst returns an element at the front of the deque.
-func (r Buffer) GetFirst() interface{} {
+// GetFirst returns an element at the front of the Buffer.
+func (r *Buffer) GetFirst() interface{} {
 	if !r.nonEmpty {
-		panic("unexpected behavior: getting first from empty deque")
+		panic("getting first from empty ring buffer")
 	}
 	return r.buffer[r.head]
 }
 
-// GetLast returns an element at the front of the deque.
-func (r Buffer) GetLast() interface{} {
+// GetLast returns an element at the front of the Buffer.
+func (r *Buffer) GetLast() interface{} {
 	if !r.nonEmpty {
-		panic("unexpected behavior: getting last from empty deque")
+		panic("getting last from empty ring buffer")
 	}
 	return r.buffer[(cap(r.buffer)+r.tail-1)%cap(r.buffer)]
 }
 
-// RemoveFirst removes a single element from the front of the deque.
+func (r *Buffer) grow(n int) {
+	newBuffer := make([]interface{}, n)
+	if r.head < r.tail {
+		copy(newBuffer[:r.Len()], r.buffer[r.head:r.tail])
+	} else {
+		copy(newBuffer[:cap(r.buffer)-r.head], r.buffer[r.head:])
+		copy(newBuffer[cap(r.buffer)-r.head:r.Len()], r.buffer[:r.tail])
+	}
+	r.head = 0
+	r.tail = cap(r.buffer)
+	r.buffer = newBuffer
+}
+
+func (r *Buffer) maybeGrow() {
+	if r.Len() != cap(r.buffer) {
+		return
+	}
+	n := 2 * cap(r.buffer)
+	if n == 0 {
+		n = 1
+	}
+	r.grow(n)
+}
+
+// AddFirst add element to the front of the Buffer and doubles it's underlying
+// slice if necessary.
+func (r *Buffer) AddFirst(element interface{}) {
+	r.maybeGrow()
+	r.head = (cap(r.buffer) + r.head - 1) % cap(r.buffer)
+	r.buffer[r.head] = element
+	r.nonEmpty = true
+}
+
+// AddLast adds element to the end of the Buffer and doubles it's underlying
+// slice if necessary.
+func (r *Buffer) AddLast(element interface{}) {
+	r.maybeGrow()
+	r.buffer[r.tail] = element
+	r.tail = (r.tail + 1) % cap(r.buffer)
+	r.nonEmpty = true
+}
+
+// RemoveFirst removes a single element from the front of the Buffer.
 func (r *Buffer) RemoveFirst() {
 	if r.Len() == 0 {
 		panic("removing first from empty ring buffer")
@@ -126,7 +121,7 @@ func (r *Buffer) RemoveFirst() {
 	}
 }
 
-// RemoveLast removes a single element from the end of the deque.
+// RemoveLast removes a single element from the end of the Buffer.
 func (r *Buffer) RemoveLast() {
 	if r.Len() == 0 {
 		panic("removing last from empty ring buffer")
@@ -136,6 +131,16 @@ func (r *Buffer) RemoveLast() {
 	r.tail = lastPos
 	if r.tail == r.head {
 		r.nonEmpty = false
+	}
+}
+
+// Reserve reserves the provided number of elemnets in the Buffer. It is an
+// error to reserve a size less than the Buffer's current length.
+func (r *Buffer) Reserve(n int) {
+	if n < r.Len() {
+		panic("reserving fewer elements than current length")
+	} else if n > cap(r.buffer) {
+		r.grow(n)
 	}
 }
 


### PR DESCRIPTION
The StmtBuf has the exact access patterns typically associated with a ring buffer. Command instances are added to the back of the buffer and trimmed from the front of the buffer. These operations are often performed in lockstep, but that is not always the case, so we need the buffer to be able to grow.

`ring.Buffer` provides exactly these semantics and it allows us to avoid memory allocations on each Command in `StmtBuf.Push`.

Release justification: None. Don't merge until branch is split.