### PR TITLE
release-19.2: backport unsafe-remove-dead-replicas tool for multiple stores

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -119,6 +119,11 @@ type TestClusterArgs struct {
 	ServerArgs TestServerArgs
 	// ReplicationMode controls how replication is to be done in the cluster.
 	ReplicationMode TestClusterReplicationMode
+	// If true, nodes will be started in parallel. This is useful in
+	// testing certain recovery scenarios, although it makes store/node
+	// IDs unpredictable. Even in ParallelStart mode, StartTestCluster
+	// waits for all nodes to start before returning.
+	ParallelStart bool
 
 	// ServerArgsPerNode override the default ServerArgs with the value in this
 	// map. The map's key is an index within TestCluster.Servers. If there is

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1094,11 +1094,6 @@ used, data may be corrupted.
 
 This comand will prompt for confirmation before committing its changes.
 
-Limitations: Can only recover from a single replica. If a range with
-four replicas has experienced two failures, or a range with five
-replicas experiences three failures, this tool cannot (yet) be used to
-recover from the two remaining replicas.
-
 `,
 	Args: cobra.ExactArgs(1),
 	RunE: MaybeDecorateGRPCError(runDebugUnsafeRemoveDeadReplicas),
@@ -1174,20 +1169,45 @@ func removeDeadReplicas(
 		hasSelf := false
 		numDeadPeers := 0
 		allReplicas := desc.Replicas().All()
-		numReplicas := len(allReplicas)
+		maxLivePeer := roachpb.StoreID(-1)
 		for _, rep := range allReplicas {
 			if rep.StoreID == storeIdent.StoreID {
 				hasSelf = true
 			}
 			if _, ok := deadStoreIDs[rep.StoreID]; ok {
 				numDeadPeers++
+			} else {
+				if rep.StoreID > maxLivePeer {
+					maxLivePeer = rep.StoreID
+				}
 			}
 		}
-		if hasSelf && numDeadPeers > 0 && numDeadPeers == numReplicas-1 {
+		if hasSelf && numDeadPeers > 0 && storeIdent.StoreID == maxLivePeer {
+			canMakeProgress := desc.Replicas().CanMakeProgress(func(rep roachpb.ReplicaDescriptor) bool {
+				_, ok := deadStoreIDs[rep.StoreID]
+				return !ok
+			})
+			if canMakeProgress {
+				return false, errors.Errorf("Range %s has dead peers but has not lost quorum; let the "+
+					"cluster run in the current state until these replicas have been removed before retrying "+
+					"this operation.", &desc)
+			}
+
+			// Rewrite the range as having a single replica. The winning
+			// replica is picked arbitrarily: the one with the highest store
+			// ID. This is not always the best option: it may lose writes
+			// that were committed on another surviving replica that had
+			// applied more of the raft log. However, in practice when we
+			// have multiple surviving replicas but still need this tool
+			// (because the replication factor was 4 or higher), we see that
+			// the logs are nearly always in sync and the choice doesn't
+			// matter. Correctly picking the replica with the longer log
+			// would complicate the use of this tool.
 			newDesc := desc
-			// Rewrite the replicas list. Bump the replica ID as an extra
-			// defense against one of the old replicas returning from the
-			// dead.
+			// Rewrite the replicas list. Bump the replica ID so that in
+			// case there are other surviving nodes that were members of the
+			// old incarnation of the range, they no longer recognize this
+			// revived replica (because they are not in sync with it).
 			replicas := []roachpb.ReplicaDescriptor{{
 				NodeID:    storeIdent.NodeID,
 				StoreID:   storeIdent.StoreID,
@@ -1210,6 +1230,37 @@ func removeDeadReplicas(
 
 	batch := db.NewBatch()
 	for _, desc := range newDescs {
+		// Write the rewritten descriptor to the range-local descriptor
+		// key. We do not update the meta copies of the descriptor.
+		// Instead, we leave them in a temporarily inconsistent state and
+		// they will be overwritten when the cluster recovers and
+		// up-replicates this range from its single copy to multiple
+		// copies. We rely on the fact that all range descriptor updates
+		// start with a CPut on the range-local copy followed by a blind
+		// Put to the meta copy.
+		//
+		// For example, if we have replicas on s1-s4 but s3 and s4 are
+		// dead, we will rewrite the replica on s2 to have s2 as its only
+		// member only. When the cluster is restarted (and the dead nodes
+		// remain dead), the rewritten replica will be the only one able
+		// to make progress. It will elect itself leader and upreplicate.
+		//
+		// The old replica on s1 is untouched by this process. It will
+		// eventually either be overwritten by a new replica when s2
+		// upreplicates, or it will be destroyed by the replica GC queue
+		// after upreplication has happened and s1 is no longer a member.
+		// (Note that in the latter case, consistency between s1 and s2 no
+		// longer matters; the consistency checker will only run on nodes
+		// that the new leader believes are members of the range).
+		//
+		// Note that this tool does not guarantee fully consistent
+		// results; the most recent writes to the raft log may have been
+		// lost. In the most unfortunate cases, this means that we would
+		// be "winding back" a split or a merge, which is almost certainly
+		// to result in irrecoverable corruption (for example, not only
+		// will individual values stored in the meta ranges diverge, but
+		// there will be keys not represented by any ranges or vice
+		// versa).
 		key := keys.RangeDescriptorKey(desc.StartKey)
 		err := engine.MVCCPutProto(ctx, batch, nil /* stats */, key, clock.Now(), nil /* txn */, &desc)
 		if wiErr, ok := err.(*roachpb.WriteIntentError); ok {
@@ -1217,6 +1268,19 @@ func removeDeadReplicas(
 				return nil, errors.Errorf("expected 1 intent, found %d: %s", len(wiErr.Intents), wiErr)
 			}
 			intent := wiErr.Intents[0]
+			// We rely on the property that transactions involving the range
+			// descriptor always start on the range-local descriptor's key.
+			// This guarantees that when the transaction commits, the intent
+			// will be resolved synchronously. If we see an intent on this
+			// key, we know that the transaction did not commit and we can
+			// abort it.
+			//
+			// TODO(nvanbenschoten): This need updating for parallel
+			// commits. If the transaction record is in the STAGING state,
+			// we can't just delete it. Simplest solution to this is to
+			// avoid parallel commits for membership change transactions; if
+			// we can't do that I don't think we'll be able to recover them
+			// with an offline tool.
 			fmt.Printf("Conflicting intent found on %s. Aborting txn %s to resolve.\n", key, intent.Txn.ID)
 
 			// A crude form of the intent resolution process: abort the

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1188,9 +1188,7 @@ func removeDeadReplicas(
 				return !ok
 			})
 			if canMakeProgress {
-				return false, errors.Errorf("Range %s has dead peers but has not lost quorum; let the "+
-					"cluster run in the current state until these replicas have been removed before retrying "+
-					"this operation.", &desc)
+				return false, nil
 			}
 
 			// Rewrite the range as having a single replica. The winning

--- a/pkg/cli/debug_test.go
+++ b/pkg/cli/debug_test.go
@@ -12,8 +12,10 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -27,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -131,161 +134,259 @@ func TestRemoveDeadReplicas(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
-	baseDir, dirCleanupFn := testutils.TempDir(t)
-	defer dirCleanupFn()
-
-	// The first node gets a real store, others are just in memory.
-	storePath := filepath.Join(baseDir, "store")
-
-	clusterArgs := base.TestClusterArgs{
-		ServerArgsPerNode: map[int]base.TestServerArgs{
-			0: {
-				StoreSpecs:      []base.StoreSpec{{Path: storePath}},
-				ScanMaxIdleTime: time.Millisecond,
-			},
-		},
-	}
-	// Start the cluster, let it replicate, then stop it. Since two
-	// nodes use in-memory stores, this automatically causes the cluster
-	// to lose its quorum.
-	//
-	// While it's running, start a transaction and write an intent to
-	// one of the range descriptors (without committing or aborting the
-	// transaction). This exercises a special case in removeDeadReplicas.
-	func() {
-		tc := testcluster.StartTestCluster(t, 3, clusterArgs)
-		defer tc.Stopper().Stop(ctx)
-
-		// Perform a write, to ensure that pre-crash data is preserved.
-		// Creating a table causes extra friction in the test harness when
-		// we restart the cluster, so just write a setting.
-		s := sqlutils.MakeSQLRunner(tc.Conns[0])
-		s.Exec(t, "set cluster setting cluster.organization='remove dead replicas test'")
-
-		txn := client.NewTxn(ctx, tc.Servers[0].DB(), 1, client.RootTxn)
-		var desc roachpb.RangeDescriptor
-		// Pick one of the predefined split points.
-		rdKey := keys.RangeDescriptorKey(roachpb.RKey(keys.TimeseriesPrefix))
-		if err := txn.GetProto(ctx, rdKey, &desc); err != nil {
-			t.Fatal(err)
-		}
-		desc.NextReplicaID++
-		if err := txn.Put(ctx, rdKey, &desc); err != nil {
-			t.Fatal(err)
-		}
-
-		// At this point the intent has been written to rocksdb but this
-		// write was not synced (only the raft log append was synced). We
-		// need to force another sync, but we're far from the storage
-		// layer here so the easiest thing to do is simply perform a
-		// second write. This will force the first write to be persisted
-		// to disk (the second write may or may not make it to disk due to
-		// timing).
-		desc.NextReplicaID++
-		if err := txn.Put(ctx, rdKey, &desc); err != nil {
-			t.Fatal(err)
-		}
-
-		// We deliberately do not close this transaction so the intent is
-		// left behind.
-	}()
-
-	// Open the store directly to repair it.
-	func() {
-		stopper := stop.NewStopper()
-		defer stopper.Stop(ctx)
-
-		db, err := OpenExistingStore(storePath, stopper, false /* readOnly */)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer db.Close()
-
-		batch, err := removeDeadReplicas(db, map[roachpb.StoreID]struct{}{
-			2: {},
-			3: {},
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if batch == nil {
-			t.Fatal("expected non-nil batch")
-		}
-		if err := batch.Commit(true); err != nil {
-			t.Fatal(err)
-		}
-		batch.Close()
-
-		// The repair process is idempotent and should give a nil batch the second time.
-		batch, err = removeDeadReplicas(db, map[roachpb.StoreID]struct{}{
-			2: {},
-			3: {},
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if batch != nil {
-			batch.Close()
-			t.Fatalf("expected nil batch on second attempt")
-		}
-	}()
-
-	// Now that the data is salvaged, we can restart the cluster. The
-	// nodes with the in-memory stores will be assigned new node IDs 4
-	// and 5.
-	//
-	// This activates the adaptive zone config feature (using 5x
-	// replication for clusters of 5 nodes or more), so we must
-	// decommission nodes 2 or 3 for WaitForFullReplication to complete.
-	// (note that the cluster is working even when it doesn't consider
-	// itself fully replicated - that's what allows the decommissioning
-	// to succeed. We're just waiting for full replication so that we
-	// can validate that ranges were moved from {1,2,3} to {1,4,5}).
-	//
-	// Set replication mode to manual so that TestCluster doesn't call
-	// WaitForFullReplication before we've decommissioned the nodes.
-	clusterArgs.ReplicationMode = base.ReplicationManual
-	tc := testcluster.StartTestCluster(t, 3, clusterArgs)
-	defer tc.Stopper().Stop(ctx)
-
-	grpcConn, err := tc.Server(0).RPCContext().GRPCDialNode(
-		tc.Server(0).ServingRPCAddr(),
-		tc.Server(0).NodeID(),
-		rpc.DefaultClass,
-	).Connect(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	adminClient := serverpb.NewAdminClient(grpcConn)
-
-	if err := runDecommissionNodeImpl(
-		ctx, adminClient, nodeDecommissionWaitNone, []string{"2", "3"},
-	); err != nil {
-		t.Fatal(err)
+	testCases := []struct {
+		survivingNodes, totalNodes, replicationFactor int
+	}{
+		{1, 3, 3},
+		{2, 4, 4},
 	}
 
-	store, err := tc.Servers[0].Stores().GetStore(1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	store.SetReplicateQueueActive(true)
-	if err := tc.WaitForFullReplication(); err != nil {
-		t.Fatal(err)
-	}
+	for _, testCase := range testCases {
+		for _, allNodesStopped := range []bool{true, false} {
+			t.Run(fmt.Sprintf("%d/%d/r=%d,allStopped=%v", testCase.survivingNodes, testCase.totalNodes,
+				testCase.replicationFactor, allNodesStopped),
+				func(t *testing.T) {
+					baseDir, dirCleanupFn := testutils.TempDir(t)
+					defer dirCleanupFn()
 
-	s := sqlutils.MakeSQLRunner(tc.Conns[0])
-	row := s.QueryRow(t, "select replicas from [show ranges from table system.namespace] limit 1")
-	var replicaStr string
-	row.Scan(&replicaStr)
-	if replicaStr != "{1,4,5}" {
-		t.Fatalf("expected replicas on {1,4,5} but got %s", replicaStr)
-	}
+					// The surviving nodes get a real store, others are just in memory.
+					var storePaths []string
+					clusterArgs := base.TestClusterArgs{ServerArgsPerNode: map[int]base.TestServerArgs{}}
+					deadReplicas := map[roachpb.StoreID]struct{}{}
 
-	row = s.QueryRow(t, "show cluster setting cluster.organization")
-	var org string
-	row.Scan(&org)
-	if org != "remove dead replicas test" {
-		t.Fatalf("expected old setting to be present, got %s instead", org)
+					for i := 0; i < testCase.totalNodes; i++ {
+						storeID := roachpb.StoreID(i + 1)
+						if i < testCase.survivingNodes {
+							path := filepath.Join(baseDir, fmt.Sprintf("store%d", storeID))
+							storePaths = append(storePaths, path)
+							// ServerArgsPerNode uses 0-based index, not node ID.
+							clusterArgs.ServerArgsPerNode[i] = base.TestServerArgs{
+								StoreSpecs:      []base.StoreSpec{{Path: path}},
+								ScanMaxIdleTime: time.Millisecond,
+							}
+						} else {
+							deadReplicas[storeID] = struct{}{}
+						}
+					}
+
+					// Start the cluster, let it replicate, then stop it. Since the
+					// non-surviving nodes use in-memory stores, this automatically
+					// causes the cluster to lose its quorum.
+					//
+					// While it's running, start a transaction and write an intent to
+					// one of the range descriptors (without committing or aborting the
+					// transaction). This exercises a special case in removeDeadReplicas.
+					func() {
+						tc := testcluster.StartTestCluster(t, testCase.totalNodes, clusterArgs)
+						defer tc.Stopper().Stop(ctx)
+
+						s := sqlutils.MakeSQLRunner(tc.Conns[0])
+
+						// Set the replication factor on all zones.
+						func() {
+							rows := s.Query(t, "show all zone configurations")
+							defer rows.Close()
+							re := regexp.MustCompile(`num_replicas = \d+`)
+							var sqls []string
+							for rows.Next() {
+								var name, configSQL string
+								if err := rows.Scan(&name, &configSQL); err != nil {
+									t.Fatal(err)
+								}
+								sqls = append(sqls, configSQL)
+							}
+							for _, sql := range sqls {
+								if re.FindString(sql) != "" {
+									sql = re.ReplaceAllString(sql,
+										fmt.Sprintf("num_replicas = %d", testCase.replicationFactor))
+								} else {
+									sql = fmt.Sprintf("%s, num_replicas = %d", sql, testCase.replicationFactor)
+								}
+								s.Exec(t, sql)
+							}
+						}()
+						if err := tc.WaitForFullReplication(); err != nil {
+							t.Fatal(err)
+						}
+
+						// Perform a write, to ensure that pre-crash data is preserved.
+						// Creating a table causes extra friction in the test harness when
+						// we restart the cluster, so just write a setting.
+						s.Exec(t, "set cluster setting cluster.organization='remove dead replicas test'")
+
+						txn := client.NewTxn(ctx, tc.Servers[0].DB(), 1, client.RootTxn)
+						var desc roachpb.RangeDescriptor
+						// Pick one of the predefined split points.
+						rdKey := keys.RangeDescriptorKey(roachpb.RKey(keys.TimeseriesPrefix))
+						if err := txn.GetProto(ctx, rdKey, &desc); err != nil {
+							t.Fatal(err)
+						}
+						desc.NextReplicaID++
+						if err := txn.Put(ctx, rdKey, &desc); err != nil {
+							t.Fatal(err)
+						}
+
+						// At this point the intent has been written to rocksdb but this
+						// write was not synced (only the raft log append was synced). We
+						// need to force another sync, but we're far from the storage
+						// layer here so the easiest thing to do is simply perform a
+						// second write. This will force the first write to be persisted
+						// to disk (the second write may or may not make it to disk due to
+						// timing).
+						desc.NextReplicaID++
+						if err := txn.Put(ctx, rdKey, &desc); err != nil {
+							t.Fatal(err)
+						}
+
+						// We deliberately do not close this transaction so the intent is
+						// left behind.
+					}()
+
+					// Open the surviving stores directly to repair them.
+					repairStore := func(idx int) error {
+						stopper := stop.NewStopper()
+						defer stopper.Stop(ctx)
+
+						db, err := OpenExistingStore(storePaths[idx], stopper, false /* readOnly */)
+						if err != nil {
+							return err
+						}
+						defer db.Close()
+
+						batch, err := removeDeadReplicas(db, deadReplicas)
+						if err != nil {
+							return err
+						}
+						if batch != nil {
+							if err := batch.Commit(true); err != nil {
+								return err
+							}
+							batch.Close()
+						}
+
+						// The repair process is idempotent and should give a nil batch the second time
+						batch, err = removeDeadReplicas(db, deadReplicas)
+						if err != nil {
+							return err
+						}
+						if batch != nil {
+							batch.Close()
+							return errors.New("expected nil batch on second attempt")
+						}
+						return nil
+					}
+					for i := 0; i < testCase.survivingNodes; i++ {
+						err := repairStore(i)
+						if err != nil {
+							t.Fatal(err)
+						}
+					}
+
+					// Now that the data is salvaged, we can restart the cluster.
+					// The nodes with the in-memory stores will be assigned new,
+					// higher node IDs (e.g. in the 1/3 case, the restarted nodes
+					// will be 4 and 5).
+					//
+					// This can activate the adaptive zone config feature (using 5x
+					// replication for clusters of 5 nodes or more), so we must
+					// decommission the dead nodes for WaitForFullReplication to
+					// complete. (note that the cluster is working even when it
+					// doesn't consider itself fully replicated - that's what allows
+					// the decommissioning to succeed. We're just waiting for full
+					// replication so that we can validate that ranges were moved
+					// from e.g. {1,2,3} to {1,4,5}).
+					//
+					// Set replication mode to manual so that TestCluster doesn't call
+					// WaitForFullReplication before we've decommissioned the nodes.
+					clusterArgs.ReplicationMode = base.ReplicationManual
+					clusterArgs.ParallelStart = true
+					tc := testcluster.StartTestCluster(t, testCase.totalNodes, clusterArgs)
+					defer tc.Stopper().Stop(ctx)
+
+					grpcConn, err := tc.Server(0).RPCContext().GRPCDialNode(
+						tc.Server(0).ServingRPCAddr(),
+						tc.Server(0).NodeID(),
+						rpc.DefaultClass,
+					).Connect(ctx)
+					if err != nil {
+						t.Fatal(err)
+					}
+					adminClient := serverpb.NewAdminClient(grpcConn)
+
+					deadNodeStrs := []string{}
+					for i := testCase.survivingNodes; i < testCase.totalNodes; i++ {
+						deadNodeStrs = append(deadNodeStrs, fmt.Sprintf("%d", i+1))
+					}
+
+					if err := runDecommissionNodeImpl(
+						ctx, adminClient, nodeDecommissionWaitNone, deadNodeStrs,
+					); err != nil {
+						t.Fatal(err)
+					}
+
+					for i := 0; i < len(tc.Servers); i++ {
+						err = tc.Servers[i].Stores().VisitStores(func(store *storage.Store) error {
+							store.SetReplicateQueueActive(true)
+							return nil
+						})
+						if err != nil {
+							t.Fatal(err)
+						}
+					}
+					if err := tc.WaitForFullReplication(); err != nil {
+						t.Fatal(err)
+					}
+
+					for i := 0; i < len(tc.Servers); i++ {
+						err = tc.Servers[i].Stores().VisitStores(func(store *storage.Store) error {
+							return store.ForceConsistencyQueueProcess()
+						})
+						if err != nil {
+							t.Fatal(err)
+						}
+					}
+
+					expectedReplicas := []string{}
+					for i := 0; i < testCase.totalNodes; i++ {
+						var storeID int
+						if i < testCase.survivingNodes {
+							// If the replica survived, just adjust from zero-based to one-based.
+							storeID = i + 1
+						} else {
+							storeID = i + 1 + testCase.totalNodes - testCase.survivingNodes
+						}
+						expectedReplicas = append(expectedReplicas, fmt.Sprintf("%d", storeID))
+					}
+					expectedReplicaStr := fmt.Sprintf("{%s}", strings.Join(expectedReplicas, ","))
+
+					s := sqlutils.MakeSQLRunner(tc.Conns[0])
+					row := s.QueryRow(t, "select replicas from [show ranges from table system.namespace] limit 1")
+					var replicaStr string
+					row.Scan(&replicaStr)
+					if replicaStr != expectedReplicaStr {
+						t.Fatalf("expected replicas on %s but got %s", expectedReplicaStr, replicaStr)
+					}
+
+					row = s.QueryRow(t, "show cluster setting cluster.organization")
+					var org string
+					row.Scan(&org)
+
+					// If there was only one surviving node, we know we
+					// recovered the write we did at the start of the test. But
+					// if there were multiples, we might have picked a lagging
+					// replica that didn't have it. See comments around
+					// maxLivePeer in debug.go.
+					//
+					// TODO(bdarnell): It doesn't look to me like this is
+					// guaranteed even in the single-survivor case, but it's
+					// only flaky when there are multiple survivors.
+					if testCase.survivingNodes == 1 {
+						if org != "remove dead replicas test" {
+							t.Fatalf("expected old setting to be present, got %s instead", org)
+						}
+					}
+				})
+		}
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1663,11 +1663,19 @@ func (s *Server) startListenRPCAndSQL(
 	if s.cfg.SplitListenSQL {
 		rpcChanName = "rpc"
 	}
-	ln, err := listen(ctx, &s.cfg.Addr, &s.cfg.AdvertiseAddr, rpcChanName)
-	if err != nil {
-		return nil, nil, err
+	var ln net.Listener
+	if k := s.cfg.TestingKnobs.Server; k != nil {
+		knobs := k.(*TestingKnobs)
+		ln = knobs.RPCListener
 	}
-	log.Eventf(ctx, "listening on port %s", s.cfg.Addr)
+	if ln == nil {
+		var err error
+		ln, err = listen(ctx, &s.cfg.Addr, &s.cfg.AdvertiseAddr, rpcChanName)
+		if err != nil {
+			return nil, nil, err
+		}
+		log.Eventf(ctx, "listening on port %s", s.cfg.Addr)
+	}
 
 	var pgL net.Listener
 	if s.cfg.SplitListenSQL {

--- a/pkg/server/server_update.go
+++ b/pkg/server/server_update.go
@@ -15,36 +15,12 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/config"
-	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/pkg/errors"
 )
-
-// TestingKnobs groups testing knobs for the Server.
-type TestingKnobs struct {
-	// DisableAutomaticVersionUpgrade, if set, temporarily disables the server's
-	// automatic version upgrade mechanism.
-	DisableAutomaticVersionUpgrade int32 // accessed atomically
-	// DefaultZoneConfigOverride, if set, overrides the default zone config defined in `pkg/config/zone.go`
-	DefaultZoneConfigOverride *config.ZoneConfig
-	// DefaultSystemZoneConfigOverride, if set, overrides the default system zone config defined in `pkg/config/zone.go`
-	DefaultSystemZoneConfigOverride *config.ZoneConfig
-	// PauseAfterGettingRPCAddress, if non-nil, instructs the server to wait until
-	// the channel is closed after getting an RPC serving address.
-	PauseAfterGettingRPCAddress chan struct{}
-	// SignalAfterGettingRPCAddress, if non-nil, is closed after the server gets
-	// an RPC server address.
-	SignalAfterGettingRPCAddress chan struct{}
-	// ContextTestingKnobs allows customization of the RPC context testing knobs.
-	ContextTestingKnobs rpc.ContextTestingKnobs
-}
-
-// ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.
-func (*TestingKnobs) ModuleTestingKnobs() {}
 
 // startAttemptUpgrade attempts to upgrade cluster version.
 func (s *Server) startAttemptUpgrade(ctx context.Context) {

--- a/pkg/server/testing_knobs.go
+++ b/pkg/server/testing_knobs.go
@@ -1,0 +1,38 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
+)
+
+// TestingKnobs groups testing knobs for the Server.
+type TestingKnobs struct {
+	// DisableAutomaticVersionUpgrade, if set, temporarily disables the server's
+	// automatic version upgrade mechanism.
+	DisableAutomaticVersionUpgrade int32 // accessed atomically
+	// DefaultZoneConfigOverride, if set, overrides the default zone config defined in `pkg/config/zone.go`
+	DefaultZoneConfigOverride *config.ZoneConfig
+	// DefaultSystemZoneConfigOverride, if set, overrides the default system zone config defined in `pkg/config/zone.go`
+	DefaultSystemZoneConfigOverride *config.ZoneConfig
+	// PauseAfterGettingRPCAddress, if non-nil, instructs the server to wait until
+	// the channel is closed after getting an RPC serving address.
+	PauseAfterGettingRPCAddress chan struct{}
+	// SignalAfterGettingRPCAddress, if non-nil, is closed after the server gets
+	// an RPC server address.
+	SignalAfterGettingRPCAddress chan struct{}
+	// ContextTestingKnobs allows customization of the RPC context testing knobs.
+	ContextTestingKnobs rpc.ContextTestingKnobs
+}
+
+// ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.
+func (*TestingKnobs) ModuleTestingKnobs() {}

--- a/pkg/server/testing_knobs.go
+++ b/pkg/server/testing_knobs.go
@@ -11,6 +11,8 @@
 package server
 
 import (
+	"net"
+
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 )
@@ -32,6 +34,19 @@ type TestingKnobs struct {
 	SignalAfterGettingRPCAddress chan struct{}
 	// ContextTestingKnobs allows customization of the RPC context testing knobs.
 	ContextTestingKnobs rpc.ContextTestingKnobs
+
+	// If set, use this listener for RPC (and possibly SQL, depending on
+	// the SplitListenSQL setting), instead of binding a new listener.
+	// This is useful in tests that need an ephemeral listening port but
+	// must know it before the server starts.
+	//
+	// When this is used, the advertise address should also be set to
+	// match.
+	//
+	// The Server takes responsibility for closing this listener.
+	// TODO(bdarnell): That doesn't give us a good way to clean up if the
+	// server fails to start.
+	RPCListener net.Listener
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/storage/replica_gc_queue.go
+++ b/pkg/storage/replica_gc_queue.go
@@ -243,6 +243,14 @@ func (rgcq *replicaGCQueue) process(
 		if err := repl.setLastReplicaGCTimestamp(ctx, repl.store.Clock().Now()); err != nil {
 			return err
 		}
+
+		// Note that we do not check the replicaID at this point. If our
+		// local replica ID is behind the one in the meta descriptor, we
+		// could safely delete our local copy, but this would just force
+		// the use of a snapshot when catching up to the new replica ID.
+		// We don't normally expect to have a *higher* local replica ID
+		// than the one in the meta descriptor, but it's possible after
+		// recovering with unsafe-remove-dead-replicas.
 	} else if sameRange {
 		// We are no longer a member of this range, but the range still exists.
 		// Clean up our local data.


### PR DESCRIPTION
Backport:
  * 3/3 commits from "cli: Make unsafe-remove-dead-replicas work with multiple stores" (#41266)
  * 1/1 commits from "cli: Fix unsafe-remove-dead-replicas to skip over ranges that are ok" (#41483)

Please see individual PRs for details.

/cc @cockroachdb/release
