### PR TITLE
storage: Add GetSSTables on Pebble struct, enable compaction suggester

### DIFF
--- a/pkg/storage/engine/engine_test.go
+++ b/pkg/storage/engine/engine_test.go
@@ -13,6 +13,7 @@ package engine
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"math/rand"
 	"path/filepath"
 	"reflect"
@@ -487,6 +488,37 @@ func TestEngineMerge(t *testing.T) {
 			if !reflect.DeepEqual(resultV, expectedV) {
 				t.Errorf("unexpected append-merge result: %v != %v", resultV, expectedV)
 			}
+		}
+	}, t)
+}
+
+func TestFlushWithSSTables(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	runWithAllEngines(func(engine Engine, t *testing.T) {
+		batch := engine.NewBatch()
+		for i := 0; i < 10000; i++ {
+			key := make([]byte, 4)
+			binary.BigEndian.PutUint32(key, uint32(i))
+			err := batch.Put(MVCCKey{Key: key}, []byte("foobar"))
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		err := batch.Commit(true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		batch.Close()
+
+		err = engine.Flush()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ssts := engine.(WithSSTables).GetSSTables()
+		if len(ssts) == 0 {
+			t.Fatal("expected non-zero sstables, got 0")
 		}
 	}, t)
 }

--- a/pkg/storage/replica_destroy.go
+++ b/pkg/storage/replica_destroy.go
@@ -98,10 +98,7 @@ func (r *Replica) postDestroyRaftMuLocked(ctx context.Context, ms enginepb.MVCCS
 	//
 	// TODO(benesch): we would ideally atomically suggest the compaction with
 	// the deletion of the data itself.
-	//
-	// TODO(itsbilal): Remove the compactor != nil check once Pebble supports
-	// GetSSTables.
-	if ms != (enginepb.MVCCStats{}) && r.store.compactor != nil {
+	if ms != (enginepb.MVCCStats{}) {
 		desc := r.Desc()
 		r.store.compactor.Suggest(ctx, storagepb.SuggestedCompaction{
 			StartKey: roachpb.Key(desc.StartKey),

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -821,20 +821,17 @@ func NewStore(
 	s.txnWaitMetrics = txnwait.NewMetrics(cfg.HistogramWindowInterval)
 	s.metrics.registry.AddMetricStruct(s.txnWaitMetrics)
 
-	// TODO(itsbilal): Remove this check once Pebble supports GetSSTables.
-	if engine, ok := s.engine.(engine.WithSSTables); ok {
-		s.compactor = compactor.NewCompactor(
-			s.cfg.Settings,
-			engine,
-			func() (roachpb.StoreCapacity, error) {
-				return s.Capacity(false /* useCached */)
-			},
-			func(ctx context.Context) {
-				s.asyncGossipStore(ctx, "compactor-initiated rocksdb compaction", false /* useCached */)
-			},
-		)
-		s.metrics.registry.AddMetricStruct(s.compactor.Metrics)
-	}
+	s.compactor = compactor.NewCompactor(
+		s.cfg.Settings,
+		s.engine.(engine.WithSSTables),
+		func() (roachpb.StoreCapacity, error) {
+			return s.Capacity(false /* useCached */)
+		},
+		func(ctx context.Context) {
+			s.asyncGossipStore(ctx, "compactor-initiated rocksdb compaction", false /* useCached */)
+		},
+	)
+	s.metrics.registry.AddMetricStruct(s.compactor.Metrics)
 
 	s.snapshotApplySem = make(chan struct{}, cfg.concurrentSnapshotApplyLimit)
 
@@ -1449,7 +1446,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	}
 
 	// Start the storage engine compactor.
-	if envutil.EnvOrDefaultBool("COCKROACH_ENABLE_COMPACTOR", true) && s.compactor != nil {
+	if envutil.EnvOrDefaultBool("COCKROACH_ENABLE_COMPACTOR", true) {
 		s.compactor.Start(s.AnnotateCtx(context.Background()), s.stopper)
 	}
 


### PR DESCRIPTION
This change updates the Pebble wrapper struct to implement `GetSSTables()`,
which lets the compactor suggest compactions on pebble instances. Also
remove related compactor != nil checks.

Release note: None