### PR TITLE
pkg: Ensure calls to 'MakeNameMetadataKey' use DescriptorKey interface

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -917,7 +917,8 @@ func (r *importResumer) OnFailOrCancel(ctx context.Context, txn *client.Txn) err
 			tableDesc.DropTime = 1
 			var existingIDVal roachpb.Value
 			existingIDVal.SetInt(int64(tableDesc.ID))
-			b.CPut(sqlbase.MakeNameMetadataKey(tableDesc.ParentID, tableDesc.Name), nil, &existingIDVal)
+			tKey := sqlbase.NewTableKey(tableDesc.ParentID, tableDesc.Name)
+			b.CPut(tKey.Key(), nil, &existingIDVal)
 		} else {
 			// IMPORT did not create this table, so we should not drop it.
 			tableDesc.State = sqlbase.TableDescriptor_PUBLIC

--- a/pkg/sql/create_test.go
+++ b/pkg/sql/create_test.go
@@ -52,7 +52,7 @@ func TestDatabaseDescriptor(t *testing.T) {
 	}
 
 	// Database name.
-	nameKey := sqlbase.MakeNameMetadataKey(keys.RootNamespaceID, "test")
+	nameKey := sqlbase.NewDatabaseKey("test").Key()
 	if gr, err := kvDB.Get(ctx, nameKey); err != nil {
 		t.Fatal(err)
 	} else if gr.Exists() {

--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -79,7 +78,7 @@ func getKeysForDatabaseDescriptor(
 	dbDesc *sqlbase.DatabaseDescriptor,
 ) (zoneKey roachpb.Key, nameKey roachpb.Key, descKey roachpb.Key) {
 	zoneKey = config.MakeZoneKey(uint32(dbDesc.ID))
-	nameKey = sqlbase.MakeNameMetadataKey(keys.RootNamespaceID, dbDesc.GetName())
+	nameKey = sqlbase.NewDatabaseKey(dbDesc.GetName()).Key()
 	descKey = sqlbase.MakeDescMetadataKey(dbDesc.ID)
 	return
 }

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -234,7 +234,7 @@ func GetAllDescriptors(ctx context.Context, txn *client.Txn) ([]sqlbase.Descript
 // descriptor IDs.
 func GetAllDatabaseDescriptorIDs(ctx context.Context, txn *client.Txn) ([]sqlbase.ID, error) {
 	log.Eventf(ctx, "fetching all database descriptor IDs")
-	nameKey := sqlbase.MakeNameMetadataKey(keys.RootNamespaceID, "" /* name */)
+	nameKey := sqlbase.NewDatabaseKey("" /* name */).Key()
 	kvs, err := txn.Scan(ctx, nameKey, nameKey.PrefixEnd(), 0 /*maxRows */)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -133,7 +133,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 		t.Fatal(err)
 	}
 
-	dbNameKey := sqlbase.MakeNameMetadataKey(keys.RootNamespaceID, "t")
+	dbNameKey := sqlbase.NewDatabaseKey("t").Key()
 	r, err := kvDB.Get(ctx, dbNameKey)
 	if err != nil {
 		t.Fatal(err)
@@ -148,7 +148,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	}
 	dbDesc := desc.GetDatabase()
 
-	tbNameKey := sqlbase.MakeNameMetadataKey(dbDesc.ID, "kv")
+	tbNameKey := sqlbase.NewTableKey(dbDesc.ID, "kv").Key()
 	gr, err := kvDB.Get(ctx, tbNameKey)
 	if err != nil {
 		t.Fatal(err)
@@ -253,8 +253,8 @@ CREATE DATABASE t;
 		t.Fatal(err)
 	}
 
-	dbNameKey := sqlbase.MakeNameMetadataKey(keys.RootNamespaceID, "t")
-	r, err := kvDB.Get(ctx, dbNameKey)
+	dKey := sqlbase.NewDatabaseKey("t")
+	r, err := kvDB.Get(ctx, dKey.Key())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -307,8 +307,8 @@ INSERT INTO t.kv2 VALUES ('c', 'd'), ('a', 'b'), ('e', 'a');
 		t.Fatal(err)
 	}
 
-	dbNameKey := sqlbase.MakeNameMetadataKey(keys.RootNamespaceID, "t")
-	r, err := kvDB.Get(ctx, dbNameKey)
+	dKey := sqlbase.NewDatabaseKey("t")
+	r, err := kvDB.Get(ctx, dKey.Key())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -322,8 +322,8 @@ INSERT INTO t.kv2 VALUES ('c', 'd'), ('a', 'b'), ('e', 'a');
 	}
 	dbDesc := desc.GetDatabase()
 
-	tbNameKey := sqlbase.MakeNameMetadataKey(dbDesc.ID, "kv")
-	gr, err := kvDB.Get(ctx, tbNameKey)
+	tKey := sqlbase.NewTableKey(dbDesc.ID, "kv")
+	gr, err := kvDB.Get(ctx, tKey.Key())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -337,8 +337,8 @@ INSERT INTO t.kv2 VALUES ('c', 'd'), ('a', 'b'), ('e', 'a');
 	}
 	tbDesc := desc.Table(ts)
 
