### PR TITLE
backupccl: fix sanitizeLocalityKV() char handling

### DIFF
--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -898,8 +898,8 @@ func sanitizeLocalityKV(kv string) string {
 	sanitizedKV := make([]byte, len(kv))
 	for i := 0; i < len(kv); i++ {
 		if (kv[i] >= 'a' && kv[i] <= 'z') ||
-			(kv[i] >= 'A' && kv[i] >= 'Z') ||
-			(kv[i] >= '0' && kv[i] >= '9') || kv[i] == '-' || kv[i] == '=' {
+			(kv[i] >= 'A' && kv[i] <= 'Z') ||
+			(kv[i] >= '0' && kv[i] <= '9') || kv[i] == '-' || kv[i] == '=' {
 			sanitizedKV[i] = kv[i]
 		} else {
 			sanitizedKV[i] = '_'


### PR DESCRIPTION
This PR fixes `sanitizeLocalityKV()`, which sanitizes locality KV strings so
they can be used in filepaths for partitioned backups, and was using the wrong
bounds to check for alphanumeric characters.

Release justification: This is a minor low-risk fix for a bug in a new feature.

Release note: None