### PR TITLE
sql/parser: support string values in EXTRACT arguments

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -2393,6 +2393,7 @@ extract_arg ::=
 	| 'HOUR'
 	| 'MINUTE'
 	| 'SECOND'
+	| 'SCONST'
 
 overlay_placing ::=
 	'PLACING' a_expr

--- a/pkg/sql/logictest/testdata/logic_test/time
+++ b/pkg/sql/logictest/testdata/logic_test/time
@@ -327,3 +327,19 @@ SELECT extract(epoch from time '12:00:00')
 
 query error pgcode 22023 extract\(\): unsupported timespan: day
 SELECT extract(day from time '12:00:00')
+
+query I
+SELECT extract('microsecond' from time '12:01:02.345678')
+----
+2345678
+
+query I
+SELECT extract('EPOCH' from time '12:00:00')
+----
+43200
+
+query error pgcode 22023 extract\(\): unsupported timespan: day
+SELECT extract('day' from time '12:00:00')
+
+query error pgcode 22023 extract\(\): unsupported timespan: day
+SELECT extract('DAY' from time '12:00:00')

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1671,6 +1671,8 @@ func TestParse2(t *testing.T) {
 		// Special extract syntax
 		{`SELECT EXTRACT(second from now())`,
 			`SELECT extract('second', now())`},
+		{`SELECT EXTRACT('second' from now())`,
+			`SELECT extract('second', now())`},
 		// Special trim syntax
 		{`SELECT TRIM('xy' from 'xyxtrimyyx')`,
 			`SELECT btrim('xyxtrimyyx', 'xy')`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -8627,6 +8627,7 @@ extract_arg:
 | HOUR
 | MINUTE
 | SECOND
+| SCONST
 
 // OVERLAY() arguments
 // SQL99 defines the OVERLAY() function:

--- a/pkg/sql/sem/tree/testdata/eval/extract
+++ b/pkg/sql/sem/tree/testdata/eval/extract
@@ -6,7 +6,12 @@ extract(year from '2010-09-28'::date)
 2010
 
 eval
-extract(year from '2010-09-28'::date)
+extract('year' from '2010-09-28'::date)
+----
+2010
+
+eval
+extract('YEAR' from '2010-09-28'::date)
 ----
 2010
 
@@ -143,6 +148,16 @@ extract(epoch from '2010-01-10 12:13:14.1+00:00'::timestamp)
 
 eval
 extract_duration(hour from '123m')
+----
+2
+
+eval
+extract_duration('hour' from '123m')
+----
+2
+
+eval
+extract_duration('HOUR' from '123m')
 ----
 2
 


### PR DESCRIPTION
This adds support to use string constant as element argument in EXTRACT
function (e.g. `EXTRACT ('month' FROM now())`).

Fixes #41408.

Release note (sql change): Support string constant as element argument
in EXTRACT function.