### PR TITLE
util/tracing: change the default of trace.debug.enable to false

### DIFF
--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -795,7 +795,7 @@ func TestAdminAPIEvents(t *testing.T) {
 		{sql.EventLogCreateDatabase, false, 0, 3},
 		{sql.EventLogDropTable, false, 0, 2},
 		{sql.EventLogCreateTable, false, 0, 3},
-		{sql.EventLogSetClusterSetting, false, 0, 5},
+		{sql.EventLogSetClusterSetting, false, 0, 4},
 		{sql.EventLogCreateTable, true, 0, 3},
 		{sql.EventLogCreateTable, true, -1, 3},
 		{sql.EventLogCreateTable, true, 2, 2},

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -731,10 +731,10 @@ func TestReportUsage(t *testing.T) {
 		}
 	}
 
-	// 3 + 4 = 7: set 3 initially and org is set mid-test for 3 altered settings,
-	// plus version, reporting, trace and secret settings are set in startup
+	// 3 + 3 = 6: set 3 initially and org is set mid-test for 3 altered settings,
+	// plus version, reporting and secret settings are set in startup
 	// migrations.
-	if expected, actual := 7, len(r.last.AlteredSettings); expected != actual {
+	if expected, actual := 6, len(r.last.AlteredSettings); expected != actual {
 		t.Fatalf("expected %d changed settings, got %d: %v", expected, actual, r.last.AlteredSettings)
 	}
 	for key, expected := range map[string]string{
@@ -742,7 +742,6 @@ func TestReportUsage(t *testing.T) {
 		"diagnostics.reporting.enabled":            "true",
 		"diagnostics.reporting.send_crash_reports": "false",
 		"server.time_until_store_dead":             "1m30s",
-		"trace.debug.enable":                       "false",
 		"version":                                  cluster.BinaryServerVersion.String(),
 		"cluster.secret":                           "<redacted>",
 	} {

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -366,7 +366,6 @@ AND info NOT LIKE '%sql.defaults.vectorize%'
 ORDER BY "timestamp"
 ----
 0  1  {"SettingName":"diagnostics.reporting.enabled","Value":"true","User":"root"}
-0  1  {"SettingName":"trace.debug.enable","Value":"false","User":"root"}
 0  1  {"SettingName":"kv.range_merge.queue_enabled","Value":"false","User":"root"}
 0  1  {"SettingName":"sql.stats.automatic_collection.min_stale_rows","Value":"5","User":"root"}
 0  1  {"SettingName":"kv.allocator.load_based_lease_rebalancing.enabled","Value":"false","User":"root"}

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -500,7 +500,6 @@ cluster.secret
 diagnostics.reporting.enabled
 kv.range_merge.queue_enabled
 sql.stats.automatic_collection.min_stale_rows
-trace.debug.enable
 version
 
 statement ok
@@ -518,7 +517,6 @@ diagnostics.reporting.enabled                  true
 kv.range_merge.queue_enabled                   false
 somesetting                                    somevalue
 sql.stats.automatic_collection.min_stale_rows  5
-trace.debug.enable                             false
 
 user testuser
 

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -99,11 +99,6 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		workFn: populateVersionSetting,
 	},
 	{
-		// Introduced in v1.1. Permanent migration.
-		name:   "persist trace.debug.enable = 'false'",
-		workFn: disableNetTrace,
-	},
-	{
 		// Introduced in v2.0. Baked into v2.1.
 		name:             "create system.table_statistics table",
 		newDescriptorIDs: staticIDs(keys.TableStatisticsTableID),
@@ -629,7 +624,6 @@ func runStmtAsRootWithRetry(
 // from what was defined in code.
 var SettingsDefaultOverrides = map[string]string{
 	"diagnostics.reporting.enabled": "true",
-	"trace.debug.enable":            "false",
 	"cluster.secret":                "<random>",
 }
 
@@ -640,11 +634,6 @@ func optInToDiagnosticsStatReporting(ctx context.Context, r runner) error {
 	}
 	return runStmtAsRootWithRetry(
 		ctx, r, "optInToDiagnosticsStatReporting", `SET CLUSTER SETTING diagnostics.reporting.enabled = true`)
-}
-
-func disableNetTrace(ctx context.Context, r runner) error {
-	return runStmtAsRootWithRetry(
-		ctx, r, "disableNetTrace", `SET CLUSTER SETTING trace.debug.enable = false`)
 }
 
 func initializeClusterSecret(ctx context.Context, r runner) error {

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -55,11 +55,7 @@ const (
 var enableNetTrace = settings.RegisterBoolSetting(
 	"trace.debug.enable",
 	"if set, traces for recent requests can be seen in the /debug page",
-	// This setting defaults to true, but there is a sql migration that sets it
-	// to false. The effect is that we have tracing when the server starts and
-	// gets stuck there, without paying the overhead of having it on all the
-	// time (unless that's how the operator explicitly configures the cluster).
-	true,
+	false,
 )
 
 var lightstepToken = settings.RegisterStringSetting(


### PR DESCRIPTION
Before this patch, we weirdly defaulted that setting to true and then
had a migration setting it to false. The reason for this dance was to
trace the node startup (or the cluster bootstrap?) (i.e. the
debug/requests web page would show one trace for the cluster bootstrap
always). Cute, but I doubt this has been useful recently and is too
magic. It also has unintended consequences, as global variables do.
Tests and benchmarks that don't start a server end up running with this
sort of tracing enabled, which has effects for logging and other things.
In particular, I have another change where the size of Raft proposal
messages changes some when tracing is enabled. And so, I'd like to get
rid of the magic.

Release note: None