### PR TITLE
backup: allow more outstanding requests

### DIFF
--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -746,7 +746,7 @@ func backup(
 	// TODO(dan): Make this limiting per node.
 	//
 	// TODO(dan): See if there's some better solution than rate-limiting #14798.
-	maxConcurrentExports := clusterNodeCount(gossip) * int(storage.ExportRequestsLimit.Get(&settings.SV))
+	maxConcurrentExports := clusterNodeCount(gossip) * int(storage.ExportRequestsLimit.Get(&settings.SV)) * 10
 	exportsSem := make(chan struct{}, maxConcurrentExports)
 
 	g := ctxgroup.WithContext(ctx)


### PR DESCRIPTION
Currently we limit the number of outstanding requests to num-nodes * reqs-a-node-processes-concurrently (1).

However, this means there are no _queued_ requests, and we end up with under-utilization. In some cases,
when multiple requests go to a single node, the under-utilization can be dramatic.

These requests are not that large or expensive if they queue at the client side, so allowing more to be
sent should let the existing client-side limiting do its job, without under-utilizing quiet so much
due to send-side limiting.

Release note (enterprise change): increase BACKUP parallelism in some cases.