### PR TITLE
storage/engine: pebble timeseries merge operator

### DIFF
--- a/pkg/storage/engine/engine_test.go
+++ b/pkg/storage/engine/engine_test.go
@@ -416,13 +416,6 @@ func TestEnginePutGetDelete(t *testing.T) {
 func TestEngineMerge(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	runWithAllEngines(func(engine Engine, t *testing.T) {
-		// TODO(itsbilal): Stop skipping this test for pebble when the timeseries
-		// merge operator has been ported to Go and/or the current merger passes.
-		switch engine.(type) {
-		case *Pebble:
-			return
-		default:
-		}
 		testcases := []struct {
 			testKey  MVCCKey
 			merges   [][]byte

--- a/pkg/storage/engine/merge.go
+++ b/pkg/storage/engine/merge.go
@@ -16,6 +16,39 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 )
 
+func serializeMergeInputs(sources ...roachpb.InternalTimeSeriesData) ([][]byte, error) {
+	// Wrap each proto in an inlined MVCC value, and marshal each wrapped value
+	// to bytes. This is the format required by the engine.
+	srcBytes := make([][]byte, 0, len(sources))
+	var val roachpb.Value
+	for _, src := range sources {
+		if err := val.SetProto(&src); err != nil {
+			return nil, err
+		}
+		bytes, err := protoutil.Marshal(&enginepb.MVCCMetadata{
+			RawBytes: val.RawBytes,
+		})
+		if err != nil {
+			return nil, err
+		}
+		srcBytes = append(srcBytes, bytes)
+	}
+	return srcBytes, nil
+}
+
+func deserializeMergeOutput(mergedBytes []byte) (roachpb.InternalTimeSeriesData, error) {
+	// Unmarshal merged bytes and extract the time series value within.
+	var meta enginepb.MVCCMetadata
+	if err := protoutil.Unmarshal(mergedBytes, &meta); err != nil {
+		return roachpb.InternalTimeSeriesData{}, err
+	}
+	mergedTS, err := MakeValue(meta).GetTimeseries()
+	if err != nil {
+		return roachpb.InternalTimeSeriesData{}, err
+	}
+	return mergedTS, nil
+}
+
 // MergeInternalTimeSeriesData exports the engine's C++ merge logic for
 // InternalTimeSeriesData to higher level packages. This is intended primarily
 // for consumption by high level testing of time series functionality.
@@ -29,28 +62,12 @@ import (
 func MergeInternalTimeSeriesData(
 	mergeIntoNil, usePartialMerge bool, sources ...roachpb.InternalTimeSeriesData,
 ) (roachpb.InternalTimeSeriesData, error) {
-	// Wrap each proto in an inlined MVCC value, and marshal each wrapped value
-	// to bytes. This is the format required by the engine.
-	srcBytes := make([][]byte, 0, len(sources))
-	var val roachpb.Value
-	for _, src := range sources {
-		if err := val.SetProto(&src); err != nil {
-			return roachpb.InternalTimeSeriesData{}, err
-		}
-		bytes, err := protoutil.Marshal(&enginepb.MVCCMetadata{
-			RawBytes: val.RawBytes,
-		})
-		if err != nil {
-			return roachpb.InternalTimeSeriesData{}, err
-		}
-		srcBytes = append(srcBytes, bytes)
-	}
-
 	// Merge every element into a nil byte slice, one at a time.
-	var (
-		mergedBytes []byte
-		err         error
-	)
+	var mergedBytes []byte
+	srcBytes, err := serializeMergeInputs(sources...)
+	if err != nil {
+		return roachpb.InternalTimeSeriesData{}, nil
+	}
 	if !mergeIntoNil {
 		mergedBytes = srcBytes[0]
 		srcBytes = srcBytes[1:]
@@ -72,15 +89,5 @@ func MergeInternalTimeSeriesData(
 			return roachpb.InternalTimeSeriesData{}, err
 		}
 	}
-
-	// Unmarshal merged bytes and extract the time series value within.
-	var meta enginepb.MVCCMetadata
-	if err := protoutil.Unmarshal(mergedBytes, &meta); err != nil {
-		return roachpb.InternalTimeSeriesData{}, err
-	}
-	mergedTS, err := MakeValue(meta).GetTimeseries()
-	if err != nil {
-		return roachpb.InternalTimeSeriesData{}, err
-	}
-	return mergedTS, nil
+	return deserializeMergeOutput(mergedBytes)
 }

--- a/pkg/storage/engine/merge_test.go
+++ b/pkg/storage/engine/merge_test.go
@@ -130,11 +130,10 @@ func timeSeriesColumnAsValue(
 	return v
 }
 
-// TestGoMerge tests the function goMerge but not the integration with
-// the storage engines. For that, see the engine tests.
-func TestGoMerge(t *testing.T) {
+// TestGoMergeCorruption tests the function goMerge with error inputs but does not test the
+// integration with the storage engines. For that, see the engine tests.
+func TestGoMergeCorruption(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	// Let's start with stuff that should go wrong.
 	badCombinations := []struct {
 		existing, update []byte
 	}{
@@ -179,8 +178,18 @@ func TestGoMerge(t *testing.T) {
 		if err == nil {
 			t.Errorf("goMerge: %d: expected error", i)
 		}
+		_, err = merge(nil /* key */, c.existing, c.update, nil /* buf */)
+		if err == nil {
+			t.Fatalf("pebble merge: %d: expected error", i)
+		}
 	}
+}
 
+// TestGoMergeAppend tests the function goMerge with the default append operator
+// but does not test the integration with the storage engines. For that, see the
+// engine tests.
+func TestGoMergeAppend(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	gibber1, gibber2 := gibberishString(100), gibberishString(200)
 
 	testCasesAppender := []struct {
@@ -211,7 +220,28 @@ func TestGoMerge(t *testing.T) {
 			t.Errorf("goMerge error: %d: want %+v, got %+v", i, expectedV, resultV)
 		}
 	}
+}
 
+func MergeInternalTimeSeriesDataPebble(
+	sources ...roachpb.InternalTimeSeriesData,
+) (roachpb.InternalTimeSeriesData, error) {
+	srcBytes, err := serializeMergeInputs(sources...)
+	if err != nil {
+		return roachpb.InternalTimeSeriesData{}, nil
+	}
+	merger := MVCCMerger
+	var mergedBytes = srcBytes[0]
+	for _, bytes := range srcBytes[1:] {
+		mergedBytes = merger.Merge(nil /* key */, mergedBytes, bytes, nil /* buf */)
+	}
+	return deserializeMergeOutput(mergedBytes)
+}
+
+// TestGoMergeTimeSeries tests the function goMerge with the timeseries operator
+// but does not test the integration with the storage engines. For that, see
+// the engine tests.
+func TestGoMergeTimeSeries(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	// Each time series test case is a list of byte slice. The last byte slice
 	// is the expected result; all preceding slices will be merged together
 	// to generate the actual result.
@@ -508,6 +538,18 @@ func TestGoMerge(t *testing.T) {
 						)
 					}
 				}
+			}
+			if len(operands) < 2 {
+				// TODO(ajkr): Pebble merge operator isn't currently called with one operand,
+				// though maybe it should be to match RocksDB behavior.
+				return
+			}
+			resultTS, err := MergeInternalTimeSeriesDataPebble(operands...)
+			if err != nil {
+				t.Errorf("MergeInternalTimeSeriesDataPebble error: %s", err.Error())
+			}
+			if a, e := resultTS, expectedTS; !reflect.DeepEqual(a, e) {
+				t.Errorf("MergeInternalTimeSeriesDataPebble returned wrong result got %v, wanted %v", a, e)
 			}
 		})
 	}

--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/vfs"
@@ -75,15 +76,12 @@ var MVCCComparer = &pebble.Comparer{
 // by Cockroach.
 var MVCCMerger = &pebble.Merger{
 	Name: "cockroach_merge_operator",
-
 	Merge: func(key, oldValue, newValue, buf []byte) []byte {
-		// TODO(itsbilal): Port the merge operator from C++ to Go.
-		// Until then, call the C++ merge operator directly.
-		ret, err := goMerge(oldValue, newValue)
+		res, err := merge(key, oldValue, newValue, buf)
 		if err != nil {
-			return nil
+			log.Fatalf(context.Background(), "merge: %v", err)
 		}
-		return ret
+		return res
 	},
 }
 

--- a/pkg/storage/engine/pebble_merge.go
+++ b/pkg/storage/engine/pebble_merge.go
@@ -1,0 +1,265 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package engine
+
+import (
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
+	"github.com/gogo/protobuf/proto"
+)
+
+// sortAndDeduplicateRows sorts all the samples field of the time series data
+// structure according to the samples' `Offset`s. At the same time, samples with
+// duplicate offset values are removed - only the last sample with a given offset
+// in the collection is retained.
+func sortAndDeduplicateRows(ts *roachpb.InternalTimeSeriesData) {
+	// In the common case, appending the newer entries to the older entries
+	// will result in an already ordered result, and there will be one sample
+	// per offset. Optimize for that case.
+	isSortedUniq := true
+	for i := 1; i < len(ts.Samples); i++ {
+		if ts.Samples[i-1].Offset >= ts.Samples[i].Offset {
+			isSortedUniq = false
+			break
+		}
+	}
+	if isSortedUniq {
+		return
+	}
+
+	// Create an auxiliary array of array indexes, and sort that array according
+	// to the corresponding offset value in the ts.Samples collection. This
+	// yields the permutation of the current array indexes that will place the
+	// samples into sorted order. In order to guarantee only the last sample with
+	// a duplicated offset is retained, we must do a stable sort.
+	sortedSrcIdxs := make([]int, len(ts.Samples))
+	for i := range sortedSrcIdxs {
+		sortedSrcIdxs[i] = i
+	}
+	sort.SliceStable(sortedSrcIdxs, func(i, j int) bool {
+		return ts.Samples[sortedSrcIdxs[i]].Offset < ts.Samples[sortedSrcIdxs[j]].Offset
+	})
+
+	// Remove any duplicates from the permutation, keeping the *last* element
+	// merged for any given offset.
+	uniqSortedSrcIdxs := make([]int, 0, len(ts.Samples))
+	for destIdx := range sortedSrcIdxs {
+		if destIdx == len(sortedSrcIdxs)-1 || ts.Samples[sortedSrcIdxs[destIdx]].Offset != ts.Samples[sortedSrcIdxs[destIdx+1]].Offset {
+			uniqSortedSrcIdxs = append(uniqSortedSrcIdxs, sortedSrcIdxs[destIdx])
+		}
+	}
+
+	origSamples := ts.Samples
+	ts.Samples = make([]roachpb.InternalTimeSeriesSample, len(uniqSortedSrcIdxs))
+
+	// Apply the permutation in the auxiliary array to all of the relevant column
+	// arrays in the data set.
+	for destIdx, srcIdx := range uniqSortedSrcIdxs {
+		ts.Samples[destIdx] = origSamples[srcIdx]
+	}
+}
+
+// sortAndDeduplicateColumns sorts all column fields of the time series data
+// structure according to the timeseries's `Offset` column. At the same time,
+// duplicate offset values are removed - only the last instance of an offset in
+// the collection is retained.
+func sortAndDeduplicateColumns(ts *roachpb.InternalTimeSeriesData) {
+	// In the common case, appending the newer entries to the older entries
+	// will result in an already ordered result with no duplicated offsets.
+	// Optimize for that case.
+	isSortedUniq := true
+	for i := 1; i < len(ts.Offset); i++ {
+		if ts.Offset[i-1] >= ts.Offset[i] {
+			isSortedUniq = false
+			break
+		}
+	}
+	if isSortedUniq {
+		return
+	}
+
+	// Create an auxiliary array of array indexes, and sort that array according
+	// to the corresponding offset value in the `ts.Offset` collection. This yields
+	// the permutation of the current array indexes that will place the offsets into
+	// sorted order. In order to guarantee only the last column values corresponding
+	// to a duplicated offset are retained, we must do a stable sort.
+	sortedSrcIdxs := make([]int, len(ts.Offset))
+	for i := range sortedSrcIdxs {
+		sortedSrcIdxs[i] = i
+	}
+	sort.SliceStable(sortedSrcIdxs, func(i, j int) bool {
+		return ts.Offset[sortedSrcIdxs[i]] < ts.Offset[sortedSrcIdxs[j]]
+	})
+
+	// Remove any duplicates from the permutation, keeping the *last* element
+	// merged for any given offset.
+	uniqSortedSrcIdxs := make([]int, 0, len(ts.Offset))
+	for destIdx := range sortedSrcIdxs {
+		if destIdx == len(sortedSrcIdxs)-1 || ts.Offset[sortedSrcIdxs[destIdx]] != ts.Offset[sortedSrcIdxs[destIdx+1]] {
+			uniqSortedSrcIdxs = append(uniqSortedSrcIdxs, sortedSrcIdxs[destIdx])
+		}
+	}
+
+	origOffset, origLast, origCount, origSum, origMin, origMax, origFirst, origVariance :=
+		ts.Offset, ts.Last, ts.Count, ts.Sum, ts.Min, ts.Max, ts.First, ts.Variance
+	ts.Offset = make([]int32, len(uniqSortedSrcIdxs))
+	ts.Last = make([]float64, len(uniqSortedSrcIdxs))
+	// These columns are only present at resolutions generated as rollups. We
+	// detect this by checking if there are any count columns present (the
+	// choice of "count" is arbitrary, all of these columns will be present or
+	// not).
+	if len(origCount) > 0 {
+		ts.Count = make([]uint32, len(uniqSortedSrcIdxs))
+		ts.Sum = make([]float64, len(uniqSortedSrcIdxs))
+		ts.Min = make([]float64, len(uniqSortedSrcIdxs))
+		ts.Max = make([]float64, len(uniqSortedSrcIdxs))
+		ts.First = make([]float64, len(uniqSortedSrcIdxs))
+		ts.Variance = make([]float64, len(uniqSortedSrcIdxs))
+	}
+
+	// Apply the permutation in the auxiliary array to all of the relevant column
+	// arrays in the data set.
+	for destIdx, srcIdx := range uniqSortedSrcIdxs {
+		ts.Offset[destIdx] = origOffset[srcIdx]
+		ts.Last[destIdx] = origLast[srcIdx]
+
+		if len(origCount) > 0 {
+			ts.Count[destIdx] = origCount[srcIdx]
+			ts.Sum[destIdx] = origSum[srcIdx]
+			ts.Min[destIdx] = origMin[srcIdx]
+			ts.Max[destIdx] = origMax[srcIdx]
+			ts.First[destIdx] = origFirst[srcIdx]
+			ts.Variance[destIdx] = origVariance[srcIdx]
+		}
+	}
+}
+
+// ensureColumnar detects time series data which is in the old row format,
+// converting the row data into the new columnar format.
+func ensureColumnar(ts *roachpb.InternalTimeSeriesData) {
+	for _, sample := range ts.Samples {
+		ts.Offset = append(ts.Offset, sample.Offset)
+		ts.Last = append(ts.Last, sample.Sum)
+	}
+	ts.Samples = ts.Samples[:0]
+}
+
+// mergeTimeSeries combines two `InternalTimeSeriesData`s and returns the result as an
+// `InternalTimeSeriesData`.  The inputs cannot be merged if they have different start
+// timestamps or sample durations.
+func mergeTimeSeries(
+	oldTs, newTs roachpb.InternalTimeSeriesData,
+) (roachpb.InternalTimeSeriesData, error) {
+	if oldTs.StartTimestampNanos != newTs.StartTimestampNanos {
+		return roachpb.InternalTimeSeriesData{}, errors.Errorf("start timestamp mismatch")
+	}
+	if oldTs.SampleDurationNanos != newTs.SampleDurationNanos {
+		return roachpb.InternalTimeSeriesData{}, errors.Errorf("sample duration mismatch")
+	}
+
+	// TODO(ajkr): confirm it is the case that (1) today's CRDB always merges timeseries
+	// values in columnar format, and (2) today's CRDB does not need to be downgrade-
+	// compatible with any version that supports row format only. Then we can drop support
+	// for row format entirely. It requires significant cleanup effort as many tests target
+	// the row format.
+	if len(oldTs.Offset) > 0 || len(newTs.Offset) > 0 {
+		ensureColumnar(&oldTs)
+		ensureColumnar(&newTs)
+		proto.Merge(&oldTs, &newTs)
+		sortAndDeduplicateColumns(&oldTs)
+	} else {
+		proto.Merge(&oldTs, &newTs)
+		sortAndDeduplicateRows(&oldTs)
+	}
+	return oldTs, nil
+}
+
+// mergeTimeSeriesValues attempts to merge two values which contain
+// InternalTimeSeriesData messages.
+func mergeTimeSeriesValues(oldTsBytes, newTsBytes []byte) ([]byte, error) {
+	var oldTs, newTs, mergedTs roachpb.InternalTimeSeriesData
+	if err := protoutil.Unmarshal(oldTsBytes, &oldTs); err != nil {
+		return nil, errors.Errorf("corrupted old timeseries: %v", err)
+	}
+	if err := protoutil.Unmarshal(newTsBytes, &newTs); err != nil {
+		return nil, errors.Errorf("corrupted new timeseries: %v", err)
+	}
+
+	var err error
+	if mergedTs, err = mergeTimeSeries(oldTs, newTs); err != nil {
+		return nil, errors.Errorf("mergeTimeSeries: %v", err)
+	}
+
+	res, err := protoutil.Marshal(&mergedTs)
+	if err != nil {
+		return nil, errors.Errorf("corrupted merged timeseries: %v", err)
+	}
+	return res, nil
+}
+
+// merge combines two serialized `MVCCMetadata`s and returns the result as a serialized
+// `MVCCMetadata`.
+//
+// Replay Advisory: Because merge commands pass through raft, it is possible
+// for merging values to be "replayed". Currently, the only actual use of
+// the merge system is for time series data, which is safe against replay;
+// however, this property is not general for all potential mergeable types.
+// If a future need arises to merge another type of data, replay protection
+// will likely need to be a consideration.
+func merge(key, oldValue, newValue, buf []byte) ([]byte, error) {
+	const (
+		checksumSize = 4
+		tagPos       = checksumSize
+		headerSize   = checksumSize + 1
+	)
+
+	var oldMeta, newMeta, mergedMeta enginepb.MVCCMetadata
+	if err := protoutil.Unmarshal(oldValue, &oldMeta); err != nil {
+		return nil, errors.Errorf("corrupted old operand value: %v", err)
+	}
+	if len(oldMeta.RawBytes) < headerSize {
+		return nil, errors.Errorf("old operand value too short")
+	}
+	if err := protoutil.Unmarshal(newValue, &newMeta); err != nil {
+		return nil, errors.Errorf("corrupted new operand value: %v", err)
+	}
+	if len(newMeta.RawBytes) < headerSize {
+		return nil, errors.Errorf("new operand value too short")
+	}
+
+	tsTag := byte(roachpb.ValueType_TIMESERIES)
+	if oldMeta.RawBytes[tagPos] == tsTag || newMeta.RawBytes[tagPos] == tsTag {
+		if oldMeta.RawBytes[tagPos] != tsTag || newMeta.RawBytes[tagPos] != tsTag {
+			return nil, errors.Errorf("inconsistent value types for timeseries merge")
+		}
+		tsBytes, err := mergeTimeSeriesValues(
+			oldMeta.RawBytes[headerSize:], newMeta.RawBytes[headerSize:])
+		if err != nil {
+			return nil, errors.Errorf("mergeTimeSeriesValues: %v", err)
+		}
+		header := make([]byte, headerSize)
+		header[tagPos] = tsTag
+		mergedMeta.RawBytes = append(header, tsBytes...)
+	} else {
+		// For non-timeseries values, merge is a simple append.
+		mergedMeta.RawBytes = append(oldMeta.RawBytes, newMeta.RawBytes[headerSize:]...)
+	}
+
+	res, err := protoutil.Marshal(&mergedMeta)
+	if err != nil {
+		return nil, errors.Errorf("corrupted merged value: %v", err)
+	}
+	return res, nil
+}

--- a/pkg/storage/engine/sst_iterator.go
+++ b/pkg/storage/engine/sst_iterator.go
@@ -20,10 +20,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-var readerOpts = sstable.ReaderOptions{
-	Comparer: MVCCComparer,
-}
-
 type sstIterator struct {
 	sst  *sstable.Reader
 	iter sstable.Iterator
@@ -49,7 +45,9 @@ func NewSSTIterator(path string) (SimpleIterator, error) {
 	if err != nil {
 		return nil, err
 	}
-	sst, err := sstable.NewReader(file, readerOpts)
+	sst, err := sstable.NewReader(file, sstable.ReaderOptions{
+		Comparer: MVCCComparer,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +59,9 @@ func NewSSTIterator(path string) (SimpleIterator, error) {
 // Pebble's `sstable.Writer`, and assumes the keys use Cockroach's MVCC
 // format.
 func NewMemSSTIterator(data []byte, verify bool) (SimpleIterator, error) {
-	sst, err := sstable.NewReader(vfs.NewMemFile(data), readerOpts)
+	sst, err := sstable.NewReader(vfs.NewMemFile(data), sstable.ReaderOptions{
+		Comparer: MVCCComparer,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ts/timeseries_test.go
+++ b/pkg/ts/timeseries_test.go
@@ -181,6 +181,8 @@ func TestToInternal(t *testing.T) {
 // sample period; earlier samples are discarded.
 func TestDiscardEarlierSamples(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	// TODO(ajkr): this should also run on Pebble. Maybe combine it into the merge_test.go tests or prove
+	// it is redundant with the tests there.
 	ts := tsd("test.series", "",
 		tsdp(5*time.Hour+5*time.Minute, -1.0),
 		tsdp(5*time.Hour+5*time.Minute, -2.0),


### PR DESCRIPTION
Ported timeseries merge operator from C++ to Go for use in Pebble. List
of major changes/non-changes compared to the original C++ merge operator:

- Dropped the optimization to skip sort during partial merge as there's no need to defer background work to the foreground.
- Dropped the distinction between base value (sorted) and merge operand value (unsorted), and treat everything as if it might be unsorted, but with optimizations for the case where it's already sorted.
- Dropped the complicated vector in-place reordering optimization as it doesn't look necessary in the common case.
- Did not drop the row format support as it looks like too much effort for now to adapt all the test cases.

Includes Pebble version bump to 9d80716063bb38e2772ced37c428ccc47d384b23
in order to get the merge operand ordering fix. The upgrade requires
some minor adaptations for API changes.

Release note: None