### PR TITLE
release-19.2: disable release justification hint and lint.

### DIFF
--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -1,21 +1,26 @@
 #!/usr/bin/env bash
 
+# Set this to 1 to require a "release justification" note in the commit message
+# or the PR description.
+require_justification=0
+
 set -euo pipefail
 
 source "$(dirname "${0}")/teamcity-support.sh"
 
 tc_prepare
 
-# TODO(jordan): remove this after we cut the 19.2 branch.
-tc_start_block "Ensure commit message contains a release justification"
-# Ensure master branch commits have a release justification until 19.2 goes out the door.
-if [[ $(git log -n1 | grep -ci "Release justification: \S\+") == 0 ]]; then
-  echo "Build Failed. No Release justification in the commit message or in the PR description." >&2
-  echo "Commits must have a Release justification of the form:" >&2
-  echo "Release justification: <some description of why this commit is safe to add to the release branch.>" >&2
-  exit 1
+if [ "$require_justification" = 1 ]; then
+  tc_start_block "Ensure commit message contains a release justification"
+  # Ensure master branch commits have a release justification.
+  if [[ $(git log -n1 | grep -ci "Release justification: \S\+") == 0 ]]; then
+    echo "Build Failed. No Release justification in the commit message or in the PR description." >&2
+    echo "Commits must have a Release justification of the form:" >&2
+    echo "Release justification: <some description of why this commit is safe to add to the release branch.>" >&2
+    exit 1
+  fi
+  tc_end_block "Ensure commit message contains a release justification"
 fi
-tc_end_block "Ensure commit message contains a release justification"
 
 tc_start_block "Ensure dependencies are up-to-date"
 run build/builder.sh go install ./vendor/github.com/golang/dep/cmd/dep ./pkg/cmd/github-pull-request-make

--- a/githooks/commit-msg
+++ b/githooks/commit-msg
@@ -44,6 +44,8 @@ IFS='
 '
 notes=($($grep -iE '^release note' "$1"))
 
+# Set this to 1 to require a release justification note.
+require_justification=0
 justification=($($grep -iE '^release justification: \S+' "$1"))
 
 IFS=$saveIFS
@@ -62,9 +64,9 @@ hint() {
     echo "- $*" >&2
 }
 
-if [ 0 = ${#justification[*]} ]; then
+if [ "$require_justification" = 1 -a  0 = ${#justification[*]} ]; then
     warn "No release justification specified."
-    echo "Try: 'Release justification: This commit is safe for 19.2 because..." >&2
+    echo "Try: 'Release justification: This commit is safe for this release because..." >&2
     echo >&2
 fi
 

--- a/githooks/prepare-commit-msg
+++ b/githooks/prepare-commit-msg
@@ -2,6 +2,7 @@
 #
 # Prepare the commit message by adding a release note.
 
+require_justification=0
 set -euo pipefail
 
 if [[ "${2-}" = "message" ]]; then
@@ -37,20 +38,32 @@ $cchar     <pkg>: <short description>\\
 $cchar\\
 $cchar     <long description>\\
 $cchar\\
-$cchar     Release justification (category): <release justification>\\
+"
+
+if [ "$require_justification" = 1 ]; then
+  sed_script+="$cchar     Release justification (category): <release justification>\\
 $cchar\\
-$cchar     Release note (category): <release note description>\\
+"
+fi
+
+sed_script+="$cchar     Release note (category): <release note description>\\
 $cchar     ---\\
 $cchar\\
 $cchar Wrap long lines! 72 columns is best.\\
 $cchar\\
-$cchar Categories for release justification:\\
+"
+
+if [ "$require_justification" = 1 ]; then
+  sed_script+="$cchar Categories for release justification:\\
 $cchar     - non-production code changes\\
 $cchar     - bug fixes and low-risk updates to new functionality\\
 $cchar     - fixes for high-priority or high-severity bugs in existing functionality\\
 $cchar     - low risk, high benefit changes to existing functionality\\
 $cchar\\
-$cchar The release note must be present if your commit has user-facing\\
+"
+fi
+
+sed_script+="$cchar The release note must be present if your commit has user-facing\\
 $cchar changes. Leave the default above if not.\\
 $cchar\\
 $cchar Categories for release notes:\\
@@ -65,13 +78,15 @@ $cchar     - performance improvement\\
 $cchar     - bug fix\\
 "
 
-# Add an explicit "Release justification: None" if no release justification was specified.
-if ! grep -q '^Release justification' "$1"; then
-	sed_script+="
+if [ "$require_justification" = 1 ]; then
+  # Add an explicit "Release justification: None" if no release justification was specified.
+  if ! grep -q '^Release justification' "$1"; then
+  	sed_script+="
 ;/$cchar Please enter the commit message for your changes./i\\
 \\
 $cchar Release justification:\\
 "
+  fi
 fi
 
 # Add an explicit "Release note: None" if no release note was specified.


### PR DESCRIPTION
Backport 1/1 commits from #41400.

/cc @cockroachdb/release

---

This effectively disables commit feeaf62a1b5095b012096e0469a9cae4e6bb7d66.

The functionality is moved behind flags so it can easily be revived
for next release.

Release justification: how ironic.

Release note: None
