### PR TITLE
release-19.2: sql: bevy of fixes for ActiveRecord compatibility

### DIFF
--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -201,8 +201,10 @@ func (so *importSequenceOperators) ParseQualifiedTableName(
 }
 
 // Implements the tree.EvalDatabase interface.
-func (so *importSequenceOperators) ResolveTableName(ctx context.Context, tn *tree.TableName) error {
-	return errSequenceOperators
+func (so *importSequenceOperators) ResolveTableName(
+	ctx context.Context, tn *tree.TableName,
+) (tree.ID, error) {
+	return 0, errSequenceOperators
 }
 
 // Implements the tree.EvalDatabase interface.

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1922,7 +1922,7 @@ CREATE TABLE test.pg_indexdef_test (a INT, UNIQUE INDEX pg_indexdef_idx (a ASC),
 query T
 SELECT pg_catalog.pg_get_indexdef((SELECT oid from pg_class WHERE relname='pg_indexdef_idx'))
 ----
-CREATE UNIQUE INDEX pg_indexdef_idx ON test.public.pg_indexdef_test (a ASC)
+CREATE UNIQUE INDEX pg_indexdef_idx ON test.public.pg_indexdef_test USING btree (a ASC)
 
 query T
 SELECT pg_catalog.pg_get_indexdef(0, 0, true)
@@ -1932,7 +1932,7 @@ NULL
 query T
 SELECT pg_catalog.pg_get_indexdef((SELECT oid from pg_class WHERE relname='pg_indexdef_idx'), 0, true)
 ----
-CREATE UNIQUE INDEX pg_indexdef_idx ON test.public.pg_indexdef_test (a ASC)
+CREATE UNIQUE INDEX pg_indexdef_idx ON test.public.pg_indexdef_test USING btree (a ASC)
 
 statement ok
 CREATE TABLE test.pg_indexdef_test_cols (a INT, b INT, UNIQUE INDEX pg_indexdef_cols_idx (a ASC, b DESC), INDEX other (a DESC))
@@ -1940,7 +1940,7 @@ CREATE TABLE test.pg_indexdef_test_cols (a INT, b INT, UNIQUE INDEX pg_indexdef_
 query T
 SELECT pg_catalog.pg_get_indexdef((SELECT oid from pg_class WHERE relname='pg_indexdef_cols_idx'), 0, true)
 ----
-CREATE UNIQUE INDEX pg_indexdef_cols_idx ON test.public.pg_indexdef_test_cols (a ASC, b DESC)
+CREATE UNIQUE INDEX pg_indexdef_cols_idx ON test.public.pg_indexdef_test_cols USING btree (a ASC, b DESC)
 
 query T
 SELECT pg_catalog.pg_get_indexdef((SELECT oid from pg_class WHERE relname='pg_indexdef_cols_idx'), 1, true)

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -97,6 +97,7 @@ test           pg_catalog          pg_am                              public   S
 test           pg_catalog          pg_attrdef                         public   SELECT
 test           pg_catalog          pg_attribute                       public   SELECT
 test           pg_catalog          pg_auth_members                    public   SELECT
+test           pg_catalog          pg_available_extensions            public   SELECT
 test           pg_catalog          pg_cast                            public   SELECT
 test           pg_catalog          pg_class                           public   SELECT
 test           pg_catalog          pg_collation                       public   SELECT

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -273,6 +273,7 @@ pg_catalog          pg_am
 pg_catalog          pg_attrdef
 pg_catalog          pg_attribute
 pg_catalog          pg_auth_members
+pg_catalog          pg_available_extensions
 pg_catalog          pg_cast
 pg_catalog          pg_class
 pg_catalog          pg_collation
@@ -410,6 +411,7 @@ pg_am
 pg_attrdef
 pg_attribute
 pg_auth_members
+pg_available_extensions
 pg_cast
 pg_class
 pg_collation
@@ -554,6 +556,7 @@ system         pg_catalog          pg_am                              SYSTEM VIE
 system         pg_catalog          pg_attrdef                         SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_attribute                       SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_auth_members                    SYSTEM VIEW  NO                  1
+system         pg_catalog          pg_available_extensions            SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_cast                            SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_class                           SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_collation                       SYSTEM VIEW  NO                  1
@@ -1354,6 +1357,7 @@ NULL     public   system         pg_catalog          pg_am                      
 NULL     public   system         pg_catalog          pg_attrdef                         SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_attribute                       SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_auth_members                    SELECT          NULL          YES
+NULL     public   system         pg_catalog          pg_available_extensions            SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_cast                            SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_class                           SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_collation                       SELECT          NULL          YES
@@ -1644,6 +1648,7 @@ NULL     public   system         pg_catalog          pg_am                      
 NULL     public   system         pg_catalog          pg_attrdef                         SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_attribute                       SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_auth_members                    SELECT          NULL          YES
+NULL     public   system         pg_catalog          pg_available_extensions            SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_cast                            SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_class                           SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_collation                       SELECT          NULL          YES

--- a/pkg/sql/logictest/testdata/logic_test/orms
+++ b/pkg/sql/logictest/testdata/logic_test/orms
@@ -72,8 +72,8 @@ GROUP BY i.relname,
 ORDER BY i.relname
 ----
 name              primary  unique  indkey  column_indexes  column_names  definition
-customers_id_idx  false    false   2       {1,2}           {name,id}     CREATE INDEX customers_id_idx ON test.public.customers (id ASC)
-primary           true     true    1       {1,2}           {name,id}     CREATE UNIQUE INDEX "primary" ON test.public.customers (name ASC)
+customers_id_idx  false    false   2       {1,2}           {name,id}     CREATE INDEX customers_id_idx ON test.public.customers USING btree (id ASC)
+primary           true     true    1       {1,2}           {name,id}     CREATE UNIQUE INDEX "primary" ON test.public.customers USING btree (name ASC)
 
 
 query TT colnames

--- a/pkg/sql/logictest/testdata/logic_test/orms
+++ b/pkg/sql/logictest/testdata/logic_test/orms
@@ -137,3 +137,28 @@ AND t.relname = 'b'
 AND i.relnamespace IN (SELECT oid FROM pg_namespace WHERE nspname = ANY (current_schemas(false)))
 ----
 1
+
+statement ok
+CREATE TABLE c (a INT, b INT, PRIMARY KEY (a, b))
+
+# ActiveRecord query for determining primary key cols.
+query T
+SELECT
+    a.attname
+FROM
+    (
+        SELECT
+            indrelid, indkey, generate_subscripts(indkey, 1) AS idx
+        FROM
+            pg_index
+        WHERE
+            indrelid = '"c"'::REGCLASS AND indisprimary
+    )
+        AS i
+    JOIN pg_attribute AS a ON
+            a.attrelid = i.indrelid AND a.attnum = i.indkey[i.idx]
+ORDER BY
+    i.idx
+----
+a
+b

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -543,9 +543,9 @@ JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'public'
 ----
 oid         relname  adrelid  adnum  adbin           adsrc
-1666782879  t1       55       4      12:::INT8       12:::INT8
+1666782879  t1       55       4      12              12
 841178406   t2       56       2      unique_rowid()  unique_rowid()
-2186255414  t3       57       3      'FOO':::STRING  'FOO':::STRING
+2186255414  t3       57       3      'FOO'::STRING   'FOO'::STRING
 2186255409  t3       57       4      unique_rowid()  unique_rowid()
 
 ## pg_catalog.pg_indexes
@@ -570,13 +570,13 @@ FROM pg_catalog.pg_indexes
 WHERE schemaname = 'public'
 ----
 crdb_oid    tablename  indexname     indexdef
-450499963   t1         primary       CREATE UNIQUE INDEX "primary" ON constraint_db.public.t1 (p ASC)
-450499960   t1         t1_a_key      CREATE UNIQUE INDEX t1_a_key ON constraint_db.public.t1 (a ASC)
-450499961   t1         index_key     CREATE UNIQUE INDEX index_key ON constraint_db.public.t1 (b ASC, c ASC)
-2315049508  t2         primary       CREATE UNIQUE INDEX "primary" ON constraint_db.public.t2 (rowid ASC)
-2315049511  t2         t2_t1_id_idx  CREATE INDEX t2_t1_id_idx ON constraint_db.public.t2 (t1_id ASC)
-969972501   t3         primary       CREATE UNIQUE INDEX "primary" ON constraint_db.public.t3 (rowid ASC)
-969972502   t3         t3_a_b_idx    CREATE INDEX t3_a_b_idx ON constraint_db.public.t3 (a ASC, b DESC) STORING (c)
+450499963   t1         primary       CREATE UNIQUE INDEX "primary" ON constraint_db.public.t1 USING btree (p ASC)
+450499960   t1         t1_a_key      CREATE UNIQUE INDEX t1_a_key ON constraint_db.public.t1 USING btree (a ASC)
+450499961   t1         index_key     CREATE UNIQUE INDEX index_key ON constraint_db.public.t1 USING btree (b ASC, c ASC)
+2315049508  t2         primary       CREATE UNIQUE INDEX "primary" ON constraint_db.public.t2 USING btree (rowid ASC)
+2315049511  t2         t2_t1_id_idx  CREATE INDEX t2_t1_id_idx ON constraint_db.public.t2 USING btree (t1_id ASC)
+969972501   t3         primary       CREATE UNIQUE INDEX "primary" ON constraint_db.public.t3 USING btree (rowid ASC)
+969972502   t3         t3_a_b_idx    CREATE INDEX t3_a_b_idx ON constraint_db.public.t3 USING btree (a ASC, b DESC) STORING (c)
 
 ## pg_catalog.pg_index
 
@@ -1746,9 +1746,9 @@ JOIN pg_catalog.pg_class c ON def.adrelid = c.oid
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'public'
 ----
-1666782879  t1  12:::INT8
+1666782879  t1  12
 841178406   t2  unique_rowid()
-2186255414  t3  'FOO':::STRING
+2186255414  t3  'FOO'::STRING
 2186255409  t3  unique_rowid()
 
 # Verify that a set database shows tables from that database for a non-root

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -21,6 +21,7 @@ pg_am
 pg_attrdef
 pg_attribute
 pg_auth_members
+pg_available_extensions
 pg_cast
 pg_class
 pg_collation
@@ -93,6 +94,7 @@ pg_am
 pg_attrdef
 pg_attribute
 pg_auth_members
+pg_available_extensions
 pg_cast
 pg_class
 pg_collation
@@ -817,8 +819,8 @@ FROM pg_catalog.pg_depend
 ORDER BY objid
 ----
 classid     objid       objsubid  refclassid  refobjid   refobjsubid  deptype
-4294967229  2143281868  0         4294967231  450499961  0            n
-4294967229  4089604113  0         4294967231  450499960  0            n
+4294967228  2143281868  0         4294967230  450499961  0            n
+4294967228  4089604113  0         4294967230  450499960  0            n
 
 # All entries in pg_depend are dependency links from the pg_constraint system
 # table to the pg_class system table.
@@ -830,7 +832,7 @@ JOIN pg_class cla ON classid=cla.oid
 JOIN pg_class refcla ON refclassid=refcla.oid
 ----
 classid     refclassid  tablename      reftablename
-4294967229  4294967231  pg_constraint  pg_class
+4294967228  4294967230  pg_constraint  pg_class
 
 # All entries in pg_depend are foreign key constraints that reference an index
 # in pg_class.
@@ -1357,107 +1359,108 @@ SELECT objoid, classoid, objsubid, regexp_replace(description, e'\n.*', '') AS d
   FROM pg_catalog.pg_description
 ----
 objoid      classoid    objsubid  description
-4294967294  4294967231  0         backward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
-4294967292  4294967231  0         built-in functions (RAM/static)
-4294967291  4294967231  0         running queries visible by current user (cluster RPC; expensive!)
-4294967290  4294967231  0         running sessions visible to current user (cluster RPC; expensive!)
-4294967289  4294967231  0         cluster settings (RAM)
-4294967288  4294967231  0         CREATE and ALTER statements for all tables accessible by current user in current database (KV scan)
-4294967287  4294967231  0         telemetry counters (RAM; local node only)
-4294967286  4294967231  0         forward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
-4294967284  4294967231  0         locally known gossiped health alerts (RAM; local node only)
-4294967283  4294967231  0         locally known gossiped node liveness (RAM; local node only)
-4294967282  4294967231  0         locally known edges in the gossip network (RAM; local node only)
-4294967285  4294967231  0         locally known gossiped node details (RAM; local node only)
-4294967281  4294967231  0         index columns for all indexes accessible by current user in current database (KV scan)
-4294967280  4294967231  0         decoded job metadata from system.jobs (KV scan)
-4294967279  4294967231  0         node details across the entire cluster (cluster RPC; expensive!)
-4294967278  4294967231  0         store details and status (cluster RPC; expensive!)
-4294967277  4294967231  0         acquired table leases (RAM; local node only)
-4294967293  4294967231  0         detailed identification strings (RAM, local node only)
-4294967274  4294967231  0         current values for metrics (RAM; local node only)
-4294967276  4294967231  0         running queries visible by current user (RAM; local node only)
-4294967269  4294967231  0         server parameters, useful to construct connection URLs (RAM, local node only)
-4294967275  4294967231  0         running sessions visible by current user (RAM; local node only)
-4294967265  4294967231  0         statement statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967261  4294967231  0         per-application transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967273  4294967231  0         defined partitions for all tables/indexes accessible by the current user in the current database (KV scan)
-4294967272  4294967231  0         comments for predefined virtual tables (RAM/static)
-4294967271  4294967231  0         range metadata without leaseholder details (KV join; expensive!)
-4294967268  4294967231  0         ongoing schema changes, across all descriptors accessible by current user (KV scan; expensive!)
-4294967267  4294967231  0         session trace accumulated so far (RAM)
-4294967266  4294967231  0         session variables (RAM)
-4294967264  4294967231  0         details for all columns accessible by current user in current database (KV scan)
-4294967263  4294967231  0         indexes accessible by current user in current database (KV scan)
-4294967262  4294967231  0         table descriptors accessible by current user, including non-public and virtual (KV scan; expensive!)
-4294967260  4294967231  0         decoded zone configurations from system.zones (KV scan)
-4294967258  4294967231  0         roles for which the current user has admin option
-4294967257  4294967231  0         roles available to the current user
-4294967256  4294967231  0         check constraints
-4294967255  4294967231  0         column privilege grants (incomplete)
-4294967254  4294967231  0         table and view columns (incomplete)
-4294967253  4294967231  0         columns usage by constraints
-4294967252  4294967231  0         roles for the current user
-4294967251  4294967231  0         column usage by indexes and key constraints
-4294967250  4294967231  0         built-in function parameters (empty - introspection not yet supported)
-4294967249  4294967231  0         foreign key constraints
-4294967248  4294967231  0         privileges granted on table or views (incomplete; see also information_schema.table_privileges; may contain excess users or roles)
-4294967247  4294967231  0         built-in functions (empty - introspection not yet supported)
-4294967245  4294967231  0         schema privileges (incomplete; may contain excess users or roles)
-4294967246  4294967231  0         database schemas (may contain schemata without permission)
-4294967244  4294967231  0         sequences
-4294967243  4294967231  0         index metadata and statistics (incomplete)
-4294967242  4294967231  0         table constraints
-4294967241  4294967231  0         privileges granted on table or views (incomplete; may contain excess users or roles)
-4294967240  4294967231  0         tables and views
-4294967238  4294967231  0         grantable privileges (incomplete)
-4294967239  4294967231  0         views (incomplete)
-4294967236  4294967231  0         index access methods (incomplete)
-4294967235  4294967231  0         column default values
-4294967234  4294967231  0         table columns (incomplete - see also information_schema.columns)
-4294967233  4294967231  0         role membership
-4294967232  4294967231  0         casts (empty - needs filling out)
-4294967231  4294967231  0         tables and relation-like objects (incomplete - see also information_schema.tables/sequences/views)
-4294967230  4294967231  0         available collations (incomplete)
-4294967229  4294967231  0         table constraints (incomplete - see also information_schema.table_constraints)
-4294967228  4294967231  0         encoding conversions (empty - unimplemented)
-4294967227  4294967231  0         available databases (incomplete)
-4294967226  4294967231  0         default ACLs (empty - unimplemented)
-4294967225  4294967231  0         dependency relationships (incomplete)
-4294967224  4294967231  0         object comments
-4294967222  4294967231  0         enum types and labels (empty - feature does not exist)
-4294967221  4294967231  0         installed extensions (empty - feature does not exist)
-4294967220  4294967231  0         foreign data wrappers (empty - feature does not exist)
-4294967219  4294967231  0         foreign servers (empty - feature does not exist)
-4294967218  4294967231  0         foreign tables (empty  - feature does not exist)
-4294967217  4294967231  0         indexes (incomplete)
-4294967216  4294967231  0         index creation statements
-4294967215  4294967231  0         table inheritance hierarchy (empty - feature does not exist)
-4294967214  4294967231  0         available languages (empty - feature does not exist)
-4294967213  4294967231  0         locks held by active processes (empty - feature does not exist)
-4294967212  4294967231  0         available materialized views (empty - feature does not exist)
-4294967211  4294967231  0         available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
-4294967210  4294967231  0         operators (incomplete)
-4294967209  4294967231  0         prepared transactions (empty - feature does not exist)
-4294967208  4294967231  0         built-in functions (incomplete)
-4294967207  4294967231  0         range types (empty - feature does not exist)
-4294967206  4294967231  0         rewrite rules (empty - feature does not exist)
-4294967205  4294967231  0         database roles
-4294967192  4294967231  0         security labels (empty - feature does not exist)
-4294967204  4294967231  0         security labels (empty)
-4294967203  4294967231  0         sequences (see also information_schema.sequences)
-4294967202  4294967231  0         session variables (incomplete)
-4294967201  4294967231  0         shared dependencies (empty - not implemented)
-4294967223  4294967231  0         shared object comments
-4294967191  4294967231  0         shared security labels (empty - feature not supported)
-4294967193  4294967231  0         backend access statistics (empty - monitoring works differently in CockroachDB)
-4294967198  4294967231  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
-4294967197  4294967231  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
-4294967196  4294967231  0         triggers (empty - feature does not exist)
-4294967195  4294967231  0         scalar types (incomplete)
-4294967200  4294967231  0         database users
-4294967199  4294967231  0         local to remote user mapping (empty - feature does not exist)
-4294967194  4294967231  0         view definitions (incomplete - see also information_schema.views)
+4294967294  4294967230  0         backward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
+4294967292  4294967230  0         built-in functions (RAM/static)
+4294967291  4294967230  0         running queries visible by current user (cluster RPC; expensive!)
+4294967290  4294967230  0         running sessions visible to current user (cluster RPC; expensive!)
+4294967289  4294967230  0         cluster settings (RAM)
+4294967288  4294967230  0         CREATE and ALTER statements for all tables accessible by current user in current database (KV scan)
+4294967287  4294967230  0         telemetry counters (RAM; local node only)
+4294967286  4294967230  0         forward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
+4294967284  4294967230  0         locally known gossiped health alerts (RAM; local node only)
+4294967283  4294967230  0         locally known gossiped node liveness (RAM; local node only)
+4294967282  4294967230  0         locally known edges in the gossip network (RAM; local node only)
+4294967285  4294967230  0         locally known gossiped node details (RAM; local node only)
+4294967281  4294967230  0         index columns for all indexes accessible by current user in current database (KV scan)
+4294967280  4294967230  0         decoded job metadata from system.jobs (KV scan)
+4294967279  4294967230  0         node details across the entire cluster (cluster RPC; expensive!)
+4294967278  4294967230  0         store details and status (cluster RPC; expensive!)
+4294967277  4294967230  0         acquired table leases (RAM; local node only)
+4294967293  4294967230  0         detailed identification strings (RAM, local node only)
+4294967274  4294967230  0         current values for metrics (RAM; local node only)
+4294967276  4294967230  0         running queries visible by current user (RAM; local node only)
+4294967269  4294967230  0         server parameters, useful to construct connection URLs (RAM, local node only)
+4294967275  4294967230  0         running sessions visible by current user (RAM; local node only)
+4294967265  4294967230  0         statement statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967261  4294967230  0         per-application transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967273  4294967230  0         defined partitions for all tables/indexes accessible by the current user in the current database (KV scan)
+4294967272  4294967230  0         comments for predefined virtual tables (RAM/static)
+4294967271  4294967230  0         range metadata without leaseholder details (KV join; expensive!)
+4294967268  4294967230  0         ongoing schema changes, across all descriptors accessible by current user (KV scan; expensive!)
+4294967267  4294967230  0         session trace accumulated so far (RAM)
+4294967266  4294967230  0         session variables (RAM)
+4294967264  4294967230  0         details for all columns accessible by current user in current database (KV scan)
+4294967263  4294967230  0         indexes accessible by current user in current database (KV scan)
+4294967262  4294967230  0         table descriptors accessible by current user, including non-public and virtual (KV scan; expensive!)
+4294967260  4294967230  0         decoded zone configurations from system.zones (KV scan)
+4294967258  4294967230  0         roles for which the current user has admin option
+4294967257  4294967230  0         roles available to the current user
+4294967256  4294967230  0         check constraints
+4294967255  4294967230  0         column privilege grants (incomplete)
+4294967254  4294967230  0         table and view columns (incomplete)
+4294967253  4294967230  0         columns usage by constraints
+4294967252  4294967230  0         roles for the current user
+4294967251  4294967230  0         column usage by indexes and key constraints
+4294967250  4294967230  0         built-in function parameters (empty - introspection not yet supported)
+4294967249  4294967230  0         foreign key constraints
+4294967248  4294967230  0         privileges granted on table or views (incomplete; see also information_schema.table_privileges; may contain excess users or roles)
+4294967247  4294967230  0         built-in functions (empty - introspection not yet supported)
+4294967245  4294967230  0         schema privileges (incomplete; may contain excess users or roles)
+4294967246  4294967230  0         database schemas (may contain schemata without permission)
+4294967244  4294967230  0         sequences
+4294967243  4294967230  0         index metadata and statistics (incomplete)
+4294967242  4294967230  0         table constraints
+4294967241  4294967230  0         privileges granted on table or views (incomplete; may contain excess users or roles)
+4294967240  4294967230  0         tables and views
+4294967238  4294967230  0         grantable privileges (incomplete)
+4294967239  4294967230  0         views (incomplete)
+4294967236  4294967230  0         index access methods (incomplete)
+4294967235  4294967230  0         column default values
+4294967234  4294967230  0         table columns (incomplete - see also information_schema.columns)
+4294967233  4294967230  0         role membership
+4294967232  4294967230  0         available extensions
+4294967231  4294967230  0         casts (empty - needs filling out)
+4294967230  4294967230  0         tables and relation-like objects (incomplete - see also information_schema.tables/sequences/views)
+4294967229  4294967230  0         available collations (incomplete)
+4294967228  4294967230  0         table constraints (incomplete - see also information_schema.table_constraints)
+4294967227  4294967230  0         encoding conversions (empty - unimplemented)
+4294967226  4294967230  0         available databases (incomplete)
+4294967225  4294967230  0         default ACLs (empty - unimplemented)
+4294967224  4294967230  0         dependency relationships (incomplete)
+4294967223  4294967230  0         object comments
+4294967221  4294967230  0         enum types and labels (empty - feature does not exist)
+4294967220  4294967230  0         installed extensions (empty - feature does not exist)
+4294967219  4294967230  0         foreign data wrappers (empty - feature does not exist)
+4294967218  4294967230  0         foreign servers (empty - feature does not exist)
+4294967217  4294967230  0         foreign tables (empty  - feature does not exist)
+4294967216  4294967230  0         indexes (incomplete)
+4294967215  4294967230  0         index creation statements
+4294967214  4294967230  0         table inheritance hierarchy (empty - feature does not exist)
+4294967213  4294967230  0         available languages (empty - feature does not exist)
+4294967212  4294967230  0         locks held by active processes (empty - feature does not exist)
+4294967211  4294967230  0         available materialized views (empty - feature does not exist)
+4294967210  4294967230  0         available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
+4294967209  4294967230  0         operators (incomplete)
+4294967208  4294967230  0         prepared transactions (empty - feature does not exist)
+4294967207  4294967230  0         built-in functions (incomplete)
+4294967206  4294967230  0         range types (empty - feature does not exist)
+4294967205  4294967230  0         rewrite rules (empty - feature does not exist)
+4294967204  4294967230  0         database roles
+4294967191  4294967230  0         security labels (empty - feature does not exist)
+4294967203  4294967230  0         security labels (empty)
+4294967202  4294967230  0         sequences (see also information_schema.sequences)
+4294967201  4294967230  0         session variables (incomplete)
+4294967200  4294967230  0         shared dependencies (empty - not implemented)
+4294967222  4294967230  0         shared object comments
+4294967190  4294967230  0         shared security labels (empty - feature not supported)
+4294967192  4294967230  0         backend access statistics (empty - monitoring works differently in CockroachDB)
+4294967197  4294967230  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
+4294967196  4294967230  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
+4294967195  4294967230  0         triggers (empty - feature does not exist)
+4294967194  4294967230  0         scalar types (incomplete)
+4294967199  4294967230  0         database users
+4294967198  4294967230  0         local to remote user mapping (empty - feature does not exist)
+4294967193  4294967230  0         view definitions (incomplete - see also information_schema.views)
 
 ## pg_catalog.pg_shdescription
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1795,9 +1795,6 @@ SELECT count(*) FROM pg_catalog.pg_depend
 query error cannot access virtual schema in anonymous database
 select 'upper'::REGPROC;
 
-query error cannot access virtual schema in anonymous database
-select 'system.namespace'::regclass
-
 statement ok
 SET DATABASE = test
 

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -724,6 +724,7 @@ func TestParse(t *testing.T) {
 		{`SELECT 'foo'::TIMESTAMP(6)`},
 		{`SELECT 'foo'::TIMESTAMPTZ(6)`},
 		{`SELECT 'foo'::TIME(6)`},
+		{`'0'::INTERVAL`},
 
 		{`SELECT '192.168.0.1'::INET`},
 		{`SELECT '192.168.0.1':::INET`},
@@ -1606,6 +1607,11 @@ func TestParse2(t *testing.T) {
 		{`SELECT 'a' NOT SIMILAR TO '\a' ESCAPE ''`, `SELECT not_similar_to_escape('a', e'\\a', '')`},
 
 		{`SELECT (ARRAY (1, 2))[1]`, `SELECT (ARRAY[1, 2])[1]`},
+
+		// Interval precision is syntactic sugar.
+		{`SELECT '0'::INTERVAL(6)`, `SELECT '0'::INTERVAL`},
+		// Interval constructor gets eagerly processed.
+		{`SELECT INTERVAL '0'`, `SELECT '00:00:00'`},
 
 		// Pretty printing the FAMILY INET function is not normal due to the grammar
 		// definition of FAMILY.

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -6842,7 +6842,18 @@ simple_typename:
 | character_with_length
 | const_interval
 | const_interval interval_qualifier { return unimplemented(sqllex, "interval with unit qualifier") }
-| const_interval '(' ICONST ')' { return unimplementedWithIssue(sqllex, 32564) }
+| const_interval '(' ICONST ')'
+  {
+    prec, err := $3.numVal().AsInt32()
+    if err != nil {
+      return setErr(sqllex, err)
+    }
+    if prec == 6 {
+      $$.val = $1.colType()
+    } else {
+      return unimplementedWithIssue(sqllex, 32564)
+    }
+  }
 | postgres_oid
 
 // We have a separate const_typename to allow defaulting fixed-length types

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -189,6 +189,7 @@ var pgCatalog = virtualSchema{
 		sqlbase.PgCatalogAttrDefTableID:             pgCatalogAttrDefTable,
 		sqlbase.PgCatalogAttributeTableID:           pgCatalogAttributeTable,
 		sqlbase.PgCatalogAuthMembersTableID:         pgCatalogAuthMembersTable,
+		sqlbase.PgCatalogAvailableExtensionsTableID: pgCatalogAvailableExtensionsTable,
 		sqlbase.PgCatalogCastTableID:                pgCatalogCastTable,
 		sqlbase.PgCatalogClassTableID:               pgCatalogClassTable,
 		sqlbase.PgCatalogCollationTableID:           pgCatalogCollationTable,
@@ -494,6 +495,22 @@ CREATE TABLE pg_catalog.pg_auth_members (
 					tree.MakeDBool(tree.DBool(isAdmin)), // admin_option
 				)
 			})
+	},
+}
+
+var pgCatalogAvailableExtensionsTable = virtualSchemaTable{
+	comment: `available extensions
+https://www.postgresql.org/docs/9.6/view-pg-available-extensions.html`,
+	schema: `
+CREATE TABLE pg_catalog.pg_available_extensions (
+	name NAME,
+	default_version TEXT,
+	installed_version TEXT,
+	comment TEXT
+)`,
+	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+		// We support no extensions.
+		return nil
 	},
 }
 

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -402,9 +402,12 @@ func (p *planner) ParseQualifiedTableName(
 }
 
 // ResolveTableName implements the tree.EvalDatabase interface.
-func (p *planner) ResolveTableName(ctx context.Context, tn *tree.TableName) error {
-	_, err := ResolveExistingObject(ctx, p, tn, tree.ObjectLookupFlagsWithRequired(), ResolveAnyDescType)
-	return err
+func (p *planner) ResolveTableName(ctx context.Context, tn *tree.TableName) (tree.ID, error) {
+	desc, err := ResolveExistingObject(ctx, p, tn, tree.ObjectLookupFlagsWithRequired(), ResolveAnyDescType)
+	if err != nil {
+		return 0, err
+	}
+	return tree.ID(desc.ID), nil
 }
 
 // LookupTableByID looks up a table, by the given descriptor ID. Based on the

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -406,7 +406,7 @@ func getTableNameForArg(ctx *tree.EvalContext, arg tree.Datum) (*tree.TableName,
 		if err != nil {
 			return nil, err
 		}
-		if err := ctx.Planner.ResolveTableName(ctx.Ctx(), tn); err != nil {
+		if _, err := ctx.Planner.ResolveTableName(ctx.Ctx(), tn); err != nil {
 			return nil, err
 		}
 		if ctx.SessionData.Database != "" && ctx.SessionData.Database != string(tn.CatalogName) {

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -819,9 +820,12 @@ var pgBuiltins = map[string]builtinDefinition{
 				}
 				r, err := ctx.InternalExecutor.QueryRow(
 					ctx.Ctx(), "pg_get_coldesc",
-					ctx.Txn,
-					"SELECT description FROM pg_catalog.pg_description WHERE objoid=$1 AND objsubid=$2 LIMIT 1",
-					args[0], args[1])
+					ctx.Txn, `
+SELECT COALESCE(c.comment, pc.comment) FROM system.comments c
+FULL OUTER JOIN crdb_internal.predefined_comments pc
+ON pc.object_id=c.object_id AND pc.sub_id=c.sub_id AND pc.type = c.type
+WHERE c.type=$1::int AND c.object_id=$2::int AND c.sub_id=$3::int LIMIT 1
+`, keys.ColumnCommentType, args[0], args[1])
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -115,7 +115,7 @@ func (node *CreateIndex) Format(ctx *FmtCtx) {
 	if node.Unique {
 		ctx.WriteString("UNIQUE ")
 	}
-	if node.Inverted {
+	if node.Inverted && !ctx.HasFlags(FmtPGIndexDef) {
 		ctx.WriteString("INVERTED ")
 	}
 	ctx.WriteString("INDEX ")
@@ -128,6 +128,14 @@ func (node *CreateIndex) Format(ctx *FmtCtx) {
 	}
 	ctx.WriteString("ON ")
 	ctx.FormatNode(&node.Table)
+	if ctx.HasFlags(FmtPGIndexDef) {
+		ctx.WriteString(" USING")
+		if node.Inverted {
+			ctx.WriteString(" gin")
+		} else {
+			ctx.WriteString(" btree")
+		}
+	}
 	ctx.WriteString(" (")
 	ctx.FormatNode(&node.Columns)
 	ctx.WriteByte(')')

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -3128,6 +3128,17 @@ func (d *DArray) ResolvedType() *types.T {
 	return types.MakeArray(d.ParamTyp)
 }
 
+// FirstIndex returns the first index of the array. 1 for normal SQL arrays,
+// which are 1-indexed, and 0 for the special Postgers vector types which are
+// 0-indexed.
+func (d *DArray) FirstIndex() int {
+	switch d.customOid {
+	case oid.T_int2vector, oid.T_oidvector:
+		return 0
+	}
+	return 1
+}
+
 // Compare implements the Datum interface.
 func (d *DArray) Compare(ctx *EvalContext, other Datum) int {
 	if other == DNull {

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2517,8 +2517,8 @@ type EvalDatabase interface {
 	// makes it point to a valid object.
 	// If the database name is not given, it uses the search path to find it, and
 	// sets it on the returned TableName.
-	// It returns an error if the table doesn't exist.
-	ResolveTableName(ctx context.Context, tn *TableName) error
+	// It returns the ID of the resolved table, and an error if the table doesn't exist.
+	ResolveTableName(ctx context.Context, tn *TableName) (ID, error)
 
 	// LookupSchema looks up the schema with the given name in the given
 	// database.
@@ -3670,16 +3670,15 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 				if err != nil {
 					return nil, err
 				}
-				if err := ctx.Planner.ResolveTableName(ctx.Ctx(), tn); err != nil {
+				id, err := ctx.Planner.ResolveTableName(ctx.Ctx(), tn)
+				if err != nil {
 					return nil, err
 				}
-				// Determining the table's OID requires joining against the databases
-				// table because we only have the database name, not its OID, which is
-				// what is stored in pg_class. This extra join means we can't use
-				// queryOid like everyone else.
-				return queryOidWithJoin(ctx, t, NewDString(tn.Table()),
-					"JOIN pg_catalog.pg_namespace ON relnamespace = pg_namespace.oid",
-					fmt.Sprintf("AND nspname = '%s'", tn.Schema()))
+				return &DOid{
+					semanticType: t,
+					DInt:         DInt(id),
+					name:         tn.TableName.String(),
+				}, nil
 			default:
 				return queryOid(ctx, t, NewDString(s))
 			}

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1626,6 +1626,16 @@ type AnnotateTypeExpr struct {
 
 // Format implements the NodeFormatter interface.
 func (node *AnnotateTypeExpr) Format(ctx *FmtCtx) {
+	if ctx.HasFlags(FmtPGAttrdefAdbin) {
+		ctx.FormatNode(node.Expr)
+		switch node.Type.Family() {
+		case types.StringFamily, types.CollatedStringFamily:
+			// Postgres formats strings using a cast afterward. Let's do the same.
+			ctx.WriteString("::")
+			ctx.WriteString(node.Type.SQLString())
+		}
+		return
+	}
 	switch node.SyntaxMode {
 	case AnnotateShort:
 		exprFmtWithParen(ctx, node.Expr)

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -116,6 +116,16 @@ const (
 	// representation like -Inf. Negative values are preserved "inside"
 	// the numeric by enclosing them within parentheses.
 	FmtParsableNumerics
+
+	// FmtPGAttrdefAdbin is used to produce expressions formatted in a way that's
+	// as close as possible to what clients expect to live in the pg_attrdef.adbin
+	// column. Specifically, this strips type annotations, since Postgres doesn't
+	// know what those are.
+	FmtPGAttrdefAdbin
+
+	// FmtPGIndexDef is used to produce CREATE INDEX statements that are
+	// compatible with pg_get_indexdef.
+	FmtPGIndexDef
 )
 
 // Composite/derived flag definitions follow.

--- a/pkg/sql/sqlbase/constants.go
+++ b/pkg/sql/sqlbase/constants.go
@@ -111,6 +111,7 @@ const (
 	PgCatalogAttrDefTableID
 	PgCatalogAttributeTableID
 	PgCatalogAuthMembersTableID
+	PgCatalogAvailableExtensionsTableID
 	PgCatalogCastTableID
 	PgCatalogClassTableID
 	PgCatalogCollationTableID

--- a/pkg/sql/sqlbase/evalctx.go
+++ b/pkg/sql/sqlbase/evalctx.go
@@ -34,8 +34,10 @@ func (so *DummySequenceOperators) ParseQualifiedTableName(
 }
 
 // ResolveTableName is part of the tree.EvalDatabase interface.
-func (so *DummySequenceOperators) ResolveTableName(ctx context.Context, tn *tree.TableName) error {
-	return errSequenceOperators
+func (so *DummySequenceOperators) ResolveTableName(
+	ctx context.Context, tn *tree.TableName,
+) (tree.ID, error) {
+	return 0, errSequenceOperators
 }
 
 // LookupSchema is part of the tree.EvalDatabase interface.
@@ -90,8 +92,10 @@ func (ep *DummyEvalPlanner) LookupSchema(
 }
 
 // ResolveTableName is part of the tree.EvalDatabase interface.
-func (ep *DummyEvalPlanner) ResolveTableName(ctx context.Context, tn *tree.TableName) error {
-	return errEvalPlanner
+func (ep *DummyEvalPlanner) ResolveTableName(
+	ctx context.Context, tn *tree.TableName,
+) (tree.ID, error) {
+	return 0, errEvalPlanner
 }
 
 // ParseType is part of the tree.EvalPlanner interface.

--- a/pkg/sql/types/oid.go
+++ b/pkg/sql/types/oid.go
@@ -45,7 +45,7 @@ var (
 
 	// OidVector is a type-alias for an array of Oid values, but with a different
 	// OID (T_oidvector instead of T__oid). It is a special VECTOR type used by
-	// Postgres in system tables.
+	// Postgres in system tables. OidVectors are 0-indexed, unlike normal arrays.
 	OidVector = &T{InternalType: InternalType{
 		Family: ArrayFamily, Oid: oid.T_oidvector, ArrayContents: Oid, Locale: &emptyLocale}}
 )

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -358,7 +358,7 @@ var (
 
 	// Int2Vector is a type-alias for an array of Int2 values with a different
 	// OID (T_int2vector instead of T__int2). It is a special VECTOR type used
-	// by Postgres in system tables.
+	// by Postgres in system tables. Int2vectors are 0-indexed, unlike normal arrays.
 	Int2Vector = &T{InternalType: InternalType{
 		Family: ArrayFamily, Oid: oid.T_int2vector, ArrayContents: Int2, Locale: &emptyLocale}}
 )


### PR DESCRIPTION
Backport 6/6 commits from #41323.

/cc @cockroachdb/release

---

- improve efficiency of `'foo'::REGCLASS`
- improve efficiency of `pg_get_coldesc`
- parse INTERVAL(6) as a no-op meaning INTERVAL
- bugfix to generate_subscripts for oidvector and int2vector
- add pg_available_extensions
- fix `pg_get_indexdef` and `pg_attrdef.adbin` to be more Postgres compatible

With these fixes, 90% of the fork in `activerecord-cockroachdb-adapter` can go away.
