### PR TITLE
release-19.1: sql: Fix settings zone config bug with zone placeholders

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -309,6 +309,39 @@ SHOW ZONE CONFIGURATION FOR PARTITION x1 OF TABLE t35756
           constraints = '[]',
           lease_preferences = '[]'
 
+# regression for #38074
+statement ok
+CREATE TABLE t38074 (x INT, index i(x));
+
+statement ok
+ALTER INDEX t38074@i CONFIGURE ZONE USING gc.ttlseconds = 80000
+
+statement ok
+ALTER TABLE t38074 CONFIGURE ZONE USING gc.ttlseconds = 70000
+
+# Ensure that the table-level zone configuration is no longer a placeholder.
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE t38074
+----
+test.t38074 ALTER TABLE t38074 CONFIGURE ZONE USING
+                               range_min_bytes = 16777216,
+                               range_max_bytes = 67108864,
+                               gc.ttlseconds = 70000,
+                               num_replicas = 3,
+                               constraints = '[]',
+                               lease_preferences = '[]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR INDEX t38074@i
+----
+test.t38074@i ALTER INDEX t38074@i CONFIGURE ZONE USING
+                                   range_min_bytes = 16777216,
+                                   range_max_bytes = 67108864,
+                                   gc.ttlseconds = 80000,
+                                   num_replicas = 3,
+                                   constraints = '[]',
+                                   lease_preferences = '[]'
+
 # ------------------------------------------------------------------------------
 # Regression test for #36348; place this at the bottom of this file.
 # ------------------------------------------------------------------------------

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -168,7 +168,6 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 	var yamlConfig string
 	var setters []func(c *config.ZoneConfig)
 	deleteZone := false
-	subzonePlaceholder := false
 
 	// Evaluate the configuration input.
 	if n.yamlConfig != nil {
@@ -244,6 +243,7 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 		return err
 	}
 
+	subzonePlaceholder := false
 	// resolveZone determines the ID of the target object of the zone
 	// specifier. This ought to succeed regardless of whether there is
 	// already a zone config for the target object.
@@ -419,6 +419,14 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 			// No: the final zone config is the one we just processed.
 			completeZone = &newZone
 			partialZone = &finalZone
+			// Since we are writing to a zone that is not a subzone, we need to
+			// make sure that the zone config is not considered a placeholder
+			// anymore. If the settings applied to this zone don't touch the
+			// NumReplicas field, set it to nil so that the zone isn't considered a
+			// placeholder anymore.
+			if partialZone.IsSubzonePlaceholder() {
+				partialZone.NumReplicas = nil
+			}
 		} else {
 			// If the zone config for targetID was a subzone placeholder, it'll have
 			// been skipped over by GetZoneConfigInTxn. We need to load it regardless


### PR DESCRIPTION
Backport 1/1 commits from #41261.

/cc @cockroachdb/release

---

This PR fixes a bug where zone configurations applied on a table after
setting a zone configuration on a index would seemingly be ignored
unless the num_replicas field was also set on the table.

In the future, it seems like we should remove the notion of subzone
placeholders rather than using fixes like this.

Fixes #38074.

Release justification: Fixes a bug in zone configurations

Release note (bug fix): Fix bug where zone configuration changes on
tables with existing index zone configurations would not take effect
unless the num_replicas field was also set.
