### PR TITLE
Expose session ID to clients

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -835,6 +835,7 @@ const queriesSchemaPattern = `
 CREATE TABLE crdb_internal.%s (
   query_id         STRING,         -- the cluster-unique ID of the query
   node_id          INT NOT NULL,   -- the node on which the query is running
+  session_id       STRING,         -- the ID of the session
   user_name        STRING,         -- the user running the query
   start            TIMESTAMP,      -- the start time of the query
   query            STRING,         -- the SQL code of the query
@@ -851,6 +852,31 @@ func (p *planner) makeSessionsRequest(ctx context.Context) serverpb.ListSessions
 		req.Username = ""
 	}
 	return req
+}
+
+func getSessionID(session serverpb.Session) tree.Datum {
+	// TODO(knz): serverpb.Session is always constructed with an ID
+	// set from a 16-byte session ID. Yet we get crash reports
+	// that fail in BytesToClusterWideID() with a byte slice that's
+	// too short. See #32517.
+	var sessionID tree.Datum
+	if session.ID == nil {
+		// TODO(knz): NewInternalTrackingError is misdesigned. Change to
+		// not use this. See the other facilities in
+		// pgerror/internal_errors.go.
+		telemetry.RecordError(
+			pgerror.NewInternalTrackingError(32517 /* issue */, "null"))
+		sessionID = tree.DNull
+	} else if len(session.ID) != 16 {
+		// TODO(knz): ditto above.
+		telemetry.RecordError(
+			pgerror.NewInternalTrackingError(32517 /* issue */, fmt.Sprintf("len=%d", len(session.ID))))
+		sessionID = tree.NewDString("<invalid>")
+	} else {
+		clusterSessionID := BytesToClusterWideID(session.ID)
+		sessionID = tree.NewDString(clusterSessionID.String())
+	}
+	return sessionID
 }
 
 // crdbInternalLocalQueriesTable exposes the list of running queries
@@ -887,6 +913,7 @@ func populateQueriesTable(
 	ctx context.Context, addRow func(...tree.Datum) error, response *serverpb.ListSessionsResponse,
 ) error {
 	for _, session := range response.Sessions {
+		sessionID := getSessionID(session)
 		for _, query := range session.ActiveQueries {
 			isDistributedDatum := tree.DNull
 			phase := strings.ToLower(query.Phase.String())
@@ -899,6 +926,7 @@ func populateQueriesTable(
 			if err := addRow(
 				tree.NewDString(query.ID),
 				tree.NewDInt(tree.DInt(session.NodeID)),
+				sessionID,
 				tree.NewDString(session.Username),
 				tree.MakeDTimestamp(query.Start, time.Microsecond),
 				tree.NewDString(query.Sql),
@@ -920,6 +948,7 @@ func populateQueriesTable(
 			if err := addRow(
 				tree.DNull,                             // query ID
 				tree.NewDInt(tree.DInt(rpcErr.NodeID)), // node ID
+				tree.DNull,                             // session ID
 				tree.DNull,                             // username
 				tree.DNull,                             // start
 				tree.NewDString("-- "+rpcErr.Message),  // query
@@ -1013,27 +1042,7 @@ func populateSessionsTable(
 			kvTxnIDDatum = tree.NewDString(session.KvTxnID.String())
 		}
 
-		// TODO(knz): serverpb.Session is always constructed with an ID
-		// set from a 16-byte session ID. Yet we get crash reports
-		// that fail in BytesToClusterWideID() with a byte slice that's
-		// too short. See #32517.
-		var sessionID tree.Datum
-		if session.ID == nil {
-			// TODO(knz): NewInternalTrackingError is misdesigned. Change to
-			// not use this. See the other facilities in
-			// pgerror/internal_errors.go.
-			telemetry.RecordError(
-				pgerror.NewInternalTrackingError(32517 /* issue */, "null"))
-			sessionID = tree.DNull
-		} else if len(session.ID) != 16 {
-			// TODO(knz): ditto above.
-			telemetry.RecordError(
-				pgerror.NewInternalTrackingError(32517 /* issue */, fmt.Sprintf("len=%d", len(session.ID))))
-			sessionID = tree.NewDString("<invalid>")
-		} else {
-			clusterSessionID := BytesToClusterWideID(session.ID)
-			sessionID = tree.NewDString(clusterSessionID.String())
-		}
+		sessionID := getSessionID(session)
 
 		if err := addRow(
 			tree.NewDInt(tree.DInt(session.NodeID)),
@@ -1924,7 +1933,7 @@ CREATE TABLE crdb_internal.ranges_no_leases (
   database_name        STRING NOT NULL,
   table_name           STRING NOT NULL,
   index_name           STRING NOT NULL,
-  replicas             INT[] NOT NULL,	
+  replicas             INT[] NOT NULL,
   replica_localities   STRING[] NOT NULL,
 	learner_replicas     INT[] NOT NULL,
 	split_enforced_until TIMESTAMP

--- a/pkg/sql/delegate/show_queries.go
+++ b/pkg/sql/delegate/show_queries.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (d *delegator) delegateShowQueries(n *tree.ShowQueries) (tree.Statement, error) {
-	const query = `SELECT query_id, node_id, user_name, start, query, client_address, application_name, distributed, phase FROM crdb_internal.`
+	const query = `SELECT query_id, node_id, session_id, user_name, start, query, client_address, application_name, distributed, phase FROM crdb_internal.`
 	table := `node_queries`
 	if n.Cluster {
 		table = `cluster_queries`

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -154,15 +154,15 @@ SELECT * FROM crdb_internal.session_variables WHERE variable = ''
 ----
 variable  value  hidden
 
-query TITTTTTBT colnames
+query TITTTTTTBT colnames
 SELECT * FROM crdb_internal.node_queries WHERE node_id < 0
 ----
-query_id  node_id  user_name  start  query  client_address  application_name  distributed  phase
+query_id  node_id  session_id user_name  start  query  client_address  application_name  distributed  phase
 
-query TITTTTTBT colnames
+query TITTTTTTBT colnames
 SELECT * FROM crdb_internal.cluster_queries WHERE node_id < 0
 ----
-query_id  node_id  user_name  start  query  client_address  application_name  distributed  phase
+query_id  node_id  session_id user_name  start  query  client_address  application_name  distributed  phase
 
 query ITTTTTTTTTTT colnames
 SELECT * FROM crdb_internal.node_sessions WHERE node_id < 0

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1523,14 +1523,14 @@ statement ok
 SET DATABASE = test
 
 # We filter here because 'optimizer' will be different depending on which
-# configuration this logic test is running in.
+# configuration this logic test is running in, and session ID will vary.
 query TTTTTT colnames
 SELECT
   name, setting, category, short_desc, extra_desc, vartype
 FROM
   pg_catalog.pg_settings
 WHERE
-  name != 'optimizer' AND name != 'crdb_version'
+  name != 'optimizer' AND name != 'crdb_version' AND name != 'session_id'
 ----
 name                                 setting             category  short_desc  extra_desc  vartype
 application_name                     ·                   NULL      NULL        NULL        string
@@ -1586,7 +1586,7 @@ SELECT
 FROM
   pg_catalog.pg_settings
 WHERE
-  name != 'optimizer' AND name != 'crdb_version'
+  name != 'optimizer' AND name != 'crdb_version' AND name != 'session_id'
 ----
 name                                 setting             unit  context  enumvals  boot_val            reset_val
 application_name                     ·                   NULL  user     NULL      ·                   ·
@@ -1675,6 +1675,7 @@ search_path                          NULL    NULL     NULL     NULL        NULL
 server_encoding                      NULL    NULL     NULL     NULL        NULL
 server_version                       NULL    NULL     NULL     NULL        NULL
 server_version_num                   NULL    NULL     NULL     NULL        NULL
+session_id                           NULL    NULL     NULL     NULL        NULL
 session_user                         NULL    NULL     NULL     NULL        NULL
 sql_safe_updates                     NULL    NULL     NULL     NULL        NULL
 standard_conforming_strings          NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -19,11 +19,11 @@ client_encoding     ordinality
 UTF8                1
 
 # We filter here because optimizer will be different depending on which
-# configuration this logic test is running in.
+# configuration this logic test is running in, and session ID will vary.
 query TT colnames
 SELECT *
 FROM [SHOW ALL]
-WHERE variable != 'optimizer' AND variable != 'crdb_version'
+WHERE variable != 'optimizer' AND variable != 'crdb_version' AND variable != 'session_id'
 ----
 variable                             value
 application_name                     ·

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -656,6 +656,11 @@ var varGen = map[string]sessionVar{
 	// CockroachDB extension.
 	`crdb_version`: makeReadOnlyVar(build.GetInfo().Short()),
 
+	// CockroachDB extension
+	`session_id`: {
+		Get: func(evalCtx *extendedEvalContext) string { return evalCtx.SessionID.String() },
+	},
+
 	// CockroachDB extension.
 	// In PG this is a pseudo-function used with SELECT, not SHOW.
 	// See https://www.postgresql.org/docs/10/static/functions-info.html


### PR DESCRIPTION
This change exposes the ID of a session to clients in two ways:
- as a session variable (session_id)
- as a column in SHOW QUERIES

e.g.

```
root@:26257/defaultdb> show session_id;
             session_id             
+----------------------------------+
  15cded2b6282789c0000000000000001  
(1 row)

Time: 3.6358ms

root@:26257/defaultdb> show queries;
              query_id             | node_id |            session_id            | user_name |              start               |        query         | client_address  | application_name | distributed |   phase    
+----------------------------------+---------+----------------------------------+-----------+----------------------------------+----------------------+-----------------+------------------+-------------+-----------+
  15cdefea7e589d3c0000000000000001 |       1 | 15cded2b6282789c0000000000000001 | root      | 2019-10-15 21:40:35.442981+00:00 | SHOW CLUSTER QUERIES | 127.0.0.1:39450 | $ cockroach sql  |    false    | executing  
(1 row)

Time: 25.2691ms
```


Fixes #32055

Release note: None