### PR TITLE
bench: use round-robin for MultinodeCockroach

### DIFF
--- a/pkg/bench/bench_test.go
+++ b/pkg/bench/bench_test.go
@@ -12,7 +12,7 @@ package bench
 
 import (
 	"bytes"
-	gosql "database/sql"
+	"context"
 	"fmt"
 	"math/rand"
 	"reflect"
@@ -29,13 +29,10 @@ import (
 	_ "github.com/lib/pq"
 )
 
-func runBenchmarkSelect1(b *testing.B, db *gosql.DB) {
+func runBenchmarkSelect1(b *testing.B, db *sqlutils.SQLRunner) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		rows, err := db.Query(`SELECT 1`)
-		if err != nil {
-			b.Fatal(err)
-		}
+		rows := db.Query(b, `SELECT 1`)
 		rows.Close()
 	}
 	b.StopTimer()
@@ -47,17 +44,13 @@ func BenchmarkSelect1(b *testing.B) {
 }
 
 func runBenchmarkSelectWithTargetsAndFilter(
-	b *testing.B, db *gosql.DB, targets, filter string, args ...interface{},
+	b *testing.B, db *sqlutils.SQLRunner, targets, filter string, args ...interface{},
 ) {
 	defer func() {
-		if _, err := db.Exec(`DROP TABLE IF EXISTS bench.select`); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, `DROP TABLE IF EXISTS bench.select`)
 	}()
 
-	if _, err := db.Exec(`CREATE TABLE bench.select (k INT PRIMARY KEY, a INT, b INT, c INT, d INT)`); err != nil {
-		b.Fatal(err)
-	}
+	db.Exec(b, `CREATE TABLE bench.select (k INT PRIMARY KEY, a INT, b INT, c INT, d INT)`)
 
 	var buf bytes.Buffer
 	buf.WriteString(`INSERT INTO bench.select VALUES `)
@@ -78,46 +71,37 @@ func runBenchmarkSelectWithTargetsAndFilter(
 			}
 		}
 	}
-	if _, err := db.Exec(buf.String()); err != nil {
-		b.Fatal(err)
-	}
+	db.Exec(b, buf.String())
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		rows, err := db.Query(fmt.Sprintf(`SELECT %s FROM bench.select WHERE %s`, targets, filter), args...)
-		if err != nil {
-			b.Fatal(err)
-		}
+		rows := db.Query(b, fmt.Sprintf(`SELECT %s FROM bench.select WHERE %s`, targets, filter), args...)
 		rows.Close()
 	}
 	b.StopTimer()
 }
 
-// runBenchmarkSelect2 runs a SELECT query with non-trivial expressions. The main purpose is to
-// detect major regressions in query expression processing.
-func runBenchmarkSelect2(b *testing.B, db *gosql.DB) {
-	targets := `a, b, c, a+b, a+1, (a+2)*(b+3)*(c+4)`
-	filter := `(a = 1) OR ((a = 2) and (b = c)) OR (a + b = 3) OR (2*a + 4*b = 4*c)`
-	runBenchmarkSelectWithTargetsAndFilter(b, db, targets, filter)
-}
-
+// BenchmarkSelect2 runs a SELECT query with non-trivial expressions. The main
+// purpose is to detect major regressions in query expression processing.
 func BenchmarkSelect2(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	ForEachDB(b, runBenchmarkSelect2)
+	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
+		targets := `a, b, c, a+b, a+1, (a+2)*(b+3)*(c+4)`
+		filter := `(a = 1) OR ((a = 2) and (b = c)) OR (a + b = 3) OR (2*a + 4*b = 4*c)`
+		runBenchmarkSelectWithTargetsAndFilter(b, db, targets, filter)
+	})
 }
 
-// runBenchmarkSelect3 runs a SELECT query with non-trivial expressions. The main purpose is to
-// quantify regressions in numeric type processing.
-func runBenchmarkSelect3(b *testing.B, db *gosql.DB) {
-	targets := `a/b, b/c, c != 3.3 + $1, a = 2.0, c * 9.0`
-	filter := `a > 1 AND b < 4.5`
-	args := []interface{}{1.0}
-	runBenchmarkSelectWithTargetsAndFilter(b, db, targets, filter, args...)
-}
-
+// BenchmarkSelect3 runs a SELECT query with non-trivial expressions. The main
+// purpose is to quantify regressions in numeric type processing.
 func BenchmarkSelect3(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	ForEachDB(b, runBenchmarkSelect3)
+	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
+		targets := `a/b, b/c, c != 3.3 + $1, a = 2.0, c * 9.0`
+		filter := `a > 1 AND b < 4.5`
+		args := []interface{}{1.0}
+		runBenchmarkSelectWithTargetsAndFilter(b, db, targets, filter, args...)
+	})
 }
 
 func BenchmarkCount(b *testing.B) {
@@ -125,16 +109,12 @@ func BenchmarkCount(b *testing.B) {
 		b.Skip("short flag")
 	}
 	defer log.Scope(b).Close(b)
-	ForEachDB(b, func(b *testing.B, db *gosql.DB) {
+	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
 		defer func() {
-			if _, err := db.Exec(`DROP TABLE IF EXISTS bench.count`); err != nil {
-				b.Fatal(err)
-			}
+			db.Exec(b, `DROP TABLE IF EXISTS bench.count`)
 		}()
 
-		if _, err := db.Exec(`CREATE TABLE bench.count (k INT PRIMARY KEY, v TEXT)`); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, `CREATE TABLE bench.count (k INT PRIMARY KEY, v TEXT)`)
 
 		var buf bytes.Buffer
 		val := 0
@@ -148,17 +128,13 @@ func BenchmarkCount(b *testing.B) {
 				fmt.Fprintf(&buf, "(%d, '%s')", val, strconv.Itoa(val))
 				val++
 			}
-			if _, err := db.Exec(buf.String()); err != nil {
-				b.Fatal(err)
-			}
+			db.Exec(b, buf.String())
 		}
 
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			if _, err := db.Exec("SELECT count(*) FROM bench.count"); err != nil {
-				b.Fatal(err)
-			}
+			db.Exec(b, "SELECT count(*) FROM bench.count")
 		}
 		b.StopTimer()
 	})
@@ -169,17 +145,12 @@ func BenchmarkCountTwoCF(b *testing.B) {
 		b.Skip("short flag")
 	}
 	defer log.Scope(b).Close(b)
-	ForEachDB(b, func(b *testing.B, db *gosql.DB) {
+	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
 		defer func() {
-			if _, err := db.Exec(`DROP TABLE IF EXISTS bench.count`); err != nil {
-				b.Fatal(err)
-			}
+			db.Exec(b, `DROP TABLE IF EXISTS bench.count`)
 		}()
 
-		if _, err := db.Exec(
-			`CREATE TABLE bench.count (k INT PRIMARY KEY, v TEXT, FAMILY (k), FAMILY (v))`); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, `CREATE TABLE bench.count (k INT PRIMARY KEY, v TEXT, FAMILY (k), FAMILY (v))`)
 
 		var buf bytes.Buffer
 		val := 0
@@ -193,17 +164,13 @@ func BenchmarkCountTwoCF(b *testing.B) {
 				fmt.Fprintf(&buf, "(%d, '%s')", val, strconv.Itoa(val))
 				val++
 			}
-			if _, err := db.Exec(buf.String()); err != nil {
-				b.Fatal(err)
-			}
+			db.Exec(b, buf.String())
 		}
 
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			if _, err := db.Exec("SELECT count(*) FROM bench.count"); err != nil {
-				b.Fatal(err)
-			}
+			db.Exec(b, "SELECT count(*) FROM bench.count")
 		}
 		b.StopTimer()
 	})
@@ -214,16 +181,12 @@ func BenchmarkSort(b *testing.B) {
 		b.Skip("short flag")
 	}
 	defer log.Scope(b).Close(b)
-	ForEachDB(b, func(b *testing.B, db *gosql.DB) {
+	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
 		defer func() {
-			if _, err := db.Exec(`DROP TABLE IF EXISTS bench.sort`); err != nil {
-				b.Fatal(err)
-			}
+			db.Exec(b, `DROP TABLE IF EXISTS bench.sort`)
 		}()
 
-		if _, err := db.Exec(`CREATE TABLE bench.sort (k INT PRIMARY KEY, v INT)`); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, `CREATE TABLE bench.sort (k INT PRIMARY KEY, v INT)`)
 
 		var buf bytes.Buffer
 		val := 0
@@ -237,33 +200,25 @@ func BenchmarkSort(b *testing.B) {
 				fmt.Fprintf(&buf, "(%d, %d)", val, -val)
 				val++
 			}
-			if _, err := db.Exec(buf.String()); err != nil {
-				b.Fatal(err)
-			}
+			db.Exec(b, buf.String())
 		}
 
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			if _, err := db.Exec("SELECT * FROM bench.sort ORDER BY v"); err != nil {
-				b.Fatal(err)
-			}
+			db.Exec(b, "SELECT * FROM bench.sort ORDER BY v")
 		}
 		b.StopTimer()
 	})
 }
 
 // runBenchmarkInsert benchmarks inserting count rows into a table.
