### PR TITLE
colexec: fix remapping of indexed vars in filter expressions

### DIFF
--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -893,12 +893,14 @@ func (p *filterPlanningState) remapIVars(expr execinfrapb.Expression) execinfrap
 		// Now we simply need to convert the "custom" ordinal symbol by removing
 		// the pound sign (in the example above, after this loop we will have
 		// `@1 = @2`).
-		for idx := len(p.indexVarMap); idx > 0; idx-- {
-			ret.Expr = strings.ReplaceAll(
-				ret.Expr,
-				fmt.Sprintf("@#%d", idx),
-				fmt.Sprintf("@%d", idx),
-			)
+		for _, idx := range p.indexVarMap {
+			if idx != -1 {
+				ret.Expr = strings.ReplaceAll(
+					ret.Expr,
+					fmt.Sprintf("@#%d", idx+1),
+					fmt.Sprintf("@%d", idx+1),
+				)
+			}
 		}
 	}
 	return ret

--- a/pkg/sql/logictest/testdata/logic_test/exec_hash_join
+++ b/pkg/sql/logictest/testdata/logic_test/exec_hash_join
@@ -109,3 +109,43 @@ SELECT b.a, b.c, c.a FROM b JOIN c ON b.b = c.a AND b.c = c.b ORDER BY 2
 0  a  1
 2  b  1
 0  c  2
+
+# Regression test for #41407.
+statement ok
+CREATE TABLE IF NOT EXISTS t41407 AS
+	SELECT
+		g AS _float8,
+		g % 0 = 0 AS _bool,
+		g AS _decimal,
+		g AS _string,
+		g AS _bytes
+	FROM
+		generate_series(NULL, NULL) AS g;
+
+query T
+EXPLAIN (VEC)
+	SELECT
+		tab_1688._bytes,
+		tab_1688._float8,
+		tab_1689._string,
+		tab_1689._string,
+		tab_1688._float8,
+		tab_1688._float8,
+		tab_1689._bool,
+		tab_1690._decimal
+	FROM
+		t41407 AS tab_1688
+		JOIN t41407 AS tab_1689
+			JOIN t41407 AS tab_1690 ON
+					tab_1689._bool = tab_1690._bool ON
+				tab_1688._float8 = tab_1690._float8
+				AND tab_1688._bool = tab_1689._bool;
+----
+│
+└ Node 1
+  └ *colexec.selEQBoolBoolOp
+    └ *colexec.hashJoinEqOp
+      ├ *colexec.hashJoinEqOp
+      │ ├ *colexec.colBatchScan
+      │ └ *colexec.colBatchScan
+      └ *colexec.colBatchScan


### PR DESCRIPTION
Previously, the remapping of indexed variables was done incorrectly
(the range for indices was too small which would cause the "custom"
ordinal of the form '@#[d]+' to keep the pound sign). Now this is
fixed.

Fixes: #41407.

Release note: None