### PR TITLE
storage/engine: add BenchmarkMVCCGet_Pebble

### DIFF
--- a/pkg/storage/engine/bench_pebble_test.go
+++ b/pkg/storage/engine/bench_pebble_test.go
@@ -51,6 +51,22 @@ func setupMVCCInMemPebble(b testing.TB, loc string) Engine {
 	return peb
 }
 
+func BenchmarkMVCCGet_Pebble(b *testing.B) {
+	ctx := context.Background()
+	for _, numVersions := range []int{1, 10, 100} {
+		b.Run(fmt.Sprintf("versions=%d", numVersions), func(b *testing.B) {
+			for _, valueSize := range []int{8} {
+				b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
+					runMVCCGet(ctx, b, setupMVCCPebble, benchDataOptions{
+						numVersions: numVersions,
+						valueBytes:  valueSize,
+					})
+				})
+			}
+		})
+	}
+}
+
 func BenchmarkMVCCComputeStats_Pebble(b *testing.B) {
 	if testing.Short() {
 		b.Skip("short flag")


### PR DESCRIPTION
Good news is that for the `versions=1` variant, Pebble is looking
good (RocksDB is old and Pebble is new):

```
name                               old time/op    new time/op    delta
MVCCGet/versions=1/valueSize=8-16    5.55µs ± 2%    3.21µs ± 3%  -42.15%  (p=0.000 n=10+10)

name                               old speed      new speed      delta
MVCCGet/versions=1/valueSize=8-16  1.44MB/s ± 2%  2.49MB/s ± 3%  +72.88%  (p=0.000 n=10+10)
```

The bad news is that Pebble encounters an error for the
`versions={10,100}` variants. This will likely be fixed by upcoming work
on `pebbleMVCCScanner`.

Release note: None