### PR TITLE
client/kv: keep transaction UserPriority in sync across client.Txn and TxnCoordSender

### DIFF
--- a/pkg/internal/client/sender.go
+++ b/pkg/internal/client/sender.go
@@ -231,7 +231,9 @@ type TxnSenderFactory interface {
 	// DistSQL flow.
 	// coordMeta is the TxnCoordMeta which contains the transaction whose requests
 	// this sender will carry.
-	TransactionalSender(typ TxnType, coordMeta roachpb.TxnCoordMeta) TxnSender
+	TransactionalSender(
+		typ TxnType, coordMeta roachpb.TxnCoordMeta, pri roachpb.UserPriority,
+	) TxnSender
 	// NonTransactionalSender returns a sender to be used for non-transactional
 	// requests. Generally this is a sender that TransactionalSender() wraps.
 	NonTransactionalSender() Sender
@@ -392,7 +394,7 @@ func MakeMockTxnSenderFactory(
 
 // TransactionalSender is part of TxnSenderFactory.
 func (f MockTxnSenderFactory) TransactionalSender(
-	_ TxnType, coordMeta roachpb.TxnCoordMeta,
+	_ TxnType, coordMeta roachpb.TxnCoordMeta, _ roachpb.UserPriority,
 ) TxnSender {
 	return NewMockTransactionalSender(f.senderFunc, &coordMeta.Txn)
 }
@@ -410,9 +412,9 @@ var _ TxnSenderFactory = NonTransactionalFactoryFunc(nil)
 
 // TransactionalSender is part of the TxnSenderFactory.
 func (f NonTransactionalFactoryFunc) TransactionalSender(
-	typ TxnType, _ roachpb.TxnCoordMeta,
+	_ TxnType, _ roachpb.TxnCoordMeta, _ roachpb.UserPriority,
 ) TxnSender {
-	panic("not supported ")
+	panic("not supported")
 }
 
 // NonTransactionalSender is part of the TxnSenderFactory.

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -105,7 +105,7 @@ type testSenderFactory struct {
 }
 
 func (f *testSenderFactory) TransactionalSender(
-	typ client.TxnType, coordMeta roachpb.TxnCoordMeta,
+	typ client.TxnType, coordMeta roachpb.TxnCoordMeta, _ roachpb.UserPriority,
 ) client.TxnSender {
 	return client.NewMockTransactionalSender(
 		func(


### PR DESCRIPTION
Informs #32508.

Before this change, a transaction's UserPriority could diverge between the
transaction's client.Txn and its TxnCoordSender. This resulted in the need for
ugly code
(https://github.com/cockroachdb/cockroach/blob/57b02ddc74004e39a411084e05a20dccd93c3a22/pkg/kv/txn_coord_sender.go#L786),
had bugs where a transaction could be restarted with the wrong user priority,
and resulted in redundant calls to `roachpb.MakePriority`.

This last issue had a runtime cost. We saw the redundant calls to
`roachpb.MakePriority` show up in profiles. For instance, it was responsible for
**0.32%** of a CPU profile when running Sysbench's `oltp_point_select` workload,
mainly due to how slow `rand.ExpFloat64` is on the global rand object.

This commit fixes this by keeping the priority in-sync between the `client.Txn`
and the `kv.TxnCoordSender`. A side-effect of this is that we no longer perform
redundant calls to `roachpb.MakePriority`.

Release note: None