### PR TITLE
gceworker: confirm before stopping

### DIFF
--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -63,12 +63,24 @@ case "${cmd}" in
     gcloud compute ssh "${NAME}" --ssh-flag="-A" "$@"
     ;;
     stop)
+    read -r -p "This will stop the VM. Are you sure? [yes] " response
+    response=${response,,} # to lowercase
+    if [[ $response != "yes" ]]; then
+      echo Aborting
+      exit 1
+    fi
     gcloud compute instances stop "${NAME}"
     ;;
     delete|destroy)
+    read -r -p "This will delete the VM! Are you sure? [yes] " response
+    response=${response,,} # to lowercase
+    if [[ $response != "yes" ]]; then
+      echo Aborting
+      exit 1
+    fi
     status=0
-    gcloud compute firewall-rules delete "${NAME}-mosh" || status=$((status+1))
-    gcloud compute instances delete "${NAME}" || status=$((status+1))
+    gcloud compute firewall-rules delete "${NAME}-mosh" --quiet || status=$((status+1))
+    gcloud compute instances delete "${NAME}" --quiet || status=$((status+1))
     exit ${status}
     ;;
     ssh)


### PR DESCRIPTION
I accidentally executed the previous command in a terminal and that
happened to be `gceworker.sh stop`. It stopped the VM in the middle of
something, which was unfortunate. This commit adds a prompt, you have
to type "yes" if you really mean it. We also put this prompt for the
`delete` command and add the `--quiet` flag so we don't get the
prompts from `gcloud`.

Release note: None