### PR TITLE
release-19.2: storage: write to local storage before updating liveness

### DIFF
--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -830,6 +830,16 @@ func (nl *NodeLiveness) updateLiveness(
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+
+		for _, eng := range nl.engines {
+			// We synchronously write to all disks before updating liveness because we
+			// don't want any excessively slow disks to prevent leases from being
+			// shifted to other nodes. A slow/stalled disk would block here and cause
+			// the node to lose its leases.
+			if err := engine.WriteSyncNoop(ctx, eng); err != nil {
+				return errors.Wrapf(err, "couldn't update node liveness because disk write failed")
+			}
+		}
 		if err := nl.updateLivenessAttempt(ctx, update, oldLiveness, handleCondFailed); err != nil {
 			// Intentionally don't errors.Cause() the error, or we'd hop past errRetryLiveness.
 			if _, ok := err.(*errRetryLiveness); ok {


### PR DESCRIPTION
Backport 1/1 commits from #41761.

+cc @cockroachdb/release

---

Previously a disk stall could allow a node to continue heartbeating its
liveness record and prevent other nodes from taking over its leases,
despite being completely unresponsive.

This was first addressed in #24591 (+ #33122). This was undone in #32978
(which introduced a stricter version of a similar check). #32978 was
later disabled by default in #36484, leaving us without the protections
first introduced in #24591. This PR re-adds the logic from #24591.

Part of #41683.

Release note (bug fix): Previously a disk stall could allow a node to continue heartbeating its liveness record and prevent other nodes from taking over its leases, despite being completely unresponsive..
