### PR TITLE
opt: support selecting any table column when grouping by PK

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -353,8 +353,15 @@ SELECT count(*), k+v FROM kv GROUP BY k, v
 1 9
 1 NULL
 
-query error column "v" must appear in the GROUP BY clause or be used in an aggregate function
+query II rowsort
 SELECT count(*), k+v FROM kv GROUP BY k
+----
+1  3
+1  7
+1  NULL
+1  8
+1  9
+1  12
 
 query error column "k" must appear in the GROUP BY clause or be used in an aggregate function
 SELECT count(*), k+v FROM kv GROUP BY v
@@ -408,10 +415,12 @@ SELECT max(k), min(v) FROM kv HAVING k
 query error column "k" must appear in the GROUP BY clause or be used in an aggregate function
 SELECT 3 FROM kv GROUP BY v HAVING k > 5
 
-# pg has a special case for grouping on primary key, which would allow this, but we do not.
-# See http://www.postgresql.org/docs/current/static/sql-select.html#SQL-GROUPBY
-query error column "v" must appear in the GROUP BY clause or be used in an aggregate function
+# Special case for grouping on primary key.
+query I
 SELECT 3 FROM kv GROUP BY k HAVING v > 2
+----
+3
+3
 
 query error column "k" must appear in the GROUP BY clause or be used in an aggregate function
 SELECT k FROM kv HAVING k > 7
@@ -1920,3 +1929,41 @@ ORDER BY
 count_1  count_lower  count_upper  concat
 3        3            3            aaa
 3        3            3            bbb
