### PR TITLE
workload/tpcc: avoid lookup join in OrderStatus using STORING index

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats_quality/tpcc
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpcc
@@ -357,48 +357,21 @@ project
  ├── columns: o_id:1(int!null) o_entry_d:5(timestamp) o_carrier_id:6(int)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=0.974324775, distinct(1)=0.974168103, null(1)=0, distinct(5)=0.622553468, null(5)=0, distinct(6)=0.932422121, null(6)=0.292297432]
- ├── cost: 5.26974325
+ ├── cost: 1.120987
  ├── key: ()
  ├── fd: ()-->(1,5,6)
  ├── prune: (1,5,6)
- └── index-join order
-      ├── save-table-name: order_status_03_index_join_2
+ └── scan "order"@order_idx
+      ├── save-table-name: order_status_03_scan_2
       ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_c_id:4(int!null) o_entry_d:5(timestamp) o_carrier_id:6(int)
-      ├── cardinality: [0 - 1]
+      ├── constraint: /3/2/4/-1: [/4/3/10 - /4/3/10]
+      ├── limit: 1
       ├── stats: [rows=0.974324775, distinct(1)=0.974168103, null(1)=0, distinct(2)=0.974324775, null(2)=0, distinct(3)=0.974324775, null(3)=0, distinct(4)=0.974324775, null(4)=0, distinct(5)=0.622553468, null(5)=0, distinct(6)=0.932422121, null(6)=0.292297432]
-      ├── cost: 5.25
+      ├── cost: 1.10124375
       ├── key: ()
       ├── fd: ()-->(1-6)
-      ├── interesting orderings: (+3,+2,-1) (+3,+2,+4,-1)
-      └── scan "order"@order_idx
-           ├── save-table-name: order_status_03_scan_3
-           ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_c_id:4(int!null)
-           ├── constraint: /3/2/4/-1: [/4/3/10 - /4/3/10]
-           ├── limit: 1
-           ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(4)=1, null(4)=0]
-           ├── cost: 1.09
-           ├── key: ()
-           ├── fd: ()-->(1-4)
-           ├── prune: (1-4)
-           └── interesting orderings: (+3,+2,-1) (+3,+2,+4,-1)
-
-stats table=order_status_03_index_join_2
-----
-column_names    row_count  distinct_count  null_count
-{o_c_id}        1          1               0
-{o_carrier_id}  1          1               0
-{o_d_id}        1          1               0
-{o_entry_d}     1          1               0
-{o_id}          1          1               0
-{o_w_id}        1          1               0
-~~~~
-column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{o_c_id}        1.00           1.00           1.00                1.00                0.00            1.00
-{o_carrier_id}  1.00           1.00           1.00                1.00                0.00            1.00
-{o_d_id}        1.00           1.00           1.00                1.00                0.00            1.00
-{o_entry_d}     1.00           1.00           1.00                1.00                0.00            1.00
-{o_id}          1.00           1.00           1.00                1.00                0.00            1.00
-{o_w_id}        1.00           1.00           1.00                1.00                0.00            1.00
+      ├── prune: (1-6)
+      └── interesting orderings: (+3,+2,-1) (+3,+2,+4,-1)
 
 save-tables format=hide-qual database=tpcc save-tables-prefix=order_status_04
 SELECT ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d
@@ -875,7 +848,7 @@ group-by
  ├── columns: max:9(int)  [hidden: o_d_id:2(int!null) o_w_id:3(int!null)]
  ├── grouping columns: o_d_id:2(int!null) o_w_id:3(int!null)
  ├── stats: [rows=100, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(9)=100, null(9)=0, distinct(2,3)=100, null(2,3)=0]
- ├── cost: 330001.03
+ ├── cost: 336001.03
  ├── key: (2,3)
  ├── fd: (2,3)-->(9)
  ├── ordering: +3,+2
@@ -887,7 +860,7 @@ group-by
  │    ├── stats: [rows=300000, distinct(1)=2999, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(2,3)=100, null(2,3)=0]
  │    │   histogram(3)=  0 29280 0 29310 0 31560 0 30000 0 29220 0 30720 0 31110 0 30510 0 29070 0 29220
  │    │                <---- 0 ----- 1 ----- 2 ----- 3 ----- 4 ----- 5 ----- 6 ----- 7 ----- 8 ----- 9 -
- │    ├── cost: 321000.02
+ │    ├── cost: 327000.02
  │    ├── key: (1-3)
  │    ├── ordering: +3,+2
  │    ├── prune: (1-3)
@@ -1118,7 +1091,7 @@ except-all
  ├── left columns: no_w_id:3(int!null) no_d_id:2(int!null) no_o_id:1(int!null)
  ├── right columns: o_w_id:6(int) o_d_id:5(int) o_id:4(int)
  ├── stats: [rows=90000, distinct(1)=900, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0]
- ├── cost: 438000.07
+ ├── cost: 432000.07
  ├── scan new_order
  │    ├── save-table-name: consistency_08_scan_2
  │    ├── columns: no_o_id:1(int!null) no_d_id:2(int!null) no_w_id:3(int!null)
@@ -1133,7 +1106,7 @@ except-all
       ├── save-table-name: consistency_08_project_3
       ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null)
       ├── stats: [rows=90000, distinct(4)=2999, null(4)=0, distinct(5)=10, null(5)=0, distinct(6)=10, null(6)=0]
-      ├── cost: 339900.04
+      ├── cost: 333900.04
       ├── key: (4-6)
       ├── prune: (4-6)
       ├── interesting orderings: (+6,+5,-4)
@@ -1141,18 +1114,18 @@ except-all
            ├── save-table-name: consistency_08_select_4
            ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null) o_carrier_id:9(int)
            ├── stats: [rows=90000, distinct(4)=2999, null(4)=0, distinct(5)=10, null(5)=0, distinct(6)=10, null(6)=0, distinct(9)=1, null(9)=90000]
-           ├── cost: 339000.03
+           ├── cost: 333000.03
            ├── key: (4-6)
            ├── fd: ()-->(9)
            ├── prune: (4-6)
            ├── interesting orderings: (+6,+5,-4)
