### PR TITLE
sql: handle all empty input batches to vectorized ordinality operations

### DIFF
--- a/pkg/sql/colexec/ordinality.go
+++ b/pkg/sql/colexec/ordinality.go
@@ -58,6 +58,11 @@ func (c *ordinalityOp) Next(ctx context.Context) coldata.Batch {
 		c.ordinalityCol = bat.Width()
 		bat.AppendCol(coltypes.Int64)
 	}
+
+	if bat.Length() == 0 {
+		return bat
+	}
+
 	vec := bat.ColVec(c.ordinalityCol).Int64()
 	sel := bat.Selection()
 

--- a/pkg/sql/logictest/testdata/logic_test/ordinality
+++ b/pkg/sql/logictest/testdata/logic_test/ordinality
@@ -84,3 +84,9 @@ true
 # Regression test for #33659
 statement ok
 TABLE [SHOW ZONE CONFIGURATIONS] WITH ORDINALITY
+
+# Regression test for #41760
+query TI
+SELECT * FROM (SELECT * FROM foo LIMIT 1) WITH ORDINALITY
+----
+a 1


### PR DESCRIPTION
I don't know much about colexec so this is my best guess at a fix; it handles the specific case I found earlier. This function seems to assume that all subsequent batches will have the same number of columns as the initial one (including the newly-added ordinality column), so if this isn't a valid assumption it might be worth taking a closer look at how that should be handled.

***

Fixes #41760

Previously, vectorized execution of ordinality would perform
some operations (including accessing a column vector) on every empty
input batch, even those with length 0.

These operations assumed that the batch had at least one column
vector even if the batch was empty, but this is sometimes an invalid
assumption. For instance, when the input node is a limitOp, a 0-length
batch with no column vectors is returned if the row limit has been
reached.

This patch simply returns early in the case of an empty input batch.

Release note (bug fix): Vectorized execution will no longer error
when adding an ordinality column to an expression with a limit.

```
SELECT * FROM (SELECT * FROM foo LIMIT 1) WITH ORDINALITY
```

will no longer throw an index out of range error.