### PR TITLE
storage/engine: call EnsureDefaults on the global readerOpts

### DIFF
--- a/pkg/storage/engine/sst_iterator.go
+++ b/pkg/storage/engine/sst_iterator.go
@@ -20,9 +20,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-var readerOpts = &sstable.Options{
-	Comparer: MVCCComparer,
-}
+var readerOpts = func() *sstable.Options {
+	opts := &sstable.Options{
+		Comparer: MVCCComparer,
+	}
+	return opts.EnsureDefaults()
+}()
 
 type sstIterator struct {
 	sst  *sstable.Reader


### PR DESCRIPTION
Fixes race failure when multiple threads try to call
`readerOpts.EnsureDefaults` concurrently.

Release note: None