-           ├── scan "order"
+           ├── scan "order"@order_idx
            │    ├── save-table-name: consistency_08_scan_5
            │    ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null) o_carrier_id:9(int)
            │    ├── stats: [rows=300000, distinct(4)=2999, null(4)=0, distinct(5)=10, null(5)=0, distinct(6)=10, null(6)=0, distinct(9)=11, null(9)=90000]
            │    │   histogram(6)=  0 29280 0 29310 0 31560 0 30000 0 29220 0 30720 0 31110 0 30510 0 29070 0 29220
            │    │                <---- 0 ----- 1 ----- 2 ----- 3 ----- 4 ----- 5 ----- 6 ----- 7 ----- 8 ----- 9 -
-           │    ├── cost: 336000.02
+           │    ├── cost: 330000.02
            │    ├── key: (4-6)
            │    ├── fd: (4-6)-->(9)
            │    ├── prune: (4-6,9)
@@ -1199,12 +1172,12 @@ except-all
  ├── left columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null)
  ├── right columns: no_w_id:11(int) no_d_id:10(int) no_o_id:9(int)
  ├── stats: [rows=90000, distinct(1)=2999, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0]
- ├── cost: 438000.07
+ ├── cost: 432000.07
  ├── project
  │    ├── save-table-name: consistency_09_project_2
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
  │    ├── stats: [rows=90000, distinct(1)=2999, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0]
- │    ├── cost: 339900.04
+ │    ├── cost: 333900.04
  │    ├── key: (1-3)
  │    ├── prune: (1-3)
  │    ├── interesting orderings: (+3,+2,-1)
@@ -1212,18 +1185,18 @@ except-all
  │         ├── save-table-name: consistency_09_select_3
  │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │         ├── stats: [rows=90000, distinct(1)=2999, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=1, null(6)=90000]
- │         ├── cost: 339000.03
+ │         ├── cost: 333000.03
  │         ├── key: (1-3)
  │         ├── fd: ()-->(6)
  │         ├── prune: (1-3)
  │         ├── interesting orderings: (+3,+2,-1)
- │         ├── scan "order"
+ │         ├── scan "order"@order_idx
  │         │    ├── save-table-name: consistency_09_scan_4
  │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │         │    ├── stats: [rows=300000, distinct(1)=2999, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=11, null(6)=90000]
  │         │    │   histogram(3)=  0 29280 0 29310 0 31560 0 30000 0 29220 0 30720 0 31110 0 30510 0 29070 0 29220
  │         │    │                <---- 0 ----- 1 ----- 2 ----- 3 ----- 4 ----- 5 ----- 6 ----- 7 ----- 8 ----- 9 -
- │         │    ├── cost: 336000.02
+ │         │    ├── cost: 330000.02
  │         │    ├── key: (1-3)
  │         │    ├── fd: (1-3)-->(6)
  │         │    ├── prune: (1-3,6)
@@ -1433,77 +1406,58 @@ scalar-group-by
  │    ├── save-table-name: consistency_12_select_2
  │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:9(int) ol_d_id:10(int) ol_w_id:11(int)
  │    ├── stats: [rows=299711.333, distinct(1)=2999, null(1)=209767.952, distinct(2)=10, null(2)=209767.952, distinct(3)=10, null(3)=209767.952, distinct(9)=2999, null(9)=0, distinct(10)=10, null(10)=0, distinct(11)=10, null(11)=0]
- │    ├── full-join (merge)
- │    │    ├── save-table-name: consistency_12_merge_join_3
+ │    ├── full-join (hash)
+ │    │    ├── save-table-name: consistency_12_full_join_3
  │    │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:9(int) ol_d_id:10(int) ol_w_id:11(int)
- │    │    ├── left ordering: +3,+2,-1
- │    │    ├── right ordering: +11,+10,-9
  │    │    ├── stats: [rows=899134, distinct(1)=2999, null(1)=629303.857, distinct(2)=10, null(2)=629303.857, distinct(3)=10, null(3)=629303.857, distinct(9)=2999, null(9)=0, distinct(10)=10, null(10)=0, distinct(11)=10, null(11)=0]
  │    │    ├── project
  │    │    │    ├── save-table-name: consistency_12_project_4
+ │    │    │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null)
+ │    │    │    ├── stats: [rows=899134, distinct(9)=2999, null(9)=0, distinct(10)=10, null(10)=0, distinct(11)=10, null(11)=0]
+ │    │    │    └── select
+ │    │    │         ├── save-table-name: consistency_12_select_5
+ │    │    │         ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null) ol_delivery_d:15(timestamp)
+ │    │    │         ├── stats: [rows=899134, distinct(9)=2999, null(9)=0, distinct(10)=10, null(10)=0, distinct(11)=10, null(11)=0, distinct(15)=1, null(15)=899134]
+ │    │    │         ├── fd: ()-->(15)
+ │    │    │         ├── scan order_line
+ │    │    │         │    ├── save-table-name: consistency_12_scan_6
+ │    │    │         │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null) ol_delivery_d:15(timestamp)
+ │    │    │         │    └── stats: [rows=3001222, distinct(9)=2999, null(9)=0, distinct(10)=10, null(10)=0, distinct(11)=10, null(11)=0, distinct(15)=2, null(15)=899134]
+ │    │    │         │        histogram(11)=  0 3.1213e+05 0 2.7851e+05 0 2.9892e+05 0 3.0732e+05 0 2.9892e+05 0 2.9622e+05 0 3.1363e+05 0 2.8392e+05 0 2.9892e+05 0 3.1273e+05
+ │    │    │         │                      <------ 0 ---------- 1 ---------- 2 ---------- 3 ---------- 4 ---------- 5 ---------- 6 ---------- 7 ---------- 8 ---------- 9 ----
+ │    │    │         └── filters
+ │    │    │              └── ol_delivery_d IS NULL [type=bool, outer=(15), constraints=(/15: [/NULL - /NULL]; tight), fd=()-->(15)]
+ │    │    ├── project
+ │    │    │    ├── save-table-name: consistency_12_project_7
  │    │    │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
  │    │    │    ├── stats: [rows=90000, distinct(1)=2999, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0]
  │    │    │    ├── key: (1-3)
- │    │    │    ├── ordering: +3,+2,-1
  │    │    │    └── select
- │    │    │         ├── save-table-name: consistency_12_select_5
+ │    │    │         ├── save-table-name: consistency_12_select_8
  │    │    │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │    │    │         ├── stats: [rows=90000, distinct(1)=2999, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=1, null(6)=90000]
  │    │    │         ├── key: (1-3)
  │    │    │         ├── fd: ()-->(6)