-	tb2NameKey := sqlbase.MakeNameMetadataKey(dbDesc.ID, "kv2")
-	gr2, err := kvDB.Get(ctx, tb2NameKey)
+	t2Key := sqlbase.NewTableKey(dbDesc.ID, "kv2")
+	gr2, err := kvDB.Get(ctx, t2Key.Key())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -703,7 +703,7 @@ func TestDropTable(t *testing.T) {
 	}
 
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "kv")
-	nameKey := sqlbase.MakeNameMetadataKey(keys.MinNonPredefinedUserDescID, "kv")
+	nameKey := sqlbase.NewTableKey(keys.MinNonPredefinedUserDescID, "kv").Key()
 	gr, err := kvDB.Get(ctx, nameKey)
 
 	if err != nil {
@@ -800,7 +800,7 @@ func TestDropTableDeleteData(t *testing.T) {
 
 		descs = append(descs, sqlbase.GetTableDescriptor(kvDB, "t", tableName))
 
-		nameKey := sqlbase.MakeNameMetadataKey(keys.MinNonPredefinedUserDescID, tableName)
+		nameKey := sqlbase.NewTableKey(keys.MinNonPredefinedUserDescID, tableName).Key()
 		gr, err := kvDB.Get(ctx, nameKey)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/sql/physical_schema_accessors.go
+++ b/pkg/sql/physical_schema_accessors.go
@@ -96,7 +96,7 @@ func (a UncachedPhysicalAccessor) GetObjectNames(
 	}
 
 	log.Eventf(ctx, "fetching list of objects for %q", dbDesc.Name)
-	prefix := sqlbase.MakeNameMetadataKey(dbDesc.ID, "")
+	prefix := sqlbase.NewTableKey(dbDesc.ID, "").Key()
 	sr, err := txn.Scan(ctx, prefix, prefix.PrefixEnd(), 0)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/sqlbase/keys_test.go
+++ b/pkg/sql/sqlbase/keys_test.go
@@ -23,10 +23,10 @@ func TestKeyAddress(t *testing.T) {
 	testCases := []struct {
 		key roachpb.Key
 	}{
-		{MakeNameMetadataKey(0, "BAR")},
-		{MakeNameMetadataKey(1, "BAR")},
-		{MakeNameMetadataKey(1, "foo")},
-		{MakeNameMetadataKey(2, "foo")},
+		{NewTableKey(0, "BAR").Key()},
+		{NewTableKey(1, "BAR").Key()},
+		{NewTableKey(1, "foo").Key()},
+		{NewTableKey(2, "foo").Key()},
 		{MakeDescMetadataKey(123)},
 		{MakeDescMetadataKey(124)},
 	}

--- a/pkg/sql/sqlbase/metadata.go
+++ b/pkg/sql/sqlbase/metadata.go
@@ -141,7 +141,7 @@ func (ms MetadataSchema) GetInitialValues() ([]roachpb.KeyValue, []roachpb.RKey)
 		value := roachpb.Value{}
 		value.SetInt(int64(desc.GetID()))
 		ret = append(ret, roachpb.KeyValue{
-			Key:   MakeNameMetadataKey(parentID, desc.GetName()),
+			Key:   NewTableKey(parentID, desc.GetName()).Key(),
 			Value: value,
 		})
 

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -21,7 +21,6 @@ import (
 	"unicode"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -44,9 +43,9 @@ import (
 // GetTableDescriptor retrieves a table descriptor directly from the KV layer.
 func GetTableDescriptor(kvDB *client.DB, database string, table string) *TableDescriptor {
 	// log.VEventf(context.TODO(), 2, "GetTableDescriptor %q %q", database, table)
-	dbNameKey := MakeNameMetadataKey(keys.RootNamespaceID, database)
+	dKey := NewDatabaseKey(database)
 	ctx := context.TODO()
-	gr, err := kvDB.Get(ctx, dbNameKey)
+	gr, err := kvDB.Get(ctx, dKey.Key())
 	if err != nil {
 		panic(err)
 	}
@@ -55,8 +54,8 @@ func GetTableDescriptor(kvDB *client.DB, database string, table string) *TableDe
 	}
 	dbDescID := ID(gr.ValueInt())
 
-	tableNameKey := MakeNameMetadataKey(dbDescID, table)
-	gr, err = kvDB.Get(ctx, tableNameKey)
+	tKey := NewTableKey(dbDescID, table)
+	gr, err = kvDB.Get(ctx, tKey.Key())
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -208,7 +208,7 @@ func (p *planner) truncateTable(
 	//
 	// TODO(vivek): Fix properly along with #12123.
 	zoneKey := config.MakeZoneKey(uint32(tableDesc.ID))
-	nameKey := sqlbase.MakeNameMetadataKey(tableDesc.ParentID, tableDesc.GetName())
+	nameKey := sqlbase.NewTableKey(tableDesc.ParentID, tableDesc.GetName()).Key()
 	b := &client.Batch{}
 	// Use CPut because we want to remove a specific name -> id map.
 	if traceKV {

--- a/pkg/sql/zone_config.go
+++ b/pkg/sql/zone_config.go
@@ -262,7 +262,8 @@ func resolveZone(ctx context.Context, txn *client.Txn, zs *tree.ZoneSpecifier) (
 	errMissingKey := errors.New("missing key")
 	id, err := config.ResolveZoneSpecifier(zs,
 		func(parentID uint32, name string) (uint32, error) {
-			kv, err := txn.Get(ctx, sqlbase.MakeNameMetadataKey(sqlbase.ID(parentID), name))
+			tKey := sqlbase.NewTableKey(sqlbase.ID(parentID), name)
+			kv, err := txn.Get(ctx, tKey.Key())
 			if err != nil {
 				return 0, err
 			}

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -243,7 +243,7 @@ func databaseIDs(names ...string) func(ctx context.Context, db db) ([]sqlbase.ID
 	return func(ctx context.Context, db db) ([]sqlbase.ID, error) {
 		var ids []sqlbase.ID
 		for _, name := range names {
-			kv, err := db.Get(ctx, sqlbase.MakeNameMetadataKey(keys.RootNamespaceID, name))
+			kv, err := db.Get(ctx, sqlbase.NewTableKey(keys.RootNamespaceID, name).Key())
 			if err != nil {
 				return nil, err
 			}
@@ -560,7 +560,7 @@ func createSystemTable(ctx context.Context, r runner, desc sqlbase.TableDescript
 	// the reserved ID space. (The SQL layer doesn't allow this.)
 	err := r.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		b := txn.NewBatch()
-		b.CPut(sqlbase.MakeNameMetadataKey(desc.GetParentID(), desc.GetName()), desc.GetID(), nil)
+		b.CPut(sqlbase.NewTableKey(desc.GetParentID(), desc.GetName()).Key(), desc.GetID(), nil)
 		b.CPut(sqlbase.MakeDescMetadataKey(desc.GetID()), sqlbase.WrapDescriptor(&desc), nil)
 		if err := txn.SetSystemConfigTrigger(); err != nil {
 			return err

--- a/pkg/sqlmigrations/migrations_test.go
+++ b/pkg/sqlmigrations/migrations_test.go
@@ -462,7 +462,7 @@ func TestCreateSystemTable(t *testing.T) {
 	sqlbase.SystemAllowedPrivileges[table.ID] = sqlbase.SystemAllowedPrivileges[keys.NamespaceTableID]
 
 	table.Name = "dummy"
-	nameKey := sqlbase.MakeNameMetadataKey(table.ParentID, table.Name)
+	nameKey := sqlbase.NewTableKey(table.ParentID, table.Name).Key()
 	descKey := sqlbase.MakeDescMetadataKey(table.ID)
 	descVal := sqlbase.WrapDescriptor(&table)
 


### PR DESCRIPTION
Currently, only some places in the code us the DescriptorKey interface to
construct name metadata keys. Most occurrences call 'MakeNameMetadataKey'
directly. This PR addresses this.

Release note: None