### PR TITLE
storage/engine: don't set iterator bounds in pebbleMVCCScanner

### DIFF
--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -110,8 +110,10 @@ type Iterator interface {
 	// returned raw, as a buffer of varint-prefixed slices, alternating from key
 	// to value, where numKVs specifies the number of pairs in the buffer.
 	//
-	// There is little reason to use this function directly. Use the package-level
-	// MVCCScan, or one of its variants, instead.
+	// DO NOT CALL directly. Use the package-level MVCCScan, or one of its
+	// variants, instead.
+	//
+	// TODO(peter): unexport this method.
 	MVCCScan(
 		start, end roachpb.Key, max int64, timestamp hlc.Timestamp, opts MVCCScanOptions,
 	) (kvData []byte, numKVs int64, resumeSpan *roachpb.Span, intents []roachpb.Intent, err error)

--- a/pkg/storage/engine/pebble_iterator.go
+++ b/pkg/storage/engine/pebble_iterator.go
@@ -333,14 +333,10 @@ func (p *pebbleIterator) MVCCGet(
 		end:          keyEnd,
 		ts:           timestamp,
 		maxKeys:      1,
+		txn:          opts.Txn,
 		inconsistent: opts.Inconsistent,
 		tombstones:   opts.Tombstones,
 		ignoreSeq:    opts.IgnoreSequence,
-	}
-
-	if opts.Txn != nil {
-		mvccScanner.txn = opts.Txn
-		mvccScanner.checkUncertainty = timestamp.Less(opts.Txn.MaxTimestamp)
 	}
 
 	mvccScanner.init()
@@ -348,9 +344,7 @@ func (p *pebbleIterator) MVCCGet(
 
 	// Init calls SetBounds. Reset it to what this iterator had at the start.
 	defer func() {
-		if p.iter != nil {
-			p.iter.SetBounds(p.options.LowerBound, p.options.UpperBound)
-		}
+		p.iter.SetBounds(p.options.LowerBound, p.options.UpperBound)
 	}()
 
 	if mvccScanner.err != nil {
@@ -414,14 +408,10 @@ func (p *pebbleIterator) MVCCScan(
 		end:          end,
 		ts:           timestamp,
 		maxKeys:      max,
+		txn:          opts.Txn,
 		inconsistent: opts.Inconsistent,
 		tombstones:   opts.Tombstones,
 		ignoreSeq:    opts.IgnoreSequence,
-	}
-
-	if opts.Txn != nil {
-		mvccScanner.txn = opts.Txn
-		mvccScanner.checkUncertainty = timestamp.Less(opts.Txn.MaxTimestamp)
 	}
 
 	mvccScanner.init()
@@ -429,9 +419,7 @@ func (p *pebbleIterator) MVCCScan(
 
 	// Init calls SetBounds. Reset it to what this iterator had at the start.
 	defer func() {
-		if p.iter != nil {
-			p.iter.SetBounds(p.options.LowerBound, p.options.UpperBound)
-		}
+		p.iter.SetBounds(p.options.LowerBound, p.options.UpperBound)
 	}()
 
 	if mvccScanner.err != nil {

--- a/pkg/storage/engine/pebble_mvcc_scanner.go
+++ b/pkg/storage/engine/pebble_mvcc_scanner.go
@@ -129,6 +129,10 @@ func (p *pebbleMVCCScanner) init() {
 	p.startBuf = EncodeKeyToBuf(p.startBuf[:0], mvccStartKey)
 	p.endBuf = EncodeKeyToBuf(p.endBuf[:0], mvccEndKey)
 	p.parent.SetBounds(p.startBuf, p.endBuf)
+
+	if p.txn != nil {
+		p.checkUncertainty = p.ts.Less(p.txn.MaxTimestamp)
+	}
 }
 
 // seekReverse seeks to the latest revision of the key before the specified key.


### PR DESCRIPTION
The RocksDB `mvccScanner` doesn't set the iterator bounds, relying instead
on the caller to do so. I believe the `pebbleMVCCScanner` was doing this to
make `MVCCGet` work correctly, but it seems the problem there was that we
weren't using prefix iteration for
`pebbleMVCCScanner.get()`. Fixing that allows us to elide the bounds
setting.

Release note: None