### PR TITLE
release-19.2: server: add metric for number of disk stalls detected

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -81,7 +81,7 @@ import (
 	"github.com/cockroachdb/logtags"
 	raven "github.com/getsentry/raven-go"
 	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
@@ -1270,7 +1270,7 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 	s.stopper.AddCloser(&s.engines)
 
-	startAssertEngineHealth(ctx, s.stopper, s.engines)
+	s.node.startAssertEngineHealth(ctx, s.engines)
 
 	// Write listener info files early in the startup sequence. `listenerInfo` has a comment.
 	listenerFiles := listenerInfo{

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -808,7 +808,7 @@ func TestChartCatalogMetrics(t *testing.T) {
 	}
 
 	if len(undefinedMetrics) > 0 {
-		t.Fatalf(`The following metrics need are no longer present and  need to be removed
+		t.Fatalf(`The following metrics need are no longer present and need to be removed
 			from the chart catalog (pkg/ts/chart_catalog.go):%v`, undefinedMetrics)
 	}
 

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -578,6 +578,13 @@ var charts = []sectionDescription{
 					"exec.success",
 				},
 			},
+			{
+				Title:       "Storage Engine Stalls",
+				Downsampler: DescribeAggregator_MAX,
+				Rate:        DescribeDerivative_NON_NEGATIVE_DERIVATIVE,
+				Percentiles: false,
+				Metrics:     []string{"engine.stalls"},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
Backport 1/1 commits from #41337.

/cc @cockroachdb/release

---

This commit adds a counter metric on the Node object for the number of
disk stalls detected. It might have been cleaner to attach this metric to the
store associated with the engine and perhaps even to have moved this check into
storage but this seemed like the least invasive place to put it.

Fixes #38040.

Release justification: Low risk, high priority monitoring change for
high-severity bugs in existing functionality.

Release note: None
