### PR TITLE
colexec: fix null handling for LIKE '%'

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -397,7 +397,7 @@ statement ok
 CREATE TABLE e (x TEXT)
 
 statement ok
-INSERT INTO e VALUES ('abc'), ('xyz')
+INSERT INTO e VALUES ('abc'), ('xyz'), (NULL)
 
 statement ok
 SET vectorize = experimental_always
@@ -455,8 +455,9 @@ xyz
 query TBBBBBBBB
 SELECT x, x LIKE '%', x NOT LIKE '%', x LIKE 'ab%', x NOT LIKE 'ab%', x LIKE '%bc', x NOT LIKE '%bc', x LIKE 'a%c', x NOT LIKE 'a%c' FROM e ORDER BY x
 ----
-abc  true  false  true   false  true   false  true   false
-xyz  true  false  false  true   false  true   false  true
+NULL  NULL  NULL   NULL   NULL   NULL   NULL   NULL   NULL
+abc   true  false  true   false  true   false  true   false
+xyz   true  false  false  true   false  true   false  true
 
 # Test that vectorized stats are collected correctly.
 statement ok


### PR DESCRIPTION
The vectorized engine was incorrectly evaluating `NULL LIKE '%'` as
true and `NULL NOT LIKE '%'` as false. The result should be NULL in both
cases.

I implemented these cases using a prefix operator with an empty prefix,
since it has the correct null behavior.

Release note: None