+
+# Tests for selecting any columns when grouping by the PK.
+statement ok
+DELETE FROM ab WHERE true;
+INSERT INTO ab VALUES (1,1), (2,1), (3,3), (4, 7)
+
+query I rowsort
+SELECT b FROM ab GROUP BY a
+----
+1
+1
+3
+7
+
+query II rowsort
+SELECT a+b, count(*) FROM ab JOIN tab ON b=col2 GROUP BY a
+----
+11 2
+
+query IIII rowsort
+SELECT a, col1, b+col2, count(*) FROM ab JOIN tab ON b=col2 GROUP BY a, col1
+----
+4  -3  14  1
+4  0   14  1
+
+query IIII rowsort
+SELECT a, b, count(*), count(col2) FROM ab LEFT JOIN tab ON b=col2 GROUP BY a
+----
+1  1  1  0
+2  1  1  0
+3  3  1  0
+4  7  2  2
+
+query III rowsort
+SELECT a, b, count(*) FROM ab RIGHT JOIN tab ON b=col2 GROUP BY a
+----
+NULL  NULL  4
+4     7     2

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -47,12 +47,38 @@ import (
 
 // groupby information stored in scopes.
 type groupby struct {
-	// See buildAggregation for a description of these scopes.
+	// We use two scopes:
+	//   - aggInScope contains columns that are used as input by the
+	//     GroupBy operator, specifically:
+	//      - columns for the arguments to aggregate functions
+	//      - grouping columns (from the GROUP BY)
+	//     The grouping columns always come second.
+	//
+	//   - aggOutScope contains columns that are produced by the GroupBy operator,
+	//     specifically:
+	//      - columns for the results of the aggregate functions.
+	//      - the grouping columns
+	//
+	// For example:
+	//
+	//   SELECT 1 + MIN(v*2) FROM kv GROUP BY k+3
+	//
+	//   aggInScope:   v*2 (as col2), k+3 (as col1)
+	//   aggOutScope:  MIN(col2) (as col3), k+3 (as col1)
+	//
+	// Any aggregate functions which contain column references to this scope
+	// trigger the creation of new grouping columns in the grouping scope. In
+	// addition, if an aggregate function contains no column references, then the
+	// aggregate will be added to the "nearest" grouping scope. For example:
+	//   SELECT MAX(1) FROM t1
+	//
+	// TODO(radu): we aren't really using these as scopes, just as scopeColumn
+	// containers. Perhaps separate the necessary functionality in a separate
+	// structure and pass that instead of scopes.
 	aggInScope  *scope
 	aggOutScope *scope
 
-	// aggs is used by aggOutScope (see buildAggregation); it contains information
-	// about aggregate functions encountered.
+	// aggs contains information about aggregate functions encountered.
 	aggs []aggregateInfo
 
 	// groupStrs contains a string representation of each GROUP BY expression
@@ -67,25 +93,108 @@ type groupby struct {
 	// projects that expression.
 	groupStrs groupByStrSet
 
-	// inAgg is true within the body of an aggregate function. inAgg is used
-	// to ensure that nested aggregates are disallowed.
-	inAgg bool
-
 	// buildingGroupingCols is true while the grouping columns are being built.
 	// It is used to ensure that the builder does not throw a grouping error
 	// prematurely.
 	buildingGroupingCols bool
 }
 
+// groupByStrSet is a set of stringified GROUP BY expressions that map to the
+// grouping column in an aggOutScope scope that projects that expression. It
+// is used to enforce scoping rules, since any non-aggregate, variable
+// expression in the SELECT list must be a GROUP BY expression or be composed
+// of GROUP BY expressions. For example, this query is legal:
+//
+//   SELECT COUNT(*), k + v FROM kv GROUP by k, v
+//
+// but this query is not:
+//
+//   SELECT COUNT(*), k + v FROM kv GROUP BY k - v
+//
+type groupByStrSet map[string]*scopeColumn
+
 // hasNonCommutativeAggregates checks whether any of the aggregates are
 // non-commutative or ordering sensitive.
-func (g groupby) hasNonCommutativeAggregates() bool {
+func (g *groupby) hasNonCommutativeAggregates() bool {
 	for i := range g.aggs {
 		if !g.aggs[i].isCommutative() {
 			return true
 		}
 	}
 	return false
+}
+
+// groupingCols returns the columns in the aggInScope corresponding to grouping
+// columns.
+func (g *groupby) groupingCols() []scopeColumn {
+	// Grouping cols are always clustered at the end of the column list.
+	return g.aggInScope.cols[len(g.aggInScope.cols)-len(g.groupStrs):]
+}
+
+// getAggregateArgCols returns the columns in the aggInScope corresponding to
+// arguments to aggregate functions. If the aggregate has a filter, the column
+// corresponding to the filter's input will immediately follow the arguments.
+func (g *groupby) aggregateArgCols() []scopeColumn {
+	return g.aggInScope.cols[:len(g.aggInScope.cols)-len(g.groupStrs)]
+}
+
+// getAggregateResultCols returns the columns in the aggOutScope corresponding
+// to aggregate functions.
+func (g *groupby) aggregateResultCols() []scopeColumn {
+	// Aggregates are always clustered at the beginning of the column list, in
+	// the same order as s.groupby.aggs.
+	return g.aggOutScope.cols[:len(g.aggs)]
+}
+
+// hasAggregates returns true if the enclosing scope has aggregate functions.
+func (g *groupby) hasAggregates() bool {
+	return len(g.aggs) > 0
+}
+
+// findAggregate finds the given aggregate among the bound variables
+// in this scope. Returns nil if the aggregate is not found.
+func (g *groupby) findAggregate(agg aggregateInfo) *scopeColumn {
+	if g.aggs == nil {
+		return nil
+	}
+
+	for i, a := range g.aggs {
+		// Find an existing aggregate that uses the same function overload.
+		if a.def.Overload == agg.def.Overload && a.distinct == agg.distinct && a.filter == agg.filter {
+			// Now check that the arguments are identical.
+			if len(a.args) == len(agg.args) {
+				match := true
+				for j, arg := range a.args {
+					if arg != agg.args[j] {
+						match = false
+						break
+					}
+				}
+
+				// If agg is ordering sensitive, check if the orders match as well.
+				if match && !agg.isCommutative() {
+					if len(a.OrderBy) != len(agg.OrderBy) {
+						match = false
+					} else {
+						for j := range a.OrderBy {
+							if !a.OrderBy[j].Equal(agg.OrderBy[j]) {
+								match = false
+								break
+							}
+						}
+					}
+				}
+
+				if match {
+					// Aggregate already exists, so return information about the
+					// existing column that computes it.
+					return &g.aggregateResultCols()[i]
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 // aggregateInfo stores information about an aggregation function call.
@@ -150,11 +259,9 @@ func (b *Builder) needsAggregation(sel *tree.SelectClause, scope *scope) bool {
 	//  - we have a GROUP BY, or
 	//  - we have a HAVING clause, or
 	//  - we have aggregate functions in the SELECT, DISTINCT ON and/or ORDER BY expressions.
-	if len(sel.GroupBy) > 0 || sel.Having != nil || scope.hasAggregates() {
-		return true
-	}
-
-	return false
+	return len(sel.GroupBy) > 0 ||
+		sel.Having != nil ||
+		(scope.groupby != nil && scope.groupby.hasAggregates())
 }
 
 func (b *Builder) constructGroupBy(
@@ -196,62 +303,25 @@ func (b *Builder) constructGroupBy(
 // buildGroupingColumns builds the grouping columns and adds them to the
 // groupby scopes that will be used to build the aggregation expression.
 // Returns the slice of grouping columns.
-func (b *Builder) buildGroupingColumns(sel *tree.SelectClause, fromScope *scope) []scopeColumn {
-	// We use two scopes:
-	//   - aggInScope contains columns that are used as input by the
-	//     GroupBy operator, specifically:
-	//      - columns for the arguments to aggregate functions
-	//      - grouping columns (from the GROUP BY)
-	//     The grouping columns always come second.
-	//
-	//   - aggOutScope contains columns that are produced by the GroupBy operator,
-	//     specifically:
-	//      - columns for the results of the aggregate functions.
-	//      - the grouping columns
-	//
-	// For example:
-	//
-	//   SELECT 1 + MIN(v*2) FROM kv GROUP BY k+3
-	//
-	//   aggInScope:   v*2 (as col2), k+3 (as col1)
-	//   aggOutScope:  MIN(col2) (as col3), k+3 (as col1)
-	//
-	// Any aggregate functions which contain column references to this scope
-	// trigger the creation of new grouping columns in the grouping scope. In
-	// addition, if an aggregate function contains no column references, then the
-	// aggregate will be added to the "nearest" grouping scope. For example:
-	//   SELECT MAX(1) FROM t1
-	//
-	// TODO(radu): we aren't really using these as scopes, just as scopeColumn
-	// containers. Perhaps separate the scopeColumn in a separate structure and
-	// pass that instead of scopes.
-	if fromScope.groupby.aggInScope == nil {
-		fromScope.groupby.aggInScope = fromScope.replace()
+func (b *Builder) buildGroupingColumns(sel *tree.SelectClause, fromScope *scope) {
+	if fromScope.groupby == nil {
+		fromScope.initGrouping()
 	}
-	if fromScope.groupby.aggOutScope == nil {
-		fromScope.groupby.aggOutScope = fromScope.replace()
-	}
-	aggInScope := fromScope.groupby.aggInScope
-	aggOutScope := fromScope.groupby.aggOutScope
+	g := fromScope.groupby
 
 	// The "from" columns are visible to any grouping expressions.
-	b.buildGroupingList(sel.GroupBy, sel.Exprs, fromScope, aggInScope)
-	groupingsLen := len(fromScope.groupby.groupStrs)
+	b.buildGroupingList(sel.GroupBy, sel.Exprs, fromScope)
 
 	// Copy the grouping columns to the aggOutScope.
-	groupingCols := aggInScope.getGroupingCols(groupingsLen)
-	aggOutScope.appendColumns(groupingCols)
-
-	return groupingCols
+	g.aggOutScope.appendColumns(g.groupingCols())
 }
 
 // buildAggregation builds the aggregation operators and constructs the
 // GroupBy expression. Returns the output scope for the aggregation operation.
-func (b *Builder) buildAggregation(
-	groupingCols []scopeColumn, having opt.ScalarExpr, fromScope *scope,
-) (outScope *scope) {
-	aggInScope := fromScope.groupby.aggInScope
-	aggOutScope := fromScope.groupby.aggOutScope
+func (b *Builder) buildAggregation(having opt.ScalarExpr, fromScope *scope) (outScope *scope) {
+	g := fromScope.groupby
+
+	groupingCols := g.groupingCols()
 
 	// Build ColSet of grouping columns.
 	var groupingColSet opt.ColSet
@@ -261,16 +331,16 @@ func (b *Builder) buildAggregation(
 
 	// If there are any aggregates that are ordering sensitive, build the aggregations
 	// as window functions over each group.
-	if aggOutScope.groupby.hasNonCommutativeAggregates() {
+	if g.hasNonCommutativeAggregates() {
 		return b.buildAggregationAsWindow(groupingColSet, having, fromScope)
 	}
 
-	aggInfos := aggOutScope.groupby.aggs
+	aggInfos := g.aggs
 
 	// Construct the aggregation operators.
 	haveOrderingSensitiveAgg := false
-	aggCols := aggOutScope.getAggregateCols()
-	argCols := aggInScope.getAggregateArgCols(len(groupingCols))
+	aggCols := g.aggregateResultCols()
+	argCols := g.aggregateArgCols()
 	var fromCols opt.ColSet
 	if b.subquery != nil {
 		// Only calculate the set of fromScope columns if it will be used below.
@@ -322,34 +392,34 @@ func (b *Builder) buildAggregation(
 	}
 
 	if haveOrderingSensitiveAgg {
-		aggInScope.copyOrdering(fromScope)
+		g.aggInScope.copyOrdering(fromScope)
 	}
 
 	// Construct the pre-projection, which renders the grouping columns and the
 	// aggregate arguments, as well as any additional order by columns.
-	b.constructProjectForScope(fromScope, aggInScope)
+	b.constructProjectForScope(fromScope, g.aggInScope)
 
-	aggOutScope.expr = b.constructGroupBy(
-		aggInScope.expr.(memo.RelExpr),
+	g.aggOutScope.expr = b.constructGroupBy(
+		g.aggInScope.expr.(memo.RelExpr),
 		groupingColSet,
 		aggCols,
-		aggInScope.ordering,
+		g.aggInScope.ordering,
 	)
 
 	// Wrap with having filter if it exists.
 	if having != nil {
-		input := aggOutScope.expr.(memo.RelExpr)
+		input := g.aggOutScope.expr.(memo.RelExpr)
 		filters := memo.FiltersExpr{{Condition: having}}
-		aggOutScope.expr = b.factory.ConstructSelect(input, filters)
+		g.aggOutScope.expr = b.factory.ConstructSelect(input, filters)
 	}
 
-	return aggOutScope
+	return g.aggOutScope
 }
 
 // analyzeHaving analyzes the having clause and returns it as a typed
-// expression. inScope contains the name bindings that are visible for this
+// expression. fromScope contains the name bindings that are visible for this
 // HAVING clause (e.g., passed in from an enclosing statement).
-func (b *Builder) analyzeHaving(having *tree.Where, inScope *scope) tree.TypedExpr {
+func (b *Builder) analyzeHaving(having *tree.Where, fromScope *scope) tree.TypedExpr {
 	if having == nil {
 		return nil
 	}
@@ -358,59 +428,71 @@ func (b *Builder) analyzeHaving(having *tree.Where, inScope *scope) tree.TypedEx
 	// in case we are recursively called within a subquery context.
 	defer b.semaCtx.Properties.Restore(b.semaCtx.Properties)
 	b.semaCtx.Properties.Require("HAVING", tree.RejectWindowApplications|tree.RejectGenerators)
-	inScope.context = "HAVING"
-	return inScope.resolveAndRequireType(having.Expr, types.Bool)
+	fromScope.context = "HAVING"
+	return fromScope.resolveAndRequireType(having.Expr, types.Bool)
 }
 
 // buildHaving builds a set of memo groups that represent the given HAVING
-// clause. inScope contains the name bindings that are visible for this HAVING
+// clause. fromScope contains the name bindings that are visible for this HAVING
 // clause (e.g., passed in from an enclosing statement).
 //
 // The return value corresponds to the top-level memo group ID for this
 // HAVING clause.
-func (b *Builder) buildHaving(having tree.TypedExpr, inScope *scope) opt.ScalarExpr {
+func (b *Builder) buildHaving(having tree.TypedExpr, fromScope *scope) opt.ScalarExpr {
 	if having == nil {
 		return nil
 	}
 
-	return b.buildScalar(having, inScope, nil, nil, nil)
+	return b.buildScalar(having, fromScope, nil, nil, nil)
 }
 
 // buildGroupingList builds a set of memo groups that represent a list of
-// GROUP BY expressions.
+// GROUP BY expressions, adding the group-by expressions as columns to
+// aggInScope and populating groupStrs.
 //
-// groupBy  The given GROUP BY expressions.
-// selects  The select expressions are needed in case one of the GROUP BY
-//          expressions is an index into to the select list. For example,
-//              SELECT count(*), k FROM t GROUP BY 2
-//          indicates that the grouping is on the second select expression, k.
-//
-// See Builder.buildStmt for a description of the remaining input values.
+// groupBy   The given GROUP BY expressions.
+// selects   The select expressions are needed in case one of the GROUP BY
+//           expressions is an index into to the select list. For example,
+//               SELECT count(*), k FROM t GROUP BY 2
+//           indicates that the grouping is on the second select expression, k.
+// fromScope The scope for the input to the aggregation (the FROM clause).
 func (b *Builder) buildGroupingList(
-	groupBy tree.GroupBy, selects tree.SelectExprs, inScope *scope, outScope *scope,
+	groupBy tree.GroupBy, selects tree.SelectExprs, fromScope *scope,
 ) {
-	inScope.groupby.groupStrs = make(groupByStrSet, len(groupBy))
-	if outScope.cols == nil {
-		outScope.cols = make([]scopeColumn, 0, len(groupBy))
+	g := fromScope.groupby
+	g.groupStrs = make(groupByStrSet, len(groupBy))
+	if g.aggInScope.cols == nil {
+		g.aggInScope.cols = make([]scopeColumn, 0, len(groupBy))
 	}
 
-	inScope.startBuildingGroupingCols()
+	// The buildingGroupingCols flag is used to ensure that a grouping error is
+	// not called prematurely. For example:
+	//   SELECT count(*), a FROM ab GROUP BY a
+	// is legal, but
+	//   SELECT count(*), b FROM ab GROUP BY a
+	// will throw the error, `column "b" must appear in the GROUP BY clause or be
+	// used in an aggregate function`. The builder cannot know whether there is
+	// a grouping error until the grouping columns are fully built.
+	g.buildingGroupingCols = true
 	for _, e := range groupBy {
-		b.buildGrouping(e, selects, inScope, outScope)
+		b.buildGrouping(e, selects, fromScope, g.aggInScope)
 	}
-	inScope.endBuildingGroupingCols()
+	g.buildingGroupingCols = false
 }
 
 // buildGrouping builds a set of memo groups that represent a GROUP BY
-// expression.
+// expression. The expression (or expressions, if we have a star) is added to
+// groupStrs and to the aggInScope.
 //
-// groupBy  The given GROUP BY expression.
-// selects  The select expressions are needed in case the GROUP BY expression
-//          is an index into to the select list.
 //
-// See Builder.buildStmt for a description of the remaining input values.
+// groupBy    The given GROUP BY expression.
+// selects    The select expressions are needed in case the GROUP BY expression
+//            is an index into to the select list.
+// fromScope  The scope for the input to the aggregation (the FROM clause).
+// aggInScope The scope that will contain the grouping expressions as well as
+//            the aggregate function arguments.
 func (b *Builder) buildGrouping(
-	groupBy tree.Expr, selects tree.SelectExprs, inScope, outScope *scope,
+	groupBy tree.Expr, selects tree.SelectExprs, fromScope, aggInScope *scope,
 ) {
 	// Unwrap parenthesized expressions like "((a))" to "a".
 	groupBy = tree.StripParens(groupBy)
@@ -430,10 +512,10 @@ func (b *Builder) buildGrouping(
 
 	// Make sure the GROUP BY columns have no special functions.
 	b.semaCtx.Properties.Require("GROUP BY", tree.RejectSpecial)
-	inScope.context = "GROUP BY"
+	fromScope.context = "GROUP BY"
 
 	// Resolve types, expand stars, and flatten tuples.
-	exprs := b.expandStarAndResolveType(groupBy, inScope)
+	exprs := b.expandStarAndResolveType(groupBy, fromScope)
 	exprs = flattenTuples(exprs)
 
 	// Finally, build each of the GROUP BY columns.
@@ -441,16 +523,16 @@ func (b *Builder) buildGrouping(
 		// If a grouping column has already been added, don't add it again.
 		// GROUP BY a, a is semantically equivalent to GROUP BY a.
 		exprStr := symbolicExprStr(e)
-		if _, ok := inScope.groupby.groupStrs[exprStr]; ok {
+		if _, ok := fromScope.groupby.groupStrs[exprStr]; ok {
 			continue
 		}
 
 		// Save a representation of the GROUP BY expression for validation of the
 		// SELECT and HAVING expressions. This enables queries such as:
 		//   SELECT x+y FROM t GROUP BY x+y
-		col := b.addColumn(outScope, alias, e)
-		b.buildScalar(e, inScope, outScope, col, nil)
-		inScope.groupby.groupStrs[exprStr] = col
+		col := b.addColumn(aggInScope, alias, e)
+		b.buildScalar(e, fromScope, aggInScope, col, nil)
+		fromScope.groupby.groupStrs[exprStr] = col
 	}
 }
 
@@ -458,12 +540,12 @@ func (b *Builder) buildGrouping(
 // to an aggregate expression. The scopeColumn for the built expression will
 // be added to tempScope.
 func (b *Builder) buildAggArg(
-	e tree.TypedExpr, info *aggregateInfo, tempScope, inScope *scope,
+	e tree.TypedExpr, info *aggregateInfo, tempScope, fromScope *scope,
 ) opt.ScalarExpr {
 	// This synthesizes a new tempScope column, unless the argument is a
 	// simple VariableOp.
 	col := b.addColumn(tempScope, "" /* alias */, e)
-	b.buildScalar(e, inScope, tempScope, col, &info.colRefs)
+	b.buildScalar(e, fromScope, tempScope, col, &info.colRefs)
 	if col.scalar != nil {
 		return col.scalar
 	}
@@ -484,9 +566,9 @@ func (b *Builder) buildAggArg(
 // the function definition, fully built arguments, and the aggregate output
 // column.
 func (b *Builder) buildAggregateFunction(
-	f *tree.FuncExpr, def *memo.FunctionPrivate, inScope *scope,
+	f *tree.FuncExpr, def *memo.FunctionPrivate, fromScope *scope,
 ) *aggregateInfo {
-	tempScope := inScope.startAggFunc()
+	tempScope := fromScope.startAggFunc()
 	tempScopeColsBefore := len(tempScope.cols)
 
 	info := aggregateInfo{
@@ -503,45 +585,45 @@ func (b *Builder) buildAggregateFunction(
 	defer func() { b.subquery = subq }()
 
 	for i, pexpr := range f.Exprs {
-		info.args[i] = b.buildAggArg(pexpr.(tree.TypedExpr), &info, tempScope, inScope)
+		info.args[i] = b.buildAggArg(pexpr.(tree.TypedExpr), &info, tempScope, fromScope)
 	}
 
 	// If we have a filter, add it to tempScope after all the arguments. We'll
 	// later extract the column that gets added here in buildAggregation.
 	if f.Filter != nil {
-		info.filter = b.buildAggArg(f.Filter.(tree.TypedExpr), &info, tempScope, inScope)
+		info.filter = b.buildAggArg(f.Filter.(tree.TypedExpr), &info, tempScope, fromScope)
 	}
 
 	// If we have ORDER BY, add the ordering columns to the tempScope.
 	if f.OrderBy != nil {
 		for _, o := range f.OrderBy {
-			b.buildAggArg(o.Expr.(tree.TypedExpr), &info, tempScope, inScope)
+			b.buildAggArg(o.Expr.(tree.TypedExpr), &info, tempScope, fromScope)
 		}
 	}
 
 	// Find the appropriate aggregation scopes for this aggregate now that we
 	// know which columns it references. If necessary, we'll move the columns
 	// for the arguments from tempScope to aggInScope below.
-	aggInScope, aggOutScope := inScope.endAggFunc(info.colRefs)
+	g := fromScope.endAggFunc(info.colRefs)
 
 	// If we already have the same aggregation, reuse it. Otherwise add it
 	// to the list of aggregates that need to be computed by the groupby
 	// expression and synthesize a column for the aggregation result.
-	info.col = aggOutScope.findAggregate(info)
+	info.col = g.findAggregate(info)
 	if info.col == nil {
 		// Use 0 as the group for now; it will be filled in later by the
 		// buildAggregation method.
-		info.col = b.synthesizeColumn(aggOutScope, def.Name, f.ResolvedType(), f, nil /* scalar */)
+		info.col = b.synthesizeColumn(g.aggOutScope, def.Name, f.ResolvedType(), f, nil /* scalar */)
 
 		// Move the columns for the aggregate input expressions to the correct scope.
-		if aggInScope != tempScope {
-			aggInScope.cols = append(aggInScope.cols, tempScope.cols[tempScopeColsBefore:]...)
+		if g.aggInScope != tempScope {
+			g.aggInScope.cols = append(g.aggInScope.cols, tempScope.cols[tempScopeColsBefore:]...)
 			tempScope.cols = tempScope.cols[:tempScopeColsBefore]
 		}
 
 		// Add the aggregate to the list of aggregates that need to be computed by
 		// the groupby expression.
-		aggOutScope.groupby.aggs = append(aggOutScope.groupby.aggs, info)
+		g.aggs = append(g.aggs, info)
 	} else {
 		// Undo the adding of the args.
 		// TODO(radu): is there a cleaner way to do this?

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -37,6 +37,7 @@ package optbuilder
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -733,4 +734,29 @@ func newGroupingError(name *tree.Name) error {
 		"column \"%s\" must appear in the GROUP BY clause or be used in an aggregate function",
 		tree.ErrString(name),
 	)
+}
+
+// allowImplicitGroupingColumn returns true if col is part of a table and the
+// the groupby metadata indicates that we are grouping on the entire PK of that
+// table. In that case, we can allow col as an "implicit" grouping column, even
+// if it is not specified in the query.
+func (b *Builder) allowImplicitGroupingColumn(colID opt.ColumnID, g *groupby) bool {
+	md := b.factory.Metadata()
+	colMeta := md.ColumnMeta(colID)
+	if colMeta.Table == 0 {
+		return false
+	}
+	// Get all the PK columns.
+	tab := md.Table(colMeta.Table)
+	var pkCols opt.ColSet
+	primaryIndex := tab.Index(cat.PrimaryIndex)
+	for i := 0; i < primaryIndex.KeyColumnCount(); i++ {
+		pkCols.Add(colMeta.Table.ColumnID(primaryIndex.Column(i).Ordinal))
+	}
+	// Remove PK columns that are grouping cols and see if there's anything left.
+	groupingCols := g.groupingCols()
+	for i := range groupingCols {
+		pkCols.Remove(groupingCols[i].id)
+	}
+	return pkCols.Empty()
 }

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -72,7 +72,28 @@ func (b *Builder) buildScalar(
 			// Non-grouping column was referenced. Note that a column that is part
 			// of a larger grouping expression would have been detected by the
 			// groupStrs checking code above.
-			panic(newGroupingError(&t.name))
+			// Normally this would be a "column must appear in the GROUP BY clause"
+			// error. The only case where we allow this (for compatibility with
+			// Postgres) is when this column is part of a table and we are already
+			// grouping on the entire PK of that table.
+			g := inScope.groupby
+			if !b.allowImplicitGroupingColumn(t.id, g) {
+				panic(newGroupingError(&t.name))
+			}
+
+			// We add a new grouping column; these show up both in aggInScope and
+			// aggOutScope.
+			//
+			// Note that normalization rules will trim down the list of grouping
+			// columns based on FDs, so this is only for the purposes of building a
+			// valid operator.
+			aggInCol := b.addColumn(g.aggInScope, "" /* alias */, t)
+			b.finishBuildScalarRef(t, inScope, g.aggInScope, aggInCol, nil)
+			g.groupStrs[symbolicExprStr(t)] = aggInCol
+
+			g.aggOutScope.appendColumn(aggInCol)
+
+			return b.finishBuildScalarRef(t, g.aggOutScope, outScope, outCol, colRefs)
 		}
 
 		return b.finishBuildScalarRef(t, inScope, outScope, outCol, colRefs)

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -40,7 +40,17 @@ type scope struct {
 	builder *Builder
 	parent  *scope
 	cols    []scopeColumn
-	groupby groupby
+
+	// groupby is the structure that keeps the grouping metadata when this scope
+	// includes aggregate functions or GROUP BY.
+	groupby *groupby
+
+	// inAgg is true within the body of an aggregate function. inAgg is used
+	// to ensure that nested aggregates are disallowed.
+	// TODO(radu): this, together with some other fields below, belongs in a
+	// context that is threaded through the calls instead of setting and resetting
+	// it in the scope.
+	inAgg bool
 
 	// windows contains the set of window functions encountered while building
 	// the current SELECT statement.
@@ -106,32 +116,25 @@ type cteSource struct {
 	onRef func()
 }
 
-// groupByStrSet is a set of stringified GROUP BY expressions that map to the
-// grouping column in an aggOutScope scope that projects that expression. It
-// is used to enforce scoping rules, since any non-aggregate, variable
-// expression in the SELECT list must be a GROUP BY expression or be composed
-// of GROUP BY expressions. For example, this query is legal:
-//
-//   SELECT COUNT(*), k + v FROM kv GROUP by k, v
-//
-// but this query is not:
-//
-//   SELECT COUNT(*), k + v FROM kv GROUP BY k - v
-//
-type groupByStrSet map[string]*scopeColumn
+// initGrouping initializes the groupby information for this scope.
+func (s *scope) initGrouping() {
+	if s.groupby != nil {
+		panic(errors.AssertionFailedf("grouping initialized twice"))
+	}
+	s.groupby = &groupby{
+		aggInScope:  s.replace(),
+		aggOutScope: s.replace(),
+	}
+}
 
-// exists is a 0-byte dummy value used in a map that's being used to track
-// whether keys exist (i.e. where only the key matters).
-var exists = struct{}{}
-
-// inGroupingContext returns true when the aggInScope is not nil. This is the
+// inGroupingContext returns true if initGrouping was called. This is the
 // case when the builder is building expressions in a SELECT list, and
 // aggregates, GROUP BY, or HAVING are present. This is also true when the
 // builder is building expressions inside the HAVING clause. When
 // inGroupingContext returns true, groupByStrSet will be utilized to enforce
 // scoping rules. See the comment above groupByStrSet for more details.
 func (s *scope) inGroupingContext() bool {
-	return s.groupby.aggInScope != nil
+	return s.groupby != nil
 }
 
 // push creates a new scope with this scope as its parent.
@@ -471,82 +474,6 @@ func (s *scope) findExistingCol(expr tree.TypedExpr) *scopeColumn {
 	return s.findExistingColInList(expr, s.cols)
 }
 
-// getAggregateCols returns the columns in this scope corresponding
-// to aggregate functions. This call is only valid on an aggOutScope.
-func (s *scope) getAggregateCols() []scopeColumn {
-	// Aggregates are always clustered at the beginning of the column list, in
-	// the same order as s.groupby.aggs.
-	return s.cols[:len(s.groupby.aggs)]
-}
-
-// getAggregateArgCols returns the columns in this scope corresponding
-// to arguments to aggregate functions. This call is only valid on an
-// aggInScope. If the aggregate has a filter, the column corresponding
-// to its input will immediately follow its inputs.
-func (s *scope) getAggregateArgCols(groupingsLen int) []scopeColumn {
-	// Aggregate args are always clustered at the beginning of the column list.
-	return s.cols[:len(s.cols)-groupingsLen]
-}
-
-// getGroupingCols returns the columns in this scope corresponding
-// to grouping columns. This call is valid on an aggInScope or aggOutScope.
-func (s *scope) getGroupingCols(groupingsLen int) []scopeColumn {
-	// Grouping cols are always clustered at the end of the column list.
-	return s.cols[len(s.cols)-groupingsLen:]
-}
-
-// hasAggregates returns true if this scope contains aggregate functions.
-func (s *scope) hasAggregates() bool {
-	aggOutScope := s.groupby.aggOutScope
-	return aggOutScope != nil && len(aggOutScope.groupby.aggs) > 0
-}
-
-// findAggregate finds the given aggregate among the bound variables
-// in this scope. Returns nil if the aggregate is not found.
-func (s *scope) findAggregate(agg aggregateInfo) *scopeColumn {
-	if s.groupby.aggs == nil {
-		return nil
-	}
-
-	for i, a := range s.groupby.aggs {
-		// Find an existing aggregate that uses the same function overload.
-		if a.def.Overload == agg.def.Overload && a.distinct == agg.distinct && a.filter == agg.filter {
-			// Now check that the arguments are identical.
-			if len(a.args) == len(agg.args) {
-				match := true
-				for j, arg := range a.args {
-					if arg != agg.args[j] {
-						match = false
-						break
-					}
-				}
-
-				// If agg is ordering sensitive, check if the orders match as well.
-				if match && !agg.isCommutative() {
-					if len(a.OrderBy) != len(agg.OrderBy) {
-						match = false
-					} else {
-						for j := range a.OrderBy {
-							if !a.OrderBy[j].Equal(agg.OrderBy[j]) {
-								match = false
-								break
-							}
-						}
-					}
-				}
-
-				if match {
-					// Aggregate already exists, so return information about the
-					// existing column that computes it.
-					return &s.getAggregateCols()[i]
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
 // startAggFunc is called when the builder starts building an aggregate
 // function. It is used to disallow nested aggregates and ensure that a
 // grouping error is not called on the aggregate arguments. For example:
@@ -560,12 +487,12 @@ func (s *scope) findAggregate(agg aggregateInfo) *scopeColumn {
 // If endAggFunc returns a different scope than startAggFunc, the columns
 // will be transferred to the correct scope by buildAggregateFunction.
 func (s *scope) startAggFunc() *scope {
-	if s.groupby.inAgg {
+	if s.inAgg {
 		panic(sqlbase.NewAggInAggError())
 	}
-	s.groupby.inAgg = true
+	s.inAgg = true
 
-	if s.groupby.aggInScope == nil {
+	if s.groupby == nil {
 		return s.builder.allocScope()
 	}
 	return s.groupby.aggInScope
@@ -575,54 +502,28 @@ func (s *scope) startAggFunc() *scope {
 // function. It is used in combination with startAggFunc to disallow nested
 // aggregates and prevent grouping errors while building aggregate arguments.
 //
-// In addition, endAggFunc finds the correct aggInScope and aggOutScope, given
+// In addition, endAggFunc finds the correct groupby structure, given
 // that the aggregate references the columns in cols. The reference scope
 // is the one closest to the current scope which contains at least one of the
 // variables referenced by the aggregate (or the current scope if the aggregate
 // references no variables). endAggFunc also ensures that aggregate functions
 // are only used in a groupings scope.
-func (s *scope) endAggFunc(cols opt.ColSet) (aggInScope, aggOutScope *scope) {
-	if !s.groupby.inAgg {
+func (s *scope) endAggFunc(cols opt.ColSet) (g *groupby) {
+	if !s.inAgg {
 		panic(errors.AssertionFailedf("mismatched calls to start/end aggFunc"))
 	}
-	s.groupby.inAgg = false
+	s.inAgg = false
 
 	for curr := s; curr != nil; curr = curr.parent {
 		if cols.Len() == 0 || cols.Intersects(curr.colSet()) {
-			if curr.groupby.aggInScope == nil {
-				curr.groupby.aggInScope = curr.replace()
+			if curr.groupby == nil {
+				curr.initGrouping()
 			}
-			if curr.groupby.aggOutScope == nil {
-				curr.groupby.aggOutScope = curr.replace()
-			}
-			return curr.groupby.aggInScope, curr.groupby.aggOutScope
+			return curr.groupby
 		}
 	}
 
 	panic(errors.AssertionFailedf("aggregate function is not allowed in this context"))
-}
-
-// startBuildingGroupingCols is called when the builder starts building the
-// grouping columns. It is used to ensure that a grouping error is not called
-// prematurely. For example:
-//   SELECT count(*), k FROM kv GROUP BY k
-// is legal, but
-//   SELECT count(*), v FROM kv GROUP BY k
-// will throw the error, `column "v" must appear in the GROUP BY clause or be
-// used in an aggregate function`. The builder cannot know whether there is
-// a grouping error until the grouping columns are fully built.
-func (s *scope) startBuildingGroupingCols() {
-	s.groupby.buildingGroupingCols = true
-}
-
-// endBuildingGroupingCols is called when the builder finishes building the
-// grouping columns. It is used in combination with startBuildingGroupingCols
-// to ensure that a grouping error is not called prematurely.
-func (s *scope) endBuildingGroupingCols() {
-	if !s.groupby.buildingGroupingCols {
-		panic(errors.AssertionFailedf("mismatched calls to start/end groupings"))
-	}
-	s.groupby.buildingGroupingCols = false
 }
 
 // scope implements the tree.Visitor interface so that it can walk through
@@ -751,7 +652,7 @@ func (s *scope) FindSourceMatchingName(
 	for ; s != nil; s = s.parent {
 		sources := make(map[tree.TableName]struct{})
 		for i := range s.cols {
-			sources[s.cols[i].table] = exists
+			sources[s.cols[i].table] = struct{}{}
 		}
 
 		found := false

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -787,14 +787,13 @@ func (b *Builder) buildSelectClause(
 	orderByScope := b.analyzeOrderBy(orderBy, fromScope, projectionsScope)
 	distinctOnScope := b.analyzeDistinctOnArgs(sel.DistinctOn, fromScope, projectionsScope)
 
-	var groupingCols []scopeColumn
 	var having opt.ScalarExpr
 	needsAgg := b.needsAggregation(sel, fromScope)
 	if needsAgg {
 		// Grouping columns must be built before building the projection list so
 		// we can check that any column references that appear in the SELECT list
 		// outside of aggregate functions are present in the grouping list.
-		groupingCols = b.buildGroupingColumns(sel, fromScope)
+		b.buildGroupingColumns(sel, fromScope)
 		having = b.buildHaving(havingExpr, fromScope)
 	}
 
@@ -807,7 +806,7 @@ func (b *Builder) buildSelectClause(
 		// We must wait to build the aggregation until after the above block since
 		// any SRFs found in the SELECT list will change the FROM scope (they
 		// create an implicit lateral join).
-		outScope = b.buildAggregation(groupingCols, having, fromScope)
+		outScope = b.buildAggregation(having, fromScope)
 	} else {
 		outScope = fromScope
 	}

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -9,6 +9,16 @@ CREATE TABLE kv (
 )
 ----
 
+exec-ddl
+CREATE TABLE abxy (
+  a INT,
+  b INT,
+  x INT,
+  y INT,
+  PRIMARY KEY(a,b)
+)
+----
+
 build
 SELECT min(1), max(1), count(1), sum_int(1), avg(1), sum(1), stddev(1),
   variance(1), bool_and(true), bool_or(false), xor_agg(b'\x01') FROM kv
@@ -540,11 +550,6 @@ project
       └── plus [type=int]
            ├── variable: k [type=int]
            └── variable: v [type=int]
-
-build
-SELECT count(*), k+v FROM kv GROUP BY k
-----
-error (42803): column "v" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT count(*), k+v FROM kv GROUP BY v
@@ -3476,3 +3481,249 @@ build
 SELECT * FROM ROWS FROM (count(json_each('[]')))
 ----
 error (0A000): count(): json_each(): generator functions are not allowed in aggregate
+
+# Tests for projecting non-grouping columns when we group by a PK.
+build
+SELECT v FROM kv GROUP BY k
+----
+project
+ ├── columns: v:2(int)
+ └── group-by
+      ├── columns: k:1(int!null) v:2(int)
+      ├── grouping columns: k:1(int!null) v:2(int)
+      └── project
+           ├── columns: k:1(int!null) v:2(int)
+           └── scan kv
+                └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+
+# This should be equivalent to the query above.
+build
+SELECT v FROM kv GROUP BY k, v
+----
+project
+ ├── columns: v:2(int)
+ └── group-by
+      ├── columns: k:1(int!null) v:2(int)
+      ├── grouping columns: k:1(int!null) v:2(int)
+      └── project
+           ├── columns: k:1(int!null) v:2(int)
+           └── scan kv
+                └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+
+build
+SELECT count(*), k+v FROM kv GROUP BY k
+----
+project
+ ├── columns: count:5(int) "?column?":6(int)
+ ├── group-by
+ │    ├── columns: k:1(int!null) v:2(int) count_rows:5(int)
+ │    ├── grouping columns: k:1(int!null) v:2(int)
+ │    ├── project
+ │    │    ├── columns: k:1(int!null) v:2(int)
+ │    │    └── scan kv
+ │    │         └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ │    └── aggregations
+ │         └── count-rows [type=int]
+ └── projections
+      └── plus [type=int]
+           ├── variable: k [type=int]
+           └── variable: v [type=int]
+
+build
+SELECT count(*) FROM kv GROUP BY k HAVING v=1
+----
+project
+ ├── columns: count:5(int)
+ └── select
+      ├── columns: k:1(int!null) v:2(int!null) count_rows:5(int)
+      ├── group-by
+      │    ├── columns: k:1(int!null) v:2(int) count_rows:5(int)
+      │    ├── grouping columns: k:1(int!null) v:2(int)
+      │    ├── project
+      │    │    ├── columns: k:1(int!null) v:2(int)
+      │    │    └── scan kv
+      │    │         └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+      │    └── aggregations
+      │         └── count-rows [type=int]
+      └── filters
+           └── eq [type=bool]
+                ├── variable: v [type=int]
+                └── const: 1 [type=int]
+
+build
+SELECT k, v, count(*) FROM kv JOIN ab ON a=k GROUP BY k
+----
+group-by
+ ├── columns: k:1(int!null) v:2(int) count:7(int)
+ ├── grouping columns: k:1(int!null) v:2(int)
+ ├── project
+ │    ├── columns: k:1(int!null) v:2(int)
+ │    └── inner-join (hash)
+ │         ├── columns: k:1(int!null) v:2(int) w:3(int) s:4(string) a:5(int!null) b:6(int)
+ │         ├── scan kv
+ │         │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ │         ├── scan ab
+ │         │    └── columns: a:5(int!null) b:6(int)
+ │         └── filters
+ │              └── eq [type=bool]
+ │                   ├── variable: a [type=int]
+ │                   └── variable: k [type=int]
+ └── aggregations
+      └── count-rows [type=int]
+
+# Not allowed when grouping on a subset of the PK.
+build
+SELECT x, y FROM abxy GROUP BY a
+----
+error (42803): column "x" must appear in the GROUP BY clause or be used in an aggregate function
+
+build
+SELECT x, y FROM abxy GROUP BY a, b
+----
+project
+ ├── columns: x:3(int) y:4(int)
+ └── group-by
+      ├── columns: a:1(int!null) b:2(int!null) x:3(int) y:4(int)
+      ├── grouping columns: a:1(int!null) b:2(int!null) x:3(int) y:4(int)
+      └── scan abxy
+           └── columns: a:1(int!null) b:2(int!null) x:3(int) y:4(int)
+
+# The following two should be equivalent to the one above.
+build
+SELECT x, y FROM abxy GROUP BY x, a, b
+----
+project
+ ├── columns: x:3(int) y:4(int)
+ └── group-by
+      ├── columns: a:1(int!null) b:2(int!null) x:3(int) y:4(int)
+      ├── grouping columns: a:1(int!null) b:2(int!null) x:3(int) y:4(int)
+      └── scan abxy
+           └── columns: a:1(int!null) b:2(int!null) x:3(int) y:4(int)
+
+build
+SELECT x, y FROM abxy GROUP BY x, y, a, b
+----
+project
+ ├── columns: x:3(int) y:4(int)
+ └── group-by
+      ├── columns: a:1(int!null) b:2(int!null) x:3(int) y:4(int)
+      ├── grouping columns: a:1(int!null) b:2(int!null) x:3(int) y:4(int)
+      └── scan abxy
+           └── columns: a:1(int!null) b:2(int!null) x:3(int) y:4(int)
+
+build
+SELECT x, y FROM abxy NATURAL JOIN ab GROUP BY a, b
+----
+project
+ ├── columns: x:3(int) y:4(int)
+ └── group-by
+      ├── columns: abxy.a:1(int!null) abxy.b:2(int!null) x:3(int) y:4(int)
+      ├── grouping columns: abxy.a:1(int!null) abxy.b:2(int!null) x:3(int) y:4(int)
+      └── project
+           ├── columns: abxy.a:1(int!null) abxy.b:2(int!null) x:3(int) y:4(int)
+           └── inner-join (hash)
+                ├── columns: abxy.a:1(int!null) abxy.b:2(int!null) x:3(int) y:4(int) ab.a:5(int!null) ab.b:6(int!null)
+                ├── scan abxy
+                │    └── columns: abxy.a:1(int!null) abxy.b:2(int!null) x:3(int) y:4(int)
+                ├── scan ab
+                │    └── columns: ab.a:5(int!null) ab.b:6(int)
+                └── filters
+                     ├── eq [type=bool]
+                     │    ├── variable: abxy.a [type=int]
+                     │    └── variable: ab.a [type=int]
+                     └── eq [type=bool]
+                          ├── variable: abxy.b [type=int]
+                          └── variable: ab.b [type=int]
+
+# Should be equivalent to the one above.
+build
+SELECT x, y FROM abxy NATURAL JOIN ab GROUP BY a, b, x
+----
+project
+ ├── columns: x:3(int) y:4(int)
+ └── group-by
+      ├── columns: abxy.a:1(int!null) abxy.b:2(int!null) x:3(int) y:4(int)
+      ├── grouping columns: abxy.a:1(int!null) abxy.b:2(int!null) x:3(int) y:4(int)
+      └── project
+           ├── columns: abxy.a:1(int!null) abxy.b:2(int!null) x:3(int) y:4(int)
+           └── inner-join (hash)
+                ├── columns: abxy.a:1(int!null) abxy.b:2(int!null) x:3(int) y:4(int) ab.a:5(int!null) ab.b:6(int!null)
+                ├── scan abxy
+                │    └── columns: abxy.a:1(int!null) abxy.b:2(int!null) x:3(int) y:4(int)
+                ├── scan ab
+                │    └── columns: ab.a:5(int!null) ab.b:6(int)
+                └── filters
+                     ├── eq [type=bool]
+                     │    ├── variable: abxy.a [type=int]
+                     │    └── variable: ab.a [type=int]
+                     └── eq [type=bool]
+                          ├── variable: abxy.b [type=int]
+                          └── variable: ab.b [type=int]
+
+build
+SELECT abxy.*, ab.* FROM abxy, ab GROUP BY abxy.a, abxy.b, ab.a
+----
+group-by
+ ├── columns: a:1(int!null) b:2(int!null) x:3(int) y:4(int) a:5(int!null) b:6(int)
+ ├── grouping columns: abxy.a:1(int!null) abxy.b:2(int!null) x:3(int) y:4(int) ab.a:5(int!null) ab.b:6(int)
+ └── inner-join (hash)
+      ├── columns: abxy.a:1(int!null) abxy.b:2(int!null) x:3(int) y:4(int) ab.a:5(int!null) ab.b:6(int)
+      ├── scan abxy
+      │    └── columns: abxy.a:1(int!null) abxy.b:2(int!null) x:3(int) y:4(int)
+      ├── scan ab
+      │    └── columns: ab.a:5(int!null) ab.b:6(int)
+      └── filters (true)
+
+# Not allowed with UNION.
+build
+SELECT x FROM (SELECT a, b, x FROM abxy UNION SELECT a, b, 1 FROM ab) GROUP BY a,b
+----
+error (42803): column "x" must appear in the GROUP BY clause or be used in an aggregate function
+
+# Allowed with EXCEPT.
+build
+SELECT x FROM (SELECT a, b, x FROM abxy EXCEPT SELECT a, b, 1 FROM ab) GROUP BY a,b
+----
+project
+ ├── columns: x:3(int)
+ └── group-by
+      ├── columns: abxy.a:1(int!null) abxy.b:2(int) x:3(int)
+      ├── grouping columns: abxy.a:1(int!null) abxy.b:2(int) x:3(int)
+      └── except
+           ├── columns: abxy.a:1(int!null) abxy.b:2(int) x:3(int)
+           ├── left columns: abxy.a:1(int!null) abxy.b:2(int) x:3(int)
+           ├── right columns: ab.a:5(int) ab.b:6(int) "?column?":7(int)
+           ├── project
+           │    ├── columns: abxy.a:1(int!null) abxy.b:2(int!null) x:3(int)
+           │    └── scan abxy
+           │         └── columns: abxy.a:1(int!null) abxy.b:2(int!null) x:3(int) y:4(int)
+           └── project
+                ├── columns: "?column?":7(int!null) ab.a:5(int!null) ab.b:6(int)
+                ├── scan ab
+                │    └── columns: ab.a:5(int!null) ab.b:6(int)
+                └── projections
+                     └── const: 1 [type=int]
+
+# Allowed even with outer joins. It's a little subtle why this is correct: the
+# PK columns are also non-nullable so any "outer" rows are never in the same
+# group with "non-outer" rows.
+build
+SELECT v, w FROM kv FULL JOIN ab ON k=a GROUP BY k
+----
+project
+ ├── columns: v:2(int) w:3(int)
+ └── group-by
+      ├── columns: k:1(int) v:2(int) w:3(int)
+      ├── grouping columns: k:1(int) v:2(int) w:3(int)
+      └── project
+           ├── columns: k:1(int) v:2(int) w:3(int)
+           └── full-join (hash)
+                ├── columns: k:1(int) v:2(int) w:3(int) s:4(string) a:5(int) b:6(int)
+                ├── scan kv
+                │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+                ├── scan ab
+                │    └── columns: a:5(int!null) b:6(int)
+                └── filters
+                     └── eq [type=bool]
+                          ├── variable: k [type=int]
+                          └── variable: a [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -106,12 +106,27 @@ SELECT 3 FROM kv GROUP BY v HAVING k > 5
 ----
 error (42803): column "k" must appear in the GROUP BY clause or be used in an aggregate function
 
-# pg has a special case for grouping on primary key, which would allow this, but we do not.
-# See http://www.postgresql.org/docs/current/static/sql-select.html#SQL-GROUPBY
+# Special case for grouping on primary key.
 build
 SELECT 3 FROM kv GROUP BY k HAVING v > 2
 ----
-error (42803): column "v" must appear in the GROUP BY clause or be used in an aggregate function
+project
+ ├── columns: "?column?":5(int!null)
+ ├── select
+ │    ├── columns: k:1(int!null) v:2(int!null)
+ │    ├── group-by
+ │    │    ├── columns: k:1(int!null) v:2(int)
+ │    │    ├── grouping columns: k:1(int!null) v:2(int)
+ │    │    └── project
+ │    │         ├── columns: k:1(int!null) v:2(int)
+ │    │         └── scan kv
+ │    │              └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ │    └── filters
+ │         └── gt [type=bool]
+ │              ├── variable: v [type=int]
+ │              └── const: 2 [type=int]
+ └── projections
+      └── const: 3 [type=int]
 
 build
 SELECT k FROM kv HAVING k > 7


### PR DESCRIPTION
#### opt: clean up optbuilder group-by code

This refactoring cleans up some aspects of the group-by code in the
optbuilder.

Currently each scope contains a set of fields (collected in the
`groupby` struct). But building an aggregation involves multiple
scopes and subsets of these fields are used by different scopes (e.g.
`aggs` is used on the `aggOutScope`). In addition, many helper
functions related to grouping are implemented by `*scope`, and you
have to know which of the scopes needs to be used for each one (even
worse, sometimes you need to pass around information like
`groupingsLen` because it's not all in one place).

This change addresses these issues. There is now a single `groupby`
structure per grouping context and it is now a pointer inside the
`scope`. All related functionality has been moved as methods on this
structure.

Release note: None

#### opt: support selecting any table column when grouping by PK

Postgres supports selecting columns that are not grouping columns if
the entire PK is part of the grouping columns (see
https://www.postgresql.org/docs/current/sql-select.html#SQL-GROUPBY).
This commit implements this feature, motivated by the desire for
compatibility with various ORMs.

We implement this feature by adding these columns as grouping columns
on-the-fly; in other words, we interpret `SELECT v FROM kv GROUP BY k`
as having `GROUP BY k,v` (which is equivalent). Normalization rules
will subsequently trim down the list of columns.

Fixes #26709.

Release note (sql change): It is now valid for SELECT and HAVING to
refer to ungrouped columns in the special case when the grouped
columns contain the primary key of the table containing the ungrouped
column.
