### PR TITLE
roachprod: use shared user `ubuntu` instead of local user on GCE

### DIFF
--- a/pkg/cmd/roachprod/config/config.go
+++ b/pkg/cmd/roachprod/config/config.go
@@ -40,4 +40,7 @@ const (
 	DefaultHostDir  = "${HOME}/.roachprod/hosts"
 	EmailDomain     = "@cockroachlabs.com"
 	Local           = "local"
+
+	// SharedUser is the linux username for shared use on all vms.
+	SharedUser = "ubuntu"
 )

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -435,6 +435,13 @@ func setupSSH(clusterName string) error {
 	if err != nil {
 		return err
 	}
+	// For GCP clusters we need to use the config.OSUser even if the client
+	// requested the shared user.
+	for i := range installCluster.VMs {
+		if cloudCluster.VMs[i].Provider == gce.ProviderName {
+			installCluster.Users[i] = config.OSUser.Username
+		}
+	}
 	if err := installCluster.Wait(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Before this PR we would set up the shared `ubuntu` user for SSH
during cluster creation but we'd continue to use the local user
which google set up. This change bring google in line with AWS in
terms of which user on the VM it uses.

Release note: None