### PR TITLE
sql: use a different error code for communication failure

### DIFF
--- a/pkg/sql/flowinfra/inbound.go
+++ b/pkg/sql/flowinfra/inbound.go
@@ -136,7 +136,7 @@ func processInboundStreamHelper(
 			if err != nil {
 				if err != io.EOF {
 					// Communication error.
-					err = pgerror.Newf(pgcode.ConnectionFailure, "communication error: %s", err)
+					err = pgerror.Newf(pgcode.InternalConnectionFailure, "communication error: %s", err)
 					sendErrToConsumer(err)
 					errChan <- err
 					return

--- a/pkg/sql/pgwire/pgcode/codes.go
+++ b/pkg/sql/pgwire/pgcode/codes.go
@@ -247,7 +247,7 @@ const (
 	CrashShutdown        = "57P02"
 	CannotConnectNow     = "57P03"
 	DatabaseDropped      = "57P04"
-	// Class 58 - System  (errors external to PostgreSQL itself)
+	// Class 58 - System
 	System        = "58000"
 	Io            = "58030"
 	UndefinedFile = "58P01"
@@ -301,11 +301,6 @@ const (
 	// when there's no code known yet.
 	Uncategorized = "XXUUU"
 
-	// RangeUnavailable signals that some data from the cluster cannot be
-	// accessed (e.g. because all replicas awol).
-	// We're using the postgres "Internal Error" error class "XX".
-	RangeUnavailable = "XXC00"
-
 	// CCLRequired signals that a CCL binary is required to complete this
 	// task.
 	CCLRequired = "XXC01"
@@ -332,4 +327,24 @@ const (
 	//       serious error with code "XXA00" occurred; if expected,
 	//       must use 'error pgcode XXA00 ...'
 	TransactionCommittedWithSchemaChangeFailure = "XXA00"
+
+	// Class 58C - System errors related to CockroachDB node problems.
+
+	// RangeUnavailable signals that some data from the cluster cannot be
+	// accessed (e.g. because all replicas awol).
+	// We're using the postgres "Internal Error" error class "XX".
+	RangeUnavailable = "58C00"
+	// DeprecatedRangeUnavailable is code that we used for RangeUnavailable until 19.2.
+	// 20.1 needs to recognize it coming from 19.2 nodes.
+	// TODO(andrei): remove in 20.2.
+	DeprecatedRangeUnavailable = "XXC00"
+
+	// InternalConnectionFailure refers to a networking error encountered
+	// internally on a connection between different Cockroach nodes.
+	InternalConnectionFailure = "58C01"
+	// DeprecatedInternalConnectionFailure is code that we used for
+	// InternalConnectionFailure until 19.2.
+	// 20.1 needs to recognize it coming from 19.2 nodes.
+	// TODO(andrei): remove in 20.2.
+	DeprecatedInternalConnectionFailure = "XXC03"
 )

--- a/pkg/sql/pgwire/pgcode/generate.sh
+++ b/pkg/sql/pgwire/pgcode/generate.sh
@@ -10,5 +10,8 @@ sed '/^\s*$/d' errcodes.txt |
 sed '/^#.*$/d' |
 sed -E 's|^(Section.*)$|// \1|' |
 sed -E 's|^([A-Z0-9]{5})    .    ERRCODE_([A-Z_]+).*$|\2 = "\1"|' |
+# Postgres uses class 58 just for external errors, but we've extended it with some errors
+# internal to the cluster (inspired by DB2).
+sed -E 's|// Section: Class 58 - System Error \(errors external to PostgreSQL itself\)|// Section: Class 58 - System Error|' |
 awk '{$1=tolower($1); print $0}' |
 perl -pe 's/(^|_)./uc($&)/ge;s/_//g' > errcodes.generated

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -219,10 +219,10 @@ func isPermanentSchemaChangeError(err error) bool {
 	}
 
 	switch pgerror.GetPGCode(err) {
-	case pgcode.SerializationFailure, pgcode.ConnectionFailure:
+	case pgcode.SerializationFailure, pgcode.InternalConnectionFailure, pgcode.DeprecatedInternalConnectionFailure:
 		return false
 
-	case pgcode.Internal, pgcode.RangeUnavailable:
+	case pgcode.Internal, pgcode.RangeUnavailable, pgcode.DeprecatedRangeUnavailable:
 		if strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
 			return false
 		}


### PR DESCRIPTION
Before this patch, DistSQL would use the the Postgres
ConnectionFailure code when a network stream between processors on
different nodes would break. This was the wrong code to use; Postgres
uses this code for trouble with the client connection, not internal
problems. There's evidence that middleware treats this code as a signal
to tear down a connection (#31645). This patch switches to a new,
CRDB-specific error code in the "internal error" class.

Fixes #31645

Release note: None