### PR TITLE
roachtest: Add a django testing framework and blacklist

### DIFF
--- a/pkg/cmd/roachtest/README.md
+++ b/pkg/cmd/roachtest/README.md
@@ -32,4 +32,10 @@ binaries you've touched. For example, the command line that you might use
 while iterating on jepsen tests is `make bin/roachtest &&
 roachtest run jepsen/1/bank/split`
 
-TODO: document process for creating and reusing a cluster.
+To keep your cluster after the roachtest finishes, use the `--debug` flag
+with `roachtest run`. You can use `roachprod` to connect to your cluster and
+examine the state by using `roachprod setup-ssh <cluster name>`. This will print
+out an IP address to connect to using `ssh`. To have `roachtest` reuse an
+existing cluster, pass the `--cluster <clustername` argument to 
+`roachtest run`. 
+

--- a/pkg/cmd/roachtest/django.go
+++ b/pkg/cmd/roachtest/django.go
@@ -1,0 +1,219 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+)
+
+var djangoReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
+
+func registerDjango(r *testRegistry) {
+	runDjango := func(
+		ctx context.Context,
+		t *test,
+		c *cluster,
+	) {
+		if c.isLocal() {
+			t.Fatal("cannot be run in local mode")
+		}
+		node := c.Node(1)
+		t.Status("setting up cockroach")
+		c.Put(ctx, cockroach, "./cockroach", c.All())
+		c.Start(ctx, t, c.All())
+
+		version, err := fetchCockroachVersion(ctx, c, node[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = alterZoneConfigAndClusterSettings(ctx, version, c, node[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.Status("cloning django and installing prerequisites")
+
+		if err := repeatRunE(
+			ctx, c, node, "update apt-get",
+			`
+				sudo add-apt-repository ppa:deadsnakes/ppa &&
+				sudo apt-get -qq update`,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repeatRunE(
+			ctx,
+			c,
+			node,
+			"install python dependencies",
+			`sudo apt-get -qq install python3.6 python3.6-dev build-essential`,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repeatRunE(
+			ctx, c, node, "set python3.6 as default", `
+    		sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.5 1
+    		sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 2
+    		sudo update-alternatives --config python3`,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repeatRunE(
+			ctx, c, node, "install pip",
+			`curl https://bootstrap.pypa.io/get-pip.py | sudo -H python3.6`,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repeatRunE(
+			ctx, c, node, "install postgres",
+			`sudo apt-get -qq install postgresql postgresql-contrib libpq-dev`,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repeatRunE(
+			ctx, c, node, "remove old django", `rm -rf /mnt/data1/django`,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		latestTag, err := repeatGetLatestTag(
+			ctx, c, "django", "django", djangoReleaseTagRegex,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		c.l.Printf("Latest Django release is %s.", latestTag)
+
+		if err := repeatGitCloneE(
+			ctx,
+			t.l,
+			c,
+			"https://github.com/django/django/",
+			"/mnt/data1/django",
+			latestTag,
+			node,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repeatGitCloneE(
+			ctx,
+			t.l,
+			c,
+			"https://github.com/cockroachdb/cockroach-django",
+			"/mnt/data1/django/tests/cockroach-django",
+			// TODO (rohany): change the arguments to take in a specific branch here.
+			"master",
+			node,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repeatRunE(
+			ctx, c, node, "install cockroach-django", `
+					cd /mnt/data1/django/tests/cockroach-django/ && 
+					pip3 install psycopg2-binary --user && pip3 install . --user`,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repeatRunE(
+			ctx, c, node, "install django's dependencies", `
+				cd /mnt/data1/django/tests &&
+				pip3 install -e .. --user &&
+				pip3 install -r requirements/py3.txt --user && 
+				pip3 install -r requirements/postgres.txt --user`,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		// Write the cockroach config into the test suite to use.
+		if err := repeatRunE(
+			ctx, c, node, "configuring tests to use cockroach",
+			fmt.Sprintf(
+				"echo \"%s\" > /mnt/data1/django/tests/cockroach_settings.py",
+				cockroachDjangoSettings,
+			),
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		blacklistName, expectedFailureList, ignoredlistName, ignoredlist := djangoBlacklists.getLists(version)
+		if expectedFailureList == nil {
+			t.Fatalf("No django blacklist defined for cockroach version %s", version)
+		}
+		if ignoredlist == nil {
+			t.Fatalf("No django ignorelist defined for cockroach version %s", version)
+		}
+		c.l.Printf("Running cockroach version %s, using blacklist %s, using ignoredlist %s",
+			version, blacklistName, ignoredlistName)
+
+		// TODO (rohany): move this to a file backed buffer if the output becomes
+		//  too large.
+		var fullTestResults []byte
+		for _, testName := range enabledDjangoTests {
+			c.l.Printf("Running django test app %s", testName)
+			// Running the test suite is expected to error out, so swallow the error.
+			rawResults, _ := c.RunWithBuffer(
+				ctx, t.l, node, fmt.Sprintf(djangoRunTestCmd, testName))
+			fullTestResults = append(fullTestResults, rawResults...)
+			c.l.Printf("Test Results for app %s: %s", testName, rawResults)
+		}
+		t.Status("collating test results")
+
+		results := newORMTestsResults()
+		results.parsePythonUnitTestOutput(fullTestResults, expectedFailureList, ignoredlist)
+		results.summarizeAll(
+			t, "django" /* ormName */, blacklistName,
+			expectedFailureList, version, latestTag,
+		)
+	}
+
+	r.Add(testSpec{
+		Skip:       "django tests are still too flaky to run",
+		MinVersion: "v19.2.0",
+		Name:       "django",
+		Cluster:    makeClusterSpec(1),
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			runDjango(ctx, t, c)
+		},
+	})
+}
+
+const djangoRunTestCmd = `
+cd /mnt/data1/django/tests &&
+python3 runtests.py %s --settings cockroach_settings --parallel 1 -v 2
+`
+
+const cockroachDjangoSettings = `
+DATABASES = {
+    'default': {
+        'ENGINE': 'cockroach.django',
+        'NAME' : 'django_tests',
+        'USER' : 'root',
+        'PASSWORD' : '',
+        'HOST': 'localhost',
+        'PORT' : 26257,
+    },
+}
+SECRET_KEY = 'django_tests_secret_key'
+PASSWORD_HASHERS = [
+    'django.contrib.auth.hashers.MD5PasswordHasher',
+]
+`

--- a/pkg/cmd/roachtest/django_blacklist.go
+++ b/pkg/cmd/roachtest/django_blacklist.go
@@ -1,0 +1,84 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+// As of now, we only run a subset of the test apps within the django
+// testing suite. The full set we run is below, and should be kept
+// in alphabetical order. As more progress is made with adding compatibility,
+// more test apps should be added here to prevent against regression.
+var enabledDjangoTests = []string{
+	"app_loading",
+	"apps",
+	// This is a really large test. Uncomment for later runs.
+	// "auth_tests",
+	"backends",
+	"base",
+	"bash_completion",
+	"update",
+}
+
+var djangoBlacklists = blacklistsForVersion{
+	{"v19.2", "djangoBlacklist19_2", djangoBlacklist19_2, "djangoIgnoreList19_2", djangoIgnoreList19_2},
+}
+
+// Maintain that this list is alphabetized.
+// TODO (rohany): The django tests are very flaky right now, so the blacklist
+//  doesn't stay consistent across runs.
+var djangoBlacklist19_2 = blacklist{
+	// Blacklist generated from running the tests above.
+	"app_loading.tests.GetModelsTest.test_get_models_only_returns_installed_models":    "unknown",
+	"apps.tests.AppsTests.test_models_not_loaded":                                      "unknown",
+	"backends.base.test_base.ExecuteWrapperTests.test_wrapper_connection_specific":     "unknown",
+	"backends.tests.DateQuotingTest.test_django_date_trunc":                            "unknown",
+	"backends.tests.FkConstraintsTests.test_check_constraints":                         "unknown",
+	"backends.tests.FkConstraintsTests.test_disable_constraint_checks_context_manager": "unknown",
+	"backends.tests.FkConstraintsTests.test_disable_constraint_checks_manually":        "unknown",
+	"backends.tests.ThreadTests.test_connections_thread_local":                         "unknown",
+	"update.tests.SimpleTest.test_nonempty_update_with_inheritance":                    "unknown",
+	// TODO (rohany): The postgres_tests suite within Django is not in a automatically
+	//  runnable state right now.
+	//"postgres_tests.test_aggregates.TestGeneralAggregate.test_bit_and_empty_result":                                 "41334",
+	//"postgres_tests.test_aggregates.TestGeneralAggregate.test_bit_and_general":                                      "41334",
+	//"postgres_tests.test_aggregates.TestGeneralAggregate.test_bit_and_on_only_false_values":                         "41334",
+	//"postgres_tests.test_aggregates.TestGeneralAggregate.test_bit_and_on_only_true_values":                          "41334",
+	//"postgres_tests.test_aggregates.TestGeneralAggregate.test_bit_or_empty_result":                                  "41334",
+	//"postgres_tests.test_aggregates.TestGeneralAggregate.test_bit_or_general":                                       "41334",
+	//"postgres_tests.test_aggregates.TestGeneralAggregate.test_bit_or_on_only_false_values":                          "41334",
+	//"postgres_tests.test_aggregates.TestGeneralAggregate.test_bit_or_on_only_true_values":                           "41334",
+	//"postgres_tests.test_aggregates.TestStatisticsAggregate.test_corr_empty_result":                                 "41274",
+	//"postgres_tests.test_aggregates.TestStatisticsAggregate.test_corr_general":                                      "41274",
+	//"postgres_tests.test_aggregates.TestStatisticsAggregate.test_covar_pop_empty_result":                            "41274",
+	//"postgres_tests.test_aggregates.TestStatisticsAggregate.test_covar_pop_general":                                 "41274",
+	//"postgres_tests.test_aggregates.TestStatisticsAggregate.test_covar_pop_sample":                                  "41274",
+	//"postgres_tests.test_aggregates.TestStatisticsAggregate.test_covar_pop_sample_empty_result":                     "41274",
+	//"postgres_tests.test_aggregates.TestStatisticsAggregate.test_regr_avgx_empty_result":                            "41274",
+	//"postgres_tests.test_aggregates.TestStatisticsAggregate.test_regr_avgx_general":                                 "41274",
+	//"postgres_tests.test_aggregates.TestStatisticsAggregate.test_regr_avgx_with_related_obj_and_number_as_argument": "41274",
+	//"postgres_tests.test_aggregates.TestStatisticsAggregate.test_regr_avgy_empty_result":                            "41274",
+	//"postgres_tests.test_aggregates.TestStatisticsAggregate.test_regr_avgy_general":                                 "41274",
+	//"postgres_tests.test_aggregates.TestStatisticsAggregate.test_regr_count_empty_result":                           "41274",
+	//"postgres_tests.test_aggregates.TestStatisticsAggregate.test_regr_count_general":                                "41274",
+	//"postgres_tests.test_aggregates.TestStatisticsAggregate.test_regr_intercept_empty_result":                       "41274",
+	//"postgres_tests.test_aggregates.TestStatisticsAggregate.test_regr_intercept_general":                            "41274",
+	//"postgres_tests.test_aggregates.TestStatisticsAggregate.test_regr_r2_empty_result":                              "41274",
+	//"postgres_tests.test_aggregates.TestStatisticsAggregate.test_regr_r2_general":                                   "41274",
+	//"postgres_tests.test_aggregates.TestStatisticsAggregate.test_regr_slope_empty_result":                           "41274",
+	//"postgres_tests.test_aggregates.TestStatisticsAggregate.test_regr_slope_general":                                "41274",
+	//"postgres_tests.test_aggregates.TestStatisticsAggregate.test_regr_sxx_empty_result":                             "41274",
+	//"postgres_tests.test_aggregates.TestStatisticsAggregate.test_regr_sxx_general":                                  "41274",
+	//"postgres_tests.test_aggregates.TestStatisticsAggregate.test_regr_sxy_empty_result":                             "41274",
+	//"postgres_tests.test_aggregates.TestStatisticsAggregate.test_regr_sxy_general":                                  "41274",
+	//"postgres_tests.test_aggregates.TestStatisticsAggregate.test_regr_syy_empty_result":                             "41274",
+	//"postgres_tests.test_aggregates.TestStatisticsAggregate.test_regr_syy_general":                                  "41274",
+	//"postgres_tests.test_array.TestOtherTypesExactQuerying.test_exact_decimals":                                     "23468",
+}
+
+var djangoIgnoreList19_2 = blacklist{}

--- a/pkg/cmd/roachtest/psycopg.go
+++ b/pkg/cmd/roachtest/psycopg.go
@@ -11,14 +11,10 @@
 package main
 
 import (
-	"bufio"
-	"bytes"
 	"context"
-	"fmt"
 	"regexp"
 )
 
-var psycopgResultRegex = regexp.MustCompile(`(?P<name>.*) \((?P<class>.*)\) \.\.\. (?P<result>[^ ']*)(?: u?['"](?P<reason>.*)['"])?`)
 var psycopgReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)(?:_(?P<minor>\d+)(?:_(?P<point>\d+)(?:_(?P<subpoint>\d+))?)?)?$`)
 
 // This test runs psycopg full test suite against a single cockroach node.
@@ -121,58 +117,7 @@ func registerPsycopg(r *testRegistry) {
 
 		// Find all the failed and errored tests.
 		results := newORMTestsResults()
-
-		scanner := bufio.NewScanner(bytes.NewReader(rawResults))
-		for scanner.Scan() {
-			match := psycopgResultRegex.FindStringSubmatch(scanner.Text())
-			if match != nil {
-				groups := map[string]string{}
-				for i, name := range match {
-					groups[psycopgResultRegex.SubexpNames()[i]] = name
-				}
-				test := fmt.Sprintf("%s.%s", groups["class"], groups["name"])
-				var skipReason string
-				if groups["result"] == "skipped" {
-					skipReason = groups["reason"]
-				}
-				pass := groups["result"] == "ok"
-				results.allTests = append(results.allTests, test)
-
-				ignoredIssue, expectedIgnored := ignoredlist[test]
-				issue, expectedFailure := expectedFailures[test]
-				switch {
-				case expectedIgnored:
-					results.results[test] = fmt.Sprintf("--- SKIP: %s due to %s (expected)", test, ignoredIssue)
-					results.ignoredCount++
-				case len(skipReason) > 0 && expectedFailure:
-					results.results[test] = fmt.Sprintf("--- SKIP: %s due to %s (unexpected)", test, skipReason)
-					results.unexpectedSkipCount++
-				case len(skipReason) > 0:
-					results.results[test] = fmt.Sprintf("--- SKIP: %s due to %s (expected)", test, skipReason)
-					results.skipCount++
-				case pass && !expectedFailure:
-					results.results[test] = fmt.Sprintf("--- PASS: %s (expected)", test)
-					results.passExpectedCount++
-				case pass && expectedFailure:
-					results.results[test] = fmt.Sprintf("--- PASS: %s - %s (unexpected)",
-						test, maybeAddGithubLink(issue),
-					)
-					results.passUnexpectedCount++
-				case !pass && expectedFailure:
-					results.results[test] = fmt.Sprintf("--- FAIL: %s - %s (expected)",
-						test, maybeAddGithubLink(issue),
-					)
-					results.failExpectedCount++
-					results.currentFailures = append(results.currentFailures, test)
-				case !pass && !expectedFailure:
-					results.results[test] = fmt.Sprintf("--- FAIL: %s (unexpected)", test)
-					results.failUnexpectedCount++
-					results.currentFailures = append(results.currentFailures, test)
-				}
-				results.runTests[test] = struct{}{}
-			}
-		}
-
+		results.parsePythonUnitTestOutput(rawResults, expectedFailures, ignoredlist)
 		results.summarizeAll(
 			t, "psycopg" /* ormName */, blacklistName, expectedFailures,
 			version, latestTag,

--- a/pkg/cmd/roachtest/python_helpers.go
+++ b/pkg/cmd/roachtest/python_helpers.go
@@ -1,0 +1,75 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"regexp"
+)
+
+var pythonUnitTestOutputRegex = regexp.MustCompile(`(?P<name>.*) \((?P<class>.*)\) \.\.\. (?P<result>[^ ']*)(?: u?['"](?P<reason>.*)['"])?`)
+
+func (r *ormTestsResults) parsePythonUnitTestOutput(
+	input []byte, expectedFailures blacklist, ignoredList blacklist,
+) {
+	scanner := bufio.NewScanner(bytes.NewReader(input))
+	for scanner.Scan() {
+		match := pythonUnitTestOutputRegex.FindStringSubmatch(scanner.Text())
+		if match != nil {
+			groups := map[string]string{}
+			for i, name := range match {
+				groups[pythonUnitTestOutputRegex.SubexpNames()[i]] = name
+			}
+			test := fmt.Sprintf("%s.%s", groups["class"], groups["name"])
+			var skipReason string
+			if groups["result"] == "skipped" {
+				skipReason = groups["reason"]
+			}
+			pass := groups["result"] == "ok"
+			r.allTests = append(r.allTests, test)
+
+			ignoredIssue, expectedIgnored := ignoredList[test]
+			issue, expectedFailure := expectedFailures[test]
+			switch {
+			case expectedIgnored:
+				r.results[test] = fmt.Sprintf("--- SKIP: %s due to %s (expected)", test, ignoredIssue)
+				r.ignoredCount++
+			case len(skipReason) > 0 && expectedFailure:
+				r.results[test] = fmt.Sprintf("--- SKIP: %s due to %s (unexpected)", test, skipReason)
+				r.unexpectedSkipCount++
+			case len(skipReason) > 0:
+				r.results[test] = fmt.Sprintf("--- SKIP: %s due to %s (expected)", test, skipReason)
+				r.skipCount++
+			case pass && !expectedFailure:
+				r.results[test] = fmt.Sprintf("--- PASS: %s (expected)", test)
+				r.passExpectedCount++
+			case pass && expectedFailure:
+				r.results[test] = fmt.Sprintf("--- PASS: %s - %s (unexpected)",
+					test, maybeAddGithubLink(issue),
+				)
+				r.passUnexpectedCount++
+			case !pass && expectedFailure:
+				r.results[test] = fmt.Sprintf("--- FAIL: %s - %s (expected)",
+					test, maybeAddGithubLink(issue),
+				)
+				r.failExpectedCount++
+				r.currentFailures = append(r.currentFailures, test)
+			case !pass && !expectedFailure:
+				r.results[test] = fmt.Sprintf("--- FAIL: %s (unexpected)", test)
+				r.failUnexpectedCount++
+				r.currentFailures = append(r.currentFailures, test)
+			}
+			r.runTests[test] = struct{}{}
+		}
+	}
+}

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -27,6 +27,7 @@ func registerTests(r *testRegistry) {
 	registerDecommission(r)
 	registerDiskFull(r)
 	registerDiskStalledDetection(r)
+	registerDjango(r)
 	registerDrop(r)
 	registerElectionAfterRestart(r)
 	registerEncryption(r)


### PR DESCRIPTION
This PR creates a roachtest that runs a subset of the django tests
against cockroachdb, as well as performing a refactor of the python ORM
testing frameworks.

Release note: None