- │    │    │         ├── ordering: +3,+2,-1 opt(6) [actual: +3,+2,-1]
- │    │    │         ├── scan "order"
- │    │    │         │    ├── save-table-name: consistency_12_scan_6
+ │    │    │         ├── scan "order"@order_idx
+ │    │    │         │    ├── save-table-name: consistency_12_scan_9
  │    │    │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │    │    │         │    ├── stats: [rows=300000, distinct(1)=2999, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=11, null(6)=90000]
  │    │    │         │    │   histogram(3)=  0 29280 0 29310 0 31560 0 30000 0 29220 0 30720 0 31110 0 30510 0 29070 0 29220
  │    │    │         │    │                <---- 0 ----- 1 ----- 2 ----- 3 ----- 4 ----- 5 ----- 6 ----- 7 ----- 8 ----- 9 -
  │    │    │         │    ├── key: (1-3)
- │    │    │         │    ├── fd: (1-3)-->(6)
- │    │    │         │    └── ordering: +3,+2,-1 opt(6) [actual: +3,+2,-1]
+ │    │    │         │    └── fd: (1-3)-->(6)
  │    │    │         └── filters
  │    │    │              └── o_carrier_id IS NULL [type=bool, outer=(6), constraints=(/6: [/NULL - /NULL]; tight), fd=()-->(6)]
- │    │    ├── project
- │    │    │    ├── save-table-name: consistency_12_project_7
- │    │    │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null)
- │    │    │    ├── stats: [rows=899134, distinct(9)=2999, null(9)=0, distinct(10)=10, null(10)=0, distinct(11)=10, null(11)=0]
- │    │    │    ├── ordering: +11,+10,-9
- │    │    │    └── select
- │    │    │         ├── save-table-name: consistency_12_select_8
- │    │    │         ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null) ol_delivery_d:15(timestamp)
- │    │    │         ├── stats: [rows=899134, distinct(9)=2999, null(9)=0, distinct(10)=10, null(10)=0, distinct(11)=10, null(11)=0, distinct(15)=1, null(15)=899134]
- │    │    │         ├── fd: ()-->(15)
- │    │    │         ├── ordering: +11,+10,-9 opt(15) [actual: +11,+10,-9]
- │    │    │         ├── scan order_line
- │    │    │         │    ├── save-table-name: consistency_12_scan_9
- │    │    │         │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null) ol_delivery_d:15(timestamp)
- │    │    │         │    ├── stats: [rows=3001222, distinct(9)=2999, null(9)=0, distinct(10)=10, null(10)=0, distinct(11)=10, null(11)=0, distinct(15)=2, null(15)=899134]
- │    │    │         │    │   histogram(11)=  0 3.1213e+05 0 2.7851e+05 0 2.9892e+05 0 3.0732e+05 0 2.9892e+05 0 2.9622e+05 0 3.1363e+05 0 2.8392e+05 0 2.9892e+05 0 3.1273e+05
- │    │    │         │    │                 <------ 0 ---------- 1 ---------- 2 ---------- 3 ---------- 4 ---------- 5 ---------- 6 ---------- 7 ---------- 8 ---------- 9 ----
- │    │    │         │    └── ordering: +11,+10,-9 opt(15) [actual: +11,+10,-9]
- │    │    │         └── filters
- │    │    │              └── ol_delivery_d IS NULL [type=bool, outer=(15), constraints=(/15: [/NULL - /NULL]; tight), fd=()-->(15)]
- │    │    └── filters (true)
+ │    │    └── filters
+ │    │         ├── ol_w_id = o_w_id [type=bool, outer=(3,11), constraints=(/3: (/NULL - ]; /11: (/NULL - ]), fd=(3)==(11), (11)==(3)]
+ │    │         ├── ol_d_id = o_d_id [type=bool, outer=(2,10), constraints=(/2: (/NULL - ]; /10: (/NULL - ]), fd=(2)==(10), (10)==(2)]
+ │    │         └── ol_o_id = o_id [type=bool, outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
  │    └── filters
  │         └── (ol_o_id IS NULL) OR (o_id IS NULL) [type=bool, outer=(1,9)]
  └── aggregations
       └── count-rows [type=int]
 
 stats table=consistency_12_select_5
-----
-column_names    row_count  distinct_count  null_count
-{o_carrier_id}  90000      1               90000
-{o_d_id}        90000      10              0
-{o_id}          90000      900             0
-{o_w_id}        90000      10              0
-~~~~
-column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{o_carrier_id}  90000.00       1.00           1.00                1.00                90000.00        1.00
-{o_d_id}        90000.00       1.00           10.00               1.00                0.00            1.00
-{o_id}          90000.00       1.00           2999.00             3.33 <==            0.00            1.00
-{o_w_id}        90000.00       1.00           10.00               1.00                0.00            1.00
-
-stats table=consistency_12_select_8
 ----
 column_names     row_count  distinct_count  null_count
 {ol_d_id}        899134     10              0
@@ -1517,7 +1471,21 @@ column_names     row_count_est  row_count_err  distinct_count_est  distinct_coun
 {ol_o_id}        899134.00      1.00           2999.00             3.33 <==            0.00            1.00
 {ol_w_id}        899134.00      1.00           10.00               1.00                0.00            1.00
 
-stats table=consistency_12_merge_join_3
+stats table=consistency_12_select_8
+----
+column_names    row_count  distinct_count  null_count
+{o_carrier_id}  90000      1               90000
+{o_d_id}        90000      10              0
+{o_id}          90000      900             0
+{o_w_id}        90000      10              0
+~~~~
+column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
+{o_carrier_id}  90000.00       1.00           1.00                1.00                90000.00        1.00
+{o_d_id}        90000.00       1.00           10.00               1.00                0.00            1.00
+{o_id}          90000.00       1.00           2999.00             3.33 <==            0.00            1.00
+{o_w_id}        90000.00       1.00           10.00               1.00                0.00            1.00
+
+stats table=consistency_12_full_join_3
 ----
 column_names  row_count  distinct_count  null_count
 {o_d_id}      899134     10              0

--- a/pkg/sql/opt/testutils/opttester/testdata/tpcc_schema
+++ b/pkg/sql/opt/testutils/opttester/testdata/tpcc_schema
@@ -94,7 +94,7 @@ CREATE TABLE "order"
     o_ol_cnt     integer,
     o_all_local  integer,
     primary key (o_w_id, o_d_id, o_id DESC),
-    unique index order_idx (o_w_id, o_d_id, o_c_id, o_id DESC),
+    unique index order_idx (o_w_id, o_d_id, o_c_id, o_id DESC) storing (o_entry_d, o_carrier_id),
     foreign key (o_w_id, o_d_id, o_c_id) references customer (c_w_id, c_d_id, c_id)
 ) interleave in parent district (o_w_id, o_d_id)
 ----

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -1245,28 +1245,20 @@ project
  ├── columns: o_id:1(int!null) o_entry_d:5(timestamp) o_carrier_id:6(int)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=1]
