### PR TITLE
storage: remove kv.bulk_io_write.addsstable_max_rate setting

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -34,7 +34,6 @@
 <tr><td><code>kv.bulk_ingest.max_index_buffer_size</code></td><td>byte size</td><td><code>512 MiB</code></td><td>the maximum size of the BulkAdder buffer handling secondary index imports</td></tr>
 <tr><td><code>kv.bulk_ingest.max_pk_buffer_size</code></td><td>byte size</td><td><code>128 MiB</code></td><td>the maximum size of the BulkAdder buffer handling primary index imports</td></tr>
 <tr><td><code>kv.bulk_ingest.pk_buffer_size</code></td><td>byte size</td><td><code>32 MiB</code></td><td>the initial size of the BulkAdder buffer handling primary index imports</td></tr>
-<tr><td><code>kv.bulk_io_write.addsstable_max_rate</code></td><td>float</td><td><code>1.7976931348623157E+308</code></td><td>maximum number of AddSSTable requests per second for a single store</td></tr>
 <tr><td><code>kv.bulk_io_write.concurrent_addsstable_requests</code></td><td>integer</td><td><code>1</code></td><td>number of AddSSTable requests a store will handle concurrently before queuing</td></tr>
 <tr><td><code>kv.bulk_io_write.concurrent_export_requests</code></td><td>integer</td><td><code>3</code></td><td>number of export requests a store will handle concurrently before queuing</td></tr>
 <tr><td><code>kv.bulk_io_write.concurrent_import_requests</code></td><td>integer</td><td><code>1</code></td><td>number of import requests a store will handle concurrently before queuing</td></tr>

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -46,6 +46,7 @@ var retiredSettings = map[string]struct{}{
 	"timeseries.storage.10s_resolution_ttl":                {},
 	"changefeed.push.enabled":                              {},
 	"sql.defaults.optimizer":                               {},
+	"kv.bulk_io_write.addsstable_max_rate":                 {},
 }
 
 // Register adds a setting to the registry.

--- a/pkg/storage/batcheval/eval_context.go
+++ b/pkg/storage/batcheval/eval_context.go
@@ -34,7 +34,6 @@ type Limiters struct {
 	BulkIOWriteRate              *rate.Limiter
 	ConcurrentImportRequests     limit.ConcurrentRequestLimiter
 	ConcurrentExportRequests     limit.ConcurrentRequestLimiter
-	AddSSTableRequestRate        *rate.Limiter
 	ConcurrentAddSSTableRequests limit.ConcurrentRequestLimiter
 	// concurrentRangefeedIters is a semaphore used to limit the number of
 	// rangefeeds in the "catch-up" state across the store. The "catch-up" state

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -114,15 +114,6 @@ var importRequestsLimit = settings.RegisterPositiveIntSetting(
 	1,
 )
 
-// addSSTableRequestMaxRate is the maximum number of AddSSTable requests per second.
-var addSSTableRequestMaxRate = settings.RegisterNonNegativeFloatSetting(
-	"kv.bulk_io_write.addsstable_max_rate",
-	"maximum number of AddSSTable requests per second for a single store",
-	float64(rate.Inf),
-)
-
-const addSSTableRequestBurst = 32
-
 // addSSTableRequestLimit limits concurrent AddSSTable requests.
 var addSSTableRequestLimit = settings.RegisterPositiveIntSetting(
 	"kv.bulk_io_write.concurrent_addsstable_requests",
@@ -872,16 +863,6 @@ func NewStore(
 			limit = exportCores
 		}
 		s.limiters.ConcurrentExportRequests.SetLimit(limit)
-	})
-	s.limiters.AddSSTableRequestRate = rate.NewLimiter(
-		rate.Limit(addSSTableRequestMaxRate.Get(&cfg.Settings.SV)), addSSTableRequestBurst)
-	addSSTableRequestMaxRate.SetOnChange(&cfg.Settings.SV, func() {
-		rateLimit := addSSTableRequestMaxRate.Get(&cfg.Settings.SV)
-		if math.IsInf(rateLimit, 0) {
-			// This value causes the burst limit to be ignored
-			rateLimit = float64(rate.Inf)
-		}
-		s.limiters.AddSSTableRequestRate.SetLimit(rate.Limit(rateLimit))
 	})
 	s.limiters.ConcurrentAddSSTableRequests = limit.MakeConcurrentRequestLimiter(
 		"addSSTableRequestLimiter", int(addSSTableRequestLimit.Get(&cfg.Settings.SV)),

--- a/pkg/storage/store_send.go
+++ b/pkg/storage/store_send.go
@@ -64,9 +64,6 @@ func (s *Store) Send(
 		}
 		defer s.limiters.ConcurrentAddSSTableRequests.Finish()
 
-		if err := s.limiters.AddSSTableRequestRate.Wait(ctx); err != nil {
-			return nil, roachpb.NewError(err)
-		}
 		beforeEngineDelay := timeutil.Now()
 		s.engine.PreIngestDelay(ctx)
 		if waited := timeutil.Since(before); waited > time.Second {


### PR DESCRIPTION
We added this setting at the last minute in 19.1 cycle, mostly as a 'in
case we need this' / 'maybe this will prove useful'. However further
testing hasn't really found it useful. Limiting concurrency and applying
backpressure based on engine health have proved useful, but limiting the
rate of requests -- regardless of their size or effect -- hasn't proved
to be useful, and it still defaults to ~unlimited.

Given that, just removing it reduces the number of knobs we need to keep
in mind when debugging ingestion performance and makes it easier to
reason about the effects of the other knobs.

Release note (general change): remove kv.bulk_io_write.addsstable_max_rate setting.