### PR TITLE
opt: disallow subqueries in opaque statements

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -313,3 +313,14 @@ SET DATESTYLE = ISO;
   SET lock_timeout = 0;
   SET idle_in_transaction_session_timeout = 0;
   SET row_security = off;
+
+subtest regression_41567_subqueries
+
+statement error subqueries are not allowed in SET
+SET SESSION SCHEMA EXISTS ( TABLE ( ( ( ( ( ( ( ( TABLE error ) ) ) ) ) ) ) ) ORDER BY INDEX FAMILY . IS . MAXVALUE @ OF DESC , INDEX FAMILY . FOR . ident @ ident ASC )
+
+statement error subqueries are not allowed in SET
+USE EXISTS ( TABLE error ) IS NULL
+
+statement error subqueries are not allowed in SET
+PREPARE a AS USE EXISTS ( TABLE error ) IS NULL

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -38,6 +38,12 @@ func buildOpaque(
 ) (opt.OpaqueMetadata, sqlbase.ResultColumns, error) {
 	p := evalCtx.Planner.(*planner)
 
+	// Opaque statements handle their own scalar arguments, with no help from the
+	// optimizer. As such, they cannot contain subqueries.
+	scalarProps := &semaCtx.Properties
+	defer scalarProps.Restore(*scalarProps)
+	scalarProps.Require(stmt.StatementTag(), tree.RejectSubqueries)
+
 	var plan planNode
 	var err error
 	switch n := stmt.(type) {


### PR DESCRIPTION
The "opaque" statements handle their own arguments, without help from
the optimizer. As such, they don't support subqueries.

This change adds the logic to error out if we have unexpected
subqueries (instead of hitting an internal error).

Fixes #41567.

Release note (bug fix): Fixed an internal error when subqueries are used
in arguments to commands like SET.