### PR TITLE
release-19.2: importccl: Disallow IMPORT INTO interleaved tables.

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -409,6 +409,12 @@ func importPlanHook(
 				return err
 			}
 
+			// IMPORT INTO does not currently support interleaved tables.
+			if found.IsInterleaved() {
+				// TODO(miretskiy): Handle import into when tables are interleaved.
+				return pgerror.New(pgcode.FeatureNotSupported, "Cannot use IMPORT INTO with interleaved tables")
+			}
+
 			// Validate target columns.
 			var intoCols []string
 			var isTargetCol = make(map[string]bool)

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1866,6 +1866,28 @@ func TestImportIntoCSV(t *testing.T) {
 		)
 	})
 
+	// IMPORT INTO does not currently support import into interleaved tables.
+	t.Run("import-into-rejects-interleaved-tables", func(t *testing.T) {
+		sqlDB.Exec(t, `CREATE TABLE parent (parent_id INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `CREATE TABLE child (
+				parent_id INT, 
+				child_id INT,
+				PRIMARY KEY(parent_id, child_id))
+				INTERLEAVE IN PARENT parent(parent_id)`)
+		defer sqlDB.Exec(t, `DROP TABLE parent`)
+		defer sqlDB.Exec(t, `DROP TABLE child`)
+
+		// Cannot IMPORT INTO interleaved parent
+		sqlDB.ExpectErr(
+			t, "Cannot use IMPORT INTO with interleaved tables",
+			fmt.Sprintf(`IMPORT INTO parent (parent_id) CSV DATA (%s)`, testFiles.files[0]))
+
+		// Cannot IMPORT INTO interleaved child either.
+		sqlDB.ExpectErr(
+			t, "Cannot use IMPORT INTO with interleaved tables",
+			fmt.Sprintf(`IMPORT INTO child (parent_id, child_id) CSV DATA (%s)`, testFiles.files[0]))
+	})
+
 	// This tests that consecutive imports from unique data sources into an
 	// existing table without an explicit PK, do not overwrite each other. It
 	// exercises the row_id generation in IMPORT.


### PR DESCRIPTION
Backport 1/1 commits from #41326.

/cc @cockroachdb/release

---

The 'IMPORT INTO' statement requires that the target table
be offline.  However, the current implementation does not have
functionality to ensure that if the target table has interleaved
children (or itself is interleaved in some other table), then those
tables are offline as well.

This change adds a check to ensure that an error is returned if
we attempt to IMPORT INTO interleaved table.

The future versions will support proper functionality to enable
IMPORT INTO interleaved tables.

Release justification: Prevent unsafe operation

Release note (cli): prevent INSERT INTO interleaved table.
