### PR TITLE
backupccl: add setting to use TBI

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -38,6 +38,7 @@
 <tr><td><code>kv.bulk_io_write.concurrent_addsstable_requests</code></td><td>integer</td><td><code>1</code></td><td>number of AddSSTable requests a store will handle concurrently before queuing</td></tr>
 <tr><td><code>kv.bulk_io_write.concurrent_export_requests</code></td><td>integer</td><td><code>3</code></td><td>number of export requests a store will handle concurrently before queuing</td></tr>
 <tr><td><code>kv.bulk_io_write.concurrent_import_requests</code></td><td>integer</td><td><code>1</code></td><td>number of import requests a store will handle concurrently before queuing</td></tr>
+<tr><td><code>kv.bulk_io_write.experimental_incremental_export_enabled</code></td><td>boolean</td><td><code>false</code></td><td>use experimental time-bound file filter when exporting in BACKUP</td></tr>
 <tr><td><code>kv.bulk_io_write.max_rate</code></td><td>byte size</td><td><code>1.0 TiB</code></td><td>the rate limit (bytes/sec) to use for writes to disk on behalf of bulk io ops</td></tr>
 <tr><td><code>kv.bulk_sst.sync_size</code></td><td>byte size</td><td><code>2.0 MiB</code></td><td>threshold after which non-Rocks SST writes must fsync (0 disables)</td></tr>
 <tr><td><code>kv.closed_timestamp.close_fraction</code></td><td>float</td><td><code>0.2</code></td><td>fraction of closed timestamp target duration specifying how frequently the closed timestamp is advanced</td></tr>

--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/covering"
@@ -72,6 +73,12 @@ const (
 	backupOptRevisionHistory = "revision_history"
 	localityURLParam         = "COCKROACH_LOCALITY"
 	defaultLocalityValue     = "default"
+)
+
+var useTBI = settings.RegisterBoolSetting(
+	"kv.bulk_io_write.experimental_incremental_export_enabled",
+	"use experimental time-bound file filter when exporting in BACKUP",
+	false,
 )
 
 var backupOptionExpectValues = map[string]sql.KVStringOptValidate{
@@ -780,11 +787,12 @@ func backup(
 				defer func() { <-exportsSem }()
 				header := roachpb.Header{Timestamp: span.end}
 				req := &roachpb.ExportRequest{
-					RequestHeader:       roachpb.RequestHeaderFromSpan(span.span),
-					Storage:             defaultStore.Conf(),
-					StorageByLocalityKV: storageByLocalityKV,
-					StartTime:           span.start,
-					MVCCFilter:          roachpb.MVCCFilter(backupDesc.MVCCFilter),
+					RequestHeader:                       roachpb.RequestHeaderFromSpan(span.span),
+					Storage:                             defaultStore.Conf(),
+					StorageByLocalityKV:                 storageByLocalityKV,
+					StartTime:                           span.start,
+					EnableTimeBoundIteratorOptimization: useTBI.Get(&settings.SV),
+					MVCCFilter:                          roachpb.MVCCFilter(backupDesc.MVCCFilter),
 				}
 				rawRes, pErr := client.SendWrappedWith(ctx, db.NonTransactionalSender(), header, req)
 				if pErr != nil {


### PR DESCRIPTION
This should make it easier to test TBI in various incremental backup scenarios (or in customer deployments), to find out if it would make a difference if re-enabled by default.

Release note: none.