### PR TITLE
libroach: disable -Warray-bounds

### DIFF
--- a/c-deps/libroach-rebuild
+++ b/c-deps/libroach-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing libroach CMake flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-3
+4

--- a/c-deps/libroach/CMakeLists.txt
+++ b/c-deps/libroach/CMakeLists.txt
@@ -90,7 +90,7 @@ set_target_properties(roach roachccl PROPERTIES
   CXX_STANDARD 11
   CXX_STANDARD_REQUIRED YES
   CXX_EXTENSIONS NO
-  COMPILE_OPTIONS "-Werror;-Wall;-Wno-sign-compare"
+  COMPILE_OPTIONS "-Werror;-Wall;-Wno-sign-compare;-Wno-array-bounds"
 )
 
 enable_testing()
@@ -178,7 +178,7 @@ foreach(tsrc ${tests})
     CXX_STANDARD 11
     CXX_STANDARD_REQUIRED YES
     CXX_EXTENSIONS NO
-    COMPILE_OPTIONS "-Werror;-Wall;-Wno-sign-compare"
+    COMPILE_OPTIONS "-Werror;-Wall;-Wno-sign-compare;-Wno-array-bounds"
   )
 
   # Add the executable to the set of tests run by the "check" target.


### PR DESCRIPTION
Newer versions of gcc complain about array bounds violations with
generated protobuf code. The warning looks valid as the code is doing
something not quite copacetic. Specifically, it is clearing two or more
adjacent fields in a struct by using a single `memset`
call. Unfortunately, it appears this hasn't been fixed in upstream
versions of protoc, so the best we can do at this point is disable the
warning.

Fixes #41531

Release note: None