### PR TITLE
sql: clarify the handling of the first message in a remote DistSQL st…

### DIFF
--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -818,9 +818,13 @@ var _ flowinfra.InboundStreamHandler = vectorizedInboundStreamHandler{}
 func (s vectorizedInboundStreamHandler) Run(
 	ctx context.Context,
 	stream execinfrapb.DistSQL_FlowStreamServer,
-	_ *execinfrapb.ProducerMessage,
+	msg *execinfrapb.ProducerMessage,
 	_ *flowinfra.FlowBase,
 ) error {
+	if len(msg.Data.RawBytes) > 0 {
+		// TODO(andrei): We should accept data in the first message. See #41456.
+		return errors.AssertionFailedf("unexpected data in first message for vectorized stream")
+	}
 	return s.RunWithStream(ctx, stream)
 }
 


### PR DESCRIPTION
…ream

The first message in a stream is special; it includes a header
specifying whose the destination is, so it needs to be decoded before
handing it to the usual stream handling machinery. The row-based handler was
guarding unnecessarily for the case where it's not handed such a first
message. This commits removes this guard and clarifies that you always
have such a message.

Touches #41456

Release note: None