### PR TITLE
release-19.2: importccl: add 19.2 version gate check

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -138,6 +138,10 @@ func importPlanHook(
 		return nil, nil, nil, false, nil
 	}
 
+	if !p.ExecCfg().Settings.Version.IsActive(cluster.VersionPartitionedBackup) {
+		return nil, nil, nil, false, errors.Errorf("IMPORT requires a cluster fully upgraded to version >= 19.2")
+	}
+
 	filesFn, err := p.TypeAsStringArray(importStmt.Files, "IMPORT")
 	if err != nil {
 		return nil, nil, nil, false, err


### PR DESCRIPTION
Backport 1/1 commits from #41684.

/cc @cockroachdb/release

---

Ensure the cluster is fully upgraded when running import.

Release note: ensure cluster fully upgraded when running import.
