### PR TITLE
storage/rangefeed: push rangefeed.Filter into Raft processing goroutine

### DIFF
--- a/pkg/storage/rangefeed/filter.go
+++ b/pkg/storage/rangefeed/filter.go
@@ -1,0 +1,46 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rangefeed
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/interval"
+)
+
+// Filter informs the producer of logical operations of the information that a
+// rangefeed Processor is interested in, given its current set of registrations.
+// It can be used to avoid performing extra work to provide the Processor with
+// information which will be ignored.
+type Filter struct {
+	needVals interval.RangeGroup
+	// TODO(nvanbenschoten): When addressing #28666, we can extend this with
+	// a second `needPreVals interval.RangeGroup` to avoid fetching existing
+	// values for spans that don't need them.
+}
+
+func newFilterFromRegistry(reg *registry) *Filter {
+	f := &Filter{
+		needVals: interval.NewRangeList(),
+	}
+	reg.tree.Do(func(i interval.Interface) (done bool) {
+		r := i.(*registration)
+		f.needVals.Add(r.Range())
+		return false
+	})
+	return f
+}
+
+// NeedVal returns whether the Processor requires MVCCWriteValueOp and
+// MVCCCommitIntentOp operations over the specified key span to contain
+// populated Value fields.
+func (r *Filter) NeedVal(s roachpb.Span) bool {
+	return r.needVals.Overlaps(s.AsRange())
+}

--- a/pkg/storage/rangefeed/processor_test.go
+++ b/pkg/storage/rangefeed/processor_test.go
@@ -48,7 +48,7 @@ func writeValueOpWithKV(key roachpb.Key, ts hlc.Timestamp, val []byte) enginepb.
 }
 
 func writeValueOp(ts hlc.Timestamp) enginepb.MVCCLogicalOp {
-	return writeValueOpWithKV(roachpb.Key("a"), ts, nil /* val */)
+	return writeValueOpWithKV(roachpb.Key("a"), ts, []byte("val"))
 }
 
 func writeIntentOpWithDetails(

--- a/pkg/util/interval/interval.go
+++ b/pkg/util/interval/interval.go
@@ -180,7 +180,7 @@ func (c Comparable) Equal(o Comparable) bool {
 // should traverse no further.
 type Operation func(Interface) (done bool)
 
-// Tree is an interval tree. For all the functions which have a fast argment,
+// Tree is an interval tree. For all the functions which have a fast argument,
 // fast being true means a fast operation which does not adjust node ranges. If
 // fast is false, node ranges are adjusted.
 type Tree interface {


### PR DESCRIPTION
This commit creates a `rangefeed.Filter` object, which informs the producer of logical operations of the information that a `rangefeed.Processor` is interested in, given its current set of registrations. It can be used to avoid performing extra work to provide the Processor with information which will be ignored.

This is an important optimization for single-key or small key span rangefeeds, as it avoids some extraneous work for the key spans not being watched.

For now, this extra work is just fetching the post-operation value for `MVCCWriteValueOp` and `MVCCCommitIntentOp` operations, but this can be extended in the future to include the pre-operation value as well. This will be important to avoid any perf regression when addressing #28666.