### PR TITLE
engine: Fix pebble.OpenFile and related functions.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -427,7 +427,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:eb5b95cb849809eecc0f19778ea2b79d9c892208f4c57741b25102d2ceba9fa6"
+  digest = "1:ab7e14b6348c75df6fb37c3d327392aea6090e6154a95d1ff2cd0721e93fcd4d"
   name = "github.com/cockroachdb/pebble"
   packages = [
     ".",
@@ -450,7 +450,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "edde981dcc258907bdcc010017d1a7ccc6b59174"
+  revision = "9d80716063bb38e2772ced37c428ccc47d384b23"
 
 [[projects]]
   branch = "master"

--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -925,7 +925,7 @@ DBSstFileWriter* DBSstFileWriterNew() {
   rocksdb::BlockBasedTableOptions table_options;
   // Larger block size (4kb default) means smaller file at the expense of more
   // scanning during lookups.
-  table_options.block_size = 64 * 1024;
+  table_options.block_size = 32 * 1024;
   // The original LevelDB compatible format. We explicitly set the checksum too
   // to guard against the silent version upconversion. See
   // https://github.com/facebook/rocksdb/blob/972f96b3fbae1a4675043bdf4279c9072ad69645/include/rocksdb/table.h#L198

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -351,7 +351,8 @@ type Engine interface {
 	// that the key range is compacted all the way to the bottommost level of
 	// SSTables, which is necessary to pick up changes to bloom filters.
 	CompactRange(start, end roachpb.Key, forceBottommost bool) error
-	// OpenFile opens a DBFile with the given filename.
+	// OpenFile opens a DBFile with the given filename. The file should be created
+	// if it doesn't exist already, and should be writable.
 	OpenFile(filename string) (DBFile, error)
 	// ReadFile reads the content from the file with the given filename int this RocksDB's env.
 	ReadFile(filename string) ([]byte, error)

--- a/pkg/storage/engine/pebble.go
+++ b/pkg/storage/engine/pebble.go
@@ -432,12 +432,15 @@ func (p *Pebble) CompactRange(start, end roachpb.Key, forceBottommost bool) erro
 
 // OpenFile implements the Engine interface.
 func (p *Pebble) OpenFile(filename string) (DBFile, error) {
-	return p.fs.Open(p.fs.PathJoin(p.path, filename))
+	// TODO(itsbilal): Create does not currently truncate the file if it already
+	// exists. OpenFile in RocksDB truncates a file if it already exists. Unify
+	// behavior by adding a CreateWithTruncate functionality to pebble's vfs.FS.
+	return p.fs.Create(filename)
 }
 
 // ReadFile implements the Engine interface.
 func (p *Pebble) ReadFile(filename string) ([]byte, error) {
-	file, err := p.fs.Open(p.fs.PathJoin(p.path, filename))
+	file, err := p.fs.Open(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -482,9 +485,7 @@ func (p *Pebble) DeleteDirAndFiles(dir string) error {
 
 // LinkFile implements the Engine interface.
 func (p *Pebble) LinkFile(oldname, newname string) error {
-	oldPath := p.fs.PathJoin(p.path, oldname)
-	newPath := p.fs.PathJoin(p.path, newname)
-	return p.fs.Link(oldPath, newPath)
+	return p.fs.Link(oldname, newname)
 }
 
 // CreateCheckpoint implements the Engine interface.

--- a/pkg/storage/engine/sst_iterator.go
+++ b/pkg/storage/engine/sst_iterator.go
@@ -20,12 +20,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-var readerOpts = func() *sstable.Options {
-	opts := &sstable.Options{
-		Comparer: MVCCComparer,
-	}
-	return opts.EnsureDefaults()
-}()
+var readerOpts = sstable.ReaderOptions{
+	Comparer: MVCCComparer,
+}
 
 type sstIterator struct {
 	sst  *sstable.Reader


### PR DESCRIPTION
engine.OpenFile is called with the full path, not just the
filename, despite the variable name. That function is also
expected to create the file if it doesn't exist. This fix makes
changes to bring that function in line with what's in RocksDB.

Other miscellaneous sstable.{Reader,Writer} options changes to get
cockroach to build with the latest pebble.