### PR TITLE
storage: remove handleRaftReady from processRequestQueue, pool RaftMessageRequests

### DIFF
--- a/pkg/storage/raft_transport_test.go
+++ b/pkg/storage/raft_transport_test.go
@@ -289,9 +289,9 @@ func TestSendAndReceive(t *testing.T) {
 				req.Message.Type = messageType
 
 				if !transports[fromNodeID].SendAsync(&req, rpc.DefaultClass) {
-					t.Errorf("unable to send %s from %d to %d", req.Message.Type, fromNodeID, toNodeID)
+					t.Errorf("unable to send %s from %d to %d", messageType, fromNodeID, toNodeID)
 				}
-				messageTypeCounts[toStoreID][req.Message.Type]++
+				messageTypeCounts[toStoreID][messageType]++
 			}
 		}
 	}
@@ -356,7 +356,9 @@ func TestSendAndReceive(t *testing.T) {
 			ReplicaID: replicaIDs[toStoreID],
 		},
 	}
-	if !transports[storeNodes[fromStoreID]].SendAsync(expReq, rpc.DefaultClass) {
+	// NB: argument passed to SendAsync is not safe to use after; make a copy.
+	expReqCopy := *expReq
+	if !transports[storeNodes[fromStoreID]].SendAsync(&expReqCopy, rpc.DefaultClass) {
 		t.Errorf("unable to send message from %d to %d", fromStoreID, toStoreID)
 	}
 	// NB: proto.Equal will panic here since it doesn't know about `gogoproto.casttype`.

--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -416,7 +416,7 @@ type handleRaftReadyStats struct {
 var noSnap IncomingSnapshot
 
 // handleRaftReady processes a raft.Ready containing entries and messages that
-// are ready to read, be saved to stable storage, committed or sent to other
+// are ready to read, be saved to stable storage, committed, or sent to other
 // peers. It takes a non-empty IncomingSnapshot to indicate that it is
 // about to process a snapshot.
 //

--- a/pkg/storage/scheduler_test.go
+++ b/pkg/storage/scheduler_test.go
@@ -142,10 +142,11 @@ func (p *testProcessor) processReady(_ context.Context, rangeID roachpb.RangeID)
 	p.mu.Unlock()
 }
 
-func (p *testProcessor) processRequestQueue(_ context.Context, rangeID roachpb.RangeID) {
+func (p *testProcessor) processRequestQueue(_ context.Context, rangeID roachpb.RangeID) bool {
 	p.mu.Lock()
 	p.mu.raftRequest[rangeID]++
 	p.mu.Unlock()
+	return false
 }
 
 func (p *testProcessor) processTick(_ context.Context, rangeID roachpb.RangeID) bool {

--- a/pkg/storage/store_raft.go
+++ b/pkg/storage/store_raft.go
@@ -658,7 +658,8 @@ func (s *Store) sendQueuedHeartbeatsToNode(
 		log.Fatal(ctx, "cannot coalesce both heartbeats and responses")
 	}
 
-	chReq := &RaftMessageRequest{
+	chReq := newRaftMessageRequest()
+	*chReq = RaftMessageRequest{
 		RangeID: 0,
 		ToReplica: roachpb.ReplicaDescriptor{
 			NodeID:    to.NodeID,
@@ -681,6 +682,7 @@ func (s *Store) sendQueuedHeartbeatsToNode(
 	}
 
 	if !s.cfg.Transport.SendAsync(chReq, rpc.SystemClass) {
+		chReq.release()
 		for _, beat := range beats {
 			if value, ok := s.mu.replicas.Load(int64(beat.RangeID)); ok {
 				(*Replica)(value).addUnreachableRemoteReplica(beat.ToReplicaID)


### PR DESCRIPTION
This PR combines two optimizations that together speed up Sysbench's `oltp_insect` (in this config: https://github.com/cockroachdb/cockroach/pull/41465#issuecomment-540251814) from a throughput of **115,308 qps** to **119,660 qps** (averaged over a series of trials), an improvement of **3.8%**. It also reduces average latency in these tests from **4.17 ms** to **4.02 ms**.

The first optimization removes the call to `handleRaftReady` from `processRequestQueue`, which addresses an existing TODO. This is a partial revert of #12356. Calling `handleRaftReady` from `processRequestQueue` results in less batching and redundant calls to `handleRaftReady`. This does have a negative effect on throughput, as was speculated in that PR. It also makes the schedulers hooks into Raft processing more complex.

This commit removes the explicit call to handleRaftReady from `processRequestQueue`. Instead, it opts to interact with the `raftScheduler` like `processTick` does. This simplifies the raft scheduler's interactions and improves write throughput.

The second optimization pools the allocations of `RaftMessageRequest` objects. These were showing up as the top allocator in a run of Sysbench's `oltp_insert` workload.