### PR TITLE
release-19.2: add metrics for pending compactions and sstable delays

### DIFF
--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -362,6 +362,12 @@ var (
 		Measurement: "SSTables",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaRdbPendingCompaction = metric.Metadata{
+		Name:        "rocksdb.estimated-pending-compaction",
+		Help:        "Estimated pending compaction bytes",
+		Measurement: "Storage",
+		Unit:        metric.Unit_BYTES,
+	}
 
 	// Range event metrics.
 	metaRangeSplits = metric.Metadata{
@@ -1034,6 +1040,7 @@ type StoreMetrics struct {
 	RdbTableReadersMemEstimate  *metric.Gauge
 	RdbReadAmplification        *metric.Gauge
 	RdbNumSSTables              *metric.Gauge
+	RdbPendingCompaction        *metric.Gauge
 
 	// TODO(mrtracy): This should be removed as part of #4465. This is only
 	// maintained to keep the current structure of NodeStatus; it would be
@@ -1243,6 +1250,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		RdbTableReadersMemEstimate:  metric.NewGauge(metaRdbTableReadersMemEstimate),
 		RdbReadAmplification:        metric.NewGauge(metaRdbReadAmplification),
 		RdbNumSSTables:              metric.NewGauge(metaRdbNumSSTables),
+		RdbPendingCompaction:        metric.NewGauge(metaRdbPendingCompaction),
 
 		// Range event metrics.
 		RangeSplits:                     metric.NewCounter(metaRangeSplits),

--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -950,6 +950,18 @@ var (
 		Measurement: "Ingestions",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaAddSSTableEvalTotalDelay = metric.Metadata{
+		Name:        "addsstable.delay.total",
+		Help:        "Amount by which evaluation of AddSSTable requests was delayed",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
+	metaAddSSTableEvalEngineDelay = metric.Metadata{
+		Name:        "addsstable.delay.enginebackpressure",
+		Help:        "Amount by which evaluation of AddSSTable requests was delayed by storage-engine backpressure",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
 
 	// Encryption-at-rest metrics.
 	// TODO(mberhault): metrics for key age, per-key file/bytes counts.
@@ -1163,9 +1175,11 @@ type StoreMetrics struct {
 
 	// AddSSTable stats: how many AddSSTable commands were proposed and how many
 	// were applied? How many applications required writing a copy?
-	AddSSTableProposals         *metric.Counter
-	AddSSTableApplications      *metric.Counter
-	AddSSTableApplicationCopies *metric.Counter
+	AddSSTableProposals           *metric.Counter
+	AddSSTableApplications        *metric.Counter
+	AddSSTableApplicationCopies   *metric.Counter
+	AddSSTableProposalTotalDelay  *metric.Counter
+	AddSSTableProposalEngineDelay *metric.Counter
 
 	// Encryption-at-rest stats.
 	// EncryptionAlgorithm is an enum representing the cipher in use, so we use a gauge.
@@ -1365,9 +1379,11 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		BackpressuredOnSplitRequests: metric.NewGauge(metaBackpressuredOnSplitRequests),
 
 		// AddSSTable proposal + applications counters.
-		AddSSTableProposals:         metric.NewCounter(metaAddSSTableProposals),
-		AddSSTableApplications:      metric.NewCounter(metaAddSSTableApplications),
-		AddSSTableApplicationCopies: metric.NewCounter(metaAddSSTableApplicationCopies),
+		AddSSTableProposals:           metric.NewCounter(metaAddSSTableProposals),
+		AddSSTableApplications:        metric.NewCounter(metaAddSSTableApplications),
+		AddSSTableApplicationCopies:   metric.NewCounter(metaAddSSTableApplicationCopies),
+		AddSSTableProposalTotalDelay:  metric.NewCounter(metaAddSSTableEvalTotalDelay),
+		AddSSTableProposalEngineDelay: metric.NewCounter(metaAddSSTableEvalEngineDelay),
 
 		// Encryption-at-rest.
 		EncryptionAlgorithm: metric.NewGauge(metaEncryptionAlgorithm),

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2355,6 +2355,7 @@ func (s *Store) ComputeMetrics(ctx context.Context, tick int) error {
 		s.metrics.RdbNumSSTables.Update(int64(sstables.Len()))
 		readAmp := sstables.ReadAmplification()
 		s.metrics.RdbReadAmplification.Update(int64(readAmp))
+		s.metrics.RdbPendingCompaction.Update(stats.PendingCompactionBytesEstimate)
 		// Log this metric infrequently (with current configurations,
 		// every 10 minutes). Trigger on tick 1 instead of tick 0 so that
 		// non-periodic callers of this method don't trigger expensive

--- a/pkg/storage/store_send.go
+++ b/pkg/storage/store_send.go
@@ -69,9 +69,14 @@ func (s *Store) Send(
 		}
 		beforeEngineDelay := timeutil.Now()
 		s.engine.PreIngestDelay(ctx)
-		if waited := timeutil.Since(before); waited > time.Second {
+		after := timeutil.Now()
+
+		waited, waitedEngine := after.Sub(before), after.Sub(beforeEngineDelay)
+		s.metrics.AddSSTableProposalTotalDelay.Inc(waited.Nanoseconds())
+		s.metrics.AddSSTableProposalEngineDelay.Inc(waitedEngine.Nanoseconds())
+		if waited > time.Second {
 			log.Infof(ctx, "SST ingestion was delayed by %v (%v for storage engine back-pressure)",
-				waited, timeutil.Since(beforeEngineDelay))
+				waited, waitedEngine)
 		}
 	}
 

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1823,6 +1823,13 @@ var charts = []sectionDescription{
 					"addsstable.proposals",
 				},
 			},
+			{
+				Title: "Ingestion Delays",
+				Metrics: []string{
+					"addsstable.delay.total",
+					"addsstable.delay.enginebackpressure",
+				},
+			},
 		},
 	},
 	{

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1802,6 +1802,10 @@ var charts = []sectionDescription{
 				Title:   "Read Amplification",
 				Metrics: []string{"rocksdb.read-amplification"},
 			},
+			{
+				Title:   "Pending Compaction",
+				Metrics: []string{"rocksdb.estimated-pending-compaction"},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
Backport:
  * 1/1 commits from "storage: add metric tracking estimated pending compaction bytes" (#41754)
  * 1/1 commits from "storage: add metric for delayed AddSSTable requests" (#41746)

Please see individual PRs for details.

/cc @cockroachdb/release