- ├── cost: 5.27
+ ├── cost: 1.15
  ├── key: ()
  ├── fd: ()-->(1,5,6)
  ├── prune: (1,5,6)
- └── index-join order
+ └── scan "order"@order_idx
       ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_c_id:4(int!null) o_entry_d:5(timestamp) o_carrier_id:6(int)
-      ├── cardinality: [0 - 1]
+      ├── constraint: /3/2/4/-1: [/10/100/50 - /10/100/50]
+      ├── limit: 1
       ├── stats: [rows=1]
-      ├── cost: 5.25
+      ├── cost: 1.13
       ├── key: ()
       ├── fd: ()-->(1-6)
-      ├── interesting orderings: (+3,+2,-1) (+3,+2,+4,-1)
-      └── scan "order"@order_idx
-           ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_c_id:4(int!null)
-           ├── constraint: /3/2/4/-1: [/10/100/50 - /10/100/50]
-           ├── limit: 1
-           ├── stats: [rows=1, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(4)=1, null(4)=0]
-           ├── cost: 1.09
-           ├── key: ()
-           ├── fd: ()-->(1-4)
-           ├── prune: (1-4)
-           └── interesting orderings: (+3,+2,-1) (+3,+2,+4,-1)
+      ├── prune: (1-6)
+      └── interesting orderings: (+3,+2,-1) (+3,+2,+4,-1)
 
 opt format=hide-qual
 SELECT ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d
@@ -1793,7 +1785,7 @@ group-by
  ├── columns: max:9(int)  [hidden: o_d_id:2(int!null) o_w_id:3(int!null)]
  ├── grouping columns: o_d_id:2(int!null) o_w_id:3(int!null)
  ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0]
- ├── cost: 3300010.03
+ ├── cost: 3360010.03
  ├── key: (2,3)
  ├── fd: (2,3)-->(9)
  ├── ordering: +3,+2
@@ -1802,7 +1794,7 @@ group-by
  ├── scan "order"@order_idx
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
  │    ├── stats: [rows=3000000, distinct(2,3)=1000, null(2,3)=0]
- │    ├── cost: 3210000.02
+ │    ├── cost: 3270000.02
  │    ├── key: (1-3)
  │    ├── ordering: +3,+2
  │    ├── prune: (1-3)
@@ -1941,7 +1933,7 @@ except-all
  ├── left columns: no_w_id:3(int!null) no_d_id:2(int!null) no_o_id:1(int!null)
  ├── right columns: o_w_id:6(int) o_d_id:5(int) o_id:4(int)
  ├── stats: [rows=900000]
- ├── cost: 4380000.07
+ ├── cost: 4320000.07
  ├── scan new_order
  │    ├── columns: no_o_id:1(int!null) no_d_id:2(int!null) no_w_id:3(int!null)
  │    ├── stats: [rows=900000]
@@ -1952,22 +1944,22 @@ except-all
  └── project
       ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null)
       ├── stats: [rows=900000]
-      ├── cost: 3399000.04
+      ├── cost: 3339000.04
       ├── key: (4-6)
       ├── prune: (4-6)
       ├── interesting orderings: (+6,+5,-4)
       └── select
            ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null) o_carrier_id:9(int)
            ├── stats: [rows=900000, distinct(9)=1, null(9)=900000]
-           ├── cost: 3390000.03
+           ├── cost: 3330000.03
            ├── key: (4-6)
            ├── fd: ()-->(9)
            ├── prune: (4-6)
            ├── interesting orderings: (+6,+5,-4)
-           ├── scan "order"
+           ├── scan "order"@order_idx
            │    ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null) o_carrier_id:9(int)
            │    ├── stats: [rows=3000000, distinct(4)=3000, null(4)=0, distinct(5)=10, null(5)=0, distinct(6)=100, null(6)=0, distinct(9)=10, null(9)=900000]
-           │    ├── cost: 3360000.02
+           │    ├── cost: 3300000.02
            │    ├── key: (4-6)
            │    ├── fd: (4-6)-->(9)
            │    ├── prune: (4-6,9)
@@ -1987,26 +1979,26 @@ except-all
  ├── left columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null)
  ├── right columns: no_w_id:11(int) no_d_id:10(int) no_o_id:9(int)
  ├── stats: [rows=900000]
- ├── cost: 4380000.07
+ ├── cost: 4320000.07
  ├── project
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
  │    ├── stats: [rows=900000]
- │    ├── cost: 3399000.04
+ │    ├── cost: 3339000.04
  │    ├── key: (1-3)
  │    ├── prune: (1-3)
  │    ├── interesting orderings: (+3,+2,-1)
  │    └── select
  │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │         ├── stats: [rows=900000, distinct(6)=1, null(6)=900000]
- │         ├── cost: 3390000.03
+ │         ├── cost: 3330000.03
  │         ├── key: (1-3)
  │         ├── fd: ()-->(6)
  │         ├── prune: (1-3)
  │         ├── interesting orderings: (+3,+2,-1)
- │         ├── scan "order"
+ │         ├── scan "order"@order_idx
  │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │         │    ├── stats: [rows=3000000, distinct(1)=3000, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=100, null(3)=0, distinct(6)=10, null(6)=900000]
- │         │    ├── cost: 3360000.02
+ │         │    ├── cost: 3300000.02
  │         │    ├── key: (1-3)
  │         │    ├── fd: (1-3)-->(6)
  │         │    ├── prune: (1-3,6)

--- a/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
@@ -1248,28 +1248,20 @@ project
  ├── columns: o_id:1(int!null) o_entry_d:5(timestamp) o_carrier_id:6(int)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=1]
- ├── cost: 5.27
+ ├── cost: 1.15
  ├── key: ()
  ├── fd: ()-->(1,5,6)
  ├── prune: (1,5,6)
- └── index-join order
+ └── scan "order"@order_idx
       ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_c_id:4(int!null) o_entry_d:5(timestamp) o_carrier_id:6(int)
