### PR TITLE
roachtest: actually skip zerosum-splits

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -64,6 +64,7 @@ func registerAcceptance(r *testRegistry) {
 	for _, tc := range testCases {
 		tc := tc // copy for closure
 		spec := specTemplate
+		spec.Skip = tc.skip
 		spec.Name = specTemplate.Name + "/" + tc.name
 		spec.MinVersion = tc.minVersion
 		if tc.timeout != 0 {


### PR DESCRIPTION
This claims to have been skipped for a long time, but it's happily
running (and flaking).

Release note: None