### PR TITLE
roachtest: fix line break and quoting in hibernate tests

### DIFF
--- a/pkg/cmd/roachtest/hibernate.go
+++ b/pkg/cmd/roachtest/hibernate.go
@@ -42,8 +42,8 @@ func registerHibernate(r *testRegistry) {
 			c,
 			node,
 			"change database replication and GC time",
-			`./cockroach sql --insecure -e
-        'ALTER RANGE default CONFIGURE ZONE USING num_replicas = 1, gc.ttlseconds = 120;'`,
+			`./cockroach sql --insecure -e `+
+				`"ALTER RANGE default CONFIGURE ZONE USING num_replicas = 1, gc.ttlseconds = 120;"`,
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -52,8 +52,8 @@ func registerHibernate(r *testRegistry) {
 			c,
 			node,
 			"change database replication and GC time",
-			`./cockroach sql --insecure -e
-        'ALTER DATABASE system CONFIGURE ZONE USING num_replicas = 1, gc.ttlseconds = 120;'`,
+			`./cockroach sql --insecure -e `+
+				`"ALTER DATABASE system CONFIGURE ZONE USING num_replicas = 1, gc.ttlseconds = 120;"`,
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -63,7 +63,7 @@ func registerHibernate(r *testRegistry) {
 			c,
 			node,
 			"change jobs retention time",
-			`./cockroach sql --insecure -e 'SET CLUSTER SETTING jobs.retention_time = '180s';'`,
+			`./cockroach sql --insecure -e "SET CLUSTER SETTING jobs.retention_time = '180s';"`,
 		); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Fixes mistakes from #41339

Release note: None