### PR TITLE
storage: add metric tracking estimated pending compaction bytes

### DIFF
--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -362,6 +362,12 @@ var (
 		Measurement: "SSTables",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaRdbPendingCompaction = metric.Metadata{
+		Name:        "rocksdb.estimated-pending-compaction",
+		Help:        "Estimated pending compaction bytes",
+		Measurement: "Storage",
+		Unit:        metric.Unit_BYTES,
+	}
 
 	// Range event metrics.
 	metaRangeSplits = metric.Metadata{
@@ -1034,6 +1040,7 @@ type StoreMetrics struct {
 	RdbTableReadersMemEstimate  *metric.Gauge
 	RdbReadAmplification        *metric.Gauge
 	RdbNumSSTables              *metric.Gauge
+	RdbPendingCompaction        *metric.Gauge
 
 	// TODO(mrtracy): This should be removed as part of #4465. This is only
 	// maintained to keep the current structure of NodeStatus; it would be
@@ -1243,6 +1250,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		RdbTableReadersMemEstimate:  metric.NewGauge(metaRdbTableReadersMemEstimate),
 		RdbReadAmplification:        metric.NewGauge(metaRdbReadAmplification),
 		RdbNumSSTables:              metric.NewGauge(metaRdbNumSSTables),
+		RdbPendingCompaction:        metric.NewGauge(metaRdbPendingCompaction),
 
 		// Range event metrics.
 		RangeSplits:                     metric.NewCounter(metaRangeSplits),

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2360,6 +2360,7 @@ func (s *Store) ComputeMetrics(ctx context.Context, tick int) error {
 		s.metrics.RdbNumSSTables.Update(int64(sstables.Len()))
 		readAmp := sstables.ReadAmplification()
 		s.metrics.RdbReadAmplification.Update(int64(readAmp))
+		s.metrics.RdbPendingCompaction.Update(stats.PendingCompactionBytesEstimate)
 		// Log this metric infrequently (with current configurations,
 		// every 10 minutes). Trigger on tick 1 instead of tick 0 so that
 		// non-periodic callers of this method don't trigger expensive

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1802,6 +1802,10 @@ var charts = []sectionDescription{
 				Title:   "Read Amplification",
 				Metrics: []string{"rocksdb.read-amplification"},
 			},
+			{
+				Title:   "Pending Compaction",
+				Metrics: []string{"rocksdb.estimated-pending-compaction"},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
This helps when trying to identify is a node, and if so which node(s), has accumulated compaction debt or when it has cleared it.

Release note: none.