-      ├── cardinality: [0 - 1]
+      ├── constraint: /3/2/4/-1: [/10/100/50 - /10/100/50]
+      ├── limit: 1
       ├── stats: [rows=1]
-      ├── cost: 5.25
+      ├── cost: 1.13
       ├── key: ()
       ├── fd: ()-->(1-6)
-      ├── interesting orderings: (+3,+2,-1) (+3,+2,+4,-1)
-      └── scan "order"@order_idx
-           ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_c_id:4(int!null)
-           ├── constraint: /3/2/4/-1: [/10/100/50 - /10/100/50]
-           ├── limit: 1
-           ├── stats: [rows=1, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(4)=1, null(4)=0]
-           ├── cost: 1.09
-           ├── key: ()
-           ├── fd: ()-->(1-4)
-           ├── prune: (1-4)
-           └── interesting orderings: (+3,+2,-1) (+3,+2,+4,-1)
+      ├── prune: (1-6)
+      └── interesting orderings: (+3,+2,-1) (+3,+2,+4,-1)
 
 opt format=hide-qual
 SELECT ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d
@@ -1795,7 +1787,7 @@ group-by
  ├── columns: max:9(int)  [hidden: o_d_id:2(int!null) o_w_id:3(int!null)]
  ├── grouping columns: o_d_id:2(int!null) o_w_id:3(int!null)
  ├── stats: [rows=100, distinct(2,3)=100, null(2,3)=0]
- ├── cost: 72165182
+ ├── cost: 73477276.2
  ├── key: (2,3)
  ├── fd: (2,3)-->(9)
  ├── ordering: +3,+2
@@ -1804,7 +1796,7 @@ group-by
  ├── scan "order"@order_idx
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
  │    ├── stats: [rows=65604710, distinct(2,3)=100, null(2,3)=0]
- │    ├── cost: 70197039.7
+ │    ├── cost: 71509133.9
  │    ├── key: (1-3)
  │    ├── ordering: +3,+2
  │    ├── prune: (1-3)
@@ -1943,7 +1935,7 @@ except-all
  ├── left columns: no_w_id:3(int!null) no_d_id:2(int!null) no_o_id:1(int!null)
  ├── right columns: o_w_id:6(int) o_d_id:5(int) o_id:4(int)
  ├── stats: [rows=11322]
- ├── cost: 74145776.6
+ ├── cost: 72833682.4
  ├── scan new_order
  │    ├── columns: no_o_id:1(int!null) no_d_id:2(int!null) no_w_id:3(int!null)
  │    ├── stats: [rows=11322]
@@ -1954,22 +1946,22 @@ except-all
  └── project
       ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null)
       ├── stats: [rows=11322]
-      ├── cost: 74133435.6
+      ├── cost: 72821341.4
       ├── key: (4-6)
       ├── prune: (4-6)
       ├── interesting orderings: (+6,+5,-4)
       └── select
            ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null) o_carrier_id:9(int)
            ├── stats: [rows=11322, distinct(9)=1, null(9)=11322]
-           ├── cost: 74133322.3
+           ├── cost: 72821228.1
            ├── key: (4-6)
            ├── fd: ()-->(9)
            ├── prune: (4-6)
            ├── interesting orderings: (+6,+5,-4)
-           ├── scan "order"
+           ├── scan "order"@order_idx
            │    ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null) o_carrier_id:9(int)
            │    ├── stats: [rows=65604710, distinct(4)=659249, null(4)=0, distinct(5)=10, null(5)=0, distinct(6)=10, null(6)=0, distinct(9)=10, null(9)=11322]
-           │    ├── cost: 73477275.2
+           │    ├── cost: 72165181
            │    ├── key: (4-6)
            │    ├── fd: (4-6)-->(9)
            │    ├── prune: (4-6,9)
@@ -1989,26 +1981,26 @@ except-all
  ├── left columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null)
  ├── right columns: no_w_id:11(int) no_d_id:10(int) no_o_id:9(int)
  ├── stats: [rows=11322]
- ├── cost: 74145776.6
+ ├── cost: 72833682.4
  ├── project
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
  │    ├── stats: [rows=11322]
- │    ├── cost: 74133435.6
+ │    ├── cost: 72821341.4
  │    ├── key: (1-3)
  │    ├── prune: (1-3)
  │    ├── interesting orderings: (+3,+2,-1)
  │    └── select
  │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │         ├── stats: [rows=11322, distinct(6)=1, null(6)=11322]
- │         ├── cost: 74133322.3
+ │         ├── cost: 72821228.1
  │         ├── key: (1-3)
  │         ├── fd: ()-->(6)
  │         ├── prune: (1-3)
  │         ├── interesting orderings: (+3,+2,-1)
- │         ├── scan "order"
+ │         ├── scan "order"@order_idx
  │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │         │    ├── stats: [rows=65604710, distinct(1)=659249, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=10, null(6)=11322]
- │         │    ├── cost: 73477275.2
+ │         │    ├── cost: 72165181
  │         │    ├── key: (1-3)
  │         │    ├── fd: (1-3)-->(6)
  │         │    ├── prune: (1-3,6)
