### PR TITLE
Fix yarn on Debian based distributions as well

### DIFF
--- a/build/variables.mk
+++ b/build/variables.mk
@@ -161,5 +161,6 @@ define VALID_VARS
   XCXX
   XGOARCH
   XGOOS
+  YARNCMD
   prefix
 endef


### PR DESCRIPTION
On Debian based distributions there is a package called `cmdtest`
which provides a `yarn` command. Unrelated to the javascript command.

To be able to install both packages without conflict the javascript yarn
command is called `yarnpkg`.

This commit makes the Makefile detect if there is a `yarnpkg` in the path
and in that case use that instead of `yarn`.