### PR TITLE
sql/pgwire: create and optimize encoding benchmarks for UUID/Interval

### DIFF
--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -129,7 +129,11 @@ func (b *writeBuffer) writeTextDatum(
 		b.write([]byte(result))
 
 	case *tree.DUuid:
-		b.writeLengthPrefixedString(v.UUID.String())
+		// Start at offset 4 because `putInt32` clobbers the first 4 bytes.
+		s := b.putbuf[4 : 4+36]
+		v.UUID.StringBytes(s)
+		b.putInt32(int32(len(s)))
+		b.write(s)
 
 	case *tree.DIPAddr:
 		b.writeLengthPrefixedString(v.IPAddr.String())

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -167,7 +167,8 @@ func (b *writeBuffer) writeTextDatum(
 		b.write(s)
 
 	case *tree.DInterval:
-		b.writeLengthPrefixedString(v.ValueAsString())
+		b.textFormatter.FormatNode(v)
+		b.writeFromFmtCtx(b.textFormatter)
 
 	case *tree.DJSON:
 		b.writeLengthPrefixedString(v.JSON.String())

--- a/pkg/sql/pgwire/types_test.go
+++ b/pkg/sql/pgwire/types_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/lib/pq/oid"
 )
 
@@ -310,6 +311,11 @@ func benchmarkWriteBytes(b *testing.B, format pgwirebase.FormatCode) {
 	benchmarkWriteType(b, tree.NewDBytes("testing"), format)
 }
 
+func benchmarkWriteUUID(b *testing.B, format pgwirebase.FormatCode) {
+	u := uuid.MakeV4()
+	benchmarkWriteType(b, tree.NewDUuid(tree.DUuid{UUID: u}), format)
+}
+
 func benchmarkWriteString(b *testing.B, format pgwirebase.FormatCode) {
 	benchmarkWriteType(b, tree.NewDString("testing"), format)
 }
@@ -398,6 +404,13 @@ func BenchmarkWriteTextBytes(b *testing.B) {
 }
 func BenchmarkWriteBinaryBytes(b *testing.B) {
 	benchmarkWriteBytes(b, pgwirebase.FormatBinary)
+}
+
+func BenchmarkWriteTextUUID(b *testing.B) {
+	benchmarkWriteUUID(b, pgwirebase.FormatText)
+}
+func BenchmarkWriteBinaryUUID(b *testing.B) {
+	benchmarkWriteUUID(b, pgwirebase.FormatBinary)
 }
 
 func BenchmarkWriteTextString(b *testing.B) {


### PR DESCRIPTION
This PR creates the following 2 benchmarks:
- `WriteTextUUID`
- `WriteBinaryUUID`

It then optimizes them:
```
name                  old time/op  new time/op  delta
WriteTextUUID-16      82.7ns ± 4%  51.6ns ± 1%  -37.69%  (p=0.000 n=19+10)
WriteBinaryUUID-16    22.9ns ± 2%  22.6ns ± 2%   -1.44%  (p=0.003 n=10+9)
WriteTextInterval-16   343ns ± 1%   256ns ± 2%  -25.18%  (p=0.000 n=10+10)
```

Release justification: None. Don't merge.