### PR TITLE
Revert "roachprod: fatal nodes on stats mismatch"

### DIFF
--- a/pkg/cmd/roachprod/install/cockroach.go
+++ b/pkg/cmd/roachprod/install/cockroach.go
@@ -249,9 +249,6 @@ func (r Cockroach) Start(c *SyncedCluster, extraArgs []string) {
 			fmt.Sprintf(" export ROACHPROD=%d%s && ", nodes[i], c.Tag) +
 			"GOTRACEBACK=crash " +
 			"COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING=1 " +
-			// Turn stats mismatch into panic, see:
-			// https://github.com/cockroachdb/cockroach/issues/38720#issuecomment-539136246
-			"COCKROACH_FATAL_ON_STATS_MISMATCH=true " +
 			c.Env + " " + binary + " start " + strings.Join(args, " ") +
 			" >> " + logDir + "/cockroach.stdout.log 2>> " + logDir + "/cockroach.stderr.log" +
 			" || (x=$?; cat " + logDir + "/cockroach.stderr.log; exit $x)"


### PR DESCRIPTION
This commit failed acceptance/version-upgrade (most of the time) since
older versions of CRDB would introduce incorrect stats. Since there's
no good way to selectively toggle the checks off for that test,
revert the commit for now.

This reverts commit 3261b01751937af52ba6086944c55303d03a819b.

Release note: None