### PR TITLE
importccl: add 19.2 version gate check

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -131,6 +131,10 @@ func importPlanHook(
 		return nil, nil, nil, false, nil
 	}
 
+	if !p.ExecCfg().Settings.Version.IsActive(cluster.VersionPartitionedBackup) {
+		return nil, nil, nil, false, errors.Errorf("IMPORT requires a cluster fully upgraded to version >= 19.2")
+	}
+
 	filesFn, err := p.TypeAsStringArray(importStmt.Files, "IMPORT")
 	if err != nil {
 		return nil, nil, nil, false, err


### PR DESCRIPTION
Ensure the cluster is fully upgraded when running import.

Release note: ensure cluster fully upgraded when running import.