### PR TITLE
kubernetes: apps/v1beta1 removed in kubernetes 1.16

### DIFF
--- a/cloud/kubernetes/bring-your-own-certs/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/bring-your-own-certs/cockroachdb-statefulset.yaml
@@ -129,6 +129,9 @@ metadata:
 spec:
   serviceName: "cockroachdb"
   replicas: 3
+  selector:
+    matchLabels:
+      app: cockroachdb
   template:
     metadata:
       labels:

--- a/cloud/kubernetes/bring-your-own-certs/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/bring-your-own-certs/cockroachdb-statefulset.yaml
@@ -122,7 +122,7 @@ spec:
       app: cockroachdb
   maxUnavailable: 1
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: cockroachdb

--- a/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
@@ -136,7 +136,7 @@ spec:
       app: cockroachdb
   maxUnavailable: 1
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: cockroachdb

--- a/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
@@ -143,6 +143,9 @@ metadata:
 spec:
   serviceName: "cockroachdb"
   replicas: 3
+  selector:
+    matchLabels:
+      app: cockroachdb
   template:
     metadata:
       labels:

--- a/cloud/kubernetes/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset.yaml
@@ -75,6 +75,9 @@ metadata:
 spec:
   serviceName: "cockroachdb"
   replicas: 3
+  selector:
+    matchLabels:
+      app: cockroachdb
   template:
     metadata:
       labels:

--- a/cloud/kubernetes/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset.yaml
@@ -68,7 +68,7 @@ spec:
       app: cockroachdb
   maxUnavailable: 1
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: cockroachdb

--- a/cloud/kubernetes/example-app-secure.yaml
+++ b/cloud/kubernetes/example-app-secure.yaml
@@ -4,6 +4,9 @@ metadata:
   name: example-secure
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: loadgen
   template:
     metadata:
       labels:

--- a/cloud/kubernetes/example-app-secure.yaml
+++ b/cloud/kubernetes/example-app-secure.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example-secure

--- a/cloud/kubernetes/example-app.yaml
+++ b/cloud/kubernetes/example-app.yaml
@@ -4,6 +4,9 @@ metadata:
   name: example
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: loadgen
   template:
     metadata:
       labels:

--- a/cloud/kubernetes/example-app.yaml
+++ b/cloud/kubernetes/example-app.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example

--- a/cloud/kubernetes/multiregion/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/multiregion/cockroachdb-statefulset-secure.yaml
@@ -136,7 +136,7 @@ spec:
       app: cockroachdb
   maxUnavailable: 1
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: cockroachdb

--- a/cloud/kubernetes/multiregion/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/multiregion/cockroachdb-statefulset-secure.yaml
@@ -143,6 +143,9 @@ metadata:
 spec:
   serviceName: "cockroachdb"
   replicas: 3
+  selector:
+    matchLabels:
+      app: cockroachdb
   template:
     metadata:
       labels:

--- a/cloud/kubernetes/multiregion/example-app-secure.yaml
+++ b/cloud/kubernetes/multiregion/example-app-secure.yaml
@@ -4,6 +4,9 @@ metadata:
   name: example-secure
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: loadgen
   template:
     metadata:
       labels:

--- a/cloud/kubernetes/multiregion/example-app-secure.yaml
+++ b/cloud/kubernetes/multiregion/example-app-secure.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example-secure

--- a/cloud/kubernetes/performance/cockroachdb-daemonset-insecure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-daemonset-insecure.yaml
@@ -53,6 +53,9 @@ metadata:
   labels:
     app: cockroachdb
 spec:
+  selector:
+    matchLabels:
+      app: cockroachdb
   template:
     metadata:
       labels:

--- a/cloud/kubernetes/performance/cockroachdb-daemonset-insecure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-daemonset-insecure.yaml
@@ -46,7 +46,7 @@ spec:
       app: cockroachdb
   maxUnavailable: 1
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: cockroachdb

--- a/cloud/kubernetes/performance/cockroachdb-daemonset-secure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-daemonset-secure.yaml
@@ -117,7 +117,7 @@ spec:
       app: cockroachdb
   maxUnavailable: 1
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: cockroachdb

--- a/cloud/kubernetes/performance/cockroachdb-daemonset-secure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-daemonset-secure.yaml
@@ -124,6 +124,9 @@ metadata:
   labels:
     app: cockroachdb
 spec:
+  selector:
+    matchLabels:
+      app: cockroachdb
   template:
     metadata:
       labels:

--- a/cloud/kubernetes/performance/cockroachdb-statefulset-insecure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-statefulset-insecure.yaml
@@ -94,7 +94,7 @@ spec:
       app: cockroachdb
   maxUnavailable: 1
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: cockroachdb

--- a/cloud/kubernetes/performance/cockroachdb-statefulset-insecure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-statefulset-insecure.yaml
@@ -101,6 +101,9 @@ metadata:
 spec:
   serviceName: "cockroachdb"
   replicas: 3
+  selector:
+    matchLabels:
+      app: cockroachdb
   template:
     metadata:
       labels:

--- a/cloud/kubernetes/performance/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-statefulset-secure.yaml
@@ -163,6 +163,9 @@ metadata:
 spec:
   serviceName: "cockroachdb"
   replicas: 3
+  selector:
+    matchLabels:
+      app: cockroachdb
   template:
     metadata:
       labels:

--- a/cloud/kubernetes/performance/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-statefulset-secure.yaml
@@ -156,7 +156,7 @@ spec:
       app: cockroachdb
   maxUnavailable: 1
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: cockroachdb


### PR DESCRIPTION
This PR fixes compatibility with Kubernetes 1.16. `apps/v1beta` was [removed in Kubernetes 1.16](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#deprecations-and-removals).

This completes the work started by @asosso in #41359.

Release note: None