### PR TITLE
*: miscellaneous fixes to allow building with go1.13

### DIFF
--- a/pkg/acceptance/flags.go
+++ b/pkg/acceptance/flags.go
@@ -15,9 +15,5 @@ import (
 	"time"
 )
 
-func init() {
-	flag.Parse()
-}
-
 var flagDuration = flag.Duration("d", 5*time.Second, "for duration-limited tests, how long to run them for")
 var flagLogDir = flag.String("l", "", "the directory to store log files, relative to the test source")

--- a/pkg/cmd/github-pull-request-make/main.go
+++ b/pkg/cmd/github-pull-request-make/main.go
@@ -35,6 +35,7 @@ import (
 	"strings"
 	"time"
 
+	_ "github.com/cockroachdb/cockroach/pkg/testutils/buildutil"
 	"github.com/google/go-github/github"
 	"golang.org/x/oauth2"
 )

--- a/pkg/cmd/prereqs/prereqs.go
+++ b/pkg/cmd/prereqs/prereqs.go
@@ -48,6 +48,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	_ "github.com/cockroachdb/cockroach/pkg/testutils/buildutil"
 )
 
 var buildCtx = func() build.Context {

--- a/pkg/internal/sqlsmith/sqlsmith_test.go
+++ b/pkg/internal/sqlsmith/sqlsmith_test.go
@@ -35,10 +35,6 @@ var (
 	flagCheckVec    = flag.Bool("check-vec", false, "fail if a generated statement cannot be vectorized")
 )
 
-func init() {
-	flag.Parse()
-}
-
 // TestGenerateParse verifies that statements produced by Generate can be
 // parsed. This is useful because since we make AST nodes directly we can
 // sometimes put them into bad states that the parser would never do.

--- a/pkg/security/certs_test.go
+++ b/pkg/security/certs_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const testKeySize = 1024
+
 func TestGenerateCACert(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// Do not mock cert access for this test.
@@ -73,7 +75,7 @@ func TestGenerateCACert(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		err := security.CreateCAPair(tc.certsDir, tc.caKey, 512,
+		err := security.CreateCAPair(tc.certsDir, tc.caKey, testKeySize,
 			time.Hour*48, tc.allowReuse, tc.overwrite)
 		if !testutils.IsError(err, tc.errStr) {
 			t.Errorf("#%d: expected error %s but got %+v", i, tc.errStr, err)
@@ -125,21 +127,21 @@ func TestGenerateNodeCerts(t *testing.T) {
 	// Try generating node certs without CA certs present.
 	if err := security.CreateNodePair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
-		512, time.Hour*48, false, []string{"localhost"},
+		testKeySize, time.Hour*48, false, []string{"localhost"},
 	); err == nil {
 		t.Fatalf("Expected error, but got none")
 	}
 
 	// Now try in the proper order.
 	if err := security.CreateCAPair(
-		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey), 512, time.Hour*96, false, false,
+		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey), testKeySize, time.Hour*96, false, false,
 	); err != nil {
 		t.Fatalf("Expected success, got %v", err)
 	}
 
 	if err := security.CreateNodePair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
-		512, time.Hour*48, false, []string{"localhost"},
+		testKeySize, time.Hour*48, false, []string{"localhost"},
 	); err != nil {
 		t.Fatalf("Expected success, got %v", err)
 	}
@@ -152,21 +154,21 @@ func TestGenerateNodeCerts(t *testing.T) {
 func generateBaseCerts(certsDir string) error {
 	if err := security.CreateCAPair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
-		512, time.Hour*96, true, true,
+		testKeySize, time.Hour*96, true, true,
 	); err != nil {
 		return errors.Errorf("could not generate CA pair: %v", err)
 	}
 
 	if err := security.CreateNodePair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
-		512, time.Hour*48, true, []string{"127.0.0.1"},
+		testKeySize, time.Hour*48, true, []string{"127.0.0.1"},
 	); err != nil {
 		return errors.Errorf("could not generate Node pair: %v", err)
 	}
 
 	if err := security.CreateClientPair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
-		512, time.Hour*48, true, security.RootUser, false,
+		testKeySize, time.Hour*48, true, security.RootUser, false,
 	); err != nil {
 		return errors.Errorf("could not generate Client pair: %v", err)
 	}
@@ -183,49 +185,49 @@ func generateBaseCerts(certsDir string) error {
 func generateSplitCACerts(certsDir string) error {
 	if err := security.CreateCAPair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
-		512, time.Hour*96, true, true,
+		testKeySize, time.Hour*96, true, true,
 	); err != nil {
 		return errors.Errorf("could not generate CA pair: %v", err)
 	}
 
 	if err := security.CreateNodePair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
-		512, time.Hour*48, true, []string{"127.0.0.1"},
+		testKeySize, time.Hour*48, true, []string{"127.0.0.1"},
 	); err != nil {
 		return errors.Errorf("could not generate Node pair: %v", err)
 	}
 
 	if err := security.CreateClientCAPair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedClientCAKey),
