### PR TITLE
release-19.2: sql: (revert the reversion) fix various problematic uses of the txn in DistSQL flows

### DIFF
--- a/pkg/ccl/importccl/sst_writer_proc.go
+++ b/pkg/ccl/importccl/sst_writer_proc.go
@@ -64,7 +64,6 @@ func newSSTWriterProcessor(
 		settings:    flowCtx.Cfg.Settings,
 		registry:    flowCtx.Cfg.JobRegistry,
 		progress:    spec.Progress,
-		db:          flowCtx.EvalCtx.Txn.DB(),
 	}
 	if err := sp.out.Init(&execinfrapb.PostProcessSpec{}, sstOutputTypes, flowCtx.NewEvalCtx(), output); err != nil {
 		return nil, err
@@ -97,6 +96,7 @@ func (sp *sstWriter) OutputTypes() []types.T {
 }
 
 func (sp *sstWriter) Run(ctx context.Context) {
+	sp.db = sp.flowCtx.EvalCtx.Txn.DB()
 	sp.input.Start(ctx)
 
 	ctx, span := tracing.ChildSpan(ctx, "sstWriter")

--- a/pkg/sql/colexec/parallel_unordered_synchronizer.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer.go
@@ -31,6 +31,7 @@ type unorderedSynchronizerMsg struct {
 }
 
 var _ Operator = &ParallelUnorderedSynchronizer{}
+var _ execinfra.OpNode = &ParallelUnorderedSynchronizer{}
 
 // ParallelUnorderedSynchronizer is an Operator that combines multiple Operator streams
 // into one.

--- a/pkg/sql/colexec/serial_unordered_synchronizer.go
+++ b/pkg/sql/colexec/serial_unordered_synchronizer.go
@@ -1,0 +1,78 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colexec
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+)
+
+// SerialUnorderedSynchronizer is an Operator that combines multiple Operator
+// streams into one. It reads its inputs one by one until each one is exhausted,
+// at which point it moves to the next input. See ParallelUnorderedSynchronizer
+// for a parallel implementation. The serial one is used when concurrency is
+// undesirable - for example when the whole query is planned on the gateway and
+// we want to run it in the RootTxn.
+type SerialUnorderedSynchronizer struct {
+	inputs []Operator
+	// curSerialInputIdx indicates the index of the current input being consumed.
+	curSerialInputIdx int
+	zeroBatch         coldata.Batch
+}
+
+var _ Operator = &SerialUnorderedSynchronizer{}
+var _ execinfra.OpNode = &SerialUnorderedSynchronizer{}
+
+// ChildCount implements the execinfra.OpNode interface.
+func (s *SerialUnorderedSynchronizer) ChildCount() int {
+	return len(s.inputs)
+}
+
+// Child implements the execinfra.OpNode interface.
+func (s *SerialUnorderedSynchronizer) Child(nth int) execinfra.OpNode {
+	return s.inputs[nth]
+}
+
+// NewSerialUnorderedSynchronizer creates a new SerialUnorderedSynchronizer.
+func NewSerialUnorderedSynchronizer(
+	inputs []Operator, typs []coltypes.T,
+) *SerialUnorderedSynchronizer {
+	return &SerialUnorderedSynchronizer{
+		inputs:            inputs,
+		curSerialInputIdx: 0,
+		zeroBatch:         coldata.NewMemBatchWithSize(typs, 0),
+	}
+}
+
+// Init is part of the Operator interface.
+func (s *SerialUnorderedSynchronizer) Init() {
+	for _, input := range s.inputs {
+		input.Init()
+	}
+}
+
+// Next is part of the Operator interface.
+func (s *SerialUnorderedSynchronizer) Next(ctx context.Context) coldata.Batch {
+	for {
+		if s.curSerialInputIdx == len(s.inputs) {
+			return s.zeroBatch
+		}
+		b := s.inputs[s.curSerialInputIdx].Next(ctx)
+		if b.Length() == 0 {
+			s.curSerialInputIdx++
+		} else {
+			return b
+		}
+	}
+}

--- a/pkg/sql/colexec/serial_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/serial_unordered_synchronizer_test.go
@@ -1,0 +1,52 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colexec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSerialUnorderedSynchronizer(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	rng, _ := randutil.NewPseudoRand()
+	const numInputs = 3
+	const numBatches = 4
+
+	typs := []coltypes.T{coltypes.Int64}
+	inputs := make([]Operator, numInputs)
+	for i := range inputs {
+		batch := coldata.NewMemBatchWithSize(typs, int(coldata.BatchSize()))
+		batch.SetLength(coldata.BatchSize())
+		source := NewRepeatableBatchSource(
+			RandomBatch(rng, typs, int(coldata.BatchSize()), 0 /* length */, rng.Float64()))
+		source.ResetBatchesToReturn(numBatches)
+		inputs[i] = source
+	}
+	s := NewSerialUnorderedSynchronizer(inputs, typs)
+	resultBatches := 0
+	for {
+		b := s.Next(ctx)
+		if b.Length() == 0 {
+			break
+		}
+		resultBatches++
+	}
+	require.Equal(t, numInputs*numBatches, resultBatches)
+}

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -37,6 +37,8 @@ import (
 
 type vectorizedFlow struct {
 	*flowinfra.FlowBase
+	// operatorConcurrency is set if any operators are executed in parallel.
+	operatorConcurrency bool
 }
 
 var _ flowinfra.Flow = &vectorizedFlow{}
@@ -47,7 +49,9 @@ func NewVectorizedFlow(base *flowinfra.FlowBase) flowinfra.Flow {
 }
 
 // Setup is part of the flowinfra.Flow interface.
-func (f *vectorizedFlow) Setup(ctx context.Context, spec *execinfrapb.FlowSpec) error {
+func (f *vectorizedFlow) Setup(
+	ctx context.Context, spec *execinfrapb.FlowSpec, opt flowinfra.FuseOpt,
+) error {
 	f.SetSpec(spec)
 	log.VEventf(ctx, 1, "setting up vectorize flow %s", f.ID.Short())
 	acc := f.EvalCtx.Mon.MakeBoundAccount()
@@ -66,13 +70,19 @@ func (f *vectorizedFlow) Setup(ctx context.Context, spec *execinfrapb.FlowSpec) 
 		f.GetFlowCtx().Cfg.NodeDialer,
 		f.GetID(),
 	)
-	_, err := creator.setupFlow(ctx, f.GetFlowCtx(), spec.Processors, &acc)
+	_, err := creator.setupFlow(ctx, f.GetFlowCtx(), spec.Processors, &acc, opt)
 	if err == nil {
 		log.VEventf(ctx, 1, "vectorized flow setup succeeded")
 		return nil
 	}
+	f.operatorConcurrency = creator.operatorConcurrency
 	log.VEventf(ctx, 1, "failed to vectorize: %s", err)
 	return err
+}
+
+// ConcurrentExecution is part of the Flow interface.
+func (f *vectorizedFlow) ConcurrentExecution() bool {
+	return f.operatorConcurrency || f.FlowBase.ConcurrentExecution()
 }
 
 // wrapWithVectorizedStatsCollector creates a new exec.VectorizedStatsCollector
@@ -205,6 +215,8 @@ type vectorizedFlowCreator struct {
 	// leaves accumulates all operators that have no further outputs on the
 	// current node, for the purposes of EXPLAIN output.
 	leaves []execinfra.OpNode
+	// operatorConcurrency is set if any operators are executed in parallel.
+	operatorConcurrency bool
 }
 
 func newVectorizedFlowCreator(
@@ -341,7 +353,7 @@ func (s *vectorizedFlowCreator) setupRouter(
 // []distqlpb.MetadataSource so that any remote metadata can be read through
 // calling DrainMeta.
 func (s *vectorizedFlowCreator) setupInput(
-	input execinfrapb.InputSyncSpec,
+	input execinfrapb.InputSyncSpec, opt flowinfra.FuseOpt,
 ) (op colexec.Operator, _ []execinfrapb.MetadataSource, memUsed int, _ error) {
 	inputStreamOps := make([]colexec.Operator, 0, len(input.Streams))
 	metaSources := make([]execinfrapb.MetadataSource, 0, len(input.Streams))
@@ -402,7 +414,12 @@ func (s *vectorizedFlowCreator) setupInput(
 			)
 			memUsed += op.(colexec.StaticMemoryOperator).EstimateStaticMemoryUsage()
 		} else {
-			op = colexec.NewParallelUnorderedSynchronizer(inputStreamOps, typs, s.waitGroup)
+			if opt == flowinfra.FuseAggressively {
+				op = colexec.NewSerialUnorderedSynchronizer(inputStreamOps, typs)
+			} else {
+				op = colexec.NewParallelUnorderedSynchronizer(inputStreamOps, typs, s.waitGroup)
+				s.operatorConcurrency = true
+			}
 			// Don't use the unordered synchronizer's inputs for stats collection
 			// given that they run concurrently. The stall time will be collected
 			// instead.
@@ -531,6 +548,7 @@ func (s *vectorizedFlowCreator) setupFlow(
 	flowCtx *execinfra.FlowCtx,
 	processorSpecs []execinfrapb.ProcessorSpec,
 	acc *mon.BoundAccount,
+	opt flowinfra.FuseOpt,
 ) (leaves []execinfra.OpNode, err error) {
 	streamIDToSpecIdx := make(map[execinfrapb.StreamID]int)
 	// queue is a queue of indices into processorSpecs, for topologically
@@ -571,7 +589,7 @@ func (s *vectorizedFlowCreator) setupFlow(
 		metadataSourcesQueue := make([]execinfrapb.MetadataSource, 0, 1)
 		inputs = inputs[:0]
 		for i := range pspec.Input {
-			input, metadataSources, memUsed, err := s.setupInput(pspec.Input[i])
+			input, metadataSources, memUsed, err := s.setupInput(pspec.Input[i], opt)
 			if err != nil {
 				return nil, err
 			}
@@ -773,7 +791,10 @@ func (r *noopFlowCreatorHelper) getCancelFlowFn() context.CancelFunc {
 // It returns a list of the leaf operators of all flows for the purposes of
 // EXPLAIN output.
 func SupportsVectorized(
-	ctx context.Context, flowCtx *execinfra.FlowCtx, processorSpecs []execinfrapb.ProcessorSpec,
+	ctx context.Context,
+	flowCtx *execinfra.FlowCtx,
+	processorSpecs []execinfrapb.ProcessorSpec,
+	fuseOpt flowinfra.FuseOpt,
 ) (leaves []execinfra.OpNode, err error) {
 	creator := newVectorizedFlowCreator(
 		newNoopFlowCreatorHelper(),
@@ -802,7 +823,7 @@ func SupportsVectorized(
 	acc := memoryMonitor.MakeBoundAccount()
 	defer acc.Close(ctx)
 	if vecErr := execerror.CatchVectorizedRuntimeError(func() {
-		leaves, err = creator.setupFlow(ctx, flowCtx, processorSpecs, &acc)
+		leaves, err = creator.setupFlow(ctx, flowCtx, processorSpecs, &acc, fuseOpt)
 	}); vecErr != nil {
 		return leaves, vecErr
 	}

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -402,7 +402,7 @@ func (s *vectorizedFlowCreator) setupInput(
 			)
 			memUsed += op.(colexec.StaticMemoryOperator).EstimateStaticMemoryUsage()
 		} else {
-			op = colexec.NewUnorderedSynchronizer(inputStreamOps, typs, s.waitGroup)
+			op = colexec.NewParallelUnorderedSynchronizer(inputStreamOps, typs, s.waitGroup)
 			// Don't use the unordered synchronizer's inputs for stats collection
 			// given that they run concurrently. The stall time will be collected
 			// instead.

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -153,7 +153,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					materializerMetadataSources = append(materializerMetadataSources, inbox)
 					synchronizerInputs = append(synchronizerInputs, colexec.Operator(inbox))
 				}
-				synchronizer := colexec.NewUnorderedSynchronizer(synchronizerInputs, typs, &wg)
+				synchronizer := colexec.NewParallelUnorderedSynchronizer(synchronizerInputs, typs, &wg)
 				flowID := execinfrapb.FlowID{UUID: uuid.MakeV4()}
 
 				runOutboxInbox := func(

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -212,7 +212,7 @@ func TestDrainOnlyInputDAG(t *testing.T) {
 
 	acc := evalCtx.Mon.MakeBoundAccount()
 	defer acc.Close(ctx)
-	_, err := vfc.setupFlow(context.Background(), &f.FlowCtx, procs, &acc)
+	_, err := vfc.setupFlow(ctx, &f.FlowCtx, procs, &acc, flowinfra.FuseNormally)
 	require.NoError(t, err)
 
 	// Verify that an outbox was actually created.

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -189,6 +189,9 @@ func (ds *ServerImpl) setupFlow(
 	} else if localState.IsLocal {
 		// If we're a local flow, we don't need a "follows from" relationship: we're
 		// going to run this flow synchronously.
+		// TODO(andrei): localState.IsLocal is not quite the right thing to use.
+		//  If that field is unset, we might still want to create a child span if
+		//  this flow is run synchronously.
 		sp = tracing.StartChildSpan(opName, parentSpan, logtags.FromContext(ctx), false /* separateRecording */)
 	} else {
 		// We use FollowsFrom because the flow's span outlives the SetupFlow request.
@@ -378,7 +381,8 @@ func (ds *ServerImpl) SetupSyncFlow(
 type LocalState struct {
 	EvalContext *tree.EvalContext
 
-	// IsLocal is true if the flow is being run locally in the first place.
+	// IsLocal is set if the flow is running on the gateway and there are no
+	// remote flows.
 	IsLocal bool
 
 	/////////////////////////////////////////////

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -219,29 +219,10 @@ func (ds *ServerImpl) setupFlow(
 	)
 	monitor.Start(ctx, parentMonitor, mon.BoundAccount{})
 
-	// Figure out what txn the flow needs to run in, if any.
-	// For local flows, the txn comes from localState.Txn. For non-local ones, we
-	// create a txn based on the request's TxnCoordMeta.
-	var txn *client.Txn
-	if !localState.IsLocal {
-		if meta := req.TxnCoordMeta; meta != nil {
-			if meta.Txn.Status != roachpb.PENDING {
-				return nil, nil, errors.Errorf("cannot create flow in non-PENDING txn: %s",
-					meta.Txn)
-			}
-			// The flow will run in a LeafTxn because we do not want each distributed
-			// Txn to heartbeat the transaction.
-			txn = client.NewTxnWithCoordMeta(ctx, ds.FlowDB, req.Flow.Gateway, client.LeafTxn, *meta)
-		}
-	} else {
-		txn = localState.Txn
-	}
-
 	var evalCtx *tree.EvalContext
 	if localState.EvalContext != nil {
 		evalCtx = localState.EvalContext
 		evalCtx.Mon = &monitor
-		evalCtx.Txn = txn
 	} else {
 		location, err := timeutil.TimeZoneStringToLocation(req.EvalContext.Location)
 		if err != nil {
@@ -296,7 +277,6 @@ func (ds *ServerImpl) setupFlow(
 			// TODO(andrei): This is wrong. Each processor should override Ctx with its
 			// own context.
 			Context:          ctx,
-			Txn:              txn,
 			Planner:          &sqlbase.DummyEvalPlanner{},
 			SessionAccessor:  &sqlbase.DummySessionAccessor{},
 			Sequence:         &sqlbase.DummySequenceOperators{},
@@ -320,7 +300,6 @@ func (ds *ServerImpl) setupFlow(
 		Cfg:            &ds.ServerConfig,
 		ID:             req.Flow.FlowID,
 		EvalCtx:        evalCtx,
-		Txn:            txn,
 		NodeID:         nodeID,
 		TraceKV:        req.TraceKV,
 		Local:          localState.IsLocal,
@@ -353,6 +332,27 @@ func (ds *ServerImpl) setupFlow(
 	if f.IsVectorized() {
 		telemetry.Inc(sqltelemetry.VecExecCounter)
 	}
+
+	// Figure out what txn the flow needs to run in, if any. For gateway flows
+	// that have no remote flows and also no concurrency, the txn comes from
+	// localState.Txn. Otherwise, we create a txn based on the request's
+	// TxnCoordMeta.
+	var txn *client.Txn
+	if localState.IsLocal && !f.ConcurrentExecution() {
+		txn = localState.Txn
+	} else {
+		if meta := req.TxnCoordMeta; meta != nil {
+			if meta.Txn.Status != roachpb.PENDING {
+				return nil, nil, errors.Errorf("cannot create flow in non-PENDING txn: %s",
+					meta.Txn)
+			}
+			// The flow will run in a LeafTxn because we do not want each distributed
+			// Txn to heartbeat the transaction.
+			txn = client.NewTxnWithCoordMeta(ctx, ds.FlowDB, req.Flow.Gateway, client.LeafTxn, *meta)
+		}
+	}
+	f.SetTxn(txn)
+
 	return ctx, f, nil
 }
 
@@ -381,7 +381,12 @@ func (ds *ServerImpl) SetupSyncFlow(
 	req *execinfrapb.SetupFlowRequest,
 	output execinfra.RowReceiver,
 ) (context.Context, flowinfra.Flow, error) {
-	return ds.setupFlow(ds.AnnotateCtx(ctx), opentracing.SpanFromContext(ctx), parentMonitor, req, output, LocalState{})
+	ctx, f, err := ds.setupFlow(ds.AnnotateCtx(ctx), opentracing.SpanFromContext(ctx), parentMonitor,
+		req, output, LocalState{})
+	if err != nil {
+		return nil, nil, err
+	}
+	return ctx, f, err
 }
 
 // LocalState carries information that is required to set up a flow with wrapped
@@ -393,6 +398,11 @@ type LocalState struct {
 	// remote flows.
 	IsLocal bool
 
+	// Txn is filled in on the gateway only. It is the RootTxn that the query is running in.
+	// This will be used directly by the flow if the flow has no concurrency and IsLocal is set.
+	// If there is concurrency, a LeafTxn will be created.
+	Txn *client.Txn
+
 	/////////////////////////////////////////////
 	// Fields below are empty if IsLocal == false
 	/////////////////////////////////////////////
@@ -400,12 +410,11 @@ type LocalState struct {
 	// LocalProcs is an array of planNodeToRowSource processors. It's in order and
 	// will be indexed into by the RowSourceIdx field in LocalPlanNodeSpec.
 	LocalProcs []execinfra.LocalProcessor
-	Txn        *client.Txn
 }
 
 // SetupLocalSyncFlow sets up a synchronous flow on the current (planning) node.
-// It's used by the gateway node to set up the flows local to it. Otherwise,
-// the same as SetupSyncFlow.
+// It's used by the gateway node to set up the flows local to it.
+// It's the same as SetupSyncFlow except it takes the localState.
 func (ds *ServerImpl) SetupLocalSyncFlow(
 	ctx context.Context,
 	parentMonitor *mon.BytesMonitor,
@@ -413,7 +422,12 @@ func (ds *ServerImpl) SetupLocalSyncFlow(
 	output execinfra.RowReceiver,
 	localState LocalState,
 ) (context.Context, flowinfra.Flow, error) {
-	return ds.setupFlow(ctx, opentracing.SpanFromContext(ctx), parentMonitor, req, output, localState)
+	ctx, f, err := ds.setupFlow(ctx, opentracing.SpanFromContext(ctx), parentMonitor, req, output,
+		localState)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ctx, f, err
 }
 
 // RunSyncFlow is part of the DistSQLServer interface.

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/colflow"
+	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -231,8 +232,13 @@ func (p *planner) populateExplain(
 		} else if !vectorizedThresholdMet && ctxSessionData.VectorizeMode == sessiondata.VectorizeAuto {
 			isVec = false
 		} else {
-			for _, flow := range flows {
-				_, err := colflow.SupportsVectorized(params.ctx, flowCtx, flow.Processors)
+			thisNodeID := distSQLPlanner.nodeDesc.NodeID
+			for nodeID, flow := range flows {
+				fuseOpt := flowinfra.FuseNormally
+				if nodeID == thisNodeID && !isDistSQL {
+					fuseOpt = flowinfra.FuseAggressively
+				}
+				_, err := colflow.SupportsVectorized(params.ctx, flowCtx, flow.Processors, fuseOpt)
 				isVec = isVec && (err == nil)
 			}
 		}

--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -46,11 +46,24 @@ func (f StartableFn) Start(ctx context.Context, wg *sync.WaitGroup, ctxCancel co
 	f(ctx, wg, ctxCancel)
 }
 
+// FuseOpt specifies options for processor fusing at Flow.Setup() time.
+type FuseOpt bool
+
+const (
+	// FuseNormally means fuse what you can, but don't serialize unordered input
+	// synchronizers.
+	FuseNormally FuseOpt = false
+	// FuseAggressively means serialize unordered input synchronizers.
+	// This is useful for flows that might have mutations which can't have any
+	// concurrency.
+	FuseAggressively = true
+)
+
 // Flow represents a flow which consists of processors and streams.
 type Flow interface {
 	// Setup sets up all the infrastructure for the flow as defined by the flow
 	// spec. The flow will then need to be started and run.
-	Setup(context.Context, *execinfrapb.FlowSpec) error
+	Setup(ctx context.Context, spec *execinfrapb.FlowSpec, opt FuseOpt) error
 
 	// Start starts the flow. Processors run asynchronously in their own goroutines.
 	// Wait() needs to be called to wait for the flow to finish.
@@ -92,6 +105,11 @@ type Flow interface {
 	// Cleanup should be called when the flow completes (after all processors and
 	// mailboxes exited).
 	Cleanup(context.Context)
+
+	// ConcurrentExecution returns true if multiple processors/operators in the
+	// flow will execute concurrently (i.e. if not all of them have been fused).
+	// Can only be called after Setup().
+	ConcurrentExecution() bool
 }
 
 // FlowBase is the shared logic between row based and vectorized flows. It
@@ -147,8 +165,13 @@ type FlowBase struct {
 }
 
 // Setup is part of the Flow interface.
-func (f *FlowBase) Setup(context.Context, *execinfrapb.FlowSpec) error {
+func (f *FlowBase) Setup(context.Context, *execinfrapb.FlowSpec, FuseOpt) error {
 	panic("Setup should not be called on FlowBase")
+}
+
+// ConcurrentExecution is part of the Flow interface.
+func (f *FlowBase) ConcurrentExecution() bool {
+	return len(f.processors) > 1
 }
 
 var _ Flow = &FlowBase{}

--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -64,6 +65,10 @@ type Flow interface {
 	// Setup sets up all the infrastructure for the flow as defined by the flow
 	// spec. The flow will then need to be started and run.
 	Setup(ctx context.Context, spec *execinfrapb.FlowSpec, opt FuseOpt) error
+
+	// SetTxn is used to provide the transaction in which the flow will run.
+	// It needs to be called after Setup() and before Start/Run.
+	SetTxn(*client.Txn)
 
 	// Start starts the flow. Processors run asynchronously in their own goroutines.
 	// Wait() needs to be called to wait for the flow to finish.
@@ -167,6 +172,12 @@ type FlowBase struct {
 // Setup is part of the Flow interface.
 func (f *FlowBase) Setup(context.Context, *execinfrapb.FlowSpec, FuseOpt) error {
 	panic("Setup should not be called on FlowBase")
+}
+
+// SetTxn is part of the Flow interface.
+func (f *FlowBase) SetTxn(txn *client.Txn) {
+	f.FlowCtx.Txn = txn
+	f.EvalCtx.Txn = txn
 }
 
 // ConcurrentExecution is part of the Flow interface.

--- a/pkg/sql/logictest/testdata/logic_test/dist_vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/dist_vectorize
@@ -95,7 +95,7 @@ EXPLAIN (VEC, VERBOSE) SELECT count(*) FROM kv
 │   └ *colexec.orderedAggregator
 │     └ *colexec.oneShotOp
 │       └ *colexec.distinctChainOps
-│         └ *colexec.UnorderedSynchronizer
+│         └ *colexec.ParallelUnorderedSynchronizer
 │           ├ *colexec.countOp
 │           │ └ *colexec.simpleProjectOp
 │           │   └ *colexec.CancelChecker
@@ -142,10 +142,10 @@ EXPLAIN (VEC, VERBOSE) SELECT count(*) FROM kv NATURAL INNER HASH JOIN kv kv2
 │   └ *colexec.orderedAggregator
 │     └ *colexec.oneShotOp
 │       └ *colexec.distinctChainOps
-│         └ *colexec.UnorderedSynchronizer
+│         └ *colexec.ParallelUnorderedSynchronizer
 │           ├ *colexec.countOp
 │           │ └ *colexec.hashJoinEqOp
-│           │   ├ *colexec.UnorderedSynchronizer
+│           │   ├ *colexec.ParallelUnorderedSynchronizer
 │           │   │ ├ *colexec.routerOutputOp
 │           │   │ │ └ *colexec.HashRouter
 │           │   │ │   └ *colexec.CancelChecker
@@ -154,7 +154,7 @@ EXPLAIN (VEC, VERBOSE) SELECT count(*) FROM kv NATURAL INNER HASH JOIN kv kv2
 │           │   │ ├ *colrpc.Inbox
 │           │   │ ├ *colrpc.Inbox
 │           │   │ └ *colrpc.Inbox
-│           │   └ *colexec.UnorderedSynchronizer
+│           │   └ *colexec.ParallelUnorderedSynchronizer
 │           │     ├ *colexec.routerOutputOp
 │           │     │ └ *colexec.HashRouter
 │           │     │   └ *colexec.CancelChecker
@@ -172,7 +172,7 @@ EXPLAIN (VEC, VERBOSE) SELECT count(*) FROM kv NATURAL INNER HASH JOIN kv kv2
 │   └ *colexec.deselectorOp
 │     └ *colexec.countOp
 │       └ *colexec.hashJoinEqOp
-│         ├ *colexec.UnorderedSynchronizer
+│         ├ *colexec.ParallelUnorderedSynchronizer
 │         │ ├ *colrpc.Inbox
 │         │ ├ *colexec.routerOutputOp
 │         │ │ └ *colexec.HashRouter
@@ -181,7 +181,7 @@ EXPLAIN (VEC, VERBOSE) SELECT count(*) FROM kv NATURAL INNER HASH JOIN kv kv2
 │         │ ├ *colrpc.Inbox
 │         │ ├ *colrpc.Inbox
 │         │ └ *colrpc.Inbox
-│         └ *colexec.UnorderedSynchronizer
+│         └ *colexec.ParallelUnorderedSynchronizer
 │           ├ *colrpc.Inbox
 │           ├ *colexec.routerOutputOp
 │           │ └ *colexec.HashRouter
@@ -195,7 +195,7 @@ EXPLAIN (VEC, VERBOSE) SELECT count(*) FROM kv NATURAL INNER HASH JOIN kv kv2
 │   └ *colexec.deselectorOp
 │     └ *colexec.countOp
 │       └ *colexec.hashJoinEqOp
-│         ├ *colexec.UnorderedSynchronizer
+│         ├ *colexec.ParallelUnorderedSynchronizer
 │         │ ├ *colrpc.Inbox
 │         │ ├ *colrpc.Inbox
 │         │ ├ *colexec.routerOutputOp
@@ -204,7 +204,7 @@ EXPLAIN (VEC, VERBOSE) SELECT count(*) FROM kv NATURAL INNER HASH JOIN kv kv2
 │         │ │     └ *colexec.colBatchScan
 │         │ ├ *colrpc.Inbox
 │         │ └ *colrpc.Inbox
-│         └ *colexec.UnorderedSynchronizer
+│         └ *colexec.ParallelUnorderedSynchronizer
 │           ├ *colrpc.Inbox
 │           ├ *colrpc.Inbox
 │           ├ *colexec.routerOutputOp
@@ -218,7 +218,7 @@ EXPLAIN (VEC, VERBOSE) SELECT count(*) FROM kv NATURAL INNER HASH JOIN kv kv2
 │   └ *colexec.deselectorOp
 │     └ *colexec.countOp
 │       └ *colexec.hashJoinEqOp
-│         ├ *colexec.UnorderedSynchronizer
+│         ├ *colexec.ParallelUnorderedSynchronizer
 │         │ ├ *colrpc.Inbox
 │         │ ├ *colrpc.Inbox
 │         │ ├ *colrpc.Inbox
@@ -227,7 +227,7 @@ EXPLAIN (VEC, VERBOSE) SELECT count(*) FROM kv NATURAL INNER HASH JOIN kv kv2
 │         │ │   └ *colexec.CancelChecker
 │         │ │     └ *colexec.colBatchScan
 │         │ └ *colrpc.Inbox
-│         └ *colexec.UnorderedSynchronizer
+│         └ *colexec.ParallelUnorderedSynchronizer
 │           ├ *colrpc.Inbox
 │           ├ *colrpc.Inbox
 │           ├ *colrpc.Inbox
@@ -241,7 +241,7 @@ EXPLAIN (VEC, VERBOSE) SELECT count(*) FROM kv NATURAL INNER HASH JOIN kv kv2
     └ *colexec.deselectorOp
       └ *colexec.countOp
         └ *colexec.hashJoinEqOp
-          ├ *colexec.UnorderedSynchronizer
+          ├ *colexec.ParallelUnorderedSynchronizer
           │ ├ *colrpc.Inbox
           │ ├ *colrpc.Inbox
           │ ├ *colrpc.Inbox
@@ -250,7 +250,7 @@ EXPLAIN (VEC, VERBOSE) SELECT count(*) FROM kv NATURAL INNER HASH JOIN kv kv2
           │   └ *colexec.HashRouter
           │     └ *colexec.CancelChecker
           │       └ *colexec.colBatchScan
-          └ *colexec.UnorderedSynchronizer
+          └ *colexec.ParallelUnorderedSynchronizer
             ├ *colrpc.Inbox
             ├ *colrpc.Inbox
             ├ *colrpc.Inbox

--- a/pkg/sql/rowexec/scrub_tablereader.go
+++ b/pkg/sql/rowexec/scrub_tablereader.go
@@ -71,10 +71,6 @@ func newScrubTableReader(
 	if flowCtx.NodeID == 0 {
 		return nil, errors.Errorf("attempting to create a tableReader with uninitialized NodeID")
 	}
-	if flowCtx.Txn == nil {
-		return nil, errors.Errorf("scrubTableReader outside of txn")
-	}
-
 	tr := &scrubTableReader{
 		indexIdx: int(spec.IndexIdx),
 	}
@@ -214,6 +210,10 @@ func (tr *scrubTableReader) prettyPrimaryKeyValues(
 
 // Start is part of the RowSource interface.
 func (tr *scrubTableReader) Start(ctx context.Context) context.Context {
+	if tr.FlowCtx.Txn == nil {
+		tr.MoveToDraining(errors.Errorf("scrubTableReader outside of txn"))
+	}
+
 	ctx = tr.StartInternal(ctx, scrubTableReaderProcName)
 
 	log.VEventf(ctx, 1, "starting")

--- a/pkg/sql/rowflow/input_sync.go
+++ b/pkg/sql/rowflow/input_sync.go
@@ -60,6 +60,9 @@ const (
 // stream are assumed to be ordered according to the same set of columns
 // (intra-stream ordering).
 type orderedSynchronizer struct {
+	// ordering dictates the way in which rows compare. If nil (i.e.
+	// sqlbase.NoOrdering), then rows are not compared and sources are consumed in
+	// index order.
 	ordering sqlbase.ColumnOrdering
 	evalCtx  *tree.EvalContext
 
@@ -107,6 +110,12 @@ func (s *orderedSynchronizer) Len() int {
 
 // Less is part of heap.Interface and is only meant to be used internally.
 func (s *orderedSynchronizer) Less(i, j int) bool {
+	// If we're not enforcing any ordering between rows, let's consume sources in
+	// their index order.
+	if s.ordering == nil {
+		return s.heap[i] < s.heap[j]
+	}
+
 	si := &s.sources[s.heap[i]]
 	sj := &s.sources[s.heap[j]]
 	cmp, err := si.row.Compare(s.types, &s.alloc, s.ordering, s.evalCtx, sj.row)
@@ -354,6 +363,11 @@ func (s *orderedSynchronizer) consumerStatusChanged(
 	s.state = newState
 }
 
+// makeOrderedSync creates an orderedSynchronizer. ordering dictates how rows
+// are to be compared. Use sqlbase.NoOrdering to indicate that the row ordering
+// doesn't matter and sources should be consumed in index order (which is useful
+// when you intend to fuse the synchronizer and its inputs later; see
+// FuseAggresively).
 func makeOrderedSync(
 	ordering sqlbase.ColumnOrdering, evalCtx *tree.EvalContext, sources []execinfra.RowSource,
 ) (execinfra.RowSource, error) {

--- a/pkg/sql/rowflow/row_based_flow.go
+++ b/pkg/sql/rowflow/row_based_flow.go
@@ -12,6 +12,7 @@ package rowflow
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -36,10 +37,12 @@ func NewRowBasedFlow(base *flowinfra.FlowBase) flowinfra.Flow {
 }
 
 // Setup if part of the flowinfra.Flow interface.
-func (f *rowBasedFlow) Setup(ctx context.Context, spec *execinfrapb.FlowSpec) error {
+func (f *rowBasedFlow) Setup(
+	ctx context.Context, spec *execinfrapb.FlowSpec, opt flowinfra.FuseOpt,
+) error {
 	f.SetSpec(spec)
 	// First step: setup the input synchronizers for all processors.
-	inputSyncs, err := f.setupInputSyncs(ctx, spec)
+	inputSyncs, err := f.setupInputSyncs(ctx, spec, opt)
 	if err != nil {
 		return err
 	}
@@ -67,7 +70,7 @@ func (f *rowBasedFlow) setupProcessors(
 			return err
 		}
 
-		// fuse will return true if we managed to fuse p, false otherwise.
+		// fuse will return true if we managed to fuse p with its consumer.
 		fuse := func() bool {
 			// If the processor implements RowSource try to hook it up directly to the
 			// input of a later processor.
@@ -97,21 +100,39 @@ func (f *rowBasedFlow) setupProcessors(
 					continue
 				}
 				for inIdx, in := range ps.Input {
-					// Look for "simple" inputs: an unordered input (which, by definition,
-					// doesn't require an ordered synchronizer), with a single input stream
-					// (which doesn't require a multiplexed RowChannel).
-					if in.Type != execinfrapb.InputSyncSpec_UNORDERED {
+					if len(in.Streams) == 1 {
+						if in.Streams[0].StreamID != ospec.Streams[0].StreamID {
+							continue
+						}
+						// We found a consumer to fuse our proc to.
+						inputSyncs[pIdx][inIdx] = source
+						return true
+					}
+					// ps has an input with multiple streams. This can be either a
+					// multiplexed RowChannel (in case of some unordered synchronizers)
+					// or an orderedSynchronizer (for other unordered synchronizers or
+					// ordered synchronizers). If it's a multiplexed RowChannel,
+					// then its inputs run in parallel, so there's no fusing with them.
+					// If it's an orderedSynchronizer, then we look inside it to see if
+					// the processor we're trying to fuse feeds into it.
+					orderedSync, ok := inputSyncs[pIdx][inIdx].(*orderedSynchronizer)
+					if !ok {
 						continue
 					}
-					if len(in.Streams) != 1 {
-						continue
+					// See if we can find a stream attached to the processor we're
+					// trying to fuse.
+					for sIdx, sspec := range in.Streams {
+						input := findProcByOutputStreamID(spec, sspec.StreamID)
+						if input == nil {
+							continue
+						}
+						if input.ProcessorID != pspec.ProcessorID {
+							continue
+						}
+						// Fuse the processor with this orderedSynchronizer.
+						orderedSync.sources[sIdx].src = source
+						return true
 					}
-					if in.Streams[0].StreamID != ospec.Streams[0].StreamID {
-						continue
-					}
-					// We found a consumer to fuse our proc to.
-					inputSyncs[pIdx][inIdx] = source
-					return true
 				}
 			}
 			return false
@@ -121,6 +142,35 @@ func (f *rowBasedFlow) setupProcessors(
 		}
 	}
 	f.SetProcessors(processors)
+	return nil
+}
+
+// findProcByOutputStreamID looks in spec for a processor that has a
+// pass-through output router connected to the specified stream. Returns nil if
+// such a processor is not found.
+func findProcByOutputStreamID(
+	spec *execinfrapb.FlowSpec, streamID execinfrapb.StreamID,
+) *execinfrapb.ProcessorSpec {
+	for i := range spec.Processors {
+		pspec := &spec.Processors[i]
+		if len(pspec.Output) > 1 {
+			// We don't have any processors with more than one output. But if we
+			// didn't, we couldn't fuse them, so ignore.
+			continue
+		}
+		ospec := &pspec.Output[0]
+		if ospec.Type != execinfrapb.OutputRouterSpec_PASS_THROUGH {
+			// The output is not pass-through and thus is being sent through a
+			// router.
+			continue
+		}
+		if len(ospec.Streams) != 1 {
+			panic(fmt.Sprintf("pass-through router with %d streams", len(ospec.Streams)))
+		}
+		if ospec.Streams[0].StreamID == streamID {
+			return pspec
+		}
+	}
 	return nil
 }
 
@@ -191,7 +241,7 @@ func (f *rowBasedFlow) makeProcessor(
 // setupInputSyncs populates a slice of input syncs, one for each Processor in
 // f.Spec, each containing one RowSource for each input to that Processor.
 func (f *rowBasedFlow) setupInputSyncs(
-	ctx context.Context, spec *execinfrapb.FlowSpec,
+	ctx context.Context, spec *execinfrapb.FlowSpec, opt flowinfra.FuseOpt,
 ) ([][]execinfra.RowSource, error) {
 	inputSyncs := make([][]execinfra.RowSource, len(spec.Processors))
 	for pIdx, ps := range spec.Processors {
@@ -200,18 +250,31 @@ func (f *rowBasedFlow) setupInputSyncs(
 				return nil, errors.Errorf("input sync with no streams")
 			}
 			var sync execinfra.RowSource
-			switch is.Type {
-			case execinfrapb.InputSyncSpec_UNORDERED:
-				mrc := &execinfra.RowChannel{}
-				mrc.InitWithNumSenders(is.ColumnTypes, len(is.Streams))
-				for _, s := range is.Streams {
-					if err := f.setupInboundStream(ctx, s, mrc); err != nil {
-						return nil, err
+			if is.Type != execinfrapb.InputSyncSpec_UNORDERED &&
+				is.Type != execinfrapb.InputSyncSpec_ORDERED {
+				return nil, errors.Errorf("unsupported input sync type %s", is.Type)
+			}
+
+			if is.Type == execinfrapb.InputSyncSpec_UNORDERED {
+				if opt == flowinfra.FuseNormally || len(is.Streams) == 1 {
+					// Unordered synchronizer: create a RowChannel for each input.
+
+					mrc := &execinfra.RowChannel{}
+					mrc.InitWithNumSenders(is.ColumnTypes, len(is.Streams))
+					for _, s := range is.Streams {
+						if err := f.setupInboundStream(ctx, s, mrc); err != nil {
+							return nil, err
+						}
 					}
+					sync = mrc
 				}
-				sync = mrc
-			case execinfrapb.InputSyncSpec_ORDERED:
-				// Ordered synchronizer: create a RowChannel for each input.
+			}
+			if sync == nil {
+				// We have an ordered synchronizer or an unordered one that we really
+				// want to fuse because of the FuseAggressively option. We'll create a
+				// RowChannel for each input for now, but the inputs might be fused with
+				// the orderedSynchronizer later (in which case the RowChannels will be
+				// dropped).
 				streams := make([]execinfra.RowSource, len(is.Streams))
 				for i, s := range is.Streams {
 					rowChan := &execinfra.RowChannel{}
@@ -222,13 +285,14 @@ func (f *rowBasedFlow) setupInputSyncs(
 					streams[i] = rowChan
 				}
 				var err error
-				sync, err = makeOrderedSync(execinfrapb.ConvertToColumnOrdering(is.Ordering), f.EvalCtx, streams)
+				ordering := sqlbase.NoOrdering
+				if is.Type == execinfrapb.InputSyncSpec_ORDERED {
+					ordering = execinfrapb.ConvertToColumnOrdering(is.Ordering)
+				}
+				sync, err = makeOrderedSync(ordering, f.EvalCtx, streams)
 				if err != nil {
 					return nil, err
 				}
-
-			default:
-				return nil, errors.Errorf("unsupported input sync type %s", is.Type)
 			}
 			inputSyncs[pIdx] = append(inputSyncs[pIdx], sync)
 		}

--- a/pkg/sql/sqlbase/ordering.go
+++ b/pkg/sql/sqlbase/ordering.go
@@ -27,6 +27,9 @@ type ColumnOrderInfo struct {
 // represents an ordering first by column 3 (descending), then by column 1 (ascending).
 type ColumnOrdering []ColumnOrderInfo
 
+// NoOrdering is used to indicate an empty ColumnOrdering.
+var NoOrdering ColumnOrdering
+
 // CompareDatums compares two datum rows according to a column ordering. Returns:
 //  - 0 if lhs and rhs are equal on the ordering columns;
 //  - less than 0 if lhs comes first;


### PR DESCRIPTION
Backport 4/4 commits from #41457.

/cc @cockroachdb/release

---

This is a reversion of #41406, which was a reversion of #41304 

#41304 had been revert because it exposed an existing bug more broadly. That bug was fixed by #41438. So here we go again with this patch.

See individual commits for what the patch does.


