### PR TITLE
coldata: use flat bytes implementation instead of [][]byte

### DIFF
--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -135,6 +135,11 @@ func (m *MemBatch) SetSelection(b bool) {
 // SetLength implements the Batch interface.
 func (m *MemBatch) SetLength(n uint16) {
 	m.n = n
+	for _, v := range m.b {
+		if v.Type() == coltypes.Bytes {
+			v.Bytes().EnforceNonDecreasingOffsets(uint64(n))
+		}
+	}
 }
 
 // AppendCol implements the Batch interface.

--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -137,7 +137,7 @@ func (m *MemBatch) SetLength(n uint16) {
 	m.n = n
 	for _, v := range m.b {
 		if v.Type() == coltypes.Bytes {
-			v.Bytes().EnforceNonDecreasingOffsets(uint64(n))
+			v.Bytes().UpdateOffsetsToBeNonDecreasing(uint64(n))
 		}
 	}
 }

--- a/pkg/col/coldata/batch_test.go
+++ b/pkg/col/coldata/batch_test.go
@@ -61,7 +61,6 @@ func TestBatchReset(t *testing.T) {
 			case coltypes.Bytes:
 				x := vec.Bytes()
 				assert.True(t, x.Len() >= n)
-				assert.True(t, cap(x.PrimitiveRepr()) >= selCap)
 				x.Set(0, []byte{1})
 			default:
 				panic(vec.Type())

--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -15,82 +15,8 @@ import (
 	"strings"
 )
 
-// Bytes is a wrapper type for a two-dimensional byte slice.
+// Bytes is a wrapper type for a two-dimensional byte slice ([][]byte).
 type Bytes struct {
-	data [][]byte
-}
-
-// NewBytes returns a Bytes struct with enough capacity for n elements.
-func NewBytes(n int) *Bytes {
-	return &Bytes{
-		data: make([][]byte, n),
-	}
-}
-
-// Get returns the ith []byte in Bytes.
-func (b *Bytes) Get(i int) []byte {
-	return b.data[i]
-}
-
-// Set sets the ith []byte in Bytes.
-func (b *Bytes) Set(i int, v []byte) {
-	b.data[i] = v
-}
-
-// Slice returns a new Bytes struct with its internal data sliced according to
-// start and end.
-func (b *Bytes) Slice(start, end int) *Bytes {
-	return &Bytes{data: b.data[start:end]}
-}
-
-// CopySlice copies srcStartIdx inclusive and srcEndIdx inclusive []byte values
-// from src into the receiver starting at destIdx.
-func (b *Bytes) CopySlice(src *Bytes, destIdx, srcStartIdx, srcEndIdx int) {
-	copy(b.data[destIdx:], src.data[srcStartIdx:srcEndIdx])
-}
-
-// AppendSlice appends srcStartIdx inclusive and srcEndIdx inclusive []byte
-// values from src into the receiver starting at destIdx.
-func (b *Bytes) AppendSlice(src *Bytes, destIdx, srcStartIdx, srcEndIdx int) {
-	b.data = append(b.data[:destIdx], src.data[srcStartIdx:srcEndIdx]...)
-}
-
-// AppendVal appends the given []byte value to the end of the receiver.
-func (b *Bytes) AppendVal(v []byte) {
-	b.data = append(b.data, v)
-}
-
-// Len returns how many []byte values the receiver contains.
-func (b *Bytes) Len() int {
-	return len(b.data)
-}
-
-var zeroBytesColumn = make([][]byte, BatchSize())
-
-// Zero zeroes out the underlying bytes.
-func (b *Bytes) Zero() {
-	for n := 0; n < len(b.data); n += copy(b.data[n:], zeroBytesColumn) {
-	}
-}
-
-// PrimitiveRepr is a temprorary migration tool.
-// TODO(asubiotto): Remove this.
-func (b *Bytes) PrimitiveRepr() [][]byte {
-	return b.data
-}
-
-// Reset here is a stub that is added so that the calls that used to be to
-// flatBytes.Reset() don't need to be removed.
-func (b *Bytes) Reset() {}
-
-// TODO(yuzefovich): fix flatBytes implementation and use that instead of
-// Bytes.
-
-// Remove the unused warnings.
-var _ *flatBytes = newFlatBytes(0)
-
-// flatBytes is a wrapper type for a two-dimensional byte slice ([][]byte).
-type flatBytes struct {
 	// data is the slice of all bytes.
 	data []byte
 	// offsets contains the offsets for each []byte slice in data.
@@ -106,11 +32,11 @@ type flatBytes struct {
 	maxSetIndex int
 }
 
-// newFlatBytes returns a flatBytes struct with enough capacity for n zero-length
-// []byte values. It is legal to call Set on the returned flatBytes at this point,
+// NewBytes returns a Bytes struct with enough capacity for n zero-length
+// []byte values. It is legal to call Set on the returned Bytes at this point,
 // but Get is undefined until at least one element is Set.
-func newFlatBytes(n int) *flatBytes {
-	return &flatBytes{
+func NewBytes(n int) *Bytes {
+	return &Bytes{
 		// Given that the []byte slices are of variable length, we multiply the
 		// number of elements by some constant factor.
 		// TODO(asubiotto): Make this tunable.
@@ -120,17 +46,17 @@ func newFlatBytes(n int) *flatBytes {
 	}
 }
 
-// Get returns the ith []byte in flatBytes. Note that the returned byte slice is
+// Get returns the ith []byte in Bytes. Note that the returned byte slice is
 // unsafe for reuse if any write operation happens.
-func (b *flatBytes) Get(i int) []byte {
+func (b *Bytes) Get(i int) []byte {
 	return b.data[b.offsets[i] : b.offsets[i]+b.lengths[i]]
 }
 
-// Set sets the ith []byte in flatBytes. Overwriting a value that is not at the end
-// of the flatBytes is not allowed since it complicates memory movement to make/take
+// Set sets the ith []byte in Bytes. Overwriting a value that is not at the end
+// of the Bytes is not allowed since it complicates memory movement to make/take
 // away necessary space in the flat buffer. Note that a nil value will be
 // "converted" into an empty byte slice.
-func (b *flatBytes) Set(i int, v []byte) {
+func (b *Bytes) Set(i int, v []byte) {
 	if i < b.maxSetIndex {
 		panic(
 			fmt.Sprintf(
@@ -151,12 +77,12 @@ func (b *flatBytes) Set(i int, v []byte) {
 	b.maxSetIndex = i
 }
 
-// Slice modifies and returns the receiver flatBytes struct sliced according to
+// Slice modifies and returns the receiver Bytes struct sliced according to
 // start and end. Returning the result is not necessary but is done for
 // compatibility with the usage of other data representations in vectorized
 // execution. Note that Slicing can be expensive since it incurs a step to
 // translate offsets.
-func (b *flatBytes) Slice(start, end int) *flatBytes {
+func (b *Bytes) Slice(start, end int) *Bytes {
 	if start == 0 && end == len(b.offsets) {
 		return b
 	}
@@ -183,14 +109,14 @@ func (b *flatBytes) Slice(start, end int) *flatBytes {
 // min(dest.Len(), src.Len()) values will be copied. Note that if the length of
 // the receiver is greater than the length of the source, bytes will have to be
 // physically moved. Consider the following example:
-// dest flatBytes: "helloworld", offsets: []int32{0, 5}, lengths: []int32{5, 5}
-// src flatBytes: "a", offsets: []int32{0}, lengths: []int32{1}
+// dest Bytes: "helloworld", offsets: []int32{0, 5}, lengths: []int32{5, 5}
+// src Bytes: "a", offsets: []int32{0}, lengths: []int32{1}
 // If we copy src into the beginning of dest, we will have to move "world" so
 // that the result is:
-// result flatBytes: "aworld", offsets: []int32{0, 1}, lengths: []int32{1, 5}
+// result Bytes: "aworld", offsets: []int32{0, 1}, lengths: []int32{1, 5}
 // Similarly, if "a", is instead "alongerstring", "world" would have to be
 // shifted right.
-func (b *flatBytes) CopySlice(src *flatBytes, destIdx, srcStartIdx, srcEndIdx int) {
+func (b *Bytes) CopySlice(src *Bytes, destIdx, srcStartIdx, srcEndIdx int) {
 	if destIdx < 0 || destIdx > b.Len() {
 		panic(fmt.Sprintf("dest index %d out of range (len=%d)", destIdx, b.Len()))
 	} else if srcStartIdx < 0 || srcStartIdx >= src.Len() || srcEndIdx > src.Len() || srcStartIdx > srcEndIdx {
@@ -270,7 +196,7 @@ func (b *flatBytes) CopySlice(src *flatBytes, destIdx, srcStartIdx, srcEndIdx in
 
 // AppendSlice appends srcStartIdx inclusive and srcEndIdx exclusive []byte
 // values from src into the receiver starting at destIdx.
-func (b *flatBytes) AppendSlice(src *flatBytes, destIdx, srcStartIdx, srcEndIdx int) {
+func (b *Bytes) AppendSlice(src *Bytes, destIdx, srcStartIdx, srcEndIdx int) {
 	if destIdx < 0 || destIdx > b.Len() {
 		panic(fmt.Sprintf("dest index %d out of range (len=%d)", destIdx, b.Len()))
 	} else if srcStartIdx < 0 || srcStartIdx >= src.Len() || srcEndIdx > src.Len() || srcStartIdx > srcEndIdx {
@@ -298,7 +224,7 @@ func (b *flatBytes) AppendSlice(src *flatBytes, destIdx, srcStartIdx, srcEndIdx 
 	}
 
 	// Calculate the amount to translate offsets by before modifying any
-	// destination offsets since we might be appending from the same flatBytes (and
+	// destination offsets since we might be appending from the same Bytes (and
 	// might be overwriting information).
 	translateBy := destDataIdx - src.offsets[srcStartIdx]
 	b.data = append(b.data[:destDataIdx], srcDataToAppend...)
@@ -318,7 +244,7 @@ func (b *flatBytes) AppendSlice(src *flatBytes, destIdx, srcStartIdx, srcEndIdx 
 
 // AppendVal appends the given []byte value to the end of the receiver. A nil
 // value will be "converted" into an empty byte slice.
-func (b *flatBytes) AppendVal(v []byte) {
+func (b *Bytes) AppendVal(v []byte) {
 	b.maxSetIndex = len(b.offsets)
 	b.offsets = append(b.offsets, int32(len(b.data)))
 	b.lengths = append(b.lengths, int32(len(v)))
@@ -326,7 +252,7 @@ func (b *flatBytes) AppendVal(v []byte) {
 }
 
 // Len returns how many []byte values the receiver contains.
-func (b *flatBytes) Len() int {
+func (b *Bytes) Len() int {
 	return len(b.offsets)
 }
 
@@ -335,7 +261,7 @@ var zeroInt32Slice = make([]int32, BatchSize())
 // Zero zeroes out the underlying bytes. Note that this doesn't change the
 // length. Use this instead of Reset if you need to be able to Get zeroed byte
 // slices.
-func (b *flatBytes) Zero() {
+func (b *Bytes) Zero() {
 	b.data = b.data[:0]
 	for n := 0; n < len(b.offsets); n += copy(b.offsets[n:], zeroInt32Slice) {
 	}
@@ -344,18 +270,18 @@ func (b *flatBytes) Zero() {
 	b.maxSetIndex = 0
 }
 
-// Reset resets the underlying flatBytes for reuse.
+// Reset resets the underlying Bytes for reuse.
 // This is useful when the caller is going to overwrite the underlying bytes and
 // needs a quick way to Reset. Note that this doesn't change the length either.
 // TODO(asubiotto): Move towards removing Set in favor of AppendVal. At that
 //  point we can reset the length to 0.
-func (b *flatBytes) Reset() {
+func (b *Bytes) Reset() {
 	b.data = b.data[:0]
 	b.maxSetIndex = 0
 }
 
 // String is used for debugging purposes.
-func (b *flatBytes) String() string {
+func (b *Bytes) String() string {
 	var builder strings.Builder
 	for i := range b.offsets {
 		builder.WriteString(
@@ -365,7 +291,6 @@ func (b *flatBytes) String() string {
 	return builder.String()
 }
 
-/*
 // BytesFromArrowSerializationFormat takes an Arrow byte slice and accompanying
 // offsets and populates b.
 func BytesFromArrowSerializationFormat(b *Bytes, data []byte, offsets []int32) {
@@ -386,7 +311,6 @@ func BytesFromArrowSerializationFormat(b *Bytes, data []byte, offsets []int32) {
 	b.maxSetIndex = len(offsets) - 1
 }
 
-
 // ToArrowSerializationFormat returns a bytes slice and offsets that are
 // Arrow-compatible. n is the number of elements to serialize.
 func (b *Bytes) ToArrowSerializationFormat(n int) ([]byte, []int32) {
@@ -398,4 +322,3 @@ func (b *Bytes) ToArrowSerializationFormat(n int) ([]byte, []int32) {
 	offsets := append(b.offsets[:n], serializeLength)
 	return data, offsets
 }
-*/

--- a/pkg/col/coldata/bytes_test.go
+++ b/pkg/col/coldata/bytes_test.go
@@ -56,11 +56,11 @@ var bytesMethods = []bytesMethod{set, slice, copySlice, appendSlice, appendVal}
 // [][]byte implementation and checks if the results are equal. If
 // selfReferencingSources is true, this is an indication by the caller that we
 // are testing an edge case where the source for copies/appends refers to the
-// destination. In cases where *flatBytes updates itself under the hood, we also
+// destination. In cases where *Bytes updates itself under the hood, we also
 // update the corresponding b2Source to mirror the behavior.
 func applyMethodsAndVerify(
 	rng *rand.Rand,
-	b1, b1Source *flatBytes,
+	b1, b1Source *Bytes,
 	b2, b2Source [][]byte,
 	methods []bytesMethod,
 	selfReferencingSources bool,
@@ -158,7 +158,7 @@ func applyMethodsAndVerify(
 	return nil
 }
 
-func verifyEqual(flat *flatBytes, b [][]byte) error {
+func verifyEqual(flat *Bytes, b [][]byte) error {
 	if flat.Len() != len(b) {
 		return errors.Errorf("mismatched lengths %d != %d", flat.Len(), len(b))
 	}
@@ -180,7 +180,7 @@ func prettyByteSlice(b [][]byte) string {
 	return builder.String()
 }
 
-func TestFlatBytesRefImpl(t *testing.T) {
+func TestBytesRefImpl(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	rng, _ := randutil.NewPseudoRand()
@@ -192,7 +192,7 @@ func TestFlatBytesRefImpl(t *testing.T) {
 
 	n := 1 + rng.Intn(maxLength)
 
-	flat := newFlatBytes(n)
+	flat := NewBytes(n)
 	reference := make([][]byte, n)
 	for i := 0; i < n; i++ {
 		v := make([]byte, rng.Intn(16))
@@ -210,7 +210,7 @@ func TestFlatBytesRefImpl(t *testing.T) {
 	if rng.Float64() < 0.5 {
 		selfReferencingSources = false
 		sourceN = 1 + rng.Intn(maxLength)
-		flatSource = newFlatBytes(sourceN)
+		flatSource = NewBytes(sourceN)
 		referenceSource = make([][]byte, sourceN)
 		for i := 0; i < sourceN; i++ {
 			v := make([]byte, rng.Intn(16))
@@ -238,11 +238,11 @@ func TestFlatBytesRefImpl(t *testing.T) {
 	}
 }
 
-func TestFlatBytes(t *testing.T) {
+func TestBytes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	t.Run("Simple", func(t *testing.T) {
-		b1 := newFlatBytes(0)
+		b1 := NewBytes(0)
 		b1.AppendVal([]byte("hello"))
 		require.Equal(t, "hello", string(b1.Get(0)))
 		b1.AppendVal(nil)
@@ -258,7 +258,7 @@ func TestFlatBytes(t *testing.T) {
 		// However, it is legal to overwrite the last value.
 		b1.Set(1, []byte("ok"))
 
-		// If we Zero the flatBytes, we can Set any index.
+		// If we Zero the Bytes, we can Set any index.
 		b1.Zero()
 		b1.Set(1, []byte("new usage"))
 		// But not an index before that.
@@ -274,8 +274,8 @@ func TestFlatBytes(t *testing.T) {
 	})
 
 	t.Run("Append", func(t *testing.T) {
-		b1 := newFlatBytes(0)
-		b2 := newFlatBytes(0)
+		b1 := NewBytes(0)
+		b2 := NewBytes(0)
 		b2.AppendVal([]byte("source bytes value"))
 		b1.AppendVal([]byte("one"))
 		b1.AppendVal([]byte("two"))
@@ -296,7 +296,7 @@ func TestFlatBytes(t *testing.T) {
 			}
 		}
 
-		b2 = newFlatBytes(0)
+		b2 = NewBytes(0)
 		b2.AppendVal([]byte("hello again"))
 		b2.AppendVal([]byte("hello again"))
 		b2.AppendVal([]byte("hello again"))
@@ -309,8 +309,8 @@ func TestFlatBytes(t *testing.T) {
 	})
 
 	t.Run("Copy", func(t *testing.T) {
-		b1 := newFlatBytes(0)
-		b2 := newFlatBytes(0)
+		b1 := NewBytes(0)
+		b2 := NewBytes(0)
 		b1.AppendVal([]byte("one"))
 		b1.AppendVal([]byte("two"))
 		b1.AppendVal([]byte("three"))

--- a/pkg/col/coldata/bytes_test.go
+++ b/pkg/col/coldata/bytes_test.go
@@ -154,6 +154,7 @@ func applyMethodsAndVerify(
 		default:
 			return errors.Errorf("unknown method name: %s", m)
 		}
+		b1.AssertOffsetsAreNonDecreasing(uint64(b1.Len()))
 		debugString += fmt.Sprintf("\n%s\n", b1)
 		if err := verifyEqual(b1, b2); err != nil {
 			return errors.Wrap(err, fmt.Sprintf("\ndebugString:\n%sflat (maxSetIdx=%d):\n%sreference:\n%s", debugString, b1.maxSetIndex, b1.String(), prettyByteSlice(b2)))
@@ -368,5 +369,18 @@ func TestBytes(t *testing.T) {
 		b2.AppendVal([]byte("four"))
 		require.Equal(t, "four", string(b1.Get(2)), "appending to the slice of b1 should have updated b1")
 		require.Equal(t, "four", string(b2.Get(1)))
+	})
+
+	t.Run("InvariantSimple", func(t *testing.T) {
+		b1 := NewBytes(8)
+		b1.Set(0, []byte("zero"))
+		other := b1.Slice(0, 2)
+		other.AssertOffsetsAreNonDecreasing(2)
+
+		b2 := NewBytes(8)
+		b2.Set(0, []byte("zero"))
+		b2.Set(2, []byte("two"))
+		other = b2.Slice(0, 4)
+		other.AssertOffsetsAreNonDecreasing(4)
 	})
 }

--- a/pkg/col/coldata/bytes_test.go
+++ b/pkg/col/coldata/bytes_test.go
@@ -16,6 +16,7 @@ import (
 	"math/rand"
 	"strings"
 	"testing"
+	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -59,33 +60,22 @@ var bytesMethods = []bytesMethod{set, slice, copySlice, appendSlice, appendVal}
 // destination. In cases where *Bytes updates itself under the hood, we also
 // update the corresponding b2Source to mirror the behavior.
 func applyMethodsAndVerify(
-	rng *rand.Rand,
-	b1, b1Source *Bytes,
-	b2, b2Source [][]byte,
-	methods []bytesMethod,
-	selfReferencingSources bool,
+	rng *rand.Rand, b1 *Bytes, b2 [][]byte, methods []bytesMethod, maxLength int,
 ) error {
 	if err := verifyEqual(b1, b2); err != nil {
 		return errors.Wrap(err, "arguments should start as equal")
 	}
-	if err := verifyEqual(b1Source, b2Source); err != nil {
-		return errors.Wrap(err, "argument sources should start as equal")
-	}
-	var debugString string
+	debugString := fmt.Sprintf("\ninitial:\n%s\n", b1)
 	for _, m := range methods {
 		n := b1.Len()
 		if n != len(b2) {
 			return errors.Errorf("length mismatch between flat and reference: %d != %d", n, len(b2))
 		}
-		sourceN := b1Source.Len()
-		if sourceN != len(b2Source) {
-			return errors.Errorf("length mismatch between flat and reference sources: %d != %d", sourceN, len(b2Source))
-		}
 		debugString += m.String()
 		switch m {
 		case set:
-			// Can only Set the last index.
-			i := b1.Len() - 1
+			// Can only Set starting from maxSetIndex.
+			i := b1.maxSetIndex + rng.Intn(b1.Len()-b1.maxSetIndex)
 			new := make([]byte, rng.Intn(16))
 			rng.Read(new)
 			debugString += fmt.Sprintf("(%d, %v)", i, new)
@@ -105,12 +95,19 @@ func applyMethodsAndVerify(
 			debugString += fmt.Sprintf("(%d, %d)", start, end)
 			b1 = b1.Slice(start, end)
 			b2 = b2[start:end]
-			if selfReferencingSources {
-				b2Source = b2
-			}
 		case copySlice, appendSlice:
 			// Generate a length-inclusive destIdx.
 			destIdx := rng.Intn(n + 1)
+			// Make a pair of sources to copy/append from.
+			sourceN := 1 + rng.Intn(maxLength)
+			flatSource := NewBytes(sourceN)
+			referenceSource := make([][]byte, sourceN)
+			for i := 0; i < sourceN; i++ {
+				v := make([]byte, rng.Intn(16))
+				rng.Read(v)
+				flatSource.Set(i, append([]byte(nil), v...))
+				referenceSource[i] = append([]byte(nil), v...)
+			}
 			srcStartIdx := rng.Intn(sourceN)
 			srcEndIdx := rng.Intn(sourceN)
 			if srcStartIdx > srcEndIdx {
@@ -121,22 +118,12 @@ func applyMethodsAndVerify(
 				srcEndIdx = sourceN
 			}
 			debugString += fmt.Sprintf("(%d, %d, %d)", destIdx, srcStartIdx, srcEndIdx)
-			var numNewVals int
 			if m == copySlice {
-				b1.CopySlice(b1Source, destIdx, srcStartIdx, srcEndIdx)
-				numNewVals = copy(b2[destIdx:], b2Source[srcStartIdx:srcEndIdx])
+				b1.CopySlice(flatSource, destIdx, srcStartIdx, srcEndIdx)
+				copy(b2[destIdx:], referenceSource[srcStartIdx:srcEndIdx])
 			} else {
-				b1.AppendSlice(b1Source, destIdx, srcStartIdx, srcEndIdx)
-				b2 = append(b2[:destIdx], b2Source[srcStartIdx:srcEndIdx]...)
-				if selfReferencingSources {
-					b2Source = b2
-				}
-				numNewVals = srcEndIdx - srcStartIdx
-			}
-			// Deep copy the copied/appended byte slices.
-			b2Slice := b2[destIdx : destIdx+numNewVals]
-			for i := range b2Slice {
-				b2Slice[i] = append([]byte(nil), b2Slice[i]...)
+				b1.AppendSlice(flatSource, destIdx, srcStartIdx, srcEndIdx)
+				b2 = append(b2[:destIdx], referenceSource[srcStartIdx:srcEndIdx]...)
 			}
 		case appendVal:
 			v := make([]byte, 16)
@@ -144,13 +131,10 @@ func applyMethodsAndVerify(
 			debugString += fmt.Sprintf("(%v)", v)
 			b1.AppendVal(v)
 			b2 = append(b2, v)
-			if selfReferencingSources {
-				b2Source = b2
-			}
 		default:
 			return errors.Errorf("unknown method name: %s", m)
 		}
-		debugString += "\n"
+		debugString += fmt.Sprintf("\n%s\n", b1)
 		if err := verifyEqual(b1, b2); err != nil {
 			return errors.Wrap(err, fmt.Sprintf("\ndebugString:\n%sflat (maxSetIdx=%d):\n%sreference:\n%s", debugString, b1.maxSetIndex, b1.String(), prettyByteSlice(b2)))
 		}
@@ -188,53 +172,34 @@ func TestBytesRefImpl(t *testing.T) {
 	const (
 		maxNumberOfCalls = 64
 		maxLength        = 16
+		nRuns            = 100
 	)
 
-	n := 1 + rng.Intn(maxLength)
+	for nRun := 0; nRun < nRuns; nRun++ {
+		n := 1 + rng.Intn(maxLength)
 
-	flat := NewBytes(n)
-	reference := make([][]byte, n)
-	for i := 0; i < n; i++ {
-		v := make([]byte, rng.Intn(16))
-		rng.Read(v)
-		flat.Set(i, append([]byte(nil), v...))
-		reference[i] = append([]byte(nil), v...)
-	}
-
-	// Make a pair of sources to copy/append from. Use the destination variables
-	// with a certain probability.
-	sourceN := n
-	flatSource := flat
-	referenceSource := reference
-	selfReferencingSources := true
-	if rng.Float64() < 0.5 {
-		selfReferencingSources = false
-		sourceN = 1 + rng.Intn(maxLength)
-		flatSource = NewBytes(sourceN)
-		referenceSource = make([][]byte, sourceN)
-		for i := 0; i < sourceN; i++ {
+		flat := NewBytes(n)
+		reference := make([][]byte, n)
+		for i := 0; i < n; i++ {
 			v := make([]byte, rng.Intn(16))
 			rng.Read(v)
-			flatSource.Set(i, append([]byte(nil), v...))
-			referenceSource[i] = append([]byte(nil), v...)
+			flat.Set(i, append([]byte(nil), v...))
+			reference[i] = append([]byte(nil), v...)
 		}
-	}
 
-	if err := verifyEqual(flat, reference); err != nil {
-		t.Fatalf("not equal: %v\nflat:\n%sreference:\n%s", err, flat, prettyByteSlice(reference))
-	}
+		if err := verifyEqual(flat, reference); err != nil {
+			t.Fatalf("not equal: %v\nflat:\n%sreference:\n%s", err, flat, prettyByteSlice(reference))
+		}
 
-	if err := verifyEqual(flatSource, referenceSource); err != nil {
-		t.Fatalf("sources not equal: %v\nflat:\n%sreference:\n%s", err, flat, prettyByteSlice(reference))
-	}
-
-	numCalls := 1 + rng.Intn(maxNumberOfCalls)
-	methods := make([]bytesMethod, 0, numCalls)
-	for i := 0; i < numCalls; i++ {
-		methods = append(methods, bytesMethods[rng.Intn(len(bytesMethods))])
-	}
-	if err := applyMethodsAndVerify(rng, flat, flatSource, reference, referenceSource, methods, selfReferencingSources); err != nil {
-		t.Fatal(err)
+		numCalls := 1 + rng.Intn(maxNumberOfCalls)
+		methods := make([]bytesMethod, 0, numCalls)
+		for i := 0; i < numCalls; i++ {
+			methods = append(methods, bytesMethods[rng.Intn(len(bytesMethods))])
+		}
+		if err := applyMethodsAndVerify(rng, flat, reference, methods, maxLength); err != nil {
+			t.Logf("nRun = %d\n", nRun)
+			t.Fatal(err)
+		}
 	}
 }
 
@@ -346,5 +311,23 @@ func TestBytes(t *testing.T) {
 		b1.CopySlice(b2, 0, 1, b2.Len())
 		require.Equal(t, 1, b1.Len())
 		require.Equal(t, "source two", string(b1.Get(0)))
+	})
+
+	t.Run("Slice", func(t *testing.T) {
+		b1 := NewBytes(0)
+		b1.AppendVal([]byte("one"))
+		b1.AppendVal([]byte("two"))
+		b1.AppendVal([]byte("three"))
+
+		s := b1.Slice(0, 3)
+		require.NotEqual(t, unsafe.Pointer(b1), unsafe.Pointer(s), "Bytes.Slice should create a new object")
+		b2 := b1.Slice(1, 2)
+		require.Equal(t, "one", string(b1.Get(0)))
+		require.Equal(t, "two", string(b1.Get(1)))
+		require.Equal(t, "two", string(b2.Get(0)))
+
+		b2.AppendVal([]byte("four"))
+		require.Equal(t, "four", string(b1.Get(2)), "appending to the slice of b1 should have updated b1")
+		require.Equal(t, "four", string(b2.Get(1)))
 	})
 }

--- a/pkg/col/colserde/arrowbatchconverter.go
+++ b/pkg/col/colserde/arrowbatchconverter.go
@@ -15,7 +15,6 @@ import (
 	"reflect"
 	"unsafe"
 
-	"github.com/apache/arrow/go/arrow"
 	"github.com/apache/arrow/go/arrow/array"
 	"github.com/apache/arrow/go/arrow/memory"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -34,9 +33,6 @@ type ArrowBatchConverter struct {
 	builders struct {
 		// boolBuilder builds arrow bool columns as a bitmap from a bool slice.
 		boolBuilder *array.BooleanBuilder
-		// binaryBuilder builds arrow []byte columns as one []byte slice with
-		// accompanying offsets from a [][]byte slice.
-		binaryBuilder *array.BinaryBuilder
 	}
 
 	scratch struct {
@@ -60,13 +56,12 @@ func NewArrowBatchConverter(typs []coltypes.T) (*ArrowBatchConverter, error) {
 	}
 	c := &ArrowBatchConverter{typs: typs}
 	c.builders.boolBuilder = array.NewBooleanBuilder(memory.DefaultAllocator)
-	c.builders.binaryBuilder = array.NewBinaryBuilder(memory.DefaultAllocator, arrow.BinaryTypes.Binary)
 	c.scratch.arrowData = make([]*array.Data, len(typs))
 	c.scratch.buffers = make([][]*memory.Buffer, len(typs))
 	for i := range c.scratch.buffers {
-		// Only primitive types are directly constructed, therefore we only need
-		// two buffers: one for the nulls, the other for the values.
-		c.scratch.buffers[i] = make([]*memory.Buffer, 2)
+		// Most types need only two buffers: one for the nulls, and one for the
+		// values, but some type (i.e. Bytes) need an extra buffer for the offsets.
+		c.scratch.buffers[i] = make([]*memory.Buffer, 0, 3)
 	}
 	return c, nil
 }
@@ -113,20 +108,11 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]*array.Data, 
 			arrowBitmap = n.NullBitmap()
 		}
 
-		if typ == coltypes.Bool || typ == coltypes.Bytes {
-			// Bools and Bytes are handled differently from other coltypes. Refer to the
+		if typ == coltypes.Bool {
+			// Bools are handled differently from other coltypes. Refer to the
 			// comment on ArrowBatchConverter.builders for more information.
-			var data *array.Data
-			switch typ {
-			case coltypes.Bool:
-				c.builders.boolBuilder.AppendValues(vec.Bool()[:n], nil /* valid */)
-				data = c.builders.boolBuilder.NewBooleanArray().Data()
-			case coltypes.Bytes:
-				c.builders.binaryBuilder.AppendValues(vec.Bytes().PrimitiveRepr()[:n], nil /* valid */)
-				data = c.builders.binaryBuilder.NewBinaryArray().Data()
-			default:
-				panic(fmt.Sprintf("unexpected type %s", typ))
-			}
+			c.builders.boolBuilder.AppendValues(vec.Bool()[:n], nil /* valid */)
+			data := c.builders.boolBuilder.NewBooleanArray().Data()
 			if arrowBitmap != nil {
 				// Overwrite empty null bitmap with the true bitmap.
 				data.Buffers()[0] = memory.NewBufferBytes(arrowBitmap)
@@ -136,7 +122,8 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]*array.Data, 
 		}
 
 		var (
-			values []byte
+			values  []byte
+			offsets []byte
 
 			// dataHeader is the reflect.SliceHeader of the coldata.Vec's underlying
 			// data slice that we are casting to bytes.
@@ -146,6 +133,15 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]*array.Data, 
 		)
 
 		switch typ {
+		case coltypes.Bytes:
+			var int32Offsets []int32
+			values, int32Offsets = vec.Bytes().ToArrowSerializationFormat(n)
+			// Cast int32Offsets to []byte.
+			int32Header := (*reflect.SliceHeader)(unsafe.Pointer(&int32Offsets))
+			offsetsHeader := (*reflect.SliceHeader)(unsafe.Pointer(&offsets))
+			offsetsHeader.Data = int32Header.Data
+			offsetsHeader.Len = int32Header.Len * sizeOfInt32
+			offsetsHeader.Cap = int32Header.Cap * sizeOfInt32
 		case coltypes.Int16:
 			ints := vec.Int16()[:n]
 			dataHeader = (*reflect.SliceHeader)(unsafe.Pointer(&ints))
@@ -166,16 +162,22 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]*array.Data, 
 			panic(fmt.Sprintf("unsupported type for conversion to arrow data %s", typ))
 		}
 
-		// Cast values.			// Cast values if not set (mostly for non-byte types).
-		valuesHeader := (*reflect.SliceHeader)(unsafe.Pointer(&values))
-		valuesHeader.Data = dataHeader.Data
-		valuesHeader.Len = dataHeader.Len * datumSize
-		valuesHeader.Cap = dataHeader.Cap * datumSize
+		// Cast values if not set (mostly for non-byte types).
+		if values == nil {
+			valuesHeader := (*reflect.SliceHeader)(unsafe.Pointer(&values))
+			valuesHeader.Data = dataHeader.Data
+			valuesHeader.Len = dataHeader.Len * datumSize
+			valuesHeader.Cap = dataHeader.Cap * datumSize
+		}
 
 		// Construct the underlying arrow buffers.
 		// WARNING: The ordering of construction is critical.
-		c.scratch.buffers[i][0] = memory.NewBufferBytes(arrowBitmap)
-		c.scratch.buffers[i][1] = memory.NewBufferBytes(values)
+		c.scratch.buffers[i] = c.scratch.buffers[i][:0]
+		c.scratch.buffers[i] = append(c.scratch.buffers[i], memory.NewBufferBytes(arrowBitmap))
+		if offsets != nil {
+			c.scratch.buffers[i] = append(c.scratch.buffers[i], memory.NewBufferBytes(offsets))
+		}
+		c.scratch.buffers[i] = append(c.scratch.buffers[i], memory.NewBufferBytes(values))
 
 		// Create the data from the buffers. It might be surprising that we don't
 		// set a type or a null count, but these fields are not used in the way that
@@ -238,11 +240,7 @@ func (c *ArrowBatchConverter) ArrowToBatch(data []*array.Data, b coldata.Batch) 
 					// corresponds.
 					bytes = make([]byte, 0)
 				}
-				offsets := bytesArr.ValueOffsets()
-				vecArr := vec.Bytes()
-				for i := 0; i < len(offsets)-1; i++ {
-					vecArr.Set(i, bytes[offsets[i]:offsets[i+1]])
-				}
+				coldata.BytesFromArrowSerializationFormat(vec.Bytes(), bytes, bytesArr.ValueOffsets())
 				arr = bytesArr
 			default:
 				panic(fmt.Sprintf("unexpected type %s", typ))

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -105,7 +105,6 @@ func (c *Columnarizer) Next(context.Context) coldata.Batch {
 		// phase.
 		copy(c.buffered[nRows], row)
 	}
-	c.batch.SetLength(nRows)
 
 	// Write each column into the output batch.
 	for idx, ct := range columnTypes {
@@ -114,6 +113,7 @@ func (c *Columnarizer) Next(context.Context) coldata.Batch {
 			execerror.VectorizedInternalPanic(err)
 		}
 	}
+	c.batch.SetLength(nRows)
 	return c.batch
 }
 

--- a/pkg/sql/colexec/invariants_checker.go
+++ b/pkg/sql/colexec/invariants_checker.go
@@ -1,0 +1,63 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colexec
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+)
+
+// invariantsChecker is a helper Operator that will check that invariants that
+// are present in the vectorized engine are maintained on all batches. It
+// should be planned between other Operators in tests.
+type invariantsChecker struct {
+	OneInputNode
+
+	expectedBatchWidth int
+}
+
+var _ Operator = invariantsChecker{}
+
+// NewInvariantsChecker creates a new invariantsChecker.
+func NewInvariantsChecker(input Operator, expectedBatchWidth int) Operator {
+	return &invariantsChecker{
+		OneInputNode:       OneInputNode{input: input},
+		expectedBatchWidth: expectedBatchWidth,
+	}
+}
+
+func (i invariantsChecker) Init() {
+	i.input.Init()
+}
+
+func (i invariantsChecker) Next(ctx context.Context) coldata.Batch {
+	b := i.input.Next(ctx)
+	n := b.Length()
+	if n == 0 {
+		return b
+	}
+	if i.expectedBatchWidth != b.Width() {
+		panic(
+			fmt.Sprintf("unexpected batch width: expected %d, got %d",
+				i.expectedBatchWidth, b.Width(),
+			))
+	}
+	for colIdx := 0; colIdx < b.Width(); colIdx++ {
+		v := b.ColVec(colIdx)
+		if v.Type() == coltypes.Bytes {
+			v.Bytes().AssertOffsetsAreNonDecreasing(uint64(n))
+		}
+	}
+	return b
+}

--- a/pkg/sql/colexec/mergejoiner.go
+++ b/pkg/sql/colexec/mergejoiner.go
@@ -446,7 +446,7 @@ func (o *mergeJoinBase) appendToBufferedGroup(
 	bufferedGroup.length += uint64(groupLength)
 	for _, v := range bufferedGroup.colVecs {
 		if v.Type() == coltypes.Bytes {
-			v.Bytes().EnforceNonDecreasingOffsets(bufferedGroup.length)
+			v.Bytes().UpdateOffsetsToBeNonDecreasing(bufferedGroup.length)
 		}
 	}
 }

--- a/pkg/sql/colexec/mergejoiner.go
+++ b/pkg/sql/colexec/mergejoiner.go
@@ -444,6 +444,11 @@ func (o *mergeJoinBase) appendToBufferedGroup(
 	// We've added groupLength number of tuples to bufferedGroup, so we need to
 	// adjust its length.
 	bufferedGroup.length += uint64(groupLength)
+	for _, v := range bufferedGroup.colVecs {
+		if v.Type() == coltypes.Bytes {
+			v.Bytes().EnforceNonDecreasingOffsets(bufferedGroup.length)
+		}
+	}
 }
 
 // setBuilderSourceToBatch sets the builder state to use groups from the

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -32,7 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 type vectorizedFlow struct {
@@ -603,6 +603,9 @@ func (s *vectorizedFlowCreator) setupFlow(
 		result, err := colexec.NewColOperator(ctx, flowCtx, pspec, inputs)
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to vectorize execution plan")
+		}
+		if flowCtx.Cfg != nil && flowCtx.Cfg.TestingKnobs.EnableVectorizedInvariantsChecker {
+			result.Op = colexec.NewInvariantsChecker(result.Op, len(result.ColumnTypes))
 		}
 		if flowCtx.EvalCtx.SessionData.VectorizeMode == sessiondata.VectorizeAuto &&
 			!result.IsStreaming {

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -205,6 +205,10 @@ type TestingKnobs struct {
 
 	// Changefeed contains testing knobs specific to the changefeed system.
 	Changefeed base.ModuleTestingKnobs
+
+	// EnableVectorizedInvariantsChecker, if enabled, will allow for planning
+	// the invariant checkers between all columnar operators.
+	EnableVectorizedInvariantsChecker bool
 }
 
 // MetadataTestLevel represents the types of queries where metadata test

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1076,6 +1076,9 @@ func (t *logicTest) setup(cfg testClusterConfig) {
 	if cfg.distSQLMetadataTestEnabled {
 		distSQLKnobs.MetadataTestLevel = execinfra.On
 	}
+	if strings.Compare(cfg.overrideVectorize, "off") != 0 {
+		distSQLKnobs.EnableVectorizedInvariantsChecker = true
+	}
 	params.ServerArgs.Knobs.DistSQL = distSQLKnobs
 	if cfg.bootstrapVersion != (cluster.ClusterVersion{}) {
 		params.ServerArgs.Knobs.Store.(*storage.StoreTestingKnobs).BootstrapVersion = &cfg.bootstrapVersion

--- a/pkg/workload/bench_test.go
+++ b/pkg/workload/bench_test.go
@@ -29,12 +29,8 @@ func columnByteSize(col coldata.Vec) int64 {
 	case coltypes.Float64:
 		return int64(len(col.Float64()) * 8)
 	case coltypes.Bytes:
-		var bytes int64
-		colBytes := col.Bytes()
-		for i := 0; i < colBytes.Len(); i++ {
-			bytes += int64(len(colBytes.Get(i)))
-		}
-		return bytes
+		// We subtract the overhead to be in line with Int64 and Float64 cases.
+		return int64(col.Bytes().Size() - coldata.FlatBytesOverhead)
 	default:
 		panic(fmt.Sprintf(`unhandled type %s`, col.Type().GoTypeName()))
 	}


### PR DESCRIPTION
**coldata: use flat bytes implementation instead of [][]byte**

This commit reverts the revert of using []byte + offsets implementation
of two-dimensional byte slice. The original revert was done due to
several issues which will be addressed in the follow-up commits.

**coldata: fix a couple of issues with flat bytes implementation**

This commit fixes the following:
- Slice method no longer modifies the receiver in-place and returns
  a shallow copy instead (as regular slices do)
- in CopySlice, srcEndIdx has been updated to be "trimmed" so that
  offsets and lengths are not overwritten past the copied values.

**coldata: remove lengths slice from flat bytes implementation**

Previously, we would use offsets and lengths to store the
information about each of the []byte in the flat bytes.
However, that information was quite redundant since
b.lengths[i] = b.offsets[i+1] - b.offsets[i], and this commit
removes that redundancy.

Also, this commit fixes a problem with how NULLs are treated.
Previously, it was possible for offsets of flat bytes to get into
an "inconsistent" state - we assume that the offsets are
non-decreasing, but when a NULL value is set on the colexec.Vec,
then Bytes will not be notified of this. As a result, there were
"gaps" of unset zero values in offsets. Now we're actively
backfilling the offsets to maintain the invariant.

Fixes: #40244.

**colexec: add invariants checker during logic tests**

This commit adds an ability to plan vectorized invariants
checkers while running the logic tests (in all configs except
for when the vectorized engine is disabled). The only invariants
that are currently being checked are that the batches are of correct
width and that all byte slices (up to the length of the batch) can be
retrieved from the flat bytes implementation.

Release note: None