### PR TITLE
storage/engine: implement Pebble.Attrs

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -511,6 +511,7 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 					}},
 				}
 				eng, err = engine.NewPebble(spec.Path, pebbleOpts)
+				eng.(*engine.Pebble).SetAttrs(spec.Attributes)
 			} else {
 				rocksDBConfig := engine.RocksDBConfig{
 					Attrs:                   spec.Attributes,

--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -93,6 +93,7 @@ type Pebble struct {
 
 	closed bool
 	path   string
+	attrs  roachpb.Attributes
 
 	// Relevant options copied over from pebble.Options.
 	fs       vfs.FS
@@ -322,10 +323,15 @@ func (p *Pebble) LogLogicalOp(op MVCCLogicalOpType, details MVCCLogicalOpDetails
 	// No-op. Logical logging disabled.
 }
 
+// SetAttrs sets the attributes returned by Atts(). This method is not safe for
+// concurrent use.
+func (p *Pebble) SetAttrs(attrs roachpb.Attributes) {
+	p.attrs = attrs
+}
+
 // Attrs implements the Engine interface.
 func (p *Pebble) Attrs() roachpb.Attributes {
-	// TODO(itsbilal): Implement this.
-	return roachpb.Attributes{}
+	return p.attrs
 }
 
 // Capacity implements the Engine interface.


### PR DESCRIPTION
`Engine.Attrs()` is only used to implement `Store.Attrs()`, but actually
moving this to `Store` is a bit irritating due to the structure of the
server startup code. So we leave this wart in place and allow setting
the attributes on a Pebble-backed `Engine`.

Fixes #41599

Release note: None