### PR TITLE
storage: check lease/destroyStatus in replicate queue

### DIFF
--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -292,6 +292,16 @@ func (rq *replicateQueue) process(
 func (rq *replicateQueue) processOneChange(
 	ctx context.Context, repl *Replica, canTransferLease func() bool, dryRun bool,
 ) (requeue bool, _ error) {
+	// Check lease and destroy status here. The queue does this higher up already, but
+	// adminScatter (and potential other future callers) also call this method and don't
+	// perform this check, which could lead to infinite loops.
+	if _, err := repl.IsDestroyed(); err != nil {
+		return false, err
+	}
+	if _, pErr := repl.redirectOnOrAcquireLease(ctx); pErr != nil {
+		return false, pErr.GoError()
+	}
+
 	desc, zone := repl.DescAndZone()
 
 	// Avoid taking action if the range has too many dead replicas to make


### PR DESCRIPTION
While working with #41028, we encountered a RESTORE that was stuck on an
AdminScatter. Looking more closely, we realized that the retry loop in
AdminScatter got stuck on a replica that had since been removed (but
was still referenced by the scatter). We'd repeatedly call
replicateQueue.processOneChange(repl) which would try to transition out
of a joint configuration, but would hit a descriptor changed error,
which was then retried, ad infinitum.

Put both a lease and destroy status check into processOneChange to
avoid this class of problem.

Release note: None