### PR TITLE
storage: limit concurrency of ExportRequest before acquiring locks

### DIFF
--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -67,11 +67,6 @@ func evalExport(
 		reply.StartTime = gcThreshold
 	}
 
-	if err := cArgs.EvalCtx.GetLimiters().ConcurrentExportRequests.Begin(ctx); err != nil {
-		return result.Result{}, err
-	}
-	defer cArgs.EvalCtx.GetLimiters().ConcurrentExportRequests.Finish()
-
 	makeExternalStorage := !args.ReturnSST || args.Storage != roachpb.ExternalStorage{} ||
 		(args.StorageByLocalityKV != nil && len(args.StorageByLocalityKV) > 0)
 	if makeExternalStorage || log.V(1) {

--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -245,6 +245,16 @@ func (ba *BatchRequest) IsSingleAddSSTableRequest() bool {
 	return false
 }
 
+// IsSingleExportRequest returns true iff the batch contains a single
+// request, and that request is an ExportRequest.
+func (ba *BatchRequest) IsSingleExportRequest() bool {
+	if ba.IsSingleRequest() {
+		_, ok := ba.Requests[0].GetInner().(*ExportRequest)
+		return ok
+	}
+	return false
+}
+
 // IsCompleteTransaction determines whether a batch contains every write in a
 // transactions.
 func (ba *BatchRequest) IsCompleteTransaction() bool {


### PR DESCRIPTION
Limiting inside eval is unfortunate as it holds latches while sleeping -- a large export waiting on a small one may lock out other requests that could proceed in the meantime, and a queue of export requests can starve other traffic.
Instead, limiting these like we do AddSSTable at store.Send, before they get in line and acquire latches, should reduce their impact on other traffic.

Release note: none.