### PR TITLE
keys: Do not gossip the system.namespace Table

### DIFF
--- a/pkg/config/system_test.go
+++ b/pkg/config/system_test.go
@@ -293,7 +293,9 @@ func TestComputeSplitKeyTableIDs(t *testing.T) {
 	kvs, _ /* splits */ := schema.GetInitialValues()
 	userSQL := append(kvs, descriptor(start), descriptor(start+1), descriptor(start+5))
 	// Real system tables and partitioned user tables.
-	subzoneSQL := append(userSQL,
+	var userSQLCopy = make([]roachpb.KeyValue, len(userSQL))
+	copy(userSQLCopy, userSQL)
+	subzoneSQL := append(userSQLCopy,
 		zoneConfig(start+1, subzone("a", ""), subzone("c", "e")),
 		zoneConfig(start+5, subzone("b", ""), subzone("c", "d"), subzone("d", "")))
 
@@ -404,7 +406,7 @@ func TestGetZoneConfigForKey(t *testing.T) {
 		{roachpb.RKey(keys.SystemConfigSplitKey), keys.SystemDatabaseID},
 
 		// Gossiped system tables should refer to the SystemDatabaseID.
-		{tkey(keys.NamespaceTableID), keys.SystemDatabaseID},
+		{tkey(keys.NamespaceTableID), keys.NamespaceTableID},
 		{tkey(keys.ZonesTableID), keys.SystemDatabaseID},
 
 		// Non-gossiped system tables should refer to themselves.

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -295,8 +295,12 @@ const (
 	// SystemDatabaseID and following are the database/table IDs for objects
 	// in the system span.
 	// NOTE: IDs must be <= MaxSystemConfigDescID.
-	SystemDatabaseID  = 1
-	NamespaceTableID  = 2
+	SystemDatabaseID = 1
+
+	// We do not need to gossip the system.namespace table like we did when
+	// CockroachDB was first implemented
+	// NamespaceTableID  = 2
+
 	DescriptorTableID = 3
 	UsersTableID      = 4
 	ZonesTableID      = 5
@@ -330,6 +334,7 @@ const (
 	ReplicationCriticalLocalitiesTableID = 26
 	ReplicationStatsTableID              = 27
 	ReportsMetaTableID                   = 28
+	NamespaceTableID                     = 29
 
 	// CommentType is type for system.comments
 	DatabaseCommentType = 0


### PR DESCRIPTION
We do not need to gossip the system.namespace table like we did when
CockroachDB was first implemented.

Release note: None