### PR TITLE
storage/engine: pull in Pebble batch optimizations

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -427,7 +427,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:8691c0cd3246e045a951b907e94af1165904d663a4ce0013c4650751643a8945"
+  digest = "1:eb5b95cb849809eecc0f19778ea2b79d9c892208f4c57741b25102d2ceba9fa6"
   name = "github.com/cockroachdb/pebble"
   packages = [
     ".",
@@ -450,7 +450,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "b8525550fbb0604c22fbf7879e836d44e5233272"
+  revision = "edde981dcc258907bdcc010017d1a7ccc6b59174"
 
 [[projects]]
   branch = "master"

--- a/pkg/storage/engine/batch_test.go
+++ b/pkg/storage/engine/batch_test.go
@@ -302,14 +302,12 @@ func TestBatchRepr(t *testing.T) {
 
 		// The keys in the batch have the internal MVCC encoding applied which for
 		// this test implies an appended 0 byte.
-		// TODO(itsbilal): Treat SingleDeletions as Deletions until pebble.Batch
-		// works with SingleDelete.
 		expOps := []string{
 			"put(a\x00,value)",
 			"delete(b\x00)",
 			"merge(c\x00)",
 			"put(e\x00,)",
-			"delete(d\x00)",
+			"single_delete(d\x00)",
 		}
 		if !reflect.DeepEqual(expOps, ops) {
 			t.Fatalf("expected %v, but found %v", expOps, ops)


### PR DESCRIPTION
Fix the performance regressions in the `BatchApplyRepr` and
`BatchBuilderPut` benchmarks.

Minor reorg to how keys are encoded into a batch. The big win was from
not computing the encoded length of an `MVCCKey` twice.

Use binary.BigEndian.PutUint{32,64}. The stdlib versions are slightly
faster than our custom versions because they have a hack to minimize
bounds checks.

Comparison vs master:

```
name                                                                    old time/op    new time/op     delta
BatchApplyBatchRepr/writeOnly=false_/valueSize=10/batchSize=1000000-16    36.2ms ± 3%      3.0ms ± 8%    -91.77%  (p=0.000 n=10+9)
BatchApplyBatchRepr/writeOnly=true_/valueSize=10/batchSize=1000000-16     35.5ms ± 1%      2.9ms ± 7%    -91.80%  (p=0.000 n=8+10)
BatchBuilderPut-16                                                        38.1ns ± 5%     29.2ns ± 5%    -23.37%  (p=0.000 n=10+10)
```

Comparison vs v19.1.5:

```
name                                                                    old time/op    new time/op     delta
BatchApplyBatchRepr/writeOnly=false_/valueSize=10/batchSize=1000000-16    5.28ms ±13%     2.98ms ± 8%  -43.68%  (p=0.000 n=10+9)
BatchApplyBatchRepr/writeOnly=true_/valueSize=10/batchSize=1000000-16     5.10ms ±11%     2.91ms ± 7%  -42.83%  (p=0.000 n=10+10)
BatchBuilderPut-16                                                        29.8ns ± 1%     29.2ns ± 5%     ~     (p=0.050 n=9+10)
```

Release note: None