### PR TITLE
engine: Fix case where a pebbleBatchIterator is passed to ClearIterRange

### DIFF
--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -241,6 +241,10 @@ type Writer interface {
 	//
 	// It is safe to modify the contents of the arguments after ClearIterRange
 	// returns.
+	//
+	// TODO(itsbilal): All calls to ClearIterRange pass in metadata keys for
+	// start and end that have a zero timestamp. Change the type of those args
+	// to roachpb.Key to make this expectation explicit.
 	ClearIterRange(iter Iterator, start, end MVCCKey) error
 	// Merge is a high-performance write operation used for values which are
 	// accumulated over several writes. Multiple values can be merged

--- a/pkg/storage/engine/pebble_iterator.go
+++ b/pkg/storage/engine/pebble_iterator.go
@@ -159,6 +159,11 @@ func (p *pebbleIterator) UnsafeKey() MVCCKey {
 	return mvccKey
 }
 
+// unsafeRawKey returns the raw key from the underlying pebble.Iterator.
+func (p *pebbleIterator) unsafeRawKey() []byte {
+	return p.iter.Key()
+}
+
 // UnsafeValue implements the Iterator interface.
 func (p *pebbleIterator) UnsafeValue() []byte {
 	if valid, err := p.Valid(); err != nil || !valid {


### PR DESCRIPTION
Currently ClearIterRange expects a pebbleIterator to be passed in
as the iterator. This isn't always the case; occasionally, we see
a pebbleBatchIterator which currently errors out the method. Update
that method in pebble and pebbleBatch to accept both types of
iterators.

Release note: None