### PR TITLE
build: Upgrade to go 1.12.10

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -67,6 +67,16 @@ A snapshot of CockroachDB's dependencies is maintained at
 https://github.com/cockroachdb/vendored and checked out as a submodule at
 `./vendor`.
 
+## Updating the golang version
+
+Please copy this checklist ino the relevant commit message, with a link
+back to this document:
+
+* [ ] Adjust version in Docker image ([source](./builder/Dockerfile#L199-L200)).
+* [ ] Rebuild the Docker image and bump the version in builder.sh accordingly ([source](./builder.sh#L6)).
+* [ ] Bump the version in go-version-check.sh ([source](./go-version-check.sh)), unless bumping to a new patch release.
+* [ ] Bump the default installed version of Go in bootstrap-debian.sh ([source](./bootstrap/bootstrap-debian.sh#L40-42)).
+
 ## Updating Dependencies
 
 This snapshot was built and is managed using `dep` and we manage `vendor` as a

--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -38,9 +38,9 @@ echo '. ~/.bashrc_bootstrap' >> ~/.bashrc
 
 # Install Go.
 trap 'rm -f /tmp/go.tgz' EXIT
-curl https://dl.google.com/go/go1.12.7.linux-amd64.tar.gz > /tmp/go.tgz
+curl https://dl.google.com/go/go1.12.10.linux-amd64.tar.gz > /tmp/go.tgz
 sha256sum -c - <<EOF
-66d83bfb5a9ede000e33c6579a91a29e6b101829ad41fffb5c5bb6c900e109d9  /tmp/go.tgz
+aaa84147433aed24e70b31da369bb6ca2859464a45de47c2a5023d8573412f6b  /tmp/go.tgz
 EOF
 sudo tar -C /usr/local -zxf /tmp/go.tgz
 

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20190718-082058
+version=20191014-135449
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -196,8 +196,8 @@ RUN git clone git://git.sv.gnu.org/sed \
 # releases of Go will no longer be run in CI once it is changed. Consider
 # bumping the minimum allowed version of Go in /build/go-version-chech.sh.
 RUN apt-get install -y --no-install-recommends golang \
- && curl -fsSL https://storage.googleapis.com/golang/go1.12.5.src.tar.gz -o golang.tar.gz \
- && echo '2aa5f088cbb332e73fc3def546800616b38d3bfe6b8713b8a6404060f22503e8 golang.tar.gz' | sha256sum -c - \
+ && curl -fsSL https://storage.googleapis.com/golang/go1.12.10.src.tar.gz -o golang.tar.gz \
+ && echo 'f56e48fce80646d3c94dcf36d3e3f490f6d541a92070ad409b87b6bbb9da3954 golang.tar.gz' | sha256sum -c - \
  && tar -C /usr/local -xzf golang.tar.gz \
  && rm golang.tar.gz \
  && cd /usr/local/go/src \


### PR DESCRIPTION
    build: Upgrade to go 1.12.10
    
    This change updates the golang version to 1.12.10 to pick up a security fix in
    the net/http package.  This also picks up a URL parsing security fix in 1.12.8
    that eliminates the use of named ports. See the relevant discussion in
    https://github.com/golang/go/commit/3226f2d492963d361af9dfc6714ef141ba606713
    
    The change in URL parsing necessitates a test fix. Any customer impact should
    be minimal, given the rarity of named ports in common practice, and can be
    fixed by simply switching to numeric ports.
    
    Per the [checklist](build/README.md):
    * [X] Adjust version in Docker image
    * [X] Rebuild the Docker image and bump the version in builder.sh accordingly
    * [ ] ~Bump the version in go-version-check.sh~ (Patch release, not necessary)
    * [X] Bump the default installed version of Go in bootstrap-debian.sh
    
    Fixes: #40939
    X-Ref: #23481
    
    Release note (build change): The golang runtime has been upgraded to 1.12.10.
    
    Release note (general change): The use of named ports in URLs has been
    eliminated due to URL parsing ambiguities that were fixed in go 1.12.8. Any
    impact can be mitigated with the use of numeric port numbers.

