### PR TITLE
storage/engine: make DBFile implement io.Writer

### DIFF
--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -426,15 +426,7 @@ func (p *Pebble) CompactRange(start, end roachpb.Key, forceBottommost bool) erro
 
 // OpenFile implements the Engine interface.
 func (p *Pebble) OpenFile(filename string) (DBFile, error) {
-	file, err := p.fs.Open(p.fs.PathJoin(p.path, filename))
-	if err != nil {
-		return nil, err
-	}
-
-	pebbleFile := &pebbleFile{
-		file: file,
-	}
-	return pebbleFile, nil
+	return p.fs.Open(p.fs.PathJoin(p.path, filename))
 }
 
 // ReadFile implements the Engine interface.
@@ -510,29 +502,6 @@ func (p *Pebble) GetSSTables() (sstables SSTableInfos) {
 		}
 	}
 	return sstables
-}
-
-// pebbleFile wraps a pebble File and implements the DBFile interface.
-type pebbleFile struct {
-	file vfs.File
-}
-
-var _ DBFile = &pebbleFile{}
-
-// Append implements the DBFile interface.
-func (p *pebbleFile) Append(data []byte) error {
-	_, err := p.file.Write(data)
-	return err
-}
-
-// Close implements the DBFile interface.
-func (p *pebbleFile) Close() error {
-	return p.file.Close()
-}
-
-// Close implements the DBFile interface.
-func (p *pebbleFile) Sync() error {
-	return p.file.Sync()
 }
 
 // pebbleSnapshot represents a snapshot created using Pebble.NewSnapshot().

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -1359,7 +1359,7 @@ func TestRocksDBFileNotFoundError(t *testing.T) {
 		t.Fatalf("unable to open file with filename %s, got err %v", fname, err)
 	} else {
 		// Write data to file so we can read it later.
-		if err := f.Append([]byte(data)); err != nil {
+		if _, err := f.Write([]byte(data)); err != nil {
 			t.Fatalf("error writing data: '%s' to file %s, got err %v", data, fname, err)
 		}
 		if err := f.Sync(); err != nil {

--- a/pkg/storage/replica_sst_snapshot_storage.go
+++ b/pkg/storage/replica_sst_snapshot_storage.go
@@ -173,7 +173,7 @@ func (sssf *SSTSnapshotStorageFile) Write(ctx context.Context, contents []byte) 
 		return err
 	}
 	limitBulkIOWrite(ctx, sssf.ssss.sss.limiter, len(contents))
-	if err := sssf.file.Append(contents); err != nil {
+	if _, err := sssf.file.Write(contents); err != nil {
 		return err
 	}
 	return sssf.file.Sync()

--- a/pkg/storage/syncing_write.go
+++ b/pkg/storage/syncing_write.go
@@ -101,7 +101,7 @@ func writeFileSyncing(
 
 		// rate limit
 		limitBulkIOWrite(ctx, limiter, len(chunk))
-		err = f.Append(chunk)
+		_, err = f.Write(chunk)
 		if err == nil && sync {
 			err = f.Sync()
 		}


### PR DESCRIPTION
Change the `DBFile` interface to implment `io.Writer` rather than a
custom `Append` interface. This is general goodness as it allows
using alternate `io.Writer` implementations without having to write a
shim struct to adapt to the `DBFile` interface.

Fixes #41601

Release note: None