### PR TITLE
engine: Manually check for equality in MVCCGet case with pebble

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -427,7 +427,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:ab7e14b6348c75df6fb37c3d327392aea6090e6154a95d1ff2cd0721e93fcd4d"
+  digest = "1:4e4242f49156024b2a0634274376fbb2db4e2c6285ce11785b19243d7ecc000e"
   name = "github.com/cockroachdb/pebble"
   packages = [
     ".",
@@ -450,7 +450,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "9d80716063bb38e2772ced37c428ccc47d384b23"
+  revision = "48901a109734411492918b9cdd1d34009fb55a23"
 
 [[projects]]
   branch = "master"

--- a/pkg/storage/engine/pebble_iterator.go
+++ b/pkg/storage/engine/pebble_iterator.go
@@ -374,12 +374,19 @@ func (p *pebbleIterator) MVCCGet(
 	}
 
 	if len(mvccScanner.results.repr) == 0 {
-		return nil, intent, nil
+		if intent != nil && intent.Key.Equal(key) {
+			return nil, intent, nil
+		}
+		return nil, nil, nil
 	}
 
 	mvccKey, rawValue, _, err := MVCCScanDecodeKeyValue(mvccScanner.results.repr)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	if !mvccKey.Key.Equal(key) {
+		return nil, nil, nil
 	}
 
 	value = &roachpb.Value{


### PR DESCRIPTION
Currently, since the pebble MVCC Scanner doesn't do any bounds
checks other than what the underlying iterator already does,
we have a tendency to return values for other keys in the
MVCCGet case. This very obviously breaks cockroach for when
--storage-engine=pebble.

This change ensures that we return nil if we hit the case
of a non-matching KV pair.

Also bumps pebble in `vendor` to pick up recent changes.

Release note: None