### PR TITLE
release-2.1: engine: properly support batches containing only…

### DIFF
--- a/pkg/storage/engine/batch.go
+++ b/pkg/storage/engine/batch.go
@@ -89,8 +89,9 @@ const (
 // Note that the encoding of these keys needs to match up with the encoding in
 // rocksdb/db.cc:EncodeKey().
 type RocksDBBatchBuilder struct {
-	repr  []byte
-	count int
+	repr    []byte
+	count   int
+	logData bool
 }
 
 func (b *RocksDBBatchBuilder) maybeInit() {
@@ -106,6 +107,7 @@ func (b *RocksDBBatchBuilder) Finish() []byte {
 	repr := b.getRepr()
 	b.repr = b.repr[:headerSize]
 	b.count = 0
+	b.logData = false
 	return repr
 }
 
@@ -250,6 +252,7 @@ func (b *RocksDBBatchBuilder) Clear(key MVCCKey) {
 // but otherwise uninterpreted by RocksDB.
 func (b *RocksDBBatchBuilder) LogData(data []byte) {
 	b.maybeInit()
+	b.logData = true
 	pos := len(b.repr)
 	b.grow(1 + maxVarintLen32 + len(data))
 	b.repr[pos] = byte(BatchTypeLogData)

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1923,7 +1923,7 @@ func (r *rocksDBBatch) commitInternal(sync bool) error {
 }
 
 func (r *rocksDBBatch) Empty() bool {
-	return r.flushes == 0 && r.builder.Empty()
+	return r.flushes == 0 && r.builder.Empty() && !r.builder.logData
 }
 
 func (r *rocksDBBatch) Repr() []byte {

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -1596,7 +1596,7 @@ func TestRocksDBWALFileEmptyBatch(t *testing.T) {
 	if err := b.Put(mvccKey("foo"), []byte{'b', 'a', 'r'}); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Commit(true); err != nil {
+	if err := b.Commit(true /* sync */); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1615,7 +1615,7 @@ func TestRocksDBWALFileEmptyBatch(t *testing.T) {
 	// Commit an empty batch.
 	b = e.NewBatch()
 	defer b.Close()
-	if err := b.Commit(true); err != nil {
+	if err := b.Commit(true /* sync */); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1628,4 +1628,51 @@ func TestRocksDBWALFileEmptyBatch(t *testing.T) {
 		t.Fatalf("expected wal files %#v after committing empty batch, but got %#v",
 			walsBefore, walsAfter)
 	}
+
+	// Regression test a bug that would accidentally make Commit a no-op (via an
+	// errant fast-path) when a batch contained only LogData.
+	testutils.RunTrueAndFalse(t, "distinct", func(t *testing.T, distinct bool) {
+		walsBefore, err := e.GetSortedWALFiles()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(walsBefore) != 1 {
+			t.Fatalf("expected one WAL file, got %d", len(walsBefore))
+		}
+
+		batch := e.NewBatch()
+		defer batch.Close()
+
+		var writer ReadWriter = batch
+		if distinct {
+			// NB: we can't actually close this distinct batch because it auto-
+			// closes when the batch commits.
+			writer = batch.Distinct()
+		}
+
+		if err := writer.LogData([]byte("foo")); err != nil {
+			t.Fatal(err)
+		}
+		if batch.Empty() {
+			t.Error("batch is not empty")
+		}
+
+		if err := batch.Commit(true /* sync */); err != nil {
+			t.Fatal(err)
+		}
+
+		// Verify that the WAL has grown.
+		walsAfter, err := e.GetSortedWALFiles()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(walsAfter) != 1 {
+			t.Fatalf("expected one WAL file, got %+v", walsAfter)
+		}
+
+		if after, before := walsAfter[0].Size, walsBefore[0].Size; after <= before {
+			t.Fatalf("wal size was expected to increase, got %d -> %d", before, after)
+		}
+	})
 }


### PR DESCRIPTION
Backport 2/2 commits from https://github.com/cockroachdb/cockroach/pull/33122.

+cc @cockroachdb/release

https://github.com/cockroachdb/cockroach/pull/24591 attempted to ensure that a node with a stalled disk would not be considered live and would lose all its leases rather than stalling the rest of the cluster. This did not work when introduced, but was fixed in https://github.com/cockroachdb/cockroach/pull/33122. This backport picks up https://github.com/cockroachdb/cockroach/pull/33122 to 2.1 so https://github.com/cockroachdb/cockroach/pull/24591 works as intended.

Part of https://github.com/cockroachdb/cockroach/issues/41683.

---

- engine: properly support batches containing only LogData
- engine: test batch.Commit when it only contains LogData

Release note (bug fix): Previously a disk stall could allow a node to continue heartbeating its liveness record and prevent other nodes from taking over its leases, despite being completely unresponsive.