-		512, time.Hour*96, true, true,
+		testKeySize, time.Hour*96, true, true,
 	); err != nil {
 		return errors.Errorf("could not generate client CA pair: %v", err)
 	}
 
 	if err := security.CreateClientPair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedClientCAKey),
-		512, time.Hour*48, true, security.NodeUser, false,
+		testKeySize, time.Hour*48, true, security.NodeUser, false,
 	); err != nil {
 		return errors.Errorf("could not generate Client pair: %v", err)
 	}
 
 	if err := security.CreateClientPair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedClientCAKey),
-		512, time.Hour*48, true, security.RootUser, false,
+		testKeySize, time.Hour*48, true, security.RootUser, false,
 	); err != nil {
 		return errors.Errorf("could not generate Client pair: %v", err)
 	}
 
 	if err := security.CreateUICAPair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedUICAKey),
-		512, time.Hour*96, true, true,
+		testKeySize, time.Hour*96, true, true,
 	); err != nil {
 		return errors.Errorf("could not generate UI CA pair: %v", err)
 	}
 
 	if err := security.CreateUIPair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedUICAKey),
-		512, time.Hour*48, true, []string{"127.0.0.1"},
+		testKeySize, time.Hour*48, true, []string{"127.0.0.1"},
 	); err != nil {
 		return errors.Errorf("could not generate UI pair: %v", err)
 	}

--- a/pkg/sql/opt/opbench/opbench_test.go
+++ b/pkg/sql/opt/opbench/opbench_test.go
@@ -38,10 +38,6 @@ const rewriteActualFlag = "opbench-rewrite-actual"
 var rewriteEstimated = flag.Bool(rewriteEstimatedFlag, false, "re-calculate the estimated costs for each Plan")
 var rewriteActual = flag.Bool(rewriteActualFlag, false, "re-measure the runtime for each Plan")
 
-func init() {
-	flag.Parse()
-}
-
 // TODO(justin): we need a system to get consistent re-measurements of all the
 // "actual" results. We will probably want some ability to kick off a roachprod
 // cluster which will crunch through them all. It's still valuable to be

--- a/pkg/testutils/buildutil/build.go
+++ b/pkg/testutils/buildutil/build.go
@@ -12,12 +12,23 @@ package buildutil
 
 import (
 	"go/build"
+	"os"
 	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
 )
+
+func init() {
+	// NB: This is a hack to disable the use of go modules with
+	// build.Import. This will probably break with a future version of Go, but
+	// suffices until we move to using go modules. See go/build.Context.importGo
+	// (https://github.com/golang/go/blob/master/src/go/build/build.go#L999) and
+	// the logic to skip using `go list` if the env far "GO111MODULE" is set to
+	// "off".
+	_ = os.Setenv("GO111MODULE", "off")
+}
 
 func short(in string) string {
 	return strings.Replace(in, "github.com/cockroachdb/cockroach/pkg/", "./pkg/", -1)

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
+	_ "github.com/cockroachdb/cockroach/pkg/testutils/buildutil"
 	"github.com/ghemawat/stream"
 	"github.com/pkg/errors"
 	"golang.org/x/tools/go/buildutil"

--- a/pkg/util/timeutil/pgdate/parsing_test.go
+++ b/pkg/util/timeutil/pgdate/parsing_test.go
@@ -37,7 +37,6 @@ func init() {
 		`a postgresql connect string suitable for sql.Open(), `+
 			`to enable cross-checking during development; for example: `+
 			`-pgdate.db="database=bob sslmode=disable"`)
-	flag.Parse()
 }
 
 type timeData struct {


### PR DESCRIPTION
Disable modules so that `bin/prereqs` and other uses of
`go/build.Import` do not run into a weird permissioning problem with
writing to the modules cache.

Remove unnecessary calls to `flag.Parse()` from tests. Something changed
with the order of initializers and now explicitly calling `flag.Parse()` in
a test causes the flags in the `testing` package to not be registered which
causes the test to fail to run. The explicit call to
`flag.Parse()` wasn't necessary in any case, as the `testing` package does
that automatically.

Release note: None (we're not upgrading to go1.13 yet)