### PR TITLE
release-19.1: opt: disallow mutations under union

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -375,12 +375,13 @@ upsert INTO upsert_returning VALUES (1, 5, 4, 3), (6, 5, 4, 3) RETURNING *
 statement ok
 COMMIT
 
-# For #22300. Test UPSERT ... RETURNING with UNION.
-query I rowsort
-SELECT a FROM [UPSERT INTO upsert_returning VALUES (7) RETURNING a] UNION VALUES (8)
-----
-7
-8
+# This test has been disabled in 19.1.x (see #40975). It is reenabled in 19.2.
+## For #22300. Test UPSERT ... RETURNING with UNION.
+#query I rowsort
+#SELECT a FROM [UPSERT INTO upsert_returning VALUES (7) RETURNING a] UNION VALUES (8)
+#----
+#7
+#8
 
 # For #6710. Add an unused column to disable the fast path which doesn't have this bug.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -110,3 +110,28 @@ CREATE TABLE a (a INT PRIMARY KEY)
 query I
 (SELECT NULL FROM a) EXCEPT (VALUES((SELECT 1 FROM a LIMIT 1)), (1))
 ----
+
+# Ensure that mutations under a UNION or UNION ALL error out (#40853).
+statement error mutations not supported under UNION
+SELECT * FROM uniontest
+UNION SELECT * FROM [INSERT INTO uniontest VALUES (1), (1) RETURNING k, v]
+
+statement error mutations not supported under UNION
+SELECT * FROM [INSERT INTO uniontest VALUES (1), (1) RETURNING k, v]
+UNION ALL SELECT * FROM uniontest
+
+statement error mutations not supported under UNION
+SELECT * FROM uniontest
+UNION SELECT * FROM (
+  WITH cte AS (INSERT INTO uniontest VALUES (1), (1) RETURNING k, v) SELECT * FROM cte
+)
+
+# We get same error with single-use CTEs.
+statement error mutations not supported under UNION
+WITH cte AS (INSERT INTO uniontest VALUES (1), (1) RETURNING k, v)
+(SELECT * FROM cte UNION SELECT * FROM uniontest)
+
+# Other set ops are allowed.
+statement ok
+SELECT * FROM uniontest
+EXCEPT SELECT * FROM [INSERT INTO uniontest VALUES (1), (1) RETURNING k, v]


### PR DESCRIPTION
Backport 1/2 commits from #40975.

/cc @cockroachdb/release

---

#### opt: disallow mutations under union

Because the inputs of a UNION or UNION ALL are run in parallel, it is
not possible for either of them to be mutations. The right way to do
this is to use WITH (above the union). The optimizer will have code to
pull up mutations into top-level WITHs, but until then we want to
disallow such queries from executing. This change adds a check for
this condition in the execbuilder.

Informs #40853.

Release note (sql change): Mutations under UNION or UNION ALL are now
disallowed. This restriction is temporary and will be lifted in a future release.

