### PR TITLE
engine: Update MVCC tests to test both Pebble and RocksDB engines 

### DIFF
--- a/pkg/storage/engine/mvcc_logical_ops_test.go
+++ b/pkg/storage/engine/mvcc_logical_ops_test.go
@@ -26,143 +26,147 @@ import (
 func TestMVCCOpLogWriter(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	batch := engine.NewBatch()
-	ol := NewOpLoggerBatch(batch)
-	defer ol.Close()
+			batch := engine.NewBatch()
+			ol := NewOpLoggerBatch(batch)
+			defer ol.Close()
 
-	// Write a value and an intent.
-	if err := MVCCPut(ctx, ol, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, nil); err != nil {
-		t.Fatal(err)
-	}
-	txn1ts := makeTxn(*txn1, hlc.Timestamp{Logical: 2})
-	if err := MVCCPut(ctx, ol, nil, testKey1, txn1ts.OrigTimestamp, value2, txn1ts); err != nil {
-		t.Fatal(err)
-	}
+			// Write a value and an intent.
+			if err := MVCCPut(ctx, ol, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, nil); err != nil {
+				t.Fatal(err)
+			}
+			txn1ts := makeTxn(*txn1, hlc.Timestamp{Logical: 2})
+			if err := MVCCPut(ctx, ol, nil, testKey1, txn1ts.OrigTimestamp, value2, txn1ts); err != nil {
+				t.Fatal(err)
+			}
 
-	// Write a value and an intent on local keys.
-	localKey := keys.MakeRangeIDPrefix(1)
-	if err := MVCCPut(ctx, ol, nil, localKey, hlc.Timestamp{Logical: 1}, value1, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, ol, nil, localKey, txn1ts.OrigTimestamp, value2, txn1ts); err != nil {
-		t.Fatal(err)
-	}
+			// Write a value and an intent on local keys.
+			localKey := keys.MakeRangeIDPrefix(1)
+			if err := MVCCPut(ctx, ol, nil, localKey, hlc.Timestamp{Logical: 1}, value1, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, ol, nil, localKey, txn1ts.OrigTimestamp, value2, txn1ts); err != nil {
+				t.Fatal(err)
+			}
 
-	// Update the intents and write another. Use a distinct batch.
-	olDist := ol.Distinct()
-	txn1ts.Sequence++
-	txn1ts.Timestamp = hlc.Timestamp{Logical: 3}
-	if err := MVCCPut(ctx, olDist, nil, testKey1, txn1ts.OrigTimestamp, value2, txn1ts); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, olDist, nil, localKey, txn1ts.OrigTimestamp, value2, txn1ts); err != nil {
-		t.Fatal(err)
-	}
-	// Set the txn timestamp to a larger value than the intent.
-	txn1LargerTS := makeTxn(*txn1, hlc.Timestamp{Logical: 4})
-	txn1LargerTS.Timestamp = hlc.Timestamp{Logical: 4}
-	if err := MVCCPut(ctx, olDist, nil, testKey2, txn1LargerTS.OrigTimestamp, value3, txn1LargerTS); err != nil {
-		t.Fatal(err)
-	}
-	olDist.Close()
+			// Update the intents and write another. Use a distinct batch.
+			olDist := ol.Distinct()
+			txn1ts.Sequence++
+			txn1ts.Timestamp = hlc.Timestamp{Logical: 3}
+			if err := MVCCPut(ctx, olDist, nil, testKey1, txn1ts.OrigTimestamp, value2, txn1ts); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, olDist, nil, localKey, txn1ts.OrigTimestamp, value2, txn1ts); err != nil {
+				t.Fatal(err)
+			}
+			// Set the txn timestamp to a larger value than the intent.
+			txn1LargerTS := makeTxn(*txn1, hlc.Timestamp{Logical: 4})
+			txn1LargerTS.Timestamp = hlc.Timestamp{Logical: 4}
+			if err := MVCCPut(ctx, olDist, nil, testKey2, txn1LargerTS.OrigTimestamp, value3, txn1LargerTS); err != nil {
+				t.Fatal(err)
+			}
+			olDist.Close()
 
-	// Resolve all three intent.
-	txn1CommitTS := *txn1Commit
-	txn1CommitTS.Timestamp = hlc.Timestamp{Logical: 4}
-	if _, _, err := MVCCResolveWriteIntentRange(ctx, ol, nil, roachpb.Intent{
-		Span:   roachpb.Span{Key: testKey1, EndKey: testKey2.Next()},
-		Txn:    txn1CommitTS.TxnMeta,
-		Status: txn1CommitTS.Status,
-	}, math.MaxInt64); err != nil {
-		t.Fatal(err)
-	}
-	if _, _, err := MVCCResolveWriteIntentRange(ctx, ol, nil, roachpb.Intent{
-		Span:   roachpb.Span{Key: localKey, EndKey: localKey.Next()},
-		Txn:    txn1CommitTS.TxnMeta,
-		Status: txn1CommitTS.Status,
-	}, math.MaxInt64); err != nil {
-		t.Fatal(err)
-	}
+			// Resolve all three intent.
+			txn1CommitTS := *txn1Commit
+			txn1CommitTS.Timestamp = hlc.Timestamp{Logical: 4}
+			if _, _, err := MVCCResolveWriteIntentRange(ctx, ol, nil, roachpb.Intent{
+				Span:   roachpb.Span{Key: testKey1, EndKey: testKey2.Next()},
+				Txn:    txn1CommitTS.TxnMeta,
+				Status: txn1CommitTS.Status,
+			}, math.MaxInt64); err != nil {
+				t.Fatal(err)
+			}
+			if _, _, err := MVCCResolveWriteIntentRange(ctx, ol, nil, roachpb.Intent{
+				Span:   roachpb.Span{Key: localKey, EndKey: localKey.Next()},
+				Txn:    txn1CommitTS.TxnMeta,
+				Status: txn1CommitTS.Status,
+			}, math.MaxInt64); err != nil {
+				t.Fatal(err)
+			}
 
-	// Write another intent, push it, then abort it.
-	txn2ts := makeTxn(*txn2, hlc.Timestamp{Logical: 5})
-	if err := MVCCPut(ctx, ol, nil, testKey3, txn2ts.OrigTimestamp, value4, txn2ts); err != nil {
-		t.Fatal(err)
-	}
-	txn2Pushed := *txn2
-	txn2Pushed.Timestamp = hlc.Timestamp{Logical: 6}
-	if err := MVCCResolveWriteIntent(ctx, ol, nil, roachpb.Intent{
-		Span:   roachpb.Span{Key: testKey3},
-		Txn:    txn2Pushed.TxnMeta,
-		Status: txn2Pushed.Status,
-	}); err != nil {
-		t.Fatal(err)
-	}
-	txn2Abort := txn2Pushed
-	txn2Abort.Status = roachpb.ABORTED
-	if err := MVCCResolveWriteIntent(ctx, ol, nil, roachpb.Intent{
-		Span:   roachpb.Span{Key: testKey3},
-		Txn:    txn2Abort.TxnMeta,
-		Status: txn2Abort.Status,
-	}); err != nil {
-		t.Fatal(err)
-	}
+			// Write another intent, push it, then abort it.
+			txn2ts := makeTxn(*txn2, hlc.Timestamp{Logical: 5})
+			if err := MVCCPut(ctx, ol, nil, testKey3, txn2ts.OrigTimestamp, value4, txn2ts); err != nil {
+				t.Fatal(err)
+			}
+			txn2Pushed := *txn2
+			txn2Pushed.Timestamp = hlc.Timestamp{Logical: 6}
+			if err := MVCCResolveWriteIntent(ctx, ol, nil, roachpb.Intent{
+				Span:   roachpb.Span{Key: testKey3},
+				Txn:    txn2Pushed.TxnMeta,
+				Status: txn2Pushed.Status,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			txn2Abort := txn2Pushed
+			txn2Abort.Status = roachpb.ABORTED
+			if err := MVCCResolveWriteIntent(ctx, ol, nil, roachpb.Intent{
+				Span:   roachpb.Span{Key: testKey3},
+				Txn:    txn2Abort.TxnMeta,
+				Status: txn2Abort.Status,
+			}); err != nil {
+				t.Fatal(err)
+			}
 
-	// Verify that the recorded logical ops match expectations.
-	makeOp := func(val interface{}) enginepb.MVCCLogicalOp {
-		var op enginepb.MVCCLogicalOp
-		op.MustSetValue(val)
-		return op
-	}
-	exp := []enginepb.MVCCLogicalOp{
-		makeOp(&enginepb.MVCCWriteValueOp{
-			Key:       testKey1,
-			Timestamp: hlc.Timestamp{Logical: 1},
-		}),
-		makeOp(&enginepb.MVCCWriteIntentOp{
-			TxnID:           txn1.ID,
-			TxnKey:          txn1.Key,
-			TxnMinTimestamp: txn1.MinTimestamp,
-			Timestamp:       hlc.Timestamp{Logical: 2},
-		}),
-		makeOp(&enginepb.MVCCUpdateIntentOp{
-			TxnID:     txn1.ID,
-			Timestamp: hlc.Timestamp{Logical: 3},
-		}),
-		makeOp(&enginepb.MVCCWriteIntentOp{
-			TxnID:           txn1.ID,
-			TxnKey:          txn1.Key,
-			TxnMinTimestamp: txn1.MinTimestamp,
-			Timestamp:       hlc.Timestamp{Logical: 4},
-		}),
-		makeOp(&enginepb.MVCCCommitIntentOp{
-			TxnID:     txn1.ID,
-			Key:       testKey1,
-			Timestamp: hlc.Timestamp{Logical: 4},
-		}),
-		makeOp(&enginepb.MVCCCommitIntentOp{
-			TxnID:     txn1.ID,
-			Key:       testKey2,
-			Timestamp: hlc.Timestamp{Logical: 4},
-		}),
-		makeOp(&enginepb.MVCCWriteIntentOp{
-			TxnID:           txn2.ID,
-			TxnKey:          txn2.Key,
-			TxnMinTimestamp: txn2.MinTimestamp,
-			Timestamp:       hlc.Timestamp{Logical: 5},
-		}),
-		makeOp(&enginepb.MVCCUpdateIntentOp{
-			TxnID:     txn2.ID,
-			Timestamp: hlc.Timestamp{Logical: 6},
-		}),
-		makeOp(&enginepb.MVCCAbortIntentOp{
-			TxnID: txn2.ID,
-		}),
-	}
-	if ops := ol.LogicalOps(); !reflect.DeepEqual(exp, ops) {
-		t.Errorf("expected logical ops %+v, found %+v", exp, ops)
+			// Verify that the recorded logical ops match expectations.
+			makeOp := func(val interface{}) enginepb.MVCCLogicalOp {
+				var op enginepb.MVCCLogicalOp
+				op.MustSetValue(val)
+				return op
+			}
+			exp := []enginepb.MVCCLogicalOp{
+				makeOp(&enginepb.MVCCWriteValueOp{
+					Key:       testKey1,
+					Timestamp: hlc.Timestamp{Logical: 1},
+				}),
+				makeOp(&enginepb.MVCCWriteIntentOp{
+					TxnID:           txn1.ID,
+					TxnKey:          txn1.Key,
+					TxnMinTimestamp: txn1.MinTimestamp,
+					Timestamp:       hlc.Timestamp{Logical: 2},
+				}),
+				makeOp(&enginepb.MVCCUpdateIntentOp{
+					TxnID:     txn1.ID,
+					Timestamp: hlc.Timestamp{Logical: 3},
+				}),
+				makeOp(&enginepb.MVCCWriteIntentOp{
+					TxnID:           txn1.ID,
+					TxnKey:          txn1.Key,
+					TxnMinTimestamp: txn1.MinTimestamp,
+					Timestamp:       hlc.Timestamp{Logical: 4},
+				}),
+				makeOp(&enginepb.MVCCCommitIntentOp{
+					TxnID:     txn1.ID,
+					Key:       testKey1,
+					Timestamp: hlc.Timestamp{Logical: 4},
+				}),
+				makeOp(&enginepb.MVCCCommitIntentOp{
+					TxnID:     txn1.ID,
+					Key:       testKey2,
+					Timestamp: hlc.Timestamp{Logical: 4},
+				}),
+				makeOp(&enginepb.MVCCWriteIntentOp{
+					TxnID:           txn2.ID,
+					TxnKey:          txn2.Key,
+					TxnMinTimestamp: txn2.MinTimestamp,
+					Timestamp:       hlc.Timestamp{Logical: 5},
+				}),
+				makeOp(&enginepb.MVCCUpdateIntentOp{
+					TxnID:     txn2.ID,
+					Timestamp: hlc.Timestamp{Logical: 6},
+				}),
+				makeOp(&enginepb.MVCCAbortIntentOp{
+					TxnID: txn2.ID,
+				}),
+			}
+			if ops := ol.LogicalOps(); !reflect.DeepEqual(exp, ops) {
+				t.Errorf("expected logical ops %+v, found %+v", exp, ops)
+			}
+		})
 	}
 }

--- a/pkg/storage/engine/mvcc_stats_test.go
+++ b/pkg/storage/engine/mvcc_stats_test.go
@@ -65,73 +65,77 @@ func assertEq(t *testing.T, engine ReadWriter, debug string, ms, expMS *enginepb
 // the intent (before resolution) and the accumulation of GCByteAge.
 func TestMVCCStatsDeleteCommitMovesTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	ctx := context.Background()
-	aggMS := &enginepb.MVCCStats{}
+			ctx := context.Background()
+			aggMS := &enginepb.MVCCStats{}
 
-	assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
+			assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
 
-	key := roachpb.Key("a")
-	ts1 := hlc.Timestamp{WallTime: 1E9}
-	// Put a value.
-	value := roachpb.MakeValueFromString("value")
-	if err := MVCCPut(ctx, engine, aggMS, key, ts1, value, nil); err != nil {
-		t.Fatal(err)
+			key := roachpb.Key("a")
+			ts1 := hlc.Timestamp{WallTime: 1E9}
+			// Put a value.
+			value := roachpb.MakeValueFromString("value")
+			if err := MVCCPut(ctx, engine, aggMS, key, ts1, value, nil); err != nil {
+				t.Fatal(err)
+			}
+
+			mKeySize := int64(mvccKey(key).EncodedSize()) // 2
+			vKeySize := MVCCVersionTimestampSize          // 12
+			vValSize := int64(len(value.RawBytes))        // 10
+
+			expMS := enginepb.MVCCStats{
+				LiveBytes:       mKeySize + vKeySize + vValSize, // 24
+				LiveCount:       1,
+				KeyBytes:        mKeySize + vKeySize, // 14
+				KeyCount:        1,
+				ValBytes:        vValSize, // 10
+				ValCount:        1,
+				LastUpdateNanos: 1E9,
+			}
+			assertEq(t, engine, "after put", aggMS, &expMS)
+
+			// Delete the value at ts=3. We'll commit this at ts=4 later.
+			ts3 := hlc.Timestamp{WallTime: 3 * 1E9}
+			txn := &roachpb.Transaction{
+				TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts3},
+				OrigTimestamp: ts3,
+			}
+			if err := MVCCDelete(ctx, engine, aggMS, key, txn.OrigTimestamp, txn); err != nil {
+				t.Fatal(err)
+			}
+
+			// Now commit the value, but with a timestamp gap (i.e. this is a
+			// push-commit as it would happen for a SNAPSHOT txn)
+			ts4 := hlc.Timestamp{WallTime: 4 * 1E9}
+			txn.Status = roachpb.COMMITTED
+			txn.Timestamp.Forward(ts4)
+			if err := MVCCResolveWriteIntent(ctx, engine, aggMS, roachpb.Intent{
+				Span: roachpb.Span{Key: key}, Status: txn.Status, Txn: txn.TxnMeta,
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			expAggMS := enginepb.MVCCStats{
+				LastUpdateNanos: 4E9,
+				LiveBytes:       0,
+				LiveCount:       0,
+				KeyCount:        1,
+				ValCount:        2,
+				// The implicit meta record (deletion tombstone) counts for len("a")+1=2.
+				// Two versioned keys count for 2*vKeySize.
+				KeyBytes: mKeySize + 2*vKeySize,
+				ValBytes: vValSize, // the initial write (10)
+				// No GCBytesAge has been accrued yet, as the value just got non-live at 4s.
+				GCBytesAge: 0,
+			}
+
+			assertEq(t, engine, "after committing", aggMS, &expAggMS)
+		})
 	}
-
-	mKeySize := int64(mvccKey(key).EncodedSize()) // 2
-	vKeySize := MVCCVersionTimestampSize          // 12
-	vValSize := int64(len(value.RawBytes))        // 10
-
-	expMS := enginepb.MVCCStats{
-		LiveBytes:       mKeySize + vKeySize + vValSize, // 24
-		LiveCount:       1,
-		KeyBytes:        mKeySize + vKeySize, // 14
-		KeyCount:        1,
-		ValBytes:        vValSize, // 10
-		ValCount:        1,
-		LastUpdateNanos: 1E9,
-	}
-	assertEq(t, engine, "after put", aggMS, &expMS)
-
-	// Delete the value at ts=3. We'll commit this at ts=4 later.
-	ts3 := hlc.Timestamp{WallTime: 3 * 1E9}
-	txn := &roachpb.Transaction{
-		TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts3},
-		OrigTimestamp: ts3,
-	}
-	if err := MVCCDelete(ctx, engine, aggMS, key, txn.OrigTimestamp, txn); err != nil {
-		t.Fatal(err)
-	}
-
-	// Now commit the value, but with a timestamp gap (i.e. this is a
-	// push-commit as it would happen for a SNAPSHOT txn)
-	ts4 := hlc.Timestamp{WallTime: 4 * 1E9}
-	txn.Status = roachpb.COMMITTED
-	txn.Timestamp.Forward(ts4)
-	if err := MVCCResolveWriteIntent(ctx, engine, aggMS, roachpb.Intent{
-		Span: roachpb.Span{Key: key}, Status: txn.Status, Txn: txn.TxnMeta,
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	expAggMS := enginepb.MVCCStats{
-		LastUpdateNanos: 4E9,
-		LiveBytes:       0,
-		LiveCount:       0,
-		KeyCount:        1,
-		ValCount:        2,
-		// The implicit meta record (deletion tombstone) counts for len("a")+1=2.
-		// Two versioned keys count for 2*vKeySize.
-		KeyBytes: mKeySize + 2*vKeySize,
-		ValBytes: vValSize, // the initial write (10)
-		// No GCBytesAge has been accrued yet, as the value just got non-live at 4s.
-		GCBytesAge: 0,
-	}
-
-	assertEq(t, engine, "after committing", aggMS, &expAggMS)
 }
 
 // TestMVCCStatsPutCommitMovesTimestamp is similar to
@@ -139,74 +143,78 @@ func TestMVCCStatsDeleteCommitMovesTimestamp(t *testing.T) {
 // written and then committed at a later timestamp.
 func TestMVCCStatsPutCommitMovesTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	ctx := context.Background()
-	aggMS := &enginepb.MVCCStats{}
+			ctx := context.Background()
+			aggMS := &enginepb.MVCCStats{}
 
-	assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
+			assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
 
-	key := roachpb.Key("a")
-	ts1 := hlc.Timestamp{WallTime: 1E9}
-	txn := &roachpb.Transaction{
-		TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts1},
-		OrigTimestamp: ts1,
+			key := roachpb.Key("a")
+			ts1 := hlc.Timestamp{WallTime: 1E9}
+			txn := &roachpb.Transaction{
+				TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts1},
+				OrigTimestamp: ts1,
+			}
+			// Write an intent at t=1s.
+			value := roachpb.MakeValueFromString("value")
+			if err := MVCCPut(ctx, engine, aggMS, key, ts1, value, txn); err != nil {
+				t.Fatal(err)
+			}
+
+			mKeySize := int64(mvccKey(key).EncodedSize()) // 2
+			mValSize := int64((&enginepb.MVCCMetadata{    // 44
+				Timestamp: hlc.LegacyTimestamp(ts1),
+				Deleted:   false,
+				Txn:       &txn.TxnMeta,
+			}).Size())
+			vKeySize := MVCCVersionTimestampSize   // 12
+			vValSize := int64(len(value.RawBytes)) // 10
+
+			expMS := enginepb.MVCCStats{
+				LastUpdateNanos: 1E9,
+				LiveBytes:       mKeySize + mValSize + vKeySize + vValSize, // 2+44+12+10 = 68
+				LiveCount:       1,
+				KeyBytes:        mKeySize + vKeySize, // 2+12 =14
+				KeyCount:        1,
+				ValBytes:        mValSize + vValSize, // 44+10 = 54
+				ValCount:        1,
+				IntentCount:     1,
+				IntentBytes:     vKeySize + vValSize, // 12+10 = 22
+				GCBytesAge:      0,
+			}
+			assertEq(t, engine, "after put", aggMS, &expMS)
+
+			// Now commit the intent, but with a timestamp gap (i.e. this is a
+			// push-commit as it would happen for a SNAPSHOT txn)
+			ts4 := hlc.Timestamp{WallTime: 4 * 1E9}
+			txn.Status = roachpb.COMMITTED
+			txn.Timestamp.Forward(ts4)
+			if err := MVCCResolveWriteIntent(ctx, engine, aggMS, roachpb.Intent{
+				Span: roachpb.Span{Key: key}, Status: txn.Status, Txn: txn.TxnMeta,
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			expAggMS := enginepb.MVCCStats{
+				LastUpdateNanos: 4E9,
+				LiveBytes:       mKeySize + vKeySize + vValSize, // 2+12+20 = 24
+				LiveCount:       1,
+				KeyCount:        1,
+				ValCount:        1,
+				// The implicit meta record counts for len("a")+1=2.
+				// One versioned key counts for vKeySize.
+				KeyBytes:   mKeySize + vKeySize,
+				ValBytes:   vValSize,
+				GCBytesAge: 0, // this was once erroneously negative
+			}
+
+			assertEq(t, engine, "after committing", aggMS, &expAggMS)
+		})
 	}
-	// Write an intent at t=1s.
-	value := roachpb.MakeValueFromString("value")
-	if err := MVCCPut(ctx, engine, aggMS, key, ts1, value, txn); err != nil {
-		t.Fatal(err)
-	}
-
-	mKeySize := int64(mvccKey(key).EncodedSize()) // 2
-	mValSize := int64((&enginepb.MVCCMetadata{    // 44
-		Timestamp: hlc.LegacyTimestamp(ts1),
-		Deleted:   false,
-		Txn:       &txn.TxnMeta,
-	}).Size())
-	vKeySize := MVCCVersionTimestampSize   // 12
-	vValSize := int64(len(value.RawBytes)) // 10
-
-	expMS := enginepb.MVCCStats{
-		LastUpdateNanos: 1E9,
-		LiveBytes:       mKeySize + mValSize + vKeySize + vValSize, // 2+44+12+10 = 68
-		LiveCount:       1,
-		KeyBytes:        mKeySize + vKeySize, // 2+12 =14
-		KeyCount:        1,
-		ValBytes:        mValSize + vValSize, // 44+10 = 54
-		ValCount:        1,
-		IntentCount:     1,
-		IntentBytes:     vKeySize + vValSize, // 12+10 = 22
-		GCBytesAge:      0,
-	}
-	assertEq(t, engine, "after put", aggMS, &expMS)
-
-	// Now commit the intent, but with a timestamp gap (i.e. this is a
-	// push-commit as it would happen for a SNAPSHOT txn)
-	ts4 := hlc.Timestamp{WallTime: 4 * 1E9}
-	txn.Status = roachpb.COMMITTED
-	txn.Timestamp.Forward(ts4)
-	if err := MVCCResolveWriteIntent(ctx, engine, aggMS, roachpb.Intent{
-		Span: roachpb.Span{Key: key}, Status: txn.Status, Txn: txn.TxnMeta,
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	expAggMS := enginepb.MVCCStats{
-		LastUpdateNanos: 4E9,
-		LiveBytes:       mKeySize + vKeySize + vValSize, // 2+12+20 = 24
-		LiveCount:       1,
-		KeyCount:        1,
-		ValCount:        1,
-		// The implicit meta record counts for len("a")+1=2.
-		// One versioned key counts for vKeySize.
-		KeyBytes:   mKeySize + vKeySize,
-		ValBytes:   vValSize,
-		GCBytesAge: 0, // this was once erroneously negative
-	}
-
-	assertEq(t, engine, "after committing", aggMS, &expAggMS)
 }
 
 // TestMVCCStatsPutPushMovesTimestamp is similar to TestMVCCStatsPutCommitMovesTimestamp:
@@ -214,76 +222,80 @@ func TestMVCCStatsPutCommitMovesTimestamp(t *testing.T) {
 // the IntentAge computation.
 func TestMVCCStatsPutPushMovesTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	ctx := context.Background()
-	aggMS := &enginepb.MVCCStats{}
+			ctx := context.Background()
+			aggMS := &enginepb.MVCCStats{}
 
-	assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
+			assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
 
-	key := roachpb.Key("a")
-	ts1 := hlc.Timestamp{WallTime: 1E9}
-	txn := &roachpb.Transaction{
-		TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts1},
-		OrigTimestamp: ts1,
+			key := roachpb.Key("a")
+			ts1 := hlc.Timestamp{WallTime: 1E9}
+			txn := &roachpb.Transaction{
+				TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts1},
+				OrigTimestamp: ts1,
+			}
+			// Write an intent.
+			value := roachpb.MakeValueFromString("value")
+			if err := MVCCPut(ctx, engine, aggMS, key, txn.OrigTimestamp, value, txn); err != nil {
+				t.Fatal(err)
+			}
+
+			mKeySize := int64(mvccKey(key).EncodedSize()) // 2
+			mValSize := int64((&enginepb.MVCCMetadata{    // 44
+				Timestamp: hlc.LegacyTimestamp(ts1),
+				Deleted:   false,
+				Txn:       &txn.TxnMeta,
+			}).Size())
+			vKeySize := MVCCVersionTimestampSize   // 12
+			vValSize := int64(len(value.RawBytes)) // 10
+
+			expMS := enginepb.MVCCStats{
+				LastUpdateNanos: 1E9,
+				LiveBytes:       mKeySize + mValSize + vKeySize + vValSize, // 2+44+12+10 = 68
+				LiveCount:       1,
+				KeyBytes:        mKeySize + vKeySize, // 2+12 = 14
+				KeyCount:        1,
+				ValBytes:        mValSize + vValSize, // 44+10 = 54
+				ValCount:        1,
+				IntentAge:       0,
+				IntentCount:     1,
+				IntentBytes:     vKeySize + vValSize, // 12+10 = 22
+			}
+			assertEq(t, engine, "after put", aggMS, &expMS)
+
+			// Now push the value, but with a timestamp gap (i.e. this is a
+			// push as it would happen for a SNAPSHOT txn)
+			ts4 := hlc.Timestamp{WallTime: 4 * 1E9}
+			txn.Timestamp.Forward(ts4)
+			if err := MVCCResolveWriteIntent(ctx, engine, aggMS, roachpb.Intent{
+				Span: roachpb.Span{Key: key}, Status: txn.Status, Txn: txn.TxnMeta,
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			expAggMS := enginepb.MVCCStats{
+				LastUpdateNanos: 4E9,
+				LiveBytes:       mKeySize + mValSize + vKeySize + vValSize, // 2+44+12+20 = 78
+				LiveCount:       1,
+				KeyCount:        1,
+				ValCount:        1,
+				// The explicit meta record counts for len("a")+1=2.
+				// One versioned key counts for vKeySize.
+				KeyBytes: mKeySize + vKeySize,
+				// The intent is still there, so we see mValSize.
+				ValBytes:    vValSize + mValSize, // 44+10 = 54
+				IntentAge:   0,                   // this was once erroneously positive
+				IntentCount: 1,                   // still there
+				IntentBytes: vKeySize + vValSize, // still there
+			}
+
+			assertEq(t, engine, "after pushing", aggMS, &expAggMS)
+		})
 	}
-	// Write an intent.
-	value := roachpb.MakeValueFromString("value")
-	if err := MVCCPut(ctx, engine, aggMS, key, txn.OrigTimestamp, value, txn); err != nil {
-		t.Fatal(err)
-	}
-
-	mKeySize := int64(mvccKey(key).EncodedSize()) // 2
-	mValSize := int64((&enginepb.MVCCMetadata{    // 44
-		Timestamp: hlc.LegacyTimestamp(ts1),
-		Deleted:   false,
-		Txn:       &txn.TxnMeta,
-	}).Size())
-	vKeySize := MVCCVersionTimestampSize   // 12
-	vValSize := int64(len(value.RawBytes)) // 10
-
-	expMS := enginepb.MVCCStats{
-		LastUpdateNanos: 1E9,
-		LiveBytes:       mKeySize + mValSize + vKeySize + vValSize, // 2+44+12+10 = 68
-		LiveCount:       1,
-		KeyBytes:        mKeySize + vKeySize, // 2+12 = 14
-		KeyCount:        1,
-		ValBytes:        mValSize + vValSize, // 44+10 = 54
-		ValCount:        1,
-		IntentAge:       0,
-		IntentCount:     1,
-		IntentBytes:     vKeySize + vValSize, // 12+10 = 22
-	}
-	assertEq(t, engine, "after put", aggMS, &expMS)
-
-	// Now push the value, but with a timestamp gap (i.e. this is a
-	// push as it would happen for a SNAPSHOT txn)
-	ts4 := hlc.Timestamp{WallTime: 4 * 1E9}
-	txn.Timestamp.Forward(ts4)
-	if err := MVCCResolveWriteIntent(ctx, engine, aggMS, roachpb.Intent{
-		Span: roachpb.Span{Key: key}, Status: txn.Status, Txn: txn.TxnMeta,
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	expAggMS := enginepb.MVCCStats{
-		LastUpdateNanos: 4E9,
-		LiveBytes:       mKeySize + mValSize + vKeySize + vValSize, // 2+44+12+20 = 78
-		LiveCount:       1,
-		KeyCount:        1,
-		ValCount:        1,
-		// The explicit meta record counts for len("a")+1=2.
-		// One versioned key counts for vKeySize.
-		KeyBytes: mKeySize + vKeySize,
-		// The intent is still there, so we see mValSize.
-		ValBytes:    vValSize + mValSize, // 44+10 = 54
-		IntentAge:   0,                   // this was once erroneously positive
-		IntentCount: 1,                   // still there
-		IntentBytes: vKeySize + vValSize, // still there
-	}
-
-	assertEq(t, engine, "after pushing", aggMS, &expAggMS)
 }
 
 // TestMVCCStatsDeleteMovesTimestamp is similar to TestMVCCStatsPutCommitMovesTimestamp:
@@ -291,107 +303,111 @@ func TestMVCCStatsPutPushMovesTimestamp(t *testing.T) {
 // the GCBytesAge computation.
 func TestMVCCStatsDeleteMovesTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	ctx := context.Background()
-	aggMS := &enginepb.MVCCStats{}
+			ctx := context.Background()
+			aggMS := &enginepb.MVCCStats{}
 
-	assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
+			assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
 
-	ts1 := hlc.Timestamp{WallTime: 1E9}
-	ts2 := hlc.Timestamp{WallTime: 2 * 1E9}
+			ts1 := hlc.Timestamp{WallTime: 1E9}
+			ts2 := hlc.Timestamp{WallTime: 2 * 1E9}
 
-	key := roachpb.Key("a")
-	txn := &roachpb.Transaction{
-		TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts1},
-		OrigTimestamp: ts1,
+			key := roachpb.Key("a")
+			txn := &roachpb.Transaction{
+				TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts1},
+				OrigTimestamp: ts1,
+			}
+
+			// Write an intent.
+			value := roachpb.MakeValueFromString("value")
+			if err := MVCCPut(ctx, engine, aggMS, key, txn.OrigTimestamp, value, txn); err != nil {
+				t.Fatal(err)
+			}
+
+			mKeySize := int64(mvccKey(key).EncodedSize())
+			require.EqualValues(t, mKeySize, 2)
+
+			mVal1Size := int64((&enginepb.MVCCMetadata{
+				Timestamp: hlc.LegacyTimestamp(ts1),
+				Deleted:   false,
+				Txn:       &txn.TxnMeta,
+			}).Size())
+			require.EqualValues(t, mVal1Size, 46)
+
+			m1ValSize := int64((&enginepb.MVCCMetadata{
+				Timestamp: hlc.LegacyTimestamp(ts2),
+				Deleted:   false,
+				Txn:       &txn.TxnMeta,
+			}).Size())
+			require.EqualValues(t, m1ValSize, 46)
+
+			vKeySize := MVCCVersionTimestampSize
+			require.EqualValues(t, vKeySize, 12)
+
+			vValSize := int64(len(value.RawBytes))
+			require.EqualValues(t, vValSize, 10)
+
+			expMS := enginepb.MVCCStats{
+				LastUpdateNanos: 1E9,
+				LiveBytes:       mKeySize + m1ValSize + vKeySize + vValSize, // 2+44+12+10 = 68
+				LiveCount:       1,
+				KeyBytes:        mKeySize + vKeySize, // 2+12 = 14
+				KeyCount:        1,
+				ValBytes:        mVal1Size + vValSize, // 44+10 = 54
+				ValCount:        1,
+				IntentAge:       0,
+				IntentCount:     1,
+				IntentBytes:     vKeySize + vValSize, // 12+10 = 22
+			}
+			assertEq(t, engine, "after put", aggMS, &expMS)
+
+			// Now replace our intent with a deletion intent, but with a timestamp gap.
+			// This could happen if a transaction got restarted with a higher timestamp
+			// and ran logic different from that in the first attempt.
+			txn.Timestamp.Forward(ts2)
+
+			txn.Sequence++
+
+			// Annoyingly, the new meta value is actually a little larger thanks to the
+			// sequence number. Also since there was a write previously on the same
+			// transaction, the IntentHistory will add a few bytes to the metadata.
+			m2ValSize := int64((&enginepb.MVCCMetadata{
+				Timestamp: hlc.LegacyTimestamp(ts2),
+				Txn:       &txn.TxnMeta,
+				IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
+					{Sequence: 0, Value: value.RawBytes},
+				},
+			}).Size())
+			require.EqualValues(t, m2ValSize, 64)
+
+			if err := MVCCDelete(ctx, engine, aggMS, key, txn.OrigTimestamp, txn); err != nil {
+				t.Fatal(err)
+			}
+
+			expAggMS := enginepb.MVCCStats{
+				LastUpdateNanos: 2E9,
+				LiveBytes:       0,
+				LiveCount:       0,
+				KeyCount:        1,
+				ValCount:        1,
+				// The explicit meta record counts for len("a")+1=2.
+				// One versioned key counts for vKeySize.
+				KeyBytes: mKeySize + vKeySize,
+				// The intent is still there, but this time with mVal2Size, and a zero vValSize.
+				ValBytes:    m2ValSize, // 10+46 = 56
+				IntentAge:   0,
+				IntentCount: 1,        // still there
+				IntentBytes: vKeySize, // still there, but now without vValSize
+				GCBytesAge:  0,        // this was once erroneously negative
+			}
+
+			assertEq(t, engine, "after deleting", aggMS, &expAggMS)
+		})
 	}
-
-	// Write an intent.
-	value := roachpb.MakeValueFromString("value")
-	if err := MVCCPut(ctx, engine, aggMS, key, txn.OrigTimestamp, value, txn); err != nil {
-		t.Fatal(err)
-	}
-
-	mKeySize := int64(mvccKey(key).EncodedSize())
-	require.EqualValues(t, mKeySize, 2)
-
-	mVal1Size := int64((&enginepb.MVCCMetadata{
-		Timestamp: hlc.LegacyTimestamp(ts1),
-		Deleted:   false,
-		Txn:       &txn.TxnMeta,
-	}).Size())
-	require.EqualValues(t, mVal1Size, 46)
-
-	m1ValSize := int64((&enginepb.MVCCMetadata{
-		Timestamp: hlc.LegacyTimestamp(ts2),
-		Deleted:   false,
-		Txn:       &txn.TxnMeta,
-	}).Size())
-	require.EqualValues(t, m1ValSize, 46)
-
-	vKeySize := MVCCVersionTimestampSize
-	require.EqualValues(t, vKeySize, 12)
-
-	vValSize := int64(len(value.RawBytes))
-	require.EqualValues(t, vValSize, 10)
-
-	expMS := enginepb.MVCCStats{
-		LastUpdateNanos: 1E9,
-		LiveBytes:       mKeySize + m1ValSize + vKeySize + vValSize, // 2+44+12+10 = 68
-		LiveCount:       1,
-		KeyBytes:        mKeySize + vKeySize, // 2+12 = 14
-		KeyCount:        1,
-		ValBytes:        mVal1Size + vValSize, // 44+10 = 54
-		ValCount:        1,
-		IntentAge:       0,
-		IntentCount:     1,
-		IntentBytes:     vKeySize + vValSize, // 12+10 = 22
-	}
-	assertEq(t, engine, "after put", aggMS, &expMS)
-
-	// Now replace our intent with a deletion intent, but with a timestamp gap.
-	// This could happen if a transaction got restarted with a higher timestamp
-	// and ran logic different from that in the first attempt.
-	txn.Timestamp.Forward(ts2)
-
-	txn.Sequence++
-
-	// Annoyingly, the new meta value is actually a little larger thanks to the
-	// sequence number. Also since there was a write previously on the same
-	// transaction, the IntentHistory will add a few bytes to the metadata.
-	m2ValSize := int64((&enginepb.MVCCMetadata{
-		Timestamp: hlc.LegacyTimestamp(ts2),
-		Txn:       &txn.TxnMeta,
-		IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
-			{Sequence: 0, Value: value.RawBytes},
-		},
-	}).Size())
-	require.EqualValues(t, m2ValSize, 64)
-
-	if err := MVCCDelete(ctx, engine, aggMS, key, txn.OrigTimestamp, txn); err != nil {
-		t.Fatal(err)
-	}
-
-	expAggMS := enginepb.MVCCStats{
-		LastUpdateNanos: 2E9,
-		LiveBytes:       0,
-		LiveCount:       0,
-		KeyCount:        1,
-		ValCount:        1,
-		// The explicit meta record counts for len("a")+1=2.
-		// One versioned key counts for vKeySize.
-		KeyBytes: mKeySize + vKeySize,
-		// The intent is still there, but this time with mVal2Size, and a zero vValSize.
-		ValBytes:    m2ValSize, // 10+46 = 56
-		IntentAge:   0,
-		IntentCount: 1,        // still there
-		IntentBytes: vKeySize, // still there, but now without vValSize
-		GCBytesAge:  0,        // this was once erroneously negative
-	}
-
-	assertEq(t, engine, "after deleting", aggMS, &expAggMS)
 }
 
 // TestMVCCStatsPutMovesDeletionTimestamp is similar to TestMVCCStatsPutCommitMovesTimestamp: A
@@ -399,109 +415,113 @@ func TestMVCCStatsDeleteMovesTimestamp(t *testing.T) {
 // formerly messed up the GCBytesAge computation.
 func TestMVCCStatsPutMovesDeletionTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	ctx := context.Background()
-	aggMS := &enginepb.MVCCStats{}
+			ctx := context.Background()
+			aggMS := &enginepb.MVCCStats{}
 
-	assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
+			assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
 
-	ts1 := hlc.Timestamp{WallTime: 1E9}
-	ts2 := hlc.Timestamp{WallTime: 2 * 1E9}
+			ts1 := hlc.Timestamp{WallTime: 1E9}
+			ts2 := hlc.Timestamp{WallTime: 2 * 1E9}
 
-	key := roachpb.Key("a")
-	txn := &roachpb.Transaction{
-		TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts1},
-		OrigTimestamp: ts1,
+			key := roachpb.Key("a")
+			txn := &roachpb.Transaction{
+				TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts1},
+				OrigTimestamp: ts1,
+			}
+
+			// Write a deletion tombstone intent.
+			if err := MVCCDelete(ctx, engine, aggMS, key, txn.OrigTimestamp, txn); err != nil {
+				t.Fatal(err)
+			}
+
+			value := roachpb.MakeValueFromString("value")
+
+			mKeySize := int64(mvccKey(key).EncodedSize())
+			require.EqualValues(t, mKeySize, 2)
+
+			mVal1Size := int64((&enginepb.MVCCMetadata{
+				Timestamp: hlc.LegacyTimestamp(ts1),
+				Deleted:   false,
+				Txn:       &txn.TxnMeta,
+			}).Size())
+			require.EqualValues(t, mVal1Size, 46)
+
+			m1ValSize := int64((&enginepb.MVCCMetadata{
+				Timestamp: hlc.LegacyTimestamp(ts2),
+				Deleted:   false,
+				Txn:       &txn.TxnMeta,
+			}).Size())
+			require.EqualValues(t, m1ValSize, 46)
+
+			vKeySize := MVCCVersionTimestampSize
+			require.EqualValues(t, vKeySize, 12)
+
+			vValSize := int64(len(value.RawBytes))
+			require.EqualValues(t, vValSize, 10)
+
+			expMS := enginepb.MVCCStats{
+				LastUpdateNanos: 1E9,
+				LiveBytes:       0,
+				LiveCount:       0,
+				KeyBytes:        mKeySize + vKeySize, // 2 + 12 = 24
+				KeyCount:        1,
+				ValBytes:        mVal1Size, // 44
+				ValCount:        1,
+				IntentAge:       0,
+				IntentCount:     1,
+				IntentBytes:     vKeySize, // 12
+				GCBytesAge:      0,
+			}
+			assertEq(t, engine, "after delete", aggMS, &expMS)
+
+			// Now replace our deletion with a value intent, but with a timestamp gap.
+			// This could happen if a transaction got restarted with a higher timestamp
+			// and ran logic different from that in the first attempt.
+			txn.Timestamp.Forward(ts2)
+
+			txn.Sequence++
+
+			// Annoyingly, the new meta value is actually a little larger thanks to the
+			// sequence number. Also the value is larger because the previous intent on the
+			// transaction is recorded in the IntentHistory.
+			m2ValSize := int64((&enginepb.MVCCMetadata{
+				Timestamp: hlc.LegacyTimestamp(ts2),
+				Txn:       &txn.TxnMeta,
+				IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
+					{Sequence: 0, Value: []byte{}},
+				},
+			}).Size())
+			require.EqualValues(t, m2ValSize, 54)
+
+			if err := MVCCPut(ctx, engine, aggMS, key, txn.OrigTimestamp, value, txn); err != nil {
+				t.Fatal(err)
+			}
+
+			expAggMS := enginepb.MVCCStats{
+				LastUpdateNanos: 2E9,
+				LiveBytes:       mKeySize + m2ValSize + vKeySize + vValSize, // 2+46+12+10 = 70
+				LiveCount:       1,
+				KeyCount:        1,
+				ValCount:        1,
+				// The explicit meta record counts for len("a")+1=2.
+				// One versioned key counts for vKeySize.
+				KeyBytes: mKeySize + vKeySize,
+				// The intent is still there, but this time with mVal2Size, and a zero vValSize.
+				ValBytes:    vValSize + m2ValSize, // 10+46 = 56
+				IntentAge:   0,
+				IntentCount: 1,                   // still there
+				IntentBytes: vKeySize + vValSize, // still there, now bigger
+				GCBytesAge:  0,                   // this was once erroneously negative
+			}
+
+			assertEq(t, engine, "after put", aggMS, &expAggMS)
+		})
 	}
-
-	// Write a deletion tombstone intent.
-	if err := MVCCDelete(ctx, engine, aggMS, key, txn.OrigTimestamp, txn); err != nil {
-		t.Fatal(err)
-	}
-
-	value := roachpb.MakeValueFromString("value")
-
-	mKeySize := int64(mvccKey(key).EncodedSize())
-	require.EqualValues(t, mKeySize, 2)
-
-	mVal1Size := int64((&enginepb.MVCCMetadata{
-		Timestamp: hlc.LegacyTimestamp(ts1),
-		Deleted:   false,
-		Txn:       &txn.TxnMeta,
-	}).Size())
-	require.EqualValues(t, mVal1Size, 46)
-
-	m1ValSize := int64((&enginepb.MVCCMetadata{
-		Timestamp: hlc.LegacyTimestamp(ts2),
-		Deleted:   false,
-		Txn:       &txn.TxnMeta,
-	}).Size())
-	require.EqualValues(t, m1ValSize, 46)
-
-	vKeySize := MVCCVersionTimestampSize
-	require.EqualValues(t, vKeySize, 12)
-
-	vValSize := int64(len(value.RawBytes))
-	require.EqualValues(t, vValSize, 10)
-
-	expMS := enginepb.MVCCStats{
-		LastUpdateNanos: 1E9,
-		LiveBytes:       0,
-		LiveCount:       0,
-		KeyBytes:        mKeySize + vKeySize, // 2 + 12 = 24
-		KeyCount:        1,
-		ValBytes:        mVal1Size, // 44
-		ValCount:        1,
-		IntentAge:       0,
-		IntentCount:     1,
-		IntentBytes:     vKeySize, // 12
-		GCBytesAge:      0,
-	}
-	assertEq(t, engine, "after delete", aggMS, &expMS)
-
-	// Now replace our deletion with a value intent, but with a timestamp gap.
-	// This could happen if a transaction got restarted with a higher timestamp
-	// and ran logic different from that in the first attempt.
-	txn.Timestamp.Forward(ts2)
-
-	txn.Sequence++
-
-	// Annoyingly, the new meta value is actually a little larger thanks to the
-	// sequence number. Also the value is larger because the previous intent on the
-	// transaction is recorded in the IntentHistory.
-	m2ValSize := int64((&enginepb.MVCCMetadata{
-		Timestamp: hlc.LegacyTimestamp(ts2),
-		Txn:       &txn.TxnMeta,
-		IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
-			{Sequence: 0, Value: []byte{}},
-		},
-	}).Size())
-	require.EqualValues(t, m2ValSize, 54)
-
-	if err := MVCCPut(ctx, engine, aggMS, key, txn.OrigTimestamp, value, txn); err != nil {
-		t.Fatal(err)
-	}
-
-	expAggMS := enginepb.MVCCStats{
-		LastUpdateNanos: 2E9,
-		LiveBytes:       mKeySize + m2ValSize + vKeySize + vValSize, // 2+46+12+10 = 70
-		LiveCount:       1,
-		KeyCount:        1,
-		ValCount:        1,
-		// The explicit meta record counts for len("a")+1=2.
-		// One versioned key counts for vKeySize.
-		KeyBytes: mKeySize + vKeySize,
-		// The intent is still there, but this time with mVal2Size, and a zero vValSize.
-		ValBytes:    vValSize + m2ValSize, // 10+46 = 56
-		IntentAge:   0,
-		IntentCount: 1,                   // still there
-		IntentBytes: vKeySize + vValSize, // still there, now bigger
-		GCBytesAge:  0,                   // this was once erroneously negative
-	}
-
-	assertEq(t, engine, "after put", aggMS, &expAggMS)
 }
 
 // TestMVCCStatsDelDelCommit writes a non-transactional tombstone, and then adds an intent tombstone
@@ -511,130 +531,134 @@ func TestMVCCStatsPutMovesDeletionTimestamp(t *testing.T) {
 // correct stats.
 func TestMVCCStatsDelDelCommitMovesTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	ctx := context.Background()
-	aggMS := &enginepb.MVCCStats{}
+			ctx := context.Background()
+			aggMS := &enginepb.MVCCStats{}
 
-	assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
+			assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
 
-	key := roachpb.Key("a")
+			key := roachpb.Key("a")
 
-	ts1 := hlc.Timestamp{WallTime: 1E9}
-	ts2 := hlc.Timestamp{WallTime: 2E9}
-	ts3 := hlc.Timestamp{WallTime: 3E9}
+			ts1 := hlc.Timestamp{WallTime: 1E9}
+			ts2 := hlc.Timestamp{WallTime: 2E9}
+			ts3 := hlc.Timestamp{WallTime: 3E9}
 
-	// Write a non-transactional tombstone at t=1s.
-	if err := MVCCDelete(ctx, engine, aggMS, key, ts1, nil /* txn */); err != nil {
-		t.Fatal(err)
+			// Write a non-transactional tombstone at t=1s.
+			if err := MVCCDelete(ctx, engine, aggMS, key, ts1, nil /* txn */); err != nil {
+				t.Fatal(err)
+			}
+
+			mKeySize := int64(mvccKey(key).EncodedSize())
+			require.EqualValues(t, mKeySize, 2)
+			vKeySize := MVCCVersionTimestampSize
+			require.EqualValues(t, vKeySize, 12)
+
+			expMS := enginepb.MVCCStats{
+				LastUpdateNanos: 1E9,
+				KeyBytes:        mKeySize + vKeySize,
+				KeyCount:        1,
+				ValBytes:        0,
+				ValCount:        1,
+			}
+
+			assertEq(t, engine, "after non-transactional delete", aggMS, &expMS)
+
+			// Write an tombstone intent at t=2s.
+			txn := &roachpb.Transaction{
+				TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts2},
+				OrigTimestamp: ts2,
+			}
+			if err := MVCCDelete(ctx, engine, aggMS, key, txn.OrigTimestamp, txn); err != nil {
+				t.Fatal(err)
+			}
+
+			mValSize := int64((&enginepb.MVCCMetadata{
+				Timestamp: hlc.LegacyTimestamp(ts1),
+				Deleted:   true,
+				Txn:       &txn.TxnMeta,
+			}).Size())
+			require.EqualValues(t, mValSize, 46)
+
+			expMS = enginepb.MVCCStats{
+				LastUpdateNanos: 2E9,
+				KeyBytes:        mKeySize + 2*vKeySize, // 2+2*12 = 26
+				KeyCount:        1,
+				ValBytes:        mValSize, // 44
+				ValCount:        2,
+				IntentCount:     1,
+				IntentBytes:     vKeySize, // TBD
+				// The original non-transactional write (at 1s) has now aged one second.
+				GCBytesAge: 1 * vKeySize,
+			}
+			assertEq(t, engine, "after put", aggMS, &expMS)
+
+			// Now commit or abort the intent, respectively, but with a timestamp gap
+			// (i.e. this is a push-commit as it would happen for a SNAPSHOT txn).
+			t.Run("Commit", func(t *testing.T) {
+				aggMS := *aggMS
+				engine := engine.NewBatch()
+				defer engine.Close()
+
+				txnCommit := txn.Clone()
+				txnCommit.Status = roachpb.COMMITTED
+				txnCommit.Timestamp.Forward(ts3)
+				if err := MVCCResolveWriteIntent(ctx, engine, &aggMS, roachpb.Intent{
+					Span: roachpb.Span{Key: key}, Status: txnCommit.Status, Txn: txnCommit.TxnMeta,
+				}); err != nil {
+					t.Fatal(err)
+				}
+
+				expAggMS := enginepb.MVCCStats{
+					LastUpdateNanos: 3E9,
+					KeyBytes:        mKeySize + 2*vKeySize, // 2+2*12 = 26
+					KeyCount:        1,
+					ValBytes:        0,
+					ValCount:        2,
+					IntentCount:     0,
+					IntentBytes:     0,
+					// The very first write picks up another second of age. Before a bug fix,
+					// this was failing to do so.
+					GCBytesAge: 2 * vKeySize,
+				}
+
+				assertEq(t, engine, "after committing", &aggMS, &expAggMS)
+			})
+			t.Run("Abort", func(t *testing.T) {
+				aggMS := *aggMS
+				engine := engine.NewBatch()
+				defer engine.Close()
+
+				txnAbort := txn.Clone()
+				txnAbort.Status = roachpb.ABORTED
+				txnAbort.Timestamp.Forward(ts3)
+				if err := MVCCResolveWriteIntent(ctx, engine, &aggMS, roachpb.Intent{
+					Span: roachpb.Span{Key: key}, Status: txnAbort.Status, Txn: txnAbort.TxnMeta,
+				}); err != nil {
+					t.Fatal(err)
+				}
+
+				expAggMS := enginepb.MVCCStats{
+					LastUpdateNanos: 3E9,
+					KeyBytes:        mKeySize + vKeySize, // 2+12 = 14
+					KeyCount:        1,
+					ValBytes:        0,
+					ValCount:        1,
+					IntentCount:     0,
+					IntentBytes:     0,
+					// We aborted our intent, but the value we first wrote was a tombstone, and
+					// so it's expected to retain its age. Since it's now the only value, it
+					// also contributes as a meta key.
+					GCBytesAge: 2 * (mKeySize + vKeySize),
+				}
+
+				assertEq(t, engine, "after aborting", &aggMS, &expAggMS)
+			})
+		})
 	}
-
-	mKeySize := int64(mvccKey(key).EncodedSize())
-	require.EqualValues(t, mKeySize, 2)
-	vKeySize := MVCCVersionTimestampSize
-	require.EqualValues(t, vKeySize, 12)
-
-	expMS := enginepb.MVCCStats{
-		LastUpdateNanos: 1E9,
-		KeyBytes:        mKeySize + vKeySize,
-		KeyCount:        1,
-		ValBytes:        0,
-		ValCount:        1,
-	}
-
-	assertEq(t, engine, "after non-transactional delete", aggMS, &expMS)
-
-	// Write an tombstone intent at t=2s.
-	txn := &roachpb.Transaction{
-		TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts2},
-		OrigTimestamp: ts2,
-	}
-	if err := MVCCDelete(ctx, engine, aggMS, key, txn.OrigTimestamp, txn); err != nil {
-		t.Fatal(err)
-	}
-
-	mValSize := int64((&enginepb.MVCCMetadata{
-		Timestamp: hlc.LegacyTimestamp(ts1),
-		Deleted:   true,
-		Txn:       &txn.TxnMeta,
-	}).Size())
-	require.EqualValues(t, mValSize, 46)
-
-	expMS = enginepb.MVCCStats{
-		LastUpdateNanos: 2E9,
-		KeyBytes:        mKeySize + 2*vKeySize, // 2+2*12 = 26
-		KeyCount:        1,
-		ValBytes:        mValSize, // 44
-		ValCount:        2,
-		IntentCount:     1,
-		IntentBytes:     vKeySize, // TBD
-		// The original non-transactional write (at 1s) has now aged one second.
-		GCBytesAge: 1 * vKeySize,
-	}
-	assertEq(t, engine, "after put", aggMS, &expMS)
-
-	// Now commit or abort the intent, respectively, but with a timestamp gap
-	// (i.e. this is a push-commit as it would happen for a SNAPSHOT txn).
-	t.Run("Commit", func(t *testing.T) {
-		aggMS := *aggMS
-		engine := engine.NewBatch()
-		defer engine.Close()
-
-		txnCommit := txn.Clone()
-		txnCommit.Status = roachpb.COMMITTED
-		txnCommit.Timestamp.Forward(ts3)
-		if err := MVCCResolveWriteIntent(ctx, engine, &aggMS, roachpb.Intent{
-			Span: roachpb.Span{Key: key}, Status: txnCommit.Status, Txn: txnCommit.TxnMeta,
-		}); err != nil {
-			t.Fatal(err)
-		}
-
-		expAggMS := enginepb.MVCCStats{
-			LastUpdateNanos: 3E9,
-			KeyBytes:        mKeySize + 2*vKeySize, // 2+2*12 = 26
-			KeyCount:        1,
-			ValBytes:        0,
-			ValCount:        2,
-			IntentCount:     0,
-			IntentBytes:     0,
-			// The very first write picks up another second of age. Before a bug fix,
-			// this was failing to do so.
-			GCBytesAge: 2 * vKeySize,
-		}
-
-		assertEq(t, engine, "after committing", &aggMS, &expAggMS)
-	})
-	t.Run("Abort", func(t *testing.T) {
-		aggMS := *aggMS
-		engine := engine.NewBatch()
-		defer engine.Close()
-
-		txnAbort := txn.Clone()
-		txnAbort.Status = roachpb.ABORTED
-		txnAbort.Timestamp.Forward(ts3)
-		if err := MVCCResolveWriteIntent(ctx, engine, &aggMS, roachpb.Intent{
-			Span: roachpb.Span{Key: key}, Status: txnAbort.Status, Txn: txnAbort.TxnMeta,
-		}); err != nil {
-			t.Fatal(err)
-		}
-
-		expAggMS := enginepb.MVCCStats{
-			LastUpdateNanos: 3E9,
-			KeyBytes:        mKeySize + vKeySize, // 2+12 = 14
-			KeyCount:        1,
-			ValBytes:        0,
-			ValCount:        1,
-			IntentCount:     0,
-			IntentBytes:     0,
-			// We aborted our intent, but the value we first wrote was a tombstone, and
-			// so it's expected to retain its age. Since it's now the only value, it
-			// also contributes as a meta key.
-			GCBytesAge: 2 * (mKeySize + vKeySize),
-		}
-
-		assertEq(t, engine, "after aborting", &aggMS, &expAggMS)
-	})
 }
 
 // TestMVCCStatsPutDelPut is similar to TestMVCCStatsDelDelCommit, but its first
@@ -646,226 +670,234 @@ func TestMVCCStatsDelDelCommitMovesTimestamp(t *testing.T) {
 // final correction is done in the put path and not the commit path.
 func TestMVCCStatsPutDelPutMovesTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	ctx := context.Background()
-	aggMS := &enginepb.MVCCStats{}
+			ctx := context.Background()
+			aggMS := &enginepb.MVCCStats{}
 
-	assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
+			assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
 
-	key := roachpb.Key("a")
+			key := roachpb.Key("a")
 
-	ts1 := hlc.Timestamp{WallTime: 1E9}
-	ts2 := hlc.Timestamp{WallTime: 2E9}
-	ts3 := hlc.Timestamp{WallTime: 3E9}
+			ts1 := hlc.Timestamp{WallTime: 1E9}
+			ts2 := hlc.Timestamp{WallTime: 2E9}
+			ts3 := hlc.Timestamp{WallTime: 3E9}
 
-	// Write a non-transactional value at t=1s.
-	value := roachpb.MakeValueFromString("value")
-	if err := MVCCPut(ctx, engine, aggMS, key, ts1, value, nil /* txn */); err != nil {
-		t.Fatal(err)
+			// Write a non-transactional value at t=1s.
+			value := roachpb.MakeValueFromString("value")
+			if err := MVCCPut(ctx, engine, aggMS, key, ts1, value, nil /* txn */); err != nil {
+				t.Fatal(err)
+			}
+
+			mKeySize := int64(mvccKey(key).EncodedSize())
+			require.EqualValues(t, mKeySize, 2)
+
+			vKeySize := MVCCVersionTimestampSize
+			require.EqualValues(t, vKeySize, 12)
+
+			vValSize := int64(len(value.RawBytes))
+			require.EqualValues(t, vValSize, 10)
+
+			expMS := enginepb.MVCCStats{
+				LastUpdateNanos: 1E9,
+				KeyBytes:        mKeySize + vKeySize,
+				KeyCount:        1,
+				ValBytes:        vValSize,
+				ValCount:        1,
+				LiveBytes:       mKeySize + vKeySize + vValSize,
+				LiveCount:       1,
+			}
+
+			assertEq(t, engine, "after non-transactional put", aggMS, &expMS)
+
+			// Write a tombstone intent at t=2s.
+			txn := &roachpb.Transaction{
+				TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts2},
+				OrigTimestamp: ts2,
+			}
+			if err := MVCCDelete(ctx, engine, aggMS, key, txn.OrigTimestamp, txn); err != nil {
+				t.Fatal(err)
+			}
+
+			mValSize := int64((&enginepb.MVCCMetadata{
+				Timestamp: hlc.LegacyTimestamp(ts1),
+				Deleted:   true,
+				Txn:       &txn.TxnMeta,
+			}).Size())
+			require.EqualValues(t, mValSize, 46)
+
+			expMS = enginepb.MVCCStats{
+				LastUpdateNanos: 2E9,
+				KeyBytes:        mKeySize + 2*vKeySize, // 2+2*12 = 26
+				KeyCount:        1,
+				ValBytes:        mValSize + vValSize, // 44+10 = 56
+				ValCount:        2,
+				IntentCount:     1,
+				IntentBytes:     vKeySize, // 12
+				// The original non-transactional write becomes non-live at 2s, so no age
+				// is accrued yet.
+				GCBytesAge: 0,
+			}
+			assertEq(t, engine, "after txn delete", aggMS, &expMS)
+
+			// Now commit or abort the intent, but with a timestamp gap (i.e. this is a push-commit as it
+			// would happen for a SNAPSHOT txn)
+
+			txn.Timestamp.Forward(ts3)
+			txn.Sequence++
+
+			// Annoyingly, the new meta value is actually a little larger thanks to the
+			// sequence number.
+			m2ValSize := int64((&enginepb.MVCCMetadata{
+				Timestamp: hlc.LegacyTimestamp(ts3),
+				Txn:       &txn.TxnMeta,
+			}).Size())
+
+			require.EqualValues(t, m2ValSize, 48)
+
+			t.Run("Abort", func(t *testing.T) {
+				aggMS := *aggMS
+				engine := engine.NewBatch()
+				defer engine.Close()
+
+				txnAbort := txn.Clone()
+				txnAbort.Status = roachpb.ABORTED // doesn't change m2ValSize, fortunately
+				if err := MVCCResolveWriteIntent(ctx, engine, &aggMS, roachpb.Intent{
+					Span: roachpb.Span{Key: key}, Status: txnAbort.Status, Txn: txnAbort.TxnMeta,
+				}); err != nil {
+					t.Fatal(err)
+				}
+
+				expAggMS := enginepb.MVCCStats{
+					LastUpdateNanos: 3E9,
+					KeyBytes:        mKeySize + vKeySize,
+					KeyCount:        1,
+					ValBytes:        vValSize,
+					ValCount:        1,
+					LiveCount:       1,
+					LiveBytes:       mKeySize + vKeySize + vValSize,
+					IntentCount:     0,
+					IntentBytes:     0,
+					// The original value is visible again, so no GCBytesAge is present. Verifying this is the
+					// main point of this test (to prevent regression of a bug).
+					GCBytesAge: 0,
+				}
+				assertEq(t, engine, "after abort", &aggMS, &expAggMS)
+			})
+			t.Run("Put", func(t *testing.T) {
+				aggMS := *aggMS
+				engine := engine.NewBatch()
+				defer engine.Close()
+
+				val2 := roachpb.MakeValueFromString("longvalue")
+				vVal2Size := int64(len(val2.RawBytes))
+				require.EqualValues(t, vVal2Size, 14)
+
+				txn.Timestamp.Forward(ts3)
+				if err := MVCCPut(ctx, engine, &aggMS, key, txn.OrigTimestamp, val2, txn); err != nil {
+					t.Fatal(err)
+				}
+
+				// Annoyingly, the new meta value is actually a little larger thanks to the
+				// sequence number.
+				m2ValSizeWithHistory := int64((&enginepb.MVCCMetadata{
+					Timestamp: hlc.LegacyTimestamp(ts3),
+					Txn:       &txn.TxnMeta,
+					IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
+						{Sequence: 0, Value: []byte{}},
+					},
+				}).Size())
+
+				require.EqualValues(t, m2ValSizeWithHistory, 54)
+
+				expAggMS := enginepb.MVCCStats{
+					LastUpdateNanos: 3E9,
+					KeyBytes:        mKeySize + 2*vKeySize, // 2+2*12 = 26
+					KeyCount:        1,
+					ValBytes:        m2ValSizeWithHistory + vValSize + vVal2Size,
+					ValCount:        2,
+					LiveCount:       1,
+					LiveBytes:       mKeySize + m2ValSizeWithHistory + vKeySize + vVal2Size,
+					IntentCount:     1,
+					IntentBytes:     vKeySize + vVal2Size,
+					// The original write was previously non-live at 2s because that's where the
+					// intent originally lived. But the intent has moved to 3s, and so has the
+					// moment in time at which the shadowed put became non-live; it's now 3s as
+					// well, so there's no contribution yet.
+					GCBytesAge: 0,
+				}
+				assertEq(t, engine, "after txn put", &aggMS, &expAggMS)
+			})
+		})
 	}
-
-	mKeySize := int64(mvccKey(key).EncodedSize())
-	require.EqualValues(t, mKeySize, 2)
-
-	vKeySize := MVCCVersionTimestampSize
-	require.EqualValues(t, vKeySize, 12)
-
-	vValSize := int64(len(value.RawBytes))
-	require.EqualValues(t, vValSize, 10)
-
-	expMS := enginepb.MVCCStats{
-		LastUpdateNanos: 1E9,
-		KeyBytes:        mKeySize + vKeySize,
-		KeyCount:        1,
-		ValBytes:        vValSize,
-		ValCount:        1,
-		LiveBytes:       mKeySize + vKeySize + vValSize,
-		LiveCount:       1,
-	}
-
-	assertEq(t, engine, "after non-transactional put", aggMS, &expMS)
-
-	// Write a tombstone intent at t=2s.
-	txn := &roachpb.Transaction{
-		TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts2},
-		OrigTimestamp: ts2,
-	}
-	if err := MVCCDelete(ctx, engine, aggMS, key, txn.OrigTimestamp, txn); err != nil {
-		t.Fatal(err)
-	}
-
-	mValSize := int64((&enginepb.MVCCMetadata{
-		Timestamp: hlc.LegacyTimestamp(ts1),
-		Deleted:   true,
-		Txn:       &txn.TxnMeta,
-	}).Size())
-	require.EqualValues(t, mValSize, 46)
-
-	expMS = enginepb.MVCCStats{
-		LastUpdateNanos: 2E9,
-		KeyBytes:        mKeySize + 2*vKeySize, // 2+2*12 = 26
-		KeyCount:        1,
-		ValBytes:        mValSize + vValSize, // 44+10 = 56
-		ValCount:        2,
-		IntentCount:     1,
-		IntentBytes:     vKeySize, // 12
-		// The original non-transactional write becomes non-live at 2s, so no age
-		// is accrued yet.
-		GCBytesAge: 0,
-	}
-	assertEq(t, engine, "after txn delete", aggMS, &expMS)
-
-	// Now commit or abort the intent, but with a timestamp gap (i.e. this is a push-commit as it
-	// would happen for a SNAPSHOT txn)
-
-	txn.Timestamp.Forward(ts3)
-	txn.Sequence++
-
-	// Annoyingly, the new meta value is actually a little larger thanks to the
-	// sequence number.
-	m2ValSize := int64((&enginepb.MVCCMetadata{
-		Timestamp: hlc.LegacyTimestamp(ts3),
-		Txn:       &txn.TxnMeta,
-	}).Size())
-
-	require.EqualValues(t, m2ValSize, 48)
-
-	t.Run("Abort", func(t *testing.T) {
-		aggMS := *aggMS
-		engine := engine.NewBatch()
-		defer engine.Close()
-
-		txnAbort := txn.Clone()
-		txnAbort.Status = roachpb.ABORTED // doesn't change m2ValSize, fortunately
-		if err := MVCCResolveWriteIntent(ctx, engine, &aggMS, roachpb.Intent{
-			Span: roachpb.Span{Key: key}, Status: txnAbort.Status, Txn: txnAbort.TxnMeta,
-		}); err != nil {
-			t.Fatal(err)
-		}
-
-		expAggMS := enginepb.MVCCStats{
-			LastUpdateNanos: 3E9,
-			KeyBytes:        mKeySize + vKeySize,
-			KeyCount:        1,
-			ValBytes:        vValSize,
-			ValCount:        1,
-			LiveCount:       1,
-			LiveBytes:       mKeySize + vKeySize + vValSize,
-			IntentCount:     0,
-			IntentBytes:     0,
-			// The original value is visible again, so no GCBytesAge is present. Verifying this is the
-			// main point of this test (to prevent regression of a bug).
-			GCBytesAge: 0,
-		}
-		assertEq(t, engine, "after abort", &aggMS, &expAggMS)
-	})
-	t.Run("Put", func(t *testing.T) {
-		aggMS := *aggMS
-		engine := engine.NewBatch()
-		defer engine.Close()
-
-		val2 := roachpb.MakeValueFromString("longvalue")
-		vVal2Size := int64(len(val2.RawBytes))
-		require.EqualValues(t, vVal2Size, 14)
-
-		txn.Timestamp.Forward(ts3)
-		if err := MVCCPut(ctx, engine, &aggMS, key, txn.OrigTimestamp, val2, txn); err != nil {
-			t.Fatal(err)
-		}
-
-		// Annoyingly, the new meta value is actually a little larger thanks to the
-		// sequence number.
-		m2ValSizeWithHistory := int64((&enginepb.MVCCMetadata{
-			Timestamp: hlc.LegacyTimestamp(ts3),
-			Txn:       &txn.TxnMeta,
-			IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
-				{Sequence: 0, Value: []byte{}},
-			},
-		}).Size())
-
-		require.EqualValues(t, m2ValSizeWithHistory, 54)
-
-		expAggMS := enginepb.MVCCStats{
-			LastUpdateNanos: 3E9,
-			KeyBytes:        mKeySize + 2*vKeySize, // 2+2*12 = 26
-			KeyCount:        1,
-			ValBytes:        m2ValSizeWithHistory + vValSize + vVal2Size,
-			ValCount:        2,
-			LiveCount:       1,
-			LiveBytes:       mKeySize + m2ValSizeWithHistory + vKeySize + vVal2Size,
-			IntentCount:     1,
-			IntentBytes:     vKeySize + vVal2Size,
-			// The original write was previously non-live at 2s because that's where the
-			// intent originally lived. But the intent has moved to 3s, and so has the
-			// moment in time at which the shadowed put became non-live; it's now 3s as
-			// well, so there's no contribution yet.
-			GCBytesAge: 0,
-		}
-		assertEq(t, engine, "after txn put", &aggMS, &expAggMS)
-	})
 }
 
 // TestMVCCStatsDelDelGC prevents regression of a bug in MVCCGarbageCollect
 // that was exercised by running two deletions followed by a specific GC.
 func TestMVCCStatsDelDelGC(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	ctx := context.Background()
-	aggMS := &enginepb.MVCCStats{}
+			ctx := context.Background()
+			aggMS := &enginepb.MVCCStats{}
 
-	assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
+			assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
 
-	key := roachpb.Key("a")
-	ts1 := hlc.Timestamp{WallTime: 1E9}
-	ts2 := hlc.Timestamp{WallTime: 2E9}
+			key := roachpb.Key("a")
+			ts1 := hlc.Timestamp{WallTime: 1E9}
+			ts2 := hlc.Timestamp{WallTime: 2E9}
 
-	// Write tombstones at ts1 and ts2.
-	if err := MVCCDelete(ctx, engine, aggMS, key, ts1, nil); err != nil {
-		t.Fatal(err)
+			// Write tombstones at ts1 and ts2.
+			if err := MVCCDelete(ctx, engine, aggMS, key, ts1, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCDelete(ctx, engine, aggMS, key, ts2, nil); err != nil {
+				t.Fatal(err)
+			}
+
+			mKeySize := int64(mvccKey(key).EncodedSize()) // 2
+			vKeySize := MVCCVersionTimestampSize          // 12
+
+			expMS := enginepb.MVCCStats{
+				LastUpdateNanos: 2E9,
+				KeyBytes:        mKeySize + 2*vKeySize, // 26
+				KeyCount:        1,
+				ValCount:        2,
+				GCBytesAge:      1 * vKeySize, // first tombstone, aged from ts1 to ts2
+			}
+			assertEq(t, engine, "after two puts", aggMS, &expMS)
+
+			// Run a GC invocation that clears it all. There used to be a bug here when
+			// we allowed limiting the number of deleted keys. Passing zero (i.e. remove
+			// one key and then bail) would mess up the stats, since the implementation
+			// would assume that the (implicit or explicit) meta entry was going to be
+			// removed, but this is only true when all values actually go away.
+			if err := MVCCGarbageCollect(
+				ctx,
+				engine,
+				aggMS,
+				[]roachpb.GCRequest_GCKey{{
+					Key:       key,
+					Timestamp: ts2,
+				}},
+				ts2,
+			); err != nil {
+				t.Fatal(err)
+			}
+
+			expAggMS := enginepb.MVCCStats{
+				LastUpdateNanos: 2E9,
+			}
+
+			assertEq(t, engine, "after GC", aggMS, &expAggMS)
+		})
 	}
-	if err := MVCCDelete(ctx, engine, aggMS, key, ts2, nil); err != nil {
-		t.Fatal(err)
-	}
-
-	mKeySize := int64(mvccKey(key).EncodedSize()) // 2
-	vKeySize := MVCCVersionTimestampSize          // 12
-
-	expMS := enginepb.MVCCStats{
-		LastUpdateNanos: 2E9,
-		KeyBytes:        mKeySize + 2*vKeySize, // 26
-		KeyCount:        1,
-		ValCount:        2,
-		GCBytesAge:      1 * vKeySize, // first tombstone, aged from ts1 to ts2
-	}
-	assertEq(t, engine, "after two puts", aggMS, &expMS)
-
-	// Run a GC invocation that clears it all. There used to be a bug here when
-	// we allowed limiting the number of deleted keys. Passing zero (i.e. remove
-	// one key and then bail) would mess up the stats, since the implementation
-	// would assume that the (implicit or explicit) meta entry was going to be
-	// removed, but this is only true when all values actually go away.
-	if err := MVCCGarbageCollect(
-		ctx,
-		engine,
-		aggMS,
-		[]roachpb.GCRequest_GCKey{{
-			Key:       key,
-			Timestamp: ts2,
-		}},
-		ts2,
-	); err != nil {
-		t.Fatal(err)
-	}
-
-	expAggMS := enginepb.MVCCStats{
-		LastUpdateNanos: 2E9,
-	}
-
-	assertEq(t, engine, "after GC", aggMS, &expAggMS)
 }
 
 // TestMVCCStatsPutIntentTimestampNotPutTimestamp exercises a scenario in which
@@ -883,255 +915,267 @@ func TestMVCCStatsDelDelGC(t *testing.T) {
 //   version, we're upgraded to write the MVCCMetadata.Timestamp.
 func TestMVCCStatsPutIntentTimestampNotPutTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	ctx := context.Background()
-	aggMS := &enginepb.MVCCStats{}
+			ctx := context.Background()
+			aggMS := &enginepb.MVCCStats{}
 
-	assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
+			assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
 
-	key := roachpb.Key("a")
-	ts201 := hlc.Timestamp{WallTime: 2E9 + 1}
-	ts099 := hlc.Timestamp{WallTime: 1E9 - 1}
-	txn := &roachpb.Transaction{
-		TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts201},
-		OrigTimestamp: ts099,
+			key := roachpb.Key("a")
+			ts201 := hlc.Timestamp{WallTime: 2E9 + 1}
+			ts099 := hlc.Timestamp{WallTime: 1E9 - 1}
+			txn := &roachpb.Transaction{
+				TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts201},
+				OrigTimestamp: ts099,
+			}
+			// Write an intent at 2s+1.
+			value := roachpb.MakeValueFromString("value")
+			if err := MVCCPut(ctx, engine, aggMS, key, txn.OrigTimestamp, value, txn); err != nil {
+				t.Fatal(err)
+			}
+
+			mKeySize := int64(mvccKey(key).EncodedSize()) // 2
+			m1ValSize := int64((&enginepb.MVCCMetadata{   // 44
+				Timestamp: hlc.LegacyTimestamp(ts201),
+				Txn:       &txn.TxnMeta,
+			}).Size())
+			vKeySize := MVCCVersionTimestampSize   // 12
+			vValSize := int64(len(value.RawBytes)) // 10
+
+			expMS := enginepb.MVCCStats{
+				LastUpdateNanos: 2E9 + 1,
+				LiveBytes:       mKeySize + m1ValSize + vKeySize + vValSize, // 2+44+12+10 = 68
+				LiveCount:       1,
+				KeyBytes:        mKeySize + vKeySize, // 14
+				KeyCount:        1,
+				ValBytes:        m1ValSize + vValSize, // 44+10 = 54
+				ValCount:        1,
+				IntentCount:     1,
+				IntentBytes:     vKeySize + vValSize, // 12+10 = 22
+			}
+			assertEq(t, engine, "after first put", aggMS, &expMS)
+
+			// Replace the intent with an identical one, but we write it at 1s-1 now. If
+			// you're confused, don't worry. There are two timestamps here: the one in
+			// the txn (which is, perhaps surprisingly, only really used when
+			// committing/aborting intents), and the timestamp passed directly to
+			// MVCCPut (which is where the intent will actually end up being written at,
+			// and which usually corresponds to txn.OrigTimestamp).
+			txn.Sequence++
+			txn.Timestamp = ts099
+
+			// Annoyingly, the new meta value is actually a little larger thanks to the
+			// sequence number.
+			m2ValSize := int64((&enginepb.MVCCMetadata{ // 46
+				Timestamp: hlc.LegacyTimestamp(ts201),
+				Txn:       &txn.TxnMeta,
+				IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
+					{Sequence: 0, Value: value.RawBytes},
+				},
+			}).Size())
+			if err := MVCCPut(ctx, engine, aggMS, key, txn.OrigTimestamp, value, txn); err != nil {
+				t.Fatal(err)
+			}
+
+			expAggMS := enginepb.MVCCStats{
+				// Even though we tried to put a new intent at an older timestamp, it
+				// will have been written at 2E9+1, so the age will be 0.
+				IntentAge: 0,
+
+				LastUpdateNanos: 2E9 + 1,
+				LiveBytes:       mKeySize + m2ValSize + vKeySize + vValSize, // 2+46+12+10 = 70
+				LiveCount:       1,
+				KeyBytes:        mKeySize + vKeySize, // 14
+				KeyCount:        1,
+				ValBytes:        m2ValSize + vValSize, // 46+10 = 56
+				ValCount:        1,
+				IntentCount:     1,
+				IntentBytes:     vKeySize + vValSize, // 12+10 = 22
+			}
+
+			assertEq(t, engine, "after second put", aggMS, &expAggMS)
+		})
 	}
-	// Write an intent at 2s+1.
-	value := roachpb.MakeValueFromString("value")
-	if err := MVCCPut(ctx, engine, aggMS, key, txn.OrigTimestamp, value, txn); err != nil {
-		t.Fatal(err)
-	}
-
-	mKeySize := int64(mvccKey(key).EncodedSize()) // 2
-	m1ValSize := int64((&enginepb.MVCCMetadata{   // 44
-		Timestamp: hlc.LegacyTimestamp(ts201),
-		Txn:       &txn.TxnMeta,
-	}).Size())
-	vKeySize := MVCCVersionTimestampSize   // 12
-	vValSize := int64(len(value.RawBytes)) // 10
-
-	expMS := enginepb.MVCCStats{
-		LastUpdateNanos: 2E9 + 1,
-		LiveBytes:       mKeySize + m1ValSize + vKeySize + vValSize, // 2+44+12+10 = 68
-		LiveCount:       1,
-		KeyBytes:        mKeySize + vKeySize, // 14
-		KeyCount:        1,
-		ValBytes:        m1ValSize + vValSize, // 44+10 = 54
-		ValCount:        1,
-		IntentCount:     1,
-		IntentBytes:     vKeySize + vValSize, // 12+10 = 22
-	}
-	assertEq(t, engine, "after first put", aggMS, &expMS)
-
-	// Replace the intent with an identical one, but we write it at 1s-1 now. If
-	// you're confused, don't worry. There are two timestamps here: the one in
-	// the txn (which is, perhaps surprisingly, only really used when
-	// committing/aborting intents), and the timestamp passed directly to
-	// MVCCPut (which is where the intent will actually end up being written at,
-	// and which usually corresponds to txn.OrigTimestamp).
-	txn.Sequence++
-	txn.Timestamp = ts099
-
-	// Annoyingly, the new meta value is actually a little larger thanks to the
-	// sequence number.
-	m2ValSize := int64((&enginepb.MVCCMetadata{ // 46
-		Timestamp: hlc.LegacyTimestamp(ts201),
-		Txn:       &txn.TxnMeta,
-		IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
-			{Sequence: 0, Value: value.RawBytes},
-		},
-	}).Size())
-	if err := MVCCPut(ctx, engine, aggMS, key, txn.OrigTimestamp, value, txn); err != nil {
-		t.Fatal(err)
-	}
-
-	expAggMS := enginepb.MVCCStats{
-		// Even though we tried to put a new intent at an older timestamp, it
-		// will have been written at 2E9+1, so the age will be 0.
-		IntentAge: 0,
-
-		LastUpdateNanos: 2E9 + 1,
-		LiveBytes:       mKeySize + m2ValSize + vKeySize + vValSize, // 2+46+12+10 = 70
-		LiveCount:       1,
-		KeyBytes:        mKeySize + vKeySize, // 14
-		KeyCount:        1,
-		ValBytes:        m2ValSize + vValSize, // 46+10 = 56
-		ValCount:        1,
-		IntentCount:     1,
-		IntentBytes:     vKeySize + vValSize, // 12+10 = 22
-	}
-
-	assertEq(t, engine, "after second put", aggMS, &expAggMS)
 }
 
 // TestMVCCStatsPutWaitDeleteGC puts a value, deletes it, and runs a GC that
 // deletes the original write, but not the deletion tombstone.
 func TestMVCCStatsPutWaitDeleteGC(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	ctx := context.Background()
-	aggMS := &enginepb.MVCCStats{}
+			ctx := context.Background()
+			aggMS := &enginepb.MVCCStats{}
 
-	assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
+			assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
 
-	key := roachpb.Key("a")
+			key := roachpb.Key("a")
 
-	ts1 := hlc.Timestamp{WallTime: 1E9}
-	ts2 := hlc.Timestamp{WallTime: 2E9}
+			ts1 := hlc.Timestamp{WallTime: 1E9}
+			ts2 := hlc.Timestamp{WallTime: 2E9}
 
-	// Write a value at ts1.
-	val1 := roachpb.MakeValueFromString("value")
-	if err := MVCCPut(ctx, engine, aggMS, key, ts1, val1, nil /* txn */); err != nil {
-		t.Fatal(err)
+			// Write a value at ts1.
+			val1 := roachpb.MakeValueFromString("value")
+			if err := MVCCPut(ctx, engine, aggMS, key, ts1, val1, nil /* txn */); err != nil {
+				t.Fatal(err)
+			}
+
+			mKeySize := int64(mvccKey(key).EncodedSize())
+			require.EqualValues(t, mKeySize, 2)
+
+			vKeySize := MVCCVersionTimestampSize
+			require.EqualValues(t, vKeySize, 12)
+
+			vValSize := int64(len(val1.RawBytes))
+			require.EqualValues(t, vValSize, 10)
+
+			expMS := enginepb.MVCCStats{
+				LastUpdateNanos: 1E9,
+				KeyCount:        1,
+				KeyBytes:        mKeySize + vKeySize, // 2+12 = 14
+				ValCount:        1,
+				ValBytes:        vValSize, // 10
+				LiveCount:       1,
+				LiveBytes:       mKeySize + vKeySize + vValSize, // 2+12+10 = 24
+			}
+			assertEq(t, engine, "after first put", aggMS, &expMS)
+
+			// Delete the value at ts5.
+
+			if err := MVCCDelete(ctx, engine, aggMS, key, ts2, nil /* txn */); err != nil {
+				t.Fatal(err)
+			}
+
+			expMS = enginepb.MVCCStats{
+				LastUpdateNanos: 2E9,
+				KeyCount:        1,
+				KeyBytes:        mKeySize + 2*vKeySize, // 2+2*12 = 26
+				ValBytes:        vValSize,              // 10
+				ValCount:        2,
+				LiveBytes:       0,
+				LiveCount:       0,
+				GCBytesAge:      0, // before a fix, this was vKeySize + vValSize
+			}
+
+			assertEq(t, engine, "after delete", aggMS, &expMS)
+
+			if err := MVCCGarbageCollect(ctx, engine, aggMS, []roachpb.GCRequest_GCKey{{
+				Key:       key,
+				Timestamp: ts1,
+			}}, ts2); err != nil {
+				t.Fatal(err)
+			}
+
+			expMS = enginepb.MVCCStats{
+				LastUpdateNanos: 2E9,
+				KeyCount:        1,
+				KeyBytes:        mKeySize + vKeySize, // 2+12 = 14
+				ValBytes:        0,
+				ValCount:        1,
+				LiveBytes:       0,
+				LiveCount:       0,
+				GCBytesAge:      0, // before a fix, this was vKeySize + vValSize
+			}
+
+			assertEq(t, engine, "after GC", aggMS, &expMS)
+		})
 	}
-
-	mKeySize := int64(mvccKey(key).EncodedSize())
-	require.EqualValues(t, mKeySize, 2)
-
-	vKeySize := MVCCVersionTimestampSize
-	require.EqualValues(t, vKeySize, 12)
-
-	vValSize := int64(len(val1.RawBytes))
-	require.EqualValues(t, vValSize, 10)
-
-	expMS := enginepb.MVCCStats{
-		LastUpdateNanos: 1E9,
-		KeyCount:        1,
-		KeyBytes:        mKeySize + vKeySize, // 2+12 = 14
-		ValCount:        1,
-		ValBytes:        vValSize, // 10
-		LiveCount:       1,
-		LiveBytes:       mKeySize + vKeySize + vValSize, // 2+12+10 = 24
-	}
-	assertEq(t, engine, "after first put", aggMS, &expMS)
-
-	// Delete the value at ts5.
-
-	if err := MVCCDelete(ctx, engine, aggMS, key, ts2, nil /* txn */); err != nil {
-		t.Fatal(err)
-	}
-
-	expMS = enginepb.MVCCStats{
-		LastUpdateNanos: 2E9,
-		KeyCount:        1,
-		KeyBytes:        mKeySize + 2*vKeySize, // 2+2*12 = 26
-		ValBytes:        vValSize,              // 10
-		ValCount:        2,
-		LiveBytes:       0,
-		LiveCount:       0,
-		GCBytesAge:      0, // before a fix, this was vKeySize + vValSize
-	}
-
-	assertEq(t, engine, "after delete", aggMS, &expMS)
-
-	if err := MVCCGarbageCollect(ctx, engine, aggMS, []roachpb.GCRequest_GCKey{{
-		Key:       key,
-		Timestamp: ts1,
-	}}, ts2); err != nil {
-		t.Fatal(err)
-	}
-
-	expMS = enginepb.MVCCStats{
-		LastUpdateNanos: 2E9,
-		KeyCount:        1,
-		KeyBytes:        mKeySize + vKeySize, // 2+12 = 14
-		ValBytes:        0,
-		ValCount:        1,
-		LiveBytes:       0,
-		LiveCount:       0,
-		GCBytesAge:      0, // before a fix, this was vKeySize + vValSize
-	}
-
-	assertEq(t, engine, "after GC", aggMS, &expMS)
 }
 
 // TestMVCCStatsSysTxnPutPut prevents regression of a bug that, when rewriting an intent
 // on a sys key, would lead to overcounting `ms.SysBytes`.
 func TestMVCCStatsTxnSysPutPut(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	ctx := context.Background()
-	aggMS := &enginepb.MVCCStats{}
+			ctx := context.Background()
+			aggMS := &enginepb.MVCCStats{}
 
-	assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
+			assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
 
-	key := keys.RangeDescriptorKey(roachpb.RKey("a"))
+			key := keys.RangeDescriptorKey(roachpb.RKey("a"))
 
-	ts1 := hlc.Timestamp{WallTime: 1E9}
-	ts2 := hlc.Timestamp{WallTime: 2E9}
+			ts1 := hlc.Timestamp{WallTime: 1E9}
+			ts2 := hlc.Timestamp{WallTime: 2E9}
 
-	txn := &roachpb.Transaction{
-		TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts1},
-		OrigTimestamp: ts1,
+			txn := &roachpb.Transaction{
+				TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts1},
+				OrigTimestamp: ts1,
+			}
+
+			// Write an intent at ts1.
+			val1 := roachpb.MakeValueFromString("value")
+			if err := MVCCPut(ctx, engine, aggMS, key, txn.OrigTimestamp, val1, txn); err != nil {
+				t.Fatal(err)
+			}
+
+			mKeySize := int64(mvccKey(key).EncodedSize())
+			require.EqualValues(t, mKeySize, 11)
+
+			mValSize := int64((&enginepb.MVCCMetadata{
+				Timestamp: hlc.LegacyTimestamp(ts1),
+				Deleted:   false,
+				Txn:       &txn.TxnMeta,
+			}).Size())
+			require.EqualValues(t, mValSize, 46)
+
+			vKeySize := MVCCVersionTimestampSize
+			require.EqualValues(t, vKeySize, 12)
+
+			vVal1Size := int64(len(val1.RawBytes))
+			require.EqualValues(t, vVal1Size, 10)
+
+			val2 := roachpb.MakeValueFromString("longvalue")
+			vVal2Size := int64(len(val2.RawBytes))
+			require.EqualValues(t, vVal2Size, 14)
+
+			expMS := enginepb.MVCCStats{
+				LastUpdateNanos: 1E9,
+				SysBytes:        mKeySize + mValSize + vKeySize + vVal1Size, // 11+44+12+10 = 77
+				SysCount:        1,
+			}
+			assertEq(t, engine, "after first put", aggMS, &expMS)
+
+			// Rewrite the intent to ts2 with a different value.
+			txn.Timestamp.Forward(ts2)
+			txn.Sequence++
+
+			// The new meta value grows because we've bumped `txn.Sequence`.
+			// The value also grows as the older value is part of the same
+			// transaction and so contributes to the intent history.
+			mVal2Size := int64((&enginepb.MVCCMetadata{
+				Timestamp: hlc.LegacyTimestamp(ts2),
+				Deleted:   false,
+				Txn:       &txn.TxnMeta,
+				IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
+					{Sequence: 0, Value: val1.RawBytes},
+				},
+			}).Size())
+			require.EqualValues(t, mVal2Size, 64)
+
+			if err := MVCCPut(ctx, engine, aggMS, key, txn.OrigTimestamp, val2, txn); err != nil {
+				t.Fatal(err)
+			}
+
+			expMS = enginepb.MVCCStats{
+				LastUpdateNanos: 1E9,
+				SysBytes:        mKeySize + mVal2Size + vKeySize + vVal2Size, // 11+46+12+14 = 83
+				SysCount:        1,
+			}
+
+			assertEq(t, engine, "after intent rewrite", aggMS, &expMS)
+		})
 	}
-
-	// Write an intent at ts1.
-	val1 := roachpb.MakeValueFromString("value")
-	if err := MVCCPut(ctx, engine, aggMS, key, txn.OrigTimestamp, val1, txn); err != nil {
-		t.Fatal(err)
-	}
-
-	mKeySize := int64(mvccKey(key).EncodedSize())
-	require.EqualValues(t, mKeySize, 11)
-
-	mValSize := int64((&enginepb.MVCCMetadata{
-		Timestamp: hlc.LegacyTimestamp(ts1),
-		Deleted:   false,
-		Txn:       &txn.TxnMeta,
-	}).Size())
-	require.EqualValues(t, mValSize, 46)
-
-	vKeySize := MVCCVersionTimestampSize
-	require.EqualValues(t, vKeySize, 12)
-
-	vVal1Size := int64(len(val1.RawBytes))
-	require.EqualValues(t, vVal1Size, 10)
-
-	val2 := roachpb.MakeValueFromString("longvalue")
-	vVal2Size := int64(len(val2.RawBytes))
-	require.EqualValues(t, vVal2Size, 14)
-
-	expMS := enginepb.MVCCStats{
-		LastUpdateNanos: 1E9,
-		SysBytes:        mKeySize + mValSize + vKeySize + vVal1Size, // 11+44+12+10 = 77
-		SysCount:        1,
-	}
-	assertEq(t, engine, "after first put", aggMS, &expMS)
-
-	// Rewrite the intent to ts2 with a different value.
-	txn.Timestamp.Forward(ts2)
-	txn.Sequence++
-
-	// The new meta value grows because we've bumped `txn.Sequence`.
-	// The value also grows as the older value is part of the same
-	// transaction and so contributes to the intent history.
-	mVal2Size := int64((&enginepb.MVCCMetadata{
-		Timestamp: hlc.LegacyTimestamp(ts2),
-		Deleted:   false,
-		Txn:       &txn.TxnMeta,
-		IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
-			{Sequence: 0, Value: val1.RawBytes},
-		},
-	}).Size())
-	require.EqualValues(t, mVal2Size, 64)
-
-	if err := MVCCPut(ctx, engine, aggMS, key, txn.OrigTimestamp, val2, txn); err != nil {
-		t.Fatal(err)
-	}
-
-	expMS = enginepb.MVCCStats{
-		LastUpdateNanos: 1E9,
-		SysBytes:        mKeySize + mVal2Size + vKeySize + vVal2Size, // 11+46+12+14 = 83
-		SysCount:        1,
-	}
-
-	assertEq(t, engine, "after intent rewrite", aggMS, &expMS)
 }
 
 // TestMVCCStatsTxnSysPutAbort prevents regression of a bug that, when aborting
@@ -1139,125 +1183,133 @@ func TestMVCCStatsTxnSysPutPut(t *testing.T) {
 // `ms.IntentCount`.
 func TestMVCCStatsTxnSysPutAbort(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	ctx := context.Background()
-	aggMS := &enginepb.MVCCStats{}
+			ctx := context.Background()
+			aggMS := &enginepb.MVCCStats{}
 
-	assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
+			assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
 
-	key := keys.RangeDescriptorKey(roachpb.RKey("a"))
+			key := keys.RangeDescriptorKey(roachpb.RKey("a"))
 
-	ts1 := hlc.Timestamp{WallTime: 1E9}
-	txn := &roachpb.Transaction{
-		TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts1},
-		OrigTimestamp: ts1,
+			ts1 := hlc.Timestamp{WallTime: 1E9}
+			txn := &roachpb.Transaction{
+				TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts1},
+				OrigTimestamp: ts1,
+			}
+
+			// Write a system intent at ts1.
+			val1 := roachpb.MakeValueFromString("value")
+			if err := MVCCPut(ctx, engine, aggMS, key, txn.OrigTimestamp, val1, txn); err != nil {
+				t.Fatal(err)
+			}
+
+			mKeySize := int64(mvccKey(key).EncodedSize())
+			require.EqualValues(t, mKeySize, 11)
+
+			mValSize := int64((&enginepb.MVCCMetadata{
+				Timestamp: hlc.LegacyTimestamp(ts1),
+				Deleted:   false,
+				Txn:       &txn.TxnMeta,
+			}).Size())
+			require.EqualValues(t, mValSize, 46)
+
+			vKeySize := MVCCVersionTimestampSize
+			require.EqualValues(t, vKeySize, 12)
+
+			vVal1Size := int64(len(val1.RawBytes))
+			require.EqualValues(t, vVal1Size, 10)
+
+			val2 := roachpb.MakeValueFromString("longvalue")
+			vVal2Size := int64(len(val2.RawBytes))
+			require.EqualValues(t, vVal2Size, 14)
+
+			expMS := enginepb.MVCCStats{
+				LastUpdateNanos: 1E9,
+				SysBytes:        mKeySize + mValSize + vKeySize + vVal1Size, // 11+44+12+10 = 77
+				SysCount:        1,
+			}
+			assertEq(t, engine, "after first put", aggMS, &expMS)
+
+			// Now abort the intent.
+			txn.Status = roachpb.ABORTED
+			if err := MVCCResolveWriteIntent(ctx, engine, aggMS, roachpb.Intent{
+				Span: roachpb.Span{Key: key}, Status: txn.Status, Txn: txn.TxnMeta,
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			expMS = enginepb.MVCCStats{
+				LastUpdateNanos: 1E9,
+			}
+			assertEq(t, engine, "after aborting", aggMS, &expMS)
+		})
 	}
-
-	// Write a system intent at ts1.
-	val1 := roachpb.MakeValueFromString("value")
-	if err := MVCCPut(ctx, engine, aggMS, key, txn.OrigTimestamp, val1, txn); err != nil {
-		t.Fatal(err)
-	}
-
-	mKeySize := int64(mvccKey(key).EncodedSize())
-	require.EqualValues(t, mKeySize, 11)
-
-	mValSize := int64((&enginepb.MVCCMetadata{
-		Timestamp: hlc.LegacyTimestamp(ts1),
-		Deleted:   false,
-		Txn:       &txn.TxnMeta,
-	}).Size())
-	require.EqualValues(t, mValSize, 46)
-
-	vKeySize := MVCCVersionTimestampSize
-	require.EqualValues(t, vKeySize, 12)
-
-	vVal1Size := int64(len(val1.RawBytes))
-	require.EqualValues(t, vVal1Size, 10)
-
-	val2 := roachpb.MakeValueFromString("longvalue")
-	vVal2Size := int64(len(val2.RawBytes))
-	require.EqualValues(t, vVal2Size, 14)
-
-	expMS := enginepb.MVCCStats{
-		LastUpdateNanos: 1E9,
-		SysBytes:        mKeySize + mValSize + vKeySize + vVal1Size, // 11+44+12+10 = 77
-		SysCount:        1,
-	}
-	assertEq(t, engine, "after first put", aggMS, &expMS)
-
-	// Now abort the intent.
-	txn.Status = roachpb.ABORTED
-	if err := MVCCResolveWriteIntent(ctx, engine, aggMS, roachpb.Intent{
-		Span: roachpb.Span{Key: key}, Status: txn.Status, Txn: txn.TxnMeta,
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	expMS = enginepb.MVCCStats{
-		LastUpdateNanos: 1E9,
-	}
-	assertEq(t, engine, "after aborting", aggMS, &expMS)
 }
 
 // TestMVCCStatsSysPutPut prevents regression of a bug that, when writing a new
 // value on top of an existing system key, would undercount.
 func TestMVCCStatsSysPutPut(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	ctx := context.Background()
-	aggMS := &enginepb.MVCCStats{}
+			ctx := context.Background()
+			aggMS := &enginepb.MVCCStats{}
 
-	assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
+			assertEq(t, engine, "initially", aggMS, &enginepb.MVCCStats{})
 
-	key := keys.RangeDescriptorKey(roachpb.RKey("a"))
+			key := keys.RangeDescriptorKey(roachpb.RKey("a"))
 
-	ts1 := hlc.Timestamp{WallTime: 1E9}
-	ts2 := hlc.Timestamp{WallTime: 2E9}
+			ts1 := hlc.Timestamp{WallTime: 1E9}
+			ts2 := hlc.Timestamp{WallTime: 2E9}
 
-	// Write a value at ts1.
-	val1 := roachpb.MakeValueFromString("value")
-	if err := MVCCPut(ctx, engine, aggMS, key, ts1, val1, nil /* txn */); err != nil {
-		t.Fatal(err)
+			// Write a value at ts1.
+			val1 := roachpb.MakeValueFromString("value")
+			if err := MVCCPut(ctx, engine, aggMS, key, ts1, val1, nil /* txn */); err != nil {
+				t.Fatal(err)
+			}
+
+			mKeySize := int64(mvccKey(key).EncodedSize())
+			require.EqualValues(t, mKeySize, 11)
+
+			vKeySize := MVCCVersionTimestampSize
+			require.EqualValues(t, vKeySize, 12)
+
+			vVal1Size := int64(len(val1.RawBytes))
+			require.EqualValues(t, vVal1Size, 10)
+
+			val2 := roachpb.MakeValueFromString("longvalue")
+			vVal2Size := int64(len(val2.RawBytes))
+			require.EqualValues(t, vVal2Size, 14)
+
+			expMS := enginepb.MVCCStats{
+				LastUpdateNanos: 1E9,
+				SysBytes:        mKeySize + vKeySize + vVal1Size, // 11+12+10 = 33
+				SysCount:        1,
+			}
+			assertEq(t, engine, "after first put", aggMS, &expMS)
+
+			// Put another value at ts2.
+
+			if err := MVCCPut(ctx, engine, aggMS, key, ts2, val2, nil /* txn */); err != nil {
+				t.Fatal(err)
+			}
+
+			expMS = enginepb.MVCCStats{
+				LastUpdateNanos: 1E9,
+				SysBytes:        mKeySize + 2*vKeySize + vVal1Size + vVal2Size,
+				SysCount:        1,
+			}
+
+			assertEq(t, engine, "after second put", aggMS, &expMS)
+		})
 	}
-
-	mKeySize := int64(mvccKey(key).EncodedSize())
-	require.EqualValues(t, mKeySize, 11)
-
-	vKeySize := MVCCVersionTimestampSize
-	require.EqualValues(t, vKeySize, 12)
-
-	vVal1Size := int64(len(val1.RawBytes))
-	require.EqualValues(t, vVal1Size, 10)
-
-	val2 := roachpb.MakeValueFromString("longvalue")
-	vVal2Size := int64(len(val2.RawBytes))
-	require.EqualValues(t, vVal2Size, 14)
-
-	expMS := enginepb.MVCCStats{
-		LastUpdateNanos: 1E9,
-		SysBytes:        mKeySize + vKeySize + vVal1Size, // 11+12+10 = 33
-		SysCount:        1,
-	}
-	assertEq(t, engine, "after first put", aggMS, &expMS)
-
-	// Put another value at ts2.
-
-	if err := MVCCPut(ctx, engine, aggMS, key, ts2, val2, nil /* txn */); err != nil {
-		t.Fatal(err)
-	}
-
-	expMS = enginepb.MVCCStats{
-		LastUpdateNanos: 1E9,
-		SysBytes:        mKeySize + 2*vKeySize + vVal1Size + vVal2Size,
-		SysCount:        1,
-	}
-
-	assertEq(t, engine, "after second put", aggMS, &expMS)
 }
 
 var mvccStatsTests = []struct {
@@ -1476,66 +1528,74 @@ func TestMVCCStatsRandomized(t *testing.T) {
 		return fmt.Sprint(gcTS)
 	}
 
-	for _, test := range []struct {
-		name string
-		key  roachpb.Key
-		seed int64
-	}{
-		{
-			name: "userspace",
-			key:  roachpb.Key("foo"),
-			seed: randutil.NewPseudoSeed(),
-		},
-		{
-			name: "sys",
-			key:  keys.RangeDescriptorKey(roachpb.RKey("bar")),
-			seed: randutil.NewPseudoSeed(),
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			testutils.RunTrueAndFalse(t, "inline", func(t *testing.T, inline bool) {
-				t.Run(fmt.Sprintf("seed=%d", test.seed), func(t *testing.T) {
-					eng := createTestEngine()
-					defer eng.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			for _, test := range []struct {
+				name string
+				key  roachpb.Key
+				seed int64
+			}{
+				{
+					name: "userspace",
+					key:  roachpb.Key("foo"),
+					seed: randutil.NewPseudoSeed(),
+				},
+				{
+					name: "sys",
+					key:  keys.RangeDescriptorKey(roachpb.RKey("bar")),
+					seed: randutil.NewPseudoSeed(),
+				},
+			} {
+				t.Run(test.name, func(t *testing.T) {
+					testutils.RunTrueAndFalse(t, "inline", func(t *testing.T, inline bool) {
+						t.Run(fmt.Sprintf("seed=%d", test.seed), func(t *testing.T) {
+							eng := engineImpl.create()
+							defer eng.Close()
 
-					s := &randomTest{
-						actions: actions,
-						inline:  inline,
-						state: state{
-							rng: rand.New(rand.NewSource(test.seed)),
-							eng: eng,
-							key: test.key,
-							MS:  &enginepb.MVCCStats{},
-						},
-					}
+							s := &randomTest{
+								actions: actions,
+								inline:  inline,
+								state: state{
+									rng: rand.New(rand.NewSource(test.seed)),
+									eng: eng,
+									key: test.key,
+									MS:  &enginepb.MVCCStats{},
+								},
+							}
 
-					for i := 0; i < count; i++ {
-						s.step(t)
-					}
+							for i := 0; i < count; i++ {
+								s.step(t)
+							}
+						})
+					})
 				})
-			})
+			}
 		})
 	}
 }
 
 func TestMVCCComputeStatsError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	// Write a MVCC metadata key where the value is not an encoded MVCCMetadata
-	// protobuf.
-	if err := engine.Put(mvccKey(roachpb.Key("garbage")), []byte("garbage")); err != nil {
-		t.Fatal(err)
-	}
+			// Write a MVCC metadata key where the value is not an encoded MVCCMetadata
+			// protobuf.
+			if err := engine.Put(mvccKey(roachpb.Key("garbage")), []byte("garbage")); err != nil {
+				t.Fatal(err)
+			}
 
-	iter := engine.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
-	defer iter.Close()
-	for _, mvccStatsTest := range mvccStatsTests {
-		t.Run(mvccStatsTest.name, func(t *testing.T) {
-			_, err := mvccStatsTest.fn(iter, mvccKey(roachpb.KeyMin), mvccKey(roachpb.KeyMax), 100)
-			if e := "unable to decode MVCCMetadata"; !testutils.IsError(err, e) {
-				t.Fatalf("expected %s, got %v", e, err)
+			iter := engine.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
+			defer iter.Close()
+			for _, mvccStatsTest := range mvccStatsTests {
+				t.Run(mvccStatsTest.name, func(t *testing.T) {
+					_, err := mvccStatsTest.fn(iter, mvccKey(roachpb.KeyMin), mvccKey(roachpb.KeyMax), 100)
+					if e := "unable to decode MVCCMetadata"; !testutils.IsError(err, e) {
+						t.Fatalf("expected %s, got %v", e, err)
+					}
+				})
 			}
 		})
 	}

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -37,6 +37,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/shuffle"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/vfs"
 	"github.com/gogo/protobuf/proto"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
@@ -78,10 +80,29 @@ var (
 	valueEmpty = roachpb.MakeValueFromString("")
 )
 
-// createTestEngine returns a new in-memory engine with 1MB of storage
-// capacity.
-func createTestEngine() Engine {
+// createTestRocksDBEngine returns a new in-memory RocksDB engine with 1MB of
+// storage capacity.
+func createTestRocksDBEngine() Engine {
 	return NewInMem(roachpb.Attributes{}, 1<<20)
+}
+
+// createTestPebbleEngine returns a new in-memory Pebble storage engine.
+func createTestPebbleEngine() Engine {
+	peb, err := NewPebble("", &pebble.Options{
+		FS: vfs.NewMem(),
+	})
+	if err != nil {
+		return nil
+	}
+	return peb
+}
+
+var mvccEngineImpls = []struct {
+	name   string
+	create func() Engine
+}{
+	{"rocksdb", createTestRocksDBEngine},
+	{"pebble", createTestPebbleEngine},
 }
 
 // makeTxn creates a new transaction using the specified base
@@ -322,25 +343,30 @@ func TestMVCCEmptyKey(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
 
-	key := roachpb.Key{}
-	ts := hlc.Timestamp{Logical: 1}
-	if _, _, err := MVCCGet(ctx, engine, key, ts, MVCCGetOptions{}); err == nil {
-		t.Error("expected empty key error")
-	}
-	if err := MVCCPut(ctx, engine, nil, key, ts, value1, nil); err == nil {
-		t.Error("expected empty key error")
-	}
-	if _, _, _, err := MVCCScan(ctx, engine, key, testKey1, math.MaxInt64, ts, MVCCScanOptions{}); err != nil {
-		t.Errorf("empty key allowed for start key in scan; got %s", err)
-	}
-	if _, _, _, err := MVCCScan(ctx, engine, testKey1, key, math.MaxInt64, ts, MVCCScanOptions{}); err == nil {
-		t.Error("expected empty key error")
-	}
-	if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{}); err == nil {
-		t.Error("expected empty key error")
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
+
+			key := roachpb.Key{}
+			ts := hlc.Timestamp{Logical: 1}
+			if _, _, err := MVCCGet(ctx, engine, key, ts, MVCCGetOptions{}); err == nil {
+				t.Error("expected empty key error")
+			}
+			if err := MVCCPut(ctx, engine, nil, key, ts, value1, nil); err == nil {
+				t.Error("expected empty key error")
+			}
+			if _, _, _, err := MVCCScan(ctx, engine, key, testKey1, math.MaxInt64, ts, MVCCScanOptions{}); err != nil {
+				t.Errorf("empty key allowed for start key in scan; got %s", err)
+			}
+			if _, _, _, err := MVCCScan(ctx, engine, testKey1, key, math.MaxInt64, ts, MVCCScanOptions{}); err == nil {
+				t.Error("expected empty key error")
+			}
+			if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{}); err == nil {
+				t.Error("expected empty key error")
+			}
+		})
 	}
 }
 
@@ -348,38 +374,46 @@ func TestMVCCGetNegativeTimestampError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, nil)
-	if err != nil {
-		t.Fatal(err)
+			err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			timestamp := hlc.Timestamp{WallTime: -1}
+			expectedErrorString := fmt.Sprintf("cannot write to %q at timestamp %s", testKey1, timestamp)
+
+			_, intent, err := MVCCGet(ctx, engine, testKey1, timestamp, MVCCGetOptions{})
+			require.EqualError(t, err, expectedErrorString, intent)
+		})
 	}
-
-	timestamp := hlc.Timestamp{WallTime: -1}
-	expectedErrorString := fmt.Sprintf("cannot write to %q at timestamp %s", testKey1, timestamp)
-
-	_, intent, err := MVCCGet(ctx, engine, testKey1, timestamp, MVCCGetOptions{})
-	require.EqualError(t, err, expectedErrorString, intent)
 }
 
 func TestMVCCGetNotExist(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	for _, impl := range mvccGetImpls {
-		t.Run(impl.name, func(t *testing.T) {
-			mvccGet := impl.fn
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			for _, impl := range mvccGetImpls {
+				t.Run(impl.name, func(t *testing.T) {
+					mvccGet := impl.fn
 
-			engine := createTestEngine()
-			defer engine.Close()
+					engine := engineImpl.create()
+					defer engine.Close()
 
-			value, _, err := mvccGet(context.Background(), engine, testKey1, hlc.Timestamp{Logical: 1},
-				MVCCGetOptions{})
-			if err != nil {
-				t.Fatal(err)
-			}
-			if value != nil {
-				t.Fatal("the value should be empty")
+					value, _, err := mvccGet(context.Background(), engine, testKey1, hlc.Timestamp{Logical: 1},
+						MVCCGetOptions{})
+					if err != nil {
+						t.Fatal(err)
+					}
+					if value != nil {
+						t.Fatal("the value should be empty")
+					}
+				})
 			}
 		})
 	}
@@ -389,22 +423,26 @@ func TestMVCCPutWithTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn1.OrigTimestamp, value1, txn1); err != nil {
+				t.Fatal(err)
+			}
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1.OrigTimestamp, value1, txn1); err != nil {
-		t.Fatal(err)
-	}
+			for _, ts := range []hlc.Timestamp{{Logical: 1}, {Logical: 2}, {WallTime: 1}} {
+				value, _, err := MVCCGet(ctx, engine, testKey1, ts, MVCCGetOptions{Txn: txn1})
 
-	for _, ts := range []hlc.Timestamp{{Logical: 1}, {Logical: 2}, {WallTime: 1}} {
-		value, _, err := MVCCGet(ctx, engine, testKey1, ts, MVCCGetOptions{Txn: txn1})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !bytes.Equal(value1.RawBytes, value.RawBytes) {
-			t.Fatalf("the value %s in get result does not match the value %s in request",
-				value1.RawBytes, value.RawBytes)
-		}
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(value1.RawBytes, value.RawBytes) {
+					t.Fatalf("the value %+v in get result does not match the value %+v in request",
+						value1.RawBytes, value.RawBytes)
+				}
+			}
+		})
 	}
 }
 
@@ -412,23 +450,27 @@ func TestMVCCPutWithoutTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+			err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	for _, ts := range []hlc.Timestamp{{Logical: 1}, {Logical: 2}, {WallTime: 1}} {
-		value, _, err := MVCCGet(ctx, engine, testKey1, ts, MVCCGetOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !bytes.Equal(value1.RawBytes, value.RawBytes) {
-			t.Fatalf("the value %s in get result does not match the value %s in request",
-				value1.RawBytes, value.RawBytes)
-		}
+			for _, ts := range []hlc.Timestamp{{Logical: 1}, {Logical: 2}, {WallTime: 1}} {
+				value, _, err := MVCCGet(ctx, engine, testKey1, ts, MVCCGetOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(value1.RawBytes, value.RawBytes) {
+					t.Fatalf("the value %s in get result does not match the value %s in request",
+						value1.RawBytes, value.RawBytes)
+				}
+			}
+		})
 	}
 }
 
@@ -438,49 +480,53 @@ func TestMVCCPutOutOfOrder(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	txn := *txn1
-	txn.OrigTimestamp = hlc.Timestamp{WallTime: 1}
-	txn.Timestamp = hlc.Timestamp{WallTime: 2, Logical: 1}
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value1, &txn); err != nil {
-		t.Fatal(err)
-	}
+			txn := *txn1
+			txn.OrigTimestamp = hlc.Timestamp{WallTime: 1}
+			txn.Timestamp = hlc.Timestamp{WallTime: 2, Logical: 1}
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value1, &txn); err != nil {
+				t.Fatal(err)
+			}
 
-	// Put operation with earlier wall time. Will NOT be ignored.
-	txn.Sequence++
-	txn.Timestamp = hlc.Timestamp{WallTime: 1}
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value2, &txn); err != nil {
-		t.Fatal(err)
-	}
+			// Put operation with earlier wall time. Will NOT be ignored.
+			txn.Sequence++
+			txn.Timestamp = hlc.Timestamp{WallTime: 1}
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value2, &txn); err != nil {
+				t.Fatal(err)
+			}
 
-	value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 3}, MVCCGetOptions{
-		Txn: &txn,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(value.RawBytes, value2.RawBytes) {
-		t.Fatalf("the value should be %s, but got %s",
-			value2.RawBytes, value.RawBytes)
-	}
+			value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 3}, MVCCGetOptions{
+				Txn: &txn,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(value.RawBytes, value2.RawBytes) {
+				t.Fatalf("the value should be %s, but got %s",
+					value2.RawBytes, value.RawBytes)
+			}
 
-	// Another put operation with earlier logical time. Will NOT be ignored.
-	txn.Sequence++
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value2, &txn); err != nil {
-		t.Fatal(err)
-	}
+			// Another put operation with earlier logical time. Will NOT be ignored.
+			txn.Sequence++
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value2, &txn); err != nil {
+				t.Fatal(err)
+			}
 
-	value, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 3}, MVCCGetOptions{
-		Txn: &txn,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(value.RawBytes, value2.RawBytes) {
-		t.Fatalf("the value should be %s, but got %s",
-			value2.RawBytes, value.RawBytes)
+			value, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 3}, MVCCGetOptions{
+				Txn: &txn,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(value.RawBytes, value2.RawBytes) {
+				t.Fatalf("the value should be %s, but got %s",
+					value2.RawBytes, value.RawBytes)
+			}
+		})
 	}
 }
 
@@ -493,62 +539,66 @@ func TestMVCCPutNewEpochLowerSequence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
-	txn.Sequence = 5
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value1, txn); err != nil {
-		t.Fatal(err)
-	}
-	value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 3}, MVCCGetOptions{
-		Txn: txn,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(value.RawBytes, value1.RawBytes) {
-		t.Fatalf("the value should be %s, but got %s",
-			value2.RawBytes, value.RawBytes)
-	}
+			txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
+			txn.Sequence = 5
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value1, txn); err != nil {
+				t.Fatal(err)
+			}
+			value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 3}, MVCCGetOptions{
+				Txn: txn,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(value.RawBytes, value1.RawBytes) {
+				t.Fatalf("the value should be %s, but got %s",
+					value2.RawBytes, value.RawBytes)
+			}
 
-	txn.Sequence = 4
-	txn.Epoch++
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value2, txn); err != nil {
-		t.Fatal(err)
-	}
+			txn.Sequence = 4
+			txn.Epoch++
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value2, txn); err != nil {
+				t.Fatal(err)
+			}
 
-	// Check that the intent meta was found and contains no intent history.
-	// The history was blown away because the epoch is now higher.
-	aggMeta := &enginepb.MVCCMetadata{
-		Txn:           &txn.TxnMeta,
-		Timestamp:     hlc.LegacyTimestamp{WallTime: 1},
-		KeyBytes:      MVCCVersionTimestampSize,
-		ValBytes:      int64(len(value2.RawBytes)),
-		IntentHistory: nil,
-	}
-	metaKey := mvccKey(testKey1)
-	meta := &enginepb.MVCCMetadata{}
-	ok, _, _, err := engine.GetProto(metaKey, meta)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok {
-		t.Fatal("intent should not be cleared")
-	}
-	if !meta.Equal(aggMeta) {
-		t.Errorf("expected metadata:\n%+v;\n got: \n%+v", aggMeta, meta)
-	}
+			// Check that the intent meta was found and contains no intent history.
+			// The history was blown away because the epoch is now higher.
+			aggMeta := &enginepb.MVCCMetadata{
+				Txn:           &txn.TxnMeta,
+				Timestamp:     hlc.LegacyTimestamp{WallTime: 1},
+				KeyBytes:      MVCCVersionTimestampSize,
+				ValBytes:      int64(len(value2.RawBytes)),
+				IntentHistory: nil,
+			}
+			metaKey := mvccKey(testKey1)
+			meta := &enginepb.MVCCMetadata{}
+			ok, _, _, err := engine.GetProto(metaKey, meta)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !ok {
+				t.Fatal("intent should not be cleared")
+			}
+			if !meta.Equal(aggMeta) {
+				t.Errorf("expected metadata:\n%+v;\n got: \n%+v", aggMeta, meta)
+			}
 
-	value, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 3}, MVCCGetOptions{
-		Txn: txn,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(value.RawBytes, value2.RawBytes) {
-		t.Fatalf("the value should be %s, but got %s",
-			value2.RawBytes, value.RawBytes)
+			value, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 3}, MVCCGetOptions{
+				Txn: txn,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(value.RawBytes, value2.RawBytes) {
+				t.Fatalf("the value should be %s, but got %s",
+					value2.RawBytes, value.RawBytes)
+			}
+		})
 	}
 }
 
@@ -558,30 +608,34 @@ func TestMVCCIncrement(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	newVal, err := MVCCIncrement(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, nil, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if newVal != 0 {
-		t.Errorf("expected new value of 0; got %d", newVal)
-	}
-	val, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{Logical: 1}, MVCCGetOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if val == nil {
-		t.Errorf("expected increment of 0 to create key/value")
-	}
+			newVal, err := MVCCIncrement(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, nil, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if newVal != 0 {
+				t.Errorf("expected new value of 0; got %d", newVal)
+			}
+			val, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{Logical: 1}, MVCCGetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if val == nil {
+				t.Errorf("expected increment of 0 to create key/value")
+			}
 
-	newVal, err = MVCCIncrement(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 2}, nil, 2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if newVal != 2 {
-		t.Errorf("expected new value of 2; got %d", newVal)
+			newVal, err = MVCCIncrement(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 2}, nil, 2)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if newVal != 2 {
+				t.Errorf("expected new value of 2; got %d", newVal)
+			}
+		})
 	}
 }
 
@@ -590,19 +644,23 @@ func TestMVCCIncrementTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	txn := *txn1
-	for i := 1; i <= 2; i++ {
-		txn.Sequence++
-		newVal, err := MVCCIncrement(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, &txn, 1)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if newVal != int64(i) {
-			t.Errorf("expected new value of %d; got %d", i, newVal)
-		}
+			txn := *txn1
+			for i := 1; i <= 2; i++ {
+				txn.Sequence++
+				newVal, err := MVCCIncrement(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, &txn, 1)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if newVal != int64(i) {
+					t.Errorf("expected new value of %d; got %d", i, newVal)
+				}
+			}
+		})
 	}
 }
 
@@ -613,34 +671,38 @@ func TestMVCCIncrementOldTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	// Write an integer value.
-	val := roachpb.Value{}
-	val.SetInt(1)
-	err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, val, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+			// Write an integer value.
+			val := roachpb.Value{}
+			val.SetInt(1)
+			err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, val, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	// Override value.
-	val.SetInt(2)
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, val, nil); err != nil {
-		t.Fatal(err)
-	}
+			// Override value.
+			val.SetInt(2)
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, val, nil); err != nil {
+				t.Fatal(err)
+			}
 
-	// Attempt to increment a value with an older timestamp than
-	// the previous put. This will fail with type mismatch (not
-	// with WriteTooOldError).
-	incVal, err := MVCCIncrement(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 2}, nil, 1)
-	if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok {
-		t.Fatalf("unexpectedly not WriteTooOld: %+v", err)
-	} else if expTS := (hlc.Timestamp{WallTime: 3, Logical: 1}); wtoErr.ActualTimestamp != (expTS) {
-		t.Fatalf("expected write too old error with actual ts %s; got %s", expTS, wtoErr.ActualTimestamp)
-	}
-	if incVal != 3 {
-		t.Fatalf("expected value=%d; got %d", 3, incVal)
+			// Attempt to increment a value with an older timestamp than
+			// the previous put. This will fail with type mismatch (not
+			// with WriteTooOldError).
+			incVal, err := MVCCIncrement(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 2}, nil, 1)
+			if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok {
+				t.Fatalf("unexpectedly not WriteTooOld: %+v", err)
+			} else if expTS := (hlc.Timestamp{WallTime: 3, Logical: 1}); wtoErr.ActualTimestamp != (expTS) {
+				t.Fatalf("expected write too old error with actual ts %s; got %s", expTS, wtoErr.ActualTimestamp)
+			}
+			if incVal != 3 {
+				t.Fatalf("expected value=%d; got %d", 3, incVal)
+			}
+		})
 	}
 }
 
@@ -648,45 +710,49 @@ func TestMVCCUpdateExistingKey(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+			err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(value1.RawBytes, value.RawBytes) {
-		t.Fatalf("the value %s in get result does not match the value %s in request",
-			value1.RawBytes, value.RawBytes)
-	}
+			value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(value1.RawBytes, value.RawBytes) {
+				t.Fatalf("the value %s in get result does not match the value %s in request",
+					value1.RawBytes, value.RawBytes)
+			}
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 2}, value2, nil); err != nil {
-		t.Fatal(err)
-	}
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 2}, value2, nil); err != nil {
+				t.Fatal(err)
+			}
 
-	// Read the latest version.
-	value, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 3}, MVCCGetOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(value2.RawBytes, value.RawBytes) {
-		t.Fatalf("the value %s in get result does not match the value %s in request",
-			value2.RawBytes, value.RawBytes)
-	}
+			// Read the latest version.
+			value, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 3}, MVCCGetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(value2.RawBytes, value.RawBytes) {
+				t.Fatalf("the value %s in get result does not match the value %s in request",
+					value2.RawBytes, value.RawBytes)
+			}
 
-	// Read the old version.
-	value, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(value1.RawBytes, value.RawBytes) {
-		t.Fatalf("the value %s in get result does not match the value %s in request",
-			value1.RawBytes, value.RawBytes)
+			// Read the old version.
+			value, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(value1.RawBytes, value.RawBytes) {
+				t.Fatalf("the value %s in get result does not match the value %s in request",
+					value1.RawBytes, value.RawBytes)
+			}
+		})
 	}
 }
 
@@ -694,19 +760,23 @@ func TestMVCCUpdateExistingKeyOldVersion(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1, Logical: 1}, value1, nil); err != nil {
-		t.Fatal(err)
-	}
-	// Earlier wall time.
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value2, nil); err == nil {
-		t.Fatal("expected error on old version")
-	}
-	// Earlier logical time.
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value2, nil); err == nil {
-		t.Fatal("expected error on old version")
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1, Logical: 1}, value1, nil); err != nil {
+				t.Fatal(err)
+			}
+			// Earlier wall time.
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value2, nil); err == nil {
+				t.Fatal("expected error on old version")
+			}
+			// Earlier logical time.
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value2, nil); err == nil {
+				t.Fatal("expected error on old version")
+			}
+		})
 	}
 }
 
@@ -714,18 +784,22 @@ func TestMVCCUpdateExistingKeyInTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	txn := *txn1
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value1, &txn); err != nil {
-		t.Fatal(err)
-	}
+			txn := *txn1
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value1, &txn); err != nil {
+				t.Fatal(err)
+			}
 
-	txn.Sequence++
-	txn.Timestamp = hlc.Timestamp{WallTime: 1}
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value1, &txn); err != nil {
-		t.Fatal(err)
+			txn.Sequence++
+			txn.Timestamp = hlc.Timestamp{WallTime: 1}
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value1, &txn); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }
 
@@ -733,15 +807,19 @@ func TestMVCCUpdateExistingKeyDiffTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1.OrigTimestamp, value1, txn1); err != nil {
-		t.Fatal(err)
-	}
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn1.OrigTimestamp, value1, txn1); err != nil {
+				t.Fatal(err)
+			}
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn2.OrigTimestamp, value2, txn2); err == nil {
-		t.Fatal("expected error on uncommitted write intent")
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn2.OrigTimestamp, value2, txn2); err == nil {
+				t.Fatal("expected error on uncommitted write intent")
+			}
+		})
 	}
 }
 
@@ -750,38 +828,42 @@ func TestMVCCGetNoMoreOldVersion(t *testing.T) {
 
 	ctx := context.Background()
 
-	for _, impl := range mvccGetImpls {
-		t.Run(impl.name, func(t *testing.T) {
-			mvccGet := impl.fn
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			for _, impl := range mvccGetImpls {
+				t.Run(impl.name, func(t *testing.T) {
+					mvccGet := impl.fn
 
-			// Need to handle the case here where the scan takes us to the
-			// next key, which may not match the key we're looking for. In
-			// other words, if we're looking for a<T=2>, and we have the
-			// following keys:
-			//
-			// a: MVCCMetadata(a)
-			// a<T=3>
-			// b: MVCCMetadata(b)
-			// b<T=1>
-			//
-			// If we search for a<T=2>, the scan should not return "b".
+					// Need to handle the case here where the scan takes us to the
+					// next key, which may not match the key we're looking for. In
+					// other words, if we're looking for a<T=2>, and we have the
+					// following keys:
+					//
+					// a: MVCCMetadata(a)
+					// a<T=3>
+					// b: MVCCMetadata(b)
+					// b<T=1>
+					//
+					// If we search for a<T=2>, the scan should not return "b".
 
-			engine := createTestEngine()
-			defer engine.Close()
+					engine := engineImpl.create()
+					defer engine.Close()
 
-			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, value1, nil); err != nil {
-				t.Fatal(err)
-			}
-			if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
-				t.Fatal(err)
-			}
+					if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, value1, nil); err != nil {
+						t.Fatal(err)
+					}
+					if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
+						t.Fatal(err)
+					}
 
-			value, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{})
-			if err != nil {
-				t.Fatal(err)
-			}
-			if value != nil {
-				t.Fatal("the value should be empty")
+					value, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{})
+					if err != nil {
+						t.Fatal(err)
+					}
+					if value != nil {
+						t.Fatal("the value should be empty")
+					}
+				})
 			}
 		})
 	}
@@ -795,274 +877,277 @@ func TestMVCCGetUncertainty(t *testing.T) {
 
 	ctx := context.Background()
 
-	for _, impl := range mvccGetImpls {
-		t.Run(impl.name, func(t *testing.T) {
-			mvccGet := impl.fn
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			for _, impl := range mvccGetImpls {
+				t.Run(impl.name, func(t *testing.T) {
+					mvccGet := impl.fn
+					engine := engineImpl.create()
+					defer engine.Close()
 
-			engine := createTestEngine()
-			defer engine.Close()
+					// Txn with read timestamp 7 and MaxTimestamp 10.
+					txn := &roachpb.Transaction{
+						TxnMeta: enginepb.TxnMeta{
+							ID:        uuid.MakeV4(),
+							Timestamp: hlc.Timestamp{WallTime: 7},
+						},
+						MaxTimestamp: hlc.Timestamp{WallTime: 10},
+					}
+					getOptsTxn := MVCCGetOptions{Txn: txn}
+					scanOptsTxn := MVCCScanOptions{Txn: txn}
 
-			// Txn with read timestamp 7 and MaxTimestamp 10.
-			txn := &roachpb.Transaction{
-				TxnMeta: enginepb.TxnMeta{
-					ID:        uuid.MakeV4(),
-					Timestamp: hlc.Timestamp{WallTime: 7},
-				},
-				MaxTimestamp: hlc.Timestamp{WallTime: 10},
-			}
-			getOptsTxn := MVCCGetOptions{Txn: txn}
-			scanOptsTxn := MVCCScanOptions{Txn: txn}
+					// Same txn but with a MaxTimestamp reduced to 9.
+					txnMaxTS9 := txn.Clone()
+					txnMaxTS9.MaxTimestamp = hlc.Timestamp{WallTime: 9}
+					getOptsTxnMaxTS9 := MVCCGetOptions{Txn: txnMaxTS9}
+					scanOptsTxnMaxTS9 := MVCCScanOptions{Txn: txnMaxTS9}
 
-			// Same txn but with a MaxTimestamp reduced to 9.
-			txnMaxTS9 := txn.Clone()
-			txnMaxTS9.MaxTimestamp = hlc.Timestamp{WallTime: 9}
-			getOptsTxnMaxTS9 := MVCCGetOptions{Txn: txnMaxTS9}
-			scanOptsTxnMaxTS9 := MVCCScanOptions{Txn: txnMaxTS9}
+					// Same txn but with a MaxTimestamp reduced to 7.
+					txnMaxTS7 := txn.Clone()
+					txnMaxTS7.MaxTimestamp = hlc.Timestamp{WallTime: 7}
+					getOptsTxnMaxTS7 := MVCCGetOptions{Txn: txnMaxTS7}
+					scanOptsTxnMaxTS7 := MVCCScanOptions{Txn: txnMaxTS7}
 
-			// Same txn but with a MaxTimestamp reduced to 7.
-			txnMaxTS7 := txn.Clone()
-			txnMaxTS7.MaxTimestamp = hlc.Timestamp{WallTime: 7}
-			getOptsTxnMaxTS7 := MVCCGetOptions{Txn: txnMaxTS7}
-			scanOptsTxnMaxTS7 := MVCCScanOptions{Txn: txnMaxTS7}
+					// Case 1: One value in the past, one value in the future of read
+					// and ahead of MaxTimestamp of read. Neither should interfere.
+					//
+					// -----------------
+					// - 12: val2
+					// |
+					// - 10: max timestamp
+					// |
+					// -  7: read timestamp
+					// |
+					// -  1: val1
+					// -----------------
+					if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
+						t.Fatal(err)
+					}
+					if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 12}, value2, nil); err != nil {
+						t.Fatal(err)
+					}
+					// Read with transaction, should get a value back.
+					if val, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 7}, getOptsTxn); err != nil {
+						t.Fatal(err)
+					} else if val == nil || !bytes.Equal(val.RawBytes, value1.RawBytes) {
+						t.Fatalf("wanted %q, got %v", value1.RawBytes, val)
+					}
+					if kvs, _, _, err := MVCCScan(
+						ctx, engine, testKey1, testKey1.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxn,
+					); err != nil {
+						t.Fatal(err)
+					} else if len(kvs) != 1 {
+						t.Fatalf("wanted 1 kv, got %d", len(kvs))
+					} else if val := kvs[0].Value; !bytes.Equal(val.RawBytes, value1.RawBytes) {
+						t.Fatalf("wanted %q, got %v", value1.RawBytes, val)
+					}
 
-			// Case 1: One value in the past, one value in the future of read
-			// and ahead of MaxTimestamp of read. Neither should interfere.
-			//
-			// -----------------
-			// - 12: val2
-			// |
-			// - 10: max timestamp
-			// |
-			// -  7: read timestamp
-			// |
-			// -  1: val1
-			// -----------------
-			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
-				t.Fatal(err)
-			}
-			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 12}, value2, nil); err != nil {
-				t.Fatal(err)
-			}
-			// Read with transaction, should get a value back.
-			if val, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 7}, getOptsTxn); err != nil {
-				t.Fatal(err)
-			} else if val == nil || !bytes.Equal(val.RawBytes, value1.RawBytes) {
-				t.Fatalf("wanted %q, got %v", value1.RawBytes, val)
-			}
-			if kvs, _, _, err := MVCCScan(
-				ctx, engine, testKey1, testKey1.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxn,
-			); err != nil {
-				t.Fatal(err)
-			} else if len(kvs) != 1 {
-				t.Fatalf("wanted 1 kv, got %d", len(kvs))
-			} else if val := kvs[0].Value; !bytes.Equal(val.RawBytes, value1.RawBytes) {
-				t.Fatalf("wanted %q, got %v", value1.RawBytes, val)
-			}
+					// Case 2a: One value in the future of read but below MaxTimestamp
+					// of read. Should result in a ReadWithinUncertaintyIntervalError
+					// when reading.
+					//
+					// -----------------
+					// - 10: max timestamp
+					// -  9: val2
+					// |
+					// -  7: read timestamp
+					// -----------------
+					if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 9}, value2, nil); err != nil {
+						t.Fatal(err)
+					}
+					// Read with transaction, should get error back.
+					if _, _, err := mvccGet(ctx, engine, testKey2, hlc.Timestamp{WallTime: 7}, getOptsTxn); err == nil {
+						t.Fatal("wanted an error")
+					} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
+						t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
+					}
+					if _, _, _, err := MVCCScan(
+						ctx, engine, testKey2, testKey2.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxn,
+					); err == nil {
+						t.Fatal("wanted an error")
+					} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
+						t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
+					}
+					// Case 2b: Reduce MaxTimestamp to exactly that of value in future.
+					// Should result in a ReadWithinUncertaintyIntervalError when
+					// reading.
+					//
+					// -----------------
+					// -  9: val2 & max timestamp
+					// |
+					// -  7: read timestamp
+					// -----------------
+					if _, _, err := mvccGet(ctx, engine, testKey2, hlc.Timestamp{WallTime: 7}, getOptsTxnMaxTS9); err == nil {
+						t.Fatal("wanted an error")
+					} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
+						t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
+					}
+					if _, _, _, err := MVCCScan(
+						ctx, engine, testKey2, testKey2.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS9,
+					); err == nil {
+						t.Fatal("wanted an error")
+					} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
+						t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
+					}
+					// Case 2c: Reduce MaxTimestamp below value in future. Value should
+					// no longer interfere when reading.
+					//
+					// -----------------
+					// -  9: val2
+					// |
+					// -  7: read timestamp & max timestamp
+					// -----------------
+					if _, _, err := mvccGet(ctx, engine, testKey2, hlc.Timestamp{WallTime: 7}, getOptsTxnMaxTS7); err != nil {
+						t.Fatal(err)
+					}
+					if _, _, _, err := MVCCScan(
+						ctx, engine, testKey2, testKey2.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS7,
+					); err != nil {
+						t.Fatal(err)
+					}
 
-			// Case 2a: One value in the future of read but below MaxTimestamp
-			// of read. Should result in a ReadWithinUncertaintyIntervalError
-			// when reading.
-			//
-			// -----------------
-			// - 10: max timestamp
-			// -  9: val2
-			// |
-			// -  7: read timestamp
-			// -----------------
-			if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 9}, value2, nil); err != nil {
-				t.Fatal(err)
-			}
-			// Read with transaction, should get error back.
-			if _, _, err := mvccGet(ctx, engine, testKey2, hlc.Timestamp{WallTime: 7}, getOptsTxn); err == nil {
-				t.Fatal("wanted an error")
-			} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
-				t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
-			}
-			if _, _, _, err := MVCCScan(
-				ctx, engine, testKey2, testKey2.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxn,
-			); err == nil {
-				t.Fatal("wanted an error")
-			} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
-				t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
-			}
-			// Case 2b: Reduce MaxTimestamp to exactly that of value in future.
-			// Should result in a ReadWithinUncertaintyIntervalError when
-			// reading.
-			//
-			// -----------------
-			// -  9: val2 & max timestamp
-			// |
-			// -  7: read timestamp
-			// -----------------
-			if _, _, err := mvccGet(ctx, engine, testKey2, hlc.Timestamp{WallTime: 7}, getOptsTxnMaxTS9); err == nil {
-				t.Fatal("wanted an error")
-			} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
-				t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
-			}
-			if _, _, _, err := MVCCScan(
-				ctx, engine, testKey2, testKey2.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS9,
-			); err == nil {
-				t.Fatal("wanted an error")
-			} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
-				t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
-			}
-			// Case 2c: Reduce MaxTimestamp below value in future. Value should
-			// no longer interfere when reading.
-			//
-			// -----------------
-			// -  9: val2
-			// |
-			// -  7: read timestamp & max timestamp
-			// -----------------
-			if _, _, err := mvccGet(ctx, engine, testKey2, hlc.Timestamp{WallTime: 7}, getOptsTxnMaxTS7); err != nil {
-				t.Fatal(err)
-			}
-			if _, _, _, err := MVCCScan(
-				ctx, engine, testKey2, testKey2.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS7,
-			); err != nil {
-				t.Fatal(err)
-			}
+					// Case 3a: One intent in the future of read but below MaxTimestamp
+					// of read. Should result in a WriteIntentError when reading.
+					//
+					// -----------------
+					// - 10: max timestamp
+					// -  9: val2 (intent)
+					// |
+					// -  7: read timestamp
+					// -----------------
+					intentTxn := &roachpb.Transaction{
+						TxnMeta: enginepb.TxnMeta{
+							ID:        uuid.MakeV4(),
+							Timestamp: hlc.Timestamp{WallTime: 9},
+						},
+						OrigTimestamp: hlc.Timestamp{WallTime: 9},
+					}
+					if err := MVCCPut(ctx, engine, nil, testKey3, hlc.Timestamp{WallTime: 9}, value2, intentTxn); err != nil {
+						t.Fatal(err)
+					}
+					// Read with transaction, should get error back.
+					if _, _, err := mvccGet(ctx, engine, testKey3, hlc.Timestamp{WallTime: 7}, getOptsTxn); err == nil {
+						t.Fatal("wanted an error")
+					} else if _, ok := err.(*roachpb.WriteIntentError); !ok {
+						t.Fatalf("wanted a WriteIntentError, got %+v", err)
+					}
+					if _, _, _, err := MVCCScan(
+						ctx, engine, testKey3, testKey3.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxn,
+					); err == nil {
+						t.Fatal("wanted an error")
+					} else if _, ok := err.(*roachpb.WriteIntentError); !ok {
+						t.Fatalf("wanted a WriteIntentError, got %+v", err)
+					}
+					// Case 3b: Reduce MaxTimestamp to exactly that of intent in future.
+					// Should result in a WriteIntentError when reading.
+					//
+					// -----------------
+					// -  9: val2 (intent) & max timestamp
+					// |
+					// -  7: read timestamp
+					// -----------------
+					if _, _, err := mvccGet(ctx, engine, testKey3, hlc.Timestamp{WallTime: 7}, getOptsTxnMaxTS9); err == nil {
+						t.Fatal("wanted an error")
+					} else if _, ok := err.(*roachpb.WriteIntentError); !ok {
+						t.Fatalf("wanted a WriteIntentError, got %+v", err)
+					}
+					if _, _, _, err := MVCCScan(
+						ctx, engine, testKey3, testKey3.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS9,
+					); err == nil {
+						t.Fatal("wanted an error")
+					} else if _, ok := err.(*roachpb.WriteIntentError); !ok {
+						t.Fatalf("wanted a WriteIntentError, got %+v", err)
+					}
+					// Case 3c: Reduce MaxTimestamp below intent in future. Intent should
+					// no longer interfere when reading.
+					//
+					// -----------------
+					// -  9: val2 (intent)
+					// |
+					// -  7: read timestamp & max timestamp
+					// -----------------
+					if _, _, err := mvccGet(ctx, engine, testKey3, hlc.Timestamp{WallTime: 7}, getOptsTxnMaxTS7); err != nil {
+						t.Fatal(err)
+					}
+					if _, _, _, err := MVCCScan(
+						ctx, engine, testKey3, testKey3.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS7,
+					); err != nil {
+						t.Fatal(err)
+					}
 
-			// Case 3a: One intent in the future of read but below MaxTimestamp
-			// of read. Should result in a WriteIntentError when reading.
-			//
-			// -----------------
-			// - 10: max timestamp
-			// -  9: val2 (intent)
-			// |
-			// -  7: read timestamp
-			// -----------------
-			intentTxn := &roachpb.Transaction{
-				TxnMeta: enginepb.TxnMeta{
-					ID:        uuid.MakeV4(),
-					Timestamp: hlc.Timestamp{WallTime: 9},
-				},
-				OrigTimestamp: hlc.Timestamp{WallTime: 9},
-			}
-			if err := MVCCPut(ctx, engine, nil, testKey3, hlc.Timestamp{WallTime: 9}, value2, intentTxn); err != nil {
-				t.Fatal(err)
-			}
-			// Read with transaction, should get error back.
-			if _, _, err := mvccGet(ctx, engine, testKey3, hlc.Timestamp{WallTime: 7}, getOptsTxn); err == nil {
-				t.Fatal("wanted an error")
-			} else if _, ok := err.(*roachpb.WriteIntentError); !ok {
-				t.Fatalf("wanted a WriteIntentError, got %+v", err)
-			}
-			if _, _, _, err := MVCCScan(
-				ctx, engine, testKey3, testKey3.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxn,
-			); err == nil {
-				t.Fatal("wanted an error")
-			} else if _, ok := err.(*roachpb.WriteIntentError); !ok {
-				t.Fatalf("wanted a WriteIntentError, got %+v", err)
-			}
-			// Case 3b: Reduce MaxTimestamp to exactly that of intent in future.
-			// Should result in a WriteIntentError when reading.
-			//
-			// -----------------
-			// -  9: val2 (intent) & max timestamp
-			// |
-			// -  7: read timestamp
-			// -----------------
-			if _, _, err := mvccGet(ctx, engine, testKey3, hlc.Timestamp{WallTime: 7}, getOptsTxnMaxTS9); err == nil {
-				t.Fatal("wanted an error")
-			} else if _, ok := err.(*roachpb.WriteIntentError); !ok {
-				t.Fatalf("wanted a WriteIntentError, got %+v", err)
-			}
-			if _, _, _, err := MVCCScan(
-				ctx, engine, testKey3, testKey3.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS9,
-			); err == nil {
-				t.Fatal("wanted an error")
-			} else if _, ok := err.(*roachpb.WriteIntentError); !ok {
-				t.Fatalf("wanted a WriteIntentError, got %+v", err)
-			}
-			// Case 3c: Reduce MaxTimestamp below intent in future. Intent should
-			// no longer interfere when reading.
-			//
-			// -----------------
-			// -  9: val2 (intent)
-			// |
-			// -  7: read timestamp & max timestamp
-			// -----------------
-			if _, _, err := mvccGet(ctx, engine, testKey3, hlc.Timestamp{WallTime: 7}, getOptsTxnMaxTS7); err != nil {
-				t.Fatal(err)
-			}
-			if _, _, _, err := MVCCScan(
-				ctx, engine, testKey3, testKey3.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS7,
-			); err != nil {
-				t.Fatal(err)
-			}
-
-			// Case 4a: Two values in future of read. One is ahead of
-			// MaxTimestamp of read and one is below MaxTimestamp of read. The
-			// value within the read's uncertainty interval should result in a
-			// ReadWithinUncertaintyIntervalError when reading.
-			//
-			// -----------------
-			// - 99: val3
-			// |
-			// - 10: max timestamp
-			// -  9: val2
-			// |
-			// -  7: read timestamp
-			// -----------------
-			if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 9}, value2, nil); err != nil {
-				t.Fatal(err)
-			}
-			if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 99}, value3, nil); err != nil {
-				t.Fatal(err)
-			}
-			if _, _, err := mvccGet(ctx, engine, testKey4, hlc.Timestamp{WallTime: 7}, getOptsTxn); err == nil {
-				t.Fatalf("wanted an error")
-			} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
-				t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
-			}
-			if _, _, _, err := MVCCScan(
-				ctx, engine, testKey4, testKey4.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxn,
-			); err == nil {
-				t.Fatal("wanted an error")
-			} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
-				t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
-			}
-			// Case 4b: Reduce MaxTimestamp to exactly that of second value in
-			// future. The value within the read's uncertainty interval should
-			// result in a ReadWithinUncertaintyIntervalError when reading.
-			//
-			// -----------------
-			// - 99: val3
-			// |
-			// -  9: val2 & max timestamp
-			// |
-			// -  7: read timestamp
-			// -----------------
-			if _, _, err := mvccGet(ctx, engine, testKey4, hlc.Timestamp{WallTime: 7}, getOptsTxnMaxTS9); err == nil {
-				t.Fatalf("wanted an error")
-			} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
-				t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
-			}
-			if _, _, _, err := MVCCScan(
-				ctx, engine, testKey4, testKey4.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS9,
-			); err == nil {
-				t.Fatal("wanted an error")
-			} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
-				t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
-			}
-			// Case 4c: Reduce MaxTimestamp below second value in future. Value should
-			// no longer interfere when reading.
-			//
-			// -----------------
-			// - 99: val3
-			// |
-			// -  9: val2
-			// |
-			// -  7: read timestamp & max timestamp
-			// -----------------
-			if _, _, err := mvccGet(ctx, engine, testKey4, hlc.Timestamp{WallTime: 7}, getOptsTxnMaxTS7); err != nil {
-				t.Fatal(err)
-			}
-			if _, _, _, err := MVCCScan(
-				ctx, engine, testKey4, testKey4.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS7,
-			); err != nil {
-				t.Fatal(err)
+					// Case 4a: Two values in future of read. One is ahead of
+					// MaxTimestamp of read and one is below MaxTimestamp of read. The
+					// value within the read's uncertainty interval should result in a
+					// ReadWithinUncertaintyIntervalError when reading.
+					//
+					// -----------------
+					// - 99: val3
+					// |
+					// - 10: max timestamp
+					// -  9: val2
+					// |
+					// -  7: read timestamp
+					// -----------------
+					if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 9}, value2, nil); err != nil {
+						t.Fatal(err)
+					}
+					if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 99}, value3, nil); err != nil {
+						t.Fatal(err)
+					}
+					if _, _, err := mvccGet(ctx, engine, testKey4, hlc.Timestamp{WallTime: 7}, getOptsTxn); err == nil {
+						t.Fatalf("wanted an error")
+					} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
+						t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
+					}
+					if _, _, _, err := MVCCScan(
+						ctx, engine, testKey4, testKey4.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxn,
+					); err == nil {
+						t.Fatal("wanted an error")
+					} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
+						t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
+					}
+					// Case 4b: Reduce MaxTimestamp to exactly that of second value in
+					// future. The value within the read's uncertainty interval should
+					// result in a ReadWithinUncertaintyIntervalError when reading.
+					//
+					// -----------------
+					// - 99: val3
+					// |
+					// -  9: val2 & max timestamp
+					// |
+					// -  7: read timestamp
+					// -----------------
+					if _, _, err := mvccGet(ctx, engine, testKey4, hlc.Timestamp{WallTime: 7}, getOptsTxnMaxTS9); err == nil {
+						t.Fatalf("wanted an error")
+					} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
+						t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
+					}
+					if _, _, _, err := MVCCScan(
+						ctx, engine, testKey4, testKey4.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS9,
+					); err == nil {
+						t.Fatal("wanted an error")
+					} else if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
+						t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", err)
+					}
+					// Case 4c: Reduce MaxTimestamp below second value in future. Value should
+					// no longer interfere when reading.
+					//
+					// -----------------
+					// - 99: val3
+					// |
+					// -  9: val2
+					// |
+					// -  7: read timestamp & max timestamp
+					// -----------------
+					if _, _, err := mvccGet(ctx, engine, testKey4, hlc.Timestamp{WallTime: 7}, getOptsTxnMaxTS7); err != nil {
+						t.Fatal(err)
+					}
+					if _, _, _, err := MVCCScan(
+						ctx, engine, testKey4, testKey4.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, scanOptsTxnMaxTS7,
+					); err != nil {
+						t.Fatal(err)
+					}
+				})
 			}
 		})
 	}
@@ -1073,56 +1158,60 @@ func TestMVCCGetAndDelete(t *testing.T) {
 
 	ctx := context.Background()
 
-	for _, impl := range mvccGetImpls {
-		t.Run(impl.name, func(t *testing.T) {
-			mvccGet := impl.fn
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			for _, impl := range mvccGetImpls {
+				t.Run(impl.name, func(t *testing.T) {
+					mvccGet := impl.fn
 
-			engine := createTestEngine()
-			defer engine.Close()
+					engine := engineImpl.create()
+					defer engine.Close()
 
-			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
-				t.Fatal(err)
-			}
-			value, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{})
-			if err != nil {
-				t.Fatal(err)
-			}
-			if value == nil {
-				t.Fatal("the value should not be empty")
-			}
+					if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
+						t.Fatal(err)
+					}
+					value, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{})
+					if err != nil {
+						t.Fatal(err)
+					}
+					if value == nil {
+						t.Fatal("the value should not be empty")
+					}
 
-			err = MVCCDelete(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, nil)
-			if err != nil {
-				t.Fatal(err)
-			}
+					err = MVCCDelete(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, nil)
+					if err != nil {
+						t.Fatal(err)
+					}
 
-			// Read the latest version which should be deleted.
-			value, _, err = mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 4}, MVCCGetOptions{})
-			if err != nil {
-				t.Fatal(err)
-			}
-			if value != nil {
-				t.Fatal("the value should be empty")
-			}
-			// Read the latest version with tombstone.
-			value, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 4},
-				MVCCGetOptions{Tombstones: true})
-			if err != nil {
-				t.Fatal(err)
-			} else if value == nil || len(value.RawBytes) != 0 {
-				t.Fatalf("the value should be non-nil with empty RawBytes; got %+v", value)
-			}
+					// Read the latest version which should be deleted.
+					value, _, err = mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 4}, MVCCGetOptions{})
+					if err != nil {
+						t.Fatal(err)
+					}
+					if value != nil {
+						t.Fatal("the value should be empty")
+					}
+					// Read the latest version with tombstone.
+					value, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 4},
+						MVCCGetOptions{Tombstones: true})
+					if err != nil {
+						t.Fatal(err)
+					} else if value == nil || len(value.RawBytes) != 0 {
+						t.Fatalf("the value should be non-nil with empty RawBytes; got %+v", value)
+					}
 
-			// Read the old version which should still exist.
-			for _, logical := range []int32{0, math.MaxInt32} {
-				value, _, err = mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2, Logical: logical},
-					MVCCGetOptions{})
-				if err != nil {
-					t.Fatal(err)
-				}
-				if value == nil {
-					t.Fatal("the value should not be empty")
-				}
+					// Read the old version which should still exist.
+					for _, logical := range []int32{0, math.MaxInt32} {
+						value, _, err = mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2, Logical: logical},
+							MVCCGetOptions{})
+						if err != nil {
+							t.Fatal(err)
+						}
+						if value == nil {
+							t.Fatal("the value should not be empty")
+						}
+					}
+				})
 			}
 		})
 	}
@@ -1134,48 +1223,52 @@ func TestMVCCGetAndDelete(t *testing.T) {
 // tombstone with its timestamp in order to push the write's timestamp.
 func TestMVCCWriteWithOlderTimestampAfterDeletionOfNonexistentKey(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	if err := MVCCDelete(
-		context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, nil,
-	); err != nil {
-		t.Fatal(err)
-	}
+			if err := MVCCDelete(
+				context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, nil,
+			); err != nil {
+				t.Fatal(err)
+			}
 
-	if err := MVCCPut(
-		context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil,
-	); !testutils.IsError(
-		err, "write at timestamp 0.000000001,0 too old; wrote at 0.000000003,1",
-	) {
-		t.Fatal(err)
-	}
+			if err := MVCCPut(
+				context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil,
+			); !testutils.IsError(
+				err, "write at timestamp 0.000000001,0 too old; wrote at 0.000000003,1",
+			) {
+				t.Fatal(err)
+			}
 
-	value, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 2},
-		MVCCGetOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	// The attempted write at ts(1,0) was performed at ts(3,1), so we should
-	// not see it at ts(2,0).
-	if value != nil {
-		t.Fatalf("value present at TS = %s", value.Timestamp)
-	}
+			value, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 2},
+				MVCCGetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			// The attempted write at ts(1,0) was performed at ts(3,1), so we should
+			// not see it at ts(2,0).
+			if value != nil {
+				t.Fatalf("value present at TS = %s", value.Timestamp)
+			}
 
-	// Read the latest version which will be the value written with the timestamp pushed.
-	value, _, err = MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 4},
-		MVCCGetOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if value == nil {
-		t.Fatal("value doesn't exist")
-	}
-	if !bytes.Equal(value.RawBytes, value1.RawBytes) {
-		t.Errorf("expected %q; got %q", value1.RawBytes, value.RawBytes)
-	}
-	if expTS := (hlc.Timestamp{WallTime: 3, Logical: 1}); value.Timestamp != expTS {
-		t.Fatalf("timestamp was not pushed: %s, expected %s", value.Timestamp, expTS)
+			// Read the latest version which will be the value written with the timestamp pushed.
+			value, _, err = MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 4},
+				MVCCGetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if value == nil {
+				t.Fatal("value doesn't exist")
+			}
+			if !bytes.Equal(value.RawBytes, value1.RawBytes) {
+				t.Errorf("expected %q; got %q", value1.RawBytes, value.RawBytes)
+			}
+			if expTS := (hlc.Timestamp{WallTime: 3, Logical: 1}); value.Timestamp != expTS {
+				t.Fatalf("timestamp was not pushed: %s, expected %s", value.Timestamp, expTS)
+			}
+		})
 	}
 }
 
@@ -1183,35 +1276,39 @@ func TestMVCCInlineWithTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	// Put an inline value.
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{}, value1, nil); err != nil {
-		t.Fatal(err)
-	}
+			// Put an inline value.
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{}, value1, nil); err != nil {
+				t.Fatal(err)
+			}
 
-	// Now verify inline get.
-	value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{}, MVCCGetOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(value1, *value) {
-		t.Errorf("the inline value should be %v; got %v", value1, *value)
-	}
+			// Now verify inline get.
+			value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{}, MVCCGetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(value1, *value) {
+				t.Errorf("the inline value should be %v; got %v", value1, *value)
+			}
 
-	// Verify inline get with txn does still work (this will happen on a
-	// scan if the distributed sender is forced to wrap it in a txn).
-	if _, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{}, MVCCGetOptions{
-		Txn: txn1,
-	}); err != nil {
-		t.Error(err)
-	}
+			// Verify inline get with txn does still work (this will happen on a
+			// scan if the distributed sender is forced to wrap it in a txn).
+			if _, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{}, MVCCGetOptions{
+				Txn: txn1,
+			}); err != nil {
+				t.Error(err)
+			}
 
-	// Verify inline put with txn is an error.
-	err = MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{}, value2, txn2)
-	if !testutils.IsError(err, "writes not allowed within transactions") {
-		t.Errorf("unexpected error: %+v", err)
+			// Verify inline put with txn is an error.
+			err = MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{}, value2, txn2)
+			if !testutils.IsError(err, "writes not allowed within transactions") {
+				t.Errorf("unexpected error: %+v", err)
+			}
+		})
 	}
 }
 
@@ -1219,15 +1316,19 @@ func TestMVCCDeleteMissingKey(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	if err := MVCCDelete(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, nil); err != nil {
-		t.Fatal(err)
-	}
-	// Verify nothing is written to the engine.
-	if val, err := engine.Get(mvccKey(testKey1)); err != nil || val != nil {
-		t.Fatalf("expected no mvcc metadata after delete of a missing key; got %q: %+v", val, err)
+			if err := MVCCDelete(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, nil); err != nil {
+				t.Fatal(err)
+			}
+			// Verify nothing is written to the engine.
+			if val, err := engine.Get(mvccKey(testKey1)); err != nil || val != nil {
+				t.Fatalf("expected no mvcc metadata after delete of a missing key; got %q: %+v", val, err)
+			}
+		})
 	}
 }
 
@@ -1236,57 +1337,61 @@ func TestMVCCGetAndDeleteInTxn(t *testing.T) {
 
 	ctx := context.Background()
 
-	for _, impl := range mvccGetImpls {
-		t.Run(impl.name, func(t *testing.T) {
-			mvccGet := impl.fn
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			for _, impl := range mvccGetImpls {
+				t.Run(impl.name, func(t *testing.T) {
+					mvccGet := impl.fn
 
-			engine := createTestEngine()
-			defer engine.Close()
+					engine := engineImpl.create()
+					defer engine.Close()
 
-			txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
-			txn.Sequence++
-			if err := MVCCPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value1, txn); err != nil {
-				t.Fatal(err)
-			}
+					txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
+					txn.Sequence++
+					if err := MVCCPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value1, txn); err != nil {
+						t.Fatal(err)
+					}
 
-			if value, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{
-				Txn: txn,
-			}); err != nil {
-				t.Fatal(err)
-			} else if value == nil {
-				t.Fatal("the value should not be empty")
-			}
+					if value, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{
+						Txn: txn,
+					}); err != nil {
+						t.Fatal(err)
+					} else if value == nil {
+						t.Fatal("the value should not be empty")
+					}
 
-			txn.Sequence++
-			txn.Timestamp = hlc.Timestamp{WallTime: 3}
-			if err := MVCCDelete(ctx, engine, nil, testKey1, txn.OrigTimestamp, txn); err != nil {
-				t.Fatal(err)
-			}
+					txn.Sequence++
+					txn.Timestamp = hlc.Timestamp{WallTime: 3}
+					if err := MVCCDelete(ctx, engine, nil, testKey1, txn.OrigTimestamp, txn); err != nil {
+						t.Fatal(err)
+					}
 
-			// Read the latest version which should be deleted.
-			if value, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 4}, MVCCGetOptions{
-				Txn: txn,
-			}); err != nil {
-				t.Fatal(err)
-			} else if value != nil {
-				t.Fatal("the value should be empty")
-			}
-			// Read the latest version with tombstone.
-			if value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 4}, MVCCGetOptions{
-				Tombstones: true,
-				Txn:        txn,
-			}); err != nil {
-				t.Fatal(err)
-			} else if value == nil || len(value.RawBytes) != 0 {
-				t.Fatalf("the value should be non-nil with empty RawBytes; got %+v", value)
-			}
+					// Read the latest version which should be deleted.
+					if value, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 4}, MVCCGetOptions{
+						Txn: txn,
+					}); err != nil {
+						t.Fatal(err)
+					} else if value != nil {
+						t.Fatal("the value should be empty")
+					}
+					// Read the latest version with tombstone.
+					if value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 4}, MVCCGetOptions{
+						Tombstones: true,
+						Txn:        txn,
+					}); err != nil {
+						t.Fatal(err)
+					} else if value == nil || len(value.RawBytes) != 0 {
+						t.Fatalf("the value should be non-nil with empty RawBytes; got %+v", value)
+					}
 
-			// Read the old version which shouldn't exist, as within a
-			// transaction, we delete previous values.
-			if value, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{}); err != nil {
-				t.Fatal(err)
-			} else if value != nil {
-				t.Fatalf("expected value nil, got: %s", value)
+					// Read the old version which shouldn't exist, as within a
+					// transaction, we delete previous values.
+					if value, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{}); err != nil {
+						t.Fatal(err)
+					} else if value != nil {
+						t.Fatalf("expected value nil, got: %s", value)
+					}
+				})
 			}
 		})
 	}
@@ -1297,25 +1402,29 @@ func TestMVCCGetWriteIntentError(t *testing.T) {
 
 	ctx := context.Background()
 
-	for _, impl := range mvccGetImpls {
-		t.Run(impl.name, func(t *testing.T) {
-			mvccGet := impl.fn
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			for _, impl := range mvccGetImpls {
+				t.Run(impl.name, func(t *testing.T) {
+					mvccGet := impl.fn
 
-			engine := createTestEngine()
-			defer engine.Close()
+					engine := engineImpl.create()
+					defer engine.Close()
 
-			if err := MVCCPut(ctx, engine, nil, testKey1, txn1.OrigTimestamp, value1, txn1); err != nil {
-				t.Fatal(err)
-			}
+					if err := MVCCPut(ctx, engine, nil, testKey1, txn1.OrigTimestamp, value1, txn1); err != nil {
+						t.Fatal(err)
+					}
 
-			if _, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{}); err == nil {
-				t.Fatal("cannot read the value of a write intent without TxnID")
-			}
+					if _, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{}); err == nil {
+						t.Fatal("cannot read the value of a write intent without TxnID")
+					}
 
-			if _, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{
-				Txn: txn2,
-			}); err == nil {
-				t.Fatal("cannot read the value of a write intent from a different TxnID")
+					if _, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{
+						Txn: txn2,
+					}); err == nil {
+						t.Fatal("cannot read the value of a write intent from a different TxnID")
+					}
+				})
 			}
 		})
 	}
@@ -1331,112 +1440,116 @@ func TestMVCCScanWriteIntentError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	ts := []hlc.Timestamp{{Logical: 1}, {Logical: 2}, {Logical: 3}, {Logical: 4}, {Logical: 5}, {Logical: 6}}
+			ts := []hlc.Timestamp{{Logical: 1}, {Logical: 2}, {Logical: 3}, {Logical: 4}, {Logical: 5}, {Logical: 6}}
 
-	txn1ts := makeTxn(*txn1, ts[2])
-	txn2ts := makeTxn(*txn2, ts[5])
+			txn1ts := makeTxn(*txn1, ts[2])
+			txn2ts := makeTxn(*txn2, ts[5])
 
-	fixtureKVs := []roachpb.KeyValue{
-		{Key: testKey1, Value: mkVal("testValue1 pre", ts[0])},
-		{Key: testKey4, Value: mkVal("testValue4 pre", ts[1])},
-		{Key: testKey1, Value: mkVal("testValue1", ts[2])},
-		{Key: testKey2, Value: mkVal("testValue2", ts[3])},
-		{Key: testKey3, Value: mkVal("testValue3", ts[4])},
-		{Key: testKey4, Value: mkVal("testValue4", ts[5])},
-	}
-	for i, kv := range fixtureKVs {
-		var txn *roachpb.Transaction
-		if i == 2 {
-			txn = txn1ts
-		} else if i == 5 {
-			txn = txn2ts
-		}
-		v := *protoutil.Clone(&kv.Value).(*roachpb.Value)
-		v.Timestamp = hlc.Timestamp{}
-		if err := MVCCPut(ctx, engine, nil, kv.Key, kv.Value.Timestamp, v, txn); err != nil {
-			t.Fatal(err)
-		}
-	}
+			fixtureKVs := []roachpb.KeyValue{
+				{Key: testKey1, Value: mkVal("testValue1 pre", ts[0])},
+				{Key: testKey4, Value: mkVal("testValue4 pre", ts[1])},
+				{Key: testKey1, Value: mkVal("testValue1", ts[2])},
+				{Key: testKey2, Value: mkVal("testValue2", ts[3])},
+				{Key: testKey3, Value: mkVal("testValue3", ts[4])},
+				{Key: testKey4, Value: mkVal("testValue4", ts[5])},
+			}
+			for i, kv := range fixtureKVs {
+				var txn *roachpb.Transaction
+				if i == 2 {
+					txn = txn1ts
+				} else if i == 5 {
+					txn = txn2ts
+				}
+				v := *protoutil.Clone(&kv.Value).(*roachpb.Value)
+				v.Timestamp = hlc.Timestamp{}
+				if err := MVCCPut(ctx, engine, nil, kv.Key, kv.Value.Timestamp, v, txn); err != nil {
+					t.Fatal(err)
+				}
+			}
 
-	scanCases := []struct {
-		consistent bool
-		txn        *roachpb.Transaction
-		expIntents []roachpb.Intent
-		expValues  []roachpb.KeyValue
-	}{
-		{
-			consistent: true,
-			txn:        nil,
-			expIntents: []roachpb.Intent{
-				{Span: roachpb.Span{Key: testKey1}, Txn: txn1ts.TxnMeta},
-				{Span: roachpb.Span{Key: testKey4}, Txn: txn2ts.TxnMeta},
-			},
-			// would be []roachpb.KeyValue{fixtureKVs[3], fixtureKVs[4]} without WriteIntentError
-			expValues: nil,
-		},
-		{
-			consistent: true,
-			txn:        txn1ts,
-			expIntents: []roachpb.Intent{
-				{Span: roachpb.Span{Key: testKey4}, Txn: txn2ts.TxnMeta},
-			},
-			expValues: nil, // []roachpb.KeyValue{fixtureKVs[2], fixtureKVs[3], fixtureKVs[4]},
-		},
-		{
-			consistent: true,
-			txn:        txn2ts,
-			expIntents: []roachpb.Intent{
-				{Span: roachpb.Span{Key: testKey1}, Txn: txn1ts.TxnMeta},
-			},
-			expValues: nil, // []roachpb.KeyValue{fixtureKVs[3], fixtureKVs[4], fixtureKVs[5]},
-		},
-		{
-			consistent: false,
-			txn:        nil,
-			expIntents: []roachpb.Intent{
-				{Span: roachpb.Span{Key: testKey1}, Txn: txn1ts.TxnMeta},
-				{Span: roachpb.Span{Key: testKey4}, Txn: txn2ts.TxnMeta},
-			},
-			expValues: []roachpb.KeyValue{fixtureKVs[0], fixtureKVs[3], fixtureKVs[4], fixtureKVs[1]},
-		},
-	}
+			scanCases := []struct {
+				consistent bool
+				txn        *roachpb.Transaction
+				expIntents []roachpb.Intent
+				expValues  []roachpb.KeyValue
+			}{
+				{
+					consistent: true,
+					txn:        nil,
+					expIntents: []roachpb.Intent{
+						{Span: roachpb.Span{Key: testKey1}, Txn: txn1ts.TxnMeta},
+						{Span: roachpb.Span{Key: testKey4}, Txn: txn2ts.TxnMeta},
+					},
+					// would be []roachpb.KeyValue{fixtureKVs[3], fixtureKVs[4]} without WriteIntentError
+					expValues: nil,
+				},
+				{
+					consistent: true,
+					txn:        txn1ts,
+					expIntents: []roachpb.Intent{
+						{Span: roachpb.Span{Key: testKey4}, Txn: txn2ts.TxnMeta},
+					},
+					expValues: nil, // []roachpb.KeyValue{fixtureKVs[2], fixtureKVs[3], fixtureKVs[4]},
+				},
+				{
+					consistent: true,
+					txn:        txn2ts,
+					expIntents: []roachpb.Intent{
+						{Span: roachpb.Span{Key: testKey1}, Txn: txn1ts.TxnMeta},
+					},
+					expValues: nil, // []roachpb.KeyValue{fixtureKVs[3], fixtureKVs[4], fixtureKVs[5]},
+				},
+				{
+					consistent: false,
+					txn:        nil,
+					expIntents: []roachpb.Intent{
+						{Span: roachpb.Span{Key: testKey1}, Txn: txn1ts.TxnMeta},
+						{Span: roachpb.Span{Key: testKey4}, Txn: txn2ts.TxnMeta},
+					},
+					expValues: []roachpb.KeyValue{fixtureKVs[0], fixtureKVs[3], fixtureKVs[4], fixtureKVs[1]},
+				},
+			}
 
-	for i, scan := range scanCases {
-		cStr := "inconsistent"
-		if scan.consistent {
-			cStr = "consistent"
-		}
-		kvs, _, intents, err := MVCCScan(ctx, engine, testKey1, testKey4.Next(), math.MaxInt64,
-			hlc.Timestamp{WallTime: 1}, MVCCScanOptions{Inconsistent: !scan.consistent, Txn: scan.txn})
-		wiErr, _ := err.(*roachpb.WriteIntentError)
-		if (err == nil) != (wiErr == nil) {
-			t.Errorf("%s(%d): unexpected error: %+v", cStr, i, err)
-		}
+			for i, scan := range scanCases {
+				cStr := "inconsistent"
+				if scan.consistent {
+					cStr = "consistent"
+				}
+				kvs, _, intents, err := MVCCScan(ctx, engine, testKey1, testKey4.Next(), math.MaxInt64,
+					hlc.Timestamp{WallTime: 1}, MVCCScanOptions{Inconsistent: !scan.consistent, Txn: scan.txn})
+				wiErr, _ := err.(*roachpb.WriteIntentError)
+				if (err == nil) != (wiErr == nil) {
+					t.Errorf("%s(%d): unexpected error: %+v", cStr, i, err)
+				}
 
-		if wiErr == nil != !scan.consistent {
-			t.Errorf("%s(%d): expected write intent error; got %s", cStr, i, err)
-			continue
-		}
+				if wiErr == nil != !scan.consistent {
+					t.Errorf("%s(%d): expected write intent error; got %s", cStr, i, err)
+					continue
+				}
 
-		if len(intents) > 0 != !scan.consistent {
-			t.Errorf("%s(%d): expected different intents slice; got %+v", cStr, i, intents)
-			continue
-		}
+				if len(intents) > 0 != !scan.consistent {
+					t.Errorf("%s(%d): expected different intents slice; got %+v", cStr, i, intents)
+					continue
+				}
 
-		if scan.consistent {
-			intents = wiErr.Intents
-		}
+				if scan.consistent {
+					intents = wiErr.Intents
+				}
 
-		if !reflect.DeepEqual(intents, scan.expIntents) {
-			t.Fatalf("%s(%d): expected intents:\n%+v;\n got\n%+v", cStr, i, scan.expIntents, intents)
-		}
+				if !reflect.DeepEqual(intents, scan.expIntents) {
+					t.Fatalf("%s(%d): expected intents:\n%+v;\n got\n%+v", cStr, i, scan.expIntents, intents)
+				}
 
-		if !reflect.DeepEqual(kvs, scan.expValues) {
-			t.Errorf("%s(%d): expected values %+v; got %+v", cStr, i, scan.expValues, kvs)
-		}
+				if !reflect.DeepEqual(kvs, scan.expValues) {
+					t.Errorf("%s(%d): expected values %+v; got %+v", cStr, i, scan.expValues, kvs)
+				}
+			}
+		})
 	}
 }
 
@@ -1447,58 +1560,62 @@ func TestMVCCGetInconsistent(t *testing.T) {
 
 	ctx := context.Background()
 
-	for _, impl := range mvccGetImpls {
-		t.Run(impl.name, func(t *testing.T) {
-			mvccGet := impl.fn
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			for _, impl := range mvccGetImpls {
+				t.Run(impl.name, func(t *testing.T) {
+					mvccGet := impl.fn
 
-			engine := createTestEngine()
-			defer engine.Close()
+					engine := engineImpl.create()
+					defer engine.Close()
 
-			// Put two values to key 1, the latest with a txn.
-			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
-				t.Fatal(err)
-			}
-			txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 2})
-			if err := MVCCPut(ctx, engine, nil, testKey1, txn1ts.OrigTimestamp, value2, txn1ts); err != nil {
-				t.Fatal(err)
-			}
-
-			// A get with consistent=false should fail in a txn.
-			if _, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{
-				Inconsistent: true,
-				Txn:          txn1,
-			}); err == nil {
-				t.Error("expected an error getting with consistent=false in txn")
-			}
-
-			// Inconsistent get will fetch value1 for any timestamp.
-			for _, ts := range []hlc.Timestamp{{WallTime: 1}, {WallTime: 2}} {
-				val, intent, err := mvccGet(ctx, engine, testKey1, ts, MVCCGetOptions{Inconsistent: true})
-				if ts.Less(hlc.Timestamp{WallTime: 2}) {
-					if err != nil {
+					// Put two values to key 1, the latest with a txn.
+					if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
 						t.Fatal(err)
 					}
-				} else {
-					if intent == nil || !intent.Key.Equal(testKey1) {
-						t.Fatalf("expected %v, but got %v", testKey1, intent)
+					txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 2})
+					if err := MVCCPut(ctx, engine, nil, testKey1, txn1ts.OrigTimestamp, value2, txn1ts); err != nil {
+						t.Fatal(err)
 					}
-				}
-				if !bytes.Equal(val.RawBytes, value1.RawBytes) {
-					t.Errorf("@%s expected %q; got %q", ts, value1.RawBytes, val.RawBytes)
-				}
-			}
 
-			// Write a single intent for key 2 and verify get returns empty.
-			if err := MVCCPut(ctx, engine, nil, testKey2, txn2.OrigTimestamp, value1, txn2); err != nil {
-				t.Fatal(err)
-			}
-			val, intent, err := mvccGet(ctx, engine, testKey2, hlc.Timestamp{WallTime: 2},
-				MVCCGetOptions{Inconsistent: true})
-			if intent == nil || !intent.Key.Equal(testKey2) {
-				t.Fatal(err)
-			}
-			if val != nil {
-				t.Errorf("expected empty val; got %+v", val)
+					// A get with consistent=false should fail in a txn.
+					if _, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{
+						Inconsistent: true,
+						Txn:          txn1,
+					}); err == nil {
+						t.Error("expected an error getting with consistent=false in txn")
+					}
+
+					// Inconsistent get will fetch value1 for any timestamp.
+					for _, ts := range []hlc.Timestamp{{WallTime: 1}, {WallTime: 2}} {
+						val, intent, err := mvccGet(ctx, engine, testKey1, ts, MVCCGetOptions{Inconsistent: true})
+						if ts.Less(hlc.Timestamp{WallTime: 2}) {
+							if err != nil {
+								t.Fatal(err)
+							}
+						} else {
+							if intent == nil || !intent.Key.Equal(testKey1) {
+								t.Fatalf("expected %v, but got %v", testKey1, intent)
+							}
+						}
+						if !bytes.Equal(val.RawBytes, value1.RawBytes) {
+							t.Errorf("@%s expected %q; got %q", ts, value1.RawBytes, val.RawBytes)
+						}
+					}
+
+					// Write a single intent for key 2 and verify get returns empty.
+					if err := MVCCPut(ctx, engine, nil, testKey2, txn2.OrigTimestamp, value1, txn2); err != nil {
+						t.Fatal(err)
+					}
+					val, intent, err := mvccGet(ctx, engine, testKey2, hlc.Timestamp{WallTime: 2},
+						MVCCGetOptions{Inconsistent: true})
+					if intent == nil || !intent.Key.Equal(testKey2) {
+						t.Fatal(err)
+					}
+					if val != nil {
+						t.Errorf("expected empty val; got %+v", val)
+					}
+				})
 			}
 		})
 	}
@@ -1510,105 +1627,109 @@ func TestMVCCGetProtoInconsistent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	bytes1, err := protoutil.Marshal(&value1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	bytes2, err := protoutil.Marshal(&value2)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	v1 := roachpb.MakeValueFromBytes(bytes1)
-	v2 := roachpb.MakeValueFromBytes(bytes2)
-
-	// Put two values to key 1, the latest with a txn.
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, v1, nil); err != nil {
-		t.Fatal(err)
-	}
-	txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 2})
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1ts.OrigTimestamp, v2, txn1ts); err != nil {
-		t.Fatal(err)
-	}
-
-	// An inconsistent get should fail in a txn.
-	if _, err := MVCCGetProto(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, nil, MVCCGetOptions{
-		Inconsistent: true,
-		Txn:          txn1,
-	}); err == nil {
-		t.Error("expected an error getting inconsistently in txn")
-	} else if _, ok := err.(*roachpb.WriteIntentError); ok {
-		t.Error("expected non-WriteIntentError with inconsistent read in txn")
-	}
-
-	// Inconsistent get will fetch value1 for any timestamp.
-
-	for _, ts := range []hlc.Timestamp{{WallTime: 1}, {WallTime: 2}} {
-		val := roachpb.Value{}
-		found, err := MVCCGetProto(ctx, engine, testKey1, ts, &val, MVCCGetOptions{
-			Inconsistent: true,
-		})
-		if ts.Less(hlc.Timestamp{WallTime: 2}) {
+			bytes1, err := protoutil.Marshal(&value1)
 			if err != nil {
 				t.Fatal(err)
 			}
-		} else if err != nil {
-			t.Fatal(err)
-		}
-		if !found {
-			t.Errorf("expected to find result with inconsistent read")
-		}
-		valBytes, err := val.GetBytes()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !bytes.Equal(valBytes, []byte("testValue1")) {
-			t.Errorf("@%s expected %q; got %q", ts, []byte("value1"), valBytes)
-		}
-	}
+			bytes2, err := protoutil.Marshal(&value2)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	{
-		// Write a single intent for key 2 and verify get returns empty.
-		if err := MVCCPut(ctx, engine, nil, testKey2, txn2.OrigTimestamp, v1, txn2); err != nil {
-			t.Fatal(err)
-		}
-		val := roachpb.Value{}
-		found, err := MVCCGetProto(ctx, engine, testKey2, hlc.Timestamp{WallTime: 2}, &val, MVCCGetOptions{
-			Inconsistent: true,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if found {
-			t.Errorf("expected no result; got %+v", val)
-		}
-	}
+			v1 := roachpb.MakeValueFromBytes(bytes1)
+			v2 := roachpb.MakeValueFromBytes(bytes2)
 
-	{
-		// Write a malformed value (not an encoded MVCCKeyValue) and a
-		// write intent to key 3; the parse error is returned instead of the
-		// write intent.
-		if err := MVCCPut(ctx, engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, value3, nil); err != nil {
-			t.Fatal(err)
-		}
-		if err := MVCCPut(ctx, engine, nil, testKey3, txn1ts.OrigTimestamp, v2, txn1ts); err != nil {
-			t.Fatal(err)
-		}
-		val := roachpb.Value{}
-		found, err := MVCCGetProto(ctx, engine, testKey3, hlc.Timestamp{WallTime: 1}, &val, MVCCGetOptions{
-			Inconsistent: true,
+			// Put two values to key 1, the latest with a txn.
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, v1, nil); err != nil {
+				t.Fatal(err)
+			}
+			txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 2})
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn1ts.OrigTimestamp, v2, txn1ts); err != nil {
+				t.Fatal(err)
+			}
+
+			// An inconsistent get should fail in a txn.
+			if _, err := MVCCGetProto(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, nil, MVCCGetOptions{
+				Inconsistent: true,
+				Txn:          txn1,
+			}); err == nil {
+				t.Error("expected an error getting inconsistently in txn")
+			} else if _, ok := err.(*roachpb.WriteIntentError); ok {
+				t.Error("expected non-WriteIntentError with inconsistent read in txn")
+			}
+
+			// Inconsistent get will fetch value1 for any timestamp.
+
+			for _, ts := range []hlc.Timestamp{{WallTime: 1}, {WallTime: 2}} {
+				val := roachpb.Value{}
+				found, err := MVCCGetProto(ctx, engine, testKey1, ts, &val, MVCCGetOptions{
+					Inconsistent: true,
+				})
+				if ts.Less(hlc.Timestamp{WallTime: 2}) {
+					if err != nil {
+						t.Fatal(err)
+					}
+				} else if err != nil {
+					t.Fatal(err)
+				}
+				if !found {
+					t.Errorf("expected to find result with inconsistent read")
+				}
+				valBytes, err := val.GetBytes()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(valBytes, []byte("testValue1")) {
+					t.Errorf("@%s expected %q; got %q", ts, []byte("value1"), valBytes)
+				}
+			}
+
+			{
+				// Write a single intent for key 2 and verify get returns empty.
+				if err := MVCCPut(ctx, engine, nil, testKey2, txn2.OrigTimestamp, v1, txn2); err != nil {
+					t.Fatal(err)
+				}
+				val := roachpb.Value{}
+				found, err := MVCCGetProto(ctx, engine, testKey2, hlc.Timestamp{WallTime: 2}, &val, MVCCGetOptions{
+					Inconsistent: true,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if found {
+					t.Errorf("expected no result; got %+v", val)
+				}
+			}
+
+			{
+				// Write a malformed value (not an encoded MVCCKeyValue) and a
+				// write intent to key 3; the parse error is returned instead of the
+				// write intent.
+				if err := MVCCPut(ctx, engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, value3, nil); err != nil {
+					t.Fatal(err)
+				}
+				if err := MVCCPut(ctx, engine, nil, testKey3, txn1ts.OrigTimestamp, v2, txn1ts); err != nil {
+					t.Fatal(err)
+				}
+				val := roachpb.Value{}
+				found, err := MVCCGetProto(ctx, engine, testKey3, hlc.Timestamp{WallTime: 1}, &val, MVCCGetOptions{
+					Inconsistent: true,
+				})
+				if err == nil {
+					t.Errorf("expected error reading malformed data")
+				} else if !strings.HasPrefix(err.Error(), "proto: ") {
+					t.Errorf("expected proto error, got %s", err)
+				}
+				if !found {
+					t.Errorf("expected to find result with malformed data")
+				}
+			}
 		})
-		if err == nil {
-			t.Errorf("expected error reading malformed data")
-		} else if !strings.HasPrefix(err.Error(), "proto: ") {
-			t.Errorf("expected proto error, got %s", err)
-		}
-		if !found {
-			t.Errorf("expected to find result with malformed data")
-		}
 	}
 }
 
@@ -1619,71 +1740,69 @@ func TestMVCCInvalidateIterator(t *testing.T) {
 
 	for _, which := range []string{"get", "scan", "findSplitKey", "computeStats"} {
 		t.Run(which, func(t *testing.T) {
-			engine := createTestEngine()
-			defer engine.Close()
+			for _, engineImpl := range mvccEngineImpls {
+				t.Run(engineImpl.name, func(*testing.T) {
+					engine := engineImpl.create()
+					defer engine.Close()
 
-			ctx := context.Background()
-			ts1 := hlc.Timestamp{WallTime: 1}
-			ts2 := hlc.Timestamp{WallTime: 2}
+					ctx := context.Background()
+					ts1 := hlc.Timestamp{WallTime: 1}
+					ts2 := hlc.Timestamp{WallTime: 2}
 
-			key := roachpb.Key("a")
-			if err := MVCCPut(ctx, engine, nil, key, ts1, value1, nil); err != nil {
-				t.Fatal(err)
-			}
+					key := roachpb.Key("a")
+					if err := MVCCPut(ctx, engine, nil, key, ts1, value1, nil); err != nil {
+						t.Fatal(err)
+					}
 
-			var iterOptions IterOptions
-			switch which {
-			case "get":
-				iterOptions.Prefix = true
-			case "scan", "findSplitKey", "computeStats":
-				iterOptions.UpperBound = roachpb.KeyMax
-			}
+					var iterOptions IterOptions
+					switch which {
+					case "get":
+						iterOptions.Prefix = true
+					case "scan", "findSplitKey", "computeStats":
+						iterOptions.UpperBound = roachpb.KeyMax
+					}
 
-			// Use a batch which internally caches the iterator.
-			batch := engine.NewBatch()
-			defer batch.Close()
+					// Use a batch which internally caches the iterator.
+					batch := engine.NewBatch()
+					defer batch.Close()
 
-			{
-				// Seek the iter to a valid position.
-				iter := batch.NewIterator(iterOptions)
-				iter.Seek(MakeMVCCMetadataKey(key))
-				iter.Close()
-			}
+					{
+						// Seek the iter to a valid position.
+						iter := batch.NewIterator(iterOptions)
+						iter.Seek(MakeMVCCMetadataKey(key))
+						iter.Close()
+					}
 
-			var err error
-			switch which {
-			case "get":
-				_, _, err = MVCCGet(ctx, batch, key, ts2, MVCCGetOptions{})
-			case "scan":
-				_, _, _, err = MVCCScan(ctx, batch, key, roachpb.KeyMax, math.MaxInt64, ts2, MVCCScanOptions{})
-			case "findSplitKey":
-				_, err = MVCCFindSplitKey(ctx, batch, roachpb.RKeyMin, roachpb.RKeyMax, 64<<20)
-			case "computeStats":
-				iter := batch.NewIterator(iterOptions)
-				_, err = iter.ComputeStats(NilKey, MVCCKeyMax, 0)
-				iter.Close()
-			}
-			if err != nil {
-				t.Fatal(err)
-			}
+					var err error
+					switch which {
+					case "get":
+						_, _, err = MVCCGet(ctx, batch, key, ts2, MVCCGetOptions{})
+					case "scan":
+						_, _, _, err = MVCCScan(ctx, batch, key, roachpb.KeyMax, math.MaxInt64, ts2, MVCCScanOptions{})
+					case "findSplitKey":
+						_, err = MVCCFindSplitKey(ctx, batch, roachpb.RKeyMin, roachpb.RKeyMax, 64<<20)
+					case "computeStats":
+						iter := batch.NewIterator(iterOptions)
+						_, err = iter.ComputeStats(NilKey, MVCCKeyMax, 0)
+						iter.Close()
+					}
+					if err != nil {
+						t.Fatal(err)
+					}
 
-			// Verify that the iter is invalid.
-			iter := batch.NewIterator(iterOptions)
-			defer iter.Close()
-			if ok, _ := iter.Valid(); ok {
-				t.Fatalf("iterator should not be valid")
+					// Verify that the iter is invalid.
+					iter := batch.NewIterator(iterOptions)
+					defer iter.Close()
+					if ok, _ := iter.Valid(); ok {
+						t.Fatalf("iterator should not be valid")
+					}
+				})
 			}
 		})
 	}
 }
 
-func TestMVCCScan(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
-
+func mvccScanTest(ctx context.Context, t *testing.T, engine Engine) {
 	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -1772,79 +1891,97 @@ func TestMVCCScan(t *testing.T) {
 	}
 }
 
+func TestMVCCScan(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
+
+			mvccScanTest(ctx, t, engine)
+		})
+	}
+}
+
 func TestMVCCScanMaxNum(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, value3, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, value4, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey6, hlc.Timestamp{WallTime: 1}, value4, nil); err != nil {
-		t.Fatal(err)
-	}
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, value3, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, value4, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey6, hlc.Timestamp{WallTime: 1}, value4, nil); err != nil {
+				t.Fatal(err)
+			}
 
-	kvs, resumeSpan, _, err := MVCCScan(ctx, engine, testKey2, testKey4, 1,
-		hlc.Timestamp{WallTime: 1}, MVCCScanOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(kvs) != 1 ||
-		!bytes.Equal(kvs[0].Key, testKey2) ||
-		!bytes.Equal(kvs[0].Value.RawBytes, value2.RawBytes) {
-		t.Fatal("the value should not be empty")
-	}
-	if expected := (roachpb.Span{Key: testKey3, EndKey: testKey4}); !resumeSpan.EqualValue(expected) {
-		t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
-	}
+			kvs, resumeSpan, _, err := MVCCScan(ctx, engine, testKey2, testKey4, 1,
+				hlc.Timestamp{WallTime: 1}, MVCCScanOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(kvs) != 1 ||
+				!bytes.Equal(kvs[0].Key, testKey2) ||
+				!bytes.Equal(kvs[0].Value.RawBytes, value2.RawBytes) {
+				t.Fatal("the value should not be empty")
+			}
+			if expected := (roachpb.Span{Key: testKey3, EndKey: testKey4}); !resumeSpan.EqualValue(expected) {
+				t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
+			}
 
-	kvs, resumeSpan, _, err = MVCCScan(ctx, engine, testKey2, testKey4, 0,
-		hlc.Timestamp{WallTime: 1}, MVCCScanOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(kvs) != 0 {
-		t.Fatal("the value should be empty")
-	}
-	if expected := (roachpb.Span{Key: testKey2, EndKey: testKey4}); !resumeSpan.EqualValue(expected) {
-		t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
-	}
+			kvs, resumeSpan, _, err = MVCCScan(ctx, engine, testKey2, testKey4, 0,
+				hlc.Timestamp{WallTime: 1}, MVCCScanOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(kvs) != 0 {
+				t.Fatal("the value should be empty")
+			}
+			if expected := (roachpb.Span{Key: testKey2, EndKey: testKey4}); !resumeSpan.EqualValue(expected) {
+				t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
+			}
 
-	// Note: testKey6, though not scanned directly, is important in testing that
-	// the computed resume span does not extend beyond the upper bound of a scan.
-	kvs, resumeSpan, _, err = MVCCScan(ctx, engine, testKey4, testKey5, 1,
-		hlc.Timestamp{WallTime: 1}, MVCCScanOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(kvs) != 1 {
-		t.Fatalf("expected 1 key but got %d", len(kvs))
-	}
-	if resumeSpan != nil {
-		t.Fatalf("resumeSpan = %+v", resumeSpan)
-	}
+			// Note: testKey6, though not scanned directly, is important in testing that
+			// the computed resume span does not extend beyond the upper bound of a scan.
+			kvs, resumeSpan, _, err = MVCCScan(ctx, engine, testKey4, testKey5, 1,
+				hlc.Timestamp{WallTime: 1}, MVCCScanOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(kvs) != 1 {
+				t.Fatalf("expected 1 key but got %d", len(kvs))
+			}
+			if resumeSpan != nil {
+				t.Fatalf("resumeSpan = %+v", resumeSpan)
+			}
 
-	kvs, resumeSpan, _, err = MVCCScan(ctx, engine, testKey5, testKey6.Next(), 1,
-		hlc.Timestamp{WallTime: 1}, MVCCScanOptions{Reverse: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(kvs) != 1 {
-		t.Fatalf("expected 1 key but got %d", len(kvs))
-	}
-	if resumeSpan != nil {
-		t.Fatalf("resumeSpan = %+v", resumeSpan)
+			kvs, resumeSpan, _, err = MVCCScan(ctx, engine, testKey5, testKey6.Next(), 1,
+				hlc.Timestamp{WallTime: 1}, MVCCScanOptions{Reverse: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(kvs) != 1 {
+				t.Fatalf("expected 1 key but got %d", len(kvs))
+			}
+			if resumeSpan != nil {
+				t.Fatalf("resumeSpan = %+v", resumeSpan)
+			}
+		})
 	}
 }
 
@@ -1852,47 +1989,51 @@ func TestMVCCScanWithKeyPrefix(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	// Let's say you have:
-	// a
-	// a<T=2>
-	// a<T=1>
-	// aa
-	// aa<T=3>
-	// aa<T=2>
-	// b
-	// b<T=5>
-	// In this case, if we scan from "a"-"b", we wish to skip
-	// a<T=2> and a<T=1> and find "aa'.
-	if err := MVCCPut(ctx, engine, nil, roachpb.Key("/a"), hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, roachpb.Key("/a"), hlc.Timestamp{WallTime: 2}, value2, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, roachpb.Key("/aa"), hlc.Timestamp{WallTime: 2}, value2, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, roachpb.Key("/aa"), hlc.Timestamp{WallTime: 3}, value3, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, roachpb.Key("/b"), hlc.Timestamp{WallTime: 1}, value3, nil); err != nil {
-		t.Fatal(err)
-	}
+			// Let's say you have:
+			// a
+			// a<T=2>
+			// a<T=1>
+			// aa
+			// aa<T=3>
+			// aa<T=2>
+			// b
+			// b<T=5>
+			// In this case, if we scan from "a"-"b", we wish to skip
+			// a<T=2> and a<T=1> and find "aa'.
+			if err := MVCCPut(ctx, engine, nil, roachpb.Key("/a"), hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, roachpb.Key("/a"), hlc.Timestamp{WallTime: 2}, value2, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, roachpb.Key("/aa"), hlc.Timestamp{WallTime: 2}, value2, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, roachpb.Key("/aa"), hlc.Timestamp{WallTime: 3}, value3, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, roachpb.Key("/b"), hlc.Timestamp{WallTime: 1}, value3, nil); err != nil {
+				t.Fatal(err)
+			}
 
-	kvs, _, _, err := MVCCScan(ctx, engine, roachpb.Key("/a"), roachpb.Key("/b"), math.MaxInt64,
-		hlc.Timestamp{WallTime: 2}, MVCCScanOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(kvs) != 2 ||
-		!bytes.Equal(kvs[0].Key, roachpb.Key("/a")) ||
-		!bytes.Equal(kvs[1].Key, roachpb.Key("/aa")) ||
-		!bytes.Equal(kvs[0].Value.RawBytes, value2.RawBytes) ||
-		!bytes.Equal(kvs[1].Value.RawBytes, value2.RawBytes) {
-		t.Fatal("the value should not be empty")
+			kvs, _, _, err := MVCCScan(ctx, engine, roachpb.Key("/a"), roachpb.Key("/b"), math.MaxInt64,
+				hlc.Timestamp{WallTime: 2}, MVCCScanOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(kvs) != 2 ||
+				!bytes.Equal(kvs[0].Key, roachpb.Key("/a")) ||
+				!bytes.Equal(kvs[1].Key, roachpb.Key("/aa")) ||
+				!bytes.Equal(kvs[0].Value.RawBytes, value2.RawBytes) ||
+				!bytes.Equal(kvs[1].Value.RawBytes, value2.RawBytes) {
+				t.Fatal("the value should not be empty")
+			}
+		})
 	}
 }
 
@@ -1900,40 +2041,44 @@ func TestMVCCScanInTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
-		t.Fatal(err)
-	}
-	txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
-	if err := MVCCPut(ctx, engine, nil, testKey3, txn.OrigTimestamp, value3, txn); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, value4, nil); err != nil {
-		t.Fatal(err)
-	}
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
+				t.Fatal(err)
+			}
+			txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
+			if err := MVCCPut(ctx, engine, nil, testKey3, txn.OrigTimestamp, value3, txn); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, value4, nil); err != nil {
+				t.Fatal(err)
+			}
 
-	kvs, _, _, err := MVCCScan(ctx, engine, testKey2, testKey4, math.MaxInt64,
-		hlc.Timestamp{WallTime: 1}, MVCCScanOptions{Txn: txn1})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(kvs) != 2 ||
-		!bytes.Equal(kvs[0].Key, testKey2) ||
-		!bytes.Equal(kvs[1].Key, testKey3) ||
-		!bytes.Equal(kvs[0].Value.RawBytes, value2.RawBytes) ||
-		!bytes.Equal(kvs[1].Value.RawBytes, value3.RawBytes) {
-		t.Fatal("the value should not be empty")
-	}
+			kvs, _, _, err := MVCCScan(ctx, engine, testKey2, testKey4, math.MaxInt64,
+				hlc.Timestamp{WallTime: 1}, MVCCScanOptions{Txn: txn1})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(kvs) != 2 ||
+				!bytes.Equal(kvs[0].Key, testKey2) ||
+				!bytes.Equal(kvs[1].Key, testKey3) ||
+				!bytes.Equal(kvs[0].Value.RawBytes, value2.RawBytes) ||
+				!bytes.Equal(kvs[1].Value.RawBytes, value3.RawBytes) {
+				t.Fatal("the value should not be empty")
+			}
 
-	if _, _, _, err := MVCCScan(
-		ctx, engine, testKey2, testKey4, math.MaxInt64, hlc.Timestamp{WallTime: 1}, MVCCScanOptions{},
-	); err == nil {
-		t.Fatal("expected error on uncommitted write intent")
+			if _, _, _, err := MVCCScan(
+				ctx, engine, testKey2, testKey4, math.MaxInt64, hlc.Timestamp{WallTime: 1}, MVCCScanOptions{},
+			); err == nil {
+				t.Fatal("expected error on uncommitted write intent")
+			}
+		})
 	}
 }
 
@@ -1943,86 +2088,90 @@ func TestMVCCScanInconsistent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	// A scan with consistent=false should fail in a txn.
-	if _, _, _, err := MVCCScan(
-		ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 1},
-		MVCCScanOptions{Inconsistent: true, Txn: txn1},
-	); err == nil {
-		t.Error("expected an error scanning with consistent=false in txn")
-	}
+			// A scan with consistent=false should fail in a txn.
+			if _, _, _, err := MVCCScan(
+				ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 1},
+				MVCCScanOptions{Inconsistent: true, Txn: txn1},
+			); err == nil {
+				t.Error("expected an error scanning with consistent=false in txn")
+			}
 
-	ts1 := hlc.Timestamp{WallTime: 1}
-	ts2 := hlc.Timestamp{WallTime: 2}
-	ts3 := hlc.Timestamp{WallTime: 3}
-	ts4 := hlc.Timestamp{WallTime: 4}
-	ts5 := hlc.Timestamp{WallTime: 5}
-	ts6 := hlc.Timestamp{WallTime: 6}
-	if err := MVCCPut(ctx, engine, nil, testKey1, ts1, value1, nil); err != nil {
-		t.Fatal(err)
-	}
-	txn1ts2 := makeTxn(*txn1, ts2)
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1ts2.OrigTimestamp, value2, txn1ts2); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey2, ts3, value1, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey2, ts4, value2, nil); err != nil {
-		t.Fatal(err)
-	}
-	txn2ts5 := makeTxn(*txn2, ts5)
-	if err := MVCCPut(ctx, engine, nil, testKey3, txn2ts5.OrigTimestamp, value3, txn2ts5); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey4, ts6, value4, nil); err != nil {
-		t.Fatal(err)
-	}
+			ts1 := hlc.Timestamp{WallTime: 1}
+			ts2 := hlc.Timestamp{WallTime: 2}
+			ts3 := hlc.Timestamp{WallTime: 3}
+			ts4 := hlc.Timestamp{WallTime: 4}
+			ts5 := hlc.Timestamp{WallTime: 5}
+			ts6 := hlc.Timestamp{WallTime: 6}
+			if err := MVCCPut(ctx, engine, nil, testKey1, ts1, value1, nil); err != nil {
+				t.Fatal(err)
+			}
+			txn1ts2 := makeTxn(*txn1, ts2)
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn1ts2.OrigTimestamp, value2, txn1ts2); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey2, ts3, value1, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey2, ts4, value2, nil); err != nil {
+				t.Fatal(err)
+			}
+			txn2ts5 := makeTxn(*txn2, ts5)
+			if err := MVCCPut(ctx, engine, nil, testKey3, txn2ts5.OrigTimestamp, value3, txn2ts5); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey4, ts6, value4, nil); err != nil {
+				t.Fatal(err)
+			}
 
-	expIntents := []roachpb.Intent{
-		{Span: roachpb.Span{Key: testKey1}, Txn: txn1ts2.TxnMeta},
-		{Span: roachpb.Span{Key: testKey3}, Txn: txn2ts5.TxnMeta},
-	}
-	kvs, _, intents, err := MVCCScan(
-		ctx, engine, testKey1, testKey4.Next(), math.MaxInt64, hlc.Timestamp{WallTime: 7},
-		MVCCScanOptions{Inconsistent: true},
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(intents, expIntents) {
-		t.Fatalf("expected %v, but found %v", expIntents, intents)
-	}
+			expIntents := []roachpb.Intent{
+				{Span: roachpb.Span{Key: testKey1}, Txn: txn1ts2.TxnMeta},
+				{Span: roachpb.Span{Key: testKey3}, Txn: txn2ts5.TxnMeta},
+			}
+			kvs, _, intents, err := MVCCScan(
+				ctx, engine, testKey1, testKey4.Next(), math.MaxInt64, hlc.Timestamp{WallTime: 7},
+				MVCCScanOptions{Inconsistent: true},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(intents, expIntents) {
+				t.Fatalf("expected %v, but found %v", expIntents, intents)
+			}
 
-	makeTimestampedValue := func(v roachpb.Value, ts hlc.Timestamp) roachpb.Value {
-		v.Timestamp = ts
-		return v
-	}
+			makeTimestampedValue := func(v roachpb.Value, ts hlc.Timestamp) roachpb.Value {
+				v.Timestamp = ts
+				return v
+			}
 
-	expKVs := []roachpb.KeyValue{
-		{Key: testKey1, Value: makeTimestampedValue(value1, ts1)},
-		{Key: testKey2, Value: makeTimestampedValue(value2, ts4)},
-		{Key: testKey4, Value: makeTimestampedValue(value4, ts6)},
-	}
-	if !reflect.DeepEqual(kvs, expKVs) {
-		t.Errorf("expected key values equal %v != %v", kvs, expKVs)
-	}
+			expKVs := []roachpb.KeyValue{
+				{Key: testKey1, Value: makeTimestampedValue(value1, ts1)},
+				{Key: testKey2, Value: makeTimestampedValue(value2, ts4)},
+				{Key: testKey4, Value: makeTimestampedValue(value4, ts6)},
+			}
+			if !reflect.DeepEqual(kvs, expKVs) {
+				t.Errorf("expected key values equal %v != %v", kvs, expKVs)
+			}
 
-	// Now try a scan at a historical timestamp.
-	expIntents = expIntents[:1]
-	kvs, _, intents, err = MVCCScan(ctx, engine, testKey1, testKey4.Next(), math.MaxInt64,
-		hlc.Timestamp{WallTime: 3}, MVCCScanOptions{Inconsistent: true})
-	if !reflect.DeepEqual(intents, expIntents) {
-		t.Fatal(err)
-	}
-	expKVs = []roachpb.KeyValue{
-		{Key: testKey1, Value: makeTimestampedValue(value1, ts1)},
-		{Key: testKey2, Value: makeTimestampedValue(value1, ts3)},
-	}
-	if !reflect.DeepEqual(kvs, expKVs) {
-		t.Errorf("expected key values equal %v != %v", kvs, expKVs)
+			// Now try a scan at a historical timestamp.
+			expIntents = expIntents[:1]
+			kvs, _, intents, err = MVCCScan(ctx, engine, testKey1, testKey4.Next(), math.MaxInt64,
+				hlc.Timestamp{WallTime: 3}, MVCCScanOptions{Inconsistent: true})
+			if !reflect.DeepEqual(intents, expIntents) {
+				t.Fatal(err)
+			}
+			expKVs = []roachpb.KeyValue{
+				{Key: testKey1, Value: makeTimestampedValue(value1, ts1)},
+				{Key: testKey2, Value: makeTimestampedValue(value1, ts3)},
+			}
+			if !reflect.DeepEqual(kvs, expKVs) {
+				t.Errorf("expected key values equal %v != %v", kvs, expKVs)
+			}
+		})
 	}
 }
 
@@ -2030,154 +2179,158 @@ func TestMVCCDeleteRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, value3, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, value4, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey5, hlc.Timestamp{WallTime: 1}, value5, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey6, hlc.Timestamp{WallTime: 1}, value6, nil); err != nil {
-		t.Fatal(err)
-	}
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, value3, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, value4, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey5, hlc.Timestamp{WallTime: 1}, value5, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey6, hlc.Timestamp{WallTime: 1}, value6, nil); err != nil {
+				t.Fatal(err)
+			}
 
-	// Attempt to delete two keys.
-	deleted, resumeSpan, num, err := MVCCDeleteRange(
-		ctx, engine, nil, testKey2, testKey6, 2, hlc.Timestamp{WallTime: 2}, nil, false,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if deleted != nil {
-		t.Fatal("the value should be empty")
-	}
-	if num != 2 {
-		t.Fatalf("incorrect number of keys deleted: %d", num)
-	}
-	if expected := (roachpb.Span{Key: testKey4, EndKey: testKey6}); !resumeSpan.EqualValue(expected) {
-		t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
-	}
-	kvs, _, _, _ := MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64,
-		hlc.Timestamp{WallTime: 2}, MVCCScanOptions{})
-	if len(kvs) != 4 ||
-		!bytes.Equal(kvs[0].Key, testKey1) ||
-		!bytes.Equal(kvs[1].Key, testKey4) ||
-		!bytes.Equal(kvs[2].Key, testKey5) ||
-		!bytes.Equal(kvs[3].Key, testKey6) ||
-		!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) ||
-		!bytes.Equal(kvs[1].Value.RawBytes, value4.RawBytes) ||
-		!bytes.Equal(kvs[2].Value.RawBytes, value5.RawBytes) ||
-		!bytes.Equal(kvs[3].Value.RawBytes, value6.RawBytes) {
-		t.Fatal("the value should not be empty")
-	}
+			// Attempt to delete two keys.
+			deleted, resumeSpan, num, err := MVCCDeleteRange(
+				ctx, engine, nil, testKey2, testKey6, 2, hlc.Timestamp{WallTime: 2}, nil, false,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if deleted != nil {
+				t.Fatal("the value should be empty")
+			}
+			if num != 2 {
+				t.Fatalf("incorrect number of keys deleted: %d", num)
+			}
+			if expected := (roachpb.Span{Key: testKey4, EndKey: testKey6}); !resumeSpan.EqualValue(expected) {
+				t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
+			}
+			kvs, _, _, _ := MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64,
+				hlc.Timestamp{WallTime: 2}, MVCCScanOptions{})
+			if len(kvs) != 4 ||
+				!bytes.Equal(kvs[0].Key, testKey1) ||
+				!bytes.Equal(kvs[1].Key, testKey4) ||
+				!bytes.Equal(kvs[2].Key, testKey5) ||
+				!bytes.Equal(kvs[3].Key, testKey6) ||
+				!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) ||
+				!bytes.Equal(kvs[1].Value.RawBytes, value4.RawBytes) ||
+				!bytes.Equal(kvs[2].Value.RawBytes, value5.RawBytes) ||
+				!bytes.Equal(kvs[3].Value.RawBytes, value6.RawBytes) {
+				t.Fatal("the value should not be empty")
+			}
 
-	// Try again, but with tombstones set to true to fetch the deleted keys as well.
-	kvs = []roachpb.KeyValue{}
-	if _, err = MVCCIterate(
-		ctx, engine, keyMin, keyMax, hlc.Timestamp{WallTime: 2}, MVCCScanOptions{Tombstones: true},
-		func(kv roachpb.KeyValue) (bool, error) {
-			kvs = append(kvs, kv)
-			return false, nil
-		},
-	); err != nil {
-		t.Fatal(err)
-	}
-	if len(kvs) != 6 ||
-		!bytes.Equal(kvs[0].Key, testKey1) ||
-		!bytes.Equal(kvs[1].Key, testKey2) ||
-		!bytes.Equal(kvs[2].Key, testKey3) ||
-		!bytes.Equal(kvs[3].Key, testKey4) ||
-		!bytes.Equal(kvs[4].Key, testKey5) ||
-		!bytes.Equal(kvs[5].Key, testKey6) ||
-		!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) ||
-		!bytes.Equal(kvs[1].Value.RawBytes, nil) ||
-		!bytes.Equal(kvs[2].Value.RawBytes, nil) ||
-		!bytes.Equal(kvs[3].Value.RawBytes, value4.RawBytes) ||
-		!bytes.Equal(kvs[4].Value.RawBytes, value5.RawBytes) ||
-		!bytes.Equal(kvs[5].Value.RawBytes, value6.RawBytes) {
-		t.Fatal("the value should not be empty")
-	}
+			// Try again, but with tombstones set to true to fetch the deleted keys as well.
+			kvs = []roachpb.KeyValue{}
+			if _, err = MVCCIterate(
+				ctx, engine, keyMin, keyMax, hlc.Timestamp{WallTime: 2}, MVCCScanOptions{Tombstones: true},
+				func(kv roachpb.KeyValue) (bool, error) {
+					kvs = append(kvs, kv)
+					return false, nil
+				},
+			); err != nil {
+				t.Fatal(err)
+			}
+			if len(kvs) != 6 ||
+				!bytes.Equal(kvs[0].Key, testKey1) ||
+				!bytes.Equal(kvs[1].Key, testKey2) ||
+				!bytes.Equal(kvs[2].Key, testKey3) ||
+				!bytes.Equal(kvs[3].Key, testKey4) ||
+				!bytes.Equal(kvs[4].Key, testKey5) ||
+				!bytes.Equal(kvs[5].Key, testKey6) ||
+				!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) ||
+				!bytes.Equal(kvs[1].Value.RawBytes, nil) ||
+				!bytes.Equal(kvs[2].Value.RawBytes, nil) ||
+				!bytes.Equal(kvs[3].Value.RawBytes, value4.RawBytes) ||
+				!bytes.Equal(kvs[4].Value.RawBytes, value5.RawBytes) ||
+				!bytes.Equal(kvs[5].Value.RawBytes, value6.RawBytes) {
+				t.Fatal("the value should not be empty")
+			}
 
-	// Attempt to delete no keys.
-	deleted, resumeSpan, num, err = MVCCDeleteRange(
-		ctx, engine, nil, testKey2, testKey6, 0, hlc.Timestamp{WallTime: 2}, nil, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if deleted != nil {
-		t.Fatal("the value should be empty")
-	}
-	if num != 0 {
-		t.Fatalf("incorrect number of keys deleted: %d", num)
-	}
-	if expected := (roachpb.Span{Key: testKey2, EndKey: testKey6}); !resumeSpan.EqualValue(expected) {
-		t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
-	}
-	kvs, _, _, _ = MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
-		MVCCScanOptions{})
-	if len(kvs) != 4 ||
-		!bytes.Equal(kvs[0].Key, testKey1) ||
-		!bytes.Equal(kvs[1].Key, testKey4) ||
-		!bytes.Equal(kvs[2].Key, testKey5) ||
-		!bytes.Equal(kvs[3].Key, testKey6) ||
-		!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) ||
-		!bytes.Equal(kvs[1].Value.RawBytes, value4.RawBytes) ||
-		!bytes.Equal(kvs[2].Value.RawBytes, value5.RawBytes) ||
-		!bytes.Equal(kvs[3].Value.RawBytes, value6.RawBytes) {
-		t.Fatal("the value should not be empty")
-	}
+			// Attempt to delete no keys.
+			deleted, resumeSpan, num, err = MVCCDeleteRange(
+				ctx, engine, nil, testKey2, testKey6, 0, hlc.Timestamp{WallTime: 2}, nil, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if deleted != nil {
+				t.Fatal("the value should be empty")
+			}
+			if num != 0 {
+				t.Fatalf("incorrect number of keys deleted: %d", num)
+			}
+			if expected := (roachpb.Span{Key: testKey2, EndKey: testKey6}); !resumeSpan.EqualValue(expected) {
+				t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
+			}
+			kvs, _, _, _ = MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
+				MVCCScanOptions{})
+			if len(kvs) != 4 ||
+				!bytes.Equal(kvs[0].Key, testKey1) ||
+				!bytes.Equal(kvs[1].Key, testKey4) ||
+				!bytes.Equal(kvs[2].Key, testKey5) ||
+				!bytes.Equal(kvs[3].Key, testKey6) ||
+				!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) ||
+				!bytes.Equal(kvs[1].Value.RawBytes, value4.RawBytes) ||
+				!bytes.Equal(kvs[2].Value.RawBytes, value5.RawBytes) ||
+				!bytes.Equal(kvs[3].Value.RawBytes, value6.RawBytes) {
+				t.Fatal("the value should not be empty")
+			}
 
-	deleted, resumeSpan, num, err = MVCCDeleteRange(
-		ctx, engine, nil, testKey4, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2}, nil, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if deleted != nil {
-		t.Fatal("the value should be empty")
-	}
-	if num != 3 {
-		t.Fatalf("incorrect number of keys deleted: %d", num)
-	}
-	if resumeSpan != nil {
-		t.Fatalf("wrong resume key: expected nil, found %v", resumeSpan)
-	}
-	kvs, _, _, _ = MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
-		MVCCScanOptions{})
-	if len(kvs) != 1 ||
-		!bytes.Equal(kvs[0].Key, testKey1) ||
-		!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) {
-		t.Fatal("the value should not be empty")
-	}
+			deleted, resumeSpan, num, err = MVCCDeleteRange(
+				ctx, engine, nil, testKey4, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2}, nil, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if deleted != nil {
+				t.Fatal("the value should be empty")
+			}
+			if num != 3 {
+				t.Fatalf("incorrect number of keys deleted: %d", num)
+			}
+			if resumeSpan != nil {
+				t.Fatalf("wrong resume key: expected nil, found %v", resumeSpan)
+			}
+			kvs, _, _, _ = MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
+				MVCCScanOptions{})
+			if len(kvs) != 1 ||
+				!bytes.Equal(kvs[0].Key, testKey1) ||
+				!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) {
+				t.Fatal("the value should not be empty")
+			}
 
-	deleted, resumeSpan, num, err = MVCCDeleteRange(
-		ctx, engine, nil, keyMin, testKey2, math.MaxInt64, hlc.Timestamp{WallTime: 2}, nil, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if deleted != nil {
-		t.Fatal("the value should not be empty")
-	}
-	if num != 1 {
-		t.Fatalf("incorrect number of keys deleted: %d", num)
-	}
-	if resumeSpan != nil {
-		t.Fatalf("wrong resume key: expected nil, found %v", resumeSpan)
-	}
-	kvs, _, _, _ = MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
-		MVCCScanOptions{})
-	if len(kvs) != 0 {
-		t.Fatal("the value should be empty")
+			deleted, resumeSpan, num, err = MVCCDeleteRange(
+				ctx, engine, nil, keyMin, testKey2, math.MaxInt64, hlc.Timestamp{WallTime: 2}, nil, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if deleted != nil {
+				t.Fatal("the value should not be empty")
+			}
+			if num != 1 {
+				t.Fatalf("incorrect number of keys deleted: %d", num)
+			}
+			if resumeSpan != nil {
+				t.Fatalf("wrong resume key: expected nil, found %v", resumeSpan)
+			}
+			kvs, _, _, _ = MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
+				MVCCScanOptions{})
+			if len(kvs) != 0 {
+				t.Fatal("the value should be empty")
+			}
+		})
 	}
 }
 
@@ -2185,144 +2338,148 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, value3, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, value4, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey5, hlc.Timestamp{WallTime: 1}, value5, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey6, hlc.Timestamp{WallTime: 1}, value6, nil); err != nil {
-		t.Fatal(err)
-	}
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, value3, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, value4, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey5, hlc.Timestamp{WallTime: 1}, value5, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey6, hlc.Timestamp{WallTime: 1}, value6, nil); err != nil {
+				t.Fatal(err)
+			}
 
-	// Attempt to delete two keys.
-	deleted, resumeSpan, num, err := MVCCDeleteRange(
-		ctx, engine, nil, testKey2, testKey6, 2, hlc.Timestamp{WallTime: 2}, nil, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(deleted) != 2 {
-		t.Fatal("the value should not be empty")
-	}
-	if num != 2 {
-		t.Fatalf("incorrect number of keys deleted: %d", num)
-	}
-	if expected, actual := testKey2, deleted[0]; !expected.Equal(actual) {
-		t.Fatalf("wrong key deleted: expected %v found %v", expected, actual)
-	}
-	if expected, actual := testKey3, deleted[1]; !expected.Equal(actual) {
-		t.Fatalf("wrong key deleted: expected %v found %v", expected, actual)
-	}
-	if expected := (roachpb.Span{Key: testKey4, EndKey: testKey6}); !resumeSpan.EqualValue(expected) {
-		t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
-	}
-	kvs, _, _, _ := MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
-		MVCCScanOptions{})
-	if len(kvs) != 4 ||
-		!bytes.Equal(kvs[0].Key, testKey1) ||
-		!bytes.Equal(kvs[1].Key, testKey4) ||
-		!bytes.Equal(kvs[2].Key, testKey5) ||
-		!bytes.Equal(kvs[3].Key, testKey6) ||
-		!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) ||
-		!bytes.Equal(kvs[1].Value.RawBytes, value4.RawBytes) ||
-		!bytes.Equal(kvs[2].Value.RawBytes, value5.RawBytes) ||
-		!bytes.Equal(kvs[3].Value.RawBytes, value6.RawBytes) {
-		t.Fatal("the value should not be empty")
-	}
+			// Attempt to delete two keys.
+			deleted, resumeSpan, num, err := MVCCDeleteRange(
+				ctx, engine, nil, testKey2, testKey6, 2, hlc.Timestamp{WallTime: 2}, nil, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(deleted) != 2 {
+				t.Fatal("the value should not be empty")
+			}
+			if num != 2 {
+				t.Fatalf("incorrect number of keys deleted: %d", num)
+			}
+			if expected, actual := testKey2, deleted[0]; !expected.Equal(actual) {
+				t.Fatalf("wrong key deleted: expected %v found %v", expected, actual)
+			}
+			if expected, actual := testKey3, deleted[1]; !expected.Equal(actual) {
+				t.Fatalf("wrong key deleted: expected %v found %v", expected, actual)
+			}
+			if expected := (roachpb.Span{Key: testKey4, EndKey: testKey6}); !resumeSpan.EqualValue(expected) {
+				t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
+			}
+			kvs, _, _, _ := MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
+				MVCCScanOptions{})
+			if len(kvs) != 4 ||
+				!bytes.Equal(kvs[0].Key, testKey1) ||
+				!bytes.Equal(kvs[1].Key, testKey4) ||
+				!bytes.Equal(kvs[2].Key, testKey5) ||
+				!bytes.Equal(kvs[3].Key, testKey6) ||
+				!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) ||
+				!bytes.Equal(kvs[1].Value.RawBytes, value4.RawBytes) ||
+				!bytes.Equal(kvs[2].Value.RawBytes, value5.RawBytes) ||
+				!bytes.Equal(kvs[3].Value.RawBytes, value6.RawBytes) {
+				t.Fatal("the value should not be empty")
+			}
 
-	// Attempt to delete no keys.
-	deleted, resumeSpan, num, err = MVCCDeleteRange(
-		ctx, engine, nil, testKey2, testKey6, 0, hlc.Timestamp{WallTime: 2}, nil, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if deleted != nil {
-		t.Fatalf("the value should be empty: %s", deleted)
-	}
-	if num != 0 {
-		t.Fatalf("incorrect number of keys deleted: %d", num)
-	}
-	if expected := (roachpb.Span{Key: testKey2, EndKey: testKey6}); !resumeSpan.EqualValue(expected) {
-		t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
-	}
-	kvs, _, _, _ = MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
-		MVCCScanOptions{})
-	if len(kvs) != 4 ||
-		!bytes.Equal(kvs[0].Key, testKey1) ||
-		!bytes.Equal(kvs[1].Key, testKey4) ||
-		!bytes.Equal(kvs[2].Key, testKey5) ||
-		!bytes.Equal(kvs[3].Key, testKey6) ||
-		!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) ||
-		!bytes.Equal(kvs[1].Value.RawBytes, value4.RawBytes) ||
-		!bytes.Equal(kvs[2].Value.RawBytes, value5.RawBytes) ||
-		!bytes.Equal(kvs[3].Value.RawBytes, value6.RawBytes) {
-		t.Fatal("the value should not be empty")
-	}
+			// Attempt to delete no keys.
+			deleted, resumeSpan, num, err = MVCCDeleteRange(
+				ctx, engine, nil, testKey2, testKey6, 0, hlc.Timestamp{WallTime: 2}, nil, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if deleted != nil {
+				t.Fatalf("the value should be empty: %s", deleted)
+			}
+			if num != 0 {
+				t.Fatalf("incorrect number of keys deleted: %d", num)
+			}
+			if expected := (roachpb.Span{Key: testKey2, EndKey: testKey6}); !resumeSpan.EqualValue(expected) {
+				t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
+			}
+			kvs, _, _, _ = MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
+				MVCCScanOptions{})
+			if len(kvs) != 4 ||
+				!bytes.Equal(kvs[0].Key, testKey1) ||
+				!bytes.Equal(kvs[1].Key, testKey4) ||
+				!bytes.Equal(kvs[2].Key, testKey5) ||
+				!bytes.Equal(kvs[3].Key, testKey6) ||
+				!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) ||
+				!bytes.Equal(kvs[1].Value.RawBytes, value4.RawBytes) ||
+				!bytes.Equal(kvs[2].Value.RawBytes, value5.RawBytes) ||
+				!bytes.Equal(kvs[3].Value.RawBytes, value6.RawBytes) {
+				t.Fatal("the value should not be empty")
+			}
 
-	deleted, resumeSpan, num, err = MVCCDeleteRange(
-		ctx, engine, nil, testKey4, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2}, nil, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(deleted) != 3 {
-		t.Fatal("the value should not be empty")
-	}
-	if num != 3 {
-		t.Fatalf("incorrect number of keys deleted: %d", num)
-	}
-	if expected, actual := testKey4, deleted[0]; !expected.Equal(actual) {
-		t.Fatalf("wrong key deleted: expected %v found %v", expected, actual)
-	}
-	if expected, actual := testKey5, deleted[1]; !expected.Equal(actual) {
-		t.Fatalf("wrong key deleted: expected %v found %v", expected, actual)
-	}
-	if expected, actual := testKey6, deleted[2]; !expected.Equal(actual) {
-		t.Fatalf("wrong key deleted: expected %v found %v", expected, actual)
-	}
-	if resumeSpan != nil {
-		t.Fatalf("wrong resume key: expected nil, found %v", resumeSpan)
-	}
-	kvs, _, _, _ = MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
-		MVCCScanOptions{})
-	if len(kvs) != 1 ||
-		!bytes.Equal(kvs[0].Key, testKey1) ||
-		!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) {
-		t.Fatal("the value should not be empty")
-	}
+			deleted, resumeSpan, num, err = MVCCDeleteRange(
+				ctx, engine, nil, testKey4, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2}, nil, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(deleted) != 3 {
+				t.Fatal("the value should not be empty")
+			}
+			if num != 3 {
+				t.Fatalf("incorrect number of keys deleted: %d", num)
+			}
+			if expected, actual := testKey4, deleted[0]; !expected.Equal(actual) {
+				t.Fatalf("wrong key deleted: expected %v found %v", expected, actual)
+			}
+			if expected, actual := testKey5, deleted[1]; !expected.Equal(actual) {
+				t.Fatalf("wrong key deleted: expected %v found %v", expected, actual)
+			}
+			if expected, actual := testKey6, deleted[2]; !expected.Equal(actual) {
+				t.Fatalf("wrong key deleted: expected %v found %v", expected, actual)
+			}
+			if resumeSpan != nil {
+				t.Fatalf("wrong resume key: expected nil, found %v", resumeSpan)
+			}
+			kvs, _, _, _ = MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
+				MVCCScanOptions{})
+			if len(kvs) != 1 ||
+				!bytes.Equal(kvs[0].Key, testKey1) ||
+				!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) {
+				t.Fatal("the value should not be empty")
+			}
 
-	deleted, resumeSpan, num, err = MVCCDeleteRange(
-		ctx, engine, nil, keyMin, testKey2, math.MaxInt64, hlc.Timestamp{WallTime: 2}, nil, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(deleted) != 1 {
-		t.Fatal("the value should not be empty")
-	}
-	if num != 1 {
-		t.Fatalf("incorrect number of keys deleted: %d", num)
-	}
-	if expected, actual := testKey1, deleted[0]; !expected.Equal(actual) {
-		t.Fatalf("wrong key deleted: expected %v found %v", expected, actual)
-	}
-	if resumeSpan != nil {
-		t.Fatalf("wrong resume key: %v", resumeSpan)
-	}
-	kvs, _, _, _ = MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
-		MVCCScanOptions{})
-	if len(kvs) != 0 {
-		t.Fatal("the value should be empty")
+			deleted, resumeSpan, num, err = MVCCDeleteRange(
+				ctx, engine, nil, keyMin, testKey2, math.MaxInt64, hlc.Timestamp{WallTime: 2}, nil, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(deleted) != 1 {
+				t.Fatal("the value should not be empty")
+			}
+			if num != 1 {
+				t.Fatalf("incorrect number of keys deleted: %d", num)
+			}
+			if expected, actual := testKey1, deleted[0]; !expected.Equal(actual) {
+				t.Fatalf("wrong key deleted: expected %v found %v", expected, actual)
+			}
+			if resumeSpan != nil {
+				t.Fatalf("wrong resume key: %v", resumeSpan)
+			}
+			kvs, _, _, _ = MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
+				MVCCScanOptions{})
+			if len(kvs) != 0 {
+				t.Fatal("the value should be empty")
+			}
+		})
 	}
 }
 
@@ -2330,36 +2487,40 @@ func TestMVCCDeleteRangeFailed(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
-		t.Fatal(err)
-	}
-	txn.Sequence++
-	if err := MVCCPut(ctx, engine, nil, testKey2, txn.OrigTimestamp, value2, txn); err != nil {
-		t.Fatal(err)
-	}
-	txn.Sequence++
-	if err := MVCCPut(ctx, engine, nil, testKey3, txn.OrigTimestamp, value3, txn); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, value4, nil); err != nil {
-		t.Fatal(err)
-	}
+			txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
+				t.Fatal(err)
+			}
+			txn.Sequence++
+			if err := MVCCPut(ctx, engine, nil, testKey2, txn.OrigTimestamp, value2, txn); err != nil {
+				t.Fatal(err)
+			}
+			txn.Sequence++
+			if err := MVCCPut(ctx, engine, nil, testKey3, txn.OrigTimestamp, value3, txn); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, value4, nil); err != nil {
+				t.Fatal(err)
+			}
 
-	if _, _, _, err := MVCCDeleteRange(
-		ctx, engine, nil, testKey2, testKey4, math.MaxInt64, hlc.Timestamp{WallTime: 1}, nil, false,
-	); err == nil {
-		t.Fatal("expected error on uncommitted write intent")
-	}
+			if _, _, _, err := MVCCDeleteRange(
+				ctx, engine, nil, testKey2, testKey4, math.MaxInt64, hlc.Timestamp{WallTime: 1}, nil, false,
+			); err == nil {
+				t.Fatal("expected error on uncommitted write intent")
+			}
 
-	txn.Sequence++
-	if _, _, _, err := MVCCDeleteRange(
-		ctx, engine, nil, testKey2, testKey4, math.MaxInt64, txn.OrigTimestamp, txn, false,
-	); err != nil {
-		t.Fatal(err)
+			txn.Sequence++
+			if _, _, _, err := MVCCDeleteRange(
+				ctx, engine, nil, testKey2, testKey4, math.MaxInt64, txn.OrigTimestamp, txn, false,
+			); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }
 
@@ -2367,29 +2528,33 @@ func TestMVCCDeleteRangeConcurrentTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
-	txn2ts := makeTxn(*txn2, hlc.Timestamp{WallTime: 2})
+			txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
+			txn2ts := makeTxn(*txn2, hlc.Timestamp{WallTime: 2})
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey2, txn1ts.OrigTimestamp, value2, txn1ts); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey3, txn2ts.OrigTimestamp, value3, txn2ts); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, value4, nil); err != nil {
-		t.Fatal(err)
-	}
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey2, txn1ts.OrigTimestamp, value2, txn1ts); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey3, txn2ts.OrigTimestamp, value3, txn2ts); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, value4, nil); err != nil {
+				t.Fatal(err)
+			}
 
-	if _, _, _, err := MVCCDeleteRange(
-		ctx, engine, nil, testKey2, testKey4, math.MaxInt64, txn1ts.OrigTimestamp, txn1ts, false,
-	); err == nil {
-		t.Fatal("expected error on uncommitted write intent")
+			if _, _, _, err := MVCCDeleteRange(
+				ctx, engine, nil, testKey2, testKey4, math.MaxInt64, txn1ts.OrigTimestamp, txn1ts, false,
+			); err == nil {
+				t.Fatal("expected error on uncommitted write intent")
+			}
+		})
 	}
 }
 
@@ -2399,43 +2564,47 @@ func TestMVCCUncommittedDeleteRangeVisible(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	if err := MVCCPut(
-		ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil,
-	); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(
-		ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value2, nil,
-	); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(
-		ctx, engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, value3, nil,
-	); err != nil {
-		t.Fatal(err)
-	}
+			if err := MVCCPut(
+				ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil,
+			); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(
+				ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value2, nil,
+			); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(
+				ctx, engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, value3, nil,
+			); err != nil {
+				t.Fatal(err)
+			}
 
-	if err := MVCCDelete(
-		ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 2, Logical: 1}, nil,
-	); err != nil {
-		t.Fatal(err)
-	}
+			if err := MVCCDelete(
+				ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 2, Logical: 1}, nil,
+			); err != nil {
+				t.Fatal(err)
+			}
 
-	txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 2})
-	if _, _, _, err := MVCCDeleteRange(
-		ctx, engine, nil, testKey1, testKey4, math.MaxInt64, txn.OrigTimestamp, txn, false,
-	); err != nil {
-		t.Fatal(err)
-	}
+			txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 2})
+			if _, _, _, err := MVCCDeleteRange(
+				ctx, engine, nil, testKey1, testKey4, math.MaxInt64, txn.OrigTimestamp, txn, false,
+			); err != nil {
+				t.Fatal(err)
+			}
 
-	txn.Epoch++
-	kvs, _, _, _ := MVCCScan(ctx, engine, testKey1, testKey4, math.MaxInt64,
-		hlc.Timestamp{WallTime: 3}, MVCCScanOptions{Txn: txn})
-	if e := 2; len(kvs) != e {
-		t.Fatalf("e = %d, got %d", e, len(kvs))
+			txn.Epoch++
+			kvs, _, _, _ := MVCCScan(ctx, engine, testKey1, testKey4, math.MaxInt64,
+				hlc.Timestamp{WallTime: 3}, MVCCScanOptions{Txn: txn})
+			if e := 2; len(kvs) != e {
+				t.Fatalf("e = %d, got %d", e, len(kvs))
+			}
+		})
 	}
 }
 
@@ -2443,105 +2612,109 @@ func TestMVCCDeleteRangeInline(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	// Make five inline values (zero timestamp).
-	for i, kv := range []struct {
-		key   roachpb.Key
-		value roachpb.Value
-	}{
-		{testKey1, value1},
-		{testKey2, value2},
-		{testKey3, value3},
-		{testKey4, value4},
-		{testKey5, value5},
-	} {
-		if err := MVCCPut(ctx, engine, nil, kv.key, hlc.Timestamp{Logical: 0}, kv.value, nil); err != nil {
-			t.Fatalf("%d: %+v", i, err)
-		}
-	}
+			// Make five inline values (zero timestamp).
+			for i, kv := range []struct {
+				key   roachpb.Key
+				value roachpb.Value
+			}{
+				{testKey1, value1},
+				{testKey2, value2},
+				{testKey3, value3},
+				{testKey4, value4},
+				{testKey5, value5},
+			} {
+				if err := MVCCPut(ctx, engine, nil, kv.key, hlc.Timestamp{Logical: 0}, kv.value, nil); err != nil {
+					t.Fatalf("%d: %+v", i, err)
+				}
+			}
 
-	// Create one non-inline value (non-zero timestamp).
-	if err := MVCCPut(ctx, engine, nil, testKey6, hlc.Timestamp{WallTime: 1}, value6, nil); err != nil {
-		t.Fatal(err)
-	}
+			// Create one non-inline value (non-zero timestamp).
+			if err := MVCCPut(ctx, engine, nil, testKey6, hlc.Timestamp{WallTime: 1}, value6, nil); err != nil {
+				t.Fatal(err)
+			}
 
-	// Attempt to delete two inline keys, should succeed.
-	deleted, resumeSpan, num, err := MVCCDeleteRange(
-		ctx, engine, nil, testKey2, testKey6, 2, hlc.Timestamp{Logical: 0}, nil, true,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if expected := int64(2); num != expected {
-		t.Fatalf("got %d deleted keys, expected %d", num, expected)
-	}
-	if expected := []roachpb.Key{testKey2, testKey3}; !reflect.DeepEqual(deleted, expected) {
-		t.Fatalf("got deleted values = %v, expected = %v", deleted, expected)
-	}
-	if expected := (roachpb.Span{Key: testKey4, EndKey: testKey6}); !resumeSpan.EqualValue(expected) {
-		t.Fatalf("got resume span = %s, expected = %s", resumeSpan, expected)
-	}
+			// Attempt to delete two inline keys, should succeed.
+			deleted, resumeSpan, num, err := MVCCDeleteRange(
+				ctx, engine, nil, testKey2, testKey6, 2, hlc.Timestamp{Logical: 0}, nil, true,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if expected := int64(2); num != expected {
+				t.Fatalf("got %d deleted keys, expected %d", num, expected)
+			}
+			if expected := []roachpb.Key{testKey2, testKey3}; !reflect.DeepEqual(deleted, expected) {
+				t.Fatalf("got deleted values = %v, expected = %v", deleted, expected)
+			}
+			if expected := (roachpb.Span{Key: testKey4, EndKey: testKey6}); !resumeSpan.EqualValue(expected) {
+				t.Fatalf("got resume span = %s, expected = %s", resumeSpan, expected)
+			}
 
-	const inlineMismatchErrString = "put is inline"
+			const inlineMismatchErrString = "put is inline"
 
-	// Attempt to delete inline keys at a timestamp; should fail.
-	if _, _, _, err := MVCCDeleteRange(
-		ctx, engine, nil, testKey1, testKey6, 1, hlc.Timestamp{WallTime: 2}, nil, true,
-	); !testutils.IsError(err, inlineMismatchErrString) {
-		t.Fatalf("got error %v, expected error with text '%s'", err, inlineMismatchErrString)
-	}
+			// Attempt to delete inline keys at a timestamp; should fail.
+			if _, _, _, err := MVCCDeleteRange(
+				ctx, engine, nil, testKey1, testKey6, 1, hlc.Timestamp{WallTime: 2}, nil, true,
+			); !testutils.IsError(err, inlineMismatchErrString) {
+				t.Fatalf("got error %v, expected error with text '%s'", err, inlineMismatchErrString)
+			}
 
-	// Attempt to delete non-inline key at zero timestamp; should fail.
-	if _, _, _, err := MVCCDeleteRange(
-		ctx, engine, nil, testKey6, keyMax, 1, hlc.Timestamp{Logical: 0}, nil, true,
-	); !testutils.IsError(err, inlineMismatchErrString) {
-		t.Fatalf("got error %v, expected error with text '%s'", err, inlineMismatchErrString)
-	}
+			// Attempt to delete non-inline key at zero timestamp; should fail.
+			if _, _, _, err := MVCCDeleteRange(
+				ctx, engine, nil, testKey6, keyMax, 1, hlc.Timestamp{Logical: 0}, nil, true,
+			); !testutils.IsError(err, inlineMismatchErrString) {
+				t.Fatalf("got error %v, expected error with text '%s'", err, inlineMismatchErrString)
+			}
 
-	// Attempt to delete inline keys in a transaction; should fail.
-	if _, _, _, err := MVCCDeleteRange(
-		ctx, engine, nil, testKey2, testKey6, 2, hlc.Timestamp{Logical: 0}, txn1, true,
-	); !testutils.IsError(err, "writes not allowed within transactions") {
-		t.Errorf("unexpected error: %+v", err)
-	}
+			// Attempt to delete inline keys in a transaction; should fail.
+			if _, _, _, err := MVCCDeleteRange(
+				ctx, engine, nil, testKey2, testKey6, 2, hlc.Timestamp{Logical: 0}, txn1, true,
+			); !testutils.IsError(err, "writes not allowed within transactions") {
+				t.Errorf("unexpected error: %+v", err)
+			}
 
-	// Verify final state of the engine.
-	expectedKvs := []roachpb.KeyValue{
-		{
-			Key:   testKey1,
-			Value: value1,
-		},
-		{
-			Key:   testKey4,
-			Value: value4,
-		},
-		{
-			Key:   testKey5,
-			Value: value5,
-		},
-		{
-			Key:   testKey6,
-			Value: value6,
-		},
-	}
-	kvs, _, _, err := MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
-		MVCCScanOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if a, e := len(kvs), len(expectedKvs); a != e {
-		t.Fatalf("engine scan found %d keys; expected %d", a, e)
-	}
-	kvs[3].Value.Timestamp = hlc.Timestamp{}
-	if !reflect.DeepEqual(expectedKvs, kvs) {
-		t.Fatalf(
-			"engine scan found key/values: %v; expected %v. Diff: %s",
-			kvs,
-			expectedKvs,
-			pretty.Diff(kvs, expectedKvs),
-		)
+			// Verify final state of the engine.
+			expectedKvs := []roachpb.KeyValue{
+				{
+					Key:   testKey1,
+					Value: value1,
+				},
+				{
+					Key:   testKey4,
+					Value: value4,
+				},
+				{
+					Key:   testKey5,
+					Value: value5,
+				},
+				{
+					Key:   testKey6,
+					Value: value6,
+				},
+			}
+			kvs, _, _, err := MVCCScan(ctx, engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2},
+				MVCCScanOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if a, e := len(kvs), len(expectedKvs); a != e {
+				t.Fatalf("engine scan found %d keys; expected %d", a, e)
+			}
+			kvs[3].Value.Timestamp = hlc.Timestamp{}
+			if !reflect.DeepEqual(expectedKvs, kvs) {
+				t.Fatalf(
+					"engine scan found key/values: %v; expected %v. Diff: %s",
+					kvs,
+					expectedKvs,
+					pretty.Diff(kvs, expectedKvs),
+				)
+			}
+		})
 	}
 }
 
@@ -2549,211 +2722,215 @@ func TestMVCCClearTimeRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
 
-	ts0 := hlc.Timestamp{WallTime: 0}
-	ts0Content := []roachpb.KeyValue{}
-	ts1 := hlc.Timestamp{WallTime: 10}
-	v1 := value1
-	v1.Timestamp = ts1
-	ts1Content := []roachpb.KeyValue{{Key: testKey2, Value: v1}}
-	ts2 := hlc.Timestamp{WallTime: 20}
-	v2 := value2
-	v2.Timestamp = ts2
-	ts2Content := []roachpb.KeyValue{{Key: testKey2, Value: v2}, {Key: testKey5, Value: v2}}
-	ts3 := hlc.Timestamp{WallTime: 30}
-	v3 := value3
-	v3.Timestamp = ts3
-	ts3Content := []roachpb.KeyValue{
-		{Key: testKey1, Value: v3}, {Key: testKey2, Value: v2}, {Key: testKey5, Value: v2},
+			ts0 := hlc.Timestamp{WallTime: 0}
+			ts0Content := []roachpb.KeyValue{}
+			ts1 := hlc.Timestamp{WallTime: 10}
+			v1 := value1
+			v1.Timestamp = ts1
+			ts1Content := []roachpb.KeyValue{{Key: testKey2, Value: v1}}
+			ts2 := hlc.Timestamp{WallTime: 20}
+			v2 := value2
+			v2.Timestamp = ts2
+			ts2Content := []roachpb.KeyValue{{Key: testKey2, Value: v2}, {Key: testKey5, Value: v2}}
+			ts3 := hlc.Timestamp{WallTime: 30}
+			v3 := value3
+			v3.Timestamp = ts3
+			ts3Content := []roachpb.KeyValue{
+				{Key: testKey1, Value: v3}, {Key: testKey2, Value: v2}, {Key: testKey5, Value: v2},
+			}
+			ts4 := hlc.Timestamp{WallTime: 40}
+			v4 := value4
+			v4.Timestamp = ts4
+			ts4Content := []roachpb.KeyValue{
+				{Key: testKey1, Value: v3}, {Key: testKey2, Value: v4}, {Key: testKey5, Value: v4},
+			}
+			ts5 := hlc.Timestamp{WallTime: 50}
+
+			// setupKVs will generate an engine with the key-time space as follows:
+			//    50 -
+			//       |
+			//    40 -      v4          v4
+			//       |
+			//    30 -  v3
+			// time  |
+			//    20 -      v2          v2
+			//       |
+			//    10 -      v1
+			//       |
+			//     0 -----------------------
+			//          k1  k2  k3  k4  k5
+			//                 keys
+			// This returns a new, populated engine since we can't just setup one and use
+			// a new batch in each subtest, since batches don't reflect ClearRange results
+			// when read.
+			setupKVs := func(t *testing.T) Engine {
+				engine := engineImpl.create()
+				require.NoError(t, MVCCPut(ctx, engine, nil, testKey2, ts1, value1, nil))
+				require.NoError(t, MVCCPut(ctx, engine, nil, testKey2, ts2, value2, nil))
+				require.NoError(t, MVCCPut(ctx, engine, nil, testKey5, ts2, value2, nil))
+				require.NoError(t, MVCCPut(ctx, engine, nil, testKey1, ts3, value3, nil))
+				require.NoError(t, MVCCPut(ctx, engine, nil, testKey5, ts4, value4, nil))
+				require.NoError(t, MVCCPut(ctx, engine, nil, testKey2, ts4, value4, nil))
+				return engine
+			}
+
+			assertKVs := func(t *testing.T, e Reader, at hlc.Timestamp, expected []roachpb.KeyValue) {
+				t.Helper()
+				actual, _, _, err := MVCCScan(ctx, e, keyMin, keyMax, 100, at, MVCCScanOptions{})
+				require.NoError(t, err)
+				require.Equal(t, expected, actual)
+			}
+
+			t.Run("clear > ts0", func(t *testing.T) {
+				e := setupKVs(t)
+				defer e.Close()
+				_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts0, ts5, 10)
+				require.NoError(t, err)
+				assertKVs(t, e, ts0, ts0Content)
+				assertKVs(t, e, ts1, ts0Content)
+				assertKVs(t, e, ts5, ts0Content)
+			})
+
+			t.Run("clear > ts1 ", func(t *testing.T) {
+				e := setupKVs(t)
+				defer e.Close()
+				_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts1, ts5, 10)
+				require.NoError(t, err)
+				assertKVs(t, e, ts1, ts1Content)
+				assertKVs(t, e, ts2, ts1Content)
+				assertKVs(t, e, ts5, ts1Content)
+			})
+
+			t.Run("clear > ts2", func(t *testing.T) {
+				e := setupKVs(t)
+				defer e.Close()
+				_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts2, ts5, 10)
+				require.NoError(t, err)
+				assertKVs(t, e, ts2, ts2Content)
+				assertKVs(t, e, ts5, ts2Content)
+			})
+
+			t.Run("clear > ts3", func(t *testing.T) {
+				e := setupKVs(t)
+				defer e.Close()
+				_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts3, ts5, 10)
+				require.NoError(t, err)
+				assertKVs(t, e, ts3, ts3Content)
+				assertKVs(t, e, ts5, ts3Content)
+			})
+
+			t.Run("clear > ts4 (nothing) ", func(t *testing.T) {
+				e := setupKVs(t)
+				defer e.Close()
+				_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts4, ts5, 10)
+				require.NoError(t, err)
+				assertKVs(t, e, ts4, ts4Content)
+				assertKVs(t, e, ts5, ts4Content)
+			})
+
+			t.Run("clear > ts5 (nothing)", func(t *testing.T) {
+				e := setupKVs(t)
+				defer e.Close()
+				_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts5, ts5, 10)
+				require.NoError(t, err)
+				assertKVs(t, e, ts4, ts4Content)
+				assertKVs(t, e, ts5, ts4Content)
+			})
+
+			t.Run("clear up to k5 to ts0", func(t *testing.T) {
+				e := setupKVs(t)
+				defer e.Close()
+				_, err := MVCCClearTimeRange(ctx, e, nil, testKey1, testKey5, ts0, ts5, 10)
+				require.NoError(t, err)
+				assertKVs(t, e, ts2, []roachpb.KeyValue{{Key: testKey5, Value: v2}})
+				assertKVs(t, e, ts5, []roachpb.KeyValue{{Key: testKey5, Value: v4}})
+			})
+
+			t.Run("clear > ts0 in empty span (nothing)", func(t *testing.T) {
+				e := setupKVs(t)
+				defer e.Close()
+				_, err := MVCCClearTimeRange(ctx, e, nil, testKey3, testKey5, ts0, ts5, 10)
+				require.NoError(t, err)
+				assertKVs(t, e, ts2, ts2Content)
+				assertKVs(t, e, ts5, ts4Content)
+			})
+
+			t.Run("clear > ts0 in empty span [k3,k5) (nothing)", func(t *testing.T) {
+				e := setupKVs(t)
+				defer e.Close()
+				_, err := MVCCClearTimeRange(ctx, e, nil, testKey3, testKey5, ts0, ts5, 10)
+				require.NoError(t, err)
+				assertKVs(t, e, ts2, ts2Content)
+				assertKVs(t, e, ts5, ts4Content)
+			})
+
+			t.Run("clear k3 and up in ts0 > x >= ts1 (nothing)", func(t *testing.T) {
+				e := setupKVs(t)
+				defer e.Close()
+				_, err := MVCCClearTimeRange(ctx, e, nil, testKey3, keyMax, ts0, ts1, 10)
+				require.NoError(t, err)
+				assertKVs(t, e, ts2, ts2Content)
+				assertKVs(t, e, ts5, ts4Content)
+			})
+
+			// Add an intent at k3@ts3.
+			txn := roachpb.MakeTransaction("test", nil, roachpb.NormalUserPriority, ts3, 1)
+			setupKVsWithIntent := func(t *testing.T) Engine {
+				e := setupKVs(t)
+				require.NoError(t, MVCCPut(ctx, e, nil, testKey3, ts3, value3, &txn))
+				return e
+			}
+			t.Run("clear everything hitting intent fails", func(t *testing.T) {
+				e := setupKVsWithIntent(t)
+				defer e.Close()
+				_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts0, ts5, 10)
+				require.EqualError(t, err, "conflicting intents on \"/db3\"")
+			})
+
+			t.Run("clear exactly hitting intent fails", func(t *testing.T) {
+				e := setupKVsWithIntent(t)
+				defer e.Close()
+				_, err := MVCCClearTimeRange(ctx, e, nil, testKey3, testKey4, ts2, ts3, 10)
+				require.EqualError(t, err, "conflicting intents on \"/db3\"")
+			})
+
+			t.Run("clear everything above intent", func(t *testing.T) {
+				e := setupKVsWithIntent(t)
+				defer e.Close()
+				_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts3, ts5, 10)
+				require.NoError(t, err)
+				assertKVs(t, e, ts2, ts2Content)
+
+				// Scan (< k3 to avoid intent) to confirm that k2 was indeed reverted to
+				// value as of ts3 (i.e. v4 was cleared to expose v2).
+				actual, _, _, err := MVCCScan(ctx, e, keyMin, testKey3, 100, ts5, MVCCScanOptions{})
+				require.NoError(t, err)
+				require.Equal(t, ts3Content[:2], actual)
+
+				// Verify the intent was left alone.
+				_, _, _, err = MVCCScan(ctx, e, testKey3, testKey4, 100, ts5, MVCCScanOptions{})
+				require.Error(t, err)
+
+				// Scan (> k3 to avoid intent) to confirm that k5 was indeed reverted to
+				// value as of ts3 (i.e. v4 was cleared to expose v2).
+				actual, _, _, err = MVCCScan(ctx, e, testKey4, keyMax, 100, ts5, MVCCScanOptions{})
+				require.NoError(t, err)
+				require.Equal(t, ts3Content[2:], actual)
+			})
+
+			t.Run("clear below intent", func(t *testing.T) {
+				e := setupKVsWithIntent(t)
+				defer e.Close()
+				assertKVs(t, e, ts2, ts2Content)
+				_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts1, ts2, 10)
+				require.NoError(t, err)
+				assertKVs(t, e, ts2, ts1Content)
+			})
+		})
 	}
-	ts4 := hlc.Timestamp{WallTime: 40}
-	v4 := value4
-	v4.Timestamp = ts4
-	ts4Content := []roachpb.KeyValue{
-		{Key: testKey1, Value: v3}, {Key: testKey2, Value: v4}, {Key: testKey5, Value: v4},
-	}
-	ts5 := hlc.Timestamp{WallTime: 50}
-
-	// setupKVs will generate an engine with the key-time space as follows:
-	//    50 -
-	//       |
-	//    40 -      v4          v4
-	//       |
-	//    30 -  v3
-	// time  |
-	//    20 -      v2          v2
-	//       |
-	//    10 -      v1
-	//       |
-	//     0 -----------------------
-	//          k1  k2  k3  k4  k5
-	//                 keys
-	// This returns a new, populated engine since we can't just setup one and use
-	// a new batch in each subtest, since batches don't reflect ClearRange results
-	// when read.
-	setupKVs := func(t *testing.T) Engine {
-		engine := createTestEngine()
-		require.NoError(t, MVCCPut(ctx, engine, nil, testKey2, ts1, value1, nil))
-		require.NoError(t, MVCCPut(ctx, engine, nil, testKey2, ts2, value2, nil))
-		require.NoError(t, MVCCPut(ctx, engine, nil, testKey5, ts2, value2, nil))
-		require.NoError(t, MVCCPut(ctx, engine, nil, testKey1, ts3, value3, nil))
-		require.NoError(t, MVCCPut(ctx, engine, nil, testKey5, ts4, value4, nil))
-		require.NoError(t, MVCCPut(ctx, engine, nil, testKey2, ts4, value4, nil))
-		return engine
-	}
-
-	assertKVs := func(t *testing.T, e Reader, at hlc.Timestamp, expected []roachpb.KeyValue) {
-		t.Helper()
-		actual, _, _, err := MVCCScan(ctx, e, keyMin, keyMax, 100, at, MVCCScanOptions{})
-		require.NoError(t, err)
-		require.Equal(t, expected, actual)
-	}
-
-	t.Run("clear > ts0", func(t *testing.T) {
-		e := setupKVs(t)
-		defer e.Close()
-		_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts0, ts5, 10)
-		require.NoError(t, err)
-		assertKVs(t, e, ts0, ts0Content)
-		assertKVs(t, e, ts1, ts0Content)
-		assertKVs(t, e, ts5, ts0Content)
-	})
-
-	t.Run("clear > ts1 ", func(t *testing.T) {
-		e := setupKVs(t)
-		defer e.Close()
-		_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts1, ts5, 10)
-		require.NoError(t, err)
-		assertKVs(t, e, ts1, ts1Content)
-		assertKVs(t, e, ts2, ts1Content)
-		assertKVs(t, e, ts5, ts1Content)
-	})
-
-	t.Run("clear > ts2", func(t *testing.T) {
-		e := setupKVs(t)
-		defer e.Close()
-		_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts2, ts5, 10)
-		require.NoError(t, err)
-		assertKVs(t, e, ts2, ts2Content)
-		assertKVs(t, e, ts5, ts2Content)
-	})
-
-	t.Run("clear > ts3", func(t *testing.T) {
-		e := setupKVs(t)
-		defer e.Close()
-		_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts3, ts5, 10)
-		require.NoError(t, err)
-		assertKVs(t, e, ts3, ts3Content)
-		assertKVs(t, e, ts5, ts3Content)
-	})
-
-	t.Run("clear > ts4 (nothing) ", func(t *testing.T) {
-		e := setupKVs(t)
-		defer e.Close()
-		_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts4, ts5, 10)
-		require.NoError(t, err)
-		assertKVs(t, e, ts4, ts4Content)
-		assertKVs(t, e, ts5, ts4Content)
-	})
-
-	t.Run("clear > ts5 (nothing)", func(t *testing.T) {
-		e := setupKVs(t)
-		defer e.Close()
-		_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts5, ts5, 10)
-		require.NoError(t, err)
-		assertKVs(t, e, ts4, ts4Content)
-		assertKVs(t, e, ts5, ts4Content)
-	})
-
-	t.Run("clear up to k5 to ts0", func(t *testing.T) {
-		e := setupKVs(t)
-		defer e.Close()
-		_, err := MVCCClearTimeRange(ctx, e, nil, testKey1, testKey5, ts0, ts5, 10)
-		require.NoError(t, err)
-		assertKVs(t, e, ts2, []roachpb.KeyValue{{Key: testKey5, Value: v2}})
-		assertKVs(t, e, ts5, []roachpb.KeyValue{{Key: testKey5, Value: v4}})
-	})
-
-	t.Run("clear > ts0 in empty span (nothing)", func(t *testing.T) {
-		e := setupKVs(t)
-		defer e.Close()
-		_, err := MVCCClearTimeRange(ctx, e, nil, testKey3, testKey5, ts0, ts5, 10)
-		require.NoError(t, err)
-		assertKVs(t, e, ts2, ts2Content)
-		assertKVs(t, e, ts5, ts4Content)
-	})
-
-	t.Run("clear > ts0 in empty span [k3,k5) (nothing)", func(t *testing.T) {
-		e := setupKVs(t)
-		defer e.Close()
-		_, err := MVCCClearTimeRange(ctx, e, nil, testKey3, testKey5, ts0, ts5, 10)
-		require.NoError(t, err)
-		assertKVs(t, e, ts2, ts2Content)
-		assertKVs(t, e, ts5, ts4Content)
-	})
-
-	t.Run("clear k3 and up in ts0 > x >= ts1 (nothing)", func(t *testing.T) {
-		e := setupKVs(t)
-		defer e.Close()
-		_, err := MVCCClearTimeRange(ctx, e, nil, testKey3, keyMax, ts0, ts1, 10)
-		require.NoError(t, err)
-		assertKVs(t, e, ts2, ts2Content)
-		assertKVs(t, e, ts5, ts4Content)
-	})
-
-	// Add an intent at k3@ts3.
-	txn := roachpb.MakeTransaction("test", nil, roachpb.NormalUserPriority, ts3, 1)
-	setupKVsWithIntent := func(t *testing.T) Engine {
-		e := setupKVs(t)
-		require.NoError(t, MVCCPut(ctx, e, nil, testKey3, ts3, value3, &txn))
-		return e
-	}
-	t.Run("clear everything hitting intent fails", func(t *testing.T) {
-		e := setupKVsWithIntent(t)
-		defer e.Close()
-		_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts0, ts5, 10)
-		require.EqualError(t, err, "conflicting intents on \"/db3\"")
-	})
-
-	t.Run("clear exactly hitting intent fails", func(t *testing.T) {
-		e := setupKVsWithIntent(t)
-		defer e.Close()
-		_, err := MVCCClearTimeRange(ctx, e, nil, testKey3, testKey4, ts2, ts3, 10)
-		require.EqualError(t, err, "conflicting intents on \"/db3\"")
-	})
-
-	t.Run("clear everything above intent", func(t *testing.T) {
-		e := setupKVsWithIntent(t)
-		defer e.Close()
-		_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts3, ts5, 10)
-		require.NoError(t, err)
-		assertKVs(t, e, ts2, ts2Content)
-
-		// Scan (< k3 to avoid intent) to confirm that k2 was indeed reverted to
-		// value as of ts3 (i.e. v4 was cleared to expose v2).
-		actual, _, _, err := MVCCScan(ctx, e, keyMin, testKey3, 100, ts5, MVCCScanOptions{})
-		require.NoError(t, err)
-		require.Equal(t, ts3Content[:2], actual)
-
-		// Verify the intent was left alone.
-		_, _, _, err = MVCCScan(ctx, e, testKey3, testKey4, 100, ts5, MVCCScanOptions{})
-		require.Error(t, err)
-
-		// Scan (> k3 to avoid intent) to confirm that k5 was indeed reverted to
-		// value as of ts3 (i.e. v4 was cleared to expose v2).
-		actual, _, _, err = MVCCScan(ctx, e, testKey4, keyMax, 100, ts5, MVCCScanOptions{})
-		require.NoError(t, err)
-		require.Equal(t, ts3Content[2:], actual)
-	})
-
-	t.Run("clear below intent", func(t *testing.T) {
-		e := setupKVsWithIntent(t)
-		defer e.Close()
-		assertKVs(t, e, ts2, ts2Content)
-		_, err := MVCCClearTimeRange(ctx, e, nil, keyMin, keyMax, ts1, ts2, 10)
-		require.NoError(t, err)
-		assertKVs(t, e, ts2, ts1Content)
-	})
 }
 
 func computeStats(
@@ -2780,97 +2957,101 @@ func TestMVCCClearTimeRangeOnRandomData(t *testing.T) {
 
 	ctx := context.Background()
 
-	e := createTestEngine()
-	defer e.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			e := engineImpl.create()
+			defer e.Close()
 
-	now := hlc.Timestamp{WallTime: 100000000}
+			now := hlc.Timestamp{WallTime: 100000000}
 
-	var ms enginepb.MVCCStats
+			var ms enginepb.MVCCStats
 
-	// Setup numKVs random kv by writing to random keys [0, keyRange) except for
-	// the span [swathStart, swathEnd). Then fill in that swath with kvs all
-	// having the same ts, to ensure they all revert at the same time, thus
-	// triggering the ClearRange optimization path.
-	const numKVs = 10000
-	const keyRange, swathStart, swathEnd = 5000, 3500, 4000
-	const swathSize = swathEnd - swathStart
-	const randTimeRange = 1000
+			// Setup numKVs random kv by writing to random keys [0, keyRange) except for
+			// the span [swathStart, swathEnd). Then fill in that swath with kvs all
+			// having the same ts, to ensure they all revert at the same time, thus
+			// triggering the ClearRange optimization path.
+			const numKVs = 10000
+			const keyRange, swathStart, swathEnd = 5000, 3500, 4000
+			const swathSize = swathEnd - swathStart
+			const randTimeRange = 1000
 
-	wrote := make(map[int]int64, keyRange)
-	for i := 0; i < numKVs-swathSize; i++ {
-		k := rng.Intn(keyRange - swathSize)
-		if k >= swathStart {
-			k += swathSize
-		}
-
-		ts := int64(rng.Intn(randTimeRange))
-		// Ensure writes to a given key are increasing in time.
-		if ts <= wrote[k] {
-			ts = wrote[k] + 1
-		}
-		wrote[k] = ts
-
-		key := roachpb.Key(fmt.Sprintf("%05d", k))
-		if rand.Float64() > 0.8 {
-			require.NoError(t, MVCCDelete(ctx, e, &ms, key, hlc.Timestamp{WallTime: ts}, nil))
-		} else {
-			v := roachpb.MakeValueFromString(fmt.Sprintf("v-%d", i))
-			require.NoError(t, MVCCPut(ctx, e, &ms, key, hlc.Timestamp{WallTime: ts}, v, nil))
-		}
-	}
-	swathTime := rand.Intn(randTimeRange-100) + 100
-	for i := swathStart; i < swathEnd; i++ {
-		key := roachpb.Key(fmt.Sprintf("%05d", i))
-		v := roachpb.MakeValueFromString(fmt.Sprintf("v-%d", i))
-		require.NoError(t, MVCCPut(ctx, e, &ms, key, hlc.Timestamp{WallTime: int64(swathTime)}, v, nil))
-	}
-
-	// Add another swath of keys above to exercise an after-iteration range flush.
-	for i := keyRange; i < keyRange+200; i++ {
-		key := roachpb.Key(fmt.Sprintf("%05d", i))
-		v := roachpb.MakeValueFromString(fmt.Sprintf("v-%d", i))
-		require.NoError(t, MVCCPut(ctx, e, &ms, key, hlc.Timestamp{WallTime: int64(randTimeRange + 1)}, v, nil))
-	}
-
-	ms.AgeTo(2000)
-
-	// Sanity check starting stats.
-	require.Equal(t, computeStats(t, e, keyMin, keyMax, 2000), ms)
-
-	// Pick timestamps to which we'll revert, and sort them so we can go back
-	// though them in order. The largest will still be less than randTimeRange so
-	// the initial revert will be assured to use ClearRange.
-	reverts := make([]int, 5)
-	for i := range reverts {
-		reverts[i] = rand.Intn(randTimeRange)
-	}
-	reverts[0] = swathTime - 1
-	sort.Ints(reverts)
-
-	for i := len(reverts) - 1; i >= 0; i-- {
-		t.Run(fmt.Sprintf("revert-%d", i), func(t *testing.T) {
-			revertTo := hlc.Timestamp{WallTime: int64(reverts[i])}
-			// MVCC-Scan at the revert time.
-			scannedBefore, _, _, err := MVCCScan(ctx, e, keyMin, keyMax, numKVs, revertTo, MVCCScanOptions{})
-			require.NoError(t, err)
-
-			// Revert to the revert time.
-			startKey := keyMin
-			for {
-				resume, err := MVCCClearTimeRange(ctx, e, &ms, startKey, keyMax, revertTo, now, 100)
-				require.NoError(t, err)
-				if resume == nil {
-					break
+			wrote := make(map[int]int64, keyRange)
+			for i := 0; i < numKVs-swathSize; i++ {
+				k := rng.Intn(keyRange - swathSize)
+				if k >= swathStart {
+					k += swathSize
 				}
-				startKey = resume.Key
+
+				ts := int64(rng.Intn(randTimeRange))
+				// Ensure writes to a given key are increasing in time.
+				if ts <= wrote[k] {
+					ts = wrote[k] + 1
+				}
+				wrote[k] = ts
+
+				key := roachpb.Key(fmt.Sprintf("%05d", k))
+				if rand.Float64() > 0.8 {
+					require.NoError(t, MVCCDelete(ctx, e, &ms, key, hlc.Timestamp{WallTime: ts}, nil))
+				} else {
+					v := roachpb.MakeValueFromString(fmt.Sprintf("v-%d", i))
+					require.NoError(t, MVCCPut(ctx, e, &ms, key, hlc.Timestamp{WallTime: ts}, v, nil))
+				}
+			}
+			swathTime := rand.Intn(randTimeRange-100) + 100
+			for i := swathStart; i < swathEnd; i++ {
+				key := roachpb.Key(fmt.Sprintf("%05d", i))
+				v := roachpb.MakeValueFromString(fmt.Sprintf("v-%d", i))
+				require.NoError(t, MVCCPut(ctx, e, &ms, key, hlc.Timestamp{WallTime: int64(swathTime)}, v, nil))
 			}
 
+			// Add another swath of keys above to exercise an after-iteration range flush.
+			for i := keyRange; i < keyRange+200; i++ {
+				key := roachpb.Key(fmt.Sprintf("%05d", i))
+				v := roachpb.MakeValueFromString(fmt.Sprintf("v-%d", i))
+				require.NoError(t, MVCCPut(ctx, e, &ms, key, hlc.Timestamp{WallTime: int64(randTimeRange + 1)}, v, nil))
+			}
+
+			ms.AgeTo(2000)
+
+			// Sanity check starting stats.
 			require.Equal(t, computeStats(t, e, keyMin, keyMax, 2000), ms)
-			// Scanning at "now" post-revert should yield the same result as scanning
-			// at revert-time pre-revert.
-			scannedAfter, _, _, err := MVCCScan(ctx, e, keyMin, keyMax, numKVs, now, MVCCScanOptions{})
-			require.NoError(t, err)
-			require.Equal(t, scannedBefore, scannedAfter)
+
+			// Pick timestamps to which we'll revert, and sort them so we can go back
+			// though them in order. The largest will still be less than randTimeRange so
+			// the initial revert will be assured to use ClearRange.
+			reverts := make([]int, 5)
+			for i := range reverts {
+				reverts[i] = rand.Intn(randTimeRange)
+			}
+			reverts[0] = swathTime - 1
+			sort.Ints(reverts)
+
+			for i := len(reverts) - 1; i >= 0; i-- {
+				t.Run(fmt.Sprintf("revert-%d", i), func(t *testing.T) {
+					revertTo := hlc.Timestamp{WallTime: int64(reverts[i])}
+					// MVCC-Scan at the revert time.
+					scannedBefore, _, _, err := MVCCScan(ctx, e, keyMin, keyMax, numKVs, revertTo, MVCCScanOptions{})
+					require.NoError(t, err)
+
+					// Revert to the revert time.
+					startKey := keyMin
+					for {
+						resume, err := MVCCClearTimeRange(ctx, e, &ms, startKey, keyMax, revertTo, now, 100)
+						require.NoError(t, err)
+						if resume == nil {
+							break
+						}
+						startKey = resume.Key
+					}
+
+					require.Equal(t, computeStats(t, e, keyMin, keyMax, 2000), ms)
+					// Scanning at "now" post-revert should yield the same result as scanning
+					// at revert-time pre-revert.
+					scannedAfter, _, _, err := MVCCScan(ctx, e, keyMin, keyMax, numKVs, now, MVCCScanOptions{})
+					require.NoError(t, err)
+					require.Equal(t, scannedBefore, scannedAfter)
+				})
+			}
 		})
 	}
 }
@@ -2879,136 +3060,140 @@ func TestMVCCConditionalPut(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	clock := hlc.NewClock(hlc.NewManualClock(123).UnixNano, time.Nanosecond)
+			clock := hlc.NewClock(hlc.NewManualClock(123).UnixNano, time.Nanosecond)
 
-	err := MVCCConditionalPut(ctx, engine, nil, testKey1, clock.Now(), value1, &value2, CPutFailIfMissing, nil)
-	if err == nil {
-		t.Fatal("expected error on key not exists")
-	}
-	switch e := err.(type) {
-	default:
-		t.Fatalf("unexpected error %T", e)
-	case *roachpb.ConditionFailedError:
-		if e.ActualValue != nil {
-			t.Fatalf("expected missing actual value: %v", e.ActualValue)
-		}
-	}
+			err := MVCCConditionalPut(ctx, engine, nil, testKey1, clock.Now(), value1, &value2, CPutFailIfMissing, nil)
+			if err == nil {
+				t.Fatal("expected error on key not exists")
+			}
+			switch e := err.(type) {
+			default:
+				t.Fatalf("unexpected error %T", e)
+			case *roachpb.ConditionFailedError:
+				if e.ActualValue != nil {
+					t.Fatalf("expected missing actual value: %v", e.ActualValue)
+				}
+			}
 
-	// Verify the difference between missing value and empty value.
-	err = MVCCConditionalPut(ctx, engine, nil, testKey1, clock.Now(), value1, &valueEmpty, CPutFailIfMissing, nil)
-	if err == nil {
-		t.Fatal("expected error on key not exists")
-	}
-	switch e := err.(type) {
-	default:
-		t.Fatalf("unexpected error %T", e)
-	case *roachpb.ConditionFailedError:
-		if e.ActualValue != nil {
-			t.Fatalf("expected missing actual value: %v", e.ActualValue)
-		}
-	}
+			// Verify the difference between missing value and empty value.
+			err = MVCCConditionalPut(ctx, engine, nil, testKey1, clock.Now(), value1, &valueEmpty, CPutFailIfMissing, nil)
+			if err == nil {
+				t.Fatal("expected error on key not exists")
+			}
+			switch e := err.(type) {
+			default:
+				t.Fatalf("unexpected error %T", e)
+			case *roachpb.ConditionFailedError:
+				if e.ActualValue != nil {
+					t.Fatalf("expected missing actual value: %v", e.ActualValue)
+				}
+			}
 
-	// Do a conditional put with expectation that the value is completely missing; will succeed.
-	err = MVCCConditionalPut(ctx, engine, nil, testKey1, clock.Now(), value1, nil, CPutFailIfMissing, nil)
-	if err != nil {
-		t.Fatalf("expected success with condition that key doesn't yet exist: %+v", err)
-	}
+			// Do a conditional put with expectation that the value is completely missing; will succeed.
+			err = MVCCConditionalPut(ctx, engine, nil, testKey1, clock.Now(), value1, nil, CPutFailIfMissing, nil)
+			if err != nil {
+				t.Fatalf("expected success with condition that key doesn't yet exist: %+v", err)
+			}
 
-	// Another conditional put expecting value missing will fail, now that value1 is written.
-	err = MVCCConditionalPut(ctx, engine, nil, testKey1, clock.Now(), value1, nil, CPutFailIfMissing, nil)
-	if err == nil {
-		t.Fatal("expected error on key already exists")
-	}
-	var actualValue *roachpb.Value
-	switch e := err.(type) {
-	default:
-		t.Fatalf("unexpected error %T", e)
-	case *roachpb.ConditionFailedError:
-		actualValue = e.ActualValue
-		if !bytes.Equal(e.ActualValue.RawBytes, value1.RawBytes) {
-			t.Fatalf("the value %s in get result does not match the value %s in request",
-				e.ActualValue.RawBytes, value1.RawBytes)
-		}
-	}
+			// Another conditional put expecting value missing will fail, now that value1 is written.
+			err = MVCCConditionalPut(ctx, engine, nil, testKey1, clock.Now(), value1, nil, CPutFailIfMissing, nil)
+			if err == nil {
+				t.Fatal("expected error on key already exists")
+			}
+			var actualValue *roachpb.Value
+			switch e := err.(type) {
+			default:
+				t.Fatalf("unexpected error %T", e)
+			case *roachpb.ConditionFailedError:
+				actualValue = e.ActualValue
+				if !bytes.Equal(e.ActualValue.RawBytes, value1.RawBytes) {
+					t.Fatalf("the value %s in get result does not match the value %s in request",
+						e.ActualValue.RawBytes, value1.RawBytes)
+				}
+			}
 
-	// Conditional put expecting wrong value2, will fail.
-	err = MVCCConditionalPut(ctx, engine, nil, testKey1, clock.Now(), value1, &value2, CPutFailIfMissing, nil)
-	if err == nil {
-		t.Fatal("expected error on key does not match")
-	}
-	switch e := err.(type) {
-	default:
-		t.Fatalf("unexpected error %T", e)
-	case *roachpb.ConditionFailedError:
-		if actualValue == e.ActualValue {
-			t.Fatalf("unexpected sharing of *roachpb.Value")
-		}
-		if !bytes.Equal(e.ActualValue.RawBytes, value1.RawBytes) {
-			t.Fatalf("the value %s in get result does not match the value %s in request",
-				e.ActualValue.RawBytes, value1.RawBytes)
-		}
-	}
+			// Conditional put expecting wrong value2, will fail.
+			err = MVCCConditionalPut(ctx, engine, nil, testKey1, clock.Now(), value1, &value2, CPutFailIfMissing, nil)
+			if err == nil {
+				t.Fatal("expected error on key does not match")
+			}
+			switch e := err.(type) {
+			default:
+				t.Fatalf("unexpected error %T", e)
+			case *roachpb.ConditionFailedError:
+				if actualValue == e.ActualValue {
+					t.Fatalf("unexpected sharing of *roachpb.Value")
+				}
+				if !bytes.Equal(e.ActualValue.RawBytes, value1.RawBytes) {
+					t.Fatalf("the value %s in get result does not match the value %s in request",
+						e.ActualValue.RawBytes, value1.RawBytes)
+				}
+			}
 
-	// Move to an empty value. Will succeed.
-	if err := MVCCConditionalPut(ctx, engine, nil, testKey1, clock.Now(), valueEmpty, &value1, CPutFailIfMissing, nil); err != nil {
-		t.Fatal(err)
-	}
+			// Move to an empty value. Will succeed.
+			if err := MVCCConditionalPut(ctx, engine, nil, testKey1, clock.Now(), valueEmpty, &value1, CPutFailIfMissing, nil); err != nil {
+				t.Fatal(err)
+			}
 
-	// Move key2 (which does not exist) to from value1 to value2.
-	// Expect it to fail since it does not exist with value1.
-	err = MVCCConditionalPut(ctx, engine, nil, testKey2, clock.Now(), value2, &value1, CPutFailIfMissing, nil)
-	if err == nil {
-		t.Fatal("expected error on key not exists")
-	}
-	switch e := err.(type) {
-	default:
-		t.Fatalf("unexpected error %T", e)
-	case *roachpb.ConditionFailedError:
-		if e.ActualValue != nil {
-			t.Fatalf("expected missing actual value: %v", e.ActualValue)
-		}
-	}
+			// Move key2 (which does not exist) to from value1 to value2.
+			// Expect it to fail since it does not exist with value1.
+			err = MVCCConditionalPut(ctx, engine, nil, testKey2, clock.Now(), value2, &value1, CPutFailIfMissing, nil)
+			if err == nil {
+				t.Fatal("expected error on key not exists")
+			}
+			switch e := err.(type) {
+			default:
+				t.Fatalf("unexpected error %T", e)
+			case *roachpb.ConditionFailedError:
+				if e.ActualValue != nil {
+					t.Fatalf("expected missing actual value: %v", e.ActualValue)
+				}
+			}
 
-	// Move key2 (which does not yet exist) to from value1 to value2, but allowing for it not existing.
-	if err := MVCCConditionalPut(ctx, engine, nil, testKey2, clock.Now(), value2, &value1, CPutAllowIfMissing, nil); err != nil {
-		t.Fatal(err)
-	}
+			// Move key2 (which does not yet exist) to from value1 to value2, but allowing for it not existing.
+			if err := MVCCConditionalPut(ctx, engine, nil, testKey2, clock.Now(), value2, &value1, CPutAllowIfMissing, nil); err != nil {
+				t.Fatal(err)
+			}
 
-	// Try to move key2 (which has value2) from value1 to empty. Expect error.
-	err = MVCCConditionalPut(ctx, engine, nil, testKey2, clock.Now(), valueEmpty, &value1, CPutAllowIfMissing, nil)
-	if err == nil {
-		t.Fatal("expected error on key not exists")
-	}
-	switch e := err.(type) {
-	default:
-		t.Fatalf("unexpected error %T", e)
-	case *roachpb.ConditionFailedError:
-		if !bytes.Equal(e.ActualValue.RawBytes, value2.RawBytes) {
-			t.Fatalf("the value %s in get result does not match the value %s in request",
-				e.ActualValue.RawBytes, value2.RawBytes)
-		}
-	}
+			// Try to move key2 (which has value2) from value1 to empty. Expect error.
+			err = MVCCConditionalPut(ctx, engine, nil, testKey2, clock.Now(), valueEmpty, &value1, CPutAllowIfMissing, nil)
+			if err == nil {
+				t.Fatal("expected error on key not exists")
+			}
+			switch e := err.(type) {
+			default:
+				t.Fatalf("unexpected error %T", e)
+			case *roachpb.ConditionFailedError:
+				if !bytes.Equal(e.ActualValue.RawBytes, value2.RawBytes) {
+					t.Fatalf("the value %s in get result does not match the value %s in request",
+						e.ActualValue.RawBytes, value2.RawBytes)
+				}
+			}
 
-	// Try to move key2 (which has value2) from value2 to empty. Expect success.
-	if err := MVCCConditionalPut(ctx, engine, nil, testKey2, clock.Now(), valueEmpty, &value2, CPutAllowIfMissing, nil); err != nil {
-		t.Fatal(err)
-	}
+			// Try to move key2 (which has value2) from value2 to empty. Expect success.
+			if err := MVCCConditionalPut(ctx, engine, nil, testKey2, clock.Now(), valueEmpty, &value2, CPutAllowIfMissing, nil); err != nil {
+				t.Fatal(err)
+			}
 
-	// Now move to value2 from expected empty value.
-	if err := MVCCConditionalPut(ctx, engine, nil, testKey1, clock.Now(), value2, &valueEmpty, CPutFailIfMissing, nil); err != nil {
-		t.Fatal(err)
-	}
-	// Verify we get value2 as expected.
-	value, _, err := MVCCGet(ctx, engine, testKey1, clock.Now(), MVCCGetOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(value2.RawBytes, value.RawBytes) {
-		t.Fatalf("the value %s in get result does not match the value %s in request",
-			value1.RawBytes, value.RawBytes)
+			// Now move to value2 from expected empty value.
+			if err := MVCCConditionalPut(ctx, engine, nil, testKey1, clock.Now(), value2, &valueEmpty, CPutFailIfMissing, nil); err != nil {
+				t.Fatal(err)
+			}
+			// Verify we get value2 as expected.
+			value, _, err := MVCCGet(ctx, engine, testKey1, clock.Now(), MVCCGetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(value2.RawBytes, value.RawBytes) {
+				t.Fatalf("the value %s in get result does not match the value %s in request",
+					value1.RawBytes, value.RawBytes)
+			}
+		})
 	}
 }
 
@@ -3016,47 +3201,51 @@ func TestMVCCConditionalPutWithTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	clock := hlc.NewClock(hlc.NewManualClock(123).UnixNano, time.Nanosecond)
+			clock := hlc.NewClock(hlc.NewManualClock(123).UnixNano, time.Nanosecond)
 
-	// Write value1.
-	txn := *txn1
-	txn.Sequence++
-	if err := MVCCConditionalPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value1, nil, CPutFailIfMissing, &txn); err != nil {
-		t.Fatal(err)
-	}
-	// Now, overwrite value1 with value2 from same txn; should see value1 as pre-existing value.
-	txn.Sequence++
-	if err := MVCCConditionalPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value2, &value1, CPutFailIfMissing, &txn); err != nil {
-		t.Fatal(err)
-	}
-	// Writing value3 from a new epoch should see nil again.
-	txn.Sequence++
-	txn.Epoch = 2
-	if err := MVCCConditionalPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value3, nil, CPutFailIfMissing, &txn); err != nil {
-		t.Fatal(err)
-	}
-	// Commit value3.
-	txnCommit := txn
-	txnCommit.Status = roachpb.COMMITTED
-	txnCommit.Timestamp = clock.Now().Add(1, 0)
-	if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
-		Span:   roachpb.Span{Key: testKey1},
-		Status: txnCommit.Status,
-		Txn:    txnCommit.TxnMeta,
-	}); err != nil {
-		t.Fatal(err)
-	}
-	// Write value4 with an old timestamp without txn...should get a write too old error.
-	err := MVCCConditionalPut(ctx, engine, nil, testKey1, clock.Now(), value4, &value3, CPutFailIfMissing, nil)
-	if _, ok := err.(*roachpb.WriteTooOldError); !ok {
-		t.Fatalf("expected write too old error; got %s", err)
-	}
-	expTS := txnCommit.Timestamp.Next()
-	if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok || wtoErr.ActualTimestamp != expTS {
-		t.Fatalf("expected wto error with actual timestamp = %s; got %s", expTS, wtoErr)
+			// Write value1.
+			txn := *txn1
+			txn.Sequence++
+			if err := MVCCConditionalPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value1, nil, CPutFailIfMissing, &txn); err != nil {
+				t.Fatal(err)
+			}
+			// Now, overwrite value1 with value2 from same txn; should see value1 as pre-existing value.
+			txn.Sequence++
+			if err := MVCCConditionalPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value2, &value1, CPutFailIfMissing, &txn); err != nil {
+				t.Fatal(err)
+			}
+			// Writing value3 from a new epoch should see nil again.
+			txn.Sequence++
+			txn.Epoch = 2
+			if err := MVCCConditionalPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value3, nil, CPutFailIfMissing, &txn); err != nil {
+				t.Fatal(err)
+			}
+			// Commit value3.
+			txnCommit := txn
+			txnCommit.Status = roachpb.COMMITTED
+			txnCommit.Timestamp = clock.Now().Add(1, 0)
+			if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
+				Span:   roachpb.Span{Key: testKey1},
+				Status: txnCommit.Status,
+				Txn:    txnCommit.TxnMeta,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			// Write value4 with an old timestamp without txn...should get a write too old error.
+			err := MVCCConditionalPut(ctx, engine, nil, testKey1, clock.Now(), value4, &value3, CPutFailIfMissing, nil)
+			if _, ok := err.(*roachpb.WriteTooOldError); !ok {
+				t.Fatalf("expected write too old error; got %s", err)
+			}
+			expTS := txnCommit.Timestamp.Next()
+			if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok || wtoErr.ActualTimestamp != expTS {
+				t.Fatalf("expected wto error with actual timestamp = %s; got %s", expTS, wtoErr)
+			}
+		})
 	}
 }
 
@@ -3064,88 +3253,92 @@ func TestMVCCInitPut(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	err := MVCCInitPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, false, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+			err := MVCCInitPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, false, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	// A repeat of the command will still succeed
-	err = MVCCInitPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 2}, value1, false, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+			// A repeat of the command will still succeed
+			err = MVCCInitPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 2}, value1, false, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	// Delete.
-	err = MVCCDelete(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 3}, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+			// Delete.
+			err = MVCCDelete(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 3}, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	// Reinserting the value fails if we fail on tombstones.
-	err = MVCCInitPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 4}, value1, true, nil)
-	switch e := err.(type) {
-	case *roachpb.ConditionFailedError:
-		if !bytes.Equal(e.ActualValue.RawBytes, nil) {
-			t.Fatalf("the value %s in get result is not a tombstone", e.ActualValue.RawBytes)
-		}
-	case nil:
-		t.Fatal("MVCCInitPut with a different value did not fail")
-	default:
-		t.Fatalf("unexpected error %T", e)
-	}
+			// Reinserting the value fails if we fail on tombstones.
+			err = MVCCInitPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 4}, value1, true, nil)
+			switch e := err.(type) {
+			case *roachpb.ConditionFailedError:
+				if !bytes.Equal(e.ActualValue.RawBytes, nil) {
+					t.Fatalf("the value %s in get result is not a tombstone", e.ActualValue.RawBytes)
+				}
+			case nil:
+				t.Fatal("MVCCInitPut with a different value did not fail")
+			default:
+				t.Fatalf("unexpected error %T", e)
+			}
 
-	// But doesn't if we *don't* fail on tombstones.
-	err = MVCCInitPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 5}, value1, false, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+			// But doesn't if we *don't* fail on tombstones.
+			err = MVCCInitPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 5}, value1, false, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	// A repeat of the command with a different value will fail.
-	err = MVCCInitPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 6}, value2, false, nil)
-	switch e := err.(type) {
-	case *roachpb.ConditionFailedError:
-		if !bytes.Equal(e.ActualValue.RawBytes, value1.RawBytes) {
-			t.Fatalf("the value %s in get result does not match the value %s in request",
-				e.ActualValue.RawBytes, value1.RawBytes)
-		}
-	case nil:
-		t.Fatal("MVCCInitPut with a different value did not fail")
-	default:
-		t.Fatalf("unexpected error %T", e)
-	}
+			// A repeat of the command with a different value will fail.
+			err = MVCCInitPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 6}, value2, false, nil)
+			switch e := err.(type) {
+			case *roachpb.ConditionFailedError:
+				if !bytes.Equal(e.ActualValue.RawBytes, value1.RawBytes) {
+					t.Fatalf("the value %s in get result does not match the value %s in request",
+						e.ActualValue.RawBytes, value1.RawBytes)
+				}
+			case nil:
+				t.Fatal("MVCCInitPut with a different value did not fail")
+			default:
+				t.Fatalf("unexpected error %T", e)
+			}
 
-	// Ensure that the timestamps were correctly updated.
-	for _, check := range []struct {
-		ts, expTS hlc.Timestamp
-	}{
-		{ts: hlc.Timestamp{Logical: 1}, expTS: hlc.Timestamp{Logical: 1}},
-		{ts: hlc.Timestamp{Logical: 2}, expTS: hlc.Timestamp{Logical: 2}},
-		// If we're checking the future wall time case, the rewrite after delete
-		// will be present.
-		{ts: hlc.Timestamp{WallTime: 1}, expTS: hlc.Timestamp{Logical: 5}},
-	} {
-		value, _, err := MVCCGet(ctx, engine, testKey1, check.ts, MVCCGetOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !bytes.Equal(value1.RawBytes, value.RawBytes) {
-			t.Fatalf("the value %s in get result does not match the value %s in request",
-				value1.RawBytes, value.RawBytes)
-		}
-		if value.Timestamp != check.expTS {
-			t.Errorf("value at timestamp %s seen, expected %s", value.Timestamp, check.expTS)
-		}
-	}
+			// Ensure that the timestamps were correctly updated.
+			for _, check := range []struct {
+				ts, expTS hlc.Timestamp
+			}{
+				{ts: hlc.Timestamp{Logical: 1}, expTS: hlc.Timestamp{Logical: 1}},
+				{ts: hlc.Timestamp{Logical: 2}, expTS: hlc.Timestamp{Logical: 2}},
+				// If we're checking the future wall time case, the rewrite after delete
+				// will be present.
+				{ts: hlc.Timestamp{WallTime: 1}, expTS: hlc.Timestamp{Logical: 5}},
+			} {
+				value, _, err := MVCCGet(ctx, engine, testKey1, check.ts, MVCCGetOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(value1.RawBytes, value.RawBytes) {
+					t.Fatalf("the value %s in get result does not match the value %s in request",
+						value1.RawBytes, value.RawBytes)
+				}
+				if value.Timestamp != check.expTS {
+					t.Errorf("value at timestamp %s seen, expected %s", value.Timestamp, check.expTS)
+				}
+			}
 
-	value, _, pErr := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{Logical: 0}, MVCCGetOptions{})
-	if pErr != nil {
-		t.Fatal(pErr)
-	}
-	if value != nil {
-		t.Fatalf("%v present at old timestamp", value)
+			value, _, pErr := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{Logical: 0}, MVCCGetOptions{})
+			if pErr != nil {
+				t.Fatal(pErr)
+			}
+			if value != nil {
+				t.Fatalf("%v present at old timestamp", value)
+			}
+		})
 	}
 }
 
@@ -3153,57 +3346,61 @@ func TestMVCCInitPutWithTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	clock := hlc.NewClock(hlc.NewManualClock(123).UnixNano, time.Nanosecond)
+			clock := hlc.NewClock(hlc.NewManualClock(123).UnixNano, time.Nanosecond)
 
-	txn := *txn1
-	txn.Sequence++
-	err := MVCCInitPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value1, false, &txn)
-	if err != nil {
-		t.Fatal(err)
-	}
+			txn := *txn1
+			txn.Sequence++
+			err := MVCCInitPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value1, false, &txn)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	// A repeat of the command will still succeed.
-	txn.Sequence++
-	err = MVCCInitPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value1, false, &txn)
-	if err != nil {
-		t.Fatal(err)
-	}
+			// A repeat of the command will still succeed.
+			txn.Sequence++
+			err = MVCCInitPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value1, false, &txn)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	// A repeat of the command with a different value at a different epoch
-	// will still succeed.
-	txn.Sequence++
-	txn.Epoch = 2
-	err = MVCCInitPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value2, false, &txn)
-	if err != nil {
-		t.Fatal(err)
-	}
+			// A repeat of the command with a different value at a different epoch
+			// will still succeed.
+			txn.Sequence++
+			txn.Epoch = 2
+			err = MVCCInitPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value2, false, &txn)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	// Commit value3.
-	txnCommit := txn
-	txnCommit.Status = roachpb.COMMITTED
-	txnCommit.Timestamp = clock.Now().Add(1, 0)
-	if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
-		Span:   roachpb.Span{Key: testKey1},
-		Status: txnCommit.Status,
-		Txn:    txnCommit.TxnMeta,
-	}); err != nil {
-		t.Fatal(err)
-	}
+			// Commit value3.
+			txnCommit := txn
+			txnCommit.Status = roachpb.COMMITTED
+			txnCommit.Timestamp = clock.Now().Add(1, 0)
+			if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
+				Span:   roachpb.Span{Key: testKey1},
+				Status: txnCommit.Status,
+				Txn:    txnCommit.TxnMeta,
+			}); err != nil {
+				t.Fatal(err)
+			}
 
-	// Write value4 with an old timestamp without txn...should get an error.
-	err = MVCCInitPut(ctx, engine, nil, testKey1, clock.Now(), value4, false, nil)
-	switch e := err.(type) {
-	case *roachpb.ConditionFailedError:
-		if !bytes.Equal(e.ActualValue.RawBytes, value2.RawBytes) {
-			t.Fatalf("the value %s in get result does not match the value %s in request",
-				e.ActualValue.RawBytes, value2.RawBytes)
-		}
+			// Write value4 with an old timestamp without txn...should get an error.
+			err = MVCCInitPut(ctx, engine, nil, testKey1, clock.Now(), value4, false, nil)
+			switch e := err.(type) {
+			case *roachpb.ConditionFailedError:
+				if !bytes.Equal(e.ActualValue.RawBytes, value2.RawBytes) {
+					t.Fatalf("the value %s in get result does not match the value %s in request",
+						e.ActualValue.RawBytes, value2.RawBytes)
+				}
 
-	default:
-		t.Fatalf("unexpected error %T", e)
+			default:
+				t.Fatalf("unexpected error %T", e)
+			}
+		})
 	}
 }
 
@@ -3216,36 +3413,40 @@ func TestMVCCConditionalPutWriteTooOld(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	// Write value1 @t=10ns.
-	err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 10}, value1, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Try a non-transactional put @t=1ns with expectation of nil; should fail.
-	err = MVCCConditionalPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value2, nil, CPutFailIfMissing, nil)
-	if err == nil {
-		t.Fatal("expected error on conditional put")
-	}
-	// Now do a non-transactional put @t=1ns with expectation of value1; will succeed @t=10,1.
-	err = MVCCConditionalPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value2, &value1, CPutFailIfMissing, nil)
-	expTS := hlc.Timestamp{WallTime: 10, Logical: 1}
-	if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok || wtoErr.ActualTimestamp != expTS {
-		t.Fatalf("expected WriteTooOldError with actual time = %s; got %s", expTS, err)
-	}
-	// Try a transactional put @t=1ns with expectation of value2; should fail.
-	txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
-	err = MVCCConditionalPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value2, &value1, CPutFailIfMissing, txn)
-	if err == nil {
-		t.Fatal("expected error on conditional put")
-	}
-	// Now do a transactional put @t=1ns with expectation of nil; will succeed @t=10,2.
-	err = MVCCConditionalPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value3, nil, CPutFailIfMissing, txn)
-	expTS = hlc.Timestamp{WallTime: 10, Logical: 2}
-	if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok || wtoErr.ActualTimestamp != expTS {
-		t.Fatalf("expected WriteTooOldError with actual time = %s; got %s", expTS, err)
+			// Write value1 @t=10ns.
+			err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 10}, value1, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Try a non-transactional put @t=1ns with expectation of nil; should fail.
+			err = MVCCConditionalPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value2, nil, CPutFailIfMissing, nil)
+			if err == nil {
+				t.Fatal("expected error on conditional put")
+			}
+			// Now do a non-transactional put @t=1ns with expectation of value1; will succeed @t=10,1.
+			err = MVCCConditionalPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value2, &value1, CPutFailIfMissing, nil)
+			expTS := hlc.Timestamp{WallTime: 10, Logical: 1}
+			if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok || wtoErr.ActualTimestamp != expTS {
+				t.Fatalf("expected WriteTooOldError with actual time = %s; got %s", expTS, err)
+			}
+			// Try a transactional put @t=1ns with expectation of value2; should fail.
+			txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
+			err = MVCCConditionalPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value2, &value1, CPutFailIfMissing, txn)
+			if err == nil {
+				t.Fatal("expected error on conditional put")
+			}
+			// Now do a transactional put @t=1ns with expectation of nil; will succeed @t=10,2.
+			err = MVCCConditionalPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value3, nil, CPutFailIfMissing, txn)
+			expTS = hlc.Timestamp{WallTime: 10, Logical: 2}
+			if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok || wtoErr.ActualTimestamp != expTS {
+				t.Fatalf("expected WriteTooOldError with actual time = %s; got %s", expTS, err)
+			}
+		})
 	}
 }
 
@@ -3256,32 +3457,36 @@ func TestMVCCIncrementWriteTooOld(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	// Start with an increment.
-	val, err := MVCCIncrement(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 10}, nil, 1)
-	if val != 1 || err != nil {
-		t.Fatalf("expected val=1 (got %d): %+v", val, err)
-	}
-	// Try a non-transactional increment @t=1ns.
-	val, err = MVCCIncrement(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, nil, 1)
-	if val != 2 || err == nil {
-		t.Fatalf("expected val=2 (got %d) and nil error: %+v", val, err)
-	}
-	expTS := hlc.Timestamp{WallTime: 10, Logical: 1}
-	if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok || wtoErr.ActualTimestamp != expTS {
-		t.Fatalf("expected WriteTooOldError with actual time = %s; got %s", expTS, wtoErr)
-	}
-	// Try a transaction increment @t=1ns.
-	txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
-	val, err = MVCCIncrement(ctx, engine, nil, testKey1, txn.OrigTimestamp, txn, 1)
-	if val != 1 || err == nil {
-		t.Fatalf("expected val=1 (got %d) and nil error: %+v", val, err)
-	}
-	expTS = hlc.Timestamp{WallTime: 10, Logical: 2}
-	if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok || wtoErr.ActualTimestamp != expTS {
-		t.Fatalf("expected WriteTooOldError with actual time = %s; got %s", expTS, wtoErr)
+			// Start with an increment.
+			val, err := MVCCIncrement(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 10}, nil, 1)
+			if val != 1 || err != nil {
+				t.Fatalf("expected val=1 (got %d): %+v", val, err)
+			}
+			// Try a non-transactional increment @t=1ns.
+			val, err = MVCCIncrement(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, nil, 1)
+			if val != 2 || err == nil {
+				t.Fatalf("expected val=2 (got %d) and nil error: %+v", val, err)
+			}
+			expTS := hlc.Timestamp{WallTime: 10, Logical: 1}
+			if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok || wtoErr.ActualTimestamp != expTS {
+				t.Fatalf("expected WriteTooOldError with actual time = %s; got %s", expTS, wtoErr)
+			}
+			// Try a transaction increment @t=1ns.
+			txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
+			val, err = MVCCIncrement(ctx, engine, nil, testKey1, txn.OrigTimestamp, txn, 1)
+			if val != 1 || err == nil {
+				t.Fatalf("expected val=1 (got %d) and nil error: %+v", val, err)
+			}
+			expTS = hlc.Timestamp{WallTime: 10, Logical: 2}
+			if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok || wtoErr.ActualTimestamp != expTS {
+				t.Fatalf("expected WriteTooOldError with actual time = %s; got %s", expTS, wtoErr)
+			}
+		})
 	}
 }
 
@@ -3291,118 +3496,122 @@ func TestMVCCReverseScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 2}, value2, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value3, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 3}, value4, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey5, hlc.Timestamp{WallTime: 3}, value5, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey6, hlc.Timestamp{WallTime: 3}, value6, nil); err != nil {
-		t.Fatal(err)
-	}
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 2}, value2, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value3, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 3}, value4, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey5, hlc.Timestamp{WallTime: 3}, value5, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey6, hlc.Timestamp{WallTime: 3}, value6, nil); err != nil {
+				t.Fatal(err)
+			}
 
-	kvs, resumeSpan, _, err := MVCCScan(ctx, engine, testKey2, testKey4, math.MaxInt64,
-		hlc.Timestamp{WallTime: 1}, MVCCScanOptions{Reverse: true})
+			kvs, resumeSpan, _, err := MVCCScan(ctx, engine, testKey2, testKey4, math.MaxInt64,
+				hlc.Timestamp{WallTime: 1}, MVCCScanOptions{Reverse: true})
 
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(kvs) != 2 ||
-		!bytes.Equal(kvs[0].Key, testKey3) ||
-		!bytes.Equal(kvs[1].Key, testKey2) ||
-		!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) ||
-		!bytes.Equal(kvs[1].Value.RawBytes, value3.RawBytes) {
-		t.Fatalf("unexpected value: %v", kvs)
-	}
-	if resumeSpan != nil {
-		t.Fatalf("resumeSpan = %+v", resumeSpan)
-	}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(kvs) != 2 ||
+				!bytes.Equal(kvs[0].Key, testKey3) ||
+				!bytes.Equal(kvs[1].Key, testKey2) ||
+				!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) ||
+				!bytes.Equal(kvs[1].Value.RawBytes, value3.RawBytes) {
+				t.Fatalf("unexpected value: %v", kvs)
+			}
+			if resumeSpan != nil {
+				t.Fatalf("resumeSpan = %+v", resumeSpan)
+			}
 
-	kvs, resumeSpan, _, err = MVCCScan(ctx, engine, testKey2, testKey4, 1, hlc.Timestamp{WallTime: 1},
-		MVCCScanOptions{Reverse: true})
+			kvs, resumeSpan, _, err = MVCCScan(ctx, engine, testKey2, testKey4, 1, hlc.Timestamp{WallTime: 1},
+				MVCCScanOptions{Reverse: true})
 
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(kvs) != 1 ||
-		!bytes.Equal(kvs[0].Key, testKey3) ||
-		!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) {
-		t.Fatalf("unexpected value: %v", kvs)
-	}
-	if expected := (roachpb.Span{Key: testKey2, EndKey: testKey2.Next()}); !resumeSpan.EqualValue(expected) {
-		t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
-	}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(kvs) != 1 ||
+				!bytes.Equal(kvs[0].Key, testKey3) ||
+				!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) {
+				t.Fatalf("unexpected value: %v", kvs)
+			}
+			if expected := (roachpb.Span{Key: testKey2, EndKey: testKey2.Next()}); !resumeSpan.EqualValue(expected) {
+				t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
+			}
 
-	kvs, resumeSpan, _, err = MVCCScan(ctx, engine, testKey2, testKey4, 0, hlc.Timestamp{WallTime: 1},
-		MVCCScanOptions{Reverse: true})
+			kvs, resumeSpan, _, err = MVCCScan(ctx, engine, testKey2, testKey4, 0, hlc.Timestamp{WallTime: 1},
+				MVCCScanOptions{Reverse: true})
 
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(kvs) != 0 {
-		t.Fatalf("unexpected value: %v", kvs)
-	}
-	if expected := (roachpb.Span{Key: testKey2, EndKey: testKey4}); !resumeSpan.EqualValue(expected) {
-		t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
-	}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(kvs) != 0 {
+				t.Fatalf("unexpected value: %v", kvs)
+			}
+			if expected := (roachpb.Span{Key: testKey2, EndKey: testKey4}); !resumeSpan.EqualValue(expected) {
+				t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
+			}
 
-	// The first key we encounter has multiple versions and we need to read the
-	// latest.
-	kvs, _, _, err = MVCCScan(ctx, engine, testKey2, testKey3, 1, hlc.Timestamp{WallTime: 4},
-		MVCCScanOptions{Reverse: true})
+			// The first key we encounter has multiple versions and we need to read the
+			// latest.
+			kvs, _, _, err = MVCCScan(ctx, engine, testKey2, testKey3, 1, hlc.Timestamp{WallTime: 4},
+				MVCCScanOptions{Reverse: true})
 
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(kvs) != 1 ||
-		!bytes.Equal(kvs[0].Key, testKey2) ||
-		!bytes.Equal(kvs[0].Value.RawBytes, value4.RawBytes) {
-		t.Errorf("unexpected value: %v", kvs)
-	}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(kvs) != 1 ||
+				!bytes.Equal(kvs[0].Key, testKey2) ||
+				!bytes.Equal(kvs[0].Value.RawBytes, value4.RawBytes) {
+				t.Errorf("unexpected value: %v", kvs)
+			}
 
-	// The first key we encounter is newer than our read timestamp and we need to
-	// back up to the previous key.
-	kvs, _, _, err = MVCCScan(ctx, engine, testKey4, testKey6, 1, hlc.Timestamp{WallTime: 1},
-		MVCCScanOptions{Reverse: true})
+			// The first key we encounter is newer than our read timestamp and we need to
+			// back up to the previous key.
+			kvs, _, _, err = MVCCScan(ctx, engine, testKey4, testKey6, 1, hlc.Timestamp{WallTime: 1},
+				MVCCScanOptions{Reverse: true})
 
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(kvs) != 1 ||
-		!bytes.Equal(kvs[0].Key, testKey4) ||
-		!bytes.Equal(kvs[0].Value.RawBytes, value2.RawBytes) {
-		t.Fatalf("unexpected value: %v", kvs)
-	}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(kvs) != 1 ||
+				!bytes.Equal(kvs[0].Key, testKey4) ||
+				!bytes.Equal(kvs[0].Value.RawBytes, value2.RawBytes) {
+				t.Fatalf("unexpected value: %v", kvs)
+			}
 
-	// Scan only the first key in the key space.
-	kvs, _, _, err = MVCCScan(ctx, engine, testKey1, testKey1.Next(), 1, hlc.Timestamp{WallTime: 1},
-		MVCCScanOptions{Reverse: true})
+			// Scan only the first key in the key space.
+			kvs, _, _, err = MVCCScan(ctx, engine, testKey1, testKey1.Next(), 1, hlc.Timestamp{WallTime: 1},
+				MVCCScanOptions{Reverse: true})
 
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(kvs) != 1 ||
-		!bytes.Equal(kvs[0].Key, testKey1) ||
-		!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) {
-		t.Fatalf("unexpected value: %v", kvs)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(kvs) != 1 ||
+				!bytes.Equal(kvs[0].Key, testKey1) ||
+				!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) {
+				t.Fatalf("unexpected value: %v", kvs)
+			}
+		})
 	}
 }
 
@@ -3413,34 +3622,38 @@ func TestMVCCReverseScanFirstKeyInFuture(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	// The value at key2 will be at a lower timestamp than the ReverseScan, but
-	// the value at key3 will be at a larger timetamp. The ReverseScan should
-	// see key3 and ignore it because none of it versions are at a low enough
-	// timestamp to read. It should then continue scanning backwards and find a
-	// value at key2.
-	//
-	// Before fixing #17825, the MVCC version scan on key3 would fall out of the
-	// scan bounds and if it never found another valid key before reaching
-	// KeyMax, would stop the ReverseScan from continuing.
-	if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey3, hlc.Timestamp{WallTime: 3}, value3, nil); err != nil {
-		t.Fatal(err)
-	}
+			// The value at key2 will be at a lower timestamp than the ReverseScan, but
+			// the value at key3 will be at a larger timetamp. The ReverseScan should
+			// see key3 and ignore it because none of it versions are at a low enough
+			// timestamp to read. It should then continue scanning backwards and find a
+			// value at key2.
+			//
+			// Before fixing #17825, the MVCC version scan on key3 would fall out of the
+			// scan bounds and if it never found another valid key before reaching
+			// KeyMax, would stop the ReverseScan from continuing.
+			if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey3, hlc.Timestamp{WallTime: 3}, value3, nil); err != nil {
+				t.Fatal(err)
+			}
 
-	kvs, _, _, err := MVCCScan(ctx, engine, testKey1, testKey4, math.MaxInt64,
-		hlc.Timestamp{WallTime: 2}, MVCCScanOptions{Reverse: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(kvs) != 1 ||
-		!bytes.Equal(kvs[0].Key, testKey2) ||
-		!bytes.Equal(kvs[0].Value.RawBytes, value2.RawBytes) {
-		t.Errorf("unexpected value: %v", kvs)
+			kvs, _, _, err := MVCCScan(ctx, engine, testKey1, testKey4, math.MaxInt64,
+				hlc.Timestamp{WallTime: 2}, MVCCScanOptions{Reverse: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(kvs) != 1 ||
+				!bytes.Equal(kvs[0].Key, testKey2) ||
+				!bytes.Equal(kvs[0].Value.RawBytes, value2.RawBytes) {
+				t.Errorf("unexpected value: %v", kvs)
+			}
+		})
 	}
 }
 
@@ -3453,31 +3666,35 @@ func TestMVCCReverseScanSeeksOverRepeatedKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	// 10 is the value of `kMaxItersBeforeSeek` at the time this test case was
-	// written. Repeat the key enough times to make sure the `SeekForPrev()`
-	// optimization will be used.
-	for i := 1; i <= 10; i++ {
-		if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: int64(i)}, value2, nil); err != nil {
-			t.Fatal(err)
-		}
-	}
-	txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 11})
-	if err := MVCCPut(ctx, engine, nil, testKey2, txn1ts.OrigTimestamp, value2, txn1ts); err != nil {
-		t.Fatal(err)
-	}
+			// 10 is the value of `kMaxItersBeforeSeek` at the time this test case was
+			// written. Repeat the key enough times to make sure the `SeekForPrev()`
+			// optimization will be used.
+			for i := 1; i <= 10; i++ {
+				if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{WallTime: int64(i)}, value2, nil); err != nil {
+					t.Fatal(err)
+				}
+			}
+			txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 11})
+			if err := MVCCPut(ctx, engine, nil, testKey2, txn1ts.OrigTimestamp, value2, txn1ts); err != nil {
+				t.Fatal(err)
+			}
 
-	kvs, _, _, err := MVCCScan(ctx, engine, testKey1, testKey3, math.MaxInt64,
-		hlc.Timestamp{WallTime: 1}, MVCCScanOptions{Reverse: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(kvs) != 1 ||
-		!bytes.Equal(kvs[0].Key, testKey2) ||
-		!bytes.Equal(kvs[0].Value.RawBytes, value2.RawBytes) {
-		t.Fatal("unexpected scan results")
+			kvs, _, _, err := MVCCScan(ctx, engine, testKey1, testKey3, math.MaxInt64,
+				hlc.Timestamp{WallTime: 1}, MVCCScanOptions{Reverse: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(kvs) != 1 ||
+				!bytes.Equal(kvs[0].Key, testKey2) ||
+				!bytes.Equal(kvs[0].Value.RawBytes, value2.RawBytes) {
+				t.Fatal("unexpected scan results")
+			}
+		})
 	}
 }
 
@@ -3501,84 +3718,91 @@ func TestMVCCReverseScanSeeksOverRepeatedKeys(t *testing.T) {
 // this whole process repeats ad infinitum.
 func TestMVCCReverseScanStopAtSmallestKey(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	run := func(numPuts int, ts int64) {
-		ctx := context.Background()
-		engine := createTestEngine()
-		defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			run := func(numPuts int, ts int64) {
+				ctx := context.Background()
+				engine := engineImpl.create()
+				defer engine.Close()
 
-		for i := 1; i <= numPuts; i++ {
-			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: int64(i)}, value1, nil); err != nil {
-				t.Fatal(err)
+				for i := 1; i <= numPuts; i++ {
+					if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: int64(i)}, value1, nil); err != nil {
+						t.Fatal(err)
+					}
+				}
+
+				kvs, _, _, err := MVCCScan(ctx, engine, testKey1, testKey3, math.MaxInt64,
+					hlc.Timestamp{WallTime: ts}, MVCCScanOptions{Reverse: true})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(kvs) != 1 ||
+					!bytes.Equal(kvs[0].Key, testKey1) ||
+					!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) {
+					t.Fatal("unexpected scan results")
+				}
 			}
-		}
-
-		kvs, _, _, err := MVCCScan(ctx, engine, testKey1, testKey3, math.MaxInt64,
-			hlc.Timestamp{WallTime: ts}, MVCCScanOptions{Reverse: true})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(kvs) != 1 ||
-			!bytes.Equal(kvs[0].Key, testKey1) ||
-			!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) {
-			t.Fatal("unexpected scan results")
-		}
+			// Satisfying (2) and (3) is incredibly intricate because of how `iters_before_seek_`
+			// is incremented/decremented heuristically. For example, at the time of writing, the
+			// infinitely looping cases are `numPuts == 6 && ts == 2`, `numPuts == 7 && ts == 3`,
+			// `numPuts == 8 && ts == 4`, `numPuts == 9 && ts == 5`, and `numPuts == 10 && ts == 6`.
+			// Tying our test case to the `iters_before_seek_` setting logic seems brittle so let's
+			// just brute force test a wide range of cases.
+			for numPuts := 1; numPuts <= 10; numPuts++ {
+				for ts := 1; ts <= 10; ts++ {
+					run(numPuts, int64(ts))
+				}
+			}
+		})
 	}
-	// Satisfying (2) and (3) is incredibly intricate because of how `iters_before_seek_`
-	// is incremented/decremented heuristically. For example, at the time of writing, the
-	// infinitely looping cases are `numPuts == 6 && ts == 2`, `numPuts == 7 && ts == 3`,
-	// `numPuts == 8 && ts == 4`, `numPuts == 9 && ts == 5`, and `numPuts == 10 && ts == 6`.
-	// Tying our test case to the `iters_before_seek_` setting logic seems brittle so let's
-	// just brute force test a wide range of cases.
-	for numPuts := 1; numPuts <= 10; numPuts++ {
-		for ts := 1; ts <= 10; ts++ {
-			run(numPuts, int64(ts))
-		}
-	}
-
 }
 
 func TestMVCCResolveTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1.OrigTimestamp, value1, txn1); err != nil {
-		t.Fatal(err)
-	}
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn1.OrigTimestamp, value1, txn1); err != nil {
+				t.Fatal(err)
+			}
 
-	{
-		value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{Logical: 1}, MVCCGetOptions{
-			Txn: txn1,
+			{
+				value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{Logical: 1}, MVCCGetOptions{
+					Txn: txn1,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(value1.RawBytes, value.RawBytes) {
+					t.Fatalf("the value %s in get result does not match the value %s in request",
+						value1.RawBytes, value.RawBytes)
+				}
+			}
+
+			// Resolve will write with txn1's timestamp which is 0,1.
+			if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
+				Span:   roachpb.Span{Key: testKey1},
+				Txn:    txn1Commit.TxnMeta,
+				Status: txn1Commit.Status,
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			{
+				value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{Logical: 1}, MVCCGetOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(value1.RawBytes, value.RawBytes) {
+					t.Fatalf("the value %s in get result does not match the value %s in request",
+						value1.RawBytes, value.RawBytes)
+				}
+			}
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !bytes.Equal(value1.RawBytes, value.RawBytes) {
-			t.Fatalf("the value %s in get result does not match the value %s in request",
-				value1.RawBytes, value.RawBytes)
-		}
-	}
-
-	// Resolve will write with txn1's timestamp which is 0,1.
-	if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
-		Span:   roachpb.Span{Key: testKey1},
-		Txn:    txn1Commit.TxnMeta,
-		Status: txn1Commit.Status,
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	{
-		value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{Logical: 1}, MVCCGetOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !bytes.Equal(value1.RawBytes, value.RawBytes) {
-			t.Fatalf("the value %s in get result does not match the value %s in request",
-				value1.RawBytes, value.RawBytes)
-		}
 	}
 }
 
@@ -3588,35 +3812,39 @@ func TestMVCCResolveNewerIntent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	// Write first value.
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1Commit.Timestamp, value1, nil); err != nil {
-		t.Fatal(err)
-	}
-	// Now, put down an intent which should return a write too old error
-	// (but will still write the intent at tx1Commit.Timestmap+1.
-	err := MVCCPut(ctx, engine, nil, testKey1, txn1.OrigTimestamp, value2, txn1)
-	if _, ok := err.(*roachpb.WriteTooOldError); !ok {
-		t.Fatalf("expected write too old error; got %s", err)
-	}
+			// Write first value.
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn1Commit.Timestamp, value1, nil); err != nil {
+				t.Fatal(err)
+			}
+			// Now, put down an intent which should return a write too old error
+			// (but will still write the intent at tx1Commit.Timestmap+1.
+			err := MVCCPut(ctx, engine, nil, testKey1, txn1.OrigTimestamp, value2, txn1)
+			if _, ok := err.(*roachpb.WriteTooOldError); !ok {
+				t.Fatalf("expected write too old error; got %s", err)
+			}
 
-	// Resolve will succeed but should remove the intent.
-	if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
-		Span:   roachpb.Span{Key: testKey1},
-		Txn:    txn1Commit.TxnMeta,
-		Status: txn1Commit.Status,
-	}); err != nil {
-		t.Fatal(err)
-	}
+			// Resolve will succeed but should remove the intent.
+			if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
+				Span:   roachpb.Span{Key: testKey1},
+				Txn:    txn1Commit.TxnMeta,
+				Status: txn1Commit.Status,
+			}); err != nil {
+				t.Fatal(err)
+			}
 
-	value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{Logical: 2}, MVCCGetOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(value1.RawBytes, value.RawBytes) {
-		t.Fatalf("expected value1 bytes; got %q", value.RawBytes)
+			value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{Logical: 2}, MVCCGetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(value1.RawBytes, value.RawBytes) {
+				t.Fatalf("expected value1 bytes; got %q", value.RawBytes)
+			}
+		})
 	}
 }
 
@@ -3624,48 +3852,52 @@ func TestMVCCResolveIntentTxnTimestampMismatch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	txn := txn1.Clone()
-	tsEarly := txn.Timestamp
-	txn.TxnMeta.Timestamp.Forward(tsEarly.Add(10, 0))
+			txn := txn1.Clone()
+			tsEarly := txn.Timestamp
+			txn.TxnMeta.Timestamp.Forward(tsEarly.Add(10, 0))
 
-	// Write an intent which has txn.Timestamp > meta.timestamp.
-	if err := MVCCPut(ctx, engine, nil, testKey1, tsEarly, value1, txn); err != nil {
-		t.Fatal(err)
-	}
+			// Write an intent which has txn.Timestamp > meta.timestamp.
+			if err := MVCCPut(ctx, engine, nil, testKey1, tsEarly, value1, txn); err != nil {
+				t.Fatal(err)
+			}
 
-	intent := roachpb.Intent{
-		Span:   roachpb.Span{Key: testKey1},
-		Status: roachpb.PENDING,
-		// The Timestamp within is equal to that of txn.Meta even though
-		// the intent sits at tsEarly. The bug was looking at the former
-		// instead of the latter (and so we could also tickle it with
-		// smaller timestamps in Txn).
-		Txn: txn.TxnMeta,
-	}
+			intent := roachpb.Intent{
+				Span:   roachpb.Span{Key: testKey1},
+				Status: roachpb.PENDING,
+				// The Timestamp within is equal to that of txn.Meta even though
+				// the intent sits at tsEarly. The bug was looking at the former
+				// instead of the latter (and so we could also tickle it with
+				// smaller timestamps in Txn).
+				Txn: txn.TxnMeta,
+			}
 
-	// A bug (see #7654) caused intents to just stay where they were instead
-	// of being moved forward in the situation set up above.
-	if err := MVCCResolveWriteIntent(ctx, engine, nil, intent); err != nil {
-		t.Fatal(err)
-	}
+			// A bug (see #7654) caused intents to just stay where they were instead
+			// of being moved forward in the situation set up above.
+			if err := MVCCResolveWriteIntent(ctx, engine, nil, intent); err != nil {
+				t.Fatal(err)
+			}
 
-	for i, test := range []struct {
-		hlc.Timestamp
-		found bool
-	}{
-		// Check that the intent has indeed moved to where we pushed it.
-		{tsEarly, false},
-		{intent.Txn.Timestamp.Prev(), false},
-		{intent.Txn.Timestamp, true},
-		{hlc.MaxTimestamp, true},
-	} {
-		_, _, err := MVCCGet(ctx, engine, testKey1, test.Timestamp, MVCCGetOptions{})
-		if _, ok := err.(*roachpb.WriteIntentError); ok != test.found {
-			t.Fatalf("%d: expected write intent error: %t, got %v", i, test.found, err)
-		}
+			for i, test := range []struct {
+				hlc.Timestamp
+				found bool
+			}{
+				// Check that the intent has indeed moved to where we pushed it.
+				{tsEarly, false},
+				{intent.Txn.Timestamp.Prev(), false},
+				{intent.Txn.Timestamp, true},
+				{hlc.MaxTimestamp, true},
+			} {
+				_, _, err := MVCCGet(ctx, engine, testKey1, test.Timestamp, MVCCGetOptions{})
+				if _, ok := err.(*roachpb.WriteIntentError); ok != test.found {
+					t.Fatalf("%d: expected write intent error: %t, got %v", i, test.found, err)
+				}
+			}
+		})
 	}
 }
 
@@ -3679,42 +3911,45 @@ func TestMVCCConditionalPutOldTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
+			err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, value2, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, value2, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+			// Check nothing is written if the value doesn't match.
+			err = MVCCConditionalPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 2}, value3, &value1, CPutFailIfMissing, nil)
+			if err == nil {
+				t.Errorf("unexpected success on conditional put")
+			}
+			if _, ok := err.(*roachpb.ConditionFailedError); !ok {
+				t.Errorf("unexpected error on conditional put: %+v", err)
+			}
 
-	// Check nothing is written if the value doesn't match.
-	err = MVCCConditionalPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 2}, value3, &value1, CPutFailIfMissing, nil)
-	if err == nil {
-		t.Errorf("unexpected success on conditional put")
-	}
-	if _, ok := err.(*roachpb.ConditionFailedError); !ok {
-		t.Errorf("unexpected error on conditional put: %+v", err)
-	}
-
-	// But if value does match the most recently written version, we'll get
-	// a write too old error but still write updated value.
-	err = MVCCConditionalPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 2}, value3, &value2, CPutFailIfMissing, nil)
-	if err == nil {
-		t.Errorf("unexpected success on conditional put")
-	}
-	if _, ok := err.(*roachpb.WriteTooOldError); !ok {
-		t.Errorf("unexpected error on conditional put: %+v", err)
-	}
-	// Verify new value was actually written at (3, 1).
-	ts := hlc.Timestamp{WallTime: 3, Logical: 1}
-	value, _, err := MVCCGet(ctx, engine, testKey1, ts, MVCCGetOptions{})
-	if err != nil || value.Timestamp != ts || !bytes.Equal(value3.RawBytes, value.RawBytes) {
-		t.Fatalf("expected err=nil (got %s), timestamp=%s (got %s), value=%q (got %q)",
-			err, value.Timestamp, ts, value3.RawBytes, value.RawBytes)
+			// But if value does match the most recently written version, we'll get
+			// a write too old error but still write updated value.
+			err = MVCCConditionalPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 2}, value3, &value2, CPutFailIfMissing, nil)
+			if err == nil {
+				t.Errorf("unexpected success on conditional put")
+			}
+			if _, ok := err.(*roachpb.WriteTooOldError); !ok {
+				t.Errorf("unexpected error on conditional put: %+v", err)
+			}
+			// Verify new value was actually written at (3, 1).
+			ts := hlc.Timestamp{WallTime: 3, Logical: 1}
+			value, _, err := MVCCGet(ctx, engine, testKey1, ts, MVCCGetOptions{})
+			if err != nil || value.Timestamp != ts || !bytes.Equal(value3.RawBytes, value.RawBytes) {
+				t.Fatalf("expected err=nil (got %s), timestamp=%s (got %s), value=%q (got %q)",
+					err, value.Timestamp, ts, value3.RawBytes, value.RawBytes)
+			}
+		})
 	}
 }
 
@@ -3727,48 +3962,52 @@ func TestMVCCMultiplePutOldTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, value1, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+			err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, value1, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	// Verify the first txn Put returns a write too old error, but the
-	// intent is written at the advanced timestamp.
-	txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
-	txn.Sequence++
-	err = MVCCPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value2, txn)
-	if _, ok := err.(*roachpb.WriteTooOldError); !ok {
-		t.Errorf("expected WriteTooOldError on Put; got %v", err)
-	}
-	// Verify new value was actually written at (3, 1).
-	value, _, err := MVCCGet(ctx, engine, testKey1, hlc.MaxTimestamp, MVCCGetOptions{Txn: txn})
-	if err != nil {
-		t.Fatal(err)
-	}
-	expTS := hlc.Timestamp{WallTime: 3, Logical: 1}
-	if value.Timestamp != expTS || !bytes.Equal(value2.RawBytes, value.RawBytes) {
-		t.Fatalf("expected timestamp=%s (got %s), value=%q (got %q)",
-			value.Timestamp, expTS, value2.RawBytes, value.RawBytes)
-	}
+			// Verify the first txn Put returns a write too old error, but the
+			// intent is written at the advanced timestamp.
+			txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
+			txn.Sequence++
+			err = MVCCPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value2, txn)
+			if _, ok := err.(*roachpb.WriteTooOldError); !ok {
+				t.Errorf("expected WriteTooOldError on Put; got %v", err)
+			}
+			// Verify new value was actually written at (3, 1).
+			value, _, err := MVCCGet(ctx, engine, testKey1, hlc.MaxTimestamp, MVCCGetOptions{Txn: txn})
+			if err != nil {
+				t.Fatal(err)
+			}
+			expTS := hlc.Timestamp{WallTime: 3, Logical: 1}
+			if value.Timestamp != expTS || !bytes.Equal(value2.RawBytes, value.RawBytes) {
+				t.Fatalf("expected timestamp=%s (got %s), value=%q (got %q)",
+					value.Timestamp, expTS, value2.RawBytes, value.RawBytes)
+			}
 
-	// Put again and verify no WriteTooOldError, but timestamp should continue
-	// to be set to (3,1).
-	txn.Sequence++
-	err = MVCCPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value3, txn)
-	if err != nil {
-		t.Error(err)
-	}
-	// Verify new value was actually written at (3, 1).
-	value, _, err = MVCCGet(ctx, engine, testKey1, hlc.MaxTimestamp, MVCCGetOptions{Txn: txn})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if value.Timestamp != expTS || !bytes.Equal(value3.RawBytes, value.RawBytes) {
-		t.Fatalf("expected timestamp=%s (got %s), value=%q (got %q)",
-			value.Timestamp, expTS, value3.RawBytes, value.RawBytes)
+			// Put again and verify no WriteTooOldError, but timestamp should continue
+			// to be set to (3,1).
+			txn.Sequence++
+			err = MVCCPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value3, txn)
+			if err != nil {
+				t.Error(err)
+			}
+			// Verify new value was actually written at (3, 1).
+			value, _, err = MVCCGet(ctx, engine, testKey1, hlc.MaxTimestamp, MVCCGetOptions{Txn: txn})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if value.Timestamp != expTS || !bytes.Equal(value3.RawBytes, value.RawBytes) {
+				t.Fatalf("expected timestamp=%s (got %s), value=%q (got %q)",
+					value.Timestamp, expTS, value3.RawBytes, value.RawBytes)
+			}
+		})
 	}
 }
 
@@ -3776,15 +4015,19 @@ func TestMVCCPutNegativeTimestampError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	timestamp := hlc.Timestamp{WallTime: -1}
-	expectedErrorString := fmt.Sprintf("cannot write to %q at timestamp %s", testKey1, timestamp)
+			timestamp := hlc.Timestamp{WallTime: -1}
+			expectedErrorString := fmt.Sprintf("cannot write to %q at timestamp %s", testKey1, timestamp)
 
-	err := MVCCPut(ctx, engine, nil, testKey1, timestamp, value1, nil)
+			err := MVCCPut(ctx, engine, nil, testKey1, timestamp, value1, nil)
 
-	require.EqualError(t, err, expectedErrorString)
+			require.EqualError(t, err, expectedErrorString)
+		})
+	}
 }
 
 // TestMVCCPutOldOrigTimestampNewCommitTimestamp tests a case where a
@@ -3797,38 +4040,42 @@ func TestMVCCPutOldOrigTimestampNewCommitTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, value1, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+			err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, value1, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	// Perform a transactional Put with a transaction whose original timestamp is
-	// below the existing key's timestamp and whose provisional commit timestamp
-	// is above the existing key's timestamp.
-	txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
-	txn.Timestamp = hlc.Timestamp{WallTime: 5}
-	txn.Sequence++
-	err = MVCCPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value2, txn)
+			// Perform a transactional Put with a transaction whose original timestamp is
+			// below the existing key's timestamp and whose provisional commit timestamp
+			// is above the existing key's timestamp.
+			txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
+			txn.Timestamp = hlc.Timestamp{WallTime: 5}
+			txn.Sequence++
+			err = MVCCPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value2, txn)
 
-	// Verify that the Put returned a WriteTooOld with the ActualTime set to the
-	// transactions provisional commit timestamp.
-	expTS := txn.Timestamp
-	if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok || wtoErr.ActualTimestamp != expTS {
-		t.Fatalf("expected WriteTooOldError with actual time = %s; got %s", expTS, wtoErr)
-	}
+			// Verify that the Put returned a WriteTooOld with the ActualTime set to the
+			// transactions provisional commit timestamp.
+			expTS := txn.Timestamp
+			if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok || wtoErr.ActualTimestamp != expTS {
+				t.Fatalf("expected WriteTooOldError with actual time = %s; got %s", expTS, wtoErr)
+			}
 
-	// Verify new value was actually written at the transaction's provisional
-	// commit timestamp.
-	value, _, err := MVCCGet(ctx, engine, testKey1, hlc.MaxTimestamp, MVCCGetOptions{Txn: txn})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if value.Timestamp != expTS || !bytes.Equal(value2.RawBytes, value.RawBytes) {
-		t.Fatalf("expected timestamp=%s (got %s), value=%q (got %q)",
-			value.Timestamp, expTS, value2.RawBytes, value.RawBytes)
+			// Verify new value was actually written at the transaction's provisional
+			// commit timestamp.
+			value, _, err := MVCCGet(ctx, engine, testKey1, hlc.MaxTimestamp, MVCCGetOptions{Txn: txn})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if value.Timestamp != expTS || !bytes.Equal(value2.RawBytes, value.RawBytes) {
+				t.Fatalf("expected timestamp=%s (got %s), value=%q (got %q)",
+					value.Timestamp, expTS, value2.RawBytes, value.RawBytes)
+			}
+		})
 	}
 }
 
@@ -3836,35 +4083,39 @@ func TestMVCCAbortTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1.OrigTimestamp, value1, txn1); err != nil {
-		t.Fatal(err)
-	}
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn1.OrigTimestamp, value1, txn1); err != nil {
+				t.Fatal(err)
+			}
 
-	txn1AbortWithTS := txn1Abort.Clone()
-	txn1AbortWithTS.Timestamp = hlc.Timestamp{Logical: 1}
+			txn1AbortWithTS := txn1Abort.Clone()
+			txn1AbortWithTS.Timestamp = hlc.Timestamp{Logical: 1}
 
-	if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
-		Span:   roachpb.Span{Key: testKey1},
-		Txn:    txn1AbortWithTS.TxnMeta,
-		Status: txn1AbortWithTS.Status,
-	}); err != nil {
-		t.Fatal(err)
-	}
+			if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
+				Span:   roachpb.Span{Key: testKey1},
+				Txn:    txn1AbortWithTS.TxnMeta,
+				Status: txn1AbortWithTS.Status,
+			}); err != nil {
+				t.Fatal(err)
+			}
 
-	if value, _, err := MVCCGet(
-		ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{},
-	); err != nil {
-		t.Fatal(err)
-	} else if value != nil {
-		t.Fatalf("expected the value to be empty: %s", value)
-	}
-	if meta, err := engine.Get(mvccKey(testKey1)); err != nil {
-		t.Fatal(err)
-	} else if len(meta) != 0 {
-		t.Fatalf("expected no more MVCCMetadata, got: %s", meta)
+			if value, _, err := MVCCGet(
+				ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{},
+			); err != nil {
+				t.Fatal(err)
+			} else if value != nil {
+				t.Fatalf("expected the value to be empty: %s", value)
+			}
+			if meta, err := engine.Get(mvccKey(testKey1)); err != nil {
+				t.Fatal(err)
+			} else if len(meta) != 0 {
+				t.Fatalf("expected no more MVCCMetadata, got: %s", meta)
+			}
+		})
 	}
 }
 
@@ -3872,46 +4123,50 @@ func TestMVCCAbortTxnWithPreviousVersion(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
-		t.Fatal(err)
-	}
-	txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 2})
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1ts.OrigTimestamp, value3, txn1ts); err != nil {
-		t.Fatal(err)
-	}
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
+				t.Fatal(err)
+			}
+			txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 2})
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn1ts.OrigTimestamp, value3, txn1ts); err != nil {
+				t.Fatal(err)
+			}
 
-	txn1AbortWithTS := txn1Abort.Clone()
-	txn1AbortWithTS.Timestamp = hlc.Timestamp{WallTime: 2}
+			txn1AbortWithTS := txn1Abort.Clone()
+			txn1AbortWithTS.Timestamp = hlc.Timestamp{WallTime: 2}
 
-	if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
-		Span:   roachpb.Span{Key: testKey1},
-		Status: txn1AbortWithTS.Status,
-		Txn:    txn1AbortWithTS.TxnMeta,
-	}); err != nil {
-		t.Fatal(err)
-	}
+			if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
+				Span:   roachpb.Span{Key: testKey1},
+				Status: txn1AbortWithTS.Status,
+				Txn:    txn1AbortWithTS.TxnMeta,
+			}); err != nil {
+				t.Fatal(err)
+			}
 
-	if meta, err := engine.Get(mvccKey(testKey1)); err != nil {
-		t.Fatal(err)
-	} else if len(meta) != 0 {
-		t.Fatalf("expected no more MVCCMetadata, got: %s", meta)
-	}
+			if meta, err := engine.Get(mvccKey(testKey1)); err != nil {
+				t.Fatal(err)
+			} else if len(meta) != 0 {
+				t.Fatalf("expected no more MVCCMetadata, got: %s", meta)
+			}
 
-	if value, _, err := MVCCGet(
-		ctx, engine, testKey1, hlc.Timestamp{WallTime: 3}, MVCCGetOptions{},
-	); err != nil {
-		t.Fatal(err)
-	} else if expTS := (hlc.Timestamp{WallTime: 1}); value.Timestamp != expTS {
-		t.Fatalf("expected timestamp %+v == %+v", value.Timestamp, expTS)
-	} else if !bytes.Equal(value2.RawBytes, value.RawBytes) {
-		t.Fatalf("the value %q in get result does not match the value %q in request",
-			value.RawBytes, value2.RawBytes)
+			if value, _, err := MVCCGet(
+				ctx, engine, testKey1, hlc.Timestamp{WallTime: 3}, MVCCGetOptions{},
+			); err != nil {
+				t.Fatal(err)
+			} else if expTS := (hlc.Timestamp{WallTime: 1}); value.Timestamp != expTS {
+				t.Fatalf("expected timestamp %+v == %+v", value.Timestamp, expTS)
+			} else if !bytes.Equal(value2.RawBytes, value.RawBytes) {
+				t.Fatalf("the value %q in get result does not match the value %q in request",
+					value.RawBytes, value2.RawBytes)
+			}
+		})
 	}
 }
 
@@ -3919,95 +4174,99 @@ func TestMVCCWriteWithDiffTimestampsAndEpochs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	// Start with epoch 1.
-	txn := *txn1
-	txn.Sequence++
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value1, &txn); err != nil {
-		t.Fatal(err)
-	}
-	// Now write with greater timestamp and epoch 2.
-	txne2 := txn
-	txne2.Sequence++
-	txne2.Epoch = 2
-	txne2.Timestamp = hlc.Timestamp{WallTime: 1}
-	if err := MVCCPut(ctx, engine, nil, testKey1, txne2.OrigTimestamp, value2, &txne2); err != nil {
-		t.Fatal(err)
-	}
-	// Try a write with an earlier timestamp; this is just ignored.
-	txne2.Sequence++
-	txne2.Timestamp = hlc.Timestamp{WallTime: 1}
-	if err := MVCCPut(ctx, engine, nil, testKey1, txne2.OrigTimestamp, value1, &txne2); err != nil {
-		t.Fatal(err)
-	}
-	// Try a write with an earlier epoch; again ignored.
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value1, &txn); err == nil {
-		t.Fatal("unexpected success of a write with an earlier epoch")
-	}
-	// Try a write with different value using both later timestamp and epoch.
-	txne2.Sequence++
-	if err := MVCCPut(ctx, engine, nil, testKey1, txne2.OrigTimestamp, value3, &txne2); err != nil {
-		t.Fatal(err)
-	}
-	// Resolve the intent.
-	txne2Commit := txne2
-	txne2Commit.Status = roachpb.COMMITTED
-	txne2Commit.Timestamp = hlc.Timestamp{WallTime: 1}
-	if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
-		Span:   roachpb.Span{Key: testKey1},
-		Status: txne2Commit.Status,
-		Txn:    txne2Commit.TxnMeta,
-	}); err != nil {
-		t.Fatal(err)
-	}
+			// Start with epoch 1.
+			txn := *txn1
+			txn.Sequence++
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value1, &txn); err != nil {
+				t.Fatal(err)
+			}
+			// Now write with greater timestamp and epoch 2.
+			txne2 := txn
+			txne2.Sequence++
+			txne2.Epoch = 2
+			txne2.Timestamp = hlc.Timestamp{WallTime: 1}
+			if err := MVCCPut(ctx, engine, nil, testKey1, txne2.OrigTimestamp, value2, &txne2); err != nil {
+				t.Fatal(err)
+			}
+			// Try a write with an earlier timestamp; this is just ignored.
+			txne2.Sequence++
+			txne2.Timestamp = hlc.Timestamp{WallTime: 1}
+			if err := MVCCPut(ctx, engine, nil, testKey1, txne2.OrigTimestamp, value1, &txne2); err != nil {
+				t.Fatal(err)
+			}
+			// Try a write with an earlier epoch; again ignored.
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn.OrigTimestamp, value1, &txn); err == nil {
+				t.Fatal("unexpected success of a write with an earlier epoch")
+			}
+			// Try a write with different value using both later timestamp and epoch.
+			txne2.Sequence++
+			if err := MVCCPut(ctx, engine, nil, testKey1, txne2.OrigTimestamp, value3, &txne2); err != nil {
+				t.Fatal(err)
+			}
+			// Resolve the intent.
+			txne2Commit := txne2
+			txne2Commit.Status = roachpb.COMMITTED
+			txne2Commit.Timestamp = hlc.Timestamp{WallTime: 1}
+			if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
+				Span:   roachpb.Span{Key: testKey1},
+				Status: txne2Commit.Status,
+				Txn:    txne2Commit.TxnMeta,
+			}); err != nil {
+				t.Fatal(err)
+			}
 
-	expTS := txne2Commit.Timestamp.Add(0, 1)
+			expTS := txne2Commit.Timestamp.Add(0, 1)
 
-	// Now try writing an earlier value without a txn--should get WriteTooOldError.
-	err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value4, nil)
-	if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok {
-		t.Fatal("unexpected success")
-	} else if wtoErr.ActualTimestamp != expTS {
-		t.Fatalf("expected write too old error with actual ts %s; got %s", expTS, wtoErr.ActualTimestamp)
-	}
-	// Verify value was actually written at (1, 1).
-	value, _, err := MVCCGet(ctx, engine, testKey1, expTS, MVCCGetOptions{})
-	if err != nil || value.Timestamp != expTS || !bytes.Equal(value4.RawBytes, value.RawBytes) {
-		t.Fatalf("expected err=nil (got %s), timestamp=%s (got %s), value=%q (got %q)",
-			err, value.Timestamp, expTS, value4.RawBytes, value.RawBytes)
-	}
-	// Now write an intent with exactly the same timestamp--ties also get WriteTooOldError.
-	err = MVCCPut(ctx, engine, nil, testKey1, txn2.OrigTimestamp, value5, txn2)
-	intentTS := expTS.Add(0, 1)
-	if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok {
-		t.Fatal("unexpected success")
-	} else if wtoErr.ActualTimestamp != intentTS {
-		t.Fatalf("expected write too old error with actual ts %s; got %s", intentTS, wtoErr.ActualTimestamp)
-	}
-	// Verify intent value was actually written at (1, 2).
-	value, _, err = MVCCGet(ctx, engine, testKey1, intentTS, MVCCGetOptions{Txn: txn2})
-	if err != nil || value.Timestamp != intentTS || !bytes.Equal(value5.RawBytes, value.RawBytes) {
-		t.Fatalf("expected err=nil (got %s), timestamp=%s (got %s), value=%q (got %q)",
-			err, value.Timestamp, intentTS, value5.RawBytes, value.RawBytes)
-	}
-	// Attempt to read older timestamp; should fail.
-	value, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{Logical: 0}, MVCCGetOptions{})
-	if value != nil || err != nil {
-		t.Fatalf("expected value nil, err nil; got %+v, %v", value, err)
-	}
-	// Read at correct timestamp.
-	value, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if expTS := (hlc.Timestamp{WallTime: 1}); value.Timestamp != expTS {
-		t.Fatalf("expected timestamp %+v == %+v", value.Timestamp, expTS)
-	}
-	if !bytes.Equal(value3.RawBytes, value.RawBytes) {
-		t.Fatalf("the value %s in get result does not match the value %s in request",
-			value3.RawBytes, value.RawBytes)
+			// Now try writing an earlier value without a txn--should get WriteTooOldError.
+			err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value4, nil)
+			if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok {
+				t.Fatal("unexpected success")
+			} else if wtoErr.ActualTimestamp != expTS {
+				t.Fatalf("expected write too old error with actual ts %s; got %s", expTS, wtoErr.ActualTimestamp)
+			}
+			// Verify value was actually written at (1, 1).
+			value, _, err := MVCCGet(ctx, engine, testKey1, expTS, MVCCGetOptions{})
+			if err != nil || value.Timestamp != expTS || !bytes.Equal(value4.RawBytes, value.RawBytes) {
+				t.Fatalf("expected err=nil (got %s), timestamp=%s (got %s), value=%q (got %q)",
+					err, value.Timestamp, expTS, value4.RawBytes, value.RawBytes)
+			}
+			// Now write an intent with exactly the same timestamp--ties also get WriteTooOldError.
+			err = MVCCPut(ctx, engine, nil, testKey1, txn2.OrigTimestamp, value5, txn2)
+			intentTS := expTS.Add(0, 1)
+			if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok {
+				t.Fatal("unexpected success")
+			} else if wtoErr.ActualTimestamp != intentTS {
+				t.Fatalf("expected write too old error with actual ts %s; got %s", intentTS, wtoErr.ActualTimestamp)
+			}
+			// Verify intent value was actually written at (1, 2).
+			value, _, err = MVCCGet(ctx, engine, testKey1, intentTS, MVCCGetOptions{Txn: txn2})
+			if err != nil || value.Timestamp != intentTS || !bytes.Equal(value5.RawBytes, value.RawBytes) {
+				t.Fatalf("expected err=nil (got %s), timestamp=%s (got %s), value=%q (got %q)",
+					err, value.Timestamp, intentTS, value5.RawBytes, value.RawBytes)
+			}
+			// Attempt to read older timestamp; should fail.
+			value, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{Logical: 0}, MVCCGetOptions{})
+			if value != nil || err != nil {
+				t.Fatalf("expected value nil, err nil; got %+v, %v", value, err)
+			}
+			// Read at correct timestamp.
+			value, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if expTS := (hlc.Timestamp{WallTime: 1}); value.Timestamp != expTS {
+				t.Fatalf("expected timestamp %+v == %+v", value.Timestamp, expTS)
+			}
+			if !bytes.Equal(value3.RawBytes, value.RawBytes) {
+				t.Fatalf("the value %s in get result does not match the value %s in request",
+					value3.RawBytes, value.RawBytes)
+			}
+		})
 	}
 }
 
@@ -4017,51 +4276,56 @@ func TestMVCCWriteWithDiffTimestampsAndEpochs(t *testing.T) {
 func TestMVCCGetWithDiffEpochs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	for _, impl := range mvccGetImpls {
-		t.Run(impl.name, func(t *testing.T) {
-			mvccGet := impl.fn
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
 
-			ctx := context.Background()
-			engine := createTestEngine()
-			defer engine.Close()
+			for _, impl := range mvccGetImpls {
+				t.Run(impl.name, func(t *testing.T) {
+					mvccGet := impl.fn
 
-			// Write initial value without a txn.
-			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, nil); err != nil {
-				t.Fatal(err)
-			}
-			// Now write using txn1, epoch 1.
-			txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
-			if err := MVCCPut(ctx, engine, nil, testKey1, txn1ts.OrigTimestamp, value2, txn1ts); err != nil {
-				t.Fatal(err)
-			}
-			// Try reading using different txns & epochs.
-			testCases := []struct {
-				txn      *roachpb.Transaction
-				expValue *roachpb.Value
-				expErr   bool
-			}{
-				// No transaction; should see error.
-				{nil, nil, true},
-				// Txn1, epoch 1; should see new value2.
-				{txn1, &value2, false},
-				// Txn1, epoch 2; should see original value1.
-				{txn1e2, &value1, false},
-				// Txn2; should see error.
-				{txn2, nil, true},
-			}
-			for i, test := range testCases {
-				t.Run(strconv.Itoa(i), func(t *testing.T) {
-					value, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{
-						Txn: test.txn,
-					})
-					if test.expErr {
-						if err == nil {
-							t.Errorf("test %d: unexpected success", i)
-						} else if _, ok := err.(*roachpb.WriteIntentError); !ok {
-							t.Errorf("test %d: expected write intent error; got %v", i, err)
-						}
-					} else if err != nil || value == nil || !bytes.Equal(test.expValue.RawBytes, value.RawBytes) {
-						t.Errorf("test %d: expected value %q, err nil; got %+v, %v", i, test.expValue.RawBytes, value, err)
+					ctx := context.Background()
+					engine := engineImpl.create()
+					defer engine.Close()
+
+					// Write initial value without a txn.
+					if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, nil); err != nil {
+						t.Fatal(err)
+					}
+					// Now write using txn1, epoch 1.
+					txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
+					if err := MVCCPut(ctx, engine, nil, testKey1, txn1ts.OrigTimestamp, value2, txn1ts); err != nil {
+						t.Fatal(err)
+					}
+					// Try reading using different txns & epochs.
+					testCases := []struct {
+						txn      *roachpb.Transaction
+						expValue *roachpb.Value
+						expErr   bool
+					}{
+						// No transaction; should see error.
+						{nil, nil, true},
+						// Txn1, epoch 1; should see new value2.
+						{txn1, &value2, false},
+						// Txn1, epoch 2; should see original value1.
+						{txn1e2, &value1, false},
+						// Txn2; should see error.
+						{txn2, nil, true},
+					}
+					for i, test := range testCases {
+						t.Run(strconv.Itoa(i), func(t *testing.T) {
+							value, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{
+								Txn: test.txn,
+							})
+							if test.expErr {
+								if err == nil {
+									t.Errorf("test %d: unexpected success", i)
+								} else if _, ok := err.(*roachpb.WriteIntentError); !ok {
+									t.Errorf("test %d: expected write intent error; got %v", i, err)
+								}
+							} else if err != nil || value == nil || !bytes.Equal(test.expValue.RawBytes, value.RawBytes) {
+								t.Errorf("test %d: expected value %q, err nil; got %+v, %v", i, test.expValue.RawBytes, value, err)
+							}
+						})
 					}
 				})
 			}
@@ -4079,65 +4343,69 @@ func TestMVCCGetWithDiffEpochs(t *testing.T) {
 func TestMVCCGetWithDiffEpochsAndTimestamps(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	for _, impl := range mvccGetImpls {
-		t.Run(impl.name, func(t *testing.T) {
-			mvccGet := impl.fn
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			for _, impl := range mvccGetImpls {
+				t.Run(impl.name, func(t *testing.T) {
+					mvccGet := impl.fn
 
-			ctx := context.Background()
-			engine := createTestEngine()
-			defer engine.Close()
+					ctx := context.Background()
+					engine := engineImpl.create()
+					defer engine.Close()
 
-			// Write initial value without a txn at timestamp 1.
-			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
-				t.Fatal(err)
-			}
-			// Write another value without a txn at timestamp 3.
-			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, value2, nil); err != nil {
-				t.Fatal(err)
-			}
-			// Now write using txn1, epoch 1.
-			txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
-			// Bump epoch 1's write timestamp to timestamp 4.
-			txn1ts.Timestamp = hlc.Timestamp{WallTime: 4}
-			// Expected to hit WriteTooOld error but to still lay down intent.
-			err := MVCCPut(ctx, engine, nil, testKey1, txn1ts.OrigTimestamp, value3, txn1ts)
-			if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok {
-				t.Fatalf("unexpectedly not WriteTooOld: %+v", err)
-			} else if expTS, actTS := txn1ts.Timestamp, wtoErr.ActualTimestamp; expTS != actTS {
-				t.Fatalf("expected write too old error with actual ts %s; got %s", expTS, actTS)
-			}
-			// Try reading using different epochs & timestamps.
-			testCases := []struct {
-				txn      *roachpb.Transaction
-				readTS   hlc.Timestamp
-				expValue *roachpb.Value
-			}{
-				// Epoch 1, read 1; should see new value3.
-				{txn1, hlc.Timestamp{WallTime: 1}, &value3},
-				// Epoch 1, read 2; should see new value3.
-				{txn1, hlc.Timestamp{WallTime: 2}, &value3},
-				// Epoch 1, read 3; should see new value3.
-				{txn1, hlc.Timestamp{WallTime: 3}, &value3},
-				// Epoch 1, read 4; should see new value3.
-				{txn1, hlc.Timestamp{WallTime: 4}, &value3},
-				// Epoch 1, read 5; should see new value3.
-				{txn1, hlc.Timestamp{WallTime: 5}, &value3},
-				// Epoch 2, read 1; should see committed value1.
-				{txn1e2, hlc.Timestamp{WallTime: 1}, &value1},
-				// Epoch 2, read 2; should see committed value1.
-				{txn1e2, hlc.Timestamp{WallTime: 2}, &value1},
-				// Epoch 2, read 3; should see committed value2.
-				{txn1e2, hlc.Timestamp{WallTime: 3}, &value2},
-				// Epoch 2, read 4; should see committed value2.
-				{txn1e2, hlc.Timestamp{WallTime: 4}, &value2},
-				// Epoch 2, read 5; should see committed value2.
-				{txn1e2, hlc.Timestamp{WallTime: 5}, &value2},
-			}
-			for i, test := range testCases {
-				t.Run(strconv.Itoa(i), func(t *testing.T) {
-					value, _, err := mvccGet(ctx, engine, testKey1, test.readTS, MVCCGetOptions{Txn: test.txn})
-					if err != nil || value == nil || !bytes.Equal(test.expValue.RawBytes, value.RawBytes) {
-						t.Errorf("test %d: expected value %q, err nil; got %+v, %v", i, test.expValue.RawBytes, value, err)
+					// Write initial value without a txn at timestamp 1.
+					if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
+						t.Fatal(err)
+					}
+					// Write another value without a txn at timestamp 3.
+					if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, value2, nil); err != nil {
+						t.Fatal(err)
+					}
+					// Now write using txn1, epoch 1.
+					txn1ts := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
+					// Bump epoch 1's write timestamp to timestamp 4.
+					txn1ts.Timestamp = hlc.Timestamp{WallTime: 4}
+					// Expected to hit WriteTooOld error but to still lay down intent.
+					err := MVCCPut(ctx, engine, nil, testKey1, txn1ts.OrigTimestamp, value3, txn1ts)
+					if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok {
+						t.Fatalf("unexpectedly not WriteTooOld: %+v", err)
+					} else if expTS, actTS := txn1ts.Timestamp, wtoErr.ActualTimestamp; expTS != actTS {
+						t.Fatalf("expected write too old error with actual ts %s; got %s", expTS, actTS)
+					}
+					// Try reading using different epochs & timestamps.
+					testCases := []struct {
+						txn      *roachpb.Transaction
+						readTS   hlc.Timestamp
+						expValue *roachpb.Value
+					}{
+						// Epoch 1, read 1; should see new value3.
+						{txn1, hlc.Timestamp{WallTime: 1}, &value3},
+						// Epoch 1, read 2; should see new value3.
+						{txn1, hlc.Timestamp{WallTime: 2}, &value3},
+						// Epoch 1, read 3; should see new value3.
+						{txn1, hlc.Timestamp{WallTime: 3}, &value3},
+						// Epoch 1, read 4; should see new value3.
+						{txn1, hlc.Timestamp{WallTime: 4}, &value3},
+						// Epoch 1, read 5; should see new value3.
+						{txn1, hlc.Timestamp{WallTime: 5}, &value3},
+						// Epoch 2, read 1; should see committed value1.
+						{txn1e2, hlc.Timestamp{WallTime: 1}, &value1},
+						// Epoch 2, read 2; should see committed value1.
+						{txn1e2, hlc.Timestamp{WallTime: 2}, &value1},
+						// Epoch 2, read 3; should see committed value2.
+						{txn1e2, hlc.Timestamp{WallTime: 3}, &value2},
+						// Epoch 2, read 4; should see committed value2.
+						{txn1e2, hlc.Timestamp{WallTime: 4}, &value2},
+						// Epoch 2, read 5; should see committed value2.
+						{txn1e2, hlc.Timestamp{WallTime: 5}, &value2},
+					}
+					for i, test := range testCases {
+						t.Run(strconv.Itoa(i), func(t *testing.T) {
+							value, _, err := mvccGet(ctx, engine, testKey1, test.readTS, MVCCGetOptions{Txn: test.txn})
+							if err != nil || value == nil || !bytes.Equal(test.expValue.RawBytes, value.RawBytes) {
+								t.Errorf("test %d: expected value %q, err nil; got %+v, %v", i, test.expValue.RawBytes, value, err)
+							}
+						})
 					}
 				})
 			}
@@ -4150,22 +4418,26 @@ func TestMVCCGetWithDiffEpochsAndTimestamps(t *testing.T) {
 func TestMVCCGetWithOldEpoch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	for _, impl := range mvccGetImpls {
-		t.Run(impl.name, func(t *testing.T) {
-			mvccGet := impl.fn
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			for _, impl := range mvccGetImpls {
+				t.Run(impl.name, func(t *testing.T) {
+					mvccGet := impl.fn
 
-			ctx := context.Background()
-			engine := createTestEngine()
-			defer engine.Close()
+					ctx := context.Background()
+					engine := engineImpl.create()
+					defer engine.Close()
 
-			if err := MVCCPut(ctx, engine, nil, testKey1, txn1e2.OrigTimestamp, value2, txn1e2); err != nil {
-				t.Fatal(err)
-			}
-			_, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{
-				Txn: txn1,
-			})
-			if err == nil {
-				t.Fatalf("unexpected success of get")
+					if err := MVCCPut(ctx, engine, nil, testKey1, txn1e2.OrigTimestamp, value2, txn1e2); err != nil {
+						t.Fatal(err)
+					}
+					_, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, MVCCGetOptions{
+						Txn: txn1,
+					})
+					if err == nil {
+						t.Fatalf("unexpected success of get")
+					}
+				})
 			}
 		})
 	}
@@ -4179,59 +4451,63 @@ func TestMVCCWriteWithSequence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	testCases := []struct {
-		name     string
-		sequence enginepb.TxnSeq
-		value    roachpb.Value
-		expWrite bool
-		expErr   string
-	}{
-		{"old seq", 1, value1, false, "missing an intent"},
-		{"same seq as overwritten intent", 2, value1, false, ""},
-		{"same seq as overwritten intent, wrong value", 2, value2, false, "has a different value"},
-		{"same seq as active intent", 3, value2, false, ""},
-		{"same seq as active intent, wrong value", 3, value3, false, "has a different value"},
-		{"new seq", 4, value4, true, ""},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			key := roachpb.Key(fmt.Sprintf("key-%d", tc.sequence))
-			txn := *txn1
-			txn.Sequence = 2
-			if err := MVCCPut(ctx, engine, nil, key, txn.Timestamp, value1, &txn); err != nil {
-				t.Fatal(err)
-			}
-			txn.Sequence = 3
-			if err := MVCCPut(ctx, engine, nil, key, txn.Timestamp, value2, &txn); err != nil {
-				t.Fatal(err)
+			testCases := []struct {
+				name     string
+				sequence enginepb.TxnSeq
+				value    roachpb.Value
+				expWrite bool
+				expErr   string
+			}{
+				{"old seq", 1, value1, false, "missing an intent"},
+				{"same seq as overwritten intent", 2, value1, false, ""},
+				{"same seq as overwritten intent, wrong value", 2, value2, false, "has a different value"},
+				{"same seq as active intent", 3, value2, false, ""},
+				{"same seq as active intent, wrong value", 3, value3, false, "has a different value"},
+				{"new seq", 4, value4, true, ""},
 			}
 
-			batch := engine.NewBatch()
-			defer batch.Close()
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					key := roachpb.Key(fmt.Sprintf("key-%d", tc.sequence))
+					txn := *txn1
+					txn.Sequence = 2
+					if err := MVCCPut(ctx, engine, nil, key, txn.Timestamp, value1, &txn); err != nil {
+						t.Fatal(err)
+					}
+					txn.Sequence = 3
+					if err := MVCCPut(ctx, engine, nil, key, txn.Timestamp, value2, &txn); err != nil {
+						t.Fatal(err)
+					}
 
-			txn.Sequence = tc.sequence
-			err := MVCCPut(ctx, batch, nil, key, txn.Timestamp, tc.value, &txn)
-			if tc.expErr != "" && err != nil {
-				if !testutils.IsError(err, tc.expErr) {
-					t.Fatalf("unexpected error: %+v", err)
-				}
-			} else if err != nil {
-				t.Fatalf("unexpected error: %+v", err)
-			}
+					batch := engine.NewBatch()
+					defer batch.Close()
 
-			write := !batch.Empty()
-			if tc.expWrite {
-				if !write {
-					t.Fatalf("expected write to batch")
-				}
-			} else {
-				if write {
-					t.Fatalf("unexpected write to batch")
-				}
+					txn.Sequence = tc.sequence
+					err := MVCCPut(ctx, batch, nil, key, txn.Timestamp, tc.value, &txn)
+					if tc.expErr != "" && err != nil {
+						if !testutils.IsError(err, tc.expErr) {
+							t.Fatalf("unexpected error: %+v", err)
+						}
+					} else if err != nil {
+						t.Fatalf("unexpected error: %+v", err)
+					}
+
+					write := !batch.Empty()
+					if tc.expWrite {
+						if !write {
+							t.Fatalf("expected write to batch")
+						}
+					} else {
+						if write {
+							t.Fatalf("unexpected write to batch")
+						}
+					}
+				})
 			}
 		})
 	}
@@ -4246,63 +4522,67 @@ func TestMVCCDeleteRangeWithSequence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	testCases := []struct {
-		name     string
-		sequence enginepb.TxnSeq
-		expErr   string
-	}{
-		{"old seq", 5, "missing an intent"},
-		{"same seq", 6, ""},
-		{"new seq", 7, ""},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			prefix := roachpb.Key(fmt.Sprintf("key-%d", tc.sequence))
-			txn := *txn1
-			for i := enginepb.TxnSeq(0); i < 3; i++ {
-				key := append(prefix, []byte(strconv.Itoa(int(i)))...)
-				txn.Sequence = 2 + i
-				if err := MVCCPut(ctx, engine, nil, key, txn.Timestamp, value1, &txn); err != nil {
-					t.Fatal(err)
-				}
+			testCases := []struct {
+				name     string
+				sequence enginepb.TxnSeq
+				expErr   string
+			}{
+				{"old seq", 5, "missing an intent"},
+				{"same seq", 6, ""},
+				{"new seq", 7, ""},
 			}
 
-			// Perform the initial DeleteRange.
-			const origSeq = 6
-			txn.Sequence = origSeq
-			origDeleted, _, origNum, err := MVCCDeleteRange(
-				ctx, engine, nil, prefix, prefix.PrefixEnd(), math.MaxInt64, txn.Timestamp, &txn, true,
-			)
-			if err != nil {
-				t.Fatal(err)
-			}
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					prefix := roachpb.Key(fmt.Sprintf("key-%d", tc.sequence))
+					txn := *txn1
+					for i := enginepb.TxnSeq(0); i < 3; i++ {
+						key := append(prefix, []byte(strconv.Itoa(int(i)))...)
+						txn.Sequence = 2 + i
+						if err := MVCCPut(ctx, engine, nil, key, txn.Timestamp, value1, &txn); err != nil {
+							t.Fatal(err)
+						}
+					}
 
-			txn.Sequence = tc.sequence
-			deleted, _, num, err := MVCCDeleteRange(
-				ctx, engine, nil, prefix, prefix.PrefixEnd(), math.MaxInt64, txn.Timestamp, &txn, true,
-			)
-			if tc.expErr != "" && err != nil {
-				if !testutils.IsError(err, tc.expErr) {
-					t.Fatalf("unexpected error: %+v", err)
-				}
-			} else if err != nil {
-				t.Fatalf("unexpected error: %+v", err)
-			}
+					// Perform the initial DeleteRange.
+					const origSeq = 6
+					txn.Sequence = origSeq
+					origDeleted, _, origNum, err := MVCCDeleteRange(
+						ctx, engine, nil, prefix, prefix.PrefixEnd(), math.MaxInt64, txn.Timestamp, &txn, true,
+					)
+					if err != nil {
+						t.Fatal(err)
+					}
 
-			// If at the same sequence as the initial DeleteRange.
-			if tc.sequence == origSeq {
-				if !reflect.DeepEqual(origDeleted, deleted) {
-					t.Fatalf("deleted keys did not match original execution: %+v vs. %+v",
-						origDeleted, deleted)
-				}
-				if origNum != num {
-					t.Fatalf("number of keys deleted did not match original execution: %d vs. %d",
-						origNum, num)
-				}
+					txn.Sequence = tc.sequence
+					deleted, _, num, err := MVCCDeleteRange(
+						ctx, engine, nil, prefix, prefix.PrefixEnd(), math.MaxInt64, txn.Timestamp, &txn, true,
+					)
+					if tc.expErr != "" && err != nil {
+						if !testutils.IsError(err, tc.expErr) {
+							t.Fatalf("unexpected error: %+v", err)
+						}
+					} else if err != nil {
+						t.Fatalf("unexpected error: %+v", err)
+					}
+
+					// If at the same sequence as the initial DeleteRange.
+					if tc.sequence == origSeq {
+						if !reflect.DeepEqual(origDeleted, deleted) {
+							t.Fatalf("deleted keys did not match original execution: %+v vs. %+v",
+								origDeleted, deleted)
+						}
+						if origNum != num {
+							t.Fatalf("number of keys deleted did not match original execution: %d vs. %d",
+								origNum, num)
+						}
+					}
+				})
 			}
 		})
 	}
@@ -4317,33 +4597,39 @@ func TestMVCCDeleteRangeWithSequence(t *testing.T) {
 func TestMVCCGetWithPushedTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	for _, impl := range mvccGetImpls {
-		t.Run(impl.name, func(t *testing.T) {
-			mvccGet := impl.fn
-
-			ctx := context.Background()
-			engine := createTestEngine()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
 			defer engine.Close()
+			for _, impl := range mvccGetImpls {
+				t.Run(impl.name, func(t *testing.T) {
+					mvccGet := impl.fn
 
-			// Start with epoch 1.
-			if err := MVCCPut(ctx, engine, nil, testKey1, txn1.OrigTimestamp, value1, txn1); err != nil {
-				t.Fatal(err)
-			}
-			// Resolve the intent, pushing its timestamp forward.
-			txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
-			if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
-				Span:   roachpb.Span{Key: testKey1},
-				Status: txn.Status,
-				Txn:    txn.TxnMeta,
-			}); err != nil {
-				t.Fatal(err)
-			}
-			// Attempt to read using naive txn's previous timestamp.
-			value, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{Logical: 1}, MVCCGetOptions{
-				Txn: txn1,
-			})
-			if err != nil || value == nil || !bytes.Equal(value.RawBytes, value1.RawBytes) {
-				t.Errorf("expected value %q, err nil; got %+v, %v", value1.RawBytes, value, err)
+					ctx := context.Background()
+					engine := engineImpl.create()
+					defer engine.Close()
+
+					// Start with epoch 1.
+					if err := MVCCPut(ctx, engine, nil, testKey1, txn1.OrigTimestamp, value1, txn1); err != nil {
+						t.Fatal(err)
+					}
+					// Resolve the intent, pushing its timestamp forward.
+					txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
+					if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
+						Span:   roachpb.Span{Key: testKey1},
+						Status: txn.Status,
+						Txn:    txn.TxnMeta,
+					}); err != nil {
+						t.Fatal(err)
+					}
+					// Attempt to read using naive txn's previous timestamp.
+					value, _, err := mvccGet(ctx, engine, testKey1, hlc.Timestamp{Logical: 1}, MVCCGetOptions{
+						Txn: txn1,
+					})
+					if err != nil || value == nil || !bytes.Equal(value.RawBytes, value1.RawBytes) {
+						t.Errorf("expected value %q, err nil; got %+v, %v", value1.RawBytes, value, err)
+					}
+				})
 			}
 		})
 	}
@@ -4353,42 +4639,46 @@ func TestMVCCResolveWithDiffEpochs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1.OrigTimestamp, value1, txn1); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey2, txn1e2.OrigTimestamp, value2, txn1e2); err != nil {
-		t.Fatal(err)
-	}
-	num, _, err := MVCCResolveWriteIntentRange(ctx, engine, nil, roachpb.Intent{
-		Span:   roachpb.Span{Key: testKey1, EndKey: testKey2.Next()},
-		Txn:    txn1e2Commit.TxnMeta,
-		Status: txn1e2Commit.Status,
-	}, 2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if num != 2 {
-		t.Errorf("expected 2 rows resolved; got %d", num)
-	}
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn1.OrigTimestamp, value1, txn1); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey2, txn1e2.OrigTimestamp, value2, txn1e2); err != nil {
+				t.Fatal(err)
+			}
+			num, _, err := MVCCResolveWriteIntentRange(ctx, engine, nil, roachpb.Intent{
+				Span:   roachpb.Span{Key: testKey1, EndKey: testKey2.Next()},
+				Txn:    txn1e2Commit.TxnMeta,
+				Status: txn1e2Commit.Status,
+			}, 2)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if num != 2 {
+				t.Errorf("expected 2 rows resolved; got %d", num)
+			}
 
-	// Verify key1 is empty, as resolution with epoch 2 would have
-	// aborted the epoch 1 intent.
-	value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{Logical: 1}, MVCCGetOptions{})
-	if value != nil || err != nil {
-		t.Errorf("expected value nil, err nil; got %+v, %v", value, err)
-	}
+			// Verify key1 is empty, as resolution with epoch 2 would have
+			// aborted the epoch 1 intent.
+			value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{Logical: 1}, MVCCGetOptions{})
+			if value != nil || err != nil {
+				t.Errorf("expected value nil, err nil; got %+v, %v", value, err)
+			}
 
-	// Key2 should be committed.
-	value, _, err = MVCCGet(ctx, engine, testKey2, hlc.Timestamp{Logical: 1}, MVCCGetOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(value2.RawBytes, value.RawBytes) {
-		t.Fatalf("the value %s in get result does not match the value %s in request",
-			value2.RawBytes, value.RawBytes)
+			// Key2 should be committed.
+			value, _, err = MVCCGet(ctx, engine, testKey2, hlc.Timestamp{Logical: 1}, MVCCGetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(value2.RawBytes, value.RawBytes) {
+				t.Fatalf("the value %s in get result does not match the value %s in request",
+					value2.RawBytes, value.RawBytes)
+			}
+		})
 	}
 }
 
@@ -4396,50 +4686,54 @@ func TestMVCCResolveWithUpdatedTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1.OrigTimestamp, value1, txn1); err != nil {
-		t.Fatal(err)
-	}
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn1.OrigTimestamp, value1, txn1); err != nil {
+				t.Fatal(err)
+			}
 
-	value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{
-		Txn: txn1,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(value1.RawBytes, value.RawBytes) {
-		t.Fatalf("the value %s in get result does not match the value %s in request",
-			value1.RawBytes, value.RawBytes)
-	}
+			value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{
+				Txn: txn1,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(value1.RawBytes, value.RawBytes) {
+				t.Fatalf("the value %s in get result does not match the value %s in request",
+					value1.RawBytes, value.RawBytes)
+			}
 
-	// Resolve with a higher commit timestamp -- this should rewrite the
-	// intent when making it permanent.
-	txn := makeTxn(*txn1Commit, hlc.Timestamp{WallTime: 1})
-	if err = MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
-		Span:   roachpb.Span{Key: testKey1},
-		Status: txn.Status,
-		Txn:    txn.TxnMeta,
-	}); err != nil {
-		t.Fatal(err)
-	}
+			// Resolve with a higher commit timestamp -- this should rewrite the
+			// intent when making it permanent.
+			txn := makeTxn(*txn1Commit, hlc.Timestamp{WallTime: 1})
+			if err = MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
+				Span:   roachpb.Span{Key: testKey1},
+				Status: txn.Status,
+				Txn:    txn.TxnMeta,
+			}); err != nil {
+				t.Fatal(err)
+			}
 
-	value, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{Logical: 1}, MVCCGetOptions{})
-	if value != nil || err != nil {
-		t.Fatalf("expected both value and err to be nil: %+v, %v", value, err)
-	}
+			value, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{Logical: 1}, MVCCGetOptions{})
+			if value != nil || err != nil {
+				t.Fatalf("expected both value and err to be nil: %+v, %v", value, err)
+			}
 
-	value, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{})
-	if err != nil {
-		t.Error(err)
-	}
-	if expTS := (hlc.Timestamp{WallTime: 1}); value.Timestamp != expTS {
-		t.Fatalf("expected timestamp %+v == %+v", value.Timestamp, expTS)
-	}
-	if !bytes.Equal(value1.RawBytes, value.RawBytes) {
-		t.Fatalf("the value %s in get result does not match the value %s in request",
-			value1.RawBytes, value.RawBytes)
+			value, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{})
+			if err != nil {
+				t.Error(err)
+			}
+			if expTS := (hlc.Timestamp{WallTime: 1}); value.Timestamp != expTS {
+				t.Fatalf("expected timestamp %+v == %+v", value.Timestamp, expTS)
+			}
+			if !bytes.Equal(value1.RawBytes, value.RawBytes) {
+				t.Fatalf("the value %s in get result does not match the value %s in request",
+					value1.RawBytes, value.RawBytes)
+			}
+		})
 	}
 }
 
@@ -4447,52 +4741,56 @@ func TestMVCCResolveWithPushedTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1.OrigTimestamp, value1, txn1); err != nil {
-		t.Fatal(err)
-	}
-	value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{
-		Txn: txn1,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(value1.RawBytes, value.RawBytes) {
-		t.Fatalf("the value %s in get result does not match the value %s in request",
-			value1.RawBytes, value.RawBytes)
-	}
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn1.OrigTimestamp, value1, txn1); err != nil {
+				t.Fatal(err)
+			}
+			value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{
+				Txn: txn1,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(value1.RawBytes, value.RawBytes) {
+				t.Fatalf("the value %s in get result does not match the value %s in request",
+					value1.RawBytes, value.RawBytes)
+			}
 
-	// Resolve with a higher commit timestamp, but with still-pending transaction.
-	// This represents a straightforward push (i.e. from a read/write conflict).
-	txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
-	if err = MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
-		Span:   roachpb.Span{Key: testKey1},
-		Status: txn.Status,
-		Txn:    txn.TxnMeta,
-	}); err != nil {
-		t.Fatal(err)
-	}
+			// Resolve with a higher commit timestamp, but with still-pending transaction.
+			// This represents a straightforward push (i.e. from a read/write conflict).
+			txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
+			if err = MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
+				Span:   roachpb.Span{Key: testKey1},
+				Status: txn.Status,
+				Txn:    txn.TxnMeta,
+			}); err != nil {
+				t.Fatal(err)
+			}
 
-	value, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{})
-	if value != nil || err == nil {
-		t.Fatalf("expected both value nil and err to be a writeIntentError: %+v", value)
-	}
+			value, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{})
+			if value != nil || err == nil {
+				t.Fatalf("expected both value nil and err to be a writeIntentError: %+v", value)
+			}
 
-	// Can still fetch the value using txn1.
-	value, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{
-		Txn: txn1,
-	})
-	if err != nil {
-		t.Error(err)
-	}
-	if expTS := (hlc.Timestamp{WallTime: 1}); value.Timestamp != expTS {
-		t.Fatalf("expected timestamp %+v == %+v", value.Timestamp, expTS)
-	}
-	if !bytes.Equal(value1.RawBytes, value.RawBytes) {
-		t.Fatalf("the value %s in get result does not match the value %s in request",
-			value1.RawBytes, value.RawBytes)
+			// Can still fetch the value using txn1.
+			value, _, err = MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 1}, MVCCGetOptions{
+				Txn: txn1,
+			})
+			if err != nil {
+				t.Error(err)
+			}
+			if expTS := (hlc.Timestamp{WallTime: 1}); value.Timestamp != expTS {
+				t.Fatalf("expected timestamp %+v == %+v", value.Timestamp, expTS)
+			}
+			if !bytes.Equal(value1.RawBytes, value.RawBytes) {
+				t.Fatalf("the value %s in get result does not match the value %s in request",
+					value1.RawBytes, value.RawBytes)
+			}
+		})
 	}
 }
 
@@ -4500,43 +4798,47 @@ func TestMVCCResolveTxnNoOps(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	// Resolve a non existent key; noop.
-	if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
-		Span:   roachpb.Span{Key: testKey1},
-		Status: txn1Commit.Status,
-		Txn:    txn1Commit.TxnMeta,
-	}); err != nil {
-		t.Fatal(err)
-	}
+			// Resolve a non existent key; noop.
+			if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
+				Span:   roachpb.Span{Key: testKey1},
+				Status: txn1Commit.Status,
+				Txn:    txn1Commit.TxnMeta,
+			}); err != nil {
+				t.Fatal(err)
+			}
 
-	// Add key and resolve despite there being no intent.
-	if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
-		Span:   roachpb.Span{Key: testKey1},
-		Status: txn2Commit.Status,
-		Txn:    txn2Commit.TxnMeta,
-	}); err != nil {
-		t.Fatal(err)
-	}
+			// Add key and resolve despite there being no intent.
+			if err := MVCCPut(ctx, engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
+				Span:   roachpb.Span{Key: testKey1},
+				Status: txn2Commit.Status,
+				Txn:    txn2Commit.TxnMeta,
+			}); err != nil {
+				t.Fatal(err)
+			}
 
-	// Write intent and resolve with different txn.
-	if err := MVCCPut(ctx, engine, nil, testKey2, txn1.OrigTimestamp, value2, txn1); err != nil {
-		t.Fatal(err)
-	}
+			// Write intent and resolve with different txn.
+			if err := MVCCPut(ctx, engine, nil, testKey2, txn1.OrigTimestamp, value2, txn1); err != nil {
+				t.Fatal(err)
+			}
 
-	txn1CommitWithTS := txn2Commit.Clone()
-	txn1CommitWithTS.Timestamp = hlc.Timestamp{WallTime: 1}
-	if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
-		Span:   roachpb.Span{Key: testKey2},
-		Status: txn1CommitWithTS.Status,
-		Txn:    txn1CommitWithTS.TxnMeta,
-	}); err != nil {
-		t.Fatal(err)
+			txn1CommitWithTS := txn2Commit.Clone()
+			txn1CommitWithTS.Timestamp = hlc.Timestamp{WallTime: 1}
+			if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
+				Span:   roachpb.Span{Key: testKey2},
+				Status: txn1CommitWithTS.Status,
+				Txn:    txn1CommitWithTS.TxnMeta,
+			}); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }
 
@@ -4544,76 +4846,80 @@ func TestMVCCResolveTxnRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1.OrigTimestamp, value1, txn1); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{Logical: 1}, value2, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey3, txn2.OrigTimestamp, value3, txn2); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCPut(ctx, engine, nil, testKey4, txn1.OrigTimestamp, value4, txn1); err != nil {
-		t.Fatal(err)
-	}
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn1.OrigTimestamp, value1, txn1); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey2, hlc.Timestamp{Logical: 1}, value2, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey3, txn2.OrigTimestamp, value3, txn2); err != nil {
+				t.Fatal(err)
+			}
+			if err := MVCCPut(ctx, engine, nil, testKey4, txn1.OrigTimestamp, value4, txn1); err != nil {
+				t.Fatal(err)
+			}
 
-	num, resumeSpan, err := MVCCResolveWriteIntentRange(ctx, engine, nil, roachpb.Intent{
-		Span:   roachpb.Span{Key: testKey1, EndKey: testKey4.Next()},
-		Txn:    txn1Commit.TxnMeta,
-		Status: txn1Commit.Status,
-	}, math.MaxInt64)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if num != 2 || resumeSpan != nil {
-		t.Fatalf("expected all keys to process for resolution, even though 2 are noops; got %d, resume=%s",
-			num, resumeSpan)
-	}
+			num, resumeSpan, err := MVCCResolveWriteIntentRange(ctx, engine, nil, roachpb.Intent{
+				Span:   roachpb.Span{Key: testKey1, EndKey: testKey4.Next()},
+				Txn:    txn1Commit.TxnMeta,
+				Status: txn1Commit.Status,
+			}, math.MaxInt64)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if num != 2 || resumeSpan != nil {
+				t.Fatalf("expected all keys to process for resolution, even though 2 are noops; got %d, resume=%s",
+					num, resumeSpan)
+			}
 
-	{
-		value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{Logical: 1}, MVCCGetOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !bytes.Equal(value1.RawBytes, value.RawBytes) {
-			t.Fatalf("the value %s in get result does not match the value %s in request",
-				value1.RawBytes, value.RawBytes)
-		}
-	}
-	{
-		value, _, err := MVCCGet(ctx, engine, testKey2, hlc.Timestamp{Logical: 1}, MVCCGetOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !bytes.Equal(value2.RawBytes, value.RawBytes) {
-			t.Fatalf("the value %s in get result does not match the value %s in request",
-				value2.RawBytes, value.RawBytes)
-		}
-	}
-	{
-		value, _, err := MVCCGet(ctx, engine, testKey3, hlc.Timestamp{Logical: 1}, MVCCGetOptions{
-			Txn: txn2,
+			{
+				value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{Logical: 1}, MVCCGetOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(value1.RawBytes, value.RawBytes) {
+					t.Fatalf("the value %s in get result does not match the value %s in request",
+						value1.RawBytes, value.RawBytes)
+				}
+			}
+			{
+				value, _, err := MVCCGet(ctx, engine, testKey2, hlc.Timestamp{Logical: 1}, MVCCGetOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(value2.RawBytes, value.RawBytes) {
+					t.Fatalf("the value %s in get result does not match the value %s in request",
+						value2.RawBytes, value.RawBytes)
+				}
+			}
+			{
+				value, _, err := MVCCGet(ctx, engine, testKey3, hlc.Timestamp{Logical: 1}, MVCCGetOptions{
+					Txn: txn2,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(value3.RawBytes, value.RawBytes) {
+					t.Fatalf("the value %s in get result does not match the value %s in request",
+						value3.RawBytes, value.RawBytes)
+				}
+			}
+			{
+				value, _, err := MVCCGet(ctx, engine, testKey4, hlc.Timestamp{Logical: 1}, MVCCGetOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(value4.RawBytes, value.RawBytes) {
+					t.Fatalf("the value %s in get result does not match the value %s in request",
+						value1.RawBytes, value.RawBytes)
+				}
+			}
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !bytes.Equal(value3.RawBytes, value.RawBytes) {
-			t.Fatalf("the value %s in get result does not match the value %s in request",
-				value3.RawBytes, value.RawBytes)
-		}
-	}
-	{
-		value, _, err := MVCCGet(ctx, engine, testKey4, hlc.Timestamp{Logical: 1}, MVCCGetOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !bytes.Equal(value4.RawBytes, value.RawBytes) {
-			t.Fatalf("the value %s in get result does not match the value %s in request",
-				value1.RawBytes, value.RawBytes)
-		}
 	}
 }
 
@@ -4621,41 +4927,45 @@ func TestMVCCResolveTxnRangeResume(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	// Write 10 keys from txn1, 10 from txn2, and 10 with no txn, interleaved.
-	for i := 0; i < 30; i += 3 {
-		key0 := roachpb.Key(fmt.Sprintf("%02d", i+0))
-		key1 := roachpb.Key(fmt.Sprintf("%02d", i+1))
-		key2 := roachpb.Key(fmt.Sprintf("%02d", i+2))
-		if err := MVCCPut(ctx, engine, nil, key0, txn1.OrigTimestamp, value1, txn1); err != nil {
-			t.Fatal(err)
-		}
-		txn2ts := makeTxn(*txn2, hlc.Timestamp{Logical: 2})
-		if err := MVCCPut(ctx, engine, nil, key1, txn2ts.OrigTimestamp, value2, txn2ts); err != nil {
-			t.Fatal(err)
-		}
-		if err := MVCCPut(ctx, engine, nil, key2, hlc.Timestamp{Logical: 3}, value3, nil); err != nil {
-			t.Fatal(err)
-		}
-	}
+			// Write 10 keys from txn1, 10 from txn2, and 10 with no txn, interleaved.
+			for i := 0; i < 30; i += 3 {
+				key0 := roachpb.Key(fmt.Sprintf("%02d", i+0))
+				key1 := roachpb.Key(fmt.Sprintf("%02d", i+1))
+				key2 := roachpb.Key(fmt.Sprintf("%02d", i+2))
+				if err := MVCCPut(ctx, engine, nil, key0, txn1.OrigTimestamp, value1, txn1); err != nil {
+					t.Fatal(err)
+				}
+				txn2ts := makeTxn(*txn2, hlc.Timestamp{Logical: 2})
+				if err := MVCCPut(ctx, engine, nil, key1, txn2ts.OrigTimestamp, value2, txn2ts); err != nil {
+					t.Fatal(err)
+				}
+				if err := MVCCPut(ctx, engine, nil, key2, hlc.Timestamp{Logical: 3}, value3, nil); err != nil {
+					t.Fatal(err)
+				}
+			}
 
-	// Resolve up to 5 intents.
-	num, resumeSpan, err := MVCCResolveWriteIntentRange(ctx, engine, nil, roachpb.Intent{
-		Span:   roachpb.Span{Key: roachpb.Key("00"), EndKey: roachpb.Key("30")},
-		Txn:    txn1Commit.TxnMeta,
-		Status: txn1Commit.Status,
-	}, 5)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if num != 5 || resumeSpan == nil {
-		t.Errorf("expected resolution for only 5 keys; got %d, resume=%s", num, resumeSpan)
-	}
-	expResumeSpan := &roachpb.Span{Key: roachpb.Key("12").Next(), EndKey: roachpb.Key("30")}
-	if !resumeSpan.Equal(expResumeSpan) {
-		t.Errorf("expected resume span %s; got %s", expResumeSpan, resumeSpan)
+			// Resolve up to 5 intents.
+			num, resumeSpan, err := MVCCResolveWriteIntentRange(ctx, engine, nil, roachpb.Intent{
+				Span:   roachpb.Span{Key: roachpb.Key("00"), EndKey: roachpb.Key("30")},
+				Txn:    txn1Commit.TxnMeta,
+				Status: txn1Commit.Status,
+			}, 5)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if num != 5 || resumeSpan == nil {
+				t.Errorf("expected resolution for only 5 keys; got %d, resume=%s", num, resumeSpan)
+			}
+			expResumeSpan := &roachpb.Span{Key: roachpb.Key("12").Next(), EndKey: roachpb.Key("30")}
+			if !resumeSpan.Equal(expResumeSpan) {
+				t.Errorf("expected resume span %s; got %s", expResumeSpan, resumeSpan)
+			}
+		})
 	}
 }
 
@@ -4695,50 +5005,54 @@ func TestFindSplitKey(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	ms := &enginepb.MVCCStats{}
-	// Generate a series of KeyValues, each containing targetLength
-	// bytes, writing key #i to (encoded) key #i through the MVCC
-	// facility. Assuming that this translates roughly into same-length
-	// values after MVCC encoding, the split key should hence be chosen
-	// as the middle key of the interval.
-	splitReservoirSize := 100
-	for i := 0; i < splitReservoirSize; i++ {
-		k := fmt.Sprintf("%09d", i)
-		v := strings.Repeat("X", 10-len(k))
-		val := roachpb.MakeValueFromString(v)
-		// Write the key and value through MVCC
-		if err := MVCCPut(ctx, engine, ms, []byte(k), hlc.Timestamp{Logical: 1}, val, nil); err != nil {
-			t.Fatal(err)
-		}
-	}
+			ms := &enginepb.MVCCStats{}
+			// Generate a series of KeyValues, each containing targetLength
+			// bytes, writing key #i to (encoded) key #i through the MVCC
+			// facility. Assuming that this translates roughly into same-length
+			// values after MVCC encoding, the split key should hence be chosen
+			// as the middle key of the interval.
+			splitReservoirSize := 100
+			for i := 0; i < splitReservoirSize; i++ {
+				k := fmt.Sprintf("%09d", i)
+				v := strings.Repeat("X", 10-len(k))
+				val := roachpb.MakeValueFromString(v)
+				// Write the key and value through MVCC
+				if err := MVCCPut(ctx, engine, ms, []byte(k), hlc.Timestamp{Logical: 1}, val, nil); err != nil {
+					t.Fatal(err)
+				}
+			}
 
-	testData := []struct {
-		targetSize int64
-		splitInd   int
-	}{
-		{(ms.KeyBytes + ms.ValBytes) / 2, splitReservoirSize / 2},
-		{0, 0},
-		{math.MaxInt64, splitReservoirSize},
-	}
+			testData := []struct {
+				targetSize int64
+				splitInd   int
+			}{
+				{(ms.KeyBytes + ms.ValBytes) / 2, splitReservoirSize / 2},
+				{0, 0},
+				{math.MaxInt64, splitReservoirSize},
+			}
 
-	for i, td := range testData {
-		humanSplitKey, err := MVCCFindSplitKey(ctx, engine, roachpb.RKeyMin, roachpb.RKeyMax, td.targetSize)
-		if err != nil {
-			t.Fatal(err)
-		}
-		ind, err := strconv.Atoi(string(humanSplitKey))
-		if err != nil {
-			t.Fatalf("%d: could not parse key %s as int: %+v", i, humanSplitKey, err)
-		}
-		if ind == 0 {
-			t.Fatalf("%d: should never select first key as split key", i)
-		}
-		if diff := td.splitInd - ind; diff > 1 || diff < -1 {
-			t.Fatalf("%d: wanted key #%d+-1, but got %d (diff %d)", i, td.splitInd, ind, diff)
-		}
+			for i, td := range testData {
+				humanSplitKey, err := MVCCFindSplitKey(ctx, engine, roachpb.RKeyMin, roachpb.RKeyMax, td.targetSize)
+				if err != nil {
+					t.Fatal(err)
+				}
+				ind, err := strconv.Atoi(string(humanSplitKey))
+				if err != nil {
+					t.Fatalf("%d: could not parse key %s as int: %+v", i, humanSplitKey, err)
+				}
+				if ind == 0 {
+					t.Fatalf("%d: should never select first key as split key", i)
+				}
+				if diff := td.splitInd - ind; diff > 1 || diff < -1 {
+					t.Fatalf("%d: wanted key #%d+-1, but got %d (diff %d)", i, td.splitInd, ind, diff)
+				}
+			}
+		})
 	}
 }
 
@@ -5043,50 +5357,54 @@ func TestFindValidSplitKeys(t *testing.T) {
 		},
 	}
 
-	for i, test := range testCases {
-		t.Run("", func(t *testing.T) {
-			ctx := context.Background()
-			engine := createTestEngine()
-			defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			for i, test := range testCases {
+				t.Run("", func(t *testing.T) {
+					ctx := context.Background()
+					engine := engineImpl.create()
+					defer engine.Close()
 
-			ms := &enginepb.MVCCStats{}
-			val := roachpb.MakeValueFromString(strings.Repeat("X", 10))
-			for _, k := range test.keys {
-				// Add three MVCC versions of every key. Splits are not allowed
-				// between MVCC versions, so this shouldn't have any effect.
-				for j := 1; j <= 3; j++ {
-					ts := hlc.Timestamp{Logical: int32(j)}
-					if err := MVCCPut(ctx, engine, ms, []byte(k), ts, val, nil); err != nil {
+					ms := &enginepb.MVCCStats{}
+					val := roachpb.MakeValueFromString(strings.Repeat("X", 10))
+					for _, k := range test.keys {
+						// Add three MVCC versions of every key. Splits are not allowed
+						// between MVCC versions, so this shouldn't have any effect.
+						for j := 1; j <= 3; j++ {
+							ts := hlc.Timestamp{Logical: int32(j)}
+							if err := MVCCPut(ctx, engine, ms, []byte(k), ts, val, nil); err != nil {
+								t.Fatal(err)
+							}
+						}
+					}
+					rangeStart := test.keys[0]
+					if len(test.rangeStart) > 0 {
+						rangeStart = test.rangeStart
+					}
+					rangeEnd := test.keys[len(test.keys)-1].Next()
+					rangeStartAddr, err := keys.Addr(rangeStart)
+					if err != nil {
 						t.Fatal(err)
 					}
-				}
-			}
-			rangeStart := test.keys[0]
-			if len(test.rangeStart) > 0 {
-				rangeStart = test.rangeStart
-			}
-			rangeEnd := test.keys[len(test.keys)-1].Next()
-			rangeStartAddr, err := keys.Addr(rangeStart)
-			if err != nil {
-				t.Fatal(err)
-			}
-			rangeEndAddr, err := keys.Addr(rangeEnd)
-			if err != nil {
-				t.Fatal(err)
-			}
-			targetSize := (ms.KeyBytes + ms.ValBytes) / 2
-			splitKey, err := MVCCFindSplitKey(ctx, engine, rangeStartAddr, rangeEndAddr, targetSize)
-			if test.expError {
-				if !testutils.IsError(err, "has no valid splits") {
-					t.Fatalf("%d: unexpected error: %+v", i, err)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("%d; unexpected error: %+v", i, err)
-			}
-			if !splitKey.Equal(test.expSplit) {
-				t.Errorf("%d: expected split key %q; got %q", i, test.expSplit, splitKey)
+					rangeEndAddr, err := keys.Addr(rangeEnd)
+					if err != nil {
+						t.Fatal(err)
+					}
+					targetSize := (ms.KeyBytes + ms.ValBytes) / 2
+					splitKey, err := MVCCFindSplitKey(ctx, engine, rangeStartAddr, rangeEndAddr, targetSize)
+					if test.expError {
+						if !testutils.IsError(err, "has no valid splits") {
+							t.Fatalf("%d: unexpected error: %+v", i, err)
+						}
+						return
+					}
+					if err != nil {
+						t.Fatalf("%d; unexpected error: %+v", i, err)
+					}
+					if !splitKey.Equal(test.expSplit) {
+						t.Errorf("%d: expected split key %q; got %q", i, test.expSplit, splitKey)
+					}
+				})
 			}
 		})
 	}
@@ -5139,31 +5457,35 @@ func TestFindBalancedSplitKeys(t *testing.T) {
 		},
 	}
 
-	for i, test := range testCases {
-		t.Run("", func(t *testing.T) {
-			ctx := context.Background()
-			engine := createTestEngine()
-			defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			for i, test := range testCases {
+				t.Run("", func(t *testing.T) {
+					ctx := context.Background()
+					engine := engineImpl.create()
+					defer engine.Close()
 
-			ms := &enginepb.MVCCStats{}
-			var expKey roachpb.Key
-			for j, keySize := range test.keySizes {
-				key := roachpb.Key(fmt.Sprintf("%d%s", j, strings.Repeat("X", keySize)))
-				if test.expSplit == j {
-					expKey = key
-				}
-				val := roachpb.MakeValueFromString(strings.Repeat("X", test.valSizes[j]))
-				if err := MVCCPut(ctx, engine, ms, key, hlc.Timestamp{Logical: 1}, val, nil); err != nil {
-					t.Fatal(err)
-				}
-			}
-			targetSize := (ms.KeyBytes + ms.ValBytes) / 2
-			splitKey, err := MVCCFindSplitKey(ctx, engine, roachpb.RKey("\x02"), roachpb.RKeyMax, targetSize)
-			if err != nil {
-				t.Fatalf("unexpected error: %+v", err)
-			}
-			if !splitKey.Equal(expKey) {
-				t.Errorf("%d: expected split key %q; got %q", i, expKey, splitKey)
+					ms := &enginepb.MVCCStats{}
+					var expKey roachpb.Key
+					for j, keySize := range test.keySizes {
+						key := roachpb.Key(fmt.Sprintf("%d%s", j, strings.Repeat("X", keySize)))
+						if test.expSplit == j {
+							expKey = key
+						}
+						val := roachpb.MakeValueFromString(strings.Repeat("X", test.valSizes[j]))
+						if err := MVCCPut(ctx, engine, ms, key, hlc.Timestamp{Logical: 1}, val, nil); err != nil {
+							t.Fatal(err)
+						}
+					}
+					targetSize := (ms.KeyBytes + ms.ValBytes) / 2
+					splitKey, err := MVCCFindSplitKey(ctx, engine, roachpb.RKey("\x02"), roachpb.RKeyMax, targetSize)
+					if err != nil {
+						t.Fatalf("unexpected error: %+v", err)
+					}
+					if !splitKey.Equal(expKey) {
+						t.Errorf("%d: expected split key %q; got %q", i, expKey, splitKey)
+					}
+				})
 			}
 		})
 	}
@@ -5176,108 +5498,112 @@ func TestMVCCGarbageCollect(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	ms := &enginepb.MVCCStats{}
+			ms := &enginepb.MVCCStats{}
 
-	bytes := []byte("value")
-	ts1 := hlc.Timestamp{WallTime: 1E9}
-	ts2 := hlc.Timestamp{WallTime: 2E9}
-	ts3 := hlc.Timestamp{WallTime: 3E9}
-	val1 := roachpb.MakeValueFromBytesAndTimestamp(bytes, ts1)
-	val2 := roachpb.MakeValueFromBytesAndTimestamp(bytes, ts2)
-	val3 := roachpb.MakeValueFromBytesAndTimestamp(bytes, ts3)
-	valInline := roachpb.MakeValueFromBytesAndTimestamp(bytes, hlc.Timestamp{})
+			bytes := []byte("value")
+			ts1 := hlc.Timestamp{WallTime: 1E9}
+			ts2 := hlc.Timestamp{WallTime: 2E9}
+			ts3 := hlc.Timestamp{WallTime: 3E9}
+			val1 := roachpb.MakeValueFromBytesAndTimestamp(bytes, ts1)
+			val2 := roachpb.MakeValueFromBytesAndTimestamp(bytes, ts2)
+			val3 := roachpb.MakeValueFromBytesAndTimestamp(bytes, ts3)
+			valInline := roachpb.MakeValueFromBytesAndTimestamp(bytes, hlc.Timestamp{})
 
-	testData := []struct {
-		key       roachpb.Key
-		vals      []roachpb.Value
-		isDeleted bool // is the most recent value a deletion tombstone?
-	}{
-		{roachpb.Key("a"), []roachpb.Value{val1, val2}, false},
-		{roachpb.Key("a-del"), []roachpb.Value{val1, val2}, true},
-		{roachpb.Key("b"), []roachpb.Value{val1, val2, val3}, false},
-		{roachpb.Key("b-del"), []roachpb.Value{val1, val2, val3}, true},
-		{roachpb.Key("inline"), []roachpb.Value{valInline}, false},
-	}
-
-	for i := 0; i < 3; i++ {
-		for _, test := range testData {
-			if i >= len(test.vals) {
-				continue
+			testData := []struct {
+				key       roachpb.Key
+				vals      []roachpb.Value
+				isDeleted bool // is the most recent value a deletion tombstone?
+			}{
+				{roachpb.Key("a"), []roachpb.Value{val1, val2}, false},
+				{roachpb.Key("a-del"), []roachpb.Value{val1, val2}, true},
+				{roachpb.Key("b"), []roachpb.Value{val1, val2, val3}, false},
+				{roachpb.Key("b-del"), []roachpb.Value{val1, val2, val3}, true},
+				{roachpb.Key("inline"), []roachpb.Value{valInline}, false},
 			}
-			for _, val := range test.vals[i : i+1] {
-				if i == len(test.vals)-1 && test.isDeleted {
-					if err := MVCCDelete(ctx, engine, ms, test.key, val.Timestamp, nil); err != nil {
-						t.Fatal(err)
+
+			for i := 0; i < 3; i++ {
+				for _, test := range testData {
+					if i >= len(test.vals) {
+						continue
 					}
-					continue
+					for _, val := range test.vals[i : i+1] {
+						if i == len(test.vals)-1 && test.isDeleted {
+							if err := MVCCDelete(ctx, engine, ms, test.key, val.Timestamp, nil); err != nil {
+								t.Fatal(err)
+							}
+							continue
+						}
+						valCpy := *protoutil.Clone(&val).(*roachpb.Value)
+						valCpy.Timestamp = hlc.Timestamp{}
+						if err := MVCCPut(ctx, engine, ms, test.key, val.Timestamp, valCpy, nil); err != nil {
+							t.Fatal(err)
+						}
+					}
 				}
-				valCpy := *protoutil.Clone(&val).(*roachpb.Value)
-				valCpy.Timestamp = hlc.Timestamp{}
-				if err := MVCCPut(ctx, engine, ms, test.key, val.Timestamp, valCpy, nil); err != nil {
+			}
+			if log.V(1) {
+				kvsn, err := Scan(engine, mvccKey(keyMin), mvccKey(keyMax), 0)
+				if err != nil {
 					t.Fatal(err)
 				}
+				for i, kv := range kvsn {
+					log.Infof(context.Background(), "%d: %s", i, kv.Key)
+				}
 			}
-		}
-	}
-	if log.V(1) {
-		kvsn, err := Scan(engine, mvccKey(keyMin), mvccKey(keyMax), 0)
-		if err != nil {
-			t.Fatal(err)
-		}
-		for i, kv := range kvsn {
-			log.Infof(context.Background(), "%d: %s", i, kv.Key)
-		}
-	}
 
-	keys := []roachpb.GCRequest_GCKey{
-		{Key: roachpb.Key("a"), Timestamp: ts1},
-		{Key: roachpb.Key("a-del"), Timestamp: ts2},
-		{Key: roachpb.Key("b"), Timestamp: ts1},
-		{Key: roachpb.Key("b-del"), Timestamp: ts2},
-		{Key: roachpb.Key("inline"), Timestamp: hlc.Timestamp{}},
-		// Keys that don't exist, which should result in a no-op.
-		{Key: roachpb.Key("a-bad"), Timestamp: ts2},
-		{Key: roachpb.Key("inline-bad"), Timestamp: hlc.Timestamp{}},
-	}
-	if err := MVCCGarbageCollect(
-		context.Background(), engine, ms, keys, ts3,
-	); err != nil {
-		t.Fatal(err)
-	}
+			keys := []roachpb.GCRequest_GCKey{
+				{Key: roachpb.Key("a"), Timestamp: ts1},
+				{Key: roachpb.Key("a-del"), Timestamp: ts2},
+				{Key: roachpb.Key("b"), Timestamp: ts1},
+				{Key: roachpb.Key("b-del"), Timestamp: ts2},
+				{Key: roachpb.Key("inline"), Timestamp: hlc.Timestamp{}},
+				// Keys that don't exist, which should result in a no-op.
+				{Key: roachpb.Key("a-bad"), Timestamp: ts2},
+				{Key: roachpb.Key("inline-bad"), Timestamp: hlc.Timestamp{}},
+			}
+			if err := MVCCGarbageCollect(
+				context.Background(), engine, ms, keys, ts3,
+			); err != nil {
+				t.Fatal(err)
+			}
 
-	expEncKeys := []MVCCKey{
-		mvccVersionKey(roachpb.Key("a"), ts2),
-		mvccVersionKey(roachpb.Key("b"), ts3),
-		mvccVersionKey(roachpb.Key("b"), ts2),
-		mvccVersionKey(roachpb.Key("b-del"), ts3),
-	}
-	kvs, err := Scan(engine, mvccKey(keyMin), mvccKey(keyMax), 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(kvs) != len(expEncKeys) {
-		t.Fatalf("number of kvs %d != expected %d", len(kvs), len(expEncKeys))
-	}
-	for i, kv := range kvs {
-		if !kv.Key.Equal(expEncKeys[i]) {
-			t.Errorf("%d: expected key %q; got %q", i, expEncKeys[i], kv.Key)
-		}
-	}
-
-	// Verify aggregated stats match computed stats after GC.
-	iter := engine.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
-	defer iter.Close()
-	for _, mvccStatsTest := range mvccStatsTests {
-		t.Run(mvccStatsTest.name, func(t *testing.T) {
-			expMS, err := mvccStatsTest.fn(iter, mvccKey(roachpb.KeyMin),
-				mvccKey(roachpb.KeyMax), ts3.WallTime)
+			expEncKeys := []MVCCKey{
+				mvccVersionKey(roachpb.Key("a"), ts2),
+				mvccVersionKey(roachpb.Key("b"), ts3),
+				mvccVersionKey(roachpb.Key("b"), ts2),
+				mvccVersionKey(roachpb.Key("b-del"), ts3),
+			}
+			kvs, err := Scan(engine, mvccKey(keyMin), mvccKey(keyMax), 0)
 			if err != nil {
 				t.Fatal(err)
 			}
-			assertEq(t, engine, "verification", ms, &expMS)
+			if len(kvs) != len(expEncKeys) {
+				t.Fatalf("number of kvs %d != expected %d", len(kvs), len(expEncKeys))
+			}
+			for i, kv := range kvs {
+				if !kv.Key.Equal(expEncKeys[i]) {
+					t.Errorf("%d: expected key %q; got %q", i, expEncKeys[i], kv.Key)
+				}
+			}
+
+			// Verify aggregated stats match computed stats after GC.
+			iter := engine.NewIterator(IterOptions{UpperBound: roachpb.KeyMax})
+			defer iter.Close()
+			for _, mvccStatsTest := range mvccStatsTests {
+				t.Run(mvccStatsTest.name, func(t *testing.T) {
+					expMS, err := mvccStatsTest.fn(iter, mvccKey(roachpb.KeyMin),
+						mvccKey(roachpb.KeyMax), ts3.WallTime)
+					if err != nil {
+						t.Fatal(err)
+					}
+					assertEq(t, engine, "verification", ms, &expMS)
+				})
+			}
 		})
 	}
 }
@@ -5288,43 +5614,46 @@ func TestMVCCGarbageCollectNonDeleted(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	s := "string"
-	ts1 := hlc.Timestamp{WallTime: 1E9}
-	ts2 := hlc.Timestamp{WallTime: 2E9}
-	val1 := mkVal(s, ts1)
-	val2 := mkVal(s, ts2)
-	valInline := mkVal(s, hlc.Timestamp{})
+			s := "string"
+			ts1 := hlc.Timestamp{WallTime: 1E9}
+			ts2 := hlc.Timestamp{WallTime: 2E9}
+			val1 := mkVal(s, ts1)
+			val2 := mkVal(s, ts2)
+			valInline := mkVal(s, hlc.Timestamp{})
 
-	testData := []struct {
-		key      roachpb.Key
-		vals     []roachpb.Value
-		expError string
-	}{
-		{roachpb.Key("a"), []roachpb.Value{val1, val2}, `request to GC non-deleted, latest value of "a"`},
-		{roachpb.Key("inline"), []roachpb.Value{valInline}, ""},
-	}
-
-	for _, test := range testData {
-		for _, val := range test.vals {
-			valCpy := *protoutil.Clone(&val).(*roachpb.Value)
-			valCpy.Timestamp = hlc.Timestamp{}
-			if err := MVCCPut(ctx, engine, nil, test.key, val.Timestamp, valCpy, nil); err != nil {
-				t.Fatal(err)
+			testData := []struct {
+				key      roachpb.Key
+				vals     []roachpb.Value
+				expError string
+			}{
+				{roachpb.Key("a"), []roachpb.Value{val1, val2}, `request to GC non-deleted, latest value of "a"`},
+				{roachpb.Key("inline"), []roachpb.Value{valInline}, ""},
 			}
-		}
-		keys := []roachpb.GCRequest_GCKey{
-			{Key: test.key, Timestamp: ts2},
-		}
-		err := MVCCGarbageCollect(ctx, engine, nil, keys, ts2)
-		if !testutils.IsError(err, test.expError) {
-			t.Fatalf("expected error %q when garbage collecting a non-deleted live value, found %v",
-				test.expError, err)
-		}
-	}
 
+			for _, test := range testData {
+				for _, val := range test.vals {
+					valCpy := *protoutil.Clone(&val).(*roachpb.Value)
+					valCpy.Timestamp = hlc.Timestamp{}
+					if err := MVCCPut(ctx, engine, nil, test.key, val.Timestamp, valCpy, nil); err != nil {
+						t.Fatal(err)
+					}
+				}
+				keys := []roachpb.GCRequest_GCKey{
+					{Key: test.key, Timestamp: ts2},
+				}
+				err := MVCCGarbageCollect(ctx, engine, nil, keys, ts2)
+				if !testutils.IsError(err, test.expError) {
+					t.Fatalf("expected error %q when garbage collecting a non-deleted live value, found %v",
+						test.expError, err)
+				}
+			}
+		})
+	}
 }
 
 // TestMVCCGarbageCollectIntent verifies that an intent cannot be GC'd.
@@ -5332,31 +5661,35 @@ func TestMVCCGarbageCollectIntent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	bytes := []byte("value")
-	ts1 := hlc.Timestamp{WallTime: 1E9}
-	ts2 := hlc.Timestamp{WallTime: 2E9}
-	key := roachpb.Key("a")
-	{
-		val1 := roachpb.MakeValueFromBytes(bytes)
-		if err := MVCCPut(ctx, engine, nil, key, ts1, val1, nil); err != nil {
-			t.Fatal(err)
-		}
-	}
-	txn := &roachpb.Transaction{
-		TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts2},
-		OrigTimestamp: ts2,
-	}
-	if err := MVCCDelete(ctx, engine, nil, key, txn.OrigTimestamp, txn); err != nil {
-		t.Fatal(err)
-	}
-	keys := []roachpb.GCRequest_GCKey{
-		{Key: key, Timestamp: ts2},
-	}
-	if err := MVCCGarbageCollect(ctx, engine, nil, keys, ts2); err == nil {
-		t.Fatal("expected error garbage collecting an intent")
+			bytes := []byte("value")
+			ts1 := hlc.Timestamp{WallTime: 1E9}
+			ts2 := hlc.Timestamp{WallTime: 2E9}
+			key := roachpb.Key("a")
+			{
+				val1 := roachpb.MakeValueFromBytes(bytes)
+				if err := MVCCPut(ctx, engine, nil, key, ts1, val1, nil); err != nil {
+					t.Fatal(err)
+				}
+			}
+			txn := &roachpb.Transaction{
+				TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts2},
+				OrigTimestamp: ts2,
+			}
+			if err := MVCCDelete(ctx, engine, nil, key, txn.OrigTimestamp, txn); err != nil {
+				t.Fatal(err)
+			}
+			keys := []roachpb.GCRequest_GCKey{
+				{Key: key, Timestamp: ts2},
+			}
+			if err := MVCCGarbageCollect(ctx, engine, nil, keys, ts2); err == nil {
+				t.Fatal("expected error garbage collecting an intent")
+			}
+		})
 	}
 }
 
@@ -5367,31 +5700,35 @@ func TestResolveIntentWithLowerEpoch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	// Lay down an intent with a high epoch.
-	if err := MVCCPut(ctx, engine, nil, testKey1, txn1e2.OrigTimestamp, value1, txn1e2); err != nil {
-		t.Fatal(err)
-	}
-	// Resolve the intent with a low epoch.
-	if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
-		Span:   roachpb.Span{Key: testKey1},
-		Status: txn1.Status,
-		Txn:    txn1.TxnMeta,
-	}); err != nil {
-		t.Fatal(err)
-	}
+			// Lay down an intent with a high epoch.
+			if err := MVCCPut(ctx, engine, nil, testKey1, txn1e2.OrigTimestamp, value1, txn1e2); err != nil {
+				t.Fatal(err)
+			}
+			// Resolve the intent with a low epoch.
+			if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
+				Span:   roachpb.Span{Key: testKey1},
+				Status: txn1.Status,
+				Txn:    txn1.TxnMeta,
+			}); err != nil {
+				t.Fatal(err)
+			}
 
-	// Check that the intent was not cleared.
-	metaKey := mvccKey(testKey1)
-	meta := &enginepb.MVCCMetadata{}
-	ok, _, _, err := engine.GetProto(metaKey, meta)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok {
-		t.Fatal("intent should not be cleared by resolve intent request with lower epoch")
+			// Check that the intent was not cleared.
+			metaKey := mvccKey(testKey1)
+			meta := &enginepb.MVCCMetadata{}
+			ok, _, _, err := engine.GetProto(metaKey, meta)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !ok {
+				t.Fatal("intent should not be cleared by resolve intent request with lower epoch")
+			}
+		})
 	}
 }
 
@@ -5401,122 +5738,126 @@ func TestMVCCIdempotentTransactions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	ts1 := hlc.Timestamp{WallTime: 1E9}
+			ts1 := hlc.Timestamp{WallTime: 1E9}
 
-	key := roachpb.Key("a")
-	value := roachpb.MakeValueFromString("first value")
-	newValue := roachpb.MakeValueFromString("second value")
-	txn := &roachpb.Transaction{
-		TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts1},
-		OrigTimestamp: ts1,
-		Status:        roachpb.PENDING,
-	}
+			key := roachpb.Key("a")
+			value := roachpb.MakeValueFromString("first value")
+			newValue := roachpb.MakeValueFromString("second value")
+			txn := &roachpb.Transaction{
+				TxnMeta:       enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: ts1},
+				OrigTimestamp: ts1,
+				Status:        roachpb.PENDING,
+			}
 
-	// Lay down an intent.
-	if err := MVCCPut(ctx, engine, nil, key, txn.OrigTimestamp, value, txn); err != nil {
-		t.Fatal(err)
-	}
+			// Lay down an intent.
+			if err := MVCCPut(ctx, engine, nil, key, txn.OrigTimestamp, value, txn); err != nil {
+				t.Fatal(err)
+			}
 
-	// Lay down an intent again with no problem because we're idempotent.
-	if err := MVCCPut(ctx, engine, nil, key, txn.OrigTimestamp, value, txn); err != nil {
-		t.Fatal(err)
-	}
+			// Lay down an intent again with no problem because we're idempotent.
+			if err := MVCCPut(ctx, engine, nil, key, txn.OrigTimestamp, value, txn); err != nil {
+				t.Fatal(err)
+			}
 
-	// Lay down an intent without increasing the sequence but with a different value.
-	if err := MVCCPut(ctx, engine, nil, key, txn.OrigTimestamp, newValue, txn); err != nil {
-		if !testutils.IsError(err, "has a different value") {
-			t.Fatal(err)
-		}
-	} else {
-		t.Fatalf("put should've failed as replay of a transaction yields a different value")
-	}
+			// Lay down an intent without increasing the sequence but with a different value.
+			if err := MVCCPut(ctx, engine, nil, key, txn.OrigTimestamp, newValue, txn); err != nil {
+				if !testutils.IsError(err, "has a different value") {
+					t.Fatal(err)
+				}
+			} else {
+				t.Fatalf("put should've failed as replay of a transaction yields a different value")
+			}
 
-	// Lay down a second intent.
-	txn.Sequence++
-	if err := MVCCPut(ctx, engine, nil, key, txn.OrigTimestamp, newValue, txn); err != nil {
-		t.Fatal(err)
-	}
+			// Lay down a second intent.
+			txn.Sequence++
+			if err := MVCCPut(ctx, engine, nil, key, txn.OrigTimestamp, newValue, txn); err != nil {
+				t.Fatal(err)
+			}
 
-	// Replay first intent without writing anything down.
-	txn.Sequence--
-	if err := MVCCPut(ctx, engine, nil, key, txn.OrigTimestamp, value, txn); err != nil {
-		t.Fatal(err)
-	}
+			// Replay first intent without writing anything down.
+			txn.Sequence--
+			if err := MVCCPut(ctx, engine, nil, key, txn.OrigTimestamp, value, txn); err != nil {
+				t.Fatal(err)
+			}
 
-	// Check that the intent meta was as expected.
-	txn.Sequence++
-	aggMeta := &enginepb.MVCCMetadata{
-		Txn:       &txn.TxnMeta,
-		Timestamp: hlc.LegacyTimestamp(ts1),
-		KeyBytes:  MVCCVersionTimestampSize,
-		ValBytes:  int64(len(newValue.RawBytes)),
-		IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
-			{Sequence: 0, Value: value.RawBytes},
-		},
-	}
-	metaKey := mvccKey(key)
-	meta := &enginepb.MVCCMetadata{}
-	ok, _, _, err := engine.GetProto(metaKey, meta)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok {
-		t.Fatal("intent should not be cleared")
-	}
-	if !meta.Equal(aggMeta) {
-		t.Errorf("expected metadata:\n%+v;\n got: \n%+v", aggMeta, meta)
-	}
-	txn.Sequence--
-	// Lay down an intent without increasing the sequence but with a different value.
-	if err := MVCCPut(ctx, engine, nil, key, txn.OrigTimestamp, newValue, txn); err != nil {
-		if !testutils.IsError(err, "has a different value") {
-			t.Fatal(err)
-		}
-	} else {
-		t.Fatalf("put should've failed as replay of a transaction yields a different value")
-	}
+			// Check that the intent meta was as expected.
+			txn.Sequence++
+			aggMeta := &enginepb.MVCCMetadata{
+				Txn:       &txn.TxnMeta,
+				Timestamp: hlc.LegacyTimestamp(ts1),
+				KeyBytes:  MVCCVersionTimestampSize,
+				ValBytes:  int64(len(newValue.RawBytes)),
+				IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
+					{Sequence: 0, Value: value.RawBytes},
+				},
+			}
+			metaKey := mvccKey(key)
+			meta := &enginepb.MVCCMetadata{}
+			ok, _, _, err := engine.GetProto(metaKey, meta)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !ok {
+				t.Fatal("intent should not be cleared")
+			}
+			if !meta.Equal(aggMeta) {
+				t.Errorf("expected metadata:\n%+v;\n got: \n%+v", aggMeta, meta)
+			}
+			txn.Sequence--
+			// Lay down an intent without increasing the sequence but with a different value.
+			if err := MVCCPut(ctx, engine, nil, key, txn.OrigTimestamp, newValue, txn); err != nil {
+				if !testutils.IsError(err, "has a different value") {
+					t.Fatal(err)
+				}
+			} else {
+				t.Fatalf("put should've failed as replay of a transaction yields a different value")
+			}
 
-	txn.Sequence--
-	// Lay down an intent with a lower sequence number to see if it detects missing intents.
-	if err := MVCCPut(ctx, engine, nil, key, txn.OrigTimestamp, newValue, txn); err != nil {
-		if !testutils.IsError(err, "missing an intent") {
-			t.Fatal(err)
-		}
-	} else {
-		t.Fatalf("put should've failed as replay of a transaction yields a different value")
-	}
-	txn.Sequence += 3
+			txn.Sequence--
+			// Lay down an intent with a lower sequence number to see if it detects missing intents.
+			if err := MVCCPut(ctx, engine, nil, key, txn.OrigTimestamp, newValue, txn); err != nil {
+				if !testutils.IsError(err, "missing an intent") {
+					t.Fatal(err)
+				}
+			} else {
+				t.Fatalf("put should've failed as replay of a transaction yields a different value")
+			}
+			txn.Sequence += 3
 
-	// on a separate key, start an increment.
-	val, err := MVCCIncrement(ctx, engine, nil, testKey1, txn.OrigTimestamp, txn, 1)
-	if val != 1 || err != nil {
-		t.Fatalf("expected val=1 (got %d): %+v", val, err)
-	}
-	// As long as the sequence in unchanged, replaying the increment doesn't
-	// increase the value.
-	for i := 0; i < 10; i++ {
-		val, err = MVCCIncrement(ctx, engine, nil, testKey1, txn.OrigTimestamp, txn, 1)
-		if val != 1 || err != nil {
-			t.Fatalf("expected val=1 (got %d): %+v", val, err)
-		}
-	}
+			// on a separate key, start an increment.
+			val, err := MVCCIncrement(ctx, engine, nil, testKey1, txn.OrigTimestamp, txn, 1)
+			if val != 1 || err != nil {
+				t.Fatalf("expected val=1 (got %d): %+v", val, err)
+			}
+			// As long as the sequence in unchanged, replaying the increment doesn't
+			// increase the value.
+			for i := 0; i < 10; i++ {
+				val, err = MVCCIncrement(ctx, engine, nil, testKey1, txn.OrigTimestamp, txn, 1)
+				if val != 1 || err != nil {
+					t.Fatalf("expected val=1 (got %d): %+v", val, err)
+				}
+			}
 
-	// Increment again.
-	txn.Sequence++
-	val, err = MVCCIncrement(ctx, engine, nil, testKey1, txn.OrigTimestamp, txn, 1)
-	if val != 2 || err != nil {
-		t.Fatalf("expected val=2 (got %d): %+v", val, err)
-	}
-	txn.Sequence--
-	// Replaying an older increment doesn't increase the value.
-	for i := 0; i < 10; i++ {
-		val, err = MVCCIncrement(ctx, engine, nil, testKey1, txn.OrigTimestamp, txn, 1)
-		if val != 1 || err != nil {
-			t.Fatalf("expected val=1 (got %d): %+v", val, err)
-		}
+			// Increment again.
+			txn.Sequence++
+			val, err = MVCCIncrement(ctx, engine, nil, testKey1, txn.OrigTimestamp, txn, 1)
+			if val != 2 || err != nil {
+				t.Fatalf("expected val=2 (got %d): %+v", val, err)
+			}
+			txn.Sequence--
+			// Replaying an older increment doesn't increase the value.
+			for i := 0; i < 10; i++ {
+				val, err = MVCCIncrement(ctx, engine, nil, testKey1, txn.OrigTimestamp, txn, 1)
+				if val != 1 || err != nil {
+					t.Fatalf("expected val=1 (got %d): %+v", val, err)
+				}
+			}
+		})
 	}
 }
 
@@ -5526,259 +5867,263 @@ func TestMVCCIntentHistory(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	ts0 := hlc.Timestamp{WallTime: 1E9}
-	ts1 := hlc.Timestamp{WallTime: 2 * 1E9}
-	ts2 := hlc.Timestamp{WallTime: 3 * 1E9}
+			ts0 := hlc.Timestamp{WallTime: 1E9}
+			ts1 := hlc.Timestamp{WallTime: 2 * 1E9}
+			ts2 := hlc.Timestamp{WallTime: 3 * 1E9}
 
-	key := roachpb.Key("a")
-	defaultValue := roachpb.MakeValueFromString("default")
-	value := roachpb.MakeValueFromString("first value")
-	newValue := roachpb.MakeValueFromString("second value")
-	txn := &roachpb.Transaction{
-		TxnMeta: enginepb.TxnMeta{
-			ID:        uuid.MakeV4(),
-			Timestamp: ts0,
-			Sequence:  1,
-		},
-		OrigTimestamp: ts0,
-		Status:        roachpb.PENDING,
-	}
+			key := roachpb.Key("a")
+			defaultValue := roachpb.MakeValueFromString("default")
+			value := roachpb.MakeValueFromString("first value")
+			newValue := roachpb.MakeValueFromString("second value")
+			txn := &roachpb.Transaction{
+				TxnMeta: enginepb.TxnMeta{
+					ID:        uuid.MakeV4(),
+					Timestamp: ts0,
+					Sequence:  1,
+				},
+				OrigTimestamp: ts0,
+				Status:        roachpb.PENDING,
+			}
 
-	// Lay down a default value on the key.
-	if err := MVCCPut(ctx, engine, nil, key, ts0, defaultValue, txn); err != nil {
-		t.Fatal(err)
-	}
-	// Resolve the intent so we can use another transaction on this key.
-	if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
-		Span:   roachpb.Span{Key: key},
-		Status: roachpb.COMMITTED,
-		Txn:    txn.TxnMeta,
-	}); err != nil {
-		t.Fatal(err)
-	}
+			// Lay down a default value on the key.
+			if err := MVCCPut(ctx, engine, nil, key, ts0, defaultValue, txn); err != nil {
+				t.Fatal(err)
+			}
+			// Resolve the intent so we can use another transaction on this key.
+			if err := MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
+				Span:   roachpb.Span{Key: key},
+				Status: roachpb.COMMITTED,
+				Txn:    txn.TxnMeta,
+			}); err != nil {
+				t.Fatal(err)
+			}
 
-	// Start a new transaction for the test.
-	txn = &roachpb.Transaction{
-		TxnMeta: enginepb.TxnMeta{
-			ID:        uuid.MakeV4(),
-			Timestamp: ts1,
-			Sequence:  1,
-		},
-		OrigTimestamp: ts1,
-		Status:        roachpb.PENDING,
-	}
+			// Start a new transaction for the test.
+			txn = &roachpb.Transaction{
+				TxnMeta: enginepb.TxnMeta{
+					ID:        uuid.MakeV4(),
+					Timestamp: ts1,
+					Sequence:  1,
+				},
+				OrigTimestamp: ts1,
+				Status:        roachpb.PENDING,
+			}
 
-	// Lay down an intent.
-	if err := MVCCPut(ctx, engine, nil, key, txn.OrigTimestamp, value, txn); err != nil {
-		t.Fatal(err)
-	}
+			// Lay down an intent.
+			if err := MVCCPut(ctx, engine, nil, key, txn.OrigTimestamp, value, txn); err != nil {
+				t.Fatal(err)
+			}
 
-	// Check that the intent meta was found.
-	aggMeta := &enginepb.MVCCMetadata{
-		Txn:       &txn.TxnMeta,
-		Timestamp: hlc.LegacyTimestamp(ts1),
-		KeyBytes:  MVCCVersionTimestampSize,
-		ValBytes:  int64(len(value.RawBytes)),
-	}
-	metaKey := mvccKey(key)
-	meta := &enginepb.MVCCMetadata{}
-	ok, _, _, err := engine.GetProto(metaKey, meta)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok {
-		t.Fatal("intent should not be cleared")
-	}
-	if !meta.Equal(aggMeta) {
-		t.Errorf("expected metadata:\n%+v;\n got: \n%+v", aggMeta, meta)
-	}
+			// Check that the intent meta was found.
+			aggMeta := &enginepb.MVCCMetadata{
+				Txn:       &txn.TxnMeta,
+				Timestamp: hlc.LegacyTimestamp(ts1),
+				KeyBytes:  MVCCVersionTimestampSize,
+				ValBytes:  int64(len(value.RawBytes)),
+			}
+			metaKey := mvccKey(key)
+			meta := &enginepb.MVCCMetadata{}
+			ok, _, _, err := engine.GetProto(metaKey, meta)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !ok {
+				t.Fatal("intent should not be cleared")
+			}
+			if !meta.Equal(aggMeta) {
+				t.Errorf("expected metadata:\n%+v;\n got: \n%+v", aggMeta, meta)
+			}
 
-	// Lay down an overriding intent with a higher sequence.
-	txn.Sequence = 2
-	txn.Timestamp = ts2
-	if err := MVCCPut(ctx, engine, nil, key, txn.OrigTimestamp, newValue, txn); err != nil {
-		t.Fatal(err)
-	}
+			// Lay down an overriding intent with a higher sequence.
+			txn.Sequence = 2
+			txn.Timestamp = ts2
+			if err := MVCCPut(ctx, engine, nil, key, txn.OrigTimestamp, newValue, txn); err != nil {
+				t.Fatal(err)
+			}
 
-	// Check that intent history is recorded when the value is overridden by the same transaction.
-	aggMeta = &enginepb.MVCCMetadata{
-		Txn:       &txn.TxnMeta,
-		Timestamp: hlc.LegacyTimestamp(ts2),
-		KeyBytes:  MVCCVersionTimestampSize,
-		ValBytes:  int64(len(newValue.RawBytes)),
-		IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
-			{Sequence: 1, Value: value.RawBytes},
-		},
-	}
-	ok, _, _, err = engine.GetProto(metaKey, meta)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok {
-		t.Fatal("intent should not be cleared")
-	}
-	if !meta.Equal(aggMeta) {
-		t.Errorf("expected metadata:\n%+v;\n got: \n%+v", aggMeta, meta)
-	}
+			// Check that intent history is recorded when the value is overridden by the same transaction.
+			aggMeta = &enginepb.MVCCMetadata{
+				Txn:       &txn.TxnMeta,
+				Timestamp: hlc.LegacyTimestamp(ts2),
+				KeyBytes:  MVCCVersionTimestampSize,
+				ValBytes:  int64(len(newValue.RawBytes)),
+				IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
+					{Sequence: 1, Value: value.RawBytes},
+				},
+			}
+			ok, _, _, err = engine.GetProto(metaKey, meta)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !ok {
+				t.Fatal("intent should not be cleared")
+			}
+			if !meta.Equal(aggMeta) {
+				t.Errorf("expected metadata:\n%+v;\n got: \n%+v", aggMeta, meta)
+			}
 
-	// Lay down a deletion intent with a higher sequence.
-	txn.Sequence = 4
-	if err := MVCCDelete(ctx, engine, nil, key, txn.OrigTimestamp, txn); err != nil {
-		t.Fatal(err)
-	}
+			// Lay down a deletion intent with a higher sequence.
+			txn.Sequence = 4
+			if err := MVCCDelete(ctx, engine, nil, key, txn.OrigTimestamp, txn); err != nil {
+				t.Fatal(err)
+			}
 
-	// Check that intent history is recorded when the value is overridden by the same transaction.
-	aggMeta = &enginepb.MVCCMetadata{
-		Txn:       &txn.TxnMeta,
-		Timestamp: hlc.LegacyTimestamp(ts2),
-		KeyBytes:  MVCCVersionTimestampSize,
-		ValBytes:  0,
-		Deleted:   true,
-		IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
-			{Sequence: 1, Value: value.RawBytes},
-			{Sequence: 2, Value: newValue.RawBytes},
-		},
-	}
-	ok, _, _, err = engine.GetProto(metaKey, meta)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok {
-		t.Fatal("intent should not be cleared")
-	}
-	if !meta.Equal(aggMeta) {
-		t.Errorf("expected metadata:\n%+v;\n got: \n%+v", aggMeta, meta)
-	}
+			// Check that intent history is recorded when the value is overridden by the same transaction.
+			aggMeta = &enginepb.MVCCMetadata{
+				Txn:       &txn.TxnMeta,
+				Timestamp: hlc.LegacyTimestamp(ts2),
+				KeyBytes:  MVCCVersionTimestampSize,
+				ValBytes:  0,
+				Deleted:   true,
+				IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
+					{Sequence: 1, Value: value.RawBytes},
+					{Sequence: 2, Value: newValue.RawBytes},
+				},
+			}
+			ok, _, _, err = engine.GetProto(metaKey, meta)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !ok {
+				t.Fatal("intent should not be cleared")
+			}
+			if !meta.Equal(aggMeta) {
+				t.Errorf("expected metadata:\n%+v;\n got: \n%+v", aggMeta, meta)
+			}
 
-	// Lay down another intent with a higher sequence to see if history accurately captures deletes.
-	txn.Sequence = 6
-	if err := MVCCPut(ctx, engine, nil, key, txn.OrigTimestamp, value, txn); err != nil {
-		t.Fatal(err)
-	}
+			// Lay down another intent with a higher sequence to see if history accurately captures deletes.
+			txn.Sequence = 6
+			if err := MVCCPut(ctx, engine, nil, key, txn.OrigTimestamp, value, txn); err != nil {
+				t.Fatal(err)
+			}
 
-	// Check that intent history is recorded when the value is overridden by the same transaction.
-	aggMeta = &enginepb.MVCCMetadata{
-		Txn:       &txn.TxnMeta,
-		Timestamp: hlc.LegacyTimestamp(ts2),
-		KeyBytes:  MVCCVersionTimestampSize,
-		ValBytes:  int64(len(value.RawBytes)),
-		IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
-			{Sequence: 1, Value: value.RawBytes},
-			{Sequence: 2, Value: newValue.RawBytes},
-			{Sequence: 4, Value: noValue.RawBytes},
-		},
-	}
-	ok, _, _, err = engine.GetProto(metaKey, meta)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok {
-		t.Fatal("intent should not be cleared")
-	}
-	if !meta.Equal(aggMeta) {
-		t.Errorf("expected metadata:\n%+v;\n got: \n%+v", aggMeta, meta)
-	}
+			// Check that intent history is recorded when the value is overridden by the same transaction.
+			aggMeta = &enginepb.MVCCMetadata{
+				Txn:       &txn.TxnMeta,
+				Timestamp: hlc.LegacyTimestamp(ts2),
+				KeyBytes:  MVCCVersionTimestampSize,
+				ValBytes:  int64(len(value.RawBytes)),
+				IntentHistory: []enginepb.MVCCMetadata_SequencedIntent{
+					{Sequence: 1, Value: value.RawBytes},
+					{Sequence: 2, Value: newValue.RawBytes},
+					{Sequence: 4, Value: noValue.RawBytes},
+				},
+			}
+			ok, _, _, err = engine.GetProto(metaKey, meta)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !ok {
+				t.Fatal("intent should not be cleared")
+			}
+			if !meta.Equal(aggMeta) {
+				t.Errorf("expected metadata:\n%+v;\n got: \n%+v", aggMeta, meta)
+			}
 
-	// Assert that the latest read should find the latest write.
-	foundVal, _, err := MVCCGet(ctx, engine, key, ts2, MVCCGetOptions{Txn: txn})
-	if err != nil {
-		t.Fatalf("MVCCGet failed with error: %+v", err)
-	}
-	if !bytes.Equal(foundVal.RawBytes, value.RawBytes) {
-		t.Fatalf("MVCCGet failed: expected %v but got %v", value.RawBytes, foundVal.RawBytes)
-	}
+			// Assert that the latest read should find the latest write.
+			foundVal, _, err := MVCCGet(ctx, engine, key, ts2, MVCCGetOptions{Txn: txn})
+			if err != nil {
+				t.Fatalf("MVCCGet failed with error: %+v", err)
+			}
+			if !bytes.Equal(foundVal.RawBytes, value.RawBytes) {
+				t.Fatalf("MVCCGet failed: expected %v but got %v", value.RawBytes, foundVal.RawBytes)
+			}
 
-	// Assert than an older read sequence gets an older versioned intent.
-	txn.Sequence = 3
-	foundVal, _, err = MVCCGet(ctx, engine, key, ts2, MVCCGetOptions{Txn: txn})
-	if err != nil {
-		t.Fatalf("MVCCGet failed with error: %+v", err)
-	}
-	if !bytes.Equal(foundVal.RawBytes, newValue.RawBytes) {
-		t.Fatalf("MVCCGet failed: expected %v but got %v", newValue.RawBytes, foundVal.RawBytes)
-	}
+			// Assert than an older read sequence gets an older versioned intent.
+			txn.Sequence = 3
+			foundVal, _, err = MVCCGet(ctx, engine, key, ts2, MVCCGetOptions{Txn: txn})
+			if err != nil {
+				t.Fatalf("MVCCGet failed with error: %+v", err)
+			}
+			if !bytes.Equal(foundVal.RawBytes, newValue.RawBytes) {
+				t.Fatalf("MVCCGet failed: expected %v but got %v", newValue.RawBytes, foundVal.RawBytes)
+			}
 
-	// Assert than an older scan sequence gets an older versioned intent.
-	kvs, _, _, err := MVCCScan(ctx, engine, key, key.Next(), math.MaxInt64, ts2, MVCCScanOptions{Txn: txn})
-	if err != nil {
-		t.Fatalf("MVCCScan failed with error: %+v", err)
-	}
-	if len(kvs) != 1 {
-		t.Fatalf("MVCCScan did not find exactly 1 key: %+v", kvs)
-	}
-	if !bytes.Equal(kvs[0].Value.RawBytes, newValue.RawBytes) {
-		t.Fatalf("MVCCScan failed: expected %v but got %v", newValue.RawBytes, foundVal.RawBytes)
-	}
+			// Assert than an older scan sequence gets an older versioned intent.
+			kvs, _, _, err := MVCCScan(ctx, engine, key, key.Next(), math.MaxInt64, ts2, MVCCScanOptions{Txn: txn})
+			if err != nil {
+				t.Fatalf("MVCCScan failed with error: %+v", err)
+			}
+			if len(kvs) != 1 {
+				t.Fatalf("MVCCScan did not find exactly 1 key: %+v", kvs)
+			}
+			if !bytes.Equal(kvs[0].Value.RawBytes, newValue.RawBytes) {
+				t.Fatalf("MVCCScan failed: expected %v but got %v", newValue.RawBytes, foundVal.RawBytes)
+			}
 
-	// Assert than an older read sequence gets no value if the value was deleted.
-	txn.Sequence = 4
-	foundVal, _, err = MVCCGet(ctx, engine, key, ts2, MVCCGetOptions{Txn: txn})
-	if err != nil {
-		t.Fatalf("MVCCGet failed with error: %+v", err)
-	}
-	if foundVal != nil {
-		t.Fatalf("MVCCGet at sequence %d found unexpected value", txn.Sequence)
-	}
+			// Assert than an older read sequence gets no value if the value was deleted.
+			txn.Sequence = 4
+			foundVal, _, err = MVCCGet(ctx, engine, key, ts2, MVCCGetOptions{Txn: txn})
+			if err != nil {
+				t.Fatalf("MVCCGet failed with error: %+v", err)
+			}
+			if foundVal != nil {
+				t.Fatalf("MVCCGet at sequence %d found unexpected value", txn.Sequence)
+			}
 
-	// Assert than an older scan sequence gets no value if the value was deleted.
-	kvs, _, _, err = MVCCScan(ctx, engine, key, key.Next(), math.MaxInt64, ts2, MVCCScanOptions{Txn: txn})
-	if err != nil {
-		t.Fatalf("MVCCScan failed with error: %+v", err)
-	}
-	if len(kvs) != 0 {
-		t.Fatalf("MVCCScan at sequence %d found unexpected values: %+v", txn.Sequence, kvs)
-	}
+			// Assert than an older scan sequence gets no value if the value was deleted.
+			kvs, _, _, err = MVCCScan(ctx, engine, key, key.Next(), math.MaxInt64, ts2, MVCCScanOptions{Txn: txn})
+			if err != nil {
+				t.Fatalf("MVCCScan failed with error: %+v", err)
+			}
+			if len(kvs) != 0 {
+				t.Fatalf("MVCCScan at sequence %d found unexpected values: %+v", txn.Sequence, kvs)
+			}
 
-	// Assert than an older read sequence gets a value if the value was deleted
-	// but we're including tombstones in our search.
-	foundVal, _, err = MVCCGet(ctx, engine, key, ts2, MVCCGetOptions{Txn: txn, Tombstones: true})
-	if err != nil {
-		t.Fatalf("MVCCGet failed with error: %+v", err)
-	}
-	if foundVal == nil || foundVal.IsPresent() {
-		t.Fatalf("MVCCGet at sequence %d did not find tombstone", txn.Sequence)
-	}
+			// Assert than an older read sequence gets a value if the value was deleted
+			// but we're including tombstones in our search.
+			foundVal, _, err = MVCCGet(ctx, engine, key, ts2, MVCCGetOptions{Txn: txn, Tombstones: true})
+			if err != nil {
+				t.Fatalf("MVCCGet failed with error: %+v", err)
+			}
+			if foundVal == nil || foundVal.IsPresent() {
+				t.Fatalf("MVCCGet at sequence %d did not find tombstone", txn.Sequence)
+			}
 
-	// Assert than an older scan sequence gets a value if the value was deleted
-	// but we're including tombstones in our search.
-	kvs, _, _, err = MVCCScan(ctx, engine, key, key.Next(), math.MaxInt64, ts2, MVCCScanOptions{Txn: txn, Tombstones: true})
-	if err != nil {
-		t.Fatalf("MVCCScan failed with error: %+v", err)
-	}
-	if len(kvs) != 1 || kvs[0].Value.IsPresent() {
-		t.Fatalf("MVCCScan at sequence %d did not find tombstone: %+v", txn.Sequence, kvs)
-	}
+			// Assert than an older scan sequence gets a value if the value was deleted
+			// but we're including tombstones in our search.
+			kvs, _, _, err = MVCCScan(ctx, engine, key, key.Next(), math.MaxInt64, ts2, MVCCScanOptions{Txn: txn, Tombstones: true})
+			if err != nil {
+				t.Fatalf("MVCCScan failed with error: %+v", err)
+			}
+			if len(kvs) != 1 || kvs[0].Value.IsPresent() {
+				t.Fatalf("MVCCScan at sequence %d did not find tombstone: %+v", txn.Sequence, kvs)
+			}
 
-	// Assert that the last committed value is found if the sequence is lower than any
-	// write from the current transaction.
-	txn.Sequence = 0
-	foundVal, _, err = MVCCGet(ctx, engine, key, ts2, MVCCGetOptions{Txn: txn})
-	if err != nil {
-		t.Fatalf("MVCCGet failed with error: %+v", err)
-	}
-	if !bytes.Equal(foundVal.RawBytes, defaultValue.RawBytes) {
-		t.Fatalf("MVCCGet failed: expected %v but got %v", defaultValue.RawBytes, foundVal.RawBytes)
-	}
+			// Assert that the last committed value is found if the sequence is lower than any
+			// write from the current transaction.
+			txn.Sequence = 0
+			foundVal, _, err = MVCCGet(ctx, engine, key, ts2, MVCCGetOptions{Txn: txn})
+			if err != nil {
+				t.Fatalf("MVCCGet failed with error: %+v", err)
+			}
+			if !bytes.Equal(foundVal.RawBytes, defaultValue.RawBytes) {
+				t.Fatalf("MVCCGet failed: expected %v but got %v", defaultValue.RawBytes, foundVal.RawBytes)
+			}
 
-	// Resolve the intent.
-	if err = MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
-		Span:   roachpb.Span{Key: key},
-		Status: roachpb.COMMITTED,
-		Txn:    txn.TxnMeta,
-	}); err != nil {
-		t.Fatal(err)
-	}
+			// Resolve the intent.
+			if err = MVCCResolveWriteIntent(ctx, engine, nil, roachpb.Intent{
+				Span:   roachpb.Span{Key: key},
+				Status: roachpb.COMMITTED,
+				Txn:    txn.TxnMeta,
+			}); err != nil {
+				t.Fatal(err)
+			}
 
-	// Check that the intent was cleared.
-	ok, _, _, err = engine.GetProto(metaKey, meta)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ok {
-		t.Fatal("intent should have been cleared")
+			// Check that the intent was cleared.
+			ok, _, _, err = engine.GetProto(metaKey, meta)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if ok {
+				t.Fatal("intent should have been cleared")
+			}
+		})
 	}
 }
 
@@ -5788,57 +6133,65 @@ func TestMVCCTimeSeriesPartialMerge(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	engine := createTestEngine()
-	defer engine.Close()
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(*testing.T) {
+			engine := engineImpl.create()
+			defer engine.Close()
 
-	// Perform the same sequence of merges on two different keys. For
-	// one of them, insert some compactions which cause partial merges
-	// to be run and affect the results.
-	vals := make([]*roachpb.Value, 2)
+			// Perform the same sequence of merges on two different keys. For
+			// one of them, insert some compactions which cause partial merges
+			// to be run and affect the results.
+			vals := make([]*roachpb.Value, 2)
 
-	for i, k := range []roachpb.Key{testKey1, testKey2} {
-		if err := MVCCMerge(ctx, engine, nil, k, hlc.Timestamp{Logical: 1}, tsvalue1); err != nil {
-			t.Fatal(err)
-		}
-		if err := MVCCMerge(ctx, engine, nil, k, hlc.Timestamp{Logical: 2}, tsvalue2); err != nil {
-			t.Fatal(err)
-		}
+			for i, k := range []roachpb.Key{testKey1, testKey2} {
+				if err := MVCCMerge(ctx, engine, nil, k, hlc.Timestamp{Logical: 1}, tsvalue1); err != nil {
+					t.Fatal(err)
+				}
+				if err := MVCCMerge(ctx, engine, nil, k, hlc.Timestamp{Logical: 2}, tsvalue2); err != nil {
+					t.Fatal(err)
+				}
 
-		if i == 1 {
-			if err := engine.(InMem).Compact(); err != nil {
-				t.Fatal(err)
+				if i == 1 {
+					if eng, ok := engine.(InMem); ok {
+						if err := eng.Compact(); err != nil {
+							t.Fatal(err)
+						}
+					}
+				}
+
+				if err := MVCCMerge(ctx, engine, nil, k, hlc.Timestamp{Logical: 2}, tsvalue2); err != nil {
+					t.Fatal(err)
+				}
+				if err := MVCCMerge(ctx, engine, nil, k, hlc.Timestamp{Logical: 1}, tsvalue1); err != nil {
+					t.Fatal(err)
+				}
+
+				if i == 1 {
+					if eng, ok := engine.(InMem); ok {
+						if err := eng.Compact(); err != nil {
+							t.Fatal(err)
+						}
+					}
+				}
+
+				if v, _, err := MVCCGet(ctx, engine, k, hlc.Timestamp{}, MVCCGetOptions{}); err != nil {
+					t.Fatal(err)
+				} else {
+					vals[i] = v
+				}
 			}
-		}
 
-		if err := MVCCMerge(ctx, engine, nil, k, hlc.Timestamp{Logical: 2}, tsvalue2); err != nil {
-			t.Fatal(err)
-		}
-		if err := MVCCMerge(ctx, engine, nil, k, hlc.Timestamp{Logical: 1}, tsvalue1); err != nil {
-			t.Fatal(err)
-		}
-
-		if i == 1 {
-			if err := engine.(InMem).Compact(); err != nil {
-				t.Fatal(err)
+			if first, second := vals[0], vals[1]; !proto.Equal(first, second) {
+				var firstTS, secondTS roachpb.InternalTimeSeriesData
+				if err := first.GetProto(&firstTS); err != nil {
+					t.Fatal(err)
+				}
+				if err := second.GetProto(&secondTS); err != nil {
+					t.Fatal(err)
+				}
+				t.Fatalf("partially merged value %v differed from expected merged value %v", secondTS, firstTS)
 			}
-		}
-
-		if v, _, err := MVCCGet(ctx, engine, k, hlc.Timestamp{}, MVCCGetOptions{}); err != nil {
-			t.Fatal(err)
-		} else {
-			vals[i] = v
-		}
-	}
-
-	if first, second := vals[0], vals[1]; !proto.Equal(first, second) {
-		var firstTS, secondTS roachpb.InternalTimeSeriesData
-		if err := first.GetProto(&firstTS); err != nil {
-			t.Fatal(err)
-		}
-		if err := second.GetProto(&secondTS); err != nil {
-			t.Fatal(err)
-		}
-		t.Fatalf("partially merged value %v differed from expected merged value %v", secondTS, firstTS)
+		})
 	}
 }
 

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -336,7 +336,7 @@ func makeKey(i int) MVCCKey {
 }
 
 func benchmarkIterOnBatch(ctx context.Context, b *testing.B, writes int) {
-	engine := createTestEngine()
+	engine := createTestRocksDBEngine()
 	defer engine.Close()
 
 	for i := 0; i < writes; i++ {
@@ -368,7 +368,7 @@ func benchmarkIterOnBatch(ctx context.Context, b *testing.B, writes int) {
 func benchmarkIterOnReadWriter(
 	ctx context.Context, b *testing.B, writes int, f func(Engine) ReadWriter, closeReadWriter bool,
 ) {
-	engine := createTestEngine()
+	engine := createTestRocksDBEngine()
 	defer engine.Close()
 
 	for i := 0; i < writes; i++ {


### PR DESCRIPTION
This commit updates MVCC tests to run on both pebble and rocksdb
in-memory test engines. Most of the diff is a simple repetitive
refactor.

The first commit is #41199, and the second commit is #41452 . This PR relies on both changes to land first. Only review the latest commit in this PR.

Release note: None