### PR TITLE
storage: change fatalOnStatsMismatch semantics

### DIFF
--- a/pkg/cmd/roachprod/install/cockroach.go
+++ b/pkg/cmd/roachprod/install/cockroach.go
@@ -249,6 +249,9 @@ func (r Cockroach) Start(c *SyncedCluster, extraArgs []string) {
 			fmt.Sprintf(" export ROACHPROD=%d%s && ", nodes[i], c.Tag) +
 			"GOTRACEBACK=crash " +
 			"COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING=1 " +
+			// Turn stats mismatch into panic, see:
+			// https://github.com/cockroachdb/cockroach/issues/38720#issuecomment-539136246
+			"COCKROACH_ENFORCE_CONSISTENT_STATS=true " +
 			c.Env + " " + binary + " start " + strings.Join(args, " ") +
 			" >> " + logDir + "/cockroach.stdout.log 2>> " + logDir + "/cockroach.stderr.log" +
 			" || (x=$?; cat " + logDir + "/cockroach.stderr.log; exit $x)"

--- a/pkg/cmd/roachtest/clearrange.go
+++ b/pkg/cmd/roachtest/clearrange.go
@@ -55,7 +55,7 @@ func runClearRange(ctx context.Context, t *test, c *cluster, aggressiveChecks bo
 		//
 		// NB: the below invocation was found to actually make it to the server at the time of writing.
 		c.Start(ctx, t, startArgs(
-			"--env", "COCKROACH_CONSISTENCY_AGGRESSIVE=true COCKROACH_FATAL_ON_STATS_MISMATCH=true",
+			"--env", "COCKROACH_CONSISTENCY_AGGRESSIVE=true COCKROACH_ENFORCE_CONSISTENT_STATS=true",
 		))
 	} else {
 		c.Start(ctx, t)


### PR DESCRIPTION
Older versions of CRDB do not necessarily maintain consistent stats.
We are more interested in violations that occur on current versions
of CRDB (19.1+) in our nightly testing, where we wish to use this
env var more pervasively.
It was difficult to do this prior to this commit since the various
upgrade tests could pick up inconsistencies and this mechanism
would have to selectively be disabled for those; doable, but not
worth it.

Instead, rename the env var (so that already-baked releases that
know about it ignore it) and change the behavior to include an
additional bootstrap version check: only clusters that came to
life on 19.1+ will fatal when the env var is set. This makes sure
that tests upgrading from old releases, even if the env var is
set, don't trip over these inconsistencies we don't care about.

I manually tested this via TestConsistencyQueueRecomputeStats by
setting the default to `true` (causing a panic) and then editing
the "cutoff version" to be 19.2 (which does not exist yet) which
removed the panic again.

Release note: None