### PR TITLE
sql: Support unnest(anyarray, anyarray, anyarray...)

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -794,6 +794,8 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><a name="pg_get_keywords"></a><code>pg_get_keywords() &rarr; tuple{string AS word, string AS catcode, string AS catdesc}</code></td><td><span class="funcdesc"><p>Produces a virtual table containing the keywords known to the SQL parser.</p>
 </span></td></tr>
+<tr><td><a name="unnest"></a><code>unnest(anyelement[], anyelement[], anyelement[]...) &rarr; tuple</code></td><td><span class="funcdesc"><p>Returns the input arrays as a set of rows</p>
+</span></td></tr>
 <tr><td><a name="unnest"></a><code>unnest(input: anyelement[]) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Returns the input array as a set of rows</p>
 </span></td></tr></tbody>
 </table>

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2321,12 +2321,14 @@ SELECT pg_get_function_result((select oid from pg_proc where proname='variance' 
 ----
 numeric
 
-
-# Slight incompatibility: in Postgres, the latter returns SETOF anyelement.
-query TT
-SELECT pg_get_function_result('pg_sleep'::regproc), pg_get_function_result('unnest'::regproc)
+query T
+SELECT pg_get_function_result('pg_sleep'::regproc)
 ----
-bool  anyelement
+bool
+
+# Note in Postgres <= 9.5, returns SETOF anyelement.
+query error pq: more than one function named 'unnest'
+SELECT pg_get_function_result('unnest'::regproc);
 
 # Regression test for #40297.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/json_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/json_builtins
@@ -324,8 +324,28 @@ SELECT to_json(x.*) FROM (VALUES (1,2)) AS x(a);
 ----
 {"a": 1, "column2": 2}
 
-query error found duplicate tuple label: \"column2\"
+# TODO(#44465): Implement the test cases below to be compatible with Postgres
+# and delete this one
+query T
 SELECT to_json(x.*) FROM (VALUES (1,2)) AS x(column2);
+----
+{"column2": 2}
+
+# Odd, but postgres-compatible
+# query T
+# SELECT to_json(x.*) FROM (VALUES (1,2)) AS x(a,a);
+# ----
+# {"a": 1, "a": 2}
+
+# query T
+# SELECT to_json(x.*) FROM (VALUES (1,2)) AS x(column1);
+# ----
+# {"column1": 1, "column2": 2}
+
+# query T
+# SELECT to_json(x.*) FROM (VALUES (1,2)) AS x(column2);
+# ----
+# {"column2": 1, "column2": 2}
 
 # Regression test for #39502.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/srfs
+++ b/pkg/sql/logictest/testdata/logic_test/srfs
@@ -1099,3 +1099,54 @@ SELECT t.* FROM unnest(ARRAY[(1,2),(3,4)]) AS t
 t
 (1,2)
 (3,4)
+
+
+subtest variadic_unnest
+
+query T
+SELECT unnest(ARRAY[1,2], ARRAY['a','b'])
+----
+(1,a)
+(2,b)
+
+query T
+SELECT unnest(ARRAY[1,2], ARRAY['a'], ARRAY[1.1, 2.2, 3.3])
+----
+(1,a,1.1)
+(2,,2.2)  
+(,,3.3)
+
+query IT colnames
+SELECT * FROM unnest(ARRAY[1,2], ARRAY['a', 'b'])
+----
+unnest unnest
+1  a
+2  b
+
+query ITT colnames
+SELECT * FROM unnest(ARRAY[1,2], ARRAY['a'], ARRAY[1.1, 2.2, 3.3])
+----
+unnest unnest unnest
+1    a    1.1
+2    NULL 2.2
+NULL NULL 3.3
+
+query II colnames
+SELECT * FROM unnest(array[1,2], array[3,4,5]) AS t(a, b);
+----
+a    b
+1    3  
+2    4  
+NULL 5 
+
+query error pq: could not determine polymorphic type
+SELECT unnest(NULL, NULL)
+
+query error pq: could not determine polymorphic type
+SELECT unnest(ARRAY[1,2], NULL)
+
+query error pq: could not determine polymorphic type
+SELECT * FROM unnest(NULL, NULL)
+
+query error pq: column reference "unnest" is ambiguous
+SELECT unnest FROM unnest(array[1,2], array[3,4,5])

--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -675,6 +675,37 @@ SELECT ((1, 2, 'hello', NULL, NULL) AS a1, b2, c3, d4, e5) AS r,
 r              s
 (1,2,hello,,)  (t,,"(f,6.6,f)")
 
+# Duplicate tuple labels are allowed (but access fails when a duplicated label is accessed,
+# see the labeled_tuple_column_access_errors subtest)
+query T colnames
+SELECT ((1, '2') AS a, a) FROM tb
+----
+?column?
+(1,2)
+
+query T
+SELECT ((1, '2', true) AS a, a, b) FROM tb
+----
+(1,2,t)
+
+query T
+SELECT ((1, '2', true) AS a, b, a) FROM tb
+----
+(1,2,t)
+
+query T
+SELECT ((1, 'asd', true) AS b, a, a) FROM tb
+----
+(1,asd,t)
+
+query TT colnames
+SELECT ((1, 2, 'hello', NULL, NULL) AS a, a, a, a, a) AS r,
+       ((true, NULL, (false, 6.6, false)) AS a, a, a) AS s
+  FROM tb
+----
+r              s
+(1,2,hello,,)  (t,,"(f,6.6,f)")
+
 # Comparing tuples
 query BBB colnames
 SELECT ((2, 2) AS a, b) < ((1, 1) AS c, d) AS r
@@ -733,19 +764,6 @@ SELECT ((1, '2') AS a) FROM tb
 query error pq: mismatch in tuple definition: 1 expressions, 2 labels
 SELECT (ROW(1) AS a, b) FROM tb
 
-# Tuple labels must be different
-query error pq: found duplicate tuple label: "a"
-SELECT ((1, '2') AS a, a) FROM tb
-
-query error pq: found duplicate tuple label: "a"
-SELECT ((1, '2', true) AS a, a, b) FROM tb
-
-query error pq: found duplicate tuple label: "a"
-SELECT ((1, '2', true) AS a, b, a) FROM tb
-
-query error pq: found duplicate tuple label: "a"
-SELECT ((1, '2', true) AS b, a, a) FROM tb
-
 # But inner tuples can reuse labels
 query T colnames
 SELECT ((
@@ -795,6 +813,13 @@ SELECT ((1,2,3) AS a,b,c).x FROM tb
 
 query error at or near ".": syntax error
 SELECT ((1,2,3) AS a,b,c).* FROM tb
+
+# Accessing duplicate labels
+query error pq: column reference "a" is ambiguous
+SELECT (((1,2,3) AS a,b,a)).a FROM tb
+
+query error pq: column reference "unnest" is ambiguous
+SELECT ((unnest(ARRAY[1,2], ARRAY[1,2]))).unnest;
 
 # No labels
 query error pq: type tuple{int, int, int} is not composite

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1660,7 +1660,7 @@ func (node *TupleStar) Format(ctx *FmtCtx) {
 }
 
 // ColumnAccessExpr represents (E).x expressions. Specifically, it
-// allows accessing the column(s) from a Set Retruning Function.
+// allows accessing the column(s) from a Set Returning Function.
 type ColumnAccessExpr struct {
 	Expr    Expr
 	ColName string


### PR DESCRIPTION
Previously `unnest` supported only one array argument. This commit
adds a variadic overload in order to support multiple array arguments,
as in Postgres.

The variadic overload is supported in a SELECT clause as well, in contrast
with Postgres that only supports it only in a FROM clause.

This change has two side effects.

1. The first side effect is that tuples are allowed to be declared with
duplicate labels, like:

`SELECT ((1, '2') AS a, a);`

This statement executes successfully since the tuple labels are declared
but not used.

However, accessing a duplicate tuple label returns AmbiguousColumn error.
Both statements below return a "column reference <column> is ambiguous"
error:

`SELECT (((1,2,3) AS a,b,a)).a;`
`SELECT ((unnest(ARRAY[1,2], ARRAY[1,2]))).unnest;`

2. The `to_json` builtin doesn't return duplicate error anymore but
succeeds when passed in values with duplicate labels. Eg:

```sql
SELECT to_json(x.*) FROM (VALUES (1,2)) AS x(column2);
+----------------+
|    to_json     |
|----------------|
| {"column2": 2} |
+----------------+
```

This is a bit more compatible with Postgres which also doesn't return
an error for this query. However, there is still an incompatibility in
the results as Postgres renders the duplicate labels as duplicate json
keys. The correct test cases have been added as a TODO comment, tracked
by #44465.

Release note (sql change): An overload was added to the `unnest` builtin
function in order to support multiple array arguments.

Release note (sql change): Duplicate labels are allowed when declaring a
tuple, but an Ambiguous column error is returned if a duplicate
label is accessed. For example:
`SELECT ((1, '2') AS a, a);` is successful but
`SELECT (((1,2,3) AS a,b,a)).a;` returns an error.

Fixes #41434
