### PR TITLE
release-19.2: storage/engine: pull in Pebble batch optimizations

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -427,7 +427,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:8691c0cd3246e045a951b907e94af1165904d663a4ce0013c4650751643a8945"
+  digest = "1:eb5b95cb849809eecc0f19778ea2b79d9c892208f4c57741b25102d2ceba9fa6"
   name = "github.com/cockroachdb/pebble"
   packages = [
     ".",
@@ -450,7 +450,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "b8525550fbb0604c22fbf7879e836d44e5233272"
+  revision = "edde981dcc258907bdcc010017d1a7ccc6b59174"
 
 [[projects]]
   branch = "master"
@@ -799,6 +799,18 @@
   packages = ["."]
   pruneopts = "UT"
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
+
+[[projects]]
+  branch = "master"
+  digest = "1:b87c6f69cfb9f9b332c582ed93f7371150d21f40da6118d6547534e69b12cabb"
+  name = "github.com/golang/leveldb"
+  packages = [
+    "crc",
+    "db",
+    "table",
+  ]
+  pruneopts = "UT"
+  revision = "259d9253d71996b7778a3efb4144fe4892342b18"
 
 [[projects]]
   digest = "1:6ce94e52c5f56dfbea4e3cb99ccf4b44d701d91b16167486e9842b2fe45e717a"
@@ -1983,6 +1995,8 @@
     "github.com/gogo/protobuf/vanity/command",
     "github.com/golang-commonmark/markdown",
     "github.com/golang/dep/cmd/dep",
+    "github.com/golang/leveldb/db",
+    "github.com/golang/leveldb/table",
     "github.com/golang/protobuf/proto",
     "github.com/golang/snappy",
     "github.com/google/btree",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -427,7 +427,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:42b3b311d72e202b62fd5d1962edc6fc099062a0b10300fa3f28481106520611"
+  digest = "1:8691c0cd3246e045a951b907e94af1165904d663a4ce0013c4650751643a8945"
   name = "github.com/cockroachdb/pebble"
   packages = [
     ".",
@@ -450,7 +450,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "b54d5a75a3c4018dced942c98d5223704789abb4"
+  revision = "b8525550fbb0604c22fbf7879e836d44e5233272"
 
 [[projects]]
   branch = "master"
@@ -799,18 +799,6 @@
   packages = ["."]
   pruneopts = "UT"
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
-
-[[projects]]
-  branch = "master"
-  digest = "1:b87c6f69cfb9f9b332c582ed93f7371150d21f40da6118d6547534e69b12cabb"
-  name = "github.com/golang/leveldb"
-  packages = [
-    "crc",
-    "db",
-    "table",
-  ]
-  pruneopts = "UT"
-  revision = "259d9253d71996b7778a3efb4144fe4892342b18"
 
 [[projects]]
   digest = "1:6ce94e52c5f56dfbea4e3cb99ccf4b44d701d91b16167486e9842b2fe45e717a"
@@ -1995,8 +1983,6 @@
     "github.com/gogo/protobuf/vanity/command",
     "github.com/golang-commonmark/markdown",
     "github.com/golang/dep/cmd/dep",
-    "github.com/golang/leveldb/db",
-    "github.com/golang/leveldb/table",
     "github.com/golang/protobuf/proto",
     "github.com/golang/snappy",
     "github.com/google/btree",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -427,20 +427,20 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:76f5abe2591e8f84524dc5cbeaf4dcb4d67565b9e994bafb6cf0879f586c989d"
+  digest = "1:42b3b311d72e202b62fd5d1962edc6fc099062a0b10300fa3f28481106520611"
   name = "github.com/cockroachdb/pebble"
   packages = [
     ".",
     "bloom",
-    "cache",
     "internal/arenaskl",
     "internal/base",
-    "internal/batch",
     "internal/batchskl",
     "internal/bytealloc",
+    "internal/cache",
     "internal/crc",
     "internal/humanize",
     "internal/manifest",
+    "internal/private",
     "internal/rangedel",
     "internal/rate",
     "internal/rawalloc",
@@ -450,7 +450,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "1acac2061f9f5430a7c69e1e5afedfdaeab9e4ef"
+  revision = "b54d5a75a3c4018dced942c98d5223704789abb4"
 
 [[projects]]
   branch = "master"
@@ -1961,7 +1961,6 @@
     "github.com/cockroachdb/gostdlib/x/tools/cmd/goimports",
     "github.com/cockroachdb/logtags",
     "github.com/cockroachdb/pebble",
-    "github.com/cockroachdb/pebble/cache",
     "github.com/cockroachdb/pebble/sstable",
     "github.com/cockroachdb/pebble/tool",
     "github.com/cockroachdb/pebble/vfs",

--- a/pkg/storage/engine/batch_test.go
+++ b/pkg/storage/engine/batch_test.go
@@ -302,14 +302,12 @@ func TestBatchRepr(t *testing.T) {
 
 		// The keys in the batch have the internal MVCC encoding applied which for
 		// this test implies an appended 0 byte.
-		// TODO(itsbilal): Treat SingleDeletions as Deletions until pebble.Batch
-		// works with SingleDelete.
 		expOps := []string{
 			"put(a\x00,value)",
 			"delete(b\x00)",
 			"merge(c\x00)",
 			"put(e\x00,)",
-			"delete(d\x00)",
+			"single_delete(d\x00)",
 		}
 		if !reflect.DeepEqual(expOps, ops) {
 			t.Fatalf("expected %v, but found %v", expOps, ops)

--- a/pkg/storage/engine/temp_engine.go
+++ b/pkg/storage/engine/temp_engine.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/diskmap"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/pebble"
-	"github.com/cockroachdb/pebble/cache"
 	"github.com/cockroachdb/pebble/vfs"
 )
 
@@ -107,7 +106,7 @@ func NewPebbleTempEngine(
 	opts := &pebble.Options{
 		// Pebble doesn't currently support 0-size caches, so use a 128MB cache for
 		// now.
-		Cache: cache.New(128 << 20),
+		Cache: pebble.NewCache(128 << 20),
 		// The Pebble temp engine does not use MVCC Encoding. Instead, the
 		// caller-provided key is used as-is (with the prefix prepended). See
 		// pebbleMap.makeKey and pebbleMap.makeKeyWithSequence on how this works.


### PR DESCRIPTION
Note that I reverted the change to `sst_iterator.go` in the second commit so that all it contains now is the Pebble version bump. The result is that this backport has 3 vendor version bumps, and the change to `RocksDBBatchBuilder` to adapt to the new Pebble interfaces.

Backport:
  * 1/1 commits from "vendor: No-change bump to Pebble" (#41397)
  * 1/1 commits from "storage/engine: migrate sstIterator to Pebble" (#41347)
  * 1/1 commits from "storage/engine: pull in Pebble batch optimizations" (#41465)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: low-risk fixes for performance regressions in batch building.
