### PR TITLE
colexec: return on zero-length batch in selBoolOp

### DIFF
--- a/pkg/sql/colexec/bool_vec_to_sel.go
+++ b/pkg/sql/colexec/bool_vec_to_sel.go
@@ -123,6 +123,10 @@ func (d selBoolOp) Init() {
 
 func (d selBoolOp) Next(ctx context.Context) coldata.Batch {
 	batch := d.input.Next(ctx)
+	n := batch.Length()
+	if n == 0 {
+		return batch
+	}
 	inputCol := batch.ColVec(d.colIdx)
 	d.boolVecToSelOp.outputCol = inputCol.Bool()
 	if inputCol.MaybeHasNulls() {
@@ -134,7 +138,6 @@ func (d selBoolOp) Next(ctx context.Context) coldata.Batch {
 		// so we need to adjust it.
 		// TODO(yuzefovich): think through this case more, possibly clean this up.
 		outputCol := d.boolVecToSelOp.outputCol
-		n := batch.Length()
 		sel := batch.Selection()
 		nulls := inputCol.Nulls()
 		if sel != nil {


### PR DESCRIPTION
Previously, a selBoolOp would attempt to perform work on a zero-length
batch. Since this indicates that the input is finished, there was no
work to do and could lead to incorrectly accessing a column that wasn't
there (zero-length batch widths are to be defined), resulting in an
index out of bounds panic.

Release note: None

cc @jordanlewis 