### PR TITLE
roachtest: optimize GC and jobs.retention_time for all ORM tests

### DIFF
--- a/pkg/cmd/roachtest/pgjdbc.go
+++ b/pkg/cmd/roachtest/pgjdbc.go
@@ -34,6 +34,15 @@ func registerPgjdbc(r *testRegistry) {
 		c.Put(ctx, cockroach, "./cockroach", c.All())
 		c.Start(ctx, t, c.All())
 
+		version, err := fetchCockroachVersion(ctx, c, node[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := alterZoneConfigAndClusterSettings(ctx, version, c, node[0]); err != nil {
+			t.Fatal(err)
+		}
+
 		t.Status("cloning pgjdbc and installing prerequisites")
 		latestTag, err := repeatGetLatestTag(
 			ctx, c, "pgjdbc", "pgjdbc", pgjdbcReleaseTagRegex,
@@ -106,10 +115,6 @@ func registerPgjdbc(r *testRegistry) {
 			t.Fatal(err)
 		}
 
-		version, err := fetchCockroachVersion(ctx, c, node[0])
-		if err != nil {
-			t.Fatal(err)
-		}
 		blacklistName, expectedFailures, _, _ := pgjdbcBlacklists.getLists(version)
 		if expectedFailures == nil {
 			t.Fatalf("No pgjdbc blacklist defined for cockroach version %s", version)

--- a/pkg/cmd/roachtest/psycopg.go
+++ b/pkg/cmd/roachtest/psycopg.go
@@ -37,6 +37,15 @@ func registerPsycopg(r *testRegistry) {
 		c.Put(ctx, cockroach, "./cockroach", c.All())
 		c.Start(ctx, t, c.All())
 
+		version, err := fetchCockroachVersion(ctx, c, node[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := alterZoneConfigAndClusterSettings(ctx, version, c, node[0]); err != nil {
+			t.Fatal(err)
+		}
+
 		t.Status("cloning psycopg and installing prerequisites")
 		latestTag, err := repeatGetLatestTag(ctx, c, "psycopg", "psycopg2", psycopgReleaseTagRegex)
 		if err != nil {
@@ -85,10 +94,6 @@ func registerPsycopg(r *testRegistry) {
 			t.Fatal(err)
 		}
 
-		version, err := fetchCockroachVersion(ctx, c, node[0])
-		if err != nil {
-			t.Fatal(err)
-		}
 		blacklistName, expectedFailureList, ignoredlistName, ignoredlist := psycopgBlacklists.getLists(version)
 		if expectedFailureList == nil {
 			t.Fatalf("No psycopg blacklist defined for cockroach version %s", version)


### PR DESCRIPTION
This should help make tests go faster, since old descriptors and jobs
can get cleaned out more frequently before accumulating.

Also, fix a bug so that jobs.retention_time is not set if the version is
<=2.1 (since that cluster setting doesn't exist until later versions).

Release note: None