### PR TITLE
release-19.1: sql: Bugfixes around zone config setting and COPY FROM PARENT

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -357,6 +357,127 @@ SELECT config_sql FROM [SHOW ZONE CONFIGURATIONS] WHERE zone_name = 'test.infect
 ALTER PARTITION p1 OF INDEX test.public.infect@primary CONFIGURE ZONE USING
   constraints = '[+dc=dc1]'
 
+# Test that copy from parent works as expected.
+statement ok
+CREATE TABLE copy_from_parent (x INT PRIMARY KEY);
+ALTER TABLE copy_from_parent PARTITION BY LIST (x) ( PARTITION p1 VALUES IN (1))
+
+statement ok
+ALTER DATABASE test CONFIGURE ZONE USING num_replicas = 7
+
+# Test that first inheriting from the parent database works correctly.
+statement ok
+ALTER TABLE copy_from_parent CONFIGURE ZONE USING num_replicas = COPY FROM PARENT
+
+query TT
+SELECT zone_name, config_sql FROM [SHOW ZONE CONFIGURATIONS] WHERE zone_name = 'test.copy_from_parent'
+----
+test.copy_from_parent  ALTER TABLE test.public.copy_from_parent CONFIGURE ZONE USING
+                  num_replicas = 7
+
+# Test that resetting the field manually works correctly.
+statement ok
+ALTER TABLE copy_from_parent CONFIGURE ZONE USING num_replicas = 3
+
+query TT
+SELECT zone_name, config_sql FROM [SHOW ZONE CONFIGURATIONS] WHERE zone_name = 'test.copy_from_parent'
+----
+test.copy_from_parent  ALTER TABLE test.public.copy_from_parent CONFIGURE ZONE USING
+                  num_replicas = 3
+
+# Test that trying to apply COPY FROM PARENT again picks up the parent's value.
+statement ok
+ALTER TABLE copy_from_parent CONFIGURE ZONE USING num_replicas = COPY FROM PARENT
+
+query TT
+SELECT zone_name, config_sql FROM [SHOW ZONE CONFIGURATIONS] WHERE zone_name = 'test.copy_from_parent'
+----
+test.copy_from_parent  ALTER TABLE test.public.copy_from_parent CONFIGURE ZONE USING
+                  num_replicas = 7
+
+# Ensure that the table has different zone configurations than its parent in
+# order to avoid accidentally copying the parent value.
+statement ok
+ALTER TABLE copy_from_parent CONFIGURE ZONE USING num_replicas = 6
+
+# Test that the partition can inherit the table's configuration values.
+statement ok
+ALTER PARTITION p1 OF TABLE copy_from_parent CONFIGURE ZONE USING num_replicas = 3
+
+query TT
+SELECT zone_name, config_sql FROM [SHOW ZONE CONFIGURATIONS] WHERE zone_name = 'test.copy_from_parent.p1'
+----
+test.copy_from_parent.p1  ALTER PARTITION p1 OF INDEX test.public.copy_from_parent@primary CONFIGURE ZONE USING
+                              num_replicas = 3
+
+statement ok
+ALTER PARTITION p1 OF TABLE copy_from_parent CONFIGURE ZONE USING num_replicas = COPY FROM PARENT
+
+query TT
+SELECT zone_name, config_sql FROM [SHOW ZONE CONFIGURATIONS] WHERE zone_name = 'test.copy_from_parent.p1'
+----
+test.copy_from_parent.p1  ALTER PARTITION p1 OF INDEX test.public.copy_from_parent@primary CONFIGURE ZONE USING
+                              num_replicas = 6
+
+statement ok
+ALTER INDEX copy_from_parent@primary CONFIGURE ZONE USING num_replicas = 5
+
+query TT
+SELECT zone_name, config_sql FROM [SHOW ZONE CONFIGURATIONS] WHERE zone_name = 'test.copy_from_parent@primary'
+----
+test.copy_from_parent@primary ALTER INDEX test.public.copy_from_parent@primary CONFIGURE ZONE USING
+                              num_replicas = 5
+
+
+# Test that an index can inherit from its parent.
+statement ok
+ALTER INDEX copy_from_parent@primary CONFIGURE ZONE USING num_replicas = COPY FROM PARENT
+
+query TT
+SELECT zone_name, config_sql FROM [SHOW ZONE CONFIGURATIONS] WHERE zone_name = 'test.copy_from_parent@primary'
+----
+test.copy_from_parent@primary ALTER INDEX test.public.copy_from_parent@primary CONFIGURE ZONE USING
+                              num_replicas = 6
+
+# Test that a partition can inherit from its parent index configuration.
+
+# First change the index's field value.
+statement ok
+ALTER INDEX copy_from_parent@primary CONFIGURE ZONE USING num_replicas = 9
+
+query TT
+SELECT zone_name, config_sql FROM [SHOW ZONE CONFIGURATIONS] WHERE zone_name = 'test.copy_from_parent@primary'
+----
+test.copy_from_parent@primary ALTER INDEX test.public.copy_from_parent@primary CONFIGURE ZONE USING
+                              num_replicas = 9
+
+statement ok
+ALTER PARTITION p1 OF TABLE copy_from_parent CONFIGURE ZONE USING num_replicas = COPY FROM PARENT
+
+query TT
+SELECT zone_name, config_sql FROM [SHOW ZONE CONFIGURATIONS] WHERE zone_name = 'test.copy_from_parent.p1'
+----
+test.copy_from_parent.p1  ALTER PARTITION p1 OF INDEX test.public.copy_from_parent@primary CONFIGURE ZONE USING
+                              num_replicas = 9
+
+# check that copy from parent on a subzone doesn't accidentally modify the parent zone.
+statement ok
+CREATE TABLE parent_modify (x INT, INDEX idx (x));
+ALTER TABLE parent_modify CONFIGURE ZONE USING gc.ttlseconds = 700;
+ALTER INDEX parent_modify@idx CONFIGURE ZONE USING num_replicas = COPY FROM PARENT
+
+query TT
+SELECT zone_name, config_sql FROM [SHOW ZONE CONFIGURATIONS] WHERE zone_name = 'test.parent_modify@idx'
+----
+test.parent_modify@idx  ALTER INDEX test.public.parent_modify@idx CONFIGURE ZONE USING
+                        num_replicas = 7
+
+query TT
+SELECT zone_name, config_sql FROM [SHOW ZONE CONFIGURATIONS] WHERE zone_name = 'test.parent_modify'
+----
+test.parent_modify  ALTER TABLE test.public.parent_modify CONFIGURE ZONE USING
+                    gc.ttlseconds = 700
+
 # ------------------------------------------------------------------------------
 # Regression test for #36348; place this at the bottom of this file.
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Backport 1/1 commits from #41506.

/cc @cockroachdb/release

---

This PR fixes two bugs related to setting zone configurations.

* COPY FROM PARENT was ignored when using it on partitions and indexes
* COPY FROM PARENT was ignored when using it on a zone that had an
existing value for the field that was being changed with COPY FROM
PARENT.

This change should be backported onto 19.2.

Release note (bug fix): Fix multiple bugs relating to zone
configurations and copy from parent:
* COPY FROM PARENT was ignored when using it on partitions and indexes
* COPY FROM PARENT was ignored when using it on a zone that had an
existing value for the field that was being changed with COPY FROM
PARENT.
