### PR TITLE
workload/ycsb: make splits uniform in the keyspace

### DIFF
--- a/pkg/workload/ycsb/ycsb.go
+++ b/pkg/workload/ycsb/ycsb.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"hash"
 	"hash/fnv"
+	"math"
 	"math/rand"
 	"strings"
 	"sync/atomic"
@@ -196,9 +197,9 @@ func (g *ycsb) Tables() []workload.Table {
 		Splits: workload.Tuples(
 			g.splits,
 			func(splitIdx int) []interface{} {
-				w := ycsbWorker{config: g, hashFunc: fnv.New64()}
+				step := math.MaxUint64 / uint64(g.splits+1)
 				return []interface{}{
-					w.buildKeyName(uint64(splitIdx)),
+					keyNameFromHash(step * uint64(splitIdx+1)),
 				}
 			},
 		),
@@ -452,7 +453,10 @@ func (yw *ycsbWorker) hashKey(key uint64) uint64 {
 }
 
 func (yw *ycsbWorker) buildKeyName(keynum uint64) string {
-	hashedKey := yw.hashKey(keynum)
+	return keyNameFromHash(yw.hashKey(keynum))
+}
+
+func keyNameFromHash(hashedKey uint64) string {
 	return fmt.Sprintf("user%d", hashedKey)
 }
 


### PR DESCRIPTION
Before this PR we'd roughly randomly place splits in the keyspace.
This changes splits to be uniformly placed throughout the keyspace.

Release note: None