### PR TITLE
colexec: add timestamp type

### DIFF
--- a/pkg/col/coldata/vec.go
+++ b/pkg/col/coldata/vec.go
@@ -12,6 +12,7 @@ package coldata
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
@@ -76,6 +77,8 @@ type Vec interface {
 	// TODO(jordan): should this be [][]byte?
 	// Decimal returns an apd.Decimal slice.
 	Decimal() []apd.Decimal
+	// Timestamp returns a time.Time slice.
+	Timestamp() []time.Time
 
 	// Col returns the raw, typeless backing storage for this Vec.
 	Col() interface{}
@@ -151,6 +154,8 @@ func NewMemColumn(t coltypes.T, n int) Vec {
 		return &memColumn{t: t, col: make([]float64, n), nulls: nulls}
 	case coltypes.Decimal:
 		return &memColumn{t: t, col: make([]apd.Decimal, n), nulls: nulls}
+	case coltypes.Timestamp:
+		return &memColumn{t: t, col: make([]time.Time, n), nulls: nulls}
 	default:
 		panic(fmt.Sprintf("unhandled type %s", t))
 	}
@@ -190,6 +195,10 @@ func (m *memColumn) Bytes() *Bytes {
 
 func (m *memColumn) Decimal() []apd.Decimal {
 	return m.col.([]apd.Decimal)
+}
+
+func (m *memColumn) Timestamp() []time.Time {
+	return m.col.([]time.Time)
 }
 
 func (m *memColumn) Col() interface{} {

--- a/pkg/col/coldata/vec_tmpl.go
+++ b/pkg/col/coldata/vec_tmpl.go
@@ -21,6 +21,7 @@ package coldata
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
@@ -44,6 +45,9 @@ type _GOTYPESLICE interface{}
 
 // Dummy import to pull in "apd" package.
 var _ apd.Decimal
+
+// Dummy import to pull in "time" package.
+var _ time.Time
 
 // */}}
 

--- a/pkg/col/colserde/arrowbatchconverter_test.go
+++ b/pkg/col/colserde/arrowbatchconverter_test.go
@@ -119,9 +119,11 @@ func assertEqualBatches(t *testing.T, expected, actual coldata.Batch) {
 func TestArrowBatchConverterRejectsUnsupportedTypes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	typs := []coltypes.T{coltypes.Decimal, coltypes.Timestamp}
-	_, err := NewArrowBatchConverter(typs)
-	require.Error(t, err)
+	unsupportedTypes := []coltypes.T{coltypes.Decimal, coltypes.Timestamp}
+	for _, typ := range unsupportedTypes {
+		_, err := NewArrowBatchConverter([]coltypes.T{typ})
+		require.Error(t, err)
+	}
 }
 
 func TestArrowBatchConverterRandom(t *testing.T) {

--- a/pkg/col/colserde/arrowbatchconverter_test.go
+++ b/pkg/col/colserde/arrowbatchconverter_test.go
@@ -30,8 +30,8 @@ func randomBatch() ([]coltypes.T, coldata.Batch) {
 
 	availableTyps := make([]coltypes.T, 0, len(coltypes.AllTypes))
 	for _, typ := range coltypes.AllTypes {
-		// TODO(asubiotto): We do not support decimal conversion yet.
-		if typ == coltypes.Decimal {
+		// TODO(asubiotto,jordan): We do not support decimal, timestamp conversion yet.
+		if typ == coltypes.Decimal || typ == coltypes.Timestamp {
 			continue
 		}
 		availableTyps = append(availableTyps, typ)
@@ -119,7 +119,7 @@ func assertEqualBatches(t *testing.T, expected, actual coldata.Batch) {
 func TestArrowBatchConverterRejectsUnsupportedTypes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	typs := []coltypes.T{coltypes.Decimal}
+	typs := []coltypes.T{coltypes.Decimal, coltypes.Timestamp}
 	_, err := NewArrowBatchConverter(typs)
 	require.Error(t, err)
 }

--- a/pkg/col/colserde/arrowbatchconverter_test.go
+++ b/pkg/col/colserde/arrowbatchconverter_test.go
@@ -119,7 +119,7 @@ func assertEqualBatches(t *testing.T, expected, actual coldata.Batch) {
 func TestArrowBatchConverterRejectsUnsupportedTypes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	unsupportedTypes := []coltypes.T{coltypes.Decimal, coltypes.Timestamp}
+	unsupportedTypes := []coltypes.T{coltypes.Decimal}
 	for _, typ := range unsupportedTypes {
 		_, err := NewArrowBatchConverter([]coltypes.T{typ})
 		require.Error(t, err)
@@ -198,11 +198,21 @@ func BenchmarkArrowBatchConverter(b *testing.B) {
 
 	rng, _ := randutil.NewPseudoRand()
 
-	typs := []coltypes.T{coltypes.Bool, coltypes.Bytes, coltypes.Int64}
+	typs := []coltypes.T{
+		coltypes.Bool,
+		coltypes.Bytes,
+		coltypes.Int64,
+		coltypes.Timestamp,
+	}
 	// numBytes corresponds 1:1 to typs and specifies how many bytes we are
 	// converting on one iteration of the benchmark for the corresponding type in
 	// typs.
-	numBytes := []int64{int64(coldata.BatchSize()), fixedLen * int64(coldata.BatchSize()), 8 * int64(coldata.BatchSize())}
+	numBytes := []int64{
+		int64(coldata.BatchSize()),
+		fixedLen * int64(coldata.BatchSize()),
+		8 * int64(coldata.BatchSize()),
+		3 * 8 * int64(coldata.BatchSize()),
+	}
 	// Run a benchmark on every type we care about.
 	for typIdx, typ := range typs {
 		batch := colexec.RandomBatch(rng, []coltypes.T{typ}, int(coldata.BatchSize()), 0 /* length */, 0 /* nullProbability */)

--- a/pkg/col/colserde/record_batch.go
+++ b/pkg/col/colserde/record_batch.go
@@ -36,7 +36,7 @@ func numBuffersForType(t coltypes.T) int {
 	// null bitmap and one for the values.
 	numBuffers := 2
 	switch t {
-	case coltypes.Bytes:
+	case coltypes.Bytes, coltypes.Timestamp:
 		// This type has an extra offsets buffer.
 		numBuffers = 3
 	}

--- a/pkg/col/colserde/record_batch_test.go
+++ b/pkg/col/colserde/record_batch_test.go
@@ -180,9 +180,9 @@ func TestRecordBatchSerializerSerializeDeserializeRandom(t *testing.T) {
 		buf             = bytes.Buffer{}
 	)
 
-	// We do not support decimals yet.
+	// We do not support decimals or timestamps yet.
 	for _, t := range coltypes.AllTypes {
-		if t == coltypes.Decimal {
+		if t == coltypes.Decimal || t == coltypes.Timestamp {
 			continue
 		}
 		supportedTypes = append(supportedTypes, t)

--- a/pkg/col/colserde/record_batch_test.go
+++ b/pkg/col/colserde/record_batch_test.go
@@ -17,6 +17,7 @@ import (
 	"math/rand"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow/go/arrow"
 	"github.com/apache/arrow/go/arrow/array"
@@ -26,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -132,6 +134,20 @@ func randomDataFromType(rng *rand.Rand, t coltypes.T, n int, nullProbability flo
 			}
 			builder.(*array.FixedSizeBinaryBuilder).AppendValues(data, valid)
 		}
+	case coltypes.Timestamp:
+		var err error
+		now := timeutil.Now()
+		builder = array.NewBinaryBuilder(memory.DefaultAllocator, arrow.BinaryTypes.Binary)
+		data := make([][]byte, n)
+		for i := range data {
+			delta := rng.Int63()
+			ts := now.Add(time.Duration(delta))
+			data[i], err = ts.MarshalBinary()
+			if err != nil {
+				panic(err)
+			}
+		}
+		builder.(*array.BinaryBuilder).AppendValues(data, valid)
 	default:
 		panic(fmt.Sprintf("unsupported type %s", t))
 	}
@@ -180,9 +196,9 @@ func TestRecordBatchSerializerSerializeDeserializeRandom(t *testing.T) {
 		buf             = bytes.Buffer{}
 	)
 
-	// We do not support decimals or timestamps yet.
+	// We do not support decimals.
 	for _, t := range coltypes.AllTypes {
-		if t == coltypes.Decimal || t == coltypes.Timestamp {
+		if t == coltypes.Decimal {
 			continue
 		}
 		supportedTypes = append(supportedTypes, t)

--- a/pkg/col/coltypes/t_string.go
+++ b/pkg/col/coltypes/t_string.go
@@ -15,12 +15,13 @@ func _() {
 	_ = x[Int32-4]
 	_ = x[Int64-5]
 	_ = x[Float64-6]
-	_ = x[Unhandled-7]
+	_ = x[Timestamp-7]
+	_ = x[Unhandled-8]
 }
 
-const _T_name = "BoolBytesDecimalInt16Int32Int64Float64Unhandled"
+const _T_name = "BoolBytesDecimalInt16Int32Int64Float64TimestampUnhandled"
 
-var _T_index = [...]uint8{0, 4, 9, 16, 21, 26, 31, 38, 47}
+var _T_index = [...]uint8{0, 4, 9, 16, 21, 26, 31, 38, 47, 56}
 
 func (i T) String() string {
 	if i < 0 || i >= T(len(_T_index)-1) {

--- a/pkg/col/coltypes/types.go
+++ b/pkg/col/coltypes/types.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/cockroachdb/apd"
 )
@@ -38,6 +39,8 @@ const (
 	Int64
 	// Float64 is a column of type float64
 	Float64
+	// Timestamp is a column of type time.Time
+	Timestamp
 
 	// Unhandled is a temporary value that represents an unhandled type.
 	// TODO(jordan): this should be replaced by a panic once all types are
@@ -74,6 +77,7 @@ func init() {
 	CompatibleTypes[Int32] = append(CompatibleTypes[Int32], NumberTypes...)
 	CompatibleTypes[Int64] = append(CompatibleTypes[Int64], NumberTypes...)
 	CompatibleTypes[Float64] = append(CompatibleTypes[Float64], NumberTypes...)
+	CompatibleTypes[Timestamp] = append(CompatibleTypes[Timestamp], Timestamp)
 }
 
 // FromGoType returns the type for a Go value, if applicable. Shouldn't be used at
@@ -96,6 +100,8 @@ func FromGoType(v interface{}) T {
 		return Bytes
 	case apd.Decimal:
 		return Decimal
+	case time.Time:
+		return Timestamp
 	default:
 		panic(fmt.Sprintf("type %T not supported yet", t))
 	}
@@ -118,6 +124,8 @@ func (t T) GoTypeName() string {
 		return "int64"
 	case Float64:
 		return "float64"
+	case Timestamp:
+		return "time.Time"
 	default:
 		panic(fmt.Sprintf("unhandled type %d", t))
 	}

--- a/pkg/sql/colencoding/key_encoding.go
+++ b/pkg/sql/colencoding/key_encoding.go
@@ -11,6 +11,8 @@
 package colencoding
 
 import (
+	"time"
+
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -225,6 +227,14 @@ func decodeTableKeyToCol(
 			rkey, t, err = encoding.DecodeVarintDescending(key)
 		}
 		vec.Int64()[idx] = t
+	case types.TimestampFamily:
+		var t time.Time
+		if dir == sqlbase.IndexDescriptor_ASC {
+			rkey, t, err = encoding.DecodeTimeAscending(key)
+		} else {
+			rkey, t, err = encoding.DecodeTimeDescending(key)
+		}
+		vec.Timestamp()[idx] = t
 	default:
 		return rkey, errors.AssertionFailedf("unsupported type %+v", log.Safe(valType))
 	}

--- a/pkg/sql/colencoding/value_encoding.go
+++ b/pkg/sql/colencoding/value_encoding.go
@@ -11,6 +11,8 @@
 package colencoding
 
 import (
+	"time"
+
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -91,6 +93,10 @@ func decodeUntaggedDatumToCol(vec coldata.Vec, idx uint16, t *types.T, buf []byt
 		if err == nil {
 			vec.Bytes().Set(int(idx), data.GetBytes())
 		}
+	case types.TimestampFamily:
+		var t time.Time
+		buf, t, err = encoding.DecodeUntaggedTimeValue(buf)
+		vec.Timestamp()[idx] = t
 	default:
 		return buf, errors.AssertionFailedf(
 			"couldn't decode type: %s", log.Safe(t))

--- a/pkg/sql/colexec/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/any_not_null_agg_tmpl.go
@@ -20,6 +20,8 @@
 package colexec
 
 import (
+	"time"
+
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
@@ -44,6 +46,9 @@ func newAnyNotNullAgg(t coltypes.T) (aggregateFunc, error) {
 
 // Dummy import to pull in "apd" package.
 var _ apd.Decimal
+
+// Dummy import to pull in "time" package.
+var _ time.Time
 
 // _GOTYPESLICE is the template Go type slice variable for this operator. It
 // will be replaced by the Go slice representation for each type in coltypes.T, for

--- a/pkg/sql/colexec/builtin_funcs.go
+++ b/pkg/sql/colexec/builtin_funcs.go
@@ -63,7 +63,7 @@ func (b *defaultBuiltinFuncOperator) Next(ctx context.Context) coldata.Batch {
 
 		for j := range b.argumentCols {
 			col := batch.ColVec(b.argumentCols[j])
-			b.row[j] = PhysicalTypeColElemToDatum(col, rowIdx, b.da, b.columnTypes[b.argumentCols[j]])
+			b.row[j] = PhysicalTypeColElemToDatum(col, rowIdx, b.da, &b.columnTypes[b.argumentCols[j]])
 			hasNulls = hasNulls || b.row[j] == tree.DNull
 		}
 

--- a/pkg/sql/colexec/cfetcher.go
+++ b/pkg/sql/colexec/cfetcher.go
@@ -788,7 +788,7 @@ func (rf *cFetcher) pushState(state fetcherState) {
 // getDatumAt returns the converted datum object at the given (colIdx, rowIdx).
 // This function is meant for tracing and should not be used in hot paths.
 func (rf *cFetcher) getDatumAt(colIdx int, rowIdx uint16, typ types.T) tree.Datum {
-	return PhysicalTypeColElemToDatum(rf.machine.colvecs[colIdx], rowIdx, rf.table.da, typ)
+	return PhysicalTypeColElemToDatum(rf.machine.colvecs[colIdx], rowIdx, rf.table.da, &typ)
 }
 
 // processValue processes the state machine's current value component, setting

--- a/pkg/sql/colexec/const_tmpl.go
+++ b/pkg/sql/colexec/const_tmpl.go
@@ -21,6 +21,7 @@ package colexec
 
 import (
 	"context"
+	"time"
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -35,6 +36,9 @@ import (
 
 // Dummy import to pull in "apd" package.
 var _ apd.Decimal
+
+// Dummy import to pull in "time" package.
+var _ time.Time
 
 // _TYPES_T is the template type variable for coltypes.T. It will be replaced by
 // coltypes.Foo for each type Foo in the coltypes.T type.

--- a/pkg/sql/colexec/distinct_tmpl.go
+++ b/pkg/sql/colexec/distinct_tmpl.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"context"
 	"math"
+	"time"
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -103,6 +104,9 @@ var _ bytes.Buffer
 
 // Dummy import to pull in "apd" package.
 var _ apd.Decimal
+
+// Dummy import to pull in "time" package.
+var _ time.Time
 
 // Dummy import to pull in "tree" package.
 var _ tree.Datum

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads.go
@@ -537,6 +537,9 @@ type floatIntCustomizer struct{}
 // side and a float right-hand side.
 type intFloatCustomizer struct{}
 
+// timestampCustomizer is necessary since time.Time doesn't have infix operators.
+type timestampCustomizer struct{}
+
 func (boolCustomizer) getCmpOpCompareFunc() compareFunc {
 	return func(target, l, r string) string {
 		args := map[string]string{"Target": target, "Left": l, "Right": r}
@@ -997,11 +1000,43 @@ func (c intFloatCustomizer) getCmpOpCompareFunc() compareFunc {
 	return getFloatCmpOpCompareFunc(false /* checkLeftNan */, true /* checkRightNan */)
 }
 
+func (c timestampCustomizer) getCmpOpCompareFunc() compareFunc {
+	return func(target, l, r string) string {
+		args := map[string]string{"Target": target, "Left": l, "Right": r}
+		buf := strings.Builder{}
+		// Inline the code from tree.compareTimestamps.
+		t := template.Must(template.New("").Parse(`
+      if {{.Left}}.Before({{.Right}}) {
+				{{.Target}} = -1
+			} else if {{.Right}}.Before({{.Left}}) {
+				{{.Target}} = 1
+			} else { 
+        {{.Target}} = 0
+      }`))
+
+		if err := t.Execute(&buf, args); err != nil {
+			execerror.VectorizedInternalPanic(err)
+		}
+		return buf.String()
+	}
+}
+
+func (timestampCustomizer) getHashAssignFunc() assignFunc {
+	return func(op overload, target, v, _ string) string {
+		return fmt.Sprintf(`
+		  s, ns := %[2]s.Second(), %[2]s.Nanosecond()
+		  %[1]s = memhash64(noescape(unsafe.Pointer(&s)), %[1]s)
+		  %[1]s = memhash64(noescape(unsafe.Pointer(&ns)), %[1]s)
+		`, target, v)
+	}
+}
+
 func registerTypeCustomizers() {
 	typeCustomizers = make(map[coltypePair]typeCustomizer)
 	registerTypeCustomizer(coltypePair{coltypes.Bool, coltypes.Bool}, boolCustomizer{})
 	registerTypeCustomizer(coltypePair{coltypes.Bytes, coltypes.Bytes}, bytesCustomizer{})
 	registerTypeCustomizer(coltypePair{coltypes.Decimal, coltypes.Decimal}, decimalCustomizer{})
+	registerTypeCustomizer(coltypePair{coltypes.Timestamp, coltypes.Timestamp}, timestampCustomizer{})
 	for _, leftFloatType := range coltypes.FloatTypes {
 		for _, rightFloatType := range coltypes.FloatTypes {
 			registerTypeCustomizer(coltypePair{leftFloatType, rightFloatType}, floatCustomizer{width: 64})

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads.go
@@ -1024,9 +1024,8 @@ func (c timestampCustomizer) getCmpOpCompareFunc() compareFunc {
 func (timestampCustomizer) getHashAssignFunc() assignFunc {
 	return func(op overload, target, v, _ string) string {
 		return fmt.Sprintf(`
-		  s, ns := %[2]s.Second(), %[2]s.Nanosecond()
+		  s := %[2]s.UnixNano()
 		  %[1]s = memhash64(noescape(unsafe.Pointer(&s)), %[1]s)
-		  %[1]s = memhash64(noescape(unsafe.Pointer(&ns)), %[1]s)
 		`, target, v)
 	}
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_test_utils_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_test_utils_gen.go
@@ -21,6 +21,7 @@ package colexec
 import (
 	"bytes"
 	"math"
+	"time"
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"

--- a/pkg/sql/colexec/materializer.go
+++ b/pkg/sql/colexec/materializer.go
@@ -165,7 +165,7 @@ func (m *Materializer) next() (sqlbase.EncDatumRow, *execinfrapb.ProducerMetadat
 		typs := m.OutputTypes()
 		for colIdx := 0; colIdx < len(typs); colIdx++ {
 			col := m.batch.ColVec(colIdx)
-			m.row[colIdx].Datum = PhysicalTypeColElemToDatum(col, rowIdx, m.da, typs[colIdx])
+			m.row[colIdx].Datum = PhysicalTypeColElemToDatum(col, rowIdx, m.da, &typs[colIdx])
 		}
 		return m.ProcessRowHelper(m.row), nil
 	}

--- a/pkg/sql/colexec/mem_estimation.go
+++ b/pkg/sql/colexec/mem_estimation.go
@@ -58,6 +58,13 @@ func EstimateBatchSizeBytes(vecTypes []coltypes.T, batchLength int) int {
 			// to hold the arbitrary precision decimal objects.
 			acc += 50
 		case coltypes.Timestamp:
+			// time.Time consists of two 64 bit integers and a pointer to
+			// time.Location. We will only account for this 3 bytes without paying
+			// attention to the full time.Location struct. The reason is that it is
+			// likely that time.Location's are cached and are shared among all the
+			// timestamps, so if we were to include that in the estimation, we would
+			// significantly overestimate.
+			// TODO(yuzefovich): figure out whether the caching does take place.
 			acc += sizeOfTime
 		default:
 			execerror.VectorizedInternalPanic(fmt.Sprintf("unhandled type %s", t))

--- a/pkg/sql/colexec/mem_estimation.go
+++ b/pkg/sql/colexec/mem_estimation.go
@@ -55,6 +55,9 @@ func EstimateBatchSizeBytes(vecTypes []coltypes.T, batchLength int) int {
 			// Similar to byte arrays, we can't tell how much space is used
 			// to hold the arbitrary precision decimal objects.
 			acc += 50
+		case coltypes.Timestamp:
+			// time.Time has 2 int64s and a pointer.
+			acc += sizeOfInt64 * 3
 		default:
 			execerror.VectorizedInternalPanic(fmt.Sprintf("unhandled type %s", t))
 		}

--- a/pkg/sql/colexec/mem_estimation.go
+++ b/pkg/sql/colexec/mem_estimation.go
@@ -12,6 +12,7 @@ package colexec
 
 import (
 	"fmt"
+	"time"
 	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
@@ -24,6 +25,7 @@ const (
 	sizeOfInt32   = int(unsafe.Sizeof(int32(0)))
 	sizeOfInt64   = int(unsafe.Sizeof(int64(0)))
 	sizeOfFloat64 = int(unsafe.Sizeof(float64(0)))
+	sizeOfTime    = int(unsafe.Sizeof(time.Time{}))
 )
 
 // EstimateBatchSizeBytes returns an estimated amount of bytes needed to
@@ -56,8 +58,7 @@ func EstimateBatchSizeBytes(vecTypes []coltypes.T, batchLength int) int {
 			// to hold the arbitrary precision decimal objects.
 			acc += 50
 		case coltypes.Timestamp:
-			// time.Time has 2 int64s and a pointer.
-			acc += sizeOfInt64 * 3
+			acc += sizeOfTime
 		default:
 			execerror.VectorizedInternalPanic(fmt.Sprintf("unhandled type %s", t))
 		}

--- a/pkg/sql/colexec/mergejoinbase_tmpl.go
+++ b/pkg/sql/colexec/mergejoinbase_tmpl.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -43,6 +44,9 @@ var _ tree.Datum
 
 // Dummy import to pull in "apd" package.
 var _ apd.Decimal
+
+// Dummy import to pull in "time" package.
+var _ time.Time
 
 // Dummy import to pull in "math" package.
 var _ = math.MaxInt64

--- a/pkg/sql/colexec/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/mergejoiner_tmpl.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -45,6 +46,9 @@ var _ tree.Datum
 
 // Dummy import to pull in "apd" package.
 var _ apd.Decimal
+
+// Dummy import to pull in "time" package.
+var _ time.Time
 
 // Dummy import to pull in "math" package.
 var _ = math.MaxInt64

--- a/pkg/sql/colexec/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/min_max_agg_tmpl.go
@@ -22,6 +22,7 @@ package colexec
 import (
 	"bytes"
 	"math"
+	"time"
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -42,6 +43,9 @@ var _ bytes.Buffer
 
 // Dummy import to pull in "apd" package.
 var _ apd.Decimal
+
+// Dummy import to pull in "time" package.
+var _ time.Time
 
 // Dummy import to pull in "tree" package.
 var _ tree.Datum

--- a/pkg/sql/colexec/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_const_ops_tmpl.go
@@ -54,7 +54,7 @@ var _ tree.Datum
 var _ = math.MaxInt64
 
 // Dummy import to pull in "time" package.
-var _ = time.Day
+var _ time.Time
 
 // _ASSIGN is the template function for assigning the first input to the result
 // of computation an operation on the second and the third inputs.

--- a/pkg/sql/colexec/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_const_ops_tmpl.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"context"
 	"math"
+	"time"
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -51,6 +52,9 @@ var _ tree.Datum
 
 // Dummy import to pull in "math" package.
 var _ = math.MaxInt64
+
+// Dummy import to pull in "time" package.
+var _ = time.Day
 
 // _ASSIGN is the template function for assigning the first input to the result
 // of computation an operation on the second and the third inputs.

--- a/pkg/sql/colexec/projection_ops_test.go
+++ b/pkg/sql/colexec/projection_ops_test.go
@@ -187,6 +187,7 @@ func TestRandomComparisons(t *testing.T) {
 	rng, _ := randutil.NewPseudoRand()
 	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	ctx := evalCtx.Ctx()
+	defer evalCtx.Stop(ctx)
 	expected := make([]bool, numTuples)
 	var da sqlbase.DatumAlloc
 	lDatums := make([]tree.Datum, numTuples)

--- a/pkg/sql/colexec/random_testutils.go
+++ b/pkg/sql/colexec/random_testutils.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
 // maxVarLen specifies a length limit for variable length types (e.g. byte slices).
@@ -83,6 +84,11 @@ func RandomVec(rng *rand.Rand, typ coltypes.T, vec coldata.Vec, n int, nullProba
 		floats := vec.Float64()
 		for i := 0; i < n; i++ {
 			floats[i] = rng.Float64()
+		}
+	case coltypes.Timestamp:
+		timestamps := vec.Timestamp()
+		for i := 0; i < n; i++ {
+			timestamps[i] = timeutil.Unix(rng.Int63n(1000000), rng.Int63n(1000000))
 		}
 	default:
 		execerror.VectorizedInternalPanic(fmt.Sprintf("unhandled type %s", typ))

--- a/pkg/sql/colexec/rowstovec_tmpl.go
+++ b/pkg/sql/colexec/rowstovec_tmpl.go
@@ -21,6 +21,7 @@ package colexec
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -36,6 +37,9 @@ import (
 
 // Dummy import to pull in "apd" package.
 var _ apd.Decimal
+
+// Dummy import to pull in "time" package.
+var _ time.Time
 
 const (
 	_FAMILY = types.Family(0)

--- a/pkg/sql/colexec/select_in_tmpl.go
+++ b/pkg/sql/colexec/select_in_tmpl.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"context"
 	"math"
+	"time"
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -44,6 +45,9 @@ type _TYPE interface{}
 
 // Dummy import to pull in "apd" package.
 var _ apd.Decimal
+
+// Dummy import to pull in "time" package.
+var _ time.Time
 
 // Dummy import to pull in "coltypes" package
 var _ coltypes.T

--- a/pkg/sql/colexec/selection_ops_tmpl.go
+++ b/pkg/sql/colexec/selection_ops_tmpl.go
@@ -54,7 +54,7 @@ var _ tree.Datum
 var _ = math.MaxInt64
 
 // Dummy import to pull in "time" package.
-var _ = time.Day
+var _ time.Time
 
 // Dummy import to pull in "coltypes" package.
 var _ = coltypes.Bool

--- a/pkg/sql/colexec/selection_ops_tmpl.go
+++ b/pkg/sql/colexec/selection_ops_tmpl.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"context"
 	"math"
+	"time"
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -51,6 +52,9 @@ var _ tree.Datum
 
 // Dummy import to pull in "math" package.
 var _ = math.MaxInt64
+
+// Dummy import to pull in "time" package.
+var _ = time.Day
 
 // Dummy import to pull in "coltypes" package.
 var _ = coltypes.Bool

--- a/pkg/sql/colexec/sort_tmpl.go
+++ b/pkg/sql/colexec/sort_tmpl.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -43,6 +44,9 @@ var _ bytes.Buffer
 
 // Dummy import to pull in "apd" package.
 var _ apd.Decimal
+
+// Dummy import to pull in "time" package.
+var _ time.Time
 
 // Dummy import to pull in "tree" package.
 var _ tree.Datum

--- a/pkg/sql/colexec/supported_sql_types.go
+++ b/pkg/sql/colexec/supported_sql_types.go
@@ -27,4 +27,5 @@ var allSupportedSQLTypes = []types.T{
 	*types.Float4,
 	*types.String,
 	*types.Uuid,
+	*types.Timestamp,
 }

--- a/pkg/sql/colexec/typeconv/typeconv.go
+++ b/pkg/sql/colexec/typeconv/typeconv.go
@@ -47,6 +47,8 @@ func FromColumnType(ct *types.T) coltypes.T {
 		execerror.VectorizedInternalPanic(fmt.Sprintf("integer with unknown width %d", ct.Width()))
 	case types.FloatFamily:
 		return coltypes.Float64
+	case types.TimestampFamily:
+		return coltypes.Timestamp
 	}
 	return coltypes.Unhandled
 }
@@ -209,6 +211,14 @@ func GetDatumToPhysicalFn(ct *types.T) func(tree.Datum) (interface{}, error) {
 				return nil, errors.Errorf("expected *tree.DUuid, found %s", reflect.TypeOf(datum))
 			}
 			return d.UUID.GetBytesMut(), nil
+		}
+	case types.TimestampFamily:
+		return func(datum tree.Datum) (interface{}, error) {
+			d, ok := datum.(*tree.DTimestamp)
+			if !ok {
+				return nil, errors.Errorf("expected *tree.DTimestamp, found %s", reflect.TypeOf(datum))
+			}
+			return d.Time, nil
 		}
 	}
 	// It would probably be more correct to return an error here, rather than a

--- a/pkg/sql/colexec/types_integration_test.go
+++ b/pkg/sql/colexec/types_integration_test.go
@@ -59,8 +59,8 @@ func TestSupportedSQLTypesIntegration(t *testing.T) {
 	rng, _ := randutil.NewPseudoRand()
 
 	for _, typ := range allSupportedSQLTypes {
-		if typ.Equal(*types.Decimal) || typ.Equal(*types.Timestamp) {
-			// Serialization of Decimals and Timestamps is currently not supported.
+		if typ.Equal(*types.Decimal) {
+			// Serialization of Decimals is currently not supported.
 			// TODO(yuzefovich): remove this once it is supported.
 			continue
 		}

--- a/pkg/sql/colexec/types_integration_test.go
+++ b/pkg/sql/colexec/types_integration_test.go
@@ -59,8 +59,8 @@ func TestSupportedSQLTypesIntegration(t *testing.T) {
 	rng, _ := randutil.NewPseudoRand()
 
 	for _, typ := range allSupportedSQLTypes {
-		if typ.Equal(*types.Decimal) {
-			// Serialization of Decimals is currently not supported.
+		if typ.Equal(*types.Decimal) || typ.Equal(*types.Timestamp) {
+			// Serialization of Decimals and Timestamps is currently not supported.
 			// TODO(yuzefovich): remove this once it is supported.
 			continue
 		}

--- a/pkg/sql/colexec/vec_comparators_tmpl.go
+++ b/pkg/sql/colexec/vec_comparators_tmpl.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -43,6 +44,9 @@ var _ bytes.Buffer
 
 // Dummy import to pull in "apd" package.
 var _ apd.Decimal
+
+// Dummy import to pull in "time" package.
+var _ time.Time
 
 // Dummy import to pull in "tree" package.
 var _ tree.Datum

--- a/pkg/sql/colexec/vec_elem_to_datum.go
+++ b/pkg/sql/colexec/vec_elem_to_datum.go
@@ -28,7 +28,7 @@ import (
 // semtype ct. Note that this function handles nulls as well, so there is no
 // need for a separate null check.
 func PhysicalTypeColElemToDatum(
-	col coldata.Vec, rowIdx uint16, da sqlbase.DatumAlloc, ct types.T,
+	col coldata.Vec, rowIdx uint16, da sqlbase.DatumAlloc, ct *types.T,
 ) tree.Datum {
 	if col.MaybeHasNulls() {
 		if col.Nulls().NullAt(rowIdx) {

--- a/pkg/sql/colexec/vec_elem_to_datum.go
+++ b/pkg/sql/colexec/vec_elem_to_datum.go
@@ -72,6 +72,8 @@ func PhysicalTypeColElemToDatum(
 			execerror.VectorizedInternalPanic(err)
 		}
 		return da.NewDUuid(tree.DUuid{UUID: id})
+	case types.TimestampFamily:
+		return da.NewDTimestamp(tree.DTimestamp{Time: col.Timestamp()[rowIdx]})
 	default:
 		execerror.VectorizedInternalPanic(fmt.Sprintf("Unsupported column type %s", ct.String()))
 		// This code is unreachable, but the compiler cannot infer that.

--- a/pkg/sql/colexec/zerocolumns_tmpl.go
+++ b/pkg/sql/colexec/zerocolumns_tmpl.go
@@ -20,6 +20,8 @@
 package colexec
 
 import (
+	"time"
+
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 )
@@ -29,6 +31,9 @@ import (
 
 // Dummy import to pull in "apd" package.
 var _ apd.Decimal
+
+// Dummy import to pull in "time" package.
+var _ time.Time
 
 // */}}
 

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_types
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_types
@@ -1,23 +1,25 @@
 # Check that all types supported by the vectorized engine can be read correctly.
 statement ok
 CREATE TABLE all_types (
-    _bool    BOOL,
-    _bytes   BYTES,
-    _date    DATE,
-    _decimal DECIMAL,
-    _int2    INT2,
-    _int4    INT4,
-    _int     INT8,
-    _oid     OID,
-    _float   FLOAT8,
-    _string  STRING,
-    _uuid    UUID
+    _bool      BOOL,
+    _bytes     BYTES,
+    _date      DATE,
+    _decimal   DECIMAL,
+    _int2      INT2,
+    _int4      INT4,
+    _int       INT8,
+    _oid       OID,
+    _float     FLOAT8,
+    _string    STRING,
+    _uuid      UUID,
+    _timestamp TIMESTAMP
 )
 
 statement ok
 INSERT
   INTO all_types
 VALUES (
+        NULL,
         NULL,
         NULL,
         NULL,
@@ -41,11 +43,12 @@ VALUES (
        123,
        1.23,
        '123',
-       '63616665-6630-3064-6465-616462656562'
+       '63616665-6630-3064-6465-616462656562',
+       '1-1-18 1:00:00.001'
        )
 
-query BTTRIIIORTT
+query BTTRIIIORTTT
 SELECT * FROM all_types ORDER BY 1
 ----
-NULL   NULL  NULL                             NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL
-false  123   2019-10-22 00:00:00 +0000 +0000  1.23  123   123   123   123   1.23  123   63616665-6630-3064-6465-616462656562
+NULL   NULL  NULL                             NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL                                  NULL
+false  123   2019-10-22 00:00:00 +0000 +0000  1.23  123   123   123   123   1.23  123   63616665-6630-3064-6465-616462656562  2001-01-18 01:00:00.001 +0000 +0000

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -21,7 +21,7 @@ EXPLAIN (PLAN) SELECT 1 FROM system.jobs WHERE TRUE
 ----
 tree       field        description
 ·          distributed  false
-·          vectorized   false
+·          vectorized   true
 render     ·            ·
  └── scan  ·            ·
 ·          table        jobs@jobs_status_created_idx

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -159,7 +159,7 @@ func RandDatumWithNullChance(rng *rand.Rand, typ *types.T, nullChance int) tree.
 	case types.TimeFamily:
 		return tree.MakeDTime(timeofday.Random(rng))
 	case types.TimestampFamily:
-		return &tree.DTimestamp{Time: timeutil.Unix(rng.Int63n(1000000), rng.Int63n(1000000))}
+		return tree.MakeDTimestamp(timeutil.Unix(rng.Int63n(1000000), rng.Int63n(1000000)), time.Microsecond)
 	case types.IntervalFamily:
 		sign := 1 - rng.Int63n(2)*2
 		return &tree.DInterval{Duration: duration.MakeDuration(


### PR DESCRIPTION
This PR is the rebased version of #40250 with a modification of how we're creating `DTimestamp` in `PhysicalTypeColElemToDatum`.

**colexec,coldata: support timestamp type**

This commit adds support for the TIMESTAMP type to the coldata and colexec
packages.

**colexec: add random projection tests for all types**

This test randomly runs binary comparisons against all types with random
data, verifying that the result of Datum.Compare matches the result of
the exec projection.

This found the bug with date infinity matching tracked in #40354, and
immediately found a bug with the timestamp implementation in the
previous commit, so I'm fairly sure it's a useful random test to have
around.

**colserde: add simple serialization for TIMESTAMP**

This commit adds simple (and quite inefficient) serialization
for TIMESTAMP type which uses the provided marshalling and
unmarshalling methods.

Release note: None