@@ -2138,55 +2130,25 @@ scalar-group-by
  ├── columns: count:19(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 818077920
+ ├── cost: 816766176
  ├── key: ()
  ├── fd: ()-->(19)
  ├── prune: (19)
  ├── select
  │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:9(int) ol_d_id:10(int) ol_w_id:11(int)
  │    ├── stats: [rows=39097.1049]
- │    ├── cost: 818077529
- │    ├── full-join (merge)
+ │    ├── cost: 816765785
+ │    ├── interesting orderings: (+11,+10,-9) (+3,+2,-1)
+ │    ├── full-join (hash)
  │    │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:9(int) ol_d_id:10(int) ol_w_id:11(int)
- │    │    ├── left ordering: +3,+2,-1
- │    │    ├── right ordering: +11,+10,-9
  │    │    ├── stats: [rows=117291.315]
- │    │    ├── cost: 818076356
- │    │    ├── project
- │    │    │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
- │    │    │    ├── stats: [rows=11322, distinct(1)=11226.2921, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0]
- │    │    │    ├── cost: 74133435.6
- │    │    │    ├── key: (1-3)
- │    │    │    ├── ordering: +3,+2,-1
- │    │    │    ├── prune: (1-3)
- │    │    │    ├── interesting orderings: (+3,+2,-1)
- │    │    │    └── select
- │    │    │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
- │    │    │         ├── stats: [rows=11322, distinct(1)=11226.2921, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=1, null(6)=11322]
- │    │    │         ├── cost: 74133322.3
- │    │    │         ├── key: (1-3)
- │    │    │         ├── fd: ()-->(6)
- │    │    │         ├── ordering: +3,+2,-1 opt(6) [actual: +3,+2,-1]
- │    │    │         ├── prune: (1-3)
- │    │    │         ├── interesting orderings: (+3,+2,-1)
- │    │    │         ├── scan "order"
- │    │    │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
- │    │    │         │    ├── stats: [rows=65604710, distinct(1)=659249, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=10, null(6)=11322]
- │    │    │         │    ├── cost: 73477275.2
- │    │    │         │    ├── key: (1-3)
- │    │    │         │    ├── fd: (1-3)-->(6)
- │    │    │         │    ├── ordering: +3,+2,-1 opt(6) [actual: +3,+2,-1]
- │    │    │         │    ├── prune: (1-3,6)
- │    │    │         │    └── interesting orderings: (+3,+2,-1)
- │    │    │         └── filters
- │    │    │              └── is [type=bool, outer=(6), constraints=(/6: [/NULL - /NULL]; tight), fd=()-->(6)]
- │    │    │                   ├── variable: o_carrier_id [type=int]
- │    │    │                   └── null [type=unknown]
+ │    │    ├── cost: 816764612
+ │    │    ├── reject-nulls: (1-3,9-11)
+ │    │    ├── interesting orderings: (+11,+10,-9) (+3,+2,-1)
  │    │    ├── project
  │    │    │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null)
  │    │    │    ├── stats: [rows=106092, distinct(9)=97907.0099, null(9)=0, distinct(10)=10, null(10)=0, distinct(11)=10, null(11)=0]
  │    │    │    ├── cost: 743940574
- │    │    │    ├── ordering: +11,+10,-9
  │    │    │    ├── prune: (9-11)
  │    │    │    ├── interesting orderings: (+11,+10,-9)
  │    │    │    └── select
@@ -2194,21 +2156,55 @@ scalar-group-by
  │    │    │         ├── stats: [rows=106092, distinct(9)=97907.0099, null(9)=0, distinct(10)=10, null(10)=0, distinct(11)=10, null(11)=0, distinct(15)=1, null(15)=106092]
  │    │    │         ├── cost: 743939513
  │    │    │         ├── fd: ()-->(15)
- │    │    │         ├── ordering: +11,+10,-9 opt(15) [actual: +11,+10,-9]
  │    │    │         ├── prune: (9-11)
  │    │    │         ├── interesting orderings: (+11,+10,-9)
  │    │    │         ├── scan order_line
  │    │    │         │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null) ol_delivery_d:15(timestamp)
  │    │    │         │    ├── stats: [rows=646903924, distinct(9)=651111, null(9)=0, distinct(10)=10, null(10)=0, distinct(11)=10, null(11)=0, distinct(15)=2351500, null(15)=106092]
  │    │    │         │    ├── cost: 737470473
- │    │    │         │    ├── ordering: +11,+10,-9 opt(15) [actual: +11,+10,-9]
  │    │    │         │    ├── prune: (9-11,15)
  │    │    │         │    └── interesting orderings: (+11,+10,-9)
  │    │    │         └── filters
  │    │    │              └── is [type=bool, outer=(15), constraints=(/15: [/NULL - /NULL]; tight), fd=()-->(15)]
  │    │    │                   ├── variable: ol_delivery_d [type=timestamp]
  │    │    │                   └── null [type=unknown]
- │    │    └── filters (true)
+ │    │    ├── project
+ │    │    │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
+ │    │    │    ├── stats: [rows=11322, distinct(1)=11226.2921, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0]
+ │    │    │    ├── cost: 72821341.4
+ │    │    │    ├── key: (1-3)
+ │    │    │    ├── prune: (1-3)
+ │    │    │    ├── interesting orderings: (+3,+2,-1)
+ │    │    │    └── select
+ │    │    │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
+ │    │    │         ├── stats: [rows=11322, distinct(1)=11226.2921, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=1, null(6)=11322]
+ │    │    │         ├── cost: 72821228.1
+ │    │    │         ├── key: (1-3)
+ │    │    │         ├── fd: ()-->(6)
+ │    │    │         ├── prune: (1-3)
+ │    │    │         ├── interesting orderings: (+3,+2,-1)
+ │    │    │         ├── scan "order"@order_idx
+ │    │    │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
+ │    │    │         │    ├── stats: [rows=65604710, distinct(1)=659249, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=10, null(6)=11322]
+ │    │    │         │    ├── cost: 72165181
+ │    │    │         │    ├── key: (1-3)
+ │    │    │         │    ├── fd: (1-3)-->(6)
+ │    │    │         │    ├── prune: (1-3,6)
+ │    │    │         │    └── interesting orderings: (+3,+2,-1)
+ │    │    │         └── filters
+ │    │    │              └── is [type=bool, outer=(6), constraints=(/6: [/NULL - /NULL]; tight), fd=()-->(6)]
+ │    │    │                   ├── variable: o_carrier_id [type=int]
+ │    │    │                   └── null [type=unknown]
+ │    │    └── filters
+ │    │         ├── eq [type=bool, outer=(3,11), constraints=(/3: (/NULL - ]; /11: (/NULL - ]), fd=(3)==(11), (11)==(3)]
+ │    │         │    ├── variable: ol_w_id [type=int]
+ │    │         │    └── variable: o_w_id [type=int]
+ │    │         ├── eq [type=bool, outer=(2,10), constraints=(/2: (/NULL - ]; /10: (/NULL - ]), fd=(2)==(10), (10)==(2)]
+ │    │         │    ├── variable: ol_d_id [type=int]
+ │    │         │    └── variable: o_d_id [type=int]
+ │    │         └── eq [type=bool, outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
+ │    │              ├── variable: ol_o_id [type=int]
+ │    │              └── variable: o_id [type=int]
  │    └── filters
  │         └── or [type=bool, outer=(1,9)]
  │              ├── is [type=bool]

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -1242,28 +1242,20 @@ project
  ├── columns: o_id:1(int!null) o_entry_d:5(timestamp) o_carrier_id:6(int)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=0.001]
