### PR TITLE
cli: Fixing --global flag in cockroach demo.

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -599,12 +599,12 @@ func init() {
 	BoolFlag(demoFlags, &demoCtx.runWorkload, cliflags.RunDemoWorkload, false)
 	VarFlag(demoFlags, &demoCtx.localities, cliflags.DemoNodeLocality)
 	BoolFlag(demoFlags, &demoCtx.geoPartitionedReplicas, cliflags.DemoGeoPartitionedReplicas, false)
+	// Mark the --global flag as hidden until we investigate it more.
+	BoolFlag(demoFlags, &demoCtx.simulateLatency, cliflags.Global, false)
+	_ = demoCmd.Flags().MarkHidden(cliflags.Global.Name)
 	// The --empty flag is only valid for the top level demo command,
 	// so we use the regular flag set.
 	BoolFlag(demoCmd.Flags(), &demoCtx.useEmptyDatabase, cliflags.UseEmptyDatabase, false)
-	BoolFlag(demoCmd.Flags(), &demoCtx.simulateLatency, cliflags.Global, false)
-	// Mark the --global flag as hidden until we investigate it more.
-	_ = demoCmd.Flags().MarkHidden(cliflags.Global.Name)
 
 	// sqlfmt command.
 	fmtFlags := sqlfmtCmd.Flags()


### PR DESCRIPTION
The global flag was not setup as a persistent flag, meaning that the
command `cockroach demo movr --global` did not work.

Fixes #41386.

Release justification: Low risk bug fix.

Release note (bug fix): Fix bug where --global was not usable when
selecting a database in cockroach demo.