### PR TITLE
sql/sem/builtins: support more time spans for EXTRACT and DATE_TRUNC

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -300,8 +300,8 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><a name="date_trunc"></a><code>date_trunc(element: <a href="string.html">string</a>, input: <a href="date.html">date</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Truncates <code>input</code> to precision <code>element</code>.  Sets all fields that are less
 significant than <code>element</code> to zero (or one, for day and month)</p>
-<p>Compatible elements: year, quarter, month, week, hour, minute, second,
-millisecond, microsecond.</p>
+<p>Compatible elements: millennium, century, decade, year, quarter, month,
+week, day, hour, minute, second, millisecond, microsecond.</p>
 </span></td></tr>
 <tr><td><a name="date_trunc"></a><code>date_trunc(element: <a href="string.html">string</a>, input: <a href="time.html">time</a>) &rarr; <a href="interval.html">interval</a></code></td><td><span class="funcdesc"><p>Truncates <code>input</code> to precision <code>element</code>.  Sets all fields that are less
 significant than <code>element</code> to zero.</p>
@@ -309,13 +309,13 @@ significant than <code>element</code> to zero.</p>
 </span></td></tr>
 <tr><td><a name="date_trunc"></a><code>date_trunc(element: <a href="string.html">string</a>, input: <a href="timestamp.html">timestamp</a>) &rarr; <a href="timestamp.html">timestamp</a></code></td><td><span class="funcdesc"><p>Truncates <code>input</code> to precision <code>element</code>.  Sets all fields that are less
 significant than <code>element</code> to zero (or one, for day and month)</p>
-<p>Compatible elements: year, quarter, month, week, hour, minute, second,
-millisecond, microsecond.</p>
+<p>Compatible elements: millennium, century, decade, year, quarter, month,
+week, day, hour, minute, second, millisecond, microsecond.</p>
 </span></td></tr>
 <tr><td><a name="date_trunc"></a><code>date_trunc(element: <a href="string.html">string</a>, input: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Truncates <code>input</code> to precision <code>element</code>.  Sets all fields that are less
 significant than <code>element</code> to zero (or one, for day and month)</p>
-<p>Compatible elements: year, quarter, month, week, hour, minute, second,
-millisecond, microsecond.</p>
+<p>Compatible elements: millennium, century, decade, year, quarter, month,
+week, day, hour, minute, second, millisecond, microsecond.</p>
 </span></td></tr>
 <tr><td><a name="experimental_follower_read_timestamp"></a><code>experimental_follower_read_timestamp() &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Returns a timestamp which is very likely to be safe to perform
 against a follower replica.</p>
@@ -335,18 +335,21 @@ return without an error.</p>
 <tr><td><a name="experimental_strptime"></a><code>experimental_strptime(input: <a href="string.html">string</a>, format: <a href="string.html">string</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Returns <code>input</code> as a timestamptz using <code>format</code> (which uses standard <code>strptime</code> formatting).</p>
 </span></td></tr>
 <tr><td><a name="extract"></a><code>extract(element: <a href="string.html">string</a>, input: <a href="date.html">date</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Extracts <code>element</code> from <code>input</code>.</p>
-<p>Compatible elements: year, quarter, month, week, dayofweek, dayofyear,
+<p>Compatible elements: millennium, century, decade, year, isoyear,
+quarter, month, week, dayofweek, isodow, dayofyear, julian,
 hour, minute, second, millisecond, microsecond, epoch</p>
 </span></td></tr>
 <tr><td><a name="extract"></a><code>extract(element: <a href="string.html">string</a>, input: <a href="time.html">time</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Extracts <code>element</code> from <code>input</code>.</p>
 <p>Compatible elements: hour, minute, second, millisecond, microsecond, epoch</p>
 </span></td></tr>
 <tr><td><a name="extract"></a><code>extract(element: <a href="string.html">string</a>, input: <a href="timestamp.html">timestamp</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Extracts <code>element</code> from <code>input</code>.</p>
-<p>Compatible elements: year, quarter, month, week, dayofweek, dayofyear,
+<p>Compatible elements: millennium, century, decade, year, isoyear,
+quarter, month, week, dayofweek, isodow, dayofyear, julian,
 hour, minute, second, millisecond, microsecond, epoch</p>
 </span></td></tr>
 <tr><td><a name="extract"></a><code>extract(element: <a href="string.html">string</a>, input: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Extracts <code>element</code> from <code>input</code>.</p>
-<p>Compatible elements: year, quarter, month, week, dayofweek, dayofyear,
+<p>Compatible elements: millennium, century, decade, year, isoyear,
+quarter, month, week, dayofweek, isodow, dayofyear, julian,
 hour, minute, second, millisecond, microsecond, epoch</p>
 </span></td></tr>
 <tr><td><a name="extract_duration"></a><code>extract_duration(element: <a href="string.html">string</a>, input: <a href="interval.html">interval</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Extracts <code>element</code> from <code>input</code>.

--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -482,7 +482,19 @@ INSERT INTO ex VALUES
   (37, 'milliseconds', '2016-02-10 19:46:33.306157519',    33306,     '2016-02-10 19:46:33.306'),
   (38, 'microsecond',  '2001-04-10 12:04:59.34565423',     59345654,  '2001-04-10 12:04:59.345654'),
   (39, 'microsecond',  '2016-02-10 19:46:33.306157519',    33306158,  '2016-02-10 19:46:33.306158'),
-  (40, 'microseconds', '2016-02-10 19:46:33.306157519',    33306158,  '2016-02-10 19:46:33.306158')
+  (40, 'microseconds', '2016-02-10 19:46:33.306157519',    33306158,  '2016-02-10 19:46:33.306158'),
+  (41, 'isodow',       '2001-04-10 12:04:59',              2,         null),
+  (42, 'isodow',       '2001-04-08 12:04:59',              7,         null),
+  (43, 'isoyear',      '2007-12-31 12:04:59',              2008,      null),
+  (44, 'isoyear',      '2008-01-01 12:04:59',              2008,      null),
+  (45, 'decade',       '2001-04-10 12:04:59',              200,       '2000-01-01 00:00:00'),
+  (46, 'decade',       '2016-02-10 19:46:33.306157519 BC', -202,      '2021-01-01 00:00:00 BC'),
+  (47, 'century',      '2016-02-10 19:46:33.306157519',    21,        '2001-01-01 00:00:00'),
+  (48, 'century',      '0004-02-10 19:46:33.306157519 BC', -1,        '0100-01-01 00:00:00 BC'),
+  (49, 'millennium',   '2016-02-10 19:46:33.306157519',    3,         '2001-01-01 00:00:00'),
+  (50, 'millennium',   '1004-02-10 19:46:33.306157519 BC', -2,        '2000-01-01 00:00:00 BC'),
+  (51, 'julian',       '4714-11-24 BC',                     0,        null),
+  (52, 'julian',       '2016-02-10 19:46:33.306157519',    2457429,   null)
 
 query IBI
 SELECT k, extract(element, input::timestamp) = extract_result, extract(element, input::timestamp) FROM ex ORDER BY k
@@ -527,6 +539,18 @@ SELECT k, extract(element, input::timestamp) = extract_result, extract(element, 
 38 true 59345654
 39 true 33306158
 40 true 33306158
+41 true 2
+42 true 7
+43 true 2008
+44 true 2008
+45 true 200
+46 true -202
+47 true 21
+48 true -1
+49 true 3
+50 true -2
+51 true 0
+52 true 2457429
 
 query error extract\(\): unsupported timespan: nansecond
 SELECT extract(nansecond from '2001-04-10 12:04:59.34565423'::timestamp)
@@ -580,6 +604,18 @@ SELECT k, extract(element, input::timestamptz) = extract_result, extract(element
 38  true  59345654
 39  true  33306158
 40  true  33306158
+41  true  2
+42  true  7
+43  true  2008
+44  true  2008
+45  true  200
+46  true  -202
+47  true  21
+48  true  -1
+49  true  3
+50  true  -2
+51  true  0
+52  true  2457429
 
 query error extract\(\): unsupported timespan: nansecond
 SELECT extract(nansecond from '2001-04-10 12:04:59.34565423'::timestamptz)
@@ -631,6 +667,12 @@ FROM ex WHERE date_trunc_result IS NOT NULL ORDER BY k
 38 true 2001-04-10 12:04:59.345654+00:00
 39 true 2016-02-10 19:46:33.306158+00:00
 40 true 2016-02-10 19:46:33.306158+00:00
+45 true 2000-01-01 00:00:00+00:00
+46 true -2020-01-01 00:00:00+00:00
+47 true 2001-01-01 00:00:00+00:00
+48 true -0099-01-01 00:00:00+00:00
+49 true 2001-01-01 00:00:00+00:00
+50 true -1999-01-01 00:00:00+00:00
 
 query IBT
 SELECT k, date_trunc(element, input::timestamptz) = date_trunc_result, date_trunc(element, input::timestamptz)::string
@@ -669,6 +711,27 @@ FROM ex WHERE date_trunc_result IS NOT NULL ORDER BY k
 38 true 2001-04-10 12:04:59.345654+00:00
 39 true 2016-02-10 19:46:33.306158+00:00
 40 true 2016-02-10 19:46:33.306158+00:00
+45 true 2000-01-01 00:00:00+00:00
+46 true -2020-01-01 00:00:00+00:00
+47 true 2001-01-01 00:00:00+00:00
+48 true -0099-01-01 00:00:00+00:00
+49 true 2001-01-01 00:00:00+00:00
+50 true -1999-01-01 00:00:00+00:00
+
+query T
+SELECT date_trunc('millennia', '2000-02-10 19:46:33.306157519-04'::timestamptz)::string
+----
+1001-01-01 00:00:00-04:00
+
+query T
+SELECT date_trunc('centuries', '2016-02-10 19:46:33.306157519-04'::timestamptz)::string
+----
+2001-01-01 00:00:00-04:00
+
+query T
+SELECT date_trunc('decades', '2016-02-10 19:46:33.306157519-04'::timestamptz)::string
+----
+2010-01-01 00:00:00-04:00
 
 query T
 SELECT date_trunc('hour', '2016-02-10 19:46:33.306157519-04'::timestamptz)::string
@@ -717,6 +780,12 @@ FROM ex WHERE date_trunc_result IS NOT NULL ORDER BY k
 38  true  2001-04-10 00:00:00+00:00
 39  true  2016-02-10 00:00:00+00:00
 40  true  2016-02-10 00:00:00+00:00
+45  true  2000-01-01 00:00:00+00:00
+46  true  -2020-01-01 00:00:00+00:00
+47  true  2001-01-01 00:00:00+00:00
+48  true  -0099-01-01 00:00:00+00:00
+49  true  2001-01-01 00:00:00+00:00
+50  true  -1999-01-01 00:00:00+00:00
 
 query T
 SELECT (timestamp '2016-02-10 19:46:33.306157519')::string

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1778,7 +1778,8 @@ may increase either contention or retry errors, or both.`,
 				return extractStringFromTimestamp(ctx, fromTS.Time, timeSpan)
 			},
 			Info: "Extracts `element` from `input`.\n\n" +
-				"Compatible elements: year, quarter, month, week, dayofweek, dayofyear,\n" +
+				"Compatible elements: millennium, century, decade, year, isoyear,\n" +
+				"quarter, month, week, dayofweek, isodow, dayofyear, julian,\n" +
 				"hour, minute, second, millisecond, microsecond, epoch",
 		},
 		tree.Overload{
@@ -1794,7 +1795,8 @@ may increase either contention or retry errors, or both.`,
 				return extractStringFromTimestamp(ctx, fromTSTZ.Time, timeSpan)
 			},
 			Info: "Extracts `element` from `input`.\n\n" +
-				"Compatible elements: year, quarter, month, week, dayofweek, dayofyear,\n" +
+				"Compatible elements: millennium, century, decade, year, isoyear,\n" +
+				"quarter, month, week, dayofweek, isodow, dayofyear, julian,\n" +
 				"hour, minute, second, millisecond, microsecond, epoch",
 		},
 		tree.Overload{
@@ -1806,7 +1808,8 @@ may increase either contention or retry errors, or both.`,
 				return extractStringFromTimestamp(ctx, fromTSTZ.Time, timeSpan)
 			},
 			Info: "Extracts `element` from `input`.\n\n" +
-				"Compatible elements: year, quarter, month, week, dayofweek, dayofyear,\n" +
+				"Compatible elements: millennium, century, decade, year, isoyear,\n" +
+				"quarter, month, week, dayofweek, isodow, dayofyear, julian,\n" +
 				"hour, minute, second, millisecond, microsecond, epoch",
 		},
 		tree.Overload{
@@ -1909,8 +1912,8 @@ may increase either contention or retry errors, or both.`,
 			},
 			Info: "Truncates `input` to precision `element`.  Sets all fields that are less\n" +
 				"significant than `element` to zero (or one, for day and month)\n\n" +
-				"Compatible elements: year, quarter, month, week, hour, minute, second,\n" +
-				"millisecond, microsecond.",
+				"Compatible elements: millennium, century, decade, year, quarter, month,\n" +
+				"week, day, hour, minute, second, millisecond, microsecond.",
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"element", types.String}, {"input", types.Date}},
@@ -1926,8 +1929,8 @@ may increase either contention or retry errors, or both.`,
 			},
 			Info: "Truncates `input` to precision `element`.  Sets all fields that are less\n" +
 				"significant than `element` to zero (or one, for day and month)\n\n" +
-				"Compatible elements: year, quarter, month, week, hour, minute, second,\n" +
-				"millisecond, microsecond.",
+				"Compatible elements: millennium, century, decade, year, quarter, month,\n" +
+				"week, day, hour, minute, second, millisecond, microsecond.",
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"element", types.String}, {"input", types.Time}},
@@ -1955,8 +1958,8 @@ may increase either contention or retry errors, or both.`,
 			},
 			Info: "Truncates `input` to precision `element`.  Sets all fields that are less\n" +
 				"significant than `element` to zero (or one, for day and month)\n\n" +
-				"Compatible elements: year, quarter, month, week, hour, minute, second,\n" +
-				"millisecond, microsecond.",
+				"Compatible elements: millennium, century, decade, year, quarter, month,\n" +
+				"week, day, hour, minute, second, millisecond, microsecond.",
 		},
 	),
 
@@ -4495,12 +4498,55 @@ func extractStringFromTime(fromTime *tree.DTime, timeSpan string) (tree.Datum, e
 	}
 }
 
+// dateToJulianDay is based on the date2j function in PostgreSQL 10.5.
+func dateToJulianDay(year int, month int, day int) int {
+	if month > 2 {
+		month++
+		year += 4800
+	} else {
+		month += 13
+		year += 4799
+	}
+
+	century := year / 100
+	jd := year*365 - 32167
+	jd += year/4 - century + century/4
+	jd += 7834*month/256 + day
+
+	return jd
+}
+
 func extractStringFromTimestamp(
 	_ *tree.EvalContext, fromTime time.Time, timeSpan string,
 ) (tree.Datum, error) {
 	switch timeSpan {
+	case "millennia", "millennium", "millenniums":
+		year := fromTime.Year()
+		if year > 0 {
+			return tree.NewDInt(tree.DInt((year + 999) / 1000)), nil
+		}
+		return tree.NewDInt(tree.DInt(-((999 - (year - 1)) / 1000))), nil
+
+	case "centuries", "century":
+		year := fromTime.Year()
+		if year > 0 {
+			return tree.NewDInt(tree.DInt((year + 99) / 100)), nil
+		}
+		return tree.NewDInt(tree.DInt(-((99 - (year - 1)) / 100))), nil
+
+	case "decade", "decades":
+		year := fromTime.Year()
+		if year >= 0 {
+			return tree.NewDInt(tree.DInt(year / 10)), nil
+		}
+		return tree.NewDInt(tree.DInt(-((8 - (year - 1)) / 10))), nil
+
 	case "year", "years":
 		return tree.NewDInt(tree.DInt(fromTime.Year())), nil
+
+	case "isoyear":
+		year, _ := fromTime.ISOWeek()
+		return tree.NewDInt(tree.DInt(year)), nil
 
 	case "quarter":
 		return tree.NewDInt(tree.DInt((fromTime.Month()-1)/3 + 1)), nil
@@ -4518,8 +4564,19 @@ func extractStringFromTimestamp(
 	case "dayofweek", "dow":
 		return tree.NewDInt(tree.DInt(fromTime.Weekday())), nil
 
+	case "isodow":
+		day := fromTime.Weekday()
+		if day == 0 {
+			return tree.NewDInt(tree.DInt(7)), nil
+		}
+		return tree.NewDInt(tree.DInt(day)), nil
+
 	case "dayofyear", "doy":
 		return tree.NewDInt(tree.DInt(fromTime.YearDay())), nil
+
+	case "julian":
+		julianDay := dateToJulianDay(fromTime.Year(), int(fromTime.Month()), fromTime.Day())
+		return tree.NewDInt(tree.DInt(julianDay)), nil
 
 	case "hour", "hours":
 		return tree.NewDInt(tree.DInt(fromTime.Hour())), nil
@@ -4716,6 +4773,30 @@ func truncateTimestamp(
 	nsecTrunc := 0
 
 	switch timeSpan {
+	case "millennia", "millennium", "millenniums":
+		if year > 0 {
+			year = ((year+999)/1000)*1000 - 999
+		} else {
+			year = -((999-(year-1))/1000)*1000 + 1
+		}
+		month, day, hour, min, sec, nsec = monthTrunc, dayTrunc, hourTrunc, minTrunc, secTrunc, nsecTrunc
+
+	case "centuries", "century":
+		if year > 0 {
+			year = ((year+99)/100)*100 - 99
+		} else {
+			year = -((99-(year-1))/100)*100 + 1
+		}
+		month, day, hour, min, sec, nsec = monthTrunc, dayTrunc, hourTrunc, minTrunc, secTrunc, nsecTrunc
+
+	case "decade", "decades":
+		if year >= 0 {
+			year = (year / 10) * 10
+		} else {
+			year = -((8 - (year - 1)) / 10) * 10
+		}
+		month, day, hour, min, sec, nsec = monthTrunc, dayTrunc, hourTrunc, minTrunc, secTrunc, nsecTrunc
+
 	case "year", "years":
 		month, day, hour, min, sec, nsec = monthTrunc, dayTrunc, hourTrunc, minTrunc, secTrunc, nsecTrunc
 

--- a/pkg/sql/sem/tree/testdata/eval/extract
+++ b/pkg/sql/sem/tree/testdata/eval/extract
@@ -41,9 +41,69 @@ extract(dayofweek from '2010-09-28'::date)
 2
 
 eval
+extract(isodow from '2010-09-28'::date)
+----
+2
+
+eval
+extract(isodow from '2010-09-26'::date)
+----
+7
+
+eval
 extract(quarter from '2010-09-28'::date)
 ----
 3
+
+eval
+extract(century from '2010-09-28'::date)
+----
+21
+
+eval
+extract(century from '2010-09-28 BC'::date)
+----
+-21
+
+eval
+extract(decade from '2010-09-28'::date)
+----
+201
+
+eval
+extract(decade from '2010-09-28 BC'::date)
+----
+-201
+
+eval
+extract(isoyear from '2006-01-01'::date)
+----
+2005
+
+eval
+extract(isoyear from '2006-01-02'::date)
+----
+2006
+
+eval
+extract(millennium from '2010-09-28'::date)
+----
+3
+
+eval
+extract(millennium from '2010-09-28 BC'::date)
+----
+-3
+
+eval
+extract(julian from '2010-09-28'::date)
+----
+2455468
+
+eval
+extract(julian from '4714-11-24 BC'::date)
+----
+0
 
 # Extract from times.
 
@@ -143,6 +203,56 @@ eval
 extract(epoch from '2010-01-10 12:13:14.1+00:00'::timestamp)
 ----
 1263125594
+
+eval
+extract(century from '2010-01-10 12:13:14.1+00:00'::timestamp)
+----
+21
+
+eval
+extract(century from '0001-01-10 12:13:14.1+00:00 BC'::timestamp)
+----
+-1
+
+eval
+extract(decade from '2010-01-10 12:13:14.1+00:00'::timestamp)
+----
+201
+
+eval
+extract(decade from '2010-01-10 12:13:14.1+00:00 BC'::timestamp)
+----
+-201
+
+eval
+extract(isoyear from '2006-01-01 12:13:14.1+00:00'::timestamp)
+----
+2005
+
+eval
+extract(isoyear from '2006-01-02 12:13:14.1+00:00'::timestamp)
+----
+2006
+
+eval
+extract(millennium from '2010-01-10 12:13:14.1+00:00'::timestamp)
+----
+3
+
+eval
+extract(millennium from '0010-01-10 12:13:14.1+00:00 BC'::timestamp)
+----
+-1
+
+eval
+extract(julian from '2010-01-10 12:13:14.1+00:00'::timestamp)
+----
+2455207
+
+eval
+extract(julian from '4714-11-24 12:13:14.1+00:00 BC'::timestamp)
+----
+0
 
 # Extract from intervals.
 


### PR DESCRIPTION
PostgreSQL supports millennium, century, decade, isoyear, isodow, and
julian as field name in EXTRACT function. PostgreSQL supports
millennium, century, and decade as field name in DATE_TRUNC function.
This patch adds supports of those elements to EXTRACT and DATE_TRUNC.

Issue: #41548

Release note (sql change): EXTRACT now supports millennium, century,
decade, isoyear, isodow, and julian for date, timestamp, and timestamptz.
DATE_TRUNC now supports millennium, century, and decade for date,
timestamp, and timestamptz.