### PR TITLE
roachtest: update pgjdbc blacklist with new expected pass

### DIFF
--- a/pkg/cmd/roachtest/pgjdbc_blacklist.go
+++ b/pkg/cmd/roachtest/pgjdbc_blacklist.go
@@ -676,8 +676,6 @@ var pgjdbcBlackList19_2 = blacklist{
 	"org.postgresql.test.jdbc2.CopyTest.testCopyOutByRow":                                                                                                                      "unknown",
 	"org.postgresql.test.jdbc2.CopyTest.testCopyQuery":                                                                                                                         "unknown",
 	"org.postgresql.test.jdbc2.CopyTest.testLockReleaseOnCancelFailure":                                                                                                        "unknown",
-	"org.postgresql.test.jdbc2.CursorFetchTest.testGetRow[binary = FORCE]":                                                                                                     "40195",
-	"org.postgresql.test.jdbc2.CursorFetchTest.testGetRow[binary = REGULAR]":                                                                                                   "40195",
 	"org.postgresql.test.jdbc2.CursorFetchTest.testMultistatement[binary = FORCE]":                                                                                             "40195",
 	"org.postgresql.test.jdbc2.CursorFetchTest.testMultistatement[binary = REGULAR]":                                                                                           "40195",
 	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testEncoding":                                                                                                              "unknown",


### PR DESCRIPTION
Tests that used to fail now pass, so we need to update the blacklist.

closes #41366

Release justification: test only change

Release note: None