### PR TITLE
release-19.1: opt: fix scalar building error handling

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -593,7 +593,7 @@ func (b *Builder) buildApplyJoin(join memo.RelExpr) (execPlan, error) {
 	if len(*filters) != 0 {
 		onExpr, err = b.buildScalar(&ctx, filters)
 		if err != nil {
-			return execPlan{}, nil
+			return execPlan{}, err
 		}
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #40617.

/cc @cockroachdb/release

---

We are incorrectly returning `nil` error in an error case. This leads
to an assertion error instead of a "could not decorrelate subquery"
error.

Fixes #40590.

Release note: None
