### PR TITLE
release-19.2: bulk: sstBatcher default to disallowShadowing

### DIFF
--- a/pkg/storage/bulk/sst_batcher.go
+++ b/pkg/storage/bulk/sst_batcher.go
@@ -93,7 +93,7 @@ type SSTBatcher struct {
 
 // MakeSSTBatcher makes a ready-to-use SSTBatcher.
 func MakeSSTBatcher(ctx context.Context, db sender, flushBytes uint64) (*SSTBatcher, error) {
-	b := &SSTBatcher{db: db, maxSize: flushBytes}
+	b := &SSTBatcher{db: db, maxSize: flushBytes, disallowShadowing: true}
 	err := b.Reset()
 	return b, err
 }


### PR DESCRIPTION
Backport 1/1 commits from #41747.

/cc @cockroachdb/release

---

IMPORT's batcher is configured by its BufferingAdder to set this to true, but RESTORE (and _only_ RESTORE) uses the raw batcher directly.

When false, mvcc stats are marked as estimates as the SST might, or might not, be adding the keys it contains. When true, we *know* every key in the SST is new (or it would be an error), so we can mark stats as exact.

Defaulting to true will mean RESTORE's SSTables are sent with DisallowShadowing=true, meaning their stats should be marked as exact. They check should be very cheap in RESTORE as it should take the empty-span fast-path, and having stats not marked as estimates is cheaper in the long-term (avoids re-computations later, e.g. in splits).

Release note: none.
