### PR TITLE
sql/pgwire: avoid new memory allocation in writeTextDatum(Date)

### DIFF
--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -141,9 +141,8 @@ func (b *writeBuffer) writeTextDatum(
 		b.writeLengthPrefixedString(v.Contents)
 
 	case *tree.DDate:
-		s := v.Date.String()
-		b.putInt32(int32(len(s)))
-		b.write([]byte(s))
+		b.textFormatter.FormatNode(v)
+		b.writeFromFmtCtx(b.textFormatter)
 
 	case *tree.DTime:
 		// Start at offset 4 because `putInt32` clobbers the first 4 bytes.


### PR DESCRIPTION
3dfd6cb introduced a performance regression in the speed of encoding
Date datums to their text representation. This commit partially avoids
the regression.

```
name              old time/op  new time/op  delta
WriteTextDate-16   446ns ± 4%   318ns ± 1%  -28.75%  (p=0.000 n=10+9)
```

Release justification: Avoids performance regression.

Release note: None