### PR TITLE
release-19.1: opt: nil presentation should not equal the 0-column presentation

### DIFF
--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -497,10 +497,14 @@ func (h *hasher) HashTupleOrdinal(val TupleOrdinal) {
 }
 
 func (h *hasher) HashPhysProps(val *physical.Required) {
-	for i := range val.Presentation {
-		col := &val.Presentation[i]
-		h.HashString(col.Alias)
-		h.HashColumnID(col.ID)
+	// Note: the Any presentation is not the same as the 0-column presentation.
+	if !val.Presentation.Any() {
+		h.HashInt(len(val.Presentation))
+		for i := range val.Presentation {
+			col := &val.Presentation[i]
+			h.HashString(col.Alias)
+			h.HashColumnID(col.ID)
+		}
 	}
 	h.HashOrderingChoice(val.Ordering)
 }

--- a/pkg/sql/opt/props/physical/required.go
+++ b/pkg/sql/opt/props/physical/required.go
@@ -119,6 +119,10 @@ func (p Presentation) Any() bool {
 // Equals returns true iff this presentation exactly matches the given
 // presentation.
 func (p Presentation) Equals(rhs Presentation) bool {
+	// The 0 column presentation is not the same as the nil presentation.
+	if p.Any() != rhs.Any() {
+		return false
+	}
 	if len(p) != len(rhs) {
 		return false
 	}

--- a/pkg/sql/opt/props/physical/required_test.go
+++ b/pkg/sql/opt/props/physical/required_test.go
@@ -46,8 +46,16 @@ func TestRequiredProps(t *testing.T) {
 		t.Error("presentation should equal itself")
 	}
 
-	if presentation.Equals(physical.Presentation{}) {
+	if presentation.Equals(physical.Presentation(nil)) {
 		t.Error("presentation should not equal the empty presentation")
+	}
+
+	if presentation.Equals(physical.Presentation{}) {
+		t.Error("presentation should not equal the 0 column presentation")
+	}
+
+	if (physical.Presentation{}).Equals(physical.Presentation(nil)) {
+		t.Error("0 column presentation should not equal the empty presentation")
 	}
 
 	// Add ordering props.


### PR DESCRIPTION
Backport 1/2 commits from #39818.

/cc @cockroachdb/release

The nil presentation means that we want all columns in no particular
order, whereas the 0-column presentation means that we don't need any
of the columns (e.g. EXISTS subqueries). Only the nil presentation
is `Any()`. But `Equals()` was incorrectly treating these as equal.
This confused the interner and a nil presentation became a 0-column
presentation which led to some internal errors in Apply.

For completeness, we also fix `HashPhysProps` to differentiate
between these two, but note that this isn't required for correctness.

Fixes #39435.

Release note (bug fix): Fixed internal errors generated during
execution of some complicated cases of correlated subqueries.

