### PR TITLE
roachtest: update hibernate blacklist after recursive CTE support

### DIFF
--- a/pkg/cmd/roachtest/hibernate_blacklist.go
+++ b/pkg/cmd/roachtest/hibernate_blacklist.go
@@ -44,7 +44,6 @@ var hibernateBlackList19_2 = blacklist{
 	"org.hibernate.jpa.test.lock.QueryLockingTest.testPessimisticForcedIncrementOverall":                                                                                             "40474",
 	"org.hibernate.jpa.test.lock.QueryLockingTest.testPessimisticForcedIncrementSpecific":                                                                                            "40474",
 	"org.hibernate.jpa.test.lock.StatementIsClosedAfterALockExceptionTest.testStatementIsClosed":                                                                                     "40476",
-	"org.hibernate.jpa.test.query.NativeQueryOrdinalParametersTest.testCteNativeQueryOrdinalParameter":                                                                               "21085",
 	"org.hibernate.test.annotations.entity.BasicHibernateAnnotationsTest.testSerialized":                                                                                             "26725",
 	"org.hibernate.test.annotations.filter.subclass.joined.JoinedSubClassTest.testClub":                                                                                              "5807",
 	"org.hibernate.test.annotations.filter.subclass.joined.JoinedSubClassTest.testIqFilter":                                                                                          "5807",


### PR DESCRIPTION
Now that #21085 is fixed, a test in hibernate started passing.

Release note: None