### PR TITLE
roachtest: specify num replicas

### DIFF
--- a/pkg/workload/tpcc/partition.go
+++ b/pkg/workload/tpcc/partition.go
@@ -393,7 +393,7 @@ func replicateItem(db *gosql.DB, cfg zoneConfig) error {
 
 		configure := fmt.Sprintf(`
 			ALTER INDEX item@%s
-			CONFIGURE ZONE USING constraints = '{"+zone=%s":1}', lease_preferences = '[[+zone=%s]]'`,
+			CONFIGURE ZONE USING num_replicas = COPY FROM PARENT, constraints = '{"+zone=%s":1}', lease_preferences = '[[+zone=%s]]'`,
 			idxName, zone, zone)
 		if _, err := db.Exec(configure); err != nil {
 			return errors.Wrapf(err, "Couldn't exec %q", configure)


### PR DESCRIPTION
We got stricter about when num_replicas needed to be specified, see
b6f8b3dacfe6966e775062efc745fd8f24728fe1.

Touches #41028.

Release justification: roachtest-only fix.

Release note: None