### PR TITLE
release-19.2: sql: Bugfixes around zone config setting and COPY FROM PARENT

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -828,3 +828,133 @@ ALTER INDEX validateTandemFields@secondary CONFIGURE ZONE USING range_min_bytes 
 
 statement error pq: could not validate zone config: range_min_bytes and range_max_bytes must be set together
 ALTER PARTITION indexPartition OF INDEX validateTandemFields@secondary CONFIGURE ZONE USING range_min_bytes = 66666
+
+# Test that copy from parent works as expected.
+statement ok
+CREATE TABLE copy_from_parent (x INT PRIMARY KEY);
+ALTER TABLE copy_from_parent PARTITION BY LIST (x) ( PARTITION p1 VALUES IN (1))
+
+statement ok
+ALTER DATABASE test CONFIGURE ZONE USING num_replicas = 7
+
+# Test that first inheriting from the parent database works correctly.
+statement ok
+ALTER TABLE copy_from_parent CONFIGURE ZONE USING num_replicas = COPY FROM PARENT
+
+query TT
+SELECT table_name, raw_config_sql FROM crdb_internal.zones WHERE table_name = 'copy_from_parent'
+----
+copy_from_parent  ALTER TABLE test.public.copy_from_parent CONFIGURE ZONE USING
+                  num_replicas = 7
+
+# Test that resetting the field manually works correctly.
+statement ok
+ALTER TABLE copy_from_parent CONFIGURE ZONE USING num_replicas = 3
+
+query TT
+SELECT table_name, raw_config_sql FROM crdb_internal.zones WHERE table_name = 'copy_from_parent'
+----
+copy_from_parent  ALTER TABLE test.public.copy_from_parent CONFIGURE ZONE USING
+                  num_replicas = 3
+
+# Test that trying to apply COPY FROM PARENT again picks up the parent's value.
+statement ok
+ALTER TABLE copy_from_parent CONFIGURE ZONE USING num_replicas = COPY FROM PARENT
+
+query TT
+SELECT table_name, raw_config_sql FROM crdb_internal.zones WHERE table_name = 'copy_from_parent'
+----
+copy_from_parent  ALTER TABLE test.public.copy_from_parent CONFIGURE ZONE USING
+                  num_replicas = 7
+
+# Ensure that the table has different zone configurations than its parent in
+# order to avoid accidentally copying the parent value.
+statement ok
+ALTER TABLE copy_from_parent CONFIGURE ZONE USING num_replicas = 6
+
+# Test that the partition can inherit the table's configuration values.
+statement ok
+ALTER PARTITION p1 OF TABLE copy_from_parent CONFIGURE ZONE USING num_replicas = 3
+
+query TTTT
+SELECT table_name, index_name, partition_name, raw_config_sql FROM crdb_internal.zones
+WHERE table_name = 'copy_from_parent' AND index_name = 'primary' AND partition_name = 'p1'
+----
+copy_from_parent  primary p1  ALTER PARTITION p1 OF INDEX test.public.copy_from_parent@primary CONFIGURE ZONE USING
+                              num_replicas = 3
+
+statement ok
+ALTER PARTITION p1 OF TABLE copy_from_parent CONFIGURE ZONE USING num_replicas = COPY FROM PARENT
+
+query TTTT
+SELECT table_name, index_name, partition_name, raw_config_sql FROM crdb_internal.zones
+WHERE table_name = 'copy_from_parent' AND index_name = 'primary' AND partition_name = 'p1'
+----
+copy_from_parent  primary p1  ALTER PARTITION p1 OF INDEX test.public.copy_from_parent@primary CONFIGURE ZONE USING
+                              num_replicas = 6
+
+statement ok
+ALTER INDEX copy_from_parent@primary CONFIGURE ZONE USING num_replicas = 5
+
+query TTTT
+SELECT table_name, index_name, partition_name, raw_config_sql FROM crdb_internal.zones
+WHERE table_name = 'copy_from_parent' AND index_name = 'primary' AND partition_name IS NULL
+----
+copy_from_parent  primary  NULL ALTER INDEX test.public.copy_from_parent@primary CONFIGURE ZONE USING
+                                num_replicas = 5
+
+
+# Test that an index can inherit from its parent.
+statement ok
+ALTER INDEX copy_from_parent@primary CONFIGURE ZONE USING num_replicas = COPY FROM PARENT
+
+query TTTT
+SELECT table_name, index_name, partition_name, raw_config_sql FROM crdb_internal.zones
+WHERE table_name = 'copy_from_parent' AND index_name = 'primary' AND partition_name IS NULL
+----
+copy_from_parent  primary  NULL ALTER INDEX test.public.copy_from_parent@primary CONFIGURE ZONE USING
+                                num_replicas = 6
+
+# Test that a partition can inherit from its parent index configuration.
+
+# First change the index's field value.
+statement ok
+ALTER INDEX copy_from_parent@primary CONFIGURE ZONE USING num_replicas = 9
+
+query TTTT
+SELECT table_name, index_name, partition_name, raw_config_sql FROM crdb_internal.zones
+WHERE table_name = 'copy_from_parent' AND index_name = 'primary' AND partition_name IS NULL
+----
+copy_from_parent  primary  NULL ALTER INDEX test.public.copy_from_parent@primary CONFIGURE ZONE USING
+                                num_replicas = 9
+
+statement ok
+ALTER PARTITION p1 OF TABLE copy_from_parent CONFIGURE ZONE USING num_replicas = COPY FROM PARENT
+
+query TTTT
+SELECT table_name, index_name, partition_name, raw_config_sql FROM crdb_internal.zones
+WHERE table_name = 'copy_from_parent' AND index_name = 'primary' AND partition_name = 'p1'
+----
+copy_from_parent  primary p1  ALTER PARTITION p1 OF INDEX test.public.copy_from_parent@primary CONFIGURE ZONE USING
+                              num_replicas = 9
+
+# check that copy from parent on a subzone doesn't accidentally modify the parent zone.
+statement ok
+CREATE TABLE parent_modify (x INT, INDEX idx (x));
+ALTER TABLE parent_modify CONFIGURE ZONE USING gc.ttlseconds = 700;
+ALTER INDEX parent_modify@idx CONFIGURE ZONE USING num_replicas = COPY FROM PARENT
+
+query TTT
+SELECT table_name, index_name, raw_config_sql FROM crdb_internal.zones
+WHERE table_name = 'parent_modify' AND index_name = 'idx'
+----
+parent_modify  idx  ALTER INDEX test.public.parent_modify@idx CONFIGURE ZONE USING
+                    num_replicas = 7
+
+query TTT
+SELECT table_name, index_name, raw_config_sql FROM crdb_internal.zones
+WHERE table_name = 'parent_modify' AND index_name IS NULL
+----
+parent_modify  NULL  ALTER TABLE test.public.parent_modify CONFIGURE ZONE USING
+                     gc.ttlseconds = 700
+

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -386,8 +387,51 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 			return err
 		}
 