- ├── cost: 0.03524
+ ├── cost: 0.02113
  ├── key: ()
  ├── fd: ()-->(1,5,6)
  ├── prune: (1,5,6)
- └── index-join order
+ └── scan "order"@order_idx
       ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_c_id:4(int!null) o_entry_d:5(timestamp) o_carrier_id:6(int)
-      ├── cardinality: [0 - 1]
+      ├── constraint: /3/2/4/-1: [/10/100/50 - /10/100/50]
+      ├── limit: 1
       ├── stats: [rows=0.001]
-      ├── cost: 0.02523
+      ├── cost: 0.01112
       ├── key: ()
       ├── fd: ()-->(1-6)
-      ├── interesting orderings: (+3,+2,-1) (+3,+2,+4,-1)
-      └── scan "order"@order_idx
-           ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_c_id:4(int!null)
-           ├── constraint: /3/2/4/-1: [/10/100/50 - /10/100/50]
-           ├── limit: 1
-           ├── stats: [rows=0.001, distinct(2)=0.001, null(2)=0, distinct(3)=0.001, null(3)=0, distinct(4)=0.001, null(4)=0]
-           ├── cost: 0.01108
-           ├── key: ()
-           ├── fd: ()-->(1-4)
-           ├── prune: (1-4)
-           └── interesting orderings: (+3,+2,-1) (+3,+2,+4,-1)
+      ├── prune: (1-6)
+      └── interesting orderings: (+3,+2,-1) (+3,+2,+4,-1)
 
 opt format=hide-qual
 SELECT ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d
@@ -1780,7 +1772,7 @@ group-by
  ├── columns: max:9(int)  [hidden: o_d_id:2(int!null) o_w_id:3(int!null)]
  ├── grouping columns: o_d_id:2(int!null) o_w_id:3(int!null)
  ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0]
- ├── cost: 1110.03
+ ├── cost: 1130.03
  ├── key: (2,3)
  ├── fd: (2,3)-->(9)
  ├── ordering: +3,+2
@@ -1789,7 +1781,7 @@ group-by
  ├── scan "order"@order_idx
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
  │    ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0]
- │    ├── cost: 1070.02
+ │    ├── cost: 1090.02
  │    ├── key: (1-3)
  │    ├── ordering: +3,+2
  │    ├── prune: (1-3)
@@ -1921,7 +1913,7 @@ except-all
  ├── left columns: no_w_id:3(int!null) no_d_id:2(int!null) no_o_id:1(int!null)
  ├── right columns: o_w_id:6(int) o_d_id:5(int) o_id:4(int)
  ├── stats: [rows=1000]
- ├── cost: 2210.27
+ ├── cost: 2190.27
  ├── scan new_order
  │    ├── columns: no_o_id:1(int!null) no_d_id:2(int!null) no_w_id:3(int!null)
  │    ├── stats: [rows=1000]
@@ -1932,22 +1924,22 @@ except-all
  └── project
       ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null)
       ├── stats: [rows=10]
-      ├── cost: 1130.14
+      ├── cost: 1110.14
       ├── key: (4-6)
       ├── prune: (4-6)
       ├── interesting orderings: (+6,+5,-4)
       └── select
            ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null) o_carrier_id:9(int)
            ├── stats: [rows=10, distinct(9)=1, null(9)=10]
-           ├── cost: 1130.03
+           ├── cost: 1110.03
            ├── key: (4-6)
            ├── fd: ()-->(9)
            ├── prune: (4-6)
            ├── interesting orderings: (+6,+5,-4)
-           ├── scan "order"
+           ├── scan "order"@order_idx
            │    ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null) o_carrier_id:9(int)
            │    ├── stats: [rows=1000, distinct(4)=100, null(4)=0, distinct(5)=100, null(5)=0, distinct(6)=100, null(6)=0, distinct(9)=100, null(9)=10]
-           │    ├── cost: 1120.02
+           │    ├── cost: 1100.02
            │    ├── key: (4-6)
            │    ├── fd: (4-6)-->(9)
            │    ├── prune: (4-6,9)
@@ -1967,26 +1959,26 @@ except-all
  ├── left columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null)
  ├── right columns: no_w_id:11(int) no_d_id:10(int) no_o_id:9(int)
  ├── stats: [rows=10]
- ├── cost: 2200.37
+ ├── cost: 2180.37
  ├── project
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
  │    ├── stats: [rows=10]
- │    ├── cost: 1130.14
+ │    ├── cost: 1110.14
  │    ├── key: (1-3)
  │    ├── prune: (1-3)
  │    ├── interesting orderings: (+3,+2,-1)
  │    └── select
  │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │         ├── stats: [rows=10, distinct(6)=1, null(6)=10]
- │         ├── cost: 1130.03
+ │         ├── cost: 1110.03
  │         ├── key: (1-3)
  │         ├── fd: ()-->(6)
  │         ├── prune: (1-3)
  │         ├── interesting orderings: (+3,+2,-1)
- │         ├── scan "order"
+ │         ├── scan "order"@order_idx
  │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │         │    ├── stats: [rows=1000, distinct(1)=100, null(1)=0, distinct(2)=100, null(2)=0, distinct(3)=100, null(3)=0, distinct(6)=100, null(6)=10]
- │         │    ├── cost: 1120.02
+ │         │    ├── cost: 1100.02
  │         │    ├── key: (1-3)
  │         │    ├── fd: (1-3)-->(6)
  │         │    ├── prune: (1-3,6)
