### PR TITLE
opt: revert removal of code reducing columns for selectivity calculation

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/prepare_opt_plan
+++ b/pkg/sql/logictest/testdata/logic_test/prepare_opt_plan
@@ -92,7 +92,7 @@ select
  ├── prune: (2)
  ├── scan t
  │    ├── columns: k:1 str:2
- │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0]
+ │    ├── stats: [rows=1000]
  │    ├── cost: 1040.02
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)

--- a/pkg/sql/opt/memo/testdata/format
+++ b/pkg/sql/opt/memo/testdata/format
@@ -37,7 +37,7 @@ sort
       │    │    ├── interesting orderings: (+3)
       │    │    ├── scan t.public.t
       │    │    │    ├── columns: t.public.t.a:1(int) t.public.t.b:2(int) t.public.t.k:3(int!null)
-      │    │    │    ├── stats: [rows=1000, distinct(1)=100, null(1)=10, distinct(2)=100, null(2)=10, distinct(3)=1000, null(3)=0]
+      │    │    │    ├── stats: [rows=1000, distinct(1)=100, null(1)=10, distinct(2)=100, null(2)=10]
       │    │    │    ├── cost: 1060.02
       │    │    │    ├── key: (3)
       │    │    │    ├── fd: (3)-->(1,2)
@@ -80,7 +80,7 @@ sort
       │    │    ├── cost: 1070.03
       │    │    ├── scan t.public.t
       │    │    │    ├── columns: t.public.t.a:1(int) t.public.t.b:2(int) t.public.t.k:3(int!null)
-      │    │    │    ├── stats: [rows=1000, distinct(1)=100, null(1)=10, distinct(2)=100, null(2)=10, distinct(3)=1000, null(3)=0]
+      │    │    │    ├── stats: [rows=1000, distinct(1)=100, null(1)=10, distinct(2)=100, null(2)=10]
       │    │    │    └── cost: 1060.02
       │    │    └── filters
       │    │         └── lt [type=bool]
@@ -202,7 +202,7 @@ sort
       │    │    ├── fd: (3)-->(1,2)
       │    │    ├── interesting orderings: (+3)
       │    │    ├── scan t.public.t
-      │    │    │    ├── stats: [rows=1000, distinct(1)=100, null(1)=10, distinct(2)=100, null(2)=10, distinct(3)=1000, null(3)=0]
+      │    │    │    ├── stats: [rows=1000, distinct(1)=100, null(1)=10, distinct(2)=100, null(2)=10]
       │    │    │    ├── cost: 1060.02
       │    │    │    ├── key: (3)
       │    │    │    ├── fd: (3)-->(1,2)

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -556,10 +556,10 @@ project
  │    │    │    ├── stats: [rows=333333.333, distinct(5,6,8,16,17)=333333.333, null(5,6,8,16,17)=16336.65]
  │    │    │    ├── scan tab0
  │    │    │    │    ├── columns: tab0.e:5(varchar) tab0.f:6("char") tab0.h:8(varchar) tab0.j:10(float!null)
- │    │    │    │    └── stats: [rows=1000, distinct(10)=100, null(10)=0, distinct(5,6,8)=1000, null(5,6,8)=29.701]
+ │    │    │    │    └── stats: [rows=1000, distinct(5,6,8)=1000, null(5,6,8)=29.701]
  │    │    │    ├── scan tab1
  │    │    │    │    ├── columns: tab1.e:16(varchar) tab1.f:17("char") tab1.j:21(float!null)
- │    │    │    │    └── stats: [rows=1000, distinct(21)=100, null(21)=0, distinct(16,17)=1000, null(16,17)=19.9]
+ │    │    │    │    └── stats: [rows=1000, distinct(16,17)=1000, null(16,17)=19.9]
  │    │    │    └── filters
  │    │    │         └── tab0.j IN (tab1.j,) [type=bool, outer=(10,21)]
  │    │    └── projections

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -101,7 +101,7 @@ select
  ├── fd: (1)-->(2)
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(int)
- │    ├── stats: [rows=4000, distinct(1)=4000, null(1)=0]
+ │    ├── stats: [rows=4000]
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── filters
@@ -118,7 +118,7 @@ select
  ├── fd: ()-->(2)
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(int)
- │    ├── stats: [rows=4000, distinct(1)=4000, null(1)=0, distinct(2)=400, null(2)=0]
+ │    ├── stats: [rows=4000, distinct(2)=400, null(2)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── filters
@@ -360,7 +360,7 @@ SELECT * FROM district WHERE d_id = 1 AND d_w_id=10 AND d_name='hello'
 select
  ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string!null)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=0.01, distinct(1)=0.01, null(1)=0, distinct(2)=0.01, null(2)=0, distinct(3)=0.01, null(3)=0]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0]
  ├── key: ()
  ├── fd: ()-->(1-3)
  ├── scan district
