### PR TITLE
kv: use better OrigTimestampWasObserved signal

### DIFF
--- a/pkg/kv/txn_interceptor_span_refresher.go
+++ b/pkg/kv/txn_interceptor_span_refresher.go
@@ -232,6 +232,9 @@ func (sr *txnSpanRefresher) maybeRetrySend(
 	pErr *roachpb.Error,
 	maxRefreshAttempts int,
 ) (*roachpb.BatchResponse, *roachpb.Error, hlc.Timestamp) {
+	if ba.Txn.OrigTimestampWasObserved {
+		return nil, pErr, hlc.Timestamp{}
+	}
 	// Check for an error which can be retried after updating spans.
 	canRetryTxn, retryTxn := roachpb.CanTransactionRetryAtRefreshedTimestamp(ctx, pErr)
 	if !canRetryTxn || !sr.canAutoRetry {

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1281,7 +1281,7 @@ func CanTransactionRetryAtRefreshedTimestamp(
 	ctx context.Context, pErr *Error,
 ) (bool, *Transaction) {
 	txn := pErr.GetTxn()
-	if txn == nil || txn.OrigTimestampWasObserved {
+	if txn == nil {
 		return false, nil
 	}
 	timestamp := txn.Timestamp


### PR DESCRIPTION
Before this patch, refreshes were inhibited when
pErr.Txn.OrigTimestampWasObserver was set. It's fragile at best to rely
on that bit being set on the response. This patch moves to checking the
bit on the request.

The best txn to look at would be the TxnCoordSender's Txn proto, but
that's not conveniently exposed to the txnSpanRefresher. Looking at the
request should be equivalent absent concurrent requests.

Release note: None