### PR TITLE
roachtest: Fix error reporting in kv50 test

### DIFF
--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -584,10 +584,12 @@ func registerKVRangeLookups(r *testRegistry) {
 				concurrency+duration+readPercent+
 				" {pgurl:1-%d}", nodes)
 			start := timeutil.Now()
-			c.Run(ctx, c.Node(nodes+1), cmd)
+			err := c.RunE(ctx, c.Node(nodes+1), cmd)
 			end := timeutil.Now()
-			verifyLookupsPerSec(ctx, c, t, c.Node(1), start, end, maximumRangeLookupsPerSec)
-			return nil
+			if err == nil {
+				verifyLookupsPerSec(ctx, c, t, c.Node(1), start, end, maximumRangeLookupsPerSec)
+			}
+			return err
 		})
 
 		<-doneInit


### PR DESCRIPTION
When one thread in a monitor fatals and another returns an error, the
fatal is the one that gets reported, even if it's an unhelpful
"signal: killed" from a cancelled process that was caused by a
previously returned error. Whenever any thread returns errors, they
all should, by using RunE instead of Run, etc. This is probably a much
more widespread problem in the roachtests, but for now I'm only fixing
this one which is causing opaque failures in #40359

Release note: None