### PR TITLE
storage/engine: add Pebble benchmarks for ComputeStats and FindSplitKey

### DIFF
--- a/pkg/storage/engine/bench_pebble_test.go
+++ b/pkg/storage/engine/bench_pebble_test.go
@@ -1,0 +1,107 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package engine
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/vfs"
+)
+
+func newPebbleOptions(fs vfs.FS) *pebble.Options {
+	return &pebble.Options{
+		Cache:                       pebble.NewCache(testCacheSize),
+		FS:                          fs,
+		MemTableSize:                64 << 20,
+		MemTableStopWritesThreshold: 4,
+		MinFlushRate:                4 << 20,
+		L0CompactionThreshold:       2,
+		L0StopWritesThreshold:       400,
+		LBaseMaxBytes:               64 << 20, // 64 MB
+		Levels: []pebble.LevelOptions{{
+			BlockSize: 32 << 10,
+		}},
+	}
+}
+
+func setupMVCCPebble(b testing.TB, dir string) Engine {
+	peb, err := NewPebble(dir, newPebbleOptions(vfs.Default))
+	if err != nil {
+		b.Fatalf("could not create new pebble instance at %s: %+v", dir, err)
+	}
+	return peb
+}
+
+func setupMVCCInMemPebble(b testing.TB, loc string) Engine {
+	peb, err := NewPebble("", newPebbleOptions(vfs.NewMem()))
+	if err != nil {
+		b.Fatalf("could not create new in-mem pebble instance: %+v", err)
+	}
+	return peb
+}
+
+func BenchmarkMVCCComputeStats_Pebble(b *testing.B) {
+	if testing.Short() {
+		b.Skip("short flag")
+	}
+	ctx := context.Background()
+	for _, valueSize := range []int{8, 32, 256} {
+		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
+			runMVCCComputeStats(ctx, b, setupMVCCPebble, valueSize)
+		})
+	}
+}
+
+func BenchmarkMVCCFindSplitKey_Pebble(b *testing.B) {
+	ctx := context.Background()
+	for _, valueSize := range []int{32} {
+		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
+			runMVCCFindSplitKey(ctx, b, setupMVCCPebble, valueSize)
+		})
+	}
+}
+
+func BenchmarkMVCCGarbageCollect_Pebble(b *testing.B) {
+	if testing.Short() {
+		b.Skip("short flag")
+	}
+
+	// NB: To debug #16068, test only 128-128-15000-6.
+	ctx := context.Background()
+	for _, keySize := range []int{128} {
+		b.Run(fmt.Sprintf("keySize=%d", keySize), func(b *testing.B) {
+			for _, valSize := range []int{128} {
+				b.Run(fmt.Sprintf("valSize=%d", valSize), func(b *testing.B) {
+					for _, numKeys := range []int{1, 1024} {
+						b.Run(fmt.Sprintf("numKeys=%d", numKeys), func(b *testing.B) {
+							for _, numVersions := range []int{2, 1024} {
+								b.Run(fmt.Sprintf("numVersions=%d", numVersions), func(b *testing.B) {
+									runMVCCGarbageCollect(ctx, b, setupMVCCInMemPebble, benchGarbageCollectOptions{
+										benchDataOptions: benchDataOptions{
+											numKeys:     numKeys,
+											numVersions: numVersions,
+											valueBytes:  valSize,
+										},
+										keyBytes:       keySize,
+										deleteVersions: numVersions - 1,
+									})
+								})
+							}
+						})
+					}
+				})
+			}
+		})
+	}
+}

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -317,6 +317,9 @@ type Engine interface {
 	// this engine. A write-only batch accumulates all mutations and applies them
 	// atomically on a call to Commit(). Read operations return an error.
 	//
+	// Note that a distinct write-only batch allows reads. Distinct batches are a
+	// means of indicating that the user does not need to read its own writes.
+	//
 	// TODO(peter): This should return a WriteBatch interface, but there are mild
 	// complications in both defining that interface and implementing it. In
 	// particular, Batch.Close would no longer come from Reader and we'd need to

--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -363,7 +363,7 @@ func (p *Pebble) NewBatch() Batch {
 	if p.readOnly {
 		panic("write operation called on read-only pebble instance")
 	}
-	return newPebbleBatch(p.db.NewIndexedBatch())
+	return newPebbleBatch(p.db, p.db.NewIndexedBatch())
 }
 
 // NewReadOnly implements the Engine interface.
@@ -382,7 +382,7 @@ func (p *Pebble) NewWriteOnlyBatch() Batch {
 	if p.readOnly {
 		panic("write operation called on read-only pebble instance")
 	}
-	return newPebbleBatch(p.db.NewBatch())
+	return newPebbleBatch(p.db, p.db.NewBatch())
 }
 
 // NewSnapshot implements the Engine interface.


### PR DESCRIPTION
RocksDB (old) vs Pebble (new):

```
name                               old time/op    new time/op    delta
MVCCComputeStats/valueSize=8-16       183ms ± 1%     176ms ± 2%   -4.11%  (p=0.000 n=10+10)
MVCCComputeStats/valueSize=32-16      124ms ± 5%     107ms ± 2%  -13.95%  (p=0.000 n=10+9)
MVCCComputeStats/valueSize=256-16    58.4ms ± 3%    49.4ms ± 6%  -15.44%  (p=0.000 n=10+9)
MVCCFindSplitKey/valueSize=32-16     88.0ms ± 2%    81.8ms ± 1%   -7.06%  (p=0.000 n=10+10)

name                               old speed      new speed      delta
MVCCComputeStats/valueSize=8-16     366MB/s ± 1%   382MB/s ± 2%   +4.29%  (p=0.000 n=10+10)
MVCCComputeStats/valueSize=32-16    539MB/s ± 4%   627MB/s ± 2%  +16.18%  (p=0.000 n=10+9)
MVCCComputeStats/valueSize=256-16  1.15GB/s ± 2%  1.36GB/s ± 5%  +18.31%  (p=0.000 n=10+9)
MVCCFindSplitKey/valueSize=32-16    763MB/s ± 2%   821MB/s ± 1%   +7.60%  (p=0.000 n=10+10)
```

Release note: None