-func runBenchmarkInsert(b *testing.B, db *gosql.DB, count int) {
+func runBenchmarkInsert(b *testing.B, db *sqlutils.SQLRunner, count int) {
 	defer func() {
-		if _, err := db.Exec(`DROP TABLE IF EXISTS bench.insert`); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, `DROP TABLE IF EXISTS bench.insert`)
 	}()
 
-	if _, err := db.Exec(`CREATE TABLE bench.insert (k INT PRIMARY KEY)`); err != nil {
-		b.Fatal(err)
-	}
+	db.Exec(b, `CREATE TABLE bench.insert (k INT PRIMARY KEY)`)
 
 	b.ResetTimer()
 	var buf bytes.Buffer
@@ -278,9 +233,7 @@ func runBenchmarkInsert(b *testing.B, db *gosql.DB, count int) {
 			fmt.Fprintf(&buf, "(%d)", val)
 			val++
 		}
-		if _, err := db.Exec(buf.String()); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, buf.String())
 	}
 	b.StopTimer()
 
@@ -288,7 +241,7 @@ func runBenchmarkInsert(b *testing.B, db *gosql.DB, count int) {
 
 // runBenchmarkInsertFK benchmarks inserting count rows into a table with a
 // present foreign key into another table.
-func runBenchmarkInsertFK(b *testing.B, db *gosql.DB, count int) {
+func runBenchmarkInsertFK(b *testing.B, db *sqlutils.SQLRunner, count int) {
 	for _, nFks := range []int{1, 5, 10} {
 		b.Run(fmt.Sprintf("nFks=%d", nFks), func(b *testing.B) {
 			defer func() {
@@ -296,18 +249,12 @@ func runBenchmarkInsertFK(b *testing.B, db *gosql.DB, count int) {
 				for i := 0; i < nFks; i++ {
 					dropStmt += fmt.Sprintf(",bench.fk%d", i)
 				}
-				if _, err := db.Exec(dropStmt); err != nil {
-					b.Fatal(err)
-				}
+				db.Exec(b, dropStmt)
 			}()
 
 			for i := 0; i < nFks; i++ {
-				if _, err := db.Exec(fmt.Sprintf(`CREATE TABLE bench.fk%d (k INT PRIMARY KEY)`, i)); err != nil {
-					b.Fatal(err)
-				}
-				if _, err := db.Exec(fmt.Sprintf(`INSERT INTO bench.fk%d VALUES(1), (2), (3)`, i)); err != nil {
-					b.Fatal(err)
-				}
+				db.Exec(b, fmt.Sprintf(`CREATE TABLE bench.fk%d (k INT PRIMARY KEY)`, i))
+				db.Exec(b, fmt.Sprintf(`INSERT INTO bench.fk%d VALUES(1), (2), (3)`, i))
 			}
 
 			createStmt := `CREATE TABLE bench.insert (k INT PRIMARY KEY`
@@ -318,9 +265,7 @@ func runBenchmarkInsertFK(b *testing.B, db *gosql.DB, count int) {
 			}
 			createStmt += ")"
 			valuesStr += ")"
-			if _, err := db.Exec(createStmt); err != nil {
-				b.Fatal(err)
-			}
+			db.Exec(b, createStmt)
 
 			b.ResetTimer()
 			var buf bytes.Buffer
@@ -335,9 +280,7 @@ func runBenchmarkInsertFK(b *testing.B, db *gosql.DB, count int) {
 					fmt.Fprintf(&buf, valuesStr, val)
 					val++
 				}
-				if _, err := db.Exec(buf.String()); err != nil {
-					b.Fatal(err)
-				}
+				db.Exec(b, buf.String())
 			}
 			b.StopTimer()
 
@@ -347,21 +290,15 @@ func runBenchmarkInsertFK(b *testing.B, db *gosql.DB, count int) {
 
 // runBenchmarkInsertSecondaryIndex benchmarks inserting count rows into a table with a
 // secondary index.
-func runBenchmarkInsertSecondaryIndex(b *testing.B, db *gosql.DB, count int) {
+func runBenchmarkInsertSecondaryIndex(b *testing.B, db *sqlutils.SQLRunner, count int) {
 	defer func() {
-		if _, err := db.Exec(`DROP TABLE IF EXISTS bench.insert`); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, `DROP TABLE IF EXISTS bench.insert`)
 	}()
 
-	if _, err := db.Exec(`CREATE TABLE bench.insert (k INT PRIMARY KEY, v INT,  INDEX(v))`); err != nil {
-		b.Fatal(err)
-	}
+	db.Exec(b, `CREATE TABLE bench.insert (k INT PRIMARY KEY, v INT,  INDEX(v))`)
 
 	for i := 0; i < 10; i++ {
-		if _, err := db.Exec(`CREATE INDEX ON bench.insert (v)`); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, `CREATE INDEX ON bench.insert (v)`)
 	}
 
 	b.ResetTimer()
@@ -377,9 +314,7 @@ func runBenchmarkInsertSecondaryIndex(b *testing.B, db *gosql.DB, count int) {
 			fmt.Fprintf(&buf, "(%d, %d)", val, val)
 			val++
 		}
-		if _, err := db.Exec(buf.String()); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, buf.String())
 	}
 	b.StopTimer()
 }
@@ -389,8 +324,8 @@ func BenchmarkSQL(b *testing.B) {
 		b.Skip("short flag")
 	}
 	defer log.Scope(b).Close(b)
-	ForEachDB(b, func(b *testing.B, db *gosql.DB) {
-		for _, runFn := range []func(*testing.B, *gosql.DB, int){
+	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
+		for _, runFn := range []func(*testing.B, *sqlutils.SQLRunner, int){
 			runBenchmarkDelete,
 			runBenchmarkInsert,
 			runBenchmarkInsertDistinct,
@@ -416,17 +351,13 @@ func BenchmarkSQL(b *testing.B) {
 }
 
 // runBenchmarkUpdate benchmarks updating count random rows in a table.
-func runBenchmarkUpdate(b *testing.B, db *gosql.DB, count int) {
+func runBenchmarkUpdate(b *testing.B, db *sqlutils.SQLRunner, count int) {
 	defer func() {
-		if _, err := db.Exec(`DROP TABLE IF EXISTS bench.update`); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, `DROP TABLE IF EXISTS bench.update`)
 	}()
 
 	const rows = 10000
-	if _, err := db.Exec(`CREATE TABLE bench.update (k INT PRIMARY KEY, v INT)`); err != nil {
-		b.Fatal(err)
-	}
+	db.Exec(b, `CREATE TABLE bench.update (k INT PRIMARY KEY, v INT)`)
 
 	var buf bytes.Buffer
 	buf.WriteString(`INSERT INTO bench.update VALUES `)
@@ -436,9 +367,7 @@ func runBenchmarkUpdate(b *testing.B, db *gosql.DB, count int) {
 		}
 		fmt.Fprintf(&buf, "(%d, %d)", i, i)
 	}
-	if _, err := db.Exec(buf.String()); err != nil {
-		b.Fatal(err)
-	}
+	db.Exec(b, buf.String())
 
 	s := rand.New(rand.NewSource(5432))
 
@@ -453,24 +382,18 @@ func runBenchmarkUpdate(b *testing.B, db *gosql.DB, count int) {
 			fmt.Fprintf(&buf, `%d`, s.Intn(rows))
 		}
 		buf.WriteString(`)`)
-		if _, err := db.Exec(buf.String()); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, buf.String())
 	}
 	b.StopTimer()
 }
 
 // runBenchmarkUpsert benchmarks upserting count rows in a table.
-func runBenchmarkUpsert(b *testing.B, db *gosql.DB, count int) {
+func runBenchmarkUpsert(b *testing.B, db *sqlutils.SQLRunner, count int) {
 	defer func() {
-		if _, err := db.Exec(`DROP TABLE IF EXISTS bench.upsert`); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, `DROP TABLE IF EXISTS bench.upsert`)
 	}()
 
-	if _, err := db.Exec(`CREATE TABLE bench.upsert (k INT PRIMARY KEY, v INT)`); err != nil {
-		b.Fatal(err)
-	}
+	db.Exec(b, `CREATE TABLE bench.upsert (k INT PRIMARY KEY, v INT)`)
 
 	// Upsert in Cockroach doesn't let you conflict the same row twice in one
 	// statement (fwiw, neither does Postgres), so build one statement that
@@ -489,28 +412,20 @@ func runBenchmarkUpsert(b *testing.B, db *gosql.DB, count int) {
 	b.ResetTimer()
 	key := 0
 	for i := 0; i < b.N; i++ {
-		if _, err := db.Exec(upsertBuf.String(), key); err != nil {
-			b.Fatal(err)
-		}
-		if _, err := db.Exec(upsertBuf.String(), key); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, upsertBuf.String(), key)
+		db.Exec(b, upsertBuf.String(), key)
 		key += count
 	}
 	b.StopTimer()
 }
 
 // runBenchmarkDelete benchmarks deleting count rows from a table.
-func runBenchmarkDelete(b *testing.B, db *gosql.DB, rows int) {
+func runBenchmarkDelete(b *testing.B, db *sqlutils.SQLRunner, rows int) {
 	defer func() {
-		if _, err := db.Exec(`DROP TABLE IF EXISTS bench.delete`); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, `DROP TABLE IF EXISTS bench.delete`)
 	}()
 
-	if _, err := db.Exec(`CREATE TABLE bench.delete (k INT PRIMARY KEY, v1 INT, v2 INT, v3 INT)`); err != nil {
-		b.Fatal(err)
-	}
+	db.Exec(b, `CREATE TABLE bench.delete (k INT PRIMARY KEY, v1 INT, v2 INT, v3 INT)`)
 
 	b.ResetTimer()
 	var buf bytes.Buffer
@@ -524,9 +439,7 @@ func runBenchmarkDelete(b *testing.B, db *gosql.DB, rows int) {
 			}
 			fmt.Fprintf(&buf, "(%d, %d, %d, %d)", j, j, j, j)
 		}
-		if _, err := db.Exec(buf.String()); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, buf.String())
 		b.StartTimer()
 
 		buf.Reset()
@@ -538,24 +451,18 @@ func runBenchmarkDelete(b *testing.B, db *gosql.DB, rows int) {
 			fmt.Fprintf(&buf, `%d`, j)
 		}
 		buf.WriteString(`)`)
-		if _, err := db.Exec(buf.String()); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, buf.String())
 	}
 	b.StopTimer()
 }
 
 // runBenchmarkScan benchmarks scanning a table containing count rows.
-func runBenchmarkScan(b *testing.B, db *gosql.DB, count int, limit int) {
+func runBenchmarkScan(b *testing.B, db *sqlutils.SQLRunner, count int, limit int) {
 	defer func() {
-		if _, err := db.Exec(`DROP TABLE IF EXISTS bench.scan`); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, `DROP TABLE IF EXISTS bench.scan`)
 	}()
 
-	if _, err := db.Exec(`CREATE TABLE bench.scan (k INT PRIMARY KEY)`); err != nil {
-		b.Fatal(err)
-	}
+	db.Exec(b, `CREATE TABLE bench.scan (k INT PRIMARY KEY)`)
 
 	var buf bytes.Buffer
 	buf.WriteString(`INSERT INTO bench.scan VALUES `)
@@ -565,9 +472,7 @@ func runBenchmarkScan(b *testing.B, db *gosql.DB, count int, limit int) {
 		}
 		fmt.Fprintf(&buf, "(%d)", i)
 	}
-	if _, err := db.Exec(buf.String()); err != nil {
-		b.Fatal(err)
-	}
+	db.Exec(b, buf.String())
 
 	query := `SELECT * FROM bench.scan`
 	if limit != 0 {
@@ -576,10 +481,7 @@ func runBenchmarkScan(b *testing.B, db *gosql.DB, count int, limit int) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		rows, err := db.Query(query)
-		if err != nil {
-			b.Fatal(err)
-		}
+		rows := db.Query(b, query)
 		n := 0
 		for rows.Next() {
 			n++
@@ -604,7 +506,7 @@ func BenchmarkScan(b *testing.B) {
 		b.Skip("short flag")
 	}
 	defer log.Scope(b).Close(b)
-	ForEachDB(b, func(b *testing.B, db *gosql.DB) {
+	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
 		for _, count := range []int{1, 10, 100, 1000, 10000} {
 			b.Run(fmt.Sprintf("count=%d", count), func(b *testing.B) {
 				for _, limit := range []int{0, 1, 10, 100} {
@@ -619,17 +521,13 @@ func BenchmarkScan(b *testing.B) {
 
 // runBenchmarkScanFilter benchmarks scanning (w/filter) from a table containing count1 * count2 rows.
 func runBenchmarkScanFilter(
-	b *testing.B, db *gosql.DB, count1, count2 int, limit int, filter string,
+	b *testing.B, db *sqlutils.SQLRunner, count1, count2 int, limit int, filter string,
 ) {
 	defer func() {
-		if _, err := db.Exec(`DROP TABLE IF EXISTS bench.scan2`); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, `DROP TABLE IF EXISTS bench.scan2`)
 	}()
 
-	if _, err := db.Exec(`CREATE TABLE bench.scan2 (a INT, b INT, PRIMARY KEY (a, b))`); err != nil {
-		b.Fatal(err)
-	}
+	db.Exec(b, `CREATE TABLE bench.scan2 (a INT, b INT, PRIMARY KEY (a, b))`)
 
 	var buf bytes.Buffer
 	buf.WriteString(`INSERT INTO bench.scan2 VALUES `)
@@ -641,9 +539,7 @@ func runBenchmarkScanFilter(
 			fmt.Fprintf(&buf, "(%d, %d)", i, j)
 		}
 	}
-	if _, err := db.Exec(buf.String()); err != nil {
-		b.Fatal(err)
-	}
+	db.Exec(b, buf.String())
 
 	query := fmt.Sprintf(`SELECT * FROM bench.scan2 WHERE %s`, filter)
 	if limit != 0 {
@@ -652,10 +548,7 @@ func runBenchmarkScanFilter(
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		rows, err := db.Query(query)
-		if err != nil {
-			b.Fatal(err)
-		}
+		rows := db.Query(b, query)
 		n := 0
 		for rows.Next() {
 			n++
@@ -672,7 +565,7 @@ func BenchmarkScanFilter(b *testing.B) {
 	defer log.Scope(b).Close(b)
 	const count1 = 25
 	const count2 = 400
-	ForEachDB(b, func(b *testing.B, db *gosql.DB) {
+	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
 		b.Run(fmt.Sprintf("count1=%d", count1), func(b *testing.B) {
 			b.Run(fmt.Sprintf("count2=%d", count2), func(b *testing.B) {
 				for _, limit := range []int{1, 10, 50} {
@@ -689,22 +582,14 @@ func BenchmarkScanFilter(b *testing.B) {
 	})
 }
 
-func runBenchmarkInterleavedSelect(b *testing.B, db *gosql.DB, count int) {
+func runBenchmarkInterleavedSelect(b *testing.B, db *sqlutils.SQLRunner, count int) {
 	defer func() {
-		if _, err := db.Exec(`DROP TABLE IF EXISTS bench.interleaved_select2`); err != nil {
-			b.Fatal(err)
-		}
-		if _, err := db.Exec(`DROP TABLE IF EXISTS bench.interleaved_select1`); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, `DROP TABLE IF EXISTS bench.interleaved_select2`)
+		db.Exec(b, `DROP TABLE IF EXISTS bench.interleaved_select1`)
 	}()
 
-	if _, err := db.Exec(`CREATE TABLE bench.interleaved_select1 (a INT PRIMARY KEY, b INT)`); err != nil {
-		b.Fatal(err)
-	}
-	if _, err := db.Exec(`CREATE TABLE bench.interleaved_select2 (c INT PRIMARY KEY, d INT) INTERLEAVE IN PARENT interleaved_select1 (c)`); err != nil {
-		b.Fatal(err)
-	}
+	db.Exec(b, `CREATE TABLE bench.interleaved_select1 (a INT PRIMARY KEY, b INT)`)
+	db.Exec(b, `CREATE TABLE bench.interleaved_select2 (c INT PRIMARY KEY, d INT) INTERLEAVE IN PARENT interleaved_select1 (c)`)
 
 	const interleaveFreq = 4
 
@@ -724,21 +609,14 @@ func runBenchmarkInterleavedSelect(b *testing.B, db *gosql.DB, count int) {
 			fmt.Fprintf(&buf2, "(%d, %d)", i, i)
 		}
 	}
-	if _, err := db.Exec(buf1.String()); err != nil {
-		b.Fatal(err)
-	}
-	if _, err := db.Exec(buf2.String()); err != nil {
-		b.Fatal(err)
-	}
+	db.Exec(b, buf1.String())
+	db.Exec(b, buf2.String())
 
 	query := `SELECT * FROM bench.interleaved_select1 is1 INNER JOIN bench.interleaved_select2 is2 on is1.a = is2.c`
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		rows, err := db.Query(query)
-		if err != nil {
-			b.Fatal(err)
-		}
+		rows := db.Query(b, query)
 		n := 0
 		for rows.Next() {
 			n++
@@ -755,23 +633,19 @@ func runBenchmarkInterleavedSelect(b *testing.B, db *gosql.DB, count int) {
 	b.StopTimer()
 }
 
-func runBenchmarkInterleavedFK(b *testing.B, db *gosql.DB, count int) {
+func runBenchmarkInterleavedFK(b *testing.B, db *sqlutils.SQLRunner, count int) {
 	defer func() {
-		if _, err := db.Exec(`DROP TABLE IF EXISTS bench.parent CASCADE; DROP TABLE IF EXISTS bench.child CASCADE`); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, `DROP TABLE IF EXISTS bench.parent CASCADE; DROP TABLE IF EXISTS bench.child CASCADE`)
 	}()
 
-	if _, err := db.Exec(`
+	db.Exec(b, `
 CREATE TABLE bench.parent (a INT PRIMARY KEY);
 INSERT INTO bench.parent VALUES(0);
 CREATE TABLE bench.child
   (a INT REFERENCES bench.parent(a),
    b INT, PRIMARY KEY(a, b))
 INTERLEAVE IN PARENT bench.parent (a)
-`); err != nil {
-		b.Fatal(err)
-	}
+`)
 
 	b.ResetTimer()
 	var buf bytes.Buffer
@@ -786,23 +660,19 @@ INTERLEAVE IN PARENT bench.parent (a)
 			fmt.Fprintf(&buf, "(0, %d)", val)
 			val++
 		}
-		if _, err := db.Exec(buf.String()); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, buf.String())
 	}
 }
 
 // runBenchmarkOrderBy benchmarks scanning a table and sorting the results.
-func runBenchmarkOrderBy(b *testing.B, db *gosql.DB, count int, limit int, distinct bool) {
+func runBenchmarkOrderBy(
+	b *testing.B, db *sqlutils.SQLRunner, count int, limit int, distinct bool,
+) {
 	defer func() {
-		if _, err := db.Exec(`DROP TABLE IF EXISTS bench.sort`); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, `DROP TABLE IF EXISTS bench.sort`)
 	}()
 
-	if _, err := db.Exec(`CREATE TABLE bench.sort (k INT PRIMARY KEY, v INT, w INT)`); err != nil {
-		b.Fatal(err)
-	}
+	db.Exec(b, `CREATE TABLE bench.sort (k INT PRIMARY KEY, v INT, w INT)`)
 
 	var buf bytes.Buffer
 	buf.WriteString(`INSERT INTO bench.sort VALUES `)
@@ -812,9 +682,7 @@ func runBenchmarkOrderBy(b *testing.B, db *gosql.DB, count int, limit int, disti
 		}
 		fmt.Fprintf(&buf, "(%d, %d, %d)", i, i%(count*4/limit), i%2)
 	}
-	if _, err := db.Exec(buf.String()); err != nil {
-		b.Fatal(err)
-	}
+	db.Exec(b, buf.String())
 
 	var dist string
 	if distinct {
@@ -827,10 +695,7 @@ func runBenchmarkOrderBy(b *testing.B, db *gosql.DB, count int, limit int, disti
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		rows, err := db.Query(query)
-		if err != nil {
-			b.Fatal(err)
-		}
+		rows := db.Query(b, query)
 		n := 0
 		for rows.Next() {
 			n++
@@ -857,7 +722,7 @@ func BenchmarkOrderBy(b *testing.B) {
 	defer log.Scope(b).Close(b)
 	const count = 100000
 	const limit = 10
-	ForEachDB(b, func(b *testing.B, db *gosql.DB) {
+	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
 		b.Run(fmt.Sprintf("count=%d", count), func(b *testing.B) {
 			b.Run(fmt.Sprintf("limit=%d", limit), func(b *testing.B) {
 				for _, distinct := range []bool{false, true} {
@@ -870,11 +735,9 @@ func BenchmarkOrderBy(b *testing.B) {
 	})
 }
 
-func runBenchmarkTrackChoices(b *testing.B, db *gosql.DB, batchSize int) {
+func runBenchmarkTrackChoices(b *testing.B, db *sqlutils.SQLRunner, batchSize int) {
 	defer func() {
-		if _, err := db.Exec(`DROP TABLE IF EXISTS bench.track_choices`); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, `DROP TABLE IF EXISTS bench.track_choices`)
 	}()
 
 	const numOptions = 10000
@@ -890,9 +753,7 @@ CREATE TABLE bench.track_choices (
 CREATE INDEX user_created_at ON bench.track_choices (user_id, created_at);
 CREATE INDEX track_created_at ON bench.track_choices (track_id, created_at);
 `
-	if _, err := db.Exec(createStmt); err != nil {
-		b.Fatal(err)
-	}
+	db.Exec(b, createStmt)
 
 	b.ResetTimer()
 	var buf bytes.Buffer
@@ -909,9 +770,7 @@ CREATE INDEX track_created_at ON bench.track_choices (track_id, created_at);
 			}
 			fmt.Fprintf(&buf, "(%d, %d, now())", rand.Int63(), rand.Int63n(numOptions))
 		}
-		if _, err := db.Exec(buf.String()); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, buf.String())
 	}
 	b.StopTimer()
 }
@@ -919,11 +778,9 @@ CREATE INDEX track_created_at ON bench.track_choices (track_id, created_at);
 // Benchmark inserting distinct rows in batches where the min and max rows in
 // separate batches overlap. This stresses the spanlatch manager implementation
 // and verifies that we're allowing parallel execution of commands where possible.
-func runBenchmarkInsertDistinct(b *testing.B, db *gosql.DB, numUsers int) {
+func runBenchmarkInsertDistinct(b *testing.B, db *sqlutils.SQLRunner, numUsers int) {
 	defer func() {
-		if _, err := db.Exec(`DROP TABLE IF EXISTS bench.insert_distinct`); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, `DROP TABLE IF EXISTS bench.insert_distinct`)
 	}()
 
 	const schema = `
@@ -933,9 +790,7 @@ CREATE TABLE bench.insert_distinct (
   uniqueID INT DEFAULT unique_rowid(),
   PRIMARY KEY (articleID, userID, uniqueID))
 `
-	if _, err := db.Exec(schema); err != nil {
-		b.Fatal(err)
-	}
+	db.Exec(b, schema)
 
 	b.ResetTimer()
 
@@ -970,7 +825,7 @@ CREATE TABLE bench.insert_distinct (
 						fmt.Fprintf(&buf, "(%d, %d)", zipf.Uint64(), n)
 					}
 
-					if _, err := db.Exec(buf.String()); err != nil {
+					if _, err := db.DB.ExecContext(context.TODO(), buf.String()); err != nil {
 						return err
 					}
 				}
@@ -995,16 +850,18 @@ const wideTableSchema = `CREATE TABLE bench.widetable (
   )`
 
 func insertIntoWideTable(
-	b *testing.B, buf bytes.Buffer, i, count, bigColumnBytes int, s *rand.Rand, db *gosql.DB,
+	b *testing.B,
+	buf bytes.Buffer,
+	i, count, bigColumnBytes int,
+	s *rand.Rand,
+	db *sqlutils.SQLRunner,
 ) {
 	buf.WriteString(`INSERT INTO bench.widetable VALUES `)
 	for j := 0; j < count; j++ {
 		if j != 0 {
 			if j%3 == 0 {
 				buf.WriteString(`;`)
-				if _, err := db.Exec(buf.String()); err != nil {
-					b.Fatal(err)
-				}
+				db.Exec(b, buf.String())
 				buf.Reset()
 				buf.WriteString(`INSERT INTO bench.widetable VALUES `)
 			} else {
@@ -1027,9 +884,7 @@ func insertIntoWideTable(
 		buf.WriteString(`)`)
 	}
 	buf.WriteString(`;`)
-	if _, err := db.Exec(buf.String()); err != nil {
-		b.Fatal(err)
-	}
+	db.Exec(b, buf.String())
 	buf.Reset()
 }
 
@@ -1043,16 +898,12 @@ func insertIntoWideTable(
 // columns in a family may be copied unnecessarily when it's updated. Perfect
 // knowledge of traffic patterns can result in much better heuristics, but we
 // don't have that information at table creation.
-func runBenchmarkWideTable(b *testing.B, db *gosql.DB, count int, bigColumnBytes int) {
+func runBenchmarkWideTable(b *testing.B, db *sqlutils.SQLRunner, count int, bigColumnBytes int) {
 	defer func() {
-		if _, err := db.Exec(`DROP TABLE IF EXISTS bench.widetable`); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, `DROP TABLE IF EXISTS bench.widetable`)
 	}()
 
-	if _, err := db.Exec(wideTableSchema); err != nil {
-		b.Fatal(err)
-	}
+	db.Exec(b, wideTableSchema)
 
 	s := rand.New(rand.NewSource(5432))
 
@@ -1091,9 +942,7 @@ func runBenchmarkWideTable(b *testing.B, db *gosql.DB, count int, bigColumnBytes
 		}
 		buf.WriteString(`);`)
 
-		if _, err := db.Exec(buf.String()); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, buf.String())
 	}
 	b.StopTimer()
 }
@@ -1104,7 +953,7 @@ func BenchmarkWideTable(b *testing.B) {
 	}
 	defer log.Scope(b).Close(b)
 	const count = 10
-	ForEachDB(b, func(b *testing.B, db *gosql.DB) {
+	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
 		b.Run(fmt.Sprintf("count=%d", count), func(b *testing.B) {
 			for _, bigColumnBytes := range []int{10, 100, 1000, 10000, 100000, 1000000} {
 				b.Run(fmt.Sprintf("bigColumnBytes=%d", bigColumnBytes), func(b *testing.B) {
@@ -1120,10 +969,8 @@ func BenchmarkWideTableIgnoreColumns(b *testing.B) {
 		b.Skip("short flag")
 	}
 	defer log.Scope(b).Close(b)
-	ForEachDB(b, func(b *testing.B, db *gosql.DB) {
-		if _, err := db.Exec(wideTableSchema); err != nil {
-			b.Fatal(err)
-		}
+	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
+		db.Exec(b, wideTableSchema)
 		var buf bytes.Buffer
 		s := rand.New(rand.NewSource(5432))
 		insertIntoWideTable(b, buf, 0, 10000, 10, s, db)
@@ -1131,22 +978,19 @@ func BenchmarkWideTableIgnoreColumns(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			if _, err := db.Exec("SELECT count(*) FROM bench.widetable WHERE f4 < 10"); err != nil {
-				b.Fatal(err)
-			}
+			db.Exec(b, "SELECT count(*) FROM bench.widetable WHERE f4 < 10")
 		}
 	})
 }
 
 // BenchmarkPlanning runs some queries on an empty table. The purpose is to
-// benchmark (and get memory allocation statistics) the planning process.
+// benchmark (and get memory allocation statistics for) the planning process.
 func BenchmarkPlanning(b *testing.B) {
 	if testing.Short() {
 		b.Skip("short flag")
 	}
-	ForEachDB(b, func(b *testing.B, db *gosql.DB) {
-		sr := sqlutils.MakeSQLRunner(db)
-		sr.Exec(b, `CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT, INDEX(b), UNIQUE INDEX(c))`)
+	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
+		db.Exec(b, `CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT, INDEX(b), UNIQUE INDEX(c))`)
 
 		queries := []string{
 			`SELECT * FROM abc`,
@@ -1159,7 +1003,7 @@ func BenchmarkPlanning(b *testing.B) {
 		for _, q := range queries {
 			b.Run(q, func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
-					sr.Exec(b, q)
+					db.Exec(b, q)
 				}
 			})
 		}
@@ -1169,7 +1013,7 @@ func BenchmarkPlanning(b *testing.B) {
 // BenchmarkIndexJoin measure an index-join with 1000 rows.
 func BenchmarkIndexJoin(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	ForEachDB(b, func(b *testing.B, db *gosql.DB) {
+	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
 		// The table will have an extra column not contained in the index to force a
 		// join with the PK.
 		create := `
@@ -1187,25 +1031,19 @@ func BenchmarkIndexJoin(b *testing.B) {
 		// optimizer doesn't know that).
 		insert := "insert into tidx(k,v) select generate_series(1,1000), (random()*1000)::int"
 
-		if _, err := db.Exec(create); err != nil {
-			b.Fatal(err)
-		}
-		if _, err := db.Exec(insert); err != nil {
-			b.Fatal(err)
-		}
+		db.Exec(b, create)
+		db.Exec(b, insert)
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			if _, err := db.Exec("select * from bench.tidx where v < 1000"); err != nil {
-				b.Fatal(err)
-			}
+			db.Exec(b, "select * from bench.tidx where v < 1000")
 		}
 	})
 }
 
 func BenchmarkSortJoinAggregation(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	ForEachDB(b, func(b *testing.B, db *gosql.DB) {
+	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
 		tables := []struct {
 			create   string
 			populate string
@@ -1233,12 +1071,8 @@ func BenchmarkSortJoinAggregation(b *testing.B) {
 		}
 
 		for _, table := range tables {
-			if _, err := db.Exec(table.create); err != nil {
-				b.Fatal(err)
-			}
-			if _, err := db.Exec(table.populate); err != nil {
-				b.Fatal(err)
-			}
+			db.Exec(b, table.create)
+			db.Exec(b, table.populate)
 		}
 
 		query := `
@@ -1252,9 +1086,7 @@ func BenchmarkSortJoinAggregation(b *testing.B) {
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			if _, err := db.Exec(query); err != nil {
-				b.Fatal(err)
-			}
+			db.Exec(b, query)
 		}
 	})
 }

--- a/pkg/bench/pgbench_test.go
+++ b/pkg/bench/pgbench_test.go
@@ -12,7 +12,6 @@ package bench
 
 import (
 	"context"
-	gosql "database/sql"
 	"fmt"
 	"math/rand"
 	"net"
@@ -33,14 +32,14 @@ import (
 // in its TPC-B(ish) mode.
 func BenchmarkPgbenchQuery(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	ForEachDB(b, func(b *testing.B, db *gosql.DB) {
-		if err := SetupBenchDB(db, 20000, true /*quiet*/); err != nil {
+	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
+		if err := SetupBenchDB(db.DB, 20000, true /*quiet*/); err != nil {
 			b.Fatal(err)
 		}
 		src := rand.New(rand.NewSource(5432))
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			if err := RunOne(db, src, 20000); err != nil {
+			if err := RunOne(db.DB, src, 20000); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -52,8 +51,8 @@ func BenchmarkPgbenchQuery(b *testing.B) {
 // in its TPC-B(ish) mode.
 func BenchmarkPgbenchQueryParallel(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	ForEachDB(b, func(b *testing.B, db *gosql.DB) {
-		if err := SetupBenchDB(db, 20000, true /*quiet*/); err != nil {
+	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
+		if err := SetupBenchDB(db.DB, 20000, true /*quiet*/); err != nil {
 			b.Fatal(err)
 		}
 
@@ -71,7 +70,7 @@ func BenchmarkPgbenchQueryParallel(b *testing.B) {
 			for pb.Next() {
 				r.Reset()
 				for r.Next() {
-					err = RunOne(db, src, 20000)
+					err = RunOne(db.DB, src, 20000)
 					if err == nil {
 						break
 					}

--- a/pkg/testutils/sqlutils/sql_runner.go
+++ b/pkg/testutils/sqlutils/sql_runner.go
@@ -29,7 +29,7 @@ type SQLRunner struct {
 }
 
 // DBHandle is an interface that applies to *gosql.DB, *gosql.Conn, and
-// *gosql.Tx.
+// *gosql.Tx, as well as *RoundRobinDBHandle.
 type DBHandle interface {
 	ExecContext(ctx context.Context, query string, args ...interface{}) (gosql.Result, error)
 	QueryContext(ctx context.Context, query string, args ...interface{}) (*gosql.Rows, error)
@@ -44,6 +44,12 @@ var _ DBHandle = &gosql.Tx{}
 // The argument can be a *gosql.DB, *gosql.Conn, or *gosql.Tx object.
 func MakeSQLRunner(db DBHandle) *SQLRunner {
 	return &SQLRunner{DB: db}
+}
+
+// MakeRoundRobinSQLRunner returns a SQLRunner that uses a set of database
+// connections, in a round-robin fashion.
+func MakeRoundRobinSQLRunner(dbs ...DBHandle) *SQLRunner {
+	return MakeSQLRunner(MakeRoundRobinDBHandle(dbs...))
 }
 
 // Exec is a wrapper around gosql.Exec that kills the test on error.
@@ -199,4 +205,45 @@ func (sr *SQLRunner) CheckQueryResultsRetry(t testing.TB, query string, expected
 		}
 		return nil
 	})
+}
+
+// RoundRobinDBHandle aggregates multiple DBHandles into a single one; each time
+// a query is issued, a handle is selected in round-robin fashion.
+type RoundRobinDBHandle struct {
+	handles []DBHandle
+	current int
+}
+
+var _ DBHandle = &RoundRobinDBHandle{}
+
+// MakeRoundRobinDBHandle creates a RoundRobinDBHandle.
+func MakeRoundRobinDBHandle(handles ...DBHandle) *RoundRobinDBHandle {
+	return &RoundRobinDBHandle{handles: handles}
+}
+
+func (rr *RoundRobinDBHandle) next() DBHandle {
+	h := rr.handles[rr.current]
+	rr.current = (rr.current + 1) % len(rr.handles)
+	return h
+}
+
+// ExecContext is part of the DBHandle interface.
+func (rr *RoundRobinDBHandle) ExecContext(
+	ctx context.Context, query string, args ...interface{},
+) (gosql.Result, error) {
+	return rr.next().ExecContext(ctx, query, args...)
+}
+
+// QueryContext is part of the DBHandle interface.
+func (rr *RoundRobinDBHandle) QueryContext(
+	ctx context.Context, query string, args ...interface{},
+) (*gosql.Rows, error) {
+	return rr.next().QueryContext(ctx, query, args...)
+}
+
+// QueryRowContext is part of the DBHandle interface.
+func (rr *RoundRobinDBHandle) QueryRowContext(
+	ctx context.Context, query string, args ...interface{},
+) *gosql.Row {
+	return rr.next().QueryRowContext(ctx, query, args...)
 }


### PR DESCRIPTION
When these benchmarks run against MultinodeCockroach, they only talk
to the first node in a three-node cluster. This is unrealistic and
leads to silly behaviors where sub-benchmarks (which run against the
same cluster) change performance when a relevant lease moves.

This change makes it so that we issue queries against all three nodes,
in round-robin fashion. This required some refactoring; we add the
round-robin capability to `SQLRunner` and use that everywhere.

Note that the results of the Multinode benchmarks going forward will
not be directly comparable with previous results.

```
name                                                                                 old time/op  new time/op   delta
Select1/Cockroach-24                                                                  167µs ± 4%    168µs ± 3%      ~     (p=0.549 n=10+9)
Select1/MultinodeCockroach-24                                                         171µs ± 2%    176µs ± 1%    +2.93%  (p=0.000 n=8+8)
Select2/Cockroach-24                                                                  866µs ± 1%    856µs ± 1%    -1.08%  (p=0.002 n=10+10)
Select2/MultinodeCockroach-24                                                         875µs ± 0%   1547µs ± 1%   +76.88%  (p=0.000 n=10+10)
Select3/Cockroach-24                                                                 1.15ms ±12%   1.10ms ± 6%      ~     (p=0.113 n=10+9)
Select3/MultinodeCockroach-24                                                        1.10ms ± 1%   1.82ms ± 1%   +65.22%  (p=0.000 n=10+10)
Count/Cockroach-24                                                                   25.7ms ± 1%   25.4ms ± 1%    -1.22%  (p=0.000 n=9+9)
Count/MultinodeCockroach-24                                                          25.5ms ± 1%   26.2ms ± 1%    +2.75%  (p=0.000 n=9+8)
CountTwoCF/Cockroach-24                                                              45.4ms ± 1%   44.8ms ± 1%    -1.37%  (p=0.000 n=10+10)
CountTwoCF/MultinodeCockroach-24                                                     45.5ms ± 1%   45.8ms ± 1%      ~     (p=0.156 n=10+9)
Sort/Cockroach-24                                                                     156ms ± 1%    157ms ± 1%      ~     (p=0.739 n=10+10)
Sort/MultinodeCockroach-24                                                            156ms ± 1%    206ms ± 1%   +32.16%  (p=0.000 n=10+9)
SQL/Cockroach/Delete/count=1-24                                                       556µs ± 3%    546µs ± 2%    -1.87%  (p=0.004 n=9+9)
SQL/Cockroach/Delete/count=10-24                                                      660µs ± 6%    675µs ±11%      ~     (p=0.631 n=10+10)
SQL/Cockroach/Delete/count=100-24                                                    1.41ms ± 5%   1.39ms ± 4%      ~     (p=0.161 n=9+9)
SQL/Cockroach/Delete/count=1000-24                                                   19.4ms ±15%   19.4ms ±14%      ~     (p=0.853 n=10+10)
SQL/Cockroach/Insert/count=1-24                                                       600µs ± 2%    592µs ± 3%      ~     (p=0.063 n=10+10)
SQL/Cockroach/Insert/count=10-24                                                      744µs ± 1%    744µs ± 3%      ~     (p=0.661 n=9+10)
SQL/Cockroach/Insert/count=100-24                                                    1.79ms ± 7%   1.77ms ± 6%      ~     (p=0.853 n=10+10)
SQL/Cockroach/Insert/count=1000-24                                                   10.6ms ± 6%   10.4ms ± 9%      ~     (p=0.393 n=10+10)
SQL/Cockroach/InsertDistinct/count=1-24                                              1.66ms ± 4%   1.63ms ± 4%      ~     (p=0.075 n=10+10)
SQL/Cockroach/InsertDistinct/count=10-24                                              326µs ± 7%    333µs ±10%      ~     (p=0.342 n=10+10)
SQL/Cockroach/InsertDistinct/count=100-24                                             346µs ± 3%    345µs ± 6%      ~     (p=0.912 n=10+10)
SQL/Cockroach/InsertDistinct/count=1000-24                                            817µs ±14%    881µs ±14%      ~     (p=0.315 n=10+8)
SQL/Cockroach/InsertFK/count=1/nFks=1-24                                              746µs ± 3%    754µs ± 8%      ~     (p=0.684 n=10+10)
SQL/Cockroach/InsertFK/count=1/nFks=5-24                                             1.09ms ± 4%   1.07ms ± 3%      ~     (p=0.075 n=10+10)
SQL/Cockroach/InsertFK/count=1/nFks=10-24                                            1.37ms ± 3%   1.35ms ± 3%      ~     (p=0.123 n=10+10)
SQL/Cockroach/InsertFK/count=10/nFks=1-24                                            1.60ms ± 3%   1.60ms ± 4%      ~     (p=0.842 n=10+9)
SQL/Cockroach/InsertFK/count=10/nFks=5-24                                            4.40ms ± 3%   4.30ms ± 6%      ~     (p=0.105 n=10+10)
SQL/Cockroach/InsertFK/count=10/nFks=10-24                                           6.65ms ±11%   6.21ms ± 9%    -6.64%  (p=0.012 n=8+10)
SQL/Cockroach/InsertFK/count=100/nFks=1-24                                           8.75ms ± 1%   8.72ms ± 2%      ~     (p=1.000 n=8+10)
SQL/Cockroach/InsertFK/count=100/nFks=5-24                                           35.5ms ± 4%   35.1ms ± 5%      ~     (p=0.237 n=10+8)
SQL/Cockroach/InsertFK/count=100/nFks=10-24                                          53.4ms ± 8%   52.1ms ± 3%      ~     (p=0.211 n=10+9)
SQL/Cockroach/InsertFK/count=1000/nFks=1-24                                          80.8ms ± 8%   78.6ms ± 6%      ~     (p=0.190 n=10+10)
SQL/Cockroach/InsertFK/count=1000/nFks=5-24                                           345ms ± 4%    350ms ± 5%      ~     (p=0.497 n=10+9)
SQL/Cockroach/InsertFK/count=1000/nFks=10-24                                          539ms ± 4%    533ms ± 6%      ~     (p=0.353 n=10+10)
SQL/Cockroach/InsertSecondaryIndex/count=1-24                                        1.27ms ± 1%   1.24ms ± 3%    -2.29%  (p=0.004 n=9+9)
SQL/Cockroach/InsertSecondaryIndex/count=10-24                                       2.08ms ± 7%   2.11ms ± 4%      ~     (p=0.481 n=10+10)
SQL/Cockroach/InsertSecondaryIndex/count=100-24                                      8.05ms ± 4%   8.52ms ± 7%    +5.90%  (p=0.009 n=10+10)
SQL/Cockroach/InsertSecondaryIndex/count=1000-24                                     69.7ms ± 9%   74.1ms ±18%      ~     (p=0.165 n=10+10)
SQL/Cockroach/InterleavedSelect/count=1-24                                            486µs ± 1%    490µs ± 2%    +0.82%  (p=0.038 n=8+8)
SQL/Cockroach/InterleavedSelect/count=10-24                                           506µs ± 1%    500µs ± 1%    -1.03%  (p=0.009 n=10+10)
SQL/Cockroach/InterleavedSelect/count=100-24                                          657µs ± 2%    654µs ± 1%      ~     (p=0.182 n=9+10)
SQL/Cockroach/InterleavedSelect/count=1000-24                                        1.96ms ± 2%   1.96ms ± 2%      ~     (p=0.739 n=10+10)
SQL/Cockroach/InterleavedFK/count=1-24                                                803µs ± 3%    797µs ± 1%      ~     (p=0.123 n=10+10)
SQL/Cockroach/InterleavedFK/count=10-24                                              1.65ms ± 3%   1.62ms ± 3%      ~     (p=0.143 n=10+10)
SQL/Cockroach/InterleavedFK/count=100-24                                             9.10ms ± 2%   8.71ms ± 7%      ~     (p=0.101 n=8+10)
SQL/Cockroach/InterleavedFK/count=1000-24                                            80.1ms ± 6%   77.6ms ± 2%      ~     (p=0.065 n=10+9)
SQL/Cockroach/TrackChoices/count=1-24                                                1.00ms ±13%   0.99ms ±18%      ~     (p=0.853 n=10+10)
SQL/Cockroach/TrackChoices/count=10-24                                                149µs ±12%    150µs ±12%      ~     (p=0.905 n=10+9)
SQL/Cockroach/TrackChoices/count=100-24                                              48.6µs ± 6%   51.0µs ± 7%    +4.76%  (p=0.023 n=10+10)
SQL/Cockroach/TrackChoices/count=1000-24                                             38.4µs ± 4%   40.8µs ±11%    +6.17%  (p=0.002 n=10+10)
SQL/Cockroach/Update/count=1-24                                                       903µs ± 3%    917µs ± 3%    +1.62%  (p=0.024 n=9+9)
SQL/Cockroach/Update/count=10-24                                                     1.23ms ± 3%   1.23ms ± 4%      ~     (p=0.912 n=10+10)
SQL/Cockroach/Update/count=100-24                                                    3.53ms ± 1%   3.64ms ± 3%    +3.24%  (p=0.002 n=8+9)
SQL/Cockroach/Update/count=1000-24                                                   23.8ms ± 5%   24.7ms ± 6%    +4.14%  (p=0.008 n=9+10)
SQL/Cockroach/Upsert/count=1-24                                                      1.75ms ±11%   1.86ms ±13%      ~     (p=0.052 n=10+10)
SQL/Cockroach/Upsert/count=10-24                                                     1.86ms ± 1%   2.08ms ±36%      ~     (p=0.089 n=10+10)
SQL/Cockroach/Upsert/count=100-24                                                    3.59ms ± 3%   3.62ms ± 2%      ~     (p=0.105 n=10+10)
SQL/Cockroach/Upsert/count=1000-24                                                   25.6ms ± 5%   27.0ms ± 5%    +5.36%  (p=0.005 n=10+10)
SQL/MultinodeCockroach/Delete/count=1-24                                              920µs ±32%   1152µs ± 3%   +25.31%  (p=0.003 n=10+8)
SQL/MultinodeCockroach/Delete/count=10-24                                             937µs ± 2%   1233µs ± 3%   +31.59%  (p=0.000 n=9+9)
SQL/MultinodeCockroach/Delete/count=100-24                                           1.62ms ± 3%   1.97ms ±15%   +22.09%  (p=0.000 n=8+8)
SQL/MultinodeCockroach/Delete/count=1000-24                                          21.6ms ±11%   23.1ms ±12%      ~     (p=0.075 n=10+10)
SQL/MultinodeCockroach/Insert/count=1-24                                              872µs ± 4%   1159µs ± 2%   +32.94%  (p=0.000 n=10+10)
SQL/MultinodeCockroach/Insert/count=10-24                                            1.01ms ± 3%   1.32ms ± 4%   +31.05%  (p=0.000 n=9+8)
SQL/MultinodeCockroach/Insert/count=100-24                                           2.02ms ± 3%   2.37ms ± 4%   +17.60%  (p=0.000 n=9+10)
SQL/MultinodeCockroach/Insert/count=1000-24                                          10.7ms ± 7%   12.2ms ± 7%   +13.84%  (p=0.000 n=10+9)
SQL/MultinodeCockroach/InsertDistinct/count=1-24                                     1.97ms ± 7%   2.27ms ± 1%   +14.78%  (p=0.000 n=10+9)
SQL/MultinodeCockroach/InsertDistinct/count=10-24                                     361µs ± 4%    422µs ± 5%   +16.83%  (p=0.000 n=9+10)
SQL/MultinodeCockroach/InsertDistinct/count=100-24                                    366µs ± 4%    451µs ± 8%   +23.08%  (p=0.000 n=10+10)
SQL/MultinodeCockroach/InsertDistinct/count=1000-24                                   807µs ± 7%   1016µs ±51%      ~     (p=0.497 n=9+10)
SQL/MultinodeCockroach/InsertFK/count=1/nFks=1-24                                    1.01ms ± 1%   1.59ms ± 2%   +56.74%  (p=0.000 n=9+8)
SQL/MultinodeCockroach/InsertFK/count=1/nFks=5-24                                    1.35ms ± 4%   2.00ms ± 3%   +48.88%  (p=0.000 n=9+9)
SQL/MultinodeCockroach/InsertFK/count=1/nFks=10-24                                   1.64ms ± 2%   2.40ms ± 2%   +45.89%  (p=0.000 n=10+9)
SQL/MultinodeCockroach/InsertFK/count=10/nFks=1-24                                   1.93ms ± 4%   4.99ms ± 2%  +158.86%  (p=0.000 n=9+10)
SQL/MultinodeCockroach/InsertFK/count=10/nFks=5-24                                   4.49ms ± 2%   8.45ms ±13%   +88.26%  (p=0.000 n=8+10)
SQL/MultinodeCockroach/InsertFK/count=10/nFks=10-24                                  6.42ms ± 3%  10.88ms ± 2%   +69.50%  (p=0.000 n=10+8)
SQL/MultinodeCockroach/InsertFK/count=100/nFks=1-24                                  9.43ms ± 1%  37.78ms ± 4%  +300.59%  (p=0.000 n=10+10)
SQL/MultinodeCockroach/InsertFK/count=100/nFks=5-24                                  34.9ms ± 5%   68.7ms ± 3%   +96.76%  (p=0.000 n=10+9)
SQL/MultinodeCockroach/InsertFK/count=100/nFks=10-24                                 53.6ms ± 4%   90.4ms ± 1%   +68.65%  (p=0.000 n=10+8)
SQL/MultinodeCockroach/InsertFK/count=1000/nFks=1-24                                 84.4ms ± 3%  373.2ms ± 3%  +342.25%  (p=0.000 n=10+10)
SQL/MultinodeCockroach/InsertFK/count=1000/nFks=5-24                                  359ms ± 9%    803ms ± 2%  +123.65%  (p=0.000 n=9+7)
SQL/MultinodeCockroach/InsertFK/count=1000/nFks=10-24                                 551ms ± 4%    967ms ±18%   +75.44%  (p=0.000 n=10+10)
SQL/MultinodeCockroach/InsertSecondaryIndex/count=1-24                               1.64ms ± 5%   2.02ms ± 3%   +23.08%  (p=0.000 n=10+9)
SQL/MultinodeCockroach/InsertSecondaryIndex/count=10-24                              2.58ms ± 8%   2.83ms ± 6%    +9.91%  (p=0.000 n=9+10)
SQL/MultinodeCockroach/InsertSecondaryIndex/count=100-24                             9.90ms ± 9%  10.67ms ±10%    +7.81%  (p=0.007 n=10+10)
SQL/MultinodeCockroach/InsertSecondaryIndex/count=1000-24                            80.7ms ± 8%   88.2ms ±15%    +9.37%  (p=0.010 n=10+9)
SQL/MultinodeCockroach/InterleavedSelect/count=1-24                                   521µs ± 1%   1041µs ± 2%   +99.79%  (p=0.000 n=10+9)
SQL/MultinodeCockroach/InterleavedSelect/count=10-24                                  535µs ± 1%   1088µs ± 3%  +103.48%  (p=0.000 n=7+10)
SQL/MultinodeCockroach/InterleavedSelect/count=100-24                                 704µs ± 2%   1299µs ± 9%   +84.64%  (p=0.000 n=10+10)
SQL/MultinodeCockroach/InterleavedSelect/count=1000-24                               2.10ms ± 3%   2.81ms ± 5%   +33.77%  (p=0.000 n=10+10)
SQL/MultinodeCockroach/InterleavedFK/count=1-24                                      1.32ms ± 3%   2.27ms ± 8%   +72.51%  (p=0.000 n=9+10)
SQL/MultinodeCockroach/InterleavedFK/count=10-24                                     2.52ms ± 5%   6.88ms ± 4%  +172.53%  (p=0.000 n=10+10)
SQL/MultinodeCockroach/InterleavedFK/count=100-24                                    13.8ms ± 6%   53.4ms ± 2%  +285.97%  (p=0.000 n=10+10)
SQL/MultinodeCockroach/InterleavedFK/count=1000-24                                    126ms ±17%    520ms ± 5%  +312.42%  (p=0.000 n=10+8)
SQL/MultinodeCockroach/TrackChoices/count=1-24                                       1.53ms ±25%   1.62ms ±11%      ~     (p=0.436 n=10+10)
SQL/MultinodeCockroach/TrackChoices/count=10-24                                       202µs ±45%    207µs ± 8%      ~     (p=0.796 n=10+10)
SQL/MultinodeCockroach/TrackChoices/count=100-24                                     53.4µs ±13%   57.6µs ± 6%    +7.74%  (p=0.043 n=10+10)
SQL/MultinodeCockroach/TrackChoices/count=1000-24                                    42.1µs ± 4%   41.4µs ± 4%      ~     (p=0.101 n=8+10)
SQL/MultinodeCockroach/Update/count=1-24                                             1.19ms ± 2%   1.80ms ±11%   +50.85%  (p=0.000 n=9+10)
SQL/MultinodeCockroach/Update/count=10-24                                            1.51ms ± 2%   2.18ms ± 2%   +44.59%  (p=0.000 n=8+9)
SQL/MultinodeCockroach/Update/count=100-24                                           3.81ms ± 4%   4.95ms ± 8%   +29.74%  (p=0.000 n=10+9)
SQL/MultinodeCockroach/Update/count=1000-24                                          24.0ms ± 4%   27.6ms ± 2%   +15.18%  (p=0.000 n=9+8)
SQL/MultinodeCockroach/Upsert/count=1-24                                             2.52ms ± 2%   3.02ms ± 2%   +19.80%  (p=0.000 n=9+10)
SQL/MultinodeCockroach/Upsert/count=10-24                                            3.60ms ± 3%   4.07ms ± 8%   +13.19%  (p=0.000 n=8+10)
SQL/MultinodeCockroach/Upsert/count=100-24                                           13.8ms ± 1%   11.9ms ± 1%   -13.93%  (p=0.000 n=10+9)
SQL/MultinodeCockroach/Upsert/count=1000-24                                          66.0ms ±92%  106.6ms ± 2%      ~     (p=0.497 n=10+9)
Scan/Cockroach/count=1/limit=0-24                                                     372µs ± 2%    377µs ± 1%    +1.37%  (p=0.019 n=10+10)
Scan/Cockroach/count=1/limit=1-24                                                     379µs ± 1%    388µs ± 2%    +2.56%  (p=0.000 n=9+9)
Scan/Cockroach/count=1/limit=10-24                                                    380µs ± 1%    388µs ± 2%    +2.08%  (p=0.001 n=9+10)
Scan/Cockroach/count=1/limit=100-24                                                   382µs ± 2%    394µs ± 1%    +2.99%  (p=0.000 n=10+9)
Scan/Cockroach/count=10/limit=0-24                                                    390µs ± 1%    400µs ± 3%    +2.41%  (p=0.000 n=10+10)
Scan/Cockroach/count=10/limit=1-24                                                    386µs ± 2%    393µs ± 2%    +1.83%  (p=0.002 n=10+8)
Scan/Cockroach/count=10/limit=10-24                                                   399µs ± 1%    406µs ± 2%    +1.92%  (p=0.000 n=10+9)
Scan/Cockroach/count=10/limit=100-24                                                  398µs ± 2%    410µs ± 1%    +2.83%  (p=0.000 n=8+10)
Scan/Cockroach/count=100/limit=0-24                                                   512µs ± 1%    526µs ± 5%    +2.72%  (p=0.007 n=10+10)
Scan/Cockroach/count=100/limit=1-24                                                   385µs ± 2%    394µs ± 2%    +2.21%  (p=0.000 n=10+10)
Scan/Cockroach/count=100/limit=10-24                                                  413µs ±10%    409µs ± 1%      ~     (p=0.353 n=10+10)
Scan/Cockroach/count=100/limit=100-24                                                 518µs ± 1%    522µs ± 1%    +0.92%  (p=0.003 n=8+10)
Scan/Cockroach/count=1000/limit=0-24                                                 1.57ms ± 1%   1.58ms ± 1%    +0.54%  (p=0.003 n=10+10)
Scan/Cockroach/count=1000/limit=1-24                                                  383µs ± 1%    394µs ± 1%    +2.93%  (p=0.000 n=9+10)
Scan/Cockroach/count=1000/limit=10-24                                                 398µs ± 2%    408µs ± 2%    +2.67%  (p=0.000 n=10+8)
Scan/Cockroach/count=1000/limit=100-24                                                520µs ± 1%    525µs ± 1%    +1.07%  (p=0.004 n=10+8)
Scan/Cockroach/count=10000/limit=0-24                                                10.4ms ± 2%   10.3ms ± 2%      ~     (p=0.105 n=8+8)
Scan/Cockroach/count=10000/limit=1-24                                                 400µs ± 3%    408µs ± 2%    +1.95%  (p=0.008 n=9+10)
Scan/Cockroach/count=10000/limit=10-24                                                423µs ± 3%    425µs ± 3%      ~     (p=0.481 n=10+10)
Scan/Cockroach/count=10000/limit=100-24                                               566µs ± 5%    557µs ± 1%      ~     (p=0.546 n=9+9)
Scan/MultinodeCockroach/count=1/limit=0-24                                            386µs ± 1%    848µs ± 3%  +119.77%  (p=0.000 n=10+10)
Scan/MultinodeCockroach/count=1/limit=1-24                                            393µs ± 2%    858µs ± 3%  +118.11%  (p=0.000 n=10+10)
Scan/MultinodeCockroach/count=1/limit=10-24                                           398µs ± 1%    858µs ± 3%  +115.68%  (p=0.000 n=10+8)
Scan/MultinodeCockroach/count=1/limit=100-24                                          397µs ± 1%    860µs ± 2%  +116.91%  (p=0.000 n=10+9)
Scan/MultinodeCockroach/count=10/limit=0-24                                           400µs ± 1%    868µs ± 2%  +117.05%  (p=0.000 n=10+9)
Scan/MultinodeCockroach/count=10/limit=1-24                                           397µs ± 3%    865µs ± 3%  +117.95%  (p=0.000 n=10+9)
Scan/MultinodeCockroach/count=10/limit=10-24                                          408µs ± 1%    879µs ± 2%  +115.53%  (p=0.000 n=9+10)
Scan/MultinodeCockroach/count=10/limit=100-24                                         410µs ± 1%    879µs ± 2%  +114.30%  (p=0.000 n=9+10)
Scan/MultinodeCockroach/count=100/limit=0-24                                          523µs ± 1%   1025µs ± 1%   +96.14%  (p=0.000 n=10+8)
Scan/MultinodeCockroach/count=100/limit=1-24                                          413µs ± 6%    876µs ± 7%  +112.21%  (p=0.000 n=10+10)
Scan/MultinodeCockroach/count=100/limit=10-24                                         406µs ± 1%    879µs ± 2%  +116.40%  (p=0.000 n=9+10)
Scan/MultinodeCockroach/count=100/limit=100-24                                        525µs ± 2%   1051µs ± 3%  +100.20%  (p=0.000 n=10+8)
Scan/MultinodeCockroach/count=1000/limit=0-24                                        1.58ms ± 1%   2.49ms ± 3%   +57.24%  (p=0.000 n=9+10)
Scan/MultinodeCockroach/count=1000/limit=1-24                                         395µs ± 3%    860µs ± 2%  +117.55%  (p=0.000 n=10+10)
Scan/MultinodeCockroach/count=1000/limit=10-24                                        411µs ± 1%    896µs ± 1%  +117.96%  (p=0.000 n=10+10)
Scan/MultinodeCockroach/count=1000/limit=100-24                                       530µs ± 1%   1046µs ± 4%   +97.44%  (p=0.000 n=9+10)
Scan/MultinodeCockroach/count=10000/limit=0-24                                       10.7ms ± 3%   14.8ms ± 4%   +38.22%  (p=0.000 n=10+10)
Scan/MultinodeCockroach/count=10000/limit=1-24                                        414µs ± 3%    880µs ± 3%  +112.64%  (p=0.000 n=10+9)
Scan/MultinodeCockroach/count=10000/limit=10-24                                       439µs ± 7%    908µs ± 1%  +106.90%  (p=0.000 n=10+8)
Scan/MultinodeCockroach/count=10000/limit=100-24                                      564µs ± 3%   1098µs ± 5%   +94.69%  (p=0.000 n=9+10)
ScanFilter/Cockroach/count1=25/count2=400/limit=1-24                                  593µs ± 1%    601µs ± 2%    +1.25%  (p=0.043 n=9+10)
ScanFilter/Cockroach/count1=25/count2=400/limit=10-24                                 625µs ± 1%    631µs ± 1%    +0.97%  (p=0.019 n=10+10)
ScanFilter/Cockroach/count1=25/count2=400/limit=50-24                                1.67ms ± 2%   1.65ms ± 2%      ~     (p=0.089 n=10+10)
ScanFilter/MultinodeCockroach/count1=25/count2=400/limit=1-24                         610µs ± 2%   1305µs ± 5%  +114.08%  (p=0.000 n=9+9)
ScanFilter/MultinodeCockroach/count1=25/count2=400/limit=10-24                        642µs ± 3%   1330µs ± 2%  +107.22%  (p=0.000 n=9+9)
ScanFilter/MultinodeCockroach/count1=25/count2=400/limit=50-24                       1.69ms ± 1%   2.43ms ± 2%   +43.57%  (p=0.000 n=9+8)
OrderBy/Cockroach/count=100000/limit=10/distinct=false-24                             209ms ± 3%    209ms ± 5%      ~     (p=0.888 n=8+9)
OrderBy/Cockroach/count=100000/limit=10/distinct=true-24                              208ms ± 5%    208ms ± 5%      ~     (p=0.721 n=8+8)
OrderBy/MultinodeCockroach/count=100000/limit=10/distinct=false-24                    213ms ± 6%    227ms ± 8%    +6.30%  (p=0.008 n=10+9)
OrderBy/MultinodeCockroach/count=100000/limit=10/distinct=true-24                     221ms ± 5%    221ms ± 4%      ~     (p=0.888 n=9+8)
WideTable/Cockroach/count=10/bigColumnBytes=10-24                                    6.04ms ± 3%   5.94ms ± 1%      ~     (p=0.089 n=10+10)
WideTable/Cockroach/count=10/bigColumnBytes=100-24                                   6.11ms ± 2%   6.10ms ± 2%      ~     (p=0.971 n=10+10)
WideTable/Cockroach/count=10/bigColumnBytes=1000-24                                  6.88ms ± 2%   6.81ms ± 1%      ~     (p=0.063 n=10+10)
WideTable/Cockroach/count=10/bigColumnBytes=10000-24                                 13.8ms ± 7%   13.7ms ± 5%      ~     (p=0.631 n=10+10)
WideTable/Cockroach/count=10/bigColumnBytes=100000-24                                90.0ms ± 8%   90.9ms ± 5%      ~     (p=0.780 n=10+9)
WideTable/Cockroach/count=10/bigColumnBytes=1000000-24                                863ms ±21%    923ms ±18%      ~     (p=0.050 n=9+9)
WideTable/MultinodeCockroach/count=10/bigColumnBytes=10-24                           8.02ms ± 3%  10.41ms ± 2%   +29.85%  (p=0.000 n=10+9)
WideTable/MultinodeCockroach/count=10/bigColumnBytes=100-24                          8.28ms ± 2%  10.63ms ± 3%   +28.49%  (p=0.000 n=9+10)
WideTable/MultinodeCockroach/count=10/bigColumnBytes=1000-24                         9.50ms ± 3%  12.29ms ± 4%   +29.29%  (p=0.000 n=10+10)
WideTable/MultinodeCockroach/count=10/bigColumnBytes=10000-24                        20.6ms ± 3%   26.5ms ±11%   +28.62%  (p=0.000 n=10+9)
WideTable/MultinodeCockroach/count=10/bigColumnBytes=100000-24                        119ms ± 3%    169ms ± 6%   +42.08%  (p=0.000 n=7+10)
WideTable/MultinodeCockroach/count=10/bigColumnBytes=1000000-24                       1.39s ±12%    2.00s ±20%   +43.75%  (p=0.000 n=10+10)
WideTableIgnoreColumns/Cockroach-24                                                  6.99ms ± 2%   6.82ms ± 1%    -2.41%  (p=0.000 n=10+8)
WideTableIgnoreColumns/MultinodeCockroach-24                                         7.05ms ± 5%   7.72ms ± 3%    +9.54%  (p=0.000 n=9+10)
Planning/Cockroach/SELECT_*_FROM_abc-24                                               365µs ± 1%    363µs ± 1%      ~     (p=0.211 n=10+9)
Planning/Cockroach/SELECT_*_FROM_abc_WHERE_a_>_5_ORDER_BY_a-24                        365µs ± 1%    360µs ± 1%    -1.25%  (p=0.002 n=10+10)
Planning/Cockroach/SELECT_*_FROM_abc_WHERE_b_=_5-24                                   411µs ± 7%    436µs ± 2%      ~     (p=0.105 n=10+10)
Planning/Cockroach/SELECT_*_FROM_abc_WHERE_b_=_5_ORDER_BY_a-24                        449µs ± 1%    440µs ± 1%    -2.01%  (p=0.000 n=10+8)
Planning/Cockroach/SELECT_*_FROM_abc_WHERE_c_=_5-24                                   435µs ± 1%    433µs ± 2%      ~     (p=0.356 n=9+10)
Planning/Cockroach/SELECT_*_FROM_abc_JOIN_abc_AS_abc2_ON_abc.a_=_abc2.a-24            518µs ± 1%    514µs ± 1%    -0.71%  (p=0.035 n=10+9)
Planning/MultinodeCockroach/SELECT_*_FROM_abc-24                                      378µs ±11%    834µs ±10%  +120.52%  (p=0.000 n=9+10)
Planning/MultinodeCockroach/SELECT_*_FROM_abc_WHERE_a_>_5_ORDER_BY_a-24               371µs ± 1%    649µs ± 4%   +74.91%  (p=0.000 n=10+8)
Planning/MultinodeCockroach/SELECT_*_FROM_abc_WHERE_b_=_5-24                          409µs ±10%    925µs ±27%  +125.90%  (p=0.000 n=10+10)
Planning/MultinodeCockroach/SELECT_*_FROM_abc_WHERE_b_=_5_ORDER_BY_a-24               458µs ± 1%   1116µs ± 2%  +143.94%  (p=0.000 n=10+8)
Planning/MultinodeCockroach/SELECT_*_FROM_abc_WHERE_c_=_5-24                          447µs ± 2%   1112µs ± 1%  +148.95%  (p=0.000 n=10+9)
Planning/MultinodeCockroach/SELECT_*_FROM_abc_JOIN_abc_AS_abc2_ON_abc.a_=_abc2.a-24   544µs ± 5%   1062µs ± 2%   +95.10%  (p=0.000 n=9+10)
IndexJoin/Cockroach-24                                                               1.89ms ± 1%   1.87ms ± 1%    -1.09%  (p=0.001 n=8+9)
IndexJoin/MultinodeCockroach-24                                                      1.90ms ± 1%   3.13ms ± 2%   +64.62%  (p=0.000 n=10+9)
SortJoinAggregation/Cockroach-24                                                     3.35ms ± 1%   3.41ms ± 2%    +1.60%  (p=0.003 n=10+10)
SortJoinAggregation/MultinodeCockroach-24                                            3.39ms ± 1%   4.53ms ± 5%   +33.73%  (p=0.000 n=10+10)
PgbenchQuery/Cockroach-24                                                            8.70ms ± 1%   8.91ms ± 2%    +2.48%  (p=0.000 n=9+10)
PgbenchQuery/MultinodeCockroach-24                                                   9.61ms ± 1%  12.58ms ± 2%   +30.87%  (p=0.000 n=10+10)
```

Release note: None