### PR TITLE
roachtest: sort clusters in leftover clusters report

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -248,15 +248,28 @@ func (r *clusterRegistry) markClusterAsSaved(c *cluster, msg string) {
 	r.mu.Unlock()
 }
 
+type clusterWithMsg struct {
+	*cluster
+	savedMsg string
+}
+
 // savedClusters returns the list of clusters that have been saved for
 // debugging.
-func (r *clusterRegistry) savedClusters() map[*cluster]string {
+func (r *clusterRegistry) savedClusters() []clusterWithMsg {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	res := make(map[*cluster]string, len(r.mu.savedClusters))
+	res := make([]clusterWithMsg, len(r.mu.savedClusters))
+	i := 0
 	for c, msg := range r.mu.savedClusters {
-		res[c] = msg
+		res[i] = clusterWithMsg{
+			cluster:  c,
+			savedMsg: msg,
+		}
+		i++
 	}
+	sort.Slice(res, func(i, j int) bool {
+		return strings.Compare(res[i].name, res[j].name) < 0
+	})
 	return res
 }
 

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -982,8 +982,8 @@ func (r *testRunner) serveHTTP(wr http.ResponseWriter, req *http.Request) {
 	<tr><th>Cluster</th>
 	<th>Test</th>
 	</tr>`)
-	for c, msg := range r.cr.savedClusters() {
-		fmt.Fprintf(wr, "<tr><td>%s</td><td>%s</td><tr/>", c.name, msg)
+	for _, c := range r.cr.savedClusters() {
+		fmt.Fprintf(wr, "<tr><td>%s</td><td>%s</td><tr/>", c.name, c.savedMsg)
 	}
 	fmt.Fprintf(wr, "</table>")
 


### PR DESCRIPTION
They used to displayed in non-deterministic map iteration order.

Release note: None