@@ -454,7 +454,7 @@ WHERE id = 1 AND name='andy'
 ----
 select
  ├── columns: id:1(int!null) name:2(string!null) state:3(string) order_id:4(int) item_id:5(int) customer_id:6(int!null) year:7(int)
- ├── stats: [rows=0.0232033556, distinct(1)=0.0232033556, null(1)=0, distinct(2)=0.0232033556, null(2)=0]
+ ├── stats: [rows=10, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0]
  ├── fd: ()-->(1-3,6), (1)==(6), (6)==(1)
  ├── project
  │    ├── columns: id:1(int!null) name:2(string) state:3(string) order_id:4(int) item_id:5(int) customer_id:6(int!null) year:7(int)
@@ -1000,7 +1000,7 @@ select
  ├── fd: (1)-->(2)
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(int)
- │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0]
+ │    ├── stats: [rows=5000]
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── filters
@@ -1017,7 +1017,7 @@ select
  ├── fd: ()-->(2)
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(int)
- │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=1000]
+ │    ├── stats: [rows=5000, distinct(2)=400, null(2)=1000]
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── filters
@@ -1062,6 +1062,16 @@ ALTER TABLE customers INJECT STATISTICS '[
 ]'
 ----
 
+# This tests selectivityFromReducedCols
+# The following two tests cases are paired together. The first has
+# one constraint, one on single non-key column. The second  query has two
+# constraints on columns which form a determinant, dependent FD pair.
+# The dependent column in this FD pair is from the first test case.
+# This series of tests demonstrates that the selectivity
+# contribution for a pair of (determinant, dependent) FDs is the
+# selectivity of the determinant.
+# 1/2 join-subquery-selectivityFromReducedCols tests
+
 build
 SELECT * FROM (SELECT * FROM customers, order_history WHERE id = customer_id)
 WHERE name='andy'
@@ -1100,16 +1110,23 @@ select
  └── filters
       └── name = 'andy' [type=bool, outer=(2), constraints=(/2: [/'andy' - /'andy']; tight), fd=()-->(2)]
 
-# TODO(rytaft): This test has two predicates on columns which form a determinant,
-# dependent FD pair. The row count is much smaller than it should be since we
-# assume the two columns are independent.
+# This tests selectivityFromReducedCols
+# The previous tests case and the following are paired together. The first has
+# one constraint, one on single non-key column. The second  query has two
+# constraints on columns which form a determinant, dependent FD pair.
+# The dependent column in this FD pair is from the first test case.
+# This series of tests demonstrates that the selectivity
+# contribution for a pair of (determinant, dependent) FDs is the
+# selectivity of the determinant.
+# 2/2 join-subquery-selectivityFromReducedCols tests
+
 build
 SELECT * FROM (SELECT * FROM customers, order_history WHERE id = customer_id)
 WHERE id = 1 AND name='andy'
 ----
 select
  ├── columns: id:1(int!null) name:2(string!null) state:3(string) order_id:4(int) item_id:5(int) customer_id:6(int!null) year:7(int)
- ├── stats: [rows=0.0186058563, distinct(1)=0.0186058563, null(1)=0, distinct(2)=0.0186058563, null(2)=0]
+ ├── stats: [rows=8, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0]
  ├── fd: ()-->(1-3,6), (1)==(6), (6)==(1)
  ├── project
  │    ├── columns: id:1(int!null) name:2(string) state:3(string) order_id:4(int) item_id:5(int) customer_id:6(int!null) year:7(int)

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -109,11 +109,11 @@ memo (optimized, ~7KB, required=[presentation: k:1])
  ├── G1: (project G2 G3 k)
  │    └── [presentation: k:1]
  │         ├── best: (project G2 G3 k)
- │         └── cost: 0.03
+ │         └── cost: 1.07
  ├── G2: (select G4 G5) (select G6 G7) (scan a@u,cols=(1,2),constrained)
  │    └── []
  │         ├── best: (scan a@u,cols=(1,2),constrained)
- │         └── cost: 0.02
+ │         └── cost: 1.05
  ├── G3: (projections)
  ├── G4: (scan a,cols=(1,2)) (scan a@u,cols=(1,2)) (scan a@v,cols=(1,2))
  │    └── []


### PR DESCRIPTION
This commit reverts part of #41520, which removed the code to reduce
the number of columns used for selectivity calculation based on functional
dependencies. I removed it because I thought it added unnecessary complexity
with minimal benefit, but we have already run into a real-world example
where it does actually provide a tangible benefit in producing a better
plan.

I was able to add it back with slightly less complexity than existed
before, so I'm satisfied that adding it back is worthwhile.

Release note: None