### PR TITLE
release-19.2: opt: clear column stats from prepared memo

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/prepare_opt_plan
+++ b/pkg/sql/logictest/testdata/logic_test/prepare_opt_plan
@@ -85,14 +85,14 @@ EXECUTE e
 ----
 select
  ├── columns: k:1 str:2
- ├── stats: [rows=333.333333, distinct(1)=333.333333, null(1)=0]
+ ├── stats: [rows=333.333333]
  ├── cost: 1050.03
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── prune: (2)
  ├── scan t
  │    ├── columns: k:1 str:2
- │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0]
+ │    ├── stats: [rows=1000]
  │    ├── cost: 1040.02
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -449,6 +449,11 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 	needed, output := b.getColumns(scan.Cols, scan.Table)
 	res := execPlan{outputCols: output}
 
+	// Get the estimated row count from the statistics.
+	// Note: if this memo was originally created as part of a PREPARE
+	// statement or was stored in the query cache, the column stats would have
+	// been removed by DetachMemo. Update that function if the column stats are
+	// needed here in the future.
 	rowCount := scan.Relational().Stats.RowCount
 	if !scan.Relational().Stats.Available {
 		// When there are no statistics available, we construct a scan node with

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -374,3 +374,18 @@ func (m *Memo) NextWithID() opt.WithID {
 	m.curWithID++
 	return m.curWithID
 }
+
+// ClearColStats clears all column statistics from every relational expression
+// in the memo. This is used to free up the potentially large amount of memory
+// used by histograms.
+func (m *Memo) ClearColStats(parent opt.Expr) {
+	for i, n := 0, parent.ChildCount(); i < n; i++ {
+		child := parent.Child(i)
+		m.ClearColStats(child)
+	}
+
+	switch t := parent.(type) {
+	case RelExpr:
+		t.Relational().Stats.ColStats = props.ColStatsMap{}
+	}
+}


### PR DESCRIPTION
Backport 1/1 commits from #41712.

/cc @cockroachdb/release

---

This commit clears all column statistics from every relational expression in
the memo when the memo is created as part of a prepared statement. The purpose
of this change is to free up the potentially large amount of memory used by
histograms.

This does not affect the quality of the plan used at execution time, since
the stats are just recalculated anyway when placeholders are assigned.

Fixes #41524

Release note: None
