### PR TITLE
roachtest: Fix partitioning roachtest failure

### DIFF
--- a/pkg/workload/interleavedpartitioned/interleavedpartitioned.go
+++ b/pkg/workload/interleavedpartitioned/interleavedpartitioned.go
@@ -749,7 +749,9 @@ func (w *interleavedPartitioned) Hooks() workload.Hooks {
 			}
 			if _, err := db.Exec(
 				fmt.Sprintf(
-					"ALTER PARTITION west OF TABLE sessions CONFIGURE ZONE USING lease_preferences = '[[+zone=%s]]'",
+					"ALTER PARTITION west OF TABLE sessions CONFIGURE ZONE USING"+
+						" lease_preferences = '[[+zone=%[1]s]]', "+
+						"constraints = '{+zone=%[1]s : 1}', num_replicas = 3",
 					w.westZoneName,
 				),
 			); err != nil {
@@ -757,7 +759,9 @@ func (w *interleavedPartitioned) Hooks() workload.Hooks {
 			}
 			if _, err := db.Exec(
 				fmt.Sprintf(
-					"ALTER PARTITION east OF TABLE sessions CONFIGURE ZONE USING lease_preferences = '[[+zone=%s]]'",
+					"ALTER PARTITION east OF TABLE sessions CONFIGURE ZONE USING"+
+						" lease_preferences = '[[+zone=%[1]s]]', "+
+						"constraints = '{+zone=%[1]s : 1}', num_replicas = 3",
 					w.eastZoneName,
 				),
 			); err != nil {


### PR DESCRIPTION
Fixes a roachtest failure caused by a recent change that performed more
zone config validation on partitions and indexes.

Fixes #41321.

Release justification: Fixes a failing roachtest.

Release note: None