-		// Copy the fields set by the INHERIT field command.
-		partialZone.CopyFromZone(*completeZone, copyFromParentList)
+		// We need to inherit zone configuration information from the correct zone,
+		// not completeZone.
+		{
+			// Function for getting the zone config within the current transaction.
+			getKey := func(key roachpb.Key) (*roachpb.Value, error) {
+				kv, err := params.p.txn.Get(params.ctx, key)
+				if err != nil {
+					return nil, err
+				}
+				return kv.Value, nil
+			}
+			if index == nil {
+				// If we are operating on a zone, get all fields that the zone would
+				// inherit from its parent. We do this by using an empty zoneConfig
+				// and completing at the level of the current zone.
+				zoneInheritedFields := config.ZoneConfig{}
+				if err := completeZoneConfig(&zoneInheritedFields, uint32(targetID), getKey); err != nil {
+					return err
+				}
+				partialZone.CopyFromZone(zoneInheritedFields, copyFromParentList)
+			} else {
+				// If we are operating on a subZone, we need to inherit all remaining
+				// unset fields in its parent zone, which is partialZone.
+				zoneInheritedFields := *partialZone
+				if err := completeZoneConfig(&zoneInheritedFields, uint32(targetID), getKey); err != nil {
+					return err
+				}
+				// In the case we have just an index, we should copy from the inherited
+				// zone's fields (whether that was the table or database).
+				if partition == "" {
+					partialSubzone.Config.CopyFromZone(zoneInheritedFields, copyFromParentList)
+				} else {
+					// In the case of updating a partition, we need try inheriting fields
+					// from the subzone's index, and inherit the remainder from the zone.
+					subzoneInheritedFields := config.ZoneConfig{}
+					if indexSubzone := completeZone.GetSubzone(uint32(index.ID), ""); indexSubzone != nil {
+						subzoneInheritedFields.InheritFromParent(&indexSubzone.Config)
+					}
+					subzoneInheritedFields.InheritFromParent(&zoneInheritedFields)
+					// After inheriting fields, copy the requested ones into the
+					// partialSubzone.Config.
+					partialSubzone.Config.CopyFromZone(subzoneInheritedFields, copyFromParentList)
+				}
+			}
+		}
 
 		if deleteZone {
 			if index != nil {


### PR DESCRIPTION
Backport 1/1 commits from #41506.

/cc @cockroachdb/release

---

This PR fixes two bugs related to setting zone configurations.

* COPY FROM PARENT was ignored when using it on partitions and indexes
* COPY FROM PARENT was ignored when using it on a zone that had an
existing value for the field that was being changed with COPY FROM
PARENT.

This change should be backported onto 19.2.

Release note (bug fix): Fix multiple bugs relating to zone
configurations and copy from parent:
* COPY FROM PARENT was ignored when using it on partitions and indexes
* COPY FROM PARENT was ignored when using it on a zone that had an
existing value for the field that was being changed with COPY FROM
PARENT.
