### PR TITLE
acceptance: Skip TestComposeGSS

### DIFF
--- a/pkg/acceptance/compose_test.go
+++ b/pkg/acceptance/compose_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestComposeGSS(t *testing.T) {
+	t.Skip("#41318")
 	out, err := exec.Command(
 		"docker-compose",
 		"-f", filepath.Join("compose", "gss", "docker-compose.yml"),


### PR DESCRIPTION
This is a test-only change to skip the TestComposeGSS acceptance
test which is failing. See #41318.

Release note: None