### PR TITLE
roachprod: set empty default value for --aws-cpu-options and only use if set

### DIFF
--- a/pkg/cmd/roachprod/vm/aws/aws.go
+++ b/pkg/cmd/roachprod/vm/aws/aws.go
@@ -125,7 +125,7 @@ func (o *providerOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&o.SSDMachineType, ProviderName+"-machine-type-ssd", defaultSSDMachineType,
 		"Machine type for --local-ssd (see https://aws.amazon.com/ec2/instance-types/)")
 
-	flags.StringVar(&o.CPUOptions, ProviderName+"-cpu-options", defaultSSDMachineType,
+	flags.StringVar(&o.CPUOptions, ProviderName+"-cpu-options", "",
 		"Options to specify number of cores and threads per core (see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-optimize-cpu.html#instance-specify-cpu-options)")
 
 	// AWS images generally use "ubuntu" or "ec2-user"
@@ -644,13 +644,15 @@ func (p *Provider) runInstance(name string, zone string, opts vm.CreateOpts) err
 		"--count", "1",
 		"--image-id", az.region.AMI,
 		"--instance-type", machineType,
-		"--cpu-options", cpuOptions,
 		"--key-name", keyName,
 		"--region", az.region.Name,
 		"--security-group-ids", az.region.SecurityGroup,
 		"--subnet-id", az.subnetID,
 		"--tag-specifications", tagSpecs,
 		"--user-data", "file://" + filename,
+	}
+	if cpuOptions != "" {
+		args = append(args, "--cpu-options", cpuOptions)
 	}
 
 	// The local NVMe devices are automatically mapped.  Otherwise, we need to map an EBS data volume.


### PR DESCRIPTION
Before this PR creating clusters which did not explicitly set the CPU options
would cause an error:

```
Cleaning up partially-created cluster (prev err: in provider: aws: failed to run: aws ec2 run-instances --associate-public-ip-address --count 1 --image-id ami-965e6bf3 --instance-type c5d.9xlarge --cpu-options c5d.9xlarge --key-name ajwerner-p3vIvVT5-GnuvUAWS4yVbt6-tSY= --region us-east-2 --security-group-ids sg-031
9fc9c9599a6145 --subnet-id subnet-09065271eb9d0144d --tag-specifications ResourceType=instance,Tags=[{Key=Lifetime,Value=12h0m0s},{Key=Name,Value=ajwerner-tpcc-big-0001},{Key=Roachprod,Value=true},] --user-data file:///tmp/aws-startup-script048426849 --output json: stderr:
Error parsing parameter '--cpu-options': Expected: '=', received: 'EOF' for input:
c5d.9xlarge
```

Release note: None