### PR TITLE
release-19.2: changefeedccl: fix bug in table history when fetching old table descs after restart

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1877,3 +1877,107 @@ func TestChangefeedMemBufferCapacity(t *testing.T) {
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
 }
+
+// Regression test for #41694
+func TestChangefeedRestartDuringBackfill(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	defer func(i time.Duration) { jobs.DefaultAdoptInterval = i }(jobs.DefaultAdoptInterval)
+	jobs.DefaultAdoptInterval = 10 * time.Millisecond
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		knobs := f.Server().(*server.TestServer).Cfg.TestingKnobs.
+			DistSQL.(*execinfra.TestingKnobs).
+			Changefeed.(*TestingKnobs)
+		beforeEmitRowCh := make(chan error, 20)
+		knobs.BeforeEmitRow = func(ctx context.Context) error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case err := <-beforeEmitRowCh:
+				return err
+			}
+		}
+
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (0), (1), (2), (3)`)
+
+		foo := feed(t, f, `CREATE CHANGEFEED FOR foo`).(*cdctest.TableFeed)
+		defer closeFeed(t, foo)
+
+		// TODO(dan): At a high level, all we're doing is trying to restart a
+		// changefeed in the middle of changefeed backfill after a schema change
+		// finishes. It turns out this is pretty hard to do with our current testing
+		// knobs and this test ends up being pretty brittle. I'd love it if anyone
+		// thought of a better way to do this.
+
+		// Read the initial data in the rows.
+		for i := 0; i < 4; i++ {
+			beforeEmitRowCh <- nil
+		}
+		assertPayloads(t, foo, []string{
+			`foo: [0]->{"after": {"a": 0}}`,
+			`foo: [1]->{"after": {"a": 1}}`,
+			`foo: [2]->{"after": {"a": 2}}`,
+			`foo: [3]->{"after": {"a": 3}}`,
+		})
+
+		// Run a schema change that backfills kvs.
+		sqlDB.Exec(t, `ALTER TABLE foo ADD COLUMN b STRING DEFAULT 'backfill'`)
+
+		// Unblock emit for each kv written by the schema change's backfill. The
+		// changefeed actually emits these, but we lose it to overaggressive
+		// duplicate detection in tableFeed.
+		// TODO(dan): Track duplicates more precisely in tableFeed.
+		for i := 0; i < 4; i++ {
+			beforeEmitRowCh <- nil
+		}
+
+		// Unblock the emit for *all but one* of the rows emitted by the changefeed
+		// backfill (run after the schema change completes and the final table
+		// descriptor is written). The reason this test has 4 rows is because the
+		// `sqlSink` that powers `tableFeed` only flushes after it has 3 rows, so we
+		// need 1 more than that to guarantee that this first one gets flushed.
+		for i := 0; i < 3; i++ {
+			beforeEmitRowCh <- nil
+		}
+		assertPayloads(t, foo, []string{
+			`foo: [0]->{"after": {"a": 0, "b": "backfill"}}`,
+		})
+
+		// Restart the changefeed without allowing the second row to be backfilled.
+		sqlDB.Exec(t, `PAUSE JOB $1`, foo.JobID)
+		// Make extra sure that the zombie changefeed can't write any more data.
+		beforeEmitRowCh <- MarkRetryableError(errors.New(`nope don't write it`))
+
+		// Insert some data that we should only see out of the changefeed after it
+		// re-runs the backfill.
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (6, 'bar')`)
+
+		// Unblock all later emits, we don't need this control anymore.
+		close(beforeEmitRowCh)
+
+		// Resume the changefeed and the backfill should start up again. Currently
+		// this does the entire backfill again, you could imagine in the future that
+		// we do some sort of backfill checkpointing and start the backfill up from
+		// the last checkpoint.
+		sqlDB.Exec(t, `RESUME JOB $1`, foo.JobID)
+		assertPayloads(t, foo, []string{
+			// The changefeed actually emits this row, but we lose it to
+			// overaggressive duplicate detection in tableFeed.
+			// TODO(dan): Track duplicates more precisely in sinklessFeed/tableFeed.
+			// `foo: [0]->{"after": {"a": 0, "b": "backfill"}}`,
+			`foo: [1]->{"after": {"a": 1, "b": "backfill"}}`,
+			`foo: [2]->{"after": {"a": 2, "b": "backfill"}}`,
+			`foo: [3]->{"after": {"a": 3, "b": "backfill"}}`,
+		})
+
+		assertPayloads(t, foo, []string{
+			`foo: [6]->{"after": {"a": 6, "b": "bar"}}`,
+		})
+	}
+
+	// Only the enterprise version uses jobs.
+	t.Run(`enterprise`, enterpriseTest(testFn))
+}


### PR DESCRIPTION
Backport 1/1 commits from #41702.

/cc @cockroachdb/release

---

Fixes: #41694

In poller.go the poller constructs a tableHistory object and
periodically calls ExportRequest with a startTS and endTS to
fetch a list of table descriptors that were modified in this
time window. Note that this doesn't fetch the table descriptor
versions that were live at startTS.

Now, consider the case where a backfill is detected, but there is a
job restart before the backfill is triggered: the poller restarts
at the previous globally resolved timestamp and starts calling
ExportRequest again with startTS set to the aforementioned globally
resolved timestamp. Now, since this ExportRequest call doesn't
fetch the table descriptor version live at startTS, it is possible
that this method only fetches the table descriptor(s) after the
column backfill mutation has already been applied.

If this happens, the tableHistory and poller have no way of detecting
and triggering a backfill, which could lead to certain row updates
simply never being emitted. This PR fixes this problem by separately
adding the *current live* table descriptor version to the list returned
by `fetchTableDescriptorVersions`.

Release note (changefeed): Fix bug in tableHistory/poller.

Release justification (changefeed): Fixes correctness bug in tableHistory/poller.

Release note: None
