### PR TITLE
storage: remove two sources of stats inconsistencies

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1262,7 +1262,12 @@ func removeDeadReplicas(
 		// there will be keys not represented by any ranges or vice
 		// versa).
 		key := keys.RangeDescriptorKey(desc.StartKey)
-		err := engine.MVCCPutProto(ctx, batch, nil /* stats */, key, clock.Now(), nil /* txn */, &desc)
+		sl := stateloader.Make(desc.RangeID)
+		ms, err := sl.LoadMVCCStats(ctx, batch)
+		if err != nil {
+			return nil, errors.Wrap(err, "loading MVCCStats")
+		}
+		err = engine.MVCCPutProto(ctx, batch, &ms, key, clock.Now(), nil /* txn */, &desc)
 		if wiErr, ok := err.(*roachpb.WriteIntentError); ok {
 			if len(wiErr.Intents) != 1 {
 				return nil, errors.Errorf("expected 1 intent, found %d: %s", len(wiErr.Intents), wiErr)
@@ -1286,21 +1291,24 @@ func removeDeadReplicas(
 			// A crude form of the intent resolution process: abort the
 			// transaction by deleting its record.
 			txnKey := keys.TransactionKey(intent.Txn.Key, intent.Txn.ID)
-			if err := engine.MVCCDelete(ctx, batch, nil /* stats */, txnKey, hlc.Timestamp{}, nil); err != nil {
+			if err := engine.MVCCDelete(ctx, batch, &ms, txnKey, hlc.Timestamp{}, nil); err != nil {
 				return nil, err
 			}
 			intent.Status = roachpb.ABORTED
-			if err := engine.MVCCResolveWriteIntent(ctx, batch, nil /* stats */, intent); err != nil {
+			if err := engine.MVCCResolveWriteIntent(ctx, batch, &ms, intent); err != nil {
 				return nil, err
 			}
 			// With the intent resolved, we can try again.
-			if err := engine.MVCCPutProto(ctx, batch, nil /* stats */, key, clock.Now(),
+			if err := engine.MVCCPutProto(ctx, batch, &ms, key, clock.Now(),
 				nil /* txn */, &desc); err != nil {
 				return nil, err
 			}
 		} else if err != nil {
 			batch.Close()
 			return nil, err
+		}
+		if err := sl.SetMVCCStats(ctx, batch, &ms); err != nil {
+			return nil, errors.Wrap(err, "updating MVCCStats")
 		}
 	}
 

--- a/pkg/cli/debug_test.go
+++ b/pkg/cli/debug_test.go
@@ -151,22 +151,25 @@ func TestRemoveDeadReplicas(t *testing.T) {
 
 					// The surviving nodes get a real store, others are just in memory.
 					var storePaths []string
-					clusterArgs := base.TestClusterArgs{ServerArgsPerNode: map[int]base.TestServerArgs{}}
+					clusterArgs := base.TestClusterArgs{
+						ServerArgsPerNode: map[int]base.TestServerArgs{},
+					}
 					deadReplicas := map[roachpb.StoreID]struct{}{}
 
 					for i := 0; i < testCase.totalNodes; i++ {
+						args := base.TestServerArgs{}
+						args.ScanMaxIdleTime = time.Millisecond
+						args.ScanMaxIdleTime = time.Millisecond
 						storeID := roachpb.StoreID(i + 1)
 						if i < testCase.survivingNodes {
 							path := filepath.Join(baseDir, fmt.Sprintf("store%d", storeID))
 							storePaths = append(storePaths, path)
 							// ServerArgsPerNode uses 0-based index, not node ID.
-							clusterArgs.ServerArgsPerNode[i] = base.TestServerArgs{
-								StoreSpecs:      []base.StoreSpec{{Path: path}},
-								ScanMaxIdleTime: time.Millisecond,
-							}
+							args.StoreSpecs = []base.StoreSpec{{Path: path}}
 						} else {
 							deadReplicas[storeID] = struct{}{}
 						}
+						clusterArgs.ServerArgsPerNode[i] = args
 					}
 
 					// Start the cluster, let it replicate, then stop it. Since the

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -1514,8 +1514,7 @@ func TestLogGrowthWhenRefreshingPendingCommands(t *testing.T) {
 }
 
 // TestStoreRangeUpReplicate verifies that the replication queue will notice
-// under-replicated ranges and replicate them. Also tests that snapshots which
-// contain sideloaded proposals don't panic the receiving end.
+// under-replicated ranges and replicate them.
 func TestStoreRangeUpReplicate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer storage.SetMockAddSSTable()()
@@ -1528,14 +1527,6 @@ func TestStoreRangeUpReplicate(t *testing.T) {
 	}
 	defer mtc.Stop()
 	mtc.Start(t, 3)
-	mtc.stopStore(2)
-	if err := storage.ProposeAddSSTable(
-		context.Background(), "k", "v", mtc.clocks[0].Now(), mtc.stores[0],
-	); err != nil {
-		t.Fatal(err)
-	}
-	mtc.restartStore(2)
-
 	mtc.initGossipNetwork()
 
 	// Once we know our peers, trigger a scan.


### PR DESCRIPTION
One in a test, one in unsafe-remove-dead-replicas. I noticed them while trying
out the unit tests with #41444.