### PR TITLE
changefeedccl: fix bug in poller that allows it to emit a resolved ts before emitting row updates at the ts

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -165,14 +165,16 @@ func emitEntries(
 ) func(context.Context) ([]jobspb.ResolvedSpan, error) {
 	var scratch bufalloc.ByteAllocator
 	emitRowFn := func(ctx context.Context, row encodeRow) error {
-		// Skip rows with a timestamp less than the local span frontier because they must
-		// have been emitted before. TODO(aayush): Note that this should technically also
-		// filter out rows with timestamps equal to the local frontier but there is
-		// currently a bug in the poller which can cause it to emit row updates at a
-		// timestamp that is equal to a previously resolved timestamp in case of a schema
-		// change with backfill. See issue #41415 for more details. This if-condition
-		// should be updated and turned into an assertion once this is fixed. Fixme.
-		if row.updated.Less(sf.Frontier()) {
+		// Ensure that row updates are strictly newer than the least resolved timestamp
+		// being tracked by the local span frontier. The poller should not be forwarding
+		// row updates that have timestamps less than or equal to any resolved timestamp
+		// it's forwarded before.
+		// TODO(aayush): This should be an assertion once we're confident this can never
+		// happen under any circumstance.
+		if !sf.Frontier().Less(row.updated) {
+			log.Errorf(ctx, "cdc ux violation: detected timestamp %s that is less than "+
+				"or equal to the local frontier %s.", cloudStorageFormatTime(row.updated),
+				cloudStorageFormatTime(sf.Frontier()))
 			return nil
 		}
 		var keyCopy, valueCopy []byte

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -89,8 +89,7 @@ func (o *changeAggregatorLowerBoundOracle) inclusiveLowerBoundTS() hlc.Timestamp
 		// on the timestamps of the updates contained within the file.
 		// Files being created at the point this method is called are guaranteed
 		// to contain row updates with timestamps strictly greater than the local
-		// span frontier timestamp (not in all cases, there's a known bug with
-		// the poller that can violate this. See: #41415. A fix is in progress).
+		// span frontier timestamp.
 		return frontier.Next()
 	}
 	// This should only be returned in the case where the changefeed job hasn't yet

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -12,7 +12,9 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
+	"math"
 	"net/url"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -302,6 +304,8 @@ func TestChangefeedResolvedFrequency(t *testing.T) {
 // operation.
 func TestChangefeedSchemaChangeNoBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	scope := log.Scope(t)
+	defer scope.Close(t)
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(db)
@@ -477,6 +481,14 @@ func TestChangefeedSchemaChangeNoBackfill(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
+	log.Flush()
+	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1, regexp.MustCompile("cdc ux violation"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) > 0 {
+		t.Fatalf("Found violation of CDC's guarantees: %v", entries)
+	}
 }
 
 func TestChangefeedSchemaChangeNoAllowBackfill(t *testing.T) {
@@ -552,6 +564,8 @@ func TestChangefeedSchemaChangeNoAllowBackfill(t *testing.T) {
 // allowed.
 func TestChangefeedSchemaChangeAllowBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	scope := log.Scope(t)
+	defer scope.Close(t)
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(db)
@@ -678,11 +692,21 @@ func TestChangefeedSchemaChangeAllowBackfill(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
+	log.Flush()
+	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1, regexp.MustCompile("cdc ux violation"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) > 0 {
+		t.Fatalf("Found violation of CDC's guarantees: %v", entries)
+	}
 }
 
 // Regression test for #34314
 func TestChangefeedAfterSchemaChangeBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	scope := log.Scope(t)
+	defer scope.Close(t)
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(db)
@@ -700,6 +724,14 @@ func TestChangefeedAfterSchemaChangeBackfill(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
+	log.Flush()
+	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1, regexp.MustCompile("cdc ux violation"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) > 0 {
+		t.Fatalf("Found violation of CDC's guarantees: %v", entries)
+	}
 }
 
 func TestChangefeedInterleaved(t *testing.T) {

--- a/pkg/ccl/changefeedccl/nemeses_test.go
+++ b/pkg/ccl/changefeedccl/nemeses_test.go
@@ -10,6 +10,8 @@ package changefeedccl
 
 import (
 	gosql "database/sql"
+	"math"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -17,12 +19,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 func TestChangefeedNemeses(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer func(i time.Duration) { jobs.DefaultAdoptInterval = i }(jobs.DefaultAdoptInterval)
 	jobs.DefaultAdoptInterval = 10 * time.Millisecond
+	scope := log.Scope(t)
+	defer scope.Close(t)
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
 		// TODO(aayush,dan): Ugly hack to disable `eventPause` in sinkless
@@ -39,4 +44,12 @@ func TestChangefeedNemeses(t *testing.T) {
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
 	t.Run(`cloudstorage`, cloudStorageTest(testFn))
+	log.Flush()
+	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1, regexp.MustCompile("cdc ux violation"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) > 0 {
+		t.Fatalf("Found violation of CDC's guarantees: %v", entries)
+	}
 }

--- a/pkg/ccl/changefeedccl/poller.go
+++ b/pkg/ccl/changefeedccl/poller.go
@@ -264,21 +264,33 @@ func (p *poller) rangefeedImpl(ctx context.Context) error {
 				} else if e.resolved != nil {
 					resolvedTS := e.resolved.Timestamp
 					boundaryBreak := false
+					// Make sure scan boundaries less than or equal to `resolvedTS` were
+					// added to the `scanBoundaries` list before proceeding.
+					if err := p.tableHist.WaitForTS(ctx, resolvedTS); err != nil {
+						return err
+					}
 					p.mu.Lock()
 					if len(p.mu.scanBoundaries) > 0 && p.mu.scanBoundaries[0].Less(resolvedTS) {
 						boundaryBreak = true
 						resolvedTS = p.mu.scanBoundaries[0]
 					}
 					p.mu.Unlock()
-					if err := p.buf.AddResolved(ctx, e.resolved.Span, resolvedTS); err != nil {
-						return err
-					}
 					if boundaryBreak {
+						// A boundary here means we're about to do a full scan (backfill)
+						// at this timestamp, so at the changefeed level the boundary
+						// itself is not resolved. Skip emitting this resolved timestamp
+						// because we want to trigger the scan first before resolving its
+						// scan boundary timestamp.
+						resolvedTS = resolvedTS.Prev()
 						frontier.Forward(e.resolved.Span, resolvedTS)
 						if frontier.Frontier() == resolvedTS {
 							// All component rangefeeds are now at the boundary.
 							// Break out of the ctxgroup by returning a sentinel error.
 							return errBoundaryReached
+						}
+					} else {
+						if err := p.buf.AddResolved(ctx, e.resolved.Span, resolvedTS); err != nil {
+							return err
 						}
 					}
 				}

--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -119,14 +119,11 @@ type cloudStorageSinkFile struct {
 // timestamp, a data file can't even be emitted at the same timestamp, it must be emitted
 // at a timestamp that is strictly greater than the last globally resolved timestamp. Note
 // that the local frontier is a guarantee that the sink will never get an EmitRow with
-// that timestamp or lower. (NOTE: there is a known bug in the poller which can cause row
-// updates to be emitted with a timestamp that is equal to the local frontier, during a
-// schema change with backfill. See #41415 for more details) (a2) is that whenever Flush
-// is called, all files written by the sink must be named using timestamps less than or
-// equal to the one for the local frontier at the time Flush is called. This is again
-// because our local progress update could cause the global progress to be updated and we
-// need everything written so far to lexically compare as less than the new resolved
-// timestamp.
+// that timestamp or lower. (a2) is that whenever Flush is called, all files written by
+// the sink must be named using timestamps less than or equal to the one for the local
+// frontier at the time Flush is called. This is again because our local progress update
+// could cause the global progress to be updated and we need everything written so far to
+// lexically compare as less than the new resolved timestamp.
 //
 // The data files written by this sink are named according to the pattern
 // `<timestamp>-<uniquer>-<topic_id>-<schema_id>.<ext>`, each component of which is as
@@ -136,8 +133,6 @@ type cloudStorageSinkFile struct {
 // `changeAggregator`, as of the time the last `Flush()` call was made (or `StatementTime`
 // if `Flush()` hasn't been called yet). Intuitively, this can be thought of as an
 // inclusive lower bound on the timestamps of updates that can be seen in a given file.
-// NOTE: Due to a bug in the poller, this is not always true when there's a schema change
-// that causes a backfill. See issue #41415 for more details.
 //
 // `<topic>` corresponds to one SQL table.
 //
@@ -208,9 +203,7 @@ type cloudStorageSinkFile struct {
 // time the last `Flush()` call was made (or StatementTime in case `Flush()` hasn't been
 // called yet). Since all EmitRow calls are guaranteed to be for rows that equal or
 // succeed this timestamp, ts(Xi) is an inclusive lower bound for the rows contained
-// inside Xi. NOTE: There is a known bug in the poller which causes this guarantee to be
-// violated in case of a schema change that causes a backfill. See issue #41415 for more
-// details.
+// inside Xi.
 // 4. When a job restarts, the new job session starts with a catch-up scan
 // from the last globally resolved timestamp of the changefeed. This catch-up
 // scan replays all rows since this resolved timestamp preserving invariant 1.


### PR DESCRIPTION
Fixes: #41415

Currently, the poller keeps track of the most recent table descriptor
version for every table being watched by it. It polls to get the current
table descriptor periodically, and triggers a backfill if it detects
that the previous version of the table descriptor has a mutation but
the current one doesn't.

It triggers the aforementioned backfill scan at the `ModificationTime`
of the new table descriptor (meaning that the row updates resulting from
this backfill scan will have the `ModificationTime` of the of the table
descriptor as their `updated` timestamps). Now, it is possible that the
poller forwarded a resolved timestamp up to the `changeAggregator` that
is equal to or greater than this `ModificationTime` *before* the
backfill scan was actually triggered.

This PR fixes this problem by first making sure that the concerned
goroutine waits until the backfill scan boundary has been detected and
then skips forwarding all resolved timestamps until the scan boundary is
executed upon.

Release note (changefeedccl): Fix bug in poller in case of schema change.

Release justification: Fix bug in poller that causes it to emit row
updates at a timestamp less than or equal to an already forwarded
resolved timestamp.