### PR TITLE
ccl: add workloadccl to imports

### DIFF
--- a/pkg/ccl/ccl_init.go
+++ b/pkg/ccl/ccl_init.go
@@ -24,4 +24,5 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/roleccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl"
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/workloadccl"
 )

--- a/pkg/ccl/workloadccl/bench_test.go
+++ b/pkg/ccl/workloadccl/bench_test.go
@@ -6,7 +6,7 @@
 //
 //     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
 
-package workloadccl
+package workloadccl_test
 
 import (
 	"context"
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl"
+	"github.com/cockroachdb/cockroach/pkg/ccl/workloadccl"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/workload"
@@ -34,7 +35,7 @@ func benchmarkImportFixture(b *testing.B, gen workload.Generator) {
 		b.StartTimer()
 		const filesPerNode = 1
 		const noInjectStats, csvServer = false, ``
-		importBytes, err := ImportFixture(
+		importBytes, err := workloadccl.ImportFixture(
 			ctx, db, gen, `d`, filesPerNode, noInjectStats, csvServer,
 		)
 		require.NoError(b, err)


### PR DESCRIPTION
I noticed that the `cockroach-short` binary did not allow `workload init
X --data-loader=IMPORT` and tracked it down to this missing import. It's
probably pulled in accidentally in the full binary.

Release note: None