### PR TITLE
backup,import: remove sticky-bit conditional

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -798,22 +798,6 @@ func (r *importResumer) Resume(
 		}
 	}
 
-	// TODO(jeffreyxiao): Remove this check in 20.1.
-	// If the cluster supports sticky bits, then we don't have to worry about the
-	// merge queue automatically merging the splits performed during IMPORT.
-	// Otherwise, we have to rely on the gossip mechanism to disable the merge
-	// queue for the table IDs being imported into.
-	stickyBitEnabled := r.settings.Version.IsActive(cluster.VersionStickyBit)
-	if !stickyBitEnabled {
-		tableIDs := make([]uint32, 0, len(tables))
-		for _, t := range tables {
-			tableIDs = append(tableIDs, uint32(t.Desc.ID))
-		}
-		disableCtx, cancel := context.WithCancel(ctx)
-		defer cancel()
-		p.ExecCfg().Gossip.DisableMerges(disableCtx, tableIDs)
-	}
-
 	walltime := details.Walltime
 	files := details.URIs
 	format := details.Format

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1260,20 +1260,7 @@ func (sc *SchemaChanger) backfillIndexes(
 		fn()
 	}
 
-	// TODO(jeffreyxiao): Remove check in 20.1.
-	// If the cluster supports sticky bits, then we should use the sticky bit to
-	// ensure that the splits are not automatically split by the merge queue. If
-	// the cluster does not support sticky bits, we disable the merge queue via
-	// gossip, so we can just set the split to expire immediately.
-	stickyBitEnabled := sc.execCfg.Settings.Version.IsActive(cluster.VersionStickyBit)
-	expirationTime := hlc.Timestamp{}
-	if !stickyBitEnabled {
-		disableCtx, cancel := context.WithCancel(ctx)
-		defer cancel()
-		sc.execCfg.Gossip.DisableMerges(disableCtx, []uint32{uint32(sc.tableID)})
-	} else {
-		expirationTime = sc.db.Clock().Now().Add(time.Hour.Nanoseconds(), 0)
-	}
+	expirationTime := sc.db.Clock().Now().Add(time.Hour.Nanoseconds(), 0)
 
 	for _, span := range addingSpans {
 		if err := sc.db.AdminSplit(ctx, span.Key, span.Key, expirationTime); err != nil {


### PR DESCRIPTION
Sticky-bit is always enabled in 20.1.

Release note: none.