### PR TITLE
builtins: allow full consistency check w/o nuking cluster

### DIFF
--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -225,6 +225,16 @@ func (ba *BatchRequest) IsSingleComputeChecksumRequest() bool {
 	return false
 }
 
+// IsSingleCheckConsistencyRequest returns true iff the batch contains a single
+// request, and that request is a CheckConsistencyRequest.
+func (ba *BatchRequest) IsSingleCheckConsistencyRequest() bool {
+	if ba.IsSingleRequest() {
+		_, ok := ba.Requests[0].GetInner().(*CheckConsistencyRequest)
+		return ok
+	}
+	return false
+}
+
 // IsSingleAddSSTableRequest returns true iff the batch contains a single
 // request, and that request is an AddSSTableRequest.
 func (ba *BatchRequest) IsSingleAddSSTableRequest() bool {

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -1015,6 +1015,8 @@ func (c *checkConsistencyGenerator) Start(_ context.Context, _ *client.Txn) erro
 		// so request one only if a full check is run.
 		WithDiff: c.mode == roachpb.ChecksumMode_CHECK_FULL,
 	})
+	// NB: DistSender has special code to avoid parallelizing the request if
+	// we're requesting CHECK_FULL.
 	if err := c.db.Run(c.ctx, &b); err != nil {
 		return err
 	}


### PR DESCRIPTION
Previously, triggering a full consistency check would have potential to
harm the cluster due to triggering checks with full DistSender
parallelism. Limit to one check at a time for a (much slower, but) less
harmful check (that we can potentially emit in roachtests).

Release note: None