### PR TITLE
vendor: No-change bump to Pebble

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -427,20 +427,20 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:76f5abe2591e8f84524dc5cbeaf4dcb4d67565b9e994bafb6cf0879f586c989d"
+  digest = "1:42b3b311d72e202b62fd5d1962edc6fc099062a0b10300fa3f28481106520611"
   name = "github.com/cockroachdb/pebble"
   packages = [
     ".",
     "bloom",
-    "cache",
     "internal/arenaskl",
     "internal/base",
-    "internal/batch",
     "internal/batchskl",
     "internal/bytealloc",
+    "internal/cache",
     "internal/crc",
     "internal/humanize",
     "internal/manifest",
+    "internal/private",
     "internal/rangedel",
     "internal/rate",
     "internal/rawalloc",
@@ -450,7 +450,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "1acac2061f9f5430a7c69e1e5afedfdaeab9e4ef"
+  revision = "b54d5a75a3c4018dced942c98d5223704789abb4"
 
 [[projects]]
   branch = "master"
@@ -1961,7 +1961,6 @@
     "github.com/cockroachdb/gostdlib/x/tools/cmd/goimports",
     "github.com/cockroachdb/logtags",
     "github.com/cockroachdb/pebble",
-    "github.com/cockroachdb/pebble/cache",
     "github.com/cockroachdb/pebble/sstable",
     "github.com/cockroachdb/pebble/tool",
     "github.com/cockroachdb/pebble/vfs",

--- a/pkg/storage/engine/temp_engine.go
+++ b/pkg/storage/engine/temp_engine.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/diskmap"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/pebble"
-	"github.com/cockroachdb/pebble/cache"
 	"github.com/cockroachdb/pebble/vfs"
 )
 
@@ -107,7 +106,7 @@ func NewPebbleTempEngine(
 	opts := &pebble.Options{
 		// Pebble doesn't currently support 0-size caches, so use a 128MB cache for
 		// now.
-		Cache: cache.New(128 << 20),
+		Cache: pebble.NewCache(128 << 20),
 		// The Pebble temp engine does not use MVCC Encoding. Instead, the
 		// caller-provided key is used as-is (with the prefix prepended). See
 		// pebbleMap.makeKey and pebbleMap.makeKeyWithSequence on how this works.


### PR DESCRIPTION
Bumps version of Pebble to b54d5a7 to pick up recent improvements,
such as new Cache instantiator, checkpointing, etc.

Release note: None