@@ -2116,44 +2108,42 @@ scalar-group-by
  ├── columns: count:19(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 2280.984
+ ├── cost: 2261.084
  ├── key: ()
  ├── fd: ()-->(19)
  ├── prune: (19)
  ├── select
  │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:9(int) ol_d_id:10(int) ol_w_id:11(int)
  │    ├── stats: [rows=6.62853719]
- │    ├── cost: 2280.89771
- │    ├── full-join (merge)
+ │    ├── cost: 2260.99771
+ │    ├── interesting orderings: (+3,+2,-1) (+11,+10,-9)
+ │    ├── full-join (hash)
  │    │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:9(int) ol_d_id:10(int) ol_w_id:11(int)
- │    │    ├── left ordering: +3,+2,-1
- │    │    ├── right ordering: +11,+10,-9
  │    │    ├── stats: [rows=19.8856116]
- │    │    ├── cost: 2280.68886
+ │    │    ├── cost: 2260.78886
+ │    │    ├── reject-nulls: (1-3,9-11)
+ │    │    ├── interesting orderings: (+3,+2,-1) (+11,+10,-9)
  │    │    ├── project
  │    │    │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
  │    │    │    ├── stats: [rows=10, distinct(1)=9.5617925, null(1)=0, distinct(2)=9.5617925, null(2)=0, distinct(3)=9.5617925, null(3)=0]
- │    │    │    ├── cost: 1130.14
+ │    │    │    ├── cost: 1110.14
  │    │    │    ├── key: (1-3)
- │    │    │    ├── ordering: +3,+2,-1
  │    │    │    ├── prune: (1-3)
  │    │    │    ├── interesting orderings: (+3,+2,-1)
  │    │    │    └── select
  │    │    │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │    │    │         ├── stats: [rows=10, distinct(1)=9.5617925, null(1)=0, distinct(2)=9.5617925, null(2)=0, distinct(3)=9.5617925, null(3)=0, distinct(6)=1, null(6)=10]
- │    │    │         ├── cost: 1130.03
+ │    │    │         ├── cost: 1110.03
  │    │    │         ├── key: (1-3)
  │    │    │         ├── fd: ()-->(6)
- │    │    │         ├── ordering: +3,+2,-1 opt(6) [actual: +3,+2,-1]
  │    │    │         ├── prune: (1-3)
  │    │    │         ├── interesting orderings: (+3,+2,-1)
- │    │    │         ├── scan "order"
+ │    │    │         ├── scan "order"@order_idx
  │    │    │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │    │    │         │    ├── stats: [rows=1000, distinct(1)=100, null(1)=0, distinct(2)=100, null(2)=0, distinct(3)=100, null(3)=0, distinct(6)=100, null(6)=10]
- │    │    │         │    ├── cost: 1120.02
+ │    │    │         │    ├── cost: 1100.02
  │    │    │         │    ├── key: (1-3)
  │    │    │         │    ├── fd: (1-3)-->(6)
- │    │    │         │    ├── ordering: +3,+2,-1 opt(6) [actual: +3,+2,-1]
  │    │    │         │    ├── prune: (1-3,6)
  │    │    │         │    └── interesting orderings: (+3,+2,-1)
  │    │    │         └── filters
@@ -2164,7 +2154,6 @@ scalar-group-by
  │    │    │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null)
  │    │    │    ├── stats: [rows=10, distinct(9)=9.5617925, null(9)=0, distinct(10)=9.5617925, null(10)=0, distinct(11)=9.5617925, null(11)=0]
  │    │    │    ├── cost: 1150.14
- │    │    │    ├── ordering: +11,+10,-9
  │    │    │    ├── prune: (9-11)
  │    │    │    ├── interesting orderings: (+11,+10,-9)
  │    │    │    └── select
@@ -2172,21 +2161,28 @@ scalar-group-by
  │    │    │         ├── stats: [rows=10, distinct(9)=9.5617925, null(9)=0, distinct(10)=9.5617925, null(10)=0, distinct(11)=9.5617925, null(11)=0, distinct(15)=1, null(15)=10]
  │    │    │         ├── cost: 1150.03
  │    │    │         ├── fd: ()-->(15)
- │    │    │         ├── ordering: +11,+10,-9 opt(15) [actual: +11,+10,-9]
  │    │    │         ├── prune: (9-11)
  │    │    │         ├── interesting orderings: (+11,+10,-9)
  │    │    │         ├── scan order_line
  │    │    │         │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null) ol_delivery_d:15(timestamp)
  │    │    │         │    ├── stats: [rows=1000, distinct(9)=100, null(9)=0, distinct(10)=100, null(10)=0, distinct(11)=100, null(11)=0, distinct(15)=100, null(15)=10]
  │    │    │         │    ├── cost: 1140.02
- │    │    │         │    ├── ordering: +11,+10,-9 opt(15) [actual: +11,+10,-9]
  │    │    │         │    ├── prune: (9-11,15)
  │    │    │         │    └── interesting orderings: (+11,+10,-9)
  │    │    │         └── filters
  │    │    │              └── is [type=bool, outer=(15), constraints=(/15: [/NULL - /NULL]; tight), fd=()-->(15)]
  │    │    │                   ├── variable: ol_delivery_d [type=timestamp]
  │    │    │                   └── null [type=unknown]
- │    │    └── filters (true)
+ │    │    └── filters
+ │    │         ├── eq [type=bool, outer=(3,11), constraints=(/3: (/NULL - ]; /11: (/NULL - ]), fd=(3)==(11), (11)==(3)]
+ │    │         │    ├── variable: ol_w_id [type=int]
+ │    │         │    └── variable: o_w_id [type=int]
+ │    │         ├── eq [type=bool, outer=(2,10), constraints=(/2: (/NULL - ]; /10: (/NULL - ]), fd=(2)==(10), (10)==(2)]
+ │    │         │    ├── variable: ol_d_id [type=int]
+ │    │         │    └── variable: o_d_id [type=int]
+ │    │         └── eq [type=bool, outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
+ │    │              ├── variable: ol_o_id [type=int]
+ │    │              └── variable: o_id [type=int]
  │    └── filters
  │         └── or [type=bool, outer=(1,9)]
  │              ├── is [type=bool]

--- a/pkg/workload/tpcc/ddls.go
+++ b/pkg/workload/tpcc/ddls.go
@@ -106,7 +106,7 @@ const (
 		o_ol_cnt     integer,
 		o_all_local  integer,
 		primary key  (o_w_id, o_d_id, o_id DESC),
-		unique index order_idx (o_w_id, o_d_id, o_c_id, o_id DESC)
+		unique index order_idx (o_w_id, o_d_id, o_c_id, o_id DESC) storing (o_entry_d, o_carrier_id)
 	)`
 	tpccOrderSchemaInterleaveSuffix = `
 		interleave in parent district (o_w_id, o_d_id)`


### PR DESCRIPTION
This is being done in http://www.tpc.org/results/fdr/tpcc/ant_financial~tpcc~alibaba_cloud_elastic_compute_service_cluster~fdr~2019-10-01~v01.pdf.
OrderStatus transactions are only 4.010% of the workload, but the fact
that OceanBase did this indicates that it's worth optimizing.

See `xform/testdata/external/tpcc` for the difference in the query plan.

I'm running this now to see if it makes a noticeable difference.

Release note: None