### PR TITLE
sql/sem/builtins: correctly quote pg_collation_for

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1526,12 +1526,12 @@ NULL
 query T
 SELECT COLLATION FOR ('foo')
 ----
-default
+"default"
 
 query T
 SELECT COLLATION FOR ('foo' COLLATE "de_DE");
 ----
-de_DE
+"de_DE"
 
 statement error pq: pg_collation_for\(\): collations are not supported by type: int
 SELECT COLLATION FOR (1);
@@ -1539,12 +1539,12 @@ SELECT COLLATION FOR (1);
 query T
 SELECT pg_collation_for ('foo')
 ----
-default
+"default"
 
 query T
 SELECT pg_collation_for ('foo' COLLATE "de_DE");
 ----
-de_DE
+"de_DE"
 
 statement error pq: pg_collation_for\(\): collations are not supported by type: int
 SELECT pg_collation_for(1);

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2869,15 +2869,17 @@ may increase either contention or retry errors, or both.`,
 			Types:      tree.ArgTypes{{"str", types.Any}},
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				var collation string
 				switch t := args[0].(type) {
 				case *tree.DString:
-					return tree.NewDString("default"), nil
+					collation = "default"
 				case *tree.DCollatedString:
-					return tree.NewDString(t.Locale), nil
+					collation = t.Locale
 				default:
 					return tree.DNull, pgerror.Newf(pgcode.DatatypeMismatch,
 						"collations are not supported by type: %s", t.ResolvedType())
 				}
+				return tree.NewDString(fmt.Sprintf(`"%s"`, collation)), nil
 			},
 			Info: "Returns the collation of the argument",
 		},


### PR DESCRIPTION
Postgres explicitly quotes these.

Release note (bug fix): pg_collation_for now correctly quotes its output.