### PR TITLE
roachprod: plumb program-filter flag

### DIFF
--- a/pkg/cmd/roachprod/install/cluster_synced.go
+++ b/pkg/cmd/roachprod/install/cluster_synced.go
@@ -1121,7 +1121,10 @@ func (c *SyncedCluster) Put(src, dest string) {
 // user and assumes that the current user used to create c has the ability to
 // sudo into <user>.
 func (c *SyncedCluster) Logs(
-	src, dest, user, filter string, interval time.Duration, from, to time.Time, out io.Writer,
+	src, dest, user, filter, programFilter string,
+	interval time.Duration,
+	from, to time.Time,
+	out io.Writer,
 ) error {
 	rsyncNodeLogs := func(ctx context.Context, idx int) error {
 		base := fmt.Sprintf("%d.logs", c.Nodes[idx-1])
@@ -1185,6 +1188,9 @@ func (c *SyncedCluster) Logs(
 			"--to", t.Format(time.RFC3339))
 		if filter != "" {
 			cmd.Args = append(cmd.Args, "--filter", filter)
+		}
+		if programFilter != "" {
+			cmd.Args = append(cmd.Args, "--program-filter", programFilter)
 		}
 		// For local clusters capture the cluster ID from the sync path because the
 		// host information is useless.

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -93,6 +93,7 @@ var (
 	stageOS           string
 	logsDir           string
 	logsFilter        string
+	logsProgramFilter string
 	logsFrom          time.Time
 	logsTo            time.Time
 	logsInterval      time.Duration
@@ -1068,7 +1069,7 @@ into a single stream.
 		} else {
 			dest = c.Name + ".logs"
 		}
-		return c.Logs(logsDir, dest, username, logsFilter, logsInterval, logsFrom, logsTo, cmd.OutOrStdout())
+		return c.Logs(logsDir, dest, username, logsFilter, logsProgramFilter, logsInterval, logsFrom, logsTo, cmd.OutOrStdout())
 	}),
 }
 
@@ -1682,6 +1683,8 @@ func main() {
 		&logsInterval, "interval", 200*time.Millisecond, "interval to poll logs from host")
 	logsCmd.Flags().StringVar(
 		&logsDir, "logs-dir", "logs", "path to the logs dir, if remote, relative to username's home dir, ignored if local")
+	logsCmd.Flags().StringVar(
+		&logsProgramFilter, "logs-program", "^cockroach$", "regular expression of the name of program in log files to search")
 
 	monitorCmd.Flags().BoolVar(
 		&monitorIgnoreEmptyNodes,


### PR DESCRIPTION
Before this PR we'd always use the default cockroach program filter which is
`^cockroach.*`, the problem with this filter is that now it picks up the very
verbose rocksdb logs which live in files like:

```
cockroach-rocksdb.ip-10-12-37-172.ubuntu.2019-10-17T15_31_15Z.004090.log
```

Which have an effective program name of `cockroach-rocksdb`.

It might be reasonable to default this value to the value of `--binary`
flag but that would lead to weird usability issues if the remote cockroach
is called something different from the